### PR TITLE
Research: Dirichlet's approximation theorem via Minkowski's convex-body theorem (oq-03)

### DIFF
--- a/research/problems/dirichlet-approximation-theorem-oq-03/state.md
+++ b/research/problems/dirichlet-approximation-theorem-oq-03/state.md
@@ -23,7 +23,18 @@ UNVERIFIED this session: the Docker build daemon was unresponsive; CI / the depl
 - [x] Unconditional Minkowski assembly `dirichlet_via_minkowski` from
       `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure` against the standard lattice
       `ℤ² = span ℤ (range (Pi.basisFun ℝ (Fin 2)))` — drafted sorry-free.
-- [ ] **Build verification** of `Proofs.DirichletApproximationOQ03` (blocked this session: Docker down).
+- [x] **Source-level Mathlib API verification** (s3, 2026-06-19): every external lemma the proof
+      consumes exists in the pinned mathlib (`leanprover/lean4:v4.26.0`) with a matching signature —
+      `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure`
+      (`MeasureTheory/Group/GeometryOfNumbers.lean:92`, args `fund h_symm h_conv h_cpt h`),
+      `ZSpan.isAddFundamentalDomain'` (`Algebra/Module/ZLattice/Basic.lean:359`),
+      `ZSpan.fundamentalDomain_pi_basisFun` (`…:113`, `= Set.pi univ (Ico 0 1)`),
+      `addHaar_image_linearMap` (`…/Lebesgue/EqHaar.lean:300`, `μ (f '' s) = ofReal |det f| * μ s`),
+      `LinearMap.det_toLin'`, `Matrix.det_fin_two_of`, `Basis.mem_span_iff_repr_mem`. Tactic-level
+      elaboration (simp lemma sets, `field_simp; ring`, term shapes) is NOT verified — needs a build.
+- [ ] **Build verification** of `Proofs.DirichletApproximationOQ03` (still blocked: Docker daemon
+      unresponsive, host load avg ~26–39). CI / the deployer must run
+      `./proofs/scripts/docker-build.sh Proofs.DirichletApproximationOQ03` before machine-checked.
 - [ ] Continued-fraction subsumption (optional).
 
 ## Build status


### PR DESCRIPTION
## Summary

Geometry-of-numbers (Minkowski) re-derivation of **Dirichlet's approximation theorem**, requested by open problem `dirichlet-approximation-theorem-oq-03`. The existing gallery entry proves the bound via the pigeonhole principle on fractional parts; this file gives the classical convex-body proof instead.

For every real `α` and `N ≥ 2`, `dirichlet_via_minkowski` produces integers `p` and `1 ≤ q ≤ N` with `|qα − p| ≤ 1/N`, by applying Mathlib's compact Minkowski theorem to the symmetric parallelogram

    K(α, N) = { v ∈ ℝ² : |v₀| ≤ N ∧ |α·v₀ − v₁| ≤ 1/N }.

## What's proved (`proofs/Proofs/DirichletApproximationOQ03.lean`, drafted sorry-free, axiom-free)

- `body_symm`, `body_convex`, `body_isClosed`, `body_isCompact` — the geometric hypotheses Minkowski needs.
- `dirichlet_of_lattice_point` — arithmetic bridge: a nonzero integer point of `K` (for `N ≥ 2`) is a Dirichlet approximation, handling sign normalisation `q ≥ 1` and the degenerate `q = 0` boundary case.
- `box_volume`, `body_volume` — `volume(K) = 4`, via the determinant-`(−1)` shear `(x,y) ↦ (x, αx−y)` and `addHaar_image_linearMap`.
- `dirichlet_via_minkowski` — the unconditional assembly, feeding `volume(K) = 4 = covol(ℤ²)·2²` into `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure` against the standard lattice `ℤ² = span ℤ (range (Pi.basisFun ℝ (Fin 2)))`.

## Verification status — **build NOT machine-checked**

The Docker build daemon is unresponsive (host load avg ~26–39), so `Proofs.DirichletApproximationOQ03` has **not** been elaborated this session. As a partial check, every external Mathlib lemma the proof consumes was confirmed to exist with a matching signature in the pinned mathlib (`v4.26.0`): `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure`, `ZSpan.isAddFundamentalDomain'`, `ZSpan.fundamentalDomain_pi_basisFun`, `addHaar_image_linearMap`, `LinearMap.det_toLin'`, `Matrix.det_fin_two_of`, `Basis.mem_span_iff_repr_mem`. Tactic-level elaboration (simp sets, `field_simp; ring`, exact term shapes) is **not** verified.

**The deployer/CI must run `./proofs/scripts/docker-build.sh Proofs.DirichletApproximationOQ03` and confirm a clean build before this is treated as verified.** No gallery `meta.json` entry is created yet for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)