### PR TITLE
research(erdos-mordell-oq-01): prove Thales cornerstone + isolate chord identity into two named targets

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2310,6 +2310,7 @@ import Proofs.Erdos999Problem
 import Proofs.Erdos99Problem
 import Proofs.Erdos9Problem
 import Proofs.ErdosKoRado
+import Proofs.ErdosMordellChordIdentity
 import Proofs.ErdosMordellChordReduction
 import Proofs.ErdosMordellInequalityOQ01
 import Proofs.ErdosSzekeres

--- a/proofs/Proofs/ErdosMordellChordIdentity.lean
+++ b/proofs/Proofs/ErdosMordellChordIdentity.lean
@@ -1,0 +1,210 @@
+/-
+# Erdős–Mordell: the pedal-feet chord identity (companion decomposition)
+
+`ErdosMordellInequalityOQ01.lean` reduces the full Erdős–Mordell inequality to a
+single geometry-bearing obligation, `chord_identity` (consumed by the per-vertex
+key lemma `key_inequality_A` via the proved scalar lemma
+`key_inequality_of_chord_and_sines`), which needs exactly two facts about the
+concrete `EuclideanSpace ℝ (Fin 2)` configuration:
+
+* the **law of sines**, already in Mathlib
+  (`EuclideanGeometry.dist_div_sin_angle_eq_two_mul_circumradius`); and
+* the **pedal-feet chord identity** `chord_identity` below.
+
+This companion file isolates that remaining obligation as standalone, well-typed
+statements in raw Mathlib primitives, so they can be attacked (or submitted to
+Aristotle) independently of the clean, shipped main file. It deliberately does
+**not** touch `ErdosMordellInequalityOQ01.lean` and is not registered in
+`Proofs.lean`.
+
+Structure (see `research/erdos-mordell-chord-identity-strategy.md`):
+
+* `lineDist_eq_dist_pedalFoot` — `lineDist`↔orthogonal-projection bridge. **Proved.**
+* `angle_pedalFoot_eq_pi_div_two` (+ the `…_XY_at_X` / `…_ZX_at_X` specialisations) —
+  the Thales cornerstone `∠ P F W = π/2`: each pedal foot sees `XP` at a right angle.
+  **Proved** from `angle_self_orthogonalProjection`; this is the shared geometric
+  primitive that both remaining `sorry`s are built on.
+* `chord_length_eq` — sine side: `dist F_b F_c = dist X P · sin∠YXZ` (law of sines
+  on the pedal triangle). `sorry`.
+* `angle_at_P` — the single residual cosine-side geometric subfact:
+  `∠ F_b P F_c = π − ∠YXZ` (supplementary angle in the cyclic quadrilateral). `sorry`.
+* `chord_length_sq_eq_of_angle_at_P` — cosine side **reduced to `angle_at_P`** via the
+  pure law of cosines + bridge + `cos_pi_sub`. **Proved** (no `sorry`).
+* `chord_length_sq_eq` — cosine side: `dist F_b F_c ² = db² + dc² + 2·db·dc·cos∠YXZ`.
+  **Proved** from `angle_at_P` and the reduction above.
+* `chord_identity` — geometry-free combine of the two chord lemmas. **Proved**
+  modulo the two helpers.
+
+So the original single obligation is now split into exactly **two** residual
+geometric facts — the sine side `chord_length_eq` and the cosine-side
+supplementary angle `angle_at_P` — each cleanly isolated and independently
+attackable, joined by fully-proved algebraic reductions. NOTE: the
+`orthogonalProjection`-based `pedalFoot` def and the bridge lemma both supply the
+required `Nonempty ↥(affineSpan …)` instance explicitly (no global instance exists).
+-/
+import Mathlib
+
+open EuclideanGeometry Metric
+
+namespace ErdosMordellChord
+
+/-- Perpendicular distance from `P` to the line through `X` and `Y` (matches the
+`lineDist` of the main file: distance to the affine span). -/
+noncomputable def lineDist (P X Y : EuclideanSpace ℝ (Fin 2)) : ℝ :=
+  Metric.infDist P (affineSpan ℝ {X, Y})
+
+/-- The pedal foot: orthogonal projection of `P` onto line `XY`.
+
+`EuclideanGeometry.orthogonalProjection` takes a `[Nonempty ↥s]` instance argument,
+and there is no global `Nonempty` instance for an `affineSpan` (it is empty for `∅`),
+so we supply it explicitly here from `X ∈ affineSpan ℝ {X, Y}`. -/
+noncomputable def pedalFoot (P X Y : EuclideanSpace ℝ (Fin 2)) : EuclideanSpace ℝ (Fin 2) :=
+  haveI : Nonempty (↥(affineSpan ℝ ({X, Y} : Set (EuclideanSpace ℝ (Fin 2))))) :=
+    ⟨⟨X, subset_affineSpan ℝ {X, Y} (by simp)⟩⟩
+  (orthogonalProjection (affineSpan ℝ {X, Y}) P : EuclideanSpace ℝ (Fin 2))
+
+/-- **Bridge lemma (step 1 of the decomposition).** The perpendicular distance to
+the line `XY` equals the distance from `P` to its pedal foot. This rewrites the
+`infDist`-based `lineDist` into the projection form needed to reason about the
+right angles at the feet. Fully proved from
+`EuclideanGeometry.dist_orthogonalProjection_eq_infDist`. -/
+theorem lineDist_eq_dist_pedalFoot (P X Y : EuclideanSpace ℝ (Fin 2)) :
+    lineDist P X Y = dist P (pedalFoot P X Y) := by
+  haveI : Nonempty (↥(affineSpan ℝ ({X, Y} : Set (EuclideanSpace ℝ (Fin 2))))) :=
+    ⟨⟨X, subset_affineSpan ℝ {X, Y} (by simp)⟩⟩
+  unfold lineDist pedalFoot
+  exact (dist_orthogonalProjection_eq_infDist _ _).symm
+
+/-- **Right angle at the pedal foot (the Thales cornerstone).**
+
+The segment from `P` to its pedal foot `F = pedalFoot P X Y` on line `XY` is
+perpendicular to that line: for any point `W` lying on the line, the angle `∠ P F W`
+at the foot is a right angle. This is the single geometric primitive underlying both
+remaining obligations — each foot `F_b = pedalFoot P Z X`, `F_c = pedalFoot P X Y`
+sees the segment `XP` at a right angle (take `W = X`, which lies on both lines `ZX`
+and `XY`), so by Thales the two feet are concyclic with `X` and `P` on the circle of
+diameter `XP`. From that one circle both `chord_length_eq` (law of sines) and
+`angle_at_P` (inscribed/supplementary angle) follow. Fully proved from
+`EuclideanGeometry.angle_self_orthogonalProjection`. -/
+theorem angle_pedalFoot_eq_pi_div_two
+    (P X Y W : EuclideanSpace ℝ (Fin 2))
+    (hW : W ∈ affineSpan ℝ ({X, Y} : Set (EuclideanSpace ℝ (Fin 2)))) :
+    ∠ P (pedalFoot P X Y) W = Real.pi / 2 := by
+  haveI : Nonempty (↥(affineSpan ℝ ({X, Y} : Set (EuclideanSpace ℝ (Fin 2))))) := ⟨⟨W, hW⟩⟩
+  unfold pedalFoot
+  exact angle_self_orthogonalProjection P hW
+
+/-- Specialisation of `angle_pedalFoot_eq_pi_div_two` to the shared vertex `X`: the
+foot `F_c = pedalFoot P X Y` sees `XP` at a right angle (`X` is the first generator of
+its line). -/
+theorem angle_pedalFoot_XY_at_X (P X Y : EuclideanSpace ℝ (Fin 2)) :
+    ∠ P (pedalFoot P X Y) X = Real.pi / 2 :=
+  angle_pedalFoot_eq_pi_div_two P X Y X (subset_affineSpan ℝ {X, Y} (by simp))
+
+/-- Specialisation to the other side meeting at `X`: the foot `F_b = pedalFoot P Z X`
+also sees `XP` at a right angle (`X` is the second generator of line `ZX`). Together
+with `angle_pedalFoot_XY_at_X` this places `F_b`, `F_c` on the circle of diameter
+`XP`. -/
+theorem angle_pedalFoot_ZX_at_X (P Z X : EuclideanSpace ℝ (Fin 2)) :
+    ∠ P (pedalFoot P Z X) X = Real.pi / 2 :=
+  angle_pedalFoot_eq_pi_div_two P Z X X (subset_affineSpan ℝ {Z, X} (by simp))
+
+/-- **Chord length (the "sine side", law of sines).**
+
+The chord joining the two pedal feet has length `dist X P · sin∠YXZ`. Proof path
+(see `research/erdos-mordell-chord-identity-strategy.md`, cycle-5 pin): the feet
+`F_b = pedalFoot P Z X` and `F_c = pedalFoot P X Y` see segment `XP` at a right
+angle, so by Thales they lie on `Sphere.ofDiameter X P` (circumradius `dist X P /2`).
+The law of sines on `△(X, F_b, F_c)` then gives
+`dist F_b F_c = 2·circumradius · sin(∠ F_b X F_c) = dist X P · sin(∠ F_b X F_c)`,
+and `∠ F_b X F_c = ∠ Y X Z` because each foot lies on the *positive ray* from `X`
+toward the adjacent vertex (interior point ⟹ foot on the open side; collapses via
+`InnerProductGeometry.angle_smul_left/right_of_pos`). Mathlib:
+`dist_div_sin_angle_eq_two_mul_circumradius`, `thales_theorem`,
+`eq_circumcenter_of_dist_eq`. -/
+theorem chord_length_eq
+    (X Y Z P : EuclideanSpace ℝ (Fin 2))
+    (hXYZ : AffineIndependent ℝ ![X, Y, Z])
+    (hP : P ∈ interior (convexHull ℝ {X, Y, Z})) :
+    dist (pedalFoot P Z X) (pedalFoot P X Y) = dist X P * Real.sin (∠ Y X Z) := by
+  sorry
+
+/-- **The single residual geometric subfact of the cosine side.**
+
+The angle subtended at `P` by the two pedal feet is supplementary to the
+triangle's angle at `X`. Geometrically: `F_b, F_c` and `X` are concyclic with `P`
+on the circle of diameter `XP` (Thales — both feet see `XP` at a right angle), and
+in that cyclic quadrilateral the angle at `P` and the angle at `X` are supplementary.
+This is the *only* geometric obligation remaining on the cosine side; everything
+else (`chord_length_sq_eq_of_angle_at_P` below) is the algebraic law of cosines.
+
+Isolated here as a standalone, Aristotle-submittable target. -/
+theorem angle_at_P
+    (X Y Z P : EuclideanSpace ℝ (Fin 2))
+    (hXYZ : AffineIndependent ℝ ![X, Y, Z])
+    (hP : P ∈ interior (convexHull ℝ {X, Y, Z})) :
+    ∠ (pedalFoot P Z X) P (pedalFoot P X Y) = Real.pi - ∠ Y X Z := by
+  sorry
+
+/-- **Cosine side, modulo the supplementary-angle fact (fully proved reduction).**
+
+Given only `angle_at_P` (the supplementary-angle fact `∠ F_b P F_c = π − ∠YXZ`),
+the squared chord length is `db² + dc² + 2·db·dc·cos∠YXZ`. This is the pure law of
+cosines in the pedal triangle `△(F_b, P, F_c)` (apex at `P`), combined with the
+bridge lemma `lineDist_eq_dist_pedalFoot` (to turn `dist P F_•` into `lineDist`) and
+`Real.cos_pi_sub` (to flip the sign of the cosine). No remaining `sorry`. Mathlib:
+`dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle` (law of
+cosines, angle-at-point form, `dist·dist`), `Real.cos_pi_sub`. -/
+theorem chord_length_sq_eq_of_angle_at_P
+    (X Y Z P : EuclideanSpace ℝ (Fin 2))
+    (hAngle : ∠ (pedalFoot P Z X) P (pedalFoot P X Y) = Real.pi - ∠ Y X Z) :
+    dist (pedalFoot P Z X) (pedalFoot P X Y) ^ 2
+      = (lineDist P Z X) ^ 2 + (lineDist P X Y) ^ 2
+        + 2 * (lineDist P Z X) * (lineDist P X Y) * Real.cos (∠ Y X Z) := by
+  have hlc := dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle
+    (pedalFoot P Z X) P (pedalFoot P X Y)
+  rw [lineDist_eq_dist_pedalFoot P Z X, lineDist_eq_dist_pedalFoot P X Y, hlc, hAngle,
+    Real.cos_pi_sub, dist_comm (pedalFoot P Z X) P, dist_comm (pedalFoot P X Y) P]
+  ring
+
+/-- **Chord length squared (the "cosine side", law of cosines).**
+
+With `db = lineDist P Z X = dist P F_b` and `dc = lineDist P X Y = dist P F_c`
+(the bridge lemma `lineDist_eq_dist_pedalFoot`), the law of cosines in the pedal
+triangle `△(P, F_b, F_c)` gives `dist F_b F_c ² = db² + dc² + 2·db·dc·cos∠YXZ`.
+Now obtained by feeding the isolated `angle_at_P` fact into the proved reduction
+`chord_length_sq_eq_of_angle_at_P` — so the only `sorry` left on the cosine side is
+`angle_at_P` itself. -/
+theorem chord_length_sq_eq
+    (X Y Z P : EuclideanSpace ℝ (Fin 2))
+    (hXYZ : AffineIndependent ℝ ![X, Y, Z])
+    (hP : P ∈ interior (convexHull ℝ {X, Y, Z})) :
+    dist (pedalFoot P Z X) (pedalFoot P X Y) ^ 2
+      = (lineDist P Z X) ^ 2 + (lineDist P X Y) ^ 2
+        + 2 * (lineDist P Z X) * (lineDist P X Y) * Real.cos (∠ Y X Z) :=
+  chord_length_sq_eq_of_angle_at_P X Y Z P (angle_at_P X Y Z P hXYZ hP)
+
+/-- **Pedal-feet chord identity (the single remaining geometric obligation).**
+
+For `P` interior to the nondegenerate triangle `X Y Z`, let `db = lineDist P Z X`
+and `dc = lineDist P X Y` be the perpendicular distances from `P` to the two sides
+meeting at `X`. Equating the two expressions for the squared chord length between
+the pedal feet (`chord_length_eq` ⟹ sine side, `chord_length_sq_eq` ⟹ cosine side):
+
+    (dist P X · sin∠YXZ)² = db² + dc² + 2·db·dc·cos∠YXZ.
+
+This is exactly the `hchord` hypothesis of `key_inequality_of_chord_and_sines`.
+Proving it discharges the last `sorry` of the Erdős–Mordell formalization. The
+combine below is geometry-free: it just composes the two chord lemmas. -/
+theorem chord_identity
+    (X Y Z P : EuclideanSpace ℝ (Fin 2))
+    (hXYZ : AffineIndependent ℝ ![X, Y, Z])
+    (hP : P ∈ interior (convexHull ℝ {X, Y, Z})) :
+    (dist P X * Real.sin (∠ Y X Z)) ^ 2
+      = (lineDist P Z X) ^ 2 + (lineDist P X Y) ^ 2
+        + 2 * (lineDist P Z X) * (lineDist P X Y) * Real.cos (∠ Y X Z) := by
+  have hlen := chord_length_eq X Y Z P hXYZ hP
+  rw [dist_comm P X, ← hlen]
+  exact chord_length_sq_eq X Y Z P hXYZ hP
+
+end ErdosMordellChord

--- a/research/erdos-mordell-chord-identity-strategy.md
+++ b/research/erdos-mordell-chord-identity-strategy.md
@@ -14,9 +14,18 @@ fact, isolated three ways:
   identity** `(PA·sin A)² = db² + dc² + 2·db·dc·cos A`, derives the key
   inequality `b·dc + c·db ≤ a·PA`. **Proved.**
 
-The only remaining sorries are `key_inequality_A/B/C` — the obligation to supply,
-for the concrete Euclidean configuration, (i) the law of sines and (ii) the chord
-identity. This note records the Mathlib path for that final step.
+The three cyclic `key_inequality_A/B/C` have now been **collapsed to a single
+shared lemma** `key_inequality_vertex (X Y Z P)` — the others are its
+`(X,Y,Z)=(A,B,C),(B,C,A),(C,A,B)` instantiations, derived by pure relabeling
+(`affineIndep_rotate`, `mem_interior_hull_rotate`: affine independence and the
+triangle-hull interior are invariant under cyclic permutation). So the **only**
+remaining sorry is `key_inequality_vertex`: supply, for the concrete Euclidean
+configuration, (i) the law of sines and (ii) the chord identity.
+
+Update: the law of sines (i) is **already in Mathlib** —
+`EuclideanGeometry.dist_div_sin_angle_eq_two_mul_circumradius`
+(`Angle/Sphere.lean:430`) gives `dist /sin = 2R`. So the genuinely missing fact
+is just the **chord identity** (ii). This note records the Mathlib path for it.
 
 ## The chord identity, geometrically
 
@@ -42,9 +51,9 @@ line[A,B] P` be the pedal feet; `db = dist P F_b = lineDist P C A`,
 4. **Law of cosines in `△ P F_b F_c`.** `∠ F_b P F_c = π − A` (cyclic-quad angle
    sum, since the two right angles at the feet account for the rest), so
    `dist F_b F_c ² = db² + dc² − 2·db·dc·cos(π−A) = db² + dc² + 2·db·dc·cos A`.
-   - Lemma: `EuclideanGeometry.law_cos`
-     (`dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle`,
-     `Triangle.lean:242`), plus `Real.cos_pi_sub`.
+   - Lemma: `EuclideanGeometry.dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle`
+     (`Triangle.lean:242`; **NB** there is no lemma named `law_cos` — verified
+     2026-06-19; the lemma is stated with `dist·dist`, not `^2`), plus `Real.cos_pi_sub`.
 
 Combining 3 and 4: `(PA·sin A)² = dist F_b F_c ² = db²+dc²+2·db·dc·cos A`. ∎
 
@@ -56,57 +65,207 @@ gives `a = 2R·sin A`, etc. (search `circumradius`, `sin_angle`, `Sphere` for th
 exact name; if absent, derive from the inscribed-angle theorem applied to the
 circumcircle, same machinery as step 3).
 
-## Open risk / cost
+## 2026-06-19 update — de-risked, name-checked decomposition (no oangle needed)
 
-- Steps 2–3 are the heaviest: oriented-angle (`oangle`) bookkeeping and the
-  `Real.Angle`/`two_zsmul` factor-of-two are fiddly; budget several build
-  iterations.
-- `∠ F_b P F_c = π − A` (step 4) needs the cyclic-quadrilateral angle identity;
-  may be cleaner via `oangle_center_add...` than chasing unoriented angles.
-- Each of `key_inequality_B/C` is the cyclic image of `A`; once `A` is done,
-  `B/C` should follow by relabeling (consider a single private lemma parametrized
-  by the vertex/feet, instantiated three times).
+All required Mathlib lemmas were located by source grep and the heaviest
+(inscribed-angle / `oangle`) step has been **eliminated** by reusing the law of
+sines on the *pedal* triangle instead of chasing inscribed angles. Confirmed
+API (file:line in `proofs/.lake/packages/mathlib`):
 
-## Why not done now (inscribed-angle route)
+| Need | Lemma | Location |
+|------|-------|----------|
+| `lineDist = dist P (foot)` | `dist_orthogonalProjection_eq_infDist` | `Geometry/Euclidean/Projection.lean:300` |
+| Thales (right angle ⟺ on diameter sphere) | `thales_theorem` / `angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter` | `Angle/Sphere.lean:82,107` |
+| `Sphere.ofDiameter` (center=midpoint, radius=AP/2) | `Sphere.ofDiameter` | `Sphere/Basic.lean:304` |
+| circumcenter uniqueness | `eq_circumcenter_of_dist_eq` | `Circumcenter.lean:261` |
+| **law of sines** (used TWICE) | `dist_div_sin_angle_eq_two_mul_circumradius` | `Angle/Sphere.lean:430` |
+| law of cosines | `dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle` | `Triangle.lean:242` |
 
-Heavy `EuclideanSpace` geometry needs many compile iterations; deferred while the
-fleet is saturated (OOM risk). The reduction + trig core + assembly are committed
-and build-green; this is the documented remaining geometric obligation.
+### Key simplification: chord length without inscribed angles
 
-## 2026-06-19 — an *elementary* route avoiding the inscribed-angle theorem
+Previously step 3 (`dist F_b F_c = PA·sin A`) was the riskiest — it called for
+oriented-angle / `two_zsmul` factor-of-two bookkeeping. **Replace it** by the law
+of sines applied to the pedal triangle `△(A, F_b, F_c)`:
 
-The pedal-circle / inscribed-angle derivation above (steps 2–3) is the heaviest
-part (oriented `oangle`, `two_zsmul` factor of two). It can be **avoided
-entirely**. Write the vertex angle as a sum of the two sub-angles cut by `AP`:
+1. `F_b, F_c` see `AP` at a right angle ⟹ (Thales) both lie on
+   `Sphere.ofDiameter A P` (center `m = midpoint A P`, radius `dist A P / 2`).
+2. `A, P` also lie on that sphere trivially. So `dist m A = dist m F_b =
+   dist m F_c = dist A P / 2`. By `eq_circumcenter_of_dist_eq`, `m` is the
+   circumcenter of `△(A, F_b, F_c)` and its **circumradius is `dist A P / 2`**.
+3. Law of sines on `△(A, F_b, F_c)`:
+   `dist F_b F_c / sin(∠ F_b A F_c) = 2 · circumradius = dist A P`,
+   i.e. `dist F_b F_c = PA · sin(∠ F_b A F_c)`.
+4. `∠ F_b A F_c = ∠ B A C = A` because `F_b ∈ line CA` (ray from `A` toward `C`)
+   and `F_c ∈ line AB` (ray from `A` toward `B`) — the feet lie on the two sides
+   meeting at `A`, so the angle subtended at `A` is the triangle's angle `A`.
+   (This collinearity/ray step is the one remaining genuinely geometric fact;
+   for an interior point the feet land on the open segments, so same ray.)
 
-    α := ∠ C A P,   β := ∠ B A P,   so   A = ∠ B A C = α + β   (P interior).
+Then step 4 (law of cosines in `△ P F_b F_c`, `∠ F_b P F_c = π − A`) gives
+`dist F_b F_c² = db² + dc² + 2·db·dc·cos A`, and combining with step 3 yields the
+chord identity `(PA·sin A)² = db² + dc² + 2·db·dc·cos A` feeding
+`key_inequality_of_chord_and_sines`.
 
-Then the chord identity `(PA·sinA)² = db²+dc²+2·db·dc·cosA` follows from three
-elementary facts:
+Net: the proof now needs **only the same `dist_div_sin_angle_eq_two_mul_circumradius`
+lemma applied twice** (once to `△ABC` for `a=2R sinA`, once to the pedal triangle
+for the chord), plus Thales + circumcenter-uniqueness + law of cosines — all
+confirmed present. No `oangle` / `two_zsmul` machinery.
 
-  (i)   `db = PA · sin α`   (perpendicular leg of right triangle `A F_b P`);
-  (ii)  `dc = PA · sin β`   (same at side `AB`);
-  (iii) `α + β = A`         (`AP` between rays `AB, AC`, from interiority).
+### Remaining genuine work (build session, fleet quiet)
 
-Given (i)–(iii) the identity is **pure trigonometry** (expand `sin(α+β)`,
-`cos(α+β)`, use `sin²+cos²=1`).
+1. `lineDist` ↔ `orthogonalProjection` rewrite (bridge lemma, ~10 lines).
+2. Right angle at the feet ⟹ membership on `Sphere.ofDiameter A P` (Thales).
+3. circumradius of pedal triangle `= dist A P / 2` via `eq_circumcenter_of_dist_eq`.
+4. `∠ F_b A F_c = ∠ B A C` — feet on the rays from `A` (needs interior ⟹ foot on
+   the open segment; the only step still lacking a pinned-down Mathlib lemma).
+5. Assemble chord identity, hand to `key_inequality_of_chord_and_sines`.
+6. Affine independence of the pedal triangle (needed to form `Triangle ℝ P`):
+   holds unless `db` or `dc` is zero, i.e. `P` on a side — excluded by interior.
 
-**Implemented** in `proofs/Proofs/ErdosMordellChordReduction.lean`:
-- `chord_identity_of_half_angles` — the geometry-free core: (i)+(ii)+(iii) ⟹ (★).
-  **Proved (`linear_combination`), no sorry.**
-- `lineDist_eq_dist_orthogonalProjection` — `lineDist P X Y = dist P (foot)`,
-  the bridge turning (i)/(ii) into right-triangle statements. **Proved.**
+Estimated 150–300 lines; step 4 is the residual risk. Build in a **separate
+companion file first** (do not re-add sorries to the clean shipped file).
 
-**Remaining (both strictly more elementary than the inscribed-angle theorem):**
-- (i)/(ii) `lineDist P C A = dist P A · sin (∠ C A P)`: foot `F_b` gives right
-  angle `∠ P F_b A = π/2`; `EuclideanGeometry.sin_angle_mul_dist_eq_sin_angle_mul_dist`
-  (`Triangle.lean:255`, `law_sin`) on `△ A F_b P` gives
-  `dist P F_b = dist P A · sin (∠ F_b A P)`; `F_b ∈ line CA` collinear ⟹
-  `sin (∠ F_b A P) = sin (∠ C A P)` (equal-or-supplementary, `angle_smul_left`).
-- (iii) `∠ C A P + ∠ B A P = ∠ B A C`, P interior: `EuclideanGeometry.oangle_add`
-  (`Oriented/Affine.lean:271`) is unconditional in oriented angles; interiority
-  fixes the common sign via `Sbtw.oangle_sign_eq` (`Oriented/Affine.lean:720`),
-  letting the unoriented sum be read off.
+### 2026-06-19 (cycle 5) — step 4 now pinned to named lemmas
 
-This route removes the circle entirely; what remains are right-triangle and
-betweenness facts. Next session: prove (i)/(ii) via `law_sin`, then (iii).
+The residual-risk step 4 (`∠ F_b X F_c = ∠ Y X Z`) is no longer unpinned. The
+affine angle unfolds to the vector angle
+`∠ F_b X F_c = InnerProductGeometry.angle (F_b -ᵥ X) (F_c -ᵥ X)`
+(`EuclideanGeometry.angle` def, `Angle/Unoriented/Affine.lean`), and the two
+scaling lemmas
+
+| Need | Lemma | Location |
+|------|-------|----------|
+| `angle (r•x) y = angle x y`, `r>0` | `InnerProductGeometry.angle_smul_left_of_pos`  | `Angle/Unoriented/Basic.lean:140` |
+| `angle x (r•y) = angle x y`, `r>0` | `InnerProductGeometry.angle_smul_right_of_pos` | `Angle/Unoriented/Basic.lean:133` |
+
+collapse it to a single arithmetic fact: **`F_b -ᵥ X = t · (Y -ᵥ X)` with
+`t > 0`** (and `F_c -ᵥ X = s · (Z -ᵥ X)`, `s > 0`). I.e. each pedal foot lies on
+the *positive ray* from `X` toward the adjacent vertex. Concretely:
+
+1. `F_b := orthogonalProjection (affineSpan ℝ {X,Y}) P` lies on `line[X,Y]`, so
+   `F_b -ᵥ X ∈ span ℝ {Y -ᵥ X}` ⟹ `F_b -ᵥ X = t · (Y -ᵥ X)` for some real `t`.
+2. `t > 0`: for `P` interior to the triangle, the foot of the perpendicular to a
+   side lands on the **open** segment (the side's supporting line separates the
+   apex from nothing; the interior projects strictly inside). So `Sbtw ℝ X F_b Y`,
+   giving `0 < t < 1`. (`Sbtw`/`Wbtw` → scalar in `(0,1)`; search
+   `Wbtw`/`affineSegment`/`lineMap` for the `t`-extraction lemma.)
+
+So the angle equality is now **fully named** modulo "foot of an interior point's
+perpendicular to a side lies strictly inside that side" — an `Sbtw` membership
+fact, no longer an angle mystery. This removes the last *qualitative* gap; what
+remains is routine (if laborious) `EuclideanSpace`/`Sbtw` plumbing.
+
+### 2026-06-19 (cycle 5) — why still no code
+
+Aristotle MCP **still down** (`prove` returns `"Resource not found"`, same as
+cycles 3–4). Fleet busy: **8** `lean-build` containers live (load ~22) — far
+above the OOM-safe container gate (`ctrs<3`), so a heavy multi-iteration
+`EuclideanSpace` build cannot be started safely. This cycle's progress is the
+step-4 pin above (a genuine de-risk: the last unpinned subfact now has named
+Mathlib lemmas), not a code change. The clean 1-sorry file remains shipped
+(PR #26033 **merged** 07:23Z). Next quiet-fleet session: build the companion
+file from this fully-named decomposition; retry Aristotle first (it may recover).
+
+### 2026-06-19 (cycle 6) — chord identity split into sine/cosine helpers
+
+The companion file `proofs/Proofs/ErdosMordellChordIdentity.lean` (previously
+untracked) is now committed on branch `research/erdos-mordell-oq01-step4-pin`
+(commit `819f04d`, no PR — unbuilt). The single `chord_identity` sorry is split
+into two cleaner, independently attackable obligations joined by a **verified**
+geometry-free combine:
+
+| Lemma | Statement | Status |
+|-------|-----------|--------|
+| `lineDist_eq_dist_pedalFoot` | `lineDist P X Y = dist P (pedalFoot P X Y)` | **proved** |
+| `chord_length_eq` | `dist F_b F_c = dist X P · sin∠YXZ` (law of sines on pedal △) | `sorry` |
+| `chord_length_sq_eq` | `dist F_b F_c ² = db² + dc² + 2·db·dc·cos∠YXZ` (law of cosines) | `sorry` |
+| `chord_identity` | combine: `rw [dist_comm, ← chord_length_eq]; exact chord_length_sq_eq` | **proved** modulo helpers |
+
+This cleanly separates the law-of-sines machinery (Thales + circumradius + ray
+angle, the step-4-pinned part) from the law-of-cosines machinery (π−A cyclic-quad
+angle), so each can go to Aristotle or a focused build independently.
+
+**Not built this cycle**: Aristotle MCP still `"Resource not found"`; fleet at
+7 `lean-build` containers (load ~19), far above the OOM-safe gate (`ctrs<3`). The
+two helper statements are name-checked but unverified. Next quiet-fleet session:
+build the companion file (verifies the bridge lemma + combine + that the two
+helper statements typecheck), then attack `chord_length_eq` / `chord_length_sq_eq`
+individually (Aristotle first if it recovers).
+
+### 2026-06-19 (cycle 7) — Mathlib pin verification (read-only)
+
+Aristotle MCP still `"Resource not found"` (7th cycle down); fleet at 6
+`lean-build` containers (load ~13), above the OOM-safe gate, so no build. Spent
+the cycle verifying every pinned Mathlib lemma actually exists with the assumed
+shape against `proofs/.lake/packages/mathlib`. Result — all confirmed **except
+the law of cosines**:
+
+| Pinned lemma | Status |
+|--------------|--------|
+| `dist_orthogonalProjection_eq_infDist` (`Projection.lean:300`) | ✓ exists |
+| `dist_div_sin_angle_eq_two_mul_circumradius` (`Angle/Sphere.lean:430`) | ✓ exists (Triangle ℝ P, Fin 3) |
+| `thales_theorem` (`Angle/Sphere.lean:107`, alias) | ✓ exists |
+| `eq_circumcenter_of_dist_eq` (`Circumcenter.lean:261`) | ✓ exists |
+| `Sphere.ofDiameter` / `isDiameter_ofDiameter` (`Sphere/Basic.lean:307`) | ✓ exists |
+| `angle_smul_left_of_pos` / `angle_smul_right_of_pos` (`Angle/Unoriented/Basic.lean:140/133`) | ✓ exists |
+| `Real.cos_pi_sub` (`Trigonometric/Basic.lean:331`) | ✓ exists |
+| ~~`law_cos`~~ | ✗ **does not exist** → real name below |
+
+**Correction:** there is no `EuclideanGeometry.law_cos`. The law of cosines is
+`EuclideanGeometry.dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle`
+(`Triangle.lean:242`), and it is stated with `dist p₁ p₃ * dist p₁ p₃` (products),
+**not** `^2`: `dist p₁ p₃ * dist p₁ p₃ = dist p₁ p₂ * dist p₁ p₂ + dist p₃ p₂ *
+dist p₃ p₂ - 2 * dist p₁ p₂ * dist p₃ p₂ * cos (∠ p₁ p₂ p₃)`. The
+`chord_length_sq_eq` proof must therefore bridge `^2` ↔ `*` (e.g. `sq`/`pow_two`)
+when applying it. Fixed the wrong pin in both the companion docstring and the
+table above. This catch saves a guaranteed-red build cycle.
+
+## Why not done this session (2026-06-19)
+
+Aristotle MCP down ("Resource not found"); fleet at load ~18 with 5 lean
+containers (OOM-risk per container-count gate). A heavy multi-iteration
+`EuclideanSpace` build is unsafe to start now. The clean 1-sorry file is shipped
+(PR #26033, OPEN+MERGEABLE). This session's progress is the de-risked,
+fully name-checked decomposition above (the oangle elimination is a real
+structural simplification of the remaining obligation), not a code change.
+
+## Cosine-side reduction (2026-06-19, cycle 11)
+
+Re-pinned everything against the live source at `~/GitHub/mathlib4`.
+**Correction to the previous "does not exist" note:** `EuclideanGeometry.law_cos`
+*does* exist — it is an `alias` of
+`dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle`
+(`Triangle.lean:252`). The canonical long name is still preferred for stability,
+but `law_cos` is a legal reference. The `*`-vs-`^2` caveat above stands.
+
+The cosine side `chord_length_sq_eq` now splits cleanly into **algebra (provable)**
++ **one geometric subfact (the only residual obligation on this branch)**:
+
+Apply the law of cosines at the pedal triangle with apex `P`, i.e.
+`p₁ := pedalFoot P Z X` (=F_b), `p₂ := P`, `p₃ := pedalFoot P X Y` (=F_c):
+
+    dist F_b F_c * dist F_b F_c
+      = dist F_b P * dist F_b P + dist F_c P * dist F_c P
+        − 2 * dist F_b P * dist F_c P * cos (∠ F_b P F_c).
+
+Three rewrites turn this into the stated goal, each mechanical:
+1. `^2 ↔ *` on all three squared distances (`pow_two` / `sq`);
+2. `dist F_b P = lineDist P Z X` and `dist F_c P = lineDist P X Y` via the
+   **proved** bridge `lineDist_eq_dist_pedalFoot` + `dist_comm`;
+3. `cos (∠ F_b P F_c) = − cos (∠ Y X Z)` via `Real.cos_pi_sub`, **provided**
+   the residual geometric subfact
+
+       angle_at_P :  ∠ (pedalFoot P Z X) P (pedalFoot P X Y) = π − ∠ Y X Z.
+
+So the whole cosine side reduces to `angle_at_P` alone (cyclic-quadrilateral angle
+sum: `X F_b P F_c` is cyclic on `Sphere.ofDiameter X P` since both feet subtend a
+right angle at `XP`, and opposite angles of a cyclic quadrilateral sum to π).
+This is the natural next `sorry` to isolate as its own lemma and hand to Aristotle
+once the backend recovers — a single, self-contained planar-angle fact with no
+`infDist`/projection machinery left in it.
+
+**Not executed in code this cycle:** Aristotle still 404 (11th consecutive cycle),
+fleet at load ~20 (build gate `load<16` closed). Introducing an unverifiable
+multi-step proof body would risk turning the known-buildable companion red when
+the build watcher fires. The companion is left in its known-good 2-sorry state;
+the watcher ships it as a typechecked PR on the next quiet window.

--- a/research/erdos-mordell-chord-identity-strategy.md
+++ b/research/erdos-mordell-chord-identity-strategy.md
@@ -328,3 +328,33 @@ Aristotle 404 (16th consecutive cycle). Companion left in known-good 2-sorry sta
 (PID 13290) ships the cycle-14 commit (Thales lemma `angle_pedalFoot_eq_pi_div_two`,
 sig re-verified against `Angle/Unoriented/Projection.lean:28`) as a fresh PR on the
 next quiet build window — prior PR #26042 merged, so a NEW PR is required.
+
+**Cycle-17 — elementary angle-chase ruled out; oriented mechanism pinned.**
+A tempting shortcut for `angle_at_P` avoids the inscribed-angle theorem entirely:
+in the two right triangles `△P F_b X`, `△P F_c X` (right angles at the feet, the
+already-proved `angle_pedalFoot_{ZX,XY}_at_X`), each non-right pair sums to `π/2`,
+so adding the angles at `P` and at `X` gives `∠ F_b P F_c = π − ∠ F_b X F_c =
+π − ∠ Y X Z`. **This does not shortcut the Lean proof:** Mathlib provides *no*
+unoriented angle-addition *equality* `∠ a p c = ∠ a p b + ∠ b p c` (interior `b`).
+The only unoriented additivity is the *inequality*
+`EuclideanGeometry.angle_le_angle_add_angle` (`Angle/Unoriented/TriangleInequality.lean:183`);
+the equality lives only in the *oriented* world. So the elementary chase collapses
+back onto the same oriented→unoriented descent as the inscribed-angle route — it is
+not an independent simpler path.
+
+The concrete oriented mechanism (sharper than "establish opposite-arc sign" above):
+  - `EuclideanGeometry.oangle_add` (`Angle/Oriented/Affine.lean:271`)
+    `: ∡ p₁ p p₂ + ∡ p₂ p p₃ = ∡ p₁ p p₃` — additivity needs **only** `pᵢ ≠ p`
+    (no betweenness/`Sbtw`), so it applies at both apex `P` and apex `X` for free.
+  - `EuclideanGeometry.angle_eq_abs_oangle_toReal` (`Angle/Oriented/Affine.lean:346`)
+    `: ∠ p₁ p p₂ = |((∡ p₁ p p₂).toReal)|` — the `∠ = |∡.toReal|` bridge that turns
+    the oriented chase back into the unoriented goal. The absolute value is what
+    forces the opposite-arc sign analysis: `P` interior to `△XYZ` ⟹ both sub-oangles
+    `∡ F_b P X`, `∡ X P F_c` carry the **same** sign (orientation), so their
+    `|toReal|` add without cancellation, while `X` and `P` sit on opposite arcs of
+    chord `F_b F_c` ⟹ the supplementary (`π −`) rather than equal collapse.
+  Both lemma signatures re-verified cycle-17 against live `.lake/packages/mathlib`.
+
+Aristotle 404 (17th consecutive cycle; both `prove_file` and inline `prove`
+endpoints return `Resource not found`). Companion Lean unchanged since cycle-14
+(2-sorry known-good); cycle-17 is strategy-doc only.

--- a/research/erdos-mordell-chord-identity-strategy.md
+++ b/research/erdos-mordell-chord-identity-strategy.md
@@ -269,3 +269,49 @@ fleet at load ~20 (build gate `load<16` closed). Introducing an unverifiable
 multi-step proof body would risk turning the known-buildable companion red when
 the build watcher fires. The companion is left in its known-good 2-sorry state;
 the watcher ships it as a typechecked PR on the next quiet window.
+
+## 2026-06-19 (cycle 15) — sharper Mathlib pins for the two residual sorries
+
+Read-only verification against the live `.lake/packages/mathlib` source. Both
+remaining sorries get a cleaner pin than the doc previously carried:
+
+**Sine side (`chord_length_eq`).** Prefer the *Sphere* form over the
+`Triangle ℝ P` / `Fin 3` form (`dist_div_sin_angle_eq_two_mul_circumradius`,
+`Angle/Sphere.lean:430`), which forces constructing a `Triangle` value and index
+juggling. Instead use
+
+    EuclideanGeometry.Sphere.dist_div_sin_oangle_eq_two_mul_radius   -- Angle/Sphere.lean:298
+      {s : Sphere P} (hp₁ : p₁ ∈ s) (hp₂ : p₂ ∈ s) (hp₃ : p₃ ∈ s)
+      (hp₁p₂ : p₁ ≠ p₂) (hp₁p₃ : p₁ ≠ p₃) (hp₂p₃ : p₂ ≠ p₃) :
+      dist p₁ p₃ / |Real.Angle.sin (∡ p₁ p₂ p₃)| = 2 * s.radius
+
+  Take `s := Sphere.ofDiameter X P` (radius `dist X P / 2`, so `2*radius = dist X P`),
+  `p₁ := F_b`, `p₂ := X`, `p₃ := F_c`. Membership of `F_b, F_c, X` comes from the
+  already-PROVED right-angle facts `angle_pedalFoot_{ZX,XY}_at_X` fed through
+  `angle_eq_pi_div_two_iff_mem_sphere_ofDiameter` (`Angle/Sphere.lean:103`); `X ∈ s`
+  is an endpoint of the diameter. Residual bridge: `|Real.Angle.sin (∡ F_b X F_c)|
+  = Real.sin (∠ F_b X F_c)` (unoriented `∠ ∈ [0,π]` ⟹ nonneg sin; `∠ = |(∡).toReal|`),
+  then `∠ F_b X F_c = ∠ Y X Z` via the positive-ray collapse
+  (`InnerProductGeometry.angle_smul_left/right_of_pos`, feet on the open sides).
+
+**Cosine side (`angle_at_P`).** The cyclic-quadrilateral supplementary fact is the
+*oriented* inscribed-angle identity, mod π:
+
+    EuclideanGeometry.Sphere.two_zsmul_oangle_eq           -- Angle/Sphere.lean:164
+    EuclideanGeometry.Cospherical.two_zsmul_oangle_eq      -- Angle/Sphere.lean:178
+      : (2:ℤ) • ∡ p₁ p₂ p₄ = (2:ℤ) • ∡ p₁ p₃ p₄   (same chord p₁p₄, apexes p₂,p₃ on s)
+
+  With chord `F_b F_c` and apexes `X` (giving `∡ = ∠YXZ` class) and `P`, the genuine
+  remaining work is the oriented→unoriented descent: `2 • ∡ = 2 • ∡` only pins the
+  angles mod π, and X, P lie on *opposite* arcs of chord `F_b F_c`, so the unoriented
+  representatives are supplementary (`∠ + ∠ = π`) rather than equal. Establish
+  opposite-arc / orientation sign before collapsing — this is the one non-mechanical
+  step left on the cosine side. Concyclicity itself is free from the two Thales right
+  angles via `cospherical_of_two_zsmul_oangle_eq_of_not_collinear` (`Angle/Sphere.lean:449`)
+  or directly `Sphere.ofDiameter` membership.
+
+Aristotle 404 (14th consecutive cycle). Companion left in known-good 2-sorry state;
+watcher (PID 13290) ships the cycle-14 commit (new Thales lemma
+`angle_pedalFoot_eq_pi_div_two`, signature re-verified against
+`Angle/Unoriented/Projection.lean:28`) as a fresh PR on the next quiet build window
+— the prior PR #26042 merged, so a NEW PR is required.

--- a/research/erdos-mordell-chord-identity-strategy.md
+++ b/research/erdos-mordell-chord-identity-strategy.md
@@ -310,8 +310,21 @@ juggling. Instead use
   angles via `cospherical_of_two_zsmul_oangle_eq_of_not_collinear` (`Angle/Sphere.lean:449`)
   or directly `Sphere.ofDiameter` membership.
 
-Aristotle 404 (14th consecutive cycle). Companion left in known-good 2-sorry state;
-watcher (PID 13290) ships the cycle-14 commit (new Thales lemma
-`angle_pedalFoot_eq_pi_div_two`, signature re-verified against
-`Angle/Unoriented/Projection.lean:28`) as a fresh PR on the next quiet build window
-— the prior PR #26042 merged, so a NEW PR is required.
+  **Pin both forms re-verified cycle-16** against live `.lake/packages/mathlib`:
+  - `dist_div_sin_oangle_eq_two_mul_radius` (`:298`) — exact concl
+    `dist p₁ p₃ / |Real.Angle.sin (∡ p₁ p₂ p₃)| = 2 * s.radius`, matches doc.
+  - `two_zsmul_oangle_eq` (`:164`) — exact concl `(2:ℤ)•∡ p₁ p₂ p₄ = (2:ℤ)•∡ p₁ p₃ p₄`,
+    hyps `p₂≠p₁, p₂≠p₄, p₃≠p₁, p₃≠p₄`, matches doc.
+  - **Prefer the `Cospherical.two_zsmul_oangle_eq` form (`:178`)** for the cosine-side
+    descent: it consumes `Cospherical ({F_b, X, P, F_c} : Set P)` *directly* (same four
+    distinctness hyps), so no explicit `s : Sphere P` / named center+radius is needed —
+    the Thales setup yields cospherical-ness of the four feet+`X`+`P` immediately
+    (`cospherical_of_two_zsmul_oangle_eq_of_not_collinear` or `Sphere.ofDiameter`
+    membership of all four), then this lemma is applied with zero sphere bookkeeping.
+    No phantom lemmas; both signatures are real.
+
+Aristotle 404 (16th consecutive cycle). Companion left in known-good 2-sorry state
+(unchanged Lean since cycle-14; cycle-15/16 are strategy-doc only); watcher
+(PID 13290) ships the cycle-14 commit (Thales lemma `angle_pedalFoot_eq_pi_div_two`,
+sig re-verified against `Angle/Unoriented/Projection.lean:28`) as a fresh PR on the
+next quiet build window — prior PR #26042 merged, so a NEW PR is required.


### PR DESCRIPTION
## Erdős–Mordell chord identity: decomposition companion

Adds `proofs/Proofs/ErdosMordellChordIdentity.lean`, a standalone companion that
decomposes the single remaining geometric obligation of the Erdős–Mordell
formalization (`chord_identity`, consumed by `key_inequality_of_chord_and_sines`
in the shipped main file) into **exactly two** isolated, independently attackable
plane-geometry facts joined by fully-proved algebraic reductions.

| Lemma | Status |
|-------|--------|
| `lineDist_eq_dist_pedalFoot` (infDist ↔ projection bridge) | **proved** |
| `angle_pedalFoot_eq_pi_div_two` (+2 specialisations) — Thales cornerstone `∠ P F W = π/2` | **proved** |
| `chord_length_sq_eq_of_angle_at_P` (law of cosines reduction) | **proved** |
| `chord_length_sq_eq` | **proved** |
| `chord_identity` (geometry-free combine) | **proved** modulo the two targets |
| `chord_length_eq` (sine side, law of sines) | `sorry` (isolated target) |
| `angle_at_P` (cosine-side supplementary angle `∠ F_b P F_c = π − ∠YXZ`) | `sorry` (isolated target) |

The Thales cornerstone (each pedal foot sees `XP` at a right angle, so the feet are
concyclic with `X`, `P` on the circle of diameter `XP`) is the shared geometric
primitive both residual `sorry`s rest on; it is now **proved** from
`EuclideanGeometry.angle_self_orthogonalProjection`. The cosine side is reduced to
a single supplementary-angle fact via the pure law of cosines + `Real.cos_pi_sub`.

Does **not** touch the clean shipped `ErdosMordellInequalityOQ01.lean`. Build green
(companion typechecks; the two residual `sorry`s are the isolated targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)