### PR TITLE
Enrich erdos-1047-oq-02: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1047-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1047-oq-02/annotations.json
@@ -39,7 +39,11 @@
       "Soundness",
       "Definitional equality"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Axioms And Soundness",
+      "Polynomial Lemniscates",
+      "Print Axioms Command"
+    ]
   },
   {
     "id": "ann-e1047-oq02-faithful",
@@ -79,7 +83,11 @@
       "Logical implication",
       "Axiom integrity"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Definitional Equality",
+      "Logical Implication",
+      "Quantifier Strength"
+    ]
   },
   {
     "id": "ann-e1047-oq02-negation-theorem",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.