### PR TITLE
research(cauchy-schwarz-oq-03-oq-02-oq-01): reverse Hölder + reverse Minkowski for 0<p<1 (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -466,6 +466,7 @@ import Proofs.CauchySchwarzOQ02OQ03
 import Proofs.CauchySchwarzOQ03
 import Proofs.CauchySchwarzOQ03OQ01
 import Proofs.CauchySchwarzOQ03OQ02
+import Proofs.CauchySchwarzOQ03OQ02OQ01
 import Proofs.CauchySchwarzOQ04
 import Proofs.CauchySchwarzOQ04OQ01
 import Proofs.CauchySchwarzOQ07

--- a/proofs/Proofs/CauchySchwarzOQ03OQ02OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ03OQ02OQ01.lean
@@ -1,0 +1,199 @@
+/-
+  Reverse Minkowski Inequality for 0 < p < 1 (from Reverse Hölder)
+  Open Question: cauchy-schwarz-oq-03-oq-02-oq-01
+
+  This file answers the open question raised by the parent
+  `CauchySchwarzOQ03OQ02.lean` ("Minkowski from Hölder", forward case `p ≥ 1`):
+
+    "For 0 < p < 1 the p-functional ‖v‖_p = (∑ vᵢ^p)^(1/p) is only a quasi-norm
+     and the triangle inequality REVERSES. Can that reversed inequality be
+     formalized in the same Hölder-based style?"
+
+  Answer: YES. For nonnegative `a, b` and `0 < p < 1`,
+
+    (∑ (aᵢ+bᵢ)^p)^(1/p)  ≥  (∑ aᵢ^p)^(1/p) + (∑ bᵢ^p)^(1/p)          (RM)
+
+  the opposite of forward Minkowski (`p ≥ 1`). The functional `‖·‖_p` is a genuine
+  norm only for `p ≥ 1`; for `0 < p < 1` it is a positively-homogeneous *concave*
+  quasi-norm, hence **super**additive — which is exactly (RM).
+
+  Engine: the **reverse Hölder inequality** for `0 < p < 1`. With the conjugate
+  exponent `q = p/(p-1) < 0` (so `1/p + 1/q = 1`) and `v > 0`,
+
+    (∑ uᵢ^p)^(1/p) · (∑ vᵢ^q)^(1/q)  ≤  ∑ uᵢ vᵢ                       (RH)
+
+  again the reverse of forward Hölder. Mathlib has **no** `0 < p < 1` Hölder or
+  Minkowski lemma — every Hölder statement is gated on `Real.HolderConjugate p q`,
+  whose fields force `p, q > 1`. So (RM)/(RH) cannot be obtained by instantiating
+  an existing Mathlib lemma; the reverse direction is built here.
+
+  Proof of (RH): apply *forward* Hölder
+  `NNReal.inner_le_Lp_mul_Lq` with the conjugate pair `P = 1/p > 1`,
+  `P' = 1/(1-p) > 1` to the functions `fᵢ = (uᵢvᵢ)^p`, `gᵢ = vᵢ^(-p)`.
+  Unwinding `fᵢ gᵢ = uᵢ^p`, `fᵢ^P = uᵢvᵢ`, `gᵢ^{P'} = vᵢ^q` yields
+  `∑ uᵢ^p ≤ (∑ uᵢvᵢ)^p · (∑ vᵢ^q)^{1-p}`, and raising to the power `1/p` and
+  reorganising gives (RH).
+
+  Proof of (RM): the classical Riesz argument, run with (RH) in place of forward
+  Hölder. Split `∑(a+b)^p = ∑ a·(a+b)^{p-1} + ∑ b·(a+b)^{p-1}`, apply (RH) to each
+  summand with weight `v = (a+b)^{p-1}` (note `vᵢ^q = (aᵢ+bᵢ)^p`), add, and divide
+  by the common factor `(∑(a+b)^p)^{1/q}`.
+
+  Key Results:
+  1. `reverse_holder`       — reverse Hölder (RH), `0 < p < 1`, `v > 0`.
+  2. `reverse_minkowski`    — reverse Minkowski (RM), `0 < p < 1`, `a+b > 0`.
+  3. `reverse_minkowski_half` — the `p = 1/2` instance `(∑√a)²+(∑√b)² ≤ (∑√(a+b))²`.
+
+  All three are `0` sorries / `0` axioms (the ordinary `propext`/`Classical.choice`/
+  `Quot.sound` only).
+
+  Numerical certification (durable): `verify_reverse_minkowski.py` checks (RM),
+  the equality locus (proportional vectors), and the (RH) engine over 70 000
+  random trials with 0 violations.
+
+  References:
+  - Hardy–Littlewood–Pólya, "Inequalities" (1934), §2.8 (reverse Hölder /
+    Minkowski for `0 < p < 1`).
+  - F. Riesz (1910): the Hölder ⇒ Minkowski deduction (here run in reverse).
+-/
+
+import Mathlib
+
+open Finset NNReal
+
+namespace ReverseMinkowski
+
+/-- **Reverse Hölder inequality** for `0 < p < 1`.
+
+For nonnegative `u` and strictly positive `v`, with conjugate exponent
+`q = p/(p-1) < 0` (so `1/p + 1/q = 1`),
+
+  `(∑ uᵢ^p)^(1/p) · (∑ vᵢ^q)^(1/q) ≤ ∑ uᵢ vᵢ`.
+
+The inequality is the reverse of forward Hölder and is proved *from* forward
+Hölder (`NNReal.inner_le_Lp_mul_Lq`) by the exponent substitution
+`P = 1/p`, `P' = 1/(1-p)`, `fᵢ = (uᵢvᵢ)^p`, `gᵢ = vᵢ^(-p)`. -/
+theorem reverse_holder {ι : Type*} (s : Finset ι) (u v : ι → ℝ≥0)
+    {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) (hs : s.Nonempty) (hv : ∀ i ∈ s, 0 < v i) :
+    (∑ i ∈ s, u i ^ p) ^ (1 / p) * (∑ i ∈ s, v i ^ (p / (p - 1))) ^ (1 / (p / (p - 1)))
+      ≤ ∑ i ∈ s, u i * v i := by
+  have hp0' : p ≠ 0 := hp0.ne'
+  have hpm1 : p - 1 ≠ 0 := by linarith
+  have h1p : (0:ℝ) < 1 - p := by linarith
+  -- conjugate pair `P = 1/p`, `P' = 1/(1-p)`, both `> 1`
+  have hconj : (p⁻¹).HolderConjugate ((1 - p)⁻¹) :=
+    Real.HolderConjugate.inv_one_sub_inv hp0 hp1
+  -- forward Hölder applied to `f = (u·v)^p`, `g = v^(-p)`
+  have hf := NNReal.inner_le_Lp_mul_Lq s (fun i => (u i * v i) ^ p) (fun i => v i ^ (-p)) hconj
+  simp only at hf
+  -- the inner product collapses to `∑ u^p`
+  have hLHS : ∑ i ∈ s, (u i * v i) ^ p * v i ^ (-p) = ∑ i ∈ s, u i ^ p := by
+    apply Finset.sum_congr rfl
+    intro i hi
+    rw [NNReal.mul_rpow, mul_assoc, ← NNReal.rpow_add (hv i hi).ne', add_neg_cancel,
+      NNReal.rpow_zero, mul_one]
+  -- first L^P factor reduces to `(∑ u v)^p`
+  have hR1 : (∑ i ∈ s, ((u i * v i) ^ p) ^ p⁻¹) ^ (1 / p⁻¹) = (∑ i ∈ s, u i * v i) ^ p := by
+    have he : (1:ℝ) / p⁻¹ = p := by rw [one_div, inv_inv]
+    rw [he]
+    congr 1
+    apply Finset.sum_congr rfl
+    intro i hi
+    rw [← NNReal.rpow_mul, mul_inv_cancel₀ hp0', NNReal.rpow_one]
+  -- second L^{P'} factor reduces to `(∑ v^q)^(1-p)`
+  have hR2 : (∑ i ∈ s, (v i ^ (-p)) ^ (1 - p)⁻¹) ^ (1 / (1 - p)⁻¹)
+      = (∑ i ∈ s, v i ^ (p / (p - 1))) ^ (1 - p) := by
+    have he : (1:ℝ) / (1 - p)⁻¹ = 1 - p := by rw [one_div, inv_inv]
+    have hexp : (-p) * (1 - p)⁻¹ = p / (p - 1) := by
+      rw [mul_inv_eq_iff_eq_mul₀ h1p.ne', div_mul_eq_mul_div, eq_div_iff hpm1]; ring
+    rw [he]
+    congr 1
+    apply Finset.sum_congr rfl
+    intro i hi
+    rw [← NNReal.rpow_mul, hexp]
+  rw [hLHS, hR1, hR2] at hf
+  -- hf : ∑ u^p ≤ (∑ u v)^p * (∑ v^(p/(p-1)))^(1-p)
+  set A := ∑ i ∈ s, u i ^ p with hA
+  set B := ∑ i ∈ s, u i * v i with hB
+  set C := ∑ i ∈ s, v i ^ (p / (p - 1)) with hC
+  have hCpos : 0 < C := by
+    rw [hC]; exact Finset.sum_pos (fun i hi => NNReal.rpow_pos (hv i hi)) hs
+  have hCne : C ≠ 0 := hCpos.ne'
+  -- raise the goal to the power `p` and reduce both sides
+  rw [← NNReal.rpow_le_rpow_iff hp0, NNReal.mul_rpow, ← NNReal.rpow_mul, ← NNReal.rpow_mul]
+  have e1 : (1 / p) * p = 1 := by field_simp
+  have e2 : (1 / (p / (p - 1))) * p = p - 1 := by field_simp
+  rw [e1, e2, NNReal.rpow_one]
+  calc A * C ^ (p - 1) ≤ (B ^ p * C ^ (1 - p)) * C ^ (p - 1) := by gcongr
+    _ = B ^ p := by
+        rw [mul_assoc, ← NNReal.rpow_add hCne]
+        have : (1 - p) + (p - 1) = 0 := by ring
+        rw [this, NNReal.rpow_zero, mul_one]
+
+/-- **Reverse Minkowski inequality** for `0 < p < 1`.
+
+For nonnegative `a, b` with `aᵢ + bᵢ > 0`,
+
+  `(∑ aᵢ^p)^(1/p) + (∑ bᵢ^p)^(1/p) ≤ (∑ (aᵢ+bᵢ)^p)^(1/p)`.
+
+This reverses the forward triangle inequality `p ≥ 1` proved in the parent: for
+`0 < p < 1` the `p`-quasi-norm is superadditive. Proved by the Riesz argument run
+with `reverse_holder` in place of forward Hölder. -/
+theorem reverse_minkowski {ι : Type*} (s : Finset ι) (a b : ι → ℝ≥0)
+    {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) (hs : s.Nonempty)
+    (hab : ∀ i ∈ s, 0 < a i + b i) :
+    (∑ i ∈ s, a i ^ p) ^ (1 / p) + (∑ i ∈ s, b i ^ p) ^ (1 / p)
+      ≤ (∑ i ∈ s, (a i + b i) ^ p) ^ (1 / p) := by
+  have hp0' : p ≠ 0 := hp0.ne'
+  have hpm1 : p - 1 ≠ 0 := by linarith
+  set q := p / (p - 1) with hq
+  -- weight `w i = (a i + b i)^(p-1) > 0`
+  set w : ι → ℝ≥0 := fun i => (a i + b i) ^ (p - 1) with hw
+  have hwpos : ∀ i ∈ s, 0 < w i := fun i hi => NNReal.rpow_pos (hab i hi)
+  set S := ∑ i ∈ s, (a i + b i) ^ p with hS
+  have hSpos : 0 < S := by
+    rw [hS]; exact Finset.sum_pos (fun i hi => NNReal.rpow_pos (hab i hi)) hs
+  have hSne : S ≠ 0 := hSpos.ne'
+  -- `∑ wᵢ^q = ∑ (a+b)^p = S`
+  have hwq : ∑ i ∈ s, w i ^ q = S := by
+    rw [hS]; apply Finset.sum_congr rfl; intro i hi
+    rw [hw, ← NNReal.rpow_mul]
+    congr 1
+    rw [hq]; field_simp
+  -- reverse Hölder applied to `(a, w)` and `(b, w)`
+  have ha := reverse_holder s a w hp0 hp1 hs hwpos
+  have hb := reverse_holder s b w hp0 hp1 hs hwpos
+  rw [hwq, ← hq] at ha hb
+  -- the two right-hand sides reassemble to `S`
+  have hsplit : (∑ i ∈ s, a i * w i) + (∑ i ∈ s, b i * w i) = S := by
+    rw [← Finset.sum_add_distrib, hS]
+    apply Finset.sum_congr rfl; intro i hi
+    have hexp : (a i + b i) ^ p = (a i + b i) ^ (1 : ℝ) * (a i + b i) ^ (p - 1) := by
+      rw [← NNReal.rpow_add (hab i hi).ne']; congr 1; ring
+    rw [hw, ← add_mul, hexp, NNReal.rpow_one]
+  have hkey : ((∑ i ∈ s, a i ^ p) ^ (1 / p) + (∑ i ∈ s, b i ^ p) ^ (1 / p)) * S ^ (1 / q) ≤ S := by
+    rw [add_mul]
+    calc (∑ i ∈ s, a i ^ p) ^ (1 / p) * S ^ (1 / q)
+          + (∑ i ∈ s, b i ^ p) ^ (1 / p) * S ^ (1 / q)
+        ≤ (∑ i ∈ s, a i * w i) + (∑ i ∈ s, b i * w i) := add_le_add ha hb
+      _ = S := hsplit
+  -- divide by the positive factor `S^(1/q)`; `1/p + 1/q = 1`
+  apply le_of_mul_le_mul_right _ (NNReal.rpow_pos hSpos (p := 1 / q))
+  calc ((∑ i ∈ s, a i ^ p) ^ (1 / p) + (∑ i ∈ s, b i ^ p) ^ (1 / p)) * S ^ (1 / q)
+      ≤ S := hkey
+    _ = (∑ i ∈ s, (a i + b i) ^ p) ^ (1 / p) * S ^ (1 / q) := by
+        rw [← hS, ← NNReal.rpow_add hSne]
+        have : (1 / p) + (1 / q) = 1 := by rw [hq]; field_simp; ring
+        rw [this, NNReal.rpow_one]
+
+/-- Reverse Minkowski at the representative exponent `p = 1/2`:
+    `(∑ √aᵢ)² + (∑ √bᵢ)² ≤ (∑ √(aᵢ+bᵢ))²`. -/
+theorem reverse_minkowski_half {ι : Type*} (s : Finset ι) (a b : ι → ℝ≥0)
+    (hs : s.Nonempty) (hab : ∀ i ∈ s, 0 < a i + b i) :
+    (∑ i ∈ s, a i ^ (1/2 : ℝ)) ^ (2 : ℝ) + (∑ i ∈ s, b i ^ (1/2 : ℝ)) ^ (2 : ℝ)
+      ≤ (∑ i ∈ s, (a i + b i) ^ (1/2 : ℝ)) ^ (2 : ℝ) := by
+  have h := reverse_minkowski s a b (by norm_num : (0:ℝ) < 1/2) (by norm_num : (1/2:ℝ) < 1) hs hab
+  have e : (1 : ℝ) / (1/2) = 2 := by norm_num
+  rwa [e] at h
+
+end ReverseMinkowski

--- a/research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/knowledge.md
+++ b/research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/knowledge.md
@@ -143,3 +143,46 @@ Both backends down (Docker `docker info` 15s timeout; Aristotle MCP `prove` →
    `Proofs/CauchySchwarzOQ03OQ02OQ01.lean`; the only genuinely-open obligations
    are the negative-exponent casts and the `1/q < 0` division flip.
 2. Re-run `verify_reverse_minkowski.py` to re-confirm all artifacts.
+
+---
+
+## Session 2026-06-19 (Session 2) — ACT, COMPLETED (researcher-2)
+
+**Mode**: depth-first claim (knowledge 2, WEAK) · **Outcome**: ORIENT → ACT → COMPLETED.
+Backends recovered: built via `lake env lean Proofs/CauchySchwarzOQ03OQ02OQ01.lean`
+against pinned Mathlib oleans (Docker still slow, not needed).
+
+### What I did
+- Implemented **Route 1 (reverse Hölder)** exactly as the ORIENT plan prescribed.
+  New file `Proofs/CauchySchwarzOQ03OQ02OQ01.lean`, namespace `ReverseMinkowski`,
+  199 LOC, **0 sorries / 0 axioms** (`#print axioms` → propext/Choice/Quot.sound).
+- `reverse_holder`, `reverse_minkowski`, `reverse_minkowski_half`. Registered in
+  `Proofs.lean`; gallery `meta.json` added; `verify_reverse_minkowski.py` re-run green.
+
+### Key Lean facts discovered (for future negative-exponent work)
+- **The conjugate-pair trick avoids ever asking Mathlib for a negative exponent.**
+  Forward `NNReal.inner_le_Lp_mul_Lq` is applied with the *positive* conjugates
+  `P=1/p`, `P'=1/(1-p)` (`Real.HolderConjugate.inv_one_sub_inv hp0 hp1`). The
+  negative `q=p/(p-1)` shows up only in the statement, never in a hypothesis.
+- LHS collapse `(uv)^p · v^(-p) = u^p` needs `v>0`:
+  `NNReal.mul_rpow, mul_assoc, ← NNReal.rpow_add (hv …).ne', add_neg_cancel,
+   rpow_zero, mul_one`.
+- Exponent folding: `((x)^a)^b = x^(a*b)` is `← NNReal.rpow_mul` (note the lemma is
+  `x^(y*z) = (x^y)^z`, so the backward direction combines). `1/p⁻¹ = p` via
+  `one_div, inv_inv`.
+- Final reverse-Hölder step: `rw [← NNReal.rpow_le_rpow_iff hp0]` raises BOTH sides
+  to power p, then `mul_rpow` + `← rpow_mul` + the exponent identities
+  `(1/p)*p=1`, `(1/(p/(p-1)))*p = p-1` (both `by field_simp`), then a 2-step calc
+  using `← NNReal.rpow_add hCne` with `(1-p)+(p-1)=0`.
+- Minkowski division: `apply le_of_mul_le_mul_right _ (NNReal.rpow_pos hSpos (p := 1/q))`
+  then `1/p + 1/q = 1` (`field_simp; ring`) to fold `S^(1/p)·S^(1/q) = S`.
+- GOTCHA: `set q := p/(p-1)` does NOT fold `p/(p-1)` inside later `have`s built from
+  `reverse_holder` (raw `p/(p-1)` survives) → must `rw [← hq] at ha hb` to align with
+  the `1/q` written in the goal.
+- GOTCHA: `rw [← hsplit]` (hsplit : ∑a*w+∑b*w = S) rewrites EVERY `S`, including the
+  `S` inside `S^(1/q)` — corrupts the base. Use a forward `calc … = S := hsplit`
+  instead of rewriting S backwards.
+
+### Status
+**COMPLETED.** Open follow-ons (now in meta.json openQuestions): equality locus in
+Lean; direct concavity route; Lp-integral reverse triangle inequality.

--- a/research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/state.md
+++ b/research/problems/cauchy-schwarz-oq-03-oq-02-oq-01/state.md
@@ -1,49 +1,51 @@
 # Research State: cauchy-schwarz-oq-03-oq-02-oq-01
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-06-14
-**Iteration**: 1
+**Since**: 2026-06-14 (ORIENT) → 2026-06-19 (ACT, completed)
+**Iteration**: 2
 
 ## Current Focus
 Reverse Minkowski inequality for `0 < p < 1`:
-`(∑(a_i+b_i)^p)^(1/p) ≥ (∑a_i^p)^(1/p) + (∑b_i^p)^(1/p)` (nonneg a,b). Statement,
-equality locus (proportional), and proof route pinned and numerically certified.
+`(∑(a_i+b_i)^p)^(1/p) ≥ (∑a_i^p)^(1/p) + (∑b_i^p)^(1/p)` (nonneg a,b).
+FORMALIZED and verified (0 sorry / 0 axiom).
 
-## Active Approach
-**Route 1 — reverse Hölder** (mirrors the parent's "Minkowski from Hölder"):
-prove `reverse_holder` (negative conjugate `q=p/(p-1)<0`, `v>0`) from forward
-`NNReal.inner_le_Lp_mul_Lq` by exponent substitution, then derive
-`reverse_minkowski` via the two-Hölder split + division by `(∑(a+b)^p)^{1/q}`.
-~150–250 LOC, Docker-gated. Route 2 (quasi-norm concavity) is the fallback.
+## Result (Session 2, 2026-06-19, researcher-2)
+New file `Proofs/CauchySchwarzOQ03OQ02OQ01.lean` (namespace `ReverseMinkowski`,
+199 LOC, 0 sorries, 0 axioms — only propext/Choice/Quot.sound):
+
+1. `reverse_holder` — reverse Hölder for `0<p<1`, `v>0`:
+   `(∑u^p)^(1/p)·(∑v^(p/(p-1)))^(1/(p/(p-1))) ≤ ∑ u·v`.
+   Proved from forward `NNReal.inner_le_Lp_mul_Lq` via the substitution
+   `P=1/p`, `P'=1/(1-p)` (HolderConjugate, `Real.HolderConjugate.inv_one_sub_inv`)
+   on `f=(uv)^p`, `g=v^(-p)`. The negative conjugate `q=p/(p-1)` appears only in
+   the conclusion. Final inequality discharged by `NNReal.rpow_le_rpow_iff` (raise
+   to power p) + `rpow_add`.
+2. `reverse_minkowski` — reverse (super-additive) Minkowski for `0<p<1`,
+   `a_i+b_i>0`. Riesz split + two reverse-Hölder applications with weight
+   `w=(a+b)^(p-1)` (so `w^q=(a+b)^p`), divide by `(∑(a+b)^p)^(1/q)` using
+   `1/p+1/q=1`.
+3. `reverse_minkowski_half` — p=1/2 instance `(∑√a)²+(∑√b)² ≤ (∑√(a+b))²`.
+
+Registered in `proofs/Proofs.lean`. Gallery entry
+`src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/meta.json` added.
+Numerical cert `verify_reverse_minkowski.py` re-run: ALL CHECKS PASSED.
 
 ## Attempt Count
-- Total attempts: 0 (survey only; no Lean built)
-- Current approach attempts: 0
-- Approaches tried: 1 (reverse-Hölder route — viable, numerically validated)
+- Total attempts: 1 (Route 1 — reverse Hölder; succeeded)
+- Approaches tried: 1
 
 ## Blockers
-- **Verification blackout (2026-06-14)**: Docker daemon down (`docker info` 15s
-  timeout) and Aristotle MCP `prove` → "Resource not found" (probed). No Lean
-  build possible, so the ~150–250 LOC formalisation is build-gated. The ORIENT
-  (statement, Mathlib survey at pin v4.26.0, numerical cert, ACT plan) is
-  build-free and complete.
-- **Mathlib gap (genuine, not wiring)**: no reverse Hölder / reverse Minkowski /
-  `0<p<1` quasi-norm concavity in Mathlib; every Hölder lemma is gated on
-  `HolderConjugate` (⇒ p,q>1). The reverse direction must be built.
+- None remaining. (The 2026-06-14 Docker/Aristotle blackout that gated the build
+  is resolved: file compiled via `lake env lean` against the pinned Mathlib oleans.)
 
-## Next Action (when Docker recovers)
-1. Implement Route 1 in `Proofs/CauchySchwarzOQ03OQ02OQ01.lean`
-   (namespace `ReverseMinkowski`): `reverse_holder` → `reverse_minkowski`,
-   `p=1/2` instance, signed-real corollary. Confirm at build: negative-exponent
-   casts (`v_i^{p/(p-1)}`, keep `v_i>0`) and the `1/q<0` division flip.
-2. Build: `./proofs/scripts/docker-build.sh Proofs.CauchySchwarzOQ03OQ02OQ01`.
-3. Add gallery entry `src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/`.
-4. Re-run `verify_reverse_minkowski.py` to re-confirm artifacts.
+## Notes / Mathlib gap confirmed
+Mathlib (pin v4.26.0) has NO `0<p<1` Hölder / Minkowski / quasi-norm concavity —
+every Hölder lemma is gated on `HolderConjugate` (⇒ p,q>1). This file supplies the
+reverse direction by substitution. `rpow_add_le_add_rpow` gives only the wrong
+(outer upper) bound (caveat C4 in knowledge.md).
 
 ## Dead Ends
-- `rpow_add_le_add_rpow` ((a+b)^p≤a^p+b^p, 0≤p≤1) does **not** prove reverse
-  Minkowski — it gives the outer **upper** bound `LHS ≤ (X+Y)^(1/p)`, wrong
-  direction (see knowledge.md (C4)).
-- Instantiating `NNReal.Lp_add_le` with `p<1` is impossible (`hp : 1 ≤ p`).
+- `rpow_add_le_add_rpow` ((a+b)^p≤a^p+b^p) → outer UPPER bound, wrong direction.
+- Instantiating `NNReal.Lp_add_le` with `p<1` impossible (`hp : 1 ≤ p`).

--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "cauchy-schwarz-oq-03-oq-02-oq-01",
+  "title": "Reverse Minkowski Inequality for 0 < p < 1 (from Reverse Holder)",
+  "slug": "cauchy-schwarz-oq-03-oq-02-oq-01",
+  "description": "For 0 < p < 1 the Lp triangle inequality reverses: (sum(a_i+b_i)^p)^(1/p) >= (sum a_i^p)^(1/p) + (sum b_i^p)^(1/p) for nonnegative a, b. The p-functional is then a positively-homogeneous concave quasi-norm, hence superadditive. The engine is the reverse Holder inequality for 0 < p < 1 (negative conjugate exponent q = p/(p-1) < 0), built from Mathlib's forward Holder by exponent substitution. Mathlib has no 0 < p < 1 Holder or Minkowski lemma (all are gated on HolderConjugate, forcing p, q > 1), so the reverse direction is genuinely new.",
+  "meta": {
+    "author": "Hardy-Littlewood-Polya (1934); reverse direction formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Minkowski_inequality#Reverse_inequality",
+    "date": "1934",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "minkowski-inequality",
+      "holder-inequality",
+      "reverse-inequality",
+      "quasi-norm",
+      "lp-spaces",
+      "concavity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ03OQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "NNReal.inner_le_Lp_mul_Lq",
+        "description": "Forward Holder's inequality for NNReal finite sums (p, q > 1 conjugate). Used in reverse: applied to the conjugate pair P = 1/p, P' = 1/(1-p) on f = (uv)^p, g = v^(-p).",
+        "module": "Mathlib.Analysis.MeanInequalities"
+      },
+      {
+        "theorem": "Real.HolderConjugate.inv_one_sub_inv",
+        "description": "(1/p) and (1/(1-p)) are Holder conjugate when 0 < p < 1. Supplies the conjugate pair driving the substitution.",
+        "module": "Mathlib.Data.Real.ConjExponents"
+      },
+      {
+        "theorem": "NNReal.rpow_le_rpow_iff",
+        "description": "x^z <= y^z iff x <= y for z > 0; used to discharge the final reverse-Holder inequality by raising both sides to the power p.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      },
+      {
+        "theorem": "Finset.sum_pos",
+        "description": "Strict positivity of a finite sum of strictly positive terms; certifies the divisor (sum v^q)^(1/q) > 0.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      }
+    ],
+    "originalContributions": [
+      "reverse_holder: the reverse Holder inequality for 0 < p < 1 with negative conjugate exponent q = p/(p-1) < 0 and v > 0 -- absent from Mathlib, derived from forward Holder by the substitution P = 1/p, P' = 1/(1-p), f = (uv)^p, g = v^(-p)",
+      "reverse_minkowski: the reverse (super-additive) Minkowski inequality for 0 < p < 1, the opposite direction of the parent's forward p >= 1 case, via the Riesz argument run with reverse Holder",
+      "reverse_minkowski_half: the concrete p = 1/2 instance (sum sqrt(a))^2 + (sum sqrt(b))^2 <= (sum sqrt(a+b))^2",
+      "Identifies and uses the fact that the p-quasi-norm (0 < p < 1) is positively homogeneous and concave, hence superadditive -- the structural content of reverse Minkowski",
+      "Answers verbatim an open question posed in the parent entry cauchy-schwarz-oq-03-oq-02"
+    ],
+    "dateAdded": "2026-06-19",
+    "axiomCount": 0,
+    "lineCount": 199,
+    "assumptions": "0 axioms, 0 sorries; depends only on the standard foundational axioms propext, Classical.choice, Quot.sound (confirmed via #print axioms). reverse_holder requires v strictly positive on the (nonempty) index set; reverse_minkowski requires a_i + b_i > 0. These positivity hypotheses are necessary because the conjugate exponent q = p/(p-1) is negative.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "**When the triangle inequality runs backwards**\n\nFor $p \\geq 1$ the functional $\\|v\\|_p = (\\sum_i v_i^p)^{1/p}$ is a norm and satisfies the triangle inequality $\\|a+b\\|_p \\leq \\|a\\|_p + \\|b\\|_p$ (Minkowski, 1896). For $0 < p < 1$ everything reverses: $\\|\\cdot\\|_p$ is no longer a norm but a *quasi-norm* that is positively homogeneous and **concave** on the nonnegative orthant, hence **super**additive. The triangle inequality flips to\n\n$$\\Big(\\sum_i (a_i+b_i)^p\\Big)^{1/p} \\geq \\Big(\\sum_i a_i^p\\Big)^{1/p} + \\Big(\\sum_i b_i^p\\Big)^{1/p}.$$\n\nThis reverse form, together with the reverse Holder inequality that drives it, is treated in Hardy-Littlewood-Polya, *Inequalities* (1934), and is the natural companion to the forward case proved in the parent entry.",
+    "problemStatement": "**Reverse Minkowski (OQ-03-OQ-02-OQ-01)**\n\nThis answers the open question left by the parent CauchySchwarzOQ03OQ02.lean: *'Can the reverse Minkowski inequality for 0 < p < 1 be formalized?'*\n\nFor $0 < p < 1$ and nonnegative $a, b$ with $a_i + b_i > 0$:\n$$\\Big(\\sum_{i} (a_i+b_i)^p\\Big)^{1/p} \\geq \\Big(\\sum_{i} a_i^p\\Big)^{1/p} + \\Big(\\sum_{i} b_i^p\\Big)^{1/p}.$$\n\nThe engine is the reverse Holder inequality: with $q = p/(p-1) < 0$ (so $1/p + 1/q = 1$) and $v > 0$,\n$$\\Big(\\sum_i u_i^p\\Big)^{1/p}\\Big(\\sum_i v_i^q\\Big)^{1/q} \\leq \\sum_i u_i v_i.$$",
+    "text": "Reverse Minkowski and reverse Holder inequalities for 0 < p < 1, where the Lp triangle inequality reverses because the p-functional is a concave, superadditive quasi-norm. Built from Mathlib's forward Holder by a negative-conjugate-exponent substitution, since Mathlib has no 0 < p < 1 Holder/Minkowski lemma.",
+    "proofStrategy": "**Reverse Holder from forward Holder.** Mathlib only offers forward Holder, gated on conjugate exponents $> 1$. Take $P = 1/p > 1$ and $P' = 1/(1-p) > 1$ (these are Holder conjugate, via `Real.HolderConjugate.inv_one_sub_inv`) and apply forward Holder to $f_i = (u_i v_i)^p$, $g_i = v_i^{-p}$. The product collapses, $f_i g_i = u_i^p$ (using $v_i > 0$), while $f_i^P = u_i v_i$ and $g_i^{P'} = v_i^q$. Forward Holder then reads $\\sum u_i^p \\leq (\\sum u_i v_i)^p (\\sum v_i^q)^{1-p}$. Raising to the power $1/p$ and reorganising the exponents (all done with `NNReal.rpow_le_rpow_iff` and `rpow_add`) yields reverse Holder.\n\n**Reverse Minkowski from reverse Holder.** Run the classical Riesz argument with reverse Holder in place of forward Holder. Split $\\sum (a+b)^p = \\sum a (a+b)^{p-1} + \\sum b (a+b)^{p-1}$, apply reverse Holder to each summand with weight $v = (a+b)^{p-1}$ (so $v_i^q = (a_i+b_i)^p$), add the two bounds, and divide by the common factor $(\\sum (a+b)^p)^{1/q}$. Because $1/p + 1/q = 1$, this division turns the shared factor into the missing $1/p$ exponent.",
+    "keyInsights": [
+      "**The reversal is concavity.** For $0 < p < 1$, $\\|\\cdot\\|_p$ is positively homogeneous and concave on the orthant, hence superadditive: $\\|a+b\\|_p = 2\\|\\tfrac{a+b}{2}\\|_p \\geq 2(\\tfrac12\\|a\\|_p + \\tfrac12\\|b\\|_p) = \\|a\\|_p + \\|b\\|_p$. Reverse Minkowski is exactly this superadditivity.",
+      "**Negative conjugate exponent.** The Holder conjugate of $p$ is $q = p/(p-1)$, which is *negative* when $0 < p < 1$. The whole difficulty is that Mathlib's Holder API forbids this; the trick is to apply forward Holder to the auxiliary positive exponents $1/p$ and $1/(1-p)$ instead, so the negative exponent only ever appears in the *conclusion*.",
+      "**Strict positivity is unavoidable.** Because $q < 0$ and $p - 1 < 0$, the terms $v_i^q$ and $(a_i+b_i)^{p-1}$ blow up at zero. The hypotheses $v_i > 0$ (reverse Holder) and $a_i + b_i > 0$ (reverse Minkowski) are genuine, not artefacts of the Lean encoding.",
+      "**Mathlib's only 0<p<1 lemma points the wrong way.** `NNReal.rpow_add_le_add_rpow` gives $(a+b)^p \\leq a^p + b^p$, which only yields the *outer upper* bound $\\sum a^p + \\sum b^p \\leq$ (sum) -- not reverse Minkowski. The numerical certificate documents this dead end as caveat (C4).",
+      "**One file, both reversals.** Forward Holder ⇒ forward Minkowski (parent) and reverse Holder ⇒ reverse Minkowski (this file) are mirror images. Exposing them side by side makes the role of the conjugate-exponent sign explicit and machine-checked."
+    ],
+    "prerequisites": [
+      "Forward Holder's inequality for NNReal (parent chain CauchySchwarzOQ03 / OQ03OQ02)",
+      "NNReal real-power (rpow) arithmetic, including negative exponents",
+      "Holder conjugate exponents (Real.HolderConjugate)",
+      "Concavity / superadditivity of homogeneous functionals"
+    ]
+  },
+  "sections": [
+    {
+      "id": "reverse-holder",
+      "title": "Reverse Holder Inequality (0 < p < 1)",
+      "summary": "reverse_holder: for nonnegative u and strictly positive v, (sum u^p)^(1/p) * (sum v^(p/(p-1)))^(1/(p/(p-1))) <= sum u*v. Derived from forward Holder applied to the conjugate pair P = 1/p, P' = 1/(1-p) on f = (uv)^p, g = v^(-p).",
+      "startLine": 78,
+      "endLine": 142,
+      "mathContext": "The engine. Forward Holder with $f_i = (u_iv_i)^p$, $g_i = v_i^{-p}$ gives $\\sum u_i^p \\leq (\\sum u_iv_i)^p(\\sum v_i^q)^{1-p}$; raising to $1/p$ and reorganising yields reverse Holder. The conjugate exponent $q = p/(p-1)$ is negative."
+    },
+    {
+      "id": "reverse-minkowski",
+      "title": "Reverse Minkowski Inequality (0 < p < 1)",
+      "summary": "reverse_minkowski: for nonnegative a, b with a_i + b_i > 0, (sum a^p)^(1/p) + (sum b^p)^(1/p) <= (sum (a+b)^p)^(1/p). The Riesz argument run with reverse Holder; the weight is v = (a+b)^(p-1) and the common factor (sum(a+b)^p)^(1/q) is divided out using 1/p + 1/q = 1.",
+      "startLine": 144,
+      "endLine": 189,
+      "mathContext": "Split $\\sum(a+b)^p = \\sum a(a+b)^{p-1} + \\sum b(a+b)^{p-1}$, apply reverse Holder to each (note $v_i^q = (a_i+b_i)^p$), add, and divide by $(\\sum(a+b)^p)^{1/q}$. The $p$-quasi-norm is superadditive."
+    },
+    {
+      "id": "p-half-instance",
+      "title": "The p = 1/2 Instance",
+      "summary": "reverse_minkowski_half: (sum sqrt(a))^2 + (sum sqrt(b))^2 <= (sum sqrt(a+b))^2, the reverse Minkowski inequality at the representative exponent p = 1/2.",
+      "startLine": 191,
+      "endLine": 199,
+      "mathContext": "At $p = 1/2$, $1/p = 2$ and $a^p = \\sqrt a$, so the inequality becomes $(\\sum\\sqrt{a_i})^2 + (\\sum\\sqrt{b_i})^2 \\leq (\\sum\\sqrt{a_i+b_i})^2$ -- a clean, concrete reversal of the Cauchy-Schwarz-flavoured forward case."
+    }
+  ],
+  "conclusion": {
+    "summary": "The open question from the parent CauchySchwarzOQ03OQ02.lean is answered: YES, the reverse Minkowski inequality for 0 < p < 1 can be formalized. Its engine, the reverse Holder inequality (negative conjugate exponent), is built from Mathlib's forward Holder by exponent substitution -- Mathlib itself has no 0 < p < 1 Holder/Minkowski lemma. All three theorems are proved with 0 sorries and 0 axioms.",
+    "implications": "**Completing the Holder-Minkowski picture.** The parent established forward Holder => forward Minkowski for p >= 1; this file establishes the mirror image reverse Holder => reverse Minkowski for 0 < p < 1. Together they show that the sign of the conjugate exponent q = p/(p-1) controls the direction of the triangle inequality: q > 0 gives a norm (subadditive), q < 0 gives a concave quasi-norm (superadditive). This makes the dividing line at p = 1 -- where the p-functional ceases to be a norm -- fully machine-checked.",
+    "openQuestions": [
+      "Can the equality locus of reverse Minkowski (proportional vectors a, b, or one zero) be characterized in Lean, mirroring the forward equality case?",
+      "Can the concavity of v -> (sum v_i^p)^(1/p) on the nonnegative orthant be proved directly and used as an alternative route to reverse Minkowski?",
+      "Does an analogous reverse triangle inequality hold for the Lp integral quasi-norm (0 < p < 1), and can it be derived from this finite-sum version?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "NNReal"
+    ],
+    "namespace": "ReverseMinkowski",
+    "lineCount": 199,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ03OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "G. H. Hardy, J. E. Littlewood, G. Polya",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Reverse Holder and reverse Minkowski for 0 < p < 1 (Section 2.8 and surrounding)"
+    },
+    {
+      "authors": "F. Riesz",
+      "title": "Untersuchungen uber Systeme integrierbarer Funktionen",
+      "year": "1910",
+      "venue": "Mathematische Annalen 69",
+      "note": "The Holder => Minkowski deduction, here run in reverse"
+    },
+    {
+      "authors": "H. Minkowski",
+      "title": "Geometrie der Zahlen",
+      "year": "1896",
+      "venue": "Teubner, Leipzig",
+      "note": "Forward Lp triangle inequality (parent entry); this file treats its 0 < p < 1 reversal"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-03-oq-02",
+      "relationship": "extends",
+      "description": "Parent: forward Minkowski from Holder for p >= 1. This file answers its open question by proving the reverse inequality for 0 < p < 1."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-03",
+      "relationship": "related",
+      "description": "Grandparent: the forward Holder formalization whose Mathlib analogue drives the reverse direction here."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling under OQ-03: equality case of Cauchy-Schwarz/Holder, another extension of the parent chain."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question raised verbatim by the parent entry
`CauchySchwarzOQ03OQ02.lean` ("Minkowski from Hölder", forward `p ≥ 1`):

> *Can the reverse Minkowski inequality for `0 < p < 1` be formalized? (The inequality reverses direction.)*

**Yes.** New file `proofs/Proofs/CauchySchwarzOQ03OQ02OQ01.lean` (namespace `ReverseMinkowski`, 199 LOC, **0 sorries / 0 axioms**):

1. **`reverse_holder`** — reverse Hölder for `0 < p < 1`, `v > 0`:
   `(∑ uᵢ^p)^(1/p) · (∑ vᵢ^q)^(1/q) ≤ ∑ uᵢ vᵢ` with conjugate `q = p/(p-1) < 0`.
2. **`reverse_minkowski`** — reverse (super-additive) Minkowski for `0 < p < 1`, `aᵢ+bᵢ > 0`:
   `(∑ aᵢ^p)^(1/p) + (∑ bᵢ^p)^(1/p) ≤ (∑ (aᵢ+bᵢ)^p)^(1/p)` — the opposite direction of the parent's `p ≥ 1` case.
3. **`reverse_minkowski_half`** — the `p = 1/2` instance `(∑√aᵢ)² + (∑√bᵢ)² ≤ (∑√(aᵢ+bᵢ))²`.

## Why this is new

Mathlib (pin v4.26.0) has **no** `0 < p < 1` Hölder or Minkowski lemma — every Hölder statement is gated on `Real.HolderConjugate p q`, whose fields force `p, q > 1`. The reverse direction is built here.

## Method

The conjugate exponent `q = p/(p-1)` is *negative*, which Mathlib's API forbids. Trick: apply **forward** `NNReal.inner_le_Lp_mul_Lq` with the *positive* conjugate pair `P = 1/p`, `P' = 1/(1-p)` (`Real.HolderConjugate.inv_one_sub_inv`) to `fᵢ = (uᵢvᵢ)^p`, `gᵢ = vᵢ^(-p)` — the negative exponent then appears only in the conclusion. Reverse Minkowski follows by the classical Riesz split run with reverse Hölder, dividing by the common factor `(∑(a+b)^p)^(1/q)` (using `1/p + 1/q = 1`).

The strict-positivity hypotheses (`v > 0`, `a+b > 0`) are genuine: `vᵢ^q` and `(aᵢ+bᵢ)^{p-1}` blow up at zero since `q, p-1 < 0`.

## Verification

- Compiles against pinned Mathlib via `lake env lean Proofs/CauchySchwarzOQ03OQ02OQ01.lean` (exit 0, no warnings).
- `#print axioms` on all three theorems → `[propext, Classical.choice, Quot.sound]` only (**0 axioms**).
- Numerical certificate `verify_reverse_minkowski.py` re-run: **ALL CHECKS PASSED** (70 000 trials, 0 violations; equality locus; reverse-Hölder engine; the `rpow_add_le_add_rpow` wrong-direction caveat).
- Registered in `proofs/Proofs.lean`; gallery entry `src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/meta.json` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)