### PR TITLE
Enrich prime-reciprocal-divergence-oq-03: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/prime-reciprocal-divergence-oq-03/annotations.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-03/annotations.json
@@ -16,6 +16,11 @@
       "counting-arguments",
       "prime-factorization"
     ],
+    "prerequisites": [
+      "prime factorization of integers",
+      "smooth (small-prime) vs rough (large-prime) numbers",
+      "counting arguments over [1,n]"
+    ],
     "proofId": "prime-reciprocal-divergence-oq-03",
     "content": "Smooth and Rough Numbers: The Counting Dichotomy. Smooth numbers (also called N-smooth or B-smooth) are central to factoring algorithms (e.g., the quadratic sieve, elliptic curve factorization). A number is B-smooth if all its prime factors are ≤ B. The count of B-smooth numbers up to n is denoted Ψ(n, B). Erdős's argument uses the cruder bound Ψ(n, N) ≤ √n · 2^π(N), which suffices for the combinatorial contradiction."
   },
@@ -35,6 +40,11 @@
       "noncomputable",
       "classical-choice",
       "square-root-bound"
+    ],
+    "prerequisites": [
+      "squarefree integers",
+      "the decomposition k = b²·a with a squarefree",
+      "the bound b ≤ √k"
     ],
     "proofId": "prime-reciprocal-divergence-oq-03",
     "content": "Squarefree Decomposition: k = b² · a via Nat.sq_mul_squarefree_of_pos. The squarefree decomposition is the basis of the factorization k = b² · a. For an N-smooth k, the squarefree part a has all prime factors ≤ N, so a ⊆ 2^{primesUpTo N} (it's a 0-1 combination of these primes). Meanwhile b ≤ √k ≤ √n. This is the key: k is determined by (b, a), and there are at most √n · 2^π(N) pairs."
@@ -56,6 +66,11 @@
       "factorization-support",
       "lean-finsupp"
     ],
+    "prerequisites": [
+      "squarefree numbers and their prime support",
+      "factorization as a finitely-supported function",
+      "a squarefree number = product of its distinct primes"
+    ],
     "proofId": "prime-reciprocal-divergence-oq-03",
     "content": "Squarefree Numbers Are Determined by Their Prime Support. In the ring ℤ, a squarefree number's factorization is its characteristic function on primes: p → 0 or 1. Two squarefree numbers are equal iff they have the same prime support. This is a discrete analogue of a set being determined by its indicator function. In Lean, the proof factors through Finsupp (factorization as ℕ →₀ ℕ), using ext to reduce to pointwise equality."
   },
@@ -75,6 +90,11 @@
       "finset-cardinality",
       "squarefree-decomposition",
       "combinatorial-counting"
+    ],
+    "prerequisites": [
+      "the squarefree decomposition k = b²·a",
+      "injections and finite-set cardinality",
+      "counting via a product set √n × 2^{primes}"
     ],
     "proofId": "prime-reciprocal-divergence-oq-03",
     "content": "The Counting Injection: smoothSet ↪ range(√n) × powerset(primesUpTo N). The map k ↦ (√part, squarefree-prime-subset) is the formal realization of Erdős's bijection argument. The key insight is that the squarefree part a of an N-smooth number is a product of distinct primes ≤ N — i.e., a subset of primesUpTo N. Since squarefree numbers are determined by their prime support (squarefree_eq_of_prime_dvd_iff), the subset uniquely determines a. The injection is proved via Finset.card_le_card_of_injOn."
@@ -96,6 +116,11 @@
       "floor-division",
       "inclusion-exclusion"
     ],
+    "prerequisites": [
+      "divisibility and multiples of p in [1,n]",
+      "floor division ⌊n/p⌋",
+      "counting multiples of a number"
+    ],
     "proofId": "prime-reciprocal-divergence-oq-03",
     "content": "Multiples Count Bijection: |{p,2p,...} ∩ [1,n]| = ⌊n/p⌋. The bound |{rough numbers in [1,n]}| ≤ Σ_{p>N, prime} ⌊n/p⌋ follows by inclusion-exclusion (lower bound by union). Under the assumption Σ_{p>N} 1/p < 1/2, the sum ≤ n/2. Combined with smooth ≤ √n · 2^π(N), the two counts show that for large n, smooth + rough < n — contradicting the fact that [1,n] has n elements."
   },
@@ -116,6 +141,11 @@
       "smooth-number-bound",
       "erdos-proof"
     ],
+    "prerequisites": [
+      "the assumption Σ1/p converges (for contradiction)",
+      "the smooth-number counting bound",
+      "proof by contradiction"
+    ],
     "proofId": "prime-reciprocal-divergence-oq-03",
     "content": "Erdős's Main Contradiction: n = (2^{K+1})² + 1 Forces Smooth Count > n. The choice n = (2^{K+1})² + 1 is the Lean-friendly witness: it's just barely above (2^{K+1})², ensuring Nat.sqrt n ≤ 2^{K+1}. The arithmetic is handled by ring + omega after establishing the key inequality 2^{2K+1} < n. This is the combinatorial core of Erdős's 1938 proof — the analytic sum Σ1/p = ∞ is derived from this infinitely-many-primes step by the analytic argument in the parent proof."
   },
@@ -135,6 +165,11 @@
       "analytic-number-theory",
       "sieve-theory",
       "mathlib-analysis"
+    ],
+    "prerequisites": [
+      "Erdős's elementary counting proof",
+      "analytic number theory / Mertens' estimates",
+      "sieve methods"
     ],
     "proofId": "prime-reciprocal-divergence-oq-03",
     "content": "Proof Comparison: Mathlib Analytic Path vs Erdős Elementary Path. Erdős's 1938 paper 'Über die Reihe Σ1/p' gave this elementary proof as an alternative to Euler's 1737 analytic proof. The combinatorial smooth number approach has since become a template for elementary proofs in analytic number theory. The squarefree decomposition k = b²a is also the basis of Legendre's formula for π(x) and sieve theory. This Lean file isolates the combinatorial content, making it available as a building block independent of Mathlib's analysis library."


### PR DESCRIPTION
Adds `prerequisites` arrays to all 7 annotations of Erdős's elementary prime-reciprocal-divergence entry. Each gains 3 foundational prerequisite concepts.

Purely additive — no existing content modified. JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)