### PR TITLE
Enrich erdos-470: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-470/annotations.json
+++ b/src/data/proofs/erdos-470/annotations.json
@@ -17,7 +17,11 @@
       "pseudoperfect numbers",
       "subset sum problem"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "divisor sum function",
+      "abundant numbers",
+      "subset sum problem"
+    ]
   },
   {
     "id": "ann-e470-imports",
@@ -36,14 +40,18 @@
       "finite sets"
     ],
     "mathContext": "See annotation content for formal details of mathlib imports",
-    "prerequisites": []
+    "prerequisites": [
+      "Lean 4",
+      "Mathlib",
+      "divisor functions"
+    ]
   },
   {
     "id": "ann-e470-sigma",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 45,
-      "endLine": 48
+      "startLine": 49,
+      "endLine": 49
     },
     "type": "definition",
     "title": "The Divisor Sum Function",
@@ -55,14 +63,18 @@
       "divisor function",
       "Finset.sum"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "divisor functions",
+      "multiplicative functions",
+      "Finset.sum"
+    ]
   },
   {
     "id": "ann-e470-abundant",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 50,
-      "endLine": 54
+      "startLine": 55,
+      "endLine": 55
     },
     "type": "definition",
     "title": "Abundant Numbers",
@@ -74,14 +86,18 @@
       "deficient numbers",
       "abundancy index"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "divisor sum function",
+      "perfect numbers",
+      "abundancy index"
+    ]
   },
   {
     "id": "ann-e470-pseudoperfect",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 56,
-      "endLine": 61
+      "startLine": 61,
+      "endLine": 67
     },
     "type": "definition",
     "title": "Pseudoperfect (Semiperfect) Numbers",
@@ -93,14 +109,18 @@
       "proper divisors",
       "existential quantifier"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "subset sum problem",
+      "proper divisors",
+      "existential quantifiers"
+    ]
   },
   {
     "id": "ann-e470-weird",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 63,
-      "endLine": 68
+      "startLine": 69,
+      "endLine": 69
     },
     "type": "definition",
     "title": "Weird Numbers",
@@ -112,14 +132,18 @@
       "negation",
       "OEIS A006037"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "abundant numbers",
+      "pseudoperfect numbers",
+      "logical negation"
+    ]
   },
   {
     "id": "ann-e470-seventy",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 70,
-      "endLine": 100
+      "startLine": 94,
+      "endLine": 117
     },
     "type": "concept",
     "title": "70 is the Smallest Weird Number",
@@ -131,7 +155,11 @@
       "subset enumeration",
       "smallest example"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "exhaustive search",
+      "subset enumeration",
+      "divisor functions"
+    ]
   },
   {
     "id": "ann-e470-oeis",
@@ -150,7 +178,11 @@
       "computational evidence",
       "parity"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "OEIS",
+      "computational number theory",
+      "parity"
+    ]
   },
   {
     "id": "ann-e470-odd-weird",
@@ -169,7 +201,11 @@
       "parity",
       "Erdos bounty"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "parity",
+      "abundant numbers",
+      "open problems"
+    ]
   },
   {
     "id": "ann-e470-fang",
@@ -188,7 +224,11 @@
       "exhaustive search",
       "algorithmic number theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "computational bounds",
+      "exhaustive search",
+      "algorithmic number theory"
+    ]
   },
   {
     "id": "ann-e470-liddy-riedl",
@@ -207,7 +247,11 @@
       "structural constraints",
       "omega function"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "prime factorization",
+      "omega function",
+      "structural constraints"
+    ]
   },
   {
     "id": "ann-e470-primitive",
@@ -226,7 +270,11 @@
       "proper divisors",
       "generating weird numbers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "proper divisors",
+      "primitive elements",
+      "weird numbers"
+    ]
   },
   {
     "id": "ann-e470-part2",
@@ -245,7 +293,11 @@
       "open problem",
       "primitive elements"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "infinite sets",
+      "primitive elements",
+      "open problems"
+    ]
   },
   {
     "id": "ann-e470-melfi",
@@ -264,7 +316,11 @@
       "Cramer's conjecture",
       "conditional results"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "prime gaps",
+      "Cramér's conjecture",
+      "conditional results"
+    ]
   },
   {
     "id": "ann-e470-density",
@@ -283,7 +339,11 @@
       "natural density",
       "probabilistic number theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "asymptotic density",
+      "natural density",
+      "probabilistic number theory"
+    ]
   },
   {
     "id": "ann-e470-abundancy",
@@ -302,7 +362,11 @@
       "Erdos #825",
       "parity constraints"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "abundancy index",
+      "divisor sum function",
+      "parity constraints"
+    ]
   },
   {
     "id": "ann-e470-why-70",
@@ -321,7 +385,11 @@
       "subset sum",
       "verification"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "subset sum problem",
+      "case analysis",
+      "divisor functions"
+    ]
   },
   {
     "id": "ann-e470-summary",
@@ -340,6 +408,10 @@
       "Open problem"
     ],
     "mathContext": "See annotation content for formal details of summary theorem",
-    "prerequisites": []
+    "prerequisites": [
+      "weird numbers",
+      "partial results",
+      "theorem composition"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for erdos-470 (Erdős Problem #470: Weird Numbers).

## Changes
- Added `prerequisites` arrays to all 18 annotations (previously all empty `[]`). Each reflects the specific background (e.g. divisor functions / multiplicative functions for sigma, subset sum problem for pseudoperfectness, prime gaps / Cramér's conjecture for Melfi's conditional result, probabilistic number theory for the Benkoski-Erdős density theorem).
- Fixed 5 stale annotation ranges (sigma, IsAbundant, IsPseudoperfect, IsWeird, and the '70 is smallest' block) that had drifted off their Lean constructs after the source file was restructured/expanded.

## Validation
- `pnpm build` produces no errors for erdos-470 (5 prior 'No Lean construct found' warnings resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)