### PR TITLE
audit(erdos-1110): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3901,10 +3901,12 @@
       "result": "clean"
     },
     "erdos-1110": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
-      "result": "clean"
+      "agentId": "auditor-loop",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T09:30:00Z",
+      "result": "clean",
+      "notes": "Re-audit CLEAN: 437L/0sorry/1axiom(erdos_lewin_theorem)/13thm/7def/0stub/0nd all match meta. status=axiomatized/badge=axiom correct for OPEN problem. {2,3} case (case_2_3_all_representable) genuinely proved in-file by strong induction, not a Mathlib wrapper; general case honestly axiomatized via erdos_lewin_theorem and disclosed in assumptions. axiomCount 1 correct (HasDensity/CoprimeNonRepresentable/minSummandBound are plain defs, no structure-encoded assumptions). Yu-Chen density/coprime items in originalContributions are doc-comments only but sections honestly say 'Documents...'; conservative direction.",
+      "issues": []
     },
     "erdos-1111": {
       "agentId": "auditor-loop",


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-1110

**Result: CLEAN** — `auditCount` 3→4.

Re-audited the stalest unclaimed target (erdos-1166 and erdos-1115 skipped — both have open auditor PRs #26076/#26078).

### Verification (meta.json vs `Proofs/Erdos1110Problem.lean`)

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 437 | 437 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`erdos_lewin_theorem`) | ✓ |
| theoremCount | 13 | 13 | ✓ |
| definitionCount | 7 | 7 | ✓ |
| True stubs | — | 0 | ✓ |
| native_decide | — | 0 | ✓ |

### Integrity findings

- **status=`axiomatized` / badge=`axiom`** — correct for an OPEN Erdős problem with 1 disclosed axiom.
- **{2,3} case** (`case_2_3_all_representable`) is a genuine in-file strong-induction proof (not a Mathlib wrapper); uses only foundational `Nat.log`/`Nat.pow_log_le_self` helpers.
- **General case** honestly axiomatized via `erdos_lewin_theorem` and correctly disclosed in `assumptions`.
- **axiomCount 1** correct — `HasDensity`/`CoprimeNonRepresentable`/`minSummandBound` are plain definitions, not assumption-carrying structures.
- Yu-Chen density/coprime items in `originalContributions` exist only as doc-comments, but sections honestly phrase them as "Documents..." and never claim them proved — conservative direction.

No overclaiming detected. Tracker-only change.

---
Discovered during gallery integrity audit.