### PR TITLE
Enrich british-flag-theorem-oq-01: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/british-flag-theorem-oq-01/annotations.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/annotations.json
@@ -39,7 +39,11 @@
       "Euclidean distance",
       "sup metric on products"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "Euclidean Distance Formula",
+      "Product Metric Spaces",
+      "Sup Metric"
+    ],
     "crossReferences": []
   },
   {


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.