### PR TITLE
audit(continuum-hypothesis): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2175,9 +2175,9 @@
       "result": "issues-fixed"
     },
     "continuum-hypothesis": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-reaudit-20260619",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T00:00:00Z",
       "result": "clean"
     },
     "continuum-hypothesis-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: continuum-hypothesis

**Result: CLEAN** ✓ (auditCount 3 → 4)

Re-audited **Independence of the Continuum Hypothesis** (Wiedijk #24 / Hilbert #1, Gödel 1940 + Cohen 1963). meta.json claims match `proofs/Proofs/ContinuumHypothesis.lean`.

### Verification
| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 4 | 4 axiom decls | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| theoremCount | 8 | 8 | ✓ |
| definitionCount | 12 | 12 | ✓ |
| status / badge | axiomatized / axiom | correct for independence result | ✓ |

The 4 load-bearing axioms (`L_exists`, `L_satisfies_CH`, `forcing_extension_exists`, `forcing_violates_CH`) stand in for the deep metamathematical constructions (constructible universe L; Cohen forcing) and are honestly disclosed in `assumptions`.

### Honest scaffolding (no overclaim)
- The `: True` fields in `ZFC`/`ZFCModel`/`ConstructibleUniverse`/`ForcingExtension` and the `holds_CH := True` / `holds_notCH := True` predicates are trivially-satisfiable placeholders, **not** counted as assumptions. `mainTheorems` explicitly labels them "placeholders standing in for the deep metamathematical constructions" and describes `continuum_hypothesis_independent` as the "scaffolded model-existence form" — conservative framing, no overclaim.
- `ch_equiv_ch_alt` is claimed "genuinely proved from Mathlib cardinal arithmetic, no axioms" — **verified accurate**: `ch_implies_no_intermediate` / `no_intermediate_implies_ch` are real proofs via `Cardinal.aleph_succ`, `Order.succ_le_of_lt`, `Cardinal.cantor` (previously axioms, now discharged). `cantor_theorem` and `gch_implies_ch` likewise genuinely proved.

No True-stub-as-verified, no sorry mismatch, no Mathlib-wrapper-as-original, no axiom undercount.

---
Discovered during periodic gallery integrity audit (saturated gallery, 2554/2554; stalest 3 targets had open audit PRs and were skipped).