### PR TITLE
fix(lagrange-theorem-oq-02-oq-02-oq-01-oq-01): broken build — recovered corollary failed to synthesize Finite X

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01.lean
@@ -91,6 +91,14 @@ theorem sum_card_fixedBy_eq_card_orbits_mul_card_group_recovered
     [Fintype G] [∀ g : G, Fintype (fixedBy X g)] [Fintype (orbitRel.Quotient G X)] :
     ∑ g : G, Fintype.card (fixedBy X g)
       = Fintype.card (orbitRel.Quotient G X) * Fintype.card G := by
+  -- The `Finite X` instance needed by the generalised lemma is *derived*, not
+  -- assumed: with `Finite G` every orbit `orbit G x = Set.range (· • x)` is the
+  -- image of a finite type (hence finite), and there are finitely many orbits
+  -- (`Fintype (orbitRel.Quotient G X)`), so `X ≃ Σ ω, orbit …` is finite. This
+  -- keeps the recovered statement verbatim equal to the Mathlib `Fintype` form.
+  haveI : ∀ ω : orbitRel.Quotient G X, Finite (orbit G (Quotient.out ω)) :=
+    fun ω => (Set.finite_range _).to_subtype
+  haveI : Finite X := Finite.of_equiv _ (selfEquivSigmaOrbits G X).symm
   have h := sum_card_fixedBy_eq_card_orbits_mul_card_group_of_finite G X
   rw [finsum_eq_sum_of_fintype] at h
   simpa only [Nat.card_eq_fintype_card] using h


### PR DESCRIPTION
## Gallery integrity violation (auditor)

**Entry:** `lagrange-theorem-oq-02-oq-02-oq-01-oq-01` — *Burnside's Lemma over `Finite`*
**meta.json claims:** `status: verified`, `badge: mathlib`, `axiomCount: 0`, `sorries: 0`
**Actual:** the Lean file **does not compile**.

### The defect
`sum_card_fixedBy_eq_card_orbits_mul_card_group_recovered` derives Mathlib's
`Fintype` Burnside statement from the file's `Finite` generalisation
`…_of_finite G X`. But `…_of_finite` requires `[Finite X]`, while the recovered
theorem deliberately assumes only the three instances of the Mathlib lemma
(`Fintype G`, `∀ g, Fintype (fixedBy X g)`, `Fintype (orbitRel.Quotient G X)`) —
no `Finite X`. So Lean reports:

```
Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01.lean:94:12: error: failed to synthesize
  Finite X
```

### The fix
`Finite X` is now **derived inside the proof** instead of assumed, so the
recovered statement stays byte-for-byte equal to Mathlib's
`sum_card_fixedBy_eq_card_orbits_mul_card_group` (the whole point of the entry):

- with `Finite G`, every orbit `orbit G x = Set.range (· • x)` is the image of a
  finite type, hence finite;
- there are finitely many orbits (`Fintype (orbitRel.Quotient G X)`);
- `selfEquivSigmaOrbits` then exhibits `X ≃ Σ ω, orbit …` as finite.

### Verification
- `lake env lean Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01.lean` → exit 0, no errors.
- `#print axioms` on both `…_of_finite` and `…_recovered` → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`). Matches the `verified` / 0-axiom claim.
- `_recovered`'s signature is unchanged — still verbatim the Mathlib lemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)