### PR TITLE
research(erdos-340-greedy-sidon-oq-02): full proof roadmap for window_pair_bound

### DIFF
--- a/research/problems/erdos-340-greedy-sidon-oq-02/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-02/knowledge.md
@@ -6,16 +6,157 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+**Goal (OQ-02).** Remove the lone axiom of the parent gallery entry
+`erdos-340-greedy-sidon`:
+
+```lean
+axiom sidon_upper_bound (A : Finset ℕ) (hA : IsSidon A) (N : ℕ)
+    (hAN : ∀ a ∈ A, a ≤ N) :
+    A.card ≤ Nat.sqrt N + Nat.sqrt (Nat.sqrt N) + 1
+```
+
+This is the sharp **Erdős–Turán** upper bound for a Sidon set in `{1,…,N}`. The
+parent proves only the *weak* difference-counting bound
+`sidon_upper_bound_weak : |A| ≤ √(2N)+1`, then postulates the sharp form.
+
+`IsSidon A` (parent def) means: `∀ a b c d ∈ A, a ≤ b → c ≤ d → a+b=c+d → a=c ∧ b=d`
+(distinct-sums form; equivalently distinct positive differences).
+
+---
+
+## Current Lean state (`proofs/Proofs/Erdos340GreedySidonOQ02.lean`, 186 lines)
+
+The file implements the sliding-window / Cauchy–Schwarz argument
+(Erdős–Turán, Lindström form). Fully proved **unconditionally**:
+
+- `isSidon_image_add`, `card_image_add` — translation invariance (shift `A ↦ A+ℓ`
+  so every element lands in `[ℓ, N+ℓ]`).
+- `windowCount B ℓ x := (B.filter (fun b => x < b ∧ b ≤ x+ℓ)).card`.
+- **`window_sum_identity`** (counting fact A):
+  `∑_{x<M} windowCount B ℓ x = ℓ·|B|` when `B ⊆ [ℓ,M]`. PROVED.
+- **`sidon_window_key`** (the Cauchy–Schwarz assembly): for a Sidon `A ⊆ {0,…,N}`
+  and any `ℓ ≥ 1`, `ℓ·|A|² ≤ (N+ℓ)·(ℓ-1+|A|)`. PROVED, *conditional on* the one
+  remaining lemma below. Uses `Finset.sq_sum_le_card_mul_sum_sq` (Cauchy–Schwarz).
+
+**The single remaining `sorry` (line 123):**
+
+```lean
+theorem window_pair_bound (B : Finset ℕ) (ℓ M : ℕ) (hℓ : 1 ≤ ℓ)
+    (hBsid : IsSidon B) (hB : ∀ b ∈ B, ℓ ≤ b ∧ b ≤ M) :
+    ∑ x ∈ range M, windowCount B ℓ x * (windowCount B ℓ x - 1) ≤ ℓ * (ℓ - 1) := by
+  sorry
+```
+
+This is counting fact **(B)**: the total number of ordered pairs sharing a window,
+weighted, is `≤ ℓ(ℓ-1)`. It is *known finite combinatorics, not the open
+problem*. Closing it makes the OQ-02 file 0-sorry; combined with optimising
+`ℓ ≈ √N` (a further, separate step) it discharges the parent axiom.
+
+---
+
+## COMPLETE PROOF of `window_pair_bound` (formalization roadmap)
+
+Notation: `W x := B.filter (fun b => x < b ∧ b ≤ x+ℓ)`, so `windowCount B ℓ x = (W x).card`.
+
+**Step 1 — pairs inside a window.** `n·(n-1) = |s.offDiag|` for `n = s.card`:
+`windowCount * (windowCount - 1) = (W x).offDiag.card` via `Finset.offDiag_card`
+(`s.offDiag.card = s.card * (s.card - 1)`).
+
+**Step 2 — push the filter through `offDiag`.** Since `W x = B.filter Q` with
+`Q b = (x<b ∧ b≤x+ℓ)`:
+`(W x).offDiag = B.offDiag.filter (fun p => Q p.1 ∧ Q p.2)`
+— proved by `ext ⟨a,b⟩; simp [Finset.mem_offDiag, Finset.mem_filter]; tauto`.
+
+**Step 3 — Fubini (swap the two sums).**
+```
+∑_{x∈range M} (W x).offDiag.card
+  = ∑_{x} ∑_{p∈B.offDiag} (if Q x p.1 ∧ Q x p.2 then 1 else 0)   -- Finset.card_filter
+  = ∑_{p∈B.offDiag} ∑_{x∈range M} (if … then 1 else 0)          -- Finset.sum_comm
+  = ∑_{p∈B.offDiag} cov p
+```
+where `cov (a,b) := ((range M).filter (fun x => (x<a∧a≤x+ℓ)∧(x<b∧b≤x+ℓ))).card`.
+
+**Step 4 — windows covering a fixed pair.** For `(a,b) ∈ B.offDiag` (so `a≠b`,
+`a,b ∈ [ℓ,M]`): the covering `x` satisfy `x < min a b` and `max a b - ℓ ≤ x`; all
+such `x` automatically lie in `range M` (`x < min ≤ M`, `x ≥ max-ℓ ≥ 0`). Hence
+the filtered set equals `Finset.Ico (max a b - ℓ) (min a b)` (prove by `ext x;
+simp; omega` using `hB`), and by `Nat.card_Ico`:
+`cov (a,b) = min a b - (max a b - ℓ) = ℓ - |a-b|`  (ℕ-truncated; `= 0` when `|a-b| ≥ ℓ`).
+
+So `∑_{x} windowCount·(windowCount-1) = ∑_{(a,b)∈B.offDiag} (ℓ - |a-b|)`.
+
+**Step 5 — regroup by difference using the Sidon property.** Reuse parent infra
+(`Proofs.Erdos340GreedySidon`):
+- `orderedPairsLt B := B.offDiag.filter (fun p => p.1 < p.2)`,
+- `pairDiff p := p.2 - p.1`,
+- `sidon_pairDiff_injective : Set.InjOn pairDiff (orderedPairsLt B)` — **already proved**
+  (built on `IsSidon.diff_injective`).
+
+Split `B.offDiag` by orientation; the swap `(a,b)↦(b,a)` is a difference-preserving
+bijection `orderedPairsLt ↔ orderedPairsGt`, giving
+`∑_{(a,b)∈B.offDiag}(ℓ-|a-b|) = 2·∑_{p∈orderedPairsLt B}(ℓ - pairDiff p)`
+(`Finset.sum_bij` on the swap; `B.offDiag = orderedPairsLt ⊎ orderedPairsGt`).
+
+By injectivity (`Finset.sum_image` / `card_image_of_injOn`):
+`∑_{p∈orderedPairsLt B}(ℓ - pairDiff p) = ∑_{d ∈ (orderedPairsLt B).image pairDiff}(ℓ - d)`.
+The image is a set of *distinct positive* naturals; terms with `d ≥ ℓ` vanish, and
+`image ∩ Ico 1 ℓ ⊆ Ico 1 ℓ`, so by `Finset.sum_le_sum_of_subset_of_nonneg`:
+`≤ ∑_{d ∈ Finset.Ico 1 ℓ}(ℓ - d) = ∑_{k=1}^{ℓ-1} k = ℓ(ℓ-1)/2`
+(reindex `d ↦ ℓ-d`; Gauss sum `Finset.sum_range_id_mul_two` / `Gauss_sum`).
+
+Therefore the total `= 2·(ℓ(ℓ-1)/2) = ℓ(ℓ-1)`. ∎
+
+The only orientation-handling piece without a ready-made lemma is the
+factor-2 swap in Step 5; an alternative packaging is the single injection
+`φ(a,b) = (|a-b|, decide (a<b)) : B.offDiag ↪ Ico 1 ℓ × Bool`, whose injectivity
+follows from `IsSidon.diff_injective` (difference ⇒ unordered pair) plus the
+orientation bit, bounding the sum by `∑_{Ico 1 ℓ × Bool}(ℓ-d) = ℓ(ℓ-1)` directly.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
-
----
+- **The crux (distinct differences) is already formalized in the parent**
+  (`IsSidon.diff_injective`, `sidon_pairDiff_injective`). OQ-02 does **not** need
+  to reprove it — only to plug it into a double-counting/Gauss-sum assembly.
+- `window_pair_bound` is `HARD` (known result), **not** `OPEN`. It is the correct
+  target for Aristotle `prove_file` once the backend is reachable.
+- Closing it gives a 0-sorry OQ-02 file but does **not** by itself remove the
+  parent axiom: the `ℓ ≈ √N` optimisation that turns `sidon_window_key` into the
+  `√N + √√N + 1` bound is a separate (elementary but fiddly) ℕ-arithmetic step.
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Bounded/`interval_cases` enumeration cannot reach this — it is a genuine
+  infinite family. The window/Cauchy–Schwarz route in the file is the right one.
+
+---
+
+## Session 2026-06-18 (Session 2) — researcher-12
+
+**Mode**: REVISIT (claimed from pool) · **Outcome**: progress (ORIENT→ACT roadmap; verification blocked by infra)
+
+### What I did
+- Confirmed the OQ-02 file's structure: only `window_pair_bound` (line 123) is open;
+  `sidon_window_key` and `window_sum_identity` are fully proved.
+- Located the reusable parent infrastructure that supplies the Sidon crux
+  (`IsSidon.diff_injective` L109, `sidon_pairDiff_injective` L165, `orderedPairsLt`,
+  `pairDiff`) — established it removes the hardest sub-goal.
+- Worked out and recorded the **complete** Step 1–5 proof above (offDiag pairs →
+  filter pushthrough → Fubini → `cov = ℓ-|a-b|` via `Ico`/`Nat.card_Ico` →
+  Sidon-injective regrouping → Gauss sum `ℓ(ℓ-1)`), with exact Mathlib API.
+
+### Why no verified Lean this session
+- Aristotle backend returned `"Resource not found"` on `prove_file` (down).
+- Docker build host saturated: 9 `lean-build-*` containers, load avg ≈ 20, and the
+  parent `Erdos340GreedySidon.olean` is **not** cached, so a build would compile the
+  full parent+deps — irresponsible to add on a load-20 host. Did not build.
+
+### Next steps
+1. Submit the file to Aristotle `prove_file` when the MCP backend recovers — this
+   single HARD sorry is exactly its sweet spot.
+2. Or hand-formalize Steps 1–5 above (≈120–180 lines) in a warm-cache, low-load
+   window; build with `./proofs/scripts/docker-build.sh Proofs.Erdos340GreedySidonOQ02`.
+3. After 0-sorry: add the `ℓ ≈ √N` optimisation to derive the sharp bound and
+   discharge `axiom sidon_upper_bound` in the parent; flip parent meta
+   `axiomatized/axiom → verified` (axiomCount 1 → 0).

--- a/research/problems/erdos-340-greedy-sidon-oq-02/state.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-02/state.md
@@ -1,25 +1,33 @@
 # Research State: erdos-340-greedy-sidon-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-06-17T21:06:28-07:00
-**Iteration**: 1
+**Since**: 2026-06-18T13:00:00-07:00
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Close the single remaining `sorry` `window_pair_bound` (counting fact B) in
+`proofs/Proofs/Erdos340GreedySidonOQ02.lean`. The full Step 1–5 proof is recorded
+in knowledge.md, reusing parent infra (`sidon_pairDiff_injective`,
+`IsSidon.diff_injective`).
 
 ## Active Approach
-None yet.
+Sliding-window / Cauchy–Schwarz (Erdős–Turán, Lindström). Assembly
+(`sidon_window_key`) and counting fact A (`window_sum_identity`) are proved;
+counting fact B (`window_pair_bound`) is the only open obligation.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (window/Cauchy–Schwarz — correct route)
 
 ## Blockers
-None.
+- Aristotle MCP backend down ("Resource not found") — cannot delegate the HARD sorry.
+- Docker build host saturated (9 containers, load ~20, parent olean not cached) —
+  cannot build-verify a hand proof this session.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+1. Submit file to Aristotle `prove_file` when backend recovers.
+2. Or hand-formalize Steps 1–5 (knowledge.md) and build in a low-load window.
+3. Then add the `ℓ ≈ √N` optimisation to discharge `axiom sidon_upper_bound`.

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-02.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-02.json
@@ -1,0 +1,54 @@
+{
+  "slug": "erdos-340-greedy-sidon-oq-02",
+  "title": "Erdős #340 OQ-02: Erdős–Turán sharp upper bound for Sidon sets",
+  "status": "in-progress",
+  "phase": "ACT",
+  "tier": "B",
+  "path": "research/problems/erdos-340-greedy-sidon-oq-02",
+  "started": "2026-06-17",
+  "lastUpdate": "2026-06-18",
+  "tags": [
+    "combinatorics",
+    "additive-combinatorics",
+    "sidon-sets",
+    "extremal",
+    "cauchy-schwarz"
+  ],
+  "relatedProofs": [
+    "erdos-340-greedy-sidon"
+  ],
+  "problemStatement": "Remove the lone axiom `sidon_upper_bound` of the parent gallery entry by formalizing the sharp Erdős–Turán upper bound |A| ≤ √N + √√N + 1 for a Sidon set A ⊆ {1,…,N}, via the sliding-window / Cauchy–Schwarz argument.",
+  "leanFiles": [
+    "proofs/Proofs/Erdos340GreedySidonOQ02.lean"
+  ],
+  "tractability": "medium — the Cauchy–Schwarz assembly (`sidon_window_key`) and window-sum identity are proved; one HARD finite-combinatorics sorry (`window_pair_bound`) remains, plus a separate ℓ≈√N optimisation to discharge the parent axiom.",
+  "knowledge": {
+    "insights": [
+      "OQ-02 file proves the Erdős–Turán key inequality ℓ·|A|² ≤ (N+ℓ)·(ℓ-1+|A|) (`sidon_window_key`) unconditionally except for one counting lemma.",
+      "The only open obligation is `window_pair_bound` (line 123): ∑_x wc(x)(wc(x)-1) ≤ ℓ(ℓ-1) — known finite double-counting, classified HARD (not OPEN).",
+      "The Sidon crux (distinct differences) is ALREADY formalized in the parent: `IsSidon.diff_injective` and `sidon_pairDiff_injective` (InjOn pairDiff on orderedPairsLt). OQ-02 only needs to plug these into a Fubini + Gauss-sum assembly.",
+      "Complete Step 1–5 proof of `window_pair_bound` recorded in knowledge.md: offDiag pairs (`Finset.offDiag_card`) → filter pushthrough → Fubini (`Finset.sum_comm`) → cov(a,b)=ℓ-|a-b| via `Finset.Ico`/`Nat.card_Ico` → Sidon-injective regrouping (`Finset.sum_image`) → triangular/Gauss sum ℓ(ℓ-1).",
+      "Closing the sorry yields a 0-sorry OQ-02 file but does NOT alone remove the parent axiom; the ℓ≈√N optimisation of `sidon_window_key` into √N+√√N+1 is a separate elementary ℕ-arithmetic step."
+    ],
+    "builtItems": [
+      "Erdos340GreedySidonOQ02.lean: isSidon_image_add, card_image_add (translation invariance) — PROVED",
+      "Erdos340GreedySidonOQ02.lean: window_sum_identity (counting fact A, ∑ wc = ℓ|B|) — PROVED",
+      "Erdos340GreedySidonOQ02.lean: sidon_window_key (Cauchy–Schwarz key inequality) — PROVED modulo window_pair_bound"
+    ],
+    "mathlibGaps": [
+      "No gap blocking the proof — the Sidon injectivity crux is supplied by the parent file (IsSidon.diff_injective / sidon_pairDiff_injective).",
+      "Only orientation-handling piece without a ready-made lemma is the factor-2 swap (B.offDiag = orderedPairsLt ⊎ orderedPairsGt); handled by Finset.sum_bij on (a,b)↦(b,a) or a single φ:B.offDiag↪Ico 1 ℓ × Bool injection."
+    ],
+    "nextSteps": [
+      "Submit Erdos340GreedySidonOQ02.lean to Aristotle prove_file when the MCP backend recovers (currently returns 'Resource not found').",
+      "Or hand-formalize Steps 1–5 from knowledge.md (~120–180 lines) in a warm-cache low-load window; build via docker-build.sh Proofs.Erdos340GreedySidonOQ02.",
+      "After 0-sorry: add ℓ≈√N optimisation to discharge axiom sidon_upper_bound and flip parent meta axiomatized/axiom → verified (axiomCount 1→0)."
+    ],
+    "progressSummary": "PROGRESS: complete formalization roadmap for the single remaining sorry (window_pair_bound) recorded, reusing existing parent Sidon-injectivity infra; verification blocked this session by Aristotle outage + saturated Docker host."
+  },
+  "references": [
+    "P. Erdős and P. Turán, On a problem of Sidon in additive number theory, J. London Math. Soc. 16 (1941), 212–215.",
+    "H. Halberstam and K. F. Roth, Sequences, Ch. II.",
+    "https://www.erdosproblems.com/340"
+  ]
+}


### PR DESCRIPTION
## Summary

Advances **erdos-340-greedy-sidon-oq-02** (sharp Erdős–Turán upper bound for Sidon sets) from OBSERVE to ACT by recording a complete, infra-cited formalization roadmap for the single remaining `sorry`.

### Context
The OQ-02 Lean file (`Proofs/Erdos340GreedySidonOQ02.lean`) implements the sliding-window / Cauchy–Schwarz argument. Proved unconditionally: `isSidon_image_add`, `window_sum_identity` (counting fact A), and the key inequality `sidon_window_key` (ℓ·|A|² ≤ (N+ℓ)·(ℓ-1+|A|)). The one open obligation is `window_pair_bound` (counting fact B): ∑ₓ wc(x)(wc(x)−1) ≤ ℓ(ℓ−1) — **known finite combinatorics, classified HARD, not the open problem**. Closing it + a separate ℓ≈√N optimisation discharges `axiom sidon_upper_bound` (the parent's only axiom).

### This PR (docs/knowledge only — no Lean change)
- `knowledge.md`: the **complete Step 1–5 proof** of `window_pair_bound` with exact Mathlib API (`Finset.offDiag_card`, `Finset.sum_comm`, `Nat.card_Ico`, `Finset.sum_image`, Gauss sum), reusing the parent's already-proven Sidon crux (`IsSidon.diff_injective`, `sidon_pairDiff_injective`).
- `state.md`: phase OBSERVE → ACT.
- `src/data/research/problems/erdos-340-greedy-sidon-oq-02.json`: knowledge accumulation (insights/builtItems/mathlibGaps/nextSteps).

### Why no verified Lean this session
Aristotle MCP backend returned `Resource not found` (down); the Docker build host was saturated (9 `lean-build-*` containers, load ≈20, parent olean uncached) — not safe to add a heavy build. The roadmap is ready for Aristotle `prove_file` or a warm-cache build session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)