### PR TITLE
Enrich erdos-1012: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1012/annotations.json
+++ b/src/data/proofs/erdos-1012/annotations.json
@@ -349,6 +349,10 @@
       "proof architecture",
       "formalization completeness"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "axiom versus sorry in Lean",
+      "separating deep results from combinatorial corollaries",
+      "axiomCount accounting for assumptions"
+    ]
   }
 ]


### PR DESCRIPTION
Per-annotation prerequisite enrichment for `erdos-1012`. Fills empty `prerequisites` arrays in annotations.json with 2-3 specific concepts per annotation. Additions only; annotation count and all other fields unchanged.