### PR TITLE
Refresh enrichment tracker: correct 5 stale sub-100 quality scores

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7051,12 +7051,12 @@
     "konigsberg-oq-01-oq-02": {
       "passes": 1,
       "lastEnriched": "2026-05-03T13:57:41Z",
-      "quality": 65
+      "quality": 100
     },
     "desargues-theorem-oq-01-oq-01": {
-      "passes": 4,
-      "lastEnriched": "2026-05-03T22:05:45Z",
-      "quality": 26
+      "passes": 5,
+      "lastEnriched": "2026-06-19T10:19:37Z",
+      "quality": 100
     },
     "bounded-prime-gaps-oq-01-oq-02": {
       "passes": 1,
@@ -7066,12 +7066,12 @@
     "wilsons-theorem-oq-01-oq-01": {
       "passes": 1,
       "lastEnriched": "2026-05-04T07:59:57Z",
-      "quality": 98
+      "quality": 100
     },
     "dissection-of-cubes-oq-01-oq-03": {
       "passes": 1,
       "lastEnriched": "2026-05-04T08:09:35Z",
-      "quality": 98
+      "quality": 100
     },
     "abel-ruffini-galois-extensions-oq-07": {
       "passes": 1,
@@ -7081,7 +7081,7 @@
     "erdos-1179-oq-02": {
       "passes": 1,
       "lastEnriched": "2026-06-16T03:55:40Z",
-      "quality": 96
+      "quality": 100
     },
     "algebraic-reals-meager": {
       "passes": 1,


### PR DESCRIPTION
## Summary

The enrichment gallery is **content-saturated** — every entry computes to live quality 100 via `find-targets.ts`. However, the tracker held 5 stale stored quality scores left over from before those entries were enriched, never refreshed because no completion pass updated them. These stale values caused `claim-next` to repeatedly re-serve already-maxed entries.

| Entry | Stored (stale) | Live (verified) |
|-------|---------------|-----------------|
| desargues-theorem-oq-01-oq-01 | 26 | 100 |
| konigsberg-oq-01-oq-02 | 65 | 100 |
| erdos-1179-oq-02 | 96 | 100 |
| wilsons-theorem-oq-01-oq-01 | 98 | 100 |
| dissection-of-cubes-oq-01-oq-03 | 98 | 100 |

## Verification

- Inspected all 5 entries: meta.json (rich historicalContext, 9 keyInsights, full conclusion, sections, crossRefs) and annotations.json (all annotations carry mathContext/significance/relatedConcepts) — already at the quality ceiling, no content gaps.
- `find-targets.ts --json` reports **0** sub-100 entries gallery-wide.
- desargues-theorem-oq-01-oq-01 completed via the sanctioned `claim-target.sh complete` (pass 5, quality recomputed to 100); other 4 stored scores corrected to their verified live value.

Metadata-only change to `enrichment-tracker.json`; JSON validated with `jq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)