### PR TITLE
research(minpoly-charpoly-oq-03-oq-01): discharge RCF bridge — entry now verified & axiom-free

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2864,6 +2864,7 @@ import Proofs.RamseysTheoremOQ04
 import Proofs.RandomizedMaxCut
 import Proofs.RandomizedMaxcutOQ02
 import Proofs.RandomizedMaxcutOQ04
+import Proofs.RationalCanonicalFormExists
 import Proofs.RelativizedHalting
 import Proofs.RelativizedHaltingBridge
 import Proofs.RepunitDivisibilityOQ01

--- a/proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Module.Torsion.Basic
 import Mathlib.RingTheory.Finiteness.Defs
 import Mathlib.Tactic
 import Proofs.MinpolyCharpolyOQ03
+import Proofs.RationalCanonicalFormExists
 
 /-
 # OQ-03-OQ-01 (S1 Scaffold): F[X]-Module Structure on K^n via Matrix Action
@@ -60,16 +61,21 @@ Both structural deliverables consumed by OQ-03-OQ-02 are now **proved**:
   `charpoly_mulVecLin` + `LinearMap.aeval_self_charpoly`, then upgraded
   to torsion via `charpoly_monic ⇒ nonZeroDivisor`).
 
-The single remaining `sorry` is `xModule_has_invariantFactorChain` (the
-invariant-factor-chain bridge to the parent's strong form), which is
-**deliberately deferred to OQ-03-OQ-02**: it requires the regrouping
-algorithm of `Module.equiv_directSum_of_isTorsion`, out of scope for
-this foundational sub-OQ. Its statement is fixed here only to pin the
-bridging API surface.
+The invariant-factor-chain bridge `xModule_has_invariantFactorChain` (to
+the parent's strong form) is now **fully discharged** — no `sorry`. The
+heavy regrouping algorithm (`Module.equiv_directSum_of_isTorsion` →
+primary decomposition → prime-power regrouping into a divisibility chain)
+lives in the companion file `Proofs/RationalCanonicalFormExists.lean` as
+the axiom-free theorem `rational_canonical_form_exists`; the bridge here
+is a one-line field copy between the two field-identical
+`InvariantFactorChain` structures.
 
-Note: the torsion proofs are **build-verified** (researcher-7, S13:
-`docker-build.sh Proofs.MinpolyCharpolyOQ03OQ01`, 3070 jobs, 1 sorry —
-the deferred bridge only). An earlier revision was build-broken: it
+Note: this file is now **build-verified sorry-free** (researcher-1, S15:
+`docker-build.sh Proofs.MinpolyCharpolyOQ03OQ01`, 7746 jobs, 0 sorry in
+this file and its companion; the lone `sorry` warning in the build is the
+unrelated parent `Proofs/MinpolyCharpolyOQ03.lean:228`). The torsion
+proofs were previously build-verified (researcher-7, S13: 3070 jobs). An
+earlier revision was build-broken: it
 relied on `LinearMap.charpoly`/`aeval_self_charpoly` and
 `charpoly_mulVecLin` without importing `Mathlib.LinearAlgebra.Charpoly.{Basic,ToMatrix}`,
 and tried to feed the strict-implicit `IsTorsionBy` proof directly into
@@ -139,7 +145,7 @@ instance for downstream use. -/
 instance xModule.instFinite (M : Matrix n n F) :
     Module.Finite F[X] (xModule M) := inferInstance
 
-/-! ## Part 3: Torsion over F[X] (statement; proof deferred)
+/-! ## Part 3: Torsion over F[X] (proved)
 
 The F[X]-module `xModule M` is torsion: every element is annihilated
 by `charpoly M`, which is monic (hence nonzero in F[X] as F is a
@@ -157,7 +163,7 @@ The proof routes through:
 
 The lemma `xModule_isTorsionBy_charpoly` captures steps 1–3;
 `xModule_isTorsion` is the deliverable consumed by OQ-03-OQ-02. Both
-are now proved (build-pending kernel verification). -/
+are proved and build-verified. -/
 
 /-- The characteristic polynomial of `M` annihilates every element of
     the `F[X]`-module `xModule M`. This is Cayley–Hamilton transported
@@ -219,7 +225,7 @@ the deliverable here so its API surface is fixed by this sub-OQ.
 The chain is packaged as the parent's `InvariantFactorChain` structure
 (see `Proofs/MinpolyCharpolyOQ03.lean`). -/
 
-/-- **OQ-03-OQ-02 target (statement, sorry-guarded here)**:
+/-- **OQ-03-OQ-02 target (now fully proved)**:
     `xModule M` admits an invariant-factor chain whose product equals
     `M.charpoly` **and** whose last factor equals `minpoly F M`. This is
     a restatement of the parent's `rational_canonical_form_exists`
@@ -235,11 +241,18 @@ The chain is packaged as the parent's `InvariantFactorChain` structure
     strong-form `rational_canonical_form_exists`. Adding `c.lastFactor =
     minpoly F M` forces the genuine invariant-factor decomposition
     (`minpoly = charpoly` holds only for non-derogatory `M`), restoring
-    the claimed mutual-derivability with the parent. The proof remains
-    deferred to the OQ-03-OQ-02 regrouping algorithm. -/
+    the claimed mutual-derivability with the parent. The proof is
+    discharged by the companion `rational_canonical_form_exists`. -/
 theorem xModule_has_invariantFactorChain (M : Matrix n n F) :
     ∃ c : MinpolyCharpolyOQ03.InvariantFactorChain F,
       c.prodFactors = M.charpoly ∧ c.lastFactor = minpoly F M := by
-  sorry
+  -- Discharged by `RationalCanonicalFormExists.rational_canonical_form_exists`
+  -- (the strong-form RCF existence theorem, proved axiom-free in the companion
+  -- file). Its `InvariantFactorChain` is field-identical to the parent's, so we
+  -- copy the four fields across; `prodFactors`/`lastFactor` are definitionally
+  -- `factors.prod` / `factors.getLast?.getD 1` on both, hence the equalities
+  -- transport unchanged.
+  obtain ⟨c, hprod, hlast⟩ := RationalCanonicalFormExists.rational_canonical_form_exists M
+  exact ⟨⟨c.factors, c.monic, c.posDegree, c.chain⟩, hprod, hlast⟩
 
 end MinpolyCharpolyOQ03OQ01

--- a/proofs/Proofs/RationalCanonicalFormExists.lean
+++ b/proofs/Proofs/RationalCanonicalFormExists.lean
@@ -1,0 +1,523 @@
+/-
+# Rational Canonical Form — Existence (strong / invariant-factor form)
+
+`rational_canonical_form_exists`: every square matrix `M` over a field admits an
+invariant-factor chain — monic polynomials of positive degree forming a
+divisibility chain `p₁ ∣ p₂ ∣ ⋯ ∣ pₖ` — whose product equals `M.charpoly` and
+whose last factor equals `minpoly F M`.
+
+This is the structural content behind the lone bridge `sorry` of
+`minpoly-charpoly-oq-03-oq-01` (`xModule_has_invariantFactorChain`) and of the
+parent OQ-03's main RCF existence statement. It is *not* available off-the-shelf
+in Mathlib: the development builds the required theory from scratch —
+
+* `RCF.mulX` and `charpoly_mulX_aeval'`/`_congr`/`_quotient`: the `F[X]`-module
+  structure on `Fⁿ` with `X` acting via `M`, and that the charpoly of
+  "multiplication by `X`" recovers `M.charpoly`, is invariant under `F[X]`-linear
+  equivalences, and equals `g` on the cyclic module `F[X]/(g)` for monic `g`;
+* `det_blockDiagonal'`/`charpoly_blockDiagonal'` and the internal/external direct
+  sum lemmas: multiplicativity of the charpoly over finite direct sums;
+* `decomp_charpoly_minpoly`/`exists_elementary_divisors`: primary decomposition
+  via Mathlib's structure theorem for f.g. torsion modules over a PID — charpoly
+  is the product of the monic associates of the elementary divisors (prime
+  powers), minpoly is governed by their lcm;
+* `exists_chain_aux`/`exists_chain_of_prime_powers`: a purely combinatorial
+  regrouping of prime powers into an invariant-factor (divisibility) chain by
+  strong induction, peeling off the lcm at each step.
+
+The final theorem is fully proved with **no `sorry` and no added axioms** (it
+type-checks depending only on the standard `propext` / `Classical.choice` /
+`Quot.sound`).
+
+Provenance: the proof body was synthesized by the Aristotle proof-search system
+(project `d2395b8d`, task `5bec9f0a`) against a self-contained Mathlib-only
+statement, then integrated here verbatim (wrapped in a namespace). The local
+`InvariantFactorChain` structure is field-identical to the parent's
+`MinpolyCharpolyOQ03.InvariantFactorChain`; the bridge in
+`MinpolyCharpolyOQ03OQ01.lean` converts between them via a one-line field copy.
+-/
+import Mathlib
+
+namespace RationalCanonicalFormExists
+
+open Matrix Polynomial
+
+variable {F : Type*} [Field F]
+
+/-- An invariant-factor chain: monic polynomials of positive degree forming a
+divisibility chain `p₁ ∣ p₂ ∣ ⋯ ∣ pₖ`. -/
+structure InvariantFactorChain (F : Type*) [Field F] where
+  factors : List F[X]
+  monic : ∀ p ∈ factors, p.Monic
+  posDegree : ∀ p ∈ factors, 0 < p.natDegree
+  chain : ∀ i j : Fin factors.length, i.val ≤ j.val → factors[i] ∣ factors[j]
+
+noncomputable def InvariantFactorChain.prodFactors (c : InvariantFactorChain F) : F[X] :=
+  c.factors.prod
+
+noncomputable def InvariantFactorChain.lastFactor (c : InvariantFactorChain F) : F[X] :=
+  c.factors.getLast?.getD 1
+
+namespace RCF
+
+/-- The `F`-linear endomorphism "multiplication by `X`" on an `F[X]`-module `W`. -/
+noncomputable def mulX (F : Type*) [Field F] (W : Type*) [AddCommGroup W] [Module F[X] W]
+    [Module F W] [IsScalarTower F F[X] W] : W →ₗ[F] W :=
+  (LinearMap.lsmul F[X] W (X : F[X])).restrictScalars F
+
+/-
+The characteristic polynomial of multiplication-by-`X` on `AEval' f` is `f.charpoly`.
+-/
+lemma charpoly_mulX_aeval' {W : Type*} [AddCommGroup W] [Module F W]
+    [Module.Finite F W] [Module.Free F W] (f : Module.End F W) :
+    (mulX F (Module.AEval' f)).charpoly = f.charpoly := by
+  -- By definition of $AEval'$, we know that $mulX F (Module.AEval' f)$ is conjugate to $f$.
+  have h_conj : (mulX F (Module.AEval' f)) = (LinearEquiv.conj (Module.AEval'.of f) f) := by
+    ext m;
+    convert Module.AEval'.of_symm_X_smul f ( ( Module.AEval'.of f ).symm m ) using 1;
+  rw [ h_conj, LinearEquiv.charpoly_conj ]
+
+/-
+An `F[X]`-linear equivalence preserves the charpoly of multiplication-by-`X`.
+-/
+lemma charpoly_mulX_congr {W₁ W₂ : Type*}
+    [AddCommGroup W₁] [Module F[X] W₁] [Module F W₁] [IsScalarTower F F[X] W₁]
+    [Module.Finite F W₁] [Module.Free F W₁]
+    [AddCommGroup W₂] [Module F[X] W₂] [Module F W₂] [IsScalarTower F F[X] W₂]
+    [Module.Finite F W₂] [Module.Free F W₂]
+    (e : W₁ ≃ₗ[F[X]] W₂) :
+    (mulX F W₁).charpoly = (mulX F W₂).charpoly := by
+  convert (LinearEquiv.charpoly_conj (e.restrictScalars F) (mulX F W₁)).symm using 2
+  ext w₂
+  -- residual point-wise goal: `X • w₂ = ((e.restrictScalars F).conj (mulX F W₁)) w₂`.
+  -- Unfold the conjugation and use that the underlying `e` is `F[X]`-linear, so it
+  -- commutes with the `X`-action.
+  simp only [mulX, LinearEquiv.conj_apply, LinearMap.comp_apply,
+    LinearMap.restrictScalars_apply, LinearMap.lsmul_apply,
+    LinearEquiv.restrictScalars_apply, LinearEquiv.coe_coe]
+  rw [map_smul, show ((e.restrictScalars F).symm) w₂ = e.symm w₂ from rfl,
+    e.apply_symm_apply]
+
+/-
+Determinant of a (dependent) block-diagonal matrix is the product of the determinants.
+-/
+lemma det_blockDiagonal' {R : Type*} [CommRing R] {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {m : ι → Type*} [∀ i, Fintype (m i)] [∀ i, DecidableEq (m i)]
+    (Mat : (i : ι) → Matrix (m i) (m i) R) :
+    (Matrix.blockDiagonal' Mat).det = ∏ i, (Mat i).det := by
+  induction' h : Fintype.card ι with k ih generalizing ι;
+  · rw [ Fintype.card_eq_zero_iff ] at h;
+    simp +decide [ Matrix.det_apply' ];
+  · obtain ⟨i, hi⟩ : ∃ i : ι, True := by
+      exact Fintype.card_pos_iff.mp ( h.symm ▸ Nat.succ_pos _ ) |> fun ⟨ i ⟩ => ⟨ i, trivial ⟩;
+    -- Let's denote the remaining part of the index type by `ι'`.
+    set ι' := {j : ι | j ≠ i} with hι';
+    -- By definition of `blockDiagonal'`, we can rewrite the determinant as the product of the determinants of the blocks.
+    have h_det : (blockDiagonal' Mat).det = (Matrix.fromBlocks (Mat i) 0 0 (blockDiagonal' (fun j : ι' => Mat j.val))).det := by
+      obtain ⟨e, he⟩ : ∃ e : (Σ j : ι, m j) ≃ (m i) ⊕ (Σ j : ι', m j.val), ∀ x y, (blockDiagonal' Mat) x y = (Matrix.fromBlocks (Mat i) 0 0 (blockDiagonal' (fun j : ι' => Mat j.val))) (e x) (e y) := by
+        refine' ⟨ _, _ ⟩;
+        refine' Equiv.ofBijective ( fun x => if hx : x.1 = i then Sum.inl ( hx ▸ x.2 ) else Sum.inr ⟨ ⟨ x.1, hx ⟩, x.2 ⟩ ) ⟨ fun x y hxy => _, fun x => _ ⟩;
+        grind;
+        rcases x with ( x | ⟨ ⟨ j, hj ⟩, x ⟩ );
+        exact ⟨ ⟨ i, x ⟩, by simp +decide ⟩;
+        exact ⟨ ⟨ j, x ⟩, by simp +decide [ hj.out ] ⟩;
+        rintro ⟨ x, y ⟩ ⟨ u, v ⟩ ; by_cases hx : x = i <;> by_cases hu : u = i <;> simp +decide [ hx, hu, blockDiagonal' ] ;
+        · aesop;
+        · exact fun h => False.elim ( hu h.symm );
+      rw [ ← Matrix.det_submatrix_equiv_self e ];
+      exact congr_arg Matrix.det ( by ext x y; exact he x y );
+    rw [ h_det, Matrix.det_fromBlocks_zero₂₁, ih ];
+    · rw [ Finset.prod_eq_mul_prod_diff_singleton ( Finset.mem_univ i ) ];
+      refine' congr rfl ( Finset.prod_bij ( fun j _ => j ) _ _ _ _ ) <;> simp +decide;
+      · exact fun x hx => hx;
+      · exact fun j hj => hj;
+    · simp +decide [ h, hι' ]
+
+/-
+Characteristic polynomial of a (dependent) block-diagonal matrix is the product.
+-/
+lemma charpoly_blockDiagonal' {R : Type*} [CommRing R] {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {m : ι → Type*} [∀ i, Fintype (m i)] [∀ i, DecidableEq (m i)]
+    (Mat : (i : ι) → Matrix (m i) (m i) R) :
+    (Matrix.blockDiagonal' Mat).charpoly = ∏ i, (Mat i).charpoly := by
+  convert det_blockDiagonal' _ using 1;
+  all_goals try infer_instance;
+  unfold Matrix.charpoly;
+  congr;
+  ext ⟨ i, a ⟩ ⟨ j, b ⟩ ; by_cases hij : i = j <;> simp +decide [ hij, Matrix.charmatrix ] ;
+  · subst hij; simp +decide [ Matrix.diagonal ] ;
+  · simp +decide [ hij, blockDiagonal' ]
+
+/-
+The charpoly of multiplication-by-`X` over an internal direct sum is the product of the
+charpolys of the restrictions to the summands.
+-/
+lemma charpoly_mulX_isInternal {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {W : Type*} [AddCommGroup W] [Module F[X] W] [Module F W] [IsScalarTower F F[X] W]
+    [Module.Finite F W] [Module.Free F W]
+    {S : ι → Submodule F W}
+    (hmap : ∀ i, ∀ x ∈ S i, mulX F W x ∈ S i)
+    (h : DirectSum.IsInternal S) :
+    (mulX F W).charpoly = ∏ i, ((mulX F W).restrict (fun x hx => hmap i x hx)).charpoly := by
+  convert ( RCF.charpoly_blockDiagonal' fun i => LinearMap.toMatrix ( Module.Free.chooseBasis F ( S i ) ) ( Module.Free.chooseBasis F ( S i ) ) ( ( mulX F W ).restrict ( hmap i ) ) ) using 1;
+  convert ( LinearMap.charpoly_toMatrix ( mulX F W ) ( h.collectedBasis ( fun i => Module.Free.chooseBasis F ( S i ) ) ) ) |> Eq.symm using 1;
+  rw [ LinearMap.toMatrix_directSum_collectedBasis_eq_blockDiagonal' ]
+
+/-
+The canonical component submodules of an external direct sum form an internal direct sum
+(viewed as `F`-submodules).
+-/
+lemma directSum_components_isInternal {ι : Type*} [DecidableEq ι]
+    (W : ι → Type*) [∀ i, AddCommGroup (W i)] [∀ i, Module F[X] (W i)]
+    [∀ i, Module F (W i)] [∀ i, IsScalarTower F F[X] (W i)] :
+    DirectSum.IsInternal
+      (fun i => (LinearMap.range (DirectSum.lof F[X] ι W i)).restrictScalars F) := by
+  convert DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top _ _;
+  · intro i; simp +decide [ Submodule.restrictScalars ] ;
+    rw [ Submodule.disjoint_def ] ; simp +decide [ Submodule.mem_iSup ];
+    intro a ha; specialize ha ( LinearMap.ker ( DirectSum.component F[X] ι W i ) |> Submodule.restrictScalars F ) ; simp_all +decide [ SetLike.le_def ] ;
+    convert ha _;
+    · exact ⟨ fun h => by simpa using congr_arg ( fun x => x i ) h, fun h => by simp +decide [ h ] ⟩;
+    · intro j hj a; erw [ DirectSum.component.of ] ; aesop;
+  · refine' eq_top_iff.mpr fun x hx => _;
+    induction x using DirectSum.induction_on ; aesop;
+    · exact Submodule.mem_iSup_of_mem ‹_› ( Set.mem_range_self _ );
+    · aesop
+
+/-
+The charpoly of multiplication-by-`X` over a finite direct sum is the product.
+-/
+lemma charpoly_mulX_directSum {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (W : ι → Type*) [∀ i, AddCommGroup (W i)] [∀ i, Module F[X] (W i)]
+    [∀ i, Module F (W i)] [∀ i, IsScalarTower F F[X] (W i)]
+    [∀ i, Module.Finite F (W i)] [∀ i, Module.Free F (W i)] :
+    (mulX F (DirectSum ι W)).charpoly = ∏ i, (mulX F (W i)).charpoly := by
+  convert RCF.charpoly_mulX_isInternal _ _;
+  any_goals try exact fun i => ( LinearMap.range ( DirectSum.lof F[X] ι W i ) ).restrictScalars F;
+  any_goals exact RCF.directSum_components_isInternal W;
+  swap;
+  intro i x hx;
+  obtain ⟨ y, rfl ⟩ := hx;
+  exact ⟨ ( X : F[X] ) • y, by simp +decide [ mulX ] ⟩;
+  convert RCF.charpoly_mulX_congr _;
+  · infer_instance;
+  · infer_instance;
+  · infer_instance;
+  · refine' LinearEquiv.ofBijective _ ⟨ _, _ ⟩;
+    refine' { toFun := fun x => ⟨ DirectSum.lof F[X] ι W _ x, _ ⟩, map_add' := _, map_smul' := _ };
+    all_goals simp +decide [ Function.Injective, Function.Surjective ];
+    · aesop;
+    · intro x y hxy;
+      replace hxy := congr_arg ( fun f => f ‹_› ) hxy ; aesop
+
+/-
+The charpoly of multiplication-by-`X` on the cyclic module `F[X] ⧸ (g)` is `g`
+(for `g` monic).
+-/
+set_option maxHeartbeats 1000000 in
+lemma charpoly_mulX_quotient (g : F[X]) (hg : g.Monic)
+    [Module.Finite F (F[X] ⧸ Ideal.span {g})] :
+    (mulX F (F[X] ⧸ Ideal.span {g})).charpoly = g := by
+  -- The minimal polynomial of multiplication-by-`X` on `F[X] ⧸ Ideal.span {g}` is `g`.
+  have h_minpoly : minpoly F (mulX F (F[X] ⧸ Ideal.span {g})) = g := by
+    have h_minpoly : ∀ p : F[X], aeval (mulX F (F[X] ⧸ Ideal.span {g})) p = 0 ↔ g ∣ p := by
+      intro p
+      have h_aeval : ∀ w : F[X] ⧸ Ideal.span {g}, (aeval (mulX F (F[X] ⧸ Ideal.span {g})) p) w = p • w := by
+        induction p using Polynomial.induction_on <;> simp_all +decide [ Polynomial.aeval_add, Polynomial.aeval_X, Polynomial.aeval_C ];
+        · intro w; exact (by
+          convert rfl;
+          ext; simp [HSMul.hSMul];
+          simp +decide [ SMul.smul ];
+          simp +decide [ Algebra.smul_def ]);
+        · simp +decide [ add_smul ];
+        · simp_all +decide [ pow_succ, mulX ];
+          simp +decide [ ← mul_assoc, ← smul_assoc ];
+      constructor;
+      · intro h
+        have h_annihilator : p • (1 : F[X] ⧸ Ideal.span {g}) = 0 := by
+          rw [ ← h_aeval, h, LinearMap.zero_apply ];
+        erw [ Ideal.Quotient.eq_zero_iff_mem ] at h_annihilator;
+        simpa [ Ideal.mem_span_singleton ] using h_annihilator;
+      · intro hp
+        have h_annihilate : ∀ w : F[X] ⧸ Ideal.span {g}, p • w = 0 := by
+          obtain ⟨ q, rfl ⟩ := hp;
+          intro w
+          obtain ⟨ w', rfl ⟩ := Ideal.Quotient.mk_surjective w;
+          erw [ Ideal.Quotient.eq_zero_iff_mem ];
+          exact Ideal.mem_span_singleton.mpr ⟨ q * w', by simp +decide [ mul_comm, mul_left_comm ] ⟩;
+        exact LinearMap.ext fun w => h_aeval w ▸ h_annihilate w;
+    have h_minpoly : minpoly F (mulX F (F[X] ⧸ Ideal.span {g})) ∣ g := by
+      exact minpoly.dvd F _ ( h_minpoly _ |>.2 dvd_rfl );
+    refine' Polynomial.eq_of_monic_of_associated _ hg _;
+    · exact minpoly.monic ( show IsIntegral F ( mulX F ( F[X] ⧸ Ideal.span { g } ) ) from by exact ( LinearMap.isIntegral _ ) );
+    · exact associated_of_dvd_dvd h_minpoly ( ‹∀ p : F[X], ( aeval ( mulX F ( F[X] ⧸ Ideal.span { g } ) ) ) p = 0 ↔ g ∣ p› _ |>.1 ( minpoly.aeval F ( mulX F ( F[X] ⧸ Ideal.span { g } ) ) ) );
+  have h_deg : Polynomial.natDegree (minpoly F (mulX F (F[X] ⧸ Ideal.span {g}))) = Polynomial.natDegree ((mulX F (F[X] ⧸ Ideal.span {g})).charpoly) := by
+    convert finrank_quotient_span_eq_natDegree ( f := g ) using 1;
+    · rw [ h_minpoly, finrank_quotient_span_eq_natDegree ];
+    · convert LinearMap.charpoly_natDegree ( mulX F ( F[X] ⧸ Ideal.span { g } ) ) using 1;
+      rw [ ← finrank_quotient_span_eq_natDegree ];
+  -- Since the minimal polynomial divides the characteristic polynomial and they have the same degree, they must be equal.
+  have h_div : minpoly F (mulX F (F[X] ⧸ Ideal.span {g})) ∣ (mulX F (F[X] ⧸ Ideal.span {g})).charpoly := by
+    exact LinearMap.minpoly_dvd_charpoly _;
+  obtain ⟨ q, hq ⟩ := h_div;
+  have hq_monic : q.Monic := by
+    have := LinearMap.charpoly_monic ( mulX F ( F[X] ⧸ Ideal.span { g } ) );
+    rw [ hq, Polynomial.Monic, Polynomial.leadingCoeff_mul ] at this ; aesop;
+  by_cases hq_zero : q = 0 <;> simp_all +decide [ Polynomial.natDegree_mul' ]
+
+/-
+The quotient of `F[X]` by the span of a nonzero polynomial is finite-dimensional over `F`.
+-/
+lemma finite_quotient_span (g : F[X]) (hg : g ≠ 0) :
+    Module.Finite F (F[X] ⧸ Ideal.span {g}) := by
+  convert ( AdjoinRoot.powerBasis hg ).finite
+
+/-- The monic associate of a polynomial. -/
+noncomputable def monicAssoc (g : F[X]) : F[X] := g * Polynomial.C (g.leadingCoeff)⁻¹
+
+lemma monicAssoc_monic {g : F[X]} (hg : g ≠ 0) : (monicAssoc g).Monic :=
+  Polynomial.monic_mul_leadingCoeff_inv hg
+
+lemma monicAssoc_associated {g : F[X]} (hg : g ≠ 0) : Associated (monicAssoc g) g := by
+  refine' associated_of_dvd_dvd _ _;
+  · exact ⟨ Polynomial.C ( Polynomial.leadingCoeff g ), by rw [ monicAssoc, mul_assoc, ← Polynomial.C_mul, inv_mul_cancel₀ ( Polynomial.leadingCoeff_ne_zero.mpr hg ), Polynomial.C_1, mul_one ] ⟩;
+  · exact dvd_mul_right _ _
+
+lemma span_monicAssoc {g : F[X]} (hg : g ≠ 0) :
+    Ideal.span {monicAssoc g} = Ideal.span {g} :=
+  Ideal.span_singleton_eq_span_singleton.mpr (monicAssoc_associated hg)
+
+lemma monicAssoc_natDegree {g : F[X]} (hg : g ≠ 0) : (monicAssoc g).natDegree = g.natDegree := by
+  unfold monicAssoc;
+  rw [ Polynomial.natDegree_mul' ] <;> aesop
+
+/-
+The module-theoretic core: given a primary decomposition of the `F[X]`-module `M`,
+the charpoly is the product of the monic associates of the prime powers, and the minpoly
+divisibility is governed by the prime powers.
+-/
+set_option maxHeartbeats 1000000 in
+set_option synthInstance.maxHeartbeats 400000 in
+lemma decomp_charpoly_minpoly {n : Type*} [Fintype n] [DecidableEq n] (M : Matrix n n F)
+    {ι' : Type*} [Fintype ι']
+    (p : ι' → F[X]) (hp : ∀ i, Irreducible (p i)) (ev : ι' → ℕ)
+    (e : Module.AEval' (Matrix.toLin' M) ≃ₗ[F[X]]
+          DirectSum ι' (fun i => F[X] ⧸ Ideal.span {p i ^ ev i})) :
+    M.charpoly = ∏ i, monicAssoc (p i ^ ev i) ∧
+    (∀ c : F[X], minpoly F M ∣ c ↔ ∀ i, (p i ^ ev i) ∣ c) := by
+  classical
+  haveI hfin : ∀ i, Module.Finite F (F[X] ⧸ Ideal.span {p i ^ ev i}) :=
+    fun i => RCF.finite_quotient_span _ (pow_ne_zero _ (hp i).ne_zero)
+  refine ⟨?_, ?_⟩
+  · have key : M.charpoly = ∏ i, (mulX F (F[X] ⧸ Ideal.span {p i ^ ev i})).charpoly := by
+      rw [← RCF.charpoly_mulX_directSum, ← RCF.charpoly_mulX_congr e,
+        RCF.charpoly_mulX_aeval', Matrix.charpoly_toLin']
+    rw [key]
+    refine Finset.prod_congr rfl fun i _ => ?_
+    haveI : Module.Finite F (F[X] ⧸ Ideal.span {monicAssoc (p i ^ ev i)}) :=
+      RCF.finite_quotient_span _
+        (RCF.monicAssoc_monic (pow_ne_zero _ (hp i).ne_zero)).ne_zero
+    rw [RCF.charpoly_mulX_congr (Submodule.quotEquivOfEq _ _
+        (RCF.span_monicAssoc (pow_ne_zero _ (hp i).ne_zero)).symm),
+      RCF.charpoly_mulX_quotient (monicAssoc (p i ^ ev i))
+        (RCF.monicAssoc_monic (pow_ne_zero _ (hp i).ne_zero))]
+  · have h_annihilator : Ideal.span {minpoly F M} = ⨅ i, Ideal.span {p i ^ ev i} := by
+      have h_annihilator : Module.annihilator F[X] (DirectSum ι' (fun i => F[X] ⧸ Ideal.span {p i ^ ev i})) = ⨅ i, Ideal.span {p i ^ ev i} := by
+        have h_annihilator : ∀ i, Module.annihilator F[X] (F[X] ⧸ Ideal.span {p i ^ ev i}) = Ideal.span {p i ^ ev i} := by
+          intro i;
+          exact Ideal.annihilator_quotient;
+        convert Module.annihilator_dfinsupp;
+        rw [ h_annihilator ];
+      rw [ ← h_annihilator, ← e.annihilator_eq ];
+      rw [ ← minpoly_toLin', Polynomial.span_minpoly_eq_annihilator ];
+    intro c; rw [ Ideal.ext_iff ] at h_annihilator; specialize h_annihilator c; simp_all +decide [ Ideal.mem_span_singleton, Submodule.mem_iInf ] ;
+
+/-
+Existence of elementary divisors: monic prime powers whose product is the charpoly,
+and whose lcm (characterized by the universal divisibility property) is the minpoly.
+-/
+lemma exists_elementary_divisors {n : Type*} [Fintype n] [DecidableEq n] (M : Matrix n n F) :
+    ∃ (m : ℕ) (q : Fin m → F[X]),
+      (∀ i, (q i).Monic) ∧ (∀ i, 0 < (q i).natDegree) ∧
+      (∀ i, ∃ π : F[X], Irreducible π ∧ ∃ k : ℕ, 0 < k ∧ q i = π ^ k) ∧
+      M.charpoly = ∏ i, q i ∧
+      (∀ c : F[X], minpoly F M ∣ c ↔ ∀ i, q i ∣ c) := by
+  obtain ⟨ι', _instι', p, hp, ev, ⟨e⟩⟩ := Module.equiv_directSum_of_isTorsion (Module.AEval.isTorsion_of_finiteDimensional F (n → F) (Matrix.toLin' M));
+  obtain ⟨hchar, hmin⟩ := RCF.decomp_charpoly_minpoly M p hp ev e;
+  refine' ⟨ Fintype.card { i : ι' // 0 < ev i }, fun j => monicAssoc ( p ( Fintype.equivFin { i : ι' // 0 < ev i } |>.symm j ) ^ ev ( Fintype.equivFin { i : ι' // 0 < ev i } |>.symm j ) ), _, _, _, _, _ ⟩;
+  · exact fun i => monicAssoc_monic ( pow_ne_zero _ ( hp _ |> Irreducible.ne_zero ) );
+  · intro i
+    simp [monicAssoc];
+    rw [ Polynomial.natDegree_mul' ] <;> simp +decide [ Polynomial.natDegree_pow, Polynomial.natDegree_C ];
+    · exact ⟨ by simpa using ( Fintype.equivFin { i // 0 < ev i } ).symm i |>.2, Polynomial.natDegree_pos_iff_degree_pos.mpr ( Polynomial.degree_pos_of_irreducible ( hp _ ) ) ⟩;
+    · exact fun h => absurd h ( Polynomial.ne_zero_of_degree_gt ( Polynomial.degree_pos_of_irreducible ( hp _ ) ) );
+  · intro i;
+    refine' ⟨ monicAssoc ( p ( Fintype.equivFin { i // 0 < ev i } |>.symm i ) ), _, ev ( Fintype.equivFin { i // 0 < ev i } |>.symm i ), _, _ ⟩;
+    · have := monicAssoc_associated ( show p ( Fintype.equivFin { i // 0 < ev i } |>.symm i ) ≠ 0 from fun h => by simpa [ h ] using hp ( Fintype.equivFin { i // 0 < ev i } |>.symm i ) );
+      exact this.irreducible_iff.mpr ( hp _ );
+    · exact ( Fintype.equivFin { i // 0 < ev i } |>.symm i ) |>.2;
+    · unfold monicAssoc; simp +decide [ Polynomial.leadingCoeff_pow ] ;
+      rw [ mul_pow, ← Polynomial.C_pow, inv_pow ];
+  · rw [ hchar, ← Finset.prod_subset ( Finset.subset_univ { i : ι' | 0 < ev i } ) ];
+    · refine' Finset.prod_bij ( fun i hi => Fintype.equivFin { i : ι' // 0 < ev i } ⟨ i, Finset.mem_filter.mp hi |>.2 ⟩ ) _ _ _ _ <;> simp +decide;
+      exact fun b => ⟨ _, Subtype.property ( Fintype.equivFin { i // 0 < ev i } |>.symm b ), by simp +decide ⟩;
+    · simp +contextual [ monicAssoc ];
+  · intro c;
+    convert hmin c using 1;
+    constructor <;> intro h i;
+    · by_cases hi : 0 < ev i;
+      · convert dvd_trans _ ( h ( Fintype.equivFin { i : ι' // 0 < ev i } ⟨ i, hi ⟩ ) ) using 1;
+        simp +decide [ monicAssoc ];
+      · aesop;
+    · exact dvd_trans ( monicAssoc_associated ( pow_ne_zero _ ( hp _ |> Irreducible.ne_zero ) ) |> Associated.dvd ) ( h _ )
+
+/-
+Distinct monic irreducible polynomials give coprime powers.
+-/
+lemma coprime_monic_irreducible_pow {a b : F[X]} (ha : Irreducible a) (hb : Irreducible b)
+    (hma : a.Monic) (hmb : b.Monic) (hne : a ≠ b) (m k : ℕ) :
+    IsCoprime (a ^ m) (b ^ k) := by
+  refine' IsCoprime.pow _;
+  refine' ha.coprime_iff_not_dvd.mpr _;
+  rintro ⟨ c, rfl ⟩;
+  rw [ irreducible_mul_iff ] at hb;
+  cases' hb with hb hb <;> simp_all +decide [ Polynomial.Monic.def, Polynomial.leadingCoeff_mul ];
+  · rw [ Polynomial.isUnit_iff ] at hb ; aesop;
+  · exact ha.not_isUnit hb.2
+
+/-
+Auxiliary regrouping over a `Finset`, by strong induction (peeling off the lcm).
+-/
+set_option maxHeartbeats 1600000 in
+set_option synthInstance.maxHeartbeats 400000 in
+lemma exists_chain_aux {ι : Type*} [DecidableEq ι]
+    (π : ι → F[X]) (k : ι → ℕ)
+    (hmonπ : ∀ i, (π i).Monic) (hirr : ∀ i, Irreducible (π i)) (hk : ∀ i, 0 < k i)
+    (s : Finset ι) :
+    ∃ L : List F[X],
+      (∀ p ∈ L, p.Monic) ∧ (∀ p ∈ L, 0 < p.natDegree) ∧
+      (∀ a b : Fin L.length, (a : ℕ) ≤ b → L[a] ∣ L[b]) ∧
+      L.prod = ∏ i ∈ s, π i ^ k i ∧
+      (∀ c : F[X], (L.getLast?.getD 1 ∣ c) ↔ ∀ i ∈ s, π i ^ k i ∣ c) := by
+  by_cases hs : s.Nonempty;
+  · induction' s using Finset.strongInduction with s ih;
+    obtain ⟨R, d, hR, hd⟩ : ∃ R : Finset ι, ∃ d : F[X], R ⊆ s ∧ R.Nonempty ∧ d = ∏ i ∈ R, (π i) ^ (k i) ∧ (∀ i ∈ s, (π i) ^ (k i) ∣ d) ∧ (∀ c : F[X], d ∣ c ↔ ∀ i ∈ R, (π i) ^ (k i) ∣ c) := by
+      obtain ⟨R, hR⟩ : ∃ R : Finset ι, R ⊆ s ∧ R.Nonempty ∧ (∀ i ∈ s, ∃ j ∈ R, π i = π j ∧ k i ≤ k j) ∧ (∀ i ∈ R, ∀ j ∈ R, π i = π j → i = j) := by
+        have hR : ∃ R : Finset ι, R ⊆ s ∧ (∀ i ∈ s, ∃ j ∈ R, π i = π j ∧ k i ≤ k j) ∧ (∀ i ∈ R, ∀ j ∈ R, π i = π j → i = j) := by
+          have hR : ∀ t : Finset ι, t ⊆ s → ∃ R : Finset ι, R ⊆ t ∧ (∀ i ∈ t, ∃ j ∈ R, π i = π j ∧ k i ≤ k j) ∧ (∀ i ∈ R, ∀ j ∈ R, π i = π j → i = j) := by
+            intro t ht;
+            induction' t using Finset.induction with i t hi ih;
+            · exact ⟨ ∅, by simp +decide ⟩;
+            · obtain ⟨ R, hR₁, hR₂, hR₃ ⟩ := ih ( Finset.Subset.trans ( Finset.subset_insert _ _ ) ht );
+              by_cases hiR : ∃ j ∈ R, π i = π j ∧ k i ≤ k j;
+              · use R;
+                grind;
+              · by_cases hiR : ∃ j ∈ R, π i = π j;
+                · obtain ⟨ j, hj₁, hj₂ ⟩ := hiR;
+                  use Insert.insert i (R.erase j);
+                  grind;
+                · use Insert.insert i R;
+                  grind;
+          exact hR s Finset.Subset.rfl;
+        grind +extAll;
+      refine' ⟨ R, _, hR.1, hR.2.1, rfl, _, _ ⟩;
+      · intro i hi; obtain ⟨ j, hj, hij, hkj ⟩ := hR.2.2.1 i hi; exact dvd_trans ( pow_dvd_pow _ hkj ) ( Finset.dvd_prod_of_mem _ hj |> dvd_trans ( by simp +decide [ hij ] ) ) ;
+      · intro c;
+        refine' ⟨ fun h i hi => dvd_trans _ h, fun h => _ ⟩;
+        · exact Finset.dvd_prod_of_mem _ hi;
+        · refine' Finset.prod_dvd_of_coprime _ _;
+          · intro i hi j hj hij;
+            exact IsCoprime.pow ( by exact ( hirr i |> Irreducible.coprime_iff_not_dvd ) |>.2 fun h => hij <| hR.2.2.2 i hi j hj <| Polynomial.eq_of_monic_of_associated ( hmonπ i ) ( hmonπ j ) <| associated_of_dvd_dvd h <| (hirr i).dvd_symm (hirr j) h );
+          · exact h;
+    obtain ⟨L', hL'mon, hL'pos, hL'chain, hL'prod, hL'last⟩ : ∃ L' : List F[X], (∀ p ∈ L', p.Monic) ∧ (∀ p ∈ L', 0 < p.natDegree) ∧ (∀ a b : Fin L'.length, a.val ≤ b.val → L'[a] ∣ L'[b]) ∧ L'.prod = ∏ i ∈ s \ R, (π i) ^ (k i) ∧ (∀ c : F[X], L'.getLast?.getD 1 ∣ c ↔ ∀ i ∈ s \ R, (π i) ^ (k i) ∣ c) := by
+      by_cases hR' : (s \ R).Nonempty;
+      · grind +extAll;
+      · use [] ; simp_all +decide [ Finset.Nonempty ] ;
+        rw [ Finset.sdiff_eq_empty_iff_subset.mpr hR', Finset.prod_empty ];
+    refine' ⟨ L' ++ [ d ], _, _, _, _, _ ⟩;
+    · simp +zetaDelta at *;
+      rintro p ( hp | rfl ) <;> [ exact hL'mon p hp; exact hd.2.1.symm ▸ Polynomial.monic_prod_of_monic _ _ fun i hi => Polynomial.Monic.pow ( hmonπ i ) _ ];
+    · simp_all +decide [ Polynomial.Monic.def ];
+      rintro p ( hp | rfl );
+      · exact hL'pos p hp;
+      · rw [ Polynomial.natDegree_prod _ _ fun i hi => pow_ne_zero _ ( Polynomial.ne_zero_of_degree_gt ( Polynomial.degree_pos_of_irreducible ( hirr i ) ) ) ];
+        exact Finset.sum_pos ( fun i hi => by rw [ Polynomial.natDegree_pow, Polynomial.natDegree_eq_of_degree_eq_some ( Polynomial.degree_eq_natDegree ( Polynomial.ne_zero_of_degree_gt ( Polynomial.degree_pos_of_irreducible ( hirr i ) ) ) ) ] ; exact mul_pos ( hk i ) ( Polynomial.natDegree_pos_iff_degree_pos.mpr ( Polynomial.degree_pos_of_irreducible ( hirr i ) ) ) ) hd.1;
+    · intro a b hab;
+      by_cases ha : a.val < L'.length <;> by_cases hb : b.val < L'.length <;> simp +decide [ ha, hb ] at hab ⊢;
+      · exact hL'chain ⟨ a, ha ⟩ ⟨ b, hb ⟩ hab;
+      · have h_div : L'[a] ∣ L'.getLast?.getD 1 := by
+          convert hL'chain ⟨ a, ha ⟩ ⟨ L'.length - 1, Nat.sub_lt ( by linarith ) zero_lt_one ⟩ _ using 1;
+          · grind;
+          · exact Nat.le_pred_of_lt ha;
+        refine' dvd_trans h_div _;
+        grind;
+      · exact False.elim ( ha ( lt_of_le_of_lt hab hb ) );
+      · grind;
+    · simp +decide [ *, Finset.prod_sdiff hR ];
+    · intro c; constructor <;> intro hc <;> simp_all +decide ;
+      · exact fun i hi => dvd_trans ( hd.2.2.1 i hi ) ( hd.2.1.symm ▸ hc );
+      · grind;
+  · refine' ⟨ [ ], _, _, _, _, _ ⟩ <;> simp +decide [ Finset.not_nonempty_iff_eq_empty.mp hs ]
+
+/-
+Regrouping prime powers into an invariant-factor chain (pure polynomial combinatorics).
+-/
+lemma exists_chain_of_prime_powers {ι : Type*} [Fintype ι]
+    (q : ι → F[X]) (hmon : ∀ i, (q i).Monic)
+    (hpp : ∀ i, ∃ π : F[X], Irreducible π ∧ ∃ k : ℕ, 0 < k ∧ q i = π ^ k) :
+    ∃ L : List F[X],
+      (∀ p ∈ L, p.Monic) ∧ (∀ p ∈ L, 0 < p.natDegree) ∧
+      (∀ s t : Fin L.length, (s : ℕ) ≤ t → L[s] ∣ L[t]) ∧
+      L.prod = ∏ i, q i ∧
+      (∀ c : F[X], (L.getLast?.getD 1 ∣ c) ↔ ∀ i, q i ∣ c) := by
+  choose π hirr k hk hq using hpp;
+  -- Define the monic prime base `base i := RCF.monicAssoc (π i)`.
+  set base : ι → F[X] := fun i => RCF.monicAssoc (π i);
+  -- By definition of `base`, we know that `base i` is monic and irreducible.
+  have hbase_monic : ∀ i, (base i).Monic := by
+    exact fun i => monicAssoc_monic ( hirr i |> Irreducible.ne_zero )
+  have hbase_irr : ∀ i, Irreducible (base i) := by
+    intro i;
+    have := RCF.monicAssoc_associated ( show π i ≠ 0 from fun h => by simpa [ h ] using hirr i );
+    exact this.irreducible_iff.mpr ( hirr i )
+  have hbase_pow : ∀ i, q i = base i ^ k i := by
+    intro i
+    simp [base, hq];
+    simp +decide [ monicAssoc ];
+    have := hmon i; simp_all +decide [ Polynomial.Monic.def ] ;
+    rw [ mul_pow, ← Polynomial.C_pow, inv_pow, hmon i, inv_one, Polynomial.C_1, mul_one ];
+  convert exists_chain_aux base k hbase_monic hbase_irr hk Finset.univ using 1;
+  · simp +decide [ ← hbase_pow ];
+  · exact Classical.decEq ι
+
+end RCF
+
+/-- Rational canonical form, existence (strong form): every square matrix `M`
+over a field admits an invariant-factor chain whose product equals `charpoly M`
+and whose last factor equals `minpoly M`. -/
+theorem rational_canonical_form_exists
+    {n : Type*} [Fintype n] [DecidableEq n] (M : Matrix n n F) :
+    ∃ c : InvariantFactorChain F,
+      c.prodFactors = M.charpoly ∧ c.lastFactor = minpoly F M := by
+  obtain ⟨m, q, hmon, _, hpp, hchar, hmin⟩ := RCF.exists_elementary_divisors M
+  obtain ⟨L, hLmon, hLpos, hLchain, hLprod, hLlast⟩ :=
+    RCF.exists_chain_of_prime_powers q hmon hpp
+  refine ⟨⟨L, hLmon, hLpos, hLchain⟩, ?_, ?_⟩
+  · show L.prod = M.charpoly
+    rw [hLprod, hchar]
+  · show L.getLast?.getD 1 = minpoly F M
+    -- both monic, mutually divide via the lcm characterizations
+    have hMint : IsIntegral F M := Algebra.IsIntegral.isIntegral M
+    have hlast_monic : (L.getLast?.getD 1).Monic := by
+      rcases h : L.getLast? with _ | a
+      · simp [monic_one]
+      · simp only [Option.getD_some]
+        exact hLmon a (List.mem_of_mem_getLast? h)
+    have h1 : (L.getLast?.getD 1) ∣ minpoly F M := by
+      rw [hLlast]; intro i; exact (hmin _).mp dvd_rfl i
+    have h2 : minpoly F M ∣ (L.getLast?.getD 1) := by
+      rw [hmin]; intro i; exact (hLlast _).mp dvd_rfl i
+    exact Polynomial.eq_of_monic_of_associated hlast_monic (minpoly.monic hMint)
+      (associated_of_dvd_dvd h1 h2)
+
+end RationalCanonicalFormExists

--- a/research/problems/minpoly-charpoly-oq-03-oq-01/state.md
+++ b/research/problems/minpoly-charpoly-oq-03-oq-01/state.md
@@ -1,33 +1,24 @@
 # Current State
 
-**Phase**: ACT (torsion deliverables BUILD-VERIFIED; RCF bridge delegated to Aristotle — job CONFIRMED RUNNING)
-**Since**: 2026-06-19 (researcher-7 S5 — build repair + verification of the two torsion proofs)
-**Iteration**: 5
+**Phase**: COMPLETE — all four deliverables proved, BUILD-VERIFIED, and axiom-free.
+**Since**: 2026-06-20 (researcher-1 S6 — Aristotle bridge integrated, last sorry discharged)
+**Iteration**: 6
 
-## Active Aristotle job
+## Resolution
 
-- **project d2395b8d-2153-48fd-823f-e267f93ec5d7** — `rational_canonical_form_exists`
-  (the underlying content of this file's lone bridge sorry), submitted async
-  2026-06-19 as a self-contained Mathlib-only snippet. **CONFIRMED RUNNING at
-  ~17% as of S4 (2026-06-19), actively exploring Mathlib `AEval` /
-  `AnnihilatingPolynomial`.** Do NOT re-submit — the job is live and progressing.
+The Aristotle job **d2395b8d** for `rational_canonical_form_exists` COMPLETED
+(task `5bec9f0a`). Its proof was integrated verbatim into a new companion file
+`proofs/Proofs/RationalCanonicalFormExists.lean` (523 lines, 19 theorems/lemmas,
+0 sorry, 0 axiom), and the file's lone bridge sorry
+(`xModule_has_invariantFactorChain`) was discharged by a one-line field copy.
 
-  **IMPORTANT — poll with the CLI, NOT the status script:** in S4 both
-  `./research/scripts/aristotle-status.sh` AND the `mcp__aristotle__*` tools
-  returned a FALSE `NOT_FOUND` / "Resource not found" for this (and every) job,
-  while `uvx --from aristotlelib aristotle list` / `... show <id>` correctly
-  showed it RUNNING. The status-script's NOT_FOUND is a false negative this
-  session; trust the CLI:
-
-  ```
-  uvx --from aristotlelib aristotle show d2395b8d-2153-48fd-823f-e267f93ec5d7
-  uvx --from aristotlelib aristotle download --project-id d2395b8d-... # on COMPLETE
-  ```
-
-  On success, integrate into `MinpolyCharpolyOQ03.lean:232` and derive
-  `xModule_has_invariantFactorChain` via a ~5-line glue. Modest odds (regrouping
-  is ~290 LOC of bookkeeping Aristotle is unlikely to synthesize), but the job is
-  free background work — let it run to a verdict.
+Build-verified: `docker-build.sh Proofs.MinpolyCharpolyOQ03OQ01` → 7746 jobs,
+**0 sorry** in this file and its companion (the only `sorry` warning in the
+build is the unrelated parent `MinpolyCharpolyOQ03.lean:228`). `#print axioms`
+on both `xModule_has_invariantFactorChain` and `rational_canonical_form_exists`
+reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no
+`Lean.ofReduceBool`/native_decide, no added axioms. Gallery entry promoted to
+status `verified` / badge `verified`.
 
 ## Current Focus
 
@@ -48,8 +39,9 @@ Deliverables (current status):
 * `xModule_isTorsion` — deliverable consumed by OQ-03-OQ-02.
   **Proved & build-verified** (S5) from the above + `charpoly_monic ⇒
   nonZeroDivisor`, with an explicit `show (M.charpoly : F[X]) • _ = 0`.
-* `xModule_has_invariantFactorChain` — bridge to parent's main theorem.
-  **Sorry** (deliberately deferred to OQ-03-OQ-02; Aristotle job above).
+* `xModule_has_invariantFactorChain` — bridge to parent's strong form
+  (`∃ chain, prod = charpoly ∧ lastFactor = minpoly`). **Proved &
+  build-verified** (S6) via the companion `rational_canonical_form_exists`.
 
 ## Active Approach
 
@@ -83,28 +75,35 @@ synonym) is now in place and build-verified.
 
 ## Next Action
 
-1. **(DONE, S5)** Build-verified; both torsion proofs are now genuinely
-   machine-checked. `meta.json` already reflects 1 sorry / status
-   `formalized` / badge `wip`, which remains correct.
+This sub-OQ is **COMPLETE**. Follow-on work lives in sibling sub-OQs:
 
-2. **Poll the Aristotle job** `d2395b8d` via the CLI (see above). On
-   COMPLETE, `download` and integrate `rational_canonical_form_exists`
-   into `MinpolyCharpolyOQ03.lean:232`, then derive the bridge.
-
-3. **OQ-03-OQ-02 SCAFFOLD** — start the next sub-OQ:
-   `MinpolyCharpolyOQ03OQ02.lean` (~300 lines) applies
-   `Module.equiv_directSum_of_isTorsion` to extract the invariant-factor
-   decomposition. The two torsion statements it consumes are now proved
-   and build-verified.
+1. **OQ-03-OQ-03** — cyclic-summand ↔ companion-block correspondence
+   (the constructive counterpart to the existential chain).
+2. **OQ-03-OQ-04** — global assembly of the similarity transform.
+3. **Mathlib upstreaming** — `RationalCanonicalFormExists.lean` builds
+   invariant-factor RCF existence from scratch (block-diagonal charpoly
+   multiplicativity, primary decomposition, prime-power regrouping); a
+   cleaned-up version is a candidate for upstream contribution.
 
 ## Attempt Counts
 
-- Total attempts: 5
-- Current approach attempts: 5
-- Approaches tried: 1 (Module.AEval' + auto Module.Finite + Cayley-Hamilton IsTorsion)
+- Total attempts: 6
+- Current approach attempts: 6
+- Approaches tried: 1 (Module.AEval' + auto Module.Finite + Cayley-Hamilton IsTorsion + Aristotle-synthesized RCF companion)
 
 ## Session Log
 
+* **S6 (researcher-1, 2026-06-20)** — RESOLVED. The Aristotle job
+  `d2395b8d` (task `5bec9f0a`) for `rational_canonical_form_exists`
+  completed; integrated its proof verbatim into a new companion file
+  `proofs/Proofs/RationalCanonicalFormExists.lean` (523 lines, axiom-free,
+  0 sorry) and discharged the lone bridge sorry
+  `xModule_has_invariantFactorChain` by a one-line field copy between the
+  two field-identical `InvariantFactorChain` structures. Build-verified
+  (7746 jobs, 0 sorry in this file + companion); `#print axioms` confirms
+  only `propext`/`Classical.choice`/`Quot.sound`. Promoted gallery entry to
+  `verified`/`verified`, updated lineCount (225→258), added the companion as
+  an `additionalFile`, and refreshed stale "sorry-guarded"/"deferred" prose.
 * **S5 (researcher-7, 2026-06-19)** — build repair + verification. Found
   the file build-BROKEN (not "proved, build-pending" as S2 recorded):
   missing `Mathlib.LinearAlgebra.Charpoly.{Basic,ToMatrix}` imports;

--- a/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03-oq-01/meta.json
@@ -1,13 +1,13 @@
 {
   "id": "minpoly-charpoly-oq-03-oq-01",
-  "title": "F[X]-Module Structure on K^n via Matrix Action (S1 Scaffold)",
+  "title": "F[X]-Module Structure on K^n via Matrix Action (Rational Canonical Form, Sub-OQ-01)",
   "slug": "minpoly-charpoly-oq-03-oq-01",
-  "description": "S1 OBSERVE/ACT scaffold for the first of four sub-OQs decomposing the rational canonical form (parent: minpoly-charpoly-oq-03). Packages K^n as an F[X]-module via M.mulVecLin using Mathlib's Module.AEval' synonym; the Module.Finite instance is unconditional (no sorry), the Cayley–Hamilton annihilation lemma `xModule_isTorsionBy_charpoly` is fully discharged (S8, PR #18507), and `xModule_isTorsion` is fully discharged (S10, PR #18583). Only the OQ-03-OQ-02 deliverable surface `xModule_has_invariantFactorChain` remains sorry-guarded (1 sorry).",
+  "description": "Sub-OQ-01 of four decomposing the rational canonical form (parent: minpoly-charpoly-oq-03), now fully discharged. Packages K^n as an F[X]-module via M.mulVecLin using Mathlib's Module.AEval' synonym; the Module.Finite instance is unconditional, the Cayley–Hamilton annihilation lemma `xModule_isTorsionBy_charpoly` (S8, PR #18507) and `xModule_isTorsion` (S10, PR #18583) are discharged, and the bridge `xModule_has_invariantFactorChain` is now proved (S15) by importing the companion file `RationalCanonicalFormExists.lean`, whose theorem `rational_canonical_form_exists` builds the full invariant-factor RCF existence theory from scratch (Aristotle-synthesized, axiom-free). Build-verified sorry-free and axiom-free (only propext/Classical.choice/Quot.sound).",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Polynomial/Module/AEval.html",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/MinpolyCharpolyOQ03OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -21,11 +21,11 @@
       "rational-canonical-form",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 225,
-    "assumptions": "0 axioms; 1 sorry — `xModule_has_invariantFactorChain` (the OQ-03-OQ-02 deliverable surface, restated here to fix the bridging API). The `xModule_isTorsionBy_charpoly` theorem (Cayley–Hamilton transported via the `Module.AEval'` synonym) is fully discharged in S8 (PR #18507) using `Matrix.charpoly_mulVecLin` + `LinearMap.aeval_self_charpoly` + `Module.AEval.of_symm_smul`. `xModule_isTorsion` is fully discharged in S10 (PR #18583) via `Matrix.charpoly_monic`/`mem_nonZeroDivisors_of_ne_zero` upgrading `IsTorsionBy` to `IsTorsion`. The `Module.Finite F[X]` instance is unconditional (no sorry) — it fires automatically from Mathlib's `Module.AEval.instFinitePolynomial`. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.{Basic,Minpoly}`, `Mathlib.LinearAlgebra.Matrix.ToLin`, `Mathlib.Algebra.Polynomial.Module.AEval`, `Mathlib.Algebra.Module.Torsion.Basic`, `Mathlib.RingTheory.Finiteness.Defs`, `Mathlib.Tactic`, `Proofs.MinpolyCharpolyOQ03`.",
+    "lineCount": 258,
+    "assumptions": "0 axioms, 0 sorries. Build-verified (researcher-1, S15: `docker-build.sh Proofs.MinpolyCharpolyOQ03OQ01`, 7746 jobs); `#print axioms` on both `xModule_has_invariantFactorChain` and the companion `rational_canonical_form_exists` reports only `[propext, Classical.choice, Quot.sound]` (the standard foundational axioms — no `sorryAx`, no `Lean.ofReduceBool`/native_decide, no added `axiom`). The `xModule_isTorsionBy_charpoly` theorem (Cayley–Hamilton transported via the `Module.AEval'` synonym) was discharged in S8 (PR #18507); `xModule_isTorsion` in S10 (PR #18583); and the bridge `xModule_has_invariantFactorChain` in S15 by a one-line field copy from the companion file `Proofs/RationalCanonicalFormExists.lean`, whose `rational_canonical_form_exists` constructs the full invariant-factor RCF existence theory from scratch (not available off-the-shelf in Mathlib). The `Module.Finite F[X]` instance is unconditional — it fires automatically from Mathlib's `Module.AEval.instFinitePolynomial`. The companion proof body was synthesized by the Aristotle proof-search system (project d2395b8d, task 5bec9f0a) against a self-contained Mathlib-only statement, then integrated verbatim.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
     "theoremCount": 3,
@@ -80,8 +80,8 @@
   "overview": {
     "historicalContext": "Viewing K^n as an F[X]-module via the action of a fixed matrix M is the bridge that converts the linear-algebraic problem of matrix similarity into the module-theoretic problem of classifying finitely generated modules over the PID F[X]. The construction is classical: Frobenius (1879) and Weyr (1885) used it implicitly in their derivations of the rational canonical form; modern formal expositions (Dummit & Foote §12.2; Hungerford §VII.4; Lang §III.7) present it as the canonical first step. In Lean 4, Mathlib provides this construction as `Module.AEval' φ`, a type synonym of the F-module M in which a polynomial p acts via aeval φ p.",
     "problemStatement": "**Sub-open question (minpoly-charpoly-oq-03-oq-01)**: Make `n → F` an `F[X]`-module via a matrix `M : Matrix n n F` and show it is (a) finitely generated and (b) torsion over `F[X]`. These two properties are exactly the input hypotheses of Mathlib's `Module.equiv_directSum_of_isTorsion`, the PID structure theorem that OQ-03-OQ-02 will apply.",
-    "text": "**Resolution (S1 OBSERVE/ACT)**: Mathlib's `Module.AEval'` synonym applied to `M.mulVecLin` is the right tool; finite generation is **automatic** (no sorry — Mathlib's `instFinitePolynomial` fires from `Pi.basisFun`'s F-finiteness). Torsion is **stated** here, with the Cayley-Hamilton bridge deferred to a follow-up iteration (one of the three sorries in this scaffold).",
-    "proofStrategy": "**Module.Finite F[X] (xModule M)**: Mathlib's `Module.AEval.instFinitePolynomial` lifts F-finiteness automatically. We expose it as a named instance for downstream use. **No sorry**.\n\n**Module.IsTorsion F[X] (xModule M)** (deferred): proof route is:\n1. `Matrix.aeval_self_charpoly`: `aeval M M.charpoly = 0` (matrix-level Cayley-Hamilton).\n2. `Matrix.toLin'` / `Pi.basisFun` algebra equivalence `Matrix n n F ≃ₐ[F] ((n→F) →ₗ[F] (n→F))` mapping `M ↦ M.mulVecLin`.\n3. Naturality of `aeval` along algebra homomorphisms: `aeval M.mulVecLin M.charpoly = 0` as a LinearMap.\n4. Smul action in `AEval'` is precisely `aeval φ p • v`, so we get `IsTorsionBy F[X] (xModule M) M.charpoly`.\n5. `charpoly_monic` ⇒ `charpoly` nonzero in F[X] ⇒ `charpoly ∈ F[X]⁰` (an integral domain), upgrading `IsTorsionBy` to `IsTorsion`.",
+    "text": "**Resolution (now complete)**: Mathlib's `Module.AEval'` synonym applied to `M.mulVecLin` is the right tool; finite generation is **automatic** (Mathlib's `instFinitePolynomial` fires from `Pi.basisFun`'s F-finiteness), torsion follows from Cayley–Hamilton (S8/S10), and the invariant-factor-chain bridge is discharged (S15) by the companion file `RationalCanonicalFormExists.lean`. The whole entry is build-verified sorry-free and axiom-free.",
+    "proofStrategy": "**Module.Finite F[X] (xModule M)**: Mathlib's `Module.AEval.instFinitePolynomial` lifts F-finiteness automatically. We expose it as a named instance for downstream use. **No sorry**.\n\n**Module.IsTorsion F[X] (xModule M)** (proved, S8/S10): proof route is:\n1. `Matrix.aeval_self_charpoly`: `aeval M M.charpoly = 0` (matrix-level Cayley-Hamilton).\n2. `Matrix.toLin'` / `Pi.basisFun` algebra equivalence `Matrix n n F ≃ₐ[F] ((n→F) →ₗ[F] (n→F))` mapping `M ↦ M.mulVecLin`.\n3. Naturality of `aeval` along algebra homomorphisms: `aeval M.mulVecLin M.charpoly = 0` as a LinearMap.\n4. Smul action in `AEval'` is precisely `aeval φ p • v`, so we get `IsTorsionBy F[X] (xModule M) M.charpoly`.\n5. `charpoly_monic` ⇒ `charpoly` nonzero in F[X] ⇒ `charpoly ∈ F[X]⁰` (an integral domain), upgrading `IsTorsionBy` to `IsTorsion`.",
     "keyInsights": [
       "**Finite generation is free**: Mathlib's `Module.AEval.instFinitePolynomial` automatically lifts F-finiteness (which `Pi.basisFun` provides for `n → F`) to F[X]-finiteness on the AEval' synonym. No work is required in this sub-OQ for the first input hypothesis of the structure theorem.",
       "**Torsion is the substantive content**: the entire mathematical work of OQ-03-OQ-01 is concentrated in `xModule_isTorsion`. Once Cayley-Hamilton is transported across the standard-basis algebra equivalence, the IsTorsion conclusion follows mechanically from charpoly_monic.",
@@ -104,8 +104,8 @@
       "title": "§0: Open Question, Resolution Plan, and Sub-OQ Position",
       "startLine": 1,
       "endLine": 80,
-      "summary": "Imports (Matrix charpoly/minpoly/ToLin, AEval module synonym, Module Torsion, Finiteness, Tactic, parent OQ-03) and top-level docstring stating the sub-OQ-01 position in the four-step decomposition, the S1 scaffold scope (one unconditional instance + three sorry-guarded theorems), and the proof-route sketch for the deferred torsion proof.",
-      "mathContext": "Sub-OQ-01 / 4 of minpoly-charpoly-oq-03 (parent: rational canonical form). Goal: (a) make K^n an F[X]-module via M, (b) show finitely generated, (c) show torsion. (a)+(b) are unconditional; (c) is the substantive Cayley-Hamilton content, sorry-guarded in this scaffold."
+      "summary": "Imports (Matrix charpoly/minpoly/ToLin, AEval module synonym, Module Torsion, Finiteness, Tactic, parent OQ-03, and the companion RationalCanonicalFormExists) and top-level docstring stating the sub-OQ-01 position in the four-step decomposition, the now-complete scope (one unconditional instance + three proved theorems), and the proof routes.",
+      "mathContext": "Sub-OQ-01 / 4 of minpoly-charpoly-oq-03 (parent: rational canonical form). Goal: (a) make K^n an F[X]-module via M, (b) show finitely generated, (c) show torsion, (d) extract the invariant-factor chain. (a)+(b) unconditional; (c) is the Cayley-Hamilton content; (d) is bridged to the companion's full RCF existence theorem. All proved."
     },
     {
       "id": "xmodule-definition",
@@ -125,28 +125,27 @@
     },
     {
       "id": "torsion-statement",
-      "title": "§3: Module.IsTorsion statement (sorry-guarded)",
+      "title": "§3: Module.IsTorsion (proved)",
       "startLine": 124,
       "endLine": 165,
-      "summary": "Two sorry-guarded theorems: `xModule_isTorsionBy_charpoly` (Cayley-Hamilton restated: charpoly M annihilates every element of xModule M) and `xModule_isTorsion` (the deliverable: xModule M is a torsion F[X]-module). The proof route is documented in detail in the file's top docstring; S2+ iterations of this sub-OQ will discharge the sorries.",
+      "summary": "Two proved theorems: `xModule_isTorsionBy_charpoly` (Cayley-Hamilton restated: charpoly M annihilates every element of xModule M, S8) and `xModule_isTorsion` (the deliverable: xModule M is a torsion F[X]-module, S10). The proof route is documented in detail in the file's top docstring.",
       "mathContext": "**Cayley-Hamilton on xModule**: $\\forall v \\in F^n,\\ \\mathrm{charpoly}(M) \\cdot v = 0$ in $\\mathrm{xModule}\\, M$. Equivalently, $\\mathrm{aeval}(\\mathrm{mulVecLin}\\, M)(\\mathrm{charpoly}\\, M) = 0$ as a LinearMap. Combined with $\\mathrm{charpoly}\\, M \\neq 0$ (monic), gives $\\mathrm{IsTorsion}\\, F[X]\\, (\\mathrm{xModule}\\, M)$."
     },
     {
       "id": "bridge-statement",
-      "title": "§4: Bridge to OQ-03-OQ-02 (statement only)",
+      "title": "§4: Bridge to the strong form (proved)",
       "startLine": 167,
-      "endLine": 187,
-      "summary": "Restates the parent's `rational_canonical_form_exists` in terms of this file's `xModule`, exposing `xModule_has_invariantFactorChain` as the OQ-03-OQ-02 deliverable surface. Sorry-guarded; the two formulations are mutually-derivable, and stating both fixes the bridging API between OQ-03-OQ-01 and the parent scaffold.",
+      "endLine": 253,
+      "summary": "Proves `xModule_has_invariantFactorChain`: xModule M admits an invariant-factor chain whose product equals M.charpoly AND whose last factor equals minpoly F M. Discharged by a one-line field copy from the companion `RationalCanonicalFormExists.rational_canonical_form_exists`, the two `InvariantFactorChain` structures being field-identical.",
       "mathContext": "$\\forall M \\in \\mathrm{Mat}_n(F),\\ \\exists\\ \\mathrm{InvariantFactorChain}\\, c,\\ \\prod_i c_i = \\mathrm{charpoly}(M)$ — restated to consume the xModule built in this file."
     }
   ],
   "conclusion": {
-    "summary": "S1 OBSERVE/ACT scaffold for OQ-03-OQ-01 (the first of four sub-OQs decomposing the rational canonical form). Packages K^n as an F[X]-module via Mathlib's AEval' synonym, supplies the Module.Finite instance unconditionally (no sorry), and states the IsTorsion + bridging theorems as sorry-guarded API surfaces for S2+ iterations to discharge. Together with the Module.Finite instance, the (deferred) IsTorsion theorem will form the input hypothesis for Mathlib's PID structure theorem in OQ-03-OQ-02.",
-    "implications": "Locks down the API surface between OQ-03-OQ-01 and OQ-03-OQ-02: the latter can be developed against `xModule.instFinite` and `xModule_isTorsion` without waiting for the Cayley-Hamilton bridge proof. The Module.Finite instance is genuine progress (real proof, no sorry); the IsTorsion theorem is statement-level progress (proof deferred but the surface is final).",
+    "summary": "Complete resolution of OQ-03-OQ-01 (the first of four sub-OQs decomposing the rational canonical form). Packages K^n as an F[X]-module via Mathlib's AEval' synonym, supplies the Module.Finite instance unconditionally, proves IsTorsion via Cayley–Hamilton (S8/S10), and discharges the invariant-factor-chain bridge (S15) using the companion `RationalCanonicalFormExists.lean`. Both the Module.Finite instance and the IsTorsion theorem are the input hypotheses for Mathlib's PID structure theorem, which the companion file applies to build the full RCF existence proof. Build-verified sorry-free and axiom-free.",
+    "implications": "Establishes the F[X]-module foundation and the verified invariant-factor existence statement consumed by OQ-03-OQ-02+. All four theorems (instFinite, isTorsionBy_charpoly, isTorsion, has_invariantFactorChain) are genuine machine-checked results with no remaining sorries or added axioms.",
     "openQuestions": [
-      "**S2 immediate next-action**: discharge `xModule_isTorsionBy_charpoly` by combining `Matrix.aeval_self_charpoly` with the `Matrix.toLin'` / `Pi.basisFun` algebra equivalence. Estimate: ~30-50 lines (the technical core is naturality of `aeval` along an algebra equivalence).",
-      "**S3**: discharge `xModule_isTorsion` from `xModule_isTorsionBy_charpoly` + `charpoly_monic` (charpoly nonzero in F[X] since F is a field). Estimate: ~10-15 lines.",
-      "**S4 (or merge into S3)**: discharge `xModule_has_invariantFactorChain` by combining S3's result with Mathlib's `Module.equiv_directSum_of_isTorsion` — this lands in OQ-03-OQ-02 territory but the statement is restated here for API fixedness."
+      "**OQ-03-OQ-02/03/04 (downstream)**: with the invariant-factor chain now available as a verified existence theorem, the remaining sub-OQs concern the *constructive* similarity transform — the cyclic-summand ↔ companion-block correspondence (OQ-03-OQ-03) and the global assembly of the change-of-basis matrix realizing the rational canonical form (OQ-03-OQ-04).",
+      "**Mathlib upstreaming**: the companion file's `rational_canonical_form_exists` builds invariant-factor RCF existence from scratch (block-diagonal charpoly multiplicativity, primary decomposition, prime-power regrouping). None of this is currently in Mathlib; a cleaned-up version is a candidate for upstream contribution."
     ]
   },
   "leanFile": {
@@ -166,12 +165,24 @@
       "Module"
     ],
     "namespace": "MinpolyCharpolyOQ03OQ01",
-    "lineCount": 225,
+    "lineCount": 258,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 3,
     "path": "Proofs/MinpolyCharpolyOQ03OQ01.lean",
-    "sorries": 1
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/RationalCanonicalFormExists.lean",
+        "namespace": "RationalCanonicalFormExists",
+        "lineCount": 523,
+        "axiomCount": 0,
+        "theoremCount": 19,
+        "definitionCount": 5,
+        "sorries": 0,
+        "description": "Companion file: the strong-form rational canonical form existence theorem `rational_canonical_form_exists` (every square matrix over a field admits an invariant-factor chain whose product is the charpoly and whose last factor is the minpoly), built from scratch (F[X]-module mulX theory, block-diagonal charpoly multiplicativity, primary decomposition via Mathlib's PID structure theorem, and combinatorial regrouping of prime powers into a divisibility chain). Aristotle-synthesized (project d2395b8d, task 5bec9f0a), build-verified sorry-free and axiom-free."
+      }
+    ]
   },
   "crossReferences": [
     {
@@ -219,13 +230,13 @@
     },
     {
       "name": "xModule_has_invariantFactorChain",
-      "type": "supporting",
-      "statement": "∀ (M : Matrix n n F), ∃ c : InvariantFactorChain F, c.prodFactors = M.charpoly",
-      "description": "Restatement of the parent's main theorem in terms of xModule. Sorry-guarded; the two formulations are mutually-derivable, fixing the bridging API between OQ-03-OQ-01 and the parent scaffold.",
-      "significance": "API bridge between this sub-OQ and the parent's rational_canonical_form_exists."
+      "type": "core",
+      "statement": "∀ (M : Matrix n n F), ∃ c : InvariantFactorChain F, c.prodFactors = M.charpoly ∧ c.lastFactor = minpoly F M",
+      "description": "The full bridge to the parent's strong form, now proved (S15): xModule M admits an invariant-factor chain whose product is M.charpoly AND whose last factor is minpoly F M. Discharged by a one-line field copy from the companion `RationalCanonicalFormExists.rational_canonical_form_exists`. The `lastFactor = minpoly` conjunct is load-bearing: without it the existential is vacuously satisfiable by a degenerate single-factor chain, making the bridge strictly weaker than the parent's strong form.",
+      "significance": "Completes the discharge of OQ-03-OQ-01; supplies the verified, axiom-free invariant-factor existence statement consumed by the parent's rational_canonical_form_exists."
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "references": {
     "papers": [
       "Dummit & Foote. *Abstract Algebra* (3rd ed., 2004), §12.2 — K^n as an F[X]-module via M.",


### PR DESCRIPTION
## Summary

Discharges the **last remaining `sorry`** in `minpoly-charpoly-oq-03-oq-01`, promoting the gallery entry from `formalized`/`wip` to **`verified`/`verified`** (sorry-free, axiom-free).

The sub-OQ packages `Kⁿ` as an `F[X]`-module via a matrix `M` and required four deliverables; three (`instFinite`, `isTorsionBy_charpoly`, `isTorsion`) were already proved. This PR closes the fourth — the invariant-factor-chain bridge `xModule_has_invariantFactorChain`.

## What's new

- **New companion file** `proofs/Proofs/RationalCanonicalFormExists.lean` (523 lines, 19 lemmas) proving the strong-form RCF existence theorem `rational_canonical_form_exists`: every square matrix over a field admits an invariant-factor chain (monic, positive-degree, divisibility-ordered) whose product is `charpoly M` and whose last factor is `minpoly F M`. Built from scratch — not available off-the-shelf in Mathlib:
  - `mulX` F[X]-module-action theory + charpoly invariance under F[X]-linear equivalences;
  - block-diagonal determinant/charpoly multiplicativity over finite direct sums;
  - primary decomposition via Mathlib's `Module.equiv_directSum_of_isTorsion`;
  - combinatorial regrouping of prime powers into a divisibility chain (strong induction, peeling off the lcm).
- **Bridge discharged** in `MinpolyCharpolyOQ03OQ01.lean` by a one-line field copy between the two field-identical `InvariantFactorChain` structures.

## Provenance

The companion proof body was synthesized by the **Aristotle** proof-search system (project `d2395b8d`, task `5bec9f0a`) against a self-contained Mathlib-only statement, then integrated verbatim in a namespace.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03OQ01` → **7746 jobs, build succeeded**. The only `sorry` warning in the build is the unrelated parent `MinpolyCharpolyOQ03.lean:228`.
- `#print axioms` on both `xModule_has_invariantFactorChain` and `rational_canonical_form_exists` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`/native_decide, no added `axiom`).

## Gallery metadata

`status` formalized→verified, `badge` wip→verified, `sorries` 1→0, `lineCount` 225→258, companion added as `additionalFile`; stale "sorry-guarded"/"deferred" narrative refreshed to reflect the completed proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)