### PR TITLE
Enrich Taylor's Theorem (parent): forward-link its two verified OQ extensions

### DIFF
--- a/src/data/proofs/taylor-theorem/meta.json
+++ b/src/data/proofs/taylor-theorem/meta.json
@@ -196,6 +196,16 @@
       "targetId": "intermediate-value-theorem",
       "relationship": "foundational",
       "description": "IVT guarantees the existence of the intermediate point $c$ in the Lagrange remainder: $R_n = f^{(n+1)}(c)(x-a)^{n+1}/(n+1)!$ for some $c$ between $a$ and $x$. Without IVT (or the completeness of $\\mathbb{R}$), this intermediate value might not exist"
+    },
+    {
+      "targetId": "taylor-theorem-oq-02",
+      "relationship": "extended-by",
+      "description": "Extends the convergence result to all analytic functions: the Taylor remainder Rₙ(x)→0 whenever f has a convergent power series at x₀, giving a structural generalization of the ad hoc exponential case."
+    },
+    {
+      "targetId": "taylor-theorem-oq-03",
+      "relationship": "extended-by",
+      "description": "Proves the Taylor series of exp converges to exp(x) for all real x via the Lagrange remainder, with explicit error bound |e − Sₙ(1)| ≤ 3/n!."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Adds `extended-by` cross-references from the parent **taylor-theorem** to its two **verified** open-question children. Both children already backlink to the parent; this closes the forward-link gap so gallery navigation works in both directions.

- **taylor-theorem-oq-02** — Taylor remainder Rₙ(x)→0 for all analytic functions
- **taylor-theorem-oq-03** — Taylor series of exp converges via the Lagrange remainder

Only verified children linked. No Lean changes; meta.json cross-references only.