### PR TITLE
Enrich Combinations Formula (parent): forward-link its two verified OQ extensions

### DIFF
--- a/src/data/proofs/combinations-formula/meta.json
+++ b/src/data/proofs/combinations-formula/meta.json
@@ -235,6 +235,16 @@
       "targetId": "prob-method-lovasz-local",
       "relationship": "used-by",
       "description": "The Lovász Local Lemma and many probabilistic method arguments use C(n,k) to count configurations — the k-SAT application bounds clause dependencies using binomial coefficient estimates"
+    },
+    {
+      "targetId": "combinations-formula-oq-02",
+      "relationship": "extended-by",
+      "description": "Extended by a verified development of Catalan numbers $C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$ built on central binomial coefficients, including the bound $\\binom{2n}{n} \\le 4^n$ and the identity $C_n(n+1) = \\binom{2n}{n}$."
+    },
+    {
+      "targetId": "combinations-formula-oq-03",
+      "relationship": "extended-by",
+      "description": "Extended by a verified theory of q-analog (Gaussian) binomial coefficients $[n,k]_q$ over arbitrary commutative rings, recovering $\\binom{n}{k}$ at $q=1$ via q-Pascal recurrences, the product formula, and symmetry $[n,k]_q = [n,n-k]_q$."
     }
   ],
   "references": [


### PR DESCRIPTION
Adds `extended-by` cross-references from the **combinations-formula** parent to its two verified OQ children:

- `combinations-formula-oq-02` — Catalan numbers & central binomial coefficients (verified, original)
- `combinations-formula-oq-03` — q-analog (Gaussian) binomial coefficients (verified, original)

Both children already backlink to the parent; this closes the forward-link gap so the relationship is navigable in both directions. The axiomatized `oq-01` child is intentionally excluded per the axiom-integrity policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)