### PR TITLE
audit(cramers-rule): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2194,8 +2194,8 @@
     },
     "cramers-rule": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T00:00:00Z",
       "result": "clean"
     },
     "cramers-rule-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — cramers-rule

**Result: CLEAN** ✓ (re-audit, auditCount 3→4)

Cramer's Rule (Wiedijk #97), `status: verified` / `badge: mathlib`.

### Verification (Lean source vs meta.json)
| Check | meta.json | Lean file | Match |
|-------|-----------|-----------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (`axiom` decls) + 0 struct fields | ✓ |
| True stubs | — | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| theoremCount | 9 | 9 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| lineCount | 161 | 161 | ✓ |

### Tier classification: B (Mathlib-derived) — correctly labeled
- Core results (`cramer_component`, `cramers_rule`, `cramer_eq_adjugate_mulVec`, `adjugate_mul_self`, `cramer_transpose`, linearity) are thin wrappers over `Matrix.cramer_apply`, `Matrix.mulVec_cramer`, `Matrix.cramer_eq_adjugate_mulVec`, `Matrix.mul_adjugate`, `LinearMap` API.
- Badge `mathlib` is correct; `originalContributions` honestly tag `(curated)` (Mathlib) vs `(original)` — the genuinely original bits are `cramers_rule_solution` (small `rw` derivation) and the 2×2 field `example`.
- Overview/conclusion repeatedly credit "via Mathlib's X" and "building on Mathlib's matrix adjugate infrastructure" → **no delegation opacity**.

### Narrative failure modes — none present
No axiom masking (0 axioms), no inequality-≠-theorem, no pipeline inflation, no "0 sorries with hidden imports" overclaim (badge is `mathlib`, not `original`). The overview explicitly notes "a separate uniqueness theorem is not formalized" — conservative scoping.

---
Durable tracker bump only (`src/data/proofs/audit-tracker.json`). No content changes.
🤖 Generated with [Claude Code](https://claude.com/claude-code)