### PR TITLE
research(bezout-identity-oq-01-oq-01-oq-02-oq-01): constructive extended binary GCD (verified)

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,272 @@
+import Mathlib.Data.Int.GCD
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Tactic
+import Proofs.BezoutIdentityOQ01OQ01OQ02
+
+/-
+# Extended Binary GCD: Tracking Bézout Coefficients Through the Algorithm
+
+## Open Question (bezout-identity-oq-01-oq-01-oq-02-oq-01)
+
+The parent `BezoutIdentityOQ01OQ01OQ02` defines `intBinaryGcd : ℤ → ℤ → ℤ`
+(Stein's binary algorithm) and proves a Bézout identity
+`bezout_via_intBinaryGcd` — but the coefficients there are *borrowed* from
+Mathlib's `Int.gcdA` / `Int.gcdB`, not produced by the binary algorithm itself.
+
+This file closes that gap: it builds a **constructive** extended binary GCD that
+threads a Bézout pair `(x, y)` through every halving and subtraction step, so the
+witnesses `a * x + b * y = gcd a b` are computed by the algorithm, not imported.
+
+## The Algorithm
+
+`ebGcd a b` returns `(g, x, y)` with `g = Nat.gcd a b` and
+`(a : ℤ) * x + (b : ℤ) * y = g`.  We use the *subtract-don't-rehalve* binary
+variant: the classic Stein step `gcd a b = gcd a ((b-a)/2)` (both odd) is
+replaced by `gcd a b = gcd a (b - a)`.  This keeps it a genuine binary GCD —
+common factors of two are still stripped by halving even arguments — while making
+the coefficient transforms exact integer identities (no coefficient ever needs to
+be halved in a *subtraction* branch, which is the classic extended-binary-GCD
+pitfall).
+
+### Coefficient transforms (each is a one-line `ring`/`omega` identity)
+
+Let the recursive call return `(g, x, y)`.
+
+| Branch                | Recurse on   | New `(x', y')`                         |
+|-----------------------|--------------|----------------------------------------|
+| both even `2a',2b'`   | `(a', b')`   | `(x, y)`, result `g ↦ 2g`              |
+| `a=2a'` even, `b` odd | `(a', b)`    | `x` even: `(x/2, y)`; odd: `((x+b)/2, y-a')` |
+| `a` odd, `b=2b'` even | `(a, b')`    | `y` even: `(x, y/2)`; odd: `(x-b', (y+a)/2)` |
+| both odd, `a ≤ b`     | `(a, b-a)`   | `(x - y, y)`                           |
+| both odd, `a > b`     | `(a-b, b)`   | `(x, y - x)`                           |
+
+The two single-even branches use a parity case split: when the carried
+coefficient is odd, adding the (odd) other argument makes it even before halving,
+which is the only subtlety in the whole construction.
+
+## Results
+
+* `ebGcd_fst` — the first component is `Nat.gcd a b`.
+* `ebGcd_bezout` / `ebGcd_bezout_gcd` — the threaded coefficients are a genuine
+  Bézout witness: `a * x + b * y = gcd a b`.
+* `intExtBinaryGcd_fst` — the signed extension agrees with the parent
+  `intBinaryGcd`.
+* `intExtBinaryGcd_bezout` — the signed Bézout identity over `ℤ`.
+
+## Status
+
+Fully machine-checked: no `sorry`, no extra axioms.  The four correctness theorems
+depend only on Lean/Mathlib's foundational axioms `propext`, `Classical.choice`,
+`Quot.sound` (verifiable with `#print axioms`).  Worked-out numerical instances
+(e.g. `ebGcd 12 8 = (4, 1, -1)`, so `12·1 + 8·(-1) = 4`) are recorded as comments
+in Part V to keep the file free of the `Lean.ofReduceBool` axiom that
+`native_decide` would introduce.
+
+The gcd-correctness proof mirrors the *verified* grandparent
+`BezoutIdentityOQ01OQ01.binaryGcd_eq_gcd` (same recursion shape); the Bézout proof
+discharges each branch by `linear_combination` of the inductive hypothesis with
+the relevant cast/parity facts (all `omega`-provable).
+-/
+
+namespace BezoutIdentityOQ01OQ01OQ02OQ01
+
+open BezoutIdentityOQ01OQ01OQ02
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART I: THE EXTENDED BINARY GCD (constructive Bézout witness)
+-- ═══════════════════════════════════════════════════════════════
+
+/-- Extended binary GCD over `ℕ`, returning `(g, x, y)` with `g = Nat.gcd a b`
+and the Bézout identity `(a : ℤ) * x + (b : ℤ) * y = g`.  Coefficients are
+threaded through each halving/subtraction step of Stein's algorithm.
+
+In the two single-even branches the carried `r.1` (the gcd) is pulled out front of
+the inner parity `if`, so that `(ebGcd a b).1` reduces without splitting on parity. -/
+def ebGcd (a b : ℕ) : ℕ × ℤ × ℤ :=
+  if a = 0 then (b, 0, 1)
+  else if b = 0 then (a, 1, 0)
+  else if a % 2 = 0 ∧ b % 2 = 0 then
+    -- both even: gcd a b = 2 * gcd (a/2) (b/2); coefficients unchanged
+    let r := ebGcd (a / 2) (b / 2)
+    (2 * r.1, r.2.1, r.2.2)
+  else if a % 2 = 0 then
+    -- a even, b odd: gcd a b = gcd (a/2) b
+    let r := ebGcd (a / 2) b
+    let x := r.2.1
+    let y := r.2.2
+    (r.1, if x % 2 = 0 then (x / 2, y) else ((x + (b : ℤ)) / 2, y - ((a / 2 : ℕ) : ℤ)))
+  else if b % 2 = 0 then
+    -- a odd, b even: gcd a b = gcd a (b/2)
+    let r := ebGcd a (b / 2)
+    let x := r.2.1
+    let y := r.2.2
+    (r.1, if y % 2 = 0 then (x, y / 2) else (x - ((b / 2 : ℕ) : ℤ), (y + (a : ℤ)) / 2))
+  else if a ≤ b then
+    -- both odd, a ≤ b: gcd a b = gcd a (b - a)
+    let r := ebGcd a (b - a)
+    (r.1, r.2.1 - r.2.2, r.2.2)
+  else
+    -- both odd, a > b: gcd a b = gcd (a - b) b
+    let r := ebGcd (a - b) b
+    (r.1, r.2.1, r.2.2 - r.2.1)
+termination_by a + b
+decreasing_by
+  all_goals simp_wf
+  all_goals omega
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART II: GCD COMPONENT IS CORRECT
+-- ═══════════════════════════════════════════════════════════════
+
+/-- The first component of `ebGcd` is `Nat.gcd`.  Mirrors the grandparent
+`binaryGcd_eq_gcd`: the even branches use coprimality/`gcd_mul_left`, the subtract
+branches use `Nat.gcd_rec` together with `(b - a) % a = b % a`. -/
+theorem ebGcd_fst (a b : ℕ) : (ebGcd a b).1 = Nat.gcd a b := by
+  unfold ebGcd
+  split_ifs with h1 h2 h3 h4 h5 h6 <;> dsimp only
+  · simp [h1, Nat.gcd_zero_left]
+  · simp [h2, Nat.gcd_zero_right]
+  · obtain ⟨ha2, hb2⟩ := h3
+    rw [ebGcd_fst (a / 2) (b / 2)]
+    conv_rhs => rw [show a = 2 * (a / 2) from by omega,
+                    show b = 2 * (b / 2) from by omega]
+    exact (Nat.gcd_mul_left 2 (a / 2) (b / 2)).symm
+  · have hb1 : b % 2 = 1 := by omega
+    rw [ebGcd_fst (a / 2) b]
+    conv_rhs => rw [show a = 2 * (a / 2) from by omega]
+    exact ((Nat.coprime_two_left.mpr (Nat.odd_iff.mpr hb1)).gcd_mul_left_cancel _).symm
+  · have ha1 : a % 2 = 1 := by omega
+    rw [ebGcd_fst a (b / 2), Nat.gcd_comm a (b / 2)]
+    conv_rhs => rw [show b = 2 * (b / 2) from by omega]
+    rw [Nat.gcd_comm a]
+    exact ((Nat.coprime_two_left.mpr (Nat.odd_iff.mpr ha1)).gcd_mul_left_cancel _).symm
+  · have hmod : (b - a) % a = b % a := by
+      conv_rhs => rw [show b = (b - a) + a from by omega]
+      rw [Nat.add_mod_right]
+    rw [ebGcd_fst a (b - a), Nat.gcd_rec a (b - a), Nat.gcd_rec a b, hmod]
+  · have hmod : (a - b) % b = a % b := by
+      conv_rhs => rw [show a = (a - b) + b from by omega]
+      rw [Nat.add_mod_right]
+    rw [ebGcd_fst (a - b) b, Nat.gcd_comm (a - b) b, Nat.gcd_comm a b,
+        Nat.gcd_rec b (a - b), Nat.gcd_rec b a, hmod]
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART III: BÉZOUT IDENTITY (the constructive witness is correct)
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **Extended Binary Bézout Identity.** The coefficients threaded through the
+algorithm satisfy `a * x + b * y = gcd a b`, with `(x, y) = (ebGcd a b).2`.
+
+Each branch closes by `linear_combination` of the inductive hypothesis with the
+cast/parity facts.  In the single-even branches the carried coefficient is made
+even *before* halving (`x = 2 * (x / 2)`, `x + b = 2 * ((x + b) / 2)`), and in the
+subtraction branches the `ℕ → ℤ` cast of `b - a` distributes (`a ≤ b`). -/
+theorem ebGcd_bezout (a b : ℕ) :
+    (a : ℤ) * (ebGcd a b).2.1 + (b : ℤ) * (ebGcd a b).2.2 = ((ebGcd a b).1 : ℤ) := by
+  unfold ebGcd
+  split_ifs with h1 h2 h3 h4 h5 h6 <;> dsimp only
+  · -- a = 0
+    push_cast [h1]; ring
+  · -- b = 0
+    push_cast [h2]; ring
+  · -- both even
+    obtain ⟨ha2, hb2⟩ := h3
+    have ih := ebGcd_bezout (a / 2) (b / 2)
+    have ea : (a : ℤ) = 2 * ((a / 2 : ℕ) : ℤ) := by omega
+    have eb : (b : ℤ) = 2 * ((b / 2 : ℕ) : ℤ) := by omega
+    push_cast
+    linear_combination 2 * ih + (ebGcd (a / 2) (b / 2)).2.1 * ea
+      + (ebGcd (a / 2) (b / 2)).2.2 * eb
+  · -- a even, b odd
+    split_ifs with hx <;> dsimp only
+    · -- carried x even
+      have ih := ebGcd_bezout (a / 2) b
+      have ea : (a : ℤ) = 2 * ((a / 2 : ℕ) : ℤ) := by omega
+      have hx2 : (ebGcd (a / 2) b).2.1 = 2 * ((ebGcd (a / 2) b).2.1 / 2) := by omega
+      linear_combination ih + ((ebGcd (a / 2) b).2.1 / 2) * ea
+        - ((a / 2 : ℕ) : ℤ) * hx2
+    · -- carried x odd
+      have ih := ebGcd_bezout (a / 2) b
+      have ea : (a : ℤ) = 2 * ((a / 2 : ℕ) : ℤ) := by omega
+      have hxb : (ebGcd (a / 2) b).2.1 + (b : ℤ)
+          = 2 * (((ebGcd (a / 2) b).2.1 + (b : ℤ)) / 2) := by omega
+      linear_combination ih + (((ebGcd (a / 2) b).2.1 + (b : ℤ)) / 2) * ea
+        - ((a / 2 : ℕ) : ℤ) * hxb
+  · -- a odd, b even
+    split_ifs with hy <;> dsimp only
+    · -- carried y even
+      have ih := ebGcd_bezout a (b / 2)
+      have eb : (b : ℤ) = 2 * ((b / 2 : ℕ) : ℤ) := by omega
+      have hy2 : (ebGcd a (b / 2)).2.2 = 2 * ((ebGcd a (b / 2)).2.2 / 2) := by omega
+      linear_combination ih + ((ebGcd a (b / 2)).2.2 / 2) * eb
+        - ((b / 2 : ℕ) : ℤ) * hy2
+    · -- carried y odd
+      have ih := ebGcd_bezout a (b / 2)
+      have eb : (b : ℤ) = 2 * ((b / 2 : ℕ) : ℤ) := by omega
+      have hya : (ebGcd a (b / 2)).2.2 + (a : ℤ)
+          = 2 * (((ebGcd a (b / 2)).2.2 + (a : ℤ)) / 2) := by omega
+      linear_combination ih + (((ebGcd a (b / 2)).2.2 + (a : ℤ)) / 2) * eb
+        - ((b / 2 : ℕ) : ℤ) * hya
+  · -- both odd, a ≤ b
+    have ih := ebGcd_bezout a (b - a)
+    have hsub : ((b - a : ℕ) : ℤ) = (b : ℤ) - (a : ℤ) := by
+      rw [Nat.cast_sub h6]
+    linear_combination ih - (ebGcd a (b - a)).2.2 * hsub
+  · -- both odd, a > b
+    have ih := ebGcd_bezout (a - b) b
+    have hsub : ((a - b : ℕ) : ℤ) = (a : ℤ) - (b : ℤ) := by
+      rw [Nat.cast_sub (by omega)]
+    linear_combination ih - (ebGcd (a - b) b).2.1 * hsub
+
+/-- Packaged form: the witnesses certify `Nat.gcd a b`. -/
+theorem ebGcd_bezout_gcd (a b : ℕ) :
+    (a : ℤ) * (ebGcd a b).2.1 + (b : ℤ) * (ebGcd a b).2.2 = (Nat.gcd a b : ℤ) := by
+  rw [ebGcd_bezout, ebGcd_fst]
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART IV: INTEGER EXTENSION (signs folded onto the coefficients)
+-- ═══════════════════════════════════════════════════════════════
+
+/-- Extended binary GCD over `ℤ`: reduce to `natAbs`, then push the input signs
+onto the Bézout coefficients via `a.sign * a.natAbs = a`. Returns `(g, x, y)`
+with `g = intBinaryGcd a b` and `a * x + b * y = g`. -/
+def intExtBinaryGcd (a b : ℤ) : ℤ × ℤ × ℤ :=
+  let r := ebGcd a.natAbs b.natAbs
+  ((r.1 : ℤ), a.sign * r.2.1, b.sign * r.2.2)
+
+/-- The gcd component equals the parent `intBinaryGcd`: both sides are
+`↑(Nat.gcd a.natAbs b.natAbs)`, via `ebGcd_fst` and `binaryGcd_eq_gcd`. -/
+theorem intExtBinaryGcd_fst (a b : ℤ) :
+    (intExtBinaryGcd a b).1 = intBinaryGcd a b := by
+  simp only [intExtBinaryGcd, intBinaryGcd, ebGcd_fst,
+    BezoutIdentityOQ01OQ01.binaryGcd_eq_gcd]
+
+/-- **Integer Extended Binary Bézout Identity.**
+`a * (a.sign * x) + b * (b.sign * y) = |a| * x + |b| * y = g`, using
+`a * a.sign = a.natAbs` (`Int.sign_mul_self_eq_natAbs`) and `ebGcd_bezout`. -/
+theorem intExtBinaryGcd_bezout (a b : ℤ) :
+    a * (intExtBinaryGcd a b).2.1 + b * (intExtBinaryGcd a b).2.2
+      = (intExtBinaryGcd a b).1 := by
+  simp only [intExtBinaryGcd]
+  have hsa : a * a.sign = (a.natAbs : ℤ) := by
+    rw [mul_comm]; exact Int.sign_mul_self_eq_natAbs a
+  have hsb : b * b.sign = (b.natAbs : ℤ) := by
+    rw [mul_comm]; exact Int.sign_mul_self_eq_natAbs b
+  have key := ebGcd_bezout a.natAbs b.natAbs
+  linear_combination key + (ebGcd a.natAbs b.natAbs).2.1 * hsa
+    + (ebGcd a.natAbs b.natAbs).2.2 * hsb
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART V: COMPUTATIONAL INSTANCES (recorded as comments)
+-- ═══════════════════════════════════════════════════════════════
+
+-- The following witnesses were checked by `decide`/`native_decide` during
+-- development and are recorded here as documentation.  They are *consequences*
+-- of the universally-quantified theorems above, so they are stated as comments to
+-- keep this file's axiom footprint limited to the foundational three.
+--
+--   ebGcd 12 8 = (4, 1, -1)              -- 12·1 + 8·(-1) = 4 = gcd 12 8
+--   ebGcd 17 5 = (1, 3, -10)            -- 17·3 + 5·(-10) = 1 = gcd 17 5
+--   intExtBinaryGcd (-12) 8 = (4, -1, -1) -- (-12)·(-1) + 8·(-1) = 4
+
+end BezoutIdentityOQ01OQ01OQ02OQ01

--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "ann-ext-binary-overview",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 72 },
+    "type": "concept",
+    "title": "Tracking Bézout Coefficients Through Stein's Algorithm",
+    "content": "The parent entry **OQ-01-OQ-01-OQ-02** lifted Stein's binary GCD to ℤ but *borrowed* its Bézout witnesses from Mathlib's extended Euclidean (`Int.gcdA`, `Int.gcdB`), leaving as its headline open question whether the coefficients can be produced by the binary algorithm itself. This file answers yes: `ebGcd a b = (g, x, y)` threads a Bézout pair through every halving and subtraction step, and `ebGcd_bezout` proves $a x + b y = g$ with $x, y$ computed by Stein's iteration. The signed version `intExtBinaryGcd` folds the input signs onto the coefficients.",
+    "mathContext": "The **extended** Euclidean algorithm maintains a unimodular $2\\times2$ transform alongside the quotient–remainder recurrence. Stein's algorithm uses subtraction and halving instead, and the naïve coefficient recurrence wants to halve a coefficient that need not be even — the classic obstruction. The fix here is the *subtract-don't-rehalve* variant.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Stein's binary GCD (1967)",
+      "extended Euclidean algorithm",
+      "Bézout's identity",
+      "coefficient threading / unimodular transforms"
+    ],
+    "prerequisites": [
+      "binaryGcd on ℕ (BezoutIdentityOQ01OQ01)",
+      "intBinaryGcd on ℤ (BezoutIdentityOQ01OQ01OQ02)"
+    ]
+  },
+  {
+    "id": "ann-ext-binary-subtract-dont-rehalve",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 20, "endLine": 44 },
+    "type": "insight",
+    "title": "Subtract-Don't-Rehalve: Why Every Transform Is Exact",
+    "content": "The decisive design choice. The classic both-odd Stein step is $\\gcd(a,b) = \\gcd(a, (b-a)/2)$; this file uses $\\gcd(a,b) = \\gcd(a, b-a)$ instead. The difference of two odd numbers is even, so the classic step saves one halving — but it would force the coefficient recurrence to halve a quantity that is not provably even. Dropping the rehalve makes the subtraction-branch transform a plain integer identity $(x,y) \\mapsto (x-y, y)$, with no division. The algorithm stays a genuine binary GCD because the even-argument halving steps still strip every factor of two.",
+    "mathContext": "Termination is by $a + b$: each subtraction branch replaces $\\{a,b\\}$ by $\\{a, b-a\\}$ (sum strictly smaller since $a \\ge 1$), and each halving branch shrinks an argument. The both-odd difference $b - a$ is even but is *not* halved, trading one extra recursion step for an exact coefficient transform.",
+    "significance": "key",
+    "relatedConcepts": [
+      "binary GCD halving steps",
+      "termination by a + b",
+      "exact integer coefficient recurrence"
+    ],
+    "prerequisites": [
+      "parity arithmetic",
+      "well-founded recursion"
+    ]
+  },
+  {
+    "id": "ann-ext-binary-def",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 85, "endLine": 115 },
+    "type": "definition",
+    "title": "ebGcd: The Constructive Extended Binary GCD",
+    "content": "`ebGcd a b : ℕ × ℤ × ℤ` returns $(g, x, y)$. Both-even: recurse on $(a/2, b/2)$, double $g$, keep $(x,y)$. Single-even (say $a$ even, $b$ odd): recurse on $(a/2, b)$; if the carried $x$ is even use $(x/2, y)$, else $((x+b)/2,\\, y - a/2)$ — adding the odd $b$ makes $x+b$ even before halving. Both-odd $a \\le b$: recurse on $(a, b-a)$ with $(x-y, y)$. The carried gcd `r.1` is pulled out front of the inner parity `if` so that `(ebGcd a b).1` projects cleanly.",
+    "mathContext": "Each branch corresponds to one row of the transform table in the header. The single-even parity split is the only place coefficient division occurs, and it is always guarded so the halved quantity is even.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Stein's recurrences",
+      "parity-guarded halving",
+      "well-founded recursion on a + b"
+    ],
+    "prerequisites": [
+      "ℕ × ℤ × ℤ products and projections",
+      "termination_by / decreasing_by"
+    ]
+  },
+  {
+    "id": "ann-ext-binary-gcd-fst",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 124, "endLine": 156 },
+    "type": "proof-technique",
+    "title": "ebGcd_fst: gcd Component via the Grandparent Template",
+    "content": "`(ebGcd a b).1 = Nat.gcd a b`, proved by induction following the definition. Both-even uses `Nat.gcd_mul_left 2`; the single-even branches use coprimality cancellation `(Nat.coprime_two_left.mpr (Nat.odd_iff.mpr _)).gcd_mul_left_cancel`; the subtraction branches use `Nat.gcd_rec` twice plus the fact $(b - a) \\bmod a = b \\bmod a$, itself proved from `Nat.add_mod_right`. Because `ebGcd` shares its recursion shape with the verified grandparent `binaryGcd`, the proof is a branch-for-branch transcription of `binaryGcd_eq_gcd`.",
+    "mathContext": "$(b-a) \\bmod a = b \\bmod a$ holds for $a \\le b$ since $b = (b-a) + a$ and $(n+a) \\bmod a = n \\bmod a$. omega cannot do modulo by the *variable* $a$, so this step is a rewrite, not an omega call.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.gcd_rec",
+      "Nat.gcd_mul_left",
+      "coprimality cancellation",
+      "proof transcription from a verified template"
+    ],
+    "prerequisites": [
+      "binaryGcd_eq_gcd (grandparent)",
+      "Euclidean recurrence for gcd"
+    ]
+  },
+  {
+    "id": "ann-ext-binary-bezout",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 164, "endLine": 220 },
+    "type": "proof-technique",
+    "title": "ebGcd_bezout: One linear_combination Per Branch",
+    "content": "$(a:\\mathbb{Z})x + (b:\\mathbb{Z})y = g$, proved by induction. After `split_ifs` and projection reduction, each of the nine leaves closes by `linear_combination` of the inductive hypothesis with the relevant cast/parity facts: both-even contributes coefficient 2, the subtraction branches use $\\uparrow(b-a) = \\uparrow b - \\uparrow a$ (`Nat.cast_sub`), and the single-even branches split on coefficient parity and use $x = 2(x/2)$ or $x + b = 2((x+b)/2)$. Every auxiliary equation is `omega`-provable.",
+    "mathContext": "`linear_combination e` reduces the goal to `ring`-checking $\\text{lhs} - \\text{rhs} - e = 0$; the coefficient multipliers (e.g. $(x/2)$ on the cast fact $a = 2(a/2)$) are exactly those that cancel the division terms. omega supplies division/modulo-by-2 and ℕ→ℤ cast facts.",
+    "significance": "key",
+    "relatedConcepts": [
+      "linear_combination tactic",
+      "induction following a recursive definition",
+      "omega for division/modulo by 2",
+      "Nat.cast_sub"
+    ],
+    "prerequisites": [
+      "ring identities over ℤ",
+      "the coefficient transform table"
+    ]
+  },
+  {
+    "id": "ann-ext-binary-int",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 233, "endLine": 258 },
+    "type": "proof-technique",
+    "title": "intExtBinaryGcd: Folding Signs onto the Coefficients",
+    "content": "`intExtBinaryGcd a b := (↑g, a.sign * x, b.sign * y)` with $(g,x,y) = \\text{ebGcd}\\,|a|\\,|b|$. `intExtBinaryGcd_fst` shows the gcd value equals the parent `intBinaryGcd` (both are $\\uparrow(\\gcd |a| |b|)$, via `ebGcd_fst` and `binaryGcd_eq_gcd`). `intExtBinaryGcd_bezout` proves $a x + b y = g$ over ℤ: `Int.sign_mul_self_eq_natAbs` gives $a \\cdot \\operatorname{sign} a = |a|$, turning the ℕ-level identity into the signed one with a single `linear_combination` of `ebGcd_bezout`.",
+    "mathContext": "$a(\\operatorname{sign} a \\cdot x) = (a \\cdot \\operatorname{sign} a)x = |a|\\,x$. Signs are handled only at this boundary; the recursion never reasons about them, mirroring the parent's natAbs reduction.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Int.sign_mul_self_eq_natAbs",
+      "natAbs reduction",
+      "agreement with the parent intBinaryGcd"
+    ],
+    "prerequisites": [
+      "Int.sign and Int.natAbs",
+      "ebGcd_bezout, ebGcd_fst"
+    ]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,223 @@
+{
+  "id": "bezout-identity-oq-01-oq-01-oq-02-oq-01",
+  "title": "Extended Binary GCD: Tracking Bézout Coefficients Through Stein's Algorithm",
+  "slug": "bezout-identity-oq-01-oq-01-oq-02-oq-01",
+  "description": "Answers the open question posed by the parent entry: can Stein's binary GCD be extended to compute Bézout coefficients directly, rather than borrowing them from the extended Euclidean algorithm? Defines a constructive extended binary GCD ebGcd that threads a Bézout pair (x, y) through every halving and subtraction step, and proves a * x + b * y = gcd a b with witnesses produced by the binary algorithm itself. Lifts to ℤ by folding the input signs onto the coefficients. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm#Extension_to_signed_integers_and_other_rings",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "algorithm",
+      "gcd",
+      "bezout",
+      "extended-binary-gcd",
+      "constructive",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 272,
+    "assumptions": "",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "ebGcd: a constructive extended binary GCD over ℕ returning (g, x, y), threading Bézout coefficients through each step of Stein's algorithm",
+      "The subtract-don't-rehalve design: replacing the both-odd step gcd a b = gcd a ((b-a)/2) by gcd a b = gcd a (b-a), so no coefficient is ever halved in a subtraction branch (the classic extended-binary-GCD pitfall)",
+      "ebGcd_fst: the first component equals Nat.gcd a b (mirrors the verified grandparent binaryGcd_eq_gcd)",
+      "ebGcd_bezout / ebGcd_bezout_gcd: the threaded coefficients are a genuine Bézout witness a*x + b*y = gcd a b, proved branch-by-branch by linear_combination of the inductive hypothesis",
+      "intExtBinaryGcd: signed extension folding the input signs onto the coefficients via a.sign * a.natAbs = a",
+      "intExtBinaryGcd_fst: agrees with the parent intBinaryGcd",
+      "intExtBinaryGcd_bezout: the signed Bézout identity a*x + b*y = g over ℤ"
+    ],
+    "prerequisites": [
+      "BezoutIdentityOQ01OQ01OQ02 (Proofs/BezoutIdentityOQ01OQ01OQ02.lean): intBinaryGcd over ℤ",
+      "BezoutIdentityOQ01OQ01 (Proofs/BezoutIdentityOQ01OQ01.lean): binaryGcd for ℕ and binaryGcd_eq_gcd (the recursion-shape template for ebGcd_fst)",
+      "Mathlib Nat.gcd_rec, Nat.gcd_mul_left, Nat.Coprime.gcd_mul_left_cancel",
+      "Mathlib Int.sign_mul_self_eq_natAbs (sign folding)",
+      "linear_combination and omega tactics"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.gcd_rec",
+        "description": "gcd m n = gcd (n % m) m, the Euclidean recurrence used in the subtraction branches",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.gcd_mul_left",
+        "description": "gcd (k*m) (k*n) = k * gcd m n, used for the both-even branch",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.Coprime.gcd_mul_left_cancel",
+        "description": "When k is coprime to n, gcd (k*m) n = gcd m n, used for the single-even branches",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Int.sign_mul_self_eq_natAbs",
+        "description": "sign a * a = ↑a.natAbs, the identity that folds the input sign onto the Bézout coefficient",
+        "module": "Mathlib.Data.Int.Init"
+      },
+      {
+        "theorem": "Nat.add_mod_right",
+        "description": "(n + k) % k = n % k, used to prove (b - a) % a = b % a in the subtraction branches",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "theoremCount": 5,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "**Stein's binary GCD** (1967) computes $\\gcd(a,b)$ using only parity tests, right-shifts, and subtraction — no division. The **extended** Euclidean algorithm additionally returns Bézout coefficients $u, v$ with $ua + vb = \\gcd(a,b)$, by maintaining a $2\\times 2$ unimodular transform alongside the quotient-remainder recurrence. Doing the same for *Stein's* algorithm is subtler: the both-odd step replaces a pair by their difference, and the halving steps divide an even argument by two — and the naïve coefficient recurrence wants to halve a *coefficient*, which need not be even. Knuth sketches an extended binary GCD in TAOCP Vol. 2 (Ex. 4.5.2.39); the parent entry **OQ-01-OQ-01-OQ-02** left this as its headline open question, having borrowed its Bézout witnesses from Mathlib's extended Euclidean (`Int.gcdA`, `Int.gcdB`) rather than from the binary algorithm itself. This file answers that question constructively and proves the answer correct.",
+    "problemStatement": "Build an **extended binary GCD** `ebGcd a b = (g, x, y)` whose Bézout coefficients $x, y$ are produced *by Stein's iteration*, and prove:\n\n1. **gcd correctness**: $g = \\gcd(a, b)$ (`ebGcd_fst`).\n2. **Bézout identity**: $(a : \\mathbb{Z})\\,x + (b : \\mathbb{Z})\\,y = g$ (`ebGcd_bezout`, `ebGcd_bezout_gcd`).\n3. **integer extension**: a signed version `intExtBinaryGcd` agreeing with the parent `intBinaryGcd` (`intExtBinaryGcd_fst`) and satisfying $a\\,x + b\\,y = g$ over $\\mathbb{Z}$ (`intExtBinaryGcd_bezout`).\n\nAll with 0 axioms and 0 sorries.",
+    "text": "A constructive extended binary GCD that threads Bézout coefficients through Stein's halving/subtraction steps, with full machine-checked correctness — answering the parent's open question.",
+    "proofStrategy": "**Subtract-don't-rehalve, so every coefficient transform is an exact integer identity.** The key design choice is to use the both-odd step $\\gcd(a,b) = \\gcd(a, b-a)$ (for $a \\le b$) instead of the classic $\\gcd(a, (b-a)/2)$. This keeps the algorithm a genuine *binary* GCD — common factors of two are still stripped by halving even arguments — but ensures no coefficient is ever halved inside a subtraction branch, which is exactly where the naïve extended-binary-GCD recurrence breaks. Halving of coefficients occurs only in the two single-even branches, and there a parity case-split makes the carried coefficient even *before* the halve (when it is odd, adding the odd other-argument restores even parity). \n\n**gcd component** (`ebGcd_fst`): structural induction following the definition, mirroring the verified grandparent `binaryGcd_eq_gcd` (identical recursion shape). The both-even branch uses `Nat.gcd_mul_left`, the single-even branches use coprimality-cancellation `Nat.Coprime.gcd_mul_left_cancel`, and the subtraction branches use `Nat.gcd_rec` together with $(b - a) \\bmod a = b \\bmod a$ (proved from `Nat.add_mod_right`). \n\n**Bézout identity** (`ebGcd_bezout`): the same induction; each of the nine leaves closes by `linear_combination` of the inductive hypothesis with the relevant cast/parity facts, every one of which is `omega`-provable (omega handles division and modulo by the literal 2 over both ℕ and ℤ, including the ℕ→ℤ casts). The single-even branches additionally split on the carried coefficient's parity. \n\n**integer extension**: `intExtBinaryGcd a b := (↑g, a.sign · x, b.sign · y)` with $(g,x,y) = \\text{ebGcd}\\,|a|\\,|b|$. The gcd component agrees with the parent by `ebGcd_fst` + `binaryGcd_eq_gcd`; the Bézout identity uses `Int.sign_mul_self_eq_natAbs` ($a \\cdot \\operatorname{sign} a = |a|$) to fold the signs back, then `linear_combination` of the ℕ-level `ebGcd_bezout`.",
+    "keyInsights": [
+      "**Subtract-don't-rehalve is what makes the extension exact.** The classic Stein both-odd step $\\gcd(a,b) = \\gcd(a, (b-a)/2)$ would force the coefficient recurrence to halve a quantity that is not provably even, the standard obstruction to a clean extended binary GCD. Replacing it by $\\gcd(a,b) = \\gcd(a, b-a)$ makes every coefficient transform in the subtraction branches a plain integer identity $((x,y) \\mapsto (x-y, y))$, with no division at all. The algorithm still strips factors of two via the even-argument halving steps, so it remains a genuine binary GCD.",
+      "**Halving a coefficient is safe exactly when you first make it even.** The only divisions of *coefficients* happen in the single-even branches. There the recurrence wants $(x, y) \\mapsto (x/2, y)$, valid only when $x$ is even. When $x$ is odd, the algorithm instead uses $((x + b)/2, y - a/2)$: since $b$ is odd in that branch, $x + b$ is even, and the substitution preserves the Bézout invariant. This parity case-split is the entire subtlety of the construction — captured by a single `omega`-provable fact $x + b = 2\\big((x+b)/2\\big)$.",
+      "**The correctness proofs are a near-mechanical transcription of one verified template.** `ebGcd` has the same recursion shape as the grandparent `binaryGcd`, so `ebGcd_fst` follows `binaryGcd_eq_gcd` branch-for-branch. For the Bézout identity, each branch is a one-line `linear_combination` of the inductive hypothesis: the exact coefficients are dictated by the transform table, and every auxiliary cast/parity equation is discharged by `omega`. This is a reusable recipe for verifying *any* coefficient-threading variant of a recursive arithmetic algorithm.",
+      "**Signs are folded at the boundary, not handled in the loop.** As with the parent, the integer version reduces to `natAbs` and never reasons about signs inside the recursion. The one new ingredient is `a \\cdot \\operatorname{sign} a = |a|` (`Int.sign_mul_self_eq_natAbs`), which converts the ℕ-level identity $|a|\\,x + |b|\\,y = g$ into the signed identity $a\\,(\\operatorname{sign} a \\cdot x) + b\\,(\\operatorname{sign} b \\cdot y) = g$ in a single `linear_combination` step.",
+      "**This closes the parent's headline open question constructively.** Where `bezout_via_intBinaryGcd` *borrowed* its witnesses from Mathlib's extended Euclidean (`Int.gcdA`/`Int.gcdB`), `intExtBinaryGcd` *computes* them by Stein's iteration. The two agree on the gcd value (`intExtBinaryGcd_fst`), so this is a drop-in upgrade that makes the Bézout coefficients an output of the binary algorithm rather than an external import."
+    ],
+    "prerequisites": [
+      "Stein's binary GCD (1967) and its ℕ formalization binaryGcd (BezoutIdentityOQ01OQ01)",
+      "The parent integer extension intBinaryGcd (BezoutIdentityOQ01OQ01OQ02)",
+      "Bézout's identity and the extended Euclidean algorithm (for contrast)",
+      "Well-founded recursion with termination_by a + b",
+      "linear_combination for closing ring identities modulo hypotheses",
+      "omega for division/modulo-by-2 and ℕ→ℤ cast facts"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header and Algorithm Description",
+      "startLine": 1,
+      "endLine": 72,
+      "summary": "Poses the open question (track Bézout coefficients through Stein's iteration), presents the subtract-don't-rehalve design and the coefficient-transform table, and records the verified (0 sorry / 0 extra axiom) status.",
+      "mathContext": "The transform table gives, for each branch, the recursive subproblem and the new coefficient pair — e.g. both-odd $a \\le b$ recurses on $(a, b-a)$ with $(x,y) \\mapsto (x-y, y)$."
+    },
+    {
+      "id": "definition-ebgcd",
+      "title": "Part I: The Extended Binary GCD (ebGcd)",
+      "startLine": 74,
+      "endLine": 115,
+      "summary": "Defines ebGcd : ℕ → ℕ → ℕ × ℤ × ℤ by well-founded recursion on a + b, threading the Bézout pair through both-even, single-even (with an inner parity split), and subtraction branches. The carried gcd r.1 is pulled out front of the inner parity if for clean projection.",
+      "mathContext": "Returns $(g, x, y)$ with $g = \\gcd(a,b)$ and $a x + b y = g$. Termination is by $a + b$, strictly decreasing in every branch (each halve or subtract shrinks the sum)."
+    },
+    {
+      "id": "gcd-correctness",
+      "title": "Part II: GCD Component is Correct (ebGcd_fst)",
+      "startLine": 117,
+      "endLine": 156,
+      "summary": "Proves (ebGcd a b).1 = Nat.gcd a b by induction following the definition: both-even via Nat.gcd_mul_left, single-even via coprimality cancellation, subtraction via Nat.gcd_rec and (b - a) % a = b % a.",
+      "mathContext": "Mirrors the verified grandparent binaryGcd_eq_gcd; the recursion shape is identical, so the proof is a branch-for-branch transcription."
+    },
+    {
+      "id": "bezout-identity",
+      "title": "Part III: Bézout Identity (ebGcd_bezout)",
+      "startLine": 158,
+      "endLine": 230,
+      "summary": "Proves (a:ℤ)*x + (b:ℤ)*y = g for the threaded coefficients, by induction with one linear_combination per branch; single-even branches split on coefficient parity. ebGcd_bezout_gcd repackages it against Nat.gcd a b.",
+      "mathContext": "Each branch is an exact integer identity dictated by the transform table; the only divisions (single-even branches) are justified by omega-provable parity facts that make the halved quantity even first."
+    },
+    {
+      "id": "integer-extension",
+      "title": "Part IV: Integer Extension (intExtBinaryGcd)",
+      "startLine": 232,
+      "endLine": 258,
+      "summary": "Defines intExtBinaryGcd a b = (↑g, a.sign * x, b.sign * y) over the natAbs reduction, proves it agrees with the parent intBinaryGcd (intExtBinaryGcd_fst) and satisfies the signed Bézout identity (intExtBinaryGcd_bezout) via Int.sign_mul_self_eq_natAbs.",
+      "mathContext": "Sign folding: $a (\\operatorname{sign} a \\cdot x) = (a \\cdot \\operatorname{sign} a) x = |a|\\,x$, turning the ℕ-level identity into the signed one with a single cast lemma."
+    },
+    {
+      "id": "computational-instances",
+      "title": "Part V: Computational Instances",
+      "startLine": 260,
+      "endLine": 272,
+      "summary": "Worked witnesses recorded as comments (e.g. ebGcd 12 8 = (4, 1, -1), so 12·1 + 8·(-1) = 4; intExtBinaryGcd (-12) 8 = (4, -1, -1)). Stated as comments rather than native_decide goals to keep the file's axiom footprint to the foundational three.",
+      "mathContext": "Each instance is a consequence of the universally-quantified theorems above; they illustrate that the coefficients are genuinely computed by the algorithm."
+    }
+  ],
+  "conclusion": {
+    "summary": "Defines a constructive extended binary GCD ebGcd that threads Bézout coefficients through Stein's halving and subtraction steps, and proves — with 0 axioms and 0 sorries — that its first component is Nat.gcd a b and that the threaded coefficients satisfy a*x + b*y = gcd a b. A signed extension intExtBinaryGcd folds the input signs onto the coefficients, agrees with the parent intBinaryGcd, and satisfies the Bézout identity over ℤ. The decisive design choice is subtract-don't-rehalve, which makes every coefficient transform an exact integer identity and confines all coefficient halving to two parity-guarded branches.",
+    "implications": "This entry closes the headline open question of its parent: the Bézout coefficients of Stein's binary GCD can be computed by the algorithm itself, not borrowed from the extended Euclidean algorithm. The proof recipe — match the recursion shape of a verified gcd lemma, then close each Bézout branch by a linear_combination of the inductive hypothesis with omega-discharged cast/parity facts — transfers to other coefficient-threading variants of recursive arithmetic algorithms (e.g. the half-GCD, continued-fraction expansions, or modular-inverse routines). The subtract-don't-rehalve insight is itself reusable: when extending a subtractive algorithm to carry linear-algebraic state, prefer the variant whose state recurrence avoids division.",
+    "openQuestions": [
+      "Can the subtract-don't-rehalve variant be tuned to keep the Bézout coefficients bounded (|x| ≤ b/2g, |y| ≤ a/2g, the reduced witnesses), matching the size guarantees of the extended Euclidean algorithm?",
+      "Does the construction extend to a *certified executable* extended binary GCD competitive with GMP's mpn_gcdext, via Lean's native compilation?",
+      "Can the same coefficient-threading discipline be carried through the half-GCD subroutine to obtain a verified quasi-linear-time extended GCD?",
+      "Does ebGcd generalize to Bézout domains with a suitable 2-adic valuation (e.g. ℤ[i]), where 'halving' becomes division by a fixed prime element?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Direct parent. This entry answers the parent's open question (track Bézout coefficients through the binary algorithm) and provides intExtBinaryGcd, whose gcd value agrees with the parent's intBinaryGcd while computing the Bézout witnesses constructively rather than borrowing them from extended Euclidean."
+    },
+    {
+      "targetId": "bezout-identity-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent. ebGcd_fst mirrors the verified binaryGcd_eq_gcd (identical recursion shape), and ebGcd_bezout strengthens bezout_via_binaryGcd from an existence statement to a constructive coefficient-threading algorithm."
+    },
+    {
+      "targetId": "bezout-identity",
+      "relationship": "specializes-to",
+      "description": "Specializes the abstract Bézout identity to integers, with the witnesses produced by an extended binary GCD."
+    }
+  ],
+  "references": [
+    {
+      "title": "Computational problems associated with Racah algebra",
+      "author": "Josef Stein",
+      "year": "1967",
+      "venue": "Journal of Computational Physics 1, 397–405",
+      "description": "Original binary GCD algorithm."
+    },
+    {
+      "title": "The Art of Computer Programming, Volume 2: Seminumerical Algorithms",
+      "author": "Donald E. Knuth",
+      "year": "1997",
+      "venue": "Addison-Wesley, 3rd edition",
+      "description": "§4.5.2 and Exercise 4.5.2.39 sketch an extended binary GCD that tracks Bézout coefficients — the algorithmic gap this entry formalizes and proves correct."
+    },
+    {
+      "title": "A binary recursive gcd algorithm",
+      "author": "Damien Stehlé and Paul Zimmermann",
+      "year": "2004",
+      "venue": "ANTS-VI, LNCS 3076, 411–425",
+      "description": "Binary recursive (quasi-linear) GCD and its extended variant; context for the bounded-coefficient and half-GCD open questions."
+    },
+    {
+      "title": "GMP – The GNU Multiple Precision Arithmetic Library",
+      "author": "Torbjörn Granlund et al.",
+      "year": "ongoing",
+      "venue": "gmplib.org",
+      "description": "mpn_gcdext is the empirical reference for extended GCD; uses binary and half-GCD methods."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Int.GCD",
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Tactic",
+      "Proofs.BezoutIdentityOQ01OQ01OQ02"
+    ],
+    "namespace": "BezoutIdentityOQ01OQ01OQ02OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 272,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "path": "Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean"
+  },
+  "openQuestions": [
+    {
+      "id": "bezout-identity-oq-01-oq-01-oq-02-oq-01-oq-01",
+      "question": "Can the subtract-don't-rehalve extended binary GCD be tuned to return the size-reduced Bézout coefficients (|x| ≤ b/2g, |y| ≤ a/2g), matching the extended Euclidean algorithm's bounds?",
+      "significance": "medium"
+    }
+  ]
+}

--- a/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-02-oq-01.json
@@ -1,0 +1,121 @@
+{
+  "slug": "bezout-identity-oq-01-oq-01-oq-02-oq-01",
+  "title": "Extended Binary GCD: Tracking Bézout Coefficients Through Stein's Algorithm",
+  "phase": "COMPLETED",
+  "status": "graduated",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "Build an extended binary GCD ebGcd : \\mathbb{N} \\to \\mathbb{N} \\to \\mathbb{N} \\times \\mathbb{Z} \\times \\mathbb{Z} returning (g, x, y) whose Bézout coefficients are produced by Stein's iteration, and prove (1) (ebGcd a b).1 = \\mathrm{Nat.gcd}\\, a\\, b; (2) (a:\\mathbb{Z}) x + (b:\\mathbb{Z}) y = g; (3) a signed extension intExtBinaryGcd agreeing with the parent intBinaryGcd and satisfying a x + b y = g over \\mathbb{Z}.",
+    "plain": "The parent extended Stein's binary GCD to the integers but borrowed its Bézout coefficients from the extended Euclidean algorithm. Can the coefficients instead be computed by the binary algorithm itself — tracking a Bézout pair through every halving and subtraction step — and proved correct?",
+    "whyMatters": [
+      "Closes the headline open question of the parent entry (bezout-identity-oq-01-oq-01-oq-02): a constructive extended binary GCD rather than a fallback to extended Euclidean.",
+      "Stein's algorithm is used in GMP, OpenSSL, and Java BigInteger; an extended variant that tracks Bézout coefficients is the basis of modular-inverse and CRT routines.",
+      "Demonstrates a reusable proof recipe: match the recursion shape of a verified gcd lemma, then close each Bézout branch by linear_combination of the inductive hypothesis with omega-discharged cast/parity facts."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "ebGcd_fst: (ebGcd a b).1 = Nat.gcd a b",
+      "ebGcd_bezout: (a:ℤ)*x + (b:ℤ)*y = (ebGcd a b).1 for (x,y) = (ebGcd a b).2",
+      "ebGcd_bezout_gcd: the same identity against Nat.gcd a b",
+      "intExtBinaryGcd_fst: the signed extension agrees with the parent intBinaryGcd",
+      "intExtBinaryGcd_bezout: a*x + b*y = g over ℤ with signs folded onto the coefficients"
+    ],
+    "open": [
+      "Return the size-reduced Bézout coefficients (|x| ≤ b/2g, |y| ≤ a/2g) matching the extended Euclidean bounds.",
+      "A certified executable extended binary GCD competitive with GMP's mpn_gcdext via Lean native compilation.",
+      "Carry the coefficient-threading discipline through the half-GCD subroutine for a quasi-linear-time verified extended GCD."
+    ],
+    "goal": "0 sorries, 0 axioms — a constructive extended binary GCD with machine-checked gcd and Bézout correctness."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-19T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "Slug fully verified; all four correctness theorems discharged and confirmed axiom-free.",
+    "blockers": [],
+    "nextAction": "None on this slug. Natural follow-up: size-reduced coefficients or a half-GCD extension.",
+    "attemptCounts": {
+      "total": 3,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: 5 theorems + 2 defs, 0 sorries, 0 axioms (verified; #print axioms shows only propext/Classical.choice/Quot.sound). ebGcd threads a Bézout pair (x,y) through Stein's halving and subtraction steps using the subtract-don't-rehalve variant, so every coefficient transform is an exact integer identity. ebGcd_fst mirrors the verified grandparent binaryGcd_eq_gcd; ebGcd_bezout closes each branch by a single linear_combination of the inductive hypothesis with omega-provable cast/parity facts. intExtBinaryGcd folds the input signs onto the coefficients via Int.sign_mul_self_eq_natAbs and agrees with the parent intBinaryGcd.",
+    "builtItems": [
+      "Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean:85 — def ebGcd : ℕ → ℕ → ℕ × ℤ × ℤ (constructive extended binary GCD, well-founded on a + b)",
+      "Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean:124 — ebGcd_fst: first component is Nat.gcd a b",
+      "Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean:164 — ebGcd_bezout: the threaded coefficients satisfy a*x + b*y = g",
+      "Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean:222 — ebGcd_bezout_gcd: same against Nat.gcd",
+      "Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean:233 — def intExtBinaryGcd : ℤ → ℤ → ℤ × ℤ × ℤ (sign-folded extension)",
+      "Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean:239 — intExtBinaryGcd_fst: agrees with parent intBinaryGcd",
+      "Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean:247 — intExtBinaryGcd_bezout: signed Bézout identity over ℤ",
+      "src/data/proofs/bezout-identity-oq-01-oq-01-oq-02-oq-01/meta.json — gallery entry, status=verified, badge=original"
+    ],
+    "insights": [
+      "Subtract-don't-rehalve is the key: replacing the both-odd step gcd a b = gcd a ((b-a)/2) by gcd a b = gcd a (b-a) means no coefficient is ever halved in a subtraction branch, the classic extended-binary-GCD pitfall. The algorithm stays a binary GCD because even arguments are still halved.",
+      "Coefficient halving occurs only in the two single-even branches, and a parity case-split makes the carried coefficient even before the halve: when x is odd, x+b is even (b odd), so ((x+b)/2, y - a/2) preserves the Bézout invariant.",
+      "The correctness proofs are a near-mechanical transcription: ebGcd shares its recursion shape with the verified grandparent binaryGcd, so ebGcd_fst follows binaryGcd_eq_gcd branch-for-branch, and each ebGcd_bezout branch is one linear_combination of the IH with omega-discharged facts.",
+      "omega cannot prove (b - a) % a = b % a (modulo by the variable a is non-linear); use b = (b-a) + a and Nat.add_mod_right instead.",
+      "Sign folding is a single cast lemma: Int.sign_mul_self_eq_natAbs gives a * a.sign = ↑a.natAbs, turning the ℕ-level identity into the signed one in one linear_combination step.",
+      "Both backends (Docker, Aristotle MCP) were down across all three sessions; verification was achieved with single-file `lake env lean` against the prebuilt Mathlib oleans (no lake build, ~8s, bounded memory) after building the two parent oleans the same way."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Strengthen ebGcd to return the size-reduced (minimal) Bézout coefficients matching the extended Euclidean bounds.",
+      "Derive a verified modular inverse / CRT routine on top of intExtBinaryGcd.",
+      "Extend the coefficient-threading discipline to the half-GCD subroutine for quasi-linear-time extended GCD."
+    ],
+    "markdown": "# Knowledge Base: bezout-identity-oq-01-oq-01-oq-02-oq-01\n\n## Status\n\nVerified gallery entry. 5 theorems + 2 defs, 0 sorries, 0 axioms (#print axioms shows only the foundational three).\n\n## Key Technique\n\n**Subtract-don't-rehalve + linear_combination per branch.** The both-odd step uses gcd a b = gcd a (b-a) (no rehalve), making every coefficient transform an exact integer identity. Coefficient halving is confined to two parity-guarded single-even branches. ebGcd_fst mirrors the verified grandparent binaryGcd_eq_gcd; ebGcd_bezout closes each of the nine leaves by a single linear_combination of the inductive hypothesis with omega-provable cast/parity facts. The integer version folds signs onto the coefficients via Int.sign_mul_self_eq_natAbs.\n\n## Verification under a backend blackout\n\nDocker and the Aristotle MCP were both unavailable; the proof was machine-checked with single-file `lake env lean Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean` against the prebuilt Mathlib oleans (after building the two parent oleans the same way), which type-checks in ~8s with bounded memory and never invokes `lake build`.\n"
+  },
+  "tags": [
+    "seeker-selected",
+    "number-theory",
+    "algorithm",
+    "gcd",
+    "bezout",
+    "extended-binary-gcd",
+    "verified"
+  ],
+  "relatedProofs": [
+    "bezout-identity",
+    "bezout-identity-oq-01",
+    "bezout-identity-oq-01-oq-01",
+    "bezout-identity-oq-01-oq-01-oq-02",
+    "bezout-identity-oq-01-oq-01-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [
+      "Stein, J. (1967). Computational problems associated with Racah algebra. Journal of Computational Physics 1, 397–405.",
+      "Knuth, D. E. (1997). The Art of Computer Programming, Vol. 2, §4.5.2 and Ex. 4.5.2.39 (extended binary GCD)."
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Binary_GCD_algorithm#Extension_to_signed_integers_and_other_rings"
+    ],
+    "mathlib": [
+      "Mathlib.Data.Int.GCD",
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Data.Int.Init"
+    ]
+  },
+  "started": "2026-06-19T00:00:00.000Z",
+  "lastUpdate": "2026-06-19T12:00:00.000Z",
+  "completed": "2026-06-19T12:00:00.000Z",
+  "significance": 6,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01OQ02OQ01.lean",
+      "lineCount": 272,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **open question posed by the parent entry** `bezout-identity-oq-01-oq-01-oq-02`: can Stein's binary GCD be extended to compute Bézout coefficients *directly*, rather than borrowing them from the extended Euclidean algorithm? **Yes** — and this PR proves it correct.

`ebGcd a b = (g, x, y)` threads a Bézout pair `(x, y)` through every halving and subtraction step of Stein's algorithm, with the witnesses computed by the binary algorithm itself.

## What's proved (5 theorems, 2 defs)

- `ebGcd_fst`: `(ebGcd a b).1 = Nat.gcd a b` — mirrors the verified grandparent `binaryGcd_eq_gcd`.
- `ebGcd_bezout` / `ebGcd_bezout_gcd`: `(a:ℤ)*x + (b:ℤ)*y = gcd a b` — one `linear_combination` of the inductive hypothesis per branch.
- `intExtBinaryGcd_fst`: the signed extension agrees with the parent `intBinaryGcd`.
- `intExtBinaryGcd_bezout`: the signed Bézout identity `a*x + b*y = g` over ℤ.

## Key idea: subtract-don't-rehalve

The classic both-odd Stein step `gcd a b = gcd a ((b-a)/2)` is replaced by `gcd a b = gcd a (b-a)`. This keeps it a genuine binary GCD (even arguments are still halved) while making every coefficient transform an **exact integer identity** — no coefficient is ever halved in a subtraction branch (the classic extended-binary-GCD pitfall). Coefficient halving is confined to two parity-guarded single-even branches, where adding the odd other-argument restores even parity before the halve.

## Verification

**Fully machine-checked: 0 sorries, 0 axioms.** `#print axioms` on all five theorems shows only the foundational `propext`, `Classical.choice`, `Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`).

Both verification backends were down this cycle (Docker daemon unresponsive; Aristotle MCP returns `Resource not found`). Verification was achieved with single-file `lake env lean Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean` against the prebuilt Mathlib oleans (after building the two parent oleans the same way) — type-checks in ~8s with bounded memory and never invokes `lake build`.

## Files

- `proofs/Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean` (272 lines, verified)
- `src/data/proofs/bezout-identity-oq-01-oq-01-oq-02-oq-01/{meta.json,annotations.json}` — gallery entry (status `verified`, badge `original`)
- `src/data/research/problems/bezout-identity-oq-01-oq-01-oq-02-oq-01.json` — graduated research record

🤖 Generated with [Claude Code](https://claude.com/claude-code)