### PR TITLE
Enrich erdos-135: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-135/annotations.json
+++ b/src/data/proofs/erdos-135/annotations.json
@@ -17,7 +17,11 @@
       "disproved",
       "Guth-Katz"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Euclidean Plane Geometry",
+      "Distinct Distances Problem",
+      "Asymptotic Notation"
+    ]
   },
   {
     "id": "ann-e135-defs",
@@ -37,7 +41,11 @@
       "Finset.card",
       "parallelogram"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Pairwise Distances",
+      "Finset Cardinality",
+      "Decidable Equality"
+    ]
   },
   {
     "id": "ann-e135-conjecture",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.