### PR TITLE
Enrich Ptolemy's Theorem (complex proof, parent): forward-link its two verified OQ extensions

### DIFF
--- a/src/data/proofs/ptolemys-complex-proof/meta.json
+++ b/src/data/proofs/ptolemys-complex-proof/meta.json
@@ -145,6 +145,16 @@
       "targetId": "law-of-sines-oq-06",
       "relationship": "related",
       "description": "Ptolemy's theorem (equality case) applied to cyclic quadrilaterals inscribed in a circle of radius R directly yields the law of sines: the diagonal of a cyclic quadrilateral with one diagonal as a diameter equals 2R·sin(angle), recovering a/sin(A) = 2R; the two theorems are classically paired in the study of cyclic quadrilaterals"
+    },
+    {
+      "targetId": "ptolemys-complex-proof-oq-01",
+      "relationship": "extended-by",
+      "description": "Extended by a verified equality-case characterization: Ptolemy's equality holds for four complex numbers iff the two opposite-side products lie on the same ray in $\\mathbb{C}$ (zero or positively proportional), completing the biconditional."
+    },
+    {
+      "targetId": "ptolemys-complex-proof-oq-02",
+      "relationship": "extended-by",
+      "description": "Extended by a verified classical application deriving the sine addition formula $\\sin(\\alpha+\\beta) = \\sin\\alpha\\cos\\beta + \\cos\\alpha\\sin\\beta$ from Ptolemy's equality on the unit circle, reproducing Ptolemy's original argument."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Adds `extended-by` cross-references from the **ptolemys-complex-proof** parent to its two verified OQ children:

- `ptolemys-complex-proof-oq-01` — equality-case characterization via same ray in ℂ (verified, original)
- `ptolemys-complex-proof-oq-02` — derivation of the sine addition formula from Ptolemy (verified, mathlib)

Both children already backlink to the parent; this closes the forward-link gap so navigation works in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)