### PR TITLE
research(pythagorean-triples-oq-04): Fermat's two-square theorem for primes

### DIFF
--- a/proofs/Proofs/PythagoreanTriplesOQ04.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ04.lean
@@ -1,0 +1,135 @@
+import Mathlib.NumberTheory.SumTwoSquares
+import Mathlib.Tactic
+
+/-
+# Fermat's Two-Square Theorem for Primes (pythagorean-triples-oq-04)
+
+Pythagorean triples a² + b² = c² are the integer points on the unit circle scaled
+up; a closely related and more delicate question is which integers — and in
+particular which *primes* — are themselves sums of two squares a² + b².
+
+**Fermat's theorem on sums of two squares** (his "Christmas theorem", 1640)
+answers this for primes: a prime p is a sum of two squares if and only if
+p ≢ 3 (mod 4), i.e. p = 2 or p ≡ 1 (mod 4).
+
+This file packages the prime case as a clean biconditional:
+
+  * the **hard forward direction** (every prime p with p % 4 ≠ 3 is a sum of two
+    squares) is Mathlib's `Nat.Prime.sq_add_sq`, which goes through the
+    arithmetic of the Gaussian integers ℤ[i];
+  * the **easy converse** (no number ≡ 3 mod 4 is a sum of two squares) is proved
+    here from scratch: squares are 0 or 1 mod 4, so a sum of two squares is
+    0, 1, or 2 mod 4 — never 3.
+
+We also record the special cases p = 2 and p ≡ 1 (mod 4), and the
+Brahmagupta–Fibonacci identity exhibiting the sums of two squares as closed under
+multiplication.
+
+Status: 0 axioms, 0 sorries
+-/
+
+namespace PythagoreanTriplesOQ04
+
+-- ============================================================================
+-- Part I: The elementary mod-4 obstruction (the easy converse)
+-- ============================================================================
+
+/-- A perfect square is `0` or `1` modulo `4`. -/
+theorem sq_mod_four (n : ℕ) : n ^ 2 % 4 = 0 ∨ n ^ 2 % 4 = 1 := by
+  have e : n ^ 2 % 4 = (n % 4) ^ 2 % 4 := by rw [Nat.pow_mod]
+  have h : n % 4 < 4 := Nat.mod_lt _ (by norm_num)
+  interval_cases (n % 4) <;> simp_all
+
+/-- **The mod-4 obstruction.** A sum of two squares is never congruent to `3`
+modulo `4`, because each square contributes `0` or `1`. This is the elementary
+half of Fermat's two-square theorem. -/
+theorem sum_two_squares_mod_four_ne_three (a b : ℕ) : (a ^ 2 + b ^ 2) % 4 ≠ 3 := by
+  rcases sq_mod_four a with ha | ha <;> rcases sq_mod_four b with hb | hb <;> omega
+
+/-- Contrapositive packaging: if `n ≡ 3 (mod 4)` then `n` is not a sum of two
+squares. -/
+theorem not_sum_two_squares_of_mod_four_eq_three {n : ℕ} (h : n % 4 = 3) :
+    ¬ ∃ a b : ℕ, a ^ 2 + b ^ 2 = n := by
+  rintro ⟨a, b, rfl⟩
+  exact sum_two_squares_mod_four_ne_three a b h
+
+-- ============================================================================
+-- Part II: Fermat's theorem for primes (the biconditional)
+-- ============================================================================
+
+/-- **Fermat's two-square theorem for primes.** A prime `p` is a sum of two
+squares **iff** `p ≢ 3 (mod 4)`. The forward direction is the deep statement
+(`Nat.Prime.sq_add_sq`, via the Gaussian integers); the converse is the
+elementary mod-4 obstruction above. -/
+theorem prime_sq_add_sq_iff {p : ℕ} [Fact p.Prime] :
+    (∃ a b : ℕ, a ^ 2 + b ^ 2 = p) ↔ p % 4 ≠ 3 := by
+  constructor
+  · rintro ⟨a, b, rfl⟩
+    exact sum_two_squares_mod_four_ne_three a b
+  · intro h
+    exact Nat.Prime.sq_add_sq h
+
+/-- The hard direction on its own: every prime `p` with `p % 4 ≠ 3` is a sum of
+two squares. -/
+theorem prime_sq_add_sq {p : ℕ} [Fact p.Prime] (hp : p % 4 ≠ 3) :
+    ∃ a b : ℕ, a ^ 2 + b ^ 2 = p :=
+  Nat.Prime.sq_add_sq hp
+
+-- ============================================================================
+-- Part III: Special cases
+-- ============================================================================
+
+/-- The prime `2 = 1² + 1²`. -/
+theorem two_eq_sq_add_sq : ∃ a b : ℕ, a ^ 2 + b ^ 2 = 2 :=
+  ⟨1, 1, by norm_num⟩
+
+/-- Every prime `p ≡ 1 (mod 4)` is a sum of two squares (the odd-prime case of
+Fermat's theorem). -/
+theorem prime_one_mod_four_sq_add_sq {p : ℕ} [Fact p.Prime] (hp : p % 4 = 1) :
+    ∃ a b : ℕ, a ^ 2 + b ^ 2 = p :=
+  Nat.Prime.sq_add_sq (by omega)
+
+-- ============================================================================
+-- Part IV: Multiplicative structure (Brahmagupta–Fibonacci identity)
+-- ============================================================================
+
+/-- **Brahmagupta–Fibonacci identity.** The sums of two squares are closed under
+multiplication: if `m` and `n` are each a sum of two squares, so is `m * n`.
+This is the multiplicative backbone that, together with Fermat's prime case,
+characterizes *all* sums of two squares via their prime factorizations. -/
+theorem mul_sum_two_squares {m n : ℕ}
+    (hm : ∃ x y : ℕ, x ^ 2 + y ^ 2 = m) (hn : ∃ u v : ℕ, u ^ 2 + v ^ 2 = n) :
+    ∃ r s : ℕ, r ^ 2 + s ^ 2 = m * n := by
+  obtain ⟨x, y, hx⟩ := hm
+  obtain ⟨u, v, hu⟩ := hn
+  obtain ⟨r, s, h⟩ := Nat.sq_add_sq_mul hx.symm hu.symm
+  exact ⟨r, s, h.symm⟩
+
+-- ============================================================================
+-- Part V: Summary
+-- ============================================================================
+
+/-
+## Summary
+
+| Result | Statement | Backing |
+|--------|-----------|---------|
+| `sq_mod_four` | n² ≡ 0 or 1 (mod 4) | elementary (this file) |
+| `sum_two_squares_mod_four_ne_three` | a² + b² ≢ 3 (mod 4) | elementary (this file) |
+| `prime_sq_add_sq_iff` | prime p is a²+b² ⟺ p ≢ 3 (mod 4) | Fermat + mod-4 |
+| `prime_sq_add_sq` | p ≢ 3 (mod 4) ⟹ p = a²+b² | `Nat.Prime.sq_add_sq` |
+| `mul_sum_two_squares` | sums of two squares closed under × | `Nat.sq_add_sq_mul` |
+
+Fermat's theorem is the prime case of the full characterization: a positive
+integer is a sum of two squares iff every prime ≡ 3 (mod 4) occurs to an even
+power in its factorization (`Nat.eq_sq_add_sq_iff`). The biconditional packaged
+here isolates the prime case, pairing Mathlib's Gaussian-integer forward
+direction with the elementary mod-4 converse that this file supplies.
+-/
+
+end PythagoreanTriplesOQ04
+
+#check @PythagoreanTriplesOQ04.prime_sq_add_sq_iff
+#check @PythagoreanTriplesOQ04.sum_two_squares_mod_four_ne_three
+#check @PythagoreanTriplesOQ04.mul_sum_two_squares
+#check @PythagoreanTriplesOQ04.prime_one_mod_four_sq_add_sq

--- a/src/data/proofs/pythagorean-triples-oq-04/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-04/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-pt04-obstruction",
+    "proofId": "pythagorean-triples-oq-04",
+    "range": { "startLine": 33, "endLine": 60 },
+    "type": "technique",
+    "title": "The Elementary Mod-4 Obstruction",
+    "content": "sq_mod_four shows a perfect square is 0 or 1 modulo 4: rewriting n² % 4 as (n % 4)² % 4 via Nat.pow_mod reduces the claim to the four residues, dispatched by interval_cases. From this, sum_two_squares_mod_four_ne_three follows by casing on the two possible square residues and closing with omega — a sum of two squares lands in {0,1,2} mod 4, never 3. This is the 'only if' half of Fermat's theorem and is entirely elementary, requiring no Gaussian integers."
+  },
+  {
+    "id": "ann-pt04-biconditional",
+    "proofId": "pythagorean-triples-oq-04",
+    "range": { "startLine": 61, "endLine": 86 },
+    "type": "concept",
+    "title": "Fermat's Theorem as a Biconditional",
+    "content": "prime_sq_add_sq_iff states: a prime p is a sum of two squares ⟺ p ≢ 3 (mod 4). The two halves have wildly different depth. The converse (right-to-left) is Mathlib's Nat.Prime.sq_add_sq, which routes through unique factorization in the Gaussian integers ℤ[i] and the fact that −1 is a quadratic residue mod p exactly when p ≢ 3 (mod 4). The forward direction (left-to-right) is just the mod-4 obstruction. Splitting the theorem this way isolates precisely where the mathematical content lives."
+  },
+  {
+    "id": "ann-pt04-special",
+    "proofId": "pythagorean-triples-oq-04",
+    "range": { "startLine": 87, "endLine": 102 },
+    "type": "concept",
+    "title": "Special Cases: 2 and Primes ≡ 1 (mod 4)",
+    "content": "two_eq_sq_add_sq records 2 = 1² + 1² (the ramified prime). prime_one_mod_four_sq_add_sq specializes the hard direction to odd primes p ≡ 1 (mod 4), the classical statement of Fermat's Christmas theorem, discharging the p % 4 ≠ 3 hypothesis with omega from p % 4 = 1."
+  },
+  {
+    "id": "ann-pt04-mult",
+    "proofId": "pythagorean-triples-oq-04",
+    "range": { "startLine": 103, "endLine": 120 },
+    "type": "technique",
+    "title": "Brahmagupta–Fibonacci Multiplicativity",
+    "content": "mul_sum_two_squares packages Nat.sq_add_sq_mul: the product of two sums of two squares is again a sum of two squares, via (x²+y²)(u²+v²) = (xu−yv)² + (xv+yu)². This multiplicativity, discovered by Brahmagupta and rediscovered by Fibonacci, reflects the norm map on ℤ[i] being multiplicative. Together with the prime case it characterizes all sums of two squares through prime factorization."
+  },
+  {
+    "id": "ann-pt04-summary",
+    "proofId": "pythagorean-triples-oq-04",
+    "range": { "startLine": 121, "endLine": 135 },
+    "type": "concept",
+    "title": "Summary and the Full Characterization",
+    "content": "The closing table situates the prime biconditional within the complete characterization of sums of two squares (Mathlib's Nat.eq_sq_add_sq_iff): a positive integer is a sum of two squares iff every prime ≡ 3 (mod 4) in its factorization occurs to an even power. The prime case proved here plus Brahmagupta–Fibonacci multiplicativity are exactly the ingredients that assemble into that global statement."
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-04/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-04/meta.json
@@ -1,0 +1,117 @@
+{
+  "id": "pythagorean-triples-oq-04",
+  "title": "Pythagorean Triples OQ-04: Fermat's Two-Square Theorem for Primes",
+  "slug": "pythagorean-triples-oq-04",
+  "description": "Packages Fermat's theorem on sums of two squares for primes as a clean biconditional: a prime p is a sum of two squares a² + b² iff p ≢ 3 (mod 4). The hard forward direction is Mathlib's Nat.Prime.sq_add_sq (via the Gaussian integers); the elementary mod-4 converse — that a sum of two squares is never 3 mod 4 — is proved from scratch. Includes the p=2 and p≡1 (mod 4) cases and the Brahmagupta–Fibonacci multiplicativity identity. 8 theorems, 0 definitions, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ04.lean",
+    "tags": [
+      "number-theory",
+      "pythagorean-triples",
+      "sum-of-two-squares",
+      "fermat",
+      "gaussian-integers",
+      "primes",
+      "modular-arithmetic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "assumptions": "None. The forward (hard) direction uses Mathlib's Nat.Prime.sq_add_sq; the converse and special cases are proved from scratch. Depends only on propext, Classical.choice, and Quot.sound.",
+    "lineCount": 135,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "originalContributions": [
+      "sq_mod_four: a perfect square is 0 or 1 modulo 4 (proved by interval_cases on n mod 4)",
+      "sum_two_squares_mod_four_ne_three: a sum of two squares is never 3 mod 4 — the elementary converse of Fermat's theorem",
+      "prime_sq_add_sq_iff: the biconditional 'prime p is a sum of two squares ⟺ p ≢ 3 (mod 4)', pairing Mathlib's hard direction with the self-contained converse",
+      "mul_sum_two_squares: the Brahmagupta–Fibonacci identity packaged as 'sums of two squares are closed under multiplication'"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Albert Girard stated in 1625, and Pierre de Fermat claimed in a 1640 letter to Mersenne (his 'Christmas theorem'), that an odd prime is a sum of two squares exactly when it is congruent to 1 modulo 4. Fermat asserted a proof by infinite descent but, as usual, did not record it; the first published proof is due to Euler (1749), who labored on it for seven years. Lagrange, Gauss, and Dedekind later recast the result through the arithmetic of the Gaussian integers ℤ[i], where it becomes the statement that a rational prime p ≡ 1 (mod 4) splits, p = (a+bi)(a−bi). The two-square theorem is the prototype of class-field theory's description of which primes are represented by a quadratic form, and a cousin of Pythagorean triples a² + b² = c², which are the sums of two squares that happen to be perfect squares.",
+    "problemStatement": "Show that a prime p is a sum of two squares a² + b² if and only if p ≢ 3 (mod 4), packaging the deep Gaussian-integer direction together with the elementary mod-4 obstruction, and record the multiplicative structure of sums of two squares.",
+    "text": "A prime p is a sum of two squares iff p = 2 or p ≡ 1 (mod 4). One direction is elementary: any square is 0 or 1 mod 4, so a sum of two squares lies in {0,1,2} mod 4 and can never be 3 — hence no number ≡ 3 (mod 4), prime or not, is a sum of two squares. The converse is the hard theorem of Fermat: every prime p with p ≢ 3 (mod 4) actually is a sum of two squares, proved via unique factorization in ℤ[i] (the relevant prime splits because −1 is a quadratic residue mod p when p ≡ 1 mod 4). The Brahmagupta–Fibonacci identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² shows the sums of two squares form a multiplicative monoid, which combined with the prime case yields the full characterization of representable integers.",
+    "proofStrategy": "Prove sq_mod_four by reducing n² mod 4 to (n mod 4)² mod 4 via Nat.pow_mod and discharging the four residues with interval_cases. Deduce sum_two_squares_mod_four_ne_three by casing on the two square residues and closing with omega. Assemble prime_sq_add_sq_iff: the converse is this mod-4 obstruction, the forward direction is Mathlib's Nat.Prime.sq_add_sq. Read off the p=2 and p≡1 (mod 4) cases, and wrap Nat.sq_add_sq_mul for the multiplicativity statement.",
+    "keyInsights": [
+      "The 'only if' half of Fermat's theorem is completely elementary — a one-line mod-4 argument — while the 'if' half requires the full arithmetic of the Gaussian integers; isolating them clarifies exactly where the depth lies",
+      "Squares occupy only half the residues mod 4 (just 0 and 1), so a sum of two of them misses 3 entirely — this single congruence is the obstruction that makes the theorem's necessity trivial",
+      "Sums of two squares are closed under multiplication via the Brahmagupta–Fibonacci identity, so the prime case propagates to all integers through their factorizations",
+      "The result is the quadratic-form shadow of splitting in ℤ[i]: p ≡ 1 (mod 4) splits, p ≡ 3 (mod 4) stays inert, and p = 2 ramifies — the three behaviours match 1²+1²=2, representability, and non-representability"
+    ],
+    "prerequisites": [
+      "Modular arithmetic: residues of squares mod 4",
+      "Fermat's theorem on sums of two squares (Nat.Prime.sq_add_sq)",
+      "Gaussian integers ℤ[i] and the splitting of primes (background)",
+      "The Brahmagupta–Fibonacci two-square identity"
+    ]
+  },
+  "conclusion": {
+    "summary": "Fully machine-verified packaging of Fermat's two-square theorem for primes as the biconditional 'prime p is a sum of two squares ⟺ p ≢ 3 (mod 4)'. The elementary converse (a sum of two squares is never 3 mod 4) and the special cases p=2, p≡1 (mod 4) are proved from scratch; the hard direction reuses Mathlib's Gaussian-integer development. The Brahmagupta–Fibonacci identity records closure under multiplication. Zero axioms, zero sorries.",
+    "implications": "Fermat's two-square theorem is the entry point to the theory of representation by binary quadratic forms and to the arithmetic of imaginary quadratic fields. The mod-4 obstruction isolated here is the simplest example of a local obstruction (a congruence condition) deciding a global representability question — the prototype for the Hasse principle. Combined with the multiplicativity identity and the prime characterization, it gives the full description of which positive integers are sums of two squares (those whose prime factors ≡ 3 mod 4 all occur to even powers, Mathlib's Nat.eq_sq_add_sq_iff), with applications to lattice point counting (the Gauss circle problem) and the average number of representations.",
+    "openQuestions": [
+      "Derive the full characterization of sums of two squares directly from the prime case and multiplicativity, matching Nat.eq_sq_add_sq_iff",
+      "Formalize the three-prime trichotomy in ℤ[i]: p ≡ 1 (mod 4) splits, p ≡ 3 (mod 4) is inert, p = 2 ramifies",
+      "Count representations: relate r₂(n) (the number of ways n is a sum of two squares) to the divisors of n via Jacobi's two-square formula",
+      "Extend to sums of three and four squares (Legendre's and Lagrange's theorems) and contrast the obstruction patterns"
+    ]
+  },
+  "leanFile": {
+    "namespace": "PythagoreanTriplesOQ04",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/PythagoreanTriplesOQ04.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "extends",
+      "description": "The parent entry studies Pythagorean triples a² + b² = c² — the sums of two squares that are themselves perfect squares. This entry asks the companion question of which primes are sums of two squares, answered by Fermat's theorem."
+    }
+  ],
+  "sections": [
+    {
+      "id": "obstruction",
+      "title": "Part I: The elementary mod-4 obstruction",
+      "startLine": 33,
+      "endLine": 60,
+      "summary": "Proves sq_mod_four (a square is 0 or 1 mod 4, via Nat.pow_mod + interval_cases) and deduces sum_two_squares_mod_four_ne_three: a sum of two squares is never 3 mod 4. Packages the contrapositive: no number ≡ 3 (mod 4) is a sum of two squares. This is the easy half of Fermat's theorem, proved from scratch."
+    },
+    {
+      "id": "biconditional",
+      "title": "Part II: Fermat's theorem for primes",
+      "startLine": 61,
+      "endLine": 86,
+      "summary": "Assembles prime_sq_add_sq_iff: a prime p is a sum of two squares iff p ≢ 3 (mod 4). The forward direction is the mod-4 obstruction; the converse is Mathlib's Nat.Prime.sq_add_sq (the deep Gaussian-integer result). Records the standalone hard direction prime_sq_add_sq."
+    },
+    {
+      "id": "special-cases",
+      "title": "Part III: Special cases",
+      "startLine": 87,
+      "endLine": 102,
+      "summary": "The prime 2 = 1² + 1² and the odd-prime case: every prime p ≡ 1 (mod 4) is a sum of two squares."
+    },
+    {
+      "id": "multiplicativity",
+      "title": "Part IV: Multiplicative structure",
+      "startLine": 103,
+      "endLine": 120,
+      "summary": "mul_sum_two_squares wraps the Brahmagupta–Fibonacci identity (Nat.sq_add_sq_mul): the sums of two squares are closed under multiplication, the backbone that propagates the prime case to all integers."
+    },
+    {
+      "id": "summary",
+      "title": "Part V: Summary",
+      "startLine": 121,
+      "endLine": 135,
+      "summary": "Tabulates the results and situates the prime biconditional within the full characterization of sums of two squares (Nat.eq_sq_add_sq_iff)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **Fermat's theorem on sums of two squares** for primes as a clean biconditional:

> A prime `p` is a sum of two squares `a² + b²` **iff** `p ≢ 3 (mod 4)`.

`proofs/Proofs/PythagoreanTriplesOQ04.lean` (namespace `PythagoreanTriplesOQ04`), **8 theorems, 0 definitions, 0 sorries, 0 axioms**.

### The split: deep vs. elementary
- **Hard direction** (`p ≢ 3 mod 4 ⟹ p = a²+b²`): Mathlib's `Nat.Prime.sq_add_sq`, via unique factorization in the Gaussian integers ℤ[i].
- **Easy converse** (`p = a²+b² ⟹ p ≢ 3 mod 4`): proved here from scratch — `sq_mod_four` (a square is 0 or 1 mod 4, by `Nat.pow_mod` + `interval_cases`), hence `sum_two_squares_mod_four_ne_three` (a sum of two squares is never 3 mod 4, closed by `omega`).

Isolating the halves shows exactly where the depth lives: the necessity is a one-line congruence; the sufficiency needs ℤ[i].

### Also included
- `prime_sq_add_sq_iff` — the packaged biconditional.
- `two_eq_sq_add_sq` (2 = 1²+1²) and `prime_one_mod_four_sq_add_sq` (the classical p≡1 mod 4 case).
- `mul_sum_two_squares` — Brahmagupta–Fibonacci identity: sums of two squares are closed under multiplication (`Nat.sq_add_sq_mul`).

### Verification
- Single-file `lake env lean proofs/Proofs/PythagoreanTriplesOQ04.lean` against pinned **Mathlib v4.26.0** oleans: **exit 0**, all `#check`s resolve.
- `#print axioms prime_sq_add_sq_iff` and `sum_two_squares_mod_four_ne_three` → `[propext, Classical.choice, Quot.sound]` only (axiom-free).
- Full `docker-build` not run (host Docker unavailable this session); type-checked at single-file level. Deployer gates on the build.

Gallery entry at `src/data/proofs/pythagorean-triples-oq-04/` (meta.json + annotations.json), badge `mathlib`, status `verified`, extends parent `pythagorean-triples`.

Closes research problem `pythagorean-triples-oq-04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)