### PR TITLE
audit(cantors-theorem): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1515,9 +1515,9 @@
       "result": "clean"
     },
     "cantors-theorem": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "agentId": "auditor-reaudit-20260619",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T09:25:00Z",
       "result": "clean"
     },
     "cantors-theorem-oq-01": {


### PR DESCRIPTION
## Re-audit: cantors-theorem (Cantor's Theorem, Wiedijk #63)

**Result: CLEAN** — `auditCount` 3 → 4.

### Verification
| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 157 | 157 | ✓ |
| theoremCount | 7 | 7 | ✓ |
| definitionCount | 1 | 1 (`diagonalSet`) | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True-stubs | — | 0 | ✓ |

### Integrity assessment
- **status `verified` / badge `mathlib`** — correct. The main theorem `cantor_no_surjection` delegates to Mathlib's `Function.cantor_surjective` (Tier B), while the Set formulation `cantor_no_surjection_set` is genuinely proved in-file via the diagonal construction `D = {x | x ∉ f x}`.
- **`originalContributions` / `assumptions`** honestly disclose the Mathlib delegation alongside the original diagonal construction and pedagogical corollaries. No delegation opacity.
- **Minor (non-blocking):** `mainTheorems` lists name `cantor_theorem` where the in-file theorem is `cantor_no_surjection_set`, and uses `alpha` ASCII notation — cosmetic, not an integrity overclaim.

No overclaim detected. Durable tracker bump only; no source or meta changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)