### PR TITLE
audit(de-moivre-oq-02-oq-03): CLEAN — durable tracker entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2278,6 +2278,12 @@
       "lastAudited": "2026-05-04T04:06:43Z",
       "result": "clean"
     },
+    "de-moivre-oq-02-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-19T08:14:07Z",
+      "result": "clean"
+    },
     "de-moivre-oq-03": {
       "auditCount": 4,
       "issues": [],
@@ -16029,5 +16035,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-19T07:15:00Z"
+  "lastUpdated": "2026-06-19T08:14:07Z"
 }


### PR DESCRIPTION
## Audit result: CLEAN

Audited the newly-merged (#26059) entry **Chebyshev Minimax: Equioscillation and the Monic Achievability Half** (`de-moivre-oq-02-oq-03`). It was the sole unaudited gallery entry.

### Verification vs `proofs/Proofs/DeMoivreOQ02OQ03.lean`
All meta.json claims match the source:
- **200 lines**, **0 sorries**, **0 axiom declarations**, **0 `native_decide`/`decide`**, **no `True` stubs**, **no assumption-carrying structures/classes** → `status: verified`, `badge: original`, `axiomCount: 0` all correct.
- **11 theorems, 1 definition** — match `theoremCount`/`definitionCount`.
- Registered at `Proofs.lean:615`.

### Narrative / tier check (LOW risk)
The entry is scrupulously scoped: title, description, `assumptions`, `problemStatement`, and `keyInsights` all state it proves only the equioscillation envelope (`|Tₙ|≤1`, `Tₙ(cos kπ/n)=(-1)^k`), the degree/leading-coefficient infrastructure Mathlib lacks (`natDegree Tₙ=n`, `leadingCoeff Tₙ=2^(n-1)`), and the monic **achievability (upper) half**. The minimax **lower bound** is explicitly flagged as the remaining open continuation. No failure mode #3 (inequality≠theorem) or #4 (pipeline inflation); the famous minimax theorem is not claimed complete. Core results genuinely proved in-file via the Chebyshev recurrence + De Moivre identity (foundational Mathlib lemmas, not a deep theorem masking the core), so `original` is appropriate.

### Why this PR
`claim-target.sh complete` reports success but does **not** persist a tracker entry, leaving the proof to be re-served as unaudited indefinitely. This adds the durable entry (surgical 7-line diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)