### PR TITLE
audit(erdos-1176): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4432,9 +4432,9 @@
       ]
     },
     "erdos-1176": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-reaudit",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T08:01:33Z",
       "result": "clean"
     },
     "erdos-1177": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-1176

**Result: CLEAN** ✓

Re-audited the stalest unclaimed entry (gallery saturated 2552/2552; erdos-118 #26056 and erdos-1171 #26058 already have open PRs, so audited next stalest).

### Verification (meta.json vs Proofs/Erdos1176Problem.lean)

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`hajnal_komjath_consistency_witness`) | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 11 | 11 | ✓ |
| lineCount | 225 | 225 | ✓ |
| True-stubs | — | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| structure-encoded assumptions | — | none | ✓ |

### Findings

- **status `axiomatized` / badge `axiom`** — correct for an OPEN problem carrying a single disclosed consistency axiom.
- The sole axiom (Hajnal-Komjáth ZFC-consistency witness) is honestly disclosed in `assumptions`; the main theorems `erdos_1176` / `erdos_1176_from_consistency` correctly delegate to it rather than claiming an independent proof. Structural results (`not_aleph0_colorable_of_chi_aleph1`, etc.) are genuinely proved in-file.
- Registered in `proofs/Proofs.lean:1053`.
- Minor cosmetic note (not blocking, enrichment-level): the section "summary" description text reads "states the open ZFC version with a sorry", but the actual Part 9 code has no sorry — the `sorries: 0` field is accurate.

Surgical tracker bump only: `auditCount` 3→4, `lastAudited` refreshed.

---
Discovered during gallery integrity audit.