### PR TITLE
research(erdos-1006-oq-01-oq-01): de-axiom target axiom is FALSE — hasDependentArc inequality backwards

### DIFF
--- a/research/problems/erdos-1006-oq-01-oq-01/sessions/2026-06-19-s1-observe-dependent-arc-definitional-bug.md
+++ b/research/problems/erdos-1006-oq-01-oq-01/sessions/2026-06-19-s1-observe-dependent-arc-definitional-bug.md
@@ -1,0 +1,179 @@
+# S1 OBSERVE — `hasDependentArc` is mis-encoded ⇒ the de-axiomatization target is currently *false* (doc-only)
+
+**Date**: 2026-06-19 (~11:24 UTC)
+**Researcher**: researcher-2
+**Mode**: OBSERVE — first session on this slug. Read `problem.md`, audited the
+parent Lean file `Proofs/Erdos1006OQ01.lean`, and discovered a definitional
+soundness bug that *blocks* the stated goal until the definition is repaired.
+**Status**: thin doc-only OBSERVE. No Lean edit, no build, no Mathlib bearer
+search, no parent gallery touch. (Build gate respected — host is saturated and
+`docker-build` clones Mathlib from source.)
+
+## §0. The task
+
+`problem.md` (id `erdos-1006-oq-01-oq-01`, category extension, tractability
+*challenging*): **"Prove `cover_graph_characterization` without axioms"** —
+formalize Pretzel's proof that robustly acyclic orientations must be Hasse
+diagrams.
+
+Parent: `Proofs/Erdos1006OQ01.lean` (277 LOC, **3 axioms**, 0 sorries, badge
+`axiom`, status `axiomatized`). The de-axiomatization target is the first axiom:
+
+```lean
+axiom cover_graph_characterization [Fintype V] :
+  admitsRobustAcyclicOrientation G ↔ isCoverGraph G
+```
+
+## §1. Finding: `hasDependentArc` is vacuously false ⇒ `isRobustlyAcyclic ≡ isAcyclic`
+
+The relevant definitions (lines 56–74):
+
+```lean
+def GraphOrientation.isAcyclic (O : GraphOrientation G) : Prop :=
+  ∃ (rank : V → ℕ), ∀ u v, O.arc u v → rank u < rank v
+
+def GraphOrientation.hasDependentArc (O : GraphOrientation G) : Prop :=
+  ∃ u v, O.arc u v ∧
+    ∀ (rank : V → ℕ), (∀ a b, O.arc a b → (a, b) ≠ (u, v) → rank a < rank b) →
+      rank v ≤ rank u                                  -- ← BUG: inequality backwards
+
+def GraphOrientation.isRobustlyAcyclic (O : GraphOrientation G) : Prop :=
+  O.isAcyclic ∧ ¬O.hasDependentArc
+```
+
+**Claim.** For *every* acyclic `O`, `hasDependentArc O` is **False**, hence
+`isRobustlyAcyclic O ↔ isAcyclic O`.
+
+**Proof.** Let `O` be acyclic and let `R : V → ℕ` be a global rank witness
+(`∀ a b, O.arc a b → R a < R b`). Fix any candidate arc `(u,v)` with
+`O.arc u v`. The inner hypothesis of `hasDependentArc` asks for ranks
+respecting *all arcs except `(u,v)`*; `R` respects **all** arcs, so it
+satisfies that hypothesis. But `O.arc u v` gives `R u < R v`, i.e.
+`¬ (R v ≤ R u)`. So `R` refutes the inner `∀`-statement
+`(respects others) → rank v ≤ rank u` for this `(u,v)`. As `(u,v)` was
+arbitrary, no arc satisfies the existential, so `hasDependentArc O` is False. ∎
+
+Equivalently: an arc `(u,v)` could only be "dependent" in this encoding if the
+*remaining* arcs forced `rank v ≤ rank u`, i.e. forced a directed path
+`v → … → u`. But together with `O.arc u v` that is a directed cycle, impossible
+in an acyclic `O`. The encoding therefore detects nothing.
+
+## §2. Consequence: the axiom is *false*, and lets you derive `False`
+
+Because `isRobustlyAcyclic ≡ isAcyclic`, we get
+`admitsRobustAcyclicOrientation G ↔ (G admits an acyclic orientation)`, which is
+**True for every finite `G`** (any linear order works — the file's own
+`linearOrientation` is acyclic). So under the current definitions the axiom
+asserts
+
+> every finite graph is a cover graph of some poset
+
+which is **false**. Concrete refutation — the triangle `K₃` (complete graph on
+`Fin 3`):
+
+- `admitsRobustAcyclicOrientation K₃ = True`: `linearOrientation` orients
+  `0→1→2`, `0→2`; `rank = Fin.val` witnesses acyclicity; `hasDependentArc` is
+  vacuously false by §1.
+- `isCoverGraph K₃ = False`: a 3-element poset cannot have all three pairs
+  covering. If `0 ⋖ 1` and `1 ⋖ 2` then `0 < 1 < 2`, so `0 ⋖ 2` fails (1 lies
+  strictly between). By symmetry every linear/branching arrangement kills one
+  of the three covering edges. Hence `K₃` is not a Hasse diagram.
+
+Then `(cover_graph_characterization).mp (proof_admits) : isCoverGraph K₃`
+contradicts `isCoverGraph K₃ = False`, i.e. `False` is derivable from the
+axiom. **The current axiomatization is unsound, not merely strong.**
+
+> Audit note for Mechanic/Auditor: `meta.json` honestly reports
+> `status: axiomatized`, badge `axiom`, 3 axioms — the *disclosure* is fine.
+> The problem is the *content* of one axiom contradicts the file's own
+> definitions. This is a correctness bug in the Lean source, independent of the
+> gallery-integrity numerics (which all match: 277 LOC / 3 axioms / 0 sorries).
+
+## §3. The one-line fix
+
+The intended notion: arc `(u,v)` is **dependent** iff *reversing* it (to `v→u`)
+while keeping the other arcs creates a directed cycle — equivalently, no acyclic
+ranking of the reversed orientation exists — equivalently, every ranking
+respecting the other arcs already forces `rank u ≤ rank v` (so you cannot place
+`v` below `u`). That is the **opposite** inequality:
+
+```lean
+def GraphOrientation.hasDependentArc (O : GraphOrientation G) : Prop :=
+  ∃ u v, O.arc u v ∧
+    ∀ (rank : V → ℕ), (∀ a b, O.arc a b → (a, b) ≠ (u, v) → rank a < rank b) →
+      rank u ≤ rank v                                  -- FIX: was `rank v ≤ rank u`
+```
+
+Sanity check of the fix:
+- **No path `u → … → v` in the remaining arcs** ⇒ one can choose a respecting
+  ranking with `rank v < rank u` (rank the two independently) ⇒ inner `∀` is
+  False ⇒ arc **not** dependent (reversible). ✓
+- **A path `u → … → v` in the remaining arcs** ⇒ every respecting ranking has
+  `rank u < … < rank v`, so `rank u ≤ rank v` always holds ⇒ arc **dependent**
+  (reversal closes a cycle). ✓
+
+So `isRobustlyAcyclic` becomes the genuine "every arc is a covering relation"
+property, and `admitsRobustAcyclicOrientation` becomes a *restrictive* property
+(Nešetřil–Rödl: graphs of high girth and chromatic number fail it), as intended.
+
+## §4. De-axiomatization roadmap (post-fix)
+
+The proof file already contains the *forward* direction skeleton; the bug is why
+it currently typechecks too easily. After the §3 fix the work is:
+
+1. **STEP A (fix + re-prove forward).** Apply §3. Re-prove
+   `cover_graph_admits_robust` (lines 157–167) under the corrected
+   `hasDependentArc`. The old proof leaned on the vacuous collapse (it discharged
+   `¬hasDependentArc` with a single global `posetRank`). Now `¬hasDependentArc`
+   requires: for each covering arc `u ⋖ v`, a ranking respecting all *other*
+   covering arcs with `rank v < rank u`. This is realizable because `u ⋖ v`
+   means nothing lies strictly between `u` and `v`, so the pair can be swapped
+   without violating other covers — but it must be constructed (perturb
+   `posetRank`), not asserted.
+
+2. **STEP B (reverse direction = the actual Pretzel content).**
+   `admitsRobustAcyclicOrientation G → isCoverGraph G`. Given robustly acyclic
+   `O`, define the **reachability preorder** `u ≤ v := Relation.ReflTransGen O.arc u v`.
+   Acyclicity (the rank witness) gives antisymmetry ⇒ `PartialOrder V`. Then show
+   `isCoverGraphOf G`, i.e. `G.Adj u v ↔ (u ⋖ v ∨ v ⋖ u)`:
+   - (→) `Adj u v` ⇒ WLOG `O.arc u v` (covers) ⇒ `u < v`. Robustness (every arc
+     independent under the *corrected* def) ⇒ no path `u → … → v` of length ≥ 2
+     ⇒ nothing strictly between ⇒ `u ⋖ v`.
+   - (←) `u ⋖ v` ⇒ `u < v` ⇒ a directed `O`-path `u → … → v`. Its first arc
+     `u → w` gives `u < w ≤ v`; covering ⇒ `w = v` ⇒ `O.arc u v` ⇒ `Adj u v`.
+
+3. **STEP C.** Combine A+B into `cover_graph_characterization` as a `theorem`,
+   delete the axiom, update `meta.json` (`axiomCount 3 → 2`, refresh
+   `assumptions`). The other two axioms (`chromatic_lt_girth_implies_robust`,
+   `nesetril_rodl_counterexample`) are *separate, genuinely deep* results and
+   stay axiomatized for now — out of scope for this slug.
+
+**Mathlib infrastructure**: `Relation.ReflTransGen` / `Relation.TransGen` for
+reachability; `Finset.card_lt_card` (already used by `posetRank_strictMono`);
+`PartialOrder.lift` is not directly applicable (no carrier map) — build the
+instance by hand from reachability with antisymmetry from the rank witness.
+
+**Tractability re-assessment**: STEP B is the real theorem and is *moderate*,
+not *challenging*, once the reachability poset is set up — the robustness ⇔
+covering equivalence is exactly what the corrected definition encodes. STEP A
+(re-proving forward under the fix) is the fiddlier part (constructing per-arc
+swapped rankings).
+
+## §5. Why no Lean edit this session
+
+The §3 fix cascades into STEP A (the existing `cover_graph_admits_robust` proof
+breaks under the corrected definition). Shipping the definition swap *without*
+the repaired forward proof would leave the file broken; shipping both requires a
+Docker build to verify, and the host is saturated (per project policy, never run
+`lake build`; `docker-build` clones Mathlib from source = OOM risk). Pushing
+unverified Lean is unsafe (deployer auto-merges math PRs). This session therefore
+ships the **finding + roadmap only**; the Lean change is the next build-capable
+session's STEP A/B/C.
+
+## §6. State transition
+
+OBSERVE → **ORIENT**. The obstacle is identified (definitional bug), the fix is
+known (§3), and the reverse-direction strategy is sketched (§4 STEP B). Next
+action: in a build-capable session, apply §3, re-prove forward (STEP A), then
+formalize the reachability-poset reverse direction (STEP B), build via
+`docker-build Proofs.Erdos1006OQ01`, and de-axiomatize.

--- a/research/problems/erdos-1006-oq-01-oq-01/state.md
+++ b/research/problems/erdos-1006-oq-01-oq-01/state.md
@@ -1,16 +1,26 @@
 # Research State: erdos-1006-oq-01-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-04-05T20:06:18-07:00
-**Iteration**: 1
+**Since**: 2026-06-19T11:24:00Z
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+S1 OBSERVE found a definitional soundness bug in the parent Lean file
+`Proofs/Erdos1006OQ01.lean`: `hasDependentArc` has its rank inequality
+backwards (`rank v ≤ rank u`), so it is vacuously false for every acyclic
+orientation, collapsing `isRobustlyAcyclic` to `isAcyclic`. As a result the
+target axiom `cover_graph_characterization` is **false** (it asserts every
+finite graph is a cover graph; `K₃` refutes it) and lets `False` be derived.
+The de-axiomatization is blocked until the definition is repaired.
 
 ## Active Approach
-None yet.
+Repair-then-prove. (1) Fix `hasDependentArc` to `rank u ≤ rank v` (§3 of S1).
+(2) Re-prove `cover_graph_admits_robust` under the corrected def (STEP A).
+(3) Prove the reverse direction via the reachability preorder
+`Relation.ReflTransGen O.arc` made into a `PartialOrder` (STEP B). (4) Combine
+and delete the axiom (STEP C). See S1 note §4 for the full roadmap.
 
 ## Attempt Count
 - Total attempts: 0
@@ -18,8 +28,13 @@ None yet.
 - Approaches tried: 0
 
 ## Blockers
-None.
+- Build gate: host saturated; `docker-build` clones Mathlib from source (OOM
+  risk); cannot compile-verify the §3 fix + STEP A re-proof this session.
+- The §3 one-line fix cascades into STEP A (breaks the existing forward proof),
+  so it cannot be shipped in isolation without a build.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+In a build-capable session: apply §3 fix, re-prove `cover_graph_admits_robust`
+(STEP A), formalize the reachability-poset reverse direction (STEP B), build via
+`docker-build Proofs.Erdos1006OQ01`, then de-axiomatize (STEP C) and update
+`meta.json` axiomCount 3 → 2.

--- a/research/problems/erdos-998-oq-04/knowledge.md
+++ b/research/problems/erdos-998-oq-04/knowledge.md
@@ -412,3 +412,30 @@ This is a documentation/decomposition session, NOT a proving session — both ba
   the 3+-sessions-stuck rule. **Next build-capable session**: run one
   `docker-build Proofs.Erdos998ThreeGapOQ04` (when ≤8 containers) to convert this
   hand-audit into a kernel check, then retry Aristotle on STEP D.
+
+## S10 (researcher-2, 2026-06-19 ~04:12 PDT) — Aristotle CLI REACHABLE → STEP D submitted
+
+- **Backend status flip**: Aristotle MCP `prove_file` STILL 404s (`{"status":"error",
+  "message":"Resource not found."}`), but the **CLI is reachable** (`uvx --from
+  aristotlelib aristotle list` returns jobs). Same split observed by researcher-2/9/10
+  this date. So the 5+-session blackout on STEP D is broken via the CLI path.
+- **Action**: submitted the whole `Erdos998ThreeGapOQ04.lean` (build-verified, sole
+  `sorry` = STEP D classification, witnesses confirmed correct in S8) as a self-contained
+  CLI project (temp dir + `lakefile.toml` requiring mathlib v4.26.0 + `lean-toolchain`).
+  Prompt scoped Aristotle to prove ONLY the final `sorry` in `exists_gap_triple` (N≥2
+  three-gap classification), using the in-file infra (`orbit_card`,
+  `fract_fract_sub_fract`, `card_le_three_of_subset_triple`) as warm-up lemmas.
+  - **project_id**: `f3b4620d-814e-430d-97a8-c40321b48abf`
+  - CLI warned host toolchain v4.26.0 vs Aristotle-preferred v4.28.0, and no `.lake`
+    folder uploaded (deps resolved server-side) — both non-fatal, job created.
+  - Tracked in `research/aristotle-jobs.json`.
+- **RETRIEVE (next session)**: `uvx --from aristotlelib aristotle show f3b4620d` →
+  if PROVED, `aristotle download` the result, paste the proof body over the `sorry` at
+  `Erdos998ThreeGapOQ04.lean:335` (the `· -- N ≥ 2` branch of `exists_gap_triple`),
+  then `docker-build Proofs.Erdos998ThreeGapOQ04` (≤8 containers) to kernel-check, and
+  flip meta.json sorries 1→0 / badge → verified if green. STEP D is known math (van
+  Ravenstein), so a successful close is plausible but not guaranteed — it is the genuine
+  combinatorial core, so partial/failed is a real outcome; re-decompose into A/B/C
+  warm-up lemmas if Aristotle returns `partial`.
+- **Status**: STEP D submitted to Aristotle (async); frontier otherwise unchanged
+  (1 `sorry`, 0 axioms, build-verified). Released claim, moving on per loop workflow.


### PR DESCRIPTION
## Summary

S1 OBSERVE on `erdos-1006-oq-01-oq-01` ("prove `cover_graph_characterization` without axioms"). Found a **soundness bug** that blocks the goal until repaired.

## Finding

In `Proofs/Erdos1006OQ01.lean`, `hasDependentArc` has its rank inequality **backwards**:

```lean
-- current (BUG):  ... → rank v ≤ rank u
-- correct:        ... → rank u ≤ rank v
```

Consequence chain:
1. For **every** acyclic `O`, the global rank witness `R` refutes the inner ∀ for every arc ⇒ `hasDependentArc O` is **vacuously False**.
2. So `isRobustlyAcyclic ≡ isAcyclic`, and `admitsRobustAcyclicOrientation G` is **True for all finite G** (any linear order).
3. The target axiom then asserts *every finite graph is a cover graph* — **false**. `K₃` (triangle) admits an acyclic orientation but is not a Hasse diagram ⇒ the axiom lets `False` be derived.

`meta.json` disclosure (status `axiomatized`, 3 axioms) is honest; the bug is in the **content** of one axiom vs. the file's own definitions.

## Fix + roadmap (next build-capable session)

- **STEP A**: swap to `rank u ≤ rank v`; re-prove `cover_graph_admits_robust` (old proof relied on the vacuous collapse).
- **STEP B**: reverse direction (the real Pretzel content) via reachability preorder `Relation.ReflTransGen O.arc` → `PartialOrder` → `isCoverGraphOf`.
- **STEP C**: combine, delete axiom, `axiomCount 3 → 2`.

Full derivation in the session note. **Doc-only** — no Lean edit (build-gated; the §3 fix cascades into STEP A and needs a Docker build to verify).

## Files
- `research/problems/erdos-1006-oq-01-oq-01/sessions/2026-06-19-s1-observe-dependent-arc-definitional-bug.md` (new)
- `research/problems/erdos-1006-oq-01-oq-01/state.md` (OBSERVE → ORIENT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)