### PR TITLE
Enrich Harmonic Series Divergence (parent): forward-link its three verified OQ extensions

### DIFF
--- a/src/data/proofs/harmonic-divergence/meta.json
+++ b/src/data/proofs/harmonic-divergence/meta.json
@@ -186,6 +186,21 @@
       "targetId": "stirling-formula",
       "relationship": "related",
       "description": "Both $H_n = \\ln n + \\gamma + O(1/n)$ and $\\ln(n!) = n\\ln n - n + O(\\ln n)$ are logarithmic estimates proved by Euler-Maclaurin summation"
+    },
+    {
+      "targetId": "harmonic-divergence-oq-01",
+      "relationship": "extended-by",
+      "description": "Studies the constant $\\gamma \\approx 0.5772$ measuring the gap $H_n - \\ln n$: convergence and monotonicity of the defining sequences, Theisinger's theorem that $H_n \\notin \\mathbb{Z}$ for $n \\ge 2$, and conditional irrationality consequences for the Euler-Mascheroni constant"
+    },
+    {
+      "targetId": "harmonic-divergence-oq-02",
+      "relationship": "extended-by",
+      "description": "Sharpens the boundary of divergence: $\\sum 1/(n\\ln n)$ still diverges while $\\sum 1/(n(\\ln n)^2)$ converges, both decided by Cauchy condensation, which rescales the harmonic series and the Basel $p$-series respectively"
+    },
+    {
+      "targetId": "harmonic-divergence-oq-04",
+      "relationship": "extended-by",
+      "description": "Abstracts Oresme's 14th-century grouping argument into the Cauchy condensation test, which fully characterizes convergence of monotone decreasing nonnegative series — the harmonic divergence is the prototypical instance"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Forward cross-reference gap

The parent `harmonic-divergence` entry linked to 7 related gallery entries but **none of its own three verified open-question extensions**, although all three children link back. This PR adds the missing forward `crossReferences` (relationship `extended-by`):

| Child | Topic |
|-------|-------|
| `harmonic-divergence-oq-01` | Euler-Mascheroni constant $\gamma$; Theisinger non-integrality of $H_n$ |
| `harmonic-divergence-oq-02` | Boundary of divergence: $\sum 1/(n\ln n)$ diverges, $\sum 1/(n(\ln n)^2)$ converges |
| `harmonic-divergence-oq-04` | Cauchy condensation test generalizing Oresme's grouping |

All three children are `status: verified`. No claims changed; descriptions summarize each child's own metadata. Parent now has 10 cross-references (was 7).