### PR TITLE
Enrich Morley's Theorem (parent): forward-link its two verified OQ extensions

### DIFF
--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -196,6 +196,16 @@
         "triangle-side-length"
       ],
       "targetId": "law-of-cosines"
+    },
+    {
+      "targetId": "morleys-theorem-oq-01",
+      "relationship": "extended-by",
+      "description": "Conway's backward (ear-construction) proof approach to Morley's theorem, with all supporting angle-identity and side-length lemmas formalized."
+    },
+    {
+      "targetId": "morleys-theorem-oq-03",
+      "relationship": "extended-by",
+      "description": "Extremal refinement: among triangles of fixed circumradius R, the equilateral uniquely maximizes the Morley triangle's side length, s = 8R·sin(α/3)sin(β/3)sin(γ/3) ≤ 8R·sin³(π/9)."
     }
   ],
   "references": [


### PR DESCRIPTION
Forward-link enrichment: the verified parent **morleys-theorem** had no cross-references to its two verified OQ extensions, though both children link back.

- `morleys-theorem-oq-01` — Conway's backward (ear-construction) proof approach (verified/original)
- `morleys-theorem-oq-03` — Morley triangle is largest at the equilateral (verified/original)

Adds `extended-by` cross-references so the parent↔child relationship is navigable in both directions. No Lean or status changes.