### PR TITLE
Enrich abundant-number-oq-02: add inline annotations

### DIFF
--- a/src/data/proofs/abundant-number-oq-02/annotations.json
+++ b/src/data/proofs/abundant-number-oq-02/annotations.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "abundant02-ann-statement",
+    "proofId": "abundant-number-oq-02",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "The Smallest Odd Abundant Number Is 945",
+    "content": "A natural number $n$ is **abundant** when the sum of its proper divisors exceeds $n$, equivalently $\\sigma(n) > 2n$ with $\\sigma(n) = \\sum_{d \\mid n} d$. The smallest abundant number is $12$, but $12$ — and every abundant number below $945$ — is **even**. The smallest *odd* abundant number is\n$$ 945 = 3^3 \\cdot 5 \\cdot 7, \\qquad \\sigma(945) = \\tfrac{3^4-1}{2}\\cdot 6 \\cdot 8 = 40 \\cdot 6 \\cdot 8 = 1920 > 1890 = 2 \\cdot 945. $$\nThe entry proves `IsLeast {n | Odd n ∧ Nat.Abundant n} 945`, fully machine-checked with $0$ axioms and $0$ sorries. The obstacle is the minimality half — the bounded check $\\forall n < 945,\\ \\mathrm{Odd}\\,n \\to \\lnot\\,n.\\mathrm{Abundant}$ — which is far too large to discharge by `decide` on Mathlib's `Finset`-based `Nat.Abundant`. The file's contribution is a **kernel-reducible** divisor sum that makes the same check feasible inside the trusted kernel, hence axiom-free.",
+    "mathContext": "`Nat.Abundant n := n < ∑_{d ∈ properDivisors n} d`. Target: `IsLeast {n | Odd n ∧ Nat.Abundant n} 945` (OEIS A005231 begins 945, 1575, 2205, …).",
+    "significance": "key",
+    "prerequisites": [
+      "sum-of-divisors function σ and proper divisors",
+      "deficient / perfect / abundant classification and the abundancy index σ(n)/n",
+      "`IsLeast` (membership + lower bound)"
+    ],
+    "relatedConcepts": [
+      "odd abundant number",
+      "abundancy index",
+      "OEIS A005231",
+      "kernel decide vs native_decide"
+    ]
+  },
+  {
+    "id": "abundant02-ann-sigmafast",
+    "proofId": "abundant-number-oq-02",
+    "range": { "startLine": 30, "endLine": 52 },
+    "type": "insight",
+    "title": "A Kernel-Reducible Sum of Divisors",
+    "content": "The enabling idea. Mathlib's `Nat.Abundant` unfolds to a `Finset` divisor sum whose kernel reduction is *structural* — folds over `Multiset`/`range` — and exhausts the recursion/heartbeat budget far below $945$. The file replaces it with `sigmaAux n m`, summing $(d \\text{ if } d \\mid n \\text{ else } 0)$ for $d = 1,\\dots,m$ by **plain structural recursion on $\\mathbb{N}$**, and sets `sigmaFast n := sigmaAux n n`. No `Finset`/`Multiset` survives to reduction time, so the Lean kernel evaluates `sigmaFast` through ordinary GMP-accelerated $\\mathbb{N}$ arithmetic. `sigmaAux_eq_sum` then identifies it with the indicator `Finset` sum\n$$ \\mathtt{sigmaAux}\\,n\\,m = \\sum_{d \\in \\mathrm{range}(m+1)} [\\,d \\mid n\\,]\\cdot d, $$\nby induction on $m$ using `Finset.sum_range_succ` — the bridge from the fast recursion back to Mathlib's divisor machinery.",
+    "mathContext": "`sigmaAux n (m+1) = (if (m+1) ∣ n then m+1 else 0) + sigmaAux n m`; `sigmaFast n = sigmaAux n n`. Reduction stays in ℕ, not Finset.",
+    "significance": "key",
+    "prerequisites": [
+      "structural recursion on ℕ and kernel reduction",
+      "`Finset.sum_range_succ`",
+      "indicator (if-then-else) sums"
+    ],
+    "relatedConcepts": [
+      "kernel reduction",
+      "GMP-accelerated ℕ arithmetic",
+      "divisor sum σ(n)",
+      "reflection / decision procedures"
+    ]
+  },
+  {
+    "id": "abundant02-ann-bridge",
+    "proofId": "abundant-number-oq-02",
+    "range": { "startLine": 53, "endLine": 77 },
+    "type": "lemma",
+    "title": "Agreement with Mathlib's σ and the Abundance Bridge",
+    "content": "Two lemmas connect the fast sum to the goal. `sigmaFast_eq_sigma` ($n \\neq 0$) shows the indicator sum over $\\mathrm{range}(n+1)$ collapses to the canonical $\\sum_{d \\mid n} d$: rewrite with `Finset.sum_filter`, then prove $\\mathrm{filter}(\\cdot \\mid n)\\,(\\mathrm{range}(n+1)) = n.\\mathrm{divisors}$ by `Finset.ext` — the only content is that $d \\mid n$ with $n \\neq 0$ forces $1 \\le d \\le n$ (`Nat.le_of_dvd`). Then `abundant_iff_sigmaFast` ($n \\neq 0$) gives\n$$ n.\\mathrm{Abundant} \\iff 2n < \\mathtt{sigmaFast}\\,n, $$\nby rewriting the full divisor sum as proper-divisor sum plus $n$ (`Nat.sum_divisors_eq_sum_properDivisors_add_self`) and closing with `omega`. This equivalence is what lets the bounded minimality check run by `decide` on `sigmaFast` rather than on the `Finset`-based `Nat.Abundant`.",
+    "mathContext": "`sigmaFast_eq_sigma : n ≠ 0 → sigmaFast n = ∑ d ∈ n.divisors, d`; `abundant_iff_sigmaFast : n ≠ 0 → (Nat.Abundant n ↔ 2*n < sigmaFast n)`.",
+    "significance": "supporting",
+    "prerequisites": [
+      "`Finset.sum_filter`, `Finset.ext`",
+      "`Nat.le_of_dvd`, `Nat.sum_divisors_eq_sum_properDivisors_add_self`",
+      "`omega`"
+    ],
+    "relatedConcepts": [
+      "proper divisors vs full divisor sum",
+      "divisor finset `n.divisors`",
+      "decidable rewriting"
+    ]
+  },
+  {
+    "id": "abundant02-ann-minimality",
+    "proofId": "abundant-number-oq-02",
+    "range": { "startLine": 79, "endLine": 94 },
+    "type": "insight",
+    "title": "945 Is Abundant; No Smaller Odd Number Is",
+    "content": "The two computational facts. `abundant_945` evaluates `sigmaFast 945` in the kernel (`maxRecDepth 4000`) to get $1920$, and applies the bridge: $2 \\cdot 945 = 1890 < 1920$, so $945$ is abundant. `not_abundant_odd_below_945 : \\forall n < 945,\\ \\mathrm{Odd}\\,n \\to \\mathtt{sigmaFast}\\,n \\le 2n$ is a single bounded `decide` (`Nat.decidableBallLT`, with `maxHeartbeats`/`maxRecDepth` raised). Crucially, phrasing the bound as $\\mathrm{Odd}\\,n \\to \\dots$ lets the decision procedure discharge every **even** $n$ on the cheap `Odd n = false` test, so a divisor sum is actually computed only for the $\\approx 472$ odd residues below $945$ — the case-pruning is free. This is exactly the step a `Finset`-based `decide` cannot perform at this scale.",
+    "mathContext": "`abundant_945 : Nat.Abundant 945`; `not_abundant_odd_below_945 : ∀ n < 945, Odd n → sigmaFast n ≤ 2*n`, both kernel `decide` over `sigmaFast`.",
+    "significance": "key",
+    "prerequisites": [
+      "`Nat.decidableBallLT` (decidable bounded quantifiers)",
+      "`set_option maxRecDepth` / `maxHeartbeats`",
+      "kernel `decide`"
+    ],
+    "relatedConcepts": [
+      "bounded decision procedure",
+      "short-circuit on `Odd n`",
+      "σ(945) = 1920"
+    ]
+  },
+  {
+    "id": "abundant02-ann-isleast",
+    "proofId": "abundant-number-oq-02",
+    "range": { "startLine": 95, "endLine": 115 },
+    "type": "concept",
+    "title": "Least Odd Abundant Number, Axiom-Free",
+    "content": "`smallest_odd_abundant : IsLeast {n | Odd n ∧ Nat.Abundant n} 945` assembles the pieces. **Membership** pairs `Odd 945` (by `decide`) with `abundant_945`. **Lower bound:** for any odd abundant $n$, suppose $n < 945$; oddness gives $n \\neq 0$, so `abundant_iff_sigmaFast` turns abundance into $2n < \\mathtt{sigmaFast}\\,n$, while `not_abundant_odd_below_945` gives $\\mathtt{sigmaFast}\\,n \\le 2n$ — `omega` closes the contradiction. Because every step reduces by **kernel `decide`** rather than `native_decide`, `#print axioms smallest_odd_abundant` reports only the standard foundational axioms `propext`, `Classical.choice`, `Quot.sound`, and **not** `Lean.ofReduceBool` — so the badge is `verified`, not `axiomatized`. This settles the open question recorded in `abundant-number-oq-01`, whose $n < 12$ minimality `decide` does not scale.",
+    "mathContext": "`IsLeast S a := a ∈ S ∧ ∀ b ∈ S, a ≤ b`. Axiom audit: propext / Classical.choice / Quot.sound only — no `Lean.ofReduceBool`.",
+    "significance": "key",
+    "prerequisites": [
+      "`IsLeast`, `Set.mem_setOf`",
+      "kernel `decide` vs `native_decide` and `Lean.ofReduceBool`",
+      "`omega`"
+    ],
+    "relatedConcepts": [
+      "axiom-free verification",
+      "abundant-number-oq-01 (smallest abundant number 12)",
+      "verified vs axiomatized status"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment: The Smallest Odd Abundant Number Is 945

The `abundant-number-oq-02` entry had a rich `meta.json` but **no `annotations.json`** — the inline-annotation layer was missing entirely (quality score 43, 0 passes).

### What this adds

Five line-anchored annotations covering the full 115-line Lean file:

1. **Statement & IsLeast goal** — abundance, the abundancy index, why 945 = 3³·5·7 is the smallest *odd* abundant number, and the kernel-feasibility obstacle.
2. **Kernel-reducible `sigmaFast`** — structural ℕ recursion with no Finset/Multiset at reduction time, and the `sigmaAux_eq_sum` bridge.
3. **Agreement with Mathlib's σ** — `sigmaFast_eq_sigma` and `abundant_iff_sigmaFast`.
4. **945 is abundant; no smaller odd number is** — `abundant_945` and the bounded `decide` minimality check (free even-case pruning via `Odd n`).
5. **Axiom-free IsLeast assembly** — `smallest_odd_abundant`, kernel `decide` vs `native_decide`, and why the badge is `verified` (no `Lean.ofReduceBool`).

Each annotation carries `mathContext`, `significance`, `prerequisites`, and `relatedConcepts`.

### Validation

- `pnpm annotations:build` reports **no errors for this entry** (all 5 annotations resolve to Lean constructs).
- Only this entry's `annotations.json` is committed; the build's normalization churn to ~34 unrelated entries was discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)