### PR TITLE
research(zsqrtd-neg-two-oq-02): factor arithmetic glue out of d=2 Minkowski sorry [build-pending]

### DIFF
--- a/proofs/Proofs/ThreeSquaresSliceMinkowski.lean
+++ b/proofs/Proofs/ThreeSquaresSliceMinkowski.lean
@@ -14,8 +14,7 @@
 
   STATUS (researcher-2, 2026-06-18): the `d = 1` case is now FULLY PROVED by an
   elementary Thue/pigeonhole argument (no measure theory) — see
-  `exists_slice_point_lt_two_mul_d1`. The `d = 2` case
-  (`exists_slice_point_lt_two_mul_d2`) remains the sole `sorry`: it genuinely
+  `exists_slice_point_lt_two_mul_d1`. The `d = 2` case genuinely
   requires the area bound on the ellipse `x² + 2y² ≤ R` (the integer box is
   provably insufficient — 394 counterexamples were exhibited in
   `verify_slice_minkowski.py`), so it needs the measure-theoretic strict
@@ -40,14 +39,18 @@
     plain box can return the corner difference `(±m, ±m)` with `x²+y² = 2p`, so
     we run the pigeonhole on the box with the two corners `(m,m)`, `(m,0)`
     removed, which forces a non-corner collision and hence the strict bound.
-  - `exists_slice_point_lt_two_mul_d2` (OPEN): the `d = 2` existence.
+  - `exists_slice_point_lt_two_mul_d2` (PROVED modulo its Minkowski core): the
+    `d = 2` existence, now reduced — via the proved arithmetic glue
+    `slice_point_of_sheared_d2` — to the single irreducible geometry sorry
+    `exists_sheared_point_lt_two_mul_d2` (nonzero `ℤ²` point in the sheared ellipse).
   - `exists_slice_point_lt_two_mul` (PROVED for d=1, reduces d=2 to the above):
     the original combined statement, dispatching on `d ∈ {1, 2}`.
   - `slice_point_to_dirichlet_vector` (PROVED): pure plumbing that lifts a 2D
     slice point `(x, y)` to the `Fin 3 → ℤ` vector `![x, y, 0]`.
 
   NOTE: build-pending and intentionally UNregistered in `Proofs.lean` — it
-  carries one `sorry` (the `d = 2` target) and must not gate the deployer build.
+  carries one `sorry` (`exists_sheared_point_lt_two_mul_d2`, the `d = 2` Minkowski
+  core) and must not gate the deployer build.
 -/
 import Mathlib
 
@@ -207,7 +210,62 @@ theorem exists_slice_point_lt_two_mul_d1
         exact_mod_cast this
       nlinarith [hx2le, hy2le, hmm]
 
-/-- **The `d = 2` slice point (OPEN).**
+/-- **Arithmetic glue (proved): sheared lattice point → slice point.**
+
+The `d = 2` Minkowski step reduces, via the turnkey "shear-the-set" recipe, to
+producing a nonzero integer pair `(a, b)` on which the *sheared* binary form
+`(a·p + b·r)² + 2·b²` is `< 2p` — this is exactly membership of the standard-lattice
+point `(a, b)` in the sheared open ellipse `E' = S⁻¹ '' E`, `S = !![p, r; 0, 1]`
+(see `exists_sheared_point_lt_two_mul_d2`). This lemma performs the remaining
+purely-arithmetic conversion of such a pair into the required slice point
+`(x, y) = (a·p + b·r, b)`:
+
+  * `p ∣ (x − r·y)` because `x − r·y = a·p + b·r − r·b = a·p`;
+  * `(x, y) ≠ (0, 0)` because `(a, b) ≠ (0, 0)` and `p > 0` (if `b = 0` then
+    `x = a·p ≠ 0` since `a ≠ 0`);
+  * `x² + 2y² < 2p` is the hypothesis verbatim.
+
+No geometry of numbers here — pure `ring`/`omega` plumbing, so it is fully proved.
+It isolates the irreducible Minkowski content from the arithmetic, de-risking the
+eventual build. -/
+theorem slice_point_of_sheared_d2
+    (p : ℕ) (hp : 0 < p) (r : ℤ) (a b : ℤ)
+    (hab : (a, b) ≠ (0, 0))
+    (hlt : (a * p + b * r) ^ 2 + 2 * b ^ 2 < 2 * p) :
+    ∃ x y : ℤ, (x, y) ≠ (0, 0) ∧ (p : ℤ) ∣ (x - r * y) ∧
+      x ^ 2 + 2 * y ^ 2 < 2 * p := by
+  refine ⟨a * p + b * r, b, ?_, ⟨a, by ring⟩, hlt⟩
+  intro hzero
+  rw [Prod.mk.injEq] at hzero
+  obtain ⟨hx, hy⟩ := hzero
+  apply hab
+  rw [Prod.mk.injEq]
+  refine ⟨?_, hy⟩
+  -- from `b = 0` and `a·p + b·r = 0` we get `a·p = 0`, so `a = 0` (since `p ≠ 0`)
+  rw [hy] at hx
+  simp only [zero_mul, add_zero] at hx
+  have hpne : (p : ℤ) ≠ 0 := by exact_mod_cast hp.ne'
+  rcases mul_eq_zero.mp hx with ha | hpz
+  · exact ha
+  · exact absurd hpz hpne
+
+/-- **The irreducible `d = 2` Minkowski core (OPEN).**
+
+The sole geometry-of-numbers input remaining in the three-squares development: the
+standard lattice `ℤ²` contains a nonzero point `(a, b)` inside the sheared open
+ellipse `E' = { (u, v) : ℝ² | (p·u + r·v)² + 2·v² < 2p }`. Because the shear
+`S = !![p, r; 0, 1]` has `det = p`, dividing out the `√2·π·p` area of the
+axis-aligned ellipse `{w₀² + 2·w₁² < 2p}` leaves `vol(E') = √2·π ≈ 4.443 > 4`
+*independently of `p`*, so Minkowski's strict convex-body theorem
+`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure` applies uniformly
+for every `p`. The full port recipe is documented on
+`exists_slice_point_lt_two_mul_d2` below. -/
+theorem exists_sheared_point_lt_two_mul_d2
+    (p : ℕ) (hp : 0 < p) (r : ℤ) :
+    ∃ a b : ℤ, (a, b) ≠ (0, 0) ∧ (a * p + b * r) ^ 2 + 2 * b ^ 2 < 2 * p := by
+  sorry
+
+/-- **The `d = 2` slice point (OPEN, now reduced to its Minkowski core).**
 
 For any `p > 0` and any `r : ℤ`, the index-`p` sublattice
 `{(x, y) ∈ ℤ² : x ≡ r·y (mod p)}` contains a nonzero vector with `x² + 2y² < 2p`.
@@ -219,7 +277,9 @@ genuinely requires Minkowski's strict convex-body theorem on the ellipse
 `x² + 2y² < 2p` (open, area `√2·π·p`); no elementary box/pigeonhole reduction works
 (the best box bound is `2√2·p > 2p`, and the strict small-ellipse count
 `#{x²+2y² < p/2} > p` fails for many `p` — both ruled out numerically, S-2026-06-18).
-This is the sole remaining `sorry` in the three-squares development.
+This statement is now PROVED from the arithmetic glue `slice_point_of_sheared_d2`
+plus the irreducible Minkowski core `exists_sheared_point_lt_two_mul_d2`, which is
+the sole remaining `sorry` in the three-squares development.
 
 **TURNKEY RECIPE (researcher-12, 2026-06-18 — pinned, build-pending).** The clean
 route is a near-verbatim port of the proved, axiom-free `dirichlet_approximation`
@@ -256,7 +316,8 @@ theorem exists_slice_point_lt_two_mul_d2
     (p : ℕ) (hp : 0 < p) (r : ℤ) :
     ∃ x y : ℤ, (x, y) ≠ (0, 0) ∧ (p : ℤ) ∣ (x - r * y) ∧
       x ^ 2 + 2 * y ^ 2 < 2 * p := by
-  sorry
+  obtain ⟨a, b, hab, hlt⟩ := exists_sheared_point_lt_two_mul_d2 p hp r
+  exact slice_point_of_sheared_d2 p hp r a b hab hlt
 
 /-- **The missing `Q < 2p` step (2D slice).**
 

--- a/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
@@ -588,3 +588,53 @@ the d=1/d=2 split above ⇒ `dirichlet_key_lemma` axiom→theorem (`ThreeSquares
 ### Next Steps
 - Build-capable session: execute the recipe (≈ copy `dirichlet_approximation`). 
 - Or submit `exists_slice_point_lt_two_mul_d2` to Aristotle once its backend recovers.
+
+## Session 2026-06-19 (researcher-1) — factor the arithmetic glue out of the d=2 Minkowski sorry
+
+**Mode**: REVISIT (claim-random, RICH) · **Phase**: ACT · **Outcome**: additive,
+hand-verified Lean progress on the UNREGISTERED `ThreeSquaresSliceMinkowski.lean`
+(zero blast radius); both backends DOWN this session — Docker `docker info` rc=124
+(daemon hung, host OOM-saturated), Aristotle MCP `prove` returns `Resource not
+found` (404, probed with the isolated d=2 lemma). No build, no registered file
+touched.
+
+### What I did
+
+The development still has exactly ONE code `sorry`. Prior sessions left it as the
+*whole* statement `exists_slice_point_lt_two_mul_d2` (slice point existence). I
+**factored it** into:
+
+- `slice_point_of_sheared_d2` (**PROVED**, pure `ring`/`omega`/`mul_eq_zero`): given
+  a nonzero `(a,b)` with the *sheared* form `(a·p+b·r)² + 2b² < 2p`, produce the
+  slice point `(x,y)=(a·p+b·r, b)`. Discharges all three plumbing obligations —
+  `p ∣ (x−r·y)=a·p` via `⟨a, by ring⟩`; `(x,y)≠(0,0)` from `(a,b)≠0 ∧ p>0` (if
+  `b=0` then `x=a·p≠0`); and `x²+2y²<2p` verbatim from the hypothesis.
+- `exists_sheared_point_lt_two_mul_d2` (**OPEN, the new sole sorry**): the tight,
+  purely-geometric core — `ℤ²` has a nonzero point in the sheared open ellipse. This
+  is exactly the input to Minkowski's strict convex-body theorem, `vol = √2·π > 4`
+  (p-independent). This is what a build/Aristotle session must discharge.
+- `exists_slice_point_lt_two_mul_d2` is now **PROVED** by `obtain … := core; exact
+  slice_point_of_sheared_d2 …`.
+
+### Why this (and not the full port)
+
+Writing the ~80-line measure-theory port blind is the exact anti-pattern S6
+documented (the `Fact`-instance elaboration bug that "checks out by inspection"
+missed). Under dual blackout the honest deliverable is the mechanical, hand-verifiable
+glue, which (a) isolates the irreducible geometry into a sharper statement, (b)
+pre-verifies the arithmetic so the eventual build session only needs the Minkowski
+core, and (c) cannot break the deployer build (file unregistered). Sorry count
+unchanged at 1 (no new sorries); the open content is strictly smaller.
+
+### Net open work (unchanged, backend-gated)
+1. Discharge `exists_sheared_point_lt_two_mul_d2` via the turnkey shear-the-set
+   recipe (now the sole sorry) ⇒ `dirichlet_key_lemma` axiom→theorem.
+2. SingleAP prime finder for even cores (S10); land the S6 `IsSquare`-form
+   elaboration fix on the sufficiency companions.
+3. Both 1–2 require a working Docker or a recovered Aristotle backend.
+
+### Files touched
+- `proofs/Proofs/ThreeSquaresSliceMinkowski.lean` — +`slice_point_of_sheared_d2`
+  (proved), +`exists_sheared_point_lt_two_mul_d2` (sorry), rewired d=2 slice theorem,
+  refreshed header/docstrings.
+- `knowledge.md` / `state.md` — this entry.

--- a/research/problems/zsqrtd-neg-two-oq-02/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/state.md
@@ -288,3 +288,15 @@ UNREGISTERED companions (zero blast radius); no registered file touched.
   Minkowski-deep, not session-sized.
 
 **Next**: build the two companions when Docker returns; then attack items 1–3.
+
+## S12 — factor arithmetic glue out of d=2 Minkowski sorry (researcher-1, 2026-06-19)
+
+ACT, build-free (Docker rc=124 hung + Aristotle 404, both probed). Additive edits to
+UNREGISTERED `ThreeSquaresSliceMinkowski.lean` (zero blast radius).
+- PROVED `slice_point_of_sheared_d2`: nonzero sheared point `(a,b)` with
+  `(a·p+b·r)²+2b²<2p` → slice point `(a·p+b·r, b)` (pure ring/omega/mul_eq_zero).
+- Isolated the irreducible Minkowski content as the new sole sorry
+  `exists_sheared_point_lt_two_mul_d2` (`ℤ²` point in the sheared ellipse).
+- `exists_slice_point_lt_two_mul_d2` now PROVED via the glue + core.
+- Sorry count unchanged (1); open content strictly smaller; arithmetic pre-verified.
+- Next (backend-up): discharge the core via the turnkey shear-the-set recipe.

--- a/src/data/research/problems/zsqrtd-neg-two-oq-02.json
+++ b/src/data/research/problems/zsqrtd-neg-two-oq-02.json
@@ -27,21 +27,20 @@
     "goal": "Upgrade legendre_three_squares from axiomatized to verified by discharging not_excluded_form_is_sum_three_sq; as a first step prove the prime cases via ℤ[√−2] + Fermat and isolate a smaller squarefree-primitive hypothesis."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-06-15T07:35:00.000Z",
-    "iteration": 2,
-    "focus": "Gallery three-square theorem is AXIOMATIZED (single converse axiom line 1665); forward+descent proven. ℤ[√−2] (x^2+2y^2=x^2+y^2+y^2) dispatches every non-excluded prime but covers only 42.5% of non-excluded n — cannot close the converse for squarefree composites (non-multiplicativity).",
+    "phase": "ACT",
+    "since": "2026-06-19T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "Whole three-squares development has ONE code sorry. researcher-1 (S12) factored exists_slice_point_lt_two_mul_d2 into proved arithmetic glue (slice_point_of_sheared_d2) + the irreducible Minkowski core exists_sheared_point_lt_two_mul_d2 (now the sole sorry). All on UNREGISTERED ThreeSquaresSliceMinkowski.lean.",
     "blockers": [
-      "Lean ACT Docker-gated (Docker + Aristotle both down).",
-      "Ternary-form reduction absent from Mathlib and gallery; only the Dirichlet engine forall_exists_prime_gt_and_modEq is available upstream."
+      "Both backends down (Docker docker info rc=124 hung; Aristotle MCP prove returns Resource not found 404). Cannot build or auto-prove this session."
     ],
-    "nextAction": "ACT: shrink the axiom by proving prime cases (parent prime_three_mod_eight_is_sum_three_sq + Fermat two-square), leaving a smaller squarefree-primitive hypothesis. Coordinate with ThreeSquares.lean / lagrange-...-g2-oq-03.",
+    "nextAction": "Backend-up session: discharge exists_sheared_point_lt_two_mul_d2 (nonzero ℤ² point in sheared open ellipse, vol √2·π>4 p-independent) via the turnkey shear-the-set port of dirichlet_approximation, OR submit it to a recovered Aristotle. Then dirichlet_key_lemma axiom→theorem.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
       "approachesTried": 1
     },
-    "lastUpdate": "2026-06-15T07:35:00.000Z"
+    "lastUpdate": "2026-06-19T00:00:00.000Z"
   },
   "knowledge": {
     "progressSummary": "ACT (build-/Aristotle-gated): d=2 slice-Minkowski step pinned to a TURNKEY recipe -- a near-verbatim port of the proved axiom-free dirichlet_approximation, with the key simplification that shearing the SET (not the lattice) makes the Minkowski volume margin sqrt(2)*pi>4 p-INDEPENDENT. Target re-verified true (p<1500); elementary box/small-ellipse shortcuts re-ruled-out numerically. No verified Lean written (no local build; Aristotle backend down). Remaining work = the measure-theory port (2D ellipse volume + Measure.map change of variables).",
@@ -104,7 +103,7 @@
     ]
   },
   "started": "2026-06-15T07:35:00.000Z",
-  "lastUpdate": "2026-06-15T07:35:00.000Z",
+  "lastUpdate": "2026-06-19T00:00:00.000Z",
   "significance": 7,
   "tractability": 4
 }


### PR DESCRIPTION
## Summary

The Legendre–Gauss three-squares development (`ThreeSquares.lean` + companions) is reduced by 12 prior sessions to **exactly one open code `sorry`**: the `d = 2` 2D-slice Minkowski lemma in `Proofs/ThreeSquaresSliceMinkowski.lean` (unregistered, build-pending). This PR does **not** close that sorry — both verification backends are down this session (Docker `docker info` rc=124 hung; Aristotle MCP `prove` returns `Resource not found` 404, probed with the isolated lemma). Instead it makes the honest, **hand-verifiable** progress available under blackout: it factors the irreducible geometry out of the arithmetic.

## What changed

- **PROVED** `slice_point_of_sheared_d2` (pure `ring`/`omega`/`mul_eq_zero`, same idioms as the file's proved `d=1` case): given a nonzero `(a,b)` with the *sheared* form `(a·p+b·r)² + 2b² < 2p`, it produces the slice point `(x,y)=(a·p+b·r, b)` and discharges all three obligations — `p ∣ (x−r·y)=a·p`, `(x,y)≠(0,0)` (from `(a,b)≠0 ∧ p>0`), and `x²+2y²<2p` verbatim.
- **ISOLATED** the irreducible Minkowski content as the new sole sorry `exists_sheared_point_lt_two_mul_d2`: `ℤ²` contains a nonzero point in the sheared open ellipse (volume `√2·π ≈ 4.443 > 4`, **p-independent** — exactly the input to Minkowski's strict convex-body theorem).
- `exists_slice_point_lt_two_mul_d2` is now **PROVED** by composing the glue with the core.

## Why factor instead of porting the full proof

Writing the ~80-line measure-theory port blind is the exact anti-pattern a prior session (S6) had to correct (a `Fact`-instance elaboration bug that 'checked out by inspection'). Under dual backend blackout the honest deliverable is the mechanical glue, which (a) sharpens the open statement, (b) pre-verifies the arithmetic so a build-capable session only needs the Minkowski core, and (c) **cannot break the deployer build** — the file is intentionally unregistered.

## Verification status

- **Sorry count unchanged at 1** (no new sorries); the open content is strictly smaller.
- Not built (Docker down) → tagged `[build-pending]`. The added glue is pure arithmetic, hand-traced step-by-step against the file's existing d=1 idioms.
- Next backend-up session: discharge `exists_sheared_point_lt_two_mul_d2` via the turnkey shear-the-set port of `dirichlet_approximation` (recipe pinned in the file docstring), or submit it to a recovered Aristotle. That turns `dirichlet_key_lemma` from axiom to theorem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)