### PR TITLE
audit(erdos-1179-oq-02-rigidity): first audit clean — rigidity/equality case 0-sorry/0-axiom verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16075,6 +16075,12 @@
       "lastAudited": "2026-06-19T12:15:00Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1179-oq-02-rigidity": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T12:31:08Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

First audit of the newly-added 2561st gallery entry **erdos-1179-oq-02-rigidity** (the rigidity / equality case of the Erdős #1179 OQ-02 trivial lower bound).

### Claims verified against Lean source

| Claim | meta.json | `Erdos1179OQ02Rigidity.lean` |
|-------|-----------|------------------------------|
| lineCount | 106 | 106 ✓ |
| theoremCount | 3 | 3 ✓ |
| definitionCount | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |
| sorries | 0 | none ✓ |
| status / badge | verified / verified | defensible ✓ |
| registered | — | `Proofs.lean:1064` ✓ |

### Honesty review (Tier A, defensible)
- **No overclaim**: title is strongly qualified ("Rigidity / Equality Case of the Trivial Lower Bound"); both description and conclusion explicitly state the headline OQ-02 (the additive O_ε(1) upper bound) **remains open**.
- **Clean dependency chain**: rests solely on the fully-proved `total_reprCount` (fiberwise counting, `Erdos1179Problem.lean:74`) and `epsUniform_spanning` (`nlinarith`/`omega`, `Erdos1179OQ02.lean:55`). The parent's axioms (`gEps`, `basic_lower_bound`, `erdos_hall_upper`) feed only the asymptotic g_ε(N) and are **not** in this entry's chain.
- **Mathlib bearers disclosed**: `Finset.sum_eq_sum_iff_of_le` and `Nat.clog_pow` are elementary and named in the `assumptions` field.
- None of the five narrative failure modes apply. Risk: **LOW**.

Gallery now fully saturated: **2561/2561 audited, 0 issues**.

---
Discovered during gallery integrity audit.