### PR TITLE
research(cantor-diagonalization-oq-04-oq-01-oq-01): Lawvere's Fixed-Point Theorem in a Cartesian Closed Category

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ04OQ01OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ04OQ01OQ01.lean
@@ -1,0 +1,120 @@
+import Mathlib.CategoryTheory.Monoidal.Closed.Cartesian
+import Mathlib.Tactic
+
+/-
+# Lawvere's Fixed-Point Theorem in a Cartesian Closed Category
+
+## Open Question (cantor-diagonalization-oq-04-oq-01-oq-01)
+"Can the setoid version be lifted to a proof using Mathlib's `CartesianClosed`
+typeclass, working in any CCC with a terminal object?"
+
+## Answer: YES.
+
+This file proves **Lawvere's fixed-point theorem** at full categorical generality,
+using Mathlib's `CartesianClosed` (= `MonoidalClosed` for a cartesian monoidal
+category).  No `Type`-level surjections, no `Setoid` quotients: the argument lives
+entirely in the category, with the terminal object `𝟙_ C` supplying "global
+points" `𝟙_ C ⟶ X`.
+
+### Statement
+
+Let `C` be a cartesian closed category and `A B : C`.  A morphism
+`φ : A ⟶ (A ⟹ B)` is **point-surjective** when every `f : A ⟶ B` is the *name* of
+some global point of `A`: there is `a : 𝟙_ C ⟶ A` with `a ≫ φ = name f`, where
+`name f := curry ((ρ_ A).hom ≫ f)` is the exponential transpose of `f`.
+
+**Theorem (Lawvere).** If some `φ : A ⟶ (A ⟹ B)` is point-surjective, then every
+endomorphism `t : B ⟶ B` has a fixed point: a global point `s : 𝟙_ C ⟶ B` with
+`s ≫ t = s`.
+
+### The diagonal argument (point-free)
+
+Build the diagonal `f := Δ ≫ uncurry φ ≫ t : A ⟶ B`, where `Δ = lift (𝟙 A) (𝟙 A)`
+is the categorical diagonal.  Point-surjectivity yields `a : 𝟙_ C ⟶ A` with
+`a ≫ φ = name f`.  The fixed point is `s := a ≫ f`.  Two computations close it:
+
+* **β-reduction** `lift a a ≫ uncurry φ = a ≫ f` — "evaluating `φ(a)` at `a` equals
+  evaluating `f` at `a`", obtained from `a ≫ φ = name f` and the unit coherence
+  `(ρ_ A).hom = fst _ _`.
+* **diagonal unfolding** `a ≫ f = (lift a a ≫ uncurry φ) ≫ t` — pushing the point
+  `a` through `Δ` via `comp_lift`.
+
+Substituting one into the other gives `a ≫ f = (a ≫ f) ≫ t`, i.e. `s ≫ t = s`.
+
+### Corollaries
+* `lawvere_cantor` — contrapositive: if `t` has no fixed point, no `φ` is
+  point-surjective (the abstract Cantor diagonal).
+* In `Type u` this specializes to: no `f : A → (A → B)` is surjective when `B`
+  carries a fixed-point-free endomorphism (e.g. `B = Bool`, `t = not`).
+
+This strictly generalizes the parent `Setoid` proof (`CantorDiagonalizationOQ04OQ01`)
+and the original `Type` diagonal (`CantorDiagonalization`).
+-/
+
+universe v u
+
+namespace LawvereCCC
+
+open CategoryTheory CategoryTheory.Category CategoryTheory.Limits
+open CategoryTheory.MonoidalCategory CategoryTheory.CartesianMonoidalCategory
+open CategoryTheory.CartesianClosed
+
+variable {C : Type u} [Category.{v} C] [CartesianMonoidalCategory C] [CartesianClosed C]
+variable {A B : C}
+
+/-- The *name* (exponential transpose) of a morphism `f : A ⟶ B`: the global point
+`𝟙_ C ⟶ (A ⟹ B)` that internalizes `f`. -/
+def name (f : A ⟶ B) : 𝟙_ C ⟶ (A ⟹ B) := curry ((ρ_ A).hom ≫ f)
+
+@[simp] lemma name_def (f : A ⟶ B) : name f = curry ((ρ_ A).hom ≫ f) := rfl
+
+/-- `φ : A ⟶ (A ⟹ B)` is *point-surjective* if every `f : A ⟶ B` is the name of a
+global point of `A` factored through `φ`. -/
+def PointSurjective (φ : A ⟶ (A ⟹ B)) : Prop :=
+  ∀ f : A ⟶ B, ∃ a : 𝟙_ C ⟶ A, a ≫ φ = name f
+
+/-- A global point `s : 𝟙_ C ⟶ B` is a fixed point of `t : B ⟶ B` if `s ≫ t = s`. -/
+def IsFixedPoint (t : B ⟶ B) (s : 𝟙_ C ⟶ B) : Prop := s ≫ t = s
+
+/-- **Lawvere's fixed-point theorem.**  If some `φ : A ⟶ (A ⟹ B)` is
+point-surjective, then every endomorphism `t : B ⟶ B` admits a fixed point. -/
+theorem lawvere_fixedPoint {φ : A ⟶ (A ⟹ B)} (hφ : PointSurjective φ)
+    (t : B ⟶ B) : ∃ s : 𝟙_ C ⟶ B, IsFixedPoint t s := by
+  -- The diagonal morphism `f a = t (φ(a)(a))`.
+  set f : A ⟶ B := lift (𝟙 A) (𝟙 A) ≫ uncurry φ ≫ t with hf
+  -- Point-surjectivity names the diagonal: `a ≫ φ = name f`.
+  obtain ⟨a, ha⟩ := hφ f
+  refine ⟨a ≫ f, ?_⟩
+  -- (★) the uncurried form of the naming equation.
+  have star : (A ◁ a) ≫ uncurry φ = (ρ_ A).hom ≫ f := by
+    have h1 : uncurry (a ≫ φ) = (A ◁ a) ≫ uncurry φ := uncurry_natural_left a φ
+    rw [ha, name_def, uncurry_curry] at h1
+    exact h1.symm
+  -- β-reduction: evaluating `φ(a)` at `a` is `a ≫ f`.
+  have beta : lift a a ≫ uncurry φ = a ≫ f := by
+    have e : lift a (𝟙 (𝟙_ C)) ≫ (A ◁ a) = lift a a := by
+      rw [lift_whiskerLeft, Category.id_comp]
+    calc lift a a ≫ uncurry φ
+        = (lift a (𝟙 (𝟙_ C)) ≫ (A ◁ a)) ≫ uncurry φ := by rw [e]
+      _ = lift a (𝟙 (𝟙_ C)) ≫ ((A ◁ a) ≫ uncurry φ) := by rw [Category.assoc]
+      _ = lift a (𝟙 (𝟙_ C)) ≫ ((ρ_ A).hom ≫ f) := by rw [star]
+      _ = (lift a (𝟙 (𝟙_ C)) ≫ (ρ_ A).hom) ≫ f := by rw [Category.assoc]
+      _ = a ≫ f := by rw [rightUnitor_hom, lift_fst]
+  -- Diagonal unfolding: push the point `a` through `Δ = lift (𝟙 A) (𝟙 A)`.
+  have factI : a ≫ f = (lift a a ≫ uncurry φ) ≫ t := by
+    rw [hf, ← Category.assoc a, comp_lift, Category.comp_id, Category.assoc]
+  -- Combine: `a ≫ f = (a ≫ f) ≫ t`.
+  rw [beta] at factI
+  exact factI.symm
+
+/-- **Abstract Cantor / Lawvere contrapositive.**  If `t : B ⟶ B` is fixed-point
+free (no global point `s` with `s ≫ t = s`), then no `φ : A ⟶ (A ⟹ B)` can be
+point-surjective. -/
+theorem lawvere_cantor {t : B ⟶ B}
+    (ht : ∀ s : 𝟙_ C ⟶ B, ¬ IsFixedPoint t s)
+    (φ : A ⟶ (A ⟹ B)) : ¬ PointSurjective φ := by
+  intro hφ
+  obtain ⟨s, hs⟩ := lawvere_fixedPoint hφ t
+  exact ht s hs
+
+end LawvereCCC

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-lawvere-ccc-context",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 64 },
+    "type": "concept",
+    "title": "Lawvere's Fixed-Point Theorem in a Genuine Cartesian Closed Category",
+    "content": "This file answers the **headline open question** of the parent (`CantorDiagonalizationOQ04OQ01`): can Lawvere's fixed-point theorem be stated and proved using Mathlib's `CartesianClosed` typeclass, in *any* cartesian closed category with a terminal object? The parent had conjectured that the setoid layer was the maximal version achievable in Lean. **It is not** — Mathlib's curry/uncurry adjunction and cartesian-monoidal lemmas are exactly enough. The proof is fully *point-free*: there are no set elements, only **global points** `𝟙_ C ⟶ X` (morphisms out of the terminal object, which is the monoidal unit in a cartesian monoidal category).",
+    "mathContext": "Lawvere's theorem (1969): in a cartesian closed category, if some object $A$ *point-surjectively parametrizes* the morphisms $A \\to B$ — i.e. there is $\\varphi : A \\to B^A$ such that every $f : A \\to B$ is the name of some global point of $A$ — then **every endomorphism $t : B \\to B$ has a fixed point**. Contrapositively, an object $B$ with a fixed-point-free endomorphism cannot be parametrized by any $A$ inside $A \\to B^A$. This single statement specializes to Cantor's theorem, Russell's paradox, Gödel's first incompleteness theorem, Tarski's undefinability of truth, and the unsolvability of the halting problem, by choosing the category and the fixed-point-free $t$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lawvere's fixed-point theorem (1969)",
+      "cartesian closed category",
+      "exponential object A ⟹ B and the curry/uncurry adjunction",
+      "global points 𝟙_C ⟶ X as element substitutes",
+      "Cantor, Russell, Gödel, Tarski, Turing as instances"
+    ],
+    "prerequisites": [
+      "Mathlib CategoryTheory.Monoidal.Closed.Cartesian (CartesianClosed = MonoidalClosed on a cartesian monoidal category)",
+      "Parent setoid version CantorDiagonalizationOQ04OQ01",
+      "Adjunction tensorLeft A ⊣ exp A"
+    ]
+  },
+  {
+    "id": "ann-lawvere-ccc-name",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01",
+    "range": { "startLine": 66, "endLine": 71 },
+    "type": "definition",
+    "title": "The Name (Exponential Transpose) of a Morphism",
+    "content": "`name f := curry ((ρ_ A).hom ≫ f)` is the global point `𝟙_ C ⟶ (A ⟹ B)` that internalizes a morphism `f : A ⟶ B`. Currying turns `A ⊗ 𝟙_ C ⟶ B` into `𝟙_ C ⟶ (A ⟹ B)`, and the right unitor `(ρ_ A).hom : A ⊗ 𝟙_ C ⟶ A` provides the needed map. In `Type`, `name f` is just `f` regarded as a single point of the function space `B^A`. The whole argument is mediated by names: a *point* of `A ⟹ B` and a *morphism* `A ⟶ B` are interchangeable up to the unit isomorphism `A ⊗ 𝟙_ C ≅ A`.",
+    "mathContext": "The bijection $\\mathrm{Hom}(A, B) \\cong \\mathrm{Hom}(\\mathbf 1, B^A)$ is the global-points instance of the exponential adjunction $\\mathrm{Hom}(A \\otimes Y, B) \\cong \\mathrm{Hom}(Y, B^A)$ at $Y = \\mathbf 1$. Stating point-surjectivity through `name` is what keeps the hypothesis categorical rather than relying on a Lean-level surjection of function types.",
+    "significance": "important",
+    "relatedConcepts": ["exponential transpose", "currying", "right unitor", "global elements"],
+    "prerequisites": ["curry : (A ⊗ Y ⟶ X) → (Y ⟶ A ⟹ X)", "right unitor ρ"]
+  },
+  {
+    "id": "ann-lawvere-ccc-hypotheses",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01",
+    "range": { "startLine": 72, "endLine": 80 },
+    "type": "definition",
+    "title": "Point-Surjectivity and Fixed Points, Categorically",
+    "content": "`PointSurjective φ` says every `f : A ⟶ B` equals `name f` reached through `φ`: there is a global point `a : 𝟙_ C ⟶ A` with `a ≫ φ = name f`. This is the categorical replacement for 'the coding map is surjective' — but only on *points*, which is all the diagonal argument needs (hence Lawvere's term 'weakly point-surjective'). `IsFixedPoint t s` is simply `s ≫ t = s` for a global point `s : 𝟙_ C ⟶ B`. Note the hypothesis is a *premise* of the theorem, not an axiom: Lawvere's theorem is genuinely conditional, so the file remains axiom-free.",
+    "mathContext": "Point-surjectivity is strictly weaker than surjectivity of $\\varphi$ as a morphism, yet sufficient. The asymmetry is the crux of every diagonal argument: a set can name all of its endo-*functions* pointwise without the naming map being epi.",
+    "significance": "important",
+    "relatedConcepts": ["weak point-surjectivity", "fixed point of an endomorphism", "conditional theorem"],
+    "prerequisites": ["global points", "name (exponential transpose)"]
+  },
+  {
+    "id": "ann-lawvere-ccc-diagonal",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01",
+    "range": { "startLine": 81, "endLine": 88 },
+    "type": "technique",
+    "title": "The Diagonal Morphism",
+    "content": "The heart of the argument: `f := lift (𝟙 A) (𝟙 A) ≫ uncurry φ ≫ t`. Here `lift (𝟙 A) (𝟙 A) : A ⟶ A ⊗ A` is the **categorical diagonal** Δ, `uncurry φ : A ⊗ A ⟶ B` evaluates `φ(a)` at `a` (the self-application `a ↦ φ(a)(a)`), and `t : B ⟶ B` is post-composed. Point-surjectivity then names this very `f`: `obtain ⟨a, ha⟩ := hφ f` gives a global point `a` with `a ≫ φ = name f`. The fixed point will be `s := a ≫ f` (in elements: `s = φ(a)(a)`).",
+    "mathContext": "Diagonalization $g(x) = t(\\varphi(x)(x))$ is the same move as Cantor's $g(x) = \\lnot \\varphi(x)(x)$; substituting the name $a$ of $g$ into itself forces $\\varphi(a)(a) = g(a) = t(\\varphi(a)(a))$, a fixed point. The categorical diagonal $\\Delta$ replaces the duplication of the variable $x$.",
+    "significance": "key",
+    "relatedConcepts": ["categorical diagonal lift (𝟙 A) (𝟙 A)", "self-application via uncurry", "Cantor diagonal"],
+    "prerequisites": ["lift / fst / snd in a cartesian monoidal category", "uncurry"]
+  },
+  {
+    "id": "ann-lawvere-ccc-beta",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01",
+    "range": { "startLine": 89, "endLine": 103 },
+    "type": "technique",
+    "title": "β-Reduction: Evaluating φ(a) at a Equals f(a)",
+    "content": "The key lemma `beta : lift a a ≫ uncurry φ = a ≫ f`. Step `star` uncurries the naming equation: from `a ≫ φ = name f`, naturality `uncurry_natural_left` gives `(A ◁ a) ≫ uncurry φ = (ρ_ A).hom ≫ f` (since `uncurry (name f) = (ρ_ A).hom ≫ f` by `uncurry_curry`). Then `beta` factors `lift a a` through the whiskering `A ◁ a` via `lift_whiskerLeft`, applies `star`, and collapses the right unitor with the unit coherence **`(ρ_ A).hom = fst _ _`** (`rightUnitor_hom`) so that `lift a (𝟙 _) ≫ (ρ_ A).hom = a` by `lift_fst`. This is exactly the β-rule 'apply the name of f to the point a, get f(a)' done with morphisms.",
+    "mathContext": "In any CCC the evaluation of a transposed morphism reproduces the original: $\\mathrm{ev} \\circ \\langle \\mathrm{name}(f), \\mathrm{id}\\rangle = f$. Here it appears as `lift a a ≫ uncurry φ = a ≫ f`, the single non-trivial coherence calculation. The unit law `(ρ_ A).hom = fst` is what makes the terminal-object bookkeeping disappear.",
+    "significance": "key",
+    "relatedConcepts": ["β-reduction in a CCC", "uncurry_natural_left", "rightUnitor_hom = fst", "lift_whiskerLeft"],
+    "prerequisites": ["naturality of uncurry", "unit coherence in a cartesian monoidal category"]
+  },
+  {
+    "id": "ann-lawvere-ccc-close",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01",
+    "range": { "startLine": 104, "endLine": 111 },
+    "type": "technique",
+    "title": "Closing the Fixed Point",
+    "content": "`factI : a ≫ f = (lift a a ≫ uncurry φ) ≫ t` simply unfolds the diagonal definition of `f` and pushes the point `a` through `Δ = lift (𝟙 A) (𝟙 A)` using `comp_lift` (`a ≫ lift (𝟙 A) (𝟙 A) = lift a a`). Rewriting `factI` with `beta` turns it into `a ≫ f = (a ≫ f) ≫ t`, i.e. `s = s ≫ t`. Taking `.symm` gives the goal `s ≫ t = s`. The fixed point `s = a ≫ f` is produced with no choice beyond the witness `a` already handed to us by point-surjectivity.",
+    "mathContext": "The two equations `s = lift a a ≫ uncurry φ` (β) and `a ≫ f = s ≫ t` (diagonal unfolding) intersect at `s = s ≫ t`. This is the categorical shadow of `φ(a)(a) = f(a) = t(φ(a)(a))`.",
+    "significance": "important",
+    "relatedConcepts": ["comp_lift", "fixed-point equation s ≫ t = s"],
+    "prerequisites": ["β-reduction lemma above"]
+  },
+  {
+    "id": "ann-lawvere-ccc-cantor",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01",
+    "range": { "startLine": 112, "endLine": 120 },
+    "type": "concept",
+    "title": "The Abstract Cantor / Diagonal Contrapositive",
+    "content": "`lawvere_cantor`: if `t : B ⟶ B` is fixed-point free (no global point `s` with `s ≫ t = s`), then **no** `φ : A ⟶ (A ⟹ B)` is point-surjective. This is the form in which Lawvere's theorem yields impossibility results. Choosing `B` to be a two-element object with `t = ¬` recovers Cantor: there is no point-surjective coding of `A ⟹ Ω` inside `A`. The same statement, read in a category of computable functions, is the halting problem; read in arithmetic, it is Gödel/Tarski.",
+    "mathContext": "Cantor, Russell, Gödel, Tarski, Turing are all the contrapositive of one fact: a fixed-point-free endomorphism witnesses non-parametrizability. `lawvere_cantor` is that fact, stated once and for all in a CCC.",
+    "significance": "key",
+    "relatedConcepts": ["Cantor's theorem", "Russell's paradox", "Gödel incompleteness", "halting problem", "fixed-point-free endomorphism"],
+    "prerequisites": ["lawvere_fixedPoint"]
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "cantor-diagonalization-oq-04-oq-01-oq-01",
+  "slug": "cantor-diagonalization-oq-04-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.CategoryTheory.Monoidal.Closed.Cartesian",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "CategoryTheory",
+      "CategoryTheory.Category",
+      "CategoryTheory.Limits",
+      "CategoryTheory.MonoidalCategory",
+      "CategoryTheory.CartesianMonoidalCategory",
+      "CategoryTheory.CartesianClosed"
+    ],
+    "namespace": "LawvereCCC",
+    "lineCount": 120,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 3,
+    "path": "Proofs/CantorDiagonalizationOQ04OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Lawvere's Fixed-Point Theorem in a Cartesian Closed Category",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CantorDiagonalizationOQ04OQ01OQ01.lean",
+    "tags": [
+      "category-theory",
+      "cartesian-closed-category",
+      "lawvere",
+      "cantor",
+      "diagonal-argument",
+      "fixed-point",
+      "monoidal-closed",
+      "topos",
+      "generalization",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 120,
+    "theoremCount": 3,
+    "definitionCount": 3,
+    "badge": "original",
+    "originalContributions": [
+      "lawvere_fixedPoint: Lawvere's fixed-point theorem stated and proved in any cartesian closed category using Mathlib's CartesianClosed typeclass — a genuine Mathlib gap (Mathlib has no Lawvere FPT)",
+      "Fully point-free diagonal argument: the global point 𝟙_C ⟶ X replaces set elements; the diagonal Δ = lift (𝟙 A) (𝟙 A), evaluation via uncurry, and the exponential transpose `name` carry the whole proof",
+      "name: the exponential transpose 𝟙_C ⟶ (A ⟹ B) of a morphism f : A ⟶ B as curry ((ρ_ A).hom ≫ f)",
+      "PointSurjective: a morphism-level (point-surjective) hypothesis, the categorical replacement for surjectivity of a coding map",
+      "lawvere_cantor: the abstract Cantor/diagonal contrapositive — a fixed-point-free endomorphism of B forbids any point-surjective φ : A ⟶ (A ⟹ B)",
+      "Resolves the headline open question of the parent (CantorDiagonalizationOQ04OQ01), which conjectured the CCC reformulation was beyond Lean's term language"
+    ],
+    "prerequisites": [
+      "Cartesian closed categories (Mathlib.CategoryTheory.Monoidal.Closed.Cartesian)",
+      "Curry/uncurry adjunction tensorLeft A ⊣ exp A and the evaluation morphism",
+      "Cartesian monoidal structure: lift, fst, the terminal unit 𝟙_C, right unitor",
+      "Parent: CantorDiagonalizationOQ04OQ01 (setoid generalization)",
+      "Lawvere's fixed-point theorem (1969)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "CartesianClosed.uncurry_natural_left",
+        "description": "uncurry (f ≫ g) = _ ◁ f ≫ uncurry g — naturality of the transpose in the domain, the engine of the β-reduction step",
+        "module": "Mathlib.CategoryTheory.Monoidal.Closed.Cartesian"
+      },
+      {
+        "theorem": "CartesianClosed.uncurry_curry",
+        "description": "uncurry (curry f) = f — the round-trip that turns the named diagonal back into a morphism",
+        "module": "Mathlib.CategoryTheory.Monoidal.Closed.Cartesian"
+      },
+      {
+        "theorem": "CartesianMonoidalCategory.comp_lift",
+        "description": "f ≫ lift g h = lift (f ≫ g) (f ≫ h) — pushes the global point a through the diagonal Δ",
+        "module": "Mathlib.CategoryTheory.Monoidal.Cartesian.Basic"
+      },
+      {
+        "theorem": "CartesianMonoidalCategory.lift_whiskerLeft",
+        "description": "lift f g ≫ (Y ◁ h) = lift f (g ≫ h) — factors lift a a through the whiskering A ◁ a",
+        "module": "Mathlib.CategoryTheory.Monoidal.Cartesian.Basic"
+      },
+      {
+        "theorem": "CartesianMonoidalCategory.rightUnitor_hom",
+        "description": "(ρ_ X).hom = fst _ _ — the unit coherence that collapses the transpose's right unitor to a projection, giving lift a (𝟙 _) ≫ (ρ_ A).hom = a",
+        "module": "Mathlib.CategoryTheory.Monoidal.Cartesian.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01",
+      "question": "Instantiate this CCC theorem in concrete categories: derive Cantor's theorem in Type (no surjection A → (A → Bool)) and the fixed-point form in a presheaf topos as corollaries of lawvere_fixedPoint, by exhibiting the CartesianClosed instances and a fixed-point-free t.",
+      "significance": "high"
+    },
+    {
+      "id": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-02",
+      "question": "Prove the converse direction in CCC form: if every endomorphism of B has a fixed point then a weakly-point-surjective φ : A ⟶ (A ⟹ B) exists for suitable A — characterizing the 'rich' objects A in terms of B.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: the setoid generalization. This file answers the parent's headline open question by proving Lawvere's FPT in a genuine cartesian closed category via Mathlib's CartesianClosed typeclass, rather than in Lean's term language with setoids. The parent conjectured this was the unachievable maximal goal; it is achieved here."
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-04",
+      "relationship": "extends",
+      "description": "Grandparent: the Type-level retraction version. The point-free argument here recovers it when C = Type, points are elements, and `name` is the curry isomorphism (Type → (Type → Type))."
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "specializes-to",
+      "description": "Cantor's diagonal argument is lawvere_cantor applied with a fixed-point-free endomorphism (e.g. negation on a two-element object): no point-surjective coding of A ⟹ B inside A exists."
+    },
+    {
+      "targetId": "godel-incompleteness",
+      "relationship": "related",
+      "description": "Lawvere's FPT in a CCC is the categorical kernel of the Gödel–Tarski–Turing diagonal phenomena: incompleteness, undefinability of truth, and the halting problem are all instances of lawvere_cantor in suitable categories (Lawvere 1969)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Diagonal arguments and cartesian closed categories",
+      "author": "F. William Lawvere",
+      "year": "1969",
+      "venue": "Lecture Notes in Mathematics, Vol. 92, Springer, pp. 134–145",
+      "description": "Original publication. Theorem: in a cartesian closed category, if some A weakly parametrizes the morphisms A ⟶ B (point-surjective A ⟶ B^A), then every endomorphism of B has a fixed point. Unifies Cantor, Russell, Gödel, Tarski, and Turing."
+    },
+    {
+      "title": "A universal approach to self-referential paradoxes, incompleteness and fixed points",
+      "author": "Noson S. Yanofsky",
+      "year": "2003",
+      "venue": "Bulletin of Symbolic Logic 9(3), 362–386",
+      "description": "Accessible exposition of Lawvere's theorem and its corollaries; the point-surjectivity formulation used in this formalization follows Yanofsky's presentation."
+    },
+    {
+      "title": "Topoi: The Categorial Analysis of Logic",
+      "author": "Robert Goldblatt",
+      "year": "1984",
+      "venue": "North-Holland (Dover reprint 2006)",
+      "description": "Standard reference for cartesian closed categories, the internal hom, currying-as-morphisms, and Lawvere's theorem in elementary toposes."
+    },
+    {
+      "title": "Über eine elementare Frage der Mannigfaltigkeitslehre",
+      "author": "Georg Cantor",
+      "year": "1891",
+      "venue": "Jahresbericht der DMV 1, 75–78",
+      "description": "Cantor's original diagonal argument, |Y| < |2^Y|; the simplest corollary of lawvere_cantor."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Lawvere's fixed-point theorem is proved at full categorical generality in any cartesian closed category, using Mathlib's CartesianClosed typeclass. Given a point-surjective φ : A ⟶ (A ⟹ B) — every f : A ⟶ B is the name of some global point of A — every endomorphism t : B ⟶ B has a fixed point s : 𝟙_C ⟶ B with s ≫ t = s. The proof is entirely point-free: the diagonal Δ = lift (𝟙 A) (𝟙 A), the uncurried evaluation uncurry φ, and the exponential transpose `name` carry the argument. The fixed point s = a ≫ f is closed by two equational lemmas — a β-reduction (lift a a ≫ uncurry φ = a ≫ f) from naturality of uncurry plus the unit coherence (ρ_ A).hom = fst, and a diagonal unfolding (a ≫ f = (lift a a ≫ uncurry φ) ≫ t) from comp_lift. 120 lines, 3 theorems, 3 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This resolves the headline open question of the parent setoid entry, which had conjectured that 'the setoid layer is the maximal Lawvere FPT achievable purely in Lean' and that a CartesianClosed reformulation would require an internal-language layer Mathlib lacks. In fact Mathlib's existing curry/uncurry adjunction and cartesian-monoidal lemmas suffice: the only non-formal ingredient is choosing point-surjectivity (rather than a Lean-level surjection) as the categorical hypothesis, and global points 𝟙_C ⟶ X as the stand-in for elements. Mathlib itself has no Lawvere fixed-point theorem, so this fills a genuine gap and is a candidate for upstreaming. The contrapositive lawvere_cantor packages the Cantor/Russell/Gödel/Tarski/Turing diagonal as a single categorical statement, instantiable in any CCC.",
+    "openQuestions": [
+      "Instantiate lawvere_fixedPoint in Type to recover Cantor (no surjection A → (A → Bool), via the fixed-point-free `not`), and in a presheaf topos for a genuinely non-Type example.",
+      "Prove a CCC-level converse: characterize when fixed points for all endomorphisms of B force the existence of a (weakly) point-surjective parametrization A ⟶ (A ⟹ B).",
+      "Upstream candidate: package `name`, `PointSurjective`, and `lawvere_fixedPoint` for Mathlib's CategoryTheory.Closed namespace; Mathlib currently has no Lawvere FPT.",
+      "Lift the sibling surjection-version (cantor-diagonalization-oq-03) into the same CCC framework, mirroring this proof."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Proves **Lawvere's fixed-point theorem** at full categorical generality using Mathlib's `CartesianClosed` typeclass — a result **Mathlib does not currently have**. This resolves the headline open question of the parent setoid entry (`cantor-diagonalization-oq-04-oq-01`), which had conjectured that the setoid layer was "the maximal Lawvere FPT achievable purely in Lean" and that a `CartesianClosed` reformulation was beyond reach. In fact Mathlib's curry/uncurry adjunction plus the cartesian-monoidal lemmas are exactly enough.

### Theorem (`lawvere_fixedPoint`)

In any cartesian closed category `C`, if `φ : A ⟶ (A ⟹ B)` is **point-surjective** — every `f : A ⟶ B` is the name of some global point of `A` (`∃ a : 𝟙_C ⟶ A, a ≫ φ = name f`) — then every endomorphism `t : B ⟶ B` has a fixed point `s : 𝟙_C ⟶ B` with `s ≫ t = s`.

The argument is **fully point-free**: global points `𝟙_C ⟶ X` replace set elements. The diagonal is `f := lift (𝟙 A) (𝟙 A) ≫ uncurry φ ≫ t`; the fixed point is `s = a ≫ f`, closed by
- a **β-reduction** `lift a a ≫ uncurry φ = a ≫ f` (naturality of `uncurry` + the unit coherence `(ρ_ A).hom = fst`), and
- a **diagonal unfolding** `a ≫ f = (lift a a ≫ uncurry φ) ≫ t` (`comp_lift`).

`lawvere_cantor` is the contrapositive: a fixed-point-free `t` forbids any point-surjective `φ` — the single categorical statement underlying Cantor, Russell, Gödel, Tarski, and Turing.

## Verification

- **120 lines, 3 theorems, 3 definitions, 0 axioms, 0 sorries**
- `#print axioms lawvere_fixedPoint` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`) → **verified**, axiom-free
- Type-checked via `lake env lean Proofs/CantorDiagonalizationOQ04OQ01OQ01.lean` against the pinned Mathlib in `proofs/.lake` (toolchain `v4.26.0`). Full `lake build` not run (Docker build infra); single-file elaboration against prebuilt oleans is sound.

## Gallery

- `src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01/meta.json` — status `verified`, badge `original`
- `annotations.json` — 7 annotations walking through name/transpose, point-surjectivity, the diagonal, β-reduction, and the Cantor contrapositive

## Status / Badge

`verified` / `original`. The core diagonal argument is classical (Lawvere 1969), but the categorical formalization via `CartesianClosed` is original to this project and fills a genuine Mathlib gap — a candidate for upstreaming. The `PointSurjective` hypothesis is a premise of the theorem (Lawvere's theorem is genuinely conditional), not a structure-encoded assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)