### PR TITLE
Enrich de-moivre-oq-02-oq-03: Chebyshev minimax (0→100)

### DIFF
--- a/src/data/proofs/de-moivre-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03/annotations.json
@@ -1,0 +1,253 @@
+[
+  {
+    "id": "ann-abs-eval-le-one",
+    "proofId": "de-moivre-oq-02-oq-03",
+    "range": {
+      "startLine": 50,
+      "endLine": 55
+    },
+    "type": "theorem",
+    "title": "The Sup-Norm Envelope |Tₙ(x)| ≤ 1 on [-1,1]",
+    "content": "The analytic backbone of the minimax theorem: every Chebyshev polynomial of the first kind stays inside the band [-1, 1] over the interval [-1, 1]. The proof is pure De Moivre and needs no calculus of extrema. For x ∈ [-1, 1] write x = cos(arccos x) — this is exactly Real.cos_arccos, valid precisely because -1 ≤ x ≤ 1 (the two interval hypotheses h1, h2 are consumed here). Substituting and applying the defining identity T_real_cos turns Tₙ(x) into cos(n · arccos x), whose absolute value is ≤ 1 because cosine lands in [-1, 1] (Real.neg_one_le_cos and Real.cos_le_one). The geometry: parametrizing [-1,1] by the cosine wraps the polynomial onto a pure cosine wave, which automatically obeys the envelope.",
+    "mathContext": "$x = \\cos(\\arccos x),\\quad T_n(x) = \\cos(n\\arccos x),\\quad |T_n(x)| \\le 1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "De Moivre's identity",
+      "equioscillation envelope",
+      "Chebyshev polynomials of the first kind",
+      "sup-norm bound"
+    ],
+    "prerequisites": [
+      "Real.cos_arccos",
+      "Polynomial.Chebyshev.T_real_cos",
+      "Real.cos_le_one"
+    ]
+  },
+  {
+    "id": "ann-eval-node",
+    "proofId": "de-moivre-oq-02-oq-03",
+    "range": {
+      "startLine": 60,
+      "endLine": 68
+    },
+    "type": "theorem",
+    "title": "Equioscillation at the n+1 Extreme Nodes",
+    "content": "The engine of the minimax theorem: at the Chebyshev extreme nodes xₖ = cos(kπ/n), the polynomial attains its extreme values ±1 with strictly alternating sign, Tₙ(xₖ) = (-1)^k. After applying T_real_cos the value becomes cos(n · kπ/n). The argument simplification harg cancels the n (using n ≠ 0, supplied by the hypothesis hn) to leave cos(kπ), and Real.cos_nat_mul_pi evaluates cos(kπ) = (-1)^k. These n+1 alternations (k = 0, …, n) are the combinatorial content that forces minimality: a competitor with smaller sup-norm would have to cross the monic Chebyshev polynomial at each of the n+1 nodes, producing too many roots.",
+    "mathContext": "$x_k = \\cos\\!\\big(\\tfrac{k\\pi}{n}\\big),\\qquad T_n(x_k) = \\cos\\!\\big(n\\cdot\\tfrac{k\\pi}{n}\\big) = \\cos(k\\pi) = (-1)^k$",
+    "significance": "key",
+    "relatedConcepts": [
+      "equioscillation",
+      "Chebyshev extreme nodes",
+      "alternation",
+      "De Moivre's identity"
+    ],
+    "prerequisites": [
+      "Polynomial.Chebyshev.T_real_cos",
+      "Real.cos_nat_mul_pi"
+    ]
+  },
+  {
+    "id": "ann-eval-one",
+    "proofId": "de-moivre-oq-02-oq-03",
+    "range": {
+      "startLine": 71,
+      "endLine": 72
+    },
+    "type": "theorem",
+    "title": "Sharpness at the Endpoint: Tₙ(1) = 1",
+    "content": "A one-line witness that the envelope bound |Tₙ| ≤ 1 is attained: at the right endpoint Tₙ(1) = 1 for every n, by the Mathlib lemma T_eval_one. This is the k = 0 case of the equioscillation nodes (cos 0 = 1) and confirms the band [-1,1] is the tightest possible — the polynomial actually touches the top of its envelope.",
+    "mathContext": "$T_n(1) = 1 \\quad\\text{for all } n$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "endpoint sharpness",
+      "Chebyshev polynomials",
+      "envelope attainment"
+    ],
+    "prerequisites": [
+      "Polynomial.Chebyshev.T_eval_one"
+    ]
+  },
+  {
+    "id": "ann-recurrence-step",
+    "proofId": "de-moivre-oq-02-oq-03",
+    "range": {
+      "startLine": 79,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "One Recurrence Step: Degree d+1, Leading Coefficient 2c",
+    "content": "The reusable algebraic heart of the degree infrastructure, isolating a single application of the Chebyshev recurrence Tₙ₊₂ = 2X·Tₙ₊₁ − Tₙ. Given a polynomial a of degree d with nonzero leading coefficient c, and a polynomial b of degree ≤ d, it shows 2X·a − b has degree d+1 and leading coefficient 2c. The proof first pins down 2X (degree 1, leading coefficient 2) via C_ofNat to rewrite the literal 2 as C 2, then computes that 2X·a has degree d+1 and leading coefficient 2c by natDegree_mul and leadingCoeff_mul. The decisive observation is that the subtracted term b sits strictly below the top degree (degree b < degree(2X·a)), so leadingCoeff_sub_of_degree_lt and natDegree_sub_eq_left_of_natDegree_lt guarantee the −b is harmless to both the degree and the leading coefficient.",
+    "mathContext": "$\\deg a = d,\\ \\operatorname{lead} a = c \\ne 0,\\ \\deg b \\le d \\;\\Rightarrow\\; \\deg(2Xa - b) = d+1,\\ \\operatorname{lead}(2Xa - b) = 2c$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chebyshev recurrence",
+      "leading coefficient",
+      "polynomial degree",
+      "leadingCoeff_sub_of_degree_lt"
+    ],
+    "prerequisites": [
+      "Polynomial.natDegree_mul",
+      "Polynomial.leadingCoeff_mul",
+      "Polynomial.leadingCoeff_sub_of_degree_lt"
+    ]
+  },
+  {
+    "id": "ann-deg-lead-pair",
+    "proofId": "de-moivre-oq-02-oq-03",
+    "range": {
+      "startLine": 109,
+      "endLine": 146
+    },
+    "type": "theorem",
+    "title": "Paired Induction for Degree and Leading Coefficient",
+    "content": "Because the Chebyshev recurrence is second-order, the degree and leading-coefficient facts cannot be proved by ordinary induction on a single index — the step from n+1 needs information about both Tₙ₊₁ and Tₙ. The fix is to carry a paired invariant for two consecutive indices simultaneously: 'natDegree Tₙ₊₁ = n+1 ∧ lead Tₙ₊₁ = 2ⁿ, and natDegree Tₙ₊₂ = n+2 ∧ lead Tₙ₊₂ = 2ⁿ⁺¹'. The base case n = 0 uses T_one (T₁ = X) and T_two (T₂ = 2X² − 1), the latter handled by compute_degree! and a leadingCoeff_add_of_degree_lt rewrite. The successor case feeds the inductive data into the single-step lemma deg_lead_recurrence_step via the recurrence T_add_two, doubling the leading coefficient at each step to build 2ⁿ.",
+    "mathContext": "$\\deg T_{n+1} = n+1,\\ \\operatorname{lead} T_{n+1} = 2^{n};\\quad \\deg T_{n+2} = n+2,\\ \\operatorname{lead} T_{n+2} = 2^{n+1}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "paired induction",
+      "second-order recurrence",
+      "Chebyshev polynomials",
+      "leading coefficient"
+    ],
+    "prerequisites": [
+      "Polynomial.Chebyshev.T_add_two",
+      "Polynomial.Chebyshev.T_one",
+      "Polynomial.Chebyshev.T_two"
+    ]
+  },
+  {
+    "id": "ann-natdegree",
+    "proofId": "de-moivre-oq-02-oq-03",
+    "range": {
+      "startLine": 149,
+      "endLine": 155
+    },
+    "type": "theorem",
+    "title": "Degree of Tₙ is Exactly n (Mathlib Gap)",
+    "content": "A degree lemma that Mathlib's Chebyshev file does not provide: natDegree(Tₙ) = n. The n = 0 case is T₀ = 1 (a degree-0 constant) via T_zero; the positive case unpacks the first component of the paired induction chebyshev_deg_lead_pair and re-indexes m+1 to match. This is exactly the kind of infrastructure flagged as a TODO in Mathlib's RingTheory/Polynomial/Chebyshev.lean ('Compute zeroes and extrema'), and is a candidate for upstreaming.",
+    "mathContext": "$\\deg T_n = n \\quad\\text{for all } n \\ge 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "polynomial degree",
+      "Mathlib gap",
+      "Chebyshev polynomials",
+      "upstreaming candidate"
+    ],
+    "prerequisites": [
+      "Polynomial.Chebyshev.T_zero",
+      "chebyshev_deg_lead_pair"
+    ]
+  },
+  {
+    "id": "ann-leadingcoeff",
+    "proofId": "de-moivre-oq-02-oq-03",
+    "range": {
+      "startLine": 158,
+      "endLine": 166
+    },
+    "type": "theorem",
+    "title": "Leading Coefficient of Tₙ is 2^(n-1) (Mathlib Gap)",
+    "content": "The companion leading-coefficient lemma, also absent from Mathlib: for n ≥ 1, lead(Tₙ) = 2^(n-1). The n = 0 case is impossible under the hypothesis 0 < n and is discharged by absurd; the positive case reads off the second component of chebyshev_deg_lead_pair and simplifies the index. This 2^(n-1) is precisely the factor that the monic normalization divides out, and together with chebyshev_natDegree it supplies everything needed to build the monic Chebyshev polynomial.",
+    "mathContext": "$\\operatorname{lead} T_n = 2^{\\,n-1} \\quad\\text{for } n \\ge 1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "leading coefficient",
+      "monic normalization",
+      "Mathlib gap",
+      "Chebyshev polynomials"
+    ],
+    "prerequisites": [
+      "chebyshev_deg_lead_pair"
+    ]
+  },
+  {
+    "id": "ann-monic-def",
+    "proofId": "de-moivre-oq-02-oq-03",
+    "range": {
+      "startLine": 171,
+      "endLine": 172
+    },
+    "type": "definition",
+    "title": "The Monic Chebyshev Polynomial Mₙ = Tₙ / 2^(n-1)",
+    "content": "The protagonist of the minimax theorem, defined by dividing Tₙ by its leading coefficient 2^(n-1) (multiplying by C of the inverse). This is the unique scaling that makes the top coefficient 1 while preserving the equioscillation shape. All three achievability facts below — monicity, the sup-norm bound 2^(1-n), and equioscillation between ±2^(1-n) — follow by scaling the core results for Tₙ by this constant factor.",
+    "mathContext": "$M_n = \\frac{T_n}{2^{\\,n-1}} = C\\big((2^{\\,n-1})^{-1}\\big)\\cdot T_n$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monic polynomial",
+      "normalization",
+      "Chebyshev polynomials",
+      "minimax"
+    ],
+    "prerequisites": [
+      "chebyshev_leadingCoeff"
+    ]
+  },
+  {
+    "id": "ann-monic-monic",
+    "proofId": "de-moivre-oq-02-oq-03",
+    "range": {
+      "startLine": 175,
+      "endLine": 183
+    },
+    "type": "theorem",
+    "title": "Mₙ is Monic of Degree n",
+    "content": "The normalization works as intended: monicChebyshev_monic shows the leading coefficient of Mₙ is 1 (Monic.def), by computing lead(C c · Tₙ) = c · lead(Tₙ) = (2^(n-1))⁻¹ · 2^(n-1) = 1 through leadingCoeff_mul, leadingCoeff_C, chebyshev_leadingCoeff, and inv_mul_cancel₀. The companion monicChebyshev_natDegree confirms the degree is unchanged at n, since multiplying by a nonzero constant C does not alter the degree (natDegree_C_mul). Together these place Mₙ in the competition class of the minimax problem — monic real polynomials of degree exactly n.",
+    "mathContext": "$\\operatorname{lead} M_n = (2^{\\,n-1})^{-1}\\cdot 2^{\\,n-1} = 1,\\qquad \\deg M_n = n$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monic polynomial",
+      "leading coefficient",
+      "minimax competition class",
+      "degree"
+    ],
+    "prerequisites": [
+      "Polynomial.Monic",
+      "chebyshev_leadingCoeff",
+      "chebyshev_natDegree"
+    ]
+  },
+  {
+    "id": "ann-monic-abs-le",
+    "proofId": "de-moivre-oq-02-oq-03",
+    "range": {
+      "startLine": 186,
+      "endLine": 192
+    },
+    "type": "theorem",
+    "title": "Achievability: Sup-Norm of Mₙ is ≤ 2^(1-n)",
+    "content": "The upper (achievability) half of the minimax theorem: on [-1, 1] the monic Chebyshev polynomial never exceeds 2^(1-n) in absolute value. Evaluating Mₙ = C c · Tₙ at x factors |Mₙ(x)| = (2^(n-1))⁻¹ · |Tₙ(x)| (eval_mul, eval_C, abs_mul, with the constant positive by positivity). The core envelope bound chebyshev_abs_eval_le_one pins |Tₙ(x)| ≤ 1, so the product is ≤ (2^(n-1))⁻¹ = 2^(1-n). This proves a monic degree-n polynomial exists whose sup-norm is exactly 2^(1-n) — the value the full minimax theorem claims is optimal.",
+    "mathContext": "$|M_n(x)| = (2^{\\,n-1})^{-1}\\,|T_n(x)| \\le (2^{\\,n-1})^{-1} = 2^{\\,1-n}\\quad (x \\in [-1,1])$",
+    "significance": "key",
+    "relatedConcepts": [
+      "minimax achievability",
+      "sup-norm",
+      "monic polynomial",
+      "approximation theory"
+    ],
+    "prerequisites": [
+      "chebyshev_abs_eval_le_one"
+    ]
+  },
+  {
+    "id": "ann-monic-eval-node",
+    "proofId": "de-moivre-oq-02-oq-03",
+    "range": {
+      "startLine": 195,
+      "endLine": 198
+    },
+    "type": "theorem",
+    "title": "Mₙ Equioscillates Between ±2^(1-n)",
+    "content": "The achievability bound is sharp at the same n+1 nodes: Mₙ(cos(kπ/n)) = (-1)^k · 2^(1-n). Scaling the equioscillation identity chebyshev_eval_node by the constant (2^(n-1))⁻¹ gives the alternating values ±2^(1-n) at the extreme nodes. This alternation is the engine of both halves of the minimax theorem — it makes the upper bound tight here, and (in the open continuation) forces any monic competitor to have sup-norm ≥ 2^(1-n) by a root-counting argument on the difference Mₙ − competitor.",
+    "mathContext": "$M_n\\!\\big(\\cos\\tfrac{k\\pi}{n}\\big) = (-1)^k\\,(2^{\\,n-1})^{-1} = (-1)^k\\,2^{\\,1-n}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "equioscillation",
+      "minimax",
+      "alternation",
+      "root counting"
+    ],
+    "prerequisites": [
+      "chebyshev_eval_node"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-02-oq-03/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03/meta.json
@@ -50,6 +50,77 @@
       "**Achievability vs. minimality**: equioscillation between $\\pm 2^{1-n}$ at $n+1$ nodes is the engine of *both* halves of the minimax theorem; this entry completes the upper (achievability) half, leaving the alternation→root-counting lower bound as the open continuation."
     ]
   },
+  "overview": {
+    "historicalContext": "Chebyshev's 1854 theorem states that among all monic real polynomials of degree n, the rescaled Chebyshev polynomial Tₙ/2^(n-1) has the smallest possible maximum absolute value on [-1,1], namely 2^(1-n). The mechanism is equioscillation: Tₙ alternately attains +1 and -1 at the n+1 points cos(kπ/n), k = 0..n, so the monic normalization alternates between ±2^(1-n). Mathlib's RingTheory/Polynomial/Chebyshev.lean explicitly flags 'Prove minimax properties of Chebyshev polynomials' and 'Compute zeroes and extrema' as open TODOs, and provides no degree or leading-coefficient lemmas for Tₙ. This entry supplies that missing infrastructure and the achievability half of the theorem, all derived from the single De Moivre identity Tₙ(cos θ) = cos(nθ) and the two-term recurrence Tₙ₊₂ = 2X·Tₙ₊₁ − Tₙ.",
+    "problemStatement": "**The Open Question**\n\nDoes the monic Chebyshev polynomial $M_n = T_n/2^{n-1}$ minimize the sup-norm on $[-1,1]$ among all monic degree-$n$ real polynomials, with minimal value $2^{1-n}$?\n\n**This entry's contribution**\n\nThe analytic core and the achievability (upper) half, fully verified:\n- $|T_n(x)| \\le 1$ on $[-1,1]$ with equioscillation $T_n(\\cos(k\\pi/n)) = (-1)^k$;\n- $\\deg T_n = n$ and $\\operatorname{lead} T_n = 2^{n-1}$ (new infrastructure);\n- $M_n$ is monic of degree $n$, has sup-norm $\\le 2^{1-n}$, and equioscillates between $\\pm 2^{1-n}$.\n\nThe matching lower bound (every monic degree-$n$ polynomial has sup-norm $\\ge 2^{1-n}$, by the alternation/root-counting argument) is the remaining open continuation.",
+    "text": "Builds the analytic core and the achievability half of the Chebyshev minimax theorem from the De Moivre identity: the sup-norm envelope |Tₙ| ≤ 1, equioscillation at the n+1 extreme nodes, the degree and leading-coefficient infrastructure Mathlib lacks, and the monic Chebyshev polynomial with sup-norm 2^(1-n).",
+    "proofStrategy": "**De Moivre for the analysis core; two-step induction for the degree facts.**\n\n1. **Sup-norm bound** `chebyshev_abs_eval_le_one`: for $x \\in [-1,1]$ write $x = \\cos(\\arccos x)$; then $T_n(x) = \\cos(n\\arccos x)$ by `T_real_cos`, so $|T_n(x)| \\le 1$.\n2. **Equioscillation** `chebyshev_eval_node`: at $x_k = \\cos(k\\pi/n)$, $T_n(x_k) = \\cos(n \\cdot k\\pi/n) = \\cos(k\\pi) = (-1)^k$ (`cos_nat_mul_pi`).\n3. **Degree infrastructure** `chebyshev_deg_lead_pair`: a single induction over the paired statement for $T_{n+1}, T_{n+2}$, driven by $T_{n+2} = 2X T_{n+1} - T_n$. The recurrence step `deg_lead_recurrence_step` shows $\\deg(2Xa - b) = d+1$ and $\\operatorname{lead}(2Xa - b) = 2c$ when $\\deg a = d$, $\\operatorname{lead} a = c \\ne 0$, $\\deg b \\le d$ (the $-b$ term is below the top degree, so it does not perturb the leading coefficient).\n4. **Monic normalization** `monicChebyshev` $= C(2^{n-1})^{-1} \\cdot T_n$: monicity and degree follow from the leading-coefficient and degree facts; the sup-norm bound and equioscillation follow by scaling the core results.",
+    "keyInsights": [
+      "**De Moivre is the whole analytic story**: the single identity $T_n(\\cos\\theta) = \\cos(n\\theta)$ delivers both the envelope bound $|T_n| \\le 1$ and the equioscillation values $(-1)^k$ at $\\cos(k\\pi/n)$ — no calculus of extrema needed.",
+      "**Degree facts need a paired induction**: the Chebyshev recurrence is second-order, so degree $n$ and leading coefficient $2^{n-1}$ must be carried for two consecutive indices simultaneously; the single recurrence step is isolated as a reusable lemma.",
+      "**The subtraction is harmless to the top**: in $T_{n+2} = 2X T_{n+1} - T_n$, the subtracted $T_n$ has degree $n < n+2$, so `leadingCoeff_sub_of_degree_lt` keeps the leading coefficient equal to that of $2X T_{n+1}$, doubling it each step to give $2^{n-1}$.",
+      "**Mathlib gap**: there are no `natDegree`/`leadingCoeff` lemmas for `Polynomial.Chebyshev.T`; this file derives them and they are candidates for upstreaming (the Chebyshev file lists exactly these as TODOs).",
+      "**Achievability vs. minimality**: equioscillation between $\\pm 2^{1-n}$ at $n+1$ nodes is the engine of *both* halves of the minimax theorem; this entry completes the upper (achievability) half, leaving the alternation→root-counting lower bound as the open continuation."
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials of the first kind Tₙ and the De Moivre identity Tₙ(cos θ) = cos(nθ)",
+      "The two-term recurrence Tₙ₊₂ = 2X·Tₙ₊₁ − Tₙ",
+      "Polynomial degree and leading-coefficient algebra (natDegree_mul, leadingCoeff_mul, leadingCoeff_sub_of_degree_lt)",
+      "Monic polynomials and the sup-norm on [-1,1]"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sup-norm-equioscillation",
+      "title": "The Sup-Norm Bound and Equioscillation",
+      "startLine": 45,
+      "endLine": 72,
+      "description": "From De Moivre: |Tₙ(x)| ≤ 1 on [-1,1], equioscillation Tₙ(cos(kπ/n)) = (-1)^k at the n+1 extreme nodes, and endpoint sharpness Tₙ(1) = 1.",
+      "summary": "From De Moivre: |Tₙ(x)| ≤ 1 on [-1,1], equioscillation Tₙ(cos(kπ/n)) = (-1)^k at the n+1 extreme nodes, and endpoint sharpness Tₙ(1) = 1."
+    },
+    {
+      "id": "recurrence-step",
+      "title": "One Recurrence Step",
+      "startLine": 74,
+      "endLine": 105,
+      "description": "The reusable lemma deg_lead_recurrence_step: 2X·a − b has degree d+1 and leading coefficient 2c when deg a = d, lead a = c ≠ 0, deg b ≤ d.",
+      "summary": "The reusable lemma deg_lead_recurrence_step: 2X·a − b has degree d+1 and leading coefficient 2c when deg a = d, lead a = c ≠ 0, deg b ≤ d."
+    },
+    {
+      "id": "paired-induction",
+      "title": "Paired Degree/Leading-Coefficient Induction",
+      "startLine": 107,
+      "endLine": 146,
+      "description": "chebyshev_deg_lead_pair carries the degree and leading-coefficient invariant for two consecutive indices, driven by the second-order recurrence T_add_two.",
+      "summary": "chebyshev_deg_lead_pair carries the degree and leading-coefficient invariant for two consecutive indices, driven by the second-order recurrence T_add_two."
+    },
+    {
+      "id": "degree-leading-coeff",
+      "title": "Degree and Leading Coefficient of Tₙ",
+      "startLine": 148,
+      "endLine": 166,
+      "description": "The public corollaries Mathlib lacks: natDegree(Tₙ) = n and leadingCoeff(Tₙ) = 2^(n-1) for n ≥ 1.",
+      "summary": "The public corollaries Mathlib lacks: natDegree(Tₙ) = n and leadingCoeff(Tₙ) = 2^(n-1) for n ≥ 1."
+    },
+    {
+      "id": "monic-achievability",
+      "title": "The Monic Chebyshev Polynomial and Achievability",
+      "startLine": 168,
+      "endLine": 200,
+      "description": "monicChebyshev = Tₙ/2^(n-1): monic of degree n, sup-norm ≤ 2^(1-n) on [-1,1], equioscillating between ±2^(1-n) — the achievability half of the minimax theorem.",
+      "summary": "monicChebyshev = Tₙ/2^(n-1): monic of degree n, sup-norm ≤ 2^(1-n) on [-1,1], equioscillating between ±2^(1-n) — the achievability half of the minimax theorem."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization establishes, axiom-free and sorry-free, the analytic core and the achievability (upper) half of the classical Chebyshev minimax theorem. From the single De Moivre identity Tₙ(cos θ) = cos(nθ) it derives the sup-norm envelope |Tₙ| ≤ 1 on [-1,1] and the equioscillation values Tₙ(cos(kπ/n)) = (-1)^k at the n+1 extreme nodes. It then supplies the degree and leading-coefficient infrastructure that Mathlib lacks — natDegree(Tₙ) = n and leadingCoeff(Tₙ) = 2^(n-1) — via a paired induction over the second-order recurrence, and assembles the monic Chebyshev polynomial Tₙ/2^(n-1), proving it is monic of degree n with sup-norm ≤ 2^(1-n) and equioscillation between ±2^(1-n).",
+    "implications": "Demonstrates that a monic degree-n real polynomial with sup-norm exactly 2^(1-n) on [-1,1] exists — the achievability witness the minimax theorem requires. The degree and leading-coefficient lemmas fill a documented gap in Mathlib's Chebyshev file (which lists 'minimax properties' and 'zeroes and extrema' as open TODOs) and are reusable, upstreamable infrastructure for any further Chebyshev development. The equioscillation envelope proved here is the exact mechanism that drives the matching lower bound.",
+    "openQuestions": [
+      "Prove the matching lower bound: every monic degree-n real polynomial has sup-norm ≥ 2^(1-n) on [-1,1], via the alternation→root-counting argument (a competitor with smaller sup-norm forces too many sign changes of the difference Mₙ − competitor across the n+1 nodes, exceeding its degree).",
+      "Combine the two halves into the full Chebyshev minimax / equioscillation theorem with uniqueness of the optimal monic polynomial.",
+      "Upstream natDegree(Tₙ) = n and leadingCoeff(Tₙ) = 2^(n-1) to Mathlib's RingTheory/Polynomial/Chebyshev.lean, closing the listed TODOs.",
+      "Extend to the second-kind Chebyshev polynomials Uₙ and the corresponding L¹/weighted extremal problems."
+    ]
+  },
   "leanFile": {
     "imports": ["Mathlib"],
     "opens": ["Polynomial", "Polynomial.Chebyshev", "Real"],


### PR DESCRIPTION
Enriches **de-moivre-oq-02-oq-03** (Chebyshev Minimax: Equioscillation and the Monic Achievability Half), freshly merged from research #26059. On origin/main it had only `meta.json` and no annotations (quality **0**).

## Changes

**annotations.json (new)** — 11 line-accurate annotations covering every theorem plus the `monicChebyshev` definition:
- the sup-norm envelope `|Tₙ| ≤ 1` and equioscillation `Tₙ(cos kπ/n) = (-1)^k` (the De Moivre analytic core)
- the reusable recurrence step and the **paired** second-order induction for degree/leading-coefficient
- the Mathlib-gap lemmas `natDegree Tₙ = n`, `leadingCoeff Tₙ = 2^(n-1)`
- the monic normalization and the achievability half (monic, sup-norm ≤ 2^(1-n), equioscillation between ±2^(1-n))

Each annotation carries `mathContext`, `significance`, `relatedConcepts`, and Mathlib `prerequisites`.

**meta.json** — added the top-level gallery fields the research shape lacked:
- `overview` (historicalContext, problemStatement, proofStrategy, 5 keyInsights, prerequisites)
- `sections` (5, with Lean line ranges)
- `conclusion` (summary, implications, openQuestions — including the open minimax **lower bound** continuation)

## Quality

0 → **100** (annotations 25, mathContext 10, significance 10, historicalContext 10, keyInsights 10, conclusion 15, sections 10, crossRefs 10). Gallery now fully saturated.

No Lean source changed; comment/metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)