### PR TITLE
Enrich Erdős Divisibility Pigeonhole (oq-01): canonicalize annotation type/significance

### DIFF
--- a/src/data/proofs/erdos-divisibility-pigeonhole-oq-01/annotations.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole-oq-01/annotations.json
@@ -28,7 +28,7 @@
       "startLine": 54,
       "endLine": 66
     },
-    "type": "technique",
+    "type": "concept",
     "title": "Identifying the Predicate with Mathlib's IsAntichain",
     "content": "isDivAntichain_iff proves IsDivAntichain n S ↔ (S ⊆ {1,…,2n} ∧ IsAntichain (· ∣ ·) (S : Set ℕ)). After unfolding IsDivAntichain, the interval-membership conjunct is shared (and_congr_right), and the remaining equivalence is just the definitional unfolding of IsAntichain as Set.Pairwise (fun a b => ¬ a ∣ b) — the Finset and coerced-Set membership are definitionally interchangeable. This places the result inside Mathlib's general antichain theory.",
     "mathContext": "$\\mathrm{IsAntichain}\\ r\\ s := s.\\mathrm{Pairwise}\\ (\\lambda a\\,b,\\ \\lnot\\, r\\,a\\,b)$. For $r = (\\mid)$ this is exactly the divisibility-antichain condition.",
@@ -49,11 +49,11 @@
       "startLine": 69,
       "endLine": 77
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Upper Bound as a Contrapositive of Pigeonhole",
     "content": "antichain_card_le turns the parent's pigeonhole theorem into the antichain bound |S| ≤ n. The proof is by_contra: assuming |S| ≥ n+1 (push_neg on ¬ |S| ≤ n), erdos_divisibility_pigeonhole applied to S ⊆ {1,…,2n} produces distinct a, b ∈ S with a ∣ b, which directly contradicts the antichain conjunct hS.2. No new combinatorics — the entire content is the parent theorem transported across the logical equivalence 'every (n+1)-set has a divisible pair' ⟺ 'every antichain has ≤ n elements'.",
     "mathContext": "If a divisibility-antichain had $\\ge n+1$ elements, the Erdős pigeonhole would force a comparable pair, contradicting antichainness; hence its size is $\\le n$.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "pigeonhole principle",
       "contrapositive",
@@ -70,11 +70,11 @@
       "startLine": 79,
       "endLine": 90
     },
-    "type": "key-insight",
+    "type": "insight",
     "title": "The Extremal Optimum: IsGreatest = n",
     "content": "max_antichain_card is the headline: IsGreatest { k | ∃ S, IsDivAntichain n S ∧ S.card = k } n. IsGreatest splits into membership and upper-bound. Membership: instantiate the parent's erdos_divisibility_pigeonhole_sharp, whose explicit witness {n+1,…,2n} is a divisibility-antichain of size n, so n is an achievable size. Upper bound: rintro the achieving set S and apply antichain_card_le. Thus the two one-sided facts of the parent — a bound and a witness — assemble into a single optimality statement: the maximum divisibility-antichain in {1,…,2n} has size exactly n.",
     "mathContext": "$\\max\\{|S| : S \\text{ a divisibility-antichain in } \\{1,\\dots,2n\\}\\} = n$, the extremal value of the Erdős pigeonhole gem.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "IsGreatest",
       "extremal optimum",
@@ -93,7 +93,7 @@
       "startLine": 92,
       "endLine": 114
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "The Top Block Attains the Maximum",
     "content": "block_isDivAntichain certifies the witness explicitly: {n+1,…,2n} is a divisibility-antichain of size n. Membership in {1,…,2n} and the cardinality (Nat.card_Icc gives 2n − (n+1) + 1 = n, closed by omega) are immediate; the antichain property reuses the parent's sharpness argument — a ∣ b with a ≠ b forces b = a·c with c ≥ 2, hence b ≥ 2a ≥ 2(n+1) > 2n, impossible inside the block. This makes the maximum n of max_antichain_card genuinely attained by a concrete set rather than only existentially.",
     "mathContext": "For $a, b \\in \\{n+1,\\dots,2n\\}$ with $a \\mid b$ and $a \\ne b$: $b \\ge 2a \\ge 2n+2 > 2n$, a contradiction. So the block is divisibility-free and has $n$ elements.",


### PR DESCRIPTION
## Summary

Fixes the five annotations in `erdos-divisibility-pigeonhole-oq-01` to use the gallery's canonical `Annotation` type union (`src/types/proof.ts`). The previous values fell outside the union and degraded rendering in `AnnotationPanel.tsx`.

| Annotation | Before | After |
|---|---|---|
| Upper Bound (contrapositive) | `technique` / `central` | `tactic` / `critical` |
| The Extremal Optimum (IsGreatest) | `key-insight` / `central` | `insight` / `critical` |
| IsAntichain identification | `technique` / supporting | `concept` / supporting |
| Top block witness | `technique` / supporting | `tactic` / supporting |

### Why this matters

- `significance: "central"` has **no** entry in `significanceStyles` / `significanceLabels`, so the two most important annotations (the upper bound and the headline IsGreatest result) rendered with a **blank significance badge and no colored left border**. `critical` restores the red "Critical" styling.
- `technique` and `key-insight` are not in `AnnotationType`, so `typeLabels[type]` missed and the UI showed raw lowercase strings ("technique", "key-insight") instead of clean labels.

Annotation **content is unchanged** — only `type`/`significance` keys are corrected. The conclusion (`implications`/`openQuestions`) was already completed in #26840, so this PR is annotations-only.

### Validation

- `pnpm build` passes (exit 0).
- 6-line diff, single file: `src/data/proofs/erdos-divisibility-pigeonhole-oq-01/annotations.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)