### PR TITLE
audit(erdos-122): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4579,9 +4579,9 @@
       "result": "clean"
     },
     "erdos-122": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-reaudit",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T07:48:26Z",
       "result": "clean"
     },
     "erdos-123": {


### PR DESCRIPTION
## Gallery integrity re-audit: erdos-122

Stalest unaudited target (gallery saturated 2550/2550). Last audited
2026-05-03; `auditCount` 3→4, result remains **clean**.

### Verification (meta.json vs `proofs/Proofs/Erdos122Problem.lean`)

| Check | Claimed | Source | ✓ |
|---|---|---|---|
| lineCount | 157 | 157 | ✓ |
| axiomCount | 2 | 2 (`divisor_count_has_SICP`, `prime_count_has_SICP`) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 1 | 1 (`erdos_122_known_results`) | ✓ |
| definitionCount | 10 | 10 | ✓ |
| native_decide / True-stubs / structures | none | none | ✓ |

### Findings

- **Tier C scaffold, honestly framed.** `status: axiomatized`, `badge: axiom`. The sole theorem bundles the two cited axioms (Erdős–Pomerance–Sárközy 1997); axioms disclosed in `assumptions`. Description labels the problem **OPEN**; conjectured failures for φ, σ are labeled as conjectures.
- No overclaim, no axiom masking, no hidden-import inflation. **LOW risk, CLEAN.**

Durable tracker-only change (no source/meta edits).