### PR TITLE
Enrich Is e a Normal Number? (e-transcendental-oq-02): add annotation prerequisites

### DIFF
--- a/src/data/proofs/e-transcendental-oq-02/annotations.json
+++ b/src/data/proofs/e-transcendental-oq-02/annotations.json
@@ -17,6 +17,11 @@
       "absolutely normal",
       "digit frequency",
       "e"
+    ],
+    "prerequisites": [
+      "measure theory (Lebesgue measure)",
+      "real analysis (limits and asymptotic density)",
+      "base-b digit expansions"
     ]
   },
   {
@@ -35,6 +40,11 @@
       "digit extraction",
       "floor function",
       "base-b expansion"
+    ],
+    "prerequisites": [
+      "floor function",
+      "modular arithmetic",
+      "positional (base-b) numeral systems"
     ]
   },
   {
@@ -54,6 +64,11 @@
       "Filter.atTop",
       "digit frequency",
       "Finset.filter"
+    ],
+    "prerequisites": [
+      "filters and limits (Filter.Tendsto)",
+      "Finset cardinality",
+      "Lean 4 dependent types (Fin)"
     ]
   },
   {
@@ -74,6 +89,11 @@
       "Int.floor_eq_iff",
       "linarith",
       "decide"
+    ],
+    "prerequisites": [
+      "floor function and interval arithmetic",
+      "rational bounds on e (exp_one_gt_d9 / exp_one_lt_d9)",
+      "Lean tactic proofs (linarith, decide)"
     ]
   },
   {
@@ -93,6 +113,11 @@
       "pigeonhole principle",
       "rational numbers",
       "period"
+    ],
+    "prerequisites": [
+      "modular arithmetic and the division algorithm",
+      "pigeonhole principle",
+      "multiplicative order and Euler's totient function"
     ]
   },
   {
@@ -112,6 +137,11 @@
       "irrationality",
       "periodic expansion",
       "orbit cardinality"
+    ],
+    "prerequisites": [
+      "eventually periodic sequences",
+      "asymptotic density and limits",
+      "proof by contradiction"
     ]
   },
   {
@@ -131,6 +161,11 @@
       "decimal digits",
       "Tendsto",
       "normality consequence"
+    ],
+    "prerequisites": [
+      "filters and limits (Filter.Tendsto)",
+      "definition of normality (digit frequency)",
+      "Lean simplification tactics (simp, norm_num)"
     ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass: e-transcendental-oq-02

This entry ("Is e a Normal Number?") is content-rich (7 deep annotations, full overview, 9 sections, conclusion with 7 open questions) but its annotations were the **only remaining gap**: none carried a `prerequisites` array.

Every tracked q100 gallery entry carries per-annotation `prerequisites` — this brings the entry to that norm.

### Changes
- Added `prerequisites` to all 7 annotations in `annotations.json`. Each is content-specific:
  - **overview** → measure theory, real analysis, base-b expansions
  - **nthDigit** → floor function, modular arithmetic, positional numerals
  - **IsNormalInBase** → Filter.Tendsto, Finset cardinality, Lean Fin types
  - **e-digits** → floor/interval arithmetic, rational bounds on e, Lean tactics
  - **rational-periodic** → division algorithm, pigeonhole, multiplicative order
  - **normal-irrational** → eventually periodic sequences, asymptotic density, contradiction
  - **uniform-digits** → Filter.Tendsto, normality definition, simp/norm_num
- No other fields touched; `mathContext`, `significance`, `relatedConcepts` preserved.
- `prerequisites` is a typed, optional `Annotation` field rendered by `AnnotationPanel.tsx`.

### Notes
- This entry was **absent from `enrichment-tracker.json`** (one of ~395 committed-but-untracked entries the `claim-next` saturation signal can't see, though all are reachable via `listings.json`/`data-manifest.json`).
- JSON validated with `jq`. Full `pnpm build` not run in-worktree (no `node_modules`); the per-proof `annotations.json` is line-based (no `annotations.source.json`), so the build only validates line alignment — line ranges are unchanged.