### PR TITLE
Enrich erdos-328: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-328/annotations.json
+++ b/src/data/proofs/erdos-328/annotations.json
@@ -42,7 +42,11 @@
       "Set",
       "BigOperators"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Lean namespaces",
+      "Mathlib Finset and Set types",
+      "BigOperators summation notation"
+    ]
   },
   {
     "id": "ann-328-repr-func",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays in `erdos-328/annotations.json` with concise, content-grounded prerequisite phrases (2-3 per annotation). Data-only change; JSON validated.