### PR TITLE
research(quadratic-gauss-sum-square-oq-01): p=7 sign witness g=+i√7

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2863,6 +2863,7 @@ import Proofs.QuadraticGaussSumSquareOQ01
 import Proofs.QuadraticGaussSumSignReduction
 import Proofs.QuadraticGaussSumSignSmall
 import Proofs.QuadraticGaussSumSignSmallFive
+import Proofs.QuadraticGaussSumSignSmallSeven
 import Proofs.QuadraticReciprocity
 import Proofs.QuadraticReciprocityAlgorithmOQ01
 import Proofs.QuadraticReciprocityAlgorithmOQ03

--- a/proofs/Proofs/QuadraticGaussSumSignSmallSeven.lean
+++ b/proofs/Proofs/QuadraticGaussSumSignSmallSeven.lean
@@ -1,0 +1,202 @@
+/-
+  A concrete small-prime witness for Gauss's hard sign theorem: the prime `p = 7`.
+
+  Background.  For an odd prime `p` and a primitive additive character
+  `ψ : ZMod p → ℂ`, the quadratic Gauss sum `g = gaussSum (chiC p) ψ` is pinned by the
+  elementary dichotomy + magnitude (see `QuadraticGaussSumSignReduction`) to one of four
+  points: `±√p` for `p ≡ 1 (mod 4)`, or `±i√p` for `p ≡ 3 (mod 4)`.  Gauss's *hard* sign
+  theorem fixes the leading sign,
+      g = √p     (p ≡ 1 mod 4),     g = i·√p   (p ≡ 3 mod 4).
+  The general positivity `0 < Re g` / `0 < Im g` is open and needs heavy DFT/theta
+  infrastructure absent from Mathlib.
+
+  The companion files settle the smallest cases of each residue class: `p = 3`
+  (`QuadraticGaussSumSignSmall`, confirming `0 < Im g`) and `p = 5`
+  (`QuadraticGaussSumSignSmallFive`, confirming `0 < Re g`).  This file adds the next
+  witness on the `p ≡ 3 (mod 4)` branch, `p = 7`, a further confirmation of the open
+  crux `0 < Im g`.
+
+  Method (sign estimate, not exact trig).  For the standard character `ψ(x) = ζ^x` with
+  `ζ = exp(2πi/7)`, the values of `quadraticChar (ZMod 7)` are `0, 1, 1, -1, 1, -1, -1`
+  at `0,1,2,3,4,5,6` (the quadratic residues mod 7 are `1, 2, 4`), so the seven-term sum
+  collapses to
+
+      g = ζ + ζ² - ζ³ + ζ⁴ - ζ⁵ - ζ⁶.
+
+  Taking imaginary parts and folding `sin(8π/7) = -sin(6π/7)`, `sin(10π/7) = -sin(4π/7)`,
+  `sin(12π/7) = -sin(2π/7)` gives
+
+      Im g = 2·sin(2π/7) + 2·sin(4π/7) - 2·sin(6π/7).
+
+  As in the `p = 5` case we do NOT need exact radical values: positivity follows from the
+  coarse facts `sin(2π/7) > 0` and `sin(4π/7) > sin(6π/7)` (both angles fold to `(0, π/2)`
+  where `sin` is strictly monotone, and `4π/7 ↦ 3π/7 > π/7 ↤ 6π/7`).  Combined with the
+  four-point pinning `g = ±i√7`, this forces `g = +i√7`.
+
+  Sorry-free and axiom-free.
+-/
+import Mathlib
+import Proofs.QuadraticGaussSumSquare
+import Proofs.QuadraticGaussSumSignReduction
+
+open scoped BigOperators Real
+open Complex QuadraticGaussSumSquare QuadraticGaussSumSignReduction
+
+namespace QuadraticGaussSumSignSmallSeven
+
+/-- `7` is prime; needed for `chiC 7` and the Gauss-sum machinery. -/
+instance : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+
+/-- The standard primitive seventh root of unity `ζ = exp(2πi/7)`. -/
+noncomputable def ζ : ℂ := Complex.exp (2 * π * Complex.I / 7)
+
+theorem ζ_pow_seven : ζ ^ 7 = 1 := by
+  have h : IsPrimitiveRoot (Complex.exp (2 * π * Complex.I / 7)) 7 :=
+    Complex.isPrimitiveRoot_exp 7 (by norm_num)
+  simpa [ζ] using h.pow_eq_one
+
+/-- The standard additive character of `ZMod 7` valued in `ℂ`, `ψ(x) = ζ^x`. -/
+noncomputable def ψ₇ : AddChar (ZMod 7) ℂ := AddChar.zmodChar 7 ζ_pow_seven
+
+theorem ψ₇_isPrimitive : ψ₇.IsPrimitive := by
+  have hroot : IsPrimitiveRoot ζ 7 := by
+    simpa [ζ] using Complex.isPrimitiveRoot_exp 7 (by norm_num)
+  exact AddChar.zmodChar_primitive_of_primitive_root 7 hroot
+
+/-! ### The Gauss sum for `p = 7` collapses to `ζ + ζ² - ζ³ + ζ⁴ - ζ⁵ - ζ⁶` -/
+
+/-- `chiC 7` takes values `0, 1, 1, -1, 1, -1, -1` at `0, 1, 2, 3, 4, 5, 6` (residues
+`1, 2, 4`), so the seven-term Gauss sum is `ζ + ζ² - ζ³ + ζ⁴ - ζ⁵ - ζ⁶`. -/
+theorem gaussSum_seven_eq :
+    gaussSum (chiC 7) ψ₇ = ζ + ζ ^ 2 - ζ ^ 3 + ζ ^ 4 - ζ ^ 5 - ζ ^ 6 := by
+  have huniv : (Finset.univ : Finset (ZMod 7)) = {0, 1, 2, 3, 4, 5, 6} := by decide
+  rw [gaussSum, huniv, Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_singleton]
+  -- character values (residues mod 7 are 1, 2, 4)
+  have h0 : chiC 7 (0 : ZMod 7) = 0 := by simp [chiC]
+  have h1 : chiC 7 (1 : ZMod 7) = 1 := by simp
+  have h2 : chiC 7 (2 : ZMod 7) = 1 := by
+    have hsq : IsSquare (2 : ZMod 7) := by decide
+    have hq : (quadraticChar (ZMod 7)) 2 = 1 :=
+      (quadraticChar_one_iff_isSquare (by decide)).mpr hsq
+    simp [chiC, MulChar.ringHomComp_apply, hq]
+  have h3 : chiC 7 (3 : ZMod 7) = -1 := by
+    have hns : ¬ IsSquare (3 : ZMod 7) := by decide
+    have hq : (quadraticChar (ZMod 7)) 3 = -1 :=
+      (quadraticChar_neg_one_iff_not_isSquare).mpr hns
+    simp [chiC, MulChar.ringHomComp_apply, hq]
+  have h4 : chiC 7 (4 : ZMod 7) = 1 := by
+    have hsq : IsSquare (4 : ZMod 7) := by decide
+    have hq : (quadraticChar (ZMod 7)) 4 = 1 :=
+      (quadraticChar_one_iff_isSquare (by decide)).mpr hsq
+    simp [chiC, MulChar.ringHomComp_apply, hq]
+  have h5 : chiC 7 (5 : ZMod 7) = -1 := by
+    have hns : ¬ IsSquare (5 : ZMod 7) := by decide
+    have hq : (quadraticChar (ZMod 7)) 5 = -1 :=
+      (quadraticChar_neg_one_iff_not_isSquare).mpr hns
+    simp [chiC, MulChar.ringHomComp_apply, hq]
+  have h6 : chiC 7 (6 : ZMod 7) = -1 := by
+    have hns : ¬ IsSquare (6 : ZMod 7) := by decide
+    have hq : (quadraticChar (ZMod 7)) 6 = -1 :=
+      (quadraticChar_neg_one_iff_not_isSquare).mpr hns
+    simp [chiC, MulChar.ringHomComp_apply, hq]
+  -- additive character values
+  have e0 : ψ₇ (0 : ZMod 7) = 1 := by simp [ψ₇]
+  have e1 : ψ₇ (1 : ZMod 7) = ζ := by
+    rw [ψ₇, AddChar.zmodChar_apply, show ZMod.val (1 : ZMod 7) = 1 from by decide, pow_one]
+  have e2 : ψ₇ (2 : ZMod 7) = ζ ^ 2 := by
+    rw [ψ₇, AddChar.zmodChar_apply, show ZMod.val (2 : ZMod 7) = 2 from by decide]
+  have e3 : ψ₇ (3 : ZMod 7) = ζ ^ 3 := by
+    rw [ψ₇, AddChar.zmodChar_apply, show ZMod.val (3 : ZMod 7) = 3 from by decide]
+  have e4 : ψ₇ (4 : ZMod 7) = ζ ^ 4 := by
+    rw [ψ₇, AddChar.zmodChar_apply, show ZMod.val (4 : ZMod 7) = 4 from by decide]
+  have e5 : ψ₇ (5 : ZMod 7) = ζ ^ 5 := by
+    rw [ψ₇, AddChar.zmodChar_apply, show ZMod.val (5 : ZMod 7) = 5 from by decide]
+  have e6 : ψ₇ (6 : ZMod 7) = ζ ^ 6 := by
+    rw [ψ₇, AddChar.zmodChar_apply, show ZMod.val (6 : ZMod 7) = 6 from by decide]
+  rw [h0, h1, h2, h3, h4, h5, h6, e0, e1, e2, e3, e4, e5, e6]
+  ring
+
+/-! ### Folding the redundant sines into `sin(2π/7), sin(4π/7), sin(6π/7)` -/
+
+theorem sin_eight_pi_div_seven : Real.sin (8 * π / 7) = - Real.sin (6 * π / 7) := by
+  have h8 : (8 * π / 7 : ℝ) = π / 7 + π := by ring
+  have h6 : (6 * π / 7 : ℝ) = π - π / 7 := by ring
+  rw [h8, h6, Real.sin_add_pi, Real.sin_pi_sub]
+
+theorem sin_ten_pi_div_seven : Real.sin (10 * π / 7) = - Real.sin (4 * π / 7) := by
+  have h10 : (10 * π / 7 : ℝ) = 3 * π / 7 + π := by ring
+  have h4 : (4 * π / 7 : ℝ) = π - 3 * π / 7 := by ring
+  rw [h10, h4, Real.sin_add_pi, Real.sin_pi_sub]
+
+theorem sin_twelve_pi_div_seven : Real.sin (12 * π / 7) = - Real.sin (2 * π / 7) := by
+  have h12 : (12 * π / 7 : ℝ) = 5 * π / 7 + π := by ring
+  have h2 : (2 * π / 7 : ℝ) = π - 5 * π / 7 := by ring
+  rw [h12, h2, Real.sin_add_pi, Real.sin_pi_sub]
+
+/-! ### The imaginary part of the Gauss sum -/
+
+/-- The Gauss sum for `p = 7` is imaginary with
+`Im g = 2·sin(2π/7) + 2·sin(4π/7) - 2·sin(6π/7)`. -/
+theorem gaussSum_seven_im :
+    (gaussSum (chiC 7) ψ₇).im =
+      2 * Real.sin (2 * π / 7) + 2 * Real.sin (4 * π / 7) - 2 * Real.sin (6 * π / 7) := by
+  rw [gaussSum_seven_eq]
+  have hz1 : ζ = Complex.exp ((↑(2 * π / 7) : ℂ) * Complex.I) := by
+    rw [ζ]; congr 1; push_cast; ring
+  have hz2 : ζ ^ 2 = Complex.exp ((↑(4 * π / 7) : ℂ) * Complex.I) := by
+    rw [ζ, ← Complex.exp_nat_mul]; congr 1; push_cast; ring
+  have hz3 : ζ ^ 3 = Complex.exp ((↑(6 * π / 7) : ℂ) * Complex.I) := by
+    rw [ζ, ← Complex.exp_nat_mul]; congr 1; push_cast; ring
+  have hz4 : ζ ^ 4 = Complex.exp ((↑(8 * π / 7) : ℂ) * Complex.I) := by
+    rw [ζ, ← Complex.exp_nat_mul]; congr 1; push_cast; ring
+  have hz5 : ζ ^ 5 = Complex.exp ((↑(10 * π / 7) : ℂ) * Complex.I) := by
+    rw [ζ, ← Complex.exp_nat_mul]; congr 1; push_cast; ring
+  have hz6 : ζ ^ 6 = Complex.exp ((↑(12 * π / 7) : ℂ) * Complex.I) := by
+    rw [ζ, ← Complex.exp_nat_mul]; congr 1; push_cast; ring
+  -- resolve the higher powers first so `hz1` does not fire inside `ζ^k`
+  rw [hz6, hz5, hz4, hz3, hz2, hz1]
+  simp only [Complex.add_im, Complex.sub_im, Complex.exp_ofReal_mul_I_im]
+  rw [sin_eight_pi_div_seven, sin_ten_pi_div_seven, sin_twelve_pi_div_seven]
+  ring
+
+/-! ### Positivity of the imaginary part, hence the sign theorem for `p = 7` -/
+
+/-- The open positivity crux `0 < Im g`, verified in the base case `p = 7`. -/
+theorem gaussSum_seven_im_pos : 0 < (gaussSum (chiC 7) ψ₇).im := by
+  rw [gaussSum_seven_im]
+  -- `sin(2π/7) > 0`: angle in `(0, π)`.
+  have hsin2 : 0 < Real.sin (2 * π / 7) :=
+    Real.sin_pos_of_pos_of_lt_pi (by linarith [Real.pi_pos]) (by linarith [Real.pi_pos])
+  -- `sin(4π/7) > sin(6π/7)`: fold both to `(0, π/2)`, where `sin` is strictly monotone,
+  -- via `sin(4π/7) = sin(3π/7)` and `sin(6π/7) = sin(π/7)`, then `π/7 < 3π/7`.
+  have e4 : Real.sin (4 * π / 7) = Real.sin (3 * π / 7) := by
+    have : (4 * π / 7 : ℝ) = π - 3 * π / 7 := by ring
+    rw [this, Real.sin_pi_sub]
+  have e6 : Real.sin (6 * π / 7) = Real.sin (π / 7) := by
+    have : (6 * π / 7 : ℝ) = π - π / 7 := by ring
+    rw [this, Real.sin_pi_sub]
+  have hmono : Real.sin (π / 7) < Real.sin (3 * π / 7) := by
+    apply Real.strictMonoOn_sin
+    · constructor
+      · linarith [Real.pi_pos]
+      · linarith [Real.pi_pos]
+    · constructor
+      · linarith [Real.pi_pos]
+      · linarith [Real.pi_pos]
+    · linarith [Real.pi_pos]
+  have hsin46 : Real.sin (6 * π / 7) < Real.sin (4 * π / 7) := by
+    rw [e4, e6]; exact hmono
+  linarith
+
+/-- **Gauss's hard sign theorem, witness `p = 7`.** For the standard additive character
+`ψ₇(x) = exp(2πi/7)^x`, the quadratic Gauss sum equals exactly `+i·√7` (not `-i·√7`).
+This is a second witness on the `p ≡ 3 (mod 4)` branch (after `p = 3`), confirming the
+open positivity crux `0 < Im g`. -/
+theorem gaussSum_seven_eq_I_sqrt_seven :
+    gaussSum (chiC 7) ψ₇ = (Real.sqrt 7 : ℂ) * Complex.I := by
+  have hp4 : (7 : ℕ) % 4 = 3 := by norm_num
+  exact (gaussSum_eq_I_sqrt_iff_im_pos hp4 ψ₇_isPrimitive).mpr gaussSum_seven_im_pos
+
+end QuadraticGaussSumSignSmallSeven

--- a/research/problems/quadratic-gauss-sum-square-oq-01/knowledge.md
+++ b/research/problems/quadratic-gauss-sum-square-oq-01/knowledge.md
@@ -128,3 +128,49 @@ both routes, so it is reusable groundwork rather than throwaway.
 - Reframe `0 < Re(∑ ζ_p^{k²})` and look for a positivity argument that avoids full
   eigenvalue-multiplicity computation (e.g. pairing `k` with `p−k`, partial-sum bounds).
 - Consider upstreaming `gaussSum_chiC_eq_sum_sq` to Mathlib's `NumberTheory/GaussSum.lean`.
+## Session 2026-06-19 (Session 5) — p = 7 witness (second `p ≡ 3 mod 4` case)
+
+Note: the Session-4 diagonal note remarked that the *diagonal* form `∑ζ^{k²}` does not
+make `p = 7` tractable (it needs the cubic value `cos(2π/7)`). This session shows the
+*Legendre-weighted* form does: comparing two folded sines (`sin(4π/7) > sin(6π/7)`)
+sidesteps exact radicals entirely.
+
+**Mode:** depth-first · **Outcome:** progress (new sorry-free, axiom-free witness)
+
+### What I did
+- New companion file `Proofs/QuadraticGaussSumSignSmallSeven.lean` (verified): the next
+  prime on the `p ≡ 3 (mod 4)` branch after `p = 3`, mirroring the p=3/p=5 files.
+  - `gaussSum_seven_eq` — seven-term enumeration over `ZMod 7` collapses to
+    `ζ + ζ² − ζ³ + ζ⁴ − ζ⁵ − ζ⁶` (`quadraticChar (ZMod 7)` = `0,1,1,-1,1,-1,-1`; the
+    quadratic residues mod 7 are `1,2,4`). Used `quadraticChar_one_iff_isSquare` for the
+    residues (+1) and `quadraticChar_neg_one_iff_not_isSquare` for the non-residues (−1),
+    each `IsSquare`/`¬IsSquare` discharged by `decide`.
+  - `sin_eight/ten/twelve_pi_div_seven` — fold the upper-half sines via
+    `sin(x+π)=−sin x` (`Real.sin_add_pi`) and `sin(π−x)=sin x` (`Real.sin_pi_sub`):
+    `sin(8π/7)=−sin(6π/7)`, `sin(10π/7)=−sin(4π/7)`, `sin(12π/7)=−sin(2π/7)`.
+  - `gaussSum_seven_im` — `Im g = 2·sin(2π/7) + 2·sin(4π/7) − 2·sin(6π/7)`.
+  - `gaussSum_seven_im_pos` — **`0 < Im g`** from coarse signs only: `sin(2π/7) > 0`
+    (`sin_pos_of_pos_of_lt_pi`) and `sin(4π/7) > sin(6π/7)` (fold to `sin(3π/7) > sin(π/7)`
+    via `Real.strictMonoOn_sin` on `[-π/2, π/2]`). No exact radical values needed.
+  - `gaussSum_seven_eq_I_sqrt_seven` — feeds the positivity into the reduction lemma
+    `gaussSum_eq_I_sqrt_iff_im_pos` (with `7 % 4 = 3`) to get the FULL determination
+    `gaussSum (chiC 7) ψ₇ = +i·√7` (not `−i·√7`).
+  - Verified by single-file olean-chain compile (Docker host-blocked); `#print axioms`
+    on both `gaussSum_seven_eq_I_sqrt_seven` and `gaussSum_seven_im_pos` =
+    `[propext, Classical.choice, Quot.sound]` only (axiom-free).
+
+### Key findings
+- The `p = 5` coarse-sign method (compare two cosines/sines, sidestepping exact radicals)
+  generalises cleanly to `p = 7`: the only new ingredient is the strict monotonicity of
+  `sin` on `[-π/2, π/2]` to compare two sines after folding both into that interval.
+- The `p ≡ 3 (mod 4)` branch now has two machine-checked witnesses (`p = 3`, `p = 7`); the
+  general `0 < Im g` remains the open DFT-spectrum crux (>1000 lines either route).
+
+### Files modified
+- `proofs/Proofs/QuadraticGaussSumSignSmallSeven.lean` (new, verified)
+- `proofs/Proofs.lean` (import)
+- `src/data/research/problems/quadratic-gauss-sum-square-oq-01.json` (new knowledge)
+
+### Next steps
+- `p = 13` / `p = 17` as further `p ≡ 1 (mod 4)` witnesses, or pivot to the general
+  DFT-spectrum route once (or if) Mathlib gains finite-Fourier eigenvalue infrastructure.

--- a/src/data/research/problems/quadratic-gauss-sum-square-oq-01.json
+++ b/src/data/research/problems/quadratic-gauss-sum-square-oq-01.json
@@ -8,7 +8,8 @@
       "Dichotomy + magnitude pin g to exactly four points: ±√p (p≡1 mod 4) or ±i√p (p≡3 mod 4). Proved sorry-free in QuadraticGaussSumSignReduction.gaussSum_eq_pm_sqrt / gaussSum_eq_pm_I_sqrt by extracting g.re²=p (resp g.im²=p) from normSq and splitting |·|=√p via abs_eq.",
       "KEY REDUCTION: Gauss's hard sign theorem is EQUIVALENT to a single real positivity. g=√p ↔ 0<g.re (p≡1 mod 4); g=i√p ↔ 0<g.im (p≡3 mod 4). Proved sorry-free (gaussSum_eq_sqrt_iff_re_pos / gaussSum_eq_I_sqrt_iff_im_pos). This isolates the entire open content into one inequality.",
       "Mathlib (v4.26.x) has NO sign determination for the quadratic Gauss sum and no finite-Fourier-transform determinant infrastructure. NumberTheory/GaussSum.lean stops at gaussSum_sq (the square identity); there is nothing about Re(g)>0 or the DFT eigenvalue multiplicities.",
-      "DIAGONAL REPRESENTATION (verified, axiom-free): gaussSum (chiC p) ψ = ∑ k, ψ(k²) for any primitive additive character ψ. Proved by fibre counting: grouping ∑ψ(k²) by t=k² turns the multiplicity into #{k:k²=t}=χ(t)+1 (quadraticChar_card_sqrts), giving ∑ψ(k²)=∑(χ(t)+1)ψ(t)=g+∑ψ(t)=g+0. This is the universal starting point of every classical sign proof and was absent from Mathlib."
+      "DIAGONAL REPRESENTATION (verified, axiom-free): gaussSum (chiC p) ψ = ∑ k, ψ(k²) for any primitive additive character ψ. Proved by fibre counting: grouping ∑ψ(k²) by t=k² turns the multiplicity into #{k:k²=t}=χ(t)+1 (quadraticChar_card_sqrts), giving ∑ψ(k²)=∑(χ(t)+1)ψ(t)=g+∑ψ(t)=g+0. This is the universal starting point of every classical sign proof and was absent from Mathlib.",
+      "Witness p=7 (≡3 mod 4): chiC 7 = (0,1,1,-1,1,-1,-1) (residues 1,2,4), so g=ζ+ζ²-ζ³+ζ⁴-ζ⁵-ζ⁶. Folding sin(8π/7)=-sin(6π/7), sin(10π/7)=-sin(4π/7), sin(12π/7)=-sin(2π/7) gives Im g = 2sin(2π/7)+2sin(4π/7)-2sin(6π/7). Positivity from coarse signs: sin(2π/7)>0 and sin(4π/7)>sin(6π/7) (fold to sin(3π/7)>sin(π/7) via strictMonoOn_sin on [-π/2,π/2]) — NO exact radicals. Feeds gaussSum_eq_I_sqrt_iff_im_pos to force g=+i√7. NOTE: this uses the Legendre-WEIGHTED form, not the diagonal ∑ζ^{k²} form (which would need cos(2π/7))."
     ],
     "builtItems": [
       "QuadraticGaussSumSignReduction.gaussSum_eq_pm_sqrt — g=±√p for p≡1 mod 4 (sorry-free)",
@@ -16,7 +17,8 @@
       "QuadraticGaussSumSignReduction.gaussSum_eq_sqrt_iff_re_pos — sign theorem ⟺ 0<Re g (p≡1) (sorry-free)",
       "QuadraticGaussSumSignReduction.gaussSum_eq_I_sqrt_iff_im_pos — sign theorem ⟺ 0<Im g (p≡3) (sorry-free)",
       "QuadraticGaussSumDiagonal.gaussSum_chiC_eq_sum_sq — g = ∑ k, ψ(k²) (sorry-free, axiom-free)",
-      "QuadraticGaussSumDiagonal.card_sqrts_cast — (#{x:x²=t}.card : ℂ) = chiC p t + 1, ℂ-transport of quadraticChar_card_sqrts"
+      "QuadraticGaussSumDiagonal.card_sqrts_cast — (#{x:x²=t}.card : ℂ) = chiC p t + 1, ℂ-transport of quadraticChar_card_sqrts",
+      "QuadraticGaussSumSignSmallSeven.gaussSum_seven_eq_I_sqrt_seven — g=+i√7 for p=7 (≡3 mod 4), second witness on that branch (sorry-free, axiom-free)"
     ],
     "mathlibGaps": [
       "No formalization of the sign of the quadratic Gauss sum (g=√p for p≡1, g=i√p for p≡3).",


### PR DESCRIPTION
## Summary

Adds `Proofs/QuadraticGaussSumSignSmallSeven.lean`, a new small-prime witness for **Gauss's hard sign theorem** on the open follow-up problem `quadratic-gauss-sum-square-oq-01`. It is the **second witness on the `p ≡ 3 (mod 4)` branch** (after the existing `p = 3` case), determining the leading sign:

```
gaussSum (chiC 7) ψ₇ = +i·√7   (not −i·√7)
```

## Method (no exact radicals)

For the standard character `ψ(x) = exp(2πi/7)^x`, the quadratic residues mod 7 are `1,2,4`, so `chiC 7 = (0,1,1,-1,1,-1,-1)` and the seven-term sum collapses to

```
g = ζ + ζ² − ζ³ + ζ⁴ − ζ⁵ − ζ⁶.
```

Folding the upper-half sines (`sin(8π/7)=−sin(6π/7)`, `sin(10π/7)=−sin(4π/7)`, `sin(12π/7)=−sin(2π/7)`) gives

```
Im g = 2·sin(2π/7) + 2·sin(4π/7) − 2·sin(6π/7).
```

Positivity follows from **coarse sign facts only**: `sin(2π/7) > 0` and `sin(4π/7) > sin(6π/7)` (both fold into `(0, π/2)`, where `sin` is strictly monotone: `sin(3π/7) > sin(π/7)`). No exact value like `cos(2π/7)` is needed. Feeding `0 < Im g` into the existing reduction lemma `gaussSum_eq_I_sqrt_iff_im_pos` (with `7 % 4 = 3`) forces `g = +i√7`.

This extends the coarse-sign technique that settled `p = 5` to the `p = 7` case, and notably bypasses the obstruction noted for the *diagonal* form `∑ ζ^{k²}` (which would require `cos(2π/7)`).

## Status

- **Sorry-free and axiom-free**: `#print axioms` on `gaussSum_seven_eq_I_sqrt_seven` and `gaussSum_seven_im_pos` = `[propext, Classical.choice, Quot.sound]` only.
- Verified by single-file olean-chain compile (Docker host-blocked this session).
- The general crux `0 < Im g` for arbitrary `p ≡ 3 (mod 4)` remains open (DFT-spectrum content, >1000 lines either route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)