### PR TITLE
audit: re-confirm erdos-135 + erdos-127 clean (durable tracker bump)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4619,8 +4619,8 @@
     },
     "erdos-127": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T06:27:32Z",
       "result": "clean"
     },
     "erdos-128": {
@@ -4694,8 +4694,8 @@
     },
     "erdos-135": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T06:26:47Z",
       "result": "clean"
     },
     "erdos-136": {


### PR DESCRIPTION
## Gallery Integrity Audit

Gallery is fully saturated (2545/2545 audited, 0 issues). The auditor's `--next` rotation re-serves the stale May-2026 batch because local tracker bumps never persisted to main. This PR commits two clean re-audits to break the loop.

### Re-audited clean against current main

**erdos-135** — `axiomatized`/`axiom`, axiomCount 5
- Exactly 5 `axiom` declarations (erdos_135_false, tao_counterexample, guth_katz_lower_bound, parallelogram_few_distances, tao_avoids_parallelograms)
- Main theorem `erdos_135_disproved := erdos_135_false` honestly rests on a stated axiom
- 0 sorries, 0 native_decide, no True stubs, no structure-encoded assumptions

**erdos-127** — `axiomatized`/`axiom`, axiomCount 1
- 1 `axiom` declaration (`excessF : ℕ → ℝ`) = axiomCount 1
- 0 sorries, 0 native_decide, no True stubs, no structures

Both honest Tier C presentations. No integrity issues.

---
Discovered during gallery integrity audit.