### PR TITLE
Enrich cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -184,6 +184,10 @@
       "axiom elimination",
       "proof engineering"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Axiom Elimination",
+      "Mathlib Infrastructure",
+      "Proof Formalization"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.