### PR TITLE
audit(erdos-1106): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3865,9 +3865,9 @@
       "result": "clean"
     },
     "erdos-1106": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-reaudit-20260619",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T00:00:00Z",
       "result": "clean"
     },
     "erdos-1107": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-1106

**Result**: CLEAN (auditCount 3→4)

Re-audited **erdos-1106** (Erdős #1106: Prime Factors of Partition Products) — stalest unaudited target without an open PR (erdos-1166/1115/1110 already have open auditor PRs #26076/#26078/#26081).

### Verification (meta.json vs `Proofs/Erdos1106Problem.lean`)

| Field | meta | Lean source | Match |
|-------|------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 4 | 4 axioms | ✓ |
| theoremCount | 9 | 9 | ✓ |
| definitionCount | 7 | 7 | ✓ |
| lineCount | 246 | 246 | ✓ |
| status/badge | axiomatized/axiom | OPEN problem | ✓ |

The 4 axioms (`schinzel_wirsing_lower_bound`, `hardy_ramanujan_asymptotic`, `ono_prime_divisibility`, `erdos_1106_part1`) are all disclosed and correctly counted. Part 1 (F(n)→∞) is honestly axiomatized (deep analytic NT beyond Mathlib); Part 2 (F(n)>n) is left as an open `Prop`. Proved lemmas (`partitionProduct_pos`, `F_eq_card`, `F_mono`) are genuine — no inequality inflation, no Mathlib-wrapper masking the main result.

**Minor (non-blocking, conservative direction):** the meta section "prime-factors" summary says `F_mono` is stated "with sorry", but it is actually fully proved (lines 100–110). This *understates* the work, so it is not an integrity overclaim.

---
Durable tracker bump only. Discovered during autonomous gallery integrity audit.