### PR TITLE
Enrich erdos-344: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-344/annotations.json
+++ b/src/data/proofs/erdos-344/annotations.json
@@ -84,7 +84,11 @@
       "arithmetic-progressions",
       "periodicity"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "infinite arithmetic progressions of the form a + k·d",
+      "indexing terms by the natural numbers k",
+      "positive common difference d giving constant gaps"
+    ]
   },
   {
     "id": "ann-e344-subcomplete",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays in `erdos-344/annotations.json` with concise, content-grounded prerequisite phrases (2-3 per annotation). Data-only change; JSON validated.