### PR TITLE
Enrich factor-remainder-nullstellensatz-oq-02: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/factor-remainder-nullstellensatz-oq-02/annotations.json
+++ b/src/data/proofs/factor-remainder-nullstellensatz-oq-02/annotations.json
@@ -151,6 +151,10 @@
       "MvPolynomial division",
       "Mathlib infrastructure"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Polynomial Method",
+      "MvPolynomial Division",
+      "Combinatorial Nullstellensatz"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.