### PR TITLE
Enrich divisibility-by-3-oq-04: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/divisibility-by-3-oq-04/annotations.json
+++ b/src/data/proofs/divisibility-by-3-oq-04/annotations.json
@@ -130,6 +130,10 @@
       "detection probability",
       "error analysis"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Casting Out Nines",
+      "Digit Sum Modulo 9",
+      "Error Detection Probability"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.