### PR TITLE
Enrich erdos-331: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-331/annotations.json
+++ b/src/data/proofs/erdos-331/annotations.json
@@ -17,7 +17,11 @@
       "binary representation",
       "Filter.Tendsto"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Lean module headers and import statements",
+      "Mathlib namespaces (Nat, Real, Finset, Filter)",
+      "binary-digit representation of natural numbers"
+    ]
   },
   {
     "id": "ann-331-counting",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays in `erdos-331/annotations.json` with concise, content-grounded prerequisite phrases (2-3 per annotation). Data-only change; JSON validated.