### PR TITLE
research(geometric-series-oq-06): arithmetico-geometric series ∑ n·rⁿ = r/(1−r)²

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2474,6 +2474,7 @@ import Proofs.GeometricSeriesOQ02
 import Proofs.GeometricSeriesOQ02OQ03
 import Proofs.GeometricSeriesOQ02OQ05
 import Proofs.GeometricSeriesOQ03
+import Proofs.GeometricSeriesOQ06
 import Proofs.GnedenkoKolmogorov
 import Proofs.GodelFirstIncompletenessOQ01
 import Proofs.GodelFirstIncompletenessOQ01OQ01

--- a/proofs/Proofs/GeometricSeriesOQ06.lean
+++ b/proofs/Proofs/GeometricSeriesOQ06.lean
@@ -1,0 +1,144 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+
+/-
+# The Arithmetico-Geometric Series ∑ n·rⁿ = r/(1−r)² (geometric-series-oq-06)
+
+Differentiating the geometric series `∑ rⁿ = 1/(1 − r)` term by term gives the
+**arithmetico-geometric series**
+
+    ∑' n, n · rⁿ = r / (1 − r)²      (‖r‖ < 1).
+
+This is the first moment of the geometric distribution: with success probability
+`p = 1 − r`, the expected number of trials is `∑ n·rⁿ⁻¹·p = 1/p`, and the bare
+weighted sum `∑ n·rⁿ` is exactly `r/(1 − r)²`.  It is the prototype of every
+"weighted geometric" sum appearing in generating-function calculus, queueing
+theory, and the analysis of expected running times.
+
+This file packages the identity over a normed field, together with its `HasSum`
+and `Summable` forms, the general normed-ring version (using `Ring.inverse`), the
+shifted companion `∑ (n+1)·rⁿ = 1/(1 − r)²`, and a concrete evaluation
+`∑ n·(1/2)ⁿ = 2`.
+
+Each statement is a thin, named wrapper around Mathlib's
+`hasSum_coe_mul_geometric_of_norm_lt_one` / `tsum_coe_mul_geometric_of_norm_lt_one`
+(and the `'` ring variants); the shifted companion is a genuine derivation
+combining the weighted sum with the plain geometric series.
+
+Status: 0 axioms, 0 sorries
+-/
+
+namespace GeometricSeriesOQ06
+
+open scoped Topology
+
+-- ============================================================================
+-- Part I: The arithmetico-geometric series over a normed field
+-- ============================================================================
+
+variable {𝕜 : Type*} [NormedField 𝕜]
+
+/-- **Arithmetico-geometric series, `HasSum` form.** For `‖r‖ < 1` the partial
+sums of `n · rⁿ` converge to `r / (1 − r)²`. -/
+theorem hasSum_coe_mul_geometric {r : 𝕜} (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ => (n : 𝕜) * r ^ n) (r / (1 - r) ^ 2) :=
+  hasSum_coe_mul_geometric_of_norm_lt_one hr
+
+/-- The weighted geometric series `∑ n·rⁿ` is summable when `‖r‖ < 1`. -/
+theorem summable_coe_mul_geometric {r : 𝕜} (hr : ‖r‖ < 1) :
+    Summable (fun n : ℕ => (n : 𝕜) * r ^ n) :=
+  (hasSum_coe_mul_geometric hr).summable
+
+/-- **Arithmetico-geometric series.** For `‖r‖ < 1`,
+
+    ∑' n, n · rⁿ = r / (1 − r)². -/
+theorem tsum_coe_mul_geometric {r : 𝕜} (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, (n : 𝕜) * r ^ n = r / (1 - r) ^ 2 :=
+  tsum_coe_mul_geometric_of_norm_lt_one hr
+
+-- ============================================================================
+-- Part II: The shifted companion ∑ (n+1)·rⁿ = 1/(1 − r)²
+-- ============================================================================
+
+/-- **Shifted arithmetico-geometric series.** Adding the plain geometric series
+`∑ rⁿ = (1 − r)⁻¹` to `∑ n·rⁿ = r/(1 − r)²` shifts the index:
+
+    ∑' n, (n + 1) · rⁿ = (1 − r)⁻² .
+
+This is the second derivative form `d²/dr² ∑ rⁿ`-style identity that underlies the
+negative-binomial generating function. -/
+theorem tsum_succ_mul_geometric {r : 𝕜} (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, ((n : 𝕜) + 1) * r ^ n = (1 - r)⁻¹ ^ 2 := by
+  have hne : (1 : 𝕜) - r ≠ 0 := by
+    rcases eq_or_ne r 1 with rfl | hr1
+    · simp at hr
+    · exact sub_ne_zero.mpr (Ne.symm hr1)
+  have hsum := (hasSum_coe_mul_geometric hr).add (hasSum_geometric_of_norm_lt_one hr)
+  have hcongr : (fun n : ℕ => (n : 𝕜) * r ^ n + r ^ n)
+      = fun n : ℕ => ((n : 𝕜) + 1) * r ^ n := by
+    funext n; ring
+  rw [hcongr] at hsum
+  have hval : r / (1 - r) ^ 2 + (1 - r)⁻¹ = (1 - r)⁻¹ ^ 2 := by
+    field_simp
+    ring
+  rw [hval] at hsum
+  exact hsum.tsum_eq
+
+-- ============================================================================
+-- Part III: The general normed-ring version (Ring.inverse)
+-- ============================================================================
+
+/-- **Arithmetico-geometric series over a normed ring.** In any normed ring with
+summable geometric series (e.g. a Banach algebra), for `‖x‖ < 1`,
+
+    ∑' n, n · xⁿ = x · (1 − x)⁻¹ ²,
+
+using `Ring.inverse` in place of field division. -/
+theorem tsum_coe_mul_geometric_ring {R : Type*} [NormedRing R] [HasSummableGeomSeries R]
+    {x : R} (hx : ‖x‖ < 1) :
+    ∑' n : ℕ, (n : R) * x ^ n = x * Ring.inverse (1 - x) ^ 2 :=
+  (hasSum_coe_mul_geometric_of_norm_lt_one' hx).tsum_eq
+
+-- ============================================================================
+-- Part IV: A concrete evaluation
+-- ============================================================================
+
+/-- **Concrete value.** Taking `r = 1/2` over `ℝ`:
+
+    ∑' n, n · (1/2)ⁿ = 2.
+
+So the expected number of fair-coin tosses weighted by trial index sums to 2 —
+the classic `∑ n/2ⁿ = 2`. -/
+theorem tsum_nat_mul_half_pow : ∑' n : ℕ, (n : ℝ) * (1 / 2) ^ n = 2 := by
+  have h : ‖(1 / 2 : ℝ)‖ < 1 := by rw [Real.norm_eq_abs]; norm_num
+  rw [tsum_coe_mul_geometric h]
+  norm_num
+
+-- ============================================================================
+-- Part V: Summary
+-- ============================================================================
+
+/-
+## Summary
+
+| Result | Statement | Backing |
+|--------|-----------|---------|
+| `hasSum_coe_mul_geometric` | partial sums → r/(1−r)² | `hasSum_coe_mul_geometric_of_norm_lt_one` |
+| `tsum_coe_mul_geometric` | ∑ n·rⁿ = r/(1−r)² | `tsum_coe_mul_geometric_of_norm_lt_one` |
+| `summable_coe_mul_geometric` | ∑ n·rⁿ summable | `HasSum.summable` |
+| `tsum_succ_mul_geometric` | ∑ (n+1)·rⁿ = (1−r)⁻² | weighted + geometric series |
+| `tsum_coe_mul_geometric_ring` | ring version (Ring.inverse) | `…_of_norm_lt_one'` |
+| `tsum_nat_mul_half_pow` | ∑ n·(1/2)ⁿ = 2 | specialize at r = 1/2 |
+
+The arithmetico-geometric series is the term-by-term derivative of the geometric
+series: from `∑ rⁿ = 1/(1 − r)` one gets `∑ n·rⁿ⁻¹ = 1/(1 − r)²`, i.e.
+`∑ n·rⁿ = r/(1 − r)²`.  Specializing to `r = 1/2` recovers the textbook
+`∑ n/2ⁿ = 2`, the first moment of the geometric distribution.
+-/
+
+end GeometricSeriesOQ06
+
+#check @GeometricSeriesOQ06.tsum_coe_mul_geometric
+#check @GeometricSeriesOQ06.tsum_succ_mul_geometric
+#check @GeometricSeriesOQ06.tsum_coe_mul_geometric_ring
+#check @GeometricSeriesOQ06.tsum_nat_mul_half_pow

--- a/src/data/proofs/geometric-series-oq-06/meta.json
+++ b/src/data/proofs/geometric-series-oq-06/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "geometric-series-oq-06",
+  "title": "The Arithmetico-Geometric Series ∑ n·rⁿ = r/(1−r)²",
+  "slug": "geometric-series-oq-06",
+  "description": "Differentiating the geometric series term by term gives the arithmetico-geometric series ∑' n, n·rⁿ = r/(1−r)² for ‖r‖ < 1 — the first moment of the geometric distribution, recovering the textbook ∑ n/2ⁿ = 2.",
+  "meta": {
+    "author": "Classical (Euler-era generating functions), formalized via Mathlib",
+    "sourceUrl": "https://github.com/leanprover-community/mathlib4",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ06.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "arithmetico-geometric",
+      "infinite-series",
+      "generating-functions",
+      "probability",
+      "geometric-distribution"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_coe_mul_geometric_of_norm_lt_one",
+        "description": "HasSum (fun n ↦ n·rⁿ) (r/(1−r)²) for ‖r‖ < 1 in a normed field",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "tsum_coe_mul_geometric_of_norm_lt_one",
+        "description": "∑' n, n·rⁿ = r/(1−r)² for ‖r‖ < 1 in a normed field",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "tsum_coe_mul_geometric_of_norm_lt_one'",
+        "description": "General normed-ring version using Ring.inverse: ∑' n, n·xⁿ = x·(1−x)⁻¹²",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "hasSum_geometric_of_norm_lt_one",
+        "description": "HasSum (fun n ↦ rⁿ) (1−r)⁻¹ for ‖r‖ < 1, the plain geometric series",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      }
+    ],
+    "originalContributions": [
+      "Named normed-field API for the arithmetico-geometric series: HasSum, Summable, and tsum forms of ∑ n·rⁿ = r/(1−r)²",
+      "Shifted companion ∑' n, (n+1)·rⁿ = (1−r)⁻², derived by combining the weighted sum with the plain geometric series and clearing denominators",
+      "General normed-ring version via Ring.inverse for Banach-algebra settings",
+      "Concrete evaluation ∑' n, n·(1/2)ⁿ = 2 (the first moment of the fair geometric distribution)"
+    ],
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "lineCount": 144,
+    "theoremCount": 6,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The geometric series $\\sum_{n=0}^\\infty r^n = \\frac{1}{1-r}$ for $|r| < 1$ is the most basic convergent power series. Differentiating it term by term — a manipulation made rigorous by uniform convergence on compact subsets of the unit disk — yields $\\sum_{n=1}^\\infty n r^{n-1} = \\frac{1}{(1-r)^2}$, equivalently the **arithmetico-geometric series** $\\sum_{n=0}^\\infty n r^n = \\frac{r}{(1-r)^2}$. This identity is the workhorse of generating-function calculus and appears throughout probability: it computes the expectation of the geometric distribution and the expected running time of algorithms with geometrically decaying success probabilities.",
+    "problemStatement": "**Theorem**: For $r$ in a normed field with $\\|r\\| < 1$,\n$$\\sum_{n=0}^{\\infty} n\\, r^{n} = \\frac{r}{(1-r)^2}.$$\nSpecializing $r = \\tfrac12$ over $\\mathbb{R}$ recovers $\\sum_{n=0}^\\infty \\frac{n}{2^n} = 2$.",
+    "proofStrategy": "**Core identity**: The result is Mathlib's `tsum_coe_mul_geometric_of_norm_lt_one`, the tsum form of `hasSum_coe_mul_geometric_of_norm_lt_one`, which in turn is built from the descending-factorial weighted geometric series and the plain geometric series.\n\n**Shifted companion**: Adding the geometric series $\\sum r^n = (1-r)^{-1}$ to the weighted sum $\\sum n r^n = r/(1-r)^2$ gives a `HasSum` for $\\sum (n+1) r^n$ with value $r/(1-r)^2 + (1-r)^{-1}$. Since $\\|r\\| < 1 \\Rightarrow 1 - r \\neq 0$, clearing denominators (`field_simp`; `ring`) shows this equals $(1-r)^{-2}$.\n\n**Concrete value**: At $r = 1/2$, $\\|1/2\\| = 1/2 < 1$, and $\\frac{1/2}{(1-1/2)^2} = \\frac{1/2}{1/4} = 2$ by `norm_num`.",
+    "keyInsights": [
+      "**Term-by-term differentiation, made rigorous**: The identity is exactly $r \\frac{d}{dr}\\sum r^n = r \\cdot \\frac{1}{(1-r)^2}$. Mathlib supplies the rigorous summability backing so no analytic-continuation or interchange-of-limits argument is needed at the gallery level.",
+      "**The shift trick**: $\\sum (n+1) r^n = \\sum n r^n + \\sum r^n$ turns a weighted sum into a cleaner closed form $(1-r)^{-2}$ — the same telescoping that powers negative-binomial generating functions.",
+      "**Probabilistic reading**: With $p = 1 - r$ the geometric distribution has weights $p r^n$, so $\\sum n p r^n = p \\cdot r/(1-r)^2 = r/(1-r)$, the mean offset; the bare sum $\\sum n r^n = r/(1-r)^2$ is its un-normalized form.",
+      "**Field vs. ring**: Over a normed field the answer is the literal fraction $r/(1-r)^2$; over a general Banach algebra the same series sums to $x \\cdot (1-x)^{-2}$ with `Ring.inverse`, since $1-x$ is a unit whenever $\\|x\\| < 1$."
+    ]
+  },
+  "sections": [
+    {
+      "id": "field-version",
+      "title": "The Series over a Normed Field",
+      "startLine": 35,
+      "endLine": 66,
+      "summary": "hasSum_coe_mul_geometric, summable_coe_mul_geometric, tsum_coe_mul_geometric — the HasSum, Summable, and tsum forms of ∑ n·rⁿ = r/(1−r)² for ‖r‖ < 1.",
+      "mathContext": "Direct wrappers of Mathlib's hasSum_coe_mul_geometric_of_norm_lt_one and its tsum corollary, specialized to a NormedField."
+    },
+    {
+      "id": "shifted",
+      "title": "The Shifted Companion",
+      "startLine": 67,
+      "endLine": 96,
+      "summary": "tsum_succ_mul_geometric: ∑' n, (n+1)·rⁿ = (1−r)⁻², derived by adding the plain geometric series to the weighted one and clearing denominators.",
+      "mathContext": "Uses HasSum.add of the weighted and geometric series, a funext+ring index shift, and field_simp/ring to evaluate r/(1−r)² + (1−r)⁻¹ = (1−r)⁻²."
+    },
+    {
+      "id": "ring-version",
+      "title": "The Normed-Ring Version",
+      "startLine": 97,
+      "endLine": 114,
+      "summary": "tsum_coe_mul_geometric_ring: ∑' n, n·xⁿ = x·(Ring.inverse (1−x))² over any normed ring with summable geometric series.",
+      "mathContext": "Thin wrapper of tsum_coe_mul_geometric_of_norm_lt_one', the Ring.inverse variant valid in Banach algebras."
+    },
+    {
+      "id": "concrete",
+      "title": "A Concrete Evaluation",
+      "startLine": 115,
+      "endLine": 132,
+      "summary": "tsum_nat_mul_half_pow: ∑' n, n·(1/2)ⁿ = 2 over ℝ.",
+      "mathContext": "Specializes the field identity at r = 1/2: the norm bound is norm_num, and (1/2)/(1−1/2)² = 2."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry packages the arithmetico-geometric series ∑ n·rⁿ = r/(1−r)² as a named, reusable API over normed fields and Banach algebras, with a shifted companion and the concrete ∑ n/2ⁿ = 2. It is the first-moment refinement of the base geometric series.",
+    "implications": "The identity is the simplest nontrivial weighted power series and the engine behind expected-value computations for the geometric distribution and generating-function manipulations. The shifted form (1−r)⁻² is the negative-binomial generating function of order 2.",
+    "openQuestions": [
+      "Can the second-moment sum ∑ n²·rⁿ = r(1+r)/(1−r)³ be packaged the same way (a second differentiation), giving the variance of the geometric distribution? (See geometric-series-oq-07.)",
+      "Does the term-by-term differentiation generalize cleanly to ∑ binom(n+k, k)·rⁿ = (1−r)⁻⁽ᵏ⁺¹⁾ for all k, via Mathlib's descending-factorial weighted geometric series?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "geometric-series",
+      "relationship": "foundation",
+      "description": "The base geometric series ∑ rⁿ = 1/(1−r) (Wiedijk #66). This entry is its term-by-term derivative, the first weighted moment."
+    },
+    {
+      "targetId": "geometric-series-oq-03",
+      "relationship": "sibling",
+      "description": "The Euler-product entry uses the same plain geometric series per prime factor; this entry differentiates it instead."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Topology"
+    ],
+    "namespace": "GeometricSeriesOQ06",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/GeometricSeriesOQ06.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Packages the **arithmetico-geometric series** ∑' n, n·rⁿ = r/(1−r)² (‖r‖ < 1) — the term-by-term derivative of the geometric series and the first moment of the geometric distribution — as a named, reusable Lean API.

## Contents

| Theorem | Statement | Backing |
|---------|-----------|---------|
| `hasSum_coe_mul_geometric` | partial sums → r/(1−r)² | `hasSum_coe_mul_geometric_of_norm_lt_one` |
| `summable_coe_mul_geometric` | ∑ n·rⁿ summable | `HasSum.summable` |
| `tsum_coe_mul_geometric` | ∑ n·rⁿ = r/(1−r)² | `tsum_coe_mul_geometric_of_norm_lt_one` |
| `tsum_succ_mul_geometric` | ∑ (n+1)·rⁿ = (1−r)⁻² | **derived**: weighted + plain geometric series, field_simp/ring |
| `tsum_coe_mul_geometric_ring` | ring version via `Ring.inverse` | `…_of_norm_lt_one'` |
| `tsum_nat_mul_half_pow` | ∑ n·(1/2)ⁿ = 2 | specialize r = 1/2 |

## Verification

- Compiles cleanly (`lake env lean`), no errors.
- `#print axioms` on all named results: `[propext, Classical.choice, Quot.sound]` only.
- **0 sorries, 0 axioms.** Status: `verified`, badge `mathlib`.

The shifted companion is genuine derivation; the core identity and ring version are thin named wrappers over Mathlib's weighted-geometric-series lemmas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)