### PR TITLE
audit(shannon-channel-coding-bec-oq-01): clean — durable tracker entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15926,6 +15926,13 @@
       "result": "issues-fixed",
       "issues": []
     },
+    "shannon-channel-coding-bec-oq-01": {
+      "agentId": "auditor-agent",
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T07:15:00Z",
+      "result": "clean",
+      "issues": []
+    },
     "stern-brocot-tree-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-06-18T16:45:23Z",
@@ -16012,5 +16019,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-19T06:45:37Z"
+  "lastUpdated": "2026-06-19T07:15:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `shannon-channel-coding-bec-oq-01` — q-ary Erasure Channel Capacity (C = (1 − p) log q), from #26030
**Result**: CLEAN, LOW risk, no overclaim.

### Verified meta.json vs `proofs/Proofs/ShannonChannelCodingBECOQ01.lean`

| Check | meta.json | source | match |
|-------|-----------|--------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 `axiom` decls, no `native_decide`/`decide` → no `Lean.ofReduceBool` | ✓ |
| theoremCount | 14 | 14 | ✓ |
| definitionCount | 2 | 2 | ✓ |
| status/badge | verified / original | honest (see below) | ✓ |
| True stubs | — | none | ✓ |
| registration | — | `import Proofs.ShannonChannelCodingBECOQ01` in Proofs.lean:2871 | ✓ |

### Tier & badge honesty
Tier A — complete machine-checked theorem. The QEC erasure identity `H(X|Y)=p·H(X)`, the mutual-information identity `I(X;Y)=(1−p)·H(X)`, the converse bound, and uniform-input achievability are all proven **in-file**. The dependencies (`chain_rule`, `entropy_le_log_card`, `entropy_of_uniform_eq_log_card`) are repo-internal scaffold lemmas that are themselves 0-axiom/0-sorry — not a deep Mathlib theorem doing the core work — so badge `original` / status `verified` is appropriate.

The `assumptions` field is exemplary: it discloses the scaffold reuse and correctly **scopes out** the operational coding theorem (random codebooks / Fano converse), formalizing only the discrete information capacity (sSup of mutual information). No inequality≠theorem inflation, no delegation opacity.

### Why this PR
The entry was **absent from the main `audit-tracker.json`** (fresh research entry from #26030 with no main-tracker auditCount), so `find-targets` re-serves it indefinitely — same re-serve trap fixed by #26031 / #26027 / #26020. This records a durable CLEAN tracker entry.

---
Discovered during gallery integrity audit. 8-line tracker-only diff.