### PR TITLE
research(erdos-divisibility-pigeonhole-oq-01): extremal form — max divisibility-antichain in {1,…,2n} is exactly n

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2326,6 +2326,7 @@ import Proofs.Erdos999Problem
 import Proofs.Erdos99Problem
 import Proofs.Erdos9Problem
 import Proofs.ErdosDivisibilityPigeonhole
+import Proofs.ErdosDivisibilityPigeonholeOQ01
 import Proofs.ErdosKoRado
 import Proofs.ErdosMordellChordIdentity
 import Proofs.ErdosMordellChordReduction

--- a/proofs/Proofs/ErdosDivisibilityPigeonholeOQ01.lean
+++ b/proofs/Proofs/ErdosDivisibilityPigeonholeOQ01.lean
@@ -1,0 +1,118 @@
+/-
+# Erdős Divisibility Pigeonhole — extremal form: the largest divisibility-antichain
+  in `{1, …, 2n}` has size exactly `n`
+
+The parent entry (`Proofs/ErdosDivisibilityPigeonhole.lean`) proves two complementary
+facts about subsets of `{1, …, 2n}`:
+
+* `erdos_divisibility_pigeonhole` — any `n + 1` elements contain a pair `a ∣ b`
+  (`a ≠ b`); and
+* `erdos_divisibility_pigeonhole_sharp` — the block `{n+1, …, 2n}` has `n` elements
+  and **no** such pair.
+
+The first is an upper bound on "how big can a divisibility-free set be?"; the second
+exhibits a set meeting it. This file packages the two into the single **extremal**
+statement they jointly prove:
+
+> The maximum size of a *divisibility-antichain* in `{1, …, 2n}` — a subset no two
+> distinct members of which are related by `∣` — is exactly `n`.
+
+This is the Sperner/Dilworth-flavoured optimum of the pigeonhole gem. A
+divisibility-antichain is precisely an `IsAntichain (· ∣ ·)` set drawn from the
+interval; we keep the explicit `Finset` predicate `IsDivAntichain` here for a clean
+`IsGreatest` statement and record the `IsAntichain` reading in `isDivAntichain_iff`.
+
+## Proof
+
+* **Upper bound** (`antichain_card_le`): a divisibility-antichain `S ⊆ {1, …, 2n}`
+  has `|S| ≤ n`. If instead `|S| ≥ n + 1`, the pigeonhole theorem produces a pair
+  `a ∣ b` inside `S`, contradicting the antichain property.
+* **Attained** (`erdos_divisibility_pigeonhole_sharp`): the block `{n+1, …, 2n}` is a
+  divisibility-antichain of size `n`.
+
+Together these give `IsGreatest` for the achievable antichain sizes
+(`max_antichain_card`).
+
+Axiom-free: the file is built entirely from the parent's verified theorems plus
+foundational Mathlib lemmas (no `sorry`, no `axiom`, no `native_decide`).
+-/
+import Mathlib
+import Proofs.ErdosDivisibilityPigeonhole
+
+namespace ErdosDivisibilityPigeonhole
+
+open Finset
+
+/-- A **divisibility-antichain** in `{1, …, 2n}`: a finite set of integers drawn from
+the interval `{1, …, 2n}` no two distinct members of which are related by divisibility. -/
+def IsDivAntichain (n : ℕ) (S : Finset ℕ) : Prop :=
+  S ⊆ Finset.Icc 1 (2 * n) ∧ ∀ a ∈ S, ∀ b ∈ S, a ≠ b → ¬ a ∣ b
+
+/-- `IsDivAntichain n S` is exactly "`S ⊆ {1, …, 2n}` and `S` is an `IsAntichain` for
+the divisibility relation", connecting the bespoke predicate to Mathlib's general
+order-theoretic notion. -/
+theorem isDivAntichain_iff {n : ℕ} {S : Finset ℕ} :
+    IsDivAntichain n S ↔
+      S ⊆ Finset.Icc 1 (2 * n) ∧ IsAntichain (· ∣ ·) (S : Set ℕ) := by
+  unfold IsDivAntichain
+  refine and_congr_right fun _ => ?_
+  constructor
+  · intro h a ha b hb hab
+    exact h a ha b hb hab
+  · intro h a ha b hb hab
+    exact h ha hb hab
+
+/-- **Upper bound.** A divisibility-antichain in `{1, …, 2n}` has at most `n`
+elements. Were it larger (`|S| ≥ n + 1`), the pigeonhole theorem
+`erdos_divisibility_pigeonhole` would force a pair `a ∣ b` with `a ≠ b`, contradicting
+the antichain hypothesis. -/
+theorem antichain_card_le {n : ℕ} {S : Finset ℕ} (hS : IsDivAntichain n S) :
+    S.card ≤ n := by
+  by_contra h
+  push_neg at h
+  obtain ⟨a, ha, b, hb, hab, hdvd⟩ := erdos_divisibility_pigeonhole hS.1 h
+  exact hS.2 a ha b hb hab hdvd
+
+/-- **Extremal form of the Erdős divisibility pigeonhole.** The maximum size of a
+divisibility-antichain in `{1, …, 2n}` is exactly `n`: the block `{n+1, …, 2n}`
+attains it, and `antichain_card_le` shows nothing larger is possible. -/
+theorem max_antichain_card (n : ℕ) :
+    IsGreatest { k : ℕ | ∃ S : Finset ℕ, IsDivAntichain n S ∧ S.card = k } n := by
+  constructor
+  · -- `n` is achievable, witnessed by the sharp block `{n+1, …, 2n}`.
+    obtain ⟨S, hsub, hcard, hanti⟩ := erdos_divisibility_pigeonhole_sharp n
+    exact ⟨S, ⟨hsub, hanti⟩, hcard⟩
+  · -- `n` is an upper bound for every achievable size.
+    rintro k ⟨S, hS, rfl⟩
+    exact antichain_card_le hS
+
+/-- The extremal value stated for the canonical witness: `{n+1, …, 2n}` is a
+divisibility-antichain of size `n`, so the maximum `n` of `max_antichain_card` is
+genuinely attained by an explicit set. -/
+theorem block_isDivAntichain (n : ℕ) :
+    IsDivAntichain n (Finset.Icc (n + 1) (2 * n)) ∧
+      (Finset.Icc (n + 1) (2 * n)).card = n := by
+  refine ⟨⟨?_, ?_⟩, ?_⟩
+  · intro x hx
+    rw [Finset.mem_Icc] at hx ⊢; omega
+  · intro a ha b hb hab hdvd
+    rw [Finset.mem_Icc] at ha hb
+    have hble : a ≤ b := Nat.le_of_dvd (by omega) hdvd
+    have hlt : a < b := lt_of_le_of_ne hble hab
+    obtain ⟨c, hc⟩ := hdvd
+    have hc2 : 2 ≤ c := by
+      rcases c with _ | _ | c
+      · simp at hc; omega
+      · simp at hc; omega
+      · omega
+    have hba : 2 * a ≤ b := by
+      rw [hc, mul_comm a c]; exact mul_le_mul_right' hc2 a
+    omega
+  · rw [Nat.card_Icc]; omega
+
+-- Axiom audit: confirms the extremal result depends only on the standard
+-- foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms max_antichain_card
+
+end ErdosDivisibilityPigeonhole

--- a/src/data/proofs/erdos-divisibility-pigeonhole-oq-01/annotations.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole-oq-01/annotations.json
@@ -1,0 +1,111 @@
+[
+  {
+    "id": "ann-erdos-div-pigeon-oq01-isdivantichain",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01",
+    "range": {
+      "startLine": 48,
+      "endLine": 49
+    },
+    "type": "definition",
+    "title": "Divisibility-Antichain on the Interval",
+    "content": "IsDivAntichain n S bundles the two conditions defining the objects whose size we are maximizing: S is drawn from {1,…,2n} (S ⊆ Finset.Icc 1 (2*n)) and no two distinct members are related by divisibility (∀ a ∈ S, ∀ b ∈ S, a ≠ b → ¬ a ∣ b). Keeping it as a bespoke Finset predicate — rather than inlining Mathlib's IsAntichain — makes the IsGreatest statement read cleanly; isDivAntichain_iff then certifies the two are the same notion.",
+    "mathContext": "A divisibility-antichain is an antichain of the poset $(\\{1,\\dots,2n\\}, \\mid)$: a set of pairwise incomparable elements under divisibility.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "antichain",
+      "divisibility poset",
+      "Finset.Icc"
+    ],
+    "prerequisites": [
+      "partial orders and antichains",
+      "Finset membership"
+    ]
+  },
+  {
+    "id": "ann-erdos-div-pigeon-oq01-isantichain-bridge",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01",
+    "range": {
+      "startLine": 54,
+      "endLine": 66
+    },
+    "type": "technique",
+    "title": "Identifying the Predicate with Mathlib's IsAntichain",
+    "content": "isDivAntichain_iff proves IsDivAntichain n S ↔ (S ⊆ {1,…,2n} ∧ IsAntichain (· ∣ ·) (S : Set ℕ)). After unfolding IsDivAntichain, the interval-membership conjunct is shared (and_congr_right), and the remaining equivalence is just the definitional unfolding of IsAntichain as Set.Pairwise (fun a b => ¬ a ∣ b) — the Finset and coerced-Set membership are definitionally interchangeable. This places the result inside Mathlib's general antichain theory.",
+    "mathContext": "$\\mathrm{IsAntichain}\\ r\\ s := s.\\mathrm{Pairwise}\\ (\\lambda a\\,b,\\ \\lnot\\, r\\,a\\,b)$. For $r = (\\mid)$ this is exactly the divisibility-antichain condition.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "IsAntichain",
+      "Set.Pairwise",
+      "coercion Finset → Set"
+    ],
+    "prerequisites": [
+      "Mathlib order/antichain API"
+    ]
+  },
+  {
+    "id": "ann-erdos-div-pigeon-oq01-upper-bound",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01",
+    "range": {
+      "startLine": 69,
+      "endLine": 77
+    },
+    "type": "technique",
+    "title": "Upper Bound as a Contrapositive of Pigeonhole",
+    "content": "antichain_card_le turns the parent's pigeonhole theorem into the antichain bound |S| ≤ n. The proof is by_contra: assuming |S| ≥ n+1 (push_neg on ¬ |S| ≤ n), erdos_divisibility_pigeonhole applied to S ⊆ {1,…,2n} produces distinct a, b ∈ S with a ∣ b, which directly contradicts the antichain conjunct hS.2. No new combinatorics — the entire content is the parent theorem transported across the logical equivalence 'every (n+1)-set has a divisible pair' ⟺ 'every antichain has ≤ n elements'.",
+    "mathContext": "If a divisibility-antichain had $\\ge n+1$ elements, the Erdős pigeonhole would force a comparable pair, contradicting antichainness; hence its size is $\\le n$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "contrapositive",
+      "extremal upper bound"
+    ],
+    "prerequisites": [
+      "erdos_divisibility_pigeonhole (parent)"
+    ]
+  },
+  {
+    "id": "ann-erdos-div-pigeon-oq01-isgreatest",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 90
+    },
+    "type": "key-insight",
+    "title": "The Extremal Optimum: IsGreatest = n",
+    "content": "max_antichain_card is the headline: IsGreatest { k | ∃ S, IsDivAntichain n S ∧ S.card = k } n. IsGreatest splits into membership and upper-bound. Membership: instantiate the parent's erdos_divisibility_pigeonhole_sharp, whose explicit witness {n+1,…,2n} is a divisibility-antichain of size n, so n is an achievable size. Upper bound: rintro the achieving set S and apply antichain_card_le. Thus the two one-sided facts of the parent — a bound and a witness — assemble into a single optimality statement: the maximum divisibility-antichain in {1,…,2n} has size exactly n.",
+    "mathContext": "$\\max\\{|S| : S \\text{ a divisibility-antichain in } \\{1,\\dots,2n\\}\\} = n$, the extremal value of the Erdős pigeonhole gem.",
+    "significance": "central",
+    "relatedConcepts": [
+      "IsGreatest",
+      "extremal optimum",
+      "Dilworth/Mirsky"
+    ],
+    "prerequisites": [
+      "IsGreatest / upperBounds",
+      "antichain_card_le",
+      "erdos_divisibility_pigeonhole_sharp (parent)"
+    ]
+  },
+  {
+    "id": "ann-erdos-div-pigeon-oq01-block-witness",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 114
+    },
+    "type": "technique",
+    "title": "The Top Block Attains the Maximum",
+    "content": "block_isDivAntichain certifies the witness explicitly: {n+1,…,2n} is a divisibility-antichain of size n. Membership in {1,…,2n} and the cardinality (Nat.card_Icc gives 2n − (n+1) + 1 = n, closed by omega) are immediate; the antichain property reuses the parent's sharpness argument — a ∣ b with a ≠ b forces b = a·c with c ≥ 2, hence b ≥ 2a ≥ 2(n+1) > 2n, impossible inside the block. This makes the maximum n of max_antichain_card genuinely attained by a concrete set rather than only existentially.",
+    "mathContext": "For $a, b \\in \\{n+1,\\dots,2n\\}$ with $a \\mid b$ and $a \\ne b$: $b \\ge 2a \\ge 2n+2 > 2n$, a contradiction. So the block is divisibility-free and has $n$ elements.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "extremal witness",
+      "Nat.card_Icc",
+      "divisibility bound"
+    ],
+    "prerequisites": [
+      "natural-number arithmetic",
+      "Finset.Icc cardinality"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-divisibility-pigeonhole-oq-01/meta.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole-oq-01/meta.json
@@ -1,0 +1,109 @@
+{
+  "id": "erdos-divisibility-pigeonhole-oq-01",
+  "title": "Erdős Divisibility Pigeonhole — extremal form: the largest divisibility-antichain in {1,…,2n} has size exactly n",
+  "slug": "erdos-divisibility-pigeonhole-oq-01",
+  "description": "The parent entry proves the Erdős divisibility pigeonhole (any n+1 elements of {1,…,2n} contain a pair a ∣ b) and its sharpness (the block {n+1,…,2n} is divisibility-free). This entry packages the two halves into the single extremal statement they jointly prove: the maximum size of a divisibility-antichain in {1,…,2n} — a subset no two distinct members of which are related by divisibility — is exactly n. The upper bound n is the contrapositive of the pigeonhole theorem; the lower bound is the explicit n-element block {n+1,…,2n}. Stated as an IsGreatest, with the bespoke Finset predicate identified with Mathlib's order-theoretic IsAntichain (· ∣ ·). Formalized over Mathlib with zero sorries and zero axioms, built entirely from the parent's verified theorems.",
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Pigeonhole_principle",
+    "date": "folklore",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ErdosDivisibilityPigeonholeOQ01.lean",
+    "tags": [
+      "combinatorics",
+      "number-theory",
+      "pigeonhole-principle",
+      "divisibility",
+      "antichain",
+      "extremal",
+      "erdos"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "IsAntichain",
+        "description": "Mathlib's order-theoretic antichain predicate: IsAntichain r s ↔ s.Pairwise (fun a b => ¬ r a b). Identifying the bespoke Finset predicate IsDivAntichain with IsAntichain (· ∣ ·) (S : Set ℕ) connects the extremal statement to the general theory of antichains in a poset (here {1,…,2n} under divisibility).",
+        "module": "Mathlib.Order.Antichain"
+      },
+      {
+        "theorem": "IsGreatest",
+        "description": "IsGreatest s a means a ∈ s ∧ a ∈ upperBounds s. Used to state that n is exactly the maximum of the set of achievable divisibility-antichain sizes — membership from the sharp block, upper bound from the pigeonhole theorem.",
+        "module": "Mathlib.Order.Bounds.Basic"
+      }
+    ],
+    "originalContributions": [
+      "max_antichain_card: the extremal form of the Erdős divisibility pigeonhole — IsGreatest { k | ∃ S, IsDivAntichain n S ∧ S.card = k } n — packaging the parent's upper bound and sharpness witness into a single optimality statement (the maximum divisibility-antichain in {1,…,2n} has size exactly n).",
+      "antichain_card_le: the clean upper bound |S| ≤ n for any divisibility-antichain S ⊆ {1,…,2n}, derived as the contrapositive of the parent's erdos_divisibility_pigeonhole.",
+      "IsDivAntichain together with isDivAntichain_iff: a reusable Finset predicate for divisibility-antichains in the interval, proved equivalent to Mathlib's IsAntichain (· ∣ ·) — making the Dilworth/Sperner reading of the pigeonhole gem explicit.",
+      "block_isDivAntichain: the explicit witness {n+1,…,2n} is a divisibility-antichain of size n, certifying that the maximum n is genuinely attained."
+    ],
+    "dateAdded": "2026-06-19",
+    "relatedProblems": [
+      {
+        "id": "erdos-divisibility-pigeonhole",
+        "relationship": "Parent. Supplies both ingredients this extremal statement combines: erdos_divisibility_pigeonhole (upper bound) and erdos_divisibility_pigeonhole_sharp (attained lower bound)."
+      },
+      {
+        "id": "dilworth-theorem-oq-01",
+        "relationship": "The maximum-antichain quantity is exactly the Dilworth/Mirsky optimum: {1,…,2n} partitions into n divisibility chains (one per odd part), so the largest antichain has size n."
+      }
+    ],
+    "lineCount": 118,
+    "assumptions": "0 axioms, 0 sorries. Built entirely from the parent file's two verified theorems (erdos_divisibility_pigeonhole and erdos_divisibility_pigeonhole_sharp) plus foundational Mathlib order lemmas (IsAntichain, IsGreatest). The only hypotheses are structural: membership in {1,…,2n} and the antichain property, both part of the statement. Badge is 'original' because the extremal/optimality packaging is formalized from first principles on top of the original parent proof; Mathlib does not contain this application.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Erdős divisibility pigeonhole — popularized by Paul Erdős, who reportedly posed it to the young Lajos Pósa — asks for the maximum size of a subset of {1,…,2n} containing no pair related by divisibility. The pigeonhole argument (classify by odd part; there are exactly n odd parts) shows n+1 elements always force a divisible pair, and the top block {n+1,…,2n} shows n is achievable. The optimal value n is the extremal content of the result, and it coincides with the Dilworth/Mirsky optimum for the divisibility poset on {1,…,2n}, which decomposes into exactly n chains (one chain o, 2o, 4o, … per odd part o ≤ 2n).",
+    "problemStatement": "Let $n \\ge 0$. Call $S \\subseteq \\{1, \\dots, 2n\\}$ a *divisibility-antichain* if no two distinct $a, b \\in S$ satisfy $a \\mid b$. Then $\\max\\{|S| : S \\text{ a divisibility-antichain in } \\{1,\\dots,2n\\}\\} = n$, attained by $\\{n+1, \\dots, 2n\\}$.",
+    "text": "The maximum size of a divisibility-antichain in $\\{1,\\dots,2n\\}$ is exactly $n$. The upper bound $|S| \\le n$ is the contrapositive of the pigeonhole theorem: a set of size $\\ge n+1$ contains a divisible pair, so cannot be an antichain. The block $\\{n+1,\\dots,2n\\}$ attains $n$: any proper multiple of $a \\ge n+1$ exceeds $2n$.",
+    "proofStrategy": "State the maximum as IsGreatest over the set of achievable sizes { k | ∃ S, IsDivAntichain n S ∧ S.card = k }. Membership of n: instantiate the parent's erdos_divisibility_pigeonhole_sharp, whose witness {n+1,…,2n} is a divisibility-antichain of size n. Upper bound: for any achievable size coming from an antichain S, antichain_card_le shows |S| ≤ n by contradiction — if |S| ≥ n+1, erdos_divisibility_pigeonhole produces a pair a ∣ b inside S, contradicting the antichain property. The bridge isDivAntichain_iff records that IsDivAntichain is exactly IsAntichain (· ∣ ·) restricted to the interval.",
+    "keyInsights": [
+      "**Two one-sided facts become one optimum**: the parent's pigeonhole bound (no antichain of size n+1) and its sharpness witness (an antichain of size n) are precisely the upper bound and the attainment needed for IsGreatest. The extremal value n is what the gem is really about.",
+      "**The upper bound is a pure contrapositive**: 'every (n+1)-set has a divisible pair' is logically identical to 'every divisibility-antichain has ≤ n elements'. antichain_card_le is the one-line transport of erdos_divisibility_pigeonhole across this equivalence.",
+      "**It is the divisibility poset's Dilworth optimum**: {1,…,2n} splits into n chains (o, 2o, 4o, … for each odd o ≤ 2n), so the largest antichain has size n. The pigeonhole 'n+1 elements share a chain' is exactly Dilworth/Mirsky for this poset, and the extremal value n is the number of chains.",
+      "**Order-theoretic packaging**: identifying the bespoke IsDivAntichain with Mathlib's IsAntichain (· ∣ ·) (isDivAntichain_iff) places the result inside the general theory of antichains, making it reusable and the Sperner-flavoured reading explicit."
+    ],
+    "prerequisites": [
+      "The Erdős divisibility pigeonhole theorem and its sharpness (the parent entry)",
+      "Mathlib's IsAntichain and IsGreatest / upperBounds",
+      "Elementary divisibility and natural-number arithmetic"
+    ]
+  },
+  "conclusion": {
+    "summary": "The extremal form of the Erdős divisibility pigeonhole is formalized with zero sorries and zero axioms: the maximum size of a divisibility-antichain in {1,…,2n} is exactly n (max_antichain_card, an IsGreatest), with the upper bound n derived as the contrapositive of the parent pigeonhole theorem and the value attained by the explicit block {n+1,…,2n}. The bespoke antichain predicate is identified with Mathlib's IsAntichain (· ∣ ·), exposing the Dilworth/Sperner reading of the result.",
+    "futureDirections": "Generalize from the interval {1,…,2n} to the maximum primitive subset of {1,…,N} for arbitrary N (the largest antichain in the divisibility poset on {1,…,N}), and connect to Mathlib's developing antichain/Sperner infrastructure."
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-divisibility-pigeonhole",
+      "relationship": "extends",
+      "description": "Packages the parent's upper bound (erdos_divisibility_pigeonhole) and sharpness witness (erdos_divisibility_pigeonhole_sharp) into the single extremal optimum: the maximum divisibility-antichain in {1,…,2n} has size exactly n."
+    },
+    {
+      "targetId": "dilworth-theorem-oq-01",
+      "relationship": "uses-similar-technique",
+      "description": "The maximum-antichain value n is the Dilworth/Mirsky optimum for the divisibility poset on {1,…,2n}, which decomposes into n chains (one per odd part)."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/ErdosDivisibilityPigeonholeOQ01.lean",
+    "imports": [
+      "Mathlib",
+      "Proofs.ErdosDivisibilityPigeonhole"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ErdosDivisibilityPigeonhole",
+    "lineCount": 118,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 4
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Packages the parent entry's two complementary facts about `{1,…,2n}` into the single **extremal** statement they jointly prove:

> The maximum size of a divisibility-antichain in `{1,…,2n}` — a subset no two distinct members of which are related by `∣` — is exactly `n`.

- **Upper bound** (`antichain_card_le`): contrapositive of the parent's `erdos_divisibility_pigeonhole` — a set of size `≥ n+1` contains a divisible pair, so any antichain has `≤ n` elements.
- **Attained** (`block_isDivAntichain` / parent's `erdos_divisibility_pigeonhole_sharp`): the block `{n+1,…,2n}` is a divisibility-antichain of size `n`.
- **Headline** (`max_antichain_card`): the two assemble into `IsGreatest { k | ∃ S, IsDivAntichain n S ∧ S.card = k } n`.
- **Bridge** (`isDivAntichain_iff`): the bespoke `IsDivAntichain` predicate is exactly `IsAntichain (· ∣ ·)` on the interval — the Dilworth/Sperner reading.

## Verification

- Build **GREEN** (7744 jobs) via `./proofs/scripts/docker-build.sh Proofs.ErdosDivisibilityPigeonholeOQ01`.
- **verified / 0 axioms**: `#print axioms max_antichain_card` → `[propext, Classical.choice, Quot.sound]` only (no `Lean.ofReduceBool`, no `sorryAx`).
- 4 theorems, 1 definition, 0 sorries. Built entirely on the parent's verified theorems plus foundational Mathlib order lemmas.

## Files

- `proofs/Proofs/ErdosDivisibilityPigeonholeOQ01.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/erdos-divisibility-pigeonhole-oq-01/` (meta.json + annotations.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)