### PR TITLE
Enrich euler-polyhedral-formula-oq-01-oq-01: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01-oq-01/annotations.json
@@ -17,7 +17,11 @@
       "topological embedding",
       "face enumeration"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Planar Graphs",
+      "Euler's Formula",
+      "Integer Coercion"
+    ]
   },
   {
     "id": "ann-fct-edge-bound",
@@ -81,7 +85,11 @@
       "Equiv.swap",
       "injectivity"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Proper Graph Coloring",
+      "Transpositions",
+      "Function Injectivity"
+    ]
   },
   {
     "id": "ann-fct-kempe-chain-def",
@@ -213,6 +221,10 @@
       "Colorable.mono",
       "base case"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Graph Colorability",
+      "Finite Type Cardinality",
+      "Bijections Of Fintypes"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.