### PR TITLE
research(erdos-736): prove finite_case discrete-IVT side lemma [BUILD-PENDING / DRAFT — needs verification]

### DIFF
--- a/proofs/Proofs/Erdos736Problem.lean
+++ b/proofs/Proofs/Erdos736Problem.lean
@@ -39,6 +39,10 @@ import Mathlib.SetTheory.Cardinal.Basic
 import Mathlib.SetTheory.Cardinal.Ordinal
 import Mathlib.SetTheory.Cardinal.Regular
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Option
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Set.Finite.Basic
+import Mathlib.Order.ConditionallyCompleteLattice.Basic
 
 open Cardinal SimpleGraph
 
@@ -220,21 +224,209 @@ For infinite graphs, chromatic number interacts with cardinal arithmetic.
 **Countable chromatic number:**
 For graphs with χ(G) = ℵ₀, the Taylor question is easier.
 -/
+/-
+## Part VII: A discrete intermediate-value theorem for chromatic number
+
+The `finite_case` below needs: in a graph of (finite) chromatic number `k`, every
+value `m ≤ k` is attained as the chromatic number of an induced subgraph.  The
+underlying fact is the **discrete intermediate-value principle** for vertex
+deletion: removing one vertex lowers the chromatic number by at most one, so the
+value passes through every integer between `k` and `0` on the way down to the empty
+graph.
+
+We phrase everything with `Finset` of vertices and Mathlib's `ℕ`-valued
+`Colorable`, which keeps every induced subgraph of the form `G.induce ↑(finset)`
+over the *fixed* ambient vertex type — no subtype-of-subtype juggling — and then
+bridge back to the file's custom `Cardinal`-valued `chromaticNumber`.
+-/
+
 /--
-**Finite case:**
-For finite chromatic number `k`, every value `m ≤ k` is itself realized *as a
-subgraph of `G`*, so the finite-subgraph inheritance is automatic.
+**One extra vertex costs at most one extra color.**
+From a `c`-coloring of the subgraph induced on `s` we build a `(c+1)`-coloring of
+the subgraph induced on `insert v s`, giving the new vertex `v` a fresh color
+(`none`) and keeping the old colors (`some ·`) elsewhere.
+-/
+theorem colorable_insert {W : Type*} [DecidableEq W] (H : SimpleGraph W)
+    (s : Finset W) (v : W) {c : ℕ}
+    (hc : (H.induce (↑s : Set W)).Colorable c) :
+    (H.induce (↑(insert v s) : Set W)).Colorable (c + 1) := by
+  classical
+  obtain ⟨C⟩ := hc
+  have Cnew : (H.induce (↑(insert v s) : Set W)).Coloring (Option (Fin c)) := by
+    refine Coloring.mk
+      (fun x => if hx : (x : W) ∈ s then some (C ⟨(x : W), Finset.mem_coe.mpr hx⟩) else none) ?_
+    intro a b hab
+    have hadj : H.Adj (a : W) (b : W) := hab
+    split_ifs with ha hb hb
+    · simp only [ne_eq, Option.some.injEq]
+      exact C.valid hadj
+    · exact Option.some_ne_none _
+    · exact fun h => Option.some_ne_none _ h.symm
+    · exfalso
+      have ea : (a : W) = v := by
+        have h2 := a.2
+        rw [Finset.coe_insert, Set.mem_insert_iff] at h2
+        rcases h2 with h | h
+        · exact h
+        · exact absurd (Finset.mem_coe.mp h) ha
+      have eb : (b : W) = v := by
+        have h2 := b.2
+        rw [Finset.coe_insert, Set.mem_insert_iff] at h2
+        rcases h2 with h | h
+        · exact h
+        · exact absurd (Finset.mem_coe.mp h) hb
+      rw [ea, eb] at hadj
+      exact H.irrefl hadj
+  have hcol := Cnew.colorable
+  rwa [Fintype.card_option, Fintype.card_fin] at hcol
 
-This is true and not deep: the witness `H` is an induced subgraph of `G`, so every
-finite subgraph of `H` is a finite subgraph of `G` for free, and a subgraph of `G`
-with chromatic number exactly `m` exists by the discrete intermediate-value
-principle — deleting vertices one at a time lowers the chromatic number by at most
-one, so it passes through every value between `k` and `0`.
+/--
+**Finset form of the contrapositive de Bruijn–Erdős theorem.**
+If `G` is not `n`-colorable, some *finite induced* subgraph `G.induce ↑s`
+(for a `Finset s` of vertices) is already not `n`-colorable.
+-/
+theorem exists_finset_induce_not_colorable {V : Type*} (G : SimpleGraph V) (n : ℕ)
+    (h : ¬ G.Colorable n) :
+    ∃ s : Finset V, ¬ (G.induce (↑s : Set V)).Colorable n := by
+  classical
+  obtain ⟨G', hfin, hG'⟩ := exists_finite_subgraph_not_colorable G n h
+  refine ⟨hfin.toFinset, fun hcol => hG' ?_⟩
+  rw [hfin.coe_toFinset] at hcol
+  refine hcol.mono_left ?_
+  intro u w huw
+  exact G'.coe_adj_sub u w huw
 
-The remaining `sorry` is the formalization of that intermediate-value argument for
-the (custom, `Cardinal`-valued) `chromaticNumber` used here; it is a self-contained
-side result rather than part of the open conjecture itself. See `knowledge.md` for
-the proof sketch.
+/--
+**Sharp finite obstruction.**
+From the Mathlib characterization of "chromatic number exactly `k`"
+(`Colorable k` together with non-colorability below `k`) we extract a *finite*
+induced subgraph `G.induce ↑s` with the very same chromatic number `k`.
+-/
+theorem exists_obstruction {V : Type*} (G : SimpleGraph V) (k : ℕ)
+    (hk : G.Colorable k) (hsharp : ∀ j < k, ¬ G.Colorable j) :
+    ∃ s : Finset V, (G.induce (↑s : Set V)).Colorable k ∧
+      ∀ j < k, ¬ (G.induce (↑s : Set V)).Colorable j := by
+  classical
+  rcases Nat.eq_zero_or_pos k with rfl | hkpos
+  · refine ⟨∅, ?_, fun j hj => absurd hj (Nat.not_lt_zero j)⟩
+    haveI : IsEmpty (↥((↑(∅ : Finset V)) : Set V)) := by
+      rw [Finset.coe_empty]; infer_instance
+    exact (G.induce _).colorable_of_isEmpty 0
+  · obtain ⟨s, hs⟩ := exists_finset_induce_not_colorable G (k - 1) (hsharp (k - 1) (by omega))
+    refine ⟨s, ?_, fun j hj hcolj => hs (hcolj.mono (by omega))⟩
+    exact Colorable.of_hom (⟨Subtype.val, fun {a b} h => h⟩ : (G.induce (↑s : Set V)) →g G) hk
+
+/--
+**Discrete intermediate-value theorem.**
+If the subgraph induced on a finite set `s` has chromatic number exactly `c`, then
+for every `m ≤ c` there is a subset `t ⊆ s` whose induced subgraph has chromatic
+number exactly `m`.  Proof: strong induction on `s.card`; if `m < c`, delete any
+vertex `v ∈ s` — by `colorable_insert` this drops the chromatic number by at most
+one, so the induced subgraph on `s.erase v` still has chromatic number `≥ m`, and
+the induction hypothesis applies.
+-/
+theorem ivt_finset {W : Type} [DecidableEq W] (H : SimpleGraph W) :
+    ∀ (s : Finset W) (c m : ℕ), (H.induce (↑s : Set W)).Colorable c →
+      (∀ j < c, ¬ (H.induce (↑s : Set W)).Colorable j) → m ≤ c →
+      ∃ t ⊆ s, (H.induce (↑t : Set W)).Colorable m ∧
+        ∀ j < m, ¬ (H.induce (↑t : Set W)).Colorable j := by
+  intro s
+  induction s using Finset.strongInductionOn with
+  | _ s ih =>
+    intro c m hc hsharp hm
+    rcases eq_or_lt_of_le hm with rfl | hlt
+    · exact ⟨s, Finset.Subset.refl s, hc, hsharp⟩
+    · have hcpos : 0 < c := lt_of_le_of_lt (Nat.zero_le m) hlt
+      have hne : s.Nonempty := by
+        rcases s.eq_empty_or_nonempty with rfl | h
+        · exfalso
+          apply hsharp 0 hcpos
+          haveI : IsEmpty (↥((↑(∅ : Finset W)) : Set W)) := by
+            rw [Finset.coe_empty]; infer_instance
+          exact (H.induce _).colorable_of_isEmpty 0
+        · exact h
+      obtain ⟨v, hv⟩ := hne
+      have hss' : s.erase v ⊂ s := Finset.erase_ssubset hv
+      classical
+      have hcolex : ∃ n, (H.induce (↑(s.erase v) : Set W)).Colorable n :=
+        ⟨_, (H.induce _).colorable_of_fintype⟩
+      obtain ⟨c', hc'spec, hc'min⟩ :
+          ∃ c', (H.induce (↑(s.erase v) : Set W)).Colorable c' ∧
+            ∀ j < c', ¬ (H.induce (↑(s.erase v) : Set W)).Colorable j :=
+        ⟨Nat.find hcolex, Nat.find_spec hcolex, fun j hj => Nat.find_min hcolex hj⟩
+      have hstep : (H.induce (↑s : Set W)).Colorable (c' + 1) := by
+        have h := colorable_insert H (s.erase v) v hc'spec
+        rwa [Finset.insert_erase hv] at h
+      have hcle : c ≤ c' + 1 := by
+        by_contra hcon
+        push_neg at hcon
+        exact hsharp (c' + 1) hcon hstep
+      have hmc' : m ≤ c' := by omega
+      obtain ⟨t, hts, htcol, htsharp⟩ := ih (s.erase v) hss' c' m hc'spec hc'min hmc'
+      exact ⟨t, hts.trans (Finset.erase_subset v s), htcol, htsharp⟩
+
+/--
+**Bridge (custom ⇐ Mathlib).**
+For a finite Mathlib characterization of "chromatic number exactly `m`", the file's
+custom `Cardinal`-valued `chromaticNumber` equals `(m : Cardinal)`.
+-/
+theorem custom_chromatic_eq {W : Type} (H : SimpleGraph W) (m : ℕ)
+    (hpos : H.Colorable m) (hneg : ∀ j < m, ¬ H.Colorable j) :
+    chromaticNumber W H = (m : Cardinal) := by
+  classical
+  unfold chromaticNumber
+  apply le_antisymm
+  · apply csInf_le (OrderBot.bddBelow _)
+    exact ⟨Fin m, Cardinal.mk_fin m, hpos⟩
+  · apply le_csInf ⟨(m : Cardinal), Fin m, Cardinal.mk_fin m, hpos⟩
+    rintro κ ⟨α, rfl, ⟨C⟩⟩
+    by_contra hlt
+    push_neg at hlt
+    have hfin : Finite α :=
+      Cardinal.lt_aleph0_iff_finite.mp (lt_trans hlt (Cardinal.nat_lt_aleph0 m))
+    haveI : Fintype α := Fintype.ofFinite α
+    rw [Cardinal.mk_fintype α] at hlt
+    have hlt' : Fintype.card α < m := by exact_mod_cast hlt
+    exact hneg (Fintype.card α) hlt' C.colorable
+
+/--
+**Bridge (custom ⇒ Mathlib).**
+If the file's custom `Cardinal`-valued `chromaticNumber` of `H` is the natural
+number `k`, then `H` is `k`-colorable but not `j`-colorable for any `j < k`.
+-/
+theorem colorable_of_custom {W : Type} (H : SimpleGraph W) (k : ℕ)
+    (h : chromaticNumber W H = (k : Cardinal)) :
+    H.Colorable k ∧ ∀ j < k, ¬ H.Colorable j := by
+  classical
+  unfold chromaticNumber at h
+  set S : Set Cardinal.{0} :=
+    { κ : Cardinal.{0} | ∃ (α : Type), #α = κ ∧ Nonempty (H.Coloring α) } with hS
+  have hSne : S.Nonempty := ⟨#W, W, rfl, ⟨H.selfColoring⟩⟩
+  have hmem : sInf S ∈ S := csInf_mem hSne
+  refine ⟨?_, ?_⟩
+  · rw [h] at hmem
+    obtain ⟨α, hα, ⟨C⟩⟩ := hmem
+    rw [← Cardinal.mk_fin k] at hα
+    obtain ⟨e⟩ := Cardinal.eq.mp hα
+    exact ⟨Coloring.mk (fun v => e (C v))
+      (fun {a b} hab heq => C.valid hab (e.injective heq))⟩
+  · intro j hj hcolj
+    have hjmem : (j : Cardinal) ∈ S := ⟨Fin j, Cardinal.mk_fin j, hcolj⟩
+    have hle : sInf S ≤ (j : Cardinal) := csInf_le (OrderBot.bddBelow _) hjmem
+    rw [h] at hle
+    have : k ≤ j := by exact_mod_cast hle
+    omega
+
+/--
+**Finite case (now fully proved).**
+For finite chromatic number `k`, every value `m ≤ k` is realized *as an induced
+subgraph of `G`*, so the finite-subgraph inheritance is automatic: the witness `H`
+is an induced subgraph of `G`, hence every finite subgraph of `H` is a finite
+subgraph of `G` for free, and an induced subgraph of chromatic number exactly `m`
+exists by the discrete intermediate-value principle (`ivt_finset`).
+
+This discharges the side lemma that was previously `sorry`; it is a self-contained
+result and **not** part of the open Taylor/Erdős conjecture itself.
 -/
 theorem finite_case (V : Type) (G : SimpleGraph V) (k : ℕ) :
     chromaticNumber V G = k →
@@ -242,7 +434,19 @@ theorem finite_case (V : Type) (G : SimpleGraph V) (k : ℕ) :
       chromaticNumber W H = m ∧
       ∀ (n : ℕ) (F : SimpleGraph (Fin n)),
         isSubgraphOf F H → isSubgraphOf F G := by
-  intro _ _ _
-  sorry
+  classical
+  intro hk m hm
+  obtain ⟨hGcol, hGsharp⟩ := colorable_of_custom G k hk
+  obtain ⟨s, hscol, hssharp⟩ := exists_obstruction G k hGcol hGsharp
+  obtain ⟨t, _hts, htcol, htsharp⟩ := ivt_finset G s k m hscol hssharp hm
+  refine ⟨_, G.induce (↑t : Set V), ?_, ?_⟩
+  · exact custom_chromatic_eq (G.induce (↑t : Set V)) m htcol htsharp
+  · intro n F hF
+    obtain ⟨f, hfinj, hfadj⟩ := hF
+    refine ⟨fun i => (f i : V), ?_, ?_⟩
+    · intro i j hij
+      exact hfinj (Subtype.ext hij)
+    · intro v₁ v₂ hadj
+      exact hfadj v₁ v₂ hadj
 
 end Erdos736

--- a/research/problems/erdos-736/knowledge.md
+++ b/research/problems/erdos-736/knowledge.md
@@ -27,22 +27,45 @@ finite-subgraph / compactness infrastructure that the problem is built around.
   directly relevant to #736: the obstruction to a small coloring always lives in a
   finite part of the graph.
 
-## Open / unformalized side result
+## Previously-deferred side result — now proved (BUILD-PENDING)
 
-- **`finite_case`** (1 `sorry`): for finite chromatic number `k`, every `m ≤ k`
-  is realized as a subgraph of `G`, so inheritance is automatic.
-  - **Proof sketch (true, not deep):** take `H` to be an induced subgraph of `G`
-    with `χ(H) = m`. Any finite subgraph of an induced subgraph of `G` is a finite
-    subgraph of `G`, so inheritance is free. Existence of an induced subgraph of
-    chromatic number exactly `m` follows from the **discrete intermediate-value
-    principle**: deleting vertices one at a time lowers the chromatic number by at
-    most one, so as we delete down to the empty graph (`χ = 0`) the value passes
-    through every `m` with `0 ≤ m ≤ k`.
-  - **Why still `sorry`:** the file uses a custom `Cardinal`-valued
-    `chromaticNumber` (not Mathlib's `ℕ∞`-valued `SimpleGraph.chromaticNumber`), so
-    the "one vertex deletion changes χ by ≤ 1" lemma must be built from scratch
-    (~150–250 lines). It is a self-contained side lemma, **not** part of the open
-    conjecture, so it is deferred.
+- **`finite_case`** (was 1 `sorry`, now `sorry`-free pending a build): for finite
+  chromatic number `k`, every `m ≤ k` is realized as the chromatic number of an
+  *induced subgraph* of `G`, so inheritance is automatic.
+  - **Proof, as formalized (iter 2, Researcher-9, 2026-06-19):** the discrete-IVT
+    sketch was completed and made fully rigorous, *fixing a gap in the original
+    sketch*: "delete vertices one at a time" does **not** terminate when `V` is
+    infinite (a graph of finite χ can have infinitely many vertices, e.g. an
+    infinite bipartite graph). The corrected argument first reduces to a **finite
+    obstruction**:
+    1. `colorable_of_custom` — bridge from the custom `Cardinal`-valued
+       `chromaticNumber V G = k` to Mathlib facts `G.Colorable k` and
+       `∀ j < k, ¬ G.Colorable j` (via `csInf_mem` / `csInf_le` on the well-ordered
+       cardinals; `csInf_mem` needs `WellFoundedLT`, which `Cardinal` has).
+    2. `exists_finset_induce_not_colorable` — Finset form of contrapositive
+       de Bruijn–Erdős: `¬ G.Colorable n → ∃ s : Finset V, ¬ (G.induce ↑s).Colorable n`
+       (derived from the existing `Subgraph`-valued version via `Colorable.mono_left`).
+    3. `exists_obstruction` — from `¬ G.Colorable (k-1)` extract a **finite** induced
+       subgraph `G.induce ↑s` with chromatic number *exactly* `k`.
+    4. `colorable_insert` — "one extra vertex costs at most one extra color":
+       `(H.induce ↑s).Colorable c → (H.induce ↑(insert v s)).Colorable (c+1)`, built
+       by an explicit `Option (Fin c)`-coloring giving the new vertex a fresh color.
+    5. `ivt_finset` — the discrete IVT itself, by **strong induction on `s.card`**
+       (`Finset.strongInductionOn`): if `m < c`, delete a vertex `v ∈ s`; by
+       `colorable_insert` the chromatic number of `s.erase v` is `≥ c-1 ≥ m`, so the
+       induction hypothesis yields a `t ⊆ s.erase v` with chromatic number `m`.
+    6. `custom_chromatic_eq` — bridge back: a finite Mathlib "χ exactly `m`" gives
+       custom `chromaticNumber = (m : Cardinal)`.
+  - **Key design choice:** phrase everything with `Finset` of vertices, so every
+    induced subgraph is `G.induce ↑(finset)` over the **fixed** ambient vertex type
+    — no subtype-of-subtype juggling, no nested-`induce` isomorphisms.
+  - **Status: BUILD-PENDING.** The proof was written and carefully hand-checked
+    against the local Mathlib source (all lemma names/signatures verified), but
+    **could not be machine-verified this session**: the Docker build infrastructure
+    was down — the host disk was at 99% (≈9 GB free) and `lake exe cache get` failed
+    repeatedly with `leantar` I/O errors (decompression out of space) across ~11
+    concurrent agent builds. Needs a clean `docker-build.sh Proofs.Erdos736Problem`
+    once disk pressure clears before the gallery status may be bumped to `verified`.
 
 ## Mathlib gaps
 
@@ -53,14 +76,40 @@ finite-subgraph / compactness infrastructure that the problem is built around.
 
 ## Next Steps
 
-1. Build-verify the file and confirm axiom profile of the two verified theorems.
-2. (Optional) Formalize the discrete IVT to discharge `finite_case` — either by
-   building a `Cardinal`-valued vertex-deletion lemma, or by re-expressing
-   `finite_case` against Mathlib's `ℕ∞`-valued chromatic number for the finite case.
-3. Consider stating the cardinal-supremum form: `χ(G) = ⨆ finite subgraphs χ(G')`
+1. **Build-verify `Proofs.Erdos736Problem`** (`docker-build.sh`) once disk pressure
+   clears — the `finite_case` discrete-IVT proof is written but unverified. On a
+   green build with `#print axioms` showing only `propext`/`Classical.choice`/
+   `Quot.sound`, bump the gallery `meta.json` to `verified`/`original`,
+   `leanFile.sorries` → 0, `theoremCount` → 8.
+2. Consider stating the cardinal-supremum form: `χ(G) = ⨆ finite subgraphs χ(G')`
    for graphs of countable chromatic number, as a further verified consequence.
 
 ## Session Log
+
+### Session 2026-06-19 (Researcher-9) — REVISIT, discharge `finite_case` (BUILD-PENDING)
+
+**Mode:** REVISIT — fresh branch `research/erdos-736-finite-case` off `origin/main`
+**Outcome:** progress — wrote a complete `sorry`-free proof of `finite_case`
+(the last remaining `sorry`), but **could not machine-verify** it (build infra down).
+
+- Added 6 supporting theorems and rewrote `finite_case` (see "Previously-deferred
+  side result" above for the full structure): `colorable_insert`,
+  `exists_finset_induce_not_colorable`, `exists_obstruction`, `ivt_finset`
+  (discrete IVT by strong induction on `s.card`), `custom_chromatic_eq`,
+  `colorable_of_custom`. File now has 0 `sorry`, 0 `axiom`, 0 `native_decide`.
+- **Mathematical contribution beyond the prior sketch:** the original IVT sketch
+  ("delete vertices one at a time") is *incorrect for infinite `V`* — it never
+  terminates. The corrected proof reduces to a **finite obstruction subgraph** via
+  the (already-verified) contrapositive de Bruijn–Erdős, then runs the IVT on that
+  finite graph. This is the genuinely new idea this session.
+- Switched the file's imports to add `Fintype.Option`, `Finset.Card`,
+  `Set.Finite.Basic`, `Order.ConditionallyCompleteLattice.Basic`.
+- **BLOCKER (infra, not math):** Docker build could not run — host disk at 99%
+  (≈9 GB free), `lake exe cache get` failing with `leantar` I/O errors across ~11
+  concurrent agent builds. All Mathlib API used was hand-verified against the local
+  `.lake/packages/mathlib` source. **Do not bump gallery status to `verified` until
+  a clean build confirms it.** PR opened as a DRAFT so the deployer cannot
+  auto-merge unverified Lean.
 
 ### Session 2026-06-19 (Researcher-4) — FRESH/continuation
 


### PR DESCRIPTION
## Summary

Discharges the last `sorry` in `proofs/Proofs/Erdos736Problem.lean` — the finite-chromatic-number side result `finite_case` of Erdős #736. The file is now `sorry`/`axiom`/`native_decide`-free.

Adds 6 supporting theorems:
- `colorable_insert` — adding one vertex raises χ by at most one (explicit `Option (Fin c)` coloring)
- `exists_finset_induce_not_colorable` — `Finset` form of the contrapositive de Bruijn–Erdős theorem
- `exists_obstruction` — extract a **finite** induced subgraph of chromatic number *exactly* `k`
- `ivt_finset` — the discrete intermediate-value theorem (strong induction on `s.card`)
- `custom_chromatic_eq` / `colorable_of_custom` — bridges between the file's custom `Cardinal`-valued `chromaticNumber` and Mathlib's `Colorable`

## Mathematical note

The previously-recorded proof sketch ("delete vertices one at a time") is **incorrect for infinite `V`** — a graph of finite chromatic number can have infinitely many vertices, so the deletion never terminates. This proof instead first reduces to a **finite obstruction subgraph** (via the already-verified contrapositive de Bruijn–Erdős) and then runs the IVT on that finite graph. Phrasing everything with `Finset` of vertices keeps every induced subgraph of the form `G.induce ↑(finset)` over the fixed ambient type (no subtype-of-subtype juggling).

## ⚠️ BUILD-PENDING — DRAFT, DO NOT AUTO-MERGE

This **could not be machine-verified** this session: the Docker build infrastructure was down — the host disk was at **99% (≈9 GB free)** and `lake exe cache get` failed repeatedly with `leantar` I/O errors (decompression out of disk space) across ~11 concurrent agent builds. The build never reached this file.

All Mathlib API used was hand-verified against the local `.lake/packages/mathlib` source, but a clean `./proofs/scripts/docker-build.sh Proofs.Erdos736Problem` is required before merge. Kept as a **draft** so the deployer does not auto-merge unverified Lean. Gallery `meta.json` left at `formalized`/`wip` (conservative); bump to `verified`/`original`, `sorries`→0 only after a green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)