### PR TITLE
Fix: remove native_decide from Sqrt2Minpoly (axiom-integrity)

### DIFF
--- a/proofs/Proofs/Sqrt2Minpoly.lean
+++ b/proofs/Proofs/Sqrt2Minpoly.lean
@@ -45,7 +45,7 @@ private theorem irred_X_sq_sub_two_int : Irreducible (X ^ 2 - C (2 : ℤ) : ℤ[
   apply Polynomial.irreducible_of_eisenstein_criterion (P := Ideal.span {(2 : ℤ)})
   · -- (2) is a prime ideal in ℤ
     rw [Ideal.span_singleton_prime (show (2 : ℤ) ≠ 0 from by norm_num)]
-    exact Int.prime_iff_natAbs_prime.mpr (by native_decide)
+    exact Int.prime_two
   · -- Leading coefficient 1 ∉ (2)
     rw [leadingCoeff_X_pow_sub_C (show (0 : ℕ) < 2 from by norm_num),
         Ideal.mem_span_singleton]


### PR DESCRIPTION
## Fix

`Sqrt2Minpoly.lean` proved `Prime (2 : ℤ)` via `Int.prime_iff_natAbs_prime.mpr (by native_decide)`. `native_decide` trusts kernel `Lean.ofReduceBool`, so the proof was **not** axiom-free — yet `meta.json` declares `status: "verified"`, `axiomCount: 0`, and `"Fully verified with 0 axioms and 0 sorries"`. That was an overclaim.

Replaced the only `native_decide` with the canonical Mathlib lemma `Int.prime_two : Prime (2 : ℤ)`, which is exactly the goal after the `Ideal.span_singleton_prime` rewrite in the Eisenstein step.

## Evidence

**Before**: `exact Int.prime_iff_natAbs_prime.mpr (by native_decide)` → entry depends on `Lean.ofReduceBool`, contradicting the `axiomCount: 0` / verified claim.
**After**: `exact Int.prime_two` → no `native_decide`/`decide` anywhere in the file; the 0-axiom claim is now genuine.

**Build**: `./proofs/scripts/docker-build.sh Proofs.Sqrt2Minpoly` → `✔ [7743/7743] Built Proofs.Sqrt2Minpoly`, exit 0. No meta.json change needed (it already claimed 0 axioms; this makes it true).

---
Automated fix by lean-mechanic agent.