### PR TITLE
research(quadratic-gauss-sum-square-oq-01): real/imaginary dichotomy of quadratic Gauss sum

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2817,6 +2817,7 @@ import Proofs.PythagoreanTriplesOQ01
 import Proofs.PythagoreanTriplesOQ01Aristotle
 import Proofs.PythagoreanTriplesOQ02
 import Proofs.QuadraticGaussSumSquare
+import Proofs.QuadraticGaussSumSquareOQ01
 import Proofs.QuadraticReciprocity
 import Proofs.QuadraticReciprocityAlgorithmOQ01
 import Proofs.QuadraticReciprocityAlgorithmOQ03

--- a/proofs/Proofs/QuadraticGaussSumSquareOQ01.lean
+++ b/proofs/Proofs/QuadraticGaussSumSquareOQ01.lean
@@ -1,0 +1,116 @@
+/-
+  Real / imaginary dichotomy of the quadratic Gauss sum.
+
+  Parent (`Proofs/QuadraticGaussSumSquare.lean`) establishes, for an odd prime `p`
+  and a primitive additive character `ψ : ZMod p → ℂ`, the SQUARE of the quadratic
+  Gauss sum `g = gaussSum (chiC p) ψ`:
+
+      g² = (-1)^((p-1)/2) · p.
+
+  This pins `g` down only up to sign.  Gauss's *hard* theorem fixes the sign:
+
+      g = √p          if p ≡ 1 (mod 4),
+      g = i·√p        if p ≡ 3 (mod 4).
+
+  The full sign is genuinely deep (Schur's eigenvalue argument / Dirichlet's
+  analytic evaluation) and is NOT formalized here.  This file proves the
+  *elementary half* — the real/imaginary DICHOTOMY — which already follows from
+  the parent's square identity by pure complex arithmetic:
+
+    * p ≡ 1 (mod 4)  ⟹  g² = +p > 0  ⟹  g is real      (`g.im = 0`),
+    * p ≡ 3 (mod 4)  ⟹  g² = −p < 0  ⟹  g is imaginary  (`g.re = 0`),
+
+  together with the magnitude `‖g‖² = p` (so `g = ±√p` resp. `±i√p`).  The
+  remaining `±` choice is exactly the open hard theorem.
+-/
+import Mathlib
+import Proofs.QuadraticGaussSumSquare
+
+open scoped BigOperators
+open QuadraticGaussSumSquare
+
+namespace QuadraticGaussSumSquareOQ01
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-- A complex number whose square is a **positive real** is itself real. -/
+theorem im_eq_zero_of_sq_eq_pos_real {z : ℂ} {r : ℝ} (hr : 0 < r)
+    (hz : z ^ 2 = (r : ℂ)) : z.im = 0 := by
+  -- imaginary part of `z² = r`:  z.re·z.im + z.im·z.re = 0
+  have h1 : z.re * z.im + z.im * z.re = 0 := by
+    have := congrArg Complex.im hz
+    rwa [pow_two, Complex.mul_im, Complex.ofReal_im] at this
+  -- real part of `z² = r`:  z.re·z.re − z.im·z.im = r
+  have h2 : z.re * z.re - z.im * z.im = r := by
+    have := congrArg Complex.re hz
+    rwa [pow_two, Complex.mul_re, Complex.ofReal_re] at this
+  -- hence z.re·z.im = 0
+  have hprod : z.re * z.im = 0 := by linarith [h1, mul_comm z.im z.re]
+  rcases mul_eq_zero.mp hprod with hre0 | him0
+  · -- z.re = 0 forces −z.im² = r > 0, impossible
+    rw [hre0] at h2
+    nlinarith [mul_self_nonneg z.im]
+  · exact him0
+
+/-- A complex number whose square is a **negative real** is purely imaginary. -/
+theorem re_eq_zero_of_sq_eq_neg_real {z : ℂ} {r : ℝ} (hr : r < 0)
+    (hz : z ^ 2 = (r : ℂ)) : z.re = 0 := by
+  have h1 : z.re * z.im + z.im * z.re = 0 := by
+    have := congrArg Complex.im hz
+    rwa [pow_two, Complex.mul_im, Complex.ofReal_im] at this
+  have h2 : z.re * z.re - z.im * z.im = r := by
+    have := congrArg Complex.re hz
+    rwa [pow_two, Complex.mul_re, Complex.ofReal_re] at this
+  have hprod : z.re * z.im = 0 := by linarith [h1, mul_comm z.im z.re]
+  rcases mul_eq_zero.mp hprod with hre0 | him0
+  · exact hre0
+  · -- z.im = 0 forces z.re² = r < 0, impossible
+    rw [him0] at h2
+    nlinarith [mul_self_nonneg z.re]
+
+/-- **Dichotomy, case `p ≡ 1 (mod 4)`.** The quadratic Gauss sum is real. -/
+theorem gaussSum_im_eq_zero_of_one_mod_four (hp4 : p % 4 = 1)
+    {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    (gaussSum (chiC p) ψ).im = 0 := by
+  have hp2 : p ≠ 2 := by omega
+  have hsq := gaussSum_quadratic_sq (p := p) hp2 hψ
+  have heven : Even ((p - 1) / 2) := by rw [Nat.even_iff]; omega
+  rw [heven.neg_one_pow, one_mul] at hsq
+  have hppos : (0 : ℝ) < (p : ℝ) := by exact_mod_cast (Fact.out : p.Prime).pos
+  refine im_eq_zero_of_sq_eq_pos_real hppos ?_
+  rw [hsq]; push_cast; ring
+
+/-- **Dichotomy, case `p ≡ 3 (mod 4)`.** The quadratic Gauss sum is purely imaginary. -/
+theorem gaussSum_re_eq_zero_of_three_mod_four (hp4 : p % 4 = 3)
+    {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    (gaussSum (chiC p) ψ).re = 0 := by
+  have hp2 : p ≠ 2 := by omega
+  have hsq := gaussSum_quadratic_sq (p := p) hp2 hψ
+  have hodd : Odd ((p - 1) / 2) := by rw [Nat.odd_iff]; omega
+  rw [hodd.neg_one_pow] at hsq
+  have hpneg : (-(p : ℝ)) < 0 := by
+    have : (0 : ℝ) < (p : ℝ) := by exact_mod_cast (Fact.out : p.Prime).pos
+    linarith
+  refine re_eq_zero_of_sq_eq_neg_real hpneg ?_
+  rw [hsq]; push_cast; ring
+
+/-- **Magnitude.** `‖g‖² = p`, so the Gauss sum has absolute value `√p`.
+Combined with the dichotomy this gives `g = ±√p` (p ≡ 1) resp. `g = ±i√p`
+(p ≡ 3); only the leading sign remains open. -/
+theorem gaussSum_normSq_eq (hp2 : p ≠ 2) {ψ : AddChar (ZMod p) ℂ}
+    (hψ : ψ.IsPrimitive) : Complex.normSq (gaussSum (chiC p) ψ) = p := by
+  have hsq := gaussSum_quadratic_sq (p := p) hp2 hψ
+  -- `normSq` is multiplicative: normSq (g²) = (normSq g)²
+  have h := congrArg Complex.normSq hsq
+  rw [map_pow, map_mul, map_pow] at h
+  -- normSq (-1) = 1 and normSq (p : ℂ) = p²
+  have hneg : Complex.normSq (-1 : ℂ) = 1 := by simp
+  have hpc : Complex.normSq (p : ℂ) = (p : ℝ) ^ 2 := by
+    simp [Complex.normSq_apply]; ring
+  rw [hneg, one_pow, one_mul, hpc] at h
+  -- h : (normSq g)² = p²; both sides nonneg ⟹ equal
+  have hnn : (0 : ℝ) ≤ Complex.normSq (gaussSum (chiC p) ψ) := Complex.normSq_nonneg _
+  have hpnn : (0 : ℝ) ≤ (p : ℝ) := by positivity
+  nlinarith [h, hnn, hpnn]
+
+end QuadraticGaussSumSquareOQ01

--- a/proofs/Proofs/QuadraticGaussSumSquareOQ01.lean
+++ b/proofs/Proofs/QuadraticGaussSumSquareOQ01.lean
@@ -106,7 +106,7 @@ theorem gaussSum_normSq_eq (hp2 : p ≠ 2) {ψ : AddChar (ZMod p) ℂ}
   -- normSq (-1) = 1 and normSq (p : ℂ) = p²
   have hneg : Complex.normSq (-1 : ℂ) = 1 := by simp
   have hpc : Complex.normSq (p : ℂ) = (p : ℝ) ^ 2 := by
-    simp [Complex.normSq_apply]; ring
+    rw [Complex.normSq_natCast]; ring
   rw [hneg, one_pow, one_mul, hpc] at h
   -- h : (normSq g)² = p²; both sides nonneg ⟹ equal
   have hnn : (0 : ℝ) ≤ Complex.normSq (gaussSum (chiC p) ψ) := Complex.normSq_nonneg _

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-01/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-01/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "quadratic-gauss-sum-square-oq-01",
+  "title": "Real/Imaginary Dichotomy of the Quadratic Gauss Sum",
+  "slug": "quadratic-gauss-sum-square-oq-01",
+  "description": "Building on the square identity g² = (-1)^((p-1)/2)·p for the quadratic Gauss sum g = ∑ₙ χ(n)·ψ(n) (odd prime p, primitive additive character ψ), this entry proves the elementary half of Gauss's sign theorem: the real/imaginary DICHOTOMY. When p ≡ 1 (mod 4) the square is the positive real +p, forcing g to be real (g.im = 0); when p ≡ 3 (mod 4) the square is the negative real −p, forcing g to be purely imaginary (g.re = 0). Together with the magnitude ‖g‖² = p this gives g = ±√p resp. g = ±i√p — only the leading ± sign, the genuinely deep part of Gauss's theorem, remains open.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-18",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticGaussSumSquareOQ01.lean",
+    "tags": [
+      "number-theory",
+      "gauss-sum",
+      "quadratic-character",
+      "quadratic-reciprocity",
+      "complex-analysis",
+      "zmod",
+      "additive-character"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 116,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": ""
+  },
+  "overview": {
+    "historicalContext": "Gauss's $g^2 = (-1)^{(p-1)/2} p$ pins the quadratic Gauss sum down only up to sign. Gauss famously struggled for four years to determine the sign of $g$ itself — the statement $g = \\sqrt{p}$ for $p \\equiv 1 \\pmod 4$ and $g = i\\sqrt{p}$ for $p \\equiv 3 \\pmod 4$ — before finding the argument (28 August 1805) now usually presented via Schur's eigenvalue computation on the finite Fourier transform or Dirichlet's analytic evaluation. That full sign determination remains out of scope here. What this entry isolates is the *elementary half*: the real/imaginary dichotomy, which already follows from the square identity by pure complex arithmetic without any of Gauss's analytic input. It tells us $g$ lies on the real axis when $p \\equiv 1$ and on the imaginary axis when $p \\equiv 3$, leaving exactly the leading $\\pm$ that the hard theorem fixes.",
+    "problemStatement": "Let $p$ be an odd prime and $\\psi : \\mathbb{Z}/p\\mathbb{Z} \\to \\mathbb{C}$ a primitive additive character, with $g = \\operatorname{gaussSum}(\\chi_{\\mathbb{C}}, \\psi)$ the transported quadratic Gauss sum. Granting the parent's square identity $g^2 = (-1)^{(p-1)/2}\\,p$, prove: (1) if $p \\equiv 1 \\pmod 4$ then $g$ is real ($\\operatorname{Im} g = 0$); (2) if $p \\equiv 3 \\pmod 4$ then $g$ is purely imaginary ($\\operatorname{Re} g = 0$); (3) the magnitude satisfies $\\lVert g \\rVert^2 = p$.",
+    "proofStrategy": "Two self-contained complex-arithmetic lemmas do the work. `im_eq_zero_of_sq_eq_pos_real`: if $z^2$ is a positive real $r$, then taking real and imaginary parts of $z^2 = r$ gives $2\\,\\operatorname{Re}(z)\\operatorname{Im}(z) = 0$ and $\\operatorname{Re}(z)^2 - \\operatorname{Im}(z)^2 = r$; the product being zero splits into cases, and $\\operatorname{Re}(z) = 0$ is excluded because it would force $-\\operatorname{Im}(z)^2 = r > 0$, so $\\operatorname{Im}(z) = 0$. `re_eq_zero_of_sq_eq_neg_real` is the mirror image for negative reals. The two dichotomy theorems then feed the parent's `gaussSum_quadratic_sq`: for $p \\equiv 1 \\pmod 4$ the exponent $(p-1)/2$ is even, so $(-1)^{(p-1)/2} = 1$ and $g^2 = +p$ is a positive real; for $p \\equiv 3 \\pmod 4$ it is odd, so $g^2 = -p$ is a negative real. The magnitude theorem `gaussSum_normSq_eq` applies the multiplicative `Complex.normSq` to $g^2 = (-1)^{(p-1)/2} p$, giving $(\\operatorname{normSq} g)^2 = p^2$, whence $\\operatorname{normSq} g = p$ by nonnegativity.",
+    "keyInsights": [
+      "The dichotomy is the *soft* half of Gauss's sign theorem: it needs nothing beyond the square identity and the algebra of $\\mathbb{C} = \\mathbb{R}[i]$. Concretely, a complex number whose square is a nonzero real must lie on one of the two coordinate axes — real axis if the square is positive, imaginary axis if negative — and which axis is decided entirely by the sign $(-1)^{(p-1)/2}$ already computed in the parent.",
+      "The parity of $(p-1)/2$ is the hinge. `Nat.even_iff`/`Nat.odd_iff` plus `omega` translate $p \\bmod 4 \\in \\{1,3\\}$ into `Even`/`Odd ((p-1)/2)`, and `Even.neg_one_pow`/`Odd.neg_one_pow` collapse the sign factor to $+1$ or $-1$ — exactly the input the two arithmetic lemmas need.",
+      "Both arithmetic lemmas are proved by extracting `Complex.re` and `Complex.im` of the hypothesis $z^2 = r$ via `congrArg`, expanding with `Complex.mul_re`/`Complex.mul_im`, and discharging the resulting real (in)equalities with `linarith`/`nlinarith` and `mul_self_nonneg`. No appeal to square roots or the argument function is needed — the obstruction $\\operatorname{Re}(z) = 0$ (resp. $\\operatorname{Im}(z) = 0$) is ruled out purely by sign.",
+      "The magnitude $\\lVert g \\rVert^2 = p$ is independent of the residue of $p$ mod 4 and of the unknown leading sign: `Complex.normSq` is multiplicative, so $\\operatorname{normSq}(g)^2 = \\operatorname{normSq}(g^2) = \\operatorname{normSq}((-1)^{(p-1)/2} p) = p^2$, and nonnegativity of `normSq` selects the positive square root. This is the Parseval/orthogonality content $|g| = \\sqrt{p}$ made explicit.",
+      "Dichotomy plus magnitude pin $g$ to one of just four points: $\\pm\\sqrt{p}$ when $p \\equiv 1 \\pmod 4$ and $\\pm i\\sqrt{p}$ when $p \\equiv 3 \\pmod 4$. The remaining binary choice — which sign — is precisely Gauss's hard theorem and the sole piece this entry leaves open, cleanly separating the elementary from the deep."
+    ]
+  },
+  "conclusion": {
+    "summary": "For every odd prime $p$ and primitive additive character $\\psi$, the quadratic Gauss sum $g$ is machine-checked to be real when $p \\equiv 1 \\pmod 4$ and purely imaginary when $p \\equiv 3 \\pmod 4$, with magnitude $\\lVert g \\rVert^2 = p$. These follow from the parent's square identity by elementary complex arithmetic, with no axioms and no sorries.",
+    "implications": "The dichotomy and magnitude reduce the full sign-determination problem to a single binary choice — the leading $\\pm$ — making explicit exactly where Gauss's deep analytic argument is required and where it is not. The same real/imaginary split governs the functional equation of the Dirichlet $L$-function attached to the quadratic character mod $p$, where the location of $g$ on the real or imaginary axis controls the root number.",
+    "openQuestions": [
+      "Can the leading sign of $g$ — $g = +\\sqrt{p}$ for $p \\equiv 1 \\pmod 4$ and $g = +i\\sqrt{p}$ for $p \\equiv 3 \\pmod 4$ (Gauss's hard theorem) — be formalized in Lean 4 on top of this dichotomy, e.g. via Schur's eigenvalue argument on the finite Fourier transform?",
+      "Does the dichotomy-from-square-sign mechanism extend to higher-order Gauss sums, where the square (or higher power) lands on a denser set of rays in $\\mathbb{C}$?",
+      "Can the magnitude $\\lVert g \\rVert^2 = p$ be derived directly from character orthogonality (Parseval) as an independent cross-check on the square-identity route used here?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "quadratic-gauss-sum-square",
+      "relationship": "extends",
+      "description": "This entry is the direct sequel: it takes the parent's square identity g² = (-1)^((p-1)/2)·p as its sole mathematical input and extracts the real/imaginary dichotomy and magnitude from it by complex arithmetic."
+    },
+    {
+      "proofId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "The sign (-1)^((p-1)/2) that decides whether g is real or imaginary is the first supplement to quadratic reciprocity; the dichotomy makes the p mod 4 distinction geometrically visible in the complex plane."
+    },
+    {
+      "proofId": "gauss-wilson-non-cyclic",
+      "relationship": "related",
+      "description": "Both entries study the quadratic residue character of (ZMod p)×; the Gauss sum whose location is pinned here is the discrete Fourier transform of that character."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/QuadraticGaussSumSquareOQ01.lean",
+    "axiomCount": 0,
+    "lineCount": 116,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "header-and-imports",
+      "title": "Setup: the Square Identity and What Remains",
+      "startLine": 1,
+      "endLine": 34,
+      "summary": "The module docstring recalls the parent's square identity g² = (-1)^((p-1)/2)·p and states the goal: the elementary real/imaginary dichotomy (g real for p ≡ 1, imaginary for p ≡ 3 mod 4) plus magnitude ‖g‖² = p, leaving only the leading ± of Gauss's hard theorem open. Imports `Mathlib` and the parent `Proofs.QuadraticGaussSumSquare`, opens the namespace and fixes `variable {p : ℕ} [Fact p.Prime]`."
+    },
+    {
+      "id": "arithmetic-lemmas",
+      "title": "Complex Arithmetic: a Square that is Real Forces an Axis",
+      "startLine": 36,
+      "endLine": 69,
+      "summary": "`im_eq_zero_of_sq_eq_pos_real`: if z² is a positive real r then z is real. Taking Im and Re of z² = r gives 2·Re(z)·Im(z) = 0 and Re(z)² − Im(z)² = r; the product splitting plus the exclusion Re(z) = 0 ⟹ −Im(z)² = r > 0 (impossible) forces Im(z) = 0. `re_eq_zero_of_sq_eq_neg_real` is the mirror lemma for negative reals. Both run on `Complex.mul_re`/`mul_im`, `linarith`, `nlinarith`, and `mul_self_nonneg`."
+    },
+    {
+      "id": "dichotomy-one-mod-four",
+      "title": "Case p ≡ 1 (mod 4): g is Real",
+      "startLine": 71,
+      "endLine": 81,
+      "summary": "`gaussSum_im_eq_zero_of_one_mod_four`: from `Even ((p-1)/2)` (via `Nat.even_iff` + `omega`) the sign factor is 1, so the parent gives g² = +p, a positive real; `im_eq_zero_of_sq_eq_pos_real` then yields Im g = 0."
+    },
+    {
+      "id": "dichotomy-three-mod-four",
+      "title": "Case p ≡ 3 (mod 4): g is Purely Imaginary",
+      "startLine": 83,
+      "endLine": 95,
+      "summary": "`gaussSum_re_eq_zero_of_three_mod_four`: from `Odd ((p-1)/2)` the sign factor is −1, so g² = −p, a negative real; `re_eq_zero_of_sq_eq_neg_real` yields Re g = 0."
+    },
+    {
+      "id": "magnitude",
+      "title": "Magnitude: ‖g‖² = p",
+      "startLine": 97,
+      "endLine": 116,
+      "summary": "`gaussSum_normSq_eq`: applying the multiplicative `Complex.normSq` to g² = (-1)^((p-1)/2)·p gives normSq(g)² = p²; with `Complex.normSq_nonneg` and `nlinarith` this forces normSq g = p, i.e. |g| = √p, independent of p mod 4 and of the open leading sign."
+    }
+  ],
+  "references": [
+    {
+      "title": "Disquisitiones Arithmeticae",
+      "author": "C. F. Gauss",
+      "year": 1801,
+      "note": "Introduces Gauss sums and the g² identity; the determination of the sign of g itself was completed by Gauss only in 1805."
+    },
+    {
+      "title": "A Classical Introduction to Modern Number Theory",
+      "author": "K. Ireland and M. Rosen",
+      "year": 1990,
+      "note": "Chapter 6 develops Gauss sums, the identity g² = (-1)^((p-1)/2)·p, and the sign theorem; the real/imaginary dichotomy is the immediate corollary isolated here."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions and Data.Complex",
+      "author": "The Mathlib Community",
+      "year": 2024,
+      "note": "Provides `Complex.mul_re`, `Complex.mul_im`, and `Complex.normSq` used in the arithmetic lemmas."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
Proves the elementary half of Gauss's sign theorem: the **real/imaginary dichotomy** of the quadratic Gauss sum `g = gaussSum (chiC p) ψ` for an odd prime `p`.

From the parent square identity `g² = (-1)^((p-1)/2)·p`:
- `p ≡ 1 (mod 4)` ⟹ `g² = +p > 0` ⟹ `g.im = 0` (real)
- `p ≡ 3 (mod 4)` ⟹ `g² = -p < 0` ⟹ `g.re = 0` (imaginary)
- magnitude `‖g‖² = p`, so `g = ±√p` resp. `±i√p`

The leading `±` sign is the genuinely deep open theorem (Schur eigenvalue / Dirichlet analytic evaluation) and is **not** claimed here.

116 lines, 5 theorems, 0 sorry / 0 axiom / 0 native_decide. Build verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)