### PR TITLE
Enrich Smallest Prime > 211 Failing Erdős 1059: family cross-references

### DIFF
--- a/src/data/proofs/erdos-1059-oq-03/meta.json
+++ b/src/data/proofs/erdos-1059-oq-03/meta.json
@@ -101,6 +101,21 @@
       "targetId": "erdos-1059",
       "relationship": "extends",
       "description": "Computational extension of the main Erdős 1059 formalization — this file finds the first prime after 211 that fails the property, complementing the main file's verification that 211 satisfies it"
+    },
+    {
+      "targetId": "erdos-1059-oq-05",
+      "relationship": "supporting",
+      "description": "Decidable Factorial Compositeness Verification — the **decision-procedure infrastructure** this entry's result is built on. This entry certifies that $p = 223$ fails the Erdős 1059 property (because $223 - 4! = 199$ is prime), 'fully verified by decision procedure with 0 sorries'; the supporting entry supplies exactly that machinery — a `Decidable` instance for `AllFactorialSubtractionsComposite` that lets any concrete prime be checked by `decide` without hand-written per-prime factorial-bound lemmas. The general instance there is what makes pointwise verdicts like the one here ($p=223$) routine and axiom-free."
+    },
+    {
+      "targetId": "erdos-1059-oq-01",
+      "relationship": "related",
+      "description": "Density of Factorial-Avoiding Primes — the **statistical question** that individual verdicts like this one feed into. This entry pins a single boundary fact (the smallest prime above 211 that *fails* the all-$p-k!$-composite property is 223); the related entry asks what *fraction* of primes satisfy the property, formalizing the natural-density formulation of Erdős #1059. Concrete failures such as $p=223$ (via $223-4!=199$, prime) are exactly the events the density count must track, so this computational data point is a sample from that distribution."
+    },
+    {
+      "targetId": "erdos-1059-oq-04",
+      "relationship": "related",
+      "description": "Density Conjecture Implies Infinite Witnesses — the **structural payoff** of the density program these checks probe. That entry proves the conditional implication `density_one_conjecture` $\\Rightarrow$ there are infinitely many primes $p$ with every $p - k!$ composite (the full Erdős #1059 statement). This entry contributes a concrete *non*-witness ($p=223$), delimiting where the property fails; together they frame the problem from both ends — the conditional infinitude of witnesses above, and explicit small counterexamples below."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `erdos-1059-oq-03` — an under-linked computational entry (1 cross-reference, to the root `erdos-1059` only) within a substantial Erdős #1059 family.

## What (1 → 4 cross-references)
- **`erdos-1059-oq-05`** (supporting) — the `Decidable` instance for `AllFactorialSubtractionsComposite` that powers this entry's 'verified by decision procedure' result (=223$ fails via -4!=199$ prime).
- **`erdos-1059-oq-01`** (related) — the natural-density question; this entry's concrete non-witness is a data point that the density count tracks.
- **`erdos-1059-oq-04`** (related) — density conjecture ⟹ infinite witnesses; this entry delimits the property from below with an explicit counterexample.

## Why substantive
The `-oq-05` link is the actual infrastructure this entry's proof depends on. All descriptions are mathematically specific (exact factorial arithmetic, density framing).

## Verification
- All 4 cross-ref `targetId`s validated against existing gallery dirs.
- `research:build` ✓ and `tsc -b` ✓ (exit 0). Additive 15-line diff.