### PR TITLE
research(area-of-circle-oq-07-oq-04): squared complex Gaussian (∫ e^{-b x²})² = π/b

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ07OQ04.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ04.lean
@@ -1,0 +1,64 @@
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Tactic
+
+/-
+# The Squared Complex Gaussian Integral (∫ e^{-b x²})² = π/b
+
+## Open Question (area-of-circle-oq-07-oq-04)
+For the complex-parameter Gaussian of the sibling `area-of-circle-oq-07-oq-01`,
+∫_ℝ e^{-b x²} dx = (π/b)^{1/2}, formalize that its **square** is the clean
+rational value
+    (∫_ℝ e^{-b x²} dx)² = π / b
+for every `b : ℂ` with `0 < re b`.
+
+## Answer: YES.
+
+Squaring removes the branch-cut subtlety of the principal `(1/2)`-power: while
+the integral itself is `(π/b)^{1/2}`, its square collapses to `π/b` directly.
+Over the right half-plane `{b : ℂ | re b > 0}` the base `π/b` is nonzero, so
+`(π/b)^{1/2} · (π/b)^{1/2} = (π/b)^{1/2 + 1/2} = (π/b)^1 = π/b`
+by `Complex.cpow_add`.  This is the complex-parameter form of the classical
+two-dimensional trick `(∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} = π` that underlies the
+area-of-a-circle / Gaussian computation in the parent `area-of-circle-oq-07`.
+
+The parent's real value `(∫_ℝ e^{-x²})² = π` is the `b = 1` specialization,
+recorded as `gaussian_integral_sq_eq_pi`: the integrand is real-valued, so the
+real integral is the pushforward of the complex one through `ℂ`
+(`integral_complex_ofReal`), and `π / 1 = π`.
+
+No new axioms: a routine squaring and casting of existing Mathlib results.
+-/
+
+open Real Complex MeasureTheory
+
+/-- **The squared complex Gaussian integral.** For every complex `b` with
+positive real part, `(∫_ℝ e^{-b x²} dx)² = π/b`.  Squaring the principal
+`(1/2)`-power value `(π/b)^{1/2}` of Mathlib's `integral_gaussian_complex`
+returns the clean rational value `π/b`, the complex-parameter form of the
+classical `(∫ e^{-x²})² = π`. -/
+theorem gaussian_integral_complex_sq {b : ℂ} (hb : 0 < b.re) :
+    (∫ x : ℝ, Complex.exp (-b * (x : ℂ) ^ 2)) ^ 2 = (↑π : ℂ) / b := by
+  have hb_ne : b ≠ 0 := by rintro rfl; simp at hb
+  have hz : ((↑π : ℂ) / b) ≠ 0 :=
+    div_ne_zero (by exact_mod_cast Real.pi_ne_zero) hb_ne
+  rw [integral_gaussian_complex hb, pow_two, ← Complex.cpow_add _ _ hz]
+  norm_num
+
+/-- The real parent value `(∫_ℝ e^{-x²} dx)² = π` is the `b = 1` case: the
+integrand is real-valued, so the real integral pushes forward to the complex
+Gaussian, and `π / 1 = π`. -/
+theorem gaussian_integral_sq_eq_pi :
+    (∫ x : ℝ, Real.exp (-x ^ 2)) ^ 2 = Real.pi := by
+  have hc := gaussian_integral_complex_sq (b := 1) (by simp)
+  have hLcast : ((∫ x : ℝ, Real.exp (-x ^ 2) : ℝ) : ℂ)
+      = ∫ x : ℝ, Complex.exp (-1 * (x : ℂ) ^ 2) := by
+    rw [← integral_complex_ofReal]
+    congr 1
+    funext x
+    rw [Complex.ofReal_exp]
+    congr 1
+    push_cast
+    ring
+  rw [div_one] at hc
+  rw [← hLcast] at hc
+  exact_mod_cast hc

--- a/src/data/proofs/area-of-circle-oq-07-oq-04/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-aoc07oq04-context",
+    "proofId": "area-of-circle-oq-07-oq-04",
+    "range": { "startLine": 4, "endLine": 30 },
+    "type": "concept",
+    "title": "Squaring Removes the Branch Cut",
+    "content": "The sibling `area-of-circle-oq-07-oq-01` evaluates the complex Gaussian `∫_ℝ e^{-b x²} dx = (π/b)^{1/2}`, a genuine complex principal `(1/2)`-power. This entry observes that its **square** is far simpler: `(∫_ℝ e^{-b x²} dx)² = π/b`, with no fractional power. Over the right half-plane `{b : ℂ | re b > 0}` the base `π/b` is nonzero, so the two half-powers add cleanly. This is the complex-parameter form of the classical two-dimensional identity `(∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} = π` that computes the Gaussian (and, in the parent, the area of a circle).",
+    "mathContext": "The one-dimensional value $(\\pi/b)^{1/2}$ is single-valued only after fixing the principal branch of the complex power, and on the boundary $\\operatorname{re} b = 0$ that branch governs the Fresnel phase. Its square $\\pi/b$ is a single-valued rational function of $b$ on the half-plane, which is why downstream normalization constants are stated in terms of the square.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complex Gaussian integral",
+      "principal complex power",
+      "two-dimensional squaring trick",
+      "branch cut"
+    ],
+    "prerequisites": [
+      "complex-valued Lebesgue integral over ℝ",
+      "Mathlib integral_gaussian_complex",
+      "sibling area-of-circle-oq-07-oq-01 (the complex Gaussian value)"
+    ]
+  },
+  {
+    "id": "ann-aoc07oq04-sq",
+    "proofId": "area-of-circle-oq-07-oq-04",
+    "range": { "startLine": 34, "endLine": 45 },
+    "type": "technique",
+    "title": "Collapsing the Power via Complex.cpow_add",
+    "content": "`gaussian_integral_complex_sq` rewrites the integral to `(π/b)^{1/2}` (Mathlib's `integral_gaussian_complex`), expands the square with `pow_two` to `(π/b)^{1/2} · (π/b)^{1/2}`, then applies `Complex.cpow_add` in reverse to fuse the exponents into `(π/b)^{1/2 + 1/2}`. The side condition of `cpow_add` is `π/b ≠ 0`, supplied by `div_ne_zero` from `Real.pi_ne_zero` and `b ≠ 0` (which follows from `0 < re b`). A final `norm_num` evaluates `1/2 + 1/2 = 1` and discharges `(π/b)^1 = π/b`.",
+    "mathContext": "The additive law $x^{y+z} = x^y\\,x^z$ for complex principal powers holds precisely when $x \\neq 0$; this is the single hypothesis that the right half-plane guarantees. Without it (e.g. crossing to $b$ with $\\pi/b$ a negative real) the half-powers would not add and the square would pick up a sign from the branch cut.",
+    "significance": "important",
+    "relatedConcepts": ["Complex.cpow_add", "pow_two", "div_ne_zero", "right half-plane re b > 0"],
+    "prerequisites": ["integral_gaussian_complex", "Complex.cpow_add"]
+  },
+  {
+    "id": "ann-aoc07oq04-recover",
+    "proofId": "area-of-circle-oq-07-oq-04",
+    "range": { "startLine": 47, "endLine": 64 },
+    "type": "technique",
+    "title": "Recovering π as the b = 1 Case",
+    "content": "`gaussian_integral_sq_eq_pi` derives the parent's real value `(∫_ℝ e^{-x²} dx)² = π` from the complex result at `b = 1`. The cast `hLcast` identifies the real integral with its complex image: since the integrand is real-valued, `integral_complex_ofReal` moves the `ℂ`-coercion outside the integral, and pointwise `↑(e^{-x²}) = e^{-1·(↑x)²}` by `Complex.ofReal_exp` plus `push_cast; ring`. With `π/1` simplified to `π` by `div_one`, rewriting the hypothesis and `exact_mod_cast` finishes.",
+    "mathContext": "The squared statement is what the parent `area-of-circle-oq-07` actually computes en route to `√π`: the two-dimensional Gaussian integral equals `π` directly, and the square root is extracted afterward. Recovering `π` (rather than `√π`) at `b = 1` makes this entry the faithful complex lift of the parent's central computation.",
+    "significance": "important",
+    "relatedConcepts": ["integral_complex_ofReal", "Complex.ofReal_exp", "div_one", "exact_mod_cast"],
+    "prerequisites": ["gaussian_integral_complex_sq", "Complex.ofReal_exp"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-04/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "area-of-circle-oq-07-oq-04",
+  "slug": "area-of-circle-oq-07-oq-04",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Complex",
+      "MeasureTheory"
+    ],
+    "namespace": "",
+    "lineCount": 64,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ04.lean",
+    "sorries": 0
+  },
+  "title": "The Squared Complex Gaussian Integral (∫ e^{-b x²})² = π/b",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ04.lean",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "complex-analysis",
+      "special-functions",
+      "measure-theory",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 64,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "gaussian_integral_complex_sq: (∫_ℝ e^{-b x²} dx)² = π/b for every b : ℂ with 0 < re b — squaring the principal (1/2)-power value (π/b)^{1/2} of the sibling area-of-circle-oq-07-oq-01 collapses to the clean rational value π/b, the complex-parameter form of the classical (∫ e^{-x²})² = π",
+      "gaussian_integral_sq_eq_pi: recovers the real parent (∫_ℝ e^{-x²} dx)² = π as the b = 1 specialization, pushing the real-valued integral through ℂ (integral_complex_ofReal) and simplifying π/1 = π"
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ with complex-valued integrand (MeasureTheory)",
+      "Mathlib's complex Gaussian integral integral_gaussian_complex",
+      "Complex principal powers (Complex.cpow) and the additive law Complex.cpow_add",
+      "Sibling: area-of-circle-oq-07-oq-01 (the complex Gaussian ∫ e^{-b x²} = (π/b)^{1/2})",
+      "Parent: area-of-circle-oq-07 (the real Gaussian ∫ e^{-x²} = √π)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_gaussian_complex",
+        "description": "For b : ℂ with 0 < re b, ∫ x : ℝ, exp (-b * x²) = (π/b)^{1/2} — the complex-parameter Gaussian integral. Squared here to obtain π/b.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "Complex.cpow_add",
+        "description": "x ≠ 0 → x ^ (y + z) = x ^ y * x ^ z — the additive law for complex principal powers. Used in reverse to collapse (π/b)^{1/2} · (π/b)^{1/2} = (π/b)^{1/2+1/2} = (π/b)^1, valid because π/b ≠ 0 on the right half-plane.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Complex"
+      },
+      {
+        "theorem": "integral_complex_ofReal",
+        "description": "∫ x, ((f x : ℝ) : ℂ) = ↑(∫ x, f x) — moves a real-valued integrand through the ℂ coercion. Used to identify the real squared Gaussian with its complex image at b = 1.",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-04-oq-01",
+      "question": "Derive the two-dimensional area form directly: prove (∫_ℝ e^{-b x²})² = ∫_{ℝ²} e^{-b(x²+y²)} by Fubini and a polar-coordinate change of variables, exhibiting π/b as the literal area integral of the radially symmetric Gaussian rather than as the square of the one-dimensional value.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07-oq-01",
+      "relationship": "extends",
+      "description": "Sibling. This entry squares oq-01's complex Gaussian value (π/b)^{1/2} to the clean rational π/b, removing the branch-cut subtlety of the principal (1/2)-power via Complex.cpow_add over the right half-plane {re b > 0}."
+    },
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "extends",
+      "description": "Parent. Recovers the parent's squared real value (∫_ℝ e^{-x²})² = π as the b = 1 specialization in gaussian_integral_sq_eq_pi."
+    },
+    {
+      "targetId": "gaussian-integral",
+      "relationship": "related",
+      "description": "The real parametrized Gaussian ∫ e^{-b x²} = √(π/b), whose square π/b this entry establishes in the complex-parameter form."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_gaussian_complex : for 0 < re b, ∫ x : ℝ, exp (-b * x²) = (π/b)^{1/2}, squared here to π/b."
+    },
+    {
+      "title": "Fourier Analysis",
+      "author": "Elias M. Stein and Rami Shakarchi",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "description": "Classical treatment of the Gaussian integral, including the two-dimensional squaring trick (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} = π that this entry mirrors in the complex parameter."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Squaring the complex Gaussian removes the branch-cut subtlety of the principal (1/2)-power: for every b : ℂ with 0 < re b, (∫_ℝ e^{-b x²} dx)² = π/b. The integral itself is (π/b)^{1/2} (sibling area-of-circle-oq-07-oq-01, Mathlib's integral_gaussian_complex), and because π/b is nonzero on the right half-plane, Complex.cpow_add collapses (π/b)^{1/2} · (π/b)^{1/2} = (π/b)^{1/2+1/2} = (π/b)^1 = π/b. The parent's real value (∫_ℝ e^{-x²})² = π is the b = 1 case, recorded in gaussian_integral_sq_eq_pi via integral_complex_ofReal and π/1 = π. 64 lines, 2 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The clean value π/b — with no fractional power — is the complex-parameter analogue of the classical two-dimensional trick (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} = π that underlies the area-of-a-circle computation. Where the one-dimensional integral carries a genuine complex (1/2)-power that must be tracked through its branch cut, the square is single-valued and rational in b. This makes the squared form the natural object for downstream identities (normalization constants of complex Gaussians, Fresnel-integral products on the boundary re b → 0).",
+    "openQuestions": [
+      "Prove (∫_ℝ e^{-b x²})² = ∫_{ℝ²} e^{-b(x²+y²)} by Fubini and polar coordinates, exhibiting π/b as the literal two-dimensional area integral."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers **area-of-circle-oq-07-oq-04**: for the complex-parameter Gaussian of sibling `area-of-circle-oq-07-oq-01`, the **square** of the integral is the clean rational value
```
(∫_ℝ e^{-b x²} dx)² = π / b   for every b : ℂ with 0 < re b.
```

Squaring removes the branch-cut subtlety of the principal `(1/2)`-power: the integral itself is `(π/b)^{1/2}` (Mathlib's `integral_gaussian_complex`), but over the right half-plane `π/b ≠ 0`, so `Complex.cpow_add` fuses
`(π/b)^{1/2}·(π/b)^{1/2} = (π/b)^{1/2+1/2} = (π/b)^1 = π/b`.
This is the complex-parameter form of the classical 2-D trick `(∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} = π` underlying the parent area-of-circle computation.

## Theorems
- `gaussian_integral_complex_sq` — `(∫_ℝ e^{-b x²})² = π/b` for `0 < re b`.
- `gaussian_integral_sq_eq_pi` — recovers the real parent `(∫_ℝ e^{-x²})² = π` as the `b = 1` case via `integral_complex_ofReal` and `div_one`.

## Verification
- `lake env lean` single-file type-check: **clean**, exit 0.
- `#print axioms` on both theorems: `[propext, Classical.choice, Quot.sound]` only — **0 axioms**, 0 sorries.
- 64 lines, 2 theorems, 0 definitions. Status `verified`, badge `mathlib` (routine squaring/casting of existing Mathlib results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)