### PR TITLE
Enrich Erdős Divisibility Pigeonhole: add annotations, sections (39→100)

### DIFF
--- a/src/data/proofs/erdos-divisibility-pigeonhole/annotations.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole/annotations.json
@@ -1,0 +1,163 @@
+[
+  {
+    "id": "ann-erdos-div-pigeon-odd-recover",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": {
+      "startLine": 41,
+      "endLine": 46
+    },
+    "type": "technique",
+    "title": "The Half-Map Is Injective on Odd Numbers",
+    "content": "odd_recover establishes that for an odd o, the operation o ↦ (o−1)/2 loses no information: 2·((o−1)/2)+1 = o reconstructs o exactly. This injectivity is what lets the proof pigeonhole into Finset.range n via half-indices instead of computing the cardinality of the odd numbers in {1,…,2n}. The proof destructures Odd o as o = 2k+1 and simplifies, so the integer division is exact rather than truncating.",
+    "mathContext": "For odd $o = 2k+1$: $\\frac{o-1}{2} = k$ and $2\\cdot\\frac{o-1}{2} + 1 = 2k+1 = o$. Hence $o \\mapsto \\frac{o-1}{2}$ is a bijection between odd numbers and $\\mathbb{N}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "injective map",
+      "odd numbers",
+      "integer division",
+      "Odd predicate"
+    ],
+    "prerequisites": [
+      "natural-number arithmetic",
+      "Nat.div exactness on odd inputs"
+    ]
+  },
+  {
+    "id": "ann-erdos-div-pigeon-odd-ordcompl",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": {
+      "startLine": 48,
+      "endLine": 52
+    },
+    "type": "definition",
+    "title": "The Odd Part ordCompl[2] m Is Odd",
+    "content": "odd_ordCompl confirms the defining property of the odd part: ordCompl[2] m = m / 2^(v₂ m) carries away every factor of two, so it is coprime to 2 and therefore odd whenever m ≠ 0. The proof uses Nat.not_dvd_ordCompl (2 does not divide the 2-complement) and converts ¬(2 ∣ x) to Odd x via omega. Oddness is exactly the hypothesis needed to invoke odd_recover.",
+    "mathContext": "$\\mathrm{ordCompl}_2(m) = m / 2^{v_2(m)}$ where $v_2$ is the 2-adic valuation. By construction $2 \\nmid \\mathrm{ordCompl}_2(m)$, i.e. it is odd, for every $m \\neq 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ordCompl",
+      "2-adic valuation",
+      "Nat.not_dvd_ordCompl",
+      "odd part"
+    ],
+    "prerequisites": [
+      "p-adic valuation",
+      "Mathlib factorization API"
+    ]
+  },
+  {
+    "id": "ann-erdos-div-pigeon-dvd-or-dvd",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": {
+      "startLine": 54,
+      "endLine": 74
+    },
+    "type": "insight",
+    "title": "Same Odd Part ⇒ One Divides the Other",
+    "content": "dvd_or_dvd_of_ordCompl_eq is the heart of the argument: once two numbers share an odd part, they sit on a common chain of the divisibility poset and are comparable. Writing a = 2^(v₂ a)·o and b = 2^(v₂ b)·o via Nat.ordProj_mul_ordCompl_eq_self, the proof compares the two exponents with le_total; the smaller power of two divides the larger (pow_dvd_pow), and mul_dvd_mul_right lifts this to a ∣ b (or b ∣ a). This is the step that turns an equality of labels into a divisibility relation.",
+    "mathContext": "If $\\mathrm{ordCompl}_2(a) = \\mathrm{ordCompl}_2(b) = o$, write $a = 2^{i}o,\\ b = 2^{j}o$. WLOG $i \\le j$, then $2^{i} \\mid 2^{j}$ so $a = 2^{i}o \\mid 2^{j}o = b$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.ordProj_mul_ordCompl_eq_self",
+      "pow_dvd_pow",
+      "divisibility chain",
+      "2-adic factorization"
+    ],
+    "prerequisites": [
+      "unique factorization",
+      "divisibility of prime powers"
+    ]
+  },
+  {
+    "id": "ann-erdos-div-pigeon-maps-to-range",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": {
+      "startLine": 82,
+      "endLine": 92
+    },
+    "type": "technique",
+    "title": "The Half-Index Lands in Finset.range n",
+    "content": "The pigeons are S and the holes are Finset.range n. The map is f(m) = (ordCompl[2] m − 1)/2. Membership f(m) < n follows because the odd part o = ordCompl[2] m satisfies o ≤ m ≤ 2n (Nat.ordCompl_le), so (o−1)/2 < n by Nat.div_lt_iff_lt_mul and omega. Crucially the proof never counts the odd numbers — it encodes 'there are only n possible odd parts' geometrically by squeezing the half-index into range n.",
+    "mathContext": "$o = \\mathrm{ordCompl}_2(m) \\le m \\le 2n \\Rightarrow \\frac{o-1}{2} < n$. So $f : S \\to \\{0,1,\\dots,n-1\\} = \\mathrm{range}\\,n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.ordCompl_le",
+      "Finset.range",
+      "Nat.div_lt_iff_lt_mul",
+      "maps_to"
+    ],
+    "prerequisites": [
+      "Finset membership",
+      "natural-number inequalities"
+    ]
+  },
+  {
+    "id": "ann-erdos-div-pigeon-pigeonhole",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": {
+      "startLine": 93,
+      "endLine": 97
+    },
+    "type": "concept",
+    "title": "The Pigeonhole Collision",
+    "content": "With |range n| = n < n+1 ≤ |S| (Finset.card_range and the hypothesis hcard), Finset.exists_ne_map_eq_of_card_lt_of_maps_to delivers two distinct a, b ∈ S with f(a) = f(b). This is the abstract pigeonhole principle in its Finset incarnation: a map from a larger set into a strictly smaller one must identify two points. Everything before this prepares the map; everything after decodes the collision.",
+    "mathContext": "$|\\mathrm{range}\\,n| = n < n+1 \\le |S|$, so a map $f : S \\to \\mathrm{range}\\,n$ cannot be injective: $\\exists\\, a \\ne b,\\ f(a) = f(b)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.exists_ne_map_eq_of_card_lt_of_maps_to",
+      "pigeonhole principle",
+      "Finset.card_range",
+      "non-injectivity"
+    ],
+    "prerequisites": [
+      "pigeonhole principle",
+      "Finset cardinality"
+    ]
+  },
+  {
+    "id": "ann-erdos-div-pigeon-decode",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": {
+      "startLine": 98,
+      "endLine": 115
+    },
+    "type": "insight",
+    "title": "Decoding the Collision and Orienting the Divisibility",
+    "content": "The collision f(a) = f(b) is an equality of half-indices; positivity of a, b (from S ⊆ Icc 1 (2n)) makes their odd parts odd, and odd_recover upgrades the half-index equality to a genuine equality of odd parts ordCompl[2] a = ordCompl[2] b. Then dvd_or_dvd_of_ordCompl_eq yields a ∣ b ∨ b ∣ a, and the disjunction is oriented using a ≠ b: in either branch the pair is returned with distinctness intact.",
+    "mathContext": "$f(a)=f(b) \\xRightarrow{\\text{odd\\_recover}} \\mathrm{ordCompl}_2(a) = \\mathrm{ordCompl}_2(b) \\Rightarrow a \\mid b \\lor b \\mid a$, oriented by $a \\ne b$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "odd_recover",
+      "case analysis",
+      "rcases orientation",
+      "divisibility"
+    ],
+    "prerequisites": [
+      "case analysis on disjunctions",
+      "Finset membership extraction"
+    ]
+  },
+  {
+    "id": "ann-erdos-div-pigeon-sharpness",
+    "proofId": "erdos-divisibility-pigeonhole",
+    "range": {
+      "startLine": 117,
+      "endLine": 141
+    },
+    "type": "insight",
+    "title": "Sharpness: The Top Block {n+1,…,2n} Is Divisibility-Free",
+    "content": "erdos_divisibility_pigeonhole_sharp shows n+1 cannot be lowered by exhibiting an n-element antichain. The witness is Icc (n+1) (2n): it has cardinality n (Nat.card_Icc) and contains no pair a ∣ b with a ≠ b. The key arithmetic: if a ∣ b and a ≠ b then b = a·c with c ≥ 2, so b ≥ 2a ≥ 2(n+1) > 2n ≥ b — a contradiction. Thus the threshold n+1 in the main theorem is genuinely optimal, not an artifact of the proof.",
+    "mathContext": "In $\\{n+1,\\dots,2n\\}$: $a \\mid b,\\ a \\ne b \\Rightarrow b = ac,\\ c \\ge 2 \\Rightarrow b \\ge 2a \\ge 2(n+1) > 2n \\ge b$, contradiction. So this $n$-set is an antichain and $n+1$ is sharp.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.card_Icc",
+      "antichain",
+      "extremal optimality",
+      "Nat.le_of_dvd"
+    ],
+    "prerequisites": [
+      "divisibility bounds",
+      "extremal set theory"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-divisibility-pigeonhole/meta.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole/meta.json
@@ -65,7 +65,8 @@
       "**The odd part is the right pigeonhole**: classifying integers by ⌊2-free core⌋ rather than by value turns a divisibility question into an equality-of-labels collision. {1,…,2n} has exactly n odd parts, one short of the n+1 elements",
       "**Same odd part ⇒ comparable in the divisibility order**: two numbers sharing an odd part differ only by a power of two, so they form a chain — the smaller exponent divides the larger. This is where 'collision' becomes 'divides'",
       "**Avoid counting odds with a half-index**: instead of computing the cardinality of the odd numbers in {1,…,2n}, the proof maps odd parts into Finset.range n via o ↦ (o−1)/2 and uses injectivity-on-odds to recover the collision; this keeps the Lean proof free of Finset.filter cardinality lemmas",
-      "**Sharpness is one line of arithmetic**: the top half {n+1,…,2n} is an antichain because doubling the smallest possible divisor already leaves the window — so n+1 is genuinely the optimal threshold, not an artifact of the proof"
+      "**Sharpness is one line of arithmetic**: the top half {n+1,…,2n} is an antichain because doubling the smallest possible divisor already leaves the window — so n+1 is genuinely the optimal threshold, not an artifact of the proof",
+      "**It is a chain decomposition in disguise**: grouping {1,…,2n} by odd part partitions it into exactly n divisibility chains (each chain o, 2o, 4o, … capped at 2n). The pigeonhole 'n+1 elements meet a common chain' is the Dilworth/Mirsky reading — the same combinatorial skeleton behind primitive-set and antichain extremal bounds"
     ],
     "prerequisites": [
       "The pigeonhole principle in Finset form (Finset.exists_ne_map_eq_of_card_lt_of_maps_to)",
@@ -75,12 +76,28 @@
   },
   "sections": [
     {
-      "id": "module-overview-and-helpers",
-      "title": "Module Overview and Odd-Part Helpers",
+      "id": "module-overview",
+      "title": "Module Overview",
       "startLine": 1,
-      "endLine": 75,
-      "mathContext": "Odd parts: $o(m) = \\mathrm{ordCompl}_2(m)$ is odd, and $o \\mapsto (o-1)/2$ is injective on odd numbers since $2\\cdot((o-1)/2)+1 = o$.",
-      "summary": "Docstring states the theorem, the odd-part pigeonhole proof, and sharpness. Helpers: odd_recover (2·((o−1)/2)+1 = o, injectivity of the half-map on odds), odd_ordCompl (ordCompl[2] m is odd for m ≠ 0, via Nat.not_dvd_ordCompl), and dvd_or_dvd_of_ordCompl_eq (equal odd parts ⇒ one divides the other, via the 2-adic decomposition and pow_dvd_pow)."
+      "endLine": 39,
+      "mathContext": "$S \\subseteq \\{1,\\dots,2n\\},\\ |S| \\ge n+1 \\Rightarrow \\exists\\, a \\ne b,\\ a \\mid b$; sharp via the antichain $\\{n+1,\\dots,2n\\}$.",
+      "summary": "Docstring states the theorem, sketches the odd-part pigeonhole proof (m = 2^k·o with o = ordCompl[2] m; only n odd parts available in {1,…,2n}), the half-index encoding that avoids counting, and the sharpness witness {n+1,…,2n}. Imports Mathlib and opens Finset."
+    },
+    {
+      "id": "odd-part-helpers",
+      "title": "Odd-Part Helper Lemmas",
+      "startLine": 41,
+      "endLine": 52,
+      "mathContext": "$o \\mapsto (o-1)/2$ is injective on odds since $2\\cdot((o-1)/2)+1 = o$; and $\\mathrm{ordCompl}_2(m)$ is odd for $m \\neq 0$.",
+      "summary": "odd_recover: 2·((o−1)/2)+1 = o, so the half-map o ↦ (o−1)/2 loses no information on odd numbers. odd_ordCompl: ordCompl[2] m is odd for m ≠ 0, via Nat.not_dvd_ordCompl converted with omega. Together they let the proof read an odd part back off its half-index."
+    },
+    {
+      "id": "same-odd-part-divides",
+      "title": "Same Odd Part ⇒ One Divides the Other",
+      "startLine": 54,
+      "endLine": 74,
+      "mathContext": "$\\mathrm{ordCompl}_2(a) = \\mathrm{ordCompl}_2(b) = o,\\ a = 2^{i}o,\\ b = 2^{j}o,\\ i \\le j \\Rightarrow a \\mid b$.",
+      "summary": "dvd_or_dvd_of_ordCompl_eq: equal odd parts force comparability. Writing a = 2^(v₂ a)·o and b = 2^(v₂ b)·o (Nat.ordProj_mul_ordCompl_eq_self), le_total on the exponents plus pow_dvd_pow and mul_dvd_mul_right give a ∣ b or b ∣ a. This converts an equality of labels into a divisibility relation."
     },
     {
       "id": "main-theorem",


### PR DESCRIPTION
Enrichment pass for `erdos-divisibility-pigeonhole` — the **only** gallery entry of 2556 with no `annotations.json`, which was its entire quality deficit.

## Changes
- **annotations.json (new, 7 annotations)** — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. They walk the proof: `odd_recover` (half-map injectivity on odds), `odd_ordCompl`, the same-odd-part⇒divides core (`dvd_or_dvd_of_ordCompl_eq`), the half-index `maps_to range n`, the pigeonhole collision (`Finset.exists_ne_map_eq_of_card_lt_of_maps_to`), decoding + orienting the divisibility, and the sharpness antichain `{n+1,…,2n}`.
- **meta.json** — added a 5th keyInsight (the chain-decomposition / Dilworth–Mirsky reading) and split `sections` 3→5 along the proof's structure.

## Quality
Score **39 → 100** (perfect breakdown: annotations 25, mathContext 10, significance 10, historicalContext 10, keyInsights 10, conclusion 15, sections 10, crossRefs 10).

## Verification
- `pnpm build` green; entry now present in build-generated `listings.json` + `data-manifest.json`, public data emits all 7 annotations.
- No mathematical claims altered; status/badge/axiomCount untouched (still verified / original / 0). Annotations describe only what the Lean source proves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)