### PR TITLE
audit(erdos-divisibility-pigeonhole): first audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16047,6 +16047,12 @@
       "lastAudited": "2026-06-19T10:43:33Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-divisibility-pigeonhole": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T11:12:32Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `erdos-divisibility-pigeonhole` (last unaudited entry in gallery)

### Verified against Lean source (`Proofs/ErdosDivisibilityPigeonhole.lean`)
| Field | meta.json | Actual | ✓ |
|-------|-----------|--------|---|
| lineCount | 143 | 143 | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

### Tier / badge assessment
Badge `original` / status `verified` is **defensible**. Mathlib dependencies (`Finset.exists_ne_map_eq_of_card_lt_of_maps_to`, `Nat.ordProj_mul_ordCompl_eq_self`, `Nat.not_dvd_ordCompl`) are honest general-purpose building blocks, fully disclosed in `mathlibDependencies`. The specific theorem (the Erdős divisibility application via odd-part pigeonhole) and its sharpness are constructed in-file from elementary divisibility/`Nat` arithmetic — not a wrapper around an imported core theorem. No delegation opacity, axiom masking, or inflation.

Tracker `auditCount` 0→1, `result: clean`.

---
Discovered during gallery integrity audit. Gallery now fully audited (2556/2556).