### PR TITLE
research(cube-root-2-irrational-oq-05): the n-th root of a prime is irrational (verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -612,6 +612,7 @@ import Proofs.CramersRuleOQ04
 import Proofs.CubeRoot10Irrational
 import Proofs.CubeRoot2Irrational
 import Proofs.CubeRoot2IrrationalOQ03
+import Proofs.CubeRoot2IrrationalOQ05
 import Proofs.CubeRoot3Irrational
 import Proofs.CubeRoot3IrrationalOQ02
 import Proofs.CubeRoot3IrrationalOQ02OQ01

--- a/proofs/Proofs/CubeRoot2IrrationalOQ05.lean
+++ b/proofs/Proofs/CubeRoot2IrrationalOQ05.lean
@@ -1,0 +1,78 @@
+/-
+# Cube Root of 2 OQ-05: the n-th root of a prime is irrational
+
+## Open Question
+Generalize the irrationality of ∛2 (and √2) to: for every prime `p` and every degree
+`n ≥ 2`, the real n-th root `p ^ (1/n)` is irrational. The base entry proves the single
+case `p = 2, n = 3`; this entry proves the whole two-parameter family at once.
+
+## Approach
+The engine is Mathlib's `irrational_nrt_of_n_not_dvd_multiplicity`: if `x ^ n = m` (an
+integer) and `n ∤ multiplicity p m`, then `x` is irrational. Take `x = p ^ (1/n)` and
+`m = p`. Then:
+  * `x ^ n = p` because `(p ^ (1/n)) ^ n = p ^ (n⁻¹ · n) = p ^ 1 = p` (real rpow, `p ≥ 0`).
+  * `multiplicity (p:ℤ) (p:ℤ) = 1` (`multiplicity_self`), and `1 % n = 1 ≠ 0` whenever
+    `n ≥ 2`, so `n` does not divide the multiplicity.
+Hence `p ^ (1/n)` is irrational. Specializing `n = 3` recovers ∛p irrational for every
+prime — in particular ∛2, the base entry — and `n = 2` recovers `Nat.Prime.irrational_sqrt`.
+Specializing `p = 2` gives the irrationality of every n-th root of 2.
+
+Mathlib has `Nat.Prime.irrational_sqrt` (square roots only) but no n-th-root analogue;
+this fills that gap.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace CubeRoot2IrrationalOQ05
+
+open Real
+
+/-- **The n-th root of a prime is irrational.** For a prime `p` and any degree `n ≥ 2`,
+`p ^ (1/n)` is not rational. This is the two-parameter generalization of both
+`irrational_sqrt_two` (`p = 2, n = 2`) and the gallery's ∛2 result (`p = 2, n = 3`).
+
+Proof: with `x = p ^ (n⁻¹)` we have `x ^ n = p` (rpow composition, `p ≥ 0`), and
+`multiplicity (p:ℤ) (p:ℤ) = 1` is not divisible by `n ≥ 2`, so
+`irrational_nrt_of_n_not_dvd_multiplicity` applies. -/
+theorem irrational_rpow_inv_prime {p n : ℕ} (hp : p.Prime) (hn : 2 ≤ n) :
+    Irrational ((p : ℝ) ^ ((n : ℝ)⁻¹)) := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hp0 : (0 : ℝ) ≤ (p : ℝ) := by positivity
+  have hn0 : (n : ℝ) ≠ 0 := by positivity
+  -- x ^ n = p, as a real equal to the integer cast of p
+  have hxr : ((p : ℝ) ^ ((n : ℝ)⁻¹)) ^ n = ((p : ℤ) : ℝ) := by
+    rw [← Real.rpow_natCast ((p : ℝ) ^ ((n : ℝ)⁻¹)) n, ← Real.rpow_mul hp0,
+      inv_mul_cancel₀ hn0, Real.rpow_one]
+    push_cast
+    ring
+  -- multiplicity p p = 1, and 1 % n = 1 ≠ 0 since n ≥ 2
+  have hpz : (p : ℤ) ≠ 0 := by exact_mod_cast hp.ne_zero
+  refine irrational_nrt_of_n_not_dvd_multiplicity n hpz p hxr ?_
+  rw [multiplicity_self, Nat.one_mod_eq_one.mpr (by omega)]
+  exact one_ne_zero
+
+/-- **The cube root of a prime is irrational** (`n = 3`). The direct generalization of the
+base entry: ∛p is irrational for every prime `p`, not just `p = 2`. -/
+theorem irrational_cbrt_prime {p : ℕ} (hp : p.Prime) :
+    Irrational ((p : ℝ) ^ ((3 : ℝ)⁻¹)) :=
+  irrational_rpow_inv_prime hp (by norm_num)
+
+/-- **∛2 is irrational** — the base entry recovered as the `p = 2` case of
+`irrational_cbrt_prime`. -/
+theorem irrational_cbrt_two : Irrational ((2 : ℝ) ^ ((3 : ℝ)⁻¹)) := by
+  have := irrational_cbrt_prime (p := 2) (by norm_num)
+  simpa using this
+
+/-- **∛3 is irrational.** -/
+theorem irrational_cbrt_three : Irrational ((3 : ℝ) ^ ((3 : ℝ)⁻¹)) := by
+  have := irrational_cbrt_prime (p := 3) (by norm_num)
+  simpa using this
+
+/-- **Every n-th root of 2 (n ≥ 2) is irrational** — the `p = 2` slice of the family. -/
+theorem irrational_rpow_inv_two {n : ℕ} (hn : 2 ≤ n) :
+    Irrational ((2 : ℝ) ^ ((n : ℝ)⁻¹)) := by
+  have := irrational_rpow_inv_prime (p := 2) (by norm_num) hn
+  simpa using this
+
+end CubeRoot2IrrationalOQ05

--- a/src/data/proofs/cube-root-2-irrational-oq-05/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "cube-root-2-irrational-oq-05",
+  "title": "The n-th Root of a Prime Is Irrational",
+  "slug": "cube-root-2-irrational-oq-05",
+  "description": "For every prime p and every degree n ≥ 2, the real n-th root p^(1/n) is irrational. The two-parameter generalization of the base entry (∛2): one theorem subsumes ∛p for every prime, every n-th root of 2, and (at n = 2) Mathlib's Nat.Prime.irrational_sqrt. Routes through Cardinal-free p-adic multiplicity: irrational_nrt_of_n_not_dvd_multiplicity with multiplicity_self.",
+  "meta": {
+    "author": "classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Nth_root#Irrationality",
+    "date": "antiquity",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "irrationality",
+      "nth-root",
+      "prime",
+      "multiplicity",
+      "real-analysis",
+      "rpow",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CubeRoot2IrrationalOQ05.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "irrational_nrt_of_n_not_dvd_multiplicity",
+        "description": "If x ^ n = m (an integer) and n ∤ multiplicity p m, then x is irrational — the engine for n-th-root irrationality",
+        "module": "Mathlib.NumberTheory.Real.Irrational"
+      },
+      {
+        "theorem": "multiplicity_self",
+        "description": "multiplicity a a = 1 — the p-adic valuation of a prime p at itself is 1, so n ∤ 1 for every n ≥ 2",
+        "module": "Mathlib.RingTheory.Multiplicity"
+      },
+      {
+        "theorem": "Real.rpow_mul",
+        "description": "0 ≤ x → x ^ (y * z) = (x ^ y) ^ z — collapses (p^(1/n))^n to p^(n⁻¹·n) = p^1 = p",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_natCast",
+        "description": "x ^ (n : ℝ) = x ^ n — bridges the monoid power x^n and the real power x^(n:ℝ)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Nat.Prime.irrational_sqrt",
+        "description": "√p is irrational for prime p — the n = 2 case recovered by the general theorem",
+        "module": "Mathlib.NumberTheory.Real.Irrational"
+      }
+    ],
+    "originalContributions": [
+      "irrational_rpow_inv_prime: for prime p and n ≥ 2, p^(1/n) is irrational (main result, two-parameter family)",
+      "irrational_cbrt_prime: ∛p is irrational for every prime p (n = 3 generalization of the base ∛2 entry)",
+      "irrational_cbrt_two: ∛2 irrational, the base entry recovered as p = 2",
+      "irrational_cbrt_three: ∛3 irrational",
+      "irrational_rpow_inv_two: every n-th root of 2 (n ≥ 2) is irrational (p = 2 slice)"
+    ],
+    "dateAdded": "2026-06-19",
+    "lineCount": 78,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The irrationality of √2 is the archetypal impossibility proof of Greek mathematics; the same phenomenon extends to every root of every prime. Theodorus of Cyrene (5th c. BCE) is credited with the irrationality of √3, √5, …, √17, and the general statement — that p^(1/n) is irrational for any prime p and n ≥ 2 — is the natural closure of that programme. In modern terms it is a one-line consequence of unique factorization: if p^(1/n) were a rational a/b, then p·bⁿ = aⁿ would force the exponent of p on both sides to be a multiple of n, contradicting that p contributes exponent 1 on the left. Mathlib packages exactly this counting argument as irrational_nrt_of_n_not_dvd_multiplicity. The base gallery entry handled the single case ∛2; this entry proves the entire two-parameter family.",
+    "problemStatement": "**Open Question (cube-root-2-irrational-oq-05)**: Generalize the irrationality of ∛2 to arbitrary primes and arbitrary root degrees — for every prime p and n ≥ 2, p^(1/n) is irrational.\n\n**Result**: irrational_rpow_inv_prime (p^(1/n) irrational for prime p, n ≥ 2), with specializations irrational_cbrt_prime (∛p for all primes), irrational_cbrt_two / irrational_cbrt_three (∛2, ∛3), and irrational_rpow_inv_two (every n-th root of 2).",
+    "text": "For every prime p and degree n ≥ 2, the n-th root p^(1/n) is irrational — generalizing ∛2 in both the base and the exponent.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Fix a prime p and n ≥ 2, and set x = p^(1/n) (real rpow, well-defined since p ≥ 0).\n2. `irrational_nrt_of_n_not_dvd_multiplicity` reduces irrationality of x to two facts: x^n is an integer, and n does not divide the multiplicity of p in that integer.\n3. **x^n = p**: convert the monoid power to rpow via `Real.rpow_natCast`, combine exponents with `Real.rpow_mul` (needs p ≥ 0), and simplify n⁻¹·n = 1 (`inv_mul_cancel₀`), so (p^(1/n))^n = p^1 = p.\n4. **n ∤ multiplicity**: `multiplicity_self` gives multiplicity (p:ℤ) (p:ℤ) = 1, and 1 % n = 1 ≠ 0 for n ≥ 2 (`Nat.one_mod_eq_one`), so n does not divide it.\n5. The specializations follow by plugging n = 3 (cube roots), p = 2 (roots of two), and `norm_num`/`simpa` to discharge the primality and numeral side goals.",
+    "keyInsights": [
+      "**One counting argument, two parameters.** Irrationality of p^(1/n) is governed entirely by a single divisibility: n must divide the p-adic valuation of the radicand. Since a prime has valuation 1 at itself, and n ≥ 2 never divides 1, every such root is irrational.",
+      "**Subsumes the base entry and Mathlib's square-root lemma.** ∛2 (p = 2, n = 3) is the base gallery entry; √p (n = 2) is `Nat.Prime.irrational_sqrt`. Both are single instances of irrational_rpow_inv_prime.",
+      "**rpow makes the radical algebraic.** Writing the n-th root as the real power p^(n⁻¹) turns 'x^n = p' into the exponent identity n⁻¹·n = 1, so the only analytic input is the homomorphism law `Real.rpow_mul` for nonnegative base.",
+      "**Sharpness.** The hypothesis n ≥ 2 is necessary (n = 1 gives p, rational) and primality can be relaxed to 'p is not a perfect n-th power' — the multiplicity argument is exactly the obstruction."
+    ],
+    "prerequisites": [
+      "p-adic multiplicity / valuation and unique factorization (multiplicity, multiplicity_self)",
+      "The n-th-root irrationality criterion irrational_nrt_of_n_not_dvd_multiplicity",
+      "Real power (rpow) arithmetic: rpow_mul, rpow_natCast for nonnegative base"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring describing the two-parameter generalization of ∛2, the Mathlib import, namespace, and Real open.",
+      "mathContext": "$p^{1/n} \\notin \\mathbb{Q}$ for prime $p$ and $n \\geq 2$."
+    },
+    {
+      "id": "main",
+      "title": "The n-th Root of a Prime",
+      "startLine": 38,
+      "endLine": 60,
+      "summary": "irrational_rpow_inv_prime: for prime p and n ≥ 2, p^(1/n) is irrational — x^n = p via rpow composition, multiplicity (p:ℤ)(p:ℤ) = 1 not divisible by n.",
+      "mathContext": "$\\left(p^{1/n}\\right)^n = p$ and $n \\nmid v_p(p) = 1$."
+    },
+    {
+      "id": "specializations",
+      "title": "Cube Roots and Roots of Two",
+      "startLine": 62,
+      "endLine": 78,
+      "summary": "irrational_cbrt_prime (∛p for all primes), irrational_cbrt_two and irrational_cbrt_three (∛2, ∛3), and irrational_rpow_inv_two (every n-th root of 2).",
+      "mathContext": "$\\sqrt[3]{p}, \\sqrt[3]{2}, \\sqrt[3]{3}, \\sqrt[n]{2} \\notin \\mathbb{Q}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cube-root-2-irrational",
+      "relationship": "extends",
+      "description": "Generalizes the base entry (∛2 irrational, the single case p = 2, n = 3) to all primes p and all degrees n ≥ 2"
+    },
+    {
+      "targetId": "cube-root-3-irrational",
+      "relationship": "related",
+      "description": "∛3 irrational is recovered here as irrational_cbrt_three, an instance of irrational_cbrt_prime"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization that p^(1/n) is irrational for every prime p and every n ≥ 2, unifying ∛2, ∛p, every n-th root of 2, and (at n = 2) Mathlib's Nat.Prime.irrational_sqrt under a single p-adic-multiplicity argument.",
+    "implications": "Closes the natural generalization of the base ∛2 entry. The same multiplicity obstruction shows m^(1/n) is irrational whenever m is not a perfect n-th power, of which the prime case is the cleanest witness.",
+    "openQuestions": [
+      "State and prove the full criterion: m^(1/n) is rational iff m is a perfect n-th power (for m, n ≥ 1).",
+      "Extend to sums such as ∛2 + ∛3 and to irrationality of p^(q) for rational non-integer exponents q."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "CubeRoot2IrrationalOQ05",
+    "lineCount": 78,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CubeRoot2IrrationalOQ05.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Hardy, G. H. and Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "Theorem 44 and surrounding discussion: irrationality of roots via unique factorization"
+    },
+    {
+      "authors": "Niven, Ivan",
+      "title": "Irrational Numbers",
+      "year": "1956",
+      "venue": "Carus Mathematical Monographs, MAA",
+      "note": "Classical treatment of irrationality of n-th roots of integers that are not perfect powers"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Generalizes the base entry (∛2 irrational) in **both parameters**: for every prime `p` and every degree `n ≥ 2`, the real n-th root `p^(1/n)` is irrational. A single theorem subsumes ∛p for all primes, every n-th root of 2, and — at `n = 2` — Mathlib's `Nat.Prime.irrational_sqrt`.

## Results (5 theorems, 0 sorries, 0 axioms)

- `irrational_rpow_inv_prime`: prime `p`, `n ≥ 2` ⟹ `Irrational (p^(1/n))` (main result)
- `irrational_cbrt_prime`: ∛p irrational for **every** prime (the `n = 3` generalization of the base ∛2)
- `irrational_cbrt_two`: ∛2 irrational — the base entry recovered as `p = 2`
- `irrational_cbrt_three`: ∛3 irrational
- `irrational_rpow_inv_two`: every n-th root of 2 (`n ≥ 2`) irrational

## Proof route

Engine: `irrational_nrt_of_n_not_dvd_multiplicity` — if `x^n = m ∈ ℤ` and `n ∤ v_p(m)` then `x` is irrational. With `x = p^(1/n)`, `m = p`:
- `x^n = p`: `Real.rpow_natCast` + `Real.rpow_mul` (p ≥ 0) collapse `(p^(1/n))^n = p^(n⁻¹·n) = p^1 = p`.
- `v_p(p) = 1` (`multiplicity_self`), and `1 % n = 1 ≠ 0` for `n ≥ 2` (`Nat.one_mod_eq_one`), so `n ∤ v_p(p)`.

Mathlib has the square-root case (`Nat.Prime.irrational_sqrt`) but no n-th-root analogue; this fills the gap.

## Verification

- Compiles clean under Mathlib 4.26.0: `lake env lean Proofs/CubeRoot2IrrationalOQ05.lean`
- `#print axioms` on all theorems: `[propext, Classical.choice, Quot.sound]` only — **0 custom axioms**
- Registered in `proofs/Proofs.lean`; gallery `meta.json` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)