### PR TITLE
Enrich erdos-1043: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1043/annotations.json
+++ b/src/data/proofs/erdos-1043/annotations.json
@@ -17,7 +17,11 @@
       "complex norm",
       "metric spaces"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Lebesgue Measure",
+      "Complex Polynomials",
+      "Metric Space Topology"
+    ]
   },
   {
     "id": "ann-1043-levelset",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.