### PR TITLE
Enrich erdos-355: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-355/annotations.json
+++ b/src/data/proofs/erdos-355/annotations.json
@@ -17,7 +17,11 @@
       "egyptian-fractions",
       "reciprocal-sums"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "lacunary sequences with consecutive-ratio bound",
+      "Egyptian fractions and finite reciprocal sums",
+      "the Bleicher-Erdős conjecture"
+    ]
   },
   {
     "id": "ann-e355-lacunary-def",
@@ -36,7 +40,11 @@
       "sequences",
       "ratios"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "sequences of positive reals",
+      "ratios of consecutive terms",
+      "existential quantification over a parameter λ > 1"
+    ]
   },
   {
     "id": "ann-e355-reciprocal-sums",
@@ -55,7 +63,11 @@
       "unit-fractions",
       "density"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "finite subsets (Finset) of the natural numbers",
+      "sums of unit fractions 1/a_i",
+      "rationals lying in an open interval (u, v)"
+    ]
   },
   {
     "id": "ann-e355-strict-mono",
@@ -73,7 +85,11 @@
       "strict-monotonicity",
       "induction"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "strictly increasing sequences",
+      "induction on index difference",
+      "ratio bound a_{n+1}/a_n ≥ λ > 1 implies growth"
+    ]
   },
   {
     "id": "ann-e355-powers-of-two",
@@ -92,7 +108,11 @@
       "exponential",
       "boundary-case"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "powers of two as a sequence",
+      "the positivity tactic and field_simp",
+      "ratio exactly 2 as a boundary value"
+    ]
   },
   {
     "id": "ann-e355-boundary-section",
@@ -111,7 +131,11 @@
       "nowhere-dense",
       "gaps"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "dyadic rationals k/2^n",
+      "nowhere-dense sets in ℝ",
+      "the geometric series ∑ 1/2^n = 1"
+    ]
   },
   {
     "id": "ann-e355-van-doorn-kovac",
@@ -130,7 +154,11 @@
       "main-theorem",
       "2025-result"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "axioms as stated assumptions in Lean",
+      "explicit constructions beyond Mathlib",
+      "density versus lacunary sparsity trade-off"
+    ]
   },
   {
     "id": "ann-e355-main-theorem",
@@ -149,7 +177,11 @@
       "existence",
       "solved"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "instantiating a theorem at λ = 3/2",
+      "norm_num for the bound 1 < 3/2 < 2",
+      "extracting an existential witness from an axiom"
+    ]
   },
   {
     "id": "ann-e355-sharp-threshold",
@@ -168,7 +200,11 @@
       "dichotomy",
       "completeness"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "two-direction (dichotomy) theorem statements",
+      "the failure axiom lambda_two_fails at λ = 2",
+      "sharp thresholds in (1, 2)"
+    ]
   },
   {
     "id": "ann-e355-fibonacci-example",
@@ -187,7 +223,11 @@
       "golden-ratio",
       "recurrence"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "the Fibonacci recurrence f_{n+2} = f_n + f_{n+1}",
+      "the golden ratio φ = (1+√5)/2 as a limiting ratio",
+      "convergence of consecutive Fibonacci ratios"
+    ]
   },
   {
     "id": "ann-e355-intuition",
@@ -206,7 +246,11 @@
       "density",
       "construction"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "overlap of intervals [1/a_{n+1}, 1/a_n]",
+      "the inequality a_{n+1} < 2a_n when λ < 2",
+      "density of reciprocal sums versus dyadic discreteness"
+    ]
   },
   {
     "id": "ann-e355-summary",
@@ -225,6 +269,10 @@
       "bundled-theorem",
       "completeness"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "bundling multiple results into one statement",
+      "the refine tactic for constructing tuples of proofs",
+      "membership of 3/2 in the valid range (1, 2)"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays in `erdos-355/annotations.json` with concise, content-grounded prerequisite phrases (2-3 per annotation). Data-only change; JSON validated.