### PR TITLE
research(lagrange-theorem-oq-02-oq-01-oq-02): stabilizer sum ∑ₓ|Stab(x)| = |X/G|·|G|

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ02OQ01OQ02.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ02OQ01OQ02.lean
@@ -1,0 +1,94 @@
+import Mathlib.GroupTheory.GroupAction.Quotient
+import Mathlib.Algebra.BigOperators.Finprod
+import Mathlib.SetTheory.Cardinal.Finite
+import Mathlib.Tactic
+
+/-
+# The Stabilizer Sum: ∑ₓ |Stab(x)| = |X/G| · |G|
+
+## Open Question (lagrange-theorem-oq-02-oq-01-oq-02)
+For a finite group `G` acting on a finite set `X`, evaluate the sum of stabilizer
+orders over the *points* of `X`:
+
+  `∑ₓ |Stab(x)| = |X⧸G| · |G|`.
+
+This is the "dual" of Burnside / Cauchy–Frobenius, which sums fixed-point counts
+over the *group*: `∑_g |Fix(g)| = |X⧸G| · |G|`.
+
+## Answer: YES — it is the same orbit-count `|X⧸G| · |G|`, by Fubini on fixed pairs.
+
+Both sums count the **same set of fixed pairs** `{(g, x) : g • x = x}`:
+
+  `∑ₓ |Stab(x)| = #{(x, g) : g • x = x} = #{(g, x) : g • x = x} = ∑_g |Fix(g)|`,
+
+because `g ∈ Stab(x) ↔ g • x = x ↔ x ∈ Fix(g)` — the two membership conditions are
+literally the same proposition.  The swap of summation order is realized by the
+explicit `Equiv`
+
+  `stabSigmaEquivFixedBySigma : (Σ x : X, Stab(x)) ≃ (Σ g : G, Fix(g))`,
+
+which transposes a pair `(x, ⟨g, hg⟩)` to `(g, ⟨x, hx⟩)` (the proofs `hg` and `hx`
+coincide).  Composing it with Mathlib's finiteness-free orbit-counting bijection
+`MulAction.sigmaFixedByEquivOrbitsProdGroup : (Σ g, Fix(g)) ≃ (X⧸G) × G` and taking
+`Nat.card` of both sides yields the result directly — never passing through
+Burnside's sum as an intermediate quantity.
+
+We state the result with the instance-free `Nat.card` and a `finsum` (`∑ᶠ`), the
+canonical way to sum over a `Finite` type without choosing a `Fintype`, exactly as
+the sibling `BurnsideFinite` entry does, and then recover the bundled `Fintype`
+form as a corollary.
+
+No new axioms: `propext`, `Classical.choice`, `Quot.sound` only.
+-/
+
+namespace StabilizerSum
+
+open MulAction
+
+variable (G : Type*) (X : Type*) [Group G] [MulAction G X]
+
+/-- **The transposition of fixed pairs.** Sending `(x, ⟨g, hg⟩)` to `(g, ⟨x, hx⟩)`
+is a bijection between `Σ x, Stab(x)` and `Σ g, Fix(g)`: the stabilizer condition
+`g ∈ stabilizer G x` and the fixed-point condition `x ∈ fixedBy X g` are both the
+single proposition `g • x = x`. -/
+def stabSigmaEquivFixedBySigma :
+    (Σ x : X, stabilizer G x) ≃ Σ g : G, fixedBy X g where
+  toFun := fun ⟨x, g, hg⟩ => ⟨g, x, (mem_fixedBy).2 ((mem_stabilizer_iff).1 hg)⟩
+  invFun := fun ⟨g, x, hx⟩ => ⟨x, g, (mem_stabilizer_iff).2 ((mem_fixedBy).1 hx)⟩
+  left_inv := fun ⟨_, _, _⟩ => rfl
+  right_inv := fun ⟨_, _, _⟩ => rfl
+
+/-- **The stabilizer sum over `Finite`.**
+
+For a `Finite` group `G` acting on a `Finite` set `X`, the sum of stabilizer orders
+over the points of `X` equals the number of orbits times the group order:
+
+  `∑ᶠ x : X, Nat.card (stabilizer G x) = Nat.card (X ⧸ G) · Nat.card G`.
+
+The proof transposes the fixed-pair sigma type via `stabSigmaEquivFixedBySigma`,
+then applies Mathlib's orbit-counting bijection `sigmaFixedByEquivOrbitsProdGroup`
+— so it equals `|X⧸G|·|G|` without computing Burnside's group-side sum. -/
+theorem sum_card_stabilizer_eq_card_orbits_mul_card_group_of_finite
+    [Finite G] [Finite X] :
+    ∑ᶠ x : X, Nat.card (stabilizer G x)
+      = Nat.card (orbitRel.Quotient G X) * Nat.card G := by
+  -- A (non-constructive) `Fintype X` turns the `finsum` into a `Finset` sum.
+  cases nonempty_fintype X
+  rw [finsum_eq_sum_of_fintype, ← Nat.card_sigma,
+    Nat.card_congr ((stabSigmaEquivFixedBySigma G X).trans
+      (sigmaFixedByEquivOrbitsProdGroup G X)),
+    Nat.card_prod]
+
+/-- The same identity in bundled `Fintype` form, summing `Fintype.card (stabilizer G x)`
+over a `Finset` and matching the shape of Mathlib's
+`sum_card_fixedBy_eq_card_orbits_mul_card_group`. -/
+theorem sum_card_stabilizer_eq_card_orbits_mul_card_group
+    [Fintype G] [Fintype X] [∀ x : X, Fintype (stabilizer G x)]
+    [Fintype (orbitRel.Quotient G X)] :
+    ∑ x : X, Fintype.card (stabilizer G x)
+      = Fintype.card (orbitRel.Quotient G X) * Fintype.card G := by
+  have h := sum_card_stabilizer_eq_card_orbits_mul_card_group_of_finite G X
+  rw [finsum_eq_sum_of_fintype] at h
+  simpa only [Nat.card_eq_fintype_card] using h
+
+end StabilizerSum

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "ann-lag020102-context",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "The Stabilizer Sum as the Dual of Burnside",
+    "content": "Burnside's lemma sums fixed-point counts over the group: ∑_g |Fix(g)| = |X⧸G|·|G|. This entry proves the dual that sums stabilizer orders over the points: ∑ₓ |Stab(x)| = |X⧸G|·|G|. The two are equal because both count the single set of fixed pairs {(g,x) : g•x=x} — reading it column-by-column (fix g, count fixed x) gives Burnside, reading it row-by-row (fix x, count stabilizing g) gives this sum. The pool's requirement was to obtain |X⧸G|·|G| 'without Burnside as intermediate', so the proof routes through the orbit-counting bijection directly rather than citing Burnside's value.",
+    "mathContext": "For a finite group action, $\\sum_{x\\in X}|\\mathrm{Stab}(x)| = \\#\\{(g,x): g\\cdot x = x\\} = \\sum_{g\\in G}|\\mathrm{Fix}(g)| = |X/G|\\cdot|G|$. The middle equality is Fubini on a finite double-indexed set; the last is the orbit-counting (Cauchy–Frobenius) lemma. Dividing by $|G|$ recovers the orbit-count average $|X/G| = \\frac{1}{|G|}\\sum_g|\\mathrm{Fix}(g)|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "orbit-counting lemma",
+      "Cauchy–Frobenius / Burnside",
+      "stabilizer vs fixed-point duality",
+      "Fubini on fixed pairs"
+    ],
+    "prerequisites": [
+      "group action stabilizer and fixed-point sets",
+      "orbit space X⧸G",
+      "Mathlib sigmaFixedByEquivOrbitsProdGroup"
+    ]
+  },
+  {
+    "id": "ann-lag020102-equiv",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 51, "endLine": 64 },
+    "type": "technique",
+    "title": "The Transposition Equiv stabSigmaEquivFixedBySigma",
+    "content": "The heart of the proof is the bijection (Σ x : X, stabilizer G x) ≃ (Σ g : G, fixedBy X g) that transposes a fixed pair: (x, ⟨g, hg⟩) ↦ (g, ⟨x, hx⟩). The membership proofs convert via `(mem_fixedBy).2 ((mem_stabilizer_iff).1 hg)` — but since both `g ∈ stabilizer G x` and `x ∈ fixedBy X g` unfold to the same proposition `g • x = x`, the round-trips `left_inv` and `right_inv` are closed by `rfl`. This is the formal content of 'swap the order of summation'.",
+    "mathContext": "Transposing the indexing of a sum over a product/relation is the categorical statement of Fubini for counting measures. Here the relation is the graph of the action's fixed pairs; its two projections give the stabilizer sum and the fixed-point sum.",
+    "significance": "important",
+    "relatedConcepts": ["Equiv on sigma types", "mem_stabilizer_iff", "mem_fixedBy", "definitional equality"],
+    "prerequisites": ["sigma types", "subtype membership defeq"]
+  },
+  {
+    "id": "ann-lag020102-main",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 66, "endLine": 81 },
+    "type": "technique",
+    "title": "Counting the Fixed Pairs over Finite",
+    "content": "`sum_card_stabilizer_eq_card_orbits_mul_card_group_of_finite` is stated with the instance-free `Nat.card` and a `finsum` (∑ᶠ), the canonical 'sum over a Finite type' idiom (matching the sibling BurnsideFinite entry). After `cases nonempty_fintype X` supplies a non-constructive Fintype, the single rewrite chain does it all: `finsum_eq_sum_of_fintype` turns ∑ᶠ into a Finset sum, `← Nat.card_sigma` folds it into `Nat.card (Σ x, stabilizer G x)`, `Nat.card_congr (stabSigmaEquivFixedBySigma.trans sigmaFixedByEquivOrbitsProdGroup)` transports along the composed bijection to `Nat.card ((X⧸G) × G)`, and `Nat.card_prod` splits the product. Burnside's group-side sum is never formed.",
+    "mathContext": "The composition stabSigmaEquivFixedBySigma ≫ sigmaFixedByEquivOrbitsProdGroup is a single bijection (Σ x, Stab x) ≃ (X⧸G) × G; taking cardinalities is the whole proof. Working with Nat.card avoids any Fintype-instance diamond and keeps the statement at the Finite level of generality.",
+    "significance": "important",
+    "relatedConcepts": ["Nat.card_sigma", "Nat.card_congr", "Nat.card_prod", "finsum_eq_sum_of_fintype"],
+    "prerequisites": ["sigmaFixedByEquivOrbitsProdGroup", "Nat.card API"]
+  },
+  {
+    "id": "ann-lag020102-recovered",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 83, "endLine": 92 },
+    "type": "technique",
+    "title": "The Bundled Fintype Corollary",
+    "content": "`sum_card_stabilizer_eq_card_orbits_mul_card_group` restates the identity with explicit Fintype instances and `Fintype.card`, matching the shape of Mathlib's `sum_card_fixedBy_eq_card_orbits_mul_card_group`. It is recovered from the Finite version by `finsum_eq_sum_of_fintype` and `simpa only [Nat.card_eq_fintype_card]`, certifying that the Nat.card statement subsumes the bundled one.",
+    "mathContext": "Recovering the Fintype.card form confirms no generality was lost: the Finite/Nat.card statement specializes to the classical finite-group form by supplying the (constructive) instances.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.card_eq_fintype_card", "Fintype vs Finite", "simpa"],
+    "prerequisites": ["Fintype.card", "Nat.card_eq_fintype_card"]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,122 @@
+{
+  "id": "lagrange-theorem-oq-02-oq-01-oq-02",
+  "slug": "lagrange-theorem-oq-02-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.GroupAction.Quotient",
+      "Mathlib.Algebra.BigOperators.Finprod",
+      "Mathlib.SetTheory.Cardinal.Finite",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MulAction"
+    ],
+    "namespace": "StabilizerSum",
+    "lineCount": 94,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "path": "Proofs/LagrangeTheoremOQ02OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Stabilizer Sum: ∑ₓ |Stab(x)| = |X/G| · |G|",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ02OQ01OQ02.lean",
+    "tags": [
+      "group-theory",
+      "orbit-counting",
+      "stabilizer",
+      "burnside",
+      "mulaction",
+      "fixed-pairs",
+      "nat-card",
+      "finsum",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 94,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "badge": "mathlib",
+    "originalContributions": [
+      "stabSigmaEquivFixedBySigma: the explicit transposition (Σ x : X, stabilizer G x) ≃ (Σ g : G, fixedBy X g) of the fixed-pair set {(g,x) : g•x=x}, built from the defeq of mem_stabilizer_iff and mem_fixedBy (both g•x=x)",
+      "sum_card_stabilizer_eq_card_orbits_mul_card_group_of_finite: ∑ᶠ x, Nat.card (stabilizer G x) = Nat.card (X⧸G) · Nat.card G over Finite G, X — the point-side dual of Burnside, proved by composing the transposition with sigmaFixedByEquivOrbitsProdGroup (never passing through Burnside's group-side sum)",
+      "sum_card_stabilizer_eq_card_orbits_mul_card_group: the bundled Fintype form ∑ x, Fintype.card (stabilizer G x) = Fintype.card (X⧸G) · Fintype.card G, matching the shape of Mathlib's sum_card_fixedBy_eq_card_orbits_mul_card_group"
+    ],
+    "prerequisites": [
+      "Group actions and stabilizers (MulAction.stabilizer)",
+      "Fixed-point sets (MulAction.fixedBy)",
+      "Mathlib's orbit-counting bijection sigmaFixedByEquivOrbitsProdGroup",
+      "Nat.card / finsum bookkeeping (Nat.card_sigma, Nat.card_prod, Nat.card_congr, finsum_eq_sum_of_fintype)",
+      "Parent: lagrange-theorem (group order divisibility) and the orbit-stabilizer theorem"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.sigmaFixedByEquivOrbitsProdGroup",
+        "description": "The finiteness-free bijection (Σ g : G, fixedBy X g) ≃ (X⧸G) × G underlying Burnside's lemma. Composed with the stabilizer-side transposition to count the fixed pairs as |X⧸G|·|G|.",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "MulAction.mem_stabilizer_iff",
+        "description": "g ∈ stabilizer G a ↔ g • a = a. Together with mem_fixedBy this is the defeq that makes the transposition stabSigmaEquivFixedBySigma well-defined.",
+        "module": "Mathlib.GroupTheory.GroupAction.Defs"
+      },
+      {
+        "theorem": "MulAction.mem_fixedBy",
+        "description": "a ∈ fixedBy α m ↔ m • a = a. The fixed-point membership condition matched against the stabilizer condition in the transposition.",
+        "module": "Mathlib.GroupTheory.GroupAction.Defs"
+      },
+      {
+        "theorem": "Nat.card_sigma",
+        "description": "Nat.card (Σ i, f i) = ∑ i, Nat.card (f i) — converts the stabilizer-sum into the cardinality of the fixed-pair sigma type.",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "lagrange-theorem-oq-02-oq-01-oq-02-oq-01",
+      "question": "Derive the two-sided averaging identity directly: combine the stabilizer sum ∑ₓ |Stab(x)| and Burnside's ∑_g |Fix(g)| into a single statement ∑ₓ |Stab(x)| = ∑_g |Fix(g)| as an explicit Fubini theorem on the fixed-pair set, and deduce the Burnside orbit-count average |X⧸G| = (1/|G|) ∑_g |Fix(g)| from it.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling. That entry proves the group-side Burnside sum ∑_g |Fix(g)| = |X⧸G|·|G| over Finite via the same sigmaFixedByEquivOrbitsProdGroup bijection; this entry proves the point-side dual ∑ₓ |Stab(x)| = |X⧸G|·|G|. Both count the fixed pairs {(g,x) : g•x=x}; together they give ∑ₓ |Stab(x)| = ∑_g |Fix(g)|."
+    },
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "extends",
+      "description": "Parent. The orbit-stabilizer theorem |orbit x|·|Stab x| = |G| is the per-point form of Lagrange's theorem; summing it over the orbit decomposition of X gives this entry's ∑ₓ |Stab(x)| = |X⧸G|·|G|."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: GroupTheory.GroupAction.Quotient",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of sigmaFixedByEquivOrbitsProdGroup and the orbit-stabilizer theorem card_orbit_mul_card_stabilizer_eq_card_group."
+    },
+    {
+      "title": "Théorie des substitutions et des équations algébriques",
+      "author": "William Burnside / Augustin-Louis Cauchy / Ferdinand Frobenius",
+      "year": "1897",
+      "venue": "orbit-counting lemma (Cauchy–Frobenius)",
+      "description": "The classical orbit-counting lemma whose point-side dual is formalized here."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For a finite group G acting on a finite set X, the sum of stabilizer orders over the points of X equals the number of orbits times the group order: ∑ₓ |Stab(x)| = |X⧸G|·|G|. This is the point-side dual of Burnside's group-side sum ∑_g |Fix(g)| = |X⧸G|·|G|, and the proof makes the duality explicit: both sums count the fixed-pair set {(g,x) : g•x=x}, related by the transposition Equiv stabSigmaEquivFixedBySigma, which composed with Mathlib's sigmaFixedByEquivOrbitsProdGroup gives |X⧸G|·|G| directly — never invoking Burnside's sum as an intermediate. Stated over Finite with Nat.card and finsum, with the bundled Fintype form recovered as a corollary. 94 lines, 1 definition, 2 theorems, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The honest content is the transposition of summation order on the fixed pairs — the rest is inherited from Mathlib's finiteness-free Burnside bijection. Its value is to complete the orbit-counting picture with the point-indexed sum, exhibiting ∑ₓ |Stab(x)| = ∑_g |Fix(g)| as two readings of the same fixed-pair count, and to do so without taking Burnside's sum as a black box (the pool's stated requirement: 'without Burnside as intermediate').",
+    "openQuestions": [
+      "State the Fubini identity ∑ₓ |Stab(x)| = ∑_g |Fix(g)| directly and derive the Burnside orbit-count average |X⧸G| = (1/|G|) ∑_g |Fix(g)| from it."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

The **point-side dual** of Burnside's lemma. Where the sibling `lagrange-theorem-oq-02-oq-02-oq-01-oq-01` sums fixed-point counts over the *group* (`∑_g |Fix(g)| = |X⧸G|·|G|`), this entry sums stabilizer orders over the *points*:

```
∑ₓ |Stab(x)| = |X⧸G| · |G|
```

Both sums count the same fixed-pair set `{(g,x) : g•x = x}`. The proof makes the duality explicit and, per the pool's requirement, reaches `|X⧸G|·|G|` **without forming Burnside's sum as an intermediate**.

Contents (`Proofs/LagrangeTheoremOQ02OQ01OQ02.lean`, namespace `StabilizerSum`):

- `stabSigmaEquivFixedBySigma` — the transposition `Equiv` `(Σ x, stabilizer G x) ≃ (Σ g, fixedBy X g)`; well-defined because `mem_stabilizer_iff` and `mem_fixedBy` both unfold to `g • x = x` (round-trips close by `rfl`).
- `sum_card_stabilizer_eq_card_orbits_mul_card_group_of_finite` — over `Finite G`, `Finite X`, with `Nat.card`/`finsum`: composes the transposition with Mathlib's finiteness-free `sigmaFixedByEquivOrbitsProdGroup`, so a single `Nat.card_congr` lands directly on `(X⧸G) × G`.
- `sum_card_stabilizer_eq_card_orbits_mul_card_group` — bundled `Fintype` form, matching Mathlib's `sum_card_fixedBy_eq_card_orbits_mul_card_group`.

## Honesty

The honest new content is the transposition of summation order; everything else is inherited from Mathlib's Burnside bijection. This is a routine-but-clean orbit-counting result, not original mathematics. Badge: `mathlib`.

## Verification

`lake env lean` against pinned Mathlib (v4.26): compiles clean, 0 sorries, 0 `axiom` declarations.

```
#print axioms = [propext, Classical.choice, Quot.sound]
```

→ `status: verified`, `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)