### PR TITLE
Enrich szemeredi-full: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/szemeredi-full/annotations.json
+++ b/src/data/proofs/szemeredi-full/annotations.json
@@ -83,7 +83,11 @@
       "pigeonhole principle",
       "nonempty sets"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Nonempty Finsets",
+      "Density Lower Bounds",
+      "Witness Extraction"
+    ]
   },
   {
     "id": "ann-k2-case-split",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.