### PR TITLE
audit(buffons-needle): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1340,8 +1340,8 @@
     },
     "buffons-needle": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T09:26:10Z",
       "result": "clean"
     },
     "buffons-needle-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: buffons-needle

**Result: CLEAN** ✓ (auditCount 3→4)

Re-audited **Buffon's Needle Problem** (Wiedijk #99) against `proofs/Proofs/BuffonsNeedle.lean`.

### Integrity checks (all pass)

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 266 | 266 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 literal axioms | ✓ |
| native_decide | — | 0 | ✓ |
| theoremCount | 9 | 9 | ✓ |
| definitionCount | 3 | 3 | ✓ |
| True stubs | — | 0 | ✓ |
| structures (encoded assumptions) | — | 0 | ✓ |

### Notes

- **Badge `mathlib` is correct.** The computational core, `∫₀^π sin θ = 2`, comes from Mathlib's `integral_sin`; the file contributes the geometric model (`crossingRegion`/`sampleSpace`), the bridge, and the closed-form algebra. Not presented as an independent proof.
- **Exemplary honest scoping.** The meta repeatedly discloses (in `assumptions`, `overview.text`, `keyInsights`, and the `main-theorem` section) that `P = 2ℓ/(πd)` is **modeled geometrically, not derived measure-theoretically** — no probability measure or random variable is formalized. This directly avoids the inequality≠theorem / delegation-opacity overclaim traps.
- `long_needle_remark` (L221) proves `(1:ℕ)+1=2 := rfl` — an honestly-labeled placeholder ("stated as a remark without proof", "beyond our current scope"), non-load-bearing; 8/9 theorems are genuine. Conservative → CLEAN.

Durable tracker bump only; no source or meta changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)