### PR TITLE
Enrich algebraic-reals-meager: add annotations.json (7 deep annotations)

### DIFF
--- a/src/data/proofs/algebraic-reals-meager/annotations.json
+++ b/src/data/proofs/algebraic-reals-meager/annotations.json
@@ -1,0 +1,188 @@
+[
+  {
+    "id": "ann-meager-overview",
+    "proofId": "algebraic-reals-meager",
+    "range": {
+      "startLine": 8,
+      "endLine": 59
+    },
+    "type": "concept",
+    "title": "Three Independent Senses of 'Small': Cardinality, Measure, and Baire Category",
+    "content": "This module upgrades the classical fact that the algebraic reals are countable to the strictly stronger topological statement that they are meagre (of the first Baire category) in ℝ. The docstring frames the result against a trio of independent smallness notions that all hold simultaneously for the algebraic reals:\n\n- Cardinality: they are countable (ℵ₀ < 𝔠), Cantor 1874.\n- Measure: they are Lebesgue-null (μ = 0), since a countable set has measure zero.\n- Category: they are meagre — a countable union of nowhere-dense sets — which is the new contribution here.\n\nThese three notions are genuinely distinct: there exist meagre sets of full Lebesgue measure and null sets that are comeagre, so neither smallness notion implies the other in general. For the algebraic reals all three coincide, and dually the transcendentals are co-small in every sense — 'almost every real is transcendental' holds categorically, not merely cardinally. The entry explicitly closes a follow-up flagged in the companion nested-interval entry algebraic-numbers-countable-oq-02-oq-02, which named the abstract Baire-category generalization as the piece that would 'subsume both this entry and the more general statement'.",
+    "mathContext": "A set $A \\subseteq X$ is **nowhere dense** if $\\operatorname{int}(\\overline{A}) = \\varnothing$, and **meagre** (first category) if $A = \\bigcup_{n} A_n$ with each $A_n$ nowhere dense. A **residual** (comeagre) set is the complement of a meagre set. The Baire Category Theorem states that a nonempty complete metric space (or any Baire space) is **not** meagre in itself, so $X \\notin \\mathcal{M}(X)$. For the algebraic reals: $\\overline{\\mathbb{Q}} \\cap \\mathbb{R}$ is simultaneously countable ($\\aleph_0 < 2^{\\aleph_0}$), Lebesgue-null ($\\mu = 0$), and meagre — while $\\mathbb{R} \\setminus \\overline{\\mathbb{Q}}$ is comeagre and dense.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Baire category theorem",
+      "meagre / first category sets",
+      "nowhere-dense sets",
+      "residual / comeagre sets",
+      "Lebesgue-null sets",
+      "Cantor 1874 countability",
+      "transcendental numbers",
+      "algebraic-numbers-countable",
+      "algebraic-numbers-countable-oq-02-oq-02",
+      "descriptive set theory"
+    ],
+    "prerequisites": [
+      "Baire category theorem and the meagre / nowhere-dense / residual API",
+      "countability of the algebraic reals",
+      "basic point-set topology of ℝ"
+    ]
+  },
+  {
+    "id": "ann-meager-nowheredense-meagre",
+    "proofId": "algebraic-reals-meager",
+    "range": {
+      "startLine": 65,
+      "endLine": 73
+    },
+    "type": "technique",
+    "title": "A Nowhere-Dense Set is Meagre (the Trivial One-Element Cover)",
+    "content": "isMeagre_of_isNowhereDense records the base case of the category hierarchy: a single nowhere-dense set t is itself meagre, witnessed by the one-element family {t}. The proof uses isMeagre_iff_countable_union_isNowhereDense, supplying the singleton family {t} (countable via Set.countable_singleton), checking every member of the family is nowhere dense, and verifying ⋃{t} ⊇ t via Set.sUnion_singleton. This is logically trivial — every nowhere-dense set is a one-term union of nowhere-dense sets — but isolating it as a named lemma lets the main argument cover a countable set by a countable union of these atoms without re-deriving the meagreness API each time.",
+    "mathContext": "If $t$ is nowhere dense, then $t = \\bigcup_{u \\in \\{t\\}} u$ is a union over a one-element (hence countable) family of nowhere-dense sets, so $t$ is meagre by definition. Formally $\\operatorname{int}(\\overline{t}) = \\varnothing \\Rightarrow t \\in \\mathcal{M}$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "isMeagre_iff_countable_union_isNowhereDense",
+      "Set.countable_singleton",
+      "Set.sUnion_singleton",
+      "nowhere-dense sets",
+      "first category"
+    ],
+    "prerequisites": [
+      "definition of meagre as a countable union of nowhere-dense sets",
+      "Mathlib's IsMeagre / IsNowhereDense API"
+    ]
+  },
+  {
+    "id": "ann-meager-singleton-nowheredense",
+    "proofId": "algebraic-reals-meager",
+    "range": {
+      "startLine": 75,
+      "endLine": 79
+    },
+    "type": "insight",
+    "title": "The Atom of the Argument: A Singleton is Nowhere Dense in a Perfect T1 Space",
+    "content": "This lemma is where all the topological content lives — the rest of the proof is bookkeeping over countable unions. In a T1 space {x} is closed, so its closure is itself and IsClosed.isNowhereDense_iff reduces nowhere-density to interior {x} = ∅. The PerfectSpace hypothesis supplies exactly that: a perfect space has no isolated points, so x is a cluster point of its neighborhoods and interior_singleton x gives the empty interior. The two typeclass assumptions T1Space and PerfectSpace are individually necessary: in a non-T1 space a singleton need not be closed, and in a space with an isolated point {x} would be open and not nowhere dense. ℝ satisfies both (it is T1 and, being connected, T1, and nontrivial, a PerfectSpace), which is why the abstract lemma applies to it.",
+    "mathContext": "A point $x$ is **isolated** iff $\\{x\\}$ is open iff $\\mathcal{N}[\\ne]\\,x = \\bot$ (the punctured neighborhood filter is trivial). A **perfect space** has no isolated points, so for every $x$, $\\operatorname{int}(\\{x\\}) = \\varnothing$. Combined with $\\overline{\\{x\\}} = \\{x\\}$ (from $T_1$), this gives $\\operatorname{int}(\\overline{\\{x\\}}) = \\varnothing$, i.e. $\\{x\\}$ is nowhere dense.",
+    "significance": "key",
+    "relatedConcepts": [
+      "perfect space (no isolated points)",
+      "T1 space",
+      "interior_singleton",
+      "IsClosed.isNowhereDense_iff",
+      "isolated points and the punctured neighborhood filter 𝓝[≠] x",
+      "isClosed_singleton"
+    ],
+    "prerequisites": [
+      "T1 separation and closed singletons",
+      "perfect spaces and isolated points",
+      "interior and closure operators"
+    ]
+  },
+  {
+    "id": "ann-meager-countable-ismeagre",
+    "proofId": "algebraic-reals-meager",
+    "range": {
+      "startLine": 81,
+      "endLine": 92
+    },
+    "type": "concept",
+    "title": "countable_isMeagre: The Reusable Abstract Baire-Category Lemma",
+    "content": "This is the headline result — the abstract lemma the companion nested-interval entry flagged as an unformalized follow-up. It states that in any T1 perfect topological space, every countable set is meagre, with no completeness or metric hypothesis required for meagreness itself. The proof rewrites s as a union of its singletons via Set.biUnion_of_singleton and Set.biUnion_eq_iUnion, promotes countability to a Countable subtype instance (hs.to_subtype) so the index type is countable, and applies isMeagre_iUnion to the family of meagre singletons supplied by the two preceding lemmas. Stated for an arbitrary X, it is reusable far beyond ℝ: it holds in any nontrivial real or complex normed space, any connected T1 nontrivial space, and any perfect Polish space — in the last case, pairing it with completeness (where the ambient Baire property forbids the whole space from being meagre) recovers the full Baire-category proof that such spaces are uncountable.",
+    "mathContext": "For countable $s$, write $s = \\bigcup_{x \\in s} \\{x\\}$. Each $\\{x\\}$ is nowhere dense (perfect $T_1$), hence meagre, and a **countable** union of meagre sets is meagre, so $s \\in \\mathcal{M}(X)$. Symbolically: $s\\text{ countable} \\;\\wedge\\; T_1 \\;\\wedge\\; \\text{Perfect} \\;\\Longrightarrow\\; \\operatorname{IsMeagre} s$. No completeness is needed for meagreness; completeness enters only to deduce that a meagre set is *proper*.",
+    "significance": "key",
+    "relatedConcepts": [
+      "isMeagre_iUnion",
+      "Set.biUnion_of_singleton",
+      "Set.Countable.to_subtype",
+      "countable union of meagre sets",
+      "perfect Polish spaces",
+      "abstract Baire category theorem",
+      "algebraic-numbers-countable-oq-02-oq-02"
+    ],
+    "prerequisites": [
+      "countable unions of meagre sets (isMeagre_iUnion)",
+      "Countable subtype instances",
+      "the singleton-nowhere-dense lemma above"
+    ]
+  },
+  {
+    "id": "ann-meager-algebraic-reals",
+    "proofId": "algebraic-reals-meager",
+    "range": {
+      "startLine": 94,
+      "endLine": 102
+    },
+    "type": "definition",
+    "title": "algebraicReals_isMeagre: Instantiating at the Algebraic Reals",
+    "content": "The headline application is a one-liner: feed the countability of {x : ℝ | IsAlgebraic ℚ x} into countable_isMeagre. The countability input is Mathlib's Algebraic.countable, repackaged as AlgebraicNumbersCountable.algebraic_reals_countable and reused from the grandparent gallery entry algebraic-numbers-countable — so this proof genuinely strengthens that entry's conclusion (countable) to a topological one (meagre) by composing across the gallery rather than re-deriving countability. The typeclass resolver discharges T1Space ℝ and PerfectSpace ℝ automatically, so no real-specific topological work appears at this step; all of it was front-loaded into isNowhereDense_singleton.",
+    "mathContext": "$\\{x \\in \\mathbb{R} : x \\text{ algebraic over } \\mathbb{Q}\\} = \\overline{\\mathbb{Q}} \\cap \\mathbb{R}$ is countable (Cantor 1874 / `Algebraic.countable`), and $\\mathbb{R}$ is a perfect $T_1$ space, so $\\operatorname{IsMeagre}\\{x \\in \\mathbb{R} : \\operatorname{IsAlgebraic}_{\\mathbb{Q}} x\\}$ follows directly from `countable_isMeagre`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Algebraic.countable",
+      "AlgebraicNumbersCountable.algebraic_reals_countable",
+      "IsAlgebraic ℚ",
+      "PerfectSpace ℝ",
+      "algebraic-numbers-countable",
+      "meagre sets"
+    ],
+    "prerequisites": [
+      "countability of the algebraic reals",
+      "ℝ is a perfect T1 space",
+      "the abstract countable_isMeagre lemma"
+    ]
+  },
+  {
+    "id": "ann-meager-transcendental-dense",
+    "proofId": "algebraic-reals-meager",
+    "range": {
+      "startLine": 104,
+      "endLine": 117
+    },
+    "type": "concept",
+    "title": "Transcendentals are Residual and Dense (the Comeagre Dual)",
+    "content": "Two short corollaries pass from the algebraic side to the transcendental side. transcendentalReals_residual unfolds IsMeagre — which is by definition the statement that the complement lies in residual ℝ — and rewrites the complement of {x | IsAlgebraic ℚ x} as {x | ¬ IsAlgebraic ℚ x}, so 'algebraic reals meagre' is definitionally 'transcendental reals residual'. transcendentalReals_dense then invokes dense_of_mem_residual, the Baire-space fact that every residual set is dense; ℝ is a Baire space (a complete metric space), so the transcendentals form a dense Gδ-ish comeagre set. This is the topological analogue of Cantor's observation that transcendentals are 'everywhere': not only do they exist, they are topologically generic — a property held by all but a meagre exceptional set.",
+    "mathContext": "By definition $\\operatorname{IsMeagre} A \\iff A^c \\in \\operatorname{residual} X$. Here $A = \\{x : \\operatorname{IsAlgebraic}_{\\mathbb{Q}} x\\}$ and $A^c = \\{x : \\neg\\,\\operatorname{IsAlgebraic}_{\\mathbb{Q}} x\\}$, so the transcendentals are residual. In a Baire space every residual set is dense (`dense_of_mem_residual`), and $\\mathbb{R}$ is Baire, hence $\\overline{\\{x : \\neg\\,\\operatorname{IsAlgebraic}_{\\mathbb{Q}} x\\}} = \\mathbb{R}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "residual / comeagre sets",
+      "dense_of_mem_residual",
+      "Baire space",
+      "dense Gδ sets",
+      "topological genericity",
+      "transcendental numbers"
+    ],
+    "prerequisites": [
+      "definition of IsMeagre via residual",
+      "residual sets are dense in a Baire space",
+      "ℝ is a Baire space"
+    ]
+  },
+  {
+    "id": "ann-meager-existence-from-smallness",
+    "proofId": "algebraic-reals-meager",
+    "range": {
+      "startLine": 119,
+      "endLine": 134
+    },
+    "type": "insight",
+    "title": "Existence of Transcendentals from Smallness Alone (No Construction)",
+    "content": "The closing pair of theorems recovers the existence of transcendental numbers purely from meagreness, dual to Liouville's explicit constructions. algebraicReals_ne_univ argues by contradiction: if the algebraic reals were all of ℝ, then univ would be meagre, but not_isMeagre_of_isOpen (a nonempty open set in a Baire space is not meagre) shows univ is not meagre — contradiction. exists_transcendental_real then extracts an actual witness by classical contradiction (by_contra / push_neg / Set.eq_univ_of_forall): if no real were transcendental the algebraic reals would exhaust ℝ. This is the non-constructive, category-theoretic face of transcendence: it asserts a transcendental exists and is in fact generic, while exhibiting none — complementing Liouville's 1844 explicit witnesses and Hermite/Lindemann's proofs that e and π specifically are transcendental.",
+    "mathContext": "A nonempty Baire space is not meagre in itself: $\\operatorname{univ}$ is open and nonempty, so $\\neg\\,\\operatorname{IsMeagre}(\\operatorname{univ})$ (`not_isMeagre_of_isOpen`). If $\\{x : \\operatorname{IsAlgebraic}_{\\mathbb{Q}} x\\} = \\operatorname{univ}$ then $\\operatorname{univ}$ would be meagre — contradiction. Hence $\\{x : \\operatorname{IsAlgebraic}_{\\mathbb{Q}} x\\} \\subsetneq \\mathbb{R}$, i.e. $\\exists x,\\ \\neg\\,\\operatorname{IsAlgebraic}_{\\mathbb{Q}} x$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "not_isMeagre_of_isOpen",
+      "Baire category theorem",
+      "non-constructive existence",
+      "Liouville's theorem (explicit transcendentals)",
+      "Hermite–Lindemann (e and π transcendental)",
+      "Set.eq_univ_of_forall",
+      "liouville-theorem"
+    ],
+    "prerequisites": [
+      "a nonempty Baire space is not meagre in itself",
+      "proof by contradiction / classical logic",
+      "the meagreness of the algebraic reals"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment pass: `algebraic-reals-meager`

This entry was the **sole sub-100 gallery entry** (quality **41**). It shipped via #25994 with a rich `meta.json` (full overview, sections, conclusion, cross-references, references) but **no `annotations.json`** — so the annotation-derived quality components (count, mathContext, significance, relatedConcepts) were all zero.

### What changed
Added `annotations.json` with **7 line-anchored annotations** spanning all three sections of `proofs/Proofs/AlgebraicRealsMeager.lean`:

1. **Overview** (8–59) — the three independent smallness notions (cardinality / measure / Baire category) and the follow-up this entry closes
2. **`isMeagre_of_isNowhereDense`** (65–73) — the trivial one-element cover
3. **`isNowhereDense_singleton`** (75–79) — the topological atom: perfect + T1 ⇒ a singleton has empty interior
4. **`countable_isMeagre`** (81–92) — the reusable abstract Baire-category lemma
5. **`algebraicReals_isMeagre`** (94–102) — instantiation via `Algebraic.countable`
6. **`transcendentalReals_residual` / `_dense`** (104–117) — the comeagre dual
7. **existence of transcendentals from smallness alone** (119–134) — non-constructive, dual to Liouville

Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

### Verification
- `find-targets` quality: **41 → 96**
- `annotations:build`: clean for this entry (no line-matching errors)
- JSON validated (7 annotations, all 4 enrichment fields present)
- Content cross-checked against the Lean source; no axiom/status claims altered (`verified` / `original` / 0-axiom preserved, matching the source's `#print axioms`)

Note: full `tsc -b && vite build` could not run in this worktree (`better-sqlite3` native build fails under node v26 — environment, unrelated to this change). The data-generation pipeline steps validating annotation JSON completed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)