### PR TITLE
research(cantor-diagonalization-oq-05): continuum stable under countable powers #(ℕ→ℝ)=#ℝ (verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -414,6 +414,7 @@ import Proofs.CantorDiagonalizationOQ04OQ01
 import Proofs.CantorDiagonalizationOQ04OQ01OQ03
 import Proofs.CantorDiagonalizationOQ04OQ03
 import Proofs.CantorDiagonalizationOQ04OQ03Aristotle
+import Proofs.CantorDiagonalizationOQ05
 import Proofs.CantorDiagonalizationOQ06
 import Proofs.CantorDiagonalizationOQ07
 import Proofs.CantorsTheorem

--- a/proofs/Proofs/CantorDiagonalizationOQ05.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ05.lean
@@ -1,0 +1,81 @@
+/-
+# Cantor Diagonalization OQ-05: the continuum is stable under countable powers, #(ℕ → ℝ) = #ℝ
+
+## Open Question
+Formalize `#(ℕ → ℝ) = #ℝ` (equivalently `𝔠 ^ ℵ₀ = 𝔠`): the space of *real
+sequences* has the same cardinality as the real line, via Mathlib's `Cardinal.mk_arrow`,
+`Cardinal.mk_real`, `Cardinal.mk_nat`, and the countable-power theorem
+`Cardinal.continuum_power_aleph0`.
+
+## Approach
+This is the countable-power strengthening of OQ-07. Where OQ-07 shows the *finite*
+product `#(ℝ × ℝ) = 𝔠` (doubling the dimension does not raise cardinality), the present
+companion shows the continuum is stable even under a *countably infinite* power: passing
+from `ℝ` to the whole sequence space `ℕ → ℝ` still does not increase cardinality.
+
+`Cardinal.mk_arrow` expands `#(ℕ → ℝ)` to `#ℝ ^ #ℕ`; `Cardinal.mk_real` and
+`Cardinal.mk_nat` rewrite the base and exponent to `𝔠` and `ℵ₀`; and
+`Cardinal.continuum_power_aleph0 : 𝔠 ^ ℵ₀ = 𝔠` collapses the power. The cardinal equality
+then unpacks, via `Cardinal.eq`, to an honest bijection `(ℕ → ℝ) ≃ ℝ`.
+
+The same engine yields Baire space `#(ℕ → ℕ) = 𝔠` (`aleph0_power_aleph0`) and, in full
+generality, `#(ℕ → α) = 𝔠` for every type `α` sandwiched `2 ≤ #α ≤ 𝔠`
+(`power_aleph0_of_le_continuum`). Since a countable power dominates any finite product,
+this subsumes OQ-07: both the plane `ℝ × ℝ` and the sequence space `ℕ → ℝ` collapse to `𝔠`.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace CantorDiagonalizationOQ05
+
+open Cardinal
+
+/-- **`𝔠 ^ ℵ₀ = 𝔠`.** The continuum is fixed by countable exponentiation. This is Mathlib's
+`Cardinal.continuum_power_aleph0` (`(2 ^ ℵ₀) ^ ℵ₀ = 2 ^ (ℵ₀ * ℵ₀) = 2 ^ ℵ₀`). It is the
+engine behind every statement below, and the countable-power analogue of OQ-07's
+`continuum_mul_self : 𝔠 * 𝔠 = 𝔠`. -/
+theorem continuum_pow_aleph0 : (𝔠 : Cardinal) ^ (ℵ₀ : Cardinal) = 𝔠 :=
+  Cardinal.continuum_power_aleph0
+
+/-- **`#(ℕ → ℝ) = 𝔠`.** The space of real sequences has cardinality the continuum:
+`Cardinal.mk_arrow` expands `#(ℕ → ℝ)` to `#ℝ ^ #ℕ`, `mk_real`/`mk_nat` turn the base and
+exponent into `𝔠`/`ℵ₀`, and `continuum_pow_aleph0` collapses `𝔠 ^ ℵ₀` to `𝔠`. -/
+theorem mk_seq_real_eq_continuum : #(ℕ → ℝ) = 𝔠 := by
+  rw [mk_arrow, lift_uzero, lift_uzero, mk_real, mk_nat, continuum_power_aleph0]
+
+/-- **The sequence space and the line are equinumerous: `#(ℕ → ℝ) = #ℝ`.** A countably
+infinite power does not raise cardinality — the strong companion to Cantor's diagonal
+result that ℝ strictly exceeds ℕ. Both sides equal `𝔠`. -/
+theorem mk_seq_real : #(ℕ → ℝ) = #ℝ := by
+  rw [mk_seq_real_eq_continuum, mk_real]
+
+/-- **An explicit bijection `(ℕ → ℝ) ≃ ℝ` exists.** The cardinal equality `#(ℕ → ℝ) = #ℝ`
+is, by `Cardinal.eq`, exactly the existence of a bijection between real sequences and the
+line. (Classical / non-constructive: the witness comes from the cardinal-arithmetic proof,
+not an explicit coding formula.) -/
+theorem nonempty_equiv_seq_real : Nonempty ((ℕ → ℝ) ≃ ℝ) :=
+  Cardinal.eq.mp mk_seq_real
+
+/-- **Baire space `#(ℕ → ℕ) = 𝔠`.** Even with the *smallest* infinite base, countable
+sequences already reach the continuum: `mk_arrow` gives `#ℕ ^ #ℕ = ℵ₀ ^ ℵ₀`, collapsed by
+`aleph0_power_aleph0`. So `ℕ → ℕ`, `ℕ → ℝ`, and `ℝ` are all equinumerous. -/
+theorem mk_seq_nat_eq_continuum : #(ℕ → ℕ) = 𝔠 := by
+  rw [mk_arrow, lift_uzero, mk_nat, aleph0_power_aleph0]
+
+/-- **The general principle.** For any type `α` whose cardinality is sandwiched
+`2 ≤ #α ≤ 𝔠`, the countable power collapses: `#(ℕ → α) = 𝔠`. Both `ℝ` (base `𝔠`) and `ℕ`
+(base `ℵ₀`) are instances. This is `power_aleph0_of_le_continuum` transported across
+`mk_arrow`. -/
+theorem mk_seq_eq_continuum {α : Type} (h₁ : 2 ≤ #α) (h₂ : #α ≤ 𝔠) :
+    #(ℕ → α) = 𝔠 := by
+  rw [mk_arrow, lift_uzero, lift_uzero, mk_nat]
+  exact power_aleph0_of_le_continuum h₁ h₂
+
+/-- **Subsumes OQ-07: `#(ℕ → ℝ) = #(ℝ × ℝ)`.** A countable power dominates any finite
+product, so the space of real sequences and the plane have the same cardinality — both are
+`𝔠`. The right side uses `mk_prod` and `continuum_mul_self` exactly as in OQ-07. -/
+theorem mk_seq_real_eq_mk_prod_real : #(ℕ → ℝ) = #(ℝ × ℝ) := by
+  rw [mk_seq_real_eq_continuum, mk_prod, lift_id, mk_real, continuum_mul_self]
+
+end CantorDiagonalizationOQ05

--- a/src/data/proofs/cantor-diagonalization-oq-05/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-05/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "cantor-diagonalization-oq-05",
+  "title": "The Continuum Is Stable Under Countable Powers: #(ℕ → ℝ) = #ℝ",
+  "slug": "cantor-diagonalization-oq-05",
+  "description": "#(ℕ → ℝ) = #ℝ — the space of real sequences has the same cardinality as the line (equivalently 𝔠 ^ ℵ₀ = 𝔠). The countable-power strengthening of OQ-07: where the finite product 𝔠 · 𝔠 = 𝔠 keeps the plane the size of the line, the countable power keeps the whole sequence space the size of the line. Routes through Cardinal.mk_arrow, Cardinal.mk_real, Cardinal.mk_nat, and Cardinal.continuum_power_aleph0, unpacks to an explicit bijection (ℕ → ℝ) ≃ ℝ, and yields Baire space #(ℕ → ℕ) = 𝔠.",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cardinality_of_the_continuum",
+    "date": "1878",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "cantor",
+      "continuum",
+      "cardinal-arithmetic",
+      "real-numbers",
+      "sequences",
+      "baire-space",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CantorDiagonalizationOQ05.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.continuum_power_aleph0",
+        "description": "𝔠 ^ ℵ₀ = 𝔠 — the continuum is fixed by countable exponentiation ((2 ^ ℵ₀) ^ ℵ₀ = 2 ^ (ℵ₀ · ℵ₀) = 2 ^ ℵ₀)",
+        "module": "Mathlib.SetTheory.Cardinal.Continuum"
+      },
+      {
+        "theorem": "Cardinal.power_aleph0_of_le_continuum",
+        "description": "2 ≤ x → x ≤ 𝔠 → x ^ ℵ₀ = 𝔠 — every cardinal sandwiched between 2 and the continuum has countable power 𝔠; the engine unifying the ℝ and ℕ instances",
+        "module": "Mathlib.SetTheory.Cardinal.Continuum"
+      },
+      {
+        "theorem": "Cardinal.aleph0_power_aleph0",
+        "description": "ℵ₀ ^ ℵ₀ = 𝔠 — Baire space (sequences of naturals) already has continuum cardinality",
+        "module": "Mathlib.SetTheory.Cardinal.Continuum"
+      },
+      {
+        "theorem": "Cardinal.mk_arrow",
+        "description": "#(α → β) = lift #β ^ lift #α — cardinality of a function type; lifts are identities in a single universe (Cardinal.lift_uzero)",
+        "module": "Mathlib.SetTheory.Cardinal.Defs"
+      },
+      {
+        "theorem": "Cardinal.mk_real",
+        "description": "#ℝ = 𝔠, the reals have cardinality the continuum",
+        "module": "Mathlib.Analysis.Real.Cardinality"
+      },
+      {
+        "theorem": "Cardinal.mk_nat",
+        "description": "#ℕ = ℵ₀, the naturals have the least infinite cardinality",
+        "module": "Mathlib.SetTheory.Cardinal.Defs"
+      },
+      {
+        "theorem": "Cardinal.eq",
+        "description": "#α = #β ↔ Nonempty (α ≃ β) — a cardinal equality is exactly the existence of a bijection",
+        "module": "Mathlib.SetTheory.Cardinal.Defs"
+      },
+      {
+        "theorem": "Cardinal.continuum_mul_self",
+        "description": "𝔠 * 𝔠 = 𝔠 — the finite-product absorption used to connect back to OQ-07's plane #(ℝ × ℝ)",
+        "module": "Mathlib.SetTheory.Cardinal.Continuum"
+      }
+    ],
+    "originalContributions": [
+      "continuum_pow_aleph0: 𝔠 ^ ℵ₀ = 𝔠 re-exported as the engine of the entry",
+      "mk_seq_real_eq_continuum: #(ℕ → ℝ) = 𝔠, real sequences have cardinality the continuum",
+      "mk_seq_real: #(ℕ → ℝ) = #ℝ, the sequence space and the line are equinumerous (main result)",
+      "nonempty_equiv_seq_real: Nonempty ((ℕ → ℝ) ≃ ℝ), the equality unpacked to an explicit bijection",
+      "mk_seq_nat_eq_continuum: #(ℕ → ℕ) = 𝔠, Baire space already reaches the continuum",
+      "mk_seq_eq_continuum: 2 ≤ #α → #α ≤ 𝔠 → #(ℕ → α) = 𝔠, the unified sandwich principle",
+      "mk_seq_real_eq_mk_prod_real: #(ℕ → ℝ) = #(ℝ × ℝ), subsuming OQ-07's finite product"
+    ],
+    "dateAdded": "2026-06-19",
+    "lineCount": 81,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Cantor's 1878 discovery that the line and the plane are equinumerous (𝔠 · 𝔠 = 𝔠) raised an immediate further question: what about infinite products and powers? The space of all real-valued sequences ℕ → ℝ is the countable power 𝔠^ℵ₀, and Cantor-era cardinal arithmetic shows it too collapses to 𝔠: 𝔠^ℵ₀ = (2^ℵ₀)^ℵ₀ = 2^(ℵ₀·ℵ₀) = 2^ℵ₀ = 𝔠. This is the same phenomenon as the finite case — products and countable powers do not enlarge an infinite cardinal — pushed one cardinal-arithmetic step further. It sits beside the gallery's diagonal results (uncountability of ℝ, the no-surjection theorem A → 𝒫(A)) as the strongest 'stability' counterpart to their 'strict growth': only the power set 2^𝔠 escapes 𝔠, never a countable power of it.",
+    "problemStatement": "**Open Question (cantor-diagonalization-oq-05)**: Formalize #(ℕ → ℝ) = #ℝ (equivalently 𝔠 ^ ℵ₀ = 𝔠), via Mathlib's Cardinal.mk_arrow, Cardinal.mk_real, Cardinal.mk_nat, and Cardinal.continuum_power_aleph0. (This is the countable-power version explicitly flagged as an open question by OQ-07.)\n\n**Result**: mk_seq_real (#(ℕ → ℝ) = #ℝ), mk_seq_real_eq_continuum (#(ℕ → ℝ) = 𝔠), nonempty_equiv_seq_real (a bijection (ℕ → ℝ) ≃ ℝ), continuum_pow_aleph0 (𝔠 ^ ℵ₀ = 𝔠), mk_seq_nat_eq_continuum (Baire space #(ℕ → ℕ) = 𝔠), the unified mk_seq_eq_continuum (#(ℕ → α) = 𝔠 for 2 ≤ #α ≤ 𝔠), and mk_seq_real_eq_mk_prod_real (#(ℕ → ℝ) = #(ℝ × ℝ)) tying back to OQ-07.",
+    "text": "#(ℕ → ℝ) = #ℝ — the space of real sequences and the real line are equinumerous, so the continuum satisfies 𝔠 ^ ℵ₀ = 𝔠. A countably infinite power does not increase cardinality.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `continuum_pow_aleph0` re-exports `Cardinal.continuum_power_aleph0 : 𝔠 ^ ℵ₀ = 𝔠`, the countable-power analogue of OQ-07's `continuum_mul_self`. This is the only nontrivial ingredient — the choice-dependent cardinal arithmetic for infinite powers.\n2. `mk_seq_real_eq_continuum`: `Cardinal.mk_arrow` rewrites #(ℕ → ℝ) to #ℝ ^ #ℕ (lifts vanish via `lift_uzero` in one universe), `mk_real`/`mk_nat` turn the base and exponent into 𝔠 and ℵ₀, and `continuum_pow_aleph0` collapses 𝔠 ^ ℵ₀ to 𝔠.\n3. `mk_seq_real`: both #(ℕ → ℝ) and #ℝ equal 𝔠, so they are equal.\n4. `nonempty_equiv_seq_real`: `Cardinal.eq` turns the cardinal equality into the existence of a bijection (ℕ → ℝ) ≃ ℝ.\n5. `mk_seq_nat_eq_continuum`: the identical route with base ℕ and `aleph0_power_aleph0 : ℵ₀ ^ ℵ₀ = 𝔠` shows even Baire space reaches 𝔠.\n6. `mk_seq_eq_continuum`: transporting `power_aleph0_of_le_continuum` across `mk_arrow` proves #(ℕ → α) = 𝔠 for every base with 2 ≤ #α ≤ 𝔠 — the single principle of which ℝ and ℕ are instances.\n7. `mk_seq_real_eq_mk_prod_real`: since a countable power dominates a finite product, #(ℕ → ℝ) = #(ℝ × ℝ), recovering OQ-07.",
+    "keyInsights": [
+      "**Countable power, not just finite product.** OQ-07 shows 𝔠 · 𝔠 = 𝔠 (the plane is the size of the line). This entry shows the far stronger 𝔠 ^ ℵ₀ = 𝔠 (the whole space of real sequences is the size of the line). Finite products are a trivial corollary of the countable power.",
+      "**Everything between 2 and 𝔠 has the same countable power.** mk_seq_eq_continuum captures the sandwich: 2 ≤ #α ≤ 𝔠 forces #(ℕ → α) = 𝔠. So ℕ → ℕ (Baire space), ℕ → ℝ, ℕ → ℂ, and ℕ → 𝒫(ℕ) are all equinumerous with ℝ.",
+      "**Only the power set escapes.** The continuum absorbs countable powers (𝔠 ^ ℵ₀ = 𝔠) but not its own power set (2 ^ 𝔠 > 𝔠 by Cantor). Stability under sequences, strict growth under power sets — the two faces of the family.",
+      "**Cardinal equality is a bijection.** `Cardinal.eq` makes #(ℕ → ℝ) = #ℝ literally Nonempty ((ℕ → ℝ) ≃ ℝ): a single real number can encode an entire sequence of reals."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (Cardinal.mk, ℵ₀, 𝔠, exponentiation)",
+      "The countable-power law 𝔠 ^ ℵ₀ = 𝔠 (Cardinal.continuum_power_aleph0) and its sandwich generalization",
+      "Cardinality of function types and of ℝ, ℕ (Cardinal.mk_arrow, Cardinal.mk_real, Cardinal.mk_nat)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring framing the countable-power strengthening of OQ-07, the Mathlib import, namespace, and Cardinal open.",
+      "mathContext": "$\\#(\\mathbb{N} \\to \\mathbb{R}) = \\#\\mathbb{R}$, equivalently $\\mathfrak{c}^{\\aleph_0} = \\mathfrak{c}$."
+    },
+    {
+      "id": "engine",
+      "title": "The Countable-Power Law 𝔠 ^ ℵ₀ = 𝔠",
+      "startLine": 41,
+      "endLine": 48,
+      "summary": "continuum_pow_aleph0: 𝔠 ^ ℵ₀ = 𝔠, re-exporting Cardinal.continuum_power_aleph0.",
+      "mathContext": "$\\mathfrak{c}^{\\aleph_0} = \\mathfrak{c}$, the continuum fixed by countable exponentiation."
+    },
+    {
+      "id": "sequences",
+      "title": "Real Sequences Equal the Line",
+      "startLine": 50,
+      "endLine": 67,
+      "summary": "mk_seq_real_eq_continuum (#(ℕ → ℝ) = 𝔠) via mk_arrow + mk_real + mk_nat + continuum_pow_aleph0, mk_seq_real (#(ℕ → ℝ) = #ℝ, the main result), and nonempty_equiv_seq_real (an explicit bijection (ℕ → ℝ) ≃ ℝ).",
+      "mathContext": "$\\#(\\mathbb{N} \\to \\mathbb{R}) = \\mathfrak{c} = \\#\\mathbb{R}$."
+    },
+    {
+      "id": "general",
+      "title": "Baire Space, the Sandwich, and OQ-07",
+      "startLine": 69,
+      "endLine": 81,
+      "summary": "mk_seq_nat_eq_continuum (Baire space #(ℕ → ℕ) = 𝔠), mk_seq_eq_continuum (the unified principle #(ℕ → α) = 𝔠 for 2 ≤ #α ≤ 𝔠), and mk_seq_real_eq_mk_prod_real (#(ℕ → ℝ) = #(ℝ × ℝ), subsuming OQ-07).",
+      "mathContext": "$\\#(\\mathbb{N} \\to \\mathbb{N}) = \\mathfrak{c}$ and $\\#(\\mathbb{N} \\to \\mathbb{R}) = \\#(\\mathbb{R} \\times \\mathbb{R})$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization-oq-07",
+      "relationship": "extends",
+      "description": "The countable-power strengthening: OQ-07 proves the finite product 𝔠 · 𝔠 = 𝔠 (plane = line); this proves 𝔠 ^ ℵ₀ = 𝔠 (sequence space = line), of which the finite product is a corollary (mk_seq_real_eq_mk_prod_real)"
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-06",
+      "relationship": "related",
+      "description": "Companion to the uncountability of ℝ: there diagonalization gives ℵ₀ < 𝔠 (strict growth); here countable exponentiation gives 𝔠 ^ ℵ₀ = 𝔠 (stability under sequences)"
+    },
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "related",
+      "description": "Countable powers leave the continuum fixed (𝔠 ^ ℵ₀ = 𝔠), whereas Cantor's theorem #A < #𝒫(A) shows the power set 2 ^ 𝔠 strictly exceeds it"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization that #(ℕ → ℝ) = #ℝ: the continuum is stable under countable powers (𝔠 ^ ℵ₀ = 𝔠), the sequence space carries an explicit bijection to the line ((ℕ → ℝ) ≃ ℝ), Baire space #(ℕ → ℕ) = 𝔠, the unified sandwich #(ℕ → α) = 𝔠 for 2 ≤ #α ≤ 𝔠, and the link back to OQ-07's plane.",
+    "implications": "Settles the countable-power open question raised by OQ-07. Dimension does not affect cardinality even when the 'dimension' is countably infinite — only the power set escapes the continuum. The same absorption law κ ^ ℵ₀ = κ underlies the stability of every cardinal in [2, 𝔠] under countable products.",
+    "openQuestions": [
+      "Push to higher powers: identify exactly which exponents λ keep 𝔠 ^ λ = 𝔠 (it holds iff λ ≤ ℵ₀; 𝔠 ^ 𝔠 = 2 ^ 𝔠 > 𝔠).",
+      "Exhibit a concrete digit-interleaving bijection (ℕ → ℝ) ≃ ℝ rather than routing through cardinal arithmetic."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "CantorDiagonalizationOQ05",
+    "lineCount": 81,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/CantorDiagonalizationOQ05.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Ein Beitrag zur Mannigfaltigkeitslehre",
+      "year": "1878",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 84, pp. 242–258",
+      "note": "Proves the bijection between ℝ and ℝⁿ — dimension does not change cardinality"
+    },
+    {
+      "authors": "Jech, Thomas",
+      "title": "Set Theory",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics, 3rd ed.",
+      "note": "Cardinal exponentiation: κ ^ λ = 2 ^ λ when 2 ≤ κ ≤ 2 ^ λ, giving 𝔠 ^ ℵ₀ = 𝔠"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **#(ℕ → ℝ) = #ℝ** — equivalently `𝔠 ^ ℵ₀ = 𝔠`: the space of real sequences has the same cardinality as the line. This is the **countable-power strengthening of OQ-07** (`𝔠 · 𝔠 = 𝔠`, the plane = the line), and was explicitly listed as an open question in OQ-07's `openQuestions`.

Where Cantor's diagonal argument (OQ-06) makes ℝ *strictly* larger than ℕ, this entry shows the continuum is *stable* even under a countably infinite power: passing from ℝ to the whole sequence space ℕ → ℝ does not increase cardinality.

## Results (7 theorems, 0 sorries, 0 axioms)

- `continuum_pow_aleph0`: `𝔠 ^ ℵ₀ = 𝔠` (the engine — `Cardinal.continuum_power_aleph0`)
- `mk_seq_real_eq_continuum`: `#(ℕ → ℝ) = 𝔠`
- `mk_seq_real`: `#(ℕ → ℝ) = #ℝ` (main result)
- `nonempty_equiv_seq_real`: `Nonempty ((ℕ → ℝ) ≃ ℝ)` — a single real encodes a whole real sequence
- `mk_seq_nat_eq_continuum`: Baire space `#(ℕ → ℕ) = 𝔠`
- `mk_seq_eq_continuum`: the unified sandwich — `2 ≤ #α → #α ≤ 𝔠 → #(ℕ → α) = 𝔠`
- `mk_seq_real_eq_mk_prod_real`: `#(ℕ → ℝ) = #(ℝ × ℝ)`, subsuming OQ-07's finite product

## Proof route

`Cardinal.mk_arrow` expands `#(ℕ → ℝ)` to `#ℝ ^ #ℕ`; `mk_real`/`mk_nat` rewrite base/exponent to `𝔠`/`ℵ₀`; `continuum_power_aleph0` collapses the power. `Cardinal.eq` unpacks the equality to a bijection. The general `power_aleph0_of_le_continuum` (`2 ≤ x ≤ 𝔠 → x^ℵ₀ = 𝔠`) gives the sandwich, of which ℝ and ℕ are instances.

## Verification

- Compiles clean under Mathlib (mathlib 4.26.0): `lake env lean Proofs/CantorDiagonalizationOQ05.lean`
- `#print axioms` on all 7 theorems: `[propext, Classical.choice, Quot.sound]` only — **0 custom axioms**
- Registered in `proofs/Proofs.lean`; gallery `meta.json` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)