### PR TITLE
audit(erdos-1017): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3064,8 +3064,8 @@
     },
     "erdos-1017": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 6,
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "auditCount": 7,
+      "lastAudited": "2026-06-19T10:10:56Z",
       "result": "clean"
     },
     "erdos-1017-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit — erdos-1017

**Result: CLEAN** ✅ (Tier C — axiomatized)

Erdős Problem #1017 (clique partition of graphs). General case OPEN; the K₄-free case is resolved (Győri-Keszegh 2017).

### Verification (Erdos1017OQ01.lean, 696 lines vs meta.json)

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| Line count | 696 | 696 | ✅ |
| Axioms | 2 | 2 (`egp_theorem`, `k4free_partition_number`) | ✅ |
| Sorries | 0 | 0 | ✅ |
| native_decide | — | 0 | ✅ |
| True stubs | — | 0 | ✅ |
| status / badge | axiomatized / axiom | correct for OPEN problem | ✅ |

### Notes
- Both axioms are **disclosed** in `assumptions` with attribution (EGP 1966, Győri-Keszegh 2017) and proof sketches in docstrings. No axiom masking.
- `EdgeCliquePartition` is a *definition* of the partition object — its fields (`cliques`, `isClique`, `covers`) are the data of a partition, not inherited mathematical assumptions → axiomCount stays **2**.
- Derived corollaries (`cliquePartitionNum_le_turan`, `k4free_improves`, `k4free_savings_linear`) descend from the two disclosed axioms — no inflation.
- Cosmetic only: `theoremCount` 37 vs 30 actual `theorem`/`lemma` decls (metadata overcount, not an integrity overclaim).

auditCount 6→7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)