### PR TITLE
research(geometric-series-oq-02-oq-03-oq-01): Neumann series for the inverse of 1 − t

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ02OQ03OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ02OQ03OQ01.lean
@@ -1,0 +1,129 @@
+import Mathlib.Analysis.Normed.Ring.Units
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+
+/-
+# The Neumann Series for the Inverse of 1 − t (geometric-series-oq-02-oq-03-oq-01)
+
+The geometric series ∑ rⁿ = 1/(1 − r) for |r| < 1 has a sweeping operator-theoretic
+generalization.  In any Banach algebra (a complete normed ring), if ‖t‖ < 1 then
+1 − t is invertible and its inverse is given by the convergent series
+
+    (1 − t)⁻¹ = ∑' n, tⁿ      (the **Neumann series**).
+
+This is the cornerstone of perturbation theory: a small perturbation of the
+identity stays invertible, with an inverse computable to any order by truncating
+the series.  It underlies the openness of the unit group, the holomorphy of the
+resolvent, and the convergence of iterative solvers (Jacobi / Gauss–Seidel).
+
+This file packages the Neumann series over a normed ring with summable geometric
+series (`HasSummableGeomSeries`, which holds for every complete normed ring /
+Banach algebra):
+
+  * `neumann_series` — `Ring.inverse (1 - t) = ∑' n, tⁿ`;
+  * `hasSum_neumann_series` — the `HasSum` form;
+  * `isUnit_one_sub` — `1 − t` is a unit;
+  * `neumann_mul_left` / `neumann_mul_right` — the series is a genuine two-sided
+    inverse of `1 − t`;
+  * `neumann_partial_remainder` — the finite truncation with explicit remainder.
+
+Each result is a thin wrapper around Mathlib's `geom_series_eq_inverse`,
+`hasSum_geom_series_inverse`, and `NormedRing.inverse_one_sub_nth_order'`; the
+contribution is the packaged, named Neumann-series API.
+
+Status: 0 axioms, 0 sorries
+-/
+
+namespace GeometricSeriesOQ02OQ03OQ01
+
+open scoped Topology
+open Finset
+
+variable {R : Type*} [NormedRing R] [HasSummableGeomSeries R]
+
+-- ============================================================================
+-- Part I: The Neumann series identity
+-- ============================================================================
+
+/-- **Neumann series.** In a normed ring with summable geometric series (e.g. any
+Banach algebra), if `‖t‖ < 1` then the inverse of `1 − t` is the convergent
+series `∑' n, tⁿ`. -/
+theorem neumann_series (t : R) (h : ‖t‖ < 1) :
+    Ring.inverse (1 - t) = ∑' n : ℕ, t ^ n :=
+  (geom_series_eq_inverse t h).symm
+
+/-- The `HasSum` form of the Neumann series: the partial sums `∑_{i<N} tⁱ`
+converge to `(1 − t)⁻¹`. -/
+theorem hasSum_neumann_series (t : R) (h : ‖t‖ < 1) :
+    HasSum (fun n : ℕ => t ^ n) (Ring.inverse (1 - t)) :=
+  hasSum_geom_series_inverse t h
+
+/-- The geometric series `∑' n, tⁿ` is summable when `‖t‖ < 1`. -/
+theorem summable_neumann_series (t : R) (h : ‖t‖ < 1) :
+    Summable (fun n : ℕ => t ^ n) :=
+  summable_geometric_of_norm_lt_one h
+
+-- ============================================================================
+-- Part II: Invertibility of 1 − t
+-- ============================================================================
+
+/-- A small perturbation of the identity stays invertible: `‖t‖ < 1 ⟹ 1 − t` is a
+unit. This is the qualitative heart of the Neumann series. -/
+theorem isUnit_one_sub (t : R) (h : ‖t‖ < 1) : IsUnit (1 - t) :=
+  isUnit_one_sub_of_norm_lt_one h
+
+/-- The Neumann series is a genuine **left** inverse: `(∑' n, tⁿ) · (1 − t) = 1`. -/
+theorem neumann_mul_left (t : R) (h : ‖t‖ < 1) :
+    (∑' n : ℕ, t ^ n) * (1 - t) = 1 := by
+  rw [← neumann_series t h]
+  exact Ring.inverse_mul_cancel _ (isUnit_one_sub t h)
+
+/-- The Neumann series is a genuine **right** inverse: `(1 − t) · (∑' n, tⁿ) = 1`. -/
+theorem neumann_mul_right (t : R) (h : ‖t‖ < 1) :
+    (1 - t) * (∑' n : ℕ, t ^ n) = 1 := by
+  rw [← neumann_series t h]
+  exact Ring.mul_inverse_cancel _ (isUnit_one_sub t h)
+
+-- ============================================================================
+-- Part III: Finite truncation with remainder
+-- ============================================================================
+
+/-- **Partial-sum remainder.** Truncating the Neumann series after `N` terms
+leaves the explicit remainder `tᴺ · (1 − t)⁻¹`:
+
+    (1 − t)⁻¹ = (∑_{i<N} tⁱ) + tᴺ · (1 − t)⁻¹.
+
+Since `‖tᴺ‖ → 0`, the truncation `∑_{i<N} tⁱ` approximates the inverse to any
+desired accuracy — the basis of iterative inversion. -/
+theorem neumann_partial_remainder (N : ℕ) (t : R) (h : ‖t‖ < 1) :
+    Ring.inverse (1 - t) = (∑ i ∈ range N, t ^ i) + t ^ N * Ring.inverse (1 - t) :=
+  NormedRing.inverse_one_sub_nth_order' N h
+
+-- ============================================================================
+-- Part IV: Summary
+-- ============================================================================
+
+/-
+## Summary
+
+| Result | Statement | Backing |
+|--------|-----------|---------|
+| `neumann_series` | (1 − t)⁻¹ = ∑' n, tⁿ | `geom_series_eq_inverse` |
+| `hasSum_neumann_series` | partial sums → (1 − t)⁻¹ | `hasSum_geom_series_inverse` |
+| `isUnit_one_sub` | 1 − t is a unit | `isUnit_one_sub_of_norm_lt_one` |
+| `neumann_mul_left/right` | two-sided inverse | `Ring.inverse_mul_cancel` |
+| `neumann_partial_remainder` | truncation + tᴺ·(1−t)⁻¹ | `inverse_one_sub_nth_order'` |
+
+The scalar geometric series ∑ rⁿ = 1/(1 − r) is the case `R = ℝ` (or ℂ).  Over a
+Banach algebra the same series inverts `1 − t` for any `t` in the open unit ball,
+making the unit group open and the map `t ↦ (1 − t)⁻¹` analytic.  Specializing to
+bounded operators on a Banach space recovers the operator Neumann series used in
+the theory of integral equations and the resolvent `(λ − T)⁻¹` of spectral theory.
+-/
+
+end GeometricSeriesOQ02OQ03OQ01
+
+#check @GeometricSeriesOQ02OQ03OQ01.neumann_series
+#check @GeometricSeriesOQ02OQ03OQ01.hasSum_neumann_series
+#check @GeometricSeriesOQ02OQ03OQ01.neumann_mul_left
+#check @GeometricSeriesOQ02OQ03OQ01.neumann_partial_remainder

--- a/src/data/proofs/geometric-series-oq-02-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-03-oq-01/annotations.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "ann-gs0201-identity",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01",
+    "range": { "startLine": 39, "endLine": 62 },
+    "type": "concept",
+    "title": "The Neumann Series Identity",
+    "content": "neumann_series is the operator-theoretic geometric series: in a normed ring with summable geometric series (any Banach algebra), ‖t‖ < 1 gives (1 − t)⁻¹ = ∑' n, tⁿ. It is Mathlib's geom_series_eq_inverse read in the natural direction. hasSum_neumann_series records the same fact as a HasSum (the partial sums converge to the inverse), and summable_neumann_series notes the series converges because ‖tⁿ‖ ≤ ‖t‖ⁿ is geometrically dominated."
+  },
+  {
+    "id": "ann-gs0201-invertibility",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01",
+    "range": { "startLine": 63, "endLine": 86 },
+    "type": "technique",
+    "title": "Invertibility and the Two-Sided Inverse",
+    "content": "isUnit_one_sub captures the qualitative heart: a perturbation of the identity by anything of norm < 1 stays invertible — the reason the unit group of a Banach algebra is open. neumann_mul_left and neumann_mul_right then verify the series really is a two-sided inverse of 1 − t: each rewrites ∑' n, tⁿ back to Ring.inverse (1 − t) and applies Ring.inverse_mul_cancel / mul_inverse_cancel with the unit witness from isUnit_one_sub."
+  },
+  {
+    "id": "ann-gs0201-truncation",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01",
+    "range": { "startLine": 87, "endLine": 104 },
+    "type": "technique",
+    "title": "Finite Truncation with Explicit Remainder",
+    "content": "neumann_partial_remainder (Mathlib's inverse_one_sub_nth_order') gives (1 − t)⁻¹ = (∑_{i<N} tⁱ) + tᴺ·(1 − t)⁻¹. The remainder term tᴺ·(1 − t)⁻¹ has norm at most ‖t‖ᴺ·‖(1 − t)⁻¹‖, which decays geometrically, so truncating after N terms yields an inverse to any prescribed accuracy. This is exactly the convergence mechanism of stationary iterative solvers and of successive approximation for integral equations."
+  },
+  {
+    "id": "ann-gs0201-summary",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01",
+    "range": { "startLine": 105, "endLine": 129 },
+    "type": "concept",
+    "title": "Summary: From Scalars to Operators",
+    "content": "The closing table pairs each result with its Mathlib backing. The scalar geometric series 1/(1 − r) = ∑ rⁿ is the R = ℝ case; abstracting to a normed ring makes the one identity cover scalars, matrices, and bounded operators at once. Downstream it yields the openness of the unit group, the analyticity of inversion and of the resolvent (λ − T)⁻¹, and the spectral theory built on them."
+  }
+]

--- a/src/data/proofs/geometric-series-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-03-oq-01/meta.json
@@ -1,0 +1,110 @@
+{
+  "id": "geometric-series-oq-02-oq-03-oq-01",
+  "title": "Geometric Series OQ-02-03-01: The Neumann Series for the Inverse of 1 − t",
+  "slug": "geometric-series-oq-02-oq-03-oq-01",
+  "description": "Generalizes the scalar geometric series 1/(1−r) = ∑ rⁿ to a Banach algebra: in a normed ring with summable geometric series, if ‖t‖ < 1 then 1 − t is invertible and (1 − t)⁻¹ = ∑' n, tⁿ — the Neumann series. Packages the identity, its HasSum form, the unit property of 1 − t, the two-sided-inverse relations, and the finite truncation with explicit remainder tᴺ·(1−t)⁻¹. 7 theorems, 0 definitions, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ02OQ03OQ01.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "neumann-series",
+      "normed-ring",
+      "banach-algebra",
+      "operator-inverse",
+      "perturbation-theory"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified using Mathlib's geom_series_eq_inverse, hasSum_geom_series_inverse, isUnit_one_sub_of_norm_lt_one, and NormedRing.inverse_one_sub_nth_order'. Depends only on propext, Classical.choice, and Quot.sound.",
+    "lineCount": 129,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "originalContributions": [
+      "neumann_series: (1 − t)⁻¹ = ∑' n, tⁿ in any normed ring with summable geometric series",
+      "neumann_mul_left / neumann_mul_right: the series is a genuine two-sided inverse of 1 − t",
+      "isUnit_one_sub: a norm-< 1 perturbation of the identity stays invertible",
+      "neumann_partial_remainder: the finite truncation (∑_{i<N} tⁱ) + tᴺ·(1−t)⁻¹, the basis of iterative inversion"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Carl Neumann introduced the series (I − T)⁻¹ = ∑ Tⁿ in the 1870s while solving boundary-value problems via integral equations — the method of successive approximations. The idea is the operator-theoretic descendant of the geometric series 1/(1 − r) = ∑ rⁿ known since Euclid. In the 20th century, with the rise of functional analysis (Banach, von Neumann, Gelfand), the Neumann series became the standard tool for showing that the invertible elements of a Banach algebra form an open set and that the resolvent (λ − T)⁻¹ is an analytic function of λ — the foundation of spectral theory. The same truncation underlies the convergence analysis of stationary iterative methods (Jacobi, Gauss–Seidel, Richardson) in numerical linear algebra, where one writes A = M − N and iterates with the splitting matrix M.",
+    "problemStatement": "Show that in a normed ring with summable geometric series, ‖t‖ < 1 implies 1 − t is invertible with inverse the convergent series ∑' n, tⁿ, and package the identity together with the unit property, the two-sided-inverse relations, and the truncation-with-remainder formula.",
+    "text": "For a scalar r with |r| < 1, the geometric series sums to (1 − r)⁻¹. Replacing r by an element t of a Banach algebra with ‖t‖ < 1, the partial sums ∑_{i<N} tⁱ form a Cauchy sequence (dominated by the convergent ∑ ‖t‖ⁱ) and converge to an element S with S(1 − t) = (1 − t)S = 1, so S = (1 − t)⁻¹. The truncation identity (1 − t)⁻¹ = ∑_{i<N} tⁱ + tᴺ(1 − t)⁻¹ follows by telescoping (1 − t)∑_{i<N} tⁱ = 1 − tᴺ; since ‖tᴺ‖ ≤ ‖t‖ᴺ → 0, the partial sums approximate the inverse geometrically fast.",
+    "proofStrategy": "Work over a NormedRing R with the [HasSummableGeomSeries R] typeclass (satisfied by every Banach algebra). neumann_series is geom_series_eq_inverse symmetrized; hasSum_neumann_series and summable_neumann_series wrap the corresponding Mathlib lemmas. isUnit_one_sub is isUnit_one_sub_of_norm_lt_one. The two-sided-inverse relations rewrite ∑' n, tⁿ back to Ring.inverse (1 − t) and apply Ring.inverse_mul_cancel / mul_inverse_cancel with the unit witness. neumann_partial_remainder is NormedRing.inverse_one_sub_nth_order'.",
+    "keyInsights": [
+      "The geometric series is not merely a scalar identity but a universal Banach-algebra fact: the same ∑ tⁿ inverts 1 − t for operators, matrices, and any element of norm < 1",
+      "Invertibility is an open condition — a perturbation of the identity by anything of norm < 1 remains invertible — which is exactly why the unit group of a Banach algebra is open",
+      "The remainder term tᴺ·(1 − t)⁻¹ has norm ≤ ‖t‖ᴺ·‖(1 − t)⁻¹‖, so truncating the series gives an inverse to any accuracy: this is iterative inversion and the engine of stationary solvers",
+      "Summability comes for free from the geometric domination ‖tⁿ‖ ≤ ‖t‖ⁿ < ∞, abstracted in Mathlib by the HasSummableGeomSeries typeclass rather than requiring full completeness in the statement"
+    ],
+    "prerequisites": [
+      "Geometric series ∑ rⁿ = 1/(1 − r) for |r| < 1",
+      "Normed rings and Banach algebras",
+      "Summability and tsum in a complete normed space",
+      "Ring.inverse and the unit group Rˣ"
+    ]
+  },
+  "conclusion": {
+    "summary": "Fully machine-verified Neumann series over a normed ring with summable geometric series: (1 − t)⁻¹ = ∑' n, tⁿ for ‖t‖ < 1, packaged with the HasSum form, the unit property of 1 − t, the left/right two-sided-inverse relations, and the finite truncation with explicit remainder tᴺ·(1 − t)⁻¹. Zero axioms, zero sorries.",
+    "implications": "The Neumann series is the analytic backbone of Banach-algebra theory: it proves the unit group is open, the inversion map is continuous (indeed analytic), and the resolvent (λ − T)⁻¹ of an operator is holomorphic on the resolvent set — the gateway to spectral theory, holomorphic functional calculus, and the spectral radius formula. In numerical analysis the truncation-with-remainder formula is the convergence criterion for stationary iterative methods. The abstraction over an arbitrary normed ring means the single identity simultaneously covers scalars, square matrices, and bounded operators on a Banach space.",
+    "openQuestions": [
+      "Derive the openness of the unit group and continuity of t ↦ (1 − t)⁻¹ from the Neumann series",
+      "Bound the truncation error ‖(1 − t)⁻¹ − ∑_{i<N} tⁱ‖ ≤ ‖t‖ᴺ/(1 − ‖t‖) and connect to geometric convergence of iterative solvers",
+      "Generalize to (x − t)⁻¹ for an arbitrary unit x with ‖x⁻¹ t‖ < 1 (Mathlib's inverse_add), giving local analyticity of inversion",
+      "Specialize to the resolvent (λ − T)⁻¹ of a bounded operator and establish its analyticity in λ"
+    ]
+  },
+  "leanFile": {
+    "namespace": "GeometricSeriesOQ02OQ03OQ01",
+    "lineCount": 129,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ02OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "geometric-series",
+      "relationship": "extends",
+      "description": "The parent entry establishes the scalar geometric series ∑ rⁿ = 1/(1 − r) for |r| < 1. This entry lifts it to a Banach-algebra setting: the same series inverts 1 − t for any ring element t with ‖t‖ < 1 (the Neumann series)."
+    }
+  ],
+  "sections": [
+    {
+      "id": "identity",
+      "title": "Part I: The Neumann series identity",
+      "startLine": 39,
+      "endLine": 62,
+      "summary": "neumann_series states (1 − t)⁻¹ = ∑' n, tⁿ (from geom_series_eq_inverse), with the HasSum form hasSum_neumann_series and summability summable_neumann_series, valid in any normed ring with summable geometric series."
+    },
+    {
+      "id": "invertibility",
+      "title": "Part II: Invertibility of 1 − t",
+      "startLine": 63,
+      "endLine": 86,
+      "summary": "isUnit_one_sub: a norm-< 1 perturbation of the identity stays invertible. neumann_mul_left and neumann_mul_right confirm the series is a genuine two-sided inverse, via Ring.inverse_mul_cancel / mul_inverse_cancel."
+    },
+    {
+      "id": "truncation",
+      "title": "Part III: Finite truncation with remainder",
+      "startLine": 87,
+      "endLine": 104,
+      "summary": "neumann_partial_remainder gives (1 − t)⁻¹ = (∑_{i<N} tⁱ) + tᴺ·(1 − t)⁻¹; since ‖tᴺ‖ → 0, the truncation approximates the inverse to any accuracy — the basis of iterative inversion."
+    },
+    {
+      "id": "summary",
+      "title": "Part IV: Summary",
+      "startLine": 105,
+      "endLine": 129,
+      "summary": "Tabulates the results and situates the Neumann series as the source of the openness of the unit group, analyticity of inversion and the resolvent, and convergence of stationary iterative solvers."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Lifts the scalar geometric series `1/(1−r) = ∑ rⁿ` to a **Banach algebra**: in a normed ring with summable geometric series, if `‖t‖ < 1` then `1 − t` is invertible and

> `(1 − t)⁻¹ = ∑' n, tⁿ`  — the **Neumann series**.

`proofs/Proofs/GeometricSeriesOQ02OQ03OQ01.lean` (namespace `GeometricSeriesOQ02OQ03OQ01`), **7 theorems, 0 definitions, 0 sorries, 0 axioms**.

### Results
- `neumann_series` — `Ring.inverse (1 - t) = ∑' n, tⁿ` (via `geom_series_eq_inverse`).
- `hasSum_neumann_series` / `summable_neumann_series` — the `HasSum` and `Summable` forms.
- `isUnit_one_sub` — a norm-`< 1` perturbation of the identity stays invertible (unit group is open).
- `neumann_mul_left` / `neumann_mul_right` — the series is a genuine **two-sided** inverse.
- `neumann_partial_remainder` — truncation with explicit remainder `(∑_{i<N} tⁱ) + tᴺ·(1−t)⁻¹`, the basis of iterative inversion.

Abstracting over an arbitrary `NormedRing` with `[HasSummableGeomSeries R]` means the one identity covers scalars, square matrices, and bounded operators on a Banach space simultaneously — the source of the openness of the unit group, analyticity of the resolvent `(λ − T)⁻¹`, and convergence of stationary iterative solvers.

### Verification
- Single-file `lake env lean proofs/Proofs/GeometricSeriesOQ02OQ03OQ01.lean` against pinned **Mathlib v4.26.0** oleans: **exit 0**, all `#check`s resolve.
- `#print axioms neumann_series` and `neumann_mul_left` → `[propext, Classical.choice, Quot.sound]` only (axiom-free).
- Full `docker-build` not run (host Docker unavailable this session); type-checked at single-file level. Deployer gates on the build.

Gallery entry at `src/data/proofs/geometric-series-oq-02-oq-03-oq-01/` (meta.json + annotations.json), badge `mathlib`, status `verified`, extends parent `geometric-series`.

Closes research problem `geometric-series-oq-02-oq-03-oq-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)