### PR TITLE
audit(dirichlet-approximation-theorem-oq-02): first audit CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16041,6 +16041,12 @@
       "lastAudited": "2026-06-19T07:03:42Z",
       "result": "clean",
       "issues": []
+    },
+    "dirichlet-approximation-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T10:43:33Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `dirichlet-approximation-theorem-oq-02` (Simultaneous Dirichlet Approximation)
**Result**: clean — this was the last unaudited proof in the gallery (2554/2555 → 2555/2555).

### Verification

Source-vs-claims check of `meta.json` against `proofs/Proofs/DirichletApproximationOQ02.lean`:

| Field | meta.json | source | ✓ |
|-------|-----------|--------|---|
| sorries | 0 | 0 (only in docstring) | ✓ |
| axiomCount | 0 | 0 literal, no `native_decide`, no `Lean.ofReduceBool` | ✓ |
| theoremCount | 1 | 1 top-level theorem | ✓ |
| definitionCount | 0 | 0 (`set ξ/δ` are tactic lets) | ✓ |
| lineCount | 106 | 106 | ✓ |
| True stubs | — | none | ✓ |

- **Theorem statement matches the claim exactly**: `simultaneous_dirichlet_approximation` proves `∃ p q, 1 ≤ q ∧ q ≤ Q^d ∧ ∀ i, |q·θᵢ − pᵢ| ≤ 1/Q` under `0 < Q` — the genuine simultaneous (d-dimensional) Dirichlet theorem, not just a bound.
- **Tier B, correctly handled**: the load-bearing pigeonhole is Mathlib's `NormedAddCommGroup.exists_norm_nsmul_le`, specialized to the d-torus. Badge is `mathlib` (not `original`/`verified`), and the dependency is explicitly disclosed in `assumptions` and throughout the overview — no delegation opacity, no axiom masking, no inequality-vs-theorem inflation.
- **status "verified" + badge "mathlib"**: consistent with the established gallery pattern for machine-checked proofs whose core result comes via a Mathlib bridge.

No overclaiming detected. Durable tracker bump only (`auditCount` 0 → 1).

---
Discovered during gallery integrity audit.