### PR TITLE
research(combinations-formula-oq-05): alternating row sum and the even/odd binomial split

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ05.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ05.lean
@@ -1,0 +1,114 @@
+import Mathlib
+
+/-
+# The Alternating Row Sum of Pascal's Triangle and the Even/Odd Split
+
+## Open Question OQ-05
+
+For `n ≥ 1`, the alternating sum of the `n`-th row of Pascal's triangle vanishes:
+
+  ∑_{k=0}^{n} (-1)^k · C(n, k) = 0 .
+
+Mathlib provides this as `Int.alternating_sum_range_choose_of_ne`.  Standing
+alone it is a one-line corollary, so this file develops its genuine
+combinatorial content: combined with the total row sum
+`∑_{k} C(n, k) = 2^n` (`Nat.sum_range_choose`), the vanishing alternating sum
+says the even-indexed and odd-indexed binomial coefficients contribute equally.
+
+1. `alternating_sum_choose_eq_zero` — anchor: `∑ (-1)^k C(n,k) = 0` for `n ≥ 1`.
+
+2. `sum_even_choose_eq_sum_odd_choose` — the even/odd split:
+        ∑_{k even} C(n, k) = ∑_{k odd} C(n, k)   (n ≥ 1).
+
+3. `sum_even_choose` — each half is exactly `2^{n-1}`:
+        ∑_{k even} C(n, k) = 2^{n-1}             (n ≥ 1).
+
+## Mathematical Context
+
+The two fundamental row identities of Pascal's triangle are the total sum
+`∑ C(n,k) = 2^n` (number of all subsets) and the alternating sum
+`∑ (-1)^k C(n,k) = 0` (subsets of even size minus subsets of odd size).
+Together they are equivalent to the statement that an `n`-element set with
+`n ≥ 1` has equally many even-sized and odd-sized subsets, each numbering
+`2^{n-1}`.  This is the simplest instance of the inclusion–exclusion
+cancellation that underlies the binomial transform.
+
+The proof splits the row sum over the even/odd parity of the index using
+`Finset.sum_filter_add_sum_filter_not`, evaluating `(-1)^k` as `+1` on even
+indices (`Even.neg_one_pow`) and `-1` on odd indices (`Odd.neg_one_pow`).
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ05
+
+open Finset
+
+/-- **Anchor.** The alternating row sum of Pascal's triangle vanishes for `n ≥ 1`.
+    This is `Int.alternating_sum_range_choose_of_ne`. -/
+theorem alternating_sum_choose_eq_zero {n : ℕ} (hn : n ≠ 0) :
+    ∑ k ∈ Finset.range (n + 1), ((-1) ^ k * n.choose k : ℤ) = 0 :=
+  Int.alternating_sum_range_choose_of_ne hn
+
+/-- **Even/odd split.** For `n ≥ 1` the even-indexed and odd-indexed binomial
+    coefficients of row `n` have equal sums. -/
+theorem sum_even_choose_eq_sum_odd_choose {n : ℕ} (hn : n ≠ 0) :
+    ∑ k ∈ (Finset.range (n + 1)).filter (fun k => Even k), (n.choose k : ℤ)
+      = ∑ k ∈ (Finset.range (n + 1)).filter (fun k => Odd k), (n.choose k : ℤ) := by
+  have key := alternating_sum_choose_eq_zero hn
+  rw [← Finset.sum_filter_add_sum_filter_not (Finset.range (n + 1)) (fun k => Even k)
+        (fun k => ((-1) ^ k * n.choose k : ℤ))] at key
+  -- Evaluate (-1)^k on the even part (= +1) and the odd part (= -1).
+  have hE : ∑ k ∈ (Finset.range (n + 1)).filter (fun k => Even k),
+      ((-1) ^ k * n.choose k : ℤ)
+      = ∑ k ∈ (Finset.range (n + 1)).filter (fun k => Even k), (n.choose k : ℤ) := by
+    refine Finset.sum_congr rfl fun k hk => ?_
+    rw [Finset.mem_filter] at hk
+    rw [hk.2.neg_one_pow, one_mul]
+  have hO : ∑ k ∈ (Finset.range (n + 1)).filter (fun k => ¬ Even k),
+      ((-1) ^ k * n.choose k : ℤ)
+      = - ∑ k ∈ (Finset.range (n + 1)).filter (fun k => Odd k), (n.choose k : ℤ) := by
+    rw [← Finset.sum_neg_distrib]
+    refine Finset.sum_congr ?_ fun k hk => ?_
+    · simp only [Nat.not_even_iff_odd]
+    · rw [Finset.mem_filter] at hk
+      rw [hk.2.neg_one_pow, neg_one_mul]
+  rw [hE, hO] at key
+  linarith
+
+/-- The total row sum, cast to `ℤ`: `∑ C(n,k) = 2^n`. -/
+private theorem sum_choose_int (n : ℕ) :
+    ∑ k ∈ Finset.range (n + 1), (n.choose k : ℤ) = 2 ^ n := by
+  exact_mod_cast Nat.sum_range_choose n
+
+/-- **Each half equals `2^{n-1}`.** For `n ≥ 1`,
+    `∑_{k even} C(n, k) = 2^{n-1}`. -/
+theorem sum_even_choose {n : ℕ} (hn : n ≠ 0) :
+    ∑ k ∈ (Finset.range (n + 1)).filter (fun k => Even k), (n.choose k : ℤ)
+      = 2 ^ (n - 1) := by
+  have hEO := sum_even_choose_eq_sum_odd_choose hn
+  have hsplit :
+      (∑ k ∈ (Finset.range (n + 1)).filter (fun k => Even k), (n.choose k : ℤ))
+        + (∑ k ∈ (Finset.range (n + 1)).filter (fun k => ¬ Even k), (n.choose k : ℤ))
+      = ∑ k ∈ Finset.range (n + 1), (n.choose k : ℤ) :=
+    Finset.sum_filter_add_sum_filter_not _ _ _
+  rw [sum_choose_int] at hsplit
+  -- rewrite the ¬Even filter as Odd, then use even = odd
+  have hodd_filter :
+      (Finset.range (n + 1)).filter (fun k => ¬ Even k)
+        = (Finset.range (n + 1)).filter (fun k => Odd k) := by
+    simp only [Nat.not_even_iff_odd]
+  rw [hodd_filter, ← hEO] at hsplit
+  -- hsplit : E + E = 2^n, i.e. 2*E = 2^n; and 2^n = 2 * 2^(n-1)
+  have hpow : (2 : ℤ) ^ n = 2 * 2 ^ (n - 1) := by
+    rw [← pow_succ']
+    congr 1
+    omega
+  linarith
+
+/-- Sanity check (row 4): even part `C(4,0)+C(4,2)+C(4,4) = 1+6+1 = 8 = 2^3`. -/
+example :
+    ∑ k ∈ (Finset.range 5).filter (fun k => Even k), (Nat.choose 4 k : ℤ) = 8 := by
+  decide
+
+end CombinationsFormulaOQ05

--- a/src/data/proofs/combinations-formula-oq-05/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-05/annotations.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "alt-sum-context",
+    "proofId": "combinations-formula-oq-05",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "concept",
+    "title": "The Alternating Row Sum and the Even/Odd Subset Count",
+    "content": "Pascal's triangle has two fundamental row identities: the total sum ∑ C(n,k) = 2^n and the alternating sum ∑ (-1)^k C(n,k) = 0 (for n ≥ 1). Mathlib proves the alternating sum directly; this entry develops its combinatorial meaning. Together the two identities say the even-indexed and odd-indexed binomial coefficients have equal sums, each equal to 2^{n-1} — i.e. a nonempty finite set has equally many even-sized and odd-sized subsets.",
+    "mathContext": "Both identities are evaluations of the binomial theorem $(1+x)^n = \\sum_k \\binom{n}{k} x^k$: at $x=1$ it gives $\\sum_k \\binom{n}{k} = 2^n$, and at $x=-1$ it gives $\\sum_k (-1)^k \\binom{n}{k} = 0$ for $n \\ge 1$. Writing $E = \\sum_{k\\text{ even}}\\binom{n}{k}$ and $O = \\sum_{k\\text{ odd}}\\binom{n}{k}$, these read $E+O = 2^n$ and $E-O = 0$, so $E = O = 2^{n-1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "binomial theorem",
+      "Pascal's triangle",
+      "inclusion-exclusion",
+      "parity of subset sizes",
+      "binomial transform"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "the binomial theorem",
+      "Even / Odd predicates"
+    ]
+  },
+  {
+    "id": "anchor-theorem",
+    "proofId": "combinations-formula-oq-05",
+    "range": { "startLine": 43, "endLine": 49 },
+    "type": "theorem",
+    "title": "Anchor: Alternating Sum Vanishes",
+    "content": "alternating_sum_choose_eq_zero restates Mathlib's Int.alternating_sum_range_choose_of_ne: for n ≥ 1, ∑_{k∈range(n+1)} (-1)^k · C(n,k) = 0 over ℤ. Mathlib proves this by recognizing the sum as the coefficient extraction from ((-1)+1)^n = 0^n = 0. It serves as the starting point for the parity split.",
+    "mathContext": "$\\sum_{k=0}^{n} (-1)^k \\binom{n}{k} = (1 + (-1))^n = 0^n = 0$ for $n \\ge 1$. The case $n = 0$ gives $0^0 = 1$, which is why the vanishing requires $n \\ne 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Int.alternating_sum_range_choose",
+      "binomial theorem at x = -1"
+    ],
+    "prerequisites": [
+      "alternating sums over Finset.range"
+    ]
+  },
+  {
+    "id": "even-odd-split-theorem",
+    "proofId": "combinations-formula-oq-05",
+    "range": { "startLine": 51, "endLine": 84 },
+    "type": "theorem",
+    "title": "Even/Odd Split",
+    "content": "sum_even_choose_eq_sum_odd_choose proves ∑_{k even} C(n,k) = ∑_{k odd} C(n,k) for n ≥ 1. The proof partitions the alternating sum over the parity of k using Finset.sum_filter_add_sum_filter_not. On the even part (-1)^k = 1 (Even.neg_one_pow), giving ∑_{k even} C(n,k); on the odd part (-1)^k = -1 (Odd.neg_one_pow), giving -∑_{k odd} C(n,k). Since the alternating sum is 0, the two parity sums are equal.",
+    "mathContext": "Splitting $\\sum_k (-1)^k\\binom{n}{k}$ by parity yields $\\sum_{k\\text{ even}}\\binom{n}{k} - \\sum_{k\\text{ odd}}\\binom{n}{k} = E - O = 0$, hence $E = O$. The sign of each term is determined entirely by the parity of $k$ via $(-1)^k$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_filter_add_sum_filter_not",
+      "Even.neg_one_pow",
+      "Odd.neg_one_pow",
+      "Finset.sum_neg_distrib",
+      "parity filtering of sums"
+    ],
+    "prerequisites": [
+      "filtering finite sums by a predicate",
+      "evaluation of (-1)^k by parity"
+    ]
+  },
+  {
+    "id": "each-half-theorem",
+    "proofId": "combinations-formula-oq-05",
+    "range": { "startLine": 86, "endLine": 114 },
+    "type": "theorem",
+    "title": "Each Half Equals 2^{n-1}",
+    "content": "sum_choose_int casts the total row sum to ℤ: ∑ C(n,k) = 2^n (from Nat.sum_range_choose). sum_even_choose then combines the even/odd equality E = O with the total E + O = 2^n and the identity 2^n = 2·2^{n-1} (for n ≥ 1) to conclude ∑_{k even} C(n,k) = 2^{n-1}. A worked example confirms the even part of row 4 sums to 8 = 2^3.",
+    "mathContext": "From $E = O$ and $E + O = 2^n$ we get $2E = 2^n = 2 \\cdot 2^{n-1}$, so $E = 2^{n-1}$ (and likewise $O = 2^{n-1}$). The exponent arithmetic $2^n = 2\\cdot 2^{n-1}$ for $n \\ge 1$ is handled by omega. For $n=4$: even terms $\\binom{4}{0}+\\binom{4}{2}+\\binom{4}{4} = 1+6+1 = 8 = 2^3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.sum_range_choose",
+      "total row sum 2^n",
+      "pow_succ",
+      "cancellation 2E = 2^n"
+    ],
+    "prerequisites": [
+      "total row sum ∑ C(n,k) = 2^n",
+      "casting Nat sums to ℤ"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-05/meta.json
+++ b/src/data/proofs/combinations-formula-oq-05/meta.json
@@ -1,0 +1,105 @@
+{
+  "id": "combinations-formula-oq-05",
+  "title": "Alternating Row Sum of Pascal's Triangle and the Even/Odd Split",
+  "slug": "combinations-formula-oq-05",
+  "description": "Formalizes that the alternating sum of the n-th row of Pascal's triangle vanishes for n ≥ 1, and develops its combinatorial meaning: combined with the total row sum 2^n, it shows the even-indexed and odd-indexed binomial coefficients have equal sums, each exactly 2^{n-1}. Equivalently, every nonempty finite set has as many even-sized as odd-sized subsets.",
+  "meta": {
+    "author": "Lean Genius researcher-10",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ05.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 114,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. All identities are fully machine-checked for every n ≥ 1. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms).",
+    "tags": [
+      "combinatorics",
+      "pascals-triangle",
+      "binomial-coefficients",
+      "alternating-sum",
+      "parity",
+      "finset-sums"
+    ],
+    "dateAdded": "2026-06-19",
+    "originalContributions": [
+      "alternating_sum_choose_eq_zero: anchor restating Mathlib's Int.alternating_sum_range_choose_of_ne for n ≥ 1",
+      "sum_even_choose_eq_sum_odd_choose: the even/odd split ∑_{k even} C(n,k) = ∑_{k odd} C(n,k), proved by parity-filtering the alternating sum and evaluating (-1)^k via Even.neg_one_pow / Odd.neg_one_pow",
+      "sum_even_choose: each parity class sums to exactly 2^{n-1}, combining the even/odd split with the total row sum Nat.sum_range_choose (= 2^n)",
+      "Worked verification (row 4): C(4,0)+C(4,2)+C(4,4) = 1+6+1 = 8 = 2^3"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ05.lean",
+    "namespace": "CombinationsFormulaOQ05",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 114,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The two fundamental identities of a row of Pascal's triangle — the total sum ∑ C(n,k) = 2^n and the alternating sum ∑ (-1)^k C(n,k) = 0 — both follow from the binomial theorem applied at x = 1 and x = -1. Their combination is the elementary fact, known since the earliest combinatorics, that a nonempty finite set has equally many subsets of even and of odd cardinality. It is the prototype of inclusion–exclusion cancellation and of the binomial transform's behaviour under sign alternation.",
+    "problemStatement": "Open Question OQ-05: Formalize that for n ≥ 1 the alternating sum ∑_{k=0}^{n} (-1)^k C(n,k) is 0 (Mathlib's Int.alternating_sum_range_choose). Develop the combinatorial content: show the even-indexed and odd-indexed binomial coefficients of row n have equal sums, each equal to 2^{n-1}.",
+    "proofStrategy": "Start from Mathlib's Int.alternating_sum_range_choose_of_ne (the alternating sum is 0 for n ≥ 1). Split the index range range(n+1) by parity using Finset.sum_filter_add_sum_filter_not. On the even part (-1)^k = 1 (Even.neg_one_pow), so it contributes ∑_{k even} C(n,k); on the odd part (-1)^k = -1 (Odd.neg_one_pow), contributing -∑_{k odd} C(n,k). The vanishing alternating sum therefore gives ∑_{k even} C(n,k) = ∑_{k odd} C(n,k). Adding the two halves recovers the total row sum ∑ C(n,k) = 2^n (Nat.sum_range_choose, cast to ℤ), so 2·∑_{k even} C(n,k) = 2^n = 2·2^{n-1}, whence each half is 2^{n-1}.",
+    "keyInsights": [
+      "The alternating sum is exactly the difference E − O of the even-index and odd-index partial sums; its vanishing is precisely the statement E = O.",
+      "The total sum 2^n is E + O; combined with E = O it forces E = O = 2^{n-1} — two classical identities pin down both partial sums.",
+      "Parity filtering (Finset.sum_filter_add_sum_filter_not with predicate Even) plus the sign evaluations Even.neg_one_pow and Odd.neg_one_pow is all the machinery needed; no generating functions are required.",
+      "The n ≥ 1 hypothesis enters only through 2^n = 2·2^{n-1} (handled by omega on the exponent) and the alternating sum's case split at n = 0."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Header stating OQ-05: the alternating row sum vanishes, and its combinatorial content as the even/odd subset-count equality. Explains the relationship to Mathlib's alternating sum lemma and the total row sum."
+    },
+    {
+      "id": "anchor",
+      "title": "Anchor: Alternating Sum Vanishes",
+      "startLine": 43,
+      "endLine": 49,
+      "summary": "alternating_sum_choose_eq_zero: restates Mathlib's Int.alternating_sum_range_choose_of_ne, ∑ (-1)^k C(n,k) = 0 for n ≥ 1, as the starting point."
+    },
+    {
+      "id": "even-odd-split",
+      "title": "Even/Odd Split",
+      "startLine": 51,
+      "endLine": 84,
+      "summary": "sum_even_choose_eq_sum_odd_choose: ∑_{k even} C(n,k) = ∑_{k odd} C(n,k). Splits the alternating sum by parity via Finset.sum_filter_add_sum_filter_not, evaluating (-1)^k = +1 on even (Even.neg_one_pow) and -1 on odd (Odd.neg_one_pow) indices."
+    },
+    {
+      "id": "each-half",
+      "title": "Each Half Equals 2^{n-1}",
+      "startLine": 86,
+      "endLine": 110,
+      "summary": "sum_choose_int casts the total row sum to ℤ (= 2^n). sum_even_choose: combines E = O with E + O = 2^n and 2^n = 2·2^{n-1} to conclude each parity class sums to 2^{n-1}."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verification",
+      "startLine": 112,
+      "endLine": 114,
+      "summary": "example: the even part of row 4 sums to C(4,0)+C(4,2)+C(4,4) = 1+6+1 = 8 = 2^3."
+    }
+  ],
+  "conclusion": {
+    "summary": "4 theorems, 0 sorries, 0 axioms. The alternating row sum identity ∑ (-1)^k C(n,k) = 0 is formalized together with its combinatorial content: for n ≥ 1 the even-indexed and odd-indexed binomial coefficients have equal sums, each exactly 2^{n-1}.",
+    "implications": "This converts a one-line Mathlib corollary into the full classical statement that a nonempty finite set has equally many even-sized and odd-sized subsets. The parity-filtering technique (sum_filter_add_sum_filter_not together with the sign evaluations of (-1)^k) is reusable for any signed binomial identity one wishes to resolve into its even and odd parts.",
+    "openQuestions": [
+      "Can the partial alternating sums ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j) be formalized, refining the full cancellation into a telescoping identity?",
+      "Does the analogous three-way (or m-way) split by residue of k modulo 3 (or m), evaluated via roots of unity, admit a clean formalization building on this parity case?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-02",
+      "relationship": "ancestor — the core combinations formula entry providing binomial coefficient context"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Takes Mathlib's one-line alternating-sum corollary and develops its **combinatorial content**: for `n ≥ 1`, the even-indexed and odd-indexed binomial coefficients of row `n` have equal sums, each exactly `2^{n-1}`. Equivalently, a nonempty finite set has equally many even-sized and odd-sized subsets.

- `alternating_sum_choose_eq_zero` — anchor: `∑ (-1)^k C(n,k) = 0` (`n ≥ 1`)
- `sum_even_choose_eq_sum_odd_choose` — `∑_{k even} C(n,k) = ∑_{k odd} C(n,k)`
- `sum_even_choose` — each half equals `2^{n-1}`

## Proof technique

Partition the alternating sum by parity via `Finset.sum_filter_add_sum_filter_not`; `(-1)^k` evaluates to `+1` on even indices (`Even.neg_one_pow`) and `-1` on odd (`Odd.neg_one_pow`), so the vanishing alternating sum gives `E = O`. Adding the halves recovers the total row sum `2^n` (`Nat.sum_range_choose`, cast to ℤ), so `2E = 2^n = 2·2^{n-1}` and `E = 2^{n-1}`. Worked example: even part of row 4 = `1+6+1 = 8 = 2^3`.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` reports only `propext, Classical.choice, Quot.sound`.
- Compiled with `lake env lean Proofs/CombinationsFormulaOQ05.lean` (clean).
- `E = O = 2^{n-1}` numerically cross-checked for n = 1..8.
- Gallery `meta.json` + `annotations.json` added; annotations build validates with no errors for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)