### PR TITLE
research(combinations-formula-oq-06): hockey-stick identity + figurate-number tower

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -593,6 +593,7 @@ import Proofs.CombinationsFormulaOQ02
 import Proofs.CombinationsFormulaOQ02Aristotle
 import Proofs.CombinationsFormulaOQ03
 import Proofs.CombinationsFormulaOQ03OQ06
+import Proofs.CombinationsFormulaOQ06
 import Proofs.ComplexityCore
 import Proofs.ContinuumHypothesis
 import Proofs.ContinuumHypothesisOQ01

--- a/proofs/Proofs/CombinationsFormulaOQ06.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ06.lean
@@ -1,0 +1,118 @@
+import Mathlib
+
+/-
+# The Hockey-Stick Identity and the Figurate-Number Tower
+
+## Open Question OQ-06
+
+Fix a column index `k` in Pascal's triangle and walk down the diagonal
+`C(k,k), C(k+1,k), C(k+2,k), …`.  The **hockey-stick** (a.k.a. *Christmas-stocking*)
+identity states that the partial sums along this diagonal land one row below and one
+column to the right:
+
+  ∑_{m=k}^{n} C(m, k) = C(n+1, k+1).
+
+In Pascal's triangle the summands trace the long shaft of a hockey stick and the
+answer is the blade.  Mathlib packages the identity as `Nat.sum_Icc_choose`, summed
+over the closed interval `Icc k n`.
+
+## Contribution
+
+The sibling file `CombinationsFormulaOQ01` records the *shifted* presentation
+`∑_{i<n+1} C(i + r, r) = C(n + r + 1, r + 1)` proved by a hand induction.  This file
+takes the **column-indexed** viewpoint instead and pushes it through to its classical
+consequences, the *figurate numbers*:
+
+1. `hockey_stick_Icc`   — the identity in Mathlib's interval form `∑_{m ∈ Icc k n}`.
+2. `hockey_stick_range` — the reformulation over `Finset.range (n+1)`, valid because
+   the low terms `C(m, k)` with `m < k` vanish (`Nat.choose_eq_zero_of_lt`).
+3. `triangular_eq_choose` — the `k = 1` slice: `0 + 1 + ⋯ + n = C(n+1, 2)`, the `n`-th
+   **triangular number** as a binomial coefficient, plus the closed form `n(n+1)/2`.
+4. `tetrahedral_eq_choose` — the `k = 2` slice: `∑_{m≤n} C(m, 2) = C(n+1, 3)`, the
+   **tetrahedral numbers**.
+5. `sum_triangular_eq_tetrahedral` — assembling the tower: the sum of the first `n+1`
+   triangular numbers `T_m = C(m+1, 2)` is the tetrahedral number `C(n+2, 3)`.
+
+The column index `k` is exactly the "dimension" of the figurate number: `k = 1` counts
+points on a line, `k = 2` triangles, `k = 3` tetrahedra, and the hockey-stick identity
+is the single statement that each layer is the running total of the one beneath it.
+
+## Mathematical Context
+
+`Nat.sum_Icc_choose` is itself a telescoping consequence of Pascal's rule
+`C(m+1, k+1) = C(m, k) + C(m, k+1)`.  Reading it as a recurrence on the partial sums
+gives the figurate-number recurrences `T_{n} = T_{n-1} + n` and `Te_n = Te_{n-1} + T_n`,
+which is why the same identity specialises to every column at once.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ06
+
+open Finset
+
+/-- **Hockey-stick identity (interval form).**  Summing column `k` of Pascal's triangle
+    from row `k` to row `n` gives the single entry `C(n+1, k+1)`.  This is exactly
+    `Nat.sum_Icc_choose`, restated as the anchor for the developments below. -/
+theorem hockey_stick_Icc (n k : ℕ) :
+    ∑ m ∈ Finset.Icc k n, Nat.choose m k = Nat.choose (n + 1) (k + 1) :=
+  Nat.sum_Icc_choose n k
+
+/-- **Hockey-stick identity (range form).**  The same sum taken over the full initial
+    segment `Finset.range (n+1) = {0, 1, …, n}`.  Extending the index range down to `0`
+    changes nothing because `C(m, k) = 0` whenever `m < k`. -/
+theorem hockey_stick_range (n k : ℕ) :
+    ∑ m ∈ Finset.range (n + 1), Nat.choose m k = Nat.choose (n + 1) (k + 1) := by
+  rw [← hockey_stick_Icc n k]
+  refine (Finset.sum_subset ?_ ?_).symm
+  · -- `Icc k n ⊆ range (n+1)`
+    intro x hx
+    rw [Finset.mem_Icc] at hx
+    rw [Finset.mem_range]
+    omega
+  · -- the extra indices `m < k` contribute `0`
+    intro m hm hmIcc
+    rw [Finset.mem_range] at hm
+    rw [Finset.mem_Icc] at hmIcc
+    exact Nat.choose_eq_zero_of_lt (by omega)
+
+/-- **Triangular numbers as binomial coefficients.**  The `k = 1` slice of the
+    hockey-stick identity: `0 + 1 + ⋯ + n = C(n+1, 2)`. -/
+theorem triangular_eq_choose (n : ℕ) :
+    ∑ m ∈ Finset.range (n + 1), m = Nat.choose (n + 1) 2 := by
+  rw [← hockey_stick_range n 1]
+  refine Finset.sum_congr rfl (fun m _ => ?_)
+  rw [Nat.choose_one_right]
+
+/-- The triangular number `C(n+1, 2)` in its familiar closed form `n(n+1)/2`. -/
+theorem triangular_closed_form (n : ℕ) :
+    Nat.choose (n + 1) 2 = n * (n + 1) / 2 := by
+  rw [Nat.choose_two_right]
+  congr 1
+  simp only [Nat.add_sub_cancel]
+  ring
+
+/-- **Tetrahedral numbers as binomial coefficients.**  The `k = 2` slice of the
+    hockey-stick identity: `∑_{m ≤ n} C(m, 2) = C(n+1, 3)`. -/
+theorem tetrahedral_eq_choose (n : ℕ) :
+    ∑ m ∈ Finset.range (n + 1), Nat.choose m 2 = Nat.choose (n + 1) 3 :=
+  hockey_stick_range n 2
+
+/-- **The figurate tower.**  The sum of the first `n+1` triangular numbers
+    `T_m = C(m+1, 2)` is the tetrahedral number `C(n+2, 3)`.  This is the hockey-stick
+    identity for column `2` after dropping the vanishing `C(0, 2) = 0` term. -/
+theorem sum_triangular_eq_tetrahedral (n : ℕ) :
+    ∑ m ∈ Finset.range (n + 1), Nat.choose (m + 1) 2 = Nat.choose (n + 2) 3 := by
+  have h := hockey_stick_range (n + 1) 2
+  rw [Finset.sum_range_succ'] at h
+  simpa using h
+
+-- Concrete verifications.
+/-- `1 + 2 + 3 + 4 = 10 = C(5, 2)`. -/
+example : ∑ m ∈ Finset.range 5, m = Nat.choose 5 2 := by decide
+/-- `C(2,2) + C(3,2) + C(4,2) = 1 + 3 + 6 = 10 = C(5, 3)`. -/
+example : ∑ m ∈ Finset.range 5, Nat.choose m 2 = Nat.choose 5 3 := by decide
+/-- The triangular numbers `T_0 + ⋯ + T_4 = 0 + 1 + 3 + 6 + 10 = 20 = C(6, 3)`. -/
+example : ∑ m ∈ Finset.range 5, Nat.choose (m + 1) 2 = Nat.choose 6 3 := by decide
+
+end CombinationsFormulaOQ06

--- a/src/data/proofs/combinations-formula-oq-06/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-06/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "hockey-stick-context",
+    "proofId": "combinations-formula-oq-06",
+    "range": { "startLine": 1, "endLine": 55 },
+    "type": "concept",
+    "title": "The Hockey-Stick Identity and Figurate Numbers",
+    "content": "Fix a column k in Pascal's triangle and walk down the diagonal C(k,k), C(k+1,k), C(k+2,k), …. The hockey-stick (Christmas-stocking) identity states the partial sums land one row below and one column right: ∑_{m=k}^{n} C(m,k) = C(n+1,k+1). Reading this column by column reproduces the figurate numbers: column 1 gives the triangular numbers, column 2 the tetrahedral numbers, and so on. This entry formalizes the identity and its figurate specializations.",
+    "mathContext": "The hockey-stick identity $\\sum_{m=k}^{n} \\binom{m}{k} = \\binom{n+1}{k+1}$ is a telescoping consequence of Pascal's rule $\\binom{m+1}{k+1} = \\binom{m}{k} + \\binom{m}{k+1}$. Specializing the column index $k$ recovers the simplicial figurate numbers: $k=1$ gives $\\sum_{m=0}^{n} m = \\binom{n+1}{2} = \\tfrac{n(n+1)}{2}$ (triangular), and $k=2$ gives $\\sum_{m=0}^{n} \\binom{m}{2} = \\binom{n+1}{3}$ (tetrahedral).",
+    "significance": "key",
+    "relatedConcepts": [
+      "hockey-stick identity",
+      "Pascal's triangle",
+      "binomial coefficients",
+      "triangular numbers",
+      "tetrahedral numbers",
+      "figurate numbers"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "Finset.Icc and Finset.range sums",
+      "Pascal's rule"
+    ]
+  },
+  {
+    "id": "hockey-stick-icc-anchor",
+    "proofId": "combinations-formula-oq-06",
+    "range": { "startLine": 56, "endLine": 62 },
+    "type": "theorem",
+    "title": "Hockey-Stick Identity (Interval Form)",
+    "content": "hockey_stick_Icc restates Mathlib's Nat.sum_Icc_choose: ∑_{m∈Icc k n} C(m,k) = C(n+1,k+1). Summing column k from row k down to row n collapses to the single entry one row lower and one column to the right. This serves as the anchor that the range form and the figurate specializations build on.",
+    "mathContext": "$\\sum_{m \\in [k, n]} \\binom{m}{k} = \\binom{n+1}{k+1}$. The interval $[k,n]$ starts at $m = k$ because $\\binom{m}{k} = 0$ for $m < k$; Mathlib's lemma is stated over this exact support.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.sum_Icc_choose", "closed interval sums"],
+    "prerequisites": ["Finset.Icc", "Nat.choose"]
+  },
+  {
+    "id": "hockey-stick-range-thm",
+    "proofId": "combinations-formula-oq-06",
+    "range": { "startLine": 63, "endLine": 79 },
+    "type": "theorem",
+    "title": "Hockey-Stick Identity (Range Form)",
+    "content": "hockey_stick_range transports the identity to a sum over Finset.range (n+1) = {0,1,…,n}: ∑_{m<n+1} C(m,k) = C(n+1,k+1). Extending the index range down to 0 changes nothing because C(m,k) = 0 whenever m < k. The proof uses Finset.sum_subset with Icc k n ⊆ range (n+1), discharging the membership arithmetic with omega and the vanishing terms with Nat.choose_eq_zero_of_lt.",
+    "mathContext": "Since $\\binom{m}{k} = 0$ for $m < k$, the sums over $[k,n]$ and over $\\{0,\\dots,n\\}$ agree. Finset.sum_subset $s \\subseteq t$ requires the extra elements of $t$ to be zeroed by the summand, which is exactly $\\binom{m}{k}=0$ for $m<k$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_subset", "Nat.choose_eq_zero_of_lt"],
+    "prerequisites": ["Finset.range", "Finset subset sums"]
+  },
+  {
+    "id": "triangular-thm",
+    "proofId": "combinations-formula-oq-06",
+    "range": { "startLine": 80, "endLine": 95 },
+    "type": "theorem",
+    "title": "Triangular Numbers as Binomial Coefficients",
+    "content": "triangular_eq_choose is the k=1 slice: 0+1+⋯+n = C(n+1,2). Because C(m,1) = m (Nat.choose_one_right), the column-1 hockey stick is exactly Gauss's sum of the first n integers, exhibited as a binomial coefficient. triangular_closed_form then gives the familiar C(n+1,2) = n(n+1)/2 via Nat.choose_two_right.",
+    "mathContext": "$\\sum_{m=0}^{n} m = \\binom{n+1}{2} = \\tfrac{n(n+1)}{2}$. The $n$-th triangular number $T_n$ is the count of points in a triangular array, equal to the number of 2-element subsets of an $(n+1)$-element set.",
+    "significance": "key",
+    "relatedConcepts": ["triangular numbers", "Gauss summation", "Nat.choose_one_right", "Nat.choose_two_right"],
+    "prerequisites": ["Nat.choose", "Finset.sum_congr"]
+  },
+  {
+    "id": "tetrahedral-thm",
+    "proofId": "combinations-formula-oq-06",
+    "range": { "startLine": 96, "endLine": 102 },
+    "type": "theorem",
+    "title": "Tetrahedral Numbers as Binomial Coefficients",
+    "content": "tetrahedral_eq_choose is the k=2 slice: ∑_{m≤n} C(m,2) = C(n+1,3), a direct instance of hockey_stick_range. The tetrahedral numbers are the running totals of the triangular column of Pascal's triangle, just as the triangular numbers are the running totals of the natural numbers.",
+    "mathContext": "$\\sum_{m=0}^{n} \\binom{m}{2} = \\binom{n+1}{3}$. The tetrahedral number $\\binom{n+1}{3} = \\tfrac{(n-1)n(n+1)}{6}$ counts points in a triangular pyramid and equals the number of 3-element subsets of an $(n+1)$-element set.",
+    "significance": "key",
+    "relatedConcepts": ["tetrahedral numbers", "simplicial numbers", "partial sums"],
+    "prerequisites": ["hockey-stick range form", "Nat.choose"]
+  },
+  {
+    "id": "figurate-tower-thm",
+    "proofId": "combinations-formula-oq-06",
+    "range": { "startLine": 103, "endLine": 109 },
+    "type": "theorem",
+    "title": "The Figurate Tower",
+    "content": "sum_triangular_eq_tetrahedral assembles the hierarchy: the sum of the first n+1 triangular numbers T_m = C(m+1,2) is the tetrahedral number C(n+2,3). It follows from the column-2 hockey stick after Finset.sum_range_succ' peels off and discards the vanishing head term C(0,2) = 0. This is the literal statement that the tetrahedral numbers are the partial sums of the triangular numbers.",
+    "mathContext": "With $T_m = \\binom{m+1}{2}$, we have $\\sum_{m=0}^{n} T_m = \\binom{n+2}{3}$. Reindexing $\\sum_{m=0}^{n+1}\\binom{m}{2}$ by stripping the $m=0$ term (which is $0$) yields $\\sum_{m=0}^{n}\\binom{m+1}{2}$, and the hockey stick evaluates the former to $\\binom{n+2}{3}$.",
+    "significance": "key",
+    "relatedConcepts": ["figurate number tower", "Finset.sum_range_succ'", "partial sums"],
+    "prerequisites": ["tetrahedral numbers", "reindexing finite sums"]
+  },
+  {
+    "id": "verification-examples",
+    "proofId": "combinations-formula-oq-06",
+    "range": { "startLine": 110, "endLine": 116 },
+    "type": "example",
+    "title": "Worked Verifications",
+    "content": "Three concrete checks via kernel decide: 1+2+3+4 = 10 = C(5,2) (triangular); C(2,2)+C(3,2)+C(4,2) = 1+3+6 = 10 = C(5,3) (tetrahedral as running totals); and T_0+⋯+T_4 = 0+1+3+6+10 = 20 = C(6,3) (the figurate tower). Using decide rather than native_decide keeps the verification kernel-checked and free of the Lean.ofReduceBool axiom.",
+    "mathContext": "These instantiate the general theorems at small $n$, confirming the figurate identities numerically against Pascal's triangle.",
+    "significance": "supporting",
+    "relatedConcepts": ["decide", "kernel verification"],
+    "prerequisites": ["Nat.choose evaluation"]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-06/meta.json
+++ b/src/data/proofs/combinations-formula-oq-06/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "combinations-formula-oq-06",
+  "title": "The Hockey-Stick Identity and the Figurate-Number Tower",
+  "slug": "combinations-formula-oq-06",
+  "description": "Formalizes the hockey-stick (Christmas-stocking) identity ∑_{m=k}^{n} C(m,k) = C(n+1,k+1) in both Mathlib's interval form and a range reformulation, then specializes the column index k to recover the figurate numbers: triangular numbers (k=1) as C(n+1,2)=n(n+1)/2, tetrahedral numbers (k=2) as C(n+1,3), and the tower identity that the sum of the first triangular numbers is a tetrahedral number.",
+  "meta": {
+    "author": "Lean Genius researcher-4",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ06.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 118,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None. All identities hold for every natural number n (and column index k) and are fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms); the concrete checks use kernel `decide`, not `native_decide`, so no Lean.ofReduceBool dependency.",
+    "tags": [
+      "combinatorics",
+      "hockey-stick-identity",
+      "pascals-triangle",
+      "binomial-coefficients",
+      "figurate-numbers",
+      "triangular-numbers",
+      "tetrahedral-numbers",
+      "finset-sums"
+    ],
+    "dateAdded": "2026-06-19",
+    "originalContributions": [
+      "hockey_stick_range: the hockey-stick identity reformulated over the full initial segment Finset.range (n+1), derived from Mathlib's interval form Nat.sum_Icc_choose via Finset.sum_subset and the vanishing of C(m,k) for m < k (a column-indexed presentation distinct from the shifted ∑ C(i+r,r) form in CombinationsFormulaOQ01)",
+      "triangular_eq_choose: the k=1 slice 0+1+⋯+n = C(n+1,2), exhibiting the triangular numbers as binomial coefficients, together with triangular_closed_form giving the closed form C(n+1,2) = n(n+1)/2",
+      "tetrahedral_eq_choose: the k=2 slice ∑_{m≤n} C(m,2) = C(n+1,3), the tetrahedral numbers as the running totals of the triangular column",
+      "sum_triangular_eq_tetrahedral: the figurate tower — the sum of the first n+1 triangular numbers T_m = C(m+1,2) equals the tetrahedral number C(n+2,3), obtained from the column-2 hockey stick by dropping the vanishing C(0,2)=0 term"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ06.lean",
+    "namespace": "CombinationsFormulaOQ06",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 118,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The hockey-stick identity — so named because the summed entries form the long shaft of a hockey stick in Pascal's triangle and the total is its blade — is among the oldest binomial-coefficient identities, implicit already in the medieval study of figurate numbers. Reading the identity column by column reproduces the classical figurate-number hierarchy of the Pythagoreans and Nicomachus: the natural numbers (column 1) sum to the triangular numbers (column 2), which sum to the tetrahedral numbers (column 3), and so on up the simplicial tower. Each layer is the partial-sum sequence of the one beneath it, and the hockey-stick identity is the single statement that captures every layer at once.",
+    "problemStatement": "Open Question OQ-06: Formalize the column-k diagonal sum of Pascal's triangle, ∑_{m∈Icc k n} C(m,k) = C(n+1, k+1) (the hockey-stick / Christmas-stocking identity), via Mathlib's Nat.sum_Icc_choose, and give the Finset.range reformulation in which the low terms vanish by Nat.choose_eq_zero_of_lt. Specialize the column index to recover the figurate numbers.",
+    "proofStrategy": "Anchor on Mathlib's Nat.sum_Icc_choose, which states ∑_{m∈Icc k n} C(m,k) = C(n+1,k+1). Transport this to a sum over Finset.range (n+1) with Finset.sum_subset: Icc k n ⊆ range (n+1), and every extra index m has m < k, so C(m,k) = 0 by Nat.choose_eq_zero_of_lt (the membership bookkeeping is discharged by omega). The figurate specializations then follow by instantiating the column index: k=1 with Nat.choose_one_right turns C(m,1) into m, giving the triangular-number sum, whose closed form n(n+1)/2 comes from Nat.choose_two_right; k=2 is the tetrahedral sum directly; and the sum-of-triangular-numbers tower drops the vanishing C(0,2)=0 head term via Finset.sum_range_succ'.",
+    "keyInsights": [
+      "The column index k of the hockey-stick identity is exactly the 'dimension' of the resulting figurate number: k=1 counts points on a line (triangular numbers), k=2 counts triangles (tetrahedral numbers), k=3 counts tetrahedra, and the single identity ∑_{m≤n} C(m,k) = C(n+1,k+1) specializes to every dimension at once.",
+      "Passing from Mathlib's interval form (Icc k n) to the range form (range (n+1)) costs nothing because the binomial coefficients C(m,k) below the diagonal (m < k) are identically zero — exactly the content of Nat.choose_eq_zero_of_lt — so Finset.sum_subset absorbs them.",
+      "The figurate-number recurrences T_n = T_{n-1} + n and Te_n = Te_{n-1} + T_n are the same Pascal recurrence C(m+1,k+1) = C(m,k) + C(m,k+1) read as a recurrence on partial sums; this is why hockey-stick and the figurate tower are one theorem rather than three.",
+      "The closed form C(n+1,2) = n(n+1)/2 follows mechanically from Nat.choose_two_right; combining it with the column-1 hockey stick recovers Gauss's schoolboy sum 0+1+⋯+n as a binomial coefficient."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Header stating OQ-06: the hockey-stick identity and its specialization to the figurate numbers. Explains the column-indexed viewpoint, its distinction from the shifted form in CombinationsFormulaOQ01, and how the figurate tower (triangular → tetrahedral) arises from a single identity."
+    },
+    {
+      "id": "hockey-stick-icc",
+      "title": "Hockey-Stick Identity (Interval Form)",
+      "startLine": 56,
+      "endLine": 62,
+      "summary": "hockey_stick_Icc: ∑_{m∈Icc k n} C(m,k) = C(n+1,k+1), restating Mathlib's Nat.sum_Icc_choose as the anchor for the developments below."
+    },
+    {
+      "id": "hockey-stick-range",
+      "title": "Hockey-Stick Identity (Range Form)",
+      "startLine": 63,
+      "endLine": 79,
+      "summary": "hockey_stick_range: the same sum over Finset.range (n+1). Proved by Finset.sum_subset — Icc k n ⊆ range (n+1) and the extra terms with m < k vanish by Nat.choose_eq_zero_of_lt, with omega handling the membership arithmetic."
+    },
+    {
+      "id": "triangular",
+      "title": "Triangular Numbers",
+      "startLine": 80,
+      "endLine": 95,
+      "summary": "triangular_eq_choose: the k=1 slice 0+1+⋯+n = C(n+1,2), via Nat.choose_one_right; triangular_closed_form: C(n+1,2) = n(n+1)/2, via Nat.choose_two_right."
+    },
+    {
+      "id": "tetrahedral",
+      "title": "Tetrahedral Numbers",
+      "startLine": 96,
+      "endLine": 102,
+      "summary": "tetrahedral_eq_choose: the k=2 slice ∑_{m≤n} C(m,2) = C(n+1,3), the tetrahedral numbers as the running totals of the triangular column — a direct instance of hockey_stick_range."
+    },
+    {
+      "id": "figurate-tower",
+      "title": "The Figurate Tower",
+      "startLine": 103,
+      "endLine": 109,
+      "summary": "sum_triangular_eq_tetrahedral: the sum of the first n+1 triangular numbers T_m = C(m+1,2) equals the tetrahedral number C(n+2,3), from the column-2 hockey stick after Finset.sum_range_succ' drops the vanishing C(0,2)=0 head term."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 110,
+      "endLine": 116,
+      "summary": "Concrete checks via kernel decide: 1+2+3+4 = 10 = C(5,2); C(2,2)+C(3,2)+C(4,2) = 10 = C(5,3); and T_0+⋯+T_4 = 0+1+3+6+10 = 20 = C(6,3)."
+    }
+  ],
+  "conclusion": {
+    "summary": "6 theorems, 0 sorries, 0 axioms. The hockey-stick identity ∑_{m=k}^{n} C(m,k) = C(n+1,k+1) is formalized in both Mathlib's interval form and a range reformulation, then specialized down the figurate-number tower: triangular numbers C(n+1,2) = n(n+1)/2 (k=1), tetrahedral numbers C(n+1,3) (k=2), and the identity that the sum of the first triangular numbers is tetrahedral.",
+    "implications": "Treating the column index k as a free parameter turns one binomial identity into the entire Pythagorean hierarchy of figurate numbers, making the 'each layer is the running total of the one below' picture literal in Lean. The pattern (anchor on an Icc-indexed Mathlib lemma, transport to range via sum_subset over vanishing terms, then specialize the free index) is reusable for any column- or diagonal-indexed binomial identity one wishes to read as a bounded range sum.",
+    "openQuestions": [
+      "Does the uniform statement ∑_{m≤n} C(m,k) = C(n+1,k+1) admit a clean Lean specialization to arbitrary simplicial (k-dimensional figurate) numbers C(n+k-1,k), giving the full Pythagorean tower as a single parametrized family?",
+      "Can the closed forms for the higher figurate numbers (e.g. tetrahedral n(n+1)(n+2)/6) be derived inside Lean from the hockey-stick recurrence without a separate induction, mirroring the n(n+1)/2 closed form obtained here for the triangular case?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-01",
+      "relationship": "sibling — proves the shifted hockey-stick form ∑ C(i+r,r) = C(n+r+1,r+1) and the row/alternating sums; this entry gives the column-indexed form and the figurate specializations"
+    },
+    {
+      "targetId": "combinations-formula-oq-02",
+      "relationship": "ancestor — the core combinations formula entry providing binomial coefficient context"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **hockey-stick (Christmas-stocking) identity** and pushes it through to its classical figurate-number consequences. 6 theorems, **0 sorries, 0 axioms** (only `propext`/`Classical.choice`/`Quot.sound`; concrete checks use kernel `decide`, not `native_decide`, so no `Lean.ofReduceBool`).

The hockey-stick identity says that summing column `k` of Pascal's triangle from row `k` to row `n` collapses to a single entry:

  ∑_{m=k}^{n} C(m, k) = C(n+1, k+1).

## Theorems

- `hockey_stick_Icc` — the identity in Mathlib's interval form (`Nat.sum_Icc_choose`), the anchor.
- `hockey_stick_range` — reformulation over `Finset.range (n+1)`, valid because `C(m,k)=0` for `m<k` (`Finset.sum_subset` + `Nat.choose_eq_zero_of_lt`).
- `triangular_eq_choose` — the `k=1` slice `0+1+⋯+n = C(n+1,2)`, plus `triangular_closed_form` giving `C(n+1,2) = n(n+1)/2`.
- `tetrahedral_eq_choose` — the `k=2` slice `∑_{m≤n} C(m,2) = C(n+1,3)`.
- `sum_triangular_eq_tetrahedral` — the figurate tower: the sum of the first `n+1` triangular numbers `T_m = C(m+1,2)` is the tetrahedral number `C(n+2,3)`.

## Contribution / distinctness

The sibling entry `combinations-formula-oq-01` proves the *shifted* hockey-stick form `∑ C(i+r,r) = C(n+r+1,r+1)` by hand induction. This entry takes the **column-indexed** viewpoint (Mathlib's `Nat.sum_Icc_choose`) and specializes the free column index `k` to recover the Pythagorean figurate tower — natural numbers (k=1) → triangular → tetrahedral — exhibiting "each layer is the running total of the one below" as a single identity. No overlap with the existing standalone proof content.

## Verification

`lake env lean Proofs/CombinationsFormulaOQ06.lean` compiles clean (exit 0). `#print axioms` on the main theorems returns only `[propext, Classical.choice, Quot.sound]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)