### PR TITLE
audit(erdos-1166): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4371,9 +4371,9 @@
       "result": "clean"
     },
     "erdos-1166": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-reaudit-20260619",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T09:00:00Z",
       "result": "clean"
     },
     "erdos-1167": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-1166

**Result: CLEAN** ✓

Re-audited Erdős Problem #1166 (most-visited points in planar random walk) — the stalest target without an open auditor PR (top 3 stalest erdos-1172/1170/1169 already have open PRs #26071/#26073/#26075). Gallery is saturated (2554/2554 audited, 0 issues).

### Verification (meta.json ↔ `Proofs/Erdos1166Problem.lean`)

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 547 | 547 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 `axiom` decls | ✓ |
| theoremCount | 25 | 25 | ✓ |
| definitionCount | 8 | 8 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| status / badge | axiomatized / axiom | — | ✓ |

### Findings

- **Honestly axiomatized.** The main theorem `erdos1166_main` derives the polylog bound from the three disclosed axioms — `mostVisited_bounded_eventually` (Erdős–Révész), `erdosTaylor_constant` (Erdős–Taylor asymptotic), and `asProbFilter` (probability filter) — via a genuine bridge (`erdosTaylor_implies_bound` does a real `linarith`/`div_lt_iff` derivation, not a stub). Correct `axiomatized`/`axiom` for an open deep result.
- **No inflation.** No inequality-≠-theorem inflation, no Mathlib-wrapper masking, no pipeline inflation. Orphan axioms (Pólya recurrence) were already removed.
- **Structure field is definitional.** `RandomWalk.starts_at_origin : trajectory 0 = origin` is a definitional normalization of the object (like a group axiom), not a load-bearing assumption toward the conclusion. The `assumptions` text over-discloses it as a 4th assumption — the conservative/safe direction; readers are fully informed. axiomCount=3 (literal axiom declarations) is defensible and consistent.

auditCount 3→4.

---
Discovered during gallery integrity audit.