### PR TITLE
research(abel-galois-oq06): fold in Step 4 normalizer_iso_AGL1Z — frontier 1→0 (DRAFT, build-gated)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -13,6 +13,7 @@ import Proofs.AbelRuffiniGaloisExtensionsOQ05OQ01
 import Proofs.AbelRuffiniGaloisExtensionsOQ06
 import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirection
 import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep1
+import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4
 import Proofs.AbelRuffiniGaloisExtensionsOQ07
 import Proofs.AbelRuffiniOQ04
 import Proofs.AbelRuffiniOQ04OQ01

--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
@@ -31,6 +31,7 @@
 -/
 
 import Proofs.AbelRuffiniGaloisExtensionsOQ06
+import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4
 -- Full Mathlib. Step 3's discharge (`sylow_p_is_pcycle`, folded in from the
 -- build-verified orphan) draws on factorization/Legendre (`Nat.factorization_factorial`),
 -- orbit–stabilizer (`MulAction.orbitEquivQuotientStabilizer`, `orbit_eq_univ`),
@@ -425,8 +426,9 @@ theorem sylow_p_is_pcycle
 theorem normalizer_iso_AGL1Z
     (σ : Equiv.Perm (ZMod p)) (_hσ : σ.IsCycle) (_hσ_card : σ.support.card = p) :
     ∃ φ : (Subgroup.zpowers σ).normalizer →* AGL1Z p,
-      Function.Injective φ ∧ Function.Surjective φ := by
-  sorry
+      Function.Injective φ ∧ Function.Surjective φ :=
+  AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.normalizer_iso_AGL1Z
+    σ _hσ _hσ_card
 
 /-- **Step 5 (H ≤ N_{S_p}(P)).** Since the Sylow-p subgroup `P` is
     normal in `H` and its image under `ι = H.subtype ∘ P.subtype` is the

--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.lean
@@ -2,29 +2,28 @@ import Mathlib
 import Proofs.AbelRuffiniGaloisExtensionsOQ06
 
 /-
-  BUILD STATUS (researcher-2, S23, 2026-06-18): this file is a COMPLETE,
-  `sorry`-free discharge of Step 4 (`normalizer_iso_AGL1Z`), but it is **not yet
-  build-verified**. It is intentionally an UNREGISTERED orphan (absent from
-  `Proofs.lean` and not yet wired into the registered `…GaloisDirection.lean`
-  `sorry`), so it cannot affect the gated green build — the same staging the
-  Step 1 / Step 3 orphans used before they were folded in once compiled.
+  BUILD STATUS (researcher-2, S24, 2026-06-18): this file is a COMPLETE,
+  `sorry`-free discharge of Step 4 (`normalizer_iso_AGL1Z`). On THIS branch
+  (`research/abel-galois-oq06-step4-foldin`) it has been FOLDED IN: it is now
+  registered in `Proofs.lean`, imported by `…GaloisDirection.lean`, and the
+  registered `normalizer_iso_AGL1Z` `sorry` (formerly at L429) is discharged by
+  `… Step4.normalizer_iso_AGL1Z σ _hσ _hσ_card`. Step 1 (`sylow_p_unique`) was
+  already folded into the main file in a prior session, so this fold-in drops
+  the Galois-direction sorry frontier 1 → 0.
 
-  A Docker build was launched this session: it fetched the Mathlib cache,
-  compiled the parent `AbelRuffiniGaloisExtensionsOQ06.olean`, and reached the
-  `lean … Step4.lean` elaboration step emitting no errors, but the host was
-  badly oversaturated (load ~13, ~18 concurrent build containers; the lean
-  process accrued only ~40 s of CPU in 25 min of wall time) and the 60-min
-  build cap fired before a green result. The Docker daemon then degraded to a
-  hard fault (`input/output error` on the containerd blob store — even a
-  trivial `docker run` fails), so no further build was possible.
+  **NOT yet build-verified** — the fold-in PR is shipped as a DRAFT precisely
+  because the build remains gated: this session's Docker daemon is in a hard
+  fault (`input/output error` on the containerd content store — the
+  `lean4-arm64` image blob is unreadable, `docker images`/`system df` both
+  throw, even a trivial `docker run` fails), and the Aristotle backend returns
+  404 ("Resource not found"). Neither verifier is available. An earlier
+  session's Docker build reached the `lean … Step4.lean` elaboration step
+  emitting no errors before being CPU-starved off the 60-min cap.
 
-  NEXT SESSION (build-capable): rebuild this file in isolation
-  (`docker-build.sh Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4`);
-  once green, register it in `Proofs.lean` and replace the `sorry` at
-  `…GaloisDirection.lean:429` with
-  `exact …GaloisDirectionStep4.normalizer_iso_AGL1Z σ _hσ _hσ_card`, dropping
-  the Galois-direction sorry frontier 2 → 1 (only Step 1 `sylow_p_unique`
-  would remain). The statement is numerically certified by
+  NEXT SESSION (build-capable): build the fleet target
+  (`docker-build.sh Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirection`,
+  which transitively compiles this file); on GREEN, mark the draft PR ready so
+  the deployer merges it. The statement is numerically certified by
   `verify_step4_normalizer.py` (brute-force `N_{S_p}(⟨σ⟩) = AGL(1,p)` image,
   both injective and surjective, for p ∈ {3,5,7}).
 


### PR DESCRIPTION
## Summary

Folds the build-pending, **sorry-free** Step 4 orphan (`AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.normalizer_iso_AGL1Z`, merged in #25968) into the registered headline file. This discharges the **last remaining frontier sorry** of the Galois-direction sub-problem.

### Changes
- `Proofs.lean`: register `…GaloisDirectionStep4` (symmetric with the already-registered Step 1).
- `…GaloisDirection.lean`: `import` Step 4 and replace the registered `normalizer_iso_AGL1Z` `sorry` (formerly L429) with `… Step4.normalizer_iso_AGL1Z σ _hσ _hσ_card`.
- `…GaloisDirectionStep4.lean`: refresh the now-stale BUILD STATUS docstring.

Step 1 (`sylow_p_unique`) was already folded into `main` in a prior session, so this takes the Galois-direction sorry frontier **1 → 0**. `grep` confirms no real `sorry` remains in `…GaloisDirection.lean` on this branch.

### Why DRAFT / build-gated
Both verifiers are unavailable this session:
- **Docker**: daemon content store corrupted — `input/output error` on the containerd blob store; the `lean4-arm64:v4.26.0` image is unreadable (`docker images`/`system df` both throw); even `docker run` fails. Fleet-wide all day, needs an operator Docker restart.
- **Aristotle**: backend returns `404 Resource not found`.

The fold-in typechecks by inspection: the orphan's theorem signature is **identical** to the in-file statement (`(σ : Equiv.Perm (ZMod p)) (_hσ : σ.IsCycle) (_hσ_card : σ.support.card = p)`, same goal type, same `{p : ℕ} [Fact p.Prime]` context), and its bearer lemmas (`Subgroup.map_equiv_normalizer_eq`, `MonoidHom.map_zpowers`, `Subgroup.equivMapOfInjective`, `MulEquiv.subgroupCongr`, `Equiv.Perm.isConj_iff_cycleType_eq`) were audited against the Mathlib v4.26 pin in prior sessions. An earlier Docker build reached the Step 4 elaboration step with **no errors** before being CPU-starved off the cap.

### Next build-capable session
```
./proofs/scripts/docker-build.sh Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirection
```
On GREEN, mark this PR ready — the deployer merges math PRs directly. Kept as a **draft** so the deployer will not merge an unverified change to a registered (fleet-compiled) file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)