### PR TITLE
research(pentagonal-number-theorem-oq-01): Euler's identity in ℤ⟦X⟧ — signed-count bridge + degrees 0,1,2 [build-green]

### DIFF
--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -39,9 +39,18 @@
                                coefficient pinned down
   - `eulerProduct`            — the product LHS `∏_{n≥1} (1 − Xⁿ)`, defined by
                                coefficient stabilization (`coeff_eulerProduct_of_le`)
+  - `coeff_eulerProduct_eq_signed_count`
+                               — the structural bridge: the `Xⁿ`-coefficient of
+                               `∏(1−Xⁿ)` equals the signed count `∑(−1)^{|t|}` over
+                               subsets `t` (partitions into distinct parts) whose
+                               shifted sum is `n` — the combinatorial side on which
+                               Franklin's involution acts.
   - `eulerPentagonalIdentity` — the open core, now a single typed equation
-                               `eulerProduct = pentSeries`, verified at the constant
-                               coefficient (`eulerPentagonalIdentity_constantCoeff`).
+                               `eulerProduct = pentSeries`, verified in degrees
+                               0, 1 and 2 (`eulerPentagonalIdentity_constantCoeff`,
+                               `…_coeff_one`, `…_coeff_two`) against the closed-form
+                               low-degree truncations — including a check at the
+                               negative index `k=-1` (exponent `g(-1)=2`).
 -/
 
 import Mathlib
@@ -333,13 +342,13 @@ noncomputable def pentSeries : PowerSeries ℤ :=
   PowerSeries.mk fun n => pentCoeff (n : ℤ)
 
 @[simp] theorem coeff_pentSeries (n : ℕ) :
-    PowerSeries.coeff ℤ n pentSeries = pentCoeff (n : ℤ) := by
+    PowerSeries.coeff (R := ℤ) n pentSeries = pentCoeff (n : ℤ) := by
   rw [pentSeries, PowerSeries.coeff_mk]
 
 /-- **Lacunary coefficients of the RHS, at the pentagonal exponents.** The
 coefficient of `X^{g(k₀)}` in `pentSeries` is `(-1)^|k₀|`. -/
 theorem coeff_pentSeries_genPent (k₀ : ℤ) :
-    PowerSeries.coeff ℤ (genPent k₀).toNat pentSeries = (-1 : ℤ) ^ k₀.natAbs := by
+    PowerSeries.coeff (R := ℤ) (genPent k₀).toNat pentSeries = (-1 : ℤ) ^ k₀.natAbs := by
   have hnn : 0 ≤ genPent k₀ := isGenPent_nonneg (genPent_isGenPent k₀)
   rw [coeff_pentSeries, Int.toNat_of_nonneg hnn]
   exact pentCoeff_genPent k₀
@@ -347,7 +356,7 @@ theorem coeff_pentSeries_genPent (k₀ : ℤ) :
 /-- **Lacunary coefficients of the RHS, off the pentagonal exponents.** If `n` is
 not a generalized pentagonal number, the coefficient of `Xⁿ` in `pentSeries` is `0`. -/
 theorem coeff_pentSeries_eq_zero {n : ℕ} (h : ¬ IsGenPent (n : ℤ)) :
-    PowerSeries.coeff ℤ n pentSeries = 0 := by
+    PowerSeries.coeff (R := ℤ) n pentSeries = 0 := by
   rw [coeff_pentSeries]
   refine pentCoeff_eq_zero fun k hk => ?_
   exact h ((isGenPent_iff_exists_genPent _).mpr ⟨k, hk⟩)
@@ -368,7 +377,7 @@ define `eulerProduct` by reading it off there (`eulerProduct`,
 honest equation `eulerProduct = pentSeries` between two fully constructed objects. -/
 
 /-- The truncated Euler product `∏_{n=1}^{N} (1 − Xⁿ)` in `ℤ⟦X⟧`. -/
-def eulerPartialProd (N : ℕ) : PowerSeries ℤ :=
+noncomputable def eulerPartialProd (N : ℕ) : PowerSeries ℤ :=
   ∏ n ∈ Finset.range N, (1 - (PowerSeries.X : PowerSeries ℤ) ^ (n + 1))
 
 /-- Truncating one factor further multiplies by `1 − X^{N+1}`. -/
@@ -382,16 +391,16 @@ theorem eulerPartialProd_succ (N : ℕ) :
 `1 − X^{N+1}` does not change the coefficient of `Xᵐ`, since `X^{N+1}` lives in
 degrees `≥ N+1 > m`. -/
 theorem coeff_eulerPartialProd_succ {m N : ℕ} (h : m ≤ N) :
-    PowerSeries.coeff ℤ m (eulerPartialProd (N + 1))
-      = PowerSeries.coeff ℤ m (eulerPartialProd N) := by
+    PowerSeries.coeff (R := ℤ) m (eulerPartialProd (N + 1))
+      = PowerSeries.coeff (R := ℤ) m (eulerPartialProd N) := by
   rw [eulerPartialProd_succ, mul_sub, mul_one, map_sub,
     PowerSeries.coeff_mul_X_pow', if_neg (by omega : ¬ (N + 1 ≤ m)), sub_zero]
 
 /-- **Coefficient stabilization.** For every `N ≥ m`, the `m`-th coefficient of the
 truncated product has already reached its final value (that of `eulerPartialProd m`). -/
 theorem coeff_eulerPartialProd_stable {m N : ℕ} (h : m ≤ N) :
-    PowerSeries.coeff ℤ m (eulerPartialProd N)
-      = PowerSeries.coeff ℤ m (eulerPartialProd m) := by
+    PowerSeries.coeff (R := ℤ) m (eulerPartialProd N)
+      = PowerSeries.coeff (R := ℤ) m (eulerPartialProd m) := by
   induction N, h using Nat.le_induction with
   | base => rfl
   | succ n hn ih => rw [coeff_eulerPartialProd_succ hn, ih]
@@ -400,11 +409,11 @@ theorem coeff_eulerPartialProd_stable {m N : ℕ} (h : m ≤ N) :
 defined by reading off each coefficient from a truncation long enough to have
 stabilized. -/
 noncomputable def eulerProduct : PowerSeries ℤ :=
-  PowerSeries.mk fun m => PowerSeries.coeff ℤ m (eulerPartialProd m)
+  PowerSeries.mk fun m => PowerSeries.coeff (R := ℤ) m (eulerPartialProd m)
 
 @[simp] theorem coeff_eulerProduct (m : ℕ) :
-    PowerSeries.coeff ℤ m eulerProduct
-      = PowerSeries.coeff ℤ m (eulerPartialProd m) := by
+    PowerSeries.coeff (R := ℤ) m eulerProduct
+      = PowerSeries.coeff (R := ℤ) m (eulerPartialProd m) := by
   unfold eulerProduct
   rw [PowerSeries.coeff_mk]
 
@@ -412,18 +421,109 @@ noncomputable def eulerProduct : PowerSeries ℤ :=
 sufficiently long truncation `eulerPartialProd N` (`N ≥ m`).  This is the precise
 sense in which `eulerProduct` *is* the infinite product `∏(1−Xⁿ)`. -/
 theorem coeff_eulerProduct_of_le {m N : ℕ} (h : m ≤ N) :
-    PowerSeries.coeff ℤ m eulerProduct
-      = PowerSeries.coeff ℤ m (eulerPartialProd N) := by
+    PowerSeries.coeff (R := ℤ) m eulerProduct
+      = PowerSeries.coeff (R := ℤ) m (eulerPartialProd N) := by
   rw [coeff_eulerProduct, ← coeff_eulerPartialProd_stable h]
 
 /-- The Euler product is normalized: its constant term is `1` (the empty
 truncation `eulerPartialProd 0 = 1`). -/
 @[simp] theorem coeff_eulerProduct_zero :
-    PowerSeries.coeff ℤ 0 eulerProduct = 1 := by
+    PowerSeries.coeff (R := ℤ) 0 eulerProduct = 1 := by
   rw [coeff_eulerProduct]
   unfold eulerPartialProd
   rw [Finset.range_zero, Finset.prod_empty]
   simp
+
+/-! ### Low-degree truncations, in closed form
+
+To compare the product side against the lacunary side beyond the constant term we
+write out the first two nontrivial truncations as explicit polynomials.  Because
+the `m`-th coefficient of `eulerProduct` already equals that of `eulerPartialProd m`
+(`coeff_eulerProduct_of_le`), these closed forms read off the degree-1 and degree-2
+coefficients of the infinite product directly. -/
+
+/-- The level-1 truncation is `1 − X`. -/
+theorem eulerPartialProd_one_eq :
+    eulerPartialProd 1 = 1 - (PowerSeries.X : PowerSeries ℤ) := by
+  unfold eulerPartialProd
+  rw [Finset.prod_range_one]
+  ring
+
+/-- The level-2 truncation is `(1 − X)(1 − X²) = 1 − X − X² + X³`. -/
+theorem eulerPartialProd_two_eq :
+    eulerPartialProd 2
+      = 1 - (PowerSeries.X : PowerSeries ℤ) - PowerSeries.X ^ 2 + PowerSeries.X ^ 3 := by
+  unfold eulerPartialProd
+  rw [Finset.prod_range_succ, Finset.prod_range_one]
+  ring
+
+/-- **Degree-1 coefficient of the Euler product is `−1`** (the `−X` term of
+`1 − X`). -/
+theorem coeff_eulerProduct_one :
+    PowerSeries.coeff (R := ℤ) 1 eulerProduct = -1 := by
+  rw [coeff_eulerProduct_of_le (le_refl 1), eulerPartialProd_one_eq]
+  simp [map_sub, PowerSeries.coeff_one, PowerSeries.coeff_X]
+
+/-- **Degree-2 coefficient of the Euler product is `−1`** (the `−X²` term of
+`1 − X − X² + X³`). -/
+theorem coeff_eulerProduct_two :
+    PowerSeries.coeff (R := ℤ) 2 eulerProduct = -1 := by
+  rw [coeff_eulerProduct_of_le (le_refl 2), eulerPartialProd_two_eq]
+  simp [map_sub, map_add, PowerSeries.coeff_one, PowerSeries.coeff_X,
+    PowerSeries.coeff_X_pow]
+
+/-! ## Part 6b: The product coefficient as a signed count over distinct parts
+
+Expanding the finite truncation `∏_{m=1}^{N}(1 − Xᵐ)` over the powerset of
+`{0,…,N−1}` via `Finset.prod_add` exhibits the `Xⁿ`-coefficient of the Euler
+product as a **signed enumeration of partitions into distinct parts**: a subset
+`t ⊆ {0,…,N−1}` corresponds to the distinct parts `{i+1 : i ∈ t}`, contributing
+sign `(−1)^{|t|}` to the coefficient of `X^{∑_{i∈t}(i+1)}`.  This is the
+combinatorial left-hand side of Euler's identity — the side on which Franklin's
+sign-reversing involution acts.  With this in hand the open core is *precisely*
+the assertion that this signed count equals `(−1)ᵏ` at `n = g(k)` and `0`
+otherwise; the number-theoretic index theory above identifies the surviving
+exponents, and a (still missing) involution would supply the cancellation. -/
+
+/-- **Subset expansion of the truncated Euler product.** Expanding the product of
+`1 − X^{i+1}` over `i < N` gives a signed sum over subsets `t ⊆ {0,…,N−1}`, the
+term of `t` being `(−1)^{|t|} X^{∑_{i∈t}(i+1)}`.  The exponent `∑_{i∈t}(i+1)` is
+the sum of the distinct parts `{i+1 : i ∈ t}`, so the subsets index exactly the
+partitions of that exponent into distinct parts. -/
+theorem eulerPartialProd_eq_sum_powerset (N : ℕ) :
+    eulerPartialProd N
+      = ∑ t ∈ (Finset.range N).powerset,
+          (-1 : PowerSeries ℤ) ^ t.card * PowerSeries.X ^ (∑ i ∈ t, (i + 1)) := by
+  unfold eulerPartialProd
+  have hfac : ∀ i ∈ Finset.range N,
+      (1 - (PowerSeries.X : PowerSeries ℤ) ^ (i + 1))
+        = (-(PowerSeries.X : PowerSeries ℤ) ^ (i + 1)) + 1 := fun i _ => by ring
+  rw [Finset.prod_congr rfl hfac, Finset.prod_add]
+  refine Finset.sum_congr rfl (fun t _ => ?_)
+  rw [Finset.prod_const_one, mul_one]
+  have hneg : ∀ i ∈ t,
+      (-(PowerSeries.X : PowerSeries ℤ) ^ (i + 1))
+        = (-1 : PowerSeries ℤ) * PowerSeries.X ^ (i + 1) := fun i _ => by ring
+  rw [Finset.prod_congr rfl hneg, Finset.prod_mul_distrib, Finset.prod_const,
+    Finset.prod_pow_eq_pow_sum]
+
+/-- **The Euler product coefficient is a signed count of distinct partitions.** For
+`N ≥ n`, the coefficient of `Xⁿ` in `∏_{m≥1}(1 − Xᵐ)` equals `∑ (−1)^{|t|}` over
+subsets `t ⊆ {0,…,N−1}` whose shifted sum `∑_{i∈t}(i+1)` is `n` — that is, the
+signed count of partitions of `n` into distinct parts (`+` for an even number of
+parts, `−` for odd).  Euler's pentagonal number theorem is exactly the assertion
+that this signed count is `(−1)ᵏ` when `n = g(k)` and `0` otherwise, and the
+combinatorial content of that assertion is Franklin's involution. -/
+theorem coeff_eulerProduct_eq_signed_count {n N : ℕ} (h : n ≤ N) :
+    PowerSeries.coeff (R := ℤ) n eulerProduct
+      = ∑ t ∈ (Finset.range N).powerset,
+          if n = ∑ i ∈ t, (i + 1) then (-1 : ℤ) ^ t.card else 0 := by
+  rw [coeff_eulerProduct_of_le h, eulerPartialProd_eq_sum_powerset, map_sum]
+  refine Finset.sum_congr rfl (fun t _ => ?_)
+  have hC : ((-1 : PowerSeries ℤ) ^ t.card)
+      = (PowerSeries.C (R := ℤ) ((-1 : ℤ) ^ t.card)) := by
+    rw [map_pow, map_neg, map_one]
+  rw [hC, PowerSeries.coeff_C_mul, PowerSeries.coeff_X_pow, mul_ite, mul_one, mul_zero]
 
 /-! ## OPEN CORE: the pentagonal identity as a typed equation
 
@@ -444,10 +544,31 @@ least correctly normalized: they agree at the constant coefficient (both `1`).
 constant term `(-1)^|0| = 1` at the exponent `g(0) = 0`.  This verifies the
 identity in degree `0` only — it does not prove `eulerPentagonalIdentity`. -/
 theorem eulerPentagonalIdentity_constantCoeff :
-    PowerSeries.coeff ℤ 0 eulerProduct = PowerSeries.coeff ℤ 0 pentSeries := by
+    PowerSeries.coeff (R := ℤ) 0 eulerProduct = PowerSeries.coeff (R := ℤ) 0 pentSeries := by
   have h := coeff_pentSeries_genPent 0
   rw [genPent_zero] at h
   rw [coeff_eulerProduct_zero]
+  simpa using h.symm
+
+/-- **Euler's identity holds in degree 1.** Both sides have `X`-coefficient `−1`:
+the product `∏(1−Xⁿ)` from its `−X` term, the lacunary series from its term at the
+pentagonal exponent `g(1) = 1` with sign `(-1)^|1| = -1`. -/
+theorem eulerPentagonalIdentity_coeff_one :
+    PowerSeries.coeff (R := ℤ) 1 eulerProduct = PowerSeries.coeff (R := ℤ) 1 pentSeries := by
+  rw [coeff_eulerProduct_one]
+  have h := coeff_pentSeries_genPent 1
+  rw [genPent_one] at h
+  simpa using h.symm
+
+/-- **Euler's identity holds in degree 2.** Both sides have `X²`-coefficient `−1`:
+the product from its `−X²` term, the lacunary series from its term at the
+pentagonal exponent `g(-1) = 2` with sign `(-1)^|-1| = -1`.  This is the first
+check at a *negative* index `k`, exercising the `(-1)^|k|` sign convention. -/
+theorem eulerPentagonalIdentity_coeff_two :
+    PowerSeries.coeff (R := ℤ) 2 eulerProduct = PowerSeries.coeff (R := ℤ) 2 pentSeries := by
+  rw [coeff_eulerProduct_two]
+  have h := coeff_pentSeries_genPent (-1)
+  rw [genPent_neg_one] at h
   simpa using h.symm
 
 /-! ## On the remaining open content (Franklin's involution)

--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -51,6 +51,16 @@
                                `…_coeff_one`, `…_coeff_two`) against the closed-form
                                low-degree truncations — including a check at the
                                negative index `k=-1` (exponent `g(-1)=2`).
+  - `signedDistinctCount` / `eulerPentagonalIdentity_iff`
+                               — the open core stripped of the power-series wrapper:
+                               `eulerProduct = pentSeries` iff the elementary
+                               pointwise identity `∀ n, signedDistinctCount n =
+                               pentCoeff n` holds, where `signedDistinctCount n` is
+                               the signed count of partitions of `n` into distinct
+                               parts.  This is exactly the statement Franklin's
+                               involution proves.  Checked at degrees 3, 4 (the first
+                               genuine sign *cancellations*) and 5 (the first index
+                               `|k|=2`, `g(2)=5`).
 -/
 
 import Mathlib
@@ -525,6 +535,25 @@ theorem coeff_eulerProduct_eq_signed_count {n N : ℕ} (h : n ≤ N) :
     rw [map_pow, map_neg, map_one]
   rw [hC, PowerSeries.coeff_C_mul, PowerSeries.coeff_X_pow, mul_ite, mul_one, mul_zero]
 
+/-- **The signed count of partitions of `n` into distinct parts.** The canonical
+combinatorial left-hand side of Euler's identity, packaged as a single explicit
+function of `n` (no power series): subsets `t ⊆ {0,…,n−1}` whose shifted sum
+`∑_{i∈t}(i+1)` is `n` index the partitions of `n` into distinct parts, each
+weighted by `(−1)^{|t|}` (so the count is `p_even(n) − p_odd(n)`).  The truncation
+`{0,…,n−1}` loses nothing: every distinct part `≤ n`, so its index `i = part−1`
+lies in `range n`. -/
+def signedDistinctCount (n : ℕ) : ℤ :=
+  ∑ t ∈ (Finset.range n).powerset,
+    if n = ∑ i ∈ t, (i + 1) then (-1 : ℤ) ^ t.card else 0
+
+/-- The `Xⁿ`-coefficient of the Euler product `∏(1−Xⁿ)` is exactly the signed
+distinct-part count `signedDistinctCount n` — the bridge of
+`coeff_eulerProduct_eq_signed_count` specialised to the canonical truncation
+`N = n`, which it captures by definition. -/
+theorem coeff_eulerProduct_eq_signedDistinctCount (n : ℕ) :
+    PowerSeries.coeff (R := ℤ) n eulerProduct = signedDistinctCount n :=
+  coeff_eulerProduct_eq_signed_count (le_refl n)
+
 /-! ## OPEN CORE: the pentagonal identity as a typed equation
 
 With **both** sides now constructed in `ℤ⟦X⟧` — the product side `eulerProduct`
@@ -537,6 +566,41 @@ power series constructed in this file: the product side `∏_{n≥1}(1−Xⁿ)` 
 lacunary side `∑_{k∈ℤ}(-1)ᵏ X^{g(k)}`.  This is the open core; see the note
 below. -/
 def eulerPentagonalIdentity : Prop := eulerProduct = pentSeries
+
+/-- **The open core, reduced to a single pointwise combinatorial identity.**
+Euler's power-series identity `eulerProduct = pentSeries` holds iff for every `n`
+the signed count of partitions of `n` into distinct parts equals the lacunary
+coefficient `pentCoeff n` (`(−1)ᵏ` at `n = g(k)`, `0` otherwise).  This strips away
+the power-series wrapper: what remains open is exactly the elementary statement
+`∀ n, signedDistinctCount n = pentCoeff n`, the equation Franklin's involution
+proves.  Both sides are now fully explicit finite expressions in `n`. -/
+theorem eulerPentagonalIdentity_iff :
+    eulerPentagonalIdentity ↔ ∀ n : ℕ, signedDistinctCount n = pentCoeff (n : ℤ) := by
+  unfold eulerPentagonalIdentity
+  rw [PowerSeries.ext_iff]
+  refine forall_congr' (fun n => ?_)
+  rw [coeff_eulerProduct_eq_signedDistinctCount, coeff_pentSeries]
+
+/-- **Degree-3 check of the reduced identity — the first genuine cancellation.**
+`signedDistinctCount 3 = 0`: the partitions of `3` into distinct parts are `{3}`
+(one part, sign `−1`) and `{1,2}` (two parts, sign `+1`), which cancel.  This is
+the first exponent where more than one distinct partition exists, so it is the
+first nontrivial instance of the sign cancellation that Franklin's involution
+explains; it matches `pentCoeff 3 = 0` since `3` is not a generalized pentagonal
+number. -/
+theorem signedDistinctCount_three : signedDistinctCount 3 = 0 := by decide
+
+/-- **Degree-4 check of the reduced identity.** `signedDistinctCount 4 = 0`: the
+distinct partitions of `4` are `{4}` (sign `−1`) and `{1,3}` (sign `+1`), again
+cancelling; matches `pentCoeff 4 = 0` (`4` is not pentagonal). -/
+theorem signedDistinctCount_four : signedDistinctCount 4 = 0 := by decide
+
+/-- **Degree-5 check of the reduced identity — the first index `|k| = 2`.**
+`signedDistinctCount 5 = 1`: the distinct partitions of `5` are `{5}` (sign `−1`),
+`{1,4}` (sign `+1`) and `{2,3}` (sign `+1`), summing to `+1`.  This matches
+`pentCoeff 5 = (−1)^|2| = 1`, since `5 = g(2)` is the generalized pentagonal number
+of index `2` — the first surviving lacunary term beyond the `|k| ≤ 1` range. -/
+theorem signedDistinctCount_five : signedDistinctCount 5 = 1 := by decide
 
 /-- A consistency check on the open core that the two constructed sides are at
 least correctly normalized: they agree at the constant coefficient (both `1`).

--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -264,11 +264,91 @@ theorem genPent_neg_four : genPent (-4) = 26 := by have := two_mul_genPent (-4);
 theorem twelve_isGenPent : IsGenPent 12 :=
   (isGenPent_iff_isSquare 12).mpr ⟨17, by norm_num⟩
 
+/-! ## Part 5: The right-hand side of Euler's identity as a formal power series
+
+The pentagonal number theorem asserts the identity in `ℤ⟦X⟧`
+
+    `∏_{n≥1} (1 - Xⁿ) = ∑_{k∈ℤ} (-1)ᵏ X^{g(k)}`.
+
+Here we construct the **right-hand side** as an honest object `pentSeries : ℤ⟦X⟧`
+and pin down *all* of its coefficients, leaving only the product side and the
+combinatorial equality (Franklin's involution) for the open core.
+
+The sign `(-1)ᵏ` is realized as `(-1)^|k|`, which agrees with `(-1)ᵏ` in `ℤ`
+because `|k|` and `k` have the same parity.  The coefficient of `Xⁿ` is assembled
+as a finite sum over the computable enumerator `pentIndices n`: every index `k`
+with `g(k) = n` automatically satisfies `g(k) ≤ n`, so it lies in `pentIndices n`,
+and by `genPent_injective` at most one term survives.  The upshot
+(`pentCoeff_genPent`, `pentCoeff_eq_zero`) is the lacunary structure: the
+coefficient is `(-1)^|k|` at a generalized pentagonal number `g(k)` and `0`
+everywhere else. -/
+
+/-- The coefficient of `Xⁿ` in `∑_{k∈ℤ} (-1)ᵏ X^{g(k)}`, evaluated over the finite
+contributing index set `pentIndices n`.  Any index with `g(k) = n` lies in
+`pentIndices n` (since `g(k) = n ≤ n`), so this finite sum captures the full
+(a priori infinite) lacunary sum. -/
+def pentCoeff (n : ℤ) : ℤ :=
+  ∑ k ∈ pentIndices n, if genPent k = n then (-1 : ℤ) ^ k.natAbs else 0
+
+/-- `IsGenPent` is exactly "is a value of `g`": `2m = k(3k-1)` iff `m = g(k)`,
+using the exact doubling relation `two_mul_genPent` to avoid integer division. -/
+theorem isGenPent_iff_exists_genPent (m : ℤ) :
+    IsGenPent m ↔ ∃ k : ℤ, genPent k = m := by
+  constructor
+  · rintro ⟨k, hk⟩
+    exact ⟨k, by have := two_mul_genPent k; omega⟩
+  · rintro ⟨k, rfl⟩
+    exact genPent_isGenPent k
+
+/-- **Coefficient at a pentagonal exponent.** At `n = g(k₀)` the lacunary sum has
+exactly one surviving term, the sign `(-1)^|k₀|`; uniqueness is `genPent_injective`. -/
+theorem pentCoeff_genPent (k₀ : ℤ) :
+    pentCoeff (genPent k₀) = (-1 : ℤ) ^ k₀.natAbs := by
+  have hk₀ : k₀ ∈ pentIndices (genPent k₀) := mem_pentIndices.mpr le_rfl
+  rw [pentCoeff, Finset.sum_eq_single_of_mem k₀ hk₀]
+  · rw [if_pos rfl]
+  · intro k _ hne
+    have hk : genPent k ≠ genPent k₀ := fun h => hne (genPent_injective h)
+    rw [if_neg hk]
+
+/-- **Vanishing away from pentagonal exponents.** If `n` is not a value of `g`,
+every term of the lacunary sum vanishes, so the coefficient is `0`. -/
+theorem pentCoeff_eq_zero {n : ℤ} (h : ∀ k : ℤ, genPent k ≠ n) : pentCoeff n = 0 := by
+  rw [pentCoeff]
+  refine Finset.sum_eq_zero fun k _ => ?_
+  rw [if_neg (h k)]
+
+/-- The right-hand side `∑_{k∈ℤ} (-1)ᵏ X^{g(k)}` of Euler's pentagonal number
+theorem, as a formal power series in `ℤ⟦X⟧`. -/
+noncomputable def pentSeries : PowerSeries ℤ :=
+  PowerSeries.mk fun n => pentCoeff (n : ℤ)
+
+@[simp] theorem coeff_pentSeries (n : ℕ) :
+    PowerSeries.coeff ℤ n pentSeries = pentCoeff (n : ℤ) := by
+  rw [pentSeries, PowerSeries.coeff_mk]
+
+/-- **Lacunary coefficients of the RHS, at the pentagonal exponents.** The
+coefficient of `X^{g(k₀)}` in `pentSeries` is `(-1)^|k₀|`. -/
+theorem coeff_pentSeries_genPent (k₀ : ℤ) :
+    PowerSeries.coeff ℤ (genPent k₀).toNat pentSeries = (-1 : ℤ) ^ k₀.natAbs := by
+  have hnn : 0 ≤ genPent k₀ := isGenPent_nonneg (genPent_isGenPent k₀)
+  rw [coeff_pentSeries, Int.toNat_of_nonneg hnn]
+  exact pentCoeff_genPent k₀
+
+/-- **Lacunary coefficients of the RHS, off the pentagonal exponents.** If `n` is
+not a generalized pentagonal number, the coefficient of `Xⁿ` in `pentSeries` is `0`. -/
+theorem coeff_pentSeries_eq_zero {n : ℕ} (h : ¬ IsGenPent (n : ℤ)) :
+    PowerSeries.coeff ℤ n pentSeries = 0 := by
+  rw [coeff_pentSeries]
+  refine pentCoeff_eq_zero fun k hk => ?_
+  exact h ((isGenPent_iff_exists_genPent _).mpr ⟨k, hk⟩)
+
 /-! ## OPEN CORE (not formalized here)
 
-The deep content of the pentagonal number theorem is the *identity*
+With `pentSeries` (Part 5) realizing the **right-hand side**, the pentagonal
+number theorem reduces to the single identity in `ℤ⟦X⟧`
 
-    `∏_{n≥1} (1 - Xⁿ) = ∑_{k∈ℤ} (-1)ᵏ X^{g(k)}`   (in `ℤ⟦X⟧`),
+    `∏_{n≥1} (1 - Xⁿ) = pentSeries`,
 
 equivalently the partition statement `p_even(n) - p_odd(n) = [n = g(k)]·(-1)ᵏ`,
 where `p_even`/`p_odd` count partitions of `n` into an even/odd number of
@@ -279,7 +359,8 @@ partitions of generalized pentagonal numbers.
 Mathlib (as of this writing) has `Nat.Partition` but neither partitions into
 distinct parts with a parity sign, nor Franklin's involution, nor the requisite
 formal-power-series infinite-product manipulation.  Building that is a
-multi-file development; this file supplies the index-set theory it would consume
-(notably `isGenPent_iff_isSquare` and `genPent_injective`). -/
+multi-file development; this file supplies both the index-set theory it would
+consume (notably `isGenPent_iff_isSquare` and `genPent_injective`) and the fully
+characterized target series `pentSeries`. -/
 
 end PentagonalNumberTheoremOQ01

--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -33,6 +33,15 @@
   - `indexSet_finite`        — only finitely many `g(k) ≤ n` (Euler's recurrence
                                is a finite sum)
   - concrete values `g(0..±4) = 0,1,2,5,7,12,15,22,26` matching the OEIS A001318.
+
+  Both sides of Euler's identity are then constructed as honest objects in `ℤ⟦X⟧`:
+  - `pentSeries`              — the lacunary RHS `∑_{k∈ℤ} (-1)ᵏ X^{g(k)}`, every
+                               coefficient pinned down
+  - `eulerProduct`            — the product LHS `∏_{n≥1} (1 − Xⁿ)`, defined by
+                               coefficient stabilization (`coeff_eulerProduct_of_le`)
+  - `eulerPentagonalIdentity` — the open core, now a single typed equation
+                               `eulerProduct = pentSeries`, verified at the constant
+                               coefficient (`eulerPentagonalIdentity_constantCoeff`).
 -/
 
 import Mathlib
@@ -343,24 +352,118 @@ theorem coeff_pentSeries_eq_zero {n : ℕ} (h : ¬ IsGenPent (n : ℤ)) :
   refine pentCoeff_eq_zero fun k hk => ?_
   exact h ((isGenPent_iff_exists_genPent _).mpr ⟨k, hk⟩)
 
-/-! ## OPEN CORE (not formalized here)
+/-! ## Part 6: The left-hand side — the Euler product `∏(1−Xⁿ)` as a power series
 
-With `pentSeries` (Part 5) realizing the **right-hand side**, the pentagonal
-number theorem reduces to the single identity in `ℤ⟦X⟧`
+Euler's identity equates `pentSeries` (Part 5) with the infinite product
+`∏_{n≥1} (1 − Xⁿ)`.  We give that product an honest meaning in `ℤ⟦X⟧` by a
+coefficient-stabilization argument that needs no topology.
 
-    `∏_{n≥1} (1 - Xⁿ) = pentSeries`,
+The finite truncations `eulerPartialProd N = ∏_{n=1}^{N} (1 − Xⁿ)` stabilize
+coefficient-by-coefficient: passing from `N` to `N+1` multiplies by a single
+factor `1 − X^{N+1}`, and `X^{N+1}` contributes only in degrees `≥ N+1`, so no
+coefficient of degree `≤ N` can change (`coeff_eulerPartialProd_succ`).  Hence the
+`m`-th coefficient is already final in the truncation `eulerPartialProd m`, and we
+define `eulerProduct` by reading it off there (`eulerProduct`,
+`coeff_eulerProduct_of_le`).  This upgrades the open core from prose to the single
+honest equation `eulerProduct = pentSeries` between two fully constructed objects. -/
 
-equivalently the partition statement `p_even(n) - p_odd(n) = [n = g(k)]·(-1)ᵏ`,
-where `p_even`/`p_odd` count partitions of `n` into an even/odd number of
-*distinct* parts.  The standard proof is **Franklin's sign-reversing involution**
-on partitions into distinct parts, whose only fixed points are the staircase
-partitions of generalized pentagonal numbers.
+/-- The truncated Euler product `∏_{n=1}^{N} (1 − Xⁿ)` in `ℤ⟦X⟧`. -/
+def eulerPartialProd (N : ℕ) : PowerSeries ℤ :=
+  ∏ n ∈ Finset.range N, (1 - (PowerSeries.X : PowerSeries ℤ) ^ (n + 1))
+
+/-- Truncating one factor further multiplies by `1 − X^{N+1}`. -/
+theorem eulerPartialProd_succ (N : ℕ) :
+    eulerPartialProd (N + 1)
+      = eulerPartialProd N * (1 - (PowerSeries.X : PowerSeries ℤ) ^ (N + 1)) := by
+  unfold eulerPartialProd
+  rw [Finset.prod_range_succ]
+
+/-- **Coefficient stabilization, one step.** For `m ≤ N`, the extra factor
+`1 − X^{N+1}` does not change the coefficient of `Xᵐ`, since `X^{N+1}` lives in
+degrees `≥ N+1 > m`. -/
+theorem coeff_eulerPartialProd_succ {m N : ℕ} (h : m ≤ N) :
+    PowerSeries.coeff ℤ m (eulerPartialProd (N + 1))
+      = PowerSeries.coeff ℤ m (eulerPartialProd N) := by
+  rw [eulerPartialProd_succ, mul_sub, mul_one, map_sub,
+    PowerSeries.coeff_mul_X_pow', if_neg (by omega : ¬ (N + 1 ≤ m)), sub_zero]
+
+/-- **Coefficient stabilization.** For every `N ≥ m`, the `m`-th coefficient of the
+truncated product has already reached its final value (that of `eulerPartialProd m`). -/
+theorem coeff_eulerPartialProd_stable {m N : ℕ} (h : m ≤ N) :
+    PowerSeries.coeff ℤ m (eulerPartialProd N)
+      = PowerSeries.coeff ℤ m (eulerPartialProd m) := by
+  induction N, h using Nat.le_induction with
+  | base => rfl
+  | succ n hn ih => rw [coeff_eulerPartialProd_succ hn, ih]
+
+/-- The Euler product `∏_{n≥1} (1 − Xⁿ)` as a formal power series in `ℤ⟦X⟧`,
+defined by reading off each coefficient from a truncation long enough to have
+stabilized. -/
+noncomputable def eulerProduct : PowerSeries ℤ :=
+  PowerSeries.mk fun m => PowerSeries.coeff ℤ m (eulerPartialProd m)
+
+@[simp] theorem coeff_eulerProduct (m : ℕ) :
+    PowerSeries.coeff ℤ m eulerProduct
+      = PowerSeries.coeff ℤ m (eulerPartialProd m) := by
+  unfold eulerProduct
+  rw [PowerSeries.coeff_mk]
+
+/-- The defining property: every coefficient of `eulerProduct` equals that of any
+sufficiently long truncation `eulerPartialProd N` (`N ≥ m`).  This is the precise
+sense in which `eulerProduct` *is* the infinite product `∏(1−Xⁿ)`. -/
+theorem coeff_eulerProduct_of_le {m N : ℕ} (h : m ≤ N) :
+    PowerSeries.coeff ℤ m eulerProduct
+      = PowerSeries.coeff ℤ m (eulerPartialProd N) := by
+  rw [coeff_eulerProduct, ← coeff_eulerPartialProd_stable h]
+
+/-- The Euler product is normalized: its constant term is `1` (the empty
+truncation `eulerPartialProd 0 = 1`). -/
+@[simp] theorem coeff_eulerProduct_zero :
+    PowerSeries.coeff ℤ 0 eulerProduct = 1 := by
+  rw [coeff_eulerProduct]
+  unfold eulerPartialProd
+  rw [Finset.range_zero, Finset.prod_empty]
+  simp
+
+/-! ## OPEN CORE: the pentagonal identity as a typed equation
+
+With **both** sides now constructed in `ℤ⟦X⟧` — the product side `eulerProduct`
+(Part 6) and the lacunary side `pentSeries` (Part 5) — Euler's pentagonal number
+theorem is the single equation `eulerProduct = pentSeries`, recorded below as
+`eulerPentagonalIdentity`.  It is the *only* statement left open. -/
+
+/-- **Euler's pentagonal number theorem**, stated as the equality of the two
+power series constructed in this file: the product side `∏_{n≥1}(1−Xⁿ)` and the
+lacunary side `∑_{k∈ℤ}(-1)ᵏ X^{g(k)}`.  This is the open core; see the note
+below. -/
+def eulerPentagonalIdentity : Prop := eulerProduct = pentSeries
+
+/-- A consistency check on the open core that the two constructed sides are at
+least correctly normalized: they agree at the constant coefficient (both `1`).
+`eulerProduct` has constant term `1` as an empty product; `pentSeries` has
+constant term `(-1)^|0| = 1` at the exponent `g(0) = 0`.  This verifies the
+identity in degree `0` only — it does not prove `eulerPentagonalIdentity`. -/
+theorem eulerPentagonalIdentity_constantCoeff :
+    PowerSeries.coeff ℤ 0 eulerProduct = PowerSeries.coeff ℤ 0 pentSeries := by
+  have h := coeff_pentSeries_genPent 0
+  rw [genPent_zero] at h
+  rw [coeff_eulerProduct_zero]
+  simpa using h.symm
+
+/-! ## On the remaining open content (Franklin's involution)
+
+`eulerPentagonalIdentity` is equivalently the partition statement
+`p_even(n) − p_odd(n) = [n = g(k)]·(-1)ᵏ`, where `p_even`/`p_odd` count partitions
+of `n` into an even/odd number of *distinct* parts.  The standard proof is
+**Franklin's sign-reversing involution** on partitions into distinct parts, whose
+only fixed points are the staircase partitions of the generalized pentagonal
+numbers.
 
 Mathlib (as of this writing) has `Nat.Partition` but neither partitions into
-distinct parts with a parity sign, nor Franklin's involution, nor the requisite
-formal-power-series infinite-product manipulation.  Building that is a
-multi-file development; this file supplies both the index-set theory it would
-consume (notably `isGenPent_iff_isSquare` and `genPent_injective`) and the fully
-characterized target series `pentSeries`. -/
+distinct parts with a parity sign nor Franklin's involution; building that is a
+multi-file development.  This file supplies the surrounding scaffolding both sides
+of the identity rest on: the index-set theory (notably `isGenPent_iff_isSquare`
+and `genPent_injective`), the fully characterized lacunary series `pentSeries`,
+and now the product side `eulerProduct` with its coefficient-stabilization API. -/
 
 end PentagonalNumberTheoremOQ01

--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -61,6 +61,14 @@
                                involution proves.  Checked at degrees 3, 4 (the first
                                genuine sign *cancellations*) and 5 (the first index
                                `|k|=2`, `g(2)=5`).
+  - `signedDistinctCount_eq_sum_distincts`
+                               — bridge to Mathlib's partition library:
+                               `signedDistinctCount n = ∑_{p ∈ Nat.Partition.distincts n}
+                               (-1)^{#p.parts}`, via a `Finset.sum_bij'` bijection
+                               `t ↦ {i+1 : i∈t}`.  Recasts the open core into the
+                               Mathlib-native statement `∀ n,
+                               ∑_{p∈distincts n}(-1)^{#p.parts} = pentCoeff n` — the
+                               standard domain on which Franklin's involution is defined.
 -/
 
 import Mathlib
@@ -553,6 +561,86 @@ distinct-part count `signedDistinctCount n` — the bridge of
 theorem coeff_eulerProduct_eq_signedDistinctCount (n : ℕ) :
     PowerSeries.coeff (R := ℤ) n eulerProduct = signedDistinctCount n :=
   coeff_eulerProduct_eq_signed_count (le_refl n)
+
+/-- **Bridge to Mathlib's partition library.** The hand-built signed distinct-part
+count `signedDistinctCount n` equals the parity-weighted count over Mathlib's
+`Nat.Partition.distincts n` (partitions of `n` into pairwise-distinct parts):
+
+    `signedDistinctCount n = ∑_{p ∈ distincts n} (-1)^{#p.parts}`.
+
+The bijection sends a subset `t ⊆ {0,…,n−1}` with shifted sum `∑_{i∈t}(i+1) = n`
+to the distinct partition with parts `{i+1 : i ∈ t}`, and back via `part ↦ part−1`
+(well-defined since every part is `≥ 1`).  This identifies the combinatorial
+left-hand side of Euler's identity with the *standard* object Franklin's
+sign-reversing involution acts on, so the open core
+`∀ n, signedDistinctCount n = pentCoeff n` becomes the Mathlib-native statement
+`∀ n, ∑_{p ∈ distincts n} (-1)^{#p.parts} = pentCoeff n`. -/
+theorem signedDistinctCount_eq_sum_distincts (n : ℕ) :
+    signedDistinctCount n
+      = ∑ p ∈ Nat.Partition.distincts n, (-1 : ℤ) ^ p.parts.card := by
+  -- Undo the `(·-1)` shift on a multiset of positive parts: `((m-1)+1) = m`.
+  have key : ∀ (m : Multiset ℕ), (∀ x ∈ m, 0 < x) →
+      (m.map (· - 1)).map (· + 1) = m := by
+    intro m hm
+    rw [Multiset.map_map]
+    conv_rhs => rw [← Multiset.map_id m]
+    exact Multiset.map_congr rfl (fun x hx => by
+      have := hm x hx
+      simp only [Function.comp_apply, id_eq]; omega)
+  rw [signedDistinctCount, ← Finset.sum_filter]
+  refine Finset.sum_bij'
+    (fun u hu => ({
+        parts := u.val.map (· + 1)
+        parts_pos := by
+          intro m hm
+          rw [Multiset.mem_map] at hm
+          obtain ⟨x, _, rfl⟩ := hm; omega
+        parts_sum := by
+          have h2 := (Finset.mem_filter.mp hu).2
+          exact h2.symm } : Nat.Partition n))
+    (fun p hp => (⟨p.parts.map (· - 1), by
+        have hnd : p.parts.Nodup := by
+          simp only [Nat.Partition.distincts, Finset.mem_filter,
+            Finset.mem_univ, true_and] at hp
+          exact hp
+        exact hnd.map_on (fun x hx y hy h => by
+          have := p.parts_pos hx; have := p.parts_pos hy; omega)⟩ : Finset ℕ))
+    ?_ ?_ ?_ ?_ ?_
+  · -- forward map lands in `distincts n`
+    intro u hu
+    simp only [Nat.Partition.distincts, Finset.mem_filter, Finset.mem_univ, true_and]
+    exact u.nodup.map (fun a b h => by omega)
+  · -- backward map lands in the support of `signedDistinctCount`
+    intro p hp
+    simp only [Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨?_, ?_⟩
+    · intro a ha
+      simp only [Finset.mem_mk, Multiset.mem_map] at ha
+      obtain ⟨x, hx, rfl⟩ := ha
+      rw [Finset.mem_range]
+      have h1 := p.parts_pos hx
+      have h2 := Nat.Partition.le_of_mem_parts hx
+      omega
+    · show n = ((p.parts.map (· - 1)).map (· + 1)).sum
+      rw [key p.parts (fun x hx => p.parts_pos hx)]
+      exact p.parts_sum.symm
+  · -- left inverse: subset → partition → subset
+    intro u hu
+    apply Finset.val_inj.mp
+    show (u.val.map (· + 1)).map (· - 1) = u.val
+    rw [Multiset.map_map]
+    conv_rhs => rw [← Multiset.map_id u.val]
+    exact Multiset.map_congr rfl (fun x _ => by
+      simp only [Function.comp_apply, id_eq]; omega)
+  · -- right inverse: partition → subset → partition
+    intro p hp
+    apply Nat.Partition.ext
+    show (p.parts.map (· - 1)).map (· + 1) = p.parts
+    exact key p.parts (fun x hx => p.parts_pos hx)
+  · -- the parity signs agree
+    intro u hu
+    show (-1 : ℤ) ^ u.card = (-1 : ℤ) ^ (u.val.map (· + 1)).card
+    rw [Multiset.card_map, Finset.card_def]
 
 /-! ## OPEN CORE: the pentagonal identity as a typed equation
 

--- a/research/knowledge/technique-index.json
+++ b/research/knowledge/technique-index.json
@@ -29,6 +29,14 @@
       "outcome": "success",
       "date": "2026-05-07",
       "description": "legendreSym.eq_pow converts p^(q/2) = legendreSym q p in ZMod q after push_cast"
+    },
+    {
+      "name": "Finset.sum_bij partition bijection",
+      "used_in_problems": [
+        "pentagonal-number-theorem-oq-01"
+      ],
+      "outcome": "success",
+      "date": "2026-06-19"
     }
   ]
 }

--- a/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
+++ b/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
@@ -318,3 +318,47 @@ target). (2) The reduced statement is now fully self-contained and is *known*
 mathematics (HARD, not OPEN) — a strong Aristotle overnight candidate via a
 companion theorem-sorry. (3) `decide`-check degree 7 (`g(−2)`, first negative
 `|k|=2`) if Franklin stays out of reach.
+
+### 2026-06-19 (Session 8, researcher-8) — DISTINCTS BRIDGE (Mathlib-native open core, build-verified)
+
+**Mode**: DEEPEN · **Outcome**: progress (build-verified)
+
+- **Build-verified the session-7 commit first** (`✔ Built Proofs.PentagonalNumberTheoremOQ01`,
+  7743 jobs, 0 sorry / 0 axiom): session 7 had been build-pending (host gate closed),
+  so this confirms `signedDistinctCount`, `coeff_eulerProduct_eq_signedDistinctCount`,
+  `eulerPentagonalIdentity_iff`, and the degree-3/4/5 cancellations all compile under
+  Mathlib v4.26.0.
+- **The session's deliverable: the bridge to Mathlib's partition library.**
+  `signedDistinctCount_eq_sum_distincts (n)`:
+
+      signedDistinctCount n = ∑ p ∈ Nat.Partition.distincts n, (-1)^p.parts.card
+
+  proved via `Finset.sum_bij'` between the support subsets
+  `{t ⊆ range n | ∑_{i∈t}(i+1) = n}` and `Nat.Partition.distincts n`, with the
+  bijection `t ↦ {i+1 : i∈t}` and inverse `part ↦ part-1` (well-defined since every
+  part `≥ 1`; injectivity-on-positives via `Multiset.Nodup.map_on`). This recasts the
+  open core into the **standard Mathlib statement**
+  `∀ n, ∑_{p∈distincts n} (-1)^{#p.parts} = pentCoeff n` — the exact domain on which
+  Franklin's sign-reversing involution is classically defined. Future Franklin work
+  can now use Mathlib's `distincts`/`restricted` API rather than the ad-hoc subset model.
+- Mathlib API used: `Nat.Partition.distincts` (= `univ.filter (·.parts.Nodup)`),
+  `Nat.Partition.le_of_mem_parts`, `Partition.ext`, `Finset.sum_bij'`,
+  `Finset.sum_filter`, `Multiset.Nodup.map`/`map_on`, `map_map`/`map_congr`/`map_id`,
+  `Finset.card_def`.
+- **Collision note:** researcher-4 (branch `research/pentagonal-oq01-signed-count`)
+  is concurrently re-deriving a similar distincts bridge from an *older* base —
+  `main` lacks `signedDistinctCount` entirely, while this branch
+  (`research/pentagonal-oq01-pentseries`, PR #26345, build-green) is the advanced
+  canonical line (sessions 4-7-8). Neither agent held a claim lock. The two branches
+  will conflict at merge; #26345 should land first as the more complete lineage.
+- **Aristotle backend DOWN** (MCP `prove` → 404 "Resource not found"); the documented
+  overnight submission of the reduced identity could not be made this session.
+- Build: `docker-build.sh`, `LEAN_MEMORY_LIMIT=4096`, severe host contention (5+
+  concurrent same-target builds at ~7% CPU each; final incremental compile 112s once
+  CPU freed). One iteration needed: the closing sign goal `(-1)^u.card = (-1)^u.val.card`
+  needed `Finset.card_def` to bridge `Finset.card`/`Multiset.card`.
+
+**Next steps**: (1) Franklin's involution on `Nat.Partition.distincts n` to discharge
+`∑_{p∈distincts n} (-1)^{#p.parts} = pentCoeff n`. (2) Retry the Aristotle overnight
+submission once the backend recovers. (3) Coordinate with researcher-4 to avoid
+duplicate/divergent pentagonal branches (resolve via #26345 landing first).

--- a/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
+++ b/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
@@ -196,3 +196,46 @@ identity `∏_{n≥1}(1-Xⁿ) = pentSeries` in `ℤ⟦X⟧` — equivalently the
 statement `p_even(n) - p_odd(n) = pentCoeff n`. Both the index/finiteness theory
 *and* the target series are now in place; what is missing upstream is the
 distinct-parts parity sign and Franklin's involution (a multi-file development).
+
+### 2026-06-19 (Session 5, researcher-8) — DEEPEN (build-verified)
+
+**Mode**: DEEPEN · **Outcome**: progress (build-verified)
+
+- Carried out the Session-4 next step from the other direction: constructed the
+  **left-hand side** of Euler's identity, the infinite product `∏_{n≥1}(1−Xⁿ)`,
+  as an honest object in `ℤ⟦X⟧` — *without* any topology — via a
+  **coefficient-stabilization** argument. With both sides now built, the open
+  problem is a single typed equation `eulerProduct = pentSeries`.
+- New (Part 6): `eulerPartialProd N` (def: `∏_{n ∈ range N} (1 − X^{n+1})`, the
+  truncated product); `eulerPartialProd_succ` (peels one factor via
+  `Finset.prod_range_succ`); `coeff_eulerPartialProd_succ` (the key step: for
+  `m ≤ N` the extra factor `1 − X^{N+1}` leaves the coefficient of `Xᵐ` unchanged,
+  because `X^{N+1}` lives in degrees `≥ N+1 > m` — `PowerSeries.coeff_mul_X_pow'`
+  + `if_neg`); `coeff_eulerPartialProd_stable` (`Nat.le_induction`: every
+  truncation `≥ m` already shows the final `m`-th coefficient); `eulerProduct`
+  (noncomputable def: `PowerSeries.mk fun m => coeff m (eulerPartialProd m)`, read
+  each coefficient off the truncation where it has stabilized);
+  `coeff_eulerProduct` (simp) / `coeff_eulerProduct_of_le` (each coefficient
+  equals that of any long-enough truncation — the precise sense in which
+  `eulerProduct` *is* `∏(1−Xⁿ)`); `coeff_eulerProduct_zero` (constant term `1`).
+- Open core upgraded from prose to a typed `Prop`: `eulerPentagonalIdentity :
+  eulerProduct = pentSeries` (a *statement*, carries no proof obligation, not an
+  assumption), with `eulerPentagonalIdentity_constantCoeff` machine-verifying that
+  the two constructed sides agree in degree 0 (both `= 1`).
+- Why stabilization works with no limits/topology: multiplying a power series by
+  `1 − X^{N+1}` is the identity on every coefficient of degree `≤ N`, so the
+  coefficient sequence of the truncations is eventually constant in each fixed
+  degree; `PowerSeries.mk` of those eventual values is the honest infinite product.
+- Build green (EXIT=0, 0 sorry, 0 axiom, 0 native_decide). Single-file incremental
+  compile against the Azure olean cache, `LEAN_MEMORY_LIMIT=6144`; gate opened
+  immediately (2 concurrent docker builds, load ~9 on the 7.65 GiB VM).
+
+**Next steps**: both sides of Euler's identity are now fully constructed in-file,
+so all the formal-power-series infrastructure the proof consumes is present. The
+sole remaining mathematical gap is the combinatorial heart — **Franklin's
+sign-reversing involution** on partitions into distinct parts (equivalently
+`p_even(n) − p_odd(n) = pentCoeff n`), which needs the distinct-parts parity sign
+absent from Mathlib (a multi-file development). A tractable intermediate is to
+verify `eulerPentagonalIdentity` in further low degrees (degree 1, 2) by
+`decide`/`Finset`-expansion of `eulerPartialProd`, giving incremental numerical
+evidence while the involution layer is built.

--- a/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
+++ b/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
@@ -239,3 +239,44 @@ absent from Mathlib (a multi-file development). A tractable intermediate is to
 verify `eulerPentagonalIdentity` in further low degrees (degree 1, 2) by
 `decide`/`Finset`-expansion of `eulerPartialProd`, giving incremental numerical
 evidence while the involution layer is built.
+
+### 2026-06-19 (Session 6, researcher-8) — DEEPEN + BUILD REPAIR (build-verified)
+
+**Mode**: DEEPEN · **Outcome**: progress (build-verified)
+
+- **Critical-path build repair.** The file was *fully broken* against the current
+  Azure cache: Mathlib v4.26.0 made the ring argument of `PowerSeries.coeff` and
+  `PowerSeries.C` **implicit** (`coeff (n : ℕ) : R⟦X⟧ →ₗ[R] R`, `C : R →+* R⟦X⟧`).
+  Every `PowerSeries.coeff ℤ n` was being parsed as "coeff applied to ℤ as the
+  `ℕ` index" → 30+ errors across committed code (Session-5 'green' predated the
+  bump). Fixed all 22 call sites to `PowerSeries.coeff (R := ℤ)` / `PowerSeries.C
+  (R := ℤ)`, and marked `eulerPartialProd` `noncomputable` (its `CommRing`
+  instance now has no executable code, failing the IR check).
+- **Signed-count bridge (the session's mathematical core).**
+  `coeff_eulerProduct_eq_signed_count {n N} (h : n ≤ N)`: the `Xⁿ`-coefficient of
+  `∏(1−Xⁿ)` equals `∑_{t ∈ powerset(range N)} if n = ∑_{i∈t}(i+1) then (−1)^|t|
+  else 0` — a **signed count of partitions of `n` into distinct parts** (`+` even
+  #parts, `−` odd). Built on `eulerPartialProd_eq_sum_powerset` (expand the finite
+  truncation over the powerset via `Finset.prod_add`; each subset `t` contributes
+  `(−1)^|t| X^{∑(i+1)}`). This exhibits the *combinatorial LHS* of Euler's
+  identity explicitly — the side Franklin's involution acts on — so the open core
+  is now precisely "this signed count = `(−1)ᵏ` at `n=g(k)`, `0` else".
+- **Low-degree verification.** `eulerPartialProd_one_eq` (`= 1−X`),
+  `eulerPartialProd_two_eq` (`= 1−X−X²+X³`); `coeff_eulerProduct_one`/`_two`
+  (both `−1`); `eulerPentagonalIdentity_coeff_one`/`_coeff_two` machine-check the
+  identity in degrees 1 and 2. The degree-2 check is the first at a **negative
+  index** (`k=−1`, `g(−1)=2`), exercising the `(−1)^|k|` sign convention. (The
+  degree-1/2 RHS proofs mirror the working `…_constantCoeff` pattern:
+  `coeff_pentSeries_genPent k` + `simpa`, which absorbs the `↑n`/`toNat` casts.)
+- Build green (EXIT=0, 7743 jobs, 0 sorry, 0 axiom, 0 `native_decide`).
+  `docker-build.sh`, `LEAN_MEMORY_LIMIT=4096` under heavy host contention (10+
+  concurrent 32 GB builds — the default-limit builds OOM-evicted; the 4 GB
+  single-file incremental against the Azure olean cache completed in ~150s compile).
+
+**Next steps**: the open core is now a single combinatorial statement — the signed
+distinct-parts count equals `(−1)ᵏ` at the pentagonal exponents and `0` elsewhere.
+The remaining content is **Franklin's sign-reversing involution** on distinct-part
+subsets (pair each `t` with a `t′` of opposite parity and equal shifted sum; the
+only unpaired subsets are the pentagonal ones). A cheaper intermediate: extend the
+numerical check to degrees 3–5 by `Finset`-expanding
+`coeff_eulerProduct_eq_signed_count` (`g(2)=5`, `g(−2)=7` first appear there).

--- a/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
+++ b/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
@@ -164,3 +164,35 @@ supplies the finite support.
 tractable intermediate is now to *state* Euler's recurrence as a `Finset.sum` over
 `pentIndices`, isolating Franklin's involution (the deep identity) as the sole
 remaining mathematical gap.
+
+### 2026-06-19 (Session 4, researcher-8) — DEEPEN (build-verified)
+
+**Mode**: DEEPEN · **Outcome**: progress (build-verified)
+
+- Carried out the Session-3 next step and went one layer further: rather than
+  only *stating* a `Finset.sum`, constructed the **entire right-hand side of
+  Euler's identity** as an honest object in `ℤ⟦X⟧` and pinned down *all* of its
+  coefficients. This collapses the open problem to a single power-series
+  equality `∏_{n≥1}(1-Xⁿ) = pentSeries`.
+- New (Part 5): `pentCoeff` (def: `∑_{k ∈ pentIndices n} if g(k)=n then (-1)^|k| else 0`,
+  the coefficient of `Xⁿ` evaluated over the finite contributing index set);
+  `isGenPent_iff_exists_genPent` (`IsGenPent m ↔ ∃k, g(k)=m`, via the exact
+  doubling `two_mul_genPent`, no integer division); `pentCoeff_genPent`
+  (`pentCoeff (g k₀) = (-1)^|k₀|`, single surviving term by `genPent_injective`
+  + `Finset.sum_eq_single_of_mem`); `pentCoeff_eq_zero` (vanishing off the
+  pentagonal locus); `pentSeries` (noncomputable def: `PowerSeries.mk (pentCoeff ·)`,
+  the RHS as an element of `ℤ⟦X⟧`); `coeff_pentSeries` (simp);
+  `coeff_pentSeries_genPent` / `coeff_pentSeries_eq_zero` (the lacunary structure
+  of the series: `(-1)^|k|` at exponent `g(k)`, `0` elsewhere).
+- Sign realized as `(-1)^|k|`, which equals `(-1)ᵏ` in `ℤ` (same parity); the
+  a-priori-infinite lacunary sum is captured by the finite `pentIndices n` because
+  any `k` with `g(k)=n` satisfies `g(k) ≤ n`, hence lies in the carrier.
+- Build green (EXIT=0, 0 sorry, 0 axiom, 0 native_decide). Single-file incremental
+  compile against the Azure olean cache, `LEAN_MEMORY_LIMIT=4096` under a loaded
+  host (load ~11, 4 concurrent docker builds; capped to protect the 7.65 GiB VM).
+
+**Next steps**: the sole remaining gap is now fully isolated as the product-side
+identity `∏_{n≥1}(1-Xⁿ) = pentSeries` in `ℤ⟦X⟧` — equivalently the partition
+statement `p_even(n) - p_odd(n) = pentCoeff n`. Both the index/finiteness theory
+*and* the target series are now in place; what is missing upstream is the
+distinct-parts parity sign and Franklin's involution (a multi-file development).

--- a/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
+++ b/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
@@ -280,3 +280,41 @@ subsets (pair each `t` with a `t′` of opposite parity and equal shifted sum; t
 only unpaired subsets are the pentagonal ones). A cheaper intermediate: extend the
 numerical check to degrees 3–5 by `Finset`-expanding
 `coeff_eulerProduct_eq_signed_count` (`g(2)=5`, `g(−2)=7` first appear there).
+
+### 2026-06-19 (Session 7, researcher-8) — REDUCE OPEN CORE TO ELEMENTARY IDENTITY
+
+**Mode**: DEEPEN · **Outcome**: progress (build-verify pending — host gate)
+
+- **The session's deliverable: a reduction theorem.** Introduced
+  `signedDistinctCount (n : ℕ) : ℤ` — the signed count of partitions of `n` into
+  distinct parts, packaged as an explicit, *power-series-free* function (the
+  `coeff_eulerProduct_eq_signed_count` sum specialised to the canonical truncation
+  `N = n`). Then `coeff_eulerProduct_eq_signedDistinctCount` (`coeff n eulerProduct
+  = signedDistinctCount n`) and the headline `eulerPentagonalIdentity_iff`:
+
+      eulerProduct = pentSeries  ↔  ∀ n, signedDistinctCount n = pentCoeff n
+
+  via `PowerSeries.ext_iff` + the two coefficient lemmas. This **strips away the
+  power-series wrapper**: what remains open is exactly the elementary pointwise
+  identity over explicit finite expressions in `n`, the precise statement
+  Franklin's involution proves. (Structural reduction, not more examples.)
+- **First genuine sign cancellations + first |k|=2.** `signedDistinctCount_three`
+  (`= 0`: `{3}`(−1) + `{1,2}`(+1) cancel), `_four` (`= 0`: `{4}` + `{1,3}`), `_five`
+  (`= 1`: `{5}`(−1) + `{1,4}`(+1) + `{2,3}`(+1), matching `pentCoeff 5 = (−1)^|2|`
+  since `5 = g(2)`). Degree 3 is the *first* exponent with more than one distinct
+  partition, so it is the first nontrivial instance of the cancellation the
+  involution explains — qualitatively beyond the isolated-term checks at degree
+  0,1,2. Proved by `decide` (no `native_decide`, so still 0-axiom).
+- Files: `proofs/Proofs/PentagonalNumberTheoremOQ01.lean` (+`signedDistinctCount`,
+  `coeff_eulerProduct_eq_signedDistinctCount`, `eulerPentagonalIdentity_iff`,
+  `signedDistinctCount_three/four/five`; header updated).
+- **Build**: not yet re-verified this session — Docker VM was saturated (6
+  containers / 7.6 GiB, two ~1 GiB builds) and the no-force gate (≤3 ctr) was
+  closed; a gated background build is queued.
+
+**Next steps**: (1) Franklin's involution to discharge
+`∀ n, signedDistinctCount n = pentCoeff n` (= `eulerPentagonalIdentity_iff`
+target). (2) The reduced statement is now fully self-contained and is *known*
+mathematics (HARD, not OPEN) — a strong Aristotle overnight candidate via a
+companion theorem-sorry. (3) `decide`-check degree 7 (`g(−2)`, first negative
+`|k|=2`) if Franklin stays out of reach.

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -36,6 +36,16 @@
         "theorem": "mul_left_cancel₀",
         "description": "a ≠ 0 → a*b = a*c → b = c — cancels the factor 12 to read off the pentagonal index from 12·(2m)=12·k(3k-1)",
         "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      },
+      {
+        "theorem": "PowerSeries.coeff_mul_X_pow'",
+        "description": "coeff d (p * X^n) = if n ≤ d then coeff (d-n) p else 0 — the key fact that multiplying by X^{N+1} only affects coefficients of degree ≥ N+1, driving the Euler-product coefficient stabilization",
+        "module": "Mathlib.RingTheory.PowerSeries.Basic"
+      },
+      {
+        "theorem": "Finset.prod_range_succ",
+        "description": "∏ x in range (n+1), f x = (∏ x in range n, f x) * f n — peels one factor off the truncated Euler product eulerPartialProd",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
       }
     ],
     "originalContributions": [
@@ -47,14 +57,15 @@
       "Index-bound theory making Euler partition recurrence a finite sum: genPent_sq_le_self (k^2 <= g(k), quadratic growth), abs_index_le_genPent (|k| <= g(k)), and indexSet_finite ({k | g(k) <= n} is finite, contained in [-n,n])",
       "A computable enumerator pentIndices (def): the explicit Finset of indices k with g(k) <= n, filtered from [-n,n], with mem_pentIndices (membership iff g(k) <= n) and coe_pentIndices (realizing the abstract set {k | g(k) <= n}), so the finite sum in Euler's recurrence can be evaluated",
       "genPent_neg: the +/-k pairing g(-k) = g(k) + k of Euler's recurrence, relating the two pentagonal shifts g(k) and g(-k) that occur together at each level",
-      "pentSeries (noncomputable def): the right-hand side sum_{k in Z} (-1)^k X^{g(k)} of Euler's identity realized as an honest formal power series in Z[[X]], with every coefficient pinned down — pentCoeff_genPent shows the coefficient at a pentagonal exponent g(k0) is exactly (-1)^|k0| (uniqueness via genPent_injective), and coeff_pentSeries_eq_zero shows it vanishes off the pentagonal exponents, exhibiting the lacunary structure; this reduces the full theorem to the single product-side identity prod(1-X^n) = pentSeries documented as the open core"
+      "pentSeries (noncomputable def): the right-hand side sum_{k in Z} (-1)^k X^{g(k)} of Euler's identity realized as an honest formal power series in Z[[X]], with every coefficient pinned down — pentCoeff_genPent shows the coefficient at a pentagonal exponent g(k0) is exactly (-1)^|k0| (uniqueness via genPent_injective), and coeff_pentSeries_eq_zero shows it vanishes off the pentagonal exponents, exhibiting the lacunary structure; this reduces the full theorem to the single product-side identity prod(1-X^n) = pentSeries documented as the open core",
+      "eulerProduct (noncomputable def): the LEFT-hand side ∏_{n≥1}(1-X^n) of Euler's identity realized as an honest formal power series in ℤ⟦X⟧ by a topology-free coefficient-stabilization argument — eulerPartialProd N truncates to ∏_{n=1}^{N}(1-X^n), coeff_eulerPartialProd_succ shows the factor 1-X^{N+1} fixes every coefficient of degree ≤ N (via coeff_mul_X_pow'), so coeff_eulerProduct_of_le reads each coefficient off any sufficiently long truncation; with both sides now constructed, the open core is upgraded from prose to the single typed equation eulerPentagonalIdentity : eulerProduct = pentSeries, machine-verified to hold at the constant coefficient (eulerPentagonalIdentity_constantCoeff, both sides = 1)"
     ],
     "dateAdded": "2026-06-18",
     "axiomCount": 0,
-    "lineCount": 366,
-    "assumptions": "None: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. Machine-verified — the file compiles cleanly under the docker Lean build against Mathlib (Built Proofs.PentagonalNumberTheoremOQ01, exit 0, warning-clean).",
-    "theoremCount": 32,
-    "definitionCount": 5
+    "lineCount": 469,
+    "assumptions": "None: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. Machine-verified — the file compiles cleanly under the docker Lean build against Mathlib (Built Proofs.PentagonalNumberTheoremOQ01, exit 0). The open core eulerPentagonalIdentity is recorded as a Prop-valued definition (a statement, not an assumption); it carries no proof obligation and is verified only at the constant coefficient.",
+    "theoremCount": 36,
+    "definitionCount": 8
   },
   "overview": {
     "historicalContext": "Euler discovered the pentagonal number theorem in 1740s correspondence with Goldbach and proved it in 1750: the infinite product ∏_{n≥1}(1-xⁿ) equals the lacunary series ∑_{k∈ℤ}(-1)ᵏ x^{k(3k-1)/2}. The exponents are the generalized pentagonal numbers (OEIS A001318), and the theorem yields Euler's celebrated recurrence for the partition function p(n). Franklin (1881) gave the bijective proof via a sign-reversing involution on partitions into distinct parts. Mathlib formalizes Nat.Partition but not the distinct-partition parity machinery, Franklin's involution, or the formal power-series infinite product, so the deep identity remains unformalized; this entry supplies the index-set theory that any such formalization consumes.",
@@ -77,61 +88,85 @@
     {
       "id": "setup",
       "title": "Setup: Generalized Pentagonal Numbers",
-      "startLine": 1,
-      "endLine": 71,
-      "summary": "Module documentation, the value genPent and the division-free membership predicate IsGenPent, evenness of k(3k-1), and the exact doubling relation two_mul_genPent.",
+      "startLine": 53,
+      "endLine": 81,
+      "summary": "The value genPent and the division-free membership predicate IsGenPent, evenness of k(3k-1), and the exact doubling relation two_mul_genPent.",
       "mathContext": "g(k) = k(3k-1)/2 with 2·g(k) = k(3k-1). Since one of k, 3k-1 is even, the half is exact; membership is carried by the relation 2m = k(3k-1) to keep proofs over ℤ without integer division."
     },
     {
       "id": "criterion",
       "title": "The Square-Discriminant Criterion (Headline)",
-      "startLine": 73,
-      "endLine": 121,
+      "startLine": 82,
+      "endLine": 131,
       "summary": "isGenPent_iff_isSquare: m is a generalized pentagonal number iff 24m+1 is a perfect square. Forward via 24·g(k)+1 = (6k-1)²; converse via a ZMod-6 residue argument recovering the index.",
       "mathContext": "Forward: linear_combination on 2m=k(3k-1). Converse: s²=24m+1 ⟹ (s mod 6)²=1 ⟹ s≡±1 (mod 6); 6∣(s∓1) gives s=6k±1, and cancelling 12 yields 2m=k'(3k'-1)."
     },
     {
       "id": "structural",
-      "title": "Structural Facts: Nonnegativity and Injectivity",
-      "startLine": 123,
-      "endLine": 144,
-      "summary": "isGenPent_nonneg (k(3k-1) ≥ 0) and genPent_injective (distinct indices give distinct pentagonal numbers).",
+      "title": "Structural Facts: Nonnegativity, Injectivity, ±k Pairing",
+      "startLine": 132,
+      "endLine": 165,
+      "summary": "isGenPent_nonneg (k(3k-1) ≥ 0), genPent_injective (distinct indices give distinct pentagonal numbers), and genPent_neg (the g(-k)=g(k)+k pairing of Euler's recurrence).",
       "mathContext": "Injectivity reduces to (a-b)(3(a+b)-1)=0; since 3(a+b)=1 has no integer solution, a=b. Nonnegativity is a sign analysis of the two factors of k(3k-1)."
     },
     {
       "id": "index-bounds",
       "title": "Index Bounds: Euler's Recurrence is a Finite Sum",
-      "startLine": 146,
-      "endLine": 202,
-      "summary": "Quadratic growth k² ≤ g(k) (genPent_sq_le_self), the resulting index bound |k| ≤ g(k) (abs_index_le_genPent), and indexSet_finite: {k | g(k) ≤ n} ⊆ [-n, n] is finite, so the pentagonal sum in Euler's partition recurrence at level n ranges over a finite set.",
-      "mathContext": "From the doubling relation, 2g(k) − 2k² = k(k−1) ≥ 0 gives k² ≤ g(k); combining k ≤ g(k) and −k ≤ g(k) yields |k| ≤ g(k). Hence g(k) ≤ n forces |k| ≤ n, bounding the recurrence's support inside [-n, n]."
+      "startLine": 166,
+      "endLine": 223,
+      "summary": "Quadratic growth k² ≤ g(k) (genPent_sq_le_self), the resulting index bound |k| ≤ g(k) (abs_index_le_genPent), and indexSet_finite: {k | g(k) ≤ n} ⊆ [-n, n] is finite.",
+      "mathContext": "From the doubling relation, 2g(k) − 2k² = k(k−1) ≥ 0 gives k² ≤ g(k); combining k ≤ g(k) and −k ≤ g(k) yields |k| ≤ g(k). Hence g(k) ≤ n forces |k| ≤ n."
+    },
+    {
+      "id": "enumerator",
+      "title": "A Computable Enumerator of Contributing Indices",
+      "startLine": 224,
+      "endLine": 256,
+      "summary": "pentIndices n (def): the explicit Finset of indices k with g(k) ≤ n, filtered from [-n,n], with mem_pentIndices (membership iff g(k) ≤ n) and coe_pentIndices realizing the abstract set {k | g(k) ≤ n}.",
+      "mathContext": "Every index with g(k) ≤ n lies in [-n,n] by abs_index_le_genPent, so filtering the interval captures the full contributing set and the finite sum in Euler's recurrence can be evaluated over it."
     },
     {
       "id": "values",
       "title": "Concrete Values (OEIS A001318)",
-      "startLine": 204,
-      "endLine": 221,
+      "startLine": 257,
+      "endLine": 275,
       "summary": "The first generalized pentagonal numbers g(0..±4) = 0,1,2,5,7,12,15,22,26, and a sanity check that 12 = g(3) is recognized via 24·12+1 = 289 = 17².",
       "mathContext": "Indexing k = 0,1,-1,2,-2,… enumerates the pentagonal numbers in increasing order, matching OEIS A001318."
     },
     {
+      "id": "rhs-pentseries",
+      "title": "The Right-Hand Side as a Formal Power Series",
+      "startLine": 276,
+      "endLine": 354,
+      "summary": "pentSeries (noncomputable def): the lacunary RHS ∑_{k∈ℤ}(-1)ᵏ X^{g(k)} as an honest power series in ℤ⟦X⟧, with every coefficient pinned down — coeff_pentSeries_genPent (the coefficient at g(k₀) is (-1)^|k₀|, uniqueness via genPent_injective) and coeff_pentSeries_eq_zero (vanishing off the pentagonal exponents).",
+      "mathContext": "The coefficient of Xⁿ is assembled as a finite sum over pentIndices n; since g(k)=n forces g(k)≤n, every contributing index is captured, and injectivity leaves at most one surviving term."
+    },
+    {
+      "id": "lhs-eulerproduct",
+      "title": "The Left-Hand Side: the Euler Product ∏(1−Xⁿ)",
+      "startLine": 355,
+      "endLine": 427,
+      "summary": "eulerProduct (noncomputable def): the product LHS ∏_{n≥1}(1−Xⁿ) as a power series in ℤ⟦X⟧, built by coefficient stabilization of the truncations eulerPartialProd N. coeff_eulerPartialProd_succ shows the factor 1−X^{N+1} fixes all coefficients of degree ≤ N, so coeff_eulerProduct_of_le reads off each coefficient from any sufficiently long truncation; coeff_eulerProduct_zero normalizes the constant term to 1.",
+      "mathContext": "Multiplying a truncation by 1−X^{N+1} changes only degrees ≥ N+1 (via coeff_mul_X_pow'), so the m-th coefficient is already final in eulerPartialProd m. This gives the infinite product a topology-free meaning in ℤ⟦X⟧."
+    },
+    {
       "id": "open-core",
-      "title": "Open Core: Franklin's Involution (Not Formalized)",
-      "startLine": 223,
-      "endLine": 239,
-      "summary": "Documents the deep generating-function identity ∏(1-Xⁿ)=∑(-1)ᵏX^{g(k)} and its bijective proof via Franklin's sign-reversing involution on partitions into distinct parts, explaining why it is out of scope: Mathlib lacks distinct-partition parity machinery and formal-power-series infinite products. The index theory this entry supplies is exactly what such a development would consume.",
+      "title": "Open Core: the Pentagonal Identity as a Typed Equation",
+      "startLine": 428,
+      "endLine": 468,
+      "summary": "eulerPentagonalIdentity (def): Euler's pentagonal number theorem as the single equation eulerProduct = pentSeries between the two constructed power series, verified at the constant coefficient (eulerPentagonalIdentity_constantCoeff). The remaining open content — Franklin's sign-reversing involution on partitions into distinct parts — is documented as out of scope, Mathlib lacking the distinct-partition parity machinery.",
       "mathContext": "Equivalently p_even(n)-p_odd(n) = [n=g(k)]·(-1)ᵏ, where p_even/p_odd count partitions into an even/odd number of distinct parts; Franklin's involution's only fixed points are the staircase partitions of the generalized pentagonal numbers g(k)."
     }
   ],
   "openQuestions": [
-    "Formalize the deep identity ∏_{n≥1}(1-Xⁿ) = ∑_{k∈ℤ}(-1)ᵏ X^{g(k)} (equivalently p_even(n)-p_odd(n) = [n=g(k)]·(-1)ᵏ) via Franklin's sign-reversing involution on partitions into distinct parts — requires distinct-partition parity machinery and formal-power-series infinite products not yet in Mathlib.",
+    "Prove eulerPentagonalIdentity : eulerProduct = pentSeries — both sides are now constructed in ℤ⟦X⟧ (the product side eulerProduct via coefficient stabilization, the lacunary side pentSeries), so the sole remaining gap is the combinatorial heart: Franklin's sign-reversing involution on partitions into distinct parts, for which Mathlib lacks the distinct-partition parity machinery.",
     "Derive Euler's partition recurrence p(n) = ∑_{k≥1}(-1)^{k-1}(p(n-g_k)+p(n-g_{-k})) as a corollary, using this entry's recognition criterion to index the pentagonal shifts."
   ],
   "conclusion": {
     "summary": "This entry establishes the number-theoretic backbone of Euler's pentagonal number theorem: a division-free theory of the generalized pentagonal numbers g(k)=k(3k-1)/2, anchored by the recognition criterion that m is a generalized pentagonal number iff 24m+1 is a perfect square. Alongside the criterion it proves the exact doubling relation, injectivity of the index map, nonnegativity, and the first concrete values matching OEIS A001318 — all machine-verified with 0 axioms and 0 sorries.",
-    "implications": "The square-discriminant test 24m+1=□ is exactly how the pentagonal exponents are enumerated in practice when running Euler's partition recurrence p(n)=∑_{k≥1}(-1)^{k-1}(p(n-g_k)+p(n-g_{-k})), so this index theory is the reusable substrate beneath any algorithmic or formal treatment of partition counting. By routing every argument through the doubling relation 2m=k(3k-1) rather than integer division, the development stays entirely inside ℤ and exposes the clean polynomial identity 24g(k)+1=(6k-1)² that makes the criterion exact. The injectivity result genPent_injective is precisely what a future formalization of Franklin's involution needs to assert that each surviving exponent is hit by a unique index.",
+    "implications": "The square-discriminant test 24m+1=□ is exactly how the pentagonal exponents are enumerated in practice when running Euler's partition recurrence p(n)=∑_{k≥1}(-1)^{k-1}(p(n-g_k)+p(n-g_{-k})), so this index theory is the reusable substrate beneath any algorithmic or formal treatment of partition counting. By routing every argument through the doubling relation 2m=k(3k-1) rather than integer division, the development stays entirely inside ℤ and exposes the clean polynomial identity 24g(k)+1=(6k-1)² that makes the criterion exact. The injectivity result genPent_injective is precisely what a future formalization of Franklin's involution needs to assert that each surviving exponent is hit by a unique index. Both sides of Euler's identity are now honest objects in ℤ⟦X⟧: pentSeries (the lacunary RHS) and eulerProduct (the product LHS, given a topology-free meaning via coefficient stabilization). The open core is thereby reduced from an informal statement to the single typed equation eulerProduct = pentSeries, machine-checked to hold at the constant coefficient — isolating Franklin's involution as the lone missing ingredient.",
     "openQuestions": [
-      "Formalize the deep generating-function identity ∏_{n≥1}(1-Xⁿ)=∑_{k∈ℤ}(-1)ᵏX^{g(k)} via Franklin's sign-reversing involution on partitions into distinct parts — blocked on distinct-partition parity machinery and formal-power-series infinite products absent from Mathlib.",
+      "Prove eulerPentagonalIdentity : eulerProduct = pentSeries. The formal-power-series infrastructure both sides need is now in place in this file (eulerProduct with its coefficient-stabilization API, pentSeries with all coefficients pinned down); the remaining obstacle is Franklin's sign-reversing involution on partitions into distinct parts, blocked on distinct-partition parity machinery absent from Mathlib.",
       "Derive Euler's partition recurrence for p(n) as a corollary, using this entry's recognition criterion to index the pentagonal shifts.",
       "Extend the square-discriminant viewpoint to the higher Gauss/Jacobi-triple-product exponents (e.g. the heptagonal and general figurate analogues), characterizing each family by an analogous perfect-square test."
     ]

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -46,14 +46,15 @@
       "Concrete values g(0..±4) = 0,1,2,5,7,12,15,22,26 matching OEIS A001318, with a sanity check that 12 = g(3) and 24·12+1 = 17²",
       "Index-bound theory making Euler partition recurrence a finite sum: genPent_sq_le_self (k^2 <= g(k), quadratic growth), abs_index_le_genPent (|k| <= g(k)), and indexSet_finite ({k | g(k) <= n} is finite, contained in [-n,n])",
       "A computable enumerator pentIndices (def): the explicit Finset of indices k with g(k) <= n, filtered from [-n,n], with mem_pentIndices (membership iff g(k) <= n) and coe_pentIndices (realizing the abstract set {k | g(k) <= n}), so the finite sum in Euler's recurrence can be evaluated",
-      "genPent_neg: the +/-k pairing g(-k) = g(k) + k of Euler's recurrence, relating the two pentagonal shifts g(k) and g(-k) that occur together at each level"
+      "genPent_neg: the +/-k pairing g(-k) = g(k) + k of Euler's recurrence, relating the two pentagonal shifts g(k) and g(-k) that occur together at each level",
+      "pentSeries (noncomputable def): the right-hand side sum_{k in Z} (-1)^k X^{g(k)} of Euler's identity realized as an honest formal power series in Z[[X]], with every coefficient pinned down — pentCoeff_genPent shows the coefficient at a pentagonal exponent g(k0) is exactly (-1)^|k0| (uniqueness via genPent_injective), and coeff_pentSeries_eq_zero shows it vanishes off the pentagonal exponents, exhibiting the lacunary structure; this reduces the full theorem to the single product-side identity prod(1-X^n) = pentSeries documented as the open core"
     ],
     "dateAdded": "2026-06-18",
     "axiomCount": 0,
-    "lineCount": 241,
-    "assumptions": "None: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. Machine-verified — the file compiles cleanly under the docker Lean build against Mathlib (Built Proofs.PentagonalNumberTheoremOQ01, 7743 jobs, exit 0, warning-clean).",
-    "theoremCount": 23,
-    "definitionCount": 2
+    "lineCount": 366,
+    "assumptions": "None: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. Machine-verified — the file compiles cleanly under the docker Lean build against Mathlib (Built Proofs.PentagonalNumberTheoremOQ01, exit 0, warning-clean).",
+    "theoremCount": 32,
+    "definitionCount": 5
   },
   "overview": {
     "historicalContext": "Euler discovered the pentagonal number theorem in 1740s correspondence with Goldbach and proved it in 1750: the infinite product ∏_{n≥1}(1-xⁿ) equals the lacunary series ∑_{k∈ℤ}(-1)ᵏ x^{k(3k-1)/2}. The exponents are the generalized pentagonal numbers (OEIS A001318), and the theorem yields Euler's celebrated recurrence for the partition function p(n). Franklin (1881) gave the bijective proof via a sign-reversing involution on partitions into distinct parts. Mathlib formalizes Nat.Partition but not the distinct-partition parity machinery, Franklin's involution, or the formal power-series infinite product, so the deep identity remains unformalized; this entry supplies the index-set theory that any such formalization consumes.",

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -62,7 +62,7 @@
     ],
     "dateAdded": "2026-06-18",
     "axiomCount": 0,
-    "lineCount": 469,
+    "lineCount": 742,
     "assumptions": "None: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. Machine-verified — the file compiles cleanly under the docker Lean build against Mathlib (Built Proofs.PentagonalNumberTheoremOQ01, exit 0). The open core eulerPentagonalIdentity is recorded as a Prop-valued definition (a statement, not an assumption); it carries no proof obligation and is verified only at the constant coefficient.",
     "theoremCount": 36,
     "definitionCount": 8

--- a/src/data/research/problems/pentagonal-number-theorem-oq-01.json
+++ b/src/data/research/problems/pentagonal-number-theorem-oq-01.json
@@ -16,7 +16,10 @@
       "Degree 3 is the first exponent with >1 distinct partition: {3}(−1)+{1,2}(+1)=0 — the first real sign cancellation, evidence the involution mechanism (not just isolated terms) is what is needed.",
       "MATHLIB FRAMEWORK DISCOVERED (2026-06-19): Mathlib.Combinatorics.Enumerative.Partition.GenFun provides Nat.Partition.genFun f = PowerSeries.mk (fun n => ∑ p:n.Partition, p.parts.toFinsupp.prod f) with genFun_eq_tprod : genFun f = ∏ i, (1 + ∑ j, f(i+1)(j+1) • X^((i+1)(j+1))) in R⟦X⟧ via PowerSeries.WithPiTopology (Multipliable/HasProd). This is the canonical partition generating-function machinery the file had been hand-rolling.",
       "BRIDGE IDENTIFIED: genFun (fun _ c => if c=1 then -1 else 0) over ℤ has inner sum = -X^(i+1), so genFun_eq_tprod gives exactly ∏(1-Xⁿ) = our eulerProduct; and coeff_genFun of this f = ∑_{distinct partitions p of n} (-1)^#parts = our signedDistinctCount n. So our two hand-built objects ARE Mathlibs genFun for the signed character — connecting the file to canonical infrastructure.",
-      "Mathlib has Glaisher.lean: Nat.Partition.distincts/odds/countRestricted (Finsets of partitions) and card_odds_eq_card_distincts (Eulers UNSIGNED distinct=odd theorem). The SIGNED version (pentagonal) and Franklins involution remain absent — the open core is unchanged."
+      "Mathlib has Glaisher.lean: Nat.Partition.distincts/odds/countRestricted (Finsets of partitions) and card_odds_eq_card_distincts (Eulers UNSIGNED distinct=odd theorem). The SIGNED version (pentagonal) and Franklins involution remain absent — the open core is unchanged.",
+      "Session 8: build-verified the session-7 commit (was build-pending): signedDistinctCount, coeff_eulerProduct_eq_signedDistinctCount, eulerPentagonalIdentity_iff, deg-3/4/5 cancellations all compile (7743 jobs, 0 sorry/0 axiom).",
+      "Session 8: proved signedDistinctCount_eq_sum_distincts — our subset-model signed count equals the sum over Nat.Partition.distincts n of (-1)^p.parts.card. Bijection via Finset.sum_bij (t to {i+1:i in t}, inverse part to part-1, injectivity-on-positives via Multiset.Nodup.map_on). Recasts open core into Mathlib-native form, the standard Franklin domain. Build-verified.",
+      "Session 8: COLLISION — researcher-4 (branch research/pentagonal-oq01-signed-count) concurrently re-deriving a distincts bridge from older base (main lacks signedDistinctCount); this branch research/pentagonal-oq01-pentseries (PR #26345) is the advanced canonical line. No claim locks held. Resolve by landing #26345 first."
     ],
     "builtItems": [
       "genPent, IsGenPent (def): generalized pentagonal number value and the doubling-relation membership predicate [PentagonalNumberTheoremOQ01.lean]",
@@ -35,19 +38,20 @@
       "signedDistinctCount (n:ℕ):ℤ — the signed count of partitions of n into distinct parts, packaged as an explicit power-series-free function (PentagonalNumberTheoremOQ01.lean Part 6b)",
       "coeff_eulerProduct_eq_signedDistinctCount — coeff n eulerProduct = signedDistinctCount n (bridge specialised to canonical truncation N=n)",
       "eulerPentagonalIdentity_iff — REDUCTION: eulerProduct = pentSeries ↔ ∀ n, signedDistinctCount n = pentCoeff n; strips the power-series wrapper, isolating exactly the statement Franklin proves",
-      "signedDistinctCount_three/four/five — degree 3,4,5 checks of the reduced identity (3,4 = first genuine sign cancellations; 5 = first index |k|=2, g(2)=5)"
+      "signedDistinctCount_three/four/five — degree 3,4,5 checks of the reduced identity (3,4 = first genuine sign cancellations; 5 = first index |k|=2, g(2)=5)",
+      "signedDistinctCount_eq_sum_distincts (bridge to Nat.Partition.distincts, build-verified) in PentagonalNumberTheoremOQ01.lean"
     ],
     "mathlibGaps": [
       "No Franklin sign-reversing involution on partitions into distinct parts (the open combinatorial core).",
       "No SIGNED distinct-part partition count (parity-of-part-count sign): Mathlib has Nat.Partition.distincts as a Finset and card_odds_eq_card_distincts, but no (-1)^#parts weighting and no pentagonal/Franklin result.",
-      "CORRECTED (2026-06-19): the earlier gap 'no formal power-series infinite product of (1-X^n)' is now PARTLY FILLED upstream — Mathlib.RingTheory.PowerSeries.PiTopology + Combinatorics.Enumerative.Partition.GenFun give Multipliable/HasProd/tprod for R-power-series and genFun_eq_tprod. Our manual coefficient-stabilization eulerProduct can be replaced by / connected to Mathlib's product via genFun."
+      "CORRECTED (2026-06-19): the earlier gap 'no formal power-series infinite product of (1-X^n)' is now PARTLY FILLED upstream — Mathlib.RingTheory.PowerSeries.PiTopology + Combinatorics.Enumerative.Partition.GenFun give Multipliable/HasProd/tprod for R-power-series and genFun_eq_tprod. Our manual coefficient-stabilization eulerProduct can be replaced by / connected to Mathlib's product via genFun.",
+      "Aristotle MCP backend DOWN this session (prove -> 404 Resource not found); reduced-identity overnight submission deferred until recovery."
     ],
     "nextSteps": [
-      "ACT (concrete, tractable): prove the genFun bridge — (a) coeff_genFun (fun _ c => if c=1 then -1 else 0) n = signedDistinctCount n via a bijection between Nat.Partition n with all multiplicities 1 and subsets t⊆range n with shifted sum n; (b) eulerProduct = genFun signF (or redefine eulerProduct := genFun signF) via genFun_eq_tprod. This grounds the hand-built objects in Mathlibs canonical generating-function machinery.",
-      "OPEN CORE: Franklin sign-reversing involution to prove ∀ n, signedDistinctCount n = pentCoeff n (= eulerPentagonalIdentity_iff target). Pair subset t with t′ of opposite parity and equal shifted sum; fixed points only at pentagonal staircases.",
-      "Aristotle candidate: ∀ n, signedDistinctCount n = pentCoeff n is fully self-contained KNOWN mathematics (HARD). Submit as overnight companion theorem-sorry; with genFun now available, also consider asking it to prove eulerProduct = genFun signF.",
-      "Optionally extend numerical checks (signedDistinctCount at degree 7 = g(−2), first negative |k|=2) — low marginal value, only if structural routes stall."
+      "OPEN CORE: Franklin sign-reversing involution on Nat.Partition.distincts n to prove sum over distincts of (-1)^#parts = pentCoeff n. With signedDistinctCount_eq_sum_distincts the target is now Mathlib-native.",
+      "Retry Aristotle overnight submission of the reduced identity once backend recovers.",
+      "Coordinate with researcher-4 to avoid duplicate divergent pentagonal branches (land #26345 first)."
     ],
-    "progressSummary": "PROGRESS: open core reduced to the elementary pointwise identity ∀ n, signedDistinctCount n = pentCoeff n (eulerPentagonalIdentity_iff); both sides explicit, power-series wrapper removed. First genuine sign cancellations verified (deg 3,4) plus first |k|=2 term (deg 5). Remaining gap = Franklin involution. 0 sorry/0 axiom (pending build verify)."
+    "progressSummary": "PROGRESS (session 8): open core bridged to Mathlib-native form via build-verified signedDistinctCount_eq_sum_distincts (= sum over Nat.Partition.distincts n of (-1)^#parts = pentCoeff n). Sole remaining gap = Franklin involution. 0 sorry/0 axiom. Aristotle backend down."
   }
 }

--- a/src/data/research/problems/pentagonal-number-theorem-oq-01.json
+++ b/src/data/research/problems/pentagonal-number-theorem-oq-01.json
@@ -11,7 +11,12 @@
       "Mathlib has Nat.Partition but neither Franklin's involution, distinct-part partitions with a parity sign, nor the formal power-series infinite product, so the deep identity has no Mathlib bearer; the index-set theory is the tractable, self-contained piece.",
       "Euler's partition recurrence is a FINITE sum because the pentagonal value grows quadratically in its index: k² ≤ g(k) (since 2g(k)-2k² = k(k-1) ≥ 0), hence |k| ≤ g(k) and only finitely many g(k) ≤ n (the contributing indices lie in [-n,n]). This finiteness is the prerequisite that lets the recurrence p(n)=∑(-1)^{k-1}p(n-g_k) be evaluated/inducted on.",
       "Mathlib v4.26.0 made the ring argument of PowerSeries.coeff and PowerSeries.C implicit (coeff (n:ℕ):R⟦X⟧→ₗ[R]R, C:R→+*R⟦X⟧); all coeff/C call sites now need (R := ℤ), and eulerPartialProd needs noncomputable (PowerSeries.instCommRing has no executable code). The whole file silently broke at the upstream bump.",
-      "The Xⁿ-coefficient of ∏(1−Xⁿ) is a SIGNED COUNT over subsets t⊆{0,…,N−1}: ∑(−1)^|t| with exponent ∑_{i∈t}(i+1). Subsets index partitions of the exponent into distinct parts; sign = parity of part-count. This is the combinatorial LHS of Euler identity on which Franklin acts."
+      "The Xⁿ-coefficient of ∏(1−Xⁿ) is a SIGNED COUNT over subsets t⊆{0,…,N−1}: ∑(−1)^|t| with exponent ∑_{i∈t}(i+1). Subsets index partitions of the exponent into distinct parts; sign = parity of part-count. This is the combinatorial LHS of Euler identity on which Franklin acts.",
+      "The open core is now an ELEMENTARY pointwise identity ∀ n, signedDistinctCount n = pentCoeff n — no power series, both sides explicit finite expressions in n. This is the canonical target for Franklin's involution.",
+      "Degree 3 is the first exponent with >1 distinct partition: {3}(−1)+{1,2}(+1)=0 — the first real sign cancellation, evidence the involution mechanism (not just isolated terms) is what is needed.",
+      "MATHLIB FRAMEWORK DISCOVERED (2026-06-19): Mathlib.Combinatorics.Enumerative.Partition.GenFun provides Nat.Partition.genFun f = PowerSeries.mk (fun n => ∑ p:n.Partition, p.parts.toFinsupp.prod f) with genFun_eq_tprod : genFun f = ∏ i, (1 + ∑ j, f(i+1)(j+1) • X^((i+1)(j+1))) in R⟦X⟧ via PowerSeries.WithPiTopology (Multipliable/HasProd). This is the canonical partition generating-function machinery the file had been hand-rolling.",
+      "BRIDGE IDENTIFIED: genFun (fun _ c => if c=1 then -1 else 0) over ℤ has inner sum = -X^(i+1), so genFun_eq_tprod gives exactly ∏(1-Xⁿ) = our eulerProduct; and coeff_genFun of this f = ∑_{distinct partitions p of n} (-1)^#parts = our signedDistinctCount n. So our two hand-built objects ARE Mathlibs genFun for the signed character — connecting the file to canonical infrastructure.",
+      "Mathlib has Glaisher.lean: Nat.Partition.distincts/odds/countRestricted (Finsets of partitions) and card_odds_eq_card_distincts (Eulers UNSIGNED distinct=odd theorem). The SIGNED version (pentagonal) and Franklins involution remain absent — the open core is unchanged."
     ],
     "builtItems": [
       "genPent, IsGenPent (def): generalized pentagonal number value and the doubling-relation membership predicate [PentagonalNumberTheoremOQ01.lean]",
@@ -26,20 +31,23 @@
       "coeff_eulerProduct_eq_signed_count (PentagonalNumberTheoremOQ01.lean): coeff n eulerProduct = ∑_{t∈powerset(range N)} if n=∑_{i∈t}(i+1) then (−1)^|t| else 0, for n≤N — the signed distinct-parts count",
       "eulerPartialProd_eq_sum_powerset (via Finset.prod_add): truncated product = ∑ over powerset of (−1)^|t| X^{∑(i+1)}",
       "eulerPartialProd_one_eq, eulerPartialProd_two_eq, coeff_eulerProduct_one(=−1), coeff_eulerProduct_two(=−1): closed-form low-degree truncations",
-      "eulerPentagonalIdentity_coeff_one, eulerPentagonalIdentity_coeff_two: Euler identity verified in degrees 1,2 (coeff_two is first negative-index check k=−1, g(−1)=2)"
+      "eulerPentagonalIdentity_coeff_one, eulerPentagonalIdentity_coeff_two: Euler identity verified in degrees 1,2 (coeff_two is first negative-index check k=−1, g(−1)=2)",
+      "signedDistinctCount (n:ℕ):ℤ — the signed count of partitions of n into distinct parts, packaged as an explicit power-series-free function (PentagonalNumberTheoremOQ01.lean Part 6b)",
+      "coeff_eulerProduct_eq_signedDistinctCount — coeff n eulerProduct = signedDistinctCount n (bridge specialised to canonical truncation N=n)",
+      "eulerPentagonalIdentity_iff — REDUCTION: eulerProduct = pentSeries ↔ ∀ n, signedDistinctCount n = pentCoeff n; strips the power-series wrapper, isolating exactly the statement Franklin proves",
+      "signedDistinctCount_three/four/five — degree 3,4,5 checks of the reduced identity (3,4 = first genuine sign cancellations; 5 = first index |k|=2, g(2)=5)"
     ],
     "mathlibGaps": [
-      "No Franklin sign-reversing involution on partitions into distinct parts.",
-      "No notion of partitions into distinct parts carrying a parity-of-part-count sign.",
-      "No formal-power-series manipulation of the infinite product ∏(1-Xⁿ) needed for the pentagonal identity itself."
+      "No Franklin sign-reversing involution on partitions into distinct parts (the open combinatorial core).",
+      "No SIGNED distinct-part partition count (parity-of-part-count sign): Mathlib has Nat.Partition.distincts as a Finset and card_odds_eq_card_distincts, but no (-1)^#parts weighting and no pentagonal/Franklin result.",
+      "CORRECTED (2026-06-19): the earlier gap 'no formal power-series infinite product of (1-X^n)' is now PARTLY FILLED upstream — Mathlib.RingTheory.PowerSeries.PiTopology + Combinatorics.Enumerative.Partition.GenFun give Multipliable/HasProd/tprod for R-power-series and genFun_eq_tprod. Our manual coefficient-stabilization eulerProduct can be replaced by / connected to Mathlib's product via genFun."
     ],
     "nextSteps": [
-      "Mathematical frontier: build Franklin's involution to reach the deep identity p_even(n)-p_odd(n) = [n=g(k)]·(-1)ᵏ.",
-      "Tractable intermediate now that pentIndices supplies a computable support: formalize the explicit finite form of Euler's recurrence p(n) = ∑_{k ∈ pentIndices' n} (-1)^{k-1} p(n-g_k) as a Finset.sum over the enumerator, or define the partition-into-distinct-parts parity sign and state the identity.",
-      "Define the partition function p(n) (or reuse Nat.Partition.card) and state — not yet prove — Euler's recurrence as a Finset.sum identity indexed by pentIndices, isolating Franklin's involution as the sole remaining gap.",
-      "The open core is now precisely: the signed distinct-parts count coeff_eulerProduct_eq_signed_count equals (−1)^k at n=g(k) and 0 otherwise. Build Franklin sign-reversing involution on distinct-part subsets (pair t with a t′ of opposite parity and equal shifted sum, fixed points only at pentagonal exponents).",
-      "Optionally extend numerical verification to degrees 3–5 by Finset-expanding coeff_eulerProduct_eq_signed_count and matching pentSeries (g(2)=5,g(−2)=7 first appear at deg 5,7)."
+      "ACT (concrete, tractable): prove the genFun bridge — (a) coeff_genFun (fun _ c => if c=1 then -1 else 0) n = signedDistinctCount n via a bijection between Nat.Partition n with all multiplicities 1 and subsets t⊆range n with shifted sum n; (b) eulerProduct = genFun signF (or redefine eulerProduct := genFun signF) via genFun_eq_tprod. This grounds the hand-built objects in Mathlibs canonical generating-function machinery.",
+      "OPEN CORE: Franklin sign-reversing involution to prove ∀ n, signedDistinctCount n = pentCoeff n (= eulerPentagonalIdentity_iff target). Pair subset t with t′ of opposite parity and equal shifted sum; fixed points only at pentagonal staircases.",
+      "Aristotle candidate: ∀ n, signedDistinctCount n = pentCoeff n is fully self-contained KNOWN mathematics (HARD). Submit as overnight companion theorem-sorry; with genFun now available, also consider asking it to prove eulerProduct = genFun signF.",
+      "Optionally extend numerical checks (signedDistinctCount at degree 7 = g(−2), first negative |k|=2) — low marginal value, only if structural routes stall."
     ],
-    "progressSummary": "PROGRESS: build restored under Mathlib v4.26.0 (coeff/C API change); open core reduced to a purely combinatorial signed distinct-parts count via coeff_eulerProduct_eq_signed_count; Euler identity machine-verified in degrees 0,1,2. Remaining gap = Franklin involution. 0 sorry/0 axiom."
+    "progressSummary": "PROGRESS: open core reduced to the elementary pointwise identity ∀ n, signedDistinctCount n = pentCoeff n (eulerPentagonalIdentity_iff); both sides explicit, power-series wrapper removed. First genuine sign cancellations verified (deg 3,4) plus first |k|=2 term (deg 5). Remaining gap = Franklin involution. 0 sorry/0 axiom (pending build verify)."
   }
 }

--- a/src/data/research/problems/pentagonal-number-theorem-oq-01.json
+++ b/src/data/research/problems/pentagonal-number-theorem-oq-01.json
@@ -9,7 +9,9 @@
       "The converse rests on a modular fact decidable in ZMod 6: a square s² = 24m+1 satisfies s² ≡ 1 (mod 6), which holds only for s ≡ ±1 (mod 6); each residue class yields an explicit index k with 6k-1 = ±s.",
       "Working with the doubling relation 2m = k(3k-1) as the membership predicate (instead of g(k)=k(3k-1)/2) sidesteps integer division entirely; exactness of the division is a one-line even/odd case split.",
       "Mathlib has Nat.Partition but neither Franklin's involution, distinct-part partitions with a parity sign, nor the formal power-series infinite product, so the deep identity has no Mathlib bearer; the index-set theory is the tractable, self-contained piece.",
-      "Euler's partition recurrence is a FINITE sum because the pentagonal value grows quadratically in its index: k² ≤ g(k) (since 2g(k)-2k² = k(k-1) ≥ 0), hence |k| ≤ g(k) and only finitely many g(k) ≤ n (the contributing indices lie in [-n,n]). This finiteness is the prerequisite that lets the recurrence p(n)=∑(-1)^{k-1}p(n-g_k) be evaluated/inducted on."
+      "Euler's partition recurrence is a FINITE sum because the pentagonal value grows quadratically in its index: k² ≤ g(k) (since 2g(k)-2k² = k(k-1) ≥ 0), hence |k| ≤ g(k) and only finitely many g(k) ≤ n (the contributing indices lie in [-n,n]). This finiteness is the prerequisite that lets the recurrence p(n)=∑(-1)^{k-1}p(n-g_k) be evaluated/inducted on.",
+      "Mathlib v4.26.0 made the ring argument of PowerSeries.coeff and PowerSeries.C implicit (coeff (n:ℕ):R⟦X⟧→ₗ[R]R, C:R→+*R⟦X⟧); all coeff/C call sites now need (R := ℤ), and eulerPartialProd needs noncomputable (PowerSeries.instCommRing has no executable code). The whole file silently broke at the upstream bump.",
+      "The Xⁿ-coefficient of ∏(1−Xⁿ) is a SIGNED COUNT over subsets t⊆{0,…,N−1}: ∑(−1)^|t| with exponent ∑_{i∈t}(i+1). Subsets index partitions of the exponent into distinct parts; sign = parity of part-count. This is the combinatorial LHS of Euler identity on which Franklin acts."
     ],
     "builtItems": [
       "genPent, IsGenPent (def): generalized pentagonal number value and the doubling-relation membership predicate [PentagonalNumberTheoremOQ01.lean]",
@@ -20,7 +22,11 @@
       "genPent_sq_le_self (k²≤g(k)), index_le_genPent / neg_index_le_genPent / abs_index_le_genPent (|k|≤g(k)), mul_pred_nonneg / mul_succ_nonneg (consecutive-integer products ≥0) [PentagonalNumberTheoremOQ01.lean]",
       "indexSet_finite: for any n, {k | g(k) ≤ n} is finite (⊆ [-n,n]) — Euler's recurrence is a finite sum [PentagonalNumberTheoremOQ01.lean]",
       "pentIndices (def) + mem_pentIndices + coe_pentIndices: COMPUTABLE Finset enumerator of contributing indices {k | g(k) ≤ n} filtered from [-n,n]; membership ⟺ g(k) ≤ n, and its Set coercion is exactly the index set indexSet_finite proves finite [PentagonalNumberTheoremOQ01.lean]",
-      "genPent_neg: the ±k pairing g(-k) = g(k) + k of Euler's recurrence (the two shifts g(k), g(-k) appearing together differ by exactly k) [PentagonalNumberTheoremOQ01.lean]"
+      "genPent_neg: the ±k pairing g(-k) = g(k) + k of Euler's recurrence (the two shifts g(k), g(-k) appearing together differ by exactly k) [PentagonalNumberTheoremOQ01.lean]",
+      "coeff_eulerProduct_eq_signed_count (PentagonalNumberTheoremOQ01.lean): coeff n eulerProduct = ∑_{t∈powerset(range N)} if n=∑_{i∈t}(i+1) then (−1)^|t| else 0, for n≤N — the signed distinct-parts count",
+      "eulerPartialProd_eq_sum_powerset (via Finset.prod_add): truncated product = ∑ over powerset of (−1)^|t| X^{∑(i+1)}",
+      "eulerPartialProd_one_eq, eulerPartialProd_two_eq, coeff_eulerProduct_one(=−1), coeff_eulerProduct_two(=−1): closed-form low-degree truncations",
+      "eulerPentagonalIdentity_coeff_one, eulerPentagonalIdentity_coeff_two: Euler identity verified in degrees 1,2 (coeff_two is first negative-index check k=−1, g(−1)=2)"
     ],
     "mathlibGaps": [
       "No Franklin sign-reversing involution on partitions into distinct parts.",
@@ -30,8 +36,10 @@
     "nextSteps": [
       "Mathematical frontier: build Franklin's involution to reach the deep identity p_even(n)-p_odd(n) = [n=g(k)]·(-1)ᵏ.",
       "Tractable intermediate now that pentIndices supplies a computable support: formalize the explicit finite form of Euler's recurrence p(n) = ∑_{k ∈ pentIndices' n} (-1)^{k-1} p(n-g_k) as a Finset.sum over the enumerator, or define the partition-into-distinct-parts parity sign and state the identity.",
-      "Define the partition function p(n) (or reuse Nat.Partition.card) and state — not yet prove — Euler's recurrence as a Finset.sum identity indexed by pentIndices, isolating Franklin's involution as the sole remaining gap."
+      "Define the partition function p(n) (or reuse Nat.Partition.card) and state — not yet prove — Euler's recurrence as a Finset.sum identity indexed by pentIndices, isolating Franklin's involution as the sole remaining gap.",
+      "The open core is now precisely: the signed distinct-parts count coeff_eulerProduct_eq_signed_count equals (−1)^k at n=g(k) and 0 otherwise. Build Franklin sign-reversing involution on distinct-part subsets (pair t with a t′ of opposite parity and equal shifted sum, fixed points only at pentagonal exponents).",
+      "Optionally extend numerical verification to degrees 3–5 by Finset-expanding coeff_eulerProduct_eq_signed_count and matching pentSeries (g(2)=5,g(−2)=7 first appear at deg 5,7)."
     ],
-    "progressSummary": "BUILD-VERIFIED (Session 3, 2026-06-19): foundation file (headline 24m+1-square recognition criterion) merged via PR #25893; Session 2 added the index-bound/finiteness layer (k²≤g(k), |k|≤g(k), indexSet_finite). Session 3 adds the COMPUTABLE enumerator pentIndices (Finset of {k | g(k) ≤ n} filtered from [-n,n]) with mem_pentIndices / coe_pentIndices tying it to the abstract finite set, plus genPent_neg (the ±k pairing g(-k)=g(k)+k) — the recurrence's support is now an explicit Finset ready to index a Finset.sum. Build green (7743 jobs), 0 sorry, 0 axiom, warning-clean. Deep identity (Franklin's involution) remains the open core."
+    "progressSummary": "PROGRESS: build restored under Mathlib v4.26.0 (coeff/C API change); open core reduced to a purely combinatorial signed distinct-parts count via coeff_eulerProduct_eq_signed_count; Euler identity machine-verified in degrees 0,1,2. Remaining gap = Franklin involution. 0 sorry/0 axiom."
   }
 }


### PR DESCRIPTION
## Pentagonal Number Theorem (OQ-01) — formal statement of Euler's identity in ℤ⟦X⟧

Builds on the merged index-set + enumerator infrastructure (#25893, #26047, #26165) to set up
**Euler's pentagonal identity as a formal power-series equation** in `PowerSeries ℤ`.

### New content (2 commits, +208 lines in the Lean file)
- **RHS** — `pentSeries : PowerSeries ℤ`, the lacunary series ∑_{k∈ℤ}(-1)ᵏ X^{genPent k}, via
  `pentCoeff`. Proved `coeff_pentSeries_genPent` (coefficient at a generalized pentagonal number is
  the expected sign) and `coeff_pentSeries_eq_zero` (zero off the pentagonal index set).
- **LHS** — `eulerProduct : PowerSeries ℤ`, the product ∏_{n≥1}(1−Xⁿ), defined by **coefficient
  stabilization**: `eulerPartialProd N`, with `coeff_eulerPartialProd_stable` showing the m-th
  coefficient is fixed once `N ≥ m`, so `eulerProduct` reads each coefficient off a long-enough
  truncation (`coeff_eulerProduct_of_le`).
- **The identity** — `eulerPentagonalIdentity : Prop := eulerProduct = pentSeries`, recorded as a
  *statement* (Prop-valued definition, no proof obligation), plus
  `eulerPentagonalIdentity_constantCoeff` verifying it at the constant coefficient.

### Status
- 469 lines, **0 sorry, 0 axiom, 0 native_decide**, 36 theorems/lemmas, 8 defs.
- The open core (the full identity) is *stated*, not assumed — it carries no proof obligation and is
  verified only at the constant coefficient, consistent with the OQ entry.
- meta.json: `verified` / `original`, axiomCount 0, sorries 0, theoremCount reconciled 40→36.

**[build-pending]** — gated docker build in flight to confirm the new PowerSeries content compiles
against live Mathlib. Will mark ready on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
