### PR TITLE
Enrich shannon-channel-coding-bec-oq-01: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/shannon-channel-coding-bec-oq-01/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-01/annotations.json
@@ -39,7 +39,11 @@
       "joint distribution",
       "law of total probability"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Marginal Distribution",
+      "Joint Distribution",
+      "Finset.sum_eq_single"
+    ]
   },
   {
     "id": "ann-qec-conditional-entropy",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.