### PR TITLE
Enrich erdos-357: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-357/annotations.json
+++ b/src/data/proofs/erdos-357/annotations.json
@@ -17,7 +17,11 @@
       "asymptotics",
       "sidon-sets"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "strictly increasing integer sequences in [1,n]",
+      "consecutive (contiguous) sums of a sequence",
+      "little-o asymptotic notation"
+    ]
   },
   {
     "id": "ann-357-has-distinct-sums",
@@ -37,7 +41,11 @@
       "Finset.sum",
       "consecutive-intervals"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Finset.OrdConnected and contiguous index intervals",
+      "Set.InjOn injectivity on a family of subsets",
+      "Finset.sum over a Preorder and AddCommMonoid"
+    ]
   },
   {
     "id": "ann-357-function-f",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays in `erdos-357/annotations.json` with concise, content-grounded prerequisite phrases (2-3 per annotation). Data-only change; JSON validated.