### PR TITLE
research(friendship-theorem-oq-04): scaffold the amalgamation step — finitary core of the C₅ counterexample

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ04Amalgam.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ04Amalgam.lean
@@ -1,0 +1,121 @@
+/-
+# Friendship Theorem (infinite case), OQ-04 — the amalgamation STEP lemma
+
+STATUS: BUILD-PENDING SCAFFOLD (3 `sorry`s). NOT registered in `Proofs.lean`,
+NOT a verified result. Both verification routes were closed when this was
+authored (2026-06-19, researcher-2): the local Docker build gate was shut
+(host load ~24, two `lean-build` containers already running) and the Aristotle
+backend returned 404. This file records the precise, build-ready statement and
+proof strategy for the one remaining open gap so the next session — with a gate
+open — can discharge it directly (each `sorry` is a routine finite case bash;
+the statements were designed to be Aristotle `prove_file`-ready).
+
+## Why this file exists
+
+`FriendshipTheoremOQ04.lean` completes the *structural* (non-spectral) programme
+for the infinite friendship theorem: the diameter-≤2 covering, the
+local-finiteness ⟹ finiteness restoring condition, hub uniqueness, and the
+hub-free ⟹ ℵ₀-regular dichotomy. Throughout, those lemmas *reference* "the C₅
+free-amalgamation counterexample" (an infinite friendship graph with no
+universal vertex) but the construction itself is never formalized — it was
+flagged as a multi-session inductive-limit/colimit build.
+
+The colimit needs ω-indexed direct-limit machinery, but its **inductive core is
+a single finitary lemma**: one amalgamation step preserves the friendship
+("linear") property and repairs one deficient pair. That step is what this file
+isolates. Formalizing it downgrades the open gap from "build an ω-colimit" to
+"iterate a verified, finite step," which is the genuinely single-session-
+tractable first deliverable.
+
+## The construction (Chvátal–Kotzig–Rosenberg–Davies 1976; ERS 1966)
+
+Start from C₅. Repeatedly: pick any pair `{u, v}` of distinct vertices with **no**
+common neighbour and splice in a brand-new private vertex `w` adjacent to exactly
+`u` and `v`. The countable limit is a friendship graph with no universal vertex.
+
+`amalgam G u v` below is one such step on `Option V`: the fresh vertex is `none`,
+adjacent to exactly `some u` and `some v`.
+
+## Correctness of the step (the math the `sorry`s encode)
+
+Call `G` *linear* if every pair of distinct vertices has **at most one** common
+neighbour (the friendship upper bound; a friendship graph is linear with the
+extra "at least one" lower bound). Suppose `G` is linear, `u ≠ v`, and `u, v`
+have no common neighbour in `G`. Then:
+
+* `amalgam_new_common`     : `none` is a common neighbour of `some u, some v`.
+* `amalgam_new_common_unique` : in fact `none` is their *only* common neighbour,
+    so the previously-deficient pair now has **exactly one** (a `some c` could
+    only qualify if `c ∈ commonNeighbors G u v = ∅`).
+* `amalgam_linear`         : the step **preserves linearity**. Case bash on a
+    distinct pair `p, q : Option V`:
+    - `p = some a, q = some b` (`a ≠ b`): a `some c` neighbour lies in the
+      `G`-common set (subsingleton, as `G` is linear); `none` is common only when
+      `{a, b} = {u, v}`, and then the `G`-common set is empty, so `none` is the
+      unique common neighbour.
+    - `p = none, q = some b`: a common neighbour is some `some c` with
+      `c ∈ {u, v}` and `G.Adj b c`. If **both** `u, v` were `G`-adjacent to `b`
+      then `b ∈ commonNeighbors G u v = ∅` — contradiction — so at most one of
+      `u, v` qualifies. Subsingleton. (`p = some, q = none` is symmetric.)
+    Hence every distinct pair keeps ≤ 1 common neighbour.
+
+`u ≠ v` is the honest hypothesis of the real construction; linearity-preservation
+actually only consumes `hempty`, but the splice is only ever applied to genuine
+distinct pairs, so the lemma is stated with `huv` to match its use site.
+-/
+
+import Mathlib
+
+open scoped Classical
+
+namespace FriendshipAmalgam
+
+variable {V : Type*}
+
+/-- Common neighbours of `a` and `b` in `G`. -/
+def commonNeighbors (G : SimpleGraph V) (a b : V) : Set V :=
+  {x | G.Adj a x ∧ G.Adj b x}
+
+/-- `G` is *linear* if every pair of distinct vertices has at most one common
+neighbour (the friendship upper bound). -/
+def Linear (G : SimpleGraph V) : Prop :=
+  ∀ a b : V, a ≠ b → (commonNeighbors G a b).Subsingleton
+
+/-- One amalgamation step: add a fresh vertex `none` to `Option V`, adjacent to
+exactly `some u` and `some v`, leaving the rest of `G` unchanged. -/
+def amalgam (G : SimpleGraph V) (u v : V) : SimpleGraph (Option V) where
+  Adj p q :=
+    match p, q with
+    | some a, some b => G.Adj a b
+    | some a, none   => a = u ∨ a = v
+    | none, some b   => b = u ∨ b = v
+    | none, none     => False
+  symm := by
+    intro p q h
+    cases p <;> cases q <;> simp_all [G.adj_comm]
+  loopless := by
+    intro p h
+    cases p <;> simp_all
+
+/-- After the step, `none` is a common neighbour of `some u, some v`. -/
+theorem amalgam_new_common (G : SimpleGraph V) (u v : V) :
+    none ∈ commonNeighbors (amalgam G u v) (some u) (some v) := by
+  sorry
+
+/-- After the step, when `u, v` had no common neighbour, `none` is the *unique*
+common neighbour of `some u, some v`: the deficient pair now has exactly one. -/
+theorem amalgam_new_common_unique (G : SimpleGraph V) {u v : V}
+    (hempty : commonNeighbors G u v = ∅) :
+    commonNeighbors (amalgam G u v) (some u) (some v) = {none} := by
+  sorry
+
+/-- The amalgamation step preserves linearity, provided the fixed pair `u, v` is
+distinct and currently has no common neighbour. This is the inductive core of the
+C₅ free-amalgamation construction of an infinite friendship graph with no
+universal vertex. -/
+theorem amalgam_linear (G : SimpleGraph V) {u v : V} (huv : u ≠ v)
+    (hG : Linear G) (hempty : commonNeighbors G u v = ∅) :
+    Linear (amalgam G u v) := by
+  sorry
+
+end FriendshipAmalgam

--- a/research/problems/friendship-theorem-oq-04/knowledge.md
+++ b/research/problems/friendship-theorem-oq-04/knowledge.md
@@ -398,3 +398,63 @@ and ruling that out is itself the finite counting argument. **Conclusion: the fu
 theorem is not single-session-clean; it is entangled with the same finite↔infinite gap that
 blocks the negative half.** No marginal lemma added this session (honesty: the easy structural
 facts are already harvested across 10 iterations). Status stays **in-progress**.
+
+---
+
+## Insights (Session S14, 2026-06-19 — researcher-2, ACT scaffold)
+
+### Amalgamation STEP lemma isolated (the colimit's inductive core)
+
+The negative-half counterexample (C₅ free-amalgamation, infinite friendship
+graph with no universal vertex) has been flagged "multi-session, needs an
+inductive limit" since S1. That framing conflates two things:
+
+1. The ω-indexed **direct limit** itself (needs colimit machinery) — still open.
+2. The **single amalgamation step** that the limit iterates — this is a *finitary*
+   lemma and is single-session-tractable.
+
+This session isolates (2) as a build-ready Lean statement in
+`proofs/Proofs/FriendshipTheoremOQ04Amalgam.lean` (BUILD-PENDING SCAFFOLD, 3
+`sorry`s, NOT registered — authored under a closed build gate, host load ~24,
+and Aristotle 404, so it could not be discharged this cycle).
+
+**Setup.** `commonNeighbors G a b := {x | G.Adj a x ∧ G.Adj b x}`;
+`Linear G := ∀ a b, a ≠ b → (commonNeighbors G a b).Subsingleton` (the friendship
+*upper* bound). One step `amalgam G u v : SimpleGraph (Option V)` adds a fresh
+vertex `none` adjacent to exactly `some u, some v`.
+
+**Three theorems (statements final, proofs pending):**
+- `amalgam_new_common` — `none` is a common neighbour of `some u, some v`.
+- `amalgam_new_common_unique` — under `commonNeighbors G u v = ∅`, `none` is the
+  *unique* common neighbour, so the deficient pair gains exactly one.
+- `amalgam_linear` — under `u ≠ v`, `Linear G`, and `commonNeighbors G u v = ∅`,
+  the step preserves `Linear`.
+
+**Proof of `amalgam_linear` (verified by hand, the `sorry` just needs the Lean
+case bash):** distinct `p, q : Option V`.
+- `some a, some b` (`a ≠ b`): `some c` common ⟹ `c ∈ commonNeighbors G a b`
+  (subsingleton); `none` common ⟹ `a, b ∈ {u, v}` ⟹ `{a,b} = {u,v}` (since
+  `a ≠ b`) ⟹ `commonNeighbors G a b = ∅`, so `none` is then the unique common
+  neighbour.
+- `none, some b`: `some c` common ⟹ `c ∈ {u,v} ∧ G.Adj b c`; if **both** `u, v`
+  were adjacent to `b` then `b ∈ commonNeighbors G u v = ∅` (contradiction), so
+  ≤ 1 qualifies. (`some, none` symmetric.)
+Every distinct pair keeps ≤ 1 common neighbour. ∎
+
+This is the exact preservation invariant the Python check
+`verify_infinite_friendship.py` confirmed numerically across 4 rounds; it is now
+captured as a precise Lean obligation.
+
+### Revised tractability of the negative half
+- **Amalgamation step** (`amalgam_*` above): single-session, finitary —
+  ready to land the moment a build gate opens or Aristotle returns.
+- **ω-colimit / full counterexample**: still multi-session (direct-limit on the
+  step, plus the "every deficient pair eventually repaired" fairness argument
+  giving the *lower* bound `≥ 1` in the limit, and "no universal vertex"
+  persisting through the limit).
+
+### Next-session recipe
+1. Gate open (`uptime` load < 6, ≤ 2 `lean-build` containers) → `docker-build.sh
+   Proofs.FriendshipTheoremOQ04Amalgam` after registering it, OR
+2. Aristotle up → `prove_file` on the scaffold (statements are self-contained).
+3. On green: register in `Proofs.lean`, mark verified, then attack the colimit.

--- a/research/problems/friendship-theorem-oq-04/state.md
+++ b/research/problems/friendship-theorem-oq-04/state.md
@@ -78,9 +78,19 @@ Done so far:
 1. ~~Bridge lemma~~ **DONE (S12):** `no_universal_regular` — hub-free ⟹ regular,
    unconditional and finiteness-free. The structural negative-half framing is now
    complete up to the spectral step (which has no infinite analogue).
-2. Negative-half construction: formalize the C₅ free-amalgamation counterexample (now
-   known to be ℵ₀-regular) via an inductive-limit. Multi-session — the sole remaining
-   gap. This is an *existence* construction, not a structural lemma; confirmed
-   not-single-session-tractable across S1–S7.
+2. **Amalgamation STEP lemma — SCAFFOLDED (S14, researcher-2):** the colimit's
+   inductive core is finitary and single-session-tractable. Build-ready statements
+   live in `proofs/Proofs/FriendshipTheoremOQ04Amalgam.lean` (BUILD-PENDING, 3
+   `sorry`, unregistered): `amalgam` (one C₅-style splice on `Option V`),
+   `amalgam_new_common`, `amalgam_new_common_unique`, `amalgam_linear` (step
+   preserves the friendship upper bound). Authored under a closed build gate
+   (load ~24) + Aristotle 404, so not yet discharged. **Next session, gate open
+   OR Aristotle up:** register + `docker-build.sh Proofs.FriendshipTheoremOQ04Amalgam`
+   (or `prove_file`), then mark verified. Full hand proof in knowledge.md S14.
+3. Negative-half **full** construction: the ω-colimit on the verified step (plus
+   the fairness "every deficient pair eventually repaired" lower bound and
+   "no universal vertex persists in the limit"). Multi-session — the genuinely
+   remaining open gap; the *step* (item 2) is no longer part of it.
 The structural programme (positive half + finiteness-free negative-half framing) is
-COMPLETED; only the explicit colimit counterexample construction remains open.
+COMPLETED. The negative-half construction is now split: STEP scaffolded (item 2),
+COLIMIT still open (item 3).

--- a/src/data/research/problems/friendship-theorem-oq-04.json
+++ b/src/data/research/problems/friendship-theorem-oq-04.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-06-14T22:54:16-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "S14 (researcher-2): amalgamation STEP lemma scaffolded in proofs/Proofs/FriendshipTheoremOQ04Amalgam.lean (BUILD-PENDING, 3 sorry, unregistered) — the finitary inductive core of the C5 free-amalgamation counterexample, isolated out of the multi-session colimit. amalgam (one Option V splice), amalgam_new_common, amalgam_new_common_unique, amalgam_linear (step preserves the friendship upper bound). Authored under closed build gate (load ~24) + Aristotle 404. NEXT: gate open or Aristotle up -> register + docker-build.sh Proofs.FriendshipTheoremOQ04Amalgam (or prove_file), mark verified, then attack the omega-colimit (fairness lower bound + no-universal-vertex persistence). Full hand proof in knowledge.md S14.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -135,5 +135,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FriendshipTheoremOQ03.lean"
     }
-  ]
+  ],
+  "lastUpdate": "2026-06-19T12:40:00.000Z"
 }


### PR DESCRIPTION
## Summary

`friendship-theorem-oq-04` (the infinite Friendship Theorem) has its **structural / non-spectral programme complete** — diameter-≤2 covering, local-finiteness restoring condition, hub uniqueness, hub-free ⟹ ℵ₀-regular dichotomy (all 0-sorry/0-axiom in `FriendshipTheoremOQ04.lean`). The one remaining open gap is the **negative-half counterexample**: an explicit infinite friendship graph with no universal vertex (C₅ free-amalgamation, Chvátal–Kotzig–Rosenberg–Davies 1976), long flagged as a multi-session inductive-limit build.

That framing conflated the ω-colimit with its **single inductive step**. This PR isolates the step — a finitary, single-session-tractable lemma — into a build-ready form.

## What's in `FriendshipTheoremOQ04Amalgam.lean`

- `amalgam G u v : SimpleGraph (Option V)` — one C₅-style splice: a fresh vertex `none` adjacent to exactly `some u, some v`.
- `amalgam_new_common` — `none` is a common neighbour of the spliced pair.
- `amalgam_new_common_unique` — under `commonNeighbors G u v = ∅`, `none` is their **unique** common neighbour (the deficient pair gains exactly one).
- `amalgam_linear` — under `u ≠ v`, `Linear G`, `commonNeighbors G u v = ∅`, the step **preserves linearity** (the friendship upper bound).

The full hand proof of `amalgam_linear` (a finite case bash over `Option V`, hinging on `b ∈ commonNeighbors G u v = ∅`) is in `knowledge.md` S14.

## Honesty / status

⚠️ **BUILD-PENDING SCAFFOLD — not a verified result.** Both verification routes were closed when this was authored: the local Docker build gate (host load ~24, two `lean-build` containers running) and the Aristotle backend (404). The file carries **3 `sorry`s** and is **not registered** in `Proofs.lean`, so it does not touch the verified build. No gallery `meta.json` status was changed.

The deliverable is the precise, ready-to-discharge statement + proof strategy, which converts the open gap from "build an ω-colimit" into "iterate a verified finite step." **Next session, gate open or Aristotle up:** register + `docker-build.sh Proofs.FriendshipTheoremOQ04Amalgam` (or `prove_file`), mark verified, then attack the colimit (fairness lower bound + no-universal-vertex persistence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)