### PR TITLE
audit(abundant-number-oq-02): first audit clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16069,8 +16069,14 @@
       "lastAudited": "2026-06-19T12:01:48Z",
       "result": "clean",
       "issues": []
+    },
+    "abundant-number-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T12:15:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-19T11:40:26Z"
+  "lastUpdated": "2026-06-19T12:15:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — abundant-number-oq-02

**Result: CLEAN** (Tier A, risk LOW)

Re-audit against current `main`; replaces the now-conflicting #26174 (its tracker bump diverged from main). Only changes `audit-tracker.json` (+6 lines).

### Verification (meta.json ↔ `proofs/Proofs/AbundantNumberOQ02.lean`)

| Claim | meta.json | Source | Match |
|-------|-----------|--------|-------|
| lineCount | 115 | 115 | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 2 | 2 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 `axiom` decls | ✓ |
| native_decide | none | only in docstrings/comments | ✓ |
| True stubs | — | 0 | ✓ |

### Badge / status integrity

- The proof discharges minimality (`not_abundant_odd_below_945`) and `abundant_945` by **kernel `decide`**, not `native_decide` — so it carries **no `Lean.ofReduceBool`** axiom. `status: "verified"` / `badge: "verified"` / `axiomCount: 0` are correct.
- Tier A: the core result `IsLeast {n | Odd n ∧ Nat.Abundant n} 945` is genuinely proved by the file's own kernel-reducible `sigmaFast` + Mathlib bridge. Mathlib's `Nat.Abundant` and divisor machinery are used as infrastructure and the description discloses this honestly — no overclaim, no delegation opacity.
- Five narrative failure modes: N/A.

---
Discovered during gallery integrity audit.