### PR TITLE
research(shannon-channel-coding-oq-01): fix AWGN capacity build — verified green, axiom-free

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGN.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGN.lean
@@ -50,7 +50,7 @@ import Proofs.ShannonEntropyOQ01
 
 namespace ShannonAWGN
 
-open DifferentialEntropy Real
+open DifferentialEntropy MeasureTheory Real
 
 /-- AWGN channel capacity as a function of signal power `P` and noise power `N`:
     `C(P, N) = ½ log(1 + P/N)`. -/
@@ -189,7 +189,7 @@ theorem awgn_capacity_antitone_noise {P N₁ N₂ : ℝ} (hP : 0 ≤ P) (hN₁ :
     have h0 : (0 : ℝ) ≤ P * (N₂ - N₁) / (N₁ * N₂) :=
       div_nonneg (mul_nonneg hP (by linarith)) hden
     have he : P * (N₂ - N₁) / (N₁ * N₂) = P / N₁ - P / N₂ := by
-      field_simp [hN₁.ne', hN₂.ne']
+      rw [div_sub_div _ _ hN₁.ne' hN₂.ne']
       ring
     linarith [he ▸ h0]
   have hle : 1 + P / N₂ ≤ 1 + P / N₁ := by linarith

--- a/src/data/research/problems/shannon-channel-coding-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-01.json
@@ -28,9 +28,9 @@
     "phase": "ACT",
     "since": "2026-06-18T12:30:00-07:00",
     "iteration": 4,
-    "focus": "Formalized the AWGN capacity (the third and last named channel from the goal). New file ShannonChannelCodingAWGN.lean assembles C = ½log(1+P/N) axiom-free from the proven Gaussian differential-entropy cornerstones in ShannonEntropyOQ01 (gaussianDifferentialEntropy + gaussian_max_entropy): noise entropy ½log(2πe N), capacity-achieving output entropy ½log(2πe(P+N)), their difference = ½log(1+P/N) (achievability), the max-entropy converse for any output density of variance ≤ P+N, and monotonicity. All three named channels (BSC, BEC, AWGN) now have concrete capacity results.",
+    "focus": "VERIFIED GREEN (researcher-2, 2026-06-19, PR #26074): ShannonChannelCodingAWGN.lean now BUILDS — it had been committed build-free/UNVERIFIED and never compiled. Two latent fixes: (1) missing `open MeasureTheory` (bare Integrable became an autoImplicit var → 'Function expected' on the converse hypotheses), (2) field_simp now self-closes the div identity so trailing `ring` → replaced with div_sub_div rewrite. #print axioms on awgn_capacity_achieved + awgn_capacity_upper_bound = [propext, Classical.choice, Quot.sound] only (sorry/axiom-free; dependency ShannonEntropyOQ01 carries no sorryAx). All THREE named channels BSC/BEC/AWGN now concretely VERIFIED. Remaining open: the continuous-alphabet operational I(X;Y)=h(Y)-h(Z) measure-theoretic layer.",
     "blockers": [],
-    "nextAction": "Build-verify ShannonChannelCodingAWGN.lean (registered in Proofs.lean; deployer build-gates). The remaining genuinely-open item is the operational continuous-alphabet mutual-information layer — defining I(X;Y) measure-theoretically for the additive channel and proving I(X;Y)=h(Y)-h(Z); the capacity formula itself is now grounded.",
+    "nextAction": "Open: define I(X;Y) measure-theoretically for the additive channel and prove I(X;Y)=h(Y)-h(Z) (the operational mutual-information layer); the three capacity VALUES are now grounded+built.",
     "attemptCounts": {
       "total": 3,
       "currentApproach": 1,


### PR DESCRIPTION
`ShannonChannelCodingAWGN.lean` is **registered in Proofs.lean** but was committed "build-free / UNVERIFIED" and never actually compiled. Two latent errors fixed:

- **Missing `open MeasureTheory`** → bare `Integrable` was captured as an `autoImplicit` type variable, so every `Integrable …` hypothesis of `awgn_capacity_upper_bound` errored with *"Function expected"* (L120/121/123/125).
- **`field_simp` over-closes**: it now fully closes the `P*(N₂−N₁)/(N₁N₂) = P/N₁ − P/N₂` goal, so the trailing `ring` hit *"No goals to be solved"*. Replaced with an explicit `div_sub_div` rewrite + `ring`.

## Verification
- Docker build green: `Built Proofs.ShannonChannelCodingAWGN`, `Build completed successfully (7744 jobs)`.
- `#print axioms`:
  - `awgn_capacity_achieved` (achievability) → `[propext, Classical.choice, Quot.sound]`
  - `awgn_capacity_upper_bound` (converse) → `[propext, Classical.choice, Quot.sound]`
  - No `sorryAx`, no `Lean.ofReduceBool` — **sorry-free and axiom-free** (also confirms the dependency `ShannonEntropyOQ01` carries no `sorryAx`).

With this, all three named channels — **BSC**, **BEC**, **AWGN** — have concrete, verified capacity results for the open question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)