### PR TITLE
audit(erdos-998-oq-04): record clean audit result in tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16093,6 +16093,12 @@
       "lastAudited": "2026-06-19T12:46:53Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-998-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T15:29:58Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: erdos-998-oq-04 — The Three-Gap (Steinhaus) Theorem for Irrational Rotations

### Finding
The tracker entry for this proof was `null` on `main`, so the auditor re-claims it every iteration even though it passes cleanly. The gallery directory is now committed, so persisting the clean audit record permanently resolves the perpetual re-hand.

### Verification (source vs meta.json)
| Claim | meta.json | Source (`Erdos998ThreeGapOQ04.lean`) |
|-------|-----------|--------------------------------------|
| status / badge | verified / verified | ✅ Tier A — fully formalized |
| axiomCount | 0 | 0 `axiom` decls, no structure-encoded assumptions |
| sorries | 0 | 0 real sorries (all `sorry` greps are docstring prose) |
| lineCount | 760 | 760 |
| theorems / defs | 22 / 3 | 22 / 3 |

No `native_decide`, no `True` stubs, no Mathlib-wrapper masking. Claims are accurate.

---
Discovered during gallery integrity audit.