### PR TITLE
research(kepler-conjecture-oq-04): sync stale theoremCount 8→11

### DIFF
--- a/src/data/proofs/kepler-conjecture-oq-04/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-04/meta.json
@@ -181,6 +181,6 @@
       "description": "Ehrhart theory counts lattice points in polytope dilations, complementing the volumetric density theory of Kepler/Hales; the 4000/4671 dimer construction is polytopal and interfaces naturally with Ehrhart techniques."
     }
   ],
-  "theoremCount": 8,
+  "theoremCount": 11,
   "definitionCount": 6
 }


### PR DESCRIPTION
## Summary

Fixes an internal inconsistency in `src/data/proofs/kepler-conjecture-oq-04/meta.json`: `meta.theoremCount` was already `11` but the top-level `theoremCount` field was a stale `8` (the S7-era count, before three theorems — `fccDensity_lt_35329_div_46710`, `tetrahedronDimerDensity_gt_fccDensity_margin`, `ellipsoid_lattice_lt_tetrahedronDimer` — were added in later iterations).

## Verification

`Proofs/KeplerConjectureOQ04.lean` has **11** real theorem declarations: `grep '^theorem '` returns 13, of which 2 (L194, L316) are docstring lines beginning "theorem shows…" inside `/- … -/` comment blocks. The remaining 11 are genuine declarations. This matches the already-correct `meta.theoremCount: 11`.

Metadata-only change; no Lean source touched. The problem itself is structurally closed (8→11 theorems / 2 statement axioms / 0 sorries) with the main non-spherical-packing questions remaining open as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)