### PR TITLE
Enrich Napoleon's Theorem (parent): forward-link its two verified OQ extensions

### DIFF
--- a/src/data/proofs/napoleons-theorem/meta.json
+++ b/src/data/proofs/napoleons-theorem/meta.json
@@ -169,6 +169,16 @@
       "targetId": "triangle-angle-sum",
       "relationship": "foundational",
       "description": "The triangle angle sum theorem (angles sum to π) is foundational for the equilateral triangle geometry used in Napoleon's construction; the 60° angles of the constructed equilateral triangles give the rotation by e^{±iπ/3} that drives the proof"
+    },
+    {
+      "targetId": "napoleons-theorem-oq-02",
+      "relationship": "extended-by",
+      "description": "Extended by a discrete-Fourier-transform characterization of Napoleon's theorem."
+    },
+    {
+      "targetId": "napoleons-theorem-oq-03",
+      "relationship": "extended-by",
+      "description": "Extended by a spectral-complementarity formulation with shape annihilation."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Adds forward `extended-by` cross-references from the verified parent **Napoleon's Theorem** to its two verified open-question extensions (oq-02 DFT characterization; oq-03 spectral complementarity & shape annihilation). Both children already backlink to the parent; this closes the missing forward direction. Pure metadata enrichment.