### PR TITLE
Enrich erdos-1174: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1174/annotations.json
+++ b/src/data/proofs/erdos-1174/annotations.json
@@ -16,7 +16,12 @@
       "set-theoretic independence",
       "partition calculus"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Ramsey’s theorem (finite version)",
+      "complete graph K_ω on ℕ",
+      "edge 2-coloring",
+      "monochromatic clique"
+    ]
   },
   {
     "id": "ann-e1174-clique",
@@ -35,7 +40,11 @@
       "Ramsey theory",
       "induced subgraph"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "SimpleGraph.Adj (adjacency relation)",
+      "complete subgraph K_k",
+      "definition of a clique as a set of pairwise-adjacent vertices"
+    ]
   },
   {
     "id": "ann-e1174-k4free",
@@ -54,7 +63,12 @@
       "graph density",
       "forbidden subgraph"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "clique definition (preceding)",
+      "complete graph K₄",
+      "forbidden-subgraph constraint",
+      "the 6 edges among 4 vertices"
+    ]
   },
   {
     "id": "ann-e1174-cardinal-clique",
@@ -73,7 +87,12 @@
       "cardinal arithmetic",
       "set theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Cardinal.mk and cardinal comparison",
+      "ℵ₁ as the first uncountable cardinal",
+      "clique definition",
+      "strict cardinal inequality < κ"
+    ]
   },
   {
     "id": "ann-e1174-symmetric-coloring",
@@ -91,7 +110,11 @@
       "graph homomorphism"
     ],
     "mathContext": "See annotation content for formal details of symmetric coloring structure",
-    "prerequisites": []
+    "prerequisites": [
+      "function type V → V → C",
+      "symmetry condition f(v,w)=f(w,v)",
+      "unordered edges {v,w}"
+    ]
   },
   {
     "id": "ann-e1174-mono-triangle",
@@ -110,7 +133,12 @@
       "monochromatic subgraph",
       "countable coloring"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "SimpleGraph.Adj",
+      "triangle as a 3-clique",
+      "symmetric coloring f",
+      "equality of three edge colors"
+    ]
   },
   {
     "id": "ann-e1174-eh-finite",
@@ -129,7 +157,12 @@
       "Ramsey forcing"
     ],
     "mathContext": "See annotation content for formal details of erdős-hajnal finite property",
-    "prerequisites": []
+    "prerequisites": [
+      "K₄-free definition",
+      "HasMonochromaticTriangle",
+      "countably many colors (ℵ₀ colors)",
+      "conjunction of two predicates"
+    ]
   },
   {
     "id": "ann-e1174-part-a",
@@ -148,7 +181,11 @@
       "Type*"
     ],
     "mathContext": "See annotation content for formal details of problem 1174 part (a)",
-    "prerequisites": []
+    "prerequisites": [
+      "existential quantification over Type*",
+      "SimpleGraph G on V",
+      "Erdős–Hajnal finite property predicate"
+    ]
   },
   {
     "id": "ann-e1174-mono-aleph0",
@@ -167,7 +204,11 @@
       "aleph-0",
       "infinite Ramsey theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "ℵ₀ and Set.Countable / Set.Infinite",
+      "clique definition",
+      "constant color c on all edges of S"
+    ]
   },
   {
     "id": "ann-e1174-eh-infinite",
@@ -186,7 +227,12 @@
       "uncountable cardinals"
     ],
     "mathContext": "See annotation content for formal details of erdős-hajnal infinite property and part (b)",
-    "prerequisites": []
+    "prerequisites": [
+      "IsCliqueFreeCardinal G ℵ₁",
+      "countable edge coloring",
+      "HasMonochromaticAleph0Clique",
+      "transfinite analog of the finite property"
+    ]
   },
   {
     "id": "ann-e1174-ramsey",
@@ -205,7 +251,11 @@
       "König's lemma",
       "infinite combinatorics"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "infinite Ramsey theorem for 2 colors",
+      "axiom declaration in Lean",
+      "monochromatic countably infinite clique"
+    ]
   },
   {
     "id": "ann-e1174-complete-not-k4free",
@@ -224,7 +274,12 @@
       "proof by contradiction",
       "constructive mathematics"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "complete graph (⊤ : SimpleGraph ℕ)",
+      "proof by contradiction",
+      "K₄-free definition",
+      "the explicit 4-clique {0,1,2,3}"
+    ]
   },
   {
     "id": "ann-e1174-partition",
@@ -243,7 +298,12 @@
       "Erdős-Rado theorem",
       "arrow notation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "arrow notation G → (k)²_c",
+      "partition calculus",
+      "edge coloring with numColors colors",
+      "monochromatic clique of size k"
+    ]
   },
   {
     "id": "ann-e1174-nesetril-rodl",
@@ -262,7 +322,12 @@
       "Hales-Jewett theorem",
       "amalgamation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "structural Ramsey theory",
+      "partitionProperty predicate",
+      "axiomatization of a deep theorem",
+      "K₄-free graphs with G → (3)²_{k+1}"
+    ]
   },
   {
     "id": "ann-e1174-shelah",
@@ -281,7 +346,11 @@
       "consistency",
       "set-theoretic independence"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "ZFC consistency statements",
+      "forcing",
+      "distinction between a comment and a formal axiom"
+    ]
   },
   {
     "id": "ann-e1174-summary",
@@ -300,6 +369,10 @@
       "Ramsey theory"
     ],
     "mathContext": "See annotation content for formal details of open status summary",
-    "prerequisites": []
+    "prerequisites": [
+      "independence from ZFC",
+      "the Nešetřil–Rödl and Shelah results above",
+      "open-problem status"
+    ]
   }
 ]


### PR DESCRIPTION
Adds `prerequisites` to all 16 annotations (was empty). Prereq-only change to annotations.json; no source/build churn.