### PR TITLE
Enrich erdos-1095: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1095/annotations.json
+++ b/src/data/proofs/erdos-1095/annotations.json
@@ -17,7 +17,11 @@
       "prime-factors",
       "analytic-number-theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Binomial Coefficients",
+      "Prime Factorization",
+      "Asymptotic Notation"
+    ]
   },
   {
     "id": "ann-1095-krough",
@@ -36,7 +40,11 @@
       "Kummer-theorem",
       "p-adic-valuation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Prime Factors",
+      "Smooth Numbers",
+      "Kummer's Theorem"
+    ]
   },
   {
     "id": "ann-1095-g-axioms",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.