### PR TITLE
research(brianchon-theorem-oq-01): prove Brianchon as the projective dual of Pascal

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -336,6 +336,7 @@ import Proofs.BoundedPrimeGapsOQ04OQ01Aristotle
 import Proofs.BoundedPrimeGapsOQ04OQ02
 import Proofs.BoundedPrimeGapsSieve
 import Proofs.BoundedPrimeGapsTPC
+import Proofs.BrianchonTheorem
 import Proofs.BritishFlagTheorem
 import Proofs.BrouwerFixedPoint
 import Proofs.BrouwerFixedPointOQ01

--- a/proofs/Proofs/BrianchonTheorem.lean
+++ b/proofs/Proofs/BrianchonTheorem.lean
@@ -1,0 +1,293 @@
+import Mathlib.Data.Real.Basic
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.LinearAlgebra.CrossProduct
+import Mathlib.LinearAlgebra.Matrix.Adjugate
+import Mathlib.Tactic
+
+/-
+# Brianchon's Theorem — proved as the projective dual of Pascal's theorem
+
+## What This Proves
+
+Brianchon's theorem: if a hexagon is *circumscribed* about a conic (each of its
+six sides is tangent to the conic), then the three main diagonals joining
+opposite vertices are concurrent.  This is the projective dual of Pascal's
+hexagon theorem (`PascalsHexagon.lean`).
+
+## The mathematical content
+
+The deep geometric fact behind Pascal's theorem (six points on a conic ⟹ the
+three intersections of opposite sides are collinear) is, as in the gallery's
+`PascalsHexagon.lean`, taken as the single axiom `conic_implies_pascal`.
+
+The new content here is the **pole–polar duality bridge**
+`concurrent_brianchon_of_collinear_pascal`, which is proved with **no axioms and
+no `sorry`**: it shows that, purely by linear algebra, Pascal's "three points
+collinear" forces Brianchon's "three lines concurrent".  Brianchon's theorem
+then follows by feeding Pascal's axiom into this bridge, introducing no new
+assumption beyond the one Pascal already needs.
+
+## The duality, in coordinates
+
+Points and lines are nonzero vectors in `ℝ³`; the join of two points / meet of
+two lines is the cross product; three points are collinear (resp. three lines
+concurrent) iff the `3×3` determinant of their coordinate vectors vanishes.
+
+For a symmetric conic `C` (a symmetric `3×3` matrix) the polarity `P ↦ C · P`
+sends a point `P` on the conic to the tangent line of `C` at `P`.  A hexagon
+circumscribed about `C` is therefore the dual of an inscribed hexagon whose
+vertices `A, …, F` are the six contact points: its sides are the tangent lines
+`C·A, …, C·F`, and its vertices are the meets of consecutive sides.
+
+The bridge rests on two computational facts (proved below by `ring`):
+
+* `crossProduct_mulMatrix` :
+  `(M·u) × (M·v) = (adjugate M)ᵀ · (u × v)`              (the cofactor identity),
+* `det_threeVectorMatrix_mulMatrix` :
+  `det (M·u, M·v, M·w) = det M · det (u, v, w)`.
+
+Applying the first twice (with `M = C`, then `M = adjugate C`) and using
+`adjugate (adjugate C) = det C • C` (true for `3×3`), each Brianchon diagonal
+equals `(det C • C)` applied to the corresponding Pascal point.  The second fact
+then turns Pascal's vanishing determinant into Brianchon's.
+
+## Status
+
+`status: axiomatized` — the unconditional `brianchon_theorem` relies on exactly
+one axiom, `conic_implies_pascal` (the *same* fact axiomatized by the Pascal
+gallery entry), and on no others.  The duality bridge
+`concurrent_brianchon_of_collinear_pascal` is axiom-free and `sorry`-free.
+-/
+
+set_option linter.unusedVariables false
+
+open Matrix
+
+namespace Brianchon
+
+-- ============================================================
+-- PART 1: Projective model (homogeneous coordinates in ℝ³)
+-- ============================================================
+
+/-- A projective point: a (nonzero) vector in `ℝ³`. -/
+abbrev ProjPoint := Fin 3 → ℝ
+
+/-- A projective line: a (nonzero) covector in `ℝ³`. -/
+abbrev ProjLine := Fin 3 → ℝ
+
+/-- The line through two points is their cross product. -/
+noncomputable def lineThrough (p q : ProjPoint) : ProjLine := crossProduct p q
+
+/-- The meet of two lines is their cross product. -/
+noncomputable def lineIntersection (l m : ProjLine) : ProjPoint := crossProduct l m
+
+/-- The `3×3` matrix whose rows are the three given vectors. -/
+def threeVectorMatrix (u v w : Fin 3 → ℝ) : Matrix (Fin 3) (Fin 3) ℝ :=
+  Matrix.of fun i j =>
+    match i with
+    | 0 => u j
+    | 1 => v j
+    | 2 => w j
+
+/-- Three points are collinear iff their coordinate determinant vanishes. -/
+def collinear (p q r : ProjPoint) : Prop := (threeVectorMatrix p q r).det = 0
+
+/-- Three lines are concurrent iff their coefficient determinant vanishes. -/
+def concurrent (l m n : ProjLine) : Prop := (threeVectorMatrix l m n).det = 0
+
+/-- A conic is a symmetric `3×3` matrix `C`; a point `p` lies on it iff
+`pᵀ C p = 0`. -/
+abbrev Conic := Matrix (Fin 3) (Fin 3) ℝ
+
+/-- The conic's quadratic form `pᵀ C p`. -/
+noncomputable def conicQuadraticForm (C : Conic) (p : ProjPoint) : ℝ :=
+  ∑ i, ∑ j, C i j * p i * p j
+
+/-- A point lies on a conic iff its quadratic form vanishes. -/
+def pointOnConic (p : ProjPoint) (C : Conic) : Prop := conicQuadraticForm C p = 0
+
+/-- `C` is symmetric (`Cᵢⱼ = Cⱼᵢ`). -/
+def Conic.symmetric (C : Conic) : Prop := ∀ i j, C i j = C j i
+
+/-- Apply a matrix to a projective point (a projective transformation when the
+matrix is invertible). -/
+def mapPoint (M : Matrix (Fin 3) (Fin 3) ℝ) (p : ProjPoint) : ProjPoint := M *ᵥ p
+
+-- ============================================================
+-- PART 2: The two computational identities
+-- ============================================================
+
+set_option maxHeartbeats 2000000 in
+/-- **Cofactor / Binet–Cauchy identity for the cross product.**
+`(M·u) × (M·v) = (adjugate M)ᵀ · (u × v)`.  This is the algebraic heart of
+pole–polar duality: the join/meet operation intertwines the point map `M` with
+the line map `(adjugate M)ᵀ` (the cofactor matrix). -/
+theorem crossProduct_mulMatrix (M : Matrix (Fin 3) (Fin 3) ℝ) (u v : Fin 3 → ℝ) :
+    crossProduct (M *ᵥ u) (M *ᵥ v) = (M.adjugate)ᵀ *ᵥ (crossProduct u v) := by
+  ext i
+  fin_cases i <;>
+    simp only [cross_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_three, Fin.isValue,
+      Matrix.adjugate_fin_three, Matrix.transpose_apply, Matrix.of_apply,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+      Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk] <;>
+    ring
+
+/-- Applying a fixed matrix `M` to the three rows multiplies the
+`threeVectorMatrix` determinant by `det M`.  Hence collinearity/concurrency is
+governed by `det M`: in particular a vanishing source determinant forces a
+vanishing target determinant. -/
+theorem det_threeVectorMatrix_mulMatrix (M : Matrix (Fin 3) (Fin 3) ℝ) (u v w : Fin 3 → ℝ) :
+    (threeVectorMatrix (M *ᵥ u) (M *ᵥ v) (M *ᵥ w)).det
+      = M.det * (threeVectorMatrix u v w).det := by
+  have h : threeVectorMatrix (M *ᵥ u) (M *ᵥ v) (M *ᵥ w) = threeVectorMatrix u v w * Mᵀ := by
+    ext i j
+    fin_cases i <;>
+      simp only [threeVectorMatrix, Matrix.of_apply, Matrix.mul_apply, Matrix.transpose_apply,
+        Matrix.mulVec, dotProduct, Fin.sum_univ_three, Fin.isValue] <;>
+      ring
+  rw [h, Matrix.det_mul, Matrix.det_transpose]
+  ring
+
+-- ============================================================
+-- PART 3: Symmetric-conic bookkeeping
+-- ============================================================
+
+/-- A symmetric matrix equals its own transpose. -/
+theorem transpose_of_symmetric {C : Conic} (hC : C.symmetric) : Cᵀ = C := by
+  ext i j
+  exact hC j i
+
+/-- The adjugate of a symmetric matrix is symmetric. -/
+theorem adjugate_symmetric {C : Conic} (hC : C.symmetric) : (C.adjugate)ᵀ = C.adjugate := by
+  rw [Matrix.adjugate_transpose, transpose_of_symmetric hC]
+
+/-- For a symmetric `3×3` conic, the iterated cofactor matrix `((adj C)ᵀ adj)ᵀ`
+collapses to the single linear map `det C • C`. -/
+theorem dual_matrix_eq {C : Conic} (hC : C.symmetric) :
+    ((C.adjugate)ᵀ.adjugate)ᵀ = C.det • C := by
+  rw [adjugate_symmetric hC, Matrix.adjugate_adjugate _ (by decide : Fintype.card (Fin 3) ≠ 1),
+    Matrix.transpose_smul, transpose_of_symmetric hC]
+  simp [Fintype.card_fin]
+
+-- ============================================================
+-- PART 4: The circumscribed hexagon (dual configuration)
+-- ============================================================
+
+/-- The tangent line of the conic `C` at a contact point `P` lying on `C` is the
+polar line `C ·ᵥ P`. -/
+noncomputable def tangentLine (C : Conic) (P : ProjPoint) : ProjLine := mapPoint C P
+
+/-- A vertex of the circumscribed hexagon: the meet of the tangent lines at two
+contact points (the intersection of two adjacent sides). -/
+noncomputable def circVertex (C : Conic) (P Q : ProjPoint) : ProjPoint :=
+  lineIntersection (tangentLine C P) (tangentLine C Q)
+
+-- ============================================================
+-- PART 5: Each diagonal is the dual image of a Pascal point
+-- ============================================================
+
+/-- **Key reduction lemma.**  A circumscribed-hexagon diagonal
+`lineThrough (circVertex C P Q) (circVertex C R S)` equals the fixed linear map
+`det C • C` applied to the corresponding Pascal point
+`lineIntersection (lineThrough P Q) (lineThrough R S)`. -/
+theorem diag_eq {C : Conic} (hC : C.symmetric) (P Q R S : ProjPoint) :
+    lineThrough (circVertex C P Q) (circVertex C R S)
+      = (C.det • C) *ᵥ lineIntersection (lineThrough P Q) (lineThrough R S) := by
+  unfold circVertex tangentLine mapPoint lineThrough lineIntersection
+  -- Apply the cofactor identity bottom-up: inner meets first, then the outer join.
+  simp only [crossProduct_mulMatrix]
+  rw [dual_matrix_eq hC]
+
+-- ============================================================
+-- PART 6: The axiom-free duality bridge
+-- ============================================================
+
+/-- **Brianchon ⇐ Pascal (axiom-free duality bridge).**
+
+For a symmetric conic `C` with six contact points `A, B, C', D, E, F`: if the
+three Pascal points (intersections of opposite sides of the *inscribed* hexagon
+of contact points) are collinear, then the three main diagonals of the
+*circumscribed* hexagon are concurrent.
+
+This is the projective duality between Pascal and Brianchon, made completely
+explicit.  It is proved with **no axioms and no `sorry`** — it is pure linear
+algebra: each diagonal is `(det C • C)` applied to a Pascal point, and applying
+a fixed matrix scales the triple determinant by its own determinant. -/
+theorem concurrent_brianchon_of_collinear_pascal {C : Conic} (hC : C.symmetric)
+    (A B C' D E F : ProjPoint)
+    (hPascal : collinear
+      (lineIntersection (lineThrough A B) (lineThrough D E))
+      (lineIntersection (lineThrough B C') (lineThrough E F))
+      (lineIntersection (lineThrough C' D) (lineThrough F A))) :
+    concurrent
+      (lineThrough (circVertex C A B) (circVertex C D E))
+      (lineThrough (circVertex C B C') (circVertex C E F))
+      (lineThrough (circVertex C C' D) (circVertex C F A)) := by
+  unfold concurrent
+  rw [diag_eq hC, diag_eq hC, diag_eq hC, det_threeVectorMatrix_mulMatrix]
+  unfold collinear at hPascal
+  rw [hPascal, mul_zero]
+
+-- ============================================================
+-- PART 7: The circumscribed hexagon of contact points + Pascal's axiom
+-- ============================================================
+
+/-- Six contact points on a conic `C` (the points where the six sides of a
+circumscribed hexagon touch `C`).  Equivalently, an inscribed hexagon whose
+projective dual is the circumscribed hexagon of Brianchon's theorem. -/
+structure ContactHexagon (C : Conic) where
+  A : ProjPoint
+  B : ProjPoint
+  C' : ProjPoint
+  D : ProjPoint
+  E : ProjPoint
+  F : ProjPoint
+  hA : pointOnConic A C
+  hB : pointOnConic B C
+  hC : pointOnConic C' C
+  hD : pointOnConic D C
+  hE : pointOnConic E C
+  hF : pointOnConic F C
+
+/-- **Pascal's hexagon theorem (axiomatized).**  Six points on a conic make the
+three intersections of opposite sides collinear.  This is exactly the deep fact
+the gallery's `PascalsHexagon.lean` axiomatizes as `conic_implies_pascal_constraint`;
+we restate it here in collinearity form and reuse it unchanged. -/
+axiom conic_implies_pascal (C : Conic) (hex : ContactHexagon C) :
+    collinear
+      (lineIntersection (lineThrough hex.A hex.B) (lineThrough hex.D hex.E))
+      (lineIntersection (lineThrough hex.B hex.C') (lineThrough hex.E hex.F))
+      (lineIntersection (lineThrough hex.C' hex.D) (lineThrough hex.F hex.A))
+
+-- ============================================================
+-- PART 8: Brianchon's Theorem
+-- ============================================================
+
+/-- First main diagonal of the circumscribed hexagon. -/
+noncomputable def brianchonDiag1 {C : Conic} (hex : ContactHexagon C) : ProjLine :=
+  lineThrough (circVertex C hex.A hex.B) (circVertex C hex.D hex.E)
+
+/-- Second main diagonal of the circumscribed hexagon. -/
+noncomputable def brianchonDiag2 {C : Conic} (hex : ContactHexagon C) : ProjLine :=
+  lineThrough (circVertex C hex.B hex.C') (circVertex C hex.E hex.F)
+
+/-- Third main diagonal of the circumscribed hexagon. -/
+noncomputable def brianchonDiag3 {C : Conic} (hex : ContactHexagon C) : ProjLine :=
+  lineThrough (circVertex C hex.C' hex.D) (circVertex C hex.F hex.A)
+
+/-- **Brianchon's Theorem** (projective dual of Pascal's hexagon theorem).
+
+Let `C` be a symmetric conic and let a hexagon be circumscribed about `C`, its
+six sides being the tangent lines of `C` at six contact points
+`A, B, C', D, E, F` on `C`.  Then the three main diagonals of the circumscribed
+hexagon are concurrent.
+
+The proof combines Pascal's theorem (the shared axiom) with the axiom-free
+duality bridge `concurrent_brianchon_of_collinear_pascal`.  It uses **no axiom
+beyond** `conic_implies_pascal`, the same fact the Pascal gallery entry assumes. -/
+theorem brianchon_theorem {C : Conic} (hC : C.symmetric) (hex : ContactHexagon C) :
+    concurrent (brianchonDiag1 hex) (brianchonDiag2 hex) (brianchonDiag3 hex) :=
+  concurrent_brianchon_of_collinear_pascal hC hex.A hex.B hex.C' hex.D hex.E hex.F
+    (conic_implies_pascal C hex)
+
+end Brianchon

--- a/research/problems/brianchon-theorem-oq-01/knowledge.md
+++ b/research/problems/brianchon-theorem-oq-01/knowledge.md
@@ -6,16 +6,112 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Brianchon's theorem (1806): a hexagon circumscribed about a conic (all six sides
+tangent) has its three main diagonals concurrent. It is the exact projective
+dual of Pascal's hexagon theorem (1639), which is already formalized in the
+gallery (`pascals-hexagon`, `PascalsHexagon.lean`). Pascal: hexagon *inscribed*,
+opposite-side intersections *collinear*. Brianchon: hexagon *circumscribed*,
+main diagonals *concurrent*. Duality swaps points↔lines and collinear↔concurrent.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **The gallery's projective model is self-dual.** In `PascalsHexagon.lean`,
+  points and lines are nonzero vectors in ℝ³, join/meet are both the cross
+  product, and `collinear`/`concurrent` are *the same* predicate
+  `(threeVectorMatrix · · ·).det = 0`. So duality is just relabelling vectors.
+
+- **One computational identity drives the whole duality.** The cofactor /
+  Binet–Cauchy identity `(M·u)×(M·v) = (adj M)ᵀ·(u×v)` (a degree-3 polynomial
+  identity, closed by `ring` once `Matrix.adjugate_fin_three` expands the 3×3
+  adjugate). PascalsHexagon already proves this as `crossProduct_projTransform`;
+  we reprove a clean standalone version `crossProduct_mulMatrix`.
+
+- **Each Brianchon diagonal = (det C • C) applied to the matching Pascal point.**
+  For a symmetric conic C, the tangent at a contact point P is the polar C·P.
+  A circumscribed-hexagon vertex is `(C·P)×(C·Q) = (adj C)·(P×Q)` (using
+  symmetry: `(adj C)ᵀ = adj C`). A diagonal joins two such vertices, so applying
+  the identity again gives `adj(adj C)·(Pascal point)`. For 3×3,
+  `adjugate (adjugate C) = det C • C` (Mathlib `adjugate_adjugate`, exponent
+  card−2 = 1). Hence each diagonal is `(det C • C)·(Pascal point)`.
+
+- **Determinant transport closes it with no nondegeneracy needed.** Since
+  `det(M·u, M·v, M·w) = det M · det(u,v,w)`, the Brianchon triple determinant is
+  `det(det C • C)` times the Pascal triple determinant. Pascal collinearity ⟹
+  the Pascal determinant is 0 ⟹ product is 0 ⟹ Brianchon concurrency — even
+  without assuming `det C ≠ 0`.
+
+- **No new axiom.** `concurrent_brianchon_of_collinear_pascal` (the bridge) is
+  axiom-free and sorry-free (`#print axioms`: propext, Classical.choice,
+  Quot.sound only). `brianchon_theorem` adds exactly `conic_implies_pascal`, the
+  same fact `pascals-hexagon` already assumes. This answers an open question the
+  Pascal entry itself recorded.
+
+## Built Items
+
+- `proofs/Proofs/BrianchonTheorem.lean` (293 lines, builds clean, 0 sorries):
+  - `crossProduct_mulMatrix` — cofactor cross-product identity (ring).
+  - `det_threeVectorMatrix_mulMatrix` — determinant transport.
+  - `dual_matrix_eq` — `((adj C)ᵀ adj)ᵀ = det C • C` for symmetric 3×3.
+  - `diag_eq` — each diagonal = (det C • C)·(Pascal point).
+  - `concurrent_brianchon_of_collinear_pascal` — axiom-free duality bridge.
+  - `brianchon_theorem` — unconditional Brianchon (1 axiom).
+- Gallery entry `src/data/proofs/brianchon-theorem-oq-01/meta.json`.
+
+## Mathlib Gaps
+
+- Mathlib has no off-the-shelf `(M·u)×(M·v) = (adj M)ᵀ·(u×v)`; proved locally by
+  `ring` via `adjugate_fin_three`. (Candidate for upstreaming.)
+
+## Why self-contained (not `import Proofs.PascalsHexagon`)
+
+`PascalsHexagon.lean` currently has a hard build error in its WIP Sylvester
+section (`associated (R := ℝ)` — invalid argument name) plus a known `sorry`, so
+it cannot be imported. `BrianchonTheorem.lean` therefore redefines the minimal
+projective model and restates the Pascal fact as its own axiom
+`conic_implies_pascal` (identical in content). This keeps the proof
+independently verifiable.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Importing `Proofs.PascalsHexagon` to reuse its `projTransform` /
+  `crossProduct_projTransform` / `conic_implies_pascal_constraint`: blocked by
+  the pre-existing hard build error in that file (Sylvester section). Resolved
+  by going self-contained.
+
+---
+
+## Sessions
+
+## Session 2026-06-19 (Session 2) — Brianchon proved via Pascal duality
+
+**Mode**: FRESH
+**Outcome**: completed
+
+### What I Did
+- Surveyed `PascalsHexagon.lean`; found its self-dual ℝ³ model and the existing
+  cofactor/determinant-transport lemmas.
+- Designed the pole–polar reduction: diagonal = (det C • C)·(Pascal point).
+- Discovered `PascalsHexagon.lean` does not build (Sylvester-section error);
+  pivoted to a self-contained file.
+- Wrote and machine-verified `BrianchonTheorem.lean` (0 sorries); confirmed the
+  axiom budget with `#print axioms`.
+- Added gallery `meta.json`; advanced phase to COMPLETED.
+
+### Key Findings
+- The duality bridge is genuinely axiom-free; only Pascal's own fact is assumed.
+- No nondegeneracy hypothesis is needed for the concurrency conclusion.
+
+### Files Modified
+- proofs/Proofs/BrianchonTheorem.lean (new)
+- proofs/Proofs.lean (import)
+- src/data/proofs/brianchon-theorem-oq-01/meta.json (new)
+- research/problems/brianchon-theorem-oq-01/{state.md, knowledge.md}
+- src/data/research/problems/brianchon-theorem-oq-01.json (new)
+
+### Next Steps
+- Eliminate the shared `conic_implies_pascal` axiom (Pascal-side work).
+- Optionally add nondegeneracy to recover the genuine Brianchon point.

--- a/research/problems/brianchon-theorem-oq-01/state.md
+++ b/research/problems/brianchon-theorem-oq-01/state.md
@@ -1,25 +1,39 @@
 # Research State: brianchon-theorem-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-06-16T06:50:55-07:00
-**Iteration**: 1
+**Since**: 2026-06-19
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Proof complete and machine-verified. Brianchon's theorem is formalized as the
+projective dual of Pascal's theorem in `proofs/Proofs/BrianchonTheorem.lean`
+(builds clean, 0 sorries).
 
 ## Active Approach
-None yet.
+Pole–polar dualization of Pascal (Approach 1 from problem.md), realized in the
+homogeneous ℝ³ coordinate model: the tangent line at a contact point P is the
+polar C·P; each Brianchon diagonal equals the fixed linear map (det C • C)
+applied to the corresponding Pascal point, via the cofactor cross-product
+identity.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (pole–polar dualization — SUCCESS)
+
+## Result
+- `concurrent_brianchon_of_collinear_pascal`: axiom-free, sorry-free duality
+  bridge (Pascal collinearity ⟹ Brianchon concurrency). `#print axioms` shows
+  only propext / Classical.choice / Quot.sound.
+- `brianchon_theorem`: unconditional statement; uses exactly one axiom,
+  `conic_implies_pascal` (the same fact axiomatized by `pascals-hexagon`).
+- Status: axiomatized (1 axiom, 0 sorries). Verified via docker-build.sh.
 
 ## Blockers
-None.
+None. (Remaining open: eliminate the shared `conic_implies_pascal` axiom — a
+Pascal-side problem, tracked under `pascals-hexagon`.)
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Done. Follow-up open questions recorded in the gallery entry's `openQuestions`.

--- a/src/data/proofs/brianchon-theorem-oq-01/meta.json
+++ b/src/data/proofs/brianchon-theorem-oq-01/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "brianchon-theorem-oq-01",
+  "title": "Brianchon's Theorem",
+  "slug": "brianchon-theorem-oq-01",
+  "description": "If a hexagon is circumscribed about a conic (each side tangent to it), the three main diagonals joining opposite vertices are concurrent. Proved here as the projective dual of Pascal's hexagon theorem, with the duality bridge fully verified and axiom-free.",
+  "meta": {
+    "author": "Charles-Julien Brianchon (1806)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Brianchon%27s_theorem",
+    "date": "1806",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/BrianchonTheorem.lean",
+    "tags": [
+      "geometry",
+      "projective",
+      "conic",
+      "duality",
+      "concurrency",
+      "classic"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Mathlib.LinearAlgebra.CrossProduct",
+        "description": "Cross product in ℝ³ for line-through and line-intersection (join/meet) operations",
+        "module": "Mathlib.LinearAlgebra.CrossProduct"
+      },
+      {
+        "theorem": "Matrix.adjugate_adjugate",
+        "description": "adjugate (adjugate A) = det A ^ (card - 2) • A; for 3×3 this collapses the iterated cofactor map to det C • C",
+        "module": "Mathlib.LinearAlgebra.Matrix.Adjugate"
+      },
+      {
+        "theorem": "Matrix.adjugate_fin_three",
+        "description": "Explicit 3×3 adjugate entries, enabling the cofactor cross-product identity to be discharged by `ring`",
+        "module": "Mathlib.LinearAlgebra.Matrix.Adjugate"
+      },
+      {
+        "theorem": "Matrix.det_mul",
+        "description": "Multiplicativity of the determinant, used to transport Pascal's vanishing determinant to Brianchon's",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      }
+    ],
+    "originalContributions": [
+      "First formal proof of Brianchon's theorem in the gallery, derived from Pascal's theorem via pole–polar duality",
+      "An axiom-free, sorry-free duality bridge `concurrent_brianchon_of_collinear_pascal`: Pascal collinearity ⟹ Brianchon concurrency, by pure linear algebra",
+      "The cofactor / Binet–Cauchy cross-product identity `(M·u)×(M·v) = (adj M)ᵀ·(u×v)` proved by `ring`",
+      "Reduction showing each Brianchon diagonal equals the fixed linear map `det C • C` applied to the corresponding Pascal point",
+      "Answers an open question posed in the `pascals-hexagon` gallery entry"
+    ],
+    "dateAdded": "2026-06-19",
+    "axiomCount": 1,
+    "lineCount": 293,
+    "assumptions": "1 axiom: `conic_implies_pascal` — the same deep geometric fact (six points on a conic ⟹ opposite-side intersections collinear) axiomatized by the `pascals-hexagon` gallery entry as `conic_implies_pascal_constraint`. No new axiom is introduced. The duality bridge `concurrent_brianchon_of_collinear_pascal` is axiom-free and sorry-free (verified via `#print axioms`: depends only on propext, Classical.choice, Quot.sound). The full `brianchon_theorem` adds only `conic_implies_pascal`.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 14
+  },
+  "overview": {
+    "historicalContext": "Charles-Julien Brianchon discovered this theorem in 1806 as a student at the École Polytechnique, publishing it in the *Journal de l'École Polytechnique*. It is the projective dual of Pascal's hexagon theorem (1639): where Pascal's theorem concerns a hexagon *inscribed* in a conic and concludes that the intersections of opposite sides are collinear, Brianchon's theorem concerns a hexagon *circumscribed* about a conic and concludes that the main diagonals are concurrent. The two statements are exchanged by the principle of projective duality, which swaps points with lines and 'collinear' with 'concurrent'. Brianchon's result was historically significant as one of the first striking applications of the (then-new) duality principle in projective geometry, later systematized by Poncelet and Gergonne.",
+    "problemStatement": "**Brianchon's Theorem**: Let a hexagon with sides $a, b, c, d, e, f$ be circumscribed about a conic (each side tangent to the conic), and let its vertices be the meets of consecutive sides. Then the three main diagonals joining opposite vertices are **concurrent** — they pass through a common point, the *Brianchon point*.",
+    "text": "If a hexagon is circumscribed about a conic, the three main diagonals joining opposite vertices are concurrent. The projective dual of Pascal's theorem.",
+    "proofStrategy": "Work in the same homogeneous model as `pascals-hexagon`: points and lines are nonzero vectors in $\\mathbb{R}^3$, the join of two points / meet of two lines is the cross product, and three points are collinear (resp. three lines concurrent) iff their $3\\times3$ coordinate determinant vanishes. For a symmetric conic matrix $C$, the polarity $P \\mapsto C\\cdot P$ sends a contact point on the conic to its tangent line, so a circumscribed hexagon is the dual of an inscribed hexagon of contact points $A,\\dots,F$. The proof hinges on the cofactor identity $(M\\cdot u)\\times(M\\cdot v) = (\\operatorname{adj} M)^{\\mathsf T}\\cdot(u\\times v)$. Applying it twice (with $M=C$ then $M=\\operatorname{adj} C$) and using $\\operatorname{adj}(\\operatorname{adj} C)=\\det C\\cdot C$ for $3\\times3$ matrices shows each Brianchon diagonal equals $(\\det C\\cdot C)$ applied to the corresponding Pascal point. Since applying a fixed matrix multiplies the triple determinant by its own determinant, Pascal's vanishing determinant forces Brianchon's. This duality bridge is axiom-free; the unconditional theorem then feeds in Pascal's axiom.",
+    "keyInsights": [
+      "**Self-dual coordinates**: In the homogeneous $\\mathbb{R}^3$ model the predicates `collinear` (of points) and `concurrent` (of lines) are *the same function* — both are 'the $3\\times3$ determinant vanishes' — so projective duality is literally the relabelling of vectors as points or as lines",
+      "**The cofactor identity is the whole duality**: $(M\\cdot u)\\times(M\\cdot v) = (\\operatorname{adj} M)^{\\mathsf T}\\cdot(u\\times v)$ says the join/meet operation intertwines the point map $M$ with the line map $(\\operatorname{adj} M)^{\\mathsf T}$; this one degree-3 polynomial identity, closed by `ring`, drives the entire reduction",
+      "**Diagonals are a fixed image of Pascal points**: applying the identity twice collapses the iterated cofactor matrix via $\\operatorname{adj}(\\operatorname{adj} C)=\\det C\\cdot C$, so every Brianchon diagonal is $(\\det C\\cdot C)$ applied to the matching Pascal point",
+      "**No nondegeneracy needed for the bridge**: because $\\det(M\\cdot u, M\\cdot v, M\\cdot w)=\\det M\\cdot\\det(u,v,w)$ and $0$ times anything is $0$, Pascal's collinearity forces Brianchon's concurrency even without assuming $\\det C\\neq0$",
+      "**No new axiom**: Brianchon is proved using exactly the one axiom Pascal already needs (`conic_implies_pascal`); the duality bridge itself depends only on the foundational axioms propext / Classical.choice / Quot.sound"
+    ],
+    "prerequisites": [
+      "Projective plane in homogeneous coordinates (points and lines as vectors in ℝ³)",
+      "Cross product as join/meet; determinant as the collinearity/concurrency test",
+      "Adjugate / cofactor matrix and the identity adjugate (adjugate A) = det A ^ (n-2) • A",
+      "Pole–polar duality with respect to a conic"
+    ]
+  },
+  "conclusion": {
+    "summary": "Brianchon's theorem is proved as the projective dual of Pascal's hexagon theorem. The core deliverable is the axiom-free, sorry-free duality bridge `concurrent_brianchon_of_collinear_pascal`, which shows by pure linear algebra that Pascal's three collinear points force Brianchon's three concurrent diagonals. The unconditional `brianchon_theorem` combines this bridge with the single Pascal axiom `conic_implies_pascal`, introducing no new assumption.",
+    "implications": "This closes the classic Pascal/Brianchon duality pair and answers an open question recorded in the `pascals-hexagon` entry ('Can the Brianchon dual be formally proved from Pascal's theorem via projective duality?'). The reusable bridge — cofactor cross-product identity plus determinant transport — is a template for dualizing other projective incidence theorems (e.g. Desargues self-duality, the dual of Pappus).",
+    "openQuestions": [
+      "Eliminate the shared `conic_implies_pascal` axiom (via Cayley–Bacharach or the Sylvester reduction to the standard conic), upgrading both Pascal and Brianchon to fully verified",
+      "Add the nondegeneracy hypothesis to recover the converse and the genuine Brianchon point as an honest projective point (validity of the diagonals)",
+      "Formalize the limiting/degenerate cases (a side through a point at infinity) explicitly"
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "Brianchon's theorem is the exact projective dual of Pascal's hexagon theorem; this proof derives Brianchon from Pascal via pole–polar duality and reuses the same homogeneous-coordinate model and the same `conic_implies_pascal` fact",
+      "sharedConcepts": [
+        "projective-geometry",
+        "conic-sections",
+        "duality",
+        "incidence-theorem"
+      ],
+      "targetId": "pascals-hexagon"
+    },
+    {
+      "relationship": "Both are fundamental incidence theorems of projective geometry exhibiting point-line duality; Desargues concerns perspective triangles, Brianchon concerns circumscribed hexagons",
+      "sharedConcepts": [
+        "projective-geometry",
+        "concurrency",
+        "incidence-theorem"
+      ],
+      "targetId": "desargues-theorem"
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/BrianchonTheorem.lean",
+    "lineCount": 293,
+    "axiomCount": 1,
+    "sorries": 0,
+    "theoremCount": 8,
+    "definitionCount": 14,
+    "imports": [
+      "import Mathlib.Data.Real.Basic",
+      "import Mathlib.LinearAlgebra.Matrix.Determinant.Basic",
+      "import Mathlib.LinearAlgebra.CrossProduct",
+      "import Mathlib.LinearAlgebra.Matrix.Adjugate",
+      "import Mathlib.Tactic"
+    ],
+    "opens": [
+      "Matrix"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "concurrent_brianchon_of_collinear_pascal",
+      "type": "core",
+      "description": "Axiom-free duality bridge: for a symmetric conic, if the three Pascal points of the contact hexagon are collinear, then the three main diagonals of the circumscribed hexagon are concurrent",
+      "leanType": "C.symmetric → collinear (pascal points) → concurrent (brianchon diagonals)"
+    },
+    {
+      "name": "brianchon_theorem",
+      "type": "core",
+      "description": "Brianchon's theorem: the three main diagonals of a hexagon circumscribed about a symmetric conic are concurrent",
+      "leanType": "C.symmetric → (hex : ContactHexagon C) → concurrent (brianchonDiag1 hex) (brianchonDiag2 hex) (brianchonDiag3 hex)"
+    },
+    {
+      "name": "crossProduct_mulMatrix",
+      "type": "supporting",
+      "description": "Cofactor / Binet–Cauchy identity: (M·u)×(M·v) = (adjugate M)ᵀ·(u×v)",
+      "leanType": "crossProduct (M *ᵥ u) (M *ᵥ v) = (M.adjugate)ᵀ *ᵥ crossProduct u v"
+    },
+    {
+      "name": "det_threeVectorMatrix_mulMatrix",
+      "type": "supporting",
+      "description": "Determinant transport: applying a fixed matrix to the three rows scales the triple determinant by det M",
+      "leanType": "det (threeVectorMatrix (M·u) (M·v) (M·w)) = det M * det (threeVectorMatrix u v w)"
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Brianchon, Charles-Julien",
+      "title": "Sur les surfaces courbes du second degré",
+      "year": "1806",
+      "venue": "Journal de l'École Polytechnique",
+      "note": "Original statement of Brianchon's theorem: the three main diagonals of a hexagon circumscribed about a conic are concurrent"
+    },
+    {
+      "authors": "Coxeter, H. S. M.",
+      "title": "Projective Geometry",
+      "year": "1987",
+      "venue": "Springer",
+      "note": "Modern treatment of Pascal/Brianchon duality and the pole–polar correspondence with respect to a conic"
+    }
+  ]
+}

--- a/src/data/research/problems/brianchon-theorem-oq-01.json
+++ b/src/data/research/problems/brianchon-theorem-oq-01.json
@@ -1,0 +1,73 @@
+{
+  "slug": "brianchon-theorem-oq-01",
+  "title": "Brianchon's Theorem (projective dual of Pascal)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "A hexagon circumscribed about a conic (each side tangent) has its three main diagonals joining opposite vertices concurrent. The projective dual of Pascal's hexagon theorem.",
+    "plain": "If a six-sided figure has all six sides touching one conic, the three long diagonals connecting opposite corners all pass through a single point (the Brianchon point).",
+    "whyMatters": [
+      "Completes the classic Pascal/Brianchon duality pair already partly present in the gallery",
+      "Exercises pole–polar duality / cofactor matrix algebra formally",
+      "Answers an open question recorded in the pascals-hexagon gallery entry"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Brianchon's theorem is formalized and machine-verified in BrianchonTheorem.lean (0 sorries).",
+      "The duality bridge concurrent_brianchon_of_collinear_pascal is axiom-free (only propext/Classical.choice/Quot.sound).",
+      "Pascal's hexagon theorem is in the gallery (pascals-hexagon) as the dual statement."
+    ],
+    "open": [
+      "The shared conic_implies_pascal axiom (Cayley–Bacharach / Sylvester reduction) is not yet eliminated — a Pascal-side problem.",
+      "Adding nondegeneracy to recover the genuine Brianchon point (validity of the diagonals) and the converse."
+    ],
+    "goal": "Formalize Brianchon's theorem by dualizing the existing Pascal proof via the conic's polarity, introducing no new axiom."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-19",
+    "iteration": 2,
+    "focus": "Proved Brianchon from Pascal via pole–polar duality in the homogeneous ℝ³ model. Self-contained file (PascalsHexagon.lean does not currently build). Status axiomatized: 1 axiom (conic_implies_pascal), 0 sorries."
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED: Brianchon's theorem proved as the projective dual of Pascal's theorem. Axiom-free duality bridge + unconditional theorem using only the shared Pascal axiom. Gallery entry added.",
+    "builtItems": [
+      "proofs/Proofs/BrianchonTheorem.lean (293 lines, 0 sorries, builds via docker-build.sh)",
+      "crossProduct_mulMatrix: cofactor identity (M·u)×(M·v) = (adj M)ᵀ·(u×v), by ring",
+      "det_threeVectorMatrix_mulMatrix: det(M·u, M·v, M·w) = det M · det(u,v,w)",
+      "dual_matrix_eq: ((adj C)ᵀ adj)ᵀ = det C • C for symmetric 3×3",
+      "diag_eq: each Brianchon diagonal = (det C • C)·(corresponding Pascal point)",
+      "concurrent_brianchon_of_collinear_pascal: axiom-free, sorry-free duality bridge",
+      "brianchon_theorem: unconditional Brianchon's theorem (1 axiom, conic_implies_pascal)",
+      "Gallery entry src/data/proofs/brianchon-theorem-oq-01/meta.json"
+    ],
+    "insights": [
+      "The gallery's projective ℝ³ model is self-dual: collinear (of points) and concurrent (of lines) are the same determinant predicate.",
+      "One cofactor cross-product identity drives the entire duality; applying it twice + adjugate_adjugate (det C • C for 3×3) reduces each diagonal to a fixed linear image of a Pascal point.",
+      "Determinant transport (det(M·rows) = det M · det rows) needs no nondegeneracy: 0 times anything is 0, so Pascal collinearity forces Brianchon concurrency.",
+      "Brianchon introduces no axiom beyond the one Pascal already needs."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks the cofactor cross-product identity (M·u)×(M·v) = (adj M)ᵀ·(u×v); proved locally via adjugate_fin_three. Candidate for upstreaming."
+    ],
+    "nextSteps": [
+      "Eliminate the shared conic_implies_pascal axiom (Cayley–Bacharach or Sylvester reduction) — Pascal-side work.",
+      "Add nondegeneracy to recover the genuine Brianchon point and the converse.",
+      "Formalize the degenerate/point-at-infinity cases explicitly."
+    ]
+  },
+  "tags": [
+    "projective-geometry",
+    "conics",
+    "duality",
+    "concurrency",
+    "classic"
+  ],
+  "started": "2026-06-16",
+  "lastUpdate": "2026-06-19",
+  "significance": 6,
+  "tractability": 7
+}


### PR DESCRIPTION
## Summary

Formalizes **Brianchon's theorem** — a hexagon circumscribed about a conic has its three main diagonals concurrent — as the **projective dual of Pascal's hexagon theorem**, in the same homogeneous ℝ³ model used by `PascalsHexagon.lean`.

This answers an open question recorded in the `pascals-hexagon` gallery entry: *"Can the Brianchon dual be formally proved from Pascal's theorem via projective duality?"*

## What's proved

- **`concurrent_brianchon_of_collinear_pascal`** — the duality bridge, **axiom-free and sorry-free**. By pure linear algebra, Pascal's "three points collinear" ⟹ Brianchon's "three lines concurrent".
- **`brianchon_theorem`** — the unconditional statement, using exactly **one** axiom, `conic_implies_pascal` (the same fact `PascalsHexagon.lean` assumes as `conic_implies_pascal_constraint`). **No new axiom.**

### The reduction
The proof rests on:
1. the cofactor / Binet–Cauchy identity `(M·u)×(M·v) = (adj M)ᵀ·(u×v)` (closed by `ring` via `adjugate_fin_three`), and
2. `adjugate (adjugate C) = det C • C` for 3×3.

Together these make **each Brianchon diagonal equal to the fixed linear map `det C • C` applied to the corresponding Pascal point**. Since `det(M·u, M·v, M·w) = det M · det(u,v,w)`, Pascal's vanishing determinant forces Brianchon's — no nondegeneracy hypothesis required.

## Verification

- Built clean via `./proofs/scripts/docker-build.sh Proofs.BrianchonTheorem` (0 sorries).
- `#print axioms` audit:
  - bridge → `[propext, Classical.choice, Quot.sound]` (axiom-free)
  - `brianchon_theorem` → `[propext, conic_implies_pascal, Classical.choice, Quot.sound]`
- **Status: axiomatized** — `axiomCount = 1`, `badge: axiom`, `sorries: 0`.

## Note on self-containment

The file is **self-contained** rather than `import Proofs.PascalsHexagon`, because that file currently has a hard build error in its WIP Sylvester section (`associated (R := ℝ)` — invalid argument name) and so cannot be imported. The minimal projective model is redefined locally and the Pascal fact is restated as an identical-content axiom, keeping this proof independently verifiable.

## Files
- `proofs/Proofs/BrianchonTheorem.lean` (new, 293 lines)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/brianchon-theorem-oq-01/meta.json` (new gallery entry)
- `src/data/research/problems/brianchon-theorem-oq-01.json` (new)
- `research/problems/brianchon-theorem-oq-01/{state.md, knowledge.md}` (phase → COMPLETED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)