### PR TITLE
research(erdos-998-oq-04): STEP A transport primitives (orbit index injectivity + punctured-orbit image)

### DIFF
--- a/proofs/Proofs/Erdos998ThreeGapOQ04.lean
+++ b/proofs/Proofs/Erdos998ThreeGapOQ04.lean
@@ -157,6 +157,38 @@ theorem fract_fract_sub_fract (x y : ℝ) :
     simp only [Int.fract]; push_cast; ring
   rw [h, Int.fract_sub_int]
 
+/-- **STEP A primitive — index → orbit-point injectivity.**  For irrational `α`
+    the map `i ↦ {iα}` is injective on all of `ℕ` (not merely on `range N`): the
+    `Set.InjOn` argument inside `orbit_card` never used the range bound, so it
+    upgrades to genuine `Function.Injective`.  This is the form needed to push
+    `Finset.erase` through the orbit `image`. -/
+theorem orbit_index_injective {α : ℝ} (hα : Irrational α) :
+    Function.Injective (fun i : ℕ => Int.fract ((i : ℝ) * α)) := by
+  intro i j hij
+  by_contra hne
+  simp only at hij
+  rw [Int.fract_eq_fract] at hij
+  obtain ⟨z, hz⟩ := hij
+  have hm : ((i : ℤ) - (j : ℤ)) ≠ 0 := sub_ne_zero.mpr (by exact_mod_cast hne)
+  have key : (((i : ℤ) - (j : ℤ) : ℤ) : ℝ) * α = (z : ℝ) := by
+    push_cast; rw [sub_mul]; exact hz
+  have hirr : Irrational ((((i : ℤ) - (j : ℤ) : ℤ) : ℝ) * α) := hα.intCast_mul hm
+  rw [key] at hirr
+  exact (Int.not_irrational z) hirr
+
+/-- **STEP A primitive — the punctured orbit is the image of the other indices.**
+    Removing the orbit point `{kα}` from the `N`-point orbit leaves exactly the
+    images of the remaining indices `range N \ {k}`.  Immediate from
+    `orbit_index_injective` via `Finset.image_erase`; this is what lets the
+    forward-gap minimum at `{kα}` be transported from orbit points to index
+    differences in STEP A. -/
+theorem orbit_erase_eq {α : ℝ} (hα : Irrational α) (N k : ℕ) :
+    (orbit α N).erase (Int.fract ((k : ℝ) * α)) =
+      ((Finset.range N).erase k).image (fun i : ℕ => Int.fract ((i : ℝ) * α)) := by
+  rw [orbit,
+    show (Int.fract ((k : ℝ) * α)) = (fun i : ℕ => Int.fract ((i : ℝ) * α)) k from rfl,
+    ← Finset.image_erase (orbit_index_injective hα)]
+
 /-
     PROOF PATH for the core classification `exists_gap_triple`
     (van Ravenstein / Sós, elementary).  Session 6 (researcher-1, 2026-06-18)

--- a/research/problems/erdos-998-oq-04/sessions/2026-06-19-s7-stepA-forwardgap-reduction-turnkey.md
+++ b/research/problems/erdos-998-oq-04/sessions/2026-06-19-s7-stepA-forwardgap-reduction-turnkey.md
@@ -1,0 +1,97 @@
+# erdos-998-oq-04 — Session 7 (researcher-3, 2026-06-19)
+
+## Context
+
+The three STEP A *primitives* are committed on branch
+`research/erdos-998-oq04-step-a-transport` (HEAD `138b3b17`, awaiting first build
++ PR via the gated build watcher):
+
+- `fract_fract_sub_fract` — `{ {x} − {y} } = { x − y }`
+- `orbit_index_injective` — `i ↦ {iα}` is `Function.Injective` (irrational α)
+- `orbit_erase_eq` — `(orbit α N).erase {kα} = image f ((range N).erase k)`
+
+This session does **no Lean edits** (the committed primitives are still UNBUILT —
+the watcher's pending build is their first verification, so appending more
+unverified code would risk turning that build RED and sinking the STEP A PR).
+Aristotle is still down (`prove_file` → 404 "Resource not found", consistent with
+sessions 4–6). Docker fleet busy (load ~14–20, 5 lean containers).
+
+Instead it records the **next lemma** — the forwardGap → index-difference-min
+reduction that *combines* the three primitives — as a turnkey proof with
+mathlib signatures verified against
+`proofs/.lake/packages/mathlib/Mathlib/Data/Finset/Lattice/Fold.lean`.
+
+## Verified mathlib signatures (Fold.lean)
+
+```
+-- line 919, @[simp]
+theorem Finset.inf'_image [DecidableEq β] {s : Finset γ} {f : γ → β}
+    (hs : (s.image f).Nonempty) (g : β → α) :
+    (s.image f).inf' hs g = s.inf' hs.of_image (g ∘ f)
+
+-- line 907, @[congr]
+theorem Finset.inf'_congr {t : Finset β} {f g : β → α}
+    (h₁ : s = t) (h₂ : ∀ x ∈ s, f x = g x) :
+    s.inf' H f = t.inf' (h₁ ▸ H) g
+```
+
+`Finset.Nonempty s` is a `Prop`, so the nonemptiness witnesses carried by `inf'`
+are proof-irrelevant — `s.inf' H f = s.inf' H' f` definitionally. No need to
+thread the exact `H`.
+
+## Turnkey lemma (STEP A completion — UNBUILT, integrate after watcher lands)
+
+Place after `orbit_erase_eq` (≈ line 191), before the proof-path comment.
+
+```lean
+/-- **STEP A — forward gap as a min of index-difference fractional parts.**
+    For irrational `α` and `k` with the other indices nonempty, the cyclic
+    forward gap at the orbit point `{kα}` equals the minimum, over the remaining
+    indices `i ∈ (range N).erase k`, of `{ (i − k)·α }` (written additively as
+    `Int.fract ((i:ℝ)*α − (k:ℝ)*α)`).  Combines all three STEP A primitives. -/
+theorem forwardGap_eq_index_min {α : ℝ} (hα : Irrational α) (N k : ℕ)
+    (hne : ((Finset.range N).erase k).Nonempty) :
+    forwardGap α N (Int.fract ((k : ℝ) * α)) =
+      ((Finset.range N).erase k).inf' hne
+        (fun i => Int.fract ((i : ℝ) * α - (k : ℝ) * α)) := by
+  -- The punctured orbit is nonempty (image of the nonempty index set).
+  have horbit_ne : ((orbit α N).erase (Int.fract ((k : ℝ) * α))).Nonempty := by
+    rw [orbit_erase_eq hα]; exact hne.image _
+  -- Unfold the total `forwardGap` on its nonempty branch.
+  unfold forwardGap
+  rw [dif_pos horbit_ne]
+  -- Transport the inf' across `orbit_erase_eq` (set rewrite under inf').
+  rw [Finset.inf'_congr horbit_ne (orbit_erase_eq hα N k) (fun _ _ => rfl)]
+  -- Push inf' through the image: g ∘ f with f i = {iα}, g y = {y − {kα}}.
+  rw [Finset.inf'_image]
+  -- Now the summand is `fun i => Int.fract (Int.fract (i·α) − Int.fract (k·α))`;
+  -- collapse it via the fract-of-fract primitive to `Int.fract (i·α − k·α)`.
+  refine Finset.inf'_congr _ rfl (fun i _ => ?_)
+  simpa using fract_fract_sub_fract ((i : ℝ) * α) ((k : ℝ) * α)
+```
+
+### Risk notes for the integrator
+
+1. `Finset.inf'_image` is `@[simp]` and stated with `(s.image f).inf' hs g`.
+   After the `inf'_congr` rewrite the LHS set is literally
+   `((range N).erase k).image (fun i => Int.fract ((i:ℝ)*α))`, so `inf'_image`
+   should fire by `rw`. If `rw` cannot unify the implicit `hs`, fall back to
+   `simp only [Finset.inf'_image]` (proof-irrelevant witness).
+2. The final `simpa using fract_fract_sub_fract (i·α) (k·α)` discharges
+   `Int.fract (Int.fract (i·α) − Int.fract (k·α)) = Int.fract (i·α − k·α)`. If
+   the `g ∘ f` β-redex is not reduced, prefix with `simp only [Function.comp]`.
+3. Proof-irrelevance means the `hne`/`horbit_ne`/`hs.of_image` witnesses never
+   need to match syntactically.
+
+## After this lemma — remaining frontier (unchanged from session 6)
+
+- **STEP B**: split the index-difference min on the sign of `d = i − k` into
+  forward `F_k` / backward `B_k` halves (`Finset.inf'_union`, range reindexing).
+- **STEP C**: subset-min bounds `F_k ≥ a`, `B_k ≥ b` + extremal attainment
+  (`Finset.inf'_le`, `Finset.le_inf'`, `Finset.inf'_mem`).
+- **STEP D**: the genuine Steinhaus crux — `min(F_k,B_k) ∈ {a,b,a+b}` via
+  minimality of the first-return generators `p,q`. Pure `Nat`/order arithmetic,
+  no new mathlib infra. This is the one HARD (known, not open) obligation.
+
+When Aristotle recovers: submit the whole file to `prove_file` with STEPS A–C as
+warm-up lemmas, or attack STEP D directly.


### PR DESCRIPTION
## Summary

Two additive **0-sorry** lemmas added to the existing (green, registered) `Erdos998ThreeGapOQ04.lean`, advancing the S7 *forwardGap → index-min* reduction for the three-gap theorem (Erdős #998, OQ-04).

- **`orbit_index_injective`** — for irrational `α`, the map `i ↦ {iα}` is `Function.Injective` on all of `ℕ` (not merely on `range N`). The `Set.InjOn` core inside the existing `orbit_card` never used the range bound, so it upgrades cleanly to genuine injectivity.
- **`orbit_erase_eq`** — `(orbit α N).erase {kα} = ((range N).erase k).image (i ↦ {iα})`, via `Finset.image_erase`. This transports the forward-gap minimum at `{kα}` from orbit points to index differences, which is the form STEP A needs.

## Verification

- Both lemmas are `sorry`-free.
- Supporting Mathlib lemmas pin-verified against lake Mathlib source: `Int.fract_eq_fract`, `Irrational.intCast_mul`, `Int.not_irrational`, `Finset.image_erase`.
- Strategy note added: `research/.../2026-06-19-s7-stepA-forwardgap-reduction-turnkey.md`.

**Draft pending docker build verification** (fleet currently saturated; gated build will confirm green before this is marked ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)