### PR TITLE
research(area-of-circle-oq-07-oq-03): Γ(1/2) = √π, the Gamma-function shadow of the Gaussian integral (verified)

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ07OQ03.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ03.lean
@@ -1,0 +1,57 @@
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Tactic
+
+/-
+# `Γ(1/2) = √π`: the Gamma-function shadow of the Gaussian integral
+
+## Open Question (area-of-circle-oq-07-oq-03)
+Formalize the special-value identity `Real.Gamma (1/2) = √π` — the Gamma-function
+shadow of the parent entry `area-of-circle-oq-07`, whose theorem states
+`∫_ℝ e^{-x²} dx = √π`.
+
+## Answer: YES — and the two are literally the same number.
+
+The Euler Gamma function `Γ(s) = ∫₀^∞ u^{s-1} e^{-u} du` at `s = 1/2` becomes
+`∫₀^∞ u^{-1/2} e^{-u} du`.  The substitution `u = x²` (so `du = 2x dx`,
+`u^{-1/2} = x⁻¹`) turns this into `2 ∫₀^∞ e^{-x²} dx`, which by even symmetry is
+`∫_ℝ e^{-x²} dx = √π`.  Mathlib packages this substitution inside the proof of
+`Real.Gamma_one_half_eq : Real.Gamma (1 / 2) = √π`.
+
+This file records the identity together with two bridges that exhibit `Γ(1/2)`
+explicitly as a Gaussian value:
+
+* `gamma_one_half_eq_sqrt_pi`     — `Γ(1/2) = √π`;
+* `gamma_one_half_eq_gaussian`    — `Γ(1/2) = ∫_ℝ e^{-x²}`, identifying `Γ(1/2)`
+  with the full-line Gaussian integral of the parent entry;
+* `gamma_one_half_eq_two_mul_gaussian_Ioi` — `Γ(1/2) = 2 · ∫_{x>0} e^{-x²}`,
+  the half-line form that is the direct image of the `u = x²` substitution.
+
+No new axioms: every step is a routine consequence of existing Mathlib results
+(`Real.Gamma_one_half_eq`, `integral_gaussian_Ioi`).
+-/
+
+open Real MeasureTheory
+
+/-- **`Γ(1/2) = √π`.** The Euler Gamma function at `1/2` evaluates to `√π`. -/
+theorem gamma_one_half_eq_sqrt_pi : Real.Gamma (1 / 2) = Real.sqrt Real.pi :=
+  Real.Gamma_one_half_eq
+
+/-- **Bridge to the parent Gaussian integral.** `Γ(1/2)` equals the full-line
+Gaussian integral `∫_ℝ e^{-x²}`, the quantity proved equal to `√π` in
+`area-of-circle-oq-07`. -/
+theorem gamma_one_half_eq_gaussian :
+    Real.Gamma (1 / 2) = ∫ x : ℝ, Real.exp (-x ^ 2) := by
+  rw [Real.Gamma_one_half_eq]
+  have h := integral_gaussian 1
+  simp only [neg_one_mul, div_one] at h
+  exact h.symm
+
+/-- **Half-line form.** `Γ(1/2) = 2 · ∫_{x>0} e^{-x²}`, the direct image of the
+substitution `u = x²` in `Γ(1/2) = ∫₀^∞ u^{-1/2} e^{-u} du`. -/
+theorem gamma_one_half_eq_two_mul_gaussian_Ioi :
+    Real.Gamma (1 / 2) = 2 * ∫ x in Set.Ioi (0 : ℝ), Real.exp (-x ^ 2) := by
+  rw [Real.Gamma_one_half_eq]
+  have h := integral_gaussian_Ioi 1
+  simp only [neg_one_mul, div_one] at h
+  rw [h]
+  ring

--- a/src/data/proofs/area-of-circle-oq-07-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03/meta.json
@@ -1,0 +1,108 @@
+{
+  "id": "area-of-circle-oq-07-oq-03",
+  "slug": "area-of-circle-oq-07-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory"
+    ],
+    "namespace": "",
+    "lineCount": 57,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ03.lean",
+    "sorries": 0
+  },
+  "title": "Γ(1/2) = √π: the Gamma-Function Shadow of the Gaussian Integral",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ03.lean",
+    "tags": [
+      "analysis",
+      "gamma-function",
+      "gaussian-integral",
+      "special-functions",
+      "euler-gamma",
+      "measure-theory",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 57,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "gamma_one_half_eq_sqrt_pi: Γ(1/2) = √π, the Euler Gamma function's special value at 1/2, recorded as the Gamma-function shadow of the parent entry's Gaussian integral ∫_ℝ e^{-x²} = √π",
+      "gamma_one_half_eq_gaussian: Γ(1/2) = ∫_ℝ e^{-x²}, identifying Γ(1/2) with the full-line Gaussian integral of the parent entry area-of-circle-oq-07 (both equal √π)",
+      "gamma_one_half_eq_two_mul_gaussian_Ioi: Γ(1/2) = 2 · ∫_{x>0} e^{-x²}, the half-line form that is the direct image of the substitution u = x² in the integral defining Γ(1/2)"
+    ],
+    "prerequisites": [
+      "Euler Gamma function Real.Gamma and its integral representation",
+      "Mathlib's special-value lemma Real.Gamma_one_half_eq",
+      "Mathlib's parametrized Gaussian integrals integral_gaussian and integral_gaussian_Ioi",
+      "Parent: area-of-circle-oq-07 (the Gaussian integral ∫ e^{-x²} = √π)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.Gamma_one_half_eq",
+        "description": "Real.Gamma (1 / 2) = √π — the special-value formula, proved in Mathlib via the substitution u = x² that reduces Γ(1/2) to the Gaussian integral.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "integral_gaussian",
+        "description": "∫ x : ℝ, exp (-b * x ^ 2) = √(π / b) for every real b. Specialized at b = 1 to identify Γ(1/2) with the full-line Gaussian integral.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "integral_gaussian_Ioi",
+        "description": "∫ x in Ioi 0, exp (-b * x ^ 2) = √(π / b) / 2 for every real b. Specialized at b = 1 to give the half-line form Γ(1/2) = 2 · ∫_{x>0} e^{-x²}.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-03-oq-01",
+      "question": "Derive the reflection-formula consequence Γ(1/2)² = π directly from gamma_one_half_eq_sqrt_pi, and connect it to the Beta-function value B(1/2, 1/2) = π via Mathlib's Gamma_mul_Gamma_add_half or the Beta–Gamma relation.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "extends",
+      "description": "Parent. The parent proves ∫_ℝ e^{-x²} = √π; this entry exhibits the same number as the Euler Gamma value Γ(1/2), with gamma_one_half_eq_gaussian making the identification explicit and gamma_one_half_eq_two_mul_gaussian_Ioi recording the half-line substitution u = x² that underlies Mathlib's proof of Γ(1/2) = √π."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.Gamma_one_half_eq : Real.Gamma (1 / 2) = √π and the parametrized Gaussian integrals integral_gaussian and integral_gaussian_Ioi used here."
+    },
+    {
+      "title": "Leonhard Euler and the Gamma function",
+      "author": "Leonhard Euler",
+      "year": "1729",
+      "venue": "correspondence with Goldbach",
+      "description": "Origin of the Gamma function interpolating the factorial; Γ(1/2) = √π is its archetypal non-integer special value."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The Euler Gamma function satisfies Γ(1/2) = √π, the same number as the parent entry's Gaussian integral ∫_ℝ e^{-x²}. This file records the identity (gamma_one_half_eq_sqrt_pi, a restatement of Mathlib's Real.Gamma_one_half_eq) together with two bridges that exhibit Γ(1/2) explicitly as a Gaussian value: gamma_one_half_eq_gaussian (Γ(1/2) = ∫_ℝ e^{-x²}) and gamma_one_half_eq_two_mul_gaussian_Ioi (Γ(1/2) = 2 · ∫_{x>0} e^{-x²}, the half-line form produced by the substitution u = x²). 57 lines, 3 theorems, 0 definitions, 0 axioms, 0 sorries; each theorem depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This is an honest, routine consequence of existing Mathlib results rather than original mathematics — Mathlib already proves Γ(1/2) = √π, and its proof internally performs exactly the u = x² substitution surfaced here. The value to the gallery is the explicit identification of the Euler Gamma special value with the parent's Gaussian integral, tying the factorial-interpolation viewpoint (Γ) to the probability/normalization viewpoint (∫ e^{-x²}) on a single √π.",
+    "openQuestions": [
+      "Derive Γ(1/2)² = π and connect it to the Beta-function value B(1/2, 1/2) = π via the Beta–Gamma relation."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Settles open question `area-of-circle-oq-07-oq-03`: formalize the Euler Gamma special value **Γ(1/2) = √π** and bridge it to the parent entry's Gaussian integral ∫_ℝ e^{-x²} = √π.

Three verified theorems (`proofs/Proofs/AreaOfCircleOQ07OQ03.lean`):

| Theorem | Statement |
|---|---|
| `gamma_one_half_eq_sqrt_pi` | Γ(1/2) = √π |
| `gamma_one_half_eq_gaussian` | Γ(1/2) = ∫_ℝ e^{-x²}  (the parent's Gaussian value) |
| `gamma_one_half_eq_two_mul_gaussian_Ioi` | Γ(1/2) = 2·∫_{x>0} e^{-x²}  (the u = x² substitution shadow) |

The half-line identity is the direct image of the substitution u = x² in Γ(1/2) = ∫₀^∞ u^{-1/2} e^{-u} du — exactly the step Mathlib performs internally to prove `Real.Gamma_one_half_eq`. This entry surfaces that bridge explicitly, tying the factorial-interpolation viewpoint (Γ) to the probability/normalization viewpoint (∫ e^{-x²}) on a single √π.

## Honesty

This is a **routine consequence of existing Mathlib results** (`Real.Gamma_one_half_eq`, `integral_gaussian`, `integral_gaussian_Ioi`), not original mathematics — Mathlib already contains the analytic work. Badge: `mathlib`.

## Verification

`lake env lean` single-file compile: **EXIT 0, no errors**. `#print axioms` on all three theorems: `[propext, Classical.choice, Quot.sound]` only — fully verified, no `sorry`, no extra axioms.

- 57 lines, 3 theorems, 0 definitions, 0 axioms, 0 sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)