### PR TITLE
Enrich Chebyshev Minimax (de-moivre-oq-02-oq-03): annotations + overview/sections/conclusion

### DIFF
--- a/src/data/proofs/de-moivre-oq-02-oq-03/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03/meta.json
@@ -122,8 +122,14 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Polynomial", "Polynomial.Chebyshev", "Real"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Polynomial.Chebyshev",
+      "Real"
+    ],
     "namespace": "DeMoivreOQ0203",
     "lineCount": 200,
     "axiomCount": 0,
@@ -152,6 +158,77 @@
         "statement": "∀ (n : ℕ), 0 < n → (monicChebyshev n).Monic",
         "description": "The monic Chebyshev polynomial Tₙ/2^(n-1) is monic"
       }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's 1854 theorem states that among all monic real polynomials of degree n, the rescaled Chebyshev polynomial Tₙ/2^(n-1) has the smallest possible maximum absolute value on [-1,1], namely 2^(1-n). The mechanism is equioscillation: Tₙ alternately attains +1 and -1 at the n+1 points cos(kπ/n), k = 0..n, so the monic normalization alternates between ±2^(1-n). Mathlib's RingTheory/Polynomial/Chebyshev.lean explicitly flags 'Prove minimax properties of Chebyshev polynomials' and 'Compute zeroes and extrema' as open TODOs, and provides no degree or leading-coefficient lemmas for Tₙ. This entry supplies that missing infrastructure and the achievability half of the theorem.",
+    "problemStatement": "**The Open Question**\n\nDoes the monic Chebyshev polynomial $M_n = T_n/2^{n-1}$ minimize the sup-norm on $[-1,1]$ among all monic degree-$n$ real polynomials, with minimal value $2^{1-n}$?\n\n**This entry's contribution**\n\nThe analytic core and the achievability (upper) half, fully verified:\n- $|T_n(x)| \\le 1$ on $[-1,1]$ with equioscillation $T_n(\\cos(k\\pi/n)) = (-1)^k$;\n- $\\deg T_n = n$ and $\\operatorname{lead} T_n = 2^{n-1}$ (new infrastructure);\n- $M_n$ is monic of degree $n$, has sup-norm $\\le 2^{1-n}$, and equioscillates between $\\pm 2^{1-n}$.\n\nThe matching lower bound (every monic degree-$n$ polynomial has sup-norm $\\ge 2^{1-n}$, by the alternation/root-counting argument) is the remaining open continuation.",
+    "text": "Builds the analytic core and the achievability (upper) half of the classical Chebyshev minimax theorem. From the De Moivre identity Tₙ(cos θ) = cos(nθ) it derives the sup-norm envelope |Tₙ(x)| ≤ 1 on [-1,1] and the equioscillation values Tₙ(cos(kπ/n)) = (-1)^k at the n+1 extreme nodes. It then supplies the degree infrastructure Mathlib lacks — natDegree Tₙ = n and leadingCoeff Tₙ = 2^(n-1), proved by a paired induction on the second-order recurrence T_{n+2} = 2X·T_{n+1} − Tₙ — and assembles the monic Chebyshev polynomial Mₙ = Tₙ/2^(n-1), showing it is monic of degree n, has sup-norm ≤ 2^(1-n) on [-1,1], and equioscillates between ±2^(1-n). The matching lower bound (every monic degree-n polynomial has sup-norm ≥ 2^(1-n)) is the stated open continuation. 0 sorries, 0 axioms over ℝ.",
+    "proofStrategy": "**De Moivre for the analysis core; two-step induction for the degree facts.**\n\n1. **Sup-norm bound** `chebyshev_abs_eval_le_one`: for $x \\in [-1,1]$ write $x = \\cos(\\arccos x)$; then $T_n(x) = \\cos(n\\arccos x)$ by `T_real_cos`, so $|T_n(x)| \\le 1$.\n2. **Equioscillation** `chebyshev_eval_node`: at $x_k = \\cos(k\\pi/n)$, $T_n(x_k) = \\cos(n \\cdot k\\pi/n) = \\cos(k\\pi) = (-1)^k$ (`cos_nat_mul_pi`).\n3. **Degree infrastructure** `chebyshev_deg_lead_pair`: a single induction over the paired statement for $T_{n+1}, T_{n+2}$, driven by $T_{n+2} = 2X T_{n+1} - T_n$. The recurrence step `deg_lead_recurrence_step` shows $\\deg(2Xa - b) = d+1$ and $\\operatorname{lead}(2Xa - b) = 2c$ when $\\deg a = d$, $\\operatorname{lead} a = c \\ne 0$, $\\deg b \\le d$ (the $-b$ term is below the top degree, so it does not perturb the leading coefficient).\n4. **Monic normalization** `monicChebyshev` $= C(2^{n-1})^{-1} \\cdot T_n$: monicity and degree follow from the leading-coefficient and degree facts; the sup-norm bound and equioscillation follow by scaling the core results.",
+    "keyInsights": [
+      "**De Moivre is the whole analytic story**: the single identity $T_n(\\cos\\theta) = \\cos(n\\theta)$ delivers both the envelope bound $|T_n| \\le 1$ and the equioscillation values $(-1)^k$ at $\\cos(k\\pi/n)$ — no calculus of extrema needed.",
+      "**Degree facts need a paired induction**: the Chebyshev recurrence is second-order, so degree $n$ and leading coefficient $2^{n-1}$ must be carried for two consecutive indices simultaneously; the single recurrence step is isolated as a reusable lemma.",
+      "**The subtraction is harmless to the top**: in $T_{n+2} = 2X T_{n+1} - T_n$, the subtracted $T_n$ has degree $n < n+2$, so `leadingCoeff_sub_of_degree_lt` keeps the leading coefficient equal to that of $2X T_{n+1}$, doubling it each step to give $2^{n-1}$.",
+      "**Mathlib gap**: there are no `natDegree`/`leadingCoeff` lemmas for `Polynomial.Chebyshev.T`; this file derives them and they are candidates for upstreaming (the Chebyshev file lists exactly these as TODOs).",
+      "**Achievability vs. minimality**: equioscillation between $\\pm 2^{1-n}$ at $n+1$ nodes is the engine of *both* halves of the minimax theorem; this entry completes the upper (achievability) half, leaving the alternation→root-counting lower bound as the open continuation."
+    ],
+    "prerequisites": [
+      "De Moivre identity Tₙ(cos θ) = cos(nθ) (T_real_cos) and arccos as a right inverse of cos on [-1,1]",
+      "Chebyshev recurrence T_add_two: T_{n+2} = 2X·T_{n+1} − Tₙ",
+      "Polynomial.natDegree / leadingCoeff API (natDegree_mul, leadingCoeff_sub_of_degree_lt)",
+      "induction with a strengthened (paired) motive for second-order recurrences",
+      "Real.cos_nat_mul_pi: cos(kπ) = (-1)^k"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview and Research Question",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring posing the classical Chebyshev minimax / equioscillation question — among monic degree-n real polynomials, Mₙ = Tₙ/2^(n-1) minimizes the sup-norm on [-1,1] with value 2^(1-n) — and stating what this entry contributes: the analysis core, the missing degree/leading-coefficient infrastructure, and the achievability half. Notes Mathlib's explicit TODO flag for Chebyshev minimax properties.",
+      "mathContext": "Target: $\\min_{p\\ \\text{monic},\\ \\deg p=n}\\ \\|p\\|_{\\infty,[-1,1]} = 2^{1-n}$, attained by $M_n=T_n/2^{n-1}$. This file proves the upper (achievability) half and the supporting envelope, degree, and equioscillation facts."
+    },
+    {
+      "id": "analysis-core",
+      "title": "Part I: Sup-norm bound and equioscillation",
+      "startLine": 45,
+      "endLine": 72,
+      "summary": "The De Moivre analysis core: chebyshev_abs_eval_le_one proves |Tₙ(x)| ≤ 1 on [-1,1] by writing x = cos(arccos x) and using Tₙ(cos θ) = cos(nθ); chebyshev_eval_node proves the equioscillation Tₙ(cos(kπ/n)) = (-1)^k via cos(kπ) = (-1)^k; chebyshev_eval_one records the sharp endpoint value Tₙ(1) = 1.",
+      "mathContext": "$|T_n(x)|=|\\cos(n\\arccos x)|\\le 1$, with equality at $x_k=\\cos(k\\pi/n)$ where $T_n(x_k)=\\cos(k\\pi)=(-1)^k$ for $k=0,\\dots,n$."
+    },
+    {
+      "id": "recurrence-step",
+      "title": "Part II-a: One recurrence step on degree and leading coefficient",
+      "startLine": 74,
+      "endLine": 105,
+      "summary": "deg_lead_recurrence_step isolates exactly what one application of T_{n+2} = 2X·T_{n+1} − Tₙ does: given deg a = d, lead a = c ≠ 0, deg b ≤ d, the polynomial 2X·a − b has degree d+1 and leading coefficient 2c. The subtracted term sits strictly below the top degree, so natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_sub_of_degree_lt leave both unchanged.",
+      "mathContext": "$\\deg(2Xa-b)=d+1$ and $\\operatorname{lead}(2Xa-b)=2c$ whenever $\\deg a=d,\\ \\operatorname{lead}a=c\\ne0,\\ \\deg b\\le d$. Iterating doubles the leading coefficient to $2^{n-1}$."
+    },
+    {
+      "id": "degree-facts",
+      "title": "Part II-b: Paired induction and the degree/leading-coefficient facts",
+      "startLine": 107,
+      "endLine": 166,
+      "summary": "chebyshev_deg_lead_pair carries the degree/leading-coefficient statement for two consecutive indices through one induction driven by the recurrence; the scalar theorems chebyshev_natDegree (= n) and chebyshev_leadingCoeff (= 2^(n-1)) project out a component and rebase the index. These fill a documented Mathlib gap.",
+      "mathContext": "$\\deg T_n=n$, $\\operatorname{lead}T_n=2^{n-1}$ ($n\\ge1$): $T_n(x)=2^{n-1}x^n+\\text{lower order}$."
+    },
+    {
+      "id": "monic-achievability",
+      "title": "Part III: Monic Chebyshev polynomial and achievability",
+      "startLine": 168,
+      "endLine": 200,
+      "summary": "Defines monicChebyshev n = Tₙ/2^(n-1) and proves the achievability half: monicChebyshev_monic (monic), monicChebyshev_natDegree (degree n), monicChebyshev_abs_le (sup-norm ≤ 2^(1-n) on [-1,1]) and monicChebyshev_eval_node (equioscillates between ±2^(1-n) at the n+1 nodes). These scale the Part I bounds by the inverse leading coefficient from Part II.",
+      "mathContext": "$M_n=T_n/2^{n-1}$ is monic of degree $n$, $\\|M_n\\|_{\\infty,[-1,1]}\\le 2^{1-n}$, and $M_n(\\cos(k\\pi/n))=(-1)^k2^{1-n}$ — the equioscillation certificate of the minimax polynomial."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves 11 theorems and 1 definition with 0 sorries and 0 axioms over ℝ, establishing three things the classical Chebyshev minimax theorem needs: (1) the De Moivre analysis core |Tₙ| ≤ 1 with equioscillation Tₙ(cos(kπ/n)) = (-1)^k; (2) the degree facts natDegree Tₙ = n and leadingCoeff Tₙ = 2^(n-1), absent from Mathlib; and (3) the achievability half — the monic polynomial Mₙ = Tₙ/2^(n-1) is monic of degree n, has sup-norm ≤ 2^(1-n) on [-1,1], and equioscillates between ±2^(1-n).",
+    "implications": "**Significance**\n\n1. **Mathlib gap filled**: Mathlib's RingTheory/Polynomial/Chebyshev.lean lists 'Compute zeroes and extrema' and 'Prove minimax properties of Chebyshev polynomials' as open TODOs and provides no natDegree/leadingCoeff lemmas for Tₙ. chebyshev_natDegree and chebyshev_leadingCoeff are clean upstreaming candidates.\n\n2. **De Moivre is the whole analytic story**: the single identity Tₙ(cos θ) = cos(nθ) yields both the envelope and the alternation, with no calculus of extrema.\n\n3. **Reusable recurrence infrastructure**: deg_lead_recurrence_step packages the degree/leading-coefficient behaviour of any second-order recurrence p_{n+2} = 2X·p_{n+1} − pₙ, reusable beyond Chebyshev.\n\n4. **Equioscillation certificate**: the alternation between ±2^(1-n) at n+1 nodes is exactly the engine that, paired with the lower bound, proves minimality.",
+    "openQuestions": [
+      "The matching lower bound: every monic degree-n real polynomial has sup-norm ≥ 2^(1-n) on [-1,1], via the alternation → root-counting argument (if some monic p had smaller sup-norm, Mₙ − p would change sign at the n+1 equioscillation nodes, forcing n roots in a degree < n difference — a contradiction). Combining it with this entry's achievability half yields the full minimax theorem.",
+      "Uniqueness of the minimax polynomial: Mₙ is the unique monic degree-n polynomial attaining 2^(1-n), again from the equioscillation/root-counting argument.",
+      "Upstreaming chebyshev_natDegree and chebyshev_leadingCoeff to Mathlib, closing part of the Chebyshev TODO list."
     ]
   },
   "relatedProblems": [


### PR DESCRIPTION
## Enrichment pass — quality 0 → 100

Freshly-merged research entry (#26059) had a rich inner \`meta.meta\` block but **no annotations.json** and no top-level \`overview\`/\`sections\`/\`conclusion\` (the fields the gallery scorer reads), scoring 0.

### Added
- **annotations.json** — 7 line-accurate annotations, each with \`mathContext\`, \`significance\`, \`relatedConcepts\`, \`prerequisites\`, covering:
  - sup-norm envelope \`|Tₙ(x)| ≤ 1\` from De Moivre (L50–55)
  - equioscillation \`Tₙ(cos(kπ/n)) = (-1)^k\` (L60–68)
  - the reusable recurrence-step degree lemma (L79–105)
  - the paired induction (L109–146)
  - the Mathlib degree/leading-coefficient gap (L148–166)
  - the monic normalization (L171–183)
  - the achievability half + open lower bound (L185–198)
- **meta.json** — top-level \`overview\` (historicalContext, problemStatement, text, proofStrategy, 5 keyInsights, prerequisites), **5 \`sections\`** spanning lines 1–200 of the Lean file, and a \`conclusion\` with summary, implications, and 3 open questions (notably the matching minimax lower bound).

Annotation/section line ranges verified against \`proofs/Proofs/DeMoivreOQ02OQ03.lean\`. JSON validated; quality score 100/100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)