### PR TITLE
research(abel-ruffini-oq-07): corrected S₅ criterion — verified Galois-group reduction

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -23,6 +23,7 @@ import Proofs.AbelRuffiniOQ04OQ02OQ03
 import Proofs.AbelRuffiniOQ04OQ03
 import Proofs.AbelRuffiniOQ04OQ07
 import Proofs.AbelRuffiniOQ04OQ09Cyclic
+import Proofs.AbelRuffiniOQ07
 import Proofs.AbelRuffiniOQ09
 import Proofs.AbelRuffiniOQ10
 import Proofs.AbundantMultiplesOQ01

--- a/proofs/Proofs/AbelRuffiniOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniOQ07.lean
@@ -1,0 +1,129 @@
+/-
+  Galois group of f = X⁵ − X − 1 over ℚ  (Open Question OQ-07 of abel-ruffini)
+
+  ## Statement (as curated)
+  Gal(X⁵ − X − 1 / ℚ) ≅ S₅, hence the quintic is not solvable by radicals — a
+  second Abel–Ruffini witness, complementing the Eisenstein examples.
+
+  ## ⚠ Correction to the curated route
+  The curated problem statement proposed proving S₅ via:
+    (i)   f irreducible (Selmer 1956);
+    (ii)  Δ(f) = 2869 = 19·151 is not a perfect square ⟹ Gal ⊄ A₅;
+    (iii) "f has exactly three real roots" ⟹ complex conjugation is a transposition.
+
+  Point (iii) is **mathematically false**. Verified symbolically (sympy/numpy):
+  X⁵ − X − 1 has **exactly ONE real root** (≈ 1.1673); its four non-real roots form
+  TWO complex-conjugate pairs. Hence complex conjugation acts as a **product of two
+  transpositions** — an *even* permutation lying in A₅, **not** a transposition. So
+  Mathlib's clean real-roots assembler `galActionHom_bijective_of_prime_degree`
+  (which needs `card ℂ-roots = card ℝ-roots + 2`, i.e. exactly one conjugate pair)
+  does NOT apply to this polynomial. We formalise this correction below
+  (`prod_two_swaps_mem_alternating`).
+
+  Moreover route (ii) **alone is insufficient**: among the transitive subgroups of S₅
+  (C₅, D₅, F₂₀, A₅, S₅), those containing an odd permutation are exactly {F₂₀, S₅}.
+  Excluding F₂₀ (order 20) requires the supplementary input `3 ∣ |Gal|`.
+
+  ## The corrected proof (Dedekind / Frobenius cycle types)
+  Verified mod-p factorisation types of f:
+    p = 3 : irreducible  ⟹ Frobenius is a 5-cycle  ⟹ transitive, 5 ∣ |Gal|.
+    p = 2 : (deg-2)·(deg-3), Frobenius σ of order 6 ⟹ σ³ is a **transposition** ∈ Gal.
+  Then `subgroup_eq_top_of_swap_mem` (card of the root set = 5 is prime, 5 ∣ |Gal|,
+  and a swap ∈ Gal) gives Gal = ⊤ = S₅.
+
+  ## What THIS file verifies (0 sorry, 0 axiom)
+  The group-theoretic *reduction* of the corrected proof, machine-checked down to its
+  two number-theoretic inputs (which the Dedekind–Frobenius bridge supplies):
+
+    * `gal_eq_top_of_five_dvd_and_swap` — the assembly: any subgroup G ≤ S₅ with
+      5 ∣ |G| and containing a transposition equals ⊤.  This is the corrected
+      criterion stated as a clean, reusable, hypothesis-driven theorem.
+    * `isSwap_not_mem_alternating` — a transposition is odd (the (ii) direction).
+    * `prod_two_swaps_mem_alternating` — a product of two swaps is even: the formal
+      content of the correction (complex conjugation, being a double transposition,
+      lies in A₅ and cannot be the transposition the curated route assumed).
+    * `f_natDegree`, `f_monic`, `natDegree_prime` — anchoring numeric facts about f.
+
+  ## The genuinely-open gap
+  The two hypotheses `5 ∣ |Gal|` and `∃ swap ∈ Gal` are exactly the outputs of the
+  **Dedekind–Frobenius bridge** ("factor type of f mod an unramified prime p ⟹ a
+  Frobenius element of matching cycle type in `f.Gal`"), which Mathlib (pin v4.26.0)
+  does not yet provide. This is the same machinery the flagship gallery entry
+  `InverseGaloisA5.lean` axiomatises as `three_dvd_gal_card`; closing it there closes
+  this problem too. We therefore expose those two facts as *hypotheses* rather than
+  axioms — keeping this file fully verified — and document the bridge as future work.
+
+  ## References
+  - Selmer, E. S. (1956). "On the irreducibility of certain trinomials." Math. Scand. 4.
+  - Dummit & Foote, Abstract Algebra, §14.8 (Galois groups of quintics; Frobenius).
+  - van der Waerden, Algebra I, §61 (Dedekind's theorem on factorisation mod p).
+-/
+
+import Mathlib.GroupTheory.Perm.Cycle.Type
+import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.Tactic
+
+open Equiv Equiv.Perm Polynomial
+
+namespace AbelRuffiniOQ07
+
+/-- The root set of a degree-5 polynomial has 5 elements; we work concretely with
+    `Equiv.Perm (Fin 5)`, the symmetric group `S₅`. -/
+abbrev S5 := Equiv.Perm (Fin 5)
+
+/-- `Fintype.card (Fin 5) = 5` is prime — the hypothesis the assembler needs. -/
+theorem card_fin5_prime : (Fintype.card (Fin 5)).Prime := by
+  rw [Fintype.card_fin]; norm_num
+
+/-- **Corrected assembly criterion.**
+    A subgroup `G ≤ S₅` that (a) has order divisible by 5 and (b) contains a
+    transposition must be all of `S₅`.  This is the group-theoretic core of the
+    corrected proof of `Gal(X⁵−X−1) ≅ S₅`: input (a) comes from irreducibility of
+    `f` mod 3 (a 5-cycle Frobenius), input (b) from the order-6 Frobenius at `p = 2`
+    (its cube is a transposition). -/
+theorem gal_eq_top_of_five_dvd_and_swap
+    {G : Subgroup S5} [DecidablePred (· ∈ G)]
+    (h5 : 5 ∣ Fintype.card G)
+    {τ : S5} (hτG : τ ∈ G) (hτ : τ.IsSwap) :
+    G = ⊤ := by
+  refine Equiv.Perm.subgroup_eq_top_of_swap_mem ?_ ?_ hτG hτ
+  · exact card_fin5_prime
+  · rwa [Fintype.card_fin]
+
+/-- A transposition is an **odd** permutation, hence lies outside `A₅`.
+    This is the discriminant direction (Δ not a square ⟹ Gal ⊄ A₅) at the level of
+    a single odd element. -/
+theorem isSwap_not_mem_alternating {τ : S5} (hτ : τ.IsSwap) :
+    τ ∉ alternatingGroup (Fin 5) := by
+  rw [Equiv.Perm.mem_alternatingGroup, hτ.sign_eq]
+  decide
+
+/-- **The formal correction.**
+    A product of two transpositions is an **even** permutation: it lies in `A₅`.
+    Complex conjugation on the roots of `X⁵−X−1` is exactly such a double
+    transposition (one real root fixed, two conjugate pairs swapped), so — contrary
+    to the curated statement — it is *not* a transposition and cannot by itself
+    force the Galois group to be `S₅`. -/
+theorem prod_two_swaps_mem_alternating {τ₁ τ₂ : S5}
+    (h₁ : τ₁.IsSwap) (h₂ : τ₂.IsSwap) :
+    τ₁ * τ₂ ∈ alternatingGroup (Fin 5) := by
+  rw [Equiv.Perm.mem_alternatingGroup, map_mul, h₁.sign_eq, h₂.sign_eq]
+  decide
+
+/-- The quintic under study. -/
+noncomputable def f : ℚ[X] := X ^ 5 - X - 1
+
+/-- `f` has degree 5. -/
+@[simp] theorem f_natDegree : f.natDegree = 5 := by
+  unfold f; compute_degree!
+
+/-- `f` is monic. -/
+theorem f_monic : f.Monic := by
+  unfold f; monicity!
+
+/-- The degree is prime — the structural fact that makes the prime-degree machinery
+    (`subgroup_eq_top_of_swap_mem`, `prime_degree_dvd_card`) applicable. -/
+theorem natDegree_prime : Nat.Prime f.natDegree := by
+  rw [f_natDegree]; norm_num
+
+end AbelRuffiniOQ07

--- a/src/data/proofs/abel-ruffini-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-07/meta.json
@@ -1,0 +1,89 @@
+{
+  "id": "abel-ruffini-oq-07",
+  "title": "Corrected S₅ Criterion for X⁵ − X − 1 (Galois Group Reduction)",
+  "slug": "abel-ruffini-oq-07",
+  "description": "A machine-verified group-theoretic reduction of the claim Gal(X⁵−X−1/ℚ) ≅ S₅, plus a correction to the curated proof route. The curated statement asserted X⁵−X−1 has three real roots so complex conjugation is a transposition; this is FALSE — the polynomial has exactly one real root, so conjugation is a double transposition (an EVEN permutation in A₅), formalized here as prod_two_swaps_mem_alternating. The correct proof uses Dedekind/Frobenius cycle types: irreducibility mod 3 gives a 5-cycle (5 ∣ |Gal|) and the order-6 Frobenius at p=2 gives a transposition; the assembler subgroup_eq_top_of_swap_mem then yields S₅. This file verifies that assembly (gal_eq_top_of_five_dvd_and_swap) and the supporting sign facts unconditionally (0 sorry, 0 axiom), exposing the two number-theoretic inputs as explicit hypotheses. Those inputs are precisely the output of the Dedekind–Frobenius bridge that Mathlib lacks (the same machinery InverseGaloisA5 axiomatises as three_dvd_gal_card).",
+  "meta": {
+    "author": "Selmer (1956), Dedekind / Frobenius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Galois_group",
+    "date": "1956",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ07.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "galois-theory",
+      "symmetric-group",
+      "alternating-group",
+      "abel-ruffini",
+      "frobenius"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "This file proves the group-theoretic REDUCTION of Gal(X⁵−X−1) ≅ S₅, not the full unconditional statement. The two number-theoretic inputs — 5 ∣ |Gal| (from irreducibility mod 3) and the existence of a transposition in Gal (from the order-6 Frobenius at p=2) — are exposed as explicit hypotheses of gal_eq_top_of_five_dvd_and_swap, NOT as axioms. Supplying them in Lean requires the Dedekind–Frobenius bridge (factor type mod an unramified prime ⟹ a Frobenius element of matching cycle type in f.Gal), which Mathlib v4.26.0 does not provide; it is the same open bridge InverseGaloisA5.lean axiomatises as three_dvd_gal_card. All theorems in this file are fully machine-checked with 0 sorries and 0 axioms.",
+    "dateAdded": "2026-06-18",
+    "mathlibDependencies": [
+      {
+        "theorem": "Equiv.Perm.subgroup_eq_top_of_swap_mem",
+        "description": "A subgroup of Perm α with α of prime cardinality, that cardinality dividing |H|, and containing a swap, is ⊤",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      },
+      {
+        "theorem": "Equiv.Perm.mem_alternatingGroup",
+        "description": "f ∈ alternatingGroup α ↔ sign f = 1",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Alternating"
+      },
+      {
+        "theorem": "Equiv.Perm.IsSwap.sign_eq",
+        "description": "A transposition has sign -1",
+        "module": "Mathlib.GroupTheory.Perm.Sign"
+      }
+    ],
+    "originalContributions": [
+      "Correction (prod_two_swaps_mem_alternating): formalizes that a product of two transpositions is even, i.e. lies in A₅ — refuting the curated route's claim that complex conjugation on the roots of X⁵−X−1 is a transposition (the polynomial has one real root, so conjugation is a double transposition).",
+      "Assembly criterion (gal_eq_top_of_five_dvd_and_swap): the corrected proof's group-theoretic core, stated as a clean reusable theorem — 5 ∣ |G| and a transposition in G ⟹ G = S₅ — verified down to its two number-theoretic hypotheses.",
+      "Discriminant direction (isSwap_not_mem_alternating): a transposition is odd, hence outside A₅.",
+      "Polynomial anchoring (f_natDegree, f_monic, natDegree_prime): X⁵−X−1 is monic of prime degree 5.",
+      "Documentation of the open gap: the two hypotheses are the output of the Dedekind–Frobenius bridge shared with inverse-galois-a5-oq-01; closing it there closes this problem."
+    ],
+    "prerequisites": [
+      "Symmetric and alternating groups; permutation sign",
+      "Transitive subgroups of S₅ (C₅, D₅, F₂₀, A₅, S₅)",
+      "Dedekind's theorem (factorisation mod p ⟹ Frobenius cycle type)",
+      "Galois groups of polynomials",
+      "Lean 4 and Mathlib"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 129,
+    "relatedProblems": [
+      {
+        "id": "abel-ruffini-oq-04-oq-01",
+        "relationship": "Sibling concrete S₅ witness: proves Gal(x⁵−4x+2)=S₅ via the real-roots route (that quintic genuinely has 3 real roots), which X⁵−X−1 cannot use."
+      },
+      {
+        "id": "inverse-galois-a5-oq-01",
+        "relationship": "Needs the SAME Dedekind–Frobenius bridge (cycle type of Frobenius from factor type mod p); closing it there supplies this file's two hypotheses."
+      }
+    ],
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-oq-04-oq-01",
+      "relationship": "complementary",
+      "description": "That entry proves Gal(x⁵−4x+2)=S₅ via complex conjugation as a transposition (3 real roots). X⁵−X−1 has only ONE real root, so that route fails here — this file documents and formalizes why, and gives the corrected Frobenius-based reduction."
+    },
+    {
+      "targetId": "inverse-galois-a5-oq-01",
+      "relationship": "related",
+      "description": "Both depend on the Dedekind–Frobenius bridge (factor type mod unramified p ⟹ matching cycle type in the Galois group), axiomatised as three_dvd_gal_card in InverseGaloisA5.lean."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "extends",
+      "description": "A second concrete Abel–Ruffini witness quintic: X⁵−X−1, unsolvable by radicals because (modulo the Frobenius inputs) its Galois group is S₅."
+    }
+  ]
+}

--- a/src/data/research/problems/abel-ruffini-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-oq-07.json
@@ -1,7 +1,7 @@
 {
   "slug": "abel-ruffini-oq-07",
   "title": "Selmer-Style S₅ Galois Group for x⁵ − x − 1",
-  "phase": "ORIENT",
+  "phase": "FORMALIZE",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,17 +16,14 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-06-16T03:36:37-07:00",
-    "iteration": 1,
-    "focus": "ORIENT: corrected statement + verified Dedekind-Frobenius proof skeleton; blocked on Dedekind bridge (same as InverseGaloisA5 axiom).",
-    "blockers": [],
-    "nextAction": "Wait on inverse-galois-a5-oq-01 Frobenius lemma; or ship axiomatized entry.",
-    "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
-    }
+    "phase": "FORMALIZE",
+    "since": "2026-06-18T21:30:00-07:00",
+    "iteration": 2,
+    "focus": "Verified the corrected group-theoretic reduction in Lean (Proofs/AbelRuffiniOQ07.lean): assembly criterion gal_eq_top_of_five_dvd_and_swap (5∣|G| + swap ∈ G ⟹ S₅), formalized the correction prod_two_swaps_mem_alternating (double transposition is EVEN, refuting the curated 3-real-roots route), plus discriminant direction and polynomial degree facts. 0 sorry / 0 axiom; the two Frobenius inputs are explicit hypotheses.",
+    "blockers": [
+      "Dedekind–Frobenius bridge (factor type mod unramified p ⟹ matching cycle type in f.Gal) not in Mathlib v4.26.0; same bridge axiomatised as three_dvd_gal_card in InverseGaloisA5.lean. Supplies the two hypotheses (5∣|Gal|, swap∈Gal)."
+    ],
+    "nextAction": "When inverse-galois-a5-oq-01 lands a reusable cycle-type-from-factor-type lemma, discharge the two hypotheses to obtain Gal(X⁵−X−1)=S₅ unconditionally."
   },
   "knowledge": {
     "progressSummary": "ORIENT: corrected the statement (x⁵−x−1 has 1 real root, NOT 3 → real-roots/conjugation route inapplicable; conjugation is even, in A₅). Disc=2869=19·151 not square but disc-alone only narrows G to {F₂₀,S₅}. Correct proof = Dedekind/Frobenius: 5-cycle@p=3 + transposition(σ³)@p=2 + subgroup_eq_top_of_swap_mem ⟹ S₅. Buildability blocker = Dedekind-Frobenius bridge, the SAME axiom (three_dvd_gal_card) the gallery A5 entry still carries.",
@@ -334,6 +331,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ10.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ07.lean",
+      "filename": "AbelRuffiniOQ07.lean",
+      "lineCount": 129,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ07.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

A machine-verified group-theoretic **reduction** of `Gal(X⁵−X−1/ℚ) ≅ S₅`, plus a formal **correction** to the curated proof route. New file `proofs/Proofs/AbelRuffiniOQ07.lean` (7 theorems, 1 def, **0 sorry, 0 axiom**).

## The correction
The curated statement claimed *"X⁵−X−1 has three real roots, so complex conjugation is a transposition."* This is **false**: X⁵−X−1 has **exactly one** real root (≈1.1673), so its four non-real roots form two conjugate pairs and complex conjugation is a **double transposition — an even permutation in A₅**, not a transposition. Mathlib's clean real-roots assembler `galActionHom_bijective_of_prime_degree` therefore does not apply. Formalized as `prod_two_swaps_mem_alternating`.

## The corrected proof (Dedekind / Frobenius)
- p = 3: f irreducible ⟹ Frobenius is a 5-cycle ⟹ 5 ∣ |Gal|.
- p = 2: f = (deg 2)·(deg 3) ⟹ order-6 Frobenius; its cube is a transposition ∈ Gal.
- `subgroup_eq_top_of_swap_mem` (degree 5 prime, 5 ∣ |Gal|, swap ∈ Gal) ⟹ Gal = S₅.

The assembly criterion `gal_eq_top_of_five_dvd_and_swap` is verified **down to its two number-theoretic hypotheses**, exposed as explicit theorem hypotheses (NOT axioms). Those two inputs are exactly the output of the Dedekind–Frobenius bridge that Mathlib v4.26.0 lacks — the same bridge `InverseGaloisA5.lean` axiomatises as `three_dvd_gal_card`. Closing it there closes this too.

## Verification
- Docker build green: `[3062/3062] Built Proofs.AbelRuffiniOQ07`.
- `#print axioms` on all main theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.
- Registered in `Proofs.lean`; gallery entry + research JSON included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)