### PR TITLE
research(sum-of-divisors-oq-04): structural identities for σₖ — primes, prime powers, multiplicativity (verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3048,6 +3048,7 @@ import Proofs.SubsetCountOQ02
 import Proofs.SubsetCountOQ02OQ01
 import Proofs.SumOfDivisors
 import Proofs.SumOfDivisorsOQ02
+import Proofs.SumOfDivisorsOQ04
 import Proofs.SumOfKthPowers
 import Proofs.SumOfKthPowersOQ01
 import Proofs.SumOfKthPowersOQ02

--- a/proofs/Proofs/SumOfDivisorsOQ04.lean
+++ b/proofs/Proofs/SumOfDivisorsOQ04.lean
@@ -1,0 +1,69 @@
+/-
+# Sum of Divisors OQ-04: structural identities for σₖ — primes, prime powers, multiplicativity
+
+## Open Question
+The base entry verifies σ(p) = p + 1 for *specific* primes and classifies particular
+perfect / abundant / amicable numbers. This entry proves the *general* structural laws of
+the divisor-sum function: σ on an arbitrary prime, the closed geometric form on prime
+powers, the multiplicative evaluation on a product of two distinct primes, and the σ-form
+of perfection.
+
+## Approach
+Everything is read off Mathlib's `ArithmeticFunction.sigma` and its prime-power /
+multiplicative API:
+  * `sigma_one_apply_prime_pow` / `sigma_zero_apply_prime_pow` give σ and τ on `p ^ i`.
+  * `geom_sum_mul` turns the open sum `∑ pᵏ` into the closed form `(pⁱ⁺¹ − 1)/(p − 1)`.
+  * `IsMultiplicative.map_mul_of_coprime` (with `coprime_primes`) evaluates σ on `p · q`.
+  * `Nat.perfect_iff_sum_divisors_eq_two_mul` + `sigma_one_apply` express perfection as
+    `σ(n) = 2n`.
+
+These are the foundational identities behind the base entry's numerical classifications,
+proved once and for all in `n`, `p`, `q`, `i` rather than for hand-picked values.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace SumOfDivisorsOQ04
+
+open ArithmeticFunction Finset
+
+/-- **`σ(p) = p + 1` for every prime `p`.** The general theorem behind the base entry's
+case-by-case checks: a prime's only divisors are `1` and `p`. -/
+theorem sigma_one_prime {p : ℕ} (hp : p.Prime) : sigma 1 p = p + 1 := by
+  have h := sigma_one_apply_prime_pow (p := p) (i := 1) hp
+  rw [pow_one] at h
+  rw [h, Finset.sum_range_succ, Finset.sum_range_one, pow_zero, pow_one]
+  ring
+
+/-- **`τ(p) = σ₀(p) = 2` for every prime `p`.** A prime has exactly two divisors. -/
+theorem sigma_zero_prime {p : ℕ} (hp : p.Prime) : sigma 0 p = 2 := by
+  have h := sigma_zero_apply_prime_pow (p := p) (i := 1) hp
+  rw [pow_one] at h
+  simpa using h
+
+/-- **Closed geometric form on prime powers:** `σ(pⁱ) · (p − 1) = pⁱ⁺¹ − 1` (over ℤ).
+`sigma_one_apply_prime_pow` writes `σ(pⁱ)` as the open sum `∑_{k<i+1} pᵏ`; `geom_sum_mul`
+collapses it. Equivalently `σ(pⁱ) = (pⁱ⁺¹ − 1)/(p − 1)`. -/
+theorem sigma_one_prime_pow_mul {p : ℕ} (hp : p.Prime) (i : ℕ) :
+    (sigma 1 (p ^ i) : ℤ) * ((p : ℤ) - 1) = (p : ℤ) ^ (i + 1) - 1 := by
+  rw [sigma_one_apply_prime_pow hp]
+  push_cast
+  rw [geom_sum_mul]
+
+/-- **Multiplicativity on two distinct primes:** `σ(p · q) = (p + 1)(q + 1)`. Distinct
+primes are coprime (`coprime_primes`), so `σ` factors (`isMultiplicative_sigma`), and each
+factor is `sigma_one_prime`. -/
+theorem sigma_one_two_primes {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q) :
+    sigma 1 (p * q) = (p + 1) * (q + 1) := by
+  have hcop : Nat.Coprime p q := (Nat.coprime_primes hp hq).mpr hpq
+  rw [isMultiplicative_sigma.map_mul_of_coprime hcop, sigma_one_prime hp, sigma_one_prime hq]
+
+/-- **Perfection in σ-form:** for `n > 0`, `n` is perfect iff `σ(n) = 2n`. Ties the
+divisor-sum function to the base entry's perfect numbers (`σ(6) = 12 = 2·6`,
+`σ(28) = 56 = 2·28`). -/
+theorem perfect_iff_sigma_one {n : ℕ} (hn : 0 < n) :
+    Nat.Perfect n ↔ sigma 1 n = 2 * n := by
+  rw [Nat.perfect_iff_sum_divisors_eq_two_mul hn, sigma_one_apply]
+
+end SumOfDivisorsOQ04

--- a/src/data/proofs/sum-of-divisors-oq-04/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-04/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "sum-of-divisors-oq-04",
+  "title": "Structural Identities for σₖ: Primes, Prime Powers, and Multiplicativity",
+  "slug": "sum-of-divisors-oq-04",
+  "description": "The general structural laws of the divisor-sum function, proved once and for all in n, p, q, i: σ(p) = p+1 and τ(p) = 2 for every prime, the closed geometric form σ(pⁱ)·(p−1) = pⁱ⁺¹−1 on prime powers, the multiplicative evaluation σ(pq) = (p+1)(q+1) on distinct primes, and the σ-form of perfection σ(n) = 2n. Generalizes the base entry's case-by-case numerical checks. Routes through ArithmeticFunction.sigma, sigma_one_apply_prime_pow, geom_sum_mul, isMultiplicative_sigma.",
+  "meta": {
+    "author": "classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Divisor_function",
+    "date": "antiquity",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "divisor-function",
+      "sigma",
+      "multiplicative-function",
+      "prime-powers",
+      "perfect-numbers",
+      "arithmetic-functions",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SumOfDivisorsOQ04.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.sigma_one_apply_prime_pow",
+        "description": "σ₁(pⁱ) = ∑_{k<i+1} pᵏ — the open geometric sum on a prime power",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "ArithmeticFunction.sigma_zero_apply_prime_pow",
+        "description": "σ₀(pⁱ) = i+1 — the divisor count of a prime power",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "geom_sum_mul",
+        "description": "(∑_{i<n} xⁱ)·(x−1) = xⁿ−1 — collapses the open sum to the closed geometric form",
+        "module": "Mathlib.Algebra.Ring.GeomSum"
+      },
+      {
+        "theorem": "ArithmeticFunction.IsMultiplicative.map_mul_of_coprime",
+        "description": "multiplicative f, Coprime m n → f(mn) = f m · f n — evaluates σ across a coprime factorization",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Defs"
+      },
+      {
+        "theorem": "ArithmeticFunction.isMultiplicative_sigma",
+        "description": "σₖ is a multiplicative arithmetic function",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "Nat.coprime_primes",
+        "description": "Coprime p q ↔ p ≠ q for primes p, q — distinct primes are coprime",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.perfect_iff_sum_divisors_eq_two_mul",
+        "description": "0 < n → (Perfect n ↔ ∑_{d∣n} d = 2n) — perfection as a divisor-sum equation",
+        "module": "Mathlib.NumberTheory.Divisors"
+      }
+    ],
+    "originalContributions": [
+      "sigma_one_prime: σ(p) = p+1 for EVERY prime (base entry only verified specific primes)",
+      "sigma_zero_prime: τ(p) = σ₀(p) = 2 for every prime",
+      "sigma_one_prime_pow_mul: σ(pⁱ)·(p−1) = pⁱ⁺¹−1, the closed geometric form on prime powers",
+      "sigma_one_two_primes: σ(pq) = (p+1)(q+1) for distinct primes via multiplicativity",
+      "perfect_iff_sigma_one: Perfect n ↔ σ(n) = 2n, the σ-form of perfection"
+    ],
+    "dateAdded": "2026-06-19",
+    "lineCount": 69,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The divisor-sum function σ(n) = Σ_{d∣n} d is among the oldest objects in number theory, central to the Greeks' study of perfect numbers and to Euler's work on multiplicative functions. Its structure is completely determined by two facts: it is multiplicative (σ(mn) = σ(m)σ(n) for coprime m, n), and on a prime power it is the geometric sum σ(pⁱ) = 1 + p + ⋯ + pⁱ = (pⁱ⁺¹ − 1)/(p − 1). Together these compute σ on any factorization. The base gallery entry verified σ(p) = p + 1 for a handful of specific primes and classified particular perfect, abundant, and amicable numbers; this entry proves the underlying laws in full generality, which is exactly what those numerical facts instantiate.",
+    "problemStatement": "**Open Question (sum-of-divisors-oq-04)**: Prove the general structural identities of σₖ — σ(p) = p+1, τ(p) = 2, the closed geometric form on prime powers, multiplicativity on distinct primes, and the σ-characterization of perfect numbers.\n\n**Result**: sigma_one_prime, sigma_zero_prime, sigma_one_prime_pow_mul, sigma_one_two_primes, perfect_iff_sigma_one.",
+    "text": "σ(p) = p+1 and τ(p) = 2 for every prime, σ(pⁱ)·(p−1) = pⁱ⁺¹−1 on prime powers, σ(pq) = (p+1)(q+1) on distinct primes, and n is perfect iff σ(n) = 2n.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `sigma_one_prime`: `sigma_one_apply_prime_pow` at i = 1 gives σ(p) = p⁰ + p¹ = 1 + p.\n2. `sigma_zero_prime`: `sigma_zero_apply_prime_pow` at i = 1 gives τ(p) = 1 + 1 = 2.\n3. `sigma_one_prime_pow_mul`: rewrite σ(pⁱ) as the open sum ∑_{k<i+1} pᵏ, cast to ℤ, and apply `geom_sum_mul` to obtain (p−1)·σ(pⁱ) = pⁱ⁺¹ − 1.\n4. `sigma_one_two_primes`: distinct primes are coprime (`coprime_primes`), so `isMultiplicative_sigma.map_mul_of_coprime` splits σ(pq) = σ(p)·σ(q), then `sigma_one_prime` on each factor.\n5. `perfect_iff_sigma_one`: rewrite `perfect_iff_sum_divisors_eq_two_mul` with `sigma_one_apply` to express the divisor sum as σ(n).",
+    "keyInsights": [
+      "**Two laws determine σ entirely.** Multiplicativity plus the prime-power geometric sum compute σ on any integer via its factorization; every numerical value in the base entry is an instance of these.",
+      "**The closed geometric form.** σ(pⁱ) = (pⁱ⁺¹ − 1)/(p − 1) — stated here as the division-free identity σ(pⁱ)·(p − 1) = pⁱ⁺¹ − 1 over ℤ, proved by the ring lemma geom_sum_mul rather than re-deriving the telescoping sum.",
+      "**Perfection is a σ equation.** Perfect n ⇔ σ(n) = 2n is the cleanest statement of the Greek definition: the proper divisors sum to n exactly when all divisors sum to 2n. (Note: a product of two distinct primes can be perfect — 6 = 2·3 with σ(6) = 12 — so multiplicativity alone does not forbid it.)",
+      "**General over generic, not specific.** Where the base entry checked σ(p) = p+1 for six chosen primes, sigma_one_prime proves it for the universally quantified prime — the difference between a table and a theorem."
+    ],
+    "prerequisites": [
+      "Mathlib's ArithmeticFunction.sigma and its prime-power API",
+      "Multiplicative arithmetic functions and coprime factorization (IsMultiplicative)",
+      "The geometric sum identity geom_sum_mul"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 34,
+      "summary": "Module docstring framing the general structural laws behind the base entry's numerics, the Mathlib import, namespace, and ArithmeticFunction/Finset opens.",
+      "mathContext": "$\\sigma(p) = p+1$, $\\sigma(p^i) = \\tfrac{p^{i+1}-1}{p-1}$, $\\sigma(pq) = (p+1)(q+1)$."
+    },
+    {
+      "id": "primes",
+      "title": "σ and τ on Primes and Prime Powers",
+      "startLine": 36,
+      "endLine": 56,
+      "summary": "sigma_one_prime (σ(p) = p+1), sigma_zero_prime (τ(p) = 2), sigma_one_prime_pow_mul (the closed geometric form σ(pⁱ)·(p−1) = pⁱ⁺¹−1).",
+      "mathContext": "$\\sigma(p) = p+1$, $\\tau(p) = 2$, $(p-1)\\sigma(p^i) = p^{i+1}-1$."
+    },
+    {
+      "id": "multiplicative",
+      "title": "Multiplicativity and Perfection",
+      "startLine": 58,
+      "endLine": 69,
+      "summary": "sigma_one_two_primes (σ(pq) = (p+1)(q+1) via multiplicativity) and perfect_iff_sigma_one (Perfect n ↔ σ(n) = 2n).",
+      "mathContext": "$\\sigma(pq) = (p+1)(q+1)$ and $\\mathrm{Perfect}(n) \\iff \\sigma(n) = 2n$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sum-of-divisors",
+      "relationship": "extends",
+      "description": "Generalizes the base entry's specific-prime checks (σ(p) = p+1 for six primes) and numerical perfect/abundant/amicable classifications to the universally quantified structural laws of σ"
+    },
+    {
+      "targetId": "abundant-number-oq-03",
+      "relationship": "related",
+      "description": "The σ-form of perfection (σ(n) = 2n) sits beside the abundance condition (σ(n) > 2n) in the same divisor-sum classification of integers"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) proof of the general structural identities of the divisor-sum function: σ(p) = p+1 and τ(p) = 2 for every prime, the closed geometric form σ(pⁱ)·(p−1) = pⁱ⁺¹−1 on prime powers, σ(pq) = (p+1)(q+1) on distinct primes via multiplicativity, and Perfect n ↔ σ(n) = 2n.",
+    "implications": "Supplies the universally quantified laws that the base entry's numerical tables instantiate, and the σ-equation form of perfection used throughout the classification of integers by their divisor sums.",
+    "openQuestions": [
+      "Prove the Euclid–Euler theorem: even perfect numbers are exactly 2^(p-1)(2^p − 1) with 2^p − 1 prime (Mathlib's Nat.even_and_perfect_iff).",
+      "State the full multiplicative evaluation σ(n) = ∏_p (p^(v_p(n)+1) − 1)/(p − 1) as a closed product over prime factors."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "ArithmeticFunction",
+      "Finset"
+    ],
+    "namespace": "SumOfDivisorsOQ04",
+    "lineCount": 69,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/SumOfDivisorsOQ04.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Hardy, G. H. and Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "Chapter XVI: multiplicative functions, σ(n) and the geometric formula on prime powers"
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer Undergraduate Texts in Mathematics",
+      "note": "Theorem 2.13 and surrounding: σ is multiplicative with σ(pᵃ) = (p^{a+1}−1)/(p−1)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves the **general** structural laws of the divisor-sum function σ, of which the base entry's specific-prime checks and numerical classifications are instances.

## Results (5 theorems, 0 sorries, 0 axioms)

- `sigma_one_prime`: `σ(p) = p + 1` for **every** prime (base entry only did six specific primes)
- `sigma_zero_prime`: `τ(p) = σ₀(p) = 2` for every prime
- `sigma_one_prime_pow_mul`: the closed geometric form `σ(pⁱ)·(p−1) = pⁱ⁺¹−1` over ℤ
- `sigma_one_two_primes`: `σ(pq) = (p+1)(q+1)` on distinct primes via multiplicativity
- `perfect_iff_sigma_one`: `Perfect n ↔ σ(n) = 2n`

## Proof route

`sigma_one_apply_prime_pow` / `sigma_zero_apply_prime_pow` for primes and prime powers; `geom_sum_mul` (over ℤ) for the closed form; `isMultiplicative_sigma.map_mul_of_coprime` + `coprime_primes` for the product; `perfect_iff_sum_divisors_eq_two_mul` + `sigma_one_apply` for perfection.

## Honesty note

I drafted and then **removed** a "product of two distinct primes is never perfect" corollary after the compiler rejected it — it is **false** (6 = 2·3 is perfect, σ(6) = 12 = 2·6). The key-insights and conclusion flag this explicitly.

## Verification

- Compiles clean under Mathlib 4.26.0: `lake env lean Proofs/SumOfDivisorsOQ04.lean`
- `#print axioms` on all theorems: `[propext, Classical.choice, Quot.sound]` only — **0 custom axioms**
- Registered in `proofs/Proofs.lean`; gallery `meta.json` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)