### PR TITLE
research(geometric-series-oq-09): even/odd split ∑ r^(2n) = 1/(1−r²)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2481,6 +2481,7 @@ import Proofs.GeometricSeriesOQ02OQ03
 import Proofs.GeometricSeriesOQ02OQ05
 import Proofs.GeometricSeriesOQ03
 import Proofs.GeometricSeriesOQ06
+import Proofs.GeometricSeriesOQ09
 import Proofs.GnedenkoKolmogorov
 import Proofs.GodelFirstIncompletenessOQ01
 import Proofs.GodelFirstIncompletenessOQ01OQ01

--- a/proofs/Proofs/GeometricSeriesOQ09.lean
+++ b/proofs/Proofs/GeometricSeriesOQ09.lean
@@ -1,0 +1,127 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+
+/-
+# Even/Odd Splitting of the Geometric Series: ∑ r^(2n) = 1/(1−r²)
+
+## What This Proves
+
+For a real ratio `r` with `‖r‖ < 1`, the geometric series splits over its even
+and odd index subsequences into two geometric series of ratio `r²`:
+
+  ∑_{n=0}^{∞} r^(2n)    =  1/(1 − r²)        (even-power subseries)
+  ∑_{n=0}^{∞} r^(2n+1)  =  r/(1 − r²)        (odd-power subseries)
+
+and these recombine into the full geometric series
+
+  ∑_{n=0}^{∞} r^(2n) + ∑_{n=0}^{∞} r^(2n+1)  =  ∑_{n=0}^{∞} rⁿ  =  1/(1 − r),
+
+which is the analytic identity `1/(1−r²) + r/(1−r²) = 1/(1−r)` underneath the
+factorisation `1 − r² = (1 − r)(1 + r)`.
+
+## Why This Is Not Already in Mathlib
+
+Mathlib provides the plain geometric series `tsum_geometric_of_norm_lt_one`
+(`∑ rⁿ = (1−r)⁻¹`) but does not record the index-parity subsums.  Each of the
+two subsums is *itself* a geometric series — but of ratio `r²`, not `r` — so the
+content here is the reindexing `r^(2n) = (r²)ⁿ` together with the bound
+`‖r²‖ = ‖r‖² < 1` that makes Mathlib's lemma applicable at the new ratio, plus
+the recombination identity.
+
+## Proof Strategy
+
+1. **Even subseries.** Rewrite `r^(2n) = (r²)ⁿ` (`pow_mul`) and apply
+   `hasSum_geometric_of_norm_lt_one` at ratio `r²`, valid because
+   `‖r²‖ = ‖r‖² < 1`.
+2. **Odd subseries.** Factor `r^(2n+1) = r · r^(2n)` and use `HasSum.mul_left r`
+   on the even subseries; the value `r · (1−r²)⁻¹` is `r/(1−r²)`.
+3. **Recombination.** Add the two `tsum` values and simplify
+   `(1−r²)⁻¹ + r(1−r²)⁻¹ = (1−r)⁻¹` with `field_simp; ring` (both `1−r ≠ 0` and
+   `1−r² ≠ 0` hold since `r² < 1`).
+
+## Status: 0 sorries, 0 axioms
+-/
+
+namespace GeometricSeriesOQ09
+
+variable {r : ℝ}
+
+/-! ## Nonvanishing denominators -/
+
+/-- `1 - r ≠ 0` whenever `‖r‖ < 1` (so `r ≠ 1`). -/
+lemma one_sub_ne_zero (hr : ‖r‖ < 1) : (1 : ℝ) - r ≠ 0 :=
+  sub_ne_zero.mpr fun h => by simp [← h] at hr
+
+/-- `‖r²‖ < 1` whenever `‖r‖ < 1`, the key bound that lets us apply the
+geometric-series lemma at the squared ratio. -/
+lemma norm_sq_lt_one (hr : ‖r‖ < 1) : ‖r ^ 2‖ < 1 := by
+  rw [norm_pow]
+  exact pow_lt_one₀ (norm_nonneg r) hr (by norm_num)
+
+/-- `1 - r² ≠ 0` whenever `‖r‖ < 1` (so `r² ≠ 1`). -/
+lemma one_sub_sq_ne_zero (hr : ‖r‖ < 1) : (1 : ℝ) - r ^ 2 ≠ 0 :=
+  sub_ne_zero.mpr fun h => by simpa [← h] using norm_sq_lt_one hr
+
+/-! ## Even-power subseries -/
+
+/-- **Even subseries, `HasSum` form**: `∑ r^(2n) = 1/(1 − r²)`. -/
+theorem hasSum_geometric_even (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ => r ^ (2 * n)) (1 - r ^ 2)⁻¹ := by
+  have h := hasSum_geometric_of_norm_lt_one (norm_sq_lt_one hr)
+  simpa only [pow_mul] using h
+
+/-- **Even subseries, `tsum` form**: `∑ r^(2n) = 1/(1 − r²)`. -/
+theorem tsum_geometric_even (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, r ^ (2 * n) = (1 - r ^ 2)⁻¹ :=
+  (hasSum_geometric_even hr).tsum_eq
+
+/-- The even subseries is summable. -/
+theorem summable_geometric_even (hr : ‖r‖ < 1) :
+    Summable (fun n : ℕ => r ^ (2 * n)) :=
+  (hasSum_geometric_even hr).summable
+
+/-! ## Odd-power subseries -/
+
+/-- **Odd subseries, `HasSum` form**: `∑ r^(2n+1) = r/(1 − r²)`. -/
+theorem hasSum_geometric_odd (hr : ‖r‖ < 1) :
+    HasSum (fun n : ℕ => r ^ (2 * n + 1)) (r * (1 - r ^ 2)⁻¹) := by
+  have key : (fun n : ℕ => r ^ (2 * n + 1)) = (fun n : ℕ => r * r ^ (2 * n)) := by
+    funext n; rw [pow_succ, mul_comm]
+  rw [key]
+  exact (hasSum_geometric_even hr).mul_left r
+
+/-- **Odd subseries, `tsum` form**: `∑ r^(2n+1) = r/(1 − r²)`. -/
+theorem tsum_geometric_odd (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, r ^ (2 * n + 1) = r * (1 - r ^ 2)⁻¹ :=
+  (hasSum_geometric_odd hr).tsum_eq
+
+/-- The odd subseries is summable. -/
+theorem summable_geometric_odd (hr : ‖r‖ < 1) :
+    Summable (fun n : ℕ => r ^ (2 * n + 1)) :=
+  (hasSum_geometric_odd hr).summable
+
+/-! ## Recombination into the full geometric series -/
+
+/-- The even and odd subsums recombine into the full geometric series:
+`∑ r^(2n) + ∑ r^(2n+1) = ∑ rⁿ = 1/(1 − r)`. -/
+theorem tsum_even_add_odd (hr : ‖r‖ < 1) :
+    (∑' n : ℕ, r ^ (2 * n)) + (∑' n : ℕ, r ^ (2 * n + 1)) = ∑' n : ℕ, r ^ n := by
+  rw [tsum_geometric_even hr, tsum_geometric_odd hr, tsum_geometric_of_norm_lt_one hr]
+  have h1 : (1 : ℝ) - r ≠ 0 := one_sub_ne_zero hr
+  have h2 : (1 : ℝ) - r ^ 2 ≠ 0 := one_sub_sq_ne_zero hr
+  field_simp
+  ring
+
+/-! ## Concrete values -/
+
+/-- Sanity check at `r = 1/2`: `∑ (1/2)^(2n) = ∑ (1/4)ⁿ = 4/3`. -/
+example : ∑' n : ℕ, (1 / 2 : ℝ) ^ (2 * n) = 4 / 3 := by
+  rw [tsum_geometric_even (by norm_num : ‖(1 / 2 : ℝ)‖ < 1)]
+  norm_num
+
+/-- Sanity check at `r = 1/2`: `∑ (1/2)^(2n+1) = 2/3`. -/
+example : ∑' n : ℕ, (1 / 2 : ℝ) ^ (2 * n + 1) = 2 / 3 := by
+  rw [tsum_geometric_odd (by norm_num : ‖(1 / 2 : ℝ)‖ < 1)]
+  norm_num
+
+end GeometricSeriesOQ09

--- a/src/data/proofs/geometric-series-oq-09/meta.json
+++ b/src/data/proofs/geometric-series-oq-09/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "geometric-series-oq-09",
+  "slug": "geometric-series-oq-09",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "GeometricSeriesOQ09",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ09.lean",
+    "sorries": 0
+  },
+  "title": "Even/Odd Splitting of the Geometric Series: ∑ r^(2n) = 1/(1−r²)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ09.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "infinite-series",
+      "power-series",
+      "summability",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 127,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "hasSum_geometric_even / tsum_geometric_even: the closed form ∑_{n≥0} r^(2n) = 1/(1−r²) for ‖r‖ < 1 over ℝ — the even-index subseries of the geometric series, which is itself geometric of ratio r². Mathlib records the plain geometric series ∑ rⁿ = 1/(1−r) but not its index-parity subsums",
+      "hasSum_geometric_odd / tsum_geometric_odd: the complementary closed form ∑_{n≥0} r^(2n+1) = r/(1−r²) for the odd-index subseries, obtained by factoring r^(2n+1) = r · r^(2n) and applying HasSum.mul_left to the even subseries",
+      "tsum_even_add_odd: the recombination ∑ r^(2n) + ∑ r^(2n+1) = ∑ rⁿ = 1/(1−r), the analytic identity 1/(1−r²) + r/(1−r²) = 1/(1−r) underneath the factorisation 1 − r² = (1−r)(1+r)",
+      "norm_sq_lt_one: the bound ‖r²‖ = ‖r‖² < 1 that makes Mathlib's geometric-series lemma applicable at the squared ratio r², together with the nonvanishing denominators 1−r ≠ 0 and 1−r² ≠ 0",
+      "summable_geometric_even / summable_geometric_odd and concrete checks ∑ (1/2)^(2n) = 4/3, ∑ (1/2)^(2n+1) = 2/3"
+    ],
+    "prerequisites": [
+      "Mathlib's geometric series hasSum_geometric_of_norm_lt_one (∑ ξⁿ = (1−ξ)⁻¹ for ‖ξ‖ < 1), applied at the squared ratio ξ = r²",
+      "pow_mul: r^(2n) = (r²)ⁿ, the reindexing that exhibits the even subseries as a geometric series of ratio r²",
+      "norm_pow and pow_lt_one₀: ‖r²‖ = ‖r‖² < 1 from ‖r‖ < 1",
+      "HasSum arithmetic (HasSum.mul_left, HasSum.tsum_eq, HasSum.summable)",
+      "Parent: geometric-series (∑ rⁿ = 1/(1−r))"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_geometric_of_norm_lt_one",
+        "description": "∑_n ξⁿ = (1−ξ)⁻¹ for ‖ξ‖ < 1 over a normed division ring. Applied at ξ = r² to sum the even subseries, then transported to the odd subseries by HasSum.mul_left.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "pow_mul",
+        "description": "a^(m·n) = (a^m)ⁿ. Used as r^(2n) = (r²)ⁿ to rewrite the even subseries into a geometric series of ratio r².",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "pow_lt_one₀",
+        "description": "0 ≤ a → a < 1 → a^n < 1 (n ≠ 0). Combined with norm_pow to give ‖r²‖ = ‖r‖² < 1, the hypothesis Mathlib's geometric lemma needs at the squared ratio.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-09-oq-01",
+      "question": "Generalise to an arbitrary residue class: prove ∑_{n≥0} r^(qn+a) = r^a/(1−r^q) for ‖r‖ < 1 and 0 ≤ a < q, the q-fold splitting of the geometric series into q geometric subseries of ratio r^q. The even/odd case here is q=2, a∈{0,1}.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-09-oq-02",
+      "question": "Over ℂ, relate the alternating recombination ∑ r^(2n) − ∑ r^(2n+1) = 1/(1+r) to the even/odd parts of 1/(1−r), and identify the even subseries 1/(1−r²) as the generating function of the indicator of even integers.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series",
+      "relationship": "extends",
+      "description": "Parent. The base entry proves ∑ rⁿ = 1/(1−r). This entry splits that series over its even and odd index subsequences — each a geometric series of ratio r² — proving ∑ r^(2n) = 1/(1−r²) and ∑ r^(2n+1) = r/(1−r²), and verifying that the two subsums recombine into the parent value."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of hasSum_geometric_of_norm_lt_one, the geometric series lemma applied at the squared ratio r²."
+    },
+    {
+      "title": "Concrete Mathematics (geometric series; generating functions and bisection)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the bisection of a power series into even and odd parts, of which the even/odd geometric subsums are the simplest instance."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For ‖r‖ < 1 over ℝ, the geometric series splits over index parity into two geometric series of ratio r²: ∑_{n≥0} r^(2n) = 1/(1−r²) (even subseries) and ∑_{n≥0} r^(2n+1) = r/(1−r²) (odd subseries), and these recombine into the full series ∑ rⁿ = 1/(1−r). The even subseries is proved by the reindexing r^(2n) = (r²)ⁿ together with the bound ‖r²‖ = ‖r‖² < 1 that lets Mathlib's hasSum_geometric_of_norm_lt_one apply at ratio r²; the odd subseries follows by factoring r^(2n+1) = r·r^(2n) and HasSum.mul_left; the recombination 1/(1−r²) + r/(1−r²) = 1/(1−r) is closed by field_simp; ring under 1 − r² = (1−r)(1+r). The file gives HasSum, tsum, and summability forms for both subseries plus concrete checks ∑ (1/2)^(2n) = 4/3 and ∑ (1/2)^(2n+1) = 2/3. 127 lines, 10 theorems/lemmas, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Mathlib records the geometric series but not its index-parity subsums, so the even and odd closed forms fill a small gap and illustrate a reusable move: a subseries taken along an arithmetic progression of indices is again geometric, with ratio r^q, so summing it reduces to Mathlib's lemma at a new ratio plus the bound ‖r^q‖ < 1. The even/odd case is q=2; the same template gives the general q-fold splitting ∑ r^(qn+a) = r^a/(1−r^q), the natural open question.",
+    "openQuestions": [
+      "Prove the q-fold splitting ∑ r^(qn+a) = r^a/(1−r^q) for 0 ≤ a < q.",
+      "Over ℂ, relate the alternating recombination to the even/odd parts of 1/(1−r) as generating functions."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Splits the geometric series over its **even and odd index subsequences**, each itself a geometric series of ratio `r²`, for `‖r‖ < 1` over ℝ:

- **Even subseries:** `∑_{n≥0} r^(2n) = 1/(1 − r²)`
- **Odd subseries:** `∑_{n≥0} r^(2n+1) = r/(1 − r²)`
- **Recombination:** `∑ r^(2n) + ∑ r^(2n+1) = ∑ rⁿ = 1/(1 − r)`

## Why this isn't already in Mathlib

Mathlib records the plain geometric series `tsum_geometric_of_norm_lt_one` but not its index-parity subsums. Each subsum is geometric of ratio `r²` (not `r`), so the content is the reindexing `r^(2n) = (r²)ⁿ` plus the bound `‖r²‖ = ‖r‖² < 1` that makes Mathlib's lemma applicable at the new ratio, plus the recombination identity `1/(1−r²) + r/(1−r²) = 1/(1−r)` under `1 − r² = (1−r)(1+r)`.

## Proof

1. Even: rewrite `r^(2n) = (r²)ⁿ` (`pow_mul`), apply `hasSum_geometric_of_norm_lt_one` at ratio `r²`.
2. Odd: factor `r^(2n+1) = r · r^(2n)`, use `HasSum.mul_left r` on the even subseries.
3. Recombine: `field_simp; ring` with `1−r ≠ 0` and `1−r² ≠ 0`.

HasSum / tsum / summability forms for both subseries, plus concrete checks `∑ (1/2)^(2n) = 4/3`, `∑ (1/2)^(2n+1) = 2/3`.

## Verification

- 127 lines, 10 theorems/lemmas, 0 definitions, **0 sorries, 0 axioms**
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` (foundational only)
- Compiles clean via `lake env lean Proofs/GeometricSeriesOQ09.lean` (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)