### PR TITLE
research(erdos-mordell-oq-01): submit reduced chord_cos_eq sorry to Aristotle

### DIFF
--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -2199,6 +2199,18 @@
       "notes": "COMPLETE/PROVED. Retrieved by researcher-3 via CLI download, grafted into Erdos998ThreeGapOQ04.lean (full file: +10 supporting lemmas fract_add_of_lt_one/_one_le, fract_nat_add_lt/_ge, fract_neg_mul, forwardGap_ge, forwardGap_region_a/b/c, forwardGap_mem_triple; dropped unused forwardGap_attained). 0 sorry, 0 axiom (propext/Classical.choice/Quot.sound only). Public statements byte-identical to pre-graft; defs/imports identical. Aristotle reports clean lake build 8027 jobs under v4.28.0; BUILD VERIFICATION PENDING under repo-pinned v4.26.0 (Docker down this session). Toolchain NOT changed in repo.",
       "status": "integrated",
       "last_check": "2026-06-19T14:28:05Z"
+    },
+    {
+      "project_id": "62d1066c-7edd-4419-b588-4bc430d4d4fb",
+      "file": "proofs/Proofs/ErdosMordellChordIdentity.lean",
+      "problem_id": "erdos-mordell-inequality-oq-01",
+      "submitted": "2026-06-19T15:16Z (researcher-1, CLI; from research/erdos-mordell-pedalfoot-eq branch)",
+      "sorries": [
+        "chord_cos_eq — cosine-side core: ⟪F_b−P,F_c−P⟫/(‖F_b−P‖‖F_c−P‖) = −⟪Y−X,Z−X⟫/(‖Y−X‖‖Z−X‖). Pure Fin 2 coordinate identity; squared half is ring, sign half is [u,w]·[v,w]=−s·t·[u,v]² from interior_barycentric."
+      ],
+      "notes": "MORE-REDUCED target than still-RUNNING 55ae116d (which works main's 2 unreduced geometric sorries). This is the unmerged research/erdos-mordell-pedalfoot-eq branch state: chord_length_eq (sine side) and angle_at_P (wrapper over chord_cos_eq) are HAND-PROVED; only the single algebraic chord_cos_eq remains. Submitting also build-VERIFIES the branch's unmerged hand-proofs server-side (local Docker gate closed: 11 containers, load 15). chord_cos_eq follows the same coordinate-ring pattern as the already-proved chord_length_eq → high success odds. MCP prove/prove_file/check_proof return 404 this session; CLI works. v4.26↔v4.28 toolchain warning noted. Poll: aristotle show 62d1066c-7edd-4419-b588-4bc430d4d4fb. On PROVED: graft into the branch file, rebuild when gate opens, then the whole E–M closes (chord_identity already wired turnkey).",
+      "status": "submitted",
+      "last_check": "2026-06-19T15:16Z"
     }
   ]
 }

--- a/src/data/research/problems/erdos-mordell-inequality-oq-01.json
+++ b/src/data/research/problems/erdos-mordell-inequality-oq-01.json
@@ -9,12 +9,12 @@
   "status": "in-progress",
   "phase": "ACT",
   "started": "2026-06-18T23:00:00Z",
-  "lastUpdate": "2026-06-18T23:35:00Z",
+  "lastUpdate": "2026-06-19T15:16:00Z",
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-18T23:35:00Z",
-    "iteration": 2,
-    "focus": "Added verified chord-to-key assembly lemma (key_inequality_of_chord_and_sines); each remaining geometric sorry now reduces to supplying the chord identity + law of sines. Aristotle endpoint down (Resource not found)."
+    "since": "2026-06-19T15:16:00Z",
+    "iteration": 3,
+    "focus": "Branch research/erdos-mordell-pedalfoot-eq reduces all of E–M to ONE algebraic sorry chord_cos_eq (chord_length_eq + angle_at_P now hand-proved). Submitted to Aristotle as project 62d1066c (CLI; MCP 404). Local build gate closed; submission build-verifies the hand-proofs server-side."
   },
   "tags": [
     "seeker-selected",
@@ -29,7 +29,7 @@
     "Not present in Mathlib4 (as of v4.26.0): no `mordell` geometry result; Mathlib has Triangle, Incenter, Projection, SignedDist, angle infrastructure but no Erdős–Mordell."
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-06-19, r1): submitted both residual geometric sorries (chord_length_eq sine-side + angle_at_P cosine-side) of ErdosMordellChordIdentity.lean to Aristotle as ONE file job (project 55ae116d, MCP wrapper was 404 → used CLI submit). Both are isolated with COMPLETE coordinate-ring roadmaps in their docstrings (Gram-determinant vanishing for chord_length_eq; cross-product identity [u,w]·[v,w] = −s·t·[u,v]² from hP barycentric witness for angle_at_P). v4.26↔v4.28 toolchain warning noted. Poll: aristotle show 55ae116d. On PROVED: integrate (build-pending until docker gate opens, load<6).",
+    "progressSummary": "PROGRESS (2026-06-19, researcher-1): the unmerged branch research/erdos-mordell-pedalfoot-eq has HAND-PROVED chord_length_eq (sine side, 2D Gram via coordinate ring) AND angle_at_P (now a wrapper over a single new algebraic core chord_cos_eq), reducing the ENTIRE Erdős–Mordell formalization to ONE pure inner-product/Fin-2 coordinate identity: chord_cos_eq. Submitted that reduced file to Aristotle (CLI) as project 62d1066c-7edd-4419-b588-4bc430d4d4fb — a strictly EASIER target than the still-RUNNING 55ae116d (which works main's 2 unreduced geometric sorries, ~15% at 51min). The submission also build-verifies the branch's unmerged hand-proofs server-side (local Docker gate closed: 11 containers, load 15). chord_cos_eq follows the SAME proof pattern as the already-proved chord_length_eq (recenter, sq_eq_sq, field_simp, PiLp.inner_apply expansion, ring) so success odds are high. MCP prove/check_proof 404 this session; CLI works. Poll: aristotle show 62d1066c. On PROVED: graft into the pedalfoot-eq branch file, rebuild when gate opens (load<6), and the whole proof closes (chord_identity already wired turnkey).",
     "builtItems": [
       "proofs/Proofs/ErdosMordellInequalityOQ01.lean: erdos_mordell_reduction — from the three key inequalities a·PA≥b·dc+c·db (cyclic), derives PA+PB+PC≥2(da+db+dc) via explicit nonnegative certificate, 0 sorry, 0 axiom (build-pending verification).",
       "Certificate: a·b·c·(PA+PB+PC) − 2abc·(da+db+dc) = a·da·(b−c)² + b·db·(a−c)² + c·dc·(a−b)² + (key-inequality slack), each summand ≥ 0; closed by mul_le_mul_of_nonneg_left scaling + nlinarith + le_of_mul_le_mul_left.",
@@ -45,7 +45,8 @@
       "ErdosMordellFeetAngleAristotle.lean helpers (build-verified): pedalFoot_mem_affineSpan (orthogonalProjection_mem), collinear_pedalFoot {foot,X,Y}, collinear_foot_vertex {foot,B,A} (vertex-in-middle via Set.pair_comm + collinear_insert_iff_of_mem_affineSpan).",
       "pedalFoot_eq PROVED + build-verified (ErdosMordellChordIdentity.lean:172, Lean v4.26 7743 jobs green): pedalFoot P X Y = (⟪P−X,Y−X⟫/‖Y−X‖²)•(Y−X)+X via coe_orthogonalProjection_eq_iff_mem (membership + perpendicular residual). The keystone bridge; sorries 3→2.",
       "Fixed latent build error in chord_length_sq_eq_of_angle_at_P (rw[hlc] dist^2 vs dist*dist + dist_comm mismatch) → hAngle/cos_pi_sub into hlc, align pow_two+dist_comm, linear_combination. Companion now compiles for the first time.",
-      "Aristotle file submission (project 55ae116d, r1 2026-06-19): ErdosMordellChordIdentity.lean (both sorries chord_length_eq + angle_at_P). CLI submit since MCP prove/prove_file returned 404 this session."
+      "Aristotle file submission (project 55ae116d, r1 2026-06-19): ErdosMordellChordIdentity.lean (both sorries chord_length_eq + angle_at_P). CLI submit since MCP prove/prove_file returned 404 this session.",
+      "Aristotle submission (project 62d1066c-7edd-4419-b588-4bc430d4d4fb, researcher-1 2026-06-19, CLI): the research/erdos-mordell-pedalfoot-eq reduced ErdosMordellChordIdentity.lean (single sorry chord_cos_eq). MORE-reduced than 55ae116d: chord_length_eq and angle_at_P are hand-proved on that branch; only the algebraic cosine-side core chord_cos_eq remains. Also build-verifies the branch hand-proofs server-side (Docker gate closed locally)."
     ],
     "insights": [
       "The inequality cleanly factors: ALL the AM-GM / side-length algebra is captured by erdos_mordell_reduction (now proved), isolating the genuinely hard work into the three geometric key inequalities.",


### PR DESCRIPTION
## Summary

Advances **erdos-mordell-inequality-oq-01** by leveraging the unmerged
`research/erdos-mordell-pedalfoot-eq` branch, which has hand-proved both
residual geometric sorries of `ErdosMordellChordIdentity.lean`:

- `chord_length_eq` (sine side) — proved via the 2D Gram-determinant identity as a coordinate `ring` computation.
- `angle_at_P` (cosine side) — now a hypothesis-free wrapper over a single new algebraic core, `chord_cos_eq`.

This reduces the **entire** Erdős–Mordell formalization to ONE pure
inner-product / `Fin 2` coordinate identity: `chord_cos_eq`.

## What this PR does

Submits that reduced file to Aristotle (CLI) as project
`62d1066c-7edd-4419-b588-4bc430d4d4fb`, targeting the lone `chord_cos_eq` sorry.

- **Strictly easier target** than the still-running `55ae116d`, which is grinding main's *two* unreduced geometric sorries (~15% at 51 min). Here the geometric reduction is hand-done; only the coordinate algebra remains.
- **Build-verifies** the branch's unmerged hand-proofs server-side — the local Docker gate is closed (11 build containers, host load 15), so this is the only way to verify them this session.
- `chord_cos_eq` follows the **same proof pattern** as the already-proved `chord_length_eq` (recenter, `sq_eq_sq`, `field_simp`, `PiLp.inner_apply` expansion, `ring`), so success odds are high.

## Scope

No Lean changes to `main`. Only `research/aristotle-jobs.json` and the
`erdos-mordell-inequality-oq-01` research record are updated. MCP
`prove`/`check_proof` returned 404 all session; the CLI path works.

**On `PROVED`:** graft into the `pedalfoot-eq` branch file, rebuild when the
gate opens (`load < 6`), and the whole proof closes (`chord_identity` is
already wired turnkey).

🤖 Generated with [Claude Code](https://claude.com/claude-code)