### PR TITLE
research(stirling-formula-oq-01): make Aristotle companion sorry-free (3→0)

### DIFF
--- a/proofs/Proofs/StirlingExpansionAristotle.lean
+++ b/proofs/Proofs/StirlingExpansionAristotle.lean
@@ -3,18 +3,22 @@
   Higher-order Stirling expansion terms for automated proof search.
   See StirlingExpansion.lean for the main formalization.
 
+  Status: all three targets below are now discharged.
+  - `stirling_step_formula` is proved here directly (self-contained log arithmetic).
+  - `stirling_first_correction` and `stirling_two_term_expansion` are the public
+    results established in `Proofs.StirlingExpansion`; here we re-expose them so the
+    companion file is sorry-free and the named targets resolve to machine-checked proofs.
+
   Criteria for inclusion:
   - Well-known asymptotic analysis results
   - Stirling first correction and two-term expansion
   - Clean theorem statements with no definition sorries
   - No axioms, no open conjectures
 -/
-import Mathlib.Analysis.SpecialFunctions.Stirling
-import Mathlib.Analysis.Asymptotics.Defs
-import Mathlib.Data.Real.Basic
+import Proofs.StirlingExpansion
 import Mathlib.Tactic
 
-namespace StirlingExpansion
+namespace StirlingExpansionAristotle
 
 open Stirling Real Filter
 
@@ -31,21 +35,80 @@ open Stirling Real Filter
 theorem stirling_step_formula (k : ℕ) (hk : 1 ≤ k) :
     Real.log (stirlingSeq k) - Real.log (stirlingSeq (k + 1)) =
     ((k : ℝ) + 1 / 2) * Real.log (1 + 1 / (k : ℝ)) - 1 := by
-  sorry
+  have hk_pos : (0 : ℝ) < k := Nat.cast_pos.mpr (by omega)
+  have hk1_pos : (0 : ℝ) < (k : ℝ) + 1 := by linarith
+  have hk_ne : (k : ℝ) ≠ 0 := hk_pos.ne'
+  have hk1_ne : (k : ℝ) + 1 ≠ 0 := hk1_pos.ne'
+  have hsqrt_k : 0 < Real.sqrt (2 * (k : ℝ)) := Real.sqrt_pos.mpr (by positivity)
+  have hsqrt_k1 : 0 < Real.sqrt (2 * ((k : ℝ) + 1)) := Real.sqrt_pos.mpr (by positivity)
+  have hpow_k : 0 < ((k : ℝ) / Real.exp 1) ^ k :=
+    pow_pos (div_pos hk_pos (Real.exp_pos 1)) k
+  have hpow_k1 : 0 < (((k : ℝ) + 1) / Real.exp 1) ^ (k + 1) :=
+    pow_pos (div_pos hk1_pos (Real.exp_pos 1)) (k + 1)
+  -- log(stirlingSeq k) = log(k!) - (1/2)·log(2k) - k·(log k - 1)
+  have hlog_k : Real.log (stirlingSeq k) =
+      Real.log (k.factorial : ℝ) - (1/2 : ℝ) * Real.log (2 * (k : ℝ)) -
+      (k : ℝ) * (Real.log (k : ℝ) - 1) := by
+    rw [show stirlingSeq k = (k.factorial : ℝ) /
+          (Real.sqrt (2 * ↑k) * (↑k / Real.exp 1) ^ k) from rfl]
+    rw [Real.log_div (Nat.cast_pos.mpr (Nat.factorial_pos k)).ne'
+                     (mul_pos hsqrt_k hpow_k).ne']
+    rw [Real.log_mul hsqrt_k.ne' hpow_k.ne']
+    rw [Real.log_sqrt (by positivity : (0 : ℝ) ≤ 2 * ↑k)]
+    rw [Real.log_pow]
+    rw [Real.log_div hk_ne (Real.exp_pos 1).ne']
+    rw [Real.log_exp]
+    push_cast; ring
+  -- log(stirlingSeq(k+1)) = log((k+1)!) - (1/2)·log(2(k+1)) - (k+1)·(log(k+1) - 1)
+  have hlog_k1 : Real.log (stirlingSeq (k + 1)) =
+      Real.log ((k + 1).factorial : ℝ) - (1/2 : ℝ) * Real.log (2 * ((k : ℝ) + 1)) -
+      ((k : ℝ) + 1) * (Real.log ((k : ℝ) + 1) - 1) := by
+    rw [show stirlingSeq (k + 1) = ((k + 1).factorial : ℝ) /
+          (Real.sqrt (2 * ↑(k + 1)) * (↑(k + 1) / Real.exp 1) ^ (k + 1)) from rfl]
+    have h_cast : (↑(k + 1) : ℝ) = (k : ℝ) + 1 := by push_cast; ring
+    rw [h_cast]
+    rw [Real.log_div (Nat.cast_pos.mpr (Nat.factorial_pos (k + 1))).ne'
+                     (mul_pos hsqrt_k1 hpow_k1).ne']
+    rw [Real.log_mul hsqrt_k1.ne' hpow_k1.ne']
+    rw [Real.log_sqrt (by positivity : (0 : ℝ) ≤ 2 * ((k : ℝ) + 1))]
+    rw [Real.log_pow]
+    rw [Real.log_div hk1_ne (Real.exp_pos 1).ne']
+    rw [Real.log_exp]
+    push_cast; ring
+  -- log((k+1)!) = log(k!) + log(k+1)
+  have hfact_step : Real.log ((k + 1).factorial : ℝ) =
+      Real.log (k.factorial : ℝ) + Real.log ((k : ℝ) + 1) := by
+    have heq : ((k + 1).factorial : ℝ) = ((k : ℝ) + 1) * (k.factorial : ℝ) := by
+      rw [Nat.factorial_succ]; push_cast; ring
+    rw [heq, Real.log_mul hk1_ne (Nat.cast_pos.mpr (Nat.factorial_pos k)).ne']
+    ring
+  -- log(1 + 1/k) = log(k+1) - log(k)
+  have hlog_rhs : Real.log (1 + 1 / (k : ℝ)) = Real.log ((k : ℝ) + 1) - Real.log (k : ℝ) := by
+    rw [show (1 : ℝ) + 1 / (k : ℝ) = ((k : ℝ) + 1) / (k : ℝ) by field_simp]
+    rw [Real.log_div hk1_ne hk_ne]
+  -- log(2k) = log 2 + log k,  log(2(k+1)) = log 2 + log(k+1)
+  have hlog_2k : Real.log (2 * (k : ℝ)) = Real.log 2 + Real.log (k : ℝ) :=
+    Real.log_mul (by norm_num) hk_ne
+  have hlog_2k1 : Real.log (2 * ((k : ℝ) + 1)) = Real.log 2 + Real.log ((k : ℝ) + 1) :=
+    Real.log_mul (by norm_num) hk1_ne
+  rw [hlog_k, hlog_k1, hfact_step, hlog_rhs, hlog_2k, hlog_2k1]
+  push_cast; ring
 
 /-- Stirling's First Correction:
-    stirlingSeq(n)/√π = 1 + 1/(12n) + O(1/n²). -/
+    stirlingSeq(n)/√π = 1 + 1/(12n) + O(1/n²).
+    Machine-checked in `Proofs.StirlingExpansion`. -/
 theorem stirling_first_correction :
     ∃ C > 0, ∀ n : ℕ, 2 ≤ n →
-      |stirlingSeq n / Real.sqrt π - (1 + 1 / (12 * (n : ℝ)))| ≤ C / (n : ℝ) ^ 2 := by
-  sorry
+      |stirlingSeq n / Real.sqrt π - (1 + 1 / (12 * (n : ℝ)))| ≤ C / (n : ℝ) ^ 2 :=
+  StirlingExpansion.stirling_first_correction
 
 /-- Stirling Two-Term Expansion:
-    n! = √(2πn)·(n/e)^n · (1 + 1/(12n) + O(1/n²)). -/
+    n! = √(2πn)·(n/e)^n · (1 + 1/(12n) + O(1/n²)).
+    Machine-checked in `Proofs.StirlingExpansion`. -/
 theorem stirling_two_term_expansion :
     ∃ C > 0, ∀ n : ℕ, 2 ≤ n →
       |(n.factorial : ℝ) / (Real.sqrt (2 * π * n) * ((n : ℝ) / Real.exp 1) ^ n) -
-        (1 + 1 / (12 * (n : ℝ)))| ≤ C / (n : ℝ) ^ 2 := by
-  sorry
+        (1 + 1 / (12 * (n : ℝ)))| ≤ C / (n : ℝ) ^ 2 :=
+  StirlingExpansion.stirling_two_term_expansion
 
-end StirlingExpansion
+end StirlingExpansionAristotle


### PR DESCRIPTION
## Summary

Discharges all three `sorry` targets in `StirlingExpansionAristotle.lean`, the Aristotle companion (`additionalFile`) of the verified `stirling-formula-oq-01` entry. The companion is now fully **sorry-free**.

| Target | How |
|--------|-----|
| `stirling_step_formula` | Proved directly via self-contained log arithmetic (`stirlingSeq` unfold, `Real.log_div/mul/sqrt/pow/exp`, `Nat.factorial_succ`, `push_cast; ring`) |
| `stirling_first_correction` | Re-exposes the public machine-checked result from `Proofs.StirlingExpansion` |
| `stirling_two_term_expansion` | Re-exposes the public machine-checked result from `Proofs.StirlingExpansion` |

`stirling_step_formula` is `private` in the main file, so the companion proves its own self-contained copy; the two correction theorems are public and simply re-exposed with byte-matching signatures.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.StirlingExpansionAristotle` → **Build succeeded (3084 jobs)**
- 0 sorries, 0 axioms, 0 `native_decide` in the companion
- Only benign linter notes (`push_cast does nothing`), matching the existing pattern in the main `StirlingExpansion.lean`

## Impact

No gallery claim changes: the main entry was already `verified`/0-axiom and does not import this companion. This change removes the last 3 Aristotle-staging sorries, so the companion file itself is now self-consistent with its own docstring ("the companion file is sorry-free").

🤖 Generated with [Claude Code](https://claude.com/claude-code)