### PR TITLE
audit(erdos-653-oq-01): first audit clean — axiom-free elementary lower bounds, 0-sorry/0-axiom chain verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16081,6 +16081,12 @@
       "lastAudited": "2026-06-19T12:31:08Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-653-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T12:34:13Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit: erdos-653-oq-01 (Elementary Lower Bounds for g(n))

First audit of the 2562nd gallery entry. **Result: CLEAN.**

### Counts (all exact vs meta.json)
| field | meta | source |
|-------|------|--------|
| lineCount | 293 | 293 ✓ |
| theoremCount | 17 | 17 ✓ |
| definitionCount | 2 | 2 ✓ |
| axiomCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |
| native_decide | — | 0 ✓ |

### Transitive-axiom trap did NOT fire
The companion imports `Proofs.Erdos653Problem`, which declares two literature axioms (`csizmadia_bound`, `upper_bound`). The integrity question is whether the companion's "0 axioms / verified" claim survives transitively.

- The parent axioms feed **only** `erdos_653_summary` / `erdos_653` (parent L325).
- The upper-bound lemmas the companion actually cites — `g_le_n` (parent L156) and `g_le_n_sub_one` (parent L192) — are pure `csSup_le'` / `Finset.card_image_le` proofs with **zero** references to either axiom in their bodies.
- The companion's lower bounds (`g_ge_one`, `g_ge_half`) are constructive `le_csSup` witnesses on `collinearConfig`.
- Therefore `g_zero`/`g_one`/`g_two`/`g_three` rest entirely on axiom-free foundations. The only `csizmadia_bound` mentions in the companion are docstrings (L9, L252).

### Narrative
- **Tier A**, **LOW risk**. Title "Elementary Lower Bounds for g(n)" is honestly scoped; the open conjecture `g(n) ≥ (1-o(1))n` is explicitly OUT OF SCOPE; `g(4)=3` honestly noted as escaping the elementary bounds. The `assumptions` field correctly explains the import does not contaminate the axiom-free theorems.
- Badge/status `verified`, axiomCount 0 — all defensible.

Gallery now **2562/2562 audited, 0 issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)