### PR TITLE
Enrich algebraic-reals-meager: split sections 3→5 + complete mainTheorems

### DIFF
--- a/src/data/proofs/algebraic-reals-meager/meta.json
+++ b/src/data/proofs/algebraic-reals-meager/meta.json
@@ -216,6 +216,18 @@
       "type": "core",
       "description": "The transcendental reals are residual (comeagre) and dense in ℝ",
       "leanType": "Dense {x : ℝ | ¬ IsAlgebraic ℚ x}"
+    },
+    {
+      "name": "transcendentalReals_residual",
+      "type": "supporting",
+      "description": "The transcendental reals are residual (comeagre): the complement of the meagre algebraic reals lies in residual ℝ — the step bridging meagreness to density",
+      "leanType": "{x : ℝ | ¬ IsAlgebraic ℚ x} ∈ residual ℝ"
+    },
+    {
+      "name": "exists_transcendental_real",
+      "type": "corollary",
+      "description": "Transcendental reals exist — the headline corollary, recovered purely from meagreness with no explicit Diophantine construction (contrast Liouville's explicit witnesses)",
+      "leanType": "∃ x : ℝ, ¬ IsAlgebraic ℚ x"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Two non-overlapping, meta-only enrichment passes on `algebraic-reals-meager` (verified/original/0-axiom; all 4 cross-references resolve on main).

**1. Sections 3 → 5** (quality 96 → 100)
Split the `sections` array along the Lean file's natural structure: overview, building blocks (nowhere-dense + singletons), abstract Baire lemma, application, existence + axiom audit. Reaches the 10/10 section-coverage cap under `scripts/enricher/find-targets.ts`.

**2. Complete `mainTheorems`** (3 → 5 substantive theorems)
The listing omitted two of the five substantive theorems. Added:
- `transcendentalReals_residual` — the meagre→residual bridge step
- `exists_transcendental_real` — the headline corollary (transcendentals exist with no explicit construction, dual to Liouville)

Both `leanType`s verified verbatim against `Proofs/AlgebraicRealsMeager.lean`. No claims changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)