### PR TITLE
audit(erdos-1008): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2934,9 +2934,9 @@
       "result": "clean"
     },
     "erdos-1008": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-19T10:40:23Z",
       "result": "clean"
     },
     "erdos-1008-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit: erdos-1008

**Result: CLEAN** — all meta.json fields verified exact against `proofs/Proofs/Erdos1008Problem.lean`.

Erdős #1008 (C₄-free subgraphs, Conlon-Fox-Sudakov 2014, SOLVED). Tier C axiomatized entry — single disclosed axiom, supporting results genuinely proved.

### Verification

| Field | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| axiomCount | 1 | 1 (`axiom erdos_1008`, L590) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 27 | 27 (incl. `private theorem`/`private lemma`) | ✓ |
| definitionCount | 6 | 6 | ✓ |
| lineCount | 698 | 698 | ✓ |
| native_decide | — | 0 | ✓ |
| status/badge | axiomatized / axiom | correct for 1 axiom | ✓ |

### Integrity findings

- **Axiom properly disclosed.** The single axiom is the Conlon-Fox-Sudakov existential (Ω(m^{2/3}) C₄-free subgraph), disclosed in description, `proofStrategy`, and `assumptions`. No axiom-masking.
- **Supporting results genuinely proved.** Kővári-Sós-Turán C₄-case (`kovari_sos_turan`), K₂₂↔C₄ equivalence, hereditary/monotone/common-neighbor lemmas, Folkman ratio, and `exponent_optimal` (2/3 tightness) are all proved from first principles — only the CFS existential is axiomatized.
- **No overclaim on existence.** `c4free_subgraph_exists` (L690) is the honest *trivial* empty-graph existence — the Lean docstring explicitly states "trivially: the empty graph" — not the strong bound.
- **Companion not counted.** `Erdos1008ProblemProvable.lean` has 4 axioms but is **not imported** by the main file and does not drive the primary entry's claims (additionalFile axioms ≠ primary entry assumptions).
- No `True` stubs, no `native_decide`, no Mathlib-wrapper masking.

### Gotcha logged
`grep '^theorem'` / `^(theorem|lemma)` reports only 13 — it misses `private theorem` / `private lemma`. Real declaration count is 27, matching meta exactly.

auditCount 5 → 6, lastAudited refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)