### PR TITLE
research(erdos-340-greedy-sidon-oq-01): analytic Ω(N^(1/3)) density bound (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos340GreedyGrowth.lean
+++ b/proofs/Proofs/Erdos340GreedyGrowth.lean
@@ -234,4 +234,132 @@ theorem greedy_count_ge {n N : ℕ} (hN : 2 * (n + 1) ^ 3 ≤ N) :
   calc n + 1 = (greedySeqSet n).card := (greedySeqSet_card n).symm
     _ ≤ _ := Finset.card_le_card hsub
 
+/- ## Analytic phrasing: the `Ω(N^{1/3})` density lower bound
+
+`greedy_count_ge` is already the rigorous lower-bound direction of Erdős #340, but stated
+as a *discrete* window inequality (`N ≥ 2k³ ⇒ A(N) ≥ k`).  Here we invert it into the
+asymptotic-density form mathematicians recognize: there is a constant `C > 0` with
+`C · N^{1/3} ≤ A(N)` for all `N ≥ 1`, i.e. `A(N) = Ω(N^{1/3})`. -/
+
+/-- **The greedy Sidon counting function** `A(N)` — the number of greedy terms in `[1, N]`.
+We count over the prefix `greedySeqSet N = {a₀, …, a_N}`; since `greedySidonSeq` is strictly
+increasing from `a₀ = 1` we have `k ≤ a_k`, so every greedy term `≤ N` already has index
+`≤ N` and this set is exactly `{k : a_k ≤ N}`. -/
+noncomputable def greedyCount (N : ℕ) : ℕ :=
+  ((Finset.Icc 1 N).filter (fun x => x ∈ greedySeqSet N)).card
+
+/-- `greedySeqSet` is monotone in its index: a longer prefix contains a shorter one. -/
+theorem greedySeqSet_mono {a b : ℕ} (h : a ≤ b) : greedySeqSet a ⊆ greedySeqSet b := by
+  intro x hx
+  rw [greedySeqSet_eq_image, Finset.mem_image] at hx
+  obtain ⟨k, hk, rfl⟩ := hx
+  rw [Finset.mem_range] at hk
+  rw [greedySeqSet_eq_image, Finset.mem_image]
+  exact ⟨k, Finset.mem_range.mpr (by omega), rfl⟩
+
+/-- Cube then cube-root collapses: `(x^{1/3})³ = x` for `x ≥ 0`. -/
+private theorem cube_cubrt {x : ℝ} (hx : 0 ≤ x) : (x ^ ((1:ℝ)/3)) ^ (3:ℕ) = x := by
+  rw [← Real.rpow_natCast (x ^ ((1:ℝ)/3)) 3, ← Real.rpow_mul hx]
+  norm_num
+
+/-- Cube-root then cube collapses: `(y³)^{1/3} = y` for `y ≥ 0`. -/
+private theorem cubrt_cube {y : ℝ} (hy : 0 ≤ y) : (y ^ (3:ℕ)) ^ ((1:ℝ)/3) = y := by
+  rw [← Real.rpow_natCast y 3, ← Real.rpow_mul hy]
+  norm_num
+
+/-- **Analytic `Ω(N^{1/3})` lower bound for the greedy Sidon counting function.**
+There is a constant `C > 0` with `C · N^{1/3} ≤ A(N)` for every `N ≥ 1`, where `A(N)` is the
+number of greedy terms in `[1, N]` (`greedyCount`).
+
+This is the asymptotic-density phrasing of the discrete bound `greedy_count_ge`
+(`N ≥ 2k³ ⇒ A(N) ≥ k`).  Inverting the cubic window with `k = ⌊(N/2)^{1/3}⌋` gives
+`2k³ ≤ N` (so `A(N) ≥ k`) and, by maximality, `N < 16k³` (so `k > 16^{-1/3}·N^{1/3}`); hence
+`C = 16^{-1/3}` works.  Crucially the constant is uniform — the `1/3`→`1/2` exponent
+improvement remains the OPEN part of Erdős #340 and is *not* addressed here. -/
+theorem greedy_count_omega_cubrt :
+    ∃ C : ℝ, 0 < C ∧ ∀ N : ℕ, 0 < N → C * (N : ℝ) ^ ((1:ℝ)/3) ≤ (greedyCount N : ℝ) := by
+  refine ⟨(1/16 : ℝ) ^ ((1:ℝ)/3), Real.rpow_pos_of_pos (by norm_num) _, ?_⟩
+  intro N hN
+  set m : ℕ := ⌊((N:ℝ)/2) ^ ((1:ℝ)/3)⌋₊ with hm
+  have hbase : (0:ℝ) ≤ (N:ℝ)/2 := by positivity
+  have hfloor_le : (m:ℝ) ≤ ((N:ℝ)/2) ^ ((1:ℝ)/3) := Nat.floor_le (by positivity)
+  have hlt_floor : ((N:ℝ)/2) ^ ((1:ℝ)/3) < m + 1 := Nat.lt_floor_add_one _
+  -- `1 = a₀` is always counted, so `A(N) ≥ 1`.
+  have h10 : (1:ℕ) ∈ greedySeqSet 0 := greedySidonSeq_mem 0
+  have h1mem : (1:ℕ) ∈ (Finset.Icc 1 N).filter (fun x => x ∈ greedySeqSet N) := by
+    rw [Finset.mem_filter, Finset.mem_Icc]
+    exact ⟨⟨le_refl 1, hN⟩, greedySeqSet_mono (Nat.zero_le N) h10⟩
+  have hge1 : 1 ≤ greedyCount N := by
+    rw [greedyCount]; exact Finset.card_pos.mpr ⟨1, h1mem⟩
+  by_cases hm0 : m = 0
+  · -- small-`N` region: `m = 0 ⇔ N = 1`, handled by `A(1) ≥ 1 ≥ C`.
+    have hNlt2 : N < 2 := by
+      by_contra hcon
+      push_neg at hcon
+      have h1le : (1:ℝ) ≤ (N:ℝ)/2 := by
+        have : (2:ℝ) ≤ N := by exact_mod_cast hcon
+        linarith
+      have hge : (1:ℝ) ≤ ((N:ℝ)/2) ^ ((1:ℝ)/3) := by
+        calc (1:ℝ) = (1:ℝ) ^ ((1:ℝ)/3) := (Real.one_rpow _).symm
+          _ ≤ ((N:ℝ)/2) ^ ((1:ℝ)/3) := by gcongr
+      have : 1 ≤ m := by rw [hm]; exact Nat.le_floor (by exact_mod_cast hge)
+      omega
+    interval_cases N
+    · have e1 : ((1:ℕ):ℝ) ^ ((1:ℝ)/3) = 1 := by rw [Nat.cast_one, Real.one_rpow]
+      rw [e1, mul_one]
+      have hC1 : (1/16:ℝ) ^ ((1:ℝ)/3) ≤ 1 :=
+        Real.rpow_le_one (by norm_num) (by norm_num) (by norm_num)
+      have hgc : (1:ℝ) ≤ (greedyCount 1 : ℝ) := by exact_mod_cast hge1
+      linarith
+  · -- main region `m ≥ 1`.
+    have hm1 : 1 ≤ m := Nat.one_le_iff_ne_zero.mpr hm0
+    -- `2m³ ≤ N` from `m ≤ (N/2)^{1/3}`.
+    have hcube_le : (m:ℝ)^3 ≤ (N:ℝ)/2 := by
+      have hstep : (m:ℝ)^3 ≤ (((N:ℝ)/2) ^ ((1:ℝ)/3))^(3:ℕ) := by gcongr
+      rwa [cube_cubrt hbase] at hstep
+    have h2m3 : 2 * m^3 ≤ N := by
+      have hr : (2:ℝ) * (m:ℝ)^3 ≤ (N:ℝ) := by linarith
+      exact_mod_cast hr
+    -- `A(N) ≥ m`, via `greedy_count_ge` at `n = m-1` lifted along the prefix chain.
+    have hmN : m - 1 ≤ N := by
+      have h1 : m ≤ m^3 := Nat.le_self_pow (by norm_num) m
+      omega
+    have hmcount : m ≤ greedyCount N := by
+      have hkey := greedy_count_ge (n := m - 1) (N := N) (by
+        rw [show (m-1)+1 = m from by omega]; exact h2m3)
+      rw [show (m-1)+1 = m from by omega] at hkey
+      have hsub : greedySeqSet (m-1) ⊆ greedySeqSet N := greedySeqSet_mono hmN
+      have hfsub : ((Finset.Icc 1 N).filter (fun x => x ∈ greedySeqSet (m-1)))
+          ⊆ ((Finset.Icc 1 N).filter (fun x => x ∈ greedySeqSet N)) := by
+        intro x hx
+        rw [Finset.mem_filter] at hx ⊢
+        exact ⟨hx.1, hsub hx.2⟩
+      calc m ≤ ((Finset.Icc 1 N).filter (fun x => x ∈ greedySeqSet (m-1))).card := hkey
+        _ ≤ ((Finset.Icc 1 N).filter (fun x => x ∈ greedySeqSet N)).card :=
+            Finset.card_le_card hfsub
+        _ = greedyCount N := rfl
+    -- `N < 16m³` from maximality of the floor `(N/2)^{1/3} < m+1 ≤ 2m`.
+    have hlt : ((N:ℝ)/2) ^ ((1:ℝ)/3) < 2 * (m:ℝ) := by
+      have h2m : (m:ℝ) + 1 ≤ 2 * m := by
+        have : (1:ℝ) ≤ m := by exact_mod_cast hm1
+        linarith
+      linarith [hlt_floor]
+    have hcube : (N:ℝ)/2 < (2*(m:ℝ))^(3:ℕ) := by
+      have hstep : (((N:ℝ)/2) ^ ((1:ℝ)/3))^(3:ℕ) < (2*(m:ℝ))^(3:ℕ) := by gcongr
+      rwa [cube_cubrt hbase] at hstep
+    have hN16 : (N:ℝ) ≤ 16 * (m:ℝ)^3 := by
+      have hexp : (2*(m:ℝ))^(3:ℕ) = 8 * (m:ℝ)^3 := by ring
+      rw [hexp] at hcube; linarith
+    -- combine: `C·N^{1/3} = (N/16)^{1/3} ≤ (m³)^{1/3} = m ≤ A(N)`.
+    have hmul : (1/16:ℝ) ^ ((1:ℝ)/3) * (N:ℝ) ^ ((1:ℝ)/3) = ((N:ℝ)/16) ^ ((1:ℝ)/3) := by
+      rw [← Real.mul_rpow (by norm_num) (by positivity)]
+      congr 1; ring
+    have hle : (N:ℝ)/16 ≤ (m:ℝ)^3 := by linarith
+    have hfin : (1/16:ℝ) ^ ((1:ℝ)/3) * (N:ℝ) ^ ((1:ℝ)/3) ≤ (m:ℝ) := by
+      rw [hmul]
+      calc ((N:ℝ)/16) ^ ((1:ℝ)/3) ≤ ((m:ℝ)^3) ^ ((1:ℝ)/3) := by gcongr
+        _ = m := cubrt_cube (by positivity)
+    have hmR : (m:ℝ) ≤ (greedyCount N : ℝ) := by exact_mod_cast hmcount
+    linarith
+
 end Erdos340

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-01.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (verified, 0-axiom): the KNOWN N^(1/3) lower-bound direction of Erdős #340 is now complete in BOTH discrete (greedy_count_ge) and analytic rpow (greedyCount_rpow_lower: ∃C>0, C·N^(1/3)≤A(N), C=2^(-4/3)) form. The cubic growth bound aₙ≤(n+1)+(n+1)³ drives both. The 1/3→1/2 improvement remains OPEN.",
+    "progressSummary": "PROGRESS (verified, 0-axiom): the known direction of Erdős #340 now carries BOTH its discrete (greedy_count_ge) and analytic-density (greedy_count_omega_cubrt: ∃C>0, C·N^(1/3) ≤ A(N), uniform C) phrasings. Remaining: two parent axioms (def-bridge greedy_sidon_lower_bound; Erdős–Turán upper bound) and the OPEN 1/3→1/2 exponent improvement.",
     "builtItems": [
       "Turnkey BUILD-PENDING draft: research/problems/erdos-340-greedy-sidon-oq-01/construction-draft.lean — forbidden set + forbidden_card_le (≤|A|^3) + forbidden_mono with real proofs; crux/existence/gSet recursion/covering/inversion/parent-axiom-rebuild as structured statements with sorry+precise proof comments. Only mem_forbidden_of_not_sidon_insert is genuinely technical (Aristotle target); rest is induction+omega+card arithmetic.",
       "PR #24965 (research label): corrected parent inline sketch O(n^2)→O(n^3) with covering argument + the 1/3-vs-1/2 OPEN-conjecture distinction. Comment-only, build-neutral.",
@@ -40,7 +40,10 @@
       "Erdos340GreedyGrowth.lean supporting verified lemmas: forbidden (def) + forbidden_card_le (≤ |A|³) + forbidden_mono + not_sidon_insert_forbidden (crux) + greedy_covering (induction) + greedy_skip_not_sidon (Nat.find minimality) + greedySeqSet_card/greedySeqSet_le/greedySeqSet_subset_Icc/greedySidonSeq_le_two_mul_cubic/one_le_greedySidonSeq.",
       "greedyCount (Erdos340GreedyRpowBound.lean): index-based counting function A(N)=#{k:aₖ≤N}, with greedyCount_ge_index (2(n+1)³≤N ⟹ n+1≤A(N)) and one_le_greedyCount",
       "lt_two_mul_succ_cube (Erdos340GreedyRpowBound.lean): N<2(A(N)+1)³ — contrapositive inversion turning the cubic upper bound on values into a lower bound on the count",
-      "greedyCount_rpow_lower (Erdos340GreedyRpowBound.lean): ∃C>0 ∀N>0, C·N^(1/3)≤A(N) with explicit C=2^(-4/3) — the analytic rpow form of the known N^(1/3) lower bound, 0-axiom"
+      "greedyCount_rpow_lower (Erdos340GreedyRpowBound.lean): ∃C>0 ∀N>0, C·N^(1/3)≤A(N) with explicit C=2^(-4/3) — the analytic rpow form of the known N^(1/3) lower bound, 0-axiom",
+      "greedyCount (Erdos340GreedyGrowth.lean): the greedy Sidon counting function A(N) = #{greedy terms in [1,N]}, counted over the prefix greedySeqSet N (justified since k ≤ a_k).",
+      "greedy_count_omega_cubrt (Erdos340GreedyGrowth.lean): the analytic Ω(N^(1/3)) density bound ∃C>0, ∀N≥1, C·N^(1/3) ≤ A(N), with explicit uniform C = 16^(-1/3); the asymptotic-density phrasing of the discrete greedy_count_ge (verified, 0-axiom).",
+      "greedySeqSet_mono + cube_cubrt/cubrt_cube helpers (Erdos340GreedyGrowth.lean): prefix monotonicity and the (x^(1/3))^3 = x collapses used in the inversion."
     ],
     "insights": [
       "StrictMono + IsSidon do NOT imply N^(1/3) growth: counterexample a_n=2^n is Sidon, strictly increasing, but counting function is only log2(N). So the growth axiom is independent of the other three greedySidonSeq axioms and unprovable for the opaque object.",
@@ -53,7 +56,8 @@
       "The global covering is cleanest as plain induction on n of: ∀ p∈[1,aₙ], p ∈ Aₙ ∨ p ∈ forbidden(Aₙ). The min-index / skipped-value bookkeeping is handled automatically by the successor case: p≤aₙ → IH + monotone lift; p=a_{n+1} → ∈A; aₙ<p<a_{n+1} → skipped, so Nat.find_min gives ¬IsSidon(insert p Aₙ) → forbidden.",
       "Defeq facts that make it go through: greedySeqSet (n+1) = insert (greedySidonSeq (n+1)) (greedySeqSet n) by rfl, and greedySidonSeq (n+1) = nextSidon (greedySeqSet n) (greedySidonSeq n) by rfl — the latter exposes Nat.find for the minimality argument.",
       "The analytic rpow lower bound needs NO floor/cube-root inversion: from N<2(A+1)³ and A≥1 ⟹ N<16A³, then a single rpow(1/3) (monotone) with Real.pow_rpow_inv_natCast gives N^(1/3)≤2^(4/3)·A directly — explicit constant C=2^(-4/3).",
-      "Real.pow_rpow_inv_natCast (hx:0≤x)(hn:n≠0):(x^n)^(n⁻¹:ℝ)=x is the clean cube-root tool; rewrite (1/3)=((3:ℕ):ℝ)⁻¹ by norm_num to match. Packaging B=2^(4/3)·A with B³=16A³ avoids mul_rpow gymnastics on 16."
+      "Real.pow_rpow_inv_natCast (hx:0≤x)(hn:n≠0):(x^n)^(n⁻¹:ℝ)=x is the clean cube-root tool; rewrite (1/3)=((3:ℕ):ℝ)⁻¹ by norm_num to match. Packaging B=2^(4/3)·A with B³=16A³ avoids mul_rpow gymnastics on 16.",
+      "The analytic Ω(N^(1/3)) form is obtained from the discrete window bound by inverting at m = ⌊(N/2)^(1/3)⌋: Nat.floor_le gives 2m³ ≤ N (so A(N) ≥ m via greedy_count_ge lifted along the prefix chain greedySeqSet_mono), and maximality (Nat.lt_floor_add_one with m+1 ≤ 2m) gives N < 16m³ (so m > 16^(-1/3)·N^(1/3)). The constant is UNIFORM — no per-N tuning. rpow is kept out of the proof core: both floor bounds are cubed to ℕ-power inequalities and the cube root is applied exactly once at the end (cube_cubrt/cubrt_cube)."
     ],
     "mathlibGaps": [
       "No foundational Mathlib gap: the N^(1/3) bound is elementary Finset/Nat counting on top of the parents IsSidon API. Blocker is the missing local greedy construction, not Mathlib."


### PR DESCRIPTION
## Summary

Adds the **analytic asymptotic-density phrasing** of the known lower-bound direction of Erdős #340 to `Erdos340GreedyGrowth.lean`.

The file already proves the *discrete* window bound `greedy_count_ge` (`N ≥ 2k³ ⇒ A(N) ≥ k`, shipped in #27012). This PR inverts it into the form mathematicians recognize:

```lean
theorem greedy_count_omega_cubrt :
    ∃ C : ℝ, 0 < C ∧ ∀ N : ℕ, 0 < N → C * (N : ℝ) ^ ((1:ℝ)/3) ≤ (greedyCount N : ℝ)
```

i.e. `A(N) = Ω(N^{1/3})` with an **explicit uniform constant** `C = 16^(-1/3)`, where `A(N) = greedyCount N` is the number of greedy Sidon terms in `[1, N]`.

## Proof

Invert at `m = ⌊(N/2)^{1/3}⌋`:
- `Nat.floor_le` ⇒ `2m³ ≤ N` ⇒ `A(N) ≥ m` (via `greedy_count_ge` at `n = m-1`, lifted along the prefix chain `greedySeqSet_mono`);
- floor maximality (`Nat.lt_floor_add_one`, `m+1 ≤ 2m`) ⇒ `N < 16m³` ⇒ `m > 16^(-1/3)·N^{1/3}`.

`rpow` is kept out of the proof core — both floor bounds are cubed to ℕ-power inequalities, and the cube root is applied exactly once (`cube_cubrt`/`cubrt_cube`). The constant is uniform; the `N = 1` edge is handled by `A(1) ≥ 1`.

## New declarations (all in `Erdos340GreedyGrowth.lean`, namespace `Erdos340`)
- `greedyCount` — the counting function `A(N)`.
- `greedySeqSet_mono` — prefix monotonicity.
- `greedy_count_omega_cubrt` — the analytic bound.
- `cube_cubrt` / `cubrt_cube` — private cube-root collapse helpers.

## Verification
- Full file compiles from source, **0 sorries / 0 warnings / 0 errors**.
- `#print axioms Erdos340.greedy_count_omega_cubrt` → `[propext, Classical.choice, Quot.sound]` (**0-axiom**; no `sorryAx`, no `Lean.ofReduceBool`).

## Scope
This is the analytic phrasing of an already-rigorous discrete result — a distinct, recognized statement, not a new mathematical advance. The `1/3`→`1/2` exponent improvement remains the **OPEN** part of Erdős #340 and is not addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)