### PR TITLE
research(basel-problem-oq-08): ζ(4) = π⁴/90

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -201,6 +201,7 @@ import Proofs.BaselProblemOQ02Aristotle
 import Proofs.BaselProblemOQ04
 import Proofs.BaselProblemOQ04OQ03
 import Proofs.BaselProblemOQ05
+import Proofs.BaselProblemOQ08
 import Proofs.BertrandsPostulate
 import Proofs.BertrandsPostulateOQ03
 import Proofs.BertrandsPostulateOQ03OQ04

--- a/proofs/Proofs/BaselProblemOQ08.lean
+++ b/proofs/Proofs/BaselProblemOQ08.lean
@@ -1,0 +1,47 @@
+/-
+# Basel Problem OQ-08: the value ζ(4) = π⁴/90
+
+## Open Question
+Formalize `∑' n, 1 / n⁴ = π⁴ / 90`, the degree-4 analogue of the Basel problem
+`∑' n, 1 / n² = π²/6`, by specialising Mathlib's even-zeta formula at argument 4.
+
+## Approach
+Mathlib already proves `hasSum_zeta_four : HasSum (fun n => 1/n⁴) (π⁴/90)` (and the
+companion `hasSum_zeta_two`) via the Bernoulli/Hurwitz-zeta even-argument formula. This
+entry packages the `tsum` value, the `riemannZeta 4` value, and — combining the two
+classical even-zeta values — the dimensionless Euler ratio
+`ζ(4) / ζ(2)² = 2/5`, which is independent of π.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace BaselProblemOQ08
+
+open Real BigOperators
+
+/-- The summable family `n ↦ 1/n⁴` has sum `π⁴/90` (Mathlib's `hasSum_zeta_four`). -/
+theorem hasSum_one_div_nat_pow_four :
+    HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 4) (π ^ 4 / 90) :=
+  hasSum_zeta_four
+
+/-- **ζ(4) = π⁴/90.** The infinite sum `∑' n, 1/n⁴` over the naturals equals `π⁴/90`. -/
+theorem tsum_one_div_nat_pow_four :
+    ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4 = π ^ 4 / 90 :=
+  hasSum_zeta_four.tsum_eq
+
+/-- The Riemann zeta function at `4` equals `π⁴/90` (Mathlib's `riemannZeta_four`). -/
+theorem riemannZeta_four_eq : riemannZeta 4 = (π : ℂ) ^ 4 / 90 :=
+  riemannZeta_four
+
+/-- **Euler's ratio `ζ(4) / ζ(2)² = 2/5`.** Dividing the two classical even-zeta values
+`ζ(4) = π⁴/90` and `ζ(2) = π²/6` makes π cancel, leaving the rational `2/5`. -/
+theorem tsum_four_div_tsum_two_sq :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4) / (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) ^ 2 = 2 / 5 := by
+  rw [tsum_one_div_nat_pow_four, hasSum_zeta_two.tsum_eq]
+  have hπ : (π : ℝ) ≠ 0 := Real.pi_ne_zero
+  have h4 : (π : ℝ) ^ 4 ≠ 0 := pow_ne_zero _ hπ
+  field_simp
+  ring
+
+end BaselProblemOQ08

--- a/src/data/proofs/basel-problem-oq-08/annotations.json
+++ b/src/data/proofs/basel-problem-oq-08/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "baseloq08-header",
+    "proofId": "basel-problem-oq-08",
+    "range": {
+      "startLine": 1,
+      "endLine": 23
+    },
+    "type": "concept",
+    "title": "Module Header and Problem Setup",
+    "content": "The open question asks for $\\sum_{n=1}^\\infty 1/n^4 = \\pi^4/90$, the degree-4 analogue of the Basel problem $\\sum 1/n^2 = \\pi^2/6$. Euler's 1740 even-argument formula $\\zeta(2k) = (-1)^{k+1} B_{2k}(2\\pi)^{2k}/(2(2k)!)$ gives this at $k=2$ (using $B_4 = -1/30$). Mathlib formalizes the underlying Hurwitz-zeta computation, so the entry specialises it."
+  },
+  {
+    "id": "baseloq08-zeta-four",
+    "proofId": "basel-problem-oq-08",
+    "range": {
+      "startLine": 24,
+      "endLine": 39
+    },
+    "type": "theorem",
+    "title": "The Value ζ(4) = π⁴/90",
+    "content": "`tsum_one_div_nat_pow_four` is the headline result $\\sum' n,\\ 1/n^4 = \\pi^4/90$, obtained as `hasSum_zeta_four.tsum_eq`. `hasSum_one_div_nat_pow_four` re-exports the `HasSum` form, and `riemannZeta_four_eq` records the same value for the analytically continued zeta function, $\\zeta(4) = \\pi^4/90$ over $\\mathbb{C}$ (Mathlib's `riemannZeta_four`)."
+  },
+  {
+    "id": "baseloq08-ratio",
+    "proofId": "basel-problem-oq-08",
+    "range": {
+      "startLine": 41,
+      "endLine": 47
+    },
+    "type": "theorem",
+    "title": "Euler's π-free Ratio ζ(4)/ζ(2)² = 2/5",
+    "content": "`tsum_four_div_tsum_two_sq` divides the two classical even-zeta values: $\\zeta(4)/\\zeta(2)^2 = (\\pi^4/90)/(\\pi^2/6)^2 = (\\pi^4/90)/(\\pi^4/36) = 36/90 = 2/5$. The factor of $\\pi^4$ cancels, so the ratio is a rational number determined purely by the Bernoulli numbers, independent of the transcendence of $\\pi$. Proved by rewriting both sums and finishing with `field_simp` (using $\\pi \\neq 0$) and `ring`."
+  }
+]

--- a/src/data/proofs/basel-problem-oq-08/meta.json
+++ b/src/data/proofs/basel-problem-oq-08/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "basel-problem-oq-08",
+  "title": "ζ(4) = π⁴/90: the Degree-4 Basel Value",
+  "slug": "basel-problem-oq-08",
+  "description": "The value ζ(4) = ∑' n, 1/n⁴ = π⁴/90, the degree-4 analogue of the Basel problem, obtained by specialising Mathlib's even-argument zeta formula at 4. Includes the riemannZeta 4 value and Euler's dimensionless ratio ζ(4)/ζ(2)² = 2/5.",
+  "meta": {
+    "author": "Euler (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Particular_values_of_the_Riemann_zeta_function",
+    "date": "1740",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "basel-problem",
+      "riemann-zeta",
+      "euler",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/BaselProblemOQ08.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_four",
+        "description": "HasSum (fun n => 1/n⁴) (π⁴/90) — the degree-4 even-zeta value",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "hasSum_zeta_two",
+        "description": "HasSum (fun n => 1/n²) (π²/6) — the classical Basel value",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "riemannZeta_four",
+        "description": "riemannZeta 4 = π⁴/90",
+        "module": "Mathlib.NumberTheory.LSeries.HurwitzZetaValues"
+      }
+    ],
+    "originalContributions": [
+      "tsum_one_div_nat_pow_four: the tsum value ∑' n, 1/n⁴ = π⁴/90 (from hasSum_zeta_four.tsum_eq)",
+      "hasSum_one_div_nat_pow_four: the HasSum re-export",
+      "riemannZeta_four_eq: the riemannZeta 4 = π⁴/90 value over ℂ",
+      "tsum_four_div_tsum_two_sq: Euler's dimensionless ratio ζ(4)/ζ(2)² = 2/5, π cancelling between the two even-zeta values"
+    ],
+    "dateAdded": "2026-06-19",
+    "lineCount": 47,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Euler solved the Basel problem ζ(2) = ∑ 1/n² = π²/6 in 1735, and his method — comparing the power-series and product expansions of sin(πx)/(πx) — immediately generalized to all even arguments. By 1740 he had the full family ζ(2k) = (−1)^{k+1} B_{2k} (2π)^{2k} / (2(2k)!), where B_{2k} are the Bernoulli numbers; at k = 2 this gives ζ(4) = π⁴/90. The even-zeta values are rational multiples of powers of π and hence transcendental; by sharp contrast the odd values ζ(2k+1) are far less understood (ζ(3) was only proved irrational by Apéry in 1978, and the arithmetic nature of ζ(5), ζ(7), … remains open). The ratio ζ(4)/ζ(2)² = 2/5 is the simplest π-free shadow of these formulas, depending only on the Bernoulli numbers B₂ = 1/6 and B₄ = −1/30.",
+    "problemStatement": "**Open Question (basel-problem-oq-08)**: Formalize ∑' n, 1/n⁴ = π⁴/90, the degree-4 analogue of the Basel problem, by specialising Mathlib's even-argument zeta formula at 4 (or by a Parseval argument on the degree-4 Bernoulli polynomial).\n\n**Result**: tsum_one_div_nat_pow_four proves ∑' n, 1/n⁴ = π⁴/90. The companion riemannZeta_four_eq gives riemannZeta 4 = π⁴/90, and tsum_four_div_tsum_two_sq derives Euler's dimensionless ratio ζ(4)/ζ(2)² = 2/5.",
+    "text": "The value ζ(4) = ∑' n, 1/n⁴ = π⁴/90, the degree-4 analogue of the Basel problem, with the riemannZeta 4 value and the π-free Euler ratio ζ(4)/ζ(2)² = 2/5.",
+    "proofStrategy": "**Proof Strategy: specialise the even-zeta formula.**\n\n1. Mathlib's `hasSum_zeta_four` proves `HasSum (fun n => 1/n⁴) (π⁴/90)` via the Hurwitz-zeta / Bernoulli-polynomial even-argument formula. `.tsum_eq` converts it to the tsum value ∑' n, 1/n⁴ = π⁴/90.\n2. `riemannZeta_four` gives the same value for the analytically-continued zeta function at 4.\n3. For the ratio, rewrite ∑ 1/n⁴ = π⁴/90 and ∑ 1/n² = π²/6 (`hasSum_zeta_two.tsum_eq`); the squared denominator is π⁴/36, and (π⁴/90)/(π⁴/36) = 36/90 = 2/5 after `field_simp` (π ≠ 0) and `ring`.",
+    "keyInsights": [
+      "**Even zeta values are rational multiples of powers of π.** ζ(2k) = (−1)^{k+1} B_{2k}(2π)^{2k}/(2(2k)!); at k = 2, B₄ = −1/30 yields ζ(4) = π⁴/90.",
+      "**The ratio ζ(4)/ζ(2)² is π-free.** Dividing the two even-zeta values cancels π entirely, leaving the rational 2/5 — a structural fact about the Bernoulli numbers, not about π.",
+      "**Mathlib already carries the hard analysis.** The Hurwitz-zeta even-argument formula is formalized upstream; this entry is the routine specialisation requested by the open question."
+    ],
+    "prerequisites": [
+      "Infinite sums / tsum and HasSum in Mathlib",
+      "The Riemann zeta function and its even-argument values",
+      "The classical Basel value ζ(2) = π²/6"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 23,
+      "summary": "Module docstring stating the open question and approach, Mathlib import, BaselProblemOQ08 namespace, and Real/BigOperators opens.",
+      "mathContext": "The degree-4 Basel value ζ(4) = ∑_{n≥1} 1/n⁴ = π⁴/90, the k=2 case of Euler's even-zeta formula."
+    },
+    {
+      "id": "zeta-four",
+      "title": "The Value ζ(4) = π⁴/90",
+      "startLine": 24,
+      "endLine": 39,
+      "summary": "hasSum_one_div_nat_pow_four (HasSum form), tsum_one_div_nat_pow_four (the headline tsum value ∑' n, 1/n⁴ = π⁴/90), and riemannZeta_four_eq (the riemannZeta 4 value over ℂ).",
+      "mathContext": "$\\sum_{n=1}^\\infty 1/n^4 = \\pi^4/90$ and $\\zeta(4) = \\pi^4/90$, from Mathlib's `hasSum_zeta_four` and `riemannZeta_four`."
+    },
+    {
+      "id": "ratio",
+      "title": "Euler's π-free Ratio ζ(4)/ζ(2)² = 2/5",
+      "startLine": 41,
+      "endLine": 47,
+      "summary": "tsum_four_div_tsum_two_sq divides the two even-zeta values, cancelling π to leave the rational 2/5.",
+      "mathContext": "$\\zeta(4)/\\zeta(2)^2 = (\\pi^4/90)/(\\pi^2/6)^2 = (\\pi^4/90)/(\\pi^4/36) = 36/90 = 2/5$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "basel-problem",
+      "relationship": "extends",
+      "description": "The Basel problem proves ζ(2) = π²/6; this entry is the degree-4 analogue ζ(4) = π⁴/90, and the ratio theorem combines both even-zeta values"
+    },
+    {
+      "targetId": "basel-problem-oq-05",
+      "relationship": "related",
+      "description": "OQ-05 formalizes Euler's Weierstrass-product route to ζ(2); the same product method generalizes to every even ζ(2k), of which ζ(4) is the next case"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of ζ(4) = ∑' n, 1/n⁴ = π⁴/90, the degree-4 Basel value, together with the riemannZeta 4 value and Euler's π-free ratio ζ(4)/ζ(2)² = 2/5. Obtained by specialising Mathlib's even-argument zeta formula, as the open question requests.",
+    "implications": "Establishes the next even-zeta value in the gallery after ζ(2). The π-free ratio ζ(4)/ζ(2)² = 2/5 isolates the Bernoulli-number content of the even-zeta formula, independent of the transcendence of π, and contrasts with the still-mysterious odd zeta values.",
+    "openQuestions": [
+      "Formalize the general even-zeta formula ζ(2k) = (−1)^{k+1} B_{2k}(2π)^{2k}/(2(2k)!) as a single Lean statement.",
+      "Formalize ζ(6) = π⁶/945 and the ratio chain ζ(2k)/π^{2k}."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "BigOperators"
+    ],
+    "namespace": "BaselProblemOQ08",
+    "lineCount": 47,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/BaselProblemOQ08.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "De summis serierum reciprocarum",
+      "year": "1740",
+      "venue": "Commentarii academiae scientiarum Petropolitanae 7, pp. 123–134",
+      "note": "Derives the even-zeta values ζ(2k) as rational multiples of π^{2k}, including ζ(4) = π⁴/90"
+    },
+    {
+      "authors": "Apéry, Roger",
+      "title": "Irrationalité de ζ(2) et ζ(3)",
+      "year": "1979",
+      "venue": "Astérisque 61, pp. 11–13",
+      "note": "Highlights the contrast: odd zeta values are arithmetically hard, while even ones (like ζ(4)) are explicit rational multiples of powers of π"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds `Proofs/BaselProblemOQ08.lean` and the gallery entry `basel-problem-oq-08`, formalizing the **degree-4 Basel value**

```
∑' n, 1/n⁴ = π⁴/90
```

by specialising Mathlib's even-argument zeta formula at 4, as the open question requests.

## Theorems

- **`tsum_one_div_nat_pow_four`** — the headline value `∑' n, 1/n⁴ = π⁴/90` (from `hasSum_zeta_four.tsum_eq`).
- **`hasSum_one_div_nat_pow_four`** — the `HasSum` form.
- **`riemannZeta_four_eq`** — `riemannZeta 4 = π⁴/90` over ℂ (Mathlib's `riemannZeta_four`).
- **`tsum_four_div_tsum_two_sq`** — Euler's dimensionless ratio `ζ(4)/ζ(2)² = 2/5`: dividing the two even-zeta values `π⁴/90` and `(π²/6)²` cancels π, leaving the rational `2/5` — a fact about the Bernoulli numbers, independent of the transcendence of π.

## Context

This is the degree-4 analogue of the Basel problem `ζ(2) = π²/6`. Mathlib already carries the hard Hurwitz-zeta / Bernoulli-polynomial analysis (`hasSum_zeta_four`, `hasSum_zeta_two`, `riemannZeta_four`); this entry is the routine specialisation plus the π-free ratio corollary.

## Status

- **Sorry-free and axiom-free**: `#print axioms` on all named theorems = `[propext, Classical.choice, Quot.sound]` only.
- Verified by single-file `lake env lean` compile (Docker host-blocked this session).
- Honest framing: a routine specialisation of existing Mathlib infrastructure (badge `mathlib`), not original research.

🤖 Generated with [Claude Code](https://claude.com/claude-code)