### PR TITLE
research(combinations-formula-oq-08): Fibonacci as shallow-diagonal sums of Pascal's triangle

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ08.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ08.lean
@@ -1,0 +1,102 @@
+import Mathlib
+
+/-
+# Fibonacci Numbers as Sums Along the Shallow Diagonals of Pascal's Triangle
+
+## Open Question OQ-08
+
+The Fibonacci numbers are the sums of the binomial coefficients lying along the
+"shallow diagonals" of Pascal's triangle:
+
+  fib (n + 1) = C(n,0) + C(n-1,1) + C(n-2,2) + ⋯
+
+Mathlib already provides this identity in its *antidiagonal* form,
+`Nat.fib_succ_eq_sum_choose`:
+
+  fib (n + 1) = ∑ p ∈ antidiagonal n, choose p.1 p.2 .
+
+The antidiagonal `{(i, j) : i + j = n}` is not the textbook presentation, and the
+visible "diagonal" indexing is hidden inside the pair structure.  The contribution
+of this file is to reindex that sum into the two presentations one actually meets
+in combinatorics texts:
+
+1. `fib_eq_sum_range_choose`  — a single sum over `Finset.range (n + 1)`:
+        fib (n + 1) = ∑ k < n+1, C(n - k, k).
+   This is the literal "shallow diagonal" formula: the k-th term `C(n-k, k)` is the
+   entry that sits k steps up the diagonal.
+
+2. `fib_eq_sum_range_half_choose` — the same sum truncated to its genuinely nonzero
+   range `0 ≤ k ≤ ⌊n/2⌋`:
+        fib (n + 1) = ∑ k < n/2 + 1, C(n - k, k),
+   reflecting that `C(n - k, k) = 0` once `k` overshoots `n/2`.
+
+## Mathematical Context
+
+A shallow diagonal of Pascal's triangle collects entries `C(n, 0), C(n-1, 1), …`,
+stepping one row up and one column right at each step.  The classical theorem
+(due to Lucas) states their sum is a Fibonacci number.  The proof reduces to the
+antidiagonal identity by:
+
+* `Finset.Nat.sum_antidiagonal_eq_sum_range_succ`, which evaluates the antidiagonal
+  pair `(i, j)` as `(k, n - k)` over `k ∈ range (n+1)`, and
+* `Finset.sum_range_reflect`, which reverses the index `k ↦ n - k` so that the
+  surviving summand becomes the textbook `C(n - k, k)`.
+
+The truncation step uses `Finset.sum_subset` together with
+`Nat.choose_eq_zero_of_lt`: when `k > n/2` we have `n - k < k`, so `C(n - k, k) = 0`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ08
+
+open Finset
+
+/-- **Anchor (Mathlib form).** Fibonacci as a sum over the antidiagonal of `n`.
+    This is exactly `Nat.fib_succ_eq_sum_choose`, restated here as the starting
+    point for the reindexed diagonal presentations below. -/
+theorem fib_eq_sum_antidiagonal_choose (n : ℕ) :
+    Nat.fib (n + 1) = ∑ p ∈ Finset.antidiagonal n, Nat.choose p.1 p.2 :=
+  Nat.fib_succ_eq_sum_choose n
+
+/-- **Shallow-diagonal formula (range form).**
+    `fib (n + 1) = ∑_{k=0}^{n} C(n - k, k)` — the textbook sum along the shallow
+    diagonal of Pascal's triangle. -/
+theorem fib_eq_sum_range_choose (n : ℕ) :
+    Nat.fib (n + 1) = ∑ k ∈ Finset.range (n + 1), Nat.choose (n - k) k := by
+  rw [fib_eq_sum_antidiagonal_choose,
+      Finset.Nat.sum_antidiagonal_eq_sum_range_succ (fun i j => Nat.choose i j) n,
+      ← Finset.sum_range_reflect (fun k => Nat.choose (n - k) k) (n + 1)]
+  refine Finset.sum_congr rfl (fun k hk => ?_)
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+  simp only [Nat.add_sub_cancel, Nat.sub_sub_self hk]
+
+/-- The shallow-diagonal terms vanish past the midpoint: for `k > n / 2` we have
+    `n - k < k`, hence `C(n - k, k) = 0`. -/
+theorem choose_shallow_eq_zero {n k : ℕ} (hk : n / 2 < k) :
+    Nat.choose (n - k) k = 0 := by
+  -- `omega` understands `n / 2` (division by the literal `2`): `n / 2 < k ⟹ n - k < k`.
+  exact Nat.choose_eq_zero_of_lt (by omega)
+
+/-- **Truncated shallow-diagonal formula.**
+    `fib (n + 1) = ∑_{k=0}^{⌊n/2⌋} C(n - k, k)` — the sum restricted to the range
+    where the binomial coefficients are nonzero. -/
+theorem fib_eq_sum_range_half_choose (n : ℕ) :
+    Nat.fib (n + 1) = ∑ k ∈ Finset.range (n / 2 + 1), Nat.choose (n - k) k := by
+  rw [fib_eq_sum_range_choose]
+  symm
+  apply Finset.sum_subset
+  · intro x hx
+    rw [Finset.mem_range] at hx ⊢
+    omega
+  · intro k _ hk
+    rw [Finset.mem_range, Nat.lt_succ_iff, not_le] at hk
+    exact choose_shallow_eq_zero hk
+
+/-- Sanity check: `fib 6 = 8` recovered from the shallow-diagonal sum
+    `C(5,0) + C(4,1) + C(3,2) = 1 + 4 + 3 = 8`. -/
+example : Nat.fib 6 = 8 := by
+  rw [fib_eq_sum_range_half_choose 5]
+  decide
+
+end CombinationsFormulaOQ08

--- a/src/data/proofs/combinations-formula-oq-08/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-08/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "shallow-diagonal-context",
+    "proofId": "combinations-formula-oq-08",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "concept",
+    "title": "Fibonacci Numbers and the Shallow Diagonals of Pascal's Triangle",
+    "content": "A shallow diagonal of Pascal's triangle collects entries C(n,0), C(n-1,1), C(n-2,2), …, stepping one row up and one column right at each step. Lucas's classical theorem states their sum is a Fibonacci number: fib(n+1) = ∑ C(n-k, k). Mathlib already proves the equivalent antidiagonal form Nat.fib_succ_eq_sum_choose, but the visible diagonal indexing is hidden inside the antidiagonal pair structure. This entry reindexes it into the two single-sum presentations found in combinatorics texts.",
+    "mathContext": "Summing $\\binom{n-k}{k}$ over $k \\ge 0$ traces a shallow diagonal of Pascal's triangle (stepping one row up and one column right), and the entries on that diagonal sum to $\\mathrm{fib}(n+1)$. The identity $\\mathrm{fib}(n+1) = \\sum_{k=0}^{\\lfloor n/2 \\rfloor} \\binom{n-k}{k}$ is the discrete counterpart of the generating function $\\sum_n \\mathrm{fib}(n+1) x^n = \\frac{1}{1 - x - x^2}$ expanded via $\\frac{1}{1-(x+x^2)} = \\sum_m (x + x^2)^m$ and the binomial theorem.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fibonacci numbers",
+      "Pascal's triangle",
+      "binomial coefficients",
+      "Lucas identities",
+      "linear recurrences"
+    ],
+    "prerequisites": [
+      "Nat.fib and the Fibonacci recurrence",
+      "Nat.choose binomial coefficients",
+      "Finset.antidiagonal and Finset.range sums"
+    ]
+  },
+  {
+    "id": "antidiagonal-anchor",
+    "proofId": "combinations-formula-oq-08",
+    "range": { "startLine": 56, "endLine": 63 },
+    "type": "theorem",
+    "title": "Anchor: Antidiagonal Form (Mathlib)",
+    "content": "fib_eq_sum_antidiagonal_choose restates Mathlib's Nat.fib_succ_eq_sum_choose: fib(n+1) = ∑ over p ∈ antidiagonal n of C(p.1, p.2). The antidiagonal {(i,j) : i+j = n} carries the diagonal data implicitly — each pair (i,j) is a Pascal entry C(i,j) with i+j fixed. This serves as the starting point that the subsequent theorems reindex into explicit single sums.",
+    "mathContext": "Mathlib's proof of $\\mathrm{fib}(n+1) = \\sum_{(i,j) \\in \\mathrm{antidiagonal}(n)} \\binom{i}{j}$ proceeds by two-step induction matching the Fibonacci recurrence, using the antidiagonal-of-successor decomposition and Pascal's rule $\\binom{n+1}{k+1} = \\binom{n}{k} + \\binom{n}{k+1}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.antidiagonal",
+      "Nat.fib_succ_eq_sum_choose",
+      "two-step induction"
+    ],
+    "prerequisites": [
+      "Finset.antidiagonal over ℕ"
+    ]
+  },
+  {
+    "id": "range-form-theorem",
+    "proofId": "combinations-formula-oq-08",
+    "range": { "startLine": 65, "endLine": 74 },
+    "type": "theorem",
+    "title": "Shallow-Diagonal Range Form",
+    "content": "fib_eq_sum_range_choose proves fib(n+1) = ∑_{k ∈ range(n+1)} C(n-k, k), the textbook single-sum shallow-diagonal formula. The proof rewrites the antidiagonal sum into a range sum via Finset.Nat.sum_antidiagonal_eq_sum_range_succ (evaluating (i,j) as (k, n-k), giving ∑ C(k, n-k)), then applies Finset.sum_range_reflect to reverse the index k ↦ n-k. A final sum_congr uses Nat.sub_sub_self (n-(n-k) = k for k ≤ n) to identify the reflected summand with C(n-k, k).",
+    "mathContext": "The key symmetry is the index reflection $k \\mapsto n-k$ on $\\{0, 1, \\ldots, n\\}$: it sends the direct antidiagonal evaluation $\\binom{k}{n-k}$ to the conventional $\\binom{n-k}{k}$. Both sums equal $\\mathrm{fib}(n+1)$; the reflection just chooses which index labels the 'distance up the diagonal'.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_range_reflect",
+      "Finset.Nat.sum_antidiagonal_eq_sum_range_succ",
+      "Nat.sub_sub_self",
+      "index reindexing"
+    ],
+    "prerequisites": [
+      "reindexing finite sums",
+      "Nat truncated subtraction"
+    ]
+  },
+  {
+    "id": "tail-vanishing-lemma",
+    "proofId": "combinations-formula-oq-08",
+    "range": { "startLine": 76, "endLine": 79 },
+    "type": "theorem",
+    "title": "Tail-Vanishing Lemma",
+    "content": "choose_shallow_eq_zero proves C(n-k, k) = 0 whenever k > ⌊n/2⌋. This is the combinatorial reason the diagonal sum is effectively finite: once the lower index k overtakes the upper index n-k, the binomial coefficient vanishes. omega derives n-k < k from n/2 < k (handling the division by the literal 2), and Nat.choose_eq_zero_of_lt finishes.",
+    "mathContext": "For natural numbers, $\\binom{m}{k} = 0$ exactly when $k > m$. Here $m = n-k$, so the coefficient vanishes when $k > n-k$, i.e. $2k > n$, i.e. $k > \\lfloor n/2 \\rfloor$. This bounds the genuinely contributing terms to $0 \\le k \\le \\lfloor n/2 \\rfloor$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.choose_eq_zero_of_lt",
+      "omega division reasoning",
+      "support of a finite sum"
+    ],
+    "prerequisites": [
+      "Nat.choose vanishing condition"
+    ]
+  },
+  {
+    "id": "truncated-form-theorem",
+    "proofId": "combinations-formula-oq-08",
+    "range": { "startLine": 81, "endLine": 99 },
+    "type": "theorem",
+    "title": "Truncated Textbook Form and Verification",
+    "content": "fib_eq_sum_range_half_choose proves fib(n+1) = ∑_{k ∈ range(⌊n/2⌋+1)} C(n-k, k), the standard textbook statement with the sum running only over the nonzero range. The proof starts from the range form and applies Finset.sum_subset, using the tail-vanishing lemma to justify discarding the terms with k > ⌊n/2⌋. A worked example confirms fib 6 = C(5,0)+C(4,1)+C(3,2) = 1+4+3 = 8.",
+    "mathContext": "$\\mathrm{fib}(n+1) = \\sum_{k=0}^{\\lfloor n/2 \\rfloor} \\binom{n-k}{k}$ is the form most commonly quoted. For $n=5$: $\\binom{5}{0} + \\binom{4}{1} + \\binom{3}{2} = 1 + 4 + 3 = 8 = \\mathrm{fib}(6)$, reading the shallow diagonal of Pascal's triangle through rows 5, 4, 3.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_subset",
+      "restricting a sum to its support",
+      "concrete verification by decide"
+    ],
+    "prerequisites": [
+      "Finset.sum_subset",
+      "vanishing-term sum restriction"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-08/meta.json
+++ b/src/data/proofs/combinations-formula-oq-08/meta.json
@@ -1,0 +1,112 @@
+{
+  "id": "combinations-formula-oq-08",
+  "title": "Fibonacci Numbers as Shallow-Diagonal Sums of Pascal's Triangle",
+  "slug": "combinations-formula-oq-08",
+  "description": "Formalizes Lucas's classical identity that Fibonacci numbers are the sums of binomial coefficients along the shallow diagonals of Pascal's triangle. Starting from Mathlib's antidiagonal form Nat.fib_succ_eq_sum_choose, we reindex into the two textbook presentations: the range form fib(n+1) = ∑_{k=0}^{n} C(n-k, k), and its truncation to the genuinely nonzero range fib(n+1) = ∑_{k=0}^{⌊n/2⌋} C(n-k, k).",
+  "meta": {
+    "author": "Lean Genius researcher-10",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ08.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 102,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. All identities hold for every natural number n and are fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms).",
+    "tags": [
+      "combinatorics",
+      "fibonacci",
+      "pascals-triangle",
+      "binomial-coefficients",
+      "finset-sums",
+      "number-theory"
+    ],
+    "dateAdded": "2026-06-19",
+    "originalContributions": [
+      "fib_eq_sum_range_choose: the shallow-diagonal formula as a single range sum fib(n+1) = ∑_{k<n+1} C(n-k, k), reindexed from Mathlib's antidiagonal form via sum_antidiagonal_eq_sum_range_succ and sum_range_reflect",
+      "choose_shallow_eq_zero: the tail-vanishing lemma C(n-k, k) = 0 for k > ⌊n/2⌋, the combinatorial reason the diagonal sum is finite",
+      "fib_eq_sum_range_half_choose: the truncated textbook form fib(n+1) = ∑_{k≤⌊n/2⌋} C(n-k, k), restricting to the nonzero terms via Finset.sum_subset",
+      "Worked verification fib 6 = C(5,0)+C(4,1)+C(3,2) = 1+4+3 = 8 from the truncated formula"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ08.lean",
+    "namespace": "CombinationsFormulaOQ08",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 102,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The appearance of Fibonacci numbers as sums along the diagonals of Pascal's triangle is attributed to Édouard Lucas (1876), who systematized many Fibonacci identities. The shallow diagonals of Pascal's triangle — the lines of slope obtained by stepping one row up and one column right — sum precisely to the Fibonacci sequence. The identity is a discrete shadow of the generating-function relation between the Fibonacci recurrence and the binomial expansion, and is a standard exercise illustrating the interplay between linear recurrences and binomial coefficients.",
+    "problemStatement": "Open Question OQ-08: Formalize that the Fibonacci numbers are the sums of binomial coefficients along the shallow diagonals of Pascal's triangle. Mathlib provides the antidiagonal form $\\mathrm{fib}(n+1) = \\sum_{(i,j):\\,i+j=n} \\binom{i}{j}$; the task is to reindex it into the textbook single-sum presentations $\\mathrm{fib}(n+1) = \\sum_{k=0}^{n} \\binom{n-k}{k} = \\sum_{k=0}^{\\lfloor n/2 \\rfloor} \\binom{n-k}{k}$.",
+    "proofStrategy": "Begin from Mathlib's Nat.fib_succ_eq_sum_choose, which expresses fib(n+1) as a sum of choose p.1 p.2 over Finset.antidiagonal n. Apply Finset.Nat.sum_antidiagonal_eq_sum_range_succ to evaluate the antidiagonal pair (i,j) as (k, n-k) over k ∈ range(n+1), giving ∑ C(k, n-k). Then Finset.sum_range_reflect reverses the index k ↦ n-k; a sum_congr with Nat.sub_sub_self turns the surviving summand into the textbook C(n-k, k). For the truncated form, choose_shallow_eq_zero shows C(n-k, k) = 0 whenever k > ⌊n/2⌋ (since then n-k < k), and Finset.sum_subset discards those vanishing tail terms, restricting the index set to range(⌊n/2⌋+1).",
+    "keyInsights": [
+      "The 'shallow diagonal' indexing hidden inside Mathlib's antidiagonal pair (i,j) with i+j=n becomes visible once reindexed: the k-th diagonal term is C(n-k, k), the entry k steps up the diagonal.",
+      "Finset.sum_range_reflect is the precise tool for the symmetry k ↦ n-k that converts C(k, n-k) (the direct antidiagonal evaluation) into the conventional C(n-k, k).",
+      "The diagonal sum is automatically finite because C(n-k, k) vanishes once k exceeds ⌊n/2⌋: at that point the lower index k overtakes the upper index n-k, and Nat.choose_eq_zero_of_lt applies.",
+      "omega handles the division-by-two reasoning (n/2 < k ⟹ n - k < k) needed to locate the vanishing tail, keeping the truncation argument fully automatic."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Header stating OQ-08: Fibonacci numbers as shallow-diagonal sums of Pascal's triangle. Explains the relationship to Mathlib's antidiagonal form and the two reindexed presentations (range form and truncated form) that constitute the contribution."
+    },
+    {
+      "id": "anchor",
+      "title": "Anchor: Antidiagonal Form",
+      "startLine": 56,
+      "endLine": 63,
+      "summary": "fib_eq_sum_antidiagonal_choose: restates Mathlib's Nat.fib_succ_eq_sum_choose, fib(n+1) = ∑ over antidiagonal n of C(p.1, p.2), as the starting point for the reindexed forms."
+    },
+    {
+      "id": "range-form",
+      "title": "Shallow-Diagonal Range Form",
+      "startLine": 65,
+      "endLine": 74,
+      "summary": "fib_eq_sum_range_choose: fib(n+1) = ∑_{k<n+1} C(n-k, k). Proved by rewriting with the antidiagonal-to-range lemma, reflecting the index via Finset.sum_range_reflect, and a sum_congr using Nat.sub_sub_self."
+    },
+    {
+      "id": "tail-vanishing",
+      "title": "Tail-Vanishing Lemma",
+      "startLine": 76,
+      "endLine": 79,
+      "summary": "choose_shallow_eq_zero: for k > ⌊n/2⌋, C(n-k, k) = 0. omega derives n-k < k from n/2 < k, then Nat.choose_eq_zero_of_lt finishes."
+    },
+    {
+      "id": "truncated-form",
+      "title": "Truncated Textbook Form",
+      "startLine": 81,
+      "endLine": 93,
+      "summary": "fib_eq_sum_range_half_choose: fib(n+1) = ∑_{k≤⌊n/2⌋} C(n-k, k). Uses Finset.sum_subset to discard the vanishing tail terms from the range form."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verification",
+      "startLine": 95,
+      "endLine": 99,
+      "summary": "example: fib 6 = 8 recovered from the truncated formula as C(5,0)+C(4,1)+C(3,2) = 1+4+3."
+    }
+  ],
+  "conclusion": {
+    "summary": "4 theorems, 0 sorries, 0 axioms. Lucas's shallow-diagonal identity for Fibonacci numbers is formalized in both its range form fib(n+1) = ∑_{k<n+1} C(n-k, k) and its truncated textbook form fib(n+1) = ∑_{k≤⌊n/2⌋} C(n-k, k), reindexed from Mathlib's antidiagonal presentation.",
+    "implications": "This turns Mathlib's somewhat opaque antidiagonal identity into the presentation actually used in combinatorics texts, making the 'diagonals of Pascal's triangle' picture literal in Lean. The reindexing pattern (sum_antidiagonal_eq_sum_range_succ followed by sum_range_reflect, then sum_subset to drop vanishing tail terms) is reusable for any antidiagonal binomial identity that one wishes to present as a single bounded sum.",
+    "openQuestions": [
+      "Can the companion Lucas identity for the partial sums ∑_{i<n} fib(i) = fib(n+1) - 1 be linked to the diagonal sums to give a generating-function-free proof of the Fibonacci recurrence from binomial coefficients?",
+      "Does the analogous shallow-diagonal sum with a fixed stride s (stepping s columns per row) recover the s-bonacci / higher-order recurrence numbers, and can that be formalized uniformly?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-02",
+      "relationship": "ancestor — the core combinations formula entry providing binomial coefficient context"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes Lucas's classical identity that **Fibonacci numbers are the sums of binomial coefficients along the shallow diagonals of Pascal's triangle**.

Mathlib already proves the equivalent *antidiagonal* form (`Nat.fib_succ_eq_sum_choose`), but the diagonal indexing is hidden inside the pair structure. This entry reindexes it into the two single-sum presentations actually used in combinatorics texts:

- `fib_eq_sum_range_choose` — range form: `fib(n+1) = ∑_{k<n+1} C(n-k, k)`
- `fib_eq_sum_range_half_choose` — truncated textbook form: `fib(n+1) = ∑_{k≤⌊n/2⌋} C(n-k, k)`
- `choose_shallow_eq_zero` — tail-vanishing lemma: `C(n-k, k) = 0` for `k > ⌊n/2⌋`

## Proof technique

`sum_antidiagonal_eq_sum_range_succ` (evaluate `(i,j)` as `(k, n-k)`) → `Finset.sum_range_reflect` (reverse `k ↦ n-k`) → `sum_congr` with `Nat.sub_sub_self`. The truncation drops vanishing tail terms via `Finset.sum_subset`. A worked example confirms `fib 6 = C(5,0)+C(4,1)+C(3,2) = 8`.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` reports only `propext, Classical.choice, Quot.sound`.
- Compiled with `lake env lean Proofs/CombinationsFormulaOQ08.lean` (clean).
- Identity numerically cross-checked for n = 0..11.
- Gallery `meta.json` + `annotations.json` added; annotations build validates with no errors for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)