### PR TITLE
audit(borsuk-ulam-oq-03-oq-03): re-audit ISSUES-FOUND — durable tracker bump (#26061)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1224,10 +1224,12 @@
       "result": "clean"
     },
     "borsuk-ulam-oq-03-oq-03": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T08:07:38Z",
+      "result": "issues-found",
+      "issue": 26061,
+      "notes": "Re-audit: meta.json accurate (axiomatized/axiom, 1 axiom tucker_2d_grid, sorries 0, lineCount 2633, theoremCount 123, definitionCount 36 all match; main result borsuk_ulam_2d_corrected honestly axiomatized). Found 3 non-load-bearing auxiliary True-stub theorems with 'PROVED' docstrings (#26061, LOW severity; mechanic fix PR #26062)."
     },
     "borsuk-ulam-oq-04": {
       "auditCount": 6,


### PR DESCRIPTION
## Audit: borsuk-ulam-oq-03-oq-03 (Constructive 2D Borsuk-Ulam via Tucker's Lemma)

Re-audit of the stalest gallery entry (gallery saturated 2552/2552). Durable tracker bump `auditCount` 3 → 4, `result` clean → issues-found.

### Gallery meta.json — accurate ✓
- `status: axiomatized`, `badge: axiom` — correct (1 axiom).
- `sorries: 0`, `axiomCount: 1` (tucker_2d_grid), `lineCount: 2633`, `theoremCount: 123`, `definitionCount: 36` — all match source.
- Main result `borsuk_ulam_2d_corrected` genuinely proved modulo the single disclosed axiom. No structure-encoded hidden assumptions (well-formedness fields only).

### Finding (LOW severity) → #26061
3 non-load-bearing auxiliary theorems carry `**PROVED: X**` docstrings but prove only `True := trivial`:
`gridEdgesTriFin_from_triangles` (L2155), `boundary_edge_one_triangle` (L2165), `interior_edge_two_triangles` (L2175). The axiom short-circuits the combinatorial chain, so these play no role in the main proof — no gallery-facing field is wrong.

Mechanic fix already in flight: **PR #26062** relabels the docstrings honestly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)