### PR TITLE
audit(area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01): re-audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -379,9 +379,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-19T00:00:00Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02": {
@@ -16050,5 +16050,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-19T08:19:24Z"
+  "lastUpdated": "2026-06-19T00:00:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01` — *Unit n-Ball Volumes Tend to Zero: ω_n → 0 as n → ∞*

### Numeric meta verified EXACT against Lean source
| Field | meta.json | Lean file | ✓ |
|-------|-----------|-----------|---|
| lineCount | 163 | 163 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 7 | 7 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

### Tier / badge classification
Badge `original` / status `verified` is **defensible**. The main theorem ω_n → 0 is genuinely proved in-file:
- `omega_even_formula` (ω_{2k} = π^k/k!) — by induction on the parent recurrence
- `omega_odd_le_two_even` (ω_{2k+1} ≤ 2·ω_{2k}) — by induction with arithmetic squeeze
- `omega_le_two_even_half` — universal bound via even/odd case split
- `omega_tendsto_zero` — main theorem via composition + squeeze theorem

Mathlib's `summable_pow_div_factorial` supplies only the elementary building-block fact π^k/k! → 0 (terms of e^π series). This is **honestly disclosed** in `mathlibDependencies` and is **not** a wrapper of the main result — no delegation opacity, no axiom masking, no inequality-as-theorem inflation.

### Dependency chain checked
Imported parent `AreaOfCircleOQ01OQ02OQ01OQ01` is itself clean: `def ω = π^(n/2)/Γ(n/2+1)`, recurrence ω_{n+2} = 2π/(n+2)·ω_n proved from Mathlib Gamma lemmas, **0 axioms / 0 sorries**. No hidden assumptions inherited.

### Result
No issues. `auditCount` 2 → 3, `lastAudited` refreshed.

---
Discovered during gallery integrity audit loop. Selected the stalest target (lastAudited 2026-05-03) without an existing open re-audit PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)