### PR TITLE
research(area-of-circle-oq-07-oq-02): half-line Gaussian ∫₀^∞ e^{-bx²} = √(π/b)/2

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ07OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ02.lean
@@ -1,0 +1,64 @@
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Tactic
+
+/-
+# The Half-Line Gaussian Integral
+
+## Open Question (area-of-circle-oq-07-oq-02)
+"What is the value of the Gaussian integral taken over the positive half-line
+`(0, ∞)` instead of all of `ℝ`?"
+
+$$ \int_{0}^{\infty} e^{-b x^2}\, dx = \tfrac{1}{2}\sqrt{\tfrac{\pi}{b}}. $$
+
+## Answer: it is exactly half of the full-line value `√(π/b)`.
+
+The parent entry `area-of-circle-oq-07` evaluates the **full-line** Gaussian
+`∫_{-∞}^{∞} e^{-x²} dx = √π`.  Because the integrand `e^{-b x²}` is even, the
+positive half-line carries exactly half of the total mass, so the half-line
+integral is `√(π/b)/2`.  Mathlib's `integral_gaussian_Ioi` records this value
+directly (and, like the full-line version, evaluates to `0` for `b ≤ 0`, where
+the integrand fails to be integrable).
+
+What makes this a genuine extension of the parent rather than a notational
+variant is the **even-symmetry bridge**: we prove that the full-line integral is
+*twice* the half-line one (`gaussian_full_eq_two_mul_half`, via
+`integral_comp_abs`), and then use the half-line value at `b = 1` to *re-derive*
+the parent's `√π` along a completely different route — through `Set.Ioi 0` and
+even symmetry rather than through the parametrized `integral_gaussian`.
+
+No new axioms: every step is a routine consequence of existing Mathlib results.
+-/
+
+open Real MeasureTheory
+
+/-- **The half-line Gaussian integral.** For every real `b`, the integral of
+`e^{-b x²}` over the positive half-line `(0, ∞)` equals `√(π/b)/2`. -/
+theorem half_gaussian_integral (b : ℝ) :
+    ∫ x in Set.Ioi (0 : ℝ), Real.exp (-b * x ^ 2) = Real.sqrt (Real.pi / b) / 2 :=
+  integral_gaussian_Ioi b
+
+/-- **Even-symmetry bridge.** The full-line Gaussian integral is exactly twice
+the half-line one, because `e^{-x²}` is an even function. -/
+theorem gaussian_full_eq_two_mul_half :
+    (∫ x : ℝ, Real.exp (-x ^ 2))
+      = 2 * ∫ x in Set.Ioi (0 : ℝ), Real.exp (-x ^ 2) := by
+  have heven : (∫ x : ℝ, Real.exp (-x ^ 2))
+      = ∫ x : ℝ, Real.exp (-(|x|) ^ 2) := by
+    simp [sq_abs]
+  rw [heven]
+  exact integral_comp_abs (f := fun y : ℝ => Real.exp (-y ^ 2))
+
+/-- The half-line Gaussian at `b = 1`: `∫_{0}^{∞} e^{-x²} dx = √π / 2`. -/
+theorem half_gaussian_integral_one :
+    ∫ x in Set.Ioi (0 : ℝ), Real.exp (-x ^ 2) = Real.sqrt Real.pi / 2 := by
+  have h := half_gaussian_integral 1
+  simpa only [neg_one_mul, div_one] using h
+
+/-- **Recovering the parent.** Re-derive `∫_{-∞}^{∞} e^{-x²} dx = √π` from the
+half-line value via the even-symmetry bridge — an independent route to the
+parent entry `area-of-circle-oq-07`, going through `Set.Ioi 0` rather than the
+parametrized full-line `integral_gaussian`. -/
+theorem gaussian_integral_eq_sqrt_pi :
+    (∫ x : ℝ, Real.exp (-x ^ 2)) = Real.sqrt Real.pi := by
+  rw [gaussian_full_eq_two_mul_half, half_gaussian_integral_one]
+  ring

--- a/src/data/proofs/area-of-circle-oq-07-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-02/annotations.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "ann-aoc0702-context",
+    "proofId": "area-of-circle-oq-07-oq-02",
+    "range": { "startLine": 1, "endLine": 30 },
+    "type": "concept",
+    "title": "From the Full Line to the Half Line",
+    "content": "This entry extends the parent `area-of-circle-oq-07` from the full-line Gaussian `∫_ℝ e^{-x²} = √π` to the positive half-line `∫_{(0,∞)} e^{-b x²} = √(π/b)/2`. The half-line value is recorded directly by Mathlib's `integral_gaussian_Ioi`. The genuinely new content is the *even-symmetry bridge*: a machine-checked proof that the full-line integral is exactly twice the half-line one, which lets us re-derive the parent's `√π` through `Set.Ioi 0` instead of through the parametrized `integral_gaussian` the parent used.",
+    "mathContext": "For an even integrable function $f$, $\\int_{-\\infty}^{\\infty} f = 2\\int_0^{\\infty} f$, because the substitution $x \\mapsto -x$ maps the negative half-line onto the positive one measure-preservingly. The Gaussian $e^{-bx^2}$ is even, so its mass splits evenly: $\\int_0^\\infty e^{-bx^2}\\,dx = \\tfrac12\\sqrt{\\pi/b}$. Like the full-line case, the value is $0$ for $b \\le 0$, where the integrand is not integrable on $(0,\\infty)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "half-line Gaussian integral",
+      "even-function symmetry",
+      "improper integral over Ioi",
+      "half-normal distribution"
+    ],
+    "prerequisites": [
+      "Lebesgue integral over Set.Ioi 0",
+      "Mathlib integral_gaussian_Ioi",
+      "parent area-of-circle-oq-07 (the full-line value √π)"
+    ]
+  },
+  {
+    "id": "ann-aoc0702-half",
+    "proofId": "area-of-circle-oq-07-oq-02",
+    "range": { "startLine": 34, "endLine": 38 },
+    "type": "technique",
+    "title": "The Half-Line Value via integral_gaussian_Ioi",
+    "content": "`half_gaussian_integral` states `∫ x in Set.Ioi 0, exp (-b·x²) = √(π/b)/2` for every real `b`, and its proof is exactly `integral_gaussian_Ioi b` — Mathlib already proves this. Stating it as a named theorem fixes the half-line value used by the rest of the entry and makes the comparison with the parent's full-line `√(π/b)` immediate: the half line carries precisely half the value.",
+    "mathContext": "Mathlib's `integral_gaussian_Ioi` derives the half-line value from the complex-analytic `integral_gaussian_complex_Ioi`, handling the non-integrable regime $b \\le 0$ by sending the integral to $0$. We inherit all of that wholesale.",
+    "significance": "important",
+    "relatedConcepts": ["integral_gaussian_Ioi", "Set.Ioi", "named restatement"],
+    "prerequisites": ["integral_gaussian_Ioi"]
+  },
+  {
+    "id": "ann-aoc0702-bridge",
+    "proofId": "area-of-circle-oq-07-oq-02",
+    "range": { "startLine": 40, "endLine": 49 },
+    "type": "technique",
+    "title": "The Even-Symmetry Bridge",
+    "content": "`gaussian_full_eq_two_mul_half` proves `∫_ℝ e^{-x²} = 2·∫_{(0,∞)} e^{-x²}`. The key move is to recognize `e^{-x²}` as `f |x|` for `f y = e^{-y²}`: since `|x|² = x²` (lemma `sq_abs`), `simp` rewrites the integrand into the absolute-value form, after which Mathlib's `integral_comp_abs : ∫ x, f |x| = 2 * ∫ x in Ioi 0, f x` closes the goal exactly. This is the one place even symmetry is used, and stating it separately isolates it from the numerical value.",
+    "mathContext": "`integral_comp_abs` is the formal content of 'an even function has equal mass on the two half-lines': it folds the negative half-line onto the positive one through the absolute value. The Gaussian fits because squaring annihilates the sign, $|x|^2 = x^2$, so $e^{-|x|^2} = e^{-x^2}$ identically.",
+    "significance": "key",
+    "relatedConcepts": ["integral_comp_abs", "sq_abs", "even function", "reflection x ↦ -x"],
+    "prerequisites": ["integral_comp_abs", "sq_abs"]
+  },
+  {
+    "id": "ann-aoc0702-recover",
+    "proofId": "area-of-circle-oq-07-oq-02",
+    "range": { "startLine": 51, "endLine": 64 },
+    "type": "technique",
+    "title": "Recovering √π Along an Independent Route",
+    "content": "`half_gaussian_integral_one` specializes the half-line value at `b = 1` to `∫_{(0,∞)} e^{-x²} = √π/2` (via `neg_one_mul` and `div_one`). Feeding this and the bridge into `gaussian_integral_eq_sqrt_pi` re-proves the parent's `∫_ℝ e^{-x²} = √π` by `rw [...]; ring` — `2 · (√π/2) = √π`. Crucially this route never touches `integral_gaussian` (the full-line parametrized lemma the parent used): it reaches `√π` purely through the half-line value and even symmetry, giving the gallery two independent formal derivations of the same constant.",
+    "mathContext": "Two evaluation strategies converge: the parent specializes a full-line parametrized integral, while here the full-line value is reconstructed from the half-line one by reflection. Agreement of the two is a (trivial but real) consistency check on Mathlib's Gaussian API.",
+    "significance": "important",
+    "relatedConcepts": ["neg_one_mul", "div_one", "independent proof path", "consistency check"],
+    "prerequisites": ["half_gaussian_integral", "gaussian_full_eq_two_mul_half"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-02/meta.json
@@ -1,0 +1,115 @@
+{
+  "id": "area-of-circle-oq-07-oq-02",
+  "slug": "area-of-circle-oq-07-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory"
+    ],
+    "namespace": "",
+    "lineCount": 64,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Half-Line Gaussian Integral",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ02.lean",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "special-functions",
+      "measure-theory",
+      "even-symmetry",
+      "improper-integral",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 64,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "half_gaussian_integral: ∫_{0}^{∞} e^{-b x²} dx = √(π/b)/2 for every real b, the half-line value recorded by Mathlib's integral_gaussian_Ioi",
+      "gaussian_full_eq_two_mul_half: the even-symmetry bridge ∫_ℝ e^{-x²} = 2·∫_{(0,∞)} e^{-x²}, proved via Mathlib's integral_comp_abs, that turns the half-line value into the full-line one",
+      "gaussian_integral_eq_sqrt_pi: an independent re-derivation of the parent's ∫_ℝ e^{-x²} = √π through Set.Ioi 0 and even symmetry, rather than through the parametrized integral_gaussian used by the parent entry"
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ and over Set.Ioi 0 (MeasureTheory)",
+      "Mathlib's half-line Gaussian integral_gaussian_Ioi",
+      "Even-function integral identity integral_comp_abs",
+      "Real.sqrt and Real.pi API",
+      "Parent: area-of-circle-oq-07 (the full-line value √π)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_gaussian_Ioi",
+        "description": "∫ x in Ioi 0, exp (-b * x ^ 2) = √(π / b) / 2 for every real b — the half-line Gaussian integral. Stated directly as half_gaussian_integral.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "integral_comp_abs",
+        "description": "∫ x, f |x| = 2 * ∫ x in Ioi 0, f x — the even-function reflection identity. Applied to f y = exp (-y²) (using |x|² = x²) it yields the full-line = 2 × half-line bridge.",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Integral"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-02-oq-01",
+      "question": "Generalize the even-symmetry bridge: state ∫_ℝ f = 2·∫_{(0,∞)} f for an arbitrary even integrable f directly from integral_comp_abs, and instantiate it at the parametrized Gaussian e^{-b x²} to recover ∫_ℝ e^{-b x²} = √(π/b) from the half-line value for every b > 0.",
+      "significance": "medium"
+    },
+    {
+      "id": "area-of-circle-oq-07-oq-02-oq-02",
+      "question": "Evaluate the first absolute moment ∫_{(0,∞)} x · e^{-b x²} dx = 1/(2b) and the second moment ∫_{(0,∞)} x² · e^{-b x²} dx = √(π/b)/(4b), connecting the half-line Gaussian to the variance of the half-normal distribution.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "extends",
+      "description": "Parent. That entry evaluates the full-line Gaussian ∫_ℝ e^{-x²} = √π by specializing integral_gaussian at b = 1. This entry evaluates the half-line ∫_{(0,∞)} e^{-x²} = √π/2 and, via the even-symmetry bridge, re-derives the parent's √π along an independent route through Set.Ioi 0."
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "related",
+      "description": "Grandparent. The factor of π in the Gaussian value ultimately traces to the circle-area Jacobian r dr dθ of the polar-coordinate evaluation studied in the area-of-circle entry."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_gaussian_Ioi (b : ℝ) : ∫ x in Ioi 0, exp (-b * x ^ 2) = √(π / b) / 2, the half-line value stated here directly."
+    },
+    {
+      "title": "Mathlib4: MeasureTheory.Measure.Lebesgue.Integral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_comp_abs : ∫ x, f |x| = 2 * ∫ x in Ioi 0, f x, the even-function reflection identity used in the symmetry bridge."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The Gaussian integral over the positive half-line is ∫_{0}^{∞} e^{-b x²} dx = √(π/b)/2 — exactly half of the full-line value √(π/b). half_gaussian_integral states this directly from Mathlib's integral_gaussian_Ioi. The entry then proves the even-symmetry bridge gaussian_full_eq_two_mul_half: ∫_ℝ e^{-x²} = 2·∫_{(0,∞)} e^{-x²}, obtained by writing the integrand as f|x| for f y = e^{-y²} (since |x|² = x²) and applying integral_comp_abs. Combining the bridge with the b = 1 half-line value √π/2 re-derives the parent's ∫_ℝ e^{-x²} = √π through Set.Ioi 0 and reflection, an independent route to the same constant. 64 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Like the parent, the analytic content is inherited from Mathlib — the value of the entry is structural. It isolates the even-symmetry argument that is usually left implicit when one says the Gaussian 'is symmetric', turning 'half the mass lives on each side' into the explicit, machine-checked identity ∫_ℝ = 2·∫_{(0,∞)}. By recovering √π from the half-line rather than from the parametrized full-line integral, it gives a genuinely different proof path to the same normalization constant and provides the natural launching point for half-normal-distribution moments.",
+    "openQuestions": [
+      "Generalize the bridge to an arbitrary even integrable f and recover ∫_ℝ e^{-b x²} = √(π/b) for every b > 0.",
+      "Compute the half-line moments ∫_{(0,∞)} x e^{-b x²} and ∫_{(0,∞)} x² e^{-b x²}, linking to the half-normal distribution's mean and variance."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers open question **area-of-circle-oq-07-oq-02**: the value of the Gaussian integral over the positive half-line `(0, ∞)`.

$$\int_{0}^{\infty} e^{-b x^2}\,dx = \frac{1}{2}\sqrt{\frac{\pi}{b}}$$

This extends the parent `area-of-circle-oq-07` (full-line `∫_ℝ e^{-x²} = √π`) from the whole line to the half-line, and — the genuinely new content — establishes the **even-symmetry bridge** linking the two.

## Theorems (`Proofs/AreaOfCircleOQ07OQ02.lean`, 4 theorems)

- `half_gaussian_integral (b)` — `∫ x in Ioi 0, e^{-b x²} = √(π/b)/2`, stated directly from Mathlib's `integral_gaussian_Ioi`.
- `gaussian_full_eq_two_mul_half` — `∫_ℝ e^{-x²} = 2·∫_{(0,∞)} e^{-x²}`, proved by recognizing `e^{-x²} = f|x|` (`sq_abs`) and applying `integral_comp_abs`.
- `half_gaussian_integral_one` — the `b = 1` half-line value `√π/2`.
- `gaussian_integral_eq_sqrt_pi` — re-derives the parent's `√π` through `Set.Ioi 0` and even symmetry, an **independent route** never touching the parametrized `integral_gaussian` used by the parent.

## Verification

Type-checked single-file against prebuilt Mathlib oleans (`lake env lean`): **0 errors, 0 warnings, 0 sorries**.

`#print axioms` on all four theorems → `[propext, Classical.choice, Quot.sound]` only — no `Lean.ofReduceBool`, no `sorryAx`. Status: **verified**, axiomCount 0, badge `mathlib` (the analytic content is inherited from Mathlib; the contribution is the symmetry bridge and the independent derivation of the parent's value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)