### PR TITLE
research(pythagorean-triples-oq-05): Brahmagupta–Fibonacci two-squares identity

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2857,6 +2857,7 @@ import Proofs.PythagoreanTriples
 import Proofs.PythagoreanTriplesOQ01
 import Proofs.PythagoreanTriplesOQ01Aristotle
 import Proofs.PythagoreanTriplesOQ02
+import Proofs.PythagoreanTriplesOQ05
 import Proofs.QuadraticGaussSumDiagonal
 import Proofs.QuadraticGaussSumSquare
 import Proofs.QuadraticGaussSumSquareOQ01

--- a/proofs/Proofs/PythagoreanTriplesOQ05.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ05.lean
@@ -1,0 +1,75 @@
+/-
+# Pythagorean Triples OQ-05: the Brahmagupta–Fibonacci identity
+
+## Open Question
+Formalize the two-squares identity
+    (a² + b²)·(c² + d²) = (a·c − b·d)² + (a·d + b·c)²
+over a commutative ring, and derive that "being a sum of two squares" is closed under
+multiplication.
+
+## Approach
+The identity is a polynomial identity, dispatched by `ring`. Its content is structural:
+it expresses the multiplicativity of the norm `N(a + b·i) = a² + b²` on the Gaussian
+integers (equivalently `|z·w|² = |z|²·|w|²` for `z, w ∈ ℂ`), and it is the algebraic
+heart of the classification of which integers are sums of two squares (the set is closed
+under multiplication, so it suffices to understand primes). A second form with the signs
+swapped, `(a·c + b·d)² + (a·d − b·c)²`, comes from conjugating one factor.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace PythagoreanTriplesOQ05
+
+section CommRing
+
+variable {R : Type*} [CommRing R]
+
+/-- **The Brahmagupta–Fibonacci (two-squares) identity** over any commutative ring:
+`(a² + b²)(c² + d²) = (ac − bd)² + (ad + bc)²`. -/
+theorem sq_add_sq_mul_sq_add_sq (a b c d : R) :
+    (a ^ 2 + b ^ 2) * (c ^ 2 + d ^ 2) = (a * c - b * d) ^ 2 + (a * d + b * c) ^ 2 := by
+  ring
+
+/-- The conjugate form of the identity, obtained by swapping the roles of the cross terms:
+`(a² + b²)(c² + d²) = (ac + bd)² + (ad − bc)²`. -/
+theorem sq_add_sq_mul_sq_add_sq' (a b c d : R) :
+    (a ^ 2 + b ^ 2) * (c ^ 2 + d ^ 2) = (a * c + b * d) ^ 2 + (a * d - b * c) ^ 2 := by
+  ring
+
+/-- A predicate: `x` is a sum of two squares. -/
+def IsSumOfTwoSquares (x : R) : Prop := ∃ a b : R, x = a ^ 2 + b ^ 2
+
+/-- **Sums of two squares are closed under multiplication.** This is the structural
+consequence of the Brahmagupta–Fibonacci identity. -/
+theorem IsSumOfTwoSquares.mul {x y : R}
+    (hx : IsSumOfTwoSquares x) (hy : IsSumOfTwoSquares y) :
+    IsSumOfTwoSquares (x * y) := by
+  obtain ⟨a, b, rfl⟩ := hx
+  obtain ⟨c, d, rfl⟩ := hy
+  exact ⟨a * c - b * d, a * d + b * c, sq_add_sq_mul_sq_add_sq a b c d⟩
+
+/-- Every square is a sum of two squares (take the second summand to be `0`). -/
+theorem IsSumOfTwoSquares.sq (a : R) : IsSumOfTwoSquares (a ^ 2) :=
+  ⟨a, 0, by ring⟩
+
+/-- Closure under multiplication extends to finite products: a product of a list of
+sums-of-two-squares is itself a sum of two squares. -/
+theorem IsSumOfTwoSquares.listProd :
+    ∀ {l : List R}, (∀ x ∈ l, IsSumOfTwoSquares x) → IsSumOfTwoSquares l.prod
+  | [], _ => ⟨1, 0, by rw [List.prod_nil]; ring⟩
+  | a :: l, h => by
+      rw [List.prod_cons]
+      exact (h a (List.mem_cons_self ..)).mul
+        (IsSumOfTwoSquares.listProd fun x hx => h x (List.mem_cons_of_mem _ hx))
+
+end CommRing
+
+/-! ### Concrete witness over ℤ -/
+
+/-- A concrete instance: `(1² + 2²)(1² + 1²) = 5·2 = 10 = 1² + 3²`, exhibiting `10` as a
+sum of two squares via the identity. -/
+example : (1 ^ 2 + 2 ^ 2) * (1 ^ 2 + 1 ^ 2) = (1 : ℤ) ^ 2 + 3 ^ 2 := by
+  rw [sq_add_sq_mul_sq_add_sq (1 : ℤ) 2 1 1]; norm_num
+
+end PythagoreanTriplesOQ05

--- a/src/data/proofs/pythagorean-triples-oq-05/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-05/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "pythoq05-header",
+    "proofId": "pythagorean-triples-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 24
+    },
+    "type": "concept",
+    "title": "Module Header and Problem Setup",
+    "content": "The open question asks for the two-squares identity $(a^2+b^2)(c^2+d^2) = (ac-bd)^2 + (ad+bc)^2$ over a commutative ring, and the derivation that being a sum of two squares is closed under multiplication. The identity is exactly the multiplicativity of the Gaussian-integer norm $N(a+bi) = a^2+b^2$, and is the algebraic heart of the classification of integers that are sums of two squares."
+  },
+  {
+    "id": "pythoq05-identity",
+    "proofId": "pythagorean-triples-oq-05",
+    "range": {
+      "startLine": 25,
+      "endLine": 40
+    },
+    "type": "theorem",
+    "title": "The Brahmagupta–Fibonacci Identity",
+    "content": "`sq_add_sq_mul_sq_add_sq` states $(a^2+b^2)(c^2+d^2) = (ac-bd)^2 + (ad+bc)^2$, a polynomial identity over any `CommRing`, closed by `ring`. The conjugate form `sq_add_sq_mul_sq_add_sq'` gives $(ac+bd)^2 + (ad-bc)^2$, corresponding to multiplying by the conjugate $\\overline{c+di}$. The two witnesses $(ac-bd,\\ ad+bc)$ are the real and imaginary parts of $(a+bi)(c+di)$."
+  },
+  {
+    "id": "pythoq05-closure",
+    "proofId": "pythagorean-triples-oq-05",
+    "range": {
+      "startLine": 42,
+      "endLine": 70
+    },
+    "type": "theorem",
+    "title": "Closure of Sums of Two Squares",
+    "content": "`IsSumOfTwoSquares x := ∃ a b, x = a²+b²`. `IsSumOfTwoSquares.mul` proves the set is closed under multiplication by supplying the explicit witness from the identity; `IsSumOfTwoSquares.sq` notes every square qualifies; `IsSumOfTwoSquares.listProd` extends closure to finite products by list induction (empty product $1 = 1^2+0^2$, cons step via binary closure). This multiplicative closure is what reduces the two-squares theorem to prime factors."
+  },
+  {
+    "id": "pythoq05-example",
+    "proofId": "pythagorean-triples-oq-05",
+    "range": {
+      "startLine": 72,
+      "endLine": 75
+    },
+    "type": "example",
+    "title": "Concrete Witness over ℤ",
+    "content": "A worked instance over ℤ: $(1^2+2^2)(1^2+1^2) = 5 \\cdot 2 = 10 = 1^2 + 3^2$, exhibiting 10 as a sum of two squares directly through the identity with $(a,b,c,d) = (1,2,1,1)$."
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-05/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-05/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "pythagorean-triples-oq-05",
+  "title": "The Brahmagupta–Fibonacci Two-Squares Identity",
+  "slug": "pythagorean-triples-oq-05",
+  "description": "The two-squares identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² over a commutative ring, with the structural consequence that sums of two squares are closed under multiplication (and finite products).",
+  "meta": {
+    "author": "Brahmagupta, Fibonacci (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Brahmagupta%E2%80%93Fibonacci_identity",
+    "date": "628",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "algebra",
+      "pythagorean-triples",
+      "sum-of-two-squares",
+      "gaussian-integers",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ05.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "List.prod_cons",
+        "description": "Unfolds the product of a cons list for the finite-product closure",
+        "module": "Mathlib.Algebra.BigOperators.Group.List"
+      }
+    ],
+    "originalContributions": [
+      "sq_add_sq_mul_sq_add_sq: the Brahmagupta–Fibonacci identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² over any CommRing",
+      "sq_add_sq_mul_sq_add_sq': the conjugate form (ac+bd)² + (ad−bc)²",
+      "IsSumOfTwoSquares: predicate ∃ a b, x = a² + b²",
+      "IsSumOfTwoSquares.mul: sums of two squares are closed under multiplication",
+      "IsSumOfTwoSquares.sq: every square is a sum of two squares",
+      "IsSumOfTwoSquares.listProd: closure under finite products"
+    ],
+    "dateAdded": "2026-06-19",
+    "lineCount": 75,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² appears in Brahmagupta's Brāhmasphuṭasiddhānta (628 CE) — in fact in the more general Brahmagupta identity with a parameter — and was transmitted to Europe through Fibonacci's Liber Quadratorum (1225). Its modern reading is that the Gaussian-integer norm N(a+bi) = a²+b² is multiplicative: N(zw) = N(z)N(w). This multiplicativity is the engine behind the two-squares theorem (which integers are sums of two squares): since the set of sums of two squares is closed under multiplication, the question reduces to prime factors, and Fermat's theorem on sums of two squares settles the primes (p = a²+b² iff p = 2 or p ≡ 1 mod 4). The same identity underlies the parametrization of Pythagorean triples and generalizes to the four-square (Euler) and eight-square (Degen–Graves–Cayley) identities for quaternion and octonion norms.",
+    "problemStatement": "**Open Question (pythagorean-triples-oq-05)**: Formalize the ring identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² over a commutative ring and derive that being a sum of two squares is preserved under multiplication.\n\n**Result**: sq_add_sq_mul_sq_add_sq (the identity, by `ring`), its conjugate form, and IsSumOfTwoSquares.mul / IsSumOfTwoSquares.listProd (closure under multiplication and finite products).",
+    "text": "The Brahmagupta–Fibonacci identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² over a commutative ring, with closure of sums of two squares under multiplication.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. The identity is a polynomial identity over a commutative ring, dispatched by `ring`; the conjugate form differs only by the sign convention on the cross terms.\n2. For closure under multiplication, destructure the witnesses x = a²+b², y = c²+d² and supply the explicit witnesses (ac−bd, ad+bc) from the identity.\n3. Finite-product closure follows by list induction: the empty product 1 = 1²+0², and the cons step applies binary closure.",
+    "keyInsights": [
+      "**The identity IS norm multiplicativity.** N(z)N(w) = N(zw) for the Gaussian-integer norm N(a+bi) = a²+b²; the explicit witnesses (ac−bd, ad+bc) are the real and imaginary parts of the product (a+bi)(c+di).",
+      "**Closure reduces the two-squares theorem to primes.** Because sums of two squares form a multiplicatively closed set, deciding which integers are sums of two squares reduces to the prime factors — the structural reason Fermat's theorem on primes ≡ 1 mod 4 suffices.",
+      "**Ring-level generality.** Stated over an arbitrary CommRing, the identity applies uniformly to ℤ, ℝ, ℂ, polynomial rings, and finite rings — wherever a 'sum of two squares' makes sense."
+    ],
+    "prerequisites": [
+      "Commutative rings and the `ring` tactic",
+      "Existential witnesses in Lean",
+      "List induction for the finite-product version"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 24,
+      "summary": "Module docstring stating the open question and the Gaussian-norm reading, Mathlib import, and the PythagoreanTriplesOQ05 namespace over a commutative ring.",
+      "mathContext": "Work over an arbitrary commutative ring R; 'sum of two squares' means $\\exists a\\,b,\\ x = a^2 + b^2$."
+    },
+    {
+      "id": "identity",
+      "title": "The Brahmagupta–Fibonacci Identity",
+      "startLine": 25,
+      "endLine": 40,
+      "summary": "sq_add_sq_mul_sq_add_sq and its conjugate form sq_add_sq_mul_sq_add_sq', both proved by `ring`.",
+      "mathContext": "$(a^2+b^2)(c^2+d^2) = (ac-bd)^2 + (ad+bc)^2 = (ac+bd)^2 + (ad-bc)^2$, the multiplicativity of the Gaussian norm."
+    },
+    {
+      "id": "closure",
+      "title": "Closure of Sums of Two Squares",
+      "startLine": 42,
+      "endLine": 70,
+      "summary": "Defines IsSumOfTwoSquares and proves closure under multiplication (.mul), that squares are sums of two squares (.sq), and closure under finite products (.listProd).",
+      "mathContext": "The set $\\{x : \\exists a\\,b,\\ x = a^2+b^2\\}$ is a multiplicative submonoid; the explicit product witness comes from the identity."
+    },
+    {
+      "id": "example",
+      "title": "Concrete Witness over ℤ",
+      "startLine": 72,
+      "endLine": 75,
+      "summary": "A worked instance: (1²+2²)(1²+1²) = 10 = 1²+3², exhibiting 10 as a sum of two squares through the identity.",
+      "mathContext": "$5 \\cdot 2 = 10 = 1^2 + 3^2$, the identity applied to (a,b,c,d) = (1,2,1,1)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "extends",
+      "description": "The two-squares identity is the algebraic backbone of Pythagorean-triple parametrization and the Gaussian-integer view of sums of squares"
+    },
+    {
+      "targetId": "pythagorean-triples-oq-04",
+      "relationship": "related",
+      "description": "OQ-04 addresses Fermat's two-square theorem for primes; this entry supplies the multiplicative closure that reduces the general two-squares question to those primes"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the Brahmagupta–Fibonacci two-squares identity over an arbitrary commutative ring, with the structural corollary that sums of two squares are closed under multiplication and finite products.",
+    "implications": "Provides the multiplicativity of the Gaussian-integer norm in ring-level generality and the closure property that, together with Fermat's prime two-square theorem, characterizes the integers expressible as a sum of two squares. Generalizes to the four- and eight-square identities for quaternion and octonion norms.",
+    "openQuestions": [
+      "Connect IsSumOfTwoSquares over ℤ to Mathlib's ZMod / Gaussian-integer machinery for the full two-squares theorem.",
+      "Formalize Euler's four-square identity and the Hurwitz–quaternion norm multiplicativity in the same style."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "PythagoreanTriplesOQ05",
+    "lineCount": 75,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/PythagoreanTriplesOQ05.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Brahmagupta",
+      "title": "Brāhmasphuṭasiddhānta",
+      "year": "628",
+      "venue": "",
+      "note": "Contains the (general) Brahmagupta identity, of which the two-squares identity is the unit-parameter case"
+    },
+    {
+      "authors": "Fibonacci (Leonardo of Pisa)",
+      "title": "Liber Quadratorum (The Book of Squares)",
+      "year": "1225",
+      "venue": "",
+      "note": "Transmits and uses the two-squares identity in the study of sums of squares"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds `Proofs/PythagoreanTriplesOQ05.lean` and the gallery entry `pythagorean-triples-oq-05`, formalizing the **Brahmagupta–Fibonacci two-squares identity**

```
(a² + b²)(c² + d²) = (ac − bd)² + (ad + bc)²
```

over an arbitrary commutative ring, and deriving that being a sum of two squares is closed under multiplication — exactly what the open question asks.

## Theorems

- **`sq_add_sq_mul_sq_add_sq`** (and the conjugate form `sq_add_sq_mul_sq_add_sq'` with the cross-term signs swapped) — the identity, a polynomial identity over any `CommRing` closed by `ring`.
- **`IsSumOfTwoSquares`** — the predicate `∃ a b, x = a² + b²`.
- **`IsSumOfTwoSquares.mul`** — sums of two squares are closed under multiplication, via the explicit witness `(ac − bd, ad + bc)`. This is the multiplicativity of the Gaussian-integer norm `N(a+bi) = a²+b²`.
- **`IsSumOfTwoSquares.sq`** / **`IsSumOfTwoSquares.listProd`** — every square qualifies; closure under finite products (by list induction).
- A concrete ℤ witness: `(1²+2²)(1²+1²) = 10 = 1²+3²`.

## Context

The identity (Brahmagupta, 628 CE; Fibonacci, 1225) is the algebraic engine of the two-squares theorem: because sums of two squares are multiplicatively closed, the question of which integers are sums of two squares reduces to the prime factors (where Fermat's theorem on primes ≡ 1 mod 4 applies). It generalizes to Euler's four-square and the eight-square identities for quaternion/octonion norms.

## Status

- **Sorry-free and axiom-free**: `#print axioms` on the named theorems = `[propext, Quot.sound]` only.
- Verified by single-file `lake env lean` compile (Docker host-blocked this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)