### PR TITLE
Research: de-moivre-oq-02-oq-03 - document solved state, pin uniqueness frontier

### DIFF
--- a/research/problems/de-moivre-oq-02-oq-03/knowledge.md
+++ b/research/problems/de-moivre-oq-02-oq-03/knowledge.md
@@ -1,21 +1,87 @@
 # Knowledge Base: de-moivre-oq-02-oq-03
 
-Insights accumulated during research on this problem.
+Minimax property of Chebyshev polynomials. Lean: `proofs/Proofs/DeMoivreOQ02OQ03.lean`.
 
 ---
 
-## Problem Understanding
+## Status (as of researcher-1, 2026-06-19)
 
-[Initial observations about the problem will be recorded here]
+**SOLVED for the minimax value.** The capstone `chebyshev_minimax` proves both
+halves of the classical theorem over `ℝ`, `0 sorry / 0 axiom / 0 native_decide`:
 
----
+- **Achievability** (`monicChebyshev_abs_le` + `monicChebyshev_eval_node`): the
+  monic Chebyshev polynomial `Mₙ = Tₙ / 2^(n-1)` has sup-norm `≤ 2^(1-n)` on
+  `[-1,1]` and equioscillates between `±2^(1-n)` at the `n+1` nodes
+  `cos(kπ/n)`.
+- **Optimality** (`monicChebyshev_minimax`): every monic degree-`n` real `p`
+  attains `|p| ≥ 2^(1-n)` somewhere on `[-1,1]`, so nothing beats `Mₙ`.
 
-## Insights
+Gallery `meta.json` accurately records `status: verified`, `badge: original`,
+`axiomCount 0`, `sorries 0`, `theoremCount 15` — confirmed against the source.
 
-[Insights from research attempts will be accumulated here]
+> Verification caveat: not re-run through the kernel this session — Docker was
+> OOM-unsafe (15 concurrent sibling containers, ~7.0/7.83 GiB) and the Aristotle
+> MCP was down (`prove_file` → 404). The `verified` claim rests on the prior
+> build that registered the gallery entry; the source is unchanged this session.
 
----
+## Proof architecture (for future sessions)
 
-## Dead Ends
+The file is self-contained from two Mathlib facts: `T_real_cos`
+(`Tₙ(cos θ) = cos nθ`, the De Moivre identity) and the recurrence `T_add_two`.
 
-[Approaches known not to work will be documented here]
+1. **Analysis core** — `chebyshev_abs_eval_le_one` (`|Tₙ| ≤ 1` on `[-1,1]` via
+   `x = cos(arccos x)`) and `chebyshev_eval_node` (`Tₙ(cos kπ/n) = (-1)^k`).
+2. **Degree infrastructure** (absent from Mathlib — fills its explicit TODO):
+   `chebyshev_natDegree = n` and `chebyshev_leadingCoeff = 2^(n-1)`, both from a
+   single paired induction `chebyshev_deg_lead_pair` driven by the two-term
+   recurrence and the helper `deg_lead_recurrence_step`
+   (`(2 X a − b)` degree/leading-coeff under `deg b ≤ deg a`).
+3. **Monic normalization** — `monicChebyshev`, `_monic`, `_natDegree`, `_abs_le`,
+   `_eval_node`.
+4. **Optimality** — the classical equioscillation + IVT root-count: if a monic
+   `p` had `‖p‖∞ < 2^(1-n)`, then `q = Mₙ − p` (degree `< n`, since the leading
+   `2^(1-n)·X^n` terms cancel) would *strictly* alternate sign at the `n+1`
+   nodes, so by `intermediate_value_uIcc` it would have a root strictly inside
+   each of the `n` node-intervals — `n` distinct roots (`StrictAnti` node map
+   `node_strict_anti` ⟹ injective root family) — contradicting
+   `card_roots' q ≤ natDegree q < n`.
+
+## Open frontier — UNIQUENESS (the natural next target)
+
+`problem.md` headlines "the monic Chebyshev polynomial **uniquely** minimizes",
+but the file proves only that the minimal *value* is `2^(1-n)` (existence +
+optimality). **Uniqueness — that `Mₙ` is the only monic degree-`n` minimizer —
+is not yet formalized.** Proposed statement:
+
+```lean
+theorem monicChebyshev_unique (p : ℝ[X]) (hp : p.Monic) (n : ℕ) (hn : 0 < n)
+    (hpdeg : p.natDegree = n)
+    (hmin : ∀ x ∈ Set.Icc (-1 : ℝ) 1, |p.eval x| ≤ ((2 : ℝ) ^ (n - 1))⁻¹) :
+    p = monicChebyshev n
+```
+
+**Strategy & why it is genuinely harder than optimality.** For a minimizer `p`
+the inequality at the nodes is only *weak*: `(-1)^k·q(x_k) = 2^(1-n) −
+(-1)^k·p(x_k) ≥ 2^(1-n) − |p(x_k)| ≥ 0`, i.e. `q = Mₙ − p` (degree `≤ n−1`)
+*weakly* alternates over the `n+1` nodes. The optimality proof exploited a
+**strict** alternation to drop a root strictly *inside* each interval; with weak
+inequalities a node can itself be a zero, and turning "weak alternation across
+`n+1` nodes" into "`n` roots counted with multiplicity" needs the multiplicity
+bookkeeping (a node-zero shared by two adjacent intervals must be counted with
+multiplicity ≥ 2, via a Rolle/`rootMultiplicity` argument). This is the standard
+Chebyshev-uniqueness subtlety; budget ~100–150 lines and a careful
+`Polynomial.roots`-with-multiplicity count. **Do not ship it unbuilt** — it is
+delicate enough that kernel verification is essential.
+
+## Other outward directions (lower priority)
+
+- **General interval `[a,b]`**: affine change of variables rescales the minimax
+  value to `2·((b−a)/4)^n`. A corollary, not new theory — weaker as a follow-up.
+- **Discrete / weighted minimax, `Lᵖ` analogues**: different machinery; out of
+  scope of the equioscillation route.
+
+## Dead ends / notes
+
+- The inner-product/orthogonality route to optimality (Approach B in
+  `problem.md`) was not needed — the sign-change/IVT route (Approach A) carried
+  the whole proof and is the cleaner Lean path.

--- a/src/data/research/problems/de-moivre-oq-02-oq-03.json
+++ b/src/data/research/problems/de-moivre-oq-02-oq-03.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-19T01:45:00-07:00",
-    "iteration": 2,
-    "focus": "Both halves of the Chebyshev minimax theorem formalized in proofs/Proofs/DeMoivreOQ02OQ03.lean: achievability (monicChebyshev sup-norm ≤ 2^(1-n), equioscillation) and optimality (monicChebyshev_minimax: every monic degree-n p attains |p| ≥ 2^(1-n) somewhere). Capstone chebyshev_minimax bundles both. 0 sorry / 0 axiom.",
+    "iteration": 3,
+    "focus": "researcher-1, 2026-06-19 (iter3): SOLVED-state review. Confirmed DeMoivreOQ02OQ03.lean is genuinely complete for the minimax VALUE (chebyshev_minimax bundles achievability + optimality, 0 sorry/0 axiom/0 native_decide; gallery meta verified/original is accurate). Could NOT re-run kernel build (Docker OOM-unsafe: 15 sibling containers ~7.0/7.83 GiB; Aristotle MCP 404). Filled the previously-EMPTY knowledge.md stub with the full proof architecture and pinned the precise open frontier: UNIQUENESS of the minimizer (problem.md headlines uniquely-minimizes, but only the value is proved). Drafted the monicChebyshev_unique target + strategy; flagged it as delicate (weak equioscillation => n roots WITH MULTIPLICITY, ~100-150 lines, Rolle/rootMultiplicity bookkeeping) and NOT to be shipped unbuilt. No new Lean this iteration (documentation + frontier identification only).",
     "blockers": [],
     "nextAction": "Docker build verification of Proofs.DeMoivreOQ02OQ03, then ship PR.",
     "attemptCounts": {
@@ -38,15 +38,18 @@
     "insights": [
       "Optimality half = classical equioscillation argument: if monic p had ‖p‖∞<2^(1-n) on [-1,1], then q=Mₙ-p inherits the sign of Mₙ at the n+1 extreme nodes cos(kπ/n) (strict alternation (-1)^k·q(node)>0), giving by IVT a root strictly between each consecutive node pair = n distinct roots; but deg q < n (difference of two monic degree-n polys via degree_sub_lt), contradicting card_roots'.",
       "Lean trick to avoid parity case-explosion in the IVT step: intermediate_value_uIcc works on the unordered interval, so with Set.mem_uIcc_of_le/_of_ge a single Nat.even_or_odd split suffices to place 0 between the two node values.",
-      "Roots are strictly interior (open intervals) because q is nonzero at the nodes themselves, so the n chosen roots are distinct via StrictAnti (node_strict_anti: cos(kπ/n) strictly decreasing in k), hence the selection map is injective."
+      "Roots are strictly interior (open intervals) because q is nonzero at the nodes themselves, so the n chosen roots are distinct via StrictAnti (node_strict_anti: cos(kπ/n) strictly decreasing in k), hence the selection map is injective.",
+      "chebyshev_minimax proves the minimax VALUE (achievability + optimality) but NOT uniqueness of the minimizer; problem.md headlines uniqueness, so uniqueness is the genuine open frontier.",
+      "Uniqueness is strictly harder than optimality: a minimizer gives only WEAK alternation of q = Mₙ - p at the n+1 nodes, so the strict-IVT root-count of monicChebyshev_minimax does not transfer; need n roots counted WITH MULTIPLICITY (Rolle/rootMultiplicity).",
+      "Degree infrastructure chebyshev_natDegree/chebyshev_leadingCoeff fills an explicit Mathlib TODO (Polynomial/Chebyshev.lean) — candidate for upstream contribution."
     ],
     "mathlibGaps": [
       "Mathlib lacks the Chebyshev minimax theorem and the natDegree/leadingCoeff lemmas for Tₙ; this file now supplies both halves plus that infrastructure. The TODO in Mathlib/RingTheory/Polynomial/Chebyshev.lean ('Prove minimax properties of Chebyshev polynomials') remains open upstream."
     ],
     "nextSteps": [
-      "Upstream the degree/leadingCoeff infrastructure and the minimax theorem to Mathlib (fills the explicit TODO).",
-      "Follow-up OQ: uniqueness of the minimizer — Mₙ is the *unique* monic degree-n polynomial attaining 2^(1-n) (equioscillation forces equality).",
-      "Follow-up OQ: weighted / L^p Chebyshev minimax variants and the second-kind polynomials Uₙ."
+      "Prove monicChebyshev_unique (the uniqueness half) via the weak-equioscillation + multiplicity root count. Requires a kernel build — do not ship unbuilt.",
+      "Once a backend recovers, route the uniqueness multiplicity lemma to Aristotle prove() as a single hard supporting lemma.",
+      "Optional: consider upstreaming chebyshev_natDegree / chebyshev_leadingCoeff to Mathlib (fills its Chebyshev minimax TODO)."
     ],
     "markdown": "# Knowledge Base: de-moivre-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -62,5 +65,6 @@
     "urls": [],
     "mathlib": []
   },
-  "started": "2026-06-18T23:18:44-07:00"
+  "started": "2026-06-18T23:18:44-07:00",
+  "lastUpdate": "2026-06-19T10:40:00-08:00"
 }


### PR DESCRIPTION
## Summary
SOLVED-state review of the Chebyshev minimax formalization (`DeMoivreOQ02OQ03.lean`). **No new Lean** — both verification backends were unavailable this session, so I did documentation + open-frontier identification rather than risk shipping an unbuilt delicate proof.

## What I confirmed
- `chebyshev_minimax` genuinely proves the minimax **value** `2^(1-n)` in full: achievability (`monicChebyshev_abs_le` + equioscillation) **and** optimality (`monicChebyshev_minimax`, the equioscillation + IVT root-count argument). `0 sorry / 0 axiom / 0 native_decide`.
- Gallery `meta.json` (`status: verified`, `badge: original`, `axiomCount 0`, `sorries 0`) is **accurate** — no integrity gap.

## What I added
- Filled the previously **empty** `knowledge.md` stub with the full proof architecture (analysis core → degree infrastructure that fills a Mathlib TODO → monic normalization → equioscillation+IVT optimality).
- Pinned the precise **open frontier: uniqueness of the minimizer**. `problem.md` headlines "the monic Chebyshev polynomial *uniquely* minimizes", but the file proves only the value (existence + optimality). Drafted the `monicChebyshev_unique` target statement and its strategy.

## Findings
- **Uniqueness is strictly harder than optimality.** A minimizer yields only *weak* alternation of `q = Mₙ − p` at the `n+1` nodes, so the strict-IVT root-count used for optimality does not transfer; uniqueness needs `n` roots counted **with multiplicity** (Rolle / `rootMultiplicity` bookkeeping at shared node-zeros), ~100–150 lines. Flagged as **not to be shipped unbuilt**.
- `chebyshev_natDegree` / `chebyshev_leadingCoeff` fill an explicit Mathlib TODO — candidate for upstream contribution.

## Verification caveat (honest)
Not kernel-checked this session: Docker host OOM-unsafe (15 concurrent sibling agent containers, ~7.0/7.83 GiB) and Aristotle MCP `prove_file` → `404`. The `verified` status rests on the prior build that registered the gallery entry; the Lean source is unchanged.

## Files modified
- `research/problems/de-moivre-oq-02-oq-03/knowledge.md`
- `src/data/research/problems/de-moivre-oq-02-oq-03.json`

## Status
**Outcome**: surveyed (solved-state documentation; no new theorems)
**Next Steps**: prove `monicChebyshev_unique` (uniqueness) once a build backend is available — the multiplicity root-count is the crux and must be kernel-verified.

🤖 Generated by researcher-1