### PR TITLE
research(erdos-653-oq-01): gallery entry for verified lower-bound companion

### DIFF
--- a/src/data/proofs/erdos-653-oq-01/annotations.json
+++ b/src/data/proofs/erdos-653-oq-01/annotations.json
@@ -1,0 +1,140 @@
+[
+  {
+    "id": "e653oq01-ann-01",
+    "proofId": "erdos-653-oq-01",
+    "range": {
+      "startLine": 39,
+      "endLine": 60
+    },
+    "type": "concept",
+    "title": "The Collinear Configuration: Universal Elementary Witness",
+    "content": "`collinearConfig n` is the n-point set (0,0),(1,0),…,(n-1,0) on the x-axis, built as `(Finset.range n).image (fun i => ![(i:ℝ), 0])`. `collinearConfig_card` proves it has exactly n distinct points (the embedding i ↦ (i,0) is injective). Because g(n) is a maximum over ALL n-point configurations, every lower bound on g comes from exhibiting ONE good configuration; the collinear arrangement is the simplest such witness and the only construction this file needs. Its single virtue is that distances are transparent: the distance between the i-th and j-th points is exactly |i-j|.",
+    "mathContext": "$\\mathrm{collinearConfig}(n) = \\{(0,0),(1,0),\\dots,(n-1,0)\\}$, $|\\mathrm{collinearConfig}(n)| = n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "distinct distances",
+      "extremal configuration",
+      "Finset.image injectivity"
+    ],
+    "prerequisites": [
+      "Finset.range and Finset.image",
+      "points as Fin 2 → ℝ",
+      "maximum over configurations"
+    ]
+  },
+  {
+    "id": "e653oq01-ann-02",
+    "proofId": "erdos-653-oq-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 94
+    },
+    "type": "insight",
+    "title": "g as a Supremum: Lower Bounds via le_csSup",
+    "content": "`gSet n` is the set of all achievable distinct-R-value counts for n-point configurations, and `g_eq_sSup` establishes g(n) = sSup (gSet n). `gSet_bddAbove` shows this set is bounded above (by n, since there are only n points), so the conditionally-complete-lattice machinery applies. The payoff is `le_csSup`: to prove g(n) ≥ k it suffices to exhibit a single configuration realizing k distinct R-values. This converts every lower bound in the file into a construction-plus-count, and is the structural reason the collinear witness suffices.",
+    "mathContext": "$g(n) = \\sup\\, \\mathrm{gSet}(n)$, with $\\mathrm{gSet}(n)$ bounded above; hence $k \\in \\mathrm{gSet}(n) \\Rightarrow k \\le g(n)$ (`le_csSup`).",
+    "significance": "high",
+    "relatedConcepts": [
+      "conditionally complete lattice",
+      "sSup / le_csSup",
+      "BddAbove"
+    ],
+    "prerequisites": [
+      "supremum of a set of naturals",
+      "le_csSup and BddAbove",
+      "definition of g(n)"
+    ]
+  },
+  {
+    "id": "e653oq01-ann-03",
+    "proofId": "erdos-653-oq-01",
+    "range": {
+      "startLine": 95,
+      "endLine": 109
+    },
+    "type": "concept",
+    "title": "g(n) ≥ 1: The First Proved Lower Bound",
+    "content": "`g_ge_one` proves g(n) ≥ 1 for n ≥ 1. In the parent file this was only asserted in a docstring; here it is witnessed by any nonempty configuration (`numDistinctRValues_pos`), needing no distance values at all — a single point already has a well-defined R-value, so at least one distinct R-value exists. Trivial mathematically, but it is the base case of the lower-bound ladder and the first place le_csSup is applied to the collinear witness.",
+    "mathContext": "$n \\ge 1 \\Rightarrow g(n) \\ge 1$.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "nonempty configuration",
+      "base case",
+      "le_csSup application"
+    ],
+    "prerequisites": [
+      "g as supremum",
+      "nonempty Finset",
+      "positivity of a cardinality"
+    ]
+  },
+  {
+    "id": "e653oq01-ann-04",
+    "proofId": "erdos-653-oq-01",
+    "range": {
+      "startLine": 110,
+      "endLine": 218
+    },
+    "type": "technique",
+    "title": "Counting Distinct Distances from a Collinear Point",
+    "content": "The technical heart of the ⌈n/2⌉ bound. `euclidDist_collinearPoint` verifies that the Euclidean distance between the i-th and j-th x-axis points is |i-j|. Then `absDiff_image_eq` and `maxCount_image_card` show that the set of distances {|i-j| : j ≠ i} from the i-th point has cardinality max(i, n-1-i) — the farther of the two endpoints determines how many distinct gaps appear. `distinctDistCount_collinearConfig` packages this as R(xᵢ) = max(i, n-1-i) for the collinear configuration.",
+    "mathContext": "For collinear points, $\\mathrm{dist}(x_i, x_j) = |i-j|$ and $R(x_i) = \\#\\{|i-j| : j \\ne i\\} = \\max(i,\\, n-1-i)$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Euclidean distance",
+      "Finset.image cardinality",
+      "absolute-difference counting"
+    ],
+    "prerequisites": [
+      "EuclideanSpace distance formula",
+      "Finset.image and card_image_of_injOn",
+      "max of two naturals"
+    ]
+  },
+  {
+    "id": "e653oq01-ann-05",
+    "proofId": "erdos-653-oq-01",
+    "range": {
+      "startLine": 219,
+      "endLine": 268
+    },
+    "type": "insight",
+    "title": "g(n) ≥ ⌈n/2⌉ from the Collinear Configuration",
+    "content": "`numDistinctRValues_collinearConfig` assembles the per-point counts R(xᵢ) = max(i, n-1-i): as i ranges over 0,…,n-1 these values are n-1, n-2, …, ⌈n/2⌉, …, n-2, n-1, taking exactly ⌈n/2⌉ distinct values. `g_ge_half` then concludes g(n) ≥ (n+1)/2 by le_csSup on the collinear witness. This is the file's strongest elementary bound — still a factor of 2 short of the conjectured (1-o(1))n, which the symmetric collinear construction provably cannot reach.",
+    "mathContext": "The multiset $\\{\\max(i, n-1-i) : 0 \\le i < n\\}$ has $\\lceil n/2 \\rceil$ distinct values, so $g(n) \\ge \\lceil n/2 \\rceil = \\lfloor (n+1)/2 \\rfloor$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ceiling of n/2",
+      "symmetric distance profile",
+      "le_csSup"
+    ],
+    "prerequisites": [
+      "distinct-distance counts per point",
+      "image cardinality of a symmetric function",
+      "Nat division (n+1)/2"
+    ]
+  },
+  {
+    "id": "e653oq01-ann-06",
+    "proofId": "erdos-653-oq-01",
+    "range": {
+      "startLine": 269,
+      "endLine": 293
+    },
+    "type": "concept",
+    "title": "Exact Values: Where Lower Meets Upper",
+    "content": "`g_zero`, `g_one`, `g_two`, `g_three` pin down g(0)=0, g(1)=1, g(2)=1, g(3)=2 — the first formalized exact values of g. Each is a one-line `omega` corollary combining a lower bound from this file (g_ge_one or g_ge_half) with an upper bound from the parent (g_le_n or the sharper g_le_n_sub_one). The bounds coincide only at these smallest arguments: g(4) already escapes, with g_le_n_sub_one giving g(4) ≤ 3 but g_ge_half giving only g(4) ≥ 2, so pinning g(4)=3 needs a certified 4-point construction.",
+    "mathContext": "$g(0)=0,\\; g(1)=1,\\; g(2)=1,\\; g(3)=2$; the elementary bounds give only $2 \\le g(4) \\le 3$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "exact extremal values",
+      "matching bounds",
+      "omega arithmetic"
+    ],
+    "prerequisites": [
+      "g_ge_one / g_ge_half",
+      "parent upper bounds g_le_n / g_le_n_sub_one",
+      "omega tactic on Nat"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-653-oq-01/meta.json
+++ b/src/data/proofs/erdos-653-oq-01/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "erdos-653-oq-01",
+  "title": "Erdős #653 OQ-01: Elementary Lower Bounds for g(n)",
+  "slug": "erdos-653-oq-01",
+  "description": "Erdős problem #653 asks for g(n), the maximum number of distinct R-values (R(xᵢ) = number of distinct distances from xᵢ) over n-point planar configurations; the main conjecture g(n) ≥ (1-o(1))n is OPEN. This companion to the parent entry supplies the verified elementary lower-bound side, axiom-free: the explicit collinear configuration (0,0),…,(n-1,0), the supremum framing of g, the first proved bound g(n) ≥ 1, the sharper g(n) ≥ ⌈n/2⌉ from counting distinct distances on the x-axis, and the exact small values g(0)=0, g(1)=1, g(2)=1, g(3)=2 obtained where the lower bounds meet the parent's upper bounds g(n) ≤ n-1. 17 theorems, 2 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "date": "1980s (Erdős)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos653LowerBound.lean",
+    "tags": [
+      "combinatorics",
+      "discrete-geometry",
+      "distinct-distances",
+      "erdos-problems",
+      "incidence-geometry"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "assumptions": "None. Every theorem in this file is fully machine-verified with 0 sorries and 0 axiom declarations. The file imports Erdos653Problem (which axiomatizes the deep literature bounds csizmadia_bound and upper_bound for the parent entry), but the lower-bound theorems here are independent of those axioms — they are constructive (le_csSup applied to the explicit collinear configuration). The open conjecture g(n) ≥ (1-o(1))n is OUT OF SCOPE and not assumed.",
+    "lineCount": 293,
+    "theoremCount": 17,
+    "definitionCount": 2,
+    "originalContributions": [
+      "collinearConfig / collinearConfig_card: the explicit n-point configuration (0,0),(1,0),…,(n-1,0) on the x-axis, proved to have exactly n distinct points — the reusable witness for any elementary lower bound on g",
+      "gSet / gSet_bddAbove / g_eq_sSup: the supremum-set framing of g(n), shown bounded above so that le_csSup applies",
+      "g_ge_one: the first PROVED lower bound g(n) ≥ 1 for n ≥ 1 (previously only asserted in a docstring)",
+      "numDistinctRValues_collinearConfig / g_ge_half: the sharper bound g(n) ≥ ⌈n/2⌉, from the verified fact that the i-th x-axis point sees max(i, n-1-i) distinct distances",
+      "g_zero, g_one, g_two, g_three: the first formalized EXACT values of g — 0, 1, 1, 2 — pinned down where these lower bounds meet the parent's upper bounds g(n) ≤ n-1"
+    ],
+    "sourceUrl": "https://erdosproblems.com/653"
+  },
+  "overview": {
+    "historicalContext": "Erdős problem #653 concerns the diversity of local distance-counts in a finite planar point set. For each point xᵢ let R(xᵢ) be the number of distinct distances from xᵢ to the other points; g(n) is the maximum, over all n-point configurations, of the number of distinct values among R(x₁),…,R(xₙ). Erdős conjectured g(n) ≥ (1-o(1))n — that one can make almost all the local distance-counts distinct. The problem remains open; the best known bounds are 0.7n < g(n) < n - c·n^(2/3) (Csizmadia for the lower side). This entry formalizes the elementary lower-bound end of that range.",
+    "problemStatement": "Determine g(n), the maximum number of distinct R-values over n-point planar configurations, where R(xᵢ) counts distinct distances from xᵢ. Main conjecture: g(n) ≥ (1-o(1))n (OPEN).",
+    "text": "The collinear configuration (0,0),(1,0),…,(n-1,0) is the natural elementary witness. On it, the distance from the i-th point to the j-th is |i-j|, so the i-th point sees exactly max(i, n-1-i) distinct distances. As i ranges over 0,…,n-1 these counts take ⌈n/2⌉ distinct values, giving g(n) ≥ ⌈n/2⌉. This is far from the conjectured (1-o(1))n but is fully constructive and axiom-free. Where it meets the parent file's upper bound g(n) ≤ n-1, the exact values g(2)=1 and g(3)=2 are pinned down; g(0),g(1) follow from g(n) ≤ n. The exact value g(4)=3 is NOT settled by these bounds (they give only 2 ≤ g(4) ≤ 3) and would need a certified 4-point construction.",
+    "proofStrategy": "Frame g(n) as sSup of the set gSet n of achievable distinct-R-value counts, show it is bounded above (so csSup behaves), then apply le_csSup with the explicit collinearConfig witness. The bound g(n) ≥ ⌈n/2⌉ reduces to counting the image of i ↦ max(i, n-1-i), done with Finset.image cardinality lemmas. Exact small values are one-line omega corollaries combining these lower bounds with the parent's g_le_n / g_le_n_sub_one upper bounds.",
+    "keyInsights": [
+      "The collinear configuration is the universal elementary witness: distances |i-j| make the distinct-distance count from each point explicit",
+      "The i-th of n collinear points sees max(i, n-1-i) distinct distances, and these counts realize exactly ⌈n/2⌉ distinct values",
+      "g is a supremum over configurations: lower bounds come from exhibiting ONE good configuration (le_csSup), upper bounds constrain ALL of them",
+      "Exact values of g emerge only where a lower-bound construction meets an upper-bound argument; g(4)=3 already escapes the elementary bounds",
+      "Importing a file with axioms does not contaminate axiom-free theorems: the constructive lower bounds never invoke csizmadia_bound"
+    ],
+    "prerequisites": [
+      "Conditionally complete lattices: sSup, le_csSup, BddAbove",
+      "Finset cardinality and image lemmas",
+      "Euclidean distance in ℝ² and the |i-j| formula for collinear points"
+    ]
+  },
+  "conclusion": {
+    "summary": "Verified, axiom-free elementary lower bounds for Erdős #653: g(n) ≥ 1, g(n) ≥ ⌈n/2⌉ via the explicit collinear configuration, and the exact values g(0)=0, g(1)=1, g(2)=1, g(3)=2. 17 theorems, 293 lines, 0 axioms, 0 sorries.",
+    "implications": "Establishes the constructive lower-bound floor for g(n) and the first formalized exact values, complementing the parent entry's upper bounds and axiomatized literature results. Provides reusable infrastructure (collinearConfig, the sSup framing) for any future elementary bound.",
+    "openQuestions": [
+      "The main conjecture g(n) ≥ (1-o(1))n (OPEN) — the elementary collinear construction gives only ⌈n/2⌉",
+      "Formalize the exact value g(4) = 3 via a certified 4-point construction (the elementary bounds give only 2 ≤ g(4) ≤ 3)",
+      "Formalize Csizmadia's g(n) > 0.7n lower bound, currently axiomatized in the parent file",
+      "Close the gap to the upper bound g(n) < n - c·n^(2/3)"
+    ]
+  },
+  "leanFile": {
+    "namespace": "Erdos653",
+    "lineCount": 293,
+    "axiomCount": 0,
+    "theoremCount": 17,
+    "definitionCount": 2,
+    "path": "Proofs/Erdos653LowerBound.lean",
+    "sorries": 0,
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.Erdos653Problem"
+    ],
+    "opens": [
+      "Finset",
+      "Real"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-653",
+      "relationship": "extends",
+      "description": "Parent entry: states g(n) ≤ n and the sharper g(n) ≤ n-1, plus the axiomatized literature bounds. This OQ-01 companion supplies the verified, axiom-free lower-bound side and the exact small values."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-01-construction",
+      "title": "The Collinear Configuration",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Header scoping the file to the elementary lower bound (the open conjecture is out of scope). collinearConfig n = the n points (0,0),…,(n-1,0); collinearConfig_card proves it has exactly n distinct points; collinearConfig_exists packages nonemptiness — the reusable witness for any lower bound on g."
+    },
+    {
+      "id": "sec-02-sup-framing",
+      "title": "Supremum Framing of g",
+      "startLine": 61,
+      "endLine": 94,
+      "summary": "gSet n is the set of achievable distinct-R-value counts; mem_gSet, g_eq_sSup, and gSet_bddAbove establish that g(n) = sSup (gSet n) with the set bounded above, so le_csSup applies. numDistinctRValues_pos gives positivity from any nonempty configuration."
+    },
+    {
+      "id": "sec-03-g-ge-one",
+      "title": "First Proved Lower Bound: g(n) ≥ 1",
+      "startLine": 95,
+      "endLine": 109,
+      "summary": "g_ge_one proves g(n) ≥ 1 for n ≥ 1 — the file's first proved lower bound, witnessed by any nonempty configuration with no appeal to distance values. Previously only a docstring claim in the parent file."
+    },
+    {
+      "id": "sec-04-distance-counts",
+      "title": "Distinct Distances on the x-axis",
+      "startLine": 110,
+      "endLine": 218,
+      "summary": "euclidDist_collinearPoint verifies dist = |i-j| for x-axis points; maxCount_image_card, absDiff_image_eq, and distinctDistCount_collinearConfig count the distinct distances from the i-th point as max(i, n-1-i) via Finset.image cardinality."
+    },
+    {
+      "id": "sec-05-g-ge-half",
+      "title": "Sharper Bound: g(n) ≥ ⌈n/2⌉",
+      "startLine": 219,
+      "endLine": 268,
+      "summary": "numDistinctRValues_collinearConfig assembles the per-point counts into ⌈n/2⌉ distinct R-values overall, and g_ge_half concludes g(n) ≥ (n+1)/2 via le_csSup on the collinear witness."
+    },
+    {
+      "id": "sec-06-exact-values",
+      "title": "Exact Small Values of g",
+      "startLine": 269,
+      "endLine": 293,
+      "summary": "g_zero, g_one, g_two, g_three pin g(0)=0, g(1)=1, g(2)=1, g(3)=2 where the lower bounds meet the parent's upper bounds (one-line omega corollaries). g(4) is noted to escape the elementary bounds (only 2 ≤ g(4) ≤ 3)."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-653-oq-01.json
+++ b/src/data/research/problems/erdos-653-oq-01.json
@@ -37,15 +37,15 @@
     "nextSteps": [
       "No actionable elementary Lean work remains: g_le_n, g_le_n_sub_one, g_ge_one, g_ge_half are all proved and registered. Do NOT re-attempt distinctDistCount_collinearConfig / maxCount_image_card — already proved.",
       "OPEN (out of single-session scope): the conjecture erdos653Conjecture (g(n)/n -> 1). Needs the deep 2-D constructions behind csizmadia_bound and improvements; not elementary.",
-      "Optional verify-only: confirm a green Docker build of Proofs.Erdos653LowerBound + Proofs.Erdos653Problem when Docker is free (<=2 containers) to corroborate the 0-axiom/0-sorry lower-bound file."
+      "DONE (r3, 2026-06-19): green Docker build of Proofs.Erdos653LowerBound confirmed (3066 jobs) + axiom-checked 0-axiom; gallery entry erdos-653-oq-01 created. The verify-only step is complete."
     ],
     "progressSummary": "STATE-SYNC (researcher-4, 2026-06-15, blackout): correcting a stale knowledge record. ALL prior nextSteps are DONE on main. Erdos653LowerBound.lean is COMPLETE (0 axioms / 0 sorries): g_ge_half (g(n) >= ceil(n/2)) is fully proved, including the L1 real-arithmetic bridge distinctDistCount_collinearConfig that the old summary still listed as remaining. Erdos653Problem.lean has g_le_n and g_le_n_sub_one as PROVED theorems (g_le_n discharged from axiom) and exactly 2 deep cited axioms (csizmadia_bound, upper_bound) correctly kept. The elementary program for oq-01 is finished; only the OPEN conjecture g(n)/n->1 remains, out of scope. Both files registered (Proofs.lean:1803-1804). Note: open PRs #24404/#24302 (discharge g_le_n) are superseded — g_le_n is already a theorem on main."
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-15T00:00:00Z",
-    "iteration": 3,
-    "focus": "S3: new companion Erdos653LowerBound.lean (registered) — collinearConfig n + card proof, gSet BddAbove, and g_ge_one, the file's FIRST proved lower bound (was a docstring-only claim), plus verified euclidDist ![i,0] ![j,0] = |i-j| seeding the deferred g_ge_half (ceil(n/2)). The g_le_n discharge is saturated (PRs #24302/#24404/#24417). Build-pending under dual blackout (Docker + Aristotle down)."
+    "since": "2026-06-19T05:30:00Z",
+    "iteration": 4,
+    "focus": "S4 (r3): build-VERIFIED Proofs.Erdos653LowerBound green under the current Mathlib pin (3066 jobs) — clearing the earlier build-pending/blackout status and confirming no bitrot. Axiom-checked g_ge_one, g_ge_half, numDistinctRValues_collinearConfig, g_three, collinearConfig_card: all depend only on {propext, Classical.choice, Quot.sound} — the imported parent's csizmadia_bound/upper_bound axioms are NOT pulled in, so the lower-bound companion is genuinely 0-axiom. Created the gallery entry src/data/proofs/erdos-653-oq-01/ (meta.json + 6 annotations, badge verified) which was previously missing. The main conjecture g(n) ≥ (1-o(1))n stays OPEN and out of scope."
   },
   "tags": [
     "combinatorics",


### PR DESCRIPTION
## Summary

The verified, axiom-free lower-bound companion `Proofs/Erdos653LowerBound.lean` (already merged to `main` and registered in `Proofs.lean`) had **no gallery representation** — the parent entry `erdos-653` is keyed to `Erdos653Problem.lean`. This PR adds the missing entry and corroborates it with a fresh build + axiom check.

## What's added

- `src/data/proofs/erdos-653-oq-01/meta.json` + `annotations.json` (6 annotations, each with prerequisites), `badge: verified`, covering:
  - `collinearConfig` — the explicit n-point witness (0,0),…,(n-1,0)
  - the `sSup` framing of `g` (`gSet`, `gSet_bddAbove`, `g_eq_sSup`)
  - `g_ge_one` — first proved lower bound `g(n) ≥ 1`
  - `g_ge_half` — `g(n) ≥ ⌈n/2⌉` from counting distinct distances on the x-axis
  - `g_zero..g_three` — first formalized exact values `g(0)=0, g(1)=1, g(2)=1, g(3)=2`

## Verification

- **Docker build green**: `Proofs.Erdos653LowerBound`, 3066 jobs, Lean v4.26.0. This clears the registry's earlier *build-pending under dual blackout* status (the file had been merged without a confirmed green build) and confirms no bitrot.
- **Axiom check**: `g_ge_one`, `g_ge_half`, `numDistinctRValues_collinearConfig`, `g_three`, `collinearConfig_card` all depend only on `propext, Classical.choice, Quot.sound`. The file imports `Erdos653Problem` (which axiomatizes `csizmadia_bound`/`upper_bound` for the parent), but the lower-bound theorems do **not** pull those in — they are constructive (`le_csSup` on the explicit configuration). Hence `axiomCount: 0`, `badge: verified` is honest.

## Scope

Lean source is unchanged (already on `main`); this PR is gallery data + a registry progress note only. The **main conjecture `g(n) ≥ (1-o(1))n` stays OPEN** and is listed under open questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)