### PR TITLE
audit(erdos-1033): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3226,9 +3226,9 @@
       "result": "clean"
     },
     "erdos-1033": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-19T09:56:07Z",
       "result": "clean"
     },
     "erdos-1034": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-1033

**Result: CLEAN** — auditCount 5→6.

Erdős Problem #1033 (Triangle Degree Sums in Dense Graphs, Erdős–Laskar 1985 / Fan 1988). Open problem, Tier C axiomatized.

### Verified against `proofs/Proofs/Erdos1033Problem.lean` (1018L)
- **sorries 0** ✓ — main file + `Erdos1033Aristotle.lean` companion (127L) both 0-sorry
- **axiomCount 3** ✓ — all literal axioms (`erdos_laskar_upper`, `erdos_laskar_lower`, `fan_lower`), disclosed in `assumptions` with honest "too strong for small n / asymptotic" warnings
- **status `axiomatized` / badge `axiom`** ✓ — correct for an open problem
- **native_decide ×7** only on small concrete cases (n=3, n=4 graph `G4`) — not the headline result; entry already axiomatized, so no `Lean.ofReduceBool` masking concern
- **conjecture honestly open** — `erdos_1033_conjecture` is a `Prop` def; `conjecture_gives_asymptotic` derives FROM it as hypothesis (no axiom masking, no pipeline inflation)
- **no True stubs**; derived theorems descend from the 3 disclosed axioms

### Minor cosmetic (not an integrity issue)
`theoremCount` 28 / `definitionCount` 20 over-count comment occurrences of "lemma"/"def" (real declarations: 16 theorems, 0 lemmas). Descriptive metadata only — does not affect status/badge/sorry/axiom claims.

---
Discovered during gallery integrity audit. Top-3 stalest (erdos-1034 #26108, erdos-1035 #26104, erdos-110 #26105) skipped — open audit PRs.