### PR TITLE
audit(erdos-110): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3809,8 +3809,8 @@
     },
     "erdos-110": {
       "agentId": "auditor-reaudit-20260619",
-      "auditCount": 4,
-      "lastAudited": "2026-06-19T00:00:00Z",
+      "auditCount": 5,
+      "lastAudited": "2026-06-19T09:48:09Z",
       "result": "clean"
     },
     "erdos-110-oq-03": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-110

**Result: CLEAN** — all public claims match the Lean source.

Re-audited Erdős Problem #110 (chromatic number growth in uncountable graphs; Erdős–Hajnal–Szemerédi conjecture, DISPROVED by Lambie-Hanson 2020 in ZFC).

### Verification (proofs/Proofs/Erdos110Problem.lean)
| Check | meta.json | Source | Match |
|-------|-----------|--------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 literal | ✓ |
| theoremCount | 8 | 8 | ✓ |
| definitionCount | 15 | 14 def + 1 structure | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

### Integrity notes
- **Tier C / axiomatized / badge `axiom`** — honest. The core result is the axiom `lambie_hanson_counterexample`; the three literal axioms (`de_bruijn_erdos`, `lambie_hanson_counterexample`, `graph_compactness`) are all disclosed in the `assumptions` field.
- Derived theorems (`shelah_consistency`, `conjecture_fails_aleph0`, `erdos_110_disproved`, `erdos_growth_expectation_moot`) all descend from the single disclosed Lambie-Hanson axiom — **no inflation**, no "verified" overclaim.
- The `LambieHansonGraph` Prop-structure packages properties but is **proven to exist** via `lambie_hanson_graph_exists` from the axioms → its fields are not load-bearing extra assumptions; axiomCount 3 is correct.
- 0 `native_decide` → no `Lean.ofReduceBool`; axiomCount counts the 3 literal axioms only.

Durable tracker: auditCount 4→5.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)