### PR TITLE
research(hilbert-10-oq-04-oq-03-oq-01-oq-01): vecGcd = Finset.gcd bridge [VERIFIED]

### DIFF
--- a/proofs/Proofs/Hilbert10OQ04OQ03OQ01OQ01.lean
+++ b/proofs/Proofs/Hilbert10OQ04OQ03OQ01OQ01.lean
@@ -1,0 +1,113 @@
+/-
+# Hilbert's 10th Problem OQ-04 · OQ-03 · OQ-01 · OQ-01:
+  The constructive Bézout solver matches Mathlib's abstract `Finset.gcd`
+
+The parent entry (`Proofs/Hilbert10OQ04OQ03OQ01.lean`, merged PR #26924) builds an
+*explicit, computable* solver for linear Diophantine equations
+`a₀x₀ + … + aₙ₋₁xₙ₋₁ = c`.  Its solvability test is the hand-rolled fold
+`vecGcd n a = Int.gcd (a 0) (Int.gcd (a 1) (… 0))`, defined by structural recursion
+on the coefficient vector so that the extended Euclidean witness can be peeled off
+one coordinate at a time.
+
+Mathlib, on the other hand, packages the gcd of a family of ring elements as the
+abstract `Finset.gcd : Finset β → (β → α) → α`, the normalized gcd over a
+`NormalizedGCDMonoid`.  This is the object that appears in the structural theory of
+finitely generated ideals and invariant factors.
+
+This file **bridges the two**:
+
+* `vecGcd_eq_finset_gcd` — the parent's recursive `vecGcd n a` equals
+  `Finset.univ.gcd a` (the normalized `Finset.gcd` over all coordinates).  Both are
+  non-negative integers, and the fold is exactly the `Finset.cons`-recursion of
+  `Finset.gcd` on `Fin (n+1)`.
+
+* `solvable_iff_finset_gcd_dvd` — consequently the divisibility criterion
+  `Finset.univ.gcd a ∣ c` is **equivalent** to solvability of
+  `∑ i, a i · x i = c`.  The hard ("yes-instance") direction is discharged
+  *verbatim* by the parent's constructive `exists_vec_combo`; the easy direction is
+  the standard "the gcd divides every coefficient, hence the linear combination".
+
+The upshot is that the project's explicit-Bézout-witness construction and Mathlib's
+abstract `Finset.gcd` divisibility criterion describe one and the same predicate.
+
+Self-contained: depends only on Mathlib and the parent file.
+
+Toolchain: leanprover/lean4 v4.26.0.
+-/
+import Mathlib
+import Proofs.Hilbert10OQ04OQ03OQ01
+
+open Hilbert10OQ04OQ03OQ01
+
+namespace Hilbert10OQ04OQ03OQ01OQ01
+
+/-! ## The recursive `vecGcd` agrees with the abstract `Finset.gcd` -/
+
+/-- **The parent's recursive fold equals Mathlib's normalized `Finset.gcd`.**
+
+    `vecGcd n a` (the explicit `Int.gcd`-fold used by the constructive solver) is
+    equal to `Finset.univ.gcd a`, the normalized gcd of the family `a : Fin n → ℤ`.
+    The proof is the induction making the `Fin (n+1)` decomposition
+    `univ = cons 0 (map succ univ)` match the recursion clause
+    `vecGcd (n+1) a = Int.gcd (a 0) (vecGcd n (Fin.tail a))`. -/
+theorem vecGcd_eq_finset_gcd :
+    ∀ (n : ℕ) (a : Fin n → ℤ), vecGcd n a = (Finset.univ : Finset (Fin n)).gcd a := by
+  intro n
+  induction n with
+  | zero =>
+      intro a
+      simp [vecGcd]
+  | succ n ih =>
+      intro a
+      simp only [vecGcd]
+      rw [Fin.univ_succ, Finset.cons_eq_insert, Finset.gcd_insert,
+          Finset.map_eq_image, Finset.gcd_image, Int.coe_gcd]
+      -- Goal: GCDMonoid.gcd (a 0) (vecGcd n (Fin.tail a))
+      --     = GCDMonoid.gcd (a 0) (univ.gcd (a ∘ Fin.succ))
+      -- and `a ∘ Fin.succ` is definitionally `Fin.tail a`.
+      congr 1
+      exact ih (Fin.tail a)
+
+/-! ## Solvability ⇔ the abstract `Finset.gcd` divisibility criterion -/
+
+/-- **Easy direction.**  If `∑ i, a i · x i = c` has a solution, then the gcd of the
+    coefficients divides `c`: the gcd divides every `a i`, hence every summand,
+    hence the sum. -/
+theorem finset_gcd_dvd_of_solvable (n : ℕ) (a : Fin n → ℤ) (c : ℤ)
+    (h : ∃ x : Fin n → ℤ, ∑ i, a i * x i = c) :
+    (Finset.univ : Finset (Fin n)).gcd a ∣ c := by
+  obtain ⟨x, hx⟩ := h
+  rw [← hx]
+  exact Finset.dvd_sum fun i _ => (Finset.gcd_dvd (Finset.mem_univ i)).mul_right (x i)
+
+/-- **Hard direction.**  If the gcd of the coefficients divides `c`, then
+    `∑ i, a i · x i = c` is solvable.  This is the parent's constructive
+    `exists_vec_combo`, restated against the abstract `Finset.gcd` criterion via the
+    bridge `vecGcd_eq_finset_gcd`. -/
+theorem solvable_of_finset_gcd_dvd (n : ℕ) (a : Fin n → ℤ) (c : ℤ)
+    (h : (Finset.univ : Finset (Fin n)).gcd a ∣ c) :
+    ∃ x : Fin n → ℤ, ∑ i, a i * x i = c :=
+  exists_vec_combo n a c (by rw [vecGcd_eq_finset_gcd]; exact h)
+
+/-- **Linear Diophantine solvability ⇔ `Finset.gcd` divisibility.**
+
+    Unifies the project's explicit-Bézout-witness solver with Mathlib's abstract
+    invariant-factor divisibility criterion: the equation `∑ i, a i · x i = c` has an
+    integer solution **iff** `Finset.univ.gcd a ∣ c`.  Both directions are fully
+    proved — the forward implication reuses the parent's constructive witness. -/
+theorem solvable_iff_finset_gcd_dvd (n : ℕ) (a : Fin n → ℤ) (c : ℤ) :
+    (∃ x : Fin n → ℤ, ∑ i, a i * x i = c) ↔
+      (Finset.univ : Finset (Fin n)).gcd a ∣ c :=
+  ⟨finset_gcd_dvd_of_solvable n a c, solvable_of_finset_gcd_dvd n a c⟩
+
+/-! ## Sanity checks -/
+
+-- `3·x + 5·y = 1`: the abstract gcd criterion fires (`Finset.gcd {3,5} = 1 ∣ 1`).
+example : ∃ x : Fin 2 → ℤ, ∑ i, ![3, 5] i * x i = 1 :=
+  (solvable_iff_finset_gcd_dvd 2 ![3, 5] 1).mpr (by decide)
+
+-- `6·x + 4·y = 10`: solvable, and conversely the gcd `2` must divide `10`.
+example : ∃ x : Fin 2 → ℤ, ∑ i, ![6, 4] i * x i = 10 :=
+  (solvable_iff_finset_gcd_dvd 2 ![6, 4] 10).mpr (by decide)
+
+end Hilbert10OQ04OQ03OQ01OQ01

--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "hilbert-10-oq-04-oq-03-oq-01-oq-01",
+  "title": "Hilbert's 10th Problem OQ-04·OQ-03·OQ-01·OQ-01: The Constructive Bézout Solver Matches Mathlib's Finset.gcd",
+  "slug": "hilbert-10-oq-04-oq-03-oq-01-oq-01",
+  "description": "Answers open question oq-01 of the parent (hilbert-10-oq-04-oq-03-oq-01): reconcile the parent's hand-rolled recursive fold vecGcd with Mathlib's abstract normalized Finset.gcd. The bridge vecGcd_eq_finset_gcd proves vecGcd n a = Finset.univ.gcd a by matching the Fin (n+1) decomposition univ = cons 0 (map succ univ) against the recursion clause of vecGcd. As a consequence the divisibility criterion Finset.univ.gcd a ∣ c becomes provably equivalent to solvability of ∑ aᵢxᵢ = c — the forward (hard) direction discharged verbatim by the parent's constructive exists_vec_combo, the reverse by the standard 'gcd divides each coefficient'. This unifies the project's explicit-Bézout-witness construction with Mathlib's abstract invariant-factor divisibility criterion.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-19",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/Hilbert10OQ04OQ03OQ01OQ01.lean",
+    "tags": [
+      "hilbert-10",
+      "diophantine-equations",
+      "bezout",
+      "gcd",
+      "finset-gcd",
+      "normalized-gcd-monoid",
+      "constructive",
+      "research"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 113,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-19",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.gcd",
+        "description": "The normalized gcd of a family f : β → α over a Finset, in a NormalizedGCDMonoid; here α = ℤ",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      },
+      {
+        "theorem": "Int.coe_gcd",
+        "description": "↑(Int.gcd i j) = GCDMonoid.gcd i j; identifies the Nat-valued Int.gcd cast to ℤ with the abstract normalized gcd",
+        "module": "Mathlib.RingTheory.Int.Basic"
+      },
+      {
+        "theorem": "Fin.univ_succ",
+        "description": "(univ : Finset (Fin (n+1))) = cons 0 (univ.map ⟨Fin.succ, _⟩); the head/tail decomposition matching vecGcd's recursion",
+        "module": "Mathlib.Data.Fintype.Basic"
+      },
+      {
+        "theorem": "Finset.gcd_insert",
+        "description": "(insert b s).gcd f = GCDMonoid.gcd (f b) (s.gcd f); peels the head coordinate off the abstract gcd",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      },
+      {
+        "theorem": "Finset.gcd_image",
+        "description": "(s.image g).gcd f = s.gcd (f ∘ g); reindexes the tail gcd along Fin.succ",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      },
+      {
+        "theorem": "Finset.gcd_dvd",
+        "description": "b ∈ s → s.gcd f ∣ f b; the gcd divides every coefficient, giving the easy direction",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      },
+      {
+        "theorem": "Finset.dvd_sum",
+        "description": "(∀ i ∈ s, a ∣ f i) → a ∣ ∑ i ∈ s, f i; lifts per-summand divisibility to the sum",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "vecGcd_eq_finset_gcd: the parent's recursive Int.gcd-fold vecGcd n a equals Mathlib's normalized Finset.univ.gcd a. Proof by induction on n: the Fin (n+1) decomposition univ = cons 0 (map succ univ) (Fin.univ_succ) turns Finset.gcd into GCDMonoid.gcd (a 0) ((map succ univ).gcd a); map_eq_image + Finset.gcd_image reindex the tail to univ.gcd (a ∘ Fin.succ), and Int.coe_gcd identifies the cast Int.gcd with the abstract GCDMonoid.gcd, so the inductive hypothesis on Fin.tail a closes the goal.",
+      "finset_gcd_dvd_of_solvable: the easy direction — if ∑ aᵢxᵢ = c is solvable then Finset.univ.gcd a ∣ c, via Finset.gcd_dvd (gcd divides each aᵢ) and Finset.dvd_sum.",
+      "solvable_of_finset_gcd_dvd: the hard direction — restates the parent's constructive exists_vec_combo against the abstract criterion, transporting the hypothesis Finset.univ.gcd a ∣ c back to vecGcd n a ∣ c through the bridge.",
+      "solvable_iff_finset_gcd_dvd: the resulting equivalence (∃ x, ∑ aᵢxᵢ = c) ↔ Finset.univ.gcd a ∣ c — a fully proved iff whose forward implication reuses the project's explicit witness, unifying the constructive solver with Mathlib's abstract gcd-divisibility criterion."
+    ],
+    "assumptions": "None. The development is sorry-free and axiom-free: only the foundational propext / Classical.choice / Quot.sound are used (no Lean.ofReduceBool, no native_decide). The hard direction of the equivalence inherits the parent's fully constructive witness.",
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Two ways to speak of the gcd of a list of integers coexist in this project. The constructive solver of the parent entry (hilbert-10-oq-04-oq-03-oq-01) uses a hand-rolled fold vecGcd, defined by structural recursion so the extended-Euclidean witness can be peeled off one coordinate at a time. Mathlib instead packages the gcd of a family of ring elements abstractly as Finset.gcd, the normalized gcd over a NormalizedGCDMonoid — the object that appears in the structural theory of finitely generated ideals and invariant factors over a PID. The parent's own open question asked whether these two descriptions are literally the same predicate.",
+    "problemStatement": "Open question oq-01 of hilbert-10-oq-04-oq-03-oq-01: *Can vecGcd be reconciled with Finset.univ.gcd so that the constructive solver discharges the forward direction of the parent's solvable_iff_gcd_dvd verbatim?* Concretely: prove vecGcd n a = Finset.univ.gcd a, and deduce the equivalence (∃ x, ∑ᵢ aᵢ·xᵢ = c) ↔ Finset.univ.gcd a ∣ c.",
+    "proofStrategy": "The core is the identity vecGcd n a = Finset.univ.gcd a, by induction on n. The base case n = 0 is gcd of the empty family = 0 on both sides. For n+1, Fin.univ_succ rewrites the index set univ : Finset (Fin (n+1)) as cons 0 (map Fin.succ univ); cons_eq_insert + Finset.gcd_insert turn the abstract gcd into GCDMonoid.gcd (a 0) ((map Fin.succ univ).gcd a). Finset.map_eq_image and Finset.gcd_image reindex the tail factor to univ.gcd (a ∘ Fin.succ), and a ∘ Fin.succ is definitionally Fin.tail a. On the vecGcd side, Int.coe_gcd identifies ↑(Int.gcd (a 0) (vecGcd n (tail a))) with GCDMonoid.gcd (a 0) (vecGcd n (tail a)). The two heads (a 0) agree, and the inductive hypothesis applied to Fin.tail a equates the tail factors. With the bridge in hand, the equivalence follows: the reverse direction is Finset.gcd_dvd plus Finset.dvd_sum, and the forward direction transports the hypothesis through the bridge into the parent's exists_vec_combo.",
+    "keyInsights": [
+      "Both gcds are normalized to be non-negative: vecGcd is a cast of the Nat-valued Int.gcd, and Finset.gcd over ℤ is normalized by |·|. So they are not merely associated — they are equal on the nose, which is what lets exists_vec_combo be reused verbatim with no associate-juggling.",
+      "Int.coe_gcd is the precise hinge: it says the concrete, computable Int.gcd cast to ℤ *is* the abstract GCDMonoid.gcd. Without it the recursion clause of vecGcd and the insert-clause of Finset.gcd would live in different vocabularies.",
+      "The Fin (n+1) index decomposition Fin.univ_succ (cons 0 (map succ univ)) is exactly the head/tail split that vecGcd recurses on, so the abstract Finset.gcd and the hand-rolled fold unfold in lockstep.",
+      "Once vecGcd = Finset.gcd, the project's explicit-witness solver and Mathlib's abstract divisibility criterion are revealed to be two presentations of a single decidable predicate — the constructive content (an actual solution vector) and the structural content (ideal/invariant-factor divisibility) coincide."
+    ],
+    "text": "This entry settles the parent's open question oq-01. It proves that the constructive solver's bespoke fold vecGcd is literally Mathlib's normalized Finset.univ.gcd, and uses that bridge to upgrade solvability of a linear Diophantine equation into a clean biconditional against the abstract gcd-divisibility criterion. The hard half of the equivalence is the parent's explicit extended-Euclidean witness; the easy half is the observation that the gcd divides every coefficient. The two halves together show the project's computable solver and Mathlib's abstract criterion describe the same predicate."
+  },
+  "sections": [
+    {
+      "id": "vecgcd-bridge",
+      "title": "vecGcd Equals the Abstract Finset.gcd",
+      "startLine": 47,
+      "endLine": 72,
+      "summary": "vecGcd_eq_finset_gcd: by induction on n, the parent's recursive Int.gcd-fold equals Finset.univ.gcd a, matching Fin.univ_succ against the recursion clause.",
+      "mathContext": "Fin.univ_succ + Finset.gcd_insert + Finset.gcd_image align the abstract gcd with the fold; Int.coe_gcd identifies the cast Int.gcd with GCDMonoid.gcd."
+    },
+    {
+      "id": "equivalence",
+      "title": "Solvability ⇔ Finset.gcd Divisibility",
+      "startLine": 74,
+      "endLine": 105,
+      "summary": "finset_gcd_dvd_of_solvable (easy direction via Finset.gcd_dvd / Finset.dvd_sum), solvable_of_finset_gcd_dvd (hard direction via the bridge + parent's exists_vec_combo), and the packaged biconditional solvable_iff_finset_gcd_dvd.",
+      "mathContext": "The gcd divides each coefficient so it divides any combination; conversely if it divides c the explicit witness exists."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Worked Instances",
+      "startLine": 103,
+      "endLine": 111,
+      "summary": "3x + 5y = 1 and 6x + 4y = 10 solved through the abstract criterion via solvable_iff_finset_gcd_dvd.mpr (by decide).",
+      "mathContext": "Finset.gcd of {3,5} is 1 ∣ 1 and of {6,4} is 2 ∣ 10."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "oq-01",
+      "question": "Does the equivalence extend to systems A·x = b over ℤ, identifying solvability with the divisibility of b by the invariant factors (Smith normal form) of A?",
+      "status": "open",
+      "notes": "This is the sibling direction hilbert-10-oq-04-oq-03-oq-02: the single-equation Finset.gcd criterion would generalize to the invariant-factor divisibility criterion for systems, with Module.Basis.SmithNormalForm providing the constructive witness."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "hilbert-10-oq-04-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "Answers open question oq-01 of the parent: reconciles the parent's recursive vecGcd with Mathlib's Finset.univ.gcd, so the constructive solver discharges the forward direction of solvable_iff_gcd_dvd verbatim."
+    },
+    {
+      "targetId": "hilbert-10-oq-04-oq-03",
+      "relationship": "extends",
+      "description": "Recasts the grandparent's gcd-divisibility decision criterion as an explicit biconditional against Mathlib's abstract Finset.gcd."
+    }
+  ]
+}

--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01/meta.json
@@ -115,8 +115,8 @@
     {
       "id": "oq-01",
       "question": "Can vecGcd be reconciled with Finset.univ.gcd so the constructive solver discharges the forward direction of the parent's solvable_iff_gcd_dvd verbatim?",
-      "status": "feasible",
-      "notes": "vecGcd and Finset.univ.gcd are both gcds of the coefficient set, hence associated over ℤ, so vecGcd n a ∣ c ↔ (Finset.univ.gcd a : ℤ) ∣ c. Proving this bridge would let exists_vec_combo replace the non-constructive forward direction of solvable_iff_gcd_dvd directly."
+      "status": "resolved",
+      "notes": "Answered by hilbert-10-oq-04-oq-03-oq-01-oq-01: vecGcd_eq_finset_gcd proves vecGcd n a = Finset.univ.gcd a on the nose (both are normalized non-negative gcds), and solvable_iff_finset_gcd_dvd packages the resulting equivalence (∃ x, ∑ aᵢxᵢ = c) ↔ Finset.univ.gcd a ∣ c, with exists_vec_combo discharging the forward direction verbatim."
     },
     {
       "id": "oq-02",


### PR DESCRIPTION
## Summary

Answers open question **oq-01** of the constructive Bézout solver (`hilbert-10-oq-04-oq-03-oq-01`, merged PR #26924): reconcile the parent's hand-rolled recursive fold `vecGcd` with Mathlib's abstract normalized `Finset.gcd`.

## Results (`Proofs/Hilbert10OQ04OQ03OQ01OQ01.lean`)

- **`vecGcd_eq_finset_gcd`** — `vecGcd n a = Finset.univ.gcd a`, on the nose. Both are normalized, non-negative gcds, so equality holds (no associate-juggling). Proof by induction: `Fin.univ_succ`'s `cons 0 (map succ univ)` decomposition matches `vecGcd`'s recursion clause; `Finset.gcd_insert` + `Finset.gcd_image` peel/reindex; `Int.coe_gcd` identifies the cast `Int.gcd` with `GCDMonoid.gcd`.
- **`solvable_iff_finset_gcd_dvd`** — `(∃ x, ∑ aᵢxᵢ = c) ↔ Finset.univ.gcd a ∣ c`. The hard (forward) direction is discharged **verbatim** by the parent's constructive `exists_vec_combo`; the easy direction is `Finset.gcd_dvd` + `Finset.dvd_sum`.

This unifies the project's explicit-Bézout-witness construction with Mathlib's abstract invariant-factor divisibility criterion — they describe one and the same decidable predicate.

## Verification

Sorry-free and axiom-free — `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` (no `Lean.ofReduceBool`, no `native_decide`). Type-checked via single-file `lake env lean` against the prebuilt Mathlib oleans and the parent module (Docker build infra independent).

- `status: verified`, `badge: original`, `sorries: 0`, `axiomCount: 0`
- Marks the parent entry's oq-01 as `resolved`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)