### PR TITLE
Enrich erdos-670: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-670/annotations.json
+++ b/src/data/proofs/erdos-670/annotations.json
@@ -23,7 +23,11 @@
       "open-problem",
       "erdos"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Euclidean space",
+      "Pairwise distances",
+      "Diameter of a set"
+    ]
   },
   {
     "id": "ann-e670-definitions",
@@ -48,7 +52,11 @@
       "finset",
       "formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Euclidean distance",
+      "Finset.sup'",
+      "Predicates in Lean"
+    ]
   },
   {
     "id": "ann-e670-bounds",
@@ -73,7 +81,11 @@
       "conjecture",
       "combinatorics"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Binomial coefficients",
+      "Asymptotic analysis",
+      "Little-o notation"
+    ]
   },
   {
     "id": "ann-e670-d1",
@@ -98,7 +110,11 @@
       "ordering-argument",
       "erdos"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Ordering on ℝ",
+      "Real line",
+      "Telescoping argument"
+    ]
   },
   {
     "id": "ann-e670-constructions",
@@ -122,7 +138,11 @@
       "arithmetic-progression",
       "tightness"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Arithmetic progressions",
+      "Extremal constructions",
+      "Tightness"
+    ]
   },
   {
     "id": "ann-e670-connections",
@@ -147,6 +167,10 @@
       "distinct-distances",
       "connections"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Distinct distances problem",
+      "Guth–Katz theorem",
+      "Pigeonhole principle"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-670` (Erdős Problem #670: Diameter of Sets with Distinct Distances).

Fills the empty per-annotation `prerequisites` field on all 6 annotations with the specific background concepts a reader needs to follow each step. Annotation-only change; no Lean source or build-artifact churn.