### PR TITLE
Enrich isosceles-triangle: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/isosceles-triangle/annotations.json
+++ b/src/data/proofs/isosceles-triangle/annotations.json
@@ -158,6 +158,10 @@
       "API design",
       "theorem export"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Theorem Type Checking",
+      "Lean API Design",
+      "Isosceles Triangle Theorem"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.