### PR TITLE
audit(area-of-circle-oq-01-oq-02-oq-03): fix theorem-count drift 10→14

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ03.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ03.lean
@@ -23,7 +23,7 @@ The key connection: both limits equal πr². By limit uniqueness in ℝ (Hausdor
 there is a unique value toward which both the polygon approximations and the
 FTC integral converge.
 
-## What This File Proves (10 theorems, 0 sorries, 0 axioms)
+## What This File Proves (14 theorems, 0 sorries, 0 axioms)
 
 **Part I**: FTC proof: ∫₀ʳ 2πρ dρ = πr²
 **Part II**: Exhaustion proof: inscribedArea n r → πr²

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03/meta.json
@@ -75,7 +75,7 @@
       "archimedes_squeeze_from_below: inscribed areas form lower Riemann sums",
       "archimedes_squeeze_approx: ε-N formulation of Archimedes' exhaustion",
       "two_methods_one_area: uniqueness — any limit of inscribed areas equals the FTC integral",
-      "10 total theorems, 0 sorries, 0 axioms connecting two millennia of mathematics"
+      "14 total theorems, 0 sorries, 0 axioms connecting two millennia of mathematics"
     ],
     "dateAdded": "2026-04-04",
     "assumptions": "None. This is fully verified with 0 sorries and 0 axioms.",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -409,10 +409,10 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
-      "result": "clean"
+      "lastAudited": "2026-06-19T10:53:13Z",
+      "result": "issues-fixed"
     },
     "area-of-circle-oq-01-oq-02-oq-03-oq-03": {
       "auditCount": 2,


### PR DESCRIPTION
## Re-audit: ISSUES-FIXED (prose drift, undercount)

**Proof**: `area-of-circle-oq-01-oq-02-oq-03` — "Archimedes' Exhaustion Meets the FTC"

### Verification (all EXACT against `Proofs/AreaOfCircleOQ01OQ02OQ03.lean`)
| Field | meta | source | ✓ |
|-------|------|--------|---|
| theoremCount | 14 | 14 (theorem+lemma decls) | ✓ |
| definitionCount | 3 | 3 (`circleArea`, `circumference`, `inscribedArea`) | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 literal axioms, no structure-encoded assumptions | ✓ |
| lineCount | 217 | 217 | ✓ |
| native_decide | — | none → no `Lean.ofReduceBool` | ✓ |

### Tier / claim integrity
- Tier B. Core FTC step (`circumference_integral_eq`) derives from Mathlib's `integral_eq_sub_of_hasDerivAt`. Correctly disclosed via `badge: "mathlib"` + `mathlibDependencies`. No "first formalization" / "we proved" overclaim.
- No True stubs; all 14 theorems have genuine proof bodies.
- `status: verified` is honest — 0 sorries/axioms at the kernel level; `assumptions` accurately notes full verification.

### Sole issue (undercount, not overclaim)
- `originalContributions` final bullet said **"10 total theorems"** and the Lean docstring header (L26) said **"10 theorems"**, while the file has **14** and `description`/`conclusion` already say 14.
- Fixed both: meta text + comment-only Lean edit (zero build impact). Tracker bumped 3→4.

Discovered during gallery integrity re-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)