### PR TITLE
Enrich Radon–Nikodym (σ-finite): fix malformed section, realign line numbers, add coverage

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-05/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-05/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "lebesgue-measure-oq-05",
     "range": {
       "startLine": 1,
-      "endLine": 42
+      "endLine": 64
     },
     "type": "concept",
     "title": "Setup: Packaging Mathlib's HaveLebesgueDecomposition Theory",
@@ -27,8 +27,8 @@
     "id": "ann-lebesgueoq05-witness",
     "proofId": "lebesgue-measure-oq-05",
     "range": {
-      "startLine": 44,
-      "endLine": 52
+      "startLine": 66,
+      "endLine": 74
     },
     "type": "insight",
     "title": "Measurability and the Canonical Density",
@@ -51,8 +51,8 @@
     "id": "ann-lebesgueoq05-existence",
     "proofId": "lebesgue-measure-oq-05",
     "range": {
-      "startLine": 54,
-      "endLine": 58
+      "startLine": 76,
+      "endLine": 80
     },
     "type": "concept",
     "title": "Existence of a Density",
@@ -73,8 +73,8 @@
     "id": "ann-lebesgueoq05-integral",
     "proofId": "lebesgue-measure-oq-05",
     "range": {
-      "startLine": 60,
-      "endLine": 71
+      "startLine": 82,
+      "endLine": 93
     },
     "type": "insight",
     "title": "Integral Characterization and Total Mass",
@@ -97,8 +97,8 @@
     "id": "ann-lebesgueoq05-uniqueness",
     "proofId": "lebesgue-measure-oq-05",
     "range": {
-      "startLine": 73,
-      "endLine": 83
+      "startLine": 95,
+      "endLine": 105
     },
     "type": "insight",
     "title": "ν-a.e. Uniqueness of the Density",
@@ -121,8 +121,8 @@
     "id": "ann-lebesgueoq05-decomposition",
     "proofId": "lebesgue-measure-oq-05",
     "range": {
-      "startLine": 85,
-      "endLine": 91
+      "startLine": 107,
+      "endLine": 112
     },
     "type": "insight",
     "title": "General Lebesgue Decomposition",
@@ -139,6 +139,78 @@
       "singular part of a measure",
       "mutual singularity μ ⊥ ν",
       "decomposition into a.c. + singular parts"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq05-calculus",
+    "proofId": "lebesgue-measure-oq-05",
+    "range": {
+      "startLine": 114,
+      "endLine": 144
+    },
+    "type": "insight",
+    "title": "Calculus of Densities: Chain Rule, Self-Derivative, Reciprocal",
+    "content": "The calculus-of-densities section treats `μ.rnDeriv ν` as a genuine derivative obeying algebraic composition laws. `rnDeriv_chain` is the **chain rule**: for σ-finite `μ, ν, λ` with `μ ≪ ν`, `(dμ/dν)·(dν/dλ) = dμ/dλ` holds `λ`-a.e. (`Measure.rnDeriv_mul_rnDeriv`). `rnDeriv_self_ae_one` is the **self-derivative** `dμ/dμ = 1` (`μ`-a.e., `Measure.rnDeriv_self`) — the multiplicative identity of the chain rule. `rnDeriv_mul_symm_ae_one` is the **reciprocal relation** `(dμ/dν)·(dν/dμ) = 1` (`μ`-a.e. for `μ ≪ ν`), obtained by specialising the chain rule to `λ = μ` and composing with the self-derivative via `.trans`.",
+    "mathContext": "The three laws make $d\\mu/d\\nu$ behave like a Leibniz differential: $\\frac{d\\mu}{d\\nu}\\frac{d\\nu}{d\\lambda} = \\frac{d\\mu}{d\\lambda}$ ($\\lambda$-a.e.), $\\frac{d\\mu}{d\\mu} = 1$ ($\\mu$-a.e.), and the inverse law $\\frac{d\\mu}{d\\nu}\\frac{d\\nu}{d\\mu} = 1$ ($\\mu$-a.e.) — the measure-theoretic analogue of $\\frac{dx}{dy}\\frac{dy}{dx} = 1$. The reciprocal law is a *derived* corollary: chain rule at $\\lambda = \\mu$ gives $\\frac{d\\mu}{d\\nu}\\frac{d\\nu}{d\\mu} =^{ae}_\\mu \\frac{d\\mu}{d\\mu}$, then the self-derivative collapses the right side to $1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MeasureTheory.Measure.rnDeriv_mul_rnDeriv",
+      "MeasureTheory.Measure.rnDeriv_self",
+      "chain rule",
+      "change of variables for measures"
+    ],
+    "prerequisites": [
+      "Radon–Nikodym derivative as a density",
+      "almost-everywhere equality =ᵐ[λ]",
+      "transitivity of a.e. equality"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq05-regularity",
+    "proofId": "lebesgue-measure-oq-05",
+    "range": {
+      "startLine": 146,
+      "endLine": 172
+    },
+    "type": "insight",
+    "title": "Pointwise Regularity of the Density",
+    "content": "Basic almost-everywhere regularity of `μ.rnDeriv ν` as a function. `rnDeriv_lt_top_ae` / `rnDeriv_ne_top_ae` record **finiteness**: for σ-finite `μ`, the derivative is finite `ν`-a.e. (`Measure.rnDeriv_lt_top` / `Measure.rnDeriv_ne_top`). `rnDeriv_pos_ae` records **positivity**: for σ-finite `μ ≪ ν`, the derivative is strictly positive `μ`-a.e. (`Measure.rnDeriv_pos`) — it cannot vanish on the support of `μ`. `inv_rnDeriv_ae` is the **pointwise inverse law** `(dμ/dν)⁻¹ = dν/dμ` (`μ`-a.e., `Measure.inv_rnDeriv`), the pointwise refinement of the reciprocal relation `rnDeriv_mul_symm_ae_one`.",
+    "mathContext": "Finiteness $\\frac{d\\mu}{d\\nu} < \\infty$ ($\\nu$-a.e.) ensures the density is a genuine $[0,\\infty)$-valued function a.e.; positivity $0 < \\frac{d\\mu}{d\\nu}$ ($\\mu$-a.e., for $\\mu \\ll \\nu$) is what makes the inverse $\\left(\\frac{d\\mu}{d\\nu}\\right)^{-1}$ meaningful $\\mu$-a.e. The pointwise inverse law $\\left(\\frac{d\\mu}{d\\nu}\\right)^{-1} = \\frac{d\\nu}{d\\mu}$ ($\\mu$-a.e.) upgrades the multiplicative reciprocal relation to an explicit reciprocal of functions.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "MeasureTheory.Measure.rnDeriv_lt_top",
+      "MeasureTheory.Measure.rnDeriv_pos",
+      "MeasureTheory.Measure.inv_rnDeriv",
+      "almost-everywhere properties"
+    ],
+    "prerequisites": [
+      "extended non-negative reals ℝ≥0∞",
+      "almost-everywhere quantifier ∀ᵐ",
+      "the reciprocal relation (previous section)"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq05-condexp",
+    "proofId": "lebesgue-measure-oq-05",
+    "range": {
+      "startLine": 176,
+      "endLine": 202
+    },
+    "type": "insight",
+    "title": "Conditional Expectation as a Radon–Nikodym Derivative",
+    "content": "`condExp_ae_eq_signed_rnDeriv` identifies the **conditional expectation** with a Radon–Nikodym derivative, placing conditioning inside the calculus of this file. For a sub-σ-algebra `m ≤ m₀` with `ρ.trim hm` σ-finite and `f` integrable, the conditional expectation `ρ[f|m]` equals, `ρ`-a.e., the *signed* Radon–Nikodym derivative of the `f`-weighted measure `ρ.withDensityᵥ f` trimmed to `m`, with respect to `ρ` trimmed to `m`. It is a thin wrapper over Mathlib's `MeasureTheory.rnDeriv_ae_eq_condExp`, exposing the probabilistic face of the package: conditional expectation *is* a density.",
+    "mathContext": "$\\rho[f\\mid m] =^{ae}_\\rho \\mathrm{rnDeriv}\\big((\\rho.\\mathrm{withDensity}_v\\, f).\\mathrm{trim}\\, m,\\ \\rho.\\mathrm{trim}\\, m\\big)$. The signed Radon–Nikodym derivative extends the non-negative theory to signed measures (the $f$-weighted measure $\\rho.\\mathrm{withDensity}_v f$ is signed because $f$ may take negative values). This is the measure-theoretic *definition* of conditional expectation underlying martingale theory: $E[f\\mid m]$ is the density of the conditioned measure relative to the base measure on the coarser σ-algebra $m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MeasureTheory.rnDeriv_ae_eq_condExp",
+      "MeasureTheory.condExp",
+      "MeasureTheory.SignedMeasure.rnDeriv",
+      "MeasureTheory.Measure.trim"
+    ],
+    "prerequisites": [
+      "conditional expectation E[f|m]",
+      "signed measures and withDensityᵥ",
+      "trimming a measure to a sub-σ-algebra"
     ]
   }
 ]

--- a/src/data/proofs/lebesgue-measure-oq-05/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-05/meta.json
@@ -56,59 +56,66 @@
       "id": "preamble",
       "title": "§0: Module Setup and Statement",
       "startLine": 1,
-      "endLine": 43,
+      "endLine": 64,
       "summary": "Imports, namespace, and the module docstring stating the σ-finite Radon–Nikodym package and its honest formalization scope.",
       "mathContext": "Fixes a measurable space $\\alpha$ and measures $\\mu, \\nu$ on it. The classical σ-finite Radon–Nikodym theorem and the general Lebesgue decomposition are the targets."
     },
     {
       "id": "measurability-witness",
       "title": "Measurability and the Canonical Density",
-      "startLine": 52,
-      "endLine": 60,
+      "startLine": 66,
+      "endLine": 74,
       "summary": "rnDeriv_measurable (the Radon–Nikodym derivative is measurable) and rnDeriv_isDensity (ν.withDensity (dμ/dν) = μ for σ-finite μ ≪ ν).",
       "mathContext": "$d\\mu/d\\nu$ is measurable, and for $\\sigma$-finite $\\mu \\ll \\nu$ it is a density: $\\nu.\\mathrm{withDensity}(d\\mu/d\\nu) = \\mu$. The HaveLebesgueDecomposition instance comes from σ-finiteness."
     },
     {
       "id": "existence",
       "title": "Existence of a Density",
-      "startLine": 62,
-      "endLine": 66,
+      "startLine": 76,
+      "endLine": 80,
       "summary": "exists_density: there is a measurable f with ν.withDensity f = μ.",
       "mathContext": "Packages measurability and the witness identity into the existential form of the Radon–Nikodym theorem."
     },
     {
       "id": "integral-characterization",
       "title": "Integral Characterization and Total Mass",
-      "startLine": 68,
-      "endLine": 79,
+      "startLine": 82,
+      "endLine": 93,
       "summary": "rnDeriv_setLIntegral (∫⁻_s (dμ/dν) dν = μ s for measurable s) and rnDeriv_lintegral (the total-mass specialization to s = univ).",
       "mathContext": "$\\int_s (d\\mu/d\\nu)\\, d\\nu = \\mu(s)$ via withDensity_apply and the witness identity; specializing to $s = \\mathrm{univ}$ gives $\\int (d\\mu/d\\nu)\\, d\\nu = \\mu(\\mathrm{univ})$."
     },
     {
       "id": "uniqueness",
       "title": "ν-a.e. Uniqueness",
-      "startLine": 81,
-      "endLine": 91,
+      "startLine": 95,
+      "endLine": 105,
       "summary": "density_unique: any two measurable densities for μ with respect to σ-finite ν agree ν-a.e.",
       "mathContext": "From Measure.rnDeriv_withDensity, any density $f$ satisfies $f =^{ae}_\\nu (\\nu.\\mathrm{withDensity}\\,f).\\mathrm{rnDeriv}\\,\\nu = \\mu.\\mathrm{rnDeriv}\\,\\nu$; transitivity gives $f =^{ae}_\\nu g$."
     },
     {
       "id": "lebesgue-decomposition",
       "title": "General Lebesgue Decomposition",
-      "startLine": 93,
-      "endLine": 98,
+      "startLine": 107,
+      "endLine": 112,
       "summary": "lebesgue_decomposition: μ = μ.singularPart ν + ν.withDensity (μ.rnDeriv ν) for any σ-finite pair, no absolute continuity assumed.",
       "mathContext": "Measure.haveLebesgueDecomposition_add: every σ-finite $\\mu$ splits as a $\\nu$-singular part plus an absolutely-continuous part with density $d\\mu/d\\nu$."
     },
     {
       "id": "calculus-of-densities",
       "title": "Calculus of Densities: Chain Rule, Self-Derivative, Reciprocal",
-      "startLine": 100,
-      "endLine": 131,
+      "startLine": 114,
+      "endLine": 144,
       "summary": "rnDeriv_chain ((dμ/dν)·(dν/dλ) = dμ/dλ, λ-a.e.), rnDeriv_self_ae_one (dμ/dμ = 1, μ-a.e.), and rnDeriv_mul_symm_ae_one ((dμ/dν)·(dν/dμ) = 1, μ-a.e. for μ ≪ ν).",
       "mathContext": "The Radon–Nikodym derivative composes multiplicatively (chain rule, Measure.rnDeriv_mul_rnDeriv), has constant value 1 against its own base measure (Measure.rnDeriv_self), and therefore satisfies a reciprocal law $(d\\mu/d\\nu)(d\\nu/d\\mu) = 1$ — the chain rule at $\\lambda = \\mu$ composed with the self-derivative."
     },
-    "Pointwise Regularity and Conditional Expectation as a Density"
+    {
+      "id": "regularity-and-conditioning",
+      "title": "Pointwise Regularity and Conditional Expectation as a Density",
+      "startLine": 146,
+      "endLine": 202,
+      "summary": "Pointwise regularity of the density — rnDeriv_lt_top_ae / rnDeriv_ne_top_ae (dμ/dν < ∞ and ≠ ∞, ν-a.e.), rnDeriv_pos_ae (0 < dμ/dν, μ-a.e. for μ ≪ ν), and inv_rnDeriv_ae ((dμ/dν)⁻¹ = dν/dμ, μ-a.e.) — followed by condExp_ae_eq_signed_rnDeriv, identifying the conditional expectation μ[f|m] with the signed Radon–Nikodym derivative of the f-weighted measure trimmed to the sub-σ-algebra m.",
+      "mathContext": "The density is a.e. finite ($d\\mu/d\\nu < \\infty$, $\\nu$-a.e.) and, for $\\mu \\ll \\nu$, strictly positive $\\mu$-a.e. with pointwise inverse $(d\\mu/d\\nu)^{-1} = d\\nu/d\\mu$ ($\\mu$-a.e.). Conditional expectation is itself a density: $\\mu[f\\mid m] =^{ae}_\\mu \\mathrm{rnDeriv}\\big((\\mu.\\mathrm{withDensity}_v\\, f).\\mathrm{trim}\\,m,\\ \\mu.\\mathrm{trim}\\,m\\big)$, placing conditioning inside the same Radon–Nikodym calculus (Mathlib's rnDeriv_ae_eq_condExp)."
+    }
   ],
   "conclusion": {
     "summary": "The σ-finite Radon–Nikodym theorem and the general Lebesgue decomposition are assembled from Mathlib's HaveLebesgueDecomposition theory: existence of a measurable density, the canonical Radon–Nikodym derivative as witness, the integral characterization ∫⁻_s (dμ/dν) dν = μ s, ν-a.e. uniqueness, and the decomposition μ = μ.singularPart ν + ν.withDensity (dμ/dν). A calculus of densities is then derived: the chain rule (dμ/dν)·(dν/dλ) = dμ/dλ (λ-a.e.), the self-derivative dμ/dμ = 1 (μ-a.e.), and the reciprocal relation (dμ/dν)·(dν/dμ) = 1 (μ-a.e.) for μ ≪ ν. Finally the density's basic regularity (finiteness, positivity, pointwise inverse) and the identification of conditional expectation E[f|m] with a signed Radon–Nikodym derivative (Mathlib's rnDeriv_ae_eq_condExp) round out the package.",
@@ -134,6 +141,16 @@
       "proofId": "lebesgue-measure-oq-03",
       "relationship": "related",
       "description": "Infinite-Dimensional Measure Theory shows that no translation-invariant σ-finite measure exists on an infinite-dimensional space, forcing Gaussian/Wiener substitutes. It probes the same structural hypothesis — σ-finiteness — that this entry depends on: the σ-finite Radon–Nikodym theorem (and the third open question's counterexample) is exactly where σ-finiteness becomes load-bearing, so the two entries together map both the reach and the failure boundary of σ-finite measure theory."
+    },
+    {
+      "targetId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01",
+      "relationship": "used-by",
+      "description": "The 'Radon–Nikodým Route to Lp Duality' uses exactly the σ-finite Radon–Nikodym derivative packaged here to construct the representing function in the Riesz representation theorem for Lᵖ spaces: a bounded functional defines an absolutely-continuous measure whose density dμ/dν is the sought Lᵠ representative. This entry is the measure-theoretic engine behind that duality argument."
+    },
+    {
+      "targetId": "lebesgue-measure-oq-02",
+      "relationship": "complementary",
+      "description": "Hölder's Inequality for Lebesgue Integration supplies the norm estimate ‖fg‖₁ ≤ ‖f‖ₚ‖g‖ᵩ that bounds the functional in Lᵖ duality, while the Radon–Nikodym derivative developed here supplies its representative. The two together — Hölder for boundedness, Radon–Nikodym for representability — are the standard pair underlying the identification (Lᵖ)* ≅ Lᵠ."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for **lebesgue-measure-oq-05** (Radon–Nikodym Theorem for σ-finite Measures). Content-only changes to `meta.json` and `annotations.json`; no Lean source touched.

**Rebased onto current main — complements, does not overlap, the merged #25925** (which added open questions + cross-references). `openQuestions` is left untouched; this PR fixes structural/coverage defects #25925 did not address.

## What was wrong (still present in main after #25925)
- **Malformed `sections[]`**: the last element was a bare string `"Pointwise Regularity and Conditional Expectation as a Density"` instead of a section object — the regularity + conditional-expectation theorems (file lines 146–202) had no navigable section.
- **Line-number drift**: all section ranges were uniformly ~14 lines behind the actual Lean file, and all annotation ranges ~22 lines behind. The gallery renders the raw `.lean` (`?raw` import), so these pointed above the real declarations. In particular the calculus section's `endLine: 131` excluded the headline reciprocal theorem `rnDeriv_mul_symm_ae_one` (lines 138–144).
- **Coverage gap**: annotations stopped at line 91 of 202 — the entire second half (calculus of densities, regularity, conditional expectation) was unannotated.

## Changes
- Replaced the bare-string section with a proper object (lines 146–202).
- Realigned **all** section ranges to true file lines; calculus `endLine` 131→144.
- Realigned **all** annotation ranges to true file lines.
- Added 3 annotations (now 9, all with `mathContext`) covering calculus of densities (114–144), pointwise regularity (146–172), and conditional-expectation-as-density (176–202). Annotations now span the full file.
- Appended 2 cross-references to the 3 from #25925: Lp Riesz duality (`cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01`) and Hölder (`lebesgue-measure-oq-02`). **`openQuestions` not modified** (preserves #25925).

## Axiom integrity
`status: verified` / `badge: mathlib` / `axiomCount: 0` unchanged and accurate — file has 0 sorries, 0 `axiom` declarations, no assumption-carrying structures (verified by re-reading the Lean source). `theoremCount: 15` confirmed.

## Verification
- Both JSON files validated (`json.load`).
- Section/annotation line ranges cross-checked against `proofs/Proofs/LebesgueMeasureOQ05.lean` declaration positions.
- `tsc` type-check could not run: `pnpm install` fails in this worktree on `better-sqlite3`'s native build under node v26 (pre-existing environment issue, unrelated to these JSON-only edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)