### PR TITLE
research(hilbert-10-oq-01-oq-02): correct stale axiom disclosure (2→1) in docstring

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -36,12 +36,17 @@ rather than redefining them.
 
 ## Status
 
-OPEN, axiomatized: 2 axioms.
+OPEN, axiomatized: 1 axiom declared in this file.
   1. `koenigsmann_2016_universal` — Π₂-definability of ℤ in ℚ (PROVED in
      Koenigsmann, Annals 2016; axiomatized here pending model-theoretic
      formalization).
-  2. `mazur_conjecture_implies_not_diophantine_over_Q` — Mazur ⟹ ¬Σ₁
-     (a topological argument; restated against this file's predicate).
+
+The Mazur direction (Mazur ⟹ ¬Σ₁) is NOT a new axiom here: it is stated
+*conditionally* as the theorem
+  `mazur_implies_not_sigma1_definable : MazurConjecture → ¬IntegersAreDiophantineOverQ`,
+which carries the `MazurConjecture` hypothesis explicitly and reuses the
+imported parent's conditional axiom `mazur_implies_not_diophantine`
+(`Hilbert10OQ01.lean`) rather than asserting a fresh one.
 
 The Σ₁ question itself is left as a `Prop`-valued statement, NOT axiomatized
 either way: we encode it as `IntegersDiophantineOverQ` (already in OQ-01) and

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -289,7 +289,7 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 3316,
+    "lineCount": 3321,
     "axiomCount": 1,
     "theoremCount": 100,
     "definitionCount": 16,


### PR DESCRIPTION
## Summary

The `Hilbert10OQ01OQ02.lean` Status docstring claimed **"2 axioms"** and named a declaration that does not exist anywhere in the codebase (`mazur_conjecture_implies_not_diophantine_over_Q`). The file actually declares exactly **one** axiom:

- `koenigsmann_2016_universal` — Π₂-definability of ℤ in ℚ (Koenigsmann, Annals 2016), axiomatized pending model-theoretic formalization in Mathlib.

The Mazur direction is **not** a fresh axiom in this file: it is the *conditional theorem*

```
mazur_implies_not_sigma1_definable : MazurConjecture → ¬IntegersAreDiophantineOverQ
```

which carries its `MazurConjecture` hypothesis explicitly and reuses the imported parent's (`Hilbert10OQ01.lean`) conditional axiom `mazur_implies_not_diophantine`.

## Why

`meta.json` already reports `axiomCount: 1`, so the docstring was the only place overstating the assumption count and citing a phantom axiom. This aligns the in-file disclosure with both the code (`grep '^axiom ' → 1`) and the gallery metadata, per the Axiom Integrity Policy.

## Changes

- `proofs/Proofs/Hilbert10OQ01OQ02.lean` — **comment-only** edit inside the top block comment (no semantic change; cannot affect the build).
- `src/data/proofs/hilbert-10-oq-01-oq-02/meta.json` — bump `leanFile.lineCount` 3316→3321 to match the +5 docstring lines.

## Verification

- `grep -c '^axiom ' Hilbert10OQ01OQ02.lean` → `1`
- `grep -c 'sorry'` (real, non-docstring) → `0`
- Change is restricted to a block comment + one metadata integer; no Lean elaboration is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)