### PR TITLE
Enrich erdos-1032: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1032/annotations.json
+++ b/src/data/proofs/erdos-1032/annotations.json
@@ -16,7 +16,11 @@
       "critical graphs",
       "minimum degree"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "proper vertex coloring",
+      "edge-deletion subgraphs",
+      "asymptotic constant c > 0 (linear growth)"
+    ]
   },
   {
     "id": "ann-e1032-axioms",
@@ -35,7 +39,11 @@
       "Mathlib"
     ],
     "mathContext": "See annotation content for formal details of graph properties (axiomatised)",
-    "prerequisites": []
+    "prerequisites": [
+      "Fintype.card and finite vertex types",
+      "vertex degree as neighbor count",
+      "axiomatic specification vs constructive definition"
+    ]
   },
   {
     "id": "ann-e1032-critical",
@@ -54,7 +62,11 @@
       "graph colouring",
       "Dirac's theorem"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "complete graphs K_k",
+      "greedy coloring of low-degree vertices",
+      "color-critical subgraph minimality"
+    ]
   },
   {
     "id": "ann-e1032-dirac",
@@ -73,7 +85,11 @@
       "Mycielski construction",
       "dense graphs"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Mycielskian (triangle-free chromatic lifting)",
+      "graph join operation",
+      "Theta(n) asymptotic density"
+    ]
   },
   {
     "id": "ann-e1032-simonovits-toft",
@@ -92,7 +108,11 @@
       "cube-root barrier",
       "extremal graph theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "existential lower-bound construction",
+      "n^{1/3} scaling exponent",
+      "vertex blow-up / replacement substitution"
+    ]
   },
   {
     "id": "ann-e1032-toft",
@@ -111,7 +131,11 @@
       "Toft's conjecture",
       "extremal graph theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "average degree from edge count (2|E|/n)",
+      "little-o asymptotic notation",
+      "edge-density extremal bound"
+    ]
   },
   {
     "id": "ann-e1032-conjecture",
@@ -130,6 +154,10 @@
       "chromatic number",
       "open problem"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "existential quantification over all n",
+      "5-chromatic critical graphs",
+      "degree-gap from n^{1/3} to linear"
+    ]
   }
 ]


### PR DESCRIPTION
Per-annotation prerequisite enrichment for `erdos-1032`. Fills empty `prerequisites` arrays in annotations.json with 2-3 specific concepts per annotation. Additions only; annotation count and all other fields unchanged.