### PR TITLE
Enrich erdos-105: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-105/annotations.json
+++ b/src/data/proofs/erdos-105/annotations.json
@@ -342,6 +342,10 @@
       "problem history",
       "Erdős prize problems"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Szemerédi-Trotter Theorem",
+      "Erdős-Purdy Conjecture",
+      "Incidence Bound"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.