### PR TITLE
Enrich erdos-561: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-561/annotations.json
+++ b/src/data/proofs/erdos-561/annotations.json
@@ -17,7 +17,11 @@
       "star graphs",
       "edge coloring"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Ramsey Theory",
+      "Star Graphs",
+      "Edge Coloring"
+    ]
   },
   {
     "id": "ann-e561-star",
@@ -36,7 +40,11 @@
       "complete bipartite graphs",
       "claw graph"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Complete Bipartite Graphs",
+      "Graph Edges And Vertices",
+      "Claw Graph"
+    ]
   },
   {
     "id": "ann-e561-union",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.