### PR TITLE
Enrich amgm-inequality-oq-03-oq-01: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01/annotations.json
@@ -111,6 +111,10 @@
       "mean inequality hierarchy",
       "interpolation"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Power Mean Inequality",
+      "Mean Inequality Hierarchy",
+      "Jensen's Inequality"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.