### PR TITLE
research(fermat-defect-one-oq-03): box-minimal Fermat defect is non-monotone in n

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2368,6 +2368,7 @@ import Proofs.FairGamesTheoremOQ03Aristotle
 import Proofs.FermatDefectOne
 import Proofs.FermatDefectOneFamilies
 import Proofs.FermatDefectOneNegInfinitude
+import Proofs.FermatDefectOneOQ03
 import Proofs.FermatDefectOneOQ04
 import Proofs.FermatTwoSquares
 import Proofs.FermatTwoSquaresOQ01

--- a/proofs/Proofs/FermatDefectOneOQ03.lean
+++ b/proofs/Proofs/FermatDefectOneOQ03.lean
@@ -1,0 +1,169 @@
+/-
+  Fermat Defect-One — OQ-03: does the minimal defect M(n) grow with n?
+
+  Parent problem (`Proofs.FermatDefectOne`): does the Fermat defect
+  $|a^n + b^n - c^n|$ ever equal exactly $1$ for a primitive nontrivial triple
+  $2 \le a \le b < c$, $\gcd(a,b,c) = 1$?  At $n = 3$ both signs are witnessed;
+  for $n \ge 4$ existence is open.  OQ-03 asks the *quantitative* companion
+  question: does the **minimal defect**
+
+  $$M(n) := \min \{\, |a^n + b^n - c^n| \;:\; 2 \le a \le b < c,\ \gcd(a,b,c)=1 \,\}$$
+
+  grow with $n$?  Heuristically yes — the expected number of primitive triples of
+  height $\le X$ with bounded defect scales like $X^{3-n}$, so $n = 3$ is critical
+  (infinitely many defect-one triples) while $n \ge 4$ is convergent.  But the
+  *global* $M(n)$ is out of reach (it bumps into the open existence question and
+  abc/Fermat–Catalan finiteness).
+
+  This file supplies the natural **finite, machine-checkable** handle: the
+  box-restricted minimal defect
+
+  $$m_N(n) := \min \{\, |a^n + b^n - c^n| \;:\; 2 \le a \le b < c \le N \,\}.$$
+
+  The headline finding (all `native_decide`-certified, box $N = 100$):
+
+  | $n$ | $m_{100}(n)$ | achiever | sign |
+  |-----|--------------|----------|------|
+  | 3   | 1            | $(6,8,9)$       | $6^3+8^3+1=9^3$        |
+  | 4   | 46           | $(5,5,6)$       | $5^4+5^4+46=6^4$       |
+  | 5   | 12           | $(13,16,17)$    | $13^5+16^5=17^5+12$    |
+  | 6   | 601          | $(2,2,3)$       | $2^6+2^6+601=3^6$      |
+
+  **The box proxy is non-monotone: $m_{100}(4) = 46 > 12 = m_{100}(5)$.**  The
+  drop at $n = 5$ is caused by the genuinely small primitive near-miss
+  $13^5 + 16^5 = 17^5 + 12$ (gcd$(13,16,17)=1$).  Consequently $M(n)$ growth, if
+  true, is *not* visible in the obvious bounded computation and must be argued
+  globally (abc / Fermat–Catalan), not by exhibiting a monotone finite minimum.
+
+  Each minimum is certified as a *matching pair*: a `native_decide` lower bound
+  (every box triple has defect $\ge K$) together with an explicit achiever
+  (defect exactly $K$), so the box minimum is pinned to the exact value $K$.
+
+  Honesty note: the lower bounds are discharged by `native_decide`, which trusts
+  the compiler's kernel reduction and therefore depends on the `Lean.ofReduceBool`
+  axiom.  These are finite certificates over the box $c \le 100$, not statements
+  about the (open) global $M(n)$.
+-/
+
+import Mathlib
+import Proofs.FermatDefectOne
+
+namespace FermatDefectOne.OQ03
+
+open FermatDefectOne
+
+/-! ## Box-minimal-defect lower bounds (`native_decide` core)
+
+For a triple `2 ≤ a ≤ b < c ≤ 100`, the defect is `|a^n + b^n - c^n|`.  Over
+`Nat` the statement "defect `≥ K`" is the decidable disjunction
+`a^n + b^n + K ≤ c^n ∨ c^n + K ≤ a^n + b^n`.  The bounded `∀` shape
+`∀ c < 101, ∀ b < c, ∀ a < b + 1, 2 ≤ a → …` enumerates exactly the admissible
+triples `2 ≤ a ≤ b < c ≤ 100`. -/
+
+/-- Every box triple `2 ≤ a ≤ b < c ≤ 100` has defect `≥ 46` at exponent `4`. -/
+theorem box_defect_ge_46_n4 :
+    ∀ c < 101, ∀ b < c, ∀ a < b + 1, 2 ≤ a →
+      a ^ 4 + b ^ 4 + 46 ≤ c ^ 4 ∨ c ^ 4 + 46 ≤ a ^ 4 + b ^ 4 := by
+  native_decide
+
+/-- Every box triple `2 ≤ a ≤ b < c ≤ 100` has defect `≥ 12` at exponent `5`. -/
+theorem box_defect_ge_12_n5 :
+    ∀ c < 101, ∀ b < c, ∀ a < b + 1, 2 ≤ a →
+      a ^ 5 + b ^ 5 + 12 ≤ c ^ 5 ∨ c ^ 5 + 12 ≤ a ^ 5 + b ^ 5 := by
+  native_decide
+
+/-- Every box triple `2 ≤ a ≤ b < c ≤ 100` has defect `≥ 601` at exponent `6`. -/
+theorem box_defect_ge_601_n6 :
+    ∀ c < 101, ∀ b < c, ∀ a < b + 1, 2 ≤ a →
+      a ^ 6 + b ^ 6 + 601 ≤ c ^ 6 ∨ c ^ 6 + 601 ≤ a ^ 6 + b ^ 6 := by
+  native_decide
+
+/-! ## Lower bounds in ordered-hypothesis form
+
+Restated with the natural ordering hypotheses up front (no primitivity needed:
+the bound is on the raw defect). -/
+
+/-- `n = 4`: every box triple has `|a^4 + b^4 - c^4| ≥ 46`. -/
+theorem box_min_defect_n4 (a b c : Nat)
+    (ha : 2 ≤ a) (hab : a ≤ b) (hbc : b < c) (hc : c ≤ 100) :
+    a ^ 4 + b ^ 4 + 46 ≤ c ^ 4 ∨ c ^ 4 + 46 ≤ a ^ 4 + b ^ 4 :=
+  box_defect_ge_46_n4 c (by omega) b hbc a (by omega) ha
+
+/-- `n = 5`: every box triple has `|a^5 + b^5 - c^5| ≥ 12`. -/
+theorem box_min_defect_n5 (a b c : Nat)
+    (ha : 2 ≤ a) (hab : a ≤ b) (hbc : b < c) (hc : c ≤ 100) :
+    a ^ 5 + b ^ 5 + 12 ≤ c ^ 5 ∨ c ^ 5 + 12 ≤ a ^ 5 + b ^ 5 :=
+  box_defect_ge_12_n5 c (by omega) b hbc a (by omega) ha
+
+/-- `n = 6`: every box triple has `|a^6 + b^6 - c^6| ≥ 601`. -/
+theorem box_min_defect_n6 (a b c : Nat)
+    (ha : 2 ≤ a) (hab : a ≤ b) (hbc : b < c) (hc : c ≤ 100) :
+    a ^ 6 + b ^ 6 + 601 ≤ c ^ 6 ∨ c ^ 6 + 601 ≤ a ^ 6 + b ^ 6 :=
+  box_defect_ge_601_n6 c (by omega) b hbc a (by omega) ha
+
+/-! ## Achievers (the lower bounds are tight)
+
+Each minimum is realised by an explicit primitive triple in the box, so
+`m₁₀₀(n)` equals the bound above exactly. -/
+
+/-- `n = 4` minimum achieved: `5^4 + 5^4 + 46 = 6^4` (defect exactly `46`,
+negative sign), with `2 ≤ 5 ≤ 5 < 6 ≤ 100` and `gcd(gcd 5 5) 6 = 1`. -/
+theorem achiever_n4 : (5 : Nat) ^ 4 + 5 ^ 4 + 46 = 6 ^ 4 := by norm_num
+
+/-- `n = 5` minimum achieved: `13^5 + 16^5 = 17^5 + 12` (defect exactly `12`,
+positive sign), with `2 ≤ 13 ≤ 16 < 17 ≤ 100` and `gcd(gcd 13 16) 17 = 1`.  This
+small primitive near-miss is what makes the box minimum drop at `n = 5`. -/
+theorem achiever_n5 : (13 : Nat) ^ 5 + 16 ^ 5 = 17 ^ 5 + 12 := by norm_num
+
+/-- `n = 6` minimum achieved: `2^6 + 2^6 + 601 = 3^6` (defect exactly `601`,
+negative sign). -/
+theorem achiever_n6 : (2 : Nat) ^ 6 + 2 ^ 6 + 601 = 3 ^ 6 := by norm_num
+
+/-- The achiever triple `(13, 16, 17)` at `n = 5` is admissible and primitive. -/
+theorem achiever_n5_primitive :
+    2 ≤ 13 ∧ (13 : Nat) ≤ 16 ∧ (16 : Nat) < 17 ∧
+      Nat.gcd (Nat.gcd 13 16) 17 = 1 := by
+  refine ⟨by norm_num, by norm_num, by norm_num, ?_⟩
+  native_decide
+
+/-! ## Headline: the box-minimal defect is non-monotone in `n`
+
+`m₁₀₀(4) = 46` but `m₁₀₀(5) = 12`.  Since `46 > 12`, the bounded minimal defect
+does **not** increase from `n = 4` to `n = 5`.  Any growth of the true global
+`M(n)` is therefore invisible to the finite box proxy and must come from a global
+argument (abc / Fermat–Catalan), not from a monotone finite minimum. -/
+
+/-- **Non-monotonicity of the box-minimal defect.**
+
+Witnessed concretely:
+
+* at `n = 5` there is a primitive box triple of defect exactly `12`
+  (the near-miss `13^5 + 16^5 = 17^5 + 12`), so `m₁₀₀(5) ≤ 12`; while
+* at `n = 4` *every* box triple has defect `≥ 46`, so `m₁₀₀(4) ≥ 46`.
+
+Hence `m₁₀₀(4) ≥ 46 > 12 ≥ m₁₀₀(5)`: the finite minimal defect drops as `n` goes
+from `4` to `5`. -/
+theorem box_min_defect_nonmonotone :
+    (∃ a b c : Nat, 2 ≤ a ∧ a ≤ b ∧ b < c ∧ c ≤ 100 ∧
+        a ^ 5 + b ^ 5 = c ^ 5 + 12) ∧
+    (∀ a b c : Nat, 2 ≤ a → a ≤ b → b < c → c ≤ 100 →
+        a ^ 4 + b ^ 4 + 46 ≤ c ^ 4 ∨ c ^ 4 + 46 ≤ a ^ 4 + b ^ 4) := by
+  refine ⟨⟨13, 16, 17, by norm_num, by norm_num, by norm_num, by norm_num,
+      achiever_n5⟩, ?_⟩
+  intro a b c ha hab hbc hc
+  exact box_min_defect_n4 a b c ha hab hbc hc
+
+/-! ## Contrast with `n = 3`
+
+At `n = 3` the box minimum is `1` — the defect-one witness `(6, 8, 9)` — so the
+sequence of box minima begins `1, 46, 12, 601`.  The `n = 3` value is the only
+`1`; for `n ≥ 4` the box minimum exceeds `1` (cf. `Proofs.FermatDefectOneOQ04`,
+`no_small_witness_*`), but it is *not* monotone thereafter. -/
+
+/-- At `n = 3` the box contains a defect-`1` (i.e. defect-one) primitive witness,
+`(6, 8, 9)`, so `m₁₀₀(3) = 1`. -/
+theorem box_min_defect_n3_is_one :
+    ∃ a b c : Nat, c ≤ 100 ∧ FermatDefectWitness 3 a b c :=
+  ⟨6, 8, 9, by norm_num, fermat_defect_three_neg⟩
+
+end FermatDefectOne.OQ03

--- a/research/problems/fermat-defect-one-oq-03/knowledge.md
+++ b/research/problems/fermat-defect-one-oq-03/knowledge.md
@@ -1,0 +1,76 @@
+# Knowledge Base: fermat-defect-one-oq-03
+
+## Source
+Seeker-selected open question extending **fermat-defect-one**. Companion to
+OQ-04 (verified no-small-witness lower bound). OQ-03 is the *quantitative*
+question.
+
+## Problem
+Does the **minimal Fermat defect**
+`M(n) := min { |aⁿ + bⁿ − cⁿ| : 2 ≤ a ≤ b < c, gcd(a,b,c)=1 }`
+**grow** with `n`? Heuristically yes (critical-exponent count `X^{3−n}`: `n=3`
+log-divergent ⇒ `M(3)=1` with infinitely many achievers, `n≥4` convergent), but
+the global `M(n)` runs straight into the open existence question and
+abc/Fermat–Catalan finiteness, so it is not directly attackable.
+
+## Progress Summary
+
+### S-this-session (researcher-1, 2026-06-19) — box-min defect is NON-MONOTONE
+
+**Finding.** The natural finite handle is the *box-restricted* minimal defect
+`m_N(n) := min { |aⁿ + bⁿ − cⁿ| : 2 ≤ a ≤ b < c ≤ N }`. Exhaustive computation
+for `N = 100` (`verify_box_min_defect.py`) gives the exact minima:
+
+| n | m₁₀₀(n) | unique achiever | identity |
+|---|---------|-----------------|----------|
+| 3 | 1   | (6, 8, 9), (9, 10, 12) | 6³+8³+1 = 9³ |
+| 4 | 46  | (5, 5, 6)    | 5⁴+5⁴+46 = 6⁴ |
+| 5 | 12  | (13, 16, 17) | 13⁵+16⁵ = 17⁵+12 |
+| 6 | 601 | (2, 2, 3)    | 2⁶+2⁶+601 = 3⁶ |
+
+The sequence `1, 46, 12, 601` is **not monotone**: `m₁₀₀(4) = 46 > 12 = m₁₀₀(5)`.
+The dip at `n = 5` is caused by the genuinely small *primitive* near-miss
+`13⁵ + 16⁵ = 17⁵ + 12` (gcd(13,16,17)=1). The minima at `n=4,5,6` are achieved by
+a unique box triple (`n=3` has two, both defect-one); every achiever is primitive.
+
+**Consequence for OQ-03.** Any growth of the true global `M(n)` is **invisible to
+the obvious bounded computation** — the finite proxy actively decreases from
+`n=4` to `n=5`. So `M(n)` growth, if true, cannot be certified by exhibiting a
+monotone finite minimum; it must come from a global argument (abc /
+Fermat–Catalan effective finiteness). This reframes OQ-03 away from "compute and
+watch it grow" toward "find the global lever."
+
+### Formalized (Lean, `native_decide`, build-verified)
+`proofs/Proofs/FermatDefectOneOQ03.lean` — each box minimum pinned as a matching
+pair (lower bound + achiever):
+- `box_min_defect_n4` : every box triple has `|a⁴+b⁴−c⁴| ≥ 46`; `achiever_n4`
+  realises `46` at `(5,5,6)`.
+- `box_min_defect_n5` : `≥ 12`; `achiever_n5` realises `12` at `(13,16,17)`,
+  `achiever_n5_primitive` certifies admissibility + gcd = 1.
+- `box_min_defect_n6` : `≥ 601`; `achiever_n6` realises `601` at `(2,2,3)`.
+- `box_min_defect_nonmonotone` : the headline — a primitive box defect of `12` at
+  `n=5` coexists with a uniform `≥ 46` lower bound at `n=4`.
+- `box_min_defect_n3_is_one` : the `n=3` contrast (the defect-one witness (6,8,9)).
+
+Lower bounds discharged by `native_decide` (depends on `Lean.ofReduceBool`);
+finite certificates over `c ≤ 100`, **not** statements about the global `M(n)`.
+
+**Build status (researcher-1, 2026-06-20):** `docker-build.sh
+Proofs.FermatDefectOneOQ03` → 7744 jobs, GREEN, 0 sorry in this file (the only
+`sorry` warning is the unrelated parent headline conjecture
+`FermatDefectOne.lean:280`). Wired into `Proofs.lean`; registered as an
+`additionalFile` under the `fermat-defect-one` gallery entry (axiomatized:
+`native_decide` ⇒ `Lean.ofReduceBool`).
+
+## Relationship to siblings
+- **OQ-04** certifies `m₁₀₀(n) ≥ 2` for `n∈{4,5,6}` (no defect-*one* witness in
+  the box). OQ-03 sharpens this to the *exact* box minima and exposes the
+  non-monotonicity OQ-04's coarse `≥ 2` bound hides.
+- **OQ-02** (existence/infinitude at `n=3`) supplies the critical-exponent
+  heuristic explaining why `m(3)=1` is special.
+
+## Open / next
+- The global `M(n)` growth question remains **open** (conditional on abc).
+- Possible increment: certify exact box minima at larger `N` or `n=7,8` to test
+  whether the non-monotone wobble persists, or formalize the `X^{3−n}` expected
+  count as a heuristic statement (no Mathlib bearer for the analytic estimate).

--- a/research/problems/fermat-defect-one-oq-03/verify_box_min_defect.py
+++ b/research/problems/fermat-defect-one-oq-03/verify_box_min_defect.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""OQ-03: exact box-restricted minimal Fermat defect m_N(n).
+
+m_N(n) = min { |a^n + b^n - c^n| : 2 <= a <= b < c <= N }.
+
+Demonstrates the non-monotone wobble m_100(4)=46 > 12=m_100(5) that motivates
+proofs/Proofs/FermatDefectOneOQ03.lean. Each minimum below c<=100 is unique and
+achieved by a primitive triple (gcd=1).
+"""
+from math import gcd
+
+N = 100
+for n in range(3, 9):
+    best = None
+    achievers = []
+    for c in range(3, N + 1):
+        cn = c ** n
+        for b in range(2, c):
+            bn = b ** n
+            for a in range(2, b + 1):
+                d = abs(a ** n + bn - cn)
+                if best is None or d < best:
+                    best, achievers = d, [(a, b, c)]
+                elif d == best:
+                    achievers.append((a, b, c))
+    prim = all(gcd(gcd(a, b), c) == 1 for (a, b, c) in achievers)
+    print(f"n={n}: m_{N}(n) = {best:>5}  achievers={achievers}  all_primitive={prim}")
+
+print()
+print("Non-monotonicity:  m_100(4) = 46  >  12 = m_100(5)")
+print("  n=4 achiever 5^4+5^4+46 =", 5**4 + 5**4 + 46, "= 6^4 =", 6**4)
+print("  n=5 achiever 13^5+16^5  =", 13**5 + 16**5, "= 17^5+12 =", 17**5 + 12)

--- a/src/data/proofs/fermat-defect-one/meta.json
+++ b/src/data/proofs/fermat-defect-one/meta.json
@@ -69,6 +69,7 @@
       "defect_pos_witnesses_infinite (FermatDefectOneFamilies.lean): the positive-defect family (9s^3+1, 9s^4, 9s^4+3s) gives infinitely many primitive witnesses at n=3 (set of attainable c is infinite, via a strictly-monotone injection)",
       "defect_neg_witnesses_infinite (FermatDefectOneNegInfinitude.lean): the negative-defect family (9t^3-1, 9t^4-3t, 9t^4) gives infinitely many primitive witnesses at n=3, closing the sign symmetry — both signs occur infinitely often at n=3",
       "no_small_witness_4/5/6 and no_defect_one_eqn_below_4/5/6 (FermatDefectOneOQ04.lean): a verified no-small-witness lower bound M(n) ≥ 2 inside the box c ≤ 100 for n ∈ {4,5,6}, both signs, via native_decide — strengthening the parent's sorry'd no_witness_n_eq_4_below_20 (c ≤ 20, n=4) to c ≤ 100 across n ∈ {4,5,6}; stated without a gcd hypothesis since defect one forces primitivity, with defect_one_three_in_box exhibiting (6,8,9) at n=3 to show the n ≥ 4 vanishing is an exponent effect",
+      "box_min_defect_nonmonotone and box_min_defect_n4/n5/n6 + achiever_n4/n5/n6 (FermatDefectOneOQ03.lean): the box-restricted minimal defect m₁₀₀(n) computed exactly for n in {3,4,5,6} as 1, 46, 12, 601 (matching native_decide lower bounds + explicit achievers), proving the box proxy is NON-MONOTONE (m₁₀₀(4)=46 > 12=m₁₀₀(5), via the near-miss 13^5+16^5=17^5+12) — so any growth of the global M(n) cannot be exhibited via a monotone finite minimum and must be argued globally (abc / Fermat–Catalan)",
       "fermat_defect_one_exists: headline open conjecture stated as a sorry'd target for all n ≥ 3"
     ]
   },
@@ -290,6 +291,15 @@
         "axioms": 0,
         "sorries": 0,
         "description": "OQ-04 — a verified no-small-witness lower bound on the minimal defect M(n). For each n in {4,5,6}, NO triple 2 ≤ a ≤ b < c ≤ 100 has defect one in either sign (a^n+b^n+1=c^n or a^n+b^n=c^n+1), so M(n) ≥ 2 inside the box (no_defect_one_eqn_below_4/5/6). Restated without a gcd hypothesis (no_small_defect_one_4/5/6) — defect one forces primitivity (d^n | 1 ⇒ d=1) — and specialized to the parent predicate (no_small_witness_4/5/6: no FermatDefectWitness n a b c with c ≤ 100). defect_one_three_in_box exhibits (6,8,9) at n=3 inside the same box, showing the vanishing for n ≥ 4 is an exponent effect, not a bound artifact. Strengthens the parent's sorry'd no_witness_n_eq_4_below_20 (c ≤ 20, n=4) to c ≤ 100 across n in {4,5,6}. 10 theorems, 0 axioms, 0 sorries; the three headline non-existence theorems are discharged by native_decide (Nat.decidableBallLT enumeration), which introduces Lean.ofReduceBool. Namespace FermatDefectOne.OQ04; imports parent Proofs.FermatDefectOne."
+      },
+      {
+        "path": "Proofs/FermatDefectOneOQ03.lean",
+        "lineCount": 169,
+        "theorems": 12,
+        "definitions": 0,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "OQ-03 — does the minimal defect M(n) grow with n? Supplies the finite, machine-checkable proxy m_N(n) := min{|a^n+b^n-c^n| : 2 ≤ a ≤ b < c ≤ N} and computes it exactly over the box N=100 for n in {3,4,5,6}: m₁₀₀ = 1, 46, 12, 601 (each pinned as a matching pair — a native_decide lower bound 'every box triple has defect ≥ K' together with an explicit achiever of defect exactly K). Headline result box_min_defect_nonmonotone: the box proxy is NON-MONOTONE, m₁₀₀(4) = 46 > 12 = m₁₀₀(5), driven by the genuinely small primitive near-miss 13^5 + 16^5 = 17^5 + 12 (gcd(13,16,17)=1, achiever_n5). Consequence: growth of the true global M(n), if it holds, is invisible to the obvious bounded computation and must be argued globally (abc / Fermat–Catalan), not by exhibiting a monotone finite minimum. 12 theorems, 0 axioms, 0 sorries; the three box lower bounds and the primitivity check are discharged by native_decide (bounded ∀ enumeration), which introduces Lean.ofReduceBool. Namespace FermatDefectOne.OQ03; imports parent Proofs.FermatDefectOne."
       }
     ]
   },


### PR DESCRIPTION
## Summary

Adds `Proofs/FermatDefectOneOQ03.lean` (169 lines, 12 theorems, **0 sorry**), the OQ-03 companion to the `fermat-defect-one` gallery entry.

**OQ-03** asks: does the minimal Fermat defect `M(n) := min |aⁿ+bⁿ−cⁿ|` (over primitive `2 ≤ a ≤ b < c`) grow with `n`? The global `M(n)` is out of reach (open existence question + abc / Fermat–Catalan finiteness), so this file supplies the finite, machine-checkable proxy `m_N(n) := min` over the box `2 ≤ a ≤ b < c ≤ N`.

## Headline finding

Computed exactly over the box `N = 100`:

| n | m₁₀₀(n) | achiever | identity |
|---|---------|----------|----------|
| 3 | 1   | (6,8,9)    | 6³+8³+1 = 9³ |
| 4 | 46  | (5,5,6)    | 5⁴+5⁴+46 = 6⁴ |
| 5 | 12  | (13,16,17) | 13⁵+16⁵ = 17⁵+12 |
| 6 | 601 | (2,2,3)    | 2⁶+2⁶+601 = 3⁶ |

**The proxy is non-monotone: `m₁₀₀(4) = 46 > 12 = m₁₀₀(5)`**, driven by the genuinely small primitive near-miss `13⁵ + 16⁵ = 17⁵ + 12` (gcd = 1). Consequence: any growth of the true global `M(n)`, if it holds, is **invisible to the obvious bounded computation** and must be argued globally (abc / Fermat–Catalan), not by exhibiting a monotone finite minimum. This reframes OQ-03 away from "compute and watch it grow."

Each box minimum is pinned as a **matching pair**: a `native_decide` lower bound (every box triple has defect `≥ K`) plus an explicit achiever (defect exactly `K`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.FermatDefectOneOQ03` → **7744 jobs, build succeeded, 0 sorry** in this file. (The only `sorry` warning in the build is the unrelated parent headline conjecture `FermatDefectOne.lean:280`.)
- Wired into `Proofs.lean`; registered as an `additionalFile` under the `fermat-defect-one` gallery entry.

## Axiom status (per project policy)

**Axiomatized.** The box lower bounds and the primitivity check use `native_decide`, which trusts the compiler's kernel reduction and so depends on `Lean.ofReduceBool`. There are 0 literal `axiom` declarations; these are finite certificates over `c ≤ 100`, **not** statements about the open global `M(n)`. The file carries an explicit honesty note to this effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)