### PR TITLE
Enrich pentagonal-number-theorem-oq-01: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/pentagonal-number-theorem-oq-01/annotations.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/annotations.json
@@ -2,73 +2,135 @@
   {
     "id": "ann-overview",
     "proofId": "pentagonal-number-theorem-oq-01",
-    "range": { "startLine": 1, "endLine": 45 },
+    "range": {
+      "startLine": 1,
+      "endLine": 45
+    },
     "type": "concept",
     "title": "Scope: The Index Theory Beneath Euler's Theorem",
     "content": "The module header fixes the scope of the file. Euler's pentagonal number theorem expands the infinite product `∏_{n≥1}(1-xⁿ)` as the lacunary series `∑_{k∈ℤ}(-1)ᵏx^{g(k)}`, whose exponents are the generalized pentagonal numbers `g(k)=k(3k-1)/2`.\n\n**What is and isn't formalized.** The analytic/combinatorial heart — Franklin's sign-reversing involution and the formal-power-series identity — is deliberately left to the OPEN CORE note (see the final annotation); Mathlib lacks the requisite distinct-partition and power-series machinery. This file instead supplies the *number-theoretic index theory* that any such formalization consumes: the recognition criterion, the doubling relation, injectivity, and the OEIS A001318 values.\n\n**Indexing convention.** The exponents are indexed by `k : ℤ` (not `ℕ`): the order `k = 0, 1, -1, 2, -2, …` enumerates the generalized pentagonal numbers in increasing order. The single `import Mathlib` and `maxHeartbeats 400000` are the only build prerequisites.",
     "mathContext": "$\\prod_{n\\ge1}(1-x^n)=\\sum_{k\\in\\mathbb{Z}}(-1)^k x^{g(k)}$, $\\;g(k)=\\tfrac{k(3k-1)}{2}$, indexed by $k\\in\\mathbb{Z}$.",
     "significance": "supporting",
-    "relatedConcepts": ["pentagonal number theorem", "lacunary series", "generating functions", "OEIS A001318"],
-    "prerequisites": ["integer partitions", "generating functions"]
+    "relatedConcepts": [
+      "pentagonal number theorem",
+      "lacunary series",
+      "generating functions",
+      "OEIS A001318"
+    ],
+    "prerequisites": [
+      "integer partitions",
+      "generating functions"
+    ]
   },
   {
     "id": "ann-setup",
     "proofId": "pentagonal-number-theorem-oq-01",
-    "range": { "startLine": 47, "endLine": 67 },
+    "range": {
+      "startLine": 47,
+      "endLine": 67
+    },
     "type": "definition",
     "title": "Division-Free Generalized Pentagonal Numbers",
     "content": "Defines `genPent k = k*(3*k-1)/2` and the membership predicate `IsGenPent m := ∃ k, 2*m = k*(3*k-1)`.\n\n**Why the doubling relation.** Integer division is awkward to reason about, so membership is phrased through `2*m = k*(3*k-1)` rather than `m = k*(3*k-1)/2`. The two agree because `k*(3*k-1)` is always even: if `k` is even the first factor is, otherwise `3k-1 = 3k-1` is even. `two_dvd_index_mul` proves the evenness by an even/odd split, and `two_mul_genPent` then certifies `2·g(k) = k(3k-1)` via `Int.mul_ediv_cancel'`. `genPent_isGenPent` records that every value `g(k)` is in the membership set.",
     "mathContext": "$g(k) = k(3k-1)/2$ with $2g(k) = k(3k-1)$; one of $k$, $3k-1$ is even, so the half is exact.",
     "significance": "supporting",
-    "relatedConcepts": ["generalized pentagonal numbers", "parity", "integer division"],
-    "prerequisites": ["parity of integers"]
+    "relatedConcepts": [
+      "generalized pentagonal numbers",
+      "parity",
+      "integer division"
+    ],
+    "prerequisites": [
+      "parity of integers"
+    ]
   },
   {
     "id": "ann-criterion",
     "proofId": "pentagonal-number-theorem-oq-01",
-    "range": { "startLine": 68, "endLine": 116 },
+    "range": {
+      "startLine": 68,
+      "endLine": 116
+    },
     "type": "theorem",
     "title": "The Square-Discriminant Recognition Criterion",
     "content": "Proves `isGenPent_iff_isSquare`: `m` is a generalized pentagonal number iff `24m+1` is a perfect square.\n\n**Forward.** From `2m = k(3k-1)`, the polynomial identity `24m+1 = (6k-1)²` follows by a single `linear_combination 12 * hk`, exhibiting the witness `6k-1`.\n\n**Converse.** Given `24m+1 = s²`, reduce in `ZMod 6`: `s² = 1` there (since `24 ≡ 0`), and a six-element `decide` shows the only roots are `1` and `5`, i.e. `s ≡ ±1 (mod 6)`. Each case gives `6 ∣ (s∓1)`, hence `s = 6k±1`; substituting into `24m+1 = s²` and cancelling the common factor `12` (`mul_left_cancel₀`) recovers `2m = k'(3k'-1)` for the index `k' = -k` or `k+1`.",
     "mathContext": "$24\\,g(k)+1 = (6k-1)^2$; conversely $s^2 = 24m+1 \\Rightarrow s \\equiv \\pm1 \\pmod 6 \\Rightarrow 6k-1 = \\pm s$.",
     "significance": "key",
-    "relatedConcepts": ["perfect square", "modular arithmetic", "ZMod", "Euler partition recurrence"],
-    "prerequisites": ["divisibility", "residues mod 6"]
+    "relatedConcepts": [
+      "perfect square",
+      "modular arithmetic",
+      "ZMod",
+      "Euler partition recurrence"
+    ],
+    "prerequisites": [
+      "divisibility",
+      "residues mod 6"
+    ]
   },
   {
     "id": "ann-structural",
     "proofId": "pentagonal-number-theorem-oq-01",
-    "range": { "startLine": 118, "endLine": 139 },
+    "range": {
+      "startLine": 118,
+      "endLine": 139
+    },
     "type": "theorem",
     "title": "Nonnegativity and Injectivity of the Index Map",
     "content": "`isGenPent_nonneg` shows generalized pentagonal numbers are `≥ 0` by a sign analysis of the two factors of `k(3k-1)`.\n\n`genPent_injective` shows the index map is injective: from `genPent a = genPent b`, multiplying by 2 gives `a(3a-1) = b(3b-1)`, which `linear_combination` rearranges to `(a-b)(3(a+b)-1) = 0`. Since `3(a+b) = 1` has no integer solution (`omega`), the only factor that can vanish is `a-b`, so `a = b`.",
     "mathContext": "$(a-b)(3(a+b)-1)=0$ with $3(a+b)\\neq1$ over $\\mathbb{Z}$ forces $a=b$.",
     "significance": "supporting",
-    "relatedConcepts": ["injectivity", "factorization over ℤ"],
-    "prerequisites": ["integer factorization of a product equal to zero"]
+    "relatedConcepts": [
+      "injectivity",
+      "factorization over ℤ"
+    ],
+    "prerequisites": [
+      "integer factorization of a product equal to zero"
+    ]
   },
   {
     "id": "ann-values",
     "proofId": "pentagonal-number-theorem-oq-01",
-    "range": { "startLine": 141, "endLine": 159 },
+    "range": {
+      "startLine": 141,
+      "endLine": 159
+    },
     "type": "concept",
     "title": "Concrete Values (OEIS A001318)",
     "content": "The first generalized pentagonal numbers, indexed `k = 0,1,-1,2,-2,…`, are `0,1,2,5,7,12,15,22,26`, each proved from the doubling relation by `omega`. The sanity check `twelve_isGenPent` confirms the recognition criterion fires: `12 = g(3)` is pentagonal because `24·12+1 = 289 = 17²`.",
     "mathContext": "Indexing $k=0,1,-1,2,-2,\\dots$ enumerates A001318 in increasing order.",
     "significance": "supporting",
-    "relatedConcepts": ["OEIS A001318", "pentagonal numbers"],
-    "prerequisites": []
+    "relatedConcepts": [
+      "OEIS A001318",
+      "pentagonal numbers"
+    ],
+    "prerequisites": [
+      "Generalized Pentagonal Numbers",
+      "OEIS Integer Sequences",
+      "Perfect Square Discriminant"
+    ]
   },
   {
     "id": "ann-open-core",
     "proofId": "pentagonal-number-theorem-oq-01",
-    "range": { "startLine": 161, "endLine": 177 },
+    "range": {
+      "startLine": 161,
+      "endLine": 177
+    },
     "type": "insight",
     "title": "The Open Core: Franklin's Involution and the Generating Identity",
     "content": "Documents what this file deliberately does *not* prove: the analytic/combinatorial heart of the theorem.\n\n**The identity.** In the ring of formal power series $\\mathbb{Z}[\\![X]\\!]$, Euler's theorem asserts $\\prod_{n\\ge1}(1-X^n) = \\sum_{k\\in\\mathbb{Z}}(-1)^k X^{g(k)}$. Equivalently, letting $p_{\\mathrm{even}}(n)$ and $p_{\\mathrm{odd}}(n)$ count partitions of $n$ into an even/odd number of *distinct* parts, $p_{\\mathrm{even}}(n)-p_{\\mathrm{odd}}(n)$ equals $(-1)^k$ when $n=g(k)$ and $0$ otherwise.\n\n**Franklin's involution (1881).** The bijective proof builds a sign-reversing involution on partitions into distinct parts using the two statistics $s$ (smallest part) and $\\sigma$ (length of the longest 'staircase' run ending at the largest part). Either the smallest part moves up or the staircase moves down, pairing each partition with one of opposite parity — *except* the staircase partitions $j{+}(j{+}1){+}\\cdots{+}(2j{-}1)$ and their variants, the unmatched fixed points, which sit exactly at $n=g(\\pm j)$ and contribute the surviving $(-1)^k$ term.\n\n**Why it is out of scope.** Mathlib has `Nat.Partition` but not distinct-part partitions with a parity sign, not Franklin's involution, and not the formal-power-series infinite product. This entry supplies the index-set theory (`isGenPent_iff_isSquare`, `genPent_injective`) that any such formalization would consume to locate the surviving exponents.",
     "mathContext": "$\\prod_{n\\ge1}(1-X^n)=\\sum_{k\\in\\mathbb{Z}}(-1)^k X^{g(k)}$; fixed points of Franklin's involution occur precisely at $n=g(k)$.",
     "significance": "supporting",
-    "relatedConcepts": ["Franklin's involution", "partitions into distinct parts", "formal power series", "generating functions", "sign-reversing involution"],
-    "prerequisites": ["integer partitions", "generating functions", "involutions and bijective combinatorics"]
+    "relatedConcepts": [
+      "Franklin's involution",
+      "partitions into distinct parts",
+      "formal power series",
+      "generating functions",
+      "sign-reversing involution"
+    ],
+    "prerequisites": [
+      "integer partitions",
+      "generating functions",
+      "involutions and bijective combinatorics"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.