### PR TITLE
research(pythagorean-triples-oq-06): classification of primitive Pythagorean triples

### DIFF
--- a/proofs/Proofs/PythagoreanTriplesOQ06.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ06.lean
@@ -1,0 +1,85 @@
+/-
+  # Classification of primitive Pythagorean triples
+  # (pythagorean-triples-oq-06)
+
+  ## The Open Question
+
+  A Pythagorean triple is a solution of x² + y² = z² in integers; it is **primitive**
+  when gcd(x, y) = 1 (so the three numbers share no common factor). The classical
+  classification theorem (Euclid, *Elements* Book X) says every primitive triple is,
+  up to swapping the legs and signs, of the form
+
+      x = m² − n²,   y = 2mn,   z = m² + n²
+
+  for coprime integers m, n of opposite parity — and conversely every such (m, n)
+  produces a primitive triple. This file packages both directions on top of Mathlib's
+  `PythagoreanTriple.coprime_classification`, and instantiates the parametrization at
+  m = 2, n = 1 to recover the smallest triple (3, 4, 5).
+
+  ## Axiom count: 0
+-/
+
+import Mathlib.NumberTheory.PythagoreanTriples
+import Mathlib.Tactic
+
+open PythagoreanTriple
+
+namespace PythTriplesClassification
+
+/-- **Forward direction (parametrization exists).** Every primitive Pythagorean triple
+    with odd first leg `x` and positive hypotenuse `z` arises from a unique pair of
+    coprime, opposite-parity integers `m ≥ 0`, `n`:
+
+      x = m² − n²,   y = 2mn,   z = m² + n².
+
+    This is exactly Mathlib's `coprime_classification'`. -/
+theorem primitive_param {x y z : ℤ} (h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) (hodd : x % 2 = 1) (hz : 0 < z) :
+    ∃ m n : ℤ, x = m ^ 2 - n ^ 2 ∧ y = 2 * m * n ∧ z = m ^ 2 + n ^ 2 ∧
+      Int.gcd m n = 1 ∧ (m % 2 = 0 ∧ n % 2 = 1 ∨ m % 2 = 1 ∧ n % 2 = 0) ∧ 0 ≤ m :=
+  h.coprime_classification' hco hodd hz
+
+/-- **Converse direction (parametrization suffices).** For any coprime integers `m, n`
+    of opposite parity, the Euclid parametrization
+
+      (m² − n²,  2mn,  m² + n²)
+
+    is a Pythagorean triple, and it is primitive: gcd(m² − n², 2mn) = 1. -/
+theorem param_primitive (m n : ℤ) (hco : Int.gcd m n = 1)
+    (hpar : m % 2 = 0 ∧ n % 2 = 1 ∨ m % 2 = 1 ∧ n % 2 = 0) :
+    PythagoreanTriple (m ^ 2 - n ^ 2) (2 * m * n) (m ^ 2 + n ^ 2) ∧
+      Int.gcd (m ^ 2 - n ^ 2) (2 * m * n) = 1 :=
+  (coprime_classification (x := m ^ 2 - n ^ 2) (y := 2 * m * n) (z := m ^ 2 + n ^ 2)).mpr
+    ⟨m, n, Or.inl ⟨rfl, rfl⟩, Or.inl rfl, hco, hpar⟩
+
+/-- The parametrization always solves `x² + y² = z²` (the Pythagorean identity for the
+    Euclid form), with no coprimality or parity hypothesis. -/
+theorem param_eq (m n : ℤ) :
+    (m ^ 2 - n ^ 2) ^ 2 + (2 * m * n) ^ 2 = (m ^ 2 + n ^ 2) ^ 2 := by
+  ring
+
+/-- The smallest primitive Pythagorean triple `(3, 4, 5)`, recovered from the
+    parametrization at `m = 2`, `n = 1`. -/
+theorem triple_3_4_5 : PythagoreanTriple 3 4 5 ∧ Int.gcd 3 4 = 1 :=
+  (coprime_classification (x := 3) (y := 4) (z := 5)).mpr
+    ⟨2, 1, Or.inl ⟨by norm_num, by norm_num⟩, Or.inl (by norm_num), by decide,
+      Or.inl ⟨by decide, by decide⟩⟩
+
+end PythTriplesClassification
+
+/-
+  ## Summary
+
+  | Result | Statement |
+  |--------|-----------|
+  | `primitive_param` | Every primitive triple (x odd, z > 0) is (m²−n², 2mn, m²+n²) |
+  | `param_primitive` | Coprime opposite-parity (m, n) ⟹ a primitive triple |
+  | `param_eq`        | (m²−n²)² + (2mn)² = (m²+n²)² (the Euclid identity) |
+  | `triple_3_4_5`    | (3, 4, 5) is primitive, from m = 2, n = 1 |
+
+  Both directions of the classification are specializations of Mathlib's
+  `PythagoreanTriple.coprime_classification` / `coprime_classification'`.
+
+  **Sorries**: 0
+  **Axioms**: 0
+-/

--- a/src/data/proofs/pythagorean-triples-oq-06/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-06/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "pythagorean-triples-oq-06",
+  "title": "Classification of primitive Pythagorean triples",
+  "slug": "pythagorean-triples-oq-06",
+  "description": "Formalizes Euclid's classification of primitive Pythagorean triples: every primitive solution of x² + y² = z² (gcd(x,y) = 1) with x odd and z > 0 is x = m² - n², y = 2mn, z = m² + n² for coprime integers m, n of opposite parity, and conversely every such (m, n) yields a primitive triple. Both directions are packaged over Mathlib's PythagoreanTriple.coprime_classification, with the Euclid identity (m²-n²)² + (2mn)² = (m²+n²)² and the smallest triple (3,4,5) at m=2, n=1. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ06.lean",
+    "tags": [
+      "number-theory",
+      "diophantine",
+      "pythagorean-triples",
+      "classification",
+      "euclid",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 85,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-19",
+    "mathlibDependencies": [
+      {
+        "theorem": "PythagoreanTriple.coprime_classification",
+        "description": "The full biconditional classification: (x,y,z) is a primitive triple ↔ it is the Euclid parametrization of some coprime opposite-parity (m,n)",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      },
+      {
+        "theorem": "PythagoreanTriple.coprime_classification'",
+        "description": "The sharpened forward direction assuming x odd and z > 0, fixing the signs and leg order",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      }
+    ],
+    "originalContributions": [
+      "primitive_param: forward direction — every primitive triple (x odd, z > 0) is parametrized by coprime opposite-parity (m,n) as (m²-n², 2mn, m²+n²)",
+      "param_primitive: converse — any coprime opposite-parity (m,n) yields a Pythagorean triple that is primitive (gcd(m²-n², 2mn) = 1)",
+      "param_eq: the underlying Euclid identity (m²-n²)² + (2mn)² = (m²+n²)², a hypothesis-free `ring` fact",
+      "triple_3_4_5: the smallest primitive triple (3,4,5) recovered from the parametrization at m=2, n=1"
+    ],
+    "prerequisites": [
+      "Pythagorean triples and primitivity (gcd(x,y) = 1)",
+      "Mathlib's PythagoreanTriple structure and coprime_classification",
+      "Coprimality and parity of integers"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.PythagoreanTriples",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["PythagoreanTriple"],
+    "namespace": "PythTriplesClassification",
+    "path": "Proofs/PythagoreanTriplesOQ06.lean",
+    "lineCount": 85,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The classification of Pythagorean triples is one of the oldest results in number theory. Babylonian tablet Plimpton 322 (c. 1800 BC) already lists primitive triples, and Euclid's Elements (Book X, Lemma 1 before Proposition 29) gives the parametrization x = m² - n², y = 2mn, z = m² + n². The condition that m, n be coprime of opposite parity exactly picks out the primitive triples. The result is the genus-0 case of the general study of rational points on conics: dividing by z² turns x² + y² = z² into a rational point on the unit circle, and stereographic projection from (-1, 0) parametrizes all such points by a single rational slope n/m — the source of the m, n in Euclid's formula.",
+    "problemStatement": "Formalize, with 0 sorries and 0 axioms, both directions of Euclid's classification of primitive Pythagorean triples: every primitive solution of x² + y² = z² (with x odd, z > 0) is (m² - n², 2mn, m² + n²) for coprime opposite-parity integers m, n, and conversely every such (m, n) gives a primitive triple.",
+    "text": "Euclid's classification: primitive Pythagorean triples are exactly the Euclid parametrizations (m²-n², 2mn, m²+n²) of coprime, opposite-parity integers m, n.",
+    "proofStrategy": "Four results layered on Mathlib's PythagoreanTriple.coprime_classification. (1) primitive_param: the forward direction is a direct application of coprime_classification' (the sharpened form assuming x odd and z > 0, which fixes the leg order and signs). (2) param_primitive: the converse applies the .mpr of the biconditional coprime_classification with the explicit witness (m, n) and the trivial disjunction choices, certifying both that the parametrization solves x²+y²=z² and that the resulting triple is primitive. (3) param_eq: the bare Pythagorean identity for the parametrization closes by ring, with no hypotheses. (4) triple_3_4_5: instantiating the converse at m=2, n=1 recovers (3,4,5), with the parity/coprimality side conditions discharged by decide/norm_num.",
+    "keyInsights": [
+      "**Both directions live in one Mathlib biconditional.** `coprime_classification` states (x,y,z) primitive ↔ ∃ m n, Euclid form with coprime opposite parity. The forward direction extracts (m,n); the converse supplies them — the same lemma read left-to-right and right-to-left.",
+      "**Opposite parity is exactly the primitivity condition.** If m, n had the same parity, every term of (m²-n², 2mn, m²+n²) would be even, so gcd ≥ 2; requiring one of m, n even and the other odd is precisely what forces gcd(x,y) = 1.",
+      "**The parametrization is geometric.** (m, n) is the homogeneous form of the rational slope n/m of the line through (-1, 0) on the unit circle; Euclid's formula is stereographic projection in disguise, which is why a single integer pair captures every triple.",
+      "**The Pythagorean identity itself is hypothesis-free.** (m²-n²)² + (2mn)² = (m²+n²)² holds for all m, n by `ring`; coprimality and parity are needed only for primitivity and for the exhaustiveness of the parametrization, not for the equation.",
+      "**(3,4,5) is the base case m=2, n=1.** The smallest primitive triple drops out of the converse with the side conditions (2,1 coprime, opposite parity) settled by decide — a concrete sanity check that the abstract classification is correctly stated."
+    ],
+    "prerequisites": [
+      "Pythagorean triples x² + y² = z² and primitivity",
+      "Euclid's parametrization m² - n², 2mn, m² + n²",
+      "Coprimality and parity of integers",
+      "Rational points on the unit circle (stereographic projection)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "States Euclid's classification and primitivity; imports Mathlib's PythagoreanTriples and opens the PythagoreanTriple namespace.",
+      "mathContext": "Primitive Pythagorean triples and the Euclid parametrization."
+    },
+    {
+      "id": "forward",
+      "title": "primitive_param — every primitive triple is a Euclid parametrization",
+      "startLine": 29,
+      "endLine": 47,
+      "summary": "The forward direction via coprime_classification', extracting coprime opposite-parity (m,n) from a primitive triple with x odd, z > 0.",
+      "mathContext": "Exhaustiveness: no primitive triple escapes the parametrization."
+    },
+    {
+      "id": "converse",
+      "title": "param_primitive / param_eq — the parametrization yields a primitive triple",
+      "startLine": 48,
+      "endLine": 61,
+      "summary": "The converse via coprime_classification.mpr (a primitive triple from any coprime opposite-parity (m,n)), plus the hypothesis-free Euclid identity by ring.",
+      "mathContext": "Soundness: every coprime opposite-parity (m,n) gives a primitive triple."
+    },
+    {
+      "id": "example",
+      "title": "triple_3_4_5 — the smallest primitive triple",
+      "startLine": 62,
+      "endLine": 67,
+      "summary": "Instantiates the converse at m=2, n=1 to recover (3,4,5), discharging parity/coprimality by decide.",
+      "mathContext": "A concrete witness of the classification."
+    }
+  ],
+  "conclusion": {
+    "summary": "Euclid's classification of primitive Pythagorean triples is formalized in both directions with 0 axioms and 0 sorries: every primitive triple (x odd, z > 0) is the Euclid parametrization (m²-n², 2mn, m²+n²) of a coprime opposite-parity pair (m,n), and conversely every such pair yields a primitive triple. The bare Pythagorean identity and the base triple (3,4,5) round out the entry.",
+    "implications": "Packages Mathlib's coprime_classification into a directly reusable forward/converse pair and a concrete instance, giving a clean reference for the structure of primitive solutions of x²+y²=z². The same parametrization underlies the descent step in Fermat's proof that x⁴+y⁴=z² has no nontrivial solutions and the rational-point analysis of conics.",
+    "openQuestions": [
+      {
+        "id": "pythagorean-triples-oq-06-oq-01",
+        "question": "Use the classification to enumerate all primitive triples with hypotenuse below a bound, or to prove that exactly one leg of a primitive triple is even (the parity dichotomy).",
+        "significance": "low"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "extends",
+      "description": "Root Pythagorean-triples entry; this gives the full Euclid classification of the primitive ones."
+    }
+  ],
+  "references": [
+    {
+      "title": "Elements, Book X",
+      "author": "Euclid",
+      "year": "-300",
+      "description": "The classical parametrization x = m² - n², y = 2mn, z = m² + n² of Pythagorean triples."
+    },
+    {
+      "title": "An Introduction to the Theory of Numbers",
+      "author": "Hardy, Wright",
+      "year": "2008",
+      "venue": "Oxford University Press",
+      "description": "Theorem 225: the classification of primitive Pythagorean triples and its proof via coprimality and parity."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "pythagorean-triples-oq-06-oq-01",
+      "question": "Use the classification to prove the parity dichotomy (exactly one leg even) or to enumerate primitive triples below a hypotenuse bound.",
+      "significance": "low"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **Euclid's classification of primitive Pythagorean triples** in both directions, on top of Mathlib's `PythagoreanTriple.coprime_classification`.

Every primitive solution of $x^2 + y^2 = z^2$ (gcd(x,y)=1) with $x$ odd and $z>0$ is

$$x = m^2 - n^2,\quad y = 2mn,\quad z = m^2 + n^2$$

for coprime integers $m,n$ of opposite parity — and conversely every such $(m,n)$ gives a primitive triple.

## Results

| Theorem | Statement |
|---------|-----------|
| `primitive_param` | forward: every primitive triple (x odd, z>0) is the Euclid parametrization of coprime opposite-parity (m,n) |
| `param_primitive` | converse: any coprime opposite-parity (m,n) yields a primitive triple |
| `param_eq` | the hypothesis-free identity (m²−n²)² + (2mn)² = (m²+n²)² |
| `triple_3_4_5` | (3,4,5) recovered from the parametrization at m=2, n=1 |

## Verification

- **0 sorries, 0 axioms** — `#print axioms` yields `[propext, Classical.choice, Quot.sound]` for all named results.
- Compiles clean against Mathlib v4.26.0.
- Forward direction = `coprime_classification'`; converse = `coprime_classification.mpr` with explicit witness.

## Files

- `proofs/Proofs/PythagoreanTriplesOQ06.lean` (85 lines, 4 theorems)
- `src/data/proofs/pythagorean-triples-oq-06/meta.json` (gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)