### PR TITLE
Enrich erdos-75: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-75/annotations.json
+++ b/src/data/proofs/erdos-75/annotations.json
@@ -35,7 +35,11 @@
       "cardinal numbers",
       "axiomatization"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "Chromatic Number",
+      "Abstract Axiomatization",
+      "Predicate Monotonicity"
+    ],
     "range": {
       "startLine": 26,
       "endLine": 33


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.