### PR TITLE
Enrich erdos-461: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-461/annotations.json
+++ b/src/data/proofs/erdos-461/annotations.json
@@ -16,7 +16,11 @@
       "Dickman function",
       "Hildebrand-Tenenbaum estimates"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "smooth numbers and the smooth-counting function",
+      "Dickman's rho function and Hildebrand-Tenenbaum estimates",
+      "asymptotic growth notation"
+    ]
   },
   {
     "id": "ann-461-smooth-component",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays in `erdos-461/annotations.json` with concise, content-grounded prerequisite phrases (2-3 per annotation). Data-only change; JSON validated.