### PR TITLE
Enrich Infinite-Dimensional Measure Theory: measure-theory cross-references

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03/meta.json
@@ -106,6 +106,16 @@
       "targetId": "lebesgue-measure",
       "relationship": "parent-problem",
       "description": "Extends the Lebesgue measure formalization to the infinite-dimensional setting"
+    },
+    {
+      "targetId": "lebesgue-measure-oq-03-oq-01",
+      "relationship": "extended-by",
+      "description": "No Translation-Invariant Measure in Infinite Dimensions — the **rigorous formalization of this entry's central impossibility claim**. Where this entry surveys *why* Lebesgue measure has no infinite-dimensional analogue and sketches the orthonormal separation heuristic, the child entry proves the precise theorem: on an infinite-dimensional separable Hilbert space there is no nonzero translation-invariant $\\sigma$-finite Borel measure. The mechanism is exactly the orthonormal separation argument referenced here — an infinite orthonormal sequence $\\{e_n\\}$ yields infinitely many disjoint translates of a fixed ball $B(0,r)$ (the balls $B(\\tfrac{r}{2}e_n, \\tfrac{r}{2})$ are pairwise disjoint by $\\|e_n - e_m\\| = \\sqrt2 > 1$), so translation invariance forces each translate to have equal measure while $\\sigma$-finiteness forbids infinitely many disjoint sets of equal positive measure — a contradiction unless the measure is zero."
+    },
+    {
+      "targetId": "lebesgue-measure-oq-05",
+      "relationship": "related",
+      "description": "Radon–Nikodym Theorem for $\\sigma$-finite Measures — the **constructive counterpart** to this entry's impossibility result, both turning on $\\sigma$-finiteness. The obstruction proved here is precisely the *failure* of a $\\sigma$-finite translation-invariant measure in infinite dimensions; Radon–Nikodym shows what structure *survives* once one drops translation invariance and keeps $\\sigma$-finiteness: any $\\mu \\ll \\nu$ between $\\sigma$-finite measures admits a density $d\\mu/d\\nu$. This is exactly the route by which Gaussian/Wiener measures (the replacements named in this entry) are handled — they are not translation-invariant, but the Cameron–Martin theorem describes their behaviour under translation via Radon–Nikodym derivatives, quantifying how far a shifted Gaussian deviates from the original."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `lebesgue-measure-oq-03` — an under-linked entry (1 cross-reference, to the root `lebesgue-measure` only), despite having a direct child entry that proves its central claim.

## What (1 → 3 cross-references)
- **`lebesgue-measure-oq-03-oq-01`** (extended-by) — 'No Translation-Invariant Measure in Infinite Dimensions', the rigorous formalization of this entry's central impossibility claim. The cross-ref spells out the shared orthonormal-separation mechanism ($\|e_n-e_m\|=\sqrt2$ ⟹ infinitely many disjoint equal-measure translates ⟹ contradiction with σ-finiteness).
- **`lebesgue-measure-oq-05`** (related) — Radon–Nikodym for σ-finite measures, the constructive counterpart (same σ-finiteness hinge) and the route to the Gaussian/Wiener replacements via Cameron–Martin.

## Why substantive
The `-oq-03-oq-01` link is a genuine parent→refinement connection that was missing entirely; the Radon–Nikodym link ties the impossibility result to what structure survives. Both descriptions are mathematically specific, not generic pointers.

## Verification
- All 3 cross-ref `targetId`s validated against existing gallery dirs.
- `research:build` ✓ and `tsc -b` ✓ (exit 0). Additive 10-line diff.