### PR TITLE
audit(erdos-1107): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3871,9 +3871,9 @@
       "result": "clean"
     },
     "erdos-1107": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "agentId": "auditor-reaudit-20260619",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T10:05:00Z",
       "result": "clean"
     },
     "erdos-1107-oq-02": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-1107

**Result: CLEAN** — meta.json claims match Lean source (`Proofs/Erdos1107Problem.lean`, 172L).

### Checks
| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 literal (`erdos_1107`) | ✓ |
| theoremCount | 12 | 12 | ✓ |
| definitionCount | 2 | 2 | ✓ |
| lineCount | 172 | 172 | ✓ |
| True stubs | — | 0 | ✓ |
| status/badge | axiomatized/axiom | open conjecture axiomatized | ✓ |

### Notes
- **Tier C (axiomatized), honest.** The general conjecture (open for r>2) is an explicit `axiom erdos_1107`; title is a question with no "proved"/"solved" overclaim.
- **Heath-Brown r=2** (`erdos_1107_squareful`) is honestly derived as a corollary of the general axiom — docstring and `assumptions` field disclose this; no independent-proof overclaim.
- **native_decide (8 uses)** appear only on concrete demonstration examples (isFull_four/eight/nine/thirtySix, sum_example_13/17), not the substantive result. Status is axiomatized/axiom, so `Lean.ofReduceBool` need not be counted.
- Cosmetic nit (not an issue): `originalContributions` still says "Heath-Brown's theorem for r=2 as separate axiom" (stale — now a derived corollary). Conservative, no overclaim.

Durable tracker bump: auditCount 3→4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)