### PR TITLE
research(area-of-circle-oq-07): the Gaussian integral ∫ e^{-x²} = √π

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ07.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07.lean
@@ -1,0 +1,41 @@
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Tactic
+
+/-
+# The Gaussian Integral Equals √π
+
+## Open Question (area-of-circle-oq-07)
+"The total integral of the Gaussian bell curve `e^{-x²}` over the whole real
+line equals `√π`."
+
+$$ \int_{-\infty}^{\infty} e^{-x^2}\, dx = \sqrt{\pi}. $$
+
+## Answer: YES — it is the `b = 1` specialization of the general Gaussian integral.
+
+Mathlib's `integral_gaussian (b : ℝ) : ∫ x, exp (-b * x ^ 2) = √(π / b)` already
+evaluates the parametrized Gaussian integral for every real `b`.  Setting `b = 1`
+turns the integrand `exp (-1 * x ^ 2)` into `exp (-x ^ 2)` (via `neg_one_mul`) and
+the value `√(π / 1)` into `√π` (via `div_one`), giving the classical normalization
+constant behind the standard normal distribution.
+
+The classical evaluation squares the integral and passes to polar coordinates,
+where the circle-area Jacobian — the subject of the parent entry `area-of-circle`
+— appears.  The corollary `gaussian_integral_sq` records that squared identity
+`(∫ e^{-x²})² = π`, the algebraic heart of that polar-coordinate argument.
+
+No new axioms: the proof is a routine specialization of an existing Mathlib result.
+-/
+
+open Real MeasureTheory
+
+/-- **The Gaussian integral.** The integral of `e^{-x²}` over all of `ℝ` is `√π`. -/
+theorem gaussian_integral_eq_sqrt_pi :
+    (∫ x : ℝ, Real.exp (-x ^ 2)) = Real.sqrt Real.pi := by
+  have h := integral_gaussian 1
+  simpa only [neg_one_mul, div_one] using h
+
+/-- The squared Gaussian integral equals `π` — the identity obtained by squaring
+`∫ e^{-x²}` and evaluating the resulting planar integral in polar coordinates. -/
+theorem gaussian_integral_sq :
+    (∫ x : ℝ, Real.exp (-x ^ 2)) ^ 2 = Real.pi := by
+  rw [gaussian_integral_eq_sqrt_pi, Real.sq_sqrt Real.pi_nonneg]

--- a/src/data/proofs/area-of-circle-oq-07/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-aoc07-context",
+    "proofId": "area-of-circle-oq-07",
+    "range": { "startLine": 1, "endLine": 27 },
+    "type": "concept",
+    "title": "The Gaussian Integral and Its Place in the Gallery",
+    "content": "This entry answers open question 7 of the `area-of-circle` parent: the total integral of the Gaussian bell curve `e^{-x²}` over all of ℝ is `√π`. Rather than redo the classical squaring-and-polar-coordinates evaluation, it specializes Mathlib's already-proved parametrized Gaussian integral `integral_gaussian (b) : ∫ x, exp (-b·x²) = √(π/b)` at `b = 1`. This is deliberately a *routine specialization* — the analytic content lives entirely inside Mathlib — but it is the iconic case: `√π` is the normalization constant of the standard normal distribution and the simplest definite integral whose value carries a factor of π with no circle in sight.",
+    "mathContext": "The classical evaluation, due to Laplace and Poisson, computes $I = \\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx$ by squaring: $I^2 = \\int\\!\\!\\int_{\\mathbb R^2} e^{-(x^2+y^2)}\\,dx\\,dy$, then switching to polar coordinates $x = r\\cos\\theta,\\ y = r\\sin\\theta$ with Jacobian $r$, giving $I^2 = \\int_0^{2\\pi}\\!\\!\\int_0^\\infty e^{-r^2} r\\,dr\\,d\\theta = \\pi$, hence $I = \\sqrt{\\pi}$. The factor of $\\pi$ enters through exactly the circle-area Jacobian studied in the parent entry.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gaussian integral",
+      "normal distribution normalization",
+      "polar-coordinate evaluation",
+      "circle-area Jacobian r dr dθ"
+    ],
+    "prerequisites": [
+      "Lebesgue integral over ℝ",
+      "Mathlib integral_gaussian",
+      "parent area-of-circle (polar Jacobian)"
+    ]
+  },
+  {
+    "id": "ann-aoc07-main",
+    "proofId": "area-of-circle-oq-07",
+    "range": { "startLine": 31, "endLine": 35 },
+    "type": "technique",
+    "title": "Specializing integral_gaussian at b = 1",
+    "content": "The whole proof is two lines. `have h := integral_gaussian 1` instantiates Mathlib's lemma to `∫ x, exp (-1 * x ^ 2) = √(π / 1)`. The goal differs only cosmetically: its integrand is `exp (-x ^ 2)` and its value is `√π`. `simpa only [neg_one_mul, div_one] using h` closes the gap — `neg_one_mul` rewrites `-1 * x ^ 2` to `-(x ^ 2)` (definitionally `-x ^ 2`, since `^` binds tighter than unary `-`), and `div_one` rewrites `π / 1` to `π`. No measure-theoretic reasoning is reproduced here; it is inherited wholesale from `integral_gaussian`.",
+    "mathContext": "Specialization of a parametrized result is the cheapest possible kind of formal proof, but it is only valid when the syntactic match is exact. The only real obligations are the coefficient `1 *` in the exponent and the `/ 1` in the value — both discharged by `simp` normal-form lemmas.",
+    "significance": "important",
+    "relatedConcepts": ["parametrized lemma specialization", "neg_one_mul", "div_one", "simpa"],
+    "prerequisites": ["integral_gaussian", "simp normal forms"]
+  },
+  {
+    "id": "ann-aoc07-sq",
+    "proofId": "area-of-circle-oq-07",
+    "range": { "startLine": 37, "endLine": 41 },
+    "type": "technique",
+    "title": "The Squared Identity (∫ e^{-x²})² = π",
+    "content": "`gaussian_integral_sq` records the value that the classical polar-coordinate computation actually produces: the *square* of the integral is exactly `π`. It follows immediately from the main theorem by `rw [gaussian_integral_eq_sqrt_pi, Real.sq_sqrt Real.pi_nonneg]`, since `√π ^ 2 = π` whenever `π ≥ 0`. This is the algebraic heart of the squaring argument — the step where, in the from-scratch derivation, the two-dimensional integral over ℝ² in polar coordinates evaluates to `π` via the `r dr dθ` Jacobian of the parent `area-of-circle` entry.",
+    "mathContext": "Squaring is the natural object: $I^2$ is a genuine planar integral that polar coordinates evaluate cleanly, whereas $I$ itself has no elementary antiderivative. Stating the squared identity separately makes the connection to the parent's circle-area Jacobian explicit and isolates the one place a factor of $\\pi$ is created.",
+    "significance": "important",
+    "relatedConcepts": ["Real.sq_sqrt", "squaring the Gaussian integral", "polar-coordinate Jacobian"],
+    "prerequisites": ["gaussian_integral_eq_sqrt_pi", "Real.sq_sqrt", "Real.pi_nonneg"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "area-of-circle-oq-07",
+  "slug": "area-of-circle-oq-07",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory"
+    ],
+    "namespace": "",
+    "lineCount": 41,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07.lean",
+    "sorries": 0
+  },
+  "title": "The Gaussian Integral Equals √π",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07.lean",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "special-functions",
+      "probability",
+      "measure-theory",
+      "normal-distribution",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 41,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "gaussian_integral_eq_sqrt_pi: ∫_ℝ e^{-x²} dx = √π, the classical normalization constant of the standard normal distribution, obtained as the b = 1 specialization of Mathlib's integral_gaussian",
+      "gaussian_integral_sq: (∫_ℝ e^{-x²})² = π — the squared identity that is the algebraic heart of the classical polar-coordinate evaluation, where the circle-area Jacobian of the parent entry appears"
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ (MeasureTheory)",
+      "Mathlib's parametrized Gaussian integral integral_gaussian",
+      "Real.sqrt and Real.pi API",
+      "Parent: area-of-circle (the polar-coordinate Jacobian)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_gaussian",
+        "description": "∫ x : ℝ, exp (-b * x ^ 2) = √(π / b) for every real b — the parametrized Gaussian integral. Specialized here at b = 1.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "0 ≤ a → √a ^ 2 = a — used to square √π back to π in gaussian_integral_sq.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-01",
+      "question": "Formalize the normalized standard-normal density: prove ∫_ℝ (1/√(2π)) · e^{-x²/2} dx = 1, deriving it from integral_gaussian at b = 1/2 together with the √π value, to connect this normalization directly to probability theory.",
+      "significance": "medium"
+    },
+    {
+      "id": "area-of-circle-oq-07-oq-02",
+      "question": "Make the polar-coordinate link explicit: derive gaussian_integral_sq from a Fubini/polar-coordinate change of variables on ∫∫_{ℝ²} e^{-(x²+y²)} rather than from squaring the 1D value, exhibiting the circle-area Jacobian r dr dθ of the parent entry inside the proof.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle",
+      "relationship": "extends",
+      "description": "Parent. The classical evaluation of ∫ e^{-x²} squares the integral and passes to polar coordinates, where the circle-area Jacobian r dr dθ — the subject of the parent entry — appears. gaussian_integral_sq records the squared value π that this Jacobian computation produces."
+    },
+    {
+      "targetId": "gaussian-integral",
+      "relationship": "related",
+      "description": "The general Gaussian integral ∫ e^{-b x²} = √(π/b). This entry is its b = 1 special case, the normalization constant behind the normal distribution."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_gaussian (b : ℝ) : ∫ x, exp (-b * x ^ 2) = √(π / b), the parametrized result specialized here at b = 1."
+    },
+    {
+      "title": "Théorie analytique des probabilités",
+      "author": "Pierre-Simon Laplace",
+      "year": "1812",
+      "venue": "Courcier, Paris",
+      "description": "Classical home of the Gaussian integral and its role as the normalization of the normal distribution."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The total integral of the Gaussian bell curve, ∫_ℝ e^{-x²} dx, equals √π. The proof is a one-step specialization of Mathlib's parametrized Gaussian integral integral_gaussian at b = 1: the integrand exp (-1 · x²) collapses to exp (-x²) via neg_one_mul and the value √(π/1) collapses to √π via div_one. A short corollary, gaussian_integral_sq, squares the result to (∫ e^{-x²})² = π using Real.sq_sqrt. 41 lines, 2 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This is an honest, routine specialization rather than original mathematics — Mathlib already contains the hard analytic work (the polar-coordinate evaluation lives inside integral_gaussian). Its value to the gallery is as the iconic b = 1 case: the normalization constant of the standard normal distribution and the simplest non-trivial definite integral whose value involves π without an explicit circle. The squared form π = (∫ e^{-x²})² ties the entry back to the parent area-of-circle proof, where the same factor of π enters through the circle-area Jacobian of the polar-coordinate substitution.",
+    "openQuestions": [
+      "Normalize the standard-normal density: ∫_ℝ (1/√(2π)) e^{-x²/2} dx = 1 from integral_gaussian at b = 1/2.",
+      "Recover gaussian_integral_sq via an explicit Fubini/polar change of variables on ∫∫_{ℝ²} e^{-(x²+y²)}, surfacing the r dr dθ Jacobian of the parent."
+    ]
+  }
+}


### PR DESCRIPTION
## Open Question (area-of-circle-oq-07)

The total integral of the Gaussian bell curve over the whole real line:

$$\int_{-\infty}^{\infty} e^{-x^2}\,dx = \sqrt{\pi}.$$

## What this adds

`proofs/Proofs/AreaOfCircleOQ07.lean` (41 lines, 2 theorems, **0 axioms, 0 sorries**):

- `gaussian_integral_eq_sqrt_pi : (∫ x : ℝ, Real.exp (-x ^ 2)) = Real.sqrt Real.pi`
- `gaussian_integral_sq : (∫ x : ℝ, Real.exp (-x ^ 2)) ^ 2 = Real.pi`

## Approach (honest framing)

This is a **routine specialization**, not original mathematics. Mathlib already
contains the hard analytic work in `integral_gaussian (b) : ∫ x, exp (-b * x^2) = √(π/b)`
(the polar-coordinate evaluation). Setting `b = 1` and discharging two syntactic
obligations — `neg_one_mul` (`-1*x²` → `-x²`) and `div_one` (`√(π/1)` → `√π`) —
gives the iconic `√π`, the normalization constant of the standard normal distribution.
The corollary squares it to `π`, the algebraic heart of the classical
squaring-and-polar-coordinates argument, tying back to the parent `area-of-circle`
entry where the same `π` enters via the circle-area Jacobian `r dr dθ`.

Badge is `mathlib` to reflect this.

## Verification

Type-checked against pinned Mathlib via `lake env lean Proofs/AreaOfCircleOQ07.lean` (RC=0).
`#print axioms` for both theorems: `[propext, Classical.choice, Quot.sound]` — fully verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)