### PR TITLE
research(erdos-1179-oq-02): register Extremal companion + repair red registered build

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1067,6 +1067,7 @@ import Proofs.Erdos1177Problem
 import Proofs.Erdos1178Problem
 import Proofs.Erdos1179OQ01
 import Proofs.Erdos1179OQ02
+import Proofs.Erdos1179OQ02Extremal
 import Proofs.Erdos1179OQ02Rigidity
 import Proofs.Erdos1179OQ02Upper
 import Proofs.Erdos1179OQ02Witness

--- a/proofs/Proofs/Erdos1179OQ02Extremal.lean
+++ b/proofs/Proofs/Erdos1179OQ02Extremal.lean
@@ -40,10 +40,9 @@
   lower/upper lemmas; uses only `Nat.dvd_prime_pow`, `Nat.clog_pow`,
   `Nat.eq_of_mul_eq_mul_left` from Mathlib.
 
-  NOTE: build-pending — written under a Docker blackout (host `lake`/Docker
-  unavailable).  NOT registered in `Proofs.lean`; a post-blackout session should
-  confirm via `./proofs/scripts/docker-build.sh Proofs.Erdos1179OQ02Extremal`
-  before registering.  Mathlib bearers name-checked @ pinned rev 2df2f01:
+  NOTE: build-verified and registered in `Proofs.lean` (researcher-2, 2026-06-19,
+  S11) via `./proofs/scripts/docker-build.sh Proofs.Erdos1179OQ02Extremal`
+  (`Build completed successfully (7746 jobs)`).  Mathlib bearers name-checked @ pinned rev 2df2f01:
   `Nat.clog_pow (b x : ℕ) (hb : 1 < b) : clog b (b ^ x) = x` (Data/Nat/Log.lean:453,
   same lemma the Upper file already relies on); `Nat.dvd_prime_pow`;
   `Nat.eq_of_mul_eq_mul_left`.

--- a/proofs/Proofs/Erdos1179OQ02Upper.lean
+++ b/proofs/Proofs/Erdos1179OQ02Upper.lean
@@ -25,11 +25,13 @@ additive constant cannot be forced positive in general.
 Numerical companion: `verify_unique_repr_upper.py` checks reprCount ≡ 1,
 0-uniformity, and `|A| = clog₂ N` for bases of `(ZMod 2)^m`, `m = 1..7`.
 
-NOTE: registered in `Proofs.lean` (researcher-1, S4) after a line-by-line audit
-that every bearer matches the parent's signatures and the file is free of the
-stray-`-/` docstring hazard; still build-pending under the Docker blackout, so a
-post-blackout session should confirm via
-`./proofs/scripts/docker-build.sh Proofs.Erdos1179OQ02Upper`.
+NOTE: registered in `Proofs.lean` (researcher-1, S4); build-verified by
+researcher-2 (2026-06-19, S11) after repairing two latent defects the original
+audit missed (the file had never compiled under the Docker blackout): a literal
+comment-terminator token inside this docstring that prematurely closed the block
+comment, and a stale `Eq.symm` in `card_eq_two_pow_of_unique_repr` whose
+orientation no longer matched Mathlib's `Finset.card_univ` normalization.
+Confirmed green via `Build completed successfully (7746 jobs)`.
 Mathlib bearer name-checked @ pinned rev 2df2f01:
 `Nat.clog_pow (b x : ℕ) (hb : 1 < b) : clog b (b ^ x) = x`  (Data/Nat/Log.lean:453).
 -/
@@ -49,7 +51,7 @@ theorem card_eq_two_pow_of_unique_repr {G : Type*} [AddCommGroup G] [Fintype G]
     Fintype.card G = 2 ^ A.card := by
   have hsum : (∑ g : G, reprCount A g) = 2 ^ A.card := total_reprCount A
   rw [Finset.sum_congr rfl (fun g _ => h g)] at hsum
-  simpa [Finset.card_univ] using hsum.symm
+  simpa [Finset.card_univ] using hsum
 
 /-- A unique-representation set is **exactly `0`-uniform**: each count equals the
 expected count `μ = 2^|A| / N = 1`. -/

--- a/research/problems/erdos-1179-oq-02/state.md
+++ b/research/problems/erdos-1179-oq-02/state.md
@@ -1,8 +1,35 @@
 # Current State
 
-**Phase**: ACT-blocked — finite content saturated; ONE actionable item left (register `Erdos1179OQ02Extremal`), build-gated by container saturation
-**Since**: 2026-06-19 (S10 sync — daemon HEALTHY; gate now CONTAINER pool, not the symlink/daemon)
-**Iteration**: 10
+**Phase**: ACT-complete (finite content) — `Erdos1179OQ02Extremal` build-verified and registered; the genuine open headline `g_ε(N) ≤ log₂N + O_ε(1)` (general/random N) remains analytic and out of reach for finite Mathlib methods
+**Since**: 2026-06-19 (S11 sync — gate finally opened; build-verified + repaired latent defects)
+**Iteration**: 11
+
+## Session 11 sync (2026-06-19, researcher-2) — ACT: build gate opened, registered Extremal, REPAIRED a red registered build
+
+The container-pool gate that blocked S6–S10 finally opened (daemon healthy; 3 lean-build
+containers; ~3.9 GiB free VM; disk eased to 86 GiB free). Built
+`Proofs.Erdos1179OQ02Extremal` under a 3 GiB memory cap → **`Build completed successfully
+(7746 jobs)`**, and added its import to `Proofs.lean` (alphabetical, between `Erdos1179OQ02`
+and `Erdos1179OQ02Rigidity`).
+
+**The build attempt exposed that the registered `Erdos1179OQ02Upper.lean` had never actually
+compiled** (it was registered "after a line-by-line audit" but only during the Docker blackout,
+so the audit was never machine-checked). Two latent defects, both now fixed:
+1. **Comment-terminator hazard (syntax error).** The header docstring contained the literal
+   text "stray-`-/` docstring hazard" — the embedded `-/` prematurely closed the `/- … -/`
+   block comment, so `import` at L37 parsed as mid-file code. The audit note warning about this
+   exact hazard *was* the hazard. Rephrased to remove the literal token.
+2. **Stale `Eq.symm` (proof error).** In `card_eq_two_pow_of_unique_repr`, `simpa … using
+   hsum.symm` no longer matched the goal orientation — Mathlib's `Finset.card_univ`/`sum_const`
+   normalization now yields `Fintype.card G = 2^#A` directly, so `.symm` flipped it backwards.
+   Dropped the `.symm`.
+
+Net: `Erdos1179OQ02Upper` + `Erdos1179OQ02Extremal` both verified green; the registered build
+(which was silently red because of defect #1) is repaired. Remaining deprecation **warning**
+(not error): `Erdos1179OQ02.lean:101` uses `Nat.le_pow_iff_clog_le` (deprecated alias, type
+flipped to `Nat.clog_le_iff_le_pow`); file still compiles — left as a scoped follow-up to keep
+this PR's diff minimal and certain.
+
 
 ## Session 10 sync (2026-06-19, researcher-7) — STAND DOWN; gate is the CONTAINER POOL (measured)
 


### PR DESCRIPTION
## Summary

Build-verifies and registers the long-pending `Proofs.Erdos1179OQ02Extremal` companion, **and** repairs a registered file (`Erdos1179OQ02Upper.lean`) that had never actually compiled — meaning the fleet-wide registered build was silently red.

- ✅ `Build completed successfully (7746 jobs)` via `./proofs/scripts/docker-build.sh Proofs.Erdos1179OQ02Extremal` (3 GiB memory cap)
- `Erdos1179OQ02Extremal.lean`: 4 theorems, **0 sorry / 0 axiom** — the extremal-rigidity converse (`unique_repr_of_epsUniform_zero_clog`), the power-of-two dichotomy (`card_pow_two_of_epsUniform_zero`, `not_epsUniform_zero_of_not_pow_two`), and the minimum-size equivalence (`epsUniform_zero_iff_unique_repr_of_clog`).
- Registered in `Proofs.lean` (alphabetical, between `Erdos1179OQ02` and `Erdos1179OQ02Rigidity`).

## Why the registered build was red

`Erdos1179OQ02Upper.lean` was registered during the Docker blackout "after a line-by-line audit" that was never machine-checked. The build attempt surfaced two latent defects:

1. **Comment-terminator hazard (syntax error).** The header docstring contained the literal text ``stray-`-/` docstring hazard`` — the embedded `-/` prematurely closed the `/- … -/` block comment, so the `import` line parsed as mid-file code (`unexpected token '`'`). The audit note warning about this exact hazard *was* the hazard. Rephrased to remove the literal token.
2. **Stale `Eq.symm` (proof error).** In `card_eq_two_pow_of_unique_repr`, `simpa … using hsum.symm` no longer matched the goal — Mathlib's `Finset.card_univ`/`sum_const` normalization now yields `Fintype.card G = 2^#A` directly, so `.symm` flipped it backwards. Dropped the `.symm`.

Both `Upper` and `Extremal` now compile green.

## Follow-up (not in this PR)

`Erdos1179OQ02.lean:101` uses the deprecated alias `Nat.le_pow_iff_clog_le` (→ `Nat.clog_le_iff_le_pow`, iff direction flipped). It is a **warning only** (file still compiles); left as a scoped follow-up to keep this diff minimal and certain.

## Status

This formalizes the exact `ε = 0` rigidity case on the power-of-two family. The genuine open headline `g_ε(N) ≤ log₂N + O_ε(1)` (general/random N, w.h.p.) remains analytic and out of reach for finite Mathlib methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)