### PR TITLE
Enrich triangle-inequality: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/triangle-inequality/annotations.json
+++ b/src/data/proofs/triangle-inequality/annotations.json
@@ -14,6 +14,11 @@
     "relatedConcepts": [
       "abs_add",
       "metric axioms"
+    ],
+    "prerequisites": [
+      "the absolute value |x| on \u211d",
+      "case analysis on signs",
+      "the inequality |a+b| \u2264 |a|+|b|"
     ]
   },
   {
@@ -31,6 +36,11 @@
     "relatedConcepts": [
       "Lipschitz continuity",
       "abs_abs_sub_abs_le_abs_sub"
+    ],
+    "prerequisites": [
+      "the triangle inequality",
+      "absolute value and its properties",
+      "the bound ||a|\u2212|b|| \u2264 |a\u2212b|"
     ]
   },
   {
@@ -48,6 +58,11 @@
     "relatedConcepts": [
       "SeminormedAddCommGroup",
       "norm_add_le"
+    ],
+    "prerequisites": [
+      "normed / seminormed groups",
+      "the norm \u2016\u00b7\u2016 and its axioms",
+      "the subadditivity \u2016a+b\u2016 \u2264 \u2016a\u2016+\u2016b\u2016"
     ]
   },
   {
@@ -65,6 +80,11 @@
     "relatedConcepts": [
       "PseudoMetricSpace",
       "dist_triangle"
+    ],
+    "prerequisites": [
+      "metric spaces and the distance function",
+      "the metric-space axioms",
+      "dist(x,z) \u2264 dist(x,y)+dist(y,z)"
     ]
   },
   {
@@ -82,6 +102,11 @@
     "relatedConcepts": [
       "path length",
       "iterated inequality"
+    ],
+    "prerequisites": [
+      "the basic triangle inequality",
+      "iterating an inequality along a path",
+      "path length as a sum of distances"
     ]
   },
   {
@@ -99,6 +124,11 @@
     "relatedConcepts": [
       "collinearity",
       "degenerate triangle"
+    ],
+    "prerequisites": [
+      "the (non-strict) triangle inequality",
+      "collinearity / degenerate configurations",
+      "when equality holds vs strict inequality"
     ]
   },
   {
@@ -115,6 +145,11 @@
     "significance": "key",
     "relatedConcepts": [
       "Lipschitz continuity",
+      "uniform continuity"
+    ],
+    "prerequisites": [
+      "the reverse triangle inequality",
+      "Lipschitz continuity (constant 1)",
       "uniform continuity"
     ]
   },
@@ -133,6 +168,11 @@
     "relatedConcepts": [
       "functional analysis",
       "continuous functions"
+    ],
+    "prerequisites": [
+      "normed vector spaces",
+      "the reverse triangle inequality for norms",
+      "Lipschitz / continuous maps"
     ]
   },
   {
@@ -150,6 +190,11 @@
     "relatedConcepts": [
       "series convergence",
       "error bounds"
+    ],
+    "prerequisites": [
+      "finite sums over a Finset",
+      "induction on the number of summands",
+      "the generalized triangle inequality \u2016\u03a3a\u1d62\u2016 \u2264 \u03a3\u2016a\u1d62\u2016"
     ]
   }
 ]


### PR DESCRIPTION
Adds `prerequisites` arrays to all 9 annotations of the triangle-inequality entry. Each gains 3 foundational prerequisite concepts.

Purely additive — no existing content modified (encoding preserved). JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)