### PR TITLE
research(dirichlet-approximation-theorem-oq-02): register simultaneous Dirichlet proof in CI + research registry

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -655,6 +655,7 @@ import Proofs.DescartesRuleOfSignsOQ04
 import Proofs.DilworthTheoremOQ01
 import Proofs.DirichletApproximation
 import Proofs.DirichletApproximationOQ01
+import Proofs.DirichletApproximationOQ02
 import Proofs.DirichletsTheorem
 import Proofs.DirichletsTheoremOQ01
 import Proofs.DirichletsTheoremOQ01OQ01

--- a/src/data/research/problems/dirichlet-approximation-theorem-oq-02.json
+++ b/src/data/research/problems/dirichlet-approximation-theorem-oq-02.json
@@ -1,0 +1,74 @@
+{
+  "slug": "dirichlet-approximation-theorem-oq-02",
+  "title": "Simultaneous Dirichlet approximation: one denominator for several reals",
+  "problemStatement": "Extend the parent one-dimensional Dirichlet pigeonhole bound to the simultaneous (higher-dimensional) form: for real numbers θ₁,…,θ_d and any Q ≥ 1 there exist a single common denominator q with 1 ≤ q ≤ Q^d and integers p₁,…,p_d such that |q·θᵢ − pᵢ| ≤ 1/Q for every coordinate i at once. The one common q serves all d coordinates simultaneously, at the cost of enlarging the denominator range from Q to Q^d. This is the foundational input to the geometry of numbers and the theory of badly approximable systems (answers the third open question of OQ-01).",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "significance": 6,
+  "tractability": 6,
+  "path": "full",
+  "started": "2026-06-19",
+  "lastUpdate": "2026-06-19",
+  "tags": [
+    "number-theory",
+    "diophantine-approximation",
+    "simultaneous-approximation",
+    "geometry-of-numbers",
+    "pigeonhole-principle",
+    "torus",
+    "haar-measure"
+  ],
+  "currentState": {
+    "summary": "Formalized and build-verified. The simultaneous theorem is realized as Mathlib's abstract group-theoretic Dirichlet theorem NormedAddCommGroup.exists_norm_nsmul_le read on the d-torus 𝕋^d = (Fin d → AddCircle 1). 1 theorem, 0 sorry, 0 axiom (only the foundational propext/Classical.choice/Quot.sound; no Lean.ofReduceBool). File registered in Proofs.lean this session.",
+    "leanFile": "proofs/Proofs/DirichletApproximationOQ02.lean",
+    "sorries": 0,
+    "axioms": 0
+  },
+  "knowledge": {
+    "insights": [
+      "Simultaneous Dirichlet IS pigeonhole on the torus: the d-dimensional theorem is not a new combinatorial argument but the single abstract statement NormedAddCommGroup.exists_norm_nsmul_le (Dirichlet for any compact connected normed additive group with Haar measure) read on 𝕋^d = (Fin d → AddCircle 1). Once the ambient group is the torus, the geometry-of-numbers box-counting is Mathlib's existing proof.",
+      "The supremum norm makes simultaneity automatic: on the product torus ‖q • ξ‖ = maxᵢ ‖(q • ξ)ᵢ‖, so a single bound ‖q • ξ‖ ≤ 1/Q is by definition a bound on every coordinate at once — norm_le_pi_norm is the only step needed to recover the d simultaneous estimates.",
+      "The denominator range Q^d is exactly the box count: the abstract theorem's parameter n is the number of pigeonholes; choosing n = Q^d makes the measure inequality 1 ≤ (Q^d+1)(1/Q)^d hold, and is precisely why the simultaneous denominator can be as large as Q^d.",
+      "round is the nearest-integer witness: AddCircle.norm_eq at period 1 states ‖x‖ = |x − round x|, so the integer pᵢ realizing the approximation is literally round(q·θᵢ) — the formalization extracts the witnesses with no separate construction.",
+      "The measure hypothesis is a one-line volume product: discharging the abstract theorem reduces, through volume_pi_closedBall and AddCircle.volume_closedBall, to the scalar inequality 1 ≤ (Q^d + 1)(1/Q)^d — no analytic content beyond a Haar-volume computation on a product of circles."
+    ],
+    "builtItems": [
+      "simultaneous_dirichlet_approximation (DirichletApproximationOQ02.lean:49) — the simultaneous Dirichlet approximation theorem: for θ : Fin d → ℝ and Q ≥ 1, a single denominator q ∈ [1, Q^d] and integer vector p : Fin d → ℤ with |q·θᵢ − pᵢ| ≤ 1/Q for every i at once.",
+      "In-file: reduction to NormedAddCommGroup.exists_norm_nsmul_le by instantiating the ambient group as the d-torus (Fin d → AddCircle 1); the product measure computation discharging its hypothesis (vol(𝕋^d)=1 via Measure.pi_univ + UnitAddCircle.measure_univ; vol(closedBall 0 (δ/2)) = (ofReal δ)^d via volume_pi_closedBall + AddCircle.volume_closedBall); and the coordinatewise readout via AddCircle.norm_eq + norm_le_pi_norm.",
+      "Registered import Proofs.DirichletApproximationOQ02 in proofs/Proofs.lean so the entry is part of the CI build."
+    ],
+    "mathlibGaps": [
+      "Mathlib has the abstract Dirichlet theorem NormedAddCommGroup.exists_norm_nsmul_le but no packaged simultaneous-approximation corollary on the torus; this entry supplies that specialization and the product measure computation discharging its hypothesis.",
+      "No Mathlib statement of the dual (transference) form or the linearly-independent infinitude refinement in the simultaneous setting."
+    ],
+    "nextSteps": [
+      "Upgrade to the infinitude statement in the simultaneous setting: for 1, θ₁,…,θ_d linearly independent over ℚ, infinitely many denominators q with maxᵢ |q·θᵢ − pᵢ| < q^{-1/d} (simultaneous analogue of OQ-01).",
+      "Derive the dual form (one linear form q·θ close to an integer with bounded integer coefficients) from the same torus pigeonhole, toward Khintchine's transference inequalities in Lean.",
+      "Sharpen ≤ 1/Q to a strict inequality and restate the denominator bound in the sharper exponent form q ≤ N with error < N^{-1/d}."
+    ],
+    "progressSummary": "COMPLETE: simultaneous Dirichlet approximation formalized (1 theorem, 0 sorry, 0 axiom) as Mathlib's abstract Dirichlet theorem on the d-torus, and registered in the CI build this session."
+  },
+  "approaches": [
+    {
+      "name": "Specialize Mathlib's abstract Dirichlet theorem to the d-torus",
+      "outcome": "success",
+      "notes": "NormedAddCommGroup.exists_norm_nsmul_le applied to ξ : Fin d → AddCircle 1 with n = Q^d, δ = 1/Q; measure hypothesis discharged by the product computation, sup-norm bound dropped to coordinates by norm_le_pi_norm, witnesses pᵢ = round(q·θᵢ) via AddCircle.norm_eq."
+    }
+  ],
+  "knownResults": [
+    "Dirichlet (1842): one-shot one-dimensional pigeonhole bound (parent entry).",
+    "Simultaneous Dirichlet theorem: geometry-of-numbers box-counting on the d-torus; foundational to badly approximable systems and the Littlewood conjecture.",
+    "Mathlib: NormedAddCommGroup.exists_norm_nsmul_le (abstract Dirichlet theorem in a compact normed group with Haar measure)."
+  ],
+  "references": [
+    "Mathlib/NumberTheory/WellApproximable.lean (NormedAddCommGroup.exists_norm_nsmul_le)",
+    "Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean (AddCircle.volume_closedBall)",
+    "Mathlib/Analysis/Normed/Group/AddCircle.lean (AddCircle.norm_eq)",
+    "https://en.wikipedia.org/wiki/Dirichlet%27s_approximation_theorem"
+  ],
+  "relatedProofs": [
+    "dirichlet-approximation-theorem (parent, one-shot one-dimensional bound)",
+    "dirichlet-approximation-theorem-oq-01 (sibling, infinitude upgrade in dimension 1)"
+  ]
+}


### PR DESCRIPTION
## Summary

The **simultaneous (d-dimensional) Dirichlet approximation theorem** (`simultaneous_dirichlet_approximation`) was already on `main` — a complete, **0-sorry / 0-axiom** proof with a fully-enriched gallery `meta.json` (landed via #26132) — but it was **never registered in `Proofs.lean`** (so it never built in CI) and had **no research problem JSON**. This PR closes both gaps.

For `θ : Fin d → ℝ` and `Q ≥ 1`: a single common denominator `q ∈ [1, Q^d]` and integers `pᵢ` with `|q·θᵢ − pᵢ| ≤ 1/Q` for **every** coordinate `i` at once.

## Changes
- `proofs/Proofs.lean`: `import Proofs.DirichletApproximationOQ02`
- `src/data/research/problems/dirichlet-approximation-theorem-oq-02.json` (new research registry entry)

## Verification
Build-verified GREEN locally (docker, `LEAN_MEMORY_LIMIT=8192`):
```
⚠ [7743/7743] Built Proofs.DirichletApproximationOQ02 (10s)
Build completed successfully (7743 jobs).
=== Build succeeded ===
```
0 sorry / 0 axiom (only two harmless unused-simp-argument linter warnings). No `Lean.ofReduceBool`; only foundational `propext`/`Classical.choice`/`Quot.sound`.

## Approach
The proof realizes simultaneous Dirichlet as Mathlib's abstract `NormedAddCommGroup.exists_norm_nsmul_le` read on the d-torus `(Fin d → AddCircle 1)`. The measure hypothesis collapses to the product computation `1 ≤ (Q^d+1)(1/Q)^d` (via `volume_pi_closedBall`, `AddCircle.volume_closedBall`, `UnitAddCircle.measure_univ`), and `norm_le_pi_norm` drops the single sup-norm bound `‖q • ξ‖ ≤ 1/Q` to all `d` coordinates simultaneously; witnesses are `pᵢ = round(q·θᵢ)` via `AddCircle.norm_eq`.

## Note
Supersedes the stale, **conflicting draft PR #25988**, which carries a manual `intervalMapMulti` pigeonhole on a now-diverged copy of the file. This PR uses the cleaner Mathlib-abstract version already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)