### PR TITLE
Enrich Leibniz Pi Series (parent): forward-link its two verified OQ extensions

### DIFF
--- a/src/data/proofs/leibniz-pi/meta.json
+++ b/src/data/proofs/leibniz-pi/meta.json
@@ -157,6 +157,16 @@
       "targetId": "geometric-series",
       "relationship": "foundational",
       "description": "The derivation of $\\arctan(x) = \\int_0^x 1/(1+t^2)\\,dt$ starts from the geometric series $1/(1+t^2) = 1 - t^2 + t^4 - \\cdots$ (setting $r = -t^2$), then integrates term by term to get $\\arctan(x) = x - x^3/3 + x^5/5 - \\cdots$"
+    },
+    {
+      "targetId": "leibniz-pi-oq-01",
+      "relationship": "extended-by",
+      "description": "Open-question extension (verified): pins down the convergence rate of the Leibniz series as the sharp bound |π/4 - S_N| ≤ 1/(2N+1) (Θ(1/N)), and contrasts it with the exponential rates of Machin-type formulas."
+    },
+    {
+      "targetId": "leibniz-pi-oq-03",
+      "relationship": "extended-by",
+      "description": "Open-question extension (verified): formalizes two acceleration schemes for the Leibniz series — the midpoint average M(k) = (S(2k)+S(2k+1))/2 and the Euler transform — sharpening the slow alternating convergence."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment: forward cross-references

Parent **leibniz-pi** did not link forward to its two *verified* open-question children, though both back-link to it.

Adds `extended-by` crossReferences to:
- **leibniz-pi-oq-01** — sharp Θ(1/N) convergence rate (|π/4 − S_N| ≤ 1/(2N+1))
- **leibniz-pi-oq-03** — midpoint + Euler acceleration transforms

oq-02 excluded (axiomatized). Metadata-only, JSON validated.