### PR TITLE
Enrich erdos-244: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-244/annotations.json
+++ b/src/data/proofs/erdos-244/annotations.json
@@ -17,7 +17,11 @@
       "density",
       "Romanoff"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Prime numbers",
+      "Asymptotic density",
+      "Additive number theory"
+    ]
   },
   {
     "id": "ann-representable-def",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.