### PR TITLE
research(repunit-oq-02): repunits are a strong divisibility sequence gcd(R_m,R_n)=R_gcd(m,n) (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2916,6 +2916,7 @@ import Proofs.RationalCanonicalFormExists
 import Proofs.RelativizedHalting
 import Proofs.RelativizedHaltingBridge
 import Proofs.RepunitDivisibilityOQ01
+import Proofs.RepunitDivisibilityOQ02
 import Proofs.RiemannHypothesis
 import Proofs.RiemannHypothesisConsequences
 import Proofs.RothTheorem

--- a/proofs/Proofs/RepunitDivisibilityOQ02.lean
+++ b/proofs/Proofs/RepunitDivisibilityOQ02.lean
@@ -1,0 +1,113 @@
+import Proofs.RepunitDivisibilityOQ01
+
+/-!
+# Repunits are a strong divisibility sequence: `gcd(R_m, R_n) = R_{gcd(m,n)}`
+
+The base-`b` repunit `R_b(n) = ∑_{i<n} b^i` (see `RepunitDivisibilityOQ01`) satisfies
+the **divisibility** criterion `R_b(m) ∣ R_b(n) ↔ m ∣ n`. This file proves the strictly
+stronger **strong divisibility** identity
+
+  **`gcd(R_b(m), R_b(n)) = R_b(gcd(m, n))`**   (`repunit_gcd`),
+
+i.e. the repunit sequence is a *strong divisibility sequence* (an SDS). The divisibility
+criterion is the special case where one index divides the other; the gcd identity holds for
+*every* pair of indices.
+
+## Method
+
+The engine is the corresponding identity for `b^k − 1`:
+
+  **`gcd(b^m − 1, b^n − 1) = b^{gcd(m,n)} − 1`**   (`gcd_pow_sub_one`),
+
+proved by Euclidean descent along `Nat.gcd.induction`. Writing `n = m·q + r` with `r = n % m`,
+the geometric factorisation `(b^m − 1) ∣ ((b^m)^q − 1)` gives
+`b^n − 1 = (b^m − 1)·(c·b^r) + (b^r − 1)`, so
+`gcd(b^m − 1, b^n − 1) = gcd(b^m − 1, b^r − 1)` (`Nat.gcd_mul_left_add_right`); this matches the
+recursion `gcd m n = gcd (n % m) m` (`Nat.gcd_rec`), closing the induction.
+
+The transfer to repunits cancels the common factor `b − 1` via the multiplicative bridge
+`(b − 1)·R_b(n) = b^n − 1` (`pred_mul_repunit`) and `Nat.gcd_mul_left`.
+
+As a corollary, `R_b(m)` and `R_b(n)` are coprime iff `m` and `n` are (`repunit_coprime_iff`),
+since `R_b(d) = 1 ↔ d = 1` (`repunit_eq_one_iff`).
+
+No axioms, no sorries.
+-/
+
+namespace RepunitDivisibilityOQ02
+
+open RepunitDivisibilityOQ01
+
+/-- **Strong divisibility for `b^k − 1`** (`b ≥ 1`):
+`gcd(b^m − 1, b^n − 1) = b^{gcd(m,n)} − 1`.
+
+Proved by Euclidean descent: the geometric factorisation reduces the gcd of
+`b^m − 1` and `b^n − 1` to that of `b^m − 1` and `b^{n % m} − 1`, mirroring `Nat.gcd_rec`. -/
+theorem gcd_pow_sub_one (b : ℕ) (hb : 1 ≤ b) (m n : ℕ) :
+    Nat.gcd (b ^ m - 1) (b ^ n - 1) = b ^ Nat.gcd m n - 1 := by
+  induction m, n using Nat.gcd.induction with
+  | H0 n => simp
+  | H1 m n hm ih =>
+    -- `n = m * (n / m) + n % m`; reduce `b^n − 1` modulo `b^m − 1`.
+    have hbr_pos : 1 ≤ b ^ (n % m) := Nat.one_le_pow _ _ hb
+    have hdvd : (b ^ m - 1) ∣ ((b ^ m) ^ (n / m) - 1) := by
+      simpa using Nat.sub_dvd_pow_sub_pow (b ^ m) 1 (n / m)
+    obtain ⟨c, hc⟩ := hdvd
+    have hAq_pos : 1 ≤ (b ^ m) ^ (n / m) := Nat.one_le_pow _ _ (Nat.one_le_pow _ _ hb)
+    have hA : (b ^ m) ^ (n / m) = (b ^ m - 1) * c + 1 := by omega
+    have hexp : b ^ n = (b ^ m) ^ (n / m) * b ^ (n % m) := by
+      rw [← pow_mul, ← pow_add, Nat.div_add_mod]
+    have hbn : b ^ n = (b ^ m - 1) * (c * b ^ (n % m)) + b ^ (n % m) := by
+      rw [hexp, hA]; ring
+    have hbn1 : b ^ n - 1 = (b ^ m - 1) * (c * b ^ (n % m)) + (b ^ (n % m) - 1) := by
+      omega
+    rw [Nat.gcd_rec m n, ← ih, Nat.gcd_comm (b ^ (n % m) - 1) (b ^ m - 1),
+      hbn1, Nat.gcd_mul_left_add_right]
+
+/-- **Repunits are a strong divisibility sequence** (base `b ≥ 2`):
+`gcd(R_b(m), R_b(n)) = R_b(gcd(m, n))`.
+
+This strengthens `repunit_dvd_iff`: the divisibility criterion `R_m ∣ R_n ↔ m ∣ n` is the
+special case `gcd(m, n) ∈ {m, n}`. -/
+theorem repunit_gcd {b : ℕ} (hb : 2 ≤ b) (m n : ℕ) :
+    Nat.gcd (repunit b m) (repunit b n) = repunit b (Nat.gcd m n) := by
+  have hb1 : 1 ≤ b := by omega
+  have lhs : (b - 1) * Nat.gcd (repunit b m) (repunit b n)
+      = Nat.gcd ((b - 1) * repunit b m) ((b - 1) * repunit b n) :=
+    (Nat.gcd_mul_left (b - 1) (repunit b m) (repunit b n)).symm
+  rw [pred_mul_repunit b m hb1, pred_mul_repunit b n hb1, gcd_pow_sub_one b hb1 m n,
+    ← pred_mul_repunit b (Nat.gcd m n) hb1] at lhs
+  exact Nat.eq_of_mul_eq_mul_left (show 0 < b - 1 by omega) lhs
+
+/-- Base-ten repunits `R_n = 11…1`: `gcd(R_m, R_n) = R_{gcd(m,n)}`. -/
+theorem repunit_ten_gcd (m n : ℕ) :
+    Nat.gcd (repunit 10 m) (repunit 10 n) = repunit 10 (Nat.gcd m n) :=
+  repunit_gcd (by norm_num) m n
+
+/-- A repunit equals `1` exactly at length `1` (base `b ≥ 2`): `R_b(d) = 1 ↔ d = 1`.
+(`R_b(0) = 0`, `R_b(1) = 1`, and `R_b(d) ≥ 2` for `d ≥ 2`.) -/
+theorem repunit_eq_one_iff {b : ℕ} (hb : 2 ≤ b) (d : ℕ) :
+    repunit b d = 1 ↔ d = 1 := by
+  constructor
+  · intro h
+    match d with
+    | 0 => simp [repunit] at h
+    | 1 => rfl
+    | (k + 2) =>
+      exfalso
+      have hb1 : 2 ≤ b ^ (k + 1) := by
+        calc 2 ≤ b := hb
+          _ = b ^ 1 := (pow_one b).symm
+          _ ≤ b ^ (k + 1) := Nat.pow_le_pow_right (by omega) (by omega)
+      rw [repunit_succ] at h
+      omega
+  · rintro rfl
+    simp [repunit]
+
+/-- **Coprimality criterion** (base `b ≥ 2`): `R_b(m)` and `R_b(n)` are coprime iff
+`m` and `n` are coprime. A direct consequence of the strong divisibility identity. -/
+theorem repunit_coprime_iff {b : ℕ} (hb : 2 ≤ b) (m n : ℕ) :
+    Nat.Coprime (repunit b m) (repunit b n) ↔ Nat.Coprime m n := by
+  simp only [Nat.Coprime, repunit_gcd hb, repunit_eq_one_iff hb]
+
+end RepunitDivisibilityOQ02

--- a/src/data/proofs/repunit-oq-02/meta.json
+++ b/src/data/proofs/repunit-oq-02/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "repunit-oq-02",
+  "slug": "repunit-oq-02",
+  "title": "Repunits Are a Strong Divisibility Sequence: gcd(R_m, R_n) = R_gcd(m,n)",
+  "description": "A base-b repunit R_b(n) = 1 + b + b² + ⋯ + b^{n-1} is the number written as n ones in base b (R₁₀(3) = 111). This entry proves, fully machine-checked with 0 sorries and 0 axioms, that the repunit sequence is a strong divisibility sequence: gcd(R_b(m), R_b(n)) = R_b(gcd(m, n)) for every base b ≥ 2 and all indices m, n. This strictly strengthens the divisibility criterion R_b(m) ∣ R_b(n) ⟺ m ∣ n (entry repunit-oq-01), which is the special case gcd(m, n) ∈ {m, n}. The engine is the analogous identity gcd(b^m − 1, b^n − 1) = b^{gcd(m,n)} − 1, proved by Euclidean descent along Nat.gcd.induction; transfer to repunits cancels the universal factor b − 1. As corollaries: R_b(m) and R_b(n) are coprime iff m and n are.",
+  "leanFile": {
+    "imports": ["Proofs.RepunitDivisibilityOQ01"],
+    "opens": ["RepunitDivisibilityOQ01"],
+    "namespace": "RepunitDivisibilityOQ02",
+    "lineCount": 113,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 3,
+    "trivialSpecializations": 1,
+    "definitionCount": 0,
+    "path": "Proofs/RepunitDivisibilityOQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Classical (strong divisibility sequences; repunits popularized by A. H. Beiler, 1966)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Divisibility_sequence",
+    "date": "1966",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RepunitDivisibilityOQ02.lean",
+    "tags": [
+      "number-theory",
+      "repunit",
+      "divisibility",
+      "gcd",
+      "strong-divisibility-sequence",
+      "euclidean-algorithm"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Repunits are defined directly as ∑_{i<n} b^i in ℕ (reused from repunit-oq-01); all results are proved from elementary divisibility and the Euclidean recursion with no axioms and no structure-encoded hypotheses.",
+    "dateAdded": "2026-06-19",
+    "mathlibDependencies": [
+      "Nat.gcd.induction",
+      "Nat.gcd_rec",
+      "Nat.gcd_mul_left",
+      "Nat.gcd_mul_left_add_right",
+      "Nat.sub_dvd_pow_sub_pow"
+    ],
+    "originalContributions": [
+      "Strong divisibility identity for repunits repunit_gcd: for base b ≥ 2, gcd(R_b(m), R_b(n)) = R_b(gcd(m, n)) — the repunit sequence is a strong divisibility sequence",
+      "Power-difference strong divisibility gcd_pow_sub_one: gcd(b^m − 1, b^n − 1) = b^{gcd(m,n)} − 1, proved by Euclidean descent along Nat.gcd.induction (matches the gcd recursion gcd m n = gcd (n % m) m)",
+      "Coprimality criterion repunit_coprime_iff: R_b(m) and R_b(n) are coprime ⟺ m and n are coprime",
+      "Auxiliary repunit_eq_one_iff: R_b(d) = 1 ⟺ d = 1 for base b ≥ 2",
+      "Base-ten corollary repunit_ten_gcd: gcd(R₁₀(m), R₁₀(n)) = R₁₀(gcd(m, n))"
+    ],
+    "prerequisites": [
+      "The Euclidean algorithm and the gcd recursion gcd m n = gcd (n % m) m",
+      "Geometric factorization (b^m − 1) ∣ (b^m)^q − 1",
+      "Elementary divisibility and gcd arithmetic in ℕ"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 113,
+    "relatedProblems": ["repunit-oq-01"],
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "A sequence $(a_n)$ of integers is a *divisibility sequence* if $m \\mid n \\Rightarrow a_m \\mid a_n$, and a *strong divisibility sequence* (SDS) if $\\gcd(a_m, a_n) = a_{\\gcd(m,n)}$. The classical examples are $b^n - 1$, the Fibonacci numbers, and — proved here — the base-$b$ repunits $R_b(n) = (b^n - 1)/(b - 1)$. The SDS property is strictly stronger than plain divisibility (which is the special case $\\gcd(m,n) \\in \\{m,n\\}$) and is the structural reason behind repunit and Mersenne factorization tables: it pins down $\\gcd(R_m, R_n)$ for *every* pair of lengths, not just nested ones. Entry repunit-oq-01 proved the divisibility criterion $R_m \\mid R_n \\iff m \\mid n$; its open-question list explicitly asks for this gcd sharpening, which this entry supplies.",
+    "problemStatement": "Fix an integer base $b \\ge 2$ and define $R_b(n) = \\sum_{i=0}^{n-1} b^i$. Prove that for all natural numbers $m, n$, $\\gcd(R_b(m), R_b(n)) = R_b(\\gcd(m, n))$; equivalently, the repunits form a strong divisibility sequence.",
+    "proofStrategy": "Prove the corresponding identity for the power-difference sequence $f(k) = b^k - 1$ and transfer. For $f$, run Euclidean descent via `Nat.gcd.induction`: with $n = m q + r$, $r = n \\bmod m$, the geometric factorization $(b^m - 1) \\mid ((b^m)^q - 1)$ yields $b^n - 1 = (b^m - 1)\\,(c\\,b^r) + (b^r - 1)$, so $\\gcd(b^m - 1, b^n - 1) = \\gcd(b^m - 1, b^r - 1)$ by `Nat.gcd_mul_left_add_right`. This is exactly the gcd recursion $\\gcd(m,n) = \\gcd(n \\bmod m, m)$ (`Nat.gcd_rec`), so induction gives $\\gcd(b^m - 1, b^n - 1) = b^{\\gcd(m,n)} - 1$. Transfer to repunits by cancelling the universal positive factor $b - 1$: from $(b-1) R_b(k) = b^k - 1$ and `Nat.gcd_mul_left`, $(b-1)\\gcd(R_m, R_n) = \\gcd(b^m - 1, b^n - 1) = b^{\\gcd(m,n)} - 1 = (b-1) R_b(\\gcd(m,n))$, and cancellation finishes.",
+    "keyInsights": [
+      "The strong divisibility property is the natural completion of the divisibility criterion: $R_m \\mid R_n \\iff m \\mid n$ is exactly $\\gcd(R_m, R_n) = R_{\\gcd(m,n)}$ restricted to nested pairs $\\gcd(m,n) \\in \\{m, n\\}$.",
+      "Euclidean descent transports verbatim from the exponents to the values: the single reduction $\\gcd(b^m-1, b^n-1) = \\gcd(b^{n \\bmod m}-1, b^m-1)$ mirrors $\\gcd(m,n) = \\gcd(n \\bmod m, m)$, so `Nat.gcd.induction` closes the whole identity in one step.",
+      "The reduction needs no modular arithmetic, only the exact factorization $b^n - 1 = (b^m - 1)(c\\,b^{r}) + (b^{r} - 1)$ obtained from $(b^m - 1) \\mid (b^m)^{q} - 1$; `Nat.gcd_mul_left_add_right` then peels the multiple of $b^m - 1$.",
+      "Cancelling the universal factor $b - 1$ commutes with gcd (`Nat.gcd_mul_left`), so the repunit identity is a one-line consequence of the power-difference identity — the same $b - 1$ trick that powered the divisibility criterion.",
+      "Coprimality drops out: since $R_b(d) = 1 \\iff d = 1$, the gcd identity gives $\\gcd(R_m, R_n) = 1 \\iff \\gcd(m,n) = 1$, i.e. consecutive-length repunits (and more generally coprime lengths) are coprime."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "repunit_gcd",
+      "statement": "2 ≤ b → gcd(repunit b m, repunit b n) = repunit b (gcd m n)",
+      "description": "The main result: for any base b ≥ 2 the repunits form a strong divisibility sequence, gcd(R_m, R_n) = R_{gcd(m,n)}. Subsumes the divisibility criterion R_m ∣ R_n ⟺ m ∣ n."
+    },
+    {
+      "name": "gcd_pow_sub_one",
+      "statement": "1 ≤ b → gcd(b^m − 1, b^n − 1) = b^{gcd(m,n)} − 1",
+      "description": "The power-difference engine, proved by Euclidean descent along Nat.gcd.induction. Specializes at b = 2 to gcd(2^m − 1, 2^n − 1) = 2^{gcd(m,n)} − 1 for Mersenne numbers."
+    },
+    {
+      "name": "repunit_coprime_iff",
+      "statement": "2 ≤ b → (Coprime (repunit b m) (repunit b n) ↔ Coprime m n)",
+      "description": "Coprimality criterion: repunits of lengths m and n are coprime iff m and n are coprime, a direct corollary of the strong divisibility identity and repunit_eq_one_iff."
+    },
+    {
+      "name": "repunit_ten_gcd",
+      "statement": "gcd(repunit 10 m, repunit 10 n) = repunit 10 (gcd m n)",
+      "description": "Base-ten corollary: the ordinary repunits 1, 11, 111, … satisfy gcd(R_m, R_n) = R_{gcd(m,n)}."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "import Proofs.RepunitDivisibilityOQ01 (reusing the repunit definition and power bridge), the module docstring stating the strong divisibility identity gcd(R_m, R_n) = R_{gcd(m,n)} and sketching the Euclidean-descent reduction, and `namespace RepunitDivisibilityOQ02` with `open RepunitDivisibilityOQ01`."
+    },
+    {
+      "id": "power-engine",
+      "title": "Strong Divisibility for b^k − 1",
+      "startLine": 50,
+      "endLine": 78,
+      "summary": "Proves gcd_pow_sub_one: gcd(b^m − 1, b^n − 1) = b^{gcd(m,n)} − 1 (b ≥ 1) by Nat.gcd.induction. The H1 step writes n = m·(n/m) + n%m, uses the geometric factorization (b^m − 1) ∣ (b^m)^{n/m} − 1 to obtain b^n − 1 = (b^m − 1)·(c·b^{n%m}) + (b^{n%m} − 1), then peels the multiple of b^m − 1 with Nat.gcd_mul_left_add_right; this matches Nat.gcd_rec, closing the induction.",
+      "mathContext": "$\\gcd(b^m-1, b^n-1) = \\gcd(b^{n\\bmod m}-1, b^m-1)$ mirrors $\\gcd(m,n) = \\gcd(n\\bmod m, m)$."
+    },
+    {
+      "id": "repunit-gcd",
+      "title": "Repunit Strong Divisibility and the Base-Ten Case",
+      "startLine": 79,
+      "endLine": 96,
+      "summary": "Concludes repunit_gcd by cancelling the universal factor b − 1: from (b−1)·R_b(k) = b^k − 1 (pred_mul_repunit) and Nat.gcd_mul_left, (b−1)·gcd(R_m, R_n) = gcd(b^m−1, b^n−1) = b^{gcd(m,n)}−1 = (b−1)·R_b(gcd m n), and Nat.eq_of_mul_eq_mul_left finishes. Instantiates the base-ten corollary repunit_ten_gcd.",
+      "mathContext": "$(b-1)\\gcd(R_m,R_n) = \\gcd(b^m-1,b^n-1) = (b-1)R_b(\\gcd(m,n))$."
+    },
+    {
+      "id": "coprime",
+      "title": "Coprimality Criterion",
+      "startLine": 97,
+      "endLine": 113,
+      "summary": "Proves repunit_eq_one_iff (R_b(d) = 1 ⟺ d = 1 for b ≥ 2, via R_b(0) = 0, R_b(1) = 1, and R_b(d) ≥ 2 for d ≥ 2) and deduces repunit_coprime_iff: Coprime(R_m, R_n) ⟺ Coprime m n, by rewriting gcd through repunit_gcd and repunit_eq_one_iff."
+    }
+  ],
+  "references": [
+    {
+      "title": "Divisibility sequence",
+      "url": "https://en.wikipedia.org/wiki/Divisibility_sequence"
+    },
+    {
+      "title": "Repunit",
+      "url": "https://en.wikipedia.org/wiki/Repunit"
+    },
+    {
+      "title": "OEIS A002275 — Repunits (10^n − 1)/9",
+      "url": "https://oeis.org/A002275"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "repunit-oq-01",
+      "relationship": "Strengthens the divisibility criterion to the gcd form",
+      "description": "repunit-oq-01 proves R_m ∣ R_n ⟺ m ∣ n and reuses its repunit definition and the bridge (b − 1)·R_b(n) = b^n − 1. The present entry answers that file's open question: gcd(R_m, R_n) = R_{gcd(m,n)}, of which the divisibility iff is the nested-pair special case."
+    }
+  ],
+  "conclusion": {
+    "summary": "For every base b ≥ 2, the base-b repunits form a strong divisibility sequence: gcd(R_b(m), R_b(n)) = R_b(gcd(m, n)), fully machine-checked with zero sorries and zero axioms. The proof establishes the power-difference identity gcd(b^m − 1, b^n − 1) = b^{gcd(m,n)} − 1 by Euclidean descent and transfers it to repunits by cancelling the universal factor b − 1.",
+    "implications": "The identity is the structural completion of the repunit divisibility law: it determines gcd(R_m, R_n) for all pairs of lengths, specializes at b = 2 to the Mersenne-number gcd identity gcd(2^m − 1, 2^n − 1) = 2^{gcd(m,n)} − 1, and yields the coprimality criterion that repunits of coprime lengths are coprime. It models the SDS-via-Euclidean-descent technique entirely inside the kernel with no native_decide and no axioms.",
+    "openQuestions": [
+      "Does the same Euclidean-descent template give gcd identities for the related sequences b^n + 1 (where gcd depends on the 2-adic valuations of m and n), making the dependence on parity explicit?",
+      "Can repunit_coprime_iff be packaged with repunit-oq-01 into a Mathlib-style `IsStrongDivisibilitySequence` instance for the generic sequence n ↦ (b^n − 1)/(b − 1)?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Proves that base-`b` repunits $R_b(n)=\sum_{i<n}b^i$ form a **strong divisibility sequence**:

$$\gcd(R_b(m),\,R_b(n)) = R_b(\gcd(m,n))\quad(b\ge 2).$$

This strictly strengthens entry `repunit-oq-01` (the divisibility criterion $R_m\mid R_n\iff m\mid n$, which is the nested-pair special case $\gcd(m,n)\in\{m,n\}$) and **answers that entry's stated open question** verbatim.

## Contributions (all verified, 0 sorries, 0 axioms)

- `gcd_pow_sub_one` — $\gcd(b^m-1,\,b^n-1)=b^{\gcd(m,n)}-1$, proved by Euclidean descent along `Nat.gcd.induction`. The single reduction $\gcd(b^m-1,b^n-1)=\gcd(b^{n\bmod m}-1,\,b^m-1)$ (via the geometric factorization $(b^m-1)\mid(b^m)^q-1$ and `Nat.gcd_mul_left_add_right`) mirrors `Nat.gcd_rec`. Specializes at $b=2$ to the Mersenne identity $\gcd(2^m-1,2^n-1)=2^{\gcd(m,n)}-1$.
- `repunit_gcd` — the main result, obtained by cancelling the universal factor $b-1$ (`Nat.gcd_mul_left` + `pred_mul_repunit` from oq-01).
- `repunit_coprime_iff` — $R_b(m),R_b(n)$ coprime $\iff m,n$ coprime.
- `repunit_eq_one_iff` — $R_b(d)=1\iff d=1$ (supporting lemma).
- `repunit_ten_gcd` — base-ten corollary.

## Verification

- `lake env lean Proofs/RepunitDivisibilityOQ02.lean` — compiles clean (exit 0).
- `#print axioms` on all five theorems: only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). 0-axiom.
- Reuses `repunit` and the power bridge from `Proofs.RepunitDivisibilityOQ01`; no new definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)