### PR TITLE
Enrich erdos-671: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-671/annotations.json
+++ b/src/data/proofs/erdos-671/annotations.json
@@ -12,7 +12,12 @@
       "Lebesgue function",
       "Approximation theory"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "Lagrange interpolation operator L^n f",
+      "Lebesgue function lambda_n(x)",
+      "limsup and divergence to infinity",
+      "uniform vs pointwise convergence of polynomials"
+    ],
     "range": {
       "startLine": 1,
       "endLine": 23
@@ -30,7 +35,12 @@
       "Interpolation",
       "Chebyshev nodes"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "Lean structure declaration syntax",
+      "Fin n indexing type",
+      "Set.Icc closed interval membership",
+      "distinctness of a finite indexed family"
+    ],
     "range": {
       "startLine": 34,
       "endLine": 37
@@ -48,7 +58,12 @@
       "formal definition",
       "polynomial theory"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "InterpolationPoints structure (prior annotation)",
+      "Polynomial R and Polynomial.C / Polynomial.X",
+      "Finset.prod over univ.filter",
+      "Kronecker delta interpolation property p_i(a_j)=delta_ij"
+    ],
     "range": {
       "startLine": 43,
       "endLine": 46
@@ -66,7 +81,12 @@
       "formal definition",
       "polynomial theory"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "lagrangeBasis definition (prior annotation)",
+      "Finset.sum over Fin n",
+      "uniqueness of interpolating polynomial of degree < n",
+      "polynomial degree bound natDegree <= n-1"
+    ],
     "range": {
       "startLine": 73,
       "endLine": 75
@@ -84,7 +104,12 @@
       "formal definition",
       "Lean 4 formalization"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "lagrangeBasis polynomials p_i^n (prior annotation)",
+      "absolute value and Finset.sum of |p_i(x)|",
+      "best polynomial approximation error E_n(f)",
+      "operator norm / error amplification bound"
+    ],
     "range": {
       "startLine": 118,
       "endLine": 119
@@ -102,7 +127,12 @@
       "formal definition",
       "Lean 4 formalization"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "lebesgueFunction lambda_n(x) (prior annotation)",
+      "supremum/maximum over compact interval [-1,1]",
+      "Chebyshev nodes and equidistant nodes",
+      "asymptotic growth notation (~ log n, ~ 2^n/n)"
+    ],
     "range": {
       "startLine": 183,
       "endLine": 184
@@ -120,7 +150,12 @@
       "Divergence",
       "Pointwise vs uniform convergence"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "lebesgueFunction lambda_n (prior annotation)",
+      "limsup_{n->infinity} = infinity",
+      "existential quantification over x in [-1,1]",
+      "uniform convergence for all continuous functions"
+    ],
     "range": {
       "startLine": 198,
       "endLine": 200
@@ -138,7 +173,12 @@
       "proof technique",
       "Lean 4 formalization"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "lagrangeInterp operator L^n f (prior annotation)",
+      "continuous function f on [-1,1]",
+      "almost-everywhere convergence (Lebesgue measure)",
+      "divergence |L^n f(x)| -> infinity"
+    ],
     "range": {
       "startLine": 216,
       "endLine": 220
@@ -156,7 +196,12 @@
       "formal definition",
       "convergence"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "lebesgueFunction lambda_n and limsup = infinity",
+      "lagrangeInterp convergence L^n f(x) -> f(x)",
+      "point sequence (PointSequence) of nodes",
+      "quantifier alternation: exists sequence, forall f, exists x"
+    ],
     "range": {
       "startLine": 227,
       "endLine": 231
@@ -174,7 +219,12 @@
       "formal definition",
       "convergence"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "Question1 formalization (prior annotation)",
+      "universal Lebesgue divergence: lambda_n(x) -> infinity for all x",
+      "pointwise convergence L^n f(x) -> f(x)",
+      "logical implication Q2 => Q1"
+    ],
     "range": {
       "startLine": 239,
       "endLine": 244
@@ -192,7 +242,12 @@
       "formal definition",
       "polynomial theory"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "InterpolationPoints / node families",
+      "Chebyshev polynomial T_n and its zeros",
+      "cosine function cos((2k-1)pi/2n)",
+      "Lebesgue constant Lambda_n and its (2/pi) log n minimum"
+    ],
     "range": {
       "startLine": 259,
       "endLine": 261
@@ -209,7 +264,12 @@
     "relatedConcepts": [
       "Runge phenomenon"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "InterpolationPoints / node families",
+      "equally-spaced node formula x_k = -1 + 2k/(n-1)",
+      "Lebesgue constant Lambda_n growth",
+      "Runge phenomenon and exponential 2^n/n divergence"
+    ],
     "range": {
       "startLine": 289,
       "endLine": 290
@@ -227,7 +287,12 @@
       "proof technique",
       "convergence"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "lagrangeInterp operator L^n f",
+      "uniform convergence to f for all continuous f",
+      "Bernstein's theorem (prior annotation)",
+      "existence of a divergent continuous function for any nodes"
+    ],
     "range": {
       "startLine": 331,
       "endLine": 334
@@ -245,7 +310,12 @@
       "proof technique",
       "combinatorics"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "lagrangeInterp divergence |L^n f(x)| -> infinity",
+      "Lebesgue measure of a subset of [-1,1]",
+      "positive measure vs almost-everywhere",
+      "Erdos-Vertesi theorem (prior annotation)"
+    ],
     "range": {
       "startLine": 342,
       "endLine": 345
@@ -263,7 +333,12 @@
       "formal definition",
       "convergence"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "Question1 formalization (prior annotation)",
+      "Question2 formalization (prior annotation)",
+      "logical equivalence (iff) of two Props",
+      "q2_implies_q1 (Q2 trivially implies Q1)"
+    ],
     "range": {
       "startLine": 358,
       "endLine": 359


### PR DESCRIPTION
Adds `prerequisites` to all 15 annotations (was empty). Prereq-only change to annotations.json; no source/build churn.