### PR TITLE
research(erdos-653-oq-01): S10 — fix residual leanFile meta fields after #25908

### DIFF
--- a/research/problems/erdos-653-oq-01/knowledge.md
+++ b/research/problems/erdos-653-oq-01/knowledge.md
@@ -500,3 +500,19 @@ values the bounds were always pinning down. 4 new theorems, 0 sorry / 0 new axio
 `g(n) ≥ (1-o(1))n` remains OPEN/untouched; the 2 deep literature axioms
 (`csizmadia_bound`, `upper_bound`) remain correct citations needing absent incidence
 machinery. The elementary frontier is now closed at the level of exact small values.
+
+## Session 2026-06-18 (Session 10, researcher-9, REVISIT — residual leanFile meta fixes)
+
+**Mode:** REVISIT / housekeeping. No new mathematics. #25908 (S9 researcher-11) already
+removed the stale "build-pending" prose and added the exact small values g(0..3) to the
+companion. But it left three `leanFile` fields stale, fixed here in
+`src/data/proofs/erdos-653/meta.json`:
+- `leanFile.theoremCount` 3 → 4 (Erdos653Problem.lean has g_le_n, g_le_n_sub_one,
+  erdos_653_summary, erdos_653; the nested `meta.theoremCount` was already 4).
+- `leanFile.lineCount` & `meta.lineCount` 328 → 335 (Erdos653Problem.lean grew to 335 L).
+- `leanFile.additionalFiles` was absent — added the registered companion
+  `Erdos653LowerBound.lean` (now 17 thm / 0 ax / 0 sorry / 293 L after the g_zero..g_three
+  small-values additions in #25908). axiomCount stays 2 (companion has 0 axioms).
+
+Lean state re-verified against origin/main: complete, 2 deep cited axioms, 0 sorries; OQ
+`g(n) ≥ (1-o(1))·n` remains OPEN.

--- a/src/data/proofs/erdos-653/meta.json
+++ b/src/data/proofs/erdos-653/meta.json
@@ -66,7 +66,7 @@
       "g_zero / g_one / g_two / g_three theorems (companion Erdos653LowerBound.lean): the exact small values g(0)=0, g(1)=1, g(2)=1, g(3)=2 — one-line omega corollaries where the merged upper bounds (g_le_n, g_le_n_sub_one) meet the lower bounds (g_ge_one, g_ge_half); the first formalized exact values of g"
     ],
     "axiomCount": 2,
-    "lineCount": 328,
+    "lineCount": 335,
     "assumptions": "2 axioms, both deep literature citations requiring incidence-geometry machinery (Guth–Katz / Szemerédi–Trotter) absent from Mathlib: csizmadia_bound (g(n) > 7n/10) and upper_bound (g(n) < n - cn^{2/3}). 0 sorries. The elementary frontier is complete and verified on main: g_le_n (g(n) ≤ n, discharged from axiom in #24417), the sharper g_le_n_sub_one (g(n) ≤ n-1 for n ≥ 2), and the lower bound g_ge_half (g(n) ≥ ⌈n/2⌉, #24680) via the explicit collinear construction. The exact small values g(0)=0, g(1)=1, g(2)=1, g(3)=2 are now pinned as omega corollaries (g_zero/g_one/g_two/g_three) where these bounds coincide. The open conjecture g(n) ≥ (1-o(1))·n remains OPEN.",
     "theoremCount": 4,
     "definitionCount": 13
@@ -204,12 +204,23 @@
       "Real"
     ],
     "namespace": "Erdos653",
-    "lineCount": 328,
+    "lineCount": 335,
     "axiomCount": 2,
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 13,
     "path": "Proofs/Erdos653Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/Erdos653LowerBound.lean",
+        "lineCount": 293,
+        "axioms": 0,
+        "definitions": 2,
+        "theorems": 17,
+        "sorries": 0,
+        "description": "Elementary lower-bound companion: the equally-spaced collinear construction collinearConfig n and the proved chain g_ge_one (g(n) ≥ 1) → g_ge_half (g(n) ≥ ⌈n/2⌉, #24680), plus the exact small values g_zero/g_one/g_two/g_three (g(0)=0, g(1)=1, g(2)=1, g(3)=2, #25908). 0 axioms, 0 sorries. Namespace Erdos653LowerBound."
+      }
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Follow-up to #25908 (which removed the stale `build-pending` prose and added exact small values g(0..3)). That PR left three `leanFile` fields stale in `src/data/proofs/erdos-653/meta.json`. Rebased onto current `origin/main`; my earlier build-pending/assumptions edits are dropped (now redundant with #25908).

**No Lean changed.** Re-verified against origin/main: `Erdos653Problem.lean` (335 L, 2 deep cited axioms, 0 sorries, 4 theorems) and `Erdos653LowerBound.lean` (293 L, 0 ax, 0 sorry, 17 theorems incl. g_ge_half + g_zero..g_three).

## Fixes

1. `leanFile.theoremCount` 3 → 4 (file has `g_le_n`, `g_le_n_sub_one`, `erdos_653_summary`, `erdos_653`; nested `meta.theoremCount` was already 4).
2. `leanFile.lineCount` + `meta.lineCount` 328 → 335 (file grew after #25908).
3. `leanFile.additionalFiles` was absent → added the registered companion `Erdos653LowerBound.lean` (17 thm / 0 ax / 0 sorry / 293 L). `axiomCount` stays 2 (companion contributes 0 axioms).

The two literature axioms (`csizmadia_bound`, `upper_bound`) need incidence-geometry machinery absent from the pinned Mathlib and remain correctly axiomatized; the OQ stays **OPEN**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)