### PR TITLE
research(infinitude-primes-oq-05): Goldbach's proof of infinitude of primes via Fermat numbers (verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2586,6 +2586,7 @@ import Proofs.InfinitudePrimes4k3OQ01Klein2
 import Proofs.InfinitudePrimes4k3OQ01Q12Q24
 import Proofs.InfinitudePrimes4k3OQ01Tower
 import Proofs.InfinitudePrimes4k3OQ03
+import Proofs.InfinitudePrimesOQ05
 import Proofs.IntermediateValueTheorem
 import Proofs.IntermediateValueTheoremOQ01
 import Proofs.IntermediateValueTheoremOQ02

--- a/proofs/Proofs/InfinitudePrimesOQ05.lean
+++ b/proofs/Proofs/InfinitudePrimesOQ05.lean
@@ -1,0 +1,124 @@
+import Mathlib
+
+/-
+# Infinitude of Primes OQ-05: Goldbach's Proof via Fermat Numbers
+
+## Research Problem: infinitude-primes-oq-05
+
+Goldbach's proof (from a 1730 letter to Euler) that there are infinitely many primes,
+*without* Euclid's N! + 1 construction. The Fermat numbers
+
+  Fₙ = 2^(2ⁿ) + 1   (F₀ = 3, F₁ = 5, F₂ = 17, F₃ = 257, …)
+
+are **pairwise coprime**: any two distinct Fermat numbers share no common factor.
+Hence each Fₙ contributes a prime factor that no other Fₘ can share, so the assignment
+n ↦ (smallest prime factor of Fₙ) is an injection from ℕ into the set of primes.
+An injection from an infinite set forces the codomain to be infinite.
+
+## Mathematical Content
+
+The crux is `Nat.coprime_fermatNumber_fermatNumber` (distinct Fermat numbers are
+coprime), which Mathlib proves from the telescoping identity
+F₀·F₁·⋯·Fₙ₋₁ = Fₙ − 2. Goldbach's elegant point is that pairwise coprimality is by
+itself enough to manufacture infinitely many primes — the primes need not be exhibited,
+only counted.
+
+This file packages that lemma into the statement that the set of primes is infinite, via:
+- `fermatPrimeFactor n := (Fₙ).minFac`, a prime (since Fₙ > 1);
+- injectivity of `n ↦ fermatPrimeFactor n` (a shared minFac would divide both Fₘ and Fₙ,
+  hence divide their gcd = 1, contradicting primality);
+- `Set.infinite_of_injective_forall_mem` to conclude `{p | p.Prime}.Infinite`.
+
+## References
+- Christian Goldbach (1730): letter to Leonhard Euler
+- Aigner & Ziegler, *Proofs from THE BOOK*: "Six proofs of the infinity of primes" (Third proof)
+- Mathlib: `Nat.coprime_fermatNumber_fermatNumber`, `Nat.two_lt_fermatNumber`
+-/
+
+open Nat
+
+namespace InfinitudePrimesOQ05
+
+/-- The prime factor extracted from the n-th Fermat number Fₙ = 2^(2ⁿ) + 1:
+    its smallest prime factor. -/
+def fermatPrimeFactor (n : ℕ) : ℕ := (fermatNumber n).minFac
+
+/-! ## Part I: Each Fermat number yields a prime -/
+
+/-- Every Fermat number exceeds 1 (indeed Fₙ > 2), so it is not the unit. -/
+theorem fermatNumber_ne_one (n : ℕ) : fermatNumber n ≠ 1 :=
+  Nat.ne_of_gt (lt_trans one_lt_two (two_lt_fermatNumber n))
+
+/-- The extracted factor is genuinely prime. -/
+theorem fermatPrimeFactor_prime (n : ℕ) : (fermatPrimeFactor n).Prime :=
+  Nat.minFac_prime (fermatNumber_ne_one n)
+
+/-- The extracted factor divides its Fermat number. -/
+theorem fermatPrimeFactor_dvd (n : ℕ) : fermatPrimeFactor n ∣ fermatNumber n :=
+  Nat.minFac_dvd _
+
+/-! ## Part II: Distinct Fermat numbers give distinct primes -/
+
+/-- The map n ↦ (smallest prime factor of Fₙ) is injective.
+
+    If `fermatPrimeFactor m = fermatPrimeFactor n` with `m ≠ n`, that common value `p`
+    divides both `Fₘ` and `Fₙ`; but `Fₘ` and `Fₙ` are coprime, so `p = 1` — impossible
+    since `p` is prime. -/
+theorem fermatPrimeFactor_injective : Function.Injective fermatPrimeFactor := by
+  intro m n hmn
+  by_contra hne
+  have hp := fermatPrimeFactor_prime m
+  have hdm : fermatPrimeFactor m ∣ fermatNumber m := fermatPrimeFactor_dvd m
+  have hdn : fermatPrimeFactor m ∣ fermatNumber n := hmn ▸ fermatPrimeFactor_dvd n
+  have hcop : Nat.Coprime (fermatNumber m) (fermatNumber n) :=
+    Nat.coprime_fermatNumber_fermatNumber hne
+  have h1 : fermatPrimeFactor m = 1 := Nat.eq_one_of_dvd_coprimes hcop hdm hdn
+  exact hp.ne_one h1
+
+/-! ## Part III: Infinitely many primes (Goldbach) -/
+
+/-- **Goldbach's theorem**: there are infinitely many primes, proved via the pairwise
+    coprimality of the Fermat numbers (no Euclid construction). -/
+theorem infinite_setOf_prime : {p : ℕ | p.Prime}.Infinite :=
+  Set.infinite_of_injective_forall_mem
+    fermatPrimeFactor_injective fermatPrimeFactor_prime
+
+/-- The Fermat-number proof in fully self-contained form: an injection from ℕ into the
+    primes, exhibiting infinitely many of them. -/
+theorem exists_injection_nat_to_primes :
+    ∃ f : ℕ → ℕ, Function.Injective f ∧ ∀ n, (f n).Prime :=
+  ⟨fermatPrimeFactor, fermatPrimeFactor_injective, fermatPrimeFactor_prime⟩
+
+/-! ## Part IV: Verified small cases -/
+
+-- F₀ = 3 is prime, so its smallest prime factor is 3
+example : fermatPrimeFactor 0 = 3 := by
+  rw [fermatPrimeFactor, fermatNumber_zero]; exact Nat.Prime.minFac_eq (by norm_num)
+
+-- F₁ = 5 is prime, so its smallest prime factor is 5
+example : fermatPrimeFactor 1 = 5 := by
+  rw [fermatPrimeFactor, fermatNumber_one]; exact Nat.Prime.minFac_eq (by norm_num)
+
+-- F₂ = 17 is prime, so its smallest prime factor is 17
+example : fermatPrimeFactor 2 = 17 := by
+  rw [fermatPrimeFactor, fermatNumber_two]; exact Nat.Prime.minFac_eq (by norm_num)
+
+-- The extracted primes are pairwise distinct (direct from injectivity)
+example : fermatPrimeFactor 0 ≠ fermatPrimeFactor 1 :=
+  fermatPrimeFactor_injective.ne (by decide)
+example : fermatPrimeFactor 1 ≠ fermatPrimeFactor 2 :=
+  fermatPrimeFactor_injective.ne (by decide)
+
+/-! ## Part V: Summary -/
+
+/-- **Infinitude of Primes OQ-05 Summary** (Goldbach via Fermat numbers):
+    (1) each `fermatPrimeFactor n` is prime;
+    (2) the map is injective;
+    (3) therefore the set of primes is infinite. -/
+theorem infinitude_primes_oq05_summary :
+    (∀ n, (fermatPrimeFactor n).Prime) ∧
+    Function.Injective fermatPrimeFactor ∧
+    {p : ℕ | p.Prime}.Infinite :=
+  ⟨fermatPrimeFactor_prime, fermatPrimeFactor_injective, infinite_setOf_prime⟩
+
+end InfinitudePrimesOQ05

--- a/src/data/proofs/infinitude-primes-oq-05/meta.json
+++ b/src/data/proofs/infinitude-primes-oq-05/meta.json
@@ -1,0 +1,208 @@
+{
+  "id": "infinitude-primes-oq-05",
+  "title": "Infinitude of Primes OQ-05: Goldbach's Proof via Fermat Numbers",
+  "slug": "infinitude-primes-oq-05",
+  "description": "Goldbach's 1730 proof that there are infinitely many primes, using only the pairwise coprimality of the Fermat numbers Fₙ = 2^(2ⁿ)+1: the map n ↦ smallest prime factor of Fₙ is an injection ℕ → primes, so the primes are infinite — no Euclid construction.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InfinitudePrimesOQ05.lean",
+    "tags": [
+      "number-theory",
+      "prime-numbers",
+      "infinitude-of-primes",
+      "fermat-numbers",
+      "coprimality"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.coprime_fermatNumber_fermatNumber",
+        "description": "Distinct Fermat numbers are coprime (from the telescoping identity F₀⋯Fₙ₋₁ = Fₙ − 2)",
+        "module": "Mathlib.NumberTheory.Fermat"
+      },
+      {
+        "theorem": "Nat.two_lt_fermatNumber",
+        "description": "Every Fermat number exceeds 2, hence is ≠ 1",
+        "module": "Mathlib.NumberTheory.Fermat"
+      },
+      {
+        "theorem": "Nat.minFac_prime",
+        "description": "The smallest factor of n ≠ 1 is prime",
+        "module": "Mathlib.Data.Nat.Prime.Defs"
+      },
+      {
+        "theorem": "Nat.eq_one_of_dvd_coprimes",
+        "description": "A common divisor of two coprime numbers equals 1",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Set.infinite_of_injective_forall_mem",
+        "description": "An injection from an infinite type into a set proves the set infinite",
+        "module": "Mathlib.Data.Set.Finite.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Goldbach's Fermat-number proof of the infinitude of primes packaged as Set.Infinite {p | p.Prime}",
+      "Definition fermatPrimeFactor n = (Fₙ).minFac and proof it is always prime",
+      "Injectivity of n ↦ fermatPrimeFactor n via pairwise coprimality (a shared factor would divide gcd(Fₘ,Fₙ) = 1)",
+      "Self-contained existence of an injection ℕ → primes",
+      "Verified small cases F₀=3, F₁=5, F₂=17 and their distinct prime factors"
+    ],
+    "dateAdded": "2026-06-19",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 124,
+    "assumptions": "0 axioms, 0 sorries. Uses Mathlib's coprime_fermatNumber_fermatNumber; the injection-to-primes packaging and infinitude conclusion are original.",
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "In a 1730 letter to Leonhard Euler, Christian Goldbach gave a proof of the infinitude of primes strikingly different from Euclid's. Where Euclid forms N = p₁⋯pₖ + 1 and finds a new prime factor, Goldbach observed that the **Fermat numbers** Fₙ = 2^(2ⁿ) + 1 (3, 5, 17, 257, 65537, …) are *pairwise coprime*: no two of them share a factor. Consequently the prime factors drawn from different Fermat numbers must be different, and since there are infinitely many Fermat numbers, there are infinitely many primes. The argument is one of the six classic proofs collected in Aigner & Ziegler's *Proofs from THE BOOK*. Its charm is that it never exhibits a single 'new' prime — it merely *counts* them through an injection, an early instance of the now-routine move of proving infinitude by constructing an injection from ℕ.",
+    "problemStatement": "**Open Question**: Prove the infinitude of primes by Goldbach's method, via the pairwise coprimality of the Fermat numbers, rather than Euclid's construction.\n\n**Answer**: Each Fₙ > 1 has a smallest prime factor pₙ. If pₘ = pₙ for m ≠ n, then pₘ divides both Fₘ and Fₙ, hence divides gcd(Fₘ,Fₙ) = 1 — impossible. So n ↦ pₙ is an injection ℕ → {primes}, and {p | p.Prime} is infinite.",
+    "text": "Goldbach's proof of the infinitude of primes using the pairwise coprimality of the Fermat numbers Fₙ = 2^(2ⁿ)+1.",
+    "proofStrategy": "The proof has three movements:\n1. **Primes from Fermat numbers**: Since 2 < Fₙ (`two_lt_fermatNumber`), Fₙ ≠ 1, so its smallest factor `fermatPrimeFactor n = (Fₙ).minFac` is prime (`minFac_prime`) and divides Fₙ (`minFac_dvd`).\n2. **Distinct primes from distinct indices**: Suppose `fermatPrimeFactor m = fermatPrimeFactor n` with m ≠ n. The common value p divides both Fₘ and Fₙ; but `coprime_fermatNumber_fermatNumber` gives gcd(Fₘ,Fₙ) = 1, so `eq_one_of_dvd_coprimes` forces p = 1, contradicting primality. Hence the map is injective.\n3. **Infinitude**: `Set.infinite_of_injective_forall_mem` turns the injection ℕ → {p | p.Prime} into the conclusion that the set of primes is infinite.",
+    "keyInsights": [
+      "Goldbach's proof **counts** primes rather than constructing them: it proves infinitude by exhibiting an injection ℕ → {primes}, never naming a specific 'next' prime",
+      "The engine is **pairwise coprimality** of the Fermat numbers, which Mathlib derives from the telescoping product identity F₀F₁⋯Fₙ₋₁ = Fₙ − 2 (so any common divisor of two Fermat numbers divides 2, yet Fermat numbers are odd)",
+      "Coprimality is *exactly* what makes the smallest-prime-factor map injective: a repeated prime factor would be a common divisor of two coprime numbers, i.e. would divide 1",
+      "The proof is non-constructive in spirit but fully constructive in Lean: `fermatPrimeFactor` is a concrete computable function and the injection is explicit",
+      "This is a different infinitude proof from Euclid's N!+1 and from the Dirichlet-style arithmetic-progression results (the 4k±1 entries) — the same theorem reached through coprimality"
+    ],
+    "prerequisites": [
+      "Divisibility, gcd, and coprimality in ℕ",
+      "Smallest prime factor (minFac) and its basic properties",
+      "Injections and the notion of an infinite set"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: Goldbach's Fermat-number proof, the pairwise-coprimality engine, and references",
+      "startLine": 1,
+      "endLine": 39,
+      "mathContext": "Fₙ = 2^(2ⁿ) + 1 are pairwise coprime; each contributes a distinct prime factor ⇒ infinitely many primes."
+    },
+    {
+      "id": "definition",
+      "title": "The Fermat Prime Factor",
+      "summary": "Defines fermatPrimeFactor n = (fermatNumber n).minFac, the smallest prime factor of the n-th Fermat number",
+      "startLine": 40,
+      "endLine": 45,
+      "mathContext": "fermatPrimeFactor n = (Fₙ).minFac, a concrete computable assignment of a prime to each index n."
+    },
+    {
+      "id": "primes-from-fermat",
+      "title": "Part I: Each Fermat Number Yields a Prime",
+      "summary": "fermatNumber_ne_one (Fₙ ≠ 1), fermatPrimeFactor_prime (the factor is prime), fermatPrimeFactor_dvd (it divides Fₙ)",
+      "startLine": 46,
+      "endLine": 59,
+      "mathContext": "2 < Fₙ ⇒ Fₙ ≠ 1 ⇒ minFac Fₙ is prime and divides Fₙ."
+    },
+    {
+      "id": "distinct-primes",
+      "title": "Part II: Distinct Fermat Numbers Give Distinct Primes",
+      "summary": "fermatPrimeFactor_injective: a shared prime factor of Fₘ, Fₙ (m ≠ n) would divide gcd(Fₘ,Fₙ) = 1, contradicting primality",
+      "startLine": 60,
+      "endLine": 77,
+      "mathContext": "p = pₘ = pₙ ⇒ p ∣ Fₘ and p ∣ Fₙ ⇒ p ∣ gcd(Fₘ,Fₙ) = 1 ⇒ p = 1, contradiction. So m ↦ pₘ is injective."
+    },
+    {
+      "id": "infinitude",
+      "title": "Part III: Infinitely Many Primes (Goldbach)",
+      "summary": "infinite_setOf_prime: the injection ℕ → {primes} gives {p | p.Prime}.Infinite; plus exists_injection_nat_to_primes",
+      "startLine": 78,
+      "endLine": 91,
+      "mathContext": "An injection from the infinite type ℕ into {p | p.Prime} proves the set of primes infinite."
+    },
+    {
+      "id": "examples",
+      "title": "Part IV: Verified Small Cases",
+      "summary": "F₀=3, F₁=5, F₂=17 are prime so equal their own smallest prime factor; the first three extracted primes are pairwise distinct",
+      "startLine": 92,
+      "endLine": 111,
+      "mathContext": "fermatPrimeFactor 0 = 3, = 5, = 17 (each Fₙ prime), and distinctness follows from injectivity."
+    },
+    {
+      "id": "summary",
+      "title": "Part V: Summary Theorem",
+      "summary": "infinitude_primes_oq05_summary bundles primality, injectivity, and the infinitude of the prime set",
+      "startLine": 112,
+      "endLine": 124,
+      "mathContext": "(1) each fermatPrimeFactor n is prime; (2) the map is injective; (3) {p | p.Prime} is infinite."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes Goldbach's proof of the infinitude of primes: the Fermat numbers Fₙ = 2^(2ⁿ)+1 are pairwise coprime, so n ↦ (smallest prime factor of Fₙ) is an injection from ℕ into the primes, forcing the set of primes to be infinite. All results are verified with 0 sorries and 0 axioms beyond Lean's foundations.",
+    "implications": "Provides a coprimality-based proof of infinitude, complementing the Euclid-style and arithmetic-progression (4k±1) entries in the gallery. The technique — proving infinitude by an explicit injection grounded in pairwise coprimality — generalizes to any sequence of pairwise-coprime integers greater than 1.",
+    "openQuestions": [
+      "Show any sequence of pairwise-coprime integers > 1 yields infinitely many primes (abstract the Fermat-number argument)",
+      "Relate the extracted Fermat prime factors to the open question of whether infinitely many Fermat numbers are prime/composite",
+      "Quantify the growth: the n-th Goldbach prime is at most Fₙ = 2^(2ⁿ)+1, a doubly-exponential bound"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "infinitude-primes",
+      "relationship": "Parent theorem: the infinitude of primes (Euclid's proof)"
+    },
+    {
+      "id": "infinitude-primes-4k1",
+      "relationship": "Sibling: infinitely many primes ≡ 1 (mod 4)"
+    },
+    {
+      "id": "infinitude-primes-4k3",
+      "relationship": "Sibling: infinitely many primes ≡ 3 (mod 4)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "InfinitudePrimesOQ05",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/InfinitudePrimesOQ05.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Christian Goldbach",
+      "title": "Letter to Leonhard Euler (Fermat-number proof of the infinitude of primes)",
+      "year": "1730",
+      "venue": "Correspondence"
+    },
+    {
+      "authors": "Martin Aigner, Günter M. Ziegler",
+      "title": "Proofs from THE BOOK — Six proofs of the infinity of primes (Third proof)",
+      "year": "2018",
+      "venue": "Springer"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "extends",
+      "description": "Reproves the infinitude of primes by Goldbach's Fermat-number method instead of Euclid's N!+1 construction."
+    },
+    {
+      "targetId": "infinitude-primes-4k1",
+      "relationship": "sibling",
+      "description": "Sibling infinitude result restricted to primes ≡ 1 (mod 4); this entry proves infinitude of all primes via coprimality."
+    },
+    {
+      "targetId": "infinitude-primes-4k3",
+      "relationship": "sibling",
+      "description": "Sibling infinitude result restricted to primes ≡ 3 (mod 4); both are special cases of the unrestricted infinitude proved here."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **infinitude-primes-oq-05**: Goldbach's 1730 proof (to Euler) that there are
infinitely many primes, using only the **pairwise coprimality of the Fermat numbers**
Fₙ = 2^(2ⁿ) + 1 — no Euclid N!+1 construction.

### Mathematical content

The Fermat numbers 3, 5, 17, 257, 65537, … are pairwise coprime
(`Nat.coprime_fermatNumber_fermatNumber`, from the telescoping identity
F₀⋯Fₙ₋₁ = Fₙ − 2). Define `fermatPrimeFactor n = (Fₙ).minFac`. Then:
- `fermatPrimeFactor_prime` — it is prime (Fₙ > 1)
- `fermatPrimeFactor_injective` — the map is injective: a shared value p would divide
  both Fₘ and Fₙ, hence divide gcd(Fₘ,Fₙ) = 1, contradicting primality
- `infinite_setOf_prime` — `Set.infinite_of_injective_forall_mem` turns the injection
  ℕ → {p | p.Prime} into the infinitude of the prime set

Goldbach's elegance: it **counts** primes via an injection rather than constructing a
"next" prime. One of the six classic proofs in *Proofs from THE BOOK*.

### Verification

- `lake env lean Proofs/InfinitudePrimesOQ05.lean` compiles cleanly (no errors/sorries/warnings).
- `#print axioms` on `infinite_setOf_prime` and the summary: `[propext, Classical.choice, Quot.sound]` — **0-axiom / verified**.
- 7 theorems, 1 definition, 0 sorries. Verified small cases F₀=3, F₁=5, F₂=17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)