### PR TITLE
research(pentagonal-number-theorem-oq-01): index bounds make Euler's recurrence a finite sum

### DIFF
--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -28,6 +28,10 @@
   - `isGenPent_iff_isSquare` — HEADLINE: pentagonality ⟺ `24m+1` a perfect square
   - `isGenPent_nonneg`       — generalized pentagonal numbers are nonnegative
   - `genPent_injective`      — distinct indices give distinct pentagonal numbers
+  - `genPent_sq_le_self`     — quadratic growth `k² ≤ g(k)`
+  - `abs_index_le_genPent`   — index bound `|k| ≤ g(k)`
+  - `indexSet_finite`        — only finitely many `g(k) ≤ n` (Euler's recurrence
+                               is a finite sum)
   - concrete values `g(0..±4) = 0,1,2,5,7,12,15,22,26` matching the OEIS A001318.
 -/
 
@@ -122,7 +126,7 @@ theorem isGenPent_iff_isSquare (m : ℤ) :
 theorem isGenPent_nonneg {m : ℤ} (h : IsGenPent m) : 0 ≤ m := by
   obtain ⟨k, hk⟩ := h
   have hnn : 0 ≤ k * (3 * k - 1) := by
-    rcases le_or_lt k 0 with hk0 | hk0
+    rcases le_or_gt k 0 with hk0 | hk0
     · have hrw : k * (3 * k - 1) = (-k) * (1 - 3 * k) := by ring
       rw [hrw]; exact mul_nonneg (by omega) (by omega)
     · exact mul_nonneg (by omega) (by omega)
@@ -138,6 +142,64 @@ theorem genPent_injective : Function.Injective genPent := by
   rcases mul_eq_zero.mp hfac with h | h
   · linarith
   · omega
+
+/-! ## Part 3b: Index bounds — Euler's recurrence is a finite sum
+
+Euler's partition recurrence `p(n) = ∑_{k≠0} (-1)^{k-1} p(n - g(k))` is only
+useful because the sum is **finite**: for fixed `n` only finitely many
+generalized pentagonal numbers are `≤ n`.  We make this precise and quantitative.
+The key estimate is `k² ≤ g(k)` (so the value grows at least quadratically in the
+index), which immediately bounds the index `|k| ≤ g(k)` and shows the set of
+indices contributing to the recurrence at level `n` is finite. -/
+
+/-- Product of consecutive integers `k·(k-1) ≥ 0` (one factor is `≤ 0` exactly
+when the other is). -/
+theorem mul_pred_nonneg (k : ℤ) : 0 ≤ k * (k - 1) := by
+  rcases le_or_gt k 0 with hk | hk
+  · have h : k * (k - 1) = (-k) * (1 - k) := by ring
+    rw [h]; exact mul_nonneg (by omega) (by omega)
+  · exact mul_nonneg (by omega) (by omega)
+
+/-- Product of consecutive integers `k·(k+1) ≥ 0`. -/
+theorem mul_succ_nonneg (k : ℤ) : 0 ≤ k * (k + 1) := by
+  rcases le_or_gt k (-1) with hk | hk
+  · have h : k * (k + 1) = (-k) * (-(k + 1)) := by ring
+    rw [h]; exact mul_nonneg (by omega) (by omega)
+  · exact mul_nonneg (by omega) (by omega)
+
+/-- **Quadratic growth.** `k² ≤ g(k)`: the pentagonal number dominates the square
+of its index, since `2g(k) - 2k² = k(k-1) ≥ 0`. -/
+theorem genPent_sq_le_self (k : ℤ) : k ^ 2 ≤ genPent k := by
+  have hd := two_mul_genPent k
+  nlinarith [hd, mul_pred_nonneg k]
+
+/-- `k ≤ g(k)`, from `2g(k) - 2k = 3k(k-1) ≥ 0`. -/
+theorem index_le_genPent (k : ℤ) : k ≤ genPent k := by
+  have hd := two_mul_genPent k
+  nlinarith [hd, mul_pred_nonneg k]
+
+/-- `-k ≤ g(k)`, from `2g(k) + 2k = 2k² + k(k+1) ≥ 0`. -/
+theorem neg_index_le_genPent (k : ℤ) : -k ≤ genPent k := by
+  have hd := two_mul_genPent k
+  nlinarith [hd, mul_succ_nonneg k, sq_nonneg k]
+
+/-- **Index bound.** `|k| ≤ g(k)`: the index of a generalized pentagonal number is
+bounded by its value. -/
+theorem abs_index_le_genPent (k : ℤ) : |k| ≤ genPent k := by
+  rw [abs_le]
+  exact ⟨by linarith [neg_index_le_genPent k], index_le_genPent k⟩
+
+/-- **Finite support of Euler's recurrence.** For any bound `n`, only finitely many
+indices `k` have `g(k) ≤ n`; equivalently, the sum in Euler's partition recurrence
+at level `n` ranges over a finite set.  Indeed every such index lies in `[-n, n]`. -/
+theorem indexSet_finite (n : ℤ) : {k : ℤ | genPent k ≤ n}.Finite := by
+  apply Set.Finite.subset (Set.finite_Icc (-n) n)
+  intro k hk
+  rw [Set.mem_setOf_eq] at hk
+  have hb : |k| ≤ n := le_trans (abs_index_le_genPent k) hk
+  rw [Set.mem_Icc]
+  rw [abs_le] at hb
+  exact hb
 
 /-! ## Part 4: Concrete values (OEIS A001318)
 

--- a/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
+++ b/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
@@ -36,9 +36,30 @@ Supporting, fully proved:
 - `isGenPent_nonneg`.
 - Concrete values `g(0..±4) = 0,1,2,5,7,12,15,22,26` matching A001318.
 
+**Session 2 addition — index bounds / finiteness of Euler's recurrence:**
+- `mul_pred_nonneg`, `mul_succ_nonneg`: products of consecutive integers
+  `k(k-1) ≥ 0`, `k(k+1) ≥ 0` (case split + `mul_nonneg`).
+- `genPent_sq_le_self`: **quadratic growth** `k² ≤ g(k)` (since
+  `2g(k) - 2k² = k(k-1) ≥ 0`).
+- `index_le_genPent` / `neg_index_le_genPent` / `abs_index_le_genPent`:
+  the index is bounded by the value, `|k| ≤ g(k)`.
+- `indexSet_finite`: for any `n`, `{k | g(k) ≤ n}` is **finite** (⊆ `[-n,n]`).
+  This is the precise statement that Euler's partition recurrence
+  `p(n) = ∑_{k≠0} (-1)^{k-1} p(n-g(k))` is a *finite* sum — a prerequisite for
+  any algorithmic/inductive use of the recurrence.
+
 ## Status of verification
 
-**BUILD-PENDING.** This cycle both verification backends were unavailable:
+**BUILD-VERIFIED (2026-06-19, Session 2).** Docker build green, 7743 jobs,
+`✔ Built Proofs.PentagonalNumberTheoremOQ01`, 0 errors, 0 warnings (the
+`le_or_lt` deprecation warnings were fixed to `le_or_gt`). The Session-1 file was
+already merged build-verified via PR #25893; Session 2 adds the index-bound /
+finiteness layer (`genPent_sq_le_self`, `abs_index_le_genPent`, `indexSet_finite`)
+on top, build-confirmed.
+
+---
+
+### Historical (Session 1, 2026-06-18) — was BUILD-PENDING at the time:
 - Aristotle MCP returned `Resource not found` (404) on every call.
 - Docker Lean build was blocked: 10+ concurrent worktree builds contend on the
   shared (symlinked) `proofs/.lake`; a deterministic ProofWidgets cloud-release
@@ -79,3 +100,25 @@ fails, the likely culprits are exact lemma names (`Int.cast_pow`,
 `ZMod.intCast_zmod_eq_zero_iff_dvd`, `Int.mul_ediv_cancel'`) and the `ZMod 6`
 `decide` / `push_cast` plumbing in `isGenPent_iff_isSquare`; (3) the genuine
 mathematical frontier is Franklin's involution for the deep identity.
+
+### 2026-06-19 (Session 2) — DEEPEN (build-verified)
+
+**Mode**: DEEPEN · **Outcome**: progress (build-verified)
+
+- Session-1 file was already merged build-verified (PR #25893). Rather than
+  re-survey, added the next tractable, on-target layer: the **index-bound /
+  finiteness** theory that makes Euler's partition recurrence a *finite* sum.
+- New: `mul_pred_nonneg`, `mul_succ_nonneg` (consecutive-integer products ≥ 0);
+  `genPent_sq_le_self` (`k² ≤ g(k)`, quadratic growth); `index_le_genPent`,
+  `neg_index_le_genPent`, `abs_index_le_genPent` (`|k| ≤ g(k)`);
+  `indexSet_finite` (`{k | g(k) ≤ n}` finite, ⊆ `[-n,n]`). All via
+  `two_mul_genPent` + `nlinarith` / `Set.Finite.subset Set.finite_Icc`.
+- Build green (7743 jobs, 0 sorry, 0 axiom). Fixed `le_or_lt`→`le_or_gt`
+  deprecation so the file is warning-clean.
+
+**Next steps**: the genuine frontier remains Franklin's involution for the deep
+identity `p_even(n) - p_odd(n) = [n=g(k)]·(-1)ᵏ`. A tractable intermediate would
+be to *define* the partition-into-distinct-parts sign and state (not yet prove)
+the identity, or to formalize the explicit finite form of Euler's recurrence
+`p(n) = ∑_{k=1}^{K(n)} (-1)^{k-1}(p(n-g_k)+p(n-g_{-k}))` now that `indexSet_finite`
+supplies the finite support.

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -43,13 +43,14 @@
       "A division-free formalization of generalized pentagonal numbers via the doubling predicate 2m = k(3k-1), with two_mul_genPent certifying exactness",
       "genPent_injective: distinctness of pentagonal numbers across indices, via the factorization (a-b)(3(a+b)-1)=0 and impossibility of 3(a+b)=1 over ℤ",
       "A ZMod-6 decision argument turning 's² = 24m+1' into 's ≡ ±1 (mod 6)', recovering the index from each residue class",
-      "Concrete values g(0..±4) = 0,1,2,5,7,12,15,22,26 matching OEIS A001318, with a sanity check that 12 = g(3) and 24·12+1 = 17²"
+      "Concrete values g(0..±4) = 0,1,2,5,7,12,15,22,26 matching OEIS A001318, with a sanity check that 12 = g(3) and 24·12+1 = 17²",
+      "Index-bound theory making Euler partition recurrence a finite sum: genPent_sq_le_self (k^2 <= g(k), quadratic growth), abs_index_le_genPent (|k| <= g(k)), and indexSet_finite ({k | g(k) <= n} is finite, contained in [-n,n])"
     ],
     "dateAdded": "2026-06-18",
     "axiomCount": 0,
-    "lineCount": 179,
-    "assumptions": "None: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. Machine-verified — the file compiles cleanly under the docker Lean build against Mathlib (Built Proofs.PentagonalNumberTheoremOQ01, 7743 jobs, exit 0; only a single harmless `le_or_lt` deprecation warning).",
-    "theoremCount": 16,
+    "lineCount": 241,
+    "assumptions": "None: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. Machine-verified — the file compiles cleanly under the docker Lean build against Mathlib (Built Proofs.PentagonalNumberTheoremOQ01, 7743 jobs, exit 0, warning-clean).",
+    "theoremCount": 23,
     "definitionCount": 2
   },
   "overview": {

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -75,39 +75,47 @@
       "id": "setup",
       "title": "Setup: Generalized Pentagonal Numbers",
       "startLine": 1,
-      "endLine": 66,
+      "endLine": 71,
       "summary": "Module documentation, the value genPent and the division-free membership predicate IsGenPent, evenness of k(3k-1), and the exact doubling relation two_mul_genPent.",
       "mathContext": "g(k) = k(3k-1)/2 with 2·g(k) = k(3k-1). Since one of k, 3k-1 is even, the half is exact; membership is carried by the relation 2m = k(3k-1) to keep proofs over ℤ without integer division."
     },
     {
       "id": "criterion",
       "title": "The Square-Discriminant Criterion (Headline)",
-      "startLine": 68,
-      "endLine": 116,
+      "startLine": 73,
+      "endLine": 121,
       "summary": "isGenPent_iff_isSquare: m is a generalized pentagonal number iff 24m+1 is a perfect square. Forward via 24·g(k)+1 = (6k-1)²; converse via a ZMod-6 residue argument recovering the index.",
       "mathContext": "Forward: linear_combination on 2m=k(3k-1). Converse: s²=24m+1 ⟹ (s mod 6)²=1 ⟹ s≡±1 (mod 6); 6∣(s∓1) gives s=6k±1, and cancelling 12 yields 2m=k'(3k'-1)."
     },
     {
       "id": "structural",
       "title": "Structural Facts: Nonnegativity and Injectivity",
-      "startLine": 118,
-      "endLine": 139,
+      "startLine": 123,
+      "endLine": 144,
       "summary": "isGenPent_nonneg (k(3k-1) ≥ 0) and genPent_injective (distinct indices give distinct pentagonal numbers).",
       "mathContext": "Injectivity reduces to (a-b)(3(a+b)-1)=0; since 3(a+b)=1 has no integer solution, a=b. Nonnegativity is a sign analysis of the two factors of k(3k-1)."
     },
     {
+      "id": "index-bounds",
+      "title": "Index Bounds: Euler's Recurrence is a Finite Sum",
+      "startLine": 146,
+      "endLine": 202,
+      "summary": "Quadratic growth k² ≤ g(k) (genPent_sq_le_self), the resulting index bound |k| ≤ g(k) (abs_index_le_genPent), and indexSet_finite: {k | g(k) ≤ n} ⊆ [-n, n] is finite, so the pentagonal sum in Euler's partition recurrence at level n ranges over a finite set.",
+      "mathContext": "From the doubling relation, 2g(k) − 2k² = k(k−1) ≥ 0 gives k² ≤ g(k); combining k ≤ g(k) and −k ≤ g(k) yields |k| ≤ g(k). Hence g(k) ≤ n forces |k| ≤ n, bounding the recurrence's support inside [-n, n]."
+    },
+    {
       "id": "values",
       "title": "Concrete Values (OEIS A001318)",
-      "startLine": 141,
-      "endLine": 159,
+      "startLine": 204,
+      "endLine": 221,
       "summary": "The first generalized pentagonal numbers g(0..±4) = 0,1,2,5,7,12,15,22,26, and a sanity check that 12 = g(3) is recognized via 24·12+1 = 289 = 17².",
       "mathContext": "Indexing k = 0,1,-1,2,-2,… enumerates the pentagonal numbers in increasing order, matching OEIS A001318."
     },
     {
       "id": "open-core",
       "title": "Open Core: Franklin's Involution (Not Formalized)",
-      "startLine": 161,
-      "endLine": 177,
+      "startLine": 223,
+      "endLine": 239,
       "summary": "Documents the deep generating-function identity ∏(1-Xⁿ)=∑(-1)ᵏX^{g(k)} and its bijective proof via Franklin's sign-reversing involution on partitions into distinct parts, explaining why it is out of scope: Mathlib lacks distinct-partition parity machinery and formal-power-series infinite products. The index theory this entry supplies is exactly what such a development would consume.",
       "mathContext": "Equivalently p_even(n)-p_odd(n) = [n=g(k)]·(-1)ᵏ, where p_even/p_odd count partitions into an even/odd number of distinct parts; Franklin's involution's only fixed points are the staircase partitions of the generalized pentagonal numbers g(k)."
     }

--- a/src/data/research/problems/pentagonal-number-theorem-oq-01.json
+++ b/src/data/research/problems/pentagonal-number-theorem-oq-01.json
@@ -8,14 +8,17 @@
       "Euler's pentagonal number theorem's exponents g(k)=k(3k-1)/2 form an index set whose recognition criterion is purely number-theoretic: m is generalized pentagonal iff 24m+1 is a perfect square, because 24·g(k)+1 = (6k-1)².",
       "The converse rests on a modular fact decidable in ZMod 6: a square s² = 24m+1 satisfies s² ≡ 1 (mod 6), which holds only for s ≡ ±1 (mod 6); each residue class yields an explicit index k with 6k-1 = ±s.",
       "Working with the doubling relation 2m = k(3k-1) as the membership predicate (instead of g(k)=k(3k-1)/2) sidesteps integer division entirely; exactness of the division is a one-line even/odd case split.",
-      "Mathlib has Nat.Partition but neither Franklin's involution, distinct-part partitions with a parity sign, nor the formal power-series infinite product, so the deep identity has no Mathlib bearer; the index-set theory is the tractable, self-contained piece."
+      "Mathlib has Nat.Partition but neither Franklin's involution, distinct-part partitions with a parity sign, nor the formal power-series infinite product, so the deep identity has no Mathlib bearer; the index-set theory is the tractable, self-contained piece.",
+      "Euler's partition recurrence is a FINITE sum because the pentagonal value grows quadratically in its index: k² ≤ g(k) (since 2g(k)-2k² = k(k-1) ≥ 0), hence |k| ≤ g(k) and only finitely many g(k) ≤ n (the contributing indices lie in [-n,n]). This finiteness is the prerequisite that lets the recurrence p(n)=∑(-1)^{k-1}p(n-g_k) be evaluated/inducted on."
     ],
     "builtItems": [
       "genPent, IsGenPent (def): generalized pentagonal number value and the doubling-relation membership predicate [PentagonalNumberTheoremOQ01.lean]",
       "isGenPent_iff_isSquare: HEADLINE — m generalized pentagonal ⟺ 24m+1 a perfect square [PentagonalNumberTheoremOQ01.lean]",
       "two_dvd_index_mul, two_mul_genPent: k(3k-1) even; exact doubling 2·g(k)=k(3k-1) [PentagonalNumberTheoremOQ01.lean]",
       "genPent_injective: distinct indices give distinct pentagonal numbers, via (a-b)(3(a+b)-1)=0 and 3(a+b)≠1 over ℤ [PentagonalNumberTheoremOQ01.lean]",
-      "isGenPent_nonneg + concrete values g(0..±4)=0,1,2,5,7,12,15,22,26 (OEIS A001318) [PentagonalNumberTheoremOQ01.lean]"
+      "isGenPent_nonneg + concrete values g(0..±4)=0,1,2,5,7,12,15,22,26 (OEIS A001318) [PentagonalNumberTheoremOQ01.lean]",
+      "genPent_sq_le_self (k²≤g(k)), index_le_genPent / neg_index_le_genPent / abs_index_le_genPent (|k|≤g(k)), mul_pred_nonneg / mul_succ_nonneg (consecutive-integer products ≥0) [PentagonalNumberTheoremOQ01.lean]",
+      "indexSet_finite: for any n, {k | g(k) ≤ n} is finite (⊆ [-n,n]) — Euler's recurrence is a finite sum [PentagonalNumberTheoremOQ01.lean]"
     ],
     "mathlibGaps": [
       "No Franklin sign-reversing involution on partitions into distinct parts.",
@@ -23,10 +26,10 @@
       "No formal-power-series manipulation of the infinite product ∏(1-Xⁿ) needed for the pentagonal identity itself."
     ],
     "nextSteps": [
-      "Confirm the file compiles: re-run the docker build when concurrent load drops, or submit to Aristotle when the MCP recovers (both backends were down this cycle).",
-      "If a tactic fails, suspect exact lemma names (Int.cast_pow, ZMod.intCast_zmod_eq_zero_iff_dvd, Int.mul_ediv_cancel') and the ZMod 6 decide / push_cast plumbing in isGenPent_iff_isSquare.",
-      "Mathematical frontier: build Franklin's involution to reach the deep identity p_even(n)-p_odd(n) = [n=g(k)]·(-1)ᵏ."
+      "Mathematical frontier: build Franklin's involution to reach the deep identity p_even(n)-p_odd(n) = [n=g(k)]·(-1)ᵏ.",
+      "Tractable intermediate now that indexSet_finite supplies finite support: formalize the explicit finite form of Euler's recurrence p(n) = ∑_{k=1}^{K(n)} (-1)^{k-1}(p(n-g_k)+p(n-g_{-k})), or define the partition-into-distinct-parts parity sign and state the identity.",
+      "Define a Finset enumerator of pentagonal indices ≤ n (via abs_index_le_genPent / indexSet_finite) to make the recurrence computable."
     ],
-    "progressSummary": "PROGRESS (build-pending): formalized the generalized-pentagonal-number foundation with the headline 24m+1-square recognition criterion (16 thms, 0 ax, 0 sorry). Hand-audited; not yet machine-checked (Aristotle 404 + docker build contention). Deep identity (Franklin's involution) documented as open core."
+    "progressSummary": "BUILD-VERIFIED (Session 2, 2026-06-19): foundation file (headline 24m+1-square recognition criterion) was merged build-verified via PR #25893; Session 2 adds the index-bound / finiteness layer — k²≤g(k) (quadratic growth), |k|≤g(k), and indexSet_finite ({k|g(k)≤n} finite ⊆ [-n,n]), which is the precise statement that Euler's partition recurrence is a finite sum. Build green (7743 jobs), 0 sorry, 0 axiom, warning-clean. Deep identity (Franklin's involution) remains the open core."
   }
 }


### PR DESCRIPTION
## Summary

Adds an **Index Bounds** layer to the pentagonal-number-theorem entry, formalizing
*why Euler's partition recurrence is a finite sum*. The recurrence
`p(n) = ∑_{k≠0} (-1)^{k-1} p(n − g(k))` is only well-defined because, for fixed `n`,
only finitely many generalized pentagonal numbers `g(k) = k(3k−1)/2` are `≤ n`.

## New lemmas (all sorry-free, axiom-free)

- `mul_pred_nonneg` / `mul_succ_nonneg` — `k(k−1) ≥ 0`, `k(k+1) ≥ 0` over ℤ.
- `genPent_sq_le_self` — **quadratic growth** `k² ≤ g(k)`, since `2g(k) − 2k² = k(k−1) ≥ 0`.
- `index_le_genPent` / `neg_index_le_genPent` — `k ≤ g(k)` and `−k ≤ g(k)`.
- `abs_index_le_genPent` — **index bound** `|k| ≤ g(k)`.
- `indexSet_finite` — `{k | g(k) ≤ n}` is finite (⊆ `[−n, n]`), so the recurrence's
  support at level `n` is finite.

All proofs go through `two_mul_genPent` (the existing exact doubling relation) plus
`nlinarith` / `omega` / `Set.Finite.subset`. No new axioms; no `native_decide`.

## Build

`✔ [7743/7743] Built Proofs.PentagonalNumberTheoremOQ01` — green via Docker wrapper.
File: 0 `sorry`, 0 `axiom`, 0 `native_decide`. Status `verified`/`original`/`axiomCount 0`.

## Scope

This is supporting index theory; the deep generating-function identity (Franklin's
sign-reversing involution) remains documented as the out-of-scope open core, exactly
as before. The index bounds added here are precisely what a future formalization of
that identity would consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)