### PR TITLE
audit: record clean audit of algebraic-reals-meager (durable tracker fix)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15961,6 +15961,12 @@
       "lastAudited": "2026-06-19T01:02:20Z",
       "result": "clean",
       "issues": []
+    },
+    "algebraic-reals-meager": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T04:38:15Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: algebraic-reals-meager
**Result**: clean

### Problem

`algebraic-reals-meager` was absent from `main`'s `audit-tracker.json`. `find-targets.ts` keys on entry presence, so it re-served this slug every audit cycle even after a clean audit (the `complete` write lands in the agent worktree's tracker, not main's). This durably records the clean record on main.

### Audit findings (clean)

- **0 sorries**, 0 `admit`
- **0 `axiom` declarations**, 0 structure-encoded assumptions
- **0 `native_decide`** / no `Lean.ofReduceBool` exposure
- **0 True stubs**
- 8 theorems, all substantive (`countable_isMeagre`, `algebraicReals_isMeagre`, `transcendentalReals_residual/dense`, `exists_transcendental_real`, ...)
- Title/description honestly qualify the Baire-category strengthening; `assumptions` discloses Mathlib Baire-category reliance
- Badge `original` justified — `countable_isMeagre` (countable ⇒ meagre in any T1 perfect space) is genuine original infrastructure proved in-file, not a thin Mathlib wrapper

Meta `status: verified` / `badge: original` / `axiomCount: 0` all consistent with the Lean source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)