### PR TITLE
Enrich Abel-Ruffini Galois extensions OQ-04: repoint Jordan-Hölder annotation

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/annotations.json
@@ -309,7 +309,7 @@
     "id": "ann-jordan-holder",
     "proofId": "abel-ruffini-galois-extensions-oq-04",
     "range": {
-      "startLine": 208,
+      "startLine": 212,
       "endLine": 225
     },
     "type": "insight",


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-galois-extensions-oq-04`.

## Problem found
The `ann-jordan-holder` annotation pointed at a `-- ====` section divider (line 208) instead of the actual Jordan-Hölder theorems it describes — the file's headline result.

## Change
- Repointed `ann-jordan-holder` to **212–225** (`jordan_holder_subgroups` + `jordan_holder_finite_groups`).

## Deliberately NOT changed
The other 6 `annotations:build` flags for this entry are **validator false-positives**, not misalignments — the annotations already point at real code the validator simply doesn't model as top-level constructs:
- 5 are **instance-field proofs** inside `instJordanHolderLatticeSubgroup` (`sup_eq_of_isMaximal`, `isMaximal_inf_left_of_isMaximal_sup`, `Iso`, `iso_symm`, `iso_trans`, `second_iso`).
- 1 is the `#check`/`end` type-verification block (`Part V`), which contains no declarations.

Forcing those to anchor at the instance signature would *degrade* correctly-placed annotations, so they are intentionally left as-is.

Part of the gallery-wide annotation→construct realignment effort (cf. #25892, #25897, #25900, #25901, #25903, #25905, #25909, #25910).