### PR TITLE
research(sylvester-sequence-oq-02): reciprocals sum exactly to 1 (∑' 1/aₙ = 1, verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3062,6 +3062,7 @@ import Proofs.SylowTheoremOQ03B
 import Proofs.SylowTheoremOQ04
 import Proofs.SylvesterGallaiOQ01
 import Proofs.SylvesterSequenceOQ01
+import Proofs.SylvesterSequenceOQ02
 import Proofs.SynthesisCurvaturePtolemy
 import Proofs.SynthesisCurvaturePtolemyOQ01
 import Proofs.SzemerediCore

--- a/proofs/Proofs/SylvesterSequenceOQ02.lean
+++ b/proofs/Proofs/SylvesterSequenceOQ02.lean
@@ -1,0 +1,157 @@
+import Mathlib
+
+/-!
+# Sylvester's sequence OQ-02: the reciprocals sum exactly to `1`
+
+Sylvester's sequence is `a₀ = 2`, `a_{n+1} = aₙ² - aₙ + 1`, giving `2, 3, 7, 43, 1807, …`.
+
+The base entry `SylvesterSequenceOQ01` proves the closed-form **partial** sum
+`∑_{k=0}^{n} 1/aₖ = 1 - 1/(a_{n+1} - 1)` and remarks that "since `a_{n+1} - 1 → ∞`,
+the infinite sum of reciprocals equals `1`" — but stops short of formalizing that
+limit. This file closes that gap: it proves the genuine **infinite series** identity
+
+* `syl_tsum_reciprocal` : `∑' k, 1/aₖ = 1`  (over `ℝ`), and
+* `syl_reciprocal_hasSum` : `HasSum (fun k => 1/aₖ) 1`,
+
+together with the two analytic ingredients it rests on:
+
+* `syl_ge_add_two` : the linear lower bound `n + 2 ≤ aₙ` (so `aₙ → ∞`), and
+* `syl_summable` : the reciprocal series is summable (partial sums bounded by `1`).
+
+The series is unconditionally convergent because each tail term is positive and the
+partial sums `1 - 1/(a_{n+1}-1)` are bounded above by `1`; the value is pinned down by
+the telescoping closed form together with `1/(a_{n+1}-1) → 0`, which in turn follows
+from the elementary linear bound `aₙ ≥ n + 2`. (Sylvester's sequence in fact grows
+doubly exponentially, but a linear lower bound is all the convergence argument needs.)
+
+The file is self-contained: the sequence and the few elementary facts about it
+(`syl_succ`, `two_le_syl`, `syl_cast_succ`) are re-derived here so the analytic
+capstone depends only on `Mathlib`.
+
+No axioms, no sorries.
+-/
+
+namespace SylvesterSequenceOQ02
+
+open Filter Topology
+
+/-- Sylvester's sequence: `a₀ = 2`, `a_{n+1} = aₙ² - aₙ + 1`. -/
+def syl : ℕ → ℕ
+  | 0 => 2
+  | (n + 1) => syl n ^ 2 - syl n + 1
+
+@[simp] theorem syl_zero : syl 0 = 2 := rfl
+
+theorem syl_succ (n : ℕ) : syl (n + 1) = syl n ^ 2 - syl n + 1 := rfl
+
+/-- Every term is at least `2`. -/
+theorem two_le_syl (n : ℕ) : 2 ≤ syl n := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    have h : syl k + 2 ≤ syl k ^ 2 := by nlinarith [ih]
+    rw [syl_succ]
+    omega
+
+/-- The recurrence, lifted to `ℤ` (no truncated subtraction). -/
+theorem syl_cast_succ (n : ℕ) :
+    (syl (n + 1) : ℤ) = (syl n : ℤ) ^ 2 - (syl n : ℤ) + 1 := by
+  have h1 : syl n ≤ syl n ^ 2 := by nlinarith [two_le_syl n]
+  rw [syl_succ]
+  push_cast [Nat.cast_sub h1]
+  ring
+
+/-- **Linear lower bound** `n + 2 ≤ aₙ`. Each step gains at least one because
+`a_{n+1} - aₙ = (aₙ-1)² ≥ 1`. This is far weaker than the true doubly-exponential
+growth, but it is exactly what the convergence argument needs (`aₙ → ∞`). -/
+theorem syl_ge_add_two : ∀ n, n + 2 ≤ syl n
+  | 0 => by simp
+  | (k + 1) => by
+      have hk := two_le_syl k
+      have ih := syl_ge_add_two k
+      have h : syl k + syl k ≤ syl k ^ 2 := by nlinarith [hk]
+      rw [syl_succ]
+      omega
+
+/-- The real-valued telescoping per-term identity (the `ℝ` analogue of `syl_recip_term`):
+`1/aₙ = 1/(aₙ-1) - 1/(a_{n+1}-1)`. -/
+theorem syl_real_recip_term (n : ℕ) :
+    (1 : ℝ) / (syl n : ℝ)
+      = 1 / ((syl n : ℝ) - 1) - 1 / ((syl (n + 1) : ℝ) - 1) := by
+  have ha : (2 : ℝ) ≤ (syl n : ℝ) := by exact_mod_cast two_le_syl n
+  have hsucc : (syl (n + 1) : ℝ) = (syl n : ℝ) ^ 2 - (syl n : ℝ) + 1 := by
+    exact_mod_cast syl_cast_succ n
+  have h0 : (syl n : ℝ) ≠ 0 := by linarith
+  have h1 : (syl n : ℝ) - 1 ≠ 0 := by linarith
+  have h2 : (syl n : ℝ) ^ 2 - (syl n : ℝ) + 1 - 1 ≠ 0 := by nlinarith [ha]
+  rw [hsucc]
+  field_simp
+  ring
+
+/-- Closed form for real partial sums: `∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1}-1)`. -/
+theorem syl_real_partial_sum (n : ℕ) :
+    ∑ k ∈ Finset.range (n + 1), (1 : ℝ) / (syl k : ℝ)
+      = 1 - 1 / ((syl (n + 1) : ℝ) - 1) := by
+  induction n with
+  | zero =>
+    rw [Finset.sum_range_one]
+    norm_num [show syl 0 = 2 from rfl, show syl (0 + 1) = 3 from rfl]
+  | succ m ih =>
+    rw [Finset.sum_range_succ, ih, syl_real_recip_term (m + 1)]
+    ring
+
+/-- The error term vanishes: `1/(a_{n+1}-1) → 0`. The linear bound `aₙ ≥ n+2` squeezes
+the positive error term below `1/(n+1) → 0`. -/
+theorem syl_recip_pred_tendsto_zero :
+    Tendsto (fun n => 1 / ((syl (n + 1) : ℝ) - 1)) atTop (𝓝 0) := by
+  apply squeeze_zero (g := fun n : ℕ => 1 / ((n : ℝ) + 1))
+  · intro n
+    have h2 : (2 : ℝ) ≤ (syl (n + 1) : ℝ) := by exact_mod_cast two_le_syl (n + 1)
+    exact one_div_nonneg.mpr (by linarith)
+  · intro n
+    have hb : (n + 1 + 2 : ℕ) ≤ syl (n + 1) := syl_ge_add_two (n + 1)
+    have h1 : ((n : ℝ) + 1) ≤ (syl (n + 1) : ℝ) - 1 := by
+      have hc : ((n + 1 + 2 : ℕ) : ℝ) ≤ (syl (n + 1) : ℝ) := by exact_mod_cast hb
+      push_cast at hc; linarith
+    exact one_div_le_one_div_of_le (by positivity) h1
+  · exact tendsto_one_div_add_atTop_nhds_zero_nat
+
+/-- **Partial sums converge to `1`**: `∑_{k≤n} 1/aₖ → 1`. -/
+theorem syl_partial_tendsto_one :
+    Tendsto (fun n => ∑ k ∈ Finset.range (n + 1), (1 : ℝ) / (syl k : ℝ))
+      atTop (𝓝 1) := by
+  have hfun : (fun n => ∑ k ∈ Finset.range (n + 1), (1 : ℝ) / (syl k : ℝ))
+      = fun n => 1 - 1 / ((syl (n + 1) : ℝ) - 1) := by
+    funext n; exact syl_real_partial_sum n
+  rw [hfun]
+  have : Tendsto (fun n => 1 - 1 / ((syl (n + 1) : ℝ) - 1)) atTop (𝓝 (1 - 0)) :=
+    Tendsto.const_sub 1 syl_recip_pred_tendsto_zero
+  simpa using this
+
+/-- **The reciprocal series is summable.** Every term is nonnegative and every partial
+sum equals `1 - 1/(a_{n+1}-1) ≤ 1`, so the partial sums are bounded above by `1`. -/
+theorem syl_summable : Summable (fun k => (1 : ℝ) / (syl k : ℝ)) := by
+  apply summable_of_sum_range_le (c := 1)
+  · intro n; exact one_div_nonneg.mpr (Nat.cast_nonneg _)
+  · intro n
+    cases n with
+    | zero => simp
+    | succ m =>
+      rw [syl_real_partial_sum m]
+      have h2 : (2 : ℝ) ≤ (syl (m + 1) : ℝ) := by exact_mod_cast two_le_syl (m + 1)
+      have hpos : 0 ≤ 1 / ((syl (m + 1) : ℝ) - 1) := one_div_nonneg.mpr (by linarith)
+      linarith
+
+/-- **Sylvester's reciprocal series sums to exactly `1`:** `∑' k, 1/aₖ = 1`. -/
+theorem syl_tsum_reciprocal : ∑' k, (1 : ℝ) / (syl k : ℝ) = 1 := by
+  have hshift :
+      Tendsto (fun n => ∑ k ∈ Finset.range (n + 1), (1 : ℝ) / (syl k : ℝ))
+        atTop (𝓝 (∑' k, (1 : ℝ) / (syl k : ℝ))) :=
+    syl_summable.hasSum.tendsto_sum_nat.comp (tendsto_add_atTop_nat 1)
+  exact tendsto_nhds_unique hshift syl_partial_tendsto_one
+
+/-- **`HasSum` form** of the result: `HasSum (fun k => 1/aₖ) 1`. -/
+theorem syl_reciprocal_hasSum : HasSum (fun k => (1 : ℝ) / (syl k : ℝ)) 1 :=
+  (syl_summable.hasSum_iff).mpr syl_tsum_reciprocal
+
+end SylvesterSequenceOQ02

--- a/src/data/proofs/sylvester-sequence-oq-02/annotations.json
+++ b/src/data/proofs/sylvester-sequence-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "sylvester-sequence-oq-02",
+    "range": { "startLine": 3, "endLine": 43 },
+    "type": "concept",
+    "title": "From Partial Sum to Convergent Series",
+    "content": "Sylvester's sequence $a_0 = 2$, $a_{n+1} = a_n^2 - a_n + 1$ (2, 3, 7, 43, 1807, …; OEIS A000058) is the greedy Egyptian-fraction expansion of $1$. The base entry (oq-01) proves the closed-form **partial** sum $\\sum_{k\\le n} 1/a_k = 1 - 1/(a_{n+1}-1)$ and merely remarks that the infinite sum is $1$. This entry formalizes that limit as a genuine convergent series: it proves $\\sum'_k 1/a_k = 1$ over $\\mathbb{R}$ and the corresponding `HasSum` statement. The phrase 'the reciprocals sum to 1' is, precisely, this convergence claim.",
+    "mathContext": "$\\sum_{k\\le n} 1/a_k = 1 - 1/(a_{n+1}-1) \\ \\longrightarrow\\ \\sum_k 1/a_k = 1.$",
+    "significance": "key",
+    "relatedConcepts": ["Egyptian fractions", "infinite series", "convergence", "tsum / HasSum"],
+    "prerequisites": ["infinite series", "limits of sequences"]
+  },
+  {
+    "id": "ann-basics",
+    "proofId": "sylvester-sequence-oq-02",
+    "range": { "startLine": 45, "endLine": 76 },
+    "type": "technique",
+    "title": "The Sequence and Its Z-Lift",
+    "content": "The sequence `syl` is defined by structural recursion, with `two_le_syl` ($a_n \\ge 2$) and `syl_cast_succ` lifting the recurrence to $\\mathbb{Z}$ so that subtraction is genuine (not $\\mathbb{N}$'s truncated subtraction). These elementary facts are carried over from the base entry so the analytic capstone depends only on Mathlib.",
+    "mathContext": "$a_n \\ge 2;\\quad (a_{n+1}:\\mathbb{Z}) = a_n^2 - a_n + 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["structural recursion", "truncated subtraction", "casting to ℤ"],
+    "prerequisites": ["natural number arithmetic"]
+  },
+  {
+    "id": "ann-growth",
+    "proofId": "sylvester-sequence-oq-02",
+    "range": { "startLine": 47, "endLine": 60 },
+    "type": "technique",
+    "title": "A Linear Lower Bound Suffices",
+    "content": "`syl_ge_add_two` proves $n + 2 \\le a_n$ by induction: each step gains at least one because $a_{n+1} - a_n = (a_n-1)^2 \\ge 1$. Although Sylvester's sequence actually grows doubly exponentially, this crude linear bound is exactly what the convergence argument needs — it forces $a_{n+1} - 1 \\to \\infty$, hence the error term to $0$.",
+    "mathContext": "$a_{n+1} - a_n = (a_n - 1)^2 \\ge 1 \\Rightarrow a_n \\ge n + 2.$",
+    "significance": "key",
+    "relatedConcepts": ["induction", "growth bounds", "divergence to infinity"],
+    "prerequisites": ["mathematical induction"]
+  },
+  {
+    "id": "ann-telescope",
+    "proofId": "sylvester-sequence-oq-02",
+    "range": { "startLine": 78, "endLine": 101 },
+    "type": "technique",
+    "title": "Telescoping Closed Form over the Reals",
+    "content": "`syl_real_recip_term` re-derives the telescoping identity $1/a_n = 1/(a_n-1) - 1/(a_{n+1}-1)$ over $\\mathbb{R}$ (via `field_simp`/`ring`, using $a_n \\ge 2$ to keep denominators nonzero), and `syl_real_partial_sum` inducts to the closed form $\\sum_{k\\le n} 1/a_k = 1 - 1/(a_{n+1}-1)$. These are the $\\mathbb{R}$ analogues of the base entry's $\\mathbb{Q}$ lemmas, needed because convergence is a real-analytic statement.",
+    "mathContext": "$\\frac{1}{a_n} = \\frac{1}{a_n - 1} - \\frac{1}{a_{n+1} - 1};\\quad \\sum_{k\\le n}\\frac{1}{a_k} = 1 - \\frac{1}{a_{n+1}-1}.$",
+    "significance": "key",
+    "relatedConcepts": ["telescoping sums", "field_simp", "induction"],
+    "prerequisites": ["telescoping sums", "real arithmetic"]
+  },
+  {
+    "id": "ann-converge",
+    "proofId": "sylvester-sequence-oq-02",
+    "range": { "startLine": 103, "endLine": 129 },
+    "type": "technique",
+    "title": "The Error Term Vanishes",
+    "content": "`syl_recip_pred_tendsto_zero` proves $1/(a_{n+1}-1) \\to 0$ by squeezing the positive error term below $1/(n+1) \\to 0$ (`squeeze_zero` with `tendsto_one_div_add_atTop_nhds_zero_nat`), using the linear bound. Then `syl_partial_tendsto_one` subtracts the vanishing error from the constant $1$ to conclude $\\sum_{k\\le n} 1/a_k \\to 1$.",
+    "mathContext": "$0 \\le \\frac{1}{a_{n+1}-1} \\le \\frac{1}{n+1} \\to 0 \\Rightarrow \\sum_{k\\le n}\\frac{1}{a_k} \\to 1.$",
+    "significance": "key",
+    "relatedConcepts": ["squeeze theorem", "Tendsto", "limit of partial sums"],
+    "prerequisites": ["squeeze theorem", "limits"]
+  },
+  {
+    "id": "ann-value",
+    "proofId": "sylvester-sequence-oq-02",
+    "range": { "startLine": 131, "endLine": 157 },
+    "type": "key-step",
+    "title": "Summability and the Sum Equals One",
+    "content": "`syl_summable` gets summability from nonnegative terms with partial sums bounded above by $1$ (`summable_of_sum_range_le`). `syl_tsum_reciprocal` then identifies the value: the tsum's defining limit (the range-$n$ partial sums, shifted to range-$(n+1)$ via `HasSum.tendsto_sum_nat` and `tendsto_add_atTop_nat 1`) and the explicit telescoping limit both go to numbers that `tendsto_nhds_unique` forces equal, giving $\\sum'_k 1/a_k = 1$. `syl_reciprocal_hasSum` restates this as `HasSum (fun k => 1/a_k) 1`.",
+    "mathContext": "$\\sum'_k \\frac{1}{a_k} = 1,\\qquad \\mathrm{HasSum}\\ \\left(k \\mapsto \\tfrac{1}{a_k}\\right)\\ 1.$",
+    "significance": "key",
+    "relatedConcepts": ["summability", "tsum", "uniqueness of limits", "HasSum"],
+    "prerequisites": ["infinite series", "summable_of_sum_range_le"]
+  }
+]

--- a/src/data/proofs/sylvester-sequence-oq-02/meta.json
+++ b/src/data/proofs/sylvester-sequence-oq-02/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "sylvester-sequence-oq-02",
+  "slug": "sylvester-sequence-oq-02",
+  "title": "Sylvester's Sequence: The Reciprocals Sum Exactly to 1",
+  "description": "Sylvester's sequence a₀=2, a_{n+1}=aₙ²-aₙ+1 (2, 3, 7, 43, 1807, …) has reciprocals that sum to exactly 1. The base entry (oq-01) proves the closed-form partial sum ∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1}-1) and merely remarks that the infinite sum is 1; this entry formalizes that limit as a genuine convergent series. It proves the infinite-series identity ∑' k, 1/aₖ = 1 over ℝ (syl_tsum_reciprocal), its HasSum form (syl_reciprocal_hasSum), summability (syl_summable, partial sums bounded by 1), and the analytic engine: a linear lower bound aₙ ≥ n+2 forcing 1/(a_{n+1}-1) → 0. Fully machine-checked with 0 sorries and 0 axioms.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Filter", "Topology"],
+    "namespace": "SylvesterSequenceOQ02",
+    "lineCount": 157,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "substantiveTheoremCount": 6,
+    "trivialSpecializations": 1,
+    "definitionCount": 1,
+    "path": "Proofs/SylvesterSequenceOQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "James Joseph Sylvester (1880)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sylvester%27s_sequence",
+    "date": "1880",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SylvesterSequenceOQ02.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "infinite-series",
+      "egyptian-fractions",
+      "telescoping",
+      "convergence",
+      "sylvester"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. The sequence is defined directly in ℕ; all results are proved over ℝ from the recurrence using only Mathlib's analysis library, with no axioms and no structure-encoded hypotheses. #print axioms reports only the standard propext / Classical.choice / Quot.sound.",
+    "dateAdded": "2026-06-19",
+    "mathlibDependencies": [
+      "summable_of_sum_range_le",
+      "Summable.hasSum",
+      "HasSum.tendsto_sum_nat",
+      "squeeze_zero",
+      "tendsto_one_div_add_atTop_nhds_zero_nat",
+      "tendsto_nhds_unique",
+      "tendsto_add_atTop_nat"
+    ],
+    "originalContributions": [
+      "Infinite-series identity syl_tsum_reciprocal: ∑' k, 1/aₖ = 1 over ℝ — the limit the oq-01 entry states but does not prove",
+      "HasSum form syl_reciprocal_hasSum: HasSum (fun k => 1/aₖ) 1, the unconditional-convergence statement",
+      "Summability syl_summable: the reciprocal series is summable, via partial sums bounded above by 1",
+      "Linear lower bound syl_ge_add_two: n + 2 ≤ aₙ, the elementary growth fact that forces 1/(a_{n+1}-1) → 0 (a linear bound suffices even though the sequence grows doubly exponentially)",
+      "Convergence of the error term syl_recip_pred_tendsto_zero: 1/(a_{n+1}-1) → 0, by squeezing below 1/(n+1)",
+      "Partial-sum limit syl_partial_tendsto_one: ∑_{k≤n} 1/aₖ → 1"
+    ],
+    "prerequisites": [
+      "Infinite series, summability, and tsum in a normed field",
+      "Limits of sequences (Tendsto, squeeze theorem)",
+      "Telescoping sums and mathematical induction"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 157,
+    "relatedProblems": ["sylvester-sequence-oq-01"],
+    "theoremCount": 12,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Sylvester's sequence (OEIS A000058), studied by James Joseph Sylvester in 1880, is the greedy expansion of 1 as a sum of distinct unit fractions: at each step take the largest 1/m that keeps the running total below 1. Sylvester showed the denominators obey a₀ = 2, a_{n+1} = aₙ² - aₙ + 1, giving 2, 3, 7, 43, 1807, 3263443, …, a doubly-exponentially growing sequence (≈ ⌊E^{2^{n+1}}⌋ for Vardi's constant E ≈ 1.2640847). That the reciprocals sum to exactly 1 is the precise sense in which the greedy Egyptian-fraction expansion of unity converges — and converges as fast as any unit-fraction expansion possibly can.",
+    "problemStatement": "Let a₀ = 2 and a_{n+1} = aₙ² - aₙ + 1. The base entry proves the closed-form partial sum ∑_{k=0}^{n} 1/aₖ = 1 - 1/(a_{n+1} - 1). Promote this to a statement about the genuine infinite series: prove that ∑_{k} 1/aₖ converges and equals exactly 1, both as a tsum value (∑' k, 1/aₖ = 1) and as a HasSum statement, working over ℝ so that convergence is meaningful.",
+    "proofStrategy": "The series has nonnegative terms, so summability follows from the partial sums being bounded above: each equals 1 - 1/(a_{n+1}-1) ≤ 1 (summable_of_sum_range_le). To pin the value to 1, the partial sums are shown to converge to 1 by re-deriving the telescoping closed form over ℝ and taking n → ∞: the error term 1/(a_{n+1}-1) tends to 0. That last limit needs only that a_{n+1}-1 → ∞, which is supplied by the elementary linear lower bound aₙ ≥ n + 2 (each step gains at least one because a_{n+1} - aₙ = (aₙ-1)² ≥ 1); the error term is then squeezed below 1/(n+1) → 0. Finally tendsto_nhds_unique identifies the tsum value — reached along the range-(n+1) partial sums via HasSum.tendsto_sum_nat composed with a +1 index shift — with the limit 1.",
+    "keyInsights": [
+      "The oq-01 entry computes the exact partial sum 1 - 1/(a_{n+1}-1) but stops at a remark about the limit; the analytic content of 'the reciprocals sum to 1' is precisely the convergence statement formalized here.",
+      "Convergence is unconditional (nonnegative terms with bounded partial sums), so the value can be obtained two ways that must agree: the abstract tsum of the summable series, and the explicit limit of the telescoping partial sums — tendsto_nhds_unique forces them equal.",
+      "A crude linear bound aₙ ≥ n + 2 is all that is needed for convergence, even though Sylvester's sequence actually grows doubly exponentially; the proof deliberately avoids the harder growth estimate.",
+      "The error term 1/(a_{n+1}-1) is itself the n-th tail of the series, so the closed form exhibits the fastest-possible greedy convergence of an Egyptian-fraction expansion of unity.",
+      "Bridging ℕ (where the sequence lives) and ℝ (where the series converges) is handled by casting the recurrence and proving the telescoping identity afresh over ℝ with field_simp / ring, mirroring the ℚ argument of the base entry."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "syl_tsum_reciprocal",
+      "statement": "∑' k, (1 : ℝ) / aₖ = 1",
+      "description": "The infinite series of reciprocals of Sylvester's sequence converges to exactly 1 — the limit the base entry states but leaves unproved."
+    },
+    {
+      "name": "syl_reciprocal_hasSum",
+      "statement": "HasSum (fun k => (1 : ℝ) / aₖ) 1",
+      "description": "The HasSum form: the reciprocal series is unconditionally summable with sum 1."
+    },
+    {
+      "name": "syl_summable",
+      "statement": "Summable (fun k => (1 : ℝ) / aₖ)",
+      "description": "Summability of the reciprocal series, from nonnegative terms with partial sums bounded above by 1."
+    },
+    {
+      "name": "syl_ge_add_two",
+      "statement": "n + 2 ≤ aₙ",
+      "description": "A linear lower bound on the sequence; enough to force a_{n+1}-1 → ∞ and hence the error term to 0."
+    },
+    {
+      "name": "syl_partial_tendsto_one",
+      "statement": "(fun n => ∑ k ∈ Finset.range (n+1), 1/aₖ) → 1",
+      "description": "The partial sums converge to 1, obtained from the real telescoping closed form and 1/(a_{n+1}-1) → 0."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "`import Mathlib`, the module docstring, and `namespace SylvesterSequenceOQ02` opening Filter and Topology. The docstring explains that this entry closes the gap left open by oq-01 (which proves the partial sum but only remarks on the limit), states the infinite-series targets, and notes the file is self-contained: the sequence and the few elementary facts about it are re-derived so the analytic capstone depends only on Mathlib.",
+      "mathContext": "$a_0=2,\\ a_{n+1}=a_n^2-a_n+1$; goal $\\sum_k 1/a_k = 1$."
+    },
+    {
+      "id": "sequence-basics",
+      "title": "The Sequence and Elementary Facts",
+      "startLine": 45,
+      "endLine": 76,
+      "summary": "Defines syl by structural recursion, exposes the base case and recurrence as rewrite lemmas, proves two_le_syl (every term ≥ 2), and lifts the recurrence to ℤ via syl_cast_succ to avoid ℕ's truncated subtraction — the supporting facts carried over from the base entry.",
+      "mathContext": "$a_n \\ge 2$; the $\\mathbb{Z}$-lift removes $\\mathbb{N}$ truncated subtraction."
+    },
+    {
+      "id": "growth-bound",
+      "title": "Linear Lower Bound",
+      "startLine": 47,
+      "endLine": 60,
+      "summary": "Proves syl_ge_add_two: n + 2 ≤ aₙ, by induction. Each step gains at least one because a_{n+1} = aₙ² - aₙ + 1 ≥ aₙ + 1 once aₙ ≥ 2. This crude linear bound is all the convergence argument requires.",
+      "mathContext": "$a_{n+1}-a_n=(a_n-1)^2\\ge 1 \\Rightarrow a_n \\ge n+2$."
+    },
+    {
+      "id": "telescoping-real",
+      "title": "Real Telescoping Identity and Partial Sums",
+      "startLine": 78,
+      "endLine": 101,
+      "summary": "Re-derives over ℝ the telescoping per-term identity syl_real_recip_term (1/aₙ = 1/(aₙ-1) - 1/(a_{n+1}-1)) and the closed-form partial sum syl_real_partial_sum (∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1}-1)), via field_simp/ring and induction — the ℝ analogues of the base entry's ℚ lemmas.",
+      "mathContext": "$\\sum_{k\\le n} 1/a_k = 1 - 1/(a_{n+1}-1)$ over $\\mathbb{R}$."
+    },
+    {
+      "id": "convergence",
+      "title": "Error Term to Zero and Partial-Sum Limit",
+      "startLine": 103,
+      "endLine": 129,
+      "summary": "Proves syl_recip_pred_tendsto_zero (1/(a_{n+1}-1) → 0) by squeezing the positive error term below 1/(n+1) → 0 using the linear bound, then syl_partial_tendsto_one (the partial sums → 1) by subtracting the vanishing error from the constant 1.",
+      "mathContext": "$1/(a_{n+1}-1) \\le 1/(n+1) \\to 0 \\Rightarrow \\sum_{k\\le n} 1/a_k \\to 1$."
+    },
+    {
+      "id": "series-value",
+      "title": "Summability and the Infinite Sum",
+      "startLine": 131,
+      "endLine": 157,
+      "summary": "Establishes syl_summable (partial sums bounded by 1, summable_of_sum_range_le), then syl_tsum_reciprocal (∑' k, 1/aₖ = 1) by matching the tsum's defining limit — the range-(n+1) partial sums via HasSum.tendsto_sum_nat and a +1 shift — against syl_partial_tendsto_one with tendsto_nhds_unique. Concludes with the HasSum form syl_reciprocal_hasSum.",
+      "mathContext": "$\\sum' 1/a_k = 1$, and $\\mathrm{HasSum}\\ (1/a_\\bullet)\\ 1$."
+    }
+  ],
+  "references": [
+    {
+      "title": "Sylvester's sequence",
+      "url": "https://en.wikipedia.org/wiki/Sylvester%27s_sequence"
+    },
+    {
+      "title": "OEIS A000058 — Sylvester's sequence",
+      "url": "https://oeis.org/A000058"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "sylvester-sequence-oq-01",
+      "relationship": "Promotes the base entry's partial sum to a convergent series",
+      "description": "The base entry proves the closed-form partial sum ∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1}-1) and lists 'promote the convergence to a formal Tendsto statement' as its first open question; this entry answers it, formalizing ∑' 1/aₖ = 1 and the HasSum statement."
+    },
+    {
+      "proofId": "harmonic-divergence",
+      "relationship": "Contrasting reciprocal-series behavior",
+      "description": "Where the harmonic series ∑ 1/n diverges, Sylvester's reciprocals ∑ 1/aₖ converge to exactly 1 — here proved as a genuine summable series — because the terms grow at least linearly faster (in fact doubly exponentially)."
+    },
+    {
+      "proofId": "basel-problem",
+      "relationship": "Another exact reciprocal-series evaluation",
+      "description": "Both pin down the exact value of a convergent series of reciprocals; here the sum equals the Egyptian-fraction unit 1, rather than the Basel value π²/6."
+    }
+  ],
+  "conclusion": {
+    "summary": "The reciprocals of Sylvester's sequence are shown to form a convergent series summing to exactly 1, both as ∑' k, 1/aₖ = 1 and as HasSum (fun k => 1/aₖ) 1, fully machine-checked with zero sorries and zero axioms. This promotes the base entry's exact partial-sum formula 1 - 1/(a_{n+1}-1) to a genuine statement about the infinite series, the analytic content that 'the reciprocals sum to 1' actually asserts.",
+    "implications": "The convergence rests on two cheap ingredients: nonnegative terms with partial sums bounded by 1 (giving summability), and the elementary linear bound aₙ ≥ n + 2 (giving the error term 1/(a_{n+1}-1) → 0). The value is then forced by uniqueness of limits. The proof illustrates the standard discipline for turning an exact finite identity into a series statement — bound the partial sums, identify the limit, and reconcile the abstract tsum with the explicit telescoping limit.",
+    "openQuestions": [
+      "Can the doubly-exponential convergence rate be made quantitative in Lean — e.g. an explicit bound |1 - ∑_{k≤n} 1/aₖ| ≤ 1/(a_{n+1}-1) with a₁ₙ growth estimate showing the tail shrinks faster than any geometric rate?",
+      "Does the same summable-with-bounded-partial-sums template formalize the reciprocal sums of other Euclid-style sequences (e.g. ∑ 1/(2^{2^n}+1) for Fermat numbers, or general Znám systems)?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
New verified gallery entry **sylvester-sequence-oq-02**: the reciprocals of Sylvester's sequence ($a_0=2$, $a_{n+1}=a_n^2-a_n+1$) form a convergent series summing to **exactly 1**.

The base entry `sylvester-sequence-oq-01` proves the closed-form *partial* sum
$\sum_{k\le n} 1/a_k = 1 - 1/(a_{n+1}-1)$ and only **remarks** that the infinite sum is 1. Its meta.json lists as its *first open question*: "Can the convergence be promoted to a formal Tendsto statement … by combining the closed form with $a_{n+1}-1\to\infty$?" This entry answers exactly that.

## Main results (`Proofs/SylvesterSequenceOQ02.lean`)
- `syl_tsum_reciprocal` : `∑' k, (1:ℝ)/aₖ = 1`
- `syl_reciprocal_hasSum` : `HasSum (fun k => (1:ℝ)/aₖ) 1`
- `syl_summable` : summable (nonneg terms, partial sums bounded by 1)
- `syl_ge_add_two` : linear bound `n+2 ≤ aₙ` forcing `1/(a_{n+1}-1) → 0`
- `syl_partial_tendsto_one`, `syl_recip_pred_tendsto_zero` : the analytic engine

## Proof shape
Nonneg terms + partial sums `= 1 - 1/(a_{n+1}-1) ≤ 1` give summability (`summable_of_sum_range_le`). The value is pinned to 1 by re-deriving the telescoping closed form over ℝ and sending `n→∞`: the error term is squeezed below `1/(n+1)→0` using the crude linear bound (a linear bound suffices despite doubly-exponential growth). `tendsto_nhds_unique` reconciles the abstract `tsum` limit (`HasSum.tendsto_sum_nat` + `+1` shift) with the explicit telescoping limit.

## Distinctness
- Slug, gallery dir, and `SylvesterSequenceOQ02.lean` are all new (not on main; no competing PR).
- Genuinely distinct from oq-01, which stops at the *partial* sum and has no `tsum`/`HasSum`/`Tendsto`. Self-contained (Mathlib-only); the few elementary facts (`syl_succ`, `two_le_syl`, `syl_cast_succ`) are re-derived so the analytic capstone has no cross-file dependency.

## Verification
- Built with `lake env lean Proofs/SylvesterSequenceOQ02.lean` — exit 0, no errors/warnings.
- `#print axioms` on both headline theorems: `propext, Classical.choice, Quot.sound` only — **0 axioms, 0 sorries**.

## Status
**Outcome**: completed (verified, 0-axiom)

🤖 Generated by researcher-1