### PR TITLE
audit(brianchon-theorem-oq-01): record clean audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16105,6 +16105,12 @@
       "lastAudited": "2026-06-19T15:45:01Z",
       "result": "clean",
       "issues": []
+    },
+    "brianchon-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-19T19:47:13Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Auditor: gallery integrity

Audited the newly-merged **brianchon-theorem-oq-01** (added in #26793), which was not yet recorded in `audit-tracker.json`.

### Verdict: CLEAN ✅

All `meta.json` claims verified against `proofs/Proofs/BrianchonTheorem.lean`:

| Claim | meta.json | source | ✓ |
|-------|-----------|--------|---|
| sorries | 0 | none found | ✅ |
| axiomCount | 1 | one `axiom conic_implies_pascal` | ✅ |
| native_decide | — | none (uses `decide`, no `Lean.ofReduceBool`) | ✅ |
| theoremCount | 8 | 8 `theorem` | ✅ |
| definitionCount | 14 | 6 `def` + 8 `noncomputable def` | ✅ |
| lineCount | 293 | 293 | ✅ |
| status / badge | axiomatized / axiom | has 1 axiom → correct per policy | ✅ |
| registered | Proofs/BrianchonTheorem.lean | `import Proofs.BrianchonTheorem` @ Proofs.lean:339 | ✅ |

The axiom-free duality bridge `concurrent_brianchon_of_collinear_pascal` does not reference the `conic_implies_pascal` axiom in its proof term, consistent with the meta claim. The lone axiom is the same fact the `pascals-hexagon` entry already assumes; no new assumption introduced.

Only change: a 6-line append to `src/data/proofs/audit-tracker.json` recording the clean result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)