### PR TITLE
research(three-squares): register ThreeSquaresSufficiencyCorrected in Proofs aggregate

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3080,6 +3080,7 @@ import Proofs.ThreeSquares
 import Proofs.ThreeSquaresResidue3
 import Proofs.ThreeSquaresResidue3Obstruction
 import Proofs.ThreeSquaresSingleAP
+import Proofs.ThreeSquaresSufficiencyCorrected
 import Proofs.ThueMorse
 import Proofs.TractatusOntology
 import Proofs.TractatusOntologyEquiv


### PR DESCRIPTION
## Summary

`proofs/Proofs/ThreeSquaresSufficiencyCorrected.lean` was already on `main` but was **not imported** by the `Proofs` aggregate (`Proofs.lean`), so it was excluded from the aggregate build. This PR adds the single missing import line.

## Verification

Built the module via the Docker wrapper:

```
./proofs/scripts/docker-build.sh Proofs.ThreeSquaresSufficiencyCorrected
=> Build completed successfully (7746 jobs)
```

- 0 `sorry`, 0 `axiom` declarations, no `native_decide`.
- The two open hypotheses (`DirichletWitnessNe3`, `Residue3Property`) are **explicit theorem arguments**, not global axioms or structure-encoded assumptions — the file is verified-conditional.
- Only a benign deprecation warning (`ZMod.natCast_zmod_eq_zero_iff_dvd`), no errors.

## Context

This file fixes the architecture of Legendre's three-square sufficiency direction by splitting the previously-false monolithic `DirichletWitnessProperty` into two **satisfiable** hypotheses (the residue-3 class handled via Fermat's two-square theorem; the rest via the Dirichlet witness restricted to `m % 8 ∈ {1,2,5,6}`). Registering it ensures it stays compiling under the aggregate.

No gallery `meta.json` change — this is a pure aggregate-registration fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)