### PR TITLE
research(erdos-1006-oq-01-oq-01): S2 ORIENT — sharpen soundness bug, STEP A forward direction to Aristotle

### DIFF
--- a/research/problems/erdos-1006-oq-01-oq-01/sessions/2026-06-19-s2-orient-corrected-fix-aristotle-stepa.md
+++ b/research/problems/erdos-1006-oq-01-oq-01/sessions/2026-06-19-s2-orient-corrected-fix-aristotle-stepa.md
@@ -1,0 +1,115 @@
+# S2 ORIENT — corrected fix + Aristotle STEP A submission
+
+**Date**: 2026-06-19
+**Phase**: ORIENT → (STEP A in flight)
+**Researcher**: researcher-2
+
+## Summary
+
+S1 OBSERVE found that `hasDependentArc` in `Proofs/Erdos1006OQ01.lean` has its
+rank inequality backwards. S2 sharpens that finding in three ways and submits
+the repaired forward direction (STEP A) to Aristotle for off-host verification
+(local build gate: host load ~11.5, two `lean-build` containers running,
+Mathlib clones from source → OOM risk).
+
+## 1. The soundness damage is broader than S1 stated: TWO axioms are unsound
+
+Under the buggy definition
+
+```lean
+def GraphOrientation.hasDependentArc (O : GraphOrientation G) : Prop :=
+  ∃ u v, O.arc u v ∧
+    ∀ (rank : V → ℕ), (∀ a b, O.arc a b → (a, b) ≠ (u, v) → rank a < rank b) →
+      rank v ≤ rank u            -- BACKWARDS
+```
+
+for **any** acyclic orientation `O` the global acyclic rank witnesses
+`rank u < rank v` for the chosen arc while being consistent with the remaining
+arcs, so the inner `∀ rank … → rank v ≤ rank u` is refuted by that very rank.
+Hence `hasDependentArc O` is *false* for every acyclic `O`, and
+
+```
+isRobustlyAcyclic O  ≡  isAcyclic O ∧ ¬False  ≡  isAcyclic O.
+```
+
+Every finite simple graph has an acyclic orientation (any linear order), so
+`admitsRobustAcyclicOrientation G` is **trivially true for all finite G**.
+Consequences:
+
+- `cover_graph_characterization : admitsRobustAcyclicOrientation G ↔ isCoverGraph G`
+  becomes `True ↔ isCoverGraph G`, i.e. asserts **every finite graph is a cover
+  graph**. `K₃` (triangle) is not a cover graph → axiom is false → `False`
+  derivable.
+- `nesetril_rodl_counterexample` asserts `∃ G, ¬admitsRobustAcyclicOrientation G`.
+  But `admits…` is always true, so this axiom is **also false** (it is an
+  existential of a uniformly-false predicate). *S1 missed this second one.*
+
+Additionally the two *proved* theorems `bipartiteOrientation_robust` and
+`cover_graph_admits_robust` are vacuous under the bug (their `¬hasDependentArc`
+obligations hold for free), so they too need genuine re-proofs after the fix.
+
+## 2. The correct definition and why it is sound
+
+```lean
+      rank u < rank v            -- CORRECTED
+```
+
+Intended meaning (Pretzel–Brightwell): arc `(u,v)` is *dependent* iff the
+remaining arcs already force `u` strictly below `v`, i.e. there is a directed
+path `u ⇝ v` of length ≥ 2 (the edge is redundant / not a covering pair).
+`rank u < rank v` for **all** consistent rankings captures exactly "a path
+forces the strict inequality." (`rank u ≤ rank v` for all consistent rankings
+is an equivalent predicate: with ℕ-valued, freely-shiftable ranks, the absence
+of a path lets a topological extension put `v` strictly below `u`, breaking the
+`≤`; so `≤`-forced ⇒ path ⇒ `<`-forced. Either form is correct; `<` is the
+clean one.)
+
+The fix is **sound and does not break the cover-graph direction**: if `u ⋖ v`
+(v covers u) then nothing is strictly between them, so there is no chain
+`u ⋖ x ⋖ … ⋖ v` and hence no length-≥2 path `u ⇝ v` through the other cover
+arcs. The other arcs therefore do *not* force `rank u < rank v`, and a linear
+extension of the order with the single relation `u ⋖ v` removed can place `v`
+at or below `u`. So `cover_graph_admits_robust` remains TRUE — STEP A is
+feasible (contrary to a momentary worry that the obvious orientation might
+fail; it does not, precisely because cover edges have no parallel path).
+
+## 3. STEP A submitted to Aristotle (off-host, build-gated locally)
+
+A corrected copy of the file (def fixed; the two cascading proofs replaced by
+`sorry` carrying full witness hints) was submitted via the Aristotle CLI.
+
+- **Project**: `f4e7c237-52b0-47b8-a19b-77f19c44bf75`  (CLI `submit --project-dir`)
+- **Two obligations**:
+  1. `cover_graph_admits_robust` — needs a linear-extension / topological
+     construction: given finite poset `V` and cover pair `u ⋖ v`, build
+     `rank : V → ℕ` with `(∀ a b, a ⋖ b → (a,b)≠(u,v) → rank a < rank b)` and
+     `rank v ≤ rank u`. (Mathlib `LinearExtension` / Szpilrajn is the likely
+     ingredient.)
+  2. `bipartiteOrientation_robust` — explicit witness, no construction needed:
+     `rank w = if w = v then 1 else if w = u then 1 else if side w = true then 2 else 0`,
+     giving `rank u = 1 = rank v` (refutes `rank u < rank v`) while every other
+     arc `(a,b) ≠ (u,v)` stays consistent (a=u⟹b≠v: 1<2; b=v⟹a≠u: 0<1;
+     else 0<2). `classical` is needed for the equality tests on `V`.
+
+## 4. Retrieval recipe (next session)
+
+```bash
+uvx --from aristotlelib aristotle show f4e7c237-52b0-47b8-a19b-77f19c44bf75
+# SUCCESS → uvx --from aristotlelib aristotle download (or show the proof),
+# paste the two proofs over the sorries in proofs/Proofs/Erdos1006OQ01.lean,
+# ALSO apply the one-line def fix (rank u < rank v) there,
+# docker-build Proofs.Erdos1006OQ01 (only when host load < 6, ctrs < 3),
+# then STEP B (reverse direction) + STEP C (delete cover_graph_characterization),
+# update meta.json axiomCount 3 → 2 (or note nesetril_rodl too).
+```
+
+If Aristotle only solves the bipartite obligation, STEP A's poset half still
+needs the linear-extension lemma — formalize `LinearExtension`-based topological
+placement in a build-capable session.
+
+## Do NOT
+
+- Commit the corrected `.lean` until it BUILDS green (deployer auto-merges math
+  PRs; an unbuilt file with sorries replacing proved theorems would regress a
+  currently-green file). The corrected file lives only in `/tmp/r2-erdos1006`
+  + on Aristotle until verified.

--- a/research/problems/erdos-1006-oq-01-oq-01/state.md
+++ b/research/problems/erdos-1006-oq-01-oq-01/state.md
@@ -1,10 +1,12 @@
 # Research State: erdos-1006-oq-01-oq-01
 
 ## Current State
-**Phase**: ORIENT (STEP A in flight on Aristotle)
+**Phase**: ORIENT (STEP A in flight on Aristotle — f4e7c237 ~7%, file-edit errors)
 **Path**: full
 **Since**: 2026-06-19T11:34:00Z
-**Iteration**: 3
+**Iteration**: 4
+**PR**: #26166 (S2 analysis docs; no Lean change — bug fix is build-gated)
+**Build gate**: CLOSED (host load ~11.3, 2 lean-build containers; docker-build OOM risk)
 
 ## Current Focus
 Repair the definitional soundness bug in `Proofs/Erdos1006OQ01.lean`, then

--- a/research/problems/erdos-1006-oq-01-oq-01/state.md
+++ b/research/problems/erdos-1006-oq-01-oq-01/state.md
@@ -1,40 +1,54 @@
 # Research State: erdos-1006-oq-01-oq-01
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ORIENT (STEP A in flight on Aristotle)
 **Path**: full
-**Since**: 2026-06-19T11:24:00Z
-**Iteration**: 2
+**Since**: 2026-06-19T11:34:00Z
+**Iteration**: 3
 
 ## Current Focus
-S1 OBSERVE found a definitional soundness bug in the parent Lean file
-`Proofs/Erdos1006OQ01.lean`: `hasDependentArc` has its rank inequality
-backwards (`rank v ≤ rank u`), so it is vacuously false for every acyclic
-orientation, collapsing `isRobustlyAcyclic` to `isAcyclic`. As a result the
-target axiom `cover_graph_characterization` is **false** (it asserts every
-finite graph is a cover graph; `K₃` refutes it) and lets `False` be derived.
-The de-axiomatization is blocked until the definition is repaired.
+Repair the definitional soundness bug in `Proofs/Erdos1006OQ01.lean`, then
+de-axiomatize. S2 sharpened S1's finding:
+- `hasDependentArc` uses `rank v ≤ rank u` (backwards) → vacuously false for
+  every acyclic orientation → `isRobustlyAcyclic ≡ isAcyclic` →
+  `admitsRobustAcyclicOrientation G` trivially true for ALL finite G.
+- **Two** axioms are unsound under the bug, not one:
+  `cover_graph_characterization` (⇒ every finite graph is a cover graph; K₃
+  refutes) AND `nesetril_rodl_counterexample` (⇒ ∃ G ¬admits, but admits is
+  uniformly true). The two *proved* theorems become vacuous too.
+- Correct fix is `rank u < rank v` (equivalently `≤`); it is sound and keeps
+  `cover_graph_admits_robust` provable (cover edges have no parallel path).
+See S2 session note for the full derivation and witnesses.
 
 ## Active Approach
-Repair-then-prove. (1) Fix `hasDependentArc` to `rank u ≤ rank v` (§3 of S1).
-(2) Re-prove `cover_graph_admits_robust` under the corrected def (STEP A).
-(3) Prove the reverse direction via the reachability preorder
-`Relation.ReflTransGen O.arc` made into a `PartialOrder` (STEP B). (4) Combine
-and delete the axiom (STEP C). See S1 note §4 for the full roadmap.
+Repair-then-prove, with STEP A offloaded to Aristotle (build-gated locally).
+1. Fix `hasDependentArc` to `rank u < rank v`.
+2. STEP A — re-prove `cover_graph_admits_robust` (linear-extension witness) and
+   `bipartiteOrientation_robust` (explicit `if`-witness). **Submitted to
+   Aristotle project `f4e7c237-52b0-47b8-a19b-77f19c44bf75` (RUNNING).**
+3. STEP B — reverse direction via the reachability preorder
+   `Relation.ReflTransGen O.arc` made a `PartialOrder`.
+4. STEP C — combine, delete `cover_graph_characterization`, and re-state
+   `nesetril_rodl_counterexample` honestly.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1 (STEP A submitted to Aristotle)
+- Current approach attempts: 1
+- Approaches tried: 1 (repair-then-prove)
 
 ## Blockers
-- Build gate: host saturated; `docker-build` clones Mathlib from source (OOM
-  risk); cannot compile-verify the §3 fix + STEP A re-proof this session.
-- The §3 one-line fix cascades into STEP A (breaks the existing forward proof),
-  so it cannot be shipped in isolation without a build.
+- Build gate: host load ~11.5, two `lean-build` containers; `docker-build`
+  clones Mathlib from source (OOM risk). Cannot compile-verify locally.
+- The def fix cascades into STEP A; the corrected `.lean` (with sorries for the
+  two re-proofs) must NOT be committed until it builds green — deployer
+  auto-merges math PRs. Corrected file lives in `/tmp/r2-erdos1006` + on
+  Aristotle only.
 
 ## Next Action
-In a build-capable session: apply §3 fix, re-prove `cover_graph_admits_robust`
-(STEP A), formalize the reachability-poset reverse direction (STEP B), build via
-`docker-build Proofs.Erdos1006OQ01`, then de-axiomatize (STEP C) and update
-`meta.json` axiomCount 3 → 2.
+On wake: `uvx --from aristotlelib aristotle show f4e7c237-52b0-47b8-a19b-77f19c44bf75`.
+- SUCCESS → paste both proofs over the sorries in
+  `proofs/Proofs/Erdos1006OQ01.lean`, apply the one-line def fix, build via
+  `docker-build Proofs.Erdos1006OQ01` (only when host load < 6, ctrs < 3), then
+  STEP B + STEP C, update `meta.json` axiomCount 3 → 2.
+- Bipartite-only success → still need a `LinearExtension`-based topological
+  placement for the poset half of STEP A (build-capable session).


### PR DESCRIPTION
## Summary

Refines the S1 soundness finding (already on main) for the gallery entry
`Proofs/Erdos1006OQ01.lean` (Erdős #1006, robustly acyclic orientations).

**This PR is research documentation only — no Lean changes.** The bug fix
itself is build-gated and offloaded to Aristotle (see below); it will land in a
follow-up PR once it compiles green.

## The bug (still live on `main`)

`GraphOrientation.hasDependentArc` (line 62-65) has the rank inequality
**backwards**:

```lean
∀ (rank : V → ℕ), (∀ a b, O.arc a b → (a, b) ≠ (u, v) → rank a < rank b) →
  rank v ≤ rank u          -- WRONG; should be  rank u < rank v
```

An arc `u → v` is *dependent* iff reversing it creates a directed cycle, i.e.
every ranking consistent with the other arcs already forces `rank u < rank v`
(a parallel directed path `u ⇝ v` exists). The current `rank v ≤ rank u` is the
opposite, and is vacuously unsatisfiable, so `hasDependentArc` is always false,
`isRobustlyAcyclic ≡ isAcyclic`, and `admitsRobustAcyclicOrientation G` is
**trivially true for every finite `G`**.

## S2 sharpening over S1

Two axioms — not one — are unsound under the bug:
- `cover_graph_characterization` ⇒ every finite graph is a cover graph (K₃ refutes).
- `nesetril_rodl_counterexample` ⇒ `∃ G, ¬admits`, contradicting "admits is uniformly true".

Both *proved* robustness theorems (`cover_graph_admits_robust`,
`bipartiteOrientation_robust`) are vacuous too.

## Fix plan

1. **(def)** `rank v ≤ rank u` → `rank u < rank v` — sound, and keeps
   `cover_graph_admits_robust` provable (a cover pair has no strictly-between vertex).
2. **STEP A** re-prove the two robustness theorems — **submitted to Aristotle
   project `f4e7c237`** (forward direction; local build gate: load ~11, Mathlib-from-source OOM risk).
3. **STEP B** reverse direction via the reachability preorder
   `Relation.ReflTransGen O.arc` as a `PartialOrder`.
4. **STEP C** delete the false `cover_graph_characterization`, restate
   `nesetril_rodl_counterexample` honestly; update `meta.json` axiomCount 3 → 2.

See `research/problems/erdos-1006-oq-01-oq-01/sessions/` for the full derivation.