### PR TITLE
Enrich erdos-262: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-262/annotations.json
+++ b/src/data/proofs/erdos-262/annotations.json
@@ -17,7 +17,11 @@
       "Growth rates",
       "Doubly exponential"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Irrational Numbers",
+      "Infinite Series Convergence",
+      "Sequence Growth Rates"
+    ]
   },
   {
     "id": "ann-e262-definitions",
@@ -36,7 +40,11 @@
       "Summable",
       "ℕ → ℕ"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Monotone Sequences",
+      "Infinite Series",
+      "Reciprocal Sums"
+    ]
   },
   {
     "id": "ann-e262-irrationality-seq",
@@ -55,7 +63,11 @@
       "Universal quantification",
       "Growth rate"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Universal Quantification",
+      "Irrationality Of Series",
+      "Strictly Increasing Sequences"
+    ]
   },
   {
     "id": "ann-e262-examples",
@@ -74,7 +86,11 @@
       "Nat.factorial",
       "Telescoping series"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Double Exponential Growth",
+      "Telescoping Series",
+      "Factorial Sequence"
+    ]
   },
   {
     "id": "ann-e262-hancl",
@@ -94,7 +110,11 @@
       "Filter.atTop",
       "limsup"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Iterated Logarithms",
+      "Limit Superior",
+      "Real Exponentiation"
+    ]
   },
   {
     "id": "ann-e262-criterion",
@@ -113,7 +133,11 @@
       "Geometric series",
       "Sufficient condition"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Geometric Series",
+      "Summability Criterion",
+      "Sufficient Conditions"
+    ]
   },
   {
     "id": "ann-e262-summary",
@@ -131,6 +155,10 @@
       "erdos_1975",
       "factorial_not_irrationality"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Logical Conjunction",
+      "Necessary And Sufficient",
+      "Double Exponential Sequence"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.