### PR TITLE
Enrich Dirichlet's Approximation Theorem: add family cross-references

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem/meta.json
@@ -133,6 +133,26 @@
   },
   "crossReferences": [
     {
+      "targetId": "dirichlet-approximation-theorem-oq-01",
+      "relationship": "extended-by",
+      "description": "Answers this entry's first open question: OQ-01 upgrades the one-shot bound to the infinitude statement — infinitely many coprime p/q with |α − p/q| < 1/q² for irrational α — and recasts it in the classical coprime integer-pair form."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-02",
+      "relationship": "extended-by",
+      "description": "Answers this entry's second open question: OQ-02 is the simultaneous d-dimensional generalization, finding one common denominator q ≤ Q^d that approximates all of θ₁,…,θ_d to within 1/Q at once via a higher-dimensional pigeonhole. The d = 1 case recovers this entry."
+    },
+    {
+      "targetId": "hurwitz-theorem",
+      "relationship": "sharpened-by",
+      "description": "Hurwitz's theorem sharpens the constant in the corollary |α − p/q| < 1/q² proved here to the best-possible 1/(√5 q²), still over infinitely many coprime pairs; the golden ratio shows √5 cannot be improved. This entry supplies the unsharpened existence result Hurwitz refines."
+    },
+    {
+      "targetId": "liouville-theorem",
+      "relationship": "contrasts",
+      "description": "Liouville's theorem runs in the opposite direction: algebraic irrationals of degree n cannot be approximated to order better than n. Combined with the unconditional order-2 approximability established here, it yields explicit transcendental numbers (Liouville numbers approximable to every order)."
+    },
+    {
       "targetId": "dirichlets-theorem",
       "relationship": "related",
       "description": "Dirichlet's theorem on primes in arithmetic progressions — a different, analytic theorem of the same author. Both descend from Dirichlet's methodological innovations, but the approximation theorem is elementary and combinatorial."


### PR DESCRIPTION
## Enrichment pass

The parent entry `dirichlet-approximation-theorem` only cross-linked to `dirichlets-theorem`, even though its three open questions are directly answered or refined by sibling gallery entries. Its OQ children already link *back* to it, but the parent had no forward links to its own family.

Added 4 cross-references (all justified by text already present in the entry):

| Target | Relationship | Why |
|--------|-------------|-----|
| `dirichlet-approximation-theorem-oq-01` | extended-by | Answers OQ1: infinitude upgrade, coprime-pair form |
| `dirichlet-approximation-theorem-oq-02` | extended-by | Answers OQ2: simultaneous d-dimensional generalization |
| `hurwitz-theorem` | sharpened-by | Sharpens 1/q² constant to best-possible 1/(√5 q²) |
| `liouville-theorem` | contrasts | Opposite-direction bound → Liouville transcendence |

All four target entries verified to exist. No claim/status fields touched — cross-reference-only enrichment. `pnpm build` green.