### PR TITLE
Enrich erdos-1148: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1148/annotations.json
+++ b/src/data/proofs/erdos-1148/annotations.json
@@ -17,7 +17,11 @@
       "Waring's problem",
       "geometry of numbers"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Sum Of Two Squares",
+      "Ternary Quadratic Forms",
+      "Geometry Of Numbers"
+    ]
   },
   {
     "id": "ann-e1148-structure-defs",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.