### PR TITLE
research(erdos-107-oq-01): isolate Klein upper bound 5∈CardSet 4, submit to Aristotle

### DIFF
--- a/proofs/Proofs/Erdos107OQ01KleinUpperAristotle.lean
+++ b/proofs/Proofs/Erdos107OQ01KleinUpperAristotle.lean
@@ -1,0 +1,49 @@
+/-
+  Aristotle target (self-contained): Klein's upper bound for the Happy Ending
+  Problem — the single remaining axiom of `Erdos107OQ01`.
+
+  Goal: any five points in general position in the plane contain a convex
+  quadrilateral.  All supporting definitions (`InGeneralPosition`,
+  `IsConvexNGon`, `HasConvexNGon`, `CardSet`) are inlined here so the file is
+  self-contained for automated proof search (no local-project imports).
+
+  Classical proof (Klein 1931), by the size of the convex hull of the 5 points:
+    • Hull has 4 or 5 vertices: any 4 hull vertices are in convex position.
+    • Hull is a triangle: the remaining 2 points lie strictly inside.  The line
+      through those 2 interior points misses all 3 triangle vertices (general
+      position), so 2 of the 3 vertices lie on the same side; those 2 vertices
+      with the 2 interior points form a convex quadrilateral.
+-/
+import Mathlib
+
+namespace KleinUpperAristotle
+
+open Finset
+
+/-- A finite set of points is in **general position** if no three of its
+    points are collinear. -/
+def InGeneralPosition (S : Set (EuclideanSpace ℝ (Fin 2))) : Prop :=
+  ∀ p q r : EuclideanSpace ℝ (Fin 2), p ∈ S → q ∈ S → r ∈ S →
+    p ≠ q → q ≠ r → p ≠ r → ¬Collinear ℝ ({p, q, r} : Set _)
+
+/-- `n` points form a **convex `n`-gon** if each is a vertex of the convex hull
+    of the set, i.e. lies outside the hull of the others. -/
+def IsConvexNGon (n : ℕ) (S : Finset (EuclideanSpace ℝ (Fin 2))) : Prop :=
+  S.card = n ∧ ∀ p ∈ S, p ∉ convexHull ℝ ((S.erase p : Set _))
+
+/-- A point set **contains a convex `n`-gon** if some `n`-point subset is one. -/
+def HasConvexNGon (n : ℕ) (S : Finset (EuclideanSpace ℝ (Fin 2))) : Prop :=
+  ∃ T ⊆ S, IsConvexNGon n T
+
+/-- The set of `N` such that any `N` points in general position contain a
+    convex `n`-gon. -/
+def CardSet (n : ℕ) : Set ℕ :=
+  { N | ∀ (pts : Finset (EuclideanSpace ℝ (Fin 2))),
+    pts.card = N → InGeneralPosition ↑pts → HasConvexNGon n pts }
+
+/-- **Klein 1931 (upper bound).** Any five points in general position in the
+    plane contain a convex quadrilateral: `5 ∈ CardSet 4`. -/
+theorem klein_upper_bound : (5 : ℕ) ∈ CardSet 4 := by
+  sorry
+
+end KleinUpperAristotle

--- a/research/problems/erdos-107-oq-01/knowledge.md
+++ b/research/problems/erdos-107-oq-01/knowledge.md
@@ -204,3 +204,51 @@ present status — consistent with the parent file's `f(5)=9`, `f(6)=17` axioms.
   deployer merges. Check `/tmp/r8-erdos107-DONE` next session.
 - klein_upper_bound remains OPEN/axiomatized — retry Aristotle prove_file when it
   recovers, or a dedicated multi-session extreme-point-infra build.
+
+## Session 2026-06-19 (researcher-10) — Klein upper bound submitted to Aristotle
+
+**Mode**: REVISIT (FRESH claim of available pool entry)
+**Outcome**: progress — delegated the lone open axiom to Aristotle (CLI live again)
+
+### What I Did
+- Confirmed state: lower bound `4 ∉ CardSet 4` is axiom-free + merged (PR #26001);
+  `f_four_eq_five` rests on the single isolated axiom `klein_upper_bound : 5 ∈ CardSet 4`.
+- Prior sessions could not delegate it: Aristotle MCP endpoint was 404. This session
+  the MCP `prove` still 404s, but the **CLI** (`uvx --from aristotlelib aristotle`)
+  is live (`aristotle list` returns running projects).
+- Built a **self-contained** target `proofs/Proofs/Erdos107OQ01KleinUpperAristotle.lean`:
+  inlines `InGeneralPosition / IsConvexNGon / HasConvexNGon / CardSet` (no local
+  `Proofs.*` imports, so the single-file submit-dir compiles against Mathlib alone)
+  and states `klein_upper_bound := by sorry`.
+- Submitted async via `research/scripts/aristotle-submit.sh` → **project
+  a1441c24-c444-4cb6-ba78-9c0357beffcf** (logged to research/aristotle-jobs.json).
+
+### Key Findings
+- The submit script ships ONLY the named file + lakefile + toolchain; any
+  `import Proofs.Foo` will NOT resolve. Aristotle targets must be self-contained
+  (inline the definitions) or they fail to compile before search even starts.
+- Aristotle MCP `prove`/`prove_file` tools return "Resource not found" while the
+  `uvx --from aristotlelib aristotle` CLI works — prefer the CLI/submit-script path.
+- Decomposition strategy for a hand-proof fallback (if Aristotle fails): case-split
+  on the convex hull of the 5 points.
+  (1) Hull ≥4 vertices ⇒ any 4 hull vertices are in convex position (each is an
+      extreme point, so not in the hull of the others).
+  (2) Hull = triangle ⇒ exactly 2 points interior; the line through them misses all
+      3 vertices (general position) ⇒ 2 vertices share a side ⇒ those 2 + the 2
+      interior points are a convex quadrilateral.
+  Mathlib gap: convex-hull vertex-count case split and "a line separates points"
+  for `EuclideanSpace ℝ (Fin 2)` are not packaged; a hand-proof is ~800–1200 lines.
+
+### Files Modified
+- proofs/Proofs/Erdos107OQ01KleinUpperAristotle.lean (new self-contained Aristotle target)
+- research/aristotle-jobs.json (job a1441c24 logged)
+- research/problems/erdos-107-oq-01/knowledge.md (this entry)
+
+### Next Steps
+- Check Aristotle project a1441c24 next session (`uvx --from aristotlelib aristotle
+  list` / `aristotle show a1441c24-...`). If PROVED: paste the proof over the axiom
+  in `Erdos107OQ01.lean` (convert `axiom klein_upper_bound` → `theorem ... := <proof>`),
+  rebuild, `#print axioms f_four_eq_five` should drop to only propext/Choice/Quot,
+  flip meta status axiomatized→verified.
+- If Aristotle fails/counterexamples (it won't — statement is TRUE): the hand-proof
+  needs the extreme-point/separating-line infra above as a dedicated multi-session build.

--- a/research/registry.json
+++ b/research/registry.json
@@ -22986,11 +22986,11 @@
     },
     {
       "slug": "erdos-107-oq-01",
-      "phase": "OBSERVE",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-18T21:42:27.141Z",
       "status": "active",
-      "lastUpdate": "2026-06-18T21:42:27.251Z"
+      "lastUpdate": "2026-06-19T12:42:00Z"
     },
     {
       "slug": "erdos-1104-oq-01",


### PR DESCRIPTION
## Summary

The Happy Ending entry `f(4) = 5` (`Erdos107OQ01`) rests on a **single open axiom**, `klein_upper_bound : 5 ∈ CardSet 4` — Klein 1931's upper bound: any 5 points in general position contain a convex quadrilateral. The lower bound (`4 ∉ CardSet 4`) is already axiom-free and merged (#26001).

Prior sessions could not delegate this axiom because the Aristotle **MCP** endpoint returned 404. This session the Aristotle **CLI** is live again, so I:

- Isolated the axiom as a **self-contained** `theorem ... := by sorry` in a new target file `proofs/Proofs/Erdos107OQ01KleinUpperAristotle.lean`, inlining `InGeneralPosition / IsConvexNGon / HasConvexNGon / CardSet` so the single-file submit-dir compiles against Mathlib alone (a `import Proofs.Foo` would not resolve in Aristotle's project dir).
- Submitted it async → Aristotle **project `a1441c24-c444-4cb6-ba78-9c0357beffcf`** (logged in `research/aristotle-jobs.json`).
- Documented the convex-hull case-analysis decomposition as a hand-proof fallback in `knowledge.md`, and advanced the registry phase `OBSERVE → ACT`.

## Decomposition (hand-proof fallback)

Case-split on the convex hull of the 5 points:
1. **Hull has ≥4 vertices** → any 4 hull vertices are in convex position.
2. **Hull is a triangle** → the other 2 points are interior; the line through them misses all 3 vertices (general position), so 2 vertices share a side → those 2 vertices + the 2 interior points form a convex quadrilateral.

Mathlib gap: convex-hull vertex-count case split and "a line separates points" for `EuclideanSpace ℝ (Fin 2)` are not packaged; a full hand-proof is ~800–1200 lines.

## Notes

- The new target file is **not** imported in `Proofs.lean`, so it is excluded from the default CI build — the `sorry` does not affect verification of the gallery.
- No gallery `meta.json` change: `erdos-107-oq-01` remains correctly `axiomatized` until the axiom is discharged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)