### PR TITLE
research(erdos-divisibility-pigeonhole): classical pigeonhole divisibility gem (verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2309,6 +2309,7 @@ import Proofs.Erdos998ThreeGapOQ04
 import Proofs.Erdos999Problem
 import Proofs.Erdos99Problem
 import Proofs.Erdos9Problem
+import Proofs.ErdosDivisibilityPigeonhole
 import Proofs.ErdosKoRado
 import Proofs.ErdosMordellChordReduction
 import Proofs.ErdosMordellInequalityOQ01

--- a/proofs/Proofs/ErdosDivisibilityPigeonhole.lean
+++ b/proofs/Proofs/ErdosDivisibilityPigeonhole.lean
@@ -1,0 +1,143 @@
+/-
+# Erdős Divisibility Pigeonhole: among any `n+1` integers from `{1, …, 2n}`, one divides another
+
+A classical pigeonhole gem (often attributed to Erdős; a staple competition
+problem). The statement:
+
+> If `S ⊆ {1, 2, …, 2n}` has `|S| ≥ n + 1`, then there are two **distinct**
+> elements `a, b ∈ S` with `a ∣ b`.
+
+## Proof
+
+Write each `m ≥ 1` uniquely as `m = 2^k · o(m)` with `o(m) := ordCompl[2] m` its
+**odd part**. There are exactly `n` odd numbers in `{1, …, 2n}`, namely
+`1, 3, …, 2n−1`, so the map `m ↦ o(m)` sends the `n+1` elements of `S` into a set
+of size `n`. By pigeonhole two distinct `a, b ∈ S` share an odd part,
+`o(a) = o(b) =: o`. Then `a = 2^{v_2(a)} · o` and `b = 2^{v_2(b)} · o`; whichever
+has the smaller power of two divides the other.
+
+We avoid counting the odd numbers directly: the odd part `o = ordCompl[2] m`
+satisfies `1 ≤ o ≤ m ≤ 2n`, so `(o − 1) / 2 < n`, i.e. `m ↦ (o(m) − 1)/2` lands
+in `Finset.range n`. Because the odd part is *odd*, this half-map is injective on
+odd parts, so a collision of half-maps recovers `o(a) = o(b)`.
+
+## Sharpness
+
+The bound `n+1` is best possible: the `n`-element set `{n+1, …, 2n}` contains no
+pair `a ∣ b` (a proper multiple of `a ≥ n+1` already exceeds `2n`). This is
+recorded as `erdos_divisibility_pigeonhole_sharp`.
+
+## References
+
+* P. Erdős, problem folklore; see e.g. Bóna, *A Walk Through Combinatorics*,
+  the pigeonhole chapter.
+-/
+import Mathlib
+
+namespace ErdosDivisibilityPigeonhole
+
+open Finset
+
+/-- For an odd `o`, halving `(o − 1)/2` and rebuilding recovers `o`:
+    `2 · ((o − 1)/2) + 1 = o`. This makes `o ↦ (o − 1)/2` injective on odd
+    numbers, the key to reading an odd part back off its half-index. -/
+private lemma odd_recover {o : ℕ} (h : Odd o) : 2 * ((o - 1) / 2) + 1 = o := by
+  obtain ⟨k, rfl⟩ := h
+  simp [Nat.add_sub_cancel, Nat.mul_div_cancel_left]
+
+/-- The odd part `ordCompl[2] m` is odd whenever `m ≠ 0`. -/
+private lemma odd_ordCompl {m : ℕ} (hm : m ≠ 0) : Odd (ordCompl[2] m) := by
+  rw [Nat.odd_iff]
+  have h2 : ¬ (2 ∣ ordCompl[2] m) := Nat.not_dvd_ordCompl (by norm_num) hm
+  omega
+
+/-- If two positive numbers share an odd part (`ordCompl[2] a = ordCompl[2] b`),
+    then one divides the other: with `a = 2^{v_2 a}·o` and `b = 2^{v_2 b}·o`, the
+    smaller power of two wins. -/
+private lemma dvd_or_dvd_of_ordCompl_eq {a b : ℕ} (_ha : a ≠ 0) (_hb : b ≠ 0)
+    (h : ordCompl[2] a = ordCompl[2] b) : a ∣ b ∨ b ∣ a := by
+  have ea : 2 ^ (a.factorization 2) * ordCompl[2] a = a :=
+    Nat.ordProj_mul_ordCompl_eq_self a 2
+  have eb : 2 ^ (b.factorization 2) * ordCompl[2] b = b :=
+    Nat.ordProj_mul_ordCompl_eq_self b 2
+  rcases le_total (a.factorization 2) (b.factorization 2) with hle | hle
+  · left
+    -- a ∣ b : 2^{v_2 a}·o ∣ 2^{v_2 b}·o since 2^{v_2 a} ∣ 2^{v_2 b}
+    calc a = 2 ^ (a.factorization 2) * ordCompl[2] a := ea.symm
+      _ ∣ 2 ^ (b.factorization 2) * ordCompl[2] b := by
+          rw [h]; exact mul_dvd_mul_right (pow_dvd_pow 2 hle) _
+      _ = b := eb
+  · right
+    calc b = 2 ^ (b.factorization 2) * ordCompl[2] b := eb.symm
+      _ ∣ 2 ^ (a.factorization 2) * ordCompl[2] a := by
+          rw [h]; exact mul_dvd_mul_right (pow_dvd_pow 2 hle) _
+      _ = a := ea
+
+/-- **Erdős Divisibility Pigeonhole.** Among any `n + 1` integers chosen from
+    `{1, 2, …, 2n}`, some one divides another: if `S ⊆ Icc 1 (2n)` and
+    `n + 1 ≤ |S|`, then there exist distinct `a, b ∈ S` with `a ∣ b`. -/
+theorem erdos_divisibility_pigeonhole {n : ℕ} {S : Finset ℕ}
+    (hsub : S ⊆ Finset.Icc 1 (2 * n)) (hcard : n + 1 ≤ S.card) :
+    ∃ a ∈ S, ∃ b ∈ S, a ≠ b ∧ a ∣ b := by
+  -- The half-index of the odd part lands in `range n`.
+  set f : ℕ → ℕ := fun m => (ordCompl[2] m - 1) / 2 with hf
+  have hmaps : ∀ m ∈ S, f m ∈ Finset.range n := by
+    intro m hm
+    obtain ⟨hm1, hm2⟩ := Finset.mem_Icc.mp (hsub hm)
+    have hmne : m ≠ 0 := by omega
+    have ho_le : ordCompl[2] m ≤ 2 * n := le_trans (Nat.ordCompl_le m 2) hm2
+    rw [Finset.mem_range, hf]
+    -- (o − 1)/2 < n ↔ o − 1 < 2n, and o ≤ 2n.
+    rw [Nat.div_lt_iff_lt_mul (by norm_num)]
+    omega
+  -- Pigeonhole: `range n` is strictly smaller than `S`.
+  have hlt : (Finset.range n).card < S.card := by
+    rw [Finset.card_range]; omega
+  obtain ⟨a, ha, b, hb, hab, hfab⟩ :=
+    Finset.exists_ne_map_eq_of_card_lt_of_maps_to hlt hmaps
+  -- Positivity of `a, b` from `S ⊆ Icc 1 (2n)`.
+  have hane : a ≠ 0 := by
+    obtain ⟨h, _⟩ := Finset.mem_Icc.mp (hsub ha); omega
+  have hbne : b ≠ 0 := by
+    obtain ⟨h, _⟩ := Finset.mem_Icc.mp (hsub hb); omega
+  -- Equal half-indices of (odd) odd parts ⇒ equal odd parts.
+  have hoa : Odd (ordCompl[2] a) := odd_ordCompl hane
+  have hob : Odd (ordCompl[2] b) := odd_ordCompl hbne
+  have hocc : ordCompl[2] a = ordCompl[2] b := by
+    have hhalf : (ordCompl[2] a - 1) / 2 = (ordCompl[2] b - 1) / 2 := by
+      have := hfab
+      simp only [hf] at this
+      exact this
+    rw [← odd_recover hoa, ← odd_recover hob, hhalf]
+  -- One divides the other; orient using `a ≠ b`.
+  rcases dvd_or_dvd_of_ordCompl_eq hane hbne hocc with hd | hd
+  · exact ⟨a, ha, b, hb, hab, hd⟩
+  · exact ⟨b, hb, a, ha, hab.symm, hd⟩
+
+/-- **Sharpness.** The threshold `n + 1` is optimal: the `n`-element set
+    `{n+1, …, 2n}` has no pair `a ∣ b` with `a ≠ b`, because a proper multiple of
+    any `a ≥ n+1` already exceeds `2n`. Hence no `n`-element bound suffices. -/
+theorem erdos_divisibility_pigeonhole_sharp (n : ℕ) :
+    ∃ S : Finset ℕ, S ⊆ Finset.Icc 1 (2 * n) ∧ S.card = n ∧
+      ∀ a ∈ S, ∀ b ∈ S, a ≠ b → ¬ a ∣ b := by
+  refine ⟨Finset.Icc (n + 1) (2 * n), ?_, ?_, ?_⟩
+  · intro x hx
+    rw [Finset.mem_Icc] at hx ⊢; omega
+  · rw [Nat.card_Icc]; omega
+  · intro a ha b hb hab hdvd
+    rw [Finset.mem_Icc] at ha hb
+    -- a ∣ b with a ≠ b and b > 0 forces b ≥ 2a, but 2a ≥ 2(n+1) > 2n ≥ b.
+    have hble : a ≤ b := Nat.le_of_dvd (by omega) hdvd
+    have hlt : a < b := lt_of_le_of_ne hble hab
+    obtain ⟨c, hc⟩ := hdvd
+    have hc2 : 2 ≤ c := by
+      rcases c with _ | _ | c
+      · simp at hc; omega
+      · simp at hc; omega
+      · omega
+    -- `b = a · c` with `c ≥ 2` gives `2a ≤ c·a = a·c = b`, deterministically.
+    have hmul : 2 * a ≤ c * a := mul_le_mul_right' hc2 a
+    have hba : 2 * a ≤ b := by rw [hc, mul_comm a c]; exact hmul
+    omega
+
+end ErdosDivisibilityPigeonhole

--- a/src/data/proofs/erdos-divisibility-pigeonhole/meta.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "erdos-divisibility-pigeonhole",
+  "title": "Erdős Divisibility Pigeonhole: among n+1 integers from {1,…,2n}, one divides another",
+  "slug": "erdos-divisibility-pigeonhole",
+  "description": "A classical pigeonhole theorem (folklore, attributed to Erdős and a staple competition problem): if S ⊆ {1, 2, …, 2n} has at least n+1 elements, then there are two distinct a, b ∈ S with a ∣ b. The proof writes each m as 2^k·o(m) with o(m) = ordCompl[2] m its odd part; there are only n odd numbers in {1,…,2n}, so n+1 elements force a collision o(a) = o(b), after which the smaller power of two divides the larger. The threshold n+1 is sharp: the n-element block {n+1,…,2n} is divisibility-free. Formalized over Mathlib with zero sorries and zero axioms.",
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Pigeonhole_principle",
+    "date": "folklore",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ErdosDivisibilityPigeonhole.lean",
+    "tags": [
+      "combinatorics",
+      "number-theory",
+      "pigeonhole-principle",
+      "divisibility",
+      "erdos",
+      "extremal"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.exists_ne_map_eq_of_card_lt_of_maps_to",
+        "description": "The Finset pigeonhole principle: a map from S into a strictly smaller target collapses two distinct elements. Applied to m ↦ (ordCompl[2] m − 1)/2 : S → Finset.range n, with |range n| = n < n+1 ≤ |S|, it produces the colliding pair.",
+        "module": "Mathlib.Combinatorics.Pigeonhole"
+      },
+      {
+        "theorem": "Nat.ordProj_mul_ordCompl_eq_self",
+        "description": "The 2-adic factorization m = 2^(v₂ m) · ordCompl[2] m. This unique decomposition into a power of two times an odd part is what turns 'equal odd parts' into 'one divides the other'.",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.not_dvd_ordCompl / Nat.ordCompl_le / Nat.ordCompl_pos",
+        "description": "Properties of the odd part o = ordCompl[2] m: it is coprime to 2 (hence odd), satisfies o ≤ m, and is positive when m ≠ 0. These pin o into {1,…,2n} and make the half-index map o ↦ (o−1)/2 injective on odd parts.",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      }
+    ],
+    "originalContributions": [
+      "erdos_divisibility_pigeonhole: a from-scratch Lean proof that any S ⊆ Icc 1 (2n) with |S| ≥ n+1 contains distinct a, b with a ∣ b. Mathlib has the abstract pigeonhole and the 2-adic factorization but not this classical application",
+      "The reduction encoding: rather than counting odd numbers, the proof maps each element to the half-index (ordCompl[2] m − 1)/2 ∈ Finset.range n, sidestepping any Finset.filter cardinality computation; injectivity of this half-map on odd parts (odd_recover) recovers the equality of odd parts from a collision",
+      "dvd_or_dvd_of_ordCompl_eq: equal odd parts ⇒ one divides the other, proved cleanly via the 2-adic decomposition and pow_dvd_pow on the smaller exponent",
+      "erdos_divisibility_pigeonhole_sharp: optimality of the n+1 threshold, exhibiting the divisibility-free n-element block {n+1,…,2n} (a proper multiple of any a ≥ n+1 exceeds 2n)"
+    ],
+    "dateAdded": "2026-06-19",
+    "relatedProblems": [
+      {
+        "id": "dilworth-theorem-oq-01",
+        "relationship": "Both are pigeonhole/extremal results proved with Finset.exists_ne_map_eq_of_card_lt_of_maps_to; the divisibility poset on {1,…,2n} is the natural order-theoretic backdrop (an antichain of odd parts has size n)."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 143,
+    "assumptions": "0 axioms, 0 sorries. The only hypotheses are the structural ones in the statement: S ⊆ {1,…,2n} and |S| ≥ n+1. The proof is self-contained over Mathlib — the abstract Finset pigeonhole principle and the 2-adic factorization m = 2^k·(odd part) are the only non-elementary inputs; everything else is divisibility and Nat arithmetic. Badge is 'original' because the theorem and its sharpness are formalized from first principles (Mathlib does not contain this application).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "This is one of the canonical illustrations of the pigeonhole principle, popularized by Paul Erdős (who reportedly posed it to the young Lajos Pósa over dinner) and a perennial olympiad and Putnam-style problem. Its charm is the choice of pigeonholes: not the numbers themselves but their odd parts. Every positive integer factors uniquely as 2^k times an odd number, and {1,…,2n} contains exactly n odd numbers (1, 3, …, 2n−1); so any n+1 of the integers must repeat an odd part, and two numbers with the same odd part are related by a power of two — one divides the other. The result is the prototype for 'choose the right invariant' pigeonhole arguments throughout combinatorial number theory.",
+    "problemStatement": "Let $n \\ge 0$ and let $S \\subseteq \\{1, 2, \\dots, 2n\\}$ with $|S| \\ge n+1$. Then there exist distinct $a, b \\in S$ with $a \\mid b$. Moreover the threshold is sharp: the $n$-element set $\\{n+1, \\dots, 2n\\}$ contains no such pair.",
+    "text": "Each integer $m \\ge 1$ has a unique odd part $o(m)$ with $m = 2^{k} o(m)$. There are only $n$ possible odd parts in $\\{1,\\dots,2n\\}$, so $n+1$ elements force $o(a) = o(b)$ for some distinct $a, b$; then the one with the smaller power of two divides the other. The block $\\{n+1,\\dots,2n\\}$ shows $n+1$ cannot be lowered.",
+    "proofStrategy": "Map each m ∈ S to the half-index f(m) = (ordCompl[2] m − 1)/2. Since the odd part o = ordCompl[2] m satisfies 1 ≤ o ≤ m ≤ 2n, we get f(m) < n, so f maps S into Finset.range n. As |range n| = n < n+1 ≤ |S|, Finset.exists_ne_map_eq_of_card_lt_of_maps_to yields distinct a, b ∈ S with f(a) = f(b). Both odd parts are odd (Nat.not_dvd_ordCompl), and o ↦ (o−1)/2 is injective on odd numbers (odd_recover: 2·((o−1)/2)+1 = o), so f(a) = f(b) forces ordCompl[2] a = ordCompl[2] b. Finally, writing a = 2^(v₂ a)·o and b = 2^(v₂ b)·o (Nat.ordProj_mul_ordCompl_eq_self) and comparing the exponents, pow_dvd_pow gives a ∣ b or b ∣ a; orient by a ≠ b. Sharpness: in {n+1,…,2n}, a ∣ b with a ≠ b forces b ≥ 2a ≥ 2n+2 > 2n, impossible.",
+    "keyInsights": [
+      "**The odd part is the right pigeonhole**: classifying integers by ⌊2-free core⌋ rather than by value turns a divisibility question into an equality-of-labels collision. {1,…,2n} has exactly n odd parts, one short of the n+1 elements",
+      "**Same odd part ⇒ comparable in the divisibility order**: two numbers sharing an odd part differ only by a power of two, so they form a chain — the smaller exponent divides the larger. This is where 'collision' becomes 'divides'",
+      "**Avoid counting odds with a half-index**: instead of computing the cardinality of the odd numbers in {1,…,2n}, the proof maps odd parts into Finset.range n via o ↦ (o−1)/2 and uses injectivity-on-odds to recover the collision; this keeps the Lean proof free of Finset.filter cardinality lemmas",
+      "**Sharpness is one line of arithmetic**: the top half {n+1,…,2n} is an antichain because doubling the smallest possible divisor already leaves the window — so n+1 is genuinely the optimal threshold, not an artifact of the proof"
+    ],
+    "prerequisites": [
+      "The pigeonhole principle in Finset form (Finset.exists_ne_map_eq_of_card_lt_of_maps_to)",
+      "The 2-adic factorization of a natural number: m = 2^(v₂ m) · (odd part), with ordCompl[2] and ordProj[2]",
+      "Elementary divisibility and natural-number arithmetic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-overview-and-helpers",
+      "title": "Module Overview and Odd-Part Helpers",
+      "startLine": 1,
+      "endLine": 75,
+      "mathContext": "Odd parts: $o(m) = \\mathrm{ordCompl}_2(m)$ is odd, and $o \\mapsto (o-1)/2$ is injective on odd numbers since $2\\cdot((o-1)/2)+1 = o$.",
+      "summary": "Docstring states the theorem, the odd-part pigeonhole proof, and sharpness. Helpers: odd_recover (2·((o−1)/2)+1 = o, injectivity of the half-map on odds), odd_ordCompl (ordCompl[2] m is odd for m ≠ 0, via Nat.not_dvd_ordCompl), and dvd_or_dvd_of_ordCompl_eq (equal odd parts ⇒ one divides the other, via the 2-adic decomposition and pow_dvd_pow)."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Erdős Divisibility Pigeonhole",
+      "startLine": 76,
+      "endLine": 115,
+      "mathContext": "$S \\subseteq \\{1,\\dots,2n\\}$, $|S| \\ge n+1 \\Rightarrow \\exists\\, a \\ne b \\in S,\\ a \\mid b$.",
+      "summary": "erdos_divisibility_pigeonhole: the half-index f(m) = (ordCompl[2] m − 1)/2 maps S into Finset.range n (because o ≤ m ≤ 2n), and |range n| = n < |S|, so the Finset pigeonhole gives distinct a, b with f(a) = f(b). Oddness of the odd parts plus odd_recover upgrade this to ordCompl[2] a = ordCompl[2] b, and dvd_or_dvd_of_ordCompl_eq closes the goal, oriented by a ≠ b."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness of the n+1 Threshold",
+      "startLine": 116,
+      "endLine": 141,
+      "mathContext": "$\\{n+1,\\dots,2n\\}$ has $n$ elements and no pair $a \\mid b$ with $a \\ne b$.",
+      "summary": "erdos_divisibility_pigeonhole_sharp: the block Icc (n+1) (2n) has cardinality n (Nat.card_Icc) and is divisibility-free — if a ∣ b with a ≠ b then b ≥ 2a ≥ 2(n+1) > 2n ≥ b, a contradiction. Hence no n-element bound can replace n+1."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Erdős divisibility pigeonhole theorem is formalized with zero sorries and zero axioms: any n+1 integers from {1,…,2n} contain a pair with one dividing the other, and the threshold n+1 is sharp. The crux is to pigeonhole by odd part — there are exactly n odd parts available — and to observe that two integers with the same odd part are related by a power of two.",
+    "implications": "The argument is the archetype of 'invariant-based' pigeonhole proofs: the useful classification is not the object itself but a well-chosen function of it (here the 2-free core). The same template — chain decomposition of a divisibility poset by odd part — underlies extremal results on primitive sets and Behrend-type bounds, and pairs naturally with Dilworth/Mirsky chain-antichain dualities.",
+    "openQuestions": [
+      "Quantitative refinement: among any n+1 elements of {1,…,2n}, must there exist a chain a₁ ∣ a₂ ∣ … of length growing with n, or can collisions always be confined to pairs?",
+      "Coprimality dual: any n+1 elements of {1,…,2n} contain two consecutive integers, hence a coprime pair — can this be unified with the divisibility statement in one Lean development?",
+      "Does the odd-part chain decomposition give a clean Lean proof that the maximum divisibility-free subset of {1,…,2n} has size exactly n (the antichain/primitive-set extremal bound)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "dilworth-theorem-oq-01",
+      "relationship": "uses-similar-technique",
+      "description": "Both invoke Finset.exists_ne_map_eq_of_card_lt_of_maps_to. The divisibility poset on {1,…,2n} decomposes into n chains (one per odd part); a set larger than the number of chains must put two elements in a common chain — the pigeonhole/Dilworth picture behind this theorem."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/ErdosDivisibilityPigeonhole.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ErdosDivisibilityPigeonhole",
+    "lineCount": 143,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 5
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Erdős Divisibility Pigeonhole

Among any `n+1` integers from `{1, …, 2n}`, one divides another — a classical pigeonhole gem, plus sharpness of the `n+1` threshold.

**Statement.** If `S ⊆ Icc 1 (2n)` and `n + 1 ≤ |S|`, then there exist distinct `a, b ∈ S` with `a ∣ b`.

**Proof.** Each `m ≥ 1` is `2^k · o(m)` with odd part `o(m) = ordCompl[2] m`. The half-index `m ↦ (o(m)−1)/2` maps `S` into `range n` (since `1 ≤ o(m) ≤ 2n`), so two distinct `a,b ∈ S` collide; odd-part recovery (`2·((o−1)/2)+1 = o` for odd `o`) gives `o(a)=o(b)`, and the smaller power of two divides the larger.

**Sharpness.** `{n+1, …, 2n}` is divisibility-free (a proper multiple of `a ≥ n+1` exceeds `2n`), so `n+1` is optimal (`erdos_divisibility_pigeonhole_sharp`).

- 143 lines, 5 theorems, **0 sorries, 0 axioms**, kernel-clean (no `decide`/`native_decide`).
- Verified against Mathlib v4.26.0 via Docker build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)