### PR TITLE
research(cramers-rule-oq-05): similarity invariants — det, trace, charpoly under unit conjugation

### DIFF
--- a/proofs/Proofs/CramersRuleOQ05.lean
+++ b/proofs/Proofs/CramersRuleOQ05.lean
@@ -1,0 +1,148 @@
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.LinearAlgebra.Matrix.Trace
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
+import Mathlib.Tactic
+
+/-
+# Conjugation Invariance of Determinant, Trace, and Characteristic Polynomial (cramers-rule-oq-05)
+
+Cramer's rule expresses the solution of a linear system through determinants.  A
+natural follow-up question is *which* matrix quantities are intrinsic to the
+underlying linear map rather than to the chosen basis.  Concretely: if `U` is a
+unit (invertible) matrix and `N` is any square matrix, the conjugate
+
+    U N U⁻¹
+
+represents the same endomorphism in a different basis.  The basis-independent
+("similarity") invariants are exactly the quantities that survive this
+conjugation.
+
+This file packages the three fundamental similarity invariants over an arbitrary
+commutative ring `R`:
+
+  * `det (U N U⁻¹) = det N`        (`Matrix.det_units_conj`)
+  * `trace (U N U⁻¹) = trace N`    (`Matrix.trace_units_conj`)
+  * `charpoly (U N U⁻¹) = charpoly N`  (`Matrix.charpoly_units_conj`)
+
+and bundles them into a single `similarity_invariants` statement.  As corollaries
+we record that similar matrices share these invariants (in the textbook
+`∃ U, N = U M U⁻¹` formulation) and that the determinant and trace, being read
+off the characteristic polynomial, are themselves invariant — a structural
+reason the three facts cohere.
+
+Each result is a thin, basis-free wrapper around Mathlib's `*_units_conj`
+lemmas; the contribution is the packaged statement and the similarity
+corollaries, which Mathlib does not state directly.
+
+Status: 0 axioms, 0 sorries
+-/
+
+namespace CramersRuleOQ05
+
+open Matrix BigOperators
+
+variable {n : Type*} [DecidableEq n] [Fintype n]
+variable {R : Type*} [CommRing R]
+
+/-- Conjugation of a matrix `N` by a unit matrix `U`, i.e. the matrix
+`U N U⁻¹` representing the same endomorphism in a `U`-transformed basis. -/
+def conj (U : (Matrix n n R)ˣ) (N : Matrix n n R) : Matrix n n R :=
+  U.val * N * U⁻¹.val
+
+@[simp]
+theorem conj_apply (U : (Matrix n n R)ˣ) (N : Matrix n n R) :
+    conj U N = U.val * N * U⁻¹.val := rfl
+
+-- ============================================================================
+-- Part I: The three similarity invariants
+-- ============================================================================
+
+/-- **Determinant is a similarity invariant**: `det (U N U⁻¹) = det N`. -/
+theorem det_conj (U : (Matrix n n R)ˣ) (N : Matrix n n R) :
+    (conj U N).det = N.det :=
+  Matrix.det_units_conj U N
+
+/-- **Trace is a similarity invariant**: `trace (U N U⁻¹) = trace N`. -/
+theorem trace_conj (U : (Matrix n n R)ˣ) (N : Matrix n n R) :
+    (conj U N).trace = N.trace :=
+  Matrix.trace_units_conj U N
+
+/-- **Characteristic polynomial is a similarity invariant**:
+`charpoly (U N U⁻¹) = charpoly N`. -/
+theorem charpoly_conj (U : (Matrix n n R)ˣ) (N : Matrix n n R) :
+    (conj U N).charpoly = N.charpoly :=
+  Matrix.charpoly_units_conj U N
+
+-- ============================================================================
+-- Part II: The packaged statement
+-- ============================================================================
+
+/-- **Bundled similarity invariants.** Conjugating a matrix by a unit `U`
+preserves its determinant, trace, and characteristic polynomial simultaneously.
+These are the three classical basis-independent invariants of an endomorphism. -/
+theorem similarity_invariants (U : (Matrix n n R)ˣ) (N : Matrix n n R) :
+    (conj U N).det = N.det ∧
+    (conj U N).trace = N.trace ∧
+    (conj U N).charpoly = N.charpoly :=
+  ⟨det_conj U N, trace_conj U N, charpoly_conj U N⟩
+
+-- ============================================================================
+-- Part III: Similarity formulation (`∃ U, N = U M U⁻¹`)
+-- ============================================================================
+
+/-- Two matrices are *similar* when one is obtained from the other by conjugation
+by a unit matrix. -/
+def IsSimilar (M N : Matrix n n R) : Prop :=
+  ∃ U : (Matrix n n R)ˣ, N = conj U M
+
+/-- Similarity is reflexive (conjugate by the identity unit). -/
+theorem IsSimilar.refl (M : Matrix n n R) : IsSimilar M M :=
+  ⟨1, by simp [conj]⟩
+
+/-- **Similar matrices have equal determinant.** -/
+theorem IsSimilar.det_eq {M N : Matrix n n R} (h : IsSimilar M N) :
+    N.det = M.det := by
+  obtain ⟨U, rfl⟩ := h
+  exact det_conj U M
+
+/-- **Similar matrices have equal trace.** -/
+theorem IsSimilar.trace_eq {M N : Matrix n n R} (h : IsSimilar M N) :
+    N.trace = M.trace := by
+  obtain ⟨U, rfl⟩ := h
+  exact trace_conj U M
+
+/-- **Similar matrices have equal characteristic polynomial.** -/
+theorem IsSimilar.charpoly_eq {M N : Matrix n n R} (h : IsSimilar M N) :
+    N.charpoly = M.charpoly := by
+  obtain ⟨U, rfl⟩ := h
+  exact charpoly_conj U M
+
+-- ============================================================================
+-- Part IV: Summary
+-- ============================================================================
+
+/-
+## Summary
+
+| Invariant | Statement | Mathlib backing |
+|-----------|-----------|-----------------|
+| Determinant | `det (U N U⁻¹) = det N` | `Matrix.det_units_conj` |
+| Trace | `trace (U N U⁻¹) = trace N` | `Matrix.trace_units_conj` |
+| Char. poly | `charpoly (U N U⁻¹) = charpoly N` | `Matrix.charpoly_units_conj` |
+
+The bundled `similarity_invariants` and the `IsSimilar.*_eq` corollaries give the
+textbook statement "similar matrices share their determinant, trace, and
+characteristic polynomial" directly.  Because both `det` and `trace` appear (up
+to sign) as coefficients of the characteristic polynomial, the determinant and
+trace invariances are in fact consequences of the characteristic-polynomial
+invariance — the three facts are not independent but form a coherent package, as
+the bundling makes explicit.
+-/
+
+end CramersRuleOQ05
+
+#check @CramersRuleOQ05.det_conj
+#check @CramersRuleOQ05.trace_conj
+#check @CramersRuleOQ05.charpoly_conj
+#check @CramersRuleOQ05.similarity_invariants
+#check @CramersRuleOQ05.IsSimilar.charpoly_eq

--- a/src/data/proofs/cramers-rule-oq-05/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-05/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-cro05-setup",
+    "proofId": "cramers-rule-oq-05",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "Setup: Imports and the Commutative-Ring Setting",
+    "content": "The file imports Mathlib's determinant, trace, and characteristic-polynomial libraries and fixes a finite decidable index type n and a commutative ring R. The choice of CommRing (rather than a field) is deliberate: the similarity invariants require only conjugation by a *unit* matrix, so they remain valid over ℤ and polynomial rings where invertible scalars are scarce. This makes the results applicable in commutative algebra and representation theory, not just over fields."
+  },
+  {
+    "id": "ann-cro05-conj",
+    "proofId": "cramers-rule-oq-05",
+    "range": { "startLine": 48, "endLine": 55 },
+    "type": "definition",
+    "title": "Conjugation by a Unit Matrix",
+    "content": "conj U N := U.val * N * U⁻¹.val packages the change-of-basis action on the matrix of an endomorphism: U is an element of the unit group (Matrix n n R)ˣ, so its inverse is genuinely a matrix over R, and U N U⁻¹ represents the same linear map in a U-transformed basis. Giving this a name turns three separate Mathlib lemmas into a coherent 'similarity' API; the simp lemma conj_apply unfolds it on demand."
+  },
+  {
+    "id": "ann-cro05-invariants",
+    "proofId": "cramers-rule-oq-05",
+    "range": { "startLine": 56, "endLine": 75 },
+    "type": "technique",
+    "title": "The Three Similarity Invariants",
+    "content": "det_conj, trace_conj, and charpoly_conj re-express Mathlib's det_units_conj, trace_units_conj, and charpoly_units_conj through conj. Determinant invariance follows from multiplicativity (det U · det N · det U⁻¹ = det N); trace invariance from cyclic invariance trace(AB) = trace(BA); characteristic-polynomial invariance because conjugation commutes with forming X·I − N over R[X]. Each is a one-line wrapper, but together they constitute the basis-independent data of the operator."
+  },
+  {
+    "id": "ann-cro05-bundle",
+    "proofId": "cramers-rule-oq-05",
+    "range": { "startLine": 76, "endLine": 92 },
+    "type": "concept",
+    "title": "Packaging the Invariants",
+    "content": "similarity_invariants bundles the three facts into a single conjunction: conjugation by a unit preserves det, trace, and charpoly simultaneously. The packaging is the point — det and trace are (up to sign) the constant and subleading coefficients of the characteristic polynomial, so the three invariances are not independent but form a coherent whole, which the conjunction makes explicit and reusable downstream."
+  },
+  {
+    "id": "ann-cro05-similarity",
+    "proofId": "cramers-rule-oq-05",
+    "range": { "startLine": 93, "endLine": 118 },
+    "type": "technique",
+    "title": "The Similarity Relation and Its Corollaries",
+    "content": "IsSimilar M N := ∃ U, N = conj U M is the textbook similarity relation. After proving reflexivity (conjugate by the identity unit), the corollaries IsSimilar.det_eq, trace_eq, and charpoly_eq are discharged by destructuring the witness U and applying the corresponding invariance. This yields the familiar statement 'similar matrices have the same determinant, trace, and characteristic polynomial' directly in the ∃-quantified form used in linear-algebra texts."
+  },
+  {
+    "id": "ann-cro05-summary",
+    "proofId": "cramers-rule-oq-05",
+    "range": { "startLine": 119, "endLine": 148 },
+    "type": "concept",
+    "title": "Summary: Coherence of the Invariants",
+    "content": "The closing table pairs each invariant with its Mathlib backing and records the structural observation that determinant and trace invariance descend from characteristic-polynomial invariance, because both quantities are coefficients of the characteristic polynomial. The IsSimilar relation packaged here is the natural launching point for formalizing canonical forms and the invariance of the minimal polynomial."
+  }
+]

--- a/src/data/proofs/cramers-rule-oq-05/meta.json
+++ b/src/data/proofs/cramers-rule-oq-05/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "cramers-rule-oq-05",
+  "title": "Cramer's Rule OQ-05: Conjugation Invariance of Determinant, Trace, and Characteristic Polynomial",
+  "slug": "cramers-rule-oq-05",
+  "description": "Packages the three fundamental similarity invariants of a square matrix over a commutative ring: conjugating by a unit matrix U preserves the determinant, trace, and characteristic polynomial. Bundles Mathlib's det_units_conj, trace_units_conj, and charpoly_units_conj into a single similarity_invariants statement and derives the textbook 'similar matrices share these invariants' corollaries in the ∃U, N = U M U⁻¹ formulation. 9 theorems, 2 definitions, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CramersRuleOQ05.lean",
+    "tags": [
+      "linear-algebra",
+      "cramers-rule",
+      "determinant",
+      "trace",
+      "characteristic-polynomial",
+      "similarity-invariants",
+      "matrix-conjugation"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified using Mathlib's Matrix.det_units_conj, Matrix.trace_units_conj, and Matrix.charpoly_units_conj. Depends only on propext, Classical.choice, and Quot.sound.",
+    "lineCount": 148,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "originalContributions": [
+      "conj: packaged conjugation U N U⁻¹ of a matrix by a unit matrix",
+      "similarity_invariants: bundled statement that det, trace, and charpoly are all preserved under unit conjugation",
+      "IsSimilar: the textbook similarity relation ∃ U, N = U M U⁻¹ on matrices over a commutative ring",
+      "IsSimilar.det_eq / trace_eq / charpoly_eq: similar matrices share their determinant, trace, and characteristic polynomial"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The notion that certain matrix quantities are intrinsic to a linear map rather than to a chosen basis crystallized in the 19th century with the work of Cayley, Sylvester, and Frobenius on invariant theory and the theory of elementary divisors. Two matrices representing the same endomorphism in different bases are 'similar' — related by N = U M U⁻¹ — and the quantities invariant under this relation (determinant, trace, characteristic polynomial, and more generally the rational canonical form) are precisely the basis-independent data of the operator. Frobenius's 1878 memoir on bilinear forms and the Jordan–Chevalley decomposition made the similarity-invariant viewpoint central to linear algebra. The determinant and trace are, up to sign, the extreme coefficients of the characteristic polynomial (the constant term and the subleading coefficient), so their invariance is subsumed by the invariance of the characteristic polynomial — a structural coherence this entry makes explicit.",
+    "problemStatement": "Show that for a unit matrix U and any square matrix N over a commutative ring R, the conjugate U N U⁻¹ has the same determinant, trace, and characteristic polynomial as N, and package these into a single similarity-invariants statement with the textbook 'similar matrices' corollaries.",
+    "text": "A change of basis acts on the matrix of an endomorphism by conjugation N ↦ U N U⁻¹ where U is invertible. A quantity f(N) is a similarity invariant when f(U N U⁻¹) = f(N) for every unit U. The determinant, trace, and characteristic polynomial are the three classical examples: det is multiplicative so det(U N U⁻¹) = det U · det N · det U⁻¹ = det N; trace is invariant under cyclic permutation so trace(U N U⁻¹) = trace(U⁻¹ U N) = trace N; and the characteristic polynomial of U N U⁻¹ equals that of N because conjugation commutes with forming X·I − N over the polynomial ring. Mathlib provides each invariance as det_units_conj, trace_units_conj, and charpoly_units_conj; this entry packages them and states the similarity corollaries.",
+    "proofStrategy": "Define conj U N := U.val * N * U⁻¹.val and re-express Mathlib's three *_units_conj lemmas through it, yielding det_conj, trace_conj, and charpoly_conj. Bundle these into similarity_invariants as a conjunction. Introduce IsSimilar M N := ∃ U, N = conj U M and discharge det_eq / trace_eq / charpoly_eq by destructuring the witness and applying the corresponding invariance.",
+    "keyInsights": [
+      "The three invariances hold over an arbitrary commutative ring R, not just a field — conjugation by a *unit* matrix is all that is needed, so the results apply over ℤ and polynomial rings where invertible scalars are scarce",
+      "Determinant and trace are (up to sign) the constant and subleading coefficients of the characteristic polynomial, so charpoly invariance already implies det and trace invariance — the bundle is coherent rather than three independent facts",
+      "Packaging the conjugation as a named definition conj turns three separate Mathlib lemmas into a reusable 'similarity invariants' API and makes the textbook statement ∃U, N = U M U⁻¹ directly available",
+      "Similarity is the matrix-level shadow of 'same endomorphism in a different basis'; the invariants proved here are exactly the data that descends to the underlying linear map"
+    ],
+    "prerequisites": [
+      "Determinant: multiplicativity over a commutative ring",
+      "Trace: cyclic invariance trace(AB) = trace(BA)",
+      "Characteristic polynomial of a matrix over a commutative ring",
+      "Units of the matrix ring (Matrix n n R)ˣ"
+    ]
+  },
+  "conclusion": {
+    "summary": "Fully machine-verified packaging of the three classical similarity invariants over a commutative ring: det(U N U⁻¹) = det N, trace(U N U⁻¹) = trace N, and charpoly(U N U⁻¹) = charpoly N, bundled as similarity_invariants, plus the IsSimilar relation and its det/trace/charpoly corollaries. Zero axioms, zero sorries.",
+    "implications": "Similarity invariants are the foundation of the structure theory of linear operators: the characteristic polynomial controls eigenvalues, the trace and determinant give the sum and product of eigenvalues, and invariance under conjugation is what makes these well-defined for an abstract endomorphism independent of basis. Working over a commutative ring rather than a field makes the package available in commutative algebra and algebraic geometry, where matrices over ℤ and polynomial rings arise in syzygies, group representations, and the theory of modules over a PID. The IsSimilar relation packaged here is the natural launching point for formalizing canonical forms (rational and Jordan) and the fact that the minimal polynomial is also a similarity invariant.",
+    "openQuestions": [
+      "Prove that similarity is an equivalence relation (symmetry and transitivity) and that IsSimilar is preserved by polynomial evaluation p(M)",
+      "Show the minimal polynomial is a similarity invariant: minpoly of U M U⁻¹ equals minpoly of M (cf. cayley-hamilton-minpoly-oq-06 via minpoly.algEquiv_eq)",
+      "Formalize that similar matrices have equal rank, eigenvalues (with multiplicity), and the same rational canonical form",
+      "Connect to the characteristic-polynomial coefficients: extract det and trace as ± specific coefficients and derive their invariance as corollaries of charpoly invariance"
+    ]
+  },
+  "leanFile": {
+    "namespace": "CramersRuleOQ05",
+    "lineCount": 148,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "path": "Proofs/CramersRuleOQ05.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cramers-rule",
+      "relationship": "extends",
+      "description": "The parent Cramer's rule entry expresses linear-system solutions through determinants. This entry studies which matrix quantities (determinant, trace, characteristic polynomial) are intrinsic to the underlying endomorphism by showing they are invariant under change of basis (unit conjugation)."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly",
+      "relationship": "related",
+      "description": "The characteristic-polynomial invariance proved here is the companion to minimal-polynomial invariance under conjugation; together they show both polynomials descend to the underlying linear map."
+    }
+  ],
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Imports and Variable Setup",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Imports Mathlib's determinant, trace, and characteristic-polynomial libraries. Declares universe-polymorphic variables: n (finite decidable index type) and R (commutative ring). The commutative-ring setting matters — the invariances need only conjugation by a unit matrix, so they hold over ℤ and polynomial rings, not just fields."
+    },
+    {
+      "id": "conj-def",
+      "title": "Conjugation by a unit matrix",
+      "startLine": 48,
+      "endLine": 55,
+      "summary": "Defines conj U N := U.val * N * U⁻¹.val, the matrix representing the same endomorphism as N in a U-transformed basis, with a simp lemma unfolding it."
+    },
+    {
+      "id": "invariants",
+      "title": "Part I: The three similarity invariants",
+      "startLine": 56,
+      "endLine": 75,
+      "summary": "Re-expresses Mathlib's det_units_conj, trace_units_conj, and charpoly_units_conj through conj, yielding det_conj, trace_conj, and charpoly_conj: determinant, trace, and characteristic polynomial are each preserved under unit conjugation."
+    },
+    {
+      "id": "bundle",
+      "title": "Part II: The packaged statement",
+      "startLine": 76,
+      "endLine": 92,
+      "summary": "Bundles the three invariances into similarity_invariants, a single conjunction asserting that conjugation by a unit simultaneously preserves det, trace, and charpoly — the three classical basis-independent invariants of an endomorphism."
+    },
+    {
+      "id": "similarity",
+      "title": "Part III: Similarity formulation",
+      "startLine": 93,
+      "endLine": 118,
+      "summary": "Introduces IsSimilar M N := ∃ U, N = conj U M, proves reflexivity, and derives the textbook corollaries IsSimilar.det_eq, IsSimilar.trace_eq, and IsSimilar.charpoly_eq: similar matrices share their determinant, trace, and characteristic polynomial."
+    },
+    {
+      "id": "summary",
+      "title": "Part IV: Summary",
+      "startLine": 119,
+      "endLine": 148,
+      "summary": "Tabulates the three invariants against their Mathlib backing and notes that det and trace invariance are consequences of charpoly invariance, since both appear as coefficients of the characteristic polynomial."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **conjugation invariance of the determinant, trace, and characteristic polynomial** over an arbitrary commutative ring — the three classical *similarity invariants* of a square matrix (the basis-independent data of the underlying endomorphism).

`proofs/Proofs/CramersRuleOQ05.lean` (namespace `CramersRuleOQ05`), **9 theorems, 2 definitions, 0 sorries, 0 axioms**.

### Results
- `conj U N := U.val * N * U⁻¹.val` — conjugation by a unit matrix `U : (Matrix n n R)ˣ`.
- `det_conj` / `trace_conj` / `charpoly_conj` — each invariant is preserved, thin wrappers over Mathlib's `Matrix.det_units_conj`, `Matrix.trace_units_conj`, `Matrix.charpoly_units_conj`.
- `similarity_invariants` — bundled conjunction of all three.
- `IsSimilar M N := ∃ U, N = conj U M` with `refl` and the textbook corollaries `IsSimilar.det_eq` / `trace_eq` / `charpoly_eq`.

### Why it holds over `CommRing` (not just a field)
Only conjugation by a **unit** matrix is needed, so the results apply over ℤ and polynomial rings. det/trace invariance are in fact consequences of charpoly invariance, since both are coefficients of the characteristic polynomial — the bundle is coherent rather than three independent facts.

### Verification
- Single-file `lake env lean proofs/Proofs/CramersRuleOQ05.lean` against pinned **Mathlib v4.26.0** oleans: **exit 0**, all `#check`s resolve.
- `#print axioms similarity_invariants` and `IsSimilar.charpoly_eq` → `[propext, Classical.choice, Quot.sound]` only (axiom-free).
- Full `docker-build` not run (host Docker unavailable this session); type-checked at the single-file level against the prebuilt Mathlib. Deployer gates on the build.

Gallery entry added at `src/data/proofs/cramers-rule-oq-05/` (meta.json + annotations.json), badge `mathlib`, status `verified`, extends parent `cramers-rule`.

Closes research problem `cramers-rule-oq-05`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)