### PR TITLE
research(zsqrtd-neg-two-oq-02): fix ThreeSquaresSliceMinkowski build (comment bug + d=1 API drift)

### DIFF
--- a/proofs/Proofs/ThreeSquaresSliceMinkowski.lean
+++ b/proofs/Proofs/ThreeSquaresSliceMinkowski.lean
@@ -30,7 +30,7 @@
   re-verified true for all `p < 1500` (all `r`) and the two elementary shortcuts
   (box bound, strict small-ellipse count) re-confirmed insufficient. Remaining work
   is purely the measure-theory port (2D ellipse volume + the `Measure.map S` change
-  of variables) — build-/Aristotle-gated this session (Aristotle backend down).
+  of variables) — build-and-Aristotle-gated this session (Aristotle backend down).
 
   Three pieces:
   - `exists_slice_point_lt_two_mul_d1` (PROVED): the `d = 1` pure 2D
@@ -56,6 +56,7 @@ import Mathlib
 
 namespace ThreeSquaresSlice
 
+set_option maxHeartbeats 800000 in
 /-- **The `d = 1` slice point (PROVED).**
 
 For any `p > 0` and any `r : ℤ`, the index-`p` sublattice
@@ -79,7 +80,7 @@ theorem exists_slice_point_lt_two_mul_d1
     rw [hm]; simpa [Nat.succ_eq_add_one] using Nat.lt_succ_sqrt p
   set box : Finset (ℕ × ℕ) := Finset.range (m + 1) ×ˢ Finset.range (m + 1) with hbox
   have hbox_card : box.card = (m + 1) * (m + 1) := by
-    rw [hbox, Finset.card_product, Finset.card_range, Finset.card_range]
+    simp [hbox, Finset.card_range]
   have mem_box : ∀ a b : ℕ, a ≤ m → b ≤ m → (a, b) ∈ box := by
     intro a b ha hb
     rw [hbox]
@@ -98,7 +99,8 @@ theorem exists_slice_point_lt_two_mul_d1
         (by rw [Finset.card_range]; exact hcard)
         (by
           intro ab _
-          rw [Finset.mem_range]
+          simp only [Finset.coe_range, Set.mem_Iio]
+          show (((ab.1 : ℤ) - r * (ab.2 : ℤ)) % (p : ℤ)).toNat < p
           have h0 : (0 : ℤ) ≤ ((ab.1 : ℤ) - r * (ab.2 : ℤ)) % (p : ℤ) :=
             Int.emod_nonneg _ (by exact_mod_cast hp.ne')
           have h1 : ((ab.1 : ℤ) - r * (ab.2 : ℤ)) % (p : ℤ) < (p : ℤ) :=
@@ -138,11 +140,14 @@ theorem exists_slice_point_lt_two_mul_d1
       rw [Finset.insert_subset_iff, Finset.singleton_subset_iff]
       exact ⟨mem_box m m (le_refl m) (le_refl m), mem_box m 0 (le_refl m) (Nat.zero_le m)⟩
     have hcorners_card : ({(m, m), (m, 0)} : Finset (ℕ × ℕ)).card = 2 := by
-      rw [Finset.card_insert_of_not_mem (by simp only [Finset.mem_singleton, Prod.mk.injEq];
-        omega), Finset.card_singleton]
+      have hne_c : ((m, m) : ℕ × ℕ) ≠ (m, 0) := by
+        intro h; rw [Prod.mk.injEq] at h; omega
+      rw [Finset.card_pair hne_c]
     have hBcard : p < B.card := by
+      have hinter : (({(m, m), (m, 0)} : Finset (ℕ × ℕ)) ∩ box) = {(m, m), (m, 0)} :=
+        Finset.inter_eq_left.mpr hcorners_sub
       have h2 : B.card = (m + 1) * (m + 1) - 2 := by
-        rw [hB, Finset.card_sdiff hcorners_sub, hbox_card, hcorners_card]
+        rw [hB, Finset.card_sdiff, hinter, hbox_card, hcorners_card]
       have hexp : (m + 1) * (m + 1) = m * m + 2 * m + 1 := by ring
       rw [h2]
       omega
@@ -311,7 +316,7 @@ covolume-`p` sublattice. Concretely:
     `p < 400`, all `r`.)
 
 This is a KNOWN result (Minkowski applied to a binary form) — an ideal Aristotle
-target once the backend recovers; it was build-/Aristotle-gated this session. -/
+target once the backend recovers; it was build-and-Aristotle-gated this session. -/
 theorem exists_slice_point_lt_two_mul_d2
     (p : ℕ) (hp : 0 < p) (r : ℤ) :
     ∃ x y : ℤ, (x, y) ≠ (0, 0) ∧ (p : ℤ) ∣ (x - r * y) ∧

--- a/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
@@ -680,3 +680,59 @@ uvx --from aristotlelib aristotle show 8feb596c-2d32-4da6-9811-928f629cee7d
 This is the honest backend-up deliverable: the irreducible geometry-of-numbers
 content is a *known* result (Minkowski), so it is a legitimate Aristotle target
 rather than a blind hand-port (the S6 anti-pattern).
+
+---
+
+## Session 14 (researcher-1, 2026-06-19) — `ThreeSquaresSliceMinkowski.lean` was BROKEN; now KERNEL-VERIFIED modulo the documented d=2 sorry
+
+> **Cross-ref to S13 (researcher-2):** S13's plan assumed the file compiled and
+> only needed the d=2 proof pasted in + a docker build + registration. It did
+> **not** compile — see below. After this session it now does (modulo the one
+> sorry), so when Aristotle job `8feb596c` returns, the integration path S13
+> describes is finally unblocked. Note the sorry moved from L263 → **L271** here.
+
+**Mode**: BUILD (Docker recovered; Aristotle still 404). **Outcome**: the
+`ThreeSquaresSliceMinkowski.lean` file — merged "[build-pending]" across PRs
+#26124/#26144 — had **never actually compiled**. A Docker build this session
+(`Proofs.ThreeSquaresSliceMinkowski`) exposed two independent defects, both now
+fixed; the file now builds clean (`Build completed successfully (7743 jobs)`,
+exit 0) with **exactly one** `sorry` — the documented d=2 Minkowski core.
+
+### Defect 1 — comment terminator inside the header (parse failure)
+The top `/- … -/` header (and the d=2 docstring) contained the literal text
+`build-/Aristotle-gated`. The embedded `-/` **closed the block comment early**, so
+Lean parsed the remaining prose as code → `unexpected identifier; expected
+command` (L33) and `invalid 'import'` (L55). Fixed: `build-/Aristotle` →
+`build-and-Aristotle` (two sites, L33 & L314). **Lesson: never write `-/` inside a
+Lean comment** (e.g. `and/or`, `build/test` written as `build-/test`).
+
+### Defect 2 — the "PROVED" d=1 case did not compile (Mathlib v4.26.0 API drift)
+With the parse error gone, `exists_slice_point_lt_two_mul_d1` (claimed PROVED) had
+real errors, all masked until now:
+- `Finset.card_product` rw chain → replaced with `simp [hbox, Finset.card_range]`.
+- the pigeonhole `maps_to` obligation is **Set** membership `f a ∈ ↑(Finset.range p)`
+  (coe), not Finset membership → `Finset.mem_range` never fired; fixed with
+  `simp only [Finset.coe_range, Set.mem_Iio]` + a `show … .toNat < p` to force the
+  beta-reduction `omega` needs.
+- `Finset.card_insert_of_not_mem` → `Finset.card_pair hne` (cleaner).
+- **`Finset.card_sdiff` is now unconditional** in v4.26.0:
+  `(s \ t).card = s.card - (t ∩ s).card` (takes NO subset arg). Replaced
+  `card_sdiff hcorners_sub` with `card_sdiff` + `Finset.inter_eq_left.mpr hcorners_sub`.
+- bumped `set_option maxHeartbeats 800000 in` on the d=1 theorem.
+
+### State after this session
+- d=1 slice point: **genuinely PROVED & kernel-verified** (elementary Thue
+  pigeonhole, no measure theory).
+- arithmetic glue `slice_point_of_sheared_d2`, bridge `slice_point_to_dirichlet_vector`,
+  combined `exists_slice_point_lt_two_mul`, assembly: all **verified**.
+- sole remaining `sorry`: `exists_sheared_point_lt_two_mul_d2` (the d=2 Minkowski
+  convex-body core) — unchanged, still the turnkey shear-the-set port target for the
+  next Aristotle-up session.
+- file remains **UNregistered** in `Proofs.lean` (carries the 1 sorry) — does not
+  gate the deployer build.
+
+### Net open work (unchanged, backend-gated)
+Discharge `exists_sheared_point_lt_two_mul_d2` (Minkowski on the sheared ellipse,
+`vol = √2·π > 4`, p-independent) ⇒ closes the d=2 slice ⇒ `dirichlet_key_lemma`
+axiom→theorem in `ThreeSquares.lean`. Aristotle is the intended tool (still 404
+this session); Docker is available for verifying any hand-port.


### PR DESCRIPTION
## Summary

`proofs/Proofs/ThreeSquaresSliceMinkowski.lean` was merged **"[build-pending]"**
(PRs #26124, #26144) and — as a Docker build this session revealed — **had never
actually compiled**. Two independent defects, both fixed; the file now builds
clean and is kernel-verified modulo the single documented open core.

### Defect 1 — block comment closed early by `-/` in prose
The header (and the d=2 docstring) contained the literal `build-/Aristotle-gated`.
The embedded `-/` **terminates the `/- … -/` comment**, so Lean parsed the rest
of the prose as code (`unexpected identifier` at L33, `invalid 'import'` at L55).
Fixed to `build-and-Aristotle-gated` (2 sites).

### Defect 2 — the "PROVED" d=1 case did not compile (Mathlib v4.26.0 drift)
All masked by defect 1. `exists_slice_point_lt_two_mul_d1`:
- `Finset.card_product` rw → `simp [hbox, Finset.card_range]`
- pigeonhole `maps_to` goal is **Set** membership `∈ ↑(Finset.range p)` (coe), not
  Finset → `Finset.mem_range` never fired; fixed with `simp [Finset.coe_range,
  Set.mem_Iio]` + `show … .toNat < p` (forces the beta-reduction `omega` needs)
- `Finset.card_insert_of_not_mem` → `Finset.card_pair`
- `Finset.card_sdiff` is now **unconditional** (`(s\t).card = s.card - (t∩s).card`,
  no subset arg) → use it + `Finset.inter_eq_left.mpr`
- `set_option maxHeartbeats 800000`

## Verification

`./proofs/scripts/docker-build.sh Proofs.ThreeSquaresSliceMinkowski` →
**`Build completed successfully (7743 jobs)`, exit 0**, with exactly **one** `sorry`:
the documented d=2 Minkowski core `exists_sheared_point_lt_two_mul_d2` (L271). The
d=1 case, the arithmetic glue `slice_point_of_sheared_d2`, the bridge, and the
assembly lemmas are now all genuinely kernel-verified.

## Scope / safety

File stays **UNregistered** in `Proofs.lean` (it carries the one open sorry), so
this does not gate the deployer build. This change **unblocks** integration of the
Aristotle proof of the d=2 core (job `8feb596c`, submitted by researcher-2): once
that lands, the proof can be pasted over the sorry and the file built green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)