### PR TITLE
audit(sylvester-gallai-theorem-oq-01): first audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16063,6 +16063,12 @@
       "lastAudited": "2026-06-19T11:47:13Z",
       "result": "clean",
       "issues": []
+    },
+    "sylvester-gallai-theorem-oq-01": {
+      "auditCount": 2,
+      "lastAudited": "2026-06-19T12:01:48Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — `sylvester-gallai-theorem-oq-01`

**Result: CLEAN** ✓ (first audit of the gallery's newest entry, added today via #26171)

### Numeric claims — all EXACT
| Field | meta.json | Lean source |
|-------|-----------|-------------|
| lineCount | 222 | 222 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ (no `axiom` decls) |
| theoremCount | 6 | 6 ✓ |
| definitionCount | 3 | 3 ✓ (`E` abbrev, `φ`, `IsOrdinary`) |
| native_decide | — | 0 ✓ |
| True stubs | — | 0 ✓ |

### Tier & honesty
- **Honest reduction.** The canonical Mathlib-form statement (`EuclideanSpace ℝ (Fin 2)`, `Collinear ℝ`) is obtained as a corollary of the gallery's **own verified** `SylvesterGallai.sylvester_gallai` (`Erdos606OQ03OQ03.lean`, 0-sorry/0-axiom Kelly proof) — **not** a deep Mathlib theorem. The geometric kernel is reused, not re-proved.
- **Badge `verified` defensible.** The entire chain (this file + parent) is 0-sorry/0-axiom. The dependency is disclosed in description, `assumptions`, `originalContributions`, `conclusion`, and `crossReferences` (extends `erdos-606-oq-03-oq-03`).
- **`originalContributions` correctly scoped** to the four mechanical bridge lemmas (`phi_injective`, `three_le_card_of_not_collinear`, `collinear_iff_sg`, `not_allCollinear_image`) — does **not** claim to have proved Kelly's argument.
- **No narrative failure modes.** Not inequality-as-theorem (proves the real existential ordinary-line conclusion); title qualified "in Canonical Mathlib Form"; no axiom masking; the Mathlib-gap claim (Sylvester–Gallai absent from Mathlib) is the documented contribution.

**Risk: LOW.** Tracker bump only.

---
Discovered during gallery integrity audit.