### PR TITLE
fix(lagrange-theorem-oq-02-oq-01): repair Mathlib v4.26.0 API drift [VERIFIED]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ02OQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ02OQ01.lean
@@ -43,6 +43,10 @@ Verified: 0 sorries, 0 axioms. All theorems machine-checked.
 -/
 
 open MulAction Finset BigOperators
+-- Decidability of orbit/stabilizer membership (finite sets) is classical; this
+-- supplies the `Fintype (orbit G x)` / `Fintype (stabilizer G x)` instances the
+-- statements below need under Mathlib v4.26.0.
+open scoped Classical
 
 namespace LagrangeTheoremOQ02OQ01
 
@@ -219,7 +223,7 @@ theorem lagrange_orbitstab_burnside_chain
     -- Burnside: Σ_g |Fix(g)| = |X/G| × |G|
     ∧ ∑ g : G, Fintype.card (MulAction.fixedBy X g) =
         Fintype.card (MulAction.orbitRel.Quotient G X) * Fintype.card G :=
-  ⟨Subgroup.card_subgroup_dvd_card H,
+  ⟨by simpa only [Nat.card_eq_fintype_card] using Subgroup.card_subgroup_dvd_card H,
    MulAction.card_orbit_mul_card_stabilizer_eq_card_group G x,
    burnside_from_orbit_stabilizer⟩
 


### PR DESCRIPTION
## Summary

`proofs/Proofs/LagrangeTheoremOQ02OQ01.lean` (gallery entry **lagrange-theorem-oq-02-oq-01**, "Burnside via explicit double-counting") **no longer compiled** against the project's pinned Mathlib v4.26.0. Discovered while attempting to build a child entry on top of it.

Two independent regressions from Mathlib API drift:

1. **Missing classical decidability.** `Fintype (orbit G x)` and `Fintype (stabilizer G x)` are not synthesizable in this Mathlib without classical decidability of set/subgroup membership. Every statement mentioning `Fintype.card (orbit ..)` / `Fintype.card (stabilizer ..)` failed to elaborate, and `sum_card_stabilizer_orbit` silently degraded to `sorry`. Fixed with `open scoped Classical` (finite sets — no new mathematical assumption).

2. **`Nat.card` / `Fintype.card` drift.** `Subgroup.card_subgroup_dvd_card H` now returns `Nat.card ↥H ∣ Nat.card G`, mismatching the `Fintype.card` form asserted by `lagrange_orbitstab_burnside_chain`. Bridged with `simpa only [Nat.card_eq_fintype_card] using …`.

The fix is **6 lines** and weakens no statement.

## Verification

```
lake env lean Proofs/LagrangeTheoremOQ02OQ01.lean   # exit 0
```

`#print axioms`:
- `burnside_from_orbit_stabilizer` → `[propext, Classical.choice, Quot.sound]`
- `lagrange_orbitstab_burnside_chain` → `[propext, Classical.choice, Quot.sound]`

No `sorryAx`, no `Lean.ofReduceBool` — genuinely verified (status remains `verified`, 0 axioms).

## Note

Builds were verified via single-file `lake env lean` (Docker build infra unavailable). This was a pre-existing breakage on `main` exposed by a Mathlib version bump (cf. the v4.26.0 `ord_compl` regression report, #18987).

🤖 Generated with [Claude Code](https://claude.com/claude-code)