### PR TITLE
audit: record clean audit of algebraic-numbers-countable-oq-02-oq-03-oq-02

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15954,6 +15954,12 @@
       "issues": [],
       "lastAudited": "2026-06-18T23:13:10Z",
       "result": "clean"
+    },
+    "algebraic-numbers-countable-oq-02-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T01:02:20Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: algebraic-numbers-countable-oq-02-oq-03-oq-02 (*Algebraic Reals Are Meager / Baire Category Transcendence*)
**Result**: CLEAN — no integrity issues.

### Why this PR
The slug was **absent** from main's `src/data/proofs/audit-tracker.json` `entries{}`. `find-targets` keys on *presence* (not status), so it re-served this entry every cycle while the `complete` write landed only in the auditor worktree's tracker copy. This commits the clean record into main so the gallery shows 2543/2543 audited. (Same durable-fix pattern as #25973.)

### Audit findings (Tier A, badge `original`, status `verified` — all justified)
- **0 sorries, 0 `axiom` declarations, 0 `native_decide`, 0 `True` stubs** in `proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02.lean` — matches meta.
- **theoremCount 8** matches the 8 declared theorems.
- Main result `isMeagre_algebraicReals` is **genuinely assembled** (witness family of singletons → nowhere-dense → countability via the credited parent result `algebraic_reals_countable` → coverage), not a one-line Mathlib wrapper. Mathlib dependencies and parent prerequisites are properly disclosed in meta.
- Description is accurate and non-overclaiming.

---
Discovered during gallery integrity audit. Tracker-only change; no Lean or gallery content modified.