### PR TITLE
Enrich chinese-remainder-constructive-oq-04-oq-02: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-02/annotations.json
@@ -18,7 +18,10 @@
       "ring isomorphism",
       "NatCast"
     ],
-    "prerequisites": ["modular arithmetic", "ring theory"]
+    "prerequisites": [
+      "modular arithmetic",
+      "ring theory"
+    ]
   },
   {
     "id": "ann-imports-namespace-opens",
@@ -32,8 +35,14 @@
     "content": "Imports `Mathlib.Data.ZMod.Basic` (for `ZMod.chineseRemainder`, `ZMod.natCast_eq_natCast_iff`, `ZMod.natCast_zmod_val`, `ZMod.val_lt`) plus the two parent OQ-04 files supplying `CRTList.Satisfies`, `moduli`, `moduliProd`, and `crt_list_minimal_unique`. The `set_option maxHeartbeats 400000` doubles the default to handle the heavy ZMod typeclass elaboration. The `open CRTList ZMod Nat` exposes the API in unqualified form, so theorem statements like `Satisfies x [(a,m),(b,n)]` and `chineseRemainder hmn` read cleanly.",
     "mathContext": "Two parent files anchor the construction: `ChineseRemainderConstructiveOQ04.lean` (list-based formulation, `CRTList.Satisfies`) and `ChineseRemainderConstructiveOQ04OQ04.lean` (uniqueness theorem `crt_list_minimal_unique`). The bridge to `ZMod` lives in this OQ-02 child.",
     "significance": "supporting",
-    "relatedConcepts": ["maxHeartbeats", "namespace organization", "Mathlib.Data.ZMod.Basic"],
-    "prerequisites": ["Lean 4 imports"]
+    "relatedConcepts": [
+      "maxHeartbeats",
+      "namespace organization",
+      "Mathlib.Data.ZMod.Basic"
+    ],
+    "prerequisites": [
+      "Lean 4 imports"
+    ]
   },
   {
     "id": "ann-section-1-helpers",
@@ -47,8 +56,16 @@
     "content": "Four helper lemmas reduce the list-based formulation at length 2 to its essential ingredients: `moduli_pair` ([m,n]), `moduliProd_pair` (m·n), `pairwise_coprime_pair` (reduces `List.Pairwise Coprime` on [m,n] to `Nat.Coprime m n`), and `satisfies_pair_iff` (unpacks `Satisfies x [(a,m),(b,n)]` into the conjunction `x ≡ a [MOD m] ∧ x ≡ b [MOD n]`). The proofs are short `simp` and case-splits on `List.mem_cons`. These lemmas isolate the 'list of length 2' boilerplate so the bridge theorems in Section 2 can focus on the substantive ZMod content.",
     "mathContext": "$\\text{moduli}([(a,m),(b,n)]) = [m,n]$; $\\text{moduliProd}([(a,m),(b,n)]) = m \\cdot n$. Pairwise coprimality of the singleton-tail list collapses to $\\gcd(m,n) = 1$. The 2-element `Satisfies` predicate is precisely the system $x \\equiv a \\pmod m \\land x \\equiv b \\pmod n$.",
     "significance": "supporting",
-    "relatedConcepts": ["List.Pairwise", "Nat.Coprime", "CRTList.Satisfies", "list-of-length-2"],
-    "prerequisites": ["Lean 4 simp tactic", "list pattern matching"]
+    "relatedConcepts": [
+      "List.Pairwise",
+      "Nat.Coprime",
+      "CRTList.Satisfies",
+      "list-of-length-2"
+    ],
+    "prerequisites": [
+      "Lean 4 simp tactic",
+      "list pattern matching"
+    ]
   },
   {
     "id": "ann-map-natcast-key",
@@ -68,7 +85,10 @@
       "map_natCast",
       "ZMod.chineseRemainder"
     ],
-    "prerequisites": ["ring homomorphism", "product NatCast instance"]
+    "prerequisites": [
+      "ring homomorphism",
+      "product NatCast instance"
+    ]
   },
   {
     "id": "ann-bridge-theorem",
@@ -88,7 +108,10 @@
       "ring isomorphism",
       "Chinese Remainder Theorem"
     ],
-    "prerequisites": ["ring isomorphism", "modular arithmetic"]
+    "prerequisites": [
+      "ring isomorphism",
+      "modular arithmetic"
+    ]
   },
   {
     "id": "ann-canonical-bridge",
@@ -102,8 +125,16 @@
     "content": "Two preparatory lemmas for the canonical-form bridge. `chineseRemainder_symm_val_lt` shows the ring-theoretic preimage's `ZMod.val` lies in [0, m·n) (immediate from `ZMod.val_lt` once `NeZero (m*n)` is supplied via `Nat.mul_pos`). `chineseRemainder_symm_satisfies` shows the same preimage satisfies the congruence system: rewrite via the bridge theorem, then close with `ZMod.natCast_zmod_val` (val is right inverse of cast) and `RingEquiv.apply_symm_apply`. Together these establish that the ring-theoretic preimage is a *valid candidate* for the canonical solution.",
     "mathContext": "Let $w = \\phi^{-1}((\\bar a, \\bar b))$. Then $\\text{val}(w) < m \\cdot n$ (range of `ZMod`), and $\\overline{\\text{val}(w)} = w$ (val ∘ cast = id), so $\\phi(\\overline{\\text{val}(w)}) = \\phi(w) = (\\bar a, \\bar b)$. Combined with `satisfies_pair_iff_chineseRemainder`, this gives `Satisfies (val w) [(a,m),(b,n)]`.",
     "significance": "supporting",
-    "relatedConcepts": ["ZMod.val_lt", "ZMod.natCast_zmod_val", "RingEquiv.apply_symm_apply", "NeZero typeclass"],
-    "prerequisites": ["ZMod.val", "ring isomorphism inverse"]
+    "relatedConcepts": [
+      "ZMod.val_lt",
+      "ZMod.natCast_zmod_val",
+      "RingEquiv.apply_symm_apply",
+      "NeZero typeclass"
+    ],
+    "prerequisites": [
+      "ZMod.val",
+      "ring isomorphism inverse"
+    ]
   },
   {
     "id": "ann-canonical-bridge-main",
@@ -123,7 +154,9 @@
       "canonical representative",
       "uniqueness"
     ],
-    "prerequisites": ["unique-existence theorems"]
+    "prerequisites": [
+      "unique-existence theorems"
+    ]
   },
   {
     "id": "ann-section-4-existence-uniqueness",
@@ -137,8 +170,16 @@
     "content": "Two summary theorems package the round-trip. `crt_exists_via_zmod` is an alternative existence proof for the 2-fold CRT — instead of constructing the solution by hand, take `ZMod.val ∘ symm` of the target pair; the witness lies in [0, m·n) and satisfies the system by the lemmas of Section 3a. `crt_unique_two_fold` is uniqueness in the 2-element case: any two solutions in [0, m·n) coincide, by `crt_list_minimal_unique` applied to both. Together they re-prove the existence-and-uniqueness statement of the 2-fold CRT entirely through the ring-theoretic interface.",
     "mathContext": "Existence: $\\exists x \\in [0, m\\cdot n) : \\text{Satisfies}(x, [(a,m),(b,n)])$ — witness is $\\text{val}(\\phi^{-1}((\\bar a, \\bar b)))$. Uniqueness: $x, y \\in [0, m\\cdot n)$ both satisfying the system $\\Rightarrow x = y$. Together: a unique solution in the canonical interval.",
     "significance": "supporting",
-    "relatedConcepts": ["existence-uniqueness", "alternative proof", "ring-theoretic CRT"],
-    "prerequisites": []
+    "relatedConcepts": [
+      "existence-uniqueness",
+      "alternative proof",
+      "ring-theoretic CRT"
+    ],
+    "prerequisites": [
+      "Existence And Uniqueness",
+      "Chinese Remainder Theorem",
+      "ZMod.val"
+    ]
   },
   {
     "id": "ann-concrete-example",
@@ -152,7 +193,13 @@
     "content": "A regression-test theorem: `example_8_mod3_mod5` verifies that the system $x \\equiv 2 \\pmod 3, x \\equiv 3 \\pmod 5$ has the unique solution $x = 8$ in $[0, 15)$. The proof uses `native_decide` for the congruence checks and `crt_unique_two_fold` for uniqueness against an arbitrary candidate. This serves as both a regression test for the API and a Lean-checked instance of the bridge theorems — the value 8 is simultaneously the list-based minimal representative AND the `ZMod.val` of the ring-theoretic preimage `(ZMod.chineseRemainder).symm (2, 3)`.",
     "mathContext": "$8 \\equiv 2 \\pmod 3$ ($8 = 2 \\cdot 3 + 2$) and $8 \\equiv 3 \\pmod 5$ ($8 = 1 \\cdot 5 + 3$). Range: $0 \\leq 8 < 15 = 3 \\cdot 5$. By the unification theorem, $\\text{val}((\\phi^{-1})(\\bar 2, \\bar 3)) = 8$ in $\\mathbb{Z}/15\\mathbb{Z}$.",
     "significance": "supporting",
-    "relatedConcepts": ["native_decide", "regression test", "concrete instance"],
-    "prerequisites": ["Lean 4 native_decide tactic"]
+    "relatedConcepts": [
+      "native_decide",
+      "regression test",
+      "concrete instance"
+    ],
+    "prerequisites": [
+      "Lean 4 native_decide tactic"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.