### PR TITLE
research(cantor-diagonalization-oq-07): the continuum is multiplicatively idempotent #(ℝ×ℝ)=#ℝ (verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -414,6 +414,7 @@ import Proofs.CantorDiagonalizationOQ04OQ01OQ03
 import Proofs.CantorDiagonalizationOQ04OQ03
 import Proofs.CantorDiagonalizationOQ04OQ03Aristotle
 import Proofs.CantorDiagonalizationOQ06
+import Proofs.CantorDiagonalizationOQ07
 import Proofs.CantorsTheorem
 import Proofs.CantorsTheoremOQ01
 import Proofs.CantorsTheoremOQ01OQ01

--- a/proofs/Proofs/CantorDiagonalizationOQ07.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ07.lean
@@ -1,0 +1,60 @@
+/-
+# Cantor Diagonalization OQ-07: the continuum is multiplicatively idempotent, #(ℝ × ℝ) = #ℝ
+
+## Open Question
+Formalize `#(ℝ × ℝ) = #ℝ` (equivalently `𝔠 · 𝔠 = 𝔠`): the plane has the same
+cardinality as the line, via Mathlib's `Cardinal.mk_prod`, `Cardinal.mk_real`, and the
+infinite-cardinal multiplication theorem `Cardinal.continuum_mul_self` (a specialization
+of `Cardinal.mul_eq_self`).
+
+## Approach
+Where Cantor's diagonal argument (cantor-diagonalization-oq-06) shows ℝ is *strictly*
+larger than ℕ, the present companion shows the continuum is *stable* under products:
+doubling the dimension does not increase cardinality. `Cardinal.mk_prod` expands
+`#(ℝ × ℝ)` to `#ℝ * #ℝ`; `Cardinal.mk_real` rewrites each factor to `𝔠`; and
+`Cardinal.continuum_mul_self : 𝔠 * 𝔠 = 𝔠` (itself `mul_eq_self` at `ℵ₀ ≤ 𝔠`) collapses the
+product. The cardinal equality `#(ℝ × ℝ) = #ℝ` then unpacks, via `Cardinal.eq`, to an
+honest bijection `ℝ × ℝ ≃ ℝ`. As a corollary the complex plane `ℂ ≃ ℝ × ℝ` also has
+cardinality `#ℝ`.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace CantorDiagonalizationOQ07
+
+open Cardinal
+
+/-- The continuum is multiplicatively idempotent: `𝔠 · 𝔠 = 𝔠`. This is Mathlib's
+`Cardinal.continuum_mul_self`, the case `c = 𝔠` of `Cardinal.mul_eq_self` (any infinite
+cardinal absorbs self-multiplication, `ℵ₀ ≤ c → c * c = c`). It is the engine behind every
+statement below. -/
+theorem continuum_sq : (𝔠 : Cardinal) * 𝔠 = 𝔠 :=
+  Cardinal.continuum_mul_self
+
+/-- **`#(ℝ × ℝ) = 𝔠`.** The plane has cardinality the continuum: `Cardinal.mk_prod`
+expands the product to `#ℝ * #ℝ`, `Cardinal.mk_real` turns each factor into `𝔠`, and
+`continuum_sq` collapses `𝔠 * 𝔠` to `𝔠`. -/
+theorem mk_prod_real_eq_continuum : #(ℝ × ℝ) = 𝔠 := by
+  rw [mk_prod, lift_id, mk_real, continuum_sq]
+
+/-- **The plane and the line are equinumerous: `#(ℝ × ℝ) = #ℝ`.** Dimension does not raise
+cardinality — the companion to Cantor's diagonal result that ℝ strictly exceeds ℕ. Both
+sides equal `𝔠`. -/
+theorem mk_prod_real : #(ℝ × ℝ) = #ℝ := by
+  rw [mk_prod_real_eq_continuum, mk_real]
+
+/-- **An explicit bijection `ℝ × ℝ ≃ ℝ` exists.** The cardinal equality `#(ℝ × ℝ) = #ℝ`
+is, by `Cardinal.eq`, exactly the existence of a bijection between the plane and the line.
+(Classical / non-constructive: the witness comes from the cardinal-arithmetic proof, not an
+explicit pairing formula.) -/
+theorem nonempty_equiv_prod_real : Nonempty (ℝ × ℝ ≃ ℝ) :=
+  Cardinal.eq.mp mk_prod_real
+
+/-- **The complex plane has the cardinality of the real line: `#ℂ = #ℝ`.** Immediate from
+`ℂ ≃ ℝ × ℝ` (`Complex.equivRealProd`) and `#(ℝ × ℝ) = #ℝ`; equivalently from
+`Cardinal.mk_complex : #ℂ = 𝔠` and `Cardinal.mk_real : #ℝ = 𝔠`. -/
+theorem mk_complex_eq_mk_real : #ℂ = #ℝ := by
+  rw [mk_complex, mk_real]
+
+end CantorDiagonalizationOQ07

--- a/src/data/proofs/cantor-diagonalization-oq-07/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-07/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "cantoroq07-header",
+    "proofId": "cantor-diagonalization-oq-07",
+    "range": {
+      "startLine": 1,
+      "endLine": 26
+    },
+    "type": "concept",
+    "title": "Module Header and Problem Setup",
+    "content": "The open question asks for $\\#(\\mathbb{R} \\times \\mathbb{R}) = \\#\\mathbb{R}$, equivalently $\\mathfrak{c} \\cdot \\mathfrak{c} = \\mathfrak{c}$. Where Cantor's 1874 diagonal argument (cantor-diagonalization-oq-06) shows ℝ is *strictly* larger than ℕ, his surprising 1878 result shows the continuum is *stable* under products: the line and the plane are in bijection, so dimension does not change cardinality."
+  },
+  {
+    "id": "cantoroq07-engine",
+    "proofId": "cantor-diagonalization-oq-07",
+    "range": {
+      "startLine": 28,
+      "endLine": 33
+    },
+    "type": "theorem",
+    "title": "The Absorption Law 𝔠 · 𝔠 = 𝔠",
+    "content": "`continuum_sq` re-exports Mathlib's `Cardinal.continuum_mul_self`, which is the case $c = \\mathfrak{c}$ of `Cardinal.mul_eq_self` ($\\aleph_0 \\le c \\Rightarrow c \\cdot c = c$). This absorption law — every infinite cardinal is multiplicatively idempotent — is the only nontrivial ingredient, and is itself equivalent to the axiom of choice (Tarski). Every result below is a one-line specialization of it at the continuum."
+  },
+  {
+    "id": "cantoroq07-plane",
+    "proofId": "cantor-diagonalization-oq-07",
+    "range": {
+      "startLine": 35,
+      "endLine": 45
+    },
+    "type": "theorem",
+    "title": "The Plane Equals the Line",
+    "content": "`mk_prod_real_eq_continuum` computes $\\#(\\mathbb{R} \\times \\mathbb{R}) = \\mathfrak{c}$: `Cardinal.mk_prod` expands the product to $\\#\\mathbb{R} \\cdot \\#\\mathbb{R}$ (the universe lifts vanish by `Cardinal.lift_id`), `Cardinal.mk_real` rewrites each factor to $\\mathfrak{c}$, and `continuum_sq` collapses $\\mathfrak{c} \\cdot \\mathfrak{c}$ to $\\mathfrak{c}$. The main result `mk_prod_real` then reads off $\\#(\\mathbb{R} \\times \\mathbb{R}) = \\#\\mathbb{R}$ since both sides equal $\\mathfrak{c}$."
+  },
+  {
+    "id": "cantoroq07-bijection",
+    "proofId": "cantor-diagonalization-oq-07",
+    "range": {
+      "startLine": 47,
+      "endLine": 60
+    },
+    "type": "theorem",
+    "title": "Bijection and Complex Corollary",
+    "content": "`nonempty_equiv_prod_real` applies `Cardinal.eq` ($\\#\\alpha = \\#\\beta \\leftrightarrow \\mathrm{Nonempty}\\,(\\alpha \\simeq \\beta)$) to turn the cardinal equality into an honest bijection $\\mathbb{R} \\times \\mathbb{R} \\simeq \\mathbb{R}$ — Cantor's 1878 'line ≅ plane' map, recovered from the cardinal computation. `mk_complex_eq_mk_real` records the corollary $\\#\\mathbb{C} = \\#\\mathbb{R}$, immediate from $\\mathbb{C} \\simeq \\mathbb{R} \\times \\mathbb{R}$ (`Complex.equivRealProd`) or from `Cardinal.mk_complex`."
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-07/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-07/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "cantor-diagonalization-oq-07",
+  "title": "The Continuum Is Multiplicatively Idempotent: #(ℝ × ℝ) = #ℝ",
+  "slug": "cantor-diagonalization-oq-07",
+  "description": "#(ℝ × ℝ) = #ℝ — the plane has the same cardinality as the line (equivalently 𝔠 · 𝔠 = 𝔠). A companion to Cantor's diagonal results: where diagonalization makes ℝ strictly larger than ℕ, infinite-cardinal multiplication makes the continuum stable under products. Routes through Cardinal.mk_prod, Cardinal.mk_real, and Cardinal.continuum_mul_self, unpacks to an explicit bijection ℝ × ℝ ≃ ℝ, and yields #ℂ = #ℝ.",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cardinality_of_the_continuum",
+    "date": "1878",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "cantor",
+      "continuum",
+      "cardinal-arithmetic",
+      "real-numbers",
+      "complex-numbers",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CantorDiagonalizationOQ07.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.continuum_mul_self",
+        "description": "𝔠 * 𝔠 = 𝔠 — the continuum absorbs self-multiplication (the case c = 𝔠 of Cardinal.mul_eq_self)",
+        "module": "Mathlib.SetTheory.Cardinal.Continuum"
+      },
+      {
+        "theorem": "Cardinal.mul_eq_self",
+        "description": "ℵ₀ ≤ c → c * c = c — every infinite cardinal is multiplicatively idempotent; the engine behind continuum_mul_self",
+        "module": "Mathlib.SetTheory.Cardinal.Arithmetic"
+      },
+      {
+        "theorem": "Cardinal.mk_prod",
+        "description": "#(α × β) = lift #α * lift #β — cardinality of a product; lifts are identities in a single universe (Cardinal.lift_id)",
+        "module": "Mathlib.SetTheory.Cardinal.Defs"
+      },
+      {
+        "theorem": "Cardinal.mk_real",
+        "description": "#ℝ = 𝔠, the reals have cardinality the continuum",
+        "module": "Mathlib.Analysis.Real.Cardinality"
+      },
+      {
+        "theorem": "Cardinal.eq",
+        "description": "#α = #β ↔ Nonempty (α ≃ β) — a cardinal equality is exactly the existence of a bijection",
+        "module": "Mathlib.SetTheory.Cardinal.Defs"
+      },
+      {
+        "theorem": "Cardinal.mk_complex",
+        "description": "#ℂ = 𝔠, the complex numbers have cardinality the continuum (used with Complex.equivRealProd : ℂ ≃ ℝ × ℝ)",
+        "module": "Mathlib.Analysis.Complex.Cardinality"
+      }
+    ],
+    "originalContributions": [
+      "continuum_sq: 𝔠 · 𝔠 = 𝔠 re-exported as the engine of the entry",
+      "mk_prod_real_eq_continuum: #(ℝ × ℝ) = 𝔠, the plane has cardinality the continuum",
+      "mk_prod_real: #(ℝ × ℝ) = #ℝ, the plane and the line are equinumerous (main result)",
+      "nonempty_equiv_prod_real: Nonempty (ℝ × ℝ ≃ ℝ), the equality unpacked to an explicit bijection",
+      "mk_complex_eq_mk_real: #ℂ = #ℝ, the complex plane has the cardinality of the real line"
+    ],
+    "dateAdded": "2026-06-19",
+    "lineCount": 60,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Having shown in 1874 that ℝ is uncountable, Cantor asked whether higher-dimensional spaces are 'larger' still. In 1878 he proved the surprising opposite: there is a bijection between the line ℝ and the plane ℝ × ℝ (and indeed ℝⁿ), so dimension does not change cardinality. Dedekind, to whom Cantor wrote 'I see it, but I do not believe it', helped clarify the argument. In modern cardinal arithmetic this is the identity 𝔠 · 𝔠 = 𝔠, an instance of the general theorem that every infinite cardinal κ satisfies κ · κ = κ (a consequence of the axiom of choice, due to Hessenberg/Zermelo). It sits beside the gallery's diagonal results — uncountability of ℝ and the no-surjection theorem A → 𝒫(A) — as the 'stability' counterpart to their 'strict growth'.",
+    "problemStatement": "**Open Question (cantor-diagonalization-oq-07)**: Formalize #(ℝ × ℝ) = #ℝ (equivalently 𝔠 · 𝔠 = 𝔠), via Mathlib's Cardinal.mk_prod, Cardinal.mk_real, and Cardinal.continuum_mul_self.\n\n**Result**: mk_prod_real (#(ℝ × ℝ) = #ℝ), mk_prod_real_eq_continuum (#(ℝ × ℝ) = 𝔠), nonempty_equiv_prod_real (a bijection ℝ × ℝ ≃ ℝ), continuum_sq (𝔠 · 𝔠 = 𝔠), and the corollary mk_complex_eq_mk_real (#ℂ = #ℝ).",
+    "text": "#(ℝ × ℝ) = #ℝ — the plane and the line are equinumerous, so the continuum satisfies 𝔠 · 𝔠 = 𝔠. Dimension does not increase cardinality.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `continuum_sq` re-exports `Cardinal.continuum_mul_self : 𝔠 * 𝔠 = 𝔠`, the case c = 𝔠 of `Cardinal.mul_eq_self` (ℵ₀ ≤ c → c * c = c). This is the only nontrivial ingredient — the choice-dependent absorption law for infinite cardinals.\n2. `mk_prod_real_eq_continuum`: `Cardinal.mk_prod` rewrites #(ℝ × ℝ) to #ℝ * #ℝ (lifts vanish via `lift_id` in one universe), `Cardinal.mk_real` turns each factor into 𝔠, and `continuum_sq` collapses 𝔠 * 𝔠 to 𝔠.\n3. `mk_prod_real`: both #(ℝ × ℝ) and #ℝ equal 𝔠, so they are equal.\n4. `nonempty_equiv_prod_real`: `Cardinal.eq` turns the cardinal equality into the existence of a bijection ℝ × ℝ ≃ ℝ.\n5. `mk_complex_eq_mk_real`: `Cardinal.mk_complex` and `Cardinal.mk_real` both give 𝔠, so #ℂ = #ℝ (equivalently, transport ℂ ≃ ℝ × ℝ through step 3).",
+    "keyInsights": [
+      "**Stability vs. strict growth.** Diagonalization (oq-06) shows ℝ is strictly larger than ℕ (ℵ₀ < 𝔠); cardinal multiplication shows the continuum is *stable* under products (𝔠 · 𝔠 = 𝔠). Products do not grow an infinite cardinal; power sets do.",
+      "**A choice-dependent absorption law.** κ · κ = κ for every infinite κ is equivalent to the axiom of choice (Tarski). Mathlib's `Cardinal.mul_eq_self` supplies it; everything here is a one-line specialization at κ = 𝔠.",
+      "**Cardinal equality is a bijection.** `Cardinal.eq` makes #(ℝ × ℝ) = #ℝ literally the statement Nonempty (ℝ × ℝ ≃ ℝ) — Cantor's 1878 'line ≅ plane' bijection, recovered from the cardinal computation.",
+      "**The complex plane is no bigger than the line.** #ℂ = #ℝ falls out immediately, since ℂ ≃ ℝ × ℝ."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (Cardinal.mk, ℵ₀, 𝔠, multiplication)",
+      "The infinite-cardinal absorption law κ · κ = κ (Cardinal.mul_eq_self)",
+      "Cardinality of products and of ℝ (Cardinal.mk_prod, Cardinal.mk_real)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 26,
+      "summary": "Module docstring contrasting the diagonal 'strict growth' results with the present 'stability' result, the Mathlib import, namespace, and Cardinal open.",
+      "mathContext": "$\\#(\\mathbb{R} \\times \\mathbb{R}) = \\#\\mathbb{R}$, equivalently $\\mathfrak{c} \\cdot \\mathfrak{c} = \\mathfrak{c}$."
+    },
+    {
+      "id": "engine",
+      "title": "The Absorption Law 𝔠 · 𝔠 = 𝔠",
+      "startLine": 28,
+      "endLine": 33,
+      "summary": "continuum_sq: 𝔠 * 𝔠 = 𝔠, re-exporting Cardinal.continuum_mul_self (the c = 𝔠 case of Cardinal.mul_eq_self).",
+      "mathContext": "$\\mathfrak{c} \\cdot \\mathfrak{c} = \\mathfrak{c}$, the infinite-cardinal absorption law at the continuum."
+    },
+    {
+      "id": "plane",
+      "title": "The Plane Equals the Line",
+      "startLine": 35,
+      "endLine": 45,
+      "summary": "mk_prod_real_eq_continuum (#(ℝ × ℝ) = 𝔠) via mk_prod + mk_real + continuum_sq, and mk_prod_real (#(ℝ × ℝ) = #ℝ), the main result.",
+      "mathContext": "$\\#(\\mathbb{R} \\times \\mathbb{R}) = \\mathfrak{c} = \\#\\mathbb{R}$."
+    },
+    {
+      "id": "bijection",
+      "title": "Bijection and Complex Corollary",
+      "startLine": 47,
+      "endLine": 60,
+      "summary": "nonempty_equiv_prod_real (an explicit bijection ℝ × ℝ ≃ ℝ via Cardinal.eq) and mk_complex_eq_mk_real (#ℂ = #ℝ via ℂ ≃ ℝ × ℝ).",
+      "mathContext": "$\\mathbb{R} \\times \\mathbb{R} \\simeq \\mathbb{R}$ and $\\#\\mathbb{C} = \\#\\mathbb{R}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization-oq-06",
+      "relationship": "extends",
+      "description": "Companion to the uncountability of ℝ: there diagonalization gives ℵ₀ < 𝔠 (strict growth); here cardinal multiplication gives 𝔠 · 𝔠 = 𝔠 (stability under products)"
+    },
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "related",
+      "description": "Products leave the continuum fixed (𝔠 · 𝔠 = 𝔠), whereas Cantor's theorem #A < #𝒫(A) shows the power set strictly increases it"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization that #(ℝ × ℝ) = #ℝ: the continuum is multiplicatively idempotent (𝔠 · 𝔠 = 𝔠), the plane carries an explicit bijection to the line (ℝ × ℝ ≃ ℝ), and the complex plane has the same cardinality as the real line (#ℂ = #ℝ).",
+    "implications": "Pins down that dimension does not affect cardinality — the surprising 1878 companion to Cantor's diagonal theorems. The same absorption law κ · κ = κ underlies the stability of every infinite cardinal under finite (and countable) products.",
+    "openQuestions": [
+      "Formalize the n-fold and countable versions: #(ℝⁿ) = #ℝ and #(ℕ → ℝ) = 𝔠.",
+      "Exhibit a concrete interleaving-of-digits bijection ℝ × ℝ ≃ ℝ rather than routing through cardinal arithmetic."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "CantorDiagonalizationOQ07",
+    "lineCount": 60,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CantorDiagonalizationOQ07.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Ein Beitrag zur Mannigfaltigkeitslehre",
+      "year": "1878",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 84, pp. 242–258",
+      "note": "Proves the bijection between ℝ and ℝⁿ — dimension does not change cardinality"
+    },
+    {
+      "authors": "Jech, Thomas",
+      "title": "Set Theory",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics, 3rd ed.",
+      "note": "Theorem 5.20: κ · κ = κ for every infinite cardinal κ (equivalent to AC, Tarski)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **#(ℝ × ℝ) = #ℝ** (equivalently **𝔠 · 𝔠 = 𝔠**): the plane and the line are equinumerous. This is the *stability* companion to the gallery's Cantor diagonal results — where diagonalization (cantor-diagonalization-oq-06) makes ℝ *strictly* larger than ℕ (ℵ₀ < 𝔠), infinite-cardinal multiplication shows the continuum is *fixed* by products. Cantor's surprising 1878 theorem: dimension does not change cardinality.

## Theorems (`Proofs/CantorDiagonalizationOQ07.lean`)

| Theorem | Statement |
|---|---|
| `continuum_sq` | 𝔠 · 𝔠 = 𝔠 (re-export of `Cardinal.continuum_mul_self`, the engine) |
| `mk_prod_real_eq_continuum` | #(ℝ × ℝ) = 𝔠 |
| `mk_prod_real` | **#(ℝ × ℝ) = #ℝ** (main result) |
| `nonempty_equiv_prod_real` | Nonempty (ℝ × ℝ ≃ ℝ) — an explicit bijection, via `Cardinal.eq` |
| `mk_complex_eq_mk_real` | #ℂ = #ℝ — the complex plane has the cardinality of the line |

## Proof route

`Cardinal.mk_prod` expands #(ℝ × ℝ) to #ℝ · #ℝ (lifts vanish by `lift_id`), `Cardinal.mk_real` turns each factor into 𝔠, and `Cardinal.continuum_mul_self` (the c = 𝔠 case of `Cardinal.mul_eq_self`, ℵ₀ ≤ c → c·c = c) collapses 𝔠 · 𝔠. `Cardinal.eq` recovers the bijection; `Cardinal.mk_complex` + `Complex.equivRealProd` give the complex corollary.

## Verification

- 5 theorems, **0 sorries, 0 axioms**
- `#print axioms` on all five: `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`)
- Compiles against Mathlib 4.26.0 (`lake env lean`, 0 errors)
- Gallery data: `meta.json` (status `verified`, badge `mathlib`) + `annotations.json`; registered in `Proofs.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)