### PR TITLE
research(erdos-679): prove nth_prime_coprime_primorial_ari (Aristotle companion sorry 1→0)

### DIFF
--- a/proofs/Proofs/Erdos679ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos679ProblemAristotle.lean
@@ -71,10 +71,26 @@ It holds because the r-th prime is strictly larger than all primes in primorial 
 (which are the 0th through (r-1)-th primes).
 -/
 
-/-- The r-th prime is coprime with primorial r. -/
+/-- The r-th prime is coprime with primorial r.
+
+    Proof: `Nat.nth Nat.Prime r` is prime, so coprimality reduces to non-divisibility
+    of the product `∏ i < r, Nat.nth Nat.Prime i`. If it divided the product it would
+    divide some factor `Nat.nth Nat.Prime i` with `i < r`; two primes dividing one
+    another are equal, forcing `r = i` by injectivity of `Nat.nth Nat.Prime`,
+    contradicting `i < r`. Mirrors the coprimality step inside `omega_primorial`. -/
 theorem nth_prime_coprime_primorial_ari (r : ℕ) :
     Nat.Coprime (Nat.nth Nat.Prime r) (primorial r) := by
-  sorry
+  have hp : (Nat.nth Nat.Prime r).Prime := nth_prime_is_prime_ari r
+  rw [hp.coprime_iff_not_dvd]
+  intro hdvd
+  simp only [primorial] at hdvd
+  obtain ⟨i, hi, hdvd_i⟩ := hp.prime.exists_mem_finset_dvd hdvd
+  have hpi : (Nat.nth Nat.Prime i).Prime := nth_prime_is_prime_ari i
+  have heq : Nat.nth Nat.Prime r = Nat.nth Nat.Prime i :=
+    (Nat.prime_dvd_prime_iff_eq hp hpi).mp hdvd_i
+  have hni : r = i := Nat.nth_injective Nat.infinite_setOf_prime heq
+  rw [Finset.mem_range] at hi
+  omega
 
 /-
 ## Section 4: The omega_primorial Inductive Proof


### PR DESCRIPTION
## Summary

Fills the lone `sorry` in `proofs/Proofs/Erdos679ProblemAristotle.lean`:
`nth_prime_coprime_primorial_ari` — the r-th prime is coprime with
`primorial r` (the product of the first r primes).

With this, the entire Aristotle companion file for Erdős #679 is
**axiom-free and sorry-free**: `omega_primorial_ari` (ω(primorial r) = r)
now has all supporting lemmas discharged.

## Proof

A structural mirror of the already-verified coprimality step inside
`omega_primorial` (`Erdos679Problem.lean`), which #26774 confirmed builds
cleanly via `docker-build.sh`:

- `Nat.nth Nat.Prime r` is prime ⟹ coprimality reduces (via
  `Nat.Prime.coprime_iff_not_dvd`) to `¬ p ∣ ∏ i<r, Nat.nth Nat.Prime i`.
- If it divided the product, `Prime.exists_mem_finset_dvd` yields a factor
  `Nat.nth Nat.Prime i` (i < r) it divides.
- Two primes dividing one another are equal
  (`Nat.prime_dvd_prime_iff_eq`), forcing `r = i` by injectivity of
  `Nat.nth Nat.Prime` — contradicting `i < r`.

No new axioms, no new imports.

## Verification

⚠️ **Build-pending — relying on CI.** The Docker container pool was
saturated during this session (host at 4–5 concurrent `lean-build`
containers on an 8 GB VM), so a local `docker-build.sh` would have risked
OOM. The proof is a near-verbatim copy of an already-verified proof in the
same module (`omega_primorial`), so confidence is high; CI is the ground
truth.

The companion file is registered in `Proofs.lean:1899`, so CI compiles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)