### PR TITLE
research(area-of-circle-oq-07-oq-01): complex Gaussian ∫ e^{-b x²} = (π/b)^{1/2}

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ07OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ01.lean
@@ -1,0 +1,60 @@
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Tactic
+
+/-
+# The Complex Gaussian Integral ∫ e^{-b x²} = (π/b)^{1/2}
+
+## Open Question (area-of-circle-oq-07-oq-01)
+Extend the real Gaussian integral ∫_ℝ e^{-x²} dx = √π (the parent
+`area-of-circle-oq-07`, the `b = 1` case) to the complex-parameter Gaussian
+∫_ℝ e^{-b x²} dx = (π/b)^{1/2} for any `b : ℂ` with `0 < re b`.
+
+## Answer: YES — Mathlib's `integral_gaussian_complex` evaluates it for every such b.
+
+This is a genuine generalization of the parent to the full complex right
+half-plane `{b : ℂ | re b > 0}`, the analytic continuation that underlies the
+Fresnel-type oscillatory integrals reached as `re b → 0⁺`.  Unlike the real
+case, the value is a complex principal `(1/2)`-power `(π/b)^{1/2}` rather than a
+real square root.
+
+The parent's real result `∫_ℝ e^{-x²} dx = √π` is recovered as the `b = 1`
+specialization: the integrand is real-valued, so the real integral is the
+pushforward of the complex one through `ℂ` (`integral_complex_ofReal`), and the
+principal power `(π/1)^{1/2}` collapses to `(√π : ℂ)` via `Complex.ofReal_cpow`
+and `Real.sqrt_eq_rpow`.  The bridge theorem
+`gaussian_integral_eq_sqrt_pi_via_complex` records this recovery explicitly.
+
+No new axioms: a routine specialization and casting of existing Mathlib results.
+-/
+
+open Real Complex MeasureTheory
+
+/-- **The complex Gaussian integral.** For every complex `b` with positive real
+part, `∫_ℝ e^{-b x²} dx = (π/b)^{1/2}`.  A restatement of Mathlib's
+`integral_gaussian_complex`, generalizing the real parent to the complex right
+half-plane. -/
+theorem gaussian_integral_complex {b : ℂ} (hb : 0 < b.re) :
+    (∫ x : ℝ, Complex.exp (-b * (x : ℂ) ^ 2)) = (↑π / b) ^ (1 / 2 : ℂ) :=
+  integral_gaussian_complex hb
+
+/-- The real parent `√π` is the `b = 1` case of the complex Gaussian:
+`∫_ℝ e^{-x²} dx = √π`, recovered by pushing the (real-valued) integral through
+`ℂ` and identifying `(π/1)^{1/2}` with `(√π : ℂ)`. -/
+theorem gaussian_integral_eq_sqrt_pi_via_complex :
+    (∫ x : ℝ, Real.exp (-x ^ 2)) = Real.sqrt Real.pi := by
+  have hc := gaussian_integral_complex (b := 1) (by simp)
+  have hLcast : ((∫ x : ℝ, Real.exp (-x ^ 2) : ℝ) : ℂ)
+      = ∫ x : ℝ, Complex.exp (-1 * (x : ℂ) ^ 2) := by
+    rw [← integral_complex_ofReal]
+    congr 1
+    funext x
+    rw [Complex.ofReal_exp]
+    congr 1
+    push_cast
+    ring
+  have hRcast : ((↑π : ℂ) / 1) ^ (1 / 2 : ℂ) = ((Real.sqrt Real.pi : ℝ) : ℂ) := by
+    rw [Real.sqrt_eq_rpow, Complex.ofReal_cpow Real.pi_nonneg]
+    push_cast
+    ring_nf
+  rw [← hLcast, hRcast] at hc
+  exact_mod_cast hc

--- a/src/data/proofs/area-of-circle-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-01/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-aoc07oq01-context",
+    "proofId": "area-of-circle-oq-07-oq-01",
+    "range": { "startLine": 4, "endLine": 41 },
+    "type": "concept",
+    "title": "From the Real Gaussian to the Complex Right Half-Plane",
+    "content": "This entry answers open question 1 of the `area-of-circle-oq-07` parent (the real Gaussian `∫ e^{-x²} = √π`): it extends the parameter from the single real value `b = 1` to every complex `b` with `0 < re b`, giving `∫_ℝ e^{-b x²} dx = (π/b)^{1/2}`. The value is now a complex principal `(1/2)`-power rather than a real square root. The genuine content is twofold: the move to complex `b` is the analytic continuation that links the absolutely convergent Gaussian regime to the Fresnel oscillatory integrals on the boundary `re b = 0`, and the bridge theorem shows this complex statement strictly subsumes the real parent.",
+    "mathContext": "For $\\operatorname{re} b > 0$ the integrand $e^{-b x^2}$ decays and $\\int_{\\mathbb R} e^{-b x^2}\\,dx = (\\pi/b)^{1/2}$ holds with the principal branch. Holding $|b|$ fixed and rotating $b$ toward the imaginary axis, $b = a + i t$ with $a \\to 0^+$, continues this to the Fresnel integrals $\\int \\cos(t x^2)\\,dx$ and $\\int \\sin(t x^2)\\,dx$, which converge only conditionally. The real parent is the on-axis case $b = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complex Gaussian integral",
+      "analytic continuation in the parameter",
+      "Fresnel integrals",
+      "principal complex power"
+    ],
+    "prerequisites": [
+      "complex-valued Lebesgue integral over ℝ",
+      "Mathlib integral_gaussian_complex",
+      "parent area-of-circle-oq-07 (real Gaussian)"
+    ]
+  },
+  {
+    "id": "ann-aoc07oq01-complex",
+    "proofId": "area-of-circle-oq-07-oq-01",
+    "range": { "startLine": 44, "endLine": 51 },
+    "type": "technique",
+    "title": "Restating integral_gaussian_complex",
+    "content": "`gaussian_integral_complex` is a direct restatement of Mathlib's `integral_gaussian_complex`: under the hypothesis `0 < re b` it returns `∫ x : ℝ, exp (-b · x²) = (π/b)^{1/2}`. All analytic work — differentiating the Gaussian under the integral sign and the polar-coordinate evaluation — is inherited wholesale; the entry contributes the gallery framing and, in the companion theorem, the explicit recovery of the parent.",
+    "mathContext": "Stating the lemma with `b : ℂ` rather than `b : ℝ` is what makes the result a generalization rather than a notation variant: the codomain value `(π/b)^{1/2}` is a `Complex.cpow`, and only on the positive real axis does it reduce to a real square root.",
+    "significance": "important",
+    "relatedConcepts": ["integral_gaussian_complex", "Complex.cpow", "right half-plane re b > 0"],
+    "prerequisites": ["integral_gaussian_complex"]
+  },
+  {
+    "id": "ann-aoc07oq01-bridge",
+    "proofId": "area-of-circle-oq-07-oq-01",
+    "range": { "startLine": 53, "endLine": 60 },
+    "type": "technique",
+    "title": "Recovering √π as the b = 1 Case",
+    "content": "`gaussian_integral_eq_sqrt_pi_via_complex` derives the parent's real value `∫_ℝ e^{-x²} dx = √π` from the complex result at `b = 1`. The proof has two casting steps. `hLcast` identifies the real integral with its complex image: since the integrand is real-valued, `integral_complex_ofReal` moves the `ℂ`-coercion outside the integral, and pointwise `↑(e^{-x²}) = e^{-1·(↑x)²}` by `Complex.ofReal_exp` plus `push_cast; ring` on the exponent. `hRcast` collapses the principal power: `Real.sqrt_eq_rpow` writes `√π = π^{1/2}` (real rpow), `Complex.ofReal_cpow π_nonneg` turns `↑(π^{1/2})` into `(↑π)^{(1/2 : ℂ)}`, matching `(π/1)^{1/2}`. Rewriting both sides of the specialized hypothesis and `exact_mod_cast` finishes.",
+    "mathContext": "The non-trivial part of relating a complex statement to a real one is precisely the two identifications performed here: that a real-valued integral equals the real part of (here, the `ℂ`-coercion of) its complex form, and that a complex principal `(1/2)`-power of a positive real equals that real's square root. Both are exactly where a careless 'just set b = 1' would go wrong.",
+    "significance": "important",
+    "relatedConcepts": ["integral_complex_ofReal", "Complex.ofReal_cpow", "Real.sqrt_eq_rpow", "exact_mod_cast"],
+    "prerequisites": ["gaussian_integral_complex", "Complex.ofReal_exp", "Complex.ofReal_cpow"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-01/meta.json
@@ -1,0 +1,119 @@
+{
+  "id": "area-of-circle-oq-07-oq-01",
+  "slug": "area-of-circle-oq-07-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Complex",
+      "MeasureTheory"
+    ],
+    "namespace": "",
+    "lineCount": 60,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Complex Gaussian Integral (π/b)^{1/2}",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ01.lean",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "complex-analysis",
+      "special-functions",
+      "measure-theory",
+      "fresnel",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 60,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "gaussian_integral_complex: ∫_ℝ e^{-b x²} dx = (π/b)^{1/2} for every b : ℂ with 0 < re b — the complex-parameter Gaussian over the right half-plane, generalizing the parent's real b = 1 case via Mathlib's integral_gaussian_complex",
+      "gaussian_integral_eq_sqrt_pi_via_complex: recovers the real parent ∫_ℝ e^{-x²} dx = √π as the b = 1 specialization of the complex result, pushing the real-valued integral through ℂ (integral_complex_ofReal) and collapsing (π/1)^{1/2} to (√π : ℂ) via Complex.ofReal_cpow and Real.sqrt_eq_rpow"
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ with complex-valued integrand (MeasureTheory)",
+      "Mathlib's complex Gaussian integral integral_gaussian_complex",
+      "Complex principal powers (Complex.cpow) and Complex.ofReal_cpow",
+      "Real.sqrt as a real rpow (Real.sqrt_eq_rpow)",
+      "Parent: area-of-circle-oq-07 (the real Gaussian ∫ e^{-x²} = √π)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_gaussian_complex",
+        "description": "For b : ℂ with 0 < re b, ∫ x : ℝ, exp (-b * x²) = (π/b)^{1/2} — the complex-parameter Gaussian integral. Restated directly as gaussian_integral_complex.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "integral_complex_ofReal",
+        "description": "∫ x, ((f x : ℝ) : ℂ) = ↑(∫ x, f x) — moves a real-valued integrand through the ℂ coercion. Used to identify the real Gaussian with its complex image at b = 1.",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap"
+      },
+      {
+        "theorem": "Complex.ofReal_cpow",
+        "description": "0 ≤ x → ((x ^ y : ℝ) : ℂ) = (x : ℂ) ^ (y : ℂ) — identifies the complex principal power (π/1)^{1/2} with the real square root of π.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.sqrt_eq_rpow",
+        "description": "√x = x ^ (1/2 : ℝ) — writes Real.sqrt as a real rpow so it can be matched with the complex cpow value.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-01-oq-01",
+      "question": "Exhibit the Fresnel degeneration explicitly: evaluate the boundary oscillatory integrals ∫_ℝ e^{-(a + i t) x²} dx as a → 0⁺ for fixed real t ≠ 0, recovering the Fresnel integrals ∫ cos(t x²) and ∫ sin(t x²) from the b = a + i t case of gaussian_integral_complex.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "extends",
+      "description": "Parent. This entry generalizes the parent's real Gaussian ∫ e^{-x²} = √π to the complex parameter ∫ e^{-b x²} = (π/b)^{1/2} over the right half-plane {re b > 0}, and recovers the parent's value as the b = 1 case in gaussian_integral_eq_sqrt_pi_via_complex."
+    },
+    {
+      "targetId": "gaussian-integral",
+      "relationship": "related",
+      "description": "The real parametrized Gaussian ∫ e^{-b x²} = √(π/b). This entry is its analytic continuation to complex b with positive real part, where the real square root becomes a complex principal (1/2)-power."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_gaussian_complex : for 0 < re b, ∫ x : ℝ, exp (-b * x²) = (π/b)^{1/2}, the complex-parameter Gaussian integral restated and specialized here."
+    },
+    {
+      "title": "Fourier Analysis",
+      "author": "Elias M. Stein and Rami Shakarchi",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "description": "Classical treatment of the Gaussian and Fresnel integrals, including the analytic continuation in the parameter b that takes the Gaussian value √(π/b) to the oscillatory Fresnel regime as re b → 0."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The Gaussian integral extends from the real line to the complex right half-plane: for every b : ℂ with 0 < re b, ∫_ℝ e^{-b x²} dx = (π/b)^{1/2}. This is Mathlib's integral_gaussian_complex, restated as gaussian_integral_complex. The parent's real value ∫_ℝ e^{-x²} dx = √π is recovered as the b = 1 specialization in gaussian_integral_eq_sqrt_pi_via_complex: the integrand is real-valued, so the real integral pushes through ℂ via integral_complex_ofReal, and the complex principal power (π/1)^{1/2} collapses to (√π : ℂ) via Complex.ofReal_cpow and Real.sqrt_eq_rpow. 60 lines, 2 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The genuine content is the move to complex b: the value (π/b)^{1/2} is a complex principal power, not a real square root, and it is the analytic continuation that connects the (absolutely convergent) Gaussian regime re b > 0 to the conditionally convergent Fresnel oscillatory integrals on the boundary re b = 0. The bridge theorem shows this complex result strictly subsumes the parent, with the real √π emerging as the on-axis b = 1 value. The hard analytic work — differentiating under the integral and the polar-coordinate evaluation — lives inside Mathlib's integral_gaussian_complex; this entry's contribution is the explicit parent-recovery cast, which is the non-trivial part of connecting the complex statement to the real one.",
+    "openQuestions": [
+      "Take re b → 0⁺ along b = a + i t to recover the Fresnel integrals ∫ cos(t x²), ∫ sin(t x²) from gaussian_integral_complex."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers open question **area-of-circle-oq-07-oq-01**: extends the parent's real Gaussian `∫_ℝ e^{-x²} dx = √π` (the `b = 1` case) to the **complex-parameter Gaussian** `∫_ℝ e^{-b x²} dx = (π/b)^{1/2}` for every `b : ℂ` with `0 < re b`.

This is a genuine generalization to the complex right half-plane — the value is a complex principal `(1/2)`-power, the analytic continuation that links the absolutely convergent Gaussian regime to the conditionally convergent Fresnel oscillatory integrals on the boundary `re b = 0`.

## Theorems (`proofs/Proofs/AreaOfCircleOQ07OQ01.lean`, 60 lines)

- **`gaussian_integral_complex`** `{b : ℂ} (hb : 0 < b.re) : ∫ x : ℝ, exp (-b * x²) = (π/b)^{1/2}` — restates Mathlib's `integral_gaussian_complex`.
- **`gaussian_integral_eq_sqrt_pi_via_complex`** `: ∫ x : ℝ, exp (-x²) = √π` — recovers the **real parent** as the `b = 1` case. The non-trivial content: `integral_complex_ofReal` moves the ℂ-coercion outside the real-valued integral, and `Complex.ofReal_cpow` + `Real.sqrt_eq_rpow` collapse `(π/1)^{1/2}` to `(√π : ℂ)`.

## Verification

- `lake env lean Proofs/AreaOfCircleOQ07OQ01.lean` → **exit 0**, 0 sorries.
- `#print axioms` for both theorems → `[propext, Classical.choice, Quot.sound]` only.
- **status `verified`, badge `mathlib`, axiomCount 0.**

## Gallery

Adds `src/data/proofs/area-of-circle-oq-07-oq-01/` (meta.json + annotations.json), cross-referenced to the parent `area-of-circle-oq-07` and the `gaussian-integral` entry. Files one follow-up open question (Fresnel degeneration as `re b → 0⁺`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)