### PR TITLE
audit(erdos-661 + riemann-hypothesis): fix overclaimed axiomatization + literal axiom count

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4817,9 +4817,9 @@
       "result": "clean"
     },
     "erdos-152": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "lastAudited": "2026-06-18T20:56:51Z",
       "result": "clean"
     },
     "erdos-152-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5235,9 +5235,9 @@
     },
     "erdos-203": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T20:53:13Z",
+      "result": "issues-fixed"
     },
     "erdos-204": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4720,8 +4720,8 @@
     },
     "erdos-139": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T20:59:34Z",
       "result": "clean"
     },
     "erdos-14": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8749,9 +8749,12 @@
     },
     "erdos-661": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-04T04:04:41Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-06-18T20:40:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "axiomCount 2→0 (no axiom decls; F/f are opaque stubs := fun _=>0 asserting nothing); status axiomatized→formalized; rewrote proofStrategy/section/conclusion prose that falsely claimed F/f, the conjecture, Guth–Katz, and lattice bounds were axiomatized — they are opaque placeholders or prose comments. Only Lenz ℝ⁴ + infra proved."
+      ]
     },
     "erdos-662": {
       "agentId": "auditor-cycle-20-batch",
@@ -12873,10 +12876,12 @@
       "result": "clean"
     },
     "riemann-hypothesis": {
-      "auditCount": 4,
-      "issues": [],
-      "lastAudited": "2026-05-04T04:08:16Z",
-      "result": "clean"
+      "auditCount": 5,
+      "issues": [
+        "leanFile.axiomCount 44→32 to match literal axiom declarations (32); meta.axiomCount kept at 44 as literal+structure-assumption aggregate per convention."
+      ],
+      "lastAudited": "2026-06-18T20:40:00Z",
+      "result": "issues-fixed"
     },
     "roth-theorem-k3": {
       "auditCount": 5,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5256,8 +5256,8 @@
     },
     "erdos-206": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-18T20:40:02Z",
       "result": "clean"
     },
     "erdos-207": {
@@ -15934,6 +15934,12 @@
     "napoleons-theorem-oq-03": {
       "auditCount": 1,
       "lastAudited": "2026-06-18T18:45:39Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pentagonal-number-theorem-oq-01": {
+      "auditCount": 2,
+      "lastAudited": "2026-06-18T20:41:43Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/erdos-137/meta.json
+++ b/src/data/proofs/erdos-137/meta.json
@@ -48,9 +48,9 @@
       "Axiomatization of the main conjecture (powerful products)",
       "Verified counterexample: 72 = 8 × 9 is powerful for k=2"
     ],
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 225,
-    "assumptions": "2 axioms: erdos_selfridge_theorem, erdos_powerful_conjecture. See Lean source for complete statements.",
+    "assumptions": "2 axiom declarations (erdos_selfridge_theorem, erdos_powerful_conjecture) plus Lean.ofReduceBool: the credited counterexample theorem two_consecutive_can_be_powerful proves consecutiveProduct 7 2 = 72 via native_decide, which trusts the compiler's kernel reduction (Lean.ofReduceBool). leanFile.axiomCount remains 2 (literal axiom declarations only). 0 sorries. See Lean source for complete statements.",
     "theoremCount": 9,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-203/meta.json
+++ b/src/data/proofs/erdos-203/meta.json
@@ -16,7 +16,7 @@
       "sierpinski",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 203,
     "erdosUrl": "https://erdosproblems.com/203",
@@ -56,9 +56,9 @@
       "IsGeneralizedAvoiding definition: multi-prime generalization",
       "erdos_203_statement theorem: formal main statement"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 390,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified.",
+    "assumptions": "Depends on Lean.ofReduceBool: the Selfridge supporting result selfridge_sierpinski_is_sierpinski (78557 is a Sierpiński number) is proved via covering_prime, which discharges its divisibility and period facts with `native_decide` (7 calls). native_decide trusts the compiler's kernel reduction and so introduces the Lean.ofReduceBool axiom (the proof is not axiom-free). No literal `axiom` declarations and 0 sorries. The main Erdős #203 conjecture (ErdosConjecture203) remains OPEN and is stated, not proved.",
     "theoremCount": 44,
     "definitionCount": 13
   },

--- a/src/data/proofs/erdos-661/meta.json
+++ b/src/data/proofs/erdos-661/meta.json
@@ -5,7 +5,7 @@
   "description": "Do there exist point sets x₁,...,xₙ and y₁,...,yₙ in ℝ² with o(n/√log n) distinct bipartite distances? Is F(2n) = o(f(2n))? In ℝ⁴ all distances can be equal (Lenz). $50 reward. Open.",
   "meta": {
     "erdosNumber": 661,
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos661Problem.lean",
     "tags": [
       "erdos",
@@ -19,10 +19,10 @@
     "sourceUrl": "https://erdosproblems.com/661",
     "erdosUrl": "https://erdosproblems.com/661",
     "erdosProblemStatus": "open",
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 10,
     "lineCount": 164,
-    "assumptions": "2 assumption-bearing opaque constants (minBipartiteDist and minDistinct2n, both declared `opaque ... := fun _ => 0` as placeholders since exact values are unknown). 0 explicit `axiom` declarations, 0 sorries. The Lenz construction theorems in ℝ⁴ are fully proved.",
+    "assumptions": "0 `axiom` declarations and 0 sorries. F(2n) and f(2n) are declared as `opaque` constants with concrete bodies (`:= fun _ => 0`); being sealed definitions with a fixed value they assert nothing and carry no assumption. The deep results (the F(2n) = o(f(2n)) conjecture, the Guth–Katz lower bound, and the lattice upper bound) appear only as informal comments and are NOT formalized. The verified mathematical content is the elementary distance-squared infrastructure, the bipartite-distance-set cardinality bound, and the Lenz construction in ℝ⁴ (all bipartite distances equal √2), all fully proved.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
     "definitionCount": 9
@@ -49,32 +49,32 @@
       "title": "Part III: Extremal Functions F(2n) and f(2n)",
       "startLine": 38,
       "endLine": 45,
-      "summary": "Axiomatizes $F(2n)$, the minimum bipartite distinct distances between two $n$-point sets, and $f(2n)$, the minimum over all $2n$-point sets. The central question is whether $F(2n) = o(f(2n))$.",
-      "mathContext": "Axiomatized: Axiomatizes $F(2n)$, the minimum bipartite distinct distances between two $n$-point sets, and $f(2n)$, the minimum over all $2n$-point sets. The central question is whether $F(2n) = o(f(2n))$."
+      "summary": "Declares $F(2n)$ (the minimum bipartite distinct distances between two $n$-point sets) and $f(2n)$ (the minimum over all $2n$-point sets) as `opaque` placeholder constants with body `:= fun _ => 0`, since their exact values are unknown. These are sealed definitions, not axioms — they assert nothing. The central question is whether $F(2n) = o(f(2n))$.",
+      "mathContext": "Declares $F(2n)$ and $f(2n)$ as `opaque` placeholder constants (`:= fun _ => 0`), since their exact values are unknown. These are sealed definitions, not axioms, and assert nothing."
     },
     {
       "id": "main-conjecture",
       "title": "Part IV: The Erdős–Pach Conjecture",
       "startLine": 46,
       "endLine": 55,
-      "summary": "States the main conjecture: $\\forall \\varepsilon > 0, \\exists N_0$ such that $n \\ge N_0 \\Rightarrow F(2n) \\le \\varepsilon \\cdot f(2n)$, formalized as `erdos_661_bipartite_advantage`. This asserts the bipartite structure provides asymptotically fewer distances.",
-      "mathContext": "States the main conjecture: $\\forall \\varepsilon > 0, \\exists N_0$ such that $n \\ge N_0 \\Rightarrow F(2n) \\le \\varepsilon \\cdot f(2n)$, formalized as `erdos_661_bipartite_advantage`."
+      "summary": "States the main conjecture in an informal source comment: $\\forall \\varepsilon > 0, \\exists N_0$ such that $n \\ge N_0 \\Rightarrow F(2n) \\le \\varepsilon \\cdot f(2n)$. This is NOT formalized as a Lean declaration — it is documented as prose only.",
+      "mathContext": "States the main conjecture as an informal source comment ($F(2n) = o(f(2n))$). It is NOT formalized as a Lean declaration."
     },
     {
       "id": "guth-katz",
       "title": "Part V: Guth–Katz Lower Bound",
       "startLine": 56,
       "endLine": 64,
-      "summary": "Axiomatizes the landmark Guth–Katz (2015) result: $f(2n) \\ge C \\cdot n / \\log n$ for some constant $C > 0$. This essentially resolved Erdős's distinct distances problem (Problem #89) and sets the benchmark for the bipartite variant.",
-      "mathContext": "Axiomatizes the landmark Guth–Katz (2015) result: $f(2n) \\ge C \\cdot n / \\log n$ for some constant $C > 0$."
+      "summary": "Documents, as an informal source comment, the landmark Guth–Katz (2015) result $f(2n) \\ge C \\cdot n / \\log n$ for some constant $C > 0$. This essentially resolved Erdős's distinct distances problem (Problem #89) and sets the benchmark for the bipartite variant. It is described in prose only and is NOT formalized as a Lean declaration.",
+      "mathContext": "Documents the Guth–Katz (2015) result $f(2n) \\ge C \\cdot n / \\log n$ as an informal source comment. It is NOT formalized as a Lean declaration."
     },
     {
       "id": "lattice-upper",
       "title": "Part VI: Lattice Upper Bound",
       "startLine": 65,
       "endLine": 71,
-      "summary": "Axiomatizes the lattice upper bound: $f(2n) \\le C \\cdot n / \\sqrt{\\log n}$, achieved by the integer lattice $\\{1,\\ldots,\\sqrt{n}\\}^2$. The gap between $n/\\log n$ and $n/\\sqrt{\\log n}$ remains open even for general point sets.",
-      "mathContext": "Axiomatizes the lattice upper bound: $f(2n) \\le C \\cdot n / \\sqrt{\\log n}$, achieved by the integer lattice $\\{1,\\ldots,\\sqrt{n}\\}^2$. The gap between $n/\\log n$ and $n/\\sqrt{\\log n}$ remains open even for general point sets."
+      "summary": "Documents, as an informal source comment, the lattice upper bound $f(2n) \\le C \\cdot n / \\sqrt{\\log n}$, achieved by the integer lattice $\\{1,\\ldots,\\sqrt{n}\\}^2$. The gap between $n/\\log n$ and $n/\\sqrt{\\log n}$ remains open even for general point sets. It is described in prose only and is NOT formalized as a Lean declaration.",
+      "mathContext": "Documents the lattice upper bound $f(2n) \\le C \\cdot n / \\sqrt{\\log n}$ as an informal source comment. It is NOT formalized as a Lean declaration."
     },
     {
       "id": "lenz-construction",
@@ -89,7 +89,7 @@
     "historicalContext": "Erdős and Pach posed Problem #661 around 1990, asking whether bipartite point configurations in ℝ² can have asymptotically fewer distinct cross-distances than general configurations. The question is deeply connected to the celebrated Erdős distinct distances problem (Problem #89), essentially resolved by Guth and Katz in 2015 using the polynomial method and algebraic geometry of ruled surfaces. Their proof showed f(2n) ≥ Ω(n/log n), matching the lattice upper bound f(2n) ≤ O(n/√(log n)) up to a √(log n) factor. For the bipartite variant, Lenz demonstrated that in ℝ⁴, placing points on two orthogonal circles yields F(2n) = 1 — a maximal saving. Whether any analogous saving is possible in ℝ² remains completely open, making this one of the outstanding problems in combinatorial geometry. The problem connects to the Szemerédi–Trotter incidence theorem, Elekes–Rónyai type results on expanding polynomials, and the sum-product phenomenon.",
     "problemStatement": "Do there exist point sets x₁,...,xₙ and y₁,...,yₙ in ℝ² such that the number of distinct distances d(xᵢ,yⱼ) is o(n/√(log n))?",
     "text": "Do there exist point sets x₁,...,xₙ and y₁,...,yₙ in ℝ² with o(n/√log n) distinct bipartite distances? Is F(2n) = o(f(2n))? In ℝ⁴ all distances can be equal (Lenz). $50 reward. Open.",
-    "proofStrategy": "We define ℝ² points and squared Euclidean distance, then construct the bipartite distance set via Finset product. The extremal functions F(2n) and f(2n) are axiomatized. The main conjecture, Guth–Katz lower bound, lattice upper bound, and Lenz's ℝ⁴ construction are formalized as axioms. The structure separates definitions (computable) from deep results (axiomatized).",
+    "proofStrategy": "We define ℝ² points and squared Euclidean distance, then construct the bipartite distance set via Finset product and prove its elementary properties (non-negativity, symmetry, the cardinality bound, monotonicity). The extremal functions F(2n) and f(2n) are declared as `opaque` placeholder constants (sealed value 0), since their exact values are unknown. The deep results — the F(2n) = o(f(2n)) conjecture, the Guth–Katz lower bound, and the lattice upper bound — are recorded only as informal comments and are NOT formalized. The single substantive formalized result is Lenz's ℝ⁴ construction: two orthogonal unit circles whose every bipartite distance equals √2 (so F₄(2n) = 1), proved with 0 axioms and 0 sorries.",
     "keyInsights": [
       "**Guth–Katz polynomial method**: Their 2015 proof that $f(2n) \\ge \\Omega(n/\\log n)$ used the Elekes–Sharir framework, reducing distinct distances to counting point-line incidences in 3D, then bounding these via algebraic geometry of ruled surfaces",
       "**Lenz construction in $\\mathbb{R}^4$**: Two orthogonal unit circles in $\\mathbb{R}^4$ yield $F(2n) = 1$, showing that dimensional constraints are essential — the problem is specifically about $\\mathbb{R}^2$",
@@ -103,7 +103,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #661 asks whether the bipartite structure can reduce the number of distinct distances below the general Guth–Katz threshold in ℝ². The formalization captures the extremal functions F(2n) and f(2n), the Guth–Katz and lattice bounds, and the Lenz construction showing dramatic savings in ℝ⁴. The problem remains fully open in the plane.",
+    "summary": "Erdős Problem #661 asks whether the bipartite structure can reduce the number of distinct distances below the general Guth–Katz threshold in ℝ². This entry provides verified infrastructure (squared-distance properties, the bipartite-distance-set cardinality bound) and a full formalization of the Lenz construction in ℝ⁴, which shows all bipartite distances can be made equal (F₄(2n) = 1). The extremal functions F(2n) and f(2n) are opaque placeholders, and the Guth–Katz lower bound, lattice upper bound, and the main conjecture are recorded as background commentary rather than formalized. The problem remains fully open in the plane.",
     "implications": "**Theoretical Significance**: Resolving this would clarify whether bipartite point configurations have fundamentally different distance properties than general configurations.\n\nA positive answer (F(2n) = o(f(2n))) would reveal hidden structure in bipartite geometry; a negative answer would suggest the Guth–Katz bound is universal. Either way, the result would impact incidence geometry, additive combinatorics, and the sum-product phenomenon.",
     "openQuestions": [
       "Is F(2n) = o(f(2n)) in ℝ²? Even a single construction beating the lattice bound would be significant",
@@ -123,7 +123,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 164,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 9,
     "path": "Proofs/Erdos661Problem.lean",

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -355,7 +355,7 @@
     "opens": [],
     "namespace": "RiemannHypothesis",
     "lineCount": 6594,
-    "axiomCount": 44,
+    "axiomCount": 32,
     "theoremCount": 363,
     "definitionCount": 63,
     "path": "Proofs/RiemannHypothesis.lean",


### PR DESCRIPTION
## Gallery Integrity Audit

Two integrity issues found during a gallery-wide axiom/sorry discrepancy scan.

### 1. erdos-661 — fabricated axiomatization claims (MEDIUM/HIGH)

**meta.json claimed:**
- `status: axiomatized`, `axiomCount: 2`
- proofStrategy: *"The extremal functions F(2n) and f(2n) are axiomatized. The main conjecture, Guth–Katz lower bound, lattice upper bound ... are formalized as axioms."*
- Section summaries: *"Axiomatizes F(2n)/f(2n)"*, *"formalized as `erdos_661_bipartite_advantage`"*, *"Axiomatizes the landmark Guth–Katz (2015) result"*, *"Axiomatizes the lattice upper bound"*

**Lean source (`Proofs/Erdos661Problem.lean`) actually shows:**
- **0 `axiom` declarations, 0 sorries** (verified, block-comment-aware).
- `F(2n)`/`f(2n)` are `opaque` constants with concrete bodies `:= fun _ => 0` — sealed definitions that assert nothing (not axioms, carry no assumption).
- The conjecture, Guth–Katz bound, and lattice bound appear **only as `/- … -/` prose comments**. No `erdos_661_bipartite_advantage` declaration exists.
- The only substantive formalized result is the **Lenz ℝ⁴ construction** (`lenz_distSq4_eq`, `lenzCircle1_unit`, `lenzCircle2_unit`), plus elementary distance-squared lemmas and a bipartite-distance-set cardinality bound — all genuinely proved.

**Fix:** `axiomCount` 2→0 (meta + leanFile); `status` axiomatized→formalized (badge `wip` retained — open problem, infrastructure only); rewrote proofStrategy, the four section summaries/mathContexts, conclusion summary, and assumptions to state what is actually formalized vs. documented in prose.

### 2. riemann-hypothesis — leanFile.axiomCount off

**meta.json claimed:** `leanFile.axiomCount: 44`.
**Source shows:** **32** literal `axiom` declarations (verified raw + block-stripped).

The file additionally has assumption-carrying structures (`SelbergClassAxioms`, `SiegelZero`, `ZetaMoment`, …), so `meta.axiomCount: 44` is left in place as the literal+structure aggregate. Per the `leanFile.axiomCount = literal-only` / `meta.axiomCount = aggregate` convention, only `leanFile.axiomCount` is corrected (44→32). Status `axiomatized/axiom` is correct and unchanged.

All changes are meta.json-only; no Lean source modified. JSON validated.