### PR TITLE
Enrich erdos-661: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-661/annotations.json
+++ b/src/data/proofs/erdos-661/annotations.json
@@ -253,6 +253,10 @@
       "Erdős prizes",
       "open problems"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Erdős prize problems",
+      "Distinct distances problem",
+      "Open problems in combinatorics"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty `prerequisites` arrays for 1 annotations in `src/data/proofs/erdos-661/annotations.json` with 2-3 concept/Lean identifiers each, derived from each annotation's title, content, and related concepts.

Annotations-only change; no build artifacts touched.