### PR TITLE
research(cauchy-schwarz-oq-06): equality case as linear dependence

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ06.lean
+++ b/proofs/Proofs/CauchySchwarzOQ06.lean
@@ -1,0 +1,166 @@
+/-
+  Cauchy-Schwarz Equality: The Linear-Dependence Characterization
+  Open Question: cauchy-schwarz-oq-06
+
+  The Cauchy-Schwarz inequality `‖⟪x, y⟫‖ ≤ ‖x‖ * ‖y‖` holds in every inner-product
+  space over `𝕜 = ℝ` or `ℂ`. This file characterizes EXACTLY when equality occurs:
+
+      ‖⟪x, y⟫‖ = ‖x‖ * ‖y‖   ↔   the pair {x, y} is linearly dependent.
+
+  Mathlib's `norm_inner_eq_norm_iff` already proves an equality case, but it requires
+  BOTH vectors to be nonzero and phrases proportionality asymmetrically as
+  `∃ r, y = r • x`. The contribution here is the fully UNCONDITIONAL and SYMMETRIC
+  statement in terms of `¬ LinearIndependent 𝕜 ![x, y]` — the standard textbook
+  formulation of "linearly dependent" — which automatically subsumes the degenerate
+  cases `x = 0` and `y = 0`.
+
+  We also record the sharp boundary form:
+
+      ‖⟪x, y⟫‖ < ‖x‖ * ‖y‖   ↔   {x, y} is linearly INDEPENDENT,
+
+  i.e. strict inequality is exactly the generic (independent) situation.
+
+  References:
+  - Cauchy (1821), Bunyakovsky (1859), Schwarz (1888): the inequality and its
+    equality case.
+  - Steele, "The Cauchy-Schwarz Master Class" (2004), Chapter 1.
+  - Mathlib `Mathlib/Analysis/InnerProductSpace/Basic.lean`:
+    `norm_inner_eq_norm_tfae`, `norm_inner_eq_norm_iff`, `norm_inner_le_norm`.
+-/
+
+import Mathlib
+
+namespace CauchySchwarzOQ06
+
+open scoped InnerProductSpace
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+-- ============================================================================
+-- Part I: Linear dependence of a pair, in explicit form
+-- ============================================================================
+
+/-- A pair of vectors fails to be linearly independent exactly when some nontrivial
+linear combination vanishes. This is `LinearIndependent.pair_iff` negated, repackaged
+into the convenient "exists a nonzero coefficient" shape. -/
+theorem not_linearIndependent_pair_iff (x y : E) :
+    ¬ LinearIndependent 𝕜 ![x, y] ↔
+      ∃ s t : 𝕜, (s ≠ 0 ∨ t ≠ 0) ∧ s • x + t • y = 0 := by
+  rw [LinearIndependent.pair_iff]
+  constructor
+  · intro h
+    rw [not_forall] at h
+    obtain ⟨s, h⟩ := h
+    rw [not_forall] at h
+    obtain ⟨t, h⟩ := h
+    rw [_root_.not_imp] at h
+    obtain ⟨hst, hnot⟩ := h
+    rw [not_and_or] at hnot
+    exact ⟨s, t, hnot, hst⟩
+  · rintro ⟨s, t, hne, hst⟩ hLI
+    obtain ⟨hs, ht⟩ := hLI s t hst
+    rcases hne with h | h
+    · exact h hs
+    · exact h ht
+
+-- ============================================================================
+-- Part II: The equality case of Cauchy-Schwarz
+-- ============================================================================
+
+/-- **Equality case of Cauchy-Schwarz (linear-dependence form).**
+
+For any two vectors `x y` in an inner-product space over `𝕜 = ℝ` or `ℂ`,
+
+    ‖⟪x, y⟫‖ = ‖x‖ * ‖y‖   ↔   ¬ LinearIndependent 𝕜 ![x, y].
+
+Unlike Mathlib's `norm_inner_eq_norm_iff`, this needs no nonzero hypotheses and is
+symmetric in `x` and `y`: the degenerate cases `x = 0` and `y = 0` are absorbed into
+the linear-dependence condition. -/
+theorem norm_inner_eq_norm_mul_iff_not_linearIndependent (x y : E) :
+    ‖⟪x, y⟫_𝕜‖ = ‖x‖ * ‖y‖ ↔ ¬ LinearIndependent 𝕜 ![x, y] := by
+  have key : ‖⟪x, y⟫_𝕜‖ = ‖x‖ * ‖y‖ ↔ x = 0 ∨ ∃ r : 𝕜, y = r • x :=
+    (norm_inner_eq_norm_tfae 𝕜 x y).out 0 2
+  rw [key, not_linearIndependent_pair_iff]
+  constructor
+  · rintro (rfl | ⟨r, rfl⟩)
+    · -- x = 0: the combination 1 • 0 + 0 • y = 0 witnesses dependence.
+      exact ⟨1, 0, Or.inl one_ne_zero, by simp⟩
+    · -- y = r • x: the combination r • x + (-1) • (r • x) = 0 witnesses dependence.
+      exact ⟨r, -1, Or.inr (neg_ne_zero.mpr one_ne_zero), by rw [neg_one_smul, add_neg_cancel]⟩
+  · rintro ⟨s, t, hne, hst⟩
+    rcases eq_or_ne t 0 with rfl | ht
+    · -- The `y` coefficient is zero, so `s ≠ 0` and `s • x = 0`, forcing `x = 0`.
+      have hs : s ≠ 0 := hne.resolve_right (by simp)
+      simp only [zero_smul, add_zero] at hst
+      exact Or.inl ((smul_eq_zero.mp hst).resolve_left hs)
+    · -- The `y` coefficient is nonzero, so `y` is the explicit multiple `(-(t⁻¹ s)) • x`.
+      right
+      have h1 : t • y = (-s) • x := by
+        rw [neg_smul, eq_neg_iff_add_eq_zero, add_comm]; exact hst
+      have h2 : (t⁻¹ * (-s)) • x = y := by
+        rw [mul_smul, ← h1, smul_smul, inv_mul_cancel₀ ht, one_smul]
+      exact ⟨t⁻¹ * (-s), h2.symm⟩
+
+/-- The equality case stated as an explicit vanishing combination (symmetric form). -/
+theorem norm_inner_eq_norm_mul_iff_exists (x y : E) :
+    ‖⟪x, y⟫_𝕜‖ = ‖x‖ * ‖y‖ ↔ ∃ s t : 𝕜, (s ≠ 0 ∨ t ≠ 0) ∧ s • x + t • y = 0 := by
+  rw [norm_inner_eq_norm_mul_iff_not_linearIndependent, not_linearIndependent_pair_iff]
+
+-- ============================================================================
+-- Part III: The sharp boundary — strict inequality is linear independence
+-- ============================================================================
+
+/-- **Sharp form of Cauchy-Schwarz.**
+
+Strict inequality `‖⟪x, y⟫‖ < ‖x‖ * ‖y‖` holds exactly when `x` and `y` are linearly
+independent. Together with the equality case this gives a complete dichotomy governed
+by linear (in)dependence. -/
+theorem norm_inner_lt_norm_mul_iff_linearIndependent (x y : E) :
+    ‖⟪x, y⟫_𝕜‖ < ‖x‖ * ‖y‖ ↔ LinearIndependent 𝕜 ![x, y] := by
+  rw [lt_iff_le_and_ne, and_iff_right (norm_inner_le_norm x y), ne_eq,
+    norm_inner_eq_norm_mul_iff_not_linearIndependent, not_not]
+
+-- ============================================================================
+-- Part IV: Real specialization (absolute value form)
+-- ============================================================================
+
+/-- The equality case over a real inner-product space, with the inner product's
+absolute value in place of its norm. -/
+theorem abs_real_inner_eq_norm_mul_iff_not_linearIndependent
+    {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] (x y : F) :
+    |⟪x, y⟫_ℝ| = ‖x‖ * ‖y‖ ↔ ¬ LinearIndependent ℝ ![x, y] := by
+  rw [← Real.norm_eq_abs]
+  exact norm_inner_eq_norm_mul_iff_not_linearIndependent x y
+
+/-- The real sharp form: strict inequality `|⟪x, y⟫| < ‖x‖ * ‖y‖` is linear independence. -/
+theorem abs_real_inner_lt_norm_mul_iff_linearIndependent
+    {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] (x y : F) :
+    |⟪x, y⟫_ℝ| < ‖x‖ * ‖y‖ ↔ LinearIndependent ℝ ![x, y] := by
+  rw [← Real.norm_eq_abs]
+  exact norm_inner_lt_norm_mul_iff_linearIndependent x y
+
+-- ============================================================================
+-- Part V: Sanity corollaries
+-- ============================================================================
+
+/-- Equality always holds when the left vector is zero (a degenerate case the
+nonzero-hypothesis form cannot state). -/
+theorem norm_inner_eq_norm_mul_left_zero (y : E) :
+    ‖⟪(0 : E), y⟫_𝕜‖ = ‖(0 : E)‖ * ‖y‖ := by
+  rw [norm_inner_eq_norm_mul_iff_not_linearIndependent]
+  -- ![0, y] is dependent: `1 • 0 + 0 • y = 0`.
+  rw [not_linearIndependent_pair_iff]
+  exact ⟨1, 0, Or.inl one_ne_zero, by simp⟩
+
+/-- Equality holds whenever `y` is a scalar multiple of `x`. -/
+theorem norm_inner_eq_norm_mul_of_smul (x : E) (r : 𝕜) :
+    ‖⟪x, r • x⟫_𝕜‖ = ‖x‖ * ‖r • x‖ := by
+  rw [norm_inner_eq_norm_mul_iff_not_linearIndependent, not_linearIndependent_pair_iff]
+  exact ⟨r, -1, Or.inr (neg_ne_zero.mpr one_ne_zero), by rw [neg_one_smul, add_neg_cancel]⟩
+
+#check @norm_inner_eq_norm_mul_iff_not_linearIndependent
+#check @norm_inner_lt_norm_mul_iff_linearIndependent
+#check @abs_real_inner_eq_norm_mul_iff_not_linearIndependent
+
+end CauchySchwarzOQ06

--- a/src/data/proofs/cauchy-schwarz-oq-06/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-06/meta.json
@@ -1,0 +1,174 @@
+{
+  "id": "cauchy-schwarz-oq-06",
+  "title": "Cauchy-Schwarz Equality: The Linear-Dependence Characterization",
+  "slug": "cauchy-schwarz-oq-06",
+  "description": "The equality case of Cauchy-Schwarz, stated unconditionally and symmetrically: for vectors x, y in any real or complex inner-product space, ‖⟪x,y⟫‖ = ‖x‖·‖y‖ holds iff {x,y} is linearly dependent (¬ LinearIndependent 𝕜 ![x,y]). Dually, strict inequality holds iff {x,y} is linearly independent. Subsumes the degenerate cases x=0, y=0 that Mathlib's nonzero-hypothesis form cannot state.",
+  "meta": {
+    "author": "Cauchy, Bunyakovsky, Schwarz (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cauchy%E2%80%93Schwarz_inequality",
+    "date": "1821",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "inner-product-spaces",
+      "cauchy-schwarz",
+      "equality-case",
+      "linear-dependence",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ06.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "norm_inner_eq_norm_tfae",
+        "description": "TFAE giving ‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ x = 0 ∨ ∃ r, y = r • x",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "norm_inner_le_norm",
+        "description": "The Cauchy-Schwarz inequality ‖⟪x,y⟫‖ ≤ ‖x‖·‖y‖",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "LinearIndependent.pair_iff",
+        "description": "LinearIndependent ![x,y] ↔ ∀ s t, s•x+t•y=0 → s=0 ∧ t=0",
+        "module": "Mathlib.LinearAlgebra.LinearIndependent.Lemmas"
+      },
+      {
+        "theorem": "inv_mul_cancel₀",
+        "description": "Cancellation t⁻¹ * t = 1 for nonzero scalar t",
+        "module": "Mathlib.Algebra.Group.Basic"
+      }
+    ],
+    "originalContributions": [
+      "not_linearIndependent_pair_iff: linear dependence of a pair as an explicit nontrivial vanishing combination ∃ s t, (s≠0 ∨ t≠0) ∧ s•x+t•y=0",
+      "norm_inner_eq_norm_mul_iff_not_linearIndependent: the equality case ‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ ¬ LinearIndependent 𝕜 ![x,y] — unconditional and symmetric, unlike Mathlib's nonzero-hypothesis norm_inner_eq_norm_iff",
+      "norm_inner_eq_norm_mul_iff_exists: the same equality case as an explicit symmetric vanishing combination",
+      "norm_inner_lt_norm_mul_iff_linearIndependent: the sharp boundary — strict inequality ‖⟪x,y⟫‖ < ‖x‖·‖y‖ ↔ LinearIndependent 𝕜 ![x,y]",
+      "abs_real_inner_eq_norm_mul_iff_not_linearIndependent / abs_real_inner_lt_norm_mul_iff_linearIndependent: real specializations in absolute-value form",
+      "norm_inner_eq_norm_mul_left_zero, norm_inner_eq_norm_mul_of_smul: degenerate-case sanity corollaries the nonzero-hypothesis form cannot express"
+    ],
+    "dateAdded": "2026-06-19",
+    "lineCount": 166,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries; all main theorems depend only on [propext, Classical.choice, Quot.sound].",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Cauchy-Schwarz inequality $|\\langle x,y\\rangle| \\leq \\|x\\|\\|y\\|$ traces to Cauchy's 1821 *Cours d'Analyse* (discrete sums), Bunyakovsky's 1859 integral version, and Schwarz's 1888 proof for square-integrable functions. Its equality case is classically stated as 'equality holds iff $x$ and $y$ are linearly dependent' — a clean, symmetric statement that treats the zero vector and proportional vectors on the same footing. Mathlib, however, proves the equality case in the asymmetric form $\\|\\langle x,y\\rangle\\| = \\|x\\|\\|y\\| \\iff \\exists r,\\ y = r\\cdot x$ under the hypothesis that both vectors are nonzero (`norm_inner_eq_norm_iff`). This entry closes that gap by proving the textbook linear-dependence formulation directly, with no side conditions.",
+    "problemStatement": "**Open Question (cauchy-schwarz-oq-06)**: Characterize the equality case of Cauchy-Schwarz, $\\|\\langle x,y\\rangle\\| = \\|x\\|\\|y\\|$, in terms of linear dependence, for arbitrary vectors (including the degenerate cases $x=0$, $y=0$).\n\n**Result**: $\\|\\langle x,y\\rangle\\| = \\|x\\|\\|y\\| \\iff \\neg\\,\\mathrm{LinearIndependent}\\ \\mathbb{K}\\ [x,y]$, and dually $\\|\\langle x,y\\rangle\\| < \\|x\\|\\|y\\| \\iff \\mathrm{LinearIndependent}\\ \\mathbb{K}\\ [x,y]$, over any $\\mathbb{K} \\in \\{\\mathbb{R},\\mathbb{C}\\}$.",
+    "text": "The equality case of Cauchy-Schwarz, stated unconditionally and symmetrically as linear dependence of the pair {x,y}, with the dual sharp form characterizing strict inequality as linear independence.",
+    "proofStrategy": "**Proof Strategy: bridge the Mathlib TFAE to linear dependence**\n\n1. **Unfold dependence.** From `LinearIndependent.pair_iff`, negate to get the explicit form $\\neg\\,\\mathrm{LinearIndependent}\\ \\mathbb{K}\\ [x,y] \\iff \\exists s\\,t,\\ (s\\neq 0 \\lor t\\neq 0) \\land s\\cdot x + t\\cdot y = 0$.\n2. **Invoke Mathlib's TFAE.** `norm_inner_eq_norm_tfae` gives $\\|\\langle x,y\\rangle\\| = \\|x\\|\\|y\\| \\iff (x = 0 \\lor \\exists r,\\ y = r\\cdot x)$, valid unconditionally.\n3. **Equate the two right-hand sides.** Forward: $x=0$ gives the combination $1\\cdot x + 0\\cdot y = 0$; $y = r\\cdot x$ gives $r\\cdot x + (-1)\\cdot y = 0$. Reverse: split on whether the $y$-coefficient $t$ is zero — if $t=0$ then $s\\neq 0$ forces $x=0$; if $t\\neq 0$ then $y = (-(t^{-1}s))\\cdot x$.\n4. **Sharp form.** Combine the equality case with `norm_inner_le_norm` via `lt_iff_le_and_ne`: strict inequality is exactly the negation of equality, i.e. linear independence.",
+    "keyInsights": [
+      "**Linear dependence is the right invariant.** Phrasing the equality case as $\\neg\\,\\mathrm{LinearIndependent}\\ \\mathbb{K}\\ [x,y]$ is symmetric in $x,y$ and automatically absorbs the degenerate cases $x=0$ and $y=0$, which Mathlib's $\\exists r,\\ y=r\\cdot x$ form must exclude by hypothesis.",
+      "**One TFAE entry does the analytic work.** All inner-product analysis is delegated to Mathlib's `norm_inner_eq_norm_tfae`; the new content is the purely linear-algebraic equivalence between 'one vector is a multiple of the other (or is zero)' and 'a nontrivial combination vanishes'.",
+      "**Equality and strict inequality are complementary.** Because Cauchy-Schwarz always gives $\\leq$, the equality case and the strict-inequality case partition every pair: dependent pairs saturate the bound, independent pairs fall strictly below it.",
+      "**The reverse direction is a field computation.** Recovering $y = r\\cdot x$ from a vanishing combination $s\\cdot x + t\\cdot y = 0$ with $t\\neq 0$ is exactly $y = (-(t^{-1}s))\\cdot x$, using only invertibility of nonzero scalars in $\\mathbb{R}$ or $\\mathbb{C}$."
+    ],
+    "prerequisites": [
+      "Inner product spaces over ℝ or ℂ (RCLike 𝕜, InnerProductSpace 𝕜 E in Mathlib)",
+      "The Cauchy-Schwarz inequality and its equality case",
+      "Linear independence of a pair of vectors (LinearIndependent 𝕜 ![x, y])"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "extends",
+      "description": "Recasts the base Cauchy-Schwarz equality characterization in the unconditional, symmetric language of linear dependence of the pair {x,y}."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-04",
+      "relationship": "related",
+      "description": "OQ-04 pins down the exact proportionality constant u = (⟪u,v⟫/‖v‖²)·v when equality holds (assuming v ≠ 0); this entry instead removes all nonzero hypotheses and characterizes equality as linear dependence over ℝ or ℂ."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-01",
+      "relationship": "related",
+      "description": "A sibling extension in the same Cauchy-Schwarz open-question family."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, unconditional, machine-checked characterization of the Cauchy-Schwarz equality case as linear dependence of the vector pair, over any real or complex inner-product space, together with the dual sharp form for strict inequality. Fully verified (0 sorries, 0 axioms).",
+    "implications": "The linear-dependence formulation is the form used throughout linear algebra and functional analysis: it is the criterion for when the Gram matrix of {x,y} is singular, when the parallelogram spanned by x and y degenerates, and when the angle between x and y is 0 or π. The sharp dual (strict inequality ↔ independence) is precisely the statement that the Gram determinant is positive for independent vectors.",
+    "openQuestions": [
+      "Extend the linear-dependence equality case to a finite family {x_1,…,x_n}: the Gram determinant vanishes iff the family is linearly dependent.",
+      "Connect the sharp form to Mathlib's Gram matrix / Gram determinant API, identifying strict Cauchy-Schwarz with positivity of the 2×2 Gram determinant."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "InnerProductSpace"
+    ],
+    "namespace": "CauchySchwarzOQ06",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ06.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "norm_inner_eq_norm_mul_iff_not_linearIndependent",
+      "type": "core",
+      "description": "**The headline result.** For any vectors x, y in an inner-product space over 𝕜 = ℝ or ℂ, ‖⟪x,y⟫‖ = ‖x‖·‖y‖ holds if and only if ¬ LinearIndependent 𝕜 ![x,y]. Unlike Mathlib's norm_inner_eq_norm_iff, this requires no nonzero hypotheses and is symmetric in x and y, absorbing the degenerate cases x=0 and y=0 into the linear-dependence condition.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] (x y : E), ‖⟪x, y⟫_𝕜‖ = ‖x‖ * ‖y‖ ↔ ¬ LinearIndependent 𝕜 ![x, y]"
+    },
+    {
+      "name": "norm_inner_lt_norm_mul_iff_linearIndependent",
+      "type": "core",
+      "description": "**The sharp boundary form.** Strict inequality ‖⟪x,y⟫‖ < ‖x‖·‖y‖ holds exactly when x and y are linearly independent. Proved by combining the equality case with the Cauchy-Schwarz inequality norm_inner_le_norm via lt_iff_le_and_ne. Together with the equality case this gives a complete dichotomy governed by linear (in)dependence.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] (x y : E), ‖⟪x, y⟫_𝕜‖ < ‖x‖ * ‖y‖ ↔ LinearIndependent 𝕜 ![x, y]"
+    },
+    {
+      "name": "not_linearIndependent_pair_iff",
+      "type": "supporting",
+      "description": "Linear dependence of a pair, repackaged: ¬ LinearIndependent 𝕜 ![x,y] ↔ ∃ s t, (s ≠ 0 ∨ t ≠ 0) ∧ s•x + t•y = 0. This is LinearIndependent.pair_iff negated into a convenient 'some nonzero coefficient' form, used by the equality-case proof.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] (x y : E), ¬ LinearIndependent 𝕜 ![x, y] ↔ ∃ s t : 𝕜, (s ≠ 0 ∨ t ≠ 0) ∧ s • x + t • y = 0"
+    },
+    {
+      "name": "norm_inner_eq_norm_mul_iff_exists",
+      "type": "supporting",
+      "description": "The equality case stated as an explicit symmetric vanishing combination: ‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ ∃ s t, (s ≠ 0 ∨ t ≠ 0) ∧ s•x + t•y = 0. A reformulation of the headline result that exposes the witnessing coefficients.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] (x y : E), ‖⟪x, y⟫_𝕜‖ = ‖x‖ * ‖y‖ ↔ ∃ s t : 𝕜, (s ≠ 0 ∨ t ≠ 0) ∧ s • x + t • y = 0"
+    },
+    {
+      "name": "abs_real_inner_eq_norm_mul_iff_not_linearIndependent",
+      "type": "core",
+      "description": "Real specialization in absolute-value form: over a real inner-product space, |⟪x,y⟫_ℝ| = ‖x‖·‖y‖ ↔ ¬ LinearIndependent ℝ ![x,y]. Obtained from the general result by rewriting the real norm as absolute value.",
+      "leanType": "∀ {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] (x y : F), |⟪x, y⟫_ℝ| = ‖x‖ * ‖y‖ ↔ ¬ LinearIndependent ℝ ![x, y]"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Cauchy, Augustin-Louis",
+      "title": "Cours d'Analyse de l'École Royale Polytechnique",
+      "year": "1821",
+      "venue": "Paris",
+      "note": "Original discrete inequality with the equality case recognized as proportionality (linear dependence) of the sequences."
+    },
+    {
+      "authors": "Schwarz, Hermann Amandus",
+      "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem der Variationsrechnung",
+      "year": "1888",
+      "venue": "Acta Societatis Scientiarum Fennicae",
+      "note": "Rigorous proof of the integral version; the equality case is the proportionality (linear dependence) condition."
+    },
+    {
+      "authors": "Halmos, Paul R.",
+      "title": "Finite-Dimensional Vector Spaces",
+      "year": "1958",
+      "venue": "Springer, Undergraduate Texts in Mathematics (2nd edition)",
+      "note": "Section 67: equality in Cauchy-Schwarz holds iff the vectors are linearly dependent — the abstract statement formalized in this entry."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the open question **cauchy-schwarz-oq-06**: characterize the equality case of Cauchy-Schwarz as linear dependence, unconditionally.

**Headline result** (over any `𝕜 ∈ {ℝ, ℂ}`):
```
‖⟪x, y⟫‖ = ‖x‖ * ‖y‖  ↔  ¬ LinearIndependent 𝕜 ![x, y]
```
**Sharp dual form:**
```
‖⟪x, y⟫‖ < ‖x‖ * ‖y‖  ↔  LinearIndependent 𝕜 ![x, y]
```

## What's new vs. Mathlib

Mathlib's `norm_inner_eq_norm_iff` proves an equality case but **requires both vectors nonzero** and phrases proportionality asymmetrically as `∃ r, y = r • x`. This entry proves the standard textbook **linear-dependence** form, which is symmetric in `x, y` and absorbs the degenerate cases `x = 0`, `y = 0`. The analytic content is delegated to Mathlib's `norm_inner_eq_norm_tfae`; the new work is the linear-algebra bridge (via `LinearIndependent.pair_iff`) plus the sharp strict-inequality dichotomy.

Also included: explicit-combination reformulation, real absolute-value specializations, and degenerate-case sanity corollaries.

## Verification

- Compiles against Mathlib v4.26.0 (`lake env lean`).
- **0 sorries, 0 axioms.** `#print axioms` on all main theorems: `[propext, Classical.choice, Quot.sound]` only.
- 8 theorems, 166 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)