### PR TITLE
audit(erdos-103): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3196,9 +3196,9 @@
       "result": "clean"
     },
     "erdos-103": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-19T10:04:52Z",
       "result": "clean"
     },
     "erdos-103-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-103

**Result: CLEAN** — no integrity issues. Tracker bump (auditCount 5→6).

**Proof**: Incongruent Optimal Point Configurations (Erdős #103, OPEN — does h(n)→∞?)

### Verified against `proofs/Proofs/Erdos103Problem.lean`
| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 253 | 253 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 literal axioms | ✓ |
| native_decide | — | 0 | ✓ (no `Lean.ofReduceBool`) |
| status/badge | axiomatized/wip | open conjecture as Prop | ✓ honest |

### Notes
- **Tier C honest scaffold.** The headline conjecture `ErdosConjecture103` (h(n)→∞) is stated as a `Prop` definition — **not** proven. Status `axiomatized`/`wip` is correctly conservative.
- **`Isometry2D` structure is not assumption-carrying.** Its fields (`preserves_dist`, `bijective`) are discharged constructively — `congruent_refl/symm/trans` build concrete isometries (identity, `surjInv`, composition) and prove every field. No load-bearing assumptions → `axiomCount 0` is exact.
- Genuine supporting results: congruence equivalence relation, `conjecture_implies_unbounded`, `related_to_problem_99` (nonemptiness from `Nat.card`). The two `rfl` theorems (`h_counts_optimal`, `erdos_103_statement`) are honest tautological restatements, not claimed as proving the conjecture.
- Cosmetic nits only: `definitionCount` 20 vs 19 plain defs (the `Setoid` instance is the 20th). No integrity impact.

---
Discovered during gallery integrity audit.