### PR TITLE
research(simson-line-theorem-oq-01): nine-point-circle membership of Simson bisection point (+2 thms, 0 ax, 0 sorry)

### DIFF
--- a/proofs/Proofs/SimsonLineTheorem.lean
+++ b/proofs/Proofs/SimsonLineTheorem.lean
@@ -211,7 +211,7 @@ theorem simson_converse {a b c p : ℂ}
         · rcases mul_eq_zero.mp h' with h'' | h''
           · exact (sub_ne_zero.mpr hca) h''
           · exact (sub_ne_zero.mpr hbc) h''
-        · exact (sub_ne_zero.mpr hab) h''
+        · exact (sub_ne_zero.mpr hab) h'
       · exact h
     have h2 : p * conj p = 1 := by linear_combination -hpp
     rw [Complex.mul_conj] at h2
@@ -273,7 +273,7 @@ theorem simson_bisects_key {a b c p : ℂ}
     (foot b c p - simsonMidpoint a b c p) * conj (foot a b p - simsonMidpoint a b c p)
       = conj (foot b c p - simsonMidpoint a b c p) * (foot a b p - simsonMidpoint a b c p) := by
   rw [foot_bc_sub_midpoint, foot_ab_sub_midpoint]
-  simp only [map_mul, map_sub, map_add, map_neg, map_div₀, map_one, map_ofNat, Complex.conj_conj]
+  simp only [map_mul, map_sub, map_add, map_neg, map_div₀, map_ofNat, Complex.conj_conj]
   rw [conj_eq_inv ha, conj_eq_inv hb, conj_eq_inv hc, conj_eq_inv hp]
   have ha0 := ne_zero_of_normSq_one ha
   have hb0 := ne_zero_of_normSq_one hb
@@ -320,7 +320,7 @@ theorem antipodal_simson_perp {a b c p : ℂ}
     ((foot b c p - foot a b p) * conj (foot b c (-p) - foot a b (-p))).re = 0 := by
   apply re_eq_zero_of_conj_eq_neg
   rw [foot_diff, foot_diff]
-  simp only [map_mul, map_sub, map_add, map_neg, map_div₀, map_one, map_ofNat, Complex.conj_conj]
+  simp only [map_mul, map_sub, map_neg, map_div₀, map_one, map_ofNat, Complex.conj_conj]
   rw [conj_eq_inv ha, conj_eq_inv hb, conj_eq_inv hc, conj_eq_inv hp]
   have ha0 := ne_zero_of_normSq_one ha
   have hb0 := ne_zero_of_normSq_one hb
@@ -328,5 +328,37 @@ theorem antipodal_simson_perp {a b c p : ℂ}
   have hp0 := ne_zero_of_normSq_one hp
   field_simp
   ring
+
+/-! ## The Simson bisection point lies on the nine-point circle
+
+A further classical refinement. The Simson line of `P` passes through the midpoint
+`M = (P + H)/2` of `P` and the orthocenter `H` (`simson_bisects_orthocenter_segment`). That
+midpoint `M` is itself distinguished: it lies on the **nine-point circle** of `△ABC`.
+
+For the unit circumcircle (centre `0`) the nine-point circle has centre `N = H/2 = (A+B+C)/2`
+and radius `1/2`. The vector from `N` to `M` is `M - N = P/2`, so `|M - N| = |P|/2 = 1/2`,
+placing `M` on that circle. Combined with the bisection theorem, the point where the Simson line
+of `P` meets the segment `PH` is pinned to the nine-point circle — independently of `P`. -/
+
+/-- The **nine-point centre** of a triangle inscribed in the unit circle (centre `0`): the
+midpoint of the segment from the circumcentre `0` to the orthocenter `H = A + B + C`, i.e. `H/2`.
+The nine-point circle has this centre and radius `1/2`. -/
+noncomputable def ninePointCenter (a b c : ℂ) : ℂ := orthocenter a b c / 2
+
+/-- The vector from the nine-point centre `N = H/2` to the Simson bisection point `M = (P+H)/2`
+is exactly `P/2` (pure `ring`). -/
+theorem simsonMidpoint_sub_ninePointCenter (a b c p : ℂ) :
+    simsonMidpoint a b c p - ninePointCenter a b c = p / 2 := by
+  simp only [simsonMidpoint, ninePointCenter, orthocenter]; ring
+
+/-- **The Simson bisection point lies on the nine-point circle.** For `A, B, C, P` on the unit
+circumcircle, the midpoint `M = (P + H)/2` of `P` and the orthocenter — the point at which the
+Simson line of `P` bisects `PH` (`simson_bisects_orthocenter_segment`) — lies on the nine-point
+circle of `△ABC`, which has centre `N = H/2` (`ninePointCenter`) and radius `1/2`, encoded as
+`|M - N|² = 1/4`. -/
+theorem simsonMidpoint_on_nine_point_circle {a b c p : ℂ} (hp : Complex.normSq p = 1) :
+    Complex.normSq (simsonMidpoint a b c p - ninePointCenter a b c) = 1 / 4 := by
+  rw [simsonMidpoint_sub_ninePointCenter, Complex.normSq_div, hp, Complex.normSq_ofNat]
+  norm_num
 
 end SimsonLineTheorem

--- a/research/problems/simson-line-theorem-oq-01/state.md
+++ b/research/problems/simson-line-theorem-oq-01/state.md
@@ -1,25 +1,40 @@
 # Research State: simson-line-theorem-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: VERIFY
 **Path**: full
-**Since**: 2026-06-16T06:31:45-07:00
-**Iteration**: 1
+**Since**: 2026-06-18
+**Iteration**: 5
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Nine-point-circle refinement of the Simson-line results. The Simson bisection point
+M = (P+H)/2 — where the Simson line of P meets segment PH — lies on the nine-point circle
+of △ABC (centre N = H/2, radius 1/2). Proved in SimsonLineTheorem.lean via the pure-ring
+identity M − N = P/2, hence |M − N|² = |P|²/4 = 1/4 on the unit circumcircle.
 
 ## Active Approach
-None yet.
+Complex-number model on the unit circumcircle (circumcentre 0, orthocenter H = A+B+C).
+Same conj z = z⁻¹ + field_simp + ring engine as simson_key / simson_bisects_orthocenter_segment.
+New: ninePointCenter def + simsonMidpoint_sub_ninePointCenter (ring) + simsonMidpoint_on_nine_point_circle.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 5
+- Current approach attempts: 1
+- Approaches tried: 1 (complex-number / conjugate-substitution)
+
+## Established Results (verified/original, 0 axioms, 0 sorries)
+- simson_key / simson_collinear: Simson's theorem (three feet collinear)
+- simson_area_identity / simson_converse / simson_iff: converse + biconditional (collinear feet ⇔ |P|²=1)
+- simson_bisects_orthocenter_segment: Simson line of P bisects PH
+- antipodal_simson_perp: Simson lines of P and −P are perpendicular
+- simsonMidpoint_on_nine_point_circle: bisection point lies on the nine-point circle (NEW)
 
 ## Blockers
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Docker build CONFIRMED GREEN (3062 jobs, 0 sorries, 0 axioms). En route also fixed a
+build-breaking typo in simson_converse (line 214: `h''` → `h'`; the second branch of the
+outer rcases binds `h'`, so the prior branch state never actually compiled) and removed
+two genuinely-unused simp args. Committing + pushing + PR. Subsequent directions:
+Steiner deltoid envelope (needs tangency, not pure ring) — harder, deferred.

--- a/src/data/proofs/simson-line-theorem-oq-01/meta.json
+++ b/src/data/proofs/simson-line-theorem-oq-01/meta.json
@@ -56,15 +56,16 @@
       "Antipodal perpendicularity: the Simson lines of P and its antipode -P are perpendicular (antipodal_simson_perp); the antipode flips conj p -> -conj p, collapsing the Hermitian product of the two foot-difference directions to |c-a|²/4·(conj b·p - b·conj p), purely imaginary, so its real part vanishes — same conj z = z⁻¹ + field_simp + ring engine",
       "Master identity simson_area_identity: keeping conj p free gives w - conj w = (c-a)(b-c)(a-b)(1 - p*conj p)/(4abc), valid for ANY P (off the circle too)",
       "Converse direction simson_converse: for a nondegenerate triangle, collinearity of the three feet forces |P|² = 1 (P concyclic with A,B,C), via the nonzero triangle prefactor",
-      "Headline biconditional simson_iff: the three pedal feet are collinear if and only if P lies on the circumcircle — the complete statement of Simson's (Wallace's) theorem"
+      "Headline biconditional simson_iff: the three pedal feet are collinear if and only if P lies on the circumcircle — the complete statement of Simson's (Wallace's) theorem",
+      "Nine-point circle membership: the Simson bisection point M = (P+H)/2 (where the Simson line meets segment PH) lies on the nine-point circle of △ABC, which has centre N = H/2 (ninePointCenter) and radius 1/2; proved via the pure-ring identity M − N = P/2 (simsonMidpoint_sub_ninePointCenter), so |M − N|² = |P|²/4 = 1/4 on the unit circumcircle (simsonMidpoint_on_nine_point_circle)"
     ],
     "dateAdded": "2026-06-16",
     "axiomCount": 0,
-    "lineCount": 332,
+    "lineCount": 364,
     "assumptions": "0 axioms. 0 sorries. Fully verified. Circumcircle normalised to the unit circle (Complex.normSq = 1) without loss of generality; on that normalisation the orthocenter is A+B+C.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 14,
-    "definitionCount": 3
+    "theoremCount": 16,
+    "definitionCount": 4
   },
   "sections": [
     {
@@ -114,6 +115,14 @@
       "description": "Completes Simson's theorem to a biconditional. Keeping conj p free in the collinearity computation yields the master identity w - conj w = (c-a)(b-c)(a-b)(1 - p*conj p)/(4abc) (simson_area_identity), valid for any P. For a nondegenerate triangle the prefactor is nonzero, so the feet are collinear iff 1 - |P|² = 0, i.e. P is concyclic with A, B, C.",
       "summary": "Master identity simson_area_identity (any P) gives the converse simson_converse (collinear feet ⇒ |P|²=1) and the headline biconditional simson_iff.",
       "id": "converse-biconditional"
+    },
+    {
+      "title": "Nine-Point Circle Membership",
+      "startLine": 333,
+      "endLine": 363,
+      "description": "ninePointCenter N = H/2; simsonMidpoint_sub_ninePointCenter: the bisection point M = (P+H)/2 satisfies M − N = P/2 (pure ring); simsonMidpoint_on_nine_point_circle: hence |M − N|² = 1/4, placing M on the nine-point circle (centre H/2, radius 1/2) for any P on the unit circumcircle.",
+      "summary": "Nine-Point Circle Membership",
+      "id": "nine-point-circle-membership"
     }
   ],
   "overview": {
@@ -136,16 +145,16 @@
       "Collinearity of complex points via the vanishing imaginary part of a cross product"
     ],
     "openQuestions": [
-      "Can the Steiner deltoid (the envelope of all Simson lines as P moves on the circumcircle) be formalized?",
-      "Can the fact that the Simson line bisects the segment from P to the orthocenter be proved in this framework?"
+      "Can the Steiner deltoid (the envelope of all Simson lines as P moves on the circumcircle) be formalized? This needs a tangency/envelope argument rather than the pure-ring engine used here.",
+      "The bisection of segment PH (simson_bisects_orthocenter_segment) and the nine-point-circle membership of that bisection point (simsonMidpoint_on_nine_point_circle) are now formalized; can the full nine-point circle (all nine classical points) be characterized in this framework?"
     ]
   },
   "conclusion": {
     "summary": "Simson's theorem is formalized as a complete biconditional in complex coordinates with the circumcircle normalised to the unit circle. The closed-form perpendicular foot foot(u,v,p) = (u+v+p − u·v·conj p)/2 and its difference identity reduce collinearity of the three feet to the complex criterion w = conj w. Keeping conj p free upgrades this to the master identity w − conj w = (c−a)(b−c)(a−b)(1 − p·conj p)/(4abc), whose 1 − |P|² factor delivers both directions: the feet are collinear iff P lies on the circumcircle (simson_iff). All steps are discharged by the conj z = z⁻¹ substitution with field_simp and ring; no axioms, no sorries.",
     "implications": "**Theoretical Significance**: The proof again demonstrates the leverage of complex coordinates in classical plane geometry: a metric statement about perpendicular feet on a circle becomes a rational identity. The unit-circle substitution conj z = z⁻¹ is the same device that powers the complex proofs of Ptolemy's and Napoleon's theorems, situating Simson's line within a common algebraic toolkit for circle and triangle geometry.",
     "openQuestions": [
-      "Can the Steiner deltoid envelope of Simson lines be formalized?",
-      "Can the Simson-line/orthocenter bisection property be established in this framework?"
+      "Can the Steiner deltoid envelope of Simson lines be formalized (needs a tangency/envelope argument)?",
+      "The Simson-line/orthocenter bisection and the nine-point-circle membership of the bisection point are now formalized; can the complete nine-point circle be characterized in this framework?"
     ]
   },
   "crossReferences": [
@@ -171,10 +180,10 @@
       "ComplexConjugate"
     ],
     "namespace": "SimsonLineTheorem",
-    "lineCount": 332,
+    "lineCount": 364,
     "axiomCount": 0,
-    "theoremCount": 14,
-    "definitionCount": 3,
+    "theoremCount": 16,
+    "definitionCount": 4,
     "sorries": 0,
     "path": "Proofs/SimsonLineTheorem.lean"
   }


### PR DESCRIPTION
## Summary

Extends the Simson-line formalization (`simson-line-theorem-oq-01`) with a classical refinement and fixes a build-breaking bug discovered during verification.

### New result: nine-point-circle membership
The Simson bisection point `M = (P + H)/2` — the point where the Simson line of `P` meets segment `PH` (already established by `simson_bisects_orthocenter_segment`) — lies on the **nine-point circle** of `△ABC` (centre `N = H/2`, radius `1/2`).

- `ninePointCenter a b c := orthocenter a b c / 2` (new def)
- `simsonMidpoint_sub_ninePointCenter`: `M − N = P/2` (pure `ring`)
- `simsonMidpoint_on_nine_point_circle`: `|M − N|² = 1/4` for `P` on the unit circumcircle

### Build fix
While verifying, the existing `simson_converse` failed to compile: the second branch of the outer `rcases ... with h' | h'` binds `h'`, but the body referenced an out-of-scope `h''` (`Unknown identifier h''`). The prior branch state never built green. Fixed `h''` → `h'`. Also removed two genuinely-unused `simp` arguments flagged by `linter.unusedSimpArgs`.

## Verification
- **Docker build green** (`./proofs/scripts/docker-build.sh Proofs.SimsonLineTheorem`, 3062 jobs)
- 16 theorems, 4 definitions, **0 axioms, 0 sorries**, 364 lines
- meta.json counts/sections/line ranges updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)