### PR TITLE
Enrich Burnside's Lemma with No Burnside Intermediate (lagrange-theorem-oq-02-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-no-burnside-intermediate",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-01",
+    "range": { "startLine": 26, "endLine": 46 },
+    "type": "context",
+    "title": "Closing the Hidden Burnside Dependency",
+    "content": "The parent entry proves a per-orbit contribution lemma — each orbit contributes exactly |G| to the stabilizer sum — but never assembles those contributions into the global identity Σ_x |Stab(x)| = |X/G|·|G|. Instead it borrows Mathlib's own Burnside lemma (`MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`) to close that gap, so the parent's derivation is not actually self-contained: it routes Burnside through Burnside. This entry removes the intermediate by reindexing the stabilizer sum over the orbit-partition equivalence `selfEquivSigmaOrbits` and collapsing each orbit's inner sum with the parent's per-orbit lemma. No step touches Mathlib's counting lemma, so Burnside genuinely follows from orbit-stabilizer.",
+    "mathContext": "The standard derivation has two independent legs: a double-counting bijection $\\sum_g |\\text{Fix}(g)| = \\sum_x |\\text{Stab}(x)|$, and an orbit-partition computation $\\sum_x |\\text{Stab}(x)| = |X/G|\\cdot|G|$. The parent supplies the first but outsources the second. Here the second leg is built from $\\sum_{y\\in\\text{Orb}(x)}|\\text{Stab}(y)| = |G|$ summed over the $|X/G|$ orbits.",
+    "significance": "key",
+    "relatedConcepts": ["Burnside's lemma", "orbit-stabilizer theorem", "self-contained derivation", "dependency removal"],
+    "prerequisites": ["group actions", "orbit-stabilizer theorem", "Burnside's lemma"],
+    "tags": ["burnside-lemma", "proof-architecture", "self-contained"]
+  },
+  {
+    "id": "ann-orbit-partition-reindex",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-01",
+    "range": { "startLine": 81, "endLine": 91 },
+    "type": "insight",
+    "title": "Reindexing the Stabilizer Sum over the Orbit Partition",
+    "content": "`MulAction.selfEquivSigmaOrbits G X : X ≃ Σ ω : X/G, Orb(ω.out)` exhibits X as the disjoint union of its orbits, indexed by the orbit quotient. The proof reindexes Σ_x |Stab(x)| across this equivalence with `Fintype.sum_equiv`. The subtle point is that the equivalence preserves the underlying point of X, so the summand `|Stab(·)|` transports definitionally: the congruence obligation is discharged by `fun x => rfl`. This is what makes the partition usable as a change of summation index rather than just an abstract bijection of sets.",
+    "mathContext": "$\\texttt{Fintype.sum\\_equiv}\\,(e : X \\simeq \\Sigma_\\omega \\text{Orb}(\\omega.\\text{out}))$ turns $\\sum_{x:X} f(x)$ into $\\sum_{p:\\Sigma_\\omega \\text{Orb}(\\omega.\\text{out})} f(p.2)$ provided $f(x) = f(e(x).2)$ for all $x$. Since $e$ moves a point only to its own orbit fiber without changing the underlying element, $f = |\\text{Stab}(\\cdot)|$ satisfies this by $\\texttt{rfl}$.",
+    "significance": "key",
+    "relatedConcepts": ["orbit partition", "selfEquivSigmaOrbits", "sigma types", "change of summation index", "definitional equality"],
+    "prerequisites": ["group actions", "orbit quotient", "Lean 4 Equiv", "Fintype sums"],
+    "tags": ["orbit-partition", "lean4", "reindexing", "rfl-transport"]
+  },
+  {
+    "id": "ann-sum-sigma-split",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-01",
+    "range": { "startLine": 92, "endLine": 93 },
+    "type": "technique",
+    "title": "Splitting the Sigma Sum into a Double Sum over Orbits",
+    "content": "After reindexing, the sum runs over a sigma type Σ_ω Orb(ω.out). `Finset.sum_sigma` (combined with `← Finset.univ_sigma_univ` to recognize the universal finset as a sigma of universal finsets) factors this into an outer sum over the orbit quotient ω and an inner sum over the points of each orbit Orb(ω.out). This is the formal counterpart of grouping the stabilizer sum orbit-by-orbit before counting.",
+    "mathContext": "$\\sum_{p \\in \\Sigma_\\omega \\text{Orb}(\\omega.\\text{out})} |\\text{Stab}(p.2)| = \\sum_{\\omega \\in X/G}\\ \\sum_{y \\in \\text{Orb}(\\omega.\\text{out})} |\\text{Stab}(y)|$. The Finset identity $\\texttt{univ}_{\\Sigma} = \\Sigma\\,\\texttt{univ}\\,\\texttt{univ}$ licenses $\\texttt{Finset.sum\\_sigma}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_sigma", "double sums", "orbit partition", "Fubini for finite sums"],
+    "prerequisites": ["Finset big operators", "sigma types", "Lean 4"],
+    "tags": ["lean4-tactics", "sum-sigma", "double-counting"]
+  },
+  {
+    "id": "ann-per-orbit-collapse",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-01",
+    "range": { "startLine": 94, "endLine": 95 },
+    "type": "insight",
+    "title": "Each Inner Orbit Sum Collapses to |G|",
+    "content": "`simp_rw [LagrangeTheoremOQ02OQ01.sum_card_stabilizer_orbit]` rewrites every inner sum Σ_{y ∈ Orb(ω.out)} |Stab(y)| to the constant |G|. This is exactly the parent's per-orbit contribution lemma — the genuine orbit-stabilizer content: all points of an orbit have equicardinal (conjugate) stabilizers, and |Orb(x)|·|Stab(x)| = |G|. Importing this lemma rather than Mathlib's Burnside is what keeps the derivation honest: the only group-theoretic input is orbit-stabilizer, applied orbit-locally.",
+    "mathContext": "For each orbit, $\\sum_{y \\in \\text{Orb}(x)} |\\text{Stab}(y)| = |\\text{Orb}(x)|\\cdot|\\text{Stab}(x)| = |G|$, the orbit-stabilizer theorem. After the rewrite the outer sum becomes $\\sum_{\\omega \\in X/G} |G|$.",
+    "significance": "key",
+    "relatedConcepts": ["orbit-stabilizer theorem", "per-orbit contribution", "conjugate stabilizers", "Lagrange's theorem"],
+    "prerequisites": ["orbit-stabilizer theorem", "Lagrange's theorem", "Lean 4 simp_rw"],
+    "tags": ["orbit-stabilizer", "per-orbit", "lean4-tactics"]
+  },
+  {
+    "id": "ann-constant-sum",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-01",
+    "range": { "startLine": 96, "endLine": 97 },
+    "type": "technique",
+    "title": "Summing the Constant |G| over the |X/G| Orbits",
+    "content": "With every inner sum collapsed to the constant |G|, the outer sum Σ_{ω ∈ X/G} |G| is a constant sum. `Finset.sum_const` turns it into |X/G| • |G|, `Finset.card_univ` identifies the cardinality of the universal finset on the orbit quotient with Fintype.card, and `smul_eq_mul` rewrites the nat scalar action as ordinary multiplication, yielding |X/G| × |G|. This completes the global orbit-partition stabilizer sum without any appeal to Mathlib's Burnside lemma.",
+    "mathContext": "$\\sum_{\\omega \\in X/G} |G| = |X/G| \\bullet |G| = |X/G| \\cdot |G|$. Here $|X/G| = \\texttt{Fintype.card}\\,(X/G)$ counts the orbits, and $\\bullet$ is the $\\mathbb{N}$-scalar action collapsing to multiplication via $\\texttt{smul\\_eq\\_mul}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_const", "constant sum", "orbit count", "nat scalar action"],
+    "prerequisites": ["Finset big operators", "Lean 4 simp lemmas"],
+    "tags": ["lean4-tactics", "sum-const", "counting"]
+  },
+  {
+    "id": "ann-burnside-self-contained",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-01",
+    "range": { "startLine": 117, "endLine": 126 },
+    "type": "insight",
+    "title": "Burnside in Two Genuinely Independent Steps",
+    "content": "`burnside_no_intermediate` assembles Burnside's counting lemma from two legs that no longer overlap. Step 1 rewrites Σ_g |Fix(g)| to Σ_x |Stab(x)| via the parent's explicit double-counting bijection `sum_card_fixedBy_eq_sum_card_stabilizer`. Step 2 discharges the remaining goal with `sum_card_stabilizer_eq_card_orbits_mul_card_group` — the self-contained orbit-partition sum proved just above. Because Step 2 never invokes Mathlib's Burnside, the two steps are independent, and the result is a fully self-contained derivation of Burnside from orbit-stabilizer.",
+    "mathContext": "$\\sum_g |\\text{Fix}(g)| \\stackrel{(1)}{=} \\sum_x |\\text{Stab}(x)| \\stackrel{(2)}{=} |X/G|\\cdot|G|$. Step (1) is the sigma bijection $\\Sigma_g \\text{Fix}(g) \\simeq \\Sigma_x \\text{Stab}(x)$; step (2) is the orbit-partition sum built here, replacing the parent's appeal to $\\texttt{sum\\_card\\_fixedBy\\_eq\\_card\\_orbits\\_mul\\_card\\_group}$.",
+    "significance": "key",
+    "relatedConcepts": ["Burnside's lemma", "double counting", "orbit-stabilizer theorem", "proof independence"],
+    "prerequisites": ["double counting", "orbit-stabilizer theorem", "Burnside's lemma"],
+    "tags": ["burnside-lemma", "proof-structure", "self-contained"]
+  },
+  {
+    "id": "ann-divisibility",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-01",
+    "range": { "startLine": 129, "endLine": 135 },
+    "type": "concept",
+    "title": "Divisibility Corollary: |G| Divides the Fixed-Point Sum",
+    "content": "`burnside_divides_no_intermediate` records the immediate combinatorial consequence: since Σ_g |Fix(g)| = |X/G| × |G|, the group order |G| divides the total number of fixed points. After rewriting with the Burnside identity, `dvd_mul_left` finishes. This is the form most often used in counting applications — for instance, the number of distinct colorings (orbits) under a symmetry group is the fixed-point sum divided by |G|, which is only an integer because of exactly this divisibility.",
+    "mathContext": "$|G| \\mid \\sum_g |\\text{Fix}(g)|$ because $\\sum_g |\\text{Fix}(g)| = |X/G|\\cdot|G|$ and $\\texttt{dvd\\_mul\\_left}\\,(|X/G|)\\,(|G|)$ gives $|G| \\mid |X/G|\\cdot|G|$. Hence the orbit count $|X/G| = \\frac{1}{|G|}\\sum_g |\\text{Fix}(g)|$ is a genuine integer.",
+    "significance": "supporting",
+    "relatedConcepts": ["divisibility", "orbit counting", "Burnside's lemma applications", "colorings under symmetry"],
+    "prerequisites": ["Burnside's lemma", "divisibility", "Lean 4"],
+    "tags": ["divisibility", "burnside-lemma", "counting-applications"]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-01/meta.json
@@ -80,29 +80,55 @@
   ],
   "sorries": [],
   "overview": {
-    "text": "Burnside's counting lemma states that for a finite group G acting on a finite set X, the total number of fixed points Σ_{g ∈ G} |Fix(g)| equals |X/G| × |G|, where |X/G| is the number of orbits. The standard derivation has two steps: a double-counting bijection identifying Σ_g |Fix(g)| with Σ_x |Stab(x)|, and an orbit-partition argument computing Σ_x |Stab(x)| = |X/G| × |G|.\n\nThe parent entry lagrange-theorem-oq-02-oq-01 makes the double-counting step explicit but quietly outsources the orbit-partition step to Mathlib's own Burnside lemma (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group). Its per-orbit contribution lemma — each orbit contributes exactly |G| to the stabilizer sum, a genuine orbit-stabilizer consequence — is proved but never assembled into the global sum.\n\nThis entry removes that intermediate. Using the orbit-partition equivalence MulAction.selfEquivSigmaOrbits, which exhibits X as the disjoint union of its orbits indexed by the quotient X/G, we reindex Σ_x |Stab(x)| as a double sum Σ_ω Σ_{y ∈ Orb(ω)} |Stab(y)|, apply the parent's per-orbit lemma to collapse each inner sum to |G|, and sum the constant over the |X/G| orbits. No step invokes Mathlib's Burnside. Burnside's counting lemma then follows by composing with the parent's double-counting bijection, yielding a fully self-contained derivation from orbit-stabilizer."
+    "historicalContext": "Burnside's counting lemma — the orbit-counting theorem — states that for a finite group G acting on a finite set X, the number of orbits equals the average number of fixed points: |X/G| = (1/|G|) Σ_{g ∈ G} |Fix(g)|. Despite the name, it is not due to William Burnside, who merely reproduced it in his influential 1897 monograph *Theory of Groups of Finite Order* while attributing it to Frobenius (1887). The result was in fact known still earlier to Cauchy (1845) for the transitive case. This tangled attribution earned it Peter Neumann's wry nickname 'the lemma that is not Burnside's' (1979); it is also called the Cauchy–Frobenius lemma. The lemma became a cornerstone of Pólya enumeration theory and the combinatorics of counting configurations up to symmetry (necklaces, colorings, isomers). Its modern proof rests on two pillars from finite group theory: the orbit-stabilizer theorem (|Orb(x)|·|Stab(x)| = |G|, itself a consequence of Lagrange's theorem applied to the stabilizer subgroup) and a double-counting bijection on the incidence set {(g, x) : g·x = x}. This entry is part of a chain of refinements (lagrange-theorem → lagrange-theorem-oq-02 → lagrange-theorem-oq-02-oq-01) examining exactly which lemmas the Lean derivation depends on.",
+    "problemStatement": "Burnside's counting lemma: for a finite group $G$ acting on a finite set $X$, $\\sum_{g \\in G} |\\mathrm{Fix}(g)| = |X/G| \\cdot |G|$, where $|X/G|$ is the number of orbits. The standard derivation factors through two independent identities: a double-counting bijection $\\sum_{g} |\\mathrm{Fix}(g)| = \\sum_{x} |\\mathrm{Stab}(x)|$ over the incidence set $\\{(g,x) : g\\cdot x = x\\}$, and an orbit-partition computation $\\sum_{x} |\\mathrm{Stab}(x)| = |X/G| \\cdot |G|$. The parent entry supplies the first but discharges the second by calling Mathlib's own Burnside lemma. The open question this entry answers: can the orbit-partition identity be assembled directly from the per-orbit contribution lemma, so that Burnside follows from orbit-stabilizer alone with no circular appeal to Burnside?",
+    "proofStrategy": "Remove the hidden intermediate. The orbit-partition equivalence `MulAction.selfEquivSigmaOrbits G X : X ≃ Σ ω : X/G, Orb(ω.out)` exhibits X as the disjoint union of its orbits, indexed by the orbit quotient. (1) Reindex Σ_x |Stab(x)| across this equivalence with `Fintype.sum_equiv`; because the equivalence preserves the underlying point, the summand transports definitionally (`fun x => rfl`). (2) `Finset.sum_sigma` splits the resulting sigma-sum into an outer sum over orbits ω and an inner sum over each Orb(ω.out). (3) The parent's per-orbit lemma `sum_card_stabilizer_orbit` collapses every inner sum to the constant |G| — this is the only group-theoretic input, applied orbit-locally, and it is a genuine orbit-stabilizer consequence. (4) `Finset.sum_const` sums |G| over the |X/G| orbits, giving |X/G| × |G|. No step touches Mathlib's `sum_card_fixedBy_eq_card_orbits_mul_card_group`. Composing this global stabilizer sum with the parent's double-counting bijection then yields Burnside's lemma as a fully self-contained derivation from orbit-stabilizer.",
+    "keyInsights": [
+      "The parent's derivation was only superficially self-contained: it proved the per-orbit contribution 'each orbit adds |G|' but assembled the global sum by quietly invoking Mathlib's Burnside lemma — deriving Burnside through Burnside. The genuine missing step was the orbit-partition assembly, supplied here.",
+      "The orbit-partition equivalence `selfEquivSigmaOrbits` is exactly the right tool: it turns the abstract fact 'X is the disjoint union of its orbits' into a usable change of summation index, because it preserves the underlying point and so transports the stabilizer-cardinality summand by `rfl`.",
+      "Only one group-theoretic theorem is genuinely needed — orbit-stabilizer (|Orb|·|Stab| = |G|), itself Lagrange applied to the stabilizer subgroup. Everything else is bookkeeping: reindexing a sum, splitting a sigma-sum, and summing a constant.",
+      "Burnside's lemma decomposes into two logically independent legs — a combinatorial double-counting bijection and an orbit-partition count — and this entry makes that independence explicit by ensuring neither leg secretly depends on the conclusion.",
+      "The divisibility corollary |G| ∣ Σ_g |Fix(g)| is what makes the orbit count |X/G| = (1/|G|)Σ_g|Fix(g)| an integer — the quantitative backbone of Pólya counting and the reason symmetry-quotient counts always come out whole."
+    ]
   },
   "sections": [
     {
+      "id": "global-stabilizer-sum",
       "title": "The global orbit-partition stabilizer sum",
       "startLine": 60,
       "endLine": 97,
-      "text": "sum_card_stabilizer_eq_card_orbits_mul_card_group proves Σ_x |Stab(x)| = |X/G| × |G| directly. The orbit-partition equivalence selfEquivSigmaOrbits reindexes the sum over the disjoint union of orbits (the underlying point is preserved, so the summand transports by rfl); Finset.sum_sigma splits it into an outer sum over orbits and an inner sum over each orbit; the parent's sum_card_stabilizer_orbit collapses each inner sum to |G|; and Finset.sum_const sums the constant over the |X/G| orbits. Mathlib's Burnside lemma is never used."
+      "summary": "sum_card_stabilizer_eq_card_orbits_mul_card_group proves Σ_x |Stab(x)| = |X/G| × |G| directly. The orbit-partition equivalence selfEquivSigmaOrbits reindexes the sum over the disjoint union of orbits (the underlying point is preserved, so the summand transports by rfl); Finset.sum_sigma splits it into an outer sum over orbits and an inner sum over each orbit; the parent's sum_card_stabilizer_orbit collapses each inner sum to |G|; and Finset.sum_const sums the constant over the |X/G| orbits. Mathlib's Burnside lemma is never used."
     },
     {
+      "id": "burnside-self-contained",
       "title": "Burnside's counting lemma, self-contained",
       "startLine": 99,
       "endLine": 137,
-      "text": "burnside_no_intermediate composes the global stabilizer sum with the parent's double-counting bijection (sum_card_fixedBy_eq_sum_card_stabilizer) to obtain Σ_g |Fix(g)| = |X/G| × |G|, a derivation that routes entirely through orbit-stabilizer. burnside_divides_no_intermediate records the consequence |G| ∣ Σ_g |Fix(g)|."
+      "summary": "burnside_no_intermediate composes the global stabilizer sum with the parent's double-counting bijection (sum_card_fixedBy_eq_sum_card_stabilizer) to obtain Σ_g |Fix(g)| = |X/G| × |G|, a derivation that routes entirely through orbit-stabilizer. burnside_divides_no_intermediate records the consequence |G| ∣ Σ_g |Fix(g)|, the integrality behind orbit counting."
     }
   ],
   "conclusion": {
-    "summary": "The orbit-partition stabilizer sum Σ_x |Stab(x)| = |X/G| × |G| can be assembled directly from the per-orbit contribution of orbit-stabilizer and the disjoint-union decomposition of X into orbits, without borrowing Mathlib's Burnside lemma. Composing with the parent's double-counting bijection gives a fully self-contained derivation of Burnside's counting lemma from orbit-stabilizer."
+    "summary": "The orbit-partition stabilizer sum Σ_x |Stab(x)| = |X/G| × |G| can be assembled directly from the per-orbit contribution of orbit-stabilizer and the disjoint-union decomposition of X into orbits, without borrowing Mathlib's Burnside lemma. Composing with the parent's double-counting bijection gives a fully self-contained derivation of Burnside's counting lemma from orbit-stabilizer, closing the dependency gap the parent entry left open.",
+    "implications": "Tracing and removing a hidden lemma dependency is itself mathematically meaningful: it certifies that Burnside's counting lemma is a genuine corollary of orbit-stabilizer (hence of Lagrange's theorem) rather than an independent input, and that the Lean formalization reflects that logical order. The technique — reindexing a sum over an orbit-partition equivalence and collapsing per-orbit contributions — is reusable for any quantity that is constant on orbits, such as proving class equations or counting colorings up to symmetry. The divisibility corollary |G| ∣ Σ_g |Fix(g)| is precisely the integrality fact that underwrites Pólya enumeration and the orbit-counting applications (necklaces, graph colorings, molecular isomers) where Burnside's lemma is most used.",
+    "openQuestions": [
+      "Can the per-orbit contribution lemma itself be derived in a way that exposes orbit-stabilizer's dependence on Lagrange's theorem, so the entire chain Lagrange → orbit-stabilizer → Burnside is visible as a single self-contained Lean development with no Mathlib counting lemmas?",
+      "Does the orbit-partition reindexing strategy generalize cleanly to weighted versions — e.g. cycle-index/Pólya enumeration, where each group element is weighted by its cycle type — without reintroducing a high-level Mathlib lemma as an intermediate?",
+      "For infinite groups acting with finite orbits, what is the right statement and proof of the orbit-partition stabilizer sum, and which finiteness hypotheses in this development are essential versus convenient?"
+    ]
   },
   "crossReferences": [
-    "lagrange-theorem-oq-02-oq-01",
-    "lagrange-theorem-oq-02",
-    "lagrange-theorem"
+    {
+      "proofId": "lagrange-theorem-oq-02-oq-01",
+      "relationship": "Direct parent. Supplies the per-orbit contribution lemma (sum_card_stabilizer_orbit) and the double-counting bijection (sum_card_fixedBy_eq_sum_card_stabilizer) reused here, but assembles the global stabilizer sum by borrowing Mathlib's Burnside lemma — the dependency this entry removes."
+    },
+    {
+      "proofId": "lagrange-theorem-oq-02",
+      "relationship": "Grandparent. Provides the orbit-stabilizer theorem (|Orb(x)|·|Stab(x)| = |G|), the sole group-theoretic input to the self-contained derivation."
+    },
+    {
+      "proofId": "lagrange-theorem",
+      "relationship": "Root of the chain Lagrange → orbit-stabilizer → Burnside. Lagrange's theorem (|H| ∣ |G|), applied to the stabilizer subgroup, is what makes orbit-stabilizer hold."
+    }
   ],
   "references": []
 }


### PR DESCRIPTION
## Enrichment pass for `lagrange-theorem-oq-02-oq-01-oq-01`

This entry previously had **only meta.json** (no annotations, and its overview/sections/conclusion used a legacy `text` format the gallery renderer does not display). This pass makes the entry render fully and adds substantive depth.

### Changes
- **New annotations.json** — 7 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  - Closing the hidden Burnside dependency (context)
  - Reindexing the stabilizer sum over the orbit partition + `rfl` transport (insight)
  - Splitting the sigma-sum via `Finset.sum_sigma` (technique)
  - Per-orbit collapse to |G| via the parent's lemma (insight)
  - Summing the constant over |X/G| orbits (technique)
  - Burnside in two genuinely independent steps (insight)
  - Divisibility corollary |G| ∣ Σ_g |Fix(g)| (concept)
- **Restructured `overview`** from a single `text` blob into the schema fields the renderer actually reads: `historicalContext` (with the Cauchy–Frobenius / 'lemma that is not Burnside's' attribution), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **Converted `sections`** to `id`/`summary` schema (they previously used a `text` field that does not render in the table of contents).
- **Expanded `conclusion`** with `implications` and 3 `openQuestions` (both previously absent).
- **Upgraded `crossReferences`** from bare slug strings (which the renderer skips) to `proofId`/`relationship` objects with relationship descriptions.

### Axiom integrity
No change to status/badge/axiomCount. Verified against the Lean file: 0 sorries, 0 axioms, 0 structure-encoded assumptions; `status: verified`, `badge: mathlib` remain accurate. The headline result is a genuine Mathlib-dependent derivation (orbit-stabilizer + orbit-partition equivalence), not an axiomatized stub.

### Verification
`tsc -b` (exit 0) and `vite build` (✓ built) both pass; data pipeline regenerated public artifacts for the slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)