### PR TITLE
research(basel-problem-oq-09): odd-square series ∑ 1/(2k+1)² = π²/8

### DIFF
--- a/proofs/Proofs/BaselProblemOQ09.lean
+++ b/proofs/Proofs/BaselProblemOQ09.lean
@@ -1,0 +1,148 @@
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.Analysis.PSeries
+import Mathlib.Topology.Algebra.InfiniteSum.NatInt
+import Mathlib.Topology.Algebra.InfiniteSum.Ring
+import Mathlib.Tactic
+
+/-
+# The Odd-Square Series: ∑ 1/(2k+1)² = π²/8
+
+## What This Proves
+The sum of the reciprocals of the *odd* squares equals π²/8:
+
+  ∑_{k=0}^∞ 1/(2k+1)² = 1/1² + 1/3² + 1/5² + ⋯ = π²/8
+
+## Approach (the even/odd split of the Basel sum)
+This is the standard corollary of the Basel problem ∑ 1/n² = π²/6.
+Split the Basel sum into its even and odd index parts:
+
+  ∑_{n≥1} 1/n²  =  ∑_{k≥1} 1/(2k)²  +  ∑_{k≥0} 1/(2k+1)².
+
+The even part is a rescaled copy of the whole Basel sum:
+
+  ∑_{k} 1/(2k)²  =  (1/4) · ∑_{k} 1/k²  =  (1/4)·(π²/6)  =  π²/24.
+
+Mathlib's `HasSum.even_add_odd` recombines the even and odd subseries into the
+full sum, so by uniqueness of sums
+
+  π²/24 + (odd part)  =  π²/6   ⟹   (odd part) = π²/6 − π²/24 = π²/8.
+
+## Provenance
+- Foundation: `hasSum_zeta_two` from `Mathlib.NumberTheory.ZetaValues`
+  (the Basel identity, already used by the parent `basel-problem` entry).
+- Split: `HasSum.even_add_odd` from `Mathlib.Topology.Algebra.InfiniteSum.NatInt`.
+- Rescaling: `HasSum.mul_left`; summability of the odd subseries via
+  `Summable.comp_injective`; identification of the value via `HasSum.unique`.
+
+This entry answers the open question `basel-problem-oq-09`: it carries out the
+even/odd decomposition explicitly rather than quoting the odd-square value.
+
+## Status
+- [x] Complete proof, 0 sorries, 0 axioms.
+
+Original formalization for Lean Genius.
+-/
+
+namespace BaselProblemOQ09
+
+open Real Filter Topology
+
+/-- The Basel summand `n ↦ 1/n²`, named so that `HasSum.even_add_odd` can unify
+the even/odd subseries `fun k ↦ f (2*k)` and `fun k ↦ f (2*k+1)`. -/
+private noncomputable def f : ℕ → ℝ := fun n => 1 / (n : ℝ) ^ 2
+
+/-- The Basel identity, restated for the local summand `f`. -/
+private theorem basel_f : HasSum f (π ^ 2 / 6) := by
+  exact hasSum_zeta_two
+
+/-- The Basel series is summable. -/
+private theorem summable_f : Summable f := basel_f.summable
+
+/-! ## The even part -/
+
+/-- The even-index part of the Basel sum is a rescaled Basel sum:
+`∑ₖ 1/(2k)² = (1/4)·(π²/6) = π²/24`. -/
+theorem hasSum_even_squares :
+    HasSum (fun k : ℕ => 1 / (2 * (k : ℝ)) ^ 2) (π ^ 2 / 24) := by
+  have hfun : (fun k : ℕ => 1 / (2 * (k : ℝ)) ^ 2)
+            = (fun k : ℕ => (1 / 4 : ℝ) * f k) := by
+    funext k; simp only [f]; ring
+  rw [hfun]
+  have h := basel_f.mul_left (1 / 4 : ℝ)
+  have hval : (1 / 4 : ℝ) * (π ^ 2 / 6) = π ^ 2 / 24 := by ring
+  rw [hval] at h
+  exact h
+
+/-- The tsum form of the even part. -/
+theorem tsum_even_squares : ∑' k : ℕ, 1 / (2 * (k : ℝ)) ^ 2 = π ^ 2 / 24 :=
+  hasSum_even_squares.tsum_eq
+
+/-! ## The odd part — the main result -/
+
+/-- **The odd-square series.** The reciprocals of the odd squares sum to π²/8:
+
+  `∑_{k≥0} 1/(2k+1)² = 1 + 1/9 + 1/25 + ⋯ = π²/8`. -/
+theorem hasSum_odd_squares :
+    HasSum (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ 2) (π ^ 2 / 8) := by
+  -- Even part, written in the `f (2*k)` shape required by `even_add_odd`.
+  have heven : HasSum (fun k : ℕ => f (2 * k)) (π ^ 2 / 24) := by
+    have hfun : (fun k : ℕ => f (2 * k))
+              = (fun k : ℕ => 1 / (2 * (k : ℝ)) ^ 2) := by
+      funext k; simp only [f]; push_cast; ring
+    rw [hfun]; exact hasSum_even_squares
+  -- The odd subseries is summable (an injective reindexing of a summable series).
+  have hinj : Function.Injective (fun k : ℕ => 2 * k + 1) := by
+    intro a b h; dsimp only at h; omega
+  have hodd_sum : Summable (fun k : ℕ => f (2 * k + 1)) := by
+    have h := summable_f.comp_injective hinj
+    simpa [Function.comp] using h
+  have hodd : HasSum (fun k : ℕ => f (2 * k + 1)) (∑' k, f (2 * k + 1)) :=
+    hodd_sum.hasSum
+  -- Recombine even + odd into the full Basel sum, then identify the odd value.
+  have hcomb : HasSum f (π ^ 2 / 24 + ∑' k, f (2 * k + 1)) :=
+    heven.even_add_odd hodd
+  have huniq : π ^ 2 / 24 + ∑' k, f (2 * k + 1) = π ^ 2 / 6 :=
+    hcomb.unique basel_f
+  have hval : (∑' k, f (2 * k + 1)) = π ^ 2 / 8 := by linarith
+  -- Bridge the local `f`-form to the clean statement.
+  have hbridge : (fun k : ℕ => f (2 * k + 1))
+               = (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ 2) := by
+    funext k; simp only [f]; push_cast; ring
+  rw [hval] at hodd
+  rw [hbridge] at hodd
+  exact hodd
+
+/-- The tsum form of the main result: `∑' k, 1/(2k+1)² = π²/8`. -/
+theorem tsum_odd_squares : ∑' k : ℕ, 1 / (2 * (k : ℝ) + 1) ^ 2 = π ^ 2 / 8 :=
+  hasSum_odd_squares.tsum_eq
+
+/-- The odd-square series is summable. -/
+theorem summable_odd_squares : Summable (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ 2) :=
+  hasSum_odd_squares.summable
+
+/-- The value π²/8 is positive. -/
+theorem odd_squares_value_pos : (0 : ℝ) < π ^ 2 / 8 := by positivity
+
+/-! ## The decomposition identity
+
+The even and odd parts add back to the full Basel value. -/
+
+/-- The even/odd decomposition of the Basel value: `π²/6 = π²/24 + π²/8`. -/
+theorem basel_even_odd_decomposition : π ^ 2 / 6 = π ^ 2 / 24 + π ^ 2 / 8 := by
+  ring
+
+/-- The odd part exceeds the even part: `π²/24 < π²/8`
+(three quarters of the Basel mass lives on the odd indices). -/
+theorem odd_part_gt_even_part : π ^ 2 / 24 < π ^ 2 / 8 := by
+  have : (0 : ℝ) < π ^ 2 := by positivity
+  linarith
+
+/-! ## Numerical sanity checks -/
+
+/-- The first odd term is `1/1² = 1`. -/
+example : (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ 2) 0 = 1 := by norm_num
+
+/-- The second odd term is `1/3² = 1/9`. -/
+example : (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ 2) 1 = 1 / 9 := by norm_num
+
+end BaselProblemOQ09

--- a/src/data/proofs/basel-problem-oq-09/meta.json
+++ b/src/data/proofs/basel-problem-oq-09/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "basel-problem-oq-09",
+  "title": "The Odd-Square Series: ∑ 1/(2k+1)² = π²/8",
+  "slug": "basel-problem-oq-09",
+  "description": "Formalizes the sum of reciprocal odd squares ∑_{k≥0} 1/(2k+1)² = 1 + 1/9 + 1/25 + ⋯ = π²/8, the standard corollary of the Basel problem ζ(2) = π²/6. The proof carries out the even/odd decomposition explicitly: the even-indexed part ∑ 1/(2k)² = (1/4)ζ(2) = π²/24 is a quarter-scaled copy of the Basel sum, Mathlib's HasSum.even_add_odd recombines the even and odd subseries into the full ζ(2), and uniqueness of sums forces the odd part to π²/6 − π²/24 = π²/8. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ09.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "series",
+      "zeta-function",
+      "basel-problem",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 148,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "dateAdded": "2026-06-19",
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_two",
+        "description": "The Basel sum: HasSum (fun n => 1/n²) (π²/6)",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "HasSum.even_add_odd",
+        "description": "Combine the even- and odd-indexed subseries into the full sum",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "HasSum.mul_left",
+        "description": "Scale a HasSum by a constant, used to obtain the even part as (1/4)ζ(2)",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Ring"
+      },
+      {
+        "theorem": "Summable.comp_injective",
+        "description": "Summability of the odd-indexed subseries from summability of ζ(2) via k ↦ 2k+1",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "HasSum.unique",
+        "description": "Uniqueness of sums, pinning the odd part to π²/8",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      }
+    ],
+    "originalContributions": [
+      "hasSum_even_squares: ∑_k 1/(2k)² = π²/24 (quarter of ζ(2) via the rescaling 1/(2k)² = (1/4)(1/k²) and HasSum.mul_left)",
+      "hasSum_odd_squares: ∑_k 1/(2k+1)² = π²/8 (the odd-square Basel sum) derived from ζ(2) minus its even part by HasSum.even_add_odd + HasSum.unique",
+      "tsum_odd_squares / summable_odd_squares: the tsum form and summability of the odd-square series",
+      "basel_even_odd_decomposition / odd_part_gt_even_part: the value identity π²/6 = π²/24 + π²/8 and the observation that three quarters of the Basel mass lives on the odd indices"
+    ],
+    "prerequisites": [
+      "Basel problem ζ(2) = π²/6 (Mathlib hasSum_zeta_two)",
+      "Even/odd splitting of an infinite sum (HasSum.even_add_odd)",
+      "Uniqueness of sums (HasSum.unique)"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ZetaValues",
+      "Mathlib.Analysis.PSeries",
+      "Mathlib.Topology.Algebra.InfiniteSum.NatInt",
+      "Mathlib.Topology.Algebra.InfiniteSum.Ring",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Real", "Filter", "Topology"],
+    "namespace": "BaselProblemOQ09",
+    "path": "Proofs/BaselProblemOQ09.lean",
+    "lineCount": 148,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "Euler solved the Basel problem ζ(2) = ∑ 1/n² = π²/6 in 1734. Separating the sum by parity of the index immediately yields the value of the odd-square series ∑ 1/(2k+1)² = π²/8 — a quantity that also arises as the s = 2 value of the Dirichlet lambda (odd-index) function λ(s) = ∑ 1/(2k+1)^s = (1 - 2^{-s})ζ(s). The even-indexed terms reassemble a quarter-scaled copy of ζ(2), so the odd terms carry exactly three quarters of the Basel mass.",
+    "problemStatement": "Formalize, with 0 sorries and 0 axioms, the odd-square sum\n\n$$\\sum_{k=0}^{\\infty} \\frac{1}{(2k+1)^2} = 1 + \\frac{1}{9} + \\frac{1}{25} + \\cdots = \\frac{\\pi^2}{8},$$\n\nby splitting Mathlib's `hasSum_zeta_two` (ζ(2) = π²/6) into its even- and odd-indexed parts and subtracting the even part (1/4)ζ(2).",
+    "text": "The odd-square Basel sum: ∑ 1/(2k+1)² = π²/8, obtained from Mathlib's ζ(2) = π²/6 by an explicit even/odd decomposition.",
+    "proofStrategy": "Two HasSum lemmas plus the recombination. (1) hasSum_even_squares: rewrite 1/(2k)² = (1/4)(1/k²) and scale ζ(2) by 1/4 (HasSum.mul_left) to get π²/24. (2) hasSum_odd_squares: the odd subseries fun k ↦ f(2k+1) is summable (Summable.comp_injective with the injection k ↦ 2k+1), so reassembling ζ(2) = even + odd via HasSum.even_add_odd and applying HasSum.unique against hasSum_zeta_two forces π²/24 + (odd) = π²/6, hence (odd) = π²/8. A `linarith` over the atom π² closes the value, and a funext/push_cast bridge restitches the clean statement fun k ↦ 1/(2k+1)².",
+    "keyInsights": [
+      "**The even-indexed subseries is a scaled copy of ζ(2).** Since 1/(2k)² = (1/4)(1/k²), the even part is exactly (1/4)ζ(2) = π²/24 — a one-line HasSum.mul_left after a `ring` rewrite (valid even at k = 0 where both sides are 0 in ℝ).",
+      "**The odd value falls out of uniqueness, not a fresh summation.** Rather than evaluating ∑ 1/(2k+1)² directly, reassemble ζ(2) from its even and odd halves and use HasSum.unique: π²/24 + (odd) = π²/6 ⟹ (odd) = π²/8. The only arithmetic is π²/6 − π²/24 = π²/8.",
+      "**HasSum.even_add_odd needs a named summand for higher-order unification.** Defining `f n = 1/n²` as a top-level function lets `even_add_odd` infer the summand from the pattern `f (2*k)` / `f (2*k+1)`; an inline lambda would block the unification.",
+      "**Summability of the odd part is reindexing, not analysis.** k ↦ 2k+1 is injective (one `omega`), so Summable.comp_injective transports summability of ζ(2) to the odd subseries — no comparison test or p-series estimate is invoked beyond Mathlib's ζ(2).",
+      "**Three quarters of the Basel mass is odd.** The decomposition π²/6 = π²/24 + π²/8 makes the even part one quarter and the odd part three quarters of ζ(2); the corollary odd_part_gt_even_part records π²/24 < π²/8."
+    ],
+    "prerequisites": [
+      "Basel problem ζ(2) = π²/6",
+      "Even/odd decomposition of infinite sums",
+      "Uniqueness of sums (HasSum.unique)",
+      "HasSum / tsum API in Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header, Imports, and the Basel Summand",
+      "startLine": 1,
+      "endLine": 59,
+      "summary": "Documents the even/odd split of the Basel sum; imports Mathlib's ZetaValues (for hasSum_zeta_two); defines the summand f n = 1/n² and restates the Basel identity and its summability for f.",
+      "mathContext": "The odd-square value is the s = 2 case of the odd-index zeta λ(2) = (1 - 1/4)ζ(2)."
+    },
+    {
+      "id": "even-part",
+      "title": "hasSum_even_squares — ∑ 1/(2k)² = π²/24",
+      "startLine": 61,
+      "endLine": 78,
+      "summary": "Rewrites 1/(2k)² = (1/4)(1/k²) and scales ζ(2) by 1/4 with HasSum.mul_left, plus a tsum corollary.",
+      "mathContext": "The even-indexed Basel terms form a quarter-scaled copy of ζ(2)."
+    },
+    {
+      "id": "odd-part",
+      "title": "hasSum_odd_squares — ∑ 1/(2k+1)² = π²/8",
+      "startLine": 80,
+      "endLine": 121,
+      "summary": "Odd subseries summable via comp_injective; reassemble ζ(2) = even + odd with HasSum.even_add_odd and use HasSum.unique to pin the odd sum to π²/8, then bridge to the clean statement. Includes tsum and summability corollaries.",
+      "mathContext": "The odd-square Basel sum, recovered as ζ(2) minus its even part."
+    },
+    {
+      "id": "decomposition",
+      "title": "The decomposition identity and sanity checks",
+      "startLine": 123,
+      "endLine": 148,
+      "summary": "Records π²/6 = π²/24 + π²/8, that the odd part exceeds the even part, and numerical checks that the first two odd terms are 1 and 1/9.",
+      "mathContext": "Three quarters of the Basel mass lives on the odd indices."
+    }
+  ],
+  "conclusion": {
+    "summary": "The odd-square sum ∑ 1/(2k+1)² = π²/8 is formalized with 0 axioms and 0 sorries, built from Mathlib's ζ(2) = π²/6 by an explicit even/odd parity split. The proof packages the even-indexed Basel sum (π²/24) and the odd-indexed Basel sum (π²/8) as reusable HasSum lemmas, with tsum and summability corollaries and the decomposition identity π²/6 = π²/24 + π²/8.",
+    "implications": "Completes the parity corollary of the Basel problem in the gallery and demonstrates the HasSum.even_add_odd splitting idiom paired with HasSum.unique. The same template — even part = scaled ζ, odd part by uniqueness — applies directly to the odd-index zeta λ(4) = π⁴/96 from ζ(4) = π⁴/90, and is the engine behind the Dirichlet eta values η(2) = π²/12 and η(4) = 7π⁴/720.",
+    "openQuestions": [
+      {
+        "id": "basel-problem-oq-09-oq-01",
+        "question": "Generalize the even/odd parity split to a reusable lemma λ(2m) = ∑ 1/(2k+1)^{2m} = (1 - 2^{-2m}) ζ(2m), deriving λ(4) = π⁴/96 from Mathlib's hasSum_zeta_four with no new analytic input.",
+        "significance": "medium"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem",
+      "relationship": "extends",
+      "description": "Root Basel entry ζ(2) = π²/6; this is the odd-index corollary λ(2) = ∑ 1/(2k+1)² = π²/8."
+    },
+    {
+      "targetId": "basel-problem-oq-11",
+      "relationship": "related",
+      "description": "The Dirichlet eta companion η(2) = π²/12 uses the same even/odd splitting machinery and reuses the odd-square value π²/8."
+    }
+  ],
+  "references": [
+    {
+      "title": "Introductio in analysin infinitorum",
+      "author": "Leonhard Euler",
+      "year": "1748",
+      "description": "Euler's evaluation of ζ(2) and related series; the odd-square value π²/8 follows by separating the Basel sum by parity."
+    },
+    {
+      "title": "Riemann's Zeta Function",
+      "author": "Harold M. Edwards",
+      "year": "1974",
+      "venue": "Academic Press",
+      "description": "Develops ζ and its companions (the Dirichlet eta and lambda functions) whose integer values follow from the same machinery."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "basel-problem-oq-09-oq-01",
+      "question": "Generalize the even/odd parity split to λ(2m) = ∑ 1/(2k+1)^{2m} = (1 - 2^{-2m}) ζ(2m) and derive λ(4) = π⁴/96 from hasSum_zeta_four.",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## The Odd-Square Series: ∑ 1/(2k+1)² = π²/8

Answers open question **basel-problem-oq-09**: formalizes the sum of reciprocal odd squares
$$\sum_{k=0}^{\infty} \frac{1}{(2k+1)^2} = 1 + \tfrac19 + \tfrac1{25} + \cdots = \frac{\pi^2}{8},$$
the standard parity corollary of the Basel problem ζ(2) = π²/6.

### Approach — explicit even/odd decomposition
- **Even part** `hasSum_even_squares`: rewrite 1/(2k)² = (1/4)(1/k²) and scale ζ(2) by 1/4 via `HasSum.mul_left` ⟹ π²/24 (a quarter-scaled copy of the Basel sum).
- **Odd part** `hasSum_odd_squares`: the odd subseries `k ↦ f(2k+1)` is summable (`Summable.comp_injective` with the injection k ↦ 2k+1); reassemble ζ(2) = even + odd via `HasSum.even_add_odd` and apply `HasSum.unique` against `hasSum_zeta_two` to force π²/24 + (odd) = π²/6, hence (odd) = π²/8.

The odd terms carry three quarters of the Basel mass (π²/24 < π²/8), recorded as `basel_even_odd_decomposition` and `odd_part_gt_even_part`, plus tsum/summability corollaries and numerical sanity checks.

### Verification
- **0 sorries, 0 axioms.** `#print axioms hasSum_odd_squares` → `[propext, Classical.choice, Quot.sound]` (foundational only; no `sorryAx`, no `Lean.ofReduceBool`).
- Verified via single-file `lake env lean` against prebuilt Mathlib oleans (Docker daemon was unresponsive this session; elaboration is bounded and safe).
- Foundation: `hasSum_zeta_two` (`Mathlib.NumberTheory.ZetaValues`), the same identity used by the parent `basel-problem` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)