### PR TITLE
research(basel-problem-oq-10): Leibniz series π/4 is only conditionally convergent

### DIFF
--- a/proofs/Proofs/BaselProblemOQ10.lean
+++ b/proofs/Proofs/BaselProblemOQ10.lean
@@ -1,0 +1,93 @@
+import Mathlib
+
+/-
+# Basel Problem OQ-10: Leibniz's series for π — and why it is only conditional
+
+## Open Question
+Formalize the Leibniz–Madhava–Gregory series
+  1 − 1/3 + 1/5 − 1/7 + ⋯ = π/4,
+i.e. ∑_k (-1)^k / (2k+1) = π/4.
+
+## The subtlety
+The naive `tsum` reading `∑' k, (-1)^k/(2k+1) = π/4` is **false**. The Leibniz
+series is only *conditionally* convergent: the terms `(-1)^k/(2k+1)` are not
+absolutely summable (their absolute values `1/(2k+1)` form a divergent
+harmonic-type series). In Lean/Mathlib, `Summable` (and hence `tsum` / `HasSum`)
+demands *unconditional* convergence, so:
+
+  * the family `fun k => (-1)^k/(2k+1)` is **not** `Summable`, and consequently
+  * `∑' k, (-1)^k/(2k+1) = 0` (the junk value for non-summable families),
+    which is `≠ π/4`.
+
+The correct statement is the convergence of the **ordered** partial sums, a
+`Tendsto` of `∑_{i<k}`, which is exactly Mathlib's `tendsto_sum_pi_div_four`.
+
+## Contents
+* `leibniz_tendsto_pi_div_four` — the correct Leibniz statement (ordered partial sums → π/4).
+* `not_summable_leibniz` — the Leibniz family is not `Summable` (conditional convergence).
+* `tsum_leibniz_eq_zero` and `tsum_leibniz_ne_pi_div_four` — the cautionary `tsum` corollaries.
+
+## Status
+Fully machine-checked, 0 axioms, 0 sorries. The non-summability proof is the
+substantive new content; the convergence itself is Mathlib's.
+-/
+
+namespace BaselOQ10
+
+open Filter Topology BigOperators Real Finset
+
+/-- **Leibniz's series for π (correct form).** The *ordered* partial sums
+`∑_{i<k} (-1)^i/(2i+1)` converge to `π/4`. This is the statement that actually
+holds — the series is conditionally convergent. (Mathlib: `tendsto_sum_pi_div_four`.) -/
+theorem leibniz_tendsto_pi_div_four :
+    Tendsto (fun k => ∑ i ∈ range k, (-1 : ℝ) ^ i / (2 * i + 1)) atTop (𝓝 (π / 4)) :=
+  tendsto_sum_pi_div_four
+
+/-- **The Leibniz family is not summable.** The terms `(-1)^k/(2k+1)` are not
+unconditionally summable: their absolute values `1/(2k+1)` dominate the divergent
+half-harmonic series `(1/2)·1/(k+1)`. Hence Leibniz convergence is *conditional*. -/
+theorem not_summable_leibniz :
+    ¬ Summable (fun k : ℕ => (-1 : ℝ) ^ k / (2 * k + 1)) := by
+  rw [← summable_abs_iff]
+  -- |(-1)^k/(2k+1)| = 1/(2k+1)
+  have habs : (fun k : ℕ => |(-1 : ℝ) ^ k / (2 * k + 1)|)
+            = (fun k : ℕ => 1 / (2 * (k : ℝ) + 1)) := by
+    funext k
+    rw [abs_div, abs_pow, abs_neg, abs_one, one_pow, abs_of_pos (by positivity)]
+  rw [habs]
+  intro h
+  -- minorant: 1/(2k+2) ≤ 1/(2k+1), and 1/(2k+2) is half-harmonic, hence divergent
+  have hmin : Summable (fun k : ℕ => 1 / (2 * (k : ℝ) + 2)) := by
+    refine Summable.of_nonneg_of_le (fun k => by positivity) (fun k => ?_) h
+    exact one_div_le_one_div_of_le (by positivity) (by linarith)
+  have hharm : Summable (fun k : ℕ => 1 / ((k : ℝ) + 1)) := by
+    have h2 := hmin.mul_left 2
+    refine (summable_congr (fun k => ?_)).mp h2
+    rw [mul_one_div, div_eq_div_iff (by positivity) (by positivity)]
+    ring
+  have hfull : Summable (fun n : ℕ => 1 / (n : ℝ)) := by
+    rw [← summable_nat_add_iff 1]
+    refine (summable_congr (fun n => ?_)).mp hharm
+    push_cast; ring
+  exact not_summable_one_div_natCast hfull
+
+/-- **Cautionary corollary.** Because the Leibniz family is not summable, its
+`tsum` collapses to the junk value `0` — it is *not* `π/4`. -/
+theorem tsum_leibniz_eq_zero :
+    ∑' k : ℕ, (-1 : ℝ) ^ k / (2 * k + 1) = 0 :=
+  tsum_eq_zero_of_not_summable not_summable_leibniz
+
+/-- The `tsum` of the Leibniz family is `0 ≠ π/4`: the naive unconditional reading
+of "1 − 1/3 + 1/5 − ⋯ = π/4" is false; only the ordered limit above is correct. -/
+theorem tsum_leibniz_ne_pi_div_four :
+    ∑' k : ℕ, (-1 : ℝ) ^ k / (2 * k + 1) ≠ π / 4 := by
+  rw [tsum_leibniz_eq_zero]
+  have : (0 : ℝ) < π / 4 := by positivity
+  linarith
+
+end BaselOQ10
+
+#check @BaselOQ10.leibniz_tendsto_pi_div_four
+#check @BaselOQ10.not_summable_leibniz
+#check @BaselOQ10.tsum_leibniz_eq_zero
+#check @BaselOQ10.tsum_leibniz_ne_pi_div_four

--- a/src/data/proofs/basel-problem-oq-10/meta.json
+++ b/src/data/proofs/basel-problem-oq-10/meta.json
@@ -1,0 +1,106 @@
+{
+  "id": "basel-problem-oq-10",
+  "slug": "basel-problem-oq-10",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology",
+      "BigOperators",
+      "Real",
+      "Finset"
+    ],
+    "namespace": "BaselOQ10",
+    "lineCount": 93,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/BaselProblemOQ10.lean",
+    "sorries": 0
+  },
+  "title": "Leibniz's Series for π — and Why It Is Only Conditional",
+  "description": "The Leibniz–Madhava–Gregory series 1 − 1/3 + 1/5 − 1/7 + ⋯ converges to π/4, but only as an ordered limit of partial sums. The series is conditionally (not absolutely) convergent, so its Mathlib tsum/HasSum value is 0, not π/4 — a subtlety this entry makes precise.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ10.lean",
+    "tags": [
+      "analysis",
+      "infinite-series",
+      "conditional-convergence",
+      "leibniz-formula",
+      "pi",
+      "arctangent",
+      "summability",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 93,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "not_summable_leibniz: the Leibniz family (-1)^k/(2k+1) is NOT Summable — its absolute values 1/(2k+1) dominate the divergent half-harmonic series, so convergence is only conditional. This is the substantive new lemma.",
+      "tsum_leibniz_eq_zero: as a consequence, the unconditional tsum ∑' k, (-1)^k/(2k+1) equals the junk value 0, not π/4",
+      "tsum_leibniz_ne_pi_div_four: the naive 'unconditional' reading 1 − 1/3 + 1/5 − ⋯ = π/4 is false (0 ≠ π/4); only the ordered limit holds",
+      "leibniz_tendsto_pi_div_four: the correct statement — the ordered partial sums ∑_{i<k} (-1)^i/(2i+1) converge to π/4 (re-exporting Mathlib's tendsto_sum_pi_div_four)"
+    ],
+    "prerequisites": [
+      "Mathlib's tendsto_sum_pi_div_four (Leibniz series via Abel's theorem on arctan)",
+      "summable_abs_iff: in ℝ, summability is equivalent to absolute summability",
+      "not_summable_one_div_natCast: the harmonic series ∑ 1/n diverges",
+      "Summable.of_nonneg_of_le (comparison test) and summable_nat_add_iff (index shift)",
+      "Parent: basel-problem (∑ 1/n² = π²/6)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "tendsto_sum_pi_div_four",
+        "description": "The ordered partial sums ∑_{i<k} (-1)^i/(2i+1) tend to π/4; proved in Mathlib via Abel's limit theorem applied to the arctan Maclaurin series at x = 1, with arctan 1 = π/4.",
+        "module": "Mathlib.Analysis.Real.Pi.Leibniz"
+      },
+      {
+        "theorem": "summable_abs_iff",
+        "description": "For real-valued families, Summable f ↔ Summable |f|; the bridge that turns the conditional-convergence question into a question about the harmonic-type series of absolute values.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Order"
+      },
+      {
+        "theorem": "not_summable_one_div_natCast",
+        "description": "The harmonic series ∑ 1/n diverges (¬ Summable (fun n => 1/n : ℕ → ℝ)); the divergent minorant behind non-summability.",
+        "module": "Mathlib.Analysis.PSeries"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "basel-problem-oq-10-oq-01",
+      "question": "Quantify the conditional convergence: prove the alternating-series error bound |∑_{i<k} (-1)^i/(2i+1) − π/4| ≤ 1/(2k+1), giving an explicit (slow) rate for the Leibniz approximation of π/4.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "basel-problem",
+      "relationship": "extends",
+      "description": "Companion to the Basel cluster. Where ζ(2) = ∑ 1/n² = π²/6 is absolutely convergent, the Leibniz series for π/4 is only conditionally convergent — this entry highlights the contrast and the resulting tsum subtlety."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.Real.Pi.Leibniz",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of tendsto_sum_pi_div_four, the ordered-partial-sum form of the Leibniz series for π/4."
+    },
+    {
+      "title": "Leibniz formula for π",
+      "author": "Gottfried Wilhelm Leibniz (also Madhava, Gregory)",
+      "year": "1676",
+      "venue": "Classical",
+      "description": "1 − 1/3 + 1/5 − 1/7 + ⋯ = π/4, the arctangent series at x = 1; convergence is conditional."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes the **Leibniz–Madhava–Gregory series** `1 − 1/3 + 1/5 − 1/7 + ⋯ = π/4` and makes precise *why it is only conditional*.

The naive unconditional reading `∑' k, (-1)^k/(2k+1) = π/4` is **false** in Mathlib: `Summable`/`tsum` demand *unconditional* convergence, but the Leibniz series is only conditionally convergent.

## Theorems (4)
- `leibniz_tendsto_pi_div_four` — the **correct** statement: ordered partial sums `∑_{i<k} (-1)^i/(2i+1) → π/4` (re-exports Mathlib's `tendsto_sum_pi_div_four`).
- `not_summable_leibniz` — **the substantive new lemma**: the family `(-1)^k/(2k+1)` is **not** `Summable`. Via `summable_abs_iff`, `|(-1)^k/(2k+1)| = 1/(2k+1)` dominates the divergent half-harmonic series, reduced to `not_summable_one_div_natCast`.
- `tsum_leibniz_eq_zero` — consequently the unconditional `tsum` collapses to the junk value `0`.
- `tsum_leibniz_ne_pi_div_four` — hence `0 ≠ π/4`: the naive reading is false; only the ordered limit holds.

## Verification
- Compiles against Mathlib (only `import Mathlib`, no sibling deps).
- 0 sorries, 0 `axiom` declarations.
- `#print axioms` = `[propext, Classical.choice, Quot.sound]` (foundational only) → **verified / 0-axiom**.

Companion to the Basel cluster: contrasts the absolutely-convergent ζ(2) = π²/6 with the conditionally-convergent Leibniz π/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)