### PR TITLE
Enrich navier-stokes-existence: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/navier-stokes-existence/annotations.json
+++ b/src/data/proofs/navier-stokes-existence/annotations.json
@@ -16,7 +16,11 @@
       "Millennium Prize",
       "fluid dynamics"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Partial Differential Equations",
+      "Incompressible Fluid Dynamics",
+      "Global Existence And Smoothness"
+    ]
   },
   {
     "id": "ann-ns-ess-theorem",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.