### PR TITLE
Enrich Bounded Prime Gaps OQ-01 (Optimal Admissible Tuples): add family cross-references

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
@@ -85,6 +85,21 @@
       "targetId": "rh-consequences",
       "relationship": "related",
       "description": "RH implies prime gap bound p_{n+1}-pₙ = O(√pₙ log pₙ), strengthening the unconditional result"
+    },
+    {
+      "targetId": "bounded-prime-gaps-oq-01-oq-02",
+      "relationship": "extended-by",
+      "description": "Pushes the optimal-tuple analysis under the Elliott-Halberstam conjecture, formalizing the conditional gap bound H ≤ 12 from the Maynard-Tao framework — the conditional counterpart to the unconditional admissible-tuple bounds studied here."
+    },
+    {
+      "targetId": "bounded-prime-gaps-oq-01-oq-03",
+      "relationship": "extended-by",
+      "description": "Pins down a concrete instance of the optimality question raised here: the minimum diameter of an admissible 50-tuple is exactly 246, exhibited by the Engelsma tuple — the extremal object behind the Polymath 8b bound."
+    },
+    {
+      "targetId": "bounded-prime-gaps-oq-03",
+      "relationship": "related",
+      "description": "Engelsma's 246 optimality: proves the tightest admissible 50-tuple realizing the Polymath 8b bound, the explicit extremal tuple for the optimal-admissible-tuple question this entry frames in general."
     }
   ],
   "sections": [


### PR DESCRIPTION
## Enrichment pass

`bounded-prime-gaps-oq-01` (Optimal Admissible Tuples and Gap Bounds) linked only to the base file and rh-consequences. Added 3 forward links to its admissible-tuple family:

| Target | Relationship | Why |
|--------|-------------|-----|
| `bounded-prime-gaps-oq-01-oq-02` | extended-by | Elliott-Halberstam conditional gap bound H ≤ 12 |
| `bounded-prime-gaps-oq-01-oq-03` | extended-by | Engelsma 50-tuple: min admissible diameter = 246 |
| `bounded-prime-gaps-oq-03` | related | Engelsma 246 optimality — the extremal tuple behind Polymath 8b |

All targets verified to exist. Cross-reference-only — no claim/status fields touched. `pnpm build` green.