### PR TITLE
research(derangements-oq-02-oq-02-oq-01): higher factorial moments of fixed points = 1

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -627,6 +627,7 @@ import Proofs.DerangementsConvergenceOQ03
 import Proofs.DerangementsOQ02
 import Proofs.DerangementsOQ02OQ01
 import Proofs.DerangementsOQ02OQ02
+import Proofs.DerangementsOQ02OQ02OQ01
 import Proofs.DerangementsOQ03
 import Proofs.DerangementsOQ03OQ01
 import Proofs.DerangementsOQ03OQ01OQ02

--- a/proofs/Proofs/DerangementsOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/DerangementsOQ02OQ02OQ01.lean
@@ -1,0 +1,183 @@
+/-
+  Higher Factorial Moments of Fixed Points of a Random Permutation
+  (derangements-oq-02-oq-02-oq-01)
+
+  Open Question (from derangements-oq-02-oq-02): The parent established the *first*
+  factorial moment of the fixed-point count X(σ) = |Fix(σ)| of a uniform random
+  permutation of an n-element set:
+
+      ∑_{σ : Perm(Fin n)} X(σ) = n!      i.e.   E[X] = 1.
+
+  This file proves the **higher factorial moments**: for every k ≤ n,
+
+      ∑_{σ : Perm(Fin n)} (X(σ))_k = n!      i.e.   E[(X)_k] = 1,
+
+  where (X)_k = X·(X-1)···(X-k+1) = X.descFactorial k is the k-th falling
+  factorial. Equivalently, every factorial moment of X equals 1 -- the exact
+  finite-n signature of the Poisson(1) limit, whose factorial moments are all 1.
+
+  **Main Result**:
+  `sum_descFactorial_fixedPoints_eq_factorial`: For k ≤ n,
+      ∑_{σ : Perm(Fin n)} ((Fix σ).card).descFactorial k = n!.
+
+  **Proof Strategy** (Burnside on the action on ordered k-tuples):
+  The parent proved the k = 1 case by Burnside's lemma applied to the action of
+  Perm(Fin n) on Fin n. The higher moments arise from the *same* lemma applied to
+  the action of Perm(Fin n) on the set of injective k-tuples `Fin k ↪ Fin n`
+  (σ • f = σ ∘ f):
+
+  1. The number of k-tuples fixed by σ equals (X(σ))_k. An embedding f is fixed by
+     σ iff its image lands in Fix(σ); the count of such embeddings is
+     |Fix(σ)|.descFactorial k  (Mathlib's `Fintype.card_embedding_eq`).
+  2. Burnside: ∑_σ |Fix_emb(σ)| = (#orbits) · |Perm(Fin n)|.
+  3. The symmetric group is k-transitive (`Equiv.Perm.isMultiplyPretransitive`), so
+     for k ≤ n the embedding set is nonempty with a single orbit: #orbits = 1.
+  4. Hence the sum is 1 · n! = n!.
+
+  The factorial-moment-equals-1 phenomenon is thus a direct consequence of the
+  k-transitivity of the full symmetric group.
+
+  **Status**: All proved. 0 sorries, 0 `axiom` declarations, no `native_decide` in
+  the main result. n theorems + helper equiv/lemma.
+-/
+
+import Proofs.DerangementsOQ02OQ02
+import Mathlib.GroupTheory.GroupAction.Embedding
+import Mathlib.GroupTheory.GroupAction.MultipleTransitivity
+import Mathlib.GroupTheory.GroupAction.Quotient
+import Mathlib.Data.Fintype.CardEmbedding
+import Mathlib.Tactic
+
+open Finset Fintype Nat Equiv.Perm BigOperators MulAction Function
+
+namespace DerangementsOQ02OQ02OQ01
+
+variable {n k : ℕ}
+
+/-!
+## Section I: Counting embeddings fixed by a permutation
+
+An embedding `f : Fin k ↪ Fin n` is fixed by `σ` (under the action `σ • f = σ ∘ f`)
+exactly when every value `f i` is a fixed point of `σ`. Such embeddings are in
+bijection with embeddings of `Fin k` into the subtype of fixed points of `σ`.
+-/
+
+/-- Embeddings of `Fin k` into `Fin n` fixed by `σ` correspond bijectively to
+    embeddings of `Fin k` into the set of fixed points of `σ`. -/
+def fixedEmbEquiv (σ : Equiv.Perm (Fin n)) :
+    {f : Fin k ↪ Fin n // σ • f = f} ≃ (Fin k ↪ {x : Fin n // σ x = x}) where
+  toFun := fun ⟨f, hf⟩ =>
+    ⟨fun i => ⟨f i, by
+        have h := DFunLike.congr_fun hf i
+        simpa only [Function.Embedding.smul_apply, Equiv.Perm.smul_def] using h⟩,
+     fun i j h => f.injective (congrArg Subtype.val h)⟩
+  invFun := fun g =>
+    ⟨⟨fun i => (g i : Fin n), fun i j h => g.injective (Subtype.ext h)⟩, by
+        ext i
+        simp only [Function.Embedding.smul_apply, Equiv.Perm.smul_def,
+          Function.Embedding.coeFn_mk]
+        exact (g i).property⟩
+  left_inv := fun ⟨f, hf⟩ => Subtype.ext (Function.Embedding.ext fun i => rfl)
+  right_inv := fun g => Function.Embedding.ext fun i => Subtype.ext rfl
+
+/-- **Key count**: the number of embeddings `Fin k ↪ Fin n` fixed by `σ` equals the
+    `k`-th falling factorial of `|Fix(σ)|`. -/
+lemma card_fixedBy_emb (σ : Equiv.Perm (Fin n)) :
+    Fintype.card (MulAction.fixedBy (Fin k ↪ Fin n) σ) =
+      ((Finset.univ.filter fun x => σ x = x).card).descFactorial k := by
+  -- ↥(fixedBy _ σ) ≃ {f // σ • f = f} ≃ (Fin k ↪ fixed-point subtype)
+  rw [Fintype.card_congr
+        ((Equiv.subtypeEquivRight fun f => MulAction.mem_fixedBy).trans (fixedEmbEquiv σ)),
+      Fintype.card_embedding_eq, Fintype.card_fin, Fintype.card_subtype]
+
+/-!
+## Section II: Main theorem via Burnside's lemma
+
+The action of `Perm(Fin n)` on `Fin k ↪ Fin n` is transitive for `k ≤ n`
+(k-transitivity of the symmetric group), so Burnside's lemma collapses to a single
+orbit and the moment sum equals `n!`.
+-/
+
+set_option maxHeartbeats 1000000 in
+/-- **Higher factorial moments**: For `k ≤ n`,
+      ∑_{σ : Perm(Fin n)} (|Fix(σ)|)_k = n!.
+    Equivalently, the `k`-th factorial moment of the fixed-point count of a uniform
+    random permutation of `Fin n` equals `1`.
+
+    **Proof**: Burnside's lemma applied to the action of `Perm(Fin n)` on the ordered
+    `k`-tuples `Fin k ↪ Fin n`. Each summand `(|Fix(σ)|)_k` counts the `k`-tuples
+    fixed by `σ` (`card_fixedBy_emb`). Since the symmetric group is `k`-transitive,
+    for `k ≤ n` the (nonempty) tuple set forms a single orbit, so the sum is
+    `1 · |Perm(Fin n)| = n!`. -/
+theorem sum_descFactorial_fixedPoints_eq_factorial (hk : k ≤ n) :
+    ∑ σ : Equiv.Perm (Fin n),
+      ((Finset.univ.filter fun x => σ x = x).card).descFactorial k = n.factorial := by
+  -- Convert each summand into the count of embeddings fixed by σ.
+  simp_rw [← card_fixedBy_emb]
+  -- The symmetric group is k-transitive: it acts pretransitively on Fin k ↪ Fin n.
+  haveI hpre : MulAction.IsPretransitive (Equiv.Perm (Fin n)) (Fin k ↪ Fin n) :=
+    Equiv.Perm.isMultiplyPretransitive (Fin n) k
+  -- For k ≤ n the embedding set is nonempty.
+  haveI hne : Nonempty (Fin k ↪ Fin n) := ⟨(Fin.castLEOrderEmb hk).toEmbedding⟩
+  -- Hence the orbit quotient is a singleton.
+  haveI huniq : Unique (orbitRel.Quotient (Equiv.Perm (Fin n)) (Fin k ↪ Fin n)) :=
+    (MulAction.pretransitive_iff_unique_quotient_of_nonempty
+      (G := Equiv.Perm (Fin n)) (α := Fin k ↪ Fin n)).mp inferInstance |>.some
+  haveI hfinΩ : Fintype (orbitRel.Quotient (Equiv.Perm (Fin n)) (Fin k ↪ Fin n)) :=
+    Unique.fintype
+  -- Burnside: ∑_σ |Fix_emb(σ)| = |Ω| · |G|.
+  rw [MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group
+      (α := Equiv.Perm (Fin n)) (β := Fin k ↪ Fin n)]
+  rw [Fintype.card_unique, one_mul, Fintype.card_perm, Fintype.card_fin]
+
+/-!
+## Section III: Consequences and interpretation
+-/
+
+/-- The first factorial moment (`k = 1`) recovers the parent's expected-fixed-points
+    result `∑_σ |Fix(σ)| = n!` as a special case. -/
+theorem sum_fixedPoints_eq_factorial_via_moment (hn : 1 ≤ n) :
+    ∑ σ : Equiv.Perm (Fin n),
+      (Finset.univ.filter fun x => σ x = x).card = n.factorial := by
+  have h := sum_descFactorial_fixedPoints_eq_factorial (n := n) (k := 1) hn
+  simpa only [Nat.descFactorial_one] using h
+
+/-- **Factorial moment equals one**: for `k ≤ n` the moment sum equals
+    `|Perm(Fin n)| = n!`. Dividing by the number of permutations `n!` gives the
+    normalized `k`-th factorial moment `E[(X)_k] = 1`. -/
+theorem moment_sum_eq_card_perm (hk : k ≤ n) :
+    ∑ σ : Equiv.Perm (Fin n),
+      ((Finset.univ.filter fun x => σ x = x).card).descFactorial k =
+      Fintype.card (Equiv.Perm (Fin n)) := by
+  rw [sum_descFactorial_fixedPoints_eq_factorial hk, Fintype.card_perm, Fintype.card_fin]
+
+/-- **Second factorial moment** (`k = 2`): `∑_σ |Fix(σ)|·(|Fix(σ)|-1) = n!` for
+    `n ≥ 2`. Together with the first moment this yields the variance
+    `Var(X) = E[X(X-1)] + E[X] - (E[X])² = 1 + 1 - 1 = 1`, i.e. `Var(X) = 1`. -/
+theorem sum_second_factorial_moment (hn : 2 ≤ n) :
+    ∑ σ : Equiv.Perm (Fin n),
+      ((Finset.univ.filter fun x => σ x = x).card) *
+        ((Finset.univ.filter fun x => σ x = x).card - 1) = n.factorial := by
+  have h := sum_descFactorial_fixedPoints_eq_factorial (n := n) (k := 2) hn
+  -- descFactorial _ 2 = X * (X - 1)
+  have hd : ∀ m : ℕ, m.descFactorial 2 = m * (m - 1) := fun m => by
+    rw [show (2 : ℕ) = 1 + 1 from rfl, Nat.descFactorial_succ, Nat.descFactorial_one,
+      Nat.mul_comm]
+  simp_rw [hd] at h
+  exact h
+
+/-- For `k > n` every summand vanishes (no permutation has more than `n` fixed
+    points), so the higher-`k` moment sum is `0`, sharply distinguishing it from the
+    `k ≤ n` regime where the sum is `n!`. -/
+theorem sum_descFactorial_fixedPoints_eq_zero (hk : n < k) :
+    ∑ σ : Equiv.Perm (Fin n),
+      ((Finset.univ.filter fun x => σ x = x).card).descFactorial k = 0 := by
+  apply Finset.sum_eq_zero
+  intro σ _
+  apply Nat.descFactorial_eq_zero_iff_lt.mpr
+  calc (Finset.univ.filter fun x => σ x = x).card
+      ≤ (Finset.univ : Finset (Fin n)).card := Finset.card_filter_le _ _
+    _ = n := by simp
+    _ < k := hk
+
+end DerangementsOQ02OQ02OQ01

--- a/proofs/Proofs/DerangementsOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/DerangementsOQ02OQ02OQ01.lean
@@ -76,7 +76,7 @@ def fixedEmbEquiv (σ : Equiv.Perm (Fin n)) :
         ext i
         simp only [Function.Embedding.smul_apply, Equiv.Perm.smul_def,
           Function.Embedding.coeFn_mk]
-        exact (g i).property⟩
+        exact congrArg _ (g i).property⟩
   left_inv := fun ⟨f, hf⟩ => Subtype.ext (Function.Embedding.ext fun i => rfl)
   right_inv := fun g => Function.Embedding.ext fun i => Subtype.ext rfl
 

--- a/src/data/proofs/derangements-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-02-oq-01/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "derangements-oq-02-oq-02-oq-01",
+  "title": "Higher Factorial Moments of Fixed Points of a Random Permutation (OQ-02-OQ-02-OQ-01)",
+  "slug": "derangements-oq-02-oq-02-oq-01",
+  "description": "Formal proof that every factorial moment of the fixed-point count of a uniform random permutation equals 1: for k ≤ n, ∑_{σ ∈ Perm(Fin n)} (|Fix(σ)|)_k = n!, where (X)_k is the k-th falling factorial. Generalizes the parent's first-moment result (E[#fixed] = 1) by applying the same Burnside's lemma to the action of the symmetric group on ordered k-tuples Fin k ↪ Fin n, where k-transitivity collapses the orbit count to 1. Axiom-free.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-18",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsOQ02OQ02OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "permutations",
+      "derangements",
+      "burnside",
+      "probability",
+      "factorial-moments",
+      "multiple-transitivity"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-18",
+    "axiomCount": 0,
+    "lineCount": 183,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "assumptions": "None beyond Lean/Mathlib's standard foundational axioms (propext, Classical.choice, Quot.sound). The main theorem and all consequences are proved without native_decide or any axiom declaration; #print axioms on sum_descFactorial_fixedPoints_eq_factorial reports only the three standard axioms. 0 sorries, leanFile.axiomCount = 0.",
+    "originalContributions": [
+      "Proof that ∑_{σ ∈ Perm(Fin n)} (|Fix(σ)|).descFactorial k = n! for k ≤ n, i.e. every factorial moment of the fixed-point count equals 1 (the exact finite-n Poisson(1) signature)",
+      "Reduction of the higher-moment identity to Burnside's lemma applied to the action of Perm(Fin n) on ordered k-tuples Fin k ↪ Fin n, mirroring the parent's k=1 argument on Fin n",
+      "fixedEmbEquiv: a bijection between the k-tuples fixed by σ and embeddings of Fin k into the fixed-point set of σ, giving |Fix_emb(σ)| = (|Fix(σ)|)_k via Fintype.card_embedding_eq",
+      "Identification of multiple transitivity of the symmetric group (Equiv.Perm.isMultiplyPretransitive) as the precise structural reason all factorial moments equal 1",
+      "Second-moment / variance corollary (∑_σ |Fix(σ)|·(|Fix(σ)|-1) = n! giving Var(X) = 1) and the sharp k > n vanishing boundary (sum = 0)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The number of fixed points X of a uniform random permutation of an n-element set converges in distribution to a Poisson random variable with mean 1 as n → ∞ (a classical result going back to Montmort's analysis of the matching problem, 'le problème des rencontres', in 1708). A defining feature of the Poisson(1) law is that all of its factorial moments equal 1: E[X(X-1)···(X-k+1)] = 1 for every k. Remarkably, for the permutation statistic this holds exactly — not just in the limit — for every k ≤ n. The parent entry established the k = 1 case (E[X] = 1) via Burnside's lemma; this entry shows the entire factorial-moment tower collapses to 1 for the same structural reason: the full symmetric group is k-transitive for all k.\n\nThe Burnside–Cauchy–Frobenius lemma relates the number of orbits of a finite group action to the average number of fixed points: |orbits| = (1/|G|) ∑_{g} |Fix(g)|. Applied to Sₙ acting on ordered k-tuples of distinct points, the single orbit (k-transitivity) forces the average number of fixed k-tuples to be 1, and the number of k-tuples fixed by σ is exactly the falling factorial (|Fix σ|)_k. This is the clean group-theoretic mechanism behind the factorial-moment phenomenon.",
+    "problemStatement": "Prove the higher factorial moments of the fixed-point count of a uniform random permutation: for k ≤ n, ∑_{σ ∈ Perm(Fin n)} (|Fix(σ)|)_k = n!, where (m)_k = m.descFactorial k is the k-th falling factorial. Equivalently, E[(X)_k] = 1 for all k ≤ n, the finite-n analogue of the Poisson(1) factorial moments.",
+    "proofStrategy": "Apply Burnside's lemma (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group) to the action of Perm(Fin n) on the set of ordered k-tuples Fin k ↪ Fin n, where σ • f = σ ∘ f.\n\n1. Count fixed tuples: an embedding f is fixed by σ iff every value f i is a fixed point of σ. The bijection fixedEmbEquiv sends such f to an embedding Fin k ↪ {x // σ x = x}; by Fintype.card_embedding_eq the count is (|Fix σ|).descFactorial k. This is the lemma card_fixedBy_emb.\n2. Sum over σ via Burnside: ∑_σ |Fix_emb(σ)| = (#orbits) · |Perm(Fin n)|.\n3. Collapse the orbit count: Equiv.Perm.isMultiplyPretransitive gives IsPretransitive (Perm (Fin n)) (Fin k ↪ Fin n); for k ≤ n the embedding set is nonempty (Fin.castLEOrderEmb), so pretransitive_iff_unique_quotient_of_nonempty yields a Unique orbit quotient, #orbits = 1.\n4. Conclude 1 · |Perm(Fin n)| = n! via Fintype.card_perm and Fintype.card_fin.\n\nConsequences: the k = 1 specialization recovers the parent's ∑_σ |Fix(σ)| = n!; k = 2 with descFactorial_succ gives the second factorial moment and variance 1; for k > n every summand vanishes by descFactorial_eq_zero_iff_lt (card Fix ≤ n < k).",
+    "keyInsights": [
+      "The higher factorial moments arise from the SAME Burnside lemma as the first moment — only the acted-on set changes, from Fin n to the ordered k-tuples Fin k ↪ Fin n",
+      "The number of k-tuples fixed by σ is exactly the falling factorial (|Fix σ|)_k, because fixed tuples are precisely embeddings of Fin k into the fixed-point set; Mathlib's Fintype.card_embedding_eq supplies card (α ↪ β) = (card β).descFactorial (card α)",
+      "Multiple transitivity of the full symmetric group (Equiv.Perm.isMultiplyPretransitive, i.e. IsPretransitive (Perm α) (Fin k ↪ α)) is the precise structural reason every factorial moment equals 1: one orbit ⟹ average fixed-tuple count 1",
+      "For k ≤ n the embedding set is nonempty (Fin.castLEOrderEmb hk) so the orbit quotient is Unique; for k > n it is empty and the moment sum collapses to 0 — a sharp boundary distinguishing the two regimes",
+      "Avoiding native_decide entirely (no concrete native_decide verifications) keeps the entry fully axiom-free, unlike the parent which depends on Lean.ofReduceBool for its n=3,4 sanity checks"
+    ],
+    "prerequisites": [
+      "Burnside's lemma (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group)",
+      "Multiple transitivity of the symmetric group (Equiv.Perm.isMultiplyPretransitive)",
+      "MulAction.pretransitive_iff_unique_quotient_of_nonempty",
+      "Counting embeddings (Fintype.card_embedding_eq) and the falling factorial (Nat.descFactorial, Nat.factorial_mul_descFactorial)",
+      "The MulAction of a group on embeddings (Function.Embedding.smul_apply)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "fixed-tuple-count",
+      "title": "Section I: Counting k-tuples fixed by a permutation",
+      "startLine": 42,
+      "endLine": 95,
+      "summary": "Defines fixedEmbEquiv, the bijection between embeddings Fin k ↪ Fin n fixed by σ (under σ • f = σ ∘ f) and embeddings Fin k ↪ {x // σ x = x}. Proves card_fixedBy_emb: Fintype.card (fixedBy (Fin k ↪ Fin n) σ) = (|Fix σ|).descFactorial k, by transporting along the equiv and applying Fintype.card_embedding_eq, Fintype.card_fin, and Fintype.card_subtype."
+    },
+    {
+      "id": "burnside-higher-moments",
+      "title": "Section II: Higher factorial moments via Burnside's lemma",
+      "startLine": 97,
+      "endLine": 137,
+      "summary": "Main theorem sum_descFactorial_fixedPoints_eq_factorial: for k ≤ n, ∑_σ (|Fix σ|).descFactorial k = n!. Rewrites each summand to the fixed-tuple count (card_fixedBy_emb), installs the pretransitive instance from Equiv.Perm.isMultiplyPretransitive, supplies nonemptiness via Fin.castLEOrderEmb, derives the Unique orbit quotient, then applies Burnside and collapses to 1 · n!."
+    },
+    {
+      "id": "consequences",
+      "title": "Section III: Consequences and interpretation",
+      "startLine": 139,
+      "endLine": 183,
+      "summary": "Corollaries: sum_fixedPoints_eq_factorial_via_moment (k=1 recovers the parent's ∑_σ |Fix σ| = n!); moment_sum_eq_card_perm (moment sum = |Perm(Fin n)|, so normalized moment = 1); sum_second_factorial_moment (k=2 second factorial moment, giving variance 1); sum_descFactorial_fixedPoints_eq_zero (the sharp k > n vanishing boundary via descFactorial_eq_zero_iff_lt)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file proves 6 theorems/lemmas and 1 definition with 0 sorries and 0 axioms (no native_decide), establishing that every factorial moment (k ≤ n) of the fixed-point count of a uniform random permutation equals 1 via Burnside's lemma on the action on ordered k-tuples. It strictly generalizes the parent's first-moment result and is fully axiom-free.",
+    "implications": "The factorial-moment tower E[(X)_k] = 1 for all k ≤ n is the exact finite-n fingerprint of the Poisson(1) limit, and this proof exhibits multiple transitivity of the symmetric group as its structural cause. The fixedEmbEquiv bijection and card_fixedBy_emb count are reusable for any fixed-tuple counting problem; the k > n vanishing gives the sharp boundary of the identity.",
+    "openQuestions": [
+      "Combine the factorial moments E[(X)_k] = 1 (k ≤ n) with the method of moments to formalize convergence in distribution of the fixed-point count to Poisson(1) as n → ∞",
+      "Derive closed forms for the ordinary power moments E[X^k] (Bell-number / Touchard polynomial expressions) from the factorial moments via Stirling numbers of the second kind"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "derangements-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry proving the first factorial moment ∑_σ |Fix(σ)| = n! (E[#fixed] = 1) via Burnside on Fin n; this entry generalizes it to all factorial moments via Burnside on Fin k ↪ Fin n"
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "related",
+      "description": "Base derangement entry; the Poisson(1) limit whose factorial moments are all 1 is the distributional context for these exact finite-n moment identities"
+    },
+    {
+      "targetId": "burnside-counting",
+      "relationship": "uses",
+      "description": "Burnside's lemma (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group) applied to the action on ordered k-tuples is the engine of the higher-moment proof"
+    }
+  ],
+  "leanFile": {
+    "namespace": "DerangementsOQ02OQ02OQ01",
+    "lineCount": 183,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/DerangementsOQ02OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Higher factorial moments of fixed points (`derangements-oq-02-oq-02-oq-01`)

Resolves the open question raised by `derangements-oq-02-oq-02`. The parent
established the **first** factorial moment of the fixed-point count
`X(σ) = |Fix(σ)|` of a uniform random permutation of `Fin n`:

```
∑_{σ : Perm(Fin n)} X(σ) = n!     i.e.  E[X] = 1.
```

This file proves **all higher factorial moments**: for every `k ≤ n`,

```
∑_{σ : Perm(Fin n)} (X(σ))_k = n!     i.e.  E[(X)_k] = 1,
```

where `(X)_k = X·(X-1)···(X-k+1) = X.descFactorial k`. Every factorial moment
equals 1 — the exact finite-`n` signature of the Poisson(1) limit, whose
factorial moments are all 1.

### Proof strategy (Burnside on the ordered-`k`-tuple action)

The parent's `k = 1` case is Burnside's lemma applied to the action of
`Perm(Fin n)` on `Fin n`. The higher moments come from the **same** lemma applied
to the action on injective `k`-tuples `Fin k ↪ Fin n` (`σ • f = σ ∘ f`):

1. The number of `k`-tuples fixed by `σ` equals `(|Fix(σ)|)_k`: an embedding `f`
   is fixed iff its image lands in `Fix(σ)`, and the count of such embeddings is
   `|Fix(σ)|.descFactorial k` (`Fintype.card_embedding_eq`). — `card_fixedBy_emb`
2. Burnside: `∑_σ |Fix_emb(σ)| = (#orbits) · |Perm(Fin n)|`.
3. The symmetric group is `k`-transitive
   (`Equiv.Perm.isMultiplyPretransitive`), so for `k ≤ n` the (nonempty) tuple set
   is a single orbit: `#orbits = 1`.
4. Hence the sum is `1 · n! = n!`.

The factorial-moment-equals-1 phenomenon is thus a direct consequence of the
`k`-transitivity of the full symmetric group.

### Results

- `sum_descFactorial_fixedPoints_eq_factorial` — main result, `∑_σ (|Fix σ|)_k = n!` for `k ≤ n`
- `card_fixedBy_emb` — key count: `#{embeddings fixed by σ} = |Fix σ|.descFactorial k`
- `fixedEmbEquiv` — supporting equivalence (fixed embeddings ≃ embeddings into the fixed-point subtype)
- `sum_fixedPoints_eq_factorial_via_moment` — recovers the parent `k = 1` result
- `moment_sum_eq_card_perm` — normalized form `E[(X)_k] = 1`
- `sum_second_factorial_moment` — `k = 2` case, yielding `Var(X) = 1`
- `sum_descFactorial_fixedPoints_eq_zero` — for `k > n` the sum is `0`, sharply distinguishing the regimes

### Verification

- 0 sorries, 0 `axiom` declarations, no `native_decide` in the main result
- Builds green via `./proofs/scripts/docker-build.sh Proofs.DerangementsOQ02OQ02OQ01`
- `#print axioms` confirms only the foundational `propext` / `Classical.choice` / `Quot.sound`
- Status `verified` / badge `original`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
