### PR TITLE
Fix: disclose Lean.ofReduceBool for native_decide theorems in konigsberg-oq-01, erdos-770, picks-theorem-oq-03

### DIFF
--- a/src/data/proofs/erdos-770/meta.json
+++ b/src/data/proofs/erdos-770/meta.json
@@ -55,9 +55,9 @@
       "Proved h_eq_succ_of_prime: h(n) = n+1 when n+1 is prime",
       "Bridge lemma zmod_pow_eq_one_of_dvd: converts nat divisibility to ZMod equality"
     ],
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 550,
-    "assumptions": "2 axioms: erdos_770_q1 (density of {n : hMinK n = p} exists for each prime p — OPEN), erdos_770_q3 (hMinK n = p when p is the largest prime with (p-1)|n, for large n — OPEN). Q2 (h(n) unbounded) is fully proved via hMinK_unbounded. 74 theorems, 0 sorries.",
+    "assumptions": "2 axioms: erdos_770_q1 (density of {n : hMinK n = p} exists for each prime p — OPEN), erdos_770_q3 (hMinK n = p when p is the largest prime with (p-1)|n, for large n — OPEN). Q2 (h(n) unbounded) is fully proved via hMinK_unbounded. 74 theorems, 0 sorries. The numerical theorems (h(n) for n = 1..12, the gcdPowerSeq_* / fermat_* / h_eq_3_* checks) are dispatched by native_decide, which trusts the Lean compiler's kernel reduction and so adds Lean.ofReduceBool to #print axioms; per the project's native_decide policy this is counted in meta.axiomCount (propext / Classical.choice / Quot.sound are not counted).",
     "mathlib_version": "4.26.0",
     "theoremCount": 74,
     "definitionCount": 2
@@ -148,7 +148,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #770 is fully verified with 0 axioms and 0 sorries. Contains computation of h(n) for n = 1..12 via native_decide, Fermat-based structural theorems, gcd monotonicity, polynomial root counting argument for h(n) ≤ n+1, and the formal definition hMinK with its properties. New: hMinK_prime_minus_one proves h(p-1) = p for all primes p; hMinK_unbounded proves that h is unbounded (resolving Q2's upper half).",
+    "summary": "Erdős Problem #770's structural and computational content is machine-verified with 0 sorries (the open Q1/Q3 density statements remain as 2 stated axioms). It contains computation of h(n) for n = 1..12 via native_decide — which trusts the Lean compiler's kernel reduction and so depends on Lean.ofReduceBool rather than a mathematical axiom — Fermat-based structural theorems, gcd monotonicity, polynomial root counting argument for h(n) ≤ n+1, and the formal definition hMinK with its properties. New: hMinK_prime_minus_one proves h(p-1) = p for all primes p; hMinK_unbounded proves that h is unbounded (resolving Q2's upper half).",
     "implications": "**Theoretical Significance**: Understanding h(n) would illuminate the arithmetic structure of exponential sequences modulo primes.\n\nThe density question connects to the distribution of smooth numbers and Fermat quotients. The largest-prime characterization would link h(n) to the factorization of n+1, bridging analytic and algebraic number theory.",
     "openQuestions": [
       "Does the natural density of {n : h(n) = p} exist for each prime p? If so, what is its value?",

--- a/src/data/proofs/konigsberg-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-01/meta.json
@@ -18,8 +18,8 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 2,
-    "assumptions": "Sufficiency direction of Euler's theorem axiomatized in HierholzerAlgorithm.lean: (1) euler_circuit_exists — connected + all-even-degree graphs admit an Eulerian circuit; (2) euler_trail_exists — connected graph with exactly two odd-degree vertices u, v admits an Eulerian trail u→v. Both encode the classical Hierholzer construction (1873) which is not yet formalized. The necessity direction (the focus of this file) is fully machine-verified.",
+    "axiomCount": 3,
+    "assumptions": "Sufficiency direction of Euler's theorem axiomatized in HierholzerAlgorithm.lean: (1) euler_circuit_exists — connected + all-even-degree graphs admit an Eulerian circuit; (2) euler_trail_exists — connected graph with exactly two odd-degree vertices u, v admits an Eulerian trail u→v. Both encode the classical Hierholzer construction (1873) which is not yet formalized. The necessity direction (the focus of this file) is fully machine-verified. In addition, several credited computational theorems (sq_degree, sq_edge_count, sqCircuit_length, sqCircuit_visits_all and the C₅/K₄ analogues) are dispatched by native_decide, which trusts the Lean compiler's kernel reduction and so adds Lean.ofReduceBool to #print axioms; per the project's native_decide policy this is counted in meta.axiomCount. The ordinary foundational axioms propext / Classical.choice / Quot.sound are not counted.",
     "lineCount": 404,
     "theoremCount": 24,
     "definitionCount": 11,
@@ -111,12 +111,12 @@
       "title": "Summary and Sanity Checks",
       "startLine": 358,
       "endLine": 404,
-      "summary": "Closing docstring cataloguing the 24 proved theorems (C₄, C₅, K₄, and general trail theory) with 0 axioms / 0 sorries, plus #check sanity statements for the key Eulerian results.",
+      "summary": "Closing docstring cataloguing the 24 proved theorems (C₄, C₅, K₄, and general trail theory) with 0 sorries and free of mathematical axioms (several are dispatched by native_decide, which depends on Lean.ofReduceBool via the compiler's kernel reduction), plus #check sanity statements for the key Eulerian results.",
       "mathContext": "Epilogue; no new declarations. #checks confirm sqCircuit_isEulerian, pentCircuit_isEulerian, k4_not_eulerian, and regular_odd_no_euler typecheck."
     }
   ],
   "conclusion": {
-    "summary": "Verifies Eulerian circuit existence for $C_4$ (explicit 4-edge circuit) and $C_5$ (explicit 5-edge circuit), and non-existence for $K_4$ (4 odd-degree vertices) and all odd-regular graphs with $|V| \\geq 3$. Proves general necessary conditions: Eulerian circuits require all-even degrees; Eulerian paths require $\\leq 2$ odd-degree vertices. 24 theorems, 8 definitions, 404 lines, 0 axioms in the main file. The companion HierholzerAlgorithm.lean axiomatizes the sufficiency direction (2 axioms) pending Hierholzer's algorithm formalization.",
+    "summary": "Verifies Eulerian circuit existence for $C_4$ (explicit 4-edge circuit) and $C_5$ (explicit 5-edge circuit), and non-existence for $K_4$ (4 odd-degree vertices) and all odd-regular graphs with $|V| \\geq 3$. Proves general necessary conditions: Eulerian circuits require all-even degrees; Eulerian paths require $\\leq 2$ odd-degree vertices. 24 theorems, 8 definitions, 404 lines, 0 axiom declarations in the main file (several theorems use native_decide and so depend on Lean.ofReduceBool). The companion HierholzerAlgorithm.lean axiomatizes the sufficiency direction (2 axioms) pending Hierholzer's algorithm formalization.",
     "implications": "This provides machine-verified concrete examples for Euler's theorem — the foundational result of graph theory. The combination of explicit circuit constructions (positive examples) with odd-degree counting arguments (negative examples) demonstrates both directions of the degree criterion. The `Walk.IsEulerian.card_odd_degree` lemma from Mathlib is the key bridge between the combinatorial structure and the algebraic degree counts.",
     "openQuestions": [
       "Prove the sufficiency direction of Euler's theorem: if $G$ is connected and all degrees are even, then $G$ has an Eulerian circuit. This requires Hierholzer's algorithm (1873) or a constructive induction on $|E|$, both of which require more substantial formalization than the necessity direction.",

--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -67,9 +67,9 @@
       "Proofs/PicksTheoremOQ03CrossPoly.lean",
       "Proofs/PicksTheoremOQ03.lean"
     ],
-    "axiomCount": 3,
+    "axiomCount": 4,
     "lineCount": 710,
-    "assumptions": "3 axioms: ehrhart_is_polynomial (Ehrhart counting function is polynomial), ehrhart_macdonald_reciprocity (interior count via sign-change), and ehrhart_fn (Ehrhart counting function as a typed primitive, declared in PicksTheoremOQ03.lean for the d=2 Pick's-theorem specialization).",
+    "assumptions": "3 axioms: ehrhart_is_polynomial (Ehrhart counting function is polynomial), ehrhart_macdonald_reciprocity (interior count via sign-change), and ehrhart_fn (Ehrhart counting function as a typed primitive, declared in PicksTheoremOQ03.lean for the d=2 Pick's-theorem specialization). In addition, the h*-vector sum sanity checks (unitCube_hstar_sum, simplex_hstar_sum, octahedron_hstar_sum) are dispatched by native_decide, which trusts the Lean compiler's kernel reduction and so adds Lean.ofReduceBool to #print axioms; per the project's native_decide policy this is counted in meta.axiomCount (propext / Classical.choice / Quot.sound are not counted).",
     "mathlib_version": "4.26.0",
     "theoremCount": 45,
     "definitionCount": 23
@@ -196,7 +196,7 @@
       "startLine": 1,
       "endLine": 695,
       "file": "Proofs/PicksTheoremOQ03CrossPoly.lean",
-      "summary": "Complete Ehrhart theory for the cross-polytope (hyperoctahedron) family β_d in dimensions 1-3. Proves Ehrhart polynomials, Macdonald reciprocity, h*-vector palindromy (reflexivity), interior shift L*(n)=L(n-1), cube-cross duality, dimension recurrence, monotonicity, boundary counts, and the beautiful identity h*_{β_d}(z) = (1+z)^d connecting to the binomial theorem. 69 theorems, 0 sorries, 0 axioms.",
+      "summary": "Complete Ehrhart theory for the cross-polytope (hyperoctahedron) family β_d in dimensions 1-3. Proves Ehrhart polynomials, Macdonald reciprocity, h*-vector palindromy (reflexivity), interior shift L*(n)=L(n-1), cube-cross duality, dimension recurrence, monotonicity, boundary counts, and the beautiful identity h*_{β_d}(z) = (1+z)^d connecting to the binomial theorem. 69 theorems, 0 sorries, and no axiom declarations beyond the three named Ehrhart axioms (the h*-sum checks use native_decide, hence depend on Lean.ofReduceBool).",
       "mathContext": "Complete Ehrhart theory for the cross-polytope (hyperoctahedron) family β_d in dimensions 1-3."
     }
   ],


### PR DESCRIPTION
## Fix

Three `axiomatized` gallery entries claim "0 axioms" / "axiom-free" over theorem sets that include `native_decide`-dispatched **credited theorems**, without disclosing `Lean.ofReduceBool`.

Part of #25985 (the systematic native_decide disclosure gap in the axiomatized/wip population). These three entries are **disjoint** from the batch being fixed in parallel — no overlapping files. Template: #25984.

## Evidence

Per the Axiom Integrity Policy (CLAUDE.md): `native_decide` trusts the compiler's kernel reduction and adds `Lean.ofReduceBool` to `#print axioms`. When it discharges a substantive credited theorem the entry presents as verified, `meta.axiomCount` must count it and `assumptions` must disclose it.

Verified each Lean file uses `native_decide` inside `theorem`/`lemma` (not `example`/`def`):

| slug | native_decide credited theorems | meta.axiomCount |
|------|--------------------------------|-----------------|
| `konigsberg-oq-01` | `sq_degree`, `sq_edge_count`, `sqCircuit_length`, `sqCircuit_visits_all`, C₅/K₄ analogues (13 total) | 2 → 3 |
| `erdos-770` | `gcdPowerSeq_*`, `fermat_*`, `h_val_*`, `h_eq_3_*` (52 total) | 2 → 3 |
| `picks-theorem-oq-03` | `unitCube_hstar_sum`, `simplex_hstar_sum`, `octahedron_hstar_sum` | 3 → 4 |

**Before**: `status: axiomatized` but prose claims "0 axioms / 0 sorries" / "fully verified with 0 axioms" / "69 theorems, 0 sorries, 0 axioms"; no `Lean.ofReduceBool` in `assumptions`.

**After**:
- `meta.axiomCount` bumped by 1 (the `Lean.ofReduceBool` dependency). `leanFile.axiomCount` left unchanged — it counts literal `axiom` declarations only.
- `assumptions` discloses `Lean.ofReduceBool`, naming the native_decide theorems.
- "0 axioms"/"axiom-free" prose covering native_decide theorems reworded to "free of mathematical axioms; depends on `Lean.ofReduceBool` via native_decide". `status` stays `axiomatized`.

## Validation

JSON validated (parses). `pnpm build` data stages (annotations / research / enrich) consume all metas without error. (Local `tsc` binary absent in this worktree — a pre-existing env issue, unrelated to these JSON-only edits.)

Part of #25985

---
Automated fix by lean-mechanic agent.