### PR TITLE
Fix axiom integrity: 3 native_decide entries → axiomatized (follow-up to #25944)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-00/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-00/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Nicomachus of Gerasa (c. 100 CE); formalized in Lean 4",
     "date": "c. 100 CE",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ00.lean",
     "tags": [
       "number-theory",
@@ -17,11 +17,11 @@
       "power-sums",
       "classical-identity"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 160,
-    "assumptions": "0 axioms, 0 sorries. Elementary induction proof: no deep Mathlib dependencies beyond basic Finset sum lemmas and ring arithmetic.",
+    "assumptions": "Relies on `Lean.ofReduceBool`. The general Nicomachus identity (Σ k³ = (Σ k)²) and the step lemma are proved by induction/`ring` and are kernel-checked and axiom-free. However, the concrete numerical instances presented as named theorems — `sum_cubes_1`…`sum_cubes_4`, `sum_cubes_10`, and `triangular_squares` — are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so depends on the `Lean.ofReduceBool` axiom (it appears under `#print axioms` for those theorems). `leanFile.axiomCount` remains 0 because there are no literal `axiom` declarations.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -106,7 +106,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Nicomachus's theorem — that the sum of the first n cubes equals the square of the n-th triangular number — is proved here in three equivalent forms by induction. The proof is elementary: only Finset sum splitting and ring arithmetic are needed. 0 sorries, 0 axioms.",
+    "summary": "Nicomachus's theorem — that the sum of the first n cubes equals the square of the n-th triangular number — is proved here in three equivalent forms by induction. The proof is elementary: only Finset sum splitting and ring arithmetic are needed. 0 sorries, 0 literal axiom declarations (the concrete numerical instances use native_decide, which depends on Lean.ofReduceBool).",
     "implications": "Nicomachus's theorem bridges figurate numbers (triangular) and power sums (cubes). It is a special case of Faulhaber's formula for p=3, but its elementary induction proof needs no Bernoulli numbers. The identity ∑k³ = (∑k)² is one of the most visually striking in elementary number theory, with a beautiful geometric proof via gnomon decomposition.",
     "openQuestions": [
       "Is there a bijective proof in Lean? (Construct an explicit bijection between n³ objects and the 'staircase square' region of area T_n².)",

--- a/src/data/proofs/fundamental-arithmetic-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_arithmetic",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "factorization",
@@ -16,12 +16,12 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FundamentalArithmeticOQ01.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 113,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Relies on `Lean.ofReduceBool`. The general factorization/coprimality results built on Mathlib's `Nat.factorization` infrastructure are kernel-checked and axiom-free. However, the concrete instances presented as named theorems — `factorization_12`, `factorization_35`, `factorization_420_from_coprime`, and `coprime_12_35` — are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so depends on the `Lean.ofReduceBool` axiom (it appears under `#print axioms` for those theorems). `leanFile.axiomCount` remains 0 because there are no literal `axiom` declarations.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
     "definitionCount": 0

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Ladyzhenskaya (1969)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Navier%E2%80%93Stokes_equations",
     "date": "1969",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "tags": [
       "pde",
@@ -20,9 +20,9 @@
       "analysis",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "mathlibDependencies": [
       {
         "theorem": "intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le",
@@ -61,7 +61,7 @@
     ],
     "dateAdded": "2026-02-26",
     "lineCount": 21110,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries remain.",
+    "assumptions": "Relies on `Lean.ofReduceBool`. The analytic core — the quantitative enstrophy decay bound E(t) ≤ E(s)·exp(-2νμ₁(t-s)) and the integrated energy identity (FTC applied to the enstrophy ODE) — is kernel-checked and axiom-free. However, the Sobolev/Lions-threshold classification theorems `lions_3d`, `lions_2d`, `critical_at_lions_is_zero`, `standard_ns_gap`, and `standard_2d_gap` are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so depends on the `Lean.ofReduceBool` axiom (it appears under `#print axioms` for those theorems; these are rational-arithmetic facts that could alternatively be closed by kernel `decide`/`norm_num`). `leanFile.axiomCount` remains 0 because there are no literal `axiom` declarations.",
     "relatedProblems": [
       {
         "id": "navier-stokes",
@@ -137,7 +137,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization answers the open question affirmatively: all three quantitative results — inter-time decay, integrated energy identity, and total dissipation bound — can be formalized in Lean 4 with 0 axioms and 0 sorries. The key tools are the integrating factor method (for decay between arbitrary times) and the FTC via `intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le` (for the integrated identity).",
+    "summary": "This formalization answers the open question affirmatively: all three quantitative results — inter-time decay, integrated energy identity, and total dissipation bound — can be formalized in Lean 4 with 0 literal axiom declarations and 0 sorries (the auxiliary Sobolev/Lions-threshold classification theorems use native_decide, which depends on Lean.ofReduceBool). The key tools are the integrating factor method (for decay between arbitrary times) and the FTC via `intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le` (for the integrated identity).",
     "implications": "**Theoretical Significance**: **For 2D fluid mechanics**: The enstrophy_uniform_decay theorem provides a precise Lyapunov function argument: g(t) = E(t)·exp(2νμ₁t) is nonincreasing, certifying exponential stability of the zero state.\n\n**For Mathlib**: The correct FTC lemma for enstrophy integration is `integral_eq_sub_of_hasDerivAt_of_le` (not the simpler `integral_eq_sub_of_hasDerivAt`), because the enstrophy ODE holds for t > 0 but not necessarily at t = 0.\n\nThis version requires ContinuousOn on the closed interval [0,T] and HasDerivAt only on the open interval (0,T).\n\n**For Navier-Stokes research**: These results form part of the infrastructure for more advanced 2D results, such as proving the Ladyzhenskaya inequality in Lean 4 and connecting 2D global regularity to Fourier space energy cascades.\n\n**For the 3D problem**: The 2D results demonstrate that the enstrophy framework works cleanly in Lean 4. The 3D case differs because vortex stretching prevents the Poincaré bound P ≥ μ₁E from giving exponential decay.",
     "openQuestions": [
       "Can the Ladyzhenskaya inequality ‖u‖₄ ≤ C‖u‖₂^{1/2}‖∇u‖₂^{1/2} be formalized in Lean 4 using Mathlib's Sobolev space infrastructure?",


### PR DESCRIPTION
## Axiom-integrity correction (batch)

Follow-up to #25944, same bug class. Three more entries claimed `status: verified` / `axiomCount: 0` / `assumptions: "None"` while their Lean files discharge **named theorems** by `native_decide`, which depends on the `Lean.ofReduceBool` axiom (it appears in `#print axioms` for those theorems):

| Entry | native_decide named theorems |
|---|---|
| `navier-stokes-oq-01` | `lions_3d`, `lions_2d`, `critical_at_lions_is_zero`, `standard_ns_gap`, `standard_2d_gap` (Sobolev/Lions-threshold ℚ-arithmetic) |
| `arithmetic-series-oq-00` | `sum_cubes_1`…`sum_cubes_4`, `sum_cubes_10`, `triangular_squares` |
| `fundamental-arithmetic-oq-01` | `factorization_12`, `factorization_35`, `factorization_420_from_coprime`, `coprime_12_35` |

### Per entry (meta.json only)
- `status`: `verified` → `axiomatized`
- `badge`: → `axiom`
- `meta.axiomCount`: `0` → `1` (`Lean.ofReduceBool`)
- `assumptions`: disclose `ofReduceBool`, name the `native_decide` theorems, note the **general results remain kernel-checked / axiom-free**
- conclusion/description prose: `0 axioms` → `0 literal axiom declarations` with disclosure
- `leanFile.axiomCount` kept at `0` (no literal `axiom` declarations — per policy)

No mathematical content changed. For `navier-stokes-oq-01` the `native_decide` facts are trivial rational arithmetic (e.g. `lionsThreshold 3 = 5/4`) that a follow-up Lean change could close with kernel `decide`/`norm_num` to drop the `ofReduceBool` dependency entirely.

Part of a ~24-entry systemic pattern (see #25944 description). Remaining candidates for the auditor/mechanic fleet: `picks-theorem-oq-02`, `kummer-theorem-oq-01-oq-01`, `euler-polyhedral-oq-01`, `stirling-formula`, `sqrt2-minpoly`, `subset-count-oq-02-oq-01`, `elementary-quadratic-reciprocity`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)