### PR TITLE
Enrich lagrange-theorem-oq-02-oq-01-oq-01: 5-section split (counting vs divisibility, problem vs setup)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-01/meta.json
@@ -93,12 +93,20 @@
   },
   "sections": [
     {
-      "id": "setup",
-      "title": "Setup: imports, the borrowed-Burnside problem, and the proof chain",
+      "id": "problem-statement",
+      "title": "The borrowed-Burnside gap and the self-contained proof chain",
       "startLine": 1,
+      "endLine": 52,
+      "summary": "The module docstring frames the open question: the parent entry's burnside_from_orbit_stabilizer is not actually self-contained, because its final step quietly borrows Mathlib's own Burnside lemma (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group) to bridge the per-orbit contribution lemma and the global orbit-partition identity Σ_x |Stab(x)| = |X/G|×|G|. This file removes that intermediate. The docstring lays out, as an explicit reduction diagram, the replacement chain — orbit partition of X, reindex, per-orbit collapse to |G|, sum the constant, then the parent's double-counting bijection — that derives Burnside's counting lemma from orbit-stabilizer with no appeal to Mathlib's Burnside.",
+      "mathContext": "Target: Σ_x |Stab(x)| = |X/G|·|G| and hence Σ_g |Fix(g)| = |X/G|·|G|. The forbidden shortcut is Mathlib's MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group; the admissible ingredients are the orbit partition X ≃ Σ_{ω∈X/G} Orb(ω.out) (selfEquivSigmaOrbits), the parent's per-orbit lemma Σ_{y∈Orb(x)}|Stab(y)| = |G|, and the parent's double-counting bijection Σ_g Fix(g) ≃ Σ_x Stab(x)."
+    },
+    {
+      "id": "ambient-setup",
+      "title": "Ambient algebraic context: a finite group action G ↻ X",
+      "startLine": 53,
       "endLine": 59,
-      "summary": "Imports Mathlib and the parent entry Proofs.LagrangeTheoremOQ02OQ01, opens MulAction/Finset/BigOperators, and fixes the ambient group action variable {G X : Type*} [Group G] [MulAction G X]. The module docstring states the open question — the parent's burnside_from_orbit_stabilizer secretly routes through Mathlib's own Burnside lemma to close the global orbit-partition identity Σ_x |Stab(x)| = |X/G|×|G| — and lays out the self-contained proof chain that this file substitutes in its place.",
-      "mathContext": "Working over an arbitrary finite group action G ↻ X. The goal is Σ_x |Stab(x)| = |X/G|·|G| using only the orbit partition X ≃ Σ_{ω∈X/G} Orb(ω.out) and the parent's per-orbit lemma Σ_{y∈Orb(x)}|Stab(y)| = |G|, never Mathlib's MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group."
+      "summary": "Imports Mathlib and the parent entry Proofs.LagrangeTheoremOQ02OQ01 (the source of the borrowed per-orbit and double-counting lemmas), opens the MulAction, Finset, and BigOperators namespaces, and fixes the ambient variables {G X : Type*} [Group G] [MulAction G X]. Finiteness is deliberately NOT assumed here: each theorem below introduces its own Fintype/Fintype-of-quotient instances locally, so the algebraic setup stays as general as possible and the cardinality hypotheses appear exactly where they are needed.",
+      "mathContext": "Ambient context: a group G acting on a type X (G ↻ X). The orbit quotient is MulAction.orbitRel.Quotient G X, written X/G; Stab(x) = MulAction.stabilizer G x and Fix(g) = MulAction.fixedBy X g. Finiteness ([Fintype G], [Fintype X], [Fintype (X/G)], per-g [Fintype (fixedBy X g)]) is supplied per theorem rather than globally."
     },
     {
       "id": "global-stabilizer-sum",
@@ -109,12 +117,20 @@
       "mathContext": "Σ_{x:X} |Stab(x)| = Σ_{ω∈X/G} Σ_{y∈Orb(ω.out)} |Stab(y)| = Σ_{ω∈X/G} |G| = |X/G| • |G| = |X/G| · |G|, via Fintype.sum_equiv selfEquivSigmaOrbits, Finset.sum_sigma, the per-orbit collapse, and Finset.sum_const + smul_eq_mul."
     },
     {
-      "id": "burnside-self-contained",
+      "id": "burnside-counting",
       "title": "Burnside's counting lemma, self-contained",
       "startLine": 99,
+      "endLine": 127,
+      "summary": "burnside_no_intermediate assembles Burnside's counting lemma Σ_g |Fix(g)| = |X/G| × |G| from two genuinely independent steps: first the parent's double-counting bijection sum_card_fixedBy_eq_sum_card_stabilizer rewrites Σ_g |Fix(g)| as Σ_x |Stab(x)|, then the global stabilizer sum of the previous section discharges that with no Mathlib Burnside. The result is a fully self-contained route from orbit-stabilizer, closing exactly the gap the parent entry left open.",
+      "mathContext": "Σ_{g∈G} |Fix(g)| =(1)= Σ_{x∈X} |Stab(x)| =(2)= |X/G|·|G|, where (1) is the parent's bijection Σ_g Fix(g) ≃ Σ_x Stab(x) (rw sum_card_fixedBy_eq_sum_card_stabilizer) and (2) is sum_card_stabilizer_eq_card_orbits_mul_card_group from the section above (exact)."
+    },
+    {
+      "id": "burnside-divisibility",
+      "title": "Burnside's divisibility corollary",
+      "startLine": 128,
       "endLine": 137,
-      "summary": "burnside_no_intermediate composes the global stabilizer sum with the parent's double-counting bijection (sum_card_fixedBy_eq_sum_card_stabilizer) to obtain Σ_g |Fix(g)| = |X/G| × |G|, a derivation that routes entirely through orbit-stabilizer. burnside_divides_no_intermediate records the consequence |G| ∣ Σ_g |Fix(g)|, the integrality behind orbit counting.",
-      "mathContext": "Σ_{g∈G} |Fix(g)| =(1)= Σ_{x∈X} |Stab(x)| =(2)= |X/G|·|G|, where (1) is the parent's bijection Σ_g Fix(g) ≃ Σ_x Stab(x) and (2) is the section above. Corollary: |G| ∣ Σ_g |Fix(g)| by dvd_mul_left, so |X/G| = (Σ_g |Fix(g)|)/|G| is an integer."
+      "summary": "burnside_divides_no_intermediate records the integrality consequence |G| ∣ Σ_g |Fix(g)|. It rewrites the fixed-point sum by the counting lemma and then reads off divisibility of the product |X/G| × |G| by |G| via dvd_mul_left. This is the structural fact underlying orbit counting: the number of orbits |X/G| = (Σ_g |Fix(g)|)/|G| is always a genuine integer, the quantitative core of the orbit-counting (Cauchy–Frobenius) principle.",
+      "mathContext": "|G| ∣ Σ_{g∈G} |Fix(g)|: rewrite Σ_g |Fix(g)| = |X/G| · |G| (burnside_no_intermediate), then |G| ∣ |X/G| · |G| by dvd_mul_left. Equivalently |X/G| = (1/|G|) Σ_g |Fix(g)| ∈ ℤ — the averaging form of Burnside's lemma."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-02-oq-01-oq-01` (Burnside with no Burnside intermediate).

**Gap:** the entry scored 96/100 — the only deduction was `sections` (3 sections = 6/10). The 3-section layout conflated genuinely distinct material.

**Change:** refined to 5 sections that match the file's actual structure, not padding:
1. `[1-52]` **problem-statement** — the module docstring: the borrowed-Burnside gap in the parent + the self-contained proof-chain diagram.
2. `[53-59]` **ambient-setup** — imports, opens, and the `G ↻ X` typeclass context (finiteness deferred per-theorem).
3. `[60-97]` **global-stabilizer-sum** — the new content, `sum_card_stabilizer_eq_card_orbits_mul_card_group`.
4. `[99-127]` **burnside-counting** — `burnside_no_intermediate`, the counting lemma.
5. `[128-137]` **burnside-divisibility** — `burnside_divides_no_intermediate`, the integrality corollary `|G| ∣ Σ_g |Fix(g)|`.

Sections 4/5 were previously merged despite proving different statements; section 1/2 split separates the mathematical motivation from boilerplate. Each new section has a substantive summary + mathContext.

Quality 96 → 100. `pnpm build` passes. meta.json only; status/badge/axiomCount untouched.