### PR TITLE
audit(erdos-1007): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2910,9 +2910,9 @@
       "result": "clean"
     },
     "erdos-1007": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-19T10:47:40Z",
       "result": "clean"
     },
     "erdos-1007-oq-01": {


### PR DESCRIPTION
## Auditor: erdos-1007 re-audit — CLEAN

Re-audited **Erdős Problem #1007** (Graph Dimension, SOLVED — House 2013 / Chaffee-Noble 2016). Verified `meta.json` against `proofs/Proofs/Erdos1007Problem.lean`.

### Findings — all clean
| Field | meta.json | Source | ✓ |
|-------|-----------|--------|---|
| axiomCount | 4 | 4 literal axioms | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 4 | 1 structure + 3 defs | ✓ |
| sorries | 0 | 0 | ✓ |
| lineCount | 129 | 129 | ✓ |
| status / badge | axiomatized / axiom | matches | ✓ |

The 4 axioms (`hasUnitEmbedding_exists`, `min_edges_dimension_4`, `k33_unique_minimum`, `min_edges_dimension_5`) are genuine assumptions, honestly disclosed in `assumptions`. The structure `UnitDistanceEmbedding` defines what an embedding *is* (its `unit_edges` field is a constraint on the data, not a free-floating assumption), so it is not assumption-carrying — axiomCount correctly stays 4.

**No masking**: the substantive mathematics (House's 9-edge lower bound, K₃,₃ uniqueness, Chaffee-Noble dim-5 bound) is correctly axiomatized, not falsely claimed proved. The 3 theorems are trivial numeric verification lemmas. `native_decide` on `k6_has_15_edges` (`Nat.choose 6 2 = 15`) is a trivial check, not a substantive result presented as verified — the existing `axiomatized`/`axiom` classification already covers it.

**Verdict: CLEAN.** auditCount 4 → 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)