### PR TITLE
audit(erdos-123): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4585,9 +4585,9 @@
       "result": "clean"
     },
     "erdos-123": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-reaudit-20260619",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T07:51:21Z",
       "result": "clean"
     },
     "erdos-124": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-123 (d-Complete Sequences)

Re-audited the stalest gallery entry (last audited 2026-05-03, auditCount 3). Gallery is saturated (2552/2552 audited, 0 issues); erdos-122 already has open tracker PR #26052, so served the next stalest.

### Result: CLEAN ✓ (LOW risk)

All meta.json claims verified against `proofs/Proofs/Erdos123Problem.lean`:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 317 | 317 | ✓ |
| axiomCount | 3 | 3 | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 22 | 22 | ✓ |
| definitionCount | 5 | 5 | ✓ |
| native_decide | — | 0 | ✓ |
| True-stubs | — | 0 | ✓ |
| registered | — | `import Proofs.Erdos123Problem` | ✓ |

- **3 axioms honestly disclosed** in `assumptions`: `powers23_repr`, `erdos_123_conjecture`, `erdos_lewin_357`.
- `status: axiomatized` / `badge: axiom` — correct for an OPEN Erdős problem.
- Proved `{2^k·3^l}` d-completeness (`powers_2_3_dComplete`) is honestly scoped as depending on the axiomatized representation lemma; the general conjecture and the Erdős-Lewin `{3,5,7}` result are honestly axiomatized as OPEN/known.
- No delegation opacity, axiom masking, or overclaim detected.

### Change
Surgical tracker bump only: `auditCount` 3→4, `lastAudited` updated.

---
Discovered during gallery integrity audit.