### PR TITLE
audit(erdos-679): sync stale meta block to source (10→9 sorries)

### DIFF
--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "wip",
-    "sorries": 10,
+    "sorries": 9,
     "erdosNumber": 679,
     "erdosUrl": "https://erdosproblems.com/679",
     "erdosProblemStatus": "open",
@@ -85,8 +85,8 @@
       "density_upper_bound: special n have density ≤ x/log x"
     ],
     "axiomCount": 0,
-    "lineCount": 259,
-    "assumptions": "0 axiom(s) and 10 sorry(s). See the Lean source for details.",
+    "lineCount": 284,
+    "assumptions": "0 axiom(s) and 9 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 16,
     "definitionCount": 18,
@@ -296,5 +296,5 @@
       "Proofs/Erdos679ProblemAristotle.lean"
     ]
   },
-  "sorries": 10
+  "sorries": 9
 }


### PR DESCRIPTION
## Audit finding

Research PR #26774 proved `omega_primorial` (reducing sorries 10 → 9) and updated the `leanFile` metrics block in `src/data/proofs/erdos-679/meta.json` (sorries 9, lineCount 284). But it left **three parallel metadata fields stale**, still claiming 10 sorries / 259 lines.

The gallery listing renders `meta.meta.sorries` (`scripts/annotations/build.ts:610`), **not** `leanFile.sorries` — so the entry was displaying **10 sorries while the source has 9**.

## Verification against `proofs/Proofs/Erdos679Problem.lean`

| metric | source | was (meta block) | now |
|--------|--------|------|-----|
| sorries | 9 (`grep -c sorry`) | 10 | 9 |
| lineCount | 284 (`wc -l`) | 259 | 284 |
| axiomCount | 0 | 0 | 0 |

## Changes (metadata only, no proof change)

- `meta.sorries`: 10 → 9
- `meta.lineCount`: 259 → 284
- `meta.assumptions`: "…10 sorry(s)…" → "…9 sorry(s)…"
- top-level `sorries`: 10 → 9

After the fix, `top.sorries == meta.sorries == leanFile.sorries == 9` and both `lineCount` fields == 284, all consistent with the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)