### PR TITLE
research(niven-theorem-oq-02): Niven's theorem for sine — rational sin at rational multiples of π

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2791,6 +2791,7 @@ import Proofs.NewtonInductiveStepOQ02
 import Proofs.NewtonInductiveStepOQ03
 import Proofs.NewtonLogConcavity
 import Proofs.NivenTheorem
+import Proofs.NivenTheoremOQ02
 import Proofs.NthRootIrrational
 import Proofs.NthRootIrrationalOQ01
 import Proofs.NthRootIrrationalOQ01OQ01

--- a/proofs/Proofs/NivenTheoremOQ02.lean
+++ b/proofs/Proofs/NivenTheoremOQ02.lean
@@ -1,0 +1,95 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds
+import Mathlib.NumberTheory.Niven
+import Mathlib.Tactic
+
+/-
+# Niven's Theorem for Sine
+
+## What This Proves
+If `θ` is a rational multiple of `π` (i.e. `θ = (m/n)·π`) and `sin θ` is rational,
+then `sin θ ∈ {0, ±1/2, ±1}`.
+
+This is the sine companion to Niven's theorem. The gallery entry
+`niven-theorem-oq-01` (`Proofs/NivenTheorem.lean`) proves the *cosine* statement
+only: the rational values of `cos` at rational multiples of `π` are `0, ±1/2, ±1`.
+
+## Approach
+The sine result is a clean corollary of the cosine result via the co-function
+identity `cos (π/2 - θ) = sin θ` (`Real.cos_pi_div_two_sub`).
+
+If `θ = (m/n)·π`, set `φ := π/2 - θ`. Then
+`φ = (1/2 - m/n)·π = ((n - 2m)/(2n))·π`,
+so `φ` is again a rational multiple of `π` (numerator `n - 2m`, denominator `2n`).
+Moreover `cos φ = sin θ`, so if `sin θ` is rational then `cos φ` is rational.
+Cosine Niven applied to `φ` gives `cos φ ∈ {0, ±1/2, ±1}`, i.e.
+`sin θ ∈ {0, ±1/2, ±1}`.
+
+## Status
+- [x] Cosine core restated (delegates the deep algebraic-integer step to Mathlib's
+      `Real.isIntegral_two_mul_cos_rat_mul_pi`, exactly as `niven-theorem-oq-01`)
+- [x] Sine corollary derived via `Real.cos_pi_div_two_sub`
+
+## Mathlib Dependencies
+- `Real.isIntegral_two_mul_cos_rat_mul_pi` — `2 cos(q π)` is integral over `ℤ`
+- `IsIntegral.exists_int_iff_exists_rat` — a rational algebraic integer is an integer
+- `Real.cos_le_one`, `Real.neg_one_le_cos` — cosine bounds (enumeration tail)
+- `Real.cos_pi_div_two_sub` — co-function identity `cos (π/2 - x) = sin x`
+-/
+
+namespace NivenTheoremOQ02
+
+open Real
+
+/-- **Cosine Niven (helper).** Restated from `niven-theorem-oq-01` so the sine
+corollary is self-contained: if `θ` is a rational multiple of `π` and `cos θ` is
+rational, then `cos θ ∈ {0, ±1/2, ±1}`. The deep step (`2 cos θ` is an algebraic
+integer) is delegated to Mathlib. -/
+theorem cos_niven (θ : ℝ) (m n : ℤ) (hn : n ≠ 0) (hθ : θ = (m / n : ℝ) * π)
+    (hcos : ∃ r : ℚ, Real.cos θ = r) :
+    Real.cos θ = 0 ∨ Real.cos θ = 1 / 2 ∨ Real.cos θ = -1 / 2 ∨
+      Real.cos θ = 1 ∨ Real.cos θ = -1 := by
+  obtain ⟨r, hr⟩ := hcos
+  have hq : θ = ((m / n : ℚ) : ℝ) * π := by rw [hθ]; push_cast; ring
+  have hint : IsIntegral ℤ (2 * Real.cos θ) := by
+    rw [hq]; exact Real.isIntegral_two_mul_cos_rat_mul_pi (m / n)
+  obtain ⟨k, hk⟩ :=
+    hint.exists_int_iff_exists_rat.mp ⟨2 * r, by rw [hr]; push_cast; ring⟩
+  have hub : Real.cos θ ≤ 1 := Real.cos_le_one θ
+  have hlb : -1 ≤ Real.cos θ := Real.neg_one_le_cos θ
+  have hkl : -2 ≤ k := by
+    have : (-2 : ℝ) ≤ (k : ℝ) := by linarith
+    exact_mod_cast this
+  have hku : k ≤ 2 := by
+    have : (k : ℝ) ≤ 2 := by linarith
+    exact_mod_cast this
+  interval_cases k <;> push_cast at hk
+  · right; right; right; right; linarith
+  · right; right; left; linarith
+  · left; linarith
+  · right; left; linarith
+  · right; right; right; left; linarith
+
+/-- **Niven's Theorem for sine.** If `θ` is a rational multiple of `π` and
+`sin θ` is rational, then `sin θ ∈ {0, ±1/2, ±1}`. -/
+theorem sin_niven (θ : ℝ) (m n : ℤ) (hn : n ≠ 0) (hθ : θ = (m / n : ℝ) * π)
+    (hsin : ∃ r : ℚ, Real.sin θ = r) :
+    Real.sin θ = 0 ∨ Real.sin θ = 1 / 2 ∨ Real.sin θ = -1 / 2 ∨
+      Real.sin θ = 1 ∨ Real.sin θ = -1 := by
+  -- The complementary angle `φ = π/2 - θ` is again a rational multiple of `π`,
+  -- and `cos φ = sin θ`.
+  set φ := π / 2 - θ with hφ
+  have hsc : Real.cos φ = Real.sin θ := by rw [hφ, Real.cos_pi_div_two_sub]
+  have hn' : (n : ℝ) ≠ 0 := Int.cast_ne_zero.mpr hn
+  have hφeq : φ = ((↑(n - 2 * m) : ℝ) / (↑(2 * n) : ℝ)) * π := by
+    rw [hφ, hθ]
+    push_cast
+    field_simp
+  have h2n : (2 * n : ℤ) ≠ 0 := mul_ne_zero (by norm_num) hn
+  have hcosrat : ∃ r : ℚ, Real.cos φ = r := by
+    obtain ⟨r, hr⟩ := hsin
+    exact ⟨r, by rw [hsc, hr]⟩
+  have hcn := cos_niven φ (n - 2 * m) (2 * n) h2n hφeq hcosrat
+  rwa [hsc] at hcn
+
+end NivenTheoremOQ02

--- a/src/data/proofs/niven-theorem-oq-02/meta.json
+++ b/src/data/proofs/niven-theorem-oq-02/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "niven-theorem-oq-02",
+  "title": "Niven's Theorem for Sine: the only rational sines at rational multiples of π are 0, ±1/2, ±1",
+  "slug": "niven-theorem-oq-02",
+  "description": "The sine companion to Niven's theorem: if θ is a rational multiple of π and sin θ is rational, then sin θ ∈ {0, ±1/2, ±1}. This is derived as a clean corollary of the cosine statement (niven-theorem-oq-01) via the co-function identity cos(π/2 − θ) = sin θ: the complementary angle π/2 − (m/n)π = ((n − 2m)/(2n))π is again a rational multiple of π, so cosine Niven applied there transports verbatim to the sine. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Ivan Niven (1956), formalized in Lean 4 presenting Mathlib's Niven theorem (Meiburg–Broshi 2025)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Niven%27s_theorem",
+    "date": "1956",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NivenTheoremOQ02.lean",
+    "tags": [
+      "number-theory",
+      "algebraic-integers",
+      "trigonometry",
+      "rational-multiples-of-pi",
+      "co-function-identity",
+      "diophantine"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. The hypotheses are inputs to the statement: θ = (m/n)·π with n ≠ 0 (θ is a rational multiple of π) and sin θ rational. Both lemmas and the main theorem are fully machine-checked. The algebraic-integer core is cited from Mathlib (via the restated cosine helper), not re-proved from scratch; no assumptions are introduced by that delegation.",
+    "lineCount": 95,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.isIntegral_two_mul_cos_rat_mul_pi",
+        "description": "The deep step (via the cosine helper): for any rational q, the real number 2·cos(q·π) is integral over ℤ. The sine corollary applies this to the complementary angle φ = π/2 − θ, which is again a rational multiple of π.",
+        "module": "Mathlib.NumberTheory.Niven"
+      },
+      {
+        "theorem": "IsIntegral.exists_int_iff_exists_rat",
+        "description": "A rational number that is integral over ℤ is in fact a (rational) integer — ℤ is integrally closed in ℚ. Turns '2·cos φ is an algebraic integer and rational' into '2·cos φ ∈ ℤ'.",
+        "module": "Mathlib.RingTheory.IntegrallyClosed"
+      },
+      {
+        "theorem": "Real.cos_pi_div_two_sub",
+        "description": "The co-function identity cos(π/2 − x) = sin x. This is the entire bridge from the cosine classification to the sine classification: it identifies sin θ with cos φ for the complementary angle φ = π/2 − θ.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.cos_le_one / Real.neg_one_le_cos",
+        "description": "The elementary bounds −1 ≤ cos φ ≤ 1, confining the integer k = 2·cos φ to {−2,−1,0,1,2} for the finite enumeration inside the cosine helper.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The sine companion sin_niven: rational sin at a rational multiple of π forces sin θ ∈ {0, ±1/2, ±1}, a statement not present in the gallery's cosine-only entry and not stated standalone in Mathlib",
+      "An explicit complementary-angle reduction: φ = π/2 − θ = ((n − 2m)/(2n))·π is verified in Lean to be a rational multiple of π with denominator 2n, so the cosine theorem applies with concrete integer numerator/denominator data",
+      "A clean transport via the co-function identity Real.cos_pi_div_two_sub, isolating the sine result as a one-rewrite corollary of the cosine classification rather than a re-proof"
+    ],
+    "relatedProblems": [
+      {
+        "id": "niven-theorem-oq-01",
+        "relationship": "Direct parent — proves the cosine classification cos θ ∈ {0, ±1/2, ±1}. The oq-01 entry's open questions explicitly request this sine companion via the π/2 shift; this entry supplies it."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Niven's 1956 theorem (Irrational Numbers, Carus Mathematical Monographs) classifies the rational values of cosine at rational multiples of π as exactly {0, ±1/2, ±1}. Because sine is a quarter-turn shift of cosine, sin θ = cos(π/2 − θ), the same classification holds verbatim for the sine, and the complementary angle of a rational multiple of π is itself a rational multiple of π. This sine companion is the form most often quoted when one wants the irrationality of sin(rational degrees) — e.g. sin 1° is irrational — paralleling the cosine application to rotation matrices. Mathlib gained a complete Niven formalization in 2025 (Mathlib/NumberTheory/Niven.lean, Alex Meiburg and Snir Broshi) but states it for the cosine; this gallery entry derives the sine version explicitly.",
+    "problemStatement": "**Niven's Theorem for sine** (Niven, 1956): If θ is a rational multiple of π (θ = (m/n)·π with m, n integers, n ≠ 0) and sin θ is rational, then\n$$\\sin\\theta \\in \\{0,\\ \\pm\\tfrac12,\\ \\pm 1\\}.$$",
+    "proofStrategy": "Reduce to the cosine theorem via the complementary angle.\n1. **Restated cosine core** (`cos_niven`): the cosine classification, identical to niven-theorem-oq-01 — write θ = q·π, get 2·cos θ integral over ℤ via Mathlib, force it to be an integer in [−2,2], and `interval_cases`.\n2. **Complementary-angle reduction** (`sin_niven`): set φ = π/2 − θ. Then `Real.cos_pi_div_two_sub` gives cos φ = sin θ, and a `field_simp` computation shows φ = ((n − 2m)/(2n))·π, a rational multiple of π with denominator 2n ≠ 0. Applying `cos_niven` to φ yields cos φ ∈ {0, ±1/2, ±1}; rewriting cos φ = sin θ gives the result.",
+    "keyInsights": [
+      "**The complementary angle of a rational multiple of π is a rational multiple of π.** π/2 − (m/n)π = ((n − 2m)/(2n))·π; the denominator merely doubles. This is what lets the cosine theorem be reused unchanged for the sine.",
+      "**One identity does all the work.** cos(π/2 − θ) = sin θ converts the entire sine question into a cosine question; no new algebraic-number theory is needed beyond what the cosine case already imports.",
+      "**Rationality transports across the shift.** sin θ ∈ ℚ ⇔ cos φ ∈ ℚ for φ = π/2 − θ, because the two are literally equal; so the hypothesis of the cosine theorem is met exactly when the sine hypothesis is.",
+      "**The headline application: sin of rational degrees is almost never rational.** Exactly as for cosine, this forces sin 1° (and most sin of rational-degree angles) to be irrational, the standard ingredient in impossibility results about exact rational rotations."
+    ],
+    "prerequisites": [
+      "Niven's cosine theorem (niven-theorem-oq-01) and its algebraic-integer core",
+      "The co-function identity cos(π/2 − x) = sin x",
+      "Elementary rational arithmetic with π (field_simp over ℝ)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Imports (Trigonometric.Basic/Bounds, NumberTheory.Niven, Tactic), the module docstring stating the sine companion and the complementary-angle strategy, and `namespace NivenTheoremOQ02` / `open Real`.",
+      "mathContext": "θ a rational multiple of π and sin θ ∈ ℚ ⇒ sin θ ∈ {0, ±1/2, ±1}."
+    },
+    {
+      "id": "cos-helper",
+      "title": "Cosine Niven (restated helper)",
+      "startLine": 44,
+      "endLine": 71,
+      "summary": "`cos_niven`: the cosine classification, restated so the sine corollary is self-contained. Writes θ = q·π (q = m/n : ℚ), invokes `Real.isIntegral_two_mul_cos_rat_mul_pi` and `IsIntegral.exists_int_iff_exists_rat` to get 2·cos θ = k ∈ ℤ, bounds k to {−2,…,2} via the cosine bounds, and closes the five `interval_cases` branches by `linarith`.",
+      "mathContext": "θ = (m/n)π, cos θ ∈ ℚ ⇒ cos θ ∈ {0, ±1/2, ±1}."
+    },
+    {
+      "id": "sine-corollary",
+      "title": "Sine Companion via the Complementary Angle",
+      "startLine": 73,
+      "endLine": 95,
+      "summary": "`sin_niven`: set φ = π/2 − θ; `Real.cos_pi_div_two_sub` gives cos φ = sin θ. A `push_cast`/`field_simp` computation establishes φ = ((n − 2m)/(2n))·π with 2n ≠ 0, so φ is a rational multiple of π. The sine hypothesis transports to cos φ ∈ ℚ, `cos_niven` applies to φ, and rewriting cos φ = sin θ delivers sin θ ∈ {0, ±1/2, ±1}.",
+      "mathContext": "φ = π/2 − θ = ((n − 2m)/(2n))π, cos φ = sin θ ⇒ sin θ ∈ {0, ±1/2, ±1}."
+    }
+  ],
+  "conclusion": {
+    "summary": "The sine companion to Niven's theorem is presented in Lean 4 with zero sorries and zero axioms. The cosine classification is restated (delegating the algebraic-integer step to Mathlib) and the sine result is obtained as a one-rewrite corollary: the complementary angle φ = π/2 − θ is shown to be a rational multiple of π (denominator 2n), and the co-function identity cos(π/2 − θ) = sin θ transports the cosine classification to sin θ ∈ {0, ±1/2, ±1}.",
+    "implications": "Together with the cosine entry this completes the trigonometric half of Niven's classification, and supplies the form most directly used to prove the irrationality of sin at rational-degree angles. The reduction also illustrates a reusable pattern: a co-function or shift identity that maps a rational multiple of π to another rational multiple of π lets a single classification theorem cover all three of sin, cos (and, with more care, tan).",
+    "openQuestions": [
+      "Add the tangent companion: rational tan θ at a rational multiple of π forces tan θ ∈ {0, ±1} — sharper than the sine/cosine case and requiring its own argument since tan is unbounded.",
+      "Specialize to a clean corollary 'sin 1° is irrational' (and sin of rational degrees generally), packaging the irrationality consequence used in rotation-matrix impossibility results."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "niven-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent cosine entry. This sine companion is exactly the follow-up requested in the cosine entry's open questions ('Formalize the sine and tangent companions … sin θ ∈ {0, ±1/2, ±1} via the π/2 shift'), reusing its algebraic-integer core through the restated cos_niven helper."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/NivenTheoremOQ02.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "NivenTheoremOQ02",
+    "lineCount": 95,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 2
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds the **sine companion** to Niven's theorem (gallery `niven-theorem-oq-01` covers cosine only):

> If `θ = (m/n)·π` (n ≠ 0) and `sin θ` is rational, then `sin θ ∈ {0, ±1/2, ±1}`.

This is exactly the follow-up requested in the cosine entry's open questions ("Formalize the sine and tangent companions … `sin θ ∈ {0, ±1/2, ±1}` via the π/2 shift").

## Approach

A clean corollary of the cosine classification via the co-function identity `Real.cos_pi_div_two_sub` (`cos(π/2 − x) = sin x`):

- Set `φ = π/2 − θ`. Then `cos φ = sin θ`.
- `φ = π/2 − (m/n)π = ((n − 2m)/(2n))·π` is again a rational multiple of π (denominator `2n ≠ 0`), verified by `field_simp`.
- Applying the cosine theorem to `φ` gives `cos φ ∈ {0, ±1/2, ±1}`; rewriting `cos φ = sin θ` yields the sine result.

The cosine core (`cos_niven`) is restated so the file is self-contained, delegating the deep algebraic-integer step to Mathlib's `Real.isIntegral_two_mul_cos_rat_mul_pi` — identical to `niven-theorem-oq-01`.

## Verification

- **0 axioms** (`#print axioms NivenTheoremOQ02.sin_niven` → `[propext, Classical.choice, Quot.sound]` only), **0 sorries**.
- Compiles cleanly under Mathlib v4.26 (`lake env lean Proofs/NivenTheoremOQ02.lean`).

## Files

- `proofs/Proofs/NivenTheoremOQ02.lean` (new, 95 lines, 2 theorems)
- `src/data/proofs/niven-theorem-oq-02/meta.json` (new gallery entry)
- `proofs/Proofs.lean` (one import added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)