### PR TITLE
research(sylvester-gallai-oq01): signed-area lever + statement, reduce to 3 sorries

### DIFF
--- a/proofs/Proofs/SylvesterGallaiOQ01.lean
+++ b/proofs/Proofs/SylvesterGallaiOQ01.lean
@@ -1,0 +1,149 @@
+/-
+# Sylvester–Gallai theorem (ordinary line existence) — research scaffold
+
+**Problem (`sylvester-gallai-theorem-oq-01`):** every finite set of points in the
+real plane that is *not* collinear determines an *ordinary line* — a line passing
+through exactly two of the points.
+
+This file sets up Kelly's metric proof, which is the right route for Lean: it needs
+only the signed-area (2D cross-product) functional, distance, and the affine
+`Collinear` predicate, all available in Mathlib, and avoids the projective-duality
+and Euler-characteristic machinery of Melchior's proof.
+
+## Status (research, in progress)
+
+The reusable *lever* is the signed-area functional `area2 a b c` — twice the signed
+area of triangle `abc`, equal to the determinant `det[b-a, c-a]`. The perpendicular
+distance from `c` to the line through `a b` is `|area2 a b c| / dist a b`.
+
+Proved here (self-contained, no `sorry`):
+* `area2` and its full permutation/degeneracy algebra (`ring`-closed);
+* `distToLine` and its non-negativity.
+
+Open kernel (left as `sorry`, decomposed for Aristotle / future sessions):
+* `collinear_iff_area2_eq_zero` — the bridge from the affine `Collinear` predicate to
+  the vanishing of the signed area (HARD, known; clean Aristotle target);
+* `area2_strict_decrease` — Kelly's geometric inequality (the heart of the proof);
+* `sylvester_gallai` — the assembled minimization argument.
+
+This is a genuine formalization contribution: Sylvester–Gallai is **not** in Mathlib
+(no `SylvesterGallai` / `ordinaryLine` / de Bruijn–Erdős declarations exist).
+-/
+import Mathlib
+
+namespace SylvesterGallaiOQ01
+
+/-- Points of the real Euclidean plane. -/
+abbrev Pt := EuclideanSpace ℝ (Fin 2)
+
+/-- Twice the signed area of triangle `a b c`: the 2D cross product of `b - a` and
+`c - a`, i.e. the determinant `det[b-a, c-a]`. This is the lever for Kelly's proof —
+its absolute value over the base length is the perpendicular distance to the line. -/
+noncomputable def area2 (a b c : Pt) : ℝ :=
+  (b 0 - a 0) * (c 1 - a 1) - (b 1 - a 1) * (c 0 - a 0)
+
+/-! ### Algebra of the signed area (degeneracies and permutations) -/
+
+@[simp] lemma area2_self_left (a c : Pt) : area2 a a c = 0 := by
+  unfold area2; ring
+
+@[simp] lemma area2_self_mid (a b : Pt) : area2 a b a = 0 := by
+  unfold area2; ring
+
+@[simp] lemma area2_self_right (a b : Pt) : area2 a b b = 0 := by
+  unfold area2; ring
+
+/-- Swapping the last two vertices negates the signed area. -/
+lemma area2_swap_right (a b c : Pt) : area2 a c b = - area2 a b c := by
+  unfold area2; ring
+
+/-- Swapping the first two vertices negates the signed area. -/
+lemma area2_swap_left (a b c : Pt) : area2 b a c = - area2 a b c := by
+  unfold area2; ring
+
+/-- The signed area is invariant under a cyclic rotation of the vertices. -/
+lemma area2_cyclic (a b c : Pt) : area2 b c a = area2 a b c := by
+  unfold area2; ring
+
+/-- Translation invariance: shifting all three vertices by a common vector `t`
+leaves the signed area unchanged. -/
+lemma area2_vadd (t a b c : Pt) :
+    area2 (t + a) (t + b) (t + c) = area2 a b c := by
+  unfold area2
+  simp only [PiLp.add_apply]
+  ring
+
+/-! ### Perpendicular distance to a line -/
+
+/-- The perpendicular distance from `c` to the line through `a` and `b`,
+expressed via the signed area: `|area2 a b c| / dist a b`. When `a = b` this is `0`
+(degenerate base), so it is only meaningful for `a ≠ b`. -/
+noncomputable def distToLine (a b c : Pt) : ℝ := |area2 a b c| / dist a b
+
+lemma distToLine_nonneg (a b c : Pt) : 0 ≤ distToLine a b c :=
+  div_nonneg (abs_nonneg _) dist_nonneg
+
+@[simp] lemma distToLine_self_left (a c : Pt) : distToLine a a c = 0 := by
+  simp [distToLine]
+
+/-! ### The collinearity bridge (open) -/
+
+/-- **Bridge (open).** Three points are collinear exactly when the signed area
+vanishes. This connects the affine `Collinear` predicate used in the statement to
+the concrete `area2` functional used in the proof.
+
+Forward direction: `collinear_iff_of_mem` gives a common direction `v` with
+`b = r_b • v +ᵥ a`, `c = r_c • v +ᵥ a`, whence each coordinate difference is a scalar
+multiple of `v` and the determinant collapses to `0`. Reverse: a vanishing
+determinant exhibits `b - a` and `c - a` as linearly dependent, giving the direction.
+Clean `HARD` Aristotle target once the coordinate-evaluation bookkeeping is fixed. -/
+theorem collinear_iff_area2_eq_zero (a b c : Pt) :
+    Collinear ℝ ({a, b, c} : Set Pt) ↔ area2 a b c = 0 := by
+  sorry
+
+/-- `distToLine a b c = 0` iff `c` lies on the line through `a b` (for `a ≠ b`). -/
+theorem distToLine_eq_zero_iff {a b c : Pt} (hab : a ≠ b) :
+    distToLine a b c = 0 ↔ Collinear ℝ ({a, b, c} : Set Pt) := by
+  rw [distToLine, div_eq_zero_iff, abs_eq_zero, collinear_iff_area2_eq_zero]
+  have : dist a b ≠ 0 := by
+    simpa [dist_eq_zero] using hab
+  simp [this]
+
+/-! ### Kelly's geometric inequality (open kernel) -/
+
+/-- **Kelly's strict-decrease step (open).** Suppose `P₀` is off the line `ℓ₀`
+through `a₀ b₀`, and `ℓ₀` carries a third collinear point. Taking the foot `F` of the
+perpendicular from `P₀` and the two collinear points `B` (nearer `F`), `C` (farther,
+same side), one gets a strictly smaller perpendicular distance
+`distToLine P₀ C B < distToLine a₀ b₀ P₀`.
+
+This is the geometric heart of Kelly's proof; the ratio of nested similar triangles
+`CB / CP₀ < 1` drives the strict inequality. Left as a `sorry`: this is the genuinely
+hard, creative part and is **not** a known Mathlib result. -/
+theorem area2_strict_decrease
+    {a₀ b₀ P₀ B C : Pt} (hab : a₀ ≠ b₀)
+    (hP : ¬ Collinear ℝ ({a₀, b₀, P₀} : Set Pt))
+    (hB : Collinear ℝ ({a₀, b₀, B} : Set Pt))
+    (hC : Collinear ℝ ({a₀, b₀, C} : Set Pt))
+    (hBC : B ≠ C) (hPC : P₀ ≠ C)
+    (hside : True /- B, C strictly on the same side of the foot F, B nearer -/) :
+    distToLine P₀ C B < distToLine a₀ b₀ P₀ := by
+  sorry
+
+/-! ### Main theorem (open assembly) -/
+
+/-- **Sylvester–Gallai (open).** Any finite, non-collinear set of points in the plane
+admits an *ordinary line*: two distinct points `a, b ∈ S` such that every point of `S`
+collinear with `a` and `b` is equal to `a` or `b`.
+
+Proof strategy (Kelly): minimize `distToLine a b P` over the finite, nonempty set of
+triples `(a, b, P)` with `a, b, P ∈ S`, `a ≠ b`, and `P` off the line `ab`
+(nonempty since `S` is non-collinear). If the minimizing line carried a third point,
+`area2_strict_decrease` would produce a strictly smaller member — contradiction. -/
+theorem sylvester_gallai {S : Finset Pt}
+    (hS : ¬ Collinear ℝ (↑S : Set Pt)) :
+    ∃ a ∈ S, ∃ b ∈ S, a ≠ b ∧
+      ∀ c ∈ S, Collinear ℝ ({a, b, c} : Set Pt) → c = a ∨ c = b := by
+  sorry
+
+end SylvesterGallaiOQ01

--- a/src/data/research/problems/sylvester-gallai-theorem-oq-01.json
+++ b/src/data/research/problems/sylvester-gallai-theorem-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "sylvester-gallai-theorem-oq-01",
   "title": "sylvester-gallai-theorem-oq-01: every finite non-collinear point set has an ordinary line",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -26,31 +26,38 @@
     "goal": "Machine-checked Lean 4 proof of the existence of an ordinary line for any finite non-collinear point set in the Euclidean plane, with 0 sorries and 0 nonstandard axioms."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-06-18 (researcher-8, Session 1)",
-    "iteration": 1,
-    "focus": "Confirm Mathlib gap, fix the proof architecture (Kelly), map each step to concrete Mathlib API, size the build.",
+    "phase": "ACT",
+    "since": "2026-06-19 (researcher-11, Session 2)",
+    "iteration": 2,
+    "focus": "First Lean code landed: signed-area lever built and verified; proof reduced to one bridge lemma + Kelly geometric kernel.",
     "activeApproach": "Kelly's minimal-distance proof over EuclideanSpace ℝ (Fin 2).",
     "blockers": [
-      "Build host saturated (≥6 concurrent lean-build containers on a 7.65GiB Docker VM → OOM risk). No Lean build this session; ORIENT is build-free."
+      "Aristotle backend returning 404 (fleet-wide outage) — could not delegate the bridge lemma this session."
     ],
-    "nextAction": "(ACT, build host) Write the statement + Lemma B/C scaffolding and build the foot-of-perpendicular geometric kernel (Lemma D) using the cross-product distance formula in Fin 2.",
+    "nextAction": "Prove collinear_iff_area2_eq_zero (forward via collinear_iff_of_mem + PiLp coordinate eval; reverse by constructing the direction vector), then the area2_strict_decrease geometric kernel.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
+      "total": 1,
+      "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT complete: Mathlib gap confirmed; Kelly proof decomposed into 4 lemmas with exact Mathlib API mapping; geometric kernel (foot-of-perpendicular distance inequality) identified as the hard part. Estimated 500-900 line BUILD, multi-session. No Lean code yet.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS (ACT): first Lean code landed and builds. Signed-area lever (area2) fully proved; Sylvester-Gallai reduced to 3 sorries — the collinear<->area2 bridge, Kellys geometric inequality, and the minimization assembly.",
+    "builtItems": [
+      "area2 (twice signed area / 2x2 determinant) defined in SylvesterGallaiOQ01.lean:43; full permutation+degeneracy algebra proved by ring: area2_self_left/mid/right, area2_swap_left/right, area2_cyclic, area2_vadd (translation invariance)",
+      "distToLine a b c = |area2 a b c| / dist a b defined (SylvesterGallaiOQ01.lean:108); distToLine_nonneg and distToLine_self_left proved",
+      "distToLine_eq_zero_iff (a != b): distToLine = 0 iff Collinear {a,b,c} — proved MODULO the bridge lemma (div_eq_zero_iff + abs_eq_zero + bridge)",
+      "Theorem statement for Sylvester-Gallai (ordinary line) locked over EuclideanSpace R (Fin 2); file builds (7743 jobs) with exactly 3 sorries"
+    ],
     "insights": [
       "Sylvester–Gallai is NOT in Mathlib (no SylvesterGallai / ordinaryLine / de Bruijn–Erdős declarations) — confirmed by exhaustive source grep. This is a real formalization contribution.",
       "Kelly's metric proof is the right route for Lean: it avoids the projective-duality + Euler-characteristic machinery of Melchior's proof, needing only orthogonal projection, distance, and betweenness — all present in Mathlib.",
       "The hard kernel is a single geometric inequality (Lemma D): if F is the foot of the perpendicular from P₀ to the minimal line ℓ₀, and two of the ≥3 collinear points B,C lie on the same closed ray from F with FB < FC, then dist(B, line[P₀,C]) < dist(P₀, ℓ₀). Everything else is bookkeeping.",
       "In EuclideanSpace ℝ (Fin 2) the distance from a point x to line[a,b] has the closed form |det[b-a, x-a]| / ‖b-a‖ (signed-area / cross-product). This is likely far easier to manipulate for Lemma D than orthogonalProjection coordinates, since the inequality reduces to a ratio of areas / nested-similar-triangle leg ratio CB/CP₀ < 1.",
       "Pigeonhole step: parametrize ℓ₀ by an affine coordinate r about the foot F (collinear_iff_of_mem gives each point = r•v +ᵥ F); the SIGN of r is the side of F. ≥3 points ⟹ two share a sign ⟹ pick nearer (B) and farther (C); distinct same-side points have distinct |r|, so FB<FC strictly and B≠C.",
-      "Non-degeneracy facts needed: P₀ ∉ ℓ₀ and B,C ∈ ℓ₀ ⟹ line[P₀,C] meets ℓ₀ only at C ⟹ B ∉ line[P₀,C] (since B≠C); also B≠P₀, C≠P₀. So (B, line[P₀,C]) is a legitimate element of the minimization domain, contradicting minimality."
+      "Non-degeneracy facts needed: P₀ ∉ ℓ₀ and B,C ∈ ℓ₀ ⟹ line[P₀,C] meets ℓ₀ only at C ⟹ B ∉ line[P₀,C] (since B≠C); also B≠P₀, C≠P₀. So (B, line[P₀,C]) is a legitimate element of the minimization domain, contradicting minimality.",
+      "Coordinate access on EuclideanSpace R (Fin 2) works directly: (b : Pt) 0 : R typechecks (CoeFun via PiLp.toLp_apply); area2 written in scalar coords so its algebra closes by ring regardless of PiLp wrapping",
+      "PiLp.add_apply / sub_apply / smul_apply / zero_apply / neg_apply are the coordinate-eval lemmas; vadd on EuclideanSpace reduces to + via vadd_eq_add — these are the levers for the bridge forward direction"
     ],
     "mathlibGaps": [
       "No Sylvester–Gallai / ordinary-line theorem (this is the contribution).",
@@ -58,12 +65,10 @@
       "No prepackaged 'among ≥3 collinear points two lie on the same side of a given point' pigeonhole — must build from collinear_iff_of_mem + sign trichotomy (~40-80 lines)."
     ],
     "nextSteps": [
-      "ACT: State the theorem over EuclideanSpace ℝ (Fin 2) with the ordinary-line conclusion; build the file unregistered + standalone (fleet-safe).",
-      "ACT: Lemma B (minimization domain nonempty from ¬Collinear) and Lemma C (Finset.exists_min_image over the finite triple set with positive distance) — these are routine, do first.",
-      "ACT: Derive the cross-product distance formula dist x line[a,b] = |det[b-a,x-a]|/‖b-a‖ in Fin 2; this is the lever for Lemma D.",
-      "ACT: Lemma D pigeonhole (same-side-of-foot) via affine coordinate + sign trichotomy.",
-      "ACT: Lemma D inequality CB/CP₀ < 1 ⟹ dist(B,line[P₀,C]) < dist(P₀,ℓ₀); assemble the contradiction.",
-      "Consider submitting the cross-product distance formula and the pigeonhole lemma to Aristotle as independent HARD sorries once the statements are fixed and the file parses."
+      "Prove collinear_iff_area2_eq_zero: forward via collinear_iff_of_mem (a in set) giving common direction v, coordinate-eval b/c, determinant collapses; reverse constructs v from dependent columns (handle a=b, c=a degeneracies)",
+      "Prove area2_strict_decrease (Kelly kernel): set up foot-of-perpendicular F, same-side pigeonhole over collinear points, similar-triangle ratio CB/CP0 < 1",
+      "Assemble sylvester_gallai: minimize distToLine over the finite valid-triple set (Finset.exists_min_image), contradiction from strict-decrease",
+      "Retry Aristotle for the bridge lemma once the backend 404 clears"
     ],
     "markdown": "# Knowledge Base: sylvester-gallai-theorem-oq-01\n\n**Goal.** Formalize the Sylvester–Gallai theorem in Lean 4 / Mathlib: *every finite set of points in the Euclidean plane, not all collinear, determines an ordinary line* (a line through exactly two of the points).\n\n---\n\n## Session 1 (researcher-8, 2026-06-18) — OBSERVE → ORIENT (build-free)\n\nBuild host saturated (≥6 lean-build containers on a 7.65 GiB Docker VM → OOM). This session is a **build-free ORIENT**: confirm the gap, fix the architecture, map to Mathlib, size the work. No Lean code committed.\n\n### Mathlib gap — confirmed\n\nExhaustive source grep of `proofs/.lake/packages/mathlib/Mathlib/`: **no** `SylvesterGallai`, `ordinaryLine`, `OrdinaryLine`, or de Bruijn–Erdős declarations. The theorem is a genuine contribution. (The only `Erdős–Szekeres` hit is the monotone-subsequence theorem in `Order.OrderIsoNat`, unrelated.)\n\n### Why Kelly, not Melchior\n\nTwo classical proofs:\n- **Melchior (1940), dual:** apply Euler's formula `V − E + F = 2` to the arrangement of the dual lines; a counting argument forces an ordinary point. Needs planar-arrangement / Euler-characteristic infrastructure Mathlib lacks.\n- **Kelly (1948), metric:** minimize point-to-line distance; the minimizing line is ordinary. Needs only orthogonal projection, distance, betweenness, and a finite minimum — **all in Mathlib**. This is the chosen route.\n\n### Statement (target)\n\n```lean\ntheorem sylvester_gallai\n    (S : Finset (EuclideanSpace ℝ (Fin 2)))\n    (hS : ¬ Collinear ℝ (↑S : Set (EuclideanSpace ℝ (Fin 2)))) :\n    ∃ a ∈ S, ∃ b ∈ S, a ≠ b ∧\n      ∀ c ∈ S, Collinear ℝ ({a, b, c} : Set _) → c = a ∨ c = b\n```\nThe conclusion says the connecting line `line[ℝ, a, b]` is **ordinary**: any third point of `S` collinear with `a,b` is already `a` or `b`. (Working in `Fin 2` keeps the cross-product distance formula 1-dimensional; a general inner-product-space version can come later.)\n\n### Kelly's proof, decomposed into Lean lemmas\n\nLet `dline x a b := dist x (line[ℝ,a,b])` (distance from `x` to the line through `a,b`).\n\n**Lemma B — minimization domain nonempty.** From `¬ Collinear` there are distinct `a,b ∈ S`; if every `c ∈ S` lay on `line[a,b]` then `S` would be collinear, so some `P ∈ S` has `P ∉ line[a,b]`, giving a triple with `dline P a b > 0`.\n\n**Lemma C — minimizer exists.** The set of triples `T = {(P,a,b) ∈ S³ : a≠b, P ∉ line[a,b]}` is finite (`Finset` product) and (by B) nonempty, so `Finset.exists_min_image` yields a minimizer `(P₀,a₀,b₀)` with `δ := dline P₀ a₀ b₀ > 0` minimal. Let `ℓ₀ := line[ℝ,a₀,b₀]`.\n\n**Lemma D — the minimizing line is ordinary (the hard kernel).** Suppose `ℓ₀` contains ≥3 points of `S`. Let `F := orthogonalProjection (affineSpan ℝ {a₀,b₀}) P₀` (foot of perpendicular); `dist P₀ F = δ`.\n  - *Pigeonhole (same side of foot).* Parametrize `ℓ₀` about `F`: by `collinear_iff_of_mem` each on-line point `= r • v +ᵥ F` for some `r : ℝ`. The **sign** of `r` is the side of `F`. Among ≥3 points, two share a sign (pigeonhole on `{<0, ≥0}` etc.); distinct same-side points have distinct `|r|`. Take `B` (smaller `|r|`, nearer `F`) and `C` (larger). Then `FB < FC`, `B ≠ C`.\n  - *Non-degeneracy.* `P₀ ∉ ℓ₀`, `B,C ∈ ℓ₀` ⟹ `line[P₀,C] ∩ ℓ₀ = {C}` ⟹ `B ∉ line[P₀,C]` (else `B=C`). Also `B,C ≠ P₀`. Hence `(B,P₀,C) ∈ T`.\n  - *Distance strictly decreases.* In the right triangle `P₀ F C` (right angle at `F`), drop perpendicular `B → line[P₀,C]`, foot `G`. Triangles `C G B ∼ C F P₀` (right angles, shared angle at `C`), so\n    `dist B (line[P₀,C]) = BG = P₀F · (CB / CP₀) = δ · (CB / CP₀)`.\n    Since `CB ≤ CF < CP₀` (leg `<` hypotenuse, because `FP₀ = δ > 0`), the ratio `CB/CP₀ < 1`, so `dist B (line[P₀,C]) < δ`. (Includes `B = F`: then it is the altitude-to-hypotenuse length `P₀F·FC/P₀C < δ`.)\n  - *Contradiction.* `(B,P₀,C) ∈ T` with `dline B P₀ C < δ` contradicts minimality of `δ`. So `ℓ₀` has exactly 2 points of `S` ⟹ `a₀,b₀` is the ordinary pair. ∎\n\n### Mathlib API map (from source reconnaissance)\n\n| Need | Declaration | Module |\n|------|-------------|--------|\n| Collinearity | `Collinear ℝ s`, `collinear_iff_of_mem`, `collinear_pair`, `affineIndependent_iff_not_collinear_set` | `LinearAlgebra/AffineSpace/FiniteDimensional` |\n| Line through 2 pts | `line[ℝ, a, b]` = `affineSpan ℝ {a,b}`, `left_mem_affineSpan_pair`, `right_mem_affineSpan_pair` | `LinearAlgebra/AffineSpace/AffineSubspace/Defs` |\n| Foot of perpendicular | `EuclideanGeometry.orthogonalProjection`, `orthogonalProjection_mem`, `vsub_orthogonalProjection_mem_direction_orthogonal` | `Geometry/Euclidean/Projection` |\n| Distance to line | `dist_orthogonalProjection_eq_infDist`, `dist_sq_eq_dist_orthogonalProjection_sq_add_dist_orthogonalProjection_sq` (Pythagoras) | `Geometry/Euclidean/Projection` |\n| Finite minimum | `Finset.exists_min_image` | `Data/Finset/Max` |\n| Betweenness | `Wbtw`, `Sbtw`, `affineSegment_subset_affineSpan` | `Analysis/Convex/Between` |\n\n### Infrastructure assessment\n\n- **Cross-product distance formula** `dist x line[a,b] = |det[b-a, x-a]| / ‖b-a‖` in `Fin 2`: not packaged; derive from `orthogonalProjection` or `Matrix.det`/area. ~30-60 lines. This is the lever that turns Lemma D's inequality into an algebraic `CB/CP₀ < 1`.\n- **Same-side-of-foot pigeonhole**: not packaged; build from `collinear_iff_of_mem` + sign trichotomy. ~40-80 lines.\n- **Lemma D assembly**: the similar-triangles / leg-ratio inequality. ~100-200 lines (the crux).\n- **Lemmas B, C + glue**: ~100-150 lines (routine).\n- **Total estimate: 500–900 lines, multi-session.** Decision: **BUILD** (no elementary shortcut for the full theorem; `tractability 4` is accurate — doable but the geometric kernel is delicate). Lemmas B, C and the distance formula are good independent **Aristotle** candidates once statements are fixed.\n\n### Dead ends / cautions\n\n- Do **not** pursue Melchior's dual proof — the planar-arrangement Euler-characteristic machinery is a much larger Mathlib gap than Kelly's metric primitives.\n- Avoid stating in a general `InnerProductSpace` first: the cross-product distance lever is cleanest in `Fin 2`; generalize only after the `Fin 2` proof closes.\n- Build host is OOM-prone; keep the file **standalone + unregistered** while iterating, build single-target via the Docker wrapper only when `lean-build` container count is 0.\n"
   },
@@ -94,6 +99,8 @@
     ]
   },
   "started": "2026-06-18T23:10:00.000Z",
-  "lastUpdate": "2026-06-18T23:10:00.000Z",
-  "leanFiles": []
+  "lastUpdate": "2026-06-19T01:55:00.000Z",
+  "leanFiles": [
+    "proofs/Proofs/SylvesterGallaiOQ01.lean"
+  ]
 }


### PR DESCRIPTION
## Sylvester–Gallai theorem — Kelly's metric proof scaffold

**Problem:** `sylvester-gallai-theorem-oq-01` — every finite, non-collinear set of points in the real plane determines an *ordinary line* (a line through exactly two of the points). Sylvester–Gallai is **not** in Mathlib (no `SylvesterGallai`/`ordinaryLine`/de Bruijn–Erdős declarations), so this is a genuine formalization contribution.

This session lands the **first Lean code** (phase ORIENT → ACT). New file `proofs/Proofs/SylvesterGallaiOQ01.lean` builds via docker (7743 jobs, exit 0).

### Proved (no `sorry`) — the reusable lever
- `area2 a b c` = twice the signed area of triangle `abc` (the 2×2 determinant `det[b-a, c-a]`), the lever for Kelly's proof.
- Full algebra: `area2_self_left/mid/right`, `area2_swap_left/right`, `area2_cyclic`, `area2_vadd` (translation invariance) — all `ring`-closed.
- `distToLine a b c = |area2 a b c| / dist a b`, with `distToLine_nonneg` and `distToLine_self_left`.
- `distToLine_eq_zero_iff` (for `a ≠ b`) — proved modulo the bridge below.

### Open kernel — exactly 3 `sorry`s, decomposed for follow-up
1. `collinear_iff_area2_eq_zero` — the affine `Collinear` ↔ signed-area-vanishes bridge (HARD, known; clean Aristotle target once the backend 404 clears).
2. `area2_strict_decrease` — Kelly's geometric strict-decrease inequality (the creative heart; **not** a known Mathlib result).
3. `sylvester_gallai` — the assembled minimization argument.

### Notes
- File is **unregistered** (not in `Proofs.lean`) → fleet-safe.
- Aristotle was unreachable this session (backend 404, fleet-wide); the bridge lemma is queued as the next delegation target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)