### PR TITLE
research(erdos-736): verified contrapositive de Bruijn–Erdős corollary

### DIFF
--- a/proofs/Proofs/Erdos736Problem.lean
+++ b/proofs/Proofs/Erdos736Problem.lean
@@ -56,10 +56,10 @@ noncomputable def chromaticNumber (V : Type*) (G : SimpleGraph V) : Cardinal :=
 
 /--
 **Finite subgraph:**
-A subgraph induced by a finite set of vertices.
+A subgraph supported on a finite set of vertices.
 -/
 def isFiniteSubgraph {V : Type*} (G : SimpleGraph V) (H : Subgraph G) : Prop :=
-  ∃ (S : Finset V), H = G.induce S
+  H.verts.Finite
 
 /--
 **Subgraph embedding:**
@@ -90,8 +90,8 @@ a graph G_m with χ(G_m) = m whose finite subgraphs are all subgraphs of G.
 def TaylorConjecture : Prop :=
   ∀ (V : Type*) (G : SimpleGraph V),
     chromaticNumber V G = aleph 1 →
-    ∀ (m : Cardinal),
-      ∃ (W : Type*) (H : SimpleGraph W),
+    ∀ (m : Cardinal.{0}),
+      ∃ (W : Type) (H : SimpleGraph W),
         chromaticNumber W H = m ∧
         ∀ (n : ℕ) (F : SimpleGraph (Fin n)),
           isSubgraphOf F H → isSubgraphOf F G
@@ -101,11 +101,11 @@ def TaylorConjecture : Prop :=
 Same as above but for any uncountable cardinal κ.
 -/
 def GeneralizedTaylorConjecture : Prop :=
-  ∀ (κ : Cardinal), κ.IsRegular → κ > aleph 0 →
+  ∀ (κ : Cardinal.{0}), Cardinal.IsRegular κ → κ > aleph 0 →
     ∀ (V : Type*) (G : SimpleGraph V),
       chromaticNumber V G = κ →
-      ∀ (m : Cardinal),
-        ∃ (W : Type*) (H : SimpleGraph W),
+      ∀ (m : Cardinal.{0}),
+        ∃ (W : Type) (H : SimpleGraph W),
           chromaticNumber W H = m ∧
           ∀ (n : ℕ) (F : SimpleGraph (Fin n)),
             isSubgraphOf F H → isSubgraphOf F G
@@ -125,7 +125,7 @@ def FiniteGraphFamily := Set (Σ (n : ℕ), SimpleGraph (Fin n))
 A family F is realizable at ℵ_α if there exists a graph G with
 χ(G) = ℵ_α and all finite subgraphs of G are in F.
 -/
-def realizableAt (F : FiniteGraphFamily) (α : Ordinal) : Prop :=
+def realizableAt (F : FiniteGraphFamily) (α : Ordinal.{0}) : Prop :=
   ∃ (V : Type*) (G : SimpleGraph V),
     chromaticNumber V G = aleph α ∧
     finiteSubgraphClass G ⊆ F
@@ -135,20 +135,20 @@ def realizableAt (F : FiniteGraphFamily) (α : Ordinal) : Prop :=
 Characterize which families F_α of finite graphs are realizable at ℵ_α.
 -/
 def ErdosGeneralQuestion : Prop :=
-  ∃ (characterization : FiniteGraphFamily → Ordinal → Prop),
-    ∀ F α, characterization F α ↔ realizableAt F α
+  ∃ (characterization : FiniteGraphFamily → Ordinal.{0} → Prop),
+    ∀ (F : FiniteGraphFamily) (α : Ordinal.{0}),
+      characterization F α ↔ realizableAt F α
 
 /-
 ## Part IV: The Komjáth-Shelah Consistency Result
 -/
 
-/--
+/-
 **Komjáth-Shelah (2005):**
 It is consistent with ZFC that there exists a graph G with χ(G) = ℵ₁
 such that any graph H whose finite subgraphs are all subgraphs of G
 satisfies χ(H) ≤ ℵ₂.
--/
-/--
+
 **The conjecture is independent:**
 Taylor's conjecture cannot be decided in ZFC alone.
 -/
@@ -178,12 +178,11 @@ theorem deBruijn_erdos_coloring {V : Type*} (G : SimpleGraph V) (n : ℕ)
   intro G' hfin
   exact (h G' hfin).some
 
-/--
+/-
 **Compactness in graph coloring:**
 The chromatic number of a graph is determined by its finite subgraphs
 in a limiting sense.
--/
-/--
+
 **Chromatic number and cardinal arithmetic:**
 For infinite graphs, chromatic number interacts with cardinal arithmetic.
 -/
@@ -191,7 +190,7 @@ For infinite graphs, chromatic number interacts with cardinal arithmetic.
 ## Part VI: Special Cases
 -/
 
-/--
+/-
 **Countable chromatic number:**
 For graphs with χ(G) = ℵ₀, the Taylor question is easier.
 -/

--- a/proofs/Proofs/Erdos736Problem.lean
+++ b/proofs/Proofs/Erdos736Problem.lean
@@ -34,6 +34,7 @@ Tags: graph-theory, chromatic-number, infinite-graphs, set-theory
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Subgraph
 import Mathlib.Combinatorics.SimpleGraph.Coloring
+import Mathlib.Combinatorics.SimpleGraph.Finsubgraph
 import Mathlib.SetTheory.Cardinal.Basic
 import Mathlib.SetTheory.Cardinal.Ordinal
 import Mathlib.Data.Fintype.Basic
@@ -156,10 +157,27 @@ Taylor's conjecture cannot be decided in ZFC alone.
 -/
 
 /--
-**De Bruijn-Erdős theorem (finite version):**
-If every finite subgraph of G is k-colorable, then G is k-colorable.
-(This requires the axiom of choice.)
+**De Bruijn–Erdős theorem (coloring/compactness version):**
+If every finite (induced) subgraph of `G` is `n`-colorable, then `G` itself is
+`n`-colorable. This is the graph-coloring form of the compactness principle and
+genuinely requires the axiom of choice (here packaged via Mathlib's inverse-limit
+argument `nonempty_hom_of_forall_finite_subgraph_hom`).
+
+This is the key piece of infrastructure underlying the "finite subgraph
+inheritance" theme of Erdős #736: the chromatic number of an infinite graph is
+controlled by its finite subgraphs. It is fully machine-checked; the only
+foundational dependency beyond the usual `propext`/`Quot.sound` is
+`Classical.choice`.
 -/
+theorem deBruijn_erdos_coloring {V : Type*} (G : SimpleGraph V) (n : ℕ)
+    (h : ∀ G' : G.Subgraph, G'.verts.Finite → G'.coe.Colorable n) :
+    G.Colorable n := by
+  -- `Colorable n` unfolds to `Nonempty (G →g completeGraph (Fin n))`; apply
+  -- compactness with the finite target graph `completeGraph (Fin n)`.
+  apply SimpleGraph.nonempty_hom_of_forall_finite_subgraph_hom
+  intro G' hfin
+  exact (h G' hfin).some
+
 /--
 **Compactness in graph coloring:**
 The chromatic number of a graph is determined by its finite subgraphs

--- a/proofs/Proofs/Erdos736Problem.lean
+++ b/proofs/Proofs/Erdos736Problem.lean
@@ -37,6 +37,7 @@ import Mathlib.Combinatorics.SimpleGraph.Coloring
 import Mathlib.Combinatorics.SimpleGraph.Finsubgraph
 import Mathlib.SetTheory.Cardinal.Basic
 import Mathlib.SetTheory.Cardinal.Ordinal
+import Mathlib.SetTheory.Cardinal.Regular
 import Mathlib.Data.Fintype.Basic
 
 open Cardinal SimpleGraph
@@ -50,9 +51,16 @@ namespace Erdos736
 /--
 **Chromatic number of a simple graph:**
 The minimum number of colors needed to properly color the vertices.
+
+We fix the vertex universe to `Type` (i.e. `Type 0`) and the color universe to
+`Type`/`Cardinal.{0}`. This is no loss of generality: `Type 0` already contains
+types of every cardinality relevant here (ℵ₁, ℵ₂, …), and any proper coloring can
+be taken to use at most `#V` colors, so the infimum is unchanged. Pinning the
+universe also keeps the cardinal-valued statements below free of universe
+metavariables.
 -/
-noncomputable def chromaticNumber (V : Type*) (G : SimpleGraph V) : Cardinal :=
-  sInf { κ : Cardinal | ∃ (α : Type*), #α = κ ∧ Nonempty (G.Coloring α) }
+noncomputable def chromaticNumber (V : Type) (G : SimpleGraph V) : Cardinal.{0} :=
+  sInf { κ : Cardinal.{0} | ∃ (α : Type), #α = κ ∧ Nonempty (G.Coloring α) }
 
 /--
 **Finite subgraph:**
@@ -88,7 +96,7 @@ If G has chromatic number ℵ₁, then for every cardinal m, there exists
 a graph G_m with χ(G_m) = m whose finite subgraphs are all subgraphs of G.
 -/
 def TaylorConjecture : Prop :=
-  ∀ (V : Type*) (G : SimpleGraph V),
+  ∀ (V : Type) (G : SimpleGraph V),
     chromaticNumber V G = aleph 1 →
     ∀ (m : Cardinal.{0}),
       ∃ (W : Type) (H : SimpleGraph W),
@@ -102,7 +110,7 @@ Same as above but for any uncountable cardinal κ.
 -/
 def GeneralizedTaylorConjecture : Prop :=
   ∀ (κ : Cardinal.{0}), Cardinal.IsRegular κ → κ > aleph 0 →
-    ∀ (V : Type*) (G : SimpleGraph V),
+    ∀ (V : Type) (G : SimpleGraph V),
       chromaticNumber V G = κ →
       ∀ (m : Cardinal.{0}),
         ∃ (W : Type) (H : SimpleGraph W),
@@ -126,7 +134,7 @@ A family F is realizable at ℵ_α if there exists a graph G with
 χ(G) = ℵ_α and all finite subgraphs of G are in F.
 -/
 def realizableAt (F : FiniteGraphFamily) (α : Ordinal.{0}) : Prop :=
-  ∃ (V : Type*) (G : SimpleGraph V),
+  ∃ (V : Type) (G : SimpleGraph V),
     chromaticNumber V G = aleph α ∧
     finiteSubgraphClass G ⊆ F
 
@@ -178,6 +186,24 @@ theorem deBruijn_erdos_coloring {V : Type*} (G : SimpleGraph V) (n : ℕ)
   intro G' hfin
   exact (h G' hfin).some
 
+/--
+**De Bruijn–Erdős theorem (contrapositive form):**
+If `G` is *not* `n`-colorable, then some *finite* subgraph of `G` is already not
+`n`-colorable. Equivalently, the chromatic number of an infinite graph is the
+supremum of the chromatic numbers of its finite subgraphs.
+
+This is the form of the theorem most directly relevant to Erdős #736: it says the
+obstruction to a small coloring always lives in a finite part of the graph, so the
+"finite subgraph inheritance" behaviour of chromatic number is genuine. It is a
+short, fully machine-checked consequence of `deBruijn_erdos_coloring`.
+-/
+theorem exists_finite_subgraph_not_colorable {V : Type*} (G : SimpleGraph V) (n : ℕ)
+    (h : ¬ G.Colorable n) :
+    ∃ G' : G.Subgraph, G'.verts.Finite ∧ ¬ G'.coe.Colorable n := by
+  by_contra hcon
+  push_neg at hcon
+  exact h (deBruijn_erdos_coloring G n hcon)
+
 /-
 **Compactness in graph coloring:**
 The chromatic number of a graph is determined by its finite subgraphs
@@ -195,26 +221,28 @@ For infinite graphs, chromatic number interacts with cardinal arithmetic.
 For graphs with χ(G) = ℵ₀, the Taylor question is easier.
 -/
 /--
-**Finite case is trivial:**
-For finite chromatic number, inheritance is straightforward.
+**Finite case:**
+For finite chromatic number `k`, every value `m ≤ k` is itself realized *as a
+subgraph of `G`*, so the finite-subgraph inheritance is automatic.
+
+This is true and not deep: the witness `H` is an induced subgraph of `G`, so every
+finite subgraph of `H` is a finite subgraph of `G` for free, and a subgraph of `G`
+with chromatic number exactly `m` exists by the discrete intermediate-value
+principle — deleting vertices one at a time lowers the chromatic number by at most
+one, so it passes through every value between `k` and `0`.
+
+The remaining `sorry` is the formalization of that intermediate-value argument for
+the (custom, `Cardinal`-valued) `chromaticNumber` used here; it is a self-contained
+side result rather than part of the open conjecture itself. See `knowledge.md` for
+the proof sketch.
 -/
-theorem finite_case (V : Type*) (G : SimpleGraph V) (k : ℕ) :
+theorem finite_case (V : Type) (G : SimpleGraph V) (k : ℕ) :
     chromaticNumber V G = k →
-    ∀ m ≤ k, ∃ (W : Type*) (H : SimpleGraph W),
+    ∀ m ≤ k, ∃ (W : Type) (H : SimpleGraph W),
       chromaticNumber W H = m ∧
       ∀ (n : ℕ) (F : SimpleGraph (Fin n)),
         isSubgraphOf F H → isSubgraphOf F G := by
   intro _ _ _
   sorry
-
-/-
-## Part VII: Summary
--/
-
-/--
-**Summary of the problem:**
--/
-theorem erdos_736_summary : TaylorConjecture ↔ TaylorConjecture :=
-  Iff.rfl
 
 end Erdos736

--- a/research/problems/erdos-736/knowledge.md
+++ b/research/problems/erdos-736/knowledge.md
@@ -75,3 +75,9 @@ finite-subgraph / compactness infrastructure that the problem is built around.
   deferred.
 - Refreshed gallery `meta.json` to reflect the now-proved de Bruijn–Erdős theorem
   (previously listed only as a "statement").
+- **Build-verified** via Docker (`Built Proofs.Erdos736Problem`, 1158 jobs, 0 errors).
+  `#print axioms` confirms both `deBruijn_erdos_coloring` and
+  `exists_finite_subgraph_not_colorable` depend only on
+  `propext`/`Classical.choice`/`Quot.sound` — fully verified, no `sorryAx`.
+- Opened PR **#26780** (`research` label only, no Judge review per math-agent policy).
+- Remaining work: `finite_case` discrete-IVT side lemma still deferred (1 `sorry`).

--- a/research/problems/erdos-736/knowledge.md
+++ b/research/problems/erdos-736/knowledge.md
@@ -1,0 +1,77 @@
+# Erdős #736 — Chromatic Numbers and Finite Subgraph Inheritance
+
+**Source:** https://erdosproblems.com/736
+**Status:** OPEN (Taylor's conjecture; consistency/independence results known)
+
+## Problem Summary
+
+Let `G` be a graph with chromatic number ℵ₁. Taylor's conjecture asks: is there,
+for every cardinal `m`, a graph `G_m` of chromatic number `m` such that every
+finite subgraph of `G_m` is a subgraph of `G`?
+
+Komjáth–Shelah (2005) showed it is **consistent with ZFC** that the answer is NO,
+so the conjecture is independent of ZFC and cannot be proved outright in Lean.
+The achievable goal is to formalize the problem precisely and verify the supporting
+finite-subgraph / compactness infrastructure that the problem is built around.
+
+## Verified Results (machine-checked)
+
+- **`deBruijn_erdos_coloring`** — the de Bruijn–Erdős coloring theorem: if every
+  finite subgraph of `G` is `n`-colorable then `G` is `n`-colorable. Proved via
+  Mathlib's compactness lemma `SimpleGraph.nonempty_hom_of_forall_finite_subgraph_hom`
+  applied with target `completeGraph (Fin n)`. Depends only on
+  `propext` / `Quot.sound` / `Classical.choice`.
+- **`exists_finite_subgraph_not_colorable`** — contrapositive form: if `G` is not
+  `n`-colorable, some *finite* subgraph already is not `n`-colorable. Short
+  consequence of the above (`by_contra` + `push_neg`). This is the form most
+  directly relevant to #736: the obstruction to a small coloring always lives in a
+  finite part of the graph.
+
+## Open / unformalized side result
+
+- **`finite_case`** (1 `sorry`): for finite chromatic number `k`, every `m ≤ k`
+  is realized as a subgraph of `G`, so inheritance is automatic.
+  - **Proof sketch (true, not deep):** take `H` to be an induced subgraph of `G`
+    with `χ(H) = m`. Any finite subgraph of an induced subgraph of `G` is a finite
+    subgraph of `G`, so inheritance is free. Existence of an induced subgraph of
+    chromatic number exactly `m` follows from the **discrete intermediate-value
+    principle**: deleting vertices one at a time lowers the chromatic number by at
+    most one, so as we delete down to the empty graph (`χ = 0`) the value passes
+    through every `m` with `0 ≤ m ≤ k`.
+  - **Why still `sorry`:** the file uses a custom `Cardinal`-valued
+    `chromaticNumber` (not Mathlib's `ℕ∞`-valued `SimpleGraph.chromaticNumber`), so
+    the "one vertex deletion changes χ by ≤ 1" lemma must be built from scratch
+    (~150–250 lines). It is a self-contained side lemma, **not** part of the open
+    conjecture, so it is deferred.
+
+## Mathlib gaps
+
+- Custom `Cardinal`-valued chromatic number has no Mathlib lemmas; Mathlib's
+  `SimpleGraph.chromaticNumber : ℕ∞` is the only available API and does not cover
+  the cardinal-valued infinite setting used here.
+- No "vertex-deletion intermediate value" lemma for chromatic number in Mathlib.
+
+## Next Steps
+
+1. Build-verify the file and confirm axiom profile of the two verified theorems.
+2. (Optional) Formalize the discrete IVT to discharge `finite_case` — either by
+   building a `Cardinal`-valued vertex-deletion lemma, or by re-expressing
+   `finite_case` against Mathlib's `ℕ∞`-valued chromatic number for the finite case.
+3. Consider stating the cardinal-supremum form: `χ(G) = ⨆ finite subgraphs χ(G')`
+   for graphs of countable chromatic number, as a further verified consequence.
+
+## Session Log
+
+### Session 2026-06-19 (Researcher-4) — FRESH/continuation
+
+**Mode:** continuation of own branch `research/erdos-736-debruijn-erdos`
+**Outcome:** progress (added 1 verified corollary, removed vacuous tautology)
+
+- Added verified `exists_finite_subgraph_not_colorable` (contrapositive de Bruijn–
+  Erdős), the form directly relevant to #736.
+- Removed the vacuous `erdos_736_summary : TaylorConjecture ↔ TaylorConjecture :=
+  Iff.rfl` placeholder (no mathematical content).
+- Documented `finite_case` sorry with its discrete-IVT proof sketch and why it is
+  deferred.
+- Refreshed gallery `meta.json` to reflect the now-proved de Bruijn–Erdős theorem
+  (previously listed only as a "statement").

--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -51,24 +51,25 @@
       }
     ],
     "originalContributions": [
-      "Lean formalization of chromatic number for infinite graphs",
+      "Lean formalization of chromatic number for infinite graphs (Cardinal-valued)",
       "Formal statement of Taylor's conjecture using cardinals",
       "Generalized conjecture for arbitrary uncountable κ",
-      "Formalization of Komjáth-Shelah consistency result",
-      "Related De Bruijn-Erdős theorem statement"
+      "Machine-checked de Bruijn–Erdős coloring theorem (compactness form) via Mathlib's nonempty_hom_of_forall_finite_subgraph_hom",
+      "Machine-checked contrapositive: a non-n-colorable graph has a finite non-n-colorable subgraph"
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 0,
-    "assumptions": "0 axiom declarations. All former axioms (komjath_shelah_consistency, taylor_conjecture_independent, de_bruijn_erdos, chromatic_compactness, chromatic_cardinal_interaction, countable_case) now proved as theorems or definitions. 1 sorry remains in finite_case.",
-    "lineCount": 203,
-    "theoremCount": 2,
+    "assumptions": "0 axiom declarations. The de Bruijn–Erdős coloring theorem and its contrapositive are fully machine-checked (depend only on propext/Quot.sound/Classical.choice). 1 sorry remains in finite_case (a self-contained discrete intermediate-value side lemma, not part of the open conjecture). The open conjecture itself (Taylor's conjecture) is stated as a definition and is independent of ZFC (Komjáth–Shelah 2005).",
+    "lineCount": 248,
+    "theoremCount": 3,
     "prerequisites": [
       "Set-theoretic graph theory: infinite chromatic numbers (ℵ₁, ℵ₂)",
       "De Bruijn-Erdős theorem: compactness for finite chromatic numbers",
       "ZFC independence: forcing and consistency results",
       "Subgraph containment and finite approximation"
     ],
-    "definitionCount": 9
+    "definitionCount": 9,
+    "lastUpdated": "2026-06-19"
   },
   "overview": {
     "historicalContext": "Walter Taylor conjectured that if a graph G has chromatic number ℵ₁, then its finite subgraphs are 'rich enough' to build graphs of any chromatic number. Komjáth and Shelah (2005) proved this is independent of ZFC, showing in some models there exists a counterexample where the bound is ℵ₂. The background to this problem lies in the De Bruijn-Erdős theorem (1951), which established that for finite chromatic numbers, colorability is determined entirely by finite subgraphs. Erdős was fascinated by whether similar compactness principles extend to uncountable chromatic numbers, and Taylor's conjecture was one attempt to make that precise at the ℵ₁ level. The Komjáth-Shelah independence result places this question firmly at the boundary between combinatorics and set-theoretic forcing.",
@@ -161,6 +162,7 @@
       "Mathlib.Combinatorics.SimpleGraph.Basic",
       "Mathlib.Combinatorics.SimpleGraph.Subgraph",
       "Mathlib.Combinatorics.SimpleGraph.Coloring",
+      "Mathlib.Combinatorics.SimpleGraph.Finsubgraph",
       "Mathlib.SetTheory.Cardinal.Basic",
       "Mathlib.SetTheory.Cardinal.Ordinal",
       "Mathlib.Data.Fintype.Basic"
@@ -170,9 +172,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos736",
-    "lineCount": 203,
+    "lineCount": 248,
     "axiomCount": 0,
-    "theoremCount": 2,
+    "theoremCount": 3,
     "definitionCount": 9,
     "path": "Proofs/Erdos736Problem.lean",
     "sorries": 1


### PR DESCRIPTION
## Erdős #736 — Chromatic Numbers and Finite Subgraph Inheritance

Continues the de Bruijn–Erdős infrastructure for Erdős #736 (Taylor's conjecture, independent of ZFC by Komjáth–Shelah 2005).

### What's new (machine-checked)
- **`exists_finite_subgraph_not_colorable`** — contrapositive form of de Bruijn–Erdős: if `G` is not `n`-colorable, then some *finite* subgraph is already not `n`-colorable. This is the form most directly relevant to #736 — the obstruction to a small coloring always lives in a finite part of the graph. Short consequence of the existing `deBruijn_erdos_coloring` (`by_contra` + `push_neg`).

### Axiom profile (audited via `#print axioms`)
Both `deBruijn_erdos_coloring` and `exists_finite_subgraph_not_colorable` depend only on `propext`, `Classical.choice`, `Quot.sound` — fully verified, no `sorryAx`.

### Other changes
- Pin `chromaticNumber` and the conjecture statements to `Type` / `Cardinal.{0}` to eliminate universe metavariables.
- Remove the vacuous `erdos_736_summary : TaylorConjecture ↔ TaylorConjecture := Iff.rfl` placeholder (no mathematical content).
- Document the remaining `finite_case` `sorry` with its discrete intermediate-value proof sketch. It is a self-contained side lemma (custom `Cardinal`-valued chromatic number, no Mathlib API), **not** part of the open conjecture.
- Refresh gallery `meta.json`: `theoremCount` 3, `lineCount` 248, updated contributions/assumptions.

### Status
`axiomatized` is not used — the open conjecture is stated as a definition; 0 `axiom` declarations, 1 `sorry` (the deferred `finite_case` side lemma). Build verified via Docker (`Built Proofs.Erdos736Problem`, 1158 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)