### PR TITLE
Enrich erdos-1098: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1098/annotations.json
+++ b/src/data/proofs/erdos-1098/annotations.json
@@ -21,7 +21,11 @@
       "group-theory",
       "subgroup-api"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Lean Import System",
+      "Mathlib Subgroup API",
+      "Implicit Variables And Typeclasses"
+    ]
   },
   {
     "id": "ann-non-commuting-rel",
@@ -46,7 +50,11 @@
       "group-commutativity",
       "definition"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Group Multiplication",
+      "Symmetric Relations",
+      "Negation Of Equality"
+    ]
   },
   {
     "id": "ann-center-def",
@@ -71,7 +79,11 @@
       "membership-characterization",
       "definition"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Subgroups",
+      "Group Commutativity",
+      "Membership Characterization Lemmas"
+    ]
   },
   {
     "id": "ann-noncomm-graph",
@@ -96,7 +108,11 @@
       "irreflexivity",
       "definition"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Simple Graphs",
+      "Lean Structures With Default Fields",
+      "Sets As Type Universe"
+    ]
   },
   {
     "id": "ann-clique-defs",
@@ -122,7 +138,11 @@
       "graph-theory",
       "supremum"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Graph Cliques",
+      "Indexed Supremum (iSup)",
+      "Extended Natural Numbers"
+    ]
   },
   {
     "id": "ann-finite-index",
@@ -148,7 +168,11 @@
       "center",
       "definition"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Subgroup Index",
+      "Cosets And Quotient Groups",
+      "WithTop And Extended Naturals"
+    ]
   },
   {
     "id": "ann-neumann-theorem",
@@ -173,7 +197,11 @@
       "clique-bound",
       "key-result"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Quotient By The Center",
+      "Iff Rewriting Tactics",
+      "Axiom Plus Theorem Pattern"
+    ]
   },
   {
     "id": "ann-coset-structure",
@@ -198,7 +226,11 @@
       "injection",
       "proof-technique"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Cosets Of The Center",
+      "Quotient Maps And Injectivity",
+      "Cardinality Bounds Via Injection"
+    ]
   },
   {
     "id": "ann-abelian-no-edges",
@@ -223,7 +255,11 @@
       "graph-empty",
       "special-case"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Abelian Groups",
+      "Top Subgroup",
+      "Center Membership Characterization"
+    ]
   },
   {
     "id": "ann-examples",
@@ -248,7 +284,11 @@
       "examples",
       "finite-groups"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Symmetric And Dihedral Groups",
+      "Trivial Center Groups",
+      "Finite Group Typeclass"
+    ]
   },
   {
     "id": "ann-generalizations",
@@ -274,7 +314,11 @@
       "conjugacy-classes",
       "generalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Conjugacy Classes",
+      "Schur's Theorem",
+      "Commuting Probability Of Groups"
+    ]
   },
   {
     "id": "ann-summary",
@@ -298,6 +342,10 @@
       "main-result",
       "solved-problem"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Definitional Aliases",
+      "Conjunction Introduction Tactic",
+      "Logical Equivalence"
+    ]
   }
 ]


### PR DESCRIPTION
Adds 2-3 per-annotation `prerequisites` to each annotation in `erdos-1098`, filling previously-empty prerequisite lists. Single-file change; diff is prerequisite-only.