### PR TITLE
research(erdos-mordell-oq-01): submit residual chord-identity sorries to Aristotle

### DIFF
--- a/research/problems/erdos-mordell-inequality-oq-01/state.md
+++ b/research/problems/erdos-mordell-inequality-oq-01/state.md
@@ -1,0 +1,33 @@
+# Current State
+
+> **2026-06-19 (researcher-1) — both residual sorries submitted to Aristotle as one file job. READ FIRST.**
+> The two remaining geometric `sorry`s of `ErdosMordellChordIdentity.lean` —
+> `chord_length_eq` (sine side, L242) and `angle_at_P` (cosine side, L292) — were
+> submitted to Aristotle as a single `prove_file`-style job via the **CLI**
+> (`aristotle submit --project-dir …`, because the MCP `prove`/`prove_file`
+> wrapper returned 404 "Resource not found" all session).
+>
+>   **Aristotle project_id = 55ae116d-fc06-4019-9a24-1ec1f650bc96** (submitted)
+>
+> Both sorries are isolated, hypothesis-light, and carry COMPLETE coordinate-ring
+> roadmaps in their docstrings:
+>   - `chord_length_eq`: after squaring, the 3×3 Gram determinant of `u=Y−X`,
+>     `v=Z−X`, `w=P−X` vanishes (3 vectors in a 2-D space) — one-line `ring` in
+>     `Fin 2` coords: `r·(a·b−c²) = a·q² + b·p² − 2·c·p·q`.
+>   - `angle_at_P`: reduces to the sign identity `[u,w]·[v,w] ≤ 0`, which from
+>     `hP`'s barycentric witness `w = s·u + t·v` (`s,t>0`, `s+t<1`) collapses to
+>     the one-line `[u,w]·[v,w] = −s·t·[u,v]²` (♦), `< 0` for nondegenerate `[u,v]`.
+>
+> **NEXT (on wake):**
+>   1. Poll: `uvx --from aristotlelib aristotle show 55ae116d-fc06-4019-9a24-1ec1f650bc96`
+>      (and `download <id> --destination X.tar.gz`; archive is gzip-tar despite the
+>      name → `tar -xzf`).
+>   2. On PROVED: paste the two proof bodies over L242/L292, then build-verify
+>      (`docker-build.sh Proofs.ErdosMordellChordIdentity`) when the gate opens
+>      (load<6, ≤2 lean containers — was CLOSED at load ~18.6 this session).
+>   3. On FAILED: fall back to manual coordinate expansion of `pedalFoot` via
+>      `orthogonalProjection` into `Fin 2`, then the documented `ring` identities.
+>
+> NOTE: a peer (researcher-9) had near-complete manual WIP on `angle_at_P` in a
+> `/tmp` scratch (its own worktree); not committed/visible here. Aristotle results
+> are cached 30d and harmless if that manual proof lands first.

--- a/research/problems/erdos-mordell-inequality-oq-01/state.md
+++ b/research/problems/erdos-mordell-inequality-oq-01/state.md
@@ -1,5 +1,37 @@
 # Current State
 
+> **2026-06-19 (researcher-1, follow-up) — SECOND integration step verified mechanical; sine-side Mathlib hook identified. READ ALSO.**
+> Re-polled Aristotle project `55ae116d-...`: still `IN_PROGRESS` (~7%, actively on
+> the `chord_length_eq` goal having expanded `pedalFoot`). Did NOT duplicate the
+> running solver. Instead verified the *downstream* wiring so the whole proof closes
+> the moment Aristotle returns:
+>
+>   1. **Companion → main is mechanical.** The companion `ErdosMordellChord.chord_identity`
+>      (`ErdosMordellChordIdentity.lean` L346) has the SAME statement as the main
+>      `ErdosMordellOQ01.chord_identity` (`ErdosMordellInequalityOQ01.lean` L294, the
+>      lone `sorry` at L301) under the relabel `A↔X, B↔Y, C↔Z`:
+>        `(dist P A·sin∠BAC)² = lineDist P C A² + lineDist P A B² + 2·lineDist P C A·lineDist P A B·cos∠BAC`.
+>      Both files define `lineDist P X Y := Metric.infDist P (affineSpan ℝ {X,Y})`
+>      *identically* (defeq across namespaces). So once the companion's 2 sorries are
+>      filled, register the companion in `Proofs.lean`, `import` it into the main file,
+>      and discharge L301 with `exact ErdosMordellChord.chord_identity A B C P hABC hP`
+>      (add `unfold ErdosMordellChord.lineDist ErdosMordellOQ01.lineDist` only if the
+>      defeq isn't picked up automatically). No new math needed.
+>   2. **Sine-side Mathlib hook (for `chord_length_eq`, or a manual fallback).**
+>      `InnerProductGeometry.sin_angle_mul_norm_mul_norm (x y) :`
+>        `Real.sin (angle x y) * (‖x‖*‖y‖) = √(⟪x,x⟫*⟪y,y⟫ − ⟪x,y⟫*⟪x,y⟫)`
+>      with `x = Y−X, y = Z−X` gives `sin∠YXZ·‖u‖‖v‖ = √(ab−c²)` directly — this is
+>      the precise lemma that turns the documented Gram identity `r(ab−c²)=aq²+bp²−2cpq`
+>      into the unsquared `dist F_b F_c = dist X P·sin∠YXZ` (`sin_angle_nonneg` +
+>      `Real.sqrt` for the sign). `EuclideanGeometry.angle Y X Z` is defeq
+>      `InnerProductGeometry.angle (Y−X) (Z−X)`.
+>
+> Manual proof of either companion sorry was assessed as poor session ROI: it is
+> ~150 lines of `EuclideanSpace ℝ (Fin 2)` coordinate plumbing requiring several
+> cold docker builds to iterate (build gate was load-closed), while Aristotle is
+> already running on exactly these targets. Left to Aristotle; recorded the hooks
+> above so integration (both steps) is turnkey on return.
+
 > **2026-06-19 (researcher-1) — both residual sorries submitted to Aristotle as one file job. READ FIRST.**
 > The two remaining geometric `sorry`s of `ErdosMordellChordIdentity.lean` —
 > `chord_length_eq` (sine side, L242) and `angle_at_P` (cosine side, L292) — were

--- a/src/data/research/problems/erdos-mordell-inequality-oq-01.json
+++ b/src/data/research/problems/erdos-mordell-inequality-oq-01.json
@@ -29,7 +29,7 @@
     "Not present in Mathlib4 (as of v4.26.0): no `mordell` geometry result; Mathlib has Triangle, Incenter, Projection, SignedDist, angle infrastructure but no Erdős–Mordell."
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (cycle-37): KEYSTONE pedalFoot_eq PROVED + build-verified; latent cosine-side build error fixed; companion compiles for first time. Sorries 3→2 (chord_length_eq sine-side Gram + angle_at_P cosine-side sign remain). PR #26265.",
+    "progressSummary": "PROGRESS (2026-06-19, r1): submitted both residual geometric sorries (chord_length_eq sine-side + angle_at_P cosine-side) of ErdosMordellChordIdentity.lean to Aristotle as ONE file job (project 55ae116d, MCP wrapper was 404 → used CLI submit). Both are isolated with COMPLETE coordinate-ring roadmaps in their docstrings (Gram-determinant vanishing for chord_length_eq; cross-product identity [u,w]·[v,w] = −s·t·[u,v]² from hP barycentric witness for angle_at_P). v4.26↔v4.28 toolchain warning noted. Poll: aristotle show 55ae116d. On PROVED: integrate (build-pending until docker gate opens, load<6).",
     "builtItems": [
       "proofs/Proofs/ErdosMordellInequalityOQ01.lean: erdos_mordell_reduction — from the three key inequalities a·PA≥b·dc+c·db (cyclic), derives PA+PB+PC≥2(da+db+dc) via explicit nonnegative certificate, 0 sorry, 0 axiom (build-pending verification).",
       "Certificate: a·b·c·(PA+PB+PC) − 2abc·(da+db+dc) = a·da·(b−c)² + b·db·(a−c)² + c·dc·(a−b)² + (key-inequality slack), each summand ≥ 0; closed by mul_le_mul_of_nonneg_left scaling + nlinarith + le_of_mul_le_mul_left.",
@@ -44,7 +44,8 @@
       "ErdosMordellFeetAngleAristotle.lean (NEW, build-VERIFIED 0-sorry under LEAN_MEMORY_LIMIT=8192 docker): case-free oriented building block two_zsmul_oangle_feet_at_X : 2•∡(pedalFoot P Z X) X (pedalFoot P X Y) = 2•∡ Z X Y, for ALL triangles, no positivity/Sbtw hypothesis (only the four ≠X nondegeneracies). Proof = Collinear.two_zsmul_oangle_eq_left/right (ray-direction invariance of 2•∡ since 2•π≡0 in Real.Angle), swapping F_b↦Z and F_c↦Y.",
       "ErdosMordellFeetAngleAristotle.lean helpers (build-verified): pedalFoot_mem_affineSpan (orthogonalProjection_mem), collinear_pedalFoot {foot,X,Y}, collinear_foot_vertex {foot,B,A} (vertex-in-middle via Set.pair_comm + collinear_insert_iff_of_mem_affineSpan).",
       "pedalFoot_eq PROVED + build-verified (ErdosMordellChordIdentity.lean:172, Lean v4.26 7743 jobs green): pedalFoot P X Y = (⟪P−X,Y−X⟫/‖Y−X‖²)•(Y−X)+X via coe_orthogonalProjection_eq_iff_mem (membership + perpendicular residual). The keystone bridge; sorries 3→2.",
-      "Fixed latent build error in chord_length_sq_eq_of_angle_at_P (rw[hlc] dist^2 vs dist*dist + dist_comm mismatch) → hAngle/cos_pi_sub into hlc, align pow_two+dist_comm, linear_combination. Companion now compiles for the first time."
+      "Fixed latent build error in chord_length_sq_eq_of_angle_at_P (rw[hlc] dist^2 vs dist*dist + dist_comm mismatch) → hAngle/cos_pi_sub into hlc, align pow_two+dist_comm, linear_combination. Companion now compiles for the first time.",
+      "Aristotle file submission (project 55ae116d, r1 2026-06-19): ErdosMordellChordIdentity.lean (both sorries chord_length_eq + angle_at_P). CLI submit since MCP prove/prove_file returned 404 this session."
     ],
     "insights": [
       "The inequality cleanly factors: ALL the AM-GM / side-length algebra is captured by erdos_mordell_reduction (now proved), isolating the genuinely hard work into the three geometric key inequalities.",


### PR DESCRIPTION
## Summary
Submitted the two remaining geometric `sorry`s of the Erdős–Mordell pedal-feet
chord identity (`ErdosMordellChordIdentity.lean`) to Aristotle as a single
file job:
- `chord_length_eq` (sine side, L242)
- `angle_at_P` (cosine side, L292)

With these two, the chord identity and the whole Erdős–Mordell reduction close.

**Aristotle project**: `55ae116d-fc06-4019-9a24-1ec1f650bc96` (submitted)

Submitted via the **CLI** (`aristotle submit --project-dir …`) because the MCP
`prove`/`prove_file` wrapper returned `404 Resource not found` throughout this
session.

## Why these are good Aristotle targets
Both are isolated and carry complete coordinate-`ring` roadmaps in their
docstrings:
- `chord_length_eq`: after squaring, the 3×3 Gram determinant of `u=Y−X`,
  `v=Z−X`, `w=P−X` vanishes (three vectors in a 2-D space) — `r·(a·b−c²) =
  a·q² + b·p² − 2·c·p·q`, a one-line `ring` in `Fin 2` coords.
- `angle_at_P`: reduces to the sign `[u,w]·[v,w] ≤ 0`, which from `hP`'s
  barycentric witness `w = s·u + t·v` (`s,t>0`) collapses to
  `[u,w]·[v,w] = −s·t·[u,v]²` (♦).

## Changes
No Lean changes — `research/aristotle-jobs.json`, the research knowledge JSON,
and a new `state.md` record the submission and the integrate-on-PROVED plan.

## Status
**Outcome**: progress (delegated the two residual sorries; awaiting Aristotle)
**Next**: poll `aristotle show 55ae116d…`; on PROVED, integrate and build-verify
when the Docker gate opens (was closed at load ~18.6 this session).

🤖 Generated by researcher-1