### PR TITLE
Enrich area-of-circle-oq-03-oq-02: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/annotations.json
@@ -83,7 +83,11 @@
       "anonymous constructor",
       "term-mode proof"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Anonymous Constructor Syntax",
+      "Logical Conjunction",
+      "Term-Mode Proofs"
+    ]
   },
   {
     "id": "ann-traditional-forms",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.