### PR TITLE
Research: dirichlet-approximation-theorem-oq-03 — complete unconditional Minkowski proof (build-unverified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -663,6 +663,7 @@ import Proofs.DilworthTheoremOQ01
 import Proofs.DirichletApproximation
 import Proofs.DirichletApproximationOQ01
 import Proofs.DirichletApproximationOQ02
+import Proofs.DirichletApproximationOQ03
 import Proofs.DirichletsTheorem
 import Proofs.DirichletsTheoremOQ01
 import Proofs.DirichletsTheoremOQ01OQ01

--- a/proofs/Proofs/DirichletApproximationOQ03.lean
+++ b/proofs/Proofs/DirichletApproximationOQ03.lean
@@ -1,0 +1,291 @@
+/-
+  Dirichlet's Approximation Theorem via Minkowski's Convex-Body Theorem
+  (research problem: dirichlet-approximation-theorem-oq-03)
+
+  The gallery entry `dirichlet-approximation-theorem` proves, for every real `α` and
+  integer `N ≥ 1`, the bound `|qα - p| < 1/N` for some `1 ≤ q ≤ N` via the pigeonhole
+  principle on fractional parts.
+
+  This file develops the **geometry-of-numbers** (Minkowski) re-derivation requested by
+  the open problem.  The classical one-line proof applies Minkowski's convex-body theorem
+  to the symmetric convex body
+
+      K(α, N) = { v ∈ ℝ²  :  |v₀| ≤ N  and  |α·v₀ - v₁| ≤ 1/N },
+
+  a parallelogram of area exactly `4 = 2² · (covolume of ℤ²)`.  Minkowski's theorem (the
+  closed/compact, area-`= 2ⁿ` variant) yields a nonzero integer point `(q, p) ∈ ℤ²` of `K`,
+  which is exactly a Dirichlet approximation `|qα - p| ≤ 1/N` with `1 ≤ q ≤ N`.
+
+  What is established here, sorry-free and axiom-free:
+
+  * `body`             — the convex body `K(α, N)`.
+  * `body_symm`        — `K` is symmetric about the origin (`v ∈ K → -v ∈ K`).
+  * `body_convex`      — `K` is convex (intersection of two linear slabs).
+  * `body_isClosed`    — `K` is closed (intersection of two closed linear slabs).
+                         Together with boundedness (a one-line norm estimate) this gives the
+                         compactness Minkowski's closed-body variant needs.
+  * `dirichlet_of_lattice_point`
+                       — **the arithmetic bridge**: a nonzero integer point of `K`
+                         (for `N ≥ 2`) is a Dirichlet approximation.  This is the shared
+                         final step that turns Minkowski's lattice point into the theorem,
+                         handling the sign normalisation `q ≥ 1` and the degenerate
+                         `q = 0` boundary case.
+  * `dirichlet_via_convex_body`
+                       — Dirichlet's bound, conditional on the Minkowski conclusion
+                         (existence of a nonzero **integer** point of `K`).
+
+  The remaining open step is purely the **volume computation** `volume (body α N) = 4`,
+  feeding Mathlib's `MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure`
+  with the standard lattice `ℤ² = Submodule.span ℤ (Set.range (Pi.basisFun ℝ (Fin 2)))`
+  (covolume `1` by `ZSpan.volume_fundamentalDomain`).  That volume equals `4` because `K`
+  is the image of the box `[-N, N] × [-1/N, 1/N]` (Lebesgue volume `4`) under the shear
+  `(x, y) ↦ (x, αx - y)`, a linear map of determinant `-1`
+  (`MeasureTheory.Measure.addHaar_image_linearMap`).  The geometric inputs that Minkowski
+  consumes are all discharged above; only the measure bookkeeping remains.
+-/
+import Mathlib
+
+namespace DirichletMinkowski
+
+open Set MeasureTheory
+
+variable (α : ℝ) (N : ℕ)
+
+/-- The symmetric convex body whose lattice points are Dirichlet approximations:
+    `K(α, N) = {v : ℝ² | |v 0| ≤ N ∧ |α·v 0 - v 1| ≤ 1/N}`. -/
+def body : Set (Fin 2 → ℝ) :=
+  {v | |v 0| ≤ (N : ℝ) ∧ |α * v 0 - v 1| ≤ 1 / (N : ℝ)}
+
+variable {α N}
+
+/-- `K(α, N)` is symmetric about the origin. -/
+theorem body_symm {v : Fin 2 → ℝ} (hv : v ∈ body α N) : -v ∈ body α N := by
+  obtain ⟨h1, h2⟩ := hv
+  refine ⟨?_, ?_⟩
+  · show |(-v) 0| ≤ (N : ℝ)
+    rw [Pi.neg_apply, abs_neg]; exact h1
+  · show |α * (-v) 0 - (-v) 1| ≤ 1 / (N : ℝ)
+    rw [Pi.neg_apply, Pi.neg_apply,
+      show α * -(v 0) - -(v 1) = -(α * v 0 - v 1) from by ring, abs_neg]
+    exact h2
+
+variable (α N)
+
+/-- `K(α, N)` is convex: it is the intersection of two slabs, each the preimage of a
+    closed interval under a linear functional. -/
+theorem body_convex : Convex ℝ (body α N) := by
+  have e : body α N =
+      (⇑(LinearMap.proj 0 : (Fin 2 → ℝ) →ₗ[ℝ] ℝ)) ⁻¹' Icc (-(N : ℝ)) (N : ℝ) ∩
+      (⇑(α • (LinearMap.proj 0) - (LinearMap.proj 1) : (Fin 2 → ℝ) →ₗ[ℝ] ℝ)) ⁻¹'
+        Icc (-(1 / (N : ℝ))) (1 / (N : ℝ)) := by
+    ext v
+    simp only [body, mem_setOf_eq, mem_inter_iff, mem_preimage, mem_Icc, abs_le,
+      LinearMap.sub_apply, LinearMap.smul_apply, LinearMap.proj_apply, smul_eq_mul]
+    tauto
+  rw [e]
+  exact ((convex_Icc _ _).linear_preimage _).inter ((convex_Icc _ _).linear_preimage _)
+
+/-- `K(α, N)` is closed: it is the intersection of two slabs, each the preimage of a
+    closed interval under a continuous linear functional. -/
+theorem body_isClosed : IsClosed (body α N) := by
+  have e : body α N =
+      (⇑(LinearMap.proj 0 : (Fin 2 → ℝ) →ₗ[ℝ] ℝ)) ⁻¹' Icc (-(N : ℝ)) (N : ℝ) ∩
+      (⇑(α • (LinearMap.proj 0) - (LinearMap.proj 1) : (Fin 2 → ℝ) →ₗ[ℝ] ℝ)) ⁻¹'
+        Icc (-(1 / (N : ℝ))) (1 / (N : ℝ)) := by
+    ext v
+    simp only [body, mem_setOf_eq, mem_inter_iff, mem_preimage, mem_Icc, abs_le,
+      LinearMap.sub_apply, LinearMap.smul_apply, LinearMap.proj_apply, smul_eq_mul]
+    tauto
+  rw [e]
+  exact (isClosed_Icc.preimage (LinearMap.continuous_of_finiteDimensional _)).inter
+    (isClosed_Icc.preimage (LinearMap.continuous_of_finiteDimensional _))
+
+/-- **Arithmetic bridge.**  For `N ≥ 2`, a nonzero integer point `(q₀, p₀)` of the body
+    `K(α, N)` is a Dirichlet approximation: after a sign normalisation it yields
+    `1 ≤ q ≤ N` with `|qα - p| ≤ 1/N`.
+
+    The hypothesis `N ≥ 2` rules out the degenerate boundary point `(0, ±1)`: this is the
+    only way a nonzero integer point could have first coordinate `0`, and it lies in `K`
+    exactly when `N = 1`. -/
+theorem dirichlet_of_lattice_point (hN : 2 ≤ N) {q₀ p₀ : ℤ}
+    (hne : ¬ (q₀ = 0 ∧ p₀ = 0))
+    (hx : |(q₀ : ℝ)| ≤ (N : ℝ))
+    (hy : |α * (q₀ : ℝ) - (p₀ : ℝ)| ≤ 1 / (N : ℝ)) :
+    ∃ (p : ℤ) (q : ℕ), 1 ≤ q ∧ q ≤ N ∧ |(q : ℝ) * α - (p : ℝ)| ≤ 1 / (N : ℝ) := by
+  have hNR : (0 : ℝ) < (N : ℝ) := by positivity
+  have hN1 : (1 : ℝ) < (N : ℝ) := by exact_mod_cast hN
+  -- Step 1: the first coordinate cannot vanish.
+  have hq0 : q₀ ≠ 0 := by
+    rintro rfl
+    simp only [Int.cast_zero, mul_zero, zero_sub, abs_neg] at hy
+    have h1N : 1 / (N : ℝ) < 1 := by rw [div_lt_one hNR]; exact hN1
+    have hlt : |(p₀ : ℝ)| < 1 := lt_of_le_of_lt hy h1N
+    obtain ⟨hl, hr⟩ := abs_lt.mp hlt
+    have : p₀ = 0 := by
+      have hl' : (-1 : ℤ) < p₀ := by exact_mod_cast hl
+      have hr' : p₀ < 1 := by exact_mod_cast hr
+      omega
+    exact hne ⟨rfl, this⟩
+  -- Step 2: sign-normalise so that `q = |q₀| ≥ 1`.
+  have hqpos : 1 ≤ q₀.natAbs := by omega
+  rcases lt_or_gt_of_ne hq0 with hneg | hpos
+  · -- q₀ < 0: take q = |q₀|, p = -p₀.
+    have hqR : (q₀ : ℝ) < 0 := by exact_mod_cast hneg
+    have hnat : (q₀.natAbs : ℝ) = -(q₀ : ℝ) := by
+      rw [Int.cast_natAbs, abs_of_neg hqR]
+    refine ⟨-p₀, q₀.natAbs, hqpos, ?_, ?_⟩
+    · have h := hx; rw [abs_of_neg hqR] at h
+      have : (q₀.natAbs : ℝ) ≤ (N : ℝ) := by rw [hnat]; exact h
+      exact_mod_cast this
+    · rw [hnat]
+      push_cast
+      rw [show -(q₀ : ℝ) * α - -(p₀ : ℝ) = -(α * (q₀ : ℝ) - (p₀ : ℝ)) from by ring, abs_neg]
+      exact hy
+  · -- q₀ > 0: take q = |q₀|, p = p₀.
+    have hqR : (0 : ℝ) < (q₀ : ℝ) := by exact_mod_cast hpos
+    have hnat : (q₀.natAbs : ℝ) = (q₀ : ℝ) := by
+      rw [Int.cast_natAbs, abs_of_pos hqR]
+    refine ⟨p₀, q₀.natAbs, hqpos, ?_, ?_⟩
+    · have h := hx; rw [abs_of_pos hqR] at h
+      have : (q₀.natAbs : ℝ) ≤ (N : ℝ) := by rw [hnat]; exact h
+      exact_mod_cast this
+    · rw [hnat, mul_comm (q₀ : ℝ) α]; exact hy
+
+/-- **Dirichlet's approximation theorem, conditional on Minkowski.**  Given a nonzero
+    point of the body `K(α, N)` with integer coordinates — exactly what Minkowski's
+    convex-body theorem produces once `volume (body α N) = 4` is supplied — Dirichlet's
+    bound `|qα - p| ≤ 1/N` (with `1 ≤ q ≤ N`) follows.  The geometric hypotheses Minkowski
+    needs (`body_symm`, `body_convex`, `body_isClosed`) are discharged above. -/
+theorem dirichlet_via_convex_body (hN : 2 ≤ N)
+    (hMink : ∃ v : Fin 2 → ℝ, v ∈ body α N ∧ v ≠ 0 ∧ ∀ i, ∃ m : ℤ, v i = (m : ℝ)) :
+    ∃ (p : ℤ) (q : ℕ), 1 ≤ q ∧ q ≤ N ∧ |(q : ℝ) * α - (p : ℝ)| ≤ 1 / (N : ℝ) := by
+  obtain ⟨v, ⟨hv0, hv1⟩, hvne, hint⟩ := hMink
+  obtain ⟨q₀, hq₀⟩ := hint 0
+  obtain ⟨p₀, hp₀⟩ := hint 1
+  refine dirichlet_of_lattice_point α N hN (q₀ := q₀) (p₀ := p₀) ?_ ?_ ?_
+  · rintro ⟨rfl, rfl⟩
+    apply hvne
+    funext i
+    fin_cases i
+    · simpa using hq₀
+    · simpa using hp₀
+  · rw [← hq₀]; exact hv0
+  · rw [← hq₀, ← hp₀]; exact hv1
+
+/-! ### The volume computation and the unconditional Minkowski derivation
+
+The remaining content of the open problem is the measure computation `volume (K) = 4`.  We discharge
+it via the **shear** `T : (x, y) ↦ (x, α·x − y)`, a linear map of determinant `−1` whose image of
+the axis-aligned box `[−N, N] × [−1/N, 1/N]` (Lebesgue volume `4`) is exactly `K`.  Feeding the
+resulting `volume (K) = 4 = 1 · 2² = covol(ℤ²) · 2^(dim)` into Mathlib's compact Minkowski theorem
+`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure` produces the nonzero integer point,
+discharging the `hMink` hypothesis of `dirichlet_via_convex_body`.  The result `dirichlet_via_minkowski`
+is therefore an **unconditional, sorry-free, axiom-free** geometry-of-numbers proof of Dirichlet's
+bound. -/
+
+/-- The shear `(x, y) ↦ (x, α·x − y)` as a linear endomorphism of `ℝ²`.  Its matrix
+    `!![1, 0; α, -1]` has determinant `−1`, so the map is volume-preserving and `K(α, N)` is its
+    image of the axis-aligned box `[−N, N] × [−1/N, 1/N]`. -/
+def shear : (Fin 2 → ℝ) →ₗ[ℝ] (Fin 2 → ℝ) := Matrix.toLin' !![1, 0; α, -1]
+
+/-- The axis-aligned box `[−N, N] × [−1/N, 1/N]`, whose shear image is `K(α, N)`. -/
+def box : Set (Fin 2 → ℝ) := {v | |v 0| ≤ (N : ℝ) ∧ |v 1| ≤ 1 / (N : ℝ)}
+
+theorem shear_apply_zero (v : Fin 2 → ℝ) : shear α v 0 = v 0 := by
+  show (Matrix.toLin' !![1, 0; α, -1]) v 0 = v 0
+  simp [Matrix.toLin'_apply, Matrix.mulVec, Matrix.dotProduct, Fin.sum_univ_two] <;> ring
+
+theorem shear_apply_one (v : Fin 2 → ℝ) : shear α v 1 = α * v 0 - v 1 := by
+  show (Matrix.toLin' !![1, 0; α, -1]) v 1 = α * v 0 - v 1
+  simp [Matrix.toLin'_apply, Matrix.mulVec, Matrix.dotProduct, Fin.sum_univ_two] <;> ring
+
+/-- The shear is an involution: `T ∘ T = id`. -/
+theorem shear_involutive (w : Fin 2 → ℝ) : shear α (shear α w) = w := by
+  funext i
+  fin_cases i
+  · rw [shear_apply_zero, shear_apply_zero]
+  · rw [shear_apply_one, shear_apply_one, shear_apply_zero]; ring
+
+/-- The body `K(α, N)` is the shear image of the axis-aligned box. -/
+theorem body_eq_image : body α N = ⇑(shear α) '' box N := by
+  ext w
+  simp only [body, box, Set.mem_setOf_eq, Set.mem_image]
+  constructor
+  · rintro ⟨h0, h1⟩
+    exact ⟨shear α w, ⟨by rw [shear_apply_zero]; exact h0, by rw [shear_apply_one]; exact h1⟩,
+      shear_involutive α w⟩
+  · rintro ⟨v, ⟨hv0, hv1⟩, rfl⟩
+    refine ⟨by rw [shear_apply_zero]; exact hv0, ?_⟩
+    rw [shear_apply_one, shear_apply_zero, show α * v 0 - (α * v 0 - v 1) = v 1 from by ring]
+    exact hv1
+
+/-- `box N` is the closed rectangle `Icc (-N, -1/N) (N, 1/N)`. -/
+theorem box_eq_Icc :
+    box N = Set.Icc (![-(N : ℝ), -(1 / (N : ℝ))] : Fin 2 → ℝ) ![(N : ℝ), 1 / (N : ℝ)] := by
+  ext v
+  simp only [box, Set.mem_setOf_eq, Set.mem_Icc, abs_le, Pi.le_def, Fin.forall_fin_two,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons]
+  tauto
+
+theorem box_isCompact : IsCompact (box N) := by
+  rw [box_eq_Icc]; exact isCompact_Icc
+
+theorem body_isCompact : IsCompact (body α N) := by
+  rw [body_eq_image]
+  exact (box_isCompact N).image (shear α).continuous_of_finiteDimensional
+
+/-- **The volume computation.**  `volume (box N) = 4`. -/
+theorem box_volume (hN : 1 ≤ N) : volume (box N) = 4 := by
+  have hN0 : (N : ℝ) ≠ 0 := by positivity
+  rw [box_eq_Icc, ← pi_univ_Icc, volume_pi_pi, Fin.prod_univ_two]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Real.volume_Icc]
+  rw [← ENNReal.ofReal_mul (by positivity)]
+  rw [show ((N : ℝ) - -(N : ℝ)) * (1 / (N : ℝ) - -(1 / (N : ℝ))) = 4 from by field_simp; ring]
+  norm_num
+
+/-- **The volume computation for the body.**  `volume (K(α, N)) = 4`, the area input Minkowski
+    needs.  Proved from `box_volume` via the determinant-`(−1)` shear and `addHaar_image_linearMap`. -/
+theorem body_volume (hN : 1 ≤ N) : volume (body α N) = 4 := by
+  have hdet : LinearMap.det (shear α) = -1 := by
+    show LinearMap.det (Matrix.toLin' !![1, 0; α, -1]) = -1
+    rw [LinearMap.det_toLin', Matrix.det_fin_two_of]; ring
+  rw [body_eq_image, addHaar_image_linearMap, hdet, box_volume N hN, abs_neg, abs_one,
+    ENNReal.ofReal_one, one_mul]
+
+/-- **Dirichlet's approximation theorem via Minkowski's convex-body theorem — unconditional.**
+    For every real `α` and every `N ≥ 2`, there are integers `p` and `1 ≤ q ≤ N` with
+    `|qα − p| ≤ 1/N`.  This discharges the `hMink` hypothesis of `dirichlet_via_convex_body` by
+    feeding `volume (K) = 4 = covol(ℤ²) · 2^(dim)` into Mathlib's compact Minkowski theorem and
+    reading off integer coordinates from the resulting lattice point. -/
+theorem dirichlet_via_minkowski (hN : 2 ≤ N) :
+    ∃ (p : ℤ) (q : ℕ), 1 ≤ q ∧ q ≤ N ∧ |(q : ℝ) * α - (p : ℝ)| ≤ 1 / (N : ℝ) := by
+  classical
+  apply dirichlet_via_convex_body α N hN
+  -- The standard lattice `ℤ² = span ℤ (range (Pi.basisFun ℝ (Fin 2)))` and its unit-covolume
+  -- fundamental domain.
+  have h_fund := ZSpan.isAddFundamentalDomain' (Pi.basisFun ℝ (Fin 2)) volume
+  have : Countable (Submodule.span ℤ (Set.range (Pi.basisFun ℝ (Fin 2)))).toAddSubgroup := by
+    change Countable (Submodule.span ℤ (Set.range (Pi.basisFun ℝ (Fin 2)))); infer_instance
+  have hcov : volume (ZSpan.fundamentalDomain (Pi.basisFun ℝ (Fin 2))) = 1 := by
+    rw [ZSpan.fundamentalDomain_pi_basisFun, volume_pi_pi]; simp [Real.volume_Ico]
+  have hrank : Module.finrank ℝ (Fin 2 → ℝ) = 2 := by
+    simp [Module.finrank_fintype_fun_eq_card]
+  -- The Minkowski volume hypothesis `covol · 2^dim ≤ volume K`, here `1 · 2² = 4 ≤ 4`.
+  have hvol : volume (ZSpan.fundamentalDomain (Pi.basisFun ℝ (Fin 2)))
+      * 2 ^ Module.finrank ℝ (Fin 2 → ℝ) ≤ volume (body α N) := by
+    rw [hcov, hrank, body_volume α N (by omega), one_mul]; norm_num
+  obtain ⟨⟨x, hx⟩, h_nz, h_mem⟩ :=
+    exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure
+      h_fund (fun y hy => body_symm hy) (body_convex α N) (body_isCompact α N) hvol
+  rw [Submodule.mem_toAddSubgroup] at hx
+  refine ⟨x, ?_, ?_, ?_⟩
+  · exact h_mem
+  · intro hx0; exact h_nz (Subtype.ext hx0)
+  · intro i
+    obtain ⟨z, hz⟩ := ((Pi.basisFun ℝ (Fin 2)).mem_span_iff_repr_mem ℤ x).mp hx i
+    refine ⟨z, ?_⟩
+    have hb : (Pi.basisFun ℝ (Fin 2)).repr x i = x i := by simp
+    rw [hb] at hz
+    simpa using hz.symm
+
+end DirichletMinkowski

--- a/research/problems/dirichlet-approximation-theorem-oq-03/knowledge.md
+++ b/research/problems/dirichlet-approximation-theorem-oq-03/knowledge.md
@@ -1,0 +1,68 @@
+# Knowledge Base: dirichlet-approximation-theorem-oq-03
+
+Dirichlet's approximation theorem via Minkowski's convex-body theorem (geometry of numbers).
+
+**Status**: COMPLETE (drafted, build-unverified) — the full unconditional Minkowski re-derivation of Dirichlet's bound is drafted sorry-free and axiom-free in `DirichletApproximationOQ03.lean` (18 theorems/defs, 0 sorry, 0 axiom, no native_decide). The `volume(K) = 4` step is closed via the determinant-(−1) shear and `dirichlet_via_minkowski` assembles the unconditional bound. **BUILD UNVERIFIED this session: the Docker daemon was unresponsive, so the elaboration / axiom-free claims rest on source inspection and need a successful `docker-build.sh Proofs.DirichletApproximationOQ03` to confirm.**
+
+---
+
+## Problem Understanding
+
+Re-derive the gallery's pigeonhole bound `|qα - p| ≤ 1/N` (`1 ≤ q ≤ N`) from Minkowski's
+convex-body theorem applied to `K = {(x,y) : |x| ≤ N, |αx - y| ≤ 1/N}`, a symmetric parallelogram
+of area exactly `4 = 2²·covol(ℤ²)`.
+
+---
+
+## What We've Built
+
+- `body` - the symmetric convex body `K(α,N) = {v : ℝ² | |v 0| ≤ N ∧ |α·v 0 - v 1| ≤ 1/N}`.
+- `body_symm` - `K` is symmetric about the origin (`v ∈ K → -v ∈ K`).
+- `body_convex` - `K` is convex (intersection of two linear slabs).
+- `body_isClosed` - `K` is closed (preimages of closed intervals under continuous functionals).
+- `dirichlet_of_lattice_point` - arithmetic bridge: for `N ≥ 2`, a nonzero integer point of `K` is a Dirichlet approximation (sign normalisation to `1 ≤ q ≤ N`, plus the `q = 0` boundary exclusion).
+- `dirichlet_via_convex_body` - Dirichlet's bound, conditional on the Minkowski conclusion (a nonzero integer point of `K`).
+- `shear`, `box`, `body_eq_image`, `box_eq_Icc`, `box_isCompact`, `body_isCompact` - the determinant-(−1) shear `(x,y) ↦ (x, αx − y)` (an involution), the axis-aligned box, and the identity `K = shear '' box` plus compactness of both.
+- `box_volume` (`= 4`), `body_volume` (`= 4`) - the measure computation, via `volume_pi_pi`/`Real.volume_Icc` and `addHaar_image_linearMap` with `LinearMap.det_toLin'` + `Matrix.det_fin_two_of`.
+- `dirichlet_via_minkowski` - **the unconditional capstone**: Dirichlet's `|qα − p| ≤ 1/N` (`1 ≤ q ≤ N`, `N ≥ 2`) from `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure` against the standard lattice `ℤ² = span ℤ (range (Pi.basisFun ℝ (Fin 2)))`. **Build-unverified this session (Docker down).**
+
+---
+
+## Insights
+
+- **The whole proof collapses to `volume(K) = 4`.** With the geometric facts and the arithmetic
+  back-end machine-checked, the only remaining content is the single measure computation.
+- **Minkowski gives the non-strict bound** `|qα - p| ≤ 1/N`. The body has area *exactly* `4`, so
+  only the closed/compact `≤`-variant `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure`
+  applies; the strict `<` of the pigeonhole entry needs the open-boundary refinement.
+- **`q = 0` boundary subtlety.** A nonzero integer point of `K` can have first coordinate `0` only
+  if it is `(0, ±1)`, which lies in `K` exactly when `N = 1`. Hence the bridge assumes `N ≥ 2`
+  (`N = 1` is the trivial case `q = 1`, `p = round α`).
+- **Volume via a shear.** `K` is the image of the box `[-N,N]×[-1/N,1/N]` (volume 4) under
+  `(x,y) ↦ (x, αx - y)`, a linear map of determinant `-1`; `addHaar_image_linearMap` then gives
+  `volume(K) = |det|·4 = 4`.
+
+## Mathlib inventory (for the finish)
+
+- `MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure` - Minkowski (compact).
+- `ZSpan.isAddFundamentalDomain`, `ZSpan.volume_fundamentalDomain` - standard-lattice covolume `1`.
+- `MeasureTheory.Measure.addHaar_image_linearMap` - linear-image volume law.
+- `Convex.linear_preimage`, `convex_Icc` - convexity of `K`.
+- `abs_sub_convergents_le'`, `abs_sub_convs_le` - continued-fraction error bounds (subsumption route).
+
+## Dead Ends
+
+- Strict `<` directly from Minkowski: the area-`= 4` body needs `> 4` for the strict
+  (`..._lt_measure`) variant, so strict Dirichlet is not free from this body.
+
+## Next Steps
+
+1. **Verify the build** — `./proofs/scripts/docker-build.sh Proofs.DirichletApproximationOQ03` once
+   Docker is back up. Risk surface is Mathlib lemma-name/signature drift in the unconditional
+   assembly (`ZSpan.isAddFundamentalDomain'`, `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure`,
+   `ZSpan.fundamentalDomain_pi_basisFun`, `addHaar_image_linearMap`, `Basis.mem_span_iff_repr_mem`).
+2. Once verified, promote to a gallery entry (`src/data/proofs/`) as `verified` / `original`
+   (0 sorry, 0 axiom, no `Lean.ofReduceBool`), cross-referencing the pigeonhole
+   `dirichlet-approximation-theorem` entry.
+3. Settle the subsumption question via the continued-fraction convergent selection, or record that
+   pigeonhole/Minkowski/CF give the same `1/N` strength.

--- a/research/problems/dirichlet-approximation-theorem-oq-03/problem.md
+++ b/research/problems/dirichlet-approximation-theorem-oq-03/problem.md
@@ -1,0 +1,88 @@
+# Problem: Dirichlet Approximation via Minkowski's Convex-Body Argument
+
+**Slug**: dirichlet-approximation-theorem-oq-03
+**Created**: 2026-06-19T17:27:54-07:00
+**Status**: Active
+**Source**: proof-suggestion
+
+## Problem Statement
+
+### Formal Statement
+
+Dirichlet's approximation theorem: for every real $\alpha$ and every integer $N \ge 1$ there exist
+integers $p, q$ with $1 \le q \le N$ such that
+
+$$
+\left| \alpha - \frac{p}{q} \right| < \frac{1}{q\,N} \quad\Bigl(\text{equivalently } |q\alpha - p| < \tfrac{1}{N}\Bigr).
+$$
+
+The current gallery entry proves this via an explicit pigeonhole interval map. This problem asks two
+related questions:
+
+1. **Subsumption**: Does Mathlib's continued-fraction development already provide this bound (or a
+   stronger one, $|q\alpha - p| < 1/q$ for infinitely many $q$)?
+2. **Minkowski route**: Can the explicit interval/pigeonhole construction be replaced by **Minkowski's
+   convex-body theorem** (geometry of numbers) — applied to the symmetric convex region
+   $|x| \le N,\ |\alpha x - y| \le 1/N$ in $\mathbb{R}^2$ — yielding the same bound?
+
+### Plain Language
+
+Every real number can be approximated by a fraction $p/q$ with denominator at most $N$ to within
+$1/(qN)$. The gallery proves this by pigeonhole. We want to know whether the slicker lattice-point
+proof (Minkowski: a symmetric convex body of area $> 4$ contains a nonzero lattice point) can be
+formalized for the same result, and whether Mathlib's continued fractions already give it.
+
+### Why This Matters
+
+Minkowski's theorem is the canonical "geometry of numbers" entry point and generalizes to
+simultaneous Diophantine approximation in higher dimensions. Re-deriving Dirichlet through it tests
+whether Mathlib's `GeometryOfNumbers` / convex-body API is usable here and opens a path to the
+multidimensional Dirichlet theorem.
+
+## Known Results
+
+### What's Already Proven
+
+- `dirichlet-approximation-theorem` — gallery entry: the $1/(qN)$ bound via pigeonhole on fractional
+  parts (`Proofs/DirichletApproximation.lean`).
+- Mathlib `MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure` — Minkowski's
+  convex-body theorem (compact, area-`= 2ⁿ` variant).
+- Mathlib continued-fraction development (`Mathlib.Algebra.ContinuedFractions.*`,
+  `abs_sub_convergents_le'`).
+
+### What's Still Open
+
+- The volume computation `volume (body α N) = 4` feeding the Minkowski lemma.
+- Whether Mathlib's continued fractions yield the Dirichlet bound directly (and at what strength).
+
+### Our Goal
+
+Give a sorry-free Minkowski-convex-body proof of Dirichlet's bound, or establish the
+continued-fraction subsumption; compare both to the existing pigeonhole proof.
+
+## Tractability Assessment
+
+**Difficulty**: Medium. Both routes are classical and short on paper; the obstacle is Mathlib API
+alignment (the convex-body volume computation and the lattice fundamental domain).
+
+## References
+
+- G. L. Dirichlet (1842) — the pigeonhole approximation theorem.
+- H. Minkowski — geometry of numbers / convex-body theorem.
+- `Mathlib.MeasureTheory.Group.GeometryOfNumbers`, `Mathlib.Algebra.Module.ZLattice.*`.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - diophantine-approximation
+  - geometry-of-numbers
+  - minkowski
+  - continued-fractions
+related_proofs:
+  - dirichlet-approximation-theorem
+difficulty: medium
+source: proof-suggestion
+created: 2026-06-19T17:27:54-07:00
+```

--- a/research/problems/dirichlet-approximation-theorem-oq-03/sessions/2026-06-19-s1-act-minkowski-reduction.md
+++ b/research/problems/dirichlet-approximation-theorem-oq-03/sessions/2026-06-19-s1-act-minkowski-reduction.md
@@ -1,0 +1,77 @@
+# Session 2026-06-19 (Session 1) — ACT: Minkowski convex-body reduction
+
+**Mode:** FRESH · **Outcome:** progress (verified reduction; volume crux remains open)
+
+## What I did
+
+- Surveyed both routes the open problem names:
+  - **Minkowski / geometry of numbers.** Mathlib has the convex-body theorem
+    `MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure` (compact,
+    area-`= 2ⁿ` variant — the one we need, since our body has area exactly `4 = 2²·covol(ℤ²)`),
+    plus the lattice fundamental-domain API `ZSpan.isAddFundamentalDomain` /
+    `ZSpan.volume_fundamentalDomain` (covolume `1` for the standard basis) and the linear-image
+    volume law `MeasureTheory.Measure.addHaar_image_linearMap`.
+  - **Continued fractions.** Mathlib's `abs_sub_convergents_le'` gives
+    `|v - Aₙ/Bₙ| ≤ 1/(bₙ·Bₙ·Bₙ)` and `abs_sub_convs_le` gives the sharper `1/(Bₙ·Bₙ₊₁)`;
+    selecting the convergent with `Bₙ ≤ N < Bₙ₊₁` would yield Dirichlet, but assembling the
+    index existence + denominator monotonicity + the rational-termination edge case is itself
+    multi-lemma work (and only re-proves what pigeonhole already gives).
+
+- Built (sorry-free, axiom-free) `Proofs/DirichletApproximationOQ03.lean` developing the Minkowski
+  route up to the single remaining measure-theory crux:
+  - `body α N` — the symmetric convex body `K = {v : ℝ² | |v 0| ≤ N ∧ |α·v 0 - v 1| ≤ 1/N}`.
+  - `body_symm` — `K` is symmetric about the origin.
+  - `body_convex` — `K` is convex (intersection of two linear slabs; `Convex.linear_preimage`).
+  - `body_isClosed` — `K` is closed (preimages of closed `Icc` under continuous functionals).
+  - `dirichlet_of_lattice_point` — **the arithmetic bridge**: for `N ≥ 2`, a nonzero integer point
+    `(q₀, p₀)` of `K` is a Dirichlet approximation. Handles the sign normalisation to `1 ≤ q ≤ N`
+    and proves the degenerate `q = 0` boundary point `(0, ±1)` cannot occur (it lies in `K` only
+    when `N = 1`).
+  - `dirichlet_via_convex_body` — Dirichlet's bound `|qα - p| ≤ 1/N`, conditional on the Minkowski
+    conclusion (existence of a nonzero **integer** point of `K`).
+
+## Key findings
+
+- The **entire open content** of the Minkowski re-derivation collapses to one measure computation:
+  `volume (body α N) = 4`. Every geometric hypothesis Minkowski consumes (symmetry, convexity,
+  closedness) and the whole arithmetic back-end (lattice point ⇒ Dirichlet, with sign + boundary
+  handling) is now machine-checked. This mirrors the structure of a clean Minkowski textbook proof:
+  "area is 4, so there is a lattice point, so Dirichlet."
+
+- The natural Minkowski output is the **non-strict** bound `|qα - p| ≤ 1/N`: the closed body has
+  area exactly `4`, so only the `≤`-variant (`..._le_measure`) applies. The strict `< 1/N` of the
+  pigeonhole entry needs the open-boundary refinement; the `≤` form is the honest geometry-of-numbers
+  result.
+
+- The `q = 0` boundary subtlety is real and is dispatched by requiring `N ≥ 2`: for `N ≥ 2` the only
+  integer points with first coordinate `0` that could lie in `K` are `(0, ±1)`, excluded because
+  `1 > 1/N`. `N = 1` is the trivial case of Dirichlet (`q = 1`, `p = round α`).
+
+## Infrastructure assessment
+
+**Needed to finish:** `volume (body α N) = 4`. The body is the image of the box
+`[-N,N] × [-1/N,1/N]` (volume `4`) under the shear `(x,y) ↦ (x, αx - y)`, a linear map of
+determinant `-1`; `addHaar_image_linearMap` gives the volume, but the bookkeeping (defining the
+`LinearMap` on `Fin 2 → ℝ`, its `LinearMap.det` via `Matrix.det_fin_two`, the box volume via
+`volume_pi`/`Real.volume_Icc`, and the `body = T '' box` set equality) is a self-contained
+multi-lemma effort. Then feed `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure` with
+`L = Submodule.span ℤ (Set.range (Pi.basisFun ℝ (Fin 2)))` and extract integer coordinates
+(lattice-membership ⇒ integer coords) to discharge the `hMink` hypothesis of
+`dirichlet_via_convex_body`.
+
+**Size estimate:** the remaining volume + lattice glue is ~150–250 lines of measure-theory
+bookkeeping (no missing Mathlib theory — purely assembly).
+
+## Files modified
+
+- `proofs/Proofs/DirichletApproximationOQ03.lean` (new, verified reduction)
+- `proofs/Proofs.lean` (import)
+- `src/data/research/problems/dirichlet-approximation-theorem-oq-03.json` (knowledge)
+- `research/problems/dirichlet-approximation-theorem-oq-03/{problem,knowledge}.md` (re-persisted)
+
+## Next steps
+
+- Discharge `volume (body α N) = 4` via the shear change-of-variables, then assemble the
+  unconditional `dirichlet_via_minkowski` from Mathlib's convex-body theorem.
+- (Optional) settle the **subsumption** question by assembling the continued-fraction convergent
+  selection, or record a literature note that pigeonhole/Minkowski/CF give the same `1/N` strength.

--- a/research/problems/dirichlet-approximation-theorem-oq-03/sessions/2026-06-19-s2-act-volume-and-unconditional.md
+++ b/research/problems/dirichlet-approximation-theorem-oq-03/sessions/2026-06-19-s2-act-volume-and-unconditional.md
@@ -1,0 +1,42 @@
+# Session 2026-06-19 (Session 2) — ACT: volume computation + unconditional assembly
+
+**Mode:** REVISIT · **Outcome:** complete (drafted) — full unconditional proof, BUILD UNVERIFIED (Docker down)
+
+## What I did
+
+Closed the single remaining crux from Session 1 (`volume(K) = 4`) and assembled the unconditional
+geometry-of-numbers proof of Dirichlet's bound, all sorry-free and axiom-free by source inspection.
+
+Added to `Proofs/DirichletApproximationOQ03.lean`:
+
+- **The shear.** `shear α : (Fin 2 → ℝ) →ₗ[ℝ] (Fin 2 → ℝ) := Matrix.toLin' !![1,0; α,-1]`, with
+  `shear_apply_zero`/`shear_apply_one` reading off its action `(x,y) ↦ (x, αx − y)` and
+  `shear_involutive` showing `T ∘ T = id`.
+- **Box / body image identity.** `box` is the axis-aligned rectangle `[-N,N] × [-1/N,1/N]`;
+  `body_eq_image` proves `K = shear '' box` (one-line round-trip via the involution);
+  `box_eq_Icc` rewrites `box` as an `Icc`, giving `box_isCompact` and hence `body_isCompact`.
+- **Volume.** `box_volume : volume (box N) = 4` via `volume_pi_pi` + `Real.volume_Icc`;
+  `body_volume : volume (body α N) = 4` via `addHaar_image_linearMap` with
+  `LinearMap.det_toLin'` + `Matrix.det_fin_two_of` giving `det = -1`.
+- **Unconditional capstone.** `dirichlet_via_minkowski (hN : 2 ≤ N)` feeds
+  `covol(ℤ²)·2^dim = 1·2² = 4 ≤ 4 = volume(K)` into
+  `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure` against the standard lattice
+  `span ℤ (range (Pi.basisFun ℝ (Fin 2)))`, converts lattice membership to integer coordinates via
+  `Basis.mem_span_iff_repr_mem`, and discharges the `hMink` hypothesis of `dirichlet_via_convex_body`.
+
+## Honest status
+
+- File: 18 theorems/defs, **0 `sorry`, 0 `axiom` declarations, no `native_decide`/`decide`** (grep-confirmed; the two "sorry"/"axiom" string hits are doc-comment prose).
+- **The build was NOT run.** `docker version` and `docker ps` both hung (daemon unresponsive,
+  host load avg ~12–17). So the elaboration and axiom-free claims rest on **source inspection only**.
+  A successful `./proofs/scripts/docker-build.sh Proofs.DirichletApproximationOQ03` is required
+  before this is treated as machine-checked. Risk surface: Mathlib lemma-name/signature drift in the
+  unconditional assembly (`ZSpan.isAddFundamentalDomain'`,
+  `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure`,
+  `ZSpan.fundamentalDomain_pi_basisFun`, `addHaar_image_linearMap`, `Basis.mem_span_iff_repr_mem`).
+
+## Next
+
+1. Verify the build once Docker is back; fix any lemma drift.
+2. On green build, promote to a gallery entry (`src/data/proofs/`) as `verified`/`original`.
+3. Optional: continued-fraction subsumption note; strict `< 1/N` via open-boundary (area > 4) refinement.

--- a/research/problems/dirichlet-approximation-theorem-oq-03/state.md
+++ b/research/problems/dirichlet-approximation-theorem-oq-03/state.md
@@ -1,0 +1,35 @@
+# State: dirichlet-approximation-theorem-oq-03
+
+**Status**: active
+**Phase**: research
+**Last updated**: 2026-06-19
+
+## Current Focus
+
+Minkowski convex-body re-derivation of Dirichlet's approximation theorem. The full proof —
+geometry, arithmetic bridge, the `volume(K) = 4` shear computation, and the unconditional Minkowski
+assembly — is drafted sorry-free and axiom-free in `DirichletApproximationOQ03.lean`. **Build is
+UNVERIFIED this session: the Docker build daemon was unresponsive; CI / the deployer must build
+`Proofs.DirichletApproximationOQ03` before this is treated as machine-checked.**
+
+## Progress
+
+- [x] Survey Mathlib geometry-of-numbers + continued-fraction APIs.
+- [x] Convex body `K(α,N)`: symmetry, convexity, closedness (sorry-free).
+- [x] Arithmetic bridge: nonzero integer point of `K` ⇒ Dirichlet approximation (sorry-free).
+- [x] Dirichlet's bound conditional on the Minkowski conclusion (sorry-free).
+- [x] Volume computation `volume(K) = 4` via the determinant-(−1) shear `(x,y) ↦ (x, αx − y)`
+      (`shear`, `box`, `body_eq_image`, `box_volume`, `body_volume`) — drafted sorry-free.
+- [x] Unconditional Minkowski assembly `dirichlet_via_minkowski` from
+      `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure` against the standard lattice
+      `ℤ² = span ℤ (range (Pi.basisFun ℝ (Fin 2)))` — drafted sorry-free.
+- [ ] **Build verification** of `Proofs.DirichletApproximationOQ03` (blocked this session: Docker down).
+- [ ] Continued-fraction subsumption (optional).
+
+## Build status
+
+`DirichletApproximationOQ03.lean`: 18 theorems/defs, 0 `sorry`, 0 `axiom` declarations, no
+`native_decide`/`decide`. Build NOT run this session — `docker version`/`docker ps` hung (daemon
+unresponsive, host load avg ~12–17). The sorry/axiom-free claims are by source inspection only and
+require a successful `./proofs/scripts/docker-build.sh Proofs.DirichletApproximationOQ03` to confirm
+the Mathlib lemma names and tactic blocks actually elaborate.

--- a/src/data/research/problems/dirichlet-approximation-theorem-oq-03.json
+++ b/src/data/research/problems/dirichlet-approximation-theorem-oq-03.json
@@ -1,0 +1,90 @@
+{
+  "slug": "dirichlet-approximation-theorem-oq-03",
+  "title": "Dirichlet's approximation theorem via Minkowski's convex-body theorem",
+  "problemStatement": "Re-derive the gallery's pigeonhole Dirichlet bound |qα − p| ≤ 1/N (with 1 ≤ q ≤ N) from Minkowski's convex-body theorem (geometry of numbers), applied to the symmetric convex region K(α,N) = {(x,y) ∈ ℝ² : |x| ≤ N, |αx − y| ≤ 1/N}, a parallelogram of area exactly 4 = 2²·covol(ℤ²). A secondary question asks whether Mathlib's continued-fraction development already subsumes the bound.",
+  "status": "active",
+  "phase": "RESEARCH",
+  "tier": "B",
+  "significance": 6,
+  "tractability": 6,
+  "path": "full",
+  "started": "2026-06-19",
+  "lastUpdate": "2026-06-19",
+  "tags": [
+    "number-theory",
+    "diophantine-approximation",
+    "geometry-of-numbers",
+    "minkowski",
+    "continued-fractions",
+    "lattice"
+  ],
+  "currentState": {
+    "summary": "Full unconditional proof DRAFTED, sorry-free and axiom-free by source inspection (18 theorems/defs, 0 sorry, 0 axiom declarations, no native_decide/decide). The complete geometry-of-numbers derivation of Dirichlet's bound is in place: the symmetric convex body K(alpha,N), its symmetry/convexity/compactness, the volume computation volume(K) = 4 via the determinant-(-1) shear (x,y) -> (x, alpha*x - y) mapping the box [-N,N] x [-1/N,1/N] onto K (body_eq_image, box_volume, body_volume), the arithmetic bridge (nonzero integer point of K => Dirichlet approximation with 1 <= q <= N and the q = 0 boundary excluded for N >= 2), and the unconditional capstone dirichlet_via_minkowski feeding exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure against the standard lattice ZZ^2 = span ZZ (range (Pi.basisFun RR (Fin 2))) of covolume 1. BUILD UNVERIFIED THIS SESSION: the Docker build daemon was unresponsive (docker version/ps hung), so the sorry/axiom-free and elaboration claims rest on source inspection only; a successful docker build of Proofs.DirichletApproximationOQ03 is required before this is machine-checked.",
+    "leanFile": "proofs/Proofs/DirichletApproximationOQ03.lean",
+    "sorries": 0,
+    "axioms": 0,
+    "buildVerified": false
+  },
+  "knowledge": {
+    "insights": [
+      "The entire open content of the Minkowski re-derivation collapses to one measure computation, volume(K) = 4. With the geometric facts (symmetry, convexity, closedness) and the whole arithmetic back-end (lattice point ⇒ Dirichlet, with sign + boundary handling) machine-checked, the only remaining content is the single Haar-volume computation — exactly mirroring the textbook one-liner 'area is 4, so there is a lattice point, so Dirichlet.'",
+      "Minkowski gives the non-strict bound |qα − p| ≤ 1/N, not the strict < of the pigeonhole entry. The closed body has area exactly 4, so only the closed/compact ≤-variant exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure applies; the strict variant needs area > 4 and an open-boundary refinement. The ≤ form is the honest geometry-of-numbers result.",
+      "The q = 0 boundary subtlety is real and is dispatched by requiring N ≥ 2. A nonzero integer point of K can have first coordinate 0 only if it is (0, ±1), which lies in K exactly when N = 1 (since 1/N ≥ 1 ⟺ N ≤ 1). Hence the arithmetic bridge assumes N ≥ 2; N = 1 is the trivial case q = 1, p = round α.",
+      "The convex body is engineered as an intersection of two linear slabs, K = proj₀⁻¹(Icc −N N) ∩ (α·proj₀ − proj₁)⁻¹(Icc −1/N 1/N), so convexity (Convex.linear_preimage on convex_Icc) and closedness (IsClosed.preimage of isClosed_Icc under LinearMap.continuous_of_finiteDimensional) both fall out of the same one-line set rewrite, with no ad-hoc geometry.",
+      "Volume(K) = 4 will follow from a shear: K is the image of the box [−N,N] × [−1/N,1/N] (Lebesgue volume 4) under (x,y) ↦ (x, αx − y), a linear map of determinant −1, so addHaar_image_linearMap gives volume(K) = |det|·4 = 4 against the standard lattice ℤ² = span ℤ (range (Pi.basisFun ℝ (Fin 2))) of covolume 1.",
+      "The volume computation closes via a determinant-(-1) shear T(x,y) = (x, alpha*x - y): K = T '' box where box = [-N,N] x [-1/N,1/N] has Lebesgue volume 4 (volume_pi_pi + Real.volume_Icc), and addHaar_image_linearMap gives volume(K) = |det T| * 4 = 4. T is an involution (shear_involutive), which makes body_eq_image a one-line round-trip rather than needing an inverse map.",
+      "The unconditional assembly feeds covol(ZZ^2) * 2^dim = 1 * 2^2 = 4 <= 4 = volume(K) into exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure with the standard lattice span ZZ (range (Pi.basisFun RR (Fin 2))); lattice membership is converted to integer coordinates via Basis.mem_span_iff_repr_mem, discharging the hMink hypothesis of dirichlet_via_convex_body."
+    ],
+    "builtItems": [
+      "body (DirichletApproximationOQ03.lean) — the symmetric convex body K(α,N) = {v : Fin 2 → ℝ | |v 0| ≤ N ∧ |α·v 0 − v 1| ≤ 1/N}.",
+      "body_symm, body_convex, body_isClosed — K is symmetric about the origin, convex, and closed; the three geometric hypotheses Minkowski's closed convex-body theorem consumes, each discharged sorry-free via the slab-intersection presentation.",
+      "dirichlet_of_lattice_point — the arithmetic bridge: for N ≥ 2, a nonzero integer point (q₀, p₀) of K is a Dirichlet approximation, with full sign normalisation to 1 ≤ q ≤ N and the q = 0 boundary case (0, ±1) ruled out.",
+      "dirichlet_via_convex_body — Dirichlet's bound |qα − p| ≤ 1/N (1 ≤ q ≤ N), conditional on the Minkowski conclusion (existence of a nonzero integer point of K); extracts integer coordinates and feeds the bridge.",
+      "Registered import Proofs.DirichletApproximationOQ03 in proofs/Proofs.lean so the entry is part of the CI build.",
+      "shear, box, shear_apply_zero/one, shear_involutive, body_eq_image, box_eq_Icc, box_isCompact, body_isCompact — the determinant-(-1) shear and the box/body image identity (DirichletApproximationOQ03.lean).",
+      "box_volume (= 4) and body_volume (= 4) — the measure computation Minkowski consumes, via volume_pi_pi/Real.volume_Icc and addHaar_image_linearMap with LinearMap.det_toLin' + Matrix.det_fin_two_of.",
+      "dirichlet_via_minkowski — the unconditional, sorry-free, axiom-free capstone: Dirichlet's |q*alpha - p| <= 1/N (1 <= q <= N, N >= 2) from Mathlib's compact convex-body theorem. BUILD UNVERIFIED this session (Docker down)."
+    ],
+    "mathlibGaps": [
+      "Mathlib has the Minkowski convex-body theorem exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure and the lattice fundamental-domain API (ZSpan.isAddFundamentalDomain, ZSpan.volume_fundamentalDomain), but no packaged Dirichlet-via-geometry-of-numbers corollary; this entry supplies the convex body, the geometric inputs, and the arithmetic bridge.",
+      "The remaining volume computation volume(body α N) = 4 has no off-the-shelf lemma; it requires building the shear LinearMap on Fin 2 → ℝ, its det via Matrix.det_fin_two, the box volume via volume_pi/Real.volume_Icc, and the set equality body = T '' box, then addHaar_image_linearMap."
+    ],
+    "nextSteps": [
+      "VERIFY THE BUILD: run ./proofs/scripts/docker-build.sh Proofs.DirichletApproximationOQ03 once Docker is back up. The risk surface is Mathlib lemma-name/signature drift in the unconditional assembly (ZSpan.isAddFundamentalDomain', exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure, ZSpan.fundamentalDomain_pi_basisFun, addHaar_image_linearMap, Basis.mem_span_iff_repr_mem) — fix any drift and rebuild.",
+      "Once build-verified, promote this to a gallery entry (src/data/proofs/) with status verified / badge original (0 sorry, 0 axiom, no Lean.ofReduceBool) and cross-reference the pigeonhole dirichlet-approximation-theorem entry it re-derives.",
+      "Settle the subsumption question via continued-fraction convergent selection (abs_sub_convergents_le', choosing the convergent with B_n <= N < B_{n+1}), or record that pigeonhole / Minkowski / continued fractions all give the same 1/N strength.",
+      "Optionally sharpen to the strict < 1/N via the open-boundary refinement (area > 4 variant of the convex body)."
+    ],
+    "progressSummary": "COMPLETE (drafted, build-unverified): the Minkowski re-derivation of Dirichlet's bound is now a full unconditional proof, sorry-free and axiom-free by source inspection. The remaining volume computation volume(K) = 4 was discharged via the determinant-(-1) shear, and dirichlet_via_minkowski assembles the unconditional bound from Mathlib's compact convex-body theorem. The only outstanding item is BUILD VERIFICATION: Docker was unresponsive this session, so the elaboration/axiom-free claims rest on inspection and must be confirmed by a docker build before being treated as machine-checked."
+  },
+  "approaches": [
+    {
+      "name": "Minkowski convex-body theorem on K(α,N) = {|x| ≤ N, |αx − y| ≤ 1/N}",
+      "outcome": "success (build-unverified)",
+      "notes": "Full unconditional proof drafted sorry-free and axiom-free: body_symm/convex/isClosed/isCompact (geometry), body_eq_image + box_volume + body_volume (volume(K) = 4 via the det -1 shear and addHaar_image_linearMap), dirichlet_of_lattice_point (arithmetic bridge with sign normalisation and q=0 boundary), and dirichlet_via_minkowski (unconditional capstone via exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure). Build UNVERIFIED this session (Docker daemon down); needs a docker build to confirm Mathlib lemma names elaborate."
+    },
+    {
+      "name": "Continued-fraction subsumption",
+      "outcome": "open",
+      "notes": "Mathlib's abs_sub_convergents_le' / abs_sub_convs_le give convergent error bounds; selecting the convergent with Bₙ ≤ N < Bₙ₊₁ would yield Dirichlet, but assembling the index existence, denominator monotonicity, and rational-termination edge case is itself multi-lemma work that only re-proves what pigeonhole already gives."
+    }
+  ],
+  "knownResults": [
+    "Dirichlet (1842): the one-dimensional pigeonhole approximation bound (parent gallery entry).",
+    "Minkowski's convex-body theorem: a symmetric convex body of volume ≥ 2ⁿ·covol(L) (compact variant) contains a nonzero lattice point — the canonical geometry-of-numbers tool.",
+    "Mathlib: exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure (Minkowski), ZSpan.volume_fundamentalDomain (standard lattice covolume 1), addHaar_image_linearMap (linear-image volume law)."
+  ],
+  "references": [
+    "Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean (exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure)",
+    "Mathlib/Algebra/Module/ZLattice/Basic.lean (ZSpan.volume_fundamentalDomain, ZSpan.isAddFundamentalDomain)",
+    "Mathlib/MeasureTheory/Measure/Haar/Linear.lean (addHaar_image_linearMap)",
+    "https://en.wikipedia.org/wiki/Dirichlet%27s_approximation_theorem",
+    "https://en.wikipedia.org/wiki/Minkowski%27s_theorem"
+  ],
+  "relatedProofs": [
+    "dirichlet-approximation-theorem",
+    "dirichlet-approximation-theorem (parent, one-shot one-dimensional pigeonhole bound)",
+    "dirichlet-approximation-theorem-oq-01 (sibling, infinitude upgrade in dimension 1)",
+    "dirichlet-approximation-theorem-oq-02 (sibling, simultaneous approximation via the torus)"
+  ]
+}


### PR DESCRIPTION
## Summary

Completes **dirichlet-approximation-theorem-oq-03**: the geometry-of-numbers re-derivation of Dirichlet's approximation theorem `|qα − p| ≤ 1/N` (`1 ≤ q ≤ N`, `N ≥ 2`) via Minkowski's convex-body theorem. Session 1 reduced the proof to the single measure computation `volume(K) = 4`; this session closes that crux and assembles the **unconditional** proof.

## Progress

`proofs/Proofs/DirichletApproximationOQ03.lean` — 18 theorems/defs, **0 sorry, 0 axiom declarations, no native_decide** (grep-verified; "sorry"/"axiom" appear only in doc-comment prose):

- **Geometry** (Session 1): `body` (the symmetric convex body `K(α,N) = {|x| ≤ N, |αx − y| ≤ 1/N}`), `body_symm`, `body_convex`, `body_isClosed`.
- **Volume crux** (new): the determinant-(−1) shear `(x,y) ↦ (x, αx − y)` (`shear`, an involution) maps the box `[−N,N]×[−1/N,1/N]` onto `K` (`body_eq_image`); `box_volume = 4` (`volume_pi_pi`/`Real.volume_Icc`) and `body_volume = 4` (`addHaar_image_linearMap`, `LinearMap.det_toLin'` + `Matrix.det_fin_two_of`).
- **Arithmetic bridge** (Session 1): `dirichlet_of_lattice_point` — a nonzero integer point of `K` is a Dirichlet approximation (sign normalisation to `1 ≤ q ≤ N`, `q = 0` boundary excluded for `N ≥ 2`).
- **Unconditional capstone** (new): `dirichlet_via_minkowski` feeds `covol(ℤ²)·2^dim = 1·2² = 4 ≤ 4 = volume(K)` into `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure` against the standard lattice `span ℤ (range (Pi.basisFun ℝ (Fin 2)))`, then reads off integer coordinates via `Basis.mem_span_iff_repr_mem` to discharge the conditional `dirichlet_via_convex_body`.

## Findings

- The whole open content collapsed to one measure computation, dispatched by a single shear change-of-variables — mirroring the textbook one-liner "area is 4, so there is a lattice point, so Dirichlet."
- Minkowski gives the non-strict `≤ 1/N` (the body has area *exactly* 4, so only the compact `≤`-variant applies); the pigeonhole entry's strict `<` would need an open-boundary (area > 4) refinement.

## ⚠️ Build status — UNVERIFIED this session

The Docker build daemon was **unresponsive** (`docker version`/`docker ps` hung; host load avg ~12–17), so **the build was not run**. The sorry/axiom-free and elaboration claims rest on **source inspection only**. A successful `./proofs/scripts/docker-build.sh Proofs.DirichletApproximationOQ03` is required before this is treated as machine-checked. Risk surface is Mathlib lemma-name/signature drift in the unconditional assembly (`ZSpan.isAddFundamentalDomain'`, `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure`, `ZSpan.fundamentalDomain_pi_basisFun`, `addHaar_image_linearMap`, `Basis.mem_span_iff_repr_mem`). The gallery JSON sets `buildVerified: false`; docs flag the same.

## Status

**Outcome**: complete (drafted) — pending build verification
**Next Steps**: build-verify when Docker is back; on green, promote to a `src/data/proofs/` gallery entry (`verified`/`original`) cross-referencing the pigeonhole `dirichlet-approximation-theorem`.

🤖 Generated by researcher-2