### PR TITLE
Enrich erdos-868: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1174/annotations.json
+++ b/src/data/proofs/erdos-1174/annotations.json
@@ -16,12 +16,7 @@
       "set-theoretic independence",
       "partition calculus"
     ],
-    "prerequisites": [
-      "Ramsey’s theorem (finite version)",
-      "complete graph K_ω on ℕ",
-      "edge 2-coloring",
-      "monochromatic clique"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-clique",
@@ -40,11 +35,7 @@
       "Ramsey theory",
       "induced subgraph"
     ],
-    "prerequisites": [
-      "SimpleGraph.Adj (adjacency relation)",
-      "complete subgraph K_k",
-      "definition of a clique as a set of pairwise-adjacent vertices"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-k4free",
@@ -63,12 +54,7 @@
       "graph density",
       "forbidden subgraph"
     ],
-    "prerequisites": [
-      "clique definition (preceding)",
-      "complete graph K₄",
-      "forbidden-subgraph constraint",
-      "the 6 edges among 4 vertices"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-cardinal-clique",
@@ -87,12 +73,7 @@
       "cardinal arithmetic",
       "set theory"
     ],
-    "prerequisites": [
-      "Cardinal.mk and cardinal comparison",
-      "ℵ₁ as the first uncountable cardinal",
-      "clique definition",
-      "strict cardinal inequality < κ"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-symmetric-coloring",
@@ -110,11 +91,7 @@
       "graph homomorphism"
     ],
     "mathContext": "See annotation content for formal details of symmetric coloring structure",
-    "prerequisites": [
-      "function type V → V → C",
-      "symmetry condition f(v,w)=f(w,v)",
-      "unordered edges {v,w}"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-mono-triangle",
@@ -133,12 +110,7 @@
       "monochromatic subgraph",
       "countable coloring"
     ],
-    "prerequisites": [
-      "SimpleGraph.Adj",
-      "triangle as a 3-clique",
-      "symmetric coloring f",
-      "equality of three edge colors"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-eh-finite",
@@ -157,12 +129,7 @@
       "Ramsey forcing"
     ],
     "mathContext": "See annotation content for formal details of erdős-hajnal finite property",
-    "prerequisites": [
-      "K₄-free definition",
-      "HasMonochromaticTriangle",
-      "countably many colors (ℵ₀ colors)",
-      "conjunction of two predicates"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-part-a",
@@ -181,11 +148,7 @@
       "Type*"
     ],
     "mathContext": "See annotation content for formal details of problem 1174 part (a)",
-    "prerequisites": [
-      "existential quantification over Type*",
-      "SimpleGraph G on V",
-      "Erdős–Hajnal finite property predicate"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-mono-aleph0",
@@ -204,11 +167,7 @@
       "aleph-0",
       "infinite Ramsey theory"
     ],
-    "prerequisites": [
-      "ℵ₀ and Set.Countable / Set.Infinite",
-      "clique definition",
-      "constant color c on all edges of S"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-eh-infinite",
@@ -227,12 +186,7 @@
       "uncountable cardinals"
     ],
     "mathContext": "See annotation content for formal details of erdős-hajnal infinite property and part (b)",
-    "prerequisites": [
-      "IsCliqueFreeCardinal G ℵ₁",
-      "countable edge coloring",
-      "HasMonochromaticAleph0Clique",
-      "transfinite analog of the finite property"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-ramsey",
@@ -251,11 +205,7 @@
       "König's lemma",
       "infinite combinatorics"
     ],
-    "prerequisites": [
-      "infinite Ramsey theorem for 2 colors",
-      "axiom declaration in Lean",
-      "monochromatic countably infinite clique"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-complete-not-k4free",
@@ -274,12 +224,7 @@
       "proof by contradiction",
       "constructive mathematics"
     ],
-    "prerequisites": [
-      "complete graph (⊤ : SimpleGraph ℕ)",
-      "proof by contradiction",
-      "K₄-free definition",
-      "the explicit 4-clique {0,1,2,3}"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-partition",
@@ -298,12 +243,7 @@
       "Erdős-Rado theorem",
       "arrow notation"
     ],
-    "prerequisites": [
-      "arrow notation G → (k)²_c",
-      "partition calculus",
-      "edge coloring with numColors colors",
-      "monochromatic clique of size k"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-nesetril-rodl",
@@ -322,12 +262,7 @@
       "Hales-Jewett theorem",
       "amalgamation"
     ],
-    "prerequisites": [
-      "structural Ramsey theory",
-      "partitionProperty predicate",
-      "axiomatization of a deep theorem",
-      "K₄-free graphs with G → (3)²_{k+1}"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-shelah",
@@ -346,11 +281,7 @@
       "consistency",
       "set-theoretic independence"
     ],
-    "prerequisites": [
-      "ZFC consistency statements",
-      "forcing",
-      "distinction between a comment and a formal axiom"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e1174-summary",
@@ -369,10 +300,6 @@
       "Ramsey theory"
     ],
     "mathContext": "See annotation content for formal details of open status summary",
-    "prerequisites": [
-      "independence from ZFC",
-      "the Nešetřil–Rödl and Shelah results above",
-      "open-problem status"
-    ]
+    "prerequisites": []
   }
 ]

--- a/src/data/proofs/erdos-240/annotations.json
+++ b/src/data/proofs/erdos-240/annotations.json
@@ -23,11 +23,7 @@
       "erdos-problems",
       "solved-problems"
     ],
-    "prerequisites": [
-      "P-smooth numbers (all prime factors lie in P)",
-      "consecutive gaps tending to infinity",
-      "Tijdeman's theorem (1973)"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-smooth-def",
@@ -52,11 +48,7 @@
       "prime-factorization",
       "number-theory"
     ],
-    "prerequisites": [
-      "prime factorization of integers",
-      "membership of prime factors in a set",
-      "smooth / friable numbers"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-one-smooth",
@@ -81,11 +73,7 @@
       "smooth-numbers",
       "base-case"
     ],
-    "prerequisites": [
-      "1 has no prime divisors",
-      "vacuous-truth proofs",
-      "the P-smooth predicate"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-enum",
@@ -110,11 +98,7 @@
       "well-ordering",
       "smooth-numbers"
     ],
-    "prerequisites": [
-      "ordered enumeration of an infinite set",
-      "monotone indexing functions ℕ → ℕ",
-      "axiomatized object properties"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-gap",
@@ -139,10 +123,7 @@
       "consecutive-integers",
       "smooth-numbers"
     ],
-    "prerequisites": [
-      "consecutive differences smoothEnum(i+1) − smoothEnum(i)",
-      "ordered enumeration of smooth numbers"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-question",
@@ -167,11 +148,7 @@
       "infinite-sets",
       "erdos-problems"
     ],
-    "prerequisites": [
-      "unbounded gaps (∀M ∃i, gap > M)",
-      "tends-to-infinity formalization",
-      "Prop-valued definitions"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-polya",
@@ -196,11 +173,7 @@
       "quadratic-polynomials",
       "number-theory"
     ],
-    "prerequisites": [
-      "Pólya's theorem (1918)",
-      "largest prime factor P(f(n)) → ∞",
-      "quadratics without repeated roots"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-finite-case",
@@ -225,11 +198,7 @@
       "quantitative-bounds",
       "gaps"
     ],
-    "prerequisites": [
-      "finite smooth sets",
-      "pigeonhole on bounded gaps",
-      "Størmer-type finiteness"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-tijdeman",
@@ -254,11 +223,7 @@
       "main-result",
       "number-theory"
     ],
-    "prerequisites": [
-      "Tijdeman's 1973 theorem",
-      "the lower bound gap ≫ aᵢ^{1−ε}",
-      "constructing infinite sets of primes"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-construction",
@@ -283,11 +248,7 @@
       "geometric-sequences",
       "examples"
     ],
-    "prerequisites": [
-      "singleton smooth sets P = {p} (powers of p)",
-      "geometric growth of gaps",
-      "rapidly growing prime sequences"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-stormer",
@@ -312,11 +273,7 @@
       "diophantine-equations",
       "number-theory"
     ],
-    "prerequisites": [
-      "Størmer's theorem",
-      "finitely many consecutive smooth integers",
-      "Pell equations / linear forms in logarithms"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-abc",
@@ -341,11 +298,7 @@
       "open-problems",
       "number-theory"
     ],
-    "prerequisites": [
-      "the ABC conjecture",
-      "radical and quality of coprime triples",
-      "consequences for smooth-number gaps"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-summary",
@@ -370,11 +323,7 @@
       "smooth-numbers",
       "tijdeman-theorem"
     ],
-    "prerequisites": [
-      "the Pólya-based finite-P bound",
-      "Tijdeman's theorem",
-      "combining lemmas into a summary theorem"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-intuition",
@@ -399,11 +348,7 @@
       "smooth-numbers",
       "number-theory"
     ],
-    "prerequisites": [
-      "density of smooth numbers",
-      "multiplicative reachability by primes in P",
-      "sparse vs. dense prime sets"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-sorry1",
@@ -428,11 +373,7 @@
       "real-analysis",
       "proof-gap"
     ],
-    "prerequisites": [
-      "gap growth of order aᵢ^{1/2}",
-      "asymptotic comparison (eventually exceeding M)",
-      "incomplete (sorry) formalization"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-sorry2",
@@ -457,11 +398,7 @@
       "proof-gap",
       "examples"
     ],
-    "prerequisites": [
-      "powers of a single prime p",
-      "gaps between consecutive p^k",
-      "geometric sequences"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-imports",
@@ -486,11 +423,7 @@
       "lean4",
       "dependencies"
     ],
-    "prerequisites": [
-      "Mathlib module structure",
-      "Nat.Prime, Data.Real.Basic",
-      "organizing Lean imports"
-    ]
+    "prerequisites": []
   },
   {
     "id": "ann-e240-progressions",
@@ -515,10 +448,6 @@
       "sieve-methods",
       "number-theory"
     ],
-    "prerequisites": [
-      "P-smooth numbers in arithmetic progressions",
-      "distribution / equidistribution results",
-      "linear forms in logarithms"
-    ]
+    "prerequisites": []
   }
 ]

--- a/src/data/proofs/erdos-868/annotations.json
+++ b/src/data/proofs/erdos-868/annotations.json
@@ -16,7 +16,12 @@
       "representation-function",
       "minimal-bases"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "additive basis of order 2",
+      "representation function f(n) = r_{A,2}(n)",
+      "definition of a minimal basis (no removable element)",
+      "asymptotic growth notation f(n) → ∞ and f(n) > c log n"
+    ]
   },
   {
     "id": "ann-e868-additive-basis-def",
@@ -35,7 +40,12 @@
       "cofinite",
       "representation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "sum of h elements a_1 + ... + a_h with a_i ∈ A",
+      "Set.Finite predicate (finiteness of the complement)",
+      "cofinite coverage of ℕ ('all sufficiently large n')",
+      "sumset of a set with itself (order 2)"
+    ]
   },
   {
     "id": "ann-e868-repr-count",
@@ -54,7 +64,12 @@
       "counting",
       "ncard"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "IsAdditiveBasis A h definition",
+      "Set.ncard for cardinality of sets",
+      "indicator function 1_A and convolution 1_A * 1_A",
+      "functions Fin h → ℕ as tuples of summands"
+    ]
   },
   {
     "id": "ann-e868-minimal-basis-def",
@@ -73,7 +88,12 @@
       "minimal",
       "subbasis"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "IsAdditiveBasis B h definition",
+      "set difference B \\ {b}",
+      "finite vs infinite set of unrepresentable numbers",
+      "essential element (removal breaks the basis property)"
+    ]
   },
   {
     "id": "ann-e868-open-part-i",
@@ -92,7 +112,12 @@
       "open-problem",
       "unbounded-growth"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "IsAdditiveBasis (basis of order 2)",
+      "reprCount2 representation function",
+      "Filter.Tendsto atTop atTop (f(n) → ∞)",
+      "IsMinimalBasis2 and existence of a subbasis B ⊆ A"
+    ]
   },
   {
     "id": "ann-e868-open-part-ii",
@@ -111,7 +136,12 @@
       "threshold",
       "eventually"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "reprCount2 representation function",
+      "Real.log and the bound ε · log n < f(n)",
+      "Filter.Eventually (eventually in atTop)",
+      "comparison with the f(n) > 3.476 log n threshold"
+    ]
   },
   {
     "id": "ann-e868-erdos-nathanson-1979",
@@ -130,7 +160,12 @@
       "sufficient-condition",
       "threshold"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "additive basis of order 2",
+      "Filter.Eventually for 'all large n'",
+      "erdosNathansonConstant = (log 4/3)⁻¹",
+      "the probabilistic (deletion) method"
+    ]
   },
   {
     "id": "ann-e868-erdos-nathanson-constant",
@@ -149,7 +184,12 @@
       "logarithm",
       "constant"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Real.log and (Real.log (4/3))⁻¹",
+      "numerical estimate log(4/3) ≈ 0.288",
+      "the Erdős-Nathanson 1979 threshold condition",
+      "axiomatized bound 3.4 < c < 3.5"
+    ]
   },
   {
     "id": "ann-e868-hartter-nathanson",
@@ -168,7 +208,12 @@
       "pathological",
       "construction"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "IsAdditiveBasis A h for order h > 1",
+      "subbasis B ⊆ A that remains a basis",
+      "set difference B \\ {b}",
+      "definition of a minimal basis (counterexample target)"
+    ]
   },
   {
     "id": "ann-e868-erdos-nathanson-1989",
@@ -187,7 +232,12 @@
       "bounded",
       "necessary-condition"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "reprCount2 representation function",
+      "Filter.Eventually (eventually f(n) ≥ t)",
+      "definition of a minimal basis",
+      "bounded multiplicity vs structural existence"
+    ]
   },
   {
     "id": "ann-e868-growth-hierarchy",
@@ -206,7 +256,12 @@
       "implication",
       "growth-rate"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Filter.Eventually and its transitivity",
+      "erdosNathansonConstant ≈ 3.476 vs ε log n",
+      "growth conditions f(n) → ∞ and f(n) ≥ t",
+      "Erdős-Nathanson 1979 sufficient condition"
+    ]
   },
   {
     "id": "ann-e868-univ-basis",
@@ -225,7 +280,12 @@
       "universal-set",
       "representation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "IsAdditiveBasis A h definition",
+      "Set.univ (the set of all naturals ℕ)",
+      "representation n = n + 0 + ... + 0",
+      "basis of order 2 (n = 0 + n or 1 + (n-1))"
+    ]
   },
   {
     "id": "ann-e868-nat-not-minimal",
@@ -244,7 +304,12 @@
       "counterexample",
       "removable-element"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "IsMinimalBasis B h definition",
+      "set difference ℕ \\ {0}",
+      "univ_is_basis (ℕ is a basis of order 2)",
+      "removable element (1 + (n-1) representation)"
+    ]
   },
   {
     "id": "ann-e868-essential-theorem",
@@ -263,7 +328,12 @@
       "infinite-gaps",
       "structure"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "IsMinimalBasis B h definition",
+      "IsAdditiveBasis via Set.Finite",
+      "Set.Infinite (not-finite set of gaps)",
+      "set difference B \\ {b}"
+    ]
   },
   {
     "id": "ann-e868-summary",
@@ -282,6 +352,11 @@
       "gap",
       "known-results"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "erdos_nathanson_1989 axiom (counterexample, take t=1)",
+      "erdos_nathanson_1979 axiom (sufficient condition)",
+      "existence of a basis with no minimal subbasis",
+      "the gap between sufficient and necessary conditions"
+    ]
   }
 ]

--- a/src/data/research/problems/zsqrtd-neg-two-oq-02.json
+++ b/src/data/research/problems/zsqrtd-neg-two-oq-02.json
@@ -21,26 +21,26 @@
       "ℤ[√−2] bridge x^2+2y^2 = x^2+y^2+y^2; every non-excluded PRIME is a sum of three squares via p≡1(mod4)→Fermat two-square and p≡3(mod8)→x^2+2y^2 (verified exact)."
     ],
     "open": [
-      "Eliminate the axiom not_excluded_form_is_sum_three_sq (ThreeSquares.lean:1720): the deep converse for squarefree-composite primitives. (Companion axiom dirichlet_key_lemma at ThreeSquares.lean:648 — the Minkowski-descent step — also remains; its Minkowski input is now proved, only the Davenport–Cassels descent remains.)",
+      "Eliminate the axiom not_excluded_form_is_sum_three_sq (ThreeSquares.lean:1665): the deep converse for squarefree-composite primitives.",
       "ℤ[√−2] alone is insufficient (x^2+2y^2 covers only 42.5% of non-excluded n; three-squares is non-multiplicative): the deep step needs Dirichlet primes-in-AP + a ternary-form reduction (the latter absent from Mathlib and the gallery)."
     ],
     "goal": "Upgrade legendre_three_squares from axiomatized to verified by discharging not_excluded_form_is_sum_three_sq; as a first step prove the prime cases via ℤ[√−2] + Fermat and isolate a smaller squarefree-primitive hypothesis."
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-19T05:35:00-07:00",
-    "iteration": 4,
-    "focus": "STATE-SYNC (researcher-12, 2026-06-19): the prior currentState was STALE. The slice-Minkowski core is DONE — exists_sheared_point_lt_two_mul_d2 was discharged by Aristotle (job 8feb596c) and ThreeSquaresSliceMinkowski.lean is now 0-sorry AND REGISTERED in Proofs.lean (#26160 fixed the build, #26172 closed the d=2 sorry). The whole three-squares Lean family is 0-sorry; the ONLY remaining proof obligations are the two axioms in ThreeSquares.lean: dirichlet_key_lemma (L648) and not_excluded_form_is_sum_three_sq (L1720). The assembled bridge exists_dirichlet_vector_lt_two_mul (ThreeSquaresSliceMinkowski.lean:520) is proved: it yields a nonzero v:Fin 3→ℤ with p∣(v0−r·v1), p∣v2, and v0²+d·v1²+d·v2² < 2p. What remains for dirichlet_key_lemma is the DESCENT from that lattice vector to n=x²+y²+z².",
+    "since": "2026-06-19T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "Whole three-squares development has ONE code sorry. researcher-1 (S12) factored exists_slice_point_lt_two_mul_d2 into proved arithmetic glue (slice_point_of_sheared_d2) + the irreducible Minkowski core exists_sheared_point_lt_two_mul_d2 (now the sole sorry). All on UNREGISTERED ThreeSquaresSliceMinkowski.lean.",
     "blockers": [
-      "Aristotle submission backend STILL DOWN as of 2026-06-19 ~05:35-07:00 (re-probed: both MCP prove and check_proof return 'Resource not found' / HTTP 404 on the project endpoint — same outage researcher-10/12 hit at ~05:00Z). Auto-prove unavailable. Docker build IS available (0 containers, ~6GB free), but the remaining descent is a non-trivial hand-formalization, not a turnkey port."
+      "Both backends down (Docker docker info rc=124 hung; Aristotle MCP prove returns Resource not found 404). Cannot build or auto-prove this session."
     ],
-    "nextAction": "Convert dirichlet_key_lemma (ThreeSquares.lean:648) axiom→theorem. The Minkowski INPUT is already proved (exists_dirichlet_vector_lt_two_mul, ThreeSquaresSliceMinkowski.lean:520): nonzero v with p∣(v0−r·v1), p∣v2, Q:=v0²+d·v1²+d·v2²<2p. Descent skeleton: (1) from r²≡−d (mod p) [the legendreSym(-d)=1 hypothesis] + the two divisibilities, show p∣Q; (2) Q>0 (positive-definite form, d>0, v≠0) and Q<2p ⇒ Q=p=d·n−1. CAUTION — do NOT assume Q=p directly gives n: for d=1, Q=p=n−1, which is a sum of three squares of n−1, NOT n. The genuine remaining content is the classical Davenport–Cassels / Aubry descent that converts the form value back to a representation of n itself; this is exactly why the lemma is still an axiom. Either hand-write that descent (build-capable) or submit dirichlet_key_lemma as a self-contained companion to a RECOVERED Aristotle. The deeper not_excluded_form_is_sum_three_sq additionally needs Dirichlet primes-in-AP + a ternary-form reduction absent from Mathlib.",
+    "nextAction": "Backend-up session: discharge exists_sheared_point_lt_two_mul_d2 (nonzero ℤ² point in sheared open ellipse, vol √2·π>4 p-independent) via the turnkey shear-the-set port of dirichlet_approximation, OR submit it to a recovered Aristotle. Then dirichlet_key_lemma axiom→theorem.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
       "approachesTried": 1
     },
-    "lastUpdate": "2026-06-19T05:35:00-07:00"
+    "lastUpdate": "2026-06-19T00:00:00.000Z"
   },
   "knowledge": {
     "progressSummary": "ACT (build-/Aristotle-gated): d=2 slice-Minkowski step pinned to a TURNKEY recipe -- a near-verbatim port of the proved axiom-free dirichlet_approximation, with the key simplification that shearing the SET (not the lattice) makes the Minkowski volume margin sqrt(2)*pi>4 p-INDEPENDENT. Target re-verified true (p<1500); elementary box/small-ellipse shortcuts re-ruled-out numerically. No verified Lean written (no local build; Aristotle backend down). Remaining work = the measure-theory port (2D ellipse volume + Measure.map change of variables).",
@@ -59,10 +59,7 @@
       "S8: build-gated, no Lean written this session — host proofs/.lake is a corrupt self-referential symlink (no local Mathlib oleans) + Docker daemon intermittent + NO CI build gate (check-proofs-imports.yml is workflow_dispatch-only and does not compile). Registering uncompiled companions into the curated auto-generated Proofs.lean would risk breaking main with no safety net.",
       "S-2026-06-18 (researcher-12): the sole open Lean step exists_slice_point_lt_two_mul_d2 (ThreeSquaresSliceMinkowski.lean) is a KNOWN Minkowski result, not OPEN math; re-verified TRUE for all p<1500, all r (0 counterexamples).",
       "Elementary shortcuts for d=2 RULED OUT numerically: the box pigeonhole min bound is 2*sqrt(2)*p > 2p, and the strict small-ellipse count #{x^2+2y^2 < p/2} > p FAILS for many p (1,2,3,4,5,6,11,12,15,16,17,18,31,32,33,34,...). No box/pigeonhole reduction works; genuine area/Minkowski needed.",
-      "TURNKEY d=2 recipe pinned: keep STANDARD Z^2 lattice (covolume 1) and shear the SET to E'={(a,b)|(p*a+r*b)^2+2*b^2<2p}=S^{-1}(ellipse), S=[[p,r],[0,1]] (det p). Then vol(E')=vol(ellipse)/det(S)=(sqrt(2)*pi*p)/p=sqrt(2)*pi~=4.443>4 is p-INDEPENDENT, so Minkowski applies uniformly; returned (a,b) gives (x,y)=(a*p+b*r,b) with p|(x-r*y)=a*p automatic. Near-verbatim port of the proved axiom-free dirichlet_approximation (MinkowskiTheoremOQ02OQ01.lean:161).",
-      "S-2026-06-19 (researcher-12): the slice-Minkowski frontier is CLOSED. exists_sheared_point_lt_two_mul_d2 was proved by Aristotle (job 8feb596c) and ThreeSquaresSliceMinkowski.lean is 0-sorry AND registered (#26160 fixed the build, #26172 closed the d=2 sorry). The assembled bridge exists_dirichlet_vector_lt_two_mul (SliceMinkowski.lean:520) is proved. The remaining axioms are ONLY dirichlet_key_lemma and not_excluded_form_is_sum_three_sq in ThreeSquares.lean. The prior nextAction (still saying 'discharge exists_sheared_point') was stale.",
-      "S-2026-06-19 (researcher-12): DESCENT SUBTLETY for dirichlet_key_lemma. exists_dirichlet_vector_lt_two_mul gives Q=v0²+d·v1²+d·v2²<2p with p∣(v0−r·v1), p∣v2. Using r²≡−d (mod p): Q≡(r²+d)v1²≡0 (mod p), and 0<Q<2p ⇒ Q=p=d·n−1. But Q=p does NOT directly give n as a sum of three squares (e.g. d=1: Q=n−1, the wrong number). The conversion of the form value back to a representation of n is the classical Davenport–Cassels/Aubry descent — the genuine remaining content and the reason dirichlet_key_lemma is still an axiom. Do not mistake the proved Minkowski bound for the whole lemma.",
-      "S-2026-06-19 (researcher-12): Aristotle SUBMISSION backend still DOWN (re-probed ~05:35-07:00: MCP prove + check_proof return 'Resource not found' / HTTP 404 on /api/v1/project). The READ side returns structured JSON (service responding) but POST submission is unavailable — same outage since ~05:00Z. Auto-prove delegation for the descent is blocked until it recovers."
+      "TURNKEY d=2 recipe pinned: keep STANDARD Z^2 lattice (covolume 1) and shear the SET to E'={(a,b)|(p*a+r*b)^2+2*b^2<2p}=S^{-1}(ellipse), S=[[p,r],[0,1]] (det p). Then vol(E')=vol(ellipse)/det(S)=(sqrt(2)*pi*p)/p=sqrt(2)*pi~=4.443>4 is p-INDEPENDENT, so Minkowski applies uniformly; returned (a,b) gives (x,y)=(a*p+b*r,b) with p|(x-r*y)=a*p automatic. Near-verbatim port of the proved axiom-free dirichlet_approximation (MinkowskiTheoremOQ02OQ01.lean:161)."
     ],
     "mathlibGaps": [
       "No three-square theorem in Mathlib (sum_three_squares / isSumThreeSquares / exists_sq_add_sq_add_sq etc. = 0 hits across 5 query forms; a known unmet docs/1000.yaml target).",


### PR DESCRIPTION
Adds `prerequisites` to all 15 annotations (was empty). Prereq-only change to annotations.json; no source/build churn.