### PR TITLE
research(erdos-340-greedy-sidon-oq-01): cubic growth bound + discrete Ω(N^(1/3)) count (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1423,6 +1423,7 @@ import Proofs.Erdos339Aristotle
 import Proofs.Erdos339Problem
 import Proofs.Erdos33Problem
 import Proofs.Erdos340GreedyExtension
+import Proofs.Erdos340GreedyGrowth
 import Proofs.Erdos340GreedySidon
 import Proofs.Erdos340GreedySidonOQ02
 import Proofs.Erdos340Problem

--- a/proofs/Proofs/Erdos340GreedyGrowth.lean
+++ b/proofs/Proofs/Erdos340GreedyGrowth.lean
@@ -1,0 +1,237 @@
+/-
+# Erdős Problem #340 (oq-01): The cubic growth bound for the greedy Sidon sequence
+
+The parent file `Erdos340GreedySidon.lean` **constructs** the greedy (Mian–Chowla)
+Sidon sequence `aₙ` as an explicit `Nat.find` recursion and discharges the three former
+existence axioms.  What remained only as a *comment-level proof sketch* there was the
+**N^(1/3) lower bound** — the quantitative heart of Erdős #340's known direction.
+
+This file formalizes the crux of that sketch: the **global covering argument** giving the
+cubic upper bound on the sequence values,
+
+  `aₙ ≤ (n+1) + (n+1)³`            (`greedySidonSeq_le_cubic`)
+
+which is exactly the bound whose cube-root inversion yields `|A ∩ [1,N]| = Ω(N^(1/3))`.
+
+## The argument
+
+For a Sidon set `A` and a value `m` strictly above every element of `A`, inserting `m`
+breaks the Sidon property **iff** `m = c + d - a` for some `a, c, d ∈ A` (the only
+surviving collision once `m` exceeds `max A`).  Collect these *forbidden* values into
+`forbidden A`; there are at most `|A|³` of them.
+
+The greedy step picks the **least** valid `m`, so every integer `p` skipped between two
+consecutive greedy terms is forbidden against the prefix placed so far — and `forbidden`
+is monotone, so `p` is forbidden against the full set `Aₙ`.  Hence every `p ∈ [1, aₙ]` is
+either an element of `Aₙ` or forbidden against `Aₙ`:
+
+  `aₙ = |[1, aₙ]| ≤ |Aₙ| + |forbidden Aₙ| ≤ (n+1) + (n+1)³`.
+
+The crux necessary lemma (`not_sidon_insert_forbidden`) is the contrapositive of the
+parent's `sidon_insert_of_large`, which already carries the hard 6-way collision case
+analysis — so here it is a one-line `by_contra`.
+
+NOTE on the `1/3`-vs-`1/2` gap: the cubic bound is the *known* result.  Improving the
+exponent past `1/3` for the greedy sequence is the OPEN part of Erdős #340 and is **not**
+attempted here.
+-/
+import Proofs.Erdos340GreedySidon
+
+namespace Erdos340
+
+open Finset
+
+/- ## Forbidden values -/
+
+/-- The **forbidden set** of `A`: all values `c + d - a` with `a, c, d ∈ A`.  When `m`
+exceeds every element of `A`, `insert m A` stays Sidon unless `m` lands in `forbidden A`
+(see `not_sidon_insert_forbidden`). -/
+def forbidden (A : Finset ℕ) : Finset ℕ :=
+  (A ×ˢ A ×ˢ A).image (fun p => p.2.1 + p.2.2 - p.1)
+
+/-- There are at most `|A|³` forbidden values: each is the image of a triple `(a, c, d)`. -/
+theorem forbidden_card_le (A : Finset ℕ) : (forbidden A).card ≤ A.card ^ 3 := by
+  calc (forbidden A).card ≤ (A ×ˢ A ×ˢ A).card := Finset.card_image_le
+    _ = A.card ^ 3 := by rw [Finset.card_product, Finset.card_product]; ring
+
+/-- `forbidden` is monotone: a larger ground set forbids at least as much. -/
+theorem forbidden_mono {A B : Finset ℕ} (h : A ⊆ B) : forbidden A ⊆ forbidden B := by
+  apply Finset.image_subset_image
+  exact Finset.product_subset_product h (Finset.product_subset_product h h)
+
+/-- **Necessary direction** (crux).  If `m` is above every element of the Sidon set `A`
+and `insert m A` is *not* Sidon, then `m` is a forbidden value `c + d - a`.
+
+This is the contrapositive of `sidon_insert_of_large`, which already contains the hard
+case analysis. -/
+theorem not_sidon_insert_forbidden {A : Finset ℕ} (hA : IsSidon A) {m : ℕ}
+    (hm : ∀ a ∈ A, a < m) (hbad : ¬ IsSidon (insert m A)) :
+    m ∈ forbidden A := by
+  by_contra hmem
+  apply hbad
+  apply sidon_insert_of_large hA hm
+  intro a ha c hc d hd heq
+  -- heq : m + a = c + d ;  goal : False  (m + a ≠ c + d)
+  apply hmem
+  rw [forbidden, Finset.mem_image]
+  refine ⟨(a, c, d), ?_, ?_⟩
+  · simp only [Finset.mem_product]
+    exact ⟨ha, hc, hd⟩
+  · show c + d - a = m
+    omega
+
+/- ## Greedy-sequence bookkeeping -/
+
+/-- Every greedy term lies in its own prefix set. -/
+theorem greedySidonSeq_mem (n : ℕ) : greedySidonSeq n ∈ greedySeqSet n := by
+  rw [greedySeqSet_eq_image]
+  exact Finset.mem_image_of_mem _ (Finset.mem_range.mpr (Nat.lt_succ_self n))
+
+/-- `aₙ` is the largest element of the prefix `Aₙ` (the sequence is strictly increasing). -/
+theorem greedySeqSet_le {n x : ℕ} (hx : x ∈ greedySeqSet n) : x ≤ greedySidonSeq n := by
+  rw [greedySeqSet_eq_image, Finset.mem_image] at hx
+  obtain ⟨k, hk, rfl⟩ := hx
+  rw [Finset.mem_range] at hk
+  exact greedySidonSeq_strictMono.monotone (by omega)
+
+/-- The prefix set has exactly `n + 1` elements (strict monotonicity ⇒ injectivity). -/
+theorem greedySeqSet_card (n : ℕ) : (greedySeqSet n).card = n + 1 := by
+  rw [greedySeqSet_eq_image,
+      Finset.card_image_of_injective _ greedySidonSeq_strictMono.injective,
+      Finset.card_range]
+
+/-- Prefixes grow by insertion. -/
+theorem greedySeqSet_subset_succ (n : ℕ) : greedySeqSet n ⊆ greedySeqSet (n + 1) := by
+  have h : greedySeqSet (n + 1)
+      = insert (greedySidonSeq (n + 1)) (greedySeqSet n) := rfl
+  rw [h]
+  exact Finset.subset_insert _ _
+
+/-- **Greedy minimality.**  Any value strictly between consecutive greedy terms was
+*skipped*: inserting it into the prefix would have broken the Sidon property. -/
+theorem greedy_skip_not_sidon {n p : ℕ}
+    (h1 : greedySidonSeq n < p) (h2 : p < greedySidonSeq (n + 1)) :
+    ¬ IsSidon (insert p (greedySeqSet n)) := by
+  classical
+  have hSidon : IsSidon (greedySeqSet n) := greedySeqSet_isSidon n
+  have hex : ∃ m, greedySidonSeq n < m ∧ IsSidon (insert m (greedySeqSet n)) := by
+    obtain ⟨m, hbm, _, hm⟩ := sidon_exists_extension (greedySeqSet n) hSidon (greedySidonSeq n)
+    exact ⟨m, hbm, hm⟩
+  have hnext : greedySidonSeq (n + 1) = nextSidon (greedySeqSet n) (greedySidonSeq n) := rfl
+  have hval : nextSidon (greedySeqSet n) (greedySidonSeq n) = Nat.find hex := by
+    unfold nextSidon; exact dif_pos hex
+  rw [hnext, hval] at h2
+  have hmin := Nat.find_min hex h2
+  push_neg at hmin
+  exact hmin h1
+
+/- ## The covering bound -/
+
+/-- **Global covering.**  Every integer `p ∈ [1, aₙ]` is either a greedy element or a
+forbidden value against the *full* prefix `Aₙ`. -/
+theorem greedy_covering (n : ℕ) :
+    ∀ p, 1 ≤ p → p ≤ greedySidonSeq n →
+      p ∈ greedySeqSet n ∨ p ∈ forbidden (greedySeqSet n) := by
+  induction n with
+  | zero =>
+    intro p hp1 hp2
+    have h0 : greedySidonSeq 0 = 1 := rfl
+    rw [h0] at hp2
+    have hp : p = 1 := by omega
+    left
+    have hset : greedySeqSet 0 = {1} := rfl
+    rw [hp, hset]
+    exact Finset.mem_singleton_self 1
+  | succ n ih =>
+    intro p hp1 hp2
+    by_cases hle : p ≤ greedySidonSeq n
+    · rcases ih p hp1 hle with hin | hforb
+      · exact Or.inl (greedySeqSet_subset_succ n hin)
+      · exact Or.inr (forbidden_mono (greedySeqSet_subset_succ n) hforb)
+    · push_neg at hle
+      by_cases hpeq : p = greedySidonSeq (n + 1)
+      · left
+        rw [hpeq]
+        exact greedySidonSeq_mem (n + 1)
+      · have hlt : p < greedySidonSeq (n + 1) := lt_of_le_of_ne hp2 hpeq
+        have hnotsidon := greedy_skip_not_sidon hle hlt
+        right
+        have hmem : p ∈ forbidden (greedySeqSet n) := by
+          apply not_sidon_insert_forbidden (greedySeqSet_isSidon n) ?_ hnotsidon
+          intro a ha
+          exact lt_of_le_of_lt (greedySeqSet_le ha) hle
+        exact forbidden_mono (greedySeqSet_subset_succ n) hmem
+
+/-- **Cubic growth bound.**  The `n`-th greedy Sidon term satisfies `aₙ ≤ (n+1) + (n+1)³`.
+
+This is the quantitative crux of the known `N^(1/3)` lower bound for Erdős #340: the
+greedy sequence cannot grow faster than cubically, because every value it skips is one of
+at most `|Aₙ|³ = (n+1)³` forbidden differences against the placed prefix. -/
+theorem greedySidonSeq_le_cubic (n : ℕ) :
+    greedySidonSeq n ≤ (n + 1) + (n + 1) ^ 3 := by
+  have hcover : Finset.Icc 1 (greedySidonSeq n)
+      ⊆ greedySeqSet n ∪ forbidden (greedySeqSet n) := by
+    intro p hp
+    rw [Finset.mem_Icc] at hp
+    rw [Finset.mem_union]
+    exact greedy_covering n p hp.1 hp.2
+  have hcard := Finset.card_le_card hcover
+  rw [Nat.card_Icc] at hcard
+  have hunion : (greedySeqSet n ∪ forbidden (greedySeqSet n)).card
+      ≤ (greedySeqSet n).card + (forbidden (greedySeqSet n)).card :=
+    Finset.card_union_le _ _
+  have hsetcard : (greedySeqSet n).card = n + 1 := greedySeqSet_card n
+  have hforbcard : (forbidden (greedySeqSet n)).card ≤ (n + 1) ^ 3 := by
+    calc (forbidden (greedySeqSet n)).card ≤ (greedySeqSet n).card ^ 3 := forbidden_card_le _
+      _ = (n + 1) ^ 3 := by rw [hsetcard]
+  omega
+
+/- ## Cube-root inversion: the discrete `Ω(N^(1/3))` count -/
+
+/-- Every greedy term is positive (`a₀ = 1` is the minimum). -/
+theorem one_le_greedySidonSeq (k : ℕ) : 1 ≤ greedySidonSeq k := by
+  have hmono : greedySidonSeq 0 ≤ greedySidonSeq k :=
+    greedySidonSeq_strictMono.monotone (Nat.zero_le k)
+  have h0 : greedySidonSeq 0 = 1 := rfl
+  omega
+
+/-- Cleaner cubic bound: `aₙ ≤ 2(n+1)³`, absorbing the linear term. -/
+theorem greedySidonSeq_le_two_mul_cubic (n : ℕ) :
+    greedySidonSeq n ≤ 2 * (n + 1) ^ 3 := by
+  have h := greedySidonSeq_le_cubic n
+  have hle : n + 1 ≤ (n + 1) ^ 3 := Nat.le_self_pow (by norm_num) (n + 1)
+  omega
+
+/-- The first `n+1` greedy terms all lie inside the window `[1, 2(n+1)³]`. -/
+theorem greedySeqSet_subset_Icc (n : ℕ) :
+    greedySeqSet n ⊆ Finset.Icc 1 (2 * (n + 1) ^ 3) := by
+  intro x hx
+  rw [Finset.mem_Icc]
+  refine ⟨?_, le_trans (greedySeqSet_le hx) (greedySidonSeq_le_two_mul_cubic n)⟩
+  rw [greedySeqSet_eq_image, Finset.mem_image] at hx
+  obtain ⟨k, _, rfl⟩ := hx
+  exact one_le_greedySidonSeq k
+
+/-- **Discrete `Ω(N^(1/3))` lower bound for the greedy Sidon counting function.**
+
+Whenever `N ≥ 2(n+1)³`, at least `n+1` of the integers in `[1, N]` are greedy Sidon
+terms.  Reading it the other way: the count `A(N)` of greedy terms `≤ N` satisfies
+`A(N) ≥ k` as soon as `N ≥ 2k³`, i.e. `A(N) ≥ ⌊(N/2)^{1/3}⌋ = Ω(N^{1/3})`.
+
+This is the known lower-bound direction of Erdős #340, now an elementary, fully verified
+counting statement (no `rpow`, no axiom).  The `1/3`→`1/2` exponent improvement remains
+the OPEN conjecture and is not addressed here. -/
+theorem greedy_count_ge {n N : ℕ} (hN : 2 * (n + 1) ^ 3 ≤ N) :
+    n + 1 ≤ ((Finset.Icc 1 N).filter (fun x => x ∈ greedySeqSet n)).card := by
+  have hsub : greedySeqSet n
+      ⊆ (Finset.Icc 1 N).filter (fun x => x ∈ greedySeqSet n) := by
+    intro x hx
+    rw [Finset.mem_filter]
+    refine ⟨?_, hx⟩
+    have hwin := greedySeqSet_subset_Icc n hx
+    rw [Finset.mem_Icc] at hwin ⊢
+    omega
+  calc n + 1 = (greedySeqSet n).card := (greedySeqSet_card n).symm
+    _ ≤ _ := Finset.card_le_card hsub
+
+end Erdos340

--- a/research/problems/erdos-340-greedy-sidon-oq-01/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-01/knowledge.md
@@ -1,0 +1,54 @@
+# erdos-340-greedy-sidon-oq-01 — Prove the N^(1/3) greedy growth bound rigorously
+
+## Summary
+
+The greedy (Mian–Chowla) Sidon sequence `aₙ` is **constructed** in
+`proofs/Proofs/Erdos340GreedySidon.lean` (explicit `Nat.find` recursion; the three former
+existence axioms are discharged). The known **N^(1/3)** lower bound existed there only as a
+comment-level proof sketch. This OQ formalizes it.
+
+**Status (2026-06-19): the cubic growth bound and the discrete Ω(N^(1/3)) count are PROVED,
+verified, 0-axiom**, in the new companion `proofs/Proofs/Erdos340GreedyGrowth.lean`.
+
+## Session 2026-06-19 (REVISIT) — cubic bound + cube-root inversion
+
+**Mode**: REVISIT (pool of `available` candidates was 100% already-shipped duplicates;
+picked this RICH-knowledge surveyed open problem instead).
+**Outcome**: progress — major lemma chain proved.
+
+### What I Did
+- Created `proofs/Proofs/Erdos340GreedyGrowth.lean` and registered it in `Proofs.lean`.
+- Proved (all VERIFIED, axioms = [propext, Classical.choice, Quot.sound] only):
+  - `forbidden A` set + `forbidden_card_le : (forbidden A).card ≤ A.card ^ 3` + `forbidden_mono`.
+  - `not_sidon_insert_forbidden` — the crux necessary direction.
+  - `greedy_skip_not_sidon` — greedy minimality via `Nat.find_min`.
+  - `greedy_covering` — induction: every `p ∈ [1, aₙ]` is in `Aₙ` or `forbidden Aₙ`.
+  - `greedySidonSeq_le_cubic : aₙ ≤ (n+1) + (n+1)³` — the cubic growth bound.
+  - `greedySidonSeq_le_two_mul_cubic : aₙ ≤ 2(n+1)³`, `greedySeqSet_subset_Icc`.
+  - `greedy_count_ge` — for `N ≥ 2(n+1)³`, at least `n+1` greedy terms lie in `[1, N]`
+    (the discrete Ω(N^(1/3)) lower bound; no `rpow`).
+
+### Key Findings
+- The crux lemma that prior sessions flagged as the genuinely-technical Aristotle target
+  is actually a **one-line contrapositive** of the parent's `sidon_insert_of_large`
+  (line 408), which already encodes the hard 6-way collision case analysis.
+- The global covering argument is cleanest as a single induction on `n` of the
+  `∀ p ∈ [1, aₙ]` statement; the skipped-value/min-index bookkeeping falls out of the
+  successor case automatically (IH + monotonicity for `p ≤ aₙ`; `Nat.find_min` for the gap).
+- Defeq handles `greedySeqSet (n+1) = insert (greedySidonSeq (n+1)) (greedySeqSet n)` and
+  `greedySidonSeq (n+1) = nextSidon (greedySeqSet n) (greedySidonSeq n)` (both `rfl`).
+
+### Files Modified
+- `proofs/Proofs/Erdos340GreedyGrowth.lean` (new, ~210 lines, 0-axiom)
+- `proofs/Proofs.lean` (import)
+- `src/data/research/problems/erdos-340-greedy-sidon-oq-01.json` (knowledge)
+
+### Next Steps
+- Optional analytic `rpow` phrasing of `greedy_count_ge`.
+- The axiom `greedy_sidon_lower_bound` in the *separate* `Erdos340Problem.lean` uses a
+  disconnected `sInf`-based `greedySidon`; discharging it needs bridging the two definitions.
+- Remaining axiom in the parent: Erdős–Turán upper bound `sidon_upper_bound`.
+
+### Honesty note
+This is the **known** lower-bound direction (cubic ⇒ N^(1/3)). The 1/3→1/2 exponent
+improvement is the OPEN part of Erdős #340 and is NOT addressed.

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-01.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-01.json
@@ -1,0 +1,91 @@
+{
+  "slug": "erdos-340-greedy-sidon-oq-01",
+  "title": "Prove the N^(1/3) greedy growth bound rigorously (currently axiomatized)",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: seeker-selected 2026-06-15.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-06-15T19:32:03.152Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS (verified, 0-axiom): the cubic growth bound aₙ ≤ (n+1)+(n+1)³ (greedySidonSeq_le_cubic) and the discrete Ω(N^(1/3)) count lower bound (greedy_count_ge) are now PROVED in Erdos340GreedyGrowth.lean — the quantitative crux of Erdős #340 known direction, previously only a comment-level sketch in the parent. The crux necessary lemma turned out to be a one-line contrapositive of the parent sidon_insert_of_large.",
+    "builtItems": [
+      "Turnkey BUILD-PENDING draft: research/problems/erdos-340-greedy-sidon-oq-01/construction-draft.lean — forbidden set + forbidden_card_le (≤|A|^3) + forbidden_mono with real proofs; crux/existence/gSet recursion/covering/inversion/parent-axiom-rebuild as structured statements with sorry+precise proof comments. Only mem_forbidden_of_not_sidon_insert is genuinely technical (Aristotle target); rest is induction+omega+card arithmetic.",
+      "PR #24965 (research label): corrected parent inline sketch O(n^2)→O(n^3) with covering argument + the 1/3-vs-1/2 OPEN-conjecture distinction. Comment-only, build-neutral.",
+      "proofs/Proofs/Erdos340GreedyGrowth.lean: greedySidonSeq_le_cubic (aₙ ≤ (n+1)+(n+1)³) — VERIFIED 0-axiom, the global forbidden-set covering bound that was previously only a comment in the parent.",
+      "Erdos340GreedyGrowth.lean: greedy_count_ge — for N ≥ 2(n+1)³, at least n+1 greedy terms lie in [1,N]; the discrete Ω(N^(1/3)) lower bound (no rpow, no axiom).",
+      "Erdos340GreedyGrowth.lean supporting verified lemmas: forbidden (def) + forbidden_card_le (≤ |A|³) + forbidden_mono + not_sidon_insert_forbidden (crux) + greedy_covering (induction) + greedy_skip_not_sidon (Nat.find minimality) + greedySeqSet_card/greedySeqSet_le/greedySeqSet_subset_Icc/greedySidonSeq_le_two_mul_cubic/one_le_greedySidonSeq."
+    ],
+    "insights": [
+      "StrictMono + IsSidon do NOT imply N^(1/3) growth: counterexample a_n=2^n is Sidon, strictly increasing, but counting function is only log2(N). So the growth axiom is independent of the other three greedySidonSeq axioms and unprovable for the opaque object.",
+      "Correct greedy worst-case is CUBIC a_n=O(n^3) (forbidden values m=a_i+a_j-a_l number <= k^3), giving N^(1/3). The parent files inline sketch claims O(n^2) (line 435) which is wrong and would falsely yield N^(1/2).",
+      "The 1/3-vs-1/2 exponent gap IS Erdos #340 (OPEN); the file conflates them. This OQ targets only the provable 1/3 lower bound.",
+      "Parent CanAddProp (line 391) = n notin A and IsSidon(A cup {n}) is exactly the greedy-step predicate, reusable for the construction.",
+      "The crux of the whole construction is a SINGLE case-analysis lemma: for Sidon A and m>max A, ¬IsSidon(insert m A) ⟹ m=b+c-a for some a,b,c∈A. Sorting both summand-pairs, the only surviving collision is w+m=y+z (m used once); 2m=y+z is impossible (<2m) and equal-multiplicity cases reduce to A being Sidon. Existence-of-next is just its contrapositive.",
+      "WARNING: the naive INCREMENTAL gap bound a_{k+1}-a_k ≤ |A_k|^3 only telescopes to a_n=O(n^4) ⟹ N^(1/4). The cubic a_n=O(n^3) ⟹ N^(1/3) REQUIRES the GLOBAL covering argument: every p∈[1,a_n] is in A_n or forbidden(A_n) using the FULL final set A_n (each skipped p broke Sidon against a subset of A_n; forbidden is monotone). Then a_n ≤ |A_n|+|forbidden A_n| ≤ (n+1)+(n+1)^3.",
+      "KEY SIMPLIFICATION: the crux mem_forbidden_of_not_sidon_insert (flagged by prior sessions as the genuinely-technical Aristotle target) is a ONE-LINE contrapositive of the parent sidon_insert_of_large — that lemma already carries the hard 6-way collision case analysis, so the necessary direction needs no new case work.",
+      "The global covering is cleanest as plain induction on n of: ∀ p∈[1,aₙ], p ∈ Aₙ ∨ p ∈ forbidden(Aₙ). The min-index / skipped-value bookkeeping is handled automatically by the successor case: p≤aₙ → IH + monotone lift; p=a_{n+1} → ∈A; aₙ<p<a_{n+1} → skipped, so Nat.find_min gives ¬IsSidon(insert p Aₙ) → forbidden.",
+      "Defeq facts that make it go through: greedySeqSet (n+1) = insert (greedySidonSeq (n+1)) (greedySeqSet n) by rfl, and greedySidonSeq (n+1) = nextSidon (greedySeqSet n) (greedySidonSeq n) by rfl — the latter exposes Nat.find for the minimality argument."
+    ],
+    "mathlibGaps": [
+      "No foundational Mathlib gap: the N^(1/3) bound is elementary Finset/Nat counting on top of the parents IsSidon API. Blocker is the missing local greedy construction, not Mathlib."
+    ],
+    "nextSteps": [
+      "Optional rpow inversion: bridge greedy_count_ge (discrete cube form, N ≥ 2k³ ⇒ count ≥ k) to the rpow statement ∃C>0, ∀N>0, C·N^(1/3) ≤ count, if the gallery wants the analytic phrasing.",
+      "NOTE: axiom greedy_sidon_lower_bound lives in the SEPARATE Erdos340Problem.lean (sInf-based greedySidon with axiomatized initial values), disconnected from the constructed Nat.find sequence proved here. Full discharge would need bridging the two definitions, or the entry adopting the constructed sequence as canonical.",
+      "Remaining axiom in Erdos340GreedySidon.lean is the Erdős–Turán upper bound sidon_upper_bound (|A| ≤ √N + O(N^(1/4)))."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "combinatorics",
+    "sidon-sets",
+    "greedy-algorithms",
+    "additive-combinatorics",
+    "erdos",
+    "infrastructure",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "erdos-3",
+    "erdos-34",
+    "erdos-340",
+    "erdos-340-greedy-sidon"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-16T04:40:01.684Z",
+  "lastUpdate": "2026-06-19",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    "proofs/Proofs/Erdos340GreedyGrowth.lean",
+    "proofs/Proofs/Erdos340GreedySidon.lean"
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes the **known N^(1/3) lower-bound direction** of Erdős Problem #340 (greedy /
Mian–Chowla Sidon sequence). This bound existed in `Erdos340GreedySidon.lean` only as a
**comment-level proof sketch**; this PR turns it into verified theorems.

New companion file `proofs/Proofs/Erdos340GreedyGrowth.lean` (all **0-axiom**,
`#print axioms = [propext, Classical.choice, Quot.sound]`):

| Theorem | Statement |
|---|---|
| `forbidden_card_le` | `(forbidden A).card ≤ A.card ^ 3` |
| `not_sidon_insert_forbidden` | crux: `m > max A`, `¬IsSidon (insert m A)` ⇒ `m = c+d−a` for `a,c,d ∈ A` |
| `greedy_skip_not_sidon` | greedy minimality (`Nat.find_min`): a skipped value breaks Sidon |
| `greedy_covering` | every `p ∈ [1, aₙ]` is in `Aₙ` or `forbidden Aₙ` |
| `greedySidonSeq_le_cubic` | **`aₙ ≤ (n+1) + (n+1)³`** (the cubic growth bound) |
| `greedy_count_ge` | for `N ≥ 2(n+1)³`, at least `n+1` greedy terms lie in `[1, N]` — discrete `Ω(N^(1/3))` |

## Key point

The crux lemma that prior sessions flagged as the *genuinely technical* part (an Aristotle
target) turns out to be a **one-line contrapositive** of the parent's existing
`sidon_insert_of_large`, which already carries the hard 6-way collision case analysis. The
global covering then goes through as a single clean induction on `n`.

## Honesty

This is the **known** direction (cubic ⇒ N^(1/3)). The 1/3→1/2 exponent improvement is the
**OPEN** part of Erdős #340 and is *not* addressed. The pre-existing axiom
`greedy_sidon_lower_bound` lives in the separate `Erdos340Problem.lean` over a disconnected
`sInf`-based definition, so it is not directly discharged here; see the knowledge file for
the bridging note.

## Verification

`lake env lean Proofs/Erdos340GreedyGrowth.lean` → exit 0, no errors/warnings/sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)