### PR TITLE
research(zsqrtd-neg-two-oq-02): three-square theorem obstruction — 4^a(8b+7) is never x²+y²+z² (verified)

### DIFF
--- a/proofs/Proofs/ZsqrtdNegTwoOQ02.lean
+++ b/proofs/Proofs/ZsqrtdNegTwoOQ02.lean
@@ -1,0 +1,139 @@
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic
+
+/-!
+# The obstruction direction of the Legendre–Gauss three-square theorem
+
+**Open Question (`zsqrtd-neg-two-oq-02`)**: extend the parent gallery entry
+`Proofs/ZsqrtdNegTwo.lean` ("ℤ[√−2]: Euclidean Domain and x² + 2y²
+Representations") towards the full **Legendre–Gauss three-square theorem**
+
+  `n = x² + y² + z²` is solvable  ↔  `n` is **not** of the form `4^a (8b + 7)`.
+
+The parent file and its siblings establish *sufficiency* slices — e.g. every
+prime `p ≡ 3 (mod 8)` is a sum of three squares, via `p = a² + 2b² = a² + b² + b²`
+extracted from the Euclidean domain `ℤ[√−2]`.  The full forward direction (every
+`n ∉ 4^a(8b+7)` is a sum of three squares) additionally requires Dirichlet's
+theorem on primes in arithmetic progressions and is **not** formalised here (and
+is not yet in Mathlib).
+
+This file proves the **complete necessity / obstruction direction**, which is the
+genuinely elementary and self-contained half:
+
+  `not_sumThreeSq_four_pow_mul`:
+    for all `a b : ℕ`, `4^a (8b + 7)` is **never** a sum of three integer squares.
+
+Equivalently (contrapositive, `sumThreeSq_ne_four_pow_mul`): if `n` is a sum of
+three squares then `n` is not of the form `4^a (8b + 7)`.
+
+Mathlib has `Mathlib/NumberTheory/SumTwoSquares.lean` and
+`Mathlib/NumberTheory/SumFourSquares.lean`, but **no** three-square result; this
+obstruction is therefore new content.
+
+## Proof architecture
+
+Two elementary modular facts, combined by induction on the exponent `a`:
+
+1. **Mod-8 obstruction** (`sumThreeSq_ne_seven_mod_eight`): a sum of three
+   squares is never `≡ 7 (mod 8)`.  Squares mod 8 lie in `{0,1,4}`, and no three
+   of those sum to `7`; verified by `decide` over `ZMod 8`.
+
+2. **Descent** (`descent_even`): if `x² + y² + z² ≡ 0 (mod 4)` then `x, y, z` are
+   all even.  Squares mod 4 lie in `{0,1}`, and the only way three of them sum to
+   `0 (mod 4)` is `0 + 0 + 0`; verified by `decide` over `ZMod 4` (mapping down
+   to `ZMod 2` to read off parity).
+
+The induction: the base case `a = 0` gives `8b + 7 ≡ 7 (mod 8)`, excluded by (1).
+For `a + 1`, the value is `4 · (4^a (8b+7)) ≡ 0 (mod 4)`, so by (2) any
+representation halves to a representation of `4^a (8b+7)`, contradicting the
+induction hypothesis.
+-/
+
+namespace ZsqrtNegTwoOQ02
+
+open scoped Classical
+
+/-! ## Step 1 — the mod-8 obstruction -/
+
+/-- **Mod-8 obstruction.** A sum of three integer squares is never `≡ 7 (mod 8)`.
+Squares in `ZMod 8` are `{0, 1, 4}`, and no three of those sum to `7`. -/
+theorem sumThreeSq_ne_seven_mod_eight (x y z : ℤ) :
+    ((x ^ 2 + y ^ 2 + z ^ 2 : ℤ) : ZMod 8) ≠ 7 := by
+  have key : ∀ a b c : ZMod 8, a ^ 2 + b ^ 2 + c ^ 2 ≠ 7 := by decide
+  push_cast
+  exact key _ _ _
+
+/-! ## Step 2 — the descent step -/
+
+/-- **Descent.** If `x² + y² + z² ≡ 0 (mod 4)` then `x`, `y`, `z` are all even.
+Squares in `ZMod 4` are `{0, 1}`, so a sum of three of them vanishing mod 4
+forces each to be `0`, i.e. each base even.  We read off parity through the
+ring map `ZMod 4 → ZMod 2`. -/
+theorem descent_even (x y z : ℤ)
+    (h : ((x ^ 2 + y ^ 2 + z ^ 2 : ℤ) : ZMod 4) = 0) :
+    (2 : ℤ) ∣ x ∧ (2 : ℤ) ∣ y ∧ (2 : ℤ) ∣ z := by
+  -- the ring homomorphism `ZMod 4 → ZMod 2`
+  set f : ZMod 4 →+* ZMod 2 := ZMod.castHom (by norm_num) (ZMod 2) with hf
+  -- finite check: in `ZMod 4`, a²+b²+c²=0 forces all three to vanish mod 2
+  have key : ∀ a b c : ZMod 4, a ^ 2 + b ^ 2 + c ^ 2 = 0 →
+      f a = 0 ∧ f b = 0 ∧ f c = 0 := by decide
+  -- transport the hypothesis into `ZMod 4`
+  have h4 : (x : ZMod 4) ^ 2 + (y : ZMod 4) ^ 2 + (z : ZMod 4) ^ 2 = 0 := by
+    push_cast at h; exact h
+  obtain ⟨hx, hy, hz⟩ := key _ _ _ h4
+  -- `f ((x : ZMod 4)) = (x : ZMod 2)` since `f` is a ring hom out of `ℤ`'s image
+  have fx : f (x : ZMod 4) = (x : ZMod 2) := by rw [hf]; exact map_intCast _ x
+  have fy : f (y : ZMod 4) = (y : ZMod 2) := by rw [hf]; exact map_intCast _ y
+  have fz : f (z : ZMod 4) = (z : ZMod 2) := by rw [hf]; exact map_intCast _ z
+  refine ⟨?_, ?_, ?_⟩
+  · exact (ZMod.intCast_zmod_eq_zero_iff_dvd x 2).1 (by rw [← fx]; exact hx)
+  · exact (ZMod.intCast_zmod_eq_zero_iff_dvd y 2).1 (by rw [← fy]; exact hy)
+  · exact (ZMod.intCast_zmod_eq_zero_iff_dvd z 2).1 (by rw [← fz]; exact hz)
+
+/-! ## Step 3 — the main obstruction theorem -/
+
+/-- **Necessity direction of the three-square theorem.**  For every `a b : ℕ`,
+the number `4^a (8b + 7)` is *not* a sum of three integer squares. -/
+theorem not_sumThreeSq_four_pow_mul (a b : ℕ) :
+    ¬ ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = 4 ^ a * (8 * b + 7) := by
+  induction a with
+  | zero =>
+    -- base case: `8b + 7 ≡ 7 (mod 8)`, excluded by the mod-8 obstruction
+    rintro ⟨x, y, z, h⟩
+    apply sumThreeSq_ne_seven_mod_eight x y z
+    rw [h]
+    have e : ((4 : ℤ) ^ 0 * (8 * (b : ℤ) + 7) : ℤ) = 8 * (b : ℤ) + 7 := by ring
+    rw [e]
+    push_cast
+    have h8 : (8 : ZMod 8) = 0 := by decide
+    rw [h8]; ring
+  | succ a ih =>
+    -- inductive step: `4^(a+1)(8b+7) = 4 · (4^a(8b+7)) ≡ 0 (mod 4)`; descend
+    rintro ⟨x, y, z, h⟩
+    -- the right-hand side is divisible by 4
+    have hdvd : (4 : ℤ) ∣ 4 ^ (a + 1) * (8 * b + 7) :=
+      Dvd.dvd.mul_right (dvd_pow_self 4 (Nat.succ_ne_zero a)) _
+    have h0 : ((x ^ 2 + y ^ 2 + z ^ 2 : ℤ) : ZMod 4) = 0 := by
+      rw [h, ZMod.intCast_zmod_eq_zero_iff_dvd]
+      exact_mod_cast hdvd
+    obtain ⟨⟨x', hx'⟩, ⟨y', hy'⟩, ⟨z', hz'⟩⟩ := descent_even x y z h0
+    -- substitute `x = 2x'`, etc., and cancel the factor `4`
+    apply ih
+    refine ⟨x', y', z', ?_⟩
+    have hpow : (4 : ℤ) ^ (a + 1) = 4 * 4 ^ a := by rw [pow_succ]; ring
+    have h2 := h
+    rw [hpow, hx', hy', hz'] at h2
+    have h4 : (4 : ℤ) * (x' ^ 2 + y' ^ 2 + z' ^ 2) = 4 * (4 ^ a * (8 * b + 7)) := by
+      linear_combination h2
+    exact mul_left_cancel₀ (by norm_num : (4 : ℤ) ≠ 0) h4
+
+/-- **Contrapositive form.**  If `n` is a sum of three integer squares, then `n`
+is not of the form `4^a (8b + 7)`.  This is the necessity half of the
+Legendre–Gauss three-square theorem. -/
+theorem sumThreeSq_ne_four_pow_mul {n : ℤ} (a b : ℕ)
+    (h : ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = n) :
+    n ≠ 4 ^ a * (8 * b + 7) := by
+  rintro rfl
+  exact not_sumThreeSq_four_pow_mul a b h
+
+end ZsqrtNegTwoOQ02

--- a/src/data/proofs/zsqrtd-neg-two-oq-02/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-02/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "zsqrtd-neg-two-oq-02",
+  "title": "The Obstruction Direction of the Three-Square Theorem: $4^a(8b+7)$ Is Never $x^2+y^2+z^2$",
+  "slug": "zsqrtd-neg-two-oq-02",
+  "description": "Extends the parent gallery family (`zsqrtd-neg-two`, which proves sufficiency slices such as `p ≡ 3 (mod 8) ⟹ p = x² + y² + z²` via the Euclidean domain ℤ[√−2]) towards the full Legendre–Gauss three-square theorem `n = x² + y² + z² ↔ n ≠ 4^a(8b+7)`. This file proves the complete **necessity / obstruction direction**, the elementary and self-contained half: `not_sumThreeSq_four_pow_mul : ∀ a b : ℕ, ¬ ∃ x y z : ℤ, x² + y² + z² = 4^a(8b+7)`, i.e. numbers of the excluded form are never sums of three integer squares. The proof combines two purely modular facts by induction on the exponent a. (1) The mod-8 obstruction `sumThreeSq_ne_seven_mod_eight`: a sum of three squares is never ≡ 7 (mod 8) — squares mod 8 lie in {0,1,4} and no three sum to 7, verified by `decide` over ZMod 8. (2) The descent `descent_even`: if x² + y² + z² ≡ 0 (mod 4) then x, y, z are all even — squares mod 4 lie in {0,1}, so the only sum ≡ 0 is 0+0+0, verified by `decide` over ZMod 4 with parity read off through the ring map ZMod 4 → ZMod 2. The induction: base case a = 0 gives 8b+7 ≡ 7 (mod 8), excluded by (1); for a+1 the value 4·(4^a(8b+7)) ≡ 0 (mod 4), so by (2) any representation halves to one of 4^a(8b+7), contradicting the induction hypothesis. The forward direction (every n ∉ 4^a(8b+7) is a sum of three squares) additionally needs Dirichlet's theorem on primes in arithmetic progressions and is not formalised here — nor is it in Mathlib, which has only the two-square and four-square theorems. Fully machine-checked: 0 sorries, 0 axioms (no `native_decide`; the `decide` calls are over finite ZMod types and reduce in the kernel).",
+  "meta": {
+    "author": "Legendre (1797–98), Gauss (Disquisitiones Arithmeticae, 1801)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Legendre%27s_three-square_theorem",
+    "date": "1798",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ZsqrtdNegTwoOQ02.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-forms",
+      "sums-of-squares",
+      "three-square-theorem",
+      "modular-arithmetic",
+      "descent",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 139,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The two finite case-checks use `decide` (kernel reduction over ZMod 8 and ZMod 4), not `native_decide`, so no `Lean.ofReduceBool` dependency: the only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`. Depends only on Mathlib (`ZMod` arithmetic and `ZMod.intCast_zmod_eq_zero_iff_dvd`).",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "`((n : ℤ) : ZMod m) = 0 ↔ (m : ℤ) ∣ n`. Used twice: to read the divisibility `4 ∣ 4^(a+1)(8b+7)` into a vanishing residue mod 4 that triggers the descent, and to convert the `ZMod 2` parity outputs of the descent into the integer divisibilities `2 ∣ x, 2 ∣ y, 2 ∣ z`.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "map_intCast",
+        "description": "For a ring homomorphism `f`, `f (n : R) = (n : S)`. Applied to the cast map `ZMod 4 → ZMod 2` to show `castHom _ (x : ZMod 4) = (x : ZMod 2)`, the bridge that lets the mod-4 finite check report parity of the original integers.",
+        "module": "Mathlib.Data.Int.Cast.Lemmas"
+      },
+      {
+        "theorem": "ZMod.castHom",
+        "description": "The ring homomorphism `ZMod n → ZMod m` when `m ∣ n`. Instantiated at `2 ∣ 4` to project the mod-4 information down to parity in the descent step.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "dvd_pow_self",
+        "description": "`a ∣ a^n` for `n ≠ 0`, giving `4 ∣ 4^(a+1)` which (times the odd factor) makes `4^(a+1)(8b+7)` divisible by 4 in the inductive step.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "`not_sumThreeSq_four_pow_mul`: the headline necessity theorem — for all `a b : ℕ`, `4^a(8b+7)` is not a sum of three integer squares — proved by induction on the exponent `a`, combining the mod-8 obstruction in the base case with infinite descent in the inductive step. This is the complete elementary half of the Legendre–Gauss three-square theorem and is not available in Mathlib.",
+      "`sumThreeSq_ne_seven_mod_eight`: the mod-8 obstruction that a sum of three integer squares is never ≡ 7 (mod 8), via a single `decide` over `ZMod 8` after `push_cast` reduces the integer statement to its residue.",
+      "`descent_even`: the descent lemma that `x² + y² + z² ≡ 0 (mod 4)` forces `x, y, z` all even, via a `decide` over `ZMod 4` whose parity conclusions are transported to integer divisibility through the ring map `ZMod 4 → ZMod 2` (`map_intCast` + `ZMod.intCast_zmod_eq_zero_iff_dvd`).",
+      "`sumThreeSq_ne_four_pow_mul`: the contrapositive packaging — if `n` is a sum of three squares then `n ≠ 4^a(8b+7)` — the form in which the result reads as the necessity half of the classical iff."
+    ],
+    "prerequisites": [
+      "Sums of three squares and the Legendre–Gauss characterisation",
+      "Modular arithmetic over ZMod n and quadratic residues mod 8",
+      "Infinite descent / induction on a 4-adic valuation",
+      "Ring homomorphisms between ZMod n and ZMod m for m ∣ n"
+    ],
+    "dateAdded": "2026-06-19",
+    "relatedProblems": [
+      {
+        "id": "zsqrtd-neg-two",
+        "relationship": "Complements: the parent proves sufficiency slices (primes p ≡ 3 mod 8 ARE sums of three squares, via p = a² + 2b² = a² + b² + b² from ℤ[√−2]); this file proves the universal necessity obstruction that closes off the excluded numbers 4^a(8b+7)."
+      },
+      {
+        "id": "zsqrtd-neg-two-oq-01",
+        "relationship": "Analogous technique: oq-01 proves the converse `p = a² + 2b² ⟹ p ≡ 1,3 (mod 8)` by a finite `ZMod 8` residue computation; this file uses the same finite-residue method (ZMod 8 and ZMod 4) plus descent for the three-square obstruction."
+      },
+      {
+        "id": "lagrange-four-squares",
+        "relationship": "Contrast: Lagrange's theorem says every natural number is a sum of FOUR squares with no obstruction; the three-square case has exactly the obstruction `4^a(8b+7)` this file establishes."
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 139,
+    "path": "Proofs/ZsqrtdNegTwoOQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "The three-square theorem — a natural number n is a sum of three squares if and only if n is not of the form 4^a(8b+7) — was stated by **Adrien-Marie Legendre** (1797–98) and given a complete, rigorous proof by **Carl Friedrich Gauss** in the Disquisitiones Arithmeticae (1801), where it appears as part of his theory of ternary quadratic forms. The necessity direction (the excluded numbers really cannot be written as three squares) is elementary and was understood well before Gauss: it is a two-line modular observation (no sum of three squares is ≡ 7 mod 8) together with a 4-adic descent. The hard sufficiency direction — that every n outside the excluded family IS a sum of three squares — is what required Gauss's form theory, and a modern proof routes through Dirichlet's theorem on primes in arithmetic progressions. Mathlib formalises Fermat's two-square theorem (`Nat.Prime.sq_add_sq`) and Lagrange's four-square theorem (`Nat.sum_four_squares`) but, as of v4.26.0, contains no three-square result, so the obstruction proved here is new content.",
+    "problemStatement": "**Open Question (zsqrtd-neg-two-oq-02):** extend the parent ℤ[√−2] gallery family towards the full Legendre–Gauss three-square theorem `n = x² + y² + z² ↔ n ≠ 4^a(8b+7)`. This file discharges the complete necessity direction: numbers of the form 4^a(8b+7) are never sums of three integer squares.",
+    "text": "No number of the form 4^a(8b+7) is a sum of three squares — the obstruction half of Legendre's three-square theorem, proved by a mod-8 residue check plus 4-adic descent.",
+    "proofStrategy": "Induction on the exponent a. **Step 1 (mod-8 obstruction, `sumThreeSq_ne_seven_mod_eight`):** casting x² + y² + z² into ZMod 8 and checking all 8³ residue triples by `decide` shows the value 7 is unreachable (squares mod 8 are {0,1,4}, no three sum to 7). **Step 2 (descent, `descent_even`):** if x² + y² + z² ≡ 0 (mod 4), a `decide` over ZMod 4 (squares are {0,1}, only 0+0+0 ≡ 0) shows each base must be even; the parity is extracted by pushing the mod-4 data through the ring homomorphism ZMod 4 → ZMod 2 and reading `2 ∣ x`, `2 ∣ y`, `2 ∣ z`. **Induction (`not_sumThreeSq_four_pow_mul`):** base a = 0 — 4^0(8b+7) = 8b+7 ≡ 7 (mod 8), excluded by Step 1. Step a+1 — 4^(a+1)(8b+7) = 4·(4^a(8b+7)) ≡ 0 (mod 4); by Step 2 any representation x²+y²+z² has x,y,z even, so substituting x=2x' etc. and cancelling the common factor 4 yields x'²+y'²+z'² = 4^a(8b+7), contradicting the induction hypothesis.",
+    "keyInsights": [
+      "**The obstruction is entirely local at 2.** Both halves of the argument live in 2-power moduli: 7 is unreachable mod 8, and divisibility by 4 forces all three bases even. The 4^a factor is exactly a 4-adic valuation, and the descent strips it one power of 4 at a time until the residual odd part 8b+7 hits the mod-8 wall.",
+      "**Squares mod 8 are {0,1,4}, and 7 is the only odd residue they cannot reach in three terms.** Among residues mod 8, sums of three squares attain {0,1,2,3,4,5,6} but never 7 — this single finite fact (one `decide` over ZMod 8) is the whole obstruction at the base level.",
+      "**Descent needs mod 4, not mod 2.** Mod 2, x²+y²+z² ≡ 0 only forces x+y+z even, which is too weak. Mod 4, where squares are {0,1}, a vanishing sum of three forces each to be 0, i.e. each base even — this is what makes the factor-of-4 division legitimate and the induction go through.",
+      "**Parity is read off by a ring map ZMod 4 → ZMod 2.** The finite check produces information in ZMod 4; `map_intCast` for the canonical homomorphism ZMod 4 → ZMod 2 turns `castHom (x : ZMod 4) = (x : ZMod 2)`, and `ZMod.intCast_zmod_eq_zero_iff_dvd` converts the resulting `(x : ZMod 2) = 0` into the integer fact `2 ∣ x` used to halve the representation.",
+      "**Kernel `decide`, not `native_decide`.** Both finite checks are small enough (8³ and 4³ cases) to reduce in the Lean kernel via `decide`, so the proof is genuinely axiom-free — it does not incur the `Lean.ofReduceBool` dependency that `native_decide` would add."
+    ],
+    "prerequisites": [
+      "The Legendre–Gauss three-square theorem and its excluded family 4^a(8b+7)",
+      "Quadratic residues modulo 8 and modulo 4",
+      "Infinite descent on the 2-adic (4-adic) valuation",
+      "ZMod n arithmetic, `decide`, and cast homomorphisms ZMod n → ZMod m"
+    ]
+  },
+  "conclusion": {
+    "summary": "The necessity direction of the Legendre–Gauss three-square theorem — that no number 4^a(8b+7) is a sum of three integer squares — is proved with 0 sorries and 0 axioms (kernel `decide`, no `native_decide`). The file is 152 lines, 4 theorems, 0 definitions, and rests only on elementary `ZMod` arithmetic from Mathlib. It complements the parent ℤ[√−2] family, which supplies sufficiency slices, by closing off the obstructed numbers.",
+    "implications": "Together with the parent's representation results (p ≡ 3 mod 8 ⟹ p = x²+y²+z²) this pins down the obstruction side of the full three-square characterisation. The mod-8 + descent skeleton here is the standard elementary half on which any complete formalisation of the three-square theorem would build; the remaining sufficiency half is the genuinely deep input (Dirichlet / ternary form theory) still absent from Mathlib.",
+    "openQuestions": [
+      "Prove the sufficiency direction: every n with n ≠ 4^a(8b+7) is a sum of three squares. This is the hard half — the cleanest route runs through Dirichlet's theorem on primes in arithmetic progressions (to find an auxiliary prime in a suitable residue class) plus Gauss's theory of ternary quadratic forms, neither yet available in Mathlib for this purpose.",
+      "Assemble the full biconditional `n = x²+y²+z² ↔ ¬∃ a b, n = 4^a(8b+7)` once sufficiency is in place, and connect it to the parent ℤ[√−2] representation theorems as the special-prime instances.",
+      "Derive the classical corollary that a positive integer is a sum of three squares iff it is not 4^a(8b+7), and link it to Gauss's count of representations (the class number h(-n) weighting), bridging to the gallery's quadratic-form entries.",
+      "Formalise the analogous obstruction for sums of three squares with congruence side-conditions, or the polygonal-number variants (Gauss's Eureka theorem on triangular numbers), reusing the mod-8 / descent template."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Module Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring framing the goal — discharge the necessity half of the Legendre–Gauss three-square theorem (4^a(8b+7) is never a sum of three squares) — together with the imports (`Mathlib.Data.ZMod.Basic`, `Mathlib.Tactic`), a note that Mathlib has the two- and four-square theorems but no three-square result, and the proof architecture (mod-8 obstruction + mod-4 descent, combined by induction)."
+    },
+    {
+      "id": "step1-mod8",
+      "title": "Step 1 — The Mod-8 Obstruction",
+      "startLine": 56,
+      "endLine": 65,
+      "summary": "`sumThreeSq_ne_seven_mod_eight`: a sum of three integer squares is never ≡ 7 (mod 8). After `push_cast` reduces `((x²+y²+z²:ℤ):ZMod 8)` to `(x:ZMod 8)² + (y:ZMod 8)² + (z:ZMod 8)²`, a single `decide` over the 8³ residue triples in ZMod 8 confirms 7 is unreachable."
+    },
+    {
+      "id": "step2-descent",
+      "title": "Step 2 — The Descent Step",
+      "startLine": 66,
+      "endLine": 92,
+      "summary": "`descent_even`: if x²+y²+z² ≡ 0 (mod 4) then 2 ∣ x, 2 ∣ y, 2 ∣ z. A `decide` over ZMod 4 (squares {0,1}, only 0+0+0 vanishes) shows each base vanishes under the ring map ZMod 4 → ZMod 2; `map_intCast` identifies that image with `(x : ZMod 2)`, and `ZMod.intCast_zmod_eq_zero_iff_dvd` turns `(x:ZMod 2)=0` into `2 ∣ x`."
+    },
+    {
+      "id": "step3-main",
+      "title": "Step 3 — The Main Obstruction Theorem and Contrapositive",
+      "startLine": 93,
+      "endLine": 139,
+      "summary": "`not_sumThreeSq_four_pow_mul`: induction on a. Base a=0 — 8b+7 ≡ 7 (mod 8), excluded by Step 1. Step a+1 — divisibility `4 ∣ 4^(a+1)(8b+7)` gives `≡ 0 (mod 4)`, so Step 2 makes x,y,z even; substituting x=2x' and cancelling 4 yields a representation of 4^a(8b+7), contradicting the induction hypothesis. `sumThreeSq_ne_four_pow_mul` repackages this as the contrapositive necessity statement."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "zsqrtd-neg-two",
+      "relationship": "parent",
+      "description": "The parent gallery entry builds ℤ[√−2] as a Euclidean domain and proves sufficiency slices of the three-square theorem (e.g. primes p ≡ 3 mod 8 are x²+y²+z² via p = a²+2b² = a²+b²+b²). This file supplies the complementary necessity / obstruction direction, closing off the excluded numbers 4^a(8b+7)."
+    },
+    {
+      "targetId": "zsqrtd-neg-two-oq-01",
+      "relationship": "sibling",
+      "description": "oq-01 proves the converse `odd p = a²+2b² ⟹ p ≡ 1,3 (mod 8)` by a finite ZMod 8 computation; this file reuses the same finite-residue methodology (ZMod 8 for the obstruction, ZMod 4 for the descent) to handle the three-square case."
+    },
+    {
+      "targetId": "lagrange-four-squares",
+      "relationship": "contrast",
+      "description": "Lagrange's four-square theorem asserts every natural number is a sum of four squares with no obstruction whatsoever; the three-square theorem has precisely the obstruction family 4^a(8b+7) established here, marking the boundary between the two classical results."
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "foundational",
+      "description": "Quadratic reciprocity and the residue structure mod 8 underlie both the parent's splitting arguments and, in elementary form, the mod-8 residue computation that powers this file's obstruction (which odd residues a sum of squares can attain)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Discharges the **necessity / obstruction direction** of the Legendre–Gauss three-square theorem, extending the `zsqrtd-neg-two` (ℤ[√−2]) gallery family toward the full characterisation `n = x²+y²+z² ↔ n ≠ 4^a(8b+7)`.

**Main result** (`not_sumThreeSq_four_pow_mul`): for all `a b : ℕ`, no number `4^a(8b+7)` is a sum of three integer squares. Also packaged contrapositively as `sumThreeSq_ne_four_pow_mul`.

The parent family proves *sufficiency* slices (e.g. primes `p ≡ 3 (mod 8)` ARE sums of three squares, via `p = a²+2b² = a²+b²+b²` from the Euclidean domain ℤ[√−2]). This PR supplies the complementary universal obstruction, closing off the excluded numbers.

## Proof

Two elementary modular facts combined by induction on the exponent `a`:

1. **Mod-8 obstruction** (`sumThreeSq_ne_seven_mod_eight`) — a sum of three squares is never `≡ 7 (mod 8)`; squares mod 8 are `{0,1,4}` and no three sum to 7. One `decide` over `ZMod 8` after `push_cast`.
2. **Descent** (`descent_even`) — `x²+y²+z² ≡ 0 (mod 4)` forces `x,y,z` all even; squares mod 4 are `{0,1}`, only `0+0+0` vanishes. `decide` over `ZMod 4`, parity read off through the ring map `ZMod 4 → ZMod 2` (`map_intCast` + `ZMod.intCast_zmod_eq_zero_iff_dvd`).

Induction: base `a=0` gives `8b+7 ≡ 7 (mod 8)` (excluded by 1); step `a+1` gives `4·(4^a(8b+7)) ≡ 0 (mod 4)`, so by (2) any representation halves to one of `4^a(8b+7)`, contradicting the IH.

The hard *sufficiency* direction (every `n ∉ 4^a(8b+7)` is a sum of three squares) needs Dirichlet's theorem + ternary form theory and is left open (noted in `openQuestions`); it is also absent from Mathlib.

## Verification

- **0 sorries, 0 axioms.** `#print axioms not_sumThreeSq_four_pow_mul` = `[propext, Classical.choice, Quot.sound]`.
- Uses kernel `decide` (over small finite `ZMod` types), **not** `native_decide` — so no `Lean.ofReduceBool` dependency. `badge: original`, `status: verified`.
- Verified via full `lake env lean` elaboration (zero errors/sorries/warnings). Mathlib v4.26.0.
- Mathlib has `SumTwoSquares` and `SumFourSquares` but no three-square result — this obstruction is new content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)