### PR TITLE
research(quadratic-gauss-sum-square-oq-01): Parseval magnitude ‖g‖²=p, independent of the square identity

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2865,6 +2865,7 @@ import Proofs.PythagoreanTriplesOQ05
 import Proofs.QuadraticGaussSumDiagonal
 import Proofs.QuadraticGaussSumSquare
 import Proofs.QuadraticGaussSumSquareOQ01
+import Proofs.QuadraticGaussSumNormParseval
 import Proofs.QuadraticGaussSumSignReduction
 import Proofs.QuadraticGaussSumSignSmall
 import Proofs.QuadraticGaussSumSignSmallFive

--- a/proofs/Proofs/QuadraticGaussSumNormParseval.lean
+++ b/proofs/Proofs/QuadraticGaussSumNormParseval.lean
@@ -1,0 +1,79 @@
+/-
+  The magnitude `‖g‖² = p` of the quadratic Gauss sum, derived from character
+  orthogonality (Parseval) — independently of the square identity.
+
+  Background.  For an odd prime `p` and a primitive additive character
+  `ψ : ZMod p → ℂ`, write `g = gaussSum (chiC p) ψ` for the quadratic Gauss sum.
+  The entry `QuadraticGaussSumSquareOQ01` proves the magnitude `‖g‖² = p` as a
+  COROLLARY of the parent's square identity `g² = (-1)^((p-1)/2)·p`: applying the
+  multiplicative `Complex.normSq` to that identity gives `normSq(g)² = p²`, whence
+  `normSq g = p` by nonnegativity.  Its open question #3 asks whether the magnitude
+  can instead be obtained DIRECTLY from character orthogonality (Parseval), as an
+  independent cross-check that does not pass through the square identity.
+
+  This file answers that question affirmatively.  Mathlib's
+  `gaussSum_mul_gaussSum_eq_card` is exactly the Parseval/orthogonality statement
+      gaussSum χ ψ · gaussSum χ⁻¹ ψ⁻¹ = #(ZMod p)
+  for any nontrivial `χ` and primitive `ψ`.  Two elementary facts turn the left side
+  into `‖g‖²`:
+
+    * `gaussSum_conj`: complex-conjugating `g` replaces `ψ` by its inverse character
+      `ψ⁻¹` and fixes the real-valued quadratic character `chiC p`, i.e.
+      `conj (gaussSum (chiC p) ψ) = gaussSum (chiC p) ψ⁻¹`.  (Conjugation sends each
+      additive-character value, a root of unity, to its inverse — `AddChar.starComp` —
+      and fixes the integer values `0, ±1` of the quadratic character.)
+
+    * `(chiC p)⁻¹ = chiC p` because `chiC p` is a quadratic character
+      (`MulChar.IsQuadratic.inv`).
+
+  Hence `gaussSum χ⁻¹ ψ⁻¹ = gaussSum χ ψ⁻¹ = conj g`, and the orthogonality identity
+  reads `g · conj g = p`, i.e. `normSq g = p` by `Complex.mul_conj`.  No use is made
+  of the square identity `g² = ±p`, so this is a logically independent derivation of
+  the magnitude.
+
+  Sorry-free and axiom-free.
+-/
+import Mathlib
+import Proofs.QuadraticGaussSumSquare
+
+open scoped BigOperators
+open Complex QuadraticGaussSumSquare
+
+namespace QuadraticGaussSumNormParseval
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-- Complex conjugation of the quadratic Gauss sum replaces the additive character by
+its inverse and fixes the (real, `±1`-valued) quadratic character:
+`conj (gaussSum (chiC p) ψ) = gaussSum (chiC p) ψ⁻¹`. -/
+theorem gaussSum_conj (ψ : AddChar (ZMod p) ℂ) :
+    (starRingEnd ℂ) (gaussSum (chiC p) ψ) = gaussSum (chiC p) ψ⁻¹ := by
+  rw [gaussSum, gaussSum, map_sum]
+  refine Finset.sum_congr rfl (fun x _ => ?_)
+  rw [map_mul]
+  have hχ : (starRingEnd ℂ) (chiC p x) = chiC p x := by
+    simp only [chiC, MulChar.ringHomComp_apply, eq_intCast, map_intCast]
+  have hψc : (starRingEnd ℂ) (ψ x) = ψ⁻¹ x :=
+    AddChar.starComp_apply
+      (by rw [ZMod.ringChar_zmod_n]; exact (Fact.out : p.Prime).pos) x
+  rw [hχ, hψc]
+
+/-- **Magnitude of the quadratic Gauss sum via Parseval.** For an odd prime `p` and a
+primitive additive character `ψ`, `‖gaussSum (chiC p) ψ‖² = p`, derived directly from
+character orthogonality (`gaussSum_mul_gaussSum_eq_card`) without the square identity. -/
+theorem gaussSum_normSq_eq_card (hp : p ≠ 2) {ψ : AddChar (ZMod p) ℂ}
+    (hψ : ψ.IsPrimitive) :
+    Complex.normSq (gaussSum (chiC p) ψ) = p := by
+  have key : gaussSum (chiC p) ψ * gaussSum (chiC p)⁻¹ ψ⁻¹
+      = (Fintype.card (ZMod p) : ℂ) :=
+    gaussSum_mul_gaussSum_eq_card (chiC_ne_one hp) hψ
+  rw [chiC_isQuadratic.inv, ← gaussSum_conj, Complex.mul_conj, ZMod.card] at key
+  exact_mod_cast key
+
+/-- Restated as `‖g‖ = √p` (the Euclidean magnitude). -/
+theorem gaussSum_norm_eq_sqrt (hp : p ≠ 2) {ψ : AddChar (ZMod p) ℂ}
+    (hψ : ψ.IsPrimitive) :
+    ‖gaussSum (chiC p) ψ‖ = Real.sqrt p := by
+  rw [Complex.norm_def, gaussSum_normSq_eq_card hp hψ]
+
+end QuadraticGaussSumNormParseval

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-01/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-01/meta.json
@@ -39,11 +39,11 @@
   },
   "conclusion": {
     "summary": "For every odd prime $p$ and primitive additive character $\\psi$, the quadratic Gauss sum $g$ is machine-checked to be real when $p \\equiv 1 \\pmod 4$ and purely imaginary when $p \\equiv 3 \\pmod 4$, with magnitude $\\lVert g \\rVert^2 = p$. These follow from the parent's square identity by elementary complex arithmetic, with no axioms and no sorries.",
-    "implications": "The dichotomy and magnitude reduce the full sign-determination problem to a single binary choice — the leading $\\pm$ — making explicit exactly where Gauss's deep analytic argument is required and where it is not. The same real/imaginary split governs the functional equation of the Dirichlet $L$-function attached to the quadratic character mod $p$, where the location of $g$ on the real or imaginary axis controls the root number.",
+    "implications": "The dichotomy and magnitude reduce the full sign-determination problem to a single binary choice — the leading $\\pm$ — making explicit exactly where Gauss's deep analytic argument is required and where it is not. The same real/imaginary split governs the functional equation of the Dirichlet $L$-function attached to the quadratic character mod $p$, where the location of $g$ on the real or imaginary axis controls the root number. The magnitude $\\lVert g \\rVert^2 = p$ is reproved independently from character orthogonality (Parseval) in the companion `Proofs/QuadraticGaussSumNormParseval.lean`, giving a square-identity-free cross-check.",
     "openQuestions": [
       "Can the leading sign of $g$ — $g = +\\sqrt{p}$ for $p \\equiv 1 \\pmod 4$ and $g = +i\\sqrt{p}$ for $p \\equiv 3 \\pmod 4$ (Gauss's hard theorem) — be formalized in Lean 4 on top of this dichotomy, e.g. via Schur's eigenvalue argument on the finite Fourier transform?",
       "Does the dichotomy-from-square-sign mechanism extend to higher-order Gauss sums, where the square (or higher power) lands on a denser set of rays in $\\mathbb{C}$?",
-      "Can the magnitude $\\lVert g \\rVert^2 = p$ be derived directly from character orthogonality (Parseval) as an independent cross-check on the square-identity route used here?"
+      "RESOLVED (companion `Proofs/QuadraticGaussSumNormParseval.lean`): the magnitude $\\lVert g \\rVert^2 = p$ is now also derived directly from character orthogonality (Parseval) — `gaussSum_mul_gaussSum_eq_card` — independently of the square identity, by identifying $\\overline{g}$ with $\\operatorname{gaussSum}(\\chi, \\psi^{-1})$ (conjugation fixes the real quadratic character and inverts the additive character) and using $\\chi^{-1} = \\chi$. This confirms $\\lVert g \\rVert^2 = p$ on a logically separate route, sorry-free and axiom-free."
     ]
   },
   "crossReferences": [

--- a/src/data/research/problems/quadratic-gauss-sum-square-oq-01.json
+++ b/src/data/research/problems/quadratic-gauss-sum-square-oq-01.json
@@ -18,7 +18,9 @@
       "QuadraticGaussSumSignReduction.gaussSum_eq_I_sqrt_iff_im_pos — sign theorem ⟺ 0<Im g (p≡3) (sorry-free)",
       "QuadraticGaussSumDiagonal.gaussSum_chiC_eq_sum_sq — g = ∑ k, ψ(k²) (sorry-free, axiom-free)",
       "QuadraticGaussSumDiagonal.card_sqrts_cast — (#{x:x²=t}.card : ℂ) = chiC p t + 1, ℂ-transport of quadraticChar_card_sqrts",
-      "QuadraticGaussSumSignSmallSeven.gaussSum_seven_eq_I_sqrt_seven — g=+i√7 for p=7 (≡3 mod 4), second witness on that branch (sorry-free, axiom-free)"
+      "QuadraticGaussSumSignSmallSeven.gaussSum_seven_eq_I_sqrt_seven — g=+i√7 for p=7 (≡3 mod 4), second witness on that branch (sorry-free, axiom-free)",
+      "QuadraticGaussSumNormParseval.gaussSum_normSq_eq_card — ‖g‖²=p for ALL odd p via character orthogonality (gaussSum_mul_gaussSum_eq_card), INDEPENDENT of the square identity; conj g = gaussSum(chiC p, ψ⁻¹) (conjugation fixes real χ, inverts ψ via AddChar.starComp) + chiC⁻¹=chiC (IsQuadratic.inv). Answers entry open-question #3 / nextStep #4 (sorry-free, axiom-free)",
+      "QuadraticGaussSumNormParseval.gaussSum_conj — conj(gaussSum (chiC p) ψ) = gaussSum (chiC p) ψ⁻¹ (sorry-free, axiom-free)"
     ],
     "mathlibGaps": [
       "No formalization of the sign of the quadratic Gauss sum (g=√p for p≡1, g=i√p for p≡3).",
@@ -29,9 +31,9 @@
       "Prove the single open crux 0 < Re(gaussSum (chiC p) ψ) for p≡1 mod 4 (and 0 < Im for p≡3). Both classical routes target exactly this.",
       "Schur route: build the n×n finite Fourier matrix F (entries ζ^{jk}), show F has known eigenvalue multiplicities (1,−1,i,−i with counts depending on n mod 4), and identify Re(g) with trace/√n. Estimate >1000 lines given no Mathlib DFT-spectrum infra → likely BLOCKED short-term.",
       "Dirichlet route: needs Poisson summation / theta functional equation; heavy real-analysis infra. Estimate >1000 lines.",
-      "Cross-check magnitude ‖g‖²=p via character orthogonality (Parseval) independently of the square identity.",
+      "DONE (QuadraticGaussSumNormParseval): cross-checked magnitude ‖g‖²=p via character orthogonality (gaussSum_mul_gaussSum_eq_card) independently of the square identity.",
       "With the diagonal form, the standard-character Gauss sum is ∑ ζ_p^{k²}; reframe the open crux 0<Re g as positivity of ∑ cos(2π k²/p). p=7 (≡3 mod 4) is now ∑ζ^{k²}=1+2ζ+2ζ²+2ζ⁴ but still needs cubic-irrational trig (cos(2π/7)) — intractable by elementary radicals, unlike p=3,5."
     ],
-    "progressSummary": "PROGRESS (ACT): added the diagonal representation g=∑ψ(k²) (verified, axiom-free), the classical starting form absent from Mathlib. Base cases p=3,5 done; general positivity crux remains open (DFT-spectrum, >1000 lines)."
+    "progressSummary": "PROGRESS (ACT): added the diagonal representation g=∑ψ(k²) (verified, axiom-free), the classical starting form absent from Mathlib, and an independent Parseval/orthogonality derivation of the magnitude ‖g‖²=p (QuadraticGaussSumNormParseval, verified, axiom-free) — answering entry open-question #3. Base cases p=3,5,7 done; general positivity crux (the leading sign) remains open (DFT-spectrum / theta route, >1000 lines)."
   }
 }


### PR DESCRIPTION
## Summary

Answers **open question #3** of the gallery entry `quadratic-gauss-sum-square-oq-01`: derive the magnitude of the quadratic Gauss sum **directly from character orthogonality (Parseval)**, independently of the square identity `g² = (-1)^((p-1)/2)·p`.

The existing entry obtains `‖g‖² = p` as a corollary of the square identity (`normSq(g)² = p² ⟹ normSq g = p`). This PR adds a logically separate derivation through Mathlib's orthogonality lemma `gaussSum_mul_gaussSum_eq_card`.

## New file `Proofs/QuadraticGaussSumNormParseval.lean`

Verified, 0 sorries, axioms `[propext, Classical.choice, Quot.sound]` (confirmed via `#print axioms`):

- **`gaussSum_conj`** — `conj(gaussSum (chiC p) ψ) = gaussSum (chiC p) ψ⁻¹`.
  Complex conjugation fixes the real, `±1`-valued quadratic character (an integer cast) and inverts the additive character (`AddChar.starComp_apply`: each value is a root of unity).
- **`gaussSum_normSq_eq_card`** — `‖gaussSum (chiC p) ψ‖² = p` for every odd prime `p` and primitive `ψ`. Combines `gaussSum_mul_gaussSum_eq_card` with `χ⁻¹ = χ` (`MulChar.IsQuadratic.inv`): the orthogonality identity `g · gaussSum χ⁻¹ ψ⁻¹ = #(ZMod p)` becomes `g · conj g = p`, i.e. `normSq g = p` via `Complex.mul_conj`.
- **`gaussSum_norm_eq_sqrt`** — `‖g‖ = √p`.

## Mathematical content

The key observation is that for the quadratic character `χ = chiC p` (real, self-inverse) and any primitive `ψ`, conjugation sends `gaussSum χ ψ` to `gaussSum χ ψ⁻¹ = gaussSum χ⁻¹ ψ⁻¹`. Mathlib's Parseval/orthogonality lemma then evaluates the product `g·conj g` to the cardinality `p`. No appeal to `g² = ±p` is made, so this is a genuinely independent route to the magnitude.

## Integration
- Registered in `proofs/Proofs.lean`.
- `meta.json`: open question #3 marked resolved; implications note the independent cross-check.
- Research knowledge JSON: recorded built items and marked nextStep #4 done.

## Verification
`lake env lean Proofs/QuadraticGaussSumNormParseval.lean` — clean; `#print axioms` shows no `sorryAx`/`ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)