### PR TITLE
Enrich Fair Games Theorem (parent): forward-link 3 verified OQ extensions

### DIFF
--- a/src/data/proofs/fair-games-theorem/meta.json
+++ b/src/data/proofs/fair-games-theorem/meta.json
@@ -159,6 +159,21 @@
       "targetId": "stirling-formula",
       "relationship": "foundational",
       "description": "Stirling's approximation is used in sharp bounds for random walk probabilities and gambler's ruin estimates — the combinatorial constants in martingale stopping problems often require factorial asymptotics"
+    },
+    {
+      "targetId": "fair-games-theorem-oq-01",
+      "relationship": "extended-by",
+      "description": "The distribution of ruin times in the gambler's ruin process."
+    },
+    {
+      "targetId": "fair-games-theorem-oq-02",
+      "relationship": "extended-by",
+      "description": "Concrete worked examples instantiating the Fair Games Theorem."
+    },
+    {
+      "targetId": "fair-games-theorem-oq-03",
+      "relationship": "extended-by",
+      "description": "Substantive application proofs built on the Fair Games Theorem."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Adds `extended-by` cross-references from the base **Fair Games Theorem** entry to its three verified open-question children that already link back.

| Child | Status | Topic |
|-------|--------|-------|
| fair-games-theorem-oq-01 | verified | Ruin-time distribution (gambler's ruin) |
| fair-games-theorem-oq-02 | verified | Concrete examples |
| fair-games-theorem-oq-03 | verified | Substantive application proofs |

Only `meta.json` crossReferences changed.