### PR TITLE
research(abel-ruffini-oq-07): machine-check the mod-2 factorisation of X⁵−X−1

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ07.lean
+++ b/proofs/Proofs/AbelRuffiniOQ07.lean
@@ -241,9 +241,39 @@ a transposition and a 3-cycle, an order-6 permutation.  Where the prose above on
 transposition that input `(b)` feeds into the assembly criterion — turning the
 prose cycle-type computation into verified permutation data. -/
 
+/-- The reduction of `X⁵ − X − 1` to `(ZMod 2)[X] = 𝔽₂[X]`.  Over `𝔽₂` we have
+    `−1 = 1`, so `f` reduces to `X⁵ + X + 1`. -/
+noncomputable def f2 : (ZMod 2)[X] := X ^ 5 - X - 1
+
+/-- **The mod-2 factorisation, machine-checked.**
+    `X⁵ − X − 1 ≡ (X² + X + 1)(X³ + X² + 1)` over `𝔽₂` — an (irreducible quadratic)·
+    (irreducible cubic).  Where the prose above only *asserts* this factorisation, we
+    now verify it as a polynomial identity in `𝔽₂[X]`: expanding the right-hand side
+    gives `X⁵ + 2X⁴ + 2X³ + 2X² + X + 1`, and the `2`-coefficients vanish in
+    characteristic `2`, leaving `X⁵ + X + 1 = X⁵ − X − 1 = f2`.  This is the arithmetic
+    that *justifies* the `(2,3)` cycle type modelled by `frob2`. -/
+theorem f2_factorization :
+    f2 = (X ^ 2 + X + 1) * (X ^ 3 + X ^ 2 + 1) := by
+  have h2 : (2 : (ZMod 2)[X]) = 0 := by
+    simpa using CharP.cast_eq_zero ((ZMod 2)[X]) 2
+  unfold f2
+  linear_combination (-(X ^ 4 + X ^ 3 + X ^ 2 + X + 1)) * h2
+
+/-- The quadratic factor `X² + X + 1` has **no root in `𝔽₂`** (a two-element check:
+    `0 ↦ 1`, `1 ↦ 1`).  A degree-`2` polynomial with no root is irreducible, so this
+    factor is one of the two irreducible factors of the `(2,3)` decomposition. -/
+theorem quad_no_root_mod2 : ∀ x : ZMod 2, x ^ 2 + x + 1 ≠ 0 := by decide
+
+/-- The cubic factor `X³ + X² + 1` has **no root in `𝔽₂`** (`0 ↦ 1`, `1 ↦ 1`).  A
+    degree-`3` polynomial with no root is irreducible, completing the verification that
+    the mod-2 factorisation is into an irreducible quadratic times an irreducible cubic
+    — exactly the `(2,3)` factor type that forces `frob2`'s cycle structure. -/
+theorem cubic_no_root_mod2 : ∀ x : ZMod 2, x ^ 3 + x ^ 2 + 1 ≠ 0 := by decide
+
 /-- A representative `(2, 3)`-cycle-type element of `S₅`: the transposition `(0 1)`
     times the 3-cycle `(2 3 4)`.  This models a Frobenius element of `f` at `p = 2`,
-    whose factorisation type mod 2 is (irreducible quadratic)·(irreducible cubic). -/
+    whose factorisation type mod 2 is (irreducible quadratic)·(irreducible cubic)
+    (verified in `f2_factorization`, `quad_no_root_mod2`, `cubic_no_root_mod2`). -/
 def frob2 : S5 := Equiv.swap 0 1 * (Equiv.swap 2 3 * Equiv.swap 3 4)
 
 /-- `frob2` is an **odd** permutation (sign `= −1`), so a `(2, 3)`-type element lies

--- a/src/data/proofs/abel-ruffini-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-07/meta.json
@@ -57,6 +57,7 @@
       "Polynomial anchoring (f_natDegree, f_monic, natDegree_prime): X⁵−X−1 is monic of prime degree 5.",
       "Documentation of the open gap: the two hypotheses are the output of the Dedekind–Frobenius bridge shared with inverse-galois-a5-oq-01; closing it there closes this problem.",
       "Concrete Frobenius witness (frob2, frob2_not_mem_alternating, frob2_pow_three_eq_swap, frob2_pow_three_isSwap): exhibits a (2,3)-cycle-type element (0 1)(2 3 4) ∈ S₅ modelling a Frobenius element of f mod 2, machine-checks it is odd and that its cube is the transposition (0 1) — making the prose 'order-6 Frobenius ⟹ transposition' step into verified permutation data.",
+      "Machine-checked mod-2 factorisation (f2, f2_factorization, quad_no_root_mod2, cubic_no_root_mod2): verifies the polynomial identity X⁵−X−1 = (X²+X+1)(X³+X²+1) in 𝔽₂[X] (the 2-coefficients of the expansion vanish in characteristic 2, via linear_combination against (2 : 𝔽₂[X]) = 0), and that each factor has no root in 𝔽₂ — so the quadratic and cubic are irreducible. This is the arithmetic input that JUSTIFIES the (2,3) cycle type modelled by frob2, previously only asserted in prose; it parallels the mod-3 no-root corroboration (no_root_mod3) for frob3's 5-cycle.",
       "Concrete p=3 Frobenius witness and capstone (frob3, frob3_pow_five, orderOf_frob3, five_dvd_card_of_frob3_mem, gal_eq_top_of_frobenii): exhibits the 5-cycle frob3 = (0 1 2 3 4) ∈ S₅ modelling a Frobenius element of f mod 3 (irreducible quintic), machine-checks orderOf frob3 = 5, and derives via Lagrange that any subgroup containing it has 5 ∣ |G| — supplying hypothesis (a) of gal_eq_top_of_five_dvd_and_swap from a single membership fact. The capstone gal_eq_top_of_frobenii assembles G = ⊤ = S₅ from both witnesses (frob3 gives 5 ∣ |G|, frob2³ gives the transposition), turning the entire prose cycle-type computation into verified permutation data modulo the open Dedekind–Frobenius bridge.",
       "Real-Galois-group order divisibility (five_dvd_card_gal): proves 5 ∣ Nat.card f.Gal for the GENUINE Galois group f.Gal of X⁵−X−1, conditional only on Irreducible f, via Polynomial.Gal.prime_degree_dvd_card. This discharges the order-divisibility half of the corrected proof WITHOUT the Dedekind–Frobenius bridge: where frob3 supplies 5 ∣ |G| for an abstract subgroup G ≤ S₅, this supplies it for the real f.Gal, reducing that half of the open bridge to the separately-classical irreducibility of f.",
       "Unconditional generation theorem (closure_frobenii_eq_top): the two explicit permutations frob2 = (0 1)(2 3 4) and frob3 = (0 1 2 3 4) generate the whole symmetric group, Subgroup.closure {frob2, frob3} = ⊤. Specializes the conditional capstone gal_eq_top_of_frobenii to the subgroup they generate (both are members of their own closure), giving the concrete, hypothesis-free form of the S₅ criterion: the order-5 cycle forces 5 ∣ |⟨frob2,frob3⟩| and the cube of the order-6 element is the transposition, so the generated subgroup cannot be proper. (Classically, the transposition (0 1) and the 5-cycle (0 1 2 3 4) generate S₅.)",
@@ -70,7 +71,7 @@
       "Lean 4 and Mathlib"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 348,
+    "lineCount": 378,
     "relatedProblems": [
       {
         "id": "abel-ruffini-oq-04-oq-01",
@@ -81,8 +82,8 @@
         "relationship": "Needs the SAME Dedekind–Frobenius bridge (cycle type of Frobenius from factor type mod p); closing it there supplies this file's two hypotheses."
       }
     ],
-    "theoremCount": 21,
-    "definitionCount": 5
+    "theoremCount": 23,
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Paolo Ruffini (1799) and Niels Henrik Abel (1824) showed there is no general radical formula for the quintic; Évariste Galois (1831) recast solvability as a property of the equation's permutation group, making 'Gal not solvable' the modern criterion for unsolvability by radicals. A concrete unsolvable quintic therefore needs a polynomial whose Galois group is non-solvable — and the smallest non-solvable transitive subgroups of S_5 are A_5 and S_5. Ernst Selmer (1956, Math. Scand. 4) proved the trinomials X^n - X - 1 irreducible over Q for all n, making X^5 - X - 1 a natural candidate witness. The standard tool for pinning down such a Galois group is Dedekind's theorem (1880s): for a prime p not dividing the discriminant, the factorization type of f mod p equals the cycle type of a Frobenius element of Gal(f). Combined with Frobenius's density results, this turns Galois-group identification into a finite set of modular factorizations — the method underlying every computer-algebra Galois routine (GAP, PARI/GP, Magma).",
@@ -266,10 +267,10 @@
       "Polynomial"
     ],
     "namespace": "AbelRuffiniOQ07",
-    "lineCount": 348,
+    "lineCount": 378,
     "axiomCount": 0,
-    "theoremCount": 21,
-    "definitionCount": 5,
+    "theoremCount": 23,
+    "definitionCount": 6,
     "sorries": 0,
     "path": "Proofs/AbelRuffiniOQ07.lean"
   },

--- a/src/data/research/problems/abel-ruffini-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-oq-07.json
@@ -17,9 +17,9 @@
   },
   "currentState": {
     "phase": "FORMALIZE",
-    "since": "2026-06-18T21:30:00-07:00",
-    "iteration": 2,
-    "focus": "Verified the corrected group-theoretic reduction in Lean (Proofs/AbelRuffiniOQ07.lean): assembly criterion gal_eq_top_of_five_dvd_and_swap (5∣|G| + swap ∈ G ⟹ S₅), formalized the correction prod_two_swaps_mem_alternating (double transposition is EVEN, refuting the curated 3-real-roots route), plus discriminant direction and polynomial degree facts. 0 sorry / 0 axiom; the two Frobenius inputs are explicit hypotheses.",
+    "since": "2026-06-19T05:00:00-07:00",
+    "iteration": 3,
+    "focus": "Machine-checked the mod-2 factorisation underlying frob2's (2,3) cycle type (r3): f2_factorization proves X⁵−X−1 = (X²+X+1)(X³+X²+1) in 𝔽₂[X] (linear_combination against (2:𝔽₂[X])=0), and quad_no_root_mod2 / cubic_no_root_mod2 (decide) show each factor has no 𝔽₂-root, hence is irreducible. Turns the previously prose-only mod-2 factorisation insight into verified arithmetic, paralleling no_root_mod3 for frob3. Build GREEN (3066 jobs); all three new theorems depend only on propext/Classical.choice/Quot.sound. Still 0 sorry / 0 axiom; the transposition input to gal_eq_top_of_five_dvd_and_swap remains a hypothesis pending the Dedekind–Frobenius bridge.",
     "blockers": [
       "Dedekind–Frobenius bridge (factor type mod unramified p ⟹ matching cycle type in f.Gal) not in Mathlib v4.26.0; same bridge axiomatised as three_dvd_gal_card in InverseGaloisA5.lean. Supplies the two hypotheses (5∣|Gal|, swap∈Gal)."
     ],
@@ -31,7 +31,8 @@
       "five_dvd_card_gal (AbelRuffiniOQ07.lean:156): Irreducible f → 5 ∣ Nat.card f.Gal for the REAL Galois group f.Gal, via Polynomial.Gal.prime_degree_dvd_card + natDegree_prime. Verified (0 sorry/0 axiom), conditional only on Irreducible f. Connects the entry to Mathlib Polynomial.Gal for the first time (previously only abstract Subgroup S5).",
       "no_root_mod3 + f3_no_root (AbelRuffiniOQ07.lean): X⁵−X−1 has no root in 𝔽₃ (decide over ZMod 3), the linear-factor obstruction of the mod-3 irreducibility argument. f3 := (X^5-X-1 : (ZMod 3)[X]). Verified, 0 sorry. The remaining obstruction (no monic quadratic factor over 𝔽₃) resists decide because polynomial %ₘ does not kernel-reduce through Finsupp — left as documented next step.",
       "f_irreducible (AbelRuffiniOQ07.lean): Irreducible f via X_pow_sub_X_sub_one_irreducible_rat (by norm_num).",
-      "five_dvd_card_gal_unconditional (AbelRuffiniOQ07.lean): 5 ∣ Nat.card f.Gal UNCONDITIONALLY (0 sorry, 0 axiom). Build GREEN, 3066 jobs."
+      "five_dvd_card_gal_unconditional (AbelRuffiniOQ07.lean): 5 ∣ Nat.card f.Gal UNCONDITIONALLY (0 sorry, 0 axiom). Build GREEN, 3066 jobs.",
+      "f2 + f2_factorization + quad_no_root_mod2 + cubic_no_root_mod2 (AbelRuffiniOQ07.lean, r3 2026-06-19): the mod-2 factorisation X⁵−X−1 = (X²+X+1)(X³+X²+1) in 𝔽₂[X], machine-checked as a polynomial identity via linear_combination against (2:𝔽₂[X])=0 (char-2 kills the 2-coefficients of the expansion), plus decide-checks that both factors are root-free over 𝔽₂ hence irreducible. Formalizes the (2,3) factor-type insight that justifies frob2's cycle structure; the mod-2 analogue of no_root_mod3. Verified 0 sorry/0 axiom, axiom set {propext, Classical.choice, Quot.sound}. Build GREEN."
     ],
     "insights": [
       "VERIFIED (sympy/numpy): x⁵−x−1 has exactly ONE real root (≈1.1673), not three; 4 non-real roots = two conjugate pairs. Problem statement point (iii) is FALSE.",


### PR DESCRIPTION
## Summary

Fills a documented gap in the verified entry `abel-ruffini-oq-07` (corrected S₅ criterion for `X⁵−X−1`): the **mod-2 factorisation** that justifies the `p=2` Frobenius witness `frob2`'s `(2,3)` cycle type was previously stated only in prose. It is now machine-checked.

## What's added (`proofs/Proofs/AbelRuffiniOQ07.lean`, +3 theorems, +1 def)

| Decl | Statement |
|---|---|
| `f2` | reduction `X⁵−X−1` to `(ZMod 2)[X]` |
| `f2_factorization` | `X⁵ − X − 1 = (X²+X+1)(X³+X²+1)` in `𝔽₂[X]` |
| `quad_no_root_mod2` | `X²+X+1` has no root in `𝔽₂` (⟹ irreducible, deg 2) |
| `cubic_no_root_mod2` | `X³+X²+1` has no root in `𝔽₂` (⟹ irreducible, deg 3) |

The factorisation is proved as a polynomial identity: expanding the RHS gives `X⁵ + 2X⁴ + 2X³ + 2X² + X + 1`, and the `2`-coefficients vanish in characteristic 2 — handled by `linear_combination` against `(2 : (ZMod 2)[X]) = 0`. This parallels the existing `no_root_mod3` corroboration of `frob3`'s 5-cycle.

## Verification

- **Docker build green** (`Proofs.AbelRuffiniOQ07`, 3066 jobs, Lean v4.26.0). Base file confirmed building before the change (no bitrot).
- `#print axioms` on all three new theorems → only `propext, Classical.choice, Quot.sound`. The `decide` tactics use **kernel** reduction (no `Lean.ofReduceBool`). File remains **0 sorry / 0 axiom**.
- Counts updated in meta: 348→378 lines, 21→23 theorems, 5→6 definitions.

## Scope note

This is a corroborating arithmetic increment. The problem itself **remains blocked** on the Dedekind–Frobenius bridge (factor type mod *p* ⟹ matching cycle type in `f.Gal`), which Mathlib v4.26.0 lacks — the same open bridge shared with `inverse-galois-a5-oq-01`. The transposition input to `gal_eq_top_of_five_dvd_and_swap` stays an explicit hypothesis, not an axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)