### PR TITLE
research(zsqrtd-neg-two-oq-02): wire slice Minkowski into ThreeSquares (geometric half of dirichlet_key_lemma)

### DIFF
--- a/proofs/Proofs/ThreeSquares.lean
+++ b/proofs/Proofs/ThreeSquares.lean
@@ -12,6 +12,7 @@ import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
 import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 import Mathlib.Tactic
 import Proofs.ZsqrtdNegTwo
+import Proofs.ThreeSquaresSliceMinkowski
 
 /-!
 # Legendre's Three Squares Theorem
@@ -1396,6 +1397,46 @@ private lemma dirichletForm_eq_p_of_lt_two_mul
       have : 0 < d * v 2 ^ 2 := mul_pos hd hi2
       linarith
   exact multiple_p_eq_p_of_lt_two_mul hp h_pos h_lt h_dvd
+
+/-- **Geometric half of the Dirichlet Key Lemma (S12, researcher-3 2026-06-19)**:
+for a prime `p` and `d ∈ {1, 2}` with `-d` a quadratic residue mod `p`, the ternary
+Dirichlet form `x² + d·y² + d·z²` represents `p` *exactly* on a non-zero integer
+triple.
+
+This wires the now-complete geometric Minkowski input
+(`ThreeSquaresSlice.exists_dirichlet_vector_lt_two_mul`, the 2D-slice lattice point
+with form value `< 2p` lying in the sublattice `L_r`) into the integer-side
+identification chain:
+
+* `exists_int_sqrt_neg_d_mod_p` (S8) chooses the sublattice parameter `r` with
+  `p ∣ r² + d` from the quadratic-residue hypothesis;
+* `dirichletForm_dvd_of_in_sublattice` (S9) gives `p ∣ form(v)`;
+* `dirichletForm_eq_p_of_lt_two_mul` (S10A) upgrades `0 < form(v) < 2p ∧ p ∣ form(v)`
+  to `form(v) = p`.
+
+With this, the geometry-of-numbers component of `dirichlet_key_lemma` is fully
+machine-checked. The sole remaining step toward eliminating the axiom is the
+arithmetic descent from `form(v) = p = d·n − 1` to a sum-of-three-squares
+representation of `n`. -/
+private lemma exists_form_eq_p_of_qr
+    {p d : ℕ} [Fact (Nat.Prime p)]
+    (hd_pos : 0 < d) (hd_lt_p : d < p) (hd2 : d ≤ 2)
+    (hqr : legendreSym p (-d : ℤ) = 1) :
+    ∃ v : Fin 3 → ℤ, v ≠ 0 ∧
+      v 0 ^ 2 + (d : ℤ) * v 1 ^ 2 + (d : ℤ) * v 2 ^ 2 = (p : ℤ) := by
+  have hp_nat : 0 < p := (Fact.out : Nat.Prime p).pos
+  have hp_pos : (0 : ℤ) < (p : ℤ) := by exact_mod_cast hp_nat
+  have hd_pos' : (0 : ℤ) < (d : ℤ) := by exact_mod_cast hd_pos
+  -- QR ⟹ choose sublattice parameter `r` with `p ∣ r² + d`.
+  obtain ⟨r, hr⟩ := exists_int_sqrt_neg_d_mod_p hd_pos hd_lt_p hqr
+  -- Geometric Minkowski input: a non-zero `v ∈ L_r` with `form(v) < 2p`.
+  obtain ⟨v, hv_ne, ⟨hdvd_xy, hdvd_z⟩, hlt⟩ :=
+    ThreeSquaresSlice.exists_dirichlet_vector_lt_two_mul p d hp_nat hd_pos hd2 r
+  -- Divisibility side: `p ∣ form(v)` from sublattice membership.
+  have hdvd : (p : ℤ) ∣ v 0 ^ 2 + (d : ℤ) * v 1 ^ 2 + (d : ℤ) * v 2 ^ 2 :=
+    dirichletForm_dvd_of_in_sublattice hr v ⟨hdvd_xy, hdvd_z⟩
+  -- Identification: `0 < form(v) < 2p` and `p ∣ form(v)` force `form(v) = p`.
+  exact ⟨v, hv_ne, dirichletForm_eq_p_of_lt_two_mul hp_pos hd_pos' v hv_ne hlt hdvd⟩
 
 /-! ### S10B (2026-05-08): Dirichlet Sublattice as a `Submodule ℤ (Fin 3 → ℤ)`
 

--- a/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
@@ -782,3 +782,50 @@ was built precisely as that axiom's missing geometric input). Then derive
 `not_excluded_form_is_sum_three_sq` from it (file's line-1658 recipe) ⇒ both
 `ThreeSquares.lean` axioms eliminated ⇒ Legendre three-square theorem fully
 verified. Both steps are Docker-buildable now (no backend dependency).
+
+---
+
+## Session 16 (researcher-3, 2026-06-19) — geometric half of `dirichlet_key_lemma` WIRED IN & verified
+
+**Mode**: ACT/INTEGRATE (Docker up). **Outcome**: the now-complete slice Minkowski
+tool is consumed inside `ThreeSquares.lean`; the geometry-of-numbers component of the
+`dirichlet_key_lemma` axiom is fully machine-checked.
+
+### What I Did
+- S15 closed the d=2 Minkowski core, leaving `ThreeSquaresSlice.exists_dirichlet_vector_lt_two_mul`
+  (in the self-contained, Mathlib-only `ThreeSquaresSliceMinkowski.lean`) as a usable,
+  axiom-free geometric tool — but it had not yet been *used* by `ThreeSquares.lean`.
+- Imported `Proofs.ThreeSquaresSliceMinkowski` into `ThreeSquares.lean` (no circularity:
+  the slice file imports only `Mathlib`) and added the private lemma **`exists_form_eq_p_of_qr`**:
+  for prime `p`, `d ∈ {1,2}`, `-d` a QR mod `p`, the ternary form `x²+d·y²+d·z²`
+  represents `p` *exactly* on a non-zero integer triple.
+- The proof composes three existing, already-proved pieces:
+  `exists_int_sqrt_neg_d_mod_p` (S8, picks `r` with `p∣r²+d`) →
+  `exists_dirichlet_vector_lt_two_mul` (S15 geometry, nonzero `v ∈ L_r`, `form < 2p`) →
+  `dirichletForm_dvd_of_in_sublattice` (S9, `p∣form`) →
+  `dirichletForm_eq_p_of_lt_two_mul` (S10A, `0<form<2p ∧ p∣form ⟹ form=p`).
+- **Build GREEN** (`Proofs.ThreeSquares`, 7745 jobs, 0 errors; warnings all pre-existing).
+
+### Key Findings
+- This is the first time the slice Minkowski result is actually *consumed* by the main
+  three-squares development. The geometry-of-numbers half of `dirichlet_key_lemma`
+  (find a nonzero lattice point whose Dirichlet form equals `p` exactly) is now a
+  verified lemma rather than a sketch.
+- **Sole remaining gap** to eliminate the `dirichlet_key_lemma` axiom: the arithmetic
+  **descent** from `form(v) = p = d·n − 1` (with `v` in the sublattice, `r²≡−d`) to
+  `∃ x y z, x²+y²+z² = n`. This is the classical Aubry/Davenport–Cassels-style descent;
+  it is NOT in the file. Candidate for a focused next session (or Aristotle submission of
+  the isolated descent statement).
+- Note: `ThreeSquares.lean` still carries `native_decide` (line ~347) and two axioms
+  (`dirichlet_key_lemma`, `not_excluded_form_is_sum_three_sq`); my change neither adds nor
+  removes any axiom — it builds the verified input that the descent will combine with the
+  axiom's hypotheses.
+
+### Files Modified
+- proofs/Proofs/ThreeSquares.lean (+import ThreeSquaresSliceMinkowski, +exists_form_eq_p_of_qr)
+
+### Next Steps
+- Implement the descent `form(v)=p=d·n−1 ⟹ n = x²+y²+z²` and chain
+  `exists_form_eq_p_of_qr` into a proof of `dirichlet_key_lemma`, converting that axiom to
+  a theorem. Then `not_excluded_form_is_sum_three_sq` (the case split over `n mod 8` calling
+  `dirichlet_key_lemma`) and the full Legendre three-square theorem follow.


### PR DESCRIPTION
## Summary

S15 (#26172) closed the d=2 Minkowski core, making `ThreeSquaresSlice.exists_dirichlet_vector_lt_two_mul` (in the self-contained, Mathlib-only `ThreeSquaresSliceMinkowski.lean`) an **axiom-free geometric tool** — but it had not yet been *consumed* by the main three-squares development. This PR wires it in.

Adds the private lemma `exists_form_eq_p_of_qr`: for a prime `p`, `d ∈ {1,2}`, with `-d` a quadratic residue mod `p`, the ternary Dirichlet form `x² + d·y² + d·z²` **represents `p` exactly** on a non-zero integer triple.

```lean
private lemma exists_form_eq_p_of_qr
    {p d : ℕ} [Fact (Nat.Prime p)]
    (hd_pos : 0 < d) (hd_lt_p : d < p) (hd2 : d ≤ 2)
    (hqr : legendreSym p (-d : ℤ) = 1) :
    ∃ v : Fin 3 → ℤ, v ≠ 0 ∧
      v 0 ^ 2 + (d : ℤ) * v 1 ^ 2 + (d : ℤ) * v 2 ^ 2 = (p : ℤ)
```

The proof composes existing, already-proved pieces:

| step | lemma | role |
|------|-------|------|
| QR → `r` | `exists_int_sqrt_neg_d_mod_p` (S8) | choose `r` with `p ∣ r²+d` |
| geometry | `exists_dirichlet_vector_lt_two_mul` (S15) | nonzero `v ∈ L_r`, `form < 2p` |
| divisibility | `dirichletForm_dvd_of_in_sublattice` (S9) | `p ∣ form(v)` |
| identification | `dirichletForm_eq_p_of_lt_two_mul` (S10A) | `0<form<2p ∧ p∣form ⟹ form=p` |

No circularity: `ThreeSquaresSliceMinkowski.lean` imports only `Mathlib`, so `ThreeSquares.lean` may import it.

## Significance

This machine-checks the **geometry-of-numbers component** of the `dirichlet_key_lemma` axiom — the first time the slice Minkowski result is actually used by the main development. The **sole remaining gap** to eliminate the axiom is the arithmetic **descent** from `form(v) = p = d·n − 1` to `∃ x y z, x²+y²+z² = n` (classical Aubry/Davenport–Cassels descent), tracked in the problem `knowledge.md`.

This PR neither adds nor removes any axiom; it builds the verified input the descent will consume.

## Verification

- **Build GREEN**: `Built Proofs.ThreeSquares` (7745 jobs, 0 errors; warnings all pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)