### PR TITLE
Enrich erdos-337: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-337/annotations.json
+++ b/src/data/proofs/erdos-337/annotations.json
@@ -39,7 +39,11 @@
       "Finset",
       "Set"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Lean import and open commands",
+      "Mathlib Finset and Set types",
+      "BigOperators summation notation"
+    ]
   },
   {
     "id": "ann-337-counting",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays in `erdos-337/annotations.json` with concise, content-grounded prerequisite phrases (2-3 per annotation). Data-only change; JSON validated.