### PR TITLE
research(cantors-theorem-oq-05): no greatest cardinal + the iterated-powerset tower (verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -427,6 +427,7 @@ import Proofs.CantorsTheoremOQ01OQ03
 import Proofs.CantorsTheoremOQ01OQ03OQ04
 import Proofs.CantorsTheoremOQ02
 import Proofs.CantorsTheoremOQ03
+import Proofs.CantorsTheoremOQ05
 import Proofs.CarnotTheorem
 import Proofs.CauchySchwarz
 import Proofs.CauchySchwarzIntegral

--- a/proofs/Proofs/CantorsTheoremOQ05.lean
+++ b/proofs/Proofs/CantorsTheoremOQ05.lean
@@ -1,0 +1,77 @@
+/-
+# Cantor's Theorem OQ-05: there is no greatest cardinal, and an explicit power tower
+
+## Open Question
+Turn Cantor's theorem `a < 2 ^ a` into its global structural consequence: the cardinals
+have *no maximum*, and from any cardinal `a` there is an explicit strictly increasing
+ℕ-indexed tower `a < 2^a < 2^(2^a) < ⋯` of distinct cardinals above it.
+
+## Approach
+Where the base entry and OQ-03 build the *diagonal constructions* that prove `a < 2 ^ a`
+(Cantor / König / Lawvere), this entry takes that inequality as given (`Cardinal.cantor`)
+and reads off the shape of the cardinal order:
+  * `∃ b, a < b` — every cardinal is exceeded (take `b = 2 ^ a`).
+  * `¬ IsMax a` — no cardinal is a maximum.
+  * The iterated powerset `powTower a n = (2 ^ ·)^[n] a` is **strictly monotone** in `n`,
+    hence injective: infinitely many distinct cardinals lie above any `a`.
+
+A subtle point: the map `c ↦ 2 ^ c` is *not* provably strictly monotone on cardinals
+(whether `a < b → 2^a < 2^b` is independent of ZFC — the GCH question). So the tower's
+monotonicity cannot come from monotonicity of exponentiation; it comes from applying
+`Cardinal.cantor` afresh at *each* level, `powTower a n < 2 ^ (powTower a n) = powTower a (n+1)`,
+which is exactly what `strictMono_nat_of_lt_succ` needs.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace CantorsTheoremOQ05
+
+open Cardinal
+
+/-- **Cantor's inequality `a < 2 ^ a`** (`Cardinal.cantor`), re-exported as the engine. The
+powerset of any type is strictly larger than the type. -/
+theorem cantor_lt (a : Cardinal.{u}) : a < 2 ^ a :=
+  Cardinal.cantor a
+
+/-- **Every cardinal is exceeded: `∃ b, a < b`.** Witness `b = 2 ^ a`. -/
+theorem exists_gt (a : Cardinal.{u}) : ∃ b, a < b :=
+  ⟨2 ^ a, cantor_lt a⟩
+
+/-- **There is no greatest cardinal: `¬ IsMax a`.** If `a` were maximal then `2 ^ a ≤ a`
+(maximality applied to `a ≤ 2 ^ a`), contradicting `a < 2 ^ a`. -/
+theorem not_isMax (a : Cardinal.{u}) : ¬ IsMax a := by
+  intro h
+  exact absurd (h (cantor_lt a).le) (cantor_lt a).not_ge
+
+/-- **The iterated-powerset tower** above `a`: `powTower a n = (2 ^ ·)^[n] a`, i.e.
+`a, 2^a, 2^(2^a), …`. -/
+def powTower (a : Cardinal.{u}) (n : ℕ) : Cardinal.{u} :=
+  (fun c => (2 : Cardinal.{u}) ^ c)^[n] a
+
+@[simp] theorem powTower_zero (a : Cardinal.{u}) : powTower a 0 = a := rfl
+
+/-- Each rung is the powerset of the previous one: `powTower a (n+1) = 2 ^ powTower a n`. -/
+theorem powTower_succ (a : Cardinal.{u}) (n : ℕ) :
+    powTower a (n + 1) = 2 ^ powTower a n :=
+  Function.iterate_succ_apply' _ _ _
+
+/-- **The tower is strictly increasing.** Crucially this does *not* use monotonicity of
+`c ↦ 2 ^ c` (which is independent of ZFC); each step is a fresh application of
+`Cardinal.cantor` to the current rung. -/
+theorem powTower_strictMono (a : Cardinal.{u}) : StrictMono (powTower a) :=
+  strictMono_nat_of_lt_succ fun n => by
+    rw [powTower_succ]; exact cantor_lt (powTower a n)
+
+/-- **The rungs are all distinct.** Strict monotonicity gives injectivity, so the tower
+exhibits infinitely many pairwise-different cardinals — and all of them exceed `a` (for
+`n ≥ 1`). -/
+theorem powTower_injective (a : Cardinal.{u}) : Function.Injective (powTower a) :=
+  (powTower_strictMono a).injective
+
+/-- **Every rung past the base exceeds `a`: `a < powTower a (n+1)`.** Concretely the tower
+escapes `a` immediately and never returns. -/
+theorem lt_powTower_succ (a : Cardinal.{u}) (n : ℕ) : a < powTower a (n + 1) := by
+  simpa using (powTower_strictMono a) (Nat.succ_pos n)
+
+end CantorsTheoremOQ05

--- a/src/data/proofs/cantors-theorem-oq-05/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-05/meta.json
@@ -1,0 +1,164 @@
+{
+  "id": "cantors-theorem-oq-05",
+  "title": "No Greatest Cardinal: The Powerset Tower a < 2^a < 2^(2^a) < ⋯",
+  "slug": "cantors-theorem-oq-05",
+  "description": "The global structural consequence of Cantor's theorem a < 2^a: the cardinals have no maximum (¬ IsMax a, and ∃ b, a < b), and from any cardinal a the iterated powerset powTower a n = (2^·)^[n] a is a strictly increasing, injective ℕ-indexed tower of distinct cardinals above a. Crucially the tower's monotonicity comes from applying Cantor afresh at each rung, not from monotonicity of c ↦ 2^c (which is independent of ZFC).",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cantor%27s_theorem",
+    "date": "1891",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "cantor",
+      "cardinal-arithmetic",
+      "powerset",
+      "diagonal-argument",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CantorsTheoremOQ05.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.cantor",
+        "description": "a < 2 ^ a — Cantor's theorem in cardinal form; the powerset is strictly larger. The engine of the entry",
+        "module": "Mathlib.SetTheory.Cardinal.Order"
+      },
+      {
+        "theorem": "strictMono_nat_of_lt_succ",
+        "description": "(∀ n, f n < f (n+1)) → StrictMono f — lifts the per-rung Cantor inequality to monotonicity of the whole tower",
+        "module": "Mathlib.Order.Monotone.Basic"
+      },
+      {
+        "theorem": "Function.iterate_succ_apply'",
+        "description": "f^[n+1] x = f (f^[n] x) — identifies powTower a (n+1) with 2 ^ powTower a n",
+        "module": "Mathlib.Logic.Function.Iterate"
+      },
+      {
+        "theorem": "StrictMono.injective",
+        "description": "StrictMono f → Injective f — the strictly increasing tower has all-distinct rungs",
+        "module": "Mathlib.Order.Monotone.Basic"
+      }
+    ],
+    "originalContributions": [
+      "cantor_lt: a < 2 ^ a re-exported as the engine",
+      "exists_gt: ∀ a, ∃ b, a < b — every cardinal is exceeded (b = 2^a)",
+      "not_isMax: ∀ a, ¬ IsMax a — there is no greatest cardinal",
+      "powTower: the iterated-powerset tower (2^·)^[n] a above a",
+      "powTower_succ: powTower a (n+1) = 2 ^ powTower a n",
+      "powTower_strictMono: the tower is strictly increasing (per-rung Cantor, NOT exponent monotonicity)",
+      "powTower_injective: the rungs are pairwise distinct",
+      "lt_powTower_succ: a < powTower a (n+1), the tower escapes a immediately"
+    ],
+    "dateAdded": "2026-06-19",
+    "lineCount": 77,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Cantor's 1891 theorem that a set is strictly smaller than its power set (a < 2^a) immediately implies there can be no largest set or largest cardinal: the operation of taking power sets always produces something bigger. This is the engine behind the cumulative hierarchy of set theory and the beth numbers ℶ₀ < ℶ₁ < ℶ₂ < ⋯. Where the gallery's base Cantor entry and OQ-03 build the diagonal constructions that *prove* a < 2^a (Cantor, König, Lawvere), this entry takes that inequality as input and extracts the global shape of the cardinal order: it has no top, and above every cardinal sits an explicit, concrete, strictly increasing ℕ-tower obtained by iterating the powerset.",
+    "problemStatement": "**Open Question (cantors-theorem-oq-05)**: From Cantor's a < 2^a, derive the structural facts: ¬ IsMax a (no greatest cardinal), ∃ b, a < b, and the strict monotonicity / injectivity of the iterated-powerset tower powTower a n = (2^·)^[n] a.\n\n**Result**: cantor_lt, exists_gt, not_isMax, powTower (+ powTower_zero, powTower_succ), powTower_strictMono, powTower_injective, lt_powTower_succ.",
+    "text": "There is no greatest cardinal: above any cardinal a the iterated powerset a < 2^a < 2^(2^a) < ⋯ is a strictly increasing tower of distinct cardinals.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `cantor_lt` re-exports `Cardinal.cantor : a < 2 ^ a`.\n2. `exists_gt` and `not_isMax`: `2 ^ a` strictly exceeds `a`, so `a` is exceeded and cannot be maximal (maximality would force `2^a ≤ a`).\n3. `powTower a n := (fun c => 2 ^ c)^[n] a`; `powTower_succ` is `Function.iterate_succ_apply'`.\n4. `powTower_strictMono`: by `strictMono_nat_of_lt_succ` it suffices that `powTower a n < powTower a (n+1) = 2 ^ powTower a n`, which is `cantor_lt` applied at the rung `powTower a n`. **No use is made of monotonicity of `c ↦ 2 ^ c`** — that statement (`a < b → 2^a < 2^b`) is independent of ZFC, so the per-rung argument is essential.\n5. `powTower_injective` is `StrictMono.injective`; `lt_powTower_succ` is monotonicity applied to `0 < n+1`.",
+    "keyInsights": [
+      "**The diagonal argument's payoff is global, not local.** OQ-03 produces the diagonal witnesses that prove a < 2^a; this entry shows what that single inequality buys: the entire cardinal order is unbounded, with an explicit witnessing tower over every point.",
+      "**Monotonicity of the tower is NOT monotonicity of exponentiation.** Whether a < b implies 2^a < 2^b is the GCH-adjacent question, independent of ZFC. The tower climbs only because Cantor's inequality is re-applied at each rung — `strictMono_nat_of_lt_succ` needs exactly the consecutive comparisons, never the general one.",
+      "**No maximum, constructively witnessed.** ¬ IsMax a is not an abstract non-existence: powTower hands you infinitely many explicit, pairwise-distinct cardinals 2^a, 2^(2^a), … all strictly above a.",
+      "**The beth ladder in miniature.** powTower 0 is exactly the finite-index beth sequence ℶ₀, ℶ₁, ℶ₂, … starting from a; the result is the well-foundedness-free fact that this ladder never stops rising."
+    ],
+    "prerequisites": [
+      "Cantor's theorem in cardinal form (Cardinal.cantor)",
+      "Function iteration and strict monotonicity from successor comparisons (Function.iterate, strictMono_nat_of_lt_succ)",
+      "Independence of cardinal exponentiation monotonicity from ZFC (context for why the per-rung argument is necessary)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Module docstring on the global consequence of Cantor's theorem and the GCH subtlety, the Mathlib import, namespace, and Cardinal open.",
+      "mathContext": "$a < 2^a$ for every cardinal $a$, hence no greatest cardinal."
+    },
+    {
+      "id": "nomax",
+      "title": "No Greatest Cardinal",
+      "startLine": 32,
+      "endLine": 46,
+      "summary": "cantor_lt (a < 2^a), exists_gt (every cardinal exceeded), not_isMax (no maximum cardinal).",
+      "mathContext": "$\\forall a,\\ \\exists b,\\ a < b$ and $\\neg\\,\\mathrm{IsMax}\\,a$."
+    },
+    {
+      "id": "tower",
+      "title": "The Iterated-Powerset Tower",
+      "startLine": 48,
+      "endLine": 77,
+      "summary": "powTower (and powTower_zero/powTower_succ), powTower_strictMono (per-rung Cantor, not exponent monotonicity), powTower_injective, lt_powTower_succ.",
+      "mathContext": "$a < 2^a < 2^{2^a} < \\cdots$, a strictly increasing injective $\\mathbb{N}$-tower."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "extends",
+      "description": "Extends Cantor's theorem a < 2^a from a single inequality to its global consequence: the cardinal order has no maximum and carries an explicit strict powerset tower above every point"
+    },
+    {
+      "targetId": "cantors-theorem-oq-03",
+      "relationship": "related",
+      "description": "OQ-03 builds the diagonal constructions (König/Lawvere/Cantor) that prove a < 2^a; this entry consumes that inequality to derive unboundedness and the tower"
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-07",
+      "relationship": "related",
+      "description": "Counterpoint to the continuum-stability results (𝔠 · 𝔠 = 𝔠, 𝔠 ^ ℵ₀ = 𝔠): products and countable powers leave a cardinal fixed, but the power set 2^a always strictly increases it"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) derivation of the global structure implied by Cantor's theorem: there is no greatest cardinal (¬ IsMax a, ∃ b, a < b), and the iterated-powerset tower powTower a n = (2^·)^[n] a is strictly increasing and injective, exhibiting infinitely many distinct cardinals above any a — with monotonicity sourced from per-rung Cantor rather than the ZFC-independent monotonicity of exponentiation.",
+    "implications": "Pins down the cumulative-hierarchy fact that the cardinals form a proper class with no top, and supplies an explicit finite-index beth ladder over any starting cardinal. The careful sourcing of monotonicity flags exactly where GCH-independence would otherwise tempt an incorrect shortcut.",
+    "openQuestions": [
+      "Extend the tower to transfinite (ordinal-indexed) beth numbers and prove ℶ is strictly monotone and continuous at limits.",
+      "Formalize ¬ BddAbove (Set.univ : Set Cardinal) and the proper-class statement that Cardinal is not Small."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "CantorsTheoremOQ05",
+    "lineCount": 77,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/CantorsTheoremOQ05.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine elementare Frage der Mannigfaltigkeitslehre",
+      "year": "1891",
+      "venue": "Jahresbericht der Deutschen Mathematiker-Vereinigung, vol. 1, pp. 75–78",
+      "note": "The diagonal argument: a set has strictly smaller cardinality than its power set"
+    },
+    {
+      "authors": "Jech, Thomas",
+      "title": "Set Theory",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics, 3rd ed.",
+      "note": "Beth numbers, the cumulative hierarchy, and independence of GCH (monotonicity of 2^κ)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Takes Cantor's theorem `a < 2^a` as input and extracts the **global structure** of the cardinal order: there is no greatest cardinal, and above any cardinal `a` sits an explicit strictly increasing tower `a < 2^a < 2^(2^a) < ⋯` of distinct cardinals.

## Results (7 theorems + 1 def, 0 sorries, 0 axioms)

- `cantor_lt`: `a < 2 ^ a` (engine)
- `exists_gt`: every cardinal is exceeded
- `not_isMax`: **no greatest cardinal**
- `powTower a n = (2^·)^[n] a` with `powTower_zero`, `powTower_succ`
- `powTower_strictMono`: the tower strictly increases
- `powTower_injective`: rungs pairwise distinct
- `lt_powTower_succ`: `a < powTower a (n+1)`

## The key subtlety

The tower's monotonicity is **not** monotonicity of `c ↦ 2^c` — whether `a < b → 2^a < 2^b` is independent of ZFC (the GCH-adjacent question). Instead `strictMono_nat_of_lt_succ` needs only the consecutive comparisons `powTower a n < 2^(powTower a n) = powTower a (n+1)`, each a fresh application of `Cardinal.cantor` at that rung. The proof is careful to source monotonicity exactly there.

## Relation to siblings

Where `cantors-theorem-oq-03` builds the diagonal constructions (Cantor/König/Lawvere) that *prove* `a < 2^a`, this entry *consumes* that inequality to derive unboundedness and the explicit beth-style ladder. It's also the counterpoint to the continuum-stability results (`𝔠·𝔠=𝔠`, `𝔠^ℵ₀=𝔠`): products and countable powers fix a cardinal, but the power set always strictly increases it.

## Verification

- Compiles clean under Mathlib 4.26.0: `lake env lean Proofs/CantorsTheoremOQ05.lean`
- `#print axioms` on all theorems: `[propext, Classical.choice, Quot.sound]` only — **0 custom axioms**
- Registered in `proofs/Proofs.lean`; gallery `meta.json` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)