### PR TITLE
Enrich binomial-theorem-oq-04-oq-02: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02/annotations.json
@@ -190,6 +190,10 @@
       "theorem packaging",
       "conjunction witness"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Logical Conjunction",
+      "Vandermonde's Identity",
+      "Cauchy Product"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.