### PR TITLE
Enrich ℤ[√−2] x²+2y² Representations: link forward to oq-01, oq-03

### DIFF
--- a/src/data/proofs/zsqrtd-neg-two/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two/meta.json
@@ -131,6 +131,16 @@
       "targetId": "lagrange-four-squares",
       "relationship": "related",
       "description": "Every natural number is a sum of four squares; primes p ≡ 3 mod 8 proved here as sums of three squares provide special cases"
+    },
+    {
+      "targetId": "zsqrtd-neg-two-oq-01",
+      "relationship": "extended-by",
+      "description": "Strengthens this entry's two separate forward implications (p%8=1 ⇒ ∃a,b a²+2b²=p and p%8=3 ⇒ ∃a,b a²+2b²=p) into a single bi-conditional p = x²+2y² ⇔ p ≡ 1 or 3 (mod 8), adding the converse direction the parent left open."
+    },
+    {
+      "targetId": "zsqrtd-neg-two-oq-03",
+      "relationship": "extended-by",
+      "description": "Carries the method to the next quadratic form: it builds the Eisenstein integers ℤ[ω] (ring, norm, Euclidean structure) as the algebraic foundation for an x²+3y² representation theorem, mirroring the role ℤ[√−2] plays here for x²+2y²."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Closes two parent→child forward-link gaps. `zsqrtd-neg-two-oq-01` (single bi-conditional for p=x²+2y²) and `-oq-03` (Eisenstein integers ℤ[ω] toward x²+3y²) link back to the parent, but the parent linked forward to neither. Adds both reciprocal `extended-by` cross-references.

Part of the systemic forward-link enrichment sweep (~215 verified parent→child pairs missing reciprocal links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)