### PR TITLE
Enrich Schroeder-Bernstein (parent): forward cross-refs to 3 verified children

### DIFF
--- a/src/data/proofs/schroeder-bernstein/meta.json
+++ b/src/data/proofs/schroeder-bernstein/meta.json
@@ -231,6 +231,21 @@
       "targetId": "fundamental-theorem-algebra",
       "relationship": "related",
       "description": "SB establishes $|\\mathbb{C}| = |\\mathbb{R}|$: $\\mathbb{R} \\hookrightarrow \\mathbb{C}$ (inclusion) and $\\mathbb{C} \\hookrightarrow \\mathbb{R}^2 \\cong \\mathbb{R}$ (real/imaginary parts + pairing)."
+    },
+    {
+      "targetId": "schroeder-bernstein-oq-02",
+      "relationship": "specializes",
+      "description": "An alternative proof of this theorem via the Knaster–Tarski fixed-point theorem: the monotone operator $T(S) = (\\mathrm{range}\\,g)^c \\cup g''(f''S)$ on $\\mathrm{Set}\\,\\alpha$ has a least fixed point $S^*$ whose induced partition gives the bijection directly, replacing the usual back-and-forth orbit analysis with a single fixed-point argument."
+    },
+    {
+      "targetId": "schroeder-bernstein-oq-01",
+      "relationship": "specializes",
+      "description": "Lifts the question to category theory: the Schroeder–Bernstein *property* (mutual monomorphisms imply isomorphism) holds in Type but fails in general, with a six-theorem positive/negative corpus locating exactly which categorical hypotheses force it."
+    },
+    {
+      "targetId": "schroeder-bernstein-oq-04",
+      "relationship": "specializes",
+      "description": "A constructive refinement: for finite types with decidable equality the orbit classification underlying Cantor–Bernstein–Schroeder becomes decidable, yielding a fully computable bijection from mutual injections — the effective content of the classically nonconstructive theorem."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `schroeder-bernstein` (parent entry).

## Gap addressed
`schroeder-bernstein` carried 8 cross-references but **none to its own verified children**, despite each being a substantively distinct treatment of the theorem. Readers on the main page had no pointer to the alternative proofs and refinements.

## Change
Added three forward cross-references (each child already exists and is `verified/original`):
- **schroeder-bernstein-oq-02** — Knaster–Tarski fixed-point proof (least fixed point of $T(S)=(\mathrm{range}\,g)^c\cup g''(f''S)$)
- **schroeder-bernstein-oq-01** — categorical SB *property* (mutual monos ⇒ iso) with a positive/negative corpus across concrete categories
- **schroeder-bernstein-oq-04** — constructive CBS for finite types with decidable equality (computable bijection)

Completes the parent↔child link pairs. No existing content removed; `pnpm build` green; only `src/data/proofs/schroeder-bernstein/meta.json` touched (foreign annotation-rebuild churn reverted).

Note: this is one instance of a systemic gap — ~235 depth-1 verified parent→child pairs across the gallery currently lack forward links.