### PR TITLE
research(hilbert-10-oq-04-oq-03-oq-02-oq-01): decide linear systems via Smith normal form (verified)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ04OQ03OQ02OQ01.lean
+++ b/proofs/Proofs/Hilbert10OQ04OQ03OQ02OQ01.lean
@@ -1,0 +1,149 @@
+/-
+# Hilbert's Tenth Problem, degree 1: deciding linear *systems* via Smith normal form
+
+Follow-up to `Hilbert10OQ04OQ03OQ02` (its open question oq-01).
+
+The parent file `Hilbert10OQ04OQ03OQ02` reduced solvability of a linear system
+
+  `A x = b`,  `A : Matrix (Fin m) (Fin n) ℤ`,  `b : Fin m → ℤ`,
+
+to *membership of `b` in the ℤ-span of the columns of `A`* (`solvable_iff_mem_colSpan`),
+and flagged the remaining step explicitly:
+
+> "What is *not* claimed here is the full `Decidable` instance for `∃ x, A x = b`:
+>  that requires turning column-span membership into invariant-factor divisibility
+>  via the Smith normal form `U A V = D`."
+
+This file supplies exactly that step for **square systems**. Smith normal form for an
+`n × n` integer matrix `A` produces unimodular `U, V ∈ GLₙ(ℤ)` (matrices with two-sided
+integer inverses) and a diagonal `D = diagonal d` of invariant factors with `U A V = D`.
+We prove, *taking the Smith normal form as given data*:
+
+* `diagonal_mulVec_solvable_iff` — the diagonal case: `(∃ x, diagonal d *ᵥ x = c) ↔ ∀ i, d i ∣ c i`.
+  This is where invariant-factor divisibility enters; it is decidable on the nose.
+* `solvable_iff_solvable_diagonal` — the **unimodular reduction**: if `U A V = diagonal d`
+  with `U, V` invertible over `ℤ`, then `A x = b` is solvable iff the diagonalised system
+  `diagonal d *ᵥ y = U *ᵥ b` is.
+* `solvable_iff_invariantFactor_dvd` — composing the two: `(∃ x, A *ᵥ x = b) ↔ ∀ i, d i ∣ (U *ᵥ b) i`,
+  i.e. solvability is decided by `n` divisibility tests on the transformed right-hand side `U b`.
+* `decidableSolvableOfSmith` — the resulting `Decidable` instance for `∃ x, A *ᵥ x = b`,
+  given a Smith normal form of `A`.
+
+Together these complete the decision procedure *modulo the existence of the Smith normal form*.
+Mathlib has the PID structure theory (`Module.Basis.SmithNormalForm`) but does not yet expose
+a `Matrix`-level algorithm returning the unimodular `U, V` and the diagonal `D = U A V`; that
+construction is the one remaining gap, and it is the sole input these results consume. The
+rectangular `m ≠ n` case (rectangular-diagonal `D`, with zero rows forcing `cᵢ = 0`) is the
+natural further generalisation.
+
+Everything is `sorry`-free and `axiom`-free (only the foundational
+`propext`/`Classical.choice`/`Quot.sound` are used; no `Lean.ofReduceBool`).
+-/
+import Mathlib
+
+-- The four inverse hypotheses below assert `U, V ∈ GLₙ(ℤ)` (the unimodular data of a
+-- Smith normal form); the reduction proof happens to consume only two of them.
+set_option linter.unusedVariables false
+
+open Matrix
+
+namespace Hilbert10OQ04OQ03OQ02OQ01
+
+variable {n : ℕ}
+
+/-- **Diagonal case.** A diagonal integer system `diagonal d *ᵥ x = c` is solvable over `ℤ`
+iff each diagonal entry divides the corresponding right-hand side: `∀ i, d i ∣ c i`. Each
+coordinate decouples into the scalar equation `d i * xᵢ = c i`, whose solvability over `ℤ`
+is precisely `d i ∣ c i`. This is the point at which *invariant-factor divisibility* enters
+the decision procedure. -/
+theorem diagonal_mulVec_solvable_iff (d c : Fin n → ℤ) :
+    (∃ x : Fin n → ℤ, diagonal d *ᵥ x = c) ↔ ∀ i, d i ∣ c i := by
+  constructor
+  · rintro ⟨x, hx⟩ i
+    refine ⟨x i, ?_⟩
+    have h := congrFun hx i
+    rw [mulVec_diagonal] at h
+    exact h.symm
+  · intro h
+    refine ⟨fun i => (h i).choose, ?_⟩
+    funext i
+    rw [mulVec_diagonal]
+    exact ((h i).choose_spec).symm
+
+/-- **Unimodular reduction.** Let `U, V : Matrix (Fin n) (Fin n) ℤ` be invertible over `ℤ`
+(`U * Ui = 1`, `Ui * U = 1`, and likewise for `V`), and suppose `U * A * V = diagonal d`
+(a Smith normal form of the square matrix `A`). Then the system `A x = b` is solvable iff
+the diagonalised system `diagonal d *ᵥ y = U *ᵥ b` is. The bijections `x ↦ Vi *ᵥ x` and
+`y ↦ V *ᵥ y` transport solutions between the two systems. -/
+theorem solvable_iff_solvable_diagonal
+    (A : Matrix (Fin n) (Fin n) ℤ) (b d : Fin n → ℤ)
+    (U Ui V Vi : Matrix (Fin n) (Fin n) ℤ)
+    (hU : U * Ui = 1) (hUi : Ui * U = 1) (hV : V * Vi = 1) (hVi : Vi * V = 1)
+    (hD : U * A * V = diagonal d) :
+    (∃ x : Fin n → ℤ, A *ᵥ x = b) ↔ (∃ y : Fin n → ℤ, diagonal d *ᵥ y = U *ᵥ b) := by
+  constructor
+  · rintro ⟨x, hx⟩
+    refine ⟨Vi *ᵥ x, ?_⟩
+    -- `diagonal d *ᵥ (Vi x) = U A V *ᵥ (Vi x) = U *ᵥ (A *ᵥ (V *ᵥ (Vi *ᵥ x))) = U *ᵥ (A *ᵥ x) = U b`
+    have hVx : V *ᵥ (Vi *ᵥ x) = x := by
+      rw [mulVec_mulVec, hV, one_mulVec]
+    calc diagonal d *ᵥ (Vi *ᵥ x)
+        = (U * A * V) *ᵥ (Vi *ᵥ x) := by rw [hD]
+      _ = U *ᵥ (A *ᵥ (V *ᵥ (Vi *ᵥ x))) := by
+            rw [← mulVec_mulVec, ← mulVec_mulVec]
+      _ = U *ᵥ (A *ᵥ x) := by rw [hVx]
+      _ = U *ᵥ b := by rw [hx]
+  · rintro ⟨y, hy⟩
+    refine ⟨V *ᵥ y, ?_⟩
+    -- `A x = (A V) *ᵥ y` and `A V = Ui * diagonal d`, so `A x = Ui *ᵥ (diagonal d *ᵥ y) = Ui U b = b`
+    have hAV : A * V = Ui * diagonal d := by
+      have : Ui * (U * A * V) = Ui * diagonal d := by rw [hD]
+      rwa [← mul_assoc, ← mul_assoc, hUi, one_mul] at this
+    calc A *ᵥ (V *ᵥ y)
+        = (A * V) *ᵥ y := by rw [mulVec_mulVec]
+      _ = (Ui * diagonal d) *ᵥ y := by rw [hAV]
+      _ = Ui *ᵥ (diagonal d *ᵥ y) := by rw [← mulVec_mulVec]
+      _ = Ui *ᵥ (U *ᵥ b) := by rw [hy]
+      _ = (Ui * U) *ᵥ b := by rw [mulVec_mulVec]
+      _ = b := by rw [hUi, one_mulVec]
+
+/-- **Invariant-factor divisibility criterion.** Composing the unimodular reduction with the
+diagonal case: given a Smith normal form `U A V = diagonal d` of the square matrix `A`
+(`U, V` invertible over `ℤ`), the system `A x = b` is solvable over `ℤ` iff every invariant
+factor `d i` divides the corresponding coordinate of the transformed right-hand side `U b`.
+This turns column-lattice membership (the parent's `solvable_iff_mem_colSpan`) into `n`
+divisibility tests. -/
+theorem solvable_iff_invariantFactor_dvd
+    (A : Matrix (Fin n) (Fin n) ℤ) (b d : Fin n → ℤ)
+    (U Ui V Vi : Matrix (Fin n) (Fin n) ℤ)
+    (hU : U * Ui = 1) (hUi : Ui * U = 1) (hV : V * Vi = 1) (hVi : Vi * V = 1)
+    (hD : U * A * V = diagonal d) :
+    (∃ x : Fin n → ℤ, A *ᵥ x = b) ↔ ∀ i, d i ∣ (U *ᵥ b) i :=
+  (solvable_iff_solvable_diagonal A b d U Ui V Vi hU hUi hV hVi hD).trans
+    (diagonal_mulVec_solvable_iff d (U *ᵥ b))
+
+/-- **Decidability from a Smith normal form.** Given a Smith normal form `U A V = diagonal d`
+of a square integer matrix `A` (with `U, V` invertible over `ℤ`), solvability of `A x = b`
+over `ℤ` is decidable: run the `n` divisibility tests `d i ∣ (U *ᵥ b) i`. The only ingredient
+not produced here is the Smith normal form itself; everything downstream is decidable. -/
+def decidableSolvableOfSmith
+    (A : Matrix (Fin n) (Fin n) ℤ) (b d : Fin n → ℤ)
+    (U Ui V Vi : Matrix (Fin n) (Fin n) ℤ)
+    (hU : U * Ui = 1) (hUi : Ui * U = 1) (hV : V * Vi = 1) (hVi : Vi * V = 1)
+    (hD : U * A * V = diagonal d) :
+    Decidable (∃ x : Fin n → ℤ, A *ᵥ x = b) :=
+  decidable_of_iff (∀ i, d i ∣ (U *ᵥ b) i)
+    (solvable_iff_invariantFactor_dvd A b d U Ui V Vi hU hUi hV hVi hD).symm
+
+/-- Worked sanity check: the identity matrix is its own Smith normal form (`U = V = 1`,
+`d = 1`), and `1 ∣ b i` always holds, so every system `x = b` is solvable — as it must be,
+with `x = b`. -/
+example (b : Fin n → ℤ) :
+    (∃ x : Fin n → ℤ, (1 : Matrix (Fin n) (Fin n) ℤ) *ᵥ x = b) ↔
+      ∀ i, (1 : Fin n → ℤ) i ∣ ((1 : Matrix (Fin n) (Fin n) ℤ) *ᵥ b) i := by
+  have h1 : (1 : Matrix (Fin n) (Fin n) ℤ) * 1 * 1 = diagonal (1 : Fin n → ℤ) := by
+    simp
+  exact solvable_iff_invariantFactor_dvd 1 b 1 1 1 1 1
+    (by simp) (by simp) (by simp) (by simp) h1
+
+end Hilbert10OQ04OQ03OQ02OQ01

--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02-oq-01/annotations.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "h10oq04030201-ann-01",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-02-oq-01",
+    "range": { "startLine": 54, "endLine": 71 },
+    "type": "concept",
+    "title": "The Diagonal Case: Where Divisibility Enters",
+    "content": "diagonal_mulVec_solvable_iff is the heart of the criterion. Because (diagonal d *ᵥ x) i = d i * x i (Matrix.mulVec_diagonal), the system diagonal d *ᵥ x = c decouples completely into independent scalar equations d i * xᵢ = c i, one per coordinate. Such a scalar equation is solvable over ℤ exactly when d i ∣ c i. The forward direction reads off the divisibility witness x i from a solution; the backward direction assembles a solution coordinate-by-coordinate, choosing each xᵢ from the witness supplied by d i ∣ c i (Classical choice over the finite index Fin n). This is the only place invariant-factor divisibility appears — everything else is change of basis."
+  },
+  {
+    "id": "h10oq04030201-ann-02",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-02-oq-01",
+    "range": { "startLine": 73, "endLine": 108 },
+    "type": "technique",
+    "title": "Unimodular Reduction by Pure mulVec Associativity",
+    "content": "solvable_iff_solvable_diagonal transports solvability of A x = b to the diagonalised system diagonal d *ᵥ y = U *ᵥ b, given U A V = diagonal d with U, V invertible over ℤ. The two directions are mutually inverse linear bijections: forward sends a solution x to y = Vi *ᵥ x, using V *ᵥ (Vi *ᵥ x) = x; backward sends y to x = V *ᵥ y, using the rearrangement A * V = Ui * diagonal d (obtained by left-multiplying U A V = diagonal d by Ui) and Ui *ᵥ (U *ᵥ b) = b. Remarkably, no determinant or GLₙ machinery is needed — every step is an application of Matrix.mulVec_mulVec (M *ᵥ (N *ᵥ v) = (M * N) *ᵥ v) and Matrix.one_mulVec (1 *ᵥ v = v). The unimodularity of U and V enters only through the supplied two-sided inverses."
+  },
+  {
+    "id": "h10oq04030201-ann-03",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-02-oq-01",
+    "range": { "startLine": 110, "endLine": 137 },
+    "type": "concept",
+    "title": "From Criterion to Decidable Instance",
+    "content": "solvable_iff_invariantFactor_dvd composes the unimodular reduction with the diagonal case to obtain ∃ x, A *ᵥ x = b ↔ ∀ i, d i ∣ (U *ᵥ b) i: system solvability is decided by n divisibility tests on the single transformed right-hand side U b, with no search over x. Since ∀ i, d i ∣ (U *ᵥ b) i is a Fintype-decidable predicate (finite conjunction of decidable integer-divisibility tests), decidableSolvableOfSmith hands this to decidable_of_iff to produce a Decidable instance for ∃ x, A *ᵥ x = b. The only data the instance needs is the Smith normal form itself — the construction of which is the entry's sole open question."
+  }
+]

--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02-oq-01/meta.json
@@ -1,0 +1,156 @@
+{
+  "id": "hilbert-10-oq-04-oq-03-oq-02-oq-01",
+  "title": "Hilbert's 10th OQ-04-03-02-01: Deciding Linear Systems via Smith Normal Form",
+  "slug": "hilbert-10-oq-04-oq-03-oq-02-oq-01",
+  "description": "Completes the decision procedure for square linear Diophantine SYSTEMS A x = b over ℤ, modulo existence of a Smith normal form. The parent (Hilbert10OQ04OQ03OQ02) reduced system solvability to column-lattice membership and left the decision step — turning that membership into invariant-factor divisibility via SNF — open. This entry supplies it: (1) the diagonal case ∃ x, diagonal d *ᵥ x = c ↔ ∀ i, d i ∣ c i, where invariant-factor divisibility enters; (2) the unimodular reduction, that U A V = diagonal d with U,V ∈ GLₙ(ℤ) gives ∃ x, A *ᵥ x = b ↔ ∃ y, diagonal d *ᵥ y = U *ᵥ b; (3) their composition ∃ x, A *ᵥ x = b ↔ ∀ i, d i ∣ (U *ᵥ b) i; and (4) the resulting Decidable instance. The sole remaining ingredient is the Smith-normal-form construction itself (a Matrix-level algorithm Mathlib does not yet expose), which is the only input these results consume. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-19",
+    "status": "verified",
+    "badge": "verified",
+    "proofRepoPath": "Proofs/Hilbert10OQ04OQ03OQ02OQ01.lean",
+    "tags": [
+      "hilbert-10",
+      "diophantine-equations",
+      "linear-systems",
+      "smith-normal-form",
+      "decidability",
+      "linear-algebra",
+      "research"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 149,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "dateAdded": "2026-06-19",
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.mulVec_diagonal",
+        "description": "Coordinate of a diagonal matrix–vector product: (diagonal v *ᵥ w) i = v i * w i",
+        "module": "Mathlib.Data.Matrix.Mul"
+      },
+      {
+        "theorem": "Matrix.mulVec_mulVec",
+        "description": "Associativity of matrix–vector multiplication: M *ᵥ (N *ᵥ v) = (M * N) *ᵥ v",
+        "module": "Mathlib.Data.Matrix.Mul"
+      },
+      {
+        "theorem": "Matrix.one_mulVec",
+        "description": "The identity matrix acts trivially: 1 *ᵥ v = v",
+        "module": "Mathlib.Data.Matrix.Mul"
+      },
+      {
+        "theorem": "Module.Basis.SmithNormalForm",
+        "description": "Smith normal form of a submodule of a free module over a PID — the structure whose Matrix-level analogue (the unimodular U, V with U A V = D) is the single input these results consume; not yet exposed by Mathlib as a matrix algorithm",
+        "module": "Mathlib.LinearAlgebra.FreeModule.PID"
+      }
+    ],
+    "originalContributions": [
+      "diagonal_mulVec_solvable_iff: the diagonal system diagonal d *ᵥ x = c is solvable over ℤ iff ∀ i, d i ∣ c i — the coordinate-wise decoupling where invariant-factor divisibility enters, decidable on the nose",
+      "solvable_iff_solvable_diagonal: the unimodular reduction — if U A V = diagonal d with U, V invertible over ℤ, then ∃ x, A *ᵥ x = b ↔ ∃ y, diagonal d *ᵥ y = U *ᵥ b, with the solution bijections x ↦ Vi *ᵥ x and y ↦ V *ᵥ y proved purely from mulVec associativity",
+      "solvable_iff_invariantFactor_dvd: the composed criterion ∃ x, A *ᵥ x = b ↔ ∀ i, d i ∣ (U *ᵥ b) i, deciding system solvability by n divisibility tests on the transformed right-hand side U b",
+      "decidableSolvableOfSmith: a Decidable instance for ∃ x, A *ᵥ x = b given a Smith normal form of A — every step downstream of the SNF is effective",
+      "Worked sanity check: the identity matrix is its own Smith normal form, so every system x = b is solvable (witness x = b)"
+    ],
+    "assumptions": "None at the axiom level: the file is fully machine-checked with 0 axioms and 0 sorries; #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no native_decide). SCOPE: the results are stated for SQUARE systems (A : Matrix (Fin n) (Fin n) ℤ) and take a Smith normal form U A V = diagonal d (with U, V ∈ GLₙ(ℤ), supplied as explicit two-sided-inverse hypotheses) as GIVEN DATA. They are theorems about that data, not an unconditional decision procedure: producing the Smith normal form of an arbitrary integer matrix — the unimodular U, V and the diagonal D = U A V — is a Matrix-level algorithm Mathlib does not yet expose, and is the one remaining input. The rectangular m ≠ n case is the natural further generalization.",
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Hilbert's Tenth Problem is undecidable in general (MRDP, 1970), but its degree-1 edge is classically decidable. The grandparent file Hilbert10OQ04OQ03 decided a single linear Diophantine equation Σ aᵢxᵢ = b over ℤ by one gcd test; its child Hilbert10OQ04OQ03OQ02 reduced a whole system A x = b to membership of b in the ℤ-span of the columns of A, and flagged the decision step — converting that membership into invariant-factor divisibility via the Smith normal form U A V = D — as still open. The classical algorithm is textbook: over the PID ℤ every matrix admits unimodular U, V with U A V = D diagonal, and A x = b is solvable iff each invariant factor dᵢ divides the corresponding entry of U b. This entry formalizes exactly that criterion and the resulting Decidable instance for square systems, taking the Smith normal form as given data and isolating its construction as the sole remaining gap.",
+    "problemStatement": "Given a Smith normal form U A V = diagonal d of a square integer matrix A (U, V invertible over ℤ), decide solvability of A x = b over ℤ, and prove the decision is exactly the invariant-factor divisibility test ∀ i, d i ∣ (U *ᵥ b) i.",
+    "proofStrategy": "Three steps. (1) Diagonal case: diagonal d *ᵥ x = c decouples coordinate-wise into d i * xᵢ = c i (Matrix.mulVec_diagonal), whose ℤ-solvability is d i ∣ c i; the backward direction picks witnesses from the divisibility data (Classical choice over Fin n). (2) Unimodular reduction: with U A V = diagonal d and two-sided inverses Ui, Vi, the maps x ↦ Vi *ᵥ x and y ↦ V *ᵥ y are mutually inverse bijections between solutions of A x = b and of diagonal d *ᵥ y = U *ᵥ b; the computation is pure mulVec associativity (Matrix.mulVec_mulVec, Matrix.one_mulVec): forward sends x to Vi x using V (Vi x) = x, backward sends y to V y using A V = Ui (diagonal d) and Ui U b = b. (3) Compose: chaining the reduction with the diagonal case gives ∃ x, A *ᵥ x = b ↔ ∀ i, d i ∣ (U *ᵥ b) i, a Fintype-decidable predicate, hence a Decidable instance via decidable_of_iff.",
+    "keyInsights": [
+      "Invariant-factor divisibility lives entirely in the diagonal case: diagonal d *ᵥ x = c is solvable iff ∀ i, d i ∣ c i, because the system decouples into independent scalar equations d i * xᵢ = c i. Everything hard about deciding systems is pushed into producing the diagonal form.",
+      "The unimodular change of basis is bookkeeping, not mathematics: with U A V = D and two-sided inverses, x ↦ Vi *ᵥ x and y ↦ V *ᵥ y transport solutions both ways using only associativity of matrix–vector multiplication and the identity 1 *ᵥ v = v.",
+      "Decidability of system solvability reduces cleanly to n divisibility tests on the single transformed vector U b — once a Smith normal form is in hand, no search over x is needed.",
+      "The honest residue: these are theorems about a GIVEN Smith normal form. The remaining open work is the construction U, V, D = U A V at the Matrix level — Mathlib has the submodule-level SNF (Module.Basis.SmithNormalForm) but not yet the matrix algorithm — and the rectangular generalization."
+    ],
+    "text": "A square linear Diophantine system A x = b over ℤ, once put in Smith normal form U A V = diagonal d, is solvable exactly when each invariant factor dᵢ divides the matching coordinate of U b. This entry formalizes that criterion in three verified steps — the diagonal case where divisibility enters, a unimodular reduction proved from pure matrix–vector associativity, and their composition — and packages the result as a Decidable instance. The only ingredient left unformalized is the construction of the Smith normal form itself."
+  },
+  "sections": [
+    {
+      "id": "header-snf",
+      "title": "Completing the System Decision Procedure",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring: the parent reduced systems to column-lattice membership and left the decision step open; this file supplies it for square systems by turning a given Smith normal form U A V = diagonal d into an invariant-factor divisibility test, isolating the SNF construction as the sole remaining gap.",
+      "mathContext": "Over the PID $\\mathbb{Z}$, $U A V = D$ diagonal makes $A x = b$ solvable iff each invariant factor $d_i$ divides the $i$-th entry of $U b$. This entry formalizes that criterion and the resulting decidability, taking the unimodular $U, V$ as given data."
+    },
+    {
+      "id": "diagonal-case",
+      "title": "The Diagonal Case: Invariant-Factor Divisibility",
+      "startLine": 54,
+      "endLine": 71,
+      "summary": "diagonal_mulVec_solvable_iff: ∃ x, diagonal d *ᵥ x = c ↔ ∀ i, d i ∣ c i. The system decouples into scalar equations d i * xᵢ = c i; the backward direction selects witnesses from the divisibility data.",
+      "mathContext": "By Matrix.mulVec_diagonal, $(\\mathrm{diagonal}\\,d \\,*_v\\, x)_i = d_i x_i$, so the system is $d_i x_i = c_i$ for each $i$, solvable over $\\mathbb{Z}$ iff $d_i \\mid c_i$. This is where invariant-factor divisibility enters the decision procedure."
+    },
+    {
+      "id": "unimodular-reduction",
+      "title": "The Unimodular Reduction",
+      "startLine": 73,
+      "endLine": 108,
+      "summary": "solvable_iff_solvable_diagonal: if U A V = diagonal d with U, V invertible over ℤ, then ∃ x, A *ᵥ x = b ↔ ∃ y, diagonal d *ᵥ y = U *ᵥ b. The bijections x ↦ Vi *ᵥ x and y ↦ V *ᵥ y transport solutions, proved from mulVec associativity.",
+      "mathContext": "With $U A V = D$ and two-sided inverses, $y = V^{-1} x$ gives $D y = U A V (V^{-1} x) = U(A x) = U b$, and conversely $x = V y$ gives $A x = (A V) y = U^{-1} D y = U^{-1}(U b) = b$. Only Matrix.mulVec_mulVec and Matrix.one_mulVec are used."
+    },
+    {
+      "id": "criterion-and-decidability",
+      "title": "The Divisibility Criterion and Decidability",
+      "startLine": 110,
+      "endLine": 137,
+      "summary": "solvable_iff_invariantFactor_dvd composes the reduction with the diagonal case to give ∃ x, A *ᵥ x = b ↔ ∀ i, d i ∣ (U *ᵥ b) i; decidableSolvableOfSmith turns this Fintype-decidable predicate into a Decidable instance.",
+      "mathContext": "Chaining the two equivalences yields a criterion decided by $n$ divisibility tests on $U b$. Since $\\forall i,\\, d_i \\mid (U b)_i$ is Fintype-decidable, decidable_of_iff produces a Decidable instance for system solvability."
+    },
+    {
+      "id": "sanity-check",
+      "title": "Sanity Check: the Identity System",
+      "startLine": 138,
+      "endLine": 149,
+      "summary": "Worked example: the identity matrix is its own Smith normal form (U = V = 1, d = 1), so 1 ∣ b i always holds and every system x = b is solvable — with witness x = b.",
+      "mathContext": "For $A = 1$ take $U = V = 1$, $d = 1$: the criterion $\\forall i,\\, 1 \\mid b_i$ is vacuously true, matching the obvious solution $x = b$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "oq-01",
+      "question": "Construct the Smith normal form of an integer matrix at the Matrix level — unimodular U, V and diagonal D with U A V = D — to discharge the hypotheses of decidableSolvableOfSmith and obtain an UNCONDITIONAL Decidable instance for ∃ x, A x = b.",
+      "status": "open",
+      "notes": "Mathlib provides the submodule-level Module.Basis.SmithNormalForm but not a matrix algorithm returning U, V, D = U A V. Bridging the two is the sole remaining input these results consume."
+    },
+    {
+      "id": "oq-02",
+      "question": "Generalize from square to rectangular systems A : Matrix (Fin m) (Fin n) ℤ, where D = U A V is rectangular-diagonal and surplus zero rows force the corresponding entries of U b to vanish.",
+      "status": "open",
+      "notes": "The diagonal case and the reduction both extend, but the rectangular-diagonal bookkeeping (min(m,n) invariant factors plus zero-row consistency conditions) needs care."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "hilbert-10-oq-04-oq-03-oq-02",
+      "relationship": "parent",
+      "description": "Reduced linear-system solvability A x = b to column-lattice membership b ∈ span ℤ (range A.col) and left the decision step — invariant-factor divisibility via the Smith normal form U A V = D — open. This entry supplies that step for square systems, taking the Smith normal form as given data."
+    },
+    {
+      "targetId": "hilbert-10-oq-04-oq-03",
+      "relationship": "grandparent",
+      "description": "Decided a single linear Diophantine equation Σ aᵢxᵢ = b over ℤ via a gcd-divisibility test and packaged it as a Decidable instance. This entry is the systems analogue: the diagonal-case criterion plays the role the gcd test played for one equation."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry completes the decision procedure for square linear Diophantine systems A x = b over ℤ, modulo construction of a Smith normal form. It proves the diagonal-case criterion ∃ x, diagonal d *ᵥ x = c ↔ ∀ i, d i ∣ c i, the unimodular reduction that U A V = diagonal d transports solvability to the diagonalised system diagonal d *ᵥ y = U *ᵥ b, their composition ∃ x, A *ᵥ x = b ↔ ∀ i, d i ∣ (U *ᵥ b) i, and the resulting Decidable instance. The development is axiom-free and sorry-free; the reduction proofs use only associativity of matrix–vector multiplication.",
+    "implications": "The result pins the remaining work on deciding linear Diophantine systems to a single, well-isolated task: produce the Smith normal form U, V, D = U A V of an integer matrix at the Matrix level. Everything downstream — the divisibility criterion and its decidability — is now verified. Combined with the parent's column-lattice reduction, the gallery now has the full chain from system solvability to an effective test, lacking only the SNF construction that Mathlib has at the submodule level but not yet as a matrix algorithm.",
+    "openQuestions": [
+      "Construct the matrix-level Smith normal form to make decidableSolvableOfSmith unconditional.",
+      "Extend the criterion and Decidable instance to rectangular systems with zero-row consistency conditions."
+    ]
+  },
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/Hilbert10OQ04OQ03OQ02OQ01.lean",
+    "lineCount": 149,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "axiomCount": 0,
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question `oq-01` of `Hilbert10OQ04OQ03OQ02`: turn that entry's reduction of linear-system solvability to **column-lattice membership** into an effective **invariant-factor divisibility** test, and package it as a `Decidable` instance — for **square** integer systems `A x = b`, taking a **Smith normal form** `U A V = diagonal d` (`U, V ∈ GLₙ(ℤ)`) as given data.

## New file: `proofs/Proofs/Hilbert10OQ04OQ03OQ02OQ01.lean`

| Result | Statement |
|---|---|
| `diagonal_mulVec_solvable_iff` | `(∃ x, diagonal d *ᵥ x = c) ↔ ∀ i, d i ∣ c i` — the diagonal case where invariant-factor divisibility enters |
| `solvable_iff_solvable_diagonal` | `U A V = diagonal d` ⟹ `(∃ x, A *ᵥ x = b) ↔ (∃ y, diagonal d *ᵥ y = U *ᵥ b)` |
| `solvable_iff_invariantFactor_dvd` | `(∃ x, A *ᵥ x = b) ↔ ∀ i, d i ∣ (U *ᵥ b) i` |
| `decidableSolvableOfSmith` | `Decidable (∃ x, A *ᵥ x = b)` given a Smith normal form |

The reduction's two directions are mutually inverse linear bijections (`x ↦ Vi *ᵥ x`, `y ↦ V *ᵥ y`) proved from **pure matrix–vector associativity** (`Matrix.mulVec_mulVec`, `Matrix.one_mulVec`) — no determinant/GLₙ machinery.

## Scope / honesty

- **Verified, axiom-free**: 0 sorries, 0 `axiom`; `#print axioms` on all three theorems = `[propext, Classical.choice, Quot.sound]` (no `Lean.ofReduceBool`, no `native_decide`).
- Results are **conditional on a given Smith normal form**: producing the matrix-level unimodular `U, V` with `U A V = D` is the one remaining input — Mathlib has SNF only at the submodule level (`Module.Basis.SmithNormalForm`), not as a matrix algorithm. Stated for **square** systems; rectangular is the natural generalization. Both are recorded as the new entry's open questions.

## Verification

```
lake env lean Proofs/Hilbert10OQ04OQ03OQ02OQ01.lean   # clean, no warnings/errors
#print axioms diagonal_mulVec_solvable_iff      → [propext, Classical.choice, Quot.sound]
#print axioms solvable_iff_solvable_diagonal    → [propext, Classical.choice, Quot.sound]
#print axioms solvable_iff_invariantFactor_dvd  → [propext, Classical.choice, Quot.sound]
```

Builds on the column-span bridge of #26937 (`hilbert-10-oq-04-oq-03-oq-02`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)