### PR TITLE
Enrich √2 irrationality: add annotation prerequisites

### DIFF
--- a/src/data/proofs/sqrt2-irrational/annotations.json
+++ b/src/data/proofs/sqrt2-irrational/annotations.json
@@ -31,6 +31,7 @@
     "content": "A real number $x$ is **irrational** if for all integers $p, q$ with $q \\neq 0$, we have $x \\neq p/q$. This is the negation of rationality: there is no way to express $x$ as a ratio of integers.",
     "mathContext": "In Lean, this is a universal statement: `∀ p q : ℤ, q ≠ 0 → x ≠ p / q`. The proof will show this holds for $x = \\sqrt{2}$ by contradiction.",
     "significance": "key",
+    "prerequisites": [],
     "relatedConcepts": [
       "rational numbers",
       "negation",
@@ -49,6 +50,7 @@
     "content": "Two integers $p$ and $q$ are **coprime** (or relatively prime) if their greatest common divisor is 1: $\\gcd(p, q) = 1$. Equivalently, they share no prime factors.",
     "mathContext": "Every rational number can be written in lowest terms $p/q$ where $p$ and $q$ are coprime. This is crucial for the contradiction—if both are even, they're not coprime.",
     "significance": "key",
+    "prerequisites": [],
     "relatedConcepts": [
       "GCD",
       "lowest terms",
@@ -62,11 +64,12 @@
       "startLine": 5,
       "endLine": 49
     },
-    "type": "concept",
+    "type": "technique",
     "title": "Even Square Implies Even Root",
     "content": "**The key lemma**: If $n^2$ is even, then $n$ is even. The proof uses the contrapositive: assume $n$ is odd, show $n^2$ is odd, contradicting that $n^2$ is even.",
     "mathContext": "Why does odd$^2$ = odd? Write $n = 2k+1$. Then $n^2 = 4k^2 + 4k + 1 = 2(2k^2 + 2k) + 1$, which is odd. The tactic `Odd.pow` handles this in Lean.",
     "significance": "key",
+    "prerequisites": [],
     "relatedConcepts": [
       "contrapositive",
       "parity",
@@ -80,7 +83,7 @@
       "startLine": 5,
       "endLine": 49
     },
-    "type": "concept",
+    "type": "technique",
     "title": "Square of Odd is Odd",
     "content": "A direct proof that odd$^2$ = odd. If $n = 2k + 1$ (odd), then $n^2 = 4k^2 + 4k + 1 = 2(2k^2 + 2k) + 1$, which has the form $2m + 1$ (odd).",
     "mathContext": "The `ring` tactic handles the algebraic manipulation automatically. The `obtain` tactic destructs the existential in the definition of `Odd`.",
@@ -100,7 +103,7 @@
       "startLine": 5,
       "endLine": 49
     },
-    "type": "concept",
+    "type": "technique",
     "title": "Divisibility by 2 Preserved by Squaring",
     "content": "A bidirectional lemma: $2 \\mid n^2 \\iff 2 \\mid n$. The forward direction uses `even_of_even_sq`; the reverse is direct calculation: if $n = 2k$, then $n^2 = 4k^2 = 2(2k^2)$.",
     "mathContext": "The `↔` (iff) in Lean requires proving both directions. The `constructor` tactic splits this into two goals.",
@@ -165,11 +168,14 @@
       "startLine": 55,
       "endLine": 65
     },
-    "type": "concept",
+    "type": "technique",
     "title": "Squaring Both Sides",
     "content": "From $\\sqrt{2} = p/q$, we square both sides to get $2 = p^2/q^2$, hence $p^2 = 2q^2$. This eliminates the square root and gives us an equation in integers.",
     "mathContext": "This is the key algebraic step. In Lean, `congrArg (·^2)` applies squaring to both sides of an equation.",
     "significance": "key",
+    "prerequisites": [
+      "ann-sqrt2-irrational-def"
+    ],
     "relatedConcepts": [
       "algebraic manipulation",
       "congruence"
@@ -281,8 +287,8 @@
     "id": "ann-sqrt6-proof",
     "proofId": "sqrt2-irrational",
     "range": {
-      "startLine": 179,
-      "endLine": 182
+      "startLine": 190,
+      "endLine": 193
     },
     "type": "insight",
     "title": "Irrationality of √6",
@@ -302,8 +308,8 @@
     "id": "ann-sqrt7-proof",
     "proofId": "sqrt2-irrational",
     "range": {
-      "startLine": 187,
-      "endLine": 193
+      "startLine": 198,
+      "endLine": 204
     },
     "type": "insight",
     "title": "Irrationality of √7",
@@ -322,8 +328,8 @@
     "id": "ann-general-theorem",
     "proofId": "sqrt2-irrational",
     "range": {
-      "startLine": 195,
-      "endLine": 199
+      "startLine": 206,
+      "endLine": 210
     },
     "type": "insight",
     "title": "The General Theorem",
@@ -344,10 +350,10 @@
     "id": "ann-examples-squares",
     "proofId": "sqrt2-irrational",
     "range": {
-      "startLine": 201,
-      "endLine": 207
+      "startLine": 212,
+      "endLine": 218
     },
-    "type": "concept",
+    "type": "context",
     "title": "Perfect Squares vs Non-Squares",
     "content": "The `decide` tactic can verify whether a number is a perfect square. Non-squares: 2, 3, 5, 6, 7, 8, 10, ... Perfect squares: 1 = 1², 4 = 2², 9 = 3², 16 = 4², ...",
     "mathContext": "For perfect squares, we provide explicit witnesses: `IsSquare 4` is proven by `⟨2, by ring⟩` showing $4 = 2 \\cdot 2$. The `decide` tactic handles non-squares by computation.",

--- a/src/data/proofs/sqrt2-irrational/annotations.source.json
+++ b/src/data/proofs/sqrt2-irrational/annotations.source.json
@@ -30,6 +30,7 @@
     "content": "A real number $x$ is **irrational** if for all integers $p, q$ with $q \\neq 0$, we have $x \\neq p/q$. This is the negation of rationality: there is no way to express $x$ as a ratio of integers.",
     "mathContext": "In Lean, this is a universal statement: `\u2200 p q : \u2124, q \u2260 0 \u2192 x \u2260 p / q`. The proof will show this holds for $x = \\sqrt{2}$ by contradiction.",
     "significance": "key",
+    "prerequisites": [],
     "relatedConcepts": [
       "rational numbers",
       "negation",
@@ -48,6 +49,7 @@
     "content": "Two integers $p$ and $q$ are **coprime** (or relatively prime) if their greatest common divisor is 1: $\\gcd(p, q) = 1$. Equivalently, they share no prime factors.",
     "mathContext": "Every rational number can be written in lowest terms $p/q$ where $p$ and $q$ are coprime. This is crucial for the contradiction\u2014if both are even, they're not coprime.",
     "significance": "key",
+    "prerequisites": [],
     "relatedConcepts": [
       "GCD",
       "lowest terms",
@@ -66,6 +68,7 @@
     "content": "**The key lemma**: If $n^2$ is even, then $n$ is even. The proof uses the contrapositive: assume $n$ is odd, show $n^2$ is odd, contradicting that $n^2$ is even.",
     "mathContext": "Why does odd$^2$ = odd? Write $n = 2k+1$. Then $n^2 = 4k^2 + 4k + 1 = 2(2k^2 + 2k) + 1$, which is odd. The tactic `Odd.pow` handles this in Lean.",
     "significance": "key",
+    "prerequisites": [],
     "relatedConcepts": [
       "contrapositive",
       "parity",
@@ -170,6 +173,9 @@
     "content": "From $\\sqrt{2} = p/q$, we square both sides to get $2 = p^2/q^2$, hence $p^2 = 2q^2$. This eliminates the square root and gives us an equation in integers.",
     "mathContext": "This is the key algebraic step. In Lean, `congrArg (\u00b7^2)` applies squaring to both sides of an equation.",
     "significance": "key",
+    "prerequisites": [
+      "ann-sqrt2-irrational-def"
+    ],
     "relatedConcepts": [
       "algebraic manipulation",
       "congruence"


### PR DESCRIPTION
## Summary

Under gallery saturation (all 2558 entries at q100), the remaining enrichment frontier is per-annotation completeness. The √2 irrationality entry had 4 of 18 annotations missing the `prerequisites` field; this PR fills them in.

## Changes

- **`annotations.source.json`**: added `prerequisites` to the 4 annotations that lacked it:
  - *Definition of Irrational* → `[]` (foundational)
  - *Definition of Coprime* → `[]` (foundational)
  - *Even Square Implies Even Root* → `[]` (base key lemma)
  - *Squaring Both Sides* → `[ann-sqrt2-irrational-def]` (builds on the rational representation)

  All references are acyclic and follow the existing pattern in this file.

- **`annotations.json`** (regenerated via `pnpm annotations:build`): now in sync with source — picks up the new prerequisites, re-resolves line ranges against the current Lean source, and corrects stale `type` fields that had drifted from the source.

## Verification

- All 18 annotations now declare `prerequisites`.
- `type` fields match `annotations.source.json`.
- Entry remains q100 in `find-targets`.