### PR TITLE
audit: disclose Lean.ofReduceBool in picks-theorem-oq-01-oq-01-oq-01 (native_decide, missed by #25980)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4682,8 +4682,8 @@
     },
     "erdos-133": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T03:38:02Z",
       "result": "clean"
     },
     "erdos-134": {
@@ -4700,14 +4700,14 @@
     },
     "erdos-136": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T03:33:48Z",
       "result": "clean"
     },
     "erdos-137": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 6,
+      "lastAudited": "2026-06-19T03:36:54Z",
       "result": "clean"
     },
     "erdos-138": {
@@ -15208,10 +15208,11 @@
       "result": "clean"
     },
     "picks-theorem-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-05-12T14:50:30Z",
-      "result": "clean"
+      "lastAudited": "2026-06-19T03:40:00Z",
+      "result": "issues-fixed",
+      "agentId": "auditor-cycle-20-batch"
     },
     "collatz-cycles-oq-03": {
       "auditCount": 1,

--- a/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
@@ -7,10 +7,10 @@
     "author": "Lean Genius Research (researcher-4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Pick%27s_theorem",
     "date": "2026-05-12",
-    "status": "formalized",
-    "badge": "original",
+    "status": "axiomatized",
+    "badge": "axiom",
     "proofRepoPath": "Proofs/PicksTheoremOQ01OQ01OQ01.lean",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "sorries": 0,
     "theoremCount": 63,
     "definitionCount": 27,
@@ -28,7 +28,7 @@
       "translation-invariance",
       "research-scaffold"
     ],
-    "assumptions": [],
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. The credited base-case agreement theorems (unitTriangle_pick_agrees, triangle_2_1_pick_agrees, triangle_3_3_pick_agrees, plus the concrete twiceArea/boundaryCount/realInteriorCount facts) are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy this entry is therefore `axiomatized` with meta.axiomCount 1 (`Lean.ofReduceBool`). leanFile.axiomCount stays 0 (it counts literal `axiom` declarations only). The ordinary foundational axioms (propext, Classical.choice, Quot.sound) are not counted. The general primitive-triangle and translation-invariance results in this file do not rely on native_decide.",
     "imports": [
       "Mathlib.Data.Int.GCD",
       "Mathlib.Data.Int.Interval",
@@ -174,7 +174,7 @@
     }
   ],
   "conclusion": {
-    "summary": "S2 OBSERVE extends the S1 bridge with a decidable definition of the real strictly-interior lattice-point count (`realInteriorCount` via a same-sign cross-product test on a bounding-box Finset) and proves base-case agreement `realInteriorCount T = pickInterior T` on the unit, 2-by-1, and 3-by-3 test triangles. The base case is then generalized to all primitive triangles (S3-prep/S3a-plus: `realInteriorCount = pickInterior = 0` whenever `twiceArea = 1`), the GCD ↔ edge-boundary-point characterisation is established (S3b-act-1/2/3), and the whole Pick bridge is shown translation-invariant (S4-prep). Total file footprint: 27 definitions and 63 theorems. Sorry-free, 0 axioms, 1249 lines.",
+    "summary": "S2 OBSERVE extends the S1 bridge with a decidable definition of the real strictly-interior lattice-point count (`realInteriorCount` via a same-sign cross-product test on a bounding-box Finset) and proves base-case agreement `realInteriorCount T = pickInterior T` on the unit, 2-by-1, and 3-by-3 test triangles. The base case is then generalized to all primitive triangles (S3-prep/S3a-plus: `realInteriorCount = pickInterior = 0` whenever `twiceArea = 1`), the GCD ↔ edge-boundary-point characterisation is established (S3b-act-1/2/3), and the whole Pick bridge is shown translation-invariant (S4-prep). Total file footprint: 27 definitions and 63 theorems. Sorry-free with 0 literal axiom declarations, 1249 lines; the concrete base-case agreement theorems use `native_decide`, which adds `Lean.ofReduceBool` to `#print axioms` (see assumptions), so the entry is `axiomatized` rather than fully axiom-free.",
     "implications": "S2 closes the base-case agreement: the Pick formula does compute the true strictly-interior lattice-point count on three primitive and near-primitive triangles. Combined with S1's algebraic identity `2A = 2I + B − 2`, the bridge is now bidirectional — Pick's formula in cleared-denominator form is the natural induction target, with each primitive triangle contributing `(twiceArea, boundaryCount, pickInteriorNum) = (1, 3, 0)`, and the next sessions need only establish that the additivity step preserves Σ pickInteriorNum across primitive-triangulation joins.",
     "openQuestions": [
       "S3: Lift the base-case agreement from concrete triangles to all primitive (|det| = 1) lattice triangles. The unit-triangle case is dischargeable by direct enumeration of the bounding box; the general primitive case requires showing that any primitive triangle is `Affine`-equivalent (over ℤ²) to a small reference triangle, OR a direct argument via the cross-product orientation theorem.",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `picks-theorem-oq-01-oq-01-oq-01`
**Severity**: LOW (disclosure gap, no Lean source change)

### Problem

The entry's **credited** base-case agreement theorems are discharged with `native_decide`:

- `unitTriangle_pick_agrees`, `triangle_2_1_pick_agrees`, `triangle_3_3_pick_agrees`
- plus the concrete `twiceArea` / `boundaryCount` / `realInteriorCount` facts (lines 208–393)

`native_decide` trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms` — the proofs are **not** axiom-free. Yet the entry asserted:

- `badge: "original"` (claims no assumptions)
- `axiomCount: 0`, `assumptions: []`
- conclusion prose "Sorry-free, 0 axioms"

This overstates the kernel guarantee and contradicts the project's native_decide Axiom Integrity Policy (CLAUDE.md) and the erdos-137 / #25979 / #25980 precedent.

### Why it was missed

#25980 fixed **16** native_decide entries but scoped to those claiming **`verified`/0-axiom**. This entry carries `status: "formalized"` (a research scaffold), so it fell outside that pass — even though its sibling `picks-theorem-oq-02` received the identical fix.

The other 29 native_decide gallery files surfaced in this sweep use it only inside `example` demo blocks (benign, no disclosure required). This was the **only** entry of 30 with `native_decide` inside a credited `theorem`.

### Fix (matches #25980 pattern)

| field | before | after |
|-------|--------|-------|
| `meta.status` | `formalized` | `axiomatized` |
| `meta.badge` | `original` | `axiom` |
| `meta.axiomCount` | `0` | `1` (`Lean.ofReduceBool`) |
| `meta.assumptions` | `[]` | discloses `Lean.ofReduceBool` via native_decide |
| conclusion prose | "0 axioms" | clarified |

`leanFile.axiomCount` stays `0` (counts literal `axiom` declarations only). No Lean source changed; `native_decide → Lean.ofReduceBool` is definitional, so no build is required to confirm.

---
Discovered during gallery integrity audit (auditor agent, cycle 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)