### PR TITLE
research(erdos-340-greedy-sidon-oq-01): analytic rpow form of the N^(1/3) lower bound (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1432,6 +1432,7 @@ import Proofs.Erdos339Problem
 import Proofs.Erdos33Problem
 import Proofs.Erdos340GreedyExtension
 import Proofs.Erdos340GreedyGrowth
+import Proofs.Erdos340GreedyRpowBound
 import Proofs.Erdos340GreedySidon
 import Proofs.Erdos340GreedySidonOQ02
 import Proofs.Erdos340Problem

--- a/proofs/Proofs/Erdos340GreedyRpowBound.lean
+++ b/proofs/Proofs/Erdos340GreedyRpowBound.lean
@@ -1,0 +1,163 @@
+/-
+# Erdős Problem #340 (oq-01): the analytic `Ω(N^(1/3))` lower bound for the greedy Sidon counting function
+
+The companion file `Erdos340GreedyGrowth.lean` proves the **cubic growth bound**
+`aₙ ≤ (n+1) + (n+1)³` and its immediate discrete consequence
+`greedy_count_ge`: whenever `N ≥ 2(n+1)³`, at least `n+1` greedy terms lie in `[1, N]`.
+
+What remained — flagged there as the *only* missing piece of the known direction — was the
+polished **`rpow` phrasing**: the statement actually appearing in the literature (and as the
+axiom `greedy_sidon_lower_bound` in `Erdos340Problem.lean`),
+
+  `∃ C > 0, ∀ N > 0,  C · N^(1/3) ≤ A(N)`,
+
+where `A(N) = #{ k : aₖ ≤ N }` is the greedy Sidon counting function.  This file supplies it
+as a fully verified, `0`-axiom theorem (`greedyCount_rpow_lower`), with the explicit constant
+`C = 2^(-4/3)`.
+
+## The argument
+
+Define `greedyCount N = #{ k ≤ N : aₖ ≤ N }`.  Because `aₖ ≥ k` (strict monotonicity), the
+window `range (N+1)` already captures every index with `aₖ ≤ N`, so this counts *all* greedy
+terms in `[1, N]`.
+
+The cubic bound `aₙ ≤ 2(n+1)³` gives the discrete count bound (`greedyCount_ge_index`):
+
+  `2(n+1)³ ≤ N  ⟹  n+1 ≤ A(N)`.
+
+Its **contrapositive**, applied at `n = A(N)`, is the clean inversion (`lt_two_mul_succ_cube`):
+
+  `0 < N  ⟹  N < 2·(A(N) + 1)³`.
+
+Since `A(N) ≥ 1` for `N ≥ 1` (the term `a₀ = 1` is counted), `A(N) + 1 ≤ 2·A(N)`, hence
+
+  `N < 2·(2 A(N))³ = 16 · A(N)³`.
+
+Taking cube roots (`rpow (1/3)`, which is monotone on `[0, ∞)`):
+
+  `N^(1/3) < 16^(1/3) · A(N) = 2^(4/3) · A(N)`,   i.e.   `2^(-4/3) · N^(1/3) ≤ A(N)`.
+
+NOTE on the `1/3`-vs-`1/2` gap: the `N^(1/3)` exponent is the *known* lower bound.  Improving
+it for the greedy sequence is the OPEN part of Erdős #340 and is **not** attempted here.
+-/
+import Proofs.Erdos340GreedyGrowth
+
+namespace Erdos340
+
+open Finset
+
+/- ## The greedy Sidon counting function -/
+
+/-- The greedy Sidon **counting function** `A(N) = #{ k : aₖ ≤ N }`.
+
+Because `aₖ ≥ k` (strict monotonicity, `greedySidonSeq_strictMono.id_le`), the search window
+`range (N+1)` already contains every index `k` with `aₖ ≤ N`, so this Finset counts *all*
+greedy terms not exceeding `N`. -/
+noncomputable def greedyCount (N : ℕ) : ℕ :=
+  ((Finset.range (N + 1)).filter (fun k => greedySidonSeq k ≤ N)).card
+
+/-- `k ≤ aₖ`: a strictly increasing `ℕ → ℕ` sequence dominates the identity. -/
+theorem index_le_greedySidonSeq (k : ℕ) : k ≤ greedySidonSeq k :=
+  greedySidonSeq_strictMono.id_le k
+
+/-- **Discrete count bound.**  Whenever `N ≥ 2(n+1)³`, the first `n+1` greedy terms all lie in
+`[1, N]`, so `A(N) ≥ n+1`.  This repackages `greedySidonSeq_le_two_mul_cubic` against the
+index-based counting function. -/
+theorem greedyCount_ge_index {n N : ℕ} (hN : 2 * (n + 1) ^ 3 ≤ N) :
+    n + 1 ≤ greedyCount N := by
+  have hsub : Finset.range (n + 1)
+      ⊆ (Finset.range (N + 1)).filter (fun k => greedySidonSeq k ≤ N) := by
+    intro k hk
+    rw [Finset.mem_range] at hk
+    -- aₖ ≤ aₙ ≤ 2(n+1)³ ≤ N
+    have hak : greedySidonSeq k ≤ N := by
+      have h1 : greedySidonSeq k ≤ greedySidonSeq n :=
+        greedySidonSeq_strictMono.monotone (by omega)
+      have h2 : greedySidonSeq n ≤ 2 * (n + 1) ^ 3 := greedySidonSeq_le_two_mul_cubic n
+      omega
+    rw [Finset.mem_filter, Finset.mem_range]
+    refine ⟨?_, hak⟩
+    -- k ≤ aₖ ≤ N < N + 1
+    have := index_le_greedySidonSeq k
+    omega
+  calc n + 1 = (Finset.range (n + 1)).card := (Finset.card_range _).symm
+    _ ≤ _ := Finset.card_le_card hsub
+
+/-- For `N ≥ 1` the term `a₀ = 1` is always counted, so `A(N) ≥ 1`. -/
+theorem one_le_greedyCount {N : ℕ} (hN : 0 < N) : 1 ≤ greedyCount N := by
+  have hne : ((Finset.range (N + 1)).filter (fun k => greedySidonSeq k ≤ N)).Nonempty := by
+    refine ⟨0, ?_⟩
+    rw [Finset.mem_filter, Finset.mem_range]
+    refine ⟨Nat.succ_pos N, ?_⟩
+    have h0 : greedySidonSeq 0 = 1 := rfl
+    omega
+  unfold greedyCount
+  exact Finset.card_pos.mpr hne
+
+/-- **Inversion of the cubic bound** (contrapositive of `greedyCount_ge_index`).
+
+`N < 2·(A(N) + 1)³`.  If instead `N ≥ 2·(A(N)+1)³`, the count bound would force
+`A(N) + 1 ≤ A(N)`, impossible.  This is the key step turning the *upper* bound on the
+sequence values into a *lower* bound on the counting function. -/
+theorem lt_two_mul_succ_cube (N : ℕ) : N < 2 * (greedyCount N + 1) ^ 3 := by
+  by_contra h
+  push_neg at h
+  have hge := greedyCount_ge_index (n := greedyCount N) h
+  omega
+
+/- ## The analytic `Ω(N^(1/3))` lower bound -/
+
+/-- **The known `N^(1/3)` lower bound for the greedy Sidon sequence, in `rpow` form.**
+
+There is an explicit constant `C = 2^(-4/3) > 0` such that the greedy Sidon counting function
+`A(N) = #{ k : aₖ ≤ N }` satisfies
+
+  `C · N^(1/3) ≤ A(N)`   for every `N ≥ 1`.
+
+This is the polished analytic statement of Erdős #340's *known* direction — the form that
+appears in the literature and as the axiom `greedy_sidon_lower_bound` in `Erdos340Problem.lean`
+— here proved as a fully verified, `0`-axiom theorem from the elementary cubic growth bound.
+
+The `1/3`→`1/2` exponent improvement remains the OPEN conjecture and is **not** addressed. -/
+theorem greedyCount_rpow_lower :
+    ∃ C : ℝ, 0 < C ∧ ∀ N : ℕ, 0 < N →
+      C * (N : ℝ) ^ ((1 : ℝ) / 3) ≤ (greedyCount N : ℝ) := by
+  have h2 : (0 : ℝ) < 2 := by norm_num
+  refine ⟨(2 : ℝ) ^ (-(4 : ℝ) / 3), Real.rpow_pos_of_pos h2 _, ?_⟩
+  intro N hN
+  set A := greedyCount N with hA
+  have hA1 : 1 ≤ A := one_le_greedyCount hN
+  -- Discrete inversion N < 16·A³.
+  have hlt : N < 2 * (A + 1) ^ 3 := lt_two_mul_succ_cube N
+  have hAA : A + 1 ≤ 2 * A := by omega
+  have epow : (A + 1) ^ 3 ≤ (2 * A) ^ 3 := Nat.pow_le_pow_left hAA 3
+  have eexp : (2 * A) ^ 3 = 8 * A ^ 3 := by ring
+  have hN16 : N < 16 * A ^ 3 := by omega
+  have hNR : (N : ℝ) ≤ 16 * (A : ℝ) ^ 3 := by exact_mod_cast hN16.le
+  -- Package the constant: B = 2^(4/3)·A, with B³ = 16·A³.
+  set B := (2 : ℝ) ^ ((4 : ℝ) / 3) * (A : ℝ) with hB
+  have hB0 : 0 ≤ B := by positivity
+  have hBcube : B ^ 3 = 16 * (A : ℝ) ^ 3 := by
+    rw [hB, mul_pow]
+    congr 1
+    rw [← Real.rpow_natCast ((2 : ℝ) ^ ((4 : ℝ) / 3)) 3, ← Real.rpow_mul h2.le]
+    norm_num
+  have hNB : (N : ℝ) ≤ B ^ 3 := by rw [hBcube]; exact hNR
+  -- Cube roots: N^(1/3) ≤ B.
+  have hroot : (B ^ 3 : ℝ) ^ ((1 : ℝ) / 3) = B := by
+    rw [show ((1 : ℝ) / 3) = ((3 : ℕ) : ℝ)⁻¹ by norm_num]
+    exact Real.pow_rpow_inv_natCast hB0 (by norm_num)
+  have hcube_root : (N : ℝ) ^ ((1 : ℝ) / 3) ≤ B := by
+    calc (N : ℝ) ^ ((1 : ℝ) / 3)
+        ≤ (B ^ 3) ^ ((1 : ℝ) / 3) := Real.rpow_le_rpow (by positivity) hNB (by norm_num)
+      _ = B := hroot
+  -- Multiply by C = 2^(-4/3): C·B = A.
+  have hCpos : (0 : ℝ) < (2 : ℝ) ^ (-(4 : ℝ) / 3) := Real.rpow_pos_of_pos h2 _
+  calc (2 : ℝ) ^ (-(4 : ℝ) / 3) * (N : ℝ) ^ ((1 : ℝ) / 3)
+      ≤ (2 : ℝ) ^ (-(4 : ℝ) / 3) * B :=
+        mul_le_mul_of_nonneg_left hcube_root hCpos.le
+    _ = (A : ℝ) := by
+        rw [hB, ← mul_assoc, ← Real.rpow_add h2,
+          show (-(4 : ℝ) / 3 + (4 : ℝ) / 3) = 0 by ring, Real.rpow_zero, one_mul]
+
+end Erdos340

--- a/research/problems/erdos-340-greedy-sidon-oq-01/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-01/knowledge.md
@@ -52,3 +52,41 @@ picked this RICH-knowledge surveyed open problem instead).
 ### Honesty note
 This is the **known** lower-bound direction (cubic ⇒ N^(1/3)). The 1/3→1/2 exponent
 improvement is the OPEN part of Erdős #340 and is NOT addressed.
+
+## Session 2026-06-20 (Session N+1) - Analytic rpow lower bound
+
+**Mode**: REVISIT (depth-over-breadth follow-up)
+**Outcome**: progress (verified, 0-axiom)
+
+### What I Did
+- Built `proofs/Proofs/Erdos340GreedyRpowBound.lean` (new, ~165 lines, 0-axiom) on top of
+  the just-merged `Erdos340GreedyGrowth.lean` (PR #27012).
+- Defined the index-based counting function `greedyCount N = #{ k ≤ N : aₖ ≤ N }` and proved
+  `greedyCount_ge_index` (`2(n+1)³ ≤ N ⟹ n+1 ≤ A(N)`) and `one_le_greedyCount`.
+- Proved the inversion `lt_two_mul_succ_cube : N < 2·(A(N)+1)³` (contrapositive of the count
+  bound at `n = A(N)`).
+- Proved the headline `greedyCount_rpow_lower : ∃ C>0, ∀ N>0, C·N^(1/3) ≤ A(N)` with explicit
+  `C = 2^(-4/3)` — the analytic `rpow` form matching the literature / the
+  `greedy_sidon_lower_bound` axiom in `Erdos340Problem.lean`.
+
+### Key Findings
+- No floor / real cube-root inversion is needed: `N < 2(A+1)³` together with `A ≥ 1` gives
+  `N < 16 A³`, and a single monotone `rpow (1/3)` finishes it.
+- `Real.pow_rpow_inv_natCast (0≤x) (n≠0) : (x^n)^(n⁻¹:ℝ) = x` is the clean cube-root lemma;
+  rewrite `(1/3) = ((3:ℕ):ℝ)⁻¹` (`by norm_num`) to match. Packaging `B = 2^(4/3)·A` with
+  `B³ = 16 A³` sidesteps `mul_rpow` on the constant `16`.
+- The constant collapses via `← Real.rpow_add`: `2^(-4/3) · 2^(4/3) = 2^0 = 1`.
+
+### Files Modified
+- `proofs/Proofs/Erdos340GreedyRpowBound.lean` (new, 0-axiom)
+- `proofs/Proofs.lean` (import)
+- `src/data/research/problems/erdos-340-greedy-sidon-oq-01.json` (knowledge)
+
+### Next Steps
+- Discharge the `greedy_sidon_lower_bound` axiom in the *separate* `Erdos340Problem.lean` by
+  bridging its `sInf`-based `greedySidon` to the `Nat.find`-based `greedySidonSeq`.
+- Parent's remaining axiom: Erdős–Turán upper bound `sidon_upper_bound`.
+
+### Honesty note
+This is still the **known** lower-bound direction, now in its polished analytic form. The
+1/3→1/2 exponent improvement is the OPEN part of Erdős #340 and is NOT addressed.

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-01.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-01.json
@@ -31,13 +31,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (verified, 0-axiom): the cubic growth bound aₙ ≤ (n+1)+(n+1)³ (greedySidonSeq_le_cubic) and the discrete Ω(N^(1/3)) count lower bound (greedy_count_ge) are now PROVED in Erdos340GreedyGrowth.lean — the quantitative crux of Erdős #340 known direction, previously only a comment-level sketch in the parent. The crux necessary lemma turned out to be a one-line contrapositive of the parent sidon_insert_of_large.",
+    "progressSummary": "PROGRESS (verified, 0-axiom): the KNOWN N^(1/3) lower-bound direction of Erdős #340 is now complete in BOTH discrete (greedy_count_ge) and analytic rpow (greedyCount_rpow_lower: ∃C>0, C·N^(1/3)≤A(N), C=2^(-4/3)) form. The cubic growth bound aₙ≤(n+1)+(n+1)³ drives both. The 1/3→1/2 improvement remains OPEN.",
     "builtItems": [
       "Turnkey BUILD-PENDING draft: research/problems/erdos-340-greedy-sidon-oq-01/construction-draft.lean — forbidden set + forbidden_card_le (≤|A|^3) + forbidden_mono with real proofs; crux/existence/gSet recursion/covering/inversion/parent-axiom-rebuild as structured statements with sorry+precise proof comments. Only mem_forbidden_of_not_sidon_insert is genuinely technical (Aristotle target); rest is induction+omega+card arithmetic.",
       "PR #24965 (research label): corrected parent inline sketch O(n^2)→O(n^3) with covering argument + the 1/3-vs-1/2 OPEN-conjecture distinction. Comment-only, build-neutral.",
       "proofs/Proofs/Erdos340GreedyGrowth.lean: greedySidonSeq_le_cubic (aₙ ≤ (n+1)+(n+1)³) — VERIFIED 0-axiom, the global forbidden-set covering bound that was previously only a comment in the parent.",
       "Erdos340GreedyGrowth.lean: greedy_count_ge — for N ≥ 2(n+1)³, at least n+1 greedy terms lie in [1,N]; the discrete Ω(N^(1/3)) lower bound (no rpow, no axiom).",
-      "Erdos340GreedyGrowth.lean supporting verified lemmas: forbidden (def) + forbidden_card_le (≤ |A|³) + forbidden_mono + not_sidon_insert_forbidden (crux) + greedy_covering (induction) + greedy_skip_not_sidon (Nat.find minimality) + greedySeqSet_card/greedySeqSet_le/greedySeqSet_subset_Icc/greedySidonSeq_le_two_mul_cubic/one_le_greedySidonSeq."
+      "Erdos340GreedyGrowth.lean supporting verified lemmas: forbidden (def) + forbidden_card_le (≤ |A|³) + forbidden_mono + not_sidon_insert_forbidden (crux) + greedy_covering (induction) + greedy_skip_not_sidon (Nat.find minimality) + greedySeqSet_card/greedySeqSet_le/greedySeqSet_subset_Icc/greedySidonSeq_le_two_mul_cubic/one_le_greedySidonSeq.",
+      "greedyCount (Erdos340GreedyRpowBound.lean): index-based counting function A(N)=#{k:aₖ≤N}, with greedyCount_ge_index (2(n+1)³≤N ⟹ n+1≤A(N)) and one_le_greedyCount",
+      "lt_two_mul_succ_cube (Erdos340GreedyRpowBound.lean): N<2(A(N)+1)³ — contrapositive inversion turning the cubic upper bound on values into a lower bound on the count",
+      "greedyCount_rpow_lower (Erdos340GreedyRpowBound.lean): ∃C>0 ∀N>0, C·N^(1/3)≤A(N) with explicit C=2^(-4/3) — the analytic rpow form of the known N^(1/3) lower bound, 0-axiom"
     ],
     "insights": [
       "StrictMono + IsSidon do NOT imply N^(1/3) growth: counterexample a_n=2^n is Sidon, strictly increasing, but counting function is only log2(N). So the growth axiom is independent of the other three greedySidonSeq axioms and unprovable for the opaque object.",
@@ -48,15 +51,17 @@
       "WARNING: the naive INCREMENTAL gap bound a_{k+1}-a_k ≤ |A_k|^3 only telescopes to a_n=O(n^4) ⟹ N^(1/4). The cubic a_n=O(n^3) ⟹ N^(1/3) REQUIRES the GLOBAL covering argument: every p∈[1,a_n] is in A_n or forbidden(A_n) using the FULL final set A_n (each skipped p broke Sidon against a subset of A_n; forbidden is monotone). Then a_n ≤ |A_n|+|forbidden A_n| ≤ (n+1)+(n+1)^3.",
       "KEY SIMPLIFICATION: the crux mem_forbidden_of_not_sidon_insert (flagged by prior sessions as the genuinely-technical Aristotle target) is a ONE-LINE contrapositive of the parent sidon_insert_of_large — that lemma already carries the hard 6-way collision case analysis, so the necessary direction needs no new case work.",
       "The global covering is cleanest as plain induction on n of: ∀ p∈[1,aₙ], p ∈ Aₙ ∨ p ∈ forbidden(Aₙ). The min-index / skipped-value bookkeeping is handled automatically by the successor case: p≤aₙ → IH + monotone lift; p=a_{n+1} → ∈A; aₙ<p<a_{n+1} → skipped, so Nat.find_min gives ¬IsSidon(insert p Aₙ) → forbidden.",
-      "Defeq facts that make it go through: greedySeqSet (n+1) = insert (greedySidonSeq (n+1)) (greedySeqSet n) by rfl, and greedySidonSeq (n+1) = nextSidon (greedySeqSet n) (greedySidonSeq n) by rfl — the latter exposes Nat.find for the minimality argument."
+      "Defeq facts that make it go through: greedySeqSet (n+1) = insert (greedySidonSeq (n+1)) (greedySeqSet n) by rfl, and greedySidonSeq (n+1) = nextSidon (greedySeqSet n) (greedySidonSeq n) by rfl — the latter exposes Nat.find for the minimality argument.",
+      "The analytic rpow lower bound needs NO floor/cube-root inversion: from N<2(A+1)³ and A≥1 ⟹ N<16A³, then a single rpow(1/3) (monotone) with Real.pow_rpow_inv_natCast gives N^(1/3)≤2^(4/3)·A directly — explicit constant C=2^(-4/3).",
+      "Real.pow_rpow_inv_natCast (hx:0≤x)(hn:n≠0):(x^n)^(n⁻¹:ℝ)=x is the clean cube-root tool; rewrite (1/3)=((3:ℕ):ℝ)⁻¹ by norm_num to match. Packaging B=2^(4/3)·A with B³=16A³ avoids mul_rpow gymnastics on 16."
     ],
     "mathlibGaps": [
       "No foundational Mathlib gap: the N^(1/3) bound is elementary Finset/Nat counting on top of the parents IsSidon API. Blocker is the missing local greedy construction, not Mathlib."
     ],
     "nextSteps": [
-      "Optional rpow inversion: bridge greedy_count_ge (discrete cube form, N ≥ 2k³ ⇒ count ≥ k) to the rpow statement ∃C>0, ∀N>0, C·N^(1/3) ≤ count, if the gallery wants the analytic phrasing.",
-      "NOTE: axiom greedy_sidon_lower_bound lives in the SEPARATE Erdos340Problem.lean (sInf-based greedySidon with axiomatized initial values), disconnected from the constructed Nat.find sequence proved here. Full discharge would need bridging the two definitions, or the entry adopting the constructed sequence as canonical.",
-      "Remaining axiom in Erdos340GreedySidon.lean is the Erdős–Turán upper bound sidon_upper_bound (|A| ≤ √N + O(N^(1/4)))."
+      "Discharge axiom greedy_sidon_lower_bound in the SEPARATE Erdos340Problem.lean: needs bridging its sInf-based greedySidon to the Nat.find-based greedySidonSeq (prove the two definitions agree, or re-prove strict_mono/is_sidon for the sInf form).",
+      "Remaining parent axiom: Erdős–Turán upper bound sidon_upper_bound (√N + O(N^(1/4))).",
+      "OPEN: the 1/3→1/2 exponent improvement (the genuinely open part of Erdős #340)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Completes the **polished analytic phrasing** of Erdős #340's *known* lower-bound direction — the final item flagged in the cubic-bound PR (#27012, now merged) next-steps. Builds directly on the just-merged `Erdos340GreedyGrowth.lean`.

New `proofs/Proofs/Erdos340GreedyRpowBound.lean` (**0-axiom**):

| Result | Statement |
|--------|-----------|
| `greedyCount N` | the greedy Sidon counting function `#{ k : aₖ ≤ N }` |
| `greedyCount_ge_index` | `2(n+1)³ ≤ N ⟹ n+1 ≤ A(N)` (discrete count bound) |
| `lt_two_mul_succ_cube` | `N < 2·(A(N)+1)³` (contrapositive inversion) |
| `greedyCount_rpow_lower` | `∃ C>0, ∀ N>0, C·N^(1/3) ≤ A(N)`, explicit `C = 2^(-4/3)` |

`greedyCount_rpow_lower` is exactly the form appearing in the literature and as the axiom `greedy_sidon_lower_bound` in `Erdos340Problem.lean`, now a fully verified theorem.

## How the argument simplifies

The cubic growth bound `aₙ ≤ 2(n+1)³` (from `Erdos340GreedyGrowth.lean`) gives the discrete count bound. Its contrapositive at `n = A(N)` yields `N < 2(A(N)+1)³`. Since `A(N) ≥ 1`, this gives `N < 16·A(N)³`, and a **single monotone `rpow(1/3)`** (via `Real.pow_rpow_inv_natCast`) gives `N^(1/3) ≤ 2^(4/3)·A(N)` — **no floor or real cube-root inversion needed**.

## Verification

```
#print axioms greedyCount_rpow_lower
-- [propext, Classical.choice, Quot.sound]
```

Compiles clean under `lake env lean Proofs/Erdos340GreedyRpowBound.lean` (exit 0, no warnings/sorries).

## Scope / honesty

This is the **known** `N^(1/3)` lower-bound direction, now in its polished analytic form. The `1/3 → 1/2` exponent improvement is the **OPEN** part of Erdős #340 and is **not** addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)