### PR TITLE
audit(erdos-101): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2964,9 +2964,9 @@
       "result": "clean"
     },
     "erdos-101": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-19T10:28:22Z",
       "result": "clean"
     },
     "erdos-1010": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-101 (CLEAN)

**Proof**: Erdős Problem #101 — Four-Point Lines from Planar Point Sets (OPEN, \$100)
**Result**: CLEAN — all meta.json claims match the Lean source. Durable tracker bump (auditCount 4→5).

## Verification

Source `proofs/Proofs/Erdos101Problem.lean`:
- **758 lines** ✓ (matches `lineCount`)
- **0 literal axioms** ✓ (matches `axiomCount` 0)
- **0 sorries** ✓
- **0 native_decide**, **0 True-stubs** ✓
- **23 theorems** ✓ (matches `theoremCount`)
- **5 defs + 1 structure** ✓ (matches `definitionCount` 5)

### Integrity checks
- `axiomCount 0` is correct: `PlanarPointSet.size_pos : points.card > 0` is data well-formedness (nonemptiness), not an assumption-carrying field — consistent with the policy applied to erdos-102/103.
- No **Mathlib-wrapper masking**: the upper-bound ladder (`trivial_upper_bound_sq` ≤ n², `trivial_upper_bound` ≤ n(n−1)/2, `improved_upper_bound` ≤ n(n−1)/12, `fourCollinearThrough_bound` ≤ (n−1)/3) is proved from first principles via `noFiveCollinear_line_bound` + overlap lemmas + disjoint pair-packing, not delegated to a deep Mathlib theorem.
- All 7 proofStrategy-cited theorem names exist and match.
- `status: axiomatized` / `badge: wip` is the conservative framing: the main o(n²) conjecture is recorded as a comment only (carries no logical force), and the file proves only unconditional partial bounds. `assumptions` field honestly states 0 axioms / 0 sorries with main result not yet fully formalized.
- Companion `Erdos101OQ04.lean` (additionalFile) carries 2 open-question sorries, each labeled in its own docstrings as sorry-bodied scaffolds — outside erdos-101's primary claims (meta counts pertain to the main proofRepoPath).

No overclaiming detected. Tracker updated to reflect re-audit.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)