### PR TITLE
Enrich shannon-channel-coding-oq-01: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-01/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-oq-01/annotations.json
@@ -40,7 +40,11 @@
       "noise model",
       "AWGN"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Additive Noise Channel",
+      "Conditional Probability Density",
+      "Density Of A Shift"
+    ]
   },
   {
     "id": "ann-conditional-entropy-eq",
@@ -127,7 +131,11 @@
       "KL divergence",
       "conditional entropy"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Mutual Information",
+      "Differential Entropy",
+      "Entropy Chain Rule"
+    ]
   },
   {
     "id": "ann-decomposition",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.