### PR TITLE
research(zsqrtd-neg-two-oq-01): unified iff for primes p = x²+2y² [build-pending]

### DIFF
--- a/proofs/Proofs/ZsqrtdNegTwoOQ01.lean
+++ b/proofs/Proofs/ZsqrtdNegTwoOQ01.lean
@@ -1,0 +1,108 @@
+/-
+# A single bi-conditional characterization of primes `p = x² + 2y²`
+
+  (`zsqrtd-neg-two-oq-01`, open question on the parent gallery proof
+   `zsqrtd-neg-two`: "ℤ[√−2]: Euclidean Domain and x² + 2y² Representations")
+
+## The question
+
+The parent file `Proofs.ZsqrtdNegTwo` proves the two *forward* implications
+
+* `p % 8 = 1 → ∃ a b : ℤ, a² + 2 b² = p`   (`SqAddTwoSq.sq_add_two_sq_of_prime_one_mod_eight`)
+* `p % 8 = 3 → ∃ a b : ℤ, a² + 2 b² = p`   (`SqAddTwoSq.sq_add_two_sq_of_prime_three_mod_eight`)
+
+but never assembles them, together with the (missing) *converse* and the even
+prime `2 = 0² + 2·1²`, into one bi-conditional.  The open question asks precisely
+for that single `↔` statement.
+
+## What this file adds
+
+1. `repr_mod_eight` — the **converse** (the genuinely new content).  If an
+   *odd* natural number `p` is represented as `a² + 2 b²` then `p ≡ 1` or
+   `3 (mod 8)`.  This is elementary: `p` odd forces `a` odd, so `a² ≡ 1 (mod 8)`,
+   while `2 b² ≡ 0` or `2 (mod 8)`; hence `p ≡ 1` or `3 (mod 8)`.  The argument is
+   carried out in `ZMod 8`, where the achievable values of `x² + 2 y²` are
+   `{0,1,2,3,4,6}` — in particular never `5` or `7` — and the odd residues are
+   `{1,3,5,7}`; intersecting gives `{1,3}`.
+
+2. `prime_sq_add_two_sq_iff` — the **unified characterization** the open
+   question asks for: for every prime `p`,
+   `(∃ a b : ℤ, a² + 2 b² = p) ↔ (p = 2 ∨ p % 8 = 1 ∨ p % 8 = 3)`.
+
+## Status
+
+Build-pending: the host Docker/Lean toolchain and the Aristotle backend were
+both unavailable when this file was written, so it has not yet been machine
+checked.  Every lemma name used against Mathlib (pin `v4.26.0`) was verified to
+exist by direct inspection of `proofs/.lake/packages/mathlib`
+(`ZMod.natCast_mod`, `ZMod.val_natCast`, `Nat.Prime.eq_two_or_odd`).  Do **not**
+register this file in `Proofs.lean` until it has been Docker-built.
+-/
+import Mathlib
+import Proofs.ZsqrtdNegTwo
+
+open SqAddTwoSq
+
+namespace ZsqrtdNegTwoOQ01
+
+/-- **Converse direction.**  If an odd natural number `p` is representable as
+`a² + 2 b²` (with `a b : ℤ`), then `p ≡ 1` or `3 (mod 8)`.
+
+Primality is *not* needed — only that `p` is odd.  The proof reduces the
+identity modulo `8`: in `ZMod 8` the value `x² + 2 y²` is never `5` or `7`
+(a finite `decide` check), so the odd residue `p % 8 ∈ {1,3,5,7}` must lie in
+`{1,3}`. -/
+theorem repr_mod_eight (p : ℕ) (hodd : p % 2 = 1)
+    (a b : ℤ) (h : a ^ 2 + 2 * b ^ 2 = (p : ℤ)) : p % 8 = 1 ∨ p % 8 = 3 := by
+  -- (A) Reduce the representing identity modulo 8.
+  have h8 : (a : ZMod 8) ^ 2 + 2 * (b : ZMod 8) ^ 2 = (p : ZMod 8) := by
+    have hh := congrArg (fun z : ℤ => (z : ZMod 8)) h
+    push_cast at hh
+    exact_mod_cast hh
+  -- (B) `x² + 2 y²` is never `5` or `7` in `ZMod 8` (finite check).
+  have hforbidden : ∀ x y : ZMod 8, x ^ 2 + 2 * y ^ 2 ≠ 5 ∧ x ^ 2 + 2 * y ^ 2 ≠ 7 := by
+    decide
+  have h5 : (p : ZMod 8) ≠ 5 := by
+    rw [← h8]; exact (hforbidden (a : ZMod 8) (b : ZMod 8)).1
+  have h7 : (p : ZMod 8) ≠ 7 := by
+    rw [← h8]; exact (hforbidden (a : ZMod 8) (b : ZMod 8)).2
+  -- (C) Transport the two exclusions back to `p % 8`.
+  have cast_mod : (p : ZMod 8) = ((p % 8 : ℕ) : ZMod 8) := (ZMod.natCast_mod p 8).symm
+  have hv5 : p % 8 ≠ 5 := by
+    intro hc; apply h5; rw [cast_mod, hc]; simp
+  have hv7 : p % 8 ≠ 7 := by
+    intro hc; apply h7; rw [cast_mod, hc]; simp
+  -- (D) `p % 8 < 8` is odd and avoids `5, 7`, hence equals `1` or `3`.
+  have hlt : p % 8 < 8 := Nat.mod_lt _ (by norm_num)
+  have hpar : p % 8 % 2 = 1 := by omega
+  omega
+
+/-- **Unified characterization (the open question).**  For every prime `p`,
+`p` is of the form `a² + 2 b²` (with `a b : ℤ`) iff `p = 2` or `p ≡ 1` or
+`3 (mod 8)`.
+
+* `→` combines the even prime case `2 = 0² + 2·1²` with `repr_mod_eight`.
+* `←` combines the explicit witness for `2` with the parent file's two forward
+  theorems. -/
+theorem prime_sq_add_two_sq_iff (p : ℕ) (hp : p.Prime) :
+    (∃ a b : ℤ, a ^ 2 + 2 * b ^ 2 = (p : ℤ)) ↔ (p = 2 ∨ p % 8 = 1 ∨ p % 8 = 3) := by
+  constructor
+  · rintro ⟨a, b, hab⟩
+    by_cases hp2 : p = 2
+    · exact Or.inl hp2
+    · have hodd : p % 2 = 1 := (hp.eq_two_or_odd).resolve_left hp2
+      exact Or.inr (repr_mod_eight p hodd a b hab)
+  · rintro (h2 | h1 | h3)
+    · exact ⟨0, 1, by rw [h2]; norm_num⟩
+    · haveI : Fact (Nat.Prime p) := ⟨hp⟩
+      exact sq_add_two_sq_of_prime_one_mod_eight h1
+    · haveI : Fact (Nat.Prime p) := ⟨hp⟩
+      exact sq_add_two_sq_of_prime_three_mod_eight h3
+
+/-- Sanity checks against small primes. -/
+example : (∃ a b : ℤ, a ^ 2 + 2 * b ^ 2 = (2 : ℤ)) := ⟨0, 1, by norm_num⟩
+example : (∃ a b : ℤ, a ^ 2 + 2 * b ^ 2 = (3 : ℤ)) := ⟨1, 1, by norm_num⟩
+example : (∃ a b : ℤ, a ^ 2 + 2 * b ^ 2 = (11 : ℤ)) := ⟨3, 1, by norm_num⟩
+example : (∃ a b : ℤ, a ^ 2 + 2 * b ^ 2 = (17 : ℤ)) := ⟨3, 2, by norm_num⟩
+
+end ZsqrtdNegTwoOQ01

--- a/research/problems/zsqrtd-neg-two-oq-01/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-01/knowledge.md
@@ -1,27 +1,44 @@
-# Knowledge Base: zsqrtd-neg-two-oq-01
+# zsqrtd-neg-two-oq-01 — single bi-conditional for primes p = x² + 2y²
 
-Insights accumulated during research on this problem.
+## Problem
+Unify the complete characterization of primes representable as `x² + 2y²` into a
+single `↔` in Lean. Parent: `zsqrtd-neg-two` (ℤ[√−2] Euclidean domain).
 
----
+## Status: ACT (proof written, build-pending)
 
-## Problem Understanding
+Both verification backends were down this session (host Docker containerd blob
+I/O corruption, fleet-wide; Aristotle MCP returning 404 "Resource not found").
+The proof is verify-by-construction: every Mathlib lemma name was confirmed to
+exist by direct inspection of `proofs/.lake/packages/mathlib` (pin v4.26.0).
+NOT yet machine-checked → not registered in `Proofs.lean`.
 
-(Initial observations from OBSERVE phase will be recorded here.)
+## Session 2026-06-18 (s01) — FRESH
 
----
+### Key mathematical content
+The parent file already proves the two FORWARD implications (`p % 8 = 1` and
+`p % 8 = 3` ⟹ representable) via `-2` being a QR mod p. It never assembled them
+into an iff and never proved the CONVERSE.
 
-## Insights
+- **Converse (new, elementary):** odd `p = a² + 2b²` ⟹ `p ≡ 1` or `3 (mod 8)`.
+  `p` odd ⟹ `a` odd ⟹ `a² ≡ 1 (mod 8)`; `2b² ≡ 0` or `2 (mod 8)`. In `ZMod 8`
+  the achievable values of `x²+2y²` are `{0,1,2,3,4,6}` (a 64-case `decide`),
+  never `5` or `7`; intersect with odd residues `{1,3,5,7}` ⟹ `{1,3}`.
+- **Unified iff:** for prime `p`,
+  `(∃ a b : ℤ, a²+2b² = p) ↔ (p = 2 ∨ p % 8 = 1 ∨ p % 8 = 3)`.
+  `←`: even case `2 = 0²+2·1²` + parent's two forward theorems.
+  `→`: even case + converse.
 
-(Insights from research attempts will be accumulated here.)
+### Built items
+- `ZsqrtdNegTwoOQ01.repr_mod_eight` (converse) — proofs/Proofs/ZsqrtdNegTwoOQ01.lean
+- `ZsqrtdNegTwoOQ01.prime_sq_add_two_sq_iff` (the open-question iff) — same file
 
----
+### Lemmas relied on (all confirmed present in pin v4.26.0)
+`ZMod.natCast_mod`, `ZMod.val_natCast`, `Nat.Prime.eq_two_or_odd`,
+`SqAddTwoSq.sq_add_two_sq_of_prime_{one,three}_mod_eight` (parent).
 
-## Mathlib Coverage Audit
-
-(After ORIENT phase: list of relevant Mathlib lemmas / APIs and their applicability.)
-
----
-
-## Anti-Goals
-
-(Things explicitly NOT to attempt — discovered duplicates, scope creep risks, etc.)
+### Next steps
+1. When Docker/Aristotle recover: `./proofs/scripts/docker-build.sh Proofs.ZsqrtdNegTwoOQ01`.
+2. If green, register in `proofs/Proofs.lean` and add gallery meta under
+   `src/data/proofs/zsqrtd-neg-two/` (or OQ-01 entry).
+3. Risk points to watch on first build: the `decide`/`simp` cast-back closers in
+   `repr_mod_eight` step (C), and `exact_mod_cast` after `push_cast` in step (A).

--- a/research/problems/zsqrtd-neg-two-oq-01/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-01/state.md
@@ -1,9 +1,9 @@
 # Research State: zsqrtd-neg-two-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: fast
-**Since**: 2026-05-12T23:37:36Z
+**Since**: 2026-06-18T15:52:48-07:00
 **Iteration**: 1
 
 ## Current Focus

--- a/research/registry.json
+++ b/research/registry.json
@@ -23026,11 +23026,11 @@
     },
     {
       "slug": "zsqrtd-neg-two-oq-01",
-      "phase": "OBSERVE",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-18T21:42:27.143Z",
       "status": "active",
-      "lastUpdate": "2026-06-18T21:42:27.257Z"
+      "lastUpdate": "2026-06-18T15:52:48-07:00"
     }
   ],
   "config": {


### PR DESCRIPTION
## Summary

Resolves the open question `zsqrtd-neg-two-oq-01`: assemble the complete characterization of primes representable as `a² + 2b²` into a **single bi-conditional** in Lean.

The parent gallery proof `zsqrtd-neg-two` already proves the two *forward* implications (`p ≡ 1` and `p ≡ 3 (mod 8)` ⟹ representable, via `-2` a QR mod p) but never assembled them, and never proved the converse.

## New content (`proofs/Proofs/ZsqrtdNegTwoOQ01.lean`)

- **`repr_mod_eight`** — the **converse** (the genuinely new piece, elementary): an *odd* `p = a² + 2b²` forces `p ≡ 1` or `3 (mod 8)`. Proof reduces mod 8 in `ZMod 8`, where `x² + 2y²` ranges over `{0,1,2,3,4,6}` (a 64-case `decide`) and so is never `5` or `7`; intersecting with the odd residues `{1,3,5,7}` leaves `{1,3}`.
- **`prime_sq_add_two_sq_iff`** — the open question itself: for every prime `p`,
  `(∃ a b : ℤ, a² + 2b² = p) ↔ (p = 2 ∨ p % 8 = 1 ∨ p % 8 = 3)`.
  Forward = even case `2 = 0²+2·1²` + `repr_mod_eight`; backward = even witness + the parent's two forward theorems.

## Status: build-pending — do NOT register

Both verification paths were unavailable this session:
- host Docker: containerd content-store blob I/O corruption (fleet-wide, also hitting sibling researchers today);
- Aristotle MCP backend: `404 Resource not found`.

So this file is **verify-by-construction** and is **not** imported in `Proofs.lean`. Every Mathlib lemma used was confirmed to exist in pin `v4.26.0` by direct inspection of `proofs/.lake/packages/mathlib` (`ZMod.natCast_mod`, `ZMod.val_natCast`, `Nat.Prime.eq_two_or_odd`, parent `SqAddTwoSq.sq_add_two_sq_of_prime_{one,three}_mod_eight`).

**Next build-capable session:** `./proofs/scripts/docker-build.sh Proofs.ZsqrtdNegTwoOQ01`; if green, register + add gallery meta. First-build risk points: the `exact_mod_cast`/`push_cast` step and the `simp` cast-back closers in `repr_mod_eight`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)