### PR TITLE
research(lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01): orbit-stabilizer over Nat.card

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01.lean
@@ -1,0 +1,103 @@
+import Mathlib.GroupTheory.GroupAction.Quotient
+import Mathlib.SetTheory.Cardinal.Finite
+import Mathlib.Tactic
+
+/-!
+# The Orbit-Stabilizer Family over `Nat.card`
+
+## What This Proves
+
+This file answers `oq-01` of the parent
+`lagrange-theorem-oq-02-oq-02-oq-01-oq-01` (Burnside's lemma over `Finite`).  The
+parent observed that Mathlib's orbit-counting lemma
+`MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` lifts off `Fintype` to
+the merely `Finite` setting because its mathematical core is a *finiteness-free
+bijection*.  Here we push the **same observation** through the other orbit-counting
+identity that bijection's machinery bundles — the **orbit-stabilizer theorem** —
+giving it a uniformly `Nat.card`-stated form.
+
+Mathlib states orbit-stabilizer only for `Fintype`:
+
+  `MulAction.card_orbit_mul_card_stabilizer_eq_card_group (b) [Fintype α] … :`
+  `  Fintype.card (orbit α b) * Fintype.card (stabilizer α b) = Fintype.card α`.
+
+We replace every `Fintype.card` by the total, instance-free `Nat.card`:
+
+  `Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G`,
+
+and add the companion **index form** `Nat.card (orbit G x) = Nat.card (G ⧸ stabilizer G x)`
+(orbit size equals the index of the stabilizer — the orbit-counting half of
+Lagrange's theorem).
+
+## Why the proofs lift unchanged — and need *no* finiteness at all
+
+The content is the finiteness-free bijection
+`MulAction.orbitProdStabilizerEquivGroup : orbit G x × stabilizer G x ≃ G`
+(and its sibling `orbitEquivQuotientStabilizer : orbit G x ≃ G ⧸ stabilizer G x`),
+provided by Mathlib for *any* group action with no `Fintype`/`Finite` hypotheses.
+Because `Nat.card` is total (it is `0` on infinite types) and `Nat.card_prod`,
+`Nat.card_congr` hold unconditionally, transporting the bijection through
+`Nat.card` requires **no finiteness instance whatsoever** — strictly more general
+than even the parent's `Finite` Burnside form, which still needed a `Fintype G` to
+collapse its `finsum`.  We recover Mathlib's exact `Fintype` statement as a
+corollary, confirming the generalisation subsumes the original.
+
+## Status
+- [x] `Nat.card` orbit-stabilizer product — `0` sorries, `0` axioms, no finiteness
+- [x] `Nat.card` orbit/stabilizer-index form
+- [x] Original `Fintype` statement recovered as a corollary
+
+## Mathlib Dependencies
+- `Mathlib.GroupTheory.GroupAction.Quotient` : `orbitProdStabilizerEquivGroup`,
+  `orbitEquivQuotientStabilizer`, `card_orbit_mul_card_stabilizer_eq_card_group`
+- `Mathlib.SetTheory.Cardinal.Finite` : `Nat.card_congr`, `Nat.card_prod`,
+  `Nat.card_eq_fintype_card`
+-/
+
+namespace OrbitStabilizerFinite
+
+open MulAction
+
+variable (G : Type*) (X : Type*) [Group G] [MulAction G X]
+
+/-- **Orbit-stabilizer theorem over `Nat.card`.**
+
+For any group `G` acting on any `X` and any point `x : X`,
+
+  `Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G`.
+
+This is the `Fintype`-free generalisation of Mathlib's
+`MulAction.card_orbit_mul_card_stabilizer_eq_card_group`.  The proof transports the
+finiteness-free bijection `orbitProdStabilizerEquivGroup` through `Nat.card`, so it
+needs **no** `Finite` or `Fintype` instance — every step is unconditional. -/
+theorem card_orbit_mul_card_stabilizer_eq_card_group_nat (x : X) :
+    Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G := by
+  rw [← Nat.card_prod, Nat.card_congr (orbitProdStabilizerEquivGroup G x)]
+
+/-- **Orbit size equals stabilizer index, over `Nat.card`.**
+
+  `Nat.card (orbit G x) = Nat.card (G ⧸ stabilizer G x)`.
+
+The orbit-counting half of Lagrange's theorem, obtained by transporting the
+finiteness-free bijection `orbitEquivQuotientStabilizer` through `Nat.card`.  Again
+no finiteness hypothesis is required. -/
+theorem card_orbit_eq_card_quotient_stabilizer_nat (x : X) :
+    Nat.card (orbit G x) = Nat.card (G ⧸ stabilizer G x) :=
+  Nat.card_congr (orbitEquivQuotientStabilizer G x)
+
+/-- The original Mathlib statement
+`MulAction.card_orbit_mul_card_stabilizer_eq_card_group`, recovered as a special
+case of the `Nat.card` generalisation: supplying the constructive `Fintype`
+instances and unfolding `Nat.card` to `Fintype.card` returns the bundled Mathlib
+lemma verbatim. -/
+theorem card_orbit_mul_card_stabilizer_eq_card_group_recovered (x : X)
+    [Fintype G] [Fintype (orbit G x)] [Fintype (stabilizer G x)] :
+    Fintype.card (orbit G x) * Fintype.card (stabilizer G x) = Fintype.card G := by
+  have h := card_orbit_mul_card_stabilizer_eq_card_group_nat G X x
+  simpa only [Nat.card_eq_fintype_card] using h
+
+#check @card_orbit_mul_card_stabilizer_eq_card_group_nat
+#check @card_orbit_eq_card_quotient_stabilizer_nat
+#check @card_orbit_mul_card_stabilizer_eq_card_group_recovered
+
+end OrbitStabilizerFinite

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "ann-lag0201-context",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 5, "endLine": 55 },
+    "type": "concept",
+    "title": "Extending the Finite Orbit-Counting Family",
+    "content": "The parent entry generalised Burnside's lemma off `Fintype` to `Finite` by observing that its core is a finiteness-free bijection. This entry applies the very same recipe to the orbit-stabilizer theorem — the other identity that bijection's machinery bundles — and reaches an even stronger conclusion: stated over `Nat.card`, orbit-stabilizer needs *no* finiteness hypothesis at all. We obtain `Nat.card (orbit G x) · Nat.card (stabilizer G x) = Nat.card G` for an arbitrary group action, plus the index form `Nat.card (orbit G x) = Nat.card (G ⧸ stabilizer G x)`.",
+    "mathContext": "Orbit-stabilizer says the map $g \\mapsto g \\cdot x$ descends to a bijection $G/\\mathrm{Stab}(x) \\cong \\mathrm{orbit}(x)$, and pairing with the stabilizer recovers all of $G$: $\\mathrm{orbit}(x) \\times \\mathrm{Stab}(x) \\cong G$. Over a finite group this gives $|\\mathrm{orbit}(x)|\\,|\\mathrm{Stab}(x)| = |G|$; over `Nat.card` the same bijection gives the identity unconditionally, with both sides equal to $0$ exactly when $G$ is infinite.",
+    "significance": "key",
+    "relatedConcepts": [
+      "orbit-stabilizer theorem",
+      "finiteness-free bijection",
+      "Nat.card totality",
+      "Burnside's lemma over Finite"
+    ],
+    "prerequisites": [
+      "group action: orbit, stabilizer, orbit space",
+      "Mathlib orbitProdStabilizerEquivGroup",
+      "parent lagrange-theorem-oq-02-oq-02-oq-01-oq-01 (Burnside over Finite)"
+    ]
+  },
+  {
+    "id": "ann-lag0201-product",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 63, "endLine": 75 },
+    "type": "technique",
+    "title": "Transporting orbitProdStabilizerEquivGroup through Nat.card",
+    "content": "`card_orbit_mul_card_stabilizer_eq_card_group_nat` is a two-rewrite proof: `← Nat.card_prod` folds the product `Nat.card (orbit) * Nat.card (stabilizer)` into `Nat.card (orbit × stabilizer)`, and `Nat.card_congr (orbitProdStabilizerEquivGroup G x)` rewrites that to `Nat.card G` along Mathlib's bijection. There is no `cases nonempty_fintype` step (which the parent needed to collapse its `finsum`): `Nat.card_prod` and `Nat.card_congr` are unconditional, so the theorem carries no finiteness instance.",
+    "mathContext": "This mirrors Mathlib's own `Fintype` proof line for line — `rw [← Fintype.card_prod, Fintype.card_congr (orbitProdStabilizerEquivGroup α b)]` — with `Fintype.card` replaced by `Nat.card`. The substitution is sound precisely because `Nat.card` agrees with `Fintype.card` on finite types and the transport lemmas have the same shape.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.card_prod", "Nat.card_congr", "orbitProdStabilizerEquivGroup"],
+    "prerequisites": ["orbitProdStabilizerEquivGroup", "Nat.card transport lemmas"]
+  },
+  {
+    "id": "ann-lag0201-index",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 77, "endLine": 86 },
+    "type": "technique",
+    "title": "Orbit Size = Stabilizer Index",
+    "content": "`card_orbit_eq_card_quotient_stabilizer_nat` is a single term, `Nat.card_congr (orbitEquivQuotientStabilizer G x)`: the orbit of `x` is in bijection with the cosets `G ⧸ stabilizer G x`, so they have equal `Nat.card`. This is the orbit-counting form of Lagrange's theorem — the orbit size *is* the index of the stabilizer — and combined with the product identity it expresses both halves of the count.",
+    "mathContext": "The bijection $\\mathrm{orbit}(x) \\cong G/\\mathrm{Stab}(x)$ is the heart of the orbit-stabilizer correspondence; reading it as $|\\mathrm{orbit}(x)| = [G : \\mathrm{Stab}(x)]$ recovers the statement that orbit sizes divide the group order, the orbit-theoretic shadow of Lagrange's theorem.",
+    "significance": "important",
+    "relatedConcepts": ["orbitEquivQuotientStabilizer", "stabilizer index", "Lagrange's theorem"],
+    "prerequisites": ["orbitEquivQuotientStabilizer", "Nat.card_congr"]
+  },
+  {
+    "id": "ann-lag0201-recovered",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 88, "endLine": 96 },
+    "type": "technique",
+    "title": "Recovering the Fintype Statement",
+    "content": "`card_orbit_mul_card_stabilizer_eq_card_group_recovered` supplies the constructive `Fintype G`, `Fintype (orbit G x)`, `Fintype (stabilizer G x)` instances and derives Mathlib's exact `Fintype.card` identity from the `Nat.card` one by `simpa only [Nat.card_eq_fintype_card]`. This certifies the generalisation genuinely subsumes the original — the classical orbit-stabilizer theorem is the finite shadow of the unconditional `Nat.card` version.",
+    "mathContext": "`Nat.card_eq_fintype_card : Nat.card α = Fintype.card α` whenever a `Fintype α` instance is present. Rewriting all three occurrences turns the `Nat.card` identity into the `Fintype.card` one, with no further mathematical input.",
+    "significance": "important",
+    "relatedConcepts": ["Nat.card_eq_fintype_card", "Fintype recovery", "subsumption"],
+    "prerequisites": ["card_orbit_mul_card_stabilizer_eq_card_group_nat", "Nat.card_eq_fintype_card"]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,112 @@
+{
+  "id": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
+  "slug": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.GroupAction.Quotient",
+      "Mathlib.SetTheory.Cardinal.Finite",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MulAction"
+    ],
+    "namespace": "OrbitStabilizerFinite",
+    "lineCount": 103,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Orbit-Stabilizer Family over Nat.card",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01.lean",
+    "tags": [
+      "group-theory",
+      "group-action",
+      "orbit-stabilizer",
+      "burnside",
+      "nat-card",
+      "finite",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 103,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "card_orbit_mul_card_stabilizer_eq_card_group_nat: Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G — the orbit-stabilizer theorem in instance-free Nat.card form, which Mathlib provides only for Fintype; needs no Finite or Fintype hypothesis at all",
+      "card_orbit_eq_card_quotient_stabilizer_nat: Nat.card (orbit G x) = Nat.card (G ⧸ stabilizer G x) — orbit size equals stabilizer index over Nat.card, the orbit-counting half of Lagrange's theorem",
+      "card_orbit_mul_card_stabilizer_eq_card_group_recovered: recovers Mathlib's exact Fintype orbit-stabilizer statement as a corollary, confirming the Nat.card form subsumes it"
+    ],
+    "prerequisites": [
+      "Group actions: orbit, stabilizer, the orbit space G ⧸ stabilizer (MulAction)",
+      "Mathlib's finiteness-free bijections orbitProdStabilizerEquivGroup and orbitEquivQuotientStabilizer",
+      "Nat.card and its transport lemmas (Nat.card_congr, Nat.card_prod)",
+      "Parent: lagrange-theorem-oq-02-oq-02-oq-01-oq-01 (Burnside's lemma over Finite)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.orbitProdStabilizerEquivGroup",
+        "description": "orbit G x × stabilizer G x ≃ G — the finiteness-free orbit-stabilizer bijection, valid for any group action. Transported through Nat.card to give the product identity.",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "MulAction.orbitEquivQuotientStabilizer",
+        "description": "orbit G x ≃ G ⧸ stabilizer G x — the finiteness-free orbit/coset bijection. Transported through Nat.card to give the orbit-size-equals-index identity.",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "MulAction.card_orbit_mul_card_stabilizer_eq_card_group",
+        "description": "The Fintype-only orbit-stabilizer theorem recovered here as a corollary of the Nat.card form.",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
+      "question": "Combine the orbit-stabilizer product Nat.card (orbit G x) · Nat.card (stabilizer G x) = Nat.card G with Lagrange's theorem Nat.card (stabilizer G x) · Nat.card (G ⧸ stabilizer G x) = Nat.card G to derive the orbit-counting / index identity Nat.card (orbit G x) = [G : stabilizer G x] entirely over Nat.card, with no finiteness instances.",
+      "significance": "medium"
+    },
+    {
+      "id": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-02",
+      "question": "Specialise the Nat.card orbit-stabilizer identity to the conjugation action of a group on itself to obtain the conjugacy-class size formula Nat.card (conjugacy class of g) = [G : centralizer g] over Nat.card, connecting this family to the class equation Group.nat_card_center_add_sum_card_noncenter_eq_card.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent. That entry generalised Burnside's orbit-counting lemma off Fintype to Finite by transporting the finiteness-free bijection sigmaFixedByEquivOrbitsProdGroup through Nat.card. This entry applies the same recipe to the sibling orbit-stabilizer bijection orbitProdStabilizerEquivGroup, and finds it needs no finiteness hypothesis at all."
+    },
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "related",
+      "description": "Grandparent family. The orbit-size-equals-stabilizer-index identity card_orbit_eq_card_quotient_stabilizer_nat is the orbit-counting form of Lagrange's theorem: the orbit of x is in bijection with the cosets of its stabilizer."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: GroupTheory.GroupAction.Quotient",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of orbitProdStabilizerEquivGroup, orbitEquivQuotientStabilizer, and the Fintype-form orbit-stabilizer theorem card_orbit_mul_card_stabilizer_eq_card_group."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The orbit-stabilizer theorem, stated by Mathlib only for Fintype, generalises to the instance-free Nat.card form Nat.card (orbit G x) · Nat.card (stabilizer G x) = Nat.card G — and, unlike the parent's Finite Burnside lemma, needs no finiteness hypothesis whatsoever, because Nat.card is total and the underlying bijection orbitProdStabilizerEquivGroup is finiteness-free. The companion card_orbit_eq_card_quotient_stabilizer_nat records the orbit-size-equals-stabilizer-index identity (the orbit-counting half of Lagrange's theorem), and the Fintype statement is recovered as a corollary. 103 lines, 3 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Together with the parent (Burnside over Finite) this builds a uniform Nat.card-stated family of orbit-counting identities: every Fintype-form statement in Mathlib's orbit-stabilizer/Burnside cluster has a total, instance-free shadow obtained by transporting the same finiteness-free bijection through Nat.card. The practical payoff is that downstream results no longer need to manufacture Fintype instances to state cardinality identities about orbits and stabilizers — the Nat.card forms hold unconditionally and specialise back to the classical Fintype versions on demand.",
+    "openQuestions": [
+      "Derive the orbit-counting index identity Nat.card (orbit G x) = [G : stabilizer G x] over Nat.card by combining with Lagrange.",
+      "Specialise to the conjugation action to obtain the conjugacy-class size formula and connect to the class equation."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers `oq-01` of the parent **lagrange-theorem-oq-02-oq-02-oq-01-oq-01** (Burnside's lemma over `Finite`). The parent generalised Burnside's orbit-counting lemma off `Fintype` by transporting a finiteness-free bijection through `Nat.card`. This entry applies the **same recipe** to the sibling **orbit-stabilizer theorem**, and finds an even stronger result: stated over `Nat.card` it needs **no finiteness hypothesis at all**.

## Theorems (`Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01.lean`, 3 theorems)

- `card_orbit_mul_card_stabilizer_eq_card_group_nat` — `Nat.card (orbit G x) · Nat.card (stabilizer G x) = Nat.card G`, the instance-free orbit-stabilizer identity (Mathlib has only the `Fintype` form). Two-rewrite proof via `Nat.card_prod` + `Nat.card_congr (orbitProdStabilizerEquivGroup G x)`; no `Fintype`/`Finite` instance.
- `card_orbit_eq_card_quotient_stabilizer_nat` — `Nat.card (orbit G x) = Nat.card (G ⧸ stabilizer G x)`, orbit size = stabilizer index (the orbit-counting half of Lagrange), via `orbitEquivQuotientStabilizer`.
- `card_orbit_mul_card_stabilizer_eq_card_group_recovered` — recovers Mathlib's exact `Fintype` statement, confirming subsumption.

## Verification

Type-checked single-file against prebuilt Mathlib oleans (`lake env lean`): **0 errors, 0 warnings, 0 sorries**; all three `#check`s confirm signatures.

`#print axioms` on all three → `[propext, Classical.choice, Quot.sound]` only — no `Lean.ofReduceBool`, no `sorryAx`. Status: **verified**, axiomCount 0, badge `mathlib` (the bijections are Mathlib's; the contribution is the unconditional `Nat.card` family extending the parent off `Fintype`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)