### PR TITLE
Enrich zsqrtd-neg-two-oq-01: add 8 annotations + 5-section split (39→100)

### DIFF
--- a/src/data/proofs/zsqrtd-neg-two-oq-01/annotations.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "zsqrtd-neg-two-oq-01",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "The open question: assemble one bi-conditional for $p = x^2 + 2y^2$",
+    "content": "The module docstring fixes the scope precisely. The parent file `Proofs.ZsqrtdNegTwo` proves the two *forward* implications $p \\equiv 1 \\pmod 8 \\Rightarrow \\exists a\\,b,\\ a^2 + 2b^2 = p$ and $p \\equiv 3 \\pmod 8 \\Rightarrow \\exists a\\,b,\\ a^2 + 2b^2 = p$ via the Euclidean structure of $\\mathbb{Z}[\\sqrt{-2}]$, but never states the **converse** or glues everything into a single $\\iff$. This file adds exactly two things: (1) `repr_mod_eight`, the converse, which is the genuinely new mathematical content; and (2) `prime_sq_add_two_sq_iff`, the unified characterization the open question requests. No new ring theory is introduced — the heavy lifting (the two forward directions) is imported and reused verbatim.",
+    "mathContext": "The classical theorem is that an odd prime $p$ is represented by the principal form $x^2 + 2y^2$ of discriminant $-8$ iff $p \\equiv 1$ or $3 \\pmod 8$, equivalently iff $\\left(\\tfrac{-2}{p}\\right) = 1$. Together with the even prime $2 = 0^2 + 2\\cdot 1^2$ this gives the full list $\\{p : p = 2 \\lor p \\equiv 1,3 \\pmod 8\\}$. This is the $n = 2$ analogue of Fermat's two-squares theorem ($n = 1$: $p = x^2 + y^2 \\iff p = 2 \\lor p \\equiv 1 \\pmod 4$).",
+    "significance": "key",
+    "relatedConcepts": ["binary quadratic forms", "discriminant -8", "Fermat's two-squares theorem", "forward vs converse implication", "open question scoping"],
+    "prerequisites": ["modular arithmetic", "sum-of-two-squares representation theorems"]
+  },
+  {
+    "id": "ann-imports",
+    "proofId": "zsqrtd-neg-two-oq-01",
+    "range": { "startLine": 41, "endLine": 46 },
+    "type": "concept",
+    "title": "Imports and the inherited $\\mathtt{SqAddTwoSq}$ namespace",
+    "content": "Two imports: `Mathlib` (the kitchen-sink, bringing `decide`, `omega`, `push_cast`, `norm_num`, `simp` into scope) and `Proofs.ZsqrtdNegTwo`, the parent file. `open SqAddTwoSq` pulls the parent's two forward theorems — `sq_add_two_sq_of_prime_one_mod_eight` and `sq_add_two_sq_of_prime_three_mod_eight` — into the unqualified namespace so the backward direction of the bi-conditional can name them directly. The new declarations live under a fresh `namespace ZsqrtdNegTwoOQ01` to avoid clashing with the parent.",
+    "mathContext": "The parent's forward theorems are the deep inputs: each asserts that a prime in a given residue class mod 8 is a norm from $\\mathbb{Z}[\\sqrt{-2}]$, proved through that ring being a Euclidean domain (hence a PID, hence every prime $p$ with $\\left(\\tfrac{-2}{p}\\right)=1$ splits as $p = \\alpha\\bar\\alpha = a^2 + 2b^2$). This file treats them as a black box.",
+    "significance": "supporting",
+    "relatedConcepts": ["Mathlib import discipline", "namespace management", "code reuse", "Euclidean domain"],
+    "prerequisites": ["Lean 4 modules and namespaces"]
+  },
+  {
+    "id": "ann-converse-statement",
+    "proofId": "zsqrtd-neg-two-oq-01",
+    "range": { "startLine": 48, "endLine": 56 },
+    "type": "theorem",
+    "title": "$\\mathtt{repr\\_mod\\_eight}$: the converse, with oddness only",
+    "content": "The new content. `repr_mod_eight` states: if an *odd* natural number $p$ is representable as $a^2 + 2b^2$ with $a, b : \\mathbb{Z}$, then $p \\equiv 1$ or $3 \\pmod 8$. The crucial economy is that **primality is never used** — only the hypothesis `hodd : p % 2 = 1`. This makes the lemma strictly more general than the prime case the open question literally asks about, and decouples the converse entirely from the algebraic-number-theory machinery of the parent.",
+    "mathContext": "Why oddness alone suffices: an odd $p$ forces $a$ odd (since $2b^2$ is even and $a^2 = p - 2b^2$ is then odd), and every odd square satisfies $a^2 \\equiv 1 \\pmod 8$. Meanwhile $2b^2 \\equiv 0$ or $2 \\pmod 8$ according as $b$ is even or odd. Summing, $p = a^2 + 2b^2 \\equiv 1 + \\{0,2\\} = \\{1, 3\\} \\pmod 8$. The Lean proof packages this parity bookkeeping into a single finite check rather than splitting on the parities of $a$ and $b$ by hand.",
+    "significance": "critical",
+    "relatedConcepts": ["converse implication", "odd squares mod 8", "generalization beyond primes", "quadratic form values"],
+    "prerequisites": ["squares modulo 8", "even/odd parity arithmetic"]
+  },
+  {
+    "id": "ann-reduce-mod8",
+    "proofId": "zsqrtd-neg-two-oq-01",
+    "range": { "startLine": 57, "endLine": 60 },
+    "type": "tactic",
+    "title": "Step (A): push the integer identity into $\\mathbb{Z}/8\\mathbb{Z}$",
+    "content": "The representing equation `a^2 + 2*b^2 = (p : ℤ)` is transported into `ZMod 8` by applying the ring homomorphism `Int.castRingHom (ZMod 8)` to both sides via `congrArg`, then `simpa` simplifies the cast of a sum/product/power into the corresponding `ZMod 8` operations, yielding `(a : ZMod 8)^2 + 2*(b : ZMod 8)^2 = (p : ZMod 8)`. Using `congrArg` of a ring hom (rather than `push_cast` alone) is the robust idiom when a cast must pass through `^`: a sibling file in this same development hit `push_cast` failing to push `↑(a^2)` through the power, and the fix was precisely `congrArg (Int.castRingHom _)` + `simpa`.",
+    "mathContext": "Reduction mod 8 is a ring homomorphism $\\mathbb{Z} \\to \\mathbb{Z}/8\\mathbb{Z}$, so it preserves the polynomial expression $a^2 + 2b^2$. The point of descending to $\\mathbb{Z}/8\\mathbb{Z}$ is to replace an identity over an infinite ring with an equation in an 8-element ring, where the achievable values can be enumerated by brute force.",
+    "significance": "supporting",
+    "relatedConcepts": ["ring homomorphism", "congrArg", "push_cast", "reduction modulo n", "casts through powers"],
+    "prerequisites": ["ZMod n", "ring homomorphisms preserve operations"]
+  },
+  {
+    "id": "ann-forbidden-decide",
+    "proofId": "zsqrtd-neg-two-oq-01",
+    "range": { "startLine": 61, "endLine": 67 },
+    "type": "insight",
+    "title": "Step (B): $x^2 + 2y^2$ is never $5$ or $7$ in $\\mathbb{Z}/8\\mathbb{Z}$ — a $64$-case $\\mathtt{decide}$",
+    "content": "The heart of the converse. `hforbidden : ∀ x y : ZMod 8, x^2 + 2*y^2 ≠ 5 ∧ x^2 + 2*y^2 ≠ 7` is discharged by a single `decide`, which exhaustively evaluates all $8 \\times 8 = 64$ pairs $(x,y)$ in `ZMod 8 × ZMod 8`. Because `ZMod 8` is a `Fintype` with `DecidableEq`, the universally-quantified statement is decidable and the **kernel** reduces it to `True`. This is ordinary `decide`, *not* `native_decide` — so it relies only on kernel reduction and introduces **no** `Lean.ofReduceBool` axiom, keeping the entry genuinely axiom-free. Instantiating `hforbidden` at $(a, b)$ and rewriting backward through step (A)'s identity gives `(p : ZMod 8) ≠ 5` and `≠ 7`.",
+    "mathContext": "Direct enumeration: the squares in $\\mathbb{Z}/8\\mathbb{Z}$ are $\\{0,1,4\\}$ and $2 \\cdot \\{0,1,4\\} = \\{0,2,8\\equiv 0\\} = \\{0,2\\}$, so the achievable sums $x^2 + 2y^2$ are $\\{0,1,4\\} + \\{0,2\\} = \\{0,1,2,3,4,6\\}$. The residues $5$ and $7$ are missing — and these are exactly the two odd residues that must be excluded to pin the odd $p$ into $\\{1,3\\}$.",
+    "significance": "critical",
+    "relatedConcepts": ["decide vs native_decide", "Fintype exhaustive check", "Lean.ofReduceBool axiom", "image of a quadratic form", "axiom-free verification"],
+    "prerequisites": ["decidable propositions over finite types", "squares modulo 8"]
+  },
+  {
+    "id": "ann-transport-omega",
+    "proofId": "zsqrtd-neg-two-oq-01",
+    "range": { "startLine": 68, "endLine": 77 },
+    "type": "tactic",
+    "title": "Steps (C)–(D): transport exclusions to $p \\bmod 8$ and close with $\\mathtt{omega}$",
+    "content": "Step (C) bridges the $\\mathbb{Z}/8\\mathbb{Z}$ exclusions back to natural-number residues using `ZMod.natCast_mod : ((p % 8 : ℕ) : ZMod 8) = (p : ZMod 8)`. Assuming `p % 8 = 5` (resp. `7`) and casting would contradict `h5` (resp. `h7`), giving `hv5 : p % 8 ≠ 5` and `hv7 : p % 8 ≠ 7`. Step (D) then has four purely arithmetic facts about the natural number $r := p \\% 8$: $r < 8$ (`Nat.mod_lt`), $r$ is odd (`hpar`, derived from `hodd` by `omega`), $r \\neq 5$, $r \\neq 7$. The single odd residue $< 8$ avoiding $5$ and $7$ that remains is $\\{1, 3\\}$, and `omega` closes the disjunction.",
+    "mathContext": "The transport is the standard bridge between the abstract quotient $\\mathbb{Z}/8\\mathbb{Z}$ (where the `decide` lives) and the concrete remainder $p \\bmod 8 \\in \\{0,\\dots,7\\}$ (where the conclusion lives). `omega` decides linear arithmetic over $\\mathbb{Z}$/$\\mathbb{N}$ with divisibility/modulo, so once the residue is boxed into a finite window with two forbidden values and a parity constraint, the conclusion is mechanical.",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod.natCast_mod", "omega decision procedure", "residue transport", "linear arithmetic over N"],
+    "prerequisites": ["natural-number mod", "Presburger arithmetic / omega"]
+  },
+  {
+    "id": "ann-iff-statement",
+    "proofId": "zsqrtd-neg-two-oq-01",
+    "range": { "startLine": 79, "endLine": 99 },
+    "type": "theorem",
+    "title": "$\\mathtt{prime\\_sq\\_add\\_two\\_sq\\_iff}$: the unified characterization",
+    "content": "The capstone the open question requested: for every prime $p$, $(\\exists a\\,b : \\mathbb{Z},\\ a^2 + 2b^2 = p) \\iff (p = 2 \\lor p \\% 8 = 1 \\lor p \\% 8 = 3)$. The **forward** direction (`→`) splits on $p = 2$; otherwise `Nat.Prime.eq_two_or_odd` supplies oddness and `repr_mod_eight` finishes. The **backward** direction (`←`) is a three-way case split: $p = 2$ gives the explicit witness $\\langle 0, 1\\rangle$ ($0^2 + 2\\cdot 1^2 = 2$); the $p \\% 8 = 1$ and $p \\% 8 = 3$ branches invoke the parent's two forward theorems, after introducing the `Fact (Nat.Prime p)` instance the parent's API expects. Every branch is either a one-liner witness or a verbatim call to imported machinery — the entire mathematical novelty is concentrated in `repr_mod_eight`.",
+    "mathContext": "This is the complete characterization of primes represented by the principal form $x^2 + 2y^2$ of discriminant $-8$. The class number of discriminant $-8$ is $1$ (the form is the unique reduced form), which is exactly why representability is governed by a single clean congruence condition mod 8 rather than a genus/class decomposition. The even prime $2$ is the ramified prime (it divides the discriminant) and is handled separately by an explicit witness.",
+    "significance": "key",
+    "relatedConcepts": ["bi-conditional characterization", "Nat.Prime.eq_two_or_odd", "Fact typeclass instance", "ramified prime", "class number 1"],
+    "prerequisites": ["prime case analysis (2 vs odd)", "the parent forward theorems"]
+  },
+  {
+    "id": "ann-sanity-checks",
+    "proofId": "zsqrtd-neg-two-oq-01",
+    "range": { "startLine": 101, "endLine": 105 },
+    "type": "insight",
+    "title": "Sanity checks: explicit witnesses for $2, 3, 11, 17$",
+    "content": "Four `example` declarations pin concrete representations: $2 = 0^2 + 2\\cdot 1^2$, $3 = 1^2 + 2\\cdot 1^2$, $11 = 3^2 + 2\\cdot 1^2$, $17 = 3^2 + 2\\cdot 2^2$, each closed by `norm_num` on the supplied witness. These are not used downstream — they are executable documentation guarding against a vacuous or mis-stated existential: $3 \\equiv 3 \\pmod 8$, $11 \\equiv 3$, $17 \\equiv 1$, and $2$ is the even prime, so the four examples exercise all three branches of the bi-conditional's right-hand side.",
+    "mathContext": "Spot-checking small cases of a representation theorem is a cheap correctness witness: it certifies that the existential $\\exists a\\,b,\\ a^2 + 2b^2 = p$ is genuinely satisfiable for representative primes, complementing the abstract proof. The smallest prime *not* represented is $5$ ($5 \\equiv 5 \\pmod 8$), correctly excluded by the characterization.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked examples", "norm_num", "executable documentation", "explicit witnesses"],
+    "prerequisites": ["existential witnesses in Lean"]
+  }
+]

--- a/src/data/proofs/zsqrtd-neg-two-oq-01/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-01/meta.json
@@ -75,28 +75,44 @@
   "sorries": 0,
   "sections": [
     {
-      "id": "header-imports",
-      "title": "Module Header and Imports",
+      "id": "module-header",
+      "title": "Module Header: The Open Question",
       "startLine": 1,
-      "endLine": 50,
-      "summary": "File docstring stating the open question (assemble the parent's forward implications, the even prime, and the missing converse into one ↔) and what is new (the converse repr_mod_eight). Imports Mathlib and the parent Proofs.ZsqrtdNegTwo (for the two forward representation theorems), and opens the SqAddTwoSq namespace.",
+      "endLine": 40,
+      "summary": "File docstring stating the open question — assemble the parent's two forward implications, the even prime, and the missing converse into one ↔ — and itemizing the two new declarations (the converse repr_mod_eight and the capstone prime_sq_add_two_sq_iff). The status note at lines 32-39 is a stale build-pending caveat: the file has since been Docker-built green and registered in Proofs.lean (meta status: verified, 0 sorries, 0 axioms).",
       "mathContext": "The parent file zsqrtd-neg-two proves p ≡ 1,3 (mod 8) ⟹ p = a² + 2b² via the Euclidean structure of ℤ[√−2]. The open question asks only for the missing assembly and converse — no new ring theory, just an elementary modular exclusion."
+    },
+    {
+      "id": "imports",
+      "title": "Imports and the SqAddTwoSq Namespace",
+      "startLine": 41,
+      "endLine": 47,
+      "summary": "Imports Mathlib (for decide, omega, push_cast, norm_num) and the parent Proofs.ZsqrtdNegTwo, then `open SqAddTwoSq` to bring the two forward representation theorems into the unqualified namespace. New declarations live under namespace ZsqrtdNegTwoOQ01.",
+      "mathContext": "The parent's forward theorems — sq_add_two_sq_of_prime_one_mod_eight and sq_add_two_sq_of_prime_three_mod_eight — are the deep imported inputs, each proved through ℤ[√−2] being a Euclidean domain (hence a PID in which a prime with (−2/p)=1 splits as a²+2b²)."
     },
     {
       "id": "converse",
       "title": "The Converse: repr_mod_eight",
-      "startLine": 51,
-      "endLine": 80,
-      "summary": "Proves that an odd natural p with a² + 2b² = p satisfies p % 8 ∈ {1,3}. (A) reduces the integer identity modulo 8 by congrArg + push_cast. (B) a 64-case `decide` shows x² + 2y² is never 5 or 7 in ZMod 8. (C) transports the two exclusions back to p % 8 via ZMod.natCast_mod. (D) omega closes: p % 8 < 8 is odd and avoids 5,7, hence equals 1 or 3.",
+      "startLine": 48,
+      "endLine": 77,
+      "summary": "Proves that an odd natural p with a² + 2b² = p satisfies p % 8 ∈ {1,3} (primality not needed, only oddness). (A) reduces the integer identity modulo 8 by congrArg of Int.castRingHom + simpa. (B) a 64-case `decide` shows x² + 2y² is never 5 or 7 in ZMod 8. (C) transports the two exclusions back to p % 8 via ZMod.natCast_mod. (D) omega closes: p % 8 < 8 is odd and avoids 5,7, hence equals 1 or 3.",
       "mathContext": "An odd p forces a odd, so a² ≡ 1 (mod 8); and 2b² ≡ 0 or 2 (mod 8); summing gives p ≡ 1 or 3 (mod 8). The ZMod 8 `decide` packages this case analysis without manual parity bookkeeping."
     },
     {
       "id": "iff",
       "title": "The Unified Bi-Conditional: prime_sq_add_two_sq_iff",
-      "startLine": 81,
-      "endLine": 108,
-      "summary": "States and proves (∃ a b : ℤ, a² + 2b² = p) ↔ (p = 2 ∨ p % 8 = 1 ∨ p % 8 = 3) for prime p. Forward: split on p = 2, else use Nat.Prime.eq_two_or_odd to get oddness and apply repr_mod_eight. Backward: the p = 2 branch gives the witness ⟨0,1⟩, the p % 8 = 1 and = 3 branches invoke the parent's two forward theorems (after supplying the Fact (Nat.Prime p) instance). Four `example` sanity checks pin small primes 2, 3, 11, 17.",
+      "startLine": 79,
+      "endLine": 99,
+      "summary": "States and proves (∃ a b : ℤ, a² + 2b² = p) ↔ (p = 2 ∨ p % 8 = 1 ∨ p % 8 = 3) for prime p. Forward: split on p = 2, else use Nat.Prime.eq_two_or_odd to get oddness and apply repr_mod_eight. Backward: the p = 2 branch gives the witness ⟨0,1⟩; the p % 8 = 1 and = 3 branches invoke the parent's two forward theorems (after supplying the Fact (Nat.Prime p) instance).",
       "mathContext": "This is the complete characterization of primes representable by the principal form x² + 2y² of discriminant −8, the n = 2 analog of Fermat's two-squares theorem (n = 1: p = x² + y² ⟺ p = 2 ∨ p ≡ 1 mod 4)."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Sanity Checks: Small Primes 2, 3, 11, 17",
+      "startLine": 101,
+      "endLine": 107,
+      "summary": "Four `example` declarations pin explicit witnesses — 2 = 0²+2·1², 3 = 1²+2·1², 11 = 3²+2·1², 17 = 3²+2·2² — each closed by norm_num. They are executable documentation exercising all three branches of the bi-conditional's right-hand side (p = 2 even, 3 and 11 ≡ 3 mod 8, 17 ≡ 1 mod 8).",
+      "mathContext": "Spot-checking small representable primes certifies the existential is genuinely satisfiable; the smallest non-represented prime is 5 (≡ 5 mod 8), correctly excluded by the characterization."
     }
   ],
   "overview": {
@@ -108,7 +124,8 @@
       "The converse needs no primality — only oddness. An odd p forces the ℤ-coefficient a to be odd (since 2b² is even), and odd squares are ≡ 1 (mod 8), while 2b² ≡ 0 or 2 (mod 8); the sum lands in {1,3}.",
       "Working in ZMod 8 turns the parity bookkeeping into one decidable finite check: the image of (x,y) ↦ x² + 2y² over ZMod 8 × ZMod 8 is {0,1,2,3,4,6}, so 5 and 7 are unreachable. This is ordinary kernel `decide`, not native_decide, so it adds no axioms.",
       "The forward direction is entirely reuse: the parent's sq_add_two_sq_of_prime_one_mod_eight and sq_add_two_sq_of_prime_three_mod_eight discharge the two odd residue classes, and 2 = 0² + 2·1² handles the even prime — no ring theory is re-derived.",
-      "Discriminant −8 is special among small forms: x² + 2y² is the unique reduced form of its discriminant (class number 1), which is exactly why a clean congruence condition mod 8 characterizes representability. The same phenomenon underlies the parent's choice of ℤ[√−2], whose maximal order coincides with ℤ[√−2] itself."
+      "Discriminant −8 is special among small forms: x² + 2y² is the unique reduced form of its discriminant (class number 1), which is exactly why a clean congruence condition mod 8 characterizes representability. The same phenomenon underlies the parent's choice of ℤ[√−2], whose maximal order coincides with ℤ[√−2] itself.",
+      "The verification stays genuinely axiom-free because the 64-case exclusion uses ordinary kernel `decide`, not `native_decide`. native_decide would trust the compiler and pull in the Lean.ofReduceBool axiom; here the kernel itself reduces the finite ∀ over ZMod 8 × ZMod 8 to True, so #print axioms lists only propext / Classical.choice / Quot.sound. The even prime 2 is the ramified prime (it divides the discriminant −8) and is the sole case handled by an explicit witness rather than the residue machinery."
     ],
     "prerequisites": [
       "Modular arithmetic and ZMod n",


### PR DESCRIPTION
## Enrichment pass: `zsqrtd-neg-two-oq-01` (A Single Bi-Conditional for Primes p = x² + 2y²)

This entry had a rich `meta.json` (overview, conclusion, crossReferences) but **no `annotations.json`**, scoring 39. This pass closes that gap and reaches 100.

### Added
- **`annotations.json` — 8 annotations**, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`, covering the full 107-line file:
  - module header / open-question framing
  - imports & the inherited `SqAddTwoSq` namespace
  - `repr_mod_eight` statement (the converse — oddness only, no primality)
  - step (A) ring-hom reduction into `ZMod 8`
  - step (B) the 64-case `decide` (image {0,1,2,3,4,6}, excludes 5,7) — flagged as ordinary kernel `decide`, **not** `native_decide`, so axiom-free
  - steps (C)–(D) transport via `ZMod.natCast_mod` + `omega` close
  - `prime_sq_add_two_sq_iff` (the unified characterization)
  - the four small-prime sanity checks

### meta.json
- Split `sections` 3 → 5 (header / imports / converse / iff / sanity-checks) with **corrected line ranges** (the old ranges ran to 108; file is 107 lines).
- Added a 5th `keyInsight` on the `decide` vs `native_decide` axiom-freeness and the role of the ramified prime 2.
- Noted in the header section that the in-source `build-pending / do not register` caveat (lines 32-39 of the .lean) is stale — the file is built green and registered (`status: verified`, 0 sorries, 0 axioms), matching the merged research + audit (#26028, #26031).

No changes to the Lean source or to claimed status/axiom counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)