### PR TITLE
Enrich arithmetic-series-oq-00: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-00/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-00/annotations.json
@@ -17,7 +17,11 @@
       "Pythagorean arithmetic",
       "proof without words"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Sum Of Cubes",
+      "Triangular Numbers",
+      "Odd Number Sums"
+    ]
   },
   {
     "id": "ann-nicomachus-induction",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.