### PR TITLE
Enrich Shannon Channel Coding (AWGN): add annotation prerequisites

### DIFF
--- a/src/data/proofs/shannon-channel-coding-awgn/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-awgn/annotations.json
@@ -16,7 +16,11 @@
       "signal-to-noise ratio",
       "Shannon–Hartley theorem"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "channel capacity",
+      "Gaussian (AWGN) channels",
+      "logarithms"
+    ]
   },
   {
     "id": "ann-awgn-log-identity",
@@ -34,7 +38,11 @@
       "differential entropy",
       "logarithm of a quotient"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "differential entropy",
+      "logarithm identities (log of a quotient)",
+      "real analysis"
+    ]
   },
   {
     "id": "ann-awgn-achievability",
@@ -52,7 +60,11 @@
       "Gaussian differential entropy",
       "capacity-achieving input"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Gaussian differential entropy",
+      "mutual information",
+      "capacity-achieving distributions"
+    ]
   },
   {
     "id": "ann-awgn-converse",
@@ -71,7 +83,11 @@
       "converse bound",
       "power constraint"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "differential entropy",
+      "maximum-entropy principle",
+      "average-power (variance) constraints"
+    ]
   },
   {
     "id": "ann-awgn-structural",
@@ -89,6 +105,10 @@
       "monotonicity",
       "signal-to-noise ratio"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "real analysis (monotonicity)",
+      "logarithm monotonicity",
+      "signal-to-noise ratio"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass: shannon-channel-coding-awgn

Core gallery entry (AWGN capacity C = ½·log(1 + P/N)). All 5 annotations were content-rich but lacked a `prerequisites` array.

### Changes
- Added `prerequisites` to all 5 annotations (capacity definition, entropy-difference identity, achievability, converse, structural properties). Content-specific (Gaussian channels, differential entropy, log identities, maximum-entropy principle, monotonicity).
- No other fields changed. `prerequisites` is a typed, optional `Annotation` field rendered by `AnnotationPanel.tsx`.

### Notes
- Entry was absent from `enrichment-tracker.json` (committed-but-untracked; reachable via `listings.json`/`data-manifest.json`).
- Line-based annotations; line ranges unchanged. JSON validated with `jq`.