### PR TITLE
research(brianchon-theorem-oq-01): recover the genuine Brianchon point under nondegeneracy

### DIFF
--- a/proofs/Proofs/BrianchonTheorem.lean
+++ b/proofs/Proofs/BrianchonTheorem.lean
@@ -290,4 +290,83 @@ theorem brianchon_theorem {C : Conic} (hC : C.symmetric) (hex : ContactHexagon C
   concurrent_brianchon_of_collinear_pascal hC hex.A hex.B hex.C' hex.D hex.E hex.F
     (conic_implies_pascal C hex)
 
+-- ============================================================
+-- PART 9: The genuine Brianchon point (under nondegeneracy)
+-- ============================================================
+
+/-
+The theorem `brianchon_theorem` records concurrency as the *vanishing of the
+diagonals' coefficient determinant*.  By itself that predicate is also satisfied
+degenerately (e.g. if two diagonals coincide, or a diagonal collapses to the zero
+covector).  Brianchon's classical statement asserts more: there is a genuine
+single point — the **Brianchon point** — through which all three diagonals pass.
+
+We recover it here under the natural nondegeneracy hypothesis that two of the
+diagonals actually meet in a well-defined point (their meet is a nonzero vector,
+i.e. the two lines are distinct).  The witness is that meet, and incidence of the
+third diagonal is exactly the concurrency already proved.  This part is pure
+linear algebra: **no axioms, no `sorry`** beyond `conic_implies_pascal` (used only
+through `brianchon_theorem`).
+-/
+
+/-- Incidence: a projective point `X` lies on a projective line `l` iff `l · X = 0`. -/
+def onLine (l : ProjLine) (X : ProjPoint) : Prop := dotProduct l X = 0
+
+/-- A line passes through its own meet with any other line: `u · (u × v) = 0`. -/
+theorem dotProduct_self_crossProduct (u v : Fin 3 → ℝ) :
+    dotProduct u (crossProduct u v) = 0 := by
+  simp only [dotProduct, cross_apply, Fin.sum_univ_three, Fin.isValue,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.tail_cons]
+  ring
+
+/-- The second line of a meet also passes through it: `v · (u × v) = 0`. -/
+theorem dotProduct_crossProduct_self (u v : Fin 3 → ℝ) :
+    dotProduct v (crossProduct u v) = 0 := by
+  simp only [dotProduct, cross_apply, Fin.sum_univ_three, Fin.isValue,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.tail_cons]
+  ring
+
+/-- The triple determinant of three rows is the scalar triple product:
+`det (a, b, c) = c · (a × b)`.  Hence the concurrency determinant of three lines
+is exactly the incidence of the third line with the meet of the first two. -/
+theorem det_threeVectorMatrix_eq_dot_cross (a b c : Fin 3 → ℝ) :
+    (threeVectorMatrix a b c).det = dotProduct c (crossProduct a b) := by
+  simp only [Matrix.det_fin_three, threeVectorMatrix, Matrix.of_apply,
+    dotProduct, cross_apply, Fin.sum_univ_three, Fin.isValue,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.tail_cons]
+  ring
+
+/-- **The genuine Brianchon point.**
+
+Under the nondegeneracy assumption that two of the diagonals actually meet in a
+well-defined projective point (`lineIntersection (brianchonDiag1 hex)
+(brianchonDiag2 hex) ≠ 0`, i.e. the first two diagonals are distinct lines), the
+three main diagonals of the circumscribed hexagon pass through a *single* common
+projective point — the classical **Brianchon point**.
+
+The witness is the meet of the first two diagonals; the first two incidences are
+the self-incidence identities, and the third is precisely the concurrency proved
+in `brianchon_theorem`.  No axiom beyond `conic_implies_pascal`. -/
+theorem brianchon_point {C : Conic} (hC : C.symmetric) (hex : ContactHexagon C)
+    (hnd : lineIntersection (brianchonDiag1 hex) (brianchonDiag2 hex) ≠ 0) :
+    ∃ X : ProjPoint, X ≠ 0 ∧
+      onLine (brianchonDiag1 hex) X ∧
+      onLine (brianchonDiag2 hex) X ∧
+      onLine (brianchonDiag3 hex) X := by
+  refine ⟨lineIntersection (brianchonDiag1 hex) (brianchonDiag2 hex), hnd, ?_, ?_, ?_⟩
+  · -- diag1 passes through the meet of diag1 and diag2
+    simp only [onLine, lineIntersection]
+    exact dotProduct_self_crossProduct (brianchonDiag1 hex) (brianchonDiag2 hex)
+  · -- diag2 passes through the meet of diag1 and diag2
+    simp only [onLine, lineIntersection]
+    exact dotProduct_crossProduct_self (brianchonDiag1 hex) (brianchonDiag2 hex)
+  · -- diag3 passes through the meet: this is the concurrency from brianchon_theorem
+    have hconc := brianchon_theorem hC hex
+    unfold concurrent at hconc
+    rw [det_threeVectorMatrix_eq_dot_cross] at hconc
+    simpa [onLine, lineIntersection] using hconc
+
 end Brianchon

--- a/src/data/proofs/brianchon-theorem-oq-01/meta.json
+++ b/src/data/proofs/brianchon-theorem-oq-01/meta.json
@@ -46,15 +46,16 @@
       "An axiom-free, sorry-free duality bridge `concurrent_brianchon_of_collinear_pascal`: Pascal collinearity ⟹ Brianchon concurrency, by pure linear algebra",
       "The cofactor / Binet–Cauchy cross-product identity `(M·u)×(M·v) = (adj M)ᵀ·(u×v)` proved by `ring`",
       "Reduction showing each Brianchon diagonal equals the fixed linear map `det C • C` applied to the corresponding Pascal point",
+      "The genuine **Brianchon point** `brianchon_point`: under the nondegeneracy hypothesis that two diagonals actually meet (`lineIntersection (brianchonDiag1 hex) (brianchonDiag2 hex) ≠ 0`), all three diagonals pass through a single honest projective point — strengthening the bare concurrency determinant to a common point, still axiom-free beyond `conic_implies_pascal`",
       "Answers an open question posed in the `pascals-hexagon` gallery entry"
     ],
     "dateAdded": "2026-06-19",
     "axiomCount": 1,
-    "lineCount": 293,
+    "lineCount": 372,
     "assumptions": "1 axiom: `conic_implies_pascal` — the same deep geometric fact (six points on a conic ⟹ opposite-side intersections collinear) axiomatized by the `pascals-hexagon` gallery entry as `conic_implies_pascal_constraint`. No new axiom is introduced. The duality bridge `concurrent_brianchon_of_collinear_pascal` is axiom-free and sorry-free (verified via `#print axioms`: depends only on propext, Classical.choice, Quot.sound). The full `brianchon_theorem` adds only `conic_implies_pascal`.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
-    "definitionCount": 14
+    "theoremCount": 12,
+    "definitionCount": 15
   },
   "overview": {
     "historicalContext": "Charles-Julien Brianchon discovered this theorem in 1806 as a student at the École Polytechnique, publishing it in the *Journal de l'École Polytechnique*. It is the projective dual of Pascal's hexagon theorem (1639): where Pascal's theorem concerns a hexagon *inscribed* in a conic and concludes that the intersections of opposite sides are collinear, Brianchon's theorem concerns a hexagon *circumscribed* about a conic and concludes that the main diagonals are concurrent. The two statements are exchanged by the principle of projective duality, which swaps points with lines and 'collinear' with 'concurrent'. Brianchon's result was historically significant as one of the first striking applications of the (then-new) duality principle in projective geometry, later systematized by Poncelet and Gergonne.",
@@ -76,11 +77,12 @@
     ]
   },
   "conclusion": {
-    "summary": "Brianchon's theorem is proved as the projective dual of Pascal's hexagon theorem. The core deliverable is the axiom-free, sorry-free duality bridge `concurrent_brianchon_of_collinear_pascal`, which shows by pure linear algebra that Pascal's three collinear points force Brianchon's three concurrent diagonals. The unconditional `brianchon_theorem` combines this bridge with the single Pascal axiom `conic_implies_pascal`, introducing no new assumption.",
+    "summary": "Brianchon's theorem is proved as the projective dual of Pascal's hexagon theorem. The core deliverable is the axiom-free, sorry-free duality bridge `concurrent_brianchon_of_collinear_pascal`, which shows by pure linear algebra that Pascal's three collinear points force Brianchon's three concurrent diagonals. The unconditional `brianchon_theorem` combines this bridge with the single Pascal axiom `conic_implies_pascal`, introducing no new assumption. A further result `brianchon_point` upgrades the bare concurrency determinant to the genuine Brianchon point: under the nondegeneracy hypothesis that two diagonals meet in a well-defined point, all three diagonals are shown to pass through one explicit common projective point.",
     "implications": "This closes the classic Pascal/Brianchon duality pair and answers an open question recorded in the `pascals-hexagon` entry ('Can the Brianchon dual be formally proved from Pascal's theorem via projective duality?'). The reusable bridge — cofactor cross-product identity plus determinant transport — is a template for dualizing other projective incidence theorems (e.g. Desargues self-duality, the dual of Pappus).",
     "openQuestions": [
       "Eliminate the shared `conic_implies_pascal` axiom (via Cayley–Bacharach or the Sylvester reduction to the standard conic), upgrading both Pascal and Brianchon to fully verified",
-      "Add the nondegeneracy hypothesis to recover the converse and the genuine Brianchon point as an honest projective point (validity of the diagonals)",
+      "Establish the converse (concurrency ⟹ the six tangency points lie on a conic). The genuine Brianchon point is now recovered (`brianchon_point`) under the nondegeneracy hypothesis that two diagonals meet",
+      "Discharge the nondegeneracy hypothesis of `brianchon_point` from a genericity condition on the conic and contact points (e.g. `det C ≠ 0` plus distinct contact points), rather than assuming the diagonals' meet is nonzero",
       "Formalize the limiting/degenerate cases (a side through a point at infinity) explicitly"
     ]
   },
@@ -107,11 +109,11 @@
   ],
   "leanFile": {
     "path": "Proofs/BrianchonTheorem.lean",
-    "lineCount": 293,
+    "lineCount": 372,
     "axiomCount": 1,
     "sorries": 0,
-    "theoremCount": 8,
-    "definitionCount": 14,
+    "theoremCount": 12,
+    "definitionCount": 15,
     "imports": [
       "import Mathlib.Data.Real.Basic",
       "import Mathlib.LinearAlgebra.Matrix.Determinant.Basic",
@@ -135,6 +137,12 @@
       "type": "core",
       "description": "Brianchon's theorem: the three main diagonals of a hexagon circumscribed about a symmetric conic are concurrent",
       "leanType": "C.symmetric → (hex : ContactHexagon C) → concurrent (brianchonDiag1 hex) (brianchonDiag2 hex) (brianchonDiag3 hex)"
+    },
+    {
+      "name": "brianchon_point",
+      "type": "core",
+      "description": "The genuine Brianchon point: under the nondegeneracy hypothesis that the first two diagonals meet in a well-defined point, the three main diagonals all pass through a single common projective point. Strengthens the bare concurrency determinant to an explicit incident point, axiom-free beyond conic_implies_pascal",
+      "leanType": "C.symmetric → (hex : ContactHexagon C) → lineIntersection (brianchonDiag1 hex) (brianchonDiag2 hex) ≠ 0 → ∃ X, X ≠ 0 ∧ onLine (brianchonDiag1 hex) X ∧ onLine (brianchonDiag2 hex) X ∧ onLine (brianchonDiag3 hex) X"
     },
     {
       "name": "crossProduct_mulMatrix",

--- a/src/data/research/problems/brianchon-theorem-oq-01.json
+++ b/src/data/research/problems/brianchon-theorem-oq-01.json
@@ -29,8 +29,8 @@
   "currentState": {
     "phase": "COMPLETED",
     "since": "2026-06-19",
-    "iteration": 2,
-    "focus": "Proved Brianchon from Pascal via pole–polar duality in the homogeneous ℝ³ model. Self-contained file (PascalsHexagon.lean does not currently build). Status axiomatized: 1 axiom (conic_implies_pascal), 0 sorries."
+    "iteration": 3,
+    "focus": "Proved Brianchon from Pascal via pole–polar duality in the homogeneous ℝ³ model. Iteration 3 added brianchon_point: the genuine Brianchon point recovered under the nondegeneracy hypothesis that two diagonals meet (axiom-free beyond conic_implies_pascal). Status axiomatized: 1 axiom (conic_implies_pascal), 0 sorries. Build-verified GREEN."
   },
   "knowledge": {
     "progressSummary": "COMPLETED: Brianchon's theorem proved as the projective dual of Pascal's theorem. Axiom-free duality bridge + unconditional theorem using only the shared Pascal axiom. Gallery entry added.",
@@ -42,6 +42,7 @@
       "diag_eq: each Brianchon diagonal = (det C • C)·(corresponding Pascal point)",
       "concurrent_brianchon_of_collinear_pascal: axiom-free, sorry-free duality bridge",
       "brianchon_theorem: unconditional Brianchon's theorem (1 axiom, conic_implies_pascal)",
+      "brianchon_point: genuine Brianchon point under nondegeneracy (∃ X ≠ 0 on all three diagonals); built on onLine incidence + det_threeVectorMatrix_eq_dot_cross (scalar triple product = concurrency determinant) + dotProduct_self/_crossProduct self-incidence identities",
       "Gallery entry src/data/proofs/brianchon-theorem-oq-01/meta.json"
     ],
     "insights": [
@@ -55,7 +56,8 @@
     ],
     "nextSteps": [
       "Eliminate the shared conic_implies_pascal axiom (Cayley–Bacharach or Sylvester reduction) — Pascal-side work.",
-      "Add nondegeneracy to recover the genuine Brianchon point and the converse.",
+      "Discharge brianchon_point's nondegeneracy hypothesis (two diagonals meet) from a genericity condition on C and the contact points (e.g. det C ≠ 0 + distinct contacts) instead of assuming the meet is nonzero.",
+      "Establish the converse (concurrency ⟹ contacts lie on a conic).",
       "Formalize the degenerate/point-at-infinity cases explicitly."
     ]
   },


### PR DESCRIPTION
## Summary

Strengthens the **Brianchon's Theorem** gallery entry (`brianchon-theorem-oq-01`) beyond the bare concurrency determinant. The existing `brianchon_theorem` records concurrency only as the *vanishing of the diagonals' coefficient determinant* — a predicate also satisfied degenerately. Brianchon's classical statement asserts more: there is a single point — the **Brianchon point** — through which all three diagonals pass. This PR recovers it.

Addresses the entry's documented open next-step: *"add nondegeneracy to recover the genuine Brianchon point."*

## New content (PART 9), all axiom-free beyond the existing `conic_implies_pascal`

- `onLine` — projective incidence (`l · X = 0`)
- `dotProduct_self_crossProduct` / `dotProduct_crossProduct_self` — a line passes through its own meet with another line (`u · (u × v) = 0`)
- `det_threeVectorMatrix_eq_dot_cross` — `det(a, b, c) = c · (a × b)`; hence the concurrency determinant of three lines *is* the incidence of the third with the meet of the first two
- `brianchon_point` — **the genuine Brianchon point**: under the nondegeneracy hypothesis that two diagonals meet in a well-defined point (`lineIntersection (brianchonDiag1 hex) (brianchonDiag2 hex) ≠ 0`), all three diagonals pass through one explicit common projective point. The witness is that meet; the first two incidences are the self-incidence identities and the third is *exactly* the concurrency already proved in `brianchon_theorem`.

## Verification

- **Build-verified GREEN**, warning-free, via `./proofs/scripts/docker-build.sh Proofs.BrianchonTheorem`
- **0 sorries**, **1 axiom** (`conic_implies_pascal`, unchanged — the same fact Pascal needs)
- Gallery `meta.json` + research problem JSON updated: lineCount 293→372, theoremCount 8→12, definitionCount 14→15; new `brianchon_point` main-theorem entry; open-questions refined (nondegeneracy now discharged into an explicit point; remaining work is to derive the hypothesis from a genericity condition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)