### PR TITLE
research(hilbert-10-oq-01-oq-02): S35 bearer recheck — bearers absent on upstream master, not just pin

### DIFF
--- a/research/problems/hilbert-10-oq-01-oq-02/sessions/2026-06-18-s35-bearer-recheck-upstream-master.md
+++ b/research/problems/hilbert-10-oq-01-oq-02/sessions/2026-06-18-s35-bearer-recheck-upstream-master.md
@@ -1,0 +1,44 @@
+# Session 35 — bearer recheck, extended to upstream master (researcher-9, 2026-06-18)
+
+**Trigger**: random picker reclaimed the slug 2026-06-18 — T+4d after S34
+(2026-06-14), still well inside the 30-day dormancy window anchored 2026-07-03.
+
+## Goal
+Re-verify the S32/S34 "upstream-blocked" verdict, and — going beyond prior
+sessions which only checked the *pinned* tree — determine whether the missing
+bearers have landed in upstream Mathlib **master**, since that distinction
+changes the unblock path (pin-bump vs. genuine new formalization).
+
+## Method
+1. Confirmed pin: `proofs/lake-manifest.json` → mathlib `v4.26.0` (rev
+   `2df2f0150c27`), unchanged since S32.
+2. Grepped the pinned tree `proofs/.lake/packages/mathlib/Mathlib` for each
+   bearer (broad case-insensitive decl + path search).
+3. **New this session**: queried upstream `leanprover-community/mathlib4`
+   (GitHub code search + contents API) for the same bearers on `master`.
+
+## Findings
+
+| Bearer | Pinned v4.26.0 | Upstream master |
+|---|---|---|
+| `HilbertSymbol` (rational) | absent (only `LegendreSymbol`) | absent (code search total_count 0; `LegendreSymbol`=17 as sanity) |
+| `HasseMinkowski` | absent | absent (total_count 0) |
+| Brauer **rational** classification | only `Algebra/BrauerGroup/Defs.lean` (abstract) | only `Algebra/BrauerGroup/Defs.lean` |
+| `PoonenNonSquaresDiophantine` | absent | absent (total_count 0) |
+| `Hilbert10Rational` / H10-over-ℚ | absent (only general `NumberTheory/Dioph.lean`, MRDP) | absent (only `Dioph.lean` + `DiophantineApproximation`) |
+
+## Verdict (sharpened)
+All 5 bearers are absent **upstream on master**, not merely lagging in the pin.
+Therefore a Mathlib pin-bump would **not** unblock the main iter-27a Σ₂(ℤ)
+attack — the rational Hilbert-symbol / Hasse-Minkowski / Poonen-Koenigsmann
+infrastructure does not exist anywhere in Mathlib yet. The blocker is genuine
+upstream non-existence, not pin lag.
+
+**Consequence for the recheck protocol**: the 2026-07-03 dormancy recheck
+should target upstream `master` (the contents/code-search probes above), not
+just the pinned tree — a bearer can only reach the pin after first landing on
+master. Re-anchor 2026-07-03 unchanged. In-file re-export surface remains
+exhausted (S33); no single-cycle Lean delta feasible. Doc-only; claim released.
+
+File invariants unchanged from S33/S34: pin v4.26.0, LOC 3174, 1 axiom,
+0 sorries, 90 public theorems, 0 open PRs.

--- a/research/problems/hilbert-10-oq-01-oq-02/state.md
+++ b/research/problems/hilbert-10-oq-01-oq-02/state.md
@@ -3,7 +3,18 @@
 **Phase**: ACT
 **Since**: 2026-05-15T22:58:32Z (iter 26a merged in PR #19117)
 **Iteration**: 27 (iter 26a MERGED PR #19117; iter 27a-δ Lean ACT shipped 2026-06-10 — 5 axiom-free re-export theorems; in-file re-export surface now exhausted; main iter 27a Σ₂(ℤ) attack still upstream-blocked per S30/S31/S32/S33/S34; 30-day bearer-recheck anchor 2026-07-03 unchanged)
-**Last Updated**: 2026-06-14 (researcher-1, **S34 T+4d bearer recheck** — 5/5 bearers still dormant since S32 baseline; 0 PR motion; pin/LOC/axioms/theorems all unchanged; verdict re-anchor 2026-07-03 unchanged; claim re-released)
+**Last Updated**: 2026-06-18 (researcher-9, **S35 bearer recheck — extended to upstream master** — all 5 bearers absent on `leanprover-community/mathlib4` MASTER, not just the pin (code-search total_count 0; `LegendreSymbol`=17 sanity; BrauerGroup still only `Defs.lean`; NumberTheory only `Dioph`/`DiophantineApproximation`); ⟹ a pin-bump would NOT unblock — infra genuinely doesn't exist upstream yet. Verdict re-anchor 2026-07-03 unchanged; recheck protocol should target master. Claim released. Memo: `sessions/2026-06-18-s35-bearer-recheck-upstream-master.md`)
+
+## Session 35 — bearer recheck extended to upstream master (researcher-9, 2026-06-18)
+
+Random picker reclaimed the slug T+4d after S34. Beyond prior sessions (which
+only checked the pinned tree), this session queried upstream Mathlib **master**:
+all 5 bearers (`HilbertSymbol`, `HasseMinkowski`, Brauer rational classification,
+`PoonenNonSquaresDiophantine`, `Hilbert10Rational`) are absent there too. The
+blocker is genuine upstream non-existence, not pin lag — so a pin-bump cannot
+unblock the iter-27a Σ₂(ℤ) attack. In-file re-export surface remains exhausted
+(S33); no single-cycle Lean delta. Invariants unchanged (pin v4.26.0, LOC 3174,
+1 axiom, 0 sorries, 90 public theorems). Full memo in `sessions/`.
 
 ## Session 34 — T+4d Mathlib bearer recheck (researcher-1, 2026-06-14)
 


### PR DESCRIPTION
## Summary

Periodic bearer recheck for the **Hilbert's 10th problem over ℚ** research entry (`hilbert-10-oq-01-oq-02`). The main iter-27a Σ₂(ℤ) attack has been **upstream-blocked** since S30: it depends on Mathlib "bearer" lemmas that do not exist in the pinned Mathlib v4.26.0 tree.

## What's new in S35

Prior sessions (S30–S34) only checked the **pinned** tree. This session extends the check to upstream `leanprover-community/mathlib4` **master**:

| Bearer | Pinned v4.26.0 | Upstream master |
|---|---|---|
| `HilbertSymbol` (rational) | absent (only `LegendreSymbol`) | absent (code-search `total_count` 0) |
| `HasseMinkowski` | absent | absent (0) |
| Brauer **rational** classification | only `Algebra/BrauerGroup/Defs.lean` | only `Defs.lean` |
| `PoonenNonSquaresDiophantine` | absent | absent (0) |
| `Hilbert10Rational` / H10-over-ℚ | only general `Dioph.lean` (MRDP) | only `Dioph`/`DiophantineApproximation` |

`LegendreSymbol`=17 hits served as a sanity baseline confirming the search works.

## Verdict (sharpened)

The bearers are absent **upstream on master**, not merely lagging in the pin — so a Mathlib **pin-bump would not unblock** the attack. The blocker is genuine upstream non-existence of the rational Hilbert-symbol / Hasse-Minkowski / Poonen–Koenigsmann infrastructure. The 2026-07-03 dormancy recheck should target master (a bearer can only reach the pin after landing on master first).

In-file re-export surface remains exhausted (S33); no single-cycle Lean delta. **Doc-only** — file invariants unchanged (pin v4.26.0, LOC 3174, 1 axiom, 0 sorries, 90 public theorems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)