### PR TITLE
Enrich erdos-1024: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1024/annotations.json
+++ b/src/data/proofs/erdos-1024/annotations.json
@@ -17,7 +17,11 @@
       "Steiner-triple-system",
       "probabilistic-method"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "asymptotic notation (≍, ≪)",
+      "partial Steiner triple systems",
+      "extremal combinatorics framework"
+    ]
   },
   {
     "id": "ann-1024-linear-def",
@@ -37,7 +41,11 @@
       "incidence-structure",
       "Steiner-bound"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "set-theoretic edges as finite vertex sets",
+      "intersection cardinality (|A ∩ B|)",
+      "edge-counting via the Steiner/Fisher bound"
+    ]
   },
   {
     "id": "ann-1024-independence",
@@ -57,7 +65,11 @@
       "sSup",
       "infimum"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "supremum/infimum over finite families",
+      "subset containment of edges",
+      "finiteness of hypergraphs on Fin n"
+    ]
   },
   {
     "id": "ann-1024-erdos-bounds",
@@ -77,7 +89,11 @@
       "explicit-construction",
       "exponent-gap"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "fractional exponents in growth rates",
+      "first-moment probabilistic lower bounds",
+      "projective-plane incidence constructions"
+    ]
   },
   {
     "id": "ann-1024-phelps-rodl",
@@ -97,7 +113,11 @@
       "Phelps-Rodl",
       "order-of-growth"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "matching upper and lower bounds up to constants",
+      "logarithmic correction factors",
+      "n^{1/2+o(1)} growth"
+    ]
   },
   {
     "id": "ann-1024-steiner",
@@ -117,7 +137,11 @@
       "edge-density",
       "combinatorial-design"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "pair-covering designs",
+      "Kirkman's existence congruence n ≡ 1,3 (mod 6)",
+      "maximal edge density n(n-1)/6"
+    ]
   },
   {
     "id": "ann-1024-probabilistic",
@@ -137,7 +161,11 @@
       "optimization",
       "expected-value"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "independent vertex sampling with probability p",
+      "linearity of expectation",
+      "calculus optimization of pn - mp³"
+    ]
   },
   {
     "id": "ann-1024-comparison",
@@ -157,6 +185,10 @@
       "log-vs-polynomial",
       "o(1)-exponent"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "monotonicity of log n versus n^{1/3}",
+      "little-o asymptotic notation",
+      "sub-polynomial vs polynomial growth"
+    ]
   }
 ]


### PR DESCRIPTION
Per-annotation prerequisite enrichment for `erdos-1024`. Fills empty `prerequisites` arrays in annotations.json with 2-3 specific concepts per annotation. Additions only; annotation count and all other fields unchanged.