### PR TITLE
research(zsqrtd-neg-two-oq-02): build-verify Minkowski slice GREEN + correct SingleAP overstatement

### DIFF
--- a/proofs/Proofs/ThreeSquaresSingleAP.lean
+++ b/proofs/Proofs/ThreeSquaresSingleAP.lean
@@ -10,11 +10,11 @@
   (`no_residue3_witness`), forcing a separate `Residue3Property` carve-out and a
   delicate `m = t² + 2p` Hardy–Littlewood-type existence input.
 
-  THIS FILE removes that carve-out at the source.  The Minkowski / lattice
-  construction inside `dirichlet_key_lemma` only ever uses the quadratic
-  side-condition `legendreSym p (−n) = 1`; it never uses the rigid tie
-  `p = d·n − 1`.  Dropping the tie, the side-condition is satisfied by a SINGLE
-  universal arithmetic progression:
+  THIS FILE supplies the quadratic side-condition `legendreSym p (−n) = 1` for a
+  *relaxed* form of the key lemma — one that would consume ANY prime `p` carrying
+  that residue condition, rather than the rigid `p = d·n − 1`.  For such a relaxed
+  engine the side-condition is satisfied by a SINGLE universal arithmetic
+  progression:
 
       **Single-AP witness.**  For odd `n` and any prime `p ≡ 1 (mod 4n)`,
             legendreSym p (−n) = 1.
@@ -23,6 +23,17 @@
   supplies a prime in the always-admissible class `1 (mod 4n)` (`gcd(1,4n)=1`),
   so every odd `n` — including `n ≡ 3 (mod 8)` — gets a usable witness from one
   uniform branch.  No `t² + 2p`, no multi-residue spread, no Residue3 carve-out.
+
+  CAVEAT (corrected S15, 2026-06-19 — see `ThreeSquaresResidue3Obstruction`).  The
+  `dirichlet_key_lemma` ACTUALLY PROVED in `ThreeSquares.lean:1440` is NOT that
+  relaxed engine: its elementary descent uses the tie `p = d·n − 1` essentially
+  (`p ∣ z` together with `d·z² ≥ p² > p` forces `z = 0`, after which `x² + d·y² =
+  d·n − 1` reconstructs `n`).  A large Dirichlet prime `p ≡ 1 (mod 4n)` is not of
+  the form `d·n − 1`, so the witness below does NOT slot into the proved key lemma,
+  and this file contains no descent reconnecting such a `p` to `n = x²+y²+z²`.
+  Consequently `legendreSym_neg_n_eq_one` and `exists_prime_eq_one_mod_four_mul`
+  are currently ORPHAN: a correct, reusable quadratic witness held in reserve for a
+  future relaxed-key-lemma route, not consumed by the current representation engine.
 
   PROOF.  Pure quadratic reciprocity, the positive mirror of the obstruction:
   `p ≡ 1 (mod 4) ⇒ (−1 | p) = 1`, so `(−n | p) = (n | p)`; `p ≡ 1 (mod 4)` makes
@@ -42,9 +53,8 @@
   STATUS: 0 sorries, 0 axioms.  The Dirichlet existence input
   (`exists_prime_eq_one_mod_four_mul`) is discharged via
   `Nat.forall_exists_prime_gt_and_modEq` at the always-admissible class `1 (mod 4n)`.
-  Registered in `Proofs.lean`.  Build-pending the deployer gate (Docker pool was
-  saturated this session, so no local leaf build was run); every Mathlib bearer is
-  name-checked against the pinned rev.
+  Registered in `Proofs.lean`.  Build-verified S15 (2026-06-19):
+  `docker-build.sh Proofs.ThreeSquaresSingleAP` → `Build completed successfully`.
 -/
 import Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol
 import Mathlib.NumberTheory.LegendreSymbol.Basic

--- a/research/problems/zsqrtd-neg-two-oq-02/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/state.md
@@ -1,5 +1,44 @@
 # Research State: zsqrtd-neg-two-oq-02
 
+## S15 — Minkowski slice build-verified GREEN + SingleAP docstring overstatement corrected (researcher-1, 2026-06-19)
+
+**Phase**: ACT (verify + research-hygiene). Docker AVAILABLE (`docker info` OK);
+built two leaf modules under the safety wrapper. No math changed; frontier unchanged.
+
+**1. `ThreeSquaresSliceMinkowski.lean` BUILD-VERIFIED GREEN.** The previously
+"build-pending" `d = 2` Minkowski core is now machine-checked:
+`./proofs/scripts/docker-build.sh Proofs.ThreeSquaresSliceMinkowski`
+→ `Build completed successfully (7743 jobs)` (one benign `unusedSimpArgs` linter
+warning on `hB@263`, no error). The file is sorry-free/axiom-free: the geometry-of-
+numbers input `exists_sheared_point_lt_two_mul_d2` (nonzero `ℤ²` point in the sheared
+open ellipse, `vol = √2·π ≈ 4.443 > 4` independent of `p`, via
+`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`) and the arithmetic glue
+`slice_point_of_sheared_d2` compile against the project's Mathlib. NOTE: this slice
+belongs to the *relaxed*-key-lemma route; the key lemma actually proved in
+`ThreeSquares.lean:1440` is the elementary `p = d·n − 1` descent, so the slice is
+currently a self-contained, verified-but-unconsumed companion (see item 2).
+
+**2. `ThreeSquaresSingleAP.lean` docstring OVERSTATEMENT corrected (S13 TODO).**
+S13 flagged that the header claimed the file "removes that carve-out at the source"
+and that `dirichlet_key_lemma` "never uses the rigid tie `p = d·n − 1`" — true only
+of a hypothetical relaxed engine that was never proved. The ACTUALLY-proved key lemma
+(`ThreeSquares.lean:1440`) uses the tie essentially (`p ∣ z` + `d·z² ≥ p² > p` ⟹
+`z = 0`), and the large Dirichlet prime `p ≡ 1 (mod 4n)` produced here is not of that
+form, so `legendreSym_neg_n_eq_one` / `exists_prime_eq_one_mod_four_mul` are ORPHAN
+(grep-confirmed: called nowhere outside the file). The header now states this
+accurately and labels the two theorems a reusable witness held in reserve for a future
+relaxed-key-lemma route. STATUS line updated build-pending → build-verified.
+Comment-only on a registered file; BUILD-VERIFIED:
+`docker-build.sh Proofs.ThreeSquaresSingleAP` → `Build completed successfully`.
+
+**FRONTIER UNCHANGED.** `ThreeSquares.lean` still carries the lone sufficiency axiom
+`not_excluded_form_is_sum_three_sq` (`:1838`). Both factors of the eventual
+elimination are now machine-checked or build-verified EXCEPT factor (1): every
+non-`4ᵃ(8b+7)` `n` is a sum of three *rational* squares (Hasse–Minkowski for ternary
+forms, absent from Mathlib). That remains the deep, multi-session open piece. Factor
+(2) Davenport–Cassels (rational ⟹ integral) is build-verified (S14); the Minkowski
+slice and the SingleAP witness are verified support for the relaxed route.
+
 ## S14 — `ThreeSquaresDavenportCassels.lean` REPAIRED + REGISTERED (build-verified GREEN, researcher-3, 2026-06-19)
 
 **Phase**: ACT. Docker AVAILABLE this session (`docker ps` OK); built under the 8GB cap.


### PR DESCRIPTION
## Summary

Docker became available this session (it was down for every prior session on this problem), so I ran the long-deferred ACT step: **build-verifying** the previously "build-pending" companions, plus correcting a docstring overstatement that S13 explicitly flagged for a future session.

Problem `zsqrtd-neg-two-oq-02` (Legendre–Gauss three-square theorem) is mature: `dirichlet_key_lemma` is a proved theorem, the Davenport–Cassels factor is build-verified (S14), and the only deep remaining frontier is factor (1), rational three-squares (Hasse–Minkowski for ternary forms, absent from Mathlib).

## Changes

**1. `ThreeSquaresSliceMinkowski.lean` — build-verified GREEN**
- `docker-build.sh Proofs.ThreeSquaresSliceMinkowski` → `Build completed successfully (7743 jobs)` (one benign `unusedSimpArgs` linter warning, no error).
- Confirms the `d = 2` Minkowski core `exists_sheared_point_lt_two_mul_d2` (nonzero `ℤ²` point in the sheared open ellipse; `vol = √2·π ≈ 4.443 > 4` independent of `p`) and the arithmetic glue `slice_point_of_sheared_d2` compile sorry-free / axiom-free against the project's Mathlib.
- No source change to this file; verification only.

**2. `ThreeSquaresSingleAP.lean` — docstring overstatement corrected (S13 TODO)**
- The header claimed the file "removes that carve-out at the source" and that `dirichlet_key_lemma` "never uses the rigid tie `p = d·n − 1`." That is true only of a hypothetical *relaxed* key lemma that was never proved.
- The actually-proved key lemma (`ThreeSquares.lean:1440`) uses the tie essentially (`p ∣ z` + `d·z² ≥ p² > p` ⟹ `z = 0`); a large Dirichlet prime `p ≡ 1 (mod 4n)` is not of that form, so `legendreSym_neg_n_eq_one` / `exists_prime_eq_one_mod_four_mul` are **orphan** (grep-confirmed: called nowhere outside the file).
- Header now states this accurately and labels the two theorems a reusable witness held in reserve for a future relaxed-key-lemma route. STATUS line: build-pending → build-verified.
- Comment-only on a registered file; build-verified: `docker-build.sh Proofs.ThreeSquaresSingleAP` → `Build completed successfully (3393 jobs)`.

## Frontier (unchanged)
`ThreeSquares.lean` still carries the lone sufficiency axiom `not_excluded_form_is_sum_three_sq`. Factor (2) Davenport–Cassels is build-verified; the Minkowski slice and SingleAP witness are verified support for the relaxed route. Factor (1) — every non-`4ᵃ(8b+7)` `n` is a sum of three *rational* squares — remains the deep, multi-session open piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)