### PR TITLE
audit(erdos-124-complete-sequences): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4598,8 +4598,8 @@
     },
     "erdos-124-complete-sequences": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T07:36:52Z",
       "result": "clean"
     },
     "erdos-125": {


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: erdos-124-complete-sequences (Erdős #124 — first open conjecture solved autonomously by AI, Harmonic Aristotle)
**Result**: CLEAN

Gallery is saturated (2550/2550 audited, 0 issues). `find-targets --next` served erdos-124 as the **stalest** entry (lastAudited 2026-05-03, ~6 weeks). Re-audited against `proofs/Proofs/Erdos124CompleteSequences.lean`.

## Verification (meta.json vs Lean source)

| Field | meta.json | source | ✓ |
|-------|-----------|--------|---|
| lineCount | 507 | 507 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 `axiom`, 0 `native_decide`, 0 structures | ✓ |
| theoremCount | 18 | 18 thm+lemma | ✓ |
| definitionCount | 6 | 6 | ✓ |
| status / badge | verified / mathlib | consistent | ✓ |

- No True stubs.
- Main theorem `erdos_conjecture_true` (L415) genuinely proved in-file via Brown's criterion + greedy `u_seq` + gap lemma + digit decomposition — **not** an opaque Mathlib wrapper. Badge `mathlib` is conservative.
- `formal_conjectures_erdos_124{,_corrected}` (`P ↔ true`) genuinely prove the LHS conjecture statement (construct witnesses via `erdos_conjecture_true`) — not stubs/`True`-placeholders.
- No structure-encoded assumptions (no structures/classes in file).

## Change

Tracker-only: `auditCount` 3→4, `lastAudited` bumped, `result: clean`. Surgical 2-line edit; no meta.json or source changes.

---
Discovered during gallery integrity audit.