### PR TITLE
Enrich taylor-sincos-convergence-oq-01: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/taylor-sincos-convergence-oq-01/annotations.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-01/annotations.json
@@ -249,6 +249,10 @@
       "Lean 4 #check command",
       "namespace closure"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Lean 4 #check Command",
+      "Theorem Type Signatures",
+      "Namespace Scoping"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.