### PR TITLE
audit(erdos-107-oq-01): first audit CLEAN — durable tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16053,6 +16053,12 @@
       "lastAudited": "2026-06-19T11:12:32Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-107-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T11:23:46Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-107-oq-01

First audit of **erdos-107-oq-01** (Erdős #107 OQ-01: Klein's Lower Bound for f(4) = 5). Result: **CLEAN**.

### Numeric metadata — all exact vs `Proofs/Erdos107OQ01.lean`
| field | meta.json | source | ✓ |
|-------|-----------|--------|---|
| lineCount | 294 | 294 | ✓ |
| theoremCount | 18 | 18 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| axiomCount | 1 | 1 (`klein_upper_bound`) | ✓ |
| sorries | 0 | 0 | ✓ |
| native_decide | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |

### Tier C (axiomatized) — honest
- `status: "axiomatized"`, `badge: "axiom"` — correct for the single residual axiom.
- The sole assumption `klein_upper_bound : 5 ∈ CardSet 4` (the hard Klein 1931 upper-bound half) is fully disclosed in the title context, `assumptions`, and `originalContributions`.
- The lower bound `four_notin_cardSet : 4 ∉ CardSet 4` is genuinely **proved axiom-free** via the explicit triangle-plus-centroid witness `{(0,0),(6,0),(0,6),(2,2)}`.
- `f_four_eq_five : f 4 = 5` is derived from `klein_upper_bound` + the proved lower bound (`Nat.sInf_le`, `Nat.sInf_mem`, `CardSet.mono`) and does **not** use the parent's bundled `Erdos107.f_four_eq` — confirmed by source inspection (only comment mentions remain).
- The parent's defs (`CardSet`, `f`, `HasConvexNGon`, `InGeneralPosition`, `CardSet.mono`) are honest definitions/lemmas, not load-bearing axioms.
- Listed Mathlib dependencies (`collinear_iff_of_mem`, `convex_convexHull`, `subset_convexHull`, `Nat.sInf_mem`, `Nat.sInf_le`) are honest building blocks; the lower-bound argument is in-file, not a wrapper.

### Narrative failure modes
None detected — no delegation opacity, axiom masking, inequality≠theorem, pipeline inflation, or hidden-import overclaim. **LOW risk.**

Durable tracker bump only (`audit-tracker.json`); no source or meta changes required.

---
Discovered during autonomous gallery integrity audit.