### PR TITLE
research(basel-problem-oq-12): ζ(6) = π⁶/945

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -202,6 +202,7 @@ import Proofs.BaselProblemOQ04
 import Proofs.BaselProblemOQ04OQ03
 import Proofs.BaselProblemOQ05
 import Proofs.BaselProblemOQ08
+import Proofs.BaselProblemOQ12
 import Proofs.BertrandsPostulate
 import Proofs.BertrandsPostulateOQ03
 import Proofs.BertrandsPostulateOQ03OQ04

--- a/proofs/Proofs/BaselProblemOQ12.lean
+++ b/proofs/Proofs/BaselProblemOQ12.lean
@@ -1,0 +1,77 @@
+/-
+Basel Problem OQ-12: The sixth-power zeta value ζ(6) = π⁶/945
+
+  ∑_{n=1}^∞ 1/n⁶ = π⁶/945.
+
+This is the next Euler zeta value after ζ(2) = π²/6 and ζ(4) = π⁴/90.
+Euler's general formula is
+
+  ζ(2k) = (-1)^{k+1} · 2^{2k-1} · π^{2k} · B_{2k} / (2k)!,
+
+which Mathlib packages as `hasSum_zeta_nat`. Specialising at k = 3 reduces the
+problem to the single Bernoulli number B₆ = 1/42, which Mathlib does NOT provide
+(it stops at `bernoulli'_four`). The genuine new content of this entry is the
+evaluation `bernoulli'_six : bernoulli' 6 = 1/42`, computed from the defining
+recurrence `bernoulli'_def`; everything else is bookkeeping on top of
+`hasSum_zeta_nat`.
+
+  ζ(6) = (-1)⁴ · 2⁵ · π⁶ · B₆ / 6!
+       = 32 · π⁶ · (1/42) / 720
+       = 32 π⁶ / 30240
+       = π⁶ / 945.
+
+References:
+- Mathlib: Mathlib.NumberTheory.ZetaValues (`hasSum_zeta_nat`, `hasSum_zeta_four`)
+- Mathlib: Mathlib.NumberTheory.Bernoulli (`bernoulli'_def`, `bernoulli'_four`,
+  `bernoulli'_eq_zero_of_odd`, `bernoulli_eq_bernoulli'_of_ne_one`)
+-/
+
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.NumberTheory.Bernoulli
+import Mathlib.Tactic
+
+open Real
+
+namespace BaselProblemOQ12
+
+/-- The sixth Bernoulli number `B₆ = 1/42`, computed directly from the defining
+    recurrence `bernoulli'_def`. Mathlib only provides `bernoulli'_two`,
+    `bernoulli'_three`, `bernoulli'_four`, so this fills the gap needed for ζ(6).
+
+    The recurrence gives
+    `bernoulli' 6 = 1 - ∑_{k<6} C(6,k)/(6-k+1) · bernoulli' k`, and the inner sum
+    evaluates to `1/7 + 1/2 + 1/2 + 0 - 1/6 + 0 = 41/42`, so `bernoulli' 6 = 1/42`. -/
+theorem bernoulli'_six : bernoulli' 6 = 1 / 42 := by
+  have h5 : bernoulli' 5 = 0 := bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+  have c2 : Nat.choose 6 2 = 15 := by decide
+  have c3 : Nat.choose 6 3 = 20 := by decide
+  have c4 : Nat.choose 6 4 = 15 := by decide
+  have c5 : Nat.choose 6 5 = 6 := by decide
+  rw [bernoulli'_def]
+  norm_num [Finset.sum_range_succ, Finset.sum_range_zero, c2, c3, c4, c5, h5,
+    bernoulli'_zero, bernoulli'_one, bernoulli'_two, bernoulli'_three, bernoulli'_four]
+
+/-- The signed Bernoulli number `bernoulli 6 = 1/42` (equal to `bernoulli' 6`
+    since `6 ≠ 1`). -/
+theorem bernoulli_six : bernoulli 6 = 1 / 42 := by
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide), bernoulli'_six]
+
+/-- **ζ(6) = π⁶/945.** The sixth-power zeta value, as a `HasSum`.
+
+    Specialises Euler's general formula `hasSum_zeta_nat` at `k = 3` and plugs in
+    `bernoulli 6 = 1/42`. -/
+theorem hasSum_zeta_six :
+    HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 6) (π ^ 6 / 945) := by
+  convert hasSum_zeta_nat (k := 3) (by norm_num) using 1
+  norm_num [Nat.factorial, bernoulli_six]
+  ring
+
+/-- Summability of `∑ 1/n⁶` over `ℝ`. -/
+theorem summable_zeta_six : Summable (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 6) :=
+  hasSum_zeta_six.summable
+
+/-- The `tsum` form: `∑' n, 1/n⁶ = π⁶/945`. -/
+theorem tsum_zeta_six : ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 6 = π ^ 6 / 945 :=
+  hasSum_zeta_six.tsum_eq
+
+end BaselProblemOQ12

--- a/src/data/proofs/basel-problem-oq-12/meta.json
+++ b/src/data/proofs/basel-problem-oq-12/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "basel-problem-oq-12",
+  "title": "The Sixth-Power Zeta Value ζ(6) = π⁶/945",
+  "slug": "basel-problem-oq-12",
+  "description": "Euler's general zeta formula ζ(2k) = (-1)^{k+1}·2^{2k-1}·π^{2k}·B_{2k}/(2k)! at k = 3 gives ∑' n, 1/n⁶ = π⁶/945. The only missing ingredient beyond Mathlib's hasSum_zeta_nat is the Bernoulli number B₆ = 1/42, which this entry computes from the defining recurrence (Mathlib stops at bernoulli'_four).",
+  "meta": {
+    "author": "Leonhard Euler (1740), formalized via Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Riemann_zeta_function#Specific_values",
+    "date": "1740",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ12.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "zeta-values",
+      "bernoulli-numbers",
+      "infinite-series",
+      "euler"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_nat",
+        "description": "Euler's formula ζ(2k) = (-1)^{k+1}·2^{2k-1}·π^{2k}·B_{2k}/(2k)! as a HasSum, for k ≠ 0",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "bernoulli'_def",
+        "description": "Defining recurrence bernoulli' n = 1 - ∑_{k<n} C(n,k)/(n-k+1)·bernoulli' k",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli'_eq_zero_of_odd",
+        "description": "B'_n = 0 for odd n > 1 (used to discharge B₅ = 0 in the recurrence)",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli_eq_bernoulli'_of_ne_one",
+        "description": "bernoulli n = bernoulli' n for n ≠ 1, bridging the signed and unsigned conventions",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      }
+    ],
+    "originalContributions": [
+      "bernoulli'_six : bernoulli' 6 = 1/42 — computed from the defining recurrence bernoulli'_def; Mathlib only provides the explicit values up to bernoulli'_four, so this is the genuine gap filled",
+      "hasSum_zeta_six and tsum_zeta_six : ∑ 1/n⁶ = π⁶/945, the next Euler zeta value after ζ(2) = π²/6 and ζ(4) = π⁴/90, obtained by specialising hasSum_zeta_nat at k = 3",
+      "summable_zeta_six as a reusable summability witness for the sixth-power reciprocal series"
+    ],
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "lineCount": 77,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 2,
+    "trueStubs": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries; #print axioms reports only [propext, Classical.choice, Quot.sound].",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "After solving the Basel problem $\\zeta(2) = \\pi^2/6$ in 1734, **Leonhard Euler** went on to evaluate $\\zeta(2k)$ for all positive integers $k$, publishing the general formula $$\\zeta(2k) = \\frac{(-1)^{k+1} B_{2k} (2\\pi)^{2k}}{2\\,(2k)!}$$ around 1740 (*De seriebus quibusdam considerationes*). Here $B_{2k}$ are the Bernoulli numbers: $B_2 = 1/6$, $B_4 = -1/30$, $B_6 = 1/42$, $B_8 = -1/30$, and so on. The value $\\zeta(6) = \\pi^6/945$ is the third entry in this list. The appearance of $\\pi^{2k}$ shows every even zeta value is a rational multiple of a power of $\\pi$, hence transcendental — in stark contrast to the odd zeta values, whose arithmetic nature remains largely mysterious (only $\\zeta(3)$ is known to be irrational, by Apéry, 1978).",
+    "problemStatement": "**Theorem**: $$\\sum_{n=1}^{\\infty} \\frac{1}{n^6} = \\frac{\\pi^6}{945}.$$",
+    "proofStrategy": "Mathlib packages Euler's general formula as `hasSum_zeta_nat`: for $k \\neq 0$, $$\\sum_n \\frac{1}{n^{2k}} = (-1)^{k+1}\\, 2^{2k-1}\\, \\pi^{2k}\\, \\frac{B_{2k}}{(2k)!}.$$ Specialising at $k = 3$ gives $\\zeta(6) = (-1)^4 \\cdot 2^5 \\cdot \\pi^6 \\cdot B_6 / 6!$. Everything is then explicit except $B_6$.\n\n**The Bernoulli gap**: Mathlib supplies the explicit values `bernoulli'_two = 1/6`, `bernoulli'_three = 0`, `bernoulli'_four = -1/30`, but no `bernoulli'_six`. We compute it from the defining recurrence `bernoulli'_def`: expanding $\\mathrm{B}'_6 = 1 - \\sum_{k<6}\\binom{6}{k}/(7-k)\\,\\mathrm{B}'_k$, the inner sum is $\\tfrac17 + \\tfrac12 + \\tfrac12 + 0 - \\tfrac16 + 0 = \\tfrac{41}{42}$ (the $k=5$ term vanishes by `bernoulli'_eq_zero_of_odd`), so $B_6 = 1 - 41/42 = 1/42$.\n\n**Assembly**: With $B_6 = 1/42$, the formula evaluates to $32 \\cdot \\pi^6 \\cdot (1/42) / 720 = 32\\pi^6/30240 = \\pi^6/945$, closed by `norm_num` and `ring`.",
+    "keyInsights": [
+      "**The whole content is one Bernoulli number.** Once Euler's general formula (`hasSum_zeta_nat`) is in hand, computing ζ(6) reduces entirely to evaluating $B_6 = 1/42$ — Mathlib's explicit Bernoulli table stops at $B_4$, so this single recurrence computation is the only mathematical work.",
+      "**Even zeta values are rational multiples of π powers.** $\\zeta(2) = \\pi^2/6$, $\\zeta(4) = \\pi^4/90$, $\\zeta(6) = \\pi^6/945$ — the denominators $6, 90, 945$ encode $(2k)!/(2^{2k-1}|B_{2k}|)$ and grow with the Bernoulli numbers.",
+      "**The k=5 term vanishes for free.** In the recurrence for $B_6$, the contribution of $B_5$ is killed by `bernoulli'_eq_zero_of_odd` (all odd-index Bernoulli numbers beyond $B_1$ are zero) — a structural fact, not a computation.",
+      "**Signed vs. unsigned Bernoulli.** Mathlib's `hasSum_zeta_nat` uses the signed `bernoulli`, while the explicit values are stated for `bernoulli'`; `bernoulli_eq_bernoulli'_of_ne_one` bridges them since $6 \\neq 1$."
+    ],
+    "prerequisites": [
+      "Bernoulli numbers and their defining recurrence",
+      "Euler's formula for ζ(2k)",
+      "Convergence of p-series"
+    ]
+  },
+  "sections": [
+    {
+      "id": "bernoulli-six",
+      "title": "The Bernoulli Number B₆ = 1/42",
+      "startLine": 41,
+      "endLine": 56,
+      "summary": "bernoulli'_six and bernoulli_six: compute B₆ = 1/42 from the recurrence bernoulli'_def, the one value Mathlib's explicit table omits.",
+      "mathContext": "Expands the order-6 Bernoulli recurrence; the odd term B₅ vanishes by bernoulli'_eq_zero_of_odd, leaving an inner sum of 41/42."
+    },
+    {
+      "id": "zeta-six",
+      "title": "ζ(6) = π⁶/945",
+      "startLine": 58,
+      "endLine": 76,
+      "summary": "hasSum_zeta_six, summable_zeta_six, tsum_zeta_six: the sixth-power zeta value via hasSum_zeta_nat at k = 3 with B₆ = 1/42.",
+      "mathContext": "Specialises Euler's general zeta formula and evaluates the resulting rational coefficient 32/(42·720) = 1/945."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry adds ζ(6) = π⁶/945 to the gallery's family of Euler zeta values, with the genuinely new piece being the Bernoulli number B₆ = 1/42 computed from Mathlib's recurrence (its explicit table stops at B₄). The result is fully verified with 0 axioms.",
+    "implications": "The same template — hasSum_zeta_nat at parameter k together with an explicit B_{2k} — yields every even zeta value ζ(2k); the only obstacle for larger k is computing the corresponding Bernoulli number, each of which is a finite recurrence unfolding.",
+    "openQuestions": [
+      "Can ζ(8) = π⁸/9450 be obtained the same way by computing B₈ = -1/30 from the recurrence, and does the pattern of denominators 6, 90, 945, 9450 admit a clean closed form via (2k)!/(2^{2k-1}|B_{2k}|)?",
+      "Is there a uniform Lean lemma `bernoulli'_eval` that evaluates bernoulli' at an arbitrary numeral by `decide`/`norm_num`, removing the need to hand-compute each B_{2k} for the zeta family?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem",
+      "relationship": "foundation",
+      "description": "The original Basel problem ζ(2) = π²/6 (Wiedijk #14). This entry is the k = 3 case of the same Euler zeta formula."
+    },
+    {
+      "targetId": "basel-problem-oq-08",
+      "relationship": "sibling",
+      "description": "ζ(4) = π⁴/90, the k = 2 case; this entry is the next value ζ(6) in the family."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ZetaValues",
+      "Mathlib.NumberTheory.Bernoulli",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "BaselProblemOQ12",
+    "lineCount": 77,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/BaselProblemOQ12.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Adds **ζ(6) = π⁶/945** — the third even Euler zeta value, after ζ(2) = π²/6 and ζ(4) = π⁴/90 — to the gallery.

The proof specialises Mathlib's `hasSum_zeta_nat` (Euler's general formula `ζ(2k) = (-1)^{k+1}·2^{2k-1}·π^{2k}·B_{2k}/(2k)!`) at `k = 3`. The **only ingredient missing from Mathlib** is the Bernoulli number `B₆ = 1/42`: Mathlib's explicit Bernoulli table stops at `bernoulli'_four`. The new theorem `bernoulli'_six` computes it from the defining recurrence `bernoulli'_def`, with the odd-index term `B₅` discharged by `bernoulli'_eq_zero_of_odd`. The recurrence's inner sum is `1/7 + 1/2 + 1/2 + 0 − 1/6 + 0 = 41/42`, so `B₆ = 1 − 41/42 = 1/42`.

Assembling: `ζ(6) = (-1)⁴·2⁵·π⁶·(1/42)/6! = 32π⁶/30240 = π⁶/945`.

## Contents (`Proofs/BaselProblemOQ12.lean`, 77 lines)

- `bernoulli'_six : bernoulli' 6 = 1/42` — the genuine new content (fills Mathlib's gap)
- `bernoulli_six : bernoulli 6 = 1/42`
- `hasSum_zeta_six`, `summable_zeta_six`, `tsum_zeta_six : ∑' n, 1/n⁶ = π⁶/945`

## Verification

`#print axioms BaselProblemOQ12.tsum_zeta_six` → `[propext, Classical.choice, Quot.sound]` only. **0 axioms, 0 sorries** — `status: verified`, `badge: original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)