### PR TITLE
Enrich erdos-736: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-736/annotations.json
+++ b/src/data/proofs/erdos-736/annotations.json
@@ -16,7 +16,11 @@
       "cardinal numbers",
       "proper coloring"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "graph theory",
+      "cardinal arithmetic",
+      "set theory"
+    ]
   },
   {
     "id": "ann-736-2",
@@ -35,7 +39,11 @@
       "finite sets",
       "subgraph inheritance"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "graph theory",
+      "finite combinatorics",
+      "set theory"
+    ]
   },
   {
     "id": "ann-736-3",
@@ -54,7 +62,11 @@
       "graph embedding",
       "subgraph isomorphism"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "graph theory",
+      "injective functions",
+      "structure-preserving maps"
+    ]
   },
   {
     "id": "ann-736-4",
@@ -73,7 +85,11 @@
       "universality",
       "chromatic hierarchy"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "infinite graph theory",
+      "transfinite cardinals",
+      "universal structures"
+    ]
   },
   {
     "id": "ann-736-5",
@@ -92,7 +108,11 @@
       "cardinal hierarchy",
       "generalization"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "set theory",
+      "transfinite cardinals",
+      "infinite graph theory"
+    ]
   },
   {
     "id": "ann-736-6",
@@ -111,7 +131,11 @@
       "realization",
       "characterization problem"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "infinite graph theory",
+      "cardinal hierarchy",
+      "set theory"
+    ]
   },
   {
     "id": "ann-736-7",
@@ -131,7 +155,11 @@
       "forcing",
       "Shelah"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "axiomatic set theory (ZFC)",
+      "forcing and independence",
+      "infinite combinatorics"
+    ]
   },
   {
     "id": "ann-736-8",
@@ -151,7 +179,11 @@
       "axiom of choice",
       "finite to infinite"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "graph theory",
+      "compactness arguments",
+      "axiom of choice"
+    ]
   },
   {
     "id": "ann-736-9",
@@ -171,6 +203,10 @@
       "forcing",
       "set-theoretic independence"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "mathematical logic",
+      "axiomatic set theory (ZFC)",
+      "model theory"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-736`: populated empty per-annotation `prerequisites` arrays with content-grounded foundational background topics. Diff is prerequisites-only; all other fields unchanged.