### PR TITLE
Enrich erdos-206: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-206/annotations.json
+++ b/src/data/proofs/erdos-206/annotations.json
@@ -17,7 +17,11 @@
       "Measure theory",
       "Diophantine approximation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Egyptian fractions as sums of distinct unit fractions",
+      "Lebesgue measure and sets of measure zero",
+      "greedy algorithms for fraction approximation"
+    ]
   },
   {
     "id": "ann-e206-egyptian-fraction",
@@ -36,7 +40,11 @@
       "Ancient mathematics"
     ],
     "mathContext": "See annotation content for formal details of egyptian fraction and valid denominators",
-    "prerequisites": []
+    "prerequisites": [
+      "unit fractions of the form 1/m",
+      "summation over a finite set of denominators",
+      "rational arithmetic with common denominators"
+    ]
   },
   {
     "id": "ann-e206-R-function",
@@ -55,7 +63,11 @@
       "Finite sets",
       "Supremum"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "supremum over finite n-element subsets of positive integers",
+      "strict underapproximation R_n(x) < x",
+      "monotonicity of approximations as terms increase"
+    ]
   },
   {
     "id": "ann-e206-eventually-greedy",
@@ -74,7 +86,11 @@
       "Optimal strategies"
     ],
     "mathContext": "See annotation content for formal details of eventually greedy property",
-    "prerequisites": []
+    "prerequisites": [
+      "greedy choice of the smallest valid denominator",
+      "eventual behavior governed by a threshold N",
+      "recurrence R_{n+1}(x) = R_n(x) + 1/m"
+    ]
   },
   {
     "id": "ann-e206-curtiss-erdos",
@@ -93,7 +109,11 @@
       "Historical progress"
     ],
     "mathContext": "See annotation content for formal details of curtiss and erdős: early positive results",
-    "prerequisites": []
+    "prerequisites": [
+      "eventually greedy approximations of unit fractions 1/m",
+      "divisibility condition a divides b+1 for rationals a/b",
+      "Curtiss (1922), Erdős (1950), and Nathanson (2023) results"
+    ]
   },
   {
     "id": "ann-e206-chu",
@@ -111,7 +131,11 @@
       "Rational arithmetic"
     ],
     "mathContext": "See annotation content for formal details of chu's extension (2023)",
-    "prerequisites": []
+    "prerequisites": [
+      "sufficient conditions for the eventually greedy property",
+      "predicates on numerator-denominator pairs (a, b)",
+      "extending Nathanson's divisibility condition"
+    ]
   },
   {
     "id": "ann-e206-kovac",
@@ -130,7 +154,11 @@
       "Measure zero",
       "Non-constructive existence"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Lebesgue measure zero of the eventually greedy set",
+      "full-measure complement of non-greedy numbers",
+      "non-constructive measure-theoretic existence"
+    ]
   },
   {
     "id": "ann-e206-open-questions",
@@ -149,7 +177,11 @@
       "Rational numbers"
     ],
     "mathContext": "See annotation content for formal details of open questions",
-    "prerequisites": []
+    "prerequisites": [
+      "eventually greedy property for positive rationals",
+      "gap between existence and explicit construction",
+      "the Erdős-Graham claim of an easy counterexample"
+    ]
   },
   {
     "id": "ann-e206-counterexample",
@@ -168,7 +200,11 @@
       "Optimal vs greedy"
     ],
     "mathContext": "See annotation content for formal details of the 11/24 example",
-    "prerequisites": []
+    "prerequisites": [
+      "greedy versus optimal underapproximation at finite steps",
+      "computing R_1 and R_2 for 11/24",
+      "the residual 11/24 - 1/3 = 1/8 forcing m >= 9"
+    ]
   },
   {
     "id": "ann-e206-sylvester",
@@ -187,6 +223,10 @@
       "Sylvester's algorithm",
       "Rational representations"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Sylvester's greedy algorithm for Egyptian fractions",
+      "the step m = ceil(1/x) with remainder x - 1/m",
+      "termination via strictly decreasing numerator"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays in `erdos-206/annotations.json` with concise, content-grounded prerequisite phrases (2-3 per annotation). Data-only change; JSON validated.