### PR TITLE
Enrich Friendship Theorem (parent): forward-link 3 verified OQ extensions

### DIFF
--- a/src/data/proofs/friendship-theorem/meta.json
+++ b/src/data/proofs/friendship-theorem/meta.json
@@ -179,6 +179,21 @@
       "targetId": "prob-method-expectation",
       "relationship": "related",
       "description": "The friendship theorem was proved by Erdos, who pioneered the probabilistic method: while the friendship theorem itself uses spectral rather than probabilistic methods, the expectation method provides alternative approaches to extremal graph theory problems of the same flavor"
+    },
+    {
+      "targetId": "friendship-theorem-oq-01",
+      "relationship": "extended-by",
+      "description": "An alternative spectral proof of the Friendship Theorem via the characteristic polynomial and eigenvalue structure of the adjacency matrix."
+    },
+    {
+      "targetId": "friendship-theorem-oq-03",
+      "relationship": "extended-by",
+      "description": "A hypergraph analog showing the friendship condition can fail in higher dimensions, with the Fano plane as the canonical counterexample."
+    },
+    {
+      "targetId": "friendship-theorem-oq-04",
+      "relationship": "extended-by",
+      "description": "An extension of the friendship condition to infinite graphs, analyzing whether a universal friend must still exist."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Adds `extended-by` cross-references from the base **Friendship Theorem** entry to its three verified open-question children. Each child already links back to the parent (`extends`); this closes the missing forward direction.

| Child | Status | Topic |
|-------|--------|-------|
| friendship-theorem-oq-01 | verified | Spectral proof via characteristic polynomials |
| friendship-theorem-oq-03 | verified | Hypergraph analog / Fano plane counterexample |
| friendship-theorem-oq-04 | verified | The infinite case |

Only `meta.json` crossReferences changed; annotations and Lean source untouched.