### PR TITLE
Enrich basel-problem-oq-02: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/basel-problem-oq-02/annotations.json
+++ b/src/data/proofs/basel-problem-oq-02/annotations.json
@@ -405,6 +405,10 @@
     "relatedConcepts": [
       "open problems in number theory"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Odd Zeta Values",
+      "Irrationality vs Transcendence",
+      "Open Problems in Number Theory"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.