### PR TITLE
research(lagrange-theorem-oq-02-oq-02-oq-01-oq-02): p-group fixed-point congruence ⟹ nontrivial center

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ02.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ02.lean
@@ -1,0 +1,120 @@
+import Mathlib.GroupTheory.PGroup
+import Mathlib.Tactic
+
+/-
+# Fixed-Point Congruence and the Nontrivial Center of a p-Group
+# (lagrange-theorem-oq-02-oq-02-oq-01-oq-02)
+
+Lagrange's theorem (|H| divides |G|) is the gateway to the structure theory of
+finite groups.  A `p`-group — a finite group whose order is a power of a prime
+`p` — is the most rigid such structure, and the lever that controls it is a
+single counting congruence coming from group actions.
+
+**Burnside's fixed-point congruence.** If a `p`-group `G` acts on a finite set
+`α`, then
+
+    |α| ≡ |fixed points| (mod p),
+
+because every non-singleton orbit has size a positive power of `p` (orbit–
+stabilizer + Lagrange) and so vanishes mod `p`.
+
+Applying this to `G` acting on itself by **conjugation** turns the fixed-point set
+into the center `Z(G)`, and the congruence becomes the **class equation mod p**.
+Since `p ∣ |G|` for a nontrivial `p`-group, it forces `p ∣ |Z(G)|`, so the center
+cannot be trivial.  This is the cornerstone of the theory of `p`-groups (they are
+nilpotent; Sylow theory; the classification of small groups).
+
+This file packages the chain over Mathlib's `IsPGroup` development:
+
+  * `card_modEq_card_fixedPoints` — the fixed-point congruence;
+  * `nonempty_fixedPoints_of_not_dvd` — a fixed point exists when `p ∤ |α|`;
+  * `center_nontrivial` — a nontrivial finite `p`-group has nontrivial center;
+  * `bot_lt_center` — equivalently, `⊥ < Z(G)`;
+  * `p_dvd_card_center` — and `p` divides `|Z(G)|`.
+
+Each result is a thin wrapper around Mathlib's `IsPGroup` API; the contribution is
+the packaged, named exposition of the orbit-counting ⟹ center-nontriviality chain.
+
+Status: 0 axioms, 0 sorries
+-/
+
+namespace LagrangeTheoremOQ02OQ02OQ01OQ02
+
+open scoped Pointwise
+
+variable {p : ℕ} {G : Type*} [Group G] [Fact p.Prime] (hG : IsPGroup p G)
+
+include hG
+
+-- ============================================================================
+-- Part I: Burnside's fixed-point congruence
+-- ============================================================================
+
+/-- **Fixed-point congruence.** If a `p`-group `G` acts on a finite set `α`, the
+number of fixed points is congruent to `|α|` modulo `p`. Non-trivial orbits have
+size a positive power of `p`, hence vanish mod `p`. -/
+theorem card_modEq_card_fixedPoints (α : Type*) [MulAction G α] [Finite α] :
+    Nat.card α ≡ Nat.card (MulAction.fixedPoints G α) [MOD p] :=
+  IsPGroup.card_modEq_card_fixedPoints hG α
+
+/-- If a `p`-group acts on `α` and `p` does not divide `|α|`, then the action has
+a fixed point. The Cauchy/Cayley-style consequence of the congruence. -/
+theorem nonempty_fixedPoints_of_not_dvd (α : Type*) [MulAction G α]
+    (hpα : ¬ p ∣ Nat.card α) :
+    (MulAction.fixedPoints G α).Nonempty :=
+  IsPGroup.nonempty_fixed_point_of_prime_not_dvd_card hG α hpα
+
+-- ============================================================================
+-- Part II: The class equation and the center
+-- ============================================================================
+
+/-- **The center of a nontrivial finite `p`-group is nontrivial.** Applying the
+fixed-point congruence to conjugation (whose fixed points are the center) gives
+the class equation mod `p`; since `p ∣ |G|`, it forces `Z(G)` to be nontrivial. -/
+theorem center_nontrivial [Nontrivial G] [Finite G] :
+    Nontrivial (Subgroup.center G) :=
+  IsPGroup.center_nontrivial hG
+
+/-- Equivalently, the center strictly contains the trivial subgroup. -/
+theorem bot_lt_center [Nontrivial G] [Finite G] :
+    ⊥ < Subgroup.center G :=
+  IsPGroup.bot_lt_center hG
+
+/-- The prime `p` divides the order of the center of a nontrivial finite
+`p`-group: the center is itself a nontrivial `p`-group, so its order is a positive
+power of `p`. -/
+theorem p_dvd_card_center [Nontrivial G] [Finite G] :
+    p ∣ Nat.card (Subgroup.center G) := by
+  haveI := IsPGroup.center_nontrivial hG
+  obtain ⟨n, hn0, hn⟩ :=
+    (IsPGroup.nontrivial_iff_card (IsPGroup.to_subgroup hG (Subgroup.center G))).mp inferInstance
+  exact hn.symm ▸ dvd_pow_self p hn0.ne'
+
+-- ============================================================================
+-- Part III: Summary
+-- ============================================================================
+
+/-
+## Summary
+
+| Result | Statement | Backing |
+|--------|-----------|---------|
+| `card_modEq_card_fixedPoints` | \|α\| ≡ \|fix\| (mod p) | `IsPGroup.card_modEq_card_fixedPoints` |
+| `nonempty_fixedPoints_of_not_dvd` | p ∤ \|α\| ⟹ a fixed point exists | `IsPGroup.nonempty_fixed_point_of_prime_not_dvd_card` |
+| `center_nontrivial` | nontrivial p-group has nontrivial center | `IsPGroup.center_nontrivial` |
+| `bot_lt_center` | ⊥ < Z(G) | `IsPGroup.bot_lt_center` |
+| `p_dvd_card_center` | p ∣ \|Z(G)\| | `IsPGroup.nontrivial_iff_card` |
+
+The single congruence `|α| ≡ |fixed points| (mod p)` — itself a consequence of the
+orbit–stabilizer theorem and Lagrange — drives the entire structure theory of
+`p`-groups: nontriviality of the center (here), nilpotency, the existence of
+normal subgroups of every order dividing `|G|`, and, via Sylow's theorems, the
+local structure of every finite group.
+-/
+
+end LagrangeTheoremOQ02OQ02OQ01OQ02
+
+#check @LagrangeTheoremOQ02OQ02OQ01OQ02.card_modEq_card_fixedPoints
+#check @LagrangeTheoremOQ02OQ02OQ01OQ02.center_nontrivial
+#check @LagrangeTheoremOQ02OQ02OQ01OQ02.bot_lt_center
+#check @LagrangeTheoremOQ02OQ02OQ01OQ02.p_dvd_card_center

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ann-lg020201-congruence",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 47, "endLine": 64 },
+    "type": "technique",
+    "title": "Burnside's Fixed-Point Congruence",
+    "content": "card_modEq_card_fixedPoints is the engine: when a p-group G acts on a finite set α, orbit–stabilizer plus Lagrange force every orbit to have p-power size, so orbits of size > 1 contribute multiples of p. Hence |α| ≡ (number of singleton orbits) = |fixed points| (mod p). nonempty_fixedPoints_of_not_dvd is the immediate corollary: if p does not divide |α|, the fixed-point set cannot be empty — the counting argument behind Cauchy- and Cayley-style existence results."
+  },
+  {
+    "id": "ann-lg020201-center",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 65, "endLine": 90 },
+    "type": "concept",
+    "title": "The Class Equation and Center Nontriviality",
+    "content": "Specializing the congruence to G acting on itself by conjugation, the fixed points are exactly the center Z(G), and the congruence becomes the class equation mod p: |G| ≡ |Z(G)| (mod p). For a nontrivial p-group p ∣ |G|, so p ∣ |Z(G)|; since 1 ∈ Z(G) the center has positive p-divisible order and cannot be trivial. center_nontrivial and bot_lt_center record this; p_dvd_card_center sharpens it to p ∣ |Z(G)| by observing the center is itself a nontrivial p-group via IsPGroup.to_subgroup and IsPGroup.nontrivial_iff_card."
+  },
+  {
+    "id": "ann-lg020201-summary",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 91, "endLine": 120 },
+    "type": "concept",
+    "title": "Summary: One Congruence, Many Theorems",
+    "content": "The closing table pairs each step with its Mathlib backing. The single fixed-point congruence — itself a corollary of Lagrange and orbit–stabilizer — is the common source of center nontriviality (here), the nilpotency of p-groups (induct by quotienting out Z(G)), Cauchy's theorem, and the Sylow theorems. This entry isolates the first link, the one that makes the inductive structure theory of p-groups possible."
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "lagrange-theorem-oq-02-oq-02-oq-01-oq-02",
+  "title": "Lagrange Theorem OQ-02-02-01-02: Fixed-Point Congruence and the Nontrivial Center of a p-Group",
+  "slug": "lagrange-theorem-oq-02-oq-02-oq-01-oq-02",
+  "description": "Packages the orbit-counting chain that drives the structure theory of p-groups: a p-group acting on a finite set has fixed-point count ≡ |set| (mod p); applied to conjugation this is the class equation mod p, forcing the center of a nontrivial finite p-group to be nontrivial (and p ∣ |Z(G)|). Builds on Mathlib's IsPGroup.card_modEq_card_fixedPoints, center_nontrivial, and bot_lt_center. 5 theorems, 0 definitions, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ02.lean",
+    "tags": [
+      "group-theory",
+      "lagrange-theorem",
+      "p-groups",
+      "group-actions",
+      "burnside",
+      "class-equation",
+      "center"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified using Mathlib's IsPGroup development (card_modEq_card_fixedPoints, nonempty_fixed_point_of_prime_not_dvd_card, center_nontrivial, bot_lt_center, nontrivial_iff_card). Depends only on propext, Classical.choice, and Quot.sound.",
+    "lineCount": 120,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "card_modEq_card_fixedPoints: a p-group action has fixed-point count congruent to |α| mod p",
+      "nonempty_fixedPoints_of_not_dvd: if p ∤ |α| the action has a fixed point",
+      "center_nontrivial: a nontrivial finite p-group has nontrivial center, packaged from the class equation",
+      "p_dvd_card_center: p divides the order of the center of a nontrivial finite p-group"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Lagrange's theorem (1770–71), that the order of a subgroup divides the order of the group, is the oldest counting theorem in group theory and the foundation for everything that follows. Its sharpest consequences appear for p-groups, isolated by Sylow (1872) and Frobenius. The key device is the orbit-counting congruence: when a p-group acts on a finite set, all orbits have p-power size, so non-fixed points come in blocks divisible by p. Applied to a group acting on itself by conjugation it yields the class equation |G| = |Z(G)| + Σ [G : C_G(x)], from which Burnside and Frobenius deduced that a nontrivial p-group has nontrivial center — the seed of the fact that p-groups are nilpotent and have a full chain of normal subgroups. These ideas mature into the Sylow theorems, which control the local structure of every finite group.",
+    "problemStatement": "Formalize the chain: Burnside's fixed-point congruence for a p-group action (|α| ≡ |fixed points| mod p) ⟹ the class equation mod p ⟹ the center of a nontrivial finite p-group is nontrivial (and p divides its order).",
+    "text": "Let G be a p-group acting on a finite set α. By orbit–stabilizer and Lagrange, every orbit has size pᵏ; orbits of size > 1 contribute a multiple of p, so |α| ≡ (number of singleton orbits) = |fixed points| (mod p). Specializing to the conjugation action of G on itself, the fixed points are exactly the center Z(G), and the congruence is the class equation reduced mod p: |G| ≡ |Z(G)| (mod p). For a nontrivial p-group p ∣ |G|, hence p ∣ |Z(G)|; since the identity already lies in Z(G), its order is a positive multiple of p, so Z(G) ≠ 1.",
+    "proofStrategy": "Expose Mathlib's IsPGroup API as a named chain over a hypothesis hG : IsPGroup p G. card_modEq_card_fixedPoints and nonempty_fixedPoints_of_not_dvd wrap the corresponding IsPGroup lemmas. center_nontrivial and bot_lt_center wrap IsPGroup.center_nontrivial / bot_lt_center. For p_dvd_card_center, note the center is itself a nontrivial p-group (IsPGroup.to_subgroup), so IsPGroup.nontrivial_iff_card gives |Z(G)| = pⁿ with n > 0, whence p ∣ |Z(G)| by dvd_pow_self.",
+    "keyInsights": [
+      "A single congruence — fixed points ≡ |α| (mod p) — is the engine behind the entire structure theory of p-groups; everything else is a specialization of the acting set",
+      "Choosing the conjugation action converts the abstract fixed-point set into the center, turning the counting congruence into the class equation mod p",
+      "Nontriviality of the center is what lets one induct: quotienting by the center gives a smaller p-group, yielding nilpotency and a complete normal series",
+      "The same fixed-point congruence, applied to other actions, gives Cauchy's theorem and the Sylow theorems — the local-structure backbone of finite group theory"
+    ],
+    "prerequisites": [
+      "Lagrange's theorem and the orbit–stabilizer theorem",
+      "Group actions, orbits, and fixed points",
+      "p-groups: orders are prime powers (IsPGroup)",
+      "The class equation and the center of a group"
+    ]
+  },
+  "conclusion": {
+    "summary": "Fully machine-verified packaging of the p-group fixed-point congruence and its central consequence: a p-group action satisfies |α| ≡ |fixed points| (mod p), and applied to conjugation this forces the center of a nontrivial finite p-group to be nontrivial, with p dividing |Z(G)|. Zero axioms, zero sorries.",
+    "implications": "Nontriviality of the center is the inductive lever of p-group theory: quotienting by Z(G) repeatedly shows every finite p-group is nilpotent and possesses a normal subgroup of each order dividing |G|. The underlying fixed-point congruence also yields Cauchy's theorem (a prime dividing |G| produces an element of that order) and, via actions on coset spaces, the three Sylow theorems that govern the local structure of every finite group. The result is therefore a hinge between elementary counting (Lagrange) and the deep classification machinery of finite groups.",
+    "openQuestions": [
+      "Derive nilpotency of finite p-groups by induction on |G| using center nontriviality (quotient by Z(G))",
+      "Formalize the full class equation |G| = |Z(G)| + Σ [G : C_G(xᵢ)] and read center nontriviality off it directly",
+      "Prove Cauchy's theorem from the same fixed-point congruence applied to the ℤ/p action on p-tuples with product 1",
+      "Build toward the Sylow theorems via the p-group action on coset spaces"
+    ]
+  },
+  "leanFile": {
+    "namespace": "LagrangeTheoremOQ02OQ02OQ01OQ02",
+    "lineCount": 120,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "extends",
+      "description": "The parent entry establishes Lagrange's theorem (|H| divides |G|). This entry follows the chain into p-group structure theory: the orbit-counting congruence (a consequence of Lagrange + orbit–stabilizer) forces the center of a nontrivial finite p-group to be nontrivial."
+    }
+  ],
+  "sections": [
+    {
+      "id": "congruence",
+      "title": "Part I: Burnside's fixed-point congruence",
+      "startLine": 47,
+      "endLine": 64,
+      "summary": "card_modEq_card_fixedPoints: a p-group acting on a finite set has fixed-point count ≡ |α| (mod p), since non-trivial orbits have p-power size. nonempty_fixedPoints_of_not_dvd: if p ∤ |α|, a fixed point must exist."
+    },
+    {
+      "id": "center",
+      "title": "Part II: The class equation and the center",
+      "startLine": 65,
+      "endLine": 90,
+      "summary": "Applying the congruence to conjugation gives the class equation mod p. center_nontrivial and bot_lt_center: a nontrivial finite p-group has nontrivial center (⊥ < Z(G)). p_dvd_card_center: p divides |Z(G)|, since the center is itself a nontrivial p-group."
+    },
+    {
+      "id": "summary",
+      "title": "Part III: Summary",
+      "startLine": 91,
+      "endLine": 120,
+      "summary": "Tabulates the chain and situates the fixed-point congruence as the common engine of center nontriviality, nilpotency of p-groups, Cauchy's theorem, and the Sylow theorems."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Packages the orbit-counting chain that drives the structure theory of **p-groups**, culminating in the nontriviality of the center.

`proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ02.lean` (namespace `LagrangeTheoremOQ02OQ02OQ01OQ02`), **5 theorems, 0 definitions, 0 sorries, 0 axioms**.

### The chain
1. `card_modEq_card_fixedPoints` — a p-group acting on a finite set α has `|α| ≡ |fixed points| (mod p)` (non-trivial orbits have p-power size).
2. `nonempty_fixedPoints_of_not_dvd` — if `p ∤ |α|`, a fixed point exists.
3. Applied to **conjugation**, the fixed points are the center, so the congruence is the **class equation mod p**.
4. `center_nontrivial` / `bot_lt_center` — a nontrivial finite p-group has nontrivial center (`⊥ < Z(G)`).
5. `p_dvd_card_center` — moreover `p ∣ |Z(G)|`.

Built on Mathlib's `IsPGroup` API (`card_modEq_card_fixedPoints`, `nonempty_fixed_point_of_prime_not_dvd_card`, `center_nontrivial`, `bot_lt_center`, `to_subgroup`, `nontrivial_iff_card`). The same congruence underlies Cauchy's theorem and the Sylow theorems; center nontriviality is the inductive lever for nilpotency of p-groups.

> Note: branch is named `research/cayley-hamilton-minpoly-oq-06-similar-minpoly` (a leftover ref from a yielded claim) — the content and slug are `lagrange-theorem-oq-02-oq-02-oq-01-oq-02`.

### Verification
- Single-file `lake env lean proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ02.lean` against pinned **Mathlib v4.26.0** oleans: **exit 0**, all `#check`s resolve.
- `#print axioms center_nontrivial` and `p_dvd_card_center` → `[propext, Classical.choice, Quot.sound]` only (axiom-free).
- Full `docker-build` not run (host Docker unavailable this session); type-checked at single-file level. Deployer gates on the build.

Gallery entry at `src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-02/` (meta.json + annotations.json), badge `mathlib`, status `verified`, extends parent `lagrange-theorem`.

Closes research problem `lagrange-theorem-oq-02-oq-02-oq-01-oq-02`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)