### PR TITLE
research(cauchy-schwarz-oq-02-oq-02-oq-01-oq-01): RCLike Parseval completeness criterion

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -452,6 +452,7 @@ import Proofs.CauchySchwarzOQ01OQ04
 import Proofs.CauchySchwarzOQ02
 import Proofs.CauchySchwarzOQ02OQ01
 import Proofs.CauchySchwarzOQ02OQ02
+import Proofs.CauchySchwarzOQ02OQ02OQ01OQ01
 import Proofs.CauchySchwarzOQ02OQ03
 import Proofs.CauchySchwarzOQ03
 import Proofs.CauchySchwarzOQ03OQ01

--- a/proofs/Proofs/CauchySchwarzOQ02OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ02OQ02OQ01OQ01.lean
@@ -1,0 +1,162 @@
+/-
+  Parseval Completeness over RCLike Fields: an Orthonormal System is a
+  Hilbert Basis iff Parseval's Identity Holds
+  (cauchy-schwarz-oq-02-oq-02-oq-01-oq-01)
+
+  The parent `CauchySchwarzOQ02OQ02OQ01` (Parseval Completeness) proves, for a
+  *real* orthonormal family {vᵢ} in a Hilbert space F, the characterization
+
+    (∃ b : HilbertBasis ι ℝ F, ⇑b = v)  ↔  ∀ x, ∑' i, ⟨vᵢ, x⟩² = ‖x‖².
+
+  This file lifts that equivalence to an arbitrary `RCLike` field `𝕜`
+  (i.e. ℝ or ℂ).  Over ℂ the inner product is complex-valued, so the natural
+  Parseval statement replaces the square `⟨vᵢ, x⟩²` by the squared norm of the
+  complex Fourier coefficient:
+
+    (∃ b : HilbertBasis ι 𝕜 E, ⇑b = v)  ↔  ∀ x, ∑' i, ‖⟨vᵢ, x⟩‖² = ‖x‖².
+
+  Proof strategy:
+  * (⟹) Forward: a Hilbert basis satisfies Parseval.  Mathlib's
+    `HilbertBasis.hasSum_inner_mul_inner b x x` gives
+    `∑' i, ⟪x, b i⟫ * ⟪b i, x⟫ = ⟪x, x⟫` in `𝕜`.  Projecting onto the real part
+    (via the continuous ℝ-linear map `RCLike.reCLM`) and using
+    `conj z * z = ‖z‖²` together with `re ⟪x, x⟫ = ‖x‖²` turns this into the
+    real-valued Parseval identity `∑' i, ‖⟪b i, x⟫‖² = ‖x‖²`.
+  * (⟸) Reverse (field-agnostic): from Parseval the span of {vᵢ} has trivial
+    orthogonal complement — a vector orthogonal to every `vᵢ` has all Fourier
+    coefficients zero, so Parseval forces its norm to vanish.  Trivial
+    orthogonal complement is exactly the hypothesis of Mathlib's
+    `HilbertBasis.mkOfOrthogonalEqBot`, which manufactures the basis.
+
+  This is the "totality ⟺ Parseval" half of the standard equivalence
+  (orthonormal basis ⟺ complete ⟺ Parseval ⟺ total), now over any `RCLike`
+  scalar field.  Mathlib supplies the basis-construction machinery and the
+  bilinear Parseval identity; the bridge proved here packages them into the
+  norm-squared completeness criterion and supplies the reverse implication.
+
+  Status: 0 sorries, 0 axioms (no `native_decide`/`Lean.ofReduceBool`).
+-/
+
+import Mathlib.Analysis.InnerProductSpace.l2Space
+import Mathlib.Analysis.InnerProductSpace.Orthogonal
+import Mathlib.Tactic
+
+set_option linter.unusedSectionVars false
+
+open RCLike
+
+namespace ParsevalCompletenessRCLike
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]
+
+local notation "⟪" x ", " y "⟫" => inner 𝕜 x y
+
+-- ============================================================
+-- Section 1: Forward direction — a Hilbert basis satisfies Parseval
+-- ============================================================
+
+/-- **Parseval's identity over `RCLike`.** For a Hilbert basis `b` of `E` and
+any `x`, the squared norms of the Fourier coefficients sum to `‖x‖²`.
+
+The proof takes the real part of Mathlib's bilinear identity
+`∑' i, ⟪x, b i⟫ * ⟪b i, x⟫ = ⟪x, x⟫`, using `conj z * z = ‖z‖²` on each summand
+and `re ⟪x, x⟫ = ‖x‖²` on the total. -/
+theorem parseval_rclike {ι : Type*} (b : HilbertBasis ι 𝕜 E) (x : E) :
+    (∑' i, ‖⟪b i, x⟫‖ ^ 2) = ‖x‖ ^ 2 := by
+  -- Real part of the bilinear Parseval identity.
+  have h := (b.hasSum_inner_mul_inner x x).mapL (reCLM (K := 𝕜))
+  simp only [reCLM_apply] at h
+  -- Rewrite each summand `re (⟪x, b i⟫ * ⟪b i, x⟫)` to `‖⟪b i, x⟫‖²`.
+  have hsummand : (fun i => re (⟪x, b i⟫ * ⟪b i, x⟫)) = fun i => ‖⟪b i, x⟫‖ ^ 2 := by
+    funext i
+    rw [← inner_conj_symm x (b i), RCLike.conj_mul, ← RCLike.ofReal_pow, RCLike.ofReal_re]
+  rw [hsummand, inner_self_eq_norm_sq] at h
+  exact h.tsum_eq
+
+/-- **Forward direction.** If the orthonormal family `v` underlies a Hilbert
+basis `b` (i.e. `⇑b = v`), then Parseval's identity holds for every `x`. -/
+theorem parseval_of_hilbertBasis {ι : Type*} {v : ι → E}
+    (b : HilbertBasis ι 𝕜 E) (hb : ⇑b = v) (x : E) :
+    (∑' i, ‖⟪v i, x⟫‖ ^ 2) = ‖x‖ ^ 2 := by
+  subst hb
+  exact parseval_rclike b x
+
+-- ============================================================
+-- Section 2: Reverse direction — Parseval forces completeness
+-- ============================================================
+
+/-- **Completeness from Parseval.** If Parseval's identity holds for every `x`,
+then the span of the orthonormal family has trivial orthogonal complement.
+A vector orthogonal to every `vᵢ` has all Fourier coefficients zero, so
+Parseval makes its norm vanish. -/
+theorem orthogonalComplement_eq_bot_of_parseval {ι : Type*} {v : ι → E}
+    (hp : ∀ x, (∑' i, ‖⟪v i, x⟫‖ ^ 2) = ‖x‖ ^ 2) :
+    (Submodule.span 𝕜 (Set.range v))ᗮ = ⊥ := by
+  rw [Submodule.eq_bot_iff]
+  intro x hx
+  -- Every coefficient ⟨vᵢ, x⟩ vanishes since x ⟂ span{vᵢ} ∋ vᵢ.
+  have hzero : ∀ i, ⟪v i, x⟫ = 0 := fun i =>
+    Submodule.inner_right_of_mem_orthogonal
+      (Submodule.subset_span (Set.mem_range_self i)) hx
+  -- Hence the Parseval sum is zero.
+  have hsum : (∑' i, ‖⟪v i, x⟫‖ ^ 2) = 0 := by
+    have h0 : ∀ i, ‖⟪v i, x⟫‖ ^ 2 = 0 := fun i => by rw [hzero i, norm_zero]; ring
+    simp only [h0, tsum_zero]
+  -- Parseval then forces ‖x‖² = 0, so x = 0.
+  have hnorm : ‖x‖ ^ 2 = 0 := by rw [← hp x]; exact hsum
+  have hx0 : ‖x‖ = 0 := (pow_eq_zero_iff (by norm_num : (2 : ℕ) ≠ 0)).mp hnorm
+  exact norm_eq_zero.mp hx0
+
+-- ============================================================
+-- Section 3: Main characterization
+-- ============================================================
+
+/-- **Parseval Completeness Criterion over `RCLike`.** An orthonormal family `v`
+in a Hilbert space `E` over `𝕜` (ℝ or ℂ) underlies a Hilbert basis **iff**
+Parseval's identity `∑' i, ‖⟨vᵢ, x⟩‖² = ‖x‖²` holds for every `x`. -/
+theorem hilbertBasis_iff_parseval {ι : Type*} {v : ι → E} (hv : Orthonormal 𝕜 v) :
+    (∃ b : HilbertBasis ι 𝕜 E, ⇑b = v) ↔ ∀ x, (∑' i, ‖⟪v i, x⟫‖ ^ 2) = ‖x‖ ^ 2 := by
+  constructor
+  · rintro ⟨b, hb⟩ x
+    exact parseval_of_hilbertBasis b hb x
+  · intro hp
+    exact ⟨HilbertBasis.mkOfOrthogonalEqBot hv
+      (orthogonalComplement_eq_bot_of_parseval hp),
+      HilbertBasis.coe_mkOfOrthogonalEqBot hv _⟩
+
+/-- **Completeness ⟺ Parseval (no construction).** For an orthonormal family,
+trivial orthogonal complement of its span is equivalent to Parseval holding
+everywhere. -/
+theorem orthogonalComplement_eq_bot_iff_parseval {ι : Type*} {v : ι → E}
+    (hv : Orthonormal 𝕜 v) :
+    (Submodule.span 𝕜 (Set.range v))ᗮ = ⊥ ↔
+      ∀ x, (∑' i, ‖⟪v i, x⟫‖ ^ 2) = ‖x‖ ^ 2 := by
+  constructor
+  · intro hsp x
+    exact parseval_of_hilbertBasis (HilbertBasis.mkOfOrthogonalEqBot hv hsp)
+      (HilbertBasis.coe_mkOfOrthogonalEqBot hv hsp) x
+  · exact orthogonalComplement_eq_bot_of_parseval
+
+end ParsevalCompletenessRCLike
+
+-- ============================================================
+-- Examples
+-- ============================================================
+
+section Examples
+
+open ParsevalCompletenessRCLike
+
+/-- A genuine Hilbert basis (e.g. the standard basis of a complex `ℓ²` space)
+satisfies Parseval — an immediate consequence of the forward direction. -/
+example {𝕜 : Type*} [RCLike 𝕜] {ι : Type*} {E : Type*} [NormedAddCommGroup E]
+    [InnerProductSpace 𝕜 E] [CompleteSpace E] (b : HilbertBasis ι 𝕜 E) (x : E) :
+    (∑' i, ‖inner 𝕜 (b i) x‖ ^ 2) = ‖x‖ ^ 2 :=
+  parseval_rclike b x
+
+end Examples
+
+-- Axiom audit: confirms dependence only on standard foundational axioms
+-- (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`.
+#print axioms ParsevalCompletenessRCLike.hilbertBasis_iff_parseval

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "pcq2211-ann-01",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "concept",
+    "title": "Header, Imports, and Strategy",
+    "content": "The docstring states the goal: lift the real Parseval completeness criterion to an arbitrary `RCLike` field $\\mathbb{K}$ (ℝ or ℂ), settling the parent's open question oq-01. Over ℂ the inner product is sesquilinear, so the natural Parseval statement uses the squared norm of the (complex) Fourier coefficient: $(\\exists b : \\mathrm{HilbertBasis}\\ \\iota\\ \\mathbb{K}\\ E,\\ \\underline{b} = v) \\iff \\forall x, \\sum_i \\|\\langle v_i, x\\rangle\\|^2 = \\|x\\|^2$. The strategy is two-directional: the forward implication projects Mathlib's bilinear identity onto the real part, while the reverse implication transports field-agnostically from the real case. `Mathlib.Analysis.InnerProductSpace.l2Space` supplies both `HilbertBasis.hasSum_inner_mul_inner` and `HilbertBasis.mkOfOrthogonalEqBot`; `Mathlib.Analysis.InnerProductSpace.Orthogonal` supplies orthogonal-complement membership; `open RCLike` exposes `re`, `reCLM`, and `conj_mul`. The local notation `⟪x, y⟫` abbreviates `inner 𝕜 x y`.",
+    "mathContext": "Completeness criterion for orthonormal systems over an RCLike field: basis ⟺ totality ⟺ Parseval saturation. E is a Hilbert space: NormedAddCommGroup + InnerProductSpace 𝕜 + CompleteSpace, with 𝕜 = ℝ or ℂ.",
+    "significance": "supporting",
+    "relatedConcepts": ["Hilbert basis", "Parseval identity", "RCLike field", "sesquilinear form", "orthogonal complement", "completeness"],
+    "prerequisites": ["inner product spaces over ℝ and ℂ", "Hilbert space completeness", "Mathlib InnerProductSpace API"]
+  },
+  {
+    "id": "pcq2211-ann-02",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 55, "endLine": 83 },
+    "type": "key-step",
+    "title": "Forward Direction: Real-Part Projection of the Sesquilinear Parseval Identity",
+    "content": "`parseval_rclike` is the genuine new content the parent left open. Mathlib's `HilbertBasis.hasSum_inner_mul_inner b x x` provides the *sesquilinear* identity $\\sum_i \\langle x, b_i\\rangle\\,\\langle b_i, x\\rangle = \\langle x, x\\rangle$ in $\\mathbb{K}$. The proof applies the continuous $\\mathbb{R}$-linear real-part map `RCLike.reCLM` through the infinite sum via `HasSum.mapL` — legitimate because a continuous linear map commutes with `HasSum`. On each summand, `inner_conj_symm` rewrites $\\langle x, b_i\\rangle = \\overline{\\langle b_i, x\\rangle}$, so the term becomes $\\overline{z}\\,z$ with $z = \\langle b_i, x\\rangle$; `RCLike.conj_mul` collapses this to $\\|z\\|^2$ (coerced from ℝ), whose real part is $\\|z\\|^2$ (`RCLike.ofReal_re`, after `ofReal_pow`). On the total, `inner_self_eq_norm_sq` gives $\\operatorname{re}\\langle x, x\\rangle = \\|x\\|^2$. The resulting `HasSum (fun i => ‖⟨bᵢ,x⟩‖²) (‖x‖²)` yields the identity by `tsum_eq`. `parseval_of_hilbertBasis` then transports it to the family `v` along `⇑b = v` by `subst`.",
+    "mathContext": "Forward: $\\sum_i \\|\\langle b_i, x\\rangle\\|^2 = \\|x\\|^2$ for a Hilbert basis $b$ over $\\mathbb{K}$, obtained as $\\operatorname{re}$ of $\\sum_i \\langle x, b_i\\rangle\\langle b_i, x\\rangle = \\langle x, x\\rangle$ using $\\overline z z = \\|z\\|^2$.",
+    "significance": "critical",
+    "relatedConcepts": ["sesquilinear Parseval", "real part map reCLM", "HasSum.mapL", "conj z · z = ‖z‖²", "inner_conj_symm"],
+    "prerequisites": ["continuous linear maps commute with HasSum", "RCLike conjugation identities", "inner product conjugate symmetry"]
+  },
+  {
+    "id": "pcq2211-ann-03",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 85, "endLine": 110 },
+    "type": "key-step",
+    "title": "Reverse Direction: Parseval ⟹ Trivial Orthogonal Complement",
+    "content": "`orthogonalComplement_eq_bot_of_parseval` derives completeness (totality) from Parseval, and the argument is field-agnostic — it transports verbatim from the real case. Assuming Parseval holds for every $x$, it shows $(\\mathrm{span}_{\\mathbb{K}}\\{v_i\\})^\\perp = \\bot$. After `Submodule.eq_bot_iff`, take $x$ in the orthogonal complement. Since each $v_i$ lies in the span (`Submodule.subset_span (Set.mem_range_self i)`), membership forces $\\langle v_i, x\\rangle = 0$ for all $i$ via `Submodule.inner_right_of_mem_orthogonal`. Each coefficient norm then vanishes ($\\|0\\|^2 = 0$), so the Parseval sum collapses to $0$ (`tsum_zero`). Parseval equates this with $\\|x\\|^2$, giving $\\|x\\|^2 = 0$, and `pow_eq_zero_iff` + `norm_eq_zero` yield $x = 0$. The `CompleteSpace` hypothesis is unused here (the section-variable linter is disabled file-wide), confirming totality is a purely algebraic-geometric consequence of Parseval.",
+    "mathContext": "If $x \\perp v_i$ for all $i$ then by Parseval $\\|x\\|^2 = \\sum_i \\|\\langle v_i, x\\rangle\\|^2 = 0$, so $x = 0$. Trivial orthogonal complement is exactly the hypothesis of `HilbertBasis.mkOfOrthogonalEqBot`.",
+    "significance": "critical",
+    "relatedConcepts": ["totality", "orthogonal complement", "Submodule.eq_bot_iff", "tsum_zero", "field-agnostic argument"],
+    "prerequisites": ["orthogonal complement of a subspace", "tsum of a zero family", "span membership"]
+  },
+  {
+    "id": "pcq2211-ann-04",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 111, "endLine": 141 },
+    "type": "key-step",
+    "title": "Main Characterization: the iff over 𝕜",
+    "content": "`hilbertBasis_iff_parseval` assembles the criterion over an arbitrary RCLike field. Forward: `rintro ⟨b, hb⟩` and apply `parseval_of_hilbertBasis`. Reverse: from Parseval build the basis with `HilbertBasis.mkOfOrthogonalEqBot hv (orthogonalComplement_eq_bot_of_parseval hp)`, witnessed by `HilbertBasis.coe_mkOfOrthogonalEqBot` to confirm the constructed basis has underlying family $v$. `orthogonalComplement_eq_bot_iff_parseval` packages the same equivalence in construction-free form (totality ⟺ Parseval) — the cleanest internal completeness test, producing no `HilbertBasis` object. Together these are the standard 'orthonormal system is a basis iff it is total iff Parseval saturates' equivalence, now valid over both ℝ and ℂ.",
+    "mathContext": "$(\\exists b : \\mathrm{HilbertBasis}\\ \\iota\\ \\mathbb{K}\\ E,\\ \\underline{b} = v) \\iff \\forall x, \\sum_i \\|\\langle v_i, x\\rangle\\|^2 = \\|x\\|^2$, and the construction-free $(\\mathrm{span}_{\\mathbb{K}}\\{v_i\\})^\\perp = \\bot \\iff$ Parseval.",
+    "significance": "important",
+    "relatedConcepts": ["Hilbert basis construction", "mkOfOrthogonalEqBot", "completeness criterion", "totality ⟺ Parseval"],
+    "prerequisites": ["iff assembly", "HilbertBasis.mkOfOrthogonalEqBot interface"]
+  },
+  {
+    "id": "pcq2211-ann-05",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 143, "endLine": 162 },
+    "type": "concept",
+    "title": "Examples and Axiom Audit",
+    "content": "The example confirms a genuine Hilbert basis over $\\mathbb{K}$ (e.g. the standard basis of a complex $\\ell^2$ space) satisfies Parseval, applying `parseval_rclike` directly. The closing `#print axioms ParsevalCompletenessRCLike.hilbertBasis_iff_parseval` certifies the development depends only on Mathlib's standard foundational axioms — `propext`, `Classical.choice`, `Quot.sound` — with no `Lean.ofReduceBool` (no `native_decide`) and no `sorryAx`. The entry is fully machine-checked and axiom-free in the project's sense.",
+    "mathContext": "$\\sum_i \\|\\langle b_i, x\\rangle\\|^2 = \\|x\\|^2$ for a complex Hilbert basis; axiom audit yields [propext, Classical.choice, Quot.sound].",
+    "significance": "supporting",
+    "relatedConcepts": ["axiom audit", "ℓ² space", "verified proof"],
+    "prerequisites": ["#print axioms", "foundational axioms of Lean/Mathlib"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,224 @@
+{
+  "id": "cauchy-schwarz-oq-02-oq-02-oq-01-oq-01",
+  "title": "Parseval Completeness over RCLike Fields: Orthonormal System is a Hilbert Basis iff Parseval Holds",
+  "slug": "cauchy-schwarz-oq-02-oq-02-oq-01-oq-01",
+  "description": "Settles the parent's open question (cauchy-schwarz-oq-02-oq-02-oq-01, oq-01): the real Parseval completeness criterion is lifted to an arbitrary RCLike field 𝕜 (ℝ or ℂ). An orthonormal family {vᵢ} in a Hilbert space E over 𝕜 underlies a Hilbert basis if and only if Parseval's identity ∑' i, ‖⟨vᵢ, x⟩‖² = ‖x‖² holds for every x. The forward direction takes the real part of Mathlib's bilinear identity HilbertBasis.hasSum_inner_mul_inner via the continuous ℝ-linear map RCLike.reCLM, collapsing ⟨x,bᵢ⟩·⟨bᵢ,x⟩ = conj⟨bᵢ,x⟩·⟨bᵢ,x⟩ to ‖⟨bᵢ,x⟩‖²; the reverse direction (field-agnostic) derives trivial orthogonal complement from Parseval and invokes HilbertBasis.mkOfOrthogonalEqBot. 5 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ02OQ02OQ01OQ01.lean",
+    "tags": [
+      "inner-product-spaces",
+      "functional-analysis",
+      "hilbert-spaces",
+      "orthonormal-basis",
+      "parseval",
+      "complex-analysis",
+      "rclike",
+      "completeness",
+      "verified"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 162,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "None beyond Mathlib's standard foundational axioms (propext, Classical.choice, Quot.sound). No native_decide, so no Lean.ofReduceBool; no sorries. The space E is a Hilbert space over an RCLike field 𝕜 (NormedAddCommGroup + InnerProductSpace 𝕜 + CompleteSpace), covering both the real (ℝ) and complex (ℂ) cases.",
+    "mathlibDependencies": [
+      {
+        "theorem": "HilbertBasis.hasSum_inner_mul_inner",
+        "description": "The bilinear Parseval identity over 𝕜: ∑' i, ⟪x, b i⟫ * ⟪b i, y⟫ = ⟪x, y⟫ for a Hilbert basis b. Specialized at y = x and projected to the real part to obtain the norm-squared Parseval identity.",
+        "module": "Mathlib.Analysis.InnerProductSpace.l2Space"
+      },
+      {
+        "theorem": "RCLike.conj_mul",
+        "description": "conj z * z = ↑‖z‖² in an RCLike field — turns the diagonal term ⟨bᵢ,x⟩·conj⟨bᵢ,x⟩ into the squared norm of the Fourier coefficient.",
+        "module": "Mathlib.Analysis.RCLike.Basic"
+      },
+      {
+        "theorem": "RCLike.reCLM",
+        "description": "The real part as a continuous ℝ-linear map 𝕜 →L[ℝ] ℝ; applying it to a HasSum commutes with the infinite sum (HasSum.mapL), pushing the bilinear identity onto the real-valued Parseval identity.",
+        "module": "Mathlib.Analysis.RCLike.Basic"
+      },
+      {
+        "theorem": "inner_self_eq_norm_sq",
+        "description": "re ⟪x, x⟫ = ‖x‖² — identifies the real part of the total ⟪x, x⟫ with ‖x‖².",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "HilbertBasis.mkOfOrthogonalEqBot",
+        "description": "Manufactures a Hilbert basis from an orthonormal family whose span has trivial orthogonal complement: (span 𝕜 (range v))ᗮ = ⊥ ⟹ HilbertBasis. Drives the reverse direction.",
+        "module": "Mathlib.Analysis.InnerProductSpace.l2Space"
+      },
+      {
+        "theorem": "Submodule.inner_right_of_mem_orthogonal",
+        "description": "A vector in K is orthogonal to one in Kᗮ: u ∈ K, x ∈ Kᗮ ⟹ ⟪u, x⟫ = 0 — extracts vanishing Fourier coefficients from a totally-orthogonal vector.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Orthogonal"
+      }
+    ],
+    "originalContributions": [
+      "Forward direction over 𝕜 (parseval_rclike): projects Mathlib's bilinear Parseval identity HilbertBasis.hasSum_inner_mul_inner b x x onto the real part with RCLike.reCLM, then uses conj z · z = ‖z‖² (RCLike.conj_mul) on each summand and re ⟪x,x⟫ = ‖x‖² on the total to obtain the real-valued Parseval identity ∑' i, ‖⟨bᵢ,x⟩‖² = ‖x‖² — the 'complex Parseval without real-symmetry collapse' the parent left open",
+      "Reverse implication Parseval ⟹ completeness over 𝕜 (orthogonalComplement_eq_bot_of_parseval): if Parseval holds for every x then (span 𝕜 (range v))ᗮ = ⊥, since a vector orthogonal to every vᵢ has all coefficient norms zero and Parseval forces ‖x‖² = 0 — the argument is field-agnostic",
+      "Full iff characterization over 𝕜 (hilbertBasis_iff_parseval) packaging the forward (real-part projection) and reverse (mkOfOrthogonalEqBot) directions into the completeness criterion for any RCLike scalar field",
+      "Construction-free form orthogonalComplement_eq_bot_iff_parseval expressing completeness as totality ⟺ Parseval over 𝕜"
+    ],
+    "dateAdded": "2026-06-19",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The equivalence of completeness criteria for an orthonormal system — *basis* ⟺ *totality* ⟺ *Parseval saturation* ⟺ *Fourier expansion converges* — is the organizing theorem of Hilbert-space geometry, crystallized in von Neumann's 1929 axiomatization and standard since Stone's 1932 *Linear Transformations in Hilbert Space*. Over a complex Hilbert space the inner product is sesquilinear, so Parseval is naturally stated with the *squared norm* of the (complex) Fourier coefficient, $\\sum_i \\|\\langle v_i, x\\rangle\\|^2 = \\|x\\|^2$, rather than the bare square that suffices over $\\mathbb{R}$. The parent entry (`cauchy-schwarz-oq-02-oq-02-oq-01`, Parseval Completeness) proved the criterion over real Hilbert spaces and explicitly recorded its complex/RCLike generalization as open question oq-01, noting that 'the reverse (totality) argument is field-agnostic; only the forward Parseval algebra needs the complex bilinear form.' This entry settles that question for an arbitrary `RCLike` field $\\mathbb{K}$ (covering both $\\mathbb{R}$ and $\\mathbb{C}$).",
+    "problemStatement": "Let $\\{v_i\\}_{i \\in \\iota}$ be an orthonormal family in a Hilbert space $E$ over an `RCLike` field $\\mathbb{K}$. Prove the completeness criterion:\n$$\\big(\\exists\\, b : \\mathrm{HilbertBasis}\\ \\iota\\ \\mathbb{K}\\ E,\\ \\underline{b} = v\\big) \\iff \\forall x \\in E,\\ \\sum_i \\|\\langle v_i, x\\rangle\\|^2 = \\|x\\|^2.$$",
+    "proofStrategy": "**Forward** ($\\Rightarrow$): from a Hilbert basis $b$, Mathlib's `HilbertBasis.hasSum_inner_mul_inner b x x` gives $\\sum_i \\langle x, b_i\\rangle\\,\\langle b_i, x\\rangle = \\langle x, x\\rangle$ in $\\mathbb{K}$. Apply the continuous $\\mathbb{R}$-linear real-part map `RCLike.reCLM` through the sum (`HasSum.mapL`). On each summand, $\\langle x, b_i\\rangle = \\overline{\\langle b_i, x\\rangle}$ (`inner_conj_symm`), so $\\langle x, b_i\\rangle\\,\\langle b_i, x\\rangle = \\overline{z}\\,z = \\|z\\|^2$ with $z = \\langle b_i, x\\rangle$ (`RCLike.conj_mul`), whose real part is $\\|z\\|^2$; on the total, $\\operatorname{re}\\langle x, x\\rangle = \\|x\\|^2$ (`inner_self_eq_norm_sq`). This yields $\\sum_i \\|\\langle b_i, x\\rangle\\|^2 = \\|x\\|^2$. **Reverse** ($\\Leftarrow$): assume Parseval for all $x$; by `HilbertBasis.mkOfOrthogonalEqBot` it suffices to show $(\\mathrm{span}_{\\mathbb{K}}\\{v_i\\})^\\perp = \\bot$. For $x$ in this complement, each $\\langle v_i, x\\rangle = 0$ (`Submodule.inner_right_of_mem_orthogonal`), so the Parseval sum is $0$ and $\\|x\\|^2 = 0$, hence $x = 0$.",
+    "keyInsights": [
+      "**Real-part projection is the bridge to the complex case**: Mathlib supplies the *sesquilinear* Parseval identity $\\sum_i \\langle x, b_i\\rangle\\langle b_i, x\\rangle = \\langle x, x\\rangle$ valued in $\\mathbb{K}$. Pushing the continuous $\\mathbb{R}$-linear map $\\operatorname{re}$ through the infinite sum (`HasSum.mapL`) converts it to the real-valued norm-squared identity without re-deriving any analysis.",
+      "**$\\overline{z}\\,z = \\|z\\|^2$ collapses the diagonal**: the off-diagonal symmetry that makes the real case a bare square is replaced by the conjugate-product identity `RCLike.conj_mul`, which is exactly what turns each complex term into the squared modulus of a Fourier coefficient.",
+      "**The reverse direction is genuinely field-agnostic**: the totality argument (a vector orthogonal to all $v_i$ has vanishing Parseval sum, so zero norm) uses no conjugation and transports verbatim from $\\mathbb{R}$ to $\\mathbb{K}$.",
+      "**`mkOfOrthogonalEqBot` already works over $\\mathbb{K}$**: Mathlib's basis constructor is stated for any `RCLike` field, so only the forward Parseval algebra needed new work — precisely the gap the parent identified."
+    ]
+  },
+  "sections": [
+    {
+      "id": "section-forward",
+      "title": "Forward Direction — Hilbert Basis ⟹ Parseval over 𝕜",
+      "startLine": 55,
+      "endLine": 83,
+      "summary": "`parseval_rclike`: real part of HilbertBasis.hasSum_inner_mul_inner b x x via RCLike.reCLM, with conj z · z = ‖z‖² on each summand and re ⟪x,x⟫ = ‖x‖² on the total, gives ∑' i, ‖⟨bᵢ,x⟩‖² = ‖x‖². `parseval_of_hilbertBasis` transports it along ⇑b = v.",
+      "mathContext": "(∑' i, ‖⟪b i, x⟫‖²) = ‖x‖² for b : HilbertBasis ι 𝕜 E."
+    },
+    {
+      "id": "section-reverse",
+      "title": "Reverse Direction — Parseval ⟹ Completeness",
+      "startLine": 85,
+      "endLine": 110,
+      "summary": "`orthogonalComplement_eq_bot_of_parseval`: if Parseval holds for all x then (span 𝕜 (range v))ᗮ = ⊥. A vector orthogonal to every vᵢ has all coefficient norms zero, so the Parseval sum vanishes and forces ‖x‖² = 0. Field-agnostic.",
+      "mathContext": "(Submodule.span 𝕜 (Set.range v))ᗮ = ⊥, derived from ∀ x, ∑' i, ‖⟪v i, x⟫‖² = ‖x‖²."
+    },
+    {
+      "id": "section-main",
+      "title": "Main Characterization",
+      "startLine": 111,
+      "endLine": 141,
+      "summary": "`hilbertBasis_iff_parseval`: the iff over 𝕜 — an orthonormal family underlies a Hilbert basis iff Parseval holds everywhere. `orthogonalComplement_eq_bot_iff_parseval`: the construction-free totality ⟺ Parseval form.",
+      "mathContext": "(∃ b : HilbertBasis ι 𝕜 E, ⇑b = v) ↔ ∀ x, (∑' i, ‖⟪v i, x⟫‖²) = ‖x‖²."
+    },
+    {
+      "id": "section-examples",
+      "title": "Examples",
+      "startLine": 143,
+      "endLine": 160,
+      "summary": "A genuine Hilbert basis over 𝕜 (e.g. the standard basis of a complex ℓ² space) satisfies Parseval — the forward direction applied directly.",
+      "mathContext": "(∑' i, ‖inner 𝕜 (b i) x‖²) = ‖x‖² for b : HilbertBasis ι 𝕜 E."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry settles the parent's open question oq-01 by lifting the Parseval completeness criterion from real Hilbert spaces to an arbitrary RCLike field 𝕜 (ℝ or ℂ): an orthonormal family underlies a Hilbert basis if and only if ∑' i, ‖⟨vᵢ,x⟩‖² = ‖x‖² for every x. The new content is the forward direction over 𝕜 — real-part projection of Mathlib's sesquilinear Parseval identity, using conj z · z = ‖z‖² — while the reverse (totality) direction transports field-agnostically and is fed to HilbertBasis.mkOfOrthogonalEqBot.",
+    "implications": "The complex form is the version that actually powers Fourier analysis and spectral theory, where inner products are sesquilinear: completeness of the trigonometric exponentials in L²(ℂ), of eigenfunction systems of self-adjoint operators, and of wavelet/frame bases is precisely Parseval saturation with squared moduli. The construction-free totality ⟺ Parseval form gives the practical completeness test over either scalar field without exhibiting expansions.",
+    "openQuestions": [
+      "**TFAE bundle**: package totality, density of the span, Parseval saturation, and existence of a Hilbert basis structure over 𝕜 into a single TFAE statement.",
+      "**Quantitative defect over 𝕜**: relate the pointwise Parseval gap ‖x‖² − ∑ᵢ ‖⟨vᵢ,x⟩‖² to the squared distance from x to the closed span / the orthogonal-projection operator norm.",
+      "**Frames and Riesz bases**: weaken orthonormality to a frame condition and characterize the lower/upper frame bounds via a two-sided Parseval-type inequality."
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "oq-01",
+      "title": "TFAE Completeness Bundle over RCLike",
+      "description": "Package the equivalent completeness conditions — existence of a HilbertBasis structure, totality ((span 𝕜 (range v))ᗮ = ⊥), Parseval saturation ∑' i, ‖⟨vᵢ,x⟩‖² = ‖x‖², and convergence of the Fourier expansion to every x — into a single List.TFAE statement for orthonormal families over an arbitrary RCLike field.",
+      "difficulty": "moderate"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "cauchy-schwarz-oq-02-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "Parseval Completeness (real case) — proves the criterion over real Hilbert spaces and explicitly poses the complex/RCLike generalization as its open question oq-01, noting the reverse direction is field-agnostic and only the forward Parseval algebra needs the complex bilinear form. This entry settles that question."
+    },
+    {
+      "proofId": "cauchy-schwarz-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Bessel's Inequality in Infinite Dimensions — the grandparent that established Parseval for a real Hilbert basis; this entry reaches the analogous identity over 𝕜 by real-part projection of Mathlib's sesquilinear HilbertBasis.hasSum_inner_mul_inner."
+    },
+    {
+      "proofId": "cauchy-schwarz-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Parseval's Identity (Energy Conservation in Fourier Analysis) — the concrete trigonometric Parseval; this entry abstracts the criterion to arbitrary orthonormal families over any RCLike scalar field."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "hilbertBasis_iff_parseval",
+      "type": "theorem",
+      "statement": "$\\big(\\exists\\, b : \\mathrm{HilbertBasis}\\ \\iota\\ \\mathbb{K}\\ E,\\ \\underline{b} = v\\big) \\iff \\forall x,\\ \\sum_i \\|\\langle v_i, x\\rangle\\|^2 = \\|x\\|^2$",
+      "significance": "**Headline theorem**: the Parseval completeness criterion over an arbitrary RCLike field — an orthonormal family is a Hilbert basis exactly when Parseval saturates, settling the parent's open question oq-01.",
+      "description": "Forward: `rintro ⟨b, hb⟩` then `parseval_of_hilbertBasis`. Reverse: build the basis with `HilbertBasis.mkOfOrthogonalEqBot hv (orthogonalComplement_eq_bot_of_parseval hp)`, witnessed by `coe_mkOfOrthogonalEqBot`."
+    },
+    {
+      "name": "parseval_rclike",
+      "type": "theorem",
+      "statement": "$\\sum_i \\|\\langle b_i, x\\rangle\\|^2 = \\|x\\|^2$ for $b : \\mathrm{HilbertBasis}\\ \\iota\\ \\mathbb{K}\\ E$",
+      "significance": "**The new mathematical content**: the complex/RCLike Parseval identity obtained by real-part projection of Mathlib's sesquilinear identity — exactly the forward step the parent left open.",
+      "description": "Apply `RCLike.reCLM` through `HilbertBasis.hasSum_inner_mul_inner b x x` (`HasSum.mapL`). Rewrite each summand via `inner_conj_symm` and `RCLike.conj_mul` (conj z · z = ‖z‖²) and the total via `inner_self_eq_norm_sq`, then take `tsum_eq`."
+    },
+    {
+      "name": "orthogonalComplement_eq_bot_of_parseval",
+      "type": "theorem",
+      "statement": "$\\big(\\forall x,\\ \\sum_i \\|\\langle v_i, x\\rangle\\|^2 = \\|x\\|^2\\big) \\implies (\\mathrm{span}_{\\mathbb{K}}\\{v_i\\})^\\perp = \\bot$",
+      "significance": "Completeness (totality) from Parseval — the field-agnostic reverse implication, transporting verbatim from the real case.",
+      "description": "By `Submodule.eq_bot_iff`, take x in the orthogonal complement. Each ⟨vᵢ,x⟩ = 0 via `Submodule.inner_right_of_mem_orthogonal`. The Parseval sum is then 0 (`tsum_zero`), so ‖x‖² = 0, hence x = 0 via `pow_eq_zero_iff` and `norm_eq_zero`."
+    },
+    {
+      "name": "orthogonalComplement_eq_bot_iff_parseval",
+      "type": "theorem",
+      "statement": "$(\\mathrm{span}_{\\mathbb{K}}\\{v_i\\})^\\perp = \\bot \\iff \\forall x,\\ \\sum_i \\|\\langle v_i, x\\rangle\\|^2 = \\|x\\|^2$",
+      "significance": "Construction-free completeness criterion over 𝕜: totality ⟺ Parseval, stated without producing a HilbertBasis object.",
+      "description": "Forward: build a basis via `mkOfOrthogonalEqBot` and apply `parseval_of_hilbertBasis`. Reverse: directly `orthogonalComplement_eq_bot_of_parseval`."
+    },
+    {
+      "name": "parseval_of_hilbertBasis",
+      "type": "theorem",
+      "statement": "$\\underline{b} = v \\implies \\sum_i \\|\\langle v_i, x\\rangle\\|^2 = \\|x\\|^2$",
+      "significance": "Forward direction transported to the family v: substituting ⇑b = v reduces to parseval_rclike.",
+      "description": "`subst hb` replaces v by ⇑b, reducing the goal exactly to `parseval_rclike b x`."
+    }
+  ],
+  "references": [
+    {
+      "type": "textbook",
+      "citation": "Rudin, W. (1991). Functional Analysis (2nd ed.). McGraw-Hill, Theorem 4.18.",
+      "relevance": "States the equivalence basis ⟺ totality ⟺ Parseval ⟺ Fourier expansion for orthonormal systems in a (complex) Hilbert space — the classical statement this entry formalizes over any RCLike field."
+    },
+    {
+      "type": "textbook",
+      "citation": "Reed, M. and Simon, B. (1980). Methods of Modern Mathematical Physics, Vol. I: Functional Analysis (revised ed.). Academic Press, Theorem II.6.",
+      "relevance": "Standard graduate treatment of when an orthonormal set is a complete basis via vanishing of the orthogonal complement — the totality route taken in the reverse direction, valid over ℂ."
+    },
+    {
+      "type": "paper",
+      "citation": "von Neumann, J. (1929). \"Allgemeine Eigenwerttheorie Hermitescher Funktionaloperatoren.\" Mathematische Annalen 102, 49–131.",
+      "relevance": "Axiomatization of complex Hilbert space identifying completeness of an orthonormal system with the Fourier-coefficient map being unitary — exactly Parseval saturation with squared moduli."
+    },
+    {
+      "type": "library",
+      "citation": "The mathlib Community. \"Mathlib.Analysis.InnerProductSpace.l2Space — HilbertBasis.hasSum_inner_mul_inner, HilbertBasis.mkOfOrthogonalEqBot.\" (accessed 2026).",
+      "relevance": "Supplies the sesquilinear Parseval identity projected here onto the real part, and the basis-construction machinery driving the reverse direction."
+    },
+    {
+      "type": "library",
+      "citation": "The mathlib Community. \"Mathlib.Analysis.RCLike.Basic — RCLike.conj_mul, RCLike.reCLM.\" (accessed 2026).",
+      "relevance": "The conjugate-product identity conj z · z = ‖z‖² and the continuous real-part map that together convert the complex bilinear identity into the norm-squared Parseval identity."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/CauchySchwarzOQ02OQ02OQ01OQ01.lean",
+    "filename": "CauchySchwarzOQ02OQ02OQ01OQ01.lean",
+    "lineCount": 162,
+    "theoremCount": 5,
+    "axiomCount": 0,
+    "definitionCount": 0,
+    "sorries": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzOQ02OQ02OQ01OQ01.lean"
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Settles the parent's open question **oq-01** (`cauchy-schwarz-oq-02-oq-02-oq-01`, "Complex/RCLike Completeness Criterion") by lifting the real Parseval completeness criterion to an arbitrary `RCLike` field 𝕜 (ℝ or ℂ).

**Main theorem** (`hilbertBasis_iff_parseval`): an orthonormal family `v` in a Hilbert space `E` over 𝕜 underlies a Hilbert basis **iff** Parseval's identity holds for every `x`:

> (∃ b : HilbertBasis ι 𝕜 E, ⇑b = v)  ↔  ∀ x, ∑' i, ‖⟪vᵢ, x⟫‖² = ‖x‖²

## What's new

The parent proved the real case and explicitly recorded this generalization as oq-01, noting *"the reverse (totality) argument is field-agnostic; only the forward Parseval algebra needs the complex bilinear form."* This PR supplies exactly that forward algebra:

- **Forward** (`parseval_rclike`): project Mathlib's sesquilinear `HilbertBasis.hasSum_inner_mul_inner b x x` (`∑' i, ⟪x,bᵢ⟫·⟪bᵢ,x⟫ = ⟪x,x⟫`) onto the real part via the continuous ℝ-linear map `RCLike.reCLM` (`HasSum.mapL`). Each diagonal term `conj⟪bᵢ,x⟫·⟪bᵢ,x⟫` collapses to `‖⟪bᵢ,x⟫‖²` by `RCLike.conj_mul`; the total `re⟪x,x⟫` is `‖x‖²` by `inner_self_eq_norm_sq`.
- **Reverse** (`orthogonalComplement_eq_bot_of_parseval`): field-agnostic — Parseval forces `(span 𝕜 (range v))ᗮ = ⊥`, fed to `HilbertBasis.mkOfOrthogonalEqBot`.
- Construction-free form `orthogonalComplement_eq_bot_iff_parseval` (totality ⟺ Parseval).

## Verification

- 5 theorems, **0 sorries, 0 axioms**.
- Built via `lake env lean Proofs/CauchySchwarzOQ02OQ02OQ01OQ01.lean` against the pinned Mathlib v4.26.0 oleans (Docker build infra down this session; single-file type-check is sound against prebuilt oleans).
- `#print axioms hilbertBasis_iff_parseval` → `[propext, Classical.choice, Quot.sound]` (no `Lean.ofReduceBool`, no `sorryAx`).

## Files

- `proofs/Proofs/CauchySchwarzOQ02OQ02OQ01OQ01.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/cauchy-schwarz-oq-02-oq-02-oq-01-oq-01/{meta,annotations}.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)