### PR TITLE
Enrich erdos-194: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-194/annotations.json
+++ b/src/data/proofs/erdos-194/annotations.json
@@ -16,7 +16,11 @@
       "Orderings",
       "Ramsey theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Arithmetic Progressions",
+      "Enumerations Of Sets",
+      "Ramsey Theory"
+    ]
   },
   {
     "id": "ann-e194-ap-def",
@@ -34,7 +38,11 @@
       "Common difference"
     ],
     "mathContext": "See annotation content for formal details of arithmetic progression (3-term)",
-    "prerequisites": []
+    "prerequisites": [
+      "Real Numbers",
+      "Common Difference",
+      "Arithmetic Sequence"
+    ]
   },
   {
     "id": "ann-e194-ap-equiv",
@@ -51,7 +59,11 @@
       "Arithmetic mean"
     ],
     "mathContext": "See annotation content for formal details of ap characterization",
-    "prerequisites": []
+    "prerequisites": [
+      "Arithmetic Mean",
+      "Algebraic Manipulation",
+      "Logical Equivalence"
+    ]
   },
   {
     "id": "ann-e194-increasing-ap",
@@ -69,7 +81,11 @@
       "Monotonicity"
     ],
     "mathContext": "See annotation content for formal details of increasing and decreasing aps",
-    "prerequisites": []
+    "prerequisites": [
+      "Strict Order Relations",
+      "Monotone Sequences",
+      "Arithmetic Progressions"
+    ]
   },
   {
     "id": "ann-e194-enumeration",
@@ -87,7 +103,11 @@
       "Bijections",
       "Countability"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Injective Functions",
+      "Countable Sets",
+      "Subsets Of Reals"
+    ]
   },
   {
     "id": "ann-e194-monotone-inc-ap",
@@ -105,7 +125,11 @@
       "Index ordering"
     ],
     "mathContext": "See annotation content for formal details of monotone increasing ap in enumeration",
-    "prerequisites": []
+    "prerequisites": [
+      "Index Ordering",
+      "Increasing Subsequences",
+      "Arithmetic Progressions"
+    ]
   },
   {
     "id": "ann-e194-monotone-dec-ap",
@@ -122,7 +146,11 @@
       "Decreasing sequences"
     ],
     "mathContext": "See annotation content for formal details of monotone decreasing ap in enumeration",
-    "prerequisites": []
+    "prerequisites": [
+      "Decreasing Subsequences",
+      "Index Ordering",
+      "Arithmetic Progressions"
+    ]
   },
   {
     "id": "ann-e194-chaotic",
@@ -140,7 +168,11 @@
       "Scrambling"
     ],
     "mathContext": "See annotation content for formal details of chaotic ordering",
-    "prerequisites": []
+    "prerequisites": [
+      "Pattern Avoidance",
+      "Logical Negation",
+      "Monotone Progressions"
+    ]
   },
   {
     "id": "ann-e194-main-axiom",
@@ -158,7 +190,11 @@
       "Constructive proof",
       "Base-3 representation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Rational Numbers",
+      "Constructive Existence Proof",
+      "Ternary Representation"
+    ]
   },
   {
     "id": "ann-e194-main-theorem",
@@ -176,7 +212,11 @@
       "Existence proof"
     ],
     "mathContext": "See annotation content for formal details of erdos problem #194: main result",
-    "prerequisites": []
+    "prerequisites": [
+      "Existential Quantifiers",
+      "Infinite Sets",
+      "Counterexamples"
+    ]
   },
   {
     "id": "ann-e194-natural-ordering",
@@ -194,7 +234,11 @@
       "Trivial APs"
     ],
     "mathContext": "See annotation content for formal details of natural ordering has aps",
-    "prerequisites": []
+    "prerequisites": [
+      "Order-Preserving Maps",
+      "Monotone Enumerations",
+      "Arithmetic Progressions"
+    ]
   },
   {
     "id": "ann-e194-construction",
@@ -212,7 +256,11 @@
       "Ternary representation",
       "Digit patterns"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Base-3 Representation",
+      "Digit Comparison",
+      "Average Of Endpoints"
+    ]
   },
   {
     "id": "ann-e194-k-term",
@@ -230,7 +278,11 @@
       "k-term progressions"
     ],
     "mathContext": "See annotation content for formal details of extension to k-term aps",
-    "prerequisites": []
+    "prerequisites": [
+      "k-Term Progressions",
+      "Generalization",
+      "Pattern Avoidance"
+    ]
   },
   {
     "id": "ann-e194-summary",
@@ -248,6 +300,10 @@
       "Completeness"
     ],
     "mathContext": "See annotation content for formal details of summary theorem",
-    "prerequisites": []
+    "prerequisites": [
+      "Chaotic Orderings",
+      "Dense Sets",
+      "Existence Results"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.