### PR TITLE
audit(abundant-number-oq-02): first audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16063,6 +16063,12 @@
       "lastAudited": "2026-06-19T11:47:13Z",
       "result": "clean",
       "issues": []
+    },
+    "abundant-number-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T11:58:41Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — abundant-number-oq-02

**Result: CLEAN** (first audit; gallery now 2559/2559 audited)

**Entry:** *The Smallest Odd Abundant Number Is 945* — `smallest_odd_abundant : IsLeast {n | Odd n ∧ Nat.Abundant n} 945`

### Tier classification
**Tier A — fully formalized theorem.** The `IsLeast` result is proved in-file. The minimality half is discharged by the file's *own* kernel-reducible divisor sum `sigmaFast` + a bounded kernel `decide`, not delegated to a deep Mathlib theorem. Mathlib supplies only standard building blocks (`Nat.Abundant`, `Nat.sum_divisors_eq_sum_properDivisors_add_self`, Finset sum lemmas), all disclosed.

### Numeric meta vs `Proofs/AbundantNumberOQ02.lean` — all EXACT
| Field | meta.json | source |
|-------|-----------|--------|
| lineCount | 115 | 115 ✓ |
| theoremCount | 6 | 6 ✓ |
| definitionCount | 2 | 2 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |

(grep hits for `sorry`/`native_decide` are all in comments/docstrings — none in code.)

### Axiom Integrity Policy check
Badge `verified` / status `verified` is **correct**. The result is axiom-free because it uses **kernel `decide`** (lines 82, 93, 101, 105) — **not `native_decide`** — so it carries no `Lean.ofReduceBool`. The meta is meticulous about this distinction throughout (`assumptions`, `keyInsights`, `conclusion`). `#print axioms smallest_odd_abundant` (line 113) confirms only propext / Classical.choice / Quot.sound.

Build-verified via merged PR #26164; not rebuilt here (host load ~11 > build gate).

No issues found. Tracker bumped (auditCount 1, result clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)