### PR TITLE
Enrich Vieta's Formulas (parent): forward-link its two verified OQ extensions

### DIFF
--- a/src/data/proofs/vietas-formulas/meta.json
+++ b/src/data/proofs/vietas-formulas/meta.json
@@ -185,6 +185,16 @@
       "targetId": "fermat-two-squares",
       "relationship": "related",
       "description": "The factorization of x^2 + y^2 over the Gaussian integers and resulting norm identities are instances of Vieta-type relations for quadratic norms"
+    },
+    {
+      "targetId": "vietas-formulas-oq-02",
+      "relationship": "extended-by",
+      "description": "Extends the coefficient/root relations to Newton's identities, linking power sums pₖ = Σxᵢᵏ to the elementary symmetric polynomials eₖ for 2 and 3 variables, including the cube-sum factorization and the Vieta–Newton bridge from coefficients to power sums."
+    },
+    {
+      "targetId": "vietas-formulas-oq-03",
+      "relationship": "extended-by",
+      "description": "Generalizes Newton's identities to 2, 3, and 4 variables in recursive form pₖ = Σ(−1)^{i−1} eᵢ pₖ₋ᵢ + (−1)^{k−1} k eₖ, plus inversion formulas recovering each eₖ from power sums, with applications to discriminants."
     }
   ],
   "references": [


### PR DESCRIPTION
## Forward-link enrichment

The base entry **vietas-formulas** had two verified open-question extensions linking *back* to it but no *forward* references from the parent. This adds the missing `extended-by` cross-references for bidirectional navigation.

| Child | Status | Link added |
|-------|--------|------------|
| `vietas-formulas-oq-02` — Newton's identities: multivariate Vieta (2,3 vars) | verified | ✓ |
| `vietas-formulas-oq-03` — Newton's identities: power sums ↔ elementary symmetric (2,3,4 vars) | verified | ✓ |

Only `crossReferences` in the parent meta.json is touched; no proof or Lean source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)