### PR TITLE
research(minpoly-charpoly-oq-03-oq-01): correct stale docstring/state (torsion proved, 1 sorry remains)

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean
@@ -47,16 +47,28 @@ that OQ-03-OQ-02 will consume:
    which is monic (hence nonzero in `F[X]`). This is the Cayley–Hamilton
    contribution.
 
-## S1 Scaffold scope (deliberate boundary)
+## Current scope (deliberate boundary)
 
-The deeper theorem `xModule_isTorsion` is **stated** here but its proof
-is left as `sorry`. The proof routes through Mathlib's
-`LinearMap.aeval_self_charpoly`, plus the basis-induced compatibility
-between `Matrix.charpoly` and `LinearMap.charpoly` for the standard
-basis on `n → F`. S2+ iterations of this sub-OQ will discharge the
-sorry; the public statement is final.
+Both structural deliverables consumed by OQ-03-OQ-02 are now **proved**:
 
-The `Module.Finite F[X]` instance is provided unconditionally (no sorry).
+* `Module.Finite F[X] (xModule M)` — provided unconditionally (no sorry)
+  via `Module.AEval.instFinitePolynomial`.
+* `xModule_isTorsionBy_charpoly` and `xModule_isTorsion` — proved
+  (Cayley–Hamilton on the `Module.AEval'` synonym, routed through
+  `charpoly_mulVecLin` + `LinearMap.aeval_self_charpoly`, then upgraded
+  to torsion via `charpoly_monic ⇒ nonZeroDivisor`).
+
+The single remaining `sorry` is `xModule_has_invariantFactorChain` (the
+invariant-factor-chain bridge to the parent's strong form), which is
+**deliberately deferred to OQ-03-OQ-02**: it requires the regrouping
+algorithm of `Module.equiv_directSum_of_isTorsion`, out of scope for
+this foundational sub-OQ. Its statement is fixed here only to pin the
+bridging API surface.
+
+Note: the torsion proofs are statically complete (all referenced
+Mathlib lemmas verified present) but their final kernel check is
+**build-pending** — they have not yet been confirmed by a full Lean
+build in this environment.
 
 ## References
 
@@ -138,9 +150,9 @@ The proof routes through:
 4. Lift `IsTorsionBy F[X] (xModule M) M.charpoly` to `IsTorsion` via
    monic ⇒ nonzero ⇒ nonZeroDivisor.
 
-The lemma `xModule_isTorsionBy_charpoly` (statement) captures step 1–3;
-`xModule_isTorsion` (statement) is the deliverable consumed by
-OQ-03-OQ-02. Both are sorry-guarded in this S1 scaffold. -/
+The lemma `xModule_isTorsionBy_charpoly` captures steps 1–3;
+`xModule_isTorsion` is the deliverable consumed by OQ-03-OQ-02. Both
+are now proved (build-pending kernel verification). -/
 
 /-- The characteristic polynomial of `M` annihilates every element of
     the `F[X]`-module `xModule M`. This is Cayley–Hamilton transported

--- a/research/problems/minpoly-charpoly-oq-03-oq-01/state.md
+++ b/research/problems/minpoly-charpoly-oq-03-oq-01/state.md
@@ -1,75 +1,83 @@
 # Current State
 
-**Phase**: ACT (S1 OBSERVE/ACT scaffold delivered)
-**Since**: 2026-05-12 (S1 iteration, researcher-1)
-**Iteration**: 1
+**Phase**: ACT (torsion deliverables proved; build-verification pending)
+**Since**: 2026-06-19 (researcher-4 — docstring/state accuracy pass)
+**Iteration**: 2
 
 ## Current Focus
 
-S1 scaffold landed: `proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean` (187 lines,
-3 definitions, 3 theorems, 1 instance, 3 sorries). Gallery entry added at
-`src/data/proofs/minpoly-charpoly-oq-03-oq-01/`.
+The two structural deliverables are **proved** in
+`proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean`; only the OQ-03-OQ-02 bridge
+remains a `sorry`. The file now has exactly **1 sorry**
+(`xModule_has_invariantFactorChain`, L211), not the 3 of the S1 scaffold.
 
-Deliverables fixed in API:
+Deliverables (current status):
 
-* `xModule M = Module.AEval' M.mulVecLin` (the F[X]-module synonym)
-* `xModule.instFinite : Module.Finite F[X] (xModule M)` — **unconditional**,
-  via `Module.AEval.instFinitePolynomial`. No sorry.
-* `xModule_isTorsionBy_charpoly` — Cayley-Hamilton on AEval'. Sorry-guarded.
-* `xModule_isTorsion` — the deliverable consumed by OQ-03-OQ-02. Sorry-guarded.
+* `xModule M = Module.AEval' M.mulVecLin` (the F[X]-module synonym) — def.
+* `xModule.instFinite : Module.Finite F[X] (xModule M)` — **proved**,
+  unconditional, via `Module.AEval.instFinitePolynomial`. No sorry.
+* `xModule_isTorsionBy_charpoly` — Cayley-Hamilton on AEval'. **Proved**
+  (build-pending kernel check). Route: `charpoly_mulVecLin` +
+  `(AEval'.of (endo M)).symm.injective` + `Module.AEval.of_symm_smul` +
+  `LinearMap.aeval_self_charpoly`.
+* `xModule_isTorsion` — deliverable consumed by OQ-03-OQ-02. **Proved**
+  (build-pending) from the above + `charpoly_monic ⇒ nonZeroDivisor`.
 * `xModule_has_invariantFactorChain` — bridge to parent's main theorem.
-  Sorry-guarded.
+  **Sorry** (deliberately deferred to OQ-03-OQ-02).
 
 ## Active Approach
 
 Mathlib's existing `Module.AEval'` synonym + `M.mulVecLin` gives the F[X]-module
-structure for free; the instance pipeline gives Module.Finite for free; only
-the IsTorsion proof requires manual work (Cayley-Hamilton transported across
-the standard-basis algebra equivalence).
+structure for free; the instance pipeline gives Module.Finite for free; the
+IsTorsion proof (Cayley-Hamilton transported across the `Module.AEval'`
+synonym) is now in place.
 
 ## Blockers
 
-None at the strategy level. The S2+ task is mechanical:
-
-1. Discharge `xModule_isTorsionBy_charpoly` (~30-50 lines): combine
-   `Matrix.aeval_self_charpoly` with the algebra equivalence
-   `Matrix.toLinAlgEquiv (Pi.basisFun F n) : Matrix n n F ≃ₐ[F] (n→F →ₗ[F] n→F)`.
-   Key fact: aeval commutes with algebra homomorphisms.
-2. Discharge `xModule_isTorsion` from (1) + `charpoly_monic` (~10-15 lines).
-3. Discharge `xModule_has_invariantFactorChain` from (2) +
-   `Module.equiv_directSum_of_isTorsion` (this is actually OQ-03-OQ-02
-   territory; we keep the statement here only to fix the API surface).
+* **Build verification** of the two torsion proofs is gated on the local
+  Docker container pool (each build does a fresh Mathlib clone; the gate is
+  ≤3 concurrent lean-build containers and ≥3 GiB free). When the pool frees,
+  run `./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03OQ01`.
+  All referenced Mathlib lemmas were statically confirmed present
+  (`charpoly_mulVecLin`, `Module.AEval.of_symm_smul`,
+  `LinearMap.aeval_self_charpoly`, `charpoly_monic`,
+  `mem_nonZeroDivisors_of_ne_zero`). Only residual risk: the
+  `rw [Module.AEval.of_symm_smul]` rewrite matching through `AEval'.of`.
+* The remaining `sorry` (`xModule_has_invariantFactorChain`) is **OQ-03-OQ-02
+  territory** (the `Module.equiv_directSum_of_isTorsion` regrouping
+  algorithm), not a single-session item for this sub-OQ.
 
 ## Next Action
 
-Next iteration should pick:
+1. **Build-verify** `Proofs.MinpolyCharpolyOQ03OQ01` once the container pool
+   frees (≤3 containers, ≥3 GiB). On green, mark the two torsion proofs
+   VERIFIED here and in `meta.json`. On breakage, fix the
+   `Module.AEval.of_symm_smul` API matching and rebuild.
 
-1. **S2 ACT** — discharge `xModule_isTorsionBy_charpoly` by:
-   a. Lift `Matrix.aeval_self_charpoly` across `Matrix.toLin'`'s
-      algebra-hom property to get `aeval M.mulVecLin M.charpoly = 0`
-      as a LinearMap.
-   b. Unfold `Module.AEval'`'s smul to relate it to the LinearMap action.
-   c. Conclude `M.charpoly • x = 0` for any `x : xModule M`.
-
-   Estimate: ~30-50 lines. Self-contained; no Mathlib gap.
-
-2. **S3 ACT** — discharge `xModule_isTorsion` from S2's result +
-   `Matrix.charpoly_monic`. The conversion `Monic ⇒ nonZeroDivisor` in
-   an integral domain F[X] is standard Mathlib API. Estimate: ~10-15 lines.
+2. **OQ-03-OQ-02 SCAFFOLD** — start the next sub-OQ:
 
 3. **OQ-03-OQ-02 SCAFFOLD** — start the next sub-OQ:
    `MinpolyCharpolyOQ03OQ02.lean` (~300 lines) applies
    `Module.equiv_directSum_of_isTorsion` to extract the invariant-factor
-   decomposition. Can begin in parallel with S2/S3 (statements are fixed).
+   decomposition. The two torsion statements it consumes are now proved.
 
 ## Attempt Counts
 
-- Total attempts: 1 (S1 scaffold, this session)
-- Current approach attempts: 1
-- Approaches tried: 1 (Module.AEval' + auto Module.Finite + sorry-guarded IsTorsion)
+- Total attempts: 2
+- Current approach attempts: 2
+- Approaches tried: 1 (Module.AEval' + auto Module.Finite + Cayley-Hamilton IsTorsion)
 
 ## Session Log
 
+* **S2 (researcher-4, 2026-06-19)** — accuracy pass. The two torsion
+  proofs (`xModule_isTorsionBy_charpoly`, `xModule_isTorsion`) were found
+  already discharged in the committed file (no longer `sorry`), but the
+  top docstring and this state.md still described them as sorry-guarded
+  and listed their discharge as the "Next Action". Corrected the prose to
+  reflect the true state: **1 remaining sorry**
+  (`xModule_has_invariantFactorChain`, deferred to OQ-03-OQ-02). Build
+  verification of the two proofs remains pending on the Docker container
+  pool. No proof content changed.
 * **S1 (researcher-1, 2026-05-12)** — created scaffold:
   `MinpolyCharpolyOQ03OQ01.lean` (187 lines, 3 def / 3 thm / 1 instance /
   3 sorries) + gallery entry (`meta.json` with 5 sections, `annotations.json`

--- a/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
@@ -24,7 +24,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 202,
+    "lineCount": 225,
     "assumptions": "0 axioms; 1 sorry — `xModule_has_invariantFactorChain` (the OQ-03-OQ-02 deliverable surface, restated here to fix the bridging API). The `xModule_isTorsionBy_charpoly` theorem (Cayley–Hamilton transported via the `Module.AEval'` synonym) is fully discharged in S8 (PR #18507) using `Matrix.charpoly_mulVecLin` + `LinearMap.aeval_self_charpoly` + `Module.AEval.of_symm_smul`. `xModule_isTorsion` is fully discharged in S10 (PR #18583) via `Matrix.charpoly_monic`/`mem_nonZeroDivisors_of_ne_zero` upgrading `IsTorsionBy` to `IsTorsion`. The `Module.Finite F[X]` instance is unconditional (no sorry) — it fires automatically from Mathlib's `Module.AEval.instFinitePolynomial`. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.{Basic,Minpoly}`, `Mathlib.LinearAlgebra.Matrix.ToLin`, `Mathlib.Algebra.Polynomial.Module.AEval`, `Mathlib.Algebra.Module.Torsion.Basic`, `Mathlib.RingTheory.Finiteness.Defs`, `Mathlib.Tactic`, `Proofs.MinpolyCharpolyOQ03`.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
@@ -166,7 +166,7 @@
       "Module"
     ],
     "namespace": "MinpolyCharpolyOQ03OQ01",
-    "lineCount": 202,
+    "lineCount": 225,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 3,


### PR DESCRIPTION
## Summary

Documentation-accuracy pass on `minpoly-charpoly-oq-03-oq-01` (first sub-OQ of the rational-canonical-form decomposition).

The committed file `proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean` had a **self-contradicting docstring**: it described `xModule_isTorsion` as "left as \`sorry\`" and `state.md` listed its discharge as the "Next Action" — but both torsion deliverables already carry real proofs (discharged historically in S8 #18507 / S10 #18583). An auditor reading the file would be confused by the mismatch.

## Changes

- **Docstring** (`.lean`): corrected the "scope" and Part 3 sections to state that `xModule_isTorsionBy_charpoly` and `xModule_isTorsion` are **proved** (build-pending kernel check), and that the single remaining `sorry` (`xModule_has_invariantFactorChain`) is deliberately deferred to OQ-03-OQ-02.
- **state.md**: updated phase, focus, blockers, next-action, and session log to reflect 1 remaining sorry (not 3), with the build-verification of the torsion proofs as the gated next step.
- **meta.json**: was already accurate (`status: formalized`, `badge: wip`, `sorries: 1`); only reconciled `lineCount` 202→225.

## Not changed

**No proof content was modified** — the diff is docstring/prose only (no `theorem`/`def`/`instance` lines touched). Sorry count remains 1. The two torsion proofs are statically complete (all referenced Mathlib lemmas confirmed present) but their full Lean build check remains pending on the local Docker container pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)