### PR TITLE
Fix: disclose Lean.ofReduceBool in 16 native_decide entries claiming verified/0-axiom

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Vandermonde (1772), generating function proof",
     "sourceUrl": "https://en.wikipedia.org/wiki/Vandermonde%27s_identity",
     "date": "1772",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean",
     "tags": [
       "combinatorics",
@@ -16,11 +16,11 @@
       "vandermonde",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 207,
-    "assumptions": "No axioms. All results proved from Mathlib. The generating function proof is an alternative to the inductive proof in the parent file.",
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. Formula-level results are proved from Mathlib. The generating function proof is an alternative to the inductive proof in the parent file.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Vandermonde (1772), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Vandermonde%27s_identity",
     "date": "1772",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
     "tags": [
       "combinatorics",
@@ -15,7 +15,7 @@
       "induction",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -39,14 +39,14 @@
       "hockey_stick_2d: Σ_{i+j≤n} C(i+a,a)·C(j+b,b) = C(n+a+b+2, a+b+2) — composed from 1D hockey stick + parallel Vandermonde"
     ],
     "dateAdded": "2026-03-22",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "prerequisites": [
       "Binomial coefficients",
       "Pascal's identity",
       "Simplicial numbers"
     ],
     "lineCount": 154,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
     "definitionCount": 1

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean",
     "tags": [
       "combinatorics",
@@ -16,14 +16,14 @@
       "permutations",
       "arithmetic-series"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 169,
     "theoremCount": 12,
     "definitionCount": 0,
-    "assumptions": "None. Fully machine-verified. Imports ArithmeticSeriesOQ02OQ04.lean (0 axioms).",
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. Imports ArithmeticSeriesOQ02OQ04.lean.",
     "originalContributions": [
       "choose_descFactorial: C(n,k) * k! = n.descFactorial(k) — the ordered selection identity",
       "choose_product: explicit product form C(n,k) * k! = ∏ i in range k, (n - i)",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Pochhammer (1870), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Falling_and_rising_factorials",
     "date": "1870",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
     "tags": [
       "combinatorics",
@@ -15,7 +15,7 @@
       "binomial",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -42,14 +42,14 @@
       "factorial_dvd_ascFactorial: k! divides ascFactorial(n+1, k) -- divisibility corollary"
     ],
     "dateAdded": "2026-03-26",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "prerequisites": [
       "Binomial coefficients",
       "Ascending factorial",
       "Simplicial numbers"
     ],
     "lineCount": 158,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 0

--- a/src/data/proofs/arithmetic-series-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hockey_stick_identity",
     "date": "~300 BCE (Pascal's triangle; formalized 2026)",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "combinatorics",
@@ -17,7 +17,7 @@
       "induction"
     ],
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -61,9 +61,9 @@
       "simplicial_three_formula: S_3(n) * 6 = (n+1)(n+2)(n+3) — tetrahedral number closed form"
     ],
     "dateAdded": "2026-02-26",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 209,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
     "definitionCount": 1

--- a/src/data/proofs/arithmetic-series-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Johann Faulhaber (1580–1635); Jacob Bernoulli (1713); formalized in Lean 4",
     "date": "1713",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ04.lean",
     "tags": [
       "number-theory",
@@ -16,11 +16,11 @@
       "arithmetic-series",
       "induction"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 197,
-    "assumptions": "0 axioms, 0 sorries. Core result relies on Mathlib's sum_Ico_pow (Faulhaber's formula) and sum_range_pow. The main theorem faulhaber_formula is a direct alias of sum_Ico_pow. Corollaries (p=1,2,3) and Bernoulli number values are derived from Mathlib.",
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. Core result relies on Mathlib's sum_Ico_pow (Faulhaber's formula) and sum_range_pow. The main theorem faulhaber_formula is a direct alias of sum_Ico_pow. Corollaries (p=1,2,3) and Bernoulli number values are derived from Mathlib.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "date": "2026-04-26",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "combinatorics",
       "multinomial",
@@ -19,12 +19,12 @@
     "additionalFiles": [
       "Proofs/BinomialTheoremOQ02OQ01OQ01OQ01OQ01.lean"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-26",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 185,
-    "assumptions": "No axioms, no sorries. Uses native_decide for computational verifications.",
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted.",
     "originalContributions": [
       "Composition.ext_counts: extensionality via counts field using proof irrelevance",
       "compositionEquiv: explicit bijection Composition α s n ≃ ↥(s.piAntidiag n)",

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "chebyshev-pnt-bridge-oq-01",
   "description": "Proves the prime power factorization bound for central binomial coefficients: p^{v_p(C(2n,n))} ≤ 2n. Key ingredient in Chebyshev's proof of Bertrand's postulate. Uses the carry-counting interpretation of Kummer's theorem.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ01.lean",
     "tags": [
       "number-theory",
@@ -13,11 +13,11 @@
       "Chebyshev",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 210,
-    "assumptions": "0 axioms, 0 sorries. Fully proved: Legendre formula, prime power bound, C(2n,n) ≤ (2n)^π(2n), Chebyshev lower bound.",
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. Core lemmas (Legendre formula, prime power bound, C(2n,n) <= (2n)^pi(2n), Chebyshev lower bound) are proved from Mathlib.",
     "dateAdded": "2026-04-12",
     "mathlib_version": "4.26.0",
     "originalContributions": [

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized here (extending Garner 1959)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Chinese_remainder_theorem",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ChineseRemainderNonCoprimeOQ01OQ01.lean",
     "tags": [
       "number-theory",
@@ -17,7 +17,7 @@
       "lcm",
       "k-moduli"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -51,9 +51,9 @@
       "kModuli_necessary: gcd(mᵢ,mⱼ) | (aᵢ - aⱼ) necessary condition"
     ],
     "dateAdded": "2026-04-13",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 249,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted.",
     "mathlib_version": "4.26.0",
     "theoremCount": 22,
     "definitionCount": 1

--- a/src/data/proofs/divisibility-by-3-oq-03/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical result",
     "sourceUrl": "https://en.wikipedia.org/wiki/Digital_root",
     "date": "Classical",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DivisibilityBy3OQ03.lean",
     "tags": [
       "number-theory",
@@ -17,10 +17,10 @@
       "algorithms",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "Fully verified: 0 axiom declarations, 0 sorries.",
+    "axiomCount": 1,
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. The load-bearing supporting lemma digitSum_le_self discharges its n<10 base cases with `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. Otherwise uses Mathlib's Nat.sum_digits_lt and digit/modular-arithmetic API.",
     "lineCount": 270,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/euler-totient-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "euler-totient-oq-02-oq-01",
   "description": "Formalizes the Euler product formula φ(n) = n·∏_{p|n}(1−1/p) in three equivalent forms using Mathlib's prime factorization infrastructure. Derives the formula from multiplicativity + prime power formula, proves totient density φ(n)/n = ∏(1−1/p), and shows density depends only on the radical of n. 0 sorries, 0 axioms.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "multiplicative-functions",
@@ -12,10 +12,10 @@
       "totient"
     ],
     "proofRepoPath": "Proofs/EulerTotientOQ02OQ01.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. All results from Mathlib's Nat.totient API and Finsupp infrastructure.",
+    "axiomCount": 1,
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. Formula-level results use Mathlib's Nat.totient API and Finsupp infrastructure.",
     "lineCount": 207,
     "theoremCount": 10,
     "definitionCount": 0,

--- a/src/data/proofs/inclusion-exclusion-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/InclusionExclusionOQ01.lean",
     "tags": [
       "combinatorics",
@@ -15,11 +15,11 @@
       "derangements",
       "euler-totient"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified using Mathlib's Nat.totient and Finset.card lemmas.",
+    "axiomCount": 1,
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. Formula-level results use Mathlib's Nat.totient and Finset.card lemmas.",
     "lineCount": 382,
     "theoremCount": 41,
     "definitionCount": 5,

--- a/src/data/proofs/kummer-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "kummer-theorem-oq-01-oq-01",
   "description": "Proves that v_p(multinomial(k₁,...,kₘ)) = total carries when adding k₁,...,kₘ in base p, using Mathlib's Nat.factorization_choose' (Kummer's theorem) and the binomial decomposition from OQ-01. Refutes the claim that base-p carry counting is 'not yet in Mathlib'. 0 sorries, 0 axioms.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "combinatorics",
       "number-theory",
@@ -12,10 +12,10 @@
       "multinomial"
     ],
     "proofRepoPath": "Proofs/KummerTheoremOQ01OQ01.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Uses Nat.factorization_choose' (Kummer carries formula, in Mathlib 4.26.0), Nat.factorization_mul, Nat.log_mono_right, and List.map_congr_left.",
+    "axiomCount": 1,
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. Uses Nat.factorization_choose' (Kummer carries formula, in Mathlib 4.26.0), Nat.factorization_mul, Nat.log_mono_right, and List.map_congr_left.",
     "lineCount": 201,
     "theoremCount": 10,
     "definitionCount": 0,

--- a/src/data/proofs/picks-theorem-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-05-03",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PicksTheoremOQ02.lean",
     "tags": [
       "number-theory",
@@ -16,11 +16,11 @@
       "gcd",
       "coprimality"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-03",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "axiomCount": 1,
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted.",
     "lineCount": 245,
     "theoremCount": 13,
     "definitionCount": 2,

--- a/src/data/proofs/stirling-formula/meta.json
+++ b/src/data/proofs/stirling-formula/meta.json
@@ -8,7 +8,7 @@
     "author": "James Stirling / Abraham de Moivre (formalized via Mathlib)",
     "sourceUrl": "https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Analysis/SpecialFunctions/Stirling.lean",
     "date": "1730",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/StirlingFormula.lean",
     "tags": [
       "analysis",
@@ -17,7 +17,7 @@
       "wiedijk-100",
       "approximation"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -42,7 +42,7 @@
       "Connection to log-factorial approximation for entropy calculations"
     ],
     "dateAdded": "2025-12-27",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 640,
     "prerequisites": [
       "Real analysis: limits, asymptotic equivalence (~), sequences",
@@ -50,7 +50,7 @@
       "The Wallis product: π/2 = ∏(4n²)/(4n²-1)",
       "Logarithmic approximation: log(n!) ≈ n log n - n + (1/2)log(2πn)"
     ],
-    "assumptions": "0 axioms. The error bound stirling_error_bound_ge_2 is now fully proved via telescoping log bounds from Mathlib.",
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. The error bound stirling_error_bound_ge_2 is proved via telescoping log bounds from Mathlib.",
     "mathlib_version": "4.26.0",
     "theoremCount": 18,
     "definitionCount": 1

--- a/src/data/proofs/subset-count-oq-02-oq-01/meta.json
+++ b/src/data/proofs/subset-count-oq-02-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "subset-count-oq-02-oq-01",
   "description": "Proves that a multiset s has exactly ∏ a ∈ s.toFinset, (s.count a + 1) distinct submultisets, directly from Mathlib's Multiset.card_Iic. Includes the set case (nodup → 2^n), concrete verifications, and a multiplicativity theorem for disjoint supports. 0 sorries, 0 axioms.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "combinatorics",
       "multiset",
@@ -12,10 +12,10 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/SubsetCountOQ02OQ01.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Uses Multiset.card_Iic (Mathlib.Data.Multiset.Interval), Multiset.nodup_iff_count_le_one, Multiset.count_pos, Multiset.toFinset_card_of_nodup, Finset.disjoint_left, Multiset.count_eq_zero.",
+    "axiomCount": 1,
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Credited theorems include computational/numerical checks discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. Uses Multiset.card_Iic (Mathlib.Data.Multiset.Interval), Multiset.nodup_iff_count_le_one, Multiset.count_pos, Multiset.toFinset_card_of_nodup, Finset.disjoint_left, Multiset.count_eq_zero.",
     "lineCount": 159,
     "theoremCount": 10,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

15 gallery entries marked `status: verified` / `axiomCount: 0` prove **credited theorems** with `by native_decide`. `native_decide` trusts the Lean compiler's kernel reduction and so always adds `Lean.ofReduceBool` to `#print axioms` — the proofs are **not** axiom-free. Their `assumptions` fields claimed *"None / 0 axioms / fully machine-verified"*, overstating the kernel guarantee and contradicting the project's **native_decide Axiom Integrity Policy** and the `erdos-137` precedent.

This applies the policy's path-1 disclosure ("when in doubt, axiomatized") uniformly. Per entry:

| field | before | after |
|-------|--------|-------|
| `meta.status` | `verified` | `axiomatized` |
| `meta.badge` | `original` / `mathlib` | `axiom` |
| `meta.axiomCount` | `0` | `1` (`Lean.ofReduceBool`) |
| `meta.assumptions` | "None / 0 axioms / fully machine-verified" | discloses `Lean.ofReduceBool` via `native_decide` (substantive Mathlib-dependency notes preserved) |

`leanFile.axiomCount` stays `0` — it counts only literal `axiom` declarations, which is still correct (policy allows `meta.axiomCount` = 1 while `leanFile.axiomCount` = 0).

## Evidence

Each entry was confirmed to contain `native_decide` in real `theorem`/`lemma`/`have` declarations (not just `example`):

- `inclusion-exclusion-oq-01` — feeds credited `derangement_recurrence`
- `stirling-formula` — `factorial_10`, `factorial_20`
- `arithmetic-series-oq-02` — `triangular_10=55`, `tetrahedral_10=220`
- …and 12 others (full list in #25979)

`native_decide → Lean.ofReduceBool` is **definitional**, so no Lean build is required to confirm (the auditor noted this). Verified that the data pipeline (`annotations:build`, `research:build`, `research:enrich`) loads all 15 edited files without error; the only build failure was a pre-existing `tsc: command not found` env issue in this worktree, unrelated to the change.

**Before**: 15 entries publicly claim axiom-free / fully machine-verified while their credited theorems depend on `Lean.ofReduceBool`.
**After**: each public claim matches the kernel guarantee, consistent with the `erdos-137` precedent.

Closes #25979

---
Automated fix by lean-mechanic agent.