### PR TITLE
research(cauchy-schwarz-oq-02-oq-03): verified Complex Polarization Identity

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -443,6 +443,7 @@ import Proofs.CauchySchwarzOQ01OQ04
 import Proofs.CauchySchwarzOQ02
 import Proofs.CauchySchwarzOQ02OQ01
 import Proofs.CauchySchwarzOQ02OQ02
+import Proofs.CauchySchwarzOQ02OQ03
 import Proofs.CauchySchwarzOQ03
 import Proofs.CauchySchwarzOQ03OQ01
 import Proofs.CauchySchwarzOQ03OQ02

--- a/proofs/Proofs/CauchySchwarzOQ02OQ03.lean
+++ b/proofs/Proofs/CauchySchwarzOQ02OQ03.lean
@@ -1,0 +1,114 @@
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.RCLike.Basic
+import Mathlib.Tactic
+
+/-
+# Complex Polarization Identity
+
+## What This Proves
+On any complex inner product space the inner product is completely determined by
+the norm via the **complex polarization identity**:
+
+  ⟪f, g⟫ = (‖f + g‖² - ‖f - g‖² + i‖f - i·g‖² - i‖f + i·g‖²) / 4
+
+This is the ℂ-companion to the real polarization identity
+`⟪f, g⟫_ℝ = (‖f + g‖² - ‖f - g‖²)/4` already in the gallery
+(`CauchySchwarzOQ02.lean`, `polarization_identity`). The real identity only
+recovers a *symmetric* bilinear form; over ℂ the inner product is *sesquilinear*,
+so two extra norm evaluations (at `f ± i·g`) are needed to recover the imaginary
+part. Together the real and complex versions show that on every (real or complex)
+Hilbert space **the norm determines the inner product**.
+
+## Convention
+Mathlib's `inner` is conjugate-linear in the first argument and linear in the
+second, with `RCLike.I` denoting the abstract imaginary unit (`= Complex.I` for
+`𝕜 = ℂ`). All statements below follow that convention; the sign of the imaginary
+terms is fixed by it.
+
+## Status
+- [x] Complex polarization identity over `RCLike 𝕜` (headline, wraps Mathlib)
+- [x] Specialization to `𝕜 = ℂ` with `Complex.I`
+- [x] Real part of the inner product from norms
+- [x] Imaginary part of the inner product from norms
+- [x] Complex parallelogram law
+- [x] Norm determines the inner product (uniqueness corollary)
+
+## References
+- Mathlib `inner_eq_sum_norm_sq_div_four` (Analysis.InnerProductSpace.Basic)
+- Jordan–von Neumann (1935): the parallelogram law characterises inner product
+  spaces among normed spaces; polarization then reconstructs the product.
+-/
+
+noncomputable section
+
+open RCLike
+
+namespace ComplexPolarization
+
+variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+/-- **Complex polarization identity** (general `RCLike` field).
+
+The inner product is recovered from four squared norms:
+`⟪f, g⟫ = (‖f+g‖² - ‖f-g‖² + (‖f - i·g‖² - ‖f + i·g‖²)·i) / 4`.
+This is a typed wrapper of Mathlib's `inner_eq_sum_norm_sq_div_four`. -/
+theorem polarization_identity_complex (f g : E) :
+    inner 𝕜 f g =
+      ((‖f + g‖ : 𝕜) ^ 2 - (‖f - g‖ : 𝕜) ^ 2 +
+        ((‖f - (RCLike.I : 𝕜) • g‖ : 𝕜) ^ 2 - (‖f + (RCLike.I : 𝕜) • g‖ : 𝕜) ^ 2)
+          * (RCLike.I : 𝕜)) / 4 :=
+  inner_eq_sum_norm_sq_div_four f g
+
+/-- **Real part** of the inner product from the norm:
+`re ⟪f, g⟫ = (‖f+g‖² - ‖f-g‖²)/4`. Matches the real polarization identity. -/
+theorem re_inner_eq_norm_polarization (f g : E) :
+    RCLike.re (inner 𝕜 f g) = (‖f + g‖ ^ 2 - ‖f - g‖ ^ 2) / 4 := by
+  simp only [pow_two]
+  exact re_inner_eq_norm_add_mul_self_sub_norm_sub_mul_self_div_four f g
+
+/-- **Imaginary part** of the inner product from the norm:
+`im ⟪f, g⟫ = (‖f - i·g‖² - ‖f + i·g‖²)/4`. -/
+theorem im_inner_eq_norm_polarization (f g : E) :
+    RCLike.im (inner 𝕜 f g) =
+      (‖f - (RCLike.I : 𝕜) • g‖ ^ 2 - ‖f + (RCLike.I : 𝕜) • g‖ ^ 2) / 4 := by
+  simp only [pow_two]
+  exact im_inner_eq_norm_sub_i_smul_mul_self_sub_norm_add_i_smul_mul_self_div_four f g
+
+include 𝕜 in
+/-- **Complex parallelogram law**: `‖f+g‖² + ‖f-g‖² = 2‖f‖² + 2‖g‖²`.
+The norm of an inner product space satisfies the parallelogram law over any field. -/
+theorem parallelogram_law_complex (f g : E) :
+    ‖f + g‖ ^ 2 + ‖f - g‖ ^ 2 = 2 * ‖f‖ ^ 2 + 2 * ‖g‖ ^ 2 := by
+  have h := parallelogram_law_with_norm 𝕜 f g
+  simp only [pow_two]
+  linarith [h]
+
+/-- **Uniqueness corollary**: the inner product is completely determined by the
+norm. If `f₁, g₁` and `f₂, g₂` are pairwise equinormed in the four polarization
+arguments, their inner products coincide. In particular the norm fixes `⟪f, g⟫`. -/
+theorem inner_eq_of_norm_eq {f₁ g₁ f₂ g₂ : E}
+    (h₁ : ‖f₁ + g₁‖ = ‖f₂ + g₂‖) (h₂ : ‖f₁ - g₁‖ = ‖f₂ - g₂‖)
+    (h₃ : ‖f₁ - (RCLike.I : 𝕜) • g₁‖ = ‖f₂ - (RCLike.I : 𝕜) • g₂‖)
+    (h₄ : ‖f₁ + (RCLike.I : 𝕜) • g₁‖ = ‖f₂ + (RCLike.I : 𝕜) • g₂‖) :
+    inner 𝕜 f₁ g₁ = inner 𝕜 f₂ g₂ := by
+  rw [polarization_identity_complex, polarization_identity_complex,
+    h₁, h₂, h₃, h₄]
+
+end ComplexPolarization
+
+namespace ComplexPolarization
+
+/-- **Complex polarization identity over ℂ**, stated with `Complex.I`.
+
+`⟪f, g⟫ = (‖f+g‖² - ‖f-g‖² + (‖f - i·g‖² - ‖f + i·g‖²)·i) / 4`,
+the concrete `𝕜 = ℂ` instance of `polarization_identity_complex`
+(`Complex.I = RCLike.I` for the ℂ field). -/
+theorem polarization_identity_C {E : Type*} [NormedAddCommGroup E]
+    [InnerProductSpace ℂ E] (f g : E) :
+    inner ℂ f g =
+      ((‖f + g‖ : ℂ) ^ 2 - (‖f - g‖ : ℂ) ^ 2 +
+        ((‖f - Complex.I • g‖ : ℂ) ^ 2 - (‖f + Complex.I • g‖ : ℂ) ^ 2)
+          * Complex.I) / 4 :=
+  inner_eq_sum_norm_sq_div_four f g
+
+end ComplexPolarization

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-03/annotations.json
@@ -1,0 +1,123 @@
+[
+  {
+    "id": "csq0203-ann-01",
+    "proofId": "cauchy-schwarz-oq-02-oq-03",
+    "range": {
+      "startLine": 50,
+      "endLine": 60
+    },
+    "type": "concept",
+    "title": "Complex Polarization Identity: Four Norms Recover a Sesquilinear Form",
+    "content": "`polarization_identity_complex` is the headline result: on any inner product space over an RCLike field 𝕜, ⟨f,g⟩ = (‖f+g‖² - ‖f-g‖² + (‖f-i·g‖² - ‖f+i·g‖²)·i)/4. The real polarization identity in the OQ-02 parent uses only two norm evaluations (‖f+g‖, ‖f-g‖) because it recovers a *symmetric* bilinear form. A complex inner product is *sesquilinear* — conjugate-linear in the first argument, linear in the second — so its imaginary part is invisible to those two norms. Evaluating at f ± i·g supplies the missing two values. The proof is a typed one-line application of Mathlib's `inner_eq_sum_norm_sq_div_four`, with i = RCLike.I the abstract imaginary unit that specializes to Complex.I over ℂ and to 0 over ℝ (collapsing the formula back to the real identity).",
+    "mathContext": "$\\langle f,g\\rangle = \\frac{\\|f+g\\|^2 - \\|f-g\\|^2 + \\left(\\|f-ig\\|^2 - \\|f+ig\\|^2\\right) i}{4}$, with $i = \\mathrm{RCLike.I}$. Over $\\mathbb{R}$, $i = 0$ and the bracketed term vanishes, recovering $\\langle f,g\\rangle_\\mathbb{R} = \\frac{\\|f+g\\|^2 - \\|f-g\\|^2}{4}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sesquilinear form",
+      "RCLike field abstraction",
+      "real polarization identity",
+      "inner product from norm"
+    ],
+    "prerequisites": [
+      "complex inner product spaces",
+      "sesquilinearity vs bilinearity",
+      "RCLike.I abstract imaginary unit",
+      "norm induced by an inner product"
+    ]
+  },
+  {
+    "id": "csq0203-ann-02",
+    "proofId": "cauchy-schwarz-oq-02-oq-03",
+    "range": {
+      "startLine": 62,
+      "endLine": 75
+    },
+    "type": "insight",
+    "title": "Real and Imaginary Parts Split the Identity",
+    "content": "`re_inner_eq_norm_polarization` and `im_inner_eq_norm_polarization` decompose the headline identity into its two RCLike components: Re⟨f,g⟩ = (‖f+g‖² - ‖f-g‖²)/4 and Im⟨f,g⟩ = (‖f-i·g‖² - ‖f+i·g‖²)/4. The first is *exactly* the real polarization identity — confirming that the complex identity contains the real one as its real part, and that the f ± i·g evaluations carry all and only the imaginary information. Each wraps the corresponding Mathlib re/im polarization lemma after a `pow_two` rewrite that converts Mathlib's ‖·‖·‖·‖ products to the ‖·‖² notation used in the headline. The reassembly ⟨f,g⟩ = Re⟨f,g⟩ + i·Im⟨f,g⟩ is what `inner_eq_sum_norm_sq_div_four` packages.",
+    "mathContext": "$\\operatorname{Re}\\langle f,g\\rangle = \\frac{\\|f+g\\|^2 - \\|f-g\\|^2}{4}$, $\\quad \\operatorname{Im}\\langle f,g\\rangle = \\frac{\\|f-ig\\|^2 - \\|f+ig\\|^2}{4}$. Then $\\langle f,g\\rangle = \\operatorname{Re}\\langle f,g\\rangle + i\\operatorname{Im}\\langle f,g\\rangle$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "real part of inner product",
+      "imaginary part of inner product",
+      "RCLike.re / RCLike.im",
+      "pow_two normalization"
+    ],
+    "prerequisites": [
+      "RCLike.re and RCLike.im projections",
+      "real polarization identity",
+      "squared-norm notation"
+    ]
+  },
+  {
+    "id": "csq0203-ann-03",
+    "proofId": "cauchy-schwarz-oq-02-oq-03",
+    "range": {
+      "startLine": 77,
+      "endLine": 85
+    },
+    "type": "concept",
+    "title": "Parallelogram Law: The Norm-Side Companion",
+    "content": "`parallelogram_law_complex` states ‖f+g‖² + ‖f-g‖² = 2‖f‖² + 2‖g‖² for complex inner product spaces, restating Mathlib's `parallelogram_law_with_norm` in ‖·‖² form. Polarization and the parallelogram law are the two halves of the Jordan–von Neumann dictionary: the parallelogram law detects *whether* a norm comes from an inner product, and polarization *reconstructs* that product when it does. Note the `include 𝕜` directive — the statement mentions only norms (which live on the additive group E), so Lean's automatic variable binding would otherwise drop the field 𝕜 and the `InnerProductSpace 𝕜 E` instance needed to invoke the Mathlib lemma.",
+    "mathContext": "$\\|f+g\\|^2 + \\|f-g\\|^2 = 2\\|f\\|^2 + 2\\|g\\|^2$. Jordan–von Neumann (1935): a normed space is an inner product space $\\iff$ its norm satisfies this identity.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Jordan-von Neumann theorem",
+      "parallelogram law",
+      "Banach space characterization",
+      "Lean variable inclusion"
+    ],
+    "prerequisites": [
+      "parallelogram_law_with_norm",
+      "norm of an inner product space",
+      "Lean autobound / include directive"
+    ]
+  },
+  {
+    "id": "csq0203-ann-04",
+    "proofId": "cauchy-schwarz-oq-02-oq-03",
+    "range": {
+      "startLine": 86,
+      "endLine": 94
+    },
+    "type": "insight",
+    "title": "Uniqueness: The Norm Completely Determines the Inner Product",
+    "content": "`inner_eq_of_norm_eq` is the conceptual payoff of polarization: if two vector pairs (f₁,g₁) and (f₂,g₂) are equinormed in all four polarization arguments (f+g, f-g, f-i·g, f+i·g), their inner products are equal. The proof rewrites both inner products through the headline identity and substitutes the four norm equalities — the inner product is a *function of the norm*, nothing more. Operationally this is the engine behind isometry-rigidity theorems: any surjective norm-preserving map fixing 0 must preserve the inner product, hence (over ℝ) be linear (Mazur–Ulam). It is also why two distinct inner products can never induce the same norm.",
+    "mathContext": "If $\\|f_1+g_1\\| = \\|f_2+g_2\\|$, $\\|f_1-g_1\\| = \\|f_2-g_2\\|$, $\\|f_1 - i g_1\\| = \\|f_2 - i g_2\\|$, and $\\|f_1 + i g_1\\| = \\|f_2 + i g_2\\|$, then $\\langle f_1,g_1\\rangle = \\langle f_2,g_2\\rangle$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "uniqueness of inner product",
+      "Mazur-Ulam theorem",
+      "isometry rigidity",
+      "norm determines geometry"
+    ],
+    "prerequisites": [
+      "complex polarization identity",
+      "rewriting under equalities",
+      "isometries and norm preservation"
+    ]
+  },
+  {
+    "id": "csq0203-ann-05",
+    "proofId": "cauchy-schwarz-oq-02-oq-03",
+    "range": {
+      "startLine": 99,
+      "endLine": 114
+    },
+    "type": "concept",
+    "title": "Concrete ℂ Instance with Complex.I",
+    "content": "`polarization_identity_C` specializes the RCLike-generic headline to the field 𝕜 = ℂ, stating the identity with the concrete `Complex.I` in place of the abstract `RCLike.I`. The wrapper compiles by a single application of `inner_eq_sum_norm_sq_div_four` because `Complex.I = RCLike.I` *definitionally* for the ℂ instance (the RCLike structure on ℂ defines its imaginary unit as `Complex.I`). This gives gallery readers the literal complex-Hilbert-space statement matching the problem as posed, while the generic version remains available for ℝ/ℂ-uniform developments.",
+    "mathContext": "For a complex inner product space $E$: $\\langle f,g\\rangle = \\frac{\\|f+g\\|^2 - \\|f-g\\|^2 + \\left(\\|f - \\mathrm{i}\\,g\\|^2 - \\|f + \\mathrm{i}\\,g\\|^2\\right)\\mathrm{i}}{4}$ with $\\mathrm{i} = $ `Complex.I`.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Complex.I vs RCLike.I",
+      "definitional equality",
+      "field specialization",
+      "complex Hilbert space"
+    ],
+    "prerequisites": [
+      "RCLike instance on ℂ",
+      "definitional equality in Lean",
+      "complex inner product spaces"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-03/meta.json
@@ -1,0 +1,153 @@
+{
+  "id": "cauchy-schwarz-oq-02-oq-03",
+  "title": "Complex Polarization Identity",
+  "slug": "cauchy-schwarz-oq-02-oq-03",
+  "description": "Formalizes the complex polarization identity: on any complex inner product space the inner product is determined by the norm via ⟨f,g⟩ = (‖f+g‖² - ‖f-g‖² + (‖f-i·g‖² - ‖f+i·g‖²)·i)/4. This is the ℂ-companion to the real polarization identity in the OQ-02 parent — over ℂ the inner product is sesquilinear, so two extra norm evaluations at f ± i·g recover the imaginary part. Includes the real/imaginary part decompositions, the complex parallelogram law, and a uniqueness corollary (the norm fixes the inner product). 6 theorems, 0 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ02OQ03.lean",
+    "tags": [
+      "analysis",
+      "cauchy-schwarz",
+      "polarization",
+      "complex-hilbert-space",
+      "inner-product-space"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified. The headline identity is a typed wrapper of Mathlib's inner_eq_sum_norm_sq_div_four; the supporting results wrap Mathlib's re/im polarization lemmas and parallelogram_law_with_norm.",
+    "lineCount": 114,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "inner_eq_sum_norm_sq_div_four",
+        "description": "Polarization identity over RCLike 𝕜: ⟪x,y⟫ = (‖x+y‖² - ‖x-y‖² + (‖x - i·y‖² - ‖x + i·y‖²)·i)/4, with i = RCLike.I. Specializes to both ℝ and ℂ. The headline theorem polarization_identity_complex and its ℂ instance polarization_identity_C are typed wrappers of this lemma.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "re_inner_eq_norm_add_mul_self_sub_norm_sub_mul_self_div_four / im_inner_eq_norm_sub_i_smul_mul_self_sub_norm_add_i_smul_mul_self_div_four",
+        "description": "Real and imaginary parts of the inner product in terms of the norm. re_inner_eq_norm_polarization and im_inner_eq_norm_polarization restate these with squared-norm (^2) notation matching the headline identity.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "parallelogram_law_with_norm",
+        "description": "‖x+y‖·‖x+y‖ + ‖x-y‖·‖x-y‖ = 2(‖x‖·‖x‖ + ‖y‖·‖y‖). parallelogram_law_complex restates it with ^2 notation, the norm-side companion of polarization.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      }
+    ],
+    "originalContributions": [
+      "polarization_identity_complex: complex polarization identity ⟨f,g⟩ = (‖f+g‖² - ‖f-g‖² + (‖f-i·g‖² - ‖f+i·g‖²)·i)/4 over a general RCLike field",
+      "polarization_identity_C: the concrete ℂ instance stated with Complex.I",
+      "re_inner_eq_norm_polarization / im_inner_eq_norm_polarization: real and imaginary parts of ⟨f,g⟩ from norms, in ^2 notation",
+      "parallelogram_law_complex: ‖f+g‖² + ‖f-g‖² = 2‖f‖² + 2‖g‖² for complex inner product spaces",
+      "inner_eq_of_norm_eq: uniqueness corollary — the norm completely determines the inner product"
+    ],
+    "sourceUrl": "https://en.wikipedia.org/wiki/Polarization_identity"
+  },
+  "overview": {
+    "historicalContext": "The polarization identity recovers a bilinear (or sesquilinear) form from its associated quadratic form, a principle going back to the parallelogram-law characterization of inner product spaces by Pascual Jordan and John von Neumann (1935). Over ℝ the symmetric form is determined by two norm evaluations; over ℂ the sesquilinear form requires two further evaluations at f ± i·g to recover the imaginary part. The identity is the technical backbone of uniqueness arguments throughout functional analysis — polar decomposition, the Mazur–Ulam theorem on isometries, and the GNS construction in operator algebras all begin by reconstructing an inner product from a norm.",
+    "problemStatement": "Formalize the complex polarization identity: the inner product on a complex Hilbert space is determined by four squared-norm values via ⟨f,g⟩ = (‖f+g‖² - ‖f-g‖² + (‖f-i·g‖² - ‖f+i·g‖²)·i)/4.",
+    "text": "The real polarization identity ⟨f,g⟩_ℝ = (‖f+g‖² - ‖f-g‖²)/4 (gallery parent cauchy-schwarz-oq-02) only recovers a symmetric bilinear form. A complex inner product is sesquilinear — conjugate-linear in the first argument, linear in the second — so its imaginary part Im⟨f,g⟩ cannot be read off from ‖f+g‖ and ‖f-g‖ alone. Evaluating the norm at f ± i·g supplies the missing data: Re⟨f,g⟩ = (‖f+g‖² - ‖f-g‖²)/4 and Im⟨f,g⟩ = (‖f-i·g‖² - ‖f+i·g‖²)/4. Combining the two via ⟨f,g⟩ = Re⟨f,g⟩ + i·Im⟨f,g⟩ gives the complex polarization identity. Together with the real version this shows the norm completely determines the inner product on every real or complex Hilbert space.",
+    "proofStrategy": "Wrap Mathlib's inner_eq_sum_norm_sq_div_four, stated generically over an RCLike field 𝕜 with the abstract imaginary unit RCLike.I. The headline theorem is a one-line application; specializing 𝕜 = ℂ (where RCLike.I = Complex.I definitionally) gives the concrete complex statement. The real and imaginary parts wrap Mathlib's re/im polarization lemmas after converting ‖·‖·‖·‖ to ‖·‖². The uniqueness corollary rewrites both inner products via the identity and substitutes the four equal-norm hypotheses.",
+    "keyInsights": [
+      "Sesquilinearity is why ℂ needs four norms, not two: the imaginary part is invisible to ‖f+g‖ and ‖f-g‖",
+      "RCLike.I is the abstract imaginary unit that specializes to Complex.I over ℂ and to 0 over ℝ — one lemma covers both fields",
+      "Re⟨f,g⟩ = (‖f+g‖² - ‖f-g‖²)/4 is exactly the real polarization identity, so the complex identity contains the real one as its real part",
+      "Polarization + parallelogram law is the Jordan–von Neumann dictionary: the parallelogram law says a norm comes from an inner product, polarization reconstructs that product",
+      "Uniqueness: any two inner products inducing the same norm are equal — the heart of isometry-rigidity theorems"
+    ],
+    "prerequisites": [
+      "Complex inner product spaces: sesquilinearity, ⟨f,g⟩, the induced norm",
+      "RCLike fields: the unified ℝ/ℂ abstraction and RCLike.I",
+      "Real polarization identity (gallery parent cauchy-schwarz-oq-02)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The complex polarization identity ⟨f,g⟩ = (‖f+g‖² - ‖f-g‖² + (‖f-i·g‖² - ‖f+i·g‖²)·i)/4 is verified over a general RCLike field and specialized to ℂ, with the real/imaginary decomposition, the complex parallelogram law, and a uniqueness corollary. 6 theorems, 114 lines, 0 axioms, 0 sorries.",
+    "implications": "Completes the OQ-02 inner-product-from-norm program for the field ℂ. Provides a typed, Mathlib-ready entry point for the uniqueness arguments (polar decomposition, Mazur–Ulam, GNS) that begin by reconstructing an inner product from a norm.",
+    "openQuestions": [
+      "Formalize the Jordan–von Neumann theorem: a normed space whose norm satisfies the parallelogram law admits an inner product inducing it (the converse direction)",
+      "Expose the complex Pythagorean theorem and Bessel's inequality for complex orthonormal systems as RCLike-generic gallery wrappers",
+      "Formalize the Mazur–Ulam / isometry-rigidity corollary that polarization makes immediate: a surjective norm-preserving map between complex inner product spaces fixing 0 is ℝ-linear"
+    ]
+  },
+  "leanFile": {
+    "namespace": "ComplexPolarization",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ02OQ03.lean",
+    "sorries": 0,
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Basic",
+      "Mathlib.Analysis.RCLike.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "RCLike"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-02",
+      "relationship": "extends",
+      "description": "OQ-02 parent contains the real polarization identity ⟨f,g⟩_ℝ = (‖f+g‖² - ‖f-g‖²)/4; this entry adds the complex (sesquilinear) case"
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "Cauchy-Schwarz inequality — the foundational inner-product-space result this polarization program sits within"
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-01-imports",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Three Mathlib imports (InnerProductSpace.Basic, RCLike.Basic, Tactic). Docstring states the complex polarization identity, contrasts it with the real case (sesquilinear vs symmetric), and fixes Mathlib's conjugate-linear-first convention. Namespace ComplexPolarization with RCLike-generic variables 𝕜, E."
+    },
+    {
+      "id": "sec-02-headline",
+      "title": "Complex Polarization Identity",
+      "startLine": 50,
+      "endLine": 60,
+      "summary": "polarization_identity_complex: the headline ⟨f,g⟩ = (‖f+g‖² - ‖f-g‖² + (‖f-i·g‖² - ‖f+i·g‖²)·i)/4 over a general RCLike field, a typed one-line wrapper of Mathlib's inner_eq_sum_norm_sq_div_four."
+    },
+    {
+      "id": "sec-03-re-im",
+      "title": "Real and Imaginary Parts",
+      "startLine": 62,
+      "endLine": 75,
+      "summary": "re_inner_eq_norm_polarization (Re⟨f,g⟩ = (‖f+g‖²-‖f-g‖²)/4, matching the real identity) and im_inner_eq_norm_polarization (Im⟨f,g⟩ = (‖f-i·g‖²-‖f+i·g‖²)/4), each wrapping the corresponding Mathlib re/im lemma after a pow_two normalization."
+    },
+    {
+      "id": "sec-04-parallelogram",
+      "title": "Complex Parallelogram Law",
+      "startLine": 77,
+      "endLine": 85,
+      "summary": "parallelogram_law_complex: ‖f+g‖² + ‖f-g‖² = 2‖f‖² + 2‖g‖² for complex inner product spaces, the norm-side companion of polarization (Jordan–von Neumann)."
+    },
+    {
+      "id": "sec-05-uniqueness",
+      "title": "Uniqueness Corollary",
+      "startLine": 86,
+      "endLine": 96,
+      "summary": "inner_eq_of_norm_eq: if two vector pairs are equinormed in all four polarization arguments their inner products coincide — the norm completely determines the inner product. Proved by rewriting both sides via the headline identity and substituting the norm equalities."
+    },
+    {
+      "id": "sec-06-complex-instance",
+      "title": "Concrete ℂ Instance",
+      "startLine": 99,
+      "endLine": 114,
+      "summary": "polarization_identity_C: the headline identity specialized to 𝕜 = ℂ, stated with Complex.I (= RCLike.I definitionally for the ℂ field), giving the concrete complex-Hilbert-space statement."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "cauchy-schwarz-oq-02-oq-03",
   "title": "Complex Polarization Identity",
-  "phase": "OBSERVE",
-  "status": "in-progress",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -25,27 +25,27 @@
     "goal": "Ship a verified (0 sorries, 0 axioms) gallery entry with the complex polarization identity, proven by a one-line wrapper of Mathlib's inner_eq_sum_norm_sq_div_four."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-05-12T17:46:00Z",
-    "iteration": 1,
-    "focus": "Mathlib API audit + S2 plan (no Lean changes this iteration).",
+    "phase": "COMPLETE",
+    "since": "2026-06-19T00:00:00Z",
+    "iteration": 2,
+    "focus": "S2 COMPLETE — shipped CauchySchwarzOQ02OQ03.lean + gallery entry, Docker build green (Lean v4.26.0), axiom-clean.",
     "blockers": [],
-    "nextAction": "S2 ACT: ship CauchySchwarzOQ02OQ03.lean (typed wrapper ~5 LOC) + gallery entry (~120 LOC) + Docker build verification.",
+    "nextAction": "Done. Optional future S3: Jordan–von Neumann converse, complex Pythagorean/Bessel wrappers, Mazur–Ulam corollary (see meta openQuestions).",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE — confirmed Mathlib's inner_eq_sum_norm_sq_div_four is the correct upstream lemma; identified the existing real-case polarization_identity in CauchySchwarzOQ02.lean (a hand proof, not a wrapper of the Mathlib lemma); planned single-session S2 deliverable (~60 lines Lean + gallery entry).",
+    "progressSummary": "S2 COMPLETE — shipped proofs/Proofs/CauchySchwarzOQ02OQ03.lean (114 lines, 6 theorems, 0 sorries/axioms; depends only on propext/Classical.choice/Quot.sound) plus gallery entry (meta.json + 5 annotations). Headline polarization_identity_complex wraps Mathlib's inner_eq_sum_norm_sq_div_four over a general RCLike field; polarization_identity_C gives the concrete ℂ instance with Complex.I; re/im-part wrappers, complex parallelogram law, and an inner_eq_of_norm_eq uniqueness corollary round it out. Docker build verified green on Lean v4.26.0; import registered in Proofs.lean.",
     "builtItems": [
-      "S1 documents: problem.md, knowledge.md, state.md, src/data/research/problems/cauchy-schwarz-oq-02-oq-03.json (this file)."
+      "S1 documents: problem.md, knowledge.md, state.md, src/data/research/problems/cauchy-schwarz-oq-02-oq-03.json (this file).",
+      "S2: proofs/Proofs/CauchySchwarzOQ02OQ03.lean (verified, Docker-built); src/data/proofs/cauchy-schwarz-oq-02-oq-03/{meta.json,annotations.json}; import in Proofs.lean."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "S2 ACT: create proofs/Proofs/CauchySchwarzOQ02OQ03.lean wrapping inner_eq_sum_norm_sq_div_four for the complex case; create gallery entry; Docker build verify.",
-      "S3 (optional): expose ℂ-parallelogram-law and Pythagorean-ℂ as additional gallery wrappers if not already covered by Mathlib's RCLike-generic versions."
+      "S3 (optional): Jordan–von Neumann converse (parallelogram law ⇒ inner product); complex Pythagorean theorem and Bessel's inequality as RCLike wrappers; Mazur–Ulam / isometry-rigidity corollary built on inner_eq_of_norm_eq."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Ships a **verified** (0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions) gallery entry for the **complex polarization identity** — the ℂ-companion to the real polarization identity already in the OQ-02 parent.

On any complex inner product space the inner product is completely determined by the norm:

```
⟨f, g⟩ = (‖f+g‖² - ‖f-g‖² + (‖f - i·g‖² - ‖f + i·g‖²)·i) / 4
```

Over ℝ the symmetric bilinear form needs only `‖f+g‖, ‖f-g‖`; over ℂ the inner product is *sesquilinear*, so two extra norm evaluations at `f ± i·g` recover the imaginary part.

## Lean file — `proofs/Proofs/CauchySchwarzOQ02OQ03.lean` (114 lines, 6 theorems)

| Theorem | Statement |
|---|---|
| `polarization_identity_complex` | headline, over a general `RCLike 𝕜`; typed wrapper of Mathlib `inner_eq_sum_norm_sq_div_four` |
| `polarization_identity_C` | concrete `𝕜 = ℂ` instance, stated with `Complex.I` |
| `re_inner_eq_norm_polarization` | `Re⟨f,g⟩ = (‖f+g‖² - ‖f-g‖²)/4` (= the real identity) |
| `im_inner_eq_norm_polarization` | `Im⟨f,g⟩ = (‖f-i·g‖² - ‖f+i·g‖²)/4` |
| `parallelogram_law_complex` | `‖f+g‖² + ‖f-g‖² = 2‖f‖² + 2‖g‖²` |
| `inner_eq_of_norm_eq` | uniqueness: the norm completely determines the inner product |

## Verification

- **Docker build green** (`./proofs/scripts/docker-build.sh Proofs.CauchySchwarzOQ02OQ03`, Lean v4.26.0).
- `#print axioms` on all six theorems lists only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. → `status: verified`, `badge: mathlib` (wraps Mathlib's polarization lemmas), `axiomCount: 0`.
- Import registered in `proofs/Proofs.lean`.

## Gallery

- `src/data/proofs/cauchy-schwarz-oq-02-oq-03/{meta.json, annotations.json}` (5 annotations, each with prerequisites).
- Problem `cauchy-schwarz-oq-02-oq-03` marked `completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)