### PR TITLE
research(geometric-series-oq-10): third moment ∑ n³ rⁿ = r(1+4r+r²)/(1-r)⁴

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ10.lean
+++ b/proofs/Proofs/GeometricSeriesOQ10.lean
@@ -1,0 +1,169 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Data.Nat.Choose.Cast
+import Mathlib.Tactic
+
+/-
+# Third Moment of the Geometric Series: ∑ n³ rⁿ = r(1+4r+r²)/(1-r)⁴
+
+## What This Proves
+
+For a real ratio `r` with `‖r‖ < 1`,
+
+  ∑_{n=0}^{∞} n³ · rⁿ  =  r(1 + 4r + r²) / (1-r)⁴.
+
+This is the **third moment** of the geometric series, extending the low-order
+moment family:
+
+  ∑ rⁿ        = 1/(1-r)              (zeroth moment, the geometric series itself)
+  ∑ n · rⁿ    = r/(1-r)²             (first moment)
+  ∑ n² · rⁿ   = r(1+r)/(1-r)³        (second moment, `GeometricSeriesOQ07`)
+  ∑ n³ · rⁿ   = r(1+4r+r²)/(1-r)⁴    (third moment — the new result here)
+
+## Why This Is Not Already in Mathlib
+
+Mathlib provides the zeroth and first moments directly
+(`tsum_geometric_of_norm_lt_one`, `tsum_coe_mul_geometric_of_norm_lt_one`),
+but has no closed form for `∑ n³ rⁿ`.  What it *does* provide is the family of
+**rising-binomial** sums
+
+  ∑_n (n+k choose k) · rⁿ = 1/(1-r)^{k+1}     (`hasSum_choose_mul_geometric_of_norm_lt_one`).
+
+The contribution of this file is to assemble the third moment from the
+`k = 0, 1, 2, 3` members of that family, using the polynomial identity in the
+rising-binomial basis
+
+  n³  =  6·(n+3 choose 3)  −  12·(n+2 choose 2)  +  7·(n+1 choose 1)  −  1.
+
+This is the degree-3 analogue of the degree-2 identity `n² = 2·(n+2 choose 2) − 3n − 2`
+used for the second moment.  The coefficients `(6, −12, 7, −1)` are obtained by
+Newton's forward-difference expansion of `n³` against the basis
+`{(n+k choose k)}` (the binomial transform of the sequence `n³`).
+
+## Proof Strategy
+
+1. Take four `HasSum` facts from Mathlib (the rising-binomial family at `k = 3, 2, 1, 0`):
+   - `h₃ : ∑ (n+3 choose 3) rⁿ = 1/(1-r)⁴`
+   - `h₂ : ∑ (n+2 choose 2) rⁿ = 1/(1-r)³`
+   - `h₁ : ∑ (n+1 choose 1) rⁿ = 1/(1-r)²`
+   - `h₀ : ∑ (n+0 choose 0) rⁿ = 1/(1-r)`
+2. Form the linear combination `6·h₃ − 12·h₂ + 7·h₁ − 1·h₀`, whose summand is
+   `n³ rⁿ` by the polynomial identity above.
+3. Simplify the resulting value
+   `6/(1-r)⁴ − 12/(1-r)³ + 7/(1-r)² − 1/(1-r)` to `r(1+4r+r²)/(1-r)⁴`
+   with `field_simp; ring` (valid since `1 - r ≠ 0`), the algebraic core being
+   `6 − 12(1-r) + 7(1-r)² − (1-r)³ = r(1+4r+r²)`.
+
+## Probabilistic Interpretation
+
+If `X` is geometric with `P(X = n) = (1-r) rⁿ` (`n ≥ 0`, `0 ≤ r < 1`), the first
+three moments give `E[X] = r/(1-r)`, `E[X²] = r(1+r)/(1-r)²`, and
+`E[X³] = r(1+4r+r²)/(1-r)³`, from which the skewness of the geometric
+distribution can be read off.
+
+## Status: 0 sorries, 0 axioms
+-/
+
+open Filter Topology
+
+namespace GeometricSeriesOQ10
+
+variable {r : ℝ}
+
+/-! ## Casting the rising-binomial coefficients to ℝ -/
+
+/-- `(n+3 choose 3) = (n+1)(n+2)(n+3)/6`, cast to `ℝ`.
+
+Mathlib has `Nat.cast_choose_two` for the column-2 coefficient but no ready-made
+cast for column 3, so we derive it from `Nat.cast_choose` (the factorial form)
+together with the expansion `(n+3)! = (n+1)(n+2)(n+3) · n!`. -/
+lemma cast_choose_three (n : ℕ) :
+    ((n + 3).choose 3 : ℝ) = (n + 1) * (n + 2) * (n + 3) / 6 := by
+  have hf : ((Nat.factorial (n + 3) : ℕ) : ℝ)
+      = (n + 1) * (n + 2) * (n + 3) * (Nat.factorial n : ℕ) := by
+    rw [Nat.factorial_succ (n + 2), Nat.factorial_succ (n + 1), Nat.factorial_succ n]
+    push_cast
+    ring
+  have hn : ((Nat.factorial n : ℕ) : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_pos n).ne'
+  rw [Nat.cast_choose ℝ (by omega : 3 ≤ n + 3), show n + 3 - 3 = n by omega, hf]
+  have h3 : ((Nat.factorial 3 : ℕ) : ℝ) = 6 := by norm_num [Nat.factorial]
+  rw [h3]
+  field_simp
+
+/-- The algebraic key in the rising-binomial basis:
+`n³ = 6·(n+3 choose 3) − 12·(n+2 choose 2) + 7·(n+1 choose 1) − 1`, cast to `ℝ`. -/
+lemma cube_eq (n : ℕ) :
+    (n : ℝ) ^ 3 = 6 * ((n + 3).choose 3 : ℝ) - 12 * ((n + 2).choose 2 : ℝ)
+      + 7 * ((n + 1).choose 1 : ℝ) - 1 := by
+  rw [cast_choose_three, Nat.cast_choose_two, Nat.choose_one_right]
+  push_cast
+  ring
+
+/-! ## The moment family -/
+
+/-- **Zeroth moment** (the geometric series itself): `∑ rⁿ = 1/(1-r)`. -/
+theorem tsum_geometric (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, r ^ n = (1 - r)⁻¹ :=
+  tsum_geometric_of_norm_lt_one hr
+
+/-- **First moment**: `∑ n · rⁿ = r/(1-r)²` (restatement of Mathlib's result,
+included to display the full moment family). -/
+theorem tsum_mul_geometric (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, (n : ℝ) * r ^ n = r / (1 - r) ^ 2 :=
+  tsum_coe_mul_geometric_of_norm_lt_one hr
+
+/-! ## Third moment (the new result) -/
+
+/-- `1 - r ≠ 0` whenever `‖r‖ < 1` (so `r ≠ 1`). -/
+lemma one_sub_ne_zero (hr : ‖r‖ < 1) : (1 : ℝ) - r ≠ 0 :=
+  sub_ne_zero.mpr fun h => by simp [← h] at hr
+
+/-- **Third moment, `HasSum` form**: `∑ n³ · rⁿ = r(1+4r+r²)/(1-r)⁴`. -/
+theorem hasSum_cube_mul_geometric (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ => (n : ℝ) ^ 3 * r ^ n)
+      (r * (1 + 4 * r + r ^ 2) / (1 - r) ^ 4) := by
+  have hr1 : (1 : ℝ) - r ≠ 0 := one_sub_ne_zero hr
+  -- Four members of the rising-binomial family.
+  have h₃ : HasSum (fun n : ℕ => ((n + 3).choose 3 : ℝ) * r ^ n) (1 / (1 - r) ^ (3 + 1)) :=
+    hasSum_choose_mul_geometric_of_norm_lt_one 3 hr
+  have h₂ : HasSum (fun n : ℕ => ((n + 2).choose 2 : ℝ) * r ^ n) (1 / (1 - r) ^ (2 + 1)) :=
+    hasSum_choose_mul_geometric_of_norm_lt_one 2 hr
+  have h₁ : HasSum (fun n : ℕ => ((n + 1).choose 1 : ℝ) * r ^ n) (1 / (1 - r) ^ (1 + 1)) :=
+    hasSum_choose_mul_geometric_of_norm_lt_one 1 hr
+  have h₀ : HasSum (fun n : ℕ => ((n + 0).choose 0 : ℝ) * r ^ n) (1 / (1 - r) ^ (0 + 1)) :=
+    hasSum_choose_mul_geometric_of_norm_lt_one 0 hr
+  -- Linear combination 6·h₃ − 12·h₂ + 7·h₁ − 1·h₀.
+  have hcomb := (((h₃.mul_left 6).sub (h₂.mul_left 12)).add (h₁.mul_left 7)).sub (h₀.mul_left 1)
+  -- Rewrite the summand as n³ rⁿ via the polynomial identity.
+  have hfun : (fun n : ℕ => (n : ℝ) ^ 3 * r ^ n)
+      = fun n : ℕ =>
+          6 * (((n + 3).choose 3 : ℝ) * r ^ n) - 12 * (((n + 2).choose 2 : ℝ) * r ^ n)
+            + 7 * (((n + 1).choose 1 : ℝ) * r ^ n) - 1 * (((n + 0).choose 0 : ℝ) * r ^ n) := by
+    funext n
+    have hc0 : ((n + 0).choose 0 : ℝ) = 1 := by simp
+    rw [hc0, cube_eq n]
+    ring
+  rw [hfun]
+  -- Functions now match; only the value needs simplification.
+  convert hcomb using 1
+  field_simp
+  ring
+
+/-- **Third moment, `tsum` form**: `∑ n³ · rⁿ = r(1+4r+r²)/(1-r)⁴`. -/
+theorem tsum_cube_mul_geometric (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, (n : ℝ) ^ 3 * r ^ n = r * (1 + 4 * r + r ^ 2) / (1 - r) ^ 4 :=
+  (hasSum_cube_mul_geometric hr).tsum_eq
+
+/-- The third-moment series is summable. -/
+theorem summable_cube_mul_geometric (hr : ‖r‖ < 1) :
+    Summable (fun n : ℕ => (n : ℝ) ^ 3 * r ^ n) :=
+  (hasSum_cube_mul_geometric hr).summable
+
+/-! ## A concrete value -/
+
+/-- Sanity check at `r = 1/2`: `∑ n³/2ⁿ = 26`.
+(`r(1+4r+r²)/(1-r)⁴ = (1/2)(1 + 2 + 1/4)/(1/2)⁴ = (1/2)(13/4)/(1/16) = (13/8)·16 = 26`.) -/
+example : ∑' n : ℕ, (n : ℝ) ^ 3 * (1 / 2 : ℝ) ^ n = 26 := by
+  rw [tsum_cube_mul_geometric (by norm_num : ‖(1 / 2 : ℝ)‖ < 1)]
+  norm_num
+
+end GeometricSeriesOQ10

--- a/src/data/proofs/geometric-series-oq-10/meta.json
+++ b/src/data/proofs/geometric-series-oq-10/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "geometric-series-oq-10",
+  "slug": "geometric-series-oq-10",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Data.Nat.Choose.Cast",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "GeometricSeriesOQ10",
+    "lineCount": 169,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ10.lean",
+    "sorries": 0
+  },
+  "title": "The Third Moment of the Geometric Series: ∑ n³ rⁿ = r(1+4r+r²)/(1-r)⁴",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ10.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "infinite-series",
+      "power-series",
+      "moments",
+      "summability",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 169,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "hasSum_cube_mul_geometric / tsum_cube_mul_geometric: the closed form ∑_{n≥0} n³ · rⁿ = r(1+4r+r²)/(1-r)⁴ for ‖r‖ < 1 over ℝ — a result Mathlib does not provide (it has the zeroth and first moments but no n² or n³ sum), and the next term beyond the second moment of geometric-series-oq-07",
+      "cube_eq: the degree-3 polynomial identity n³ = 6·(n+3 choose 3) − 12·(n+2 choose 2) + 7·(n+1 choose 1) − 1 (cast to ℝ), expressing n³ in the rising-binomial basis Mathlib sums; the coefficients (6,−12,7,−1) are the binomial (forward-difference) transform of the cube sequence",
+      "cast_choose_three: ((n+3 choose 3 : ℝ) = (n+1)(n+2)(n+3)/6), the column-3 cast of a binomial coefficient that Mathlib supplies only up to column 2 (Nat.cast_choose_two); derived here from Nat.cast_choose and the factorial expansion (n+3)! = (n+1)(n+2)(n+3)·n!",
+      "Assembly technique: the third moment is obtained as the linear combination 6·h₃ − 12·h₂ + 7·h₁ − 1·h₀ of four Mathlib HasSum facts (the rising-binomial sums at k=3,2,1,0), with the value 6/(1-r)⁴ − 12/(1-r)³ + 7/(1-r)² − 1/(1-r) collapsed to r(1+4r+r²)/(1-r)⁴ by field_simp; ring",
+      "summable_cube_mul_geometric: summability of n³ rⁿ for ‖r‖ < 1, and a concrete evaluation ∑ n³/2ⁿ = 26"
+    ],
+    "prerequisites": [
+      "Mathlib's rising-binomial geometric sums hasSum_choose_mul_geometric_of_norm_lt_one (∑ (n+k choose k) rⁿ = 1/(1-r)^{k+1}), used at k = 0,1,2,3",
+      "Nat.cast_choose: the factorial form ((b choose a : ℝ) = b!/(a!(b-a)!)) for a ≤ b, used to derive the column-3 cast",
+      "Nat.cast_choose_two and Nat.choose_one_right: the column-2 and column-1 casts",
+      "Nat.factorial_succ: (n+1)! = (n+1)·n!, used to expand (n+3)!",
+      "HasSum arithmetic (HasSum.mul_left, HasSum.add, HasSum.sub, HasSum.tsum_eq)",
+      "Parent: geometric-series (∑ rⁿ = 1/(1-r)); sibling: geometric-series-oq-07 (second moment ∑ n² rⁿ)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_choose_mul_geometric_of_norm_lt_one",
+        "description": "∑_n (n+k choose k) · rⁿ = 1/(1-r)^{k+1} for ‖r‖ < 1. Used at k = 0,1,2,3 as the four building blocks of the linear combination.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Nat.cast_choose",
+        "description": "((b choose a : ℝ) = b!/(a!·(b-a)!) for a ≤ b. Combined with the factorial expansion (n+3)! = (n+1)(n+2)(n+3)·n! to obtain the column-3 cast cast_choose_three.",
+        "module": "Mathlib.Data.Nat.Choose.Cast"
+      },
+      {
+        "theorem": "Nat.cast_choose_two",
+        "description": "((a choose 2 : ℝ) = a·(a-1)/2). Provides the column-2 cast in the polynomial identity for n³.",
+        "module": "Mathlib.Data.Nat.Choose.Cast"
+      },
+      {
+        "theorem": "Nat.factorial_succ",
+        "description": "(n+1)! = (n+1)·n!. Iterated three times to expand (n+3)! = (n+1)(n+2)(n+3)·n!, the algebraic core of cast_choose_three.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-10-oq-01",
+      "question": "Prove the general moment formula ∑_n n^k · rⁿ = A_k(r)/(1-r)^{k+1} for all k, where A_k is the Eulerian polynomial ∑_j ⟨k,j⟩ r^j, by induction on k using the rising-binomial basis expansion n^k = ∑_j S(k,j)·j!·(n+j choose j) (Stirling/forward-difference coefficients). The cases k=0,1,2,3 computed so far (numerators 1, r, r(1+r), r(1+4r+r²)) are the first Eulerian polynomials.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-10-oq-02",
+      "question": "Derive the skewness of the geometric distribution: for X with P(X=n) = (1-r)rⁿ, combine E[X], E[X²], E[X³] from the first three moments to obtain the third central moment and the closed-form skewness (2-r)/√r.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07",
+      "relationship": "extends",
+      "description": "Direct predecessor. oq-07 proves the second moment ∑ n² rⁿ = r(1+r)/(1-r)³ via the degree-2 identity n² = 2·(n+2 choose 2) − 3n − 2. This entry takes the next step to the third moment ∑ n³ rⁿ = r(1+4r+r²)/(1-r)⁴ using the degree-3 identity n³ = 6·(n+3 choose 3) − 12·(n+2 choose 2) + 7·(n+1 choose 1) − 1, and supplies the column-3 binomial cast that Mathlib lacks."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "extends",
+      "description": "Parent. The base entry proves ∑ rⁿ = 1/(1-r) (the zeroth moment). This entry adds the third moment, completing the family ∑ rⁿ, ∑ n rⁿ, ∑ n² rⁿ, ∑ n³ rⁿ of low-order weighted geometric sums."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the rising-binomial geometric sums hasSum_choose_mul_geometric_of_norm_lt_one used at k=0,1,2,3."
+    },
+    {
+      "title": "Concrete Mathematics (geometric series and its derivatives; Eulerian numbers)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the weighted geometric sums ∑ nᵏ rⁿ and the Eulerian-polynomial numerators that arise from repeated differentiation of ∑ rⁿ = 1/(1-r)."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For ‖r‖ < 1 over ℝ, the third moment of the geometric series is ∑_{n≥0} n³ · rⁿ = r(1+4r+r²)/(1-r)⁴. This is the next term beyond geometric-series-oq-07's second moment, extending the low-order family ∑ rⁿ = 1/(1-r), ∑ n rⁿ = r/(1-r)², ∑ n² rⁿ = r(1+r)/(1-r)³, ∑ n³ rⁿ = r(1+4r+r²)/(1-r)⁴. The proof assembles the third moment as the linear combination 6·h₃ − 12·h₂ + 7·h₁ − 1·h₀ of four Mathlib rising-binomial HasSum facts (k=0,1,2,3), using the polynomial identity n³ = 6·(n+3 choose 3) − 12·(n+2 choose 2) + 7·(n+1 choose 1) − 1. A supporting lemma cast_choose_three supplies the column-3 binomial cast ((n+3 choose 3 : ℝ) = (n+1)(n+2)(n+3)/6) that Mathlib provides only up to column 2. The file gives HasSum, tsum, and summability forms plus a concrete check ∑ n³/2ⁿ = 26. 169 lines, 8 theorems/lemmas, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Mathlib provides only the zeroth and first geometric moments, so the closed form for ∑ n³ rⁿ fills a real gap and demonstrates that the rising-binomial assembly technique of oq-07 scales: any nᵏ lies in the finite span of the functions {(n+j choose j) : j ≤ k} that Mathlib already sums, so every moment is a finite linear combination rather than a fresh convergence argument. The only genuinely new infrastructure needed at degree 3 is the column-3 binomial cast, here derived in a few lines from Nat.cast_choose and the factorial expansion. The coefficient pattern (1, r, r(1+r), r(1+4r+r²)) is the sequence of Eulerian polynomials, pointing to the general-moment open question.",
+    "openQuestions": [
+      "Prove the general formula ∑ n^k rⁿ = A_k(r)/(1-r)^{k+1} with A_k the Eulerian polynomial, by induction via the rising-binomial / Stirling expansion of n^k.",
+      "Derive the geometric-distribution skewness (2-r)/√r from the first three moments."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Closed form for the **third moment of the geometric series** over ℝ:

> For ‖r‖ < 1,  ∑_{n≥0} n³ · rⁿ = r(1 + 4r + r²) / (1−r)⁴.

This is the next term beyond the second moment (`geometric-series-oq-07`), completing the low-order family:

| moment | sum | closed form |
|---|---|---|
| 0 | ∑ rⁿ | 1/(1−r) |
| 1 | ∑ n rⁿ | r/(1−r)² |
| 2 | ∑ n² rⁿ | r(1+r)/(1−r)³ |
| **3** | **∑ n³ rⁿ** | **r(1+4r+r²)/(1−r)⁴** |

Mathlib provides only the zeroth and first moments, so the n³ form fills a real gap.

## Technique

Express n³ in the **rising-binomial basis** Mathlib already sums:

  n³ = 6·(n+3 choose 3) − 12·(n+2 choose 2) + 7·(n+1 choose 1) − 1

(the coefficients are the binomial/forward-difference transform of the cube sequence). Then the third moment is the linear combination **6·h₃ − 12·h₂ + 7·h₁ − 1·h₀** of `hasSum_choose_mul_geometric_of_norm_lt_one` at k = 0,1,2,3, with the value 6/(1−r)⁴ − 12/(1−r)³ + 7/(1−r)² − 1/(1−r) collapsed to r(1+4r+r²)/(1−r)⁴ by `field_simp; ring`.

Supporting lemma `cast_choose_three` supplies the column-3 binomial cast `((n+3 choose 3 : ℝ) = (n+1)(n+2)(n+3)/6)` that Mathlib provides only up to column 2 (`Nat.cast_choose_two`), derived from `Nat.cast_choose` plus the factorial expansion (n+3)! = (n+1)(n+2)(n+3)·n!.

## Verification

- 169 lines, 8 lemmas/theorems, 0 definitions, **0 axioms, 0 sorries**
- HasSum / tsum / summability forms + concrete check ∑ n³/2ⁿ = 26
- `#print axioms hasSum_cube_mul_geometric` → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`) → **verified, 0-axiom**

🤖 Generated with [Claude Code](https://claude.com/claude-code)