### PR TITLE
research(erdos-mordell-oq-01): collapse 3 key inequalities to one shared vertex lemma

### DIFF
--- a/proofs/Proofs/ErdosMordellInequalityOQ01.lean
+++ b/proofs/Proofs/ErdosMordellInequalityOQ01.lean
@@ -41,15 +41,19 @@ The standard proof factors into two independent pieces:
 - [x] `key_inequality_trig_core` — geometry-free trig bound, PROVED.
 - [x] `key_inequality_of_chord_and_sines` — verified assembly: from the chord
   identity + law of sines, derives the key inequality `b·dc + c·db ≤ a·PA`, PROVED.
-- [ ] `key_inequality_*` — the three geometric key inequalities (OPEN / hard);
-  each now reduces to supplying the chord identity and the law of sines for the
-  concrete Euclidean configuration (see `key_inequality_of_chord_and_sines`).
-- [ ] `erdos_mordell` — assembled geometric statement (depends on the above).
+- [ ] `key_inequality_vertex` — the **single** geometry-bearing obligation (OPEN /
+  hard); it reduces to supplying the pedal-feet chord identity and the law of sines
+  for the concrete Euclidean configuration (see `key_inequality_of_chord_and_sines`).
+- [x] `key_inequality_A/B/C` — the three classical cyclic key inequalities, now
+  PROVED as the three relabelings of `key_inequality_vertex` (no extra geometry).
+- [x] `erdos_mordell` — assembled geometric statement, PROVED modulo
+  `key_inequality_vertex`.
 
 The reduction, the trig core, and the chord-to-key assembly are the reusable,
-Mathlib-independent heart of the argument; the remaining work is purely the
-planar-geometry derivation of the chord identity and law of sines (deferred —
-see knowledge notes).
+Mathlib-independent heart of the argument. The three cyclic key inequalities have
+been collapsed to a single shared lemma, so the *entire* remaining work is one
+planar-geometry fact: the chord identity (plus the now Mathlib-available law of
+sines, `EuclideanGeometry.dist_div_sin_angle_eq_two_mul_circumradius`).
 
 ## References
 - P. Erdős, *Problem 3740*, Amer. Math. Monthly 42 (1935), 396.
@@ -195,37 +199,71 @@ theorem lineDist_nonneg (P X Y : EuclideanSpace ℝ (Fin 2)) :
     0 ≤ lineDist P X Y :=
   Metric.infDist_nonneg
 
-/-- **Erdős–Mordell key inequality at vertex `A`.**
+/-- Affine independence is invariant under the cyclic relabeling
+`(X, Y, Z) ↦ (Y, Z, X)`. Plumbing for instantiating the shared key-inequality
+lemma at all three vertices. -/
+private theorem affineIndep_rotate {X Y Z : EuclideanSpace ℝ (Fin 2)}
+    (h : AffineIndependent ℝ ![X, Y, Z]) : AffineIndependent ℝ ![Y, Z, X] := by
+  have he : ![Y, Z, X] = ![X, Y, Z] ∘ (⟨![1, 2, 0], by decide⟩ : Fin 3 ↪ Fin 3) := by
+    funext i
+    fin_cases i <;>
+      simp [Function.comp, Function.Embedding.coeFn_mk, Matrix.cons_val_zero,
+        Matrix.cons_val_one, Matrix.head_cons]
+  rw [he]; exact h.comp_embedding _
 
-`a · PA ≥ b · dc + c · db`, with `a = BC`, `b = CA`, `c = AB`, `db = dist(P, CA)`,
-`dc = dist(P, AB)`. Geometrically: the feet of the perpendiculars from `P` to the
-two sides meeting at `A` are concyclic with `A` and `P` on a circle of diameter
-`PA`; projecting the chord between the feet gives this bound.
+/-- The interior of the triangle hull is invariant under the cyclic relabeling
+`(X, Y, Z) ↦ (Y, Z, X)` (the vertex set is unchanged). -/
+private theorem mem_interior_hull_rotate {X Y Z P : EuclideanSpace ℝ (Fin 2)}
+    (h : P ∈ interior (convexHull ℝ {X, Y, Z})) :
+    P ∈ interior (convexHull ℝ {Y, Z, X}) := by
+  have hs : ({Y, Z, X} : Set (EuclideanSpace ℝ (Fin 2))) = {X, Y, Z} := by
+    ext q; simp only [Set.mem_insert_iff, Set.mem_singleton_iff]; tauto
+  rw [hs]; exact h
 
-This is the geometry-bearing obligation (OPEN / hard to formalize); the other two
-are its cyclic images. -/
+/-- **Erdős–Mordell key inequality at a generic vertex `X`** (shared geometric core).
+
+For `P` interior to the nondegenerate triangle `X Y Z`, with adjacent sides `XY`
+and `ZX` and opposite side `YZ`,
+    `dist Z X · dist(P, line XY) + dist X Y · dist(P, line ZX) ≤ dist Y Z · dist P X`.
+
+This is the single geometry-bearing obligation. The three classical cyclic key
+inequalities `key_inequality_A/B/C` are *exactly* its three instantiations
+`(X, Y, Z) = (A, B, C), (B, C, A), (C, A, B)`, so proving this one fact discharges
+all three. Geometrically: the feet of the perpendiculars from `P` to the two sides
+meeting at `X` are concyclic with `X` and `P` on a circle of diameter `PX`; the
+pedal-feet chord identity plus the law of sines (`key_inequality_of_chord_and_sines`)
+then give the bound. -/
+theorem key_inequality_vertex
+    (X Y Z P : EuclideanSpace ℝ (Fin 2))
+    (hXYZ : AffineIndependent ℝ ![X, Y, Z])
+    (hP : P ∈ interior (convexHull ℝ {X, Y, Z})) :
+    dist Z X * lineDist P X Y + dist X Y * lineDist P Z X ≤ dist Y Z * dist P X := by
+  sorry
+
+/-- **Erdős–Mordell key inequality at vertex `A`** (instance of `key_inequality_vertex`). -/
 theorem key_inequality_A
     (A B C P : EuclideanSpace ℝ (Fin 2))
     (hABC : AffineIndependent ℝ ![A, B, C])
     (hP : P ∈ interior (convexHull ℝ {A, B, C})) :
-    dist C A * lineDist P A B + dist A B * lineDist P C A ≤ dist B C * dist P A := by
-  sorry
+    dist C A * lineDist P A B + dist A B * lineDist P C A ≤ dist B C * dist P A :=
+  key_inequality_vertex A B C P hABC hP
 
-/-- **Erdős–Mordell key inequality at vertex `B`** (cyclic image of `key_inequality_A`). -/
+/-- **Erdős–Mordell key inequality at vertex `B`** (cyclic instance of `key_inequality_vertex`). -/
 theorem key_inequality_B
     (A B C P : EuclideanSpace ℝ (Fin 2))
     (hABC : AffineIndependent ℝ ![A, B, C])
     (hP : P ∈ interior (convexHull ℝ {A, B, C})) :
-    dist A B * lineDist P B C + dist B C * lineDist P A B ≤ dist C A * dist P B := by
-  sorry
+    dist A B * lineDist P B C + dist B C * lineDist P A B ≤ dist C A * dist P B :=
+  key_inequality_vertex B C A P (affineIndep_rotate hABC) (mem_interior_hull_rotate hP)
 
-/-- **Erdős–Mordell key inequality at vertex `C`** (cyclic image of `key_inequality_A`). -/
+/-- **Erdős–Mordell key inequality at vertex `C`** (cyclic instance of `key_inequality_vertex`). -/
 theorem key_inequality_C
     (A B C P : EuclideanSpace ℝ (Fin 2))
     (hABC : AffineIndependent ℝ ![A, B, C])
     (hP : P ∈ interior (convexHull ℝ {A, B, C})) :
-    dist B C * lineDist P C A + dist C A * lineDist P B C ≤ dist A B * dist P C := by
-  sorry
+    dist B C * lineDist P C A + dist C A * lineDist P B C ≤ dist A B * dist P C :=
+  key_inequality_vertex C A B P (affineIndep_rotate (affineIndep_rotate hABC))
+    (mem_interior_hull_rotate (mem_interior_hull_rotate hP))
 
 /-- **Erdős–Mordell inequality** (geometric statement).
 

--- a/research/erdos-mordell-chord-identity-strategy.md
+++ b/research/erdos-mordell-chord-identity-strategy.md
@@ -65,19 +65,71 @@ gives `a = 2R·sin A`, etc. (search `circumradius`, `sin_angle`, `Sphere` for th
 exact name; if absent, derive from the inscribed-angle theorem applied to the
 circumcircle, same machinery as step 3).
 
-## Open risk / cost
+## 2026-06-19 update — de-risked, name-checked decomposition (no oangle needed)
 
-- Steps 2–3 are the heaviest: oriented-angle (`oangle`) bookkeeping and the
-  `Real.Angle`/`two_zsmul` factor-of-two are fiddly; budget several build
-  iterations.
-- `∠ F_b P F_c = π − A` (step 4) needs the cyclic-quadrilateral angle identity;
-  may be cleaner via `oangle_center_add...` than chasing unoriented angles.
-- Each of `key_inequality_B/C` is the cyclic image of `A`; once `A` is done,
-  `B/C` should follow by relabeling (consider a single private lemma parametrized
-  by the vertex/feet, instantiated three times).
+All required Mathlib lemmas were located by source grep and the heaviest
+(inscribed-angle / `oangle`) step has been **eliminated** by reusing the law of
+sines on the *pedal* triangle instead of chasing inscribed angles. Confirmed
+API (file:line in `proofs/.lake/packages/mathlib`):
 
-## Why not done now
+| Need | Lemma | Location |
+|------|-------|----------|
+| `lineDist = dist P (foot)` | `dist_orthogonalProjection_eq_infDist` | `Geometry/Euclidean/Projection.lean:300` |
+| Thales (right angle ⟺ on diameter sphere) | `thales_theorem` / `angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter` | `Angle/Sphere.lean:82,107` |
+| `Sphere.ofDiameter` (center=midpoint, radius=AP/2) | `Sphere.ofDiameter` | `Sphere/Basic.lean:304` |
+| circumcenter uniqueness | `eq_circumcenter_of_dist_eq` | `Circumcenter.lean:261` |
+| **law of sines** (used TWICE) | `dist_div_sin_angle_eq_two_mul_circumradius` | `Angle/Sphere.lean:430` |
+| law of cosines | `law_cos` | `Triangle.lean:252` |
 
-Heavy `EuclideanSpace` geometry needs many compile iterations; deferred while the
-fleet is saturated (OOM risk). The reduction + trig core + assembly are committed
-and build-green; this is the documented remaining geometric obligation.
+### Key simplification: chord length without inscribed angles
+
+Previously step 3 (`dist F_b F_c = PA·sin A`) was the riskiest — it called for
+oriented-angle / `two_zsmul` factor-of-two bookkeeping. **Replace it** by the law
+of sines applied to the pedal triangle `△(A, F_b, F_c)`:
+
+1. `F_b, F_c` see `AP` at a right angle ⟹ (Thales) both lie on
+   `Sphere.ofDiameter A P` (center `m = midpoint A P`, radius `dist A P / 2`).
+2. `A, P` also lie on that sphere trivially. So `dist m A = dist m F_b =
+   dist m F_c = dist A P / 2`. By `eq_circumcenter_of_dist_eq`, `m` is the
+   circumcenter of `△(A, F_b, F_c)` and its **circumradius is `dist A P / 2`**.
+3. Law of sines on `△(A, F_b, F_c)`:
+   `dist F_b F_c / sin(∠ F_b A F_c) = 2 · circumradius = dist A P`,
+   i.e. `dist F_b F_c = PA · sin(∠ F_b A F_c)`.
+4. `∠ F_b A F_c = ∠ B A C = A` because `F_b ∈ line CA` (ray from `A` toward `C`)
+   and `F_c ∈ line AB` (ray from `A` toward `B`) — the feet lie on the two sides
+   meeting at `A`, so the angle subtended at `A` is the triangle's angle `A`.
+   (This collinearity/ray step is the one remaining genuinely geometric fact;
+   for an interior point the feet land on the open segments, so same ray.)
+
+Then step 4 (law of cosines in `△ P F_b F_c`, `∠ F_b P F_c = π − A`) gives
+`dist F_b F_c² = db² + dc² + 2·db·dc·cos A`, and combining with step 3 yields the
+chord identity `(PA·sin A)² = db² + dc² + 2·db·dc·cos A` feeding
+`key_inequality_of_chord_and_sines`.
+
+Net: the proof now needs **only the same `dist_div_sin_angle_eq_two_mul_circumradius`
+lemma applied twice** (once to `△ABC` for `a=2R sinA`, once to the pedal triangle
+for the chord), plus Thales + circumcenter-uniqueness + law of cosines — all
+confirmed present. No `oangle` / `two_zsmul` machinery.
+
+### Remaining genuine work (build session, fleet quiet)
+
+1. `lineDist` ↔ `orthogonalProjection` rewrite (bridge lemma, ~10 lines).
+2. Right angle at the feet ⟹ membership on `Sphere.ofDiameter A P` (Thales).
+3. circumradius of pedal triangle `= dist A P / 2` via `eq_circumcenter_of_dist_eq`.
+4. `∠ F_b A F_c = ∠ B A C` — feet on the rays from `A` (needs interior ⟹ foot on
+   the open segment; the only step still lacking a pinned-down Mathlib lemma).
+5. Assemble chord identity, hand to `key_inequality_of_chord_and_sines`.
+6. Affine independence of the pedal triangle (needed to form `Triangle ℝ P`):
+   holds unless `db` or `dc` is zero, i.e. `P` on a side — excluded by interior.
+
+Estimated 150–300 lines; step 4 is the residual risk. Build in a **separate
+companion file first** (do not re-add sorries to the clean shipped file).
+
+## Why not done this session (2026-06-19)
+
+Aristotle MCP down ("Resource not found"); fleet at load ~18 with 5 lean
+containers (OOM-risk per container-count gate). A heavy multi-iteration
+`EuclideanSpace` build is unsafe to start now. The clean 1-sorry file is shipped
+(PR #26033, OPEN+MERGEABLE). This session's progress is the de-risked,
+fully name-checked decomposition above (the oangle elimination is a real
+structural simplification of the remaining obligation), not a code change.

--- a/research/erdos-mordell-chord-identity-strategy.md
+++ b/research/erdos-mordell-chord-identity-strategy.md
@@ -14,9 +14,18 @@ fact, isolated three ways:
   identity** `(PA·sin A)² = db² + dc² + 2·db·dc·cos A`, derives the key
   inequality `b·dc + c·db ≤ a·PA`. **Proved.**
 
-The only remaining sorries are `key_inequality_A/B/C` — the obligation to supply,
-for the concrete Euclidean configuration, (i) the law of sines and (ii) the chord
-identity. This note records the Mathlib path for that final step.
+The three cyclic `key_inequality_A/B/C` have now been **collapsed to a single
+shared lemma** `key_inequality_vertex (X Y Z P)` — the others are its
+`(X,Y,Z)=(A,B,C),(B,C,A),(C,A,B)` instantiations, derived by pure relabeling
+(`affineIndep_rotate`, `mem_interior_hull_rotate`: affine independence and the
+triangle-hull interior are invariant under cyclic permutation). So the **only**
+remaining sorry is `key_inequality_vertex`: supply, for the concrete Euclidean
+configuration, (i) the law of sines and (ii) the chord identity.
+
+Update: the law of sines (i) is **already in Mathlib** —
+`EuclideanGeometry.dist_div_sin_angle_eq_two_mul_circumradius`
+(`Angle/Sphere.lean:430`) gives `dist /sin = 2R`. So the genuinely missing fact
+is just the **chord identity** (ii). This note records the Mathlib path for it.
 
 ## The chord identity, geometrically
 

--- a/src/data/research/problems/erdos-mordell-inequality-oq-01.json
+++ b/src/data/research/problems/erdos-mordell-inequality-oq-01.json
@@ -29,7 +29,7 @@
     "Not present in Mathlib4 (as of v4.26.0): no `mordell` geometry result; Mathlib has Triangle, Incenter, Projection, SignedDist, angle infrastructure but no Erdős–Mordell."
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (ACT iter 2): reduction + trig core + chord-to-key ASSEMBLY lemma all PROVED (geometry-free); main theorem assembled modulo 3 geometric key inequalities. key_inequality_of_chord_and_sines reduces each remaining sorry to supplying exactly the chord identity + law of sines for the concrete config — no opaque obligation left. Build gated (single watcher PID 85088 gate load<12 & ctrs<3, ships PR on green; killed redundant 2nd watcher to avoid OOM double-build). Gallery meta updated (8 thm, 5 substantive, 271 lines). Aristotle endpoint returns 'Resource not found' this session.",
+    "progressSummary": "PROGRESS (ACT iter 3): collapsed the 3 geometric key inequalities to ONE shared lemma key_inequality_vertex (A/B/C proved from it by cyclic relabeling). Remaining obligation is now a single fact = pedal-feet chord identity (law of sines confirmed available in Mathlib: dist_div_sin_angle_eq_two_mul_circumradius). Build gated (watcher PID 7086, gate ctrs<3 & load<40, ships PR on green/1-sorry). Aristotle endpoint still returns Resource not found this session.",
     "builtItems": [
       "proofs/Proofs/ErdosMordellInequalityOQ01.lean: erdos_mordell_reduction — from the three key inequalities a·PA≥b·dc+c·db (cyclic), derives PA+PB+PC≥2(da+db+dc) via explicit nonnegative certificate, 0 sorry, 0 axiom (build-pending verification).",
       "Certificate: a·b·c·(PA+PB+PC) − 2abc·(da+db+dc) = a·da·(b−c)² + b·db·(a−c)² + c·dc·(a−b)² + (key-inequality slack), each summand ≥ 0; closed by mul_le_mul_of_nonneg_left scaling + nlinarith + le_of_mul_le_mul_left.",
@@ -38,21 +38,25 @@
       "key_inequality_trig_core (ErdosMordellInequalityOQ01.lean:119): geometry-free, PROVED — sinB·dc + sinC·db ≤ √(db²+dc²+2·db·dc·cosA) for triangle angles",
       "key_inequality_of_chord_and_sines (ErdosMordellInequalityOQ01.lean:162): geometry-free ASSEMBLY, PROVED — from chord identity (PA·sinA)²=db²+dc²+2·db·dc·cosA and law of sines a=2R sinA/b=2R sinB/c=2R sinC, derives b·dc+c·db ≤ a·PA. Proof: trig core gives sinB·dc+sinC·db ≤ √(…)=PA·sinA (Real.sqrt_sq on the chord identity), then mul_le_mul_of_nonneg_left by 2R>0. This is the bridge that makes each geometric sorry a precise (chord-identity + law-of-sines) obligation rather than the whole key inequality.",
       "erdos_mordell now fully wired through erdos_mordell_reduction (ErdosMordellInequalityOQ01.lean:191): side-length positivity via AffineIndependent.injective + dist_pos, pedal nonneg via lineDist_nonneg, AM-GM via reduction — only 3 geometric key-inequality sorries remain",
-      "Registered Proofs.ErdosMordellInequalityOQ01 in Proofs.lean; created gallery meta erdos-mordell-inequality-oq-01 (formalized/wip, 0 axioms, 3 sorries)"
+      "Registered Proofs.ErdosMordellInequalityOQ01 in Proofs.lean; created gallery meta erdos-mordell-inequality-oq-01 (formalized/wip, 0 axioms, 3 sorries)",
+      "key_inequality_vertex (shared geometric core, 1 sorry) + key_inequality_A/B/C now PROVED from it by relabeling, ErdosMordellInequalityOQ01.lean",
+      "affineIndep_rotate / mem_interior_hull_rotate plumbing lemmas (cyclic-permutation invariance), ErdosMordellInequalityOQ01.lean"
     ],
     "insights": [
       "The inequality cleanly factors: ALL the AM-GM / side-length algebra is captured by erdos_mordell_reduction (now proved), isolating the genuinely hard work into the three geometric key inequalities.",
       "The key inequality a·PA ≥ b·dc + c·db arises from the cyclic quadrilateral A–Fc–P–Fb (Fb, Fc feet of perpendiculars to the two sides at A): A,Fb,Fc,P lie on a circle of diameter PA, so the chord FbFc = PA·sin A, and projecting the pedal segment gives the bound. This is the Mathlib-infrastructure-heavy step.",
       "Each AM-GM coefficient is t + 1/t ≥ 2 with t = ratio of two side lengths; equality forces a=b=c (equilateral), matching the known equality case.",
       "Mathlib gap is real: formalizing the key inequality needs concyclicity / inscribed-angle (chord = diameter·sin(inscribed angle)) for the diameter-PA circle, plus distance-to-affineSpan manipulation.",
-      "Trig core of each key inequality collapses to the perfect square (db·cosC − dc·cosB)² ≥ 0, using cos A = sinB·sinC − cosB·cosC (angle sum A+B+C=π). This reduces every geometric key inequality to ONE fact: the chord identity (PA·sinA)² = db²+dc²+2·db·dc·cosA (concyclicity of pedal feet on circle of diameter PA), plus the law of sines."
+      "Trig core of each key inequality collapses to the perfect square (db·cosC − dc·cosB)² ≥ 0, using cos A = sinB·sinC − cosB·cosC (angle sum A+B+C=π). This reduces every geometric key inequality to ONE fact: the chord identity (PA·sinA)² = db²+dc²+2·db·dc·cosA (concyclicity of pedal feet on circle of diameter PA), plus the law of sines.",
+      "The three cyclic key inequalities are EXACTLY the (X,Y,Z)=(A,B,C),(B,C,A),(C,A,B) instantiations of one shared lemma key_inequality_vertex; affine independence and triangle-hull interior are invariant under cyclic relabeling (AffineIndependent.comp_embedding with ![1,2,0] embedding; convexHull set equality), so A/B/C follow by pure relabeling — 3 opaque sorries collapse to 1."
     ],
     "mathlibGaps": [
       "No Erdős–Mordell in Mathlib4 v4.26.0.",
       "The chord = diameter·sin(inscribed-angle) relation for the pedal circle at a vertex is not directly packaged; would be assembled from EuclideanGeometry.Sphere + angle lemmas.",
       "Relating Metric.infDist to affineSpan {X,Y} to an explicit foot/orthogonal-projection distance needs EuclideanGeometry.orthogonalProjection bridging lemmas.",
       "No pedal-feet concyclicity / chord-length-in-circle-of-diameter-PA lemma in Mathlib; needed to prove the chord identity (PA·sinA)² = db²+dc²+2·db·dc·cosA",
-      "No directly usable extended law of sines (a = 2R·sinA) wired to EuclideanSpace triangle side lengths found yet"
+      "No directly usable extended law of sines (a = 2R·sinA) wired to EuclideanSpace triangle side lengths found yet",
+      "Law of sines IS available: EuclideanGeometry.dist_div_sin_angle_eq_two_mul_circumradius (Angle/Sphere.lean:430) gives dist/sin = 2R; only the pedal-feet chord identity remains genuinely missing."
     ],
     "nextSteps": [
       "Verify erdos_mordell_reduction builds green (single quiet-gated watcher; fleet was OOM-saturated with 6 concurrent builds at claim time).",
@@ -63,7 +67,8 @@
       "Prove the chord identity (PA·sinA)² = db²+dc²+2·db·dc·cosA in EuclideanSpace via orthogonal projection feet (EuclideanGeometry.orthogonalProjection) — the SOLE remaining geometric obligation per key_inequality_trig_core",
       "Wire law of sines to convert a·PA ≥ b·dc+c·db into the sin-form consumed by key_inequality_trig_core",
       "Confirm gated build green (/tmp/r9-mordell-DONE) — verifies injective-wiring + nlinarith trig core compile",
-      "Retry Aristotle async submit (got Resource not found this session) on key_inequality_A once endpoint healthy"
+      "Retry Aristotle async submit (got Resource not found this session) on key_inequality_A once endpoint healthy",
+      "Prove key_inequality_vertex: (1) pedal feet F_b=orthogonalProjection line[Z,X] P, F_c=orthogonalProjection line[X,Y] P; (2) right angles at feet -> A,F_b,F_c,P concyclic on circle diam PX (Thales, Angle/Sphere.lean:103); (3) dist F_b F_c = PX*sin(angle YXZ) via inscribed angle / dist_div_sin_angle_eq_two_mul_circumradius on that circle; (4) law of cosines in triangle P F_b F_c gives chord identity; (5) feed key_inequality_of_chord_and_sines with law of sines (now Mathlib) + chord identity."
     ]
   }
 }


### PR DESCRIPTION
Collapses the three cyclic Erdős–Mordell key inequalities `key_inequality_A/B/C` into a single shared lemma `key_inequality_vertex`; A/B/C now follow by pure relabeling (affine independence + triangle-hull interior are invariant under cyclic permutation). This reduces the remaining geometric obligation from **three** opaque sorries to **one**. Also records that Mathlib already provides the law-of-sines input (`dist_div_sin_angle_eq_two_mul_circumradius`), isolating the pedal-feet chord identity as the sole remaining fact.

Build: verified green, exactly 1 `sorry` warning (`key_inequality_vertex`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)