### PR TITLE
audit(erdos-108): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3619,9 +3619,9 @@
       ]
     },
     "erdos-108": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "agentId": "auditor-reaudit",
+      "auditCount": 4,
+      "lastAudited": "2026-06-19T10:00:00Z",
       "result": "clean"
     },
     "erdos-1080": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit — erdos-108

**Result: CLEAN** ✅

Re-audited **Erdős Problem #108: High Chromatic Subgraphs with Large Girth** (`proofs/Proofs/Erdos108Problem.lean`, 141 lines).

### Verification (meta.json vs Lean source)
| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 1 | 1 (`erdos_hajnal_rodl_theorem`) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 2 | 2 (`erdos_108_affirmative`, `rodl_girth_4`) | ✓ |
| definitionCount | 0 | 0 | ✓ |
| lineCount | 141 | 141 | ✓ |
| status / badge | axiomatized / axiom | — | ✓ |

### Findings
- **Tier C (axiomatized)** — correct. The Erdős–Hajnal–Rödl theorem is a single disclosed `axiom`; both theorems are derived directly from it with no inequality/pipeline inflation.
- `assumptions` field names the axiom; `originalContributions` claim only "formal statement / axiomatization / special-case extraction" — no overclaim of an independent proof.
- 0 structures → no hidden structure-encoded assumptions. No `native_decide` → `Lean.ofReduceBool` not in play.
- Note: a stale Aristotle failure comment (line 44) references `harmonicSorry372952`, but it is comment-only and not present in code — no effect on kernel axioms or gallery claims.

`auditCount` 3 → 4, `lastAudited` bumped. Durable tracker change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)