### PR TITLE
research(pythagorean-triples-oq-07): parity dichotomy — exactly one leg of a primitive triple is even

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2865,6 +2865,7 @@ import Proofs.PythagoreanTriplesOQ01
 import Proofs.PythagoreanTriplesOQ01Aristotle
 import Proofs.PythagoreanTriplesOQ02
 import Proofs.PythagoreanTriplesOQ05
+import Proofs.PythagoreanTriplesOQ07
 import Proofs.QuadraticGaussSumDiagonal
 import Proofs.QuadraticGaussSumSquare
 import Proofs.QuadraticGaussSumSquareOQ01

--- a/proofs/Proofs/PythagoreanTriplesOQ07.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ07.lean
@@ -1,0 +1,127 @@
+/-
+Parity Dichotomy: Exactly One Leg of a Primitive Pythagorean Triple is Even
+
+Source: Open question from pythagorean-triples gallery proof
+Status: VERIFIED (0 axioms, 0 sorries)
+
+In a primitive Pythagorean triple x² + y² = z² with coprime legs, exactly one
+leg is even and the other odd. There are two ingredients:
+
+  * BOTH ODD is impossible for ANY Pythagorean triple (coprimality not needed):
+    an odd square is 1 mod 4, so a sum of two odd squares is 2 mod 4, which is
+    never a perfect square (Int.sq_ne_two_mod_four).
+
+  * BOTH EVEN is excluded by coprimality: 2 would divide gcd(x, y) = 1.
+
+Together they give the dichotomy. Mathlib packages the coprime statement as
+`PythagoreanTriple.even_odd_of_coprime`; the genuine content surfaced here is
+the standalone "both odd is impossible" obstruction, which holds for every
+triple and is the arithmetic heart of why no primitive triple has two odd legs.
+-/
+
+import Mathlib
+
+namespace PythagoreanTriplesParity
+
+open PythagoreanTriple
+
+variable {x y z : ℤ}
+
+/-! ## Part I: The mod-4 obstruction
+
+The single arithmetic fact behind the whole dichotomy: an odd integer squared
+is `1 mod 4`. -/
+
+/-- An odd integer squared is `1 mod 4`. -/
+theorem sq_emod_four_of_odd {a : ℤ} (ha : a % 2 = 1) : a * a % 4 = 1 := by
+  obtain ⟨k, rfl⟩ := Int.odd_iff.mpr ha
+  have h : (2 * k + 1) * (2 * k + 1) = 4 * (k * k + k) + 1 := by ring
+  omega
+
+/-! ## Part II: Both legs odd is impossible (for every triple)
+
+This needs NO coprimality hypothesis. If both legs were odd then
+`x² + y² ≡ 2 (mod 4)`, but `x² + y² = z²` and a square is never `2 mod 4`. -/
+
+/-- For ANY Pythagorean triple, the two legs cannot both be odd. -/
+theorem not_both_odd (h : PythagoreanTriple x y z) :
+    ¬(x % 2 = 1 ∧ y % 2 = 1) := by
+  rintro ⟨hx, hy⟩
+  have hxx := sq_emod_four_of_odd hx
+  have hyy := sq_emod_four_of_odd hy
+  have hz := Int.sq_ne_two_mod_four z
+  have he : x * x + y * y = z * z := h
+  omega
+
+/-! ## Part III: Both legs even is impossible (under coprimality)
+
+If both legs were even, `2 ∣ gcd(x, y) = 1`, a contradiction. We obtain it as a
+consequence of Mathlib's `even_odd_of_coprime`. -/
+
+/-- For a primitive triple (coprime legs), the two legs cannot both be even. -/
+theorem not_both_even (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1) :
+    ¬(x % 2 = 0 ∧ y % 2 = 0) := by
+  rintro ⟨hx, hy⟩
+  rcases h.even_odd_of_coprime hc with ⟨_, hy1⟩ | ⟨hx1, _⟩ <;> omega
+
+/-! ## Part IV: The parity dichotomy
+
+Combining: exactly one leg is even and the other odd. -/
+
+/-- **Parity dichotomy** (mod-2 form). In a primitive Pythagorean triple,
+either `x` is even and `y` odd, or `x` is odd and `y` even. -/
+theorem parity_dichotomy (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1) :
+    (x % 2 = 0 ∧ y % 2 = 1) ∨ (x % 2 = 1 ∧ y % 2 = 0) :=
+  h.even_odd_of_coprime hc
+
+/-- **Exactly one leg is even** (Even/Odd form). The two legs have opposite
+parity: precisely one is even. -/
+theorem exactly_one_even (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1) :
+    (Even x ∧ Odd y) ∨ (Odd x ∧ Even y) := by
+  rcases h.even_odd_of_coprime hc with ⟨hx, hy⟩ | ⟨hx, hy⟩
+  · exact Or.inl ⟨Int.even_iff.mpr hx, Int.odd_iff.mpr hy⟩
+  · exact Or.inr ⟨Int.odd_iff.mpr hx, Int.even_iff.mpr hy⟩
+
+/-- The legs of a primitive triple never share parity: `Even x ↔ ¬ Even y`. -/
+theorem even_iff_not_even (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1) :
+    Even x ↔ ¬Even y := by
+  rcases h.even_odd_of_coprime hc with ⟨hx, hy⟩ | ⟨hx, hy⟩
+  · simp [Int.even_iff, hx, hy]
+  · simp [Int.even_iff, hx, hy]
+
+/-! ## Part V: Consequence — the hypotenuse is odd
+
+Since exactly one leg is even (`2mn`) and one odd (`m² − n²`), the hypotenuse
+`z` of a primitive triple is odd: `z² = (even)² + (odd)² ≡ 1 (mod 4)`. -/
+
+/-- The hypotenuse of a primitive Pythagorean triple is odd. -/
+theorem hypotenuse_odd (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1) :
+    z % 2 = 1 := by
+  have he : x * x + y * y = z * z := h
+  rcases h.even_odd_of_coprime hc with ⟨hx, hy⟩ | ⟨hx, hy⟩
+  · -- x even, y odd: x² ≡ 0, y² ≡ 1, so z² ≡ 1 mod 4 ⇒ z odd
+    have hxx : x * x % 4 = 0 := by
+      obtain ⟨k, rfl⟩ := Int.even_iff.mpr hx
+      have : (k + k) * (k + k) = 4 * (k * k) := by ring
+      omega
+    have hyy := sq_emod_four_of_odd hy
+    -- z² ≡ 1 mod 4 forces z odd (an even z would give z² ≡ 0 mod 4)
+    rcases Int.emod_two_eq_zero_or_one z with hz0 | hz1
+    · exfalso
+      obtain ⟨k, rfl⟩ := Int.even_iff.mpr hz0
+      have : (k + k) * (k + k) = 4 * (k * k) := by ring
+      omega
+    · exact hz1
+  · have hxx := sq_emod_four_of_odd hx
+    have hyy : y * y % 4 = 0 := by
+      obtain ⟨k, rfl⟩ := Int.even_iff.mpr hy
+      have : (k + k) * (k + k) = 4 * (k * k) := by ring
+      omega
+    rcases Int.emod_two_eq_zero_or_one z with hz0 | hz1
+    · exfalso
+      obtain ⟨k, rfl⟩ := Int.even_iff.mpr hz0
+      have : (k + k) * (k + k) = 4 * (k * k) := by ring
+      omega
+    · exact hz1
+
+end PythagoreanTriplesParity

--- a/src/data/proofs/pythagorean-triples-oq-07/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-07/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "pythagorean-triples-oq-07",
+  "title": "Parity Dichotomy: Exactly One Leg of a Primitive Pythagorean Triple is Even",
+  "slug": "pythagorean-triples-oq-07",
+  "description": "In a primitive Pythagorean triple x²+y²=z² with coprime legs, exactly one leg is even and the other odd. Both-even is excluded by coprimality; both-odd is impossible for ANY triple because a sum of two odd squares is 2 mod 4, never a perfect square. The hypotenuse is consequently odd.",
+  "meta": {
+    "author": "classical; Euclid",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ07.lean",
+    "tags": [
+      "number-theory",
+      "pythagorean-triples",
+      "parity",
+      "modular-arithmetic",
+      "diophantine",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "PythagoreanTriple.even_odd_of_coprime",
+        "description": "For coprime legs, exactly one leg is even (x%2=0 ∧ y%2=1) ∨ (x%2=1 ∧ y%2=0)",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      },
+      {
+        "theorem": "Int.sq_ne_two_mod_four",
+        "description": "z * z % 4 ≠ 2: a perfect square is never 2 mod 4",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      },
+      {
+        "theorem": "Int.odd_iff",
+        "description": "Odd n ↔ n % 2 = 1",
+        "module": "Mathlib.Algebra.Ring.Int.Parity"
+      },
+      {
+        "theorem": "Int.even_iff",
+        "description": "Even n ↔ n % 2 = 0",
+        "module": "Mathlib.Algebra.Group.Int.Even"
+      }
+    ],
+    "originalContributions": [
+      "sq_emod_four_of_odd: an odd integer squared is 1 mod 4 (the arithmetic core)",
+      "not_both_odd: NO Pythagorean triple has two odd legs — proved for ANY triple, no coprimality needed, via the 2-mod-4 obstruction",
+      "not_both_even: a primitive triple has no two even legs (coprimality)",
+      "parity_dichotomy: mod-2 form of exactly-one-even",
+      "exactly_one_even: Even/Odd form of the dichotomy",
+      "even_iff_not_even: the legs never share parity (Even x ↔ ¬Even y)",
+      "hypotenuse_odd: consequence — the hypotenuse of a primitive triple is odd"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 127,
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The classification and parity structure of Pythagorean triples is one of the oldest results in number theory, recorded in Euclid's Elements (Book X) and used implicitly by the Babylonians (Plimpton 322, c. 1800 BCE). For a primitive triple — one with coprime legs — the parametrisation x = m²−n², y = 2mn, z = m²+n² already makes the parity visible: the leg 2mn is even and m²−n² is odd. The clean modular obstruction 'a sum of two odd squares is 2 mod 4, hence never a square' is the elementary reason no primitive triple can have two odd legs, and it is exactly the step that forces the even-leg/odd-leg split that underlies the whole classification (and, downstream, the n=4 case of Fermat's Last Theorem via infinite descent).",
+    "problemStatement": "Can we machine-check that exactly one leg of a primitive Pythagorean triple is even?\n\n**Answer: Yes.** Both-odd is ruled out for every triple by a mod-4 argument; both-even is ruled out by coprimality; together they give the dichotomy, and the hypotenuse is shown to be odd as a corollary.",
+    "text": "Exactly one leg of a primitive Pythagorean triple is even — the parity split behind the classical parametrisation.",
+    "proofStrategy": "Establish that an odd square is 1 mod 4 (sq_emod_four_of_odd). Conclude both legs odd would make x²+y² ≡ 2 mod 4 = z², impossible by Int.sq_ne_two_mod_four (this needs no coprimality). Exclude both-even via Mathlib's even_odd_of_coprime. Package the dichotomy in mod-2 and Even/Odd forms, then derive that the hypotenuse is odd.",
+    "keyInsights": [
+      "The 'both odd is impossible' obstruction holds for EVERY Pythagorean triple, not just primitive ones — coprimality is only needed to exclude the both-even case",
+      "The whole dichotomy rests on a single residue fact: an odd square is 1 mod 4, so two odd squares sum to 2 mod 4, which Int.sq_ne_two_mod_four rules out as a square",
+      "omega closes the modular contradictions once the squares are rewritten in the form 4·(…)+r: it reasons about % with a literal modulus over the atoms x·x, y·y, z·z",
+      "The hypotenuse is forced odd: with one even leg (≡0 mod 4) and one odd leg (≡1 mod 4), z² ≡ 1 mod 4, and an even z would give z² ≡ 0 mod 4"
+    ],
+    "prerequisites": [
+      "Modular arithmetic (residues mod 4)",
+      "Parity of integers",
+      "Pythagorean triples and primitivity (coprime legs)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "obstruction",
+      "title": "The mod-4 Obstruction",
+      "startLine": 30,
+      "endLine": 39,
+      "summary": "An odd integer squared is 1 mod 4 — the single arithmetic fact behind everything.",
+      "mathContext": "$a \\text{ odd} \\Rightarrow a^2 \\equiv 1 \\pmod 4$."
+    },
+    {
+      "id": "both-odd",
+      "title": "Both Legs Odd is Impossible",
+      "startLine": 41,
+      "endLine": 54,
+      "summary": "For any Pythagorean triple, the two legs cannot both be odd (no coprimality needed).",
+      "mathContext": "$x,y$ odd $\\Rightarrow x^2+y^2 \\equiv 2 \\pmod 4$, but $z^2 \\not\\equiv 2 \\pmod 4$."
+    },
+    {
+      "id": "both-even",
+      "title": "Both Legs Even is Impossible",
+      "startLine": 56,
+      "endLine": 65,
+      "summary": "Under coprimality, the two legs cannot both be even.",
+      "mathContext": "$x,y$ even $\\Rightarrow 2 \\mid \\gcd(x,y) = 1$, absurd."
+    },
+    {
+      "id": "dichotomy",
+      "title": "The Parity Dichotomy",
+      "startLine": 67,
+      "endLine": 90,
+      "summary": "Exactly one leg is even, in mod-2 and Even/Odd forms, plus opposite-parity equivalence.",
+      "mathContext": "$(x \\text{ even} \\wedge y \\text{ odd}) \\vee (x \\text{ odd} \\wedge y \\text{ even})$."
+    },
+    {
+      "id": "hypotenuse",
+      "title": "The Hypotenuse is Odd",
+      "startLine": 92,
+      "endLine": 127,
+      "summary": "Consequence: the hypotenuse of a primitive triple is odd.",
+      "mathContext": "$z^2 = (\\text{even})^2 + (\\text{odd})^2 \\equiv 1 \\pmod 4 \\Rightarrow z \\text{ odd}$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Euclid",
+      "title": "Elements, Book X",
+      "year": "c. 300 BCE",
+      "note": "Classical parametrisation of Pythagorean triples"
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1938",
+      "note": "Standard treatment of the primitive triple parametrisation and its parity structure"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "extends",
+      "description": "Refines the structure of Pythagorean triples by establishing the parity of the legs and hypotenuse."
+    },
+    {
+      "targetId": "pythagorean-triples-oq-06",
+      "relationship": "related",
+      "description": "Companion open-question entry on the coprime-parameter classification (m²−n², 2mn, m²+n²); this entry isolates the parity consequence that classification relies on."
+    },
+    {
+      "targetId": "pythagorean-triples-oq-05",
+      "relationship": "related",
+      "description": "Both descend from the primitive-triple structure; oq-05 treats the Brahmagupta–Fibonacci / Gaussian-norm identity, oq-07 the parity dichotomy."
+    }
+  ],
+  "conclusion": {
+    "summary": "Exactly one leg of a primitive Pythagorean triple is even, machine-checked: both-odd is excluded for every triple by a mod-4 argument, both-even by coprimality, and the hypotenuse is shown odd as a corollary.",
+    "implications": "Isolates the elementary parity obstruction (sum of two odd squares is 2 mod 4) that underlies the classical parametrisation and the infinite-descent proof of Fermat's Last Theorem for n=4.",
+    "openQuestions": [
+      "Can the next layer of the structure be formalised — that in a primitive triple the even leg is divisible by 4, equivalently 4 ∣ mn in the parametrisation?",
+      "Does the 'sum of two odd squares is 2 mod 4' obstruction generalise to a clean Lean lemma characterising which integers are sums of two coprime squares (the 1 mod 4 prime condition)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "PythagoreanTriple"
+    ],
+    "namespace": "PythagoreanTriplesParity",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/PythagoreanTriplesOQ07.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **pythagorean-triples-oq-07**: in a primitive Pythagorean triple `x² + y² = z²` with coprime legs, exactly one leg is even and the other odd.

Two ingredients, both machine-checked:

- **Both odd is impossible — for ANY triple** (no coprimality needed): an odd square is `1 mod 4` (`sq_emod_four_of_odd`), so a sum of two odd squares is `2 mod 4`, which is never a perfect square (`Int.sq_ne_two_mod_four`). This standalone obstruction is the arithmetic heart of the result.
- **Both even is impossible — under coprimality**: `2` would divide `gcd(x, y) = 1` (via `PythagoreanTriple.even_odd_of_coprime`).

Together they give the dichotomy, packaged in mod-2 and `Even`/`Odd` forms, plus the corollary that the **hypotenuse is odd**.

## Verification

- 7 theorems, 0 definitions, 0 sorries
- `lake env lean` compiles with **0 errors / 0 warnings**
- `#print axioms` on all key theorems: only `[propext, Classical.choice, Quot.sound]` → 0-axiom / `verified`
- `Proofs.lean` aggregator updated with a single new import

## Files

- `proofs/Proofs/PythagoreanTriplesOQ07.lean` (new)
- `src/data/proofs/pythagorean-triples-oq-07/meta.json` (new)
- `proofs/Proofs.lean` (+1 import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)