### PR TITLE
Enrich lagrange-theorem-oq-03: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-03/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-03/annotations.json
@@ -37,7 +37,11 @@
       "trivial subgroup",
       "coprimality"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Trivial Subgroup",
+      "Coprimality",
+      "Greatest Common Divisor"
+    ]
   },
   {
     "id": "ann-product-formula",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.