### PR TITLE
research(area-of-circle-oq-07-oq-02): half-line Gaussian integral √(π/b)/2 + even-symmetry bridge

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ07OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ02.lean
@@ -1,0 +1,56 @@
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Tactic
+
+/-
+# The Half-Line Gaussian Integral Equals √(π/b)/2
+
+## Open Question (area-of-circle-oq-07-oq-02)
+The parent entry `area-of-circle-oq-07` evaluates the *full-line* Gaussian
+`∫_ℝ e^{-x²} dx = √π`.  This entry records its half-line companion:
+
+$$ \int_{0}^{\infty} e^{-b x^2}\, dx = \frac{1}{2}\sqrt{\frac{\pi}{b}}
+   \qquad (b > 0). $$
+
+## Answer: YES — it is `integral_gaussian_Ioi` from Mathlib.
+
+Mathlib's `integral_gaussian_Ioi (b : ℝ) : ∫ x in Ioi 0, exp (-b * x ^ 2) = √(π / b) / 2`
+already evaluates the half-line Gaussian for every real `b` (for `b ≤ 0` both
+sides are `0`, so no positivity hypothesis is needed).  Setting `b = 1` collapses
+the integrand `exp (-1 · x²)` to `exp (-x²)` via `neg_one_mul` and the value
+`√(π/1)/2` to `√π/2` via `div_one`.
+
+The mathematically substantive content here is the **even-symmetry bridge to the
+parent**: because `x ↦ e^{-x²}` is even, the full-line integral is exactly twice
+the half-line integral,
+`∫_ℝ e^{-x²} = 2 ∫_{(0,∞)} e^{-x²}`,
+which we verify by reducing both sides to their closed forms `√π` and `√π/2`.
+This makes the parent's `√π` and this entry's `√π/2` a consistent pair, with the
+factor of `2` being precisely the even-symmetry doubling.
+
+No new axioms: the proof is a routine specialization of existing Mathlib results.
+-/
+
+open Real MeasureTheory
+
+/-- **The half-line Gaussian integral.** For every real `b`, the integral of
+`e^{-b x²}` over `(0, ∞)` is `√(π/b)/2`.  (For `b ≤ 0` both sides vanish.) -/
+theorem gaussian_integral_Ioi (b : ℝ) :
+    (∫ x in Set.Ioi (0 : ℝ), Real.exp (-b * x ^ 2)) = Real.sqrt (Real.pi / b) / 2 :=
+  integral_gaussian_Ioi b
+
+/-- The `b = 1` specialization: `∫_{(0,∞)} e^{-x²} = √π/2`. -/
+theorem gaussian_integral_Ioi_one :
+    (∫ x in Set.Ioi (0 : ℝ), Real.exp (-x ^ 2)) = Real.sqrt Real.pi / 2 := by
+  have h := integral_gaussian_Ioi 1
+  simpa only [neg_one_mul, div_one] using h
+
+/-- **Even-symmetry bridge to the parent.** Since `e^{-x²}` is even, the full-line
+Gaussian `∫_ℝ e^{-x²} = √π` (parent `area-of-circle-oq-07`) is exactly twice the
+half-line value `√π/2`. -/
+theorem gaussian_integral_eq_two_mul_Ioi :
+    (∫ x : ℝ, Real.exp (-x ^ 2))
+      = 2 * ∫ x in Set.Ioi (0 : ℝ), Real.exp (-x ^ 2) := by
+  have hfull : (∫ x : ℝ, Real.exp (-x ^ 2)) = Real.sqrt Real.pi := by
+    simpa only [neg_one_mul, div_one] using integral_gaussian 1
+  rw [hfull, gaussian_integral_Ioi_one]
+  ring

--- a/src/data/proofs/area-of-circle-oq-07-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-02/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-aoc0702-context",
+    "proofId": "area-of-circle-oq-07-oq-02",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "concept",
+    "title": "The Half-Line Gaussian and Its Place in the Gallery",
+    "content": "The parent entry `area-of-circle-oq-07` evaluates the full-line Gaussian `∫_ℝ e^{-x²} = √π`. This entry records its half-line companion `∫_{(0,∞)} e^{-b x²} = √(π/b)/2`, which Mathlib already proves as `integral_gaussian_Ioi`. The value √π/2 (at b = 1) is the normalization constant of the half-normal distribution. The deliberately substantive part is the even-symmetry bridge: because `e^{-x²}` is even, the full-line integral is exactly twice the half-line integral, so the parent's √π and this entry's √π/2 form a consistent pair related by the factor 2.",
+    "mathContext": "For an even integrable function $f$, $\\int_{\\mathbb R} f = \\int_{-\\infty}^{0} f + \\int_{0}^{\\infty} f = 2\\int_{0}^{\\infty} f$, since the reflection $x\\mapsto -x$ carries the left half onto the right. Applied to $f(x)=e^{-x^2}$ this gives $\\sqrt\\pi = 2\\cdot\\tfrac{\\sqrt\\pi}{2}$. Here the relation is verified by matching the two known closed forms rather than re-deriving the symmetry from scratch.",
+    "significance": "key",
+    "relatedConcepts": [
+      "half-line Gaussian integral",
+      "half-normal distribution",
+      "even-symmetry doubling",
+      "set-restricted integral over Ioi 0"
+    ],
+    "prerequisites": [
+      "set-restricted Lebesgue integral",
+      "Mathlib integral_gaussian_Ioi",
+      "parent area-of-circle-oq-07 (full-line value √π)"
+    ]
+  },
+  {
+    "id": "ann-aoc0702-main",
+    "proofId": "area-of-circle-oq-07-oq-02",
+    "range": { "startLine": 40, "endLine": 50 },
+    "type": "technique",
+    "title": "Applying integral_gaussian_Ioi and Specializing at b = 1",
+    "content": "`gaussian_integral_Ioi` is `integral_gaussian_Ioi b` verbatim — the half-line value `√(π/b)/2` holds for every real b with no positivity hypothesis (for b ≤ 0 both sides are 0, since the integrand is non-integrable on (0,∞) and Mathlib returns 0). The b = 1 case `gaussian_integral_Ioi_one` collapses `exp (-1 · x²)` to `exp (-x²)` via `neg_one_mul` and `√(π/1)/2` to `√π/2` via `div_one`, discharged by `simpa only [neg_one_mul, div_one]`.",
+    "mathContext": "The half-line value `√(π/b)/2` is exactly half the full-line value `√(π/b)` from `integral_gaussian`; the factor 1/2 is the even-symmetry split of the full real line into its two half-lines.",
+    "significance": "important",
+    "relatedConcepts": ["parametrized lemma specialization", "neg_one_mul", "div_one", "simpa"],
+    "prerequisites": ["integral_gaussian_Ioi", "simp normal forms"]
+  },
+  {
+    "id": "ann-aoc0702-bridge",
+    "proofId": "area-of-circle-oq-07-oq-02",
+    "range": { "startLine": 52, "endLine": 56 },
+    "type": "technique",
+    "title": "The Even-Symmetry Bridge: full = 2 · half",
+    "content": "`gaussian_integral_eq_two_mul_Ioi` states `∫_ℝ e^{-x²} = 2 ∫_{(0,∞)} e^{-x²}`. The proof reduces the full-line side to `√π` (via `integral_gaussian 1`, the same specialization the parent uses) and the half-line side to `√π/2` (via `gaussian_integral_Ioi_one`), then closes `√π = 2 · (√π/2)` with `ring`. This verifies the evenness consequence through the closed forms; deriving the factor 2 structurally from the reflection x ↦ -x is left as the entry's follow-up open question.",
+    "mathContext": "The identity is the simplest quantitative manifestation of the integrand's evenness. Its honest status: we confirm consistency of two independently-known values, not a fresh symmetry argument — hence the open question asking for the structural derivation via `∫_{Iic 0} + ∫_{Ioi 0}` and the reflection.",
+    "significance": "important",
+    "relatedConcepts": ["even function integral", "half-line vs full-line", "ring", "closed-form consistency"],
+    "prerequisites": ["integral_gaussian", "gaussian_integral_Ioi_one"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-02/meta.json
@@ -1,0 +1,109 @@
+{
+  "id": "area-of-circle-oq-07-oq-02",
+  "slug": "area-of-circle-oq-07-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory"
+    ],
+    "namespace": "",
+    "lineCount": 56,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Half-Line Gaussian Integral Equals √(π/b)/2",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ02.lean",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "special-functions",
+      "probability",
+      "measure-theory",
+      "even-symmetry",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 56,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "gaussian_integral_Ioi: ∫_{(0,∞)} e^{-b x²} dx = √(π/b)/2 for every real b — the half-line companion of the parent's full-line Gaussian, obtained directly from Mathlib's integral_gaussian_Ioi (no positivity hypothesis needed; for b ≤ 0 both sides vanish)",
+      "gaussian_integral_Ioi_one: the b = 1 case ∫_{(0,∞)} e^{-x²} dx = √π/2, the half-line normalization constant",
+      "gaussian_integral_eq_two_mul_Ioi: the even-symmetry bridge ∫_ℝ e^{-x²} = 2 ∫_{(0,∞)} e^{-x²}, reducing both sides to √π and √π/2 to exhibit the parent's √π as exactly twice this entry's half-line value"
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ and set-restricted integrals (MeasureTheory)",
+      "Mathlib's half-line Gaussian integral integral_gaussian_Ioi",
+      "Mathlib's full-line Gaussian integral integral_gaussian",
+      "Real.sqrt and Real.pi API",
+      "Parent: area-of-circle-oq-07 (the full-line value √π)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_gaussian_Ioi",
+        "description": "∫ x in Ioi 0, exp (-b * x ^ 2) = √(π / b) / 2 for every real b — the half-line Gaussian integral. Used verbatim for gaussian_integral_Ioi and at b = 1 for gaussian_integral_Ioi_one.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "integral_gaussian",
+        "description": "∫ x : ℝ, exp (-b * x ^ 2) = √(π / b) for every real b — the full-line Gaussian integral. Specialized at b = 1 to supply the value √π in the even-symmetry bridge.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-02-oq-01",
+      "question": "Derive the even-symmetry bridge gaussian_integral_eq_two_mul_Ioi structurally rather than by closed-form bookkeeping: prove ∫_ℝ e^{-x²} = 2 ∫_{(0,∞)} e^{-x²} from the evenness of the integrand (e.g. via integral over Iic 0 plus Ioi 0 and the reflection x ↦ -x), so the factor of 2 is produced by symmetry rather than by matching √π against √π/2.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "extends",
+      "description": "Parent. That entry evaluates the full-line Gaussian ∫_ℝ e^{-x²} = √π; this entry records the half-line companion ∫_{(0,∞)} e^{-x²} = √π/2 and ties the two together via even symmetry (gaussian_integral_eq_two_mul_Ioi: full = 2 · half)."
+    },
+    {
+      "targetId": "gaussian-integral",
+      "relationship": "related",
+      "description": "The general Gaussian integral ∫ e^{-b x²} = √(π/b). The half-line version evaluated here is √(π/b)/2, its restriction to (0, ∞)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_gaussian_Ioi (b : ℝ) : ∫ x in Ioi 0, exp (-b * x ^ 2) = √(π / b) / 2, used here directly and at b = 1."
+    },
+    {
+      "title": "Théorie analytique des probabilités",
+      "author": "Pierre-Simon Laplace",
+      "year": "1812",
+      "venue": "Courcier, Paris",
+      "description": "Classical home of the Gaussian integral; the half-line value √π/2 is the half-normal distribution's normalization."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The half-line Gaussian integral ∫_{(0,∞)} e^{-b x²} dx equals √(π/b)/2 for every real b, a one-step application of Mathlib's integral_gaussian_Ioi; the b = 1 case gives ∫_{(0,∞)} e^{-x²} dx = √π/2. The entry's substantive content is the even-symmetry bridge gaussian_integral_eq_two_mul_Ioi, which records that the parent's full-line value √π is exactly twice this half-line value, verified by reducing both sides to closed form. 56 lines, 3 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This is an honest, routine specialization rather than original analysis — Mathlib already contains the half-line evaluation. Its value to the gallery is twofold: it completes the parent's full-line Gaussian with its half-line companion (the half-normal distribution's normalization constant √π/2), and it makes explicit the even-symmetry consistency full = 2 · half that the two closed forms encode. The integrand's evenness is exactly the structural reason the half-line carries half the mass.",
+    "openQuestions": [
+      "Prove full = 2 · half structurally from the integrand's evenness (reflection x ↦ -x over Iic 0 plus Ioi 0) rather than by matching the closed forms √π and √π/2."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Extends the parent **area-of-circle-oq-07** (full-line Gaussian `∫_ℝ e^{-x²} = √π`) with its half-line companion and the even-symmetry relation tying the two together.

Three theorems (`Proofs/AreaOfCircleOQ07OQ02.lean`):

- `gaussian_integral_Ioi (b)` — `∫_{(0,∞)} e^{-b x²} = √(π/b)/2` for **every** real `b`, directly from Mathlib's `integral_gaussian_Ioi` (no positivity hypothesis needed; for `b ≤ 0` both sides vanish).
- `gaussian_integral_Ioi_one` — the `b = 1` case `∫_{(0,∞)} e^{-x²} = √π/2`, the half-normal normalization constant.
- `gaussian_integral_eq_two_mul_Ioi` — the **even-symmetry bridge** `∫_ℝ e^{-x²} = 2 ∫_{(0,∞)} e^{-x²}`, reducing both sides to `√π` and `√π/2` so the parent's value is exactly twice this half-line value.

## Honesty

The half-line evaluation is a routine application of an existing Mathlib lemma — the analytic work lives in Mathlib. The added substance is the even-symmetry bridge, and even that is verified by matching closed forms rather than re-deriving symmetry; the structural derivation (reflection `x ↦ -x` over `Iic 0 ∪ Ioi 0`) is recorded as the entry's follow-up open question. Badge: `mathlib`.

## Verification

`lake env lean` against the pinned Mathlib (v4.26) oleans: compiles clean, 0 sorries, 0 `axiom` declarations.

```
#print axioms = [propext, Classical.choice, Quot.sound]
```

→ `status: verified`, `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)