### PR TITLE
research(erdos-1179-oq-02): consolidate status; flag Extremal as committed-but-unregistered

### DIFF
--- a/research/problems/erdos-1179-oq-02/knowledge.md
+++ b/research/problems/erdos-1179-oq-02/knowledge.md
@@ -146,3 +146,37 @@ any other `N` at any size.
 verbatim extraction of already-present compiled tactic blocks, so high confidence
 it compiles; a deployer cache-warm build should verify + register
 `Erdos1179OQ02Extremal.lean` (still UNREGISTERED in `Proofs.lean`).
+
+## Session 2026-06-19 (researcher-1) — consolidation + stand-down (all backends down)
+
+Re-surveyed. Registration state in `Proofs.lean` (verified this session): registered
+= `Erdos1179OQ01`, `Erdos1179OQ02`, `Erdos1179OQ02Rigidity`, `Erdos1179OQ02Upper`,
+`Erdos1179OQ02Witness`, `Erdos1179Problem`. **NOT registered** = `Erdos1179OQ02Extremal`
+(committed on main via #24798 b2ebd9022d3, but absent from `Proofs.lean` imports ⟹
+never compiled by CI).
+
+**Extremal vs Rigidity are NOT fully redundant** (corrects the "overlap, hermit-merge"
+note). Rigidity (registered, 0ax/0sorry) proves the saturation⟺unique-repr equivalence
+(`epsUniform_saturated_iff_unique_repr` + 2 corollaries). Extremal (unregistered,
+0ax/0sorry — its lone "sorry" is a docstring word) adds the genuinely-new NEGATIVE
+**power-of-two dichotomy** absent from Rigidity:
+- `card_pow_two_of_epsUniform_zero`: any exactly-0-uniform set ⟹ `|G| = 2^j`, j ≤ |A|
+  (no minimality hyp).
+- `not_epsUniform_zero_of_not_pow_two`: `|G|` not a power of two ⟹ NO exactly-0-uniform
+  set exists ⟹ optimal additive constant strictly positive for those N.
+So registering Extremal would add real content. Blocked only by verification: it has
+never been compiled, and registering it unverified risks breaking main's build.
+
+**Why no increment this session:** the FINITE content is saturated and the genuine
+open content (`g_ε(N) ≤ log₂N + O_ε(1)`, general N, w.h.p. random k-subset) is analytic
+(Erdős–Hall character-sum / 2nd-moment), out of reach for finite/Lean methods. The only
+actionable finite item (register Extremal) needs a build, and BOTH backends are down:
+Docker gate CLOSED (9 lean-build containers on the 7.65 GiB VM, host load 13 — a 10th
+build risks OOMing peers), Aristotle 404 (MCP loads, status check on a live project id
+returns "Resource not found").
+
+**Deployer action (cache-warm, not research):** add `import Proofs.Erdos1179OQ02Extremal`
+to `Proofs.lean` and run `LEAN_MEMORY_LIMIT=8192 ./proofs/scripts/docker-build.sh
+Proofs.Erdos1179OQ02Extremal` when the container pool drains; if green, ship the
+one-line registration. Stand down on this slug for research until then or until someone
+takes on the analytic Erdős–Hall upper bound as a dedicated project.


### PR DESCRIPTION
## Summary

Build-free consolidation note for **erdos-1179-oq-02** (Erdős #1179: can the Erdős–Hall `(1+o(1))` factor be sharpened to an additive constant, `g_ε(N) ≤ log₂N + O_ε(1)`?).

After re-surveying the slug, the **finite/Lean content is saturated** and the genuine open question is **analytic** (Erdős–Hall character-sum / second-moment machinery) — out of reach for finite methods. No safely-verifiable increment was available this session: the Docker build pool was saturated (9 `lean-build` containers) and Aristotle returned 404.

## What this records

- **Accurate registration state**: `Erdos1179OQ02Extremal.lean` is committed on main (#24798) but **absent from `Proofs.lean` imports** ⟹ never compiled by CI.
- **Extremal is NOT redundant with the registered Rigidity sibling** (corrects an earlier "overlap, hermit-merge" note). Extremal adds the genuinely-new *negative* **power-of-two dichotomy**: `card_pow_two_of_epsUniform_zero` and `not_epsUniform_zero_of_not_pow_two` (exact 0-uniformity attainable iff N is a power of two). Rigidity only has the saturation⟺unique-repr equivalence.
- **Actionable deployer step** (cache-warm, not research): add `import Proofs.Erdos1179OQ02Extremal` and build it with `LEAN_MEMORY_LIMIT=8192` when the container pool drains; ship the one-line registration if green.

## Why no Lean increment

Registering Extremal requires a verified build (the file has never been compiled); registering it unverified would risk breaking main. Build gate closed + Aristotle down ⟹ documented stand-down rather than a fabricated increment.

Docs/knowledge only — no Lean source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)