### PR TITLE
audit(erdos-1171): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4399,9 +4399,9 @@
       "result": "clean"
     },
     "erdos-1171": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-reaudit-20260619",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T07:57:24Z",
       "result": "clean"
     },
     "erdos-1172": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-1171

**Result: CLEAN** ✓

Re-audited the stalest target (erdos-118 skipped — open PR #26056). erdos-1171 (Multicolor Partition Relations for ω₁²) verified: all meta.json claims match the Lean source.

### Checks
| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 2 | 2 (`hajnal_ch`, `baumgartner_ma`) | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| theoremCount | 22 | 22 | ✓ |
| definitionCount | 8 | 8 | ✓ |
| lineCount | 445 | 445 | ✓ |
| status/badge | axiomatized / axiom | OPEN problem | ✓ |

### Narrative integrity
- **No axiom masking**: both axioms disclosed in `assumptions`; `CH` and `MartinsAxiom` are concrete `Prop` defs used as hypotheses, not hidden assumptions.
- **No overclaiming**: conditional results honestly scoped ("under CH", "under MA"); ZFC status stated as OPEN throughout.
- `reduction_to_1169` is a genuine combinatorial proof (color-merging induction), not a stub.

Durable tracker bump only: `auditCount` 3→4. No source changes.

---
Discovered during gallery integrity audit.