### PR TITLE
Enrich erdos-88: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-88/annotations.json
+++ b/src/data/proofs/erdos-88/annotations.json
@@ -422,7 +422,11 @@
       "Erdős-prizes",
       "mathematical-problem-solving"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Erdős Problems",
+      "Mathematical Prize Problems",
+      "Open Problem Conjectures"
+    ]
   },
   {
     "id": "ann-88-delta",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.