### PR TITLE
research(abel-ruffini-oq-07): Aristotle target for order-6→swap step + instantiation plan

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ07Order6Aristotle.lean
+++ b/proofs/Proofs/AbelRuffiniOQ07Order6Aristotle.lean
@@ -1,0 +1,56 @@
+/-
+  Aristotle companion for `abel-ruffini-oq-07` (Gal(X⁵ − X − 1) ≅ S₅).
+
+  ## Why this file exists
+  The gallery entry `AbelRuffiniOQ07.lean` is a fully verified (0 sorry / 0 axiom)
+  group-theoretic *reduction*: it proves `Gal(X⁵−X−1) ≅ S₅` modulo two number-theoretic
+  inputs, of which `5 ∣ |Gal|` is now discharged unconditionally from Selmer's
+  irreducibility theorem.  The SOLE remaining input is a **transposition** in the Galois
+  group, which comes from the order-6 Frobenius at `p = 2`.
+
+  The abstract Dedekind–Frobenius bridge `orderOf (arithFrobAt R G Q) = inertiaDegIn p S`
+  is now PROVED and axiom-free in `DedekindFrobeniusBridge.lean`.  Instantiated at
+  `R = ℤ`, `S = 𝓞 K`, `G = Gal`, and a prime `Q` over `2` (where the residue degree in
+  the degree-120 splitting field equals the order of the Frobenius, namely `6`), it yields
+  an element `σ ∈ f.Gal` with `orderOf σ = 6`.
+
+  The generic group-theoretic step that turns that order-6 element into the swap the
+  reduction consumes is the lemma below — the generic form of the concrete
+  `frob2_pow_three_isSwap` already in the gallery file.  It is pure `S₅` combinatorics
+  (Mathlib-only, no `Proofs.*` dependency), hence a clean Aristotle target.
+
+  ## Math content
+  In `S₅` the only cycle type of order `6` is `(2,3)` (partitions of `5` with `lcm = 6`:
+  a part divisible by `3` forces a `3`, leaving sum `≤ 2`, so a single `2`; `6 ∉ {2..5}`).
+  An element of cycle type `(2,3)` is `c₂ · c₃` (disjoint), whose cube is `c₂ · c₃³ = c₂`,
+  a transposition.  Hence `orderOf σ = 6 ⟹ (σ ^ 3).IsSwap`.
+-/
+import Mathlib
+
+open Equiv Equiv.Perm
+
+namespace AbelRuffiniOQ07Order6
+
+/-- **The generic order-6 ⟹ transposition step.**
+    In `S₅`, an element of order `6` necessarily has cycle type `(2,3)`, so its cube is a
+    transposition.  This is the reusable form of the gallery file's concrete
+    `frob2_pow_three_isSwap`; combined with the now-proved Dedekind–Frobenius bridge
+    (which supplies an order-6 element of `f.Gal` from the inertia degree at `p = 2`), it
+    discharges the last open input of `abel-ruffini-oq-07`. -/
+theorem orderOf_eq_six_pow_three_isSwap
+    (σ : Equiv.Perm (Fin 5)) (hσ : orderOf σ = 6) : (σ ^ 3).IsSwap := by
+  sorry
+
+/-- **Consumer assembly variant (real Galois-group facing).**
+    A subgroup `G ≤ S₅` with `5 ∣ |G|` that contains an order-6 element equals `⊤`.
+    This is `gal_eq_top_of_five_dvd_and_swap` with the swap input replaced by the
+    order-6 element the bridge produces, so the open gap of `abel-ruffini-oq-07` becomes
+    exactly "`∃ σ ∈ Gal, orderOf σ = 6`" — the abstract bridge's output. -/
+theorem gal_eq_top_of_five_dvd_and_order6
+    {G : Subgroup (Equiv.Perm (Fin 5))} [DecidablePred (· ∈ G)]
+    (h5 : 5 ∣ Fintype.card G)
+    {σ : Equiv.Perm (Fin 5)} (hσG : σ ∈ G) (hσ : orderOf σ = 6) :
+    G = ⊤ := by
+  sorry
+
+end AbelRuffiniOQ07Order6

--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -2174,6 +2174,19 @@
       "notes": "STEP D crux: gapLengths a N subset {a,b,c}; witnesses a,b,c fixed in file; self-contained (Mathlib-only import). MCP prove_file still 404; submitted via CLI submit --project-dir.",
       "status": "submitted",
       "last_check": null
+    },
+    {
+      "project_id": "ddd818e2-e934-4fd9-b389-15d56a22b49a",
+      "file": "proofs/Proofs/AbelRuffiniOQ07Order6Aristotle.lean",
+      "problem_id": "abel-ruffini-oq-07",
+      "submitted": "2026-06-19T13:20:00Z",
+      "sorries": [
+        "orderOf_eq_six_pow_three_isSwap : (σ:Perm(Fin5)) orderOf σ=6 → (σ^3).IsSwap",
+        "gal_eq_top_of_five_dvd_and_order6 : 5∣|G| ∧ ∃ order-6 elem → G=⊤"
+      ],
+      "notes": "Generic S5 order-6→swap step. Consumes the now-PROVED Dedekind-Frobenius bridge (DedekindFrobeniusBridge.lean) output: bridge gives orderOf(arithFrobAt)=inertiaDegIn=6 at a prime over 2 of the splitting field, this turns it into the swap the verified reduction gal_eq_top_of_five_dvd_and_swap consumes. Self-contained Mathlib-only companion (NOT registered in Proofs.lean). CLI submit; v4.26 vs Aristotle v4.28 warning (Perm(Fin5) API stable).",
+      "status": "submitted",
+      "last_check": null
     }
   ]
 }

--- a/research/problems/abel-ruffini-oq-07/knowledge.md
+++ b/research/problems/abel-ruffini-oq-07/knowledge.md
@@ -295,3 +295,55 @@ move is the self-contained extraction + Aristotle-CLI submission of `exists_gal_
   prime of the target inertia degree, and matching the abstract `arithFrobAt` order to the
   cycle type in `Gal`. Candidate for a follow-up Aristotle submission once the concrete
   scaffold compiles.
+
+---
+
+## Session 2026-06-19 (researcher-1) — bridge now PROVED ⟹ exact instantiation plan + Aristotle target for the order-6→swap step
+
+**Mode**: ACT | **Outcome**: progress (turned "bridge open" into a concrete 4-step plan; submitted the one missing group lemma to Aristotle). No build (gate closed: 5 `lean-build` containers vs VM ~7.65 GiB).
+
+### State recap
+- Gallery entry `AbelRuffiniOQ07.lean` is **verified, 0-sorry/0-axiom** as a *reduction*:
+  `gal_eq_top_of_five_dvd_and_swap` + concrete `frob2`/`frob3` witnesses +
+  `closure_frobenii_eq_top`. `5 ∣ |f.Gal|` is **unconditional** via Selmer
+  (`five_dvd_card_gal_unconditional`). The **sole** open input is a *transposition in the
+  real `f.Gal`* (exposed as a hypothesis, not an axiom — honest).
+- **Key change since prior sessions:** the shared Dedekind–Frobenius bridge is no longer
+  open. `DedekindFrobeniusBridge.lean` (researcher-3, build-verified, axiom-free) proves
+  `orderOf_arithFrobAt_eq_inertiaDegIn`: at an unramified prime `Q` over `p = Q.under R`,
+  `orderOf (arithFrobAt R G Q) = Ideal.inertiaDegIn p S`.
+
+### The exact 4-step instantiation that now closes OQ-07
+Let `K = f.SplittingField`, `S = 𝓞 K`, `R = ℤ`, `G = (K ≃ₐ[ℚ] K)` acting on `S`.
+1. **Build the Galois-action instance** `IsGaloisGroup G ℤ (𝓞 K)` (+ `IsDedekindDomain`,
+   `Module.Finite`, `NoZeroSMulDivisors` — all standard for number fields). This is the
+   main plumbing cost.
+2. **Exhibit a prime `Q | 2` with `inertiaDegIn 2 S = 6` and `ramificationIdxIn 2 S = 1`.**
+   `2 ∤ disc(f) = 2869 = 19·151`, so `2` is unramified. In the *splitting* field every
+   prime over `2` has residue degree = order of the Frobenius conjugacy class = `lcm` of the
+   mod-2 factor degrees = `lcm(2,3) = 6` (Dedekind: `f ≡ (X²+X+1)(X³+X²+1) mod 2`, both
+   irreducible — already verified in the gallery file). So `inertiaDegIn 2 S = 6`.
+3. **Bridge ⟹ `∃ σ : f.Gal, orderOf σ = 6`** (= `orderOf (arithFrobAt ℤ G Q)`), then transport
+   along the iso `f.Gal ≃ (K ≃ₐ[ℚ] K)` / through `galActionHom` (injective for separable `f`)
+   to a permutation of the 5 roots of order 6.
+4. **`orderOf = 6 ⟹ (σ³).IsSwap`** (the generic S₅ form of the file's concrete
+   `frob2_pow_three_isSwap`) gives the transposition; feed it + `5 ∣ |Gal|` into
+   `gal_eq_top_of_five_dvd_and_swap` ⟹ image `= ⊤` ⟹ `f.Gal ≅ S₅`. ∎
+
+Steps 1–2 are the genuine remaining work (number-theoretic; same `𝓞 K`/`inertiaDegIn`
+plumbing the sibling `inverse-galois-a5-oq-01` needs for its order-3 element at `p = 7`).
+Step 4 is pure `S₅` combinatorics.
+
+### This session's artifact
+- New **unregistered** companion `proofs/Proofs/AbelRuffiniOQ07Order6Aristotle.lean`
+  (Mathlib-only, NOT in `Proofs.lean`, so CI is untouched) stating step 4 generically:
+  `orderOf_eq_six_pow_three_isSwap (σ : Perm (Fin 5)) : orderOf σ = 6 → (σ^3).IsSwap`
+  plus the consumer `gal_eq_top_of_five_dvd_and_order6`.
+- **Submitted to Aristotle CLI**, job `ddd818e2-e934-4fd9-b389-15d56a22b49a`.
+  Math: in `S₅` the only order-6 cycle type is `(2,3)` (partition of 5 with `lcm 6`),
+  cube kills the 3-cycle and leaves the transposition.
+- Next session: retrieve job `ddd818e2`; if green, fold the two lemmas into
+  `AbelRuffiniOQ07.lean` (registered) and build-verify when the gate opens — this makes the
+  open gap *exactly* steps 1–2 (the `𝓞 K`/inertia computation). If Aristotle stalls, the
+  lemma is provable by hand via `Equiv.Perm.lcm_cycleType` + `sum_cycleType` +
+  `two_le_of_mem_cycleType` (multiset {parts ≥2, sum ≤5, lcm 6} = {2,3}).


### PR DESCRIPTION
## Summary

`abel-ruffini-oq-07` (Gal(X⁵ − X − 1) ≅ S₅) is **verified as a reduction** in the gallery (`AbelRuffiniOQ07.lean`, 0 sorry / 0 axiom): the assembly `gal_eq_top_of_five_dvd_and_swap`, concrete `frob2`/`frob3` witnesses, and `5 ∣ |f.Gal|` unconditionally from Selmer. The **sole** remaining input is a transposition in the *real* `f.Gal`, exposed honestly as a hypothesis (not an axiom).

The shared **Dedekind–Frobenius bridge** that supplies it is no longer open: `DedekindFrobeniusBridge.lean` now proves `orderOf (arithFrobAt R G Q) = inertiaDegIn p S` axiom-free. This PR turns that into a concrete path to closure.

## What's here (no build; build gate was closed — 5 active `lean-build` containers)

- **New unregistered companion** `proofs/Proofs/AbelRuffiniOQ07Order6Aristotle.lean` (Mathlib-only, **not** in `Proofs.lean`, CI untouched) stating the one missing generic step:
  - `orderOf_eq_six_pow_three_isSwap (σ : Perm (Fin 5)) : orderOf σ = 6 → (σ^3).IsSwap` — in S₅ the only order-6 cycle type is `(2,3)`, so the cube is a transposition.
  - `gal_eq_top_of_five_dvd_and_order6` — the consumer that lets the open gap become *exactly* the bridge's output `∃ σ ∈ Gal, orderOf σ = 6`.
- **Submitted to Aristotle** (job `ddd818e2-e934-4fd9-b389-15d56a22b49a`), recorded in `research/aristotle-jobs.json`.
- **`knowledge.md`**: the exact 4-step instantiation now closing OQ-07 (build `IsGaloisGroup G ℤ 𝓞K` → prime over 2 with `inertiaDegIn = 6`, unramified since `2 ∤ disc = 2869` → bridge → cube to swap).

## Status

`abel-ruffini-oq-07` remains `axiomatized`/open as a full theorem; this is incremental scaffolding toward closure, not a completion claim. Next session: retrieve job `ddd818e2`, fold the verified lemmas into the registered file, and build-verify when the gate opens. The genuine remaining work is the `𝓞 K`/inertia-degree computation (steps 1–2), shared with the sibling `inverse-galois-a5-oq-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)