### PR TITLE
research(stirling-formula-oq-03): standalone Wallis product ∏ 4k²/(4k²−1) → π/2 (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3042,6 +3042,7 @@ import Proofs.StirlingExpansion
 import Proofs.StirlingExpansionAristotle
 import Proofs.StirlingFormula
 import Proofs.StirlingFormulaOQ02
+import Proofs.StirlingFormulaOQ03
 import Proofs.SubsetCount
 import Proofs.SubsetCountMultisetOQ01
 import Proofs.SubsetCountOQ02

--- a/proofs/Proofs/StirlingFormulaOQ03.lean
+++ b/proofs/Proofs/StirlingFormulaOQ03.lean
@@ -1,0 +1,78 @@
+/-
+The Wallis Product as a Standalone Limit:  ∏ 4k²/(4k²−1) → π/2
+
+Source: Open question from stirling-formula gallery proof
+Status: VERIFIED (0 axioms, 0 sorries)
+
+The gallery's Stirling entries (`StirlingFormula`, `StirlingExpansion`, …) use the
+Wallis product *internally* as the engine that pins the Stirling constant to √(2π),
+but none of them states Wallis' product in its own classical textbook form. This
+file isolates it:
+
+  ∏_{k=1}^{n}  (2k)² / ((2k−1)(2k+1))  =  ∏_{k=1}^{n} 4k²/(4k²−1)  ⟶  π/2.
+
+This is John Wallis' 1656 infinite product for π (from *Arithmetica Infinitorum*),
+the historical ancestor of the Stirling-constant computation. Mathlib proves the
+limit in a shifted, index-from-zero form (`Real.tendsto_prod_pi_div_two`); we
+reindex it to the standard k-from-1 factor 4k²/(4k²−1) and record the algebraic
+identity that the two factor forms coincide.
+
+We prove:
+1. `wallis_factor`     — the textbook identity 4k²/(4k²−1) = (2k)²/((2k−1)(2k+1))
+2. `wallisProduct_eq`  — our product equals Mathlib's shifted Wallis product termwise
+3. `wallis_tendsto`    — the standalone limit ∏ 4k²/(4k²−1) → π/2
+-/
+
+import Mathlib
+
+open Finset Filter Topology Real
+
+namespace StirlingFormulaOQ03
+
+/-- The `n`-th partial Wallis product in classical form:
+`∏_{k=1}^{n} 4k²/(4k²−1)`, indexed with `k = i+1` over `range n`. -/
+noncomputable def wallisProduct (n : ℕ) : ℝ :=
+  ∏ i ∈ Finset.range n, (4 * ((i : ℝ) + 1) ^ 2) / (4 * ((i : ℝ) + 1) ^ 2 - 1)
+
+/-! ## Part I: The factor identity -/
+
+/-- The Wallis factor in its two standard forms agree:
+`4k²/(4k²−1) = (2k)²/((2k−1)(2k+1))`. The denominator factors as a difference of
+squares: `4k² − 1 = (2k−1)(2k+1)`. -/
+theorem wallis_factor (k : ℝ) :
+    4 * k ^ 2 / (4 * k ^ 2 - 1) = (2 * k) ^ 2 / ((2 * k - 1) * (2 * k + 1)) := by
+  have hd : 4 * k ^ 2 - 1 = (2 * k - 1) * (2 * k + 1) := by ring
+  rw [hd]
+  ring
+
+/-! ## Part II: Reindexing to Mathlib's shifted product -/
+
+/-- Termwise, our classical product matches Mathlib's index-from-zero Wallis
+product `(2i+2)/(2i+1) · (2i+2)/(2i+3)` (with `i = k−1`). -/
+theorem wallisProduct_eq (n : ℕ) :
+    wallisProduct n
+      = ∏ i ∈ Finset.range n,
+          ((2 : ℝ) * i + 2) / (2 * i + 1) * ((2 * i + 2) / (2 * i + 3)) := by
+  unfold wallisProduct
+  apply Finset.prod_congr rfl
+  intro i _
+  have h1 : (2 : ℝ) * i + 1 ≠ 0 := by positivity
+  have h2 : (2 : ℝ) * i + 3 ≠ 0 := by positivity
+  have h3 : 4 * ((i : ℝ) + 1) ^ 2 - 1 ≠ 0 := by
+    have : 4 * ((i : ℝ) + 1) ^ 2 - 1 = (2 * i + 1) * (2 * i + 3) := by ring
+    rw [this]; positivity
+  field_simp
+  ring
+
+/-! ## Part III: The standalone Wallis limit -/
+
+/-- **Wallis' product (1656).** The classical partial products converge to `π/2`:
+
+  `∏_{k=1}^{n} 4k²/(4k²−1) ⟶ π/2`.
+
+Obtained by reindexing Mathlib's `Real.tendsto_prod_pi_div_two`. -/
+theorem wallis_tendsto :
+    Tendsto wallisProduct atTop (𝓝 (π / 2)) :=
+  Real.tendsto_prod_pi_div_two.congr (fun n => (wallisProduct_eq n).symm)
+
+end StirlingFormulaOQ03

--- a/src/data/proofs/stirling-formula-oq-03/annotations.json
+++ b/src/data/proofs/stirling-formula-oq-03/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-imports-definition",
+    "proofId": "stirling-formula-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
+    "type": "concept",
+    "title": "The Classical Wallis Partial Product",
+    "content": "The file isolates Wallis' 1656 infinite product for π in its standard textbook form. wallisProduct n is defined as ∏_{i ∈ range n} 4(i+1)²/(4(i+1)²−1), i.e. the partial product ∏_{k=1}^{n} 4k²/(4k²−1) with the substitution k = i+1 so the index runs over range n. This is exactly the product 4/3 · 16/15 · 36/35 · …, whose limit is π/2. The Stirling entries in the gallery use Wallis' product only as an internal step; here it is a named definition.",
+    "mathContext": "$\\prod_{k=1}^{n} \\frac{4k^2}{4k^2-1} = \\frac{2\\cdot2}{1\\cdot3}\\cdot\\frac{4\\cdot4}{3\\cdot5}\\cdots\\frac{(2n)(2n)}{(2n-1)(2n+1)}$, the $n$-th partial product of Wallis' formula.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Wallis product",
+      "infinite products",
+      "Finset.prod",
+      "partial products"
+    ],
+    "prerequisites": [
+      "finite products over Finset",
+      "natural-number casts to ℝ"
+    ]
+  },
+  {
+    "id": "ann-factor-identity",
+    "proofId": "stirling-formula-oq-03",
+    "range": {
+      "startLine": 42,
+      "endLine": 47
+    },
+    "type": "key-step",
+    "title": "Two Textbook Factor Forms Coincide",
+    "content": "wallis_factor records that the Wallis factor's two standard presentations are literally the same number: 4k²/(4k²−1) = (2k)²/((2k−1)(2k+1)). The proof rewrites the denominator via the difference of squares 4k² − 1 = (2k−1)(2k+1) and closes with ring. Notably the identity is unconditional — no nonzero hypotheses on the denominators — because after factoring, the numerator (4k² = (2k)²) and denominator match as rational functions, so ring proves the equality formally even at the poles.",
+    "mathContext": "$\\frac{4k^2}{4k^2-1} = \\frac{(2k)^2}{(2k-1)(2k+1)}$ since $4k^2 - 1 = (2k-1)(2k+1)$ and $4k^2 = (2k)^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "difference of squares",
+      "field identities",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "elementary algebra",
+      "division in fields"
+    ]
+  },
+  {
+    "id": "ann-reindexing",
+    "proofId": "stirling-formula-oq-03",
+    "range": {
+      "startLine": 52,
+      "endLine": 66
+    },
+    "type": "key-step",
+    "title": "Reindexing onto Mathlib's Shifted Product",
+    "content": "wallisProduct_eq is the technical bridge: it shows our classical product equals, term by term, Mathlib's index-from-zero Wallis product (2i+2)/(2i+1)·(2i+2)/(2i+3). After Finset.prod_congr reduces to a single factor, the substitution k = i+1 makes 4(i+1)²/(4(i+1)²−1) equal (2i+2)²/((2i+1)(2i+3)) = (2i+2)/(2i+1)·(2i+2)/(2i+3). The equality is closed by field_simp + ring, using that the denominators 2i+1, 2i+3, and 4(i+1)²−1 = (2i+1)(2i+3) are all nonzero (each shown by positivity).",
+    "mathContext": "With $k = i+1$: $2k = 2i+2$, $2k-1 = 2i+1$, $2k+1 = 2i+3$, so the classical factor matches Mathlib's shifted factor exactly.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.prod_congr",
+      "reindexing products",
+      "field_simp",
+      "Real.tendsto_prod_pi_div_two"
+    ],
+    "prerequisites": [
+      "index substitution in products",
+      "clearing denominators"
+    ]
+  },
+  {
+    "id": "ann-standalone-limit",
+    "proofId": "stirling-formula-oq-03",
+    "range": {
+      "startLine": 74,
+      "endLine": 78
+    },
+    "type": "theorem",
+    "title": "Wallis' Standalone Limit ∏ 4k²/(4k²−1) → π/2",
+    "content": "wallis_tendsto is the headline result: the classical partial products converge to π/2. Since wallisProduct equals Mathlib's shifted Wallis product at every n (wallisProduct_eq), and Mathlib's Real.tendsto_prod_pi_div_two proves that shifted product tends to π/2, Filter.Tendsto.congr transfers the limit to wallisProduct. The one-line proof is the payoff of the reindexing — the gallery now has Wallis' 1656 product for π as an independent, citable theorem rather than an unnamed step inside a Stirling derivation.",
+    "mathContext": "$\\prod_{k=1}^{n} \\frac{4k^2}{4k^2-1} \\to \\frac{\\pi}{2}$ as $n \\to \\infty$, John Wallis' infinite product for $\\pi$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Filter.Tendsto.congr",
+      "Real.tendsto_prod_pi_div_two",
+      "Wallis product",
+      "convergence to π/2"
+    ],
+    "prerequisites": [
+      "limits of sequences",
+      "transferring limits along equalities"
+    ]
+  }
+]

--- a/src/data/proofs/stirling-formula-oq-03/meta.json
+++ b/src/data/proofs/stirling-formula-oq-03/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "stirling-formula-oq-03",
+  "title": "The Wallis Product as a Standalone Limit: ∏ 4k²/(4k²−1) → π/2",
+  "slug": "stirling-formula-oq-03",
+  "description": "Isolates John Wallis' 1656 infinite product for π in its classical textbook form ∏_{k=1}^{n} 4k²/(4k²−1) → π/2 — the engine the gallery's Stirling proofs use internally but never state on its own. Obtained by reindexing Mathlib's shifted Wallis limit.",
+  "meta": {
+    "author": "John Wallis (1656)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StirlingFormulaOQ03.lean",
+    "tags": [
+      "analysis",
+      "infinite-products",
+      "pi",
+      "wallis-product",
+      "limits",
+      "classic"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.tendsto_prod_pi_div_two",
+        "description": "Wallis product in shifted index-from-zero form, ∏ (2i+2)/(2i+1)·(2i+2)/(2i+3) → π/2",
+        "module": "Mathlib.Analysis.Real.Pi.Wallis"
+      },
+      {
+        "theorem": "Filter.Tendsto.congr",
+        "description": "Transfers a limit along a termwise equality of sequences",
+        "module": "Mathlib.Order.Filter.Basic"
+      },
+      {
+        "theorem": "Finset.prod_congr",
+        "description": "Termwise equality of finite products",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      }
+    ],
+    "originalContributions": [
+      "wallisProduct: the classical k-from-1 partial product ∏_{k=1}^{n} 4k²/(4k²−1)",
+      "wallis_factor: the difference-of-squares identity 4k²/(4k²−1) = (2k)²/((2k−1)(2k+1)) relating the two textbook factor forms (unconditional field identity)",
+      "wallisProduct_eq: termwise reindexing showing the classical product equals Mathlib's shifted Wallis product (k = i+1)",
+      "wallis_tendsto: the standalone limit ∏ 4k²/(4k²−1) → π/2, not stated by any sibling Stirling entry"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound.",
+    "lineCount": 78,
+    "theoremCount": 3,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "John Wallis, in his 1656 *Arithmetica Infinitorum*, derived the first infinite product representation of π: (π/2) = (2·2·4·4·6·6···)/(1·3·3·5·5·7···), i.e. the limit of ∏_{k=1}^{n} (2k)²/((2k−1)(2k+1)) = ∏_{k=1}^{n} 4k²/(4k²−1). This was a landmark in the prehistory of calculus — an exact analytic expression for π obtained by interpolating integrals of powers of sine. Two centuries later the same product became the keystone of the modern proof of Stirling's approximation: comparing the Wallis ratio to factorial expressions fixes the Stirling constant at √(2π). The gallery's Stirling entries exploit this internally via Mathlib's Wallis machinery, yet none states Wallis' product as an independent theorem. This entry does.",
+    "problemStatement": "State and verify Wallis' classical product for π in its standard textbook form ∏_{k=1}^{n} 4k²/(4k²−1) → π/2, as a standalone result rather than an intermediate step inside a Stirling proof.\n\n**Answer:** The limit holds and is obtained by reindexing Mathlib's shifted Wallis product, with the difference-of-squares identity bridging the factor forms.",
+    "text": "Wallis' 1656 infinite product for π, isolated in classical form and proved by reindexing Mathlib's shifted Wallis limit.",
+    "proofStrategy": "1. wallis_factor: prove the unconditional field identity 4k²/(4k²−1) = (2k)²/((2k−1)(2k+1)) via the factorization 4k²−1 = (2k−1)(2k+1).\n2. wallisProduct_eq: show the classical product equals Mathlib's shifted product termwise — with k = i+1, the factor 4k²/(4k²−1) becomes (2i+2)/(2i+1)·(2i+2)/(2i+3); discharged by field_simp + ring with the denominators 2i+1, 2i+3, 4(i+1)²−1 = (2i+1)(2i+3) nonzero.\n3. wallis_tendsto: apply Filter.Tendsto.congr to Mathlib's Real.tendsto_prod_pi_div_two along this termwise equality.",
+    "keyInsights": [
+      "**The product was hiding in plain sight**: the Stirling proofs depend on Wallis' product but only as an unnamed intermediate. Stating it standalone makes the classical π-product a first-class gallery result.",
+      "**Two textbook forms, one identity**: 4k²/(4k²−1) and (2k)²/((2k−1)(2k+1)) are the two ways the Wallis factor is usually written; wallis_factor records that they are literally equal via the difference of squares 4k²−1 = (2k−1)(2k+1).",
+      "**Reindexing, not reproving**: Mathlib's Real.tendsto_prod_pi_div_two uses an index-from-zero shifted factor (2i+2)/(2i+1)·(2i+2)/(2i+3). The substitution k = i+1 turns it into the classical k-from-1 form; the limit transfers verbatim via Tendsto.congr.",
+      "**Field identity needs no hypotheses**: because numerator and denominator match as rational functions after factoring, wallis_factor holds unconditionally — ring proves it even where the denominators vanish."
+    ],
+    "prerequisites": [
+      "Finite and infinite products",
+      "Limits of sequences (Filter.Tendsto, 𝓝)",
+      "Elementary algebra (difference of squares)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-definition",
+      "title": "Imports and the Classical Partial Product",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "File-level docstring stating Wallis' product, imports Mathlib, opens Finset/Filter/Topology/Real. Defines wallisProduct n = ∏_{i<n} 4(i+1)²/(4(i+1)²−1), the classical k-from-1 product with k = i+1.",
+      "mathContext": "wallisProduct n = ∏_{k=1}^{n} 4k²/(4k²−1), the n-th partial product of Wallis' formula."
+    },
+    {
+      "id": "factor-identity",
+      "title": "The Difference-of-Squares Factor Identity",
+      "startLine": 37,
+      "endLine": 47,
+      "summary": "wallis_factor: the unconditional identity 4k²/(4k²−1) = (2k)²/((2k−1)(2k+1)), proved by rewriting 4k²−1 = (2k−1)(2k+1) and ring.",
+      "mathContext": "4k² − 1 = (2k−1)(2k+1) (difference of squares), and 4k² = (2k)², so the two standard Wallis factor forms coincide."
+    },
+    {
+      "id": "reindexing",
+      "title": "Reindexing to Mathlib's Shifted Product",
+      "startLine": 48,
+      "endLine": 66,
+      "summary": "wallisProduct_eq: termwise equality of the classical product with Mathlib's (2i+2)/(2i+1)·(2i+2)/(2i+3). Uses Finset.prod_congr then field_simp + ring, with the three denominators shown nonzero (in particular 4(i+1)²−1 = (2i+1)(2i+3)).",
+      "mathContext": "With k = i+1: 2k = 2i+2, 2k−1 = 2i+1, 2k+1 = 2i+3, so 4k²/(4k²−1) = (2i+2)²/((2i+1)(2i+3)) = (2i+2)/(2i+1)·(2i+2)/(2i+3)."
+    },
+    {
+      "id": "standalone-limit",
+      "title": "Wallis' Standalone Limit",
+      "startLine": 67,
+      "endLine": 78,
+      "summary": "wallis_tendsto: ∏ 4k²/(4k²−1) → π/2, by Filter.Tendsto.congr applied to Mathlib's Real.tendsto_prod_pi_div_two along the termwise equality wallisProduct_eq.",
+      "mathContext": "Since the classical product equals Mathlib's shifted product at every n, and the latter tends to π/2, so does the former."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Wallis, John",
+      "title": "Arithmetica Infinitorum",
+      "year": "1656",
+      "note": "Original derivation of the infinite product (π/2) = ∏ (2k)²/((2k−1)(2k+1))"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "stirling-formula",
+      "relationship": "supports",
+      "description": "Wallis' product is the analytic input that fixes the Stirling constant at √(2π); this entry states it standalone, separate from the Stirling derivation"
+    },
+    {
+      "targetId": "stirling-formula-oq-02",
+      "relationship": "sibling",
+      "description": "Both extend the Stirling family; OQ-03 isolates the underlying Wallis product as an independent π-limit"
+    }
+  ],
+  "conclusion": {
+    "summary": "Wallis' 1656 product ∏_{k=1}^{n} 4k²/(4k²−1) → π/2 is stated and verified as a standalone gallery result (wallis_tendsto), with the difference-of-squares factor identity (wallis_factor) and the reindexing to Mathlib's shifted form (wallisProduct_eq) supplying the bridge. The Stirling siblings use this product internally but never state it on its own.",
+    "implications": "Makes the classical π-product a directly citable result and exposes the precise reindexing between the textbook k-from-1 form and Mathlib's index-from-zero form.",
+    "openQuestions": [
+      "Can the rate of convergence of the partial Wallis products to π/2 be made explicit (e.g. an O(1/n) error bound)?",
+      "Does the same reindexing template recover other classical product forms (e.g. the Wallis sine product) from Mathlib's primitives?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Filter",
+      "Topology",
+      "Real"
+    ],
+    "namespace": "StirlingFormulaOQ03",
+    "lineCount": 78,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "path": "Proofs/StirlingFormulaOQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Isolates **John Wallis' 1656 infinite product for π** in its classical textbook form as a standalone gallery result:

```
∏_{k=1}^{n} 4k²/(4k²−1)  ⟶  π/2
```

The gallery's Stirling entries (`StirlingFormula`, `StirlingExpansion`) use Wallis' product *internally* as the analytic input that fixes the Stirling constant at √(2π), but none of them states Wallis' product on its own. This entry does.

## Contributions

- `wallis_factor` — the unconditional difference-of-squares identity `4k²/(4k²−1) = (2k)²/((2k−1)(2k+1))` bridging the two standard textbook factor forms.
- `wallisProduct_eq` — termwise reindexing showing the classical k-from-1 product equals Mathlib's index-from-zero shifted Wallis product.
- `wallis_tendsto` — the standalone limit, via `Filter.Tendsto.congr` applied to Mathlib's `Real.tendsto_prod_pi_div_two`.

## Verification

- Compiles cleanly with `lake env lean` (0 sorries).
- `#print axioms wallis_tendsto` → `[propext, Classical.choice, Quot.sound]` only — **0 axioms**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)