### PR TITLE
Enrich binomial-theorem-oq-04-oq-03: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-03/annotations.json
@@ -106,6 +106,10 @@
       "subspace counting",
       "decidable equality"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Gaussian Binomial Coefficient",
+      "native_decide Tactic",
+      "Finite Field Subspace Counting"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.