### PR TITLE
Enrich buffons-noodle-oq-01: annotations + sections

### DIFF
--- a/src/data/proofs/buffons-noodle-oq-01/meta.json
+++ b/src/data/proofs/buffons-noodle-oq-01/meta.json
@@ -87,6 +87,91 @@
       "Field algebra"
     ]
   },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: Buffon–Laplace and Additivity of Expectation",
+      "startLine": 4,
+      "endLine": 52,
+      "summary": "Frames the extension from one family of parallel lines (Buffon's noodle, E = 2L/(pi d)) to a grid of two perpendicular families (Buffon-Laplace, E = 2L/(pi dh) + 2L/(pi dv), collapsing to 4L/(pi d) on a square grid). Stresses that the result needs no new probability: total crossings = horizontal + vertical, and E[X+Y] = E[X] + E[Y] requires no independence even though the two tallies are correlated. Scope is polygonal-only (0 axioms, 0 sorries); the smooth case depends on still-axiomatized kinematic-measure infrastructure.",
+      "mathContext": "Single family 2L/(pi d); grid 2L/(pi dh) + 2L/(pi dv); square grid 4L/(pi d). Additivity E[X+Y]=E[X]+E[Y] with no independence.",
+      "relatedConcepts": [
+        "Buffon-Laplace problem",
+        "Buffon's noodle",
+        "linearity of expectation",
+        "integral geometry"
+      ]
+    },
+    {
+      "id": "def-grid-crossings",
+      "title": "Definition: expectedGridCrossings",
+      "startLine": 58,
+      "endLine": 66,
+      "summary": "Defines expectedGridCrossings N dh dv := N.expectedCrossings dh + N.expectedCrossings dv, encoding additivity of expectation across the two families definitionally. Placed in the parent BuffonsNoodle namespace as a method on PolygonalNoodle.",
+      "mathContext": "expectedGridCrossings(N, dh, dv) := E[crossings vs family dh] + E[crossings vs family dv].",
+      "relatedConcepts": [
+        "linearity of expectation",
+        "expectedCrossings",
+        "PolygonalNoodle"
+      ]
+    },
+    {
+      "id": "part-i",
+      "title": "Part I: The Buffon–Laplace Grid Theorem",
+      "startLine": 72,
+      "endLine": 111,
+      "summary": "buffon_noodle_grid (E = 2L/(pi dh) + 2L/(pi dv)) proved by unfolding the grid expectation and applying buffon_noodle_polygon once per family; buffon_noodle_grid_eq_sum records the definitional additivity by rfl; buffon_noodle_square_grid specializes to 4L/(pi d); buffon_noodle_grid_eq_two_mul_single states the square-grid doubling E = 2*expectedCrossings d.",
+      "mathContext": "Grid identity 2L/(pi dh) + 2L/(pi dv); square grid 4L/(pi d) = 2*(2L/(pi d)).",
+      "relatedConcepts": [
+        "Buffon-Laplace theorem",
+        "buffon_noodle_polygon",
+        "shape independence",
+        "square grid"
+      ]
+    },
+    {
+      "id": "part-ii",
+      "title": "Part II: Structural Properties",
+      "startLine": 113,
+      "endLine": 150,
+      "summary": "Shape independence (equal total length => equal expected grid crossings), nonnegativity (via totalLength_nonneg, div_nonneg, positivity), and monotonicity in length (via gcongr on each fraction + linarith). Confirms the functional behaves like a genuine expected count.",
+      "mathContext": "L1=L2 => E1=E2; L>=0,dh,dv>0 => E>=0; L1<=L2 => E1<=E2 (linear, positive slope).",
+      "relatedConcepts": [
+        "shape independence",
+        "monotonicity",
+        "gcongr",
+        "positivity"
+      ]
+    },
+    {
+      "id": "part-iii",
+      "title": "Part III: The Monte-Carlo π Estimator",
+      "startLine": 152,
+      "endLine": 167,
+      "summary": "pi_times_spacing_mul_grid_crossings: pi*d*E = 4L on a square grid, i.e. pi = 4L/(d*E). Stated in multiplicative form to avoid any nondegeneracy hypothesis on E; proved via buffon_noodle_square_grid + field_simp. This is the variance-reduced Buffon-Laplace pi estimator (two tallies per trial).",
+      "mathContext": "pi*d*E = 4L <=> pi = 4L/(d*E); two crossing tallies per drop halve estimator variance vs single family.",
+      "relatedConcepts": [
+        "Monte-Carlo method",
+        "variance reduction",
+        "estimating pi",
+        "field_simp"
+      ]
+    },
+    {
+      "id": "part-iv",
+      "title": "Part IV: Numerical Examples",
+      "startLine": 169,
+      "endLine": 214,
+      "summary": "circle_grid_crossings: circle (circumference 2*pi*r) on a square grid gives 8r/d, independent of pi (the pi cancels). square_grid_crossings: square of side s gives 16s/(pi d). circle_rect_grid_crossings: on a rectangular grid the circle gives 4r(1/dh + 1/dv), recovering 8r/d only when dh=dv. Each via Fin.sum_univ_one/four then field_simp; ring.",
+      "mathContext": "Circle/square grid: 8r/d (pi cancels). Square/square grid: 16s/(pi d). Circle/rect grid: 4r(1/dh + 1/dv).",
+      "relatedConcepts": [
+        "circle and polygon perimeters",
+        "Fin.sum_univ_one",
+        "rectangular vs square grid",
+        "sanity checks"
+      ]
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "buffons-noodle",


### PR DESCRIPTION
Enrichment pass for `buffons-noodle-oq-01` (Buffon–Laplace for the Polygonal Noodle). The entry had a solid `overview`/`conclusion`/`mainTheorems` but **no annotations and no sections** (quality 32); this pass closes both gaps.

## What was added
- **annotations.json (new)** — 7 annotations, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`:
  header (Buffon–Laplace + additivity of expectation), the `expectedGridCrossings` definition, the grid theorem `buffon_noodle_grid`, the square-grid specialization, the structural properties (shape independence / nonnegativity / monotonicity), the variance-reduced π estimator, and the three numerical examples.
- **meta.sections** — 6 sections covering the full 214-line Lean file (header, definition, Parts I–IV).

## Accuracy notes
- Content tracks the Lean source exactly: 0 axioms / 0 sorries, everything a corollary of the parent's `buffon_noodle_polygon` via additivity of expectation (no independence needed). Noted the π-cancellation in `circle_grid_crossings` (8r/d) and the rectangular-grid distinction.
- Preserved all existing meta fields; only added `sections` + the new annotations file.

## Validation
Data prebuild regenerates `public/data/proofs/buffons-noodle-oq-01` with 6 sections + 7 annotations (all carrying mathContext+significance); no validation error on this entry. The broad `tsc`/markdown warnings are the pre-existing repo-wide env/research-problem issues, unrelated to this change.

Branched off `main` (not the shared `feature/enricher-1`, which carries open PR #26010).