### PR TITLE
research(de-moivre-oq-02-oq-03): complete the Chebyshev minimax theorem (optimality half + capstone)

### DIFF
--- a/proofs/Proofs/DeMoivreOQ02OQ03.lean
+++ b/proofs/Proofs/DeMoivreOQ02OQ03.lean
@@ -18,7 +18,9 @@ missing infrastructure from the De Moivre identity `Tₙ(cos θ) = cos (n θ)` a
 the two-term recurrence `T_{n+2} = 2 X T_{n+1} - Tₙ`, and assembles the
 achievability half of the minimax theorem: the monic Chebyshev polynomial is
 monic of degree `n`, has sup-norm `2^(1-n)` on `[-1,1]`, and equioscillates
-between `±2^(1-n)` at the `n+1` extreme nodes.
+between `±2^(1-n)` at the `n+1` extreme nodes.  It then proves the optimality
+(lower-bound) half by the classical equioscillation argument, giving the full
+minimax theorem `chebyshev_minimax`.
 
 ## Results
 
@@ -36,6 +38,11 @@ Monic normalization and the achievability half of the minimax:
 * `monicChebyshev_monic`      : it is monic of degree `n`.
 * `monicChebyshev_abs_le`     : its sup-norm on `[-1,1]` is `≤ 2^(1-n)`.
 * `monicChebyshev_eval_node`  : it equioscillates between `±2^(1-n)`.
+
+Optimality (lower-bound) half and the full theorem:
+* `monicChebyshev_minimax`    : every monic degree-`n` `p` has `|p| ≥ 2^(1-n)`
+  somewhere on `[-1,1]` (equioscillation + IVT root-count argument).
+* `chebyshev_minimax`         : the full minimax theorem (achievability ∧ optimality).
 -/
 
 open Polynomial Polynomial.Chebyshev Real
@@ -196,5 +203,176 @@ theorem monicChebyshev_eval_node (n k : ℕ) (hn : 0 < n) :
     (monicChebyshev n).eval (Real.cos (k * π / n)) =
       (-1) ^ k * ((2 : ℝ) ^ (n - 1))⁻¹ := by
   rw [monicChebyshev, eval_mul, eval_C, chebyshev_eval_node n k hn]; ring
+
+/-! ## Part IV: The optimality (lower-bound) half of the minimax theorem
+
+The deep direction: *no* monic polynomial of degree `n` can have sup-norm on
+`[-1,1]` smaller than `Mₙ`'s value `2^(1-n)`.  The proof is the classical
+equioscillation argument.  If a monic `p` of degree `n` had `‖p‖∞ < 2^(1-n)`,
+then `q = Mₙ - p` would inherit the sign of `Mₙ` at each of the `n+1` extreme
+nodes `cos(kπ/n)` (strict alternation), so by the intermediate value theorem `q`
+would have a root strictly between every pair of consecutive nodes — `n` distinct
+roots.  But `q` is a difference of two monic degree-`n` polynomials, hence has
+degree `< n`; a nonzero polynomial of degree `< n` cannot have `n` roots. -/
+
+/-- Strict monotonicity of the Chebyshev extreme nodes `cos(kπ/n)`: over
+`0 ≤ k ≤ n` they strictly decrease in `k`. -/
+private theorem node_strict_anti (n : ℕ) (hn : 0 < n) {i j : ℕ} (hj : j ≤ n)
+    (hij : i < j) : Real.cos (j * π / n) < Real.cos (i * π / n) := by
+  have hn' : (0 : ℝ) < n := by exact_mod_cast hn
+  have hpi := Real.pi_pos
+  have hi_le : (i : ℝ) ≤ n := by exact_mod_cast (le_of_lt (lt_of_lt_of_le hij hj))
+  have hj_le : (j : ℝ) ≤ n := by exact_mod_cast hj
+  apply Real.strictAntiOn_cos
+  · refine ⟨div_nonneg (mul_nonneg (Nat.cast_nonneg i) hpi.le) hn'.le, ?_⟩
+    rw [div_le_iff₀ hn']; nlinarith [hpi, hi_le]
+  · refine ⟨div_nonneg (mul_nonneg (Nat.cast_nonneg j) hpi.le) hn'.le, ?_⟩
+    rw [div_le_iff₀ hn']; nlinarith [hpi, hj_le]
+  · rw [div_lt_div_iff_of_pos_right hn']
+    have hij' : (i : ℝ) < j := by exact_mod_cast hij
+    nlinarith [hpi]
+
+/-- Non-strict (antitone) version of `node_strict_anti`. -/
+private theorem node_anti (n : ℕ) (hn : 0 < n) {i j : ℕ} (hj : j ≤ n)
+    (hij : i ≤ j) : Real.cos (j * π / n) ≤ Real.cos (i * π / n) := by
+  rcases eq_or_lt_of_le hij with h | h
+  · exact le_of_eq (by rw [h])
+  · exact (node_strict_anti n hn hj h).le
+
+set_option maxHeartbeats 800000 in
+/-- **Optimality (lower-bound) half of the Chebyshev minimax theorem.**
+Every monic real polynomial of degree `n ≥ 1` attains absolute value at least
+`2^(1-n)` somewhere on `[-1,1]`; equivalently, its sup-norm there is `≥ 2^(1-n)`,
+so it cannot beat the monic Chebyshev polynomial. -/
+theorem monicChebyshev_minimax (p : ℝ[X]) (hp : p.Monic) (n : ℕ) (hn : 0 < n)
+    (hpdeg : p.natDegree = n) :
+    ∃ x ∈ Set.Icc (-1 : ℝ) 1, ((2 : ℝ) ^ (n - 1))⁻¹ ≤ |p.eval x| := by
+  classical
+  by_contra hcon
+  push_neg at hcon
+  set M : ℝ := ((2 : ℝ) ^ (n - 1))⁻¹ with hM_def
+  have hMpos : 0 < M := by rw [hM_def]; positivity
+  set q : ℝ[X] := monicChebyshev n - p with hq_def
+  -- Strict sign alternation of `q` at the extreme nodes: `(-1)^k · q(cos kπ/n) > 0`.
+  have halt : ∀ k : ℕ, k ≤ n → 0 < (-1 : ℝ) ^ k * q.eval (Real.cos (k * π / n)) := by
+    intro k hk
+    have hmem : Real.cos (k * π / n) ∈ Set.Icc (-1 : ℝ) 1 :=
+      ⟨Real.neg_one_le_cos _, Real.cos_le_one _⟩
+    have hev : q.eval (Real.cos (k * π / n)) = (-1) ^ k * M - p.eval (Real.cos (k * π / n)) := by
+      rw [hq_def, eval_sub, monicChebyshev_eval_node n k hn, ← hM_def]
+    have hsq : (-1 : ℝ) ^ k * (-1) ^ k = 1 := by
+      rw [← pow_add]; exact Even.neg_one_pow ⟨k, by ring⟩
+    have hpb : (-1 : ℝ) ^ k * p.eval (Real.cos (k * π / n)) < M := by
+      calc (-1 : ℝ) ^ k * p.eval (Real.cos (k * π / n))
+          ≤ |(-1 : ℝ) ^ k * p.eval (Real.cos (k * π / n))| := le_abs_self _
+        _ = |p.eval (Real.cos (k * π / n))| := by rw [abs_mul]; simp [abs_pow]
+        _ < M := hcon _ hmem
+    have hcalc : (-1 : ℝ) ^ k * q.eval (Real.cos (k * π / n))
+        = ((-1) ^ k * (-1) ^ k) * M - (-1) ^ k * p.eval (Real.cos (k * π / n)) := by
+      rw [hev]; ring
+    rw [hcalc, hsq, one_mul]; linarith
+  -- `q ≠ 0`: it is strictly positive at the `k = 0` node.
+  have hq_ne : q ≠ 0 := by
+    intro h
+    have h0 := halt 0 (Nat.zero_le n)
+    rw [h] at h0; simp at h0
+  -- `q` has degree `< n` (difference of two monic degree-`n` polynomials).
+  have hdeg : q.natDegree < n := by
+    have hpne : p ≠ 0 := hp.ne_zero
+    have hMcne : monicChebyshev n ≠ 0 := (monicChebyshev_monic n hn).ne_zero
+    have hdegM : (monicChebyshev n).degree = (n : WithBot ℕ) := by
+      rw [degree_eq_natDegree hMcne, monicChebyshev_natDegree]
+    have hdegp : p.degree = (n : WithBot ℕ) := by
+      rw [degree_eq_natDegree hpne, hpdeg]
+    have hlc : (monicChebyshev n).leadingCoeff = p.leadingCoeff := by
+      rw [Monic.def.1 (monicChebyshev_monic n hn), Monic.def.1 hp]
+    have hsub : (monicChebyshev n - p).degree < (monicChebyshev n).degree :=
+      degree_sub_lt (by rw [hdegM, hdegp]) hMcne hlc
+    rw [hdegM, ← hq_def] at hsub
+    exact (natDegree_lt_iff_degree_lt hq_ne).mpr hsub
+  -- For each consecutive pair of nodes, `q` has a root strictly between them.
+  have hroot : ∀ k : Fin n, ∃ r, Real.cos ((k.val + 1) * π / n) < r ∧
+      r < Real.cos (k.val * π / n) ∧ q.eval r = 0 := by
+    intro k
+    have hkn : k.val < n := k.isLt
+    have hk1_le : k.val + 1 ≤ n := hkn
+    have hlt : Real.cos ((k.val + 1) * π / n) < Real.cos (k.val * π / n) := by
+      have h := node_strict_anti n hn hk1_le (Nat.lt_succ_self k.val)
+      rwa [Nat.cast_add, Nat.cast_one] at h
+    have s0 := halt k.val (le_of_lt hkn)
+    have s1 := halt (k.val + 1) hk1_le
+    rw [Nat.cast_add, Nat.cast_one] at s1
+    have hne0 : q.eval (Real.cos (k.val * π / n)) ≠ 0 := by
+      intro h; rw [h, mul_zero] at s0; exact lt_irrefl 0 s0
+    have hne1 : q.eval (Real.cos ((k.val + 1) * π / n)) ≠ 0 := by
+      intro h; rw [h, mul_zero] at s1; exact lt_irrefl 0 s1
+    have hmem0 : (0 : ℝ) ∈ Set.uIcc (q.eval (Real.cos ((k.val + 1) * π / n)))
+        (q.eval (Real.cos (k.val * π / n))) := by
+      rcases Nat.even_or_odd k.val with he | ho
+      · have e0 : (-1 : ℝ) ^ k.val = 1 := he.neg_one_pow
+        have e1 : (-1 : ℝ) ^ (k.val + 1) = -1 := by rw [pow_succ, e0]; ring
+        rw [e0, one_mul] at s0; rw [e1] at s1
+        exact Set.mem_uIcc_of_le (by linarith) (by linarith)
+      · have e0 : (-1 : ℝ) ^ k.val = -1 := ho.neg_one_pow
+        have e1 : (-1 : ℝ) ^ (k.val + 1) = 1 := by rw [pow_succ, e0]; ring
+        rw [e0] at s0; rw [e1, one_mul] at s1
+        exact Set.mem_uIcc_of_ge (by linarith) (by linarith)
+    have hcont : ContinuousOn (fun x => q.eval x)
+        (Set.uIcc (Real.cos ((k.val + 1) * π / n)) (Real.cos (k.val * π / n))) :=
+      (Polynomial.continuous q).continuousOn
+    obtain ⟨r, hr_mem, hr_eq⟩ := intermediate_value_uIcc hcont hmem0
+    rw [Set.uIcc_of_le hlt.le] at hr_mem
+    obtain ⟨hr1, hr2⟩ := hr_mem
+    refine ⟨r, ?_, ?_, hr_eq⟩
+    · rcases eq_or_lt_of_le hr1 with h | h
+      · rw [← h] at hr_eq; exact absurd hr_eq hne1
+      · exact h
+    · rcases eq_or_lt_of_le hr2 with h | h
+      · rw [h] at hr_eq; exact absurd hr_eq hne0
+      · exact h
+  -- Collect one root per interval into an injective family `f : Fin n → ℝ`.
+  let f : Fin n → ℝ := fun k => Classical.choose (hroot k)
+  have hf : ∀ k : Fin n, Real.cos ((k.val + 1) * π / n) < f k ∧
+      f k < Real.cos (k.val * π / n) ∧ q.eval (f k) = 0 :=
+    fun k => Classical.choose_spec (hroot k)
+  have hf_root : ∀ k : Fin n, f k ∈ q.roots.toFinset := by
+    intro k; rw [Multiset.mem_toFinset, mem_roots']; exact ⟨hq_ne, (hf k).2.2⟩
+  have hf_inj : Function.Injective f := by
+    have hanti : StrictAnti f := by
+      intro a b hab
+      have hab' : a.val < b.val := hab
+      have hb1 : f b < Real.cos (b.val * π / n) := (hf b).2.1
+      have ha0 : Real.cos ((a.val + 1) * π / n) < f a := (hf a).1
+      have hstep : Real.cos (b.val * π / n) ≤ Real.cos ((a.val + 1) * π / n) := by
+        have h := node_anti n hn (le_of_lt b.isLt) (show a.val + 1 ≤ b.val by omega)
+        rwa [Nat.cast_add, Nat.cast_one] at h
+      linarith
+    exact hanti.injective
+  -- `n` distinct roots, but `q ≠ 0` has at most `natDegree q < n` roots.
+  have hcard : (Finset.univ.image f).card = n := by
+    rw [Finset.card_image_of_injective _ hf_inj, Finset.card_univ, Fintype.card_fin]
+  have hsubset : Finset.univ.image f ⊆ q.roots.toFinset := by
+    intro x hx
+    rw [Finset.mem_image] at hx
+    obtain ⟨k, _, rfl⟩ := hx
+    exact hf_root k
+  have hle : n ≤ q.natDegree :=
+    calc n = (Finset.univ.image f).card := hcard.symm
+      _ ≤ q.roots.toFinset.card := Finset.card_le_card hsubset
+      _ ≤ Multiset.card q.roots := Multiset.toFinset_card_le _
+      _ ≤ q.natDegree := card_roots' q
+  omega
+
+/-- **Chebyshev minimax theorem (full statement).** Among monic real polynomials
+of degree `n ≥ 1`, the monic Chebyshev polynomial `Mₙ` minimizes the sup-norm on
+`[-1,1]` and the minimal value is exactly `2^(1-n)`: `Mₙ` stays within `2^(1-n)`
+everywhere (achievability), while every monic degree-`n` polynomial reaches at
+least `2^(1-n)` somewhere (optimality). -/
+theorem chebyshev_minimax (n : ℕ) (hn : 0 < n) :
+    (∀ x ∈ Set.Icc (-1 : ℝ) 1, |(monicChebyshev n).eval x| ≤ ((2 : ℝ) ^ (n - 1))⁻¹) ∧
+      (∀ p : ℝ[X], p.Monic → p.natDegree = n →
+        ∃ x ∈ Set.Icc (-1 : ℝ) 1, ((2 : ℝ) ^ (n - 1))⁻¹ ≤ |p.eval x|) :=
+  ⟨fun _ hx => monicChebyshev_abs_le n hx,
+    fun p hp hpd => monicChebyshev_minimax p hp n hn hpd⟩
 
 end DeMoivreOQ0203

--- a/src/data/proofs/de-moivre-oq-02-oq-03/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "de-moivre-oq-02-oq-03",
-  "title": "Chebyshev Minimax: Equioscillation and the Monic Achievability Half",
+  "title": "Chebyshev Minimax Theorem: Equioscillation and the Full Minimax (Both Halves)",
   "slug": "de-moivre-oq-02-oq-03",
-  "description": "Builds toward the classical Chebyshev minimax theorem (the monic Chebyshev polynomial Tₙ/2^(n-1) minimizes the sup-norm on [-1,1] among monic degree-n polynomials). Proves the analytic core from De Moivre — |Tₙ(x)| ≤ 1 on [-1,1] and equioscillation Tₙ(cos(kπ/n)) = (-1)^k at the n+1 extreme nodes — and the degree/leading-coefficient facts Mathlib lacks (natDegree Tₙ = n, leadingCoeff Tₙ = 2^(n-1)). Assembles the achievability half of the minimax: the monic Chebyshev polynomial is monic of degree n, has sup-norm 2^(1-n) on [-1,1], and equioscillates between ±2^(1-n). 0 sorries, 0 axioms.",
+  "description": "Proves the classical Chebyshev minimax theorem in full: the monic Chebyshev polynomial Tₙ/2^(n-1) minimizes the sup-norm on [-1,1] among all monic degree-n real polynomials, with minimal value exactly 2^(1-n). Proves the analytic core from De Moivre — |Tₙ(x)| ≤ 1 on [-1,1] and equioscillation Tₙ(cos(kπ/n)) = (-1)^k at the n+1 extreme nodes — and the degree/leading-coefficient facts Mathlib lacks (natDegree Tₙ = n, leadingCoeff Tₙ = 2^(n-1)). Assembles the achievability half (the monic Chebyshev polynomial is monic of degree n, has sup-norm 2^(1-n) on [-1,1], and equioscillates between ±2^(1-n)) and the optimality half (every monic degree-n polynomial attains absolute value ≥ 2^(1-n) somewhere on [-1,1], via the equioscillation + intermediate-value root-counting argument). The capstone chebyshev_minimax bundles both. 0 sorries, 0 axioms.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_polynomials#Minimal_%E2%88%9E-norm",
@@ -25,9 +25,9 @@
     "dateAdded": "2026-06-19",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 200,
-    "assumptions": "0 axioms, 0 sorries. All results proved over ℝ from the De Moivre identity Tₙ(cos θ) = cos(nθ) and the two-term Chebyshev recurrence. The full minimax lower bound (every monic degree-n polynomial has sup-norm ≥ 2^(1-n)) is stated in the docstring as the remaining open continuation; this entry establishes the equioscillation envelope, the degree infrastructure, and the achievability (upper) half.",
-    "theoremCount": 11,
+    "lineCount": 378,
+    "assumptions": "0 axioms, 0 sorries. All results proved over ℝ from the De Moivre identity Tₙ(cos θ) = cos(nθ) and the two-term Chebyshev recurrence. The full minimax theorem is complete: the optimality (lower-bound) half — every monic degree-n polynomial has sup-norm ≥ 2^(1-n) on [-1,1] — is proven by the classical equioscillation + intermediate-value root-counting argument, and the capstone chebyshev_minimax bundles both halves.",
+    "theoremCount": 15,
     "definitionCount": 1,
     "originalContributions": [
       "chebyshev_abs_eval_le_one: |Tₙ(x)| ≤ 1 for x ∈ [-1,1], via x = cos(arccos x) and Tₙ(cos θ) = cos(nθ)",
@@ -37,11 +37,14 @@
       "monicChebyshev: the monic Chebyshev polynomial Tₙ/2^(n-1)",
       "monicChebyshev_monic / monicChebyshev_natDegree: it is monic of degree n",
       "monicChebyshev_abs_le: its sup-norm on [-1,1] is ≤ 2^(1-n)",
-      "monicChebyshev_eval_node: it equioscillates between ±2^(1-n)"
+      "monicChebyshev_eval_node: it equioscillates between ±2^(1-n)",
+      "node_strict_anti / node_anti: strict/non-strict monotonicity of the extreme nodes cos(kπ/n) in k",
+      "monicChebyshev_minimax: optimality (lower-bound) half — every monic degree-n p attains |p| ≥ 2^(1-n) somewhere on [-1,1] (equioscillation + IVT root-count + degree_sub_lt)",
+      "chebyshev_minimax: the full Chebyshev minimax theorem (achievability ∧ optimality)"
     ],
-    "historicalContext": "Chebyshev's 1854 theorem states that among all monic real polynomials of degree n, the rescaled Chebyshev polynomial Tₙ/2^(n-1) has the smallest possible maximum absolute value on [-1,1], namely 2^(1-n). The mechanism is equioscillation: Tₙ alternately attains +1 and -1 at the n+1 points cos(kπ/n), k = 0..n, so the monic normalization alternates between ±2^(1-n). Mathlib's RingTheory/Polynomial/Chebyshev.lean explicitly flags 'Prove minimax properties of Chebyshev polynomials' and 'Compute zeroes and extrema' as open TODOs, and provides no degree or leading-coefficient lemmas for Tₙ. This entry supplies that missing infrastructure and the achievability half of the theorem.",
-    "problemStatement": "**The Open Question**\n\nDoes the monic Chebyshev polynomial $M_n = T_n/2^{n-1}$ minimize the sup-norm on $[-1,1]$ among all monic degree-$n$ real polynomials, with minimal value $2^{1-n}$?\n\n**This entry's contribution**\n\nThe analytic core and the achievability (upper) half, fully verified:\n- $|T_n(x)| \\le 1$ on $[-1,1]$ with equioscillation $T_n(\\cos(k\\pi/n)) = (-1)^k$;\n- $\\deg T_n = n$ and $\\operatorname{lead} T_n = 2^{n-1}$ (new infrastructure);\n- $M_n$ is monic of degree $n$, has sup-norm $\\le 2^{1-n}$, and equioscillates between $\\pm 2^{1-n}$.\n\nThe matching lower bound (every monic degree-$n$ polynomial has sup-norm $\\ge 2^{1-n}$, by the alternation/root-counting argument) is the remaining open continuation.",
-    "proofStrategy": "**De Moivre for the analysis core; two-step induction for the degree facts.**\n\n1. **Sup-norm bound** `chebyshev_abs_eval_le_one`: for $x \\in [-1,1]$ write $x = \\cos(\\arccos x)$; then $T_n(x) = \\cos(n\\arccos x)$ by `T_real_cos`, so $|T_n(x)| \\le 1$.\n2. **Equioscillation** `chebyshev_eval_node`: at $x_k = \\cos(k\\pi/n)$, $T_n(x_k) = \\cos(n \\cdot k\\pi/n) = \\cos(k\\pi) = (-1)^k$ (`cos_nat_mul_pi`).\n3. **Degree infrastructure** `chebyshev_deg_lead_pair`: a single induction over the paired statement for $T_{n+1}, T_{n+2}$, driven by $T_{n+2} = 2X T_{n+1} - T_n$. The recurrence step `deg_lead_recurrence_step` shows $\\deg(2Xa - b) = d+1$ and $\\operatorname{lead}(2Xa - b) = 2c$ when $\\deg a = d$, $\\operatorname{lead} a = c \\ne 0$, $\\deg b \\le d$ (the $-b$ term is below the top degree, so it does not perturb the leading coefficient).\n4. **Monic normalization** `monicChebyshev` $= C(2^{n-1})^{-1} \\cdot T_n$: monicity and degree follow from the leading-coefficient and degree facts; the sup-norm bound and equioscillation follow by scaling the core results.",
+    "historicalContext": "Chebyshev's 1854 theorem states that among all monic real polynomials of degree n, the rescaled Chebyshev polynomial Tₙ/2^(n-1) has the smallest possible maximum absolute value on [-1,1], namely 2^(1-n). The mechanism is equioscillation: Tₙ alternately attains +1 and -1 at the n+1 points cos(kπ/n), k = 0..n, so the monic normalization alternates between ±2^(1-n). Mathlib's RingTheory/Polynomial/Chebyshev.lean explicitly flags 'Prove minimax properties of Chebyshev polynomials' and 'Compute zeroes and extrema' as open TODOs, and provides no degree or leading-coefficient lemmas for Tₙ. This entry supplies that missing infrastructure and the full theorem — both the achievability and the optimality halves.",
+    "problemStatement": "**The Open Question**\n\nDoes the monic Chebyshev polynomial $M_n = T_n/2^{n-1}$ minimize the sup-norm on $[-1,1]$ among all monic degree-$n$ real polynomials, with minimal value $2^{1-n}$?\n\n**This entry's contribution — the full theorem, both halves, fully verified**\n\n- $|T_n(x)| \\le 1$ on $[-1,1]$ with equioscillation $T_n(\\cos(k\\pi/n)) = (-1)^k$;\n- $\\deg T_n = n$ and $\\operatorname{lead} T_n = 2^{n-1}$ (new infrastructure);\n- *Achievability:* $M_n$ is monic of degree $n$, has sup-norm $\\le 2^{1-n}$, and equioscillates between $\\pm 2^{1-n}$;\n- *Optimality:* every monic degree-$n$ polynomial attains $|p(x)| \\ge 2^{1-n}$ for some $x \\in [-1,1]$ (`monicChebyshev_minimax`), by the alternation/root-counting argument;\n- *Capstone:* `chebyshev_minimax` bundles achievability $\\wedge$ optimality, so $M_n$ is a sup-norm minimizer with minimal value exactly $2^{1-n}$.",
+    "proofStrategy": "**De Moivre for the analysis core; two-step induction for the degree facts.**\n\n1. **Sup-norm bound** `chebyshev_abs_eval_le_one`: for $x \\in [-1,1]$ write $x = \\cos(\\arccos x)$; then $T_n(x) = \\cos(n\\arccos x)$ by `T_real_cos`, so $|T_n(x)| \\le 1$.\n2. **Equioscillation** `chebyshev_eval_node`: at $x_k = \\cos(k\\pi/n)$, $T_n(x_k) = \\cos(n \\cdot k\\pi/n) = \\cos(k\\pi) = (-1)^k$ (`cos_nat_mul_pi`).\n3. **Degree infrastructure** `chebyshev_deg_lead_pair`: a single induction over the paired statement for $T_{n+1}, T_{n+2}$, driven by $T_{n+2} = 2X T_{n+1} - T_n$. The recurrence step `deg_lead_recurrence_step` shows $\\deg(2Xa - b) = d+1$ and $\\operatorname{lead}(2Xa - b) = 2c$ when $\\deg a = d$, $\\operatorname{lead} a = c \\ne 0$, $\\deg b \\le d$ (the $-b$ term is below the top degree, so it does not perturb the leading coefficient).\n4. **Monic normalization** `monicChebyshev` $= C(2^{n-1})^{-1} \\cdot T_n$: monicity and degree follow from the leading-coefficient and degree facts; the sup-norm bound and equioscillation follow by scaling the core results.\n5. **Optimality** `monicChebyshev_minimax`: by contradiction, suppose a monic degree-$n$ $p$ has $|p| < 2^{1-n}$ everywhere on $[-1,1]$. Then $q = M_n - p$ satisfies $(-1)^k q(\\cos(k\\pi/n)) > 0$ (strict sign alternation, since $M_n$ equioscillates and $p$ is dominated). Between each consecutive node pair the sign of $q$ flips, so `intermediate_value_uIcc` gives a root strictly interior to each of the $n$ intervals; `node_strict_anti` makes these $n$ roots distinct (`StrictAnti.injective`). But $q$ is a difference of two monic degree-$n$ polynomials, so $\\deg q < n$ by `degree_sub_lt`; a nonzero polynomial of degree $< n$ has at most $\\deg q < n$ roots (`card_roots'`), a contradiction.\n6. **Capstone** `chebyshev_minimax`: pairs `monicChebyshev_abs_le` (achievability) with `monicChebyshev_minimax` (optimality).",
     "keyInsights": [
       "**De Moivre is the whole analytic story**: the single identity $T_n(\\cos\\theta) = \\cos(n\\theta)$ delivers both the envelope bound $|T_n| \\le 1$ and the equioscillation values $(-1)^k$ at $\\cos(k\\pi/n)$ — no calculus of extrema needed.",
       "**Degree facts need a paired induction**: the Chebyshev recurrence is second-order, so degree $n$ and leading coefficient $2^{n-1}$ must be carried for two consecutive indices simultaneously; the single recurrence step is isolated as a reusable lemma.",
@@ -51,16 +54,19 @@
     ]
   },
   "overview": {
-    "historicalContext": "Chebyshev's 1854 theorem states that among all monic real polynomials of degree n, the rescaled Chebyshev polynomial Tₙ/2^(n-1) has the smallest possible maximum absolute value on [-1,1], namely 2^(1-n). The mechanism is equioscillation: Tₙ alternately attains +1 and -1 at the n+1 points cos(kπ/n), k = 0..n, so the monic normalization alternates between ±2^(1-n). Mathlib's RingTheory/Polynomial/Chebyshev.lean explicitly flags 'Prove minimax properties of Chebyshev polynomials' and 'Compute zeroes and extrema' as open TODOs, and provides no degree or leading-coefficient lemmas for Tₙ. This entry supplies that missing infrastructure and the achievability half of the theorem, all derived from the single De Moivre identity Tₙ(cos θ) = cos(nθ) and the two-term recurrence Tₙ₊₂ = 2X·Tₙ₊₁ − Tₙ.",
-    "problemStatement": "**The Open Question**\n\nDoes the monic Chebyshev polynomial $M_n = T_n/2^{n-1}$ minimize the sup-norm on $[-1,1]$ among all monic degree-$n$ real polynomials, with minimal value $2^{1-n}$?\n\n**This entry's contribution**\n\nThe analytic core and the achievability (upper) half, fully verified:\n- $|T_n(x)| \\le 1$ on $[-1,1]$ with equioscillation $T_n(\\cos(k\\pi/n)) = (-1)^k$;\n- $\\deg T_n = n$ and $\\operatorname{lead} T_n = 2^{n-1}$ (new infrastructure);\n- $M_n$ is monic of degree $n$, has sup-norm $\\le 2^{1-n}$, and equioscillates between $\\pm 2^{1-n}$.\n\nThe matching lower bound (every monic degree-$n$ polynomial has sup-norm $\\ge 2^{1-n}$, by the alternation/root-counting argument) is the remaining open continuation.",
-    "text": "Builds the analytic core and the achievability half of the Chebyshev minimax theorem from the De Moivre identity: the sup-norm envelope |Tₙ| ≤ 1, equioscillation at the n+1 extreme nodes, the degree and leading-coefficient infrastructure Mathlib lacks, and the monic Chebyshev polynomial with sup-norm 2^(1-n).",
-    "proofStrategy": "**De Moivre for the analysis core; two-step induction for the degree facts.**\n\n1. **Sup-norm bound** `chebyshev_abs_eval_le_one`: for $x \\in [-1,1]$ write $x = \\cos(\\arccos x)$; then $T_n(x) = \\cos(n\\arccos x)$ by `T_real_cos`, so $|T_n(x)| \\le 1$.\n2. **Equioscillation** `chebyshev_eval_node`: at $x_k = \\cos(k\\pi/n)$, $T_n(x_k) = \\cos(n \\cdot k\\pi/n) = \\cos(k\\pi) = (-1)^k$ (`cos_nat_mul_pi`).\n3. **Degree infrastructure** `chebyshev_deg_lead_pair`: a single induction over the paired statement for $T_{n+1}, T_{n+2}$, driven by $T_{n+2} = 2X T_{n+1} - T_n$. The recurrence step `deg_lead_recurrence_step` shows $\\deg(2Xa - b) = d+1$ and $\\operatorname{lead}(2Xa - b) = 2c$ when $\\deg a = d$, $\\operatorname{lead} a = c \\ne 0$, $\\deg b \\le d$ (the $-b$ term is below the top degree, so it does not perturb the leading coefficient).\n4. **Monic normalization** `monicChebyshev` $= C(2^{n-1})^{-1} \\cdot T_n$: monicity and degree follow from the leading-coefficient and degree facts; the sup-norm bound and equioscillation follow by scaling the core results.",
+    "historicalContext": "Chebyshev's 1854 theorem states that among all monic real polynomials of degree n, the rescaled Chebyshev polynomial Tₙ/2^(n-1) has the smallest possible maximum absolute value on [-1,1], namely 2^(1-n). The mechanism is equioscillation: Tₙ alternately attains +1 and -1 at the n+1 points cos(kπ/n), k = 0..n, so the monic normalization alternates between ±2^(1-n). Mathlib's RingTheory/Polynomial/Chebyshev.lean explicitly flags 'Prove minimax properties of Chebyshev polynomials' and 'Compute zeroes and extrema' as open TODOs, and provides no degree or leading-coefficient lemmas for Tₙ. This entry supplies that missing infrastructure and the full theorem — both the achievability and the optimality halves — all derived from the single De Moivre identity Tₙ(cos θ) = cos(nθ) and the two-term recurrence Tₙ₊₂ = 2X·Tₙ₊₁ − Tₙ.",
+    "problemStatement": "**The Open Question**\n\nDoes the monic Chebyshev polynomial $M_n = T_n/2^{n-1}$ minimize the sup-norm on $[-1,1]$ among all monic degree-$n$ real polynomials, with minimal value $2^{1-n}$?\n\n**This entry's contribution — the full theorem, both halves, fully verified**\n\n- $|T_n(x)| \\le 1$ on $[-1,1]$ with equioscillation $T_n(\\cos(k\\pi/n)) = (-1)^k$;\n- $\\deg T_n = n$ and $\\operatorname{lead} T_n = 2^{n-1}$ (new infrastructure);\n- *Achievability:* $M_n$ is monic of degree $n$, has sup-norm $\\le 2^{1-n}$, and equioscillates between $\\pm 2^{1-n}$;\n- *Optimality:* every monic degree-$n$ polynomial attains $|p(x)| \\ge 2^{1-n}$ for some $x \\in [-1,1]$ (`monicChebyshev_minimax`), by the alternation/root-counting argument;\n- *Capstone:* `chebyshev_minimax` bundles achievability $\\wedge$ optimality, so $M_n$ is a sup-norm minimizer with minimal value exactly $2^{1-n}$.",
+    "text": "Proves the full Chebyshev minimax theorem from the De Moivre identity: the sup-norm envelope |Tₙ| ≤ 1, equioscillation at the n+1 extreme nodes, the degree and leading-coefficient infrastructure Mathlib lacks, the monic Chebyshev polynomial with sup-norm 2^(1-n) (achievability), and the matching lower bound that every monic degree-n polynomial reaches ≥ 2^(1-n) somewhere (optimality), bundled as chebyshev_minimax.",
+    "proofStrategy": "**De Moivre for the analysis core; two-step induction for the degree facts.**\n\n1. **Sup-norm bound** `chebyshev_abs_eval_le_one`: for $x \\in [-1,1]$ write $x = \\cos(\\arccos x)$; then $T_n(x) = \\cos(n\\arccos x)$ by `T_real_cos`, so $|T_n(x)| \\le 1$.\n2. **Equioscillation** `chebyshev_eval_node`: at $x_k = \\cos(k\\pi/n)$, $T_n(x_k) = \\cos(n \\cdot k\\pi/n) = \\cos(k\\pi) = (-1)^k$ (`cos_nat_mul_pi`).\n3. **Degree infrastructure** `chebyshev_deg_lead_pair`: a single induction over the paired statement for $T_{n+1}, T_{n+2}$, driven by $T_{n+2} = 2X T_{n+1} - T_n$. The recurrence step `deg_lead_recurrence_step` shows $\\deg(2Xa - b) = d+1$ and $\\operatorname{lead}(2Xa - b) = 2c$ when $\\deg a = d$, $\\operatorname{lead} a = c \\ne 0$, $\\deg b \\le d$ (the $-b$ term is below the top degree, so it does not perturb the leading coefficient).\n4. **Monic normalization** `monicChebyshev` $= C(2^{n-1})^{-1} \\cdot T_n$: monicity and degree follow from the leading-coefficient and degree facts; the sup-norm bound and equioscillation follow by scaling the core results.\n5. **Optimality** `monicChebyshev_minimax`: by contradiction, suppose a monic degree-$n$ $p$ has $|p| < 2^{1-n}$ everywhere on $[-1,1]$. Then $q = M_n - p$ satisfies $(-1)^k q(\\cos(k\\pi/n)) > 0$ (strict sign alternation, since $M_n$ equioscillates and $p$ is dominated). Between each consecutive node pair the sign of $q$ flips, so `intermediate_value_uIcc` gives a root strictly interior to each of the $n$ intervals; `node_strict_anti` makes these $n$ roots distinct (`StrictAnti.injective`). But $q$ is a difference of two monic degree-$n$ polynomials, so $\\deg q < n$ by `degree_sub_lt`; a nonzero polynomial of degree $< n$ has at most $\\deg q < n$ roots (`card_roots'`), a contradiction.\n6. **Capstone** `chebyshev_minimax`: pairs `monicChebyshev_abs_le` (achievability) with `monicChebyshev_minimax` (optimality).",
     "keyInsights": [
       "**De Moivre is the whole analytic story**: the single identity $T_n(\\cos\\theta) = \\cos(n\\theta)$ delivers both the envelope bound $|T_n| \\le 1$ and the equioscillation values $(-1)^k$ at $\\cos(k\\pi/n)$ — no calculus of extrema needed.",
       "**Degree facts need a paired induction**: the Chebyshev recurrence is second-order, so degree $n$ and leading coefficient $2^{n-1}$ must be carried for two consecutive indices simultaneously; the single recurrence step is isolated as a reusable lemma.",
       "**The subtraction is harmless to the top**: in $T_{n+2} = 2X T_{n+1} - T_n$, the subtracted $T_n$ has degree $n < n+2$, so `leadingCoeff_sub_of_degree_lt` keeps the leading coefficient equal to that of $2X T_{n+1}$, doubling it each step to give $2^{n-1}$.",
       "**Mathlib gap**: there are no `natDegree`/`leadingCoeff` lemmas for `Polynomial.Chebyshev.T`; this file derives them and they are candidates for upstreaming (the Chebyshev file lists exactly these as TODOs).",
-      "**Achievability vs. minimality**: equioscillation between $\\pm 2^{1-n}$ at $n+1$ nodes is the engine of *both* halves of the minimax theorem; this entry completes the upper (achievability) half, leaving the alternation→root-counting lower bound as the open continuation."
+      "**Achievability and optimality from one envelope**: equioscillation between $\\pm 2^{1-n}$ at $n+1$ nodes is the engine of *both* halves; this entry now closes the optimality half via the alternation→root-counting argument, so the full minimax theorem is proven.",
+      "**Avoiding parity case-explosion in the IVT step**: rather than splitting on the sign at each node, the root-existence lemma uses `intermediate_value_uIcc` on the *unordered* interval plus `Set.mem_uIcc_of_le`/`_of_ge`, so a single `Nat.even_or_odd` split suffices to place $0$ between the two node values.",
+      "**Distinct roots for free from monotonicity**: the chosen roots are strictly interior (open intervals, since $q$ is nonzero at the nodes), and `node_strict_anti` (strict decrease of $\\cos(k\\pi/n)$) makes the root-selection map `StrictAnti`, hence injective — yielding $n$ distinct roots without extra bookkeeping.",
+      "**Degree drop is the contradiction**: $q = M_n - p$ is a difference of two *monic* degree-$n$ polynomials, so `degree_sub_lt` forces $\\deg q < n$; pairing $n$ distinct roots against `card_roots'` for the nonzero $q$ is the whole optimality argument."
     ],
     "prerequisites": [
       "Chebyshev polynomials of the first kind Tₙ and the De Moivre identity Tₙ(cos θ) = cos(nθ)",
@@ -71,53 +77,60 @@
   },
   "sections": [
     {
-      "id": "sup-norm-equioscillation",
-      "title": "The Sup-Norm Bound and Equioscillation",
-      "startLine": 45,
-      "endLine": 72,
-      "description": "From De Moivre: |Tₙ(x)| ≤ 1 on [-1,1], equioscillation Tₙ(cos(kπ/n)) = (-1)^k at the n+1 extreme nodes, and endpoint sharpness Tₙ(1) = 1.",
-      "summary": "From De Moivre: |Tₙ(x)| ≤ 1 on [-1,1], equioscillation Tₙ(cos(kπ/n)) = (-1)^k at the n+1 extreme nodes, and endpoint sharpness Tₙ(1) = 1."
+      "id": "overview",
+      "title": "Overview and Research Question",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Module docstring posing the classical Chebyshev minimax / equioscillation question — among monic degree-n real polynomials, Mₙ = Tₙ/2^(n-1) minimizes the sup-norm on [-1,1] with value 2^(1-n) — and stating what this entry contributes: the analysis core, the missing degree/leading-coefficient infrastructure, and the achievability half. Notes Mathlib's explicit TODO flag for Chebyshev minimax properties.",
+      "mathContext": "Target: $\\min_{p\\ \\text{monic},\\ \\deg p=n}\\ \\|p\\|_{\\infty,[-1,1]} = 2^{1-n}$, attained by $M_n=T_n/2^{n-1}$. This file proves the upper (achievability) half and the supporting envelope, degree, and equioscillation facts."
+    },
+    {
+      "id": "analysis-core",
+      "title": "Part I: Sup-norm bound and equioscillation",
+      "startLine": 52,
+      "endLine": 79,
+      "summary": "The De Moivre analysis core: chebyshev_abs_eval_le_one proves |Tₙ(x)| ≤ 1 on [-1,1] by writing x = cos(arccos x) and using Tₙ(cos θ) = cos(nθ); chebyshev_eval_node proves the equioscillation Tₙ(cos(kπ/n)) = (-1)^k via cos(kπ) = (-1)^k; chebyshev_eval_one records the sharp endpoint value Tₙ(1) = 1.",
+      "mathContext": "$|T_n(x)|=|\\cos(n\\arccos x)|\\le 1$, with equality at $x_k=\\cos(k\\pi/n)$ where $T_n(x_k)=\\cos(k\\pi)=(-1)^k$ for $k=0,\\dots,n$."
     },
     {
       "id": "recurrence-step",
-      "title": "One Recurrence Step",
-      "startLine": 74,
-      "endLine": 105,
-      "description": "The reusable lemma deg_lead_recurrence_step: 2X·a − b has degree d+1 and leading coefficient 2c when deg a = d, lead a = c ≠ 0, deg b ≤ d.",
-      "summary": "The reusable lemma deg_lead_recurrence_step: 2X·a − b has degree d+1 and leading coefficient 2c when deg a = d, lead a = c ≠ 0, deg b ≤ d."
+      "title": "Part II-a: One recurrence step on degree and leading coefficient",
+      "startLine": 81,
+      "endLine": 114,
+      "summary": "deg_lead_recurrence_step isolates exactly what one application of T_{n+2} = 2X·T_{n+1} − Tₙ does: given deg a = d, lead a = c ≠ 0, deg b ≤ d, the polynomial 2X·a − b has degree d+1 and leading coefficient 2c. The subtracted term sits strictly below the top degree, so natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_sub_of_degree_lt leave both unchanged.",
+      "mathContext": "$\\deg(2Xa-b)=d+1$ and $\\operatorname{lead}(2Xa-b)=2c$ whenever $\\deg a=d,\\ \\operatorname{lead}a=c\\ne0,\\ \\deg b\\le d$. Iterating doubles the leading coefficient to $2^{n-1}$."
     },
     {
-      "id": "paired-induction",
-      "title": "Paired Degree/Leading-Coefficient Induction",
-      "startLine": 107,
-      "endLine": 146,
-      "description": "chebyshev_deg_lead_pair carries the degree and leading-coefficient invariant for two consecutive indices, driven by the second-order recurrence T_add_two.",
-      "summary": "chebyshev_deg_lead_pair carries the degree and leading-coefficient invariant for two consecutive indices, driven by the second-order recurrence T_add_two."
-    },
-    {
-      "id": "degree-leading-coeff",
-      "title": "Degree and Leading Coefficient of Tₙ",
-      "startLine": 148,
-      "endLine": 166,
-      "description": "The public corollaries Mathlib lacks: natDegree(Tₙ) = n and leadingCoeff(Tₙ) = 2^(n-1) for n ≥ 1.",
-      "summary": "The public corollaries Mathlib lacks: natDegree(Tₙ) = n and leadingCoeff(Tₙ) = 2^(n-1) for n ≥ 1."
+      "id": "degree-facts",
+      "title": "Part II-b: Paired induction and the degree/leading-coefficient facts",
+      "startLine": 116,
+      "endLine": 173,
+      "summary": "chebyshev_deg_lead_pair carries the degree/leading-coefficient statement for two consecutive indices through one induction driven by the recurrence; the scalar theorems chebyshev_natDegree (= n) and chebyshev_leadingCoeff (= 2^(n-1)) project out a component and rebase the index. These fill a documented Mathlib gap.",
+      "mathContext": "$\\deg T_n=n$, $\\operatorname{lead}T_n=2^{n-1}$ ($n\\ge1$): $T_n(x)=2^{n-1}x^n+\\text{lower order}$."
     },
     {
       "id": "monic-achievability",
-      "title": "The Monic Chebyshev Polynomial and Achievability",
-      "startLine": 168,
-      "endLine": 200,
-      "description": "monicChebyshev = Tₙ/2^(n-1): monic of degree n, sup-norm ≤ 2^(1-n) on [-1,1], equioscillating between ±2^(1-n) — the achievability half of the minimax theorem.",
-      "summary": "monicChebyshev = Tₙ/2^(n-1): monic of degree n, sup-norm ≤ 2^(1-n) on [-1,1], equioscillating between ±2^(1-n) — the achievability half of the minimax theorem."
+      "title": "Part III: Monic Chebyshev polynomial and achievability",
+      "startLine": 175,
+      "endLine": 205,
+      "summary": "Defines monicChebyshev n = Tₙ/2^(n-1) and proves the achievability half: monicChebyshev_monic (monic), monicChebyshev_natDegree (degree n), monicChebyshev_abs_le (sup-norm ≤ 2^(1-n) on [-1,1]) and monicChebyshev_eval_node (equioscillates between ±2^(1-n) at the n+1 nodes). These scale the Part I bounds by the inverse leading coefficient from Part II.",
+      "mathContext": "$M_n=T_n/2^{n-1}$ is monic of degree $n$, $\\|M_n\\|_{\\infty,[-1,1]}\\le 2^{1-n}$, and $M_n(\\cos(k\\pi/n))=(-1)^k2^{1-n}$ — the equioscillation certificate of the minimax polynomial."
+    },
+    {
+      "id": "optimality-lower-bound",
+      "title": "Part IV: Optimality (lower bound) and the full minimax theorem",
+      "startLine": 207,
+      "endLine": 378,
+      "summary": "node_strict_anti/node_anti establish strict/non-strict monotonicity of the extreme nodes cos(kπ/n) in k. monicChebyshev_minimax then proves the optimality half by contradiction: if a monic degree-n p had |p| < 2^(1-n) everywhere on [-1,1], the difference q = Mₙ − p would inherit strict sign alternation (-1)^k·q(cos(kπ/n)) > 0 at the n+1 nodes, so the intermediate value theorem (intermediate_value_uIcc) places a root strictly inside each of the n consecutive-node intervals; node_strict_anti makes the root-selection map StrictAnti hence injective, giving n distinct roots — but q = Mₙ − p is a difference of two monic degree-n polynomials so deg q < n (degree_sub_lt), and a nonzero polynomial of degree < n cannot have n roots (card_roots'). The capstone chebyshev_minimax bundles achievability ∧ optimality.",
+      "mathContext": "If $p$ is monic of degree $n$ then $\\|p\\|_{\\infty,[-1,1]}\\ge 2^{1-n}$. Proof: $q=M_n-p$ alternates sign at $x_k=\\cos(k\\pi/n)$, giving $n$ interior roots, yet $\\deg q<n$ — contradiction. Hence $\\min_{p\\ \\text{monic},\\deg p=n}\\|p\\|_{\\infty,[-1,1]}=2^{1-n}$, attained by $M_n$."
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes, axiom-free and sorry-free, the analytic core and the achievability (upper) half of the classical Chebyshev minimax theorem. From the single De Moivre identity Tₙ(cos θ) = cos(nθ) it derives the sup-norm envelope |Tₙ| ≤ 1 on [-1,1] and the equioscillation values Tₙ(cos(kπ/n)) = (-1)^k at the n+1 extreme nodes. It then supplies the degree and leading-coefficient infrastructure that Mathlib lacks — natDegree(Tₙ) = n and leadingCoeff(Tₙ) = 2^(n-1) — via a paired induction over the second-order recurrence, and assembles the monic Chebyshev polynomial Tₙ/2^(n-1), proving it is monic of degree n with sup-norm ≤ 2^(1-n) and equioscillation between ±2^(1-n).",
-    "implications": "Demonstrates that a monic degree-n real polynomial with sup-norm exactly 2^(1-n) on [-1,1] exists — the achievability witness the minimax theorem requires. The degree and leading-coefficient lemmas fill a documented gap in Mathlib's Chebyshev file (which lists 'minimax properties' and 'zeroes and extrema' as open TODOs) and are reusable, upstreamable infrastructure for any further Chebyshev development. The equioscillation envelope proved here is the exact mechanism that drives the matching lower bound.",
+    "summary": "This formalization establishes, axiom-free and sorry-free, the full classical Chebyshev minimax theorem. From the single De Moivre identity Tₙ(cos θ) = cos(nθ) it derives the sup-norm envelope |Tₙ| ≤ 1 on [-1,1] and the equioscillation values Tₙ(cos(kπ/n)) = (-1)^k at the n+1 extreme nodes. It supplies the degree and leading-coefficient infrastructure that Mathlib lacks — natDegree(Tₙ) = n and leadingCoeff(Tₙ) = 2^(n-1) — via a paired induction over the second-order recurrence, and assembles the monic Chebyshev polynomial Tₙ/2^(n-1), proving it is monic of degree n with sup-norm ≤ 2^(1-n) and equioscillation between ±2^(1-n) (achievability). It then proves the optimality half (monicChebyshev_minimax): every monic degree-n polynomial attains |p| ≥ 2^(1-n) somewhere on [-1,1], by turning the strict sign alternation of q = Mₙ − p at the n+1 nodes into n distinct interior roots (intermediate value theorem) that contradict the degree drop deg q < n. The capstone chebyshev_minimax bundles both halves.",
+    "implications": "Proves the complete minimax statement: the monic Chebyshev polynomial Tₙ/2^(n-1) minimizes the sup-norm on [-1,1] among all monic degree-n real polynomials, with minimal value exactly 2^(1-n). The degree and leading-coefficient lemmas fill a documented gap in Mathlib's Chebyshev file (which lists 'minimax properties' and 'zeroes and extrema' as open TODOs) and, together with the minimax theorem itself, are reusable, upstreamable infrastructure for approximation theory.",
     "openQuestions": [
-      "Prove the matching lower bound: every monic degree-n real polynomial has sup-norm ≥ 2^(1-n) on [-1,1], via the alternation→root-counting argument (a competitor with smaller sup-norm forces too many sign changes of the difference Mₙ − competitor across the n+1 nodes, exceeding its degree).",
-      "Combine the two halves into the full Chebyshev minimax / equioscillation theorem with uniqueness of the optimal monic polynomial.",
-      "Upstream natDegree(Tₙ) = n and leadingCoeff(Tₙ) = 2^(n-1) to Mathlib's RingTheory/Polynomial/Chebyshev.lean, closing the listed TODOs.",
+      "Strengthen optimality to uniqueness: Tₙ/2^(n-1) is the *unique* monic degree-n minimizer (equality in the equioscillation argument forces the competitor to coincide with Mₙ).",
+      "Upstream natDegree(Tₙ) = n, leadingCoeff(Tₙ) = 2^(n-1), and the minimax theorem to Mathlib's RingTheory/Polynomial/Chebyshev.lean, closing the listed TODOs.",
       "Extend to the second-kind Chebyshev polynomials Uₙ and the corresponding L¹/weighted extremal problems."
     ]
   },
@@ -131,9 +144,9 @@
       "Real"
     ],
     "namespace": "DeMoivreOQ0203",
-    "lineCount": 200,
+    "lineCount": 378,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 15,
     "definitionCount": 1,
     "path": "Proofs/DeMoivreOQ02OQ03.lean",
     "sorries": 0,
@@ -157,78 +170,17 @@
         "name": "monicChebyshev_monic",
         "statement": "∀ (n : ℕ), 0 < n → (monicChebyshev n).Monic",
         "description": "The monic Chebyshev polynomial Tₙ/2^(n-1) is monic"
+      },
+      {
+        "name": "monicChebyshev_minimax",
+        "statement": "∀ (p : ℝ[X]), p.Monic → ∀ (n : ℕ), 0 < n → p.natDegree = n → ∃ x ∈ Set.Icc (-1 : ℝ) 1, ((2 : ℝ) ^ (n - 1))⁻¹ ≤ |p.eval x|",
+        "description": "Optimality (lower-bound) half: every monic degree-n polynomial attains |p| ≥ 2^(1-n) somewhere on [-1,1]"
+      },
+      {
+        "name": "chebyshev_minimax",
+        "statement": "∀ (n : ℕ), 0 < n → (∀ x ∈ Set.Icc (-1 : ℝ) 1, |(monicChebyshev n).eval x| ≤ ((2 : ℝ) ^ (n - 1))⁻¹) ∧ (∀ p : ℝ[X], p.Monic → p.natDegree = n → ∃ x ∈ Set.Icc (-1 : ℝ) 1, ((2 : ℝ) ^ (n - 1))⁻¹ ≤ |p.eval x|)",
+        "description": "Full Chebyshev minimax theorem: achievability ∧ optimality"
       }
-    ]
-  },
-  "overview": {
-    "historicalContext": "Chebyshev's 1854 theorem states that among all monic real polynomials of degree n, the rescaled Chebyshev polynomial Tₙ/2^(n-1) has the smallest possible maximum absolute value on [-1,1], namely 2^(1-n). The mechanism is equioscillation: Tₙ alternately attains +1 and -1 at the n+1 points cos(kπ/n), k = 0..n, so the monic normalization alternates between ±2^(1-n). Mathlib's RingTheory/Polynomial/Chebyshev.lean explicitly flags 'Prove minimax properties of Chebyshev polynomials' and 'Compute zeroes and extrema' as open TODOs, and provides no degree or leading-coefficient lemmas for Tₙ. This entry supplies that missing infrastructure and the achievability half of the theorem.",
-    "problemStatement": "**The Open Question**\n\nDoes the monic Chebyshev polynomial $M_n = T_n/2^{n-1}$ minimize the sup-norm on $[-1,1]$ among all monic degree-$n$ real polynomials, with minimal value $2^{1-n}$?\n\n**This entry's contribution**\n\nThe analytic core and the achievability (upper) half, fully verified:\n- $|T_n(x)| \\le 1$ on $[-1,1]$ with equioscillation $T_n(\\cos(k\\pi/n)) = (-1)^k$;\n- $\\deg T_n = n$ and $\\operatorname{lead} T_n = 2^{n-1}$ (new infrastructure);\n- $M_n$ is monic of degree $n$, has sup-norm $\\le 2^{1-n}$, and equioscillates between $\\pm 2^{1-n}$.\n\nThe matching lower bound (every monic degree-$n$ polynomial has sup-norm $\\ge 2^{1-n}$, by the alternation/root-counting argument) is the remaining open continuation.",
-    "text": "Builds the analytic core and the achievability (upper) half of the classical Chebyshev minimax theorem. From the De Moivre identity Tₙ(cos θ) = cos(nθ) it derives the sup-norm envelope |Tₙ(x)| ≤ 1 on [-1,1] and the equioscillation values Tₙ(cos(kπ/n)) = (-1)^k at the n+1 extreme nodes. It then supplies the degree infrastructure Mathlib lacks — natDegree Tₙ = n and leadingCoeff Tₙ = 2^(n-1), proved by a paired induction on the second-order recurrence T_{n+2} = 2X·T_{n+1} − Tₙ — and assembles the monic Chebyshev polynomial Mₙ = Tₙ/2^(n-1), showing it is monic of degree n, has sup-norm ≤ 2^(1-n) on [-1,1], and equioscillates between ±2^(1-n). The matching lower bound (every monic degree-n polynomial has sup-norm ≥ 2^(1-n)) is the stated open continuation. 0 sorries, 0 axioms over ℝ.",
-    "proofStrategy": "**De Moivre for the analysis core; two-step induction for the degree facts.**\n\n1. **Sup-norm bound** `chebyshev_abs_eval_le_one`: for $x \\in [-1,1]$ write $x = \\cos(\\arccos x)$; then $T_n(x) = \\cos(n\\arccos x)$ by `T_real_cos`, so $|T_n(x)| \\le 1$.\n2. **Equioscillation** `chebyshev_eval_node`: at $x_k = \\cos(k\\pi/n)$, $T_n(x_k) = \\cos(n \\cdot k\\pi/n) = \\cos(k\\pi) = (-1)^k$ (`cos_nat_mul_pi`).\n3. **Degree infrastructure** `chebyshev_deg_lead_pair`: a single induction over the paired statement for $T_{n+1}, T_{n+2}$, driven by $T_{n+2} = 2X T_{n+1} - T_n$. The recurrence step `deg_lead_recurrence_step` shows $\\deg(2Xa - b) = d+1$ and $\\operatorname{lead}(2Xa - b) = 2c$ when $\\deg a = d$, $\\operatorname{lead} a = c \\ne 0$, $\\deg b \\le d$ (the $-b$ term is below the top degree, so it does not perturb the leading coefficient).\n4. **Monic normalization** `monicChebyshev` $= C(2^{n-1})^{-1} \\cdot T_n$: monicity and degree follow from the leading-coefficient and degree facts; the sup-norm bound and equioscillation follow by scaling the core results.",
-    "keyInsights": [
-      "**De Moivre is the whole analytic story**: the single identity $T_n(\\cos\\theta) = \\cos(n\\theta)$ delivers both the envelope bound $|T_n| \\le 1$ and the equioscillation values $(-1)^k$ at $\\cos(k\\pi/n)$ — no calculus of extrema needed.",
-      "**Degree facts need a paired induction**: the Chebyshev recurrence is second-order, so degree $n$ and leading coefficient $2^{n-1}$ must be carried for two consecutive indices simultaneously; the single recurrence step is isolated as a reusable lemma.",
-      "**The subtraction is harmless to the top**: in $T_{n+2} = 2X T_{n+1} - T_n$, the subtracted $T_n$ has degree $n < n+2$, so `leadingCoeff_sub_of_degree_lt` keeps the leading coefficient equal to that of $2X T_{n+1}$, doubling it each step to give $2^{n-1}$.",
-      "**Mathlib gap**: there are no `natDegree`/`leadingCoeff` lemmas for `Polynomial.Chebyshev.T`; this file derives them and they are candidates for upstreaming (the Chebyshev file lists exactly these as TODOs).",
-      "**Achievability vs. minimality**: equioscillation between $\\pm 2^{1-n}$ at $n+1$ nodes is the engine of *both* halves of the minimax theorem; this entry completes the upper (achievability) half, leaving the alternation→root-counting lower bound as the open continuation."
-    ],
-    "prerequisites": [
-      "De Moivre identity Tₙ(cos θ) = cos(nθ) (T_real_cos) and arccos as a right inverse of cos on [-1,1]",
-      "Chebyshev recurrence T_add_two: T_{n+2} = 2X·T_{n+1} − Tₙ",
-      "Polynomial.natDegree / leadingCoeff API (natDegree_mul, leadingCoeff_sub_of_degree_lt)",
-      "induction with a strengthened (paired) motive for second-order recurrences",
-      "Real.cos_nat_mul_pi: cos(kπ) = (-1)^k"
-    ]
-  },
-  "sections": [
-    {
-      "id": "overview",
-      "title": "Overview and Research Question",
-      "startLine": 1,
-      "endLine": 43,
-      "summary": "Module docstring posing the classical Chebyshev minimax / equioscillation question — among monic degree-n real polynomials, Mₙ = Tₙ/2^(n-1) minimizes the sup-norm on [-1,1] with value 2^(1-n) — and stating what this entry contributes: the analysis core, the missing degree/leading-coefficient infrastructure, and the achievability half. Notes Mathlib's explicit TODO flag for Chebyshev minimax properties.",
-      "mathContext": "Target: $\\min_{p\\ \\text{monic},\\ \\deg p=n}\\ \\|p\\|_{\\infty,[-1,1]} = 2^{1-n}$, attained by $M_n=T_n/2^{n-1}$. This file proves the upper (achievability) half and the supporting envelope, degree, and equioscillation facts."
-    },
-    {
-      "id": "analysis-core",
-      "title": "Part I: Sup-norm bound and equioscillation",
-      "startLine": 45,
-      "endLine": 72,
-      "summary": "The De Moivre analysis core: chebyshev_abs_eval_le_one proves |Tₙ(x)| ≤ 1 on [-1,1] by writing x = cos(arccos x) and using Tₙ(cos θ) = cos(nθ); chebyshev_eval_node proves the equioscillation Tₙ(cos(kπ/n)) = (-1)^k via cos(kπ) = (-1)^k; chebyshev_eval_one records the sharp endpoint value Tₙ(1) = 1.",
-      "mathContext": "$|T_n(x)|=|\\cos(n\\arccos x)|\\le 1$, with equality at $x_k=\\cos(k\\pi/n)$ where $T_n(x_k)=\\cos(k\\pi)=(-1)^k$ for $k=0,\\dots,n$."
-    },
-    {
-      "id": "recurrence-step",
-      "title": "Part II-a: One recurrence step on degree and leading coefficient",
-      "startLine": 74,
-      "endLine": 105,
-      "summary": "deg_lead_recurrence_step isolates exactly what one application of T_{n+2} = 2X·T_{n+1} − Tₙ does: given deg a = d, lead a = c ≠ 0, deg b ≤ d, the polynomial 2X·a − b has degree d+1 and leading coefficient 2c. The subtracted term sits strictly below the top degree, so natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_sub_of_degree_lt leave both unchanged.",
-      "mathContext": "$\\deg(2Xa-b)=d+1$ and $\\operatorname{lead}(2Xa-b)=2c$ whenever $\\deg a=d,\\ \\operatorname{lead}a=c\\ne0,\\ \\deg b\\le d$. Iterating doubles the leading coefficient to $2^{n-1}$."
-    },
-    {
-      "id": "degree-facts",
-      "title": "Part II-b: Paired induction and the degree/leading-coefficient facts",
-      "startLine": 107,
-      "endLine": 166,
-      "summary": "chebyshev_deg_lead_pair carries the degree/leading-coefficient statement for two consecutive indices through one induction driven by the recurrence; the scalar theorems chebyshev_natDegree (= n) and chebyshev_leadingCoeff (= 2^(n-1)) project out a component and rebase the index. These fill a documented Mathlib gap.",
-      "mathContext": "$\\deg T_n=n$, $\\operatorname{lead}T_n=2^{n-1}$ ($n\\ge1$): $T_n(x)=2^{n-1}x^n+\\text{lower order}$."
-    },
-    {
-      "id": "monic-achievability",
-      "title": "Part III: Monic Chebyshev polynomial and achievability",
-      "startLine": 168,
-      "endLine": 200,
-      "summary": "Defines monicChebyshev n = Tₙ/2^(n-1) and proves the achievability half: monicChebyshev_monic (monic), monicChebyshev_natDegree (degree n), monicChebyshev_abs_le (sup-norm ≤ 2^(1-n) on [-1,1]) and monicChebyshev_eval_node (equioscillates between ±2^(1-n) at the n+1 nodes). These scale the Part I bounds by the inverse leading coefficient from Part II.",
-      "mathContext": "$M_n=T_n/2^{n-1}$ is monic of degree $n$, $\\|M_n\\|_{\\infty,[-1,1]}\\le 2^{1-n}$, and $M_n(\\cos(k\\pi/n))=(-1)^k2^{1-n}$ — the equioscillation certificate of the minimax polynomial."
-    }
-  ],
-  "conclusion": {
-    "summary": "Proves 11 theorems and 1 definition with 0 sorries and 0 axioms over ℝ, establishing three things the classical Chebyshev minimax theorem needs: (1) the De Moivre analysis core |Tₙ| ≤ 1 with equioscillation Tₙ(cos(kπ/n)) = (-1)^k; (2) the degree facts natDegree Tₙ = n and leadingCoeff Tₙ = 2^(n-1), absent from Mathlib; and (3) the achievability half — the monic polynomial Mₙ = Tₙ/2^(n-1) is monic of degree n, has sup-norm ≤ 2^(1-n) on [-1,1], and equioscillates between ±2^(1-n).",
-    "implications": "**Significance**\n\n1. **Mathlib gap filled**: Mathlib's RingTheory/Polynomial/Chebyshev.lean lists 'Compute zeroes and extrema' and 'Prove minimax properties of Chebyshev polynomials' as open TODOs and provides no natDegree/leadingCoeff lemmas for Tₙ. chebyshev_natDegree and chebyshev_leadingCoeff are clean upstreaming candidates.\n\n2. **De Moivre is the whole analytic story**: the single identity Tₙ(cos θ) = cos(nθ) yields both the envelope and the alternation, with no calculus of extrema.\n\n3. **Reusable recurrence infrastructure**: deg_lead_recurrence_step packages the degree/leading-coefficient behaviour of any second-order recurrence p_{n+2} = 2X·p_{n+1} − pₙ, reusable beyond Chebyshev.\n\n4. **Equioscillation certificate**: the alternation between ±2^(1-n) at n+1 nodes is exactly the engine that, paired with the lower bound, proves minimality.",
-    "openQuestions": [
-      "The matching lower bound: every monic degree-n real polynomial has sup-norm ≥ 2^(1-n) on [-1,1], via the alternation → root-counting argument (if some monic p had smaller sup-norm, Mₙ − p would change sign at the n+1 equioscillation nodes, forcing n roots in a degree < n difference — a contradiction). Combining it with this entry's achievability half yields the full minimax theorem.",
-      "Uniqueness of the minimax polynomial: Mₙ is the unique monic degree-n polynomial attaining 2^(1-n), again from the equioscillation/root-counting argument.",
-      "Upstreaming chebyshev_natDegree and chebyshev_leadingCoeff to Mathlib, closing part of the Chebyshev TODO list."
     ]
   },
   "relatedProblems": [

--- a/src/data/research/problems/de-moivre-oq-02-oq-03.json
+++ b/src/data/research/problems/de-moivre-oq-02-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "de-moivre-oq-02-oq-03",
   "title": "Minimax Property of Chebyshev Polynomials",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "C",
   "path": "full",
@@ -16,24 +16,38 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-06-18T23:18:44-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "phase": "ACT",
+    "since": "2026-06-19T01:45:00-07:00",
+    "iteration": 2,
+    "focus": "Both halves of the Chebyshev minimax theorem formalized in proofs/Proofs/DeMoivreOQ02OQ03.lean: achievability (monicChebyshev sup-norm ≤ 2^(1-n), equioscillation) and optimality (monicChebyshev_minimax: every monic degree-n p attains |p| ≥ 2^(1-n) somewhere). Capstone chebyshev_minimax bundles both. 0 sorry / 0 axiom.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Docker build verification of Proofs.DeMoivreOQ02OQ03, then ship PR.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "Full Chebyshev minimax theorem formalized (both halves), 0 sorry / 0 axiom. chebyshev_minimax = achievability (monicChebyshev_abs_le) ∧ optimality (monicChebyshev_minimax).",
+    "builtItems": [
+      "monicChebyshev_minimax (DeMoivreOQ02OQ03.lean Part IV): optimality/lower-bound half — every monic degree-n p has |p| ≥ 2^(1-n) somewhere on [-1,1]",
+      "chebyshev_minimax (DeMoivreOQ02OQ03.lean): full minimax theorem = achievability ∧ optimality",
+      "node_strict_anti / node_anti: strict/non-strict monotonicity of the extreme nodes cos(kπ/n) in k"
+    ],
+    "insights": [
+      "Optimality half = classical equioscillation argument: if monic p had ‖p‖∞<2^(1-n) on [-1,1], then q=Mₙ-p inherits the sign of Mₙ at the n+1 extreme nodes cos(kπ/n) (strict alternation (-1)^k·q(node)>0), giving by IVT a root strictly between each consecutive node pair = n distinct roots; but deg q < n (difference of two monic degree-n polys via degree_sub_lt), contradicting card_roots'.",
+      "Lean trick to avoid parity case-explosion in the IVT step: intermediate_value_uIcc works on the unordered interval, so with Set.mem_uIcc_of_le/_of_ge a single Nat.even_or_odd split suffices to place 0 between the two node values.",
+      "Roots are strictly interior (open intervals) because q is nonzero at the nodes themselves, so the n chosen roots are distinct via StrictAnti (node_strict_anti: cos(kπ/n) strictly decreasing in k), hence the selection map is injective."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks the Chebyshev minimax theorem and the natDegree/leadingCoeff lemmas for Tₙ; this file now supplies both halves plus that infrastructure. The TODO in Mathlib/RingTheory/Polynomial/Chebyshev.lean ('Prove minimax properties of Chebyshev polynomials') remains open upstream."
+    ],
+    "nextSteps": [
+      "Upstream the degree/leadingCoeff infrastructure and the minimax theorem to Mathlib (fills the explicit TODO).",
+      "Follow-up OQ: uniqueness of the minimizer — Mₙ is the *unique* monic degree-n polynomial attaining 2^(1-n) (equioscillation forces equality).",
+      "Follow-up OQ: weighted / L^p Chebyshev minimax variants and the second-kind polynomials Uₙ."
+    ],
     "markdown": "# Knowledge Base: de-moivre-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

Completes the classical **Chebyshev minimax theorem** in `proofs/Proofs/DeMoivreOQ02OQ03.lean` by adding the **optimality (lower-bound) half**, so the full theorem (both halves) is now formalized — **0 sorries, 0 axioms** over ℝ.

Previously this entry proved the analysis core (De Moivre envelope + equioscillation), the degree/leading-coefficient infrastructure Mathlib lacks, and the *achievability* half (Mₙ has sup-norm ≤ 2^(1-n)). This PR adds the matching optimality bound and the capstone.

## New results (Part IV)

- **`node_strict_anti` / `node_anti`** — strict / non-strict monotonicity of the extreme nodes `cos(kπ/n)` in `k` (via `Real.strictAntiOn_cos`).
- **`monicChebyshev_minimax`** — every monic degree-`n` real polynomial attains `|p(x)| ≥ 2^(1-n)` somewhere on `[-1,1]`. Classical equioscillation argument: if a monic `p` had sup-norm `< 2^(1-n)`, then `q = Mₙ − p` inherits the strict sign alternation of `Mₙ` at the `n+1` nodes (`(-1)^k · q(node) > 0`), so the intermediate value theorem yields a root strictly inside each of the `n` consecutive-node intervals; `node_strict_anti` makes the root-selection map `StrictAnti` (hence injective → `n` distinct roots), but `q` is a difference of two monic degree-`n` polynomials so `deg q < n` (`degree_sub_lt`) — contradicting `card_roots'`.
- **`chebyshev_minimax`** — capstone bundling achievability (`monicChebyshev_abs_le`) ∧ optimality, so `Mₙ = Tₙ/2^(n-1)` is a sup-norm minimizer with minimal value exactly `2^(1-n)`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.DeMoivreOQ02OQ03` → **GREEN (7743 jobs)**, build log free of sorry/axiom/warning. File: 15 theorems, 1 definition, 0 sorry, 0 `axiom`, 0 `native_decide`.

## Metadata

- `meta.json`: `status: verified` / `badge: original` / `axiomCount: 0`; `theoremCount` 11→15, `lineCount` 200→378; title/description/overview/sections (added the optimality section)/conclusion updated for the full theorem. Removed stale **duplicate** `overview`/`sections`/`conclusion` keys (the enrichment merge had appended rather than replaced).
- Research tracker advanced to `ACT` with both-halves completion knowledge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)