### PR TITLE
audit(erdos-102): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3100,9 +3100,9 @@
       "result": "clean"
     },
     "erdos-102": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-19T10:07:54Z",
       "result": "clean"
     },
     "erdos-1020": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-102

Re-audited **erdos-102** (Erdős Problem #102: maximum collinear points forced by many rich lines — **OPEN**). Result: **CLEAN**.

### Verification (meta.json vs `Proofs/Erdos102Problem.lean`)

| Field | meta.json | Actual | Match |
|-------|-----------|--------|-------|
| lineCount | 173 | 173 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`connection_101`) | ✓ |
| theoremCount | 10 | 10 | ✓ |
| definitionCount | 4 | 3 def + 1 struct | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

### Integrity findings
- **Tier C / axiomatized** correctly classified: `badge: axiom`, `status: axiomatized` — honest for an OPEN problem.
- The single `axiom connection_101` is disclosed in `assumptions` ("1 axiom: connection_101. 0 sorries."). No axiom masking — the title makes no "proved" claim and the description states "Open."
- `PointConfig.size_pos` (`points.card > 0`) is a nonemptiness well-formedness condition, **not** an open-problem assumption → axiomCount remains 1 (no structure-encoded hypothesis inflation).
- The 10 theorems are genuine: S₃ collinearity invariances proved by `ring`/`nlinarith`, and the #101-bridge lemmas (`connection_101_for_same_c`, `_for_larger_eps`, `_from_full_divergence`, `erdos_purdy_connection`) are real derivations. Notably the file *proves* `connection_101` is derivable from the full divergence conjecture.
- No delegation opacity / inequality-≠-theorem / pipeline inflation / hidden-import overclaim.

`auditCount` 4 → 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)