### PR TITLE
Enrich Erdős #1104 (parent): forward cross-ref to verified Mycielskian child

### DIFF
--- a/src/data/proofs/erdos-1104/meta.json
+++ b/src/data/proofs/erdos-1104/meta.json
@@ -145,6 +145,11 @@
       "targetId": "erdos-1015",
       "relationship": "related",
       "description": "Problem 1015 on partitioning 2-colored complete graphs uses Ramsey number R(t, t-1), connecting to R(3,k) in this problem"
+    },
+    {
+      "targetId": "erdos-1104-oq-01",
+      "relationship": "specializes",
+      "description": "Verified constructive lower-bound engine for this problem: builds Mycielski's construction M(G) from scratch (absent from Mathlib) and machine-checks χ(M(G)) = χ(G)+1, discharging the mycielski_construction property this entry posits. Iterating M from K₂ exhibits, for every k, a triangle-free graph of chromatic number exactly k+2 — the explicit witnesses behind the lower-bound side of f(n)."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `erdos-1104` (the parent open-problem entry).

## Gap addressed
`erdos-1104` carried 5 cross-references (ramseys-theorem, erdos-58, four-color-theorem, erdos-1105, erdos-1015) but **none to its own verified constructive child** `erdos-1104-oq-01`. The child links *back* to the parent (`relationship: extends`), but the parent never linked *forward* — so a reader on the open-problem page had no pointer to the machine-checked Mycielskian witness family that supplies its lower-bound side.

## Change
Added one forward cross-reference `erdos-1104 → erdos-1104-oq-01` (`relationship: specializes`) describing it as the verified constructive lower-bound engine: builds $M(G)$ from scratch and proves $\chi(M(G)) = \chi(G)+1$, with the tower over $K_2$ giving triangle-free graphs of chromatic number exactly $k+2$.

This completes the parent↔child link pair. No existing content removed; `pnpm build` green; only `src/data/proofs/erdos-1104/meta.json` touched (foreign annotation-rebuild churn reverted).