### PR TITLE
Research: zsqrtd-neg-two-oq-02 — generalize residue-3 reduction to two-square deficit (build-pending)

### DIFF
--- a/proofs/Proofs/ThreeSquaresResidue3.lean
+++ b/proofs/Proofs/ThreeSquaresResidue3.lean
@@ -18,15 +18,20 @@ instead handled by Fermat's two-square theorem (`Nat.Prime.sq_add_sq`):
   given an odd `t` with `t² ≤ m` and `mm = (m − t²)/2` a prime with `mm % 4 ≠ 3`,
   write `mm = a² + b²`; then `m = t² + (a+b)² + (a−b)²`.
 
-The two theorems below are the *algebraic reduction* — fully proved, 0 axioms,
-0 sorry.  They isolate the genuine number-theoretic input (existence of the prime
-deficit `mm`, which needs Dirichlet primes in AP, already imported as
-`Mathlib.NumberTheory.LSeries.PrimesInAP`) as a clean hypothesis, exactly
-mirroring the reduction style of #24443 but for the class #24443 misses.
+The theorems below are the *algebraic reduction* — fully proved, 0 axioms,
+0 sorry.  They isolate the genuine number-theoretic input as a clean hypothesis,
+exactly mirroring the reduction style of #24443 but for the class #24443 misses.
+The general entry point `three_sq_of_residue3_twoSq` requires only that the
+deficit `mm` be a *sum of two squares* (Fermat's two-square criterion: no prime
+factor `≡ 3 (mod 4)` to an odd power); `three_sq_of_residue3_prime` is the prime
+special case (via `Nat.Prime.sq_add_sq`, needing Dirichlet primes in AP, already
+imported as `Mathlib.NumberTheory.LSeries.PrimesInAP`).
 
-NOTE: build-pending — written under a Docker blackout (host `lake`/Docker
-unavailable). Not registered in `Proofs.lean`; harmless to the build until a
-post-blackout session verifies it via `./proofs/scripts/docker-build.sh`.
+NOTE: the `three_sq_of_residue3_twoSq` generalization + delegation refactor was
+added under a Docker blackout (host `lake`/Docker unavailable) and is therefore
+build-pending; it reuses only tactics already build-verified elsewhere in this
+file. This file IS registered in `Proofs.lean`, so the next Docker-up session
+must confirm via `./proofs/scripts/docker-build.sh Proofs.ThreeSquaresResidue3`.
 -/
 
 namespace ThreeSquaresResidue3
@@ -38,20 +43,42 @@ theorem three_sq_of_two_sq_decomp {m t mm a b : ℤ}
     t ^ 2 + (a + b) ^ 2 + (a - b) ^ 2 = m := by
   rw [hm, hmm]; ring
 
+/-- **Residue-3 two-square route — general form.** Given a deficit `mm` that is a
+sum of two *integer* squares and the decomposition `m = t² + 2·mm`, the natural
+number `m` is a sum of three integer squares.
+
+This is the mathematically correct hypothesis: the algebraic identity needs only
+that `mm` is *representable* as a sum of two squares, never that it is prime. It
+strictly generalizes `three_sq_of_residue3_prime` below (primality is only one
+sufficient condition for two-square representability, via `Nat.Prime.sq_add_sq`).
+Isolating the input this way matters because exhibiting an odd `t` whose deficit
+`(m − t²)/2` is *prime* is a thin-sequence statement strictly stronger than what
+the reduction requires — a deficit free of prime factors `≡ 3 (mod 4)` to an odd
+power (Fermat's two-square criterion) already suffices. -/
+theorem three_sq_of_residue3_twoSq {m t mm : ℕ}
+    (hsum2 : ∃ a b : ℤ, (mm : ℤ) = a ^ 2 + b ^ 2)
+    (hdecomp : m = t ^ 2 + 2 * mm) :
+    ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = (m : ℤ) := by
+  obtain ⟨a, b, hab⟩ := hsum2
+  refine ⟨(t : ℤ), a + b, a - b, ?_⟩
+  have hmZ : (m : ℤ) = (t : ℤ) ^ 2 + 2 * (a ^ 2 + b ^ 2) := by
+    rw [← hab]; exact_mod_cast hdecomp
+  rw [hmZ]; ring
+
 /-- Residue-3 two-square route. Given `t, mm : ℕ` with `mm` prime, `mm % 4 ≠ 3`,
 and the deficit identity `m = t² + 2·mm`, the natural number `m` is a sum of
 three integer squares.  Discharges the `m ≡ 3 (mod 8)` core that
-`dirichlet_key_lemma` cannot reach. -/
+`dirichlet_key_lemma` cannot reach.
+
+A corollary of `three_sq_of_residue3_twoSq`: primality with `mm % 4 ≠ 3` is just
+one way to obtain a two-square representation of the deficit (`Nat.Prime.sq_add_sq`). -/
 theorem three_sq_of_residue3_prime {m t mm : ℕ} [Fact (Nat.Prime mm)]
     (hp : mm % 4 ≠ 3) (hdecomp : m = t ^ 2 + 2 * mm) :
-    ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = (m : ℤ) := by
-  obtain ⟨a, b, hab⟩ := Nat.Prime.sq_add_sq (p := mm) hp
-  refine ⟨(t : ℤ), (a : ℤ) + b, (a : ℤ) - b, ?_⟩
-  have hmZ : (m : ℤ) = (t : ℤ) ^ 2 + 2 * ((a : ℤ) ^ 2 + (b : ℤ) ^ 2) := by
-    have : ((mm : ℤ)) = (a : ℤ) ^ 2 + (b : ℤ) ^ 2 := by exact_mod_cast hab.symm
-    rw [this.symm]
-    exact_mod_cast hdecomp
-  rw [hmZ]; ring
+    ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = (m : ℤ) :=
+  three_sq_of_residue3_twoSq
+    (by obtain ⟨a, b, hab⟩ := Nat.Prime.sq_add_sq (p := mm) hp
+        exact ⟨(a : ℤ), (b : ℤ), by exact_mod_cast hab.symm⟩)
+    hdecomp
 
 /-- The `mm % 4 ≠ 3` obligation of `three_sq_of_residue3_prime` is **automatic**
 given the residue structure of the deficit decomposition. For `m ≡ 3 (mod 8)`

--- a/research/problems/zsqrtd-neg-two-oq-02/sessions/2026-06-19-s16-residue3-twosquare-generalization.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/sessions/2026-06-19-s16-residue3-twosquare-generalization.md
@@ -1,0 +1,71 @@
+# Session 16 — residue-3 reduction generalized to two-square deficit (researcher-2, 2026-06-19)
+
+**Phase**: ACT (incremental Lean delta + frontier confirmation). Docker DOWN
+(`docker info` timed out) — change is build-pending, reuses only tactics already
+build-verified in the same file.
+
+## Frontier confirmed (verified this session)
+
+- **ThreeSquares cluster is sorry-free** with exactly **one** real axiom,
+  `not_excluded_form_is_sum_three_sq` (`ThreeSquares.lean:1838`). The two `^axiom `
+  grep hits and all `sorry` grep hits in the cluster are docstring words, not code
+  (verified by context-stripping). Cluster files all match `origin/main`.
+- **Mathlib pin still lacks the three-square / ternary-form layer.** Confirmed
+  `Mathlib/NumberTheory/SumTwoSquares.lean` and `SumFourSquares.lean` exist but
+  there is **no** `SumThreeSquares`, no ternary Hasse–Minkowski, no ternary Gauss
+  reduction (grep over the pinned tree). So the deep factor (1) — every
+  non-`4ᵃ(8b+7)` `n` is a sum of three *rational* squares — remains the genuine
+  ≫500-LOC open piece. Unchanged from S15.
+- **Dirichlet primes-in-AP IS present and already used.** `Mathlib.NumberTheory.
+  LSeries.PrimesInAP` provides `Nat.forall_exists_prime_gt_and_eq_mod` (:488),
+  `forall_exists_prime_gt_and_zmodEq` (:496), `infinite_setOf_prime_and_eq_mod`
+  (:476); the project imports/uses it across `ThreeSquaresResidue3`,
+  `ThreeSquaresSingleAP`, `ThreeSquaresSufficiency`, etc. The WITNESS-GAP-S3 memo
+  (2026-06-15) called Dirichlet-AP "the remaining open ingredient" — that is now
+  superseded: standard primes-in-AP is available; the actual residual gaps are
+  (a) ternary Hasse–Minkowski (factor 1) and (b) the *thin-sequence* existence of
+  an odd `t` with prime/two-square deficit for the `n ≡ 3 (mod 8)` class, which is
+  strictly stronger than primes-in-AP.
+
+## Delta shipped
+
+`proofs/Proofs/ThreeSquaresResidue3.lean`: added
+**`three_sq_of_residue3_twoSq`** — generalizes the residue-3 reduction from a
+*prime* deficit to the mathematically correct, strictly weaker hypothesis that the
+deficit `mm` is a *sum of two integer squares*:
+
+```lean
+theorem three_sq_of_residue3_twoSq {m t mm : ℕ}
+    (hsum2 : ∃ a b : ℤ, (mm : ℤ) = a ^ 2 + b ^ 2)
+    (hdecomp : m = t ^ 2 + 2 * mm) :
+    ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = (m : ℤ)
+```
+
+`three_sq_of_residue3_prime` is refactored to a one-line corollary delegating
+through it (primality is just one route to two-square representability, via
+`Nat.Prime.sq_add_sq`). Same downstream signature/behavior; no new axioms, no new
+imports.
+
+**Why this matters for the assembly.** Exhibiting an odd `t` whose deficit
+`(n − t²)/2` is *prime* is a thin-sequence statement strictly stronger than the
+reduction needs. The two-square form only requires the deficit to be free of prime
+factors `≡ 3 (mod 4)` to an odd power (Fermat's criterion). This widens the set of
+admissible `t` a future `n ≡ 3 (mod 8)` assembly may use, isolating the genuine
+number-theoretic input more tightly. Pure algebra; the existence of a suitable `t`
+remains the open analytic input.
+
+## Verification status
+
+Build-pending (Docker blackout). The new lemma uses only `obtain`/`refine`/
+`rw`/`exact_mod_cast`/`ring` — every one of which already appears in the
+build-verified `three_sq_of_residue3_prime` proof it replaces. Term reductions
+hand-checked: `(a+b)² + (a−b)² = 2(a²+b²)` closes by `ring`; the cast goal
+`(m:ℤ) = (t:ℤ)² + 2·(mm:ℤ)` closes by `exact_mod_cast hdecomp`. Next Docker-up
+session must confirm via `docker-build.sh Proofs.ThreeSquaresResidue3`.
+
+## Frontier UNCHANGED at the axiom level
+
+The lone sufficiency axiom is untouched. Closing it still needs ternary
+Hasse–Minkowski (factor 1, absent from Mathlib) + Davenport–Cassels (factor 2,
+already build-verified, S14). This session sharpens a support lemma; it does not
+move the axiom frontier.


### PR DESCRIPTION
## Summary

Three-square theorem (Legendre–Gauss) via the ℤ[√−2] infrastructure (OQ-02). Session 16. A focused incremental improvement to the residue-3 (mod 8) support module plus a frontier confirmation.

## Change

`proofs/Proofs/ThreeSquaresResidue3.lean`: add **`three_sq_of_residue3_twoSq`**, generalizing the residue-3 reduction from a **prime** deficit to the mathematically correct, strictly weaker hypothesis that the deficit `mm = (n − t²)/2` is a **sum of two integer squares**:

```lean
theorem three_sq_of_residue3_twoSq {m t mm : ℕ}
    (hsum2 : ∃ a b : ℤ, (mm : ℤ) = a ^ 2 + b ^ 2)
    (hdecomp : m = t ^ 2 + 2 * mm) :
    ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = (m : ℤ)
```

`three_sq_of_residue3_prime` is refactored to a one-line corollary delegating through it (primality with `mm % 4 ≠ 3` is just one route to two-square representability, via `Nat.Prime.sq_add_sq`). Same downstream signature/behavior; **no new axioms, no new imports**.

**Why it matters.** Exhibiting an odd `t` whose deficit is *prime* is a thin-sequence statement strictly stronger than the reduction requires; the two-square form only needs the deficit free of prime factors `≡ 3 (mod 4)` to an odd power (Fermat's criterion). This tightens the isolation of the genuine analytic input for any future `n ≡ 3 (mod 8)` assembly.

## Frontier (confirmed this session)

- ThreeSquares cluster is **sorry-free**, exactly **one** real axiom (`not_excluded_form_is_sum_three_sq`). Grep `sorry`/`axiom` hits are docstring words.
- Mathlib pin still has **no** three-square / ternary Hasse–Minkowski / Gauss-reduction layer (only `SumTwoSquares`, `SumFourSquares`). Factor (1) — rational three-square representation — remains the deep ≫500-LOC open piece.
- Dirichlet primes-in-AP **is** present (`Mathlib.NumberTheory.LSeries.PrimesInAP`) and already used; this supersedes the WITNESS-GAP-S3 (2026-06-15) framing that called Dirichlet-AP "the remaining open ingredient."

**Axiom frontier unchanged** — this sharpens a support lemma, it does not close the converse.

## Verification

⚠️ **Build-pending** — Docker blackout this session (`docker info` timed out), matching this file's documented original build-pending provenance. The new lemma uses only `obtain`/`refine`/`rw`/`exact_mod_cast`/`ring`, every one already build-verified in the `three_sq_of_residue3_prime` proof it replaces; term reductions hand-checked. **Next Docker-up session / CI must confirm** via `./proofs/scripts/docker-build.sh Proofs.ThreeSquaresResidue3`. The deployer gates on build status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)