### PR TITLE
Enrich erdos-769: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-769/annotations.json
+++ b/src/data/proofs/erdos-769/annotations.json
@@ -16,7 +16,11 @@
       "Homothety",
       "Packing problems"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Combinatorial geometry",
+      "Homothety",
+      "Packing problems"
+    ]
   },
   {
     "id": "ann-e769-decomp",
@@ -35,7 +39,11 @@
       "Geometric packing",
       "Homothetic copies"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Scaling and translation",
+      "Volume",
+      "Geometric packing"
+    ]
   },
   {
     "id": "ann-e769-c-function",
@@ -54,7 +62,11 @@
       "Threshold",
       "Axiomatization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Extremal functions",
+      "Thresholds",
+      "Axiomatization"
+    ]
   },
   {
     "id": "ann-e769-dim2",
@@ -73,7 +85,11 @@
       "Exact values",
       "Geometric constraints"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Square tiling",
+      "Case analysis",
+      "Geometric constraints"
+    ]
   },
   {
     "id": "ann-e769-lower-bounds",
@@ -92,7 +108,11 @@
       "Connor-Marmorino 2018",
       "Exponential bounds"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Exponential growth",
+      "Hadwiger problem",
+      "Lower bounds"
+    ]
   },
   {
     "id": "ann-e769-upper-bounds",
@@ -111,6 +131,10 @@
       "Hudelson 1998",
       "Primality dependence"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Modular arithmetic",
+      "Primality",
+      "Constructive bounds"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-769` (Erdős Problem #769: Cube Dissection into Homothetic Cubes).

Fills the empty per-annotation `prerequisites` field on all 6 annotations with the specific background concepts a reader needs to follow each step. Annotation-only change; no Lean source or build-artifact churn.