### PR TITLE
Enrich shannon-source-coding-oq-02: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/shannon-source-coding-oq-02/annotations.json
+++ b/src/data/proofs/shannon-source-coding-oq-02/annotations.json
@@ -105,7 +105,11 @@
       "positivity",
       "exponential function"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Positivity Of Exponentials",
+      "Negative Exponents",
+      "Real Power Function"
+    ]
   },
   {
     "id": "ann-log-kraft",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.