### PR TITLE
Enrich erdos-606-oq-03-oq-03: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-606-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/erdos-606-oq-03-oq-03/annotations.json
@@ -151,6 +151,10 @@
       "sorry elimination",
       "proof completion roadmap"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "axiom and sorry status",
+      "extremal argument",
+      "finite set minimum"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.