### PR TITLE
research(pentagonal-number-theorem-oq-01): machine-check both ends of Euler's identity via Mathlib genFun

### DIFF
--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -35,6 +35,10 @@
   - `pentSeriesCoeff`        — the RHS coefficient `[Xⁿ] ∑ₖ(-1)ᵏ X^{g(k)}`, well
                                defined by injectivity; supported on the pentagonal
                                numbers, value `(-1)ᵏ` at `g(k)`, everywhere `0`/`±1`
+  - `genFun_pent_eq_tprod`   — both ends of Euler's identity via Mathlib's `genFun`:
+                               the PRODUCT side `genFun pentChar = ∏_{m≥1}(1 - Xᵐ)`
+  - `coeff_genFun_pent`      — the COEFFICIENT side `[Xⁿ] genFun pentChar =
+                               ∑_{p∈distincts n}(-1)^{#parts} = p_even(n)-p_odd(n)`
   - concrete values `g(0..±4) = 0,1,2,5,7,12,15,22,26` matching the OEIS A001318.
 -/
 
@@ -304,6 +308,7 @@ in a recurrence pair carry the same `(-1)ᵏ`), since `|-k| = |k|`. -/
 @[simp] theorem pentSign_neg (k : ℤ) : pentSign (-k) = pentSign k := by
   unfold pentSign; rw [Int.natAbs_neg]
 
+open Classical in
 /-- **The coefficient of `Xⁿ` in `∑_{k∈ℤ} (-1)ᵏ X^{g(k)}`.**  If `n` is a
 generalized pentagonal number it equals `pentSign k` for the unique index `k` with
 `g(k) = n`; otherwise it is `0`.  Well-defined by `genPent_injective`. -/
@@ -362,6 +367,86 @@ theorem pentSeriesCoeff_one : pentSeriesCoeff 1 = -1 := by
   rw [genPent_one] at h
   rw [h]; rfl
 
+/-! ## Part 6: The Mathlib power-series bridges (both ends of Euler's identity)
+
+Mathlib's 2025 `Combinatorics.Enumerative.Partition.GenFun` (Weiyi Wang) supplies
+the partition generating function `Nat.Partition.genFun f : R⟦X⟧` with the proved
+product form `genFun_eq_tprod` and coefficient formula `coeff_genFun`.  We
+instantiate the **Euler character** `f i c = if c = 1 then (-1 : ℤ) else 0` and
+recover BOTH ends of Euler's pentagonal identity as fully machine-checked facts:
+
+* `genFun_pent_eq_tprod` — the PRODUCT side `∏_{m≥1}(1 - Xᵐ)` (each inner factor
+  collapses to `1 - X^{i+1}` because the character is supported on multiplicity `1`);
+* `coeff_genFun_pent`     — the COEFFICIENT side `∑_{p∈distincts n}(-1)^{#parts}`,
+  i.e. `p_even(n) - p_odd(n)` (a partition with a repeated part has a `0` factor and
+  drops out; a distinct-part partition contributes `(-1)^{#parts}`).
+
+With both ends now verified here, the entire pentagonal number theorem collapses to
+the single identity `∑_{p∈distincts n}(-1)^{#parts} = pentSeriesCoeff (n : ℤ)` —
+Franklin's involution — recorded in the OPEN CORE note below. -/
+
+section Bridges
+
+open PowerSeries Finset
+open scoped PowerSeries.WithPiTopology
+
+/-- The Euler character driving `∏(1-Xⁿ)`: weight `-1` on a part used exactly once,
+`0` on any part used more than once. -/
+private def pentChar : ℕ → ℕ → ℤ := fun _ c => if c = 1 then (-1 : ℤ) else 0
+
+/-- **Product side of Euler's identity (free from Mathlib's `genFun`).**  With the
+Euler character, Mathlib's partition generating function is exactly Euler's product
+`∏_{m≥1}(1 - Xᵐ)`. -/
+theorem genFun_pent_eq_tprod :
+    Nat.Partition.genFun pentChar = ∏' i : ℕ, (1 - (X : ℤ⟦X⟧) ^ (i + 1)) := by
+  rw [Nat.Partition.genFun_eq_tprod]
+  refine tprod_congr (fun i => ?_)
+  have hsingle :
+      (∑' j : ℕ, pentChar (i + 1) (j + 1) • (X : ℤ⟦X⟧) ^ ((i + 1) * (j + 1)))
+        = -(X : ℤ⟦X⟧) ^ (i + 1) := by
+    rw [tsum_eq_single 0]
+    · simp [pentChar]
+    · intro b hb
+      simp only [pentChar]
+      rw [if_neg (show ¬ (b + 1 = 1) by omega), zero_smul]
+  rw [hsingle]; ring
+
+/-- **Coefficient side of Euler's identity.**  The `n`-th coefficient of the same
+generating function is the signed count of partitions of `n` into distinct parts,
+`∑_{p∈distincts n}(-1)^{#parts} = p_even(n) - p_odd(n)`. -/
+theorem coeff_genFun_pent (n : ℕ) :
+    (Nat.Partition.genFun pentChar).coeff n
+      = ∑ p ∈ Nat.Partition.distincts n, (-1 : ℤ) ^ p.parts.card := by
+  rw [Nat.Partition.coeff_genFun]
+  -- A distinct-part partition contributes `(-1)^{#parts}`...
+  have hdist : ∀ p : n.Partition, p.parts.Nodup →
+      p.parts.toFinsupp.prod pentChar = (-1 : ℤ) ^ p.parts.card := by
+    intro p hp
+    simp only [Finsupp.prod, Multiset.toFinsupp_support]
+    have hval : ∀ a ∈ p.parts.toFinset, pentChar a (p.parts.toFinsupp a) = (-1 : ℤ) := by
+      intro a ha
+      have hcount : p.parts.count a = 1 :=
+        Multiset.count_eq_one_of_mem hp (Multiset.mem_toFinset.mp ha)
+      simp [pentChar, Multiset.toFinsupp_apply, hcount]
+    rw [Finset.prod_congr rfl hval, Finset.prod_const,
+      Multiset.toFinset_card_of_nodup hp]
+  -- ...while a partition with a repeated part has a `0` factor and drops out.
+  have hnodup : ∀ p : n.Partition, ¬ p.parts.Nodup →
+      p.parts.toFinsupp.prod pentChar = 0 := by
+    intro p hp
+    simp only [Finsupp.prod, Multiset.toFinsupp_support]
+    rw [Multiset.nodup_iff_count_eq_one] at hp
+    push_neg at hp
+    obtain ⟨a, ha_mem, ha_count⟩ := hp
+    refine Finset.prod_eq_zero (Multiset.mem_toFinset.mpr ha_mem) ?_
+    simp [pentChar, Multiset.toFinsupp_apply, ha_count]
+  rw [← Finset.sum_filter_add_sum_filter_not Finset.univ (fun p => p.parts.Nodup)]
+  rw [Finset.sum_eq_zero (fun p hp => hnodup p (Finset.mem_filter.mp hp).2), add_zero,
+    Nat.Partition.distincts]
+  exact Finset.sum_congr rfl (fun p hp => hdist p (Finset.mem_filter.mp hp).2)
+
+end Bridges
+
 /-! ## OPEN CORE (not formalized here) — sharply reduced by Mathlib's `Partition.genFun`
 
 The deep content of the pentagonal number theorem is the *identity*
@@ -374,11 +459,11 @@ where `p_even`/`p_odd` count partitions of `n` into an even/odd number of
 on partitions into distinct parts, whose only fixed points are the staircase
 partitions of generalized pentagonal numbers.
 
-**UPDATE (Session 5, 2026-06-19): the formal-power-series scaffolding now EXISTS in
-Mathlib** (it did not when the paragraph below was first written).
-`Mathlib.Combinatorics.Enumerative.Partition.GenFun` (Weiyi Wang, 2025) defines the
-partition generating function `Nat.Partition.genFun f : R⟦X⟧` with the *proved*
-product form
+**UPDATE (Session 6, 2026-06-19): both ends of Euler's identity are now MACHINE-
+CHECKED in this file** (Part 6 above), building on Mathlib's 2025
+`Mathlib.Combinatorics.Enumerative.Partition.GenFun` (Weiyi Wang).  That module
+defines the partition generating function `Nat.Partition.genFun f : R⟦X⟧` with the
+proved product form
 
     `genFun_eq_tprod : genFun f = ∏' i, (1 + ∑' j, f (i+1) (j+1) • X^((i+1)*(j+1)))`
 
@@ -386,20 +471,17 @@ and coefficient formula
 
     `coeff_genFun : (genFun f).coeff n = ∑ p : n.Partition, p.parts.toFinsupp.prod f`,
 
-while `Partition.Basic` supplies `distincts n` / `odds n` and `Partition.Glaisher`
-the companion product identities (`powerSeriesMk_card_restricted_eq_tprod`,
-`card_odds_eq_card_distincts`).  Instantiating the character
-`f i c = if c = 1 then (-1 : ℤ) else 0` makes each inner term `1 - X^{i+1}`, so
+while `Partition.Basic` supplies `distincts n` / `odds n`.  Instantiating the
+character `pentChar i c = if c = 1 then (-1 : ℤ) else 0`, Part 6 proves
 
-    `genFun (fun i c => if c = 1 then (-1 : ℤ) else 0) = ∏_{m≥1} (1 - Xᵐ)`        (PRODUCT side)
+    `genFun_pent_eq_tprod : genFun pentChar = ∏_{m≥1} (1 - Xᵐ)`                   (PRODUCT side)
+    `coeff_genFun_pent : (genFun pentChar).coeff n
+                            = ∑_{p ∈ distincts n} (-1)^{p.parts.card}`           (COEFFICIENT side)
 
-is now free from Mathlib, and `coeff_genFun` evaluates the SAME series' `n`-th
-coefficient to `∑_{p : n.Partition} ∏_i f(i, #i) = ∑_{p ∈ distincts n} (-1)^{p.parts.card}`
-(the weight is `0` on any partition with a repeated part and `(-1)^{#parts}` on a
-distinct-part partition) — exactly `p_even(n) - p_odd(n)`.
+— the second being exactly `p_even(n) - p_odd(n)`.
 
-Hence both the product `∏(1-Xⁿ)` AND its combinatorial coefficient are already
-available; the ENTIRE remaining open core collapses to the single identity
+Hence both the product `∏(1-Xⁿ)` AND its combinatorial coefficient are now verified
+here; the ENTIRE remaining open core collapses to the single identity
 
     `∑_{p ∈ distincts n} (-1)^{p.parts.card} = pentSeriesCoeff (n : ℤ)`           (FRANKLIN)
 

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/annotations.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/annotations.json
@@ -4,11 +4,11 @@
     "proofId": "pentagonal-number-theorem-oq-01",
     "range": {
       "startLine": 1,
-      "endLine": 45
+      "endLine": 49
     },
     "type": "concept",
     "title": "Scope: The Index Theory Beneath Euler's Theorem",
-    "content": "The module header fixes the scope of the file. Euler's pentagonal number theorem expands the infinite product `∏_{n≥1}(1-xⁿ)` as the lacunary series `∑_{k∈ℤ}(-1)ᵏx^{g(k)}`, whose exponents are the generalized pentagonal numbers `g(k)=k(3k-1)/2`.\n\n**What is and isn't formalized.** The analytic/combinatorial heart — Franklin's sign-reversing involution and the formal-power-series identity — is deliberately left to the OPEN CORE note (see the final annotation); Mathlib lacks the requisite distinct-partition and power-series machinery. This file instead supplies the *number-theoretic index theory* that any such formalization consumes: the recognition criterion, the doubling relation, injectivity, and the OEIS A001318 values.\n\n**Indexing convention.** The exponents are indexed by `k : ℤ` (not `ℕ`): the order `k = 0, 1, -1, 2, -2, …` enumerates the generalized pentagonal numbers in increasing order. The single `import Mathlib` and `maxHeartbeats 400000` are the only build prerequisites.",
+    "content": "The module header fixes the scope of the file. Euler's pentagonal number theorem expands the infinite product `∏_{n≥1}(1-xⁿ)` as the lacunary series `∑_{k∈ℤ}(-1)ᵏx^{g(k)}`, whose exponents are the generalized pentagonal numbers `g(k)=k(3k-1)/2`.\n\n**What is and isn't formalized.** This file supplies the *number-theoretic index theory* (recognition criterion, doubling relation, injectivity, OEIS A001318 values) and, in Part 6, machine-checks BOTH ends of Euler's identity through Mathlib's 2025 `Partition.genFun`: the product side `∏(1-Xᵐ)` and the coefficient side `∑_{distinct partitions}(-1)^{#parts}`. The single remaining gap — the combinatorial heart, Franklin's sign-reversing involution — is documented in the OPEN CORE note (see the final annotation).\n\n**Indexing convention.** The exponents are indexed by `k : ℤ` (not `ℕ`): the order `k = 0, 1, -1, 2, -2, …` enumerates the generalized pentagonal numbers in increasing order. The single `import Mathlib` and `maxHeartbeats 400000` are the only build prerequisites.",
     "mathContext": "$\\prod_{n\\ge1}(1-x^n)=\\sum_{k\\in\\mathbb{Z}}(-1)^k x^{g(k)}$, $\\;g(k)=\\tfrac{k(3k-1)}{2}$, indexed by $k\\in\\mathbb{Z}$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -26,12 +26,12 @@
     "id": "ann-setup",
     "proofId": "pentagonal-number-theorem-oq-01",
     "range": {
-      "startLine": 47,
-      "endLine": 67
+      "startLine": 51,
+      "endLine": 78
     },
     "type": "definition",
     "title": "Division-Free Generalized Pentagonal Numbers",
-    "content": "Defines `genPent k = k*(3*k-1)/2` and the membership predicate `IsGenPent m := ∃ k, 2*m = k*(3*k-1)`.\n\n**Why the doubling relation.** Integer division is awkward to reason about, so membership is phrased through `2*m = k*(3*k-1)` rather than `m = k*(3*k-1)/2`. The two agree because `k*(3*k-1)` is always even: if `k` is even the first factor is, otherwise `3k-1 = 3k-1` is even. `two_dvd_index_mul` proves the evenness by an even/odd split, and `two_mul_genPent` then certifies `2·g(k) = k(3k-1)` via `Int.mul_ediv_cancel'`. `genPent_isGenPent` records that every value `g(k)` is in the membership set.",
+    "content": "Defines `genPent k = k*(3*k-1)/2` and the membership predicate `IsGenPent m := ∃ k, 2*m = k*(3*k-1)`.\n\n**Why the doubling relation.** Integer division is awkward to reason about, so membership is phrased through `2*m = k*(3*k-1)` rather than `m = k*(3*k-1)/2`. The two agree because `k*(3*k-1)` is always even: if `k` is even the first factor is, otherwise `3k-1` is. `two_dvd_index_mul` proves the evenness by an even/odd split, and `two_mul_genPent` then certifies `2·g(k) = k(3k-1)` via `Int.mul_ediv_cancel'`. `genPent_isGenPent` records that every value `g(k)` is in the membership set.",
     "mathContext": "$g(k) = k(3k-1)/2$ with $2g(k) = k(3k-1)$; one of $k$, $3k-1$ is even, so the half is exact.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -47,8 +47,8 @@
     "id": "ann-criterion",
     "proofId": "pentagonal-number-theorem-oq-01",
     "range": {
-      "startLine": 68,
-      "endLine": 116
+      "startLine": 80,
+      "endLine": 128
     },
     "type": "theorem",
     "title": "The Square-Discriminant Recognition Criterion",
@@ -70,13 +70,13 @@
     "id": "ann-structural",
     "proofId": "pentagonal-number-theorem-oq-01",
     "range": {
-      "startLine": 118,
-      "endLine": 139
+      "startLine": 130,
+      "endLine": 161
     },
     "type": "theorem",
-    "title": "Nonnegativity and Injectivity of the Index Map",
-    "content": "`isGenPent_nonneg` shows generalized pentagonal numbers are `≥ 0` by a sign analysis of the two factors of `k(3k-1)`.\n\n`genPent_injective` shows the index map is injective: from `genPent a = genPent b`, multiplying by 2 gives `a(3a-1) = b(3b-1)`, which `linear_combination` rearranges to `(a-b)(3(a+b)-1) = 0`. Since `3(a+b) = 1` has no integer solution (`omega`), the only factor that can vanish is `a-b`, so `a = b`.",
-    "mathContext": "$(a-b)(3(a+b)-1)=0$ with $3(a+b)\\neq1$ over $\\mathbb{Z}$ forces $a=b$.",
+    "title": "Nonnegativity, Injectivity, and the ±k Pairing",
+    "content": "`isGenPent_nonneg` shows generalized pentagonal numbers are `≥ 0` by a sign analysis of the two factors of `k(3k-1)`.\n\n`genPent_injective` shows the index map is injective: from `genPent a = genPent b`, multiplying by 2 gives `a(3a-1) = b(3b-1)`, which `linear_combination` rearranges to `(a-b)(3(a+b)-1) = 0`. Since `3(a+b) = 1` has no integer solution (`omega`), the only factor that can vanish is `a-b`, so `a = b`.\n\n`genPent_neg` records the ±k pairing `g(-k) = g(k) + k` of Euler's recurrence, relating the two pentagonal shifts that occur together at each level.",
+    "mathContext": "$(a-b)(3(a+b)-1)=0$ with $3(a+b)\\neq1$ over $\\mathbb{Z}$ forces $a=b$; and $g(-k)=g(k)+k$.",
     "significance": "supporting",
     "relatedConcepts": [
       "injectivity",
@@ -87,38 +87,86 @@
     ]
   },
   {
-    "id": "ann-values",
+    "id": "ann-index-bounds",
     "proofId": "pentagonal-number-theorem-oq-01",
     "range": {
-      "startLine": 141,
-      "endLine": 159
+      "startLine": 164,
+      "endLine": 254
     },
-    "type": "concept",
-    "title": "Concrete Values (OEIS A001318)",
-    "content": "The first generalized pentagonal numbers, indexed `k = 0,1,-1,2,-2,…`, are `0,1,2,5,7,12,15,22,26`, each proved from the doubling relation by `omega`. The sanity check `twelve_isGenPent` confirms the recognition criterion fires: `12 = g(3)` is pentagonal because `24·12+1 = 289 = 17²`.",
-    "mathContext": "Indexing $k=0,1,-1,2,-2,\\dots$ enumerates A001318 in increasing order.",
+    "type": "theorem",
+    "title": "Index Bounds and a Computable Enumerator",
+    "content": "Makes Euler's recurrence a *finite* sum. `genPent_sq_le_self` gives quadratic growth `k² ≤ g(k)` (from `2g(k) − 2k² = k(k−1) ≥ 0`), and `abs_index_le_genPent` derives the index bound `|k| ≤ g(k)`. Hence `indexSet_finite`: `{k | g(k) ≤ n} ⊆ [-n, n]` is finite. Part 3c turns this into the computable enumerator `pentIndices n` — the explicit `Finset` of indices with `g(k) ≤ n`, filtered from `[-n, n]` — with `mem_pentIndices` and `coe_pentIndices` realizing the abstract set.",
+    "mathContext": "$k^2\\le g(k)$ and $|k|\\le g(k)$, so $g(k)\\le n \\Rightarrow |k|\\le n$; the contributing indices form a finite subset of $[-n,n]$.",
     "significance": "supporting",
     "relatedConcepts": [
+      "Euler partition recurrence",
+      "finiteness",
+      "computable enumeration"
+    ],
+    "prerequisites": [
+      "quadratic growth bounds",
+      "Finset filtering"
+    ]
+  },
+  {
+    "id": "ann-series-coefficient",
+    "proofId": "pentagonal-number-theorem-oq-01",
+    "range": {
+      "startLine": 255,
+      "endLine": 369
+    },
+    "type": "definition",
+    "title": "Concrete Values and the Series-Side Coefficient",
+    "content": "The first generalized pentagonal numbers, indexed `k = 0,1,-1,2,-2,…`, are `0,1,2,5,7,12,15,22,26`, each proved from the doubling relation by `omega`; `twelve_isGenPent` confirms the criterion fires (`24·12+1 = 289 = 17²`).\n\nPart 5 then builds the right-hand side of Euler's identity explicitly. `pentSign k = (-1)^|k|` is ±1-valued, nonvanishing, and pairing-invariant. `pentSeriesCoeff n` is the coefficient `[Xⁿ]` of `∑_{k∈ℤ}(-1)ᵏX^{g(k)}`, well-defined by `genPent_injective` (each exponent is hit by at most one index): `pentSeriesCoeff_genPent` gives `(-1)ᵏ` at `g(k)`, `pentSeriesCoeff_ne_zero_iff` fixes its support as the pentagonal numbers, `pentSeriesCoeff_eq_zero_or` bounds it to `0/±1`, and `[X⁰]=+1`, `[X¹]=-1` match the leading `1 - X` of `∏(1-Xⁿ)`.",
+    "mathContext": "Indexing $k=0,1,-1,2,-2,\\dots$ enumerates A001318; $\\texttt{pentSeriesCoeff}(g(k))=(-1)^k$ is the RHS coefficient of $\\sum_k(-1)^kX^{g(k)}$.",
+    "significance": "key",
+    "relatedConcepts": [
       "OEIS A001318",
-      "pentagonal numbers"
+      "pentagonal numbers",
+      "lacunary series",
+      "generating-function coefficients"
     ],
     "prerequisites": [
       "Generalized Pentagonal Numbers",
-      "OEIS Integer Sequences",
       "Perfect Square Discriminant"
+    ]
+  },
+  {
+    "id": "ann-bridges",
+    "proofId": "pentagonal-number-theorem-oq-01",
+    "range": {
+      "startLine": 370,
+      "endLine": 449
+    },
+    "type": "theorem",
+    "title": "Both Ends of Euler's Identity via Mathlib's genFun",
+    "content": "Part 6 instantiates Mathlib's 2025 `Nat.Partition.genFun` (Weiyi Wang) at the **Euler character** `pentChar i c = if c = 1 then -1 else 0` and recovers BOTH ends of Euler's identity as machine-checked facts.\n\n**Product side** (`genFun_pent_eq_tprod`). `genFun pentChar = ∏'_i (1 - X^{i+1})`: starting from Mathlib's proved `genFun_eq_tprod`, each inner `tsum` collapses to `-(X^{i+1})` because the character is supported on multiplicity `1` (`tsum_eq_single 0`), and `1 + (-(X^{i+1})) = 1 - X^{i+1}`.\n\n**Coefficient side** (`coeff_genFun_pent`). `[Xⁿ] genFun pentChar = ∑_{p ∈ distincts n} (-1)^{p.parts.card}`: from Mathlib's `coeff_genFun`, split `n.Partition` by `Nodup`. A partition with a repeated part has `count a ≥ 2`, so its `pentChar`-factor is `0` and it drops out (`Finset.prod_eq_zero`); a distinct-part partition has every `count = 1`, so each factor is `-1` and the product is `(-1)^{#parts}`. The two halves recombine via `Finset.sum_filter_add_sum_filter_not`, and the surviving filter is exactly `Nat.Partition.distincts n`.\n\nThis equals `p_even(n) - p_odd(n)`. With both ends verified, the entire open core collapses to the single identity `∑_{p ∈ distincts n}(-1)^{p.parts.card} = pentSeriesCoeff(n)` — Franklin's involution. Both theorems `#print axioms` to only `[propext, Classical.choice, Quot.sound]`.",
+    "mathContext": "$\\texttt{genFun}\\,\\texttt{pentChar} = \\prod_{i\\ge0}(1-X^{i+1})$ and $[X^n]\\texttt{genFun}\\,\\texttt{pentChar} = \\sum_{p\\in\\mathrm{distincts}\\,n}(-1)^{|p|} = p_{\\mathrm{even}}(n)-p_{\\mathrm{odd}}(n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "partition generating function",
+      "Euler product",
+      "partitions into distinct parts",
+      "formal power series",
+      "Nat.Partition.genFun"
+    ],
+    "prerequisites": [
+      "formal power series",
+      "integer partitions",
+      "tsum / tprod in a topological semiring"
     ]
   },
   {
     "id": "ann-open-core",
     "proofId": "pentagonal-number-theorem-oq-01",
     "range": {
-      "startLine": 161,
-      "endLine": 177
+      "startLine": 450,
+      "endLine": 497
     },
     "type": "insight",
-    "title": "The Open Core: Franklin's Involution and the Generating Identity",
-    "content": "Documents what this file deliberately does *not* prove: the analytic/combinatorial heart of the theorem.\n\n**The identity.** In the ring of formal power series $\\mathbb{Z}[\\![X]\\!]$, Euler's theorem asserts $\\prod_{n\\ge1}(1-X^n) = \\sum_{k\\in\\mathbb{Z}}(-1)^k X^{g(k)}$. Equivalently, letting $p_{\\mathrm{even}}(n)$ and $p_{\\mathrm{odd}}(n)$ count partitions of $n$ into an even/odd number of *distinct* parts, $p_{\\mathrm{even}}(n)-p_{\\mathrm{odd}}(n)$ equals $(-1)^k$ when $n=g(k)$ and $0$ otherwise.\n\n**Franklin's involution (1881).** The bijective proof builds a sign-reversing involution on partitions into distinct parts using the two statistics $s$ (smallest part) and $\\sigma$ (length of the longest 'staircase' run ending at the largest part). Either the smallest part moves up or the staircase moves down, pairing each partition with one of opposite parity — *except* the staircase partitions $j{+}(j{+}1){+}\\cdots{+}(2j{-}1)$ and their variants, the unmatched fixed points, which sit exactly at $n=g(\\pm j)$ and contribute the surviving $(-1)^k$ term.\n\n**Why it is out of scope.** Mathlib has `Nat.Partition` but not distinct-part partitions with a parity sign, not Franklin's involution, and not the formal-power-series infinite product. This entry supplies the index-set theory (`isGenPent_iff_isSquare`, `genPent_injective`) that any such formalization would consume to locate the surviving exponents.",
-    "mathContext": "$\\prod_{n\\ge1}(1-X^n)=\\sum_{k\\in\\mathbb{Z}}(-1)^k X^{g(k)}$; fixed points of Franklin's involution occur precisely at $n=g(k)$.",
+    "title": "The Open Core: Franklin's Involution (Sharply Reduced)",
+    "content": "Documents the single identity that remains after Part 6.\n\n**The identity.** In `ℤ[\\![X]\\!]`, Euler's theorem asserts `∏_{n≥1}(1-Xⁿ) = ∑_{k∈ℤ}(-1)ᵏ X^{g(k)}`. Part 6 has already machine-checked both ends of this against Mathlib's `genFun`: the product `∏(1-Xᵐ)` and the coefficient `∑_{p∈distincts n}(-1)^{#parts} = p_even(n)-p_odd(n)`. What is left is the bridge between the *combinatorial* coefficient and the *lacunary* coefficient `pentSeriesCoeff`:\n\n`∑_{p ∈ distincts n}(-1)^{p.parts.card} = pentSeriesCoeff(n)`.\n\n**Franklin's involution (1881).** This is exactly the content of Franklin's bijective proof: a sign-reversing involution on partitions into distinct parts built from the smallest part `s` and the staircase run `σ` ending at the largest part. Either the smallest part moves up or the staircase moves down, pairing each partition with one of opposite parity — *except* the staircase partitions sitting at `n = g(±j)`, the unmatched fixed points contributing the surviving `(-1)ᵏ` term.\n\n**Status.** Mathlib supplies the generating function (`genFun`) and `distincts`/`odds`, but not Franklin's involution itself; that sign-reversing bijection is the only remaining gap, and this entry's index theory (`isGenPent_iff_isSquare`, `genPent_injective`) is precisely what a future formalization would consume to locate the surviving exponents.",
+    "mathContext": "$\\sum_{p\\in\\mathrm{distincts}\\,n}(-1)^{|p|} = \\texttt{pentSeriesCoeff}(n)$; fixed points of Franklin's involution occur precisely at $n=g(k)$.",
     "significance": "supporting",
     "relatedConcepts": [
       "Franklin's involution",

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "pentagonal-number-theorem-oq-01",
   "title": "Pentagonal Number Theorem: Generalized Pentagonal Numbers and the Square-Discriminant Criterion",
   "slug": "pentagonal-number-theorem-oq-01",
-  "description": "Builds the number-theoretic foundation of Euler's pentagonal number theorem: a self-contained theory of the generalized pentagonal numbers g(k)=k(3k-1)/2 (the exponents of the lacunary series ∏(1-xⁿ)=∑(-1)ᵏx^{g(k)}). The headline is the classical recognition criterion — m is a generalized pentagonal number iff 24m+1 is a perfect square — together with injectivity of the index map, nonnegativity, and the concrete values matching OEIS A001318. The deep generating-function identity (via Franklin's involution) is documented as the open core, as Mathlib lacks the requisite distinct-partition and formal-power-series machinery.",
+  "description": "Builds the number-theoretic foundation of Euler's pentagonal number theorem: a self-contained theory of the generalized pentagonal numbers g(k)=k(3k-1)/2 (the exponents of the lacunary series ∏(1-xⁿ)=∑(-1)ᵏx^{g(k)}). The headline is the classical recognition criterion — m is a generalized pentagonal number iff 24m+1 is a perfect square — together with injectivity of the index map, nonnegativity, and the concrete values matching OEIS A001318. Building on Mathlib's 2025 Partition.GenFun, the entry now also machine-checks BOTH ends of Euler's identity for the Euler character: the product side genFun pentChar = ∏(1-Xᵐ) and the coefficient side [Xⁿ] = ∑_{distinct partitions}(-1)^{#parts} = p_even(n)-p_odd(n), narrowing the open core to the single Franklin-involution identity ∑(-1)^{#parts} = pentSeriesCoeff(n).",
   "meta": {
     "status": "verified",
     "tags": [
@@ -41,6 +41,16 @@
         "theorem": "Even.neg_one_pow / Odd.neg_one_pow",
         "description": "(-1)^n = 1 for even n, -1 for odd n — gives the ±1-valuedness of the pentagonal sign pentSign k = (-1)^|k|",
         "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.Partition.genFun_eq_tprod",
+        "description": "genFun f = ∏' i, (1 + ∑' j, f(i+1)(j+1) • X^((i+1)(j+1))) — the proved product form of the partition generating function; with the Euler character pentChar each inner factor collapses to 1 - X^{i+1}, yielding the product side genFun_pent_eq_tprod = ∏(1-Xᵐ)",
+        "module": "Mathlib.Combinatorics.Enumerative.Partition.GenFun"
+      },
+      {
+        "theorem": "Nat.Partition.coeff_genFun",
+        "description": "(genFun f).coeff n = ∑ p : n.Partition, p.parts.toFinsupp.prod f — the coefficient formula; with pentChar the weight is 0 on partitions with a repeated part and (-1)^{#parts} on distinct-part partitions, yielding the coefficient side coeff_genFun_pent = ∑_{p ∈ distincts n}(-1)^{p.parts.card}",
+        "module": "Mathlib.Combinatorics.Enumerative.Partition.GenFun"
       }
     ],
     "originalContributions": [
@@ -52,17 +62,18 @@
       "Index-bound theory making Euler partition recurrence a finite sum: genPent_sq_le_self (k^2 <= g(k), quadratic growth), abs_index_le_genPent (|k| <= g(k)), and indexSet_finite ({k | g(k) <= n} is finite, contained in [-n,n])",
       "A computable enumerator pentIndices (def): the explicit Finset of indices k with g(k) <= n, filtered from [-n,n], with mem_pentIndices (membership iff g(k) <= n) and coe_pentIndices (realizing the abstract set {k | g(k) <= n}), so the finite sum in Euler's recurrence can be evaluated",
       "genPent_neg: the +/-k pairing g(-k) = g(k) + k of Euler's recurrence, relating the two pentagonal shifts g(k) and g(-k) that occur together at each level",
-      "pentSeriesCoeff: an explicit construction of the right-hand side of Euler's identity — the coefficient [Xⁿ] of the lacunary series ∑_{k∈ℤ}(-1)ᵏ X^{g(k)}, made well-defined by genPent_injective (each exponent is hit by at most one index). pentSeriesCoeff_genPent gives the value (-1)ᵏ at g(k); pentSeriesCoeff_ne_zero_iff shows the support is exactly the generalized pentagonal numbers; pentSeriesCoeff_eq_zero_or bounds every coefficient to 0/±1; concrete [X⁰]=+1, [X¹]=-1 match the leading 1 and -X of ∏(1-Xⁿ). The pentagonal sign pentSign k = (-1)^|k| is recorded with its ±1-valuedness, nonvanishing, and pairing invariance pentSign(-k)=pentSign k."
+      "pentSeriesCoeff: an explicit construction of the right-hand side of Euler's identity — the coefficient [Xⁿ] of the lacunary series ∑_{k∈ℤ}(-1)ᵏ X^{g(k)}, made well-defined by genPent_injective (each exponent is hit by at most one index). pentSeriesCoeff_genPent gives the value (-1)ᵏ at g(k); pentSeriesCoeff_ne_zero_iff shows the support is exactly the generalized pentagonal numbers; pentSeriesCoeff_eq_zero_or bounds every coefficient to 0/±1; concrete [X⁰]=+1, [X¹]=-1 match the leading 1 and -X of ∏(1-Xⁿ). The pentagonal sign pentSign k = (-1)^|k| is recorded with its ±1-valuedness, nonvanishing, and pairing invariance pentSign(-k)=pentSign k.",
+      "Both ends of Euler's identity machine-checked through Mathlib's 2025 Partition.GenFun (Weiyi Wang) under the Euler character pentChar i c = (if c = 1 then -1 else 0): genFun_pent_eq_tprod proves the PRODUCT side genFun pentChar = ∏_{i}(1 - X^{i+1}) (each inner tsum collapses to -(X^{i+1}) since the character is supported on multiplicity 1, via tsum_eq_single), and coeff_genFun_pent proves the COEFFICIENT side [Xⁿ] genFun pentChar = ∑_{p ∈ Nat.Partition.distincts n}(-1)^{p.parts.card} = p_even(n)-p_odd(n) (a partition with a repeated part contributes a 0 factor and drops out; a distinct-part partition contributes (-1)^{#parts}, via a Nodup/¬Nodup split over n.Partition and Finset.sum_filter_add_sum_filter_not). Together these reduce the entire remaining open core to the single Franklin-involution identity ∑_{p ∈ distincts n}(-1)^{p.parts.card} = pentSeriesCoeff(n)."
     ],
     "dateAdded": "2026-06-18",
     "axiomCount": 0,
-    "lineCount": 383,
-    "assumptions": "None counted: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. pentSeriesCoeff is a noncomputable def using Classical.choice (a foundational axiom that the project's axiom policy does not count toward axiomCount). Machine-verified — the file compiles cleanly under the docker Lean build against Mathlib (Built Proofs.PentagonalNumberTheoremOQ01, 7743 jobs, exit 0).",
-    "theoremCount": 35,
-    "definitionCount": 5
+    "lineCount": 497,
+    "assumptions": "None counted: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. pentSeriesCoeff is a noncomputable def using Classical.choice (a foundational axiom that the project's axiom policy does not count toward axiomCount). The two genFun bridges genFun_pent_eq_tprod and coeff_genFun_pent each #print axioms to [propext, Classical.choice, Quot.sound] — only the standard foundational axioms, none counted. Machine-verified — the file compiles cleanly under the docker Lean build against Mathlib (Built Proofs.PentagonalNumberTheoremOQ01, 7743 jobs, exit 0).",
+    "theoremCount": 37,
+    "definitionCount": 6
   },
   "overview": {
-    "historicalContext": "Euler discovered the pentagonal number theorem in 1740s correspondence with Goldbach and proved it in 1750: the infinite product ∏_{n≥1}(1-xⁿ) equals the lacunary series ∑_{k∈ℤ}(-1)ᵏ x^{k(3k-1)/2}. The exponents are the generalized pentagonal numbers (OEIS A001318), and the theorem yields Euler's celebrated recurrence for the partition function p(n). Franklin (1881) gave the bijective proof via a sign-reversing involution on partitions into distinct parts. Mathlib formalizes Nat.Partition but not the distinct-partition parity machinery, Franklin's involution, or the formal power-series infinite product, so the deep identity remains unformalized; this entry supplies the index-set theory that any such formalization consumes.",
+    "historicalContext": "Euler discovered the pentagonal number theorem in 1740s correspondence with Goldbach and proved it in 1750: the infinite product ∏_{n≥1}(1-xⁿ) equals the lacunary series ∑_{k∈ℤ}(-1)ᵏ x^{k(3k-1)/2}. The exponents are the generalized pentagonal numbers (OEIS A001318), and the theorem yields Euler's celebrated recurrence for the partition function p(n). Franklin (1881) gave the bijective proof via a sign-reversing involution on partitions into distinct parts. Mathlib's 2025 Partition.GenFun (Weiyi Wang) now supplies the partition generating function with its proved product (genFun_eq_tprod) and coefficient (coeff_genFun) forms; this entry instantiates it at the Euler character to machine-check BOTH ends of Euler's identity (Part 6), leaving only Franklin's involution — the identity ∑(-1)^{#parts} = pentSeriesCoeff(n) — unformalized. The entry also supplies the index-set theory that any such formalization consumes.",
     "problemStatement": "Establish the number-theoretic foundation of the pentagonal exponents g(k) = k(3k-1)/2: a robust formalization of the index set together with the recognition criterion\n\n$$ m \\text{ is a generalized pentagonal number} \\iff 24m+1 \\text{ is a perfect square}, $$\n\nthe identity underlying it being $24\\,g(k)+1 = (6k-1)^2$.",
     "text": "A self-contained theory of generalized pentagonal numbers with the square-discriminant recognition criterion, the foundation that any formalization of Euler's pentagonal number theorem must rest on.",
     "proofStrategy": "1. **Division-free setup**: define membership IsGenPent m := ∃ k, 2m = k(3k-1); prove k(3k-1) is even (even/odd split) so g(k)=k(3k-1)/2 is exact (two_mul_genPent).\n\n2. **Forward criterion**: from 2m = k(3k-1), the identity 24m+1 = (6k-1)² is a single linear_combination, exhibiting the square.\n\n3. **Converse**: from 24m+1 = s², reduce mod 6 in ZMod 6 — s² = 1 forces s ∈ {1,5}, i.e. s ≡ ±1 (mod 6) (a finite decide). Each class gives 6 ∣ (s∓1), hence s = 6k±1; substituting and cancelling the common factor 12 (mul_left_cancel₀) yields 2m = k'(3k'-1) for the recovered index k'.\n\n4. **Structural facts**: injectivity of the index map ((a-b)(3(a+b)-1)=0, with 3(a+b)=1 impossible over ℤ), nonnegativity, and the concrete A001318 values.",
@@ -81,62 +92,86 @@
   "sections": [
     {
       "id": "setup",
-      "title": "Setup: Generalized Pentagonal Numbers",
-      "startLine": 1,
-      "endLine": 71,
-      "summary": "Module documentation, the value genPent and the division-free membership predicate IsGenPent, evenness of k(3k-1), and the exact doubling relation two_mul_genPent.",
+      "title": "Part 1 — Setup: Generalized Pentagonal Numbers",
+      "startLine": 51,
+      "endLine": 79,
+      "summary": "The value genPent and the division-free membership predicate IsGenPent, evenness of k(3k-1) (two_dvd_index_mul), the exact doubling relation two_mul_genPent, and genPent_isGenPent.",
       "mathContext": "g(k) = k(3k-1)/2 with 2·g(k) = k(3k-1). Since one of k, 3k-1 is even, the half is exact; membership is carried by the relation 2m = k(3k-1) to keep proofs over ℤ without integer division."
     },
     {
       "id": "criterion",
-      "title": "The Square-Discriminant Criterion (Headline)",
-      "startLine": 73,
-      "endLine": 121,
+      "title": "Part 2 — The Square-Discriminant Criterion (Headline)",
+      "startLine": 80,
+      "endLine": 129,
       "summary": "isGenPent_iff_isSquare: m is a generalized pentagonal number iff 24m+1 is a perfect square. Forward via 24·g(k)+1 = (6k-1)²; converse via a ZMod-6 residue argument recovering the index.",
       "mathContext": "Forward: linear_combination on 2m=k(3k-1). Converse: s²=24m+1 ⟹ (s mod 6)²=1 ⟹ s≡±1 (mod 6); 6∣(s∓1) gives s=6k±1, and cancelling 12 yields 2m=k'(3k'-1)."
     },
     {
       "id": "structural",
-      "title": "Structural Facts: Nonnegativity and Injectivity",
-      "startLine": 123,
-      "endLine": 144,
-      "summary": "isGenPent_nonneg (k(3k-1) ≥ 0) and genPent_injective (distinct indices give distinct pentagonal numbers).",
+      "title": "Part 3 — Structural Facts: Nonnegativity, Injectivity, ±k Pairing",
+      "startLine": 130,
+      "endLine": 163,
+      "summary": "isGenPent_nonneg (k(3k-1) ≥ 0), genPent_injective (distinct indices give distinct pentagonal numbers), and genPent_neg (g(-k) = g(k)+k, the ±k pairing of Euler's recurrence).",
       "mathContext": "Injectivity reduces to (a-b)(3(a+b)-1)=0; since 3(a+b)=1 has no integer solution, a=b. Nonnegativity is a sign analysis of the two factors of k(3k-1)."
     },
     {
       "id": "index-bounds",
-      "title": "Index Bounds: Euler's Recurrence is a Finite Sum",
-      "startLine": 146,
-      "endLine": 202,
+      "title": "Part 3b — Index Bounds: Euler's Recurrence is a Finite Sum",
+      "startLine": 164,
+      "endLine": 221,
       "summary": "Quadratic growth k² ≤ g(k) (genPent_sq_le_self), the resulting index bound |k| ≤ g(k) (abs_index_le_genPent), and indexSet_finite: {k | g(k) ≤ n} ⊆ [-n, n] is finite, so the pentagonal sum in Euler's partition recurrence at level n ranges over a finite set.",
       "mathContext": "From the doubling relation, 2g(k) − 2k² = k(k−1) ≥ 0 gives k² ≤ g(k); combining k ≤ g(k) and −k ≤ g(k) yields |k| ≤ g(k). Hence g(k) ≤ n forces |k| ≤ n, bounding the recurrence's support inside [-n, n]."
     },
     {
+      "id": "enumerator",
+      "title": "Part 3c — A Computable Enumerator of Contributing Indices",
+      "startLine": 222,
+      "endLine": 254,
+      "summary": "pentIndices n: the explicit Finset of indices k with g(k) ≤ n, filtered from [-n, n], with mem_pentIndices (membership iff g(k) ≤ n) and coe_pentIndices realizing the abstract set {k | g(k) ≤ n}.",
+      "mathContext": "Made finite by the |k| ≤ g(k) bound: every contributing index lies in [-n, n], so the finite sum in Euler's recurrence can be evaluated by filtering that interval."
+    },
+    {
       "id": "values",
-      "title": "Concrete Values (OEIS A001318)",
-      "startLine": 204,
-      "endLine": 221,
+      "title": "Part 4 — Concrete Values (OEIS A001318)",
+      "startLine": 255,
+      "endLine": 273,
       "summary": "The first generalized pentagonal numbers g(0..±4) = 0,1,2,5,7,12,15,22,26, and a sanity check that 12 = g(3) is recognized via 24·12+1 = 289 = 17².",
       "mathContext": "Indexing k = 0,1,-1,2,-2,… enumerates the pentagonal numbers in increasing order, matching OEIS A001318."
     },
     {
+      "id": "series-coefficient",
+      "title": "Part 5 — The Series-Side Coefficient (RHS of Euler's Identity)",
+      "startLine": 274,
+      "endLine": 369,
+      "summary": "pentSign k = (-1)^|k| (±1-valued, nonvanishing, pairing-invariant) and pentSeriesCoeff: the coefficient [Xⁿ] of ∑_{k∈ℤ}(-1)ᵏX^{g(k)}, well-defined by genPent_injective. pentSeriesCoeff_genPent gives (-1)ᵏ at g(k); pentSeriesCoeff_ne_zero_iff fixes the support as the pentagonal numbers; pentSeriesCoeff_eq_zero_or bounds every coefficient to 0/±1; [X⁰]=+1, [X¹]=-1.",
+      "mathContext": "This is the explicit right-hand side of Euler's identity; pentSeriesCoeff is the target of the remaining Franklin-involution identity."
+    },
+    {
+      "id": "bridges",
+      "title": "Part 6 — Mathlib Power-Series Bridges (Both Ends of Euler's Identity)",
+      "startLine": 370,
+      "endLine": 449,
+      "summary": "Instantiating Mathlib's 2025 Partition.genFun at the Euler character pentChar i c = (if c = 1 then -1 else 0): genFun_pent_eq_tprod proves the PRODUCT side genFun pentChar = ∏_i(1 - X^{i+1}), and coeff_genFun_pent proves the COEFFICIENT side [Xⁿ] genFun pentChar = ∑_{p ∈ distincts n}(-1)^{p.parts.card} = p_even(n)-p_odd(n). Both #print axioms to only [propext, Classical.choice, Quot.sound].",
+      "mathContext": "Product side: each inner tsum collapses to -(X^{i+1}) via tsum_eq_single (the character is supported on multiplicity 1). Coefficient side: a Nodup/¬Nodup split over n.Partition — repeated-part partitions carry a 0 factor and drop out, distinct-part partitions contribute (-1)^{#parts}. With both ends verified, the open core reduces to the single identity ∑_{p ∈ distincts n}(-1)^{p.parts.card} = pentSeriesCoeff(n)."
+    },
+    {
       "id": "open-core",
       "title": "Open Core: Franklin's Involution (Not Formalized)",
-      "startLine": 223,
-      "endLine": 239,
-      "summary": "Documents the deep generating-function identity ∏(1-Xⁿ)=∑(-1)ᵏX^{g(k)} and its bijective proof via Franklin's sign-reversing involution on partitions into distinct parts, explaining why it is out of scope: Mathlib lacks distinct-partition parity machinery and formal-power-series infinite products. The index theory this entry supplies is exactly what such a development would consume.",
+      "startLine": 450,
+      "endLine": 497,
+      "summary": "Documents the single remaining identity ∑_{p ∈ distincts n}(-1)^{p.parts.card} = pentSeriesCoeff(n) (Franklin's sign-reversing involution on partitions into distinct parts), now that both ends of Euler's identity are machine-checked in Part 6. Mathlib supplies the generating function and distincts/odds but not Franklin's involution itself.",
       "mathContext": "Equivalently p_even(n)-p_odd(n) = [n=g(k)]·(-1)ᵏ, where p_even/p_odd count partitions into an even/odd number of distinct parts; Franklin's involution's only fixed points are the staircase partitions of the generalized pentagonal numbers g(k)."
     }
   ],
   "openQuestions": [
-    "Formalize the deep identity ∏_{n≥1}(1-Xⁿ) = ∑_{k∈ℤ}(-1)ᵏ X^{g(k)} (equivalently p_even(n)-p_odd(n) = [n=g(k)]·(-1)ᵏ) via Franklin's sign-reversing involution on partitions into distinct parts — requires distinct-partition parity machinery and formal-power-series infinite products not yet in Mathlib.",
+    "Close the open core: prove the single Franklin-involution identity ∑_{p ∈ distincts n}(-1)^{p.parts.card} = pentSeriesCoeff(n). Both ends of Euler's identity (the product ∏(1-Xᵐ) and the coefficient ∑(-1)^{#parts}) are now machine-checked here via Mathlib's genFun (Part 6), so this sign-reversing involution on partitions into distinct parts is all that remains.",
     "Derive Euler's partition recurrence p(n) = ∑_{k≥1}(-1)^{k-1}(p(n-g_k)+p(n-g_{-k})) as a corollary, using this entry's recognition criterion to index the pentagonal shifts."
   ],
   "conclusion": {
     "summary": "This entry establishes the number-theoretic backbone of Euler's pentagonal number theorem: a division-free theory of the generalized pentagonal numbers g(k)=k(3k-1)/2, anchored by the recognition criterion that m is a generalized pentagonal number iff 24m+1 is a perfect square. Alongside the criterion it proves the exact doubling relation, injectivity of the index map, nonnegativity, and the first concrete values matching OEIS A001318 — all machine-verified with 0 axioms and 0 sorries.",
     "implications": "The square-discriminant test 24m+1=□ is exactly how the pentagonal exponents are enumerated in practice when running Euler's partition recurrence p(n)=∑_{k≥1}(-1)^{k-1}(p(n-g_k)+p(n-g_{-k})), so this index theory is the reusable substrate beneath any algorithmic or formal treatment of partition counting. By routing every argument through the doubling relation 2m=k(3k-1) rather than integer division, the development stays entirely inside ℤ and exposes the clean polynomial identity 24g(k)+1=(6k-1)² that makes the criterion exact. The injectivity result genPent_injective is precisely what a future formalization of Franklin's involution needs to assert that each surviving exponent is hit by a unique index.",
     "openQuestions": [
-      "Formalize the deep generating-function identity ∏_{n≥1}(1-Xⁿ)=∑_{k∈ℤ}(-1)ᵏX^{g(k)} via Franklin's sign-reversing involution on partitions into distinct parts — blocked on distinct-partition parity machinery and formal-power-series infinite products absent from Mathlib.",
+      "Close the open core via Franklin's sign-reversing involution: the single identity ∑_{p ∈ distincts n}(-1)^{p.parts.card} = pentSeriesCoeff(n). Both ends of Euler's identity are now machine-checked here through Mathlib's 2025 Partition.genFun (Part 6: genFun_pent_eq_tprod and coeff_genFun_pent), so the involution is the only remaining gap.",
       "Derive Euler's partition recurrence for p(n) as a corollary, using this entry's recognition criterion to index the pentagonal shifts.",
       "Extend the square-discriminant viewpoint to the higher Gauss/Jacobi-triple-product exponents (e.g. the heptagonal and general figurate analogues), characterizing each family by an analogous perfect-square test."
     ]


### PR DESCRIPTION
## Summary

Extends the Pentagonal Number Theorem OQ-01 index theory with **Part 6**, which bridges Mathlib's 2025 `Combinatorics.Enumerative.Partition.GenFun` (Weiyi Wang) and machine-checks **both ends of Euler's pentagonal identity** for the Euler character `pentChar i c = (if c = 1 then -1 else 0)`:

- **`genFun_pent_eq_tprod`** (PRODUCT side): `genFun pentChar = ∏'_i (1 - X^(i+1))`. Each inner `tsum` collapses to `-(X^(i+1))` via `tsum_eq_single` because the character is supported on multiplicity `1`.
- **`coeff_genFun_pent`** (COEFFICIENT side): `[Xⁿ] genFun pentChar = ∑_{p ∈ Nat.Partition.distincts n} (-1)^p.parts.card = p_even(n) - p_odd(n)`. A `Nodup`/`¬Nodup` split over `n.Partition`: repeated-part partitions carry a `0` factor and drop out; distinct-part partitions contribute `(-1)^#parts`.

With both ends now verified, the entire remaining open core collapses to the single **Franklin-involution identity** `∑_{p ∈ distincts n}(-1)^#parts = pentSeriesCoeff(n)`.

## Verification

- **Build GREEN** under the docker wrapper: `Built Proofs.PentagonalNumberTheoremOQ01` (7743 jobs, exit 0).
- Both new theorems `#print axioms` to only `[propext, Classical.choice, Quot.sound]` — the standard foundational axioms, none counted per the project's axiom policy. Status stays **`verified`**, `axiomCount` 0, 0 sorries.

## Other changes

- Fixed `pentSeriesCoeff`'s dite decidability with a correctly-placed `open Classical in` (the WIP had it after the docstring, a syntax error).
- Realigned the gallery `meta.json` `sections` and `annotations.json` ranges, which were stale (written for an earlier ~177–239 line version and predated Parts 3b/3c/5), to the current 497-line file; added a Part 6 section/annotation and removed the now-false claim that Mathlib lacks formal-power-series machinery. Updated `lineCount` 383→497, `theoremCount` 35→37, `definitionCount` 5→6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)