### PR TITLE
Enrich sqrt2-irrational: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/sqrt2-irrational/annotations.json
+++ b/src/data/proofs/sqrt2-irrational/annotations.json
@@ -11,7 +11,11 @@
     "content": "Three Mathlib modules power this formalization:\n\n1. **`Mathlib.Data.Real.Irrational`**: Defines the `Irrational` predicate (`x : ℝ` is irrational iff `x ∉ ℚ` embedded in `ℝ`) and supplies the key lemmas: `irrational_sqrt_two` (main result), `Nat.Prime.irrational_sqrt` (√p is irrational for prime p), and `irrational_sqrt_natCast_iff` (√n irrational iff n is not a perfect square).\n\n2. **`Mathlib.Algebra.Ring.Parity`**: Provides the `Even` and `Odd` predicates and their algebraic properties — in particular `Odd.pow` (odd^n = odd) and `Int.odd_iff_not_even`, which are essential for the classical parity argument.\n\n3. **`Mathlib.Tactic`**: Imports all standard Lean 4 tactics (`omega`, `ring`, `decide`, `by_contra`, `by_cases`, `obtain`, etc.) used throughout the pedagogical proof demonstrations.",
     "mathContext": "The central Mathlib predicate: $x \\in \\mathbb{R}$ is **irrational** iff $x \\notin \\iota(\\mathbb{Q})$ where $\\iota : \\mathbb{Q} \\hookrightarrow \\mathbb{R}$ is the canonical embedding. In Lean: `Irrational x ↔ x ∉ Set.range ((↑) : ℚ → ℝ)`. The key Mathlib theorem `irrational_sqrt_two : Irrational (Real.sqrt 2)` is available directly; this file wraps and extends it with pedagogical proofs.",
     "significance": "supporting",
-    "prerequisites": [],
+    "prerequisites": [
+      "Real Numbers",
+      "Rational Embedding",
+      "Lean Import System"
+    ],
     "relatedConcepts": [
       "Irrational predicate in Mathlib",
       "Real.sqrt",
@@ -31,7 +35,11 @@
     "content": "A real number $x$ is **irrational** if for all integers $p, q$ with $q \\neq 0$, we have $x \\neq p/q$. This is the negation of rationality: there is no way to express $x$ as a ratio of integers.",
     "mathContext": "In Lean, this is a universal statement: `∀ p q : ℤ, q ≠ 0 → x ≠ p / q`. The proof will show this holds for $x = \\sqrt{2}$ by contradiction.",
     "significance": "key",
-    "prerequisites": [],
+    "prerequisites": [
+      "Rational Numbers",
+      "Integer Ratios",
+      "Universal Quantification"
+    ],
     "relatedConcepts": [
       "rational numbers",
       "negation",
@@ -50,7 +58,11 @@
     "content": "Two integers $p$ and $q$ are **coprime** (or relatively prime) if their greatest common divisor is 1: $\\gcd(p, q) = 1$. Equivalently, they share no prime factors.",
     "mathContext": "Every rational number can be written in lowest terms $p/q$ where $p$ and $q$ are coprime. This is crucial for the contradiction—if both are even, they're not coprime.",
     "significance": "key",
-    "prerequisites": [],
+    "prerequisites": [
+      "Greatest Common Divisor",
+      "Prime Factorization",
+      "Lowest Terms"
+    ],
     "relatedConcepts": [
       "GCD",
       "lowest terms",
@@ -69,7 +81,11 @@
     "content": "**The key lemma**: If $n^2$ is even, then $n$ is even. The proof uses the contrapositive: assume $n$ is odd, show $n^2$ is odd, contradicting that $n^2$ is even.",
     "mathContext": "Why does odd$^2$ = odd? Write $n = 2k+1$. Then $n^2 = 4k^2 + 4k + 1 = 2(2k^2 + 2k) + 1$, which is odd. The tactic `Odd.pow` handles this in Lean.",
     "significance": "key",
-    "prerequisites": [],
+    "prerequisites": [
+      "Even And Odd Integers",
+      "Contrapositive Proof",
+      "Proof By Contradiction"
+    ],
     "relatedConcepts": [
       "contrapositive",
       "parity",
@@ -151,7 +167,11 @@
     "content": "This section contains six standalone educational theorems demonstrating core Lean 4 proof techniques. These are NOT part of the main irrationality argument — they serve as a teaching supplement showing how different tactic paradigms apply to simple mathematical facts:\n\n- **`int_sq_nonneg`**: `by_cases` on sign of $n$; uses `sq_nonneg` and `sq_pos_of_neg`. Demonstrates case splitting on a decidable condition.\n- **`sq_add_formula`**: $(a+b)^2 = a^2 + 2ab + b^2$; closed by `ring`. Shows algebraic identity verification.\n- **`imp_trans`**: If $P \\to Q$ and $Q \\to R$, then $P \\to R$; proved by `intro`/`apply` chains. Demonstrates basic propositional logic.\n- **`not_and_iff_or_not`**: De Morgan's law $\\neg(P \\wedge Q) \\iff \\neg P \\vee \\neg Q$; proved with `by_cases` and `cases`. Shows logical equivalence reasoning.\n- **`add_zero_nat`**: $n + 0 = n$; proved by `induction` with `rfl` and `simp`. Demonstrates structural induction on `ℕ`.\n- **`exists_gt_nat`**: $\\forall n \\in \\mathbb{N}, \\exists m > n$; proved via `use n + 1` and `omega`. Shows existential witness construction.",
     "mathContext": "These examples illustrate the main Lean 4 proof paradigms: (1) case analysis (`by_cases`, `by_contra`), (2) algebraic automation (`ring`, `omega`), (3) structural induction (`induction ... with`), (4) existential/universal reasoning (`use`, `intro`), and (5) logical connective manipulation (`constructor`, `cases`). Collectively they show that Lean 4 proofs span a spectrum from near-automatic (`ring`, `decide`) to fully explicit (`intro`/`apply` chains).",
     "significance": "supporting",
-    "prerequisites": [],
+    "prerequisites": [
+      "Lean Tactic Mode",
+      "Mathematical Induction",
+      "Propositional Logic"
+    ],
     "relatedConcepts": [
       "Lean 4 tactics",
       "ring tactic",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.