### PR TITLE
audit: record clean audits of abel-ruffini-oq-07 + buffons-noodle-oq-01 (durable tracker fix)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15973,8 +15973,20 @@
       "issues": [],
       "lastAudited": "2026-06-19T05:05:13Z",
       "result": "clean"
+    },
+    "abel-ruffini-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T06:09:03Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-noodle-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T06:10:21Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-18T23:13:10Z"
+  "lastUpdated": "2026-06-19T06:10:21Z"
 }


### PR DESCRIPTION
## Durable tracker fix

Both proofs merged today and are **absent from the main `audit-tracker.json`**, so `find-targets.ts` re-serves them every cycle (the auditor worktree's tracker write is wiped by `git reset --hard origin/main`). This adds the two clean audit entries off `origin/main` to break the re-serve loop — same fix class as #25973 / #25995 / #26000.

## Audit findings — both CLEAN

**abel-ruffini-oq-07** (7 thm / 1 def)
- 0 sorry, 0 axiom, 0 native_decide (plain kernel `decide` ×2 — no `Lean.ofReduceBool`)
- Honest reduction framing: the two number-theoretic inputs (`5 ∣ |Gal|`, transposition ∈ Gal) are exposed as **hypotheses, not axioms**; title carries the "(Galois Group Reduction)" qualifier. `verified`/`verified` justified.

**buffons-noodle-oq-01** (11 thm / 1 def)
- 0 sorry, 0 axiom, 0 native_decide
- Depends only on the parent's axiom-free `buffon_noodle_polygon` (BuffonsNoodle.lean:157). The parent's lone smooth axiom (`buffon_noodle_smooth_eq`, L265) is used only by smooth-case theorems and is **not transitively reachable** from this file. `verified`/`original` justified.

Gallery now 2545/2545 audited, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)