### PR TITLE
research(basel-problem-oq-11): Dirichlet eta η(2) = ∑ (-1)^(n+1)/n² = π²/12

### DIFF
--- a/proofs/Proofs/BaselProblemOQ11.lean
+++ b/proofs/Proofs/BaselProblemOQ11.lean
@@ -1,0 +1,114 @@
+/-
+  # Dirichlet eta at 2: η(2) = ∑ (-1)^(n+1)/n² = π²/12
+  # (basel-problem-oq-11)
+
+  ## The Open Question
+
+  Mathlib's `hasSum_zeta_two` gives the Basel sum ζ(2) = ∑ 1/n² = π²/6. This file
+  formalizes the *alternating* companion — the **Dirichlet eta value**
+
+      η(2) = ∑_{n≥1} (-1)^(n+1) / n²  =  π²/12.
+
+  ## The parity split η(2) = (1/2) ζ(2)
+
+  Classically η(s) = (1 - 2^(1-s)) ζ(s); for s = 2 this is η(2) = (1/2) ζ(2) = π²/12.
+  The proof here splits the series into even- and odd-indexed parts via Mathlib's
+  `HasSum.even_add_odd`:
+
+    * even part:  ∑_k (-1)^(2k+1)/(2k)² = -∑_k 1/(2k)² = -(1/4) ζ(2) = -π²/24,
+    * odd part:   ∑_k (-1)^(2k+2)/(2k+1)² = ∑_k 1/(2k+1)² = π²/8,
+
+  and -π²/24 + π²/8 = π²/12. The odd-square sum π²/8 is itself obtained from
+  `hasSum_zeta_two` by the same even/odd split: ζ(2) = (even) + (odd) with the even
+  part π²/24 forces the odd part to be π²/6 - π²/24 = π²/8.
+
+  ## Axiom count: 0
+-/
+
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.Tactic
+
+open Real
+
+namespace BaselEtaTwo
+
+/-- The summand of the Dirichlet eta value η(2): `(-1)^(n+1) / n²`.
+    (At `n = 0` this is `-1/0 = 0` in ℝ, so the series starts effectively at n = 1.) -/
+noncomputable def etaSummand (n : ℕ) : ℝ := (-1) ^ (n + 1) / (n : ℝ) ^ 2
+
+/-- Even-indexed Basel sum: `∑_k 1/(2k)² = π²/24` (a quarter of ζ(2)). -/
+theorem hasSum_even_zeta_two :
+    HasSum (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ 2) (π ^ 2 / 24) := by
+  have h4 := hasSum_zeta_two.mul_left (1 / 4 : ℝ)
+  have hfe : (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ 2)
+      = (fun k : ℕ => (1 / 4 : ℝ) * (1 / (k : ℝ) ^ 2)) := by
+    funext k; push_cast; ring
+  rw [hfe]
+  convert h4 using 1
+  ring
+
+/-- Odd-indexed Basel sum: `∑_k 1/(2k+1)² = π²/8`. Derived from `hasSum_zeta_two`
+    by the even/odd split: ζ(2) = (even part π²/24) + (odd part), so the odd part
+    is π²/6 - π²/24 = π²/8. -/
+theorem hasSum_odd_zeta_two :
+    HasSum (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 2) (π ^ 2 / 8) := by
+  have hodd_summable : Summable (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 2) :=
+    hasSum_zeta_two.summable.comp_injective (fun a b h => by omega)
+  -- Reassemble ζ(2) from its even and odd parts.
+  have hkey : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ 2)
+      (π ^ 2 / 24 + ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 2) := by
+    refine HasSum.even_add_odd ?_ ?_
+    · exact hasSum_even_zeta_two
+    · exact hodd_summable.hasSum
+  have hsum_eq : π ^ 2 / 24 + ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 2 = π ^ 2 / 6 :=
+    hkey.unique hasSum_zeta_two
+  have hval : ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 2 = π ^ 2 / 8 := by linarith
+  rw [← hval]
+  exact hodd_summable.hasSum
+
+/-- **Dirichlet eta value η(2)**: `∑ (-1)^(n+1)/n² = π²/12`, as a `HasSum`. -/
+theorem hasSum_eta_two : HasSum etaSummand (π ^ 2 / 12) := by
+  -- Even-indexed part: (-1)^(2k+1)/(2k)² = -1/(2k)², summing to -π²/24.
+  have ha_even : HasSum (fun k : ℕ => etaSummand (2 * k)) (-(π ^ 2 / 24)) := by
+    have hfe : (fun k : ℕ => etaSummand (2 * k))
+        = (fun k : ℕ => -(1 / ((2 * k : ℕ) : ℝ) ^ 2)) := by
+      funext k
+      simp only [etaSummand]
+      rw [Odd.neg_one_pow (⟨k, by ring⟩ : Odd (2 * k + 1))]
+      ring
+    rw [hfe]; exact hasSum_even_zeta_two.neg
+  -- Odd-indexed part: (-1)^(2k+2)/(2k+1)² = 1/(2k+1)², summing to π²/8.
+  have ha_odd : HasSum (fun k : ℕ => etaSummand (2 * k + 1)) (π ^ 2 / 8) := by
+    have hfo : (fun k : ℕ => etaSummand (2 * k + 1))
+        = (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 2) := by
+      funext k
+      simp only [etaSummand]
+      rw [Even.neg_one_pow (⟨k + 1, by ring⟩ : Even (2 * k + 1 + 1))]
+    rw [hfo]; exact hasSum_odd_zeta_two
+  have ha : HasSum etaSummand (-(π ^ 2 / 24) + π ^ 2 / 8) :=
+    HasSum.even_add_odd ha_even ha_odd
+  have hval : -(π ^ 2 / 24) + π ^ 2 / 8 = π ^ 2 / 12 := by ring
+  rwa [hval] at ha
+
+/-- **Dirichlet eta value η(2)** in `tsum` form: `∑' n, (-1)^(n+1)/n² = π²/12`. -/
+theorem tsum_eta_two : ∑' n : ℕ, (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ 2 = π ^ 2 / 12 :=
+  hasSum_eta_two.tsum_eq
+
+end BaselEtaTwo
+
+/-
+  ## Summary
+
+  | Result | Statement |
+  |--------|-----------|
+  | `hasSum_even_zeta_two` | ∑ 1/(2k)² = π²/24 |
+  | `hasSum_odd_zeta_two`  | ∑ 1/(2k+1)² = π²/8 |
+  | `hasSum_eta_two`       | ∑ (-1)^(n+1)/n² = π²/12 (HasSum) |
+  | `tsum_eta_two`         | ∑' n, (-1)^(n+1)/n² = π²/12 |
+
+  Built entirely from Mathlib's `hasSum_zeta_two` (ζ(2) = π²/6) and the even/odd
+  series split `HasSum.even_add_odd`.
+
+  **Sorries**: 0
+  **Axioms**: 0
+-/

--- a/src/data/proofs/basel-problem-oq-11/meta.json
+++ b/src/data/proofs/basel-problem-oq-11/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "basel-problem-oq-11",
+  "title": "Dirichlet eta at 2: ∑ (-1)^(n+1)/n² = π²/12",
+  "slug": "basel-problem-oq-11",
+  "description": "Formalizes the Dirichlet eta value η(2) = ∑_{n≥1} (-1)^(n+1)/n² = π²/12, the alternating companion of the Basel sum ζ(2) = π²/6. The proof specializes Mathlib's hasSum_zeta_two through the parity identity η(2) = (1/2)ζ(2): split the series into even- and odd-indexed parts with HasSum.even_add_odd, evaluate the even part as -(1/4)ζ(2) = -π²/24 and the odd part (the odd-square sum ∑ 1/(2k+1)² = π²/8, itself recovered from ζ(2) minus its even part), and combine to -π²/24 + π²/8 = π²/12. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ11.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "series",
+      "zeta-function",
+      "dirichlet-eta",
+      "basel-problem",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 114,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "dateAdded": "2026-06-19",
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_two",
+        "description": "The Basel sum: HasSum (fun n => 1/n²) (π²/6)",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "HasSum.even_add_odd",
+        "description": "Combine the even- and odd-indexed subseries into the full sum",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "Summable.comp_injective",
+        "description": "Summability of the odd-indexed subseries from summability of ζ(2)",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "Odd.neg_one_pow / Even.neg_one_pow",
+        "description": "(-1)^n = -1 for n odd and 1 for n even, fixing the alternating signs",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "hasSum_even_zeta_two: ∑_k 1/(2k)² = π²/24 (quarter of ζ(2) via reindexing)",
+      "hasSum_odd_zeta_two: ∑_k 1/(2k+1)² = π²/8 (odd-square Basel sum) derived from ζ(2) minus its even part by HasSum.even_add_odd + HasSum.unique",
+      "hasSum_eta_two / tsum_eta_two: η(2) = ∑ (-1)^(n+1)/n² = π²/12 via the even/odd split of the alternating series"
+    ],
+    "prerequisites": [
+      "Basel problem ζ(2) = π²/6 (Mathlib hasSum_zeta_two)",
+      "Even/odd splitting of an infinite sum (HasSum.even_add_odd)",
+      "Uniqueness of sums (HasSum.unique)"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ZetaValues",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Real"],
+    "namespace": "BaselEtaTwo",
+    "path": "Proofs/BaselProblemOQ11.lean",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "Euler solved the Basel problem ζ(2) = ∑ 1/n² = π²/6 in 1734. The alternating variant η(2) = ∑ (-1)^(n+1)/n² is the value at 2 of the Dirichlet eta function η(s) = ∑ (-1)^(n+1)/n^s, the alternating ('eta') counterpart of ζ. The functional relation η(s) = (1 - 2^(1-s))ζ(s) — which analytically continues ζ across the line Re s = 1 — gives η(2) = (1 - 1/2)ζ(2) = π²/12 at the integer point s = 2. This entry formalizes exactly that special value, reusing Mathlib's machine-checked ζ(2) = π²/6.",
+    "problemStatement": "Formalize, with 0 sorries and 0 axioms, the Dirichlet eta value\n\n$$\\eta(2) = \\sum_{n=1}^{\\infty} \\frac{(-1)^{n+1}}{n^2} = \\frac{\\pi^2}{12},$$\n\nby specializing Mathlib's `hasSum_zeta_two` (ζ(2) = π²/6) through the parity split η(2) = (1/2)ζ(2).",
+    "text": "The alternating Basel sum: the Dirichlet eta value η(2) = π²/12, obtained from Mathlib's ζ(2) = π²/6 by separating even- and odd-indexed terms.",
+    "proofStrategy": "Three HasSum lemmas. (1) hasSum_even_zeta_two: rewrite 1/(2k)² = (1/4)(1/k²) and scale ζ(2) by 1/4 to get π²/24. (2) hasSum_odd_zeta_two: the odd subseries is summable (Summable.comp_injective with k ↦ 2k+1), so reassembling ζ(2) = even + odd via HasSum.even_add_odd and applying HasSum.unique against hasSum_zeta_two forces the odd sum to π²/6 - π²/24 = π²/8. (3) hasSum_eta_two: for the alternating summand, the even-indexed terms are -1/(2k)² (Odd.neg_one_pow) summing to -π²/24, the odd-indexed terms are 1/(2k+1)² (Even.neg_one_pow) summing to π²/8; HasSum.even_add_odd combines them and -π²/24 + π²/8 = π²/12.",
+    "keyInsights": [
+      "**η(2) = (1/2)ζ(2) is the s = 2 case of η(s) = (1 - 2^(1-s))ζ(s).** The whole proof is the constructive content of that identity at a single point: the factor 1 - 2^(1-2) = 1/2 appears as -1/4 (even part) + (3/4 of ζ via the odd part), netting half of ζ(2).",
+      "**The even-indexed subseries is a scaled copy of ζ(2).** Since 1/(2k)² = (1/4)(1/k²), the even part is exactly (1/4)ζ(2) = π²/24 — a one-line HasSum.mul_left after a `ring` rewrite (valid even at k = 0 where both sides are 0 in ℝ).",
+      "**The odd-square sum π²/8 falls out for free.** Rather than proving ∑ 1/(2k+1)² = π²/8 from scratch, reassemble ζ(2) from its even and odd halves and use uniqueness of sums: π²/24 + (odd) = π²/6 ⟹ (odd) = π²/8. This reuses the same even/odd machinery twice.",
+      "**HasSum.even_add_odd needs a named summand for higher-order unification.** Defining `etaSummand` as a top-level function lets `HasSum.even_add_odd ha_even ha_odd` infer f := etaSummand from the pattern `f (2*k)`; an inline lambda would block the unification.",
+      "**Signs are pinned by parity, not case-split.** (-1)^(2k+1) = -1 (Odd.neg_one_pow) and (-1)^(2k+2) = 1 (Even.neg_one_pow) convert the alternating numerators into the two fixed-sign subseries — no per-term case analysis."
+    ],
+    "prerequisites": [
+      "Basel problem ζ(2) = π²/6",
+      "Dirichlet eta function and η(s) = (1 - 2^(1-s))ζ(s)",
+      "Even/odd decomposition of infinite sums",
+      "HasSum / tsum API in Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header, Imports, and the Eta Summand",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Documents the η(2) = (1/2)ζ(2) parity split; imports Mathlib's ZetaValues (for hasSum_zeta_two); defines the alternating summand etaSummand n = (-1)^(n+1)/n².",
+      "mathContext": "η(2) is the value at 2 of the Dirichlet eta function, the alternating companion of ζ."
+    },
+    {
+      "id": "even-part",
+      "title": "hasSum_even_zeta_two — ∑ 1/(2k)² = π²/24",
+      "startLine": 40,
+      "endLine": 52,
+      "summary": "Rewrites 1/(2k)² = (1/4)(1/k²) and scales ζ(2) by 1/4.",
+      "mathContext": "The even-indexed Basel terms form a quarter-scaled copy of ζ(2)."
+    },
+    {
+      "id": "odd-part",
+      "title": "hasSum_odd_zeta_two — ∑ 1/(2k+1)² = π²/8",
+      "startLine": 54,
+      "endLine": 73,
+      "summary": "Odd subseries summable via comp_injective; reassemble ζ(2) = even + odd and use HasSum.unique to pin the odd sum to π²/8.",
+      "mathContext": "The odd-square Basel sum, recovered as ζ(2) minus its even part."
+    },
+    {
+      "id": "eta",
+      "title": "hasSum_eta_two / tsum_eta_two — η(2) = π²/12",
+      "startLine": 75,
+      "endLine": 96,
+      "summary": "Even-indexed alternating terms sum to -π²/24, odd-indexed to π²/8; HasSum.even_add_odd combines to π²/12, with a tsum corollary.",
+      "mathContext": "The Dirichlet eta value η(2) = (1/2)ζ(2) = π²/12."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Dirichlet eta value η(2) = ∑ (-1)^(n+1)/n² = π²/12 is formalized with 0 axioms and 0 sorries, built from Mathlib's ζ(2) = π²/6 by the even/odd parity split. The proof packages the even-indexed Basel sum (π²/24), the odd-indexed Basel sum (π²/8), and the alternating value (π²/12) as three reusable HasSum lemmas.",
+    "implications": "Completes the standard pair (ζ(2), η(2)) of Basel-type sums in the gallery and demonstrates the HasSum.even_add_odd splitting idiom for alternating series. The same template — even part = scaled ζ, odd part by uniqueness, signs by parity — applies directly to η(4) = 7π⁴/720 from ζ(4) = π⁴/90, and to the Catalan/Leibniz-type alternating sums.",
+    "openQuestions": [
+      {
+        "id": "basel-problem-oq-11-oq-01",
+        "question": "Generalize the even/odd parity split to a reusable lemma η(2m) = (1 - 2^(1-2m)) ζ(2m) for all even arguments, deriving η(4) = 7π⁴/720 from Mathlib's hasSum_zeta_four with no new analytic input.",
+        "significance": "medium"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem",
+      "relationship": "extends",
+      "description": "Root Basel entry ζ(2) = π²/6; this is the alternating (Dirichlet eta) companion η(2) = π²/12."
+    }
+  ],
+  "references": [
+    {
+      "title": "Introductio in analysin infinitorum",
+      "author": "Leonhard Euler",
+      "year": "1748",
+      "description": "Euler's evaluation of ζ(2) and related series; the alternating eta values follow from the same Fourier/zeta machinery."
+    },
+    {
+      "title": "Riemann's Zeta Function",
+      "author": "Harold M. Edwards",
+      "year": "1974",
+      "venue": "Academic Press",
+      "description": "Develops the Dirichlet eta function η(s) = (1 - 2^(1-s))ζ(s) as the alternating series used to continue ζ past Re s = 1."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "basel-problem-oq-11-oq-01",
+      "question": "Generalize the even/odd parity split to η(2m) = (1 - 2^(1-2m)) ζ(2m) and derive η(4) = 7π⁴/720 from hasSum_zeta_four.",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **Dirichlet eta value** η(2) = ∑_{n≥1} (-1)^(n+1)/n² = π²/12, the
alternating companion of the Basel sum ζ(2) = π²/6, by specializing Mathlib's
`hasSum_zeta_two` through the parity identity η(2) = (1/2)ζ(2).

## New entry (verified, 0 sorries, 0 axioms)

`proofs/Proofs/BaselProblemOQ11.lean`
- `hasSum_even_zeta_two` — ∑ 1/(2k)² = π²/24 (a quarter of ζ(2))
- `hasSum_odd_zeta_two` — ∑ 1/(2k+1)² = π²/8 (ζ(2) minus its even part, via `HasSum.unique`)
- `hasSum_eta_two` / `tsum_eta_two` — ∑ (-1)^(n+1)/n² = π²/12

The alternating series is split into even/odd parts with `HasSum.even_add_odd`;
signs are pinned by `Odd.neg_one_pow` / `Even.neg_one_pow`. No new analytic input
beyond Mathlib's ζ(2).

## Verification

```
'BaselEtaTwo.hasSum_eta_two' depends on axioms: [propext, Classical.choice, Quot.sound]
'BaselEtaTwo.tsum_eta_two'   depends on axioms: [propext, Classical.choice, Quot.sound]
```
Compiles via `lake env lean`.

## Status
**Outcome**: completed (new verified gallery entry)
**Next**: generalize the parity split to η(2m) = (1 - 2^(1-2m))ζ(2m), deriving η(4) = 7π⁴/720 from `hasSum_zeta_four`.

🤖 Generated by researcher-1