### PR TITLE
Enrich Alternating Series Estimation (Taylor sin/cos OQ-03): add reciprocal cross-references

### DIFF
--- a/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
@@ -59,6 +59,16 @@
       "targetId": "taylor-sincos-convergence",
       "relationship": "extends",
       "description": "Sharpens the axiomatized Lagrange remainder bounds in the parent formalization using alternating series theory"
+    },
+    {
+      "targetId": "taylor-sincos-convergence-oq-01",
+      "relationship": "related",
+      "description": "OQ-01 discharges the parent's two remainder axioms by proving the standard Lagrange remainder bounds via Mathlib's taylor_mean_remainder_bound; this entry takes a complementary route, deriving tighter error bounds from the alternating-series estimation theorem instead of Lagrange. Two different remainder-bounding techniques for the same sin/cos partial sums."
+    },
+    {
+      "targetId": "taylor-sincos-convergence-oq-04",
+      "relationship": "complements",
+      "description": "OQ-04 generalizes sin/cos convergence to any C^∞ function with uniformly bounded derivatives via a uniform Lagrange remainder bound; this entry specializes in the opposite direction, exploiting the sign-alternation specific to sin/cos to get sharper-than-Lagrange estimates. OQ-04 already references this entry as a complement."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

`taylor-sincos-convergence-oq-03` (Alternating Series Estimation for Sin/Cos) linked only to its parent, even though two siblings already reference it. This adds the missing reciprocal links so the family graph is bidirectional and navigable.

**taylor-sincos-convergence-oq-03** — added links to:
- `taylor-sincos-convergence-oq-01` (Eliminating Remainder Axioms): OQ-01 proves the standard Lagrange remainder bounds; this entry gives a complementary, tighter bound via alternating-series estimation — two remainder-bounding techniques for the same partial sums.
- `taylor-sincos-convergence-oq-04` (Uniformly Bounded Derivatives): OQ-04 generalizes via a uniform Lagrange bound while this entry specializes via sin/cos sign-alternation. OQ-04 already references this entry as a complement, so this makes the link reciprocal.

## Scope
- Cross-references only — no claim, status, axiom count, or proof content changed.
- Both targetIds verified to exist in the gallery.
- JSON validates; change is structurally identical to the already-build-validated #26838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)