### PR TITLE
research(shannon-channel-coding-oq-01): additive-channel decomposition I(X;Y)=h(Y)-h(Z)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2869,6 +2869,7 @@ import Proofs.ShannonChannelCoding
 import Proofs.ShannonChannelCodingAWGN
 import Proofs.ShannonChannelCodingBEC
 import Proofs.ShannonChannelCodingBECOQ01
+import Proofs.ShannonChannelCodingOQ01
 import Proofs.ShannonChannelCodingOQ02
 import Proofs.ShannonChannelCodingOQ02OQ01
 import Proofs.ShannonChannelCodingOQ02OQ01Aristotle

--- a/proofs/Proofs/ShannonChannelCodingOQ01.lean
+++ b/proofs/Proofs/ShannonChannelCodingOQ01.lean
@@ -1,0 +1,130 @@
+/-
+  AWGN operational layer:  the additive-channel mutual-information decomposition
+  I(X;Y) = h(Y) - h(Z)
+
+  Open question (shannon-channel-coding-oq-01):
+  "Compute capacities for concrete channels such as BSC, BEC, and AWGN beyond
+   placeholder True statements."
+
+  The three named-channel capacity VALUES are already proved axiom-free:
+  - BSC(p)  = log 2 - h(p)        ShannonChannelCodingOQ02
+  - BEC(p)  = (1-p)·log 2          ShannonChannelCodingBEC
+  - AWGN    = ½ log(1 + P/N)      ShannonChannelCodingAWGN
+
+  For the AWGN channel that last value is assembled in `ShannonChannelCodingAWGN`
+  from the entropy difference h(Y) - h(Z) of the proven Gaussian differential
+  entropies. That file's scope note flagged ONE step as described in prose only:
+
+      "the chain-rule identity I(X;Y) = h(Y) - h(Z)" for the additive channel.
+
+  This file formalises the measure-theoretic core of that step.  For an additive
+  channel Y = X + Z with noise Z independent of the input, the output density
+  conditioned on the input value `x` is the noise density *shifted by x*,
+  `y ↦ fZ (y - x)`.  The decisive fact is that the differential entropy is
+  *translation invariant* — shifting a density does not change `h` — so the
+  conditional output entropy h(Y | X = x) equals h(Z) for every input value `x`,
+  and therefore the averaged conditional entropy h(Y | X) = h(Z) as well.  With
+  the chain rule I(X;Y) = h(Y) - h(Y | X) this gives the decomposition
+  I(X;Y) = h(Y) - h(Z) that the AWGN capacity rests on.
+
+  What is proved here, axiom-free:
+  - `differentialEntropy_translation`   : h(f(· - c)) = h(f)   (translation invariance)
+  - `additiveOutputDensity`             : the shifted-noise output density
+  - `additive_conditional_entropy_eq`   : h(Y | X = x) = h(Z) for every input x
+  - `gaussian_conditional_entropy_eq`   : the AWGN instance, h(Y | X = x) = ½log(2πeN)
+  - `additive_averaged_conditional_entropy` : averaging over the input law, h(Y|X)=h(Z)
+  - `additive_mutual_information_decomposition` : I(X;Y) = h(Y) - h(Z), where the
+        mutual information of the additive channel is taken as h(Y) - h(Y | X)
+
+  Scope note.  As in the parent file the two differential entropies h(Y), h(Z) and
+  the X-averaged conditional entropy are the grounded quantities; what remains
+  genuinely open is to prove that the information-theoretic mutual information,
+  defined as the KL divergence between the joint output–input law and the product
+  of its marginals, coincides with this entropy difference h(Y) - h(Y | X).  Here
+  that chain-rule form of I is taken as the definition (`additiveMutualInformation`)
+  and the translation-invariance core that makes h(Y | X) collapse to h(Z) is
+  proved outright.
+-/
+
+import Mathlib
+import Proofs.ShannonEntropyOQ01
+
+namespace ShannonAWGNOperational
+
+open DifferentialEntropy Real MeasureTheory
+
+/-! ## Translation invariance of differential entropy -/
+
+/-- **Translation invariance of differential entropy.**  Shifting a density by a
+    constant `c` leaves its differential entropy unchanged:
+    `h(f(· - c)) = h(f)`.  This is the change-of-variables `u = y - c` under the
+    translation-invariant Lebesgue measure, and it is the reason the conditional
+    output entropy of an additive channel does not depend on the input value. -/
+theorem differentialEntropy_translation (f : ℝ → ℝ) (c : ℝ) :
+    differentialEntropy (fun y => f (y - c)) = differentialEntropy f := by
+  unfold differentialEntropy
+  congr 1
+  exact integral_sub_right_eq_self (fun x => f x * Real.log (f x)) c
+
+/-! ## The additive channel -/
+
+/-- Output density of an additive channel `Y = X + Z` conditioned on the input
+    value `x`: the noise density `fZ` shifted so that its mean moves to `x`,
+    `y ↦ fZ (y - x)`.  (If `Z` has mean `0` then `Y | X = x` has mean `x`.) -/
+noncomputable def additiveOutputDensity (fZ : ℝ → ℝ) (x : ℝ) : ℝ → ℝ :=
+  fun y => fZ (y - x)
+
+/-- **Conditional output entropy of an additive channel.**  For every input value
+    `x`, the differential entropy of the (shifted) output density equals the noise
+    entropy: `h(Y | X = x) = h(Z)`.  Immediate from translation invariance. -/
+theorem additive_conditional_entropy_eq (fZ : ℝ → ℝ) (x : ℝ) :
+    differentialEntropy (additiveOutputDensity fZ x) = differentialEntropy fZ := by
+  unfold additiveOutputDensity
+  exact differentialEntropy_translation fZ x
+
+/-- The AWGN instance: with Gaussian noise `Z ~ N(0, N)` the conditional output
+    entropy `h(Y | X = x)` equals the noise entropy `½ log(2πe N)` for every input
+    `x`.  Combines `additive_conditional_entropy_eq` with the Gaussian entropy of
+    `ShannonChannelCodingAWGN`/`ShannonEntropyOQ01`. -/
+theorem gaussian_conditional_entropy_eq {N : ℝ} (hN : 0 < N) (x : ℝ) :
+    differentialEntropy (additiveOutputDensity (gaussianPDF 0 (Real.sqrt N)) x) =
+      (1 / 2) * Real.log (2 * Real.pi * Real.exp 1 * N) := by
+  rw [additive_conditional_entropy_eq]
+  have h := gaussianDifferentialEntropy 0 (Real.sqrt_pos.mpr hN)
+  rwa [Real.sq_sqrt hN.le] at h
+
+/-! ## Averaging over the input law -/
+
+/-- **Averaged conditional entropy.**  Averaging the per-input conditional output
+    entropy `h(Y | X = x)` over any input probability density `fX` (with
+    `∫ fX = 1`) gives the noise entropy `h(Z)`, because the integrand is the
+    constant `h(Z)`:  `∫ fX(x) · h(Y | X = x) dx = h(Z)`. -/
+theorem additive_averaged_conditional_entropy (fZ fX : ℝ → ℝ)
+    (hX : ∫ x, fX x = 1) :
+    ∫ x, fX x * differentialEntropy (additiveOutputDensity fZ x) =
+      differentialEntropy fZ := by
+  simp_rw [additive_conditional_entropy_eq]
+  rw [integral_mul_const, hX, one_mul]
+
+/-! ## The chain-rule decomposition -/
+
+/-- Mutual information of an additive channel, taken in its chain-rule form
+    `I(X;Y) = h(Y) - h(Y | X)`, where the conditional entropy `h(Y | X)` is the
+    `fX`-average of the per-input output entropies.  `hY` is the output
+    differential entropy `h(Y)`. -/
+noncomputable def additiveMutualInformation (fZ fX : ℝ → ℝ) (hY : ℝ) : ℝ :=
+  hY - ∫ x, fX x * differentialEntropy (additiveOutputDensity fZ x)
+
+/-- **Additive-channel decomposition `I(X;Y) = h(Y) - h(Z)`.**  For any input law
+    `fX` (`∫ fX = 1`) the chain-rule mutual information of the additive channel
+    collapses to the output entropy minus the noise entropy.  This is exactly the
+    identity that the AWGN capacity `½ log(1 + P/N)` rests on:  with the
+    capacity-achieving Gaussian output `h(Y) = ½ log(2πe(P+N))` and noise
+    `h(Z) = ½ log(2πe N)`, `I = ½ log(1 + P/N)`. -/
+theorem additive_mutual_information_decomposition (fZ fX : ℝ → ℝ) (hY : ℝ)
+    (hX : ∫ x, fX x = 1) :
+    additiveMutualInformation fZ fX hY = hY - differentialEntropy fZ := by
+  unfold additiveMutualInformation
+  rw [additive_averaged_conditional_entropy fZ fX hX]
+
+end ShannonAWGNOperational

--- a/src/data/proofs/shannon-channel-coding-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-01/meta.json
@@ -1,0 +1,148 @@
+{
+  "id": "shannon-channel-coding-oq-01",
+  "title": "Additive-Channel Decomposition I(X;Y) = h(Y) − h(Z)",
+  "slug": "shannon-channel-coding-oq-01",
+  "description": "Formalizes, axiom-free, the additive-channel mutual-information decomposition I(X;Y) = h(Y) − h(Z) that the AWGN capacity proof (ShannonChannelCodingAWGN) flagged as prose-only. The decisive fact is translation invariance of differential entropy: for an additive channel Y = X + Z the output density conditioned on input x is the noise density shifted by x, so h(Y | X = x) = h(Z) for every x; averaging over any input law (∫ fX = 1) gives h(Y | X) = h(Z), and the chain-rule form I = h(Y) − h(Y|X) collapses to h(Y) − h(Z). Introduces no axioms or sorries. SCOPE: the chain-rule form of mutual information is taken as the definition; proving it equals the KL-divergence definition is the part that remains genuinely open.",
+  "meta": {
+    "author": "Claude Shannon (1948), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Additive_white_Gaussian_noise",
+    "date": "1948",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShannonChannelCodingOQ01.lean",
+    "tags": [
+      "information-theory",
+      "analysis",
+      "probability",
+      "coding-theory",
+      "channel-capacity",
+      "differential-entropy",
+      "advanced"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.integral_sub_right_eq_self",
+        "description": "Translation invariance of the Lebesgue integral, the engine of differential-entropy translation invariance",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner"
+      },
+      {
+        "theorem": "MeasureTheory.integral_mul_const",
+        "description": "Pulls the constant noise entropy out of the input-averaging integral",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Axiom-free proof of translation invariance of differential entropy h(f(· − c)) = h(f) via integral_sub_right_eq_self",
+      "Conditional output entropy of an additive channel: h(Y | X = x) = h(Z) for every input value x",
+      "AWGN instance: with Gaussian noise N(0, N) the conditional output entropy equals ½ log(2πeN)",
+      "Averaged conditional entropy h(Y | X) = h(Z) for any input law with ∫ fX = 1",
+      "The chain-rule decomposition I(X;Y) = h(Y) − h(Z) for the additive channel, completing the step ShannonChannelCodingAWGN had flagged as prose-only"
+    ],
+    "assumptions": "0 axioms, 0 sorries, 0 native_decide. The file imports Mathlib and ShannonChannelCodingOQ01's dependency ShannonEntropyOQ01 (itself 0 axioms, 0 sorries); it uses gaussianDifferentialEntropy and differentialEntropy, neither of which lies on a path to any sorry. SCOPE: mutual information of the additive channel is taken in its chain-rule form I(X;Y) = h(Y) − h(Y|X) as a definition (additiveMutualInformation). What remains genuinely open — and is NOT formalized here — is proving that this chain-rule form coincides with the measure-theoretic definition of mutual information as the KL divergence between the joint output–input law and the product of its marginals. The translation-invariance core that makes h(Y|X) collapse to h(Z) is proved outright. This entry therefore advances, but does not close, the operational mutual-information layer flagged as prose-only in ShannonChannelCodingAWGN.",
+    "dateAdded": "2026-06-18",
+    "axiomCount": 0,
+    "lineCount": 130,
+    "prerequisites": [
+      "Differential entropy h(f) = −∫ f log f (ShannonEntropyOQ01.lean)",
+      "Gaussian differential entropy h(N(μ,σ²)) = ½ log(2πe σ²) (ShannonEntropyOQ01.lean)",
+      "Translation invariance of the Lebesgue integral",
+      "AWGN capacity formula assembly (ShannonChannelCodingAWGN.lean)"
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Shannon's 1948 treatment of the continuous (additive Gaussian) channel rests on the identity I(X;Y) = h(Y) − h(Z) for a channel of the form Y = X + Z with the noise Z independent of the input. Combined with the Gaussian maximum-entropy property and a power constraint E[X²] ≤ P, this yields the celebrated capacity C = ½ log(1 + P/N). The AWGN capacity entry in this gallery proved the capacity-value assembly but flagged one ingredient as described in prose only: the chain-rule decomposition I(X;Y) = h(Y) − h(Z) for the additive channel. This entry formalizes that decomposition, axiom-free.",
+    "problemStatement": "**Additive-channel decomposition.** For an additive channel Y = X + Z with noise Z of density fZ independent of the input X (density fX, ∫ fX = 1), the chain-rule mutual information satisfies\n$$I(X;Y) = h(Y) - h(Z),$$\nwhere h denotes differential entropy. The key sub-claim is that the conditional output entropy is input-independent: $h(Y \\mid X = x) = h(Z)$ for every $x$.",
+    "text": "Formalizes the additive-channel mutual-information decomposition I(X;Y) = h(Y) − h(Z) via translation invariance of differential entropy.",
+    "proofStrategy": "1. **Translation invariance.** h(f(· − c)) = h(f): unfolding the definition of differential entropy reduces to ∫ f(y−c) log f(y−c) dy = ∫ f(y) log f(y) dy, which is exactly integral_sub_right_eq_self for the Lebesgue measure.\n\n2. **Conditional output entropy.** For an additive channel the output density given X = x is the shifted noise density y ↦ fZ(y − x) (additiveOutputDensity). By translation invariance its differential entropy equals h(Z), independent of x: h(Y | X = x) = h(Z).\n\n3. **AWGN instance.** Specializing fZ to the Gaussian N(0, N) density and combining with gaussianDifferentialEntropy gives h(Y | X = x) = ½ log(2πeN).\n\n4. **Averaging over the input law.** Since the per-input entropy is the constant h(Z), averaging against any density fX with ∫ fX = 1 leaves it unchanged: ∫ fX(x) · h(Y | X = x) dx = h(Z) (integral_mul_const).\n\n5. **Chain-rule decomposition.** Taking mutual information in its chain-rule form I = h(Y) − h(Y|X), step 4 collapses h(Y|X) to h(Z), giving I(X;Y) = h(Y) − h(Z).",
+    "keyInsights": [
+      "Translation invariance of differential entropy is the whole engine: shifting a density does not change −∫ f log f",
+      "For an additive channel the conditional output density is just the noise density shifted by the input value, so h(Y | X = x) is independent of x",
+      "Because the per-input conditional entropy is a constant, averaging it over any input law is trivial — it stays h(Z)",
+      "The AWGN value ½ log(2πeN) for the conditional entropy drops out by reusing the proven Gaussian differential entropy",
+      "The decomposition is the exact step the AWGN capacity entry had to leave in prose; here it is machine-checked for the chain-rule definition of mutual information"
+    ],
+    "prerequisites": [
+      "Differential entropy and its definition h(f) = −∫ f log f",
+      "Gaussian differential entropy",
+      "Translation invariance of the Lebesgue integral",
+      "The AWGN capacity formula and its entropy-difference assembly"
+    ]
+  },
+  "sections": [
+    {
+      "id": "translation-invariance",
+      "title": "Translation Invariance of Differential Entropy",
+      "startLine": 56,
+      "endLine": 67,
+      "description": "h(f(· − c)) = h(f) via integral_sub_right_eq_self.",
+      "summary": "h(f(· − c)) = h(f) via integral_sub_right_eq_self."
+    },
+    {
+      "id": "additive-channel",
+      "title": "The Additive Channel",
+      "startLine": 69,
+      "endLine": 83,
+      "description": "Shifted-noise output density and the conditional output entropy h(Y | X = x) = h(Z).",
+      "summary": "Shifted-noise output density and the conditional output entropy h(Y | X = x) = h(Z)."
+    },
+    {
+      "id": "awgn-instance",
+      "title": "AWGN Instance",
+      "startLine": 85,
+      "endLine": 94,
+      "description": "With Gaussian noise N(0, N), h(Y | X = x) = ½ log(2πeN).",
+      "summary": "With Gaussian noise N(0, N), h(Y | X = x) = ½ log(2πeN)."
+    },
+    {
+      "id": "averaging",
+      "title": "Averaging Over the Input Law",
+      "startLine": 96,
+      "endLine": 107,
+      "description": "∫ fX(x) · h(Y | X = x) dx = h(Z) for any input law with ∫ fX = 1.",
+      "summary": "∫ fX(x) · h(Y | X = x) dx = h(Z) for any input law with ∫ fX = 1."
+    },
+    {
+      "id": "chain-rule",
+      "title": "The Chain-Rule Decomposition",
+      "startLine": 109,
+      "endLine": 129,
+      "description": "I(X;Y) = h(Y) − h(Z) for the chain-rule form of additive-channel mutual information.",
+      "summary": "I(X;Y) = h(Y) − h(Z) for the chain-rule form of additive-channel mutual information."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization proves, axiom-free, the additive-channel mutual-information decomposition I(X;Y) = h(Y) − h(Z) that the AWGN capacity entry had flagged as prose-only. Translation invariance of differential entropy makes the conditional output entropy h(Y | X = x) collapse to the noise entropy h(Z) for every input, and averaging over any input law preserves the constant, so the chain-rule mutual information reduces to the output entropy minus the noise entropy. No new axioms or sorries are introduced.",
+    "implications": "Completes the entropy-side reasoning behind the AWGN capacity C = ½ log(1 + P/N): together with the Gaussian maximum-entropy output and noise entropy ½ log(2πeN), the decomposition gives I = ½ log(1 + P/N). It supplies a reusable translation-invariance lemma for differential entropy and an explicit additive-channel conditional-entropy computation.",
+    "openQuestions": [
+      "Prove that the chain-rule form I = h(Y) − h(Y|X) coincides with the KL-divergence definition of mutual information (joint law vs. product of marginals) — the part taken definitionally here",
+      "Construct the joint distribution of (X, Y) measure-theoretically for the additive channel and connect it to this decomposition",
+      "Derive the variance-of-a-sum relation E[Y²] = P + N as a theorem rather than a hypothesis in the converse",
+      "Assemble a fully operational AWGN coding theorem combining this decomposition with achievability and converse"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-channel-coding-awgn",
+      "relationship": "extends",
+      "description": "Formalizes the chain-rule decomposition I(X;Y) = h(Y) − h(Z) that the AWGN capacity entry described in prose only"
+    },
+    {
+      "targetId": "shannon-entropy-oq-01",
+      "relationship": "uses",
+      "description": "Uses the differential entropy definition and the Gaussian differential entropy ½ log(2πe σ²)"
+    }
+  ],
+  "leanFile": {
+    "axiomCount": 0,
+    "lineCount": 130,
+    "path": "Proofs/ShannonChannelCodingOQ01.lean",
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 5
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
Axiom-free formalization of the additive-channel mutual-information decomposition I(X;Y)=h(Y)-h(Z) that ShannonChannelCodingAWGN flagged as prose-only. Translation invariance of differential entropy ⟹ h(Y|X=x)=h(Z); chain-rule collapses to h(Y)-h(Z). AWGN instance reuses the proven Gaussian differential entropy. 0 sorry / 0 axiom / 0 native_decide. Build verified green; `#print axioms` clean. Gallery meta verified/original/axiomCount 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)