### PR TITLE
Enrich erdos-706: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-706/annotations.json
+++ b/src/data/proofs/erdos-706/annotations.json
@@ -136,7 +136,11 @@
       "girth constraint",
       "Wormald graph"
     ],
-    "prerequisites": [],
+    "prerequisites": [
+      "Hadwiger-Nelson Problem",
+      "Unit Distance Graph",
+      "Graph Girth"
+    ],
     "significance": "key"
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.