### PR TITLE
Enrich erdos-93: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-93/annotations.json
+++ b/src/data/proofs/erdos-93/annotations.json
@@ -16,7 +16,11 @@
       "Discrete geometry"
     ],
     "mathContext": "See annotation content for formal details of problem overview",
-    "prerequisites": []
+    "prerequisites": [
+      "Convex Position",
+      "Euclidean Distance",
+      "Erdős Distinct Distances"
+    ]
   },
   {
     "id": "ann-e93-definitions",
@@ -34,7 +38,11 @@
       "formal definition",
       "Lean 4 formalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Euclidean Distance",
+      "Set Cardinality",
+      "Unordered Pairs"
+    ]
   },
   {
     "id": "ann-e93-convex",
@@ -53,7 +61,11 @@
       "Convex polygon",
       "Extreme points"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Convex Hull",
+      "Extreme Points",
+      "Interior Angles"
+    ]
   },
   {
     "id": "ann-e93-altman",
@@ -72,7 +84,11 @@
       "Regular polygons",
       "Extremal configurations"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Cyclic Vertex Ordering",
+      "Regular Polygons",
+      "Floor Function"
+    ]
   },
   {
     "id": "ann-e93-stronger",
@@ -91,7 +107,11 @@
       "Single-vertex distances"
     ],
     "mathContext": "See annotation content for formal details of stronger variant (problem #982, open)",
-    "prerequisites": []
+    "prerequisites": [
+      "Single-Vertex Distances",
+      "Open Problems",
+      "Convex Polygon"
+    ]
   },
   {
     "id": "ann-e93-fishburn",
@@ -110,7 +130,11 @@
       "Pigeonhole principle",
       "Average arguments"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Pigeonhole Principle",
+      "Averaging Argument",
+      "Binomial Coefficient"
+    ]
   },
   {
     "id": "ann-e93-summary",
@@ -128,6 +152,10 @@
       "proof technique",
       "combinatorics"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Altman's Theorem",
+      "Logical Conjunction",
+      "Floor Function"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.