### PR TITLE
Research: chinese-remainder-constructive-oq-04-oq-05 — effective canonical CRT solver

### DIFF
--- a/proofs/Proofs/ChineseRemainderConstructiveOQ04OQ05.lean
+++ b/proofs/Proofs/ChineseRemainderConstructiveOQ04OQ05.lean
@@ -1,0 +1,146 @@
+/-
+Chinese Remainder Theorem — Effective Canonical Solver (OQ-04-OQ-05)
+
+Extends ChineseRemainderConstructiveOQ04OQ04.lean. Where OQ-04-OQ-04 proves
+*non-constructively* that every pairwise-coprime system has a unique solution in
+[0, M) (reduce an arbitrary solution mod M), this file exhibits that witness as
+an explicit *computable* function `crtCanonical` by wrapping Mathlib's verified
+combinator `Nat.chineseRemainderOfList`, and bridges the two frameworks:
+
+  * the project's list-CRT (`CRTList.crt_list`, defined over `List (ℕ × ℕ)`), and
+  * Mathlib's `Nat.chineseRemainderOfList (a s : ι → ℕ)` over an index list.
+
+The system `sys : List (ℕ × ℕ)` is fed to Mathlib with `a = Prod.fst`,
+`s = Prod.snd`, `l = sys`, so `(sys.map Prod.snd).prod = moduliProd sys` and
+`Pairwise (Coprime on Prod.snd) sys ↔ (moduli sys).Pairwise Coprime`
+(via `List.pairwise_map`).
+
+Main results:
+- `crtCanonical`           : computable solver `List (ℕ × ℕ) → ℕ`
+- `crtCanonical_satisfies` : it solves the system
+- `crtCanonical_lt`        : it lands in [0, M)  (positive moduli)
+- `crtCanonical_eq_min`    : it equals the unique minimal solution of OQ-04-OQ-04
+- `crtCanonical_isLeast`   : it is the *least* element of the whole solution set
+- `sunzi_canonical_eq_23`  : the classic Sunzi system evaluates to 23
+
+No `axiom`s, no `sorry`, no `native_decide` (the worked example uses `decide`).
+-/
+
+import Proofs.ChineseRemainderConstructiveOQ04OQ04
+
+namespace CRTList
+
+open Nat
+open scoped Function -- `on` notation
+
+/-! ## Bridge to Mathlib's index-list CRT -/
+
+/-- Pairwise coprimality of the extracted moduli is exactly the
+    `Pairwise (Coprime on Prod.snd)` hypothesis Mathlib's
+    `chineseRemainderOfList` expects, via `List.pairwise_map`. -/
+lemma sys_pairwise_on_snd {sys : List (ℕ × ℕ)}
+    (hpc : (moduli sys).Pairwise Nat.Coprime) :
+    sys.Pairwise (Nat.Coprime on Prod.snd) := by
+  have h : (sys.map Prod.snd).Pairwise Nat.Coprime := hpc
+  exact (List.pairwise_map (R := Nat.Coprime) (f := Prod.snd) (l := sys)).mp h
+
+/-! ## Effective Canonical Solver -/
+
+/-- **Effective canonical CRT solver.** For a system with pairwise-coprime
+    moduli, returns the canonical representative in `{0, …, M−1}` produced by
+    Mathlib's `Nat.chineseRemainderOfList`. Unlike the existence proof of
+    OQ-04-OQ-04, this is a concrete computable function. -/
+def crtCanonical (sys : List (ℕ × ℕ))
+    (hpc : (moduli sys).Pairwise Nat.Coprime) : ℕ :=
+  (Nat.chineseRemainderOfList Prod.fst Prod.snd sys (sys_pairwise_on_snd hpc) : ℕ)
+
+/-- The canonical solver satisfies every congruence of the system: this is
+    exactly the defining property of `Nat.chineseRemainderOfList`. -/
+theorem crtCanonical_satisfies (sys : List (ℕ × ℕ))
+    (hpc : (moduli sys).Pairwise Nat.Coprime) :
+    Satisfies (crtCanonical sys hpc) sys := by
+  intro p hp
+  exact (Nat.chineseRemainderOfList Prod.fst Prod.snd sys
+    (sys_pairwise_on_snd hpc)).property p hp
+
+/-- The canonical solver lands in `[0, M)` (needs all moduli positive),
+    via Mathlib's `chineseRemainderOfList_lt_prod`. -/
+theorem crtCanonical_lt (sys : List (ℕ × ℕ))
+    (hpc : (moduli sys).Pairwise Nat.Coprime)
+    (hpos : ∀ p ∈ sys, 0 < p.2) :
+    crtCanonical sys hpc < moduliProd sys := by
+  have h := Nat.chineseRemainderOfList_lt_prod Prod.fst Prod.snd sys
+    (sys_pairwise_on_snd hpc) (fun p hp => (hpos p hp).ne')
+  simpa [moduliProd, moduli, crtCanonical] using h
+
+/-- Product of positive moduli is positive. -/
+lemma moduliProd_pos {sys : List (ℕ × ℕ)} (hpos : ∀ p ∈ sys, 0 < p.2) :
+    0 < moduliProd sys := by
+  simp only [moduliProd, moduli]
+  apply List.prod_pos
+  intro n hn
+  obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hn
+  exact hpos p hp
+
+/-! ## Bridge to the OQ-04-OQ-04 minimal representative -/
+
+/-- **Bridge.** Any solution `x` in `[0, M)` coincides with `crtCanonical`:
+    the explicit solver realises the unique minimal representative whose
+    existence/uniqueness was proved non-constructively in OQ-04-OQ-04. -/
+theorem crtCanonical_eq_min (sys : List (ℕ × ℕ))
+    (hpc : (moduli sys).Pairwise Nat.Coprime)
+    (hpos : ∀ p ∈ sys, 0 < p.2)
+    {x : ℕ} (hx : x < moduliProd sys) (hxs : Satisfies x sys) :
+    x = crtCanonical sys hpc :=
+  crt_list_minimal_unique sys hpc (moduliProd_pos hpos) hx
+    (crtCanonical_lt sys hpc hpos) hxs (crtCanonical_satisfies sys hpc)
+
+/-- **Order characterisation.** `crtCanonical` is the *least* element of the
+    entire solution set `{x | Satisfies x sys}`: it is a solution, and any
+    other solution `y` satisfies `crtCanonical ≤ y` because
+    `crtCanonical = y % M ≤ y`. -/
+theorem crtCanonical_isLeast (sys : List (ℕ × ℕ))
+    (hpc : (moduli sys).Pairwise Nat.Coprime)
+    (hpos : ∀ p ∈ sys, 0 < p.2) :
+    IsLeast {x | Satisfies x sys} (crtCanonical sys hpc) := by
+  refine ⟨crtCanonical_satisfies sys hpc, ?_⟩
+  intro y hy
+  have hlt := crtCanonical_lt sys hpc hpos
+  have hmod : crtCanonical sys hpc % moduliProd sys = y % moduliProd sys :=
+    crt_list_unique sys hpc (crtCanonical_satisfies sys hpc) hy
+  rw [Nat.mod_eq_of_lt hlt] at hmod
+  calc crtCanonical sys hpc = y % moduliProd sys := hmod
+    _ ≤ y := Nat.mod_le y _
+
+/-! ## Concrete Verification: The Sunzi Problem
+
+The classic Sunzi system
+  x ≡ 2 (mod 3),  x ≡ 3 (mod 5),  x ≡ 2 (mod 7)
+has canonical solution 23 in [0, 105). We compute it through the bridge,
+using `decide` (no `native_decide`, so the file remains axiom-free). -/
+
+theorem sunzi_canonical_eq_23
+    (hpc : (moduli [(2, 3), (3, 5), (2, 7)]).Pairwise Nat.Coprime) :
+    crtCanonical [(2, 3), (3, 5), (2, 7)] hpc = 23 := by
+  refine (crtCanonical_eq_min _ hpc ?_ ?_ ?_).symm
+  · decide                     -- hpos : ∀ p ∈ sys, 0 < p.2
+  · decide                     -- hx   : 23 < moduliProd sys
+  · intro p hp                 -- hxs  : Satisfies 23 sys
+    fin_cases hp <;> decide
+
+/-! ## Summary
+
+`crtCanonical` upgrades OQ-04-OQ-04 from an existence statement to an explicit
+algorithm:
+
+1. **Constructive**: a computable `List (ℕ × ℕ) → ℕ` returning the canonical
+   representative, built on Mathlib's certified `chineseRemainderOfList`.
+2. **Correct & bounded**: `crtCanonical_satisfies` + `crtCanonical_lt` place it
+   in `[0, M)` solving every congruence.
+3. **Canonical**: `crtCanonical_eq_min` identifies it with the unique minimal
+   representative of OQ-04-OQ-04, and `crtCanonical_isLeast` shows it is the
+   least element of the entire solution set — the sharpest possible
+   normal form.
+-/
+
+end CRTList

--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-05/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-05/annotations.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "ann-crt-canonical-overview",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 34
+    },
+    "type": "concept",
+    "title": "From Existence to Algorithm: An Explicit Canonical CRT Solver",
+    "content": "OQ-04-OQ-04 proved non-constructively that every pairwise-coprime system has a unique solution in [0, M): it reduces an arbitrary solution modulo M. This file makes that witness explicit. Mathlib already ships a certified combinator `Nat.chineseRemainderOfList (a s : ι → ℕ)` returning the bounded representative; feeding it `a = Prod.fst`, `s = Prod.snd`, `l = sys` yields a computable `crtCanonical : List (ℕ × ℕ) → ℕ`. The file then bridges back to the project's own framework, proving `crtCanonical` equals the OQ-04-OQ-04 minimal representative and is the least element of the whole solution set. Everything is discharged with `decide` rather than `native_decide`, so the entry is axiom-free.",
+    "mathContext": "$\\text{crtCanonical}(sys) = $ the unique $x \\in [0, M)$ with $x \\equiv a_i \\pmod{m_i}$, realised as Mathlib's $\\text{chineseRemainderOfList}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "Nat.chineseRemainderOfList",
+      "computable witness",
+      "canonical representative"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "CRT existence and uniqueness",
+      "Lean 4 and Mathlib"
+    ]
+  },
+  {
+    "id": "ann-crt-pairwise-bridge",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-05",
+    "range": {
+      "startLine": 36,
+      "endLine": 46
+    },
+    "type": "technique",
+    "title": "sys_pairwise_on_snd: List.pairwise_map as Hypothesis Glue",
+    "content": "Mathlib's combinator wants `sys.Pairwise (Coprime on Prod.snd)`, while the project carries `(moduli sys).Pairwise Coprime` where `moduli sys = sys.map Prod.snd`. The two are connected by `List.pairwise_map : (l.map f).Pairwise R ↔ l.Pairwise (R on f)`. The instance is supplied with explicit `R := Nat.Coprime` and `f := Prod.snd`; without them the unifier defaults `f` to the identity and the rewrite fails to typecheck.",
+    "mathContext": "$(\\,l.\\text{map } f).\\text{Pairwise } R \\iff l.\\text{Pairwise } (R \\text{ on } f)$, here $f = \\text{Prod.snd}$, $R = \\text{Coprime}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "List.pairwise_map",
+      "Function.onFun",
+      "pairwise coprimality"
+    ],
+    "prerequisites": [
+      "List.Pairwise",
+      "Lean unification of implicit arguments"
+    ]
+  },
+  {
+    "id": "ann-crt-solver",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-05",
+    "range": {
+      "startLine": 47,
+      "endLine": 83
+    },
+    "type": "concept",
+    "title": "crtCanonical: Correctness and the [0, M) Bound for Free",
+    "content": "`crtCanonical` is the coercion of `Nat.chineseRemainderOfList` to ℕ. Its two correctness facts come straight from Mathlib: `crtCanonical_satisfies` is the combinator's defining subtype property (`.property`), and `crtCanonical_lt` is `chineseRemainderOfList_lt_prod`, which needs each modulus nonzero — supplied as `(hpos p hp).ne'`. The helper `moduliProd_pos` proves M > 0 from positive moduli via `List.prod_pos`, feeding the uniqueness bridge below.",
+    "mathContext": "$0 \\le \\text{crtCanonical}(sys) < M = \\prod_i m_i$ and $\\text{crtCanonical}(sys) \\equiv a_i \\pmod{m_i}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.chineseRemainderOfList_lt_prod",
+      "List.prod_pos",
+      "subtype property"
+    ],
+    "prerequisites": [
+      "subtype coercion",
+      "Nat order and positivity"
+    ]
+  },
+  {
+    "id": "ann-crt-isleast",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-05",
+    "range": {
+      "startLine": 85,
+      "endLine": 113
+    },
+    "type": "insight",
+    "title": "crtCanonical_isLeast: The Sharpest Normal Form",
+    "content": "`crtCanonical_eq_min` identifies the explicit solver with OQ-04-OQ-04's unique minimal representative via `crt_list_minimal_unique`. `crtCanonical_isLeast` strengthens uniqueness-in-[0,M) to a genuine least-element statement: for any solution y, `crt_list_unique` gives crtCanonical ≡ y (mod M), and since crtCanonical < M, reduction yields crtCanonical = y % M ≤ y. Thus crtCanonical is the minimum of the entire solution set {x | Satisfies x sys}, expressed with `IsLeast`.",
+    "mathContext": "$\\text{IsLeast}\\,\\{x \\mid x \\equiv a_i \\ (m_i)\\ \\forall i\\}\\,(\\text{crtCanonical}\\,sys)$: it solves the system and $\\text{crtCanonical} = y \\bmod M \\le y$ for every solution $y$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsLeast",
+      "Nat.mod_le",
+      "least element of a set",
+      "canonical normal form"
+    ],
+    "prerequisites": [
+      "modular congruence",
+      "IsLeast / lower bounds"
+    ]
+  },
+  {
+    "id": "ann-crt-sunzi",
+    "proofId": "chinese-remainder-constructive-oq-04-oq-05",
+    "range": {
+      "startLine": 115,
+      "endLine": 129
+    },
+    "type": "example",
+    "title": "Sunzi Verified by decide: x = 23, Axiom-Free",
+    "content": "The classic Sunzi system x ≡ 2 (mod 3), x ≡ 3 (mod 5), x ≡ 2 (mod 7) is solved as 23 by routing through `crtCanonical_eq_min`: 23 < 105 and 23 satisfies the system, both discharged with `decide`. Using `decide` instead of `native_decide` keeps `#print axioms` at the foundational three — the entry is fully verified, unlike the `native_decide`-based sibling OQ-04-OQ-04.",
+    "mathContext": "$\\text{crtCanonical}\\,[(2,3),(3,5),(2,7)] = 23 \\in [0, 105)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Sunzi problem",
+      "decide vs native_decide",
+      "axiom-free verification"
+    ],
+    "prerequisites": [
+      "decidable propositions",
+      "modular arithmetic examples"
+    ]
+  }
+]

--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-05/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-05/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "chinese-remainder-constructive-oq-04-oq-05",
+  "title": "Effective Canonical CRT Solver",
+  "slug": "chinese-remainder-constructive-oq-04-oq-05",
+  "description": "Upgrades the minimal-representative CRT theorem (OQ-04-OQ-04) from a non-constructive existence statement to an explicit computable solver. By wrapping Mathlib's certified combinator `Nat.chineseRemainderOfList`, the function `crtCanonical` returns the canonical representative in [0, M), and is proved to coincide with the unique minimal solution — in fact to be the least element of the entire solution set. Fully machine-verified with no axioms.",
+  "meta": {
+    "author": "Classical (Sunzi / CRT), formalized via Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chinese_remainder_theorem",
+    "date": "3rd century",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChineseRemainderConstructiveOQ04OQ05.lean",
+    "tags": [
+      "number-theory",
+      "chinese-remainder-theorem",
+      "constructive",
+      "computable",
+      "canonical-form"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-19",
+    "mathlib_version": "4.26.0",
+    "lineCount": 146,
+    "assumptions": "None. All results — `crtCanonical_satisfies`, `crtCanonical_lt`, `crtCanonical_eq_min`, `crtCanonical_isLeast`, and the worked Sunzi example `sunzi_canonical_eq_23` — depend only on the standard foundational axioms `propext`, `Classical.choice`, `Quot.sound` (confirmed via `#print axioms`). Unlike the sibling OQ-04-OQ-04 (which uses `native_decide` and is therefore axiomatized), the Sunzi example here is discharged with `decide`, so the entry is fully verified with no `Lean.ofReduceBool` dependency.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.chineseRemainderOfList",
+        "description": "Certified combinator: the natural number < (l.map s).prod congruent to a i mod s i for all i ∈ l",
+        "module": "Mathlib.Data.Nat.ChineseRemainder"
+      },
+      {
+        "theorem": "Nat.chineseRemainderOfList_lt_prod",
+        "description": "The combinator's output is strictly less than the product of the moduli",
+        "module": "Mathlib.Data.Nat.ChineseRemainder"
+      },
+      {
+        "theorem": "List.pairwise_map",
+        "description": "(l.map f).Pairwise R ↔ l.Pairwise (R on f), bridging moduli-list coprimality to the index-list hypothesis",
+        "module": "Mathlib.Data.List.Pairwise"
+      },
+      {
+        "theorem": "List.prod_pos",
+        "description": "A product of positive list entries is positive",
+        "module": "Mathlib.Algebra.Order.BigOperators.GroupWithZero.List"
+      }
+    ],
+    "originalContributions": [
+      "crtCanonical: an explicit computable solver List (ℕ × ℕ) → ℕ wrapping Mathlib's index-list combinator, answering OQ-04-OQ-04's open question on extracting the constructive witness",
+      "sys_pairwise_on_snd: the bridge identifying moduli-list pairwise coprimality with Mathlib's `Pairwise (Coprime on Prod.snd)` hypothesis via `List.pairwise_map`",
+      "crtCanonical_eq_min: proof that the explicit solver realises the unique minimal representative of OQ-04-OQ-04",
+      "crtCanonical_isLeast: the sharp order characterisation — crtCanonical is the least element of the entire solution set {x | Satisfies x sys}",
+      "sunzi_canonical_eq_23: the classic Sunzi system evaluated to 23 through the bridge, using `decide` (axiom-free)"
+    ],
+    "prerequisites": [
+      "Chinese Remainder Theorem (pairwise coprime moduli)",
+      "Modular arithmetic and least-element (IsLeast) characterisations",
+      "Lean 4 and Mathlib"
+    ],
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "chinese-remainder-constructive-oq-04-oq-04",
+      "relationship": "extends",
+      "description": "Makes OQ-04-OQ-04's non-constructive minimal representative explicit: crtCanonical is the computable witness, proved equal to the unique solution in [0, M) and shown to be the least element of the solution set."
+    },
+    {
+      "targetId": "chinese-remainder-constructive-oq-04",
+      "relationship": "extends",
+      "description": "Builds on the arbitrary-length list CRT (existence + uniqueness modulo M) over List (ℕ × ℕ)."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Chinese Remainder Theorem traces to the 3rd-century mathematician Sun Tzu (Sunzi), whose classic problem asks for a number leaving remainders 2, 3, 2 when divided by 3, 5, 7 — the answer is 23. The general statement appears in Qin Jiushao's *Mathematical Treatise in Nine Sections* (1247) and Gauss's *Disquisitiones Arithmeticae* (1801). Modern algebra phrases it as the ring isomorphism $\\mathbb{Z}/M\\mathbb{Z} \\cong \\prod_i \\mathbb{Z}/m_i\\mathbb{Z}$. The element-level content is the *canonical representative* in $\\{0, \\ldots, M-1\\}$. Where OQ-04-OQ-04 proved this representative exists and is unique, the present entry exhibits it as a concrete algorithm, using Mathlib's certified `chineseRemainderOfList` (originally developed for Gödel's β-function in the incompleteness theorems).",
+    "problemStatement": "Given a system `sys : List (ℕ × ℕ)` of (remainder, modulus) pairs with pairwise coprime positive moduli and product $M$, produce an explicit computable $x = \\text{crtCanonical}(sys)$ with $0 \\le x < M$ and $x \\equiv a_i \\pmod{m_i}$ for every pair, and prove that $x$ is the unique such representative — indeed the least element of the whole solution set.",
+    "proofStrategy": "Feed the system to Mathlib's `Nat.chineseRemainderOfList` with `a = Prod.fst`, `s = Prod.snd`, `l = sys`, so that `(sys.map Prod.snd).prod = moduliProd sys`. The coprimality hypothesis is transported by `List.pairwise_map` (`sys_pairwise_on_snd`). Correctness (`crtCanonical_satisfies`) is the combinator's defining property; the bound (`crtCanonical_lt`) is `chineseRemainderOfList_lt_prod` given positive moduli. The bridge `crtCanonical_eq_min` invokes OQ-04-OQ-04's `crt_list_minimal_unique`. Finally `crtCanonical_isLeast` shows every solution $y$ satisfies $\\text{crtCanonical} = y \\bmod M \\le y$, using `crt_list_unique` and `Nat.mod_eq_of_lt`.",
+    "keyInsights": [
+      "The whole construction is a thin, certified wrapper: Mathlib's `chineseRemainderOfList` already returns the bounded representative, so `crtCanonical` inherits computability for free — directly answering the OQ-04-OQ-04 open question about extracting the constructive witness.",
+      "`List.pairwise_map` is the exact glue between the project's moduli-list phrasing `(moduli sys).Pairwise Coprime` and Mathlib's index-list phrasing `sys.Pairwise (Coprime on Prod.snd)`; providing `R` and `f` explicitly avoids the unifier defaulting `f` to the identity.",
+      "The order characterisation is sharper than uniqueness-in-[0,M): since any solution $y$ obeys $y \\equiv \\text{crtCanonical} \\pmod M$ and $\\text{crtCanonical} < M$, reduction gives $\\text{crtCanonical} = y \\bmod M \\le y$, so `crtCanonical` is literally the minimum of the solution set, expressed via `IsLeast`.",
+      "Choosing `decide` over `native_decide` for the Sunzi example keeps the entry axiom-free: `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`, in contrast to the `Lean.ofReduceBool` dependency of the sibling OQ-04-OQ-04."
+    ]
+  },
+  "sections": [
+    {
+      "id": "bridge",
+      "title": "Bridge to Mathlib's Index-List CRT",
+      "startLine": 36,
+      "endLine": 46,
+      "summary": "`sys_pairwise_on_snd`: pairwise coprimality of `moduli sys` is exactly the `Pairwise (Coprime on Prod.snd)` hypothesis Mathlib's `chineseRemainderOfList` expects, via `List.pairwise_map` with explicit `R` and `f`."
+    },
+    {
+      "id": "solver",
+      "title": "Effective Canonical Solver",
+      "startLine": 47,
+      "endLine": 83,
+      "summary": "`crtCanonical` wraps `Nat.chineseRemainderOfList` into a computable `List (ℕ × ℕ) → ℕ`. `crtCanonical_satisfies` (defining property) and `crtCanonical_lt` (`chineseRemainderOfList_lt_prod`) establish correctness and the [0, M) bound; `moduliProd_pos` supplies positivity of M."
+    },
+    {
+      "id": "bridge-min",
+      "title": "Bridge to the OQ-04-OQ-04 Minimal Representative",
+      "startLine": 85,
+      "endLine": 113,
+      "summary": "`crtCanonical_eq_min` identifies the explicit solver with the unique minimal solution via `crt_list_minimal_unique`. `crtCanonical_isLeast` strengthens this to: crtCanonical is the least element of {x | Satisfies x sys}, since crtCanonical = y % M ≤ y for every solution y."
+    },
+    {
+      "id": "sunzi",
+      "title": "Concrete Verification: The Sunzi Problem",
+      "startLine": 115,
+      "endLine": 129,
+      "summary": "`sunzi_canonical_eq_23` computes the canonical solution of x ≡ 2 (mod 3), x ≡ 3 (mod 5), x ≡ 2 (mod 7) as 23 through the bridge, discharged with `decide` so the file stays axiom-free."
+    }
+  ],
+  "conclusion": {
+    "summary": "The entry turns OQ-04-OQ-04's existence-and-uniqueness statement into an explicit algorithm: `crtCanonical` is a computable solver, certified correct and bounded, proved to be the unique minimal representative and the least element of the solution set. All results are machine-verified with no axioms beyond Lean's foundational three.",
+    "implications": "An explicit, certified canonical CRT solver underpins practical applications — RSA Chinese-remainder exponentiation, hashing, and modular computation — where one needs the actual representative, not merely its existence. The `IsLeast` characterisation pins down `crtCanonical` as the minimum-of-set normal form, the element-level realisation of the isomorphism $\\mathbb{Z}/M \\cong \\prod \\mathbb{Z}/m_i$.",
+    "openQuestions": [
+      "Can `crtCanonical` be connected to Mathlib's `ZMod.chineseRemainder` ring isomorphism, lifting the element-level solver to the ring-level statement?",
+      "Can the `IsLeast` characterisation be packaged as a `Nat`-valued `OrderBot`/`Nat.find`-style API for the solution set, giving a reusable canonical-form combinator?",
+      "Does an analogous least-representative solver exist for non-pairwise-coprime systems, replacing $\\prod m_i$ by $\\mathrm{lcm}$ and tracking the solvability condition $\\gcd(m_i, m_j) \\mid (a_i - a_j)$?"
+    ]
+  },
+  "references": [
+    {
+      "type": "book",
+      "title": "An Introduction to the Theory of Numbers",
+      "authors": [
+        "G.H. Hardy",
+        "E.M. Wright"
+      ],
+      "year": 1979,
+      "section": "§5.3"
+    }
+  ],
+  "leanFile": {
+    "lineCount": 146,
+    "path": "Proofs/ChineseRemainderConstructiveOQ04OQ05.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 7
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Upgrades the minimal-representative CRT theorem (**OQ-04-OQ-04**) from a *non-constructive existence* statement to an **explicit computable solver** — directly answering OQ-04-OQ-04's own open question about extracting the constructive witness.

Mathlib already ships a certified combinator `Nat.chineseRemainderOfList (a s : ι → ℕ)` returning the bounded representative. Feeding it `a = Prod.fst`, `s = Prod.snd`, `l = sys` gives a computable solver over the project's `List (ℕ × ℕ)` systems, which is then bridged back to the project's own list-CRT framework.

## New results (`Proofs/ChineseRemainderConstructiveOQ04OQ05.lean`)

| Declaration | Statement |
|---|---|
| `crtCanonical` | computable `List (ℕ × ℕ) → ℕ`, the canonical representative in `[0, M)` |
| `sys_pairwise_on_snd` | `(moduli sys).Pairwise Coprime` ⟹ `sys.Pairwise (Coprime on Prod.snd)` via `List.pairwise_map` |
| `crtCanonical_satisfies` | solves every congruence (combinator's defining property) |
| `crtCanonical_lt` | lands in `[0, M)` (`chineseRemainderOfList_lt_prod`, positive moduli) |
| `crtCanonical_eq_min` | equals OQ-04-OQ-04's unique minimal representative |
| `crtCanonical_isLeast` | **least** element of the entire solution set `{x \| Satisfies x sys}` |
| `sunzi_canonical_eq_23` | classic Sunzi system → 23, via `decide` |

The `IsLeast` characterisation is sharper than uniqueness-in-`[0,M)`: for any solution `y`, `crtCanonical ≡ y (mod M)` and `crtCanonical < M` give `crtCanonical = y % M ≤ y`.

## Verification

- **Fully verified, 0 axioms, 0 sorries.** `#print axioms` on all theorems lists only `propext`, `Classical.choice`, `Quot.sound`.
- Uses `decide` (not `native_decide`) for the Sunzi example, so — unlike the sibling OQ-04-OQ-04 — there is **no `Lean.ofReduceBool` dependency**.
- Compiled with `lake env lean` against pinned **Mathlib v4.26.0** via the Docker-independent single-file dependency-chain method (OQ04 → OQ04OQ04 → OQ04OQ05).

## Gallery

- `src/data/proofs/chinese-remainder-constructive-oq-04-oq-05/meta.json` (`status: verified`, `badge: verified`, `axiomCount: 0`)
- `annotations.json` (5 annotations)
- Cross-references: `extends` OQ-04-OQ-04 and OQ-04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)