### PR TITLE
Enrich abel-ruffini-oq-07: annotations + overview/sections/conclusion

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-07/meta.json
@@ -182,5 +182,181 @@
       "relationship": "extends",
       "description": "A second concrete Abel–Ruffini witness quintic: X⁵−X−1, unsolvable by radicals because (modulo the Frobenius inputs) its Galois group is S₅."
     }
-  ]
+  ],
+  "overview": {
+    "historicalContext": "Paolo Ruffini (1799) and Niels Henrik Abel (1824) showed there is no general radical formula for the quintic; Évariste Galois (1831) recast solvability as a property of the equation's permutation group, making 'Gal not solvable' the modern criterion for unsolvability by radicals. A concrete unsolvable quintic therefore needs a polynomial whose Galois group is non-solvable — and the smallest non-solvable transitive subgroups of S_5 are A_5 and S_5. Ernst Selmer (1956, Math. Scand. 4) proved the trinomials X^n - X - 1 irreducible over Q for all n, making X^5 - X - 1 a natural candidate witness. The standard tool for pinning down such a Galois group is Dedekind's theorem (1880s): for a prime p not dividing the discriminant, the factorization type of f mod p equals the cycle type of a Frobenius element of Gal(f). Combined with Frobenius's density results, this turns Galois-group identification into a finite set of modular factorizations — the method underlying every computer-algebra Galois routine (GAP, PARI/GP, Magma).",
+    "problemStatement": "Prove that the Galois group of f = X^5 - X - 1 over Q is the full symmetric group S_5, so f is a (second) explicit Abel-Ruffini witness quintic that is not solvable by radicals.",
+    "text": "This entry formalizes the group-theoretic reduction at the core of the corrected proof, and corrects a false step in the originally curated route. It verifies, with 0 sorries and 0 axioms, that (a) a subgroup G of S_5 with 5 | |G| containing a transposition equals S_5, (b) a transposition is odd, (c) a product of two transpositions is even, and (d) f = X^5 - X - 1 is a monic quintic of prime degree. The two number-theoretic inputs the assembly needs — 5 | |Gal| (from irreducibility mod 3) and a transposition in Gal (from the order-6 Frobenius mod 2) — are exposed as explicit hypotheses rather than axioms, isolating the one piece Mathlib still lacks: the Dedekind-Frobenius bridge.",
+    "proofStrategy": "Work concretely in S_5 = Equiv.Perm (Fin 5). (1) Record that the degree 5 is prime (card_fin5_prime). (2) Reduce the target to Mathlib's prime-degree assembler subgroup_eq_top_of_swap_mem, packaging it as gal_eq_top_of_five_dvd_and_swap: 5 | |G| plus a swap in G implies G = top. (3) Supply the sign facts that link the two routes to S_5: a transposition is odd (isSwap_not_mem_alternating, the discriminant direction) while complex conjugation, a double transposition, is even (prod_two_swaps_mem_alternating, the correction). (4) Anchor the polynomial's structural facts (degree 5, monic, prime degree). The number-theoretic hypotheses 5 | |Gal| and 'swap in Gal' are left explicit, to be discharged once the Dedekind-Frobenius bridge is available.",
+    "keyInsights": [
+      "The curated route's claim that complex conjugation is a transposition is false: X^5 - X - 1 has exactly one real root, so conjugation swaps two conjugate pairs and is a double transposition — an even permutation in A_5 (formalized as prod_two_swaps_mem_alternating).",
+      "A non-square discriminant alone is not enough. Among transitive subgroups of S_5 (C_5, D_5, F_20, A_5, S_5), those with an odd permutation are exactly {F_20, S_5}; ruling out F_20 (order 20) requires the independent input 5 | |Gal|.",
+      "For prime degree p, a transitive subgroup of S_p containing a single transposition is already all of S_p — so the entire identification reduces to two modular facts: a p-cycle (transitivity) and one transposition.",
+      "The odd permutation that forces Gal not-subset A_5 must come from the order-6 Frobenius at p = 2 (its cube is a transposition), NOT from complex conjugation, precisely because conjugation here is even.",
+      "Honest formalization separates the verified core from the open input: exposing 5 | |Gal| and 'swap in Gal' as hypotheses (not axioms) keeps the file axiom-free while marking exactly the Dedekind-Frobenius bridge as the missing Mathlib machinery."
+    ],
+    "prerequisites": [
+      "Symmetric and alternating groups; the sign homomorphism",
+      "Transitive subgroups of S_5 and generation of S_p",
+      "Dedekind's theorem (factorization mod p gives Frobenius cycle type)",
+      "Galois groups of polynomials and the discriminant criterion",
+      "Lean 4 and Mathlib permutation API"
+    ],
+    "relatedConcepts": [
+      "Abel-Ruffini theorem",
+      "Galois group of a quintic",
+      "Frobenius cycle type",
+      "discriminant criterion (Gal subset A_n iff disc is a square)",
+      "inverse Galois problem for S_5"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Statement, Curated-Route Correction, and the Frobenius Proof",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Documents the goal Gal(X^5 - X - 1) = S_5 and corrects the curated route: X^5 - X - 1 has ONE real root (not three), so complex conjugation is a double transposition (even, in A_5), and the real-roots assembler does not apply. Explains that a non-square discriminant alone only narrows Gal to {F_20, S_5}, and that the corrected proof uses Dedekind/Frobenius cycle types (5-cycle mod 3, transposition from the order-6 Frobenius mod 2).",
+      "mathContext": "Discriminant 2869 = 19 * 151 (not a square); real-root count 1; transitive subgroups of S_5 with an odd element are {F_20, S_5}.",
+      "relatedConcepts": [
+        "Abel-Ruffini theorem",
+        "discriminant criterion",
+        "Dedekind's theorem",
+        "Frobenius cycle type"
+      ]
+    },
+    {
+      "id": "setup",
+      "title": "Setup: S₅ as Equiv.Perm (Fin 5) and the Prime Degree",
+      "startLine": 62,
+      "endLine": 77,
+      "summary": "Imports cycle-type and alternating-group machinery, opens Equiv/Perm/Polynomial, abbreviates S5 := Equiv.Perm (Fin 5), and proves card_fin5_prime: the degree 5 is prime — the structural hypothesis that the prime-degree assembler requires.",
+      "mathContext": "S_5 = Sym({0,...,4}), |S_5| = 120; 5 is prime so 5 | |G| yields a transitive 5-cycle by Cauchy.",
+      "relatedConcepts": [
+        "symmetric group",
+        "prime degree",
+        "Cauchy's theorem",
+        "Fintype.card"
+      ]
+    },
+    {
+      "id": "assembly",
+      "title": "The Corrected Assembly Criterion",
+      "startLine": 79,
+      "endLine": 94,
+      "summary": "gal_eq_top_of_five_dvd_and_swap: a subgroup G of S_5 with 5 | |G| containing a transposition equals top. Reduces to Mathlib's subgroup_eq_top_of_swap_mem, with the two number-theoretic inputs (5 | |G|, swap in G) left as explicit hypotheses rather than axioms.",
+      "mathContext": "For p prime, a transitive G <= S_p containing a transposition equals S_p; here a 5-cycle plus one transposition generate S_5.",
+      "relatedConcepts": [
+        "subgroup_eq_top_of_swap_mem",
+        "generation of S_p",
+        "Galois group reduction"
+      ]
+    },
+    {
+      "id": "sign-facts",
+      "title": "Sign Facts: Odd Transposition vs. Even Double Transposition",
+      "startLine": 96,
+      "endLine": 112,
+      "summary": "isSwap_not_mem_alternating shows a transposition is odd (the discriminant direction, Gal not-subset A_5). prod_two_swaps_mem_alternating shows a product of two transpositions is even — the formal correction: complex conjugation on the roots of X^5 - X - 1 is a double transposition in A_5, so it cannot be the transposition the curated route assumed.",
+      "mathContext": "sign(transposition) = -1; sign(double transposition) = (-1)(-1) = 1. Conjugation fixes the one real root and swaps the two conjugate pairs.",
+      "relatedConcepts": [
+        "permutation sign",
+        "alternating group",
+        "complex conjugation on roots",
+        "double transposition"
+      ]
+    },
+    {
+      "id": "polynomial",
+      "title": "Anchoring the Quintic f = X⁵ − X − 1",
+      "startLine": 114,
+      "endLine": 129,
+      "summary": "Defines f = X^5 - X - 1 over Q and proves degree 5 (compute_degree!), monicity (monicity!), and prime degree (norm_num) — the structural facts that make the prime-degree machinery applicable to f.Gal.",
+      "mathContext": "f monic of prime degree 5; Selmer (1956) proved X^5 - X - 1 irreducible, giving transitivity and 5 | |Gal|.",
+      "relatedConcepts": [
+        "monic polynomial",
+        "Selmer irreducibility",
+        "prime degree",
+        "compute_degree!"
+      ]
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "gal_eq_top_of_five_dvd_and_swap",
+      "type": "core",
+      "description": "The corrected assembly criterion: a subgroup G <= S_5 with 5 | |G| that contains a transposition equals all of S_5. The group-theoretic core of the X^5 - X - 1 reduction, stated as a clean reusable theorem whose two number-theoretic inputs are explicit hypotheses, not axioms."
+    },
+    {
+      "name": "prod_two_swaps_mem_alternating",
+      "type": "proved",
+      "description": "A product of two transpositions is even (lies in A_5). Formalizes the correction to the curated route: complex conjugation on the roots of X^5 - X - 1 is a double transposition, hence in A_5, so it cannot be the transposition the curated argument required."
+    },
+    {
+      "name": "isSwap_not_mem_alternating",
+      "type": "proved",
+      "description": "A transposition is odd, hence outside A_5 — the single-element form of the discriminant direction (Delta not a square implies Gal not-subset A_5)."
+    },
+    {
+      "name": "card_fin5_prime",
+      "type": "proved",
+      "description": "The degree Fintype.card (Fin 5) = 5 is prime — the structural hypothesis required by the prime-degree assembler subgroup_eq_top_of_swap_mem."
+    },
+    {
+      "name": "f_natDegree / f_monic / natDegree_prime",
+      "type": "proved",
+      "description": "f = X^5 - X - 1 is monic of degree 5, and 5 is prime — anchoring numeric facts that make the prime-degree machinery applicable to f.Gal."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Perm.Cycle.Type",
+      "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Equiv",
+      "Equiv.Perm",
+      "Polynomial"
+    ],
+    "namespace": "AbelRuffiniOQ07",
+    "lineCount": 129,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/AbelRuffiniOQ07.lean"
+  },
+  "references": [
+    {
+      "key": "Selmer56",
+      "citation": "Selmer, E. S. (1956). 'On the irreducibility of certain trinomials.' Mathematica Scandinavica 4, 287-302. Proves X^n - X - 1 is irreducible over Q for all n, making X^5 - X - 1 a valid witness quintic.",
+      "type": "article"
+    },
+    {
+      "key": "DummitFoote",
+      "citation": "Dummit, D. S. and Foote, R. M., Abstract Algebra (3rd ed.), Wiley (2004). Section 14.8 treats Galois groups of quintics and the use of Frobenius/Dedekind cycle types to determine them.",
+      "type": "book"
+    },
+    {
+      "key": "vanderWaerden",
+      "citation": "van der Waerden, B. L., Algebra I (Springer). Section 61 proves Dedekind's theorem: the factorization type of f mod an unramified prime p equals the cycle type of a Frobenius element of Gal(f).",
+      "type": "book"
+    },
+    {
+      "key": "Galois1831",
+      "citation": "Galois, E. (1831/1846). 'Memoire sur les conditions de resolubilite des equations par radicaux.' Establishes that an equation is solvable by radicals iff its Galois group is solvable.",
+      "type": "article"
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry machine-verifies the group-theoretic reduction behind Gal(X^5 - X - 1 / Q) = S_5, and corrects the route originally curated for the problem. With 0 sorries and 0 axioms it proves: the assembly criterion (5 | |G| plus a transposition forces G = S_5), the discriminant direction (a transposition is odd), the correction (a product of two transpositions is even, so complex conjugation lies in A_5), and the anchoring facts that f = X^5 - X - 1 is monic of prime degree 5. The two number-theoretic inputs the assembly consumes — 5 | |Gal| from irreducibility mod 3 and a transposition in Gal from the order-6 Frobenius mod 2 — are exposed as explicit hypotheses, not axioms, so the file stays axiom-free while precisely marking the one open dependency.",
+    "implications": "1. Corrected mathematical record: the curated route claimed X^5 - X - 1 has three real roots so complex conjugation is a transposition. The polynomial has exactly one real root; conjugation is a double transposition (even, in A_5). This entry both refutes the false step and supplies the correct Frobenius-based argument, a useful caution that the real-roots route works only when the conjugate-pair count is exactly one.\n\n2. Reusable assembly lemma: gal_eq_top_of_five_dvd_and_swap packages the prime-degree S_5 criterion as a clean, hypothesis-driven theorem. Any future formalization that can produce '5 | |Gal|' and 'a transposition in Gal' for a quintic gets S_5 immediately, decoupling the group theory from the number theory.\n\n3. Honest axiom accounting: by leaving the two modular inputs as hypotheses rather than axiomatizing them, the file demonstrates the project's preferred pattern — verify the reduction completely, and isolate the genuinely missing machinery (the Dedekind-Frobenius bridge) instead of hiding it inside an axiom.\n\n4. Shared open dependency: the missing bridge — factor type of f mod an unramified prime gives a Frobenius element of matching cycle type in f.Gal — is exactly what InverseGaloisA5.lean axiomatizes as three_dvd_gal_card. Formalizing it in Mathlib would simultaneously close this problem and the inverse-Galois A_5 entry, so the work is leveraged across multiple gallery entries.",
+    "openQuestions": [
+      "Formalize the Dedekind-Frobenius bridge in Mathlib: for a prime p not dividing disc(f), the factorization type of f mod p equals the cycle type of a Frobenius element of f.Gal. This single result discharges both explicit hypotheses here (5 | |Gal| from the irreducible factorization mod 3; a transposition from the (2)(3) factorization mod 2) and closes the problem unconditionally.",
+      "Can the discriminant direction be upgraded from the single-element fact (a transposition is odd) to the full statement Gal subset A_n iff disc(f) is a square, and connected to disc(X^5 - X - 1) = 2869 not being a square in Q?",
+      "Is X^5 - X - 1 the coefficient-smallest quintic with Galois group S_5, and how does its proof cost compare to Eisenstein witnesses such as x^5 - 4x + 2 (which gets irreducibility almost mechanically but needs three real roots)?",
+      "Could a general Mathlib tactic determine the Galois group of a given quintic by running the finitely many modular factorizations the Frobenius method needs, replacing the manual hypothesis-supply step?"
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-07` (Corrected S₅ Criterion for X⁵ − X − 1). This entry shipped with only `meta.json` (no annotations, no overview/sections/conclusion); this pass brings it to gallery quality.

## What was added
- **annotations.json (new)** — 7 annotations, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`:
  - header (statement + the false-step correction), S₅ model, `card_fin5_prime`, the assembly criterion `gal_eq_top_of_five_dvd_and_swap`, the odd-transposition sign fact, the **double-transposition correction** `prod_two_swaps_mem_alternating`, and the polynomial anchoring.
- **meta.overview** — `historicalContext` (Ruffini/Abel/Galois/Selmer/Dedekind), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **meta.sections** — 5 sections covering the full 129-line Lean file.
- **meta.mainTheorems / leanFile / references** — 4 references (Selmer 1956, Dummit–Foote, van der Waerden, Galois).
- **meta.conclusion** — summary, implications, and 4 `openQuestions` centered on the missing Dedekind–Frobenius bridge.

## Accuracy notes
- Math content faithfully reflects the Lean source and the existing `description`/`assumptions`: the file is axiom-free (0 sorry, 0 axiom), with the two number-theoretic inputs (5 ∣ |Gal|, a transposition in Gal) as **explicit hypotheses**, not axioms.
- Preserved all existing meta fields; only added new top-level keys.

## Validation
Data prebuild passes (`Enriched abel-ruffini-oq-07: 24 lean files, 16 related proofs`); `public/data` regenerates with overview + 5 sections + annotations. The `tsc` step fails only due to missing `node_modules` in the isolated worktree (known env limitation), not a data issue.