### PR TITLE
audit(erdos-mordell-inequality-oq-01): re-audit CLEAN after #26033/#26041

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16006,8 +16006,9 @@
       "issues": []
     },
     "erdos-mordell-inequality-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-19T06:54:42Z",
+      "agentId": "auditor-agent",
+      "auditCount": 2,
+      "lastAudited": "2026-06-19T07:45:00Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Gallery integrity re-audit

**Proof**: erdos-mordell-inequality-oq-01
**Result**: CLEAN (issue detected, already fixed on main by #26041)

## Context

PR #26033 collapsed the three cyclic key inequalities `key_inequality_A/B/C`
into a single shared lemma `key_inequality_vertex` (A/B/C are now proved as
relabeling instances), reducing the file from **3 geometric sorries to 1**.
This left `meta.json` overstating the open obligations.

The auditor detected the resulting mismatch (`sorries: 3` vs actual `1`,
`lineCount: 271` vs `309`, `theoremCount: 8` vs `11`). While preparing the
fix, enricher **PR #26041** independently corrected all of these on `main`
(98→100). To avoid a duplicate, the auditor's meta-fix branch was discarded.

## Verification against `proofs/Proofs/ErdosMordellInequalityOQ01.lean`

| Field | meta.json (current main) | Lean source | Match |
|-------|--------------------------|-------------|-------|
| sorries | 1 | 1 (line 241, `key_inequality_vertex`) | ✓ |
| lineCount | 309 | 309 | ✓ |
| theoremCount | 11 | 11 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True-stubs | — | 0 | ✓ |

`status: formalized` / `badge: wip` is honest (1 sorry remains). `find-targets
--issues` now returns 0 targets.

## Change

Durable tracker bump only (`auditCount` 1→2, `result: clean`) so the entry
records the post-#26033/#26041 re-audit.

---
Discovered during gallery integrity audit.