### PR TITLE
Enrich erdos-782: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-782/annotations.json
+++ b/src/data/proofs/erdos-782/annotations.json
@@ -16,7 +16,11 @@
       "quasi-progression",
       "combinatorial-cube"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "number theory",
+      "additive combinatorics",
+      "open problems in mathematics"
+    ]
   },
   {
     "id": "ann-782-squares",
@@ -34,7 +38,11 @@
       "perfect-square",
       "sparse-set"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "elementary number theory",
+      "set theory notation",
+      "Lean 4 definitions"
+    ]
   },
   {
     "id": "ann-782-ap",
@@ -52,7 +60,11 @@
       "arithmetic-progression",
       "fermat"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "elementary number theory",
+      "Diophantine equations",
+      "infinite descent"
+    ]
   },
   {
     "id": "ann-782-quasi",
@@ -70,7 +82,11 @@
       "quasi-progression",
       "bounded-gaps"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "real analysis",
+      "additive combinatorics",
+      "sequences and bounded gaps"
+    ]
   },
   {
     "id": "ann-782-cubes",
@@ -88,7 +104,11 @@
       "combinatorial-cube",
       "boolean-lattice"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "combinatorics",
+      "Boolean lattice",
+      "set theory"
+    ]
   },
   {
     "id": "ann-782-question2",
@@ -106,7 +126,11 @@
       "cube-in-squares",
       "four-squares"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "number theory",
+      "Diophantine equations",
+      "combinatorics"
+    ]
   },
   {
     "id": "ann-782-implication",
@@ -124,7 +148,11 @@
       "implication",
       "ramsey"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "mathematical logic",
+      "Ramsey theory",
+      "combinatorics"
+    ]
   },
   {
     "id": "ann-782-solymosi",
@@ -142,7 +170,11 @@
       "solymosi",
       "conjecture"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "additive combinatorics",
+      "conjectures and open problems",
+      "logical negation"
+    ]
   },
   {
     "id": "ann-782-bombieri",
@@ -161,7 +193,11 @@
       "algebraic-geometry",
       "conditional"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "algebraic geometry",
+      "Diophantine geometry",
+      "number theory"
+    ]
   },
   {
     "id": "ann-782-small",
@@ -179,7 +215,11 @@
       "small-cases",
       "computation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "elementary number theory",
+      "finite computation",
+      "combinatorics"
+    ]
   },
   {
     "id": "ann-782-density",
@@ -198,7 +238,11 @@
       "counting",
       "asymptotic"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "asymptotic analysis",
+      "analytic number theory",
+      "counting arguments"
+    ]
   },
   {
     "id": "ann-782-status",
@@ -217,6 +261,10 @@
       "number-theory",
       "combinatorics"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "additive combinatorics",
+      "algebraic geometry",
+      "open problems in mathematics"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-782`: populated empty per-annotation `prerequisites` arrays with content-grounded foundational background topics. Diff is prerequisites-only; all other fields unchanged.