### PR TITLE
Enrich fermat-two-squares-oq-01: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/fermat-two-squares-oq-01/annotations.json
+++ b/src/data/proofs/fermat-two-squares-oq-01/annotations.json
@@ -376,6 +376,10 @@
       "Jacobi four-square theorem",
       "norm_num tactic"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Sum Of Squares",
+      "Prime Decomposition",
+      "Modular Arithmetic"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.