### PR TITLE
Enrich erdos-443: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-443/annotations.json
+++ b/src/data/proofs/erdos-443/annotations.json
@@ -58,7 +58,11 @@
       "Turán's theorem",
       "AM-GM inequality: $k(m-k) \\le (m/2)^2$"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Quadratic functions and their maxima (downward parabola)",
+      "Floor function and integer rounding",
+      "Symmetry of products under reflection"
+    ]
   },
   {
     "id": "ann-e443-diophantine",
@@ -119,7 +123,11 @@
       "native_decide in Lean 4",
       "Finset.inter_self"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Evaluating $k(m-k)$ for small integers",
+      "Disjoint sets and empty intersection",
+      "Decidable equality on finite sets"
+    ]
   },
   {
     "id": "ann-e443-quadratic",


### PR DESCRIPTION
Per-annotation enrichment pass for `erdos-443`. Populates empty `prerequisites` arrays with 2-3 foundational background concepts per annotation. Single-file, additive (prereq-only) diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)