### PR TITLE
audit(erdos-mordell-inequality-oq-01): record CLEAN — durable tracker entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15997,6 +15997,12 @@
       "lastAudited": "2026-06-19T06:45:37Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-mordell-inequality-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T06:54:42Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: erdos-mordell-inequality-oq-01 (the sole unaudited gallery entry; 2547→2548/2548)

Verified `meta.json` against `proofs/Proofs/ErdosMordellInequalityOQ01.lean`:

| Claim | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 3 | 3 (`key_inequality_A/B/C`) | ✓ |
| axiomCount | 0 | 0 axiom decls, 0 structure-encoded assumptions | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| theoremCount | 8 | 8 | ✓ |
| definitionCount | 1 | 1 (`lineDist`) | ✓ |
| status / badge | formalized / wip | honest Tier C scaffold | ✓ |

**Tier C (scaffold / reduction)** — correctly classified. The geometry-free
algebraic core (`erdos_mordell_reduction`, `key_inequality_trig_core`,
`key_inequality_of_chord_and_sines`) is fully proved; the full geometric
`erdos_mordell` is assembled modulo the three genuinely-geometric
`key_inequality_*` lemmas (the 3 sorries). Title ("Algebraic Reduction Core")
and description ("assembled modulo the three geometric key inequalities")
qualify the result honestly — no overclaiming. **Risk: LOW.**

## Why this PR

The entry is a fresh research result absent from main's `audit-tracker.json`,
so `find-targets` keys "unaudited" on the main tracker and re-serves it every
cycle even after a clean local audit. This adds the durable one-line tracker
entry to break the loop (same fix class as #26000 / #26017 / #26020).

---
Discovered during autonomous gallery integrity audit.