### PR TITLE
audit(de-moivre): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2261,9 +2261,9 @@
       "result": "clean"
     },
     "de-moivre": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-reaudit-20260619",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T09:50:00Z",
       "result": "clean"
     },
     "de-moivre-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: de-moivre

**Result: CLEAN** — no integrity issues found.

De Moivre's Theorem (Wiedijk #17). Re-audit of the stalest entry in the saturated gallery (2554/2554). erdos-1106 was the top target but has an open PR (#26082), so audited next-stalest.

### Verification vs `Proofs/DeMoivre.lean`
| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| theorems | 10 | 10 | ✓ |
| definitions | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| axioms | 0 | 0 (no `axiom` decls, no structures) | ✓ |
| lineCount | 239 | 239 | ✓ |
| True stubs | — | none | ✓ |

### Tier / narrative
- **Tier B** (Mathlib-backed). Badge `mathlib` / status `verified` is correct: the file has 0 sorries/axioms, and the badge honestly signals Mathlib reliance.
- Core `de_moivre` derived from `Complex.exp_mul_I` (Euler) + `Complex.exp_nat_mul`; integer extension via `Complex.exp_int_mul`; roots-of-unity via `Complex.exp_two_pi_mul_I`. All four are listed in `mathlibDependencies`.
- Overview's first approach bullet states "Foundation (from Mathlib)"; `originalContributions` scoped to formulation, double/triple-angle corollaries, and roots-of-unity connection — no overclaim.
- No delegation opacity, axiom masking, inequality inflation, or pipeline inflation.

`auditCount` 3 → 4.

---
Discovered during gallery integrity audit.