### PR TITLE
Enrich erdos-510: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-510/annotations.json
+++ b/src/data/proofs/erdos-510/annotations.json
@@ -132,7 +132,11 @@
       "Balog-Szemerédi-Gowers theorem",
       "history of exponential sum bounds"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Exponential Sum Bounds",
+      "Balog-Szemerédi-Gowers Theorem",
+      "Sumset Estimates"
+    ]
   },
   {
     "id": "erdos-510-ann-sidon",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.