### PR TITLE
research(erdos-mordell-inequality-oq-01): close final sorry — Erdős–Mordell fully verified

### DIFF
--- a/proofs/Proofs/ErdosMordellChordIdentity.lean
+++ b/proofs/Proofs/ErdosMordellChordIdentity.lean
@@ -70,6 +70,9 @@ open EuclideanGeometry Metric
 
 namespace ErdosMordellChord
 
+set_option maxRecDepth 8000
+set_option maxHeartbeats 2000000
+
 /-- Perpendicular distance from `P` to the line through `X` and `Y` (matches the
 `lineDist` of the main file: distance to the affine span). -/
 noncomputable def lineDist (P X Y : EuclideanSpace ℝ (Fin 2)) : ℝ :=
@@ -295,7 +298,7 @@ theorem chord_length_eq
       have := Real.sin_sq_add_cos_sq (∠ Y X Z); linarith,
     hcos, div_pow, mul_pow]
   simp only [← real_inner_self_eq_norm_sq, inner_sub_left, inner_sub_right,
-    real_inner_smul_left, real_inner_smul_right]
+    real_inner_smul_left, real_inner_smul_right] at ha hb ⊢
   -- clear the `⟪v,v⟫`, `⟪u,u⟫` denominators, then expand every inner product into the
   -- two `Fin 2` components; `ring` resolves inner-product commutativity and discharges the
   -- resulting polynomial identity (the 2D Gram relation `gram_two`).
@@ -361,7 +364,95 @@ theorem interior_barycentric
   rw [← hsum, hc0]
   module
 
-/-- **The single residual geometric subfact of the cosine side.**
+/-! ### Coordinate helpers for the cosine-side identity `chord_cos_eq`. -/
+
+/-- The signed area (2D cross product) of two plane vectors. -/
+noncomputable def cross (u v : EuclideanSpace ℝ (Fin 2)) : ℝ := u 0 * v 1 - u 1 * v 0
+
+/-- Lagrange's identity in the plane: `[u,v]² = ‖u‖²‖v‖² − ⟪u,v⟫²`. -/
+theorem cross_sq (u v : EuclideanSpace ℝ (Fin 2)) :
+    cross u v ^ 2 = ‖u‖ ^ 2 * ‖v‖ ^ 2 - inner ℝ u v ^ 2 := by
+  simp only [cross, ← real_inner_self_eq_norm_sq, PiLp.inner_apply, Fin.sum_univ_two,
+    RCLike.inner_apply, starRingEnd_apply, star_trivial]
+  ring
+
+/-- The displacement from `P` to its pedal foot on the line through `X` along `u`,
+in recentred form `w = P − X`: `pedalFoot − P = (⟪w,u⟫/‖u‖²)•u − w`. -/
+noncomputable def footDiff (w u : EuclideanSpace ℝ (Fin 2)) : EuclideanSpace ℝ (Fin 2) :=
+  (inner ℝ w u / ‖u‖ ^ 2) • u - w
+
+/-- `pedalFoot P X Y − P` in recentred coordinate form. -/
+theorem footDiff_pedal_XY (P X Y : EuclideanSpace ℝ (Fin 2)) (hY : Y ≠ X) :
+    pedalFoot P X Y - P = footDiff (P - X) (Y - X) := by
+  rw [pedalFoot_eq P X Y hY, footDiff]
+  abel
+
+/-- `pedalFoot P Z X − P` in recentred coordinate form (recentred at `X`). -/
+theorem footDiff_pedal_ZX (P X Z : EuclideanSpace ℝ (Fin 2)) (hXZ : X ≠ Z) :
+    pedalFoot P Z X - P = footDiff (P - X) (Z - X) := by
+  have hb : ‖Z - X‖ ^ 2 ≠ 0 :=
+    pow_ne_zero 2 (norm_ne_zero_iff.mpr (sub_ne_zero.mpr (Ne.symm hXZ)))
+  have hsc : (inner ℝ (P - Z) (X - Z) : ℝ) / ‖X - Z‖ ^ 2
+      = 1 - inner ℝ (P - X) (Z - X) / ‖Z - X‖ ^ 2 := by
+    rw [norm_sub_rev X Z, eq_sub_iff_add_eq, div_add_div_same, div_eq_one_iff_eq hb]
+    have e1 : (P - Z : EuclideanSpace ℝ (Fin 2)) = (P - X) - (Z - X) := by abel
+    have e2 : (X - Z : EuclideanSpace ℝ (Fin 2)) = -(Z - X) := by abel
+    rw [e1, e2, inner_sub_left, inner_neg_right, inner_neg_right, real_inner_self_eq_norm_sq]
+    ring
+  have hFb : pedalFoot P Z X
+      = (inner ℝ (P - X) (Z - X) / ‖Z - X‖ ^ 2) • (Z - X) + X := by
+    rw [pedalFoot_eq P Z X hXZ, hsc]; module
+  rw [hFb, footDiff]; abel
+
+/-- The pedal-foot displacement has squared length `[u,w]²/‖u‖²`. -/
+theorem footDiff_norm_sq (w u : EuclideanSpace ℝ (Fin 2)) (hu : ‖u‖ ^ 2 ≠ 0) :
+    ‖footDiff w u‖ ^ 2 * ‖u‖ ^ 2 = cross u w ^ 2 := by
+  simp only [footDiff, cross, ← real_inner_self_eq_norm_sq, inner_sub_left, inner_sub_right,
+    real_inner_smul_left, real_inner_smul_right] at hu ⊢
+  field_simp
+  simp only [PiLp.inner_apply, Fin.sum_univ_two, RCLike.inner_apply, starRingEnd_apply,
+    star_trivial] at hu ⊢
+  ring
+
+/-- Inner product of the two pedal-foot displacements, cleared of denominators. -/
+theorem footDiff_inner (w u v : EuclideanSpace ℝ (Fin 2))
+    (hu : ‖u‖ ^ 2 ≠ 0) (hv : ‖v‖ ^ 2 ≠ 0) :
+    inner ℝ (footDiff w v) (footDiff w u) * (‖u‖ ^ 2 * ‖v‖ ^ 2)
+      = cross u w * cross v w * inner ℝ u v := by
+  simp only [footDiff, cross, ← real_inner_self_eq_norm_sq, inner_sub_left, inner_sub_right,
+    real_inner_smul_left, real_inner_smul_right] at hu hv ⊢
+  field_simp
+  simp only [PiLp.inner_apply, Fin.sum_univ_two, RCLike.inner_apply, starRingEnd_apply,
+    star_trivial] at hu hv ⊢
+  ring
+
+/-- The cross-product sign identity `(♦)`: substituting `w = s•u + t•v`,
+`[u,w]·[v,w] = −s·t·[u,v]²`. -/
+theorem cross_mul_cross_smul (u v : EuclideanSpace ℝ (Fin 2)) (s t : ℝ) :
+    cross u (s • u + t • v) * cross v (s • u + t • v) = -(s * t) * cross u v ^ 2 := by
+  simp only [cross, PiLp.add_apply, PiLp.smul_apply, smul_eq_mul]
+  ring
+
+/-
+Nondegeneracy: for an affinely independent triangle the two edge vectors at `X`
+have nonzero signed area.
+-/
+theorem cross_ne_zero (X Y Z : EuclideanSpace ℝ (Fin 2))
+    (hXYZ : AffineIndependent ℝ ![X, Y, Z]) : cross (Y - X) (Z - X) ≠ 0 := by
+  by_contra h_contra;
+  obtain ⟨α, β, hαβ, h_eq⟩ : ∃ α β : ℝ, (α ≠ 0 ∨ β ≠ 0) ∧ α • (Y - X) + β • (Z - X) = 0 := by
+    by_cases hYX : Y - X = 0;
+    · exact ⟨ 1, 0, by norm_num, by norm_num [ hYX ] ⟩;
+    · obtain ⟨i, hi⟩ : ∃ i : Fin 2, (Y - X) i ≠ 0 := by
+        exact not_forall.mp fun h => hYX <| by ext i; exact h i;
+      use (Z - X) i, -(Y - X) i;
+      fin_cases i <;> simp_all +decide [ cross ]; all_goals exact ⟨ Or.inr ( by contrapose! hi; linarith ), by ext i; fin_cases i <;> simpa [ sub_eq_iff_eq_add ] using by linarith ⟩;
+  have := hXYZ; simp_all +decide [ Fin.sum_univ_three, affineIndependent_iff_of_fintype ] ;
+  specialize this ( fun i => if i = 0 then -α - β else if i = 1 then α else β ) ; simp_all +decide [ Fin.forall_fin_succ ];
+  exact hαβ.elim ( fun h => h ( this ( by ring ) ( by convert h_eq using 1; ext ; simpa using by ring ) |>.2.1 ) ) fun h => h ( this ( by ring ) ( by convert h_eq using 1; ext ; simpa using by ring ) |>.2.2 )
+
+/-
+**The single residual geometric subfact of the cosine side.**
 
 The angle subtended at `P` by the two pedal feet is supplementary to the
 triangle's angle at `X`. Geometrically: `F_b, F_c` and `X` are concyclic with `P`
@@ -403,9 +494,9 @@ have opposite signs. Feeding `hP`'s barycentric witness `w = s·u + t·v`, `s,t 
 ring identity (♦) plus `s,t>0`** — Erdős–Mordell is now `ring`-mechanical end to end.
 Both (♦) and the squared identity are numerically confirmed to ~1e-14.
 
-Isolated here as a standalone, Aristotle-submittable target. -/
+Isolated here as a standalone, Aristotle-submittable target.
 
-/-- **The cosine-fraction core of `angle_at_P` (cycle-39, researcher-11).**
+**The cosine-fraction core of `angle_at_P` (cycle-39, researcher-11).**
 
 The single remaining algebraic obligation, in raw inner-product/norm form: the
 cosine of the angle subtended at `P` by the two pedal feet is the negative of the
@@ -423,29 +514,7 @@ above: cross-multiply (all four norms are positive), reduce to `N·‖u‖·‖v
 `ring` identity in the `Fin 2` coordinates and whose sign half is `(♦)`
 (`N·‖u‖²‖v‖² = −s·t·c·(‖u‖²‖v‖²−c²)` after the barycentric substitution, with
 `‖u‖²‖v‖²−c² = cross² ≥ 0` by Lagrange's identity and `cross ≠ 0` by nondegeneracy).
-
-**CLEANEST ABS-FREE ROUTE (cycle-40, researcher-1 — barycentric-factored).** Write
-`u = Y−X`, `v = Z−X`, `c = ⟪u,v⟫`, `D = ‖u‖²‖v‖² − c²`. Recentre both feet at `X`
-(`pedalFoot P Z X − P = (⟪P−X,v⟫/‖v‖²)•v − (P−X)`, likewise for `u`) and feed the
-interior barycentric witness `P−X = s•u + t•v` (`s,t>0`, from `interior_barycentric`).
-The two residuals then *factor* as plain `ℝ`-linear combinations of `u, v`:
-
-    F_b − P = (-s)•u + (s·c/‖v‖²)•v,        F_c − P = (t·c/‖u‖²)•u + (-t)•v.
-
-From these three scalar facts follow by `inner_add/inner_smul` bilinearity alone — no
-coordinates, no `cross`, no `abs`:
-
-    ⟪F_b−P, F_c−P⟫ = − s·t·c·D / (‖u‖²‖v‖²)
-    ‖F_b−P‖²       =   s²·D / ‖v‖²          ‖F_c−P‖² = t²·D / ‖u‖²
-
-so `‖F_b−P‖·‖F_c−P‖ = s·t·D / (‖u‖·‖v‖)` (combine the squares; `s,t>0`, `D≥0`, no
-`abs`), and the quotient collapses to `−c/(‖u‖·‖v‖)` after the manifestly-positive
-factor `s·t·D` cancels. The SOLE remaining obligation is `D ≠ 0`: `D ≥ 0` is
-`abs_real_inner_le_norm`, and `D > 0` is strict Cauchy–Schwarz `inner_lt_norm_mul_iff_real`
-(applied to `(u,v)` and `(u,−v)`) once `u, v` are shown linearly independent via
-`affineIndependent_iff_linearIndependent_vsub` from `hXYZ`. Numerically confirmed
-end-to-end; not yet build-checked (Docker gate closed, Aristotle `prove` 404 this
-session) so left as the lone `sorry`. -/
+-/
 theorem chord_cos_eq
     (X Y Z P : EuclideanSpace ℝ (Fin 2))
     (hXYZ : AffineIndependent ℝ ![X, Y, Z])
@@ -453,7 +522,37 @@ theorem chord_cos_eq
     inner ℝ (pedalFoot P Z X - P) (pedalFoot P X Y - P)
         / (‖pedalFoot P Z X - P‖ * ‖pedalFoot P X Y - P‖)
       = - inner ℝ (Y - X) (Z - X) / (‖Y - X‖ * ‖Z - X‖) := by
-  sorry
+  -- By definition of pedal foot, we have:
+  have hPedalFootZ : pedalFoot P Z X - P = footDiff (P - X) (Z - X) := by
+    convert footDiff_pedal_ZX P X Z _ using 1;
+    exact fun h => by have := hXYZ.injective.ne ( show ( 0 : Fin 3 ) ≠ 2 by decide ) ; aesop;
+  have hPedalFootY : pedalFoot P X Y - P = footDiff (P - X) (Y - X) := by
+    apply footDiff_pedal_XY;
+    exact fun h => by have := hXYZ.injective.ne ( show ( 0 : Fin 3 ) ≠ 1 by decide ) ; aesop;
+  obtain ⟨s, t, hs, ht, hw⟩ := interior_barycentric X Y Z P hXYZ hP;
+  have hnu : ‖Y - X‖ ^ 2 ≠ 0 := by
+    exact ne_of_gt ( sq_pos_of_pos ( norm_pos_iff.mpr ( sub_ne_zero.mpr ( by intro h; have := hXYZ.injective.ne ( show ( 0 : Fin 3 ) ≠ 1 by decide ) ; aesop ) ) ) )
+  have hnv : ‖Z - X‖ ^ 2 ≠ 0 := by
+    exact pow_ne_zero 2 ( norm_ne_zero_iff.mpr ( sub_ne_zero.mpr ( by intro h; have := hXYZ.injective.ne ( show ( 0 : Fin 3 ) ≠ 2 by decide ) ; aesop ) ) )
+  have hN := footDiff_inner (P - X) (Y - X) (Z - X) hnu hnv
+  have hfu := footDiff_norm_sq (P - X) (Y - X) hnu
+  have hfv := footDiff_norm_sq (P - X) (Z - X) hnv
+  have hcc : cross (Y - X) (P - X) * cross (Z - X) (P - X) = -(s * t) * cross (Y - X) (Z - X) ^ 2 := by
+    rw [ hw ] ; exact cross_mul_cross_smul _ _ _ _;
+  have hcuv : cross (Y - X) (Z - X) ≠ 0 := by
+    -- By definition of cross, we know that cross (Y - X) (Z - X) ≠ 0 if and only if Y - X and Z - X are linearly independent.
+    apply cross_ne_zero X Y Z hXYZ
+  have hKneg : cross (Y - X) (P - X) * cross (Z - X) (P - X) < 0 := by
+    exact hcc.symm ▸ mul_neg_of_neg_of_pos ( neg_neg_of_pos ( mul_pos hs ht ) ) ( sq_pos_of_ne_zero hcuv );
+  rw [ hPedalFootZ, hPedalFootY, div_eq_div_iff ];
+  · have h_abs : ‖footDiff (P - X) (Y - X)‖ * ‖Y - X‖ = |cross (Y - X) (P - X)| ∧ ‖footDiff (P - X) (Z - X)‖ * ‖Z - X‖ = |cross (Z - X) (P - X)| := by
+      exact ⟨ by rw [ ← sq_eq_sq₀ ( by positivity ) ( by positivity ), mul_pow, hfu, sq_abs ], by rw [ ← sq_eq_sq₀ ( by positivity ) ( by positivity ), mul_pow, hfv, sq_abs ] ⟩;
+    have h_abs_eq : |cross (Y - X) (P - X)| * |cross (Z - X) (P - X)| = -(cross (Y - X) (P - X) * cross (Z - X) (P - X)) := by
+      rw [ ← abs_mul, abs_of_neg hKneg ];
+    grind +splitImp;
+  · simp +zetaDelta at *;
+    constructor <;> intro h <;> simp_all +decide [ sq ];
+  · exact mul_ne_zero ( norm_ne_zero_iff.mpr ( sub_ne_zero.mpr <| by intro h; simp_all +decide [ affineIndependent_iff_not_collinear, collinear_pair ] ) ) ( norm_ne_zero_iff.mpr ( sub_ne_zero.mpr <| by intro h; simp_all +decide [ affineIndependent_iff_not_collinear, collinear_pair ] ) )
 
 /-- **The single residual geometric subfact of the cosine side** (now a
 hypothesis-free wrapper over `chord_cos_eq`). The angle subtended at `P` by the two

--- a/proofs/Proofs/ErdosMordellInequalityOQ01.lean
+++ b/proofs/Proofs/ErdosMordellInequalityOQ01.lean
@@ -41,15 +41,20 @@ The standard proof factors into two independent pieces:
 - [x] `key_inequality_trig_core` — geometry-free trig bound, PROVED.
 - [x] `key_inequality_of_chord_and_sines` — verified assembly: from the chord
   identity + law of sines, derives the key inequality `b·dc + c·db ≤ a·PA`, PROVED.
-- [ ] `key_inequality_*` — the three geometric key inequalities (OPEN / hard);
-  each now reduces to supplying the chord identity and the law of sines for the
-  concrete Euclidean configuration (see `key_inequality_of_chord_and_sines`).
-- [ ] `erdos_mordell` — assembled geometric statement (depends on the above).
+- [x] `chord_identity` — the chord identity at vertex `A`, PROVED (by delegation to
+  `ErdosMordellChord.chord_identity` in `Proofs/ErdosMordellChordIdentity.lean`,
+  whose cosine-side core `chord_cos_eq` is a pure coordinate identity in
+  `EuclideanSpace ℝ (Fin 2)`).
+- [x] `key_inequality_*` — the three geometric key inequalities, PROVED; each
+  reduces to the chord identity and the law of sines for the concrete Euclidean
+  configuration (see `key_inequality_of_chord_and_sines`).
+- [x] `erdos_mordell` — assembled geometric statement, PROVED.
 
-The reduction, the trig core, and the chord-to-key assembly are the reusable,
-Mathlib-independent heart of the argument; the remaining work is purely the
-planar-geometry derivation of the chord identity and law of sines (deferred —
-see knowledge notes).
+The inequality is now fully machine-checked with no `sorry` and no axioms beyond
+Lean/Mathlib's standard foundations. The reduction, the trig core, and the
+chord-to-key assembly are the reusable, Mathlib-independent heart of the argument;
+the chord identity itself is discharged by the coordinate proof in the companion
+file `ErdosMordellChordIdentity.lean`.
 
 ## References
 - P. Erdős, *Problem 3740*, Amer. Math. Monthly 42 (1935), 396.
@@ -58,6 +63,7 @@ see knowledge notes).
 -/
 
 import Mathlib
+import Proofs.ErdosMordellChordIdentity
 
 namespace ErdosMordellOQ01
 
@@ -279,7 +285,7 @@ theorem key_inequality_A_of_chord
     (lineDist_nonneg P C A) (lineDist_nonneg P A B) dist_nonneg hRpos
     hlaw_a hlaw_b hlaw_c hchord
 
-/-- **Chord identity at vertex `A`** (the sole remaining geometric obligation).
+/-- **Chord identity at vertex `A`** (PROVED — formerly the sole remaining geometric obligation).
 
 Let `F_b, F_c` be the feet of the perpendiculars from `P` to the sides `CA, AB`,
 so `db = dist P F_b = lineDist P C A` and `dc = dist P F_c = lineDist P A B`. The
@@ -288,9 +294,10 @@ the chord `F_b F_c` has length `PA · sin (∠ B A C)` (inscribed-angle theorem)
 and the law of cosines in `△ P F_b F_c` (where `∠ F_b P F_c = π − ∠ B A C`)
 gives the identity below.
 
-This is the single open planar-geometry fact; once supplied, the entire
-Erdős–Mordell inequality is fully proved (via `key_inequality_A_of_chord`, the
-cyclic relabelings for `B`/`C`, and the algebraic reduction). -/
+This was the single open planar-geometry fact; it is now discharged by delegation
+to `ErdosMordellChord.chord_identity`, completing the entire Erdős–Mordell
+inequality (via `key_inequality_A_of_chord`, the cyclic relabelings for `B`/`C`,
+and the algebraic reduction). -/
 theorem chord_identity
     (A B C P : EuclideanSpace ℝ (Fin 2))
     (hABC : AffineIndependent ℝ ![A, B, C])
@@ -298,7 +305,11 @@ theorem chord_identity
     (dist P A * Real.sin (∠ B A C)) ^ 2
       = lineDist P C A ^ 2 + lineDist P A B ^ 2
         + 2 * lineDist P C A * lineDist P A B * Real.cos (∠ B A C) := by
-  sorry
+  -- This is exactly `ErdosMordellChord.chord_identity` with `(X, Y, Z) := (A, B, C)`:
+  -- both `lineDist` defs unfold to `Metric.infDist P (affineSpan ℝ {·, ·})`, and the
+  -- pedal-feet chord identity there was discharged via `chord_cos_eq` (the law-of-cosines
+  -- core). See `Proofs/ErdosMordellChordIdentity.lean`.
+  exact ErdosMordellChord.chord_identity A B C P hABC hP
 
 /-- **Erdős–Mordell key inequality at vertex `A`.**
 

--- a/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
+++ b/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1935), Mordell–Barrow (1937)",
     "date": "2026-06-18",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "geometry",
       "euclidean-geometry",
@@ -16,8 +16,8 @@
       "triangle"
     ],
     "proofRepoPath": "Proofs/ErdosMordellInequalityOQ01.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Affine.Triangle.dist_div_sin_angle_eq_two_mul_circumradius",
@@ -42,8 +42,8 @@
     ],
     "dateAdded": "2026-06-18",
     "axiomCount": 0,
-    "lineCount": 394,
-    "assumptions": "1 sorry: the chord identity at vertex A, (dist P A · sin ∠BAC)² = lineDist P C A² + lineDist P A B² + 2·lineDist P C A·lineDist P A B·cos ∠BAC (chord_identity). This single planar fact — the squared length of the chord between the two pedal feet — is the genuine remaining geometric content, classical mathematics not yet in Mathlib. Everything else is fully proved: the law of sines (via Mathlib's dist_div_sin_angle_eq_two_mul_circumradius), the reduction of the three cyclic key inequalities key_inequality_A/B/C to the single vertex-A case key_inequality_A_of_chord, side-length positivity, pedal-distance nonnegativity, and the AM–GM algebraic reduction. The companion file ErdosMordellChordReduction.lean additionally proves the geometry-free trigonometric core of the chord identity (chord_identity_of_half_angles), reducing the chord identity itself to three elementary right-triangle facts.",
+    "lineCount": 399,
+    "assumptions": "None. The Erdős–Mordell inequality is fully proved with no sorries and no axioms beyond Lean/Mathlib's standard foundations (propext, Classical.choice, Quot.sound). The last remaining geometric obligation — the chord identity at vertex A, (dist P A · sin ∠BAC)² = lineDist P C A² + lineDist P A B² + 2·lineDist P C A·lineDist P A B·cos ∠BAC (chord_identity) — is discharged by delegation to ErdosMordellChord.chord_identity in the companion file ErdosMordellChordIdentity.lean, whose cosine-side core chord_cos_eq is a pure inner-product/coordinate identity in EuclideanSpace ℝ (Fin 2): the cosine of the angle subtended at P by the two pedal feet equals minus the cosine of the triangle's angle at the vertex. That identity is proved via a small 2D signed-area (cross-product) toolkit — Lagrange's identity, the recentred pedal-foot displacement, the squared-length and cleared-denominator inner-product identities, and the barycentric sign witness [u,w]·[v,w] = −s·t·[u,v]² < 0 from interior_barycentric. Everything else was already proved: the law of sines (Mathlib's dist_div_sin_angle_eq_two_mul_circumradius), the reduction of the three cyclic key inequalities to the single vertex-A case, side-length positivity, pedal-distance nonnegativity, and the AM–GM algebraic reduction.",
     "originalContributions": [
       "erdos_mordell_reduction: the geometry-free AM–GM core, proving 2(da+db+dc) ≤ PA+PB+PC from the three weighted key inequalities via an explicit nonnegative certificate (a·da·(b−c)² + ... ≥ 0). Carries no geometric hypotheses; reusable for any proof of the key inequalities.",
       "key_inequality_trig_core: a geometry-free proof that sin B·dc + sin C·db ≤ √(db²+dc²+2·db·dc·cos A) for triangle angles, collapsing each key inequality (modulo the chord identity and the law of sines) to the perfect square (db·cos C − dc·cos B)² ≥ 0.",
@@ -51,7 +51,8 @@
       "key_inequality_A_of_chord: the law-of-sines reduction (geometry → algebra). Instantiating the triangle ABC, it discharges all three law-of-sines inputs a=2R sinA, b=2R sinB, c=2R sinC directly from Mathlib's Affine.Triangle.dist_div_sin_angle_eq_two_mul_circumradius (plus angle-sum = π and sin-positivity for a non-degenerate triangle), then assembles the vertex-A key inequality via key_inequality_of_chord_and_sines, leaving the chord identity as the only geometric obligation. This eliminates the heavier oriented-angle / inscribed-angle route entirely.",
       "Cyclic relabeling plumbing affineIndep_rotate and mem_interior_hull_rotate: affine independence and interior-of-hull membership are invariant under the rotation (X,Y,Z)↦(Y,Z,X), so the vertex-B and vertex-C key inequalities are proved as relabeled instances of key_inequality_A — the entire geometric obligation is isolated in a single vertex.",
       "Precise Lean statement of the geometric Erdős–Mordell inequality using Metric.infDist to the affine span (lineDist) for pedal distances, with the full modular assembly of erdos_mordell discharging all positivity/nonnegativity/algebra.",
-      "Companion file ErdosMordellChordReduction.lean: an elementary, fully-proved (no sorry) route to the chord identity that avoids the pedal circle and the inscribed-angle theorem. Its core lemma chord_identity_of_half_angles derives the chord identity from the three right-triangle facts db=PA·sin α, dc=PA·sin β, A=α+β by expanding sin(α+β), cos(α+β); the bridge lemma lineDist_eq_dist_orthogonalProjection identifies the pedal distance with the orthogonal-projection foot."
+      "Companion file ErdosMordellChordReduction.lean: an elementary, fully-proved (no sorry) route to the chord identity that avoids the pedal circle and the inscribed-angle theorem. Its core lemma chord_identity_of_half_angles derives the chord identity from the three right-triangle facts db=PA·sin α, dc=PA·sin β, A=α+β by expanding sin(α+β), cos(α+β); the bridge lemma lineDist_eq_dist_orthogonalProjection identifies the pedal distance with the orthogonal-projection foot.",
+      "ErdosMordellChordIdentity.lean closes the final geometric obligation: chord_cos_eq proves the pedal-feet cosine identity directly in coordinates (no inscribed-angle / pedal-circle machinery), and chord_identity composes it with chord_length_eq to obtain the squared-chord identity in the exact (dist P X · sin ∠YXZ)² = db² + dc² + 2·db·dc·cos ∠YXZ form. The vertex-A chord_identity in the main file is then a one-line delegation, completing a fully machine-checked, axiom-free Erdős–Mordell inequality."
     ],
     "theoremCount": 12,
     "definitionCount": 1
@@ -165,14 +166,17 @@
       "EuclideanGeometry"
     ],
     "namespace": "ErdosMordellOQ01",
-    "lineCount": 394,
+    "lineCount": 399,
     "axiomCount": 0,
     "theoremCount": 12,
     "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
     "definitionCount": 1,
     "path": "Proofs/ErdosMordellInequalityOQ01.lean",
-    "sorries": 1
+    "sorries": 0,
+    "companionFiles": [
+      "Proofs/ErdosMordellChordIdentity.lean"
+    ]
   },
   "mainTheorems": [
     {
@@ -218,5 +222,5 @@
       "leanType": "(A B C P : EuclideanSpace ℝ (Fin 2)) → AffineIndependent ℝ ![A,B,C] → P ∈ interior (convexHull ℝ {A,B,C}) → dist C A * lineDist P A B + dist A B * lineDist P C A ≤ dist B C * dist P A"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/research/problems/erdos-mordell-inequality-oq-01.json
+++ b/src/data/research/problems/erdos-mordell-inequality-oq-01.json
@@ -7,7 +7,7 @@
   "significance": 6,
   "tractability": 5,
   "status": "in-progress",
-  "phase": "ACT",
+  "phase": "COMPLETED",
   "started": "2026-06-18T23:00:00Z",
   "lastUpdate": "2026-06-19T15:16:00Z",
   "currentState": {
@@ -29,7 +29,7 @@
     "Not present in Mathlib4 (as of v4.26.0): no `mordell` geometry result; Mathlib has Triangle, Incenter, Projection, SignedDist, angle infrastructure but no Erdős–Mordell."
   ],
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-06-19, researcher-1): the unmerged branch research/erdos-mordell-pedalfoot-eq has HAND-PROVED chord_length_eq (sine side, 2D Gram via coordinate ring) AND angle_at_P (now a wrapper over a single new algebraic core chord_cos_eq), reducing the ENTIRE Erdős–Mordell formalization to ONE pure inner-product/Fin-2 coordinate identity: chord_cos_eq. Submitted that reduced file to Aristotle (CLI) as project 62d1066c-7edd-4419-b588-4bc430d4d4fb — a strictly EASIER target than the still-RUNNING 55ae116d (which works main's 2 unreduced geometric sorries, ~15% at 51min). The submission also build-verifies the branch's unmerged hand-proofs server-side (local Docker gate closed: 11 containers, load 15). chord_cos_eq follows the SAME proof pattern as the already-proved chord_length_eq (recenter, sq_eq_sq, field_simp, PiLp.inner_apply expansion, ring) so success odds are high. MCP prove/check_proof 404 this session; CLI works. Poll: aristotle show 62d1066c. On PROVED: graft into the pedalfoot-eq branch file, rebuild when gate opens (load<6), and the whole proof closes (chord_identity already wired turnkey).",
+    "progressSummary": "COMPLETE: Erdős–Mordell inequality fully machine-checked, 0 sorries, axiom-free. chord_cos_eq closed via Aristotle job 62d1066c, integrated + build-verified.",
     "builtItems": [
       "proofs/Proofs/ErdosMordellInequalityOQ01.lean: erdos_mordell_reduction — from the three key inequalities a·PA≥b·dc+c·db (cyclic), derives PA+PB+PC≥2(da+db+dc) via explicit nonnegative certificate, 0 sorry, 0 axiom (build-pending verification).",
       "Certificate: a·b·c·(PA+PB+PC) − 2abc·(da+db+dc) = a·da·(b−c)² + b·db·(a−c)² + c·dc·(a−b)² + (key-inequality slack), each summand ≥ 0; closed by mul_le_mul_of_nonneg_left scaling + nlinarith + le_of_mul_le_mul_left.",
@@ -46,7 +46,9 @@
       "pedalFoot_eq PROVED + build-verified (ErdosMordellChordIdentity.lean:172, Lean v4.26 7743 jobs green): pedalFoot P X Y = (⟪P−X,Y−X⟫/‖Y−X‖²)•(Y−X)+X via coe_orthogonalProjection_eq_iff_mem (membership + perpendicular residual). The keystone bridge; sorries 3→2.",
       "Fixed latent build error in chord_length_sq_eq_of_angle_at_P (rw[hlc] dist^2 vs dist*dist + dist_comm mismatch) → hAngle/cos_pi_sub into hlc, align pow_two+dist_comm, linear_combination. Companion now compiles for the first time.",
       "Aristotle file submission (project 55ae116d, r1 2026-06-19): ErdosMordellChordIdentity.lean (both sorries chord_length_eq + angle_at_P). CLI submit since MCP prove/prove_file returned 404 this session.",
-      "Aristotle submission (project 62d1066c-7edd-4419-b588-4bc430d4d4fb, researcher-1 2026-06-19, CLI): the research/erdos-mordell-pedalfoot-eq reduced ErdosMordellChordIdentity.lean (single sorry chord_cos_eq). MORE-reduced than 55ae116d: chord_length_eq and angle_at_P are hand-proved on that branch; only the algebraic cosine-side core chord_cos_eq remains. Also build-verifies the branch hand-proofs server-side (Docker gate closed locally)."
+      "Aristotle submission (project 62d1066c-7edd-4419-b588-4bc430d4d4fb, researcher-1 2026-06-19, CLI): the research/erdos-mordell-pedalfoot-eq reduced ErdosMordellChordIdentity.lean (single sorry chord_cos_eq). MORE-reduced than 55ae116d: chord_length_eq and angle_at_P are hand-proved on that branch; only the algebraic cosine-side core chord_cos_eq remains. Also build-verifies the branch hand-proofs server-side (Docker gate closed locally).",
+      "ErdosMordellChordIdentity.chord_cos_eq + cross/cross_sq/footDiff/footDiff_pedal_XY/footDiff_pedal_ZX/footDiff_norm_sq/footDiff_inner/cross_mul_cross_smul/cross_ne_zero (proofs/Proofs/ErdosMordellChordIdentity.lean)",
+      "ErdosMordellOQ01.chord_identity now proved by delegation to ErdosMordellChord.chord_identity (proofs/Proofs/ErdosMordellInequalityOQ01.lean:296)"
     ],
     "insights": [
       "The inequality cleanly factors: ALL the AM-GM / side-length algebra is captured by erdos_mordell_reduction (now proved), isolating the genuinely hard work into the three geometric key inequalities.",
@@ -62,7 +64,8 @@
       "Cycle-35: pedal feet in coordinates are F_b=X+(q/b).v, F_c=X+(p/a).u (orthogonalProjection onto lines ZX,XY). Then dist F_b F_c^2 = q2/b+p2/a-2pqc/(ab) directly, matching (dist X P sin)^2 = r(ab-c2)/(ab) exactly via the Gram relation.",
       "Cycle-35: angle_at_P (cosine side, supplementary angle) is EQUIVALENT to the scalar identity db.dc.cos(YXZ) = -<P-F_b,P-F_c>. Its SQUARE is hypothesis-free ring (db2 dc2 cos2 = <P-F_b,P-F_c>2, with <P-F_b,P-F_c> = r-p2/a-q2/b+pqc/(ab)). Only the SIGN needs P-interior — this is the SOLE place hP enters the entire Erdos-Mordell proof. Sign FAILS for exterior P (numerically confirmed: signErr large outside triangle, ~0 inside).",
       "cycle-36: the cosine-side sign (the WHOLE proof's only use of P-interior) reduces to ONE ring identity [u,w]·[v,w] = −s·t·[u,v]² where w=s·u+t·v are barycentric coords (s,t>0,s+t<1), [·,·]=2D cross product. Manifestly <0 for interior P + nondegenerate triangle. Replaces vaguer convexHull/λμ<0 sketch. Numerically verified ~1e-14.",
-      "The companion ErdosMordellChordIdentity.lean was NEVER build-verified before cycle-37 (unregistered, prior closed gates) — chord_length_sq_eq_of_angle_at_P carried a latent rw failure. Lesson: numerically-verified scaffolds may hide compile bugs; build-verify when the gate opens."
+      "The companion ErdosMordellChordIdentity.lean was NEVER build-verified before cycle-37 (unregistered, prior closed gates) — chord_length_sq_eq_of_angle_at_P carried a latent rw failure. Lesson: numerically-verified scaffolds may hide compile bugs; build-verify when the gate opens.",
+      "COMPLETE: chord_cos_eq (the lone sorry) is a pure 2D coordinate/inner-product identity — cosine subtended at P by the two pedal feet = −cosine of the triangle angle at the vertex; proved via a signed-area (cross) toolkit + barycentric sign witness [u,w]·[v,w]=−s·t·[u,v]²<0. No inscribed-angle/pedal-circle machinery needed."
     ],
     "mathlibGaps": [
       "No Erdős–Mordell in Mathlib4 v4.26.0.",
@@ -76,27 +79,7 @@
       "No direct Mathlib lemma for dist between two orthogonalProjections onto distinct lines; must unfold orthogonalProjection to X+(<w,dir>/<dir,dir>).dir and go to Fin 2 components, then EuclideanSpace.inner / PiLp.inner_apply + Fin.sum_univ_two + ring."
     ],
     "nextSteps": [
-      "Verify erdos_mordell_reduction builds green (single quiet-gated watcher; fleet was OOM-saturated with 6 concurrent builds at claim time).",
-      "Prove key_inequality_A: a·PA ≥ b·dc + c·db. Route: set up the pedal circle through A with diameter PA, use inscribed-angle for chord FbFc = PA·sin A, then project. Candidate Mathlib: EuclideanGeometry.Sphere, oangle/angle lemmas, law of sines in Triangle.lean.",
-      "Bridge lineDist (infDist to affineSpan) to dist to orthogonalProjection foot, so the pedal distances in the key lemma match the geometric statement.",
-      "Assemble erdos_mordell from the three key lemmas + erdos_mordell_reduction; then create gallery meta (status formalized until key lemmas closed, then verified).",
-      "Consider an alternative Ptolemy-inequality route (Avez 1993) if Mathlib has/admits a short Ptolemy inequality — may shorten the key-inequality derivation.",
-      "Prove the chord identity (PA·sinA)² = db²+dc²+2·db·dc·cosA in EuclideanSpace via orthogonal projection feet (EuclideanGeometry.orthogonalProjection) — the SOLE remaining geometric obligation per key_inequality_trig_core",
-      "Wire law of sines to convert a·PA ≥ b·dc+c·db into the sin-form consumed by key_inequality_trig_core",
-      "Confirm gated build green (/tmp/r9-mordell-DONE) — verifies injective-wiring + nlinarith trig core compile",
-      "Retry Aristotle async submit (got Resource not found this session) on key_inequality_A once endpoint healthy",
-      "Prove key_inequality_vertex: (1) pedal feet F_b=orthogonalProjection line[Z,X] P, F_c=orthogonalProjection line[X,Y] P; (2) right angles at feet -> A,F_b,F_c,P concyclic on circle diam PX (Thales, Angle/Sphere.lean:103); (3) dist F_b F_c = PX*sin(angle YXZ) via inscribed angle / dist_div_sin_angle_eq_two_mul_circumradius on that circle; (4) law of cosines in triangle P F_b F_c gives chord identity; (5) feed key_inequality_of_chord_and_sines with law of sines (now Mathlib) + chord identity.",
-      "Quiet-fleet (ctrs<3): build companion file ErdosMordellChordIdentity.lean from the fully-named 6-step decomposition; step 4 via angle_smul_left/right_of_pos + Sbtw foot-on-open-side.",
-      "Retry Aristotle MCP at session start — down (Resource not found) cycles 3-5; the whole key_inequality_vertex is a HARD known lemma ideal to delegate once it recovers.",
-      "Chain the new two_zsmul_oangle_feet_at_X with the proved cospherical two_zsmul_oangle_pedalFeet_at_P_eq_at_X to get 2•∡(F_b,P,F_c)=2•∡(Z,X,Y) as a clean verified lemma (both already build).",
-      "ALTERNATIVE that BYPASSES angle_at_P entirely: prove chord_identity directly as a coordinate/inner-product polynomial identity (numerically verified to hold incl. obtuse). Feet are orthogonalProjection (affine-linear in P); db²=lineDist², cos∠YXZ and dist² are inner products — candidate for nlinarith/polyrith after unfolding orthogonalProjection to the inner-product formula. This sidesteps the oriented→unoriented sign problem because squared lengths use sin² and cos symmetrically.",
-      "Derive the four ≠X nondegeneracy hyps of two_zsmul_oangle_feet_at_X from P∈interior(convexHull{X,Y,Z}) + AffineIndependent: P∉sideline ⟹ P≠feet; foot≠X needs ⟨P-X,·⟩≠0 which can fail only on a measure-zero perpendicular — provable from interior strictness.",
-      "PRIORITY when build gate opens (load<6,<3 containers): mechanize chord_length_eq via coordinates. Lemma chain: (1) pedalFoot_eq: pedalFoot P X Y = X + (inner (P-X) (Y-X)/inner (Y-X) (Y-X)) . (Y-X) [from orthogonalProjection_eq / EuclideanGeometry.orthogonalProjection on affineSpan {X,Y}]; (2) gram_two: for u v w : EuclideanSpace R (Fin 2), |w|^2*(|u|^2*|v|^2-<u,v>^2)=|u|^2*<w,v>^2+|v|^2*<w,u>^2-2*<u,v>*<w,u>*<w,v> by simp [EuclideanSpace inner, Fin.sum_univ_two]; ring; (3) assemble dist^2 then sqrt (both nonneg).",
-      "For angle_at_P: prove the squared scalar identity (db dc cos)^2 = <P-F_b,P-F_c>^2 hypothesis-free by ring, then recover the sign from hP. Sign lemma: P in interior(convexHull{X,Y,Z}) => the projection scalars q/b>0 and p/a>0 on the open segments => orientation scalars of P-F_b, P-F_c are opposite (lambda*mu<0) => <P-F_b,P-F_c> and <u,v> have opposite signs. Candidate Mathlib: convexHull membership -> affine combination with positive coeffs.",
-      "Retry Aristotle MCP (down/404 cycle-35) on the companion file ErdosMordellChordIdentity.lean once it recovers; both residual sorries are now coordinate-mechanical with explicit ring identities documented in their docstrings.",
-      "Prove angle_at_P via: (1) rewrite ∠ through inner-product def; (2) P−F_c=([u,w]/‖u‖²)rot90 u and P−F_b=([v,w]/‖v‖²)rot90 v by ring in Fin 2; (3) extract barycentric s,t>0 from hP (interior convexHull → positive coeffs, s+t<1); (4) ring identity [u,w][v,w]=−st[u,v]² gives sign; combine with hypothesis-free squared identity.",
-      "chord_length_eq: rewrite both pedalFoot via pedalFoot_eq, square, reduce to 2D Gram det r(ab−c²)=aq²+bp²−2cpq by ring in Fin2 coords, unsquare via sqrt_inj (both sides ≥0); needs cos_angle = ⟪u,v⟫/(‖u‖‖v‖) and sin²=1−cos².",
-      "angle_at_P: with pedalFoot_eq, P−F_c=([u,w]/‖u‖²)rot90 u etc.; reduce to ⟪P−F_b,P−F_c⟫ via ring, square hypothesis-free, then sign from hP barycentric witness w=s·u+t·v (s,t>0) giving (♦) [u,w][v,w]=−st[u,v]²<0."
+      "DONE — Erdős–Mordell inequality fully verified (0 sorries, 0 axioms). Build-verified Proofs.ErdosMordellInequalityOQ01 (7744 jobs). PR #26782."
     ]
   }
 }


### PR DESCRIPTION
## Summary

Closes the **last `sorry`** of the Erdős–Mordell inequality formalization. The gallery entry `erdos-mordell-inequality-oq-01` is now fully machine-checked with **0 sorries** and **no axioms** beyond Lean/Mathlib's standard foundations (`propext`, `Classical.choice`, `Quot.sound`).

## What changed

- **`ErdosMordellChordIdentity.lean`** — proves `chord_cos_eq`, the previously lone `sorry`: the pure inner-product/coordinate identity in `EuclideanSpace ℝ (Fin 2)` stating that the cosine of the angle subtended at `P` by the two pedal feet equals minus the cosine of the triangle's angle at the vertex. Proof introduces a small reusable 2D signed-area (cross-product) toolkit:
  - `cross` + Lagrange's identity `cross_sq` (`[u,v]² = ‖u‖²‖v‖² − ⟪u,v⟫²`)
  - `footDiff` (recentred pedal-foot displacement) with bridges `footDiff_pedal_XY` / `footDiff_pedal_ZX` over the existing `pedalFoot_eq`
  - the squared-length identity `footDiff_norm_sq` and the cleared-denominator inner-product identity `footDiff_inner`
  - the sign identity `cross_mul_cross_smul` and nondegeneracy `cross_ne_zero`
  - the sign follows from the barycentric witness `[u,w]·[v,w] = −s·t·[u,v]² < 0` via `interior_barycentric`.

- **`ErdosMordellInequalityOQ01.lean`** — the vertex-`A` `chord_identity` (its sole `sorry`) is now a one-line delegation to `ErdosMordellChord.chord_identity` (identical statement under `X,Y,Z → A,B,C`; `lineDist` is definitionally `Metric.infDist P (affineSpan ℝ {·,·})` in both files). Stale "single open obligation" docstrings updated.

- **`meta.json`** — `status` formalized → **verified**, `badge` wip → **original**, `sorries` 1 → 0, `axiomCount` 0.

## Verification

```
./proofs/scripts/docker-build.sh Proofs.ErdosMordellInequalityOQ01
✔ [7744/7744] Built Proofs.ErdosMordellInequalityOQ01 (652s)
Build completed successfully (7744 jobs).
```

No `axiom` declarations, no `native_decide`. The `chord_cos_eq` proof was generated by Aristotle (job `62d1066c`), then build-verified and integrated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)