### PR TITLE
audit(binary-gcd-oq-03-oq-02): sync meta to 0-sorry state after PR #26158

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13964,12 +13964,10 @@
       "result": "clean"
     },
     "binary-gcd-oq-03-oq-02": {
-      "auditCount": 2,
-      "issues": [
-        "missing top-level sorries field; lineCount stale 936->1020"
-      ],
-      "lastAudited": "2026-06-05T23:01:35Z",
-      "result": "clean"
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-06-19T11:40:26Z",
+      "result": "issues-fixed"
     },
     "brouwer-fixed-point-oq-01-oq-02-oq-03": {
       "auditCount": 2,
@@ -16062,5 +16060,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-19T00:00:00Z"
+  "lastUpdated": "2026-06-19T11:40:26Z"
 }

--- a/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
@@ -2,13 +2,13 @@
   "id": "binary-gcd-oq-03-oq-02",
   "title": "Schönhage's Recursive HGCD: GCD Preservation and Matrix Invariants",
   "slug": "binary-gcd-oq-03-oq-02",
-  "description": "Formalizes Schönhage's recursive half-GCD (HGCD) in Lean 4, extending the Lehmer hybrid (BinaryGcdOQ03) with the full recursive structure. Proves GCD preservation, the determinant invariant, the matrix-vector row convention, entry bounds via Cramer's rule, and perturbation infrastructure toward size reduction. One sorry remains in the original file for the recursive row-output size bound (S17 PR #17024 found this is FALSE for the unguarded algorithm). Companion file BinaryGcdOQ03OQ02PathA.lean (S18+S19) implements Path A — algorithm refinement with a runtime size-reduction safety guard, plus a verified GCD function hgcdSafeGcd with theorem hgcdSafeGcd_eq_gcd a b = Nat.gcd a b (0 sorries, 0 axioms).",
-  "sorries": 1,
+  "description": "Formalizes Schönhage's recursive half-GCD (HGCD) in Lean 4, extending the Lehmer hybrid (BinaryGcdOQ03) with the full recursive structure. Proves GCD preservation, the determinant invariant, the matrix-vector row convention, entry bounds via Cramer's rule, and perturbation infrastructure toward size reduction. The previously-open row-output size bound (S17 PR #17024 found the unconditional version is FALSE for the unguarded algorithm) has been retired (PR #26158): hgcdMatrix_row_output_le is now stated and proved in its true non-recursive regime (max a b < hgcdThreshold), and the recursive-case failure at (5, 130, 89) is recorded as decide/native_decide refutation theorems. The original file is now 0-sorry. Companion file BinaryGcdOQ03OQ02PathA.lean (S18+S19) implements Path A — algorithm refinement with a runtime size-reduction safety guard, plus a verified GCD function hgcdSafeGcd with theorem hgcdSafeGcd_eq_gcd a b = Nat.gcd a b (0 sorries, 0 literal axioms).",
+  "sorries": 0,
   "meta": {
     "author": "Schönhage (1971), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Half-GCD_algorithm",
     "date": "1971",
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "algorithms",
       "number-theory",
@@ -18,13 +18,13 @@
       "matrices"
     ],
     "proofRepoPath": "Proofs/BinaryGcdOQ03OQ02.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "axiom",
+    "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 2225,
+    "lineCount": 2277,
     "dateAdded": "2026-05-03",
-    "theoremCount": 65,
-    "assumptions": "Depends on the `Lean.ofReduceBool` axiom: several credited theorems are discharged by `native_decide`, including hgcdShift_pos, the S17 counterexample family (hgcdMatrix_130_89_value, hgcdMatrix_130_89_row_alpha, hgcdMatrix_130_89_row_beta, hgcdMatrix_row_alpha_exceeds_max, hgcdMatrix_row_beta_negative) in BinaryGcdOQ03OQ02.lean and surveyRange_length (S24) in the companion BinaryGcdOQ03OQ02PathA.lean. `native_decide` relies on Lean compiler kernel reduction (`Lean.ofReduceBool`), so these results are not axiom-free. Hence axiomCount = 1; leanFile.axiomCount remains 0 since there are no literal `axiom` declarations. (One sorry remains in the recursive row-output size bound; see status `formalized`.)",
+    "theoremCount": 68,
+    "assumptions": "Depends on the `Lean.ofReduceBool` axiom: several credited theorems are discharged by `native_decide`, including hgcdShift_pos, the S17 counterexample family (hgcdMatrix_130_89_value, hgcdMatrix_130_89_row_alpha, hgcdMatrix_130_89_row_beta, hgcdMatrix_row_alpha_exceeds_max, hgcdMatrix_row_beta_negative, and the column-convention refutation hgcdMatrix_130_89_apply / hgcdMatrix_col_snd_exceeds_max) in BinaryGcdOQ03OQ02.lean and surveyRange_length (S24) in the companion BinaryGcdOQ03OQ02PathA.lean. `native_decide` relies on Lean compiler kernel reduction (`Lean.ofReduceBool`), so these results are not axiom-free. Hence axiomCount = 1; leanFile.axiomCount remains 0 since there are no literal `axiom` declarations. The original file is now 0-sorry (PR #26158 retired the false unconditional row-output bound by restricting `hgcdMatrix_row_output_le` to its true non-recursive regime); status is `axiomatized` solely on account of the `Lean.ofReduceBool` (native_decide) dependency.",
     "mathlibDependencies": [
       {
         "theorem": "Nat.log_mono_right",
@@ -81,13 +81,13 @@
   "overview": {
     "historicalContext": "Arnold Schönhage (1971) extended Lehmer's hybrid GCD to achieve optimal O(M(n)·log n) bit complexity, where M(n) is the cost of multiplying n-bit integers. The key innovation is recursion: instead of running Lehmer's single-level approximation once, HGCD recurses on the top half of the bits to compute a cofactor matrix M₁, applies M₁ to the full inputs to get a half-size pair, then recurses again. This two-level recursion gives O(log n) levels, each costing O(M(n)), for total O(M(n)·log n). The algorithm underlies GMP's mpn_hgcd implementation and is the standard GCD algorithm for cryptographic-size integers (thousands of bits).",
     "problemStatement": "Can Schönhage's recursive HGCD (half-GCD) be formalized in Lean 4, establishing the GCD-preservation correctness proof and making progress toward the O(M(n)·log n) bit complexity bound?",
-    "proofStrategy": "The formalization is structured in nine parts. Parts I–IV establish the core correctness: the composition law for cofactor matrices, the fuel-indexed recursive definition of hgcdMatrix, the determinant invariant (proved by induction on fuel), and GCD preservation (a corollary via gcd_cofactor_eq from BinaryGcdOQ03). Parts V–VI build the size-reduction infrastructure: the row-convention matrix-vector invariant for Lehmer cofactors, residue monotonicity, the Cramer identity, and entry bounds via the alternating sign pattern (EvenPattern/OddPattern). Part VII adds the perturbation decomposition (apply distributes over shifts). Part VIII proves the induction prerequisites (shift ≥ 1, top-half strictly smaller). Part IX states the remaining size-reduction bound with one sorry for the recursive case, which requires a quotient stability lemma connecting top-half quotients to full-precision Euclidean quotients.",
+    "proofStrategy": "The formalization is structured in nine parts. Parts I–IV establish the core correctness: the composition law for cofactor matrices, the fuel-indexed recursive definition of hgcdMatrix, the determinant invariant (proved by induction on fuel), and GCD preservation (a corollary via gcd_cofactor_eq from BinaryGcdOQ03). Parts V–VI build the size-reduction infrastructure: the row-convention matrix-vector invariant for Lehmer cofactors, residue monotonicity, the Cramer identity, and entry bounds via the alternating sign pattern (EvenPattern/OddPattern). Part VII adds the perturbation decomposition (apply distributes over shifts). Part VIII proves the induction prerequisites (shift ≥ 1, top-half strictly smaller). Part IX proves the row-output size-reduction bound in its true non-recursive regime (max a b < hgcdThreshold) and records the recursive-case counterexample; the unconditional recursive bound is FALSE for the unguarded algorithm, so the file is now 0-sorry. A genuinely recursive bound would require a quotient stability lemma (under a well-behaved-input precondition) connecting top-half quotients to full-precision Euclidean quotients.",
     "keyInsights": [
       "Fuel-indexed totality decouples correctness from termination: hgcdMatrix is total by construction and GCD preservation holds for all fuel values, independently of whether the fuel is sufficient for the algorithm to run to completion.",
       "The convention dichotomy is a genuine obstruction: the apply action (column convention M·(a,b)ᵀ) tracks a different intermediate state from the row convention (a,b)·M. GCD preservation uses the column convention; size reduction requires the row convention. These agree on determinant-based theorems but diverge on state tracking.",
       "The composition law cofactor_mul_apply is the algebraic key: it states that M.mul N applied columnwise is M applied to N's output. This chains the two HGCD recursive calls into a single correct reduction.",
       "Entry bounds arise from Cramer inversion: if (a₀,b₀)·M = (ahat,bhat), then by unimodularity, each entry of M is a linear combination of ahat and bhat with coefficients ±1. With the alternating sign pattern from lehmerInnerStep, all entries are bounded by max(a₀,b₀).",
-      "The remaining sorry (recursive size-reduction) requires quotient stability: showing that the Euclidean quotients computed from the top-half approximation (a/2^s, b/2^s) match those from the full-precision (a,b) for the relevant number of steps. This is proved in Stehlé–Zimmermann (2004) but requires ≈200 lines of new Lean infrastructure."
+      "The recursive size-reduction bound is FALSE as an unconditional statement (counterexample (5, 130, 89)); a conditional version requires quotient stability under a well-behaved-input precondition: showing that the Euclidean quotients computed from the top-half approximation (a/2^s, b/2^s) match those from the full-precision (a,b) for the relevant number of steps. This is proved in Stehlé–Zimmermann (2004) but requires ≈200 lines of new Lean infrastructure."
     ]
   },
   "sections": [
@@ -189,10 +189,10 @@
     },
     {
       "id": "part-ix-row-output-bound",
-      "title": "Part IX: Row Output Bound (corrected Step 4) — contains the remaining sorry",
+      "title": "Part IX: Row Output Bound (corrected Step 4) — row bound in the true non-recursive regime",
       "startLine": 976,
       "endLine": 1079,
-      "summary": "The column-convention bound hgcdMatrix_joint_bound is FALSE as previously stated (counterexample (a,b)=(37,5): column output natAbs 184 > 64, by native_decide). Proves the base case hgcdMatrix_small_row_output_le (for max a b < hgcdThreshold the row output is ≤ max a b). The remaining file sorry hgcdMatrix_row_output_le (line 1078, recursive case) lives here — now known unprovable as stated (see Part XIV).",
+      "summary": "The column-convention bound hgcdMatrix_joint_bound is FALSE as previously stated (counterexample (a,b)=(37,5): column output natAbs 184 > 64, by native_decide). Proves the base case hgcdMatrix_small_row_output_le (for max a b < hgcdThreshold the row output is ≤ max a b) and the row-output bound hgcdMatrix_row_output_le restricted to the true non-recursive regime (max a b < hgcdThreshold). The unconditional recursive version is FALSE (see Part XIV counterexample); PR #26158 retired the former sorry by adding the threshold hypothesis, so this part is now sorry-free.",
       "mathContext": "The column convention M.apply(a,b) does not bound Euclidean residues for a right-accumulated Lehmer matrix; the row convention is the correct target, but its all-fuel recursive case is false (Part XIV)."
     },
     {
@@ -237,10 +237,10 @@
     },
     {
       "id": "summary-status",
-      "title": "Summary: Proved Results and Status of the Remaining Sorry",
+      "title": "Summary: Proved Results and Status of the Row-Output Bound",
       "startLine": 1958,
       "endLine": 2225,
-      "summary": "Closing Summary docstring enumerating the proved result-groups (0 axioms): composition, determinant, gcd preservation, Lehmer row-vector invariant + monotonicity, Cramer + sign pattern + entry bounds, perturbation/row-decomposition/row-output infrastructure, shift bounds, sign-pattern and pattern-det invariants for all fuel, and the Part XIV counterexample. Documents the single remaining sorry hgcdMatrix_row_output_le (Part IX, known unprovable as stated; paths A/B/C forward) and the out-of-scope O(M(n)·log n) bit-complexity bound (needs Mathlib fast-multiplication infrastructure).",
+      "summary": "Closing Summary docstring enumerating the proved result-groups (0 axioms): composition, determinant, gcd preservation, Lehmer row-vector invariant + monotonicity, Cramer + sign pattern + entry bounds, perturbation/row-decomposition/row-output infrastructure, shift bounds, sign-pattern and pattern-det invariants for all fuel, and the Part XIV counterexample. Documents that the unconditional recursive hgcdMatrix_row_output_le is FALSE (Part IX now proves only the true non-recursive regime; paths A/B/C forward) and the out-of-scope O(M(n)·log n) bit-complexity bound (needs Mathlib fast-multiplication infrastructure).",
       "mathContext": "Status snapshot: the matrix-algebra layer (determinant, gcd preservation, patterns, entry bounds) is fully proved; the one unmet goal is the recursive row-output size-reduction bound, refuted as stated, requiring an algorithm or statement refinement."
     }
   ],
@@ -269,21 +269,21 @@
   ],
   "leanFile": {
     "namespace": "HGcd",
-    "lineCount": 2225,
+    "lineCount": 2277,
     "axiomCount": 0,
-    "theoremCount": 64,
+    "theoremCount": 67,
     "definitionCount": 6,
     "path": "Proofs/BinaryGcdOQ03OQ02.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/BinaryGcdOQ03OQ02PathA.lean"
     ]
   },
   "conclusion": {
-    "summary": "This formalization of Schönhage's recursive HGCD establishes the core correctness layer in 936 lines with a single sorry. The three main theorems — `cofactor_mul_apply` (compositional algebra), `hgcdMatrix_det_unit` (unimodularity by fuel induction), and `hgcdMatrix_preserves_gcd` (operational correctness) — formally verify that Schönhage's two-level recursion produces a GCD-preserving matrix. The size-reduction infrastructure (row-convention invariant, Cramer identity, entry bounds, perturbation decomposition) is complete except for the quotient stability lemma needed for the recursive size bound. Together with `BinaryGcdOQ03` (the Lehmer hybrid), this represents the first Lean formalization of the HGCD algorithm's correctness structure.",
-    "implications": "Schönhage's HGCD is the inner loop of every modern number theory computation involving large integers: RSA key generation, elliptic curve scalar multiplication, polynomial GCD in computer algebra systems, and lattice basis reduction (LLL algorithm). Formalizing its correctness in Lean 4 provides a verified foundation for future cryptographic algorithm verification. The quotient stability sorry (≈200 lines remaining) is the only gap between this formalization and a complete proof of size reduction — once closed, the file would establish the full recursive structure needed to state the $O(M(n)\\log n)$ complexity claim. The GMP library's `mpn_hgcd` implements exactly this algorithm for production GCD computation; a Lean verification would enable formal auditing of such production code.",
+    "summary": "This formalization of Schönhage's recursive HGCD establishes the core correctness layer, now 0-sorry. The three main theorems — `cofactor_mul_apply` (compositional algebra), `hgcdMatrix_det_unit` (unimodularity by fuel induction), and `hgcdMatrix_preserves_gcd` (operational correctness) — formally verify that Schönhage's two-level recursion produces a GCD-preserving matrix. The size-reduction infrastructure (row-convention invariant, Cramer identity, entry bounds, perturbation decomposition) is fully discharged in its true regime: the row-output bound `hgcdMatrix_row_output_le` holds for the non-recursive case (`max a b < hgcdThreshold`), and the (5, 130, 89) counterexample family records — via decide/native_decide — that the unconditional recursive version is FALSE for the unguarded algorithm. Together with `BinaryGcdOQ03` (the Lehmer hybrid), this represents the first Lean formalization of the HGCD algorithm's correctness structure.",
+    "implications": "Schönhage's HGCD is the inner loop of every modern number theory computation involving large integers: RSA key generation, elliptic curve scalar multiplication, polynomial GCD in computer algebra systems, and lattice basis reduction (LLL algorithm). Formalizing its correctness in Lean 4 provides a verified foundation for future cryptographic algorithm verification. The unconditional recursive size-reduction bound was shown FALSE for the unguarded algorithm (S17 counterexample); the companion Path A file `BinaryGcdOQ03OQ02PathA.lean` instead adds a runtime size-reduction safety guard and verifies a total correct GCD function `hgcdSafeGcd` (theorem `hgcdSafeGcd_eq_gcd`). Stating the full $O(M(n)\\log n)$ bit-complexity claim still requires the Stehlé–Zimmermann quotient-stability analysis under a well-behaved-input precondition. The GMP library's `mpn_hgcd` implements exactly this algorithm for production GCD computation; a Lean verification would enable formal auditing of such production code.",
     "openQuestions": [
-      "Can the quotient stability lemma (Stehlé–Zimmermann §3–4) be formalized in ≈200 lines to close the sorry in `hgcdMatrix_joint_bound`? The key is Theorem 4 of Stehlé–Zimmermann 2004: 'if $2^s > 4\\max(a,b)/\\gcd(a,b)$, the first $k$ Euclidean quotients of $(a_H, b_H)$ and $(a,b)$ agree.' Lean infrastructure needed: remainder sequence properties, divisibility bounds for continued fraction convergents.",
+      "Can the quotient stability lemma (Stehlé–Zimmermann §3–4) be formalized in ≈200 lines to establish a recursive size-reduction bound under a well-behaved-input precondition (the unconditional bound is FALSE, see the (5, 130, 89) counterexample)? The key is Theorem 4 of Stehlé–Zimmermann 2004: 'if $2^s > 4\\max(a,b)/\\gcd(a,b)$, the first $k$ Euclidean quotients of $(a_H, b_H)$ and $(a,b)$ agree.' Lean infrastructure needed: remainder sequence properties, divisibility bounds for continued fraction convergents.",
       "Once Mathlib includes a formal model of fast multiplication (FFT-based or Karatsuba), can the $O(M(n)\\log n)$ bit-complexity bound be formally stated and proved? This would require defining 'arithmetic circuit complexity' or a comparable cost model in Lean 4, connecting `hgcdMatrix_joint_bound` to a recursion tree analysis.",
       "Can the verified GCD algorithm be connected to applications? E.g., a formally verified RSA key generation procedure that relies on `hgcdMatrixOf_preserves_gcd` for its correctness guarantee."
     ]


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `binary-gcd-oq-03-oq-02` (Schönhage's Recursive HGCD)
**Detected by**: gallery integrity audit (`find-targets.ts --issues` flagged `sorry mismatch: claims 1, actual 0`)

### Problem

Merged PR #26158 retired the file's only `sorry` by restricting `hgcdMatrix_row_output_le` to its **true non-recursive regime** (`max a b < hgcdThreshold`) and recording the recursive-case failure at `(5, 130, 89)` as decide/`native_decide` refutation theorems. The original `BinaryGcdOQ03OQ02.lean` is now **0-sorry** (every `sorry` token left in the file is inside a docstring).

`meta.json` was not updated to match — it still claimed `sorries: 1`, `status: "formalized"`, `badge: "wip"`, and described "one sorry remains" throughout.

### Evidence

| Field | meta.json claimed | Lean source |
|-------|-------------------|-------------|
| code sorries | 1 | **0** (all `sorry` tokens are in comments/docstrings) |
| lineCount | 2225 | 2277 |
| theoremCount (leanFile) | 64 | 67 (+3 refutation theorems from #26158) |

### Fix (no mathematical change)

- `sorries` 1 → 0 (top-level, `meta`, `leanFile`)
- `status` `formalized` → `axiomatized`, `badge` `wip` → `axiom`
  - The file remains **not** `verified`: `native_decide` discharges the substantive S17 counterexample family, so it depends on `Lean.ofReduceBool`. `axiomCount` correctly stays **1** (no literal `axiom` declarations; `leanFile.axiomCount` stays 0).
- `lineCount` 2225 → 2277; `theoremCount` 65 → 68 (meta) / 64 → 67 (leanFile)
- Rewrote `description` / `proofStrategy` / `keyInsight` / `conclusion` / `openQuestions` / Part IX section to state the sorry was **retired** and the unconditional recursive bound is **FALSE** — replacing the "remaining sorry" framing
- Tracker: `auditCount` 2 → 3, `result` `issues-fixed`, cleared stale issue note

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)