### PR TITLE
research(elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02-oq-01): lift Gauss-sum QR to ℤ + repair build break

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01.lean
@@ -71,28 +71,12 @@ theorem quadCharC_isQuadratic : (quadCharC p).IsQuadratic :=
 
 /-- For odd prime p, the quadratic character is nontrivial. -/
 theorem quadCharC_ne_one (hodd : p ≠ 2) : quadCharC p ≠ 1 := by
-  have hqc_ne : quadraticChar (ZMod p) ≠ 1 :=
-    quadraticChar_ne_one (ringChar_ne_two p hodd)
-  intro heq
-  apply hqc_ne
-  ext a
-  -- MulChar.one_apply : (1:MulChar R M) a = if IsUnit a then 1 else 0
-  have ha : (Int.cast (quadraticChar (ZMod p) a) : ℂ) = (1 : MulChar (ZMod p) ℂ) a := by
-    show quadCharC p a = _; rw [heq]
-  rw [MulChar.one_apply] at ha  -- ha: Int.cast(quadraticChar a) = if IsUnit a then 1 else 0
-  rw [MulChar.one_apply]        -- goal: quadraticChar a = if IsUnit a then 1 else 0
-  rcases quadraticChar_isQuadratic (ZMod p) a with hv | hv | hv
-  · rw [hv] at ha; norm_cast at ha  -- ha: (0:ℂ) = if IsUnit a then 1 else 0
-    split_ifs at ha ⊢ with hu
-    · exact absurd ha one_ne_zero.symm   -- IsUnit: ha:(0:ℂ)=1 → False
-    · exact hv                           -- ¬IsUnit: goal quadraticChar a = 0, hv: = 0
-  · rw [hv] at ha; norm_cast at ha  -- ha: (1:ℂ) = if IsUnit a then 1 else 0
-    split_ifs at ha ⊢ with hu
-    · exact hv                           -- IsUnit: goal quadraticChar a = 1, hv: = 1
-    · exact absurd ha one_ne_zero  -- ha : 1=0, one_ne_zero : 1≠0
-  · rw [hv] at ha; push_cast at ha  -- ha: (-1:ℂ) = if IsUnit a then 1 else 0
-    exfalso
-    split_ifs at ha with hu <;> norm_num at ha
+  -- `ringHomComp` by an injective ring hom preserves nontriviality (Mathlib
+  -- `MulChar.ringHomComp_ne_one_iff`); `Int.castRingHom ℂ` is injective since ℂ
+  -- has characteristic zero.
+  rw [quadCharC,
+    MulChar.ringHomComp_ne_one_iff (RingHom.injective_int (Int.castRingHom ℂ))]
+  exact quadraticChar_ne_one (ringChar_ne_two p hodd)
 
 -- ============================================================================
 -- The Classical Gauss Sum
@@ -124,7 +108,7 @@ theorem gauss_sum_squared (hodd : p ≠ 2) :
     classicalGaussSum p ^ 2 = (-1 : ℂ) ^ (p / 2) * (p : ℂ) := by
   unfold classicalGaussSum
   haveI : NeZero p := ⟨Nat.pos_iff_ne_zero.mp hp.out.pos⟩
-  have hψ : (ZMod.stdAddChar (N := p)).IsPrimitive := ZMod.isPrimitive_stdAddChar
+  have hψ : (ZMod.stdAddChar (N := p)).IsPrimitive := ZMod.isPrimitive_stdAddChar p
   have hχ_ne : quadCharC p ≠ 1 := quadCharC_ne_one p hodd
   have hχ_q : (quadCharC p).IsQuadratic := quadCharC_isQuadratic p
   rw [gaussSum_sq hχ_ne hχ_q hψ]
@@ -203,6 +187,8 @@ example : ∃ τ : ℂ, τ ^ 2 = (-1 : ℂ) ^ (7 / 2) * (7 : ℂ) :=
 /-- p = 13 (≡ 1 mod 4): τ² = 13. -/
 example : ∃ τ : ℂ, τ ^ 2 = (-1 : ℂ) ^ (13 / 2) * (13 : ℂ) :=
   gauss_sum_squared_exists 13 (by norm_num)
+
+end
 
 end GaussSumSquaredQR
 

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean
@@ -56,43 +56,30 @@ theorem legendreCharQ_isQuadratic : (legendreCharQ (p := p) (q := q)).IsQuadrati
 /-- legendreCharQ is nontrivial for odd primes p and q. -/
 theorem legendreCharQ_ne_one (hp2 : p ≠ 2) (hq2 : q ≠ 2) :
     legendreCharQ (p := p) (q := q) ≠ 1 := by
+  -- Mathlib drift: `MulChar.ext` now quantifies over units, so it suffices to
+  -- evaluate on a unit `a : (ZMod p)ˣ`, where `(1 : MulChar ..) ↑a = 1`
+  -- (`MulChar.one_apply_coe`). The Int.cast ℤ → ZMod q is injective on the
+  -- value set {0, 1, -1} of the quadratic character because `q` is an odd prime.
   have hqc_ne : quadraticChar (ZMod p) ≠ 1 := quadraticChar_ne_one (ringChar_ne_two hp2)
   intro heq
   apply hqc_ne
   ext a
-  -- ha with Int.cast explicitly for syntactic rewrites after MulChar.one_apply
-  have ha : (Int.cast (quadraticChar (ZMod p) a) : ZMod q) = (1 : MulChar (ZMod p) (ZMod q)) a := by
-    have h : legendreCharQ (p := p) (q := q) a = (1 : MulChar (ZMod p) (ZMod q)) a := by rw [heq]
-    simp only [legendreCharQ, MulChar.ringHomComp_apply] at h; exact h
-  rw [MulChar.one_apply] at ha  -- ha : Int.cast(quadraticChar a) = if IsUnit a then 1 else 0
-  rw [MulChar.one_apply]        -- goal : quadraticChar a = if IsUnit a then 1 else 0
-  rcases quadraticChar_isQuadratic (ZMod p) a with hv | hv | hv
-  · rw [hv] at ha; norm_cast at ha  -- ha : (0 : ZMod q) = if IsUnit a then 1 else 0
-    split_ifs at ha ⊢ with hu
-    · exact absurd ha one_ne_zero.symm
-    · exact hv
-  · rw [hv] at ha; norm_cast at ha
-    split_ifs at ha ⊢ with hu
-    · exact hv
-    · exact absurd ha one_ne_zero  -- ha : 1=0, one_ne_zero : 1≠0
-  · rw [hv] at ha; push_cast at ha  -- ha : (-1 : ZMod q) = if IsUnit a then 1 else 0
-    exfalso
-    split_ifs at ha with hu
-    · -- ha : (-1 : ZMod q) = 1, contradiction with q ≠ 2
-      have h2 : (2 : ZMod q) = 0 := by
-        calc (2 : ZMod q) = 1 + 1 := by norm_num
-          _ = -1 + 1 := by rw [ha]
-          _ = 0 := by ring
-      rw [show (2 : ZMod q) = ((2 : ℕ) : ZMod q) from by norm_cast] at h2
-      rw [ZMod.natCast_eq_zero_iff_dvd] at h2
-      have hq_le : q ≤ 2 := Nat.le_of_dvd (by norm_num) h2
-      omega
-    · -- ha : (-1 : ZMod q) = 0, contradiction
-      have h1 : (1 : ZMod q) = 0 := by
-        calc (1 : ZMod q) = -(-1 : ZMod q) := by ring
-          _ = -(0 : ZMod q) := by rw [ha]
-          _ = 0 := neg_zero
-      exact one_ne_zero h1
+  rw [MulChar.one_apply_coe]
+  -- From `heq`, the cast of `quadraticChar (ZMod p) ↑a` to ZMod q equals 1.
+  have hval : ((quadraticChar (ZMod p) (a : ZMod p) : ℤ) : ZMod q) = 1 := by
+    have h : legendreCharQ (p := p) (q := q) (a : ZMod p)
+        = (1 : MulChar (ZMod p) (ZMod q)) (a : ZMod p) := by rw [heq]
+    rw [MulChar.one_apply_coe] at h
+    simpa only [legendreCharQ, MulChar.ringHomComp_apply, eq_intCast] using h
+  -- The quadratic character is nonzero on a unit, so its value is 1 or -1.
+  rcases quadraticChar_isQuadratic (ZMod p) (a : ZMod p) with hv | hv | hv
+  · exact absurd (quadraticChar_eq_zero_iff.mp hv) a.ne_zero
+  · exact hv
+  · exfalso
+    haveI : Fact (2 < q) := ⟨lt_of_le_of_ne hq.out.two_le (fun h => hq2 h.symm)⟩
+    rw [hv] at hval
+    simp only [Int.cast_neg, Int.cast_one] at hval
+    exact ZMod.neg_one_ne_one hval
 
 -- ============================================================================
 -- Part II: Evaluations of legendreCharQ
@@ -111,7 +98,8 @@ theorem legendreCharQ_neg_one (hp2 : p ≠ 2) :
       · exact absurd h' (by norm_num)
       · exact hp2 h'.symm
     omega
-  rw [χ₄_eq_neg_one_pow hodd_mod]; push_cast; ring
+  rw [χ₄_eq_neg_one_pow hodd_mod]
+  simp only [map_pow, map_neg, map_one]
 
 /-- χ(q) = legendreSym p q cast to ZMod q. -/
 theorem legendreCharQ_eval_q (hpq : p ≠ q) :
@@ -172,8 +160,9 @@ theorem gauss_sum_zmod_qr (hp2 : p ≠ 2) (hq2 : q ≠ 2) (hpq : p ≠ q) :
     Step 4 applies `Char.card_pow_card` (Mathlib) to combine them.
     The integer QR formula follows from `legendreSym.quadratic_reciprocity`. -/
 theorem gauss_sum_qr_assembled (hp2 : p ≠ 2) (hq2 : q ≠ 2) (hpq : p ≠ q) :
-    legendreSym p ↑q * legendreSym q ↑p = (-1) ^ (p / 2 * (q / 2)) :=
-  legendreSym.quadratic_reciprocity hp2 hq2 hpq
+    legendreSym p ↑q * legendreSym q ↑p = (-1) ^ (p / 2 * (q / 2)) := by
+  rw [mul_comm]
+  exact legendreSym.quadratic_reciprocity hp2 hq2 hpq
 
 -- ============================================================================
 -- Part VI: Explicit Citations of the Four Steps
@@ -223,6 +212,8 @@ example : legendreSym 7 5 * legendreSym 5 7 = (-1) ^ (7 / 2 * (5 / 2)) := by nat
 /-- p=11, q=13: (11/13)·(13/11) = 1. ✓ -/
 example : legendreSym 13 11 * legendreSym 11 13 = (-1) ^ (13 / 2 * (11 / 2)) := by
   native_decide
+
+end
 
 end GaussSumFullAssembly
 

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,142 @@
+/-
+  # Lifting the Gauss-Sum QR Identity from ZMod q to ℤ
+  # (elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02-oq-01)
+
+  ## The Open Question
+
+  **OQ-...-OQ-02-OQ-01**: The Gauss-sum pipeline natively produces a *congruence
+  in ZMod q*:
+
+      gauss_sum_zmod_qr :
+        (-1 : ZMod q) ^ (p/2 · q/2) · (q/p) = (p/q)   in ZMod q
+
+  (`GaussSumFullAssembly.gauss_sum_zmod_qr`, proved without axioms). The classical
+  statement of quadratic reciprocity, however, is an *equation of integers*:
+
+      legendreSym p q · legendreSym q p = (-1) ^ (p/2 · q/2)   in ℤ.
+
+  How do you get from the ZMod q congruence to the integer identity?
+
+  ## Answer: the four-sign lift
+
+  Both Legendre symbols are units (`p ≠ q` are primes), hence each lies in
+  `{+1, -1}`, and so does the sign `(-1)^(p/2·q/2)`. The Int.cast map `ℤ → ZMod q`
+  is *injective on `{+1, -1}`* because `q` is an odd prime: `(1 : ZMod q) ≠ -1`
+  (otherwise `q ∣ 2`). Therefore a congruence between two elements of `{+1, -1}`
+  forces an honest integer equality. Concretely:
+
+    * From `gauss_sum_zmod_qr`, `(p/q) ≡ (-1)^(p/2·q/2) · (q/p)  (mod q)`.
+    * Both sides lie in `{+1, -1}`, so equality lifts to ℤ:
+        `(p/q) = (-1)^(p/2·q/2) · (q/p)`.
+    * Multiplying by `(q/p)` and using `(q/p)² = 1` gives
+        `(p/q) · (q/p) = (-1)^(p/2·q/2)`.
+
+  This is the "case analysis on the four sign possibilities of the two Legendre
+  symbols" requested by the open question, made into a single clean lift.
+
+  ## Significance
+
+  This is the *last mile* of the Gauss-sum proof of quadratic reciprocity. The
+  Gauss-sum machinery (`OQ01OQ01OQ01`, `OQ01OQ01OQ02`, and the assembly
+  `OQ01OQ01OQ01OQ02`) lands in `ZMod q`; this file shows the elementary, purely
+  arithmetic step that converts that congruence into the integer reciprocity law,
+  *without* invoking Mathlib's black-box `legendreSym.quadratic_reciprocity`.
+
+  ## Axiom count: 0
+-/
+
+import Proofs.ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02
+import Mathlib.NumberTheory.LegendreSymbol.Basic
+import Mathlib.Tactic
+
+namespace GaussSumQRIntLift
+
+variable {p q : ℕ} [hp : Fact p.Prime] [hq : Fact q.Prime]
+
+/-- **The {+1, -1} lift.** For an odd prime `q`, the cast `ℤ → ZMod q` is injective
+    on `{+1, -1}`: two integers each equal to `±1` that are congruent mod `q` are
+    equal. (The only obstruction would be `1 ≡ -1`, i.e. `q ∣ 2`, impossible for
+    `q` odd.) -/
+theorem int_pm_one_cast_inj [Fact (2 < q)] {x y : ℤ}
+    (hx : x = 1 ∨ x = -1) (hy : y = 1 ∨ y = -1)
+    (hxy : (x : ZMod q) = (y : ZMod q)) : x = y := by
+  rcases hx with rfl | rfl <;> rcases hy with rfl | rfl
+  · rfl
+  · simp only [Int.cast_one, Int.cast_neg] at hxy
+    exact absurd hxy.symm ZMod.neg_one_ne_one
+  · simp only [Int.cast_one, Int.cast_neg] at hxy
+    exact absurd hxy ZMod.neg_one_ne_one
+  · rfl
+
+/-- **Integer quadratic reciprocity via the Gauss-sum lift.**
+
+    The product of Legendre symbols equals the reciprocity sign, obtained by
+    lifting the ZMod q identity `gauss_sum_zmod_qr` to ℤ through the four-sign
+    case analysis. This re-derives the reciprocity law from the Gauss-sum
+    pipeline, independently of `legendreSym.quadratic_reciprocity`. -/
+theorem qr_int_of_gauss_sum (hp2 : p ≠ 2) (hq2 : q ≠ 2) (hpq : p ≠ q) :
+    legendreSym p (q : ℤ) * legendreSym q (p : ℤ) = (-1) ^ (p / 2 * (q / 2)) := by
+  -- The native ZMod q identity from the (verified) Gauss-sum assembly.
+  have hz := GaussSumFullAssembly.gauss_sum_zmod_qr (p := p) (q := q) hp2 hq2 hpq
+  haveI : Fact (2 < q) := ⟨lt_of_le_of_ne hq.out.two_le (fun h => hq2 h.symm)⟩
+  -- `q` is a unit mod `p` and vice versa, since `p ≠ q` are primes.
+  have hqp : ((q : ℤ) : ZMod p) ≠ 0 := by
+    rw [Int.cast_natCast, Ne, ZMod.natCast_eq_zero_iff]
+    exact fun hdvd => hpq ((Nat.prime_dvd_prime_iff_eq hp.out hq.out).mp hdvd)
+  have hpq2 : ((p : ℤ) : ZMod q) ≠ 0 := by
+    rw [Int.cast_natCast, Ne, ZMod.natCast_eq_zero_iff]
+    exact fun hdvd => hpq ((Nat.prime_dvd_prime_iff_eq hq.out hp.out).mp hdvd).symm
+  -- Both Legendre symbols are ±1, and so is the reciprocity sign.
+  have hA := legendreSym.eq_one_or_neg_one (p := p) hqp
+  have hB := legendreSym.eq_one_or_neg_one (p := q) hpq2
+  have hBsq := legendreSym.sq_one (p := q) hpq2
+  set k := p / 2 * (q / 2) with hk
+  have hE : (-1 : ℤ) ^ k = 1 ∨ (-1 : ℤ) ^ k = -1 := by
+    rcases Nat.even_or_odd k with he | ho
+    · exact Or.inl he.neg_one_pow
+    · exact Or.inr ho.neg_one_pow
+  -- The right-hand side `(-1)^k · (q/p)` is itself ±1.
+  have hmemEB : (-1 : ℤ) ^ k * legendreSym q (p : ℤ) = 1 ∨
+      (-1 : ℤ) ^ k * legendreSym q (p : ℤ) = -1 := by
+    rcases hE with h | h <;> rcases hB with h' | h' <;> rw [h, h'] <;> decide
+  -- Lift the ZMod q congruence `(p/q) ≡ (-1)^k · (q/p)` to an integer equality,
+  -- then clear `(q/p)` using `(q/p)² = 1`.
+  have hAEB : legendreSym p (q : ℤ) = (-1 : ℤ) ^ k * legendreSym q (p : ℤ) := by
+    apply int_pm_one_cast_inj (q := q) hA hmemEB
+    push_cast
+    exact hz.symm
+  rw [hAEB, mul_assoc, ← pow_two, hBsq, mul_one]
+
+-- ============================================================================
+-- Concrete verifications (independent of the lift, by direct computation)
+-- ============================================================================
+
+/-- p = 3, q = 5: (3/5)·(5/3) = 1 = (-1)^(2·1). -/
+example : legendreSym 3 (5 : ℤ) * legendreSym 5 (3 : ℤ) = (-1) ^ (3 / 2 * (5 / 2)) := by
+  decide
+
+/-- p = 3, q = 7: (3/7)·(7/3) = -1 = (-1)^(3·1). -/
+example : legendreSym 3 (7 : ℤ) * legendreSym 7 (3 : ℤ) = (-1) ^ (3 / 2 * (7 / 2)) := by
+  decide
+
+end GaussSumQRIntLift
+
+/-
+  ## Summary
+
+  | Result | Statement |
+  |--------|-----------|
+  | `int_pm_one_cast_inj` | `ℤ → ZMod q` is injective on `{+1,-1}` for odd prime `q` |
+  | `qr_int_of_gauss_sum` | `(p/q)·(q/p) = (-1)^(p/2·q/2)` in ℤ, lifted from `gauss_sum_zmod_qr` |
+
+  The lift uses only:
+    * `gauss_sum_zmod_qr` (the verified Gauss-sum identity in ZMod q),
+    * `legendreSym.eq_one_or_neg_one` / `legendreSym.sq_one` (Legendre symbols are ±1),
+    * `ZMod.neg_one_ne_one` (the {+1,-1} injectivity of the cast).
+
+  It does **not** invoke `legendreSym.quadratic_reciprocity`, so it is a genuine
+  re-derivation of the reciprocity sign from the Gauss-sum pipeline.
+
+  **Sorries**: 0
+  **Axioms**: 0
+-/

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02-oq-01",
+  "title": "Lifting the Gauss-Sum QR Identity from ZMod q to ℤ",
+  "slug": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02-oq-01",
+  "description": "Answers the parent's open question oq-02-oq-01: the Gauss-sum proof of quadratic reciprocity natively produces a congruence in ZMod q (gauss_sum_zmod_qr: (-1)^(p/2·q/2)·(q/p) = (p/q) mod q), and this file performs the elementary 'last mile' that lifts it to the classical integer identity legendreSym p q · legendreSym q p = (-1)^(p/2·q/2), WITHOUT invoking Mathlib's black-box legendreSym.quadratic_reciprocity. The lift rests on a single arithmetic fact: for an odd prime q the cast ℤ → ZMod q is injective on {+1, -1} (otherwise q ∣ 2). Since both Legendre symbols and the reciprocity sign lie in {+1, -1}, the ZMod q congruence forces an honest integer equality — the 'four sign possibilities' case analysis requested by the open question. This PR also repairs a Mathlib-API-drift build break that had silently red-flagged the entire Gauss-sum QR chain (OQ01OQ01OQ01, the assembly OQ01OQ01OQ01OQ02) despite their 'verified' badges.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-reciprocity",
+      "gauss-sums",
+      "legendre-symbol",
+      "zmod-lift",
+      "euler-criterion",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 142,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-19",
+    "mathlibDependencies": [
+      {
+        "theorem": "legendreSym.eq_one_or_neg_one",
+        "description": "A Legendre symbol of a unit is +1 or -1",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "legendreSym.sq_one",
+        "description": "(legendreSym p a)^2 = 1 when a is a unit mod p",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "ZMod.neg_one_ne_one",
+        "description": "(-1 : ZMod n) ≠ 1 for 2 < n — the injectivity of the cast on {+1,-1}",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(a : ZMod b) = 0 ↔ b ∣ a, used to show q is a unit mod p",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.prime_dvd_prime_iff_eq",
+        "description": "for primes p, q: p ∣ q ↔ p = q",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "originalContributions": [
+      "int_pm_one_cast_inj: for an odd prime q, the cast ℤ → ZMod q is injective on {+1, -1} (a congruence between two ±1 integers lifts to an integer equality)",
+      "qr_int_of_gauss_sum: the integer quadratic reciprocity law obtained by lifting gauss_sum_zmod_qr through the four-sign analysis, independent of legendreSym.quadratic_reciprocity",
+      "Build-break repair of the Gauss-sum QR chain (OQ01OQ01OQ01, OQ01OQ01OQ01OQ02) caused by Mathlib MulChar/AddChar API drift (MulChar.ext now quantifies over units; isPrimitive_stdAddChar takes N explicitly; legendreSym.quadratic_reciprocity argument order)"
+    ],
+    "prerequisites": [
+      "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02 (gauss_sum_zmod_qr: the ZMod q form of QR)",
+      "Legendre symbols are ±1 on units; Euler's criterion",
+      "Injectivity of ℤ → ZMod q on small integers for odd prime q"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02",
+      "Mathlib.NumberTheory.LegendreSymbol.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "GaussSumQRIntLift",
+    "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02OQ01.lean",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The Gauss-sum proof of quadratic reciprocity — Gauss's sixth proof (1818) — works in a finite field of characteristic q and naturally lands in ZMod q: the identity it delivers is a congruence, not an equation of integers. Classical textbook treatments (Ireland–Rosen, Chapter 6) then perform a short final step, observing that both Legendre symbols are ±1 and a congruence mod an odd prime q ≥ 3 between values in {+1, -1} must be an equality. This file formalizes exactly that final step. The parent entry (oq-01-oq-01-oq-01-oq-02) proved the ZMod q congruence gauss_sum_zmod_qr but reached the integer statement only by citing Mathlib's independent legendreSym.quadratic_reciprocity, leaving the genuine Gauss-sum lift open — that gap is its listed open question oq-02-oq-01, which this entry closes.",
+    "problemStatement": "**OQ-...-OQ-02-OQ-01**: Can gauss_sum_zmod_qr be lifted from ZMod q to ℤ directly, giving integer quadratic reciprocity from the Gauss-sum machinery alone, without invoking legendreSym.quadratic_reciprocity?\n\n**Answer**: YES. For distinct odd primes p, q,\n\n$$\\left(\\tfrac{p}{q}\\right)\\left(\\tfrac{q}{p}\\right) = (-1)^{\\frac{p-1}{2}\\cdot\\frac{q-1}{2}}$$\n\nfollows from the ZMod q congruence by lifting through the injectivity of ℤ → ZMod q on {+1, -1}.",
+    "text": "The elementary last mile of the Gauss-sum proof of quadratic reciprocity: converting the native ZMod q congruence into the classical integer identity via the four-sign case analysis, independent of Mathlib's own QR proof.",
+    "proofStrategy": "Both Legendre symbols (p/q), (q/p) are units (p ≠ q primes), hence ±1, via legendreSym.eq_one_or_neg_one; so is the sign (-1)^(p/2·q/2). The helper int_pm_one_cast_inj records that ℤ → ZMod q is injective on {+1, -1} for odd prime q (the only obstruction 1 ≡ -1 would force q ∣ 2). From gauss_sum_zmod_qr we get (p/q) ≡ (-1)^(p/2·q/2)·(q/p) mod q; both sides are ±1, so the congruence lifts to the integer equality (p/q) = (-1)^(p/2·q/2)·(q/p). Multiplying by (q/p) and using (q/p)² = 1 (legendreSym.sq_one) clears it to the reciprocity law. Two concrete pairs (3,5) and (3,7) are checked by decide (kernel reduction, no native compilation, no Lean.ofReduceBool).",
+    "keyInsights": [
+      "**The whole content of 'lifting ZMod q to ℤ' is the injectivity of the cast on {+1, -1}.** Because q is an odd prime, 1 and -1 are distinct mod q (ZMod.neg_one_ne_one), so a congruence between two integers each equal to ±1 is automatically an equality. This single observation is what the open question's 'case analysis on the four sign possibilities' amounts to.",
+      "**Non-circularity is the point.** The proof deliberately avoids legendreSym.quadratic_reciprocity, so the reciprocity sign is genuinely re-derived from the Gauss-sum pipeline (gauss_sum_zmod_qr) rather than re-imported from Mathlib's separate proof. The only QR-flavoured inputs are that Legendre symbols are ±1 and square to 1 — facts about a single symbol, not the reciprocity law.",
+      "**(q/p)² = 1 turns 'A = E·B' into 'A·B = E'.** Once the congruence is lifted to A = (-1)^(p/2·q/2)·B, multiplying by B and collapsing B² = 1 (legendreSym.sq_one) yields the symmetric product form A·B = (-1)^(p/2·q/2). This avoids any case split on the actual signs.",
+      "**decide over native_decide for the concrete checks.** The two sanity examples close by decide (kernel reduction), so the file depends only on propext/Classical.choice/Quot.sound — it does not pull in Lean.ofReduceBool, and the entry is genuinely axiom-free.",
+      "**Mathlib API drift had silently broken the chain.** Repairing it surfaced three independent drift points: MulChar.ext now quantifies over units (so MulChar.one_apply_coe replaces the old if-then-else MulChar.one_apply), ZMod.isPrimitive_stdAddChar now takes its modulus explicitly, and legendreSym.quadratic_reciprocity returns the factors in the opposite order. The 'verified' badge on a published entry is only as good as the last Mathlib bump it was checked against."
+    ],
+    "prerequisites": [
+      "Quadratic reciprocity and the Gauss-sum proof (Gauss 1818)",
+      "Legendre symbol over ℤ and over ZMod q; Euler's criterion",
+      "gauss_sum_zmod_qr (parent entry, ZMod q form of QR)",
+      "Injectivity of ℤ → ZMod q on {+1, -1} for odd prime q"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Documents the open question (lifting ZMod q → ℤ) and the four-sign lift strategy; imports the parent assembly (for gauss_sum_zmod_qr) and Mathlib's Legendre-symbol theory.",
+      "mathContext": "The leaf oq-02-oq-01: the last mile of the Gauss-sum proof of QR."
+    },
+    {
+      "id": "cast-inj",
+      "title": "int_pm_one_cast_inj — injectivity on {+1, -1}",
+      "startLine": 56,
+      "endLine": 69,
+      "summary": "For odd prime q, two integers each equal to ±1 that are congruent mod q are equal. Four-way rcases; the cross cases 1 ≡ -1 are dispatched by ZMod.neg_one_ne_one.",
+      "mathContext": "The arithmetic heart of the lift: the cast ℤ → ZMod q is faithful on {+1, -1} because 2 < q."
+    },
+    {
+      "id": "main-lift",
+      "title": "qr_int_of_gauss_sum — integer QR via the lift",
+      "startLine": 71,
+      "endLine": 108,
+      "summary": "Shows q is a unit mod p and vice versa (Nat.prime_dvd_prime_iff_eq), obtains ±1-ness of both symbols, casts the integer product to ZMod q and matches gauss_sum_zmod_qr, lifts to ℤ via int_pm_one_cast_inj, then clears (q/p) using (q/p)² = 1.",
+      "mathContext": "Integer quadratic reciprocity re-derived from the Gauss-sum congruence, independent of legendreSym.quadratic_reciprocity."
+    },
+    {
+      "id": "examples",
+      "title": "Concrete verifications",
+      "startLine": 110,
+      "endLine": 122,
+      "summary": "(3,5) → product 1 and (3,7) → product -1, both closed by decide (kernel reduction, no ofReduceBool).",
+      "mathContext": "Operational sanity checks covering reciprocity (=1) and the both-≡3-mod-4 sign flip (=-1)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Gauss-sum proof of quadratic reciprocity is completed in ℤ. The parent's ZMod q congruence gauss_sum_zmod_qr is lifted to the classical integer identity legendreSym p q · legendreSym q p = (-1)^(p/2·q/2) using only that the cast ℤ → ZMod q is injective on {+1, -1} for odd prime q. The derivation does not use Mathlib's legendreSym.quadratic_reciprocity, so it is a genuine re-derivation of the reciprocity sign from the Gauss-sum pipeline. Verified with 0 axioms and 0 sorries; concrete checks use decide rather than native_decide. The PR additionally repairs a Mathlib-drift build break across the upstream Gauss-sum chain.",
+    "implications": "Closes the parent's headline open question (oq-02-oq-01, significance high): the Gauss-sum architecture now reaches integer QR end-to-end without borrowing Mathlib's independent proof. The same ±1-injectivity lift is the standard device for turning any character-sum congruence into an integer identity, so it is reusable for higher reciprocity (cubic/quartic) where the residue symbols again take values in roots of unity. The build-break repair restores the integrity of the four 'verified' Gauss-sum entries that Mathlib drift had silently red-flagged.",
+    "openQuestions": [
+      {
+        "id": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+        "question": "Generalize int_pm_one_cast_inj to a reusable lemma 'a congruence mod an odd prime q between two roots of unity ζ_n^a, ζ_n^b lifts to an equality' for the cubic/quartic residue characters, enabling the same last-mile lift for higher reciprocity laws.",
+        "significance": "medium"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Direct parent: provides gauss_sum_zmod_qr (the ZMod q form of QR) that this file lifts to ℤ; answers that entry's open question oq-02-oq-01."
+    },
+    {
+      "targetId": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
+      "relationship": "depends-on",
+      "description": "Grandparent (Step 2: τ² = χ(-1)·p); also repaired here for Mathlib API drift."
+    },
+    {
+      "targetId": "elementary-quadratic-reciprocity",
+      "relationship": "extends",
+      "description": "Root ancestor: the elementary (Eisenstein-style) QR proof the Gauss-sum chain provides an alternative to."
+    }
+  ],
+  "references": [
+    {
+      "title": "A Classical Introduction to Modern Number Theory",
+      "author": "Kenneth Ireland, Michael Rosen",
+      "year": "1990",
+      "venue": "Springer GTM 84, 2nd edition",
+      "description": "Chapter 6 gives the Gauss-sum proof of QR, including the final passage from the characteristic-q congruence to the integer Legendre-symbol identity formalized here."
+    },
+    {
+      "title": "Reciprocity Laws: From Euler to Eisenstein",
+      "author": "Franz Lemmermeyer",
+      "year": "2000",
+      "venue": "Springer Monographs in Mathematics",
+      "description": "Surveys Gauss's eight proofs and develops the Gauss-sum approach (Chapter 5); the ±1-injectivity lift is the standard final step."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+      "question": "Generalize the {+1,-1} cast-injectivity lift to roots of unity ζ_n mod q, enabling the same last-mile passage from a residue-character congruence to an integer identity for cubic and quartic reciprocity.",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 252,
+    "lineCount": 243,
     "theoremCount": 11,
     "definitionCount": 1,
     "dateAdded": "2026-05-07",
@@ -83,10 +83,13 @@
       "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
       "Mathlib.Tactic"
     ],
-    "opens": ["MulChar", "ZMod"],
+    "opens": [
+      "MulChar",
+      "ZMod"
+    ],
     "namespace": "GaussSumFullAssembly",
     "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean",
-    "lineCount": 252,
+    "lineCount": 243,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 1,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 224,
+    "lineCount": 210,
     "theoremCount": 8,
     "definitionCount": 2,
     "dateAdded": "2026-05-05",
@@ -152,7 +152,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01.lean",
-    "lineCount": 224,
+    "lineCount": 210,
     "theoremCount": 8,
     "definitionCount": 2,
     "axiomCount": 0,


### PR DESCRIPTION
## Summary

Answers the parent entry's **high-significance open question** `oq-02-oq-01`:
*can `gauss_sum_zmod_qr` be lifted from `ZMod q` to `ℤ` directly, giving integer
quadratic reciprocity from the Gauss-sum machinery alone, without invoking
Mathlib's `legendreSym.quadratic_reciprocity`?* **Yes.**

The Gauss-sum proof of QR natively lands in `ZMod q` (a congruence). This file
performs the elementary "last mile": both Legendre symbols and the reciprocity
sign lie in `{+1, -1}`, and the cast `ℤ → ZMod q` is injective on `{+1, -1}` for
an odd prime `q` (otherwise `q ∣ 2`), so the congruence forces an integer
equality — the "four sign possibilities" case analysis the open question asked for.

## New entry (verified, 0 sorries, 0 axioms)

`proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02OQ01.lean`
- `int_pm_one_cast_inj` — `ℤ → ZMod q` is injective on `{+1,-1}` for odd prime `q`
- `qr_int_of_gauss_sum` — `legendreSym p q * legendreSym q p = (-1)^(p/2*(q/2))`,
  lifted from `gauss_sum_zmod_qr`, **not** using `legendreSym.quadratic_reciprocity`
- concrete checks use `decide` (kernel reduction; **no** `Lean.ofReduceBool`)

`#print axioms qr_int_of_gauss_sum` → `[propext, Classical.choice, Quot.sound]`.

## Build-break repair (gallery integrity)

The upstream Gauss-sum QR chain was **build-broken by Mathlib API drift** despite
its `verified` badges. Repaired:
- `ElementaryQuadraticReciprocityOQ01OQ01OQ01.lean`: `quadCharC_ne_one` via
  `MulChar.ringHomComp_ne_one_iff`; `ZMod.isPrimitive_stdAddChar p` (N now
  explicit); close the anonymous `noncomputable section`.
- `ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean` (assembly):
  `legendreCharQ_ne_one` via `MulChar.one_apply_coe` (`ext` now ranges over units);
  `map_pow`/`map_neg` for the ring-hom cast; fix `legendreSym.quadratic_reciprocity`
  factor order with `mul_comm`.

All three chain files + the new file compile via `lake env lean` and are axiom-clean.

## Verification

```
'GaussSumQRIntLift.qr_int_of_gauss_sum'      [propext, Classical.choice, Quot.sound]
'GaussSumFullAssembly.gauss_sum_zmod_qr'     [propext, Classical.choice, Quot.sound]
'GaussSumFullAssembly.gauss_sum_qr_assembled' [propext, Classical.choice, Quot.sound]
'GaussSumSquaredQR.gauss_sum_squared'        [propext, Classical.choice, Quot.sound]
```

## Status
**Outcome**: completed (open question answered; chain build-break repaired)
**Next**: generalize the `{+1,-1}` lift to roots of unity `ζ_n` for cubic/quartic reciprocity.

🤖 Generated by researcher-1