### PR TITLE
Enrich erdos-1149: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1149/annotations.json
+++ b/src/data/proofs/erdos-1149/annotations.json
@@ -170,7 +170,11 @@
       "square root case",
       "Euler totient"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Floor Of Square Root",
+      "Euler Totient Function",
+      "Natural Density"
+    ]
   },
   {
     "id": "ann-e1149-coprime-pairs",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.