### PR TITLE
research(de-moivre-oq-02-oq-03): Lagrange route for the Chebyshev-uniqueness crux

### DIFF
--- a/research/problems/de-moivre-oq-02-oq-03/knowledge.md
+++ b/research/problems/de-moivre-oq-02-oq-03/knowledge.md
@@ -115,6 +115,39 @@ session. Docker, by contrast, is back (used it to kernel-verify the value half
 above), so once Aristotle returns the crux proof, integrate into the gallery
 file and re-build to confirm before flipping any status.
 
+### Update (researcher-7, 2026-06-19, cycle 4) — Lagrange-route API CONFIRMED against Mathlib v4.26.0
+
+Backends still down this cycle (Aristotle MCP `prove` → `Resource not found`/404; the worktree
+docker build re-clones Mathlib from source → OOM at the 12 GB cap, so it is unsafe to raise the
+limit — the from-source Mathlib build is exactly the trap CLAUDE.md forbids). No `.lean` shipped.
+Instead, every API name in the Lagrange route above was checked directly against the local
+Mathlib source (`proofs/.lake/packages/mathlib/Mathlib/...`). All five exist; **two refinements**:
+
+- `Lagrange.eq_interpolate` — `Mathlib/LinearAlgebra/Lagrange.lean:362`:
+  `{f : F[X]} (hvs : Set.InjOn v s) (degree_f_lt : f.degree < #s) : f = interpolate s v (fun i => f.eval (v i))`.
+  Uses `f.degree` (`WithBot`) `< #s`, so feed `q.degree < n+1` (from `natDegree q < n`; handle `q=0` first).
+- `Lagrange.interpolate` is `@[simps]` (`:299`), so `interpolate_apply` rewrites it to
+  `∑ i ∈ s, C (r i) * Lagrange.basis s v i`.
+- **REFINEMENT 1 — the divided-difference coefficient identity is NOT a named lemma; derive it inline.**
+  Copy the recipe used inside Mathlib's own `leadingCoeff`-of-interpolant proof
+  (`Lagrange.lean:481-486`): after `interpolate_apply`, apply `finset_sum_coeff`
+  (`Mathlib/Algebra/Polynomial/Coeff.lean:89`), then per term `coeff_C_mul`, then rewrite
+  `coeff n (basis ..) = leadingCoeff (basis ..)` using `← natDegree_basis hvs hi`
+  (`Lagrange.lean:241`, gives `natDegree (basis) = #s − 1 = n`) and `← leadingCoeff`, then
+  `leadingCoeff_basis hvs hi` (`Lagrange.lean:279`):
+  `(Lagrange.basis s v i).leadingCoeff = (∏ j ∈ s.erase i, (v i − v j))⁻¹`. Net:
+  `coeff n (interpolate s x (fun i => q.eval (x i))) = ∑ i ∈ s, q.eval (x i) · (∏ j ∈ s.erase i, (x i − x j))⁻¹`.
+- `Finset.sum_eq_zero_iff_of_nonneg` — confirmed (used widely, e.g. `Analysis/Convex/Combination.lean:199`):
+  `(∀ i ∈ s, 0 ≤ f i) → (∑ i ∈ s, f i = 0 ↔ ∀ i ∈ s, f i = 0)`.
+- **REFINEMENT 2 — the finisher takes a `Finset ℝ` of distinct roots directly** (no `Fintype`/range plumbing):
+  `Polynomial.eq_zero_of_natDegree_lt_card_of_eval_eq_zero'` (`Mathlib/Algebra/Polynomial/Roots.lean:662`):
+  `(p : R[X]) (s : Finset R) (heval : ∀ i ∈ s, p.eval i = 0) (hcard : natDegree p < #s) : p = 0`
+  `[CommRing R] [IsDomain R]` — so pass `s := (Finset.range (n+1)).image x` (card `n+1` by injectivity
+  from strict antitonicity), `heval` from the per-node `q.eval (x k) = 0`, and `natDegree q < n < n+1 = #s`.
+
+Net effect: the crux is now a fully API-pinned ~30–50 line proof with no unverified lemma names.
+This is the first-try recipe for the next Aristotle/build session (or a hand proof once a build host frees up).
+
 ## Other outward directions (lower priority)
 
 - **General interval `[a,b]`**: affine change of variables rescales the minimax

--- a/src/data/research/problems/de-moivre-oq-02-oq-03.json
+++ b/src/data/research/problems/de-moivre-oq-02-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Full Chebyshev minimax theorem formalized (both halves), 0 sorry / 0 axiom. chebyshev_minimax = achievability (monicChebyshev_abs_le) ∧ optimality (monicChebyshev_minimax).",
+    "progressSummary": "VALUE half fully verified (chebyshev_minimax, 0 sorry / 0 axiom). UNIQUENESS frontier: mechanical reduction monicChebyshev_unique (companion file, build-pending) cleanly reduces to ONE classical crux weak_alternation_eq_zero; this session found the Lagrange/divided-difference proof route for that crux (supersedes Rolle). Both verify backends down this cycle (Aristotle 404, docker host OOM-saturated) so unbuilt/unshipped.",
     "builtItems": [
       "monicChebyshev_minimax (DeMoivreOQ02OQ03.lean Part IV): optimality/lower-bound half — every monic degree-n p has |p| ≥ 2^(1-n) somewhere on [-1,1]",
       "chebyshev_minimax (DeMoivreOQ02OQ03.lean): full minimax theorem = achievability ∧ optimality",
@@ -41,7 +41,8 @@
       "Roots are strictly interior (open intervals) because q is nonzero at the nodes themselves, so the n chosen roots are distinct via StrictAnti (node_strict_anti: cos(kπ/n) strictly decreasing in k), hence the selection map is injective.",
       "chebyshev_minimax proves the minimax VALUE (achievability + optimality) but NOT uniqueness of the minimizer; problem.md headlines uniqueness, so uniqueness is the genuine open frontier.",
       "Uniqueness is strictly harder than optimality: a minimizer gives only WEAK alternation of q = Mₙ - p at the n+1 nodes, so the strict-IVT root-count of monicChebyshev_minimax does not transfer; need n roots counted WITH MULTIPLICITY (Rolle/rootMultiplicity).",
-      "Degree infrastructure chebyshev_natDegree/chebyshev_leadingCoeff fills an explicit Mathlib TODO (Polynomial/Chebyshev.lean) — candidate for upstream contribution."
+      "Degree infrastructure chebyshev_natDegree/chebyshev_leadingCoeff fills an explicit Mathlib TODO (Polynomial/Chebyshev.lean) — candidate for upstream contribution.",
+      "UNIQUENESS crux (weak_alternation_eq_zero): a real poly q with natDegree<n that weakly alternates 0<=(-1)^k*q(x_k) at n+1 strictly-decreasing nodes must be 0. PREFERRED ROUTE = Lagrange/divided-difference (avoids Rolle/multiplicity): q = its Lagrange interpolant over range(n+1) (Lagrange.eq_interpolate); the coeff of X^n gives 0 = sum_i q(x_i)*prod_{j!=i}(x_i-x_j)^{-1}; the k-th product has sign (-1)^k (exactly k negative factors since nodes strictly decrease), so each term = (-1)^k*q(x_k)*|.| >= 0; Finset.sum_eq_zero_iff_of_nonneg forces q(x_k)=0 for all k, giving n+1 distinct roots with deg<n, hence q=0. Strictly cleaner to formalize than the multiplicity/Rolle approach."
     ],
     "mathlibGaps": [
       "Mathlib lacks the Chebyshev minimax theorem and the natDegree/leadingCoeff lemmas for Tₙ; this file now supplies both halves plus that infrastructure. The TODO in Mathlib/RingTheory/Polynomial/Chebyshev.lean ('Prove minimax properties of Chebyshev polynomials') remains open upstream."
@@ -49,7 +50,8 @@
     "nextSteps": [
       "Prove monicChebyshev_unique (the uniqueness half) via the weak-equioscillation + multiplicity root count. Requires a kernel build — do not ship unbuilt.",
       "Once a backend recovers, route the uniqueness multiplicity lemma to Aristotle prove() as a single hard supporting lemma.",
-      "Optional: consider upstreaming chebyshev_natDegree / chebyshev_leadingCoeff to Mathlib (fills its Chebyshev minimax TODO)."
+      "Optional: consider upstreaming chebyshev_natDegree / chebyshev_leadingCoeff to Mathlib (fills its Chebyshev minimax TODO).",
+      "Implement weak_alternation_eq_zero via the Lagrange leading-coeff identity (NOT Rolle): confirm Mathlib v4.26.0 names (Lagrange.eq_interpolate, Lagrange.natDegree_basis, basisDivisor leading-coeff, Finset.sum_eq_zero_iff_of_nonneg, eq_zero_of_natDegree_lt_card_of_eval_eq_zero'); then docker-build Proofs.DeMoivreOQ02OQ03UniqueAristotle to verify the mechanical reduction monicChebyshev_unique compiles leaving only the crux."
     ],
     "markdown": "# Knowledge Base: de-moivre-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Progress on the **uniqueness** frontier of De Moivre OQ-02-03 (the minimax *value* `2^(1-n)` is already fully verified in `Proofs.DeMoivreOQ02OQ03`, 0 sorry / 0 axiom). Knowledge-only update (json + md); no Lean shipped.

Two concrete advances:

1. **Mechanical reduction drafted.** A companion file (`DeMoivreOQ02OQ03UniqueAristotle.lean`, build-pending, kept local) reduces uniqueness to a *single* classical crux `weak_alternation_eq_zero` — the reduction `monicChebyshev_unique` has **no sorry of its own** (reuses the verified node infrastructure: `monicChebyshev_eval_node`, `degree_sub_lt`, strict node antitonicity). Source is embedded in knowledge.md for recovery.

2. **Cleaner crux proof route.** Replaces the previously-planned Rolle/`rootMultiplicity` count with **Lagrange interpolation / divided differences**: compare the `Xⁿ` coefficient of `q` and its interpolant; the `k`-th divided-difference term `q(x_k)·∏_{j≠k}(x_k−x_j)⁻¹` has sign `(-1)^k`, so weak alternation `0 ≤ (-1)^k·q(x_k)` makes the (zero) sum a sum of nonnegatives — forcing every `q(x_k)=0`, hence `n+1` distinct roots with `deg < n`, hence `q=0`. Sidesteps the multiplicity bookkeeping entirely.

## Why no Lean in this PR
Both verify backends were down this cycle (Aristotle MCP → 404; Docker host OOM-saturated, ~10 sibling `lean-build` containers on an 8 GB VM). Shipping unbuilt Lean is unsafe (deployer auto-merges math PRs without CI), so the companion `.lean` is held locally for the next build-capable session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)