### PR TITLE
research(quadratic-gauss-sum-square): survey sign-determination frontier (docs-only)

### DIFF
--- a/research/problems/quadratic-gauss-sum-square/knowledge.md
+++ b/research/problems/quadratic-gauss-sum-square/knowledge.md
@@ -90,3 +90,51 @@ Docker build verification was pending at session end (build host saturated).
 2. Create the gallery entry `src/data/proofs/quadratic-gauss-sum-square/` with badge
    `mathlib`, axiomCount 0, cross-referenced to `elementary-quadratic-reciprocity*`
    (headline application: `g^p` two-ways gives reciprocity).
+
+---
+
+## Session 2026-06-18 (s02) — OQ-01 dichotomy MERGED + sign-frontier survey
+
+**Mode**: FRESH (follow-up after SOLVED) · **Outcome**: completed (OQ-01) + scouted (sign)
+
+### What I did
+- Confirmed the follow-up **OQ-01 real/imaginary dichotomy** (`QuadraticGaussSumSquareOQ01.lean`,
+  116L / 5 thm / 0 sorry / 0 axiom) is **merged to main as PR #26018**
+  (commit `e79e8699219`). It derives, purely from the parent square identity
+  `g² = (-1)^((p-1)/2)·p`, the elementary half of Gauss's evaluation:
+  - `p ≡ 1 (4)` ⟹ `g² = +p > 0` ⟹ `g.im = 0` (g real);
+  - `p ≡ 3 (4)` ⟹ `g² = −p < 0` ⟹ `g.re = 0` (g imaginary);
+  - magnitude `normSq g = p` (so `g = ±√p` resp. `±i√p`).
+  Reusable lemmas: `im_eq_zero_of_sq_eq_pos_real`, `re_eq_zero_of_sq_eq_neg_real`.
+
+### Frontier: the sign determination (`±`) — buildability assessment
+The only remaining gap is the leading **sign** — Gauss's hard 1805 theorem:
+`g = +√p` (p≡1 mod 4), `g = +i√p` (p≡3 mod 4), with the *positive* root in both cases.
+Web-confirmed (June 2026) that **Mathlib still has only the square** (`gaussSum_sq`);
+no sign/exact-value lemma exists.
+
+Three known routes, all large:
+1. **Schur eigenvalue argument** — the order-4 DFT matrix `F` on `ZMod p` has
+   eigenvalues in `{±√p, ±i√p}`; `tr F` equals the Gauss sum, and a *second*
+   computation of `tr F` via eigenvalue multiplicities (which split by `p mod 4`)
+   pins the sign. **Mathlib gap**: multiplicity decomposition of the finite Fourier
+   transform / its characteristic polynomial. Est. >800 L.
+2. **Poisson summation / theta functional equation** (Dirichlet) — limiting argument
+   from the Jacobi theta transformation. **Mathlib gap**: the specialized theta
+   functional equation + the limit. Heavy analysis, est. >1000 L.
+3. **Finite Weil representation** (arXiv:0808.2447) — elegant but needs Weil-rep infra
+   Mathlib entirely lacks.
+
+**Decision: SURVEYED (large-infra, not a single-session target, NOT an Aristotle
+quick-win).** The Schur route is the most self-contained; the realistic next step is to
+isolate sub-lemma "the `p×p` DFT matrix satisfies `F⁴ = p²·I`" as standalone
+infrastructure before attempting multiplicities. Until that infra exists the sign stays
+blocked-by-scale (>500 L), not blocked-by-impossibility.
+
+### Files
+- (merged) `proofs/Proofs/QuadraticGaussSumSquareOQ01.lean`, `Proofs.lean`,
+  `src/data/proofs/quadratic-gauss-sum-square-oq-01/`
+
+### Next steps
+- If revisiting the sign: start with the standalone DFT lemma `F⁴ = p²·I` (Schur route).
+- Fleet was saturated (load ~120) this session → no new builds attempted; survey only.

--- a/src/data/research/problems/quadratic-gauss-sum-square.json
+++ b/src/data/research/problems/quadratic-gauss-sum-square.json
@@ -34,25 +34,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: full 0-sorry 0-axiom proof of g^2 = (-1)^((p-1)/2)·p via gaussSum_sq; build-pending.",
+    "progressSummary": "PROGRESS: OQ-01 dichotomy (elementary half) merged #26018; remaining sign determination SURVEYED as large-infra (>500L) frontier",
     "builtItems": [
       "chiC : MulChar (ZMod p) ℂ — ℤ-valued quadratic character transported along Int.castRingHom ℂ (Proofs/QuadraticGaussSumSquare.lean)",
       "chiC_isQuadratic via MulChar.IsQuadratic.comp (Proofs/QuadraticGaussSumSquare.lean)",
       "chiC_ne_one via MulChar.ringHomComp_ne_one_iff + RingHom.injective_int + quadraticChar_ne_one (Proofs/QuadraticGaussSumSquare.lean)",
       "chiC_neg_one : chiC p (-1) = (-1)^((p-1)/2) via quadraticChar_neg_one + ZMod.χ₄_eq_neg_one_pow (Proofs/QuadraticGaussSumSquare.lean)",
-      "gaussSum_quadratic_sq : gaussSum (chiC p) ψ ^ 2 = (-1)^((p-1)/2) * p (Proofs/QuadraticGaussSumSquare.lean)"
+      "gaussSum_quadratic_sq : gaussSum (chiC p) ψ ^ 2 = (-1)^((p-1)/2) * p (Proofs/QuadraticGaussSumSquare.lean)",
+      "QuadraticGaussSumSquareOQ01.lean (merged, 116L/5thm/0sorry/0ax): im_eq_zero_of_sq_eq_pos_real, re_eq_zero_of_sq_eq_neg_real, gaussSum_im/re_eq_zero dichotomy, gaussSum_normSq_eq"
     ],
     "insights": [
       "quadraticChar (ZMod p) is ℤ-valued; gaussSum needs χ and ψ to share a codomain, so transport via MulChar.ringHomComp (Int.castRingHom ℂ).",
       "The entire result reduces to Mathlib's gaussSum_sq; no need to reimplement the g·ḡ = p orthogonality computation.",
       "quadraticChar_neg_one packages the χ₄ evaluation directly — shorter than the legendreSym.at_neg_one chain.",
-      "For odd p, p/2 = (p-1)/2 closes by omega after destructuring Odd p."
+      "For odd p, p/2 = (p-1)/2 closes by omega after destructuring Odd p.",
+      "OQ-01 dichotomy merged (PR #26018): from g²=(-1)^((p-1)/2)·p alone, p≡1(4)⟹g real, p≡3(4)⟹g imaginary, normSq g=p — only the leading ± sign remains open"
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "Mathlib has only gaussSum_sq (the square); no sign/exact-value of the quadratic Gauss sum (Gauss 1805). Sign needs: DFT eigenvalue multiplicities (Schur, >800L) OR theta functional equation (Dirichlet, >1000L) OR finite Weil representation"
+    ],
     "nextSteps": [
       "Confirm green Docker build of Proofs.QuadraticGaussSumSquare, then flip gallery status to verified.",
       "Create gallery entry src/data/proofs/quadratic-gauss-sum-square/ (badge mathlib, axiomCount 0).",
-      "Cross-reference to elementary-quadratic-reciprocity* (headline application: g^p two-ways gives reciprocity)."
+      "Cross-reference to elementary-quadratic-reciprocity* (headline application: g^p two-ways gives reciprocity).",
+      "Sign frontier: isolate standalone DFT lemma F⁴=p²·I (Schur route) before attempting eigenvalue multiplicities; classified SURVEYED/large-infra, not an Aristotle quick-win"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Post-SOLVED follow-up survey for the quadratic Gauss sum, after the **OQ-01 real/imaginary dichotomy merged in #26018**.

This is a **documentation-only** PR (`knowledge.md` + problem JSON) — no Lean or build changes, fleet-safe under saturation.

## What's recorded
- OQ-01 dichotomy (`QuadraticGaussSumSquareOQ01.lean`, 116L/5thm/0sorry/0ax) is merged: from `g²=(-1)^((p-1)/2)·p` alone ⟹ p≡1(4)⟹g real, p≡3(4)⟹g imaginary, `normSq g=p`.
- **Only remaining gap**: Gauss's 1805 sign determination (`g=+√p` for p≡1, `g=+i√p` for p≡3 — the *positive* root). Web-confirmed (June 2026) Mathlib still has only `gaussSum_sq` (the square); no sign lemma.

## Buildability assessment of the sign frontier
Three known routes, all large:
1. **Schur eigenvalue** — DFT matrix eigenvalue multiplicities split by p mod 4. Gap: multiplicity decomposition of the finite Fourier transform. ~800L.
2. **Theta functional equation** (Dirichlet/Poisson). Gap: specialized theta transformation + limit. >1000L.
3. **Finite Weil representation** (arXiv:0808.2447). Gap: Weil-rep infra absent from Mathlib.

**Decision: SURVEYED / large-infra** — not a single-session target, not an Aristotle quick-win. Concrete next step recorded: isolate standalone DFT lemma `F⁴=p²·I` (Schur route) before attempting multiplicities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)