### PR TITLE
audit(erdos-1034): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3233,8 +3233,8 @@
     },
     "erdos-1034": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 6,
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "auditCount": 7,
+      "lastAudited": "2026-06-19T09:52:07Z",
       "result": "clean"
     },
     "erdos-1035": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-1034

**Result: CLEAN** ✅ — no overclaim, all meta.json claims match the Lean source.

Erdős Problem #1034 (Triangle Neighbors in Dense Graphs) — the Erdős–Faudree conjecture, disproved by Ma–Tang (2020).

### Verification (`proofs/Proofs/Erdos1034Problem.lean`)

| Field | meta.json | Source | ✓ |
|-------|-----------|--------|---|
| lineCount | 778 | 778 | ✓ |
| sorries | 3 | 3 (L353, L445, L552) | ✓ |
| axiomCount | 1 | 1 (`maTang_counterexample`) | ✓ |
| theoremCount | 16 | 16 | ✓ |
| definitionCount | 23 | 22 def + 1 structure | ✓ |
| status / badge | axiomatized / axiom | honest Tier C | ✓ |

### Integrity notes
- **No axiom masking**: `proofStrategy` and `keyInsights` explicitly state the Ma–Tang counterexample is axiomatized (`maTang_counterexample`); the disproof `erdos_faudree_false` is genuinely proven *modulo* that disclosed axiom.
- **4 Aristotle theorems** claimed in the conclusion are genuinely proven (`maTang_approx`, `k4Free_approx`, `gap_value`, conjecture negation) via `nlinarith` — no True stubs.
- **3 sorries** (`h_upper_bound`, `h_lower_bound`, `stronger_than_905`) honestly disclosed; bound theorems (`h_bounds`, `erdos_1034_partial`) transitively rest on them — consistent with Tier C scaffold framing.
- **0 native_decide** → no `Lean.ofReduceBool`, so `axiomCount 1` is correct.
- A duplicate `erdos_faudree_false` at L290 sits **inside a comment block** (stale Aristotle artifact) → real theorem count is 16, matching meta.
- Companion `Erdos1034Aristotle.lean`: 122 lines, 0 sorries, 0 axioms.

**Tracker**: `auditCount` 6 → 7, `lastAudited` refreshed.

---
Durable re-audit by gallery integrity auditor.