### PR TITLE
audit(erdos-1062-oq-04): record clean audit result in tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16099,6 +16099,12 @@
       "lastAudited": "2026-06-19T15:29:58Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1062-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T15:45:01Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1062-oq-04

First audit of the newly added **erdos-1062-oq-04** entry ("k-Fold 'No Element Divides k Others' Sets"). The gallery dir is committed but had no audit-tracker record, so `find-targets --next` perpetually re-handed it. This PR persists the clean result, bringing the gallery to **2565/2565 audited**.

### Verification (meta.json vs `proofs/Proofs/Erdos1062OQ04.lean`)

| Check | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| Line count | 278 | 278 | ✓ |
| Sorries | 0 | 0 | ✓ |
| Axioms | 0 | 0 (no `axiom`, no structures) | ✓ |
| True stubs | — | 0 | ✓ |
| Theorems | 12 | 12 | ✓ |
| Definitions | 5 | 5 | ✓ |
| Imports | Mathlib | Mathlib only | ✓ |

Computational verification uses `decide` (not `native_decide`), so there is **no `Lean.ofReduceBool` dependency** — `0 axioms` is honest.

### Tier classification: **Tier A (original infrastructure)**

Defines `NoDividesKOthers k` / `properMultiples` / `maxNDKOSize` and independently proves k=1 ⟺ primitive, k=2 ⟺ Erdős #1062 NDTO, monotonicity, heredity, and the two-sided bound `n − ⌊n/2⌋ ≤ maxNDKOSize k n ≤ n`. The `mathlibDependencies` are utility lemmas (`filter_subset_filter`, `one_lt_card`, `card_pair`, `card_Icc`) — none doing the core work — so badge `original` / status `verified` are correct (not a Mathlib wrapper).

**Risk: LOW.** References open Erdős #1062 but explicitly scopes the sharp density and irrationality questions out (`assumptions`, `openQuestions`). No axiom masking, no overclaim, title carries no unqualified famous-theorem claim.

**Result: clean.**

---
Discovered during autonomous gallery integrity audit.