### PR TITLE
Enrich Cayley-Hamilton Reduction (parent): forward-link its two verified OQ extensions

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction/meta.json
@@ -199,6 +199,16 @@
       "targetId": "inverse-galois",
       "relationship": "related",
       "description": "The characteristic polynomial of a matrix determines a field extension via its splitting field; the Galois group of this extension governs the algebraic structure of the matrix's eigenvalues and Jordan form"
+    },
+    {
+      "targetId": "cayley-hamilton-reduction-oq-01",
+      "relationship": "extended-by",
+      "description": "Extended by an efficient Cayley-Hamilton reduction specialized to sparse matrices."
+    },
+    {
+      "targetId": "cayley-hamilton-reduction-oq-02",
+      "relationship": "extended-by",
+      "description": "Extended by a refinement reducing via the minimal polynomial in place of the characteristic polynomial."
     }
   ],
   "references": [


### PR DESCRIPTION
Adds forward `extended-by` cross-references from the verified parent **Cayley-Hamilton Reduction** to its two verified open-question extensions (oq-01 sparse-matrix reduction; oq-02 minimal-polynomial reduction). Both children already backlink to the parent; this closes the missing forward direction. Pure metadata enrichment.