### PR TITLE
Enrich erdos-240: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-240/annotations.json
+++ b/src/data/proofs/erdos-240/annotations.json
@@ -23,7 +23,11 @@
       "erdos-problems",
       "solved-problems"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "P-smooth numbers (all prime factors lie in P)",
+      "consecutive gaps tending to infinity",
+      "Tijdeman's theorem (1973)"
+    ]
   },
   {
     "id": "ann-e240-smooth-def",
@@ -48,7 +52,11 @@
       "prime-factorization",
       "number-theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "prime factorization of integers",
+      "membership of prime factors in a set",
+      "smooth / friable numbers"
+    ]
   },
   {
     "id": "ann-e240-one-smooth",
@@ -73,7 +81,11 @@
       "smooth-numbers",
       "base-case"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "1 has no prime divisors",
+      "vacuous-truth proofs",
+      "the P-smooth predicate"
+    ]
   },
   {
     "id": "ann-e240-enum",
@@ -98,7 +110,11 @@
       "well-ordering",
       "smooth-numbers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "ordered enumeration of an infinite set",
+      "monotone indexing functions ℕ → ℕ",
+      "axiomatized object properties"
+    ]
   },
   {
     "id": "ann-e240-gap",
@@ -123,7 +139,10 @@
       "consecutive-integers",
       "smooth-numbers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "consecutive differences smoothEnum(i+1) − smoothEnum(i)",
+      "ordered enumeration of smooth numbers"
+    ]
   },
   {
     "id": "ann-e240-question",
@@ -148,7 +167,11 @@
       "infinite-sets",
       "erdos-problems"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "unbounded gaps (∀M ∃i, gap > M)",
+      "tends-to-infinity formalization",
+      "Prop-valued definitions"
+    ]
   },
   {
     "id": "ann-e240-polya",
@@ -173,7 +196,11 @@
       "quadratic-polynomials",
       "number-theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Pólya's theorem (1918)",
+      "largest prime factor P(f(n)) → ∞",
+      "quadratics without repeated roots"
+    ]
   },
   {
     "id": "ann-e240-finite-case",
@@ -198,7 +225,11 @@
       "quantitative-bounds",
       "gaps"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "finite smooth sets",
+      "pigeonhole on bounded gaps",
+      "Størmer-type finiteness"
+    ]
   },
   {
     "id": "ann-e240-tijdeman",
@@ -223,7 +254,11 @@
       "main-result",
       "number-theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Tijdeman's 1973 theorem",
+      "the lower bound gap ≫ aᵢ^{1−ε}",
+      "constructing infinite sets of primes"
+    ]
   },
   {
     "id": "ann-e240-construction",
@@ -248,7 +283,11 @@
       "geometric-sequences",
       "examples"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "singleton smooth sets P = {p} (powers of p)",
+      "geometric growth of gaps",
+      "rapidly growing prime sequences"
+    ]
   },
   {
     "id": "ann-e240-stormer",
@@ -273,7 +312,11 @@
       "diophantine-equations",
       "number-theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Størmer's theorem",
+      "finitely many consecutive smooth integers",
+      "Pell equations / linear forms in logarithms"
+    ]
   },
   {
     "id": "ann-e240-abc",
@@ -298,7 +341,11 @@
       "open-problems",
       "number-theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "the ABC conjecture",
+      "radical and quality of coprime triples",
+      "consequences for smooth-number gaps"
+    ]
   },
   {
     "id": "ann-e240-summary",
@@ -323,7 +370,11 @@
       "smooth-numbers",
       "tijdeman-theorem"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "the Pólya-based finite-P bound",
+      "Tijdeman's theorem",
+      "combining lemmas into a summary theorem"
+    ]
   },
   {
     "id": "ann-e240-intuition",
@@ -348,7 +399,11 @@
       "smooth-numbers",
       "number-theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "density of smooth numbers",
+      "multiplicative reachability by primes in P",
+      "sparse vs. dense prime sets"
+    ]
   },
   {
     "id": "ann-e240-sorry1",
@@ -373,7 +428,11 @@
       "real-analysis",
       "proof-gap"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "gap growth of order aᵢ^{1/2}",
+      "asymptotic comparison (eventually exceeding M)",
+      "incomplete (sorry) formalization"
+    ]
   },
   {
     "id": "ann-e240-sorry2",
@@ -398,7 +457,11 @@
       "proof-gap",
       "examples"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "powers of a single prime p",
+      "gaps between consecutive p^k",
+      "geometric sequences"
+    ]
   },
   {
     "id": "ann-e240-imports",
@@ -423,7 +486,11 @@
       "lean4",
       "dependencies"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Mathlib module structure",
+      "Nat.Prime, Data.Real.Basic",
+      "organizing Lean imports"
+    ]
   },
   {
     "id": "ann-e240-progressions",
@@ -448,6 +515,10 @@
       "sieve-methods",
       "number-theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "P-smooth numbers in arithmetic progressions",
+      "distribution / equidistribution results",
+      "linear forms in logarithms"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-240` (Erdős Problem #240 — gaps between P-smooth numbers).

All 18 annotations had an empty `prerequisites` field, now populated with accurate, annotation-specific background concepts: smooth/friable numbers, Pólya's theorem (1918), Tijdeman's 1973 lower bound gap ≫ aᵢ^{1−ε}, Størmer's theorem, the ABC conjecture connection, and smooth numbers in arithmetic progressions. No source or build artifacts changed — annotations.json edited directly.