### PR TITLE
Enrich Corrected S₅ Criterion for X⁵−X−1: add overview, sections, annotations

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-07/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-07/annotations.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": "ann-abel-ruffini-oq-07-01",
+    "proofId": "abel-ruffini-oq-07",
+    "range": { "startLine": 1, "endLine": 60 },
+    "type": "context",
+    "title": "The Claim, the Correction, and the Corrected Proof",
+    "content": "The curated open question asked to prove Gal(X⁵−X−1/ℚ) ≅ S₅, making X⁵−X−1 a second Abel–Ruffini witness (a quintic unsolvable by radicals). The curated *route* contained a genuine error, documented here: it claimed X⁵−X−1 has three real roots, so complex conjugation is a transposition. Verified symbolically, the polynomial has exactly ONE real root (≈ 1.1673) and two complex-conjugate pairs, so complex conjugation is a PRODUCT OF TWO transpositions — an EVEN permutation in A₅. Mathlib's clean real-roots assembler galActionHom_bijective_of_prime_degree (which needs exactly one conjugate pair) therefore does not apply. The discriminant Δ = 2869 = 19·151 being a non-square only excludes the A₅ subgroup; among the transitive subgroups {C₅, D₅, F₂₀, A₅, S₅} the odd-permutation-containing ones are {F₂₀, S₅}, so excluding F₂₀ needs the extra input 5 ∣ |Gal|. The correct route uses Dedekind/Frobenius cycle types: f irreducible mod 3 gives a 5-cycle Frobenius (5 ∣ |Gal|), and the order-6 Frobenius at p=2 cubes to a transposition.",
+    "mathContext": "$f = X^5 - X - 1$ has one real root, so conjugation $\\in A_5$ (even). Transitive subgroups of $S_5$ containing an odd element: $\\{F_{20}, S_5\\}$; excluding $F_{20}$ needs $5 \\mid |\\mathrm{Gal}|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Abel–Ruffini theorem",
+      "solvability by radicals",
+      "Galois group of a quintic",
+      "complex conjugation as a permutation of roots",
+      "discriminant and A_n"
+    ],
+    "prerequisites": ["Galois theory", "symmetric and alternating groups", "Dedekind's theorem mod p"]
+  },
+  {
+    "id": "ann-abel-ruffini-oq-07-02",
+    "proofId": "abel-ruffini-oq-07",
+    "range": { "startLine": 70, "endLine": 76 },
+    "type": "technique",
+    "title": "Modelling S₅ as Perm (Fin 5); Prime Cardinality",
+    "content": "The Galois group acts faithfully on the 5-element root set, so the file works concretely with S5 := Equiv.Perm (Fin 5). card_fin5_prime establishes that Fintype.card (Fin 5) = 5 is prime — the structural hypothesis that unlocks Mathlib's prime-degree permutation machinery (a transitive subgroup of S_p containing a transposition, with p prime dividing its order, is all of S_p).",
+    "mathContext": "$|\\mathrm{Fin}\\,5| = 5$ is prime; this primality is what makes $\\operatorname{subgroup\\_eq\\_top\\_of\\_swap\\_mem}$ applicable.",
+    "significance": "supporting",
+    "relatedConcepts": ["symmetric group S_n", "prime cardinality", "transitive group action"],
+    "prerequisites": ["permutation groups", "Fintype.card"]
+  },
+  {
+    "id": "ann-abel-ruffini-oq-07-03",
+    "proofId": "abel-ruffini-oq-07",
+    "range": { "startLine": 78, "endLine": 91 },
+    "type": "insight",
+    "title": "The Corrected Assembly Criterion",
+    "content": "gal_eq_top_of_five_dvd_and_swap is the group-theoretic core: any subgroup G ≤ S₅ with 5 ∣ |G| and containing a transposition equals ⊤ = S₅. It is proved by feeding the two number-theoretic facts into Mathlib's Equiv.Perm.subgroup_eq_top_of_swap_mem together with card_fin5_prime. Crucially the two inputs (5 ∣ |G|, transposition ∈ G) are HYPOTHESES of the theorem, not axioms — keeping the file fully verified (0 sorry, 0 axiom) while making explicit exactly what the missing Dedekind–Frobenius bridge would have to supply. This is the corrected proof's reusable, hypothesis-driven heart.",
+    "mathContext": "$5 \\mid |G| \\ \\wedge\\ \\exists\\,\\tau\\in G\\ (\\tau\\text{ a transposition}) \\ \\Rightarrow\\ G = S_5$ (for $G \\le S_5$).",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy's theorem", "generation of S_n by a p-cycle and a transposition", "subgroup_eq_top_of_swap_mem"],
+    "prerequisites": ["Lagrange's theorem", "transpositions and generation"]
+  },
+  {
+    "id": "ann-abel-ruffini-oq-07-04",
+    "proofId": "abel-ruffini-oq-07",
+    "range": { "startLine": 93, "endLine": 99 },
+    "type": "technique",
+    "title": "A Transposition is Odd (Discriminant Direction)",
+    "content": "isSwap_not_mem_alternating proves a transposition lies outside A₅, by rewriting through mem_alternatingGroup (membership ⟺ sign = 1) and IsSwap.sign_eq (a swap has sign −1), then decide. This is the element-level form of the discriminant criterion: Δ not a perfect square ⟹ Gal ⊄ A₅. It pairs with the assembly criterion to pin the group at S₅ rather than A₅.",
+    "mathContext": "$\\tau\\text{ a transposition} \\Rightarrow \\operatorname{sign}\\tau = -1 \\Rightarrow \\tau \\notin A_5$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sign of a permutation", "alternating group", "discriminant of a polynomial"],
+    "prerequisites": ["permutation sign", "parity of permutations"]
+  },
+  {
+    "id": "ann-abel-ruffini-oq-07-05",
+    "proofId": "abel-ruffini-oq-07",
+    "range": { "startLine": 101, "endLine": 111 },
+    "type": "insight",
+    "title": "The Formal Correction: a Double Transposition is Even",
+    "content": "prod_two_swaps_mem_alternating is the formal content of the correction: a product of two transpositions is an EVEN permutation (sign = (−1)(−1) = 1), so it lies in A₅. Complex conjugation on the roots of X⁵−X−1 (one real root fixed, two conjugate pairs swapped) is exactly such a double transposition — hence NOT a transposition, contradicting the curated route's assumption. The proof rewrites through map_mul (sign is multiplicative) and the two IsSwap.sign_eq facts, then decide. This single lemma is why the curated assembler fails for this polynomial.",
+    "mathContext": "$\\operatorname{sign}(\\tau_1\\tau_2) = \\operatorname{sign}\\tau_1 \\cdot \\operatorname{sign}\\tau_2 = (-1)(-1) = 1 \\Rightarrow \\tau_1\\tau_2 \\in A_5$.",
+    "significance": "key",
+    "relatedConcepts": ["sign is a homomorphism", "double transposition", "complex conjugation on roots", "cycle type"],
+    "prerequisites": ["permutation sign", "group homomorphisms"]
+  },
+  {
+    "id": "ann-abel-ruffini-oq-07-06",
+    "proofId": "abel-ruffini-oq-07",
+    "range": { "startLine": 113, "endLine": 127 },
+    "type": "definition",
+    "title": "Anchoring the Polynomial: Monic of Prime Degree 5",
+    "content": "The quintic f := X⁵ − X − 1 ∈ ℚ[X] is defined and its basic invariants verified by automation: f_natDegree (degree 5, via compute_degree!), f_monic (via monicity!), and natDegree_prime (degree is prime, via norm_num). The prime degree is the hypothesis that makes the prime-degree Galois machinery (subgroup_eq_top_of_swap_mem, prime_degree_dvd_card) applicable, tying the concrete polynomial back to the abstract assembly criterion.",
+    "mathContext": "$f = X^5 - X - 1$, $\\deg f = 5$ prime, $f$ monic.",
+    "significance": "context",
+    "relatedConcepts": ["minimal polynomial", "monic polynomial", "prime degree", "compute_degree tactic"],
+    "prerequisites": ["polynomial degree", "polynomials over ℚ"]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-07/meta.json
@@ -69,6 +69,89 @@
     "theoremCount": 7,
     "definitionCount": 1
   },
+  "overview": {
+    "historicalContext": "The Abel–Ruffini theorem (Ruffini 1799, Abel 1824) shows the general quintic is not solvable by radicals; Galois (1830s) recast solvability as a property of the polynomial's Galois group, solvable iff the group is. Concrete unsolvable quintics are exhibited by proving their Galois group is the non-solvable S₅. Selmer (1956) proved the trinomial X⁵−X−1 is irreducible over ℚ, making it a natural S₅ candidate. Determining Galois groups of quintics in practice rests on Dedekind's theorem (factorisation type mod an unramified prime p equals the cycle type of a Frobenius element), the standard computational tool described in Dummit & Foote §14.8 and van der Waerden §61.",
+    "problemStatement": "Establish that Gal(X⁵−X−1/ℚ) ≅ S₅ (so X⁵−X−1 is not solvable by radicals), and correct the curated proof route: X⁵−X−1 has exactly one real root, so complex conjugation is a double transposition (even, in A₅), not a transposition. Formalize the corrected group-theoretic reduction: a subgroup G ≤ S₅ with 5 ∣ |G| and a transposition in G must be all of S₅.",
+    "proofStrategy": "Separate the verifiable group theory from the open number theory. The file proves the assembly criterion gal_eq_top_of_five_dvd_and_swap (5 ∣ |G| and a transposition in G ⟹ G = S₅) by feeding card_fin5_prime into Mathlib's subgroup_eq_top_of_swap_mem, and the sign facts (a transposition is odd; a product of two transpositions is even) by sign computations plus decide. The two number-theoretic inputs — 5 ∣ |Gal| (from f irreducible mod 3) and a transposition in Gal (from the order-6 Frobenius at p=2) — are exposed as explicit HYPOTHESES rather than axioms, so every theorem is fully machine-checked (0 sorry, 0 axiom). Supplying those inputs in Lean requires the Dedekind–Frobenius bridge that Mathlib v4.26.0 lacks.",
+    "keyInsights": [
+      "**The curated route was false, and the file proves why.** X⁵−X−1 has one real root, so complex conjugation is a product of two transpositions — an even permutation in A₅ (prod_two_swaps_mem_alternating), not the transposition the curated proof assumed. Mathlib's real-roots assembler galActionHom_bijective_of_prime_degree therefore does not apply.",
+      "**The discriminant alone is not enough.** Δ = 2869 = 19·151 is a non-square, so Gal ⊄ A₅; but among transitive subgroups of S₅ the odd-containing ones are {F₂₀, S₅}, so excluding F₂₀ (order 20) requires the extra divisibility input 5 ∣ |Gal|.",
+      "**Hypotheses, not axioms.** The two number-theoretic facts are theorem hypotheses, keeping the file 0-axiom and 0-sorry while making the open gap explicit and reusable; this is an honest reduction rather than an axiomatization.",
+      "**Prime degree drives the machinery.** Because the root set has prime cardinality 5, a transitive subgroup containing a single transposition is forced to be the whole symmetric group — the crisp prime-degree generation fact encoded in subgroup_eq_top_of_swap_mem.",
+      "**One shared open bridge.** The missing input is the Dedekind–Frobenius bridge (factor type mod p ⟹ Frobenius cycle type), the same machinery inverse-galois-a5-oq-01 axiomatizes as three_dvd_gal_card; closing it there closes this problem too."
+    ],
+    "prerequisites": [
+      "Galois theory and solvability by radicals",
+      "Symmetric and alternating groups; permutation sign",
+      "Dedekind's theorem on factorisation mod p"
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring-correction",
+      "title": "Statement, Correction, and Corrected Proof",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Documents the curated claim Gal(X⁵−X−1)≅S₅, identifies the error in the curated route (one real root ⟹ conjugation is a double transposition in A₅, not a transposition), notes the discriminant Δ=2869 only excludes A₅, and lays out the corrected Dedekind/Frobenius route (5-cycle mod 3, order-6 Frobenius at p=2 cubing to a transposition). Marks the open Dedekind–Frobenius bridge as the sole gap."
+    },
+    {
+      "id": "s5-setup",
+      "title": "Modelling S₅ and Prime Cardinality",
+      "startLine": 62,
+      "endLine": 76,
+      "summary": "Imports the permutation-group and alternating-group machinery, defines S5 := Equiv.Perm (Fin 5), and proves card_fin5_prime (|Fin 5| = 5 is prime) — the hypothesis that activates Mathlib's prime-degree permutation machinery."
+    },
+    {
+      "id": "assembly-criterion",
+      "title": "The Corrected Assembly Criterion",
+      "startLine": 78,
+      "endLine": 91,
+      "summary": "Proves gal_eq_top_of_five_dvd_and_swap: a subgroup G ≤ S₅ with 5 ∣ |G| and containing a transposition equals ⊤. The two number-theoretic facts are hypotheses; the proof routes them through subgroup_eq_top_of_swap_mem and card_fin5_prime."
+    },
+    {
+      "id": "sign-facts",
+      "title": "Sign Facts: Odd Transposition, Even Double Transposition",
+      "startLine": 93,
+      "endLine": 111,
+      "summary": "isSwap_not_mem_alternating shows a transposition is odd (the discriminant direction, Gal ⊄ A₅); prod_two_swaps_mem_alternating shows a product of two transpositions is even — the formal correction that complex conjugation lies in A₅. Both via sign computations and decide."
+    },
+    {
+      "id": "polynomial-anchoring",
+      "title": "Anchoring the Polynomial f = X⁵ − X − 1",
+      "startLine": 113,
+      "endLine": 129,
+      "summary": "Defines f := X⁵ − X − 1 ∈ ℚ[X] and verifies f_natDegree (degree 5), f_monic, and natDegree_prime (degree prime) via compute_degree!, monicity!, and norm_num — connecting the abstract criterion to the concrete witness quintic."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "gal_eq_top_of_five_dvd_and_swap",
+      "type": "core",
+      "description": "Corrected assembly criterion: a subgroup G ≤ S₅ with 5 ∣ |G| and containing a transposition equals ⊤ = S₅ (PROVED, 0 axioms; the two arithmetic facts are hypotheses).",
+      "leanType": "∀ {G : Subgroup S5} [DecidablePred (· ∈ G)], 5 ∣ Fintype.card G → ∀ {τ : S5}, τ ∈ G → τ.IsSwap → G = ⊤"
+    },
+    {
+      "name": "prod_two_swaps_mem_alternating",
+      "type": "core",
+      "description": "The formal correction: a product of two transpositions is even (lies in A₅), so complex conjugation on the roots of X⁵−X−1 is not a transposition (PROVED, 0 axioms).",
+      "leanType": "∀ {τ₁ τ₂ : S5}, τ₁.IsSwap → τ₂.IsSwap → τ₁ * τ₂ ∈ alternatingGroup (Fin 5)"
+    },
+    {
+      "name": "isSwap_not_mem_alternating",
+      "type": "supporting",
+      "description": "A transposition is odd, hence outside A₅ — the discriminant direction (Δ non-square ⟹ Gal ⊄ A₅) at the level of a single element (PROVED, 0 axioms).",
+      "leanType": "∀ {τ : S5}, τ.IsSwap → τ ∉ alternatingGroup (Fin 5)"
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully machine-checked (0 sorries, 0 axioms) group-theoretic reduction of Gal(X⁵−X−1/ℚ) ≅ S₅, together with a formalized correction to the curated proof route. The corrected assembly criterion gal_eq_top_of_five_dvd_and_swap reduces the S₅ claim to two number-theoretic inputs (5 ∣ |Gal| and a transposition in Gal), exposed as explicit hypotheses; the sign lemmas establish that complex conjugation, a double transposition, is even and cannot supply that transposition.",
+    "implications": "Demonstrates the value of honest reductions: separating verifiable group theory from an unformalized number-theoretic bridge yields a 0-axiom file that pinpoints exactly what Mathlib must add (the Dedekind–Frobenius cycle-type bridge). The criterion is reusable for any prime-degree Galois-group determination, and the correction shows how symbolic root-counting can refute a plausible-looking proof route.",
+    "openQuestions": [
+      "Formalize the Dedekind–Frobenius bridge in Mathlib: factor type of f mod an unramified prime p ⟹ a Frobenius element of matching cycle type in f.Gal — this supplies both hypotheses and closes the problem unconditionally.",
+      "Discharge the same bridge for inverse-galois-a5-oq-01, where it is axiomatized as three_dvd_gal_card; a single formalization serves both entries.",
+      "Verify 5 ∣ |Gal(X⁵−X−1)| and the existence of a transposition directly from irreducibility mod 3 and the factorisation mod 2, once the bridge exists."
+    ]
+  },
   "crossReferences": [
     {
       "targetId": "abel-ruffini-oq-04-oq-01",


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-07`.

The entry previously had **only meta.json** with no `overview`, `sections`, `conclusion`, or `annotations.json` (quality score 0). This pass adds all of them.

## Added
- **`annotations.json` (6 annotations)** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering: the docstring correction (one real root ⟹ conjugation is a double transposition in A₅), the S₅ setup and prime cardinality, the corrected assembly criterion, the sign facts (odd transposition / even double transposition), and the polynomial anchoring.
- **`overview`** — historicalContext (Abel–Ruffini, Galois, Selmer 1956, Dedekind), problemStatement, proofStrategy, and 5 keyInsights.
- **`sections` (5)** covering the full 129-line file.
- **`mainTheorems` (3)** and a **`conclusion`** with implications and 3 open questions.

## Verification
- `pnpm run annotations:validate` reports **0 errors for this entry**; all annotation startLines land on Lean constructs.
- JSON validated; all line ranges within the 129-line file.
- No change to `status`/`badge`/`axiomCount` — remains verified/verified/0-axiom, an honest reduction (the two number-theoretic inputs are hypotheses, not axioms), consistent with the Lean source.