### PR TITLE
research(euler-totient-oq-05): Euler's theorem congruence form + exponent reduction + RSA

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2367,6 +2367,7 @@ import Proofs.EulerTotientOQ02OQ01
 import Proofs.EulerTotientOQ03
 import Proofs.EulerTotientOQ04
 import Proofs.EulerTotientOQ04OQ01
+import Proofs.EulerTotientOQ05
 import Proofs.FactorRemainderNullstellensatzOQ01
 import Proofs.FactorRemainderNullstellensatzOQ02
 import Proofs.FactorRemainderTheorem

--- a/proofs/Proofs/EulerTotientOQ05.lean
+++ b/proofs/Proofs/EulerTotientOQ05.lean
@@ -1,0 +1,178 @@
+import Mathlib.NumberTheory.PowModTotient
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.Nat.Totient
+import Mathlib.Tactic
+
+/-
+# Euler's Theorem in `Nat.ModEq` Form and the Exponent-Reduction Corollary
+
+## What This Proves
+
+The gallery's base `euler-totient` entry proves Euler's theorem as the *group*
+statement `a ^ φ(n) = 1` for units `a : (ZMod n)ˣ`. This entry develops the
+*computational* / *number-theoretic* face of the same theorem, working directly
+with natural-number congruences `[MOD n]`:
+
+1. `euler_theorem`        : `a ^ φ(n) ≡ 1 [MOD n]` for `Nat.Coprime a n`.
+2. `euler_pow_mod_one`    : `a ^ φ(n) % n = 1` for `1 < n` and coprime `a`.
+3. `exp_reduction`        : `a ^ k ≡ a ^ (k % φ(n)) [MOD n]` — **exponents may be
+                            reduced modulo `φ(n)`**, the workhorse of fast modular
+                            exponentiation and of RSA.
+4. `exp_reduction_mod`    : the same fact in `%`-normal form.
+5. `fermat_little`        : Fermat's little theorem `a ^ (p-1) ≡ 1 [MOD p]` as the
+                            `n = p` prime specialization.
+6. `fermat_little_full`   : `a ^ p ≡ a [MOD p]`, valid even when `p ∣ a`.
+7. `orderOf_dvd_totient`  : the multiplicative order of any unit divides `φ(n)`.
+8. `rsa_correctness`      : if `e * d ≡ 1 [MOD φ(n)]` then `(m ^ e) ^ d ≡ m [MOD n]`
+                            for `m` coprime to `n` — the correctness of RSA
+                            encryption/decryption, derived from Euler's theorem.
+
+## Distinctness
+
+This is deliberately disjoint from:
+- the base `euler-totient` entry (units form `a ^ φ(n) = 1` in `(ZMod n)ˣ`), and
+- `euler-totient-oq-01` (Carmichael's λ, the *minimal* universal exponent).
+
+The content here is the `[MOD n]` reformulation together with exponent reduction
+`a ^ k ≡ a ^ (k % φ(n))` and its cryptographic consequence (RSA correctness),
+none of which appear in those entries.
+
+## Mathlib foundation
+
+`Nat.ModEq.pow_totient`, `Nat.pow_totient_mod`, `Nat.pow_totient_mod_eq_one`
+(file `Mathlib/NumberTheory/PowModTotient.lean`), `ZMod.card_units_eq_totient`,
+`orderOf_dvd_card`.
+-/
+
+namespace EulerTotientOQ05
+
+open Nat
+
+/-! ## Euler's theorem, congruence form -/
+
+/-- **Euler's theorem (`Nat.ModEq` form).** For `a` coprime to `n`,
+`a ^ φ(n) ≡ 1 (mod n)`. This is the number-theoretic statement underlying the
+group-theoretic `a ^ φ(n) = 1` proved in the base entry. -/
+theorem euler_theorem {a n : ℕ} (h : Nat.Coprime a n) :
+    a ^ Nat.totient n ≡ 1 [MOD n] :=
+  Nat.ModEq.pow_totient h
+
+/-- The `%`-normal form of Euler's theorem: for `1 < n` and `a` coprime to `n`,
+`a ^ φ(n)` leaves remainder `1` on division by `n`. -/
+theorem euler_pow_mod_one {a n : ℕ} (hn : 1 < n) (h : Nat.Coprime a n) :
+    a ^ Nat.totient n % n = 1 :=
+  Nat.pow_totient_mod_eq_one hn h
+
+/-! ## Exponent reduction
+
+The practically decisive corollary: when the base is coprime to the modulus, the
+*exponent* of a modular power may be reduced modulo `φ(n)`. This is what lets one
+evaluate astronomically large modular powers, and is the algebraic heart of RSA. -/
+
+/-- **Exponent reduction.** For `1 < n` and `a` coprime to `n`,
+`a ^ k ≡ a ^ (k % φ(n)) (mod n)` for every exponent `k`. -/
+theorem exp_reduction {a n : ℕ} (hn : 1 < n) (h : Nat.Coprime a n) (k : ℕ) :
+    a ^ k ≡ a ^ (k % Nat.totient n) [MOD n] :=
+  Nat.pow_totient_mod hn h
+
+/-- Exponent reduction in `%`-normal form: `a ^ k % n = a ^ (k % φ(n)) % n`. -/
+theorem exp_reduction_mod {a n : ℕ} (hn : 1 < n) (h : Nat.Coprime a n) (k : ℕ) :
+    a ^ k % n = a ^ (k % Nat.totient n) % n :=
+  Nat.pow_totient_mod hn h
+
+/-! ## Fermat's little theorem as the prime case
+
+When `n = p` is prime, `φ(p) = p - 1`, so Euler's theorem specializes to Fermat. -/
+
+/-- **Fermat's little theorem (`Nat.ModEq` form).** For prime `p` and `a` not
+divisible by `p`, `a ^ (p-1) ≡ 1 (mod p)`. -/
+theorem fermat_little {p a : ℕ} (hp : p.Prime) (ha : ¬ p ∣ a) :
+    a ^ (p - 1) ≡ 1 [MOD p] := by
+  have hco : Nat.Coprime a p := (hp.coprime_iff_not_dvd.mpr ha).symm
+  have h := euler_theorem (n := p) hco
+  rwa [Nat.totient_prime hp] at h
+
+/-- **Fermat's little theorem, full form.** `a ^ p ≡ a (mod p)` for *every* `a`,
+including the case `p ∣ a` where both sides vanish mod `p`. -/
+theorem fermat_little_full {p : ℕ} (hp : p.Prime) (a : ℕ) :
+    a ^ p ≡ a [MOD p] := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  rw [← ZMod.natCast_eq_natCast_iff]
+  push_cast
+  exact ZMod.pow_card (a : ZMod p)
+
+/-! ## Order divides the totient -/
+
+/-- The multiplicative order of any unit of `ZMod n` divides `φ(n)`. Equivalently,
+`φ(n)` is a *universal* exponent for `(ZMod n)ˣ`; Carmichael's λ (oq-01) is the
+*least* such exponent. -/
+theorem orderOf_dvd_totient (n : ℕ) [NeZero n] (u : (ZMod n)ˣ) :
+    orderOf u ∣ Nat.totient n := by
+  rw [← ZMod.card_units_eq_totient n]
+  exact orderOf_dvd_card
+
+/-! ## RSA correctness
+
+The capstone application. RSA picks a modulus `n` and exponents `e` (public) and
+`d` (private) with `e * d ≡ 1 (mod φ(n))`. Encryption is `m ↦ m ^ e (mod n)` and
+decryption `c ↦ c ^ d (mod n)`; correctness `(m ^ e) ^ d ≡ m (mod n)` is exactly
+Euler's theorem applied to the surplus exponent `e * d - 1`, a multiple of `φ(n)`. -/
+
+/-- **RSA correctness.** If `1 < n`, `1 < φ(n)`, `m` is coprime to `n`, and the
+RSA key condition `e * d ≡ 1 (mod φ(n))` holds, then decrypting an encrypted
+message recovers it: `(m ^ e) ^ d ≡ m (mod n)`. -/
+theorem rsa_correctness {m n e d : ℕ} (hφ : 1 < Nat.totient n)
+    (hm : Nat.Coprime m n) (hed : e * d ≡ 1 [MOD Nat.totient n]) :
+    (m ^ e) ^ d ≡ m [MOD n] := by
+  -- `e * d` leaves remainder `1` modulo `φ(n)`.
+  have hmod : e * d % Nat.totient n = 1 := by
+    have h1 : (1 : ℕ) % Nat.totient n = 1 := Nat.mod_eq_of_lt hφ
+    have := hed
+    simp only [Nat.ModEq, h1] at this
+    exact this
+  -- hence `e * d = φ(n) * q + 1` for `q = (e*d) / φ(n)`.
+  have hsplit : e * d = Nat.totient n * (e * d / Nat.totient n) + 1 := by
+    conv_lhs => rw [← Nat.div_add_mod (e * d) (Nat.totient n)]
+    rw [hmod]
+  rw [← pow_mul, hsplit, pow_add, pow_mul, pow_one]
+  -- `(m ^ φ(n)) ^ q * m ≡ 1 ^ q * m = m  (mod n)`.
+  calc (m ^ Nat.totient n) ^ (e * d / Nat.totient n) * m
+      ≡ 1 ^ (e * d / Nat.totient n) * m [MOD n] :=
+        ((euler_theorem hm).pow _).mul_right m
+    _ = m := by rw [one_pow, one_mul]
+
+/-! ## Worked examples (axiom-free `decide`)
+
+Exponent reduction lets us settle large modular powers *without* evaluating them.
+The example below proves `3 ^ 100 ≡ 1 (mod 10)` by collapsing the exponent to
+`100 % φ(10) = 100 % 4 = 0`, never forming the 48-digit number `3 ^ 100`. -/
+
+/-- `φ(10) = 4`. -/
+example : Nat.totient 10 = 4 := by decide
+
+/-- `3 ^ 100 ≡ 1 (mod 10)` by exponent reduction: `3 ^ 100 ≡ 3 ^ 0 = 1`. -/
+example : 3 ^ 100 % 10 = 1 := by
+  have h : Nat.Coprime 3 10 := by decide
+  rw [exp_reduction_mod (by norm_num) h]
+  norm_num [show Nat.totient 10 = 4 from by decide]
+
+/-- `7 ^ 222 ≡ 9 (mod 10)`: reduce `222 % φ(10) = 222 % 4 = 2`, then `7 ^ 2 = 49 ≡ 9`. -/
+example : 7 ^ 222 % 10 = 9 := by
+  have h : Nat.Coprime 7 10 := by decide
+  rw [exp_reduction_mod (by norm_num) h]
+  norm_num [show Nat.totient 10 = 4 from by decide]
+
+/-- A small RSA round-trip: `n = 15`, `φ(15) = 8`, public `e = 3`, private `d = 3`
+(since `3 * 3 = 9 ≡ 1 mod 8`); message `m = 2` is recovered: `(2 ^ 3) ^ 3 ≡ 2 (mod 15)`. -/
+example : (2 ^ 3) ^ 3 ≡ 2 [MOD 15] := by
+  have hm : Nat.Coprime 2 15 := by decide
+  have hφ : 1 < Nat.totient 15 := by decide
+  have hed : 3 * 3 ≡ 1 [MOD Nat.totient 15] := by decide
+  exact rsa_correctness hφ hm hed
+
+#check @euler_theorem
+#check @exp_reduction
+#check @fermat_little
+#check @rsa_correctness
+
+end EulerTotientOQ05

--- a/src/data/proofs/euler-totient-oq-05/annotations.json
+++ b/src/data/proofs/euler-totient-oq-05/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "ann-euler-modeq",
+    "proofId": "euler-totient-oq-05",
+    "range": {
+      "startLine": 53,
+      "endLine": 58
+    },
+    "type": "theorem",
+    "title": "Euler's Theorem (congruence form)",
+    "content": "Euler's theorem stated as a natural-number congruence: if gcd(a,n)=1 then a^φ(n) ≡ 1 (mod n). This is the computational counterpart of the base entry's group identity a^φ(n)=1 in (ℤ/nℤ)×. The single-line proof delegates to Mathlib's Nat.ModEq.pow_totient, which in turn rests on Lagrange's theorem applied to the unit group of order φ(n).",
+    "mathContext": "$\\gcd(a,n)=1 \\implies a^{\\varphi(n)} \\equiv 1 \\pmod n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's theorem",
+      "modular congruence",
+      "Lagrange's theorem",
+      "totient"
+    ],
+    "prerequisites": [
+      "Nat.ModEq",
+      "Nat.Coprime",
+      "Nat.totient"
+    ]
+  },
+  {
+    "id": "ann-exp-reduction",
+    "proofId": "euler-totient-oq-05",
+    "range": {
+      "startLine": 72,
+      "endLine": 81
+    },
+    "type": "theorem",
+    "title": "Exponent Reduction modulo φ(n)",
+    "content": "The operationally decisive corollary: for a coprime to n, a^k ≡ a^(k mod φ(n)) (mod n). Exponents of modular powers may always be reduced modulo φ(n), so a power with an astronomically large exponent reduces to one with exponent below φ(n). This is what makes fast modular exponentiation possible and is the algebraic mechanism behind RSA. Proved directly from Mathlib's Nat.pow_totient_mod; the %-normal variant exp_reduction_mod restates it as a^k % n = a^(k mod φ(n)) % n.",
+    "mathContext": "$a^k \\equiv a^{\\,k \\bmod \\varphi(n)} \\pmod n$ for $\\gcd(a,n)=1$, $n>1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "exponent reduction",
+      "modular exponentiation",
+      "RSA",
+      "totient"
+    ],
+    "prerequisites": [
+      "Nat.pow_totient_mod",
+      "modular arithmetic"
+    ]
+  },
+  {
+    "id": "ann-fermat-little",
+    "proofId": "euler-totient-oq-05",
+    "range": {
+      "startLine": 87,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "Fermat's Little Theorem (prime case)",
+    "content": "Fermat's little theorem as the n=p specialization of Euler's theorem: since φ(p)=p−1, coprimality of a with p (i.e. p∤a) gives a^(p-1) ≡ 1 (mod p). The companion fermat_little_full proves the unconditional form a^p ≡ a (mod p), valid even when p divides a (both sides vanish), by casting to ZMod p and applying ZMod.pow_card.",
+    "mathContext": "$p \\nmid a \\implies a^{p-1} \\equiv 1 \\pmod p$; and $a^p \\equiv a \\pmod p$ for all $a$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fermat's little theorem",
+      "prime modulus",
+      "ZMod.pow_card"
+    ],
+    "prerequisites": [
+      "Nat.totient_prime",
+      "Nat.Prime.coprime_iff_not_dvd",
+      "ZMod.pow_card"
+    ]
+  },
+  {
+    "id": "ann-order-dvd-totient",
+    "proofId": "euler-totient-oq-05",
+    "range": {
+      "startLine": 105,
+      "endLine": 113
+    },
+    "type": "theorem",
+    "title": "Order Divides the Totient",
+    "content": "The multiplicative order of any unit u of ℤ/nℤ divides φ(n), via orderOf_dvd_card and ZMod.card_units_eq_totient (|（ℤ/nℤ)×| = φ(n)). This frames φ(n) as a universal exponent for the unit group — a^φ(n)=1 for every unit. Carmichael's λ(n) from euler-totient-oq-01 is the least such universal exponent, refining this divisibility statement.",
+    "mathContext": "$\\operatorname{ord}(u) \\mid \\varphi(n)$ for $u \\in (\\mathbb{Z}/n\\mathbb{Z})^\\times$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "order of an element",
+      "universal exponent",
+      "Carmichael function"
+    ],
+    "prerequisites": [
+      "orderOf_dvd_card",
+      "ZMod.card_units_eq_totient"
+    ]
+  },
+  {
+    "id": "ann-rsa-correctness",
+    "proofId": "euler-totient-oq-05",
+    "range": {
+      "startLine": 121,
+      "endLine": 142
+    },
+    "type": "theorem",
+    "title": "RSA Correctness",
+    "content": "The capstone application. RSA fixes a modulus n with public exponent e and private exponent d satisfying e·d ≡ 1 (mod φ(n)); encryption is m ↦ m^e (mod n) and decryption c ↦ c^d (mod n). Correctness (m^e)^d ≡ m (mod n) for gcd(m,n)=1 is Euler's theorem applied to the surplus exponent: from e·d ≡ 1 (mod φ(n)) write e·d = φ(n)·q + 1 (via Nat.div_add_mod), so m^(e·d) = (m^φ(n))^q · m ≡ 1^q · m = m (mod n), using ModEq.pow and ModEq.mul_right on Euler's theorem.",
+    "mathContext": "$e d \\equiv 1 \\pmod{\\varphi(n)},\\ \\gcd(m,n)=1 \\implies (m^e)^d \\equiv m \\pmod n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "RSA cryptosystem",
+      "Euler's theorem",
+      "modular exponentiation",
+      "public-key cryptography"
+    ],
+    "prerequisites": [
+      "Nat.div_add_mod",
+      "Nat.ModEq.pow_totient",
+      "Nat.ModEq.mul_right"
+    ]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-05/meta.json
+++ b/src/data/proofs/euler-totient-oq-05/meta.json
@@ -1,0 +1,63 @@
+{
+  "id": "euler-totient-oq-05",
+  "title": "Euler's Theorem, Congruence Form, and Exponent Reduction (RSA)",
+  "slug": "euler-totient-oq-05",
+  "description": "Develops the number-theoretic face of Euler's theorem in Nat.ModEq form: a^φ(n) ≡ 1 (mod n) for gcd(a,n)=1, the exponent-reduction corollary a^k ≡ a^(k mod φ(n)) (mod n), Fermat's little theorem (both a^(p-1)≡1 and a^p≡a forms), orderOf u | φ(n) for units, and the correctness of RSA decryption (m^e)^d ≡ m (mod n). 8 theorems, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ05.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "modular-arithmetic",
+      "fermat-little-theorem",
+      "rsa",
+      "cryptography"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified using Mathlib's Nat.ModEq.pow_totient, Nat.pow_totient_mod, ZMod.card_units_eq_totient, and ZMod.pow_card. Concrete examples use decide (no native_decide), so no Lean.ofReduceBool dependency.",
+    "lineCount": 178,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "originalContributions": [
+      "euler_theorem: a^φ(n) ≡ 1 (mod n) in Nat.ModEq form — the computational counterpart to the base entry's group statement a^φ(n)=1 in (ZMod n)ˣ",
+      "exp_reduction: a^k ≡ a^(k mod φ(n)) (mod n) — exponents reduce modulo φ(n), the workhorse of fast modular exponentiation",
+      "fermat_little / fermat_little_full: a^(p-1)≡1 (mod p) for p∤a and a^p≡a (mod p) for all a, derived as the prime specialization",
+      "orderOf_dvd_totient: the multiplicative order of any unit divides φ(n), placing Carmichael's λ (oq-01) as the minimal such exponent",
+      "rsa_correctness: (m^e)^d ≡ m (mod n) when e·d ≡ 1 (mod φ(n)) and gcd(m,n)=1 — RSA encryption/decryption correctness as a corollary of Euler's theorem",
+      "Worked examples settling 3^100 ≡ 1 and 7^222 ≡ 9 (mod 10) by exponent collapse, never forming the large powers; a small RSA round-trip with n=15"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Euler published a^φ(n) ≡ 1 (mod n) in 1763 ('Theoremata arithmetica nova methodo demonstrata'), generalizing Fermat's little theorem (1640) from prime moduli to arbitrary positive integers. The result is structural for the multiplicative group (ℤ/nℤ)*: since it has order φ(n), Lagrange's theorem forces every element to satisfy a^φ(n)=1. The congruence form proved here is the version actually used in computation — it says exponents of a modular power may be reduced modulo φ(n), which is what makes modular exponentiation tractable and is the algebraic backbone of the RSA cryptosystem (Rivest–Shamir–Adleman, 1977). In RSA one publishes a modulus n=pq and an encryption exponent e, keeps a decryption exponent d with e·d ≡ 1 (mod φ(n)) private, and the round-trip (m^e)^d ≡ m (mod n) is precisely Euler's theorem applied to the surplus exponent e·d−1, a multiple of φ(n).",
+    "problemStatement": "Formalize Euler's theorem in Nat.ModEq form, a^φ(n) ≡ 1 (mod n) for gcd(a,n)=1, together with the exponent-reduction corollary a^k ≡ a^(k mod φ(n)) (mod n), Fermat's little theorem as the prime case, the divisibility orderOf u | φ(n), and the correctness of RSA decryption as a direct consequence.",
+    "text": "The base euler-totient entry proves Euler's theorem as the group identity a^φ(n)=1 for units a:(ZMod n)ˣ. This entry works on the number-theoretic side: it states the theorem as a natural-number congruence via Nat.ModEq.pow_totient, then derives exponent reduction a^k ≡ a^(k mod φ(n)) from Nat.pow_totient_mod. The exponent-reduction step is the practically decisive one — it collapses arbitrarily large exponents to representatives mod φ(n), so 3^100 mod 10 is settled by reducing 100 to 100 mod φ(10) = 100 mod 4 = 0 without ever forming 3^100. Fermat's little theorem appears as the n=p specialization (using φ(p)=p−1), in both the a^(p-1)≡1 form (for p∤a) and the a^p≡a form valid for all a (via ZMod.pow_card). The divisibility orderOf u | φ(n) follows from orderOf_dvd_card and ZMod.card_units_eq_totient, framing φ(n) as a universal exponent and connecting to oq-01's Carmichael λ (the least such). The capstone rsa_correctness shows (m^e)^d ≡ m (mod n): writing e·d = φ(n)·q + 1 (from e·d ≡ 1 mod φ(n)), m^(e·d) = (m^φ(n))^q · m ≡ 1^q · m = m.",
+    "proofStrategy": "Euler's theorem and exponent reduction are thin wrappers over Mathlib's Nat.ModEq.pow_totient and Nat.pow_totient_mod. Fermat's full form casts to ZMod p and applies ZMod.pow_card. orderOf_dvd_totient rewrites φ(n) as the cardinality of (ZMod n)ˣ and applies orderOf_dvd_card. RSA correctness is the only multi-step proof: extract e·d mod φ(n) = 1 from the key condition, split e·d = φ(n)·q + 1 via Nat.div_add_mod, then chain m^(e·d) = (m^φ(n))^q · m through Euler's theorem with ModEq.pow and ModEq.mul_right.",
+    "keyInsights": [
+      "Euler's theorem has two faces: the group identity a^φ(n)=1 in (ZMod n)ˣ (base entry) and the congruence a^φ(n) ≡ 1 (mod n) in ℕ (this entry); the latter is what computation uses",
+      "Exponent reduction a^k ≡ a^(k mod φ(n)) is the operationally important corollary: it bounds the exponent of any modular power by φ(n), settling 3^100 ≡ 1 (mod 10) without evaluating 3^100",
+      "Fermat's little theorem is just n=p: φ(p)=p−1 gives a^(p-1)≡1 (mod p), and ZMod.pow_card gives the unconditional a^p≡a (mod p)",
+      "φ(n) is a universal exponent for (ZMod n)ˣ (orderOf u | φ(n)); Carmichael's λ from oq-01 is the least universal exponent, refining this divisibility",
+      "RSA correctness is Euler's theorem in disguise: e·d ≡ 1 (mod φ(n)) makes e·d−1 a multiple of φ(n), so (m^e)^d = m^(e·d) ≡ m (mod n)"
+    ],
+    "prerequisites": [
+      "Euler's totient function and coprimality: Nat.totient, Nat.Coprime",
+      "Modular congruence: Nat.ModEq and its pow/mul combinators",
+      "Mathlib's Nat.ModEq.pow_totient and Nat.pow_totient_mod",
+      "Finite group order: orderOf_dvd_card, ZMod.card_units_eq_totient"
+    ]
+  },
+  "conclusion": {
+    "summary": "Euler's theorem in Nat.ModEq form with the exponent-reduction corollary a^k ≡ a^(k mod φ(n)), Fermat's little theorem, orderOf u | φ(n), and RSA decryption correctness — all derived from Mathlib's Nat.ModEq.pow_totient and Nat.pow_totient_mod. 8 theorems, 0 axioms, 178 lines.",
+    "implications": "The congruence form and exponent reduction are the computationally usable face of Euler's theorem, distinct from the base entry's abstract group statement. RSA correctness shows the theorem's cryptographic payload follows in a few lines once exponent reduction is available.",
+    "openQuestions": [
+      "Prove RSA correctness without the coprimality hypothesis on m, via CRT over the prime factorization n = pq (the full RSA correctness theorem)",
+      "Formalize the converse refinement: Carmichael's λ(n) is the exact (least) universal exponent, sharpening orderOf u | φ(n)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Develops the **number-theoretic / computational face** of Euler's theorem, deliberately disjoint from the existing gallery entries:
- base `euler-totient` proves the *group* identity `a^φ(n)=1` in `(ZMod n)ˣ`;
- `euler-totient-oq-01` covers Carmichael's λ (the *minimal* universal exponent).

This entry works with natural-number congruences `[MOD n]` and the exponent-reduction corollary that powers RSA.

## Results (8 theorems, 0 axioms)

| Theorem | Statement |
|---------|-----------|
| `euler_theorem` | `a^φ(n) ≡ 1 (mod n)` for `gcd(a,n)=1` |
| `euler_pow_mod_one` | `a^φ(n) % n = 1` |
| `exp_reduction` | `a^k ≡ a^(k mod φ(n)) (mod n)` — exponents reduce mod φ(n) |
| `exp_reduction_mod` | %-normal form of the above |
| `fermat_little` | `a^(p-1) ≡ 1 (mod p)` for `p∤a` |
| `fermat_little_full` | `a^p ≡ a (mod p)` for all `a` |
| `orderOf_dvd_totient` | `ord(u) ∣ φ(n)` for units `u` |
| `rsa_correctness` | `(m^e)^d ≡ m (mod n)` when `e·d ≡ 1 (mod φ(n))`, `gcd(m,n)=1` |

Worked examples settle `3^100 ≡ 1` and `7^222 ≡ 9 (mod 10)` by exponent collapse (never forming the large powers) and a small RSA round-trip with `n=15`.

## Verification

- Compiles against Mathlib via `lake env lean Proofs/EulerTotientOQ05.lean`.
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (0-axiom).
- Concrete examples use `decide` (not `native_decide`), so **no `Lean.ofReduceBool` dependency**.

Foundation: `Nat.ModEq.pow_totient`, `Nat.pow_totient_mod`, `ZMod.card_units_eq_totient`, `ZMod.pow_card`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)