### PR TITLE
Enrich Infinitude of Primes ≡3 (mod 4) (parent): forward-link its two verified OQ extensions

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3/meta.json
@@ -86,6 +86,16 @@
       "targetId": "dirichlets-theorem",
       "relationship": "related",
       "description": "Dirichlet's theorem on primes in arithmetic progressions (1837) — the full generalization of this result to all APs a+nd with gcd(a,d)=1, requiring L-functions."
+    },
+    {
+      "targetId": "infinitude-primes-4k3-oq-01",
+      "relationship": "extended-by",
+      "description": "Specializes the Dirichlet theorem to moduli q∈{12,24}: infinitely many primes p ≡ −1 (mod q), each given in elementary (%q) and analytic (ZMod q) forms."
+    },
+    {
+      "targetId": "infinitude-primes-4k3-oq-03",
+      "relationship": "extended-by",
+      "description": "Companion classification: infinitely many primes ≡ 1 (mod 4) via Euler's criterion, completing the mod-4 dichotomy (every odd prime is ≡1 or ≡3, both infinite)."
     }
   ],
   "sections": [


### PR DESCRIPTION
Adds `extended-by` cross-references from the parent **infinitude-primes-4k3** to its two **verified** open-question children. Both already backlink to the parent; this closes the forward-link gap so gallery navigation works both directions.

- **infinitude-primes-4k3-oq-01** — Dirichlet specialization: infinitely many primes ≡ −1 (mod 12) and (mod 24)
- **infinitude-primes-4k3-oq-03** — elementary proof of infinitely many primes ≡ 1 (mod 4), completing the mod-4 dichotomy

Only verified children linked. No Lean changes; meta.json cross-references only.