### PR TITLE
research(cauchy-schwarz-oq-08): norm-rigidity of the real inner product (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -465,6 +465,7 @@ import Proofs.CauchySchwarzOQ03OQ02
 import Proofs.CauchySchwarzOQ04
 import Proofs.CauchySchwarzOQ04OQ01
 import Proofs.CauchySchwarzOQ07
+import Proofs.CauchySchwarzOQ08
 import Proofs.CayleyHamilton
 import Proofs.CayleyHamiltonCyclicVectorAllFields
 import Proofs.CayleyHamiltonCyclicVectorAllFieldsAristotle

--- a/proofs/Proofs/CauchySchwarzOQ08.lean
+++ b/proofs/Proofs/CauchySchwarzOQ08.lean
@@ -1,0 +1,83 @@
+/-
+  Norm-rigidity of the real inner product (cauchy-schwarz-oq-08).
+
+  Open question.  Formalize the polarization identity in a real inner-product space,
+      ⟪x, y⟫ = (‖x + y‖² − ‖x − y‖²) / 4,
+  and push it to its structural payoff: the inner product is *uniquely determined* by
+  the norm.
+
+  The bare identity is already in the gallery (cauchy-schwarz-oq-07,
+  `real_inner_eq_norm_sq_diff_div_four`), where it appears as a one-line corollary of the
+  parallelogram cross-term expansion.  This file takes the next step the identity is
+  really *for*: because the inner product is a function of the norm alone, any map that
+  preserves the norm must preserve the inner product.  Concretely we prove
+
+      * polarization (recalled here so the file is self-contained), then
+      * `inner_map_eq`: every **norm-preserving additive map** `f : F →+ F'` between real
+        inner-product spaces satisfies `⟪f x, f y⟫ = ⟪x, y⟫`.  Note the hypothesis is only
+        additivity (no ℝ-linearity) — polarization needs `f (x ± y) = f x ± f y` and
+        nothing more.
+
+  From this single theorem the usual rigidity facts follow as corollaries: norm-preserving
+  additive maps preserve orthogonality, are injective, and ℝ-linear isometries are
+  inner-product isometries.  This is the elementary reason isometries of Hilbert spaces are
+  unitary, derived from polarization without Mathlib's bundled `LinearIsometry` machinery.
+
+  Sorry-free and axiom-free.
+-/
+import Mathlib
+
+open scoped InnerProductSpace RealInnerProductSpace
+
+namespace CauchySchwarzOQ08
+
+variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F]
+variable {F' : Type*} [NormedAddCommGroup F'] [InnerProductSpace ℝ F']
+
+/-- **Polarization identity** over a real inner-product space (recalled, self-contained):
+the inner product is recovered from the norm via the diagonals of the parallelogram,
+`⟪x, y⟫ = (‖x + y‖² − ‖x − y‖²) / 4`.  Proved by expanding `‖x ± y‖²` through
+`inner_self`; the two cross terms `±2⟪x, y⟫` combine. -/
+theorem polarization (x y : F) :
+    ⟪x, y⟫_ℝ = (‖x + y‖ ^ 2 - ‖x - y‖ ^ 2) / 4 := by
+  rw [norm_add_sq_real, norm_sub_sq_real]; ring
+
+/-- **Norm-rigidity of the real inner product.**  Any *additive* map `f : F →+ F'` between
+real inner-product spaces that preserves the norm automatically preserves the inner
+product: `⟪f x, f y⟫ = ⟪x, y⟫`.
+
+This is the structural content of polarization: since the inner product is a function of
+the norm alone, a map that fixes the norm cannot move the inner product.  Only additivity
+is used — `f (x + y) = f x + f y` and `f (x − y) = f x − f y` — not ℝ-linearity. -/
+theorem inner_map_eq (f : F →+ F') (h : ∀ x, ‖f x‖ = ‖x‖) (x y : F) :
+    ⟪f x, f y⟫_ℝ = ⟪x, y⟫_ℝ := by
+  rw [polarization (f x) (f y), polarization x y, ← map_add, ← map_sub, h, h]
+
+/-- Norm-preserving additive maps **preserve orthogonality**: `f x ⟂ f y ↔ x ⟂ y`. -/
+theorem inner_map_eq_zero_iff (f : F →+ F') (h : ∀ x, ‖f x‖ = ‖x‖) (x y : F) :
+    ⟪f x, f y⟫_ℝ = 0 ↔ ⟪x, y⟫_ℝ = 0 := by
+  rw [inner_map_eq f h]
+
+omit [InnerProductSpace ℝ F] [InnerProductSpace ℝ F'] in
+/-- Norm-preserving additive maps are **injective** (a vector of norm `0` is `0`). -/
+theorem injective_of_norm_preserving (f : F →+ F') (h : ∀ x, ‖f x‖ = ‖x‖) :
+    Function.Injective f := by
+  rw [injective_iff_map_eq_zero]
+  intro a ha
+  have : ‖a‖ = 0 := by rw [← h a, ha, norm_zero]
+  exact norm_eq_zero.mp this
+
+/-- ℝ-linear specialization: a **norm-preserving linear map preserves the inner product**.
+The defining property of a linear isometry, obtained from `inner_map_eq` by forgetting
+linearity down to the additive structure. -/
+theorem inner_linearMap_eq (f : F →ₗ[ℝ] F') (h : ∀ x, ‖f x‖ = ‖x‖) (x y : F) :
+    ⟪f x, f y⟫_ℝ = ⟪x, y⟫_ℝ :=
+  inner_map_eq f.toAddMonoidHom h x y
+
+/-- A bundled `LinearIsometry` over `ℝ` preserves the inner product, recovered through the
+elementary polarization route of this file. -/
+theorem inner_linearIsometry_eq (f : F →ₗᵢ[ℝ] F') (x y : F) :
+    ⟪f x, f y⟫_ℝ = ⟪x, y⟫_ℝ :=
+  inner_linearMap_eq f.toLinearMap f.norm_map x y
+
+end CauchySchwarzOQ08

--- a/src/data/proofs/cauchy-schwarz-oq-08/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-08/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "csoq08-header",
+    "proofId": "cauchy-schwarz-oq-08",
+    "range": {
+      "startLine": 1,
+      "endLine": 39
+    },
+    "type": "concept",
+    "title": "Module Header and Problem Setup",
+    "content": "The open question asks for the polarization identity $\\langle x,y\\rangle = (\\|x+y\\|^2 - \\|x-y\\|^2)/4$ in a real inner-product space. The bare identity already appears in cauchy-schwarz-oq-07; this entry pushes it to its structural payoff — the inner product is uniquely determined by the norm, so any map preserving the norm must preserve the inner product. Two real inner-product spaces $F, F'$ are fixed via `[NormedAddCommGroup F] [InnerProductSpace ℝ F]`."
+  },
+  {
+    "id": "csoq08-polarization",
+    "proofId": "cauchy-schwarz-oq-08",
+    "range": {
+      "startLine": 41,
+      "endLine": 50
+    },
+    "type": "theorem",
+    "title": "The Polarization Identity",
+    "content": "`polarization` proves $\\langle x,y\\rangle = (\\|x+y\\|^2 - \\|x-y\\|^2)/4$ self-contained: expanding $\\|x+y\\|^2 = \\|x\\|^2 + 2\\langle x,y\\rangle + \\|y\\|^2$ and $\\|x-y\\|^2 = \\|x\\|^2 - 2\\langle x,y\\rangle + \\|y\\|^2$ (via `norm_add_sq_real`/`norm_sub_sq_real`), the difference is $4\\langle x,y\\rangle$. This recovers the inner product from the norm and serves as the engine for the rigidity results below."
+  },
+  {
+    "id": "csoq08-rigidity",
+    "proofId": "cauchy-schwarz-oq-08",
+    "range": {
+      "startLine": 52,
+      "endLine": 71
+    },
+    "type": "theorem",
+    "title": "Norm-Rigidity of the Inner Product",
+    "content": "`inner_map_eq` is the headline result: a norm-preserving **additive** map $f : F \\to_+ F'$ satisfies $\\langle f x, f y\\rangle = \\langle x,y\\rangle$. Rewriting both sides by polarization, additivity gives $f x \\pm f y = f(x \\pm y)$ and the hypothesis $\\|f z\\| = \\|z\\|$ equates the norms — so the inner products coincide. Crucially only additivity is used, not $\\mathbb{R}$-linearity. `inner_map_eq_zero_iff` derives preservation of orthogonality, and `injective_of_norm_preserving` shows such maps are injective (a vector of norm $0$ is $0$)."
+  },
+  {
+    "id": "csoq08-isometry",
+    "proofId": "cauchy-schwarz-oq-08",
+    "range": {
+      "startLine": 73,
+      "endLine": 83
+    },
+    "type": "theorem",
+    "title": "Linear and Bundled-Isometry Corollaries",
+    "content": "`inner_linearMap_eq` specializes the rigidity theorem to an $\\mathbb{R}$-linear map by forgetting linearity down to its additive structure, recovering the defining property of a linear isometry. `inner_linearIsometry_eq` applies this to a bundled `LinearIsometry` through its `norm_map` field — obtaining $\\langle f x, f y\\rangle = \\langle x,y\\rangle$ without invoking Mathlib's bundled `LinearIsometry.inner_map_map`. This is the elementary reason isometries of Hilbert spaces are unitary."
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-08/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-08/meta.json
@@ -1,0 +1,208 @@
+{
+  "id": "cauchy-schwarz-oq-08",
+  "title": "Norm-Rigidity of the Real Inner Product",
+  "slug": "cauchy-schwarz-oq-08",
+  "description": "The polarization identity ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖²)/4 in a real inner-product space, pushed to its structural payoff: the inner product is uniquely determined by the norm, so any norm-preserving additive map preserves the inner product. From this single rigidity theorem follow preservation of orthogonality, injectivity, and that ℝ-linear isometries are inner-product isometries.",
+  "meta": {
+    "author": "Classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Polarization_identity",
+    "date": "1935",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "inner-product-spaces",
+      "cauchy-schwarz",
+      "polarization-identity",
+      "isometry",
+      "rigidity",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ08.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "norm_add_sq_real",
+        "description": "‖x+y‖² = ‖x‖² + 2⟪x,y⟫ + ‖y‖² in a real inner-product space",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "norm_sub_sq_real",
+        "description": "‖x-y‖² = ‖x‖² − 2⟪x,y⟫ + ‖y‖² in a real inner-product space",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "injective_iff_map_eq_zero",
+        "description": "An additive group hom is injective iff its kernel is trivial (f a = 0 → a = 0)",
+        "module": "Mathlib.Algebra.Group.Hom.Basic"
+      },
+      {
+        "theorem": "LinearIsometry.norm_map",
+        "description": "A bundled linear isometry preserves the norm, ‖f x‖ = ‖x‖",
+        "module": "Mathlib.Analysis.Normed.Operator.LinearIsometry"
+      }
+    ],
+    "originalContributions": [
+      "inner_map_eq: norm-rigidity of the real inner product — every norm-preserving ADDITIVE map f : F →+ F' between real inner-product spaces satisfies ⟪f x, f y⟫ = ⟪x, y⟫. The hypothesis is only additivity (not ℝ-linearity); polarization needs f(x±y) = f x ± f y and nothing more. This is the distinct contribution beyond cauchy-schwarz-oq-07 (which proved only the bare identity within one space).",
+      "inner_map_eq_zero_iff: norm-preserving additive maps preserve orthogonality, ⟪f x, f y⟫ = 0 ↔ ⟪x, y⟫ = 0",
+      "injective_of_norm_preserving: a norm-preserving additive map is injective (a vector of norm 0 is 0)",
+      "inner_linearMap_eq: ℝ-linear specialization — a norm-preserving linear map preserves the inner product (the defining property of a linear isometry, here derived rather than assumed)",
+      "inner_linearIsometry_eq: a bundled ℝ-LinearIsometry preserves the inner product, recovered through the elementary polarization route without Mathlib's bundled inner_map_map machinery",
+      "polarization: a self-contained re-derivation of ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖²)/4 used as the engine for the rigidity results"
+    ],
+    "dateAdded": "2026-06-19",
+    "lineCount": 83,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The polarization identity reconstructs an inner product from its norm: ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖²)/4 in the real case. Together with the Jordan–von Neumann theorem (1935) — a norm comes from an inner product iff it satisfies the parallelogram law — it shows that an inner-product norm and its inner product carry exactly the same information. The immediate structural consequence, formalized here, is a RIGIDITY statement: because the inner product is a function of the norm alone, any map preserving the norm must preserve the inner product. This is the elementary reason that isometries of Hilbert spaces are automatically unitary (preserve the inner product), a cornerstone of operator theory.",
+    "problemStatement": "**Open Question (cauchy-schwarz-oq-08)**: Formalize the polarization identity ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖²)/4 in a real inner-product space.\n\n**Result**: The bare identity (`polarization`) is proved self-contained by cross-term expansion, then advanced to its structural payoff — `inner_map_eq`: every norm-preserving *additive* map between real inner-product spaces preserves the inner product. Preservation of orthogonality, injectivity, and the linear-isometry corollary follow.",
+    "text": "The polarization identity in a real inner-product space and its rigidity consequence: norm-preserving additive maps preserve the inner product, hence orthogonality, and are injective; ℝ-linear isometries are inner-product isometries.",
+    "proofStrategy": "**Proof Strategy: polarization as a rigidity engine.**\n\n1. Expand ‖x+y‖² = ‖x‖² + 2⟪x,y⟫ + ‖y‖² (`norm_add_sq_real`) and ‖x−y‖² = ‖x‖² − 2⟪x,y⟫ + ‖y‖² (`norm_sub_sq_real`); their difference is 4⟪x,y⟫, giving polarization ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖²)/4.\n2. For a norm-preserving additive map f, rewrite both ⟪f x, f y⟫ and ⟪x,y⟫ by polarization. Using additivity, f x + f y = f(x+y) and f x − f y = f(x−y); the norm-preservation hypothesis then equates ‖f(x±y)‖ with ‖x±y‖, so the two polarization expressions coincide and ⟪f x, f y⟫ = ⟪x,y⟫.\n3. Orthogonality preservation is an immediate rewrite; injectivity follows since ‖f a‖ = ‖a‖ forces a = 0 when f a = 0; the linear and bundled-isometry corollaries forget structure down to the additive hypothesis.",
+    "keyInsights": [
+      "**Polarization is a rigidity statement in disguise.** The bare identity recovers the inner product from the norm within one space; reading it across two spaces shows that fixing the norm forces fixing the inner product. The structural theorem `inner_map_eq` is the real content the identity is for.",
+      "**Additivity suffices — linearity is not needed.** Polarization only references f(x+y) and f(x−y), so the inner-product-preservation theorem holds for any norm-preserving AddMonoidHom; ℝ-linear isometries are merely a special case. This is sharper than the usual textbook statement for linear isometries.",
+      "**Why isometries are unitary, elementarily.** The chain norm-preserving ⟹ inner-product-preserving ⟹ orthogonality-preserving + injective is exactly the reason Hilbert-space isometries are unitary, derived here without the bundled `LinearIsometry.inner_map_map` machinery."
+    ],
+    "prerequisites": [
+      "Inner product spaces (InnerProductSpace ℝ F in Mathlib)",
+      "The norm–inner-product relation ‖x‖² = ⟪x,x⟫ (inner_self) and its ± expansions",
+      "Additive monoid homomorphisms and linear maps (→+, →ₗ, →ₗᵢ)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring stating the open question, its relation to cauchy-schwarz-oq-07, and the rigidity goal; Mathlib import; the CauchySchwarzOQ08 namespace; scoped real inner-product notation; and the two real inner-product-space variables F, F'.",
+      "mathContext": "Work in real inner-product spaces $(F, \\langle\\cdot,\\cdot\\rangle_\\mathbb{R})$ and $(F', \\langle\\cdot,\\cdot\\rangle_\\mathbb{R})$ with `[NormedAddCommGroup F] [InnerProductSpace ℝ F]`."
+    },
+    {
+      "id": "polarization",
+      "title": "The Polarization Identity",
+      "startLine": 41,
+      "endLine": 50,
+      "summary": "polarization: the self-contained identity ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖²)/4, proved by expanding ‖x±y‖² via the inner-product self-identity and taking the difference.",
+      "mathContext": "$\\langle x,y\\rangle = (\\|x+y\\|^2 - \\|x-y\\|^2)/4$ for $x,y$ in a real inner-product space."
+    },
+    {
+      "id": "rigidity",
+      "title": "Norm-Rigidity of the Inner Product",
+      "startLine": 52,
+      "endLine": 71,
+      "summary": "inner_map_eq proves that a norm-preserving additive map preserves the inner product; inner_map_eq_zero_iff derives preservation of orthogonality; injective_of_norm_preserving shows such maps are injective.",
+      "mathContext": "For $f : F \\to F'$ additive with $\\|f x\\| = \\|x\\|$: $\\langle f x, f y\\rangle = \\langle x,y\\rangle$, hence $f x \\perp f y \\iff x \\perp y$ and $f$ is injective."
+    },
+    {
+      "id": "isometry",
+      "title": "Linear and Bundled-Isometry Corollaries",
+      "startLine": 73,
+      "endLine": 83,
+      "summary": "inner_linearMap_eq specializes the rigidity theorem to ℝ-linear maps; inner_linearIsometry_eq applies it to a bundled LinearIsometry via its norm_map property.",
+      "mathContext": "A norm-preserving $\\mathbb{R}$-linear map, and in particular a bundled linear isometry $f : F \\to_{\\ell i} F'$, satisfies $\\langle f x, f y\\rangle = \\langle x,y\\rangle$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-07",
+      "relationship": "extends",
+      "description": "OQ-07 proves the parallelogram law and the bare polarization identity within a single space; this entry advances polarization to its rigidity consequence — norm-preservation forces inner-product-preservation across spaces"
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "Both are foundational inner-product-space results; rigidity of the inner product under norm-preserving maps complements the Cauchy–Schwarz inequality in Hilbert-space geometry"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "Orthogonality preservation (inner_map_eq_zero_iff) means a norm-preserving additive map carries Pythagorean (right-angle) configurations to Pythagorean configurations"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the real polarization identity together with its structural payoff: norm-rigidity of the inner product. Every norm-preserving additive map between real inner-product spaces preserves the inner product, hence orthogonality, and is injective; ℝ-linear isometries (bundled or not) are inner-product isometries.",
+    "implications": "Norm-rigidity is the reason Hilbert-space isometries are unitary. By isolating the additive hypothesis, the result shows inner-product preservation is forced by norm preservation alone, with no appeal to linearity — a sharpening of the usual linear-isometry statement and the elementary core of `LinearIsometry.inner_map_map`.",
+    "openQuestions": [
+      "Formalize the complex analogue: a norm-preserving ℝ-additive map that also preserves ‖x ± i·y‖ preserves the full complex inner product (via inner_eq_sum_norm_sq_div_four).",
+      "Derive that a surjective norm-preserving additive map is an inner-product isomorphism (combine injectivity here with surjectivity to get a LinearIsometryEquiv-style statement)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "RealInnerProductSpace"
+    ],
+    "namespace": "CauchySchwarzOQ08",
+    "lineCount": 83,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ08.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "inner_map_eq",
+      "type": "core",
+      "description": "**Norm-rigidity of the real inner product.** Any additive map f : F →+ F' between real inner-product spaces that preserves the norm (∀ x, ‖f x‖ = ‖x‖) automatically preserves the inner product: ⟪f x, f y⟫ = ⟪x, y⟫. Only additivity is used — not ℝ-linearity. This is the structural content of polarization and the distinct contribution over cauchy-schwarz-oq-07.",
+      "leanType": "∀ {F F' : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] [NormedAddCommGroup F'] [InnerProductSpace ℝ F'] (f : F →+ F'), (∀ x, ‖f x‖ = ‖x‖) → ∀ (x y : F), ⟪f x, f y⟫_ℝ = ⟪x, y⟫_ℝ"
+    },
+    {
+      "name": "polarization",
+      "type": "core",
+      "description": "**Polarization identity** (self-contained). In a real inner-product space the inner product is recovered from the norm via the diagonals: ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖²)/4. Proved by expanding ‖x±y‖² through inner_self and taking the difference; used as the engine for the rigidity theorems.",
+      "leanType": "∀ {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] (x y : F), ⟪x, y⟫_ℝ = (‖x + y‖ ^ 2 - ‖x - y‖ ^ 2) / 4"
+    },
+    {
+      "name": "inner_map_eq_zero_iff",
+      "type": "supporting",
+      "description": "Norm-preserving additive maps preserve orthogonality: ⟪f x, f y⟫ = 0 ↔ ⟪x, y⟫ = 0.",
+      "leanType": "∀ {F F' : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] [NormedAddCommGroup F'] [InnerProductSpace ℝ F'] (f : F →+ F'), (∀ x, ‖f x‖ = ‖x‖) → ∀ (x y : F), ⟪f x, f y⟫_ℝ = 0 ↔ ⟪x, y⟫_ℝ = 0"
+    },
+    {
+      "name": "injective_of_norm_preserving",
+      "type": "supporting",
+      "description": "A norm-preserving additive map is injective: if ‖f x‖ = ‖x‖ for all x, then f a = 0 forces ‖a‖ = 0, hence a = 0.",
+      "leanType": "∀ {F F' : Type*} [NormedAddCommGroup F] [NormedAddCommGroup F'] (f : F →+ F'), (∀ x, ‖f x‖ = ‖x‖) → Function.Injective f"
+    },
+    {
+      "name": "inner_linearMap_eq",
+      "type": "supporting",
+      "description": "ℝ-linear specialization: a norm-preserving linear map preserves the inner product — the defining property of a linear isometry, here derived from the additive rigidity theorem.",
+      "leanType": "∀ {F F' : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] [NormedAddCommGroup F'] [InnerProductSpace ℝ F'] (f : F →ₗ[ℝ] F'), (∀ x, ‖f x‖ = ‖x‖) → ∀ (x y : F), ⟪f x, f y⟫_ℝ = ⟪x, y⟫_ℝ"
+    },
+    {
+      "name": "inner_linearIsometry_eq",
+      "type": "supporting",
+      "description": "A bundled ℝ-LinearIsometry preserves the inner product, recovered through the elementary polarization route of this file (via its norm_map property).",
+      "leanType": "∀ {F F' : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] [NormedAddCommGroup F'] [InnerProductSpace ℝ F'] (f : F →ₗᵢ[ℝ] F') (x y : F), ⟪f x, f y⟫_ℝ = ⟪x, y⟫_ℝ"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Jordan, Pascual; von Neumann, John",
+      "title": "On Inner Products in Linear, Metric Spaces",
+      "year": "1935",
+      "venue": "Annals of Mathematics, vol. 36, no. 3, pp. 719–723",
+      "note": "Establishes the equivalence of the parallelogram law with the existence of an inner product, the backdrop for norm-determines-inner-product rigidity"
+    },
+    {
+      "authors": "Conway, John B.",
+      "title": "A Course in Functional Analysis",
+      "year": "1990",
+      "venue": "Springer, Graduate Texts in Mathematics 96 (2nd edition)",
+      "note": "Chapter I: the polarization identity; isometries of Hilbert spaces and their inner-product preservation"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **polarization identity** in a real inner-product space and pushes it to its structural payoff — **norm-rigidity of the inner product**.

**Open question (cauchy-schwarz-oq-08):** polarization identity ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖²)/4.

The bare identity is already in the gallery (`cauchy-schwarz-oq-07`, as a one-line corollary). This entry is **distinct**: it advances polarization to the theorem it is really *for* — because the inner product is a function of the norm alone, any **norm-preserving additive map preserves the inner product**.

## Results (`proofs/Proofs/CauchySchwarzOQ08.lean`, 83 lines)

| Theorem | Statement |
|---|---|
| `polarization` | ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖²)/4 (self-contained engine) |
| **`inner_map_eq`** | norm-preserving **additive** `f : F →+ F'` ⟹ ⟪f x, f y⟫ = ⟪x,y⟫ |
| `inner_map_eq_zero_iff` | norm-preserving additive maps preserve orthogonality |
| `injective_of_norm_preserving` | norm-preserving additive maps are injective |
| `inner_linearMap_eq` | ℝ-linear specialization |
| `inner_linearIsometry_eq` | bundled ℝ-`LinearIsometry` preserves the inner product |

The headline `inner_map_eq` uses **only additivity** — not ℝ-linearity — since polarization references just `f(x+y)` and `f(x−y)`. This is a sharpening of the usual linear-isometry statement and the elementary reason Hilbert-space isometries are unitary, derived without Mathlib's bundled `LinearIsometry.inner_map_map`.

## Verification

- Compiles clean under Mathlib v4.26.0 (`lake env lean Proofs/CauchySchwarzOQ08.lean`, no errors/warnings/sorries).
- `#print axioms`: `[propext, Classical.choice, Quot.sound]` — **0-axiom, status `verified`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)