### PR TITLE
Enrich vietas-formulas-oq-02: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/vietas-formulas-oq-02/annotations.json
+++ b/src/data/proofs/vietas-formulas-oq-02/annotations.json
@@ -130,6 +130,10 @@
       "Vieta's formulas",
       "norm_num"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Newton's Identities",
+      "Vieta's Formulas",
+      "Decidable Evaluation"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.