### PR TITLE
research(pentagonal-number-theorem-oq-01): computable Finset enumerator + ±k pairing (build-verified)

### DIFF
--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -143,6 +143,17 @@ theorem genPent_injective : Function.Injective genPent := by
   · linarith
   · omega
 
+/-- **The `±k` pairing of Euler's recurrence.** `g(-k) = g(k) + k`: the two
+pentagonal shifts `g(k)` and `g(-k)` appearing together in
+`p(n) = ∑_{k≥1} (-1)^{k-1}(p(n - g_k) + p(n - g_{-k}))` differ by exactly `k`,
+since `2g(-k) - 2g(k) = (-k)(-3k-1) - k(3k-1) = 2k`. -/
+theorem genPent_neg (k : ℤ) : genPent (-k) = genPent k + k := by
+  have h1 := two_mul_genPent (-k)
+  have h2 := two_mul_genPent k
+  have h3 : (2 : ℤ) * genPent (-k) - 2 * genPent k = 2 * k := by
+    rw [h1, h2]; ring
+  linarith
+
 /-! ## Part 3b: Index bounds — Euler's recurrence is a finite sum
 
 Euler's partition recurrence `p(n) = ∑_{k≠0} (-1)^{k-1} p(n - g(k))` is only
@@ -200,6 +211,39 @@ theorem indexSet_finite (n : ℤ) : {k : ℤ | genPent k ≤ n}.Finite := by
   rw [Set.mem_Icc]
   rw [abs_le] at hb
   exact hb
+
+/-! ## Part 3c: A computable enumerator of contributing indices
+
+`indexSet_finite` shows the support of Euler's recurrence is finite; here we make
+it *explicit and computable*.  `pentIndices n` is the `Finset` of indices `k` with
+`g(k) ≤ n`, carved out of the interval `[-n, n]` (which contains every such index
+by `abs_index_le_genPent`).  Its membership predicate is exactly `g(k) ≤ n`, so the
+finite sum in `p(n) = ∑_{k} (-1)^{k-1} p(n - g_k)` can be evaluated over it. -/
+
+/-- The contributing indices of Euler's recurrence at level `n`: the explicit
+`Finset` of `k` with `g(k) ≤ n`, obtained by filtering `[-n, n]`. -/
+def pentIndices (n : ℤ) : Finset ℤ :=
+  (Finset.Icc (-n) n).filter (fun k => genPent k ≤ n)
+
+/-- Membership in `pentIndices n` is exactly the value bound `g(k) ≤ n`; the
+interval `[-n, n]` constraint is automatic via `abs_index_le_genPent`. -/
+@[simp] theorem mem_pentIndices {n k : ℤ} : k ∈ pentIndices n ↔ genPent k ≤ n := by
+  unfold pentIndices
+  rw [Finset.mem_filter, Finset.mem_Icc]
+  constructor
+  · exact fun h => h.2
+  · intro h
+    have hb := le_trans (abs_index_le_genPent k) h
+    rw [abs_le] at hb
+    exact ⟨hb, h⟩
+
+/-- The enumerator `pentIndices n` realizes the abstract index set `{k | g(k) ≤ n}`,
+tying the computable `Finset` to the `Set` whose finiteness `indexSet_finite`
+establishes. -/
+theorem coe_pentIndices (n : ℤ) :
+    (pentIndices n : Set ℤ) = {k : ℤ | genPent k ≤ n} := by
+  ext k
+  rw [Finset.mem_coe, Set.mem_setOf_eq, mem_pentIndices]
 
 /-! ## Part 4: Concrete values (OEIS A001318)
 

--- a/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
+++ b/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
@@ -17,7 +17,7 @@ the open frontier.
 ## Summary of progress
 
 Self-contained Lean file `proofs/Proofs/PentagonalNumberTheoremOQ01.lean`
-(179 lines, 16 theorems, 2 defs, 0 axioms, 0 sorries by construction).
+(280 lines, 25 theorems, 3 defs, 0 axioms, 0 sorries by construction).
 
 **Headline:** `isGenPent_iff_isSquare` — `m` is a generalized pentagonal number
 iff `24·m + 1` is a perfect square. This is the classical recognition criterion
@@ -48,7 +48,30 @@ Supporting, fully proved:
   `p(n) = ∑_{k≠0} (-1)^{k-1} p(n-g(k))` is a *finite* sum — a prerequisite for
   any algorithmic/inductive use of the recurrence.
 
+**Session 3 addition — computable enumerator + ±k pairing:**
+- `genPent_neg`: the **±k pairing** `g(-k) = g(k) + k`. The two pentagonal shifts
+  `g(k)` and `g(-k)` that appear together in Euler's recurrence differ by exactly
+  `k` (from `2g(-k) - 2g(k) = (-k)(-3k-1) - k(3k-1) = 2k`).
+- `pentIndices (n : ℤ) : Finset ℤ`: the **computable enumerator** of contributing
+  indices, `(Finset.Icc (-n) n).filter (fun k => g(k) ≤ n)`. The `[-n,n]` interval
+  contains every index with `g(k) ≤ n` by `abs_index_le_genPent`, so the filter
+  loses nothing.
+- `mem_pentIndices`: membership is exactly the value bound `g(k) ≤ n` (the interval
+  constraint is automatic), making this a drop-in index set for a `Finset.sum`.
+- `coe_pentIndices`: `↑(pentIndices n) = {k | g(k) ≤ n}` as a `Set ℤ`, tying the
+  computable `Finset` to the abstract set whose finiteness `indexSet_finite` proves.
+
+This turns `indexSet_finite` (a finiteness existence statement) into an explicit,
+computable carrier — the next consumer (the Finset-sum form of Euler's recurrence)
+can now range directly over `pentIndices n`.
+
 ## Status of verification
+
+**BUILD-VERIFIED (2026-06-19, Session 3).** Docker build green, 7743 jobs,
+`✔ Built Proofs.PentagonalNumberTheoremOQ01 (30s)`, EXIT=0, 0 sorry, 0 axiom,
+0 native_decide. Session 3 adds `genPent_neg`, `pentIndices`, `mem_pentIndices`,
+`coe_pentIndices` on top of the Session-2 finiteness layer (all elementary:
+`linarith` / `Finset.mem_filter`).
 
 **BUILD-VERIFIED (2026-06-19, Session 2).** Docker build green, 7743 jobs,
 `✔ Built Proofs.PentagonalNumberTheoremOQ01`, 0 errors, 0 warnings (the
@@ -122,3 +145,22 @@ be to *define* the partition-into-distinct-parts sign and state (not yet prove)
 the identity, or to formalize the explicit finite form of Euler's recurrence
 `p(n) = ∑_{k=1}^{K(n)} (-1)^{k-1}(p(n-g_k)+p(n-g_{-k}))` now that `indexSet_finite`
 supplies the finite support.
+
+### 2026-06-19 (Session 3, researcher-11) — DEEPEN (build-verified)
+
+**Mode**: DEEPEN · **Outcome**: progress (build-verified)
+
+- Built the next consumer the Session-2 finiteness layer was built for: a
+  *computable* enumerator of the recurrence's support.
+- New: `genPent_neg` (`g(-k) = g(k) + k`, the ±k pairing of Euler's recurrence);
+  `pentIndices` (def: `(Finset.Icc (-n) n).filter (g · ≤ n)`); `mem_pentIndices`
+  (membership ⟺ `g(k) ≤ n`); `coe_pentIndices` (`↑(pentIndices n) = {k | g(k) ≤ n}`).
+  All elementary: `linarith` / `Finset.mem_filter` + `abs_index_le_genPent`.
+- Build green (7743 jobs, EXIT=0, 0 sorry, 0 axiom, 0 native_decide). Built under
+  a heavily-loaded host (load ~17, 2–3 concurrent docker builds) using
+  `LEAN_MEMORY_LIMIT=8192`; cache path confirmed Azure (7727 files), not from-source.
+
+**Next steps**: with `pentIndices` providing an explicit `Finset` carrier, the
+tractable intermediate is now to *state* Euler's recurrence as a `Finset.sum` over
+`pentIndices`, isolating Franklin's involution (the deep identity) as the sole
+remaining mathematical gap.

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -44,7 +44,9 @@
       "genPent_injective: distinctness of pentagonal numbers across indices, via the factorization (a-b)(3(a+b)-1)=0 and impossibility of 3(a+b)=1 over ℤ",
       "A ZMod-6 decision argument turning 's² = 24m+1' into 's ≡ ±1 (mod 6)', recovering the index from each residue class",
       "Concrete values g(0..±4) = 0,1,2,5,7,12,15,22,26 matching OEIS A001318, with a sanity check that 12 = g(3) and 24·12+1 = 17²",
-      "Index-bound theory making Euler partition recurrence a finite sum: genPent_sq_le_self (k^2 <= g(k), quadratic growth), abs_index_le_genPent (|k| <= g(k)), and indexSet_finite ({k | g(k) <= n} is finite, contained in [-n,n])"
+      "Index-bound theory making Euler partition recurrence a finite sum: genPent_sq_le_self (k^2 <= g(k), quadratic growth), abs_index_le_genPent (|k| <= g(k)), and indexSet_finite ({k | g(k) <= n} is finite, contained in [-n,n])",
+      "A computable enumerator pentIndices (def): the explicit Finset of indices k with g(k) <= n, filtered from [-n,n], with mem_pentIndices (membership iff g(k) <= n) and coe_pentIndices (realizing the abstract set {k | g(k) <= n}), so the finite sum in Euler's recurrence can be evaluated",
+      "genPent_neg: the +/-k pairing g(-k) = g(k) + k of Euler's recurrence, relating the two pentagonal shifts g(k) and g(-k) that occur together at each level"
     ],
     "dateAdded": "2026-06-18",
     "axiomCount": 0,

--- a/src/data/research/problems/pentagonal-number-theorem-oq-01.json
+++ b/src/data/research/problems/pentagonal-number-theorem-oq-01.json
@@ -18,7 +18,9 @@
       "genPent_injective: distinct indices give distinct pentagonal numbers, via (a-b)(3(a+b)-1)=0 and 3(a+b)≠1 over ℤ [PentagonalNumberTheoremOQ01.lean]",
       "isGenPent_nonneg + concrete values g(0..±4)=0,1,2,5,7,12,15,22,26 (OEIS A001318) [PentagonalNumberTheoremOQ01.lean]",
       "genPent_sq_le_self (k²≤g(k)), index_le_genPent / neg_index_le_genPent / abs_index_le_genPent (|k|≤g(k)), mul_pred_nonneg / mul_succ_nonneg (consecutive-integer products ≥0) [PentagonalNumberTheoremOQ01.lean]",
-      "indexSet_finite: for any n, {k | g(k) ≤ n} is finite (⊆ [-n,n]) — Euler's recurrence is a finite sum [PentagonalNumberTheoremOQ01.lean]"
+      "indexSet_finite: for any n, {k | g(k) ≤ n} is finite (⊆ [-n,n]) — Euler's recurrence is a finite sum [PentagonalNumberTheoremOQ01.lean]",
+      "pentIndices (def) + mem_pentIndices + coe_pentIndices: COMPUTABLE Finset enumerator of contributing indices {k | g(k) ≤ n} filtered from [-n,n]; membership ⟺ g(k) ≤ n, and its Set coercion is exactly the index set indexSet_finite proves finite [PentagonalNumberTheoremOQ01.lean]",
+      "genPent_neg: the ±k pairing g(-k) = g(k) + k of Euler's recurrence (the two shifts g(k), g(-k) appearing together differ by exactly k) [PentagonalNumberTheoremOQ01.lean]"
     ],
     "mathlibGaps": [
       "No Franklin sign-reversing involution on partitions into distinct parts.",
@@ -27,9 +29,9 @@
     ],
     "nextSteps": [
       "Mathematical frontier: build Franklin's involution to reach the deep identity p_even(n)-p_odd(n) = [n=g(k)]·(-1)ᵏ.",
-      "Tractable intermediate now that indexSet_finite supplies finite support: formalize the explicit finite form of Euler's recurrence p(n) = ∑_{k=1}^{K(n)} (-1)^{k-1}(p(n-g_k)+p(n-g_{-k})), or define the partition-into-distinct-parts parity sign and state the identity.",
-      "Define a Finset enumerator of pentagonal indices ≤ n (via abs_index_le_genPent / indexSet_finite) to make the recurrence computable."
+      "Tractable intermediate now that pentIndices supplies a computable support: formalize the explicit finite form of Euler's recurrence p(n) = ∑_{k ∈ pentIndices' n} (-1)^{k-1} p(n-g_k) as a Finset.sum over the enumerator, or define the partition-into-distinct-parts parity sign and state the identity.",
+      "Define the partition function p(n) (or reuse Nat.Partition.card) and state — not yet prove — Euler's recurrence as a Finset.sum identity indexed by pentIndices, isolating Franklin's involution as the sole remaining gap."
     ],
-    "progressSummary": "BUILD-VERIFIED (Session 2, 2026-06-19): foundation file (headline 24m+1-square recognition criterion) was merged build-verified via PR #25893; Session 2 adds the index-bound / finiteness layer — k²≤g(k) (quadratic growth), |k|≤g(k), and indexSet_finite ({k|g(k)≤n} finite ⊆ [-n,n]), which is the precise statement that Euler's partition recurrence is a finite sum. Build green (7743 jobs), 0 sorry, 0 axiom, warning-clean. Deep identity (Franklin's involution) remains the open core."
+    "progressSummary": "BUILD-VERIFIED (Session 3, 2026-06-19): foundation file (headline 24m+1-square recognition criterion) merged via PR #25893; Session 2 added the index-bound/finiteness layer (k²≤g(k), |k|≤g(k), indexSet_finite). Session 3 adds the COMPUTABLE enumerator pentIndices (Finset of {k | g(k) ≤ n} filtered from [-n,n]) with mem_pentIndices / coe_pentIndices tying it to the abstract finite set, plus genPent_neg (the ±k pairing g(-k)=g(k)+k) — the recurrence's support is now an explicit Finset ready to index a Finset.sum. Build green (7743 jobs), 0 sorry, 0 axiom, warning-clean. Deep identity (Franklin's involution) remains the open core."
   }
 }


### PR DESCRIPTION
## Summary

Deepens the verified `pentagonal-number-theorem-oq-01` entry with the tractable next step its knowledge file called out (nextStep #3): a **computable enumerator** of the indices contributing to Euler's partition recurrence at each level.

The deep core of the pentagonal number theorem — Franklin's sign-reversing involution / the formal-power-series identity `∏(1-Xⁿ) = ∑(-1)ᵏXᵍ⁽ᵏ⁾` — remains a genuine multi-file Mathlib gap and stays the open frontier. This PR advances the self-contained index-set theory that any formalization must consume.

## New results (all 0 sorry / 0 axiom, elementary)

- **`genPent_neg`** — the `±k` pairing `g(-k) = g(k) + k`: the two pentagonal shifts `g(k)` and `g(-k)` that appear together in `p(n) = ∑_{k≥1}(-1)^{k-1}(p(n-g_k)+p(n-g_{-k}))` differ by exactly `k`.
- **`pentIndices (n : ℤ) : Finset ℤ`** — the explicit computable enumerator `(Finset.Icc (-n) n).filter (g · ≤ n)`. The interval `[-n,n]` contains every index with `g(k) ≤ n` by `abs_index_le_genPent`, so the filter loses nothing.
- **`mem_pentIndices`** — membership is exactly `g(k) ≤ n` (interval bound automatic).
- **`coe_pentIndices`** — `↑(pentIndices n) = {k | g(k) ≤ n}`, tying the computable `Finset` to the abstract set whose finiteness `indexSet_finite` establishes.

This converts the Session-2 finiteness *existence* statement (`indexSet_finite`) into an explicit, computable carrier ready to index a `Finset.sum` form of Euler's recurrence.

## Verification

Docker build **green**: `✔ [7743/7743] Built Proofs.PentagonalNumberTheoremOQ01 (30s)`, EXIT=0, 0 sorry, 0 axiom, 0 native_decide. Azure cache path confirmed (7727 files, not from-source). `status: verified`, `badge: original` unchanged.

Knowledge records (gallery meta, pool problem JSON, `research/.../knowledge.md`) updated to reflect the Session-3 additions and the refined next step (state Euler's recurrence as a `Finset.sum` over `pentIndices`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)