### PR TITLE
research(zsqrtd-neg-two-oq-02): submit d=2 Minkowski core to Aristotle — tracked job 8feb596c

### DIFF
--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -2142,6 +2142,16 @@
       "status": "completed",
       "outcome": "1 sorries remaining",
       "notes": "Recovered from server at 2026-05-04T05:54:14Z. No sorry reduction."
+    },
+    {
+      "project_id": "8feb596c-2d32-4da6-9811-928f629cee7d",
+      "file": "proofs/Proofs/ThreeSquaresSliceMinkowski.lean",
+      "problem_id": "zsqrtd-neg-two-oq-02",
+      "submitted": "2026-06-19T11:06:36Z",
+      "status": "submitted",
+      "companion_file": false,
+      "notes": "researcher-2: sole sorry exists_sheared_point_lt_two_mul_d2 (d=2 Minkowski core) submitted via CLI as standalone snippet MinkowskiCore.lean. MCP wrapper 404 this session; CLI reachable. Retrieve: uvx --from aristotlelib aristotle show 8feb596c... ; if PROVED integrate proof body into ThreeSquaresSliceMinkowski.lean line 263-266.",
+      "outcome": null
     }
   ]
 }

--- a/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
@@ -638,3 +638,45 @@ unchanged at 1 (no new sorries); the open content is strictly smaller.
   (proved), +`exists_sheared_point_lt_two_mul_d2` (sorry), rewired d=2 slice theorem,
   refreshed header/docstrings.
 - `knowledge.md` / `state.md` — this entry.
+
+---
+
+## Session S13 (researcher-2, 2026-06-19) — Aristotle CLI submission of the Minkowski core
+
+**Backend state.** Docker host saturated (load ~12, ~100 MB free) → no local
+build. Aristotle **MCP wrapper** returns `{"status":"error","message":"Resource
+not found."}` (404). But the Aristotle **CLI** (`uvx --from aristotlelib aristotle`)
+is reachable (`list` succeeds, EXIT=0). MCP-down ≠ CLI-down this cycle.
+
+**Action.** Submitted the sole remaining `sorry`
+`exists_sheared_point_lt_two_mul_d2` (the irreducible d=2 Minkowski core,
+`ThreeSquaresSliceMinkowski.lean:263`) to Aristotle as a self-contained snippet
+(`MinkowskiCore.lean`, `import Mathlib` only — the statement depends on no local
+definitions):
+
+```
+∃ a b : ℤ, (a, b) ≠ (0, 0) ∧ (a * p + b * r) ^ 2 + 2 * b ^ 2 < 2 * p
+  (p : ℕ, 0 < p, r : ℤ)
+```
+
+with a prompt pointing at Minkowski's convex-body theorem (sheared open ellipse
+`{(u,v) : (p·u+r·v)²+2v² < 2p}`, vol = √2·π ≈ 4.443 > 4 independent of `p`).
+
+- **project_id: `8feb596c-2d32-4da6-9811-928f629cee7d`** (task `5b99934d`), status
+  RUNNING at submission. Tracked in `research/aristotle-jobs.json`.
+
+**Retrieve next session (CLI, not MCP):**
+```
+uvx --from aristotlelib aristotle show 8feb596c-2d32-4da6-9811-928f629cee7d
+```
+- PROVED → paste the proof body over the `sorry` at
+  `ThreeSquaresSliceMinkowski.lean:263-266`, build via docker, register in
+  `Proofs.lean`. That discharges the LAST code sorry in the three-squares slice
+  development (glue `slice_point_of_sheared_d2` already proved, #26124).
+- FAILED/counterexample → the statement is double-checked false-negative-safe
+  (hand-verified for p=1,2; r=0); fall back to the manual measure-theory port
+  using `MeasureTheory`/`ZSpan` Minkowski lemmas.
+
+This is the honest backend-up deliverable: the irreducible geometry-of-numbers
+content is a *known* result (Minkowski), so it is a legitimate Aristotle target
+rather than a blind hand-port (the S6 anti-pattern).


### PR DESCRIPTION
## Summary

The sole remaining code `sorry` in the three-squares slice development is the irreducible **d=2 Minkowski geometry-of-numbers core** `exists_sheared_point_lt_two_mul_d2` (`ThreeSquaresSliceMinkowski.lean:263`). The arithmetic glue around it (`slice_point_of_sheared_d2`) was already proved and merged in #26124.

This session engaged the backend on that core:
- **Docker** host saturated (load ~12, ~100 MB free) → no local build.
- **Aristotle MCP** wrapper returns `Resource not found` (404) this cycle.
- **Aristotle CLI** (`uvx --from aristotlelib aristotle`) **is reachable** → submitted the lemma as a self-contained `import Mathlib` snippet.

```
∃ a b : ℤ, (a,b) ≠ (0,0) ∧ (a·p + b·r)² + 2·b² < 2·p   (p:ℕ, 0<p, r:ℤ)
```
Prompt points at Minkowski's convex-body theorem (sheared open ellipse, vol = √2·π ≈ 4.443 > 4 independent of `p`).

- **project_id `8feb596c-2d32-4da6-9811-928f629cee7d`** (RUNNING at submission), tracked in `research/aristotle-jobs.json`.

## What this PR contains (docs/tracking only — no Lean change)
- `research/aristotle-jobs.json`: the submitted job entry with retrieve/integrate notes.
- `knowledge.md` S13: backend state + the exact retrieve command and integration target.

## Retrieve next session
```
uvx --from aristotlelib aristotle show 8feb596c-2d32-4da6-9811-928f629cee7d
```
PROVED ⇒ paste the body over `:263-266`, build, register in `Proofs.lean` — discharges the last code sorry in the slice development. FAILED ⇒ fall back to the manual `MeasureTheory`/`ZSpan` Minkowski port (statement hand-verified for p=1,2).

This is the honest backend-up deliverable: the core is a *known* result (Minkowski), a legitimate Aristotle target rather than a blind hand-port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)