### PR TITLE
audit(shannon-channel-coding-oq-01): re-audit CLEAN — durable tracker entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12970,6 +12970,13 @@
       "lastAudited": "2026-05-03T22:50:53Z",
       "result": "clean"
     },
+    "shannon-channel-coding-oq-01": {
+      "agentId": "auditor-agent",
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T07:41:01Z",
+      "result": "clean",
+      "issues": []
+    },
     "shannon-channel-coding-oq-02": {
       "auditCount": 5,
       "issues": [],


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: shannon-channel-coding-oq-01 — *Additive-Channel Decomposition I(X;Y) = h(Y) − h(Z)*

The entry was **absent from `audit-tracker.json`**, so `find-targets` kept re-serving it as unaudited. This PR adds the durable tracker record (surgical 7-line insert, no reformat).

### Verdict: CLEAN — LOW risk

Mechanical checks against `Proofs/ShannonChannelCodingOQ01.lean` (130 lines), all matching meta:

| Check | Lean source | meta.json |
|-------|-------------|-----------|
| sorries | 0 | 0 ✓ |
| axiom decls | 0 | axiomCount 0 ✓ |
| native_decide | 0 | — ✓ |
| True stubs | 0 | — ✓ |
| theorems | 5 | theoremCount 5 ✓ |
| definitions | 2 | definitionCount 2 ✓ |
| structures (assumption-carrying) | 0 | — ✓ |
| registered in Proofs.lean | yes (L2872) | — ✓ |

### Tier / badge assessment
- **Tier A honest.** The substantive content — translation invariance of differential entropy `h(f(·−c)) = h(f)` and the additive-channel conditional-entropy collapse `h(Y|X=x) = h(Z)` — is proved **in-file**. Mathlib dependencies (`integral_sub_right_eq_self`, `integral_mul_const`) are foundational integral lemmas, not a deep theorem doing the core work. Badge `original` / status `verified` is defensible.
- **Scope disclosure exemplary.** Mutual information is taken in its **chain-rule form** `I = h(Y) − h(Y|X)` *as a definition* (`additiveMutualInformation`); the meta explicitly flags — in description, `assumptions`, the in-file scope note, and `openQuestions` — that proving this coincides with the KL-divergence definition remains genuinely open and is **not** formalized here. No failure-mode-#3 (definition-vs-theorem) overclaim. Title names exactly the decomposition that is proved.

No changes to meta.json required.

---
🤖 Discovered during gallery integrity audit.