### PR TITLE
Enrich erdos-702: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-702/annotations.json
+++ b/src/data/proofs/erdos-702/annotations.json
@@ -165,7 +165,11 @@
       "Problem #703",
       "compression"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "Shifting Technique",
+      "Extremal Set Theory",
+      "k-Uniform Family"
+    ],
     "significance": "key"
   },
   {


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.