### PR TITLE
research(buffon-oq010202): explicit O(1/n) convergence rate for √n·c_n² [build-pending, DRAFT]

### DIFF
--- a/proofs/Proofs/BuffonConstantAsymptotic.lean
+++ b/proofs/Proofs/BuffonConstantAsymptotic.lean
@@ -278,6 +278,40 @@ lemma sqrt_mul_buffonConstant_sq_bounds (n : ℕ) (hn : 3 ≤ n) :
           mul_le_mul_of_nonneg_left hbounds.2 hc
       _ = (2 / π) * ((n : ℝ) / ((n : ℝ) - 1)) := by field_simp; ring
 
+/-- **Explicit `O(1/n)` convergence rate** for the squared target to its limit `2/π`.
+For every `n ≥ 3`,
+`|(√n · buffonConstant n)^2 - 2/π| ≤ (2/π)/(n-1)`.
+This is the quantitative companion to `sqrt_mul_buffonConstant_tendsto`: it turns the
+two-sided envelope `sqrt_mul_buffonConstant_sq_bounds` into a single explicit error term,
+making the rate of convergence to `2/π` manifest. The upper envelope contributes a
+deviation `(2/π)·n/(n-1) - 2/π = (2/π)/(n-1)`, while the lower envelope's deviation
+`2/π - (2/π)·n(n-2)/(n-1)^2 = (2/π)/(n-1)^2` is even smaller (since `(n-1)^2 ≥ (n-1)`),
+so the symmetric bound `(2/π)/(n-1)` covers both sides. -/
+lemma sqrt_mul_buffonConstant_sq_rate (n : ℕ) (hn : 3 ≤ n) :
+    |(Real.sqrt (n : ℝ) * buffonConstant n) ^ 2 - 2 / π|
+      ≤ (2 / π) / ((n : ℝ) - 1) := by
+  have hncast : (3 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have hn1 : (0 : ℝ) < (n : ℝ) - 1 := by linarith
+  have hn1ne : ((n : ℝ) - 1) ≠ 0 := ne_of_gt hn1
+  have hpine : (π : ℝ) ≠ 0 := ne_of_gt pi_pos
+  have hpos : (0 : ℝ) < 2 / π := by positivity
+  obtain ⟨hlo, hhi⟩ := sqrt_mul_buffonConstant_sq_bounds n hn
+  -- rewrite both envelopes as `2/π ± (2/π)/(n-1)^k`
+  have hloeq : (2 / π) * ((n : ℝ) * ((n : ℝ) - 2) / ((n : ℝ) - 1) ^ 2)
+      = 2 / π - (2 / π) / ((n : ℝ) - 1) ^ 2 := by
+    field_simp; ring
+  have hhieq : (2 / π) * ((n : ℝ) / ((n : ℝ) - 1))
+      = 2 / π + (2 / π) / ((n : ℝ) - 1) := by
+    field_simp; ring
+  rw [hloeq] at hlo
+  rw [hhieq] at hhi
+  -- the lower deviation `(2/π)/(n-1)^2` is dominated by `(2/π)/(n-1)`
+  have hsq : (2 / π) / ((n : ℝ) - 1) ^ 2 ≤ (2 / π) / ((n : ℝ) - 1) := by
+    rw [div_le_div_iff (by positivity) hn1]
+    nlinarith [mul_pos hpos hn1, hn1, hpos, hncast]
+  rw [abs_le]
+  exact ⟨by linarith, by linarith⟩
+
 /-- `(s n)^2 / n → 1/2`, by squeezing `s_sq_bounds` (divided by `n`) between
 `((n-2)/2)/n = 1/2 - 1/n` and `((n-1)/2)/n = 1/2 - 1/(2n)`, both `→ 1/2`. -/
 lemma s_sq_div_tendsto :

--- a/src/data/proofs/buffons-needle-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-02-oq-02/meta.json
@@ -159,9 +159,9 @@
       "Topology"
     ],
     "namespace": "BuffonOQ010202",
-    "lineCount": 394,
+    "lineCount": 444,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 16,
     "definitionCount": 2,
     "path": "Proofs/BuffonConstantAsymptotic.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds one lemma to `BuffonConstantAsymptotic.lean` (buffons-needle-oq-01-oq-02-oq-02):

**`sqrt_mul_buffonConstant_sq_rate`** — for all `n ≥ 3`,
```
|(√n · buffonConstant n)^2 − 2/π| ≤ (2/π)/(n − 1).
```

This turns the qualitative limit `sqrt_mul_buffonConstant_tendsto` (`√n·c_n → √(2/π)`)
into an **explicit O(1/n) error term** on the squared quantity. It is a direct
consequence of the two-sided envelope `sqrt_mul_buffonConstant_sq_bounds` (#25966):
each side is rewritten as `2/π ± (2/π)/(n−1)^k`, and the lower deviation (`k = 2`)
is dominated by the upper one (`k = 1`) using `(n−1)^2 ≥ (n−1)`, so the symmetric
bound `(2/π)/(n−1)` covers both directions.

- 0 sorries, 0 axioms, Mathlib-only.
- `meta.json`: `theoremCount` 15 → 16, `lineCount` → 444 (matches actual `wc -l`).

## ⚠️ Build status: PENDING — kept as DRAFT

`BuffonConstantAsymptotic.lean` is imported by `Proofs.lean`, so an uncompilable
change would break **all** fleet builds. I could not obtain a clean compile
confirmation because Docker crashed host-wide during verification:

- Run 1: container exited fast & clean (exit 0) — but `docker-build.sh` exit-0 can
  mask a quick compile error, so not authoritative.
- Run 2: timed out at 20m (full Mathlib cache re-download under fleet contention ate
  the budget — never reached a Lean error).
- Run 3 (50m timeout): container died mid-`lake build` with `error waiting for
  container: unexpected EOF`; immediately afterward all ~19 lean containers
  vanished and `docker run` reports **"Docker Desktop is unable to start"**.

This is a host-level Docker daemon failure (fleet overload), not a Lean error.
**Do not merge** until a green `docker-build.sh Proofs.BuffonConstantAsymptotic`
confirms compilation; then mark ready.

Static review: the two algebraic identities (`field_simp; ring`, same pattern used
at lines 270/279) and the `abs_le` split are verified by hand; the lone `nlinarith`
in the denominator-domination step was hardened with an explicit `mul_pos hpos hn1`
product hint so the required `(2/π)·(n−1)^2` cross-term is constructible pairwise.