### PR TITLE
research(buffons-needle-oq-01-oq-02-oq-02): sync stale lineCount 394→410 + graduate

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-02-oq-02/meta.json
@@ -25,7 +25,7 @@
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,
-    "lineCount": 394,
+    "lineCount": 410,
     "assumptions": "0 axioms, 0 sorries. Machine-checked via ./proofs/scripts/docker-build.sh Proofs.BuffonConstantAsymptotic (Lean v4.26.0, Mathlib pin 2df2f01, 7743 jobs, 0 errors). Registered in proofs/Proofs.lean. The asymptotic is additionally validated numerically (lgamma, n up to 1e6: relative error scales as 0.25/n).",
     "mathlibDependencies": [
       {
@@ -159,7 +159,7 @@
       "Topology"
     ],
     "namespace": "BuffonOQ010202",
-    "lineCount": 394,
+    "lineCount": 410,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,


### PR DESCRIPTION
## Summary

The Buffon hyperplane-constant asymptotic proof (`c_n \sim \sqrt{2/(\pi n)}`) is **already fully verified and registered on main**: `proofs/Proofs/BuffonConstantAsymptotic.lean`, 0 sorry, 0 axiom, 15 theorems, 2 definitions, machine-checked (docker-build GREEN, Lean v4.26.0, Mathlib pin 2df2f01, 7743 jobs).

This session is a **metadata-accuracy fix + graduation**:

- The Lean file grew from 394 → 410 lines via the later `ba8c7382927` ("document Kershaw sharpening") commit, but `meta.json` `lineCount` (both `.meta.lineCount` and `.leanFile.lineCount`) was left stale at 394. Synced to the actual `wc -l` = 410.
- All other counts already correct (theoremCount 15, definitionCount 2, axiomCount 0, sorries 0 — all verified against the source).
- Problem graduated to COMPLETED in the research registry.

No code or proof change — the proof was complete since #24732 (verify+register), extended by #25966 (effective bound) and #25971 (Kershaw doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)