### PR TITLE
research(denumerability-rationals-oq-06): polynomial ring ℚ[X] is countable, #(ℚ[X])=ℵ₀

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -654,6 +654,7 @@ import Proofs.DenumerabilityRationalsOQ02OQ02
 import Proofs.DenumerabilityRationalsOQ03
 import Proofs.DenumerabilityRationalsOQ04
 import Proofs.DenumerabilityRationalsOQ05
+import Proofs.DenumerabilityRationalsOQ06
 import Proofs.Derangements
 import Proofs.DerangementsConvergence
 import Proofs.DerangementsConvergenceOQ01

--- a/proofs/Proofs/DenumerabilityRationalsOQ06.lean
+++ b/proofs/Proofs/DenumerabilityRationalsOQ06.lean
@@ -1,0 +1,57 @@
+import Mathlib
+
+/-!
+# Denumerability of Rationals OQ-06: the polynomial ring `ℚ[X]` is countable
+
+The base entry and its siblings show the *rationals* are denumerable, and OQ-05
+extends this to finite products, lists and finite subsets of `ℚ` (`#(ℚ × ℚ)`,
+`#(List ℚ)`, `#(Finset ℚ)`), all of which stay at `ℵ₀`, while `ℕ → ℚ` jumps to the
+continuum `𝔠`. None of those touch the object that actually drives *algebraic*
+countability: the polynomial ring.
+
+This entry records that `ℚ[X]` — and `ℤ[X]` — is countably infinite:
+
+`#(ℚ[X]) = ℵ₀`  and  `#(ℤ[X]) = ℵ₀`,
+
+so there is an explicit bijection `ℕ ≃ ℚ[X]`. The proof is one application of
+Mathlib's `Polynomial.cardinalMk_eq_max` (`#(R[X]) = max #R ℵ₀` for a nontrivial
+semiring `R`): with `#ℚ = #ℤ = ℵ₀` the maximum collapses to `ℵ₀`.
+
+Countability of `ℚ[X]` is the cardinal fact behind the countability of the algebraic
+numbers (a single algebraic number is a root of some polynomial in `ℚ[X]`, and each
+polynomial has finitely many roots); OQ-07 pursues that consequence explicitly.
+
+No axioms beyond Lean's foundational core, no sorries.
+-/
+
+namespace DenumerabilityRationalsOQ06
+
+open Cardinal Polynomial
+
+/-- **`#ℚ = ℵ₀`.** The rationals are countable and infinite, hence exactly `ℵ₀`. -/
+theorem mk_rat : #ℚ = ℵ₀ := mk_eq_aleph0 ℚ
+
+/-- **`#(ℚ[X]) = ℵ₀`.** By `Polynomial.cardinalMk_eq_max`, `#(ℚ[X]) = max #ℚ ℵ₀`;
+since `#ℚ = ℵ₀`, the maximum is `max ℵ₀ ℵ₀ = ℵ₀`. -/
+theorem cardinalMk_polynomial_rat : #(ℚ[X]) = ℵ₀ := by
+  rw [Polynomial.cardinalMk_eq_max, mk_rat, max_self]
+
+/-- **`#(ℤ[X]) = ℵ₀`.** Same argument with `#ℤ = ℵ₀` (`Cardinal.mk_int`). -/
+theorem cardinalMk_polynomial_int : #(ℤ[X]) = ℵ₀ := by
+  rw [Polynomial.cardinalMk_eq_max, mk_int, max_self]
+
+/-- The rational and integer polynomial rings have the same cardinality. -/
+theorem cardinalMk_polynomial_rat_eq_int : #(ℚ[X]) = #(ℤ[X]) := by
+  rw [cardinalMk_polynomial_rat, cardinalMk_polynomial_int]
+
+/-- **`ℚ[X]` is denumerable**: `#ℕ = #(ℚ[X])` (both are `ℵ₀`), so there is a
+bijection `ℕ ≃ ℚ[X]`. -/
+theorem nonempty_nat_equiv_polynomial_rat : Nonempty (ℕ ≃ ℚ[X]) :=
+  Cardinal.eq.mp (by rw [mk_nat, cardinalMk_polynomial_rat])
+
+/-- An explicit (noncomputable) enumeration of `ℚ[X]` by the naturals, extracted from
+the cardinal equality. -/
+noncomputable def natEquivPolynomialRat : ℕ ≃ ℚ[X] :=
+  (nonempty_nat_equiv_polynomial_rat).some
+
+end DenumerabilityRationalsOQ06

--- a/src/data/proofs/denumerability-rationals-oq-06/annotations.json
+++ b/src/data/proofs/denumerability-rationals-oq-06/annotations.json
@@ -1,0 +1,71 @@
+[
+  {
+    "id": "ann-imports-helper",
+    "proofId": "denumerability-rationals-oq-06",
+    "range": {
+      "startLine": 29,
+      "endLine": 31
+    },
+    "type": "key-step",
+    "title": "The Engine Lemma #ℚ = ℵ₀",
+    "content": "mk_rat records that the rationals have cardinality exactly ℵ₀. It is a one-line application of Cardinal.mk_eq_aleph0, which states that any type that is simultaneously Countable and Infinite has cardinality ℵ₀; ℚ carries both instances. This single fact is what the polynomial-ring cardinality collapses against — every other result in the file feeds #ℚ = ℵ₀ (or its ℤ analogue) into Mathlib's max formula.",
+    "mathContext": "$\\#\\mathbb{Q} = \\aleph_0$ since $\\mathbb{Q}$ is countable and infinite (Cantor's enumeration of the rationals).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cardinal.mk_eq_aleph0",
+      "countable types",
+      "infinite types",
+      "ℵ₀"
+    ],
+    "prerequisites": [
+      "cardinality of a type",
+      "countable and infinite type classes"
+    ]
+  },
+  {
+    "id": "ann-polynomial-cardinality",
+    "proofId": "denumerability-rationals-oq-06",
+    "range": {
+      "startLine": 33,
+      "endLine": 40
+    },
+    "type": "theorem",
+    "title": "#(ℚ[X]) = ℵ₀ via the Max Formula",
+    "content": "cardinalMk_polynomial_rat is the headline: the polynomial ring over ℚ is countably infinite. The proof rewrites with Polynomial.cardinalMk_eq_max — Mathlib's statement that #(R[X]) = max #R ℵ₀ for any nontrivial semiring R — turning the goal into max #ℚ ℵ₀ = ℵ₀; substituting mk_rat gives max ℵ₀ ℵ₀, which max_self collapses to ℵ₀. cardinalMk_polynomial_int is the verbatim ℤ analogue using Cardinal.mk_int. The max formula is doing the real combinatorial work (a polynomial is a finitely-supported function ℕ → R, and there are only countably many of those over a countable R); the entry reduces ℚ[X] to that general fact.",
+    "mathContext": "$\\#(R[X]) = \\max(\\#R, \\aleph_0)$, so with $\\#\\mathbb{Q} = \\aleph_0$ we get $\\#(\\mathbb{Q}[X]) = \\max(\\aleph_0, \\aleph_0) = \\aleph_0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Polynomial.cardinalMk_eq_max",
+      "max_self",
+      "polynomial rings",
+      "ℵ₀ arithmetic"
+    ],
+    "prerequisites": [
+      "polynomials as finitely-supported functions",
+      "cardinal maximum"
+    ]
+  },
+  {
+    "id": "ann-denumerable-witness",
+    "proofId": "denumerability-rationals-oq-06",
+    "range": {
+      "startLine": 46,
+      "endLine": 54
+    },
+    "type": "theorem",
+    "title": "An Explicit Bijection ℕ ≃ ℚ[X]",
+    "content": "nonempty_nat_equiv_polynomial_rat upgrades the numeric equality to a structural one: because #ℕ = ℵ₀ = #(ℚ[X]), Cardinal.eq.mp produces Nonempty (ℕ ≃ ℚ[X]) — an actual bijection between the naturals and the rational polynomials. natEquivPolynomialRat then extracts a concrete (noncomputable) enumeration. This makes 'ℚ[X] is denumerable' a statement about a witnessing equivalence rather than just a sentence about cardinals, matching the constructive flavour of the base denumerability entry.",
+    "mathContext": "$\\#\\mathbb{N} = \\#(\\mathbb{Q}[X])$ gives, via $\\#\\alpha = \\#\\beta \\leftrightarrow \\text{Nonempty}(\\alpha \\simeq \\beta)$, an explicit enumeration $\\mathbb{N} \\simeq \\mathbb{Q}[X]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cardinal.eq",
+      "Cardinal.mk_nat",
+      "type equivalence",
+      "denumerability"
+    ],
+    "prerequisites": [
+      "equivalences between types",
+      "extracting a witness from a Nonempty"
+    ]
+  }
+]

--- a/src/data/proofs/denumerability-rationals-oq-06/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-06/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "denumerability-rationals-oq-06",
+  "title": "The Polynomial Ring ℚ[X] is Countable: #(ℚ[X]) = ℵ₀",
+  "slug": "denumerability-rationals-oq-06",
+  "description": "Extends the denumerability of ℚ to the polynomial ring ℚ[X] (and ℤ[X]): #(ℚ[X]) = ℵ₀, so there is an explicit bijection ℕ ≃ ℚ[X]. One application of Mathlib's Polynomial.cardinalMk_eq_max collapses max #ℚ ℵ₀ to ℵ₀. This is the cardinal fact behind the countability of the algebraic numbers, which the sibling siblings (#(ℚ×ℚ), #(List ℚ), #(Finset ℚ)) never reach.",
+  "meta": {
+    "author": "Georg Cantor (1874, countability of algebraic numbers)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ06.lean",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "countability",
+      "polynomials",
+      "aleph-null",
+      "classic"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.cardinalMk_eq_max",
+        "description": "For a nontrivial semiring R, #(R[X]) = max #R ℵ₀",
+        "module": "Mathlib.Algebra.Polynomial.Cardinal"
+      },
+      {
+        "theorem": "Cardinal.mk_eq_aleph0",
+        "description": "Any countable infinite type has cardinality exactly ℵ₀",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Cardinal.mk_int",
+        "description": "#ℤ = ℵ₀",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Cardinal.mk_nat",
+        "description": "#ℕ = ℵ₀",
+        "module": "Mathlib.SetTheory.Cardinal.Defs"
+      },
+      {
+        "theorem": "Cardinal.eq",
+        "description": "#α = #β ↔ Nonempty (α ≃ β); extracts an explicit bijection from a cardinal equality",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      }
+    ],
+    "originalContributions": [
+      "mk_rat: records #ℚ = ℵ₀ as the engine lemma (ℚ countable and infinite)",
+      "cardinalMk_polynomial_rat: #(ℚ[X]) = ℵ₀ — the polynomial ring over ℚ is denumerable",
+      "cardinalMk_polynomial_int: #(ℤ[X]) = ℵ₀ — same for the integer polynomial ring",
+      "cardinalMk_polynomial_rat_eq_int: #(ℚ[X]) = #(ℤ[X]), the two polynomial rings are equinumerous",
+      "nonempty_nat_equiv_polynomial_rat + natEquivPolynomialRat: an explicit enumeration ℕ ≃ ℚ[X]"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound.",
+    "lineCount": 57,
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Cantor's 1874 proof that the algebraic numbers are countable rests on a single cardinal observation: the set of polynomials with rational (equivalently integer) coefficients is itself countable, and each polynomial contributes only finitely many roots. The countability of the coefficient ring's polynomial ring is therefore the structural heart of the result. The denumerability-of-rationals gallery family establishes #ℚ = ℵ₀ and propagates it to finite products, lists, and finite subsets of ℚ — but stops short of the polynomial ring, the very object Cantor needed. This entry supplies it.",
+    "problemStatement": "Show that the polynomial ring over the rationals is countably infinite: #(ℚ[X]) = ℵ₀ (and likewise #(ℤ[X]) = ℵ₀), and exhibit a bijection ℕ ≃ ℚ[X].\n\n**Answer:** Both equalities hold. By Mathlib's Polynomial.cardinalMk_eq_max, #(R[X]) = max #R ℵ₀ for any nontrivial semiring R; with #ℚ = #ℤ = ℵ₀ the maximum is max ℵ₀ ℵ₀ = ℵ₀.",
+    "text": "The polynomial ring ℚ[X] is denumerable: #(ℚ[X]) = ℵ₀, the cardinal fact behind the countability of the algebraic numbers.",
+    "proofStrategy": "1. mk_rat: #ℚ = ℵ₀ from Cardinal.mk_eq_aleph0 (ℚ is countable and infinite).\n2. cardinalMk_polynomial_rat: rewrite with Polynomial.cardinalMk_eq_max to get max #ℚ ℵ₀, substitute mk_rat, and collapse max ℵ₀ ℵ₀ to ℵ₀ via max_self.\n3. cardinalMk_polynomial_int: identical with Cardinal.mk_int.\n4. nonempty_nat_equiv_polynomial_rat: since #ℕ = ℵ₀ = #(ℚ[X]), Cardinal.eq.mp yields Nonempty (ℕ ≃ ℚ[X]); natEquivPolynomialRat extracts the witness.",
+    "keyInsights": [
+      "**The polynomial ring is where algebraic countability lives**: the sibling entries reach #(ℚ×ℚ), #(List ℚ), #(Finset ℚ) but never the ring ℚ[X], which is the object Cantor's argument actually enumerates.",
+      "**One lemma does the work**: Polynomial.cardinalMk_eq_max packages the entire 'countably many coefficients, each from a countable list' combinatorics into #(R[X]) = max #R ℵ₀; the rest is the trivial collapse max ℵ₀ ℵ₀ = ℵ₀.",
+      "**ℚ and ℤ give the same answer**: both coefficient rings are ℵ₀, so #(ℚ[X]) = #(ℤ[X]) — passing from ℤ[X] to ℚ[X] does not enlarge the cardinality, mirroring #ℤ = #ℚ at the ring level.",
+      "**Cardinal equality is constructive enough for a bijection**: Cardinal.eq turns the numeric equality #ℕ = #(ℚ[X]) into an actual equivalence ℕ ≃ ℚ[X], making 'ℚ[X] is denumerable' a concrete statement rather than a cardinal slogan."
+    ],
+    "prerequisites": [
+      "Cardinal numbers and ℵ₀",
+      "Countable and infinite types",
+      "Polynomial rings R[X]"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-helper",
+      "title": "Imports and the Engine Lemma #ℚ = ℵ₀",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "File docstring positioning ℚ[X] against the sibling cardinal results, imports Mathlib, opens Cardinal and Polynomial. mk_rat records #ℚ = ℵ₀ via Cardinal.mk_eq_aleph0 (ℚ countable and infinite).",
+      "mathContext": "#ℚ = ℵ₀ because ℚ is both countable and infinite; this is the input the maximum collapses against."
+    },
+    {
+      "id": "polynomial-cardinality",
+      "title": "Countability of ℚ[X] and ℤ[X]",
+      "startLine": 33,
+      "endLine": 44,
+      "summary": "cardinalMk_polynomial_rat and cardinalMk_polynomial_int: each rewrites #(R[X]) via Polynomial.cardinalMk_eq_max to max #R ℵ₀, substitutes #R = ℵ₀, and finishes with max_self. cardinalMk_polynomial_rat_eq_int records #(ℚ[X]) = #(ℤ[X]).",
+      "mathContext": "#(R[X]) = max #R ℵ₀ and #ℚ = #ℤ = ℵ₀, so #(ℚ[X]) = #(ℤ[X]) = max ℵ₀ ℵ₀ = ℵ₀."
+    },
+    {
+      "id": "denumerable-witness",
+      "title": "An Explicit Enumeration ℕ ≃ ℚ[X]",
+      "startLine": 46,
+      "endLine": 56,
+      "summary": "nonempty_nat_equiv_polynomial_rat uses Cardinal.eq.mp on #ℕ = #(ℚ[X]) (both ℵ₀) to produce Nonempty (ℕ ≃ ℚ[X]); natEquivPolynomialRat extracts a concrete (noncomputable) bijection.",
+      "mathContext": "Since #ℕ = ℵ₀ = #(ℚ[X]), Cardinal.eq gives an equivalence ℕ ≃ ℚ[X], i.e. ℚ[X] is denumerable."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "note": "Countability of the algebraic numbers, resting on countability of polynomials with rational coefficients"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-05",
+      "relationship": "sibling",
+      "description": "OQ-05 stays inside ℚ (products, lists, finite subsets); OQ-06 moves to the polynomial ring ℚ[X], the object driving algebraic countability"
+    },
+    {
+      "targetId": "denumerability-rationals",
+      "relationship": "extends",
+      "description": "Lifts the base entry's #ℚ = ℵ₀ to the polynomial ring #(ℚ[X]) = ℵ₀"
+    }
+  ],
+  "conclusion": {
+    "summary": "The polynomial ring ℚ[X] (and ℤ[X]) is countably infinite: #(ℚ[X]) = ℵ₀, proved by collapsing Mathlib's #(R[X]) = max #R ℵ₀ against #ℚ = ℵ₀, with an explicit bijection ℕ ≃ ℚ[X] extracted from the cardinal equality.",
+    "implications": "Supplies the missing cardinal step behind the countability of the algebraic numbers and makes ℚ[X] a directly citable denumerable object in the gallery.",
+    "openQuestions": [
+      "Make the countability of the algebraic numbers explicit as a Sigma over ℚ[X] of finite root fibers (pursued in OQ-07).",
+      "Does the same max-collapse give #(ℚ[X, Y]) = ℵ₀ and, by induction, #(MvPolynomial (Fin n) ℚ) = ℵ₀ for every fixed n?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal",
+      "Polynomial"
+    ],
+    "namespace": "DenumerabilityRationalsOQ06",
+    "lineCount": 57,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/DenumerabilityRationalsOQ06.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Extends the denumerability-of-rationals family to the **polynomial ring** `ℚ[X]` (and `ℤ[X]`) — the object that actually drives the countability of the algebraic numbers, which the siblings (`#(ℚ×ℚ)`, `#(List ℚ)`, `#(Finset ℚ)` in OQ-05) never reach.

**Headline:** `#(ℚ[X]) = ℵ₀`, so `ℚ[X]` is denumerable with an explicit bijection `ℕ ≃ ℚ[X]`.

## Theorems (`Proofs/DenumerabilityRationalsOQ06.lean`, namespace `DenumerabilityRationalsOQ06`)

- `mk_rat : #ℚ = ℵ₀` — engine lemma (ℚ countable + infinite).
- `cardinalMk_polynomial_rat : #(ℚ[X]) = ℵ₀` — via `Polynomial.cardinalMk_eq_max` (`#(R[X]) = max #R ℵ₀`) collapsed by `max_self`.
- `cardinalMk_polynomial_int : #(ℤ[X]) = ℵ₀` — same with `Cardinal.mk_int`.
- `cardinalMk_polynomial_rat_eq_int : #(ℚ[X]) = #(ℤ[X])`.
- `nonempty_nat_equiv_polynomial_rat : Nonempty (ℕ ≃ ℚ[X])` + `natEquivPolynomialRat` — explicit enumeration via `Cardinal.eq`.

## Distinctness

OQ-05 stays inside ℚ (products / lists / finite subsets) and never touches the polynomial ring. `grep cardinalMk_eq_max / Polynomial.*cardinal` across `proofs/Proofs/` was empty before this entry. Distinct from OQ-07 (explicit Sigma-over-polynomials decomposition of the algebraic reals), which this supplies the cardinal input for.

## Verification

- Compiles against Mathlib 4.26.0 (`lake env lean`, no errors).
- **0 axioms / 0 sorries.** `#print axioms` on all results lists only `propext, Classical.choice, Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`. Status: `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)