### PR TITLE
Enrich motivic-flag-maps-oq-02: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/motivic-flag-maps-oq-02/annotations.json
+++ b/src/data/proofs/motivic-flag-maps-oq-02/annotations.json
@@ -14,6 +14,11 @@
       "Bryan et al. 2025",
       "based maps"
     ],
+    "prerequisites": [
+      "the Grothendieck ring of varieties K\u2080(Var)",
+      "the Lefschetz motive \ud835\udd43 = [\ud835\udd38\u00b9]",
+      "partial flag varieties and based maps"
+    ],
     "content": "Addresses OQ-02: does the Bryan et al. motivic class formula extend beyond complete flags to partial flag varieties? The answer: yes, the q-analog infrastructure extends, and the Gaussian binomial identity [Gr(d,n)] \u00b7 [d]! \u00b7 [n-d]! = [n]! serves as the bridge. The extension conjecture states the map-space class involves Levi subgroups and unipotent radicals, generalizing GL_n to block-diagonal subgroups.",
     "proofId": "motivic-flag-maps-oq-02",
     "range": {
@@ -35,6 +40,11 @@
       "Borel subgroup",
       "triangular numbers",
       "CommRing abstraction"
+    ],
+    "prerequisites": [
+      "K\u2080(Var) as a commutative ring",
+      "Schubert cell decompositions and the Bruhat order",
+      "the Lefschetz motive and triangular-number exponents"
     ],
     "content": "The K0Var structure is an abstraction over any commutative ring, not tied to a specific K\u2080(Var). This enables the duality proof strategy: work in Polynomial \u2124 (an integral domain for cancellation), then transfer to any K via ring homomorphism. The GLnClass formula encodes the Schubert cell decomposition of GL_n/B: the cells are indexed by permutations with area equal to their inversion count.",
     "proofId": "motivic-flag-maps-oq-02",
@@ -58,6 +68,11 @@
       "geometric sum",
       "fibration"
     ],
+    "prerequisites": [
+      "the motivic class of projective space [P\u207f\u207b\u00b9]",
+      "the q-number [n]_\ud835\udd43 = 1+\ud835\udd43+\u22ef+\ud835\udd43\u207f\u207b\u00b9",
+      "fibrations and multiplicativity of motivic classes"
+    ],
     "content": "The identity qFactorial = completeFlagClass is the first major theorem: the q-factorial product is not just an algebraic coincidence but has geometric content \u2014 it equals the motivic class of the complete flag variety Fl_n. The proof is a one-liner (congr 1; ext; exact (qNumber_succ_eq_projective).symm), showing that the two definitions match term-by-term. This is the motivic lift of n! = |GL_n(\ud835\udd3d_q)| / q^{n(n-1)/2}.",
     "proofId": "motivic-flag-maps-oq-02",
     "range": {
@@ -79,6 +94,11 @@
       "Schubert cell stratification",
       "Young diagrams",
       "L-weighting"
+    ],
+    "prerequisites": [
+      "the q-Pascal recurrence",
+      "Gaussian binomial coefficients",
+      "Schubert cell stratification of the Grassmannian"
     ],
     "content": "The coefficient 2 on L\u00b2 in [Gr(2,4)] reflects the two Schubert cells of dimension 2 in the 2\u00d72 box: the partitions (2,0) and (1,1). Each partition \u03bb contributes L^|\u03bb| to the Grassmannian class. The q-Pascal recurrence mirrors the Schubert cell decomposition: Gr(d+1, n+1) is the union of an A^{d+1}-bundle over Gr(d+1, n) and a copy of Gr(d, n), matching the structure constants in Schubert calculus.",
     "proofId": "motivic-flag-maps-oq-02",
@@ -102,6 +122,11 @@
       "geom_sum_split",
       "ring manipulations"
     ],
+    "prerequisites": [
+      "the flag-variety fibration Fl \u2192 Gr",
+      "induction on n",
+      "ring manipulations of geometric sums"
+    ],
     "content": "The motivic lifting of C(n,d) \u00b7 d! \u00b7 (n-d)! = n!. Geometrically: the complete flag variety Fl_n fibers over the Grassmannian Gr(d,n) with fiber Fl_d \u00d7 Fl_{n-d}. The q-analog encodes this fibration in K\u2080(Var). The proof requires the q-number splitting identity geom_sum_split (\u2211_{i<a}q^i + q^a\u00b7\u2211_{i<b}q^i = \u2211_{i<a+b}q^i), which is proved by induction on b.",
     "proofId": "motivic-flag-maps-oq-02",
     "range": {
@@ -123,6 +148,11 @@
       "eval\u2082RingHom",
       "ring homomorphism transfer",
       "symmetric Gaussian binomials"
+    ],
+    "prerequisites": [
+      "cancellation in an integral domain (\u2124[\ud835\udd43])",
+      "the symmetry of Gaussian binomials [d,n]=[n\u2212d,n]",
+      "ring-homomorphism transfer (eval\u2082)"
     ],
     "content": "The duality proof cannot be done in a general CommRing (no cancellation). The strategy \u2014 lift to Polynomial \u2124, cancel there, transfer back \u2014 is a template for motivic identities requiring integral domain properties. The private polyK\u2080 structure (Polynomial \u2124 with X as L) and evalAtL ring homomorphism provide the transfer mechanism. This is the motivic analog of the combinatorial identity C(n,d) = C(n,n-d).",
     "proofId": "motivic-flag-maps-oq-02",
@@ -146,6 +176,11 @@
       "iterated fibration",
       "tower of varieties"
     ],
+    "prerequisites": [
+      "the Grassmannian motivic class",
+      "iterated fibrations (towers of Grassmannian fibers)",
+      "factorization of the partial-flag class"
+    ],
     "content": "The partial flag class is defined recursively via List pattern matching with `termination_by l => l.length`. The formula [Fl(d\u2081,...,d\u2096; n)] = \u220f Gr factors mirrors the tower of fibrations: at each level, forget the innermost subspace to get a Grassmannian fiber. This is the geometric content of the motivic factorization. The complete flag is Fl(1,2,...,n-1; n), and complete_flag_is_partial_flag shows this gives [n]!.",
     "proofId": "motivic-flag-maps-oq-02",
     "range": {
@@ -167,6 +202,11 @@
       "unipotent radical",
       "based maps",
       "Bryan et al. extension"
+    ],
+    "prerequisites": [
+      "parabolic subgroups and their Levi decomposition",
+      "the unipotent radical",
+      "based maps and the Bryan et al. extension conjecture"
     ],
     "content": "The extension conjecture is the open part of this file (marked as axiom). For complete flags, the Levi is GL_n and dim U = 0 (Borel = parabolic for complete flags), recovering Bryan et al. For a Grassmannian Fl(d; n+1) = Gr(d, n+1), the Levi is GL_d \u00d7 GL_{n+1-d} and dim U = d(n+1-d). The conjecture says the space of maps [S\u00b2, Gr(d,n+1)]_\u03b2 has motivic class [GL_d \u00d7 GL_{n+1-d} \u00d7 A^{a''}], geometrically counting maps by Levi \u00d7 affine structure.",
     "proofId": "motivic-flag-maps-oq-02",


### PR DESCRIPTION
Adds `prerequisites` arrays to all 8 annotations of the motivic-classes-of-maps-to-partial-flag-varieties entry. Each gains 3 foundational prerequisite concepts.

Purely additive — no existing content modified (encoding preserved). JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)