### PR TITLE
research(combinations-formula-oq-09): first & second moments of a Pascal row (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -597,6 +597,7 @@ import Proofs.CombinationsFormulaOQ02Aristotle
 import Proofs.CombinationsFormulaOQ03
 import Proofs.CombinationsFormulaOQ03OQ06
 import Proofs.CombinationsFormulaOQ06
+import Proofs.CombinationsFormulaOQ09
 import Proofs.ComplexityCore
 import Proofs.ContinuumHypothesis
 import Proofs.ContinuumHypothesisOQ01

--- a/proofs/Proofs/CombinationsFormulaOQ09.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ09.lean
@@ -1,0 +1,122 @@
+import Mathlib
+
+/-
+# Weighted Binomial Sums: the First and Second Moments of a Row of Pascal's Triangle
+
+## Open Question OQ-09
+
+The row-sum identity `∑_{k=0}^{n} C(n,k) = 2ⁿ` and the alternating-sum identity
+`∑_{k=0}^{n} (-1)ᵏ C(n,k) = 0` are already in the gallery.  This file proves the
+two *weighted* companions — the first and second moments of a binomial row:
+
+1. `sum_range_mul_choose` — the first moment
+        ∑_{k=0}^{n} k · C(n,k) = n · 2ⁿ⁻¹ .
+
+2. `sum_range_sq_mul_choose` — the second moment
+        ∑_{k=0}^{n} k² · C(n,k) = n · (n+1) · 2ⁿ⁻² .
+
+Probabilistically these say that a `Binomial(n, ½)` variable has mean `n/2`
+(divide the first identity by `2ⁿ`) and second moment `n(n+1)/4`, hence variance
+`n/4`.  Combinatorially, `∑ k·C(n,k)` counts the pairs *(committee, chair)* drawn
+from `n` people: choose the chair `n` ways, then any subset of the rest, giving
+`n·2ⁿ⁻¹`.
+
+## Method
+
+Everything reduces to Mathlib's **absorption identity** `Nat.succ_mul_choose_eq`,
+
+        (n+1) · C(n,k) = C(n+1, k+1) · (k+1),
+
+which we repackage as `absorb : (k+1) · C(n+1, k+1) = (n+1) · C(n,k)`.  Peeling the
+`k = 0` term with `Finset.sum_range_succ'` and applying `absorb` turns a weighted
+sum over row `n+1` into `(n+1)` times an *un*weighted sum over row `n`, which
+`Nat.sum_range_choose` evaluates to `2ⁿ`.  The second moment writes `k² = k·k`,
+applies `absorb` once, and then reuses the first-moment identity together with the
+row sum.  Stating the lemmas in the shifted forms `n+2` / `n+3` keeps everything
+inside ℕ with no truncated subtraction; the classic `n·2ⁿ⁻¹` / `n(n+1)·2ⁿ⁻²`
+statements are recovered as corollaries.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ09
+
+open Finset
+
+/-- **Absorption identity (repackaged).**
+    `(k+1) · C(n+1, k+1) = (n+1) · C(n, k)` — pull a factor `k+1` out of a binomial
+    coefficient and trade it for the row index `n+1`.  This is
+    `Nat.add_one_mul_choose_eq` with the two sides commuted. -/
+theorem absorb (n k : ℕ) :
+    (k + 1) * (n + 1).choose (k + 1) = (n + 1) * n.choose k := by
+  rw [Nat.add_one_mul_choose_eq]; ring
+
+-- ============================================================
+-- First moment
+-- ============================================================
+
+/-- **First moment (shifted form).**
+    `∑_{k=0}^{n+1} k · C(n+1, k) = (n+1) · 2ⁿ`. -/
+theorem sum_range_succ_mul_choose (n : ℕ) :
+    ∑ k ∈ range (n + 2), k * (n + 1).choose k = (n + 1) * 2 ^ n := by
+  rw [Finset.sum_range_succ' (fun k => k * (n + 1).choose k) (n + 1)]
+  simp only [zero_mul, add_zero]
+  rw [Finset.sum_congr rfl (fun k _ => absorb n k), ← Finset.mul_sum,
+      Nat.sum_range_choose]
+
+/-- **First moment of a binomial row.**
+    `∑_{k=0}^{n} k · C(n,k) = n · 2ⁿ⁻¹`. -/
+theorem sum_range_mul_choose (n : ℕ) :
+    ∑ k ∈ range (n + 1), k * n.choose k = n * 2 ^ (n - 1) := by
+  cases n with
+  | zero => simp
+  | succ m => simpa using sum_range_succ_mul_choose m
+
+-- ============================================================
+-- Second moment
+-- ============================================================
+
+/-- **Second moment (shifted form).**
+    `∑_{k=0}^{n+2} k² · C(n+2, k) = (n+2)·(n+3) · 2ⁿ`. -/
+theorem sum_range_succ_succ_sq_mul_choose (n : ℕ) :
+    ∑ k ∈ range (n + 3), k ^ 2 * (n + 2).choose k = (n + 2) * (n + 3) * 2 ^ n := by
+  rw [Finset.sum_range_succ' (fun k => k ^ 2 * (n + 2).choose k) (n + 2)]
+  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, zero_mul, add_zero]
+  -- ∑ k ∈ range (n+2), (k+1)² · C(n+2, k+1) = (n+2)·(n+3)·2ⁿ
+  have hterm : ∀ k ∈ range (n + 2),
+      (k + 1) ^ 2 * (n + 2).choose (k + 1) = (n + 2) * ((k + 1) * (n + 1).choose k) := by
+    intro k _
+    have hab : (k + 1) * (n + 2).choose (k + 1) = (n + 2) * (n + 1).choose k := absorb (n + 1) k
+    rw [pow_two, mul_assoc, hab]; ring
+  rw [Finset.sum_congr rfl hterm, ← Finset.mul_sum]
+  -- (n+2) · ∑ (k+1)·C(n+1,k) = (n+2)·(n+3)·2ⁿ
+  have hsplit : ∑ k ∈ range (n + 2), (k + 1) * (n + 1).choose k
+      = (∑ k ∈ range (n + 2), k * (n + 1).choose k)
+        + ∑ k ∈ range (n + 2), (n + 1).choose k := by
+    rw [← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl (fun k _ => by ring)
+  rw [hsplit, sum_range_succ_mul_choose, Nat.sum_range_choose]
+  ring
+
+/-- **Second moment of a binomial row.**
+    `∑_{k=0}^{n} k² · C(n,k) = n · (n+1) · 2ⁿ⁻²`  (for `n ≥ 2`). -/
+theorem sum_range_sq_mul_choose (n : ℕ) (hn : 2 ≤ n) :
+    ∑ k ∈ range (n + 1), k ^ 2 * n.choose k = n * (n + 1) * 2 ^ (n - 2) := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le hn
+  have e : 2 + m - 2 = m := by omega
+  have e2 : 2 + m + 1 = m + 3 := by omega
+  have e3 : 2 + m = m + 2 := by omega
+  rw [e, e3]
+  simpa [e2] using sum_range_succ_succ_sq_mul_choose m
+
+-- ============================================================
+-- Sanity checks
+-- ============================================================
+
+/-- `∑ k·C(4,k) = 0+4+24+48+32 = 4·2³ = 32`. -/
+example : ∑ k ∈ range 5, k * (4 : ℕ).choose k = 4 * 2 ^ 3 := by decide
+
+/-- `∑ k²·C(4,k) = 0+4+48+144+128 = 4·5·2² = 80`. -/
+example : ∑ k ∈ range 5, k ^ 2 * (4 : ℕ).choose k = 4 * 5 * 2 ^ 2 := by decide
+
+end CombinationsFormulaOQ09

--- a/src/data/proofs/combinations-formula-oq-09/meta.json
+++ b/src/data/proofs/combinations-formula-oq-09/meta.json
@@ -1,0 +1,109 @@
+{
+  "id": "combinations-formula-oq-09",
+  "title": "Weighted Binomial Sums: First and Second Moments of a Pascal Row",
+  "slug": "combinations-formula-oq-09",
+  "description": "Formalizes the two weighted companions of the binomial row-sum identity: the first moment ∑_{k=0}^{n} k·C(n,k) = n·2^{n-1} and the second moment ∑_{k=0}^{n} k²·C(n,k) = n·(n+1)·2^{n-2}. Both reduce to Mathlib's absorption identity (n+1)·C(n,k) = C(n+1,k+1)·(k+1), repackaged as a one-step 'pull out k+1' lemma, together with the row sum ∑ C(n,k) = 2^n.",
+  "meta": {
+    "author": "Lean Genius researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ09.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 122,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "None. All identities hold for every natural number argument (the second moment is stated for n ≥ 2 so that 2^{n-2} is meaningful) and are fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "weighted-sums",
+      "binomial-moments",
+      "absorption-identity",
+      "finset-sums"
+    ],
+    "dateAdded": "2026-06-19",
+    "originalContributions": [
+      "absorb: the absorption identity repackaged as (k+1)·C(n+1,k+1) = (n+1)·C(n,k), the single workhorse for both moments",
+      "sum_range_mul_choose: the first moment ∑_{k=0}^{n} k·C(n,k) = n·2^{n-1}, with the no-subtraction shifted form sum_range_succ_mul_choose: ∑_{k=0}^{n+1} k·C(n+1,k) = (n+1)·2^n",
+      "sum_range_sq_mul_choose: the second moment ∑_{k=0}^{n} k²·C(n,k) = n·(n+1)·2^{n-2}, with the shifted form sum_range_succ_succ_sq_mul_choose: ∑_{k=0}^{n+2} k²·C(n+2,k) = (n+2)·(n+3)·2^n",
+      "Worked verifications: ∑ k·C(4,k) = 32 = 4·2³ and ∑ k²·C(4,k) = 80 = 4·5·2²"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ09.lean",
+    "namespace": "CombinationsFormulaOQ09",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 122,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The weighted binomial sums ∑ k·C(n,k) = n·2^{n-1} and ∑ k²·C(n,k) = n(n+1)·2^{n-2} are the first and second factorial-adjusted moments of a row of Pascal's triangle. Divided by 2^n they give the mean (n/2) and second moment (n(n+1)/4) of a Binomial(n, ½) random variable, whence its variance n/4. They are classical companions to the row sum ∑ C(n,k) = 2^n and the alternating sum ∑ (-1)^k C(n,k) = 0, obtained by differentiating the binomial theorem (1+x)^n and evaluating derivatives at x = 1.",
+    "problemStatement": "Open Question OQ-09: the gallery already has the binomial row sum (2^n) and alternating sum (0). Formalize their weighted companions — the first moment ∑_{k=0}^{n} k·C(n,k) = n·2^{n-1} and the second moment ∑_{k=0}^{n} k²·C(n,k) = n·(n+1)·2^{n-2} — entirely within ℕ.",
+    "proofStrategy": "Repackage Mathlib's absorption identity Nat.add_one_mul_choose_eq, (n+1)·C(n,k) = C(n+1,k+1)·(k+1), as absorb: (k+1)·C(n+1,k+1) = (n+1)·C(n,k). For the first moment, peel the k=0 term of ∑_{k=0}^{n+1} k·C(n+1,k) with Finset.sum_range_succ' (it vanishes), apply absorb termwise to convert the weighted row-(n+1) sum into (n+1)·∑ C(n,k), and finish with Nat.sum_range_choose = 2^n. For the second moment, write k² = k·k, apply absorb once so that (k+1)²·C(n+2,k+1) = (n+2)·((k+1)·C(n+1,k)), factor out (n+2), split (k+1)·C(n+1,k) = k·C(n+1,k) + C(n+1,k), and reuse the first-moment identity together with the row sum. Working in the shifted forms n+1 / n+2 keeps every quantity in ℕ with no truncated subtraction; the classic n·2^{n-1} and n(n+1)·2^{n-2} statements follow by a case split / a single index substitution.",
+    "keyInsights": [
+      "A single repackaging of the absorption identity — absorb: (k+1)·C(n+1,k+1) = (n+1)·C(n,k) — drives both moments; no generating functions or real analysis are needed.",
+      "Peeling the k=0 term with Finset.sum_range_succ' is exactly what makes the index shift k ↦ k+1 align with absorption, since absorption naturally produces a (k+1) factor.",
+      "The second moment never needs a fresh argument: after one application of absorb, k²·C reduces to a (k+1)-weighted row sum, which splits into the already-proven first moment plus the row sum.",
+      "Stating the workhorse lemmas in shifted form (∑ over range(n+2), range(n+3)) avoids ℕ-subtraction entirely; the familiar 2^{n-1}, 2^{n-2} forms are recovered only at the very end."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Header stating OQ-09: the first and second moments of a binomial row, their probabilistic meaning (mean n/2, variance n/4 of Binomial(n,½)), and the absorption-identity method."
+    },
+    {
+      "id": "absorb",
+      "title": "Absorption Identity",
+      "startLine": 46,
+      "endLine": 57,
+      "summary": "absorb: (k+1)·C(n+1,k+1) = (n+1)·C(n,k), Mathlib's Nat.add_one_mul_choose_eq with sides commuted — the single workhorse for both moments."
+    },
+    {
+      "id": "first-moment",
+      "title": "First Moment",
+      "startLine": 59,
+      "endLine": 78,
+      "summary": "sum_range_succ_mul_choose: ∑_{k≤n+1} k·C(n+1,k) = (n+1)·2^n (peel k=0, apply absorb, sum_range_choose); sum_range_mul_choose: the classic ∑_{k≤n} k·C(n,k) = n·2^{n-1}."
+    },
+    {
+      "id": "second-moment",
+      "title": "Second Moment",
+      "startLine": 80,
+      "endLine": 116,
+      "summary": "sum_range_succ_succ_sq_mul_choose: ∑_{k≤n+2} k²·C(n+2,k) = (n+2)(n+3)·2^n (k²=k·k, one absorption, split into first moment + row sum); sum_range_sq_mul_choose: the classic ∑_{k≤n} k²·C(n,k) = n(n+1)·2^{n-2} for n ≥ 2."
+    },
+    {
+      "id": "checks",
+      "title": "Sanity Checks",
+      "startLine": 118,
+      "endLine": 122,
+      "summary": "Worked numerical verifications at n = 4: ∑ k·C(4,k) = 32 = 4·2³ and ∑ k²·C(4,k) = 80 = 4·5·2²."
+    }
+  ],
+  "conclusion": {
+    "summary": "5 theorems, 0 sorries, 0 axioms. The first and second moments of a binomial row — ∑ k·C(n,k) = n·2^{n-1} and ∑ k²·C(n,k) = n(n+1)·2^{n-2} — are formalized in ℕ, each reduced to a single repackaging of Mathlib's absorption identity plus the row sum ∑ C(n,k) = 2^n.",
+    "implications": "These complete the elementary suite of binomial row identities (row sum, alternating sum, now the first two moments) and supply the mean and variance of Binomial(n, ½) by pure combinatorial manipulation. The absorb lemma and the peel-then-absorb pattern generalize directly: each further factorial moment ∑ k^{(j)}·C(n,k) follows by j applications of absorption, reducing to lower moments already proved.",
+    "openQuestions": [
+      "Does the same peel-then-absorb pattern give the general factorial moment ∑_{k} k·(k-1)···(k-j+1)·C(n,k) = n·(n-1)···(n-j+1)·2^{n-j} by induction on j?",
+      "Can these row moments be obtained instead from Mathlib's binomial theorem by formal differentiation of (1+x)^n, and do the two derivations agree definitionally?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-01",
+      "relationship": "sibling — provides the row sum ∑ C(n,k) = 2^n and alternating sum ∑ (-1)^k C(n,k) = 0 that these moments complement"
+    },
+    {
+      "targetId": "combinations-formula-oq-02",
+      "relationship": "ancestor — the core combinations formula entry providing binomial coefficient context"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds the **weighted companions** of the binomial row-sum and alternating-sum identities already in the gallery (`combinations-formula-oq-01`):

| identity | value |
|---|---|
| first moment  | ∑_{k=0}^{n} k·C(n,k)  = n·2^{n-1} |
| second moment | ∑_{k=0}^{n} k²·C(n,k) = n·(n+1)·2^{n-2}  (n ≥ 2) |

Divided by 2^n these are the mean (n/2) and second moment (n(n+1)/4) of a `Binomial(n, ½)` variable, hence variance n/4.

## Method

A single repackaging of Mathlib's absorption identity `Nat.add_one_mul_choose_eq` drives everything:

```
absorb : (k+1)·C(n+1,k+1) = (n+1)·C(n,k)
```

- **First moment:** peel the k=0 term of ∑_{k≤n+1} k·C(n+1,k) with `Finset.sum_range_succ'` (it vanishes), apply `absorb` termwise to turn the weighted row-(n+1) sum into (n+1)·∑ C(n,k), finish with `Nat.sum_range_choose = 2^n`.
- **Second moment:** write k²=k·k, apply `absorb` once so (k+1)²·C(n+2,k+1) = (n+2)·((k+1)·C(n+1,k)), factor out (n+2), split (k+1)·C = k·C + C, and reuse the first moment + row sum.

Workhorse lemmas are stated in shifted forms (`range (n+2)`, `range (n+3)`) to stay inside ℕ with no truncated subtraction; the classic 2^{n-1} / 2^{n-2} forms are recovered as corollaries.

## Verification

- 5 theorems, **0 sorries**, **0 `axiom` declarations**
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only (no `Lean.ofReduceBool`, no `sorryAx`) → status **verified**
- Compiles clean (`lake env lean Proofs/CombinationsFormulaOQ09.lean`, exit 0, no warnings)
- Sanity checks at n=4: ∑ k·C(4,k)=32=4·2³, ∑ k²·C(4,k)=80=4·5·2²

## Files
- `proofs/Proofs/CombinationsFormulaOQ09.lean` (new, 122 lines)
- `proofs/Proofs.lean` (one import)
- `src/data/proofs/combinations-formula-oq-09/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)