### PR TITLE
Research: fermat-two-squares-oq-05 — n ≡ 3 (mod 4) is never x² + y² (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2391,6 +2391,7 @@ import Proofs.FermatDefectOneOQ04
 import Proofs.FermatTwoSquares
 import Proofs.FermatTwoSquaresOQ01
 import Proofs.FermatTwoSquaresOQ01OQ03
+import Proofs.FermatTwoSquaresOQ05
 import Proofs.FermatsLastTheorem
 import Proofs.FermatsLastTheoremOQ03
 import Proofs.FeuerbachsTheorem

--- a/proofs/Proofs/FermatTwoSquaresOQ05.lean
+++ b/proofs/Proofs/FermatTwoSquaresOQ05.lean
@@ -1,0 +1,152 @@
+/-
+  Sum-of-Two-Squares Obstruction: n ≡ 3 (mod 4) Is Never x² + y²
+  Open Question: fermat-two-squares-oq-05
+
+  Fermat's two-squares theorem (Mathlib's `Nat.Prime.sq_add_sq`) supplies the
+  SUFFICIENT direction: every prime p with p % 4 ≠ 3 is a sum of two squares.
+  This file supplies the matching NECESSARY direction — the elementary
+  congruence obstruction.
+
+  The mechanism is a "local obstruction": a single modulus (4) kills the
+  global Diophantine equation n = x² + y². Every square is ≡ 0 or 1 (mod 4),
+  so a sum of two squares is ≡ 0, 1, or 2 (mod 4) and can NEVER be ≡ 3 (mod 4).
+
+  Combining the two directions sharpens Fermat's classification to a
+  biconditional for primes:
+
+        (∃ a b, a² + b² = p)  ↔  p % 4 ≠ 3.
+
+  References:
+  - Fermat (1640): two-squares characterization for primes
+  - FermatTwoSquares.lean: parent two-squares characterization
+  - FermatTwoSquaresOQ01.lean: Lagrange four-squares extension
+-/
+
+import Mathlib.NumberTheory.SumTwoSquares
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic
+
+namespace FermatTwoSquaresOQ05
+
+-- ============================================================================
+-- Part I: The Core Local Obstruction over ZMod 4
+-- ============================================================================
+
+/-- **Squares mod 4.** Every element of `ZMod 4` squares to `0` or `1`.
+This is the arithmetic heart of the obstruction. -/
+theorem sq_mem_zero_one (a : ZMod 4) : a ^ 2 = 0 ∨ a ^ 2 = 1 := by
+  revert a; decide
+
+/-- **The core obstruction.** No sum of two squares equals `3` in `ZMod 4`.
+Since each square is `0` or `1`, the possible values of `a² + b²` are
+`{0, 1, 2}` — never `3`. Verified by exhaustive check over the 16 pairs. -/
+theorem zmod_four_sq_add_sq_ne_three (a b : ZMod 4) : a ^ 2 + b ^ 2 ≠ 3 := by
+  revert a b; decide
+
+-- ============================================================================
+-- Part II: The Obstruction over ℤ (Int.ModEq form)
+-- ============================================================================
+
+/-- **Integer obstruction.** For all integers `a, b`, the sum `a² + b²` is never
+congruent to `3` modulo `4`. This is the cleanest statement of the local
+obstruction: it is a property of the equation, independent of any target `n`. -/
+theorem int_sq_add_sq_not_three_mod_four (a b : ℤ) :
+    ¬ (a ^ 2 + b ^ 2 ≡ 3 [ZMOD 4]) := by
+  intro h
+  -- Transport the congruence into ZMod 4, where it becomes a finite check.
+  have h2 : ((a ^ 2 + b ^ 2 : ℤ) : ZMod 4) = ((3 : ℤ) : ZMod 4) := by
+    rw [ZMod.intCast_eq_intCast_iff]
+    exact_mod_cast h
+  push_cast at h2
+  exact zmod_four_sq_add_sq_ne_three (a : ZMod 4) (b : ZMod 4) h2
+
+/-- **No integer `≡ 3 (mod 4)` is a sum of two integer squares.** -/
+theorem int_not_sq_add_sq_of_mod_four {n : ℤ} (hn : n ≡ 3 [ZMOD 4]) :
+    ¬ ∃ x y : ℤ, n = x ^ 2 + y ^ 2 := by
+  rintro ⟨x, y, rfl⟩
+  exact int_sq_add_sq_not_three_mod_four x y hn
+
+-- ============================================================================
+-- Part III: The Obstruction over ℕ
+-- ============================================================================
+
+/-- **Natural-number obstruction.** If `n % 4 = 3`, then `n` is not a sum of two
+natural-number squares. This is the form most directly comparable to Fermat's
+two-squares theorem. -/
+theorem not_sq_add_sq_of_mod_four_eq_three {n : ℕ} (hn : n % 4 = 3) :
+    ¬ ∃ x y : ℕ, n = x ^ 2 + y ^ 2 := by
+  rintro ⟨x, y, rfl⟩
+  -- Push the hypothesis `(x²+y²) % 4 = 3` into `ZMod 4`.
+  have hcast : ((x ^ 2 + y ^ 2 : ℕ) : ZMod 4) = 3 := by
+    have h : ((x ^ 2 + y ^ 2 : ℕ) : ZMod 4) = ((3 : ℕ) : ZMod 4) :=
+      (ZMod.natCast_eq_natCast_iff' _ _ _).mpr (by omega)
+    simpa using h
+  push_cast at hcast
+  exact zmod_four_sq_add_sq_ne_three (x : ZMod 4) (y : ZMod 4) hcast
+
+-- ============================================================================
+-- Part IV: Prime Case and the Biconditional Sharpening
+-- ============================================================================
+
+/-- **No prime `≡ 3 (mod 4)` is a sum of two squares.** A direct specialization
+of the natural-number obstruction; stated separately because it is the half of
+Fermat's classification that Mathlib does not ship. -/
+theorem prime_not_sq_add_sq_of_mod_four {p : ℕ} (hp : p % 4 = 3) :
+    ¬ ∃ x y : ℕ, p = x ^ 2 + y ^ 2 :=
+  not_sq_add_sq_of_mod_four_eq_three hp
+
+/-- **Fermat's two-squares theorem as a biconditional (for primes).**
+
+Mathlib's `Nat.Prime.sq_add_sq` gives `p % 4 ≠ 3 → ∃ a b, a² + b² = p` (the
+sufficient direction). Combining it with the obstruction of Part III closes the
+loop:
+
+        a prime `p` is a sum of two squares  ↔  `p % 4 ≠ 3`.
+
+For odd primes this is exactly Fermat's classical statement
+`p = x² + y² ↔ p ≡ 1 (mod 4)`, since an odd prime has `p % 4 ∈ {1, 3}`. -/
+theorem prime_sq_add_sq_iff_mod_four_ne_three (p : ℕ) [Fact p.Prime] :
+    (∃ a b : ℕ, a ^ 2 + b ^ 2 = p) ↔ p % 4 ≠ 3 := by
+  constructor
+  · rintro ⟨a, b, hab⟩ hp3
+    -- A representation contradicts the mod-4 obstruction.
+    exact not_sq_add_sq_of_mod_four_eq_three hp3 ⟨a, b, hab.symm⟩
+  · intro hp
+    exact Nat.Prime.sq_add_sq hp
+
+/-- **Fermat's classification for odd primes.** For an odd prime `p`, being a
+sum of two squares is equivalent to `p ≡ 1 (mod 4)`. This is the canonical
+"iff" form, obtained from the biconditional above by noting an odd prime has
+residue `1` or `3` modulo `4`. -/
+theorem odd_prime_sq_add_sq_iff_mod_four_eq_one (p : ℕ) [Fact p.Prime]
+    (hodd : Odd p) : (∃ a b : ℕ, a ^ 2 + b ^ 2 = p) ↔ p % 4 = 1 := by
+  rw [prime_sq_add_sq_iff_mod_four_ne_three]
+  -- An odd number is `1` or `3` mod 4; rule out `3`.
+  rcases hodd with ⟨k, hk⟩
+  omega
+
+-- ============================================================================
+-- Part V: Concrete Witnesses
+-- ============================================================================
+
+/-- `3` is not a sum of two squares (smallest example of the obstruction). -/
+theorem three_not_sq_add_sq : ¬ ∃ x y : ℕ, (3 : ℕ) = x ^ 2 + y ^ 2 :=
+  not_sq_add_sq_of_mod_four_eq_three (by norm_num)
+
+/-- `7` is not a sum of two squares. -/
+theorem seven_not_sq_add_sq : ¬ ∃ x y : ℕ, (7 : ℕ) = x ^ 2 + y ^ 2 :=
+  not_sq_add_sq_of_mod_four_eq_three (by norm_num)
+
+/-- The prime `11 ≡ 3 (mod 4)` is not a sum of two squares. -/
+theorem eleven_not_sq_add_sq : ¬ ∃ x y : ℕ, (11 : ℕ) = x ^ 2 + y ^ 2 :=
+  prime_not_sq_add_sq_of_mod_four (by norm_num)
+
+/-- By contrast, `5 ≡ 1 (mod 4)` IS a sum of two squares: `5 = 1² + 2²`. -/
+theorem five_is_sq_add_sq : ∃ x y : ℕ, (5 : ℕ) = x ^ 2 + y ^ 2 :=
+  ⟨1, 2, by norm_num⟩
+
+/-- And `13 = 2² + 3²`, confirming the sufficient direction for `13 ≡ 1 (mod 4)`. -/
+theorem thirteen_is_sq_add_sq : ∃ x y : ℕ, (13 : ℕ) = x ^ 2 + y ^ 2 :=
+  ⟨2, 3, by norm_num⟩
+
+end FermatTwoSquaresOQ05

--- a/src/data/proofs/fermat-two-squares-oq-05/annotations.json
+++ b/src/data/proofs/fermat-two-squares-oq-05/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ann-core-obstruction",
+    "proofId": "fermat-two-squares-oq-05",
+    "range": {
+      "startLine": 38,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "The Core Obstruction in ZMod 4",
+    "content": "Every element of ZMod 4 squares to 0 or 1 (the squares are 0²=0, 1²=1, 2²=0, 3²=1). Hence a sum of two squares lies in {0, 1, 2} and can never equal 3. The lemma `zmod_four_sq_add_sq_ne_three` proves `∀ a b : ZMod 4, a² + b² ≠ 3` by `revert a b; decide`, an exhaustive kernel check over all 16 pairs. This single finite computation is the entire arithmetic content of the necessary direction of Fermat's two-squares theorem."
+  },
+  {
+    "id": "ann-int-transport",
+    "proofId": "fermat-two-squares-oq-05",
+    "range": {
+      "startLine": 51,
+      "endLine": 62
+    },
+    "type": "technique",
+    "title": "Transporting Congruences into ZMod via Casts",
+    "content": "To use the finite ZMod 4 check on an integer congruence, `ZMod.intCast_eq_intCast_iff` rewrites `a² + b² ≡ 3 [ZMOD 4]` as the equality `(↑(a²+b²) : ZMod 4) = ↑3`, and `push_cast` distributes the ring homomorphism over `+` and `^` to expose `(↑a)² + (↑b)²`. The only friction is that the modulus literal is a Nat in `ZMod 4` but an Int in `[ZMOD 4]`; `exact_mod_cast` bridges the two. The statement `int_sq_add_sq_not_three_mod_four` is phrased purely about the equation, making clear that nothing about a target n is used beyond its residue."
+  },
+  {
+    "id": "ann-nat-form",
+    "proofId": "fermat-two-squares-oq-05",
+    "range": {
+      "startLine": 78,
+      "endLine": 89
+    },
+    "type": "concept",
+    "title": "Natural-Number Form",
+    "content": "`not_sq_add_sq_of_mod_four_eq_three` states the obstruction in the form most directly comparable to Fermat: if n % 4 = 3 then n is not a sum of two natural-number squares. The hypothesis is moved into ZMod 4 via `ZMod.natCast_eq_natCast_iff'`, whose side condition `(x²+y²) % 4 = 3 % 4` is discharged by `omega`."
+  },
+  {
+    "id": "ann-biconditional",
+    "proofId": "fermat-two-squares-oq-05",
+    "range": {
+      "startLine": 105,
+      "endLine": 121
+    },
+    "type": "concept",
+    "title": "Assembling Fermat's Biconditional",
+    "content": "Mathlib's `Nat.Prime.sq_add_sq` supplies the sufficient direction (p % 4 ≠ 3 → ∃ a b, a²+b² = p). Combining it with the obstruction yields `prime_sq_add_sq_iff_mod_four_ne_three`: a prime p is a sum of two squares iff p % 4 ≠ 3. For odd primes p % 4 ∈ {1,3}, so `odd_prime_sq_add_sq_iff_mod_four_eq_one` collapses this to the classical statement p = x² + y² ↔ p ≡ 1 (mod 4), closed by `omega` after unfolding oddness."
+  },
+  {
+    "id": "ann-witnesses",
+    "proofId": "fermat-two-squares-oq-05",
+    "range": {
+      "startLine": 137,
+      "endLine": 152
+    },
+    "type": "example",
+    "title": "Concrete Witnesses",
+    "content": "The smallest obstruction is 3; 7 and the prime 11 are further examples ≡ 3 (mod 4). By contrast 5 = 1² + 2² and 13 = 2² + 3² are ≡ 1 (mod 4) and decompose, witnessing both directions of the biconditional on small inputs."
+  }
+]

--- a/src/data/proofs/fermat-two-squares-oq-05/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-05/meta.json
@@ -1,0 +1,180 @@
+{
+  "id": "fermat-two-squares-oq-05",
+  "title": "Sum-of-Two-Squares Obstruction: n ≡ 3 (mod 4) Is Never x² + y²",
+  "slug": "fermat-two-squares-oq-05",
+  "description": "The congruence obstruction complementing Fermat's two-squares theorem: every square is 0 or 1 mod 4, so a sum of two squares is never 3 mod 4. Combined with Mathlib's sufficient direction, this sharpens Fermat's classification to a biconditional for primes.",
+  "meta": {
+    "author": "Fermat (1640) (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fermat%27s_theorem_on_sums_of_two_squares",
+    "date": "1640",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "sum-of-two-squares",
+      "modular-arithmetic",
+      "fermat",
+      "local-obstruction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FermatTwoSquaresOQ05.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Prime.sq_add_sq",
+        "description": "Sufficient direction: a prime p with p % 4 ≠ 3 is a sum of two squares",
+        "module": "Mathlib.NumberTheory.SumTwoSquares"
+      },
+      {
+        "theorem": "ZMod.intCast_eq_intCast_iff",
+        "description": "Integer congruence mod n is equivalent to equality of images in ZMod n",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_natCast_iff'",
+        "description": "Natural-number casts into ZMod n agree iff the arguments agree mod n",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "zmod_four_sq_add_sq_ne_three: the core local obstruction, a² + b² ≠ 3 in ZMod 4 (exhaustive decide over 16 pairs)",
+      "int_sq_add_sq_not_three_mod_four: for all integers, a² + b² ≢ 3 (mod 4) — the obstruction as a property of the equation itself",
+      "not_sq_add_sq_of_mod_four_eq_three: no natural number ≡ 3 (mod 4) is a sum of two squares",
+      "prime_not_sq_add_sq_of_mod_four: the prime specialization Mathlib does not ship",
+      "prime_sq_add_sq_iff_mod_four_ne_three: biconditional capstone combining the obstruction with Mathlib's Nat.Prime.sq_add_sq",
+      "odd_prime_sq_add_sq_iff_mod_four_eq_one: Fermat's classical iff form, p = x²+y² ↔ p ≡ 1 (mod 4) for odd primes",
+      "Concrete witnesses: 3, 7, 11 are not sums of two squares; 5 = 1²+2², 13 = 2²+3² are"
+    ],
+    "dateAdded": "2026-06-19",
+    "lineCount": 152,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext, Classical.choice, Quot.sound are used (verified via #print axioms). The sufficient direction (Nat.Prime.sq_add_sq) is from Mathlib; the obstruction and the biconditional assembly are original.",
+    "theoremCount": 13,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Fermat announced in a 1640 letter to Mersenne that an odd prime p is expressible as a sum of two squares if and only if p ≡ 1 (mod 4). The first published proof is due to Euler (1749), who established the hard sufficient direction by infinite descent after years of effort. The necessary direction — that no prime (indeed no integer) ≡ 3 (mod 4) can be a sum of two squares — is by contrast an elementary one-modulus argument that Fermat would have regarded as immediate.\n\nThis necessary direction is the archetypal example of a *local obstruction*: a global Diophantine equation killed by passing to a single residue ring. The same idea recurs throughout number theory, from the three-squares theorem (obstruction mod 8: 4ᵃ(8b+7) is never a sum of three squares) to the Hasse–Minkowski local–global principle for quadratic forms. Mathlib ships the deep half of Fermat's theorem (Nat.Prime.sq_add_sq, via the theory of Gaussian integers and the existence of √(-1) mod p); the obstruction half is the easy but essential other side that turns the classification into a genuine biconditional.",
+    "problemStatement": "**Open question (fermat-two-squares-oq-05)**: Supply the necessary direction of Fermat's two-squares theorem — the congruence obstruction — and combine it with Mathlib's sufficient direction to obtain a biconditional.\n\n**Result**: A fully verified (0 sorries, 0 axioms) development. The core fact is that in ZMod 4 a sum of two squares is one of {0, 1, 2} and never 3. This is transported to ℤ (Int.ModEq form) and to ℕ (% form), specialized to primes, and assembled with Nat.Prime.sq_add_sq into:\n\n  ∃ a b, a² + b² = p  ↔  p % 4 ≠ 3\n\nand, for odd primes, the classical p = x² + y² ↔ p ≡ 1 (mod 4).",
+    "text": "The congruence obstruction complementing Fermat's two-squares theorem: every square is 0 or 1 mod 4, so a sum of two squares is never 3 mod 4. Combined with Mathlib's sufficient direction this gives a biconditional for primes.",
+    "proofStrategy": "**Proof Strategy:**\n\n1. **Core obstruction (ZMod 4)**: Every square in ZMod 4 is 0 or 1, so a² + b² ∈ {0,1,2}. The statement `∀ a b : ZMod 4, a² + b² ≠ 3` is decided by exhaustive kernel computation over the 16 pairs (`revert a b; decide`).\n\n2. **Transport to ℤ**: A congruence a² + b² ≡ 3 [ZMOD 4] is equivalent, via `ZMod.intCast_eq_intCast_iff`, to the equation a² + b² = 3 in ZMod 4 (after `push_cast`), which the core lemma refutes.\n\n3. **Transport to ℕ**: From n % 4 = 3 and a hypothetical n = x² + y², `ZMod.natCast_eq_natCast_iff'` yields x² + y² = 3 in ZMod 4, again refuted.\n\n4. **Biconditional**: The obstruction gives (⇐) of `∃ a b, a²+b² = p ↔ p % 4 ≠ 3`; Mathlib's `Nat.Prime.sq_add_sq` gives (⇒). For odd primes, p % 4 ∈ {1,3}, so `p % 4 ≠ 3 ↔ p % 4 = 1` (closed by `omega`).",
+    "keyInsights": [
+      "**One modulus settles infinitely many cases**: The entire necessary direction reduces to a 16-case finite check in ZMod 4. There is no descent, no Gaussian integers, no quadratic reciprocity — just the fact that the only squares mod 4 are 0 and 1. This is the cleanest possible illustration of a local (congruence) obstruction to a global Diophantine equation.",
+      "**The obstruction is a property of the equation, not the target**: Phrasing it as `∀ a b : ℤ, a² + b² ≢ 3 (mod 4)` (int_sq_add_sq_not_three_mod_four) makes clear that nothing about n is used beyond its residue. Every statement about specific n (or primes p) is a corollary of this single congruence fact.",
+      "**Mathlib ships the hard half, not the easy half**: `Nat.Prime.sq_add_sq` encodes the sufficient direction (the descent / Gaussian-integer content), but Mathlib does not package the elementary obstruction as a named lemma. Supplying it is exactly what upgrades the library's one-directional result to the biconditional that students recognize as 'Fermat's theorem'.",
+      "**ZMod is the right bridge for both ℤ and ℕ**: `intCast_eq_intCast_iff` and `natCast_eq_natCast_iff'` turn congruences in ℤ and ℕ into equalities in the finite ring ZMod 4, where `decide` finishes. The only friction is the Nat-vs-Int numeral cast on the modulus, handled by `exact_mod_cast`.",
+      "**Generalization beyond primes is free**: Because the obstruction is about residues, it applies verbatim to *every* integer ≡ 3 (mod 4), not just primes. The prime statement is a one-line specialization, and the four-squares theorem (no obstruction at all) shows why dropping to two squares is exactly where congruence conditions appear."
+    ],
+    "prerequisites": [
+      "Modular arithmetic (residues mod 4, the ring ZMod n)",
+      "Quadratic residues (squares modulo small moduli)",
+      "Basic number theory (primes, the two-squares theorem statement)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "File header motivating the obstruction as the necessary direction complementing Mathlib's Nat.Prime.sq_add_sq. Imports SumTwoSquares, ZMod.Basic, and Tactic; opens the FermatTwoSquaresOQ05 namespace.",
+      "mathContext": "Fermat's two-squares theorem: an odd prime p is a sum of two squares iff p ≡ 1 (mod 4). Mathlib ships the sufficient direction; this file supplies the congruence obstruction (necessary direction)."
+    },
+    {
+      "id": "core-obstruction",
+      "title": "The Core Local Obstruction over ZMod 4",
+      "startLine": 31,
+      "endLine": 46,
+      "summary": "Proves every square in ZMod 4 is 0 or 1, and the core lemma a² + b² ≠ 3 in ZMod 4, by exhaustive kernel decide.",
+      "mathContext": "Squares mod 4 lie in {0,1}, so a² + b² ∈ {0,1,2} and is never 3. This 16-case finite check is the entire arithmetic content of the obstruction."
+    },
+    {
+      "id": "int-obstruction",
+      "title": "The Obstruction over ℤ",
+      "startLine": 47,
+      "endLine": 70,
+      "summary": "Transports the core lemma to ℤ: a² + b² ≢ 3 (mod 4) for all integers, and the corollary that no integer ≡ 3 (mod 4) is a sum of two squares.",
+      "mathContext": "Int.ModEq congruences become equalities in ZMod 4 via ZMod.intCast_eq_intCast_iff; push_cast distributes the cast over + and ^, reducing to the finite check."
+    },
+    {
+      "id": "nat-obstruction",
+      "title": "The Obstruction over ℕ",
+      "startLine": 71,
+      "endLine": 90,
+      "summary": "States the natural-number form: n % 4 = 3 implies n is not a sum of two natural-number squares.",
+      "mathContext": "ZMod.natCast_eq_natCast_iff' turns n % 4 = 3 into the cast equality in ZMod 4. This is the form most directly comparable to Fermat's two-squares theorem."
+    },
+    {
+      "id": "biconditional",
+      "title": "Prime Case and the Biconditional Sharpening",
+      "startLine": 91,
+      "endLine": 132,
+      "summary": "Specializes to primes and assembles the biconditional ∃ a b, a²+b² = p ↔ p % 4 ≠ 3 using Mathlib's Nat.Prime.sq_add_sq, plus the classical odd-prime form p = x²+y² ↔ p ≡ 1 (mod 4).",
+      "mathContext": "Combining the obstruction (necessary) with Nat.Prime.sq_add_sq (sufficient) yields Fermat's classification as a genuine iff. For odd primes p % 4 ∈ {1,3}, so ≠ 3 collapses to = 1."
+    },
+    {
+      "id": "witnesses",
+      "title": "Concrete Witnesses",
+      "startLine": 133,
+      "endLine": 152,
+      "summary": "Verifies 3, 7, 11 are not sums of two squares, and exhibits 5 = 1²+2², 13 = 2²+3² for the sufficient side.",
+      "mathContext": "3 is the smallest obstruction; 7 and 11 are further ≡ 3 (mod 4) examples (11 prime). 5 and 13 are ≡ 1 (mod 4) and decompose, illustrating both directions."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "extends",
+      "description": "Supplies the necessary (obstruction) direction of Fermat's two-squares theorem, upgrading the parent's sufficient-direction characterization to a biconditional for primes."
+    },
+    {
+      "targetId": "fermat-two-squares-oq-01",
+      "relationship": "related",
+      "description": "The Lagrange four-squares extension shows that allowing four squares removes all congruence obstructions; this entry isolates exactly the mod-4 obstruction that two squares cannot overcome."
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "foundational",
+      "description": "The hard (sufficient) direction of Fermat's theorem rests on -1 being a quadratic residue mod p iff p ≡ 1 (mod 4), a consequence of quadratic reciprocity. The obstruction here is the elementary complement requiring no such machinery."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) formalization of the congruence obstruction half of Fermat's two-squares theorem. The single arithmetic fact that squares are 0 or 1 mod 4 — checked exhaustively in ZMod 4 — is transported to ℤ and ℕ, specialized to primes, and combined with Mathlib's sufficient direction (Nat.Prime.sq_add_sq) to produce the biconditional ∃ a b, a²+b² = p ↔ p % 4 ≠ 3, and the classical odd-prime form p = x²+y² ↔ p ≡ 1 (mod 4).",
+    "implications": "**Theoretical Significance**: The obstruction is the prototypical local-global obstruction in number theory. Its structure — reduce a global equation to a finite check in a residue ring — recurs in the three-squares theorem (mod 8), in the Hasse–Minkowski principle for quadratic forms, and in the general theory of which integers a quadratic form represents. By packaging the elementary half that Mathlib omits, this entry turns the library's one-directional Nat.Prime.sq_add_sq into the biconditional that is the recognizable statement of Fermat's theorem.",
+    "openQuestions": [
+      "Can the analogous obstruction for the three-squares theorem (no integer of the form 4ᵃ(8b+7) is a sum of three squares) be assembled with a Mathlib sufficient direction into a biconditional, mirroring this entry?",
+      "Is there a uniform Lean framework that, given a quadratic form and a modulus, automatically derives the congruence obstruction by a ZMod decide, parameterized over the modulus?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.SumTwoSquares",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "FermatTwoSquaresOQ05",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 0,
+    "path": "Proofs/FermatTwoSquaresOQ05.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "P. de Fermat",
+      "title": "Letter to Mersenne (1640)",
+      "year": "1640",
+      "venue": "",
+      "note": "Announcement of the two-squares characterization for odd primes"
+    },
+    {
+      "authors": "L. Euler",
+      "title": "De numeris qui sunt aggregata duorum quadratorum",
+      "year": "1749",
+      "venue": "Novi Commentarii Academiae Scientiarum Petropolitanae",
+      "note": "First published proof of the sufficient direction (infinite descent)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Supplies the **necessary** direction of Fermat's two-squares theorem — the congruence obstruction that complements Mathlib's `Nat.Prime.sq_add_sq` (which gives only the sufficient direction). This sharpens Fermat's classification to a genuine biconditional for primes.

## Result (verified, 0-axiom)

The arithmetic heart is a single finite fact: in `ZMod 4` every square is 0 or 1, so `a² + b² ∈ {0,1,2}` and is **never 3** (`zmod_four_sq_add_sq_ne_three`, exhaustive kernel `decide` over 16 pairs). This is transported to:

- **ℤ**: `int_sq_add_sq_not_three_mod_four` — for all integers, `a² + b² ≢ 3 (mod 4)`.
- **ℕ**: `not_sq_add_sq_of_mod_four_eq_three` — no `n ≡ 3 (mod 4)` is a sum of two squares.
- **primes**: `prime_not_sq_add_sq_of_mod_four`, then the capstone biconditional

      ∃ a b, a² + b² = p  ↔  p % 4 ≠ 3      (prime_sq_add_sq_iff_mod_four_ne_three)

  and the classical odd-prime form `p = x² + y² ↔ p ≡ 1 (mod 4)`.

Concrete witnesses: 3, 7, 11 are not sums of two squares; 5 = 1²+2², 13 = 2²+3² are.

## Verification

- `lake env lean Proofs/FermatTwoSquaresOQ05.lean` — compiles clean, 0 errors/warnings.
- `#print axioms` on the main theorems: only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool` (kernel `decide`, not `native_decide`).
- 0 sorries, 0 `axiom` declarations, 13 theorems, 0 definitions.

## Files

- `proofs/Proofs/FermatTwoSquaresOQ05.lean` (new, 152 lines)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/fermat-two-squares-oq-05/{meta,annotations}.json` (gallery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)