### PR TITLE
Enrich Pentagonal Number Theorem (OQ-01)

### DIFF
--- a/src/data/proofs/pentagonal-number-theorem-oq-01/annotations.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/annotations.json
@@ -46,5 +46,17 @@
     "significance": "supporting",
     "relatedConcepts": ["OEIS A001318", "pentagonal numbers"],
     "prerequisites": []
+  },
+  {
+    "id": "ann-open-core",
+    "proofId": "pentagonal-number-theorem-oq-01",
+    "range": { "startLine": 161, "endLine": 177 },
+    "type": "context",
+    "title": "The Open Core: Franklin's Involution and the Generating Identity",
+    "content": "Documents what this file deliberately does *not* prove: the analytic/combinatorial heart of the theorem.\n\n**The identity.** In the ring of formal power series $\\mathbb{Z}[\\![X]\\!]$, Euler's theorem asserts $\\prod_{n\\ge1}(1-X^n) = \\sum_{k\\in\\mathbb{Z}}(-1)^k X^{g(k)}$. Equivalently, letting $p_{\\mathrm{even}}(n)$ and $p_{\\mathrm{odd}}(n)$ count partitions of $n$ into an even/odd number of *distinct* parts, $p_{\\mathrm{even}}(n)-p_{\\mathrm{odd}}(n)$ equals $(-1)^k$ when $n=g(k)$ and $0$ otherwise.\n\n**Franklin's involution (1881).** The bijective proof builds a sign-reversing involution on partitions into distinct parts using the two statistics $s$ (smallest part) and $\\sigma$ (length of the longest 'staircase' run ending at the largest part). Either the smallest part moves up or the staircase moves down, pairing each partition with one of opposite parity — *except* the staircase partitions $j{+}(j{+}1){+}\\cdots{+}(2j{-}1)$ and their variants, the unmatched fixed points, which sit exactly at $n=g(\\pm j)$ and contribute the surviving $(-1)^k$ term.\n\n**Why it is out of scope.** Mathlib has `Nat.Partition` but not distinct-part partitions with a parity sign, not Franklin's involution, and not the formal-power-series infinite product. This entry supplies the index-set theory (`isGenPent_iff_isSquare`, `genPent_injective`) that any such formalization would consume to locate the surviving exponents.",
+    "mathContext": "$\\prod_{n\\ge1}(1-X^n)=\\sum_{k\\in\\mathbb{Z}}(-1)^k X^{g(k)}$; fixed points of Franklin's involution occur precisely at $n=g(k)$.",
+    "significance": "context",
+    "relatedConcepts": ["Franklin's involution", "partitions into distinct parts", "formal power series", "generating functions", "sign-reversing involution"],
+    "prerequisites": ["integer partitions", "generating functions", "involutions and bijective combinatorics"]
   }
 ]

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/index.ts
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PentagonalNumberTheoremOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pentagonalNumberTheoremOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pentagonalNumberTheoremOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pentagonalNumberTheoremOQ01Data: ProofData = {
+  proof: pentagonalNumberTheoremOQ01Proof,
+  annotations: pentagonalNumberTheoremOQ01Annotations,
+}

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -106,5 +106,26 @@
   "openQuestions": [
     "Formalize the deep identity ∏_{n≥1}(1-Xⁿ) = ∑_{k∈ℤ}(-1)ᵏ X^{g(k)} (equivalently p_even(n)-p_odd(n) = [n=g(k)]·(-1)ᵏ) via Franklin's sign-reversing involution on partitions into distinct parts — requires distinct-partition parity machinery and formal-power-series infinite products not yet in Mathlib.",
     "Derive Euler's partition recurrence p(n) = ∑_{k≥1}(-1)^{k-1}(p(n-g_k)+p(n-g_{-k})) as a corollary, using this entry's recognition criterion to index the pentagonal shifts."
+  ],
+  "conclusion": {
+    "summary": "This entry establishes the number-theoretic backbone of Euler's pentagonal number theorem: a division-free theory of the generalized pentagonal numbers g(k)=k(3k-1)/2, anchored by the recognition criterion that m is a generalized pentagonal number iff 24m+1 is a perfect square. Alongside the criterion it proves the exact doubling relation, injectivity of the index map, nonnegativity, and the first concrete values matching OEIS A001318 — all machine-verified with 0 axioms and 0 sorries.",
+    "implications": "The square-discriminant test 24m+1=□ is exactly how the pentagonal exponents are enumerated in practice when running Euler's partition recurrence p(n)=∑_{k≥1}(-1)^{k-1}(p(n-g_k)+p(n-g_{-k})), so this index theory is the reusable substrate beneath any algorithmic or formal treatment of partition counting. By routing every argument through the doubling relation 2m=k(3k-1) rather than integer division, the development stays entirely inside ℤ and exposes the clean polynomial identity 24g(k)+1=(6k-1)² that makes the criterion exact. The injectivity result genPent_injective is precisely what a future formalization of Franklin's involution needs to assert that each surviving exponent is hit by a unique index.",
+    "openQuestions": [
+      "Formalize the deep generating-function identity ∏_{n≥1}(1-Xⁿ)=∑_{k∈ℤ}(-1)ᵏX^{g(k)} via Franklin's sign-reversing involution on partitions into distinct parts — blocked on distinct-partition parity machinery and formal-power-series infinite products absent from Mathlib.",
+      "Derive Euler's partition recurrence for p(n) as a corollary, using this entry's recognition criterion to index the pentagonal shifts.",
+      "Extend the square-discriminant viewpoint to the higher Gauss/Jacobi-triple-product exponents (e.g. the heptagonal and general figurate analogues), characterizing each family by an analogous perfect-square test."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "partition-theorem",
+      "relationship": "related",
+      "description": "Euler's theorem that partitions into odd parts equinumerate partitions into distinct parts. The pentagonal number theorem refines the distinct-parts side by signing each partition with the parity of its number of parts — the precise setting of Franklin's sign-reversing involution documented in this entry's open core."
+    },
+    {
+      "proofId": "partition-theorem-oq-01",
+      "relationship": "related",
+      "description": "Rogers-Ramanujan and Schur partition identities, proved via gap conditions and modular arithmetic. Like the pentagonal exponents characterized here, they identify partition families by residue/square criteria and inhabit the same generating-function landscape."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for **pentagonal-number-theorem-oq-01**.

## Changes
- **Created missing `index.ts`** — the entry had no Vite entry point, so the proof page rendered "proof not found" on the live site despite appearing in the gallery listing. Now wired with the correct `PentagonalNumberTheoremOQ01.lean` source import and camelCase exports.
- **Added `ann-open-core` annotation** covering lines 161–177 (the OPEN CORE section), previously uncovered. Explains the generating-function identity ∏(1−Xⁿ)=∑(−1)ᵏX^{g(k)} and Franklin's sign-reversing involution, with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`. Brings the entry to 5 fully-specified annotations.
- **Added `conclusion` object** (summary, implications, openQuestions) per the gallery schema — the entry previously had only a top-level `openQuestions` array.
- **Added `crossReferences`** to `partition-theorem` (Euler's odd/distinct partition theorem — the natural home of Franklin's involution) and `partition-theorem-oq-01` (Rogers–Ramanujan/Schur identities).

## Integrity
No status/axiom changes. Entry remains `verified` / `original`, `axiomCount: 0`, 0 sorries — consistent with the Lean file (16 theorems, 2 defs, 0 axioms; kernel `decide`, not `native_decide`). All additions are content-only.

`pnpm build` passes (✓ built; tsc + vite clean).