### PR TITLE
research(sum-of-divisors-oq-05): abundancy index σ(n)/n is multiplicative (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3058,6 +3058,7 @@ import Proofs.SubsetCountOQ02OQ01
 import Proofs.SumOfDivisors
 import Proofs.SumOfDivisorsOQ02
 import Proofs.SumOfDivisorsOQ04
+import Proofs.SumOfDivisorsOQ05
 import Proofs.SumOfDivisorsOQ06
 import Proofs.SumOfKthPowers
 import Proofs.SumOfKthPowersOQ01

--- a/proofs/Proofs/SumOfDivisorsOQ05.lean
+++ b/proofs/Proofs/SumOfDivisorsOQ05.lean
@@ -1,0 +1,90 @@
+import Mathlib
+
+/-!
+# Sum of Divisors OQ-05: the abundancy index σ(n)/n is multiplicative
+
+The **abundancy index** of `n` is the rational number `abundancy n = σ₁(n) / n`, where
+`σ₁(n)` is the sum of the divisors of `n`. It measures how "divisor-rich" `n` is:
+`< 2` deficient, `= 2` perfect, `> 2` abundant.
+
+The `SumOfDivisors` gallery entry proves that the divisor-sum function `σ₁` itself is
+multiplicative (`σ₁(mn) = σ₁(m)·σ₁(n)` for coprime `m, n`) and characterizes perfect
+numbers by `abundancy n = 2`, but it does **not** record that the *rational quotient*
+`σ₁(n)/n` is multiplicative. This entry supplies that:
+
+* `abundancy_mul_of_coprime` : `abundancy (m·n) = abundancy m · abundancy n` for coprime
+  positive `m, n` — the abundancy index is a multiplicative function.
+
+Two consequences are read off:
+
+* `one_lt_abundancy` : `abundancy n > 1` for every `n ≥ 2` (since `σ₁(n) > n`), and
+* `abundant_of_perfect_mul_coprime` : a positive coprime multiple of a perfect number is
+  **abundant** — if `abundancy m = 2` and `n ≥ 2` is coprime to `m`, then
+  `abundancy (m·n) > 2`. (This is why, e.g., `2·k` is abundant for odd `k > 1` once one
+  factor is perfect — the multiplicativity transports "perfect" past a coprime factor.)
+
+Self-contained: `abundancy` is defined here over `ℚ` from Mathlib's `ArithmeticFunction.sigma`,
+and no `native_decide` is used, so the file is genuinely axiom-free.
+
+No axioms, no sorries.
+-/
+
+namespace SumOfDivisorsOQ05
+
+open ArithmeticFunction
+
+/-- The abundancy index `σ₁(n)/n` as a rational number. -/
+noncomputable def abundancy (n : ℕ) : ℚ := (sigma 1 n : ℚ) / (n : ℚ)
+
+@[simp] theorem abundancy_one : abundancy 1 = 1 := by
+  simp [abundancy]
+
+/-- **The abundancy index is multiplicative.** For coprime positive `m, n`,
+`abundancy (m·n) = abundancy m · abundancy n`. This is the rational-quotient upgrade of
+the multiplicativity of `σ₁` itself. -/
+theorem abundancy_mul_of_coprime {m n : ℕ} (hm : 0 < m) (hn : 0 < n)
+    (h : Nat.Coprime m n) :
+    abundancy (m * n) = abundancy m * abundancy n := by
+  have hmn : sigma 1 (m * n) = sigma 1 m * sigma 1 n :=
+    isMultiplicative_sigma.map_mul_of_coprime h
+  have hm' : (m : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hm.ne'
+  have hn' : (n : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  unfold abundancy
+  rw [hmn]
+  push_cast
+  field_simp
+
+/-- The divisor sum strictly exceeds `n` once `n ≥ 2`: both `1` and `n` are distinct
+divisors, so `σ₁(n) ≥ 1 + n > n`. -/
+theorem self_lt_sigma_one {n : ℕ} (hn : 2 ≤ n) : n < sigma 1 n := by
+  have hn0 : n ≠ 0 := by omega
+  rw [sigma_one_apply]
+  have hsub : ({n} : Finset ℕ) ⊆ n.divisors := by
+    simp [Finset.singleton_subset_iff, Nat.mem_divisors, hn0]
+  have h1mem : (1 : ℕ) ∈ n.divisors := Nat.one_mem_divisors.mpr hn0
+  have h1not : (1 : ℕ) ∉ ({n} : Finset ℕ) := by
+    simp only [Finset.mem_singleton]; omega
+  calc n = ∑ d ∈ ({n} : Finset ℕ), d := by simp
+    _ < ∑ d ∈ n.divisors, d :=
+        Finset.sum_lt_sum_of_subset hsub h1mem h1not (by norm_num)
+          (fun j _ _ => Nat.zero_le j)
+
+/-- **Every `n ≥ 2` has abundancy `> 1`** (it is at least "deficient-strict"):
+`abundancy n = σ₁(n)/n > 1` because `σ₁(n) > n`. -/
+theorem one_lt_abundancy {n : ℕ} (hn : 2 ≤ n) : 1 < abundancy n := by
+  have hpos : (0 : ℚ) < (n : ℚ) := by exact_mod_cast (by omega : 0 < n)
+  rw [abundancy, lt_div_iff₀ hpos, one_mul]
+  exact_mod_cast self_lt_sigma_one hn
+
+/-- **A coprime multiple of a perfect number is abundant.** If `m` is perfect
+(`abundancy m = 2`) and `n ≥ 2` is coprime to `m`, then `abundancy (m·n) > 2`, i.e. `m·n`
+is abundant. Multiplicativity pushes the perfect value `2` past the coprime factor `n`,
+whose abundancy exceeds `1`. -/
+theorem abundant_of_perfect_mul_coprime {m n : ℕ} (hm : 0 < m) (hn : 2 ≤ n)
+    (h : Nat.Coprime m n) (hperf : abundancy m = 2) :
+    2 < abundancy (m * n) := by
+  rw [abundancy_mul_of_coprime hm (by omega) h, hperf]
+  have hn1 : 1 < abundancy n := one_lt_abundancy hn
+  linarith
+
+end SumOfDivisorsOQ05

--- a/src/data/proofs/sum-of-divisors-oq-05/annotations.json
+++ b/src/data/proofs/sum-of-divisors-oq-05/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "sum-of-divisors-oq-05",
+    "range": { "startLine": 3, "endLine": 36 },
+    "type": "concept",
+    "title": "The Abundancy Index and the Missing Multiplicativity",
+    "content": "The abundancy index $\\mathrm{abundancy}(n) = \\sigma_1(n)/n$ normalizes the sum-of-divisors function to classify integers: $< 2$ deficient, $= 2$ perfect, $> 2$ abundant. The `SumOfDivisors` entry defines this index and proves $\\sigma_1$ multiplicative and perfect $\\iff$ index $= 2$, but never records that the rational quotient $\\sigma_1(n)/n$ is itself multiplicative. This entry supplies that and reads off two corollaries.",
+    "mathContext": "$\\mathrm{abundancy}(n) = \\sigma_1(n)/n;\\ \\ \\text{perfect} \\iff = 2.$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative functions", "sum of divisors", "perfect numbers"],
+    "prerequisites": ["arithmetic functions", "coprimality"]
+  },
+  {
+    "id": "ann-def",
+    "proofId": "sum-of-divisors-oq-05",
+    "range": { "startLine": 38, "endLine": 41 },
+    "type": "technique",
+    "title": "Defining the Index over ℚ",
+    "content": "`abundancy n = (σ₁ n : ℚ) / n` is defined from Mathlib's `ArithmeticFunction.sigma`, with `abundancy_one : abundancy 1 = 1` as a simp lemma. Working over ℚ keeps the index an honest function and avoids `native_decide`, so the file is genuinely axiom-free.",
+    "mathContext": "$\\mathrm{abundancy}(1) = \\sigma_1(1)/1 = 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["ArithmeticFunction.sigma", "rational normalization"],
+    "prerequisites": ["arithmetic functions"]
+  },
+  {
+    "id": "ann-mul",
+    "proofId": "sum-of-divisors-oq-05",
+    "range": { "startLine": 43, "endLine": 56 },
+    "type": "key-step",
+    "title": "Multiplicativity from σ-Multiplicativity",
+    "content": "`abundancy_mul_of_coprime`: for coprime positive $m, n$, $\\mathrm{abundancy}(mn) = \\mathrm{abundancy}(m)\\,\\mathrm{abundancy}(n)$. The proof is short: `isMultiplicative_sigma.map_mul_of_coprime` rewrites $\\sigma_1(mn) = \\sigma_1(m)\\sigma_1(n)$, then `push_cast` moves to ℚ and `field_simp` clears the denominators $m, n \\ne 0$. The quotient inherits multiplicativity from $\\sigma_1$ and the identity $n \\mapsto n$.",
+    "mathContext": "$\\frac{\\sigma_1(mn)}{mn} = \\frac{\\sigma_1(m)}{m}\\cdot\\frac{\\sigma_1(n)}{n}.$",
+    "significance": "key",
+    "relatedConcepts": ["IsMultiplicative.map_mul_of_coprime", "field_simp", "push_cast"],
+    "prerequisites": ["multiplicative functions", "rational arithmetic"]
+  },
+  {
+    "id": "ann-bound",
+    "proofId": "sum-of-divisors-oq-05",
+    "range": { "startLine": 58, "endLine": 79 },
+    "type": "technique",
+    "title": "σ₁(n) > n via Two Distinct Divisors",
+    "content": "`self_lt_sigma_one`: for $n \\ge 2$, $n < \\sigma_1(n)$. Both $1$ and $n$ divide $n$ and are distinct, so the full divisor sum strictly exceeds the single-term sum over $\\{n\\}$; `Finset.sum_lt_sum_of_subset` (with $1$ as the extra positive divisor) makes this precise. Dividing by $n > 0$ gives `one_lt_abundancy`: $\\mathrm{abundancy}(n) > 1$ for $n \\ge 2$.",
+    "mathContext": "$1, n \\in \\mathrm{divisors}(n),\\ 1 \\ne n \\Rightarrow \\sigma_1(n) \\ge 1 + n > n.$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_lt_sum_of_subset", "divisors", "lt_div_iff"],
+    "prerequisites": ["finite sums", "divisor sets"]
+  },
+  {
+    "id": "ann-abundant",
+    "proofId": "sum-of-divisors-oq-05",
+    "range": { "startLine": 81, "endLine": 90 },
+    "type": "key-step",
+    "title": "Coprime Multiple of a Perfect Number is Abundant",
+    "content": "`abundant_of_perfect_mul_coprime`: if $\\mathrm{abundancy}(m) = 2$ (m perfect) and $n \\ge 2$ is coprime to $m$, then $\\mathrm{abundancy}(mn) > 2$. Multiplicativity gives $\\mathrm{abundancy}(mn) = 2\\cdot\\mathrm{abundancy}(n)$, and $\\mathrm{abundancy}(n) > 1$ finishes by `linarith`. Classification transports across coprime factors.",
+    "mathContext": "$\\mathrm{abundancy}(mn) = 2\\,\\mathrm{abundancy}(n) > 2.$",
+    "significance": "key",
+    "relatedConcepts": ["abundant numbers", "perfect numbers", "multiplicativity"],
+    "prerequisites": ["perfect numbers", "inequalities"]
+  }
+]

--- a/src/data/proofs/sum-of-divisors-oq-05/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-05/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "sum-of-divisors-oq-05",
+  "slug": "sum-of-divisors-oq-05",
+  "title": "The Abundancy Index σ(n)/n is Multiplicative",
+  "description": "The abundancy index of n is the rational number abundancy(n) = σ₁(n)/n (σ₁ = sum of divisors); it measures divisor-richness (< 2 deficient, = 2 perfect, > 2 abundant). The SumOfDivisors entry proves σ₁ itself is multiplicative and characterizes perfect numbers by abundancy = 2, but not that the rational QUOTIENT σ₁(n)/n is multiplicative. This entry supplies abundancy_mul_of_coprime: abundancy(mn) = abundancy(m)·abundancy(n) for coprime positive m, n. Two consequences: one_lt_abundancy (abundancy n > 1 for n ≥ 2, since σ₁(n) > n) and abundant_of_perfect_mul_coprime (a positive coprime multiple of a perfect number is abundant — abundancy(m·n) > 2). Self-contained over ℚ via Mathlib's ArithmeticFunction.sigma, no native_decide. Fully machine-checked, 0 sorries, 0 axioms.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["ArithmeticFunction"],
+    "namespace": "SumOfDivisorsOQ05",
+    "lineCount": 90,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 3,
+    "trivialSpecializations": 1,
+    "definitionCount": 1,
+    "path": "Proofs/SumOfDivisorsOQ05.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Classical (abundancy index; multiplicativity of σ)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Abundancy_index",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SumOfDivisorsOQ05.lean",
+    "tags": [
+      "number-theory",
+      "arithmetic-functions",
+      "multiplicative-functions",
+      "abundancy-index",
+      "perfect-numbers",
+      "sum-of-divisors"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. abundancy is defined over ℚ from Mathlib's ArithmeticFunction.sigma; no native_decide is used. #print axioms reports only propext / Classical.choice / Quot.sound.",
+    "dateAdded": "2026-06-20",
+    "mathlibDependencies": [
+      "ArithmeticFunction.isMultiplicative_sigma",
+      "ArithmeticFunction.IsMultiplicative.map_mul_of_coprime",
+      "ArithmeticFunction.sigma_one_apply",
+      "Finset.sum_lt_sum_of_subset",
+      "Nat.mem_divisors"
+    ],
+    "originalContributions": [
+      "abundancy_mul_of_coprime: abundancy(mn) = abundancy(m)·abundancy(n) for coprime positive m,n — the rational-quotient upgrade of σ-multiplicativity, absent from the SumOfDivisors entry",
+      "self_lt_sigma_one: n < σ₁(n) for n ≥ 2, via the distinct divisors 1 and n (Finset.sum_lt_sum_of_subset)",
+      "one_lt_abundancy: abundancy n > 1 for n ≥ 2",
+      "abundant_of_perfect_mul_coprime: abundancy m = 2 and n ≥ 2 coprime ⇒ abundancy(mn) > 2 (a coprime multiple of a perfect number is abundant)"
+    ],
+    "prerequisites": [
+      "Multiplicative arithmetic functions and σ",
+      "Coprimality and the CRT factorization of divisors",
+      "Rational arithmetic (field_simp)"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 90,
+    "relatedProblems": ["sum-of-divisors", "perfect-numbers"],
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The abundancy index σ(n)/n is the standard normalization of the sum-of-divisors function used to classify integers as deficient, perfect, or abundant — perfect numbers are exactly those with index 2. Because σ is a multiplicative arithmetic function (a consequence of the divisor structure factoring over coprime parts, the Chinese Remainder Theorem in disguise), the abundancy index is multiplicative too. This multiplicativity is the engine behind classical facts such as 'any multiple of a perfect number by a coprime factor is abundant' and the search heuristics for odd perfect and friendly numbers.",
+    "problemStatement": "Define abundancy(n) = σ₁(n)/n over ℚ. Prove that abundancy is multiplicative on coprime arguments: abundancy(m·n) = abundancy(m)·abundancy(n) for coprime positive m, n. Deduce that abundancy(n) > 1 for every n ≥ 2, and that a positive coprime multiple of a perfect number is abundant.",
+    "proofStrategy": "Multiplicativity reduces immediately to that of σ₁: writing abundancy(m·n) = σ₁(m·n)/(m·n) and applying Mathlib's isMultiplicative_sigma.map_mul_of_coprime gives σ₁(m·n) = σ₁(m)·σ₁(n); pushing the casts into ℚ and clearing denominators with field_simp closes the identity. For the lower bound σ₁(n) > n, note that 1 and n are two distinct divisors of n when n ≥ 2, so the divisor sum strictly exceeds the single-term sum over {n}; Finset.sum_lt_sum_of_subset makes this precise. Dividing by n > 0 gives abundancy(n) > 1, and the abundant-multiple corollary follows by transporting the perfect value 2 across the coprime factor via the multiplicativity identity.",
+    "keyInsights": [
+      "Multiplicativity of the abundancy index is not an independent fact: it is exactly the multiplicativity of σ₁ divided through by the multiplicativity of the identity n ↦ n, so the rational quotient inherits it.",
+      "The only genuinely new ingredient beyond the existing σ-multiplicativity is bookkeeping with the casts ℕ → ℚ and clearing denominators — which is precisely the step the SumOfDivisors entry never took.",
+      "σ₁(n) > n for n ≥ 2 because 1 and n are always two distinct divisors; this single inequality powers the 'multiple of a perfect number is abundant' phenomenon.",
+      "Multiplicativity transports classification across coprime factors: abundancy 2 (perfect) times anything with abundancy > 1 lands strictly above 2 (abundant).",
+      "Working over ℚ (rather than clearing to a ℕ inequality) keeps the index an honest multiplicative function and lets perfect/abundant be stated as clean equalities and inequalities of rationals."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "abundancy_mul_of_coprime",
+      "statement": "Nat.Coprime m n → abundancy (m * n) = abundancy m * abundancy n",
+      "description": "The abundancy index is multiplicative on coprime positive arguments — the rational-quotient form of σ-multiplicativity."
+    },
+    {
+      "name": "self_lt_sigma_one",
+      "statement": "2 ≤ n → n < σ₁(n)",
+      "description": "The divisor sum strictly exceeds n for n ≥ 2, since 1 and n are distinct divisors."
+    },
+    {
+      "name": "one_lt_abundancy",
+      "statement": "2 ≤ n → 1 < abundancy n",
+      "description": "Every integer ≥ 2 has abundancy index strictly above 1."
+    },
+    {
+      "name": "abundant_of_perfect_mul_coprime",
+      "statement": "abundancy m = 2 → 2 ≤ n → Nat.Coprime m n → 2 < abundancy (m * n)",
+      "description": "A positive coprime multiple of a perfect number is abundant: multiplicativity pushes the perfect value 2 past the coprime factor."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "`import Mathlib`, the module docstring, and `namespace SumOfDivisorsOQ05` opening `ArithmeticFunction`. The docstring defines the abundancy index, states the multiplicativity result and its two corollaries, and notes the file is self-contained over ℚ with no native_decide.",
+      "mathContext": "$\\mathrm{abundancy}(n) = \\sigma_1(n)/n.$"
+    },
+    {
+      "id": "definition",
+      "title": "The Abundancy Index",
+      "startLine": 38,
+      "endLine": 41,
+      "summary": "Defines `abundancy n = (σ₁ n : ℚ) / n` and the simp lemma `abundancy_one : abundancy 1 = 1`.",
+      "mathContext": "$\\mathrm{abundancy}(1) = 1.$"
+    },
+    {
+      "id": "multiplicative",
+      "title": "Multiplicativity on Coprime Arguments",
+      "startLine": 43,
+      "endLine": 56,
+      "summary": "Proves `abundancy_mul_of_coprime`: for coprime positive m, n, abundancy(m·n) = abundancy(m)·abundancy(n). The σ-multiplicativity `isMultiplicative_sigma.map_mul_of_coprime` rewrites σ₁(m·n) = σ₁(m)·σ₁(n); push_cast moves to ℚ and field_simp clears denominators.",
+      "mathContext": "$\\frac{\\sigma_1(mn)}{mn} = \\frac{\\sigma_1(m)}{m}\\cdot\\frac{\\sigma_1(n)}{n}.$"
+    },
+    {
+      "id": "lower-bound",
+      "title": "σ₁(n) > n and abundancy > 1",
+      "startLine": 58,
+      "endLine": 79,
+      "summary": "self_lt_sigma_one: n < σ₁(n) for n ≥ 2, via Finset.sum_lt_sum_of_subset comparing the single-term sum over {n} with the full divisor sum (1 is an extra positive divisor). one_lt_abundancy then divides by n > 0 to get abundancy n > 1.",
+      "mathContext": "$1, n \\in \\mathrm{divisors}(n),\\ 1 \\ne n \\Rightarrow \\sigma_1(n) \\ge 1 + n > n.$"
+    },
+    {
+      "id": "abundant-multiple",
+      "title": "Coprime Multiple of a Perfect Number is Abundant",
+      "startLine": 81,
+      "endLine": 90,
+      "summary": "abundant_of_perfect_mul_coprime: if abundancy m = 2 (m perfect) and n ≥ 2 is coprime to m, then abundancy(m·n) > 2. Multiplicativity gives abundancy(m·n) = 2·abundancy n, and abundancy n > 1 finishes by linarith.",
+      "mathContext": "$\\mathrm{abundancy}(mn) = 2\\cdot\\mathrm{abundancy}(n) > 2.$"
+    }
+  ],
+  "references": [
+    {
+      "title": "Abundancy index",
+      "url": "https://en.wikipedia.org/wiki/Abundancy_index"
+    },
+    {
+      "title": "Divisor function (multiplicativity of σ)",
+      "url": "https://en.wikipedia.org/wiki/Divisor_function"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "sum-of-divisors",
+      "relationship": "Supplies the missing quotient-multiplicativity",
+      "description": "The SumOfDivisors entry defines the abundancy index and proves σ₁ multiplicative and perfect ⟺ abundancy = 2, but never that the rational quotient σ₁(n)/n is itself multiplicative; this entry provides exactly that, plus the abundant-multiple corollary."
+    },
+    {
+      "proofId": "perfect-numbers",
+      "relationship": "Why coprime multiples of perfect numbers are abundant",
+      "description": "Perfect numbers have abundancy 2; multiplicativity shows that scaling a perfect number by any coprime n ≥ 2 produces an abundant number, since abundancy n > 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "The abundancy index σ₁(n)/n is shown to be multiplicative on coprime arguments, the rational-quotient upgrade of the multiplicativity of σ₁. Two consequences are derived: abundancy n > 1 for every n ≥ 2, and a positive coprime multiple of a perfect number is abundant. Everything is machine-checked over ℚ with zero sorries, zero axioms, and no native_decide.",
+    "implications": "Multiplicativity of the abundancy index is the structural reason classification (deficient/perfect/abundant) interacts cleanly with coprime factorization, underpinning heuristics for perfect, abundant, and friendly numbers. The formalization closes a gap left by the SumOfDivisors entry — which had the definition and σ-multiplicativity but not the quotient version — and demonstrates the standard cast-and-clear-denominators technique for lifting a ℕ-valued multiplicative identity to its ℚ-valued quotient.",
+    "openQuestions": [
+      "Can abundancy be packaged as a bundled multiplicative function (an ArithmeticFunction-style structure over ℚ) so that multiplicativity composes with other multiplicative quotients automatically?",
+      "Does the same template give multiplicativity of related indices (e.g. the deficiency σ(n) - n normalized, or ψ(n)/n for the Dedekind psi function)?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
New verified gallery entry **sum-of-divisors-oq-05**: the **abundancy index** `abundancy(n) = σ₁(n)/n` is multiplicative on coprime arguments. The `SumOfDivisors` entry defines this index and proves `σ₁` multiplicative + `perfect ⟺ abundancy = 2`, but never records that the rational **quotient** `σ₁(n)/n` is multiplicative. This supplies it.

## Main results (`Proofs/SumOfDivisorsOQ05.lean`)
- `abundancy_mul_of_coprime` : `Coprime m n → abundancy (m*n) = abundancy m * abundancy n` (m,n > 0)
- `self_lt_sigma_one` : `2 ≤ n → n < σ₁(n)` (1 and n are distinct divisors)
- `one_lt_abundancy` : `2 ≤ n → 1 < abundancy n`
- `abundant_of_perfect_mul_coprime` : `abundancy m = 2 → 2 ≤ n → Coprime m n → 2 < abundancy (m*n)` — a coprime multiple of a perfect number is abundant

## Proof shape
Multiplicativity reduces to `isMultiplicative_sigma.map_mul_of_coprime` (σ₁(mn)=σ₁(m)σ₁(n)); `push_cast` to ℚ and `field_simp` clear denominators. The bound `σ₁(n) > n` uses `Finset.sum_lt_sum_of_subset` (the single-term sum over {n} is strictly below the full divisor sum because 1 is an extra positive divisor). The abundant-multiple corollary transports the perfect value 2 across the coprime factor.

## Distinctness
- Slug, gallery dir, and `SumOfDivisorsOQ05.lean` are all new (not on main; no competing PR).
- Self-contained over ℚ using Mathlib's `ArithmeticFunction.sigma`; the quotient-multiplicativity is genuinely absent from `SumOfDivisors.lean` (which has σ-multiplicativity and `perfect_iff_abundancy_two` only).

## Verification
- Built with `lake env lean Proofs/SumOfDivisorsOQ05.lean` — exit 0, no errors/warnings.
- **No `native_decide`.** `#print axioms` on the headline + corollary: `propext, Classical.choice, Quot.sound` only — **0 axioms, 0 sorries**.

## Status
**Outcome**: completed (verified, 0-axiom)

🤖 Generated by researcher-1