### PR TITLE
Enrich erdos-516: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-516/annotations.json
+++ b/src/data/proofs/erdos-516/annotations.json
@@ -16,7 +16,11 @@
       "entire-functions",
       "minimum-modulus"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "complex analysis",
+      "entire functions",
+      "lacunary (gap) series"
+    ]
   },
   {
     "id": "ann-e516-imports",
@@ -34,7 +38,11 @@
       "complex-analysis"
     ],
     "mathContext": "See annotation content for formal details of mathlib imports",
-    "prerequisites": []
+    "prerequisites": [
+      "Mathlib library",
+      "complex analysis",
+      "power series"
+    ]
   },
   {
     "id": "ann-e516-fabry",
@@ -53,7 +61,11 @@
       "atTop",
       "sparse-series"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "lacunary series",
+      "limits at infinity (Tendsto/atTop)",
+      "sequence growth rates"
+    ]
   },
   {
     "id": "ann-e516-fejer",
@@ -71,7 +83,11 @@
       "summable",
       "comparison-test"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "infinite series convergence",
+      "summability",
+      "lacunary series"
+    ]
   },
   {
     "id": "ann-e516-fabry-implies-fejer",
@@ -89,7 +105,11 @@
       "comparison-test",
       "p-series"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "comparison test",
+      "p-series convergence",
+      "asymptotic growth"
+    ]
   },
   {
     "id": "ann-e516-finite-order",
@@ -108,7 +128,11 @@
       "growth-rate",
       "order"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "entire functions",
+      "order of growth",
+      "exponential growth bounds"
+    ]
   },
   {
     "id": "ann-e516-order-def",
@@ -126,7 +150,11 @@
       "growth-bound"
     ],
     "mathContext": "See annotation content for formal details of order of an entire function",
-    "prerequisites": []
+    "prerequisites": [
+      "order of an entire function",
+      "infimum",
+      "growth bounds"
+    ]
   },
   {
     "id": "ann-e516-max-modulus",
@@ -145,7 +173,11 @@
       "circle",
       "maximum-principle"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "maximum modulus principle",
+      "supremum",
+      "Hadamard three-circles theorem"
+    ]
   },
   {
     "id": "ann-e516-min-modulus",
@@ -164,7 +196,11 @@
       "zeros",
       "argument-principle"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "minimum modulus",
+      "zeros of entire functions",
+      "infimum"
+    ]
   },
   {
     "id": "ann-e516-ratio",
@@ -183,7 +219,11 @@
       "ratio",
       "asymptotic"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "maximum and minimum modulus",
+      "logarithms",
+      "asymptotic ratios"
+    ]
   },
   {
     "id": "ann-e516-fuchs",
@@ -202,7 +242,11 @@
       "logarithmic-density",
       "nevanlinna-theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nevanlinna value distribution theory",
+      "logarithmic density",
+      "limsup"
+    ]
   },
   {
     "id": "ann-e516-wiman",
@@ -220,7 +264,11 @@
       "historical",
       "stronger-gaps"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "minimum modulus",
+      "gap conditions",
+      "asymptotic analysis"
+    ]
   },
   {
     "id": "ann-e516-erdos-macintyre",
@@ -238,7 +286,11 @@
       "historical",
       "gap-reciprocals"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "gap reciprocal convergence",
+      "minimum modulus",
+      "lacunary series"
+    ]
   },
   {
     "id": "ann-e516-kovari",
@@ -256,7 +308,11 @@
       "infinite-order",
       "stronger-gaps"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "infinite order entire functions",
+      "gap conditions",
+      "modulus ratio"
+    ]
   },
   {
     "id": "ann-e516-fejer-conj",
@@ -274,7 +330,11 @@
       "open-problem",
       "optimal-condition"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Fejer gap condition",
+      "optimal gap conditions",
+      "open problems"
+    ]
   },
   {
     "id": "ann-e516-macintyre-counter",
@@ -292,6 +352,10 @@
       "counterexample",
       "optimality"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "counterexample construction",
+      "divergent series",
+      "asymptotic behavior on the real axis"
+    ]
   }
 ]


### PR DESCRIPTION
Populates the empty `prerequisites` field on every annotation in `erdos-516` (Erdős Problem #516: Gap Series and the Minimum Modulus Problem) with 2-3 concise, content-grounded prerequisite concepts. Diff is prerequisites-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)