### PR TITLE
Enrich Primes Have Natural Density Zero (erdos-31): add prime-counting cross-references

### DIFF
--- a/src/data/proofs/erdos-31-primes-density/meta.json
+++ b/src/data/proofs/erdos-31-primes-density/meta.json
@@ -89,7 +89,7 @@
     "implications": "Density zero of the primes is the qualitative content of the prime number theorem and a prerequisite for many results in additive combinatorics. In particular, it implies that for any fixed k, almost all integers are not prime. The explicit bound \u03c0(N)/N \u2264 2 log 4/log N + 1/\u221aN gives quantitative decay rates. This result underpins Erd\u0151s problem #31, which studies arithmetic progressions in sets that avoid the primes.",
     "openQuestions": [
       "Can the prime number theorem \u03c0(N) ~ N/log N be formalized in Lean 4? Mathlib has started this but the full statement requires analytic techniques (Riemann zeta function meromorphic continuation).",
-      "Can the stronger Chebyshev lower bound \u03b8(N) \u2265 N\u00b7log(1/2) be formalized, giving the two-sided bound N/2 < \u03c0(N)\u00b7log N/N < 2 log 4?",
+      "Can the stronger Chebyshev lower bound \u03b8(N) \u2265 N\u00b7log(1/2) be formalized, giving the two-sided bound N/2 < \u03c0(N)\u00b7log N/N < 2 log 4? (Now discharged in the gallery: see the `chebyshev-bounds` and `chebyshev-pnt-bridge` entries, which establish the full \u03c0(N) = \u0398(N/log N) estimate.)",
       "Can the logarithmic density of primes (\u03a3_{p\u2264N} 1/p ~ log log N, equivalently that the primes have logarithmic density 1) be proved from these methods?"
     ]
   },
@@ -97,6 +97,31 @@
     {
       "targetId": "erdos-31",
       "relationship": "Provides the prime density zero result needed for analyzing arithmetic progressions avoiding primes."
+    },
+    {
+      "targetId": "chebyshev-bounds",
+      "relationship": "generalized-by",
+      "description": "Chebyshev's Prime Counting Bounds (15 theorems, 439 lines) proves the full two-sided estimate $\\pi(n) = \\Theta(n/\\log n)$ and $\\theta(n) = \\Theta(n)$ from the same central-binomial / primorial machinery used here. The upper half of that result is exactly the $\\theta(N) \\leq N\\log 4$ bound this entry derives via `primorial_le_4_pow`; chebyshev-bounds additionally supplies the matching lower bound, directly answering this entry's open question on formalizing $\\theta(N) \\geq N\\log(1/2)$. Density zero ($\\pi(N) = o(N)$) is the immediate qualitative corollary of its upper bound."
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge",
+      "relationship": "refined-by",
+      "description": "The Chebyshev-PNT Bridge (9 theorems, 264 lines, 0 axioms) sharpens the qualitative $\\pi(N)/N \\to 0$ statement into the quantitative envelope $\\pi(x) = \\Theta(x/\\log x)$. Its upper-bound lemma $(\\sqrt{n})^{\\pi(n)-\\pi(\\sqrt n)} \\leq 4^n$ formalizes precisely the split-at-$\\sqrt N$ trick this entry uses (large primes $p > \\sqrt N$ each contribute $\\log p > (\\log N)/2$), making the two proofs structurally parallel refinements of the same Chebyshev idea."
+    },
+    {
+      "targetId": "bertrands-postulate",
+      "relationship": "shares-technique",
+      "description": "Bertrand's Postulate (Erdős's 1932 elementary proof) rests on the same combinatorial engine: bounding the central binomial coefficient $\\binom{2n}{n}$ to control the primes in $(n, 2n]$. Where Bertrand extracts existence of a prime from the lower estimate on $\\binom{2n}{n}$, this entry uses the upper estimate $\\prod_{p\\leq n} p \\leq 4^n$ to bound prime counts — the two are complementary readings of the binomial bound at the heart of elementary prime distribution."
+    },
+    {
+      "targetId": "dirichlets-theorem",
+      "relationship": "related",
+      "description": "Dirichlet's Theorem guarantees infinitely many primes in each coprime residue class $a \\bmod q$. Combined with density zero, it sharpens the global picture: the primes are an infinite but vanishingly thin set, yet still equidistribute across admissible residue classes. The logarithmic-density question raised in this entry's open problems ($\\sum_{p\\leq N} 1/p \\sim \\log\\log N$) is the Mertens-type refinement underlying both results."
+    },
+    {
+      "targetId": "bounded-prime-gaps",
+      "relationship": "related",
+      "description": "Bounded Prime Gaps (Zhang/Maynard-Tao/Polymath 8b) studies how closely primes can cluster despite their global thinning. Density zero established here is the baseline 'primes are sparse' fact; the bounded-gaps theory shows that sparsity nonetheless permits infinitely many pairs within distance 246, a striking tension between average density and local clustering."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `erdos-31-primes-density`.

## Gap addressed
The entry was fully developed (5 keyInsights, 6 fully-annotated sections, complete conclusion) but **under-linked** — it had only 1 cross-reference (to its parent `erdos-31`) despite sitting in a dense neighborhood of prime-counting proofs that share its exact machinery.

## Changes
Added 5 substantive, mathematically accurate cross-references:
- **chebyshev-bounds** (`generalized-by`) — proves the full two-sided $\pi(n)=\Theta(n/\log n)$ from the same primorial bound; supplies the lower bound this entry leaves open.
- **chebyshev-pnt-bridge** (`refined-by`) — its $(\sqrt n)^{\pi(n)-\pi(\sqrt n)}\le 4^n$ lemma formalizes the very split-at-$\sqrt N$ trick used here.
- **bertrands-postulate** (`shares-technique`) — complementary reading of the central-binomial bound.
- **dirichlets-theorem** (`related`) — primes thin globally yet equidistribute across residue classes.
- **bounded-prime-gaps** (`related`) — density zero as the baseline sparsity fact behind bounded-gaps clustering.

Also annotated the two-sided-bound open question to note it is now discharged by the `chebyshev-bounds`/`chebyshev-pnt-bridge` entries.

## Verification
- `meta.json` validates as JSON
- `pnpm build` succeeds
- No claim/status/axiom drift (verified/original/0 axioms unchanged)