### PR TITLE
research(cayley-hamilton-oq-02-oq-02): Sylvester interpolation via Frobenius covariants (verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -492,6 +492,7 @@ import Proofs.CayleyHamiltonOQ01
 import Proofs.CayleyHamiltonOQ01OQ01
 import Proofs.CayleyHamiltonOQ01OQ03
 import Proofs.CayleyHamiltonOQ02
+import Proofs.CayleyHamiltonOQ02OQ02
 import Proofs.CayleyHamiltonReductionOQ01
 import Proofs.CayleyHamiltonReductionOQ01OQ02
 import Proofs.CayleyHamiltonReductionOQ02

--- a/proofs/Proofs/CayleyHamiltonOQ02OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ02OQ02.lean
@@ -1,0 +1,243 @@
+import Mathlib
+
+/-
+# Sylvester Interpolation via Frobenius Covariants
+
+Follow-up to `CayleyHamiltonOQ02` (open question oq-02-oq-02).
+
+The parent file `CayleyHamiltonOQ02` shows that *any* polynomial function of an `n×n`
+matrix `A` reduces, via Cayley–Hamilton, to a polynomial of degree `< n` in `A`. When `A`
+is **diagonalizable** that reduction takes a sharp, fully explicit form — *Sylvester's
+interpolation formula*:
+
+  f(A) = ∑_λ f(λ) · Z_λ,
+
+where the sum runs over the distinct eigenvalues `λ` of `A`, and the matrices `Z_λ` are the
+**Frobenius covariants** — the spectral projections onto the eigenspaces. They are intrinsic
+to `A` (independent of `f`) and satisfy
+
+  Z_λ² = Z_λ,    Z_λ Z_μ = 0 (λ ≠ μ),    ∑_λ Z_λ = I,    A Z_λ = λ Z_λ,
+
+so `f(A)` is obtained by simply *re-weighting the fixed spectral projections by the scalars
+`f(λ)`*. This is the matrix analogue of Lagrange interpolation and the algebraic core of the
+holomorphic functional calculus on a diagonalizable operator.
+
+## Formalization
+
+We encode "diagonalizable" by the data of a similarity `A = U · diagonal d · V` with
+`diagonal d` the eigenvalue list and `U`, `V` mutually inverse (`U V = V U = 1`). The
+eigenvalue running over the sum is `μ ∈ Finset.univ.image d`, the set of distinct entries of
+`d`. The Frobenius covariant attached to `μ` is
+
+  `frobeniusCovariant U V d μ = U · diagonal (1 on the μ-positions) · V`,
+
+i.e. `U` conjugates the coordinate projection `E_μ` onto the `μ`-eigenspace back to the
+original basis. The functional calculus is `Polynomial.aeval` (matrix polynomial evaluation).
+
+## Main results
+
+* `aeval_conj`           : conjugation commutes with the functional calculus,
+                           `aeval (U A V) p = U · aeval A p · V`.
+* `aeval_diagonal`       : `aeval (diagonal d) p = diagonal (i ↦ p.eval (d i))`.
+* `sylvester`            : **Sylvester's formula** `aeval (U D V) p = ∑_μ p.eval μ • Z_μ`.
+* `frobenius_idem`       : `Z_μ² = Z_μ` (idempotent).
+* `frobenius_orthogonal` : `Z_μ Z_ν = 0` for `μ ≠ ν`.
+* `frobenius_complete`   : `∑_μ Z_μ = 1` (resolution of the identity).
+* `frobenius_eigen`      : `A · Z_μ = μ • Z_μ` (each covariant projects onto the μ-eigenspace).
+
+Everything is `sorry`-free and `axiom`-free (only the foundational
+`propext`/`Classical.choice`/`Quot.sound`; no `Lean.ofReduceBool`).
+-/
+
+-- `DecidableEq 𝕜` is needed for the eigenvalue indicators / `Finset.image` from
+-- `coordProj` onward; the early transport lemmas don't use it, which the section-var
+-- linter would otherwise flag.
+set_option linter.unusedSectionVars false
+
+namespace CayleyHamiltonOQ02OQ02
+
+open Matrix Polynomial Finset
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {𝕜 : Type*} [CommRing 𝕜] [DecidableEq 𝕜]
+
+/-! ## Conjugation commutes with the functional calculus -/
+
+/-- Powers of a conjugate are conjugates of powers: `(U A V)^k = U Aᵏ V`, using only
+`U V = V U = 1`. -/
+theorem conj_pow (U V A : Matrix n n 𝕜) (hUV : U * V = 1) (hVU : V * U = 1) :
+    ∀ k : ℕ, (U * A * V) ^ k = U * A ^ k * V
+  | 0 => by simpa using hUV.symm
+  | (k + 1) => by
+      rw [pow_succ, conj_pow U V A hUV hVU k]
+      calc U * A ^ k * V * (U * A * V)
+          = U * A ^ k * (V * U) * A * V := by noncomm_ring
+        _ = U * A ^ k * 1 * A * V := by rw [hVU]
+        _ = U * (A ^ k * A) * V := by noncomm_ring
+        _ = U * A ^ (k + 1) * V := by rw [pow_succ]
+
+/-- **Conjugation commutes with `aeval`.** If `U V = V U = 1`, then the polynomial functional
+calculus of a conjugate is the conjugate of the functional calculus:
+`aeval (U A V) p = U · aeval A p · V`. -/
+theorem aeval_conj (U V A : Matrix n n 𝕜) (hUV : U * V = 1) (hVU : V * U = 1) (p : 𝕜[X]) :
+    aeval (U * A * V) p = U * aeval A p * V := by
+  induction p using Polynomial.induction_on' with
+  | add p q hp hq =>
+      rw [map_add, map_add, hp, hq, Matrix.mul_add, Matrix.add_mul]
+  | monomial k a =>
+      rw [aeval_monomial, aeval_monomial, conj_pow U V A hUV hVU k,
+        ← Algebra.smul_def, ← Algebra.smul_def, mul_smul_comm, smul_mul_assoc]
+
+/-! ## The functional calculus on a diagonal matrix is diagonal -/
+
+/-- `aeval` of a diagonal matrix evaluates entrywise:
+`aeval (diagonal d) p = diagonal (i ↦ p.eval (d i))`. -/
+theorem aeval_diagonal (d : n → 𝕜) (p : 𝕜[X]) :
+    aeval (diagonal d) p = diagonal (fun i => p.eval (d i)) := by
+  induction p using Polynomial.induction_on' with
+  | add p q hp hq =>
+      rw [map_add, hp, hq]
+      ext i j
+      by_cases h : i = j <;> simp [Matrix.add_apply, h, eval_add]
+  | monomial k a =>
+      rw [aeval_monomial, ← Algebra.smul_def, diagonal_pow, ← diagonal_smul]
+      congr 1
+      funext i
+      simp [eval_monomial, Pi.smul_apply, Pi.pow_apply, smul_eq_mul]
+
+/-! ## Frobenius covariants (spectral projections) -/
+
+/-- The coordinate projection onto the `μ`-eigenspace in the diagonal basis: the diagonal
+indicator matrix with a `1` in each position `i` where `d i = μ`. -/
+def coordProj (d : n → 𝕜) (μ : 𝕜) : Matrix n n 𝕜 :=
+  diagonal (fun i => if d i = μ then 1 else 0)
+
+/-- The **Frobenius covariant** of the diagonalizable matrix `A = U · diagonal d · V`
+attached to the eigenvalue `μ`: the spectral projection onto the `μ`-eigenspace, expressed in
+the original basis by conjugating the coordinate projection. -/
+def frobeniusCovariant (U V : Matrix n n 𝕜) (d : n → 𝕜) (μ : 𝕜) : Matrix n n 𝕜 :=
+  U * coordProj d μ * V
+
+/-- The coordinate projections are idempotent in the diagonal basis. -/
+theorem coordProj_mul_self (d : n → 𝕜) (μ : 𝕜) :
+    coordProj d μ * coordProj d μ = coordProj d μ := by
+  unfold coordProj
+  rw [diagonal_mul_diagonal]
+  congr 1
+  funext i
+  by_cases h : d i = μ <;> simp [h]
+
+/-- The coordinate projections for distinct eigenvalues are orthogonal. -/
+theorem coordProj_mul_other (d : n → 𝕜) {μ ν : 𝕜} (hμν : μ ≠ ν) :
+    coordProj d μ * coordProj d ν = 0 := by
+  unfold coordProj
+  rw [diagonal_mul_diagonal]
+  rw [show (fun i => (if d i = μ then (1 : 𝕜) else 0) * (if d i = ν then 1 else 0))
+        = (fun _ => (0 : 𝕜)) from ?_, diagonal_zero]
+  funext i
+  by_cases hμ : d i = μ
+  · have hν : d i ≠ ν := by rw [hμ]; exact hμν
+    rw [if_pos hμ, if_neg hν, mul_zero]
+  · rw [if_neg hμ, zero_mul]
+
+/-- Multiplying the diagonal matrix by a coordinate projection scales it by the eigenvalue:
+`diagonal d · E_μ = μ • E_μ`. -/
+theorem diag_mul_coordProj (d : n → 𝕜) (μ : 𝕜) :
+    diagonal d * coordProj d μ = μ • coordProj d μ := by
+  unfold coordProj
+  rw [diagonal_mul_diagonal, ← diagonal_smul]
+  congr 1
+  funext i
+  by_cases h : d i = μ <;> simp [h, Pi.smul_apply, smul_eq_mul]
+
+/-- **Spectral decomposition of a diagonal matrix.** For any scalar function `g`, the diagonal
+matrix `diagonal (i ↦ g (d i))` is the `g`-weighted sum of the coordinate projections over the
+distinct eigenvalues. The two instances we need are `g = p.eval` (Sylvester) and `g = 1`
+(resolution of the identity). -/
+theorem diagonal_eq_sum_coordProj (d : n → 𝕜) (g : 𝕜 → 𝕜) :
+    diagonal (fun i => g (d i)) = ∑ μ ∈ Finset.univ.image d, g μ • coordProj d μ := by
+  ext i j
+  rw [Matrix.sum_apply]
+  by_cases hij : i = j
+  · subst hij
+    rw [diagonal_apply_eq]
+    rw [Finset.sum_eq_single (d i)]
+    · simp [coordProj, diagonal_apply_eq]
+    · intro μ _ hne
+      rw [Matrix.smul_apply, coordProj, diagonal_apply_eq, smul_eq_mul,
+        if_neg (fun h : d i = μ => hne h.symm), mul_zero]
+    · intro hmem
+      exact absurd (Finset.mem_image_of_mem d (Finset.mem_univ i)) hmem
+  · rw [diagonal_apply_ne _ hij]
+    refine (Finset.sum_eq_zero ?_).symm
+    intro μ _
+    rw [Matrix.smul_apply, coordProj, diagonal_apply_ne _ hij, smul_zero]
+
+/-! ## Sylvester's interpolation formula -/
+
+/-- **Sylvester's interpolation formula.** For a diagonalizable matrix `A = U · diagonal d · V`
+(with `U V = V U = 1`) and any polynomial `p`, the matrix `p(A)` is the sum, over the distinct
+eigenvalues `μ`, of `p.eval μ` times the Frobenius covariant `Z_μ`:
+
+  `aeval (U · diagonal d · V) p = ∑_μ p.eval μ • frobeniusCovariant U V d μ`.
+
+The covariants `Z_μ` do not depend on `p`: changing the function only re-weights the fixed
+spectral projections. -/
+theorem sylvester (U V : Matrix n n 𝕜) (hUV : U * V = 1) (hVU : V * U = 1)
+    (d : n → 𝕜) (p : 𝕜[X]) :
+    aeval (U * diagonal d * V) p
+      = ∑ μ ∈ Finset.univ.image d, p.eval μ • frobeniusCovariant U V d μ := by
+  rw [aeval_conj U V (diagonal d) hUV hVU, aeval_diagonal,
+    diagonal_eq_sum_coordProj d (fun μ => p.eval μ), Finset.mul_sum, Finset.sum_mul]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [mul_smul_comm, smul_mul_assoc]
+  rfl
+
+/-! ## Properties of the Frobenius covariants -/
+
+/-- Each Frobenius covariant is idempotent: `Z_μ² = Z_μ`. -/
+theorem frobenius_idem (U V : Matrix n n 𝕜) (hVU : V * U = 1) (d : n → 𝕜) (μ : 𝕜) :
+    frobeniusCovariant U V d μ * frobeniusCovariant U V d μ = frobeniusCovariant U V d μ := by
+  unfold frobeniusCovariant
+  calc U * coordProj d μ * V * (U * coordProj d μ * V)
+      = U * coordProj d μ * (V * U) * coordProj d μ * V := by noncomm_ring
+    _ = U * coordProj d μ * 1 * coordProj d μ * V := by rw [hVU]
+    _ = U * (coordProj d μ * coordProj d μ) * V := by noncomm_ring
+    _ = U * coordProj d μ * V := by rw [coordProj_mul_self]
+
+/-- Frobenius covariants for distinct eigenvalues are orthogonal: `Z_μ Z_ν = 0`. -/
+theorem frobenius_orthogonal (U V : Matrix n n 𝕜) (hVU : V * U = 1) (d : n → 𝕜)
+    {μ ν : 𝕜} (hμν : μ ≠ ν) :
+    frobeniusCovariant U V d μ * frobeniusCovariant U V d ν = 0 := by
+  unfold frobeniusCovariant
+  calc U * coordProj d μ * V * (U * coordProj d ν * V)
+      = U * coordProj d μ * (V * U) * coordProj d ν * V := by noncomm_ring
+    _ = U * coordProj d μ * 1 * coordProj d ν * V := by rw [hVU]
+    _ = U * (coordProj d μ * coordProj d ν) * V := by noncomm_ring
+    _ = U * 0 * V := by rw [coordProj_mul_other d hμν]
+    _ = 0 := by rw [Matrix.mul_zero, Matrix.zero_mul]
+
+/-- The Frobenius covariants resolve the identity: `∑_μ Z_μ = 1`. -/
+theorem frobenius_complete (U V : Matrix n n 𝕜) (hUV : U * V = 1) (d : n → 𝕜) :
+    ∑ μ ∈ Finset.univ.image d, frobeniusCovariant U V d μ = 1 := by
+  have hsum : ∑ μ ∈ Finset.univ.image d, coordProj d μ = 1 := by
+    have h := diagonal_eq_sum_coordProj d (fun _ => (1 : 𝕜))
+    simp only [one_smul] at h
+    rw [← h]
+    simp [diagonal_one]
+  unfold frobeniusCovariant
+  rw [← Finset.sum_mul, ← Finset.mul_sum, hsum, Matrix.mul_one, hUV]
+
+/-- **Eigen-projection.** Each Frobenius covariant projects onto the `μ`-eigenspace:
+`A · Z_μ = μ • Z_μ` for `A = U · diagonal d · V`. -/
+theorem frobenius_eigen (U V : Matrix n n 𝕜) (hVU : V * U = 1) (d : n → 𝕜) (μ : 𝕜) :
+    (U * diagonal d * V) * frobeniusCovariant U V d μ = μ • frobeniusCovariant U V d μ := by
+  unfold frobeniusCovariant
+  calc U * diagonal d * V * (U * coordProj d μ * V)
+      = U * diagonal d * (V * U) * coordProj d μ * V := by noncomm_ring
+    _ = U * diagonal d * 1 * coordProj d μ * V := by rw [hVU]
+    _ = U * (diagonal d * coordProj d μ) * V := by noncomm_ring
+    _ = U * (μ • coordProj d μ) * V := by rw [diag_mul_coordProj]
+    _ = μ • (U * coordProj d μ * V) := by rw [mul_smul_comm, smul_mul_assoc]
+
+end CayleyHamiltonOQ02OQ02

--- a/src/data/proofs/cayley-hamilton-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-02/annotations.json
@@ -1,0 +1,168 @@
+[
+  {
+    "id": "ann-ch0202-background",
+    "proofId": "cayley-hamilton-oq-02-oq-02",
+    "range": {
+      "startLine": 6,
+      "endLine": 50
+    },
+    "type": "concept",
+    "title": "Sylvester Interpolation: The Explicit Diagonalizable Form of Cayley-Hamilton Reduction",
+    "content": "The module docstring frames Sylvester's formula as the sharp, explicit form of the parent file's Cayley-Hamilton polynomial reduction. Where the parent reduces f(A) modulo the characteristic polynomial, Sylvester's formula evaluates f(A) directly from the spectrum: f(A) = ∑_λ f(λ)·Z_λ. The matrices Z_λ — the Frobenius covariants — are the spectral projections onto the eigenspaces and are intrinsic to A, so changing f only re-weights the fixed projections. Diagonalizability is encoded as the explicit similarity data A = U·diagonal(d)·V with U·V = V·U = 1, which keeps the entire development elementary: no spectral-theorem or eigenspace machinery is required, only the algebra of diagonal indicators and the single cancellation V·U = 1.",
+    "mathContext": "For a diagonalizable $A$ with distinct eigenvalues $\\lambda_1,\\dots,\\lambda_k$, $f(A) = \\sum_j f(\\lambda_j) Z_j$ where $Z_j = \\prod_{m\\ne j}\\frac{A-\\lambda_m I}{\\lambda_j-\\lambda_m}$. The $Z_j$ satisfy $Z_j^2 = Z_j$, $Z_j Z_m = 0\\ (j\\ne m)$, $\\sum_j Z_j = I$, and $A Z_j = \\lambda_j Z_j$. This is the finite-dimensional, diagonalizable case of the holomorphic functional calculus.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Sylvester interpolation formula",
+      "Frobenius covariants",
+      "spectral projections",
+      "holomorphic functional calculus",
+      "Lagrange interpolation"
+    ],
+    "prerequisites": [
+      "polynomial functional calculus (aeval)",
+      "diagonal matrix algebra",
+      "Cayley-Hamilton polynomial reduction"
+    ]
+  },
+  {
+    "id": "ann-ch0202-conj",
+    "proofId": "cayley-hamilton-oq-02-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 90
+    },
+    "type": "insight",
+    "title": "Conjugation Commutes with the Functional Calculus",
+    "content": "Two lemmas establish that the polynomial functional calculus respects similarity. `conj_pow` proves (U·A·V)^k = U·A^k·V by induction on k, the inductive step cancelling the inner V·U = 1; the base case k = 0 uses U·V = 1. `aeval_conj` then lifts this from powers to arbitrary polynomials by `Polynomial.induction_on'`: the additive case is immediate, and the monomial case a·X^k reduces to conj_pow together with the centrality of scalar matrices (algebraMap a commutes with everything, handled by rewriting algebraMap·x as a • x and sliding the scalar past the conjugation with mul_smul_comm / smul_mul_assoc). Proving this directly avoids packaging an inner-automorphism AlgEquiv, keeping the dependency surface minimal.",
+    "mathContext": "If $UV = VU = I$ then $\\mathrm{aeval}(UAV)\\,p = U\\,(\\mathrm{aeval}\\,A\\,p)\\,V$. Equivalently, conjugation by $U$ is an algebra automorphism of $M_n(\\Bbbk)$, and any algebra homomorphism transports $\\mathrm{aeval}$: $\\phi(p(A)) = p(\\phi(A))$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "similarity invariance",
+      "algebra homomorphism",
+      "Polynomial.induction_on'",
+      "centrality of scalar matrices"
+    ],
+    "prerequisites": [
+      "Polynomial.aeval",
+      "aeval_monomial",
+      "Algebra.smul_def"
+    ]
+  },
+  {
+    "id": "ann-ch0202-diagonal",
+    "proofId": "cayley-hamilton-oq-02-oq-02",
+    "range": {
+      "startLine": 91,
+      "endLine": 107
+    },
+    "type": "insight",
+    "title": "The Functional Calculus on a Diagonal Matrix is Diagonal",
+    "content": "`aeval_diagonal` computes the polynomial functional calculus of a diagonal matrix entrywise: aeval (diagonal d) p = diagonal (i ↦ p.eval (d i)). The proof is again `Polynomial.induction_on'`; the additive case is verified entrywise, and the monomial case uses `diagonal_pow` (diagonal d ^ k = diagonal (d^k)) and `diagonal_smul` (scalars pass through diagonal). This is the diagonal-basis half of Sylvester's formula: in the eigenbasis, applying f to A amounts to applying f to each eigenvalue independently.",
+    "mathContext": "For $D = \\mathrm{diag}(d_1,\\dots,d_n)$ and a polynomial $p$, $p(D) = \\mathrm{diag}(p(d_1),\\dots,p(d_n))$. This is the elementary fact that polynomials act coordinatewise on a diagonal matrix.",
+    "significance": "key",
+    "relatedConcepts": [
+      "diagonal matrix",
+      "spectral mapping",
+      "diagonal_pow",
+      "diagonal_smul"
+    ],
+    "prerequisites": [
+      "diagonal matrix algebra",
+      "Polynomial.induction_on'"
+    ]
+  },
+  {
+    "id": "ann-ch0202-covariants",
+    "proofId": "cayley-hamilton-oq-02-oq-02",
+    "range": {
+      "startLine": 108,
+      "endLine": 155
+    },
+    "type": "concept",
+    "title": "Frobenius Covariants and Coordinate Projections",
+    "content": "`coordProj d μ` is the diagonal indicator E_μ with a 1 in each position where d i = μ (the coordinate projection onto the μ-eigenspace), and `frobeniusCovariant U V d μ = U·E_μ·V` conjugates it back to the original basis. Three supporting lemmas establish the indicator algebra that drives everything downstream: `coordProj_mul_self` (E_μ² = E_μ, idempotent), `coordProj_mul_other` (E_μ E_ν = 0 for μ ≠ ν, since a coordinate cannot carry two distinct eigenvalues), and `diag_mul_coordProj` (diagonal d · E_μ = μ • E_μ, the eigen-scaling). All three reduce, via `diagonal_mul_diagonal`, to pointwise facts about indicators.",
+    "mathContext": "$E_\\mu = \\mathrm{diag}(\\mathbb{1}[d_i = \\mu])$ satisfies $E_\\mu^2 = E_\\mu$, $E_\\mu E_\\nu = 0\\ (\\mu\\ne\\nu)$, and $D E_\\mu = \\mu E_\\mu$. Conjugating by the similarity, $Z_\\mu = U E_\\mu V$ inherits these as the spectral projections of $A$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "spectral projection",
+      "idempotent",
+      "orthogonal projections",
+      "diagonal_mul_diagonal"
+    ],
+    "prerequisites": [
+      "diagonal matrix algebra",
+      "indicator functions"
+    ]
+  },
+  {
+    "id": "ann-ch0202-spectral-decomp",
+    "proofId": "cayley-hamilton-oq-02-oq-02",
+    "range": {
+      "startLine": 157,
+      "endLine": 175
+    },
+    "type": "insight",
+    "title": "Spectral Decomposition of a Diagonal Matrix",
+    "content": "`diagonal_eq_sum_coordProj` is the combinatorial heart of the formula: for any scalar function g, diagonal (i ↦ g(d i)) = ∑_μ g(μ) • E_μ, summed over the distinct eigenvalues μ ∈ Finset.univ.image d. The proof is entrywise (Matrix.ext): off the diagonal both sides vanish; on the diagonal, `Finset.sum_eq_single (d i)` isolates the unique surviving term at μ = d i. Two instantiations power the rest of the file — g = p.eval gives Sylvester's formula, and g = 1 gives the resolution of the identity ∑_μ Z_μ = I.",
+    "mathContext": "$\\mathrm{diag}(g(d_1),\\dots,g(d_n)) = \\sum_{\\mu\\in\\mathrm{im}(d)} g(\\mu)\\,E_\\mu$. The sum ranges over distinct values; each diagonal entry $g(d_i)$ is selected by the single projection $E_{d_i}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "spectral decomposition",
+      "resolution of the identity",
+      "Finset.sum_eq_single",
+      "partition by eigenvalue"
+    ],
+    "prerequisites": [
+      "Finset.image",
+      "Finset.sum_eq_single",
+      "Matrix.ext"
+    ]
+  },
+  {
+    "id": "ann-ch0202-sylvester",
+    "proofId": "cayley-hamilton-oq-02-oq-02",
+    "range": {
+      "startLine": 176,
+      "endLine": 195
+    },
+    "type": "insight",
+    "title": "Sylvester's Interpolation Formula",
+    "content": "The main theorem `sylvester` assembles the pieces: aeval (U·diagonal(d)·V) p = ∑_μ p.eval μ • frobeniusCovariant U V d μ. The proof chains the three transport lemmas — aeval_conj moves the functional calculus inside the conjugation, aeval_diagonal evaluates it on the diagonal, and diagonal_eq_sum_coordProj (with g = p.eval) splits the result over the distinct eigenvalues — then pushes the conjugation through the finite sum using Finset.mul_sum, Finset.sum_mul, and mul_smul_comm / smul_mul_assoc to land on the Frobenius covariants. The dependence of f(A) on f is entirely through the scalars p.eval μ.",
+    "mathContext": "$f(A) = \\sum_{\\mu} f(\\mu)\\,Z_\\mu$ with $Z_\\mu = U E_\\mu V$. Since the $Z_\\mu$ depend only on $A$, $f(A)$ and $g(A)$ share the same projections and differ only by the scalar weights — the Lagrange-interpolation viewpoint on matrix functions.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Sylvester interpolation",
+      "matrix function",
+      "Lagrange interpolation",
+      "spectral decomposition"
+    ],
+    "prerequisites": [
+      "aeval_conj",
+      "aeval_diagonal",
+      "diagonal_eq_sum_coordProj"
+    ]
+  },
+  {
+    "id": "ann-ch0202-covariant-properties",
+    "proofId": "cayley-hamilton-oq-02-oq-02",
+    "range": {
+      "startLine": 196,
+      "endLine": 243
+    },
+    "type": "insight",
+    "title": "The Frobenius Covariants are Spectral Projections",
+    "content": "Four theorems characterize the covariants Z_μ = U·E_μ·V as genuine spectral projections. `frobenius_idem` (Z_μ² = Z_μ) and `frobenius_orthogonal` (Z_μ Z_ν = 0 for μ ≠ ν) follow by cancelling the inner V·U = 1 and applying the indicator algebra. `frobenius_complete` (∑_μ Z_μ = I) is exactly the g = 1 instance of the spectral decomposition, conjugated. `frobenius_eigen` (A·Z_μ = μ • Z_μ) shows each covariant lands in the μ-eigenspace, using diag_mul_coordProj. Together these are the matrix form of the spectral theorem for a diagonalizable operator: an orthogonal idempotent resolution of the identity with A = ∑_μ μ Z_μ.",
+    "mathContext": "$Z_\\mu^2 = Z_\\mu$, $Z_\\mu Z_\\nu = 0\\ (\\mu\\ne\\nu)$, $\\sum_\\mu Z_\\mu = I$, $A Z_\\mu = \\mu Z_\\mu$. Consequently $A = \\sum_\\mu \\mu Z_\\mu$ and $f(A) = \\sum_\\mu f(\\mu) Z_\\mu$ for every $f$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "spectral theorem",
+      "resolution of the identity",
+      "orthogonal idempotents",
+      "eigenspace projection"
+    ],
+    "prerequisites": [
+      "coordProj algebra",
+      "diagonal_eq_sum_coordProj"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-02/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "cayley-hamilton-oq-02-oq-02",
+  "title": "Sylvester Interpolation via Frobenius Covariants",
+  "slug": "cayley-hamilton-oq-02-oq-02",
+  "description": "Proves Sylvester's interpolation formula f(A) = ∑_μ f(μ) Z_μ for a diagonalizable matrix A = U·diagonal(d)·V, where the sum runs over the distinct eigenvalues μ and the Z_μ are the Frobenius covariants (spectral projections onto the eigenspaces). Establishes that the covariants are intrinsic to A (independent of f) by proving they are idempotent (Z_μ² = Z_μ), orthogonal (Z_μ Z_ν = 0 for μ ≠ ν), resolve the identity (∑_μ Z_μ = I), and project onto eigenspaces (A·Z_μ = μ·Z_μ). Answers an open question posed in cayley-hamilton-oq-02. 12 theorems, 2 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonOQ02OQ02.lean",
+    "tags": [
+      "linear-algebra",
+      "cayley-hamilton",
+      "matrix-functions",
+      "spectral-theory",
+      "frobenius-covariants",
+      "sylvester-interpolation"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "assumptions": "Builds on Mathlib's polynomial functional calculus (Polynomial.aeval) and diagonal-matrix API. The mathematical content — conjugation/aeval commutation, the spectral decomposition of a diagonal matrix, Sylvester's formula, and the covariant identities — is proved from first principles in-file (no single Mathlib theorem is used as the crux). 'Diagonalizable' is encoded as the data of a similarity A = U·diagonal(d)·V with U·V = V·U = 1.",
+    "lineCount": 243,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "originalContributions": [
+      "aeval_conj: conjugation commutes with the functional calculus, aeval (U·A·V) p = U·(aeval A p)·V",
+      "aeval_diagonal: aeval (diagonal d) p = diagonal (i ↦ p.eval (d i))",
+      "diagonal_eq_sum_coordProj: spectral decomposition diagonal (i ↦ g(d i)) = ∑_μ g(μ) • E_μ",
+      "sylvester: f(A) = ∑_μ p.eval μ • Z_μ for A = U·diagonal(d)·V (Sylvester interpolation)",
+      "frobenius_idem / frobenius_orthogonal / frobenius_complete / frobenius_eigen: the Frobenius covariants are idempotent, orthogonal, resolve the identity, and project onto eigenspaces"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Sylvester (1883) introduced the theory of 'matrix functions' f(A), computing them by interpolation at the eigenvalues of A. For a diagonalizable matrix with distinct eigenvalues λ₁,…,λ_k, Sylvester's formula reads f(A) = ∑_j f(λ_j) Z_j, where Z_j = ∏_{m≠j}(A − λ_m I)/(λ_j − λ_m) are what Frobenius later called the covariants of A. Geometrically the Z_j are the spectral projections onto the eigenspaces: idempotent, mutually orthogonal, summing to the identity. The formula is the finite-dimensional, diagonalizable case of the holomorphic functional calculus, and the matrix analogue of Lagrange interpolation — the value f(A) depends on f only through the scalars f(λ_j), with the geometry packaged once and for all into the fixed projections Z_j. This entry answers an open question raised in the parent file cayley-hamilton-oq-02, which established the Cayley–Hamilton polynomial reduction f(A) = (f mod χ_A)(A); Sylvester's formula is the sharp, explicit form of that reduction when A is diagonalizable.",
+    "problemStatement": "For a diagonalizable matrix A = U·diagonal(d)·V (with U·V = V·U = 1) and any polynomial p, prove p(A) = ∑_μ p(μ)·Z_μ where μ ranges over the distinct eigenvalues and Z_μ are the Frobenius covariants (spectral projections onto eigenspaces), and prove the covariants are idempotent, orthogonal, complete, and eigen-projections.",
+    "text": "Write A = U·D·V with D = diagonal d and U,V mutually inverse. Polynomial evaluation transports through the similarity (aeval (U·D·V) p = U·(aeval D p)·V) because (U·D·V)^k = U·D^k·V; and the functional calculus of a diagonal matrix is computed entrywise (aeval D p = diagonal(i ↦ p.eval(d i))). A diagonal matrix whose entries are g(d i) splits as ∑_μ g(μ)·E_μ over the distinct values μ of d, where E_μ is the coordinate indicator projection. Conjugating, Z_μ := U·E_μ·V and p(A) = ∑_μ p(μ)·Z_μ. The covariant identities reduce, after cancelling the inner V·U = 1, to the corresponding facts about the diagonal indicators E_μ: E_μ² = E_μ, E_μ E_ν = 0 (μ ≠ ν), ∑_μ E_μ = I, and D·E_μ = μ·E_μ.",
+    "proofStrategy": "(1) conj_pow: induction on the exponent using V·U = 1 to cancel inner factors. (2) aeval_conj and aeval_diagonal: polynomial induction (Polynomial.induction_on'), reducing to the monomial case where conj_pow and diagonal_pow apply. (3) diagonal_eq_sum_coordProj: entrywise (Matrix.ext) using Finset.sum_eq_single at the diagonal eigenvalue d i. (4) sylvester: chain the three transports, then push the conjugation through the finite sum with mul_smul_comm/smul_mul_assoc. (5) covariant identities: cancel V·U = 1 and apply the diagonal-indicator algebra (diagonal_mul_diagonal).",
+    "keyInsights": [
+      "Encoding 'diagonalizable' as the explicit similarity data A = U·diagonal(d)·V with U·V = V·U = 1 keeps the whole development elementary and constructive — no eigenspace/spectral-theorem machinery is needed, only the algebra of diagonal indicators and one cancellation V·U = 1",
+      "The functional dependence of f(A) on f is entirely through the scalars p.eval μ: the covariants Z_μ are assembled once from A alone, so f(A) and g(A) share the same projections and differ only by re-weighting — exactly the Lagrange-interpolation viewpoint",
+      "Conjugation commutes with the entire polynomial functional calculus (aeval_conj), a clean instance of an algebra homomorphism transporting aeval; proved here directly by polynomial induction rather than via a packaged inner-automorphism, keeping the dependency surface minimal",
+      "Every covariant identity (idempotent, orthogonal, complete, eigen) collapses to a diagonal-indicator fact after the inner V·U = 1 cancellation — completeness ∑_μ Z_μ = I is literally the g = 1 instance of the spectral decomposition diagonal_eq_sum_coordProj",
+      "The development works over an arbitrary commutative ring 𝕜 (with decidable equality), not just an algebraically closed field: diagonalizability is supplied as data, so the formula and covariant algebra hold verbatim over ℤ, ℚ, or polynomial rings"
+    ],
+    "prerequisites": [
+      "Polynomial functional calculus: Polynomial.aeval, aeval_monomial, Polynomial.induction_on'",
+      "Diagonal matrix algebra: diagonal_mul_diagonal, diagonal_pow, diagonal_smul",
+      "Finite sums over Finset.image and Finset.sum_eq_single",
+      "Cayley–Hamilton polynomial reduction (parent file cayley-hamilton-oq-02)"
+    ]
+  },
+  "conclusion": {
+    "summary": "12 theorems, 2 definitions, 243 lines, 0 axioms, 0 sorries. A complete, elementary formalization of Sylvester's interpolation formula f(A) = ∑_μ f(μ) Z_μ for a diagonalizable matrix, together with the full characterization of the Frobenius covariants Z_μ as spectral projections: idempotent, orthogonal, resolving the identity, and projecting onto eigenspaces. Diagonalizability is supplied as similarity data A = U·diagonal(d)·V, and everything holds over an arbitrary commutative ring. Answers the Sylvester open question from cayley-hamilton-oq-02.",
+    "implications": "Sylvester's formula is the explicit, sharp form of the Cayley–Hamilton reduction in the diagonalizable case: instead of reducing f modulo the characteristic polynomial, one reads f(A) off the eigenvalues directly. The covariant decomposition A = ∑_μ μ Z_μ and f(A) = ∑_μ f(μ) Z_μ is the algebraic heart of the holomorphic functional calculus (f(A) = (1/2πi)∮ f(z)(zI−A)⁻¹dz collapses to this finite sum when A is diagonalizable), and underlies closed-form matrix exponentials e^{tA} = ∑_μ e^{tμ} Z_μ used in linear ODE theory and control. The orthogonality and completeness of the Z_μ are the matrix statement of the spectral theorem for diagonalizable operators.",
+    "openQuestions": [
+      "Derive the eigenvalue-quotient form of the covariants, Z_μ = ∏_{ν≠μ}(A − ν I)/(μ − ν), and prove it agrees with the conjugated indicator U·E_μ·V (requires distinct eigenvalues and field hypotheses)?",
+      "Specialize to the matrix exponential: e^{tA} = ∑_μ e^{tμ} Z_μ, recovering the Putzer-algorithm closed form from the spectral decomposition?",
+      "Extend Sylvester interpolation to the non-diagonalizable case via the Jordan form, with confluent (derivative) interpolation data at repeated eigenvalues?"
+    ]
+  },
+  "leanFile": {
+    "namespace": "CayleyHamiltonOQ02OQ02",
+    "lineCount": 243,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/CayleyHamiltonOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-oq-02",
+      "relationship": "extends",
+      "description": "Answers the open question 'Prove Sylvester's interpolation formula f(A) = ∑ f(λⱼ)Zⱼ' posed in the parent; gives the explicit diagonalizable form of the parent's Cayley–Hamilton polynomial reduction"
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "The Cayley–Hamilton theorem underlies the polynomial functional calculus that Sylvester's formula makes explicit on the spectrum"
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-doc",
+      "title": "Module Documentation: Sylvester Interpolation and Frobenius Covariants",
+      "startLine": 6,
+      "endLine": 50,
+      "summary": "Header stating Sylvester's formula f(A) = ∑_λ f(λ)Z_λ, the four covariant identities (idempotent, orthogonal, complete, eigen), the encoding of diagonalizability as similarity data A = U·diagonal(d)·V, and the list of main results. Notes the development is sorry-free and axiom-free."
+    },
+    {
+      "id": "conjugation",
+      "title": "Conjugation commutes with the functional calculus",
+      "startLine": 64,
+      "endLine": 90,
+      "summary": "conj_pow ((U·A·V)^k = U·A^k·V by induction, cancelling V·U = 1) and aeval_conj (aeval (U·A·V) p = U·(aeval A p)·V by polynomial induction, monomial case via conj_pow and the centrality of scalar matrices)."
+    },
+    {
+      "id": "diagonal-calculus",
+      "title": "The functional calculus on a diagonal matrix is diagonal",
+      "startLine": 91,
+      "endLine": 107,
+      "summary": "aeval_diagonal (aeval (diagonal d) p = diagonal (i ↦ p.eval (d i))) by polynomial induction, using diagonal_pow and diagonal_smul in the monomial case."
+    },
+    {
+      "id": "covariants-defs",
+      "title": "Frobenius covariants and coordinate projections",
+      "startLine": 108,
+      "endLine": 155,
+      "summary": "coordProj (diagonal indicator E_μ) and frobeniusCovariant (Z_μ = U·E_μ·V) definitions; coordProj_mul_self (E_μ² = E_μ), coordProj_mul_other (E_μ E_ν = 0), and diag_mul_coordProj (diagonal d · E_μ = μ • E_μ)."
+    },
+    {
+      "id": "spectral-decomposition",
+      "title": "Spectral decomposition of a diagonal matrix",
+      "startLine": 157,
+      "endLine": 175,
+      "summary": "diagonal_eq_sum_coordProj: for any scalar function g, diagonal (i ↦ g(d i)) = ∑_μ g(μ) • E_μ over the distinct eigenvalues, proved entrywise via Finset.sum_eq_single. The g = p.eval and g = 1 instances drive Sylvester's formula and completeness."
+    },
+    {
+      "id": "sylvester",
+      "title": "Sylvester's interpolation formula",
+      "startLine": 176,
+      "endLine": 195,
+      "summary": "sylvester: aeval (U·diagonal(d)·V) p = ∑_μ p.eval μ • frobeniusCovariant U V d μ, chaining aeval_conj, aeval_diagonal, and diagonal_eq_sum_coordProj, then pushing the conjugation through the finite sum."
+    },
+    {
+      "id": "covariant-properties",
+      "title": "Properties of the Frobenius covariants",
+      "startLine": 196,
+      "endLine": 243,
+      "summary": "frobenius_idem (Z_μ² = Z_μ), frobenius_orthogonal (Z_μ Z_ν = 0 for μ ≠ ν), frobenius_complete (∑_μ Z_μ = I via the g = 1 spectral decomposition), and frobenius_eigen (A·Z_μ = μ • Z_μ)."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/cayley-hamilton-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-02-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "cayley-hamilton-oq-02-oq-02",
   "title": "Sylvester Matrix Interpolation via Frobenius Covariants",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETED",
     "since": "2026-06-18T23:18:44-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Sylvester interpolation + Frobenius covariant identities formalized, build-verified GREEN (0 sorry/0 axiom; axioms = propext/Choice/Quot only), gallery-registered.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Merge PR; deployer graduates pool entry.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,32 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "COMPLETE (build-verified GREEN, 0 sorry/0 axiom): Sylvester formula f(A)=∑_μ p.eval μ • Z_μ for diagonalizable A=U·diagonal(d)·V, plus all four Frobenius-covariant identities (idempotent/orthogonal/complete/eigen), 0 sorry / 0 axiom.",
+    "builtItems": [
+      "Proofs/CayleyHamiltonOQ02OQ02.lean — 12 theorems, 2 defs, 239 lines, 0 sorry/0 axiom",
+      "conj_pow: (U·A·V)^k = U·A^k·V via induction cancelling V·U=1",
+      "aeval_conj: aeval (U·A·V) p = U·(aeval A p)·V (polynomial induction)",
+      "aeval_diagonal: aeval (diagonal d) p = diagonal (i ↦ p.eval (d i))",
+      "diagonal_eq_sum_coordProj: diagonal (i↦g(d i)) = ∑_μ g(μ)•E_μ (entrywise, Finset.sum_eq_single)",
+      "sylvester: aeval (U·diagonal(d)·V) p = ∑_μ p.eval μ • frobeniusCovariant U V d μ",
+      "frobenius_idem / frobenius_orthogonal / frobenius_complete / frobenius_eigen"
+    ],
+    "insights": [
+      "Encoding diagonalizability as explicit similarity data A=U·diagonal(d)·V with U·V=V·U=1 avoids all spectral-theorem/eigenspace machinery — everything reduces to diagonal-indicator algebra plus one cancellation V·U=1",
+      "Conjugation commutes with the whole polynomial functional calculus (aeval_conj); proved directly by Polynomial.induction_on rather than packaging an inner-automorphism AlgHom, minimizing dependencies",
+      "Every covariant identity collapses to a diagonal-indicator fact after cancelling V·U=1; completeness ∑_μ Z_μ=I is exactly the g=1 instance of the spectral decomposition lemma",
+      "The result holds over any CommRing with DecidableEq (not just an algebraically closed field) because diagonalizability is supplied as data",
+      "Mathlib API used: aeval_monomial, Algebra.smul_def, diagonal_pow, diagonal_smul, diagonal_mul_diagonal, Matrix.sum_apply, Finset.sum_eq_single, mul_smul_comm/smul_mul_assoc"
+    ],
+    "mathlibGaps": [
+      "Mathlib has no packaged inner-automorphism (conjugation) AlgEquiv for matrix/algebra elements convenient for aeval transport; worked around by direct polynomial induction (conj_pow + aeval_conj)",
+      "Matrix.diagonalAlgHom exists but its @[simps] apply lemma name was not reliably resolvable; used induction-based aeval_diagonal instead"
+    ],
+    "nextSteps": [
+      "Eigenvalue-quotient form Z_μ = ∏_{ν≠μ}(A−νI)/(μ−ν) and its agreement with U·E_μ·V (needs distinct eigenvalues + field)",
+      "Matrix exponential specialization e^{tA} = ∑_μ e^{tμ} Z_μ (Putzer closed form)",
+      "Non-diagonalizable/Jordan extension with confluent interpolation data"
+    ],
     "markdown": "# Knowledge Base: cayley-hamilton-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

Answers the open question raised in **cayley-hamilton-oq-02** ("Prove Sylvester's interpolation formula f(A) = ∑ⱼ f(λⱼ)Zⱼ where Zⱼ are the Frobenius covariants"). New verified gallery entry **cayley-hamilton-oq-02-oq-02**.

For a diagonalizable matrix `A = U · diagonal(d) · V` (with `U·V = V·U = 1`) and any polynomial `p`:

```
aeval (U · diagonal d · V) p = ∑_μ p.eval μ • frobeniusCovariant U V d μ
```

where the sum is over the **distinct** eigenvalues `μ ∈ Finset.univ.image d` and `Z_μ = U·E_μ·V` are the Frobenius covariants — the spectral projections onto the eigenspaces.

## What's proved (12 theorems, 2 defs, 243 lines)

- `sylvester` — Sylvester's interpolation formula (main result)
- `aeval_conj` — conjugation commutes with the functional calculus: `aeval (U·A·V) p = U·(aeval A p)·V`
- `aeval_diagonal` — `aeval (diagonal d) p = diagonal (i ↦ p.eval (d i))`
- `diagonal_eq_sum_coordProj` — spectral decomposition of a diagonal matrix
- `frobenius_idem` / `frobenius_orthogonal` / `frobenius_complete` / `frobenius_eigen` — the Z_μ are idempotent, mutually orthogonal, resolve the identity, and project onto eigenspaces (the matrix spectral theorem for diagonalizable operators)

## Approach

Diagonalizability is supplied as the explicit similarity data `A = U·diagonal(d)·V`, keeping the whole development **elementary** — no spectral-theorem / eigenspace machinery, only diagonal-indicator algebra plus the cancellation `V·U = 1`. Holds over any `CommRing` with `DecidableEq`.

## Verification

- Build: **GREEN** `✔ [7743/7743] Built Proofs.CayleyHamiltonOQ02OQ02` (docker-build.sh)
- `#print axioms`: `propext, Classical.choice, Quot.sound` only — **no `Lean.ofReduceBool`, no `sorryAx`**
- 0 sorries, 0 `axiom` declarations, no assumption-carrying structures → `status: verified`, `badge: mathlib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)