### PR TITLE
Enrich hilbert-13-oq-04: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/hilbert-13-oq-04/annotations.json
+++ b/src/data/proofs/hilbert-13-oq-04/annotations.json
@@ -16,6 +16,11 @@
       "refinements",
       "compact metric spaces"
     ],
+    "prerequisites": [
+      "open covers and their refinements",
+      "compact metric spaces",
+      "point-set topology of dimension"
+    ],
     "mathContext": "The Lebesgue covering dimension coincides with the small and large inductive dimensions for separable metrizable spaces. For compact metric spaces, dim(X) = n iff X embeds in R^{2n+1} (Menger-Nobeling theorem). The covering dimension controls many function-theoretic properties."
   },
   {
@@ -33,6 +38,11 @@
       "dimension monotonicity",
       "zero-dimensional spaces",
       "totally disconnected spaces"
+    ],
+    "prerequisites": [
+      "Lebesgue covering dimension",
+      "subspaces and the subspace topology",
+      "zero-dimensional / totally disconnected spaces"
     ],
     "mathContext": "Monotonicity is a basic property of covering dimension. Dimension 0 characterizes totally disconnected compact spaces (Stone spaces)."
   },
@@ -52,6 +62,11 @@
       "Lebesgue covering theorem",
       "degree theory"
     ],
+    "prerequisites": [
+      "Lebesgue covering dimension",
+      "the unit cube [0,1]ⁿ",
+      "the Lebesgue covering theorem (dim [0,1]ⁿ = n)"
+    ],
     "mathContext": "dim([0,1]^n) = n is the foundational result that connects covering dimension to the familiar notion of dimension for Euclidean spaces. The lower bound is equivalent to the Brouwer fixed point theorem."
   },
   {
@@ -70,6 +85,11 @@
       "Ostrand theorem",
       "point separation"
     ],
+    "prerequisites": [
+      "covering dimension and embeddings",
+      "continuous maps separating points",
+      "Ostrand's theorem on separating maps"
+    ],
     "mathContext": "Ostrand showed that compact metric spaces of dimension n admit 2n+1 separating maps to [0,1], extending the idea that [0,1]^n embeds into R^{2n+1} (Menger-Nobeling). The maps serve as 'coordinate functions' for the KA representation."
   },
   {
@@ -87,6 +107,11 @@
       "Kolmogorov-Arnold theorem",
       "superposition",
       "compact metric spaces"
+    ],
+    "prerequisites": [
+      "the classical Kolmogorov–Arnold superposition theorem",
+      "compact metric spaces of finite covering dimension",
+      "embeddings into Euclidean space"
     ],
     "mathContext": "The generalized KA theorem shows that covering dimension is the precise invariant governing when continuous functions can be decomposed into sums of univariate compositions. The proof uses Ostrand's separating maps and a Baire category argument to construct the outer functions."
   },
@@ -107,6 +132,11 @@
       "Menger compacta",
       "essential maps"
     ],
+    "prerequisites": [
+      "the superposition (basic embedding) property",
+      "Menger compacta and essential maps",
+      "Sternfeld's dimension characterization"
+    ],
     "mathContext": "Sternfeld's characterization completely answers the question of which compact spaces admit KA-type representations. The necessity direction (dim > n implies existence of non-decomposable functions) uses properties of Menger compacta as universal n-dimensional spaces."
   },
   {
@@ -125,6 +155,11 @@
       "special case",
       "dimension of unit cube"
     ],
+    "prerequisites": [
+      "the generalized Kolmogorov–Arnold theorem",
+      "the dimension of the unit cube",
+      "specializing a general theorem to [0,1]ⁿ"
+    ],
     "mathContext": "The classical Kolmogorov-Arnold theorem for [0,1]^n follows in one line from the generalized theorem and dim([0,1]^n) <= n."
   },
   {
@@ -142,6 +177,11 @@
       "optimal bounds",
       "cohomological obstructions",
       "Menger compacta"
+    ],
+    "prerequisites": [
+      "the 2n+1 superposition bound",
+      "Menger compacta",
+      "cohomological obstructions to embeddings"
     ],
     "mathContext": "The sharpness result uses cohomological methods and the theory of essential maps on universal n-dimensional compacta. For n=1, this says 3 terms are needed (and sufficient) for any curve; for n=2, 5 terms for any surface."
   }


### PR DESCRIPTION
Adds `prerequisites` arrays to all 8 annotations of the Kolmogorov-Arnold generalization to compact metric spaces entry. Each gains 3 foundational prerequisite concepts.

Purely additive — no existing content modified. JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)