### PR TITLE
Enrich q-ary Erasure Channel Capacity: add annotations

### DIFF
--- a/src/data/proofs/shannon-channel-coding-bec-oq-01/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-01/annotations.json
@@ -1,0 +1,153 @@
+[
+  {
+    "id": "ann-qec-channel",
+    "proofId": "shannon-channel-coding-bec-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 84
+    },
+    "type": "definition",
+    "title": "The q-ary Erasure Channel QEC(p)",
+    "content": "Defines qec as a DMChannel from an arbitrary finite input type α to Option α, where none denotes an erasure. Each symbol is erased with probability p (W x none = p) and otherwise received correctly (W x (some y) = if x = y then 1 - p else 0). Non-negativity splits on the erasure/received cases; the sum-to-one law uses Fintype.sum_option to peel off the none term and Finset.sum_ite_eq to collapse the indicator sum over α to the single received symbol, giving p + (1 - p) = 1. The simp lemmas qec_W_none and qec_W_some expose the kernel values by rfl. This single polymorphic definition recovers the parent binary channel bec at α = Bool.",
+    "mathContext": "$W(? \\mid x) = p,\\qquad W(y \\mid x) = (1-p)\\,[x = y],\\quad x,y \\in \\alpha,\\ |\\alpha| = q$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "discrete memoryless channel",
+      "erasure channel",
+      "finite alphabet",
+      "packet loss"
+    ],
+    "prerequisites": [
+      "Fintype.sum_option",
+      "Finset.sum_ite_eq"
+    ]
+  },
+  {
+    "id": "ann-qec-marginals",
+    "proofId": "shannon-channel-coding-bec-oq-01",
+    "range": {
+      "startLine": 86,
+      "endLine": 108
+    },
+    "type": "concept",
+    "title": "Output Marginals",
+    "content": "Two lemmas compute the output distribution induced by an arbitrary input. qec_ymarg_none: summing the joint over inputs, every column at the erasure output contributes p, so the marginal is p · (∑ inp.p x) = p via inp.sum_one. qec_ymarg_some: the symbol y is received un-erased only when y was sent (probability inp.p y) and not erased (probability 1 - p), so Finset.sum_eq_single collapses the indicator to the single term inp.p y · (1 - p). These marginals are precisely the conditional-probability denominators that appear inside the conditional-entropy sum.",
+    "mathContext": "$p_Y(?) = p,\\qquad p_Y(y) = p_X(y)\\,(1-p)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "marginal distribution",
+      "joint distribution",
+      "law of total probability"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-qec-conditional-entropy",
+    "proofId": "shannon-channel-coding-bec-oq-01",
+    "range": {
+      "startLine": 111,
+      "endLine": 176
+    },
+    "type": "theorem",
+    "title": "The Erasure Identity H(X|Y) = p · H(X)",
+    "content": "The mathematical heart of the proof, and the only step that does real work. For any input distribution the conditional entropy of the input given the output equals p · H(X). The argument splits the inner sum over outputs (Fintype.sum_option) into the received (some y) terms and the erasure (none) term. Each received term vanishes: when x ≠ y the joint probability is 0; when x = y the conditional probability is inp.p x (1 - p) / (inp.p x (1 - p)) = 1, and log 1 = 0. The erasure term reduces, after dividing the joint inp.p x · p by the erasure marginal p, to inp.p x · p · log(inp.p x); factoring out p across the input sum recognises −H(X), yielding p · H(X). Crucially this collapse is per-symbol and uses nothing about the alphabet size q — it is the binary proof verbatim with Bool replaced by α.",
+    "mathContext": "$H(X \\mid Y) = \\sum_{x} p_X(x)\\,p\\,\\log p_X(x) \\cdot(-1)\\ \\cdots = p\\,H(X);\\quad \\text{received terms } \\log 1 = 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "conditional entropy",
+      "Shannon entropy",
+      "data processing",
+      "side information"
+    ],
+    "prerequisites": [
+      "conditional entropy of a joint distribution",
+      "Real.log_one"
+    ]
+  },
+  {
+    "id": "ann-qec-mutual-information",
+    "proofId": "shannon-channel-coding-bec-oq-01",
+    "range": {
+      "startLine": 178,
+      "endLine": 195
+    },
+    "type": "theorem",
+    "title": "Mutual Information I(X;Y) = (1 − p) · H(X)",
+    "content": "Combines the chain rule I(X;Y) = H(X) − H(X|Y) with the erasure identity to obtain I(X;Y) = (1 − p) · H(X) for every input. The proof rewrites channelMI by chain_rule (using joint non-negativity and the joint sum-to-one), identifies the X-marginal of the joint with the input distribution inp.p (the output sum collapses by the channel's sum_one), and substitutes qec_conditional_entropy. A quarter of the information is lost to erasures exactly in proportion to p.",
+    "mathContext": "$I(X;Y) = H(X) - H(X \\mid Y) = H(X) - p\\,H(X) = (1-p)\\,H(X)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "mutual information",
+      "chain rule of entropy",
+      "channel coding"
+    ],
+    "prerequisites": [
+      "chain rule I = H(X) − H(X|Y)"
+    ]
+  },
+  {
+    "id": "ann-qec-uniform-converse",
+    "proofId": "shannon-channel-coding-bec-oq-01",
+    "range": {
+      "startLine": 197,
+      "endLine": 225
+    },
+    "type": "concept",
+    "title": "Uniform Input and the Converse Bound",
+    "content": "Sets up the two halves of the capacity optimization. uniformInput is the 1/|α| distribution (its sum-to-one is |α| · |α|⁻¹ = 1). qec_uniform_mi shows it achieves I = (1 − p) · log|α| by feeding entropy_of_uniform_eq_log_card into the mutual-information identity. qec_mi_le is the converse: for any input, H(X) ≤ log|α| (entropy_le_log_card) and multiplying by the non-negative 1 − p gives I ≤ (1 − p) · log|α|. Together they pin the supremum.",
+    "mathContext": "$H(X) \\le \\log|\\alpha|\\ \\text{(converse)},\\qquad H(\\mathrm{Unif}) = \\log|\\alpha|\\ \\text{(achievability)}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "maximum entropy",
+      "uniform distribution",
+      "capacity-achieving distribution"
+    ],
+    "prerequisites": [
+      "entropy_le_log_card",
+      "entropy_of_uniform_eq_log_card"
+    ]
+  },
+  {
+    "id": "ann-qec-capacity",
+    "proofId": "shannon-channel-coding-bec-oq-01",
+    "range": {
+      "startLine": 226,
+      "endLine": 259
+    },
+    "type": "theorem",
+    "title": "Capacity C(QEC(p)) = (1 − p) · log q",
+    "content": "Assembles the capacity as a supremum of mutual information over inputs. le_antisymm splits into csSup_le (every input is bounded by (1 − p) · log|α| via qec_mi_le, with the uniform input witnessing non-emptiness) and le_csSup (the uniform input attains the bound, with channelMI_le_log_card supplying the upper bound that makes the supremum well-defined). qec_capacity_card restates it as (1 − p) · log q when |α| = q, and qec_capacity_nonneg notes the capacity is non-negative since both 1 − p and log|α| are.",
+    "mathContext": "$C(\\mathrm{QEC}(p)) = \\sup_{p_X} I(X;Y) = (1-p)\\,\\log q$",
+    "significance": "key",
+    "relatedConcepts": [
+      "channel capacity",
+      "supremum",
+      "least upper bound"
+    ],
+    "prerequisites": [
+      "channelCapacity as sSup of mutual information",
+      "channelMI_le_log_card"
+    ]
+  },
+  {
+    "id": "ann-qec-bec-recovery",
+    "proofId": "shannon-channel-coding-bec-oq-01",
+    "range": {
+      "startLine": 261,
+      "endLine": 276
+    },
+    "type": "corollary",
+    "title": "The Binary Erasure Channel as q = 2",
+    "content": "Shows the parent binary erasure channel is literally the q = 2 instance. qec_eq_bec proves the QEC kernel over Bool equals the bec kernel on the nose (funext, then cases on the output, each closed by rfl). qec_capacity_bool specializes the capacity to (1 − p) · log 2 using Fintype.card_bool, and qec_capacity_bool_bits divides by log 2 to recover the clean C = 1 − p bits, matching the parent's bec_capacity_bits. So the entire BEC entry is a corollary of the q-ary result.",
+    "mathContext": "$(\\mathrm{QEC}_{\\mathrm{Bool}})_W = \\mathrm{bec}_W,\\qquad C = (1-p)\\log 2 = 1-p\\ \\text{bits}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "binary erasure channel",
+      "specialization",
+      "change of base (nats to bits)"
+    ],
+    "prerequisites": [
+      "Fintype.card_bool"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `shannon-channel-coding-bec-oq-01` (quality 45 → fills the sole gap: missing annotations.json).

The meta.json was already complete (rich historicalContext, proofStrategy, 5 keyInsights, 6 sections, 4 crossReferences, conclusion with 3 openQuestions, 4 mainTheorems). The entry scored 45 only because **annotations.json was absent**.

## Added
- **7 line-accurate annotations** covering all 6 sections of `ShannonChannelCodingBECOQ01.lean`:
  1. The q-ary erasure channel QEC(p) definition (59–84)
  2. Output marginals (86–108)
  3. The erasure identity H(X|Y) = p·H(X) — the mathematical core (111–176, significance `key`)
  4. Mutual information I(X;Y) = (1−p)·H(X) (178–195, `key`)
  5. Uniform input and the converse bound (197–225)
  6. Capacity C = (1−p)·log q (226–259, `key`)
  7. The binary erasure channel as q = 2 (261–276)
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Verification
- annotations.json parses and passes `annotations:validate` strict mode (0 errors for this entry; line ranges resolve to real Lean constructs).
- No content changed in meta.json; existing status (verified / original / 0 axioms / 0 sorries) preserved.
- No index.ts (siblings shannon-channel-coding-bec and -awgn carry none; loader is fetch-by-slug).