### PR TITLE
Enrich Erdős #1104 (oq-01) Mycielskian: canonicalize annotation type/significance

### DIFF
--- a/src/data/proofs/erdos-1104-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1104-oq-01/annotations.json
@@ -10,7 +10,7 @@
     "title": "The Mycielskian Construction M(G)",
     "content": "mycielskian G is SimpleGraph.fromRel (mycRel G) on the vertex type MycVertex V = Option (V ⊕ V): some (Sum.inl u) is an original, some (Sum.inr u) a shadow u', and none the apex z. The raw relation mycRel joins originals as in G, joins a shadow u' to the originals adjacent to u, leaves shadows mutually non-adjacent, and joins the apex to every shadow. Routing through fromRel discharges symmetry and looplessness automatically, so only the bespoke (possibly non-symmetric) relation needs specifying. Mathlib contains no Mycielskian, so this is built from scratch.",
     "mathContext": "$M(G)$ on $\\mathrm{Option}(V \\oplus V)$: originals join as in $G$, shadow $u'$ joins to $N_G(u)$ among originals, shadows are independent, and the apex joins to all shadows.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "Mycielskian",
       "SimpleGraph.fromRel",
@@ -27,7 +27,7 @@
       "startLine": 79,
       "endLine": 134
     },
-    "type": "technique",
+    "type": "lemma",
     "title": "Nine @[simp] Adjacency Characterisations",
     "content": "Each vertex-type pair gets a @[simp] lemma fully resolving adjacency in M(G): originals adjacent iff G-adjacent (adj_orig_orig), original–shadow iff G-adjacent (adj_orig_shadow / adj_shadow_orig), shadows never adjacent (not_adj_shadow_shadow), apex–shadow always adjacent (adj_apex_shadow / adj_shadow_apex), and apex–original / apex–apex never (not_adj_apex_orig, not_adj_orig_apex, not_adj_apex_apex). Each unfolds fromRel_adj and discharges the symmetrised disjunction via mycRel and G.adj_comm. With these tagged @[simp], every downstream case analysis over the nine vertex-type combinations closes by simp_all — the engineering backbone of the whole file.",
     "mathContext": "Adjacency in $M(G)$ is determined casewise by vertex types; making each case a simp lemma reduces all later proofs to mechanical case splits.",
@@ -53,7 +53,7 @@
     "title": "Mycielski Preserves Triangle-Freeness",
     "content": "mycielskian_cliqueFree_three: if G is triangle-free so is M(G). is3Clique_triple_iff turns a 3-clique of M(G) into three pairwise adjacencies; rcases over the three vertices across {apex, original, shadow} and simp_all with the nine adjacency lemmas eliminates every configuration except an all-originals triangle, which projects to a G-triangle and contradicts G.CliqueFree 3. Geometrically: the apex meets only the independent shadow class so lies in no triangle, and a triangle can use at most one shadow (shadows are independent), hence reduces to G.",
     "mathContext": "A triangle in $M(G)$ uses $\\le 1$ shadow and avoids the apex, so projects to a triangle of $G$; triangle-freeness of $G$ forbids it.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "CliqueFree",
       "is3Clique_triple_iff",
@@ -70,11 +70,11 @@
       "startLine": 160,
       "endLine": 177
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Chromatic Upper Bound: an Explicit (n+1)-Colouring",
     "content": "mycColor lifts a colouring C : G.Coloring (Fin n) to M(G): originals and their shadows keep C's colour via Fin.castSucc, and the apex takes the fresh top colour Fin.last n. mycielskian_colorable_succ proves this is proper by rcases over vertex types: same-colour-class edges reduce to C.valid (Fin.castSucc is injective), and any edge touching the apex differs because Fin.castSucc _ < Fin.last n. Hence G.Colorable n → (M G).Colorable (n+1): colourability rises by at most one, constructively.",
     "mathContext": "$\\chi(M(G)) \\le \\chi(G) + 1$, witnessed explicitly: reuse $G$'s colours on originals and shadows, spend one new colour on the apex.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "graph colouring",
       "Fin.castSucc",
@@ -96,7 +96,7 @@
     "title": "Chromatic Lower Bound: Mycielski's Recolouring Argument",
     "content": "mycielskian_colorable_of_succ is the deep half: (M G).Colorable (n+1) → G.Colorable n, forcing χ(M(G)) = χ(G)+1 exactly. Given a proper (n+1)-colouring C with apex colour a := C none, define D u := if C(original u) = a then C(shadow u) else C(original u). D avoids a (shadows are apex-adjacent so never coloured a), and is proper: for an edge u~v the originals are adjacent in M(G) so C differs there, ruling out both equal to a; the three remaining branches use the shadow–original and original–shadow edges of M(G). D therefore lands in the n-element complement Fin (n+1) \\ {a}, transported to Fin n by Fintype.equivFinOfCardEq — an honest n-colouring of G.",
     "mathContext": "Recolour each original by its shadow's colour exactly when it wears the apex colour $a$; the result is a proper colouring of $G$ avoiding $a$, hence using only $n$ colours.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "recolouring argument",
       "Fintype.equivFinOfCardEq",
@@ -114,7 +114,7 @@
       "startLine": 294,
       "endLine": 308
     },
-    "type": "technique",
+    "type": "lemma",
     "title": "Exact Colourability of the Iterated Tower",
     "content": "mycielskianIter builds the k-fold Mycielskian over a recursively-defined vertex type mycVertexIter. mycielskianIter_colorable (upper) and mycielskianIter_colorable_of_add (lower, the iterated form of the recolouring argument) combine into mycielskianIter_colorable_iff: (mycielskianIter G k).Colorable (m+k) ↔ G.Colorable m. Equivalently χ(mycielskianIter G k) = χ(G) + k — the chromatic number rises by exactly one per Mycielski step, pinned both above and below.",
     "mathContext": "$\\chi(M^k(G)) = \\chi(G) + k$: each iteration adds exactly one to the chromatic number while preserving triangle-freeness.",
@@ -139,7 +139,7 @@
     "title": "Headline: Triangle-Free Graphs of Every Chromatic Number",
     "content": "Instantiating the tower at K₂ = (⊤ : SimpleGraph (Fin 2)) — triangle-free (top_fin_two_cliqueFree_three, only two vertices), 2-colourable (top_fin_two_colorable_two, identity), not 1-colourable (top_fin_two_not_colorable_one, its edge needs two colours) — gives exists_triangleFree_colorable_not_colorable: for every k there is a triangle-free graph that is (2+k)-colourable but not (1+k)-colourable, i.e. of chromatic number exactly k+2. As k → ∞ these realise triangle-free graphs of arbitrarily large chromatic number — the constructive lower-bound witnesses behind Erdős #1104, fully machine-checked.",
     "mathContext": "For every $k$, $M^k(K_2)$ is triangle-free with $\\chi = k+2$; the family $\\{M^k(K_2)\\}_{k \\ge 0}$ has unbounded chromatic number.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "triangle-free unbounded chromatic number",
       "Grötzsch graph",


### PR DESCRIPTION
## Summary

Fixes all seven annotations in `erdos-1104-oq-01` to use the gallery's canonical `Annotation` type union (`src/types/proof.ts`). The previous values fell outside the union and degraded rendering in `AnnotationPanel.tsx` — the same fix applied to the divisibility-pigeonhole entry in #26842.

| Annotation | Before | After |
|---|---|---|
| The Mycielskian Construction M(G) | definition / `central` | definition / `critical` |
| Nine @[simp] Adjacency Characterisations | `technique` / supporting | `lemma` / supporting |
| Mycielski Preserves Triangle-Freeness | insight / `central` | insight / `critical` |
| Chromatic Upper Bound (explicit colouring) | `technique` / `central` | `tactic` / `critical` |
| Chromatic Lower Bound (recolouring) | insight / `central` | insight / `critical` |
| Exact Colourability of the Iterated Tower | `technique` / supporting | `lemma` / supporting |
| Headline witness | insight / `central` | insight / `critical` |

### Why this matters

- `significance: "central"` has **no** entry in `significanceStyles` / `significanceLabels`, so five annotations (including both chromatic bounds and the headline) rendered with a **blank significance badge and no colored left border**. `critical` restores the red "Critical" styling.
- `technique` is not in `AnnotationType`, so `typeLabels[type]` missed and the UI showed the raw lowercase string "technique". The nine `@[simp]` adjacency facts and the iterated colourability iff are `lemma`s; the explicit `mycColor` colouring is a `tactic` construction.

Annotation **content is unchanged** — only `type`/`significance` keys are corrected. The conclusion/overview were already completed in #26841, so this PR is annotations-only.

### Validation

- `pnpm build` passes (exit 0).
- 18-line diff, single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)