### PR TITLE
Enrich erdos-1031: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1031/annotations.json
+++ b/src/data/proofs/erdos-1031/annotations.json
@@ -17,7 +17,11 @@
       "real logarithm",
       "Ramsey theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Lean 4 module imports",
+      "undirected graph (no loops)",
+      "natural logarithm of an integer"
+    ]
   },
   {
     "id": "ann-1031-graphs",


### PR DESCRIPTION
Per-annotation prerequisite enrichment for `erdos-1031`. Fills empty `prerequisites` arrays in annotations.json with 2-3 specific concepts per annotation. Additions only; annotation count and all other fields unchanged.