### PR TITLE
Enrich area-of-circle-oq-03-oq-02-oq-02: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/annotations.json
@@ -17,7 +17,11 @@
       "ring tactic",
       "field_simp tactic"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Polynomial Long Division",
+      "Partial Fraction Decomposition",
+      "Ring Normalization"
+    ]
   },
   {
     "id": "ann-dalzell-positivity",
@@ -36,7 +40,11 @@
       "sign analysis",
       "integral positivity"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Sign Of Products",
+      "Strict Positivity",
+      "Squares Are Nonnegative"
+    ]
   },
   {
     "id": "ann-dalzell-ftc",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.