### PR TITLE
research(erdos-mordell-inequality-oq-01): prove keystone pedalFoot_eq (build-verified) + fix latent cosine-side build error

### DIFF
--- a/proofs/Proofs/ErdosMordellChordIdentity.lean
+++ b/proofs/Proofs/ErdosMordellChordIdentity.lean
@@ -26,8 +26,10 @@ Structure (see `research/erdos-mordell-chord-identity-strategy.md`):
   primitive that both remaining `sorry`s are built on.
 * `pedalFoot_eq` — the foundational coordinate bridge `pedalFoot P X Y =
   (⟪P−X,Y−X⟫/‖Y−X‖²)•(Y−X) + X`, rewriting the abstract projection into the explicit
-  `F = X + (p/a)•u` form both residual identities are stated in. `sorry` (complete
-  named-lemma proof recipe in its docstring; `coe_orthogonalProjection_eq_iff_mem`).
+  `F = X + (p/a)•u` form both residual identities are stated in. **Proved (cycle-37,
+  build-verified)** via the projection's characteristic property
+  `coe_orthogonalProjection_eq_iff_mem` (membership along the direction + the
+  perpendicular residual `⟪P−q, X−Y⟫ = 0` solving for the scalar `t`).
 * `chord_length_eq` — sine side: `dist F_b F_c = dist X P · sin∠YXZ` (law of sines
   on the pedal triangle). `sorry`.
 * `angle_at_P` — the single residual cosine-side geometric subfact:
@@ -170,7 +172,37 @@ two feet of an interior point both side directions are nonzero (from `hXYZ`). -/
 theorem pedalFoot_eq (P X Y : EuclideanSpace ℝ (Fin 2)) (hY : Y ≠ X) :
     pedalFoot P X Y
       = (inner ℝ (P - X) (Y - X) / ‖Y - X‖ ^ 2) • (Y - X) + X := by
-  sorry
+  haveI : Nonempty (↥(affineSpan ℝ ({X, Y} : Set (EuclideanSpace ℝ (Fin 2))))) :=
+    ⟨⟨X, subset_affineSpan ℝ {X, Y} (by simp)⟩⟩
+  have h0 : (Y - X : EuclideanSpace ℝ (Fin 2)) ≠ 0 := sub_ne_zero.mpr hY
+  have hnorm : ‖(Y : EuclideanSpace ℝ (Fin 2)) - X‖ ^ 2 ≠ 0 :=
+    pow_ne_zero 2 (norm_ne_zero_iff.mpr h0)
+  -- Characteristic property of the orthogonal projection: a point `q` equals the
+  -- projection iff it lies on the line and `P − q` is orthogonal to the direction.
+  unfold pedalFoot
+  rw [coe_orthogonalProjection_eq_iff_mem]
+  refine ⟨?_, ?_⟩
+  · -- Membership: `q = t•(Y−X) + X` is `X` shifted along the direction `Y − X`.
+    have hX : X ∈ affineSpan ℝ ({X, Y} : Set (EuclideanSpace ℝ (Fin 2))) :=
+      subset_affineSpan ℝ {X, Y} (by simp)
+    have hdir : (inner ℝ (P - X) (Y - X) / ‖Y - X‖ ^ 2) • (Y - X)
+        ∈ (affineSpan ℝ ({X, Y} : Set (EuclideanSpace ℝ (Fin 2)))).direction := by
+      rw [direction_affineSpan, vectorSpan_pair, Submodule.mem_span_singleton]
+      refine ⟨-(inner ℝ (P - X) (Y - X) / ‖Y - X‖ ^ 2), ?_⟩
+      rw [vsub_eq_sub, neg_smul, ← smul_neg, neg_sub]
+    simpa only [vadd_eq_add] using AffineSubspace.vadd_mem_of_mem_direction hdir hX
+  · -- Perpendicular residual: `P − q ⟂ (X − Y)` is the linear equation defining `t`.
+    rw [direction_affineSpan, vectorSpan_pair,
+      Submodule.mem_orthogonal_singleton_iff_inner_left]
+    have key : (inner ℝ (Y - X) (Y - X) : ℝ) = ‖Y - X‖ ^ 2 := real_inner_self_eq_norm_sq _
+    simp only [vsub_eq_sub]
+    rw [show (X - Y : EuclideanSpace ℝ (Fin 2)) = -(Y - X) by abel,
+      show (P - ((inner ℝ (P - X) (Y - X) / ‖Y - X‖ ^ 2) • (Y - X) + X)
+            : EuclideanSpace ℝ (Fin 2))
+          = (P - X) - (inner ℝ (P - X) (Y - X) / ‖Y - X‖ ^ 2) • (Y - X) by abel,
+      inner_neg_right, inner_sub_left, real_inner_smul_left, key,
+      div_mul_cancel₀ _ hnorm]
+    ring
 
 /-- **Chord length (the "sine side", law of sines).**
 
@@ -276,9 +308,11 @@ theorem chord_length_sq_eq_of_angle_at_P
         + 2 * (lineDist P Z X) * (lineDist P X Y) * Real.cos (∠ Y X Z) := by
   have hlc := dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle
     (pedalFoot P Z X) P (pedalFoot P X Y)
-  rw [lineDist_eq_dist_pedalFoot P Z X, lineDist_eq_dist_pedalFoot P X Y, hlc, hAngle,
-    Real.cos_pi_sub, dist_comm (pedalFoot P Z X) P, dist_comm (pedalFoot P X Y) P]
-  ring
+  rw [hAngle, Real.cos_pi_sub] at hlc
+  rw [lineDist_eq_dist_pedalFoot P Z X, lineDist_eq_dist_pedalFoot P X Y,
+    dist_comm P (pedalFoot P Z X), dist_comm P (pedalFoot P X Y)]
+  simp only [pow_two]
+  linear_combination hlc
 
 /-- **Chord length squared (the "cosine side", law of cosines).**
 

--- a/src/data/research/problems/erdos-mordell-inequality-oq-01.json
+++ b/src/data/research/problems/erdos-mordell-inequality-oq-01.json
@@ -29,7 +29,7 @@
     "Not present in Mathlib4 (as of v4.26.0): no `mordell` geometry result; Mathlib has Triangle, Incenter, Projection, SignedDist, angle infrastructure but no Erdős–Mordell."
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (cycle-36): cosine-side sign reduced to single ring identity [u,w][v,w]=−st[u,v]² + barycentric positivity; sine side already hypothesis-free 2D Gram. Erdős–Mordell now ring-mechanical end to end modulo extracting barycentric witness from hP. Both gates closed (Aristotle 404, build load 12.3) → math+doc PR only.",
+    "progressSummary": "PROGRESS (cycle-37): KEYSTONE pedalFoot_eq PROVED + build-verified; latent cosine-side build error fixed; companion compiles for first time. Sorries 3→2 (chord_length_eq sine-side Gram + angle_at_P cosine-side sign remain). PR #26265.",
     "builtItems": [
       "proofs/Proofs/ErdosMordellInequalityOQ01.lean: erdos_mordell_reduction — from the three key inequalities a·PA≥b·dc+c·db (cyclic), derives PA+PB+PC≥2(da+db+dc) via explicit nonnegative certificate, 0 sorry, 0 axiom (build-pending verification).",
       "Certificate: a·b·c·(PA+PB+PC) − 2abc·(da+db+dc) = a·da·(b−c)² + b·db·(a−c)² + c·dc·(a−b)² + (key-inequality slack), each summand ≥ 0; closed by mul_le_mul_of_nonneg_left scaling + nlinarith + le_of_mul_le_mul_left.",
@@ -42,7 +42,9 @@
       "key_inequality_vertex (shared geometric core, 1 sorry) + key_inequality_A/B/C now PROVED from it by relabeling, ErdosMordellInequalityOQ01.lean",
       "affineIndep_rotate / mem_interior_hull_rotate plumbing lemmas (cyclic-permutation invariance), ErdosMordellInequalityOQ01.lean",
       "ErdosMordellFeetAngleAristotle.lean (NEW, build-VERIFIED 0-sorry under LEAN_MEMORY_LIMIT=8192 docker): case-free oriented building block two_zsmul_oangle_feet_at_X : 2•∡(pedalFoot P Z X) X (pedalFoot P X Y) = 2•∡ Z X Y, for ALL triangles, no positivity/Sbtw hypothesis (only the four ≠X nondegeneracies). Proof = Collinear.two_zsmul_oangle_eq_left/right (ray-direction invariance of 2•∡ since 2•π≡0 in Real.Angle), swapping F_b↦Z and F_c↦Y.",
-      "ErdosMordellFeetAngleAristotle.lean helpers (build-verified): pedalFoot_mem_affineSpan (orthogonalProjection_mem), collinear_pedalFoot {foot,X,Y}, collinear_foot_vertex {foot,B,A} (vertex-in-middle via Set.pair_comm + collinear_insert_iff_of_mem_affineSpan)."
+      "ErdosMordellFeetAngleAristotle.lean helpers (build-verified): pedalFoot_mem_affineSpan (orthogonalProjection_mem), collinear_pedalFoot {foot,X,Y}, collinear_foot_vertex {foot,B,A} (vertex-in-middle via Set.pair_comm + collinear_insert_iff_of_mem_affineSpan).",
+      "pedalFoot_eq PROVED + build-verified (ErdosMordellChordIdentity.lean:172, Lean v4.26 7743 jobs green): pedalFoot P X Y = (⟪P−X,Y−X⟫/‖Y−X‖²)•(Y−X)+X via coe_orthogonalProjection_eq_iff_mem (membership + perpendicular residual). The keystone bridge; sorries 3→2.",
+      "Fixed latent build error in chord_length_sq_eq_of_angle_at_P (rw[hlc] dist^2 vs dist*dist + dist_comm mismatch) → hAngle/cos_pi_sub into hlc, align pow_two+dist_comm, linear_combination. Companion now compiles for the first time."
     ],
     "insights": [
       "The inequality cleanly factors: ALL the AM-GM / side-length algebra is captured by erdos_mordell_reduction (now proved), isolating the genuinely hard work into the three geometric key inequalities.",
@@ -57,7 +59,8 @@
       "Cycle-35 (researcher-9): the sine side chord_length_eq is HYPOTHESIS-FREE. Squared, it is the pure 2D Gram-determinant identity r(ab-c2)=a q2+b p2-2 c p q (a=|u|2,b=|v|2,c=<u,v>,p=<w,u>,q=<w,v>,r=|w|2; u=Y-X,v=Z-X,w=P-X) — three vectors in dim-2 are dependent. In Fin 2 coordinates it is a one-line ring identity; needs neither AffineIndependent nor P-interior. Numerically confirmed for arbitrary P incl. exterior+obtuse.",
       "Cycle-35: pedal feet in coordinates are F_b=X+(q/b).v, F_c=X+(p/a).u (orthogonalProjection onto lines ZX,XY). Then dist F_b F_c^2 = q2/b+p2/a-2pqc/(ab) directly, matching (dist X P sin)^2 = r(ab-c2)/(ab) exactly via the Gram relation.",
       "Cycle-35: angle_at_P (cosine side, supplementary angle) is EQUIVALENT to the scalar identity db.dc.cos(YXZ) = -<P-F_b,P-F_c>. Its SQUARE is hypothesis-free ring (db2 dc2 cos2 = <P-F_b,P-F_c>2, with <P-F_b,P-F_c> = r-p2/a-q2/b+pqc/(ab)). Only the SIGN needs P-interior — this is the SOLE place hP enters the entire Erdos-Mordell proof. Sign FAILS for exterior P (numerically confirmed: signErr large outside triangle, ~0 inside).",
-      "cycle-36: the cosine-side sign (the WHOLE proof's only use of P-interior) reduces to ONE ring identity [u,w]·[v,w] = −s·t·[u,v]² where w=s·u+t·v are barycentric coords (s,t>0,s+t<1), [·,·]=2D cross product. Manifestly <0 for interior P + nondegenerate triangle. Replaces vaguer convexHull/λμ<0 sketch. Numerically verified ~1e-14."
+      "cycle-36: the cosine-side sign (the WHOLE proof's only use of P-interior) reduces to ONE ring identity [u,w]·[v,w] = −s·t·[u,v]² where w=s·u+t·v are barycentric coords (s,t>0,s+t<1), [·,·]=2D cross product. Manifestly <0 for interior P + nondegenerate triangle. Replaces vaguer convexHull/λμ<0 sketch. Numerically verified ~1e-14.",
+      "The companion ErdosMordellChordIdentity.lean was NEVER build-verified before cycle-37 (unregistered, prior closed gates) — chord_length_sq_eq_of_angle_at_P carried a latent rw failure. Lesson: numerically-verified scaffolds may hide compile bugs; build-verify when the gate opens."
     ],
     "mathlibGaps": [
       "No Erdős–Mordell in Mathlib4 v4.26.0.",
@@ -89,7 +92,9 @@
       "PRIORITY when build gate opens (load<6,<3 containers): mechanize chord_length_eq via coordinates. Lemma chain: (1) pedalFoot_eq: pedalFoot P X Y = X + (inner (P-X) (Y-X)/inner (Y-X) (Y-X)) . (Y-X) [from orthogonalProjection_eq / EuclideanGeometry.orthogonalProjection on affineSpan {X,Y}]; (2) gram_two: for u v w : EuclideanSpace R (Fin 2), |w|^2*(|u|^2*|v|^2-<u,v>^2)=|u|^2*<w,v>^2+|v|^2*<w,u>^2-2*<u,v>*<w,u>*<w,v> by simp [EuclideanSpace inner, Fin.sum_univ_two]; ring; (3) assemble dist^2 then sqrt (both nonneg).",
       "For angle_at_P: prove the squared scalar identity (db dc cos)^2 = <P-F_b,P-F_c>^2 hypothesis-free by ring, then recover the sign from hP. Sign lemma: P in interior(convexHull{X,Y,Z}) => the projection scalars q/b>0 and p/a>0 on the open segments => orientation scalars of P-F_b, P-F_c are opposite (lambda*mu<0) => <P-F_b,P-F_c> and <u,v> have opposite signs. Candidate Mathlib: convexHull membership -> affine combination with positive coeffs.",
       "Retry Aristotle MCP (down/404 cycle-35) on the companion file ErdosMordellChordIdentity.lean once it recovers; both residual sorries are now coordinate-mechanical with explicit ring identities documented in their docstrings.",
-      "Prove angle_at_P via: (1) rewrite ∠ through inner-product def; (2) P−F_c=([u,w]/‖u‖²)rot90 u and P−F_b=([v,w]/‖v‖²)rot90 v by ring in Fin 2; (3) extract barycentric s,t>0 from hP (interior convexHull → positive coeffs, s+t<1); (4) ring identity [u,w][v,w]=−st[u,v]² gives sign; combine with hypothesis-free squared identity."
+      "Prove angle_at_P via: (1) rewrite ∠ through inner-product def; (2) P−F_c=([u,w]/‖u‖²)rot90 u and P−F_b=([v,w]/‖v‖²)rot90 v by ring in Fin 2; (3) extract barycentric s,t>0 from hP (interior convexHull → positive coeffs, s+t<1); (4) ring identity [u,w][v,w]=−st[u,v]² gives sign; combine with hypothesis-free squared identity.",
+      "chord_length_eq: rewrite both pedalFoot via pedalFoot_eq, square, reduce to 2D Gram det r(ab−c²)=aq²+bp²−2cpq by ring in Fin2 coords, unsquare via sqrt_inj (both sides ≥0); needs cos_angle = ⟪u,v⟫/(‖u‖‖v‖) and sin²=1−cos².",
+      "angle_at_P: with pedalFoot_eq, P−F_c=([u,w]/‖u‖²)rot90 u etc.; reduce to ⟪P−F_b,P−F_c⟫ via ring, square hypothesis-free, then sign from hP barycentric witness w=s·u+t·v (s,t>0) giving (♦) [u,w][v,w]=−st[u,v]²<0."
     ]
   }
 }


### PR DESCRIPTION
## Summary

Build-verified progress on **erdos-mordell-inequality-oq-01** (RICH knowledge, phase ACT). This cycle discharges the **keystone** the entire pedal-feet decomposition was built toward and fixes a latent build failure, so the companion file `ErdosMordellChordIdentity.lean` **compiles for the first time** (Lean v4.26, 7743 jobs green).

### 1. `pedalFoot_eq` — PROVED (was `sorry`)
The foundational coordinate bridge
```
pedalFoot P X Y = (⟪P−X, Y−X⟫ / ‖Y−X‖²) • (Y−X) + X
```
turning the abstract `orthogonalProjection`-based pedal foot into the explicit `F = X + (p/a)•u` form on which **both** residual identities (`chord_length_eq`, `angle_at_P`) are phrased. Proof follows the recipe in its docstring:
- **Characteristic property** `coe_orthogonalProjection_eq_iff_mem`: `q = orthogonalProjection ↔ q ∈ s ∧ P −ᵥ q ∈ s.directionᗮ`.
- **Membership**: `q = t•(Y−X) + X` lies on the line via `vadd_mem_of_mem_direction` + `vectorSpan_pair` + `mem_span_singleton`.
- **Perpendicular residual**: `⟪P−q, X−Y⟫ = 0` reduces (via `inner_sub_left`, `real_inner_smul_left`, `real_inner_self_eq_norm_sq`, `div_mul_cancel₀`) to the equation that defines the scalar `t` — needs only `Y ≠ X` (so `‖Y−X‖² ≠ 0`).

### 2. Fixed pre-existing latent build error in `chord_length_sq_eq_of_angle_at_P`
This companion was never build-verified. Its `rw [hlc]` could not fire: the goal is in `dist^2` form while the law-of-cosines `hlc` is in `dist*dist` form, with an additional `dist_comm` mismatch. Reworked to rewrite `hAngle`/`cos_pi_sub` **into** `hlc`, align orientations via `dist_comm` + `pow_two`, and close with `linear_combination hlc`.

### Status
- Sorries **3 → 2**. The two remaining are exactly the documented residual geometric facts:
  - `chord_length_eq` (sine side — hypothesis-free 2D Gram determinant identity)
  - `angle_at_P` (cosine side — the single scalar sign requiring the interior hypothesis `hP`)
- File is an **unregistered companion** (not in `Proofs.lean`); does not touch the shipped main entry `ErdosMordellInequalityOQ01.lean`. No axioms, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)