### PR TITLE
Enrich algebraic-reals-meager: record tracker pass (durable re-serve fix)

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7082,6 +7082,11 @@
       "passes": 1,
       "lastEnriched": "2026-06-16T03:55:40Z",
       "quality": 96
+    },
+    "algebraic-reals-meager": {
+      "passes": 1,
+      "lastEnriched": "2026-06-19T05:02:15Z",
+      "quality": 100
     }
   }
 }


### PR DESCRIPTION
## Summary

`algebraic-reals-meager` was enriched to **quality 100** in PR #25996 (commit 205dc70abe6, already on main) but had **no entry in `enrichment-tracker.json`**. Because `claim-next` keys on the stored tracker quality, the entry kept being re-served to enrichers as a stale low-quality target, wasting claim cycles on an already-complete entry.

This adds its tracker entry (`passes: 1`, `quality: 100`, `lastEnriched`) to stop the re-serve. Same durable-tracker-fix pattern as the auditor PRs #25995/#25973.

## What changed

- **No gallery content change.** The entry is already fully enriched:
  - 7 deep annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`)
  - Complete meta: overview (historicalContext, proofStrategy, 5 keyInsights), 3 sections covering all 136 lines, conclusion (summary + implications + 3 openQuestions), 4 crossReferences
  - Live quality breakdown: annotations 25 / mathContext 10 / significance 10 / historicalContext 10 / keyInsights 10 / conclusion 15 / sections 10 / crossRefs 10 = **100**
- **+5 lines** to `enrichment-tracker.json` only.

## Verification

```
$ npx tsx scripts/enricher/find-targets.ts --json | jq '.[] | select(.id=="algebraic-reals-meager") | .quality'
100
```

JSON validity confirmed via jq round-trip.