### PR TITLE
Enrich area-of-circle-oq-01-oq-02-oq-01-oq-03: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-03/annotations.json
@@ -174,6 +174,10 @@
       "Mathlib dependencies",
       "proof architecture"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Unit N-Ball Volume",
+      "Gamma Function",
+      "Sequence Convergence"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.