### PR TITLE
research(quadratic-gauss-sum-square-oq-01): diagonal representation g = ∑ ψ(k²)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2854,6 +2854,7 @@ import Proofs.PythagoreanTriples
 import Proofs.PythagoreanTriplesOQ01
 import Proofs.PythagoreanTriplesOQ01Aristotle
 import Proofs.PythagoreanTriplesOQ02
+import Proofs.QuadraticGaussSumDiagonal
 import Proofs.QuadraticGaussSumSquare
 import Proofs.QuadraticGaussSumSquareOQ01
 import Proofs.QuadraticGaussSumSignReduction

--- a/proofs/Proofs/QuadraticGaussSumDiagonal.lean
+++ b/proofs/Proofs/QuadraticGaussSumDiagonal.lean
@@ -1,0 +1,109 @@
+/-
+  The diagonal representation of the quadratic Gauss sum.
+
+  Background.  For an odd prime `p` and a primitive additive character
+  `ψ : ZMod p → ℂ`, the quadratic Gauss sum is
+
+      gaussSum (chiC p) ψ = ∑ x, χ(x) · ψ(x),
+
+  where `χ = quadraticChar (ZMod p)` (the Legendre symbol).  The parent file
+  `QuadraticGaussSumSquare` works with this character-weighted form, and the
+  follow-up files reduce Gauss's hard sign theorem to a single positivity
+  `0 < Re g` (resp. `0 < Im g`), proved by hand only for the base cases `p = 3, 5`.
+
+  What this file contributes is the classical **diagonal representation**
+
+      gaussSum (chiC p) ψ = ∑ k, ψ(k²)        (ψ primitive),
+
+  i.e. the Gauss sum equals the *unweighted* sum of `ψ` over the perfect squares
+  (with multiplicity).  This is the universal starting point of every classical
+  proof of the sign theorem:
+
+    * with the standard character `ψ(x) = ζ_p^x` it becomes `g = ∑ ζ_p^{k²}`,
+      the form Gauss, Schur, Dirichlet and Kronecker all evaluate;
+    * it immediately recovers the small-prime evaluations as plain finite sums
+      `∑ ζ^{k²}` with no Legendre-symbol bookkeeping;
+    * it reframes the open crux `0 < Re g` as the positivity of a sum of
+      cosines `∑ cos(2π k²/p)`.
+
+  Mathlib (v4.26.x) has the square identity `gaussSum_sq` and the square-root
+  count `quadraticChar_card_sqrts`, but no diagonal/`k²` form of the Gauss sum.
+
+  The proof is elementary fibre counting: grouping `∑ k, ψ(k²)` by the value
+  `t = k²` turns the multiplicity of `t` into `#{k : k² = t} = χ(t) + 1`
+  (`quadraticChar_card_sqrts`), so
+
+      ∑ k, ψ(k²) = ∑ t, (χ(t) + 1) · ψ(t) = gaussSum (chiC p) ψ + ∑ t, ψ(t),
+
+  and the trailing sum vanishes because `ψ` is nontrivial
+  (`AddChar.sum_eq_zero_of_ne_one`).
+
+  Sorry-free and axiom-free (ordinary `propext`/`Classical.choice`/`Quot.sound`).
+-/
+import Mathlib
+import Proofs.QuadraticGaussSumSquare
+
+open scoped BigOperators
+open Finset QuadraticGaussSumSquare
+
+namespace QuadraticGaussSumDiagonal
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-- The number of square roots of `t` in `ZMod p`, viewed in `ℂ`, equals
+`chiC p t + 1`.  This is `quadraticChar_card_sqrts` transported to `ℂ` through the
+ring hom `ℤ → ℂ` defining `chiC`. -/
+theorem card_sqrts_cast (hp : p ≠ 2) (t : ZMod p) :
+    ((univ.filter (fun x : ZMod p => x ^ 2 = t)).card : ℂ) = chiC p t + 1 := by
+  have hp2 : ringChar (ZMod p) ≠ 2 := by
+    rw [ZMod.ringChar_zmod_n]; exact hp
+  -- Mathlib: `#{x | x^2 = t}.toFinset = quadraticChar (ZMod p) t + 1`  (in ℤ)
+  have hZ : ((univ.filter (fun x : ZMod p => x ^ 2 = t)).card : ℤ)
+      = quadraticChar (ZMod p) t + 1 := by
+    rw [← Set.toFinset_setOf]
+    exact_mod_cast quadraticChar_card_sqrts hp2 t
+  have hC : ((univ.filter (fun x : ZMod p => x ^ 2 = t)).card : ℂ)
+      = ((quadraticChar (ZMod p) t : ℤ) : ℂ) + 1 := by exact_mod_cast hZ
+  rw [hC, chiC, MulChar.ringHomComp_apply]
+  simp
+
+/-- **Diagonal representation of the quadratic Gauss sum.**  For an odd prime `p`
+and a *primitive* additive character `ψ : ZMod p → ℂ`, the Gauss sum of the
+Legendre-symbol character equals the unweighted sum of `ψ` over squares:
+
+    gaussSum (chiC p) ψ = ∑ k, ψ(k²).
+
+Every classical proof of Gauss's sign theorem starts here. -/
+theorem gaussSum_chiC_eq_sum_sq (hp : p ≠ 2)
+    {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    gaussSum (chiC p) ψ = ∑ k : ZMod p, ψ (k ^ 2) := by
+  have hψ1 : ψ ≠ 1 := by
+    have h := hψ (a := (1 : ZMod p)) one_ne_zero
+    rwa [AddChar.mulShift_one] at h
+  simp only [gaussSum]
+  -- goal: ∑ a, chiC p a * ψ a = ∑ k, ψ (k ^ 2)
+  symm
+  calc ∑ k : ZMod p, ψ (k ^ 2)
+      = ∑ t : ZMod p, ∑ k ∈ univ.filter (fun k => k ^ 2 = t), ψ (k ^ 2) :=
+        (Finset.sum_fiberwise_of_maps_to (fun k _ => Finset.mem_univ _) _).symm
+    _ = ∑ t : ZMod p, ∑ _k ∈ univ.filter (fun k => k ^ 2 = t), ψ t := by
+        refine Finset.sum_congr rfl (fun t _ => Finset.sum_congr rfl (fun k hk => ?_))
+        rw [Finset.mem_filter] at hk
+        rw [hk.2]
+    _ = ∑ t : ZMod p, (univ.filter (fun k => k ^ 2 = t)).card • ψ t := by
+        refine Finset.sum_congr rfl (fun t _ => ?_)
+        rw [Finset.sum_const]
+    _ = ∑ t : ZMod p, ((univ.filter (fun k => k ^ 2 = t)).card : ℂ) * ψ t := by
+        refine Finset.sum_congr rfl (fun t _ => ?_)
+        rw [nsmul_eq_mul]
+    _ = ∑ t : ZMod p, (chiC p t + 1) * ψ t := by
+        refine Finset.sum_congr rfl (fun t _ => ?_)
+        rw [card_sqrts_cast hp t]
+    _ = (∑ t : ZMod p, chiC p t * ψ t) + ∑ t : ZMod p, ψ t := by
+        rw [← Finset.sum_add_distrib]
+        refine Finset.sum_congr rfl (fun t _ => ?_)
+        ring
+    _ = ∑ t : ZMod p, chiC p t * ψ t := by
+        rw [AddChar.sum_eq_zero_of_ne_one hψ1, add_zero]
+
+end QuadraticGaussSumDiagonal

--- a/research/problems/quadratic-gauss-sum-square-oq-01/knowledge.md
+++ b/research/problems/quadratic-gauss-sum-square-oq-01/knowledge.md
@@ -91,3 +91,40 @@ both routes, so it is reusable groundwork rather than throwaway.
 
 ### Next steps
 - `p = 7` (next `p ≡ 3 mod 4`) as a further witness, or pivot to the general DFT route.
+
+## Session 2026-06-19 (Session 4) — diagonal representation g = ∑ ψ(k²)
+
+**Mode:** FRESH (depth-first on existing MODERATE knowledge) · **Outcome:** progress (verified reusable infrastructure)
+
+### What I did
+- New companion file `Proofs/QuadraticGaussSumDiagonal.lean` (verified, axiom-free):
+  - `card_sqrts_cast` — `(#{x : ZMod p | x² = t}.card : ℂ) = chiC p t + 1`, the ℂ-transport
+    of Mathlib's `quadraticChar_card_sqrts` through the ring hom `ℤ → ℂ` defining `chiC`.
+  - `gaussSum_chiC_eq_sum_sq` — **`gaussSum (chiC p) ψ = ∑ k, ψ(k²)`** for any primitive
+    additive character `ψ`. Proof: `Finset.sum_fiberwise_of_maps_to` groups `∑ ψ(k²)` by the
+    value `t = k²`; the fibre `{k : k² = t}` has size `χ(t)+1`, so
+    `∑ ψ(k²) = ∑ (χ(t)+1)·ψ(t) = gaussSum + ∑ ψ(t)`, and `∑ ψ(t) = 0`
+    (`AddChar.sum_eq_zero_of_ne_one`, since primitivity ⟹ `ψ ≠ 1` via `mulShift_one`).
+  - Verified by single-file olean-chain compile (Docker host-blocked); `#print axioms` =
+    `[propext, Classical.choice, Quot.sound]` only (axiom-free).
+
+### Key findings
+- The diagonal form is the **universal starting point** of every classical proof of the
+  sign theorem (Gauss/Schur/Dirichlet/Kronecker), and it was absent from Mathlib (which has
+  `gaussSum_sq` and `quadraticChar_card_sqrts` but never combines them into the `k²` form).
+- It strips the Legendre-symbol weighting: with the standard character `ψ(x)=ζ_p^x` it is
+  literally `g = ∑ ζ_p^{k²}`, so the open crux `0 < Re g` becomes positivity of
+  `∑ cos(2π k²/p)`.
+- It does NOT make `p = 7` tractable: `∑ζ^{k²} = 1 + 2ζ + 2ζ² + 2ζ⁴` still requires the
+  cubic-irrational value `cos(2π/7)`, unlike the quadratic-radical values at `p = 3, 5`.
+  The next genuine advance is the general DFT-spectrum content, still >1000 lines.
+
+### Files modified
+- `proofs/Proofs/QuadraticGaussSumDiagonal.lean` (new, verified)
+- `proofs/Proofs.lean` (import)
+- `src/data/research/problems/quadratic-gauss-sum-square-oq-01.json` (knowledge)
+
+### Next steps
+- Reframe `0 < Re(∑ ζ_p^{k²})` and look for a positivity argument that avoids full
+  eigenvalue-multiplicity computation (e.g. pairing `k` with `p−k`, partial-sum bounds).
+- Consider upstreaming `gaussSum_chiC_eq_sum_sq` to Mathlib's `NumberTheory/GaussSum.lean`.

--- a/research/registry.json
+++ b/research/registry.json
@@ -23015,11 +23015,11 @@
     },
     {
       "slug": "quadratic-gauss-sum-square-oq-01",
-      "phase": "OBSERVE",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-18T21:42:27.143Z",
       "status": "active",
-      "lastUpdate": "2026-06-18T21:42:27.255Z"
+      "lastUpdate": "2026-06-19T20:51:58-07:00"
     },
     {
       "slug": "shannon-channel-coding-bec-oq-01",

--- a/src/data/research/problems/quadratic-gauss-sum-square-oq-01.json
+++ b/src/data/research/problems/quadratic-gauss-sum-square-oq-01.json
@@ -7,13 +7,16 @@
       "The gallery slug `quadratic-gauss-sum-square-oq-01` already proves (verified, 0 sorries) the elementary half: the real/imaginary DICHOTOMY (g.im=0 for p≡1, g.re=0 for p≡3) plus magnitude ‖g‖²=p. The pool candidate with the same id is the strictly harder follow-up: fixing the LEADING SIGN (g=+√p resp. g=+i√p), i.e. Gauss's hard theorem.",
       "Dichotomy + magnitude pin g to exactly four points: ±√p (p≡1 mod 4) or ±i√p (p≡3 mod 4). Proved sorry-free in QuadraticGaussSumSignReduction.gaussSum_eq_pm_sqrt / gaussSum_eq_pm_I_sqrt by extracting g.re²=p (resp g.im²=p) from normSq and splitting |·|=√p via abs_eq.",
       "KEY REDUCTION: Gauss's hard sign theorem is EQUIVALENT to a single real positivity. g=√p ↔ 0<g.re (p≡1 mod 4); g=i√p ↔ 0<g.im (p≡3 mod 4). Proved sorry-free (gaussSum_eq_sqrt_iff_re_pos / gaussSum_eq_I_sqrt_iff_im_pos). This isolates the entire open content into one inequality.",
-      "Mathlib (v4.26.x) has NO sign determination for the quadratic Gauss sum and no finite-Fourier-transform determinant infrastructure. NumberTheory/GaussSum.lean stops at gaussSum_sq (the square identity); there is nothing about Re(g)>0 or the DFT eigenvalue multiplicities."
+      "Mathlib (v4.26.x) has NO sign determination for the quadratic Gauss sum and no finite-Fourier-transform determinant infrastructure. NumberTheory/GaussSum.lean stops at gaussSum_sq (the square identity); there is nothing about Re(g)>0 or the DFT eigenvalue multiplicities.",
+      "DIAGONAL REPRESENTATION (verified, axiom-free): gaussSum (chiC p) ψ = ∑ k, ψ(k²) for any primitive additive character ψ. Proved by fibre counting: grouping ∑ψ(k²) by t=k² turns the multiplicity into #{k:k²=t}=χ(t)+1 (quadraticChar_card_sqrts), giving ∑ψ(k²)=∑(χ(t)+1)ψ(t)=g+∑ψ(t)=g+0. This is the universal starting point of every classical sign proof and was absent from Mathlib."
     ],
     "builtItems": [
       "QuadraticGaussSumSignReduction.gaussSum_eq_pm_sqrt — g=±√p for p≡1 mod 4 (sorry-free)",
       "QuadraticGaussSumSignReduction.gaussSum_eq_pm_I_sqrt — g=±i√p for p≡3 mod 4 (sorry-free)",
       "QuadraticGaussSumSignReduction.gaussSum_eq_sqrt_iff_re_pos — sign theorem ⟺ 0<Re g (p≡1) (sorry-free)",
-      "QuadraticGaussSumSignReduction.gaussSum_eq_I_sqrt_iff_im_pos — sign theorem ⟺ 0<Im g (p≡3) (sorry-free)"
+      "QuadraticGaussSumSignReduction.gaussSum_eq_I_sqrt_iff_im_pos — sign theorem ⟺ 0<Im g (p≡3) (sorry-free)",
+      "QuadraticGaussSumDiagonal.gaussSum_chiC_eq_sum_sq — g = ∑ k, ψ(k²) (sorry-free, axiom-free)",
+      "QuadraticGaussSumDiagonal.card_sqrts_cast — (#{x:x²=t}.card : ℂ) = chiC p t + 1, ℂ-transport of quadraticChar_card_sqrts"
     ],
     "mathlibGaps": [
       "No formalization of the sign of the quadratic Gauss sum (g=√p for p≡1, g=i√p for p≡3).",
@@ -24,8 +27,9 @@
       "Prove the single open crux 0 < Re(gaussSum (chiC p) ψ) for p≡1 mod 4 (and 0 < Im for p≡3). Both classical routes target exactly this.",
       "Schur route: build the n×n finite Fourier matrix F (entries ζ^{jk}), show F has known eigenvalue multiplicities (1,−1,i,−i with counts depending on n mod 4), and identify Re(g) with trace/√n. Estimate >1000 lines given no Mathlib DFT-spectrum infra → likely BLOCKED short-term.",
       "Dirichlet route: needs Poisson summation / theta functional equation; heavy real-analysis infra. Estimate >1000 lines.",
-      "Cross-check magnitude ‖g‖²=p via character orthogonality (Parseval) independently of the square identity."
+      "Cross-check magnitude ‖g‖²=p via character orthogonality (Parseval) independently of the square identity.",
+      "With the diagonal form, the standard-character Gauss sum is ∑ ζ_p^{k²}; reframe the open crux 0<Re g as positivity of ∑ cos(2π k²/p). p=7 (≡3 mod 4) is now ∑ζ^{k²}=1+2ζ+2ζ²+2ζ⁴ but still needs cubic-irrational trig (cos(2π/7)) — intractable by elementary radicals, unlike p=3,5."
     ],
-    "progressSummary": "PROGRESS (ORIENT): reduced Gauss's hard sign theorem to a single positivity (0<Re g resp 0<Im g) and strengthened the dichotomy to the exact four-point pinning g=±√p / ±i√p — all sorry-free. The positivity crux itself remains open; both classical proofs (Schur, Dirichlet) need >1000 lines of Mathlib-absent infrastructure (BLOCKED short-term)."
+    "progressSummary": "PROGRESS (ACT): added the diagonal representation g=∑ψ(k²) (verified, axiom-free), the classical starting form absent from Mathlib. Base cases p=3,5 done; general positivity crux remains open (DFT-spectrum, >1000 lines)."
   }
 }


### PR DESCRIPTION
## Summary

Adds the classical **diagonal representation** of the quadratic Gauss sum to the `quadratic-gauss-sum-square-oq-01` research line (Gauss's hard sign theorem):

```
gaussSum (chiC p) ψ = ∑ k, ψ(k²)        (ψ primitive)
```

This is the universal starting point of *every* classical proof of the sign theorem (Gauss, Schur, Dirichlet, Kronecker) — with the standard character `ψ(x)=ζ_p^x` it is literally `g = ∑ ζ_p^{k²}`. Mathlib has the square identity `gaussSum_sq` and the square-root count `quadraticChar_card_sqrts` but never combines them into the `k²` form.

## What's proved (`Proofs/QuadraticGaussSumDiagonal.lean`, new)

- `card_sqrts_cast` — `(#{x : ZMod p | x² = t}.card : ℂ) = chiC p t + 1`, the ℂ-transport of `quadraticChar_card_sqrts` through the ring hom `ℤ → ℂ` defining `chiC`.
- `gaussSum_chiC_eq_sum_sq` — the diagonal identity above.

**Proof** is elementary fibre counting: `Finset.sum_fiberwise_of_maps_to` groups `∑ ψ(k²)` by the value `t = k²`; the fibre `{k : k²=t}` has size `χ(t)+1`, giving `∑ ψ(k²) = ∑ (χ(t)+1)·ψ(t) = gaussSum + ∑ ψ(t)`, and `∑ ψ(t) = 0` since `ψ` is primitive (`AddChar.sum_eq_zero_of_ne_one`, with `ψ ≠ 1` via `mulShift_one`).

## Verification

Verified by single-file olean-chain compile against the pinned Mathlib (Docker host-blocked this session). `#print axioms gaussSum_chiC_eq_sum_sq` = `[propext, Classical.choice, Quot.sound]` — **sorry-free and axiom-free**.

## Honest scope

This is reusable infrastructure, not the open theorem. It reframes the open crux `0 < Re g` as positivity of `∑ cos(2π k²/p)`, but does **not** make new primes tractable: `p = 7` is `1 + 2ζ + 2ζ² + 2ζ⁴`, still requiring the cubic-irrational `cos(2π/7)` (unlike the quadratic-radical `p = 3, 5`). The general positivity remains open (DFT-spectrum, >1000 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)