### PR TITLE
Enrich erdos-462: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-462/annotations.json
+++ b/src/data/proofs/erdos-462/annotations.json
@@ -42,7 +42,11 @@
       "Finset.Icc",
       "Real.log"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "the Lean 4 module and import system",
+      "the Mathlib library structure",
+      "Nat.minFac and Finset.Icc API"
+    ]
   },
   {
     "id": "erdos-462-lpf",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays in `erdos-462/annotations.json` with concise, content-grounded prerequisite phrases (2-3 per annotation). Data-only change; JSON validated.