### PR TITLE
Enrich sperner-ndim-oq-03-oq-01: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/sperner-ndim-oq-03-oq-01/annotations.json
@@ -16,7 +16,11 @@
       "continuous_id",
       "continuousOn"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Intermediate Value Theorem",
+      "Continuous Functions",
+      "Fixed-Point Theorem"
+    ]
   },
   {
     "id": "ann-intermediate-value2",
@@ -35,7 +39,11 @@
       "isPreconnected_Icc",
       "ContinuousOn"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Intermediate Value Theorem",
+      "Connected Sets",
+      "Continuity On A Set"
+    ]
   },
   {
     "id": "ann-contractive-uniqueness",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.