### PR TITLE
research(combinations-formula-oq-07): Vandermonde convolution + central binomial sum of squares

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ07.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ07.lean
@@ -1,0 +1,76 @@
+import Mathlib
+
+/-
+# Vandermonde's Convolution and the Central Binomial Sum-of-Squares
+
+## Open Question OQ-07
+
+Vandermonde's convolution identity states
+
+  C(m + n, k) = ∑_{i+j=k} C(m, i) · C(n, j) .
+
+Mathlib provides this in its *antidiagonal* form, `Nat.add_choose_eq`:
+
+  (m + n).choose k = ∑ p ∈ antidiagonal k, m.choose p.1 * n.choose p.2 .
+
+This file reindexes that identity into the single-sum form one usually writes,
+and draws out the most famous special case.
+
+1. `add_choose_eq_sum_range` — the range form:
+        C(m + n, k) = ∑_{i=0}^{k} C(m, i) · C(n, k - i).
+
+2. `central_binom_eq_sum_sq` — specializing `m = n`, `k = n` and using the
+   symmetry `C(n, n-i) = C(n, i)` collapses the convolution into a sum of
+   squares:
+        C(2n, n) = ∑_{i=0}^{n} C(n, i)² .
+
+## Mathematical Context
+
+Vandermonde's identity counts the ways to choose `k` objects from a pile of
+`m + n` by splitting according to how many come from the first `m`.  Its
+diagonal (single-sum) presentation is the form that appears in generating-
+function manipulations and in Gould's tables of binomial identities.  The
+central case `C(2n, n) = ∑ C(n, i)²` says: the number of lattice paths to the
+center of Pascal's triangle equals the sum of squares of the entries in row
+`n` — a cornerstone identity in enumerative combinatorics.
+
+The proofs reduce to Mathlib's `Nat.add_choose_eq` via
+`Finset.Nat.sum_antidiagonal_eq_sum_range_succ` (which evaluates the
+antidiagonal pair `(i, j)` as `(i, k - i)` over `i ∈ range (k+1)`), and, for the
+central case, `Nat.choose_symm` (`C(n, n-i) = C(n, i)` for `i ≤ n`).
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ07
+
+open Finset
+
+/-- **Anchor (Mathlib form).** Vandermonde's convolution over the antidiagonal.
+    This is exactly `Nat.add_choose_eq`, restated as the starting point. -/
+theorem add_choose_eq_antidiagonal (m n k : ℕ) :
+    (m + n).choose k = ∑ p ∈ Finset.antidiagonal k, m.choose p.1 * n.choose p.2 :=
+  Nat.add_choose_eq m n k
+
+/-- **Vandermonde's convolution (range form).**
+    `C(m + n, k) = ∑_{i=0}^{k} C(m, i) · C(n, k - i)`. -/
+theorem add_choose_eq_sum_range (m n k : ℕ) :
+    (m + n).choose k = ∑ i ∈ Finset.range (k + 1), m.choose i * n.choose (k - i) := by
+  rw [add_choose_eq_antidiagonal,
+      Finset.Nat.sum_antidiagonal_eq_sum_range_succ (fun i j => m.choose i * n.choose j) k]
+
+/-- **Central binomial coefficient as a sum of squares.**
+    `C(2n, n) = ∑_{i=0}^{n} C(n, i)²` — the diagonal of Vandermonde's identity. -/
+theorem central_binom_eq_sum_sq (n : ℕ) :
+    (2 * n).choose n = ∑ i ∈ Finset.range (n + 1), (n.choose i) ^ 2 := by
+  rw [two_mul, add_choose_eq_sum_range]
+  refine Finset.sum_congr rfl (fun i hi => ?_)
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hi
+  rw [Nat.choose_symm hi, sq]
+
+/-- Sanity check: `C(6, 3) = 20` recovered from `∑ C(3,i)² = 1 + 9 + 9 + 1`. -/
+example : (2 * 3).choose 3 = 20 := by
+  rw [central_binom_eq_sum_sq 3]
+  decide
+
+end CombinationsFormulaOQ07

--- a/src/data/proofs/combinations-formula-oq-07/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07/annotations.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "vandermonde-context",
+    "proofId": "combinations-formula-oq-07",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "Vandermonde's Convolution and Its Central Special Case",
+    "content": "Vandermonde's identity C(m+n, k) = ∑_{i+j=k} C(m,i)·C(n,j) is the discrete convolution behind the multiplicativity of the binomial theorem: it is the coefficient of xᵏ in (1+x)^m·(1+x)^n = (1+x)^{m+n}. Mathlib proves the antidiagonal form Nat.add_choose_eq; this entry reindexes it into the textbook single-sum range form and derives the famous central case C(2n,n) = ∑ C(n,i)².",
+    "mathContext": "Combinatorially, $\\binom{m+n}{k}$ counts $k$-subsets of an $(m+n)$-set, split by how many of the $k$ elements come from the first $m$: $\\binom{m+n}{k} = \\sum_{i=0}^{k} \\binom{m}{i}\\binom{n}{k-i}$. Setting $m=n$, $k=n$ and using $\\binom{n}{n-i}=\\binom{n}{i}$ gives $\\binom{2n}{n} = \\sum_{i=0}^{n}\\binom{n}{i}^2$, which also follows from $(1+x)^{2n}=((1+x)^n)^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Vandermonde's identity",
+      "binomial theorem",
+      "convolution of sequences",
+      "central binomial coefficient",
+      "lattice paths"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "Finset.antidiagonal and Finset.range sums",
+      "the binomial theorem"
+    ]
+  },
+  {
+    "id": "antidiagonal-anchor",
+    "proofId": "combinations-formula-oq-07",
+    "range": { "startLine": 51, "endLine": 55 },
+    "type": "theorem",
+    "title": "Anchor: Antidiagonal Form (Mathlib)",
+    "content": "add_choose_eq_antidiagonal restates Mathlib's Nat.add_choose_eq: C(m+n, k) = ∑ over p ∈ antidiagonal k of C(m, p.1)·C(n, p.2). Mathlib proves this via the polynomial identity (X+1)^{m+n} = (X+1)^m·(X+1)^n and coefficient extraction (coeff_mul). It serves as the starting point that the subsequent theorems reindex and specialize.",
+    "mathContext": "The antidiagonal $\\{(i,j) : i+j=k\\}$ carries the convolution data implicitly. Mathlib's proof extracts the degree-$k$ coefficient of $(X+1)^m(X+1)^n$ as a Cauchy product (coeff_mul), each factor's coefficients being binomial coefficients (coeff_X_add_one_pow).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.add_choose_eq",
+      "polynomial coefficient extraction",
+      "Cauchy product",
+      "Finset.antidiagonal"
+    ],
+    "prerequisites": [
+      "Finset.antidiagonal over ℕ"
+    ]
+  },
+  {
+    "id": "range-form-theorem",
+    "proofId": "combinations-formula-oq-07",
+    "range": { "startLine": 57, "endLine": 62 },
+    "type": "theorem",
+    "title": "Vandermonde Range Form",
+    "content": "add_choose_eq_sum_range proves C(m+n, k) = ∑_{i ∈ range(k+1)} C(m,i)·C(n,k-i), the textbook single-sum statement of Vandermonde's convolution. The proof rewrites the antidiagonal sum into a range sum via Finset.Nat.sum_antidiagonal_eq_sum_range_succ, evaluating the antidiagonal pair (i,j) as (i, k-i).",
+    "mathContext": "The antidiagonal evaluation map sends $(i,j)$ with $i+j=k$ to $(i, k-i)$ over $i \\in \\{0,\\ldots,k\\}$, turning $\\sum_{(i,j)} \\binom{m}{i}\\binom{n}{j}$ into $\\sum_{i=0}^{k} \\binom{m}{i}\\binom{n}{k-i}$ — the form used in generating-function arguments.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.Nat.sum_antidiagonal_eq_sum_range_succ",
+      "reindexing finite sums",
+      "discrete convolution"
+    ],
+    "prerequisites": [
+      "reindexing finite sums",
+      "Nat truncated subtraction"
+    ]
+  },
+  {
+    "id": "central-binom-theorem",
+    "proofId": "combinations-formula-oq-07",
+    "range": { "startLine": 64, "endLine": 76 },
+    "type": "theorem",
+    "title": "Central Binomial Sum of Squares",
+    "content": "central_binom_eq_sum_sq proves C(2n, n) = ∑_{i ∈ range(n+1)} C(n,i)². Specializing the range form at m=n, k=n (using two_mul to rewrite 2n = n+n) yields ∑ C(n,i)·C(n,n-i); a sum_congr then applies Nat.choose_symm (C(n,n-i)=C(n,i) for i ≤ n, valid on the range) to collapse each term to a square. A worked example confirms C(6,3) = 1+9+9+1 = 20.",
+    "mathContext": "$\\binom{2n}{n} = \\sum_{i=0}^{n}\\binom{n}{i}^2$ is the diagonal of Vandermonde. It counts the lattice paths from $(0,0)$ to $(n,n)$ and equals the sum of squares of the $n$-th row of Pascal's triangle. For $n=3$: $\\binom{3}{0}^2+\\binom{3}{1}^2+\\binom{3}{2}^2+\\binom{3}{3}^2 = 1+9+9+1 = 20 = \\binom{6}{3}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.choose_symm",
+      "central binomial coefficient",
+      "sum of squares of binomial coefficients",
+      "two_mul"
+    ],
+    "prerequisites": [
+      "choose symmetry C(n,n-k)=C(n,k)",
+      "sum_congr on a summation range"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-07/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07/meta.json
@@ -1,0 +1,97 @@
+{
+  "id": "combinations-formula-oq-07",
+  "title": "Vandermonde's Convolution and the Central Binomial Sum of Squares",
+  "slug": "combinations-formula-oq-07",
+  "description": "Formalizes Vandermonde's convolution identity C(m+n, k) = ∑_{i+j=k} C(m,i)·C(n,j). Starting from Mathlib's antidiagonal form Nat.add_choose_eq, we reindex into the textbook single-sum range form C(m+n, k) = ∑_{i=0}^{k} C(m,i)·C(n,k-i), and specialize to the celebrated central case C(2n, n) = ∑_{i=0}^{n} C(n,i)².",
+  "meta": {
+    "author": "Lean Genius researcher-10",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ07.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 76,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "None. All identities hold for every natural number argument and are fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms).",
+    "tags": [
+      "combinatorics",
+      "vandermonde-identity",
+      "binomial-coefficients",
+      "central-binomial-coefficient",
+      "finset-sums",
+      "convolution"
+    ],
+    "dateAdded": "2026-06-19",
+    "originalContributions": [
+      "add_choose_eq_sum_range: Vandermonde's convolution as a single range sum C(m+n,k) = ∑_{i≤k} C(m,i)·C(n,k-i), reindexed from Mathlib's antidiagonal form via sum_antidiagonal_eq_sum_range_succ",
+      "central_binom_eq_sum_sq: the central binomial sum-of-squares identity C(2n,n) = ∑_{i≤n} C(n,i)², obtained by specializing Vandermonde at m=n, k=n and applying choose symmetry C(n,n-i)=C(n,i)",
+      "Worked verification C(6,3) = ∑ C(3,i)² = 1+9+9+1 = 20"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ07.lean",
+    "namespace": "CombinationsFormulaOQ07",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 76,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Vandermonde's identity is named for Alexandre-Théophile Vandermonde (1772), though it was known to Zhu Shijie in 14th-century China. It is the discrete convolution underlying the binomial theorem's multiplicativity: the coefficient of xᵏ in (1+x)^m(1+x)^n = (1+x)^{m+n}. The central special case C(2n,n) = ∑ C(n,i)² is one of the most-quoted binomial identities, counting lattice paths to the center of Pascal's triangle and appearing throughout enumerative combinatorics, the theory of Catalan numbers, and random-walk return probabilities.",
+    "problemStatement": "Open Question OQ-07: Formalize Vandermonde's convolution C(m+n, k) = ∑_{i+j=k} C(m,i)·C(n,j). Mathlib provides the antidiagonal form (Nat.add_choose_eq); the task is to reindex it into the textbook single-sum range form, and to derive the central binomial sum-of-squares identity C(2n,n) = ∑_{i=0}^{n} C(n,i)².",
+    "proofStrategy": "Begin from Mathlib's Nat.add_choose_eq, expressing C(m+n,k) as a sum of C(m,i)·C(n,j) over Finset.antidiagonal k. Apply Finset.Nat.sum_antidiagonal_eq_sum_range_succ to evaluate the pair (i,j) as (i, k-i) over i ∈ range(k+1), giving the range form. For the central case, set m=n and k=n (using two_mul to write 2n = n+n); a sum_congr then rewrites each term C(n,i)·C(n,n-i) using Nat.choose_symm (C(n,n-i) = C(n,i) for i ≤ n) into C(n,i)², so the convolution collapses to a sum of squares.",
+    "keyInsights": [
+      "Vandermonde's convolution is the antidiagonal-indexed statement; the textbook single sum is recovered by the same antidiagonal-to-range reindexing used for any binomial convolution.",
+      "The central sum-of-squares identity is not a separate theorem but a one-line specialization of Vandermonde once choose symmetry C(n,n-i)=C(n,i) is applied — exposing it as the 'diagonal' of the convolution.",
+      "Nat.choose_symm requires i ≤ n, which holds automatically on the summation range range(n+1); the side condition is discharged by mem_range and Nat.lt_succ_iff.",
+      "two_mul (2n = n+n) is the small bridge that lets the m=n, k=n specialization of Vandermonde land on the central binomial coefficient C(2n,n)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Header stating OQ-07: Vandermonde's convolution and its central sum-of-squares special case. Explains the relationship to Mathlib's antidiagonal form and the reindexing strategy."
+    },
+    {
+      "id": "anchor",
+      "title": "Anchor: Antidiagonal Form",
+      "startLine": 51,
+      "endLine": 55,
+      "summary": "add_choose_eq_antidiagonal: restates Mathlib's Nat.add_choose_eq, C(m+n,k) = ∑ over antidiagonal k of C(m,p.1)·C(n,p.2), as the starting point."
+    },
+    {
+      "id": "range-form",
+      "title": "Vandermonde Range Form",
+      "startLine": 57,
+      "endLine": 62,
+      "summary": "add_choose_eq_sum_range: C(m+n,k) = ∑_{i≤k} C(m,i)·C(n,k-i). Proved by rewriting the antidiagonal sum with Finset.Nat.sum_antidiagonal_eq_sum_range_succ."
+    },
+    {
+      "id": "central-binom",
+      "title": "Central Binomial Sum of Squares",
+      "startLine": 64,
+      "endLine": 76,
+      "summary": "central_binom_eq_sum_sq: C(2n,n) = ∑_{i≤n} C(n,i)². Specializes the range form at m=n, k=n via two_mul, then a sum_congr with Nat.choose_symm collapses each term to a square. Worked example: C(6,3) = 20."
+    }
+  ],
+  "conclusion": {
+    "summary": "3 theorems, 0 sorries, 0 axioms. Vandermonde's convolution is formalized in its textbook range form C(m+n,k) = ∑_{i≤k} C(m,i)·C(n,k-i), reindexed from Mathlib's antidiagonal presentation, together with the central binomial sum-of-squares identity C(2n,n) = ∑_{i≤n} C(n,i)² as its diagonal specialization.",
+    "implications": "This turns Mathlib's antidiagonal Vandermonde identity into the single-sum form used in combinatorics references and exhibits the central sum-of-squares identity as a direct corollary rather than a standalone result. The reindexing pattern (sum_antidiagonal_eq_sum_range_succ, then choose symmetry on the summation range) is reusable for any binomial convolution one wishes to state as a bounded single sum or specialize along its diagonal.",
+    "openQuestions": [
+      "Can the alternating Vandermonde / Li Jen-Shu identity ∑ (-1)^i C(m,i) C(n,k-i) be formalized and related to this convolution via the same reindexing?",
+      "Does the q-analogue (the q-Vandermonde identity) follow from the q-binomial infrastructure in combinations-formula-oq-03 by an analogous antidiagonal-to-range reindexing?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-02",
+      "relationship": "ancestor — the core combinations formula entry providing binomial coefficient context"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **Vandermonde's convolution** `C(m+n, k) = ∑_{i+j=k} C(m,i)·C(n,j)` in its textbook single-sum form, and derives the celebrated central special case.

Mathlib proves the *antidiagonal* form (`Nat.add_choose_eq`); this entry reindexes it into the form used in references and exposes the central identity as a one-line corollary:

- `add_choose_eq_sum_range` — range form: `C(m+n,k) = ∑_{i≤k} C(m,i)·C(n,k-i)`
- `central_binom_eq_sum_sq` — `C(2n,n) = ∑_{i≤n} C(n,i)²`

## Proof technique

`Finset.Nat.sum_antidiagonal_eq_sum_range_succ` evaluates the antidiagonal pair `(i,j)` as `(i, k-i)`, giving the range form. The central case specializes `m=n, k=n` (via `two_mul`) and applies `Nat.choose_symm` (`C(n,n-i)=C(n,i)` on the range) through a `sum_congr`, collapsing the convolution to a sum of squares. Worked example: `C(6,3) = 1+9+9+1 = 20`.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` reports only `propext, Classical.choice, Quot.sound`.
- Compiled with `lake env lean Proofs/CombinationsFormulaOQ07.lean` (clean).
- Both identities numerically cross-checked (Vandermonde for all m,n,k ≤ 5; central for n = 0..8).
- Gallery `meta.json` + `annotations.json` added; annotations build validates with no errors for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)