### PR TITLE
audit(area-of-circle-oq-01-oq-02-oq-02): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -397,9 +397,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-19T10:56:03Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-02-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `area-of-circle-oq-01-oq-02-oq-02` — IBP for Fourier Coefficients of Periodic Functions

Re-audited against `proofs/Proofs/AreaOfCircleOQ01OQ02OQ02.lean`. No issues found.

### Numeric metadata — all EXACT
| Field | meta.json | Lean source |
|-------|-----------|-------------|
| lineCount | 82 | 82 ✓ |
| theoremCount | 2 | 2 ✓ |
| definitionCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |

No `native_decide`, no `True` stubs.

### Tier B (Mathlib-derived core) — honestly presented
The main theorem `fourierCoeffOn_deriv_periodic` obtains its core via Mathlib's `fourierCoeffOn_of_hasDerivAt`. This reliance is correctly disclosed:
- badge is `mathlib` (not `original`)
- `originalContributions` credits "via Mathlib's fourierCoeffOn_of_hasDerivAt"
- `proofStrategy` step 2 and `keyInsights` both name the Mathlib dependency
- The file's own contributions (ofReal-composition chain rule, periodicity boundary elimination, field_simp/ring closure) are genuinely original

No delegation opacity, no axiom masking, no overclaiming. Status `verified` is honest — the file is fully kernel-checked with 0 assumptions; badge `mathlib` discloses the dependency.

**Result**: clean — auditCount 4→5.

---
Discovered during gallery integrity audit.