### PR TITLE
audit(erdos-1115): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3940,9 +3940,10 @@
       ]
     },
     "erdos-1115": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor",
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-06-19T09:15:00Z",
       "result": "clean"
     },
     "erdos-1116": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1115

**Result: CLEAN** ✓

Re-audited **erdos-1115** (Erdős Problem #1115: Path Length for Entire Functions — Gol'dberg-Eremenko 1979 disproof), the stalest unaudited target after erdos-1166 (open PR #26076).

### Verification (meta.json vs `Proofs/Erdos1115Problem.lean`)

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 102 | 102 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 | ✓ |
| theoremCount | 1 | 1 | ✓ |
| definitionCount | 2 | 2 | ✓ |
| True stubs | — | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| structures | — | 0 (no hidden assumptions) | ✓ |

### Narrative integrity
- **Tier C** (axiomatized). `status: axiomatized` / `badge: axiom` — correct for a disproved-via-counterexample problem.
- The 3 axioms (`arcLengthInDisk`, `hayman_theorem`, `goldberg_eremenko_counterexample`) are all disclosed by name in `assumptions` and in the proof-strategy narrative.
- Main theorem `erdos_1115` honestly discharged by the `goldberg_eremenko_counterexample` axiom — no overclaiming, no axiom masking, no inequality≠theorem inflation.

Durable tracker bump only: `auditCount` 3→4, `lastAudited` refreshed, `result: clean`.

---
Discovered during gallery integrity audit.