### PR TITLE
audit(cayley-hamilton-oq-02-oq-02): first audit clean — Sylvester interpolation via Frobenius covariants

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16087,6 +16087,12 @@
       "lastAudited": "2026-06-19T12:34:13Z",
       "result": "clean",
       "issues": []
+    },
+    "cayley-hamilton-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T12:46:53Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Auditor: first audit — CLEAN

**Entry:** `cayley-hamilton-oq-02-oq-02` — *Sylvester Interpolation via Frobenius Covariants* (the gallery's lone unaudited entry; 2563rd, added today via #26215).

**Source:** `proofs/Proofs/CayleyHamiltonOQ02OQ02.lean` (registered in `Proofs.lean:495`).

### Claims vs Lean source — all verified
| meta.json claim | Lean source | ✓ |
|---|---|---|
| lineCount 243 | `wc -l` = 243 | ✓ |
| theoremCount 12 | 12 `theorem` decls | ✓ |
| definitionCount 2 | `coordProj`, `frobeniusCovariant` | ✓ |
| axiomCount 0 | 0 `axiom` decls | ✓ |
| sorries 0 | 0 (lone `sorry` grep hit is the docstring "sorry-free" note, L48) | ✓ |
| status verified / badge mathlib | no `native_decide`/`decide`; no `Lean.ofReduceBool`; only foundational axioms | ✓ |

### Substantive checks
- **Faithful, not a stub.** "Diagonalizable" is honestly encoded as similarity *data* `A = U·diagonal(d)·V` with `U·V = V·U = 1`. Sylvester's formula `p(A) = ∑_μ p.eval μ • Z_μ` (`sylvester`) and all four covariant identities — idempotent (`frobenius_idem`), orthogonal (`frobenius_orthogonal`), complete (`frobenius_complete`), eigen (`frobenius_eigen`) — are genuinely proved. No `True` placeholders, no trivializing Mathlib wrapper (crux built in-file by polynomial induction + diagonal-indicator algebra).
- **No transitive-axiom trap.** File imports only `Mathlib` (not the parent `CayleyHamiltonOQ02`); every lemma rests on Mathlib primitives, so no inherited axioms.
- **Title scoped honestly.** Claim is the diagonalizable case; the eigenvalue-quotient covariant form, matrix-exponential specialization, and Jordan/non-diagonalizable extension are correctly listed as open questions.

Tracker bump only — no source change. Gallery returns to fully saturated (2563/2563 audited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)