### PR TITLE
research(geometric-series-oq-07): second moment ∑ n² rⁿ = r(1+r)/(1-r)³

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ07.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07.lean
@@ -1,0 +1,140 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Data.Nat.Choose.Cast
+import Mathlib.Tactic
+
+/-
+# Second Moment of the Geometric Series: ∑ n² rⁿ = r(1+r)/(1-r)³
+
+## What This Proves
+
+For a real ratio `r` with `‖r‖ < 1`,
+
+  ∑_{n=0}^{∞} n² · rⁿ  =  r(1+r) / (1-r)³.
+
+This is the **second moment** of the geometric series, completing the family of
+low-order moments:
+
+  ∑ rⁿ        = 1/(1-r)          (zeroth moment, the geometric series itself)
+  ∑ n · rⁿ    = r/(1-r)²         (first moment)
+  ∑ n² · rⁿ   = r(1+r)/(1-r)³    (second moment — the new result here)
+
+## Why This Is Not Already in Mathlib
+
+Mathlib provides the zeroth and first moments directly
+(`tsum_geometric_of_norm_lt_one`, `tsum_coe_mul_geometric_of_norm_lt_one`),
+but has no closed form for `∑ n² rⁿ`.  What it *does* provide is the family of
+**rising-binomial** sums
+
+  ∑_n (n+k choose k) · rⁿ = 1/(1-r)^{k+1}     (`hasSum_choose_mul_geometric_of_norm_lt_one`).
+
+The contribution of this file is to assemble the second moment from the `k = 2`
+member of that family together with the first moment and the bare geometric
+series, using the polynomial identity
+
+  n²  =  2·(n+2 choose 2)  −  3n  −  2,
+
+which holds because `(n+2 choose 2) = (n+1)(n+2)/2`, so
+`2·(n+2 choose 2) = n² + 3n + 2`.
+
+## Proof Strategy
+
+1. Take three `HasSum` facts from Mathlib:
+   - `h₂ : ∑ (n+2 choose 2) rⁿ = 1/(1-r)³`
+   - `h₁ : ∑ n rⁿ            = r/(1-r)²`
+   - `h₀ : ∑ rⁿ              = (1-r)⁻¹`
+2. Form the linear combination `2·h₂ − 3·h₁ − 2·h₀`, whose summand is
+   `2(n+2 choose 2)rⁿ − 3n rⁿ − 2 rⁿ = n² rⁿ` by the identity above.
+3. Simplify the resulting value `2/(1-r)³ − 3r/(1-r)² − 2/(1-r)` to `r(1+r)/(1-r)³`
+   with `field_simp; ring` (valid since `1 - r ≠ 0`).
+
+## Probabilistic Interpretation
+
+If `X` is geometric with `P(X = n) = (1-r) rⁿ` (`n ≥ 0`, `0 ≤ r < 1`), then these
+moments give `E[X] = r/(1-r)` and `E[X²] = r(1+r)/(1-r)²`, hence
+`Var(X) = E[X²] − E[X]² = r/(1-r)²`.
+
+## Status: 0 sorries, 0 axioms
+-/
+
+open Filter Topology
+
+namespace GeometricSeriesOQ07
+
+variable {r : ℝ}
+
+/-! ## The polynomial identity behind the second moment -/
+
+/-- The algebraic key: `n² = 2·(n+2 choose 2) − 3n − 2`, cast to `ℝ`.
+
+Since `(n+2 choose 2) = (n+1)(n+2)/2`, we have `2·(n+2 choose 2) = n² + 3n + 2`,
+so subtracting `3n + 2` recovers `n²`. -/
+lemma two_choose_two_sub (n : ℕ) :
+    (2 : ℝ) * ((n + 2).choose 2) - 3 * n - 2 = (n : ℝ) ^ 2 := by
+  rw [Nat.cast_choose_two]
+  push_cast
+  ring
+
+/-! ## The moment family -/
+
+/-- **Zeroth moment** (the geometric series itself): `∑ rⁿ = 1/(1-r)`. -/
+theorem tsum_geometric (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, r ^ n = (1 - r)⁻¹ :=
+  tsum_geometric_of_norm_lt_one hr
+
+/-- **First moment**: `∑ n · rⁿ = r/(1-r)²` (restatement of Mathlib's result,
+included to display the full moment family). -/
+theorem tsum_mul_geometric (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, (n : ℝ) * r ^ n = r / (1 - r) ^ 2 :=
+  tsum_coe_mul_geometric_of_norm_lt_one hr
+
+/-! ## Second moment (the new result) -/
+
+/-- `1 - r ≠ 0` whenever `‖r‖ < 1` (so `r ≠ 1`). -/
+lemma one_sub_ne_zero (hr : ‖r‖ < 1) : (1 : ℝ) - r ≠ 0 :=
+  sub_ne_zero.mpr fun h => by simp [← h] at hr
+
+/-- **Second moment, `HasSum` form**: `∑ n² · rⁿ = r(1+r)/(1-r)³`. -/
+theorem hasSum_sq_mul_geometric (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ => (n : ℝ) ^ 2 * r ^ n) (r * (1 + r) / (1 - r) ^ 3) := by
+  have hr1 : (1 : ℝ) - r ≠ 0 := one_sub_ne_zero hr
+  -- Three Mathlib summation facts.
+  have h₂ : HasSum (fun n : ℕ => ((n + 2).choose 2 : ℝ) * r ^ n) (1 / (1 - r) ^ (2 + 1)) :=
+    hasSum_choose_mul_geometric_of_norm_lt_one 2 hr
+  have h₁ : HasSum (fun n : ℕ => (n : ℝ) * r ^ n) (r / (1 - r) ^ 2) :=
+    hasSum_coe_mul_geometric_of_norm_lt_one hr
+  have h₀ : HasSum (fun n : ℕ => r ^ n) ((1 - r)⁻¹) :=
+    hasSum_geometric_of_norm_lt_one hr
+  -- Linear combination 2·h₂ − 3·h₁ − 2·h₀.
+  have hcomb := ((h₂.mul_left 2).sub (h₁.mul_left 3)).sub (h₀.mul_left 2)
+  -- Rewrite the summand as n² rⁿ via the polynomial identity.
+  have hfun : (fun n : ℕ => (n : ℝ) ^ 2 * r ^ n)
+      = fun n : ℕ =>
+          2 * (((n + 2).choose 2 : ℝ) * r ^ n) - 3 * ((n : ℝ) * r ^ n) - 2 * r ^ n := by
+    funext n
+    rw [← two_choose_two_sub n]
+    ring
+  rw [hfun]
+  -- Functions now match; only the value needs simplification.
+  convert hcomb using 1
+  field_simp
+  ring
+
+/-- **Second moment, `tsum` form**: `∑ n² · rⁿ = r(1+r)/(1-r)³`. -/
+theorem tsum_sq_mul_geometric (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, (n : ℝ) ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3 :=
+  (hasSum_sq_mul_geometric hr).tsum_eq
+
+/-- The second-moment series is summable. -/
+theorem summable_sq_mul_geometric (hr : ‖r‖ < 1) :
+    Summable (fun n : ℕ => (n : ℝ) ^ 2 * r ^ n) :=
+  (hasSum_sq_mul_geometric hr).summable
+
+/-! ## A concrete value -/
+
+/-- Sanity check at `r = 1/2`: `∑ n²/2ⁿ = 6`.
+(`r(1+r)/(1-r)³ = (1/2)(3/2)/(1/2)³ = (3/4)/(1/8) = 6`.) -/
+example : ∑' n : ℕ, (n : ℝ) ^ 2 * (1 / 2 : ℝ) ^ n = 6 := by
+  rw [tsum_sq_mul_geometric (by norm_num : ‖(1 / 2 : ℝ)‖ < 1)]
+  norm_num
+
+end GeometricSeriesOQ07

--- a/src/data/proofs/geometric-series-oq-07/meta.json
+++ b/src/data/proofs/geometric-series-oq-07/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "geometric-series-oq-07",
+  "slug": "geometric-series-oq-07",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Data.Nat.Choose.Cast",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "GeometricSeriesOQ07",
+    "lineCount": 140,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ07.lean",
+    "sorries": 0
+  },
+  "title": "The Second Moment of the Geometric Series: ∑ n² rⁿ = r(1+r)/(1-r)³",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "infinite-series",
+      "power-series",
+      "moments",
+      "summability",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 140,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "hasSum_sq_mul_geometric / tsum_sq_mul_geometric: the closed form ∑_{n≥0} n² · rⁿ = r(1+r)/(1-r)³ for ‖r‖ < 1 over ℝ — a result Mathlib does not provide (it has the zeroth and first moments but no n² sum)",
+      "two_choose_two_sub: the polynomial identity n² = 2·(n+2 choose 2) − 3n − 2 (cast to ℝ), the algebraic bridge that expresses n² in the rising-binomial basis Mathlib does sum",
+      "Assembly technique: the second moment is obtained as the linear combination 2·h₂ − 3·h₁ − 2·h₀ of three Mathlib HasSum facts (the k=2 rising-binomial sum, the first moment, and the bare geometric series), with the value simplified by field_simp; ring",
+      "summable_sq_mul_geometric: summability of n² rⁿ for ‖r‖ < 1, and a concrete evaluation ∑ n²/2ⁿ = 6"
+    ],
+    "prerequisites": [
+      "Mathlib's rising-binomial geometric sums hasSum_choose_mul_geometric_of_norm_lt_one (∑ (n+k choose k) rⁿ = 1/(1-r)^{k+1})",
+      "Mathlib's first moment hasSum_coe_mul_geometric_of_norm_lt_one (∑ n rⁿ = r/(1-r)²)",
+      "Mathlib's geometric series hasSum_geometric_of_norm_lt_one (∑ rⁿ = (1-r)⁻¹)",
+      "Nat.cast_choose_two: ((a choose 2 : ℝ) = a(a-1)/2)",
+      "HasSum arithmetic (HasSum.mul_left, HasSum.sub, HasSum.tsum_eq)",
+      "Parent: geometric-series (∑ rⁿ = 1/(1-r))"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_choose_mul_geometric_of_norm_lt_one",
+        "description": "∑_n (n+k choose k) · rⁿ = 1/(1-r)^{k+1} for ‖r‖ < 1. Used at k = 2 to obtain the second-order rising-binomial sum 1/(1-r)³.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "hasSum_coe_mul_geometric_of_norm_lt_one",
+        "description": "∑_n n · rⁿ = r/(1-r)² for ‖r‖ < 1 (the first moment), used as the −3·h₁ term of the combination.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "hasSum_geometric_of_norm_lt_one",
+        "description": "∑_n rⁿ = (1-r)⁻¹ for ‖r‖ < 1 (the geometric series), used as the −2·h₀ term.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Nat.cast_choose_two",
+        "description": "((a choose 2 : ℝ) = a·(a-1)/2). Provides the cast needed to prove n² = 2·(n+2 choose 2) − 3n − 2 over ℝ.",
+        "module": "Mathlib.Data.Nat.Choose.Cast"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01",
+      "question": "Generalize the moment computation to arbitrary order: prove ∑_n n^k · rⁿ = (a polynomial in r of degree k with Eulerian-number coefficients) / (1-r)^{k+1}, recovering k=0,1,2 as special cases, by expressing n^k in the rising-binomial basis {(n+j choose j)}.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-02",
+      "question": "State the probabilistic corollary: for X geometric with P(X=n) = (1-r)rⁿ, derive E[X] = r/(1-r), E[X²] = r(1+r)/(1-r)², and Var(X) = r/(1-r)² directly from the moment closed forms.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series",
+      "relationship": "extends",
+      "description": "Parent. The base entry proves ∑ rⁿ = 1/(1-r) (the zeroth moment). This entry adds the second moment ∑ n² rⁿ = r(1+r)/(1-r)³, assembling it from the geometric series together with Mathlib's first-moment and rising-binomial sums."
+    },
+    {
+      "targetId": "geometric-series-oq-03",
+      "relationship": "sibling",
+      "description": "A sibling extension of the geometric series: oq-03 builds the Euler product ζ(s) = ∏_p ∑_k (p^{-s})^k from the geometric series, while this entry builds the weighted moment sums ∑ nᵏ rⁿ."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the geometric, first-moment, and rising-binomial geometric sums (hasSum_geometric_of_norm_lt_one, hasSum_coe_mul_geometric_of_norm_lt_one, hasSum_choose_mul_geometric_of_norm_lt_one)."
+    },
+    {
+      "title": "Concrete Mathematics (geometric series and its derivatives)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the weighted geometric sums ∑ n rⁿ and ∑ n² rⁿ obtained by differentiating ∑ rⁿ = 1/(1-r)."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For ‖r‖ < 1 over ℝ, the second moment of the geometric series is ∑_{n≥0} n² · rⁿ = r(1+r)/(1-r)³. This completes the low-order moment family: ∑ rⁿ = 1/(1-r), ∑ n rⁿ = r/(1-r)², ∑ n² rⁿ = r(1+r)/(1-r)³. The proof assembles the second moment as the linear combination 2·h₂ − 3·h₁ − 2·h₀ of three Mathlib HasSum facts — the k=2 rising-binomial sum ∑ (n+2 choose 2) rⁿ = 1/(1-r)³, the first moment, and the geometric series — using the polynomial identity n² = 2·(n+2 choose 2) − 3n − 2. The file provides HasSum, tsum, and summability forms plus a concrete check ∑ n²/2ⁿ = 6. 140 lines, 7 theorems/lemmas, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Mathlib provides the zeroth and first geometric moments but no closed form for ∑ n² rⁿ, so this fills a real gap. The difficulty is routine — the work is the elementary observation that n² lies in the span of the rising-binomial functions {1, n, (n+2 choose 2)} that Mathlib already sums, which makes the moment computable by a finite linear combination rather than by re-deriving convergence. The same template (express nᵏ in the rising-binomial basis, take a linear combination) yields every higher moment, as recorded in the open questions.",
+    "openQuestions": [
+      "Generalize to ∑ n^k rⁿ for arbitrary k via the rising-binomial basis (Eulerian-number numerators over (1-r)^{k+1}).",
+      "Derive the geometric-distribution variance Var(X) = r/(1-r)² as a probabilistic corollary."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes the **second moment of the geometric series** over ℝ:

$$\sum_{n=0}^{\infty} n^2 r^n = \frac{r(1+r)}{(1-r)^3} \qquad (\lVert r \rVert < 1)$$

completing the low-order moment family:

| order | sum | value |
|-------|-----|-------|
| 0 | ∑ rⁿ | 1/(1−r) |
| 1 | ∑ n rⁿ | r/(1−r)² |
| 2 | ∑ n² rⁿ | **r(1+r)/(1−r)³** (new) |

## Why it's not a one-liner

Mathlib provides the zeroth and first moments directly, but **no closed form for ∑ n² rⁿ**. What it does provide is the rising-binomial family `hasSum_choose_mul_geometric_of_norm_lt_one`: ∑ (n+k choose k) rⁿ = 1/(1−r)^{k+1}.

The contribution is to assemble the second moment from the k=2 member of that family, the first moment, and the bare geometric series, using the polynomial identity

$$n^2 = 2\binom{n+2}{2} - 3n - 2.$$

Concretely, the result is the linear combination `2·h₂ − 3·h₁ − 2·h₀` of three Mathlib `HasSum` facts, with the value simplified by `field_simp; ring`.

## Contents

- `hasSum_sq_mul_geometric` / `tsum_sq_mul_geometric` — the closed form (HasSum + tsum)
- `summable_sq_mul_geometric` — summability
- `two_choose_two_sub` — the polynomial identity bridge
- `tsum_geometric`, `tsum_mul_geometric` — the zeroth/first moments (for the full family)
- concrete check: ∑ n²/2ⁿ = 6

## Verification

- **0 sorries, 0 axioms** — `#print axioms` reports only `propext, Classical.choice, Quot.sound`
- Compiles clean against pinned Mathlib (single-file `lake env lean`, exit 0)

Answers open question **oq-07** of the geometric-series entry. Gallery data in `src/data/proofs/geometric-series-oq-07/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)