### PR TITLE
audit(zsqrtd-neg-two-oq-01): clean — durable tracker entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16003,6 +16003,12 @@
       "lastAudited": "2026-06-19T06:54:42Z",
       "result": "clean",
       "issues": []
+    },
+    "zsqrtd-neg-two-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T07:03:42Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: zsqrtd-neg-two-oq-01 — *A Single Bi-Conditional for Primes p = x² + 2y²*

Audited the sole remaining unaudited gallery entry. All meta.json claims verified against `proofs/Proofs/ZsqrtdNegTwoOQ01.lean`:

| Claim | meta.json | Source | ✓ |
|-------|-----------|--------|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no `axiom` decls) | ✓ |
| native_decide | none | 0 (plain kernel `decide` over ZMod 8²) | ✓ |
| theoremCount | 2 | 2 (`repr_mod_eight`, `prime_sq_add_two_sq_iff`) | ✓ |
| registered | — | `Proofs.lean:3149` | ✓ |

**Tier / badge**: `original` / `verified` is honest. The genuinely new content — the converse `repr_mod_eight` (odd representable ⟹ p ≡ 1,3 mod 8, via a 64-case `decide` exclusion in ZMod 8) and the unified bi-conditional — is independently proved here. The backward direction reuses the parent's two forward theorems (`sq_add_two_sq_of_prime_one/three_mod_eight`, present at `ZsqrtdNegTwo.lean:445,451`), and this reuse is disclosed in `mathlibDependencies` and `originalContributions`. Title is qualified, no overclaim. **LOW risk.**

**Why this PR**: the entry was merged (#26028) but is absent from the main `audit-tracker.json`, so `find-targets` keeps re-serving it. This adds the durable tracker entry to break the loop. Same fix class as #26000/#26017/#26020/#26027.

> Minor non-blocking note: the in-file docstring (lines 32–39) still reads "Build-pending… do not register", which is now stale — the file built green and is registered. Cosmetic source comment only; does not affect any public gallery claim. Left for a future research/enrichment pass to avoid a rebuild on an auditor tracker PR.

---
Discovered during gallery integrity audit.