### PR TITLE
research(cube-root-3-irrational-oq-04): register + build-fix a₁₂=8, a₁₃=3

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -600,6 +600,7 @@ import Proofs.CubeRoot3IrrationalOQ04Helpers
 import Proofs.CubeRoot3IrrationalOQ04NotQuadratic
 import Proofs.CubeRoot3IrrationalOQ04Stream
 import Proofs.CubeRoot3IrrationalOQ04StreamCanonical
+import Proofs.CubeRoot3IrrationalOQ04A12
 import Proofs.CubeRoot5Irrational
 import Proofs.CubeRoot6Irrational
 import Proofs.CubeRoot7Irrational

--- a/proofs/Proofs/CubeRoot3IrrationalOQ04A12.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04A12.lean
@@ -53,6 +53,11 @@ namespace CubeRoot3IrrationalOQ04
 
 open CubeRoot3Irrational
 
+-- The two deepest-quotient proofs propagate the largest convergent sandwiches
+-- (numerators/denominators ≈ 10⁶) through eleven/twelve nested CF reciprocals;
+-- the resulting `linarith` goals exceed the default 200000-heartbeat budget.
+set_option maxHeartbeats 1600000
+
 /-- **Thirteenth partial quotient `a₁₂ = 8`.**  The next term of the simple
 continued fraction of `∛3` (OEIS A002945, 0-indexed prefix
 `[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, …]`).  Extends `cbrt3_a11` by one
@@ -191,18 +196,23 @@ theorem cbrt3_a12 :
   have hx12_gt : (3/25 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5 := by linarith
   have hx12_lt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5 < (1/8 : ℝ) := by linarith
   have hpos12 : (0 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5 := by linarith
+  -- Abbreviate the 12-deep tail `x₁₂` so the floor reasoning below operates on a
+  -- single opaque variable rather than re-normalising the giant nested-reciprocal
+  -- term (which otherwise blows the heartbeat budget). All three bounds above are
+  -- already stated in terms of this expression, so `set` folds them automatically.
+  set x12 := 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5 with hx12def
   -- Floor antisymmetry on `1/x₁₂ ∈ (8, 25/3) ⊂ (8, 9)`.
   apply le_antisymm
   · -- `⌊1/x₁₂⌋ ≤ 8`: from `1/x₁₂ < 9`.
-    have hlt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5) < (9 : ℝ) := by
+    have hlt : 1 / x12 < (9 : ℝ) := by
       rw [div_lt_iff₀ hpos12]
       linarith [hx12_gt]
-    have hflt : ⌊1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5)⌋ < (9 : ℤ) := by
+    have hflt : ⌊1 / x12⌋ < (9 : ℤ) := by
       rw [Int.floor_lt]
       exact_mod_cast hlt
     omega
   · -- `8 ≤ ⌊1/x₁₂⌋`: from `8 ≤ 1/x₁₂`.
-    have hge : (8 : ℝ) ≤ 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5) := by
+    have hge : (8 : ℝ) ≤ 1 / x12 := by
       rw [le_div_iff₀ hpos12]
       linarith [hx12_lt]
     rw [Int.le_floor]
@@ -355,16 +365,21 @@ theorem cbrt3_a13 :
   have hx13_gt : (3/10 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5) - 8 := by linarith
   have hx13_lt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5) - 8 < (1/3 : ℝ) := by linarith
   have hpos13 : (0 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5) - 8 := by linarith
+  -- Abbreviate the 13-deep tail `x₁₃` so the floor reasoning below operates on a
+  -- single opaque variable rather than re-normalising the giant nested-reciprocal
+  -- term (which otherwise blows the heartbeat budget). All three bounds above are
+  -- already stated in terms of this expression, so `set` folds them automatically.
+  set x13 := 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5) - 8 with hx13def
   -- Floor antisymmetry on `1/x₁₃ ∈ (3, 10/3) ⊂ (3, 4)`.
   apply le_antisymm
-  · have hlt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5) - 8) < (4 : ℝ) := by
+  · have hlt : 1 / x13 < (4 : ℝ) := by
       rw [div_lt_iff₀ hpos13]
       linarith [hx13_gt]
-    have hflt : ⌊1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5) - 8)⌋ < (4 : ℤ) := by
+    have hflt : ⌊1 / x13⌋ < (4 : ℤ) := by
       rw [Int.floor_lt]
       exact_mod_cast hlt
     omega
-  · have hge : (3 : ℝ) ≤ 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5) - 8) := by
+  · have hge : (3 : ℝ) ≤ 1 / x13 := by
       rw [le_div_iff₀ hpos13]
       linarith [hx13_lt]
     rw [Int.le_floor]

--- a/src/data/proofs/cube-root-3-irrational-oq-04/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-04/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "cube-root-3-irrational-oq-04",
-  "title": "Continued Fraction Prefix of ∛3: First Twelve Partial Quotients",
+  "title": "Continued Fraction Prefix of ∛3: First Fourteen Partial Quotients",
   "slug": "cube-root-3-irrational-oq-04",
-  "description": "Computes and machine-verifies the first twelve partial quotients of the simple continued fraction of ∛3, confirming the prefix [1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5] of OEIS A002945. Each partial quotient aₙ = ⌊xₙ⌋ is pinned by a two-sided rational sandwich obtained from successive convergents; the irrational xₙ is compared to its rational bounds by cubing both sides and substituting (∛3)³ = 3, reducing every step to linear arithmetic. Because ∛3 has degree 3 over ℚ, Lagrange's theorem forbids the continued fraction from being eventually periodic, so no closed form exists and a finite formalization can only certify a fixed-length prefix one quotient at a time.",
+  "description": "Computes and machine-verifies the first fourteen partial quotients of the simple continued fraction of ∛3, confirming the prefix [1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3] of OEIS A002945. Each partial quotient aₙ = ⌊xₙ⌋ is pinned by a two-sided rational sandwich obtained from successive convergents; the irrational xₙ is compared to its rational bounds by cubing both sides and substituting (∛3)³ = 3, reducing every step to linear arithmetic. Because ∛3 has degree 3 over ℚ, Lagrange's theorem forbids the continued fraction from being eventually periodic, so no closed form exists and a finite formalization can only certify a fixed-length prefix one quotient at a time.",
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "date": "2026-05-13",
@@ -31,13 +31,15 @@
       "Verification that the prefix matches OEIS A002945 through a₁₁, with the cubing gap shrinking to ≈10⁻⁵ at the sixth and seventh convergents",
       "CubeRoot3IrrationalOQ04Stream.lean: a bridge connecting the ad-hoc nested-floor lemmas cbrt3_a0…cbrt3_a11 to Mathlib's canonical continued-fraction machinery, proving (IntFractPair.stream cbrt3 n).map IntFractPair.b = some aₙ for every n = 0…11 via a reusable one-reciprocation step lemma cbrt3_stream_succ. This is concrete progress on open question #1 (relate the certified prefix to the canonical CF API).",
       "CubeRoot3IrrationalOQ04NotQuadratic.lean: a machine-verified proof that ∛3 is NOT a quadratic irrational — the structural reason Lagrange's theorem forbids its continued fraction from being eventually periodic. The core lemma cubic_lin_indep_of_irrational shows that for any irrational t with t³ = 3, the family {1, t, t²} is linearly independent over ℚ (a·t² + b·t + c = 0 forces a = b = c = 0), via a finite elimination (multiply by t, reduce t³ = 3, eliminate t²) using only linear_combination, plus a positive quadratic-factor identity to rule out a rational cube root — NO minpoly / NumberField / irreducibility machinery. Instantiated at cbrt3 as cbrt3_not_quadratic, with the contrapositive packaging cbrt3_no_nontrivial_quadratic_relation. This formalizes the Lagrange obstruction that the main file's prefix grind works around. 0 axioms, 0 sorries.",
-      "CubeRoot3IrrationalOQ04StreamCanonical.lean: completes open question #1 in its strongest form by lifting the certified prefix from the lower-level IntFractPair.stream to Mathlib's top-level canonical object GenContFract.of cbrt3. Using the translation lemmas of_h_eq_floor and get?_of_eq_some_of_succ_get?_intFractPair_stream, it proves (of cbrt3).h = 1 (a₀) and (of cbrt3).s.get? k = some ⟨1, a_{k+1}⟩ for k = 0…10, so the prefix [1; 2,3,1,4,1,5,1,1,6,2,5] reads directly off the canonical continued-fraction structure (all partial numerators 1). Each of the 13 theorems is a mechanical clone of the build-verified cbrt3_stream_b_* lemmas. 0 axioms, 0 sorries."
+      "CubeRoot3IrrationalOQ04StreamCanonical.lean: completes open question #1 in its strongest form by lifting the certified prefix from the lower-level IntFractPair.stream to Mathlib's top-level canonical object GenContFract.of cbrt3. Using the translation lemmas of_h_eq_floor and get?_of_eq_some_of_succ_get?_intFractPair_stream, it proves (of cbrt3).h = 1 (a₀) and (of cbrt3).s.get? k = some ⟨1, a_{k+1}⟩ for k = 0…10, so the prefix [1; 2,3,1,4,1,5,1,1,6,2,5] reads directly off the canonical continued-fraction structure (all partial numerators 1). Each of the 13 theorems is a mechanical clone of the build-verified cbrt3_stream_b_* lemmas. 0 axioms, 0 sorries.",
+      "CubeRoot3IrrationalOQ04A12.lean: extends the certified prefix by two further partial quotients, cbrt3_a12 = 8 and cbrt3_a13 = 3, giving the full prefix [1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3] of OEIS A002945 through a₁₃. Each new quotient starts from the tighter pair of consecutive CF convergents bracketing ∛3 (597449/414248 < ∛3 < 1865358/1293367 for a₁₂; 6193523/4294349 < ∛3 < 1865358/1293367 for a₁₃, all proved axiom-free in the helpers file) and propagates the rational interval through the CF maps x ↦ 1/(x − aᵢ): x₁₂ ∈ (3/25, 1/8) ⟹ 1/x₁₂ ∈ (8, 25/3) ⊂ (8, 9) ⟹ ⌊1/x₁₂⌋ = 8, and x₁₃ ∈ (3/10, 1/3) ⟹ 1/x₁₃ ∈ (3, 10/3) ⊂ (3, 4) ⟹ ⌊1/x₁₃⌋ = 3. Every step discharges by linarith using the same cubing-sandwich template as cbrt3_a11 — no new tactic or API surface. 0 axioms, 0 sorries."
     ],
     "additionalFiles": [
       "Proofs/CubeRoot3IrrationalOQ04Helpers.lean",
       "Proofs/CubeRoot3IrrationalOQ04Stream.lean",
       "Proofs/CubeRoot3IrrationalOQ04NotQuadratic.lean",
-      "Proofs/CubeRoot3IrrationalOQ04StreamCanonical.lean"
+      "Proofs/CubeRoot3IrrationalOQ04StreamCanonical.lean",
+      "Proofs/CubeRoot3IrrationalOQ04A12.lean"
     ]
   },
   "overview": {
@@ -147,7 +149,8 @@
       "Proofs/CubeRoot3IrrationalOQ04Helpers.lean",
       "Proofs/CubeRoot3IrrationalOQ04Stream.lean",
       "Proofs/CubeRoot3IrrationalOQ04NotQuadratic.lean",
-      "Proofs/CubeRoot3IrrationalOQ04StreamCanonical.lean"
+      "Proofs/CubeRoot3IrrationalOQ04StreamCanonical.lean",
+      "Proofs/CubeRoot3IrrationalOQ04A12.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Summary

Registers and build-fixes `CubeRoot3IrrationalOQ04A12.lean`, which landed on `main` via #25823 as a **build-pending orphan** — it was committed but never imported in `Proofs.lean` and never compiled (written under a Docker blackout). This PR makes it part of the verified gallery.

The file extends the certified continued-fraction prefix of ∛3 by two partial quotients:

- `cbrt3_a12 = 8`  (sandwich `597449/414248 < ∛3 < 1865358/1293367`)
- `cbrt3_a13 = 3`  (sandwich `6193523/4294349 < ∛3 < 1865358/1293367`)

giving the full prefix **[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3]** of OEIS A002945 through a₁₃.

## Changes

1. **Register** — `import Proofs.CubeRoot3IrrationalOQ04A12` in `Proofs.lean`; add the file to `additionalFiles` and an `originalContributions` bullet in the gallery meta; bump the entry title/description from *twelve* to *fourteen* partial quotients.
2. **Build-fix** — the orphan set no `maxHeartbeats` (default 200000) and both final floor blocks re-normalised the full 13-deep nested-reciprocal term inside `div_lt_iff₀` / `le_div_iff₀` / `exact_mod_cast`, hitting `(deterministic) timeout at whnf`. Fixed with `set_option maxHeartbeats 1600000` plus a `set`-abbreviation of the giant tail (`x12`/`x13`) so the floor reasoning runs on an opaque variable. Compile time dropped from a failing 756s to a clean **143s**.

## Verification

`✔ [7746/7746] Built Proofs.CubeRoot3IrrationalOQ04A12 (143s)` via `docker-build.sh`.

0 sorry · 0 `axiom` · 0 `native_decide` — proofs use only `linarith`/`omega`/`rw`/`exact_mod_cast` (kernel-checked). Entry remains `status: verified`, `badge: original`, `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)