### PR TITLE
fix(proofs): register verified BezoutIdentityOQ01OQ01OQ02OQ01 in Proofs.lean

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -213,6 +213,7 @@ import Proofs.BezoutIdentityOQ01Aristotle
 import Proofs.BezoutIdentityOQ01OQ01
 import Proofs.BezoutIdentityOQ01OQ01OQ01
 import Proofs.BezoutIdentityOQ01OQ01OQ02
+import Proofs.BezoutIdentityOQ01OQ01OQ02OQ01
 import Proofs.BezoutIdentityOQ02
 import Proofs.BezoutIdentityOQ02OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ01


### PR DESCRIPTION
## Problem

`Proofs/BezoutIdentityOQ01OQ01OQ02OQ01.lean` (constructive extended binary GCD, verified sorry-free, merged in #26930) is **missing from the aggregate `Proofs.lean` import list**. All three of its siblings are present:

```
import Proofs.BezoutIdentityOQ01OQ01          ✓
import Proofs.BezoutIdentityOQ01OQ01OQ01      ✓
import Proofs.BezoutIdentityOQ01OQ01OQ02      ✓
import Proofs.BezoutIdentityOQ01OQ01OQ02OQ01  ✗ (missing → added here)
```

The `[[lean_lib]] name = "Proofs"` target sets no `globs`, so Lake builds only the modules reachable from `Proofs.lean`. The verified file was therefore excluded from the aggregate `docker-build.sh Proofs` build (it only built when targeted individually). #26930 simply forgot the import line.

## Fix

Add the one missing import, in sibling order.

## Verification

Re-verified the file compiles cleanly via single-file `lake env lean` against the pinned Mathlib (v4.26.0) olean chain — exit 0, no errors. No source change to the proof itself; this only registers it in the build aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)