### PR TITLE
research(area-of-circle-oq-07-oq-05): second moment ∫ x²e^{-x²} = √π/2 (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -137,6 +137,7 @@ import Proofs.AreaOfCircleOQ05OQ01
 import Proofs.AreaOfCircleOQ05OQ01Aristotle
 import Proofs.AreaOfCircleOQ05OQ02
 import Proofs.AreaOfCircleOQ05OQ04
+import Proofs.AreaOfCircleOQ07OQ05
 import Proofs.ArithmeticSeries
 import Proofs.ArithmeticSeriesOQ00
 import Proofs.ArithmeticSeriesOQ00OQ01

--- a/proofs/Proofs/AreaOfCircleOQ07OQ05.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ05.lean
@@ -1,0 +1,118 @@
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Analysis.SpecialFunctions.Gaussian.PoissonSummation
+import Mathlib.Tactic
+
+/-
+# The Second Moment of the Gaussian  (area-of-circle-oq-07-oq-05)
+
+## Open Question (area-of-circle-oq-07-oq-05)
+"What is the value of the *second moment* of the Gaussian weight, i.e. the
+integral of `x²` against `e^{-x²}` over the whole real line?"
+
+$$ \int_{-\infty}^{\infty} x^2\, e^{-x^2}\, dx = \tfrac{\sqrt{\pi}}{2}. $$
+
+## Answer: it is exactly half of the zeroth moment `√π`.
+
+The parent entry `area-of-circle-oq-07` evaluates the **zeroth moment**
+`∫_{-∞}^{∞} e^{-x²} dx = √π` (Mathlib's `integral_gaussian`).  The siblings
+oq-01 … oq-04 study the complex parameter, the half-line, and the squared
+value.  This entry adds the **first nontrivial moment**: weighting the Gaussian
+by `x²`.
+
+The value `√π/2` is obtained by **integration by parts on the whole line**
+(`MeasureTheory.integral_mul_deriv_eq_deriv_mul`).  Writing the integrand as
+`x · (x e^{-x²})` and noting that `x e^{-x²}` is the derivative of
+`-½ e^{-x²}`, the boundary term `x · (-½ e^{-x²})` vanishes at `±∞` (Gaussian
+decay beats the linear factor, `tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact`),
+leaving
+
+  `∫ x² e^{-x²} = -∫ 1 · (-½ e^{-x²}) = ½ ∫ e^{-x²} = ½ · √π = √π/2`.
+
+Equivalently this is `½·Γ(3/2)·2 = √π/2`, the Gamma-function shadow of the
+second moment.  No new axioms: every step is a routine consequence of existing
+Mathlib results (the parent value `integral_gaussian`, the IBP lemma, and the
+Gaussian-decay tendsto).
+-/
+
+open Real MeasureTheory Filter Topology Set
+
+namespace AreaOfCircleOQ07OQ05
+
+/-- **Gaussian decay of the boundary factor.** The function `x ↦ x e^{-x²}`
+tends to `0` at both ends of the real line, because the Gaussian factor decays
+faster than any power. This is the boundary term that vanishes in the
+integration-by-parts computation of the second moment. -/
+theorem tendsto_mul_gaussian_cocompact :
+    Tendsto (fun x : ℝ => x * Real.exp (-x ^ 2)) (cocompact ℝ) (𝓝 0) := by
+  have h := tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact (a := 1) one_pos 1
+  rw [tendsto_zero_iff_norm_tendsto_zero]
+  refine h.congr (fun x => ?_)
+  rw [Real.rpow_one, norm_mul, Real.norm_eq_abs, Real.norm_eq_abs,
+    abs_of_pos (Real.exp_pos _), neg_one_mul]
+
+/-- **The second moment of the standard Gaussian.**
+`∫_{-∞}^{∞} x² e^{-x²} dx = √π / 2`, obtained by integration by parts on the
+whole real line. -/
+theorem gaussian_second_moment :
+    ∫ x : ℝ, x ^ 2 * Real.exp (-x ^ 2) = Real.sqrt Real.pi / 2 := by
+  -- Integration by parts with `u = x`, `v = -½ e^{-x²}`.
+  -- `u' = 1`, `v' = x e^{-x²}`, so `u · v' = x²e^{-x²}` and `u' · v = -½ e^{-x²}`.
+  have hu : ∀ x : ℝ, HasDerivAt (fun y : ℝ => y) (1 : ℝ) x := fun x => by
+    simpa using hasDerivAt_id x
+  have hv : ∀ x : ℝ,
+      HasDerivAt (fun y : ℝ => -(2 : ℝ)⁻¹ * Real.exp (-y ^ 2))
+        (x * Real.exp (-x ^ 2)) x := by
+    intro x
+    have hsq : HasDerivAt (fun y : ℝ => -y ^ 2) (-(2 * x)) x := by
+      simpa using (hasDerivAt_pow 2 x).neg
+    have hexp := hsq.exp
+    have hfin := hexp.const_mul (-(2 : ℝ)⁻¹)
+    convert hfin using 1
+    ring
+  -- Integrability of the two integrands.
+  have huv' : Integrable (fun x : ℝ => x * (x * Real.exp (-x ^ 2))) := by
+    have h := integrable_rpow_mul_exp_neg_mul_sq (b := 1) one_pos (s := (2 : ℝ))
+      (by norm_num)
+    refine h.congr (Filter.Eventually.of_forall (fun x => ?_))
+    simp only [neg_one_mul]
+    rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num, Real.rpow_natCast]
+    ring
+  have hu'v : Integrable (fun x : ℝ => (1 : ℝ) * (-(2 : ℝ)⁻¹ * Real.exp (-x ^ 2))) := by
+    have h := (integrable_exp_neg_mul_sq (b := 1) one_pos).const_mul (-(2 : ℝ)⁻¹)
+    refine h.congr (Filter.Eventually.of_forall (fun x => ?_))
+    simp only [neg_one_mul, one_mul]
+  -- Boundary terms vanish at ±∞.
+  have hbot : Tendsto (fun x : ℝ => x * (-(2 : ℝ)⁻¹ * Real.exp (-x ^ 2)))
+      atBot (𝓝 0) := by
+    have hb : atBot ≤ cocompact ℝ := by rw [cocompact_eq_atBot_atTop]; exact le_sup_left
+    have h := (tendsto_mul_gaussian_cocompact.mono_left hb).const_mul (-(2 : ℝ)⁻¹)
+    rw [mul_zero] at h
+    refine Filter.Tendsto.congr (fun x => ?_) h
+    ring
+  have htop : Tendsto (fun x : ℝ => x * (-(2 : ℝ)⁻¹ * Real.exp (-x ^ 2)))
+      atTop (𝓝 0) := by
+    have ht : atTop ≤ cocompact ℝ := by rw [cocompact_eq_atBot_atTop]; exact le_sup_right
+    have h := (tendsto_mul_gaussian_cocompact.mono_left ht).const_mul (-(2 : ℝ)⁻¹)
+    rw [mul_zero] at h
+    refine Filter.Tendsto.congr (fun x => ?_) h
+    ring
+  -- Apply integration by parts on (-∞, ∞).
+  have key := integral_mul_deriv_eq_deriv_mul (a' := (0 : ℝ)) (b' := (0 : ℝ))
+    hu hv huv' hu'v hbot htop
+  -- Evaluate the remaining integral `∫ 1 · (-½ e^{-x²}) = -½ √π`.
+  have hint : ∫ x : ℝ, (1 : ℝ) * (-(2 : ℝ)⁻¹ * Real.exp (-x ^ 2))
+      = -(2 : ℝ)⁻¹ * Real.sqrt Real.pi := by
+    simp only [one_mul]
+    rw [integral_const_mul]
+    have hg : ∫ x : ℝ, Real.exp (-x ^ 2) = Real.sqrt Real.pi := by
+      have := integral_gaussian 1
+      simpa [neg_one_mul, div_one] using this
+    rw [hg]
+  -- Assemble via integration by parts.
+  calc ∫ x : ℝ, x ^ 2 * Real.exp (-x ^ 2)
+      = ∫ x : ℝ, x * (x * Real.exp (-x ^ 2)) := by
+        apply integral_congr_ae; filter_upwards with x; ring
+    _ = (0 : ℝ) - 0 - ∫ x : ℝ, (1 : ℝ) * (-(2 : ℝ)⁻¹ * Real.exp (-x ^ 2)) := key
+    _ = Real.sqrt Real.pi / 2 := by rw [hint]; ring
+
+end AreaOfCircleOQ07OQ05

--- a/src/data/proofs/area-of-circle-oq-07-oq-05/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05/annotations.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "ann-aoc07oq05-context",
+    "proofId": "area-of-circle-oq-07-oq-05",
+    "range": { "startLine": 4, "endLine": 52 },
+    "type": "concept",
+    "title": "The Second Moment of the Gaussian",
+    "content": "The parent `area-of-circle-oq-07` evaluates the zeroth moment of the Gaussian weight, `∫_ℝ e^{-x²} dx = √π`. This entry adds the first nontrivial weighted moment: `∫_ℝ x² e^{-x²} dx = √π/2`. Where the siblings oq-01…oq-04 vary the parameter, the domain (half-line), or square the value — all still the zeroth moment — here the integrand carries the genuine polynomial weight `x²`. The value √π/2 is exactly half the parent's √π, a coincidence explained by integration by parts: the x² weight is `traded` for a derivative that recovers the bare Gaussian.",
+    "mathContext": "The even moments of the standard Gaussian are $\\int_{\\mathbb R} x^{2n} e^{-x^2}\\,dx = (2n-1)!!\\,\\sqrt\\pi/2^n$; for $n=1$ this is $\\sqrt\\pi/2$. Equivalently it is $\\tfrac12\\Gamma(3/2)\\cdot 2 = \\sqrt\\pi/2$, the variance integral of the (unnormalized) Gaussian.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gaussian moments",
+      "integration by parts",
+      "Gamma special value Γ(3/2)",
+      "even-moment double factorial"
+    ],
+    "prerequisites": [
+      "Lebesgue integral over ℝ",
+      "parent area-of-circle-oq-07 (∫ e^{-x²} = √π)"
+    ]
+  },
+  {
+    "id": "ann-aoc07oq05-decay",
+    "proofId": "area-of-circle-oq-07-oq-05",
+    "range": { "startLine": 54, "endLine": 67 },
+    "type": "technique",
+    "title": "The Boundary Term Vanishes: Gaussian Decay",
+    "content": "`tendsto_mul_gaussian_cocompact` proves `x e^{-x²} → 0` at both ends of the real line — the boundary product of the integration by parts. It is repackaged from Mathlib's `tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact` (with exponent s = 1, rate a = 1), which gives `|x|^1 e^{-x²} → 0` along the cocompact filter. Stripping the absolute value uses `tendsto_zero_iff_norm_tendsto_zero` together with `‖x e^{-x²}‖ = |x| e^{-x²}` (the Gaussian factor is positive). The single cocompact statement is later split into the `atBot` and `atTop` limits the IBP lemma requires, via `cocompact_eq_atBot_atTop` and `le_sup_left/right`.",
+    "mathContext": "On $\\mathbb R$ the cocompact filter equals $\\text{atBot} \\sqcup \\text{atTop}$, so a single cocompact limit packages both one-sided boundary terms. Gaussian decay $e^{-x^2}$ dominates every polynomial, so $x^k e^{-x^2}\\to 0$ at $\\pm\\infty$ for all $k$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "cocompact filter",
+      "tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact",
+      "tendsto_zero_iff_norm_tendsto_zero",
+      "cocompact_eq_atBot_atTop"
+    ],
+    "prerequisites": [
+      "filters atBot/atTop and cocompact on ℝ",
+      "Gaussian decay of polynomial weights"
+    ]
+  },
+  {
+    "id": "ann-aoc07oq05-ibp",
+    "proofId": "area-of-circle-oq-07-oq-05",
+    "range": { "startLine": 69, "endLine": 118 },
+    "type": "technique",
+    "title": "Integration by Parts on the Whole Line",
+    "content": "`gaussian_second_moment` applies `MeasureTheory.integral_mul_deriv_eq_deriv_mul` with `u = x` (derivative 1) and `v = -½ e^{-x²}` (derivative `v' = x e^{-x²}`, built from `hasDerivAt_pow`, `HasDerivAt.exp`, and `HasDerivAt.const_mul`). The integrand factors as `u·v' = x·(x e^{-x²}) = x² e^{-x²}`, so the formula `∫ u v' = b' - a' - ∫ u' v` becomes `∫ x² e^{-x²} = 0 - 0 - ∫ 1·(-½ e^{-x²}) = ½∫ e^{-x²} = ½√π`. The two integrability side-conditions use `integrable_rpow_mul_exp_neg_mul_sq` (for x² e^{-x²}, identifying `x^(2:ℝ)` with `x²` via `Real.rpow_natCast`) and `integrable_exp_neg_mul_sq` (for the bare Gaussian); the boundary limits come from `tendsto_mul_gaussian_cocompact`. The final `∫ e^{-x²} = √π` is the parent value `integral_gaussian 1`.",
+    "mathContext": "Integration by parts $\\int u\\,v' = [uv] - \\int u'\\,v$ lowers the polynomial weight by trading $x^2$ against the antiderivative of $x e^{-x^2}$. The same step iterated gives the double-factorial recursion for all even moments. Here a single application suffices because $u' = 1$ leaves only the zeroth moment behind.",
+    "significance": "key",
+    "relatedConcepts": [
+      "integral_mul_deriv_eq_deriv_mul",
+      "HasDerivAt.exp",
+      "integrable_rpow_mul_exp_neg_mul_sq",
+      "integral_gaussian"
+    ],
+    "prerequisites": [
+      "integration by parts on (-∞, ∞)",
+      "HasDerivAt calculus for compositions",
+      "integrability of Gaussian-weighted polynomials"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "area-of-circle-oq-07-oq-05",
+  "slug": "area-of-circle-oq-07-oq-05",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.PoissonSummation",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory",
+      "Filter",
+      "Topology",
+      "Set"
+    ],
+    "namespace": "AreaOfCircleOQ07OQ05",
+    "lineCount": 118,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ05.lean",
+    "sorries": 0
+  },
+  "title": "The Second Moment of the Gaussian ∫ x² e^{-x²} = √π/2",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ05.lean",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "integration-by-parts",
+      "special-functions",
+      "measure-theory",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 118,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "gaussian_second_moment: ∫_ℝ x² e^{-x²} dx = √π/2 — the first nontrivial moment of the standard Gaussian weight, established by integration by parts on the whole real line (MeasureTheory.integral_mul_deriv_eq_deriv_mul). Writing x²e^{-x²} = x·(x e^{-x²}) and recognizing x e^{-x²} = d/dx(-½ e^{-x²}), the boundary term collapses and the second moment reduces to ½ of the parent's zeroth moment √π. This is the Γ(3/2) = √π/2 moment realized directly as a real Lebesgue integral, distinct from the sibling entries which all study the zeroth moment (parent value √π, complex parameter, half-line, squared value).",
+      "tendsto_mul_gaussian_cocompact: x e^{-x²} → 0 at both ends of the real line, the Gaussian-decay fact that makes the integration-by-parts boundary term vanish. Packaged from Mathlib's tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact by stripping the absolute value through tendsto_zero_iff_norm_tendsto_zero, then split across atBot/atTop via cocompact_eq_atBot_atTop."
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ (MeasureTheory)",
+      "Integration by parts on (-∞, ∞): MeasureTheory.integral_mul_deriv_eq_deriv_mul",
+      "The parent zeroth moment: integral_gaussian (∫ e^{-b x²} = √(π/b))",
+      "Gaussian decay of polynomial weights: tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact",
+      "Integrability of x^s e^{-b x²}: integrable_rpow_mul_exp_neg_mul_sq",
+      "Parent: area-of-circle-oq-07 (the real Gaussian ∫ e^{-x²} = √π)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_mul_deriv_eq_deriv_mul",
+        "description": "Integration by parts on (-∞, ∞): ∫ u v' = b' - a' - ∫ u' v, given the derivatives, integrability of u·v' and u'·v, and convergence of the boundary product u·v at ±∞. Applied with u = x, v = -½ e^{-x²}.",
+        "module": "Mathlib.MeasureTheory.Integral.IntegralEqImproper"
+      },
+      {
+        "theorem": "integral_gaussian",
+        "description": "∫ x : ℝ, e^{-b x²} = √(π/b). At b = 1 this is the parent value √π, the zeroth moment that the second moment reduces to (after the boundary term vanishes).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact",
+        "description": "|x|^s e^{-a x²} → 0 along the cocompact filter for a > 0 — Gaussian decay beats any power. With s = 1, a = 1 this gives x e^{-x²} → 0 at ±∞, the vanishing boundary term.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.PoissonSummation"
+      },
+      {
+        "theorem": "integrable_rpow_mul_exp_neg_mul_sq",
+        "description": "x^s e^{-b x²} is integrable over ℝ for b > 0 and s > -1. At s = 2 this supplies integrability of the integrand x² e^{-x²} (via Real.rpow_natCast to identify the real power x^(2:ℝ) with the natural power x²).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-05-oq-01",
+      "question": "Evaluate the general even moment ∫_ℝ x^{2n} e^{-x²} dx = (2n-1)!!·√π / 2^n by induction on n, with the second moment (n = 1) as the base case, exhibiting the double-factorial recursion that integration by parts generates.",
+      "significance": "medium"
+    },
+    {
+      "id": "area-of-circle-oq-07-oq-05-oq-02",
+      "question": "Recover √π/2 as ½·Γ(3/2) directly through the substitution u = x² and Mathlib's Real.Gamma, identifying the second moment with a Gamma special value rather than computing it by parts.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "extends",
+      "description": "Parent. The zeroth moment ∫_ℝ e^{-x²} = √π. This entry computes the second moment ∫_ℝ x² e^{-x²} = √π/2, which integration by parts reduces to exactly half of the parent value."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-02",
+      "relationship": "related",
+      "description": "Sibling. The half-line zeroth moment ∫_{Ioi 0} e^{-x²} = √π/2. Numerically equal to this entry's full-line second moment, but for an entirely different reason (even symmetry vs. the x² weight)."
+    },
+    {
+      "targetId": "gaussian-integral",
+      "relationship": "related",
+      "description": "The Gaussian integral family. This entry adds the first weighted moment ∫ x² e^{-x²} to the gallery's collection of Gaussian evaluations."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_gaussian (∫ e^{-b x²} = √(π/b)) and the integrability lemma integrable_rpow_mul_exp_neg_mul_sq used here."
+    },
+    {
+      "title": "Fourier Analysis",
+      "author": "Elias M. Stein and Rami Shakarchi",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "description": "Classical treatment of Gaussian moments ∫ x^{2n} e^{-x²} and the integration-by-parts recursion that this entry's second moment instantiates at n = 1."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The second moment of the standard Gaussian weight is ∫_ℝ x² e^{-x²} dx = √π/2. The proof is integration by parts on the whole real line (MeasureTheory.integral_mul_deriv_eq_deriv_mul): with u = x and v = -½ e^{-x²}, the integrand factors as u·v' = x·(x e^{-x²}) = x² e^{-x²}, the boundary product u·v = -½ x e^{-x²} tends to 0 at ±∞ (Gaussian decay, tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact), and the surviving term is -∫ u'·v = ½ ∫ e^{-x²} = ½·√π (the parent value, integral_gaussian). 118 lines, 2 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The second moment √π/2 is the n = 1 case of the even-moment family ∫ x^{2n} e^{-x²} = (2n-1)!!·√π/2^n, equivalently ½·Γ(3/2)·2 — the variance integral that normalizes the standard Gaussian. Establishing it as a genuine real Lebesgue integral (rather than a Gamma special value) gives a self-contained base case for the double-factorial recursion and a template for higher moments, where each application of integration by parts lowers the power by two.",
+    "openQuestions": [
+      "Prove the general even moment ∫ x^{2n} e^{-x²} = (2n-1)!!·√π/2^n by induction, with this second moment as the base case.",
+      "Recover √π/2 as ½·Γ(3/2) via u = x² and Real.Gamma."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds **area-of-circle-oq-07-oq-05**: the second moment of the standard Gaussian weight,
$$\int_{-\infty}^{\infty} x^2 e^{-x^2}\,dx = \frac{\sqrt{\pi}}{2}.$$

The parent `area-of-circle-oq-07` and siblings oq-01…oq-04 all study the **zeroth** moment
(value √π, complex parameter, half-line, squared value). This entry adds the first nontrivial
**weighted** moment.

## Proof

Integration by parts on the whole real line (`MeasureTheory.integral_mul_deriv_eq_deriv_mul`):
- `u = x`, `v = -½ e^{-x²}`, so `v' = x e^{-x²}` and `u·v' = x² e^{-x²}`.
- Boundary term `u·v = -½ x e^{-x²} → 0` at ±∞ (Gaussian decay,
  `tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact`, split over `atBot`/`atTop`).
- Survivor: `-∫ u'·v = ½ ∫ e^{-x²} = ½·√π` (parent value, `integral_gaussian`).

Equivalently this is `½·Γ(3/2)·2 = √π/2`, the variance integral of the Gaussian, realized
directly as a real Lebesgue integral and forming the base case `n = 1` of the even-moment
family `∫ x^{2n} e^{-x²} = (2n-1)!!·√π/2^n`.

## Verification

- Compiles clean under `lake env lean Proofs/AreaOfCircleOQ07OQ05.lean`.
- `#print axioms`: `[propext, Classical.choice, Quot.sound]` — **0 axioms**, 0 sorries.
- 2 theorems, 0 definitions, 118 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)