### PR TITLE
audit: record hilbert-10-oq-04-oq-03 clean (durable tracker entry)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15985,6 +15985,12 @@
       "lastAudited": "2026-06-19T06:10:21Z",
       "result": "clean",
       "issues": []
+    },
+    "hilbert-10-oq-04-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T06:35:49Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `hilbert-10-oq-04-oq-03` — *Hilbert's 10th OQ-04-03: Linear Diophantine Solvability is Decidable*

This was the sole unaudited gallery proof. Audited against `Proofs/Hilbert10OQ04OQ03.lean`.

### meta.json claims
`status: verified` · `badge: original` · 0 axioms · 0 sorries · 3 theorems · 4 defs · 108 lines

### Verified against source
- ✅ 0 `axiom` declarations
- ✅ 0 real sorries (lone grep hit is a docstring "`sorry`-free")
- ✅ 0 `native_decide` (Decidable instance uses `decidable_of_iff'`; example uses `norm_num`) → no `Lean.ofReduceBool`
- ✅ 0 `True` stubs / `admit`
- ✅ 3 substantive theorems doing real work:
  - `span_range_eq_span_gcd` — coefficient ideal = gcd ideal (`le_antisymm` + principal-generator extraction)
  - `solvable_iff_gcd_dvd` — n-variable Bézout characterization
  - `LinearForm.solvable_iff` + `Decidable` instance
- ✅ `classical` use consistent with disclosed `Classical.choice`

### Tier / badge assessment
Honest **bridge/infrastructure** over Mathlib's PIR + `Finset.gcd` machinery — proves the gcd/Bézout characterization itself rather than wrapping a single deep decidability theorem. Badge `original` is defensible; title does not overclaim ("first formalization" not asserted). No narrative failure modes detected.

**Result**: CLEAN, no changes to meta.json needed. This PR only records the audit in the main tracker so `find-targets` advances (gallery now 2546/2546 audited, 0 unaudited).

---
Discovered during gallery integrity audit.