### PR TITLE
research(abel-ruffini-galois-extensions-oq-06): discharge Step 4 normalizer_iso_AGL1Z (last GaloisDirection sorry)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -13,6 +13,7 @@ import Proofs.AbelRuffiniGaloisExtensionsOQ05OQ01
 import Proofs.AbelRuffiniGaloisExtensionsOQ06
 import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirection
 import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep1
+import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4
 import Proofs.AbelRuffiniGaloisExtensionsOQ07
 import Proofs.AbelRuffiniOQ04
 import Proofs.AbelRuffiniOQ04OQ01

--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
@@ -512,11 +512,8 @@ theorem normalizer_iso_AGL1Z
     2026-06-15). It threads through the normal Sylow-p `P`, the inclusion
     `ι(P) ⊆ ⟨σ⟩` (`hgen`, the exact output of Step 3 `sylow_p_is_pcycle`),
     and the `p`-cycle data `hσ_card`, matching the outputs of Steps 2
-    (`sylow_p_normal`) and 3. The body remains `sorry` pending a build-capable
-    session (both Docker and Aristotle are in blackout this session, so a
-    blind tactic discharge cannot be verified and would risk the registered
-    build). The point of this edit is to remove the FALSE lemma stub from the
-    registered file: the file now contains only TRUE `sorry` stubs.
+    (`sylow_p_normal`) and 3. (The body is now fully discharged — see the
+    DISCHARGED note below.)
 
     ⚠ **The `p`-cycle hypothesis `hσ_card : σ.support.card = p` is NOT
     optional** (researcher-1, S6 OBSERVE 2026-06-14). `hgen` only states

--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean
@@ -31,6 +31,10 @@
 -/
 
 import Proofs.AbelRuffiniGaloisExtensionsOQ06
+-- Step 4 (`normalizer_iso_AGL1Z`) is discharged in the build-verified companion
+-- `…GaloisDirectionStep4` (the classical holomorph computation
+-- `N_{S_p}(⟨σ⟩) ≅ AGL(1, p)`); imported here to wire it into the main theorem.
+import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4
 -- Full Mathlib. Step 3's discharge (`sylow_p_is_pcycle`, folded in from the
 -- build-verified orphan) draws on factorization/Legendre (`Nat.factorization_factorial`),
 -- orbit–stabilizer (`MulAction.orbitEquivQuotientStabilizer`, `orbit_eq_univ`),
@@ -462,13 +466,21 @@ theorem centralizer_pcycle_eq_zpowers
     script certified only the easy inclusion `AGL image ⊆ N(⟨σ⟩)`. The
     Sylow count `n_p = |S_p|/|N| = (p−2)!` is confirmed `≡ 1 [MOD p]`, and
     the recovered conjugation map `h ↦ (a,u)` is checked multiplicative
-    (a group hom, not just a set bijection). Certifies Step 4 sound before
-    a Docker-up ACT discharges its ~80–150 LOC. -/
+    (a group hom, not just a set bijection).
+
+    **DISCHARGED (researcher-11, 2026-06-19).** The full holomorph computation
+    is carried out in the build-verified companion
+    `Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4`
+    (`normalizer_eq_range`: every normalizing permutation is affine, by the
+    functional equation `h(y+1) = h(y) + u`; then transport along the
+    conjugacy `σ ∼ τ₀` of any `p`-cycle to the standard translation). This
+    body now just delegates to it, so Step 4 is `sorry`-free. -/
 theorem normalizer_iso_AGL1Z
     (σ : Equiv.Perm (ZMod p)) (_hσ : σ.IsCycle) (_hσ_card : σ.support.card = p) :
     ∃ φ : (Subgroup.zpowers σ).normalizer →* AGL1Z p,
-      Function.Injective φ ∧ Function.Surjective φ := by
-  sorry
+      Function.Injective φ ∧ Function.Surjective φ :=
+  AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.normalizer_iso_AGL1Z
+    σ _hσ _hσ_card
 
 /-- **Step 5 (H ≤ N_{S_p}(P)).** Since the Sylow-p subgroup `P` is
     normal in `H` and its image under `ι = H.subtype ∘ P.subtype` is the

--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.lean
@@ -74,7 +74,7 @@ lemma tau0_apply (x : ZMod p) : τ₀ x = x + 1 := by
 
 /-- `τ₀⁻¹` is the `-1` translation. -/
 lemma tau0_inv_apply (x : ZMod p) : τ₀⁻¹ x = x - 1 := by
-  apply τ₀.injective
+  apply (τ₀).injective
   rw [Equiv.Perm.apply_inv_self, tau0_apply]
   ring
 
@@ -107,13 +107,13 @@ lemma transl_mem (c : ZMod p) :
 /-- Integer powers of `τ₀` act by translation. -/
 lemma tau0_zpow_apply (k : ℤ) : ∀ x : ZMod p, (τ₀ ^ k) x = x + (k : ZMod p) := by
   induction k using Int.induction_on with
-  | hz => intro x; simp
-  | hp k ih =>
+  | zero => intro x; simp
+  | succ k ih =>
       intro x
       rw [zpow_add_one, Equiv.Perm.mul_apply, tau0_apply, ih]
       push_cast
       ring
-  | hn k ih =>
+  | pred k ih =>
       intro x
       rw [zpow_sub_one, Equiv.Perm.mul_apply, tau0_inv_apply, ih]
       push_cast
@@ -144,7 +144,7 @@ lemma conj_mem (g : AGL1Z p) (n : Equiv.Perm (ZMod p))
     simp only [← MulAut.conj_apply]
     exact map_zpow _ _ _
   rw [hconj, conj_tau0]
-  exact Subgroup.zpow_mem (transl_mem _) j
+  exact zpow_mem (transl_mem _) j
 
 /-- **Affine characterization (standard translation).**
     The normalizer of `⟨τ₀⟩` in `S_p` is exactly the affine group. -/
@@ -252,18 +252,17 @@ theorem normalizer_iso_AGL1Z
   set e : Equiv.Perm (ZMod p) ≃* Equiv.Perm (ZMod p) := MulAut.conj c with he
   have hes : e σ = τ₀ := by rw [he, MulAut.conj_apply, hc]
   -- `e` maps `⟨σ⟩` onto `⟨τ₀⟩`
-  have hmapz : (Subgroup.zpowers σ).map (e : Equiv.Perm (ZMod p) →* Equiv.Perm (ZMod p))
+  have hmapz : (Subgroup.zpowers σ).map e.toMonoidHom
       = Subgroup.zpowers τ₀ := by
     rw [MonoidHom.map_zpowers,
-      show (e : Equiv.Perm (ZMod p) →* Equiv.Perm (ZMod p)) σ = τ₀ from hes]
+      show e.toMonoidHom σ = τ₀ from hes]
   -- normalizers correspond under `e`
-  have hN : (Subgroup.zpowers σ).normalizer.map
-        (e : Equiv.Perm (ZMod p) →* Equiv.Perm (ZMod p))
+  have hN : (Subgroup.zpowers σ).normalizer.map e.toMonoidHom
       = (Subgroup.zpowers τ₀).normalizer := by
     rw [Subgroup.map_equiv_normalizer_eq (Subgroup.zpowers σ) e, hmapz]
   -- assemble `N(⟨σ⟩) ≃* N(⟨τ₀⟩) ≃* AGL1Z`
   let isoConj : (Subgroup.zpowers σ).normalizer ≃* (Subgroup.zpowers τ₀).normalizer :=
-    (Subgroup.equivMapOfInjective _ (e : Equiv.Perm (ZMod p) →* Equiv.Perm (ZMod p))
+    (Subgroup.equivMapOfInjective _ e.toMonoidHom
       e.injective).trans (MulEquiv.subgroupCongr hN)
   let φe : (Subgroup.zpowers σ).normalizer ≃* AGL1Z p := isoConj.trans isoStd.symm
   exact ⟨φe.toMonoidHom, φe.injective, φe.surjective⟩


### PR DESCRIPTION
## Summary

Discharges **Step 4** (`normalizer_iso_AGL1Z`) of the Galois-direction proof for
`abel-ruffini-galois-extensions-oq-06`, eliminating the final `sorry` in
`AbelRuffiniGaloisExtensionsOQ06GaloisDirection` (Step 4 frontier: the classical
holomorph computation `N_{S_p}(⟨σ⟩) ≅ AGL(1, p)`).

The discharge lives in the companion `…GaloisDirectionStep4`, which proves
`normalizer_eq_range` (every permutation normalizing `⟨τ₀⟩` is affine, via the
functional equation `h(y+1) = h(y) + u`) and transports it along the conjugacy
`σ ∼ τ₀` of any `p`-cycle. The main file now delegates to it, so `normalizer_iso_AGL1Z`
is `sorry`-free.

## What changed

- **Wire**: register `…GaloisDirectionStep4` in `Proofs.lean`; replace the Step 4
  `sorry` in the main file with a delegation to the companion.
- **Repair Step 4 companion Mathlib v4.26.0 bit-rot** (the companion was an orphan
  never built against current Mathlib):
  - `Subgroup.zpow_mem` takes `K` explicitly → use root `zpow_mem`.
  - `map_equiv_normalizer_eq` / `equivMapOfInjective` need `e.toMonoidHom`; the
    `(e : _ →* _)` ascription elaborates to a distinct `↑e` coercion the rewrite
    pattern wouldn't match.
  - `τ₀` is `local notation`, so `τ₀.injective` fails → `(τ₀).injective`.
  - `Int.induction_on` binders `hz/hp/hn` → `zero/succ/pred`.
- Refresh the now-stale Step 4 docstring.

## Build verification

`docker-build.sh` green (no `sorry`, only deprecation/lint warnings):
- `Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4` — 7745 jobs ✓
- `Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirection` — 7746 jobs ✓

Remaining open Galois-direction frontier: Step 1 (`sylow_p_unique`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)