### PR TITLE
Enrich Sum of k-th Powers (parent): forward-link its three verified OQ extensions

### DIFF
--- a/src/data/proofs/sum-of-kth-powers/meta.json
+++ b/src/data/proofs/sum-of-kth-powers/meta.json
@@ -149,6 +149,21 @@
       "targetId": "euler-totient",
       "relationship": "related",
       "description": "Euler's totient function connects to Bernoulli numbers via the von Staudt-Clausen theorem: the denominator of $B_{2k}$ is $\\prod_{p-1 \\mid 2k} p$, involving primes whose relationship to $\\phi$ governs the arithmetic of power sums"
+    },
+    {
+      "targetId": "sum-of-kth-powers-oq-01",
+      "relationship": "extended-by",
+      "description": "Generalizes the $k=1,\\dots,5$ closed forms here into the single Faulhaber formula $\\sum_{i=1}^{n} i^k = \\frac{1}{k+1}\\sum_{j=0}^{k}\\binom{k+1}{j}B_j\\,n^{k+1-j}$, formalized via Mathlib's Bernoulli infrastructure so each specific formula falls out by pure computation"
+    },
+    {
+      "targetId": "sum-of-kth-powers-oq-02",
+      "relationship": "extended-by",
+      "description": "Pushes power sums to real exponents through the $p$-series $\\zeta(s) = \\sum_n n^{-s}$, proving the convergence dichotomy ($\\zeta(s)$ converges iff $s > 1$) and recovering $\\zeta(2) = \\pi^2/6$ and $\\zeta(4) = \\pi^4/90$"
+    },
+    {
+      "targetId": "sum-of-kth-powers-oq-03",
+      "relationship": "extended-by",
+      "description": "Gives a second, structurally independent proof of Nicomachus's identity $\\sum_{i\\le n} i^3 = (\\sum_{i\\le n} i)^2$ by tiling consecutive odd numbers, complementing the parent's closed-form algebraic route"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Forward cross-reference gap

The parent `sum-of-kth-powers` entry linked to 5 related gallery entries but **none of its own three verified open-question extensions**, although all three children link back. This PR adds the missing forward `crossReferences` (relationship `extended-by`):

| Child | Topic |
|-------|-------|
| `sum-of-kth-powers-oq-01` | General Faulhaber formula via Mathlib Bernoulli numbers |
| `sum-of-kth-powers-oq-02` | Real exponents via the $p$-series $\zeta(s)$; convergence dichotomy, $\zeta(2),\zeta(4)$ |
| `sum-of-kth-powers-oq-03` | Second independent (odd-number tiling) proof of Nicomachus's theorem |

All three children are `status: verified`. No claims changed; descriptions summarize each child's own metadata. Parent now has 8 cross-references (was 5).