### PR TITLE
research(erdos-1104-oq-01): Mycielskian witnesses for triangle-free chromatic number

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -961,6 +961,7 @@ import Proofs.Erdos1100ProblemProvable
 import Proofs.Erdos1101Problem
 import Proofs.Erdos1102Problem
 import Proofs.Erdos1103Problem
+import Proofs.Erdos1104OQ01
 import Proofs.Erdos1104Problem
 import Proofs.Erdos1105Aristotle
 import Proofs.Erdos1105Problem

--- a/proofs/Proofs/Erdos1104OQ01.lean
+++ b/proofs/Proofs/Erdos1104OQ01.lean
@@ -1,0 +1,281 @@
+/-
+# Erdős Problem #1104 (oq-01) — Mycielskian witnesses for triangle-free chromatic number
+
+Erdős problem #1104 asks for the growth rate of `f(n)`, the maximum chromatic number
+of a triangle-free graph on `n` vertices. The engine behind the lower-bound side is the
+existence of triangle-free graphs of *arbitrarily large* chromatic number — a fact with
+no entirely elementary witness family. The classical constructive source is **Mycielski's
+construction** (1955): from any graph `G` it builds a graph `M(G)` that
+
+  * stays triangle-free whenever `G` is triangle-free, and
+  * has chromatic number exactly one larger: `χ(M(G)) = χ(G) + 1`.
+
+Iterating `M` from `K₂` (chromatic number `2`) produces `C₅`, then the Grötzsch graph,
+and in general triangle-free graphs of chromatic number `k` for every `k ≥ 2`.
+
+Mathlib does **not** contain the Mycielskian. This file builds it from scratch and proves
+the **full** Mycielski theorem, fully machine-checked and `sorry`-free / `axiom`-free:
+
+  * `mycielskian_cliqueFree_three` — triangle-free is preserved by `M`;
+  * `mycielskian_colorable_succ`   — `G.Colorable n → (M G).Colorable (n+1)`, via an
+                                      explicit `(n+1)`-colouring (chromatic *upper* bound);
+  * `mycielskian_colorable_of_succ`— `(M G).Colorable (n+1) → G.Colorable n`, Mycielski's
+                                      recolouring argument (chromatic *lower* bound).
+
+Together the last two give `χ(M(G)) = χ(G) + 1`.  The file then packages the triangle-free
+witness family
+
+  * `mycielskianIter`                  — the `k`-fold Mycielskian of a base graph;
+  * `mycielskianIter_cliqueFree_three` — every iterate of a triangle-free base is
+                                          triangle-free;
+  * `mycielskianIter_colorable`        — the `k`-fold iterate of an `n`-colourable base
+                                          is `(n + k)`-colourable.
+
+Iterating `M` from `K₂` therefore yields triangle-free graphs of every chromatic number
+`≥ 2`, the constructive engine behind the lower-bound side of Erdős #1104.
+
+Reference: https://erdosproblems.com/1104
+-/
+import Mathlib
+
+namespace Erdos1104OQ01
+
+open SimpleGraph
+
+variable {V : Type*} (G : SimpleGraph V)
+
+/-! ## The Mycielskian construction
+
+Vertices of `M(G)` are `Option (V ⊕ V)`:
+* `some (Sum.inl u)` — the *original* copy of `u`;
+* `some (Sum.inr u)` — the *shadow* copy `u'`;
+* `none`             — the apex vertex `z`.
+
+Edges:
+* originals are joined exactly as in `G`;
+* a shadow `u'` is joined to the originals that are `G`-neighbours of `u`
+  (so `u' ~ v` iff `G.Adj u v`);
+* shadows form an independent set;
+* the apex `z` is joined to every shadow and to nothing else.
+-/
+
+/-- Vertex type of the Mycielskian. -/
+abbrev MycVertex (V : Type*) := Option (V ⊕ V)
+
+/-- Raw (pre-symmetrisation) adjacency relation feeding `SimpleGraph.fromRel`. -/
+def mycRel (G : SimpleGraph V) : MycVertex V → MycVertex V → Prop
+  | some (Sum.inl u), some (Sum.inl v) => G.Adj u v
+  | some (Sum.inl u), some (Sum.inr v) => G.Adj u v
+  | some (Sum.inr u), some (Sum.inl v) => G.Adj u v
+  | none,             some (Sum.inr _) => True
+  | _,                _                => False
+
+/-- The Mycielskian `M(G)` of a graph `G`. -/
+def mycielskian (G : SimpleGraph V) : SimpleGraph (MycVertex V) :=
+  SimpleGraph.fromRel (mycRel G)
+
+/-! ### Adjacency characterisations -/
+
+@[simp] lemma adj_orig_orig {u v : V} :
+    (mycielskian G).Adj (some (Sum.inl u)) (some (Sum.inl v)) ↔ G.Adj u v := by
+  rw [mycielskian, fromRel_adj]
+  constructor
+  · rintro ⟨_, h | h⟩
+    · simpa [mycRel] using h
+    · exact (G.adj_comm v u).1 (by simpa [mycRel] using h)
+  · intro h
+    exact ⟨by simp [G.ne_of_adj h], Or.inl (by simpa [mycRel] using h)⟩
+
+@[simp] lemma adj_orig_shadow {u v : V} :
+    (mycielskian G).Adj (some (Sum.inl u)) (some (Sum.inr v)) ↔ G.Adj u v := by
+  rw [mycielskian, fromRel_adj]
+  constructor
+  · rintro ⟨_, h | h⟩
+    · simpa [mycRel] using h
+    · exact (G.adj_comm v u).1 (by simpa [mycRel] using h)
+  · intro h
+    exact ⟨by simp, Or.inl (by simpa [mycRel] using h)⟩
+
+@[simp] lemma adj_shadow_orig {u v : V} :
+    (mycielskian G).Adj (some (Sum.inr u)) (some (Sum.inl v)) ↔ G.Adj u v := by
+  rw [mycielskian, fromRel_adj]
+  constructor
+  · rintro ⟨_, h | h⟩
+    · simpa [mycRel] using h
+    · exact (G.adj_comm v u).1 (by simpa [mycRel] using h)
+  · intro h
+    exact ⟨by simp, Or.inl (by simpa [mycRel] using h)⟩
+
+@[simp] lemma not_adj_shadow_shadow {u v : V} :
+    ¬ (mycielskian G).Adj (some (Sum.inr u)) (some (Sum.inr v)) := by
+  rw [mycielskian, fromRel_adj]
+  rintro ⟨_, h | h⟩ <;> simpa [mycRel] using h
+
+@[simp] lemma adj_apex_shadow {v : V} :
+    (mycielskian G).Adj none (some (Sum.inr v)) := by
+  rw [mycielskian, fromRel_adj]
+  exact ⟨by simp, Or.inl (by simp [mycRel])⟩
+
+@[simp] lemma adj_shadow_apex {v : V} :
+    (mycielskian G).Adj (some (Sum.inr v)) none := by
+  rw [adj_comm]; exact adj_apex_shadow G
+
+@[simp] lemma not_adj_apex_orig {v : V} :
+    ¬ (mycielskian G).Adj none (some (Sum.inl v)) := by
+  rw [mycielskian, fromRel_adj]
+  rintro ⟨_, h | h⟩ <;> simpa [mycRel] using h
+
+@[simp] lemma not_adj_orig_apex {v : V} :
+    ¬ (mycielskian G).Adj (some (Sum.inl v)) none := by
+  rw [adj_comm]; exact not_adj_apex_orig G
+
+@[simp] lemma not_adj_apex_apex :
+    ¬ (mycielskian G).Adj none none := by
+  rw [mycielskian, fromRel_adj]; simp
+
+/-! ## Triangle-free preservation -/
+
+/-- **Mycielski preserves triangle-freeness.**  If `G` has no triangle then neither does
+`M(G)`.  The apex only meets the independent shadow class, so it lies in no triangle; a
+triangle therefore uses at most one shadow (shadows are independent) and projects to a
+triangle of `G`. -/
+theorem mycielskian_cliqueFree_three (h : G.CliqueFree 3) :
+    (mycielskian G).CliqueFree 3 := by
+  classical
+  -- a `G`-triangle is impossible
+  have gtri : ∀ x y z : V, G.Adj x y → G.Adj x z → G.Adj y z → False :=
+    fun x y z hxy hxz hyz => h {x, y, z} (is3Clique_triple_iff.mpr ⟨hxy, hxz, hyz⟩)
+  intro s hs
+  obtain ⟨a, b, c, _, _, _, rfl⟩ := Finset.card_eq_three.mp hs.card_eq
+  obtain ⟨Aab, Aac, Abc⟩ := is3Clique_triple_iff.mp hs
+  rcases a with _ | (a | a) <;> rcases b with _ | (b | b) <;> rcases c with _ | (c | c) <;>
+    simp_all only [adj_orig_orig, adj_orig_shadow, adj_shadow_orig, not_adj_shadow_shadow,
+      adj_apex_shadow, adj_shadow_apex, not_adj_apex_orig, not_adj_orig_apex, not_adj_apex_apex] <;>
+    exact gtri _ _ _ Aab Aac Abc
+
+/-! ## Chromatic upper bound: an explicit `(n+1)`-colouring -/
+
+/-- The Mycielskian colouring built from a colouring `C` of `G`: an original or its shadow
+keep `C`'s colour (lifted along `Fin.castSucc`), and the apex takes the fresh top colour. -/
+def mycColor {n : ℕ} (C : G.Coloring (Fin n)) : MycVertex V → Fin (n + 1)
+  | some (Sum.inl u) => (C u).castSucc
+  | some (Sum.inr u) => (C u).castSucc
+  | none             => Fin.last n
+
+/-- **Mycielski raises colourability by at most one.**  An explicit `(n+1)`-colouring of
+`M(G)` from any `n`-colouring of `G`. -/
+theorem mycielskian_colorable_succ {n : ℕ} (hG : G.Colorable n) :
+    (mycielskian G).Colorable (n + 1) := by
+  obtain ⟨C⟩ := hG
+  refine ⟨Coloring.mk (mycColor G C) ?_⟩
+  intro x y hxy
+  rcases x with _ | (x | x) <;> rcases y with _ | (y | y) <;>
+  first
+    | (exfalso; simpa using hxy)
+    | (simp only [mycColor, ne_eq, Fin.castSucc_inj]; exact C.valid (by simpa using hxy))
+    | (simp only [mycColor]; exact (Fin.castSucc_lt_last _).ne)
+    | (simp only [mycColor]; exact (Fin.castSucc_lt_last _).ne')
+
+/-! ## Chromatic lower bound: Mycielski's recolouring argument
+
+This is the deep half of Mycielski's theorem.  Given a proper `(n+1)`-colouring `C` of
+`M(G)`, write `a := C z` for the apex colour.  Recolour `G` by
+
+  `D u := if C u = a then C u' else C u`
+
+(use the shadow's colour when an original wears the apex colour).  Three facts make `D` a
+proper `n`-colouring of `G`:
+
+* `D` never uses `a`: if `C u ≠ a` we keep `C u ≠ a`; otherwise `D u = C u'`, and the
+  shadow `u'` is adjacent to the apex, so `C u' ≠ C z = a`;
+* `D` is proper: for `G.Adj u v` the originals are adjacent in `M(G)`, so `C u ≠ C v`,
+  hence they cannot *both* equal `a`; in the three remaining cases the relevant vertices
+  (`u'`–`v`, `u`–`v'`, `u`–`v`) are adjacent in `M(G)`, so their colours differ;
+* `D` lands in the `n`-element set `Fin (n+1) \ {a}`, giving an `n`-colouring.
+-/
+
+/-- **Mycielski lowers colourability by exactly one.**  If the Mycielskian `M(G)` is
+`(n+1)`-colourable then `G` is `n`-colourable.  Combined with `mycielskian_colorable_succ`
+(`G.Colorable n → (M G).Colorable (n+1)`) this pins the chromatic number exactly:
+`χ(M(G)) = χ(G) + 1`. -/
+theorem mycielskian_colorable_of_succ {n : ℕ}
+    (h : (mycielskian G).Colorable (n + 1)) : G.Colorable n := by
+  classical
+  obtain ⟨C⟩ := h
+  set a : Fin (n + 1) := C none with ha
+  -- shadow colours all differ from the apex colour
+  have hshadow : ∀ u : V, C (some (Sum.inr u)) ≠ a := fun u =>
+    C.valid (adj_shadow_apex G)
+  -- the recoloured map on originals
+  let D : V → Fin (n + 1) := fun u =>
+    if C (some (Sum.inl u)) = a then C (some (Sum.inr u)) else C (some (Sum.inl u))
+  -- `D` avoids the apex colour
+  have hDne : ∀ u, D u ≠ a := by
+    intro u
+    by_cases hu : C (some (Sum.inl u)) = a
+    · simp only [D, if_pos hu]; exact hshadow u
+    · simp only [D, if_neg hu]; exact hu
+  -- `D` is a proper colouring of `G`
+  have hDvalid : ∀ {u v : V}, G.Adj u v → D u ≠ D v := by
+    intro u v huv
+    have hor : C (some (Sum.inl u)) ≠ C (some (Sum.inl v)) :=
+      C.valid ((adj_orig_orig G).mpr huv)
+    by_cases hu : C (some (Sum.inl u)) = a <;> by_cases hv : C (some (Sum.inl v)) = a
+    · exact absurd (hu.trans hv.symm) hor
+    · simp only [D, if_pos hu, if_neg hv]
+      exact C.valid ((adj_shadow_orig G).mpr huv)
+    · simp only [D, if_neg hu, if_pos hv]
+      exact C.valid ((adj_orig_shadow G).mpr huv)
+    · simp only [D, if_neg hu, if_neg hv]; exact hor
+  -- `D` lands in the `n`-element complement of `{a}`; transport to `Fin n`
+  have hcard : Fintype.card {x : Fin (n + 1) // x ≠ a} = n := by
+    simp only [ne_eq]
+    rw [Fintype.card_subtype_compl]
+    simp
+  let e : {x : Fin (n + 1) // x ≠ a} ≃ Fin n := Fintype.equivFinOfCardEq hcard
+  exact ⟨Coloring.mk (fun u => e ⟨D u, hDne u⟩) (by
+    intro u v huv
+    simp only [ne_eq, EmbeddingLike.apply_eq_iff_eq, Subtype.mk.injEq]
+    exact hDvalid huv)⟩
+
+/-! ## The iterated witness family
+
+Iterating `M` changes the vertex type, so we index the construction by a recursively
+defined vertex type. -/
+
+/-- The vertex type of the `k`-fold Mycielskian of `V`. -/
+def mycVertexIter (V : Type u) : ℕ → Type u
+  | 0     => V
+  | k + 1 => MycVertex (mycVertexIter V k)
+
+/-- The `k`-fold Mycielskian of a graph `G`. -/
+def mycielskianIter {V : Type u} (G : SimpleGraph V) :
+    (k : ℕ) → SimpleGraph (mycVertexIter V k)
+  | 0     => G
+  | k + 1 => mycielskian (mycielskianIter G k)
+
+/-- Every iterate of a triangle-free base graph is triangle-free. -/
+theorem mycielskianIter_cliqueFree_three {V : Type u} {G : SimpleGraph V}
+    (h : G.CliqueFree 3) : ∀ k, (mycielskianIter G k).CliqueFree 3
+  | 0     => h
+  | k + 1 => mycielskian_cliqueFree_three _ (mycielskianIter_cliqueFree_three h k)
+
+/-- The `k`-fold iterate of an `n`-colourable base graph is `(n + k)`-colourable. -/
+theorem mycielskianIter_colorable {V : Type u} {G : SimpleGraph V} {n : ℕ}
+    (hG : G.Colorable n) : ∀ k, (mycielskianIter G k).Colorable (n + k)
+  | 0     => hG
+  | k + 1 => by
+      have := mycielskian_colorable_succ _ (mycielskianIter_colorable hG k)
+      rw [Nat.add_succ]
+      exact this
+
+/-- **Witness family (constructive half).**  From any triangle-free, `n`-colourable base
+graph, the Mycielskian tower yields, for every `k`, a triangle-free graph that is
+`(n + k)`-colourable.  Together with the companion chromatic *lower* bound
+(`χ(M(G)) = χ(G)+1`) this exhibits triangle-free graphs of every chromatic number `≥ n`. -/
+theorem mycielskian_witness_family {V : Type u} {G : SimpleGraph V} {n : ℕ}
+    (htf : G.CliqueFree 3) (hcol : G.Colorable n) (k : ℕ) :
+    (mycielskianIter G k).CliqueFree 3 ∧ (mycielskianIter G k).Colorable (n + k) :=
+  ⟨mycielskianIter_cliqueFree_three htf k, mycielskianIter_colorable hcol k⟩
+
+end Erdos1104OQ01

--- a/research/problems/erdos-1104-oq-01/knowledge.md
+++ b/research/problems/erdos-1104-oq-01/knowledge.md
@@ -1,0 +1,94 @@
+# erdos-1104-oq-01 — Mycielskian witnesses for triangle-free chromatic number
+
+## Problem
+
+Erdős #1104 asks for the growth of `f(n) = max χ(G)` over triangle-free graphs on `n`
+vertices. The lower-bound side rests on the existence of triangle-free graphs of
+arbitrarily large chromatic number. The classical constructive witness is **Mycielski's
+construction** `M(G)`, which preserves triangle-freeness and raises the chromatic number
+by exactly one. This sub-problem formalizes that construction (Mathlib has no Mycielskian)
+and the witness machinery it powers.
+
+## Summary
+
+`proofs/Proofs/Erdos1104OQ01.lean` — 281 lines, **0 sorries, 0 axioms**, `verified`.
+The **full Mycielski theorem**: construction, triangle-free preservation, the `(n+1)`
+upper bound, the recolouring lower bound (`χ(M(G)) = χ(G)+1` pinned exactly), and the
+iterated witness family.
+
+The parent gallery entry `erdos-1104` posits a `mycielski_construction` *axiom*; this
+entry supplies the genuine construction and proves its defining properties.
+
+## Session 2026-06-19 (Session 1) — Build the Mycielskian, FRESH
+
+**Mode**: FRESH · **Outcome**: progress (verified construction + two of the three core
+properties; chromatic lower bound isolated as open crux)
+
+### What I Did
+- Defined the Mycielskian via `SimpleGraph.fromRel` on `Option (V ⊕ V)` (original /
+  shadow / apex), letting `fromRel` discharge symmetry and looplessness.
+- Proved nine adjacency-characterisation `@[simp]` lemmas (one per Option/Sum pair).
+- `mycielskian_cliqueFree_three`: triangle-free preservation, by case analysis on the
+  three triangle vertices, collapsing every surviving case to a `G`-triangle via
+  `is3Clique_triple_iff`.
+- `mycielskian_colorable_succ`: constructive `(n+1)`-colouring (`mycColor`: originals and
+  shadows keep `C`'s colour via `Fin.castSucc`, apex takes `Fin.last n`).
+- Iterated witness family: `mycVertexIter` / `mycielskianIter` (structural recursion on
+  `k`), `mycielskianIter_cliqueFree_three`, `mycielskianIter_colorable`, and
+  `mycielskian_witness_family` packaging both.
+
+### Key Findings
+- `SimpleGraph.fromRel r` (`Adj a b ↔ a ≠ b ∧ (r a b ∨ r b a)`) is the clean way to build
+  a bespoke graph: the raw relation `mycRel` need not be symmetric.
+- Triangle-free preservation hinges on: the apex is in no triangle (only adjacent to the
+  independent shadow class), and a triangle uses ≤ 1 shadow, so it projects to `G`.
+- The chromatic *upper* bound is fully constructive; the matching lower bound is the only
+  hard ingredient.
+
+### Files Modified
+- `proofs/Proofs/Erdos1104OQ01.lean` (new)
+- `proofs/Proofs.lean` (registered import)
+
+### Next Steps
+- Prove the chromatic lower bound `(mycielskian G).Colorable (n+1) → G.Colorable n`
+  (Mycielski's recolouring argument) — the open crux; submit to Aristotle.
+- With the lower bound, conclude `χ(mycielskianIter (cycleGraph 5) k) = k + 3`, giving
+  explicit triangle-free graphs of every chromatic number ≥ 3.
+- Optionally instantiate at a concrete base (`⊤ : SimpleGraph (Fin 2)` or `cycleGraph 5`)
+  for a closed-form witness count.
+
+## Session 2026-06-19 (Session 2) — Close the open crux: chromatic lower bound
+
+**Mode**: CONTINUE · **Outcome**: progress (the previously-open chromatic lower bound is
+now proven; the full Mycielski theorem is complete and machine-checked)
+
+### What I Did
+- Proved `mycielskian_colorable_of_succ`: `(M G).Colorable (n+1) → G.Colorable n`,
+  Mycielski's recolouring argument — the half flagged as the open crux in Session 1.
+- Given a proper `(n+1)`-colouring `C` of `M(G)` with apex colour `a := C none`, recolour
+  `G` by `D u := if C (orig u) = a then C (shadow u) else C (orig u)`.
+- Showed `D` never uses `a` (shadows are apex-adjacent, so `C (shadow u) ≠ a`) and is
+  proper (adjacent originals differ in `C`, so cannot both equal `a`; the remaining three
+  cases use the `u'~v`, `u~v'`, `u~v` edges of `M(G)`).
+- Transported `D` into `Fin n` via `Fintype.equivFinOfCardEq` on the `n`-element
+  complement `{x : Fin (n+1) // x ≠ a}` (`Fintype.card_subtype_compl`).
+
+### Key Findings
+- The recolouring needs no Aristotle: it is an elementary `by_cases` on whether each
+  endpoint's original wears the apex colour, dispatched by the adjacency simp-lemmas.
+- The only non-routine step is packaging "lands in an `n`-element set" as an
+  `n`-colouring — done cleanly by the subtype-complement cardinality + `equivFinOfCardEq`.
+- Combined with `mycielskian_colorable_succ`, this pins `χ(M(G)) = χ(G)+1` exactly.
+
+### Files Modified
+- `proofs/Proofs/Erdos1104OQ01.lean` (added `mycielskian_colorable_of_succ`, 217→281 lines)
+
+### Next Steps
+- Instantiate the witness tower at a concrete base (`cycleGraph 5` / `⊤ : SimpleGraph
+  (Fin 2)`) and combine both bounds to conclude `χ(mycielskianIter base k) = k + base`.
+- Discharge the parent `erdos-1104` `mycielski_construction` axiom against this proof.
+- Consider upstreaming the Mycielskian to Mathlib.
+
+## Mathlib Gaps
+- No Mycielskian construction in Mathlib (`Combinatorics/SimpleGraph/*`) — built here.
+- No `χ(M(G)) = χ(G)+1` theorem — both inequalities are proved in this file.

--- a/research/problems/erdos-1104-oq-01/state.md
+++ b/research/problems/erdos-1104-oq-01/state.md
@@ -1,0 +1,38 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-06-19
+**Iteration**: 2
+
+## Current Focus
+
+Mycielskian construction as the constructive engine for triangle-free graphs of large
+chromatic number (the lower-bound side of Erdős #1104). Built the Mycielskian from
+scratch (absent from Mathlib) and proved the **full Mycielski theorem**: triangle-free
+preservation, the constructive `(n+1)`-colouring upper bound, **and the chromatic lower
+bound** `(M G).Colorable (n+1) → G.Colorable n` (Mycielski's recolouring argument).
+Together the two bounds pin `χ(M(G)) = χ(G)+1` exactly. The iterated witness family is
+packaged on top. 281 lines, 0 sorries, 0 axioms.
+
+## Active Approach
+
+`SimpleGraph.fromRel`-based Mycielskian on `Option (V ⊕ V)`; case analysis on the
+Option/Sum vertex structure for triangle-free preservation; explicit `Coloring.mk`
+using `Fin.castSucc` + apex top colour for the upper bound; for the lower bound, recolour
+`G` by `D u := if C u = a then C u' else C u` (apex colour `a := C z`), show `D` avoids
+`a` and is proper, then transport into `Fin n` via `Fintype.equivFinOfCardEq` on the
+`n`-element complement `Fin (n+1) \ {a}`; structural recursion on the iterate count `k`
+for the witness family.
+
+## Blockers
+
+None — the previously-open chromatic lower bound is now proven. The Mycielski theorem is
+complete and machine-checked.
+
+## Next Steps
+
+- Instantiate the witness tower at a concrete base (`cycleGraph 5` or `⊤ : SimpleGraph
+  (Fin 2)`) and combine both bounds to conclude `χ(mycielskianIter base k) = k + base`.
+- Discharge the parent `erdos-1104` `mycielski_construction` axiom against this
+  verified construction.
+- Consider upstreaming the Mycielskian to Mathlib.

--- a/src/data/research/problems/erdos-1104-oq-01.json
+++ b/src/data/research/problems/erdos-1104-oq-01.json
@@ -1,0 +1,59 @@
+{
+  "slug": "erdos-1104-oq-01",
+  "title": "Mycielskian Witnesses for Triangle-Free Chromatic Number (Erdős #1104)",
+  "status": "in-progress",
+  "phase": "ACT",
+  "path": "full",
+  "tier": "A",
+  "started": "2026-06-19",
+  "lastUpdate": "2026-06-19",
+  "tags": [
+    "erdos",
+    "graph-theory",
+    "chromatic-number",
+    "triangle-free",
+    "mycielskian",
+    "graph-coloring"
+  ],
+  "problemStatement": "Erdős #1104 asks for the growth of f(n) = max χ(G) over triangle-free graphs on n vertices, whose lower-bound side rests on the existence of triangle-free graphs of arbitrarily large chromatic number. Formalize the classical constructive witness — Mycielski's construction M(G) — which is absent from Mathlib: prove it preserves triangle-freeness, gives an explicit (χ(G)+1)-colouring, the matching chromatic lower bound χ(M(G)) = χ(G)+1 (Mycielski's recolouring argument), and an iterated witness family.",
+  "currentState": "Verified Lean file proofs/Proofs/Erdos1104OQ01.lean (281 lines, 0 sorries, 0 axioms): Mycielskian construction via SimpleGraph.fromRel, nine adjacency simp-lemmas, triangle-free preservation, the constructive (n+1)-colouring UPPER bound, AND the Mycielski recolouring LOWER bound (mycielskian_colorable_of_succ: (M G).Colorable (n+1) → G.Colorable n) — together pinning χ(M(G)) = χ(G)+1 exactly — plus the iterated witness family (mycielskianIter, its triangle-freeness and (n+k)-colourability). This is the full Mycielski theorem, machine-checked. The parent erdos-1104 entry posits a mycielski_construction axiom; this entry supplies the genuine construction and discharges its defining properties.",
+  "knowledge": {
+    "insights": [
+      "SimpleGraph.fromRel (Adj a b ↔ a ≠ b ∧ (r a b ∨ r b a)) cleanly builds a bespoke graph from a non-symmetric raw relation, discharging symmetry and looplessness automatically.",
+      "Triangle-free preservation: the apex meets only the independent shadow class so lies in no triangle; a triangle therefore uses at most one shadow and projects to a G-triangle, contradicting triangle-freeness of G.",
+      "The chromatic UPPER bound is fully constructive (originals and shadows reuse C's colour via Fin.castSucc, apex takes Fin.last n).",
+      "Chromatic LOWER bound (the deep half): given a proper (n+1)-colouring C of M(G) with apex colour a := C z, recolour G by D u := if C u = a then C u' else C u (shadow's colour when an original wears the apex colour). D never uses a (shadows are apex-adjacent so avoid a), is proper (adjacent originals differ in C so cannot both equal a; the remaining cases use u'~v / u~v' / u~v edges of M(G)), and lands in the n-element complement Fin (n+1) \\ {a}, transported to Fin n via Fintype.equivFinOfCardEq.",
+      "is3Clique_triple_iff collapses the whole triangle-free case analysis to producing a single G 3-clique."
+    ],
+    "builtItems": [
+      "mycielskian (def): the Mycielskian M(G) on Option (V ⊕ V) — Erdos1104OQ01.lean:74",
+      "mycielskian_cliqueFree_three: triangle-free is preserved by M — Erdos1104OQ01.lean:142",
+      "mycielskian_colorable_succ: G.Colorable n → (M G).Colorable (n+1), explicit (n+1)-colouring (UPPER bound) — Erdos1104OQ01.lean:167",
+      "mycielskian_colorable_of_succ: (M G).Colorable (n+1) → G.Colorable n, the Mycielski recolouring argument (LOWER bound) — Erdos1104OQ01.lean:201",
+      "mycielskianIter / mycielskianIter_cliqueFree_three / mycielskianIter_colorable: the k-fold iterate is triangle-free and (n+k)-colourable — Erdos1104OQ01.lean:252-265",
+      "mycielskian_witness_family: packages the triangle-free, (n+k)-colourable witness tower — Erdos1104OQ01.lean:276"
+    ],
+    "mathlibGaps": [
+      "Mathlib has no Mycielskian construction in Combinatorics/SimpleGraph/* — built from scratch here.",
+      "No chromatic-increment theorem χ(M(G)) = χ(G)+1 — both inequalities proved here."
+    ],
+    "nextSteps": [
+      "Instantiate the witness tower at a concrete base (cycleGraph 5 or ⊤ : SimpleGraph (Fin 2)) and combine both bounds to conclude χ(mycielskianIter base k) = k + base exactly, exhibiting triangle-free graphs of every chromatic number ≥ base.",
+      "Discharge the parent erdos-1104 mycielski_construction axiom against this verified construction.",
+      "Consider upstreaming the Mycielskian to Mathlib (Combinatorics/SimpleGraph)."
+    ],
+    "progressSummary": "COMPLETE Mycielski theorem (0 sorry, 0 axiom): Mycielskian construction + triangle-free preservation + constructive (n+1)-colouring UPPER bound + recolouring LOWER bound (χ(M(G)) = χ(G)+1 pinned exactly) + iterated witness family. The lower bound — previously the open crux — is now machine-checked.",
+    "markdown": "See research/problems/erdos-1104-oq-01/knowledge.md"
+  },
+  "knownResults": [
+    "Mycielski (1955): M(G) preserves triangle-freeness and χ(M(G)) = χ(G)+1; iterating from K₂ gives triangle-free graphs of every chromatic number.",
+    "Erdős #1104: f(n) = Θ(√(n/log n)); lower bound Hefty–Horn–King–Pfender (2025), upper bound Davies–Illingworth (2022); exact constant open."
+  ],
+  "references": [
+    "Mycielski, J. (1955). Sur le coloriage des graphes. Colloq. Math. 3, 161–162.",
+    "https://erdosproblems.com/1104"
+  ],
+  "relatedProofs": [
+    "erdos-1104 (parent: posits the mycielski_construction axiom this entry discharges)"
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes the **Mycielskian construction** as the constructive engine behind the
lower-bound side of Erdős #1104 (triangle-free graphs of arbitrarily large chromatic
number). The Mycielskian is absent from Mathlib, so it is built from scratch on
`Option (V ⊕ V)` via `SimpleGraph.fromRel`, and the **full Mycielski theorem** is proved:

- `mycielskian_cliqueFree_three` — **triangle-free preservation**: `G.CliqueFree 3 → (M G).CliqueFree 3`.
- `mycielskian_colorable_succ` — **constructive upper bound**: `G.Colorable n → (M G).Colorable (n+1)`, via an explicit `Coloring.mk` (`Fin.castSucc` on originals + apex top colour).
- `mycielskian_colorable_of_succ` — **chromatic lower bound**: `(M G).Colorable (n+1) → G.Colorable n`, via Mycielski's recolouring argument (recolour `G` by `D u := if C u = a then C u' else C u`, show `D` avoids the apex colour and is proper, transport into `Fin n`).

Together the two bounds pin `χ(M(G)) = χ(G) + 1` exactly.

On top of the base theorem, the iterated witness family is packaged:

- `mycielskianIter` — the `k`-fold Mycielskian (structural recursion on `k`).
- `mycielskianIter_cliqueFree_three` / `mycielskianIter_colorable` — triangle-freeness and `(n+k)`-colourability of every iterate.
- `mycielskian_witness_family` — constructive half of the witness tower.

## Verification

- **281 lines, 0 sorries, 0 axioms** — fully machine-checked.
- Builds green via `./proofs/scripts/docker-build.sh Proofs.Erdos1104OQ01` (7743 jobs, only cosmetic `simpa`→`simp` linter hints).
- Registered in `proofs/Proofs.lean`.

## Next steps (follow-up)

- Instantiate the tower at a concrete base (`cycleGraph 5` / `⊤ : SimpleGraph (Fin 2)`) to conclude `χ(mycielskianIter base k) = k + base`.
- Discharge the parent `erdos-1104` `mycielski_construction` axiom against this verified construction.
- Candidate for upstreaming the Mycielskian to Mathlib.