### PR TITLE
research(zsqrtd-neg-two-oq-01): fix ZMod-8 cast bug + register orphan (build-verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3144,6 +3144,7 @@ import Proofs.YangMillsMassGap
 import Proofs.YangMillsTransferMatrixOQ01
 import Proofs.ZetaFiveIrrationality
 import Proofs.ZsqrtdNegTwo
+import Proofs.ZsqrtdNegTwoOQ01
 import Proofs.ZsqrtdNegTwoOQ03
 import Proofs.ZsqrtdNegTwoOQ03OQ01
 import Proofs.eTranscendental

--- a/proofs/Proofs/ZsqrtdNegTwoOQ01.lean
+++ b/proofs/Proofs/ZsqrtdNegTwoOQ01.lean
@@ -56,9 +56,8 @@ theorem repr_mod_eight (p : ℕ) (hodd : p % 2 = 1)
     (a b : ℤ) (h : a ^ 2 + 2 * b ^ 2 = (p : ℤ)) : p % 8 = 1 ∨ p % 8 = 3 := by
   -- (A) Reduce the representing identity modulo 8.
   have h8 : (a : ZMod 8) ^ 2 + 2 * (b : ZMod 8) ^ 2 = (p : ZMod 8) := by
-    have hh := congrArg (fun z : ℤ => (z : ZMod 8)) h
-    push_cast at hh
-    exact_mod_cast hh
+    have hh := congrArg (Int.castRingHom (ZMod 8)) h
+    simpa using hh
   -- (B) `x² + 2 y²` is never `5` or `7` in `ZMod 8` (finite check).
   have hforbidden : ∀ x y : ZMod 8, x ^ 2 + 2 * y ^ 2 ≠ 5 ∧ x ^ 2 + 2 * y ^ 2 ≠ 7 := by
     decide

--- a/src/data/proofs/zsqrtd-neg-two-oq-01/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-01/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "zsqrtd-neg-two-oq-01",
+  "title": "A Single Bi-Conditional for Primes p = x² + 2y²",
+  "slug": "zsqrtd-neg-two-oq-01",
+  "description": "The first open question on the parent gallery proof zsqrtd-neg-two ('ℤ[√−2]: Euclidean Domain and x² + 2y² Representations'). The parent proves the two forward implications p % 8 = 1 → ∃ a b, a² + 2b² = p and p % 8 = 3 → ∃ a b, a² + 2b² = p, but never assembles them — together with the missing converse and the even prime 2 = 0² + 2·1² — into one bi-conditional. This file supplies exactly that. The genuinely new content is the converse repr_mod_eight: if an odd natural number p is representable as a² + 2b² then p ≡ 1 or 3 (mod 8). The argument is elementary and entirely modular: in ZMod 8 the value x² + 2y² is never 5 or 7 (a finite decide check over the 64 pairs), so the odd residue p % 8 ∈ {1,3,5,7} is forced into {1,3}. The capstone prime_sq_add_two_sq_iff then states, for every prime p, (∃ a b : ℤ, a² + 2b² = p) ↔ (p = 2 ∨ p % 8 = 1 ∨ p % 8 = 3), with the forward direction combining the even-prime case with repr_mod_eight and the backward direction combining the explicit witness 2 = 0² + 2·1² with the parent's two forward theorems.",
+  "meta": {
+    "author": "Fermat (1654), Euler (1761), Lagrange (1775)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fermat%27s_theorem_on_sums_of_two_squares",
+    "date": "1761",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ZsqrtdNegTwoOQ01.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-forms",
+      "modular-arithmetic",
+      "primes",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 108,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. No native_decide is used (the ZMod 8 exclusion uses ordinary kernel `decide` over a finite type, which does not introduce Lean.ofReduceBool). The two forward representation theorems are imported from the parent file Proofs.ZsqrtdNegTwo.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.natCast_mod",
+        "description": "`((p % n : ℕ) : ZMod n) = (p : ZMod n)` — transports the two forbidden-residue exclusions in ZMod 8 back to statements about p % 8.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.eq_two_or_odd",
+        "description": "A prime is 2 or odd (`p = 2 ∨ p % 2 = 1`) — supplies the oddness hypothesis of repr_mod_eight in the forward direction of the bi-conditional.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "SqAddTwoSq.sq_add_two_sq_of_prime_one_mod_eight",
+        "description": "Parent theorem: a prime p ≡ 1 (mod 8) is of the form a² + 2b². Reused verbatim for the p % 8 = 1 branch of the backward direction.",
+        "module": "Proofs.ZsqrtdNegTwo"
+      },
+      {
+        "theorem": "SqAddTwoSq.sq_add_two_sq_of_prime_three_mod_eight",
+        "description": "Parent theorem: a prime p ≡ 3 (mod 8) is of the form a² + 2b². Reused verbatim for the p % 8 = 3 branch of the backward direction.",
+        "module": "Proofs.ZsqrtdNegTwo"
+      }
+    ],
+    "originalContributions": [
+      "repr_mod_eight: the converse direction — if an odd natural p is representable as a² + 2b² (a b : ℤ) then p ≡ 1 or 3 (mod 8). Primality is not required, only oddness. This is the new mathematical content the parent file omits.",
+      "The modular exclusion technique: the achievable values of x² + 2y² in ZMod 8 are exactly {0,1,2,3,4,6}, so 5 and 7 are never hit; intersecting with the odd residues {1,3,5,7} forces {1,3}. The exclusion is a single 64-case `decide` over ZMod 8 × ZMod 8.",
+      "prime_sq_add_two_sq_iff: the unified bi-conditional (∃ a b : ℤ, a² + 2b² = p) ↔ (p = 2 ∨ p % 8 = 1 ∨ p % 8 = 3) for every prime p, assembling the parent's two forward theorems, the even-prime witness, and the new converse into the single statement the open question asks for."
+    ],
+    "prerequisites": [
+      "Modular arithmetic in ZMod n",
+      "Fermat-style sum-of-two-squares representation theorems",
+      "The parent proof zsqrtd-neg-two (ℤ[√−2] as a Euclidean domain)"
+    ],
+    "dateAdded": "2026-06-18",
+    "relatedProblems": [
+      {
+        "id": "zsqrtd-neg-two",
+        "relationship": "Completes: assembles the parent's two forward implications, the even prime, and the missing converse into one bi-conditional"
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 108,
+    "path": "Proofs/ZsqrtdNegTwoOQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 2
+  },
+  "sorries": 0,
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "File docstring stating the open question (assemble the parent's forward implications, the even prime, and the missing converse into one ↔) and what is new (the converse repr_mod_eight). Imports Mathlib and the parent Proofs.ZsqrtdNegTwo (for the two forward representation theorems), and opens the SqAddTwoSq namespace.",
+      "mathContext": "The parent file zsqrtd-neg-two proves p ≡ 1,3 (mod 8) ⟹ p = a² + 2b² via the Euclidean structure of ℤ[√−2]. The open question asks only for the missing assembly and converse — no new ring theory, just an elementary modular exclusion."
+    },
+    {
+      "id": "converse",
+      "title": "The Converse: repr_mod_eight",
+      "startLine": 51,
+      "endLine": 80,
+      "summary": "Proves that an odd natural p with a² + 2b² = p satisfies p % 8 ∈ {1,3}. (A) reduces the integer identity modulo 8 by congrArg + push_cast. (B) a 64-case `decide` shows x² + 2y² is never 5 or 7 in ZMod 8. (C) transports the two exclusions back to p % 8 via ZMod.natCast_mod. (D) omega closes: p % 8 < 8 is odd and avoids 5,7, hence equals 1 or 3.",
+      "mathContext": "An odd p forces a odd, so a² ≡ 1 (mod 8); and 2b² ≡ 0 or 2 (mod 8); summing gives p ≡ 1 or 3 (mod 8). The ZMod 8 `decide` packages this case analysis without manual parity bookkeeping."
+    },
+    {
+      "id": "iff",
+      "title": "The Unified Bi-Conditional: prime_sq_add_two_sq_iff",
+      "startLine": 81,
+      "endLine": 108,
+      "summary": "States and proves (∃ a b : ℤ, a² + 2b² = p) ↔ (p = 2 ∨ p % 8 = 1 ∨ p % 8 = 3) for prime p. Forward: split on p = 2, else use Nat.Prime.eq_two_or_odd to get oddness and apply repr_mod_eight. Backward: the p = 2 branch gives the witness ⟨0,1⟩, the p % 8 = 1 and = 3 branches invoke the parent's two forward theorems (after supplying the Fact (Nat.Prime p) instance). Four `example` sanity checks pin small primes 2, 3, 11, 17.",
+      "mathContext": "This is the complete characterization of primes representable by the principal form x² + 2y² of discriminant −8, the n = 2 analog of Fermat's two-squares theorem (n = 1: p = x² + y² ⟺ p = 2 ∨ p ≡ 1 mod 4)."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The representation of primes by the binary quadratic form x² + 2y² was studied by Fermat (who stated the characterization in his 1654 correspondence with Pascal) and proved by Euler (1761) and Lagrange (1775), as part of the broader theory of which primes are represented by forms of small discriminant. For discriminant −8 the form x² + 2y² is the principal form, and the classical result is that an odd prime p is represented iff p ≡ 1 or 3 (mod 8) — equivalently iff −2 is a quadratic residue mod p. The parent gallery proof zsqrtd-neg-two formalizes the two forward implications via the Euclidean structure of ℤ[√−2]; this file supplies the elementary converse and assembles the single bi-conditional.",
+    "problemStatement": "Open Question (zsqrtd-neg-two-oq-01): the parent proof proves the two forward implications p % 8 = 1 → ∃ a b, a² + 2b² = p and p % 8 = 3 → ∃ a b, a² + 2b² = p separately, but never states the converse or the unified bi-conditional. Produce the single ↔ statement: for every prime p, (∃ a b : ℤ, a² + 2b² = p) ↔ (p = 2 ∨ p % 8 = 1 ∨ p % 8 = 3).",
+    "text": "Completes the parent x² + 2y² gallery proof by adding the converse (odd representable ⟹ p ≡ 1,3 mod 8) and the unified bi-conditional for all primes.",
+    "proofStrategy": "The only new content is the converse, proved by a modular exclusion in ZMod 8: reduce a² + 2b² = p modulo 8, observe (by a finite 64-case `decide`) that x² + 2y² never equals 5 or 7 there, transport the exclusion back to p % 8 with ZMod.natCast_mod, and let omega finish from 'p % 8 < 8, odd, ≠ 5, ≠ 7'. The bi-conditional then glues this converse to the parent's two forward theorems and the explicit even-prime witness 2 = 0² + 2·1².",
+    "keyInsights": [
+      "The converse needs no primality — only oddness. An odd p forces the ℤ-coefficient a to be odd (since 2b² is even), and odd squares are ≡ 1 (mod 8), while 2b² ≡ 0 or 2 (mod 8); the sum lands in {1,3}.",
+      "Working in ZMod 8 turns the parity bookkeeping into one decidable finite check: the image of (x,y) ↦ x² + 2y² over ZMod 8 × ZMod 8 is {0,1,2,3,4,6}, so 5 and 7 are unreachable. This is ordinary kernel `decide`, not native_decide, so it adds no axioms.",
+      "The forward direction is entirely reuse: the parent's sq_add_two_sq_of_prime_one_mod_eight and sq_add_two_sq_of_prime_three_mod_eight discharge the two odd residue classes, and 2 = 0² + 2·1² handles the even prime — no ring theory is re-derived.",
+      "Discriminant −8 is special among small forms: x² + 2y² is the unique reduced form of its discriminant (class number 1), which is exactly why a clean congruence condition mod 8 characterizes representability. The same phenomenon underlies the parent's choice of ℤ[√−2], whose maximal order coincides with ℤ[√−2] itself."
+    ],
+    "prerequisites": [
+      "Modular arithmetic and ZMod n",
+      "Binary quadratic forms of small discriminant",
+      "Fermat's theorem on sums of two squares (the n = 1 analog)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Adds the converse repr_mod_eight (odd p representable as a² + 2b² ⟹ p ≡ 1 or 3 mod 8) and the unified bi-conditional prime_sq_add_two_sq_iff for every prime p, the exact statement the open question requested. The file is 108 lines, 2 theorems, 0 definitions, 0 sorries, 0 axioms, no native_decide.",
+    "implications": "The parent gallery proof zsqrtd-neg-two now has a complete iff-characterization of the primes it represents, rather than two unconnected forward implications. The modular-exclusion converse technique transfers directly to the sibling open questions on x² + 3y² (Eisenstein, oq-03) and the higher Heegner forms.",
+    "openQuestions": [
+      "State and prove the analogous converse and bi-conditional for x² + 3y² (p = 3 ∨ p ≡ 1 mod 3), building on the Eisenstein-integer Euclidean structure formalized in zsqrtd-neg-two-oq-03.",
+      "Lift the residue-set computation to a general lemma: for squarefree n with class number 1, the image of x² + n y² in ZMod (4n) determines representability, mechanizing the congruence characterization uniformly rather than per-discriminant."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "zsqrtd-neg-two",
+      "relationship": "parent",
+      "description": "The parent proof formalizes ℤ[√−2] as a Euclidean domain and proves the two forward implications p ≡ 1,3 (mod 8) ⟹ p = a² + 2b². This file imports those two theorems and completes the characterization with the converse and the unified bi-conditional."
+    },
+    {
+      "targetId": "zsqrtd-neg-two-oq-03",
+      "relationship": "sibling",
+      "description": "The n = 3 open question (Eisenstein integers ℤ[ω], toward x² + 3y²). The modular-exclusion converse technique used here transfers to the x² + 3y² characterization once the Eisenstein splitting argument lands."
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "foundational",
+      "description": "The classical statement 'odd prime p is x² + 2y² iff p ≡ 1,3 (mod 8)' is equivalent to '−2 is a quadratic residue mod p', a standard consequence of quadratic reciprocity and its supplements. This file proves the congruence form directly by modular exclusion rather than via the Legendre symbol."
+    }
+  ]
+}


### PR DESCRIPTION
Fixes the orphaned `ZsqrtdNegTwoOQ01.lean` (merged via #25972 but never registered and not compiling) and registers it in `Proofs.lean` with gallery meta.

**Bug:** `repr_mod_eight` used `congrArg (fun z => (z:ZMod 8)) h` + `push_cast`, leaving `↑(a^2)` un-pushed through `^`; `exact_mod_cast` could not reconcile with `(↑a)^2`. Fixed by mapping `h` through `Int.castRingHom (ZMod 8)` so ring-hom simp lemmas push casts uniformly.

**Contents:** 2 theorems (`repr_mod_eight`, `prime_sq_add_two_sq_iff`), 0 sorry / 0 axiom / 0 native_decide. Gallery meta verified/original/0-axiom.

Build-verified green. Supersedes stale #25978 (whose branch reverts merged work).