### PR TITLE
research(erdos-1179-oq-02): ε-uniformity structural API + promote to verified

### DIFF
--- a/proofs/Proofs/Erdos1179OQ02.lean
+++ b/proofs/Proofs/Erdos1179OQ02.lean
@@ -101,4 +101,51 @@ theorem clog_le_card_of_epsUniform {G : Type*} [AddCommGroup G] [Fintype G]
   (Nat.le_pow_iff_clog_le (by norm_num)).mp
     (card_le_two_pow_of_epsUniform A ε hε1 hunif)
 
+/-! ### Structural properties of ε-uniformity
+
+A few elementary structural facts about the `IsEpsUniform` predicate and the
+lower bound above, recorded here as reusable API: the uniformity classes are
+nested in `ε`, the count is bounded on BOTH sides (the lower-side spanning
+`epsUniform_spanning` has a matching upper companion), and — as the
+contrapositive of the lower bound — a set smaller than `⌈log₂ N⌉` cannot be
+ε-uniform for any `ε < 1`. -/
+
+/-- The expected representation count `μ = 2^k / N` is nonnegative. -/
+theorem expectedReprCount_nonneg (k N : ℕ) :
+    0 ≤ expectedReprCount k N := by
+  unfold expectedReprCount
+  exact div_nonneg (by positivity) (by positivity)
+
+/-- **Monotonicity in `ε`.**  The ε-uniformity classes are nested: if `A` is
+ε-uniform and `ε ≤ ε'`, then `A` is also ε'-uniform.  Immediate from
+`|F_A(g) − μ| ≤ ε·μ ≤ ε'·μ`, using `μ ≥ 0`. -/
+theorem epsUniform_mono {G : Type*} [AddCommGroup G] [Fintype G] [DecidableEq G]
+    (A : Finset G) (ε ε' : ℝ) (hle : ε ≤ ε') (hunif : IsEpsUniform A ε) :
+    IsEpsUniform A ε' := by
+  intro g
+  refine le_trans (hunif g) ?_
+  exact mul_le_mul_of_nonneg_right hle (expectedReprCount_nonneg _ _)
+
+/-- **Upper companion of spanning.**  ε-uniformity bounds each representation
+count from above as well: `F_A(g) ≤ (1 + ε)·μ`.  This is the upper side of the
+defining inequality `|F_A(g) − μ| ≤ ε·μ`, dual to the lower side used in
+`epsUniform_spanning`. -/
+theorem epsUniform_count_upper {G : Type*} [AddCommGroup G] [Fintype G]
+    [DecidableEq G] (A : Finset G) (ε : ℝ) (hunif : IsEpsUniform A ε) (g : G) :
+    (reprCount A g : ℝ)
+      ≤ (1 + ε) * expectedReprCount A.card (Fintype.card G) := by
+  have h := (abs_le.mp (hunif g)).2
+  nlinarith [h]
+
+/-- **Contrapositive of the lower bound.**  A subset strictly smaller than
+`⌈log₂ N⌉` cannot be ε-uniform for any `ε < 1`: there is no slack below the
+trivial lower bound `g_ε(N) ≥ log₂ N`. -/
+theorem not_epsUniform_of_card_lt_clog {G : Type*} [AddCommGroup G] [Fintype G]
+    [DecidableEq G] (A : Finset G) (ε : ℝ) (hε1 : ε < 1)
+    (hlt : A.card < Nat.clog 2 (Fintype.card G)) :
+    ¬ IsEpsUniform A ε := by
+  intro hunif
+  have hge := clog_le_card_of_epsUniform A ε hε1 hunif
+  omega
+
 end Erdos1179

--- a/src/data/proofs/erdos-1179-oq-02/meta.json
+++ b/src/data/proofs/erdos-1179-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős–Hall (1976); lower-bound formalization in Lean 4",
     "sourceUrl": "https://www.erdosproblems.com/1179",
     "date": "1976",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1179OQ02.lean",
     "tags": [
       "number-theory",
@@ -18,10 +18,10 @@
       "erdos-problem",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Build-pending: authored during the Docker + Aristotle backend outage and not machine-checked this session; depends only on Erdos1179.total_reprCount and Erdos1179.expectedReprCount_pos from the parent Proofs/Erdos1179Problem.lean. This file formalizes only the LOWER-BOUND direction; the headline OQ-02 (the additive Oₑ(1) upper bound) remains open. The structural bounds and the exact small-N gap are certified by research/problems/erdos-1179-oq-02/verify_uniform_subset_sums.py (all pass; the script notes it cannot decide the asymptotic Oₑ(1) question). Promote to verified once a green docker-build of Proofs.Erdos1179OQ02 confirms the typecheck.",
+    "assumptions": "0 axioms, 0 sorries. Machine-checked: green docker-build of Proofs.Erdos1179OQ02 (7744 jobs, 2026-06-19) confirms the typecheck. Depends only on Erdos1179.total_reprCount and Erdos1179.expectedReprCount_pos from the parent Proofs/Erdos1179Problem.lean. This file formalizes only the LOWER-BOUND direction together with structural API for the ε-uniformity predicate (monotonicity in ε, the two-sided count sandwich, and the contrapositive too-small bound); the headline OQ-02 (the additive Oₑ(1) UPPER bound) remains open. The structural bounds and the exact small-N gap are additionally certified by research/problems/erdos-1179-oq-02/verify_uniform_subset_sums.py (all pass; the script notes it cannot decide the asymptotic Oₑ(1) question).",
     "mathlibDependencies": [
       {
         "theorem": "Nat.le_pow_iff_clog_le",
@@ -38,11 +38,15 @@
       "epsUniform_spanning: ε-uniformity with ε < 1 forces every group element to have at least one subset-sum representation (F_A(g) ≥ 1), with NO lower bound on |A| — unlike the parent uniform_implies_spanning which assumes |A| ≥ ⌈log₂N⌉ (the bound it would help prove)",
       "Removes the parent's circular hypothesis: positivity of the expected count μ = 2^|A|/N (which holds for any N ≥ 1) plus ε < 1 already gives F_A(g) ≥ (1−ε)μ > 0, so the lower bound becomes a genuine consequence rather than an assumption",
       "card_le_two_pow_of_epsUniform: any ε-uniform A (ε < 1) of a group of order N satisfies N ≤ 2^|A|, via spanning + the parent's total_reprCount (Σ_g F_A(g) = 2^|A|)",
-      "clog_le_card_of_epsUniform: the integer form of the headline lower bound, ⌈log₂N⌉ ≤ |A| (Nat.clog 2 N ≤ A.card)"
+      "clog_le_card_of_epsUniform: the integer form of the headline lower bound, ⌈log₂N⌉ ≤ |A| (Nat.clog 2 N ≤ A.card)",
+      "expectedReprCount_nonneg: the expected representation count μ = 2^k/N is nonnegative (structural helper for the monotonicity lemma)",
+      "epsUniform_mono: the ε-uniformity classes are nested — if A is ε-uniform and ε ≤ ε', then A is ε'-uniform, from |F_A(g) − μ| ≤ ε·μ ≤ ε'·μ (using μ ≥ 0)",
+      "epsUniform_count_upper: the upper companion of epsUniform_spanning — ε-uniformity bounds each count from above, F_A(g) ≤ (1+ε)·μ (the upper side of |F_A(g) − μ| ≤ ε·μ), completing the two-sided sandwich",
+      "not_epsUniform_of_card_lt_clog: contrapositive of the lower bound — a set strictly smaller than ⌈log₂N⌉ cannot be ε-uniform for any ε < 1 (no slack below g_ε(N) ≥ log₂N)"
     ],
     "dateAdded": "2026-06-15",
-    "lineCount": 104,
-    "theoremCount": 3,
+    "lineCount": 151,
+    "theoremCount": 7,
     "definitionCount": 0,
     "prerequisites": [
       "ε-uniform subset-sum representation functions on finite abelian groups (parent Erdos1179Problem.lean)",
@@ -54,7 +58,7 @@
   "overview": {
     "historicalContext": "Erdős problem #1179, resolved by Erdős and Hall (1976), concerns ε-uniform subset-sum representations in a finite abelian group of order N: how many random group elements A are needed so that the number of subsets of A summing to each group element g is within a factor (1±ε) of the average μ = 2^|A|/N? The answer is gₑ(N) = (1 + oₑ(1))·log₂N. Open question OQ-02 asks whether the (1 + o(1)) multiplicative factor can be sharpened to a bounded additive error, gₑ(N) ≤ log₂N + Oₑ(1), which would match the trivial lower bound gₑ(N) ≥ log₂N exactly. This entry formalizes the lower-bound side of that matching target, axiom-free and at the concrete per-subset level — replacing the parent file's abstract axiom basic_lower_bound.",
     "problemStatement": "Can the minimal uniform-representation size be sharpened to gₑ(N) ≤ log₂N + Oₑ(1), matching the trivial lower bound gₑ(N) ≥ log₂N?",
-    "text": "A 104-line, axiom-free formalization of the trivial lower bound. The key step epsUniform_spanning shows that ε-uniformity (ε < 1) alone forces every group element to be representable (F_A(g) ≥ 1), with no assumption on |A|. Summing over the N group elements and using the parent's identity Σ_g F_A(g) = 2^|A| gives N ≤ 2^|A|, hence ⌈log₂N⌉ ≤ |A|. The headline OQ-02 (the additive Oₑ(1) upper bound) remains open.",
+    "text": "A 151-line, axiom-free, machine-checked formalization of the trivial lower bound plus structural API for ε-uniformity. The key step epsUniform_spanning shows that ε-uniformity (ε < 1) alone forces every group element to be representable (F_A(g) ≥ 1), with no assumption on |A|. Summing over the N group elements and using the parent's identity Σ_g F_A(g) = 2^|A| gives N ≤ 2^|A|, hence ⌈log₂N⌉ ≤ |A|. The structural lemmas record that the ε-uniformity classes are nested (epsUniform_mono), that the count is bounded on both sides (epsUniform_count_upper companions epsUniform_spanning), and that no set below ⌈log₂N⌉ can be ε-uniform (not_epsUniform_of_card_lt_clog). The headline OQ-02 (the additive Oₑ(1) upper bound) remains open.",
     "proofStrategy": "From the ε-uniformity bound |F_A(g) − μ| ≤ ε·μ, the lower side gives F_A(g) ≥ (1−ε)·μ. Since μ = 2^|A|/N > 0 for N ≥ 1 and ε < 1, the RHS is positive, so the natural number F_A(g) is ≥ 1 (epsUniform_spanning) — crucially with no lower bound on |A|. Then N = Σ_g 1 ≤ Σ_g F_A(g) = 2^|A| (card_le_two_pow_of_epsUniform via total_reprCount), and Nat.le_pow_iff_clog_le converts this to ⌈log₂N⌉ ≤ |A| (clog_le_card_of_epsUniform).",
     "keyInsights": [
       "The lower bound gₑ(N) ≥ log₂N is information-theoretic: 2^|A| subsets must cover all N group elements, so 2^|A| ≥ N regardless of uniformity quality — uniformity (ε < 1) is only needed to guarantee every element is actually hit",
@@ -104,6 +108,14 @@
       "endLine": 104,
       "summary": "clog_le_card_of_epsUniform converts N ≤ 2^|A| into the integer headline bound Nat.clog 2 N ≤ |A| via Nat.le_pow_iff_clog_le (valid since base 2 > 1). Since Nat.clog 2 N = ⌈log₂N⌉, this is exactly the trivial lower bound gₑ(N) ≥ log₂N at the per-subset level.",
       "mathContext": "$N \\le 2^{|A|} \\iff \\lceil\\log_2 N\\rceil = \\operatorname{clog}_2 N \\le |A|$."
+    },
+    {
+      "id": "structural-api",
+      "title": "Structural Properties of ε-Uniformity",
+      "startLine": 106,
+      "endLine": 151,
+      "summary": "Reusable structural API for the IsEpsUniform predicate and the lower bound: expectedReprCount_nonneg (μ ≥ 0); epsUniform_mono (the ε-uniformity classes are nested — ε ≤ ε' carries ε-uniform to ε'-uniform, via |F−μ| ≤ ε·μ ≤ ε'·μ); epsUniform_count_upper (the upper companion of epsUniform_spanning — F_A(g) ≤ (1+ε)μ, the upper side of the defining bound, completing the two-sided sandwich); and not_epsUniform_of_card_lt_clog (contrapositive of the lower bound — no set below ⌈log₂N⌉ can be ε-uniform for any ε < 1).",
+      "mathContext": "$(1-\\varepsilon)\\mu \\le F_A(g) \\le (1+\\varepsilon)\\mu$; nesting in $\\varepsilon$ from $\\mu \\ge 0$; and $|A| < \\lceil\\log_2 N\\rceil \\Rightarrow \\neg\\,\\text{IsEpsUniform } A\\,\\varepsilon$."
     }
   ],
   "crossReferences": [
@@ -145,9 +157,9 @@
       "Real"
     ],
     "namespace": "Erdos1179",
-    "lineCount": 104,
+    "lineCount": 151,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/Erdos1179OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the axiom-free lower-bound development for Erdős #1179 OQ-02 (minimal
uniform subset-sum representation size) with reusable **structural API** for the
`IsEpsUniform` predicate, and — since the build is now machine-checked green —
promotes the entry from `formalized`/`wip` to `verified`.

## New theorems (all axiom-free, sorry-free)

- `expectedReprCount_nonneg` — the expected count `μ = 2^k/N ≥ 0`.
- `epsUniform_mono` — the ε-uniformity classes are **nested**: `ε ≤ ε'` carries
  ε-uniform to ε'-uniform, from `|F−μ| ≤ ε·μ ≤ ε'·μ`.
- `epsUniform_count_upper` — the **upper companion** of `epsUniform_spanning`:
  `F_A(g) ≤ (1+ε)·μ`, the upper side of the defining `|F−μ| ≤ ε·μ`, completing
  the two-sided sandwich `(1−ε)μ ≤ F_A(g) ≤ (1+ε)μ`.
- `not_epsUniform_of_card_lt_clog` — **contrapositive** of the lower bound: a set
  smaller than `⌈log₂N⌉` cannot be ε-uniform for any `ε < 1` (no slack below
  `g_ε(N) ≥ log₂N`).

## Build & status

`Build completed successfully (7744 jobs)` via the Docker wrapper. The file's
single pre-existing deprecation warning (`Nat.le_pow_iff_clog_le` at line 101)
is untouched. **0 axioms, 0 sorries, 0 native_decide.**

The meta `assumptions` field previously read *"Promote to verified once a green
docker-build of Proofs.Erdos1179OQ02 confirms the typecheck"* — that condition is
now met, so: status `formalized`→`verified`, badge `wip`→`verified`,
theoremCount 3→7, lineCount 104→151, plus a new section and contribution entries.
The headline OQ-02 additive `O_ε(1)` **upper bound remains open** and is
explicitly scoped out in `assumptions`/`overview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)