### PR TITLE
Enrich erdos-1039: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1039/annotations.json
+++ b/src/data/proofs/erdos-1039/annotations.json
@@ -386,7 +386,11 @@
       "conjectured bound",
       "linear rate"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Inscribed Disc Radius",
+      "Asymptotic Lower Bound",
+      "EHP Conjecture"
+    ]
   },
   {
     "id": "ann-1039-benchbound",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.