### PR TITLE
Enrich erdos-515: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-515/annotations.json
+++ b/src/data/proofs/erdos-515/annotations.json
@@ -84,7 +84,11 @@
       "Uniform vs. pointwise convergence",
       "Baire category arguments"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Quantifier Order",
+      "Uniform Versus Pointwise",
+      "Existential And Universal Quantifiers"
+    ]
   },
   {
     "id": "ann-e515-partial",
@@ -168,6 +172,10 @@
       "Axiom-based formalization",
       "Quantifier structure in analysis"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Axiomatized Theorems",
+      "Logical Conjunction",
+      "Quantifier Structure"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.