### PR TITLE
audit(quadratic-gauss-sum-square-oq-01): clean — durable tracker entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15991,8 +15991,14 @@
       "lastAudited": "2026-06-19T06:35:49Z",
       "result": "clean",
       "issues": []
+    },
+    "quadratic-gauss-sum-square-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T06:45:37Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-19T06:10:21Z"
+  "lastUpdated": "2026-06-19T06:45:37Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: \`quadratic-gauss-sum-square-oq-01\` (Real/Imaginary Dichotomy of the Quadratic Gauss Sum)
**Result**: CLEAN — no overclaim, no integrity issue.

### Verification (static, conclusive)

| Check | meta.json | Lean source | OK |
|-------|-----------|-------------|-----|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 `axiom` decls | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 0 | 0 (def `chiC` lives in parent) | ✓ |
| lineCount | 116 | 116 | ✓ |
| status / badge | `verified` / `mathlib` | honest | ✓ |

### Notes
- The two arithmetic lemmas (`im_eq_zero_of_sq_eq_pos_real`, `re_eq_zero_of_sq_eq_neg_real`) and the two dichotomy theorems are genuinely proved **in-file** from the parent's square identity `gaussSum_quadratic_sq`.
- Parent `Proofs/QuadraticGaussSumSquare.lean` is itself 0-sorry / 0-axiom (an honest Mathlib bridge over `gaussSum_sq`), so the `verified` claim is not masking a transitive assumption. Badge `mathlib` correctly reflects the Mathlib gaussSum infrastructure reliance — conservative, no overclaim.
- Title carries the qualifier "Dichotomy"; description/conclusion explicitly state the leading ± sign (Gauss's hard theorem) **remains open**. No axiom-masking, no inequality-as-theorem, no delegation opacity. **LOW** claim-risk.

### Why this PR
The entry merged via #26018 but had **no entry in the main `audit-tracker.json`**, so `find-targets --next` re-serves it every cycle. This adds the missing clean tracker entry (+7 lines) to break the loop — same durable-fix class as #26000 / #26017.

---
Discovered during autonomous gallery integrity audit. Gallery now 2547/2547 audited.