### PR TITLE
audit(cevas-theorem): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1965,8 +1965,8 @@
     },
     "cevas-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T09:15:37Z",
       "result": "clean"
     },
     "cevas-theorem-non-euclidean": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: cevas-theorem

**Result: CLEAN** ✓

Re-audited Ceva's Theorem (Wiedijk #61) against `proofs/Proofs/CevasTheorem.lean`.

### Verification
| Claim | meta.json | Source | Match |
|-------|-----------|--------|-------|
| lineCount | 263 | 264 (trailing blank) | ✓ |
| theoremCount | 8 | 8 | ✓ |
| definitionCount | 4 | 4 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no `axiom`, no `native_decide`) | ✓ |

### Integrity notes
- **No True stubs**, no inequality-as-theorem inflation, no pipeline inflation.
- Main theorem `cevas_theorem` is a genuine algebraic proof (`field_simp` + `linarith`), **not** a Mathlib wrapper of a deep theorem. `mathlibDependencies` honestly lists only real arithmetic. Badge `original` appropriate.
- **Honest scoping**: description and `mainTheorems` explicitly state only the algebraic equivalence (`cevaProduct = 1 ↔ parameter condition`) is formalized; geometric concurrency is disclosed as commentary-only, not formalized. No delegation opacity or axiom masking.
- Structure `CevianConfig` fields (`d_ne_0`, `d_ne_1`, …) are definitional non-degeneracy constraints, not load-bearing assumptions → axiomCount 0 correct.

Status `verified` / badge `original` accurate. `auditCount` 3→4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)