### PR TITLE
research(quadratic-gauss-sum-square-oq-01): reduce Gauss's sign theorem to a single positivity

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2841,6 +2841,7 @@ import Proofs.PythagoreanTriplesOQ01Aristotle
 import Proofs.PythagoreanTriplesOQ02
 import Proofs.QuadraticGaussSumSquare
 import Proofs.QuadraticGaussSumSquareOQ01
+import Proofs.QuadraticGaussSumSignReduction
 import Proofs.QuadraticReciprocity
 import Proofs.QuadraticReciprocityAlgorithmOQ01
 import Proofs.QuadraticReciprocityAlgorithmOQ03

--- a/proofs/Proofs/QuadraticGaussSumSignReduction.lean
+++ b/proofs/Proofs/QuadraticGaussSumSignReduction.lean
@@ -1,0 +1,134 @@
+/-
+  Reducing Gauss's hard sign theorem to a single positivity.
+
+  Background.  For an odd prime `p` and a primitive additive character
+  `ψ : ZMod p → ℂ`, write `g = gaussSum (chiC p) ψ` for the quadratic Gauss sum.
+  The parent file proves the SQUARE identity
+      g² = (-1)^((p-1)/2) · p,
+  and `QuadraticGaussSumSquareOQ01` extracts from it the elementary
+  real/imaginary DICHOTOMY together with the magnitude `‖g‖² = p`:
+      p ≡ 1 (mod 4)  ⟹  g.im = 0   (g real),
+      p ≡ 3 (mod 4)  ⟹  g.re = 0   (g imaginary).
+
+  Gauss's *hard* theorem fixes the leading sign:
+      g = √p     if p ≡ 1 (mod 4),
+      g = i·√p   if p ≡ 3 (mod 4).
+  This is genuinely deep (Schur's eigenvalue computation on the finite Fourier
+  transform, or Dirichlet's analytic evaluation) and is NOT proved here.
+
+  What this file contributes — entirely by elementary complex arithmetic on top
+  of the dichotomy + magnitude — is twofold:
+
+    1. The **four-point pinning**: strengthen "g is real / imaginary" to the
+       exact statement `g = ±√p` (resp. `g = ±i√p`).  Dichotomy + magnitude
+       force `g.re² = p` (resp. `g.im² = p`), and `|·| = √p` splits into the two
+       signs.
+
+    2. The **reduction to a single positivity**: Gauss's sign theorem is
+       EQUIVALENT to one real inequality,
+           g = √p    ↔    0 < g.re      (p ≡ 1 mod 4),
+           g = i·√p  ↔    0 < g.im      (p ≡ 3 mod 4).
+       This isolates the precise open crux: every classical proof (Schur,
+       Dirichlet, Kronecker) ultimately establishes exactly this positivity,
+       and nothing in this file assumes it.
+
+  All results below are sorry-free and axiom-free; only the positivity itself
+  remains open.
+-/
+import Mathlib
+import Proofs.QuadraticGaussSumSquare
+import Proofs.QuadraticGaussSumSquareOQ01
+
+open scoped BigOperators
+open QuadraticGaussSumSquare QuadraticGaussSumSquareOQ01
+
+namespace QuadraticGaussSumSignReduction
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-- Helper: the Gauss sum's magnitude is positive (`0 < √p`). -/
+theorem sqrt_p_pos : (0 : ℝ) < Real.sqrt p :=
+  Real.sqrt_pos.mpr (by exact_mod_cast (Fact.out : p.Prime).pos)
+
+/-! ### Four-point pinning -/
+
+/-- **Pinning, case `p ≡ 1 (mod 4)`.** The Gauss sum is exactly `±√p`. -/
+theorem gaussSum_eq_pm_sqrt (hp4 : p % 4 = 1)
+    {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    gaussSum (chiC p) ψ = (Real.sqrt p : ℂ) ∨
+    gaussSum (chiC p) ψ = -(Real.sqrt p : ℂ) := by
+  set g := gaussSum (chiC p) ψ with hg
+  have him : g.im = 0 := gaussSum_im_eq_zero_of_one_mod_four hp4 hψ
+  have hns : Complex.normSq g = p := gaussSum_normSq_eq (by omega) hψ
+  have hre2 : g.re ^ 2 = (p : ℝ) := by
+    have h := Complex.normSq_apply g
+    rw [him] at h
+    nlinarith [hns, h]
+  have habs : |g.re| = Real.sqrt p := by
+    rw [← Real.sqrt_sq_eq_abs, hre2]
+  have hgre : g = (g.re : ℂ) := by
+    apply Complex.ext <;> simp [him]
+  rcases (abs_eq (Real.sqrt_nonneg (p : ℝ))).mp habs with h | h
+  · left; rw [hgre, h]
+  · right; rw [hgre, h]; push_cast; ring
+
+/-- **Pinning, case `p ≡ 3 (mod 4)`.** The Gauss sum is exactly `±i·√p`. -/
+theorem gaussSum_eq_pm_I_sqrt (hp4 : p % 4 = 3)
+    {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    gaussSum (chiC p) ψ = (Real.sqrt p : ℂ) * Complex.I ∨
+    gaussSum (chiC p) ψ = -((Real.sqrt p : ℂ) * Complex.I) := by
+  set g := gaussSum (chiC p) ψ with hg
+  have hre : g.re = 0 := gaussSum_re_eq_zero_of_three_mod_four hp4 hψ
+  have hns : Complex.normSq g = p := gaussSum_normSq_eq (by omega) hψ
+  have him2 : g.im ^ 2 = (p : ℝ) := by
+    have h := Complex.normSq_apply g
+    rw [hre] at h
+    nlinarith [hns, h]
+  have habs : |g.im| = Real.sqrt p := by
+    rw [← Real.sqrt_sq_eq_abs, him2]
+  have hgim : g = (g.im : ℂ) * Complex.I := by
+    apply Complex.ext <;> simp [Complex.mul_re, Complex.mul_im, hre]
+  rcases (abs_eq (Real.sqrt_nonneg (p : ℝ))).mp habs with h | h
+  · left; rw [hgim, h]
+  · right; rw [hgim, h]; push_cast; ring
+
+/-! ### Reduction of Gauss's sign theorem to a single positivity -/
+
+/-- **Reduction, case `p ≡ 1 (mod 4)`.** Gauss's sign theorem `g = √p` holds
+iff the (already real) Gauss sum has positive real part.  This isolates the
+entire open content into the single inequality `0 < g.re`. -/
+theorem gaussSum_eq_sqrt_iff_re_pos (hp4 : p % 4 = 1)
+    {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    gaussSum (chiC p) ψ = (Real.sqrt p : ℂ) ↔ 0 < (gaussSum (chiC p) ψ).re := by
+  constructor
+  · intro h; rw [h]; simpa using (sqrt_p_pos (p := p))
+  · intro h
+    rcases gaussSum_eq_pm_sqrt hp4 hψ with hpos | hneg
+    · exact hpos
+    · exfalso
+      rw [hneg] at h
+      simp only [Complex.neg_re, Complex.ofReal_re] at h
+      linarith [sqrt_p_pos (p := p)]
+
+/-- **Reduction, case `p ≡ 3 (mod 4)`.** Gauss's sign theorem `g = i·√p` holds
+iff the (already imaginary) Gauss sum has positive imaginary part. -/
+theorem gaussSum_eq_I_sqrt_iff_im_pos (hp4 : p % 4 = 3)
+    {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    gaussSum (chiC p) ψ = (Real.sqrt p : ℂ) * Complex.I ↔
+      0 < (gaussSum (chiC p) ψ).im := by
+  constructor
+  · intro h
+    rw [h]
+    simp only [Complex.mul_im, Complex.ofReal_re, Complex.I_im, mul_one,
+      Complex.ofReal_im, Complex.I_re, mul_zero, add_zero]
+    exact sqrt_p_pos (p := p)
+  · intro h
+    rcases gaussSum_eq_pm_I_sqrt hp4 hψ with hpos | hneg
+    · exact hpos
+    · exfalso
+      rw [hneg] at h
+      simp only [Complex.neg_im, Complex.mul_im, Complex.ofReal_re, Complex.I_im,
+        mul_one, Complex.ofReal_im, Complex.I_re, mul_zero, add_zero] at h
+      linarith [sqrt_p_pos (p := p)]
+
+end QuadraticGaussSumSignReduction

--- a/research/problems/quadratic-gauss-sum-square-oq-01/knowledge.md
+++ b/research/problems/quadratic-gauss-sum-square-oq-01/knowledge.md
@@ -1,0 +1,58 @@
+# Sign of the quadratic Gauss sum (Gauss's hard theorem)
+
+**Pool id:** `quadratic-gauss-sum-square-oq-01` · **Tier B** · significance 6 · tractability 4
+
+## Problem
+
+For an odd prime `p` and a primitive additive character `ψ : ZMod p → ℂ`, let
+`g = gaussSum (chiC p) ψ`. The parent gallery entry proves `g² = (-1)^((p-1)/2)·p`,
+and the **verified** entry `quadratic-gauss-sum-square-oq-01` (slug collision — it is
+the DICHOTOMY entry) extracts `g.im = 0` for `p ≡ 1 (mod 4)`, `g.re = 0` for
+`p ≡ 3 (mod 4)`, and `‖g‖² = p`. The open target here is **Gauss's hard sign theorem**:
+
+    g = +√p     (p ≡ 1 mod 4),
+    g = +i·√p   (p ≡ 3 mod 4).
+
+## Session 2026-06-19 (Session 1) — ORIENT, reduction to a single positivity
+
+**Mode:** FRESH · **Outcome:** progress (verified reduction; deep crux remains open)
+
+### What I did
+- Confirmed the dichotomy + magnitude already exist and are verified (0 sorries) in
+  `QuadraticGaussSumSquareOQ01.lean`.
+- Confirmed Mathlib (v4.26.x) has **no** sign determination and no finite-Fourier
+  determinant/eigenvalue infrastructure (`NumberTheory/GaussSum.lean` stops at the
+  square identity `gaussSum_sq`).
+- Wrote and **built (sorry-free, axiom-free)** `Proofs/QuadraticGaussSumSignReduction.lean`:
+  - `gaussSum_eq_pm_sqrt` — strengthens "g real" to `g = ±√p` (p ≡ 1).
+  - `gaussSum_eq_pm_I_sqrt` — strengthens "g imaginary" to `g = ±i√p` (p ≡ 3).
+  - `gaussSum_eq_sqrt_iff_re_pos` — **`g = √p ↔ 0 < g.re`** (p ≡ 1).
+  - `gaussSum_eq_I_sqrt_iff_im_pos` — **`g = i√p ↔ 0 < g.im`** (p ≡ 3).
+  - Docker build: `✔ [7745/7745] Built Proofs.QuadraticGaussSumSignReduction`.
+
+### Key findings
+- The entire open content of Gauss's hard theorem collapses to **one real inequality**:
+  `0 < Re(g)` (p ≡ 1) / `0 < Im(g)` (p ≡ 3). Everything else (which axis, magnitude,
+  the ± alternative) is elementary and now machine-checked.
+- Both classical routes target exactly this positivity:
+  - **Schur** — eigenvalue multiplicities of the n×n DFT matrix (`ζ^{jk}`); needs
+    DFT-spectrum infra Mathlib lacks. Estimate ≫1000 lines.
+  - **Dirichlet** — Poisson summation / theta functional equation; heavy analysis infra.
+    Estimate ≫1000 lines.
+
+### Infrastructure assessment
+**Needed:** sign of the quadratic Gauss sum (`0 < Re g` resp `0 < Im g`).
+**Size estimate:** >1000 lines either route (no Mathlib DFT-determinant or theta infra).
+**Decision:** BLOCKED short-term — but the reduction above is the shared final step of
+both routes, so it is reusable groundwork rather than throwaway.
+
+### Files modified
+- `proofs/Proofs/QuadraticGaussSumSignReduction.lean` (new, verified)
+- `proofs/Proofs.lean` (import)
+- `src/data/research/problems/quadratic-gauss-sum-square-oq-01.json` (new knowledge)
+
+### Next steps
+- Attack `0 < Re(gaussSum (chiC p) ψ)` for `p ≡ 1 (mod 4)` via the Schur route once (or if)
+  DFT eigenvalue-multiplicity infrastructure becomes available in Mathlib.
+- Consider contributing the four-point pinning / reduction lemmas toward a future
+  Mathlib `GaussSum` sign development.

--- a/src/data/research/problems/quadratic-gauss-sum-square-oq-01.json
+++ b/src/data/research/problems/quadratic-gauss-sum-square-oq-01.json
@@ -1,0 +1,31 @@
+{
+  "id": "quadratic-gauss-sum-square-oq-01",
+  "name": "Sign of the quadratic Gauss sum (Gauss's hard theorem)",
+  "phase": "ORIENT",
+  "knowledge": {
+    "insights": [
+      "The gallery slug `quadratic-gauss-sum-square-oq-01` already proves (verified, 0 sorries) the elementary half: the real/imaginary DICHOTOMY (g.im=0 for p≡1, g.re=0 for p≡3) plus magnitude ‖g‖²=p. The pool candidate with the same id is the strictly harder follow-up: fixing the LEADING SIGN (g=+√p resp. g=+i√p), i.e. Gauss's hard theorem.",
+      "Dichotomy + magnitude pin g to exactly four points: ±√p (p≡1 mod 4) or ±i√p (p≡3 mod 4). Proved sorry-free in QuadraticGaussSumSignReduction.gaussSum_eq_pm_sqrt / gaussSum_eq_pm_I_sqrt by extracting g.re²=p (resp g.im²=p) from normSq and splitting |·|=√p via abs_eq.",
+      "KEY REDUCTION: Gauss's hard sign theorem is EQUIVALENT to a single real positivity. g=√p ↔ 0<g.re (p≡1 mod 4); g=i√p ↔ 0<g.im (p≡3 mod 4). Proved sorry-free (gaussSum_eq_sqrt_iff_re_pos / gaussSum_eq_I_sqrt_iff_im_pos). This isolates the entire open content into one inequality.",
+      "Mathlib (v4.26.x) has NO sign determination for the quadratic Gauss sum and no finite-Fourier-transform determinant infrastructure. NumberTheory/GaussSum.lean stops at gaussSum_sq (the square identity); there is nothing about Re(g)>0 or the DFT eigenvalue multiplicities."
+    ],
+    "builtItems": [
+      "QuadraticGaussSumSignReduction.gaussSum_eq_pm_sqrt — g=±√p for p≡1 mod 4 (sorry-free)",
+      "QuadraticGaussSumSignReduction.gaussSum_eq_pm_I_sqrt — g=±i√p for p≡3 mod 4 (sorry-free)",
+      "QuadraticGaussSumSignReduction.gaussSum_eq_sqrt_iff_re_pos — sign theorem ⟺ 0<Re g (p≡1) (sorry-free)",
+      "QuadraticGaussSumSignReduction.gaussSum_eq_I_sqrt_iff_im_pos — sign theorem ⟺ 0<Im g (p≡3) (sorry-free)"
+    ],
+    "mathlibGaps": [
+      "No formalization of the sign of the quadratic Gauss sum (g=√p for p≡1, g=i√p for p≡3).",
+      "No finite/discrete Fourier transform determinant or eigenvalue-multiplicity computation needed for Schur's argument.",
+      "No analytic Gauss sum evaluation (Poisson summation / theta transformation) needed for Dirichlet's route."
+    ],
+    "nextSteps": [
+      "Prove the single open crux 0 < Re(gaussSum (chiC p) ψ) for p≡1 mod 4 (and 0 < Im for p≡3). Both classical routes target exactly this.",
+      "Schur route: build the n×n finite Fourier matrix F (entries ζ^{jk}), show F has known eigenvalue multiplicities (1,−1,i,−i with counts depending on n mod 4), and identify Re(g) with trace/√n. Estimate >1000 lines given no Mathlib DFT-spectrum infra → likely BLOCKED short-term.",
+      "Dirichlet route: needs Poisson summation / theta functional equation; heavy real-analysis infra. Estimate >1000 lines.",
+      "Cross-check magnitude ‖g‖²=p via character orthogonality (Parseval) independently of the square identity."
+    ],
+    "progressSummary": "PROGRESS (ORIENT): reduced Gauss's hard sign theorem to a single positivity (0<Re g resp 0<Im g) and strengthened the dichotomy to the exact four-point pinning g=±√p / ±i√p — all sorry-free. The positivity crux itself remains open; both classical proofs (Schur, Dirichlet) need >1000 lines of Mathlib-absent infrastructure (BLOCKED short-term)."
+  }
+}


### PR DESCRIPTION
## Summary

Gauss's **hard sign theorem** for the quadratic Gauss sum — `g = +√p` for `p ≡ 1 (mod 4)` and `g = +i·√p` for `p ≡ 3 (mod 4)` — is genuinely deep (Schur's eigenvalue argument on the finite Fourier transform, or Dirichlet's analytic evaluation) and **absent from Mathlib** (`NumberTheory/GaussSum.lean` stops at the square identity).

Building on the already-verified **dichotomy + magnitude** (`QuadraticGaussSumSquareOQ01`: `g.im=0` for `p≡1`, `g.re=0` for `p≡3`, `‖g‖²=p`), this PR adds a new **sorry-free, axiom-free** file `QuadraticGaussSumSignReduction.lean` that isolates the entire remaining open content into a single real inequality.

## What's proved (all verified)

| Theorem | Statement |
|---|---|
| `gaussSum_eq_pm_sqrt` | `p≡1` ⟹ `g = √p ∨ g = -√p` (four-point pinning) |
| `gaussSum_eq_pm_I_sqrt` | `p≡3` ⟹ `g = i√p ∨ g = -i√p` |
| `gaussSum_eq_sqrt_iff_re_pos` | `p≡1` ⟹ (`g = √p` ↔ `0 < Re g`) |
| `gaussSum_eq_I_sqrt_iff_im_pos` | `p≡3` ⟹ (`g = i√p` ↔ `0 < Im g`) |

**Net effect:** Gauss's hard theorem ⟺ the positivity `0 < Re g` (resp. `0 < Im g`) — the shared final step of both classical proofs. Nothing here assumes that positivity; it remains the documented open crux (≫1000 lines either route, Mathlib-absent infra → blocked short-term).

## Build

```
✔ [7745/7745] Built Proofs.QuadraticGaussSumSignReduction (docker-build.sh)
```
0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)