### PR TITLE
research(cantor-diagonalization-oq-06): the reals are uncountable

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -413,6 +413,7 @@ import Proofs.CantorDiagonalizationOQ04OQ01
 import Proofs.CantorDiagonalizationOQ04OQ01OQ03
 import Proofs.CantorDiagonalizationOQ04OQ03
 import Proofs.CantorDiagonalizationOQ04OQ03Aristotle
+import Proofs.CantorDiagonalizationOQ06
 import Proofs.CantorsTheorem
 import Proofs.CantorsTheoremOQ01
 import Proofs.CantorsTheoremOQ01OQ01

--- a/proofs/Proofs/CantorDiagonalizationOQ06.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ06.lean
@@ -1,0 +1,52 @@
+/-
+# Cantor Diagonalization OQ-06: the reals are uncountable
+
+## Open Question
+Formalize `¬ Countable ℝ` (equivalently: there is no surjection `ℕ → ℝ`), via Mathlib's
+`Cardinal.not_countable_real`, or by transporting Cantor's theorem through
+`Cardinal.mk_real`.
+
+## Approach
+Cantor's 1874 diagonal argument shows the reals cannot be enumerated. Mathlib packages
+this as `Cardinal.not_countable_real : ¬ (Set.univ : Set ℝ).Countable` (proved via the
+binary-expansion injection `{0,1}^ℕ ↪ ℝ`, so `#ℝ = 𝔠 = 2^ℵ₀ > ℵ₀`). This entry lifts it
+to the type-level statement `¬ Countable ℝ`, derives the concrete "no surjection from ℕ"
+form, and records the continuum cardinality `#ℝ = 𝔠` together with `ℵ₀ < #ℝ`.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace CantorDiagonalizationOQ06
+
+open Cardinal
+
+/-- The universal set of reals is not countable (Mathlib's `Cardinal.not_countable_real`). -/
+theorem not_countable_univ_real : ¬ (Set.univ : Set ℝ).Countable :=
+  Cardinal.not_countable_real
+
+/-- **The reals are uncountable**, as a statement about the type `ℝ`:
+there is no countable enumeration of `ℝ`. -/
+theorem not_countable_real : ¬ Countable ℝ :=
+  fun h => Cardinal.not_countable_real (Set.countable_univ_iff.mpr h)
+
+/-- The reals carry the `Uncountable` typeclass. -/
+theorem uncountable_real : Uncountable ℝ :=
+  Set.not_countable_univ_iff.mp Cardinal.not_countable_real
+
+/-- **No surjection `ℕ → ℝ`.** Cantor's theorem in its enumeration form: the reals cannot
+be listed by the naturals.  A surjection from the (countable) naturals would make `ℝ`
+countable, contradicting `not_countable_real`. -/
+theorem not_surjective_nat_real (f : ℕ → ℝ) : ¬ Function.Surjective f :=
+  fun hf => not_countable_real hf.countable
+
+/-- The reals have cardinality the continuum, `#ℝ = 𝔠` (Mathlib's `Cardinal.mk_real`). -/
+theorem mk_real_eq_continuum : #ℝ = 𝔠 :=
+  Cardinal.mk_real
+
+/-- `ℵ₀ < #ℝ`: the reals are strictly larger than the naturals — the quantitative form of
+uncountability. -/
+theorem aleph0_lt_mk_real : ℵ₀ < #ℝ := by
+  rw [mk_real_eq_continuum]; exact aleph0_lt_continuum
+
+end CantorDiagonalizationOQ06

--- a/src/data/proofs/cantor-diagonalization-oq-06/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-06/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "cantoroq06-header",
+    "proofId": "cantor-diagonalization-oq-06",
+    "range": {
+      "startLine": 1,
+      "endLine": 22
+    },
+    "type": "concept",
+    "title": "Module Header and Problem Setup",
+    "content": "The open question asks for $\\neg\\,\\mathrm{Countable}\\,\\mathbb{R}$ (equivalently, no surjection $\\mathbb{N} \\to \\mathbb{R}$). Cantor's 1874 result, sharpened by the 1891 diagonal argument, is formalized in Mathlib via the binary-expansion injection $\\{0,1\\}^{\\mathbb{N}} \\hookrightarrow \\mathbb{R}$, giving $\\#\\mathbb{R} = 2^{\\aleph_0} = \\mathfrak{c} > \\aleph_0$."
+  },
+  {
+    "id": "cantoroq06-uncountable",
+    "proofId": "cantor-diagonalization-oq-06",
+    "range": {
+      "startLine": 23,
+      "endLine": 44
+    },
+    "type": "theorem",
+    "title": "Uncountability of ℝ",
+    "content": "`not_countable_univ_real` re-exports Mathlib's `Cardinal.not_countable_real` (about `Set.univ`). `not_countable_real` lifts it to the type level via `Set.countable_univ_iff`, giving $\\neg\\,\\mathrm{Countable}\\,\\mathbb{R}$ as the open question requests; `uncountable_real` packages the `Uncountable ℝ` instance. `not_surjective_nat_real` is the enumeration form — Cantor's original statement — proved by noting a surjection from the countable naturals would force ℝ countable (`Function.Surjective.countable`)."
+  },
+  {
+    "id": "cantoroq06-cardinality",
+    "proofId": "cantor-diagonalization-oq-06",
+    "range": {
+      "startLine": 46,
+      "endLine": 52
+    },
+    "type": "theorem",
+    "title": "Continuum Cardinality",
+    "content": "`mk_real_eq_continuum` records $\\#\\mathbb{R} = \\mathfrak{c}$ (Mathlib's `Cardinal.mk_real`), and `aleph0_lt_mk_real` gives $\\aleph_0 < \\#\\mathbb{R}$ via `Cardinal.aleph0_lt_continuum` — the quantitative form of uncountability, exhibiting ℝ as a strictly larger infinity than ℕ."
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-06/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-06/meta.json
@@ -1,0 +1,154 @@
+{
+  "id": "cantor-diagonalization-oq-06",
+  "title": "The Reals Are Uncountable",
+  "slug": "cantor-diagonalization-oq-06",
+  "description": "¬ Countable ℝ — Cantor's theorem that the reals cannot be enumerated, lifted from Mathlib's Cardinal.not_countable_real to the type level, with the no-surjection-from-ℕ form and the continuum cardinality #ℝ = 𝔠 (so ℵ₀ < #ℝ).",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cantor%27s_diagonal_argument",
+    "date": "1874",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "cantor",
+      "uncountability",
+      "real-numbers",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CantorDiagonalizationOQ06.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.not_countable_real",
+        "description": "¬ (Set.univ : Set ℝ).Countable — the reals are uncountable",
+        "module": "Mathlib.Analysis.Real.Cardinality"
+      },
+      {
+        "theorem": "Cardinal.mk_real",
+        "description": "#ℝ = 𝔠, the reals have cardinality the continuum",
+        "module": "Mathlib.Analysis.Real.Cardinality"
+      },
+      {
+        "theorem": "Set.countable_univ_iff",
+        "description": "(Set.univ).Countable ↔ Countable α, bridging set- and type-level countability",
+        "module": "Mathlib.Data.Set.Countable"
+      },
+      {
+        "theorem": "Cardinal.aleph0_lt_continuum",
+        "description": "ℵ₀ < 𝔠, the continuum strictly exceeds the countable cardinal",
+        "module": "Mathlib.SetTheory.Cardinal.Continuum"
+      }
+    ],
+    "originalContributions": [
+      "not_countable_real: the type-level ¬ Countable ℝ (lifted from the Set.univ statement)",
+      "uncountable_real: the Uncountable ℝ typeclass statement",
+      "not_surjective_nat_real: no surjection ℕ → ℝ (the enumeration form of Cantor's theorem)",
+      "mk_real_eq_continuum: #ℝ = 𝔠",
+      "aleph0_lt_mk_real: ℵ₀ < #ℝ, the quantitative form of uncountability"
+    ],
+    "dateAdded": "2026-06-19",
+    "lineCount": 52,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "In 1874 Cantor proved that the real numbers cannot be put in bijection with the natural numbers — the first proof that infinities come in different sizes. His celebrated 1891 diagonal argument gave the cleanest form: given any list r₀, r₁, r₂, … of reals, construct a real differing from rₙ in its n-th digit, which therefore appears nowhere in the list. The same diagonal idea generalizes to Cantor's theorem (no surjection A → 𝒫(A)) and underlies Gödel's incompleteness, Turing's halting problem, and Russell's paradox. Mathlib formalizes the result through the binary-expansion injection {0,1}^ℕ ↪ ℝ, giving #ℝ = 2^ℵ₀ = 𝔠 > ℵ₀; the uncountability of ℝ is the cardinal inequality ℵ₀ < 𝔠.",
+    "problemStatement": "**Open Question (cantor-diagonalization-oq-06)**: Formalize ¬ Countable ℝ (equivalently, there is no surjection ℕ → ℝ), via Mathlib's Cardinal.not_countable_real or by transporting Cantor's theorem through #ℝ = 2^ℵ₀.\n\n**Result**: not_countable_real (¬ Countable ℝ), not_surjective_nat_real (no surjection ℕ → ℝ), uncountable_real (Uncountable ℝ), and the cardinality facts #ℝ = 𝔠 and ℵ₀ < #ℝ.",
+    "text": "¬ Countable ℝ — the reals are uncountable — with the no-surjection-from-ℕ form and the continuum cardinality #ℝ = 𝔠.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Mathlib's `Cardinal.not_countable_real` gives ¬ (Set.univ : Set ℝ).Countable. Bridge to the type level with `Set.countable_univ_iff` to obtain ¬ Countable ℝ; `Set.not_countable_univ_iff` gives the `Uncountable ℝ` instance.\n2. No surjection ℕ → ℝ: a surjection from the (countable) naturals would, by `Function.Surjective.countable`, force ℝ to be countable — contradiction.\n3. Cardinality: `Cardinal.mk_real` gives #ℝ = 𝔠, and `Cardinal.aleph0_lt_continuum` gives ℵ₀ < 𝔠, hence ℵ₀ < #ℝ.",
+    "keyInsights": [
+      "**Uncountability is a cardinal inequality.** ¬ Countable ℝ is exactly ℵ₀ < #ℝ; since #ℝ = 2^ℵ₀, this is Cantor's theorem #A < #𝒫(A) at A = ℕ.",
+      "**Set-level vs. type-level countability.** Mathlib states uncountability for Set.univ; `Set.countable_univ_iff` is the bridge to the type-level `Countable ℝ` the open question asks for.",
+      "**Enumeration form is a corollary.** 'No surjection ℕ → ℝ' is the diagonal statement in its original 1874 dress, immediate from countability being preserved under surjections from ℕ."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (Cardinal.mk, ℵ₀, 𝔠)",
+      "Countable / Uncountable typeclasses and Set.Countable",
+      "Cantor's theorem #A < #𝒫(A)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 22,
+      "summary": "Module docstring stating the open question and the binary-expansion route #ℝ = 2^ℵ₀, Mathlib import, namespace, and Cardinal open.",
+      "mathContext": "Cantor's diagonal argument: the reals are uncountable because $\\#\\mathbb{R} = 2^{\\aleph_0} = \\mathfrak{c} > \\aleph_0$."
+    },
+    {
+      "id": "uncountable",
+      "title": "Uncountability of ℝ",
+      "startLine": 23,
+      "endLine": 44,
+      "summary": "not_countable_univ_real (re-export), not_countable_real (type-level, via Set.countable_univ_iff), uncountable_real (the Uncountable typeclass), and not_surjective_nat_real (no surjection ℕ → ℝ).",
+      "mathContext": "$\\neg\\,\\mathrm{Countable}\\,\\mathbb{R}$, and equivalently no surjection $\\mathbb{N} \\to \\mathbb{R}$."
+    },
+    {
+      "id": "cardinality",
+      "title": "Continuum Cardinality",
+      "startLine": 46,
+      "endLine": 52,
+      "summary": "mk_real_eq_continuum (#ℝ = 𝔠) and aleph0_lt_mk_real (ℵ₀ < #ℝ), the quantitative form of uncountability.",
+      "mathContext": "$\\#\\mathbb{R} = \\mathfrak{c}$ and $\\aleph_0 < \\#\\mathbb{R}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "extends",
+      "description": "Applies the diagonal argument to its original target: the uncountability of the real numbers"
+    },
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "related",
+      "description": "Uncountability of ℝ is Cantor's theorem #A < #𝒫(A) at A = ℕ, since #ℝ = 2^ℵ₀ = #𝒫(ℕ)"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization that the reals are uncountable: the type-level ¬ Countable ℝ, the Uncountable ℝ instance, the enumeration form 'no surjection ℕ → ℝ', and the cardinality facts #ℝ = 𝔠 and ℵ₀ < #ℝ.",
+    "implications": "Establishes the foundational distinction between countable and uncountable infinity for ℝ. The diagonal method generalizes to Cantor's theorem, the undecidability of the halting problem, and Gödel's incompleteness theorems.",
+    "openQuestions": [
+      "Formalize a self-contained diagonal construction (an explicit real missing from a given list) rather than routing through cardinality.",
+      "Relate #ℝ = 𝔠 to the Continuum Hypothesis statements already in the gallery."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "CantorDiagonalizationOQ06",
+    "lineCount": 52,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/CantorDiagonalizationOQ06.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "The first proof that the reals are uncountable"
+    },
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine elementare Frage der Mannigfaltigkeitslehre",
+      "year": "1891",
+      "venue": "Jahresbericht der Deutschen Mathematiker-Vereinigung, vol. 1, pp. 75–78",
+      "note": "Introduces the diagonal argument in its now-standard form"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds `Proofs/CantorDiagonalizationOQ06.lean` and the gallery entry `cantor-diagonalization-oq-06`, formalizing that **the reals are uncountable**

```
¬ Countable ℝ
```

in the forms the open question asks for, via Mathlib's `Cardinal.not_countable_real`.

## Theorems

- **`not_countable_real`** — the type-level `¬ Countable ℝ`, lifted from Mathlib's set-level `Cardinal.not_countable_real` through `Set.countable_univ_iff`.
- **`uncountable_real`** — the `Uncountable ℝ` typeclass statement.
- **`not_surjective_nat_real`** — no surjection `ℕ → ℝ` (Cantor's diagonal argument in its original enumeration form): a surjection from the countable naturals would force ℝ countable.
- **`mk_real_eq_continuum`** — `#ℝ = 𝔠`; **`aleph0_lt_mk_real`** — `ℵ₀ < #ℝ`, the quantitative form of uncountability.

## Context

Cantor's 1874 theorem (sharpened by the 1891 diagonal argument) that ℝ cannot be enumerated. Mathlib proves it via the binary-expansion injection `{0,1}^ℕ ↪ ℝ`, giving `#ℝ = 2^ℵ₀ = 𝔠 > ℵ₀`. This entry packages the type-level statement, the enumeration form, and the cardinality facts. The diagonal method generalizes to Cantor's theorem, the halting problem, and Gödel incompleteness.

## Status

- **Sorry-free and axiom-free**: `#print axioms` on the named theorems = `[propext, Classical.choice, Quot.sound]` only.
- Verified by single-file `lake env lean` compile.
- Honest framing: a routine specialisation of existing Mathlib infrastructure (badge `mathlib`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)