### PR TITLE
research(buffons-noodle-oq-02): machine-check Needle→Noodle composition + repair broken Buffon's Needle entry

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -379,6 +379,7 @@ import Proofs.BuffonsNeedleOQ02OQ02
 import Proofs.BuffonsNeedleOQ02OQ03
 import Proofs.BuffonsNoodle
 import Proofs.BuffonsNoodleOQ01
+import Proofs.BuffonsNoodleOQ02
 import Proofs.BurnsideCounting
 import Proofs.BurnsideCountingOQ03
 import Proofs.BurnsideCountingOQ03Aristotle

--- a/proofs/Proofs/BuffonsNeedle.lean
+++ b/proofs/Proofs/BuffonsNeedle.lean
@@ -65,13 +65,13 @@ The needle's position is characterized by two parameters:
 Both parameters are uniformly distributed and independent.
 -/
 
-/-- The length of the needle -/
+-- The length of the needle
 variable (ℓ : ℝ) (hℓ : 0 < ℓ)
 
-/-- The spacing between parallel lines -/
+-- The spacing between parallel lines
 variable (d : ℝ) (hd : 0 < d)
 
-/-- The needle is shorter than the line spacing (short needle case) -/
+-- The needle is shorter than the line spacing (short needle case)
 variable (hℓd : ℓ ≤ d)
 
 /-! ## Part II: The Crossing Condition
@@ -112,13 +112,12 @@ theorem sampleSpace_area : (d / 2) * π = π * d / 2 := by ring
 
 /-- The integral of sin over [0, π] equals 2 -/
 theorem integral_sin_zero_pi : ∫ θ in (0 : ℝ)..π, sin θ = 2 := by
-  rw [integral_sin]
-  simp [cos_zero, cos_pi]
+  rw [integral_sin, cos_zero, cos_pi]
+  norm_num
 
 /-- The area of the crossing region is ℓ -/
 theorem crossingRegion_area : ∫ θ in (0 : ℝ)..π, (ℓ / 2) * sin θ = ℓ := by
-  rw [integral_const_mul]
-  rw [integral_sin_zero_pi]
+  rw [intervalIntegral.integral_const_mul, integral_sin_zero_pi]
   ring
 
 /-! ## Part IV: The Main Theorem
@@ -143,14 +142,12 @@ Therefore P = ℓ / (πd/2) = 2ℓ/(πd)
 theorem buffon_needle_probability :
     ℓ / (π * d / 2) = 2 * ℓ / (π * d) := by
   field_simp
-  ring
 
 /-- The crossing probability in simplified form -/
 theorem buffon_needle_probability' (hπ : π ≠ 0) (hd' : d ≠ 0) :
     (∫ θ in (0 : ℝ)..π, (ℓ / 2) * sin θ) / ((d / 2) * π) = 2 * ℓ / (π * d) := by
   rw [crossingRegion_area ℓ]
   field_simp
-  ring
 
 /-! ## Part V: Connection to π Estimation
 
@@ -172,20 +169,15 @@ almost two centuries.
 theorem pi_from_crossing_probability (p : ℝ) (hp : 0 < p)
     (h_buffon : p = 2 * ℓ / (π * d)) :
     π = 2 * ℓ / (p * d) := by
-  have hπd : π * d ≠ 0 := by
-    apply mul_ne_zero
-    · exact pi_ne_zero
-    · linarith
+  have hπ : (π : ℝ) ≠ 0 := pi_ne_zero
+  have hp0 : p ≠ 0 := hp.ne'
+  -- `d ≠ 0`: otherwise `h_buffon` forces `p = 0`, contradicting `0 < p`.
+  have hd0 : d ≠ 0 := by
+    rintro rfl; rw [mul_zero, div_zero] at h_buffon; exact hp0 h_buffon
   have h1 : p * (π * d) = 2 * ℓ := by
-    rw [h_buffon]
-    field_simp
-    ring
-  have hpd : p * d ≠ 0 := by
-    apply mul_ne_zero
-    · linarith
-    · linarith
-  field_simp at h1 ⊢
-  linarith
+    rw [h_buffon]; field_simp
+  rw [eq_div_iff (mul_ne_zero hp0 hd0)]
+  linear_combination h1
 
 /-! ## Part VI: Numerical Examples
 
@@ -193,18 +185,14 @@ Let's verify the formula with some concrete examples.
 -/
 
 /-- When ℓ = d (needle length equals line spacing), P = 2/π ≈ 0.6366 -/
-theorem buffon_equal_length (h : ℓ = d) (hπ : π ≠ 0) :
+theorem buffon_equal_length (h : ℓ = d) (hπ : π ≠ 0) (hd' : d ≠ 0) :
     2 * ℓ / (π * d) = 2 / π := by
-  rw [h]
-  field_simp
-  ring
+  rw [h, div_eq_div_iff (mul_ne_zero hπ hd') hπ]; ring
 
 /-- When ℓ = d/2 (needle half the spacing), P = 1/π ≈ 0.3183 -/
 theorem buffon_half_length (h : ℓ = d / 2) (hπ : π ≠ 0) (hd' : d ≠ 0) :
     2 * ℓ / (π * d) = 1 / π := by
-  rw [h]
-  field_simp
-  ring
+  rw [h, div_eq_div_iff (mul_ne_zero hπ hd') hπ]; ring
 
 /-! ## Part VII: The Long Needle Case
 

--- a/proofs/Proofs/BuffonsNoodleOQ02.lean
+++ b/proofs/Proofs/BuffonsNoodleOQ02.lean
@@ -1,0 +1,101 @@
+import Proofs.BuffonsNeedle
+import Proofs.BuffonsNoodle
+import Mathlib.Tactic
+
+/-
+# Buffon's Noodle, OQ-02: the Needle → Noodle composition, axiom-free
+
+## What this file establishes
+
+The `buffons-noodle` gallery entry states the polygonal noodle theorem
+
+  `BuffonsNoodle.buffon_noodle_polygon : N.expectedCrossings d = 2 * N.totalLength / (π * d)`
+
+where the per-segment crossing probability is packaged as
+
+  `BuffonsNoodle.segmentCrossingProb ℓ d := 2 * ℓ / (π * d)`.
+
+The OQ-02 problem statement framed `segmentCrossingProb` as a *definitional / axiomatized
+input* and asked to "discharge an axiom" by importing Buffon's Needle. The first finding of
+this work is that the premise is inaccurate: `segmentCrossingProb` is a plain `def`, and the
+polygonal noodle theorem is **already proven with zero axioms** (purely by linearity of the
+finite sum). The two `axiom` declarations in `BuffonsNoodle.lean`
+(`smoothExpectedCrossings`, `buffon_noodle_smooth_eq`) belong exclusively to the *smooth*
+curve generalization (Part VI), i.e. the genuine Cauchy–Crofton / kinematic-measure gap;
+they play no role in the polygonal result.
+
+What is genuinely available — and what this file delivers — is the **composition** the
+problem really wanted: showing that the constant `2 * ℓ / (π * d)` used per segment is not a
+free-floating definition but exactly the favorable-area / sample-space-area ratio that the
+Buffon's Needle entry *derives by integration*:
+
+  `BuffonsNeedle.buffon_needle_probability'`
+    : `(∫ θ in 0..π, (ℓ / 2) * sin θ) / ((d / 2) * π) = 2 * ℓ / (π * d)`.
+
+Plugging this into the noodle sum gives the polygonal noodle theorem with every per-segment
+value *derived from the Needle entry* (the integral `∫₀^π (ℓ/2) sin θ = ℓ` is the crossing
+region's area), composing two gallery entries end to end with **0 axioms, 0 sorries** — and
+never touching the smooth-case axioms.
+
+## Status
+
+- [x] `segmentCrossingProb` = Needle entry's machine-derived area ratio (the bridge)
+- [x] Noodle expected crossings = sum of Needle area ratios
+- [x] Polygonal noodle theorem re-expressed through the Needle integral, axiom-free
+- [ ] Smooth case (`smoothExpectedCrossings`, `buffon_noodle_smooth_eq`): still genuinely
+      open — requires Mathlib kinematic-measure / Cauchy–Crofton machinery.
+-/
+
+namespace BuffonsNoodleOQ02
+
+open Real BuffonsNoodle
+
+/-- **The Needle → Noodle bridge.**
+
+The Noodle entry's per-segment crossing-probability constant `segmentCrossingProb ℓ d`
+equals the favorable-to-total area ratio that the Buffon's Needle entry derives by
+integration: the numerator `∫₀^π (ℓ/2) sin θ` is the area of the crossing region
+(`= ℓ`, by `BuffonsNeedle.crossingRegion_area`), and the denominator `(d/2)·π` is the area
+of the `(x, θ)` sample space. So the value plugged into the noodle sum is *derived*, not
+assumed. -/
+theorem segmentCrossingProb_eq_needle_ratio (ℓ d : ℝ) (hd : 0 < d) :
+    segmentCrossingProb ℓ d
+      = (∫ θ in (0 : ℝ)..π, (ℓ / 2) * Real.sin θ) / ((d / 2) * π) := by
+  unfold segmentCrossingProb
+  rw [← BuffonsNeedle.buffon_needle_probability' ℓ d Real.pi_ne_zero hd.ne']
+
+/-- The expected number of crossings of a polygonal noodle is the sum, over its segments, of
+the Buffon's Needle area ratio for each segment — i.e. the noodle's expectation is literally
+a sum of (derived) single-needle crossing probabilities. -/
+theorem expectedCrossings_eq_sum_needle_ratio {n : ℕ}
+    (N : PolygonalNoodle n) (d : ℝ) (hd : 0 < d) :
+    N.expectedCrossings d
+      = ∑ i : Fin n,
+          (∫ θ in (0 : ℝ)..π, (N.segLen i / 2) * Real.sin θ) / ((d / 2) * π) := by
+  unfold PolygonalNoodle.expectedCrossings
+  exact Finset.sum_congr rfl
+    (fun i _ => segmentCrossingProb_eq_needle_ratio (N.segLen i) d hd)
+
+/-- **Buffon's Noodle (polygonal case), via the Needle entry — axiom-free.**
+
+Summing the Buffon's Needle area ratios over the noodle's segments yields `2L/(πd)`, where
+`L = N.totalLength`. Every per-segment value is the Needle entry's integrated crossing
+probability, so the whole chain Needle → Noodle is machine-checked end to end with no axioms
+and no sorries. (Contrast the smooth case, whose `2L/(πd)` law remains an axiom pending
+Cauchy–Crofton machinery.) -/
+theorem buffon_noodle_via_needle {n : ℕ}
+    (N : PolygonalNoodle n) (d : ℝ) (hd : 0 < d) :
+    (∑ i : Fin n,
+        (∫ θ in (0 : ℝ)..π, (N.segLen i / 2) * Real.sin θ) / ((d / 2) * π))
+      = 2 * N.totalLength / (π * d) := by
+  rw [← expectedCrossings_eq_sum_needle_ratio N d hd]
+  exact buffon_noodle_polygon N d hd
+
+/-- A single straight needle, viewed as a one-segment noodle, has expected crossings equal to
+the Buffon's Needle area ratio for its length — the base case of the composition. -/
+theorem single_needle_ratio (ℓ d : ℝ) (hd : 0 < d) :
+    segmentCrossingProb ℓ d
+      = (∫ θ in (0 : ℝ)..π, (ℓ / 2) * Real.sin θ) / ((d / 2) * π) :=
+  segmentCrossingProb_eq_needle_ratio ℓ d hd
+
+end BuffonsNoodleOQ02

--- a/research/problems/buffons-noodle-oq-02/knowledge.md
+++ b/research/problems/buffons-noodle-oq-02/knowledge.md
@@ -1,0 +1,66 @@
+# Knowledge Base: buffons-noodle-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+Goal as stated: eliminate the "axiomatized" per-segment crossing probability
+`segmentCrossingProb = 2ℓ/(πd)` in `BuffonsNoodle.lean` by deriving it from the registered
+Buffon's Needle entry, upgrading the base `buffons-noodle` gallery entry from
+`axiomatized`/`axiom` to `verified`/`original`.
+
+---
+
+## Insights
+
+### 1. The stated premise is inaccurate — the polygonal case is already axiom-free
+`BuffonsNoodle.segmentCrossingProb ℓ d` is a plain `noncomputable def` equal to
+`2 * ℓ / (π * d)`, **not** an `axiom`. The polygonal noodle theorem
+`BuffonsNoodle.buffon_noodle_polygon : N.expectedCrossings d = 2 * N.totalLength / (π * d)`
+is proven purely by linearity of a finite sum — it uses **no axioms**. So there is no
+per-segment axiom to "discharge"; the polygonal result never depended on one.
+
+### 2. The real axioms are the *smooth*-case Cauchy–Crofton primitives
+`BuffonsNoodle.lean` carries exactly two `axiom` declarations, both in Part VI (smooth
+curves):
+- `smoothExpectedCrossings (γ : ℝ → ℝ × ℝ) (a b d : ℝ) : ℝ` — the primitive "expected
+  crossings of a C¹ curve" functional.
+- `buffon_noodle_smooth_eq : smoothExpectedCrossings γ a b d = 2 * planarCurveArcLength γ a b / (π*d)`
+  — the Barbier law for smooth curves.
+These encode the genuine integral-geometry content (kinematic measure on the space of
+lines, plus a polygonal→smooth arc-length approximation of the crossing functional). They
+are independent of the polygonal theorem and are a multi-week Mathlib gap, not a bridge.
+`leanFile.axiomCount = 2` in the base entry reflects these two, not `segmentCrossingProb`.
+
+### 3. The genuine, deliverable composition: Needle → Noodle (axiom-free)
+The Buffon's Needle entry *does* derive the constant by integration:
+`BuffonsNeedle.buffon_needle_probability'`
+  : `(∫ θ in 0..π, (ℓ/2)·sin θ) / ((d/2)·π) = 2ℓ/(πd)`  (for `π ≠ 0`, `d ≠ 0`),
+with `BuffonsNeedle.crossingRegion_area : ∫₀^π (ℓ/2)·sin θ = ℓ` the favorable area and
+`(d/2)·π` the sample-space area. Substituting this into `segmentCrossingProb` and the
+noodle sum makes every per-segment value *derived from the Needle entry* rather than
+asserted, composing the two gallery entries end to end with **0 axioms, 0 sorries**. This
+is what `proofs/Proofs/BuffonsNoodleOQ02.lean` delivers
+(`segmentCrossingProb_eq_needle_ratio`, `expectedCrossings_eq_sum_needle_ratio`,
+`buffon_noodle_via_needle`). It substantiates the problem's real intent without changing
+the base entry's axiom count (those 2 axioms remain, for the smooth case only).
+
+### 4. Convention compatibility checks out
+Both entries use the same short-segment parametrization: angle `θ ∈ [0, π]`, offset
+`x ∈ [0, d/2]`, crossing condition `x ≤ (ℓ/2) sin θ`. No normalization mismatch — the
+Needle area ratio and the Noodle constant are literally the same expression `2ℓ/(πd)`, so
+the bridge is `rw [← buffon_needle_probability']` after `unfold segmentCrossingProb`.
+
+---
+
+## Dead Ends
+
+- **"Discharge the segment axiom to make `buffons-noodle` verified."** There is no such
+  axiom; nothing to discharge in the polygonal case. The base entry's `axiomatized` status
+  (if asserted) would instead be attributable to the smooth-case axioms (#2), which this
+  bridge does not remove.
+- **Cauchy–Crofton route for the per-segment value.** Overkill: the Needle entry already
+  supplies the value by a one-line integral; the Crofton machinery would only be needed for
+  the smooth-curve axioms, which remain genuinely open.

--- a/research/problems/buffons-noodle-oq-02/literature/README.md
+++ b/research/problems/buffons-noodle-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for buffons-noodle-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/buffons-noodle-oq-02/problem.md
+++ b/research/problems/buffons-noodle-oq-02/problem.md
@@ -1,0 +1,135 @@
+# Problem: Make the Polygonal Buffon's Noodle Theorem Axiom-Free
+
+**Slug**: buffons-noodle-oq-02
+**Created**: 2026-06-19T17:27:54-07:00
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+For a polygonal noodle composed of straight segments of lengths $\ell_1, \dots, \ell_k$ dropped on a
+floor ruled with parallel lines distance $d$ apart (segments shorter than $d$), the expected number
+of line crossings is
+
+$$
+\mathbb{E}[\text{crossings}] = \sum_{i=1}^{k} p(\ell_i), \qquad p(\ell) = \frac{2\ell}{\pi d},
+$$
+
+where $p(\ell)$ is the single-segment (Buffon's Needle) crossing probability. The current gallery
+entry takes $p(\ell)$ — `segmentCrossingProb` — as a **definitional/axiomatized input**. The goal is
+to **derive** $p(\ell) = \tfrac{2\ell}{\pi d}$ from the registered measure-theoretic Buffon's Needle
+entry, eliminating the axiom so the polygonal noodle theorem is verified end to end.
+
+### Plain Language
+
+Buffon's Noodle says the expected number of times a dropped curve crosses the floor lines depends
+only on its length, by linearity of expectation over its pieces. The polygonal-case proof already
+establishes the linearity step rigorously, but it *assumes* the per-segment crossing probability
+$2\ell/(\pi d)$ rather than proving it. We want to plug in the existing Buffon's Needle formalization
+so nothing is assumed.
+
+### Why This Matters
+
+The base entry `buffons-noodle` currently carries `status: axiomatized`, `badge: axiom` solely
+because of this one definitional input. Closing this gap upgrades a known, attractive result to a
+fully machine-checked `verified` proof, and demonstrates composition of two gallery entries
+(Needle → Noodle) — a clean integral-geometry pipeline.
+
+## Known Results
+
+### What's Already Proven
+
+- **Polygonal noodle linearity** — `buffons-noodle` gallery entry: expected crossings = sum of
+  per-segment expected crossings (linearity of expectation; no independence needed).
+- **Buffon's Needle** — the registered Buffon's Needle entry provides $p(\ell) = 2\ell/(\pi d)$ for a
+  single short segment (the measure-theoretic crossing probability).
+
+### What's Still Open
+
+- The *bridge*: instantiate the Noodle's abstract `segmentCrossingProb` with the Needle entry's
+  proven probability, discharging the axiom.
+- Confirm the short-segment hypothesis ($\ell_i \le d$) is threaded consistently between the two
+  entries.
+
+### Our Goal
+
+Replace `segmentCrossingProb` with the Buffon's Needle result and re-verify the polygonal noodle
+theorem with **0 axioms, 0 sorries**, updating the base entry's `meta.json` to `verified`/`original`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| buffons-noodle | The entry being completed | linearity of expectation, integral geometry |
+| buffons-needle (registered Needle entry) | Supplies $2\ell/(\pi d)$ to discharge the axiom | measure theory, expected value |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct substitution bridge**: Import the Needle entry, prove `segmentCrossingProb ℓ = 2*ℓ/(π*d)`
+   as a lemma from it, and rewrite the noodle sum.
+   - Why it might work: linearity scaffolding already exists; only the leaf value is axiomatized.
+   - Risk: definitional/normalization mismatch between the two entries' floor parametrizations.
+
+2. **Cauchy–Crofton route**: Derive the per-segment probability via the Cauchy–Crofton arc-length
+   formula already tagged on this problem.
+   - Why it might work: gives length-only dependence intrinsically.
+   - Risk: more Mathlib integral-geometry machinery than currently available.
+
+### Key Difficulties
+
+- Reconciling the angle/offset measure conventions between Needle and Noodle entries.
+- Ensuring the short-segment assumption is identical (so $p(\ell)\le 1$ holds piecewise).
+
+### What Would a Proof Need?
+
+- Key lemma: `segmentCrossingProb ℓ = 2 * ℓ / (π * d)` proven from the Needle entry.
+- Technical requirement: a shared or compatible probability space for "drop a segment".
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The hard analytic content (Needle probability; noodle linearity) is already formalized — this is
+  primarily a composition/bridging task.
+- Risk concentrated in convention-matching, not new mathematics.
+- Mathlib provides the measure-theory and `Real.pi` infrastructure needed.
+
+**Estimated Effort**:
+- Exploration: hours (read both entries, align conventions)
+- If tractable: days
+- If hard: a week if the two entries' probability spaces don't compose cleanly
+
+## References
+
+### Papers
+- J.-A. Barbier (1860) — original noodle/needle length argument.
+
+### Online Resources
+- Buffon's noodle (Wikipedia) — statement and elementary derivation.
+
+### Mathlib
+- `MeasureTheory` / probability — expected value and crossing-probability formalization.
+- `Real.pi`, `Real.sin` — for the $2\ell/(\pi d)$ constant.
+
+## Metadata
+
+```yaml
+tags:
+  - geometric-probability
+  - integral-geometry
+  - buffon
+  - linearity-of-expectation
+  - cauchy-crofton
+  - arc-length
+related_proofs:
+  - buffons-noodle
+  - buffons-needle
+difficulty: medium
+source: proof-suggestion
+created: 2026-06-19T17:27:54-07:00
+```

--- a/research/problems/buffons-noodle-oq-02/state.md
+++ b/research/problems/buffons-noodle-oq-02/state.md
@@ -1,0 +1,55 @@
+# Research State: buffons-noodle-oq-02
+
+## Current State
+**Phase**: DELIVER
+**Path**: full
+**Since**: 2026-06-19T17:27:54-07:00
+**Iteration**: 2
+
+## Current Focus
+Composition lemma shipped; problem premise corrected. See knowledge.md.
+
+## Active Approach
+Approach 1 (Direct substitution bridge) — completed, but reframed: the target was
+*not* an axiom to discharge but a `def` to connect. Delivered the Needle→Noodle
+composition as `proofs/Proofs/BuffonsNoodleOQ02.lean` (0 axioms, 0 sorries).
+
+## Key Finding (premise correction)
+The problem statement asserted `BuffonsNoodle.segmentCrossingProb` is a
+"definitional/axiomatized input" and that the base entry is `axiomatized` *solely*
+because of it. This is inaccurate:
+
+- `segmentCrossingProb ℓ d := 2 * ℓ / (π * d)` is a plain `noncomputable def`, not an
+  `axiom`.
+- The polygonal noodle theorem `BuffonsNoodle.buffon_noodle_polygon` is **already proven
+  with 0 axioms** (pure linearity of a finite sum).
+- The two `axiom` declarations in `BuffonsNoodle.lean` — `smoothExpectedCrossings` and
+  `buffon_noodle_smooth_eq` — belong exclusively to the **smooth** curve generalization
+  (Part VI: Cauchy–Crofton / kinematic measure). They are untouched by the polygonal
+  result, and discharging them is a genuine multi-week Mathlib gap, not a bridging task.
+
+## Delivered
+`proofs/Proofs/BuffonsNoodleOQ02.lean`:
+- `segmentCrossingProb_eq_needle_ratio` — the Noodle per-segment constant equals the
+  Buffon's Needle entry's machine-derived favorable/total area ratio
+  `(∫₀^π (ℓ/2)·sin θ)/((d/2)·π)`.
+- `expectedCrossings_eq_sum_needle_ratio` — noodle expectation = sum of Needle area ratios.
+- `buffon_noodle_via_needle` — polygonal `2L/(πd)` law re-derived through the Needle
+  integral, axiom-free, end to end.
+- `single_needle_ratio` — base case.
+
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Blockers
+Smooth case only: `buffon_noodle_smooth_eq` needs Mathlib kinematic-measure /
+Cauchy–Crofton machinery (the space of lines in ℝ², its kinematic density, and a
+polygonal→smooth arc-length approximation of the crossing functional). Not currently
+available; out of scope for this OQ.
+
+## Next Action
+Ship companion + record; leave the smooth-case axioms as the genuine open residue.
+A follow-up OQ could target `buffon_noodle_smooth_eq` once Mathlib gains integral-geometry
+kinematic measure support.


### PR DESCRIPTION
## Summary

Worked the seeker-vetted pool problem **buffons-noodle-oq-02** ("make the polygonal Buffon's Noodle theorem axiom-free"). The investigation surfaced two things: a premise correction and a genuine gallery-integrity bug, both resolved here. **Build-verified GREEN** via docker (`Proofs.BuffonsNoodleOQ02`, 3084 jobs).

## 1. Premise correction

The problem asserted `BuffonsNoodle.segmentCrossingProb` is an "axiomatized input" and that removing it would upgrade `buffons-noodle` to verified. That's inaccurate:

- `segmentCrossingProb ℓ d := 2 * ℓ / (π * d)` is a plain `noncomputable def`, **not** an axiom.
- `BuffonsNoodle.buffon_noodle_polygon` (the polygonal theorem) is **already proven with 0 axioms** (linearity of a finite sum).
- The two real `axiom` declarations in `BuffonsNoodle.lean` — `smoothExpectedCrossings`, `buffon_noodle_smooth_eq` — belong **only** to the *smooth*-curve (Cauchy–Crofton / kinematic-measure) case. Discharging those is a genuine multi-week Mathlib gap and is out of scope; they are untouched.

## 2. Gallery-integrity repair: `BuffonsNeedle.lean` did not compile

The registered **Buffon's Needle** entry (Wiedijk #99; `meta.json` claims `verified` / `mathlib` / 0 axioms) **failed to build** under the pinned mathlib `v4.26.0`:

- doc-comments `/-- … -/` on `variable` declarations → parse errors;
- `integral_const_mul` → renamed to `intervalIntegral.integral_const_mul`;
- `integral_sin_zero_pi` / `buffon_needle_probability(')` broke on the modern `field_simp` (no-goals-after-simp);
- `buffon_equal_length` was **false as stated** — `2ℓ/(πd) = 2/π` needs `d ≠ 0`, which it lacked.

All repaired with robust, version-stable tactics. Public signatures preserved except `buffon_equal_length`, which now carries the mathematically required `d ≠ 0`. No Lean code depends on the changed theorems. The entry now genuinely compiles (0 sorries, 0 axioms), restoring its claimed status to reality.

## 3. New: `proofs/Proofs/BuffonsNoodleOQ02.lean` (0 axioms, 0 sorries)

Delivers the composition the problem actually wanted — every per-segment value *derived* from the Needle entry rather than assumed:

- `segmentCrossingProb_eq_needle_ratio` — the Noodle constant `2ℓ/(πd)` equals the Needle entry's machine-derived favorable/total area ratio `(∫₀^π (ℓ/2)·sin θ)/((d/2)·π)`.
- `expectedCrossings_eq_sum_needle_ratio` — noodle expectation = sum of Needle area ratios.
- `buffon_noodle_via_needle` — the polygonal `2L/(πd)` law re-expressed through the Needle integral, axiom-free, end to end.
- `single_needle_ratio` — base case.

## Residual open work

The smooth-curve axioms (`buffon_noodle_smooth_eq`) remain — they need Mathlib integral-geometry kinematic-measure support (the space of lines in ℝ² + a polygonal→smooth arc-length approximation of the crossing functional). A natural follow-up OQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)