### PR TITLE
research(abel-ruffini-oq-07): p=3 Frobenius 5-cycle witness + capstone

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniOQ07.lean
@@ -61,6 +61,7 @@
 
 import Mathlib.GroupTheory.Perm.Cycle.Type
 import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.Tactic
 
 open Equiv Equiv.Perm Polynomial
@@ -161,5 +162,66 @@ theorem frob2_pow_three_eq_swap : frob2 ^ 3 = Equiv.swap (0 : Fin 5) 1 := by dec
     by `gal_eq_top_of_five_dvd_and_swap`: `frob2 ^ 3` is a swap. -/
 theorem frob2_pow_three_isSwap : (frob2 ^ 3).IsSwap :=
   frob2_pow_three_eq_swap ▸ ⟨0, 1, by decide, rfl⟩
+
+/-! ## A concrete Frobenius witness at `p = 3`
+
+The corrected proof's *order-divisibility* input — hypothesis `(a)`,
+`5 ∣ |Gal|`, of `gal_eq_top_of_five_dvd_and_swap` — comes from the factorisation of
+`f` modulo 3:
+
+    X⁵ − X − 1  is irreducible   (mod 3).
+
+A Frobenius element of `f` at `3` therefore has cycle type `(5)`: it is a single
+`5`-cycle, an element of order `5`.  Such an element lies in the Galois group, so by
+Lagrange `5 = orderOf(Frobenius) ∣ |Gal|`.  Where the prose above only *asserts*
+"irreducible mod 3 ⟹ 5-cycle ⟹ 5 ∣ |Gal|", we now exhibit such an element
+`frob3 ∈ S₅` concretely and machine-check that it has order `5`, then derive the
+divisibility input for *any* subgroup containing it — turning the prose cycle-type
+computation into verified permutation data, exactly as `frob2` does for the swap. -/
+
+/-- A representative `5`-cycle of `S₅`, written as a product of adjacent
+    transpositions: `(0 1)(1 2)(2 3)(3 4) = (0 1 2 3 4)`.  This models a Frobenius
+    element of `f` at `p = 3`, whose factorisation type mod 3 is a single irreducible
+    quintic, i.e. one `5`-cycle. -/
+def frob3 : S5 := Equiv.swap 0 1 * (Equiv.swap 1 2 * (Equiv.swap 2 3 * Equiv.swap 3 4))
+
+/-- `frob3 ^ 5 = 1`: the `5`-cycle returns to the identity after five steps. -/
+theorem frob3_pow_five : frob3 ^ 5 = 1 := by decide
+
+/-- `frob3 ≠ 1`: it genuinely moves points (so its order is not `1`). -/
+theorem frob3_ne_one : frob3 ≠ 1 := by decide
+
+/-- The `p = 3` Frobenius `frob3` has **order `5`**.  Since `5` is prime, its order
+    divides `5` and is not `1`, hence equals `5` — the precise content of
+    "irreducible mod 3 ⟹ a `5`-cycle Frobenius". -/
+theorem orderOf_frob3 : orderOf frob3 = 5 := by
+  have hdvd : orderOf frob3 ∣ 5 := orderOf_dvd_of_pow_eq_one frob3_pow_five
+  rcases (Nat.Prime.eq_one_or_self_of_dvd (by norm_num) _ hdvd) with h | h
+  · exact absurd (orderOf_eq_one_iff.mp h) frob3_ne_one
+  · exact h
+
+/-- **The `5 ∣ |Gal|` input, made concrete.**
+    Any subgroup `G ≤ S₅` that contains the order-`5` Frobenius `frob3` has order
+    divisible by `5` (Lagrange).  This supplies hypothesis `(a)` of
+    `gal_eq_top_of_five_dvd_and_swap` from a single membership fact, replacing the
+    prose appeal to transitivity / a `5`-cycle. -/
+theorem five_dvd_card_of_frob3_mem {G : Subgroup S5} [DecidablePred (· ∈ G)]
+    (h : frob3 ∈ G) : 5 ∣ Fintype.card G := by
+  have hco : orderOf (⟨frob3, h⟩ : G) = 5 := by
+    rw [Subgroup.orderOf_mk]; exact orderOf_frob3
+  have hd : orderOf (⟨frob3, h⟩ : G) ∣ Fintype.card G := orderOf_dvd_card
+  rwa [hco] at hd
+
+/-- **Capstone: both Frobenius witnesses ⟹ the full Galois group is `S₅`.**
+    A subgroup `G ≤ S₅` containing *both* the `p = 3` Frobenius `frob3` (a `5`-cycle)
+    and the `p = 2` Frobenius `frob2` (a `(2,3)`-element) must be all of `S₅`:
+    `frob3` forces `5 ∣ |G|`, while `frob2 ^ 3 ∈ G` is the transposition.  This is the
+    corrected proof of `Gal(X⁵−X−1) ≅ S₅` assembled entirely from concrete
+    permutation data — modulo the genuinely-open Dedekind–Frobenius bridge that places
+    `frob2, frob3` (as cycle-type representatives) inside the actual Galois group. -/
+theorem gal_eq_top_of_frobenii {G : Subgroup S5} [DecidablePred (· ∈ G)]
+    (h3 : frob3 ∈ G) (h2 : frob2 ∈ G) : G = ⊤ :=
+  gal_eq_top_of_five_dvd_and_swap (five_dvd_card_of_frob3_mem h3)
+    (G.pow_mem h2 3) frob2_pow_three_isSwap
 
 end AbelRuffiniOQ07

--- a/src/data/proofs/abel-ruffini-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-07/meta.json
@@ -46,7 +46,8 @@
       "Discriminant direction (isSwap_not_mem_alternating): a transposition is odd, hence outside A₅.",
       "Polynomial anchoring (f_natDegree, f_monic, natDegree_prime): X⁵−X−1 is monic of prime degree 5.",
       "Documentation of the open gap: the two hypotheses are the output of the Dedekind–Frobenius bridge shared with inverse-galois-a5-oq-01; closing it there closes this problem.",
-      "Concrete Frobenius witness (frob2, frob2_not_mem_alternating, frob2_pow_three_eq_swap, frob2_pow_three_isSwap): exhibits a (2,3)-cycle-type element (0 1)(2 3 4) ∈ S₅ modelling a Frobenius element of f mod 2, machine-checks it is odd and that its cube is the transposition (0 1) — making the prose 'order-6 Frobenius ⟹ transposition' step into verified permutation data."
+      "Concrete Frobenius witness (frob2, frob2_not_mem_alternating, frob2_pow_three_eq_swap, frob2_pow_three_isSwap): exhibits a (2,3)-cycle-type element (0 1)(2 3 4) ∈ S₅ modelling a Frobenius element of f mod 2, machine-checks it is odd and that its cube is the transposition (0 1) — making the prose 'order-6 Frobenius ⟹ transposition' step into verified permutation data.",
+      "Concrete p=3 Frobenius witness and capstone (frob3, frob3_pow_five, orderOf_frob3, five_dvd_card_of_frob3_mem, gal_eq_top_of_frobenii): exhibits the 5-cycle frob3 = (0 1 2 3 4) ∈ S₅ modelling a Frobenius element of f mod 3 (irreducible quintic), machine-checks orderOf frob3 = 5, and derives via Lagrange that any subgroup containing it has 5 ∣ |G| — supplying hypothesis (a) of gal_eq_top_of_five_dvd_and_swap from a single membership fact. The capstone gal_eq_top_of_frobenii assembles G = ⊤ = S₅ from both witnesses (frob3 gives 5 ∣ |G|, frob2³ gives the transposition), turning the entire prose cycle-type computation into verified permutation data modulo the open Dedekind–Frobenius bridge."
     ],
     "prerequisites": [
       "Symmetric and alternating groups; permutation sign",
@@ -56,7 +57,7 @@
       "Lean 4 and Mathlib"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 165,
+    "lineCount": 227,
     "relatedProblems": [
       {
         "id": "abel-ruffini-oq-04-oq-01",
@@ -67,8 +68,8 @@
         "relationship": "Needs the SAME Dedekind–Frobenius bridge (cycle type of Frobenius from factor type mod p); closing it there supplies this file's two hypotheses."
       }
     ],
-    "theoremCount": 10,
-    "definitionCount": 2
+    "theoremCount": 15,
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "The Abel–Ruffini theorem (Ruffini 1799, Abel 1824) shows the general quintic is not solvable by radicals; Galois (1830s) recast solvability as a property of the polynomial's Galois group, solvable iff the group is. Concrete unsolvable quintics are exhibited by proving their Galois group is the non-solvable S₅. Selmer (1956) proved the trinomial X⁵−X−1 is irreducible over ℚ, making it a natural S₅ candidate. Determining Galois groups of quintics in practice rests on Dedekind's theorem (factorisation type mod an unramified prime p equals the cycle type of a Frobenius element), the standard computational tool described in Dummit & Foote §14.8 and van der Waerden §61.",
@@ -312,6 +313,7 @@
     "imports": [
       "Mathlib.GroupTheory.Perm.Cycle.Type",
       "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Mathlib.GroupTheory.OrderOfElement",
       "Mathlib.Tactic"
     ],
     "opens": [
@@ -320,10 +322,10 @@
       "Polynomial"
     ],
     "namespace": "AbelRuffiniOQ07",
-    "lineCount": 129,
+    "lineCount": 227,
     "axiomCount": 0,
-    "theoremCount": 7,
-    "definitionCount": 1,
+    "theoremCount": 12,
+    "definitionCount": 2,
     "sorries": 0,
     "path": "Proofs/AbelRuffiniOQ07.lean"
   },


### PR DESCRIPTION
## Summary

Extends the corrected Abel–Ruffini quintic entry with a **concrete `p = 3` Frobenius witness** and a capstone theorem, mirroring the merged `p = 2` witness (#26023).

The polynomial $X^5 - X - 1$ is irreducible mod 3, so a Frobenius element of $f$ at 3 has cycle type $(5)$ — a single 5-cycle of order 5. This PR exhibits such an element concretely and machine-checks its order, then derives the $5 \mid |\mathrm{Gal}|$ divisibility input for any subgroup containing it.

## New declarations (all in `Proofs/AbelRuffiniOQ07.lean`, +62 lines, pure append)

- `frob3 := (0 1 2 3 4) ∈ S₅` — the 5-cycle Frobenius representative
- `frob3_pow_five`, `frob3_ne_one` — `by decide`
- `orderOf_frob3 : orderOf frob3 = 5` — order divides prime 5 and is ≠ 1
- `five_dvd_card_of_frob3_mem` — any `G ≤ S₅` containing `frob3` has `5 ∣ |G|` (Lagrange), supplying hypothesis (a) of `gal_eq_top_of_five_dvd_and_swap` from a single membership fact
- `gal_eq_top_of_frobenii` — **capstone**: a subgroup containing both Frobenius witnesses is all of S₅ (`frob3` ⟹ `5 ∣ |G|`, `frob2³` ⟹ the transposition)

## Verification

- Build **green** (3062 jobs)
- 0 sorries, 0 axioms — all proofs by plain `decide` / standard `orderOf` lemmas (no `native_decide`)
- The genuinely-open Dedekind–Frobenius bridge (placing cycle-type representatives inside the actual Galois group) remains scoped out and documented, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)