### PR TITLE
Enrich Sum of kth Powers family: add intra-family cross-references

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-03/meta.json
@@ -118,6 +118,16 @@
       "targetId": "sum-of-kth-powers",
       "relationship": "alternative-proof",
       "description": "Gives a combinatorial (odd-number tiling) proof of Nicomachus's theorem, which the parent SumOfKthPowers.lean proves algebraically via closed-form power-sum formulas. The two proofs share no lemma beyond the Gauss sum."
+    },
+    {
+      "targetId": "sum-of-kth-powers-oq-01",
+      "relationship": "related",
+      "description": "OQ-01 unifies the parent's algebraic route into a single Bernoulli-number closed form for ∑_{i<n} i^k; the k=3 instance of that formula, ∑_{i≤n} i³ = (n(n+1)/2)², is exactly Nicomachus's identity. OQ-01 reaches it by pure computation over Bernoulli numbers, this entry by a subtraction-free combinatorial tiling — two structurally independent derivations of the same closed form."
+    },
+    {
+      "targetId": "sum-of-kth-powers-oq-04",
+      "relationship": "related",
+      "description": "Sibling open-question exploration of the same power-sum family: OQ-04 studies the asymptotics ∑_{i<n} i^k / n^{k+1} → 1/(k+1), while this entry proves the exact closed identity for the k=3 case. Together they exhibit both the exact and the limiting behavior of ∑ i^k."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -114,6 +114,16 @@
       "targetId": "sum-of-kth-powers",
       "relationship": "extends",
       "description": "Extends the power sum formulas with asymptotic analysis"
+    },
+    {
+      "targetId": "sum-of-kth-powers-oq-01",
+      "relationship": "related",
+      "description": "Shares the Bernoulli infrastructure: OQ-01 derives the exact Faulhaber closed form for ∑_{i<n} i^k from Bernoulli numbers, whose leading term n^{k+1}/(k+1) is precisely the 1/(k+1) limit this entry extracts asymptotically. The exact polynomial of OQ-01 and the asymptotic ratio here describe the same sum at different resolutions."
+    },
+    {
+      "targetId": "sum-of-kth-powers-oq-02",
+      "relationship": "related",
+      "description": "The Euler–Maclaurin machinery underlying this entry is the classical bridge from power sums to the Riemann zeta function; OQ-02 pushes the parent's power sums to non-integer exponents and analytic continuation, the regime where these same asymptotics govern the partial sums of ζ."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The `sum-of-kth-powers` family had siblings that only cross-referenced the parent, not each other. This adds accurate intra-family cross-references to the two most under-linked entries (each previously had only 1 cross-reference), making the family navigable.

**sum-of-kth-powers-oq-03** (Nicomachus's Theorem, combinatorial) — added links to:
- `sum-of-kth-powers-oq-01` (unified Bernoulli closed form; the k=3 instance is exactly Nicomachus's identity)
- `sum-of-kth-powers-oq-04` (exact identity vs. asymptotic behavior of the same power-sum family)

**sum-of-kth-powers-oq-04** (Euler–Maclaurin Asymptotics) — added links to:
- `sum-of-kth-powers-oq-01` (shared Bernoulli infrastructure; leading term n^{k+1}/(k+1) is the asymptotic limit)
- `sum-of-kth-powers-oq-02` (Euler–Maclaurin bridge from power sums to the Riemann zeta function / non-integer exponents)

## Scope
- Cross-references only — no claim, status, axiom count, or proof content changed.
- All four targetIds verified to exist in the gallery.
- `pnpm build` passes (exit 0); both meta.json files validate as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)