### PR TITLE
research(cayley-hamilton-minpoly-oq-06): similar matrices share a minimal polynomial

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -484,6 +484,7 @@ import Proofs.CayleyHamiltonMinpolyOQ04
 import Proofs.CayleyHamiltonMinpolyOQ04Backward
 import Proofs.CayleyHamiltonMinpolyOQ04BackwardAristotle
 import Proofs.CayleyHamiltonMinpolyOQ05
+import Proofs.CayleyHamiltonMinpolyOQ06
 import Proofs.CayleyHamiltonMinpolyOQ05OQ01
 import Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ01
 import Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ02

--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ06.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ06.lean
@@ -1,0 +1,79 @@
+import Mathlib
+
+/-
+# OQ-06: Similar (conjugate) elements share a minimal polynomial
+
+For a unit `u` in any `K`-algebra `A`, conjugation `x ↦ u * x * u⁻¹` is a `K`-algebra
+automorphism of `A`, so it preserves the minimal polynomial:
+
+    minpoly K (u * x * u⁻¹) = minpoly K x.
+
+Specialised to `A = Matrix n n K`, this is the classical fact that **similar
+matrices** `N = U⁻¹ * M * U` have the same minimal polynomial — the
+minimal-polynomial companion of Mathlib's `Matrix.charpoly_units_conj`, which
+gives the same statement for the characteristic polynomial.
+
+Everything rests on Mathlib's `minpoly.algEquiv_eq` (the minimal polynomial is
+invariant under any `K`-algebra equivalence).  The only new content is packaging
+inner conjugation by a unit as such an equivalence (`innerAlgEquiv`).  Note no
+integrality hypothesis is needed: the identity holds for every element, integral
+or not, because `minpoly.algEquiv_eq` is unconditional.
+
+Sorry-free and axiom-free.
+-/
+
+namespace CayleyHamiltonMinpolyOQ06
+
+open Polynomial
+
+variable {K : Type*} [Field K]
+variable {A : Type*} [Ring A] [Algebra K A]
+
+/-- Conjugation by a unit `u` of a `K`-algebra `A`, `x ↦ u * x * u⁻¹`, packaged as a
+`K`-algebra automorphism of `A`.  Inner automorphisms are the prototypical algebra
+automorphisms, and this is the bridge to `minpoly.algEquiv_eq`. -/
+def innerAlgEquiv (u : Aˣ) : A ≃ₐ[K] A where
+  toFun x := (u : A) * x * (↑u⁻¹ : A)
+  invFun x := (↑u⁻¹ : A) * x * (u : A)
+  left_inv x := by simp [mul_assoc]
+  right_inv x := by simp [mul_assoc]
+  map_mul' x y := by simp [mul_assoc]
+  map_add' x y := by simp [mul_add, add_mul]
+  commutes' r := by
+    rw [← Algebra.commutes r (u : A), mul_assoc, Units.mul_inv, mul_one]
+
+@[simp]
+theorem innerAlgEquiv_apply (u : Aˣ) (x : A) :
+    innerAlgEquiv (K := K) u x = (u : A) * x * (↑u⁻¹ : A) := rfl
+
+/-- **Inner conjugation preserves the minimal polynomial.** For a unit `u` of a
+`K`-algebra and any `x`, `u * x * u⁻¹` has the same minimal polynomial as `x`. -/
+theorem minpoly_units_conj (u : Aˣ) (x : A) :
+    minpoly K ((u : A) * x * (↑u⁻¹ : A)) = minpoly K x := by
+  have h := minpoly.algEquiv_eq (innerAlgEquiv (K := K) u) x
+  simpa using h
+
+/-- The `u⁻¹ * x * u` form (matching the standard "similar element" presentation
+`N = U⁻¹ M U`). -/
+theorem minpoly_units_conj' (u : Aˣ) (x : A) :
+    minpoly K ((↑u⁻¹ : A) * x * (u : A)) = minpoly K x := by
+  have h := minpoly_units_conj (K := K) u⁻¹ x
+  simpa using h
+
+/-! ### Matrix specialisation: similar matrices share a minimal polynomial -/
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **Similar matrices share a minimal polynomial.** If `N = U⁻¹ * M * U` for a unit
+matrix `U`, then `minpoly K N = minpoly K M`.  This is the minimal-polynomial
+analogue of `Matrix.charpoly_units_conj`. -/
+theorem minpoly_matrix_units_conj (U : (Matrix n n K)ˣ) (M : Matrix n n K) :
+    minpoly K ((↑U⁻¹ : Matrix n n K) * M * (↑U : Matrix n n K)) = minpoly K M :=
+  minpoly_units_conj' U M
+
+/-- The `U * M * U⁻¹` form of matrix similarity invariance. -/
+theorem minpoly_matrix_units_conj' (U : (Matrix n n K)ˣ) (M : Matrix n n K) :
+    minpoly K ((↑U : Matrix n n K) * M * (↑U⁻¹ : Matrix n n K)) = minpoly K M :=
+  minpoly_units_conj U M
+
+end CayleyHamiltonMinpolyOQ06

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-06/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-06/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-06",
+  "title": "Similar Matrices Share a Minimal Polynomial",
+  "slug": "cayley-hamilton-minpoly-oq-06",
+  "description": "Conjugation by a unit u in any K-algebra, x ↦ u·x·u⁻¹, is a K-algebra automorphism, so it preserves the minimal polynomial: minpoly K (u·x·u⁻¹) = minpoly K x. Specialised to matrices, similar matrices N = U⁻¹·M·U share a minimal polynomial — the minimal-polynomial companion of Mathlib's Matrix.charpoly_units_conj.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Minimal_polynomial_(linear_algebra)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ06.lean",
+    "tags": [
+      "linear-algebra",
+      "abstract-algebra",
+      "minimal-polynomial",
+      "similar-matrices",
+      "inner-automorphism",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "minpoly.algEquiv_eq",
+        "description": "The minimal polynomial is invariant under any K-algebra equivalence: minpoly A (f x) = minpoly A x",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "Algebra.commutes",
+        "description": "The image of the algebra map is central: algebraMap r * x = x * algebraMap r",
+        "module": "Mathlib.Algebra.Algebra.Defs"
+      },
+      {
+        "theorem": "Matrix.charpoly_units_conj",
+        "description": "The characteristic polynomial is invariant under conjugation by a unit matrix",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
+      }
+    ],
+    "originalContributions": [
+      "innerAlgEquiv: packages inner conjugation x ↦ u·x·u⁻¹ by a unit of any K-algebra as a K-algebra automorphism (A ≃ₐ[K] A), with all structure fields discharged by associativity plus the unit cancellation lemmas",
+      "minpoly_units_conj / minpoly_units_conj': inner conjugation (in both u·x·u⁻¹ and u⁻¹·x·u forms) preserves the minimal polynomial in any K-algebra, with no integrality hypothesis",
+      "minpoly_matrix_units_conj / ': the classical statement that similar matrices share a minimal polynomial, obtained as a one-line corollary — the minimal-polynomial analogue of charpoly_units_conj"
+    ],
+    "dateAdded": "2026-06-19",
+    "prerequisites": [
+      "Minimal polynomials in K-algebras (aeval, minpoly)",
+      "Algebra equivalences and automorphisms",
+      "Units of a ring and inner automorphisms",
+      "Matrix similarity / conjugation"
+    ],
+    "relatedProblems": [
+      {
+        "id": "cayley-hamilton-minpoly-oq-05",
+        "relationship": "Sibling: minimal polynomial reduction in general K-algebras"
+      },
+      {
+        "id": "cramers-rule-oq-05",
+        "relationship": "Companion: det/trace/charpoly similarity invariants under unit conjugation"
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 79,
+    "assumptions": "0 axioms, 0 sorries. Built on Mathlib's minpoly.algEquiv_eq; the only added content is the inner-automorphism algebra equivalence and its specialisation to matrices.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Two square matrices M and N over a field are *similar* when N = U⁻¹·M·U for some invertible U; similarity is the matrix incarnation of 'same linear map in a different basis'. Similarity invariants — quantities unchanged by conjugation — are the backbone of canonical-form theory (Jordan, rational/Frobenius normal forms). The characteristic polynomial, the determinant, and the trace are the classical similarity invariants; so is the minimal polynomial, the monic generator of the annihilator ideal of the matrix. Abstractly, conjugation by an invertible element is an inner automorphism of the matrix algebra, and any algebra automorphism carries an element to one with the same minimal polynomial. This places the matrix statement inside the general theory of inner automorphisms of K-algebras developed by Noether, Artin, and Skolem in the 1920s-30s.",
+    "problemStatement": "Prove that conjugation by a unit in a K-algebra preserves the minimal polynomial, and deduce that similar matrices N = U⁻¹·M·U share a minimal polynomial.",
+    "text": "Conjugation by a unit u in any K-algebra, x ↦ u·x·u⁻¹, is a K-algebra automorphism, so minpoly K (u·x·u⁻¹) = minpoly K x. Specialised to matrices, similar matrices share a minimal polynomial.",
+    "proofStrategy": "Package inner conjugation by a unit u as a K-algebra automorphism innerAlgEquiv u : A ≃ₐ[K] A — the multiplicative and additive structure follow from associativity and distributivity, while centrality of the algebra map handles the commutes' field. Then minpoly K (u·x·u⁻¹) = minpoly K x is exactly Mathlib's minpoly.algEquiv_eq applied to this automorphism. The matrix statement is the specialisation A = Matrix n n K with u a unit matrix, using inv_inv to land on the N = U⁻¹·M·U form.",
+    "keyInsights": [
+      "Conjugation by a unit is an inner automorphism — the prototypical algebra automorphism",
+      "minpoly.algEquiv_eq makes the result a one-liner once conjugation is an A ≃ₐ[K] A",
+      "No integrality hypothesis is needed: the identity holds for every element because minpoly.algEquiv_eq is unconditional",
+      "This is the minimal-polynomial sibling of Matrix.charpoly_units_conj; together they give that the minimal and characteristic polynomials are both similarity invariants",
+      "The general K-algebra statement subsumes the matrix case, field-extension generators, and group-algebra elements alike"
+    ],
+    "prerequisites": [
+      "Minimal polynomials in K-algebras (aeval, minpoly)",
+      "Algebra equivalences and automorphisms",
+      "Units of a ring and inner automorphisms",
+      "Matrix similarity / conjugation"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Documentation and Setup",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Header stating the inner-conjugation result and its matrix corollary. Sets up universe-polymorphic variables for a field K and a K-algebra A.",
+      "mathContext": "The setup `{K : Type*} [Field K] {A : Type*} [Ring A] [Algebra K A]` covers every K-algebra; the matrix specialisation is recovered by taking A = Matrix n n K."
+    },
+    {
+      "id": "inner-algequiv",
+      "title": "Inner Conjugation as an Algebra Automorphism",
+      "startLine": 34,
+      "endLine": 48,
+      "summary": "innerAlgEquiv u : A ≃ₐ[K] A sends x to u·x·u⁻¹. The Equiv laws follow from associativity and unit cancellation, map_mul'/map_add' from ring distributivity, and commutes' from centrality of the algebra map.",
+      "mathContext": "An inner automorphism x ↦ u·x·u⁻¹ is an algebra automorphism: it is bijective with inverse x ↦ u⁻¹·x·u, multiplicative since u⁻¹·u cancels in the middle, and fixes the central image of K."
+    },
+    {
+      "id": "minpoly-conj",
+      "title": "Conjugation Preserves the Minimal Polynomial",
+      "startLine": 50,
+      "endLine": 64,
+      "summary": "minpoly_units_conj and minpoly_units_conj': for a unit u, minpoly K (u·x·u⁻¹) = minpoly K x = minpoly K (u⁻¹·x·u), as a direct application of minpoly.algEquiv_eq to innerAlgEquiv.",
+      "mathContext": "Because the minimal polynomial is invariant under algebra equivalences, conjugating by any unit leaves it unchanged — in both the u·x·u⁻¹ and u⁻¹·x·u presentations."
+    },
+    {
+      "id": "matrix-similarity",
+      "title": "Matrix Specialisation: Similar Matrices Share a Minimal Polynomial",
+      "startLine": 66,
+      "endLine": 79,
+      "summary": "minpoly_matrix_units_conj: for a unit matrix U, minpoly K (U⁻¹·M·U) = minpoly K M (and the U·M·U⁻¹ form), the classical similarity invariance of the minimal polynomial.",
+      "mathContext": "Specialising A = Matrix n n K, the abstract result becomes the textbook fact that similar matrices N = U⁻¹·M·U have equal minimal polynomials — the minimal-polynomial companion of charpoly_units_conj."
+    }
+  ],
+  "conclusion": {
+    "summary": "Conjugation by a unit in any K-algebra is an inner automorphism and therefore preserves the minimal polynomial; specialised to matrices this is the classical statement that similar matrices share a minimal polynomial. All 5 theorems and 1 definition are fully verified with 0 sorries and 0 axioms.",
+    "implications": "Together with Mathlib's charpoly_units_conj this confirms that both the characteristic and the minimal polynomial are similarity invariants, a prerequisite for canonical-form theory (Jordan and rational normal forms).",
+    "openQuestions": [
+      "Formalize that the minimal polynomial, together with the invariant factors, forms a complete set of similarity invariants (rational canonical form).",
+      "Relate the degree of the minimal polynomial to the size of the largest Jordan block."
+    ]
+  },
+  "status": "verified",
+  "badge": "mathlib",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "CayleyHamiltonMinpolyOQ06",
+    "lineCount": 79,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ06.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly",
+      "relationship": "extends",
+      "description": "Parent formalization; this entry extends it with similarity invariance of the minimal polynomial."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-05",
+      "relationship": "related",
+      "description": "Sibling: minimal polynomial reduction in general K-algebras."
+    },
+    {
+      "targetId": "cramers-rule-oq-05",
+      "relationship": "related",
+      "description": "Companion: det/trace/charpoly similarity invariants under unit conjugation."
+    }
+  ],
+  "references": [
+    {
+      "key": "HJ13",
+      "citation": "Horn, R.A. and Johnson, C.R., Matrix Analysis, 2nd ed., Cambridge University Press (2013), Chapter 3: Canonical forms.",
+      "type": "book"
+    },
+    {
+      "key": "La02",
+      "citation": "Lang, S., Algebra, 3rd ed., Springer GTM 211 (2002), Chapter XIV: Representation of One Endomorphism.",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Settles `cayley-hamilton-minpoly-oq-06`: **similar (conjugate) matrices share a minimal polynomial**, derived from the general fact that inner conjugation by a unit of any `K`-algebra preserves the minimal polynomial.

- `innerAlgEquiv (u : Aˣ) : A ≃ₐ[K] A` — inner conjugation `x ↦ u·x·u⁻¹` packaged as a `K`-algebra automorphism (Equiv laws from associativity + unit cancellation; `commutes'` from centrality of the algebra map).
- `minpoly_units_conj` / `minpoly_units_conj'` — `minpoly K (u·x·u⁻¹) = minpoly K x = minpoly K (u⁻¹·x·u)`, a one-line consequence of Mathlib's `minpoly.algEquiv_eq`. **No integrality hypothesis** is needed.
- `minpoly_matrix_units_conj` / `'` — the classical statement that `N = U⁻¹·M·U` has the same minimal polynomial as `M` (and the `U·M·U⁻¹` form). This is the minimal-polynomial companion of Mathlib's `Matrix.charpoly_units_conj`; together they give that both the characteristic and minimal polynomials are similarity invariants.

The general `K`-algebra formulation subsumes the matrix case, field-extension generators, and group-algebra elements alike.

## Verification

- Sorry-free; `#print axioms` on the headline results = `[propext, Classical.choice, Quot.sound]` only (0 added axioms; the entry counts as `verified`, badge `mathlib`).
- Type-checked via single-file compile against pinned Mathlib v4.26 (imports `Mathlib` only). The Docker wrapper is host-blocked under heavy load this session, so the standard docker build is unavailable; the direct `lake env lean` compile is an equivalent kernel type-check.

## Files

- `proofs/Proofs/CayleyHamiltonMinpolyOQ06.lean` (new, verified — 5 theorems, 1 definition, 79 lines)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/cayley-hamilton-minpoly-oq-06/meta.json` (gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)