### PR TITLE
audit(erdos-1032): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3220,9 +3220,9 @@
       "result": "clean"
     },
     "erdos-1032": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-19T09:59:55Z",
       "result": "clean"
     },
     "erdos-1033": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1032

**Result: CLEAN** ✅ (auditCount 4→5)

Re-audited **erdos-1032** (4-Chromatic Critical Graphs with High Minimum Degree, Erdős #1032, **OPEN**).

### Verification (meta.json vs `proofs/Proofs/Erdos1032Problem.lean`)

| Claim | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 4 | 4 literal axioms (vertexCount, minDegree, chromaticNumber, edgeCount) | ✅ |
| sorries | 0 | 0 | ✅ |
| theoremCount | 0 | 0 | ✅ |
| definitionCount | 4 | 4 (IsKChromaticCritical, ToftConjecture, ErdosProblem1032, ErdosProblem1032_k5) | ✅ |
| lineCount | 77 | 77 | ✅ |
| status / badge | axiomatized / axiom | Tier C scaffold for open problem | ✅ |

### Integrity notes
- **No structure-encoded assumptions** — the 4 defs are plain `Prop` definitions, not assumption-carrying structures, so `axiomCount: 4` is exact.
- **No True stubs, no `native_decide`** → no hidden `Lean.ofReduceBool`.
- **No Mathlib-wrapper masking** — only basic `Nat`/`Finset`/`Rat` imports; the open conjecture is honestly stated as a `Prop`, not "proved".
- `originalContributions` conservatively scoped ("Axiomatised…", "Stated…", "Defined…") — no theorem-level overclaim. Dirac / Simonovits–Toft constructions appear as comments and are described as "Stated", which is honest.

Tracker-only change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)