### PR TITLE
research(cantor-diagonalization-oq-04-oq-01-oq-03): Lawvere's FPT over an arbitrary relation

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -407,6 +407,7 @@ import Proofs.CantorDiagonalizationOQ03OQ01OQ03
 import Proofs.CantorDiagonalizationOQ03OQ01OQ04
 import Proofs.CantorDiagonalizationOQ04
 import Proofs.CantorDiagonalizationOQ04OQ01
+import Proofs.CantorDiagonalizationOQ04OQ01OQ03
 import Proofs.CantorDiagonalizationOQ04OQ03
 import Proofs.CantorDiagonalizationOQ04OQ03Aristotle
 import Proofs.CantorsTheorem

--- a/proofs/Proofs/CantorDiagonalizationOQ04OQ01OQ03.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ04OQ01OQ03.lean
@@ -1,0 +1,173 @@
+import Mathlib.Logic.Function.Basic
+import Mathlib.Data.Setoid.Basic
+import Mathlib.Tactic
+
+/-
+# Lawvere Fixed-Point Theorem: Relational Generalization
+
+## Open Question (cantor-diagonalization-oq-04-oq-01-oq-03)
+"The setoid generalization (parent oq-04-oq-01) replaces strict Type equality
+with an equivalence relation, motivated as the step toward a CCC/topos version
+where equality becomes coherence. Exactly *which* properties of that relation
+does Lawvere's diagonal argument actually use?"
+
+## Answer
+**None.** Inspecting the setoid proof shows the diagonal argument uses only the
+retraction equation — it never invokes reflexivity, symmetry, or transitivity of
+the coherence relation. Lawvere's fixed-point theorem therefore holds for an
+**arbitrary binary relation** `r`, with the fixed point delivered in the
+retraction orientation `r p (f p)`:
+
+  If `Y` codes its endomorphisms up to `r` (i.e. `decode (encode g) y  r  g y`),
+  then every `f : Y → Y` has a point `p` with `r p (f p)`.
+
+Symmetry of `r` is needed *only* to flip the conclusion to the setoid-style
+orientation `r (f p) p`; reflexivity and transitivity are never used at all.
+
+This strictly generalizes the parent results:
+- **Type version** (oq-04): exact equality `decode (encode g) = g`.
+- **Setoid version** (oq-04-oq-01): an equivalence relation `≈`.
+- **Relational version** (this file): *any* relation — recovers the setoid
+  version as the symmetric special case, and additionally applies to
+  **tolerance relations** (reflexive + symmetric, non-transitive) and to
+  **strict orders** (irreflexive, non-symmetric), neither of which is a setoid.
+
+Isolating "arbitrary relation" as the true hypothesis clarifies the obstruction
+to the genuine CCC version: the categorical content is a coherence *relation* on
+global points, with no equivalence structure required of it.
+
+## Key Results
+1. `lawvere_fixpoint_rel`       — fixed point `r p (f p)` for ANY relation `r`
+2. `lawvere_fixpoint_rel_symm`  — symmetric `r` gives `r (f p) p`
+3. `no_coding_rel_of_no_prefixpoint` — contrapositive for arbitrary `r`
+4. `lawvere_fixpoint_setoid`    — recovers the setoid theorem (symmetric case)
+5. `nat_cannot_code_endos_tol`  — tolerance example (non-transitive, not a setoid)
+6. `nat_cannot_code_endos_lt`   — strict-order example (non-symmetric, not a setoid)
+
+## Proof Technique
+Identical diagonal to the parent: `g y = f (decode y y)`, `y₀ = encode g`,
+`p = decode y₀ y₀`. The retraction equation evaluated at `(g, y₀)` is *exactly*
+`r p (f p)`; no relation axioms are consumed.
+
+References:
+- F.W. Lawvere, "Diagonal arguments and cartesian closed categories" (1969)
+- Parent: CantorDiagonalizationOQ04OQ01 (Setoid generalization)
+-/
+
+namespace CantorDiagonalizationOQ04OQ01OQ03
+
+-- ============================================================
+-- Part I: Coded Endomorphisms up to an Arbitrary Relation
+-- ============================================================
+
+/-- `Y` **codes its endomorphisms up to the relation `r`** when there exist
+    encode/decode functions whose retraction holds only up to `r`:
+    `r (decode (encode g) y) (g y)` for all `g` and `y`.
+
+    No properties (reflexivity/symmetry/transitivity) are assumed of `r`. -/
+structure CodesEndomorphismsRel (Y : Type*) (r : Y → Y → Prop) where
+  encode : (Y → Y) → Y
+  decode : Y → (Y → Y)
+  retract : ∀ (g : Y → Y) (y : Y), r (decode (encode g) y) (g y)
+
+-- ============================================================
+-- Part II: Main Theorem — No Hypotheses on `r`
+-- ============================================================
+
+/-- **Lawvere Fixed-Point Theorem (Relational Version)**.
+
+    If `Y` codes its endomorphisms up to *any* relation `r`, then every
+    `f : Y → Y` has a point `p` with `r p (f p)`.
+
+    The diagonal `g y = f (decode y y)`, `y₀ = encode g`, `p = decode y₀ y₀`
+    makes the retraction equation `r (decode (encode g) y₀) (g y₀)` literally
+    `r p (f p)`. No relation axioms are used. -/
+theorem lawvere_fixpoint_rel {Y : Type*} {r : Y → Y → Prop}
+    (c : CodesEndomorphismsRel Y r) (f : Y → Y) :
+    ∃ p : Y, r p (f p) := by
+  let g : Y → Y := fun y => f (c.decode y y)
+  let y₀ := c.encode g
+  exact ⟨c.decode y₀ y₀, c.retract g y₀⟩
+
+/-- With symmetric `r`, the fixed point can be stated in the parent's
+    orientation `r (f p) p`. Symmetry is the *only* property ever needed,
+    and only to flip the conclusion. -/
+theorem lawvere_fixpoint_rel_symm {Y : Type*} {r : Y → Y → Prop}
+    (hsymm : Symmetric r) (c : CodesEndomorphismsRel Y r) (f : Y → Y) :
+    ∃ p : Y, r (f p) p := by
+  obtain ⟨p, hp⟩ := lawvere_fixpoint_rel c f
+  exact ⟨p, hsymm hp⟩
+
+-- ============================================================
+-- Part III: Contrapositive
+-- ============================================================
+
+/-- If `f` has no point `p` with `r p (f p)` (no "`r`-prefixed point"), then `Y`
+    cannot code its endomorphisms up to `r`. Holds for arbitrary `r`. -/
+theorem no_coding_rel_of_no_prefixpoint {Y : Type*} {r : Y → Y → Prop}
+    (f : Y → Y) (hf : ∀ y : Y, ¬ r y (f y)) :
+    CodesEndomorphismsRel Y r → False := fun c =>
+  let ⟨p, hp⟩ := lawvere_fixpoint_rel c f; hf p hp
+
+-- ============================================================
+-- Part IV: Recovering the Setoid Version
+-- ============================================================
+
+/-- The setoid generalization (parent oq-04-oq-01) is the symmetric special
+    case: an equivalence relation is in particular symmetric, so coding up to a
+    setoid relation `s.r` yields a setoid fixed point `s.r (f p) p`. Reflexivity
+    and transitivity of the setoid play no role. -/
+theorem lawvere_fixpoint_setoid {Y : Type*} (s : Setoid Y)
+    (c : CodesEndomorphismsRel Y s.r) (f : Y → Y) :
+    ∃ p : Y, s.r (f p) p := by
+  have hsymm : Symmetric s.r := by intro a b h; exact s.iseqv.symm h
+  exact lawvere_fixpoint_rel_symm hsymm c f
+
+-- ============================================================
+-- Part V: Tolerance Relation — Reflexive + Symmetric, NOT Transitive
+-- ============================================================
+
+/-- The tolerance "differ by at most one" on `ℕ`: `tol a b ↔ |a - b| ≤ 1`,
+    written without subtraction as `a ≤ b + 1 ∧ b ≤ a + 1`.
+
+    This is reflexive and symmetric but **not transitive** (`tol 0 1`, `tol 1 2`,
+    yet `¬ tol 0 2`), so it is genuinely **not a setoid** — outside the reach of
+    the parent's framework, but squarely inside this relational one. -/
+def tol (a b : ℕ) : Prop := a ≤ b + 1 ∧ b ≤ a + 1
+
+theorem tol_refl (a : ℕ) : tol a a := ⟨by omega, by omega⟩
+
+theorem tol_symm : Symmetric tol := by
+  intro a b h; obtain ⟨h1, h2⟩ := h; exact ⟨h2, h1⟩
+
+/-- `tol` is not transitive: `tol 0 1` and `tol 1 2` hold but `tol 0 2` fails. -/
+theorem tol_not_transitive : ¬ Transitive tol := by
+  intro htrans
+  have h01 : tol 0 1 := ⟨by omega, by omega⟩
+  have h12 : tol 1 2 := ⟨by omega, by omega⟩
+  obtain ⟨-, h2⟩ := htrans h01 h12
+  omega
+
+/-- The shift `n ↦ n + 2` has no tolerance prefixed point: `tol n (n+2)` would
+    force `n + 2 ≤ n + 1`. -/
+theorem add_two_no_tol_prefixpoint : ∀ n : ℕ, ¬ tol n (n + 2) := by
+  intro n h; obtain ⟨-, h2⟩ := h; omega
+
+/-- **ℕ cannot code its endomorphisms up to the (non-transitive) tolerance
+    `tol`.** A genuinely new instance: `tol` is not an equivalence relation, so
+    this is not reachable from the parent setoid theorem. -/
+theorem nat_cannot_code_endos_tol : CodesEndomorphismsRel ℕ tol → False :=
+  no_coding_rel_of_no_prefixpoint (fun n => n + 2) add_two_no_tol_prefixpoint
+
+-- ============================================================
+-- Part VI: Strict Order — Irreflexive + Non-Symmetric
+-- ============================================================
+
+/-- **ℕ cannot code its endomorphisms up to strict order `<`.** The identity has
+    no point with `p < id p`, since `<` is irreflexive. This relation is neither
+    reflexive nor symmetric, illustrating that the *orientation* `r p (f p)` is
+    the only thing that matters — no relation axioms whatsoever. -/
+theorem nat_cannot_code_endos_lt : CodesEndomorphismsRel ℕ (· < ·) → False :=
+  no_coding_rel_of_no_prefixpoint id (fun n => lt_irrefl n)
+
+end CantorDiagonalizationOQ04OQ01OQ03

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-03/annotations.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "ann-cantor-oq040103-context",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 55 },
+    "type": "concept",
+    "title": "Which setoid axiom does Lawvere's diagonal actually use?",
+    "content": "The parent (`cantor-diagonalization-oq-04-oq-01`) generalized Lawvere's fixed-point theorem from strict Type equality to a `Setoid` equivalence relation, calling this the step toward a CCC/topos version where equality becomes coherence. This file asks the sharp follow-up: of the three setoid axioms — reflexivity, symmetry, transitivity — which does the diagonal argument *consume*? The answer is **none**. Stated in the retraction's own orientation `r p (f p)`, Lawvere's theorem holds for an arbitrary binary relation with no axioms whatsoever; symmetry is needed only to flip the conclusion to the conventional `r (f p) p`.",
+    "mathContext": "Lawvere (1969) is the categorical heart of every diagonal argument. Pinning the exact hypotheses shows the theorem is an absolute combinatorial principle about self-applicative codings, independent of the equality discipline. This widens its reach to tolerance relations (approximate equality) and directed orders, and clarifies that a future CartesianClosed proof needs only a coherence relation respected by evaluation, not an equivalence."
+  },
+  {
+    "id": "ann-cantor-oq040103-structure",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
+    "range": { "startLine": 59, "endLine": 71 },
+    "type": "definition",
+    "title": "CodesEndomorphismsRel: coding up to an arbitrary relation",
+    "content": "`CodesEndomorphismsRel Y r` packages `encode : (Y → Y) → Y`, `decode : Y → (Y → Y)`, and the pointwise retract `r (decode (encode g) y) (g y)`. The only change from the parent's setoid structure is that `r` is an arbitrary `Y → Y → Prop` with no bundled axioms — the field type is identical, so the setoid coding is literally the special case `r = s.r`.",
+    "mathContext": "Three layers of weakening from the grandparent: (1) function equality, (2) pointwise equality, (3) pointwise setoid equivalence, and now (4) pointwise arbitrary relation. Each layer admits strictly more codings."
+  },
+  {
+    "id": "ann-cantor-oq040103-main",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
+    "range": { "startLine": 77, "endLine": 99 },
+    "type": "theorem",
+    "title": "lawvere_fixpoint_rel: fixed point with zero relation axioms",
+    "content": "The diagonal `g y = f (decode y y)`, `y₀ = encode g`, `p = decode y₀ y₀` makes the retract field evaluated at `(g, y₀)` definitionally equal to the goal `r p (f p)` — so the proof is `exact ⟨c.decode y₀ y₀, c.retract g y₀⟩`, the parent's proof with the trailing `Setoid.iseqv.symm` removed. `lawvere_fixpoint_rel_symm` then flips to `r (f p) p` using `Symmetric r`, isolating symmetry as the sole cost of the conventional orientation.",
+    "mathContext": "That the retract field *is* the conclusion (up to definitional unfolding of the diagonal lets) explains why Lawvere's theorem is so robust: no equality lemmas mediate between hypothesis and goal."
+  },
+  {
+    "id": "ann-cantor-oq040103-contrapositive",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
+    "range": { "startLine": 101, "endLine": 110 },
+    "type": "theorem",
+    "title": "no_coding_rel_of_no_prefixpoint: the impossibility engine",
+    "content": "Contrapositive: if some `f` has no point `p` with `r p (f p)`, then `Y` cannot code its endomorphisms up to `r`. To show a given `Y` is not Lawvere-coded up to `r`, it suffices to exhibit one fixed-point-free `f` (`∀ y, ¬ r y (f y)`). This drives both concrete examples below.",
+    "mathContext": "Cantor, Russell, Gödel, Tarski, and Turing are all this contrapositive applied to a specific fixed-point-free endomorphism (e.g. negation) in a specific setting."
+  },
+  {
+    "id": "ann-cantor-oq040103-recovery",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
+    "range": { "startLine": 112, "endLine": 123 },
+    "type": "theorem",
+    "title": "lawvere_fixpoint_setoid: recovering the parent",
+    "content": "Instantiating the relational theorem at a setoid relation `s.r` and supplying `s.iseqv.symm` for symmetry reproduces the parent's setoid fixed-point theorem. Reflexivity and transitivity of the setoid are demonstrably never invoked, confirming this file is a strict generalization rather than a parallel statement.",
+    "mathContext": "Every parent corollary (Bool, parity, Cantor) is therefore inherited unchanged."
+  },
+  {
+    "id": "ann-cantor-oq040103-tolerance",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
+    "range": { "startLine": 125, "endLine": 159 },
+    "type": "theorem",
+    "title": "Tolerance relation: a genuinely non-setoid instance",
+    "content": "`tol a b := a ≤ b+1 ∧ b ≤ a+1` ('differ by at most one') is reflexive (`tol_refl`) and symmetric (`tol_symm`) but provably **not transitive** (`tol_not_transitive`: `tol 0 1`, `tol 1 2`, yet `¬ tol 0 2`), so it is not a `Setoid`. Nevertheless `nat_cannot_code_endos_tol` shows ℕ cannot code its endomorphisms up to `tol`, witnessed by the fixed-point-free shift `n ↦ n+2`. This result is unstatable in the parent framework.",
+    "mathContext": "Tolerance relations (Zeeman 1962) model approximate equality and are the natural object when strict equality is too rigid — exactly the regime a CCC/coherence generalization targets."
+  },
+  {
+    "id": "ann-cantor-oq040103-strict",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
+    "range": { "startLine": 161, "endLine": 172 },
+    "type": "theorem",
+    "title": "Strict order: only the orientation matters",
+    "content": "`nat_cannot_code_endos_lt` uses strict `<` (irreflexive, non-symmetric, transitive): the identity has no `p` with `p < id p` since `<` is irreflexive (`lt_irrefl`), so ℕ cannot code its endomorphisms up to `<`. This drives home the central point — the theorem cares only about whether `f` admits a point in the relation's own orientation `r p (f p)`, not about any algebraic property of `r`.",
+    "mathContext": "Generalizes diagonal arguments uniformly across equivalence-based, tolerance-based, and order-based coherence relations."
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-03/meta.json
@@ -1,0 +1,213 @@
+{
+  "id": "cantor-diagonalization-oq-04-oq-01-oq-03",
+  "slug": "cantor-diagonalization-oq-04-oq-01-oq-03",
+  "title": "Lawvere Fixed-Point Theorem: Relational Generalization",
+  "description": "Lawvere's fixed-point theorem holds for an arbitrary binary relation, with no equivalence-relation structure required. Inspecting the parent setoid proof shows the diagonal argument uses only the retraction equation — never reflexivity, symmetry, or transitivity. So if Y codes its endomorphisms up to ANY relation r (decode(encode g) y  r  g y), every f : Y → Y has a point p with r p (f p). Symmetry of r is needed only to flip the conclusion to the setoid orientation r (f p) p; reflexivity and transitivity are never used. This recovers the setoid version as the symmetric special case and additionally applies to non-transitive tolerance relations and non-symmetric strict orders, neither of which is a setoid.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CantorDiagonalizationOQ04OQ01OQ03.lean",
+    "tags": [
+      "set-theory",
+      "logic",
+      "category-theory",
+      "lawvere",
+      "cantor",
+      "diagonal-argument",
+      "fixed-point",
+      "relation",
+      "tolerance-relation",
+      "generalization",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 173,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "badge": "original",
+    "originalContributions": [
+      "CodesEndomorphismsRel: a coding-up-to-r structure with no assumptions on the relation r",
+      "lawvere_fixpoint_rel: Lawvere's fixed point r p (f p) for arbitrary f and arbitrary relation r — zero relation axioms used",
+      "lawvere_fixpoint_rel_symm: symmetric r yields the parent's orientation r (f p) p; symmetry is the only property ever consumed",
+      "no_coding_rel_of_no_prefixpoint: contrapositive blocking codings for any relation r",
+      "lawvere_fixpoint_setoid: recovers the parent setoid theorem as the symmetric special case",
+      "tol + nat_cannot_code_endos_tol: tolerance relation (reflexive + symmetric, NOT transitive) — a genuinely non-setoid instance, with tol_not_transitive witnessing non-transitivity",
+      "nat_cannot_code_endos_lt: strict-order instance (irreflexive, non-symmetric) showing only the conclusion orientation matters"
+    ],
+    "prerequisites": [
+      "Binary relations on a type (no equivalence structure assumed)",
+      "Parent: CantorDiagonalizationOQ04OQ01 (Setoid generalization)",
+      "Symmetric / Transitive (Mathlib.Order.Defs.Unbundled)",
+      "Lawvere's fixed-point theorem (1969)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Symmetric",
+        "description": "Predicate that a relation satisfies r x y → r y x (used to flip the conclusion)",
+        "module": "Mathlib.Order.Defs.Unbundled"
+      },
+      {
+        "theorem": "Transitive",
+        "description": "Predicate that a relation is transitive (used to state tol_not_transitive)",
+        "module": "Mathlib.Order.Defs.Unbundled"
+      },
+      {
+        "theorem": "lt_irrefl",
+        "description": "Strict order is irreflexive: ¬ a < a (witness for the strict-order example)",
+        "module": "Mathlib.Order.Defs.PartialOrder"
+      },
+      {
+        "theorem": "Setoid",
+        "description": "Equivalence relation bundled with its type; its iseqv.symm supplies symmetry for the recovery theorem",
+        "module": "Mathlib.Data.Setoid.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "**Lawvere's fixed-point theorem** (F. William Lawvere, *Diagonal arguments and cartesian closed categories*, La Jolla, 1969) is the categorical heart of every diagonal argument: in a cartesian closed category, a weakly point-surjective $T : A \\to Y^A$ forces every endomorphism $f : Y \\to Y$ to have a fixed point. Cantor (1891), Russell (1901), Gödel (1931), Tarski (1936), and Turing (1936) are all corollaries. The Lean gallery formalizes this in stages: the **Type-level retraction version** (`cantor-diagonalization-oq-04`), the **Setoid generalization** (`cantor-diagonalization-oq-04-oq-01`), which replaces strict equality by an equivalence relation as the announced 'step toward a CCC/topos version where equality becomes coherence.' This file pushes that line of reasoning to its logical endpoint by asking a sharp metamathematical question: of the three setoid axioms (reflexivity, symmetry, transitivity), *which does the diagonal argument actually consume?*",
+    "problemStatement": "Let $Y$ be a type and $r : Y \\to Y \\to \\mathrm{Prop}$ an arbitrary binary relation. Define `CodesEndomorphismsRel Y r` with `encode : (Y \\to Y) \\to Y`, `decode : Y \\to (Y \\to Y)`, and the pointwise retract $\\forall g\\,y,\\ r(\\mathrm{decode}(\\mathrm{encode}\\,g)\\,y)\\,(g\\,y)$. Prove: for every $f : Y \\to Y$ there is $p$ with $r\\,p\\,(f\\,p)$, using no properties of $r$; that symmetric $r$ gives $r\\,(f\\,p)\\,p$; that this recovers the parent setoid theorem; and exhibit non-setoid relations (a non-transitive tolerance, a non-symmetric strict order) where $\\mathbb{N}$ provably fails to code its endomorphisms.",
+    "text": "Identifies the exact hypotheses of Lawvere's diagonal argument: none. The fixed point r p (f p) exists for any relation r; symmetry only reorients it. Recovers the setoid version and adds non-setoid instances (tolerance, strict order).",
+    "proofStrategy": "**The core proof is the parent's, with the final `Setoid.iseqv.symm` deleted.** (1) Define `CodesEndomorphismsRel` with no constraints on `r`. (2) Prove `lawvere_fixpoint_rel` in three lines: the diagonal $g(y) = f(\\mathrm{decode}(y,y))$ at $y_0 = \\mathrm{encode}\\,g$, $p = \\mathrm{decode}(y_0,y_0)$ makes the retract field at $(g, y_0)$ definitionally $r\\,p\\,(f\\,p)$. (3) `lawvere_fixpoint_rel_symm` flips the conclusion using `Symmetric r`. (4) `no_coding_rel_of_no_prefixpoint` is the one-line contrapositive. (5) `lawvere_fixpoint_setoid` recovers the parent by supplying `s.iseqv.symm` for symmetry. (6) Non-setoid witnesses: `tol a b := a ≤ b+1 ∧ b ≤ a+1` (reflexive, symmetric, non-transitive — `tol_not_transitive`), with `n ↦ n+2` fixed-point-free; and strict `<` with the identity fixed-point-free. Both impossibilities follow from the contrapositive. 173 lines, 10 theorems, 2 definitions, 0 axioms, 0 sorries.",
+    "keyInsights": [
+      "**The diagonal argument consumes no relation axioms.** Re-reading the parent's three-line proof, the only fact used is the retraction field itself — `Setoid.iseqv.symm` appears solely to rewrite the conclusion's direction. Stating the theorem with conclusion `r p (f p)` (the retraction's own orientation) removes even that, so the cleanest form of Lawvere's theorem assumes *nothing* about the coherence relation. Reflexivity and transitivity are pure decoration in this setting.",
+      "**Symmetry is exactly the cost of the conventional orientation.** The setoid literature states the conclusion as `f(p) ≈ p`; that orientation — and only that — needs `r` symmetric. Isolating this shows the asymmetry between the two natural statements of the theorem is a one-line `Symmetric`-application, not a structural feature.",
+      "**The setoid theorem is a strict specialization, recovered for free.** `lawvere_fixpoint_setoid` instantiates the relational theorem at `s.r` and feeds `s.iseqv.symm` as the symmetry proof. Every parent corollary (Bool, parity, Cantor) survives unchanged, confirming this is a genuine generalization rather than a parallel result.",
+      "**Tolerance relations are now in scope — and they are not setoids.** `tol` (differ by at most one) is reflexive and symmetric but provably non-transitive (`tol_not_transitive`), so it cannot be a `Setoid`. Yet `nat_cannot_code_endos_tol` shows ℕ fails to code its endomorphisms up to `tol`, via the fixed-point-free shift `n ↦ n+2`. This is a result the parent framework literally cannot state. Tolerance ('approximate equality') relations are exactly the setting category theory reaches for when strict equality is too rigid, so this is on the intended CCC/coherence path.",
+      "**Even non-symmetric relations work — orientation is all that matters.** `nat_cannot_code_endos_lt` uses strict `<` (irreflexive, non-symmetric, transitive): the identity has no `p` with `p < id p`, so ℕ cannot code its endomorphisms up to `<`. The lesson: the *only* thing the theorem cares about is whether `f` admits a point in the relation's own orientation. This reframes Lawvere as a statement about an arbitrary directed relation, generalizing both equivalence-based and order-based diagonal arguments.",
+      "**This clarifies the obstruction to the genuine CCC version.** Lifting Lawvere into Mathlib's `CartesianClosed` (internal-hom `ihom`, evaluation morphisms, global elements) is the remaining open question (sibling oq-04-oq-01-oq-01). This file shows the missing ingredient there is *not* an equivalence structure on points — an arbitrary coherence relation suffices — which narrows what a categorical proof must actually supply."
+    ],
+    "prerequisites": [
+      "Binary relations r : Y → Y → Prop with no assumed axioms",
+      "encode/decode retract pair (parent's coding, relaxed to hold up to r)",
+      "Symmetric, Transitive predicates (Mathlib.Order.Defs.Unbundled)",
+      "Setoid.iseqv.symm for the recovery theorem",
+      "omega for the tolerance arithmetic; lt_irrefl for the strict-order witness"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header: Open Question and Answer",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Documentation posing oq-04-oq-01-oq-03 (which setoid axioms does Lawvere's diagonal use?) and answering: none. Lists the six key results and the three relation classes covered (arbitrary, tolerance, strict order).",
+      "mathContext": "Of reflexivity, symmetry, transitivity, the diagonal argument uses none; symmetry reappears only to reorient the conclusion."
+    },
+    {
+      "id": "codes-endo-rel",
+      "title": "Part I: CodesEndomorphismsRel Structure",
+      "startLine": 59,
+      "endLine": 71,
+      "summary": "The coding-up-to-r structure: encode, decode, and the pointwise retract r (decode (encode g) y) (g y), with no constraint on r.",
+      "mathContext": "Weakens the parent's setoid retract to an arbitrary relation; the setoid version is the special case r = s.r."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Part II: Main Theorem (lawvere_fixpoint_rel)",
+      "startLine": 73,
+      "endLine": 99,
+      "summary": "lawvere_fixpoint_rel: for any relation r and any f, the diagonal yields p with r p (f p) — the retract field evaluated at the diagonal IS the goal. lawvere_fixpoint_rel_symm flips to r (f p) p using Symmetric r.",
+      "mathContext": "The retract at (g, y₀) is r (decode y₀ y₀) (f (decode y₀ y₀)) = r p (f p) by construction; no axioms consumed."
+    },
+    {
+      "id": "contrapositive",
+      "title": "Part III: Contrapositive",
+      "startLine": 101,
+      "endLine": 110,
+      "summary": "no_coding_rel_of_no_prefixpoint: if f has no point p with r p (f p), then Y cannot code its endomorphisms up to r. One-line proof for arbitrary r.",
+      "mathContext": "The impossibility engine: to show Y is not Lawvere-coded up to r, exhibit one f with ∀ y, ¬ r y (f y)."
+    },
+    {
+      "id": "setoid-recovery",
+      "title": "Part IV: Recovering the Setoid Version",
+      "startLine": 112,
+      "endLine": 123,
+      "summary": "lawvere_fixpoint_setoid: instantiate the relational theorem at a setoid relation s.r, supplying s.iseqv.symm for symmetry. Recovers the parent theorem; reflexivity and transitivity are shown to be unused.",
+      "mathContext": "Setoid Lawvere is the symmetric special case of relational Lawvere — a strict specialization, not a parallel statement."
+    },
+    {
+      "id": "tolerance",
+      "title": "Part V: Tolerance Relation (non-transitive)",
+      "startLine": 125,
+      "endLine": 159,
+      "summary": "tol a b := a ≤ b+1 ∧ b ≤ a+1: reflexive (tol_refl), symmetric (tol_symm), not transitive (tol_not_transitive). add_two_no_tol_prefixpoint shows n ↦ n+2 is fixed-point-free, giving nat_cannot_code_endos_tol.",
+      "mathContext": "A tolerance ('approximate equality') relation is not a setoid, yet the relational Lawvere theorem applies — a result outside the parent framework."
+    },
+    {
+      "id": "strict-order",
+      "title": "Part VI: Strict Order (non-symmetric)",
+      "startLine": 161,
+      "endLine": 172,
+      "summary": "nat_cannot_code_endos_lt: ℕ cannot code its endomorphisms up to strict <, since the identity has no p with p < id p (lt_irrefl).",
+      "mathContext": "An irreflexive, non-symmetric, transitive relation still works: only the conclusion orientation r p (f p) matters."
+    }
+  ],
+  "conclusion": {
+    "summary": "Lawvere's fixed-point theorem requires no properties of the coherence relation: for any relation r, coding endomorphisms up to r forces every f : Y → Y to have a point p with r p (f p). Symmetry is consumed only to restate the conclusion as r (f p) p, and reflexivity and transitivity are never used. The setoid theorem (parent) is recovered as the symmetric special case. Two non-setoid relation classes are newly brought into scope: a non-transitive tolerance relation on ℕ (with the fixed-point-free shift n ↦ n+2) and a non-symmetric strict order (with the fixed-point-free identity). 173 lines, 10 theorems, 2 definitions, 0 axioms, 0 sorries.",
+    "implications": "Pinning down the exact hypotheses of a diagonal argument has both foundational and practical value. Foundationally, it shows Lawvere's theorem is an absolute principle about self-applicative codings, indifferent to the equality discipline — equivalence, tolerance, or directed order all behave identically. Practically, it widens the impossibility engine to tolerance relations (approximate equality), the natural setting when strict equality is too rigid, which is exactly the regime a CCC/topos generalization targets. By proving an arbitrary coherence relation suffices, this file narrows what a future categorical proof in Mathlib's CartesianClosed must supply: not an equivalence on global points, merely a relation respected by evaluation.",
+    "openQuestions": [
+      "Does the relational form transfer to the parent's surjection version of Lawvere (sibling cantor-diagonalization-oq-04-oq-03)? The retract orientation should carry over verbatim.",
+      "Characterize, for a fixed relation r, which f : Y → Y are forced to have an r-prefixed point versus which can be fixed-point-free — i.e. the boundary of the contrapositive.",
+      "For the tolerance family tol_k a b := |a-b| ≤ k on ℕ, the shift n ↦ n+(k+1) is fixed-point-free; is there a uniform statement across all k, and a limit as k → ∞?",
+      "Lift this relational core into Mathlib's CartesianClosed (sibling oq-04-oq-01-oq-01): the coherence relation on Hom(1, B) need only be respected by the evaluation morphism, with no equivalence axioms — does that make the categorical proof go through?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: this file generalizes the setoid version to an arbitrary relation, showing the equivalence-relation structure is inessential. The setoid theorem is recovered by lawvere_fixpoint_setoid as the symmetric special case."
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-04",
+      "relationship": "extends",
+      "description": "Grandparent: the Type-level retraction version is the special case where r is equality."
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "specializes-to",
+      "description": "Cantor's diagonal argument is the contrapositive of Lawvere's theorem; here it generalizes to impossibility of coding up to an arbitrary relation, not just equality."
+    }
+  ],
+  "references": [
+    {
+      "title": "Diagonal arguments and cartesian closed categories",
+      "author": "F. William Lawvere",
+      "year": "1969",
+      "venue": "Lecture Notes in Mathematics, Vol. 92, Springer, pp. 134-145",
+      "description": "Original publication of Lawvere's fixed-point theorem; unifies Cantor, Russell, Gödel, Tarski, and Turing under one categorical principle."
+    },
+    {
+      "title": "A universal approach to self-referential paradoxes, incompleteness and fixed points",
+      "author": "Noson S. Yanofsky",
+      "year": "2003",
+      "venue": "Bulletin of Symbolic Logic 9(3), 362-386",
+      "description": "Accessible reformulation of Lawvere's theorem emphasizing the diagonal construction over the categorical machinery; supports the 'absolute combinatorial principle' reading used here."
+    },
+    {
+      "title": "Tolerance relations and quotients",
+      "author": "E. Christopher Zeeman",
+      "year": "1962",
+      "venue": "in: The topology of the brain and visual perception, Prentice-Hall",
+      "description": "Early study of tolerance relations (reflexive, symmetric, non-transitive) as a model of approximate equality; background for the non-setoid example in Part V."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Logic.Function.Basic",
+      "Mathlib.Data.Setoid.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "CantorDiagonalizationOQ04OQ01OQ03",
+    "lineCount": 173,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "path": "Proofs/CantorDiagonalizationOQ04OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "openQuestions": [],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

A new OQ extension off the **verified** parent `cantor-diagonalization-oq-04-oq-01` (Lawvere FPT: Setoid Generalization). The parent generalized Lawvere's fixed-point theorem from strict Type equality to a setoid equivalence relation, framing it as the step toward a CCC/topos version where equality becomes coherence. This PR answers the sharp follow-up:

> Of the three setoid axioms — reflexivity, symmetry, transitivity — which does the diagonal argument actually consume?

**Answer: none.** Re-reading the parent's three-line proof, the only fact used is the retraction field itself; `Setoid.iseqv.symm` appears solely to reorient the conclusion. Stated in the retraction's own orientation `r p (f p)`, Lawvere's theorem holds for an **arbitrary binary relation** with no axioms whatsoever.

## Results (`Proofs/CantorDiagonalizationOQ04OQ01OQ03.lean`)

- `lawvere_fixpoint_rel` — for any relation `r` and any `f : Y → Y`, coding endomorphisms up to `r` yields `p` with `r p (f p)`. **Zero relation axioms used.**
- `lawvere_fixpoint_rel_symm` — symmetric `r` gives the parent's orientation `r (f p) p`; symmetry is the only property ever consumed.
- `no_coding_rel_of_no_prefixpoint` — contrapositive impossibility engine for arbitrary `r`.
- `lawvere_fixpoint_setoid` — recovers the parent setoid theorem as the symmetric special case (reflexivity/transitivity demonstrably unused).
- `tol` + `tol_not_transitive` + `nat_cannot_code_endos_tol` — a **tolerance relation** (reflexive + symmetric, NOT transitive), so not a `Setoid`; ℕ fails to code its endomorphisms up to it (shift `n ↦ n+2` fixed-point-free). Unstatable in the parent framework.
- `nat_cannot_code_endos_lt` — a **strict order** (irreflexive, non-symmetric); identity is fixed-point-free, so only the conclusion orientation matters.

10 theorems, 2 definitions, **0 axioms, 0 sorries**, 173 lines.

## Why this is progress (not a cosmetic variant)

It pins down the exact hypotheses of the diagonal argument and thereby brings two new relation classes into scope — tolerance ("approximate equality") relations and directed orders — neither of which is an equivalence relation. It also narrows what a genuine `CartesianClosed` proof (sibling `oq-04-oq-01-oq-01`, separately claimed) must supply: a coherence relation respected by evaluation, not an equivalence on points.

## Verification status — VERIFIED ✅

Docker daemon is down this session, so verified the single file directly against the pinned Mathlib oleans:

```
$ lake env lean Proofs/CantorDiagonalizationOQ04OQ01OQ03.lean   # exit 0, no output
$ #print axioms ...
  lawvere_fixpoint_rel        does not depend on any axioms
  lawvere_fixpoint_setoid     does not depend on any axioms
  nat_cannot_code_endos_tol   depends on axioms: [propext, Quot.sound]
  nat_cannot_code_endos_lt    does not depend on any axioms
```

Clean compile, 0 sorries. The only axioms anywhere are `propext`/`Quot.sound` (ordinary foundational axioms, on the `omega`-discharged tolerance example) — no `sorryAx`, no `native_decide`/`Lean.ofReduceBool` — so the entry is axiom-free in the project's sense (`axiomCount: 0`, `status: verified`, `badge: original`). Sanity: the core `lawvere_fixpoint_rel` proof is literally the verified parent's proof (`CantorDiagonalizationOQ04OQ01.lean:74-79`) minus the trailing `Setoid.iseqv.symm`.

## Scope / collision check

- Off-claim sibling extension; uses the free slug `oq-04-oq-01-oq-03` (the parent already reserves `oq-02` for a different question and the CCC lift `oq-01` is claimed by a live researcher — neither touched).
- Only adds files: the Lean proof, its `Proofs.lean` import, and `src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-03/{meta,annotations}.json`. No existing entries modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)