### PR TITLE
research(lagrange-theorem-oq-07): finite group exponent g^|G|=1 ⇒ Euler & Fermat

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2667,6 +2667,7 @@ import Proofs.LagrangeTheoremOQ02OQ02OQ01
 import Proofs.LagrangeTheoremOQ02OQ02OQ01OQ01
 import Proofs.LagrangeTheoremOQ03
 import Proofs.LagrangeTheoremOQ05
+import Proofs.LagrangeTheoremOQ07
 import Proofs.LawOfCosines
 import Proofs.LawOfCosinesOQ01OQ01
 import Proofs.LawOfCosinesOQ01OQ01OQ01

--- a/proofs/Proofs/LagrangeTheoremOQ07.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ07.lean
@@ -1,0 +1,128 @@
+/-
+Finite Group Exponent: g ^ |G| = 1 for Every Element
+
+Source: Open question from lagrange-theorem gallery proof
+Status: VERIFIED (0 axioms, 0 sorries)
+
+In any finite group G, every element g satisfies g ^ |G| = 1: raising an
+element to the power equal to the group's order returns the identity. This is
+the immediate corollary of Lagrange's theorem -- the order of g divides |G| --
+and it is the structural root of the two classical number-theoretic
+congruences:
+
+  Chain:  Lagrange (orderOf g ∣ |G|)
+            → g ^ |G| = 1            (finite group exponent)
+            → exponent G ∣ |G|       (the exponent is a divisor of the order)
+            → Euler's theorem        (apply to the unit group (ZMod n)ˣ)
+            → Fermat's little theorem (the prime special case φ(p) = p − 1)
+
+Mathlib provides `pow_card_eq_one` directly. The value of this entry is the
+explicit derivation from Lagrange and the descent to Euler's and Fermat's
+theorems, which are *exactly* this theorem applied to the unit group (ZMod n)ˣ
+whose order is the totient φ(n).
+-/
+
+import Mathlib
+
+open scoped Nat
+
+namespace FiniteGroupExponent
+
+variable {G : Type*} [Group G] [Fintype G]
+
+/-! ## Part I: The core theorem — g ^ |G| = 1
+
+Lagrange's theorem says the order of any element divides the group order
+(`orderOf_dvd_card`). Combined with `orderOf_dvd_iff_pow_eq_one`, this gives
+`g ^ |G| = 1` directly. -/
+
+/-- Lagrange for elements: the order of `g` divides `|G|`. The order of `g` is
+the cardinality of the cyclic subgroup it generates, so this is Lagrange's
+theorem specialised to cyclic subgroups. -/
+theorem orderOf_dvd_groupCard (g : G) : orderOf g ∣ Fintype.card G :=
+  orderOf_dvd_card
+
+/-- **Finite group exponent.** Every element raised to the group order is the
+identity, derived explicitly from Lagrange (`orderOf_dvd_card`) via
+`orderOf_dvd_iff_pow_eq_one`. -/
+theorem pow_card_eq_one_of_lagrange (g : G) : g ^ Fintype.card G = 1 :=
+  orderOf_dvd_iff_pow_eq_one.mp orderOf_dvd_card
+
+/-- Our Lagrange-derived statement agrees with Mathlib's library lemma
+`pow_card_eq_one`. -/
+theorem pow_card_eq_one_agrees (g : G) :
+    pow_card_eq_one_of_lagrange g = pow_card_eq_one := rfl
+
+/-- `Nat.card` form. Note this holds for *any* group with no finiteness
+hypothesis: if `G` is infinite then `Nat.card G = 0` and `g ^ 0 = 1`
+vacuously. -/
+theorem pow_natCard_eq_one {H : Type*} [Group H] (g : H) :
+    g ^ Nat.card H = 1 :=
+  pow_card_eq_one'
+
+/-! ## Part II: The group exponent divides the order
+
+The exponent of `G` is the *least* `N > 0` with `g ^ N = 1` for all `g`
+(`Monoid.exponent`). Part I shows `|G|` is one such common period, so the
+exponent — being the minimum — divides `|G|`. -/
+
+/-- The group order is a common period for every element. This is the property
+the exponent is the least positive instance of. -/
+theorem card_is_common_period : ∀ g : G, g ^ Fintype.card G = 1 :=
+  fun g => pow_card_eq_one_of_lagrange g
+
+/-- The exponent of a finite group divides its order. -/
+theorem exponent_dvd_card : Monoid.exponent G ∣ Fintype.card G :=
+  Group.exponent_dvd_card
+
+/-- Repackaged via the universal property of the exponent: `|G|` annihilates
+every element, hence the exponent divides it. This makes the logical content of
+`Group.exponent_dvd_card` explicit. -/
+theorem exponent_dvd_card_via_universal :
+    Monoid.exponent G ∣ Fintype.card G :=
+  Monoid.exponent_dvd_iff_forall_pow_eq_one.mpr card_is_common_period
+
+/-! ## Part III: Euler's and Fermat's theorems as corollaries
+
+Euler's theorem is *exactly* the finite-group exponent theorem applied to the
+unit group `(ZMod n)ˣ`, whose order is Euler's totient `φ(n)`
+(`ZMod.card_units_eq_totient`). Fermat's little theorem is the prime special
+case `φ(p) = p − 1`. -/
+
+/-- **Euler's theorem.** For `x` a unit of `ZMod n`, `x ^ φ(n) = 1`. Derived
+from the finite-group exponent theorem applied to `(ZMod n)ˣ` together with
+`|(ZMod n)ˣ| = φ(n)`. -/
+theorem euler_from_exponent (n : ℕ) [NeZero n] (x : (ZMod n)ˣ) :
+    x ^ Nat.totient n = 1 := by
+  rw [← ZMod.card_units_eq_totient n]
+  exact pow_card_eq_one
+
+/-- **Fermat's little theorem** (unit-group form). For prime `p`, every unit of
+`ZMod p` satisfies `x ^ (p − 1) = 1`. This is Euler's theorem specialised to
+`φ(p) = p − 1`. -/
+theorem fermat_units (p : ℕ) [Fact p.Prime] (x : (ZMod p)ˣ) :
+    x ^ (p - 1) = 1 := by
+  haveI : NeZero p := ⟨(Fact.out : p.Prime).ne_zero⟩
+  have h := euler_from_exponent p x
+  rwa [Nat.totient_prime Fact.out] at h
+
+/-- **Fermat's little theorem** (field form, concrete capstone). For prime `p`
+and `a ≠ 0` in `ZMod p`, `a ^ (p − 1) = 1`. Mathlib derives this directly from
+the same circle of ideas (`ZMod.pow_card_sub_one_eq_one`). -/
+theorem fermat_zmod (p : ℕ) [Fact p.Prime] {a : ZMod p} (ha : a ≠ 0) :
+    a ^ (p - 1) = 1 :=
+  ZMod.pow_card_sub_one_eq_one ha
+
+/-! ## Part IV: The chain, end to end
+
+A single statement tying the foundation (Lagrange divisibility) to the apex
+corollary (Euler), to make the dependency chain explicit. -/
+
+/-- The complete chain: Lagrange's element-order divisibility implies the
+finite-group exponent identity, which specialises on `(ZMod n)ˣ` to Euler's
+theorem. -/
+theorem chain_lagrange_to_euler (n : ℕ) [NeZero n] (x : (ZMod n)ˣ) :
+    (orderOf x ∣ Fintype.card (ZMod n)ˣ) ∧ x ^ Nat.totient n = 1 :=
+  ⟨orderOf_dvd_card, euler_from_exponent n x⟩
+
+end FiniteGroupExponent

--- a/src/data/proofs/lagrange-theorem-oq-07/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-07/meta.json
@@ -1,0 +1,203 @@
+{
+  "id": "lagrange-theorem-oq-07",
+  "title": "Finite Group Exponent: g ^ |G| = 1 for Every Element",
+  "slug": "lagrange-theorem-oq-07",
+  "description": "In a finite group, every element raised to the group order is the identity. Derived explicitly from Lagrange's theorem, then descended to Euler's theorem and Fermat's little theorem as the special case of the unit group (ZMod n)ˣ.",
+  "meta": {
+    "author": "Lagrange; Euler; Fermat",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ07.lean",
+    "tags": [
+      "group-theory",
+      "algebra",
+      "number-theory",
+      "lagrange-theorem",
+      "finite-groups",
+      "order-of-element",
+      "fermat-little-theorem",
+      "euler-theorem",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "orderOf_dvd_card",
+        "description": "Lagrange for elements: orderOf g divides |G|",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "orderOf_dvd_iff_pow_eq_one",
+        "description": "orderOf x ∣ n ↔ x ^ n = 1",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "pow_card_eq_one",
+        "description": "x ^ Fintype.card G = 1 in a finite group",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "pow_card_eq_one'",
+        "description": "x ^ Nat.card G = 1 (holds unconditionally)",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "Group.exponent_dvd_card",
+        "description": "Monoid.exponent G ∣ Fintype.card G",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "Monoid.exponent_dvd_iff_forall_pow_eq_one",
+        "description": "exponent G ∣ n ↔ ∀ g, g ^ n = 1 (universal property)",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "ZMod.card_units_eq_totient",
+        "description": "|(ZMod n)ˣ| = φ(n)",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.totient_prime",
+        "description": "φ(p) = p − 1 for prime p",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "ZMod.pow_card_sub_one_eq_one",
+        "description": "Fermat's little theorem in field form: a ^ (p−1) = 1 for a ≠ 0 in ZMod p",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      }
+    ],
+    "originalContributions": [
+      "orderOf_dvd_groupCard: Lagrange for elements (orderOf g divides |G|)",
+      "pow_card_eq_one_of_lagrange: g ^ |G| = 1 derived explicitly from Lagrange via orderOf_dvd_iff_pow_eq_one",
+      "pow_card_eq_one_agrees: the Lagrange-derived proof is definitionally the library lemma pow_card_eq_one",
+      "pow_natCard_eq_one: Nat.card form, holding for any group with no finiteness hypothesis",
+      "card_is_common_period: |G| is a common period for all elements",
+      "exponent_dvd_card / exponent_dvd_card_via_universal: the group exponent divides the order, both via the library lemma and via the universal property of the exponent",
+      "euler_from_exponent: Euler's theorem x ^ φ(n) = 1 derived as the exponent theorem applied to (ZMod n)ˣ",
+      "fermat_units: Fermat's little theorem (unit-group form) as the prime special case φ(p) = p − 1",
+      "fermat_zmod: Fermat's little theorem (field form) capstone",
+      "chain_lagrange_to_euler: end-to-end statement tying Lagrange divisibility to Euler's theorem"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 128,
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That g^|G| = 1 in a finite group is the most-used corollary of Lagrange's theorem (Lagrange, 1771), which states that the order of any subgroup divides the order of the group. The order of an element g is precisely the size of the cyclic subgroup it generates, so orderOf g divides |G|, and raising g to |G| returns the identity. Historically the special cases came first: Pierre de Fermat stated his 'little theorem' (a^(p−1) ≡ 1 mod p for a coprime to a prime p) in a 1640 letter to Frénicle de Bessy, without proof; Leonhard Euler gave the first published proof in 1736 and generalised it in 1763 to a^φ(n) ≡ 1 mod n for a coprime to n, introducing the totient function φ. Only with the group-theoretic abstraction of the 19th century did it become clear that Euler's and Fermat's congruences are a single statement — the finite-group exponent identity — applied to the unit group (ℤ/nℤ)ˣ, whose order is φ(n).",
+    "problemStatement": "Can we machine-check that every element of a finite group satisfies g ^ |G| = 1, and exhibit Euler's and Fermat's classical congruences as instances?\n\n**Answer: Yes.** The identity is derived from Lagrange, the group exponent is shown to divide the order, and Euler's and Fermat's theorems are obtained as the case of the unit group (ZMod n)ˣ.",
+    "text": "Every element of a finite group raised to the group order is the identity — the engine behind Euler's and Fermat's theorems.",
+    "proofStrategy": "Specialise Lagrange to cyclic subgroups (orderOf g ∣ |G|), convert divisibility to a power identity (orderOf_dvd_iff_pow_eq_one), lift to the exponent (it divides |G| by its universal property), then instantiate on (ZMod n)ˣ where |(ZMod n)ˣ| = φ(n) to recover Euler, and specialise φ(p) = p − 1 to recover Fermat.",
+    "keyInsights": [
+      "g ^ |G| = 1 is Lagrange in disguise: orderOf g is the cardinality of ⟨g⟩, so Lagrange gives orderOf g ∣ |G|, and orderOf_dvd_iff_pow_eq_one turns that divisibility into the power identity",
+      "The group order is generally NOT the minimal common period — that minimum is the exponent, which divides |G|. The identity says |G| is *a* period; the exponent is the *least* one",
+      "Euler's theorem is exactly this theorem applied to the multiplicative group (ZMod n)ˣ, using |(ZMod n)ˣ| = φ(n); no separate number-theoretic argument is needed",
+      "Fermat's little theorem is the prime special case, since φ(p) = p − 1 — a one-line specialisation of Euler",
+      "The Nat.card form g ^ Nat.card G = 1 holds for ANY group with no finiteness hypothesis: when G is infinite, Nat.card G = 0 and g^0 = 1 vacuously"
+    ],
+    "prerequisites": [
+      "Group theory (subgroups, order of an element, cosets)",
+      "Modular arithmetic and the unit group (ZMod n)ˣ",
+      "Euler's totient function φ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "core",
+      "title": "The Core Theorem — g ^ |G| = 1",
+      "startLine": 36,
+      "endLine": 68,
+      "summary": "Lagrange for elements and the finite-group exponent identity, with the Nat.card form.",
+      "mathContext": "$\\operatorname{ord}(g) \\mid |G|$, hence $g^{|G|} = e$; also $g^{\\#G} = e$ unconditionally."
+    },
+    {
+      "id": "exponent",
+      "title": "The Group Exponent Divides the Order",
+      "startLine": 70,
+      "endLine": 95,
+      "summary": "The exponent is the least common period; |G| is one such period, so the exponent divides |G|.",
+      "mathContext": "$\\exp(G) \\mid |G|$, both via the library lemma and via the universal property $\\exp(G)\\mid n \\iff \\forall g,\\, g^n = e$."
+    },
+    {
+      "id": "euler-fermat",
+      "title": "Euler's and Fermat's Theorems",
+      "startLine": 97,
+      "endLine": 124,
+      "summary": "Euler's theorem on (ZMod n)ˣ and Fermat's little theorem in unit-group and field forms.",
+      "mathContext": "$x^{\\varphi(n)} = 1$ in $(\\mathbb{Z}/n)^\\times$; $a^{p-1} = 1$ for $a \\neq 0$ in $\\mathbb{Z}/p$."
+    },
+    {
+      "id": "chain",
+      "title": "The Chain, End to End",
+      "startLine": 126,
+      "endLine": 128,
+      "summary": "A single statement tying Lagrange divisibility to Euler's theorem.",
+      "mathContext": "Lagrange $\\Rightarrow$ exponent identity $\\Rightarrow$ Euler."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Lagrange, Joseph-Louis",
+      "title": "Réflexions sur la résolution algébrique des équations",
+      "year": "1771",
+      "note": "Origin of Lagrange's theorem on subgroup orders"
+    },
+    {
+      "authors": "Euler, Leonhard",
+      "title": "Theoremata arithmetica nova methodo demonstrata",
+      "year": "1763",
+      "note": "Generalisation of Fermat's little theorem to a^φ(n) ≡ 1 (mod n)"
+    },
+    {
+      "authors": "Fermat, Pierre de",
+      "title": "Letter to Frénicle de Bessy",
+      "year": "1640",
+      "note": "Original statement of Fermat's little theorem (without proof)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "extends",
+      "description": "Direct corollary: applying Lagrange to the cyclic subgroup ⟨g⟩ gives orderOf g ∣ |G|, hence g ^ |G| = 1."
+    },
+    {
+      "targetId": "lagrange-theorem-oq-06",
+      "relationship": "related",
+      "description": "Companion open-question entry on index multiplicativity [G:K] = [G:H]·[H:K]; both descend from the same Lagrange divisibility."
+    },
+    {
+      "targetId": "lagrange-theorem-oq-02",
+      "relationship": "related",
+      "description": "Orbit-stabilizer generalises the same divisibility; this entry instead descends to the number-theoretic corollaries."
+    }
+  ],
+  "conclusion": {
+    "summary": "The finite-group exponent identity g ^ |G| = 1 is machine-checked, derived explicitly from Lagrange, and shown to specialise to Euler's theorem and Fermat's little theorem via the unit group (ZMod n)ˣ.",
+    "implications": "Unifies Fermat (1640) and Euler (1763) as a single group-theoretic fact: both are the finite-group exponent identity applied to (ℤ/nℤ)ˣ, whose order is φ(n).",
+    "openQuestions": [
+      "Can the sharper statement — the exponent of (ZMod n)ˣ (the Carmichael function λ(n)) divides φ(n), with strict inequality for non-cyclic unit groups — be formalised and connected to the primitive-root characterisation of when (ZMod n)ˣ is cyclic?",
+      "Does the same exponent-divides-order argument formalise cleanly for the additive structure, recovering n · x = 0 in a finite abelian group of order n?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "FiniteGroupExponent",
+    "lineCount": 128,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/LagrangeTheoremOQ07.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **lagrange-theorem-oq-07**: in any finite group, every element satisfies `g ^ |G| = 1`, with the two classical number-theoretic congruences exhibited as instances.

The chain, all machine-checked:

- **Lagrange for elements** — `orderOf g ∣ |G|` (`orderOf_dvd_card`)
- **Finite group exponent** — `g ^ |G| = 1`, derived explicitly via `orderOf_dvd_iff_pow_eq_one` (and shown definitionally equal to Mathlib's `pow_card_eq_one`)
- **Exponent divides order** — `exponent G ∣ |G|`, both via `Group.exponent_dvd_card` and via the universal property of the exponent
- **Euler's theorem** — `x ^ φ(n) = 1` on `(ZMod n)ˣ`, obtained by applying the exponent identity with `|(ZMod n)ˣ| = φ(n)` (`ZMod.card_units_eq_totient`)
- **Fermat's little theorem** — the `φ(p) = p − 1` special case, in both unit-group and field forms

The pedagogical point is that Euler (1763) and Fermat (1640) are a *single* group-theoretic fact applied to `(ℤ/nℤ)ˣ`.

## Verification

- 11 theorems, 0 definitions, 0 sorries
- `lake env lean` compiles with **0 errors**
- `#print axioms` on all key theorems: only `[propext, Classical.choice, Quot.sound]` → 0-axiom / `verified`
- `Proofs.lean` aggregator updated with the single new import (minimal one-line diff)

## Files

- `proofs/Proofs/LagrangeTheoremOQ07.lean` (new)
- `src/data/proofs/lagrange-theorem-oq-07/meta.json` (new)
- `proofs/Proofs.lean` (+1 import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)