### PR TITLE
Enrich erdos-1167: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-1167/annotations.json
+++ b/src/data/proofs/erdos-1167/annotations.json
@@ -40,7 +40,11 @@
       "cardinal cardinality",
       "Ramsey-style definitions"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Dependent Types",
+      "Finset Cardinality",
+      "Subtype Construction"
+    ]
   },
   {
     "id": "ann-e1167-structural",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.