### PR TITLE
Enrich erdos-mordell-inequality-oq-01: annotations + cross-refs

### DIFF
--- a/src/data/proofs/erdos-mordell-inequality-oq-01/annotations.json
+++ b/src/data/proofs/erdos-mordell-inequality-oq-01/annotations.json
@@ -1,0 +1,149 @@
+[
+  {
+    "id": "ann-erdos-mordell-oq-01-01",
+    "proofId": "erdos-mordell-inequality-oq-01",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "context",
+    "title": "Erdős–Mordell: Statement, History, and Proof Architecture",
+    "content": "Paul Erdős posed this inequality as Problem 3740 in the American Mathematical Monthly in 1935; Mordell and Barrow supplied the first proof in 1937. For a point P interior to triangle ABC, the sum of distances to the vertices is at least twice the sum of distances to the sides — PA + PB + PC ≥ 2(da + db + dc) — with equality exactly when ABC is equilateral and P is its center. The formalization deliberately factors the classical argument into two independent pieces: a purely algebraic AM–GM reduction (proved here, geometry-free) and three geometric 'key inequalities' a·PA ≥ b·dc + c·db (and cyclic) that carry all the planar-geometry content. This separation lets the reusable algebraic heart be verified completely while isolating the single hard step. The result is not yet in Mathlib.",
+    "mathContext": "$PA + PB + PC \\ge 2(d_a + d_b + d_c)$, equality iff $ABC$ equilateral and $P$ its center.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Erdős–Mordell inequality",
+      "pedal distances",
+      "triangle geometry",
+      "geometric inequalities",
+      "modular formalization"
+    ],
+    "prerequisites": [
+      "Euclidean plane geometry",
+      "triangle inequalities"
+    ]
+  },
+  {
+    "id": "ann-erdos-mordell-oq-01-02",
+    "proofId": "erdos-mordell-inequality-oq-01",
+    "range": { "startLine": 64, "endLine": 101 },
+    "type": "technique",
+    "title": "The AM–GM Algebraic Reduction (Proved Core)",
+    "content": "erdos_mordell_reduction is the geometry-free heart: it assumes only the three weighted key inequalities, side-length positivity, and pedal-distance nonnegativity, and derives the full bound 2(da+db+dc) ≤ PA+PB+PC. Each key inequality is scaled by the product of the two OTHER side lengths so all three share the common factor a·b·c; summing them, every pedal distance picks up a coefficient of the form t + 1/t, which is ≥ 2 by AM–GM. The proof is closed by handing nlinarith an explicit nonnegative SOS-style certificate: a·b·c·(PA+PB+PC) − 2a·b·c·(da+db+dc) equals a·da·(b−c)² + b·db·(a−c)² + c·dc·(a−b)² plus the key-inequality slack, each summand manifestly ≥ 0. The final le_of_mul_le_mul_left cancels the positive factor a·b·c.",
+    "mathContext": "$abc\\,(PA{+}PB{+}PC) - 2abc\\,(d_a{+}d_b{+}d_c) = a d_a (b{-}c)^2 + b d_b (a{-}c)^2 + c d_c (a{-}b)^2 + \\text{slack} \\ge 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "AM–GM inequality",
+      "sum-of-squares certificate",
+      "nlinarith",
+      "t + 1/t ≥ 2"
+    ],
+    "prerequisites": [
+      "AM–GM inequality",
+      "polynomial inequalities",
+      "Lean nlinarith tactic"
+    ]
+  },
+  {
+    "id": "ann-erdos-mordell-oq-01-03",
+    "proofId": "erdos-mordell-inequality-oq-01",
+    "range": { "startLine": 103, "endLine": 143 },
+    "type": "insight",
+    "title": "Trigonometric Core: Collapse to a Perfect Square",
+    "content": "key_inequality_trig_core proves, with no geometry, that sin B·dc + sin C·db ≤ √(db² + dc² + 2·db·dc·cos A) for triangle angles (A+B+C = π) and nonnegative pedal distances. The mechanism: substitute cos A = sin B·sin C − cos B·cos C (valid because A = π − B − C, via cos_pi_sub and cos_add), then compare squares. After clearing the LHS square, the inequality reduces to the single perfect square (db·cos C − dc·cos B)² ≥ 0 — combined with sin² + cos² = 1 for both B and C, this is exactly what nlinarith needs. Square roots are taken via Real.sqrt_sq on the nonnegative LHS and Real.sqrt_le_sqrt. The right-hand √(…) is precisely PA·sin A once the geometric chord identity is supplied, so this lemma carries all the trigonometry, leaving only the chord identity as geometric debt.",
+    "mathContext": "$\\sin B\\, d_c + \\sin C\\, d_b \\le \\sqrt{d_b^2 + d_c^2 + 2 d_b d_c \\cos A}$, reducing to $(d_b\\cos C - d_c\\cos B)^2 \\ge 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "law of cosines",
+      "angle-sum identities",
+      "perfect-square certificate",
+      "Pythagorean identity"
+    ],
+    "prerequisites": [
+      "trigonometric identities",
+      "Cauchy–Schwarz / SOS reasoning"
+    ]
+  },
+  {
+    "id": "ann-erdos-mordell-oq-01-04",
+    "proofId": "erdos-mordell-inequality-oq-01",
+    "range": { "startLine": 145, "endLine": 186 },
+    "type": "technique",
+    "title": "Chord-to-Key Assembly: From Chord Identity + Law of Sines",
+    "content": "key_inequality_of_chord_and_sines is the verified bridge that converts the trig core into the side-length form of the key inequality. It takes exactly two geometric facts as hypotheses — the chord identity (PA·sin A)² = db² + dc² + 2·db·dc·cos A (concyclicity of the pedal feet on the circle of diameter PA) and the law of sines a = 2R sin A, b = 2R sin B, c = 2R sin C — and derives b·dc + c·db ≤ a·PA purely algebraically. The chord identity collapses the √(…) from the trig core to PA·sin A (via Real.sqrt_sq on the nonnegative product), giving sin B·dc + sin C·db ≤ PA·sin A; scaling by 2R > 0 and rewriting through the law of sines yields the side-length inequality. This sharpens each remaining open obligation from an opaque 'sorry' into the concrete task: exhibit the chord identity and law of sines for the specific Euclidean configuration.",
+    "mathContext": "$(PA\\sin A)^2 = d_b^2 + d_c^2 + 2 d_b d_c \\cos A$ and $a = 2R\\sin A \\Rightarrow b\\,d_c + c\\,d_b \\le a\\,PA$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "law of sines",
+      "circumradius",
+      "concyclic pedal feet",
+      "Ptolemy's inequality",
+      "chord projection"
+    ],
+    "prerequisites": [
+      "law of sines",
+      "cyclic quadrilaterals",
+      "circle of diameter PA"
+    ]
+  },
+  {
+    "id": "ann-erdos-mordell-oq-01-05",
+    "proofId": "erdos-mordell-inequality-oq-01",
+    "range": { "startLine": 188, "endLine": 196 },
+    "type": "definition",
+    "title": "Pedal Distance via Distance to the Affine Span",
+    "content": "lineDist P X Y is defined as Metric.infDist P (affineSpan ℝ {X, Y}) — the perpendicular distance from P to the line through X and Y, expressed as the infimum distance to the affine span rather than via an explicit foot-of-perpendicular construction. This is the cleanest Mathlib-native encoding of a pedal distance: it requires no choice of a projection point and immediately inherits nonnegativity from Metric.infDist_nonneg (lineDist_nonneg). The geometric statement of Erdős–Mordell uses lineDist for all three pedal distances da = lineDist P B C, db = lineDist P C A, dc = lineDist P A B.",
+    "mathContext": "$d(P, \\ell_{XY}) = \\operatorname{infDist}(P, \\operatorname{affineSpan}_{\\mathbb{R}}\\{X, Y\\}) \\ge 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "infimum distance",
+      "affine span",
+      "orthogonal projection",
+      "pedal triangle"
+    ],
+    "prerequisites": [
+      "metric spaces",
+      "affine geometry",
+      "EuclideanSpace"
+    ]
+  },
+  {
+    "id": "ann-erdos-mordell-oq-01-06",
+    "proofId": "erdos-mordell-inequality-oq-01",
+    "range": { "startLine": 198, "endLine": 228 },
+    "type": "context",
+    "title": "The Three Geometric Key Inequalities (Open Obligations)",
+    "content": "key_inequality_A/B/C are the three cyclic side-length-weighted bounds a·PA ≥ b·dc + c·db (and its rotations), stated over EuclideanSpace ℝ (Fin 2) and deferred with sorry. These three lemmas concentrate ALL the genuinely geometric content of Erdős–Mordell: each asserts that the feet of the perpendiculars from P to the two sides meeting at a vertex are concyclic with that vertex and P on a circle whose diameter is the vertex distance, and that projecting onto the chord between the feet yields the bound. They are cyclic images of one another (A → B → C). By key_inequality_of_chord_and_sines, closing each reduces precisely to supplying the chord identity and the law of sines for the concrete configuration — a well-defined planar-geometry task, not in Mathlib yet.",
+    "mathContext": "$a\\cdot PA \\ge b\\cdot d_c + c\\cdot d_b$, with cyclic permutations at $B$ and $C$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "concyclic points",
+      "Thales' circle",
+      "cyclic symmetry",
+      "perpendicular feet"
+    ],
+    "prerequisites": [
+      "circle geometry",
+      "inscribed angle theorem",
+      "orthogonal projection"
+    ]
+  },
+  {
+    "id": "ann-erdos-mordell-oq-01-07",
+    "proofId": "erdos-mordell-inequality-oq-01",
+    "range": { "startLine": 230, "endLine": 271 },
+    "type": "insight",
+    "title": "Final Assembly: Discharging Positivity and Algebra",
+    "content": "erdos_mordell stitches the pieces into the geometric statement for P interior to a nondegenerate triangle. Affine independence of ![A,B,C] gives an injective vertex indexing (hABC.injective), from which the three vertices are shown pairwise distinct by a Fin 3 decidability argument, hence the side lengths dist B C, dist C A, dist A B are strictly positive (dist_pos). Pedal nonnegativity comes from lineDist_nonneg. With positivity, nonnegativity, and the three key inequalities in hand, erdos_mordell_reduction delivers the bound. Everything except the three sorry-deferred key inequalities — all positivity, all nonnegativity, the entire AM–GM algebra — is fully discharged, so any future proof of the key inequalities immediately yields a complete, sorry-free Erdős–Mordell theorem.",
+    "mathContext": "$2(\\,d(P,\\ell_{BC}) + d(P,\\ell_{CA}) + d(P,\\ell_{AB})\\,) \\le PA + PB + PC$ for $P \\in \\operatorname{int}\\,\\triangle ABC$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "affine independence",
+      "convex hull interior",
+      "modular proof assembly",
+      "Fin 3 decidability"
+    ],
+    "prerequisites": [
+      "affine independence",
+      "convex geometry",
+      "EuclideanSpace metric"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
+++ b/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
@@ -115,7 +115,23 @@
       "summary": "erdos_mordell: the full geometric inequality, assembled from the reduction plus the three key inequalities, with side-length positivity (affine independence) and pedal nonnegativity fully discharged."
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "slug": "amgm-inequality",
+      "title": "Arithmetic Mean - Geometric Mean Inequality",
+      "relationship": "The algebraic reduction core rests entirely on AM–GM: each pedal distance acquires a coefficient t + 1/t ≥ 2, and the factor 2 in the Erdős–Mordell bound is exactly this AM–GM constant."
+    },
+    {
+      "slug": "ptolemys-theorem",
+      "title": "Ptolemy's Theorem",
+      "relationship": "The geometric key inequalities arise from the concyclicity of the pedal feet with P and a vertex on a circle of diameter PA; the chord-projection bound is a Ptolemy-type inequality on that cyclic configuration."
+    },
+    {
+      "slug": "triangle-inequality",
+      "title": "The Triangle Inequality",
+      "relationship": "Both are foundational distance inequalities in Euclidean geometry; Erdős–Mordell strengthens naive vertex-vs-side distance comparisons into a sharp weighted bound with an equality characterization."
+    }
+  ],
   "conclusion": {
     "summary": "The Erdős–Mordell inequality is formalized in the Euclidean plane and its geometry-free algebraic core (the AM–GM reduction) is fully proved. The full theorem is assembled modulo exactly three geometric key inequalities.",
     "implications": "The reduction is a reusable, Mathlib-independent component: any future formalization of the three key inequalities immediately yields a complete, sorry-free Erdős–Mordell proof. A full proof would be a valuable Mathlib contribution.",


### PR DESCRIPTION
Enrichment pass for `erdos-mordell-inequality-oq-01` (was quality 43, no annotations.json).

## Changes
- **annotations.json (new)**: 7 substantive annotations covering the full 271-line proof:
  1. Statement, history (Erdős 1935 / Mordell–Barrow 1937), and proof architecture
  2. The AM–GM algebraic reduction core (`erdos_mordell_reduction`) with its SOS certificate
  3. The trigonometric core collapsing to a perfect square `(db·cosC − dc·cosB)²`
  4. The chord-to-key assembly (chord identity + law of sines → key inequality)
  5. Pedal distance via `Metric.infDist` to the affine span
  6. The three open geometric key inequalities (concyclic pedal feet)
  7. Final assembly discharging positivity/nonnegativity/algebra
  
  Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- **meta.json crossReferences** (was empty): linked amgm-inequality, ptolemys-theorem, triangle-inequality with relationship notes.

Status/badge/axiomCount preserved (`formalized`/`wip`/0 axioms, 3 sorries — the three geometric key inequalities). Content verified against the Lean source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)