### PR TITLE
Enrich erdos-410: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-410/annotations.json
+++ b/src/data/proofs/erdos-410/annotations.json
@@ -186,7 +186,10 @@
       "computation",
       "examples"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "evaluating σ at small integers",
+      "step-by-step iteration"
+    ]
   },
   {
     "id": "ann-410-mult",
@@ -225,6 +228,9 @@
       "open-problem",
       "difficulty"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "open vs. solved problems",
+      "known asymptotic results"
+    ]
   }
 ]


### PR DESCRIPTION
Per-annotation enrichment pass for `erdos-410`. Populates empty `prerequisites` arrays with 2-3 foundational background concepts per annotation. Single-file, additive (prereq-only) diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)