### PR TITLE
audit(erdos-110): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3808,9 +3808,9 @@
       "result": "clean"
     },
     "erdos-110": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "agentId": "auditor-reaudit-20260619",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T00:00:00Z",
       "result": "clean"
     },
     "erdos-110-oq-03": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-110

**Result: CLEAN** — all public claims match the Lean kernel.

Erdős Problem #110 (chromatic number growth in uncountable graphs; Erdős–Hajnal–Szemerédi conjecture, DISPROVED by Lambie-Hanson 2020 in ZFC).

### Verification (`proofs/Proofs/Erdos110Problem.lean`)
| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 literal | ✓ |
| theoremCount | 8 | 8 | ✓ |
| definitionCount | 15 | 15 | ✓ |
| native_decide | — | 0 (no `ofReduceBool`) | ✓ |
| True stubs | — | 0 | ✓ |

### Tier & narrative
- **Tier C (axiomatized)** — `status: axiomatized`, `badge: axiom` correct. The disproof (`erdos_110_disproved`) is honestly derived from the disclosed `lambie_hanson_counterexample` axiom; no "verified" overclaim.
- All 3 axioms (`de_bruijn_erdos`, `lambie_hanson_counterexample`, `graph_compactness`) disclosed in `assumptions`, including the note that a prior unsound compactness variant was removed.
- No axiom masking, no inequality-as-theorem, no pipeline inflation.

auditCount 3→4. Durable tracker bump only; no content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)