### PR TITLE
research(erdos-340-greedy-sidon-oq-02): Erdős–Turán/Lindström upper bound √N+⁴√N+2 for Sidon sets (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1436,6 +1436,7 @@ import Proofs.Erdos340GreedyExtension
 import Proofs.Erdos340GreedyGrowth
 import Proofs.Erdos340GreedySidon
 import Proofs.Erdos340GreedySidonOQ02
+import Proofs.Erdos340SidonErdosTuran
 import Proofs.Erdos340Problem
 import Proofs.Erdos341Problem
 import Proofs.Erdos342Problem

--- a/proofs/Proofs/Erdos340SidonErdosTuran.lean
+++ b/proofs/Proofs/Erdos340SidonErdosTuran.lean
@@ -1,0 +1,134 @@
+/-
+# Erdős Problem #340 (oq-02): The Erdős–Turán / Lindström upper bound, verified
+
+The sibling file `Erdos340GreedySidonOQ02.lean` carries out the hard part of the
+Erdős–Turán argument for the maximal size of a Sidon set.  It proves, **fully (0
+sorries, 0 axioms)**, the sliding-window / Cauchy–Schwarz master inequality
+
+  `sidon_window_key : ∀ ℓ ≥ 1,  ℓ · |A|² ≤ (N + ℓ) · (ℓ − 1 + |A|)`            (★)
+
+for every Sidon set `A ⊆ {0,…,N}`.  What the parent file `Erdos340GreedySidon.lean`
+left as its **only axiom** is the *closed-form consequence* of (★) obtained by
+optimising the window length `ℓ`:
+
+  `axiom sidon_upper_bound : |A| ≤ √N + ⁴√N + 1`    (the Lindström constant).
+
+This file performs that optimisation **rigorously and axiom-free**.  Plugging the
+near-optimal integer window length
+
+  `ℓ = ⌊√N⌋ · ⌊⁴√N⌋ + 1   (≈ N^{3/4})`
+
+into (★) yields, by elementary integer arithmetic on `Nat.sqrt`, the bound
+
+  `sidon_card_le_sqrt : |A| ≤ ⌊√N⌋ + ⌊⁴√N⌋ + 2`.                              (†)
+
+## What this does and does not settle
+
+* (†) captures the **optimal leading term `√N`** — a genuine improvement over the
+  elementary difference-counting bound `sidon_upper_bound_weak : |A| ≤ √(2N) + 1`
+  proved in the parent (constant `√2 ≈ 1.414` vs. the optimal `1`).  It also gets
+  the correct second-order `⌊⁴√N⌋ ≈ N^{1/4}` term.
+* The master inequality (★) is very slightly lossy in its Cauchy–Schwarz step, so it
+  cannot reach the *exact* Lindström additive constant `+1`: a short search shows
+  `|A| = ⌊√N⌋ + ⌊⁴√N⌋ + 2` is genuinely **not** refutable from (★) alone (e.g.
+  `N = 15`, where (★) permits one more element than the true maximum).  Hence (†)
+  proves `+2`, not `+1`, and the parent's `sidon_upper_bound` axiom — which asserts
+  the `+1` form — is **not** discharged here.  (†) is the sharpest closed-form bound
+  that (★) supports, and is fully verified.
+
+The open growth *lower* bound `|A ∩ [1,N]| ≫ N^{1/2−ε}` (Erdős #340 proper) is a
+different, unsolved direction and is untouched.
+-/
+import Proofs.Erdos340GreedySidonOQ02
+
+namespace Erdos340
+
+open Finset
+
+/-- **Arithmetic core of the window optimisation.**
+
+With `ℓ = s·t + 1` and `k = s + t + 3 + d` (the first cardinality strictly above the
+target `s + t + 2`, where `s = ⌊√N⌋`, `t = ⌊√s⌋`), the master inequality (★) at its
+worst case `N = s² + 2s` is violated.  This is a pure polynomial inequality over `ℤ`,
+where the two `Nat.sqrt` bracketings enter as `t² ≤ s ≤ t² + 2t`.
+
+The proof writes the gap as `Q = (s·t+1)·d² + C₁·d + C₀` (a quadratic in `d` with
+nonnegative coefficients) and shows the constant term factors as
+`C₀ = (s+t+2)·R` with `R = −s² + s·t² + 3st − 2s + t + 3 ≥ 1`.  The bound `R ≥ 1`
+is the concavity estimate `2t·R = (t²+2t−s)·e₀ + (s−t²)·e₁ + 2t(s−t²)(t²+2t−s)`,
+where the endpoint values `e₀ = 3t³−2t²+t+3` and `e₁ = (t−1)²(t+2)+1` are positive. -/
+private lemma window_opt_arith (s t d : ℤ) (hs : 0 ≤ s) (ht : 0 ≤ t) (hd : 0 ≤ d)
+    (h1 : t ^ 2 ≤ s) (h2 : s ≤ t ^ 2 + 2 * t) :
+    (s ^ 2 + 2 * s + (s * t + 1)) * (s * t + (s + t + 3 + d))
+      < (s * t + 1) * (s + t + 3 + d) ^ 2 := by
+  have hg : 0 ≤ s - t ^ 2 := by linarith
+  have hh : 0 ≤ t ^ 2 + 2 * t - s := by linarith
+  -- endpoint values of the parabola `R` in `s` are ≥ 1.
+  have he0 : 1 ≤ 3 * t ^ 3 - 2 * t ^ 2 + t + 3 := by
+    nlinarith [mul_nonneg (mul_nonneg ht ht) ht, sq_nonneg t, ht]
+  have he1 : 1 ≤ t ^ 3 - 3 * t + 3 := by
+    nlinarith [mul_nonneg (sq_nonneg (t - 1)) (by linarith : (0 : ℤ) ≤ t + 2)]
+  -- `R ≥ 1` (the `d⁰` factor) via the concavity certificate.
+  have hR : 1 ≤ -s ^ 2 + s * t ^ 2 + 3 * s * t - 2 * s + t + 3 := by
+    rcases eq_or_lt_of_le ht with ht0 | htpos
+    · -- t = 0 forces s = 0
+      have hs0 : s = 0 := by nlinarith [h2, hs, ht0.symm]
+      rw [← ht0, hs0]; norm_num
+    · -- t > 0 : `2t·(R−1) = (t²+2t−s)(e₀−1) + (s−t²)(e₁−1) + 2t(s−t²)(t²+2t−s) ≥ 0`
+      have hcert : 2 * t * 1 ≤ 2 * t * (-s ^ 2 + s * t ^ 2 + 3 * s * t - 2 * s + t + 3) := by
+        nlinarith [mul_nonneg hh (by linarith : (0 : ℤ) ≤ 3 * t ^ 3 - 2 * t ^ 2 + t + 3 - 1),
+                   mul_nonneg hg (by linarith : (0 : ℤ) ≤ t ^ 3 - 3 * t + 3 - 1),
+                   mul_nonneg (mul_nonneg (by linarith : (0 : ℤ) ≤ 2 * t) hg) hh]
+      exact le_of_mul_le_mul_left hcert (by linarith)
+  -- the `d¹` coefficient is nonnegative.
+  have hC1 : 0 ≤ 2 * s ^ 2 * t - s ^ 2 + 2 * s * t ^ 2 + 5 * s * t + 2 * t + 5 := by
+    nlinarith [mul_nonneg hs hh, mul_nonneg (mul_nonneg hs hs) ht,
+               mul_nonneg hs (mul_nonneg ht ht), mul_nonneg hs ht, ht]
+  -- assemble: gap `= (s·t+1)·d² + C₁·d + (s+t+2)·R`, all pieces ≥ 0 and the last > 0.
+  have hC0 : 0 < (s + t + 2) * (-s ^ 2 + s * t ^ 2 + 3 * s * t - 2 * s + t + 3) :=
+    mul_pos (by linarith) (by linarith)
+  nlinarith [mul_nonneg (by positivity : (0 : ℤ) ≤ s * t + 1) (sq_nonneg d),
+             mul_nonneg hC1 hd, hC0, mul_nonneg hs ht]
+
+/-- **Erdős–Turán / Lindström upper bound for Sidon sets (verified, axiom-free).**
+
+A Sidon set `A ⊆ {0, …, N}` has at most `⌊√N⌋ + ⌊√⌊√N⌋⌋ + 2` elements.
+
+This is the optimised closed form of the master window inequality `sidon_window_key`
+(★), obtained at window length `ℓ = ⌊√N⌋·⌊√⌊√N⌋⌋ + 1 ≈ N^{3/4}`.  It improves the
+elementary `√(2N)` difference bound to the optimal leading constant `√N`. -/
+theorem sidon_card_le_sqrt (A : Finset ℕ) (hA : IsSidon A) (N : ℕ)
+    (hAN : ∀ a ∈ A, a ≤ N) :
+    A.card ≤ Nat.sqrt N + Nat.sqrt (Nat.sqrt N) + 2 := by
+  by_contra hcon
+  push_neg at hcon
+  set s := Nat.sqrt N with hs
+  set t := Nat.sqrt s with ht
+  -- the two square-root bracketings, in additive form.
+  have hsN : N < (s + 1) ^ 2 := Nat.lt_succ_sqrt' N
+  have hts1 : t ^ 2 ≤ s := Nat.sqrt_le' s
+  have hts2 : s < (t + 1) ^ 2 := Nat.lt_succ_sqrt' s
+  have hNb : N ≤ s ^ 2 + 2 * s := by nlinarith [hsN]
+  have h2nat : s ≤ t ^ 2 + 2 * t := by nlinarith [hts2]
+  -- master inequality at ℓ = s·t + 1.
+  have hℓ : 1 ≤ s * t + 1 := Nat.le_add_left 1 (s * t)
+  have key := Erdos340.OQ02.sidon_window_key A hA N (s * t + 1) hℓ hAN
+  rw [Nat.add_sub_cancel] at key
+  -- replace `N` by its worst case `s² + 2s`.
+  have key2 : (s * t + 1) * A.card ^ 2
+      ≤ (s ^ 2 + 2 * s + (s * t + 1)) * (s * t + A.card) :=
+    le_trans key (Nat.mul_le_mul_right _ (by omega))
+  -- write `A.card = s + t + 3 + d`.
+  obtain ⟨d, hd⟩ : ∃ d, A.card = s + t + 3 + d := ⟨A.card - (s + t + 3), by omega⟩
+  rw [hd] at key2
+  -- cast to ℤ and contradict the arithmetic core.
+  have hcontra := window_opt_arith (s : ℤ) (t : ℤ) (d : ℤ)
+    (Int.natCast_nonneg s) (Int.natCast_nonneg t) (Int.natCast_nonneg d)
+    (by exact_mod_cast hts1) (by exact_mod_cast h2nat)
+  have key2Z : ((s * t + 1 : ℕ) : ℤ) * ((s + t + 3 + d : ℕ) : ℤ) ^ 2
+      ≤ ((s ^ 2 + 2 * s + (s * t + 1) : ℕ) : ℤ) * ((s * t + (s + t + 3 + d) : ℕ) : ℤ) := by
+    exact_mod_cast key2
+  push_cast at key2Z
+  linarith [hcontra, key2Z]
+
+end Erdos340

--- a/research/problems/erdos-340-greedy-sidon-oq-02/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-02/knowledge.md
@@ -195,3 +195,40 @@ harder research line (or leave the entry honestly `axiomatized`).
 Also note: the existing axiom-free `sidon_upper_bound_weak` (`|A| ≤ ⌊√(2N)⌋+1`,
 difference-counting) already *beats* the key-inequality bound across the small/mid-N
 range, so no derived explicit cardinality theorem from `sidon_window_key` was worth adding.
+
+---
+
+## Session 2026-06-19 (researcher-10): the optimisation IS worth formalizing — `sidon_card_le_sqrt`
+
+The prior note above ("no derived explicit cardinality theorem from `sidon_window_key`
+was worth adding") under-valued the **asymptotic** picture. The elementary
+`sidon_upper_bound_weak` (`⌊√(2N)⌋+1`) beats the key-inequality bound only for small/mid
+`N`; for large `N` the optimised key bound `√N + N^{1/4} + O(1)` is dramatically tighter
+(optimal leading constant `1` vs `√2 ≈ 1.414`). That optimal leading term is worth a
+verified theorem in its own right, so this session formalized it.
+
+**New file `Erdos340SidonErdosTuran.lean`** (imports `Erdos340GreedySidonOQ02`):
+
+```lean
+theorem sidon_card_le_sqrt (A : Finset ℕ) (hA : IsSidon A) (N : ℕ)
+    (hAN : ∀ a ∈ A, a ≤ N) :
+    A.card ≤ Nat.sqrt N + Nat.sqrt (Nat.sqrt N) + 2
+```
+
+Fully **verified, 0-axiom** (`#print axioms` = `propext, Classical.choice, Quot.sound`).
+
+* **Window length.** Optimum of `ℓ·k² ≤ (N+ℓ)(ℓ-1+k)` is `ℓ* = √((k-1)N) ≈ N^{3/4}`
+  when `k ≈ √N` (NOT `≈√N`). The clean integer choice `ℓ = ⌊√N⌋·⌊√⌊√N⌋⌋ + 1` works.
+* **Why `+2` not `+1`.** Confirmed by exhaustive search (`N < 3·10⁵`): with
+  `s=⌊√N⌋, t=⌊√s⌋`, the value `k = s+t+3` is ALWAYS refuted by some `ℓ` (so `k ≤ s+t+2`
+  is provable), but `k = s+t+2` survives for ~12% of `N` (e.g. `N=15`: key permits `6`,
+  true max is `5`). The Cauchy–Schwarz step is intrinsically lossy by `+1`. **The parent
+  axiom `sidon_upper_bound` (the `+1` form) therefore stays — it is not a slack of this
+  route.** (Corroborates the prior session's conclusion.)
+* **Arithmetic core (`window_opt_arith`, over ℤ).** By-contradiction with `k=s+t+3+d`,
+  `N` at worst case `s²+2s`: the gap factors as
+  `Q = (s·t+1)d² + C₁·d + (s+t+2)·R`, `R = -s²+st²+3st-2s+t+3 ≥ 1`. `R ≥ 1` is the
+  concavity certificate `2t·R = (t²+2t-s)·e₀ + (s-t²)·e₁ + 2t(s-t²)(t²+2t-s)` with
+  endpoints `e₀ = 3t³-2t²+t+3 ≥ 1`, `e₁ = (t-1)²(t+2)+1 ≥ 1`. `C₁ ≥ 0` via
+  `s·(t²+2t-s) ≥ 0`. Each step is a low-degree `nlinarith`. Bracketings: `Nat.sqrt_le'`,
+  `Nat.lt_succ_sqrt'`.

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-02.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-02.json
@@ -6,7 +6,7 @@
   "tier": "B",
   "path": "research/problems/erdos-340-greedy-sidon-oq-02",
   "started": "2026-06-17",
-  "lastUpdate": "2026-06-18",
+  "lastUpdate": "2026-06-19",
   "tags": [
     "combinatorics",
     "additive-combinatorics",
@@ -19,32 +19,32 @@
   ],
   "problemStatement": "Remove the lone axiom `sidon_upper_bound` of the parent gallery entry by formalizing the sharp Erdős–Turán upper bound |A| ≤ √N + √√N + 1 for a Sidon set A ⊆ {1,…,N}, via the sliding-window / Cauchy–Schwarz argument.",
   "leanFiles": [
-    "proofs/Proofs/Erdos340GreedySidonOQ02.lean"
+    "proofs/Proofs/Erdos340GreedySidonOQ02.lean",
+    "proofs/Proofs/Erdos340SidonErdosTuran.lean"
   ],
-  "tractability": "medium — the Cauchy–Schwarz assembly (`sidon_window_key`) and window-sum identity are proved; one HARD finite-combinatorics sorry (`window_pair_bound`) remains, plus a separate ℓ≈√N optimisation to discharge the parent axiom.",
+  "tractability": "medium — RESOLVED to the extent this route allows: sidon_window_key is fully proved (0 sorries), and the ℓ≈√N optimisation is now formalized (sidon_card_le_sqrt). The parent +1 axiom is NOT dischargeable from this inequality (proven lossy).",
   "knowledge": {
     "insights": [
-      "OQ-02 file proves the Erdős–Turán key inequality ℓ·|A|² ≤ (N+ℓ)·(ℓ-1+|A|) (`sidon_window_key`) unconditionally except for one counting lemma.",
-      "The only open obligation is `window_pair_bound` (line 123): ∑_x wc(x)(wc(x)-1) ≤ ℓ(ℓ-1) — known finite double-counting, classified HARD (not OPEN).",
-      "The Sidon crux (distinct differences) is ALREADY formalized in the parent: `IsSidon.diff_injective` and `sidon_pairDiff_injective` (InjOn pairDiff on orderedPairsLt). OQ-02 only needs to plug these into a Fubini + Gauss-sum assembly.",
-      "Complete Step 1–5 proof of `window_pair_bound` recorded in knowledge.md: offDiag pairs (`Finset.offDiag_card`) → filter pushthrough → Fubini (`Finset.sum_comm`) → cov(a,b)=ℓ-|a-b| via `Finset.Ico`/`Nat.card_Ico` → Sidon-injective regrouping (`Finset.sum_image`) → triangular/Gauss sum ℓ(ℓ-1).",
-      "Closing the sorry yields a 0-sorry OQ-02 file but does NOT alone remove the parent axiom; the ℓ≈√N optimisation of `sidon_window_key` into √N+√√N+1 is a separate elementary ℕ-arithmetic step."
+      "OQ-02 file `Erdos340GreedySidonOQ02.lean` is now FULLY PROVED (0 sorries, 0 axioms): window_sum_identity, window_pair_bound, and the Cauchy–Schwarz key inequality sidon_window_key : ℓ·|A|² ≤ (N+ℓ)·(ℓ-1+|A|) for all ℓ≥1.",
+      "NEW (Erdos340SidonErdosTuran.lean): the ℓ≈√N optimisation of sidon_window_key is formalized as `sidon_card_le_sqrt : |A| ≤ ⌊√N⌋ + ⌊√⌊√N⌋⌋ + 2`, fully verified 0-axiom (#print axioms = propext/Classical.choice/Quot.sound only). This is the Erdős–Turán/Lindström bound with the OPTIMAL leading constant √N (vs √(2N) for the elementary parent bound sidon_upper_bound_weak) and the correct N^{1/4} second-order term.",
+      "Optimal integer window length is ℓ = ⌊√N⌋·⌊√⌊√N⌋⌋ + 1 ≈ N^{3/4} (NOT ≈√N — the real optimum of the key inequality is √((k-1)N) ≈ N^{3/4} when k≈√N).",
+      "KEY FINDING — the parent axiom `sidon_upper_bound` (the +1 Lindström form |A| ≤ √N+√√N+1) is genuinely NOT derivable from sidon_window_key alone: a finite search shows k = ⌊√N⌋+⌊√⌊√N⌋⌋+2 survives the key inequality for ~12% of N (e.g. N=15, where the key permits 6 but the true Sidon maximum is 5, caught only by difference-counting). The Cauchy–Schwarz step in sidon_window_key is slightly lossy. So this route yields +2, not +1; the axiom remains.",
+      "Proof technique for the optimisation: by_contra |A| ≥ s+t+3 (s=⌊√N⌋,t=⌊√s⌋); plug ℓ=s·t+1 into sidon_window_key; replace N by worst case s²+2s; cast to ℤ; the gap factors as Q = (s·t+1)d² + C₁·d + (s+t+2)·R with R = -s²+st²+3st-2s+t+3 ≥ 1 via the concavity certificate 2t·R = (t²+2t-s)·e₀ + (s-t²)·e₁ + 2t(s-t²)(t²+2t-s), endpoints e₀=3t³-2t²+t+3, e₁=(t-1)²(t+2)+1.",
+      "Nat.sqrt bracketings used: Nat.sqrt_le' (s² ≤ N) and Nat.lt_succ_sqrt' (N < (s+1)²), likewise for t over s."
     ],
     "builtItems": [
-      "Erdos340GreedySidonOQ02.lean: isSidon_image_add, card_image_add (translation invariance) — PROVED",
-      "Erdos340GreedySidonOQ02.lean: window_sum_identity (counting fact A, ∑ wc = ℓ|B|) — PROVED",
-      "Erdos340GreedySidonOQ02.lean: sidon_window_key (Cauchy–Schwarz key inequality) — PROVED modulo window_pair_bound"
+      "Erdos340GreedySidonOQ02.lean: isSidon_image_add, card_image_add, window_sum_identity, window_pair_bound, sidon_window_key — ALL PROVED (0 sorries, 0 axioms).",
+      "Erdos340SidonErdosTuran.lean: window_opt_arith (ℤ arithmetic core) + sidon_card_le_sqrt (|A| ≤ ⌊√N⌋+⌊√⌊√N⌋⌋+2) — PROVED, 0-axiom, verified."
     ],
     "mathlibGaps": [
-      "No gap blocking the proof — the Sidon injectivity crux is supplied by the parent file (IsSidon.diff_injective / sidon_pairDiff_injective).",
-      "Only orientation-handling piece without a ready-made lemma is the factor-2 swap (B.offDiag = orderedPairsLt ⊎ orderedPairsGt); handled by Finset.sum_bij on (a,b)↦(b,a) or a single φ:B.offDiag↪Ico 1 ℓ × Bool injection."
+      "Mathlib has no Sidon-set Erdős–Turán bound; the whole development (parent + OQ02 + this file) is original relative to Mathlib.",
+      "The +1↔+2 gap is intrinsic to sidon_window_key, not a Mathlib limitation: closing it to the exact Lindström +1 would require a sharper master inequality (e.g. a tighter window_pair_bound or a second difference-counting input)."
     ],
     "nextSteps": [
-      "Submit Erdos340GreedySidonOQ02.lean to Aristotle prove_file when the MCP backend recovers (currently returns 'Resource not found').",
-      "Or hand-formalize Steps 1–5 from knowledge.md (~120–180 lines) in a warm-cache low-load window; build via docker-build.sh Proofs.Erdos340GreedySidonOQ02.",
-      "After 0-sorry: add ℓ≈√N optimisation to discharge axiom sidon_upper_bound and flip parent meta axiomatized/axiom → verified (axiomCount 1→0)."
+      "To discharge the parent axiom sidon_upper_bound (+1 form) one must derive a sharper master inequality than sidon_window_key — e.g. combine the window bound with the difference-counting bound (C(|A|,2) ≤ N-1) which is tighter for small N, or sharpen the Cauchy–Schwarz step. This is a genuinely new formalization, not a re-optimisation.",
+      "Alternatively, weaken the parent axiom statement to the verified +2 form (sidon_card_le_sqrt) and remove the axiom — a meta/architecture decision for the parent entry."
     ],
-    "progressSummary": "PROGRESS: complete formalization roadmap for the single remaining sorry (window_pair_bound) recorded, reusing existing parent Sidon-injectivity infra; verification blocked this session by Aristotle outage + saturated Docker host."
+    "progressSummary": "RESOLVED (this route): OQ-02 file fully proved (0 sorries); the ℓ≈√N optimisation of sidon_window_key is now formalized as sidon_card_le_sqrt (|A| ≤ ⌊√N⌋+⌊√⌊√N⌋⌋+2, verified 0-axiom) — the optimal √N leading constant, a strict improvement over the elementary √(2N) bound. Proven that the exact +1 Lindström constant (the parent axiom) is NOT reachable from sidon_window_key; the axiom therefore remains and needs a sharper master inequality."
   },
   "references": [
     "P. Erdős and P. Turán, On a problem of Sidon in additive number theory, J. London Math. Soc. 16 (1941), 212–215.",


### PR DESCRIPTION
## Summary

Erdős Problem #340, OQ-02. The sibling file `Erdos340GreedySidonOQ02.lean` proves — fully (0 sorries, 0 axioms) — the sliding-window / Cauchy–Schwarz **master inequality**

```
sidon_window_key : ∀ ℓ ≥ 1,  ℓ·|A|² ≤ (N+ℓ)·(ℓ−1+|A|)
```

for every Sidon set `A ⊆ {0,…,N}`. Its tracked `nextSteps` called for "the ℓ≈√N optimisation of `sidon_window_key`". This PR carries out that optimisation **rigorously and axiom-free** in a new file `Erdos340SidonErdosTuran.lean`:

```lean
theorem sidon_card_le_sqrt (A : Finset ℕ) (hA : IsSidon A) (N : ℕ)
    (hAN : ∀ a ∈ A, a ≤ N) :
    A.card ≤ Nat.sqrt N + Nat.sqrt (Nat.sqrt N) + 2
```

obtained at window length `ℓ = ⌊√N⌋·⌊√⌊√N⌋⌋ + 1 ≈ N^(3/4)`.

`#print axioms Erdos340.sidon_card_le_sqrt` → `[propext, Classical.choice, Quot.sound]` only — **fully verified, 0-axiom**.

## Why this is worth adding

This is the Erdős–Turán/Lindström bound with the **optimal leading constant `√N`**, a strict asymptotic improvement over the parent's elementary difference-counting bound `sidon_upper_bound_weak : |A| ≤ ⌊√(2N)⌋ + 1` (constant `√2 ≈ 1.414`). It also captures the correct second-order `⌊⁴√N⌋ ≈ N^(1/4)` term. Mathlib has no Sidon-set Erdős–Turán bound, so the development is original relative to Mathlib.

## Honest scope: `+2`, not `+1` — the parent axiom is NOT discharged

An exhaustive search (`N < 3·10⁵`) shows the **exact Lindström constant `+1`** asserted by the parent's lone axiom `sidon_upper_bound` (`|A| ≤ √N + ⁴√N + 1`) is **genuinely not derivable from `sidon_window_key`**: with `s=⌊√N⌋, t=⌊√s⌋`,

- `k = s+t+3` is always refuted by some `ℓ` ⇒ `k ≤ s+t+2` is provable; but
- `k = s+t+2` survives the key inequality for ~12% of `N` (e.g. `N=15`: the key permits 6, the true Sidon maximum is 5, caught only by difference-counting).

The Cauchy–Schwarz step is intrinsically lossy by `+1`. So this route yields the verified `+2` form and the parent axiom **remains** (discharging it needs a sharper master inequality — a separate research line, documented in the problem's `knowledge.md`).

## Proof technique

By-contradiction with `|A| = s+t+3+d` and `N` at its worst case `s²+2s`; cast to ℤ. The gap factors as `Q = (s·t+1)d² + C₁·d + (s+t+2)·R` with `R = −s²+st²+3st−2s+t+3 ≥ 1` proved by the concavity certificate `2t·R = (t²+2t−s)·e₀ + (s−t²)·e₁ + 2t(s−t²)(t²+2t−s)` (endpoints `e₀ = 3t³−2t²+t+3`, `e₁ = (t−1)²(t+2)+1`). Each step is a low-degree `nlinarith`. `Nat.sqrt` bracketings: `Nat.sqrt_le'`, `Nat.lt_succ_sqrt'`.

## Verification
- `lake env lean Proofs/Erdos340SidonErdosTuran.lean` → exit 0, no warnings.
- `#print axioms` confirms 0-axiom (only the foundational `propext`/`Classical.choice`/`Quot.sound`).

## Files
- `proofs/Proofs/Erdos340SidonErdosTuran.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/research/problems/erdos-340-greedy-sidon-oq-02.json`, `research/problems/.../knowledge.md` (tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)