### PR TITLE
audit(erdos-118): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4463,9 +4463,9 @@
       "result": "clean"
     },
     "erdos-118": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-reaudit-20260619",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T13:00:00Z",
       "result": "clean"
     },
     "erdos-1181": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-118

**Result: CLEAN** ✓

Re-audited the stalest available gallery entry (erdos-122/erdos-123 already have open auditor PRs #26052/#26053). erdos-118 (*Partition Ordinals and Higher Cliques*, Erdős–Hajnal partition conjecture, **disproved**) last audited 2026-05-03.

### Integrity checks (all pass)

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 2 | 2 (`counter_partition_3`, `counter_not_partition_5`) | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 4 | 4 | ✓ |
| lineCount | 139 | 139 | ✓ |
| native_decide | — | 0 | ✓ |
| True-stubs | — | 0 | ✓ |
| registered | — | `import Proofs.Erdos118Problem` | ✓ |

### Claim accuracy

- **status `axiomatized` / badge `axiom`** — correct. DISPROVED problem; the two deep counterexample facts (Schipperus ω^(ω²) → (ω^(ω²),3)² and Larson ω^(ω²) ↛ (ω^(ω²),5)²) are honestly axiomatized.
- `erdos_118_disproved` is **genuinely proved** from the axioms (modus ponens + contradiction), not stubbed.
- `assumptions` names both axioms accurately; no axiom masking; no overclaim in title/description.

No integrity issues. Tracker `auditCount` 3→4.

---
Discovered during gallery integrity audit.