### PR TITLE
Enrich Descartes' Rule of Signs (parent): forward-link 3 verified OQ extensions

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs/meta.json
@@ -176,6 +176,21 @@
       "targetId": "sum-of-kth-powers",
       "relationship": "related",
       "description": "Both are Wiedijk-100 results about polynomial structure: Faulhaber's formulas concern polynomial evaluation (power sums as polynomials in $n$), while Descartes's rule concerns polynomial root counting — complementary perspectives on polynomial analysis"
+    },
+    {
+      "targetId": "descartes-rule-of-signs-oq-01",
+      "relationship": "extended-by",
+      "description": "The parity refinement: the number of positive roots differs from the sign-change count by an even number, with the exact-count characterization."
+    },
+    {
+      "targetId": "descartes-rule-of-signs-oq-03",
+      "relationship": "extended-by",
+      "description": "Constructive root bounds and localization derived from the sign sequence."
+    },
+    {
+      "targetId": "descartes-rule-of-signs-oq-04",
+      "relationship": "extended-by",
+      "description": "Grabiner's algebraic proof of the rule via polynomial division."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Adds `extended-by` cross-references from the base **Descartes' Rule of Signs** entry to three verified open-question children that already link back.

| Child | Status | Topic |
|-------|--------|-------|
| descartes-rule-of-signs-oq-01 | verified | Parity result and exact count |
| descartes-rule-of-signs-oq-03 | verified | Constructive root bounds / localization |
| descartes-rule-of-signs-oq-04 | verified | Grabiner algebraic proof via division |

oq-02 (Budan's theorem) is `axiomatized` and intentionally not forward-linked. Only `meta.json` crossReferences changed.