### PR TITLE
research(sum-of-divisors-oq-05): τ(n) odd ⟺ n is a perfect square (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3052,6 +3052,7 @@ import Proofs.SubsetCountOQ02OQ01
 import Proofs.SumOfDivisors
 import Proofs.SumOfDivisorsOQ02
 import Proofs.SumOfDivisorsOQ04
+import Proofs.SumOfDivisorsOQ05
 import Proofs.SumOfKthPowers
 import Proofs.SumOfKthPowersOQ01
 import Proofs.SumOfKthPowersOQ02

--- a/proofs/Proofs/SumOfDivisorsOQ05.lean
+++ b/proofs/Proofs/SumOfDivisorsOQ05.lean
@@ -1,0 +1,100 @@
+/-
+# Sum of Divisors OQ-05: the number of divisors τ(n) is odd ⟺ n is a perfect square
+
+## Open Question
+The base entry and OQ-04 develop the divisor-*sum* `σ₁` and read off `σ₀ = τ`, the number
+of divisors, only on primes and prime powers. This entry proves the classical parity
+criterion for the divisor-counting function itself:
+
+  **τ(n) is odd ⟺ n is a perfect square.**
+
+Equivalently, `#n.divisors` is odd exactly when `n = r²` for some `r`. This is the cleanest
+non-trivial structural fact about `σ₀` and it is absent from both Mathlib and the gallery
+(Mathlib has `Nat.card_divisors` but no parity / square characterisation of it).
+
+## Approach
+Everything reduces to the prime factorisation:
+  * `Nat.card_divisors` writes `τ(n) = ∏_{p ∣ n} (vₚ(n) + 1)`.
+  * A product of naturals is odd ⟺ every factor is odd (`odd_prod_iff`, proved by
+    induction with `Nat.odd_mul`).
+  * `vₚ(n) + 1` is odd ⟺ `vₚ(n)` is even, so τ(n) is odd ⟺ every exponent is even.
+  * `n` is a perfect square ⟺ every exponent `vₚ(n)` is even
+    (`isSquare_iff_factorization_even`), the forward direction from
+    `Nat.factorization_mul`, the reverse by reassembling `r = ∏ p^{vₚ(n)/2}` and using
+    `Nat.factorization_prod_pow_eq_self`.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace SumOfDivisorsOQ05
+
+open ArithmeticFunction Finset
+
+/-- **A product of naturals is odd iff every factor is odd.** Elementary induction on the
+index set using `Nat.odd_mul`. -/
+theorem odd_prod_iff (s : Finset ℕ) (f : ℕ → ℕ) :
+    Odd (∏ i ∈ s, f i) ↔ ∀ i ∈ s, Odd (f i) := by
+  induction s using Finset.induction with
+  | empty => simp
+  | insert a s ha ih =>
+      rw [Finset.prod_insert ha, Nat.odd_mul, ih]
+      constructor
+      · rintro ⟨hfa, hrest⟩ i hi
+        rcases Finset.mem_insert.mp hi with rfl | hi
+        · exact hfa
+        · exact hrest i hi
+      · intro h
+        exact ⟨h a (Finset.mem_insert_self a s),
+               fun i hi => h i (Finset.mem_insert_of_mem hi)⟩
+
+/-- **A positive natural is a perfect square iff every prime exponent is even.** -/
+theorem isSquare_iff_factorization_even {n : ℕ} (hn : n ≠ 0) :
+    IsSquare n ↔ ∀ p, Even (n.factorization p) := by
+  constructor
+  · rintro ⟨r, rfl⟩
+    have hr : r ≠ 0 := by rintro rfl; simp at hn
+    intro p
+    rw [Nat.factorization_mul hr hr, Finsupp.add_apply]
+    exact ⟨r.factorization p, rfl⟩
+  · intro h
+    refine ⟨∏ p ∈ n.primeFactors, p ^ (n.factorization p / 2), ?_⟩
+    rw [← Finset.prod_mul_distrib]
+    have : ∀ p ∈ n.primeFactors,
+        p ^ (n.factorization p / 2) * p ^ (n.factorization p / 2)
+          = p ^ (n.factorization p) := by
+      intro p _
+      rw [← pow_add]
+      congr 1
+      obtain ⟨k, hk⟩ := h p
+      omega
+    rw [Finset.prod_congr rfl this]
+    have hself := Nat.factorization_prod_pow_eq_self hn
+    rw [Finsupp.prod, Nat.support_factorization] at hself
+    exact hself.symm
+
+/-- **The number of divisors is odd iff `n` is a perfect square.** The classical parity
+criterion for `τ = σ₀`, the headline structural fact about the divisor-counting function. -/
+theorem card_divisors_odd_iff_isSquare {n : ℕ} (hn : n ≠ 0) :
+    Odd (#n.divisors) ↔ IsSquare n := by
+  rw [Nat.card_divisors hn, odd_prod_iff, isSquare_iff_factorization_even hn]
+  constructor
+  · intro h p
+    by_cases hp : p ∈ n.primeFactors
+    · have hodd := h p hp
+      rw [Nat.odd_iff] at hodd
+      rw [Nat.even_iff]; omega
+    · have : n.factorization p = 0 := by
+        rw [← Finsupp.notMem_support_iff, Nat.support_factorization]; exact hp
+      simp [this]
+  · intro h p _
+    have heven := h p
+    rw [Nat.even_iff] at heven
+    rw [Nat.odd_iff]; omega
+
+/-- **σ₀ form.** Restated through Mathlib's arithmetic function `sigma 0 = τ`. -/
+theorem sigma_zero_odd_iff_isSquare {n : ℕ} (hn : n ≠ 0) :
+    Odd (sigma 0 n) ↔ IsSquare n := by
+  rw [sigma_zero_apply]; exact card_divisors_odd_iff_isSquare hn
+
+end SumOfDivisorsOQ05

--- a/src/data/proofs/sum-of-divisors-oq-05/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-05/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "sum-of-divisors-oq-05",
+  "title": "The Number of Divisors τ(n) is Odd ⟺ n is a Perfect Square",
+  "slug": "sum-of-divisors-oq-05",
+  "description": "The classical parity criterion for the divisor-counting function τ = σ₀: the number of divisors of n is odd exactly when n is a perfect square. Proved from the prime factorisation — Nat.card_divisors writes τ(n) = ∏_{p∣n}(vₚ(n)+1), a product of naturals is odd iff every factor is odd, and vₚ(n)+1 is odd iff vₚ(n) is even, which characterises perfect squares. Absent from both Mathlib and the gallery. Routes through Nat.card_divisors, Nat.factorization_mul, Nat.factorization_prod_pow_eq_self.",
+  "meta": {
+    "author": "classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Divisor_function",
+    "date": "antiquity",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "divisor-function",
+      "tau",
+      "sigma",
+      "perfect-square",
+      "factorization",
+      "parity",
+      "arithmetic-functions",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SumOfDivisorsOQ05.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.card_divisors",
+        "description": "n ≠ 0 → #n.divisors = ∏_{p ∈ primeFactors} (vₚ(n) + 1) — the divisor count as a product over prime exponents",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "ArithmeticFunction.sigma_zero_apply",
+        "description": "σ₀(n) = #n.divisors — identifies the arithmetic function σ 0 with the divisor count τ",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "Nat.odd_mul",
+        "description": "Odd (m·n) ↔ Odd m ∧ Odd n — the inductive step for product parity",
+        "module": "Mathlib.Algebra.Ring.Parity"
+      },
+      {
+        "theorem": "Nat.factorization_mul",
+        "description": "a,b ≠ 0 → (a·b).factorization = a.factorization + b.factorization — gives even exponents on a square",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.factorization_prod_pow_eq_self",
+        "description": "n ≠ 0 → n.factorization.prod (·^·) = n — reassembles n from its prime exponents to build the square root",
+        "module": "Mathlib.Data.Nat.Factorization.Defs"
+      },
+      {
+        "theorem": "Nat.support_factorization",
+        "description": "n.factorization.support = n.primeFactors — bridges the Finsupp product and the Finset over prime factors",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      }
+    ],
+    "originalContributions": [
+      "card_divisors_odd_iff_isSquare: Odd (#n.divisors) ↔ IsSquare n — the headline parity criterion, absent from Mathlib",
+      "sigma_zero_odd_iff_isSquare: Odd (σ 0 n) ↔ IsSquare n — the same fact stated via Mathlib's arithmetic function σ₀",
+      "isSquare_iff_factorization_even: IsSquare n ↔ ∀ p, Even (vₚ(n)) — square detection by prime-exponent parity (reverse direction reassembles r = ∏ p^{vₚ(n)/2})",
+      "odd_prod_iff: Odd (∏ i ∈ s, f i) ↔ ∀ i ∈ s, Odd (f i) — a product of naturals is odd iff every factor is odd"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 100,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The divisor-counting function τ(n) = σ₀(n) = #{d : d ∣ n} is, with the divisor sum σ(n), one of the two basic multiplicative functions of antiquity. Its single most memorable structural property is the parity criterion: τ(n) is odd precisely when n is a perfect square. The reason is the divisor-pairing involution d ↦ n/d, which matches every divisor below √n with one above it and leaves a divisor unpaired exactly when n has an integer square root. Equivalently, in terms of the factorisation n = ∏ pᵉ, one has τ(n) = ∏ (eₚ + 1), an odd product iff every eₚ is even iff n is a square. The base gallery entry and OQ-04 develop σ₁ and read off σ₀ on primes and prime powers; this entry proves the parity law for σ₀ in full.",
+    "problemStatement": "**Open Question (sum-of-divisors-oq-05)**: Prove the parity criterion for the divisor-counting function — the number of divisors of n is odd if and only if n is a perfect square.\n\n**Result**: card_divisors_odd_iff_isSquare (Odd (#n.divisors) ↔ IsSquare n) and its σ₀ restatement sigma_zero_odd_iff_isSquare.",
+    "text": "For n ≠ 0, the number of divisors #n.divisors (equivalently σ₀(n) = τ(n)) is odd if and only if n is a perfect square.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `odd_prod_iff`: by induction on the index Finset using `Nat.odd_mul`, a product of naturals is odd iff every factor is odd.\n2. `isSquare_iff_factorization_even`: forward, if n = r·r then `Nat.factorization_mul` gives vₚ(n) = vₚ(r) + vₚ(r), manifestly even; reverse, given all exponents even, set r = ∏ p^{vₚ(n)/2}, so r·r = ∏ p^{vₚ(n)} = n by `Nat.factorization_prod_pow_eq_self`.\n3. `card_divisors_odd_iff_isSquare`: rewrite τ(n) = ∏ (vₚ(n) + 1) with `Nat.card_divisors`, apply `odd_prod_iff` and the square criterion, then match the two sides prime-by-prime — for p ∣ n, vₚ(n)+1 odd ⟺ vₚ(n) even (by `Nat.odd_iff`/`Nat.even_iff` + omega); for p ∤ n both sides hold since vₚ(n) = 0.\n4. `sigma_zero_odd_iff_isSquare`: `sigma_zero_apply` rewrites σ 0 n to #n.divisors.",
+    "keyInsights": [
+      "**Parity from the exponents.** Writing τ(n) = ∏ (vₚ(n) + 1), oddness of the product is oddness of every factor, i.e. evenness of every prime exponent — which is exactly the perfect-square condition.",
+      "**Square detection by exponent parity.** isSquare_iff_factorization_even is the engine: a positive integer is a square iff every exponent in its factorisation is even, with the square root reassembled as ∏ p^{vₚ(n)/2}.",
+      "**The off-support primes are free.** The product criterion ranges over the prime factors of n, while the square criterion quantifies over all primes; the two agree because vₚ(n) = 0 (even) and vₚ(n)+1 = 1 (odd) for every prime not dividing n.",
+      "**A theorem, not a table.** The classical fact 'squares have an odd number of divisors' is proved here for the universally quantified n, routed entirely through Mathlib's factorisation API with no axioms or sorries."
+    ],
+    "prerequisites": [
+      "Mathlib's Nat.card_divisors and the arithmetic function σ₀",
+      "The prime factorisation API (Nat.factorization, factorization_mul, factorization_prod_pow_eq_self)",
+      "Elementary parity reasoning (Nat.odd_mul, Nat.odd_iff/even_iff)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Module docstring framing the parity criterion for τ = σ₀, the Mathlib import, namespace, and ArithmeticFunction/Finset opens.",
+      "mathContext": "$\\tau(n) = \\sigma_0(n) = \\#\\{d : d \\mid n\\}$, $\\tau(n)\\ \\text{odd} \\iff n = r^2$."
+    },
+    {
+      "id": "odd-prod",
+      "title": "Product Parity",
+      "startLine": 34,
+      "endLine": 49,
+      "summary": "odd_prod_iff: a product of naturals over a Finset is odd iff every factor is odd, by induction with Nat.odd_mul.",
+      "mathContext": "$\\mathrm{Odd}\\!\\left(\\prod_{i \\in s} f(i)\\right) \\iff \\forall i \\in s,\\ \\mathrm{Odd}(f(i))$."
+    },
+    {
+      "id": "square-factorization",
+      "title": "Squares via Exponent Parity",
+      "startLine": 51,
+      "endLine": 74,
+      "summary": "isSquare_iff_factorization_even: a positive natural is a perfect square iff every prime exponent is even; reverse direction reassembles the square root r = ∏ p^{vₚ(n)/2}.",
+      "mathContext": "$\\mathrm{IsSquare}(n) \\iff \\forall p,\\ \\mathrm{Even}(v_p(n))$."
+    },
+    {
+      "id": "main",
+      "title": "The Parity Criterion",
+      "startLine": 76,
+      "endLine": 100,
+      "summary": "card_divisors_odd_iff_isSquare (Odd (#n.divisors) ↔ IsSquare n) and its σ₀ restatement sigma_zero_odd_iff_isSquare.",
+      "mathContext": "$\\mathrm{Odd}(\\#n.\\mathrm{divisors}) \\iff \\mathrm{IsSquare}(n)$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sum-of-divisors-oq-04",
+      "relationship": "related",
+      "description": "OQ-04 proves the structural identities of σₖ on primes and prime powers (including τ(p) = σ₀(p) = 2); this entry proves the global parity law for the same divisor-counting function σ₀"
+    },
+    {
+      "targetId": "sum-of-divisors",
+      "relationship": "extends",
+      "description": "Extends the base entry's divisor-function material with the perfect-square parity criterion for the number of divisors"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) proof that the number of divisors τ(n) = σ₀(n) is odd if and only if n is a perfect square, together with the supporting square-detection criterion isSquare_iff_factorization_even and the product-parity lemma odd_prod_iff.",
+    "implications": "Supplies the parity characterisation of the divisor count — the classical 'only squares have an odd number of divisors' — as a universally quantified theorem, and a reusable IsSquare ↔ even-exponents criterion that Mathlib does not state directly.",
+    "openQuestions": [
+      "Prove the multiplicative closed form τ(n) = ∏_p (vₚ(n) + 1) as a standalone gallery identity and derive τ(p^a) = a + 1.",
+      "Establish the divisor-pairing involution d ↦ n/d on n.divisors explicitly and recover the parity criterion from its fixed-point count."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "ArithmeticFunction",
+      "Finset"
+    ],
+    "namespace": "SumOfDivisorsOQ05",
+    "lineCount": 100,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/SumOfDivisorsOQ05.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Hardy, G. H. and Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "Chapter XVI: the divisor function d(n) = τ(n), its multiplicativity and value on prime powers"
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer Undergraduate Texts in Mathematics",
+      "note": "Theorem 2.13: d(n) = ∏ (aᵢ + 1) for n = ∏ pᵢ^{aᵢ}; the parity criterion follows immediately"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves the classical **parity criterion for the divisor-counting function** τ = σ₀:

> **The number of divisors of n is odd ⟺ n is a perfect square.**

This is the single most memorable structural fact about σ₀ and is **absent from both Mathlib and the gallery** (Mathlib has `Nat.card_divisors` but no parity/square characterisation of it). It is the result the divisor family's seeker note originally targeted; OQ-04 (now merged) instead covered the σₖ structural identities, leaving this gap open.

## Results (all in `Proofs/SumOfDivisorsOQ05.lean`)

| Theorem | Statement |
|---|---|
| `card_divisors_odd_iff_isSquare` | `Odd (#n.divisors) ↔ IsSquare n` |
| `sigma_zero_odd_iff_isSquare` | `Odd (σ 0 n) ↔ IsSquare n` (arithmetic-function form) |
| `isSquare_iff_factorization_even` | `IsSquare n ↔ ∀ p, Even (vₚ n)` (square detection by exponent parity) |
| `odd_prod_iff` | `Odd (∏ i ∈ s, f i) ↔ ∀ i ∈ s, Odd (f i)` |

## Proof route

`Nat.card_divisors` writes τ(n) = ∏_{p∣n}(vₚ(n)+1); a product of naturals is odd iff every factor is odd (`odd_prod_iff`, induction with `Nat.odd_mul`); vₚ(n)+1 is odd iff vₚ(n) is even, which characterises perfect squares (`isSquare_iff_factorization_even` — forward from `Nat.factorization_mul`, reverse reassembles r = ∏ p^{vₚ(n)/2} via `Nat.factorization_prod_pow_eq_self`).

## Verification

- **0 sorries, 0 axioms.** `#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound`.
- Compiles standalone against Mathlib (`lake env lean Proofs/SumOfDivisorsOQ05.lean`, exit 0, no warnings).
- Gallery entry added at `src/data/proofs/sum-of-divisors-oq-05/`; registered in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)