### PR TITLE
Enrich Erdős #1098 Non-Commuting Graphs: link forward to oq-01

### DIFF
--- a/src/data/proofs/erdos-1098/meta.json
+++ b/src/data/proofs/erdos-1098/meta.json
@@ -127,6 +127,11 @@
       "targetId": "erdos-134",
       "relationship": "uses-same-technique",
       "description": "Both connect graph-theoretic properties (cliques, diameter) to algebraic/combinatorial structure, demonstrating the power of structural characterizations in graph theory."
+    },
+    {
+      "targetId": "erdos-1098-oq-01",
+      "relationship": "extended-by",
+      "description": "The companion open-question formalization sharpens this entry: it characterizes groups by their clique number ω(Γ(G)) in the non-commuting graph — proving ω = 0 iff G is abelian, that central elements never join large cliques, that clique members lie in distinct cosets of Z(G), and that finite-index center forces finite clique number."
     }
   ],
   "sections": [


### PR DESCRIPTION
Closes a parent→child forward-link gap. `erdos-1098-oq-01` links back to `erdos-1098` (`extends`), but the parent never linked forward. Adds the reciprocal `extended-by` cross-reference describing the small-clique-number characterization the child proves (ω=0 iff abelian, central elements excluded from large cliques, clique members in distinct cosets of Z(G), finite-index center ⇒ finite clique number).

Part of the systemic forward-link enrichment sweep (~215 verified parent→child pairs missing reciprocal links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)