### PR TITLE
Enrich newton-inductive-step-oq-02: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/newton-inductive-step-oq-02/annotations.json
+++ b/src/data/proofs/newton-inductive-step-oq-02/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-binom-log-concave-reexport",
     "proofId": "newton-inductive-step-oq-02",
-    "range": { "startLine": 39, "endLine": 45 },
+    "range": {
+      "startLine": 39,
+      "endLine": 45
+    },
     "type": "theorem",
     "title": "Re-export: Binomial Log-Concavity from the Parent",
     "content": "`binom_log_concave'` re-exports the parent file's log-concavity result $\\binom{n}{k}^2 \\geq \\binom{n}{k-1} \\binom{n}{k+1}$ (for $1 \\leq k$ and $k+1 \\leq n$) into the current namespace. This is the foundation that ultra-log-concavity (Part I) builds on directly.",
@@ -20,7 +23,10 @@
   {
     "id": "ann-binom-ultra-log-concave",
     "proofId": "newton-inductive-step-oq-02",
-    "range": { "startLine": 51, "endLine": 70 },
+    "range": {
+      "startLine": 51,
+      "endLine": 70
+    },
     "type": "theorem",
     "title": "Ultra-Log-Concavity: The Squared Form",
     "content": "Proves $\\binom{n}{k}^4 \\geq \\binom{n}{k-1}^2 \\binom{n}{k+1}^2$ in 18 lines via the *square-then-factor* trick: from log-concavity $a^2 \\geq bc$ we get $a^2 - bc \\geq 0$. The companion factor $a^2 + bc \\geq 0$ is automatic (sum of nonnegs). The algebraic identity $(a^2 - bc)(a^2 + bc) = a^4 - b^2 c^2$ then gives $a^4 - b^2 c^2 \\geq 0$, closed by `linarith` with the explicit `key : ... = ... := by ring` and the product nonnegativity from `mul_nonneg`.",
@@ -41,7 +47,10 @@
   {
     "id": "ann-esymm-zero-tail",
     "proofId": "newton-inductive-step-oq-02",
-    "range": { "startLine": 77, "endLine": 115 },
+    "range": {
+      "startLine": 77,
+      "endLine": 115
+    },
     "type": "lemma",
     "title": "Zero-Tail Property: e_j = 0 ⇒ e_{j+1} = 0",
     "content": "If a list of nonneg reals has $e_j(\\mathbf{x}) = 0$ (for $j \\geq 1$), then $e_{j+1}(\\mathbf{x}) = 0$ as well. Combinatorial reason: $e_j = 0$ means every $j$-element product of list entries is zero, which forces the list to have *fewer than j* nonzero entries; hence every $(j+1)$-element product is also zero. The proof is by induction on the list with the Pascal-style decomposition $e_{j+1}(x :: xs) = e_{j+1}(xs) + x \\cdot e_j(xs)$.",
@@ -62,7 +71,10 @@
   {
     "id": "ann-esymm-log-concave",
     "proofId": "newton-inductive-step-oq-02",
-    "range": { "startLine": 117, "endLine": 213 },
+    "range": {
+      "startLine": 117,
+      "endLine": 213
+    },
     "type": "theorem",
     "title": "Unnormalized Newton: e_k² ≥ e_{k-1} · e_{k+1}",
     "content": "The classical log-concavity $e_k(\\mathbf{x})^2 \\geq e_{k-1}(\\mathbf{x}) \\cdot e_{k+1}(\\mathbf{x})$ for nonneg lists. Proof by induction on the list length. Boundary cases at $k = 1$ and $k = n$ both reduce to a quadratic-nonneg discriminant argument, where the discriminant simplifies via the Pascal-rule identity $2\\binom{n+1}{p+1} = n(n+1)$. The interior case uses the inductive hypothesis with `esymm_cons` decompositions and the `linear_combination` tactic to discharge the residual algebra.",
@@ -84,7 +96,10 @@
   {
     "id": "ann-esymm-cross-condition",
     "proofId": "newton-inductive-step-oq-02",
-    "range": { "startLine": 219, "endLine": 252 },
+    "range": {
+      "startLine": 219,
+      "endLine": 252
+    },
     "type": "lemma",
     "title": "Cross Condition for esymm Log-Concavity",
     "content": "A private helper packaging the two consecutive instances of the unnormalized Newton inequality (at $k$ and $k-1$) plus the zero-tail property into the `cross_product_of_log_concave` form expected by `newton_cleared_denom_inductive_step`. The cross condition: $e_k \\cdot e_{k-1} \\geq e_{k-2} \\cdot e_{k+1}$. Proof handles three sub-cases via `Nat.lt_or_ge` on the list length, falling back to zero-tail when esymm vanishes by overflow.",
@@ -105,7 +120,10 @@
   {
     "id": "ann-newton-inequality-binomial",
     "proofId": "newton-inductive-step-oq-02",
-    "range": { "startLine": 254, "endLine": 611 },
+    "range": {
+      "startLine": 254,
+      "endLine": 611
+    },
     "type": "theorem",
     "title": "Newton's Inequality (Cleared-Denominator Form)",
     "content": "The headline theorem: $\\binom{n}{k-1} \\binom{n}{k+1} e_k^2 \\geq \\binom{n}{k}^2 e_{k-1} e_{k+1}$ where $n = |\\mathbf{x}|$. Proof by induction on the list length. The k=1 base case is a direct quadratic-nonneg argument via `linear_combination` (the cleared-denominator form simplifies to a discriminant ≥ 0 statement). The inductive step (k ≥ 2) feeds the unnormalized Newton inequality and the cross condition to `newton_cleared_denom_inductive_step` from `AmgmInequalityOQ02OQ02.lean` — that lemma encapsulates the algebraic combinatorial identity needed to descend from $|\\mathbf{x}| = n$ to $|\\mathbf{x}| = n-1$ while preserving the binomial-coefficient weighting.",
@@ -128,7 +146,10 @@
   {
     "id": "ann-imports-architecture",
     "proofId": "newton-inductive-step-oq-02",
-    "range": { "startLine": 1, "endLine": 35 },
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
     "type": "concept",
     "title": "Module Architecture: Three-Layer Dependency",
     "content": "The file imports two parents: `NewtonInductiveStepOQ01` (provides binom_log_concave for Layer 1) and `AmgmInequalityOQ02OQ02` (provides newton_cleared_denom_inductive_step for Layer 3). This three-layer architecture — ultra-log-concavity from log-concavity, unnormalized Newton from zero-tail + boundary, normalized Newton from unnormalized + cross-condition + AMGM identity — is what makes the 611-line proof tractable.",
@@ -139,12 +160,19 @@
       "layered induction",
       "import-driven proof decomposition"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Newton's Inequalities",
+      "Elementary Symmetric Polynomials",
+      "Lean Module Imports"
+    ]
   },
   {
     "id": "ann-newton-binomial-k1-quadratic",
     "proofId": "newton-inductive-step-oq-02",
-    "range": { "startLine": 275, "endLine": 391 },
+    "range": {
+      "startLine": 275,
+      "endLine": 391
+    },
     "type": "insight",
     "title": "k = 1 Base Case: Discriminant Reduction via Pascal Identity",
     "content": "The k = 1 sub-proof inside `newton_inequality_binomial` is a complete quadratic-nonneg argument hand-built from two Pascal-rule identities and the inductive hypothesis at k = 1 on the tail. After unfolding `esymm_cons_succ`, the goal becomes $\\binom{n+1}{2}(E_1 + x)^2 \\geq (n+1)^2 (E_2 + x \\cdot E_1)$, a quadratic in $x$ with $\\alpha = \\binom{n+1}{2}$, $\\beta = -(n+1) E_1$, $\\gamma = \\binom{n+1}{2} E_1^2 - (n+1)^2 E_2$. The classical condition $4 \\alpha \\gamma \\geq \\beta^2$ closes the goal via `quadratic_nonneg`.\n\nThe nontrivial work is showing $4 \\alpha \\gamma \\geq \\beta^2$ — i.e., $(n+1)^2 \\cdot ((n^2 - 1) E_1^2 - 2n(n+1) E_2) \\geq 0$, which factors as $(n+1)^3 \\cdot ((n-1) E_1^2 - 2n E_2) \\geq 0$. This reduces to $E_1^2 \\geq 2 E_2 \\cdot (n / (n-1))$ in the relevant range, recovered from the IH at k = 1 for `xs` (giving $\\binom{n}{2} E_1^2 \\geq n^2 E_2$) plus the Pascal-rule identity $2 \\binom{n}{2} = n(n-1)$.\n\nThe identity $2 \\binom{n}{2} = n(n-1)$ is proved inline by induction on $n$ rather than imported from Mathlib, since the cast to ℝ and the specific shape needed for `linear_combination` make a direct proof more transparent than searching for the right Mathlib lemma. The `linear_combination` invocations at `h4C3` (showing $4(\\binom{n}{2} + n)^2 = (n(n+1))^2$) and `hd_key` (the full discriminant identity) collapse what would otherwise be 50-line `ring` expansions into 1-line cofactor specifications.",
@@ -168,7 +196,10 @@
   {
     "id": "ann-newton-binomial-induction-overflow",
     "proofId": "newton-inductive-step-oq-02",
-    "range": { "startLine": 392, "endLine": 611 },
+    "range": {
+      "startLine": 392,
+      "endLine": 611
+    },
     "type": "insight",
     "title": "k ≥ 2 Inductive Step: Overflow-Aware Case Analysis",
     "content": "The k ≥ 2 sub-proof starts with `obtain ⟨p, rfl⟩ : ∃ p, k = p + 2`, replacing $k$ with $p + 2$ uniformly to eliminate $k - 1$ and $k + 1$ obstructions. Three recurrence equations `rec_k`, `rec_km1`, `rec_kp1` expand $e_{p+2}, e_{p+1}, e_{p+3}$ on the head-cons list via `esymm_cons_succ`. Four abbreviations `ek := esymm xs (p+2)`, `ekm1, ekp1, ekm2` make the algebra readable; their nonnegativity is dispatched once at the top via `esymm_nonneg`.\n\nThree pieces of input data are assembled:\n1. **Unnormalized Newton on `xs` at $p + 2$** and at $p + 1$ — `h_unn_k`, `h_unn_km1` — both with overflow guards (when $p + 3 > n$ or $p + 2 > n$, the relevant $e_j$ is zero by `esymm_eq_zero_of_gt`).\n2. **Cross condition** `h_cross : ek · ekm1 ≥ ekm2 · ekp1` — obtained from `NewtonLogConcavity.cross_product_of_log_concave` plus a zero-tail fallback for the edge case `ekm1 = 0`.\n3. **Two normalized-Newton IHs** `h_ih_k`, `h_ih_km1` — applied at $p + 2$ and $p + 1$ respectively on `xs`, again with overflow guards (when $\\binom{n}{p+3}$ or $\\binom{n}{p+2}$ vanishes, the inequality is trivial).\n\nThe heavy lifting is then delegated to `NewtonLogConcavity.newton_cleared_denom_inductive_step` from `AmgmInequalityOQ02OQ02.lean`, which packages the algebraic combinatorial identity that drives the descent. Finally, a case split on $p + 3 \\leq n$ vs $p + 3 > n$ handles the boundary: when the new variable $x$ pushes $k + 1$ past the list length on `x :: xs`, $\\binom{n+1}{p+3} = 1$ (via $n = p + 2$) but $e_{p+3}(\\mathtt{xs}) = 0$, so the RHS collapses entirely.\n\nThis pattern — destruct via `obtain ⟨p, rfl⟩`, set abbreviations, gather all IH instances upfront with overflow guards, delegate the algebraic core to a packaged lemma — is reusable for any inequality whose induction needs to handle multiple `Nat.choose` overflow patterns simultaneously.",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.