### PR TITLE
audit(erdos-1172): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4419,9 +4419,9 @@
       "result": "clean"
     },
     "erdos-1172": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-reaudit",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T08:23:09Z",
       "result": "clean"
     },
     "erdos-1173": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1172

Re-audited **erdos-1172** (Erdős Problem #1172: Partition Relations under GCH and CH) during a saturated-gallery cycle (2554/2554 audited; selected as stalest `lastAudited` = 2026-05-03).

### Result: CLEAN ✅

All `meta.json` claims verified against `proofs/Proofs/Erdos1172Problem.lean`:

| Field | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| lineCount | 246 | 246 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 | ✓ |
| theoremCount | 19 | 19 | ✓ |
| definitionCount | 13 | 13 | ✓ |

- **3 axioms** all disclosed in `assumptions`: `erdos_dushnik_miller` (EDM 1941), `todorcevic_negative` (1989), `pfa_positive` (PFA). No hidden structure-encoded assumptions.
- No `True` stubs, no `native_decide`, no structures.
- `status: axiomatized` / `badge: axiom` is correct for an OPEN Erdős problem with stated assumptions.
- **No overclaiming**: the four questions remain open `Prop` definitions; the file only *derives weak forms* (e.g. ω₃→(ω₂,ω)² via EDM + monotonicity) and contextual independence results. EDM is axiomatized & disclosed — no Mathlib-wrapper masking, no inequality≠theorem inflation.

Tracker `auditCount` 3 → 4.

---
Discovered/verified during autonomous gallery integrity audit.