### PR TITLE
Enrich erdos-432: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-432/annotations.json
+++ b/src/data/proofs/erdos-432/annotations.json
@@ -225,7 +225,11 @@
       "Selberg sieve",
       "probabilistic method"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "additive combinatorics",
+      "multiplicative number theory",
+      "sumsets"
+    ]
   },
   {
     "id": "erdos-432-formal-structure",


### PR DESCRIPTION
Per-annotation enrichment pass for `erdos-432`. Populates empty `prerequisites` arrays with 2-3 foundational background concepts per annotation. Single-file, additive (prereq-only) diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)