### PR TITLE
research(sophie-germain-oq-04): Sophie Germain identity a⁴+4b⁴ & n⁴+4 compositeness (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2987,6 +2987,7 @@ import Proofs.SolutionOfCubicOQ05
 import Proofs.SophieGermain
 import Proofs.SophieGermainOQ01
 import Proofs.SophieGermainOQ02
+import Proofs.SophieGermainOQ04
 import Proofs.SpernerFreudenthal
 import Proofs.SpernerFreudenthalAristotle
 import Proofs.SpernerFreudenthalSimplex

--- a/proofs/Proofs/SophieGermainOQ04.lean
+++ b/proofs/Proofs/SophieGermainOQ04.lean
@@ -1,0 +1,71 @@
+import Mathlib
+
+/-!
+# Sophie Germain OQ-04: the Sophie Germain identity and its compositeness corollary
+
+Sophie Germain's *algebraic* identity (distinct from her work on Sophie Germain primes
+in the base entry) factors a sum that looks stubbornly irreducible:
+
+`a⁴ + 4·b⁴ = (a² - 2ab + 2b²) · (a² + 2ab + 2b²)`.
+
+This entry proves that identity (`sophie_germain_identity`) and reads off its classic
+consequence: numbers of the form `a⁴ + 4b⁴` are composite once both factors exceed `1`.
+The headline specialization is the famous fact that
+
+`n⁴ + 4` is prime **only** for `n = 1` (where it is `5`);
+
+for every `n ≥ 2` it factors as `(n² - 2n + 2)(n² + 2n + 2)`, both factors `> 1`
+(`not_prime_n_pow_four_add_four`). For example `5⁴ + 4 = 629 = 17 · 37`.
+
+The identity is stated and proved over `ℤ` so that the subtraction `a² - 2ab + 2b²` is
+genuine; the compositeness corollary is transported to `ℕ` by writing the smaller factor
+as `(n-1)² + 1` (substituting `n = m + 2`), which avoids `ℕ`'s truncated subtraction
+entirely.
+
+No axioms, no sorries.
+-/
+
+namespace SophieGermainOQ04
+
+/-- **The Sophie Germain identity** over `ℤ`:
+`a⁴ + 4b⁴ = (a² - 2ab + 2b²)(a² + 2ab + 2b²)`. The two quadratic factors come from
+completing `a⁴ + 4b⁴ = (a² + 2b²)² - (2ab)²` as a difference of squares. -/
+theorem sophie_germain_identity (a b : ℤ) :
+    a ^ 4 + 4 * b ^ 4
+      = (a ^ 2 - 2 * a * b + 2 * b ^ 2) * (a ^ 2 + 2 * a * b + 2 * b ^ 2) := by
+  ring
+
+/-- The `b = 1` specialization: `n⁴ + 4 = (n² - 2n + 2)(n² + 2n + 2)` over `ℤ`. -/
+theorem n_pow_four_add_four_factor (n : ℤ) :
+    n ^ 4 + 4 = (n ^ 2 - 2 * n + 2) * (n ^ 2 + 2 * n + 2) := by
+  have := sophie_germain_identity n 1
+  simpa using this
+
+/-- Each factor of the difference-of-squares form is at least `1` (over `ℤ`):
+`a² - 2ab + 2b² = (a - b)² + b² ≥ 0`, and it is `> 0` unless `a = b = 0`. -/
+theorem factor_nonneg (a b : ℤ) : 0 ≤ a ^ 2 - 2 * a * b + 2 * b ^ 2 := by
+  nlinarith [sq_nonneg (a - b), sq_nonneg b]
+
+/-- **Compositeness corollary.** For `n ≥ 2`, `n⁴ + 4` is not prime: it equals
+`((n-1)² + 1)·(n² + 2n + 2)` with both factors `> 1`. Equivalently, `n⁴ + 4` is prime
+only at `n = 1` (giving `5`). Worked out via `n = m + 2` so the smaller factor is the
+non-truncated `(m+1)² + 1`. -/
+theorem not_prime_n_pow_four_add_four {n : ℕ} (hn : 2 ≤ n) :
+    ¬ Nat.Prime (n ^ 4 + 4) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 2 := ⟨n - 2, by omega⟩
+  have hfac : (m + 2) ^ 4 + 4
+      = ((m + 1) ^ 2 + 1) * ((m + 2) ^ 2 + 2 * (m + 2) + 2) := by ring
+  rw [hfac]
+  have h1 : (m + 1) ^ 2 + 1 ≠ 1 := by nlinarith [Nat.zero_le m]
+  have h2 : (m + 2) ^ 2 + 2 * (m + 2) + 2 ≠ 1 := by nlinarith [Nat.zero_le m]
+  exact Nat.not_prime_mul h1 h2
+
+/-- The lone prime case: `1⁴ + 4 = 5` really is prime, so the bound `n ≥ 2` in
+`not_prime_n_pow_four_add_four` is sharp. -/
+theorem one_pow_four_add_four_prime : Nat.Prime (1 ^ 4 + 4) := by
+  norm_num
+
+/-- A concrete composite witness: `5⁴ + 4 = 629 = 17 · 37`. -/
+theorem five_pow_four_add_four_eq : 5 ^ 4 + 4 = 17 * 37 := by norm_num
+
+end SophieGermainOQ04

--- a/src/data/proofs/sophie-germain-oq-04/annotations.json
+++ b/src/data/proofs/sophie-germain-oq-04/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "sophie-germain-oq-04",
+    "range": { "startLine": 3, "endLine": 29 },
+    "type": "concept",
+    "title": "The Sophie Germain Identity (Not the Primes)",
+    "content": "Marie-Sophie Germain's name attaches to two distinct objects: Sophie Germain *primes* (studied in the base entry) and the Sophie Germain *identity*, a polynomial factorization. The identity $a^4 + 4b^4 = (a^2 - 2ab + 2b^2)(a^2 + 2ab + 2b^2)$ factors a sum that resists the usual irreducibility heuristics — there is no rational root and no obvious difference of squares — yet it always factors. This entry proves the identity and its primality corollary, supplying a Lean proof the family's metadata advertised but never contained.",
+    "mathContext": "$a^4 + 4b^4 = (a^2 + 2b^2)^2 - (2ab)^2.$",
+    "significance": "key",
+    "relatedConcepts": ["polynomial factorization", "difference of squares", "competition number theory"],
+    "prerequisites": ["polynomial identities", "elementary number theory"]
+  },
+  {
+    "id": "ann-identity",
+    "proofId": "sophie-germain-oq-04",
+    "range": { "startLine": 31, "endLine": 46 },
+    "type": "key-step",
+    "title": "One-Line Ring Proof and the n⁴+4 Specialization",
+    "content": "`sophie_germain_identity` is proved by `ring` over ℤ once the right-hand side is recognized as $(a^2 + 2b^2)^2 - (2ab)^2$, a difference of squares hidden inside the sum. Setting $b = 1$ gives `n_pow_four_add_four_factor`: $n^4 + 4 = (n^2 - 2n + 2)(n^2 + 2n + 2)$, the classic Olympiad factorization. Working over ℤ keeps the subtraction in $a^2 - 2ab + 2b^2$ genuine.",
+    "mathContext": "$a^4+4b^4=(a^2-2ab+2b^2)(a^2+2ab+2b^2);\\ \\ n^4+4=(n^2-2n+2)(n^2+2n+2).$",
+    "significance": "key",
+    "relatedConcepts": ["ring tactic", "completing the square", "difference of squares"],
+    "prerequisites": ["polynomial ring arithmetic"]
+  },
+  {
+    "id": "ann-factor-sign",
+    "proofId": "sophie-germain-oq-04",
+    "range": { "startLine": 48, "endLine": 53 },
+    "type": "technique",
+    "title": "Each Factor is a Sum of Two Squares",
+    "content": "`factor_nonneg` proves $a^2 - 2ab + 2b^2 = (a-b)^2 + b^2 \\ge 0$ (by `nlinarith` with the square hints). Each quadratic factor is a sum of two squares, hence nonnegative — and strictly positive away from $a = b = 0$ — which is why the factorization is into genuine positive integers.",
+    "mathContext": "$a^2 - 2ab + 2b^2 = (a-b)^2 + b^2.$",
+    "significance": "supporting",
+    "relatedConcepts": ["sum of two squares", "nlinarith", "nonnegativity"],
+    "prerequisites": ["quadratic forms"]
+  },
+  {
+    "id": "ann-composite",
+    "proofId": "sophie-germain-oq-04",
+    "range": { "startLine": 55, "endLine": 71 },
+    "type": "key-step",
+    "title": "n⁴ + 4 is Composite for n ≥ 2 — and the Threshold is Sharp",
+    "content": "`not_prime_n_pow_four_add_four`: for $n \\ge 2$, $n^4 + 4$ is composite. The obstacle is ℕ's truncated subtraction in $n^2 - 2n + 2$; substituting $n = m + 2$ rewrites the smaller factor as the addition-only $(m+1)^2 + 1$, so $(m+2)^4 + 4 = ((m+1)^2+1)\\,((m+2)^2 + 2(m+2) + 2)$ is a pure `ring` identity. Both factors are $\\ne 1$, so `Nat.not_prime_mul` finishes. `one_pow_four_add_four_prime` ($1^4 + 4 = 5$ is prime) shows $n \\ge 2$ cannot be relaxed, and `five_pow_four_add_four_eq` gives $5^4 + 4 = 629 = 17 \\cdot 37$.",
+    "mathContext": "$n\\ge 2 \\Rightarrow n^4+4 = ((n-1)^2+1)(n^2+2n+2),\\ \\text{both } > 1.$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.not_prime_mul", "truncated subtraction", "primality", "sharp bounds"],
+    "prerequisites": ["natural number primality", "ℕ vs ℤ casting"]
+  }
+]

--- a/src/data/proofs/sophie-germain-oq-04/meta.json
+++ b/src/data/proofs/sophie-germain-oq-04/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "sophie-germain-oq-04",
+  "slug": "sophie-germain-oq-04",
+  "title": "The Sophie Germain Identity a⁴ + 4b⁴ and Its Compositeness Corollary",
+  "description": "Sophie Germain's algebraic identity factors a sum that looks irreducible: a⁴ + 4b⁴ = (a² - 2ab + 2b²)(a² + 2ab + 2b²), obtained by completing a⁴ + 4b⁴ = (a²+2b²)² - (2ab)² as a difference of squares (sophie_germain_identity, one-line ring over ℤ). Its classic consequence is read off directly: n⁴ + 4 = (n² - 2n + 2)(n² + 2n + 2), so n⁴ + 4 is prime ONLY for n = 1 (where it is 5) and composite for every n ≥ 2 (not_prime_n_pow_four_add_four), with 1⁴+4 = 5 prime showing the bound is sharp and 5⁴+4 = 629 = 17·37 a concrete witness. Distinct from the base entry's Sophie Germain PRIME work (this is the algebraic identity, which the base meta lists but the source omits). Fully machine-checked, 0 sorries, 0 axioms.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "SophieGermainOQ04",
+    "lineCount": 71,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "substantiveTheoremCount": 3,
+    "trivialSpecializations": 2,
+    "definitionCount": 0,
+    "path": "Proofs/SophieGermainOQ04.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Marie-Sophie Germain (c. 1825)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sophie_Germain_identity",
+    "date": "1825",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SophieGermainOQ04.lean",
+    "tags": [
+      "number-theory",
+      "algebra",
+      "factorization",
+      "primality",
+      "polynomial-identity",
+      "sophie-germain"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. The identity is proved over ℤ by ring; the compositeness corollary is transported to ℕ without truncated subtraction. #print axioms reports only propext / Classical.choice / Quot.sound.",
+    "dateAdded": "2026-06-19",
+    "mathlibDependencies": ["Nat.not_prime_mul"],
+    "originalContributions": [
+      "Sophie Germain identity sophie_germain_identity: a⁴ + 4b⁴ = (a² - 2ab + 2b²)(a² + 2ab + 2b²) over ℤ — named in the base entry's meta but absent from the Lean source until now",
+      "Specialization n_pow_four_add_four_factor: n⁴ + 4 = (n² - 2n + 2)(n² + 2n + 2)",
+      "Compositeness corollary not_prime_n_pow_four_add_four: n ≥ 2 ⇒ ¬ Nat.Prime (n⁴ + 4), via the no-truncation substitution n = m + 2 (smaller factor written as (m+1)² + 1)",
+      "Sharpness one_pow_four_add_four_prime: 1⁴ + 4 = 5 is prime, so n ≥ 2 cannot be relaxed",
+      "Factor nonnegativity factor_nonneg: a² - 2ab + 2b² = (a-b)² + b² ≥ 0"
+    ],
+    "prerequisites": [
+      "Polynomial ring identities and difference of squares",
+      "Elementary divisibility and primality in ℕ",
+      "ℕ vs ℤ casting to avoid truncated subtraction"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 71,
+    "relatedProblems": ["sophie-germain", "sophie-germain-oq-01"],
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Marie-Sophie Germain (1776–1831), best known for her foundational work on Fermat's Last Theorem and the theory of elasticity, left her name on two quite different objects: the Sophie Germain primes (p with 2p+1 also prime) and the Sophie Germain identity, a polynomial factorization. The identity a⁴ + 4b⁴ = (a² + 2b² - 2ab)(a² + 2b² + 2ab) is a staple of competition number theory precisely because a⁴ + 4b⁴ looks like it should be irreducible — it has no rational root and is not an obvious difference of squares — yet it always factors. Setting b = 1 recovers the classic Olympiad fact that n⁴ + 4 is composite for all n > 1.",
+    "problemStatement": "Prove the Sophie Germain identity a⁴ + 4b⁴ = (a² - 2ab + 2b²)(a² + 2ab + 2b²), and derive its primality consequence: n⁴ + 4 is prime only for n = 1 (giving 5), and composite for every n ≥ 2.",
+    "proofStrategy": "The identity is a one-line ring computation once you see it as completing the square: a⁴ + 4b⁴ = (a² + 2b²)² - (2ab)² = (a² + 2b² - 2ab)(a² + 2b² + 2ab). It is stated over ℤ so the subtraction is genuine. For the compositeness corollary, the obstruction is ℕ's truncated subtraction in the factor a² - 2ab + 2b²; this is sidestepped by substituting n = m + 2 and writing the smaller factor as the manifestly addition-only (m+1)² + 1, so that n⁴ + 4 = ((m+1)² + 1)·((m+2)² + 2(m+2) + 2) is provable by ring. Both factors are visibly greater than 1, so Nat.not_prime_mul finishes. The case n = 1 is checked by norm_num (5 is prime), pinning the threshold.",
+    "keyInsights": [
+      "a⁴ + 4b⁴ is the textbook example of a sum that resists the obvious irreducibility heuristics yet factors — the trick is to read it as (a²+2b²)² - (2ab)², a difference of squares hiding inside a sum.",
+      "The two quadratic factors are a² + 2b² ∓ 2ab = (a ∓ b)² + b², so each is a sum of two squares and hence nonnegative — and strictly positive unless a = b = 0.",
+      "The primality corollary is sharp at exactly one point: n⁴ + 4 is prime only at n = 1, because there the smaller factor (n-1)² + 1 collapses to 1.",
+      "Formalizing over ℕ forces the standard discipline for truncated subtraction: substitute n = m + 2 so every quantity is built from additions, turning the factorization into a pure ring identity.",
+      "This entry closes a meta-vs-source gap — the identity was advertised in the Sophie Germain family's metadata but had no Lean proof, exactly the kind of mismatch an auditor flags."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "sophie_germain_identity",
+      "statement": "a⁴ + 4b⁴ = (a² - 2ab + 2b²)(a² + 2ab + 2b²)",
+      "description": "The Sophie Germain identity over ℤ, proved by ring after recognizing the right-hand side as the difference of squares (a²+2b²)² - (2ab)²."
+    },
+    {
+      "name": "n_pow_four_add_four_factor",
+      "statement": "n⁴ + 4 = (n² - 2n + 2)(n² + 2n + 2)",
+      "description": "The b = 1 specialization, the classic factorization of n⁴ + 4."
+    },
+    {
+      "name": "not_prime_n_pow_four_add_four",
+      "statement": "2 ≤ n → ¬ Nat.Prime (n⁴ + 4)",
+      "description": "For every n ≥ 2, n⁴ + 4 is composite, since both factors (n-1)² + 1 and n² + 2n + 2 exceed 1."
+    },
+    {
+      "name": "one_pow_four_add_four_prime",
+      "statement": "Nat.Prime (1⁴ + 4)",
+      "description": "1⁴ + 4 = 5 is prime, so the threshold n ≥ 2 in the compositeness result is sharp."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "`import Mathlib`, the module docstring, and `namespace SophieGermainOQ04`. The docstring distinguishes Sophie Germain's algebraic identity from her primes, states the factorization and the n⁴ + 4 compositeness corollary, gives the example 5⁴ + 4 = 629 = 17·37, and explains the ℤ/ℕ discipline used to avoid truncated subtraction.",
+      "mathContext": "$a^4 + 4b^4 = (a^2 + 2b^2)^2 - (2ab)^2$."
+    },
+    {
+      "id": "identity",
+      "title": "The Sophie Germain Identity and Specialization",
+      "startLine": 31,
+      "endLine": 46,
+      "summary": "Proves sophie_germain_identity (a⁴ + 4b⁴ = (a² - 2ab + 2b²)(a² + 2ab + 2b²)) by ring over ℤ, and the b = 1 specialization n_pow_four_add_four_factor (n⁴ + 4 = (n² - 2n + 2)(n² + 2n + 2)).",
+      "mathContext": "$a^4+4b^4 = (a^2-2ab+2b^2)(a^2+2ab+2b^2);\\quad n^4+4=(n^2-2n+2)(n^2+2n+2)$."
+    },
+    {
+      "id": "factor-sign",
+      "title": "Nonnegativity of the Factors",
+      "startLine": 48,
+      "endLine": 53,
+      "summary": "factor_nonneg: a² - 2ab + 2b² = (a - b)² + b² ≥ 0, so each quadratic factor is a sum of two squares; this is the structural reason the factorization is into honest positive integers (away from a = b = 0).",
+      "mathContext": "$a^2 - 2ab + 2b^2 = (a-b)^2 + b^2 \\ge 0$."
+    },
+    {
+      "id": "compositeness",
+      "title": "Compositeness of n⁴ + 4 and Sharpness",
+      "startLine": 55,
+      "endLine": 71,
+      "summary": "not_prime_n_pow_four_add_four: for n ≥ 2, n⁴ + 4 is composite. Substituting n = m + 2 turns the factorization into the addition-only ring identity (m+2)⁴ + 4 = ((m+1)² + 1)·((m+2)² + 2(m+2) + 2); both factors are ≠ 1, so Nat.not_prime_mul applies. one_pow_four_add_four_prime (5 is prime) shows the bound is sharp, and five_pow_four_add_four_eq exhibits 5⁴ + 4 = 17·37.",
+      "mathContext": "$n\\ge 2 \\Rightarrow n^4+4=((n-1)^2+1)(n^2+2n+2)$, both factors $>1$."
+    }
+  ],
+  "references": [
+    {
+      "title": "Sophie Germain identity",
+      "url": "https://en.wikipedia.org/wiki/Sophie_Germain_identity"
+    },
+    {
+      "title": "Sophie Germain",
+      "url": "https://en.wikipedia.org/wiki/Sophie_Germain"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "sophie-germain",
+      "relationship": "Companion algebraic identity to the Sophie Germain prime entry",
+      "description": "The base entry studies Sophie Germain primes (p with 2p+1 prime) and lists the algebraic identity in its metadata; this entry supplies the missing Lean proof of that identity and its compositeness corollary."
+    },
+    {
+      "proofId": "infinitude-primes",
+      "relationship": "Producing composite numbers by factorization",
+      "description": "Where Euclid's argument manufactures primes, the Sophie Germain identity manufactures composites: it certifies that an entire polynomial family n⁴ + 4 (n ≥ 2) is reducible."
+    }
+  ],
+  "conclusion": {
+    "summary": "Sophie Germain's identity a⁴ + 4b⁴ = (a² - 2ab + 2b²)(a² + 2ab + 2b²) is proved over ℤ by a single ring computation, and its classic corollary — n⁴ + 4 is prime only for n = 1 and composite for all n ≥ 2 — is derived in ℕ without truncated subtraction. Everything is machine-checked with zero sorries and zero axioms.",
+    "implications": "The result certifies an infinite family of composite numbers from one algebraic identity, and supplies the Lean proof of an identity the Sophie Germain family advertised but never formalized. The formalization illustrates the standard ℤ-then-ℕ technique: prove the factorization where subtraction is genuine, then re-express the smaller factor in addition-only form to discharge the primality statement over ℕ.",
+    "openQuestions": [
+      "Can the general two-variable compositeness be stated cleanly — e.g. for naturals with a > b ≥ 1, a⁴ + 4b⁴ is composite because both factors exceed 1?",
+      "Does the Aurifeuillian factorization of Φₙ at prime arguments (the higher-degree cousins of the Sophie Germain identity) admit a similarly short formal treatment?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
New verified gallery entry **sophie-germain-oq-04**: Sophie Germain's *algebraic* identity (distinct from the family's Sophie Germain *prime* work) and its primality corollary. This closes a **meta-vs-source gap** — the identity is listed in the Sophie Germain family's metadata `mainTheorems` but had no Lean proof in the source.

## Main results (`Proofs/SophieGermainOQ04.lean`)
- `sophie_germain_identity` : `a⁴ + 4b⁴ = (a² - 2ab + 2b²)(a² + 2ab + 2b²)` over ℤ (one-line `ring`, from the difference-of-squares form `(a²+2b²)² - (2ab)²`)
- `n_pow_four_add_four_factor` : `n⁴ + 4 = (n² - 2n + 2)(n² + 2n + 2)`
- `not_prime_n_pow_four_add_four` : `n ≥ 2 → ¬ Nat.Prime (n⁴ + 4)` — the classic Olympiad fact
- `one_pow_four_add_four_prime` : `1⁴ + 4 = 5` is prime ⇒ the threshold `n ≥ 2` is sharp
- `factor_nonneg`, `five_pow_four_add_four_eq` (`5⁴ + 4 = 629 = 17·37`)

## Proof shape
The identity is `ring` over ℤ (subtraction genuine). For compositeness, ℕ's truncated subtraction in `n² - 2n + 2` is sidestepped by substituting `n = m + 2` and writing the smaller factor as the addition-only `(m+1)² + 1`, making the factorization a pure ring identity; both factors are `≠ 1`, so `Nat.not_prime_mul` closes it.

## Distinctness
- Slug, gallery dir, and `SophieGermainOQ04.lean` are all new (not on main; no competing PR).
- The identity is genuinely absent from `SophieGermain.lean` / `SophieGermainOQ01/02` (those cover Sophie Germain primes and the mod-6 structure). `grep` for `a^4 + 4` / `sophie_germain_identity` in `proofs/Proofs` was empty.

## Verification
- Built with `lake env lean Proofs/SophieGermainOQ04.lean` — exit 0, no errors/warnings.
- `#print axioms` on the identity and the compositeness theorem: `propext, Classical.choice, Quot.sound` only — **0 axioms, 0 sorries**.

## Status
**Outcome**: completed (verified, 0-axiom)

🤖 Generated by researcher-1