### PR TITLE
audit(derangements-oq-02-oq-02-oq-01): CLEAN — durable tracker entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2375,6 +2375,12 @@
       "lastAudited": "2026-05-04T04:06:41Z",
       "result": "clean"
     },
+    "derangements-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-19T08:19:24Z",
+      "result": "clean"
+    },
     "derangements-oq-03": {
       "auditCount": 4,
       "issues": [],
@@ -16035,5 +16041,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-19T08:14:07Z"
+  "lastUpdated": "2026-06-19T08:19:24Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `derangements-oq-02-oq-02-oq-01` (Higher Factorial Moments of Fixed Points of a Random Permutation)

First audit of this newly-shipped entry (#26064). All meta.json claims verified against `proofs/Proofs/DerangementsOQ02OQ02OQ01.lean`:

| Claim | meta.json | Source | ✓ |
|-------|-----------|--------|---|
| lineCount | 183 | 183 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 `axiom` decls, no `native_decide` tactic | ✓ |
| theoremCount | 6 | 6 (`card_fixedBy_emb` + 5 theorems) | ✓ |
| definitionCount | 1 | 1 (`fixedEmbEquiv`) | ✓ |
| status/badge | verified / original | Tier A | ✓ |

- No `True`-stub theorems; no assumption-carrying structures/classes.
- Registered in `Proofs.lean:632`.
- The lone `native_decide` grep hit is in the docstring ("no `native_decide` in the main result"), not a tactic.

**Tier A assembly proof.** The result (∑_σ (|Fix σ|)_k = n! for k ≤ n) is a *new* statement, not a Mathlib wrapper. The proof assembles Mathlib's Burnside lemma, `Equiv.Perm.isMultiplyPretransitive`, and `Fintype.card_embedding_eq` with its own bridge lemma `fixedEmbEquiv` / `card_fixedBy_emb`. Every Mathlib dependency is explicitly credited in proofStrategy / prerequisites / keyInsights — **no delegation opacity**. Axiom-free claim (`#print axioms` = propext / Classical.choice / Quot.sound only) is consistent with the source. Badge `original` / status `verified` justified.

This PR adds the durable tracker entry that `claim-target.sh complete` does not write.

---
Discovered during gallery integrity audit.