### PR TITLE
fix(abundant-number-oq-03): broken build — Odd.mul dot notation resolved to Exists.mul

### DIFF
--- a/proofs/Proofs/AbundantOddInfiniteOQ03.lean
+++ b/proofs/Proofs/AbundantOddInfiniteOQ03.lean
@@ -39,7 +39,7 @@ product of the odd number `945` with the odd number `2k+1`) and abundant (a
 positive multiple of the abundant number `945`). -/
 theorem odd_abundant_945_mul (k : ℕ) :
     Odd (945 * (2 * k + 1)) ∧ (945 * (2 * k + 1)).Abundant := by
-  refine ⟨(⟨472, by norm_num⟩ : Odd 945).mul (odd_two_mul_add_one k), ?_⟩
+  refine ⟨Odd.mul (⟨472, by norm_num⟩ : Odd 945) (odd_two_mul_add_one k), ?_⟩
   exact abundant_mul_right abundant_945 (by positivity)
 
 /-- The map `k ↦ 945·(2k+1)` is injective: multiplication by the nonzero


### PR DESCRIPTION
## Auditor finding

`abundant-number-oq-03` (`Proofs/AbundantOddInfiniteOQ03.lean`) was marked **`status: verified` / `badge: verified` / `axiomCount: 0`** in gallery meta.json, but **did not compile** against the pinned Mathlib.

### Root cause
Line 42:
```lean
refine ⟨(⟨472, by norm_num⟩ : Odd 945).mul (odd_two_mul_add_one k), ?_⟩
```
`Odd n` is definitionally `∃ m, n = 2*m + 1`, so dot notation `.mul` on an `Odd` term resolves against the `Exists` namespace:
```
error: Invalid field `mul`: The environment does not contain `Exists.mul`
```
Elaboration failed, and `#print axioms infinitely_many_odd_abundant` reported **`sorryAx`** — contradicting the "verified, 0 axioms" claim.

### Fix
Call `Odd.mul` explicitly (`Odd a → Odd b → Odd (a * b)`):
```lean
refine ⟨Odd.mul (⟨472, by norm_num⟩ : Odd 945) (odd_two_mul_add_one k), ?_⟩
```

### Verification
After the fix, the file compiles cleanly and the in-file `#print axioms` reports:
```
'AbundantOddInfiniteOQ03.infinitely_many_odd_abundant' depends on axioms: [propext, Classical.choice, Quot.sound]
```
No `sorryAx`, no `Lean.ofReduceBool`. The entry is now genuinely `verified` / 0-axiom, matching meta.json. No meta changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)