### PR TITLE
Enrich erdos-754: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-754/annotations.json
+++ b/src/data/proofs/erdos-754/annotations.json
@@ -21,7 +21,11 @@
       "favorite-distances",
       "solved-problem"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Euclidean Distance Geometry",
+      "Erdős Distance Problems",
+      "Extremal Combinatorics"
+    ]
   },
   {
     "id": "ann-e754-point-config",
@@ -102,7 +106,11 @@
       "favorite-distance"
     ],
     "mathContext": "See annotation content for formal details of favorite count",
-    "prerequisites": []
+    "prerequisites": [
+      "Equidistant Set",
+      "Supremum Over Distances",
+      "Sphere Incidences"
+    ]
   },
   {
     "id": "ann-e754-function-f",
@@ -155,7 +163,11 @@
       "construction",
       "avis-erdos-pach"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Clifford Torus",
+      "Orthogonal Circles",
+      "Extremal Constructions"
+    ]
   },
   {
     "id": "ann-e754-distance-assign",
@@ -179,7 +191,11 @@
       "function-type"
     ],
     "mathContext": "See annotation content for formal details of distance assignment",
-    "prerequisites": []
+    "prerequisites": [
+      "Function Types",
+      "Favorite Distance",
+      "Generalized Bounds"
+    ]
   },
   {
     "id": "ann-e754-swanepoel-main",
@@ -203,7 +219,11 @@
       "swanepoel",
       "quadratic-bound"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Double Counting",
+      "Quadratic Upper Bounds",
+      "Distance Pair Counting"
+    ]
   },
   {
     "id": "ann-e754-swanepoel-answer",
@@ -227,7 +247,11 @@
       "tight-bound"
     ],
     "mathContext": "See annotation content for formal details of swanepoel solves erdős 754",
-    "prerequisites": []
+    "prerequisites": [
+      "Asymptotic Notation",
+      "Matching Bounds",
+      "Big-O Estimates"
+    ]
   },
   {
     "id": "ann-e754-solved",
@@ -251,7 +275,11 @@
       "main-result"
     ],
     "mathContext": "See annotation content for formal details of problem solved",
-    "prerequisites": []
+    "prerequisites": [
+      "Lower And Upper Bounds",
+      "Theta Asymptotics",
+      "Additive Constants"
+    ]
   },
   {
     "id": "ann-e754-higher-dim",
@@ -275,7 +303,11 @@
       "dimension-dependence"
     ],
     "mathContext": "See annotation content for formal details of higher dimensions",
-    "prerequisites": []
+    "prerequisites": [
+      "Clifford Torus",
+      "Dimension Dependence",
+      "Linear Growth Bounds"
+    ]
   },
   {
     "id": "ann-e754-summary",


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.