### PR TITLE
Enrich Cyclic Vector Theorem (all fields, parent): forward-link 3 verified OQ extensions

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -1,188 +1,203 @@
 {
-    "id": "cayley-hamilton-cyclic-vector-all-fields",
-    "title": "Nonderogatory → Cyclic Vector: All Fields (Primary Decomposition)",
-    "slug": "cayley-hamilton-cyclic-vector-all-fields",
-    "description": "Every nonderogatory matrix over ANY field (including finite fields F_q with q ≤ n) has a cyclic vector. Proved axiom-free via primary decomposition and CRT (WIP04): factor minpoly into coprime prime powers, construct primary vectors via minimality, combine with Bezout projections. Fully machine-verified: 0 sorries, 0 axioms.",
-    "meta": {
-        "author": "Classical linear algebra (F.G. Frobenius, 1878)",
-        "sourceUrl": "",
-        "date": "2026",
-        "status": "verified",
-        "proofRepoPath": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
-        "tags": [
-            "linear-algebra",
-            "matrices",
-            "cyclic-vector",
-            "rational-canonical-form",
-            "companion-matrix",
-            "finite-fields",
-            "minimal-polynomial"
-        ],
-        "badge": "mathlib",
-        "sorries": 0,
-        "axiomCount": 0,
-        "theoremCount": 8,
-        "lineCount": 266,
-        "assumptions": "",
-        "mathlib_version": "4.26.0",
-        "mathlibDependencies": [
-            {
-                "theorem": "minpoly.monic",
-                "description": "Minimal polynomial is monic",
-                "module": "Mathlib.FieldTheory.Minpoly.Basic"
-            },
-            {
-                "theorem": "Matrix.charpoly_natDegree_eq_dim",
-                "description": "Characteristic polynomial has degree = matrix dimension",
-                "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
-            },
-            {
-                "theorem": "Matrix.isIntegral",
-                "description": "Matrices are integral over their base field",
-                "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
-            }
-        ],
-        "originalContributions": [
-            "V2 upgrade: eliminated RCF similarity axiom via primary decomposition (WIP04)",
-            "Main theorem: nonderogatory_has_cyclic_vector (0 axioms, 0 sorries)",
-            "Corollary: nonderogatory_has_cyclic_vector_finite for any finite field",
-            "Corollary: cyclic_iff_not_killed_below_degree equivalence",
-            "Factorization bridge: monic_factored_form proved via UniqueFactorizationMonoid (0 sorry)"
-        ],
-        "dateAdded": "2026-04-26",
-        "definitionCount": 2,
-        "additionalFiles": [
-          "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean",
-          "Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean"
-        ]
-    },
-    "overview": {
-        "historicalContext": "The cyclic vector theorem lies at the intersection of two major 19th-century programs: the canonical form theory for linear operators and the module theory of rings. **Camille Jordan** (1870) established the Jordan normal form, decomposing complex matrices into Jordan blocks — a decomposition that requires all eigenvalues to lie in the base field. Jordan's theory was restricted to algebraically closed fields like $\\mathbb{C}$. **Ferdinand Georg Frobenius** (1878), in his landmark paper *Über lineare Substitutionen und bilineare Formen*, overcame this restriction by introducing the **rational canonical form** (now also called Frobenius normal form): every matrix over an arbitrary field is similar to a block-diagonal matrix of companion matrices $\\mathrm{diag}(C(d_1), \\ldots, C(d_r))$, where $d_1 \\mid \\cdots \\mid d_r$ are the **invariant factors** — computed from the matrix's characteristic polynomial via the PID $K[X]$ without reference to eigenvalues. This makes the theory valid over $\\mathbb{Q}$, $\\mathbb{F}_p$, and any field.\n\nA matrix $M \\in M_n(K)$ is **nonderogatory** when its minimal polynomial equals its characteristic polynomial; a vector $v$ is **cyclic** for $M$ when $\\{v, Mv, \\ldots, M^{n-1}v\\}$ is a basis. The cyclic vector theorem — nonderogatory $\\Rightarrow$ cyclic — holds over ALL fields. The modern module-theoretic proof, developed through **Emmy Noether's** 1929 work on the structure theorem for finitely generated modules over PIDs, shows that nonderogatory forces $K^n \\cong K[X]/(\\mathrm{minpoly}\\, M)$ as a $K[X]$-module, making cyclicity immediate. **H.J.S. Smith** (1861) gave the first constructive approach via Smith normal form for polynomial matrices, providing an algorithm for computing invariant factors. This formalization captures the theory via an explicit axiom for the PID structure theorem — the single Mathlib gap — and fully verifies the main theorem from it.",
-        "problemStatement": "For any field $K$ and any nonderogatory matrix $M \\in M_n(K)$, prove there exists a cyclic vector $v \\in K^n$ — a vector such that $\\{v, Mv, \\ldots, M^{n-1}v\\}$ is a basis for $K^n$.",
-        "proofStrategy": "V2 uses primary decomposition instead of the RCF similarity axiom. Factor $\\mathrm{minpoly}_K(M) = \\prod_i p_i^{e_i}$ (coprime prime powers). For each factor $p_i^{e_i}$, define complementary product $F_i = \\prod_{j \\neq i} p_j^{e_j}$ and choose $w_i$ with $(p_i^{e_i-1} \\cdot F_i)(M) w_i \\neq 0$ (exists by minimality of minpoly). Set $v_i = F_i(M) w_i$. Then $v = \\sum_i v_i$ is cyclic: for any $r$ with $r(M)v = 0$, Bezout projections $\\pi_i = (b_i \\cdot F_i)(M)$ extract $r(M)v_i = 0$ for each $i$. By `pow_irred_dvd_of_annihilated`, $p_i^{e_i} | r$ for all $i$. Pairwise coprimality gives $\\mathrm{minpoly} | r$, so $\\deg(r) \\geq n$, contradicting $\\deg(r) < n$. The proof never invokes field cardinality or companion matrices.",
-        "keyInsights": [
-            "The union avoidance argument (used in `cayley-hamilton-minpoly-oq-05-oq-01` for infinite fields) is a cardinality argument that fails over $\\mathbb{F}_2$ when $n = 2$: all 3 nonzero vectors of $\\mathbb{F}_2^2$ are covered by 3 proper subspaces. Yet the theorem still holds — the RCF similarity approach is purely algebraic and works over any field.",
-            "The companion matrix $C(p)$ has a built-in cyclic vector: $e_0 = (1, 0, \\ldots, 0)^T$. The orbit $\\{e_0, C(p)e_0, C(p)^2 e_0, \\ldots\\} = \\{e_0, e_1, e_2, \\ldots\\}$ is simply the standard basis. This is proved in `companionMatrix_cyclic_e0` without any hypothesis on the base field.",
-            "The factorization bridge (`monic_factored_form`) is the key abstraction: it converts Mathlib's UFD `Multiset` output to the `Fin k`-indexed array that WIP04 expects. Four private lemmas accomplish this translation: UFD multiset factorization, coprimality of distinct monic irreducibles, coprimality lifting to prime powers, and the multiset-to-Fin-array conversion. This API translation layer is what makes the primary decomposition theorem from WIP04 applicable here.",
-            "The V2 proof chain is cleaner than V1: `monic_factored_form` (Section II, proved) → `GeneralCyclicVector.nonderogatory_general_has_cyclic_vector` (WIP04, proved) → main theorem. Compared to V1's chain through `nonderogatory_similar_companion` (axiom) → `companionMatrix_cyclic_e0` → `cyclic_vector_of_similar`, V2 requires no companion matrix machinery and works by annihilator algebra alone.",
-            "**The $K[X]$-module interpretation of cyclicity**: Giving $K^n$ the $K[X]$-module structure where $X$ acts as $M$, cyclicity of $v$ means exactly that $v$ generates $K^n$ as a $K[X]$-module: $K[X] \\cdot v = K^n$. For nonderogatory $M$, this generator exists because $K^n \\cong K[X]/(\\mathrm{minpoly}\\, M)$ as $K[X]$-modules. The primary decomposition proof constructs this generator directly: $v = \\sum_i v_i$ where $v_i$ generates the $p_i^{e_i}$-primary component, and the Bezout projections ensure $v$ generates the full module. No companion matrix or RCF similarity is needed — the isomorphism is realized via the CRT combination."
-        ]
-    },
-    "sections": [
-        {
-            "id": "definitions",
-            "title": "§ I. Definitions",
-            "startLine": 48,
-            "endLine": 68,
-            "summary": "Defines `IsCyclicVector` and `IsNonderogatory` as `abbrev` (reducible) aliases for the definitions in `GeneralCyclicVector` (WIP04), ensuring type-level compatibility when delegating to the primary decomposition theorem.",
-            "mathContext": "A vector $v \\in K^n$ is cyclic for $M$ when $\\{v, Mv, \\ldots, M^{n-1}v\\}$ is linearly independent (equivalently, no nonzero polynomial of degree $< n$ annihilates both $M$ and $v$). A matrix is nonderogatory when $\\mathrm{minpoly}_K(M) = \\mathrm{charpoly}(M)$, both of degree $n$. Using `abbrev` (not `def`) ensures that WIP04's theorem result type unifies with this file's goal type without explicit coercions."
-        },
-        {
-            "id": "factorization-bridge",
-            "title": "§ II. Factorization Bridge",
-            "startLine": 69,
-            "endLine": 170,
-            "summary": "Four private theorems build up to `monic_factored_form`: every monic polynomial of positive degree factors into coprime monic irreducible prime powers (Fin k-indexed). All four are fully proved — the sorry described in the Section V docstring has been filled.",
-            "mathContext": "The bridge converts Mathlib's UFD output (a `Multiset` of primes from `UniqueFactorizationMonoid.exists_prime_factors`) to the `Fin k`-indexed form that WIP04 expects. Four lemmas: (1) multiset factorization from UFD; (2) distinct monic irreducibles are coprime; (3) coprimality lifts to prime powers; (4) multiset → Fin k conversion grouping by multiplicity. The combined result matches WIP04's interface contract exactly."
-        },
-        {
-            "id": "main-theorem",
-            "title": "§ III. Main Theorem",
-            "startLine": 172,
-            "endLine": 205,
-            "summary": "Proves `nonderogatory_has_cyclic_vector`: dispatches n=0 (trivial), then factors minpoly via `monic_factored_form` and delegates to WIP04's primary decomposition theorem. Zero axioms, zero sorries.",
-            "mathContext": "Proof: (1) $n = 0$: trivial via `Fin.elim0`. (2) $n > 0$: nonderogatory gives $\\deg(\\mathrm{minpoly}) = n$; `monic_factored_form` gives $\\mathrm{minpoly} = \\prod_i p_i^{e_i}$ (coprime prime powers); `GeneralCyclicVector.nonderogatory_general_has_cyclic_vector` (WIP04) constructs the cyclic vector via Bezout projections."
-        },
-        {
-            "id": "corollaries",
-            "title": "§ IV. Corollaries",
-            "startLine": 207,
-            "endLine": 230,
-            "summary": "Two corollaries: `nonderogatory_has_cyclic_vector_finite` (specializes to finite fields, where union avoidance fails) and `cyclic_iff_not_killed_below_degree` (polynomial annihilator reformulation).",
-            "mathContext": "The finite field corollary demonstrates that the primary decomposition approach works even when $|K| \\leq n$ — the regime where union avoidance fails over $\\mathbb{F}_2$. The equivalence corollary: $v$ is cyclic iff $\\forall p \\neq 0$ with $\\deg(p) < n$, $p(M)v \\neq 0$. Both corollaries are one-liners from the main theorem."
-        },
-        {
-            "id": "summary-block",
-            "title": "§ V. Proof Summary",
-            "startLine": 232,
-            "endLine": 266,
-            "summary": "Closing docstring: enumerates the V2 upgrade (axiom eliminated, factorization bridge proved), lists all five proved results, and documents the V1→V2 delta. Note: the 'one sorry' in lines 253–258 refers to an earlier V2-beta state; the sorry is filled in the current file.",
-            "mathContext": "V1 → V2 delta: RCF similarity axiom ($\\sim$800 lines from PID structure theorem + Smith normal form) replaced by direct UFD-based `monic_factored_form` proof. Net: the mathematical content is fully verified with 0 axioms and 0 sorries. The Section V docstring's claim of 'one sorry' describes an intermediate development state."
-        }
+  "id": "cayley-hamilton-cyclic-vector-all-fields",
+  "title": "Nonderogatory → Cyclic Vector: All Fields (Primary Decomposition)",
+  "slug": "cayley-hamilton-cyclic-vector-all-fields",
+  "description": "Every nonderogatory matrix over ANY field (including finite fields F_q with q ≤ n) has a cyclic vector. Proved axiom-free via primary decomposition and CRT (WIP04): factor minpoly into coprime prime powers, construct primary vectors via minimality, combine with Bezout projections. Fully machine-verified: 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Classical linear algebra (F.G. Frobenius, 1878)",
+    "sourceUrl": "",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
+    "tags": [
+      "linear-algebra",
+      "matrices",
+      "cyclic-vector",
+      "rational-canonical-form",
+      "companion-matrix",
+      "finite-fields",
+      "minimal-polynomial"
     ],
-    "conclusion": {
-        "summary": "V2 of this formalization eliminates the RCF similarity axiom, proving the cyclic vector theorem axiom-free via primary decomposition (WIP04). Fully machine-verified: 0 axioms, 0 sorries.",
-        "implications": "The upgrade from V1 (1 axiom, 0 sorries) to V2 (0 axioms, 0 sorries) replaces a deep mathematical assumption (PID structure theorem, ~800 lines to formalize) with a proved factorization bridge (monic_factored_form, ~100 lines of normalizedFactors navigation). The primary decomposition approach (Bezout projections + CRT) is the key innovation: it bypasses companion matrices entirely, working directly with polynomial annihilators.",
-        "openQuestions": [
-            "Can the factorization bridge be proved without Finset.equivFin? A direct Finset-indexed version of WIP04's theorem would eliminate the Fin k conversion overhead.",
-            "Can the converse be formalized to obtain a full equivalence? This file proves nonderogatory ($\\deg(\\mathrm{minpoly}_M) = n$) $\\Rightarrow$ a cyclic vector exists. The converse — a cyclic vector $v$ forces $M$ to be nonderogatory, because $\\{v, Mv, \\ldots, M^{n-1}v\\}$ being a basis means no polynomial of degree $< n$ annihilates $v$, hence $\\deg(\\mathrm{minpoly}_M) \\geq n$ — would upgrade the result to the textbook iff $M$ is nonderogatory $\\Leftrightarrow$ $M$ admits a cyclic vector $\\Leftrightarrow$ $\\mathrm{minpoly}_M = \\mathrm{charpoly}_M$.",
-            "Does the proof generalize to a coordinate-free single operator $T : V \\to V$ on a finite-dimensional $K$-vector space, and further to finitely generated torsion modules over a PID? The primary-decomposition / Bezout-projection argument used here is exactly the module-theoretic structure theorem specialized to $K[x]$; abstracting away the matrix representation (working with $K[x]$-module $V$ where $x$ acts as $T$) would connect this entry directly to Mathlib's `Module` and PID-structure infrastructure rather than `Matrix`."
-        ]
-    },
-    "leanFile": {
-        "imports": [
-            "Mathlib",
-            "Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04"
-        ],
-        "opens": [
-            "Matrix",
-            "Polynomial"
-        ],
-        "namespace": "CayleyHamiltonCyclicVectorAllFields",
-        "lineCount": 266,
-        "axiomCount": 0,
-        "theoremCount": 8,
-        "definitionCount": 2,
-        "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
-        "sorries": 0,
-        "additionalFiles": [
-            "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean",
-            "Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean"
-        ]
-    },
-    "crossReferences": [
-        {
-            "targetId": "cayley-hamilton-minpoly-oq-05-oq-01",
-            "relationship": "extends",
-            "description": "Converse: nonderogatory ← cyclic (proved for infinite fields using union avoidance). This file proves the opposite direction for ALL fields via primary decomposition (WIP04), bypassing both cardinality arguments and the RCF similarity theorem."
-        },
-        {
-            "targetId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",
-            "relationship": "companion",
-            "description": "Alternative approach using module theory with sorry. Both files now use 0 axioms; this file (V2) uses primary decomposition from WIP04 while OQ-04 uses a different module-theory approach — contrasting proof architectures for the same theorem."
-        },
-        {
-            "targetId": "cayley-hamilton-reduction-oq-02-oq-01",
-            "relationship": "uses",
-            "description": "Companion matrix definition and orbit lemma C(p)^k · e₀ = eₖ. The two proved supporting lemmas live in CayleyHamiltonMinpolyOQ05OQ01OQ04 which imports this file."
-        },
-        {
-            "targetId": "cayley-hamilton",
-            "relationship": "related",
-            "description": "The Cayley-Hamilton theorem (M satisfies its own characteristic polynomial) is the starting point of the entire series. This file builds on the charpoly infrastructure (Matrix.charpoly_natDegree_eq_dim) established there."
-        },
-        {
-            "targetId": "cayley-hamilton-minpoly-oq-05",
-            "relationship": "part-of",
-            "description": "The parent open question series on the minimal polynomial characterization of nonderogatory matrices. This All-Fields result completes the series by removing the |K| > n restriction from OQ-01."
-        }
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "lineCount": 266,
+    "assumptions": "",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "minpoly.monic",
+        "description": "Minimal polynomial is monic",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "Matrix.charpoly_natDegree_eq_dim",
+        "description": "Characteristic polynomial has degree = matrix dimension",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
+      },
+      {
+        "theorem": "Matrix.isIntegral",
+        "description": "Matrices are integral over their base field",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
+      }
     ],
-    "mainTheorems": [
-        {
-            "name": "CayleyHamiltonCyclicVectorAllFields.nonderogatory_has_cyclic_vector",
-            "statement": "∀ (M : Matrix (Fin n) (Fin n) K), IsNonderogatory M → ∃ v, IsCyclicVector M v",
-            "description": "Main theorem: every nonderogatory matrix over ANY field has a cyclic vector. 0 axioms, 0 sorries."
-        },
-        {
-            "name": "CayleyHamiltonCyclicVectorAllFields.nonderogatory_has_cyclic_vector_finite",
-            "statement": "∀ [Fintype K] (M : Matrix (Fin n) (Fin n) K), IsNonderogatory M → ∃ v, IsCyclicVector M v",
-            "description": "Specializes to finite fields F_q where q ≤ n, covering the regime where union avoidance fails."
-        },
-        {
-            "name": "CayleyHamiltonCyclicVectorAllFields.cyclic_iff_not_killed_below_degree",
-            "statement": "IsNonderogatory M → (IsCyclicVector M v ↔ ∀ p : K[X], p ≠ 0 → p.natDegree < n → ¬(aeval M p).mulVec v = 0)",
-            "description": "Polynomial annihilator characterization: cyclic iff not killed by any nonzero polynomial of degree < n."
-        }
+    "originalContributions": [
+      "V2 upgrade: eliminated RCF similarity axiom via primary decomposition (WIP04)",
+      "Main theorem: nonderogatory_has_cyclic_vector (0 axioms, 0 sorries)",
+      "Corollary: nonderogatory_has_cyclic_vector_finite for any finite field",
+      "Corollary: cyclic_iff_not_killed_below_degree equivalence",
+      "Factorization bridge: monic_factored_form proved via UniqueFactorizationMonoid (0 sorry)"
     ],
-    "sorries": 0
+    "dateAdded": "2026-04-26",
+    "definitionCount": 2,
+    "additionalFiles": [
+      "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean",
+      "Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The cyclic vector theorem lies at the intersection of two major 19th-century programs: the canonical form theory for linear operators and the module theory of rings. **Camille Jordan** (1870) established the Jordan normal form, decomposing complex matrices into Jordan blocks — a decomposition that requires all eigenvalues to lie in the base field. Jordan's theory was restricted to algebraically closed fields like $\\mathbb{C}$. **Ferdinand Georg Frobenius** (1878), in his landmark paper *Über lineare Substitutionen und bilineare Formen*, overcame this restriction by introducing the **rational canonical form** (now also called Frobenius normal form): every matrix over an arbitrary field is similar to a block-diagonal matrix of companion matrices $\\mathrm{diag}(C(d_1), \\ldots, C(d_r))$, where $d_1 \\mid \\cdots \\mid d_r$ are the **invariant factors** — computed from the matrix's characteristic polynomial via the PID $K[X]$ without reference to eigenvalues. This makes the theory valid over $\\mathbb{Q}$, $\\mathbb{F}_p$, and any field.\n\nA matrix $M \\in M_n(K)$ is **nonderogatory** when its minimal polynomial equals its characteristic polynomial; a vector $v$ is **cyclic** for $M$ when $\\{v, Mv, \\ldots, M^{n-1}v\\}$ is a basis. The cyclic vector theorem — nonderogatory $\\Rightarrow$ cyclic — holds over ALL fields. The modern module-theoretic proof, developed through **Emmy Noether's** 1929 work on the structure theorem for finitely generated modules over PIDs, shows that nonderogatory forces $K^n \\cong K[X]/(\\mathrm{minpoly}\\, M)$ as a $K[X]$-module, making cyclicity immediate. **H.J.S. Smith** (1861) gave the first constructive approach via Smith normal form for polynomial matrices, providing an algorithm for computing invariant factors. This formalization captures the theory via an explicit axiom for the PID structure theorem — the single Mathlib gap — and fully verifies the main theorem from it.",
+    "problemStatement": "For any field $K$ and any nonderogatory matrix $M \\in M_n(K)$, prove there exists a cyclic vector $v \\in K^n$ — a vector such that $\\{v, Mv, \\ldots, M^{n-1}v\\}$ is a basis for $K^n$.",
+    "proofStrategy": "V2 uses primary decomposition instead of the RCF similarity axiom. Factor $\\mathrm{minpoly}_K(M) = \\prod_i p_i^{e_i}$ (coprime prime powers). For each factor $p_i^{e_i}$, define complementary product $F_i = \\prod_{j \\neq i} p_j^{e_j}$ and choose $w_i$ with $(p_i^{e_i-1} \\cdot F_i)(M) w_i \\neq 0$ (exists by minimality of minpoly). Set $v_i = F_i(M) w_i$. Then $v = \\sum_i v_i$ is cyclic: for any $r$ with $r(M)v = 0$, Bezout projections $\\pi_i = (b_i \\cdot F_i)(M)$ extract $r(M)v_i = 0$ for each $i$. By `pow_irred_dvd_of_annihilated`, $p_i^{e_i} | r$ for all $i$. Pairwise coprimality gives $\\mathrm{minpoly} | r$, so $\\deg(r) \\geq n$, contradicting $\\deg(r) < n$. The proof never invokes field cardinality or companion matrices.",
+    "keyInsights": [
+      "The union avoidance argument (used in `cayley-hamilton-minpoly-oq-05-oq-01` for infinite fields) is a cardinality argument that fails over $\\mathbb{F}_2$ when $n = 2$: all 3 nonzero vectors of $\\mathbb{F}_2^2$ are covered by 3 proper subspaces. Yet the theorem still holds — the RCF similarity approach is purely algebraic and works over any field.",
+      "The companion matrix $C(p)$ has a built-in cyclic vector: $e_0 = (1, 0, \\ldots, 0)^T$. The orbit $\\{e_0, C(p)e_0, C(p)^2 e_0, \\ldots\\} = \\{e_0, e_1, e_2, \\ldots\\}$ is simply the standard basis. This is proved in `companionMatrix_cyclic_e0` without any hypothesis on the base field.",
+      "The factorization bridge (`monic_factored_form`) is the key abstraction: it converts Mathlib's UFD `Multiset` output to the `Fin k`-indexed array that WIP04 expects. Four private lemmas accomplish this translation: UFD multiset factorization, coprimality of distinct monic irreducibles, coprimality lifting to prime powers, and the multiset-to-Fin-array conversion. This API translation layer is what makes the primary decomposition theorem from WIP04 applicable here.",
+      "The V2 proof chain is cleaner than V1: `monic_factored_form` (Section II, proved) → `GeneralCyclicVector.nonderogatory_general_has_cyclic_vector` (WIP04, proved) → main theorem. Compared to V1's chain through `nonderogatory_similar_companion` (axiom) → `companionMatrix_cyclic_e0` → `cyclic_vector_of_similar`, V2 requires no companion matrix machinery and works by annihilator algebra alone.",
+      "**The $K[X]$-module interpretation of cyclicity**: Giving $K^n$ the $K[X]$-module structure where $X$ acts as $M$, cyclicity of $v$ means exactly that $v$ generates $K^n$ as a $K[X]$-module: $K[X] \\cdot v = K^n$. For nonderogatory $M$, this generator exists because $K^n \\cong K[X]/(\\mathrm{minpoly}\\, M)$ as $K[X]$-modules. The primary decomposition proof constructs this generator directly: $v = \\sum_i v_i$ where $v_i$ generates the $p_i^{e_i}$-primary component, and the Bezout projections ensure $v$ generates the full module. No companion matrix or RCF similarity is needed — the isomorphism is realized via the CRT combination."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "§ I. Definitions",
+      "startLine": 48,
+      "endLine": 68,
+      "summary": "Defines `IsCyclicVector` and `IsNonderogatory` as `abbrev` (reducible) aliases for the definitions in `GeneralCyclicVector` (WIP04), ensuring type-level compatibility when delegating to the primary decomposition theorem.",
+      "mathContext": "A vector $v \\in K^n$ is cyclic for $M$ when $\\{v, Mv, \\ldots, M^{n-1}v\\}$ is linearly independent (equivalently, no nonzero polynomial of degree $< n$ annihilates both $M$ and $v$). A matrix is nonderogatory when $\\mathrm{minpoly}_K(M) = \\mathrm{charpoly}(M)$, both of degree $n$. Using `abbrev` (not `def`) ensures that WIP04's theorem result type unifies with this file's goal type without explicit coercions."
+    },
+    {
+      "id": "factorization-bridge",
+      "title": "§ II. Factorization Bridge",
+      "startLine": 69,
+      "endLine": 170,
+      "summary": "Four private theorems build up to `monic_factored_form`: every monic polynomial of positive degree factors into coprime monic irreducible prime powers (Fin k-indexed). All four are fully proved — the sorry described in the Section V docstring has been filled.",
+      "mathContext": "The bridge converts Mathlib's UFD output (a `Multiset` of primes from `UniqueFactorizationMonoid.exists_prime_factors`) to the `Fin k`-indexed form that WIP04 expects. Four lemmas: (1) multiset factorization from UFD; (2) distinct monic irreducibles are coprime; (3) coprimality lifts to prime powers; (4) multiset → Fin k conversion grouping by multiplicity. The combined result matches WIP04's interface contract exactly."
+    },
+    {
+      "id": "main-theorem",
+      "title": "§ III. Main Theorem",
+      "startLine": 172,
+      "endLine": 205,
+      "summary": "Proves `nonderogatory_has_cyclic_vector`: dispatches n=0 (trivial), then factors minpoly via `monic_factored_form` and delegates to WIP04's primary decomposition theorem. Zero axioms, zero sorries.",
+      "mathContext": "Proof: (1) $n = 0$: trivial via `Fin.elim0`. (2) $n > 0$: nonderogatory gives $\\deg(\\mathrm{minpoly}) = n$; `monic_factored_form` gives $\\mathrm{minpoly} = \\prod_i p_i^{e_i}$ (coprime prime powers); `GeneralCyclicVector.nonderogatory_general_has_cyclic_vector` (WIP04) constructs the cyclic vector via Bezout projections."
+    },
+    {
+      "id": "corollaries",
+      "title": "§ IV. Corollaries",
+      "startLine": 207,
+      "endLine": 230,
+      "summary": "Two corollaries: `nonderogatory_has_cyclic_vector_finite` (specializes to finite fields, where union avoidance fails) and `cyclic_iff_not_killed_below_degree` (polynomial annihilator reformulation).",
+      "mathContext": "The finite field corollary demonstrates that the primary decomposition approach works even when $|K| \\leq n$ — the regime where union avoidance fails over $\\mathbb{F}_2$. The equivalence corollary: $v$ is cyclic iff $\\forall p \\neq 0$ with $\\deg(p) < n$, $p(M)v \\neq 0$. Both corollaries are one-liners from the main theorem."
+    },
+    {
+      "id": "summary-block",
+      "title": "§ V. Proof Summary",
+      "startLine": 232,
+      "endLine": 266,
+      "summary": "Closing docstring: enumerates the V2 upgrade (axiom eliminated, factorization bridge proved), lists all five proved results, and documents the V1→V2 delta. Note: the 'one sorry' in lines 253–258 refers to an earlier V2-beta state; the sorry is filled in the current file.",
+      "mathContext": "V1 → V2 delta: RCF similarity axiom ($\\sim$800 lines from PID structure theorem + Smith normal form) replaced by direct UFD-based `monic_factored_form` proof. Net: the mathematical content is fully verified with 0 axioms and 0 sorries. The Section V docstring's claim of 'one sorry' describes an intermediate development state."
+    }
+  ],
+  "conclusion": {
+    "summary": "V2 of this formalization eliminates the RCF similarity axiom, proving the cyclic vector theorem axiom-free via primary decomposition (WIP04). Fully machine-verified: 0 axioms, 0 sorries.",
+    "implications": "The upgrade from V1 (1 axiom, 0 sorries) to V2 (0 axioms, 0 sorries) replaces a deep mathematical assumption (PID structure theorem, ~800 lines to formalize) with a proved factorization bridge (monic_factored_form, ~100 lines of normalizedFactors navigation). The primary decomposition approach (Bezout projections + CRT) is the key innovation: it bypasses companion matrices entirely, working directly with polynomial annihilators.",
+    "openQuestions": [
+      "Can the factorization bridge be proved without Finset.equivFin? A direct Finset-indexed version of WIP04's theorem would eliminate the Fin k conversion overhead.",
+      "Can the converse be formalized to obtain a full equivalence? This file proves nonderogatory ($\\deg(\\mathrm{minpoly}_M) = n$) $\\Rightarrow$ a cyclic vector exists. The converse — a cyclic vector $v$ forces $M$ to be nonderogatory, because $\\{v, Mv, \\ldots, M^{n-1}v\\}$ being a basis means no polynomial of degree $< n$ annihilates $v$, hence $\\deg(\\mathrm{minpoly}_M) \\geq n$ — would upgrade the result to the textbook iff $M$ is nonderogatory $\\Leftrightarrow$ $M$ admits a cyclic vector $\\Leftrightarrow$ $\\mathrm{minpoly}_M = \\mathrm{charpoly}_M$.",
+      "Does the proof generalize to a coordinate-free single operator $T : V \\to V$ on a finite-dimensional $K$-vector space, and further to finitely generated torsion modules over a PID? The primary-decomposition / Bezout-projection argument used here is exactly the module-theoretic structure theorem specialized to $K[x]$; abstracting away the matrix representation (working with $K[x]$-module $V$ where $x$ acts as $T$) would connect this entry directly to Mathlib's `Module` and PID-structure infrastructure rather than `Matrix`."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial"
+    ],
+    "namespace": "CayleyHamiltonCyclicVectorAllFields",
+    "lineCount": 266,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean",
+      "Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Converse: nonderogatory ← cyclic (proved for infinite fields using union avoidance). This file proves the opposite direction for ALL fields via primary decomposition (WIP04), bypassing both cardinality arguments and the RCF similarity theorem."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",
+      "relationship": "companion",
+      "description": "Alternative approach using module theory with sorry. Both files now use 0 axioms; this file (V2) uses primary decomposition from WIP04 while OQ-04 uses a different module-theory approach — contrasting proof architectures for the same theorem."
+    },
+    {
+      "targetId": "cayley-hamilton-reduction-oq-02-oq-01",
+      "relationship": "uses",
+      "description": "Companion matrix definition and orbit lemma C(p)^k · e₀ = eₖ. The two proved supporting lemmas live in CayleyHamiltonMinpolyOQ05OQ01OQ04 which imports this file."
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "The Cayley-Hamilton theorem (M satisfies its own characteristic polynomial) is the starting point of the entire series. This file builds on the charpoly infrastructure (Matrix.charpoly_natDegree_eq_dim) established there."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-05",
+      "relationship": "part-of",
+      "description": "The parent open question series on the minimal polynomial characterization of nonderogatory matrices. This All-Fields result completes the series by removing the |K| > n restriction from OQ-01."
+    },
+    {
+      "targetId": "cayley-hamilton-cyclic-vector-all-fields-oq-01",
+      "relationship": "extended-by",
+      "description": "Factorization bridge: every monic polynomial of positive degree over a field factors into coprime monic irreducible prime powers, proved without Finset as a primitive (multiset UFD). Supplies the polynomial-factorization lemma underpinning the cyclic-vector construction."
+    },
+    {
+      "targetId": "cayley-hamilton-cyclic-vector-all-fields-oq-02",
+      "relationship": "extended-by",
+      "description": "Commutant characterization: if M has a cyclic vector then every matrix commuting with M is a polynomial in M (centralizer = K[M]), the third classical equivalent of nonderogatory."
+    },
+    {
+      "targetId": "cayley-hamilton-cyclic-vector-all-fields-oq-03",
+      "relationship": "extended-by",
+      "description": "Coordinate-free lift: a basis-free operator T on a finite-dimensional space with (minpoly K T).natDegree = finrank K V has a cyclic vector, reducing to this verified matrix theorem."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "CayleyHamiltonCyclicVectorAllFields.nonderogatory_has_cyclic_vector",
+      "statement": "∀ (M : Matrix (Fin n) (Fin n) K), IsNonderogatory M → ∃ v, IsCyclicVector M v",
+      "description": "Main theorem: every nonderogatory matrix over ANY field has a cyclic vector. 0 axioms, 0 sorries."
+    },
+    {
+      "name": "CayleyHamiltonCyclicVectorAllFields.nonderogatory_has_cyclic_vector_finite",
+      "statement": "∀ [Fintype K] (M : Matrix (Fin n) (Fin n) K), IsNonderogatory M → ∃ v, IsCyclicVector M v",
+      "description": "Specializes to finite fields F_q where q ≤ n, covering the regime where union avoidance fails."
+    },
+    {
+      "name": "CayleyHamiltonCyclicVectorAllFields.cyclic_iff_not_killed_below_degree",
+      "statement": "IsNonderogatory M → (IsCyclicVector M v ↔ ∀ p : K[X], p ≠ 0 → p.natDegree < n → ¬(aeval M p).mulVec v = 0)",
+      "description": "Polynomial annihilator characterization: cyclic iff not killed by any nonzero polynomial of degree < n."
+    }
+  ],
+  "sorries": 0
 }


### PR DESCRIPTION
## Enrichment pass

The base entry **cayley-hamilton-cyclic-vector-all-fields** had no forward cross-references to its three verified open-question children, even though all three link back via `extends`. This adds the reciprocal `extended-by` links:

- **oq-01** — Factorization Bridge via Multiset UFD (verified)
- **oq-02** — Commutant of a Cyclic Matrix is K[M] (verified)
- **oq-03** — Nonderogatory Operator Has a Cyclic Vector, coordinate-free (verified)

Closes a parent→child forward-link gap. Metadata-only change (meta.json crossReferences); no Lean source touched. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)