### PR TITLE
audit(lagrange-four-squares-oq-04): correct axiomCount 3→2 (dirichlet_key_lemma is now a theorem)

### DIFF
--- a/src/data/proofs/lagrange-four-squares-oq-04/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-04/meta.json
@@ -17,11 +17,10 @@
     "proofRepoPath": "Proofs/LagrangeFourSquaresOQ04.lean",
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 3,
-    "assumptions": "3 axioms across the chain. (1) not_obstructed_is_three_squares (main file, LagrangeFourSquaresOQ04.lean): backward direction — every number NOT of the form 4^a(8b+7) IS a sum of three squares (requires genus theory). (2) dirichlet_key_lemma (ThreeSquares.lean): Dirichlet/Minkowski lattice key lemma yielding a three-square representation from a Legendre-symbol hypothesis. (3) not_excluded_form_is_sum_three_sq (ThreeSquares.lean): a redeclaration of the backward direction under the IsExcludedForm predicate framework used by the infrastructure file. The forward direction (Legendre's mod-8 obstruction) is fully proved.",
+    "axiomCount": 2,
+    "assumptions": "2 axioms across the chain. (1) not_obstructed_is_three_squares (main file, LagrangeFourSquaresOQ04.lean): backward direction — every number NOT of the form 4^a(8b+7) IS a sum of three squares (requires genus theory). (2) not_excluded_form_is_sum_three_sq (ThreeSquares.lean): a redeclaration of the backward direction under the IsExcludedForm predicate framework used by the infrastructure file. (The former axiom dirichlet_key_lemma is no longer an assumption: it is now a proved theorem in ThreeSquares.lean for the d ≤ 2 slice — the only case the construction uses — so it no longer adds to the trusted base.) The forward direction (Legendre's mod-8 obstruction) is fully proved.",
     "axioms": [
       "not_obstructed_is_three_squares: ¬IsObstructed n → IsSumOfThreeSquares n (backward direction, requires genus theory)",
-      "dirichlet_key_lemma (ThreeSquares.lean): Minkowski/Dirichlet key lemma — produces a three-square representation of n from a Legendre-symbol hypothesis (n > 1, d > 0, p = d·n − 1 prime, legendreSym p (−d) = 1)",
       "not_excluded_form_is_sum_three_sq (ThreeSquares.lean): ¬IsExcludedForm n → ∃ a b c, a² + b² + c² = n (backward direction under the IsExcludedForm framework)"
     ],
     "originalContributions": [
@@ -30,7 +29,7 @@
       "Descent lemma: 4 | (x²+y²+z²) implies 2|x, 2|y, 2|z",
       "Full biconditional combining proved forward + axiomatized backward directions",
       "Examples: 7, 15, 28, 112 are not sums of three squares",
-      "Single-AP witness refinement (ThreeSquaresSingleAP.lean, sorry-free and axiom-free, Mathlib-only): the quadratic side-condition legendreSym p (−n) = 1 of dirichlet_key_lemma is satisfied uniformly by the single arithmetic progression p ≡ 1 (mod 4n), removing the rigid p = d·n − 1 tie and its Residue3 (n ≡ 3 mod 4) carve-out. Pure quadratic reciprocity plus Dirichlet's theorem on primes in AP; the Minkowski lattice key lemma itself remains the axiomatized component."
+      "Single-AP witness refinement (ThreeSquaresSingleAP.lean, sorry-free and axiom-free, Mathlib-only): the quadratic side-condition legendreSym p (−n) = 1 of dirichlet_key_lemma is satisfied uniformly by the single arithmetic progression p ≡ 1 (mod 4n), removing the rigid p = d·n − 1 tie and its Residue3 (n ≡ 3 mod 4) carve-out. Pure quadratic reciprocity plus Dirichlet's theorem on primes in AP. The underlying dirichlet_key_lemma is now a proved theorem (ThreeSquares.lean) for the d ≤ 2 slice the construction uses, rather than an axiom."
     ],
     "dateAdded": "2026-04-13",
     "lineCount": 226,


### PR DESCRIPTION
## Audit finding: gallery meta vs Lean source drift

**Proof:** `lagrange-four-squares-oq-04` (Legendre-Gauss Three-Square Theorem)

The gallery meta listed `dirichlet_key_lemma (ThreeSquares.lean)` as one of **"3 axioms across the chain"** (`meta.meta.axiomCount: 3`). The Lean source no longer matches.

### Source state (verified at origin/main 06badcd2987)

`proofs/Proofs/ThreeSquares.lean` now declares:

```lean
/- This replaces the former `axiom dirichlet_key_lemma`. The `d ≤ 2` hypothesis is the
   honest scope of the slice construction ... -/
theorem dirichlet_key_lemma {n d p : ℕ} (hn : n > 1) (hd : d > 0) (hd2 : d ≤ 2)
    (hp : p = d * n - 1) [Fact (Nat.Prime p)] (hqr : legendreSym p (-d : ℤ) = 1) :
    ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = n := by ...
```

It is a **proved theorem** (0 sorries in the file), not an axiom. The axiom was eliminated in #26313 and the surrounding narrative corrected in #26428 — neither updated this gallery meta.

### Actual axiom declarations across the chain (2, not 3)

| Axiom | Location |
|-------|----------|
| `not_obstructed_is_three_squares` | `LagrangeFourSquaresOQ04.lean:144` |
| `not_excluded_form_is_sum_three_sq` | `ThreeSquares.lean:1838` |

(`grep -E '^axiom '` over the main file + both supporting files confirms exactly these two; `ThreeSquaresSingleAP.lean` has none.)

### Changes
- `meta.meta.axiomCount`: `3 → 2`
- `assumptions` prose: renumbered to 2 axioms; notes `dirichlet_key_lemma` is now a proved d≤2 theorem, not an assumption
- `axioms[]`: removed the `dirichlet_key_lemma` bullet
- `originalContributions[]`: fixed the now-stale "the Minkowski lattice key lemma itself remains the axiomatized component" clause
- `leanFile.axiomCount` left at `1` (counts only the main file, still correct)

Direction of drift was conservative (meta over-counted assumptions), so status/badge (`axiomatized`/`axiom`) are unaffected.

> Note for research review (out of scope here): the Single-AP refinement bullet still asserts the side-condition is "satisfied uniformly", which the active zsqrtd-neg-two-oq-02 S14 work flags as overstated (d≤2-limited / orphaned witness). Left to the researcher to resolve.

🤖 Auditor agent — gallery integrity check