### PR TITLE
research(erdos-660): prove trivial_lower_bound + 5 base-case lemmas (GREEN)

### DIFF
--- a/proofs/Proofs/Erdos660Problem.lean
+++ b/proofs/Proofs/Erdos660Problem.lean
@@ -118,7 +118,93 @@ theorem trivial_lower_bound
     (S : Finset Point3D)
     (hn : S.card ≥ 2) :
     distinctDistances S ≥ 1 := by
-  sorry
+  unfold distinctDistances
+  obtain ⟨p, hp, q, hq, hne⟩ := Finset.one_lt_card.mp (by omega : 1 < S.card)
+  have hmem : euclideanDist p q ∈ (pairwiseDistances S).filter (· > 0) := by
+    rw [Finset.mem_filter]
+    refine ⟨?_, ?_⟩
+    · simp only [pairwiseDistances, Finset.mem_image]
+      exact ⟨(p, q), Finset.mem_product.mpr ⟨hp, hq⟩, rfl⟩
+    · simpa [euclideanDist] using dist_pos.mpr hne
+  exact Finset.card_pos.mpr ⟨_, hmem⟩
+
+/-! ### Verified base cases
+
+These small cases are fully machine-checked (no `sorry`). They pin down the
+behaviour of `distinctDistances` on empty, singleton, and two-point sets, and
+record that the count is monotone under adding vertices — the structural facts
+any lower-bound argument for the main conjecture must respect. -/
+
+/-- The empty configuration has no pairwise distances. -/
+theorem pairwiseDistances_empty :
+    pairwiseDistances (∅ : Finset Point3D) = ∅ := by
+  simp [pairwiseDistances]
+
+/-- The empty configuration has zero distinct distances. -/
+theorem distinctDistances_empty :
+    distinctDistances (∅ : Finset Point3D) = 0 := by
+  simp [distinctDistances, pairwiseDistances_empty]
+
+/-- A single point determines only the zero self-distance. -/
+theorem pairwiseDistances_singleton (p : Point3D) :
+    pairwiseDistances {p} = {0} := by
+  simp [pairwiseDistances, euclideanDist, dist_self]
+
+/-- A single point has zero distinct (positive) distances. -/
+theorem distinctDistances_singleton (p : Point3D) :
+    distinctDistances {p} = 0 := by
+  simp [distinctDistances, pairwiseDistances_singleton]
+
+/-- Two distinct points determine exactly one distinct distance. -/
+theorem two_point_one_distance (p q : Point3D) (hne : p ≠ q) :
+    distinctDistances {p, q} = 1 := by
+  have hpq : (0 : ℝ) < euclideanDist p q := dist_pos.mpr hne
+  have h1 : pairwiseDistances {p, q} = {0, euclideanDist p q} := by
+    ext d
+    constructor
+    · intro hd
+      simp only [pairwiseDistances, Finset.mem_image] at hd
+      obtain ⟨⟨a, b⟩, hab, rfl⟩ := hd
+      obtain ⟨ha, hb⟩ := Finset.mem_product.mp hab
+      simp only [Finset.mem_insert, Finset.mem_singleton] at ha hb
+      rw [Finset.mem_insert, Finset.mem_singleton]
+      rcases ha with rfl | rfl <;> rcases hb with rfl | rfl
+      · exact Or.inl (by simp [euclideanDist])
+      · exact Or.inr rfl
+      · exact Or.inr (by simp [euclideanDist, dist_comm])
+      · exact Or.inl (by simp [euclideanDist])
+    · intro hd
+      simp only [pairwiseDistances, Finset.mem_image]
+      rw [Finset.mem_insert, Finset.mem_singleton] at hd
+      rcases hd with rfl | rfl
+      · exact ⟨(p, p), Finset.mem_product.mpr
+          ⟨Finset.mem_insert_self _ _, Finset.mem_insert_self _ _⟩, by simp [euclideanDist]⟩
+      · exact ⟨(p, q), Finset.mem_product.mpr
+          ⟨Finset.mem_insert_self _ _,
+            Finset.mem_insert_of_mem (Finset.mem_singleton_self _)⟩, rfl⟩
+  unfold distinctDistances
+  rw [h1]
+  have h2 : ({0, euclideanDist p q} : Finset ℝ).filter (· > 0)
+      = {euclideanDist p q} := by
+    ext d
+    simp only [Finset.mem_filter, Finset.mem_insert, Finset.mem_singleton,
+      gt_iff_lt]
+    constructor
+    · rintro ⟨rfl | rfl, hd⟩
+      · exact absurd hd (lt_irrefl 0)
+      · rfl
+    · rintro rfl
+      exact ⟨Or.inr rfl, hpq⟩
+  rw [h2, Finset.card_singleton]
+
+/-- Distinct distances are monotone: adding vertices never decreases the count. -/
+theorem distinctDistances_mono {S T : Finset Point3D} (h : S ⊆ T) :
+    distinctDistances S ≤ distinctDistances T := by
+  unfold distinctDistances
+  apply Finset.card_le_card
+  apply Finset.filter_subset_filter
+  unfold pairwiseDistances
+  exact Finset.image_subset_image (Finset.product_subset_product h h)
 
 /-- Conjecture: Linear lower bound without the precise constant.
     The vertices of a convex polyhedron in ℝ³ determine Ω(n) distinct distances. -/

--- a/research/problems/erdos-660/knowledge.md
+++ b/research/problems/erdos-660/knowledge.md
@@ -1,0 +1,77 @@
+# Erdős #660 — Distinct Distances in Convex Polyhedra
+
+**Status:** OPEN (formalized scaffold; main conjecture remains a `sorry`)
+**Lean file:** `proofs/Proofs/Erdos660Problem.lean` (registered in `Proofs.lean`)
+**Companions:** `Erdos660Aristotle.lean` (0 sorries), `Erdos660ProblemAristotle.lean`
+
+## Problem
+
+For the vertices $x_1,\dots,x_n \in \mathbb{R}^3$ of a convex polyhedron, are there at
+least $(1-o(1))\cdot n/2$ distinct pairwise distances? This is the 3D analogue of
+Altman's 1963 result ($\ge \lfloor n/2\rfloor$ for convex polygons in $\mathbb{R}^2$).
+The 3D case is open; even a weaker linear bound $\Omega(n)$ is open.
+
+## Proof State
+
+The main conjecture and the named classical results are genuinely OPEN/HARD and
+stay axiomatized as `sorry`:
+- `erdos_660_conjecture` — OPEN (the problem itself)
+- `linear_lower_bound_conjecture` — OPEN (weaker form)
+- `altman_convex_polygon_distances` — known (Altman 1963), HARD to formalize
+- `guth_katz_distinct_distances` — known (Guth–Katz 2015), HARD to formalize
+- 5 Platonic-solid construction theorems — require explicit coordinates plus
+  `IsConvexPolyhedronVertices` (extreme points of the convex hull), HARD
+
+## Sessions
+
+### Session 2026-06-19 (s01) — FRESH
+
+**Mode:** FRESH. **Outcome:** progress (1 sorry eliminated, 6 verified theorems added).
+
+**What I did**
+- Step 0 (preamble): inspected the Aristotle companions. `Erdos660Aristotle.lean`
+  already proves (0 sorries) the supporting lemmas, including `trivial_lower_bound`
+  over its own local `dist`-based definitions in namespace `Erdos660.Aristotle`.
+- Integrated that work into the main registered file by porting the proofs to the
+  main file's `euclideanDist`-wrapped `pairwiseDistances`/`distinctDistances`:
+  - `trivial_lower_bound` — replaced the `sorry` with a real proof
+    (`Finset.one_lt_card` → a positive distance lies in the filtered image →
+    `Finset.card_pos`).
+  - Added a **Verified base cases** subsection (all machine-checked):
+    `pairwiseDistances_empty`, `distinctDistances_empty`,
+    `pairwiseDistances_singleton`, `distinctDistances_singleton`,
+    `two_point_one_distance` (exactly one distance for a 2-point set),
+    `distinctDistances_mono` (monotone under adding vertices).
+
+**Build verification**
+- Docker build GREEN (`./proofs/scripts/docker-build.sh Proofs.Erdos660Problem`):
+  `Build completed successfully (7743 jobs)`, exactly 9 `sorry` warnings, 0 errors.
+
+**Key findings**
+- The companion lemmas are stated over a *separate* `dist`-based definition, so the
+  main file gained nothing from them until ported through the `euclideanDist` def.
+  `euclideanDist p q := dist p q` is definitionally `dist`, so `simp [euclideanDist]`
+  (and `rfl` on image witnesses) bridges the two.
+- **Gotcha:** `pairwiseDistances` images over `S.product S` (a `Finset.product`).
+  `simp only [..., Finset.mem_product]` does NOT fire on the membership produced by
+  `Finset.mem_image` (linter flags it "unused"), so anonymous-constructor witnesses
+  `⟨(p,q), ⟨hp, hq⟩, rfl⟩` fail: "expected type `Quot.lift … (S.product S).val` is
+  not an inductive type". Fix: build/destruct product membership *explicitly* with
+  `Finset.mem_product.mpr ⟨hp, hq⟩` / `Finset.mem_product.mp hab`, keeping only
+  `Finset.mem_image` in the `simp only` set. This bit both `trivial_lower_bound`
+  and `two_point_one_distance`.
+- `distinctDistances_mono` is the one genuinely *structural* fact here: any lower
+  bound for the conjecture must be consistent with monotonicity under vertex
+  addition. The empty/singleton/two-point cases pin the base of the count.
+
+**Files modified**
+- `proofs/Proofs/Erdos660Problem.lean` (theoremCount 10→16, sorries 10→9)
+- `src/data/proofs/erdos-660/meta.json` (counts; status stays `formalized`)
+
+**Next steps**
+- The Platonic-solid construction theorems are the next tractable targets, but each
+  needs an explicit vertex set in `EuclideanSpace ℝ (Fin 3)` *and* a proof of
+  `IsConvexPolyhedronVertices` (extreme points of the hull) — non-trivial in Lean.
+  Octahedron $\{\pm e_i\}$ is the most approachable (2 distances: edge $\sqrt2$,
+  diagonal $2$); could be submitted to Aristotle.
+- Main conjecture stays OPEN — do not submit to Aristotle.

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -19,7 +19,7 @@
       "3D-geometry"
     ],
     "badge": "wip",
-    "sorries": 10,
+    "sorries": 9,
     "erdosNumber": 660,
     "erdosUrl": "https://erdosproblems.com/660",
     "erdosProblemStatus": "open",
@@ -54,13 +54,16 @@
       "Main conjecture: (1-o(1))·n/2 distances for 3D convex polyhedra",
       "Weaker linear conjecture: cn distances for some constant c",
       "Platonic solid examples: tetrahedron (1), octahedron (2), cube (3) distances",
-      "Guth-Katz theorem statement for general distinct distances"
+      "Guth-Katz theorem statement for general distinct distances",
+      "trivial_lower_bound: machine-checked proof that n>=2 vertices give >=1 distinct distance",
+      "Verified base cases: empty/singleton/two-point distinct-distance counts",
+      "distinctDistances_mono: monotonicity of the distinct-distance count under adding vertices"
     ],
     "axiomCount": 0,
-    "lineCount": 179,
-    "assumptions": "0 axiom(s) and 10 sorry(s). See the Lean source for details.",
+    "lineCount": 265,
+    "assumptions": "0 axiom(s) and 9 sorry(s). The main conjecture and named classical theorems (Altman, Guth-Katz) and Platonic-solid constructions remain sorry; the base-case lemmas and trivial lower bound are fully proved. See the Lean source for details.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 16,
     "definitionCount": 10,
     "additionalFiles": [
       "Proofs/Erdos660ProblemAristotle.lean",
@@ -114,23 +117,23 @@
       "id": "lower-bounds",
       "title": "Trivial and Conjectural Lower Bounds",
       "startLine": 114,
-      "endLine": 131,
-      "summary": "Proves trivial_lower_bound: ≥ 1 distinct distance (trivially, for n ≥ 2). States linear_lower_bound_conjecture: ≥ cn for some c > 0. The gap between Ω(n^{1/2}) and the conjectured Ω(n) is the main challenge.",
+      "endLine": 217,
+      "summary": "Proves trivial_lower_bound (>=1 distinct distance for n>=2), now fully machine-checked. Adds a Verified base cases subsection: empty and singleton sets have 0 distinct distances, a two-point set has exactly 1, and distinctDistances is monotone under adding vertices (distinctDistances_mono). States linear_lower_bound_conjecture (>= cn for some c>0), which remains open.",
       "mathContext": "Known: $|D(P)| = \\Omega(n^{1/2})$ for any $n$ points (not necessarily convex). Conjectured: $|D(P)| = \\Omega(n)$ for convex position. The Guth-Katz theorem (2015) proves $|D| = \\Omega(n/\\log n)$ for arbitrary point sets in $\\mathbb{R}^2$."
     },
     {
       "id": "special-cases",
       "title": "Special Cases and Constructions",
-      "startLine": 132,
-      "endLine": 167,
+      "startLine": 218,
+      "endLine": 253,
       "summary": "Computes the distinct-distance counts for the Platonic solids: regular tetrahedron (1 distinct distance), cube (3), regular octahedron (2), regular dodecahedron (20 vertices), and regular icosahedron (12 vertices). These small symmetric examples illustrate how high symmetry minimizes the number of distinct distances.",
       "mathContext": "Regular tetrahedron: 4 vertices, 1 distinct distance. Cube: 8 vertices, 3 distinct distances. Regular octahedron: 6 vertices, 2 distinct distances. High symmetry collapses many pairwise distances to a common value, giving the extremal small cases."
     },
     {
       "id": "related-distances",
       "title": "Related: General Distinct Distances Problem",
-      "startLine": 168,
-      "endLine": 179,
+      "startLine": 254,
+      "endLine": 265,
       "summary": "States the Guth-Katz Theorem (2015): any n points in ℝ² determine Ω(n/log n) distinct distances, resolving the Erdős distinct distances problem in the plane up to the logarithmic factor. Provides context for the harder convex-position and 3D variants.",
       "mathContext": "Guth-Katz (2015): $n$ points in $\\mathbb{R}^2$ determine $\\Omega(n/\\log n)$ distinct distances. This nearly resolves the general (non-convex) planar distinct distances problem; the convex-position refinement (#660) seeks a sharper $(1/2-o(1))n$ bound in 3D."
     }
@@ -150,11 +153,11 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 179,
+    "lineCount": 265,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 16,
     "definitionCount": 10,
-    "sorries": 10,
+    "sorries": 9,
     "path": "Proofs/Erdos660Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos660ProblemAristotle.lean",
@@ -178,5 +181,5 @@
       "description": "Related Erdős problem sharing themes: combinatorial-geometry, distinct-distances"
     }
   ],
-  "sorries": 10
+  "sorries": 9
 }


### PR DESCRIPTION
## Summary
Erdős #660 (distinct distances in convex polyhedra) — formalized scaffold; main conjecture stays OPEN. This session eliminates one `sorry` and adds machine-checked structural lemmas.

- **`trivial_lower_bound`**: replaced `sorry` with a real proof — any `S` with `S.card ≥ 2` has `distinctDistances S ≥ 1` (a positive distance lies in the filtered image ⇒ `Finset.card_pos`).
- **Verified base cases** (all 0-sorry): `pairwiseDistances_empty`, `distinctDistances_empty`, `pairwiseDistances_singleton`, `distinctDistances_singleton`, `two_point_one_distance` (a 2-point set has exactly one distinct distance), and `distinctDistances_mono` (the count is monotone under adding vertices — the structural fact any lower-bound argument must respect).

Counts: `sorries` 10 → 9, `theoremCount` 10 → 16, `lineCount` 179 → 265. `axiomCount` 0; status stays `formalized`.

## Verification
Docker build GREEN: `Build completed successfully (7743 jobs)`, exactly 9 `sorry` warnings (main conjecture, Altman, Guth–Katz, 5 Platonic-solid constructions, linear-bound conjecture), 0 errors.

## Note for future work
`pairwiseDistances` images over `S.product S`; `Finset.mem_product` does **not** fire as a `simp` lemma on the membership produced by `Finset.mem_image` — product membership must be built/destructed explicitly via `Finset.mem_product.mpr`/`.mp`. The Platonic-solid constructions (octahedron $\{\pm e_i\}$ most approachable) are the next tractable targets; the main conjecture stays OPEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)