### PR TITLE
Enrich erdos-806: add per-annotation prerequisites

### DIFF
--- a/src/data/proofs/erdos-806/annotations.json
+++ b/src/data/proofs/erdos-806/annotations.json
@@ -151,7 +151,11 @@
       "Existence theorem",
       "Erdős Problem #333"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Additive Bases",
+      "Sumset Definition",
+      "Square Root Bound"
+    ]
   },
   {
     "id": "ann-e806-tight-bound",
@@ -262,6 +266,10 @@
       "Problem resolution",
       "Erdős Problem #333"
     ],
-    "prerequisites": []
+    "prerequisites": [
+      "Additive Combinatorics",
+      "Little-o Notation",
+      "Asymptotic Bounds"
+    ]
   }
 ]


### PR DESCRIPTION
Fills empty per-annotation `prerequisites` arrays with 2-3 grounded prerequisite concepts each, based on annotation content. Enrichment-only; no Lean/proof changes.