### PR TITLE
Enrich erdos-450: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-450/annotations.json
+++ b/src/data/proofs/erdos-450/annotations.json
@@ -16,7 +16,11 @@
       "divisibility",
       "natural number arithmetic"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Lean 4 type universes and namespaces",
+      "Mathlib import structure",
+      "decidable predicates over Finset"
+    ]
   },
   {
     "id": "ann-450-divisor",


### PR DESCRIPTION
Per-annotation enrichment pass for `erdos-450`. Populates empty `prerequisites` arrays with 2-3 foundational background concepts per annotation. Single-file, additive (prereq-only) diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)