### PR TITLE
Enrich erdos-168: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-168/annotations.json
+++ b/src/data/proofs/erdos-168/annotations.json
@@ -16,7 +16,11 @@
       "density",
       "3-smooth numbers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Extremal Combinatorics",
+      "Asymptotic Density",
+      "Erdős Problems"
+    ]
   },
   {
     "id": "ann-e168-triple-def",
@@ -34,7 +38,11 @@
       "arithmetic progression",
       "multiplicative structure"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Arithmetic Progressions",
+      "Multiplicative Structure",
+      "Set Membership"
+    ]
   },
   {
     "id": "ann-e168-triple-free",
@@ -52,7 +60,11 @@
       "negation",
       "avoidance"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Logical Negation",
+      "Avoidance Sets",
+      "Predicate Definitions"
+    ]
   },
   {
     "id": "ann-e168-F-def",
@@ -71,7 +83,11 @@
       "cardinality",
       "extremal function"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Supremum",
+      "Set Cardinality",
+      "Extremal Functions"
+    ]
   },
   {
     "id": "ann-e168-density-bounded",
@@ -89,7 +105,11 @@
       "density",
       "bounds"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Density Ratios",
+      "Cardinality Bounds",
+      "Inequality Reasoning"
+    ]
   },
   {
     "id": "ann-e168-monotone",
@@ -107,7 +127,11 @@
       "monotonicity",
       "subset inclusion"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Monotone Functions",
+      "Subset Inclusion",
+      "Interval Sets"
+    ]
   },
   {
     "id": "ann-e168-3smooth",
@@ -126,7 +150,11 @@
       "prime factors",
       "Hamming numbers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Smooth Numbers",
+      "Prime Factorization",
+      "Hamming Numbers"
+    ]
   },
   {
     "id": "ann-e168-gsw",
@@ -144,7 +172,11 @@
       "limit existence",
       "density theorem"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Limit Existence",
+      "Density Theorems",
+      "Axiomatization"
+    ]
   },
   {
     "id": "ann-e168-lower-bound",
@@ -162,7 +194,11 @@
       "construction",
       "multiples of 3"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Constructive Lower Bounds",
+      "Multiples Of Three",
+      "Triple-Free Construction"
+    ]
   },
   {
     "id": "ann-e168-irrationality",
@@ -180,7 +216,11 @@
       "irrationality",
       "open problem"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Irrational Numbers",
+      "Open Problems",
+      "Classical Logic"
+    ]
   },
   {
     "id": "ann-e168-examples",
@@ -198,6 +238,10 @@
       "examples",
       "verification"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Case Analysis",
+      "Membership Verification",
+      "Omega Tactic"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.