### PR TITLE
research(erdos-998-oq-04): gallery entry for completed three-gap (Steinhaus) theorem

### DIFF
--- a/research/problems/erdos-998-oq-04/meta.json
+++ b/research/problems/erdos-998-oq-04/meta.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-998-oq-04",
   "title": "Three-Gap (Steinhaus) Theorem: formalization path via Finset and order theory",
-  "phase": "ACT",
-  "status": "in-progress",
+  "phase": "DONE",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -27,10 +27,11 @@
     "goal": "Discharge exists_gap_triple to obtain a sorry-free three_gap and three_gap_additive; then build, register in Proofs.lean, and add a gallery entry."
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-06-18T00:00:00Z",
-    "iteration": 10,
-    "focus": "researcher-10, 2026-06-19 (S10): BACKEND PARTIALLY RECOVERED. Aristotle MCP prove_file STILL returns 404 'Resource not found' (now S4-S10, the HTTP/MCP endpoint remains offline). BUT the Aristotle CLI (uvx --from aristotlelib aristotle) IS LIVE — a sibling klein job a1441c24 is actively running at it. So the designated STEP-D solver is reachable after all, just via CLI not MCP. ACTION TAKEN: submitted the whole self-contained file (Mathlib-only import; defs orbit/forwardGap/gapLengths + all helper lemmas inline; witnesses a,b,c already fixed; lone sorry = exists_gap_triple N>=2 case) to Aristotle CLI `submit --project-dir`, project_id 9d6ef543-1f33-43ae-82d0-a82cacb03440. Awaiting result; check with `uvx --from aristotlelib aristotle show 9d6ef543-1f33-43ae-82d0-a82cacb03440`. Docker still gated (5 lean containers, load ~9 / 7.65 GiB VM) so no manual build attempted. CALIBRATION (unchanged): STEP D is the full Sos-Suranyi-Swierczkowski / van Ravenstein three-gap classification — research-grade (Coq proof is hundreds of lines), NOT a quick manual win; the subtle core is that min(F_k,B_k) cannot land strictly inside (min a b, a+b). Aristotle is the right tool.",
+    "phase": "DONE",
+    "since": "2026-06-19T16:00:00Z",
+    "iteration": 11,
+    "focus": "researcher-7, 2026-06-19 (S11): COMPLETE. Aristotle CLI job 829de833 (project 9d6ef543) returned COMPLETE — it discharged STEP D (exists_gap_triple N>=2, the Sos-Suranyi-Swierczkowski / van Ravenstein classification) as a self-contained Mathlib-only index-arithmetic core (regional bounds region_fwd/bwd/long, value_long, forwardGap_classify, final assembly). The proved file (760 LOC, 0 axiom, 0 code-sorry; 4 textual 'sorry' are docstrings only) was merged to main via #26579 and is registered in Proofs.lean. Aristotle's #print axioms confirms three_gap / three_gap_additive / exists_gap_triple depend only on propext, Classical.choice, Quot.sound. Auditor re-audited CLEAN (760L/0ax/0sorry/22thm/3def). ACTION: built the gallery entry (src/data/proofs/erdos-998-oq-04/ meta.json + 10 annotations, all line-ranges validated 0 misaligned, status verified/badge verified/axiomCount 0) and shipped completion PR #26764. Marked problem completed and released claim. Docker was OOM-gated (load ~11 / 11 lean containers) so the in-repo green build remains Aristotle-asserted + audited rather than re-run this session; this is the only residual confirmation step.",
+    "_legacyFocusS10": "researcher-10, 2026-06-19 (S10): BACKEND PARTIALLY RECOVERED. Aristotle MCP prove_file STILL returns 404 'Resource not found' (now S4-S10, the HTTP/MCP endpoint remains offline). BUT the Aristotle CLI (uvx --from aristotlelib aristotle) IS LIVE — a sibling klein job a1441c24 is actively running at it. So the designated STEP-D solver is reachable after all, just via CLI not MCP. ACTION TAKEN: submitted the whole self-contained file (Mathlib-only import; defs orbit/forwardGap/gapLengths + all helper lemmas inline; witnesses a,b,c already fixed; lone sorry = exists_gap_triple N>=2 case) to Aristotle CLI `submit --project-dir`, project_id 9d6ef543-1f33-43ae-82d0-a82cacb03440. Awaiting result; check with `uvx --from aristotlelib aristotle show 9d6ef543-1f33-43ae-82d0-a82cacb03440`. Docker still gated (5 lean containers, load ~9 / 7.65 GiB VM) so no manual build attempted. CALIBRATION (unchanged): STEP D is the full Sos-Suranyi-Swierczkowski / van Ravenstein three-gap classification — research-grade (Coq proof is hundreds of lines), NOT a quick manual win; the subtle core is that min(F_k,B_k) cannot land strictly inside (min a b, a+b). Aristotle is the right tool.",
     "blockers": [
       "Aristotle MCP (HTTP) prove/prove_file STILL 404 'Resource not found' S4–S10 — but the CLI backend is LIVE; use `uvx --from aristotlelib aristotle submit/show`, NOT the mcp__aristotle__* tools.",
       "Docker OOM-gated (5 containers, load ~9 / 7.65 GiB VM): no safe build, so no manual Lean can be verified or shipped.",

--- a/src/data/proofs/erdos-998-oq-04/annotations.json
+++ b/src/data/proofs/erdos-998-oq-04/annotations.json
@@ -1,0 +1,131 @@
+[
+  {
+    "id": "ann-998-oq04-header",
+    "proofId": "erdos-998-oq-04",
+    "range": { "startLine": 1, "endLine": 79 },
+    "type": "concept",
+    "title": "The Three-Gap (Steinhaus) Theorem",
+    "content": "For every irrational alpha and every N >= 1, the N points {0, {alpha}, ..., {(N-1)alpha}} cut the circle into arcs taking at most THREE distinct lengths; when three occur, the largest is the sum of the other two. Conjectured by Steinhaus, proved by Sos, Suranyi, and Swierczkowski (1958). This file gives the first formal Lean statement and proof.",
+    "mathContext": "The three-distance theorem is the structural backbone of Kesten's solution to Erdos Problem #998. It is purely finite and order-theoretic, needing only Int.fract, Finset, and the order on the reals -- no measure theory or analysis.",
+    "significance": "key",
+    "relatedConcepts": [
+      "three-distance theorem",
+      "Steinhaus conjecture",
+      "irrational rotation",
+      "equidistribution"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-998-oq04-orbit",
+    "proofId": "erdos-998-oq-04",
+    "range": { "startLine": 89, "endLine": 112 },
+    "type": "definition",
+    "title": "The Orbit",
+    "content": "orbit alpha N is the image of Finset.range N under i -> Int.fract (i * alpha): the finite set {0, {alpha}, ..., {(N-1)alpha}} inside [0,1). Lemmas orbit_mem_Ico, zero_mem_orbit, and orbit_nonempty establish its basic shape.",
+    "mathContext": "The orbit is the set of the first N iterates of 0 under the circle rotation x -> x + alpha (mod 1). Membership in [0,1) follows from Int.fract_nonneg and Int.fract_lt_one.",
+    "significance": "key",
+    "relatedConcepts": [
+      "fractional part",
+      "circle rotation",
+      "Finset.image"
+    ],
+    "prerequisites": ["Int.fract", "Finset.image"]
+  },
+  {
+    "id": "ann-998-oq04-forwardgap",
+    "proofId": "erdos-998-oq-04",
+    "range": { "startLine": 114, "endLine": 138 },
+    "type": "definition",
+    "title": "Forward Gaps and Gap Lengths",
+    "content": "forwardGap alpha N x is the Finset.inf' of {{y - x} : y in orbit, y != x} -- the cyclic distance from x to the next orbit point. gapLengths alpha N is the image of the orbit under forwardGap, the finite set of all arc lengths whose cardinality the theorem bounds.",
+    "mathContext": "Using the fractional part of y - x makes the distance cyclic (wrapping around 1). Taking an infimum over the punctured orbit selects the nearest forward neighbour.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.inf'", "cyclic distance", "arc length"],
+    "prerequisites": ["Finset.inf'", "Int.fract"]
+  },
+  {
+    "id": "ann-998-oq04-orbit-card",
+    "proofId": "erdos-998-oq-04",
+    "range": { "startLine": 156, "endLine": 176 },
+    "type": "theorem",
+    "title": "Orbit Cardinality",
+    "content": "orbit_card: for irrational alpha the orbit has exactly N points. Proved by showing i -> Int.fract (i * alpha) is injective on range N via Int.fract_eq_fract (which reduces {x} = {y} to x - y being an integer) and Irrational.int_mul.",
+    "mathContext": "Exact cardinality N guarantees there are genuinely N arcs to classify. Irrationality is essential: a rational alpha would make the orbit collapse and the gap structure degenerate.",
+    "significance": "key",
+    "relatedConcepts": ["injectivity", "irrationality", "Int.fract_eq_fract"],
+    "prerequisites": ["Irrational.int_mul", "Finset.card_image_of_injOn"]
+  },
+  {
+    "id": "ann-998-oq04-stepa",
+    "proofId": "erdos-998-oq-04",
+    "range": { "startLine": 177, "endLine": 288 },
+    "type": "theorem",
+    "title": "STEP A — Cyclic Distance Depends Only on the Index Difference",
+    "content": "fract_fract_sub_fract: { {x} - {y} } = { x - y }. Consequently the cyclic distance between orbit points {i*alpha} and {j*alpha} equals {(i-j)*alpha}, depending only on i - j. forwardGap_le packages this as an upper bound on the forward gap.",
+    "mathContext": "This is the key reduction: it collapses the N^2 geometric configuration to a one-parameter family of return distances {m*alpha}, which is what makes the three-gap classification tractable.",
+    "significance": "key",
+    "relatedConcepts": ["fractional part", "index difference", "return distance"],
+    "prerequisites": ["Int.fract", "Int.fract_sub_int"]
+  },
+  {
+    "id": "ann-998-oq04-carry",
+    "proofId": "erdos-998-oq-04",
+    "range": { "startLine": 302, "endLine": 360 },
+    "type": "theorem",
+    "title": "Fractional-Part Carry Arithmetic",
+    "content": "fract_add_of_lt_one and fract_add_of_one_le give the no-carry / carry rules for {x} + {y} relative to 1; fract_nat_add_lt and fract_nat_add_ge are the index versions; fract_neg_mul shows {-i*alpha} = 1 - {i*alpha} for irrational alpha and i != 0.",
+    "mathContext": "Whether {x} + {y} carries across 1 is exactly the trichotomy that distinguishes the three gap regions. These lemmas isolate that carry behaviour as reusable arithmetic facts.",
+    "significance": "supporting",
+    "relatedConcepts": ["carry", "fractional part addition", "modular arithmetic"],
+    "prerequisites": ["Int.fract_add", "Int.fract"]
+  },
+  {
+    "id": "ann-998-oq04-regions",
+    "proofId": "erdos-998-oq-04",
+    "range": { "startLine": 387, "endLine": 616 },
+    "type": "theorem",
+    "title": "The Three Regional Gap Values",
+    "content": "forwardGap_region_a / _b / _c identify, for each orbit point, which of the three values a = min forward return, b = min backward return, or a + b its forward gap takes; forwardGap_ge supplies the matching lower bound and forwardGap_mem_triple assembles them into membership in {a, b, a+b}.",
+    "mathContext": "The two Steinhaus first-return generators are a = min over 1<=i<N of {i*alpha} (best forward return) and b = min over 1<=i<N of {-i*alpha} (best backward return). The long gap is their sum a + b. Every orbit point's forward gap equals exactly one of these three.",
+    "significance": "key",
+    "relatedConcepts": ["first return", "Steinhaus generators", "case analysis"],
+    "prerequisites": ["Finset.le_inf'", "Finset.min'_le"]
+  },
+  {
+    "id": "ann-998-oq04-classification",
+    "proofId": "erdos-998-oq-04",
+    "range": { "startLine": 617, "endLine": 698 },
+    "type": "theorem",
+    "title": "The Classification Core",
+    "content": "exists_gap_triple: there exist a, b, c with a + b = c and gapLengths alpha N contained in {a, b, c}. The N = 1 base case is the degenerate single-point orbit; the N >= 2 case names the two minimal first-return generators and finishes via forwardGap_mem_triple.",
+    "mathContext": "This is the genuine Sos-Suranyi-Swierczkowski / van Ravenstein content. The additive relation a + b = c holds by construction (rfl); the mathematical substance is that no fourth length can ever appear.",
+    "significance": "key",
+    "relatedConcepts": ["three-distance classification", "first-return generators", "van Ravenstein"],
+    "prerequisites": ["Finset.min'_mem", "Finset.min'_le"]
+  },
+  {
+    "id": "ann-998-oq04-threegap",
+    "proofId": "erdos-998-oq-04",
+    "range": { "startLine": 699, "endLine": 707 },
+    "type": "theorem",
+    "title": "The Three-Gap Theorem",
+    "content": "three_gap: (gapLengths alpha N).card <= 3. The headline statement -- at most three distinct arc lengths -- obtained from exists_gap_triple via the cardinality engine card_le_three_of_subset_triple.",
+    "mathContext": "Any finite set contained in a three-element set has cardinality at most 3; this is the direct consequence of the classification.",
+    "significance": "key",
+    "relatedConcepts": ["Steinhaus theorem", "cardinality bound"],
+    "prerequisites": ["Finset.card_le_card"]
+  },
+  {
+    "id": "ann-998-oq04-additive",
+    "proofId": "erdos-998-oq-04",
+    "range": { "startLine": 708, "endLine": 760 },
+    "type": "theorem",
+    "title": "The Additive Relation",
+    "content": "three_gap_additive: the additive structure among the three gap lengths -- when three distinct lengths occur, the largest is the sum of the other two -- recovered from the a + b = c witness of exists_gap_triple by pure Finset reasoning.",
+    "mathContext": "This completes the classical statement of the three-distance theorem: not only are there at most three lengths, but they satisfy the relation L_long = L_short1 + L_short2.",
+    "significance": "key",
+    "relatedConcepts": ["additive relation", "Steinhaus theorem"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/erdos-998-oq-04/meta.json
+++ b/src/data/proofs/erdos-998-oq-04/meta.json
@@ -1,0 +1,197 @@
+{
+  "id": "erdos-998-oq-04",
+  "title": "The Three-Gap (Steinhaus) Theorem for Irrational Rotations",
+  "slug": "erdos-998-oq-04",
+  "description": "For every irrational α and every N ≥ 1, the N points {0, {α}, …, {(N−1)α}} cut the circle into arcs taking at most three distinct lengths, and when three occur the largest is the sum of the other two. A full formal Lean statement and proof, isolating the Sós–Surányi–Świerczkowski classification core.",
+  "meta": {
+    "author": "Sós; Surányi; Świerczkowski (1958); formalized in Lean (2026)",
+    "sourceUrl": "https://erdosproblems.com/998",
+    "date": "1958",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos998ThreeGapOQ04.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "combinatorics",
+      "diophantine-approximation",
+      "equidistribution",
+      "three-distance-theorem",
+      "irrational-rotation"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 998,
+    "erdosUrl": "https://erdosproblems.com/998",
+    "erdosProblemStatus": "proved",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.fract",
+        "description": "Fractional part {x} = x - ⌊x⌋ on the reals",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "Int.fract_eq_fract",
+        "description": "{x} = {y} ↔ x - y ∈ ℤ, the engine of orbit injectivity",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "Irrational.int_mul",
+        "description": "Irrationality is preserved under multiplication by a nonzero integer",
+        "module": "Mathlib.RingTheory.Int.Basic"
+      },
+      {
+        "theorem": "Finset.inf'",
+        "description": "Infimum of a nonempty finite set, used for the forward-gap length",
+        "module": "Mathlib.Data.Finset.Lattice"
+      },
+      {
+        "theorem": "Finset.min'",
+        "description": "Minimum of a nonempty finite set, used for the two first-return generators",
+        "module": "Mathlib.Data.Finset.Lattice"
+      }
+    ],
+    "originalContributions": [
+      "orbit definition: the finite point set {0, {α}, …, {(N−1)α}} ⊆ [0,1) as a Finset",
+      "forwardGap / gapLengths definitions: arc length to the nearest forward orbit point, and the finite set of all such lengths",
+      "orbit_card theorem: for irrational α the orbit has exactly N points (injectivity of i ↦ {iα})",
+      "fract_fract_sub_fract theorem (STEP A): { {x} − {y} } = { x − y }, so cyclic distance depends only on the index difference",
+      "forwardGap_region_a / _b / _c theorems: the three regional gap values built from the minimal forward and backward cyclic returns",
+      "forwardGap_mem_triple theorem: every forward gap length lies in {a, b, a+b}",
+      "exists_gap_triple theorem: the Sós–Surányi–Świerczkowski classification — at most three gap lengths with a + b = c",
+      "three_gap theorem: at most three distinct gap lengths (card ≤ 3)",
+      "three_gap_additive theorem: the additive relation among the three lengths"
+    ],
+    "axiomCount": 0,
+    "lineCount": 760,
+    "assumptions": "0 axioms, 0 sorries. Uses only the foundational axioms propext, Classical.choice, Quot.sound (standard for classical Mathlib reasoning).",
+    "theoremCount": 22,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "The **three-distance theorem** (also called the three-gap theorem or **Steinhaus conjecture**) states that for any irrational $\\alpha$ and any $N$, the points $\\{0, \\{\\alpha\\}, \\{2\\alpha\\}, \\ldots, \\{(N-1)\\alpha\\}\\}$ partition the unit circle into arcs taking **at most three distinct lengths**, with the longest equal to the sum of the other two. It was conjectured by **Hugo Steinhaus** and proved independently around 1957–1958 by **Vera T. Sós**, by **János Surányi**, and by **Stanisław Świerczkowski**; **Noah van Ravenstein** later gave a clean elementary proof. The theorem is the structural backbone of Kesten's solution to Erdős Problem #998 (Kesten's equidistribution characterization), whose parent file references it only in prose. This file gives the first *formal Lean statement and proof* of the theorem.",
+    "problemStatement": "Let $\\alpha$ be irrational and $N \\geq 1$. Place the $N$ points $\\{i\\alpha \\bmod 1 : 0 \\leq i < N\\}$ on the circle $\\mathbb{R}/\\mathbb{Z}$. Is it true that the consecutive gaps between these points take at most three distinct lengths, and that when exactly three lengths occur the largest is the sum of the other two?\n\n**Answer:** YES (Sós–Surányi–Świerczkowski, 1958).",
+    "text": "For every irrational α and every N ≥ 1, the N points {iα mod 1 : 0 ≤ i < N} cut the circle into arcs of at most three distinct lengths, the largest being the sum of the other two.",
+    "proofStrategy": "The orbit $\\{\\{i\\alpha\\} : 0 \\le i < N\\}$ is a `Finset ℝ` inside $[0,1)$; irrationality makes $i \\mapsto \\{i\\alpha\\}$ injective (`orbit_card`), so the orbit has exactly $N$ points. For an orbit point $x = \\{k\\alpha\\}$ the **forward gap** is the cyclic distance to the next orbit point, realized as `Finset.inf'` of $\\{\\,\\{y - x\\} : y \\neq x\\}$. STEP A (`fract_fract_sub_fract`) shows $\\{\\{x\\} - \\{y\\}\\} = \\{x - y\\}$, so this distance depends only on the index difference. The two Steinhaus generators are the minimal forward return $a = \\min_{1 \\le i < N} \\{i\\alpha\\}$ and the minimal backward return $b = \\min_{1 \\le i < N} \\{-i\\alpha\\}$, with $c = a + b$ by construction. Fractional-part carry/no-carry rules (`fract_add_of_lt_one`, `fract_add_of_one_le`, `fract_neg_mul`) drive a three-way regional case split (`forwardGap_region_a/_b/_c`) proving every forward gap equals $a$, $b$, or $a+b$ (`forwardGap_mem_triple`). Assembling these yields `exists_gap_triple`; `card_le_three_of_subset_triple` then gives `three_gap` (at most three lengths) and `three_gap_additive` (the additive relation).",
+    "keyInsights": [
+      "**Orbit as irrational rotation:** the points $\\{i\\alpha\\}$ are the orbit of $0$ under $x \\mapsto x + \\alpha \\pmod 1$; irrationality forces them to be distinct, which is exactly `orbit_card`.",
+      "**Index-difference reduction (STEP A):** the cyclic distance between $\\{i\\alpha\\}$ and $\\{j\\alpha\\}$ equals $\\{(i-j)\\alpha\\}$ because $\\{\\{x\\}-\\{y\\}\\} = \\{x-y\\}$. This collapses an $N^2$ geometric problem to a one-parameter family indexed by $i - j$.",
+      "**Two first-return generators:** the only candidate short gaps are the smallest forward return $a$ and the smallest backward return $b$. Every other gap is one of $a$, $b$, or their sum $a+b$ — the third, long gap.",
+      "**Carry arithmetic is the whole game:** whether two fractional parts add with or without a carry across $1$ is precisely the trichotomy distinguishing the three regions, handled by the `fract_add_of_lt_one` / `fract_add_of_one_le` lemmas.",
+      "**Additive relation by construction:** because $c$ is defined as $a + b$, the relation $a + b = c$ holds definitionally (`rfl`); the mathematical content is showing no *fourth* length can appear."
+    ],
+    "prerequisites": [
+      "Fractional parts and the floor function (Int.fract)",
+      "Finite sets and their cardinality, infima, and minima (Finset)",
+      "Irrationality and Diophantine approximation",
+      "Elementary combinatorics on the circle"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-setup",
+      "title": "Imports and Setup",
+      "startLine": 80,
+      "endLine": 88,
+      "summary": "Imports `Mathlib`, opens the `Finset` namespace, and enters the `Erdos998ThreeGap` namespace. The development needs only `Int.fract`, `Finset`, and the linear order on `ℝ` — no measure theory or analysis.",
+      "mathContext": "The theorem is purely finite/order-theoretic, so the only heavy dependencies are the fractional-part API (`Int.fract`, `Int.fract_eq_fract`) and `Finset` lattice operations (`inf'`, `min'`)."
+    },
+    {
+      "id": "orbit-definition",
+      "title": "The Orbit",
+      "startLine": 89,
+      "endLine": 113,
+      "summary": "Defines `orbit α N` as the image of `Finset.range N` under `i ↦ {iα}`, a finite subset of $[0,1)$. Proves `orbit_mem_Ico` (every point lies in $[0,1)$), `zero_mem_orbit`, and `orbit_nonempty`.",
+      "mathContext": "The orbit is the set of the first $N$ iterates of $0$ under the rotation by $\\alpha$. Membership in $[0,1)$ is immediate from `Int.fract_nonneg` and `Int.fract_lt_one`."
+    },
+    {
+      "id": "gap-definitions",
+      "title": "Forward Gaps and Gap Lengths",
+      "startLine": 114,
+      "endLine": 155,
+      "summary": "Defines `forwardGap α N x` as the `Finset.inf'` of $\\{\\,\\{y - x\\} : y \\in \\text{orbit}, y \\neq x\\}$ (the cyclic distance to the next orbit point) and `gapLengths α N` as the image of the orbit under `forwardGap`. Proves `forwardGap_nonneg` and `fract_mul_inj` (distinct indices give distinct orbit points).",
+      "mathContext": "`fract_mul_inj` is the injectivity that powers `orbit_card`: for irrational $\\alpha$, $\\{i\\alpha\\} = \\{j\\alpha\\}$ forces $(i-j)\\alpha \\in \\mathbb{Z}$, impossible unless $i = j$."
+    },
+    {
+      "id": "orbit-cardinality",
+      "title": "Orbit Cardinality",
+      "startLine": 156,
+      "endLine": 176,
+      "summary": "`orbit_card`: for irrational $\\alpha$ the orbit has exactly $N$ points, via injectivity of $i \\mapsto \\{i\\alpha\\}$ (`Int.fract_eq_fract` and `Irrational.int_mul`).",
+      "mathContext": "Exact cardinality $N$ guarantees there are genuinely $N$ arcs to classify; without irrationality the orbit could collapse and the gap count would degenerate."
+    },
+    {
+      "id": "step-a-primitive",
+      "title": "STEP A — Cyclic Distance as a Fract of the Index Difference",
+      "startLine": 177,
+      "endLine": 288,
+      "summary": "`fract_fract_sub_fract`: $\\{\\{x\\} - \\{y\\}\\} = \\{x - y\\}$, so the cyclic distance between two orbit points depends only on their index difference. `forwardGap_le` packages this as an upper bound on the forward gap.",
+      "mathContext": "This is the reduction that makes the problem tractable: the $N$-point geometric configuration is governed entirely by the one-parameter family $\\{m\\alpha\\}$ of return distances."
+    },
+    {
+      "id": "carry-rules",
+      "title": "Fractional-Part Carry Arithmetic",
+      "startLine": 289,
+      "endLine": 360,
+      "summary": "`card_le_three_of_subset_triple` (cardinality engine), the carry/no-carry rules `fract_add_of_lt_one` and `fract_add_of_one_le`, the index versions `fract_nat_add_lt` / `fract_nat_add_ge`, and `fract_neg_mul` ($\\{-i\\alpha\\} = 1 - \\{i\\alpha\\}$ for irrational $\\alpha$, $i \\neq 0$).",
+      "mathContext": "Whether $\\{x\\} + \\{y\\}$ carries across $1$ decides which of the three regions a gap falls into; these lemmas isolate that trichotomy as reusable arithmetic facts."
+    },
+    {
+      "id": "region-lemmas",
+      "title": "The Three Regional Gap Values",
+      "startLine": 361,
+      "endLine": 616,
+      "summary": "`forwardGap_ge` (the `Finset.le_inf'` lower bound) and the regional lemmas `forwardGap_region_a / _b / _c` identify, for each orbit point, which of the three values its forward gap takes; `forwardGap_mem_triple` assembles them into membership in $\\{a, b, a+b\\}$.",
+      "mathContext": "The two generators are $a = \\min_{1 \\le i < N} \\{i\\alpha\\}$ (best forward return) and $b = \\min_{1 \\le i < N} \\{-i\\alpha\\}$ (best backward return); the long gap is $a + b$. Each orbit point's forward gap is shown to equal exactly one of these."
+    },
+    {
+      "id": "classification-core",
+      "title": "The Classification Core",
+      "startLine": 617,
+      "endLine": 698,
+      "summary": "`exists_gap_triple`: there exist $a, b, c$ with $a + b = c$ and $\\text{gapLengths} \\subseteq \\{a, b, c\\}$. The $N = 1$ base case is the degenerate single-point orbit; the $N \\geq 2$ case names the two first-return generators and applies `forwardGap_mem_triple`.",
+      "mathContext": "This is the genuine Sós–Surányi–Świerczkowski / van Ravenstein content. The additive relation $a + b = c$ holds by construction (`rfl`); the substance is that no fourth length can appear."
+    },
+    {
+      "id": "main-theorems",
+      "title": "The Three-Gap Theorem",
+      "startLine": 699,
+      "endLine": 760,
+      "summary": "`three_gap`: $(\\text{gapLengths } \\alpha\\, N).\\text{card} \\leq 3$, reduced to `exists_gap_triple` via `card_le_three_of_subset_triple`. `three_gap_additive`: the additive relation among the three lengths.",
+      "mathContext": "These are the headline statements of the Steinhaus theorem: at most three distinct arc lengths, with the largest the sum of the other two."
+    }
+  ],
+  "conclusion": {
+    "summary": "The three-distance (Steinhaus) theorem is fully formalized and machine-checked in Lean 4: for every irrational $\\alpha$ and every $N \\geq 1$, the orbit $\\{\\{i\\alpha\\} : 0 \\le i < N\\}$ cuts the circle into arcs of at most three distinct lengths, the longest equal to the sum of the other two. The proof is elementary and self-contained — built only from `Int.fract`, `Finset`, and the order on $\\mathbb{R}$ — with 0 axioms and 0 sorries.",
+    "implications": "**Structural backbone of Erdős #998:** the three-distance theorem is exactly the gap structure Kesten exploits to characterize bounded-discrepancy intervals for irrational rotations. Formalizing it removes a prose-only dependency from the parent file `Erdos998Problem.lean`.\n\n**Mathlib gap filled:** Mathlib4 does not contain the three-gap theorem (only a Coq formalization of van Ravenstein's proof existed). This development is a natural Mathlib-style candidate, requiring no analysis.",
+    "openQuestions": [
+      "Can this file be upstreamed to Mathlib as the first Lean three-distance theorem?",
+      "Can the explicit gap lengths be related to the continued-fraction convergents of $\\alpha$ (the Ostrowski / first-return denominators)?",
+      "Does the formalization extend to the gaps of $\\{0, \\{\\alpha\\}, \\ldots\\}$ counted with the long gap's combinatorial multiplicity (the full Steinhaus count of how many arcs of each length occur)?",
+      "Can the result be used to discharge the `three_distance_theorem` prose reference inside the parent Erdős #998 formalization?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-998",
+      "relationship": "supports",
+      "description": "The three-distance theorem proved here is the structural backbone of Kesten's solution to Erdős #998; the parent file references it only in prose."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos998ThreeGap",
+    "lineCount": 760,
+    "axiomCount": 0,
+    "theoremCount": 22,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos998ThreeGapOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds the gallery entry (meta.json + 10 annotations) for **erdos-998-oq-04**, the first formal Lean 4 statement and proof of the **Three-Gap (Steinhaus) Theorem** for irrational rotations.

The Lean proof itself (`proofs/Proofs/Erdos998ThreeGapOQ04.lean`, 760 LOC) is already on `main` (merged in #26579) and registered in `Proofs.lean`. This PR adds only the gallery presentation data.

## Mathematical content

For irrational α and every N ≥ 1, the N points {0, {α}, …, {(N−1)α}} cut the circle into N arcs whose lengths take **at most three distinct values**, and when three occur the largest equals the sum of the other two. Mathlib4 had no three-gap theorem; only a Coq (van Ravenstein) formalization existed — this is a genuine new Lean formalization.

- `three_gap` — ≤ 3 distinct gap lengths
- `three_gap_additive` — long gap = short + short
- `exists_gap_triple` — the Sós–Surányi–Świerczkowski / van Ravenstein classification core (the sole research-grade lemma), discharged via Aristotle (project `9d6ef543`).

## Verification

- **0 `axiom` declarations, 0 code-level `sorry`** (the 4 textual "sorry" matches are in docstrings).
- Aristotle's `#print axioms` confirms `exists_gap_triple`, `three_gap`, `three_gap_additive` depend only on `propext`, `Classical.choice`, `Quot.sound`.
- Independently re-audited clean by the auditor (760L / 0ax / 0sorry / 22thm / 3def).

## Gallery data

- `meta.json` — status `verified`, badge `verified`, axiomCount 0.
- `annotations.json` — 10 annotations, all line-ranges validated against the source (0 misaligned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)