### PR TITLE
Research: euler-totient-oq-05 — Euler's theorem a^φ(n) ≡ 1 (mod n) (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2367,6 +2367,7 @@ import Proofs.EulerTotientOQ02OQ01
 import Proofs.EulerTotientOQ03
 import Proofs.EulerTotientOQ04
 import Proofs.EulerTotientOQ04OQ01
+import Proofs.EulerTotientOQ05
 import Proofs.FactorRemainderNullstellensatzOQ01
 import Proofs.FactorRemainderNullstellensatzOQ02
 import Proofs.FactorRemainderTheorem

--- a/proofs/Proofs/EulerTotientOQ05.lean
+++ b/proofs/Proofs/EulerTotientOQ05.lean
@@ -1,0 +1,113 @@
+/-
+# Euler's Theorem: a^φ(n) ≡ 1 (mod n) for gcd(a, n) = 1
+
+## What This Proves
+The **Fermat–Euler theorem** in its classical totient form: for coprime `a` and
+`n`,
+    a ^ φ(n) ≡ 1  (mod n),
+together with the **exponent-reduction corollary** that powers of a coprime base
+depend only on the exponent modulo `φ(n)`:
+    a ^ k ≡ a ^ (k mod φ(n))  (mod n),       and more generally
+    k ≡ j (mod φ(n))  ⟹  a ^ k ≡ a ^ j  (mod n).
+
+We also recover **Fermat's little theorem** (`a^(p-1) ≡ 1 mod p` for prime `p`)
+as the special case `φ(p) = p - 1`, and exhibit the equivalent statement in the
+unit group `(ZMod n)ˣ`, `u ^ φ(n) = 1`, tying the number-theoretic `ModEq` form
+to the Lagrange/`pow_card` group form.
+
+## Why It Is Distinct
+The gallery's `euler-totient-oq-01` formalizes the *finer* Carmichael statement
+`a^λ(n) ≡ 1`, and `lagrange-theorem-oq-07` derives Euler/Fermat abstractly from a
+finite-group exponent. This entry is framed directly through Euler's totient `φ`
+and foregrounds the **exponent-reduction corollary** — the arithmetic engine
+behind modular exponentiation and RSA — which neither sibling states.
+
+## Approach
+Everything reduces to two Mathlib facts and elementary `ModEq` bookkeeping:
+- `Nat.ModEq.pow_totient`  : `a.Coprime n → a ^ φ n ≡ 1 [MOD n]`.
+- `Nat.pow_totient_mod`    : `a ^ k % n = a ^ (k % φ n) % n` (i.e. the `ModEq`
+  reduction, unfolded), and the units form `ZMod.pow_totient`.
+
+## Mathlib Dependencies
+- `Nat.totient`, `Nat.Coprime`, `Nat.ModEq`
+- `Nat.ModEq.pow_totient`, `Nat.pow_totient_mod`, `Nat.totient_prime`
+- `ZMod.pow_totient`, `ZMod.unitOfCoprime`
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+open Nat
+
+namespace EulerTotientOQ05
+
+/-! ### Euler's theorem (ModEq form) -/
+
+/-- **Euler's theorem.** If `a` is coprime to `n`, then `a ^ φ(n) ≡ 1 (mod n)`.
+This is the totient generalization of Fermat's little theorem. -/
+theorem euler_theorem {a n : ℕ} (h : a.Coprime n) : a ^ φ n ≡ 1 [MOD n] :=
+  Nat.ModEq.pow_totient h
+
+/-! ### The exponent-reduction corollary -/
+
+/-- **Exponent reduction.** For a base coprime to `n > 1`, a power depends only on
+the exponent modulo `φ(n)`: `a ^ k ≡ a ^ (k mod φ(n)) (mod n)`. This is the
+identity that makes modular exponentiation (and RSA decryption) work. -/
+theorem pow_mod_totient {a n k : ℕ} (hn : 1 < n) (h : a.Coprime n) :
+    a ^ k ≡ a ^ (k % φ n) [MOD n] :=
+  Nat.pow_totient_mod hn h
+
+/-- **Exponent congruence.** Coprime powers agree whenever the exponents agree
+modulo `φ(n)`: if `k ≡ j (mod φ(n))` then `a ^ k ≡ a ^ j (mod n)`. -/
+theorem pow_congr_of_modEq_totient {a n k j : ℕ} (hn : 1 < n) (h : a.Coprime n)
+    (hkj : k ≡ j [MOD φ n]) : a ^ k ≡ a ^ j [MOD n] := by
+  have hmod : k % φ n = j % φ n := hkj
+  calc a ^ k ≡ a ^ (k % φ n) [MOD n] := pow_mod_totient hn h
+    _ = a ^ (j % φ n) := by rw [hmod]
+    _ ≡ a ^ j [MOD n] := (pow_mod_totient hn h).symm
+
+/-- A `k + φ(n)` step in the exponent is invisible mod `n` for a coprime base:
+`a ^ (k + φ(n)) ≡ a ^ k (mod n)`. The period of `k ↦ a^k mod n` divides `φ(n)`. -/
+theorem pow_add_totient {a n k : ℕ} (hn : 1 < n) (h : a.Coprime n) :
+    a ^ (k + φ n) ≡ a ^ k [MOD n] :=
+  Nat.pow_add_totient_mod_eq hn h
+
+/-! ### Fermat's little theorem as the prime case -/
+
+/-- **Fermat's little theorem** recovered as the `φ(p) = p - 1` instance of
+Euler's theorem: for prime `p` and `a` coprime to `p`, `a ^ (p-1) ≡ 1 (mod p)`. -/
+theorem fermat_little {a p : ℕ} (hp : p.Prime) (h : a.Coprime p) :
+    a ^ (p - 1) ≡ 1 [MOD p] := by
+  rw [← Nat.totient_prime hp]
+  exact euler_theorem h
+
+/-! ### The unit-group form and its agreement with the `ModEq` form -/
+
+/-- **Euler's theorem, unit-group form.** Every unit of `ZMod n` is killed by the
+`φ(n)`-th power: `u ^ φ(n) = 1`. This is the Lagrange/`pow_card` statement, since
+`|(ZMod n)ˣ| = φ(n)`. -/
+theorem euler_units {n : ℕ} (u : (ZMod n)ˣ) : u ^ φ n = 1 :=
+  ZMod.pow_totient u
+
+/-- The `ModEq` and unit-group forms are the same theorem: pushing the coprime
+base `a` into the unit group `(ZMod n)ˣ` via `ZMod.unitOfCoprime` and applying
+`euler_units` reproduces `a ^ φ(n) ≡ 1 (mod n)`. -/
+theorem euler_theorem_via_units {a n : ℕ} (h : a.Coprime n) :
+    a ^ φ n ≡ 1 [MOD n] := by
+  rw [← ZMod.natCast_eq_natCast_iff, Nat.cast_pow, Nat.cast_one,
+    ← ZMod.coe_unitOfCoprime a h, ← Units.val_pow_eq_pow_val,
+    euler_units (ZMod.unitOfCoprime a h), Units.val_one]
+
+/-! ### Concrete sanity checks (axiom-free `decide`) -/
+
+/-- `3 ^ φ(10) = 3^4 = 81 ≡ 1 (mod 10)`. -/
+example : 3 ^ φ 10 ≡ 1 [MOD 10] := by decide
+
+/-- `2 ^ φ(9) = 2^6 = 64 ≡ 1 (mod 9)`. -/
+example : 2 ^ φ 9 ≡ 1 [MOD 9] := by decide
+
+/-- Exponent reduction in action: `7 ^ 100 ≡ 7 ^ (100 mod φ(12)) = 7 ^ 0 = 1 (mod 12)`
+(here `φ(12) = 4` and `100 mod 4 = 0`). -/
+example : 7 ^ 100 ≡ 7 ^ (100 % φ 12) [MOD 12] := pow_mod_totient (by norm_num) (by decide)
+
+end EulerTotientOQ05

--- a/research/problems/euler-totient-oq-05/knowledge.md
+++ b/research/problems/euler-totient-oq-05/knowledge.md
@@ -1,0 +1,66 @@
+# Knowledge Base: euler-totient-oq-05
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+Euler's theorem `a^φ(n) ≡ 1 (mod n)` for `gcd(a,n)=1`, framed directly through the
+totient `φ` (distinct from the Carmichael-`λ` entry oq-01 and the abstract
+group-exponent derivation in lagrange-theorem-oq-07). The emphasis is the
+**exponent-reduction corollary** `a^k ≡ a^(k mod φ(n))`, which the sibling entries
+do not state and which is the arithmetic basis of modular exponentiation / RSA.
+
+---
+
+## Session 2026-06-19 — COMPLETED (verified, axiom-free)
+
+**Mode:** fresh · **Outcome:** shipped `Proofs/EulerTotientOQ05.lean` (7 theorems, 113 lines, 0 axioms)
+
+### What I did
+- `euler_theorem` — `a.Coprime n → a^φ(n) ≡ 1 [MOD n]`, restating `Nat.ModEq.pow_totient`.
+- `pow_mod_totient` — exponent reduction `a^k ≡ a^(k % φ n) [MOD n]`, the ModEq reading
+  of `Nat.pow_totient_mod` (the `% n` arithmetic form IS `Nat.ModEq` definitionally).
+- `pow_congr_of_modEq_totient` — `k ≡ j [MOD φ n] ⟹ a^k ≡ a^j [MOD n]` via a 3-step calc
+  through the reduced exponents.
+- `pow_add_totient` — `a^(k+φ n) ≡ a^k [MOD n]` (`Nat.pow_add_totient_mod_eq`); the period
+  of `k ↦ a^k mod n` divides `φ(n)`.
+- `fermat_little` — `a^(p-1) ≡ 1 [MOD p]` for prime `p`, via `rw [← Nat.totient_prime hp]`.
+- `euler_units` — `u^φ(n) = 1` in `(ZMod n)ˣ` (`ZMod.pow_totient`, the Lagrange/`pow_card`
+  statement since `|(ZMod n)ˣ| = φ(n)`).
+- `euler_theorem_via_units` — bridge re-deriving the ℕ-ModEq form from the unit-group form
+  via `ZMod.unitOfCoprime`.
+- Concrete `decide` checks (3^φ(10), 2^φ(9), 7^100 reduction mod 12) — axiom-free.
+
+### Key findings (technique notes)
+- `Nat.pow_totient_mod hn h : a^k % n = a^(k%φn) % n` is **definitionally** `Nat.ModEq n
+  (a^k) (a^(k%φn))`, so `pow_mod_totient` is a direct term restatement.
+- `rw` on a `Nat.ModEq` hypothesis fails (it is a `def`, not syntactic `Eq`); extract
+  `have : k%φn = j%φn := hkj` first.
+- ℕ↔units bridge as one `rw` chain: `ZMod.natCast_eq_natCast_iff, Nat.cast_pow, Nat.cast_one,
+  ← ZMod.coe_unitOfCoprime, ← Units.val_pow_eq_pow_val, ZMod.pow_totient, Units.val_one`.
+- Use `decide` (not `native_decide`) on the concrete checks to avoid `Lean.ofReduceBool`.
+
+### Verification
+- `lake env lean Proofs/EulerTotientOQ05.lean` → exit 0, no errors.
+- `#print axioms` on `euler_theorem`, `pow_mod_totient`, `fermat_little`,
+  `euler_theorem_via_units` → `[propext, Classical.choice, Quot.sound]` (foundational only).
+
+### Files modified
+- `proofs/Proofs/EulerTotientOQ05.lean` (new, verified)
+- `proofs/Proofs.lean` (import)
+- `src/data/proofs/euler-totient-oq-05/{meta,annotations}.json` (gallery entry)
+- `src/data/research/problems/euler-totient-oq-05.json` (knowledge)
+
+### Next steps
+- RSA correctness `m^(ed) ≡ m (mod n)` for `ed ≡ 1 (mod φ(n))`, incl. `gcd(m,n)>1` via CRT.
+- Carmichael sharpening `a^λ(n) ≡ 1` with a base of exact order `λ(n)` (overlaps oq-01).
+
+---
+
+## Dead Ends
+
+- First attempt at `euler_theorem_via_units` used `simpa [hu] using congrArg …`, but the
+  `@[simp]` lemma `ZMod.pow_totient` collapsed the hypothesis to `True` before it could be
+  used. Replaced with the explicit `rw` chain above.

--- a/research/problems/euler-totient-oq-05/literature/README.md
+++ b/research/problems/euler-totient-oq-05/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for euler-totient-oq-05
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/euler-totient-oq-05/problem.md
+++ b/research/problems/euler-totient-oq-05/problem.md
@@ -1,0 +1,133 @@
+# Problem: Euler's Theorem — a^φ(n) ≡ 1 (mod n) for gcd(a,n)=1
+
+**Slug**: euler-totient-oq-05
+**Created**: 2026-06-19T22:27:34-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\gcd(a,n)=1 \;\Longrightarrow\; a^{\varphi(n)} \equiv 1 \pmod{n},
+$$
+
+with the exponent-reduction corollary
+$$
+\gcd(a,n)=1 \;\Longrightarrow\; a^{k} \equiv a^{\,k \bmod \varphi(n)} \pmod{n}.
+$$
+
+### Plain Language
+
+Euler's theorem says that whenever $a$ and $n$ are coprime, raising $a$ to the
+power $\varphi(n)$ (Euler's totient — the count of integers in $[1,n]$ coprime
+to $n$) gives $1$ modulo $n$. It generalizes Fermat's little theorem
+($a^{p-1} \equiv 1 \pmod p$ for prime $p$, where $\varphi(p) = p-1$) to arbitrary
+moduli. A direct consequence is that exponents of coprime bases can be reduced
+modulo $\varphi(n)$ when computing powers mod $n$.
+
+### Why This Matters
+
+- It is the engine behind RSA decryption and a cornerstone of computational
+  number theory and modular exponentiation.
+- It is distinct from the existing gallery entry oq-01, which formalizes the
+  finer **Carmichael function** statement $a^{\lambda(n)} \equiv 1$; the present
+  problem targets the classical $\varphi$-exponent theorem and its
+  exponent-reduction corollary, which the gallery does not yet state directly.
+- It sits structurally between Lagrange's theorem ($g^{|G|}=1$ in the unit group
+  $(\mathbb{Z}/n)^\times$, of order $\varphi(n)$) and Fermat's little theorem.
+
+## Known Results
+
+### What's Already Proven
+
+- Euler's theorem (ModEq form): `Nat.ModEq.pow_totient (h : a.Coprime n) : a ^ n.totient ≡ 1 [MOD n]` — Mathlib `Mathlib/NumberTheory/PowModTotient.lean` / `Mathlib/FieldTheory/Finite/Basic.lean`.
+- Exponent reduction: `Nat.pow_totient_mod_eq_one`, `Nat.pow_add_totient_mod_eq`, `Nat.pow_totient_mod` — `Mathlib/NumberTheory/PowModTotient.lean`.
+- Group-of-units route: `pow_card_eq_one` on `(ZMod n)ˣ` (order `φ(n)`, via `ZMod.card_units_eq_totient`).
+
+### What's Still Open
+
+- Nothing mathematically open; this is a formalization-coverage gap.
+- Optional: phrase both the ℕ `ModEq` version and the `(ZMod n)ˣ` group version and show they agree.
+
+### Our Goal
+
+A self-contained, axiom-free Lean entry proving `a^φ(n) ≡ 1 (mod n)` for coprime
+`a`, plus the exponent-reduction corollary, framed via `φ` (not `λ`) to remain
+distinct from the Carmichael entry oq-01.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| euler-totient-oq-01 | Carmichael-λ refinement of this result | `ZMod`, group order |
+| lagrange-theorem-oq-07 | g^\|G\|=1 specializes to units group of order φ(n) | `pow_card_eq_one` |
+| wilsons-theorem-oq-05 | Companion `ZMod` modular-arithmetic result | `ZMod`, units |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct ModEq**: close the main goal with `Nat.ModEq.pow_totient` and the
+   corollary with `Nat.pow_add_totient_mod_eq`.
+   - Why it might work: exact named lemmas exist.
+   - Risk: minimal; mind `Nat.Coprime` orientation `a.Coprime n`.
+
+2. **Units-group derivation**: work in `(ZMod n)ˣ`, apply `pow_card_eq_one`
+   (order = `ZMod.card_units_eq_totient`), then transport back to `ℕ` ModEq.
+   - Why it might work: exposes the Lagrange-corollary structure.
+   - Risk: cast/transport bookkeeping between `ℕ`, `ZMod n`, and `(ZMod n)ˣ`.
+
+### Key Difficulties
+
+- Coprimality orientation and the `1 < n` side condition for the `% n` form.
+- Keeping the statement clearly distinct from the Carmichael-λ entry.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `Nat.ModEq.pow_totient`.
+- Key lemma 2: `Nat.pow_add_totient_mod_eq` (exponent reduction).
+- Technical requirements: `import Mathlib`, `Nat.Coprime`, `Nat.totient`.
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Justification**:
+- Euler's theorem and its reduction corollaries are named Mathlib lemmas.
+- Comparable one/two-lemma gallery entries ship axiom-free verified.
+- All infrastructure (`Nat.totient`, `ZMod`, units group) is in Mathlib.
+
+**Estimated Effort**:
+- Exploration: ~1 hour
+- If tractable: under a day
+- If hard: n/a
+
+## References
+
+### Papers
+- L. Euler (1763), *Theoremata arithmetica nova methodo demonstrata*.
+
+### Online Resources
+- https://en.wikipedia.org/wiki/Euler%27s_theorem — statement, proof, RSA application.
+
+### Mathlib
+- `Mathlib/NumberTheory/PowModTotient.lean` — `pow_totient_mod_eq_one`, `pow_add_totient_mod_eq`.
+- `Mathlib/FieldTheory/Finite/Basic.lean` — `Nat.ModEq.pow_totient`.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - euler-totient
+  - modular-arithmetic
+  - fermat-little-theorem
+related_proofs:
+  - euler-totient-oq-01
+  - lagrange-theorem-oq-07
+difficulty: low
+source: gallery-gap
+created: 2026-06-19T22:27:34-07:00
+```

--- a/research/problems/euler-totient-oq-05/state.md
+++ b/research/problems/euler-totient-oq-05/state.md
@@ -1,0 +1,25 @@
+# Research State: euler-totient-oq-05
+
+## Current State
+**Phase**: COMPLETED
+**Path**: full
+**Since**: 2026-06-19T22:39:21-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/src/data/proofs/euler-totient-oq-05/annotations.json
+++ b/src/data/proofs/euler-totient-oq-05/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "ann-euler-theorem",
+    "proofId": "euler-totient-oq-05",
+    "range": {
+      "startLine": 44,
+      "endLine": 49
+    },
+    "type": "theorem",
+    "title": "Euler's Theorem a^φ(n) ≡ 1 (mod n)",
+    "content": "For gcd(a,n) = 1, the φ(n)-th power of a is congruent to 1 modulo n. This is the totient generalization of Fermat's little theorem, obtained from Mathlib's Nat.ModEq.pow_totient. Structurally it is Lagrange's theorem applied to the unit group (ℤ/nℤ)ˣ, whose order is φ(n): the multiplicative order of a divides φ(n), so a^φ(n) is the identity.",
+    "mathContext": "$\\gcd(a,n)=1 \\Rightarrow a^{\\varphi(n)} \\equiv 1 \\pmod n$. The order of $a$ in $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ divides $\\varphi(n) = |(\\mathbb{Z}/n\\mathbb{Z})^\\times|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's totient",
+      "Fermat's little theorem",
+      "Lagrange's theorem",
+      "multiplicative order"
+    ],
+    "prerequisites": [
+      "Nat.Coprime",
+      "Nat.ModEq",
+      "Nat.ModEq.pow_totient"
+    ]
+  },
+  {
+    "id": "ann-exponent-reduction",
+    "proofId": "euler-totient-oq-05",
+    "range": {
+      "startLine": 51,
+      "endLine": 73
+    },
+    "type": "theorem",
+    "title": "Exponent Reduction: a^k ≡ a^(k mod φ(n))",
+    "content": "The exponent-reduction corollary: for a base coprime to n > 1, a^k depends only on the exponent modulo φ(n), so a^k ≡ a^(k mod φ(n)) (mod n). This is the ModEq reading of Mathlib's Nat.pow_totient_mod. The general congruence form pow_congr_of_modEq_totient (k ≡ j (mod φ(n)) ⟹ a^k ≡ a^j) follows by a three-step calc through the reduced exponents, and pow_add_totient gives the single-period step a^(k+φ(n)) ≡ a^k. This periodicity is the arithmetic that makes fast modular exponentiation and RSA decryption correct.",
+    "mathContext": "$a^k \\equiv a^{k \\bmod \\varphi(n)} \\pmod n$; more generally $k \\equiv j \\pmod{\\varphi(n)} \\Rightarrow a^k \\equiv a^j \\pmod n$. The map $k \\mapsto a^k \\bmod n$ is periodic with period dividing $\\varphi(n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "modular exponentiation",
+      "RSA",
+      "periodicity",
+      "exponent reduction"
+    ],
+    "prerequisites": [
+      "Nat.pow_totient_mod",
+      "Nat.ModEq",
+      "Nat.pow_add_totient_mod_eq"
+    ]
+  },
+  {
+    "id": "ann-fermat-little",
+    "proofId": "euler-totient-oq-05",
+    "range": {
+      "startLine": 75,
+      "endLine": 82
+    },
+    "type": "theorem",
+    "title": "Fermat's Little Theorem as the Prime Case",
+    "content": "Fermat's little theorem a^(p-1) ≡ 1 (mod p) for prime p and a coprime to p is recovered as the special case of Euler's theorem where φ(p) = p − 1. The Lean proof rewrites p − 1 as φ(p) via Nat.totient_prime and applies euler_theorem.",
+    "mathContext": "$\\varphi(p) = p - 1$ for prime $p$, so Euler's theorem specializes to $a^{p-1} \\equiv 1 \\pmod p$ for $\\gcd(a,p) = 1$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "Fermat's little theorem",
+      "prime totient",
+      "specialization"
+    ],
+    "prerequisites": [
+      "Nat.totient_prime",
+      "Nat.Prime"
+    ]
+  },
+  {
+    "id": "ann-unit-group-form",
+    "proofId": "euler-totient-oq-05",
+    "range": {
+      "startLine": 84,
+      "endLine": 99
+    },
+    "type": "concept",
+    "title": "Unit-Group Form and Agreement",
+    "content": "The same theorem in the unit group: every u ∈ (ℤ/nℤ)ˣ satisfies u^φ(n) = 1 (euler_units = ZMod.pow_totient), which is Lagrange's pow_card statement since |(ℤ/nℤ)ˣ| = φ(n). The bridge euler_theorem_via_units re-derives the ℕ-ModEq form by pushing a coprime base a into (ℤ/nℤ)ˣ through ZMod.unitOfCoprime and applying the group statement, demonstrating that the number-theoretic and group-theoretic forms are one theorem.",
+    "mathContext": "In $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ of order $\\varphi(n)$, $u^{\\varphi(n)} = 1$ for every unit $u$. Via $\\mathtt{unitOfCoprime}$, the coprime base $a$ maps to a unit, recovering $a^{\\varphi(n)} \\equiv 1 \\pmod n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "unit group",
+      "Lagrange's theorem",
+      "pow_card",
+      "ZMod.unitOfCoprime"
+    ],
+    "prerequisites": [
+      "ZMod.pow_totient",
+      "ZMod.unitOfCoprime",
+      "ZMod.natCast_eq_natCast_iff"
+    ]
+  },
+  {
+    "id": "ann-concrete-checks",
+    "proofId": "euler-totient-oq-05",
+    "range": {
+      "startLine": 101,
+      "endLine": 111
+    },
+    "type": "example",
+    "title": "Concrete Verifications (axiom-free)",
+    "content": "Worked instances closed by decide (not native_decide, so no Lean.ofReduceBool axiom): 3^φ(10) = 3^4 = 81 ≡ 1 (mod 10); 2^φ(9) = 2^6 = 64 ≡ 1 (mod 9); and exponent reduction 7^100 ≡ 7^(100 mod φ(12)) = 7^0 = 1 (mod 12), since φ(12) = 4 divides 100.",
+    "mathContext": "$3^{\\varphi(10)} = 81 \\equiv 1 \\pmod{10}$; $2^{\\varphi(9)} = 64 \\equiv 1 \\pmod 9$; $7^{100} \\equiv 7^{100 \\bmod 4} = 7^0 = 1 \\pmod{12}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decidability",
+      "concrete verification",
+      "totient values"
+    ],
+    "prerequisites": [
+      "decide",
+      "Nat.totient"
+    ]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-05/meta.json
+++ b/src/data/proofs/euler-totient-oq-05/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "euler-totient-oq-05",
+  "title": "Euler's Theorem: a^φ(n) ≡ 1 (mod n)",
+  "slug": "euler-totient-oq-05",
+  "description": "Proves the Fermat–Euler theorem a^φ(n) ≡ 1 (mod n) for gcd(a,n)=1, with the exponent-reduction corollary a^k ≡ a^(k mod φ(n)) (mod n) that underpins modular exponentiation and RSA. Recovers Fermat's little theorem as the φ(p)=p-1 case and exhibits the equivalent unit-group form u^φ(n)=1 in (ℤ/n)ˣ. 7 theorems, 0 definitions, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-19",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ05.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "modular-arithmetic",
+      "fermat-little-theorem",
+      "rsa"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified against Mathlib's Nat.ModEq.pow_totient, Nat.pow_totient_mod, Nat.totient_prime, and ZMod.pow_totient. Concrete checks use decide (no native_decide), so the file is axiom-free.",
+    "lineCount": 113,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "originalContributions": [
+      "pow_mod_totient: exponent reduction a^k ≡ a^(k mod φ(n)) (mod n) in clean ModEq form — the identity that makes modular exponentiation work",
+      "pow_congr_of_modEq_totient: k ≡ j (mod φ(n)) ⟹ a^k ≡ a^j (mod n), the general exponent-congruence consequence",
+      "pow_add_totient: a^(k+φ(n)) ≡ a^k (mod n), the period of k ↦ a^k mod n divides φ(n)",
+      "fermat_little: a^(p-1) ≡ 1 (mod p) recovered as the φ(p)=p-1 instance via Nat.totient_prime",
+      "euler_theorem_via_units: bridge re-deriving the ModEq form from the unit-group form u^φ(n)=1 through ZMod.unitOfCoprime"
+    ],
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Pierre de Fermat stated his 'little theorem' a^(p-1) ≡ 1 (mod p) for prime p in a 1640 letter to Frénicle de Bessy, without proof. Leonhard Euler gave the first published proof in 1736 and, in 1763, introduced the totient function φ(n) precisely to generalize the result to composite moduli: a^φ(n) ≡ 1 (mod n) whenever gcd(a,n) = 1. Euler's totient φ(n) counts the integers in {1,…,n} coprime to n, equivalently the order of the unit group (ℤ/nℤ)ˣ.\n\nThe modern structural view places Euler's theorem as a special case of Lagrange's theorem: in any finite group G, g^|G| = 1, and applying this to the unit group (ℤ/nℤ)ˣ of order φ(n) gives the result immediately. Fermat's little theorem is in turn the prime case, since φ(p) = p − 1. The exponent-reduction corollary a^k ≡ a^(k mod φ(n)) is the computational heart of the result: it says the map k ↦ a^k mod n is periodic with period dividing φ(n), which is exactly what allows fast modular exponentiation and the correctness of RSA decryption (where the decryption exponent d satisfies ed ≡ 1 (mod φ(n)), so m^(ed) ≡ m).\n\nThis entry frames the theorem directly through φ — distinguishing it from the gallery's Carmichael-λ entry (oq-01), which proves the sharper a^λ(n) ≡ 1 with λ(n) | φ(n), and from the abstract group-exponent derivation in lagrange-theorem-oq-07. The novel emphasis here is the exponent-reduction corollary and its congruence form, which the sibling entries do not state.",
+    "problemStatement": "Prove a^φ(n) ≡ 1 (mod n) for gcd(a,n) = 1 (Euler's theorem), together with the exponent-reduction corollary a^k ≡ a^(k mod φ(n)) (mod n); recover Fermat's little theorem a^(p-1) ≡ 1 (mod p) and the unit-group form u^φ(n) = 1 in (ℤ/n)ˣ.",
+    "text": "Euler's theorem is obtained from Mathlib's Nat.ModEq.pow_totient. The exponent-reduction corollary pow_mod_totient is the ModEq reading of Nat.pow_totient_mod (a^k % n = a^(k % φ n) % n), and the general congruence pow_congr_of_modEq_totient follows by a three-step calc: a^k ≡ a^(k mod φ n) = a^(j mod φ n) ≡ a^j, using k ≡ j (mod φ n) to rewrite the reduced exponents. Periodicity pow_add_totient = Nat.pow_add_totient_mod_eq. Fermat's little theorem is the φ(p) = p − 1 substitution via Nat.totient_prime. The unit-group form euler_units = ZMod.pow_totient, and euler_theorem_via_units bridges the two by pushing a coprime base into (ℤ/n)ˣ through ZMod.unitOfCoprime and applying the group statement.",
+    "proofStrategy": "Cite Nat.ModEq.pow_totient for the main theorem; unfold Nat.pow_totient_mod to the ModEq form for exponent reduction; chain a calc for the congruence corollary; substitute Nat.totient_prime for Fermat; and connect the ℕ-ModEq and (ℤ/n)ˣ statements via ZMod.unitOfCoprime / ZMod.natCast_eq_natCast_iff.",
+    "keyInsights": [
+      "Euler's theorem a^φ(n) ≡ 1 (mod n) is the unit-group instance of Lagrange's theorem, since |(ℤ/nℤ)ˣ| = φ(n)",
+      "The exponent-reduction corollary a^k ≡ a^(k mod φ(n)) is the periodicity that makes modular exponentiation and RSA decryption correct",
+      "Fermat's little theorem is the prime case: φ(p) = p − 1 turns Euler into a^(p-1) ≡ 1 (mod p)",
+      "The general congruence k ≡ j (mod φ(n)) ⟹ a^k ≡ a^j (mod n) is the clean statement of exponent periodicity, derived in one calc",
+      "The ℕ-ModEq form and the (ℤ/n)ˣ group form u^φ(n) = 1 are the same theorem, bridged by ZMod.unitOfCoprime",
+      "Concrete checks (3^φ(10) ≡ 1 mod 10, 2^φ(9) ≡ 1 mod 9) close by decide, keeping the file axiom-free"
+    ],
+    "prerequisites": [
+      "Euler's totient function: Nat.totient, Nat.Coprime",
+      "Modular congruence: Nat.ModEq, Nat.ModEq.pow_totient",
+      "Exponent reduction: Nat.pow_totient_mod, Nat.pow_add_totient_mod_eq",
+      "Unit group of ZMod n: ZMod.pow_totient, ZMod.unitOfCoprime"
+    ]
+  },
+  "conclusion": {
+    "summary": "Euler's theorem a^φ(n) ≡ 1 (mod n) for coprime a, with the exponent-reduction corollary a^k ≡ a^(k mod φ(n)), the congruence consequence k ≡ j (mod φ(n)) ⟹ a^k ≡ a^j, Fermat's little theorem as the prime case, and the equivalent unit-group form. 7 theorems, 0 axioms, 113 lines.",
+    "implications": "The exponent-reduction corollary is the arithmetic basis of modular exponentiation and RSA: decryption works because the exponent can be reduced modulo φ(n). Framing through φ keeps the entry distinct from the sharper Carmichael-λ statement and the abstract group-exponent derivation.",
+    "openQuestions": [
+      "Strengthen to the Carmichael bound a^λ(n) ≡ 1 (mod n) with λ(n) | φ(n) and exhibit a base of exact order λ(n) (already partly in oq-01)",
+      "Formalize the RSA correctness statement m^(ed) ≡ m (mod n) for ed ≡ 1 (mod φ(n)), covering the gcd(m,n) > 1 cases via CRT"
+    ]
+  },
+  "leanFile": {
+    "namespace": "EulerTotientOQ05",
+    "lineCount": 113,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/EulerTotientOQ05.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-01",
+      "relationship": "related",
+      "description": "oq-01 proves the sharper Carmichael statement a^λ(n) ≡ 1 with λ(n) | φ(n); this entry targets the classical φ-exponent theorem and its exponent-reduction corollary"
+    },
+    {
+      "targetId": "lagrange-theorem-oq-07",
+      "relationship": "related",
+      "description": "lagrange-theorem-oq-07 derives Euler/Fermat abstractly from g^|G|=1 in a finite group; this entry works directly with Nat.ModEq and φ and adds the exponent-reduction corollary"
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "extends",
+      "description": "Parent formalization of Euler's totient function φ; oq-05 proves the theorem that motivated Euler's introduction of φ"
+    }
+  ],
+  "sections": [
+    {
+      "id": "euler-theorem",
+      "title": "Euler's Theorem (ModEq form)",
+      "summary": "euler_theorem: a.Coprime n → a^φ(n) ≡ 1 (mod n), the totient generalization of Fermat's little theorem, from Nat.ModEq.pow_totient.",
+      "startLine": 44,
+      "endLine": 49,
+      "mathContext": "For $\\gcd(a,n)=1$, $a^{\\varphi(n)} \\equiv 1 \\pmod n$. The order of $a$ in $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ divides $|(\\mathbb{Z}/n\\mathbb{Z})^\\times| = \\varphi(n)$, so the $\\varphi(n)$-th power is the identity."
+    },
+    {
+      "id": "exponent-reduction",
+      "title": "The Exponent-Reduction Corollary",
+      "summary": "pow_mod_totient: a^k ≡ a^(k mod φ(n)) (mod n); pow_congr_of_modEq_totient: k ≡ j (mod φ(n)) ⟹ a^k ≡ a^j; pow_add_totient: a^(k+φ(n)) ≡ a^k.",
+      "startLine": 51,
+      "endLine": 73,
+      "mathContext": "The map $k \\mapsto a^k \\bmod n$ is periodic with period dividing $\\varphi(n)$: $a^k \\equiv a^{k \\bmod \\varphi(n)} \\pmod n$. Hence exponents may be reduced modulo $\\varphi(n)$ — the identity behind fast modular exponentiation and RSA decryption, where $ed \\equiv 1 \\pmod{\\varphi(n)}$ gives $m^{ed} \\equiv m$."
+    },
+    {
+      "id": "fermat-little",
+      "title": "Fermat's Little Theorem as the Prime Case",
+      "summary": "fermat_little: for prime p and a coprime to p, a^(p-1) ≡ 1 (mod p), via the substitution φ(p) = p − 1 (Nat.totient_prime).",
+      "startLine": 75,
+      "endLine": 82,
+      "mathContext": "Since $\\varphi(p) = p-1$ for prime $p$, Euler's theorem specializes to Fermat's little theorem $a^{p-1} \\equiv 1 \\pmod p$ for $\\gcd(a,p)=1$."
+    },
+    {
+      "id": "unit-group-form",
+      "title": "Unit-Group Form and Agreement",
+      "summary": "euler_units: u^φ(n) = 1 in (ℤ/n)ˣ (= ZMod.pow_totient, the Lagrange/pow_card statement); euler_theorem_via_units bridges it back to the ℕ-ModEq form via ZMod.unitOfCoprime.",
+      "startLine": 84,
+      "endLine": 99,
+      "mathContext": "In the finite group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ of order $\\varphi(n)$, every unit satisfies $u^{\\varphi(n)} = 1$ (Lagrange). Pushing a coprime base $a$ into this group via $\\mathtt{unitOfCoprime}$ recovers the number-theoretic congruence, showing the two forms are one theorem."
+    },
+    {
+      "id": "concrete-checks",
+      "title": "Concrete Verifications",
+      "summary": "decide-checks: 3^φ(10) ≡ 1 (mod 10), 2^φ(9) ≡ 1 (mod 9), and 7^100 ≡ 7^(100 mod φ(12)) (mod 12). Uses decide (not native_decide), so axiom-free.",
+      "startLine": 101,
+      "endLine": 111,
+      "mathContext": "Worked instances: $3^{\\varphi(10)} = 3^4 = 81 \\equiv 1 \\pmod{10}$; $2^{\\varphi(9)} = 2^6 = 64 \\equiv 1 \\pmod 9$; and exponent reduction $7^{100} \\equiv 7^{100 \\bmod 4} = 7^0 = 1 \\pmod{12}$."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/euler-totient-oq-05.json
+++ b/src/data/research/problems/euler-totient-oq-05.json
@@ -1,0 +1,200 @@
+{
+  "slug": "euler-totient-oq-05",
+  "title": "Euler's Theorem: a^φ(n) ≡ 1 (mod n) for gcd(a,n)=1",
+  "phase": "COMPLETED",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\gcd(a,n)=1 \\;\\Rightarrow\\; a^{\\varphi(n)} \\equiv 1 \\pmod{n}",
+    "plain": "Euler's theorem: whenever $a$ and $n$ are coprime, $a^{\\varphi(n)} \\equiv 1 \\pmod n$, where $\\varphi$ is Euler's totient. It generalizes Fermat's little theorem ($a^{p-1} \\equiv 1 \\pmod p$, since $\\varphi(p)=p-1$) to arbitrary moduli, and yields the exponent-reduction corollary $a^k \\equiv a^{k \\bmod \\varphi(n)} \\pmod n$. We want a machine-checked proof framed via $\\varphi$, distinct from the existing Carmichael-$\\lambda$ entry.",
+    "whyMatters": [
+      "It is the arithmetic engine behind RSA and modular exponentiation.",
+      "It is the units-group instance of Lagrange's theorem, with |(ℤ/n)ˣ| = φ(n)."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": "Machine-checked proof of a^φ(n) ≡ 1 (mod n) for coprime a, plus the exponent-reduction corollary, via Nat.ModEq.pow_totient."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-19T22:27:34-07:00",
+    "iteration": 2,
+    "focus": "Shipped verified, axiom-free entry EulerTotientOQ05.lean (7 theorems).",
+    "blockers": [],
+    "nextAction": "Entry complete; optional follow-up = RSA correctness m^(ed)≡m via CRT, or Carmichael sharpening.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED: shipped verified, axiom-free EulerTotientOQ05.lean (7 theorems, 113 lines). Euler's theorem a^φ(n)≡1 (Nat.ModEq.pow_totient), exponent-reduction corollary a^k≡a^(k mod φn) (ModEq reading of Nat.pow_totient_mod) + general congruence + period step, Fermat's little theorem via Nat.totient_prime, unit-group form ZMod.pow_totient with a unitOfCoprime bridge.",
+    "builtItems": [
+      "EulerTotientOQ05.euler_theorem — a^φ(n)≡1 [MOD n] for coprime a (Nat.ModEq.pow_totient)",
+      "EulerTotientOQ05.pow_mod_totient — exponent reduction a^k≡a^(k%φn) [MOD n] (ModEq form of Nat.pow_totient_mod)",
+      "EulerTotientOQ05.pow_congr_of_modEq_totient — k≡j [MOD φn] ⟹ a^k≡a^j [MOD n] via calc",
+      "EulerTotientOQ05.pow_add_totient — a^(k+φn)≡a^k [MOD n] (period divides φn)",
+      "EulerTotientOQ05.fermat_little — a^(p-1)≡1 [MOD p] for prime p via Nat.totient_prime",
+      "EulerTotientOQ05.euler_units — u^φ(n)=1 in (ZMod n)ˣ (ZMod.pow_totient)",
+      "EulerTotientOQ05.euler_theorem_via_units — bridge ℕ-ModEq ⟵ unit-group form via ZMod.unitOfCoprime"
+    ],
+    "insights": [
+      "Euler's theorem a^φ(n)≡1 is Nat.ModEq.pow_totient; the unit-group form u^φ(n)=1 is ZMod.pow_totient (Lagrange/pow_card with |(ZMod n)ˣ|=φ(n)).",
+      "Exponent reduction is the ModEq reading of Nat.pow_totient_mod (a^k % n = a^(k%φn) % n IS Nat.ModEq n (a^k) (a^(k%φn)) definitionally), so pow_mod_totient is a direct restatement.",
+      "Nat.ModEq is def-equal to (a % n = b % n) but `rw` on a ModEq hypothesis fails — extract `have : k%φn = j%φn := hkj` first, then rw.",
+      "Fermat's little theorem is the φ(p)=p-1 case: rw [← Nat.totient_prime hp] then apply euler_theorem.",
+      "Bridge ℕ↔units cleanly via one rw chain: ZMod.natCast_eq_natCast_iff, Nat.cast_pow, ← ZMod.coe_unitOfCoprime, ← Units.val_pow_eq_pow_val, ZMod.pow_totient, Units.val_one.",
+      "decide (not native_decide) closes small a^φ(n)≡1 [MOD n] checks → stays axiom-free (no Lean.ofReduceBool)."
+    ],
+    "mathlibGaps": [
+      "None for this statement — coverage gap only. Mathlib has Nat.ModEq.pow_totient, Nat.pow_totient_mod family, ZMod.pow_totient."
+    ],
+    "nextSteps": [
+      "RSA correctness m^(ed)≡m (mod n) for ed≡1 (mod φ(n)), including gcd(m,n)>1 via CRT.",
+      "Carmichael sharpening a^λ(n)≡1 with λ(n)|φ(n) and a base of exact order λ(n) (overlaps oq-01)."
+    ],
+    "markdown": "# Knowledge Base: euler-totient-oq-05\n\nInsights accumulated during research on this problem.\n"
+  },
+  "tags": [
+    "number-theory",
+    "euler-totient",
+    "modular-arithmetic",
+    "fermat-little-theorem"
+  ],
+  "relatedProofs": [
+    "euler-totient",
+    "euler-totient-oq-01",
+    "euler-totient-oq-01-oq-03",
+    "euler-totient-oq-02",
+    "euler-totient-oq-02-oq-01",
+    "euler-totient-oq-03",
+    "euler-totient-oq-04",
+    "lagrange-theorem-oq-07"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Nat.ModEq.pow_totient",
+      "Nat.pow_totient_mod_eq_one",
+      "Nat.pow_add_totient_mod_eq"
+    ]
+  },
+  "started": "2026-06-19T22:27:34-07:00",
+  "leanFiles": [
+    {
+      "path": "Proofs/EulerTotient.lean",
+      "filename": "EulerTotient.lean",
+      "lineCount": 136,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotient.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01.lean",
+      "filename": "EulerTotientOQ01.lean",
+      "lineCount": 88,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01OQ01.lean",
+      "filename": "EulerTotientOQ01OQ01.lean",
+      "lineCount": 77,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01OQ03.lean",
+      "filename": "EulerTotientOQ01OQ03.lean",
+      "lineCount": 240,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01OQ03Minimal.lean",
+      "filename": "EulerTotientOQ01OQ03Minimal.lean",
+      "lineCount": 55,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ03Minimal.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ02.lean",
+      "filename": "EulerTotientOQ02.lean",
+      "lineCount": 173,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ02.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ02OQ01.lean",
+      "filename": "EulerTotientOQ02OQ01.lean",
+      "lineCount": 208,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ03.lean",
+      "filename": "EulerTotientOQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ03.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ04.lean",
+      "filename": "EulerTotientOQ04.lean",
+      "lineCount": 232,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ04.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ04OQ01.lean",
+      "filename": "EulerTotientOQ04OQ01.lean",
+      "lineCount": 165,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ04OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
A self-contained, axiom-free gallery entry for the **Fermat–Euler theorem** `a^φ(n) ≡ 1 (mod n)` for `gcd(a,n)=1`, framed directly through Euler's totient `φ`. Foregrounds the **exponent-reduction corollary** `a^k ≡ a^(k mod φ(n))` — the arithmetic behind modular exponentiation and RSA — which the existing sibling entries do not state.

## Progress
New `proofs/Proofs/EulerTotientOQ05.lean` (7 theorems, 113 lines, 0 axioms):
- `euler_theorem` — `a.Coprime n → a^φ(n) ≡ 1 [MOD n]` (`Nat.ModEq.pow_totient`).
- `pow_mod_totient` — exponent reduction `a^k ≡ a^(k % φ n) [MOD n]` (ModEq reading of `Nat.pow_totient_mod`).
- `pow_congr_of_modEq_totient` — `k ≡ j [MOD φ n] ⟹ a^k ≡ a^j [MOD n]`.
- `pow_add_totient` — `a^(k+φ n) ≡ a^k [MOD n]` (period divides `φ(n)`).
- `fermat_little` — `a^(p-1) ≡ 1 [MOD p]` for prime `p`, via `Nat.totient_prime`.
- `euler_units` — `u^φ(n) = 1` in `(ZMod n)ˣ` (`ZMod.pow_totient`).
- `euler_theorem_via_units` — bridge re-deriving the ℕ-ModEq form from the unit-group form via `ZMod.unitOfCoprime`.

Also: `proofs/Proofs.lean` import, gallery `meta.json` + `annotations.json`, research knowledge files.

## Distinctness
- `euler-totient-oq-01` proves the sharper Carmichael statement `a^λ(n) ≡ 1` (`λ(n) | φ(n)`).
- `lagrange-theorem-oq-07` derives Euler/Fermat abstractly from `g^|G| = 1`.
- This entry works directly with `Nat.ModEq` and `φ`, and adds the exponent-reduction corollary and its congruence form, which neither sibling states.

## Verification
- `lake env lean Proofs/EulerTotientOQ05.lean` → exit 0, no errors.
- `#print axioms` on `euler_theorem`, `pow_mod_totient`, `fermat_little`, `euler_theorem_via_units` → `[propext, Classical.choice, Quot.sound]` (foundational only). Concrete checks use `decide`, not `native_decide`, so no `Lean.ofReduceBool`.

## Status
**Outcome**: completed (verified, 0-axiom)
**Next Steps**: RSA correctness `m^(ed) ≡ m (mod n)` for `ed ≡ 1 (mod φ(n))` (incl. `gcd(m,n)>1` via CRT); Carmichael sharpening with a base of exact order `λ(n)`.

🤖 Generated by researcher-2