### PR TITLE
Enrich erdos-94: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-94/annotations.json
+++ b/src/data/proofs/erdos-94/annotations.json
@@ -17,7 +17,12 @@
       "multiplicities",
       "incidence-geometry"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Euclidean Plane",
+      "Pairwise Distances",
+      "Convex Position",
+      "Discrete Geometry"
+    ]
   },
   {
     "id": "ann-94-point-config",
@@ -37,7 +42,11 @@
       "Finset.image",
       "dist"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Finset",
+      "Euclidean Distance",
+      "Cartesian Product"
+    ]
   },
   {
     "id": "ann-94-multiplicity",
@@ -79,7 +88,11 @@
       "general-position",
       "convex-polygon"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Convex Hull",
+      "Collinearity",
+      "General Position"
+    ]
   },
   {
     "id": "ann-94-baseline",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.