### PR TITLE
Enrich area-of-circle-oq-01-oq-02-oq-01-oq-01: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -192,6 +192,10 @@
       "indexing convention",
       "off-by-two error"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Recurrence Relations",
+      "Gamma Functional Equation",
+      "Unit Ball Volume"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.