### PR TITLE
audit(erdos-109): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3701,8 +3701,8 @@
     },
     "erdos-109": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T09:45:00Z",
       "result": "clean"
     },
     "erdos-109-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit — erdos-109 (Erdős Sumset Conjecture, Moreira–Richter–Robertson 2019)

**Result: CLEAN** ✓ — claims match Lean source exactly; deep theorem honestly axiomatized, no overclaim.

### Verification (`proofs/Proofs/Erdos109Problem.lean`, 437 lines)
| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`moreira_richter_robertson`) | ✓ |
| native_decide | — | 0 → axiomCount stays 1 | ✓ |
| True stubs | — | 0 | ✓ |
| theoremCount | 13 | 13 | ✓ |
| definitionCount | 9 | 9 | ✓ |
| status / badge | axiomatized / axiom | correct for axiomatized deep result | ✓ |

### Tier classification: **Tier C (axiomatized)** — correct
- The 2019 MRR theorem is the single `axiom moreira_richter_robertson : ErdosSumsetConjecture`. `erdos_109_solved := moreira_richter_robertson` transparently restates the axiom — no hidden delegation.
- `assumptions` field and `originalContributions` openly disclose the axiomatization ("Axiomatization of the Moreira-Richter-Robertson theorem"). No axiom masking.
- Genuinely-proved content (density framework `lowerDensity_le_upperDensity`, sumset commutativity, consequence `posUpperDensity_infinite`, even-numbers example) matches the listed contributions.
- `StrongerSumsetConjecture` is an unproved `Prop` **definition** only — not asserted as a theorem; no inflation.

Durable tracker bump: auditCount 3→4.

---
Discovered during gallery integrity audit loop.