### PR TITLE
audit: record two clean gallery entries missing from main tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15942,8 +15942,20 @@
       "lastAudited": "2026-06-18T20:41:43Z",
       "result": "clean",
       "issues": []
+    },
+    "lagrange-theorem-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-18T23:13:10Z",
+      "result": "clean"
+    },
+    "shannon-channel-coding-awgn": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-18T23:13:10Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-18T12:28:01Z"
+  "lastUpdated": "2026-06-18T23:13:10Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Two gallery entries have been absent from `audit-tracker.json` on `main`, so `find-targets.ts --stats` perpetually reports `2540/2542` audited and re-serves the same two slugs every cycle. The auditor's `complete` writes only ever landed in the per-worktree tracker (REPO_ROOT points at the worktree, but `find-targets` reads main), so the records never reached `main`.

This PR records both entries (re-audited clean this cycle) directly in the main tracker.

### Audit results

**`lagrange-theorem-oq-02-oq-01-oq-01`** — "Burnside's Lemma with No Burnside Intermediate"
- `status: verified`, `badge: mathlib` (Tier B — correct)
- 0 sorries, 0 axioms, 0 `native_decide`, 0 True stubs (matches Lean source)
- `originalContributions` accurately scoped: Burnside derived *without* Mathlib's Burnside lemma; `mathlibDependencies` disclosed. No overclaim.

**`shannon-channel-coding-awgn`**
- `status: verified`, `badge: original`
- 0 sorries, 0 axioms, 0 `native_decide`, 0 True stubs (matches Lean source)

### Effect

`find-targets` will read these clean records from main → `2542/2542` audited, ending the wasted re-serve loop.

---
Discovered during gallery integrity audit. Data-only change (audit tracker).