### PR TITLE
Enrich Erdős Divisibility Pigeonhole: add annotations (q39→100)

### DIFF
--- a/src/data/proofs/erdos-divisibility-pigeonhole/annotations.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole/annotations.json
@@ -1,0 +1,131 @@
+[
+  {
+    "id": "ann-odd-recover",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": { "startLine": 41, "endLine": 46 },
+    "type": "proof-technique",
+    "title": "The Half-Index Map Is Injective on Odd Numbers",
+    "content": "The whole reduction hinges on encoding each odd part `o` by its half-index `(o − 1)/2`. For this encoding to recover the odd part from a collision, the map `o ↦ (o − 1)/2` must be injective on odd numbers — and it is, because it has an explicit inverse there. Writing `o = 2k + 1` (the meaning of `Odd o`), natural-number division gives `(o − 1)/2 = (2k)/2 = k`, so `2·((o − 1)/2) + 1 = 2k + 1 = o`. The lemma `odd_recover` records exactly this identity. Two odd numbers with the same half-index therefore satisfy `o₁ = 2·((o₁−1)/2)+1 = 2·((o₂−1)/2)+1 = o₂`. The point of routing through half-indices rather than the odd parts directly is that the half-indices land in `Finset.range n` (the next annotations), giving a clean pigeonhole target of size exactly `n` with no `Finset.filter` cardinality computation.",
+    "mathContext": "$o = 2k+1 \\;\\Rightarrow\\; \\tfrac{o-1}{2} = k \\;\\text{and}\\; 2\\cdot\\tfrac{o-1}{2}+1 = o$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "injective encoding",
+      "natural-number (floor) division",
+      "odd numbers as 2k+1",
+      "pigeonhole target construction"
+    ],
+    "prerequisites": [
+      "Odd o ↔ ∃ k, o = 2k + 1",
+      "Nat.add_sub_cancel / Nat.mul_div_cancel_left",
+      "natural-number division truncates toward zero"
+    ]
+  },
+  {
+    "id": "ann-odd-ordcompl",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": { "startLine": 48, "endLine": 53 },
+    "type": "definition",
+    "title": "The Odd Part ordCompl[2] m Is Genuinely Odd",
+    "content": "`ordCompl[2] m` is the odd part of `m`: it is `m` with all factors of `2` removed, so that `m = 2^(v₂ m) · ordCompl[2] m`. The lemma `odd_ordCompl` certifies that this really is odd whenever `m ≠ 0`. The key Mathlib input is `Nat.not_dvd_ordCompl`: a prime `p` never divides `ordCompl[p] m` (for `m ≠ 0`), since by construction the full power of `p` has been stripped out. With `p = 2`, `2 ∤ ordCompl[2] m`, and `Nat.odd_iff` (oddness ⇔ remainder 1 mod 2) plus `omega` close the goal. This oddness is precisely the hypothesis that lets `odd_recover` apply to the odd parts of the colliding elements — without it, the half-index map would not be invertible.",
+    "mathContext": "$m \\ne 0 \\;\\Rightarrow\\; 2 \\nmid \\mathrm{ordCompl}_2(m) \\;\\Leftrightarrow\\; \\mathrm{ordCompl}_2(m)\\ \\text{is odd}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "2-adic valuation",
+      "odd part of an integer",
+      "ordCompl / ordProj",
+      "p-adic factorization"
+    ],
+    "prerequisites": [
+      "Nat.not_dvd_ordCompl",
+      "Nat.odd_iff (odd ⇔ n % 2 = 1)",
+      "definition of ordCompl[p] m"
+    ]
+  },
+  {
+    "id": "ann-dvd-of-ordcompl-eq",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": { "startLine": 55, "endLine": 77 },
+    "type": "insight",
+    "title": "Equal Odd Parts ⇒ One Divides the Other",
+    "content": "This lemma is where a pigeonhole *collision* becomes a *divisibility*. Two positive integers sharing an odd part `o = ordCompl[2] a = ordCompl[2] b` differ only by a power of two: by the 2-adic factorization `Nat.ordProj_mul_ordCompl_eq_self`, `a = 2^(v₂ a)·o` and `b = 2^(v₂ b)·o`. Comparing the exponents via `le_total` splits into two symmetric cases. If `v₂ a ≤ v₂ b`, then `2^(v₂ a) ∣ 2^(v₂ b)` (`pow_dvd_pow`), and multiplying both sides by the common factor `o` (`mul_dvd_mul_right`) gives `a ∣ b`; otherwise `b ∣ a`. The two numbers form a chain in the divisibility poset — they sit on the same 'odd-part fiber', which is totally ordered by the power of two. This is the structural reason the theorem is true: the fibers of `m ↦ ordCompl[2] m` are exactly the chains of the divisibility order restricted to `{1,…,2n}`.",
+    "mathContext": "$a = 2^{v_2 a}\\,o,\\ b = 2^{v_2 b}\\,o,\\ v_2 a \\le v_2 b \\;\\Rightarrow\\; a \\mid b$",
+    "significance": "key",
+    "relatedConcepts": [
+      "divisibility poset",
+      "chains and fibers",
+      "2-adic factorization",
+      "pow_dvd_pow",
+      "Dilworth / chain decomposition"
+    ],
+    "prerequisites": [
+      "Nat.ordProj_mul_ordCompl_eq_self (m = 2^(v₂ m)·ordCompl[2] m)",
+      "pow_dvd_pow and mul_dvd_mul_right",
+      "le_total on the exponents"
+    ]
+  },
+  {
+    "id": "ann-halfindex-pigeonhole",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": { "startLine": 83, "endLine": 97 },
+    "type": "proof-technique",
+    "title": "Pigeonholing the Half-Indices into Finset.range n",
+    "content": "Here the abstract Finset pigeonhole is set up. Define `f m = (ordCompl[2] m − 1)/2`. The bound `hmaps` shows `f` sends `S` into `Finset.range n`: for `m ∈ S ⊆ Icc 1 (2n)` the odd part satisfies `1 ≤ o ≤ m ≤ 2n` (using `Nat.ordCompl_le`), and `Nat.div_lt_iff_lt_mul` turns `(o−1)/2 < n` into `o − 1 < 2n`, dispatched by `omega`. Then `hlt` notes `|range n| = n < n+1 ≤ |S|`. Feeding both to `Finset.exists_ne_map_eq_of_card_lt_of_maps_to` — the Finset form of the pigeonhole principle, that a map into a strictly smaller set must identify two distinct points — yields distinct `a, b ∈ S` with `f a = f b`. Crucially the target has size *exactly* `n` (the number of odd parts available in `{1,…,2n}`), so `n+1` elements force a collision; this is the quantitative heart of the argument, obtained without ever counting the odd numbers by hand.",
+    "mathContext": "$f: S \\to \\mathrm{range}\\,n,\\quad |\\mathrm{range}\\,n| = n < n+1 \\le |S| \\;\\Rightarrow\\; \\exists\\, a \\ne b,\\ f a = f b$",
+    "significance": "key",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "Finset cardinality",
+      "ordCompl_le bound",
+      "extremal counting"
+    ],
+    "prerequisites": [
+      "Finset.exists_ne_map_eq_of_card_lt_of_maps_to",
+      "Nat.ordCompl_le (ordCompl[2] m ≤ m)",
+      "Nat.div_lt_iff_lt_mul",
+      "Finset.card_range"
+    ]
+  },
+  {
+    "id": "ann-collision-to-equality",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": { "startLine": 99, "endLine": 117 },
+    "type": "insight",
+    "title": "Upgrading a Half-Index Collision to Equal Odd Parts, then Orienting",
+    "content": "The pigeonhole gave `f a = f b`, i.e. equal half-indices `(ordCompl[2] a − 1)/2 = (ordCompl[2] b − 1)/2`. To recover the odd parts themselves, the proof first notes both `a, b ≠ 0` (positivity from `S ⊆ Icc 1 (2n)`), so both odd parts are odd (`odd_ordCompl`). Then `odd_recover` inverts the half-map on each: `ordCompl[2] a = 2·(half) + 1 = ordCompl[2] b`, giving `hocc`. With equal odd parts in hand, `dvd_or_dvd_of_ordCompl_eq` delivers `a ∣ b ∨ b ∣ a`. The final `rcases` orients the witness using `a ≠ b`: in the first branch return `(a, b)`, in the second return `(b, a)` with `hab.symm`. This last step shows the theorem is genuinely symmetric — the pigeonhole does not know which of the pair is the divisor, and the disjunction is resolved purely by relabeling.",
+    "mathContext": "$f a = f b \\;\\xrightarrow{\\text{odd\\_recover}}\\; \\mathrm{ordCompl}_2 a = \\mathrm{ordCompl}_2 b \\;\\Rightarrow\\; a \\mid b \\ \\lor\\ b \\mid a$",
+    "significance": "key",
+    "relatedConcepts": [
+      "injectivity recovers equality",
+      "case orientation",
+      "symmetric witnesses",
+      "divisibility disjunction"
+    ],
+    "prerequisites": [
+      "odd_recover and odd_ordCompl (the local lemmas)",
+      "dvd_or_dvd_of_ordCompl_eq (the local lemma)",
+      "Finset.mem_Icc for positivity"
+    ]
+  },
+  {
+    "id": "ann-sharpness",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": { "startLine": 119, "endLine": 142 },
+    "type": "insight",
+    "title": "Sharpness: the Top Block {n+1,…,2n} Is Divisibility-Free",
+    "content": "The companion theorem `erdos_divisibility_pigeonhole_sharp` proves `n+1` is the optimal threshold: there is an `n`-element subset of `{1,…,2n}` with no divisibility pair, so no `n`-element bound could replace `n+1`. The witness is the top block `Icc (n+1) (2n)`. Its cardinality is `n` by `Nat.card_Icc` (`2n − (n+1) + 1 = n`). It is divisibility-free by a one-line size argument: if `a ∣ b` with `a ≠ b`, write `b = a·c`; then `c ≥ 2` (it cannot be 0 or 1 since `a < b`), so `b = a·c ≥ 2a ≥ 2(n+1) = 2n + 2 > 2n ≥ b`, a contradiction closed by `omega`. Geometrically: a proper multiple of any `a ≥ n+1` already jumps past `2n`, so the upper half of `{1,…,2n}` is an antichain in the divisibility order — and it has exactly `n` elements, matching the number of odd parts. Sharpness and the main bound are two faces of the same chain/antichain duality.",
+    "mathContext": "$|\\{n{+}1,\\dots,2n\\}| = n,\\quad a \\mid b,\\ a \\ne b \\;\\Rightarrow\\; b \\ge 2a \\ge 2n+2 > 2n$",
+    "significance": "key",
+    "relatedConcepts": [
+      "tightness / optimality of bounds",
+      "antichains in the divisibility poset",
+      "primitive sets",
+      "Nat.card_Icc",
+      "extremal set theory"
+    ],
+    "prerequisites": [
+      "Nat.card_Icc (cardinality of an integer interval)",
+      "Nat.le_of_dvd and factoring b = a·c",
+      "linear arithmetic (omega)"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-divisibility-pigeonhole/meta.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole/meta.json
@@ -65,7 +65,8 @@
       "**The odd part is the right pigeonhole**: classifying integers by ⌊2-free core⌋ rather than by value turns a divisibility question into an equality-of-labels collision. {1,…,2n} has exactly n odd parts, one short of the n+1 elements",
       "**Same odd part ⇒ comparable in the divisibility order**: two numbers sharing an odd part differ only by a power of two, so they form a chain — the smaller exponent divides the larger. This is where 'collision' becomes 'divides'",
       "**Avoid counting odds with a half-index**: instead of computing the cardinality of the odd numbers in {1,…,2n}, the proof maps odd parts into Finset.range n via o ↦ (o−1)/2 and uses injectivity-on-odds to recover the collision; this keeps the Lean proof free of Finset.filter cardinality lemmas",
-      "**Sharpness is one line of arithmetic**: the top half {n+1,…,2n} is an antichain because doubling the smallest possible divisor already leaves the window — so n+1 is genuinely the optimal threshold, not an artifact of the proof"
+      "**Sharpness is one line of arithmetic**: the top half {n+1,…,2n} is an antichain because doubling the smallest possible divisor already leaves the window — so n+1 is genuinely the optimal threshold, not an artifact of the proof",
+      "**The odd-part fibers are exactly the chains of the divisibility poset**: each fiber {m : ordCompl[2] m = o} is the totally-ordered set {o, 2o, 4o, …} ∩ {1,…,2n}, so the n odd parts partition {1,…,2n} into n chains. The main bound (n+1 elements force two in one chain) and the sharpness witness (the n-element antichain {n+1,…,2n}) are the two halves of the Dilworth chain–antichain duality for this specific poset"
     ],
     "prerequisites": [
       "The pigeonhole principle in Finset form (Finset.exists_ne_map_eq_of_card_lt_of_maps_to)",
@@ -75,28 +76,44 @@
   },
   "sections": [
     {
-      "id": "module-overview-and-helpers",
+      "id": "module-overview-and-odd-helpers",
       "title": "Module Overview and Odd-Part Helpers",
       "startLine": 1,
-      "endLine": 75,
-      "mathContext": "Odd parts: $o(m) = \\mathrm{ordCompl}_2(m)$ is odd, and $o \\mapsto (o-1)/2$ is injective on odd numbers since $2\\cdot((o-1)/2)+1 = o$.",
-      "summary": "Docstring states the theorem, the odd-part pigeonhole proof, and sharpness. Helpers: odd_recover (2·((o−1)/2)+1 = o, injectivity of the half-map on odds), odd_ordCompl (ordCompl[2] m is odd for m ≠ 0, via Nat.not_dvd_ordCompl), and dvd_or_dvd_of_ordCompl_eq (equal odd parts ⇒ one divides the other, via the 2-adic decomposition and pow_dvd_pow)."
+      "endLine": 53,
+      "mathContext": "Odd parts: $o(m) = \\mathrm{ordCompl}_2(m)$ is odd ($m \\ne 0$), and $o \\mapsto (o-1)/2$ is injective on odd numbers since $2\\cdot((o-1)/2)+1 = o$.",
+      "summary": "Docstring states the theorem, the odd-part pigeonhole proof, and sharpness. Two foundational helpers: odd_recover (2·((o−1)/2)+1 = o, so the half-map o ↦ (o−1)/2 is injective on odd numbers) and odd_ordCompl (ordCompl[2] m is odd for m ≠ 0, via Nat.not_dvd_ordCompl and Nat.odd_iff). Together they guarantee that a half-index collision can be inverted back to an equality of odd parts."
     },
     {
-      "id": "main-theorem",
-      "title": "Erdős Divisibility Pigeonhole",
-      "startLine": 76,
-      "endLine": 115,
-      "mathContext": "$S \\subseteq \\{1,\\dots,2n\\}$, $|S| \\ge n+1 \\Rightarrow \\exists\\, a \\ne b \\in S,\\ a \\mid b$.",
-      "summary": "erdos_divisibility_pigeonhole: the half-index f(m) = (ordCompl[2] m − 1)/2 maps S into Finset.range n (because o ≤ m ≤ 2n), and |range n| = n < |S|, so the Finset pigeonhole gives distinct a, b with f(a) = f(b). Oddness of the odd parts plus odd_recover upgrade this to ordCompl[2] a = ordCompl[2] b, and dvd_or_dvd_of_ordCompl_eq closes the goal, oriented by a ≠ b."
+      "id": "equal-odd-parts-divide",
+      "title": "Equal Odd Parts Force Divisibility",
+      "startLine": 55,
+      "endLine": 78,
+      "mathContext": "$\\mathrm{ordCompl}_2 a = \\mathrm{ordCompl}_2 b \\Rightarrow a \\mid b \\lor b \\mid a$, via $a = 2^{v_2 a} o$, $b = 2^{v_2 b} o$.",
+      "summary": "dvd_or_dvd_of_ordCompl_eq turns a collision into a divisibility. Using the 2-adic factorization Nat.ordProj_mul_ordCompl_eq_self, a and b sharing an odd part o differ only by a power of two; le_total on the valuations v₂ splits into two symmetric cases, and pow_dvd_pow on the smaller exponent (times the common factor o) yields a ∣ b or b ∣ a. This is the structural fact that the odd-part fibers are chains in the divisibility order."
+    },
+    {
+      "id": "halfindex-pigeonhole",
+      "title": "The Half-Index Pigeonhole",
+      "startLine": 79,
+      "endLine": 98,
+      "mathContext": "$f(m) = \\lfloor(\\mathrm{ordCompl}_2 m - 1)/2\\rfloor : S \\to \\mathrm{range}\\,n$, $|\\mathrm{range}\\,n| = n < n+1 \\le |S|$.",
+      "summary": "The first half of erdos_divisibility_pigeonhole sets up the pigeonhole. The half-index f(m) = (ordCompl[2] m − 1)/2 maps S into Finset.range n (because the odd part o satisfies 1 ≤ o ≤ m ≤ 2n, via Nat.ordCompl_le and Nat.div_lt_iff_lt_mul), and |range n| = n < n+1 ≤ |S|. Finset.exists_ne_map_eq_of_card_lt_of_maps_to then produces distinct a, b ∈ S with f(a) = f(b) — no manual counting of odd numbers required."
+    },
+    {
+      "id": "collision-to-witness",
+      "title": "From Collision to a Divisibility Witness",
+      "startLine": 99,
+      "endLine": 117,
+      "mathContext": "$f a = f b \\xrightarrow{\\text{odd\\_recover}} \\mathrm{ordCompl}_2 a = \\mathrm{ordCompl}_2 b \\Rightarrow a \\mid b \\lor b \\mid a$, oriented by $a \\ne b$.",
+      "summary": "The second half of erdos_divisibility_pigeonhole upgrades and orients. Positivity of a, b (from S ⊆ Icc 1 (2n)) makes both odd parts odd (odd_ordCompl); odd_recover inverts the half-map to give ordCompl[2] a = ordCompl[2] b; dvd_or_dvd_of_ordCompl_eq then delivers a ∣ b ∨ b ∣ a, and a final rcases relabels the pair using a ≠ b to return the witness in the right order."
     },
     {
       "id": "sharpness",
       "title": "Sharpness of the n+1 Threshold",
-      "startLine": 116,
-      "endLine": 141,
-      "mathContext": "$\\{n+1,\\dots,2n\\}$ has $n$ elements and no pair $a \\mid b$ with $a \\ne b$.",
-      "summary": "erdos_divisibility_pigeonhole_sharp: the block Icc (n+1) (2n) has cardinality n (Nat.card_Icc) and is divisibility-free — if a ∣ b with a ≠ b then b ≥ 2a ≥ 2(n+1) > 2n ≥ b, a contradiction. Hence no n-element bound can replace n+1."
+      "startLine": 119,
+      "endLine": 143,
+      "mathContext": "$|\\{n+1,\\dots,2n\\}| = n$ and the block has no pair $a \\mid b$ with $a \\ne b$, since $a \\mid b \\Rightarrow b \\ge 2a > 2n$.",
+      "summary": "erdos_divisibility_pigeonhole_sharp: the block Icc (n+1) (2n) has cardinality n (Nat.card_Icc) and is divisibility-free — if a ∣ b with a ≠ b then writing b = a·c with c ≥ 2 gives b ≥ 2a ≥ 2(n+1) > 2n ≥ b, a contradiction closed by omega. Hence no n-element bound can replace n+1, and the top half of {1,…,2n} is a maximum antichain."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `erdos-divisibility-pigeonhole` — a freshly-landed research entry (#26134) that had a rich `meta.json` but **no `annotations.json` at all** (quality 39, the lone genuine sub-100 entry in the gallery).

## Changes
- **Created `annotations.json`** with 6 proof-aligned annotations, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. `odd_recover` — the half-index map is injective on odd numbers
  2. `odd_ordCompl` — the odd part `ordCompl[2] m` is genuinely odd
  3. `dvd_or_dvd_of_ordCompl_eq` — equal odd parts ⇒ one divides the other (2-adic chains)
  4. the half-index pigeonhole into `Finset.range n`
  5. collision → divisibility witness, with orientation by `a ≠ b`
  6. sharpness: the top block `{n+1,…,2n}` is a maximum antichain
- **Added a 5th `keyInsight`**: the odd-part fibers are exactly the chains of the divisibility poset — the main bound and the sharpness witness are the two halves of Dilworth chain-antichain duality.
- **Split `sections` 3 → 5** to cover the full Lean file along its natural proof blocks.

## Verification
- JSON well-formed (`python json.load` + gallery prebuild data step parse clean)
- `find-targets` quality score: **39 → 100** (annotation count 25, mathContext 10, significance 10, relatedConcepts 10, sections 10)
- Content preserves and extends existing `meta.json`; no source/proof changes.

Mathematical accuracy: annotations describe the actual Lean tactics and Mathlib lemmas (`Finset.exists_ne_map_eq_of_card_lt_of_maps_to`, `Nat.ordProj_mul_ordCompl_eq_self`, `Nat.not_dvd_ordCompl`, `Nat.card_Icc`).