### PR TITLE
Enrich fermat-two-squares: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/fermat-two-squares/annotations.json
+++ b/src/data/proofs/fermat-two-squares/annotations.json
@@ -15,6 +15,11 @@
       "Mathlib",
       "sum of squares",
       "prime characterization"
+    ],
+    "prerequisites": [
+      "prime numbers and divisibility",
+      "sums of two squares a²+b²",
+      "Mathlib's number-theory API"
     ]
   },
   {
@@ -34,6 +39,11 @@
       "Fermat",
       "Euler",
       "Lagrange"
+    ],
+    "prerequisites": [
+      "prime numbers and their congruence classes mod 4",
+      "the statement that some primes are sums of two squares",
+      "basic history of number theory (Fermat, Euler)"
     ]
   },
   {
@@ -52,6 +62,11 @@
       "involutions",
       "combinatorial proof",
       "Zagier"
+    ],
+    "prerequisites": [
+      "involutions (self-inverse maps) and their fixed points",
+      "parity of fixed-point sets",
+      "representing p = x²+4yz as a lattice/triple count"
     ]
   },
   {
@@ -69,6 +84,11 @@
     "relatedConcepts": [
       "modular arithmetic",
       "characterization theorem"
+    ],
+    "prerequisites": [
+      "prime numbers mod 4",
+      "sums of two squares",
+      "if-and-only-if characterizations"
     ]
   },
   {
@@ -86,6 +106,11 @@
     "relatedConcepts": [
       "Fermat's original statement",
       "prime classification"
+    ],
+    "prerequisites": [
+      "congruence classes of primes mod 4",
+      "quadratic residues and −1 being a square mod p",
+      "sums of two squares"
     ]
   },
   {
@@ -103,6 +128,11 @@
     "relatedConcepts": [
       "special cases",
       "edge cases"
+    ],
+    "prerequisites": [
+      "the prime 2 and the identity 2 = 1²+1²",
+      "why 2 is the even-prime edge case",
+      "sums of two squares"
     ]
   },
   {
@@ -120,6 +150,11 @@
     "relatedConcepts": [
       "impossibility proof",
       "modular arithmetic"
+    ],
+    "prerequisites": [
+      "arithmetic mod 4 of squares (squares are 0 or 1 mod 4)",
+      "proof by contradiction",
+      "primes p ≡ 3 (mod 4)"
     ]
   },
   {
@@ -137,6 +172,11 @@
     "relatedConcepts": [
       "examples",
       "verification"
+    ],
+    "prerequisites": [
+      "the p ≡ 1 (mod 4) characterization",
+      "computing a²+b² decompositions",
+      "prime congruence classes"
     ]
   },
   {
@@ -154,6 +194,11 @@
     "relatedConcepts": [
       "prime classification",
       "complete characterization"
+    ],
+    "prerequisites": [
+      "primes split by residue mod 4 (and the prime 2)",
+      "the full sum-of-two-squares theorem",
+      "exhaustive case classification"
     ]
   },
   {
@@ -171,6 +216,11 @@
     "relatedConcepts": [
       "Gaussian integers",
       "algebraic number theory",
+      "quadratic reciprocity"
+    ],
+    "prerequisites": [
+      "the Gaussian integers ℤ[i] and their norm N(a+bi)=a²+b²",
+      "prime factorization and ramification/splitting in ℤ[i]",
       "quadratic reciprocity"
     ]
   }


### PR DESCRIPTION
Adds `prerequisites` arrays to all 10 annotations of the Fermat sum-of-two-squares entry. Each gains 3 foundational prerequisite concepts (congruences mod 4, quadratic residues, Zagier's involution, Gaussian integers, etc.).

Purely additive — no existing content modified. JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)