### PR TITLE
research(erdos-mordell-inequality-oq-01): verified geometry→algebra bridge for the open vertex sorry

### DIFF
--- a/proofs/Proofs/ErdosMordellInequalityOQ01.lean
+++ b/proofs/Proofs/ErdosMordellInequalityOQ01.lean
@@ -220,6 +220,41 @@ private theorem mem_interior_hull_rotate {X Y Z P : EuclideanSpace ℝ (Fin 2)}
     ext q; simp only [Set.mem_insert_iff, Set.mem_singleton_iff]; tauto
   rw [hs]; exact h
 
+/-- **Geometry → algebra bridge for the shared vertex inequality** (verified).
+
+This is the native-`EuclideanSpace` specialization of
+`key_inequality_of_chord_and_sines`: it states exactly which geometric data about
+the concrete configuration `(X, Y, Z, P)` suffice to prove the shared key
+inequality `key_inequality_vertex`, and discharges the inequality from them with
+no further work.
+
+The required inputs — for some triangle angles `A, B, C` at `X, Y, Z` and a common
+circumradius `R > 0` — are the **law of sines** in side-length form
+(`dist Y Z = 2R sin A`, `dist Z X = 2R sin B`, `dist X Y = 2R sin C`) and the
+**pedal-feet chord identity** at `X`
+(`(dist P X · sin A)² = (lineDist P Z X)² + (lineDist P X Y)² + 2·…·cos A`),
+which encodes the concyclicity of `P`, `X`, and the two perpendicular feet on the
+circle of diameter `PX`.
+
+After this lemma, the *only* remaining obligation inside `key_inequality_vertex`
+is to **exhibit** such `A, B, C, R` for the affine-independent interior
+configuration and verify these two identities — the algebraic assembly is done.
+The pedal distances and `dist P X` supply their own nonnegativity. -/
+theorem key_inequality_vertex_of_los_chord
+    (X Y Z P : EuclideanSpace ℝ (Fin 2)) {A B C R : ℝ}
+    (hsum : A + B + C = Real.pi)
+    (hsA : 0 ≤ Real.sin A) (hsB : 0 ≤ Real.sin B) (hsC : 0 ≤ Real.sin C)
+    (hR : 0 < R)
+    (haR : dist Y Z = 2 * R * Real.sin A)
+    (hbR : dist Z X = 2 * R * Real.sin B)
+    (hcR : dist X Y = 2 * R * Real.sin C)
+    (hchord : (dist P X * Real.sin A) ^ 2
+      = lineDist P Z X ^ 2 + lineDist P X Y ^ 2
+        + 2 * lineDist P Z X * lineDist P X Y * Real.cos A) :
+    dist Z X * lineDist P X Y + dist X Y * lineDist P Z X ≤ dist Y Z * dist P X :=
+  key_inequality_of_chord_and_sines hsum hsA hsB hsC
+    (lineDist_nonneg P Z X) (lineDist_nonneg P X Y) dist_nonneg hR haR hbR hcR hchord
+
 /-- **Erdős–Mordell key inequality at a generic vertex `X`** (shared geometric core).
 
 For `P` interior to the nondegenerate triangle `X Y Z`, with adjacent sides `XY`

--- a/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
+++ b/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-06-18",
     "axiomCount": 0,
-    "lineCount": 309,
+    "lineCount": 344,
     "assumptions": "1 sorry: the shared vertex key inequality key_inequality_vertex (dist Z X · lineDist P X Y + dist X Y · lineDist P Z X ≤ dist Y Z · dist P X). This single lemma is the genuine planar-geometry content (concyclic pedal feet / chord-projection argument), known classical mathematics not yet in Mathlib. The three classical cyclic key inequalities key_inequality_A/B/C are now fully proved as its relabeled instances, and everything else — side-length positivity, pedal-distance nonnegativity, and the AM–GM algebraic reduction — is fully proved.",
     "originalContributions": [
       "erdos_mordell_reduction: the geometry-free AM–GM core, proving 2(da+db+dc) ≤ PA+PB+PC from the three weighted key inequalities via an explicit nonnegative certificate (a·da·(b−c)² + ... ≥ 0). Carries no geometric hypotheses; reusable for any proof of the key inequalities.",
@@ -50,9 +50,10 @@
       "key_inequality_of_chord_and_sines: a verified, geometry-free assembly lemma that takes exactly the two geometric facts the chord identity supplies — the chord identity (PA·sin A)² = db²+dc²+2·db·dc·cos A and the law of sines a = 2R sin A, b = 2R sin B, c = 2R sin C — and derives the key inequality b·dc + c·db ≤ a·PA purely algebraically (via the trig core, collapsing √(…) to PA·sin A and scaling by 2R > 0). This sharpens each remaining geometric obligation from an opaque sorry into precisely 'supply the chord identity and law of sines for the concrete configuration'.",
       "Precise Lean statement of the geometric Erdős–Mordell inequality using Metric.infDist to the affine span (lineDist) for pedal distances.",
       "Full modular assembly of erdos_mordell: reduces the geometric theorem to exactly three separately-stated key-inequality lemmas, discharging all positivity/nonnegativity/algebra.",
-      "key_inequality_vertex with the cyclic-relabeling plumbing affineIndep_rotate and mem_interior_hull_rotate: collapses the three cyclic key inequalities to a single shared lemma by proving that affine independence and interior-of-hull membership are invariant under the rotation (X,Y,Z)↦(Y,Z,X), so key_inequality_A/B/C become its three relabeled instances. This reduces the open geometric content from three sorries to one."
+      "key_inequality_vertex with the cyclic-relabeling plumbing affineIndep_rotate and mem_interior_hull_rotate: collapses the three cyclic key inequalities to a single shared lemma by proving that affine independence and interior-of-hull membership are invariant under the rotation (X,Y,Z)↦(Y,Z,X), so key_inequality_A/B/C become its three relabeled instances. This reduces the open geometric content from three sorries to one.",
+      "key_inequality_vertex_of_los_chord: the verified geometry→algebra bridge for the shared vertex inequality, the native-EuclideanSpace specialization of key_inequality_of_chord_and_sines. Given triangle angles A,B,C, a common circumradius R>0, the law of sines in side-length form (dist YZ = 2R sin A, etc.), and the pedal-feet chord identity at the vertex ((dist P X · sin A)² = lineDist P Z X² + lineDist P X Y² + 2·…·cos A), it discharges dist Z X · lineDist P X Y + dist X Y · lineDist P Z X ≤ dist Y Z · dist P X with no further work (the pedal distances and dist P X supply their own nonnegativity). This isolates the remaining content of the lone open sorry to: exhibit A,B,C,R for the configuration and verify the two named identities — the algebraic assembly is now done and verified."
     ],
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 1
   },
   "overview": {
@@ -155,9 +156,9 @@
     ],
     "opens": [],
     "namespace": "ErdosMordellOQ01",
-    "lineCount": 309,
+    "lineCount": 344,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 12,
     "substantiveTheoremCount": 5,
     "duplicateTheorems": 0,
     "definitionCount": 1,


### PR DESCRIPTION
## Summary

The Erdős–Mordell entry has a single open `sorry` — `key_inequality_vertex`, the
shared planar-geometry core (concyclic pedal feet / chord-projection). This adds a
**verified** bridge lemma that pins down exactly which geometric data discharge it,
in native `EuclideanSpace` terms.

## New theorem (verified, no new sorry/axiom)

`key_inequality_vertex_of_los_chord` — the native-`EuclideanSpace` specialization of
the existing scalar assembly lemma `key_inequality_of_chord_and_sines`. Given, for
triangle angles `A, B, C` and a common circumradius `R > 0`:

- the **law of sines** in side-length form: `dist Y Z = 2R sin A`, `dist Z X = 2R sin B`, `dist X Y = 2R sin C`, and
- the **pedal-feet chord identity** at the vertex:
  `(dist P X · sin A)² = lineDist P Z X² + lineDist P X Y² + 2·lineDist P Z X·lineDist P X Y·cos A`,

it discharges the shared inequality
`dist Z X · lineDist P X Y + dist X Y · lineDist P Z X ≤ dist Y Z · dist P X`
with zero further work — the pedal distances and `dist P X` supply their own
nonnegativity (`lineDist_nonneg`, `dist_nonneg`).

## Effect

This **isolates** the remaining content of the lone open `sorry` to: *exhibit*
`A, B, C, R` for the affine-independent interior configuration and *verify* the two
named identities. The algebraic assembly is now done and verified — the open core is
purely the two classical geometric facts, stated in the exact form the bridge consumes.

## Build & integrity

`Build completed successfully (7743 jobs)` via the Docker wrapper; the only warning is
the expected `declaration uses 'sorry'` at `key_inequality_vertex` (unchanged).
**0 axioms, 1 sorry** (unchanged), 0 `native_decide`. Status stays `formalized`/`wip`.
meta: theoremCount 11→12, lineCount 309→344.

Note: Aristotle was attempted on the hard sorry but is currently unavailable
("Resource not found").

🤖 Generated with [Claude Code](https://claude.com/claude-code)