### PR TITLE
research(erdos-736): repair non-compiling file, isolate finite_case sorry

### DIFF
--- a/proofs/Proofs/Erdos736Problem.lean
+++ b/proofs/Proofs/Erdos736Problem.lean
@@ -36,6 +36,7 @@ import Mathlib.Combinatorics.SimpleGraph.Subgraph
 import Mathlib.Combinatorics.SimpleGraph.Coloring
 import Mathlib.SetTheory.Cardinal.Basic
 import Mathlib.SetTheory.Cardinal.Ordinal
+import Mathlib.SetTheory.Cardinal.Regular
 import Mathlib.Data.Fintype.Basic
 
 open Cardinal SimpleGraph
@@ -50,21 +51,21 @@ namespace Erdos736
 **Chromatic number of a simple graph:**
 The minimum number of colors needed to properly color the vertices.
 -/
-noncomputable def chromaticNumber (V : Type*) (G : SimpleGraph V) : Cardinal :=
-  sInf { κ : Cardinal | ∃ (α : Type*), #α = κ ∧ Nonempty (G.Coloring α) }
+noncomputable def chromaticNumber (V : Type) (G : SimpleGraph V) : Cardinal :=
+  sInf { κ : Cardinal | ∃ (α : Type), #α = κ ∧ Nonempty (G.Coloring α) }
 
 /--
 **Finite subgraph:**
-A subgraph induced by a finite set of vertices.
+The subgraph of `G` induced by a finite set of vertices.
 -/
-def isFiniteSubgraph {V : Type*} (G : SimpleGraph V) (H : Subgraph G) : Prop :=
-  ∃ (S : Finset V), H = G.induce S
+def isFiniteSubgraph {V : Type} (G : SimpleGraph V) (H : Subgraph G) : Prop :=
+  ∃ (S : Finset V), H = (⊤ : G.Subgraph).induce (↑S : Set V)
 
 /--
 **Subgraph embedding:**
 H is isomorphic to a subgraph of G.
 -/
-def isSubgraphOf {V W : Type*} (H : SimpleGraph V) (G : SimpleGraph W) : Prop :=
+def isSubgraphOf {V W : Type} (H : SimpleGraph V) (G : SimpleGraph W) : Prop :=
   ∃ (f : V → W), Function.Injective f ∧
     ∀ v₁ v₂ : V, H.Adj v₁ v₂ → G.Adj (f v₁) (f v₂)
 
@@ -72,7 +73,7 @@ def isSubgraphOf {V W : Type*} (H : SimpleGraph V) (G : SimpleGraph W) : Prop :=
 **Finite subgraph class:**
 The class of all finite subgraphs of a graph G.
 -/
-def finiteSubgraphClass {V : Type*} (G : SimpleGraph V) :
+def finiteSubgraphClass {V : Type} (G : SimpleGraph V) :
     Set (Σ (n : ℕ), SimpleGraph (Fin n)) :=
   { ⟨n, H⟩ | ∃ (S : Finset V) (e : S ≃ Fin n),
     ∀ i j : Fin n, H.Adj i j ↔ G.Adj (e.symm i) (e.symm j) }
@@ -87,10 +88,10 @@ If G has chromatic number ℵ₁, then for every cardinal m, there exists
 a graph G_m with χ(G_m) = m whose finite subgraphs are all subgraphs of G.
 -/
 def TaylorConjecture : Prop :=
-  ∀ (V : Type*) (G : SimpleGraph V),
+  ∀ (V : Type) (G : SimpleGraph V),
     chromaticNumber V G = aleph 1 →
     ∀ (m : Cardinal),
-      ∃ (W : Type*) (H : SimpleGraph W),
+      ∃ (W : Type) (H : SimpleGraph W),
         chromaticNumber W H = m ∧
         ∀ (n : ℕ) (F : SimpleGraph (Fin n)),
           isSubgraphOf F H → isSubgraphOf F G
@@ -100,11 +101,11 @@ def TaylorConjecture : Prop :=
 Same as above but for any uncountable cardinal κ.
 -/
 def GeneralizedTaylorConjecture : Prop :=
-  ∀ (κ : Cardinal), κ.IsRegular → κ > aleph 0 →
-    ∀ (V : Type*) (G : SimpleGraph V),
+  ∀ (κ : Cardinal), Cardinal.IsRegular κ → κ > aleph 0 →
+    ∀ (V : Type) (G : SimpleGraph V),
       chromaticNumber V G = κ →
       ∀ (m : Cardinal),
-        ∃ (W : Type*) (H : SimpleGraph W),
+        ∃ (W : Type) (H : SimpleGraph W),
           chromaticNumber W H = m ∧
           ∀ (n : ℕ) (F : SimpleGraph (Fin n)),
             isSubgraphOf F H → isSubgraphOf F G
@@ -125,7 +126,7 @@ A family F is realizable at ℵ_α if there exists a graph G with
 χ(G) = ℵ_α and all finite subgraphs of G are in F.
 -/
 def realizableAt (F : FiniteGraphFamily) (α : Ordinal) : Prop :=
-  ∃ (V : Type*) (G : SimpleGraph V),
+  ∃ (V : Type) (G : SimpleGraph V),
     chromaticNumber V G = aleph α ∧
     finiteSubgraphClass G ⊆ F
 
@@ -141,49 +142,64 @@ def ErdosGeneralQuestion : Prop :=
 ## Part IV: The Komjáth-Shelah Consistency Result
 -/
 
-/--
+/-
 **Komjáth-Shelah (2005):**
 It is consistent with ZFC that there exists a graph G with χ(G) = ℵ₁
 such that any graph H whose finite subgraphs are all subgraphs of G
 satisfies χ(H) ≤ ℵ₂.
--/
-/--
+
 **The conjecture is independent:**
 Taylor's conjecture cannot be decided in ZFC alone.
--/
-/-
-## Part V: Related Concepts
+
+(These are meta-mathematical consistency/independence results, not ZFC
+theorems; they are recorded here as prose rather than as Lean declarations.)
 -/
 
-/--
+/-
+## Part V: Related Concepts
+
 **De Bruijn-Erdős theorem (finite version):**
 If every finite subgraph of G is k-colorable, then G is k-colorable.
-(This requires the axiom of choice.)
--/
-/--
+(This requires the axiom of choice.) Mathlib does not currently provide
+this compactness theorem; it is the key missing ingredient for `finite_case`.
+
 **Compactness in graph coloring:**
 The chromatic number of a graph is determined by its finite subgraphs
 in a limiting sense.
--/
-/--
+
 **Chromatic number and cardinal arithmetic:**
 For infinite graphs, chromatic number interacts with cardinal arithmetic.
 -/
+
 /-
 ## Part VI: Special Cases
--/
 
-/--
 **Countable chromatic number:**
 For graphs with χ(G) = ℵ₀, the Taylor question is easier.
+
+**Finite case is trivial (informal):**
+For finite chromatic number, inheritance is straightforward in principle —
+see `finite_case` below for the precise statement.
 -/
 /--
-**Finite case is trivial:**
-For finite chromatic number, inheritance is straightforward.
+**Finite chromatic number case.**
+If `χ(G) = k` (finite), then for every `m ≤ k` there is a graph `H` with
+`χ(H) = m` all of whose finite subgraphs embed into `G`.
+
+The mathematically clean construction takes `H` to be an induced subgraph of
+`G` on a suitable vertex subset `S`, so that finite subgraphs of `H` embed
+into `G` for free. The remaining content is an *intermediate-value* property:
+some induced subgraph attains chromatic number exactly `m` for each
+`0 ≤ m ≤ k`. Establishing this needs (i) a finite subgraph witnessing
+`χ = k`, which is the **de Bruijn-Erdős compactness theorem** (not yet in
+Mathlib), and (ii) a vertex-deletion continuity step. The boundary cases
+`m = 0` (`H = ⊥` on an empty type) and `m = k` (`H = G`) are immediate; the
+intermediate cases are the obstruction. Left as `sorry` pending the missing
+compactness infrastructure.
 -/
-theorem finite_case (V : Type*) (G : SimpleGraph V) (k : ℕ) :
+theorem finite_case (V : Type) (G : SimpleGraph V) (k : ℕ) :
     chromaticNumber V G = k →
-    ∀ m ≤ k, ∃ (W : Type*) (H : SimpleGraph W),
+    ∀ m ≤ k, ∃ (W : Type) (H : SimpleGraph W),
       chromaticNumber W H = m ∧
       ∀ (n : ℕ) (F : SimpleGraph (Fin n)),
         isSubgraphOf F H → isSubgraphOf F G := by

--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -59,8 +59,8 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 0,
-    "assumptions": "0 axiom declarations. All former axioms (komjath_shelah_consistency, taylor_conjecture_independent, de_bruijn_erdos, chromatic_compactness, chromatic_cardinal_interaction, countable_case) now proved as theorems or definitions. 1 sorry remains in finite_case.",
-    "lineCount": 203,
+    "assumptions": "0 axiom declarations and no structure-encoded assumptions. The Komjáth-Shelah consistency result, the ZFC-independence statement, and the de Bruijn-Erdős / compactness facts are recorded as prose documentation rather than Lean declarations -- they are meta-mathematical results, not ZFC theorems. The conjecture statements are scoped to universe 0 (vertex types in `Type`, cardinals in `Cardinal.{0}`). 1 sorry remains in `finite_case`, blocked on the de Bruijn-Erdős compactness theorem, which Mathlib does not currently provide.",
+    "lineCount": 219,
     "theoremCount": 2,
     "prerequisites": [
       "Set-theoretic graph theory: infinite chromatic numbers (ℵ₁, ℵ₂)",
@@ -74,7 +74,7 @@
     "historicalContext": "Walter Taylor conjectured that if a graph G has chromatic number ℵ₁, then its finite subgraphs are 'rich enough' to build graphs of any chromatic number. Komjáth and Shelah (2005) proved this is independent of ZFC, showing in some models there exists a counterexample where the bound is ℵ₂. The background to this problem lies in the De Bruijn-Erdős theorem (1951), which established that for finite chromatic numbers, colorability is determined entirely by finite subgraphs. Erdős was fascinated by whether similar compactness principles extend to uncountable chromatic numbers, and Taylor's conjecture was one attempt to make that precise at the ℵ₁ level. The Komjáth-Shelah independence result places this question firmly at the boundary between combinatorics and set-theoretic forcing.",
     "problemStatement": "Let G be a graph with chromatic number ℵ₁. Is there, for every cardinal m, some graph G_m of chromatic number m such that every finite subgraph of G_m is a subgraph of G?",
     "text": "Taylor's conjecture: If G has chromatic number ℵ₁, can we build graphs of any chromatic number using only finite subgraphs of G? Komjáth-Shelah showed this is independent of ZFC - it can fail in some models.",
-    "proofStrategy": "The formalization defines chromatic number for infinite graphs, states Taylor's conjecture formally, and axiomatizes the Komjáth-Shelah consistency result showing independence from ZFC.",
+    "proofStrategy": "The formalization defines chromatic number for infinite graphs (universe 0), states Taylor's conjecture and its generalization formally as Lean propositions, and documents the Komjáth-Shelah consistency/independence result as prose. The single computational claim, finite_case, reduces to a de Bruijn-Erdős compactness step that Mathlib does not yet provide.",
     "keyInsights": [
       "The problem connects finite combinatorics to infinite graph theory",
       "Independence from ZFC means the answer depends on set-theoretic axioms",
@@ -170,7 +170,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos736",
-    "lineCount": 203,
+    "lineCount": 219,
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 9,

--- a/src/data/research/problems/erdos-736-incomplete-01.json
+++ b/src/data/research/problems/erdos-736-incomplete-01.json
@@ -1,39 +1,64 @@
 {
   "slug": "erdos-736-incomplete-01",
   "title": "Erdős #736: Chromatic Numbers and Finite Subgraph Inheritance (1 sorry)",
-  "phase": "NEW",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in graph theory: Erdős #736: Chromatic Numbers and Finite Subgraph Inheritance (1 sorry).",
-    "whyMatters": []
+    "formal": "\\chi(G) = \\aleph_1 \\implies \\forall m,\\ \\exists G_m:\\ \\chi(G_m) = m \\wedge (\\text{every finite subgraph of } G_m \\text{ is a subgraph of } G)",
+    "plain": "Taylor's conjecture: if a graph G has chromatic number ℵ₁, then for every cardinal m there is a graph of chromatic number m whose finite subgraphs all embed into G. Komjáth-Shelah (2005) showed this is independent of ZFC.",
+    "whyMatters": [
+      "Sits at the boundary between finite combinatorics and set-theoretic forcing.",
+      "Sharpens the contrast with de Bruijn-Erdős: finite chromatic number is determined by finite subgraphs, uncountable chromatic number is not."
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "finite_case statement is mathematically true (intermediate-value of chromatic number over induced subgraphs), but left as a documented sorry pending de Bruijn-Erdős compactness."
+    ],
+    "open": [
+      "Taylor's conjecture (independent of ZFC per Komjáth-Shelah 2005).",
+      "Erdős's general characterization of realizable finite-graph families at each ℵ_α."
+    ],
+    "goal": "Maintain a clean, compiling formalization of the problem statements; discharge finite_case once compactness infrastructure exists."
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-03T22:29:17.628Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "ORIENT",
+    "since": "2026-06-19T00:00:00.000Z",
+    "iteration": 2,
+    "focus": "Repaired the non-compiling gallery file; finite_case isolated as the sole sorry, blocked on de Bruijn-Erdős compactness (absent from Mathlib).",
+    "blockers": [
+      "de Bruijn-Erdős graph-coloring compactness theorem is not in Mathlib.",
+      "No bridge between the custom Cardinal-valued chromatic number and Mathlib's ℕ∞-valued chromaticNumber/Colorable API."
+    ],
+    "nextAction": "Build or locate de Bruijn-Erdős compactness (universe 0), then prove the chromatic intermediate-value lemma for induced subgraphs to discharge finite_case.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "2026-06-19 (researcher-2): The gallery file Erdos736Problem.lean did NOT compile -- it carried 6 pre-existing elaboration errors despite meta.json claiming status 'formalized, 1 sorry'. Repaired all 6 and the file now builds cleanly (verified via docker-build) with exactly 1 sorry in `finite_case`. Fixes: (1) `isFiniteSubgraph` compared a Subgraph to `G.induce S`, which is a SimpleGraph on a subtype, not a `G.Subgraph` -- replaced with `(⊤ : G.Subgraph).induce ↑S`; (2) universe-inference failures on bare `Cardinal`/`Ordinal` binders in TaylorConjecture / GeneralizedTaylorConjecture / realizableAt / ErdosGeneralQuestion -- resolved by scoping vertex types to `Type` and cardinals to `Cardinal.{0}` (universe 0, the standard combinatorial setting); (3) `κ.IsRegular` dot notation failed (κ is a Quot) AND `Cardinal.IsRegular`'s module was unimported -- added `import Mathlib.SetTheory.Cardinal.Regular` and used `Cardinal.IsRegular κ`; (4) six orphaned `/-- -/` doc comments (documenting deleted axioms) converted to `/- -/` prose blocks; (5) `Iff.rfl` for erdos_736_summary then went through once TaylorConjecture elaborated.",
+    "builtItems": [
+      "Erdos736Problem.lean now compiles (was previously broken with 6 errors); 9 defs + 2 theorems, 0 axioms, 1 sorry"
+    ],
+    "insights": [
+      "The main Taylor conjecture and Erdős's general question are OPEN and, per Komjáth-Shelah (2005), independent of ZFC -- not provable in Lean. They are correctly stated as `def ... : Prop` (problem statements), not theorems.",
+      "The only computational obligation, `finite_case`, is TRUE but its clean proof needs the de Bruijn-Erdős compactness theorem (every finite subgraph k-colorable ⇒ G k-colorable), which Mathlib does NOT currently provide (no 'Bruijn' lemma in Mathlib.Combinatorics).",
+      "Proof sketch for finite_case: take H to be an induced subgraph of G on a vertex subset S, so finite subgraphs of H embed into G for free; the residual content is an intermediate-value property -- some induced subgraph has chromatic number exactly m for each 0 ≤ m ≤ k. Boundary cases m=0 (H=⊥ on empty type) and m=k (H=G) are immediate; intermediate m needs a finite χ=k witness (de Bruijn-Erdős) plus vertex-deletion continuity.",
+      "The file's custom Cardinal-valued `chromaticNumber` is disconnected from Mathlib's ℕ∞-valued `SimpleGraph.chromaticNumber` / `Colorable` API; bridging them is itself prerequisite infrastructure for any real proof."
+    ],
+    "mathlibGaps": [
+      "de Bruijn-Erdős compactness theorem for graph colorings is absent from Mathlib (Mathlib.Combinatorics.SimpleGraph.Coloring has Colorable/chromaticNumber but no compactness result).",
+      "No bridge lemma between a Cardinal-valued infinite chromatic number and Mathlib's ℕ∞-valued chromaticNumber."
+    ],
+    "nextSteps": [
+      "To discharge finite_case: first build (or locate) de Bruijn-Erdős compactness in the universe-0 setting, then prove a chromatic intermediate-value lemma for induced subgraphs. This is a multi-session infrastructure project (~200+ lines, Zorn/ultrafilter compactness argument).",
+      "Alternatively, restate finite_case against Mathlib's `SimpleGraph.Colorable`/`chromaticNumber` to reuse the finite coloring API, at the cost of a definition-bridging lemma.",
+      "Lower-risk interim: leave finite_case as a documented sorry (now that the file compiles) and treat the main conjectures as the intended open-problem statements."
+    ]
   },
   "tags": [
     "seeker-selected",
@@ -47,12 +72,19 @@
     "erdos-736"
   ],
   "references": {
-    "papers": [],
-    "urls": [],
-    "mathlib": []
+    "papers": [
+      "Komjáth, Péter and Shelah, Saharon, 'Finite subgraphs of uncountably chromatic graphs', J. Graph Theory (2005), 28-38."
+    ],
+    "urls": [
+      "https://erdosproblems.com/736"
+    ],
+    "mathlib": [
+      "Mathlib.Combinatorics.SimpleGraph.Coloring (Colorable, chromaticNumber)",
+      "Mathlib.SetTheory.Cardinal.Regular (Cardinal.IsRegular)"
+    ]
   },
   "started": "2026-04-03T22:29:17.628Z",
-  "lastUpdate": "2026-04-03T22:29:17.628Z",
+  "lastUpdate": "2026-06-19T00:00:00.000Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

`Erdos736Problem.lean` (Erdős #736, Taylor's chromatic-inheritance conjecture) **did not compile** — it carried **6 pre-existing elaboration errors** despite `meta.json` claiming `status: formalized, sorries: 1`. This PR repairs all of them; the file now **builds cleanly** (verified via `docker-build.sh`) with exactly **1 documented sorry** in `finite_case`.

## Errors fixed
1. **`isFiniteSubgraph`** compared a `Subgraph` to `G.induce S`, which is a `SimpleGraph` on a subtype — not a `G.Subgraph`. Replaced with `(⊤ : G.Subgraph).induce ↑S`.
2. **Universe-inference failures** on bare `Cardinal`/`Ordinal` binders in `TaylorConjecture`, `GeneralizedTaylorConjecture`, `realizableAt`, `ErdosGeneralQuestion`. Resolved by scoping vertex types to `Type` and cardinals to `Cardinal.{0}` (universe 0 — the standard combinatorial setting).
3. **`κ.IsRegular`** dot notation failed (`κ` is a `Quot`) and `Cardinal.IsRegular`'s module was unimported. Added `import Mathlib.SetTheory.Cardinal.Regular` and used `Cardinal.IsRegular κ`.
4. **Six orphaned `/-- -/` doc comments** (documenting since-deleted axioms) converted to `/- -/` prose blocks.
5. `erdos_736_summary := Iff.rfl` then elaborates once `TaylorConjecture` is well-formed.

## The remaining sorry
`finite_case` is mathematically **true** but its clean proof needs the **de Bruijn-Erdős compactness theorem** (every finite subgraph $k$-colorable ⇒ $G$ is $k$-colorable), which **Mathlib does not currently provide**. Decomposition recorded in the research notes: reduce to an induced subgraph of $G$ (finite subgraphs embed for free), leaving a chromatic intermediate-value step whose only hard input is a finite $\chi=k$ witness (de Bruijn-Erdős) + vertex-deletion continuity. Boundary cases $m=0,k$ are immediate.

## Honesty notes
- Main Taylor conjecture + Erdős's general question are **OPEN / independent of ZFC** (Komjáth-Shelah 2005); they remain `def ... : Prop` problem statements, not theorems.
- The consistency/independence and de Bruijn-Erdős facts are **prose**, not Lean declarations; `meta.json` `assumptions` corrected accordingly (previously claimed they were "proved as theorems or definitions").
- 0 axioms, 0 structure-encoded assumptions; status stays `formalized` (1 sorry).

## Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos736Problem` → builds, only the expected `finite_case` sorry warning.