### PR TITLE
research(abel-ruffini-oq-07): ORIENT survey — statement correction + Dedekind/Frobenius skeleton

### DIFF
--- a/research/problems/abel-ruffini-oq-07/knowledge.md
+++ b/research/problems/abel-ruffini-oq-07/knowledge.md
@@ -1,21 +1,142 @@
 # Knowledge Base: abel-ruffini-oq-07
 
-Insights accumulated during research on this problem.
+Galois group of f = x⁵ − x − 1 over ℚ is S₅ (a second Abel–Ruffini quintic witness,
+complementing the Eisenstein example).
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+**Goal:** Gal(x⁵ − x − 1 / ℚ) ≅ S₅, hence not solvable.
+
+The original problem statement proposed the route:
+(i) f irreducible (Selmer 1956); (ii) Δ = 2869 = 19·151 not a perfect square ⟹ G ⊄ A₅;
+(iii) "f has exactly three real roots" ⟹ complex conjugation is a transposition ⟹ S₅.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### ⚠️ CORRECTION: the problem statement is mathematically WRONG on point (iii)
+
+Verified numerically/symbolically (sympy + numpy, session 2026-06-18):
+
+- **f = x⁵ − x − 1 has exactly ONE real root** (≈ 1.1673), NOT three.
+  The four non-real roots form **two** complex-conjugate pairs
+  (≈ 0.1812 ± 1.0840i and ≈ −0.7649 ± 0.3525i).
+  Reason: f′ = 5x⁴ − 1 has critical points ±(1/5)^{1/4} ≈ ±0.6687; both critical
+  values are negative (f(−0.6687) ≈ −0.465, f(+0.6687) ≈ −1.535), so f crosses zero once.
+- Consequence: **complex conjugation acts as a product of TWO transpositions** on the
+  four non-real roots (fixing the one real root) — an **EVEN** permutation, lying in A₅.
+  It is therefore **NOT a transposition.**
+- The clean Mathlib real-roots lemma is thus **inapplicable**:
+  `Polynomial.Gal.galActionHom_bijective_of_prime_degree`
+  (`Mathlib/Analysis/Complex/Polynomial/Basic.lean:126`) requires
+  `card (rootSet ℂ) = card (rootSet ℝ) + 2`, i.e. exactly ONE conjugate pair.
+  Here `card ℂ = card ℝ + 4`, which fails the hypothesis. (The Eisenstein examples
+  x⁵−4x+2 and x⁵−6x+3 DO have 3 real roots — verified — which is why they use this route.)
+
+### ⚠️ The discriminant route (ii) alone is INSUFFICIENT
+
+Δ not a perfect square ⟹ G ⊄ A₅ ⟹ G contains an odd permutation. But among the
+**transitive** subgroups of S₅ (C₅, D₅, F₂₀, A₅, S₅), the ones containing odd
+permutations are exactly **{F₂₀ (order 20), S₅}** — note D₅'s reflections act on 5
+points as products of two transpositions (even), so D₅ ⊂ A₅. So "irreducible +
+disc-not-square" only narrows the group to {F₂₀, S₅}. To exclude F₂₀ one must show
+**3 ∣ |G|** (|F₂₀| = 20 is not divisible by 3). The problem statement implicitly
+assumed disc-not-square + a transposition (from the false "3 real roots") gave S₅
+directly; with the real-roots claim removed, an extra mod-p (Frobenius) input is required.
+
+### Correct, fully-verified proof (Dedekind / Frobenius cycle types)
+
+Verified factorization types of f mod p (sympy, all squarefree ⟹ p unramified):
+
+| p  | factor degrees | Frobenius cycle type | contributes |
+|----|----------------|----------------------|-------------|
+| 3  | [5]            | 5-cycle              | transitive, 5 ∣ |G| |
+| 5  | [5]            | 5-cycle              | (alt for p=3) |
+| 2  | [2, 3]         | (2,3), order 6       | σ³ = **transposition**; σ² = 3-cycle ⟹ 3 ∣ |G| |
+| 7  | [2, 3]         | (2,3), order 6       | (alt for p=2) |
+| 17 | [1, 1, 3]      | 3-cycle              | 3 ∣ |G| |
+| 23 | [1, 4]         | 4-cycle (odd)        | G ⊄ A₅ |
+
+**Cleanest argument (transposition route):**
+1. f irreducible mod 3 ⟹ G (= image of `galActionHom`) contains a **5-cycle** ⟹ transitive, 5 ∣ |G|.
+2. f ≡ (irred. quadratic)·(irred. cubic) mod 2 ⟹ Frobenius σ of cycle type (2,3), order 6;
+   then **σ³ is a transposition** ∈ G.
+3. `Equiv.Perm.subgroup_eq_top_of_swap_mem` (`Mathlib/GroupTheory/Perm/Cycle/Type.lean:549`):
+   for H ≤ Perm α with `card α` prime, `card α ∣ card H`, and H containing a swap ⟹ H = ⊤.
+   With α = roots (card 5, prime), 5 ∣ |G|, transposition ∈ G ⟹ G = S₅. ∎
+
+(Alternative "resolvent/discriminant" route matching the problem title: disc-not-square ⟹
+G ⊄ A₅, plus 3 ∣ |G| from p=17 ⟹ G = S₅ since the only transitive subgroup with an odd
+element and order divisible by 3 is S₅. Same Frobenius dependency.)
+
+Independently verified: Δ(f) = 2869 = 19·151 (not a square), f irreducible over ℚ.
+
+### Buildability assessment (Lean 4 / Mathlib, pin v4.26.0)
+
+| Step | Mathlib support | Verdict |
+|------|-----------------|---------|
+| natDegree 5 is prime | trivial (`decide`) | BUILDABLE |
+| f irreducible over ℚ | reducible mod 2 (=(x²+x+1)(x³+x²+1)) and mod 7, but **irreducible mod 3/5/11/13** ⟹ irreducible over ℚ by mod-p reduction. Eisenstein does NOT apply. | BUILDABLE (~100–200 L) |
+| 5 ∣ card Gal | `Polynomial.Gal.prime_degree_dvd_card` | BUILDABLE |
+| transposition ∈ Gal (or 3 ∣ \|G\|) | **Dedekind–Frobenius bridge: factor type mod p ⟹ cycle type of Frobenius as a root-permutation.** | **NOT BUILDABLE today** |
+| assemble S₅ | `Equiv.Perm.subgroup_eq_top_of_swap_mem` | BUILDABLE |
+
+**The single blocker is the Dedekind–Frobenius bridge** — and the gallery's own
+flagship "Galois group of a specific quintic" entry confirms its difficulty:
+- `Proofs/InverseGaloisA5.lean` (2067 L) **still carries `axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal`** (line 309) — precisely this bridge, axiomatized.
+- `Proofs/InverseGaloisA5Dedekind.lean` is actively trying to discharge it via
+  `AlgHom.IsArithFrobAt` / `arithFrobAt` / `Ideal.inertiaDegIn`
+  (`Mathlib/RingTheory/Frobenius.lean`, `Mathlib/NumberTheory/RamificationInertia/Galois.lean`)
+  and still has a substantive `sorry` (the Frobenius construction `exists_gal_order_three`).
+
+**Cross-problem synergy:** OQ-07 and `inverse-galois-a5-oq-01` need the *same* Dedekind–
+Frobenius machinery. If that open work lands a reusable
+"factor type mod unramified p ⟹ element of matching cycle type in `p.Gal`" lemma, BOTH
+problems close. OQ-07 needs it for a 5-cycle (p=3) and a transposition (σ³, p=2); a5-oq-01
+needs it for a 3-cycle (p=7).
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Real-roots / complex-conjugation route** (`galActionHom_bijective_of_prime_degree`):
+  fails because f has only 1 real root ⟹ conjugation is even (∈ A₅), not a swap.
+  This is the route the Eisenstein gallery examples use; it does NOT transfer to x⁵−x−1.
+- **Discriminant alone**: only narrows G to {F₂₀, S₅}; needs a supplementary 3 ∣ |G| input.
+- **Eisenstein for irreducibility**: inapplicable (no prime divides all lower coeffs).
+  Use mod-3 (or mod-5) irreducibility instead.
+
+---
+
+## Session Log
+
+### Session 2026-06-18 (Session 1, OBSERVE → ORIENT) — FRESH
+
+**Mode:** FRESH. **Outcome:** scouted / ORIENT (no Lean written — see below).
+
+**What I did**
+- Symbolically verified (sympy/numpy, no docker): Δ = 2869 = 19·151 (not square),
+  irreducible over ℚ, **exactly 1 real root** (refuting the statement's "3 real roots"),
+  and the full table of mod-p factorization cycle types.
+- Mapped the Mathlib toolchain: `prime_degree_dvd_card`,
+  `galActionHom_bijective_of_prime_degree` (inapplicable here),
+  `subgroup_eq_top_of_swap_mem` (the assembler).
+- Grounded buildability in the gallery A5 precedent (`InverseGaloisA5*`): the Dedekind–
+  Frobenius bridge is the universal blocker and is currently axiomatized/sorry'd there.
+
+**Why no Lean file:** Both verifiers were down this session (docker image-inspect FAIL,
+host load ~19; Aristotle backend 404). More importantly, the *one buildable gap* (the
+Frobenius bridge) is open infra already under attack in `inverse-galois-a5-oq-01`; writing
+a partial S₅ file now would either be unbuildable or just re-axiomatize the same step.
+
+**Next steps**
+- Coordinate with / wait on `inverse-galois-a5-oq-01`'s `exists_gal_order_three`
+  (`IsArithFrobAt`) work; when it yields a reusable cycle-type lemma, write `AbelRuffiniOQ07.lean`:
+  irreducible(mod 3) + `prime_degree_dvd_card` + transposition(σ³, p=2) + `subgroup_eq_top_of_swap_mem`.
+- Interim option (matching gallery convention): an **axiomatized** entry that states the
+  S₅ result with `axiom`s for the two Frobenius cycle-type facts (5-cycle@3, transposition@2),
+  exactly parallel to `InverseGaloisA5.three_dvd_gal_card`. Status would be `axiomatized`.
+- File a correction note: the curated problem statement's "exactly three real roots" is false.

--- a/src/data/research/problems/abel-ruffini-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-oq-07.json
@@ -1,0 +1,339 @@
+{
+  "slug": "abel-ruffini-oq-07",
+  "title": "Selmer-Style S₅ Galois Group for x⁵ − x − 1",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\operatorname{Gal}\\!\\left(x^5 - x - 1 \\,/\\, \\mathbb{Q}\\right) \\cong S_5 .",
+    "plain": "Provide a second machine-verified example of a quintic over ℚ with non-solvable Galois group, using the classical \"resolvent/discriminant\" route rather than the Eisenstein criterion. For f = x⁵ − x − 1: (i) f is irreducible over ℚ (Selmer 1956 proved xⁿ − x − 1 is irreducible for all n); (ii) its discriminant is Δ = 2869 = 19·151, which is not a perfect square, so the Galois group is not contained in the alternating group A₅; (iii) f has exactly three real roots, so complex conjugation acts as a transposition. An irreducible quintic whose group contains a transposition and is not inside A₅ must be all of S₅, which is not solvable — a concrete witness to Abel–Ruffini.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-16T03:36:37-07:00",
+    "iteration": 1,
+    "focus": "ORIENT: corrected statement + verified Dedekind-Frobenius proof skeleton; blocked on Dedekind bridge (same as InverseGaloisA5 axiom).",
+    "blockers": [],
+    "nextAction": "Wait on inverse-galois-a5-oq-01 Frobenius lemma; or ship axiomatized entry.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT: corrected the statement (x⁵−x−1 has 1 real root, NOT 3 → real-roots/conjugation route inapplicable; conjugation is even, in A₅). Disc=2869=19·151 not square but disc-alone only narrows G to {F₂₀,S₅}. Correct proof = Dedekind/Frobenius: 5-cycle@p=3 + transposition(σ³)@p=2 + subgroup_eq_top_of_swap_mem ⟹ S₅. Buildability blocker = Dedekind-Frobenius bridge, the SAME axiom (three_dvd_gal_card) the gallery A5 entry still carries.",
+    "builtItems": [],
+    "insights": [
+      "VERIFIED (sympy/numpy): x⁵−x−1 has exactly ONE real root (≈1.1673), not three; 4 non-real roots = two conjugate pairs. Problem statement point (iii) is FALSE.",
+      "Complex conjugation here = product of two transpositions (even, ∈ A₅), NOT a transposition ⟹ Mathlib galActionHom_bijective_of_prime_degree (needs cardℂ=cardℝ+2) is INAPPLICABLE.",
+      "Disc(f)=2869=19·151, not a perfect square (verified) ⟹ G ⊄ A₅. But among transitive subgroups of S₅ only F₂₀ and S₅ contain odd perms (D₅ reflections are even), so disc-alone only gives G∈{F₂₀,S₅}; need 3∣|G| to finish.",
+      "Verified mod-p cycle types: irreducible mod 3,5,11,13 (5-cycle); mod 2,7 = (2,3) order-6 (σ³=transposition, σ²=3-cycle); mod 17=(1,1,3) 3-cycle; mod 23,29,31=(1,4) 4-cycle.",
+      "f is REDUCIBLE mod 2 (=(x²+x+1)(x³+x²+1)) so Selmer/mod-2 wont give irreducibility; use mod-3 irreducibility. Eisenstein inapplicable."
+    ],
+    "mathlibGaps": [
+      "Dedekind-Frobenius bridge (factor type of f mod unramified p ⟹ matching cycle type element in p.Gal as root-permutation) is NOT available in Mathlib v4.26.0. This is the sole blocker for a verified S₅ proof and is exactly the axiom three_dvd_gal_card (InverseGaloisA5.lean:309) the gallery A5 entry still carries; InverseGaloisA5Dedekind.lean is mid-attempt via IsArithFrobAt with a live sorry."
+    ],
+    "nextSteps": [
+      "When inverse-galois-a5-oq-01 lands a reusable cycle-type lemma (exists_gal_order_three via IsArithFrobAt), write AbelRuffiniOQ07.lean: mod-3 irreducibility + prime_degree_dvd_card + transposition(σ³,p=2) + Equiv.Perm.subgroup_eq_top_of_swap_mem.",
+      "Interim: ship an AXIOMATIZED entry parallel to InverseGaloisA5 (axioms for 5-cycle@3 and transposition@2), status=axiomatized/badge=axiom.",
+      "File correction: curated statement claims 3 real roots; actual = 1 real root."
+    ],
+    "markdown": "# Knowledge Base: abel-ruffini-oq-07\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "galois-theory",
+    "abel-ruffini",
+    "quintic",
+    "resolvent",
+    "discriminant",
+    "number-theory"
+  ],
+  "relatedProofs": [
+    "abel-ruffini",
+    "abel-ruffini-galois-extensions",
+    "abel-ruffini-galois-extensions-oq-04",
+    "abel-ruffini-galois-extensions-oq-05",
+    "abel-ruffini-galois-extensions-oq-05-oq-01",
+    "abel-ruffini-galois-extensions-oq-07",
+    "abel-ruffini-oq-04",
+    "abel-ruffini-oq-04-oq-01",
+    "abel-ruffini-oq-04-oq-02",
+    "abel-ruffini-oq-04-oq-02-oq-02",
+    "abel-ruffini-oq-04-oq-02-oq-03",
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07",
+    "abel-ruffini-oq-09",
+    "abel-ruffini-oq-10"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-16T03:36:37-07:00",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/AbelRuffini.lean",
+      "filename": "AbelRuffini.lean",
+      "lineCount": 188,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffini.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
+      "filename": "AbelRuffiniGaloisExtensions.lean",
+      "lineCount": 535,
+      "theoremCount": 57,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ04.lean",
+      "lineCount": 235,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ05.lean",
+      "lineCount": 215,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ05OQ01.lean",
+      "lineCount": 202,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06.lean",
+      "lineCount": 531,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean",
+      "lineCount": 615,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 7,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionAssembly.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06GaloisDirectionAssembly.lean",
+      "lineCount": 184,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionAssembly.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionMainAssembly.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06GaloisDirectionMainAssembly.lean",
+      "lineCount": 87,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionMainAssembly.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep1.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep1.lean",
+      "lineCount": 280,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep1.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.lean",
+      "lineCount": 272,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ07.lean",
+      "lineCount": 1974,
+      "theoremCount": 23,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 7,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04.lean",
+      "filename": "AbelRuffiniOQ04.lean",
+      "lineCount": 164,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
+      "filename": "AbelRuffiniOQ04OQ01.lean",
+      "lineCount": 1499,
+      "theoremCount": 36,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ02.lean",
+      "filename": "AbelRuffiniOQ04OQ02.lean",
+      "lineCount": 155,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ02.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ02OQ02.lean",
+      "filename": "AbelRuffiniOQ04OQ02OQ02.lean",
+      "lineCount": 168,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ02OQ02OQ06.lean",
+      "filename": "AbelRuffiniOQ04OQ02OQ02OQ06.lean",
+      "lineCount": 245,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ06.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ02OQ03.lean",
+      "filename": "AbelRuffiniOQ04OQ02OQ03.lean",
+      "lineCount": 105,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ03.lean",
+      "filename": "AbelRuffiniOQ04OQ03.lean",
+      "lineCount": 243,
+      "theoremCount": 8,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ09Cyclic.lean",
+      "filename": "AbelRuffiniOQ04OQ09Cyclic.lean",
+      "lineCount": 47,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ09Cyclic.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ09.lean",
+      "filename": "AbelRuffiniOQ09.lean",
+      "lineCount": 541,
+      "theoremCount": 21,
+      "axiomCount": 2,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ09.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ10.lean",
+      "filename": "AbelRuffiniOQ10.lean",
+      "lineCount": 370,
+      "theoremCount": 23,
+      "axiomCount": 2,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ10.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

ORIENT-phase research survey for `abel-ruffini-oq-07` (Gal(x⁵−x−1/ℚ) ≅ S₅). **Metadata only — no Lean code, no build.**

### Key finding: the curated problem statement is mathematically wrong
The statement claims *"f has exactly three real roots"* and uses that to make complex conjugation a transposition. **Verified (sympy/numpy): x⁵−x−1 has exactly ONE real root** (≈1.1673); the four non-real roots are two conjugate pairs. So complex conjugation acts as **two** transpositions — an **even** permutation in A₅, *not* a transposition. The clean Mathlib real-roots lemma `galActionHom_bijective_of_prime_degree` (needs `cardℂ = cardℝ + 2`) is therefore **inapplicable**.

### Corrected, verified mathematics
- Δ(f) = 2869 = 19·151, **not** a perfect square ⟹ Gal ⊄ A₅ — but disc alone only narrows Gal to {F₂₀, S₅} (D₅ reflections are even). Needs a supplementary **3 ∣ |Gal|**.
- Verified mod-p Frobenius cycle types: irreducible mod 3/5/11/13 (**5-cycle**); mod 2/7 = (2,3) order-6 (**σ³ = transposition**); mod 17 = (1,1,3) (3-cycle); mod 23/29/31 = (1,4) (odd 4-cycle).
- **Correct proof**: 5-cycle (mod 3) + transposition (σ³, mod 2) + `Equiv.Perm.subgroup_eq_top_of_swap_mem` ⟹ Gal = S₅.

### Buildability verdict
The sole blocker is the **Dedekind–Frobenius bridge** (factor type mod unramified p ⟹ matching cycle type in `p.Gal`), which Mathlib v4.26.0 lacks. This is *exactly* the `axiom three_dvd_gal_card` the gallery's flagship `InverseGaloisA5.lean:309` still carries; `InverseGaloisA5Dedekind.lean` is mid-attempt (live `sorry`) via `IsArithFrobAt`. **Cross-problem synergy** with `inverse-galois-a5-oq-01`: one reusable cycle-type lemma closes both. Buildable today only as an *axiomatized* entry.

### Changes
- `research/problems/abel-ruffini-oq-07/knowledge.md` — full ORIENT writeup, corrected math, proof skeleton, buildability table.
- `src/data/research/problems/abel-ruffini-oq-07.json` — knowledge insights/gaps/nextSteps, phase OBSERVE→ORIENT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)