### PR TITLE
research(area-of-circle-oq-07-oq-01): standard normal density integrates to one

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ07OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ01.lean
@@ -1,0 +1,61 @@
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Tactic
+
+/-
+# The Standard Normal Density Integrates to One
+
+## Open Question (area-of-circle-oq-07-oq-01)
+"Formalize the normalized standard-normal density: prove
+
+$$ \int_{-\infty}^{\infty} \frac{1}{\sqrt{2\pi}}\, e^{-x^2/2}\, dx = 1, $$
+
+deriving it from `integral_gaussian` at `b = 1/2` together with the `√π` value,
+to connect this normalization directly to probability theory."
+
+## Answer: YES — it is the `b = 1/2` specialization of the parametrized Gaussian.
+
+The parent entry `area-of-circle-oq-07` evaluates the bare Gaussian
+`∫ e^{-x²} = √π` as the `b = 1` case of Mathlib's
+`integral_gaussian (b : ℝ) : ∫ x, exp (-b * x ^ 2) = √(π / b)`.
+
+Taking instead `b = 1/2` turns the integrand `exp (-(1/2)·x²) = exp (-x²/2)`
+into the Gaussian kernel of the *standard normal distribution* (mean `0`,
+variance `1`), and the value `√(π / (1/2)) = √(2π)` into its normalization
+constant.  Dividing by `√(2π)` therefore yields a probability density of total
+mass `1` — the defining property that makes `N(0,1)` a probability measure.
+
+Two facts are recorded:
+
+* `integral_exp_neg_half_sq` : `∫ e^{-x²/2} = √(2π)`, the un-normalized mass of
+  the variance-`1` Gaussian, obtained directly from `integral_gaussian (1/2)`.
+* `standard_normal_density_integral_eq_one` : `∫ (1/√(2π))·e^{-x²/2} = 1`, the
+  normalization, obtained by pulling the constant out of the integral
+  (`integral_const_mul`) and cancelling `(√(2π))⁻¹ · √(2π) = 1`.
+
+No new axioms: both proofs are routine specializations of an existing Mathlib
+result, the same analytic content (squaring and polar coordinates, where the
+circle-area Jacobian of the grandparent entry `area-of-circle` appears) being
+already discharged inside `integral_gaussian`.
+-/
+
+open Real MeasureTheory
+
+/-- The Gaussian kernel of the standard normal distribution integrates to its
+normalization constant: `∫ e^{-x²/2} = √(2π)`.  This is the `b = 1/2` case of
+Mathlib's parametrized Gaussian integral, since `-x²/2 = -(1/2)·x²` and
+`π / (1/2) = 2π`. -/
+theorem integral_exp_neg_half_sq :
+    (∫ x : ℝ, Real.exp (-x ^ 2 / 2)) = Real.sqrt (2 * Real.pi) := by
+  have key : ∀ x : ℝ, Real.exp (-x ^ 2 / 2) = Real.exp (-(1 / 2) * x ^ 2) := by
+    intro x; congr 1; ring
+  simp_rw [key]
+  rw [integral_gaussian, show Real.pi / (1 / 2) = 2 * Real.pi by ring]
+
+/-- **The standard normal density integrates to one.**
+`∫ (1/√(2π))·e^{-x²/2} = 1`, the total mass of the `N(0,1)` probability density.
+Obtained from `integral_exp_neg_half_sq` by pulling out the constant factor and
+cancelling `(√(2π))⁻¹ · √(2π) = 1`. -/
+theorem standard_normal_density_integral_eq_one :
+    (∫ x : ℝ, (1 / Real.sqrt (2 * Real.pi)) * Real.exp (-x ^ 2 / 2)) = 1 := by
+  rw [MeasureTheory.integral_const_mul, integral_exp_neg_half_sq, one_div,
+      inv_mul_cancel₀ (Real.sqrt_ne_zero'.mpr (by positivity))]

--- a/src/data/proofs/area-of-circle-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-01/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-aoc0701-context",
+    "proofId": "area-of-circle-oq-07-oq-01",
+    "range": { "startLine": 5, "endLine": 39 },
+    "type": "concept",
+    "title": "From the Bare Gaussian to a Probability Density",
+    "content": "This entry answers open question 1 of `area-of-circle-oq-07`: it normalizes the Gaussian into a probability density. The parent evaluated the bare integral `∫ e^{-x²} = √π` as the `b = 1` case of Mathlib's parametrized `integral_gaussian (b) : ∫ x, exp (-b·x²) = √(π/b)`. Here we instead take `b = 1/2`, which turns the integrand into the *standard normal kernel* `e^{-x²/2}` and the value into `√(2π)` — the constant by which one must divide to make the total mass equal `1`. The property `∫ density = 1` is exactly what certifies that `N(0,1)` is a probability measure, so this is the step that connects the Gaussian integral to probability theory.",
+    "mathContext": "For variance $\\sigma^2$ the centered Gaussian density is $\\frac{1}{\\sigma\\sqrt{2\\pi}}e^{-x^2/(2\\sigma^2)}$; the standard normal is $\\sigma = 1$. Its normalization rests on $\\int_{-\\infty}^{\\infty} e^{-x^2/2}\\,dx = \\sqrt{2\\pi}$, which is the $b = 1/2$ instance of $\\int e^{-bx^2} = \\sqrt{\\pi/b}$ since $\\pi/(1/2) = 2\\pi$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "standard normal distribution",
+      "probability density normalization",
+      "Gaussian integral",
+      "parametrized lemma specialization"
+    ],
+    "prerequisites": [
+      "Lebesgue integral over ℝ",
+      "Mathlib integral_gaussian",
+      "parent area-of-circle-oq-07 (the b = 1 case)"
+    ]
+  },
+  {
+    "id": "ann-aoc0701-mass",
+    "proofId": "area-of-circle-oq-07-oq-01",
+    "range": { "startLine": 43, "endLine": 52 },
+    "type": "technique",
+    "title": "The Mass √(2π): specializing integral_gaussian at b = 1/2",
+    "content": "`integral_exp_neg_half_sq` evaluates `∫ e^{-x²/2} = √(2π)`. The only obstacle is syntactic: Mathlib's lemma expects the exponent in the shape `-b · x²`, whereas the standard-normal kernel is written `-x²/2`. The helper `key : ∀ x, exp(-x²/2) = exp(-(1/2)·x²)`, proved by `congr 1; ring`, rewrites every value of the integrand into Mathlib's shape; `simp_rw [key]` then lets `integral_gaussian` fire at `b = 1/2`, producing `√(π/(1/2))`, and `show π/(1/2) = 2π by ring` collapses that to `√(2π)`. No measure-theoretic reasoning is reproduced — it is inherited wholesale from `integral_gaussian`.",
+    "mathContext": "`congr 1` reduces the goal `exp a = exp b` to `a = b`, an honest ring identity `-x^2/2 = -(1/2)·x^2`. Rewriting under the integral sign is sound here because the equality is pointwise (genuine function equality), so the two integrals are literally the same object.",
+    "significance": "important",
+    "relatedConcepts": ["integral_gaussian", "congr", "ring", "simp_rw under a binder"],
+    "prerequisites": ["integral_gaussian", "pointwise rewriting of integrands"]
+  },
+  {
+    "id": "ann-aoc0701-norm",
+    "proofId": "area-of-circle-oq-07-oq-01",
+    "range": { "startLine": 54, "endLine": 61 },
+    "type": "technique",
+    "title": "Normalization: (√(2π))⁻¹ · √(2π) = 1",
+    "content": "`standard_normal_density_integral_eq_one` proves `∫ (1/√(2π))·e^{-x²/2} = 1`. `MeasureTheory.integral_const_mul` pulls the constant `1/√(2π)` outside the integral, `integral_exp_neg_half_sq` replaces what remains by `√(2π)`, and `one_div` rewrites `1/√(2π)` as `(√(2π))⁻¹`, leaving `(√(2π))⁻¹ · √(2π)`. `inv_mul_cancel₀` closes it, needing only `√(2π) ≠ 0` — supplied by `Real.sqrt_ne_zero'.mpr (by positivity)` since `0 < 2π`.",
+    "mathContext": "Linearity of the Lebesgue integral (pulling out a scalar) plus a single field cancellation is the entire normalization argument. The non-vanishing side condition `√(2π) ≠ 0` is where positivity of `π` is actually used.",
+    "significance": "important",
+    "relatedConcepts": ["integral_const_mul", "inv_mul_cancel₀", "Real.sqrt_ne_zero'", "positivity"],
+    "prerequisites": ["integral_exp_neg_half_sq", "linearity of the integral"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-01/meta.json
@@ -1,0 +1,112 @@
+{
+  "id": "area-of-circle-oq-07-oq-01",
+  "slug": "area-of-circle-oq-07-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory"
+    ],
+    "namespace": "",
+    "lineCount": 61,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Standard Normal Density Integrates to One",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ01.lean",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "special-functions",
+      "probability",
+      "normal-distribution",
+      "measure-theory",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 61,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "integral_exp_neg_half_sq: ∫_ℝ e^{-x²/2} dx = √(2π), the un-normalized mass of the variance-1 Gaussian kernel, obtained as the b = 1/2 specialization of Mathlib's integral_gaussian (since -x²/2 = -(1/2)·x² and π/(1/2) = 2π)",
+      "standard_normal_density_integral_eq_one: ∫_ℝ (1/√(2π))·e^{-x²/2} dx = 1, the normalization of the N(0,1) probability density, obtained by pulling the constant out of the integral (integral_const_mul) and cancelling (√(2π))⁻¹·√(2π) = 1"
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ (MeasureTheory)",
+      "Mathlib's parametrized Gaussian integral integral_gaussian",
+      "Real.sqrt and Real.pi API",
+      "Parent: area-of-circle-oq-07 (the b = 1 Gaussian ∫ e^{-x²} = √π)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_gaussian",
+        "description": "∫ x : ℝ, exp (-b * x ^ 2) = √(π / b) for every real b — the parametrized Gaussian integral. Specialized here at b = 1/2.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "MeasureTheory.integral_const_mul",
+        "description": "∫ x, r * f x = r * ∫ x, f x — used to pull the normalization constant 1/√(2π) out of the integral.",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Basic"
+      },
+      {
+        "theorem": "Real.sqrt_ne_zero'",
+        "description": "√x ≠ 0 ↔ 0 < x — supplies √(2π) ≠ 0 for the cancellation (√(2π))⁻¹·√(2π) = 1.",
+        "module": "Mathlib.Data.Real.Sqrt"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-01-oq-01",
+      "question": "Generalize to arbitrary variance σ² > 0: prove ∫_ℝ (1/(σ√(2π)))·e^{-x²/(2σ²)} dx = 1, the normalization of the centered Gaussian density N(0,σ²), from integral_gaussian at b = 1/(2σ²).",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "extends",
+      "description": "Parent. The parent evaluates the bare Gaussian ∫ e^{-x²} = √π as the b = 1 case of integral_gaussian; this entry takes b = 1/2 to obtain the standard normal kernel e^{-x²/2}, whose total mass √(2π) is the normalization constant of N(0,1)."
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "related",
+      "description": "Grandparent. The analytic content — squaring the Gaussian and passing to polar coordinates, where the circle-area Jacobian r dr dθ appears — is discharged inside Mathlib's integral_gaussian, the same lemma both entries specialize."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_gaussian (b : ℝ) : ∫ x, exp (-b * x ^ 2) = √(π / b), specialized here at b = 1/2."
+    },
+    {
+      "title": "Théorie analytique des probabilités",
+      "author": "Pierre-Simon Laplace",
+      "year": "1812",
+      "venue": "Courcier, Paris",
+      "description": "Classical home of the Gaussian integral and the normalization of the normal distribution."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The standard normal density (1/√(2π))·e^{-x²/2} integrates to 1 over ℝ. The proof is the b = 1/2 specialization of Mathlib's parametrized Gaussian integral integral_gaussian: the integrand exp(-(1/2)·x²) = exp(-x²/2) is the variance-1 Gaussian kernel, and √(π/(1/2)) = √(2π) is its mass (integral_exp_neg_half_sq). Pulling the constant 1/√(2π) out of the integral via integral_const_mul and cancelling (√(2π))⁻¹·√(2π) = 1 gives the normalization. 61 lines, 2 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "An honest, routine specialization rather than original mathematics — Mathlib already contains the hard analytic work inside integral_gaussian. Its value to the gallery is the direct bridge from the bare Gaussian integral to probability theory: the property ∫ density = 1 is precisely what makes N(0,1) a probability measure, and the constant √(2π) is the normalization that appears in every Gaussian density. It complements the parent's b = 1 case (∫ e^{-x²} = √π) by exhibiting the b = 1/2 case that probabilists actually use.",
+    "openQuestions": [
+      "Generalize to arbitrary variance σ² > 0: ∫_ℝ (1/(σ√(2π)))·e^{-x²/(2σ²)} dx = 1 from integral_gaussian at b = 1/(2σ²)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers **oq-01** of `area-of-circle-oq-07` (as declared in the parent entry's `openQuestions`): formalize the normalized standard-normal density,

$$\int_{-\infty}^{\infty} \frac{1}{\sqrt{2\pi}}\, e^{-x^2/2}\, dx = 1,$$

derived from `integral_gaussian` at `b = 1/2`. This is the step that turns the bare Gaussian integral of the parent into a genuine probability density — the property `∫ density = 1` is exactly what makes `N(0,1)` a probability measure.

## Theorems (`proofs/Proofs/AreaOfCircleOQ07OQ01.lean`)

- `integral_exp_neg_half_sq`: `∫_ℝ e^{-x²/2} = √(2π)` — the un-normalized mass of the variance-1 Gaussian kernel, the `b = 1/2` case of `integral_gaussian` (`-x²/2 = -(1/2)·x²`, `π/(1/2) = 2π`).
- `standard_normal_density_integral_eq_one`: `∫_ℝ (1/√(2π))·e^{-x²/2} = 1` — pull the constant out via `integral_const_mul`, then cancel `(√(2π))⁻¹·√(2π) = 1`.

## Verification

- 2 theorems, **0 sorries, 0 axioms**.
- `#print axioms` for both: `[propext, Classical.choice, Quot.sound]` → `verified`.
- Type-checked with `lake env lean` against pinned Mathlib **v4.26.0** (Docker build infra unavailable this session; single-file compile against prebuilt Mathlib oleans, exit 0, no errors/warnings).

## Honesty

A routine specialization, not original mathematics — the analytic content (squaring + polar coordinates, where the circle-area Jacobian of the grandparent `area-of-circle` appears) lives entirely inside Mathlib's `integral_gaussian`. Its gallery value is the explicit bridge from the iconic `b = 1` Gaussian (`√π`, the parent) to the `b = 1/2` case probabilists use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)