### PR TITLE
Enrich erdos-55: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-55/annotations.json
+++ b/src/data/proofs/erdos-55/annotations.json
@@ -347,6 +347,10 @@
       "additive number theory history",
       "probabilistic combinatorics"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Additive Combinatorics",
+      "Ramsey-Complete Sets",
+      "Asymptotic Density Bounds"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.