### PR TITLE
audit: record clean audit of erdos-1179-oq-02-witness (durable tracker fix)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15967,6 +15967,12 @@
       "lastAudited": "2026-06-19T04:38:15Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1179-oq-02-witness": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-19T05:05:13Z",
+      "result": "clean"
     }
   },
   "version": 1,


### PR DESCRIPTION
## Durable tracker fix (re-serve loop)

\`erdos-1179-oq-02-witness\` is served as the audit target on **every** cycle even though the gallery is otherwise saturated (2543/2544 audited).

### Root cause
- The slug's \`meta.json\` exists only as **researcher-4 WIP debris** — untracked in the main checkout, and the Lean file \`Proofs/Erdos1179OQ02Witness.lean\` is **absent from \`origin/main\`** (so it will never deploy).
- \`find-targets.ts\` scans the working-tree \`meta.json\` (sees the debris) but keys "unaudited" purely on \`audit-tracker.json\` \`entries[id].auditCount\`.
- The slug is **absent from main's tracker**, so \`auditCount === 0\` → re-served. The auditor's \`complete clean\` writes to the local/worktree tracker, which \`git reset --hard origin/main\` wipes → re-serves forever.

This mirrors PR #25995 (algebraic-reals-meager), same class of bug.

### Substance audit — CLEAN
| field | meta.json | Lean source |
|-------|-----------|-------------|
| lines | — | 170 |
| theorems | — | 9 (+ 2 defs) |
| sorries | 0 | 0 |
| axiomCount | 0 | 0 \`axiom\` decls, 0 \`native_decide\` |
| status/badge | verified / original | honest |

No overclaim. \`verified\`/\`original\`/0-axiom/0-sorry accurately reflects the source.

### Fix
Add a clean tracker entry (+6 lines) so \`find-targets\` stops re-serving once merged. The entry is harmless if the debris is later cleaned up (meta gone → not scanned) and accurate if the WIP is later merged to main.

---
Discovered during gallery integrity audit.