### PR TITLE
Enrich Gödel's First Incompleteness Theorem: add family cross-references

### DIFF
--- a/src/data/proofs/godel-first-incompleteness-oq01/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01/meta.json
@@ -137,6 +137,21 @@
       "targetId": "godel-incompleteness",
       "relationship": "companion",
       "description": "Pedagogical scaffold using Provable := fun _ => False; proofs hold vacuously. This file provides the non-vacuous axiomatic version."
+    },
+    {
+      "targetId": "godel-first-incompleteness-oq01-oq-01",
+      "relationship": "extended-by",
+      "description": "Rosser's 1936 improvement, which strengthens this entry by replacing the ω-consistency hypothesis with plain consistency. The Rosser sentence encodes a proof-length comparison ('every proof of me has an equally short or shorter disproof'), eliminating the asymmetry that forced ω-consistency here."
+    },
+    {
+      "targetId": "godel-first-incompleteness-oq01-oq-04",
+      "relationship": "foundational",
+      "description": "The Diagonal (Fixed-Point) Lemma, which supplies the self-referential sentence G this entry takes as an axiom. That entry constructs G as a genuine fixed point rather than assuming it for the specific formula G = ⟨42⟩, then re-derives the First Incompleteness Theorem from the lemma."
+    },
+    {
+      "targetId": "godel-second-incompleteness-oq02",
+      "relationship": "extended-by",
+      "description": "Gödel's Second Incompleteness Theorem builds directly on this formalization (GodelFirstIncompletenessOQ01), adding the Hilbert-Bernays-Löb derivability conditions to show no consistent system satisfying them can prove its own consistency."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Enrichment pass

`godel-first-incompleteness-oq01` (the non-vacuous axiomatic First Incompleteness entry) only cross-linked to its vacuous pedagogical companion. Its Gödel-family siblings already link back to it, but it had no forward links. Added 3:

| Target | Relationship | Why |
|--------|-------------|-----|
| `godel-first-incompleteness-oq01-oq-01` | extended-by | Rosser's improvement: ω-consistency → plain consistency |
| `godel-first-incompleteness-oq01-oq-04` | foundational | Diagonal/Fixed-Point Lemma that supplies the self-referential G |
| `godel-second-incompleteness-oq02` | extended-by | Second theorem, whose description states it builds on this file |

All targets verified to exist; the Second-theorem entry's own description explicitly says it builds on `GodelFirstIncompletenessOQ01`. Cross-reference-only — no claim/status fields touched. `pnpm build` green.