### PR TITLE
research(dirichlet-approximation-theorem-oq-03): publish Minkowski re-derivation gallery entry

### DIFF
--- a/research/problems/dirichlet-approximation-theorem-oq-03/knowledge.md
+++ b/research/problems/dirichlet-approximation-theorem-oq-03/knowledge.md
@@ -66,3 +66,25 @@ of area exactly `4 = 2²·covol(ℤ²)`.
    `dirichlet-approximation-theorem` entry.
 3. Settle the subsumption question via the continued-fraction convergent selection, or record that
    pigeonhole/Minkowski/CF give the same `1/N` strength.
+
+## Session 2026-06-19 — gallery promotion
+
+**Mode:** REVISIT (problem already COMPLETE + build-verified) · **Outcome:** completed (published to gallery)
+
+### What I did
+- Re-verified `Proofs/DirichletApproximationOQ03.lean` compiles cleanly via single-file
+  `lake env lean` against pinned Mathlib v4.26.0 (exit 0, 0 errors); `#print axioms
+  dirichlet_via_minkowski` = `[propext, Classical.choice, Quot.sound]` (axiom-free).
+- Authored the gallery entry `src/data/proofs/dirichlet-approximation-theorem-oq-03/`
+  (`meta.json` + `annotations.json`): status `verified`, badge `original`, 6 sections,
+  5 annotations, cross-references to the parent and the oq-02 sibling.
+- `pnpm annotations:validate` does not flag this entry (anchors resolve cleanly).
+
+### Files modified
+- `src/data/proofs/dirichlet-approximation-theorem-oq-03/meta.json` (new)
+- `src/data/proofs/dirichlet-approximation-theorem-oq-03/annotations.json` (new)
+- `src/data/research/problems/dirichlet-approximation-theorem-oq-03.json` (knowledge)
+
+### Next steps
+- Optional sharpenings only: strict `< 1/N` via the open-boundary (area > 4) refinement;
+  simultaneous (oq-02) via Minkowski instead of torus pigeonhole; reusable shear-volume lemma.

--- a/research/problems/dirichlet-approximation-theorem-oq-03/state.md
+++ b/research/problems/dirichlet-approximation-theorem-oq-03/state.md
@@ -1,7 +1,7 @@
 # State: dirichlet-approximation-theorem-oq-03
 
 **Status**: active
-**Phase**: verification
+**Phase**: COMPLETED
 **Last updated**: 2026-06-20
 
 ## Current Focus

--- a/research/registry.json
+++ b/research/registry.json
@@ -23134,11 +23134,11 @@
     },
     {
       "slug": "dirichlet-approximation-theorem-oq-03",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-06-20T00:49:11.207Z",
       "status": "active",
-      "lastUpdate": "2026-06-20T00:49:11.235Z"
+      "lastUpdate": "2026-06-19T21:03:53-07:00"
     },
     {
       "slug": "erdos-divisibility-pigeonhole-oq-01",

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-03/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-convex-body",
+    "proofId": "dirichlet-approximation-theorem-oq-03",
+    "range": { "startLine": 54, "endLine": 57 },
+    "type": "definition",
+    "title": "The Convex Body Whose Lattice Points Are Dirichlet Approximations",
+    "content": "The whole proof hinges on recognizing that a pair (q, p) is a good Diophantine approximation exactly when the lattice point (q, p) lies in the symmetric convex region K(α, N) = {v ∈ ℝ² | |v₀| ≤ N ∧ |α·v₀ − v₁| ≤ 1/N}. The two defining inequalities are precisely 'q is a denominator in range' and 'qα − p is small'. So Dirichlet's theorem becomes the single geometric assertion: this region contains a nonzero lattice point — which is exactly what Minkowski's convex-body theorem provides once the area is known to be at least 2²·covol(ℤ²) = 4.",
+    "mathContext": "$K(\\alpha,N) = \\{v : |v_0| \\le N,\\ |\\alpha v_0 - v_1| \\le 1/N\\} \\subseteq \\mathbb{R}^2$.",
+    "prerequisites": ["Lattices in ℝ²", "Diophantine approximation"],
+    "relatedConcepts": ["geometry of numbers", "symmetric convex body", "lattice point"],
+    "significance": "Reframes a number-theoretic existence statement as a single geometric one, the move that makes Minkowski's theorem directly applicable."
+  },
+  {
+    "id": "ann-slab-intersection",
+    "proofId": "dirichlet-approximation-theorem-oq-03",
+    "range": { "startLine": 74, "endLine": 100 },
+    "type": "technique",
+    "title": "Convexity and Closedness from a Single Slab-Intersection Rewrite",
+    "content": "Rather than reasoning about the slanted parallelogram directly, K is rewritten once as the intersection of two slabs: proj₀⁻¹(Icc −N N) ∩ (α·proj₀ − proj₁)⁻¹(Icc −1/N 1/N), each the preimage of a closed interval under a linear functional. From this single presentation both required properties are one-liners: convexity is (convex_Icc).linear_preimage on each factor intersected, and closedness is isClosed_Icc.preimage of maps that are continuous because every linear map on a finite-dimensional space is (LinearMap.continuous_of_finiteDimensional). No bespoke parallelogram geometry is needed.",
+    "mathContext": "$K = \\mathrm{proj}_0^{-1}[-N,N] \\cap (\\alpha\\,\\mathrm{proj}_0 - \\mathrm{proj}_1)^{-1}[-1/N,1/N]$.",
+    "prerequisites": ["Convex sets", "Preimages under linear maps", "Finite-dimensional continuity"],
+    "relatedConcepts": ["Convex.linear_preimage", "IsClosed.preimage", "linear functionals"],
+    "significance": "A reusable pattern: presenting a convex body as a slab intersection collapses several geometric obligations into interval-preimage lemmas."
+  },
+  {
+    "id": "ann-shear-volume",
+    "proofId": "dirichlet-approximation-theorem-oq-03",
+    "range": { "startLine": 184, "endLine": 256 },
+    "type": "technique",
+    "title": "Computing the Area by a Determinant-(−1) Shear",
+    "content": "The area of the slanted body K is computed without integrating over it. The shear T(x, y) = (x, αx − y) — the linear map Matrix.toLin' !![1,0; α,−1], an involution of determinant −1 — carries the axis-aligned box [−N,N]×[−1/N,1/N] exactly onto K (body_eq_image). Since the box has Lebesgue volume (2N)·(2/N) = 4 (volume_pi_pi, Real.volume_Icc) and a linear map scales volume by |det| (Measure.addHaar_image_linearMap), volume(K) = |−1|·4 = 4. The whole measure computation thus reduces to a product of interval lengths and a 2×2 determinant (Matrix.det_fin_two_of).",
+    "mathContext": "$\\mathrm{volume}(K) = |\\det T|\\cdot\\mathrm{volume}(\\mathrm{box}) = 1\\cdot 4 = 4$.",
+    "prerequisites": ["Haar measure under linear maps", "Determinants of 2×2 matrices", "Product measures"],
+    "relatedConcepts": ["addHaar_image_linearMap", "shear transformation", "volume of a parallelogram"],
+    "significance": "Turns the area of a non-axis-aligned region into a determinant times a trivial box volume — the standard device behind Minkowski's linear-forms theorem."
+  },
+  {
+    "id": "ann-arithmetic-bridge",
+    "proofId": "dirichlet-approximation-theorem-oq-03",
+    "range": { "startLine": 101, "endLine": 150 },
+    "type": "insight",
+    "title": "The q = 0 Boundary Case and Sign Normalisation",
+    "content": "Minkowski hands back some nonzero integer point (q₀, p₀) of K, but turning it into a Dirichlet approximation needs care. First, the denominator cannot vanish: if q₀ = 0 then |p₀| ≤ 1/N < 1 forces p₀ = 0, contradicting nonzeroness — so the only obstruction is the boundary point (0, ±1), which lies in K precisely when 1/N ≥ 1, i.e. N = 1; requiring N ≥ 2 excludes it. Second, a sign normalisation: take q = |q₀| ≥ 1, and when q₀ < 0 replace p by −p₀, using abs_neg to preserve |qα − p| ≤ 1/N. This is the one subtlety the textbook 'area is 4, done' glosses over.",
+    "mathContext": "$q_0 = 0 \\Rightarrow |p_0| \\le 1/N < 1 \\Rightarrow p_0 = 0$; excluded by $N \\ge 2$.",
+    "prerequisites": ["Integer absolute value (natAbs)", "Case analysis on sign"],
+    "relatedConcepts": ["boundary lattice points", "sign normalisation", "Int.natAbs"],
+    "significance": "Documents where the informal proof's hidden hypothesis (N ≥ 2, non-strict bound) actually bites, a recurring honesty point in geometry-of-numbers formalizations."
+  },
+  {
+    "id": "ann-minkowski-capstone",
+    "proofId": "dirichlet-approximation-theorem-oq-03",
+    "range": { "startLine": 258, "endLine": 294 },
+    "type": "theorem",
+    "title": "The Unconditional Minkowski Derivation",
+    "content": "dirichlet_via_minkowski is the sorry-free, axiom-free capstone. With the standard lattice ℤ² = span ℤ (range (Pi.basisFun ℝ (Fin 2))) — fundamental domain ∏ Ico 0 1 of covolume 1 — the Minkowski hypothesis is covol·2^finrank = 1·2² = 4 ≤ 4 = volume(K), which holds with equality (this is why the bound is ≤, not <). Mathlib's exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure, fed body_symm, body_convex and body_isCompact, returns a nonzero lattice point; its coordinates are pulled out as integers via Basis.mem_span_iff_repr_mem and routed through dirichlet_via_convex_body. #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "mathContext": "$1\\cdot 2^2 = 4 \\le 4 = \\mathrm{volume}(K) \\Rightarrow \\exists$ nonzero lattice point.",
+    "prerequisites": ["Minkowski's convex-body theorem", "ZLattice fundamental domains", "Basis representation over ℤ"],
+    "relatedConcepts": ["exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure", "covolume", "finrank"],
+    "significance": "Completes the geometry-of-numbers proof of Dirichlet's theorem, the alternative route to the parent's pigeonhole argument."
+  }
+]

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-03/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "dirichlet-approximation-theorem-oq-03",
+  "title": "Dirichlet Approximation OQ-03: Minkowski Geometry-of-Numbers Re-derivation",
+  "slug": "dirichlet-approximation-theorem-oq-03",
+  "description": "The geometry-of-numbers (Minkowski) re-derivation of Dirichlet's approximation theorem: for every real α and integer N ≥ 2 there are integers p and 1 ≤ q ≤ N with |qα − p| ≤ 1/N, proved not by pigeonhole on fractional parts (the parent entry) but by applying Minkowski's convex-body theorem to the symmetric convex body K(α,N) = {v ∈ ℝ² | |v₀| ≤ N ∧ |α·v₀ − v₁| ≤ 1/N}, a parallelogram of area exactly 4 = 2²·covol(ℤ²). The proof builds the body as an intersection of two linear slabs (giving convexity and closedness in one rewrite), computes volume(K) = 4 via the determinant-(−1) shear T(x,y) = (x, αx − y) carrying the axis-aligned box [−N,N]×[−1/N,1/N] onto K (addHaar_image_linearMap), feeds covol(ℤ²)·2^dim = 1·2² = 4 ≤ 4 into Mathlib's compact Minkowski theorem exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure, and converts the resulting nonzero lattice point into a Dirichlet approximation through an arithmetic bridge handling the sign normalisation 1 ≤ q ≤ N and the degenerate q = 0 boundary case. Answers the parent's open question of re-deriving the bound by geometry of numbers.",
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_approximation_theorem",
+    "date": "1842",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DirichletApproximationOQ03.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-approximation",
+      "geometry-of-numbers",
+      "minkowski-convex-body-theorem",
+      "lattice",
+      "haar-measure",
+      "convex-body"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure",
+        "description": "Minkowski's convex-body theorem (compact, symmetric, convex variant): if μ is an additive Haar measure, s is symmetric, convex and compact, and covol·2^(finrank) ≤ μ(s), then s contains a nonzero lattice point. This is the load-bearing existence engine; the whole derivation discharges its three geometric hypotheses and its single measure inequality (1·2² = 4 ≤ 4 = volume K).",
+        "module": "Mathlib.MeasureTheory.Group.GeometryOfNumbers"
+      },
+      {
+        "theorem": "MeasureTheory.Measure.addHaar_image_linearMap",
+        "description": "volume (f '' s) = ENNReal.ofReal |det f| · volume s for a linear map f. Applied to the determinant-(−1) shear T, with s the axis-aligned box of volume 4, this gives volume (K) = |−1|·4 = 4 — the entire volume computation reduces to the box volume and a 2×2 determinant.",
+        "module": "Mathlib.MeasureTheory.Measure.Haar.Linear"
+      },
+      {
+        "theorem": "ZSpan.isAddFundamentalDomain' / ZSpan.fundamentalDomain_pi_basisFun",
+        "description": "The standard lattice ℤ² = span ℤ (range (Pi.basisFun ℝ (Fin 2))) has a fundamental domain ∏ Ico 0 1 of volume 1 (covolume 1). Supplies the fundamental-domain hypothesis and the covol = 1 used in the Minkowski measure inequality.",
+        "module": "Mathlib.Algebra.Module.ZLattice.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.volume_pi_pi / Real.volume_Icc",
+        "description": "The Lebesgue volume of a product box ∏ Icc aᵢ bᵢ is ∏ (bᵢ − aᵢ). Computes volume(box) = (2N)·(2/N) = 4 directly, before the shear transports it to K.",
+        "module": "Mathlib.MeasureTheory.Constructions.Pi / Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
+      },
+      {
+        "theorem": "LinearMap.det_toLin' / Matrix.det_fin_two_of",
+        "description": "The determinant of the shear, presented as Matrix.toLin' !![1,0; α,-1], equals the 2×2 matrix determinant 1·(−1) − 0·α = −1. The |det| = 1 is exactly why the shear is volume-preserving.",
+        "module": "Mathlib.LinearAlgebra.Matrix.ToLin / Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Convex.linear_preimage / IsClosed.preimage / LinearMap.continuous_of_finiteDimensional",
+        "description": "Convexity and closedness of K both fall out of writing K as the intersection of two preimages of closed intervals under linear functionals: convex_Icc.linear_preimage and isClosed_Icc.preimage (continuity of linear maps in finite dimension). Compactness then follows from body = T '' box with box compact (isCompact_Icc).",
+        "module": "Mathlib.Analysis.Convex.Function / Mathlib.LinearAlgebra.FiniteDimensional"
+      }
+    ],
+    "originalContributions": [
+      "dirichlet_via_minkowski: the unconditional, sorry-free, axiom-free geometry-of-numbers proof of Dirichlet's bound — for every α and N ≥ 2, integers p and 1 ≤ q ≤ N with |qα − p| ≤ 1/N — obtained by feeding volume(K) = 4 = covol(ℤ²)·2^dim into Mathlib's compact Minkowski theorem and reading integer coordinates off the resulting lattice point. The parent entry proves the same bound by pigeonhole; this is the alternative geometry-of-numbers route the parent's open question requested.",
+      "body / body_symm / body_convex / body_isClosed / body_isCompact: the symmetric convex body K(α,N) and the four geometric inputs Minkowski's theorem consumes. K is engineered as the intersection of two linear slabs proj₀⁻¹[−N,N] ∩ (α·proj₀ − proj₁)⁻¹[−1/N,1/N], so convexity (Convex.linear_preimage) and closedness (IsClosed.preimage) both follow from a single set rewrite, with no ad-hoc geometry; compactness comes from body = shear '' box.",
+      "shear / box / body_eq_image / box_volume / body_volume: the determinant-(−1) shear T(x,y) = (x, αx − y) (an involution, shear_involutive) realizing K as the image of the axis-aligned box [−N,N]×[−1/N,1/N] of Lebesgue volume 4, so volume(K) = |det T|·4 = 4 (addHaar_image_linearMap with Matrix.det_fin_two). This is the volume computation the open problem identified as its remaining content.",
+      "dirichlet_of_lattice_point: the arithmetic bridge turning a nonzero integer point (q₀,p₀) of K into a Dirichlet approximation. It performs the sign normalisation to 1 ≤ q ≤ N (taking q = |q₀|, flipping p when q₀ < 0) and rules out the degenerate q = 0 boundary point (0,±1) using N ≥ 2 — the one genuine subtlety the textbook one-liner glosses over.",
+      "dirichlet_via_convex_body: the clean conditional statement isolating exactly what Minkowski supplies (existence of a nonzero integer point of K) from the geometry already discharged, so the unconditional capstone is a one-line application once the volume bound is in hand."
+    ],
+    "dateAdded": "2026-06-19",
+    "relatedProblems": [
+      {
+        "id": "dirichlet-approximation-theorem",
+        "relationship": "Parent entry: the one-dimensional pigeonhole-on-fractional-parts proof of |qα − p| < 1/N (1 ≤ q ≤ N). This OQ-03 re-derives the (non-strict ≤) bound by Minkowski's convex-body theorem instead, the geometry-of-numbers route the parent's open question asked for."
+      },
+      {
+        "id": "dirichlet-approximation-theorem-oq-02",
+        "relationship": "Sibling entry: the simultaneous d-dimensional generalization via pigeonhole on the d-torus. Both are alternative routes (geometry of numbers here, abstract torus pigeonhole there) to Dirichlet-type bounds beyond the parent's elementary argument."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 294,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational propext / Classical.choice / Quot.sound are used (no Lean.ofReduceBool; verifiable with #print axioms dirichlet_via_minkowski). The hypothesis is N ≥ 2 (the N = 1 case is the trivial q = 1, p = round α, and N ≥ 2 rules out the degenerate boundary point (0,±1)); the bound obtained is the non-strict |qα − p| ≤ 1/N, the honest output of the closed/compact area-= 4 convex body (the strict < needs the open area > 4 refinement). The load-bearing existence theorem is Mathlib's Minkowski convex-body theorem exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure; the original in-file content is the convex body, its symmetry/convexity/closedness/compactness, the volume = 4 computation via the determinant-(−1) shear, and the arithmetic bridge. Badge is 'original' because that geometry-of-numbers infrastructure (the body, the shear volume computation, and the sign/boundary bridge) is built here rather than borrowed.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 15,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Dirichlet's 1842 theorem is the foundational result of Diophantine approximation: every real α has infinitely many rational approximations p/q with |α − p/q| < 1/q². Dirichlet's own proof is the pigeonhole argument on fractional parts (the parent gallery entry). Minkowski's later geometry of numbers gives a strikingly different proof: the set of (q,p) with |q| ≤ N and |αq − p| ≤ 1/N is a centrally symmetric convex region of area exactly 4 = 2²·1, and Minkowski's convex-body theorem guarantees any such region contains a nonzero lattice point — which is precisely a good rational approximation. This geometry-of-numbers viewpoint is the gateway to Minkowski's linear-forms theorem, the theory of successive minima, and the modern theory of lattices.",
+    "problemStatement": "Let $\\alpha \\in \\mathbb{R}$ and $N \\in \\mathbb{N}$ with $N \\ge 2$. Then there exist an integer $p$ and a natural number $q$ with $1 \\le q \\le N$ such that\n\n$$\\left| q\\,\\alpha - p \\right| \\le \\frac{1}{N}.$$\n\nThis is to be proved via Minkowski's convex-body theorem rather than the pigeonhole principle of the parent entry.",
+    "text": "Mathlib contains Minkowski's convex-body theorem (exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure) and the lattice fundamental-domain API, but no packaged Dirichlet-via-geometry-of-numbers corollary. This entry supplies the missing ingredients: the symmetric convex body K(α,N), proofs that it is convex, closed and compact, the computation volume(K) = 4 via a determinant-(−1) shear, and the arithmetic bridge converting Minkowski's lattice point into a Dirichlet approximation with the sign and boundary cases handled.",
+    "proofStrategy": "Define the convex body K(α,N) = {v : ℝ² | |v₀| ≤ N ∧ |α·v₀ − v₁| ≤ 1/N}. Writing K as the intersection of two slabs — preimages of closed intervals under the linear functionals v ↦ v₀ and v ↦ α·v₀ − v₁ — makes body_convex (Convex.linear_preimage on convex_Icc) and body_isClosed (IsClosed.preimage of isClosed_Icc) one-line consequences, and body_symm is immediate. For the volume, introduce the shear T(x,y) = (x, αx − y) = Matrix.toLin' !![1,0; α,−1], a determinant-(−1) involution; body_eq_image proves K = T '' box where box = [−N,N]×[−1/N,1/N], box_volume computes volume(box) = (2N)(2/N) = 4 via volume_pi_pi and Real.volume_Icc, and body_volume = 4 follows from addHaar_image_linearMap and |det T| = 1. body_isCompact comes from box being compact (box_eq_Icc → isCompact_Icc) and T continuous. Then dirichlet_via_minkowski takes the standard lattice ℤ² = span ℤ (range (Pi.basisFun ℝ (Fin 2))) (covolume 1 via ZSpan.fundamentalDomain_pi_basisFun), checks covol·2^finrank = 1·2² = 4 ≤ 4 = volume(K), and applies Minkowski's theorem to get a nonzero lattice point; its coordinates are extracted as integers through Basis.mem_span_iff_repr_mem. Finally dirichlet_of_lattice_point normalises the sign so that q = |q₀| ∈ [1,N] and rules out q = 0 (only possible at the boundary point (0,±1), excluded by N ≥ 2), yielding |qα − p| ≤ 1/N.",
+    "keyInsights": [
+      "**Good approximations are lattice points in a parallelogram**: the pair (q,p) is a Dirichlet approximation exactly when the lattice point (q,p) lies in the symmetric convex body K(α,N); the whole theorem becomes 'this area-4 region contains a nonzero lattice point', which is Minkowski's theorem verbatim",
+      "**The body's area is forced to be 4 = 2²·covol(ℤ²)**: the closed/compact Minkowski variant needs area ≥ 2^dim·covolume, and K is engineered to hit this threshold exactly — which is also why the resulting bound is the non-strict |qα − p| ≤ 1/N rather than the strict <",
+      "**A determinant-(−1) shear turns the area computation into a 2×2 determinant**: K is not axis-aligned, but the shear T(x,y) = (x, αx − y) carries the trivial box [−N,N]×[−1/N,1/N] (area 4) onto K while preserving volume (|det| = 1), so volume(K) = 4 needs only volume_pi_pi and Matrix.det_fin_two — no integration over the slanted region",
+      "**Convexity and closedness are a single set rewrite**: presenting K as proj₀⁻¹[−N,N] ∩ (α·proj₀ − proj₁)⁻¹[−1/N,1/N] makes both properties preimages-of-intervals-under-linear-maps, dispatched by Convex.linear_preimage and IsClosed.preimage with no bespoke geometry",
+      "**The q = 0 boundary case is the only real subtlety**: a nonzero lattice point of K could a priori have first coordinate 0, but that forces the point to be (0,±1), which lies in K only when 1/N ≥ 1, i.e. N ≤ 1; requiring N ≥ 2 cleanly excludes it, and the rest of the bridge is sign normalisation"
+    ],
+    "prerequisites": [
+      "Minkowski's convex-body theorem in Mathlib (exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure) and the ZLattice fundamental-domain API (covolume of ℤ²)",
+      "Haar measure under linear maps (addHaar_image_linearMap), product Lebesgue volume (volume_pi_pi, Real.volume_Icc), and the 2×2 determinant (Matrix.det_fin_two, LinearMap.det_toLin')",
+      "Convex and closed sets as preimages of intervals under linear functionals on a finite-dimensional space (Convex.linear_preimage, IsClosed.preimage, LinearMap.continuous_of_finiteDimensional)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview-and-strategy",
+      "title": "The Convex Body and the Geometry-of-Numbers Strategy",
+      "startLine": 1,
+      "endLine": 57,
+      "mathContext": "$K(\\alpha,N) = \\{v \\in \\mathbb{R}^2 : |v_0| \\le N,\\ |\\alpha v_0 - v_1| \\le 1/N\\}$, a symmetric parallelogram of area $4$.",
+      "summary": "The docstring contrasts the parent's pigeonhole proof with the geometry-of-numbers route: apply Minkowski's convex-body theorem to the symmetric convex body K(α,N), a parallelogram of area exactly 4 = 2²·covol(ℤ²), whose nonzero lattice points are exactly Dirichlet approximations |qα − p| ≤ 1/N with 1 ≤ q ≤ N. It lists the sorry-free, axiom-free contributions (body, body_symm/convex/isClosed, the arithmetic bridge, the conditional and unconditional theorems) and notes the remaining content is the volume computation. The definition `body` then states K as a set in Fin 2 → ℝ."
+    },
+    {
+      "id": "geometric-inputs",
+      "title": "Symmetry, Convexity, and Closedness of the Body",
+      "startLine": 61,
+      "endLine": 100,
+      "mathContext": "$K = \\mathrm{proj}_0^{-1}[-N,N] \\cap (\\alpha\\,\\mathrm{proj}_0 - \\mathrm{proj}_1)^{-1}[-1/N,1/N]$.",
+      "summary": "The three geometric hypotheses Minkowski consumes. body_symm shows v ∈ K → −v ∈ K by abs_neg. body_convex and body_isClosed both proceed from the same one-line set equality presenting K as the intersection of two slabs — preimages of closed intervals under the linear functionals proj₀ and α·proj₀ − proj₁ — so convexity is (convex_Icc).linear_preimage on each factor and closedness is isClosed_Icc.preimage of the (finite-dimensional, hence continuous) linear maps."
+    },
+    {
+      "id": "arithmetic-bridge",
+      "title": "The Arithmetic Bridge: Lattice Point ⇒ Dirichlet Approximation",
+      "startLine": 101,
+      "endLine": 150,
+      "mathContext": "Nonzero integer $(q_0,p_0) \\in K$, $N \\ge 2$ $\\Rightarrow$ $\\exists\\, 1 \\le q \\le N,\\ |q\\alpha - p| \\le 1/N$.",
+      "summary": "dirichlet_of_lattice_point converts a nonzero integer point (q₀,p₀) of K into a Dirichlet approximation. Step 1 shows the first coordinate cannot vanish: if q₀ = 0 then |p₀| ≤ 1/N < 1 forces p₀ = 0, contradicting nonzeroness (this is where N ≥ 2 enters, excluding the boundary point (0,±1)). Step 2 sign-normalises: take q = |q₀| ≥ 1; when q₀ < 0 also flip p to −p₀, using (q₀.natAbs : ℝ) = ±(q₀ : ℝ) and abs_neg to preserve the bound, yielding 1 ≤ q ≤ N with |qα − p| ≤ 1/N."
+    },
+    {
+      "id": "conditional-theorem",
+      "title": "Dirichlet's Bound, Conditional on Minkowski",
+      "startLine": 152,
+      "endLine": 171,
+      "mathContext": "Given a nonzero integer point of $K$, extract its coordinates and apply the bridge.",
+      "summary": "dirichlet_via_convex_body packages the geometry already proved: given the Minkowski conclusion (a nonzero point of K all of whose coordinates are integers), it reads off integer coordinates q₀ = v 0, p₀ = v 1 (fin_cases on the index to relate v ≠ 0 to (q₀,p₀) ≠ (0,0)) and feeds them to dirichlet_of_lattice_point. This isolates exactly what the existence theorem must supply, leaving only the volume bound for the unconditional version."
+    },
+    {
+      "id": "shear-and-volume",
+      "title": "The Shear and the Volume Computation volume(K) = 4",
+      "startLine": 173,
+      "endLine": 256,
+      "mathContext": "$T(x,y) = (x, \\alpha x - y)$, $\\det T = -1$, $K = T(\\,[-N,N]\\times[-1/N,1/N]\\,)$.",
+      "summary": "The shear T = Matrix.toLin' !![1,0; α,−1] is introduced with its coordinate formulas (shear_apply_zero/one) and shown to be an involution (shear_involutive). body_eq_image proves K = T '' box for box = [−N,N]×[−1/N,1/N]; box_eq_Icc rewrites box as a product Icc giving box_isCompact (isCompact_Icc) and hence body_isCompact (continuous image). box_volume computes volume(box) = (2N)(2/N) = 4 via volume_pi_pi and Real.volume_Icc, and body_volume = 4 follows from addHaar_image_linearMap with |det T| = |−1| = 1 (LinearMap.det_toLin', Matrix.det_fin_two_of)."
+    },
+    {
+      "id": "unconditional-capstone",
+      "title": "The Unconditional Minkowski Derivation",
+      "startLine": 258,
+      "endLine": 294,
+      "mathContext": "$\\mathrm{covol}(\\mathbb{Z}^2)\\cdot 2^{\\dim} = 1\\cdot 2^2 = 4 \\le 4 = \\mathrm{volume}(K)$.",
+      "summary": "dirichlet_via_minkowski assembles the full proof. It takes the standard lattice ℤ² = span ℤ (range (Pi.basisFun ℝ (Fin 2))) with its unit-covolume fundamental domain (ZSpan.isAddFundamentalDomain', ZSpan.fundamentalDomain_pi_basisFun, volume 1), verifies the Minkowski measure inequality covol·2^finrank = 1·2² = 4 ≤ 4 = volume(K) (body_volume, finrank = 2), and applies exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure with body_symm, body_convex, body_isCompact to obtain a nonzero lattice point. Its coordinates are extracted as integers via Basis.mem_span_iff_repr_mem, discharging the hMink hypothesis of dirichlet_via_convex_body."
+    }
+  ],
+  "conclusion": {
+    "summary": "Dirichlet's approximation bound |qα − p| ≤ 1/N (1 ≤ q ≤ N) is re-derived by geometry of numbers rather than pigeonhole: the good approximations are exactly the nonzero lattice points of the symmetric convex body K(α,N), whose area is computed to be 4 = 2²·covol(ℤ²) via a determinant-(−1) shear, so Mathlib's compact Minkowski convex-body theorem produces one. The arithmetic bridge handles the sign normalisation and the q = 0 boundary case (excluded by N ≥ 2). Zero sorries, zero axioms.",
+    "implications": "The geometry-of-numbers proof is the template for the deeper results of the field: Minkowski's linear-forms theorem, the theory of successive minima, simultaneous and inhomogeneous approximation, and lattice-reduction algorithms all proceed by exhibiting the relevant Diophantine condition as membership in a symmetric convex body and computing its volume. The reusable in-file infrastructure — a convex body as a slab intersection, a volume computation by a determinant shear, and a lattice-point-to-arithmetic bridge — is exactly what those generalizations require.",
+    "openQuestions": [
+      "Can the strict inequality |qα − p| < 1/N be recovered by the open-boundary (area > 4) refinement of Minkowski's theorem, matching the parent entry's strict pigeonhole bound?",
+      "Does the same convex body, enlarged to a box of volume > 2^d in ℝ^{d+1}, give the simultaneous approximation theorem (sibling OQ-02) through Minkowski rather than torus pigeonhole, and do the two routes yield the same denominator range?",
+      "Can the determinant-shear volume technique be packaged as a reusable Mathlib lemma 'volume of a parallelogram = |det|·(box volume)' to support Minkowski's linear-forms theorem in general dimension?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "dirichlet-approximation-theorem",
+      "relationship": "extends",
+      "description": "Parent entry proving |qα − p| < 1/N by pigeonhole on fractional parts. This OQ-03 re-derives the (non-strict) bound by Minkowski's convex-body theorem — the geometry-of-numbers alternative the parent's open question requested."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-02",
+      "relationship": "related",
+      "description": "Sibling entry: the simultaneous d-dimensional theorem via pigeonhole on the d-torus. Both go beyond the parent's elementary argument — geometry of numbers here, abstract torus pigeonhole there."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/DirichletApproximationOQ03.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "MeasureTheory"
+    ],
+    "namespace": "DirichletMinkowski",
+    "lineCount": 294,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 3,
+    "theoremCount": 15
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/dirichlet-approximation-theorem-oq-03.json
+++ b/src/data/research/problems/dirichlet-approximation-theorem-oq-03.json
@@ -43,19 +43,17 @@
       "Registered import Proofs.DirichletApproximationOQ03 in proofs/Proofs.lean so the entry is part of the CI build.",
       "shear, box, shear_apply_zero/one, shear_involutive, body_eq_image, box_eq_Icc, box_isCompact, body_isCompact — the determinant-(-1) shear and the box/body image identity (DirichletApproximationOQ03.lean).",
       "box_volume (= 4) and body_volume (= 4) — the measure computation Minkowski consumes, via volume_pi_pi/Real.volume_Icc and addHaar_image_linearMap with LinearMap.det_toLin' + Matrix.det_fin_two_of.",
-      "dirichlet_via_minkowski — the unconditional, sorry-free, axiom-free capstone: Dirichlet's |q*alpha - p| <= 1/N (1 <= q <= N, N >= 2) from Mathlib's compact convex-body theorem. BUILD UNVERIFIED this session (Docker down)."
+      "dirichlet_via_minkowski — the unconditional, sorry-free, axiom-free capstone: Dirichlet's |q*alpha - p| <= 1/N (1 <= q <= N, N >= 2) from Mathlib's compact convex-body theorem. BUILD UNVERIFIED this session (Docker down).",
+      "Gallery entry src/data/proofs/dirichlet-approximation-theorem-oq-03/ (meta.json + annotations.json): status verified, badge original, 0 sorries, 0 axioms; 6 sections + 5 annotations; cross-refs to parent and oq-02."
     ],
     "mathlibGaps": [
       "Mathlib has the Minkowski convex-body theorem exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure and the lattice fundamental-domain API (ZSpan.isAddFundamentalDomain, ZSpan.volume_fundamentalDomain), but no packaged Dirichlet-via-geometry-of-numbers corollary; this entry supplies the convex body, the geometric inputs, and the arithmetic bridge.",
       "The remaining volume computation volume(body α N) = 4 has no off-the-shelf lemma; it requires building the shear LinearMap on Fin 2 → ℝ, its det via Matrix.det_fin_two, the box volume via volume_pi/Real.volume_Icc, and the set equality body = T '' box, then addHaar_image_linearMap."
     ],
     "nextSteps": [
-      "DONE — build verified via single-file `lake env lean` against pinned Mathlib v4.26.0 (0 errors/warnings/sorries; #print axioms clean). A full docker build of Proofs.DirichletApproximationOQ03 remains a nice-to-have CI confirmation but is no longer blocking.",
-      "Promote this to a gallery entry (src/data/proofs/) with status verified / badge original (0 sorry, 0 axiom, no Lean.ofReduceBool) and cross-reference the pigeonhole dirichlet-approximation-theorem entry it re-derives.",
-      "Settle the subsumption question via continued-fraction convergent selection (abs_sub_convergents_le', choosing the convergent with B_n <= N < B_{n+1}), or record that pigeonhole / Minkowski / continued fractions all give the same 1/N strength.",
-      "Optionally sharpen to the strict < 1/N via the open-boundary refinement (area > 4 variant of the convex body)."
+      "DONE — promoted to gallery entry (status verified / badge original). Remaining optional: strict < 1/N via open-boundary (area>4) refinement; simultaneous (oq-02) via Minkowski instead of torus pigeonhole; package the determinant-shear volume technique as a reusable lemma."
     ],
-    "progressSummary": "COMPLETE and BUILD VERIFIED: the Minkowski re-derivation of Dirichlet's bound is a full unconditional proof, sorry-free and axiom-free, now machine-checked. Single-file elaboration (`lake env lean Proofs/DirichletApproximationOQ03.lean`) against pinned Mathlib v4.26.0 type-checks with 0 errors/warnings/sorries, and #print axioms reports only [propext, Classical.choice, Quot.sound]. The check caught and fixed 7 real lemma-name/tactic drifts that earlier source-inspection had missed. The volume computation volume(K) = 4 is discharged via the determinant-(-1) shear, and dirichlet_via_minkowski assembles the unconditional bound from Mathlib's compact convex-body theorem. Remaining optional work: the continued-fraction subsumption question and a strict-inequality sharpening; neither is required for the core result. Ready to promote to a gallery entry."
+    "progressSummary": "COMPLETE, BUILD VERIFIED, and PROMOTED TO GALLERY: the Minkowski re-derivation of Dirichlet's bound is a full unconditional sorry-free axiom-free proof (single-file lake env lean against pinned Mathlib v4.26.0; #print axioms = [propext, Classical.choice, Quot.sound]), now published as gallery entry dirichlet-approximation-theorem-oq-03 (verified/original). Optional sharpenings remain but the core result and its gallery presentation are done."
   },
   "approaches": [
     {


### PR DESCRIPTION
## Summary

The verified Lean proof `Proofs/DirichletApproximationOQ03.lean` — the **Minkowski (geometry-of-numbers) re-derivation** of Dirichlet's approximation theorem — was already merged and is imported in `Proofs.lean`, but it had **no gallery entry**. This adds it:

```
src/data/proofs/dirichlet-approximation-theorem-oq-03/meta.json
src/data/proofs/dirichlet-approximation-theorem-oq-03/annotations.json
```

## The proof (recap)

For every real α and N ≥ 2, there exist integers p and 1 ≤ q ≤ N with |qα − p| ≤ 1/N, proved by applying Mathlib's compact Minkowski convex-body theorem to the symmetric convex body `K(α,N) = {v ∈ ℝ² | |v₀| ≤ N ∧ |α·v₀ − v₁| ≤ 1/N}` of area exactly 4 = 2²·covol(ℤ²). Original in-file infrastructure: the convex body + its symmetry/convexity/closedness/compactness, the **volume = 4 computation via a determinant-(−1) shear** (`addHaar_image_linearMap`), and the **arithmetic bridge** handling sign normalisation and the degenerate q = 0 boundary case (excluded by N ≥ 2).

## Entry details

- `status`: `verified` · `badge`: `original` · `sorries`: 0 · `axiomCount`: 0
- 6 sections, 5 annotations, cross-references to the parent (`dirichlet-approximation-theorem`) and sibling (`-oq-02`).
- Marks the research problem **COMPLETED**.

## Verification

Re-verified the Lean file compiles via single-file `lake env lean` against pinned Mathlib v4.26.0 (exit 0). `#print axioms dirichlet_via_minkowski` = `[propext, Classical.choice, Quot.sound]` — sorry-free and axiom-free (no `Lean.ofReduceBool`). `pnpm annotations:validate` does not flag this entry (anchors resolve cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)