### PR TITLE
Enrich erdos-1119: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1119/annotations.json
+++ b/src/data/proofs/erdos-1119/annotations.json
@@ -17,7 +17,12 @@
       "cardinal arithmetic",
       "ZFC independence"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "complex analysis",
+      "set theory",
+      "cardinal arithmetic",
+      "mathematical logic"
+    ]
   },
   {
     "id": "ann-e1119-definitions",
@@ -37,7 +42,12 @@
       "IsWetzelFamily",
       "Cardinal"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Lean 4 syntax",
+      "Mathlib library structure",
+      "set theory",
+      "cardinal arithmetic"
+    ]
   },
   {
     "id": "ann-e1119-wetzel",
@@ -56,7 +66,12 @@
       "Continuum Hypothesis",
       "diagonal argument"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "complex analysis",
+      "cardinal arithmetic",
+      "mathematical logic",
+      "combinatorics"
+    ]
   },
   {
     "id": "ann-e1119-easycase",
@@ -76,7 +91,12 @@
       "Hayman",
       "diagonalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "cardinal arithmetic",
+      "order theory",
+      "complex analysis",
+      "combinatorics"
+    ]
   },
   {
     "id": "ann-e1119-independence",
@@ -96,7 +116,12 @@
       "Kumar-Shelah",
       "Schilhan-Weinert"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "axiomatic set theory",
+      "forcing",
+      "mathematical logic",
+      "cardinal arithmetic"
+    ]
   },
   {
     "id": "ann-e1119-identity",
@@ -115,7 +140,11 @@
       "isolated zeros",
       "entire functions"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "complex analysis",
+      "real analysis",
+      "point-set topology"
+    ]
   },
   {
     "id": "ann-e1119-cardinals",
@@ -135,6 +164,10 @@
       "aleph",
       "Wetzel equivalence"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "cardinal arithmetic",
+      "axiomatic set theory",
+      "mathematical logic"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1119`: populated empty per-annotation `prerequisites` arrays with content-grounded foundational background topics. Diff is prerequisites-only; all other fields unchanged.