### PR TITLE
research(erdos-mordell-inequality-oq-01): reconcile gallery prose with verified status

### DIFF
--- a/src/data/proofs/erdos-mordell-inequality-oq-01/annotations.json
+++ b/src/data/proofs/erdos-mordell-inequality-oq-01/annotations.json
@@ -23,7 +23,7 @@
   {
     "id": "ann-erdos-mordell-oq-01-02",
     "proofId": "erdos-mordell-inequality-oq-01",
-    "range": { "startLine": 64, "endLine": 101 },
+    "range": { "startLine": 81, "endLine": 109 },
     "type": "technique",
     "title": "The AM–GM Algebraic Reduction (Proved Core)",
     "content": "erdos_mordell_reduction is the geometry-free heart: it assumes only the three weighted key inequalities, side-length positivity, and pedal-distance nonnegativity, and derives the full bound 2(da+db+dc) ≤ PA+PB+PC. Each key inequality is scaled by the product of the two OTHER side lengths so all three share the common factor a·b·c; summing them, every pedal distance picks up a coefficient of the form t + 1/t, which is ≥ 2 by AM–GM. The proof is closed by handing nlinarith an explicit nonnegative SOS-style certificate: a·b·c·(PA+PB+PC) − 2a·b·c·(da+db+dc) equals a·da·(b−c)² + b·db·(a−c)² + c·dc·(a−b)² plus the key-inequality slack, each summand manifestly ≥ 0. The final le_of_mul_le_mul_left cancels the positive factor a·b·c.",
@@ -67,7 +67,7 @@
     "range": { "startLine": 145, "endLine": 186 },
     "type": "technique",
     "title": "Chord-to-Key Assembly: From Chord Identity + Law of Sines",
-    "content": "key_inequality_of_chord_and_sines is the verified bridge that converts the trig core into the side-length form of the key inequality. It takes exactly two geometric facts as hypotheses — the chord identity (PA·sin A)² = db² + dc² + 2·db·dc·cos A (concyclicity of the pedal feet on the circle of diameter PA) and the law of sines a = 2R sin A, b = 2R sin B, c = 2R sin C — and derives b·dc + c·db ≤ a·PA purely algebraically. The chord identity collapses the √(…) from the trig core to PA·sin A (via Real.sqrt_sq on the nonnegative product), giving sin B·dc + sin C·db ≤ PA·sin A; scaling by 2R > 0 and rewriting through the law of sines yields the side-length inequality. This sharpens each remaining open obligation from an opaque 'sorry' into the concrete task: exhibit the chord identity and law of sines for the specific Euclidean configuration.",
+    "content": "key_inequality_of_chord_and_sines is the verified bridge that converts the trig core into the side-length form of the key inequality. It takes exactly two geometric facts as hypotheses — the chord identity (PA·sin A)² = db² + dc² + 2·db·dc·cos A (concyclicity of the pedal feet on the circle of diameter PA) and the law of sines a = 2R sin A, b = 2R sin B, c = 2R sin C — and derives b·dc + c·db ≤ a·PA purely algebraically. The chord identity collapses the √(…) from the trig core to PA·sin A (via Real.sqrt_sq on the nonnegative product), giving sin B·dc + sin C·db ≤ PA·sin A; scaling by 2R > 0 and rewriting through the law of sines yields the side-length inequality. This isolates the entire geometric content into two concrete facts — the chord identity and the law of sines — both of which are now supplied for the Euclidean configuration (the law of sines from Mathlib's circumradius lemma, the chord identity via chord_cos_eq in the companion file), completing the key inequality with no sorry.",
     "mathContext": "$(PA\\sin A)^2 = d_b^2 + d_c^2 + 2 d_b d_c \\cos A$ and $a = 2R\\sin A \\Rightarrow b\\,d_c + c\\,d_b \\le a\\,PA$.",
     "significance": "key",
     "relatedConcepts": [
@@ -86,7 +86,7 @@
   {
     "id": "ann-erdos-mordell-oq-01-05",
     "proofId": "erdos-mordell-inequality-oq-01",
-    "range": { "startLine": 188, "endLine": 196 },
+    "range": { "startLine": 198, "endLine": 199 },
     "type": "definition",
     "title": "Pedal Distance via Distance to the Affine Span",
     "content": "lineDist P X Y is defined as Metric.infDist P (affineSpan ℝ {X, Y}) — the perpendicular distance from P to the line through X and Y, expressed as the infimum distance to the affine span rather than via an explicit foot-of-perpendicular construction. This is the cleanest Mathlib-native encoding of a pedal distance: it requires no choice of a projection point and immediately inherits nonnegativity from Metric.infDist_nonneg (lineDist_nonneg). The geometric statement of Erdős–Mordell uses lineDist for all three pedal distances da = lineDist P B C, db = lineDist P C A, dc = lineDist P A B.",
@@ -109,8 +109,8 @@
     "proofId": "erdos-mordell-inequality-oq-01",
     "range": { "startLine": 198, "endLine": 228 },
     "type": "context",
-    "title": "The Three Geometric Key Inequalities (Open Obligations)",
-    "content": "key_inequality_A/B/C are the three cyclic side-length-weighted bounds a·PA ≥ b·dc + c·db (and its rotations), stated over EuclideanSpace ℝ (Fin 2) and deferred with sorry. These three lemmas concentrate ALL the genuinely geometric content of Erdős–Mordell: each asserts that the feet of the perpendiculars from P to the two sides meeting at a vertex are concyclic with that vertex and P on a circle whose diameter is the vertex distance, and that projecting onto the chord between the feet yields the bound. They are cyclic images of one another (A → B → C). By key_inequality_of_chord_and_sines, closing each reduces precisely to supplying the chord identity and the law of sines for the concrete configuration — a well-defined planar-geometry task, not in Mathlib yet.",
+    "title": "The Three Geometric Key Inequalities (Proved)",
+    "content": "key_inequality_A/B/C are the three cyclic side-length-weighted bounds a·PA ≥ b·dc + c·db (and its rotations), stated over EuclideanSpace ℝ (Fin 2) and now fully proved. These three lemmas concentrate ALL the genuinely geometric content of Erdős–Mordell: each asserts that the feet of the perpendiculars from P to the two sides meeting at a vertex are concyclic with that vertex and P on a circle whose diameter is the vertex distance, and that projecting onto the chord between the feet yields the bound. They are cyclic images of one another (A → B → C): key_inequality_A is proved via key_inequality_A_of_chord applied to the chord identity, and key_inequality_B/C are its relabelings via affineIndep_rotate and mem_interior_hull_rotate. Closing each required supplying the chord identity and the law of sines for the concrete configuration — a well-defined planar-geometry task absent from Mathlib, here discharged via chord_cos_eq and Mathlib's circumradius lemma.",
     "mathContext": "$a\\cdot PA \\ge b\\cdot d_c + c\\cdot d_b$, with cyclic permutations at $B$ and $C$.",
     "significance": "key",
     "relatedConcepts": [
@@ -131,7 +131,7 @@
     "range": { "startLine": 230, "endLine": 271 },
     "type": "insight",
     "title": "Final Assembly: Discharging Positivity and Algebra",
-    "content": "erdos_mordell stitches the pieces into the geometric statement for P interior to a nondegenerate triangle. Affine independence of ![A,B,C] gives an injective vertex indexing (hABC.injective), from which the three vertices are shown pairwise distinct by a Fin 3 decidability argument, hence the side lengths dist B C, dist C A, dist A B are strictly positive (dist_pos). Pedal nonnegativity comes from lineDist_nonneg. With positivity, nonnegativity, and the three key inequalities in hand, erdos_mordell_reduction delivers the bound. Everything except the three sorry-deferred key inequalities — all positivity, all nonnegativity, the entire AM–GM algebra — is fully discharged, so any future proof of the key inequalities immediately yields a complete, sorry-free Erdős–Mordell theorem.",
+    "content": "erdos_mordell stitches the pieces into the geometric statement for P interior to a nondegenerate triangle. Affine independence of ![A,B,C] gives an injective vertex indexing (hABC.injective), from which the three vertices are shown pairwise distinct by a Fin 3 decidability argument, hence the side lengths dist B C, dist C A, dist A B are strictly positive (dist_pos). Pedal nonnegativity comes from lineDist_nonneg. With positivity, nonnegativity, and the three key inequalities in hand, erdos_mordell_reduction delivers the bound. Every component — all positivity, all nonnegativity, the entire AM–GM algebra, and the three geometric key inequalities (via the chord identity and law of sines) — is fully discharged, so erdos_mordell is a complete, sorry-free, axiom-free Erdős–Mordell theorem.",
     "mathContext": "$2(\\,d(P,\\ell_{BC}) + d(P,\\ell_{CA}) + d(P,\\ell_{AB})\\,) \\le PA + PB + PC$ for $P \\in \\operatorname{int}\\,\\triangle ABC$.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
+++ b/src/data/proofs/erdos-mordell-inequality-oq-01/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-mordell-inequality-oq-01",
-  "title": "Erdős–Mordell Inequality: Algebraic Reduction Core",
+  "title": "Erdős–Mordell Inequality: Complete Machine-Checked Proof",
   "slug": "erdos-mordell-inequality-oq-01",
-  "description": "Formalizes the Erdős–Mordell inequality PA+PB+PC ≥ 2(da+db+dc) in the Euclidean plane and proves its geometry-free algebraic core: the AM–GM reduction from the three side-length key inequalities to the bound. A law-of-sines reduction discharges the vertex key inequality down to a single planar fact — the chord identity (PA·sin A)² = db²+dc²+2·db·dc·cos A — which is the sole remaining sorry.",
+  "description": "A complete, machine-checked, axiom-free formalization of the Erdős–Mordell inequality PA+PB+PC ≥ 2(da+db+dc) in the Euclidean plane. The geometry-free algebraic core (the AM–GM reduction from the three side-length key inequalities to the bound) and a law-of-sines reduction of the vertex key inequality are both proved; the last planar fact — the chord identity (PA·sin A)² = db²+dc²+2·db·dc·cos A — is discharged in coordinates via the cosine-side identity chord_cos_eq in the companion file, leaving no sorries.",
   "meta": {
     "author": "Erdős (1935), Mordell–Barrow (1937)",
     "date": "2026-06-18",
@@ -48,7 +48,7 @@
       "erdos_mordell_reduction: the geometry-free AM–GM core, proving 2(da+db+dc) ≤ PA+PB+PC from the three weighted key inequalities via an explicit nonnegative certificate (a·da·(b−c)² + ... ≥ 0). Carries no geometric hypotheses; reusable for any proof of the key inequalities.",
       "key_inequality_trig_core: a geometry-free proof that sin B·dc + sin C·db ≤ √(db²+dc²+2·db·dc·cos A) for triangle angles, collapsing each key inequality (modulo the chord identity and the law of sines) to the perfect square (db·cos C − dc·cos B)² ≥ 0.",
       "key_inequality_of_chord_and_sines: a verified, geometry-free assembly lemma that takes exactly the two geometric facts the chord identity supplies — the chord identity (PA·sin A)² = db²+dc²+2·db·dc·cos A and the law of sines a = 2R sin A, b = 2R sin B, c = 2R sin C — and derives the key inequality b·dc + c·db ≤ a·PA purely algebraically.",
-      "key_inequality_A_of_chord: the law-of-sines reduction (geometry → algebra). Instantiating the triangle ABC, it discharges all three law-of-sines inputs a=2R sinA, b=2R sinB, c=2R sinC directly from Mathlib's Affine.Triangle.dist_div_sin_angle_eq_two_mul_circumradius (plus angle-sum = π and sin-positivity for a non-degenerate triangle), then assembles the vertex-A key inequality via key_inequality_of_chord_and_sines, leaving the chord identity as the only geometric obligation. This eliminates the heavier oriented-angle / inscribed-angle route entirely.",
+      "key_inequality_A_of_chord: the law-of-sines reduction (geometry → algebra). Instantiating the triangle ABC, it discharges all three law-of-sines inputs a=2R sinA, b=2R sinB, c=2R sinC directly from Mathlib's Affine.Triangle.dist_div_sin_angle_eq_two_mul_circumradius (plus angle-sum = π and sin-positivity for a non-degenerate triangle), then assembles the vertex-A key inequality via key_inequality_of_chord_and_sines, reducing it to the chord identity as the only geometric obligation (itself proved in the companion file via chord_cos_eq). This eliminates the heavier oriented-angle / inscribed-angle route entirely.",
       "Cyclic relabeling plumbing affineIndep_rotate and mem_interior_hull_rotate: affine independence and interior-of-hull membership are invariant under the rotation (X,Y,Z)↦(Y,Z,X), so the vertex-B and vertex-C key inequalities are proved as relabeled instances of key_inequality_A — the entire geometric obligation is isolated in a single vertex.",
       "Precise Lean statement of the geometric Erdős–Mordell inequality using Metric.infDist to the affine span (lineDist) for pedal distances, with the full modular assembly of erdos_mordell discharging all positivity/nonnegativity/algebra.",
       "Companion file ErdosMordellChordReduction.lean: an elementary, fully-proved (no sorry) route to the chord identity that avoids the pedal circle and the inscribed-angle theorem. Its core lemma chord_identity_of_half_angles derives the chord identity from the three right-triangle facts db=PA·sin α, dc=PA·sin β, A=α+β by expanding sin(α+β), cos(α+β); the bridge lemma lineDist_eq_dist_orthogonalProjection identifies the pedal distance with the orthogonal-projection foot.",
@@ -60,7 +60,7 @@
   "overview": {
     "historicalContext": "Paul Erdős posed the inequality as Problem 3740 in the American Mathematical Monthly in 1935; the first proofs were given by L. J. Mordell and D. F. Barrow in 1937. For a point P interior to triangle ABC, the sum of distances from P to the three vertices is at least twice the sum of distances from P to the three sides, with equality exactly when the triangle is equilateral and P is its center. Many proofs are now known (trigonometric, via Ptolemy, the rotation/Avez proof); it is not yet in Mathlib.",
     "problemStatement": "Formalize the Erdős–Mordell inequality PA + PB + PC ≥ 2(da + db + dc) for P interior to triangle ABC, where da, db, dc are the distances from P to the sides.",
-    "text": "Formalizes the Erdős–Mordell inequality and proves its algebraic AM–GM reduction core plus a law-of-sines reduction of the vertex key inequality, assembling the full geometric statement modulo a single chord identity.",
+    "text": "A complete, axiom-free formalization of the Erdős–Mordell inequality: the algebraic AM–GM reduction core, a law-of-sines reduction of the vertex key inequality, and a coordinate proof of the final chord identity together assemble the full geometric statement with no sorries.",
     "proofStrategy": "Factor the standard proof into (1) three geometric key inequalities a·PA ≥ b·dc + c·db (and cyclic), and (2) a purely algebraic reduction: divide each key inequality by the appropriate side and sum, so each pedal distance picks up a coefficient t + 1/t ≥ 2 by AM–GM. The reduction is captured by the explicit nonnegative certificate a·b·c·(PA+PB+PC) − 2a·b·c·(da+db+dc) = a·da·(b−c)² + b·db·(a−c)² + c·dc·(a−b)² + key-inequality slack ≥ 0. The vertex key inequality is then reduced, via the law of sines (Mathlib's circumradius lemma) and a trigonometric core, to a single chord identity for the squared length of the chord between the two pedal feet.",
     "keyInsights": [
       "The reduction is entirely geometry-free: it is an algebraic consequence of the three key inequalities plus side-length positivity and pedal-distance nonnegativity, so it can be stated and proved independently of any planar-geometry development.",
@@ -113,10 +113,10 @@
     },
     {
       "id": "chord-identity",
-      "title": "Chord Identity at Vertex A (Open)",
+      "title": "Chord Identity at Vertex A (Proved)",
       "startLine": 282,
       "endLine": 301,
-      "summary": "chord_identity: the sole remaining sorry — (PA·sin ∠BAC)² = db²+dc²+2·db·dc·cos ∠BAC, the squared length of the chord between the two pedal feet. Its elementary trigonometric core is proved separately in the companion file."
+      "summary": "chord_identity: (PA·sin ∠BAC)² = db²+dc²+2·db·dc·cos ∠BAC, the squared length of the chord between the two pedal feet. Proved by one-line delegation to ErdosMordellChord.chord_identity in the companion file, whose cosine-side core chord_cos_eq is a coordinate (cross-product) identity — discharging the entire geometric obligation."
     },
     {
       "id": "key-inequalities",
@@ -151,11 +151,11 @@
     }
   ],
   "conclusion": {
-    "summary": "The Erdős–Mordell inequality is formalized in the Euclidean plane and its geometry-free algebraic core (the AM–GM reduction) is fully proved. A law-of-sines reduction discharges the entire vertex key inequality — including the law of sines, via Mathlib's circumradius lemma — leaving the full theorem assembled modulo a single chord identity (one remaining sorry). The companion file proves the elementary trigonometric core of that chord identity.",
-    "implications": "The reduction, the law-of-sines reduction, and the cyclic-relabeling plumbing are reusable, largely Mathlib-independent components: a single proof of the chord identity (PA·sin A)² = db²+dc²+2·db·dc·cos A immediately yields a complete, sorry-free Erdős–Mordell proof. A full proof would be a valuable Mathlib contribution.",
+    "summary": "The Erdős–Mordell inequality is fully formalized and machine-checked in the Euclidean plane, with no sorries and no axioms beyond Lean/Mathlib's standard foundations. Its geometry-free algebraic core (the AM–GM reduction) and a law-of-sines reduction of the vertex key inequality (using Mathlib's circumradius lemma) are proved, and the final chord identity is discharged in coordinates via chord_cos_eq in the companion file — completing the entire proof.",
+    "implications": "The reduction, the law-of-sines reduction, and the cyclic-relabeling plumbing are reusable, largely Mathlib-independent components, and the coordinate proof of the chord identity (PA·sin A)² = db²+dc²+2·db·dc·cos A completes a sorry-free Erdős–Mordell proof. The whole development would be a valuable Mathlib contribution, as Erdős–Mordell is not yet present upstream.",
     "openQuestions": [
-      "Can the chord identity (PA·sin A)² = db²+dc²+2·db·dc·cos A be formalized in Mathlib's Euclidean geometry — either via the pedal circle (Thales + inscribed angle) or via the elementary half-angle route db=PA·sin α, dc=PA·sin β, A=α+β proved in the companion file?",
-      "Can the half-angle inputs db=PA·sin(∠CAP), dc=PA·sin(∠BAP) and the additivity ∠CAP+∠BAP=∠BAC for interior P be discharged from Mathlib's law of sines and oriented-angle additivity (oangle_add, Sbtw.oangle_sign_eq)?"
+      "Can this self-contained development be upstreamed to Mathlib — generalizing the EuclideanSpace ℝ (Fin 2) coordinate proof of the chord identity to an inner-product-space / general-dimension statement?",
+      "Is there a shorter proof of the chord identity via the pedal circle (Thales + inscribed angle) that would compose more directly with Mathlib's existing oriented-angle infrastructure (oangle_add, Sbtw.oangle_sign_eq) than the coordinate cross-product route used here?"
     ]
   },
   "leanFile": {
@@ -212,7 +212,7 @@
     {
       "name": "chord_identity",
       "type": "core",
-      "description": "The chord identity at vertex A — the single remaining geometric obligation (sorry-deferred). Squared length of the chord between the two pedal feet. Its elementary trigonometric core is proved in the companion file ErdosMordellChordReduction.lean.",
+      "description": "The chord identity at vertex A — the squared length of the chord between the two pedal feet. Proved by one-line delegation to ErdosMordellChord.chord_identity in the companion file ErdosMordellChordIdentity.lean, whose cosine-side core chord_cos_eq is a coordinate (cross-product) identity; this discharges the entire geometric obligation, leaving the proof sorry-free.",
       "leanType": "(A B C P : EuclideanSpace ℝ (Fin 2)) → AffineIndependent ℝ ![A,B,C] → P ∈ interior (convexHull ℝ {A,B,C}) → (dist P A * sin ∠BAC)^2 = lineDist P C A^2 + lineDist P A B^2 + 2*lineDist P C A*lineDist P A B*cos ∠BAC"
     },
     {


### PR DESCRIPTION
## Summary

The Erdős–Mordell formalization is **complete and already landed on `main`** — 0 sorries, axiom-free, with the final chord identity discharged via `chord_cos_eq` in the companion file `ErdosMordellChordIdentity.lean`. However, the gallery entry's prose was internally contradictory: the `meta.json` header correctly read `status: verified`, `sorries: 0`, `axiomCount: 0`, yet the `description`, several `sections`, the `conclusion`, a `mainTheorem`, and multiple annotations still described the chord identity as **"the sole remaining sorry" / "Open" / "open obligation."**

This PR reconciles the narrative with the verified status. **No Lean changes** — all four `ErdosMordell*.lean` files remain byte-identical to `main`.

## Changes

**`meta.json`**
- Title: "Algebraic Reduction Core" → "Complete Machine-Checked Proof"
- `description`, `overview.text`, `conclusion.summary`/`implications`, the chord-identity section, and the `chord_identity` main theorem: rewritten to state the proof is complete (chord identity proved by one-line delegation to `ErdosMordellChord.chord_identity`).
- `openQuestions`: replaced now-resolved "can the chord identity be formalized?" items with forward-looking Mathlib-upstreaming questions.

**`annotations.json`**
- ann-04/06/07 content + ann-06 title: dropped stale "sorry"/"open obligation" language; the three key inequalities are now fully proved (via `key_inequality_A_of_chord` + cyclic relabeling).
- ann-02 range `64–101` → `81–109` and ann-05 range `188–196` → `198–199`: fixed line drift so the annotation resolver lands on `erdos_mordell_reduction` and the `lineDist` definition respectively — this clears two pre-existing `annotations:validate` errors on this entry.

## Verification
- Both JSON files parse.
- `pnpm annotations:validate` resolves this entry with **no errors** (previously 2 errors).
- `git diff origin/main` for all `ErdosMordell*.lean` files: empty (no proof changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)