### PR TITLE
Enrich greens-theorem-oq-02-oq-02: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/greens-theorem-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/greens-theorem-oq-02-oq-02/annotations.json
@@ -16,7 +16,11 @@
       "Boundary orientation",
       "rectLineIntegral"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Green's Theorem In The Plane",
+      "Boundary Orientation Conventions",
+      "Counterexample-Based Soundness Witnesses"
+    ]
   },
   {
     "id": "ann-greens-oq0202-imports-opens",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.