### PR TITLE
Enrich erdos-1182: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1182/annotations.json
+++ b/src/data/proofs/erdos-1182/annotations.json
@@ -17,7 +17,12 @@
       "Graph coloring",
       "Tree Ramsey numbers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "graph theory",
+      "Ramsey theory",
+      "extremal combinatorics",
+      "asymptotic notation"
+    ]
   },
   {
     "id": "ann-e1182-ramsey-def",
@@ -37,7 +42,11 @@
       "Edge coloring",
       "Clique"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Ramsey theory",
+      "infimum over natural numbers",
+      "edge colorings of complete graphs"
+    ]
   },
   {
     "id": "ann-e1182-thresholds",
@@ -57,7 +66,11 @@
       "Bounded above condition",
       "Universal vs existential thresholds"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "extremal graph theory",
+      "supremum of bounded sets",
+      "order theory on natural numbers"
+    ]
   },
   {
     "id": "ann-e1182-chvatal",
@@ -77,7 +90,11 @@
       "Connected graph",
       "Minimum spanning tree"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "graph theory",
+      "tree structure of connected graphs",
+      "Ramsey theory"
+    ]
   },
   {
     "id": "ann-e1182-proved",
@@ -97,6 +114,10 @@
       "Small Ramsey numbers",
       "Complete graph K_2"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "order theory (csSup/csInf lemmas)",
+      "Lean 4 tactic mode",
+      "Mathlib library structure"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1182`: populated empty per-annotation `prerequisites` arrays with content-grounded foundational background topics. Diff is prerequisites-only; all other fields unchanged.