### PR TITLE
Enrich erdos-1144: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1144/annotations.json
+++ b/src/data/proofs/erdos-1144/annotations.json
@@ -17,7 +17,11 @@
       "Rademacher random variables",
       "limsup"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Completely Multiplicative Functions",
+      "Rademacher Random Variables",
+      "Asymptotic Notation"
+    ]
   },
   {
     "id": "ann-e1144-IsCompletelyMultiplicative",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.