### PR TITLE
audit(erdos-1170): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4407,9 +4407,9 @@
       "result": "clean"
     },
     "erdos-1170": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-reaudit-20260619",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T08:40:00Z",
       "result": "clean"
     },
     "erdos-1171": {


### PR DESCRIPTION
## Re-audit: erdos-1170 (Partition Properties of ω₂) — CLEAN

Stalest unaudited target in a saturated gallery (2554/2554). erdos-1172 skipped (open PR #26071).

### Verification (meta.json vs Proofs/Erdos1170Problem.lean)

| Claim | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`laver_consistency`) | ✓ |
| theoremCount | 7 | 7 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| lineCount | 186 | 186 | ✓ |
| True stubs | — | 0 | ✓ |
| native_decide | — | 0 | ✓ |

### Integrity assessment
- **status `axiomatized` / badge `axiom`** — correct for an OPEN problem.
- Main conjecture `erdos1170_property` is honestly stated as an unproven `Prop`, not claimed proved.
- Sole axiom `laver_consistency` (Laver's 1982 iterated-forcing consistency result) is clearly disclosed in `assumptions`.
- The 7 proved theorems are genuine structural/cardinal-arithmetic results (`balanced_implies_polarized`, monotonicity lemmas, `omega1Sq_lt_omega2` via infinite cardinal idempotence). No inequality-as-theorem inflation, no Mathlib-wrapper masking.

No issues found. Durable tracker bump only: auditCount 3 → 4.

---
Discovered during gallery integrity audit.