### PR TITLE
research(erdos-340-greedy-sidon-oq-01): greedyCount growth bracket C·N^(1/3) ≤ A(N) ≤ √N+⁴√N+2 (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1434,6 +1434,7 @@ import Proofs.Erdos338Problem
 import Proofs.Erdos339Aristotle
 import Proofs.Erdos339Problem
 import Proofs.Erdos33Problem
+import Proofs.Erdos340GreedyCountUpper
 import Proofs.Erdos340GreedyExtension
 import Proofs.Erdos340GreedyGrowth
 import Proofs.Erdos340GreedyRpowBound

--- a/proofs/Proofs/Erdos340GreedyCountUpper.lean
+++ b/proofs/Proofs/Erdos340GreedyCountUpper.lean
@@ -1,0 +1,100 @@
+/-
+# Erdős Problem #340: the growth bracket for the greedy Sidon sequence
+
+The greedy (Mian–Chowla) Sidon sequence `a₀ < a₁ < ⋯` is constructed, fully and
+axiom-free, in `Proofs.Erdos340GreedySidon`.  Its counting function
+
+  `greedyCount N = #{ k : aₖ ≤ N }`
+
+(`Proofs.Erdos340GreedyRpowBound`) already has a verified **lower** bound
+
+  `greedyCount_rpow_lower : ∃ C > 0, ∀ N > 0,  C · N^{1/3} ≤ greedyCount N`,
+
+coming from the cubic growth bound `aₙ ≤ 2(n+1)³`.
+
+This file supplies the matching **upper** bound.  The values counted by
+`greedyCount N` form a Sidon set contained in `{0,…,N}`, so the Erdős–Turán /
+Lindström bound `Erdos340.sidon_card_le_sqrt` (proved in
+`Proofs.Erdos340SidonErdosTuran` by optimising the window inequality of
+`Proofs.Erdos340GreedySidonOQ02`) applies verbatim:
+
+  `greedyCount_le_sqrt :  greedyCount N ≤ ⌊√N⌋ + ⌊⁴√N⌋ + 2.`
+
+Together these give the **growth bracket**
+
+  `C · N^{1/3} ≤ greedyCount N ≤ √N + ⁴√N + 2`,
+
+which is the precise quantitative location of the open problem: the lower bound
+has exponent `1/3`, the upper bound exponent `1/2`, and Erdős #340 asks whether
+the greedy sequence actually attains the upper exponent `N^{1/2−ε}`.  The
+`1/3`-vs-`1/2` gap is the open problem; both bookends are here verified and
+axiom-free.
+-/
+import Mathlib
+import Proofs.Erdos340GreedySidon
+import Proofs.Erdos340GreedyRpowBound
+import Proofs.Erdos340SidonErdosTuran
+
+namespace Erdos340
+
+open Finset
+
+/-- **Upper bound on the greedy Sidon counting function.**
+
+`greedyCount N ≤ ⌊√N⌋ + ⌊√⌊√N⌋⌋ + 2`.
+
+The greedy terms `≤ N` are the image, under the (injective) greedy sequence, of
+the index set counted by `greedyCount`; this image is a Sidon set contained in
+`{0,…,N}`, so the verified Erdős–Turán bound `sidon_card_le_sqrt` applies. -/
+theorem greedyCount_le_sqrt (N : ℕ) :
+    greedyCount N ≤ Nat.sqrt N + Nat.sqrt (Nat.sqrt N) + 2 := by
+  -- The index set counted by `greedyCount`, and its value image.
+  set F : Finset ℕ := (Finset.range (N + 1)).filter (fun k => greedySidonSeq k ≤ N) with hF
+  set B : Finset ℕ := F.image greedySidonSeq with hB
+  have hinj : Function.Injective greedySidonSeq := greedySidonSeq_strictMono.injective
+  -- `|B| = greedyCount N` because the greedy sequence is injective.
+  have hcardB : B.card = greedyCount N := by
+    rw [hB, Finset.card_image_of_injective _ hinj, greedyCount, hF]
+  -- `B` is Sidon: it is a subset of the (Sidon) image of `range (N+1)`.
+  have hsub : B ⊆ Finset.image greedySidonSeq (Finset.range (N + 1)) := by
+    rw [hB]
+    exact Finset.image_subset_image (Finset.filter_subset _ _)
+  have hBsidon : IsSidon B := (greedySidonSeq_isSidon N).subset hsub
+  -- Every counted value is `≤ N`.
+  have hBmem : ∀ b ∈ B, b ≤ N := by
+    intro b hb
+    rw [hB, Finset.mem_image] at hb
+    obtain ⟨k, hk, rfl⟩ := hb
+    rw [hF, Finset.mem_filter] at hk
+    exact hk.2
+  -- Apply the Erdős–Turán upper bound.
+  have h := sidon_card_le_sqrt B hBsidon N hBmem
+  rwa [hcardB] at h
+
+/-- **The Erdős #340 growth bracket (real form).**
+
+For the greedy/Mian–Chowla Sidon sequence the counting function satisfies
+
+  `C · N^{1/3} ≤ greedyCount N ≤ √N + ⁴√N + 2`
+
+for a fixed `C > 0` and all `N > 0`.  Both bookends are verified and axiom-free;
+the gap between the `1/3` and `1/2` exponents is exactly the content of the open
+problem Erdős #340. -/
+theorem greedyCount_bracket :
+    (∃ C : ℝ, 0 < C ∧ ∀ N : ℕ, 0 < N → C * (N : ℝ) ^ ((1 : ℝ) / 3) ≤ (greedyCount N : ℝ)) ∧
+      (∀ N : ℕ, (greedyCount N : ℝ) ≤ Real.sqrt N + Real.sqrt (Real.sqrt N) + 2) := by
+  refine ⟨greedyCount_rpow_lower, fun N => ?_⟩
+  -- Lift the integer bound `⌊√N⌋ + ⌊⁴√N⌋ + 2` to the real bound `√N + ⁴√N + 2`.
+  have hnat := greedyCount_le_sqrt N
+  have h1 : (Nat.sqrt N : ℝ) ≤ Real.sqrt N :=
+    (Real.le_sqrt (by positivity) (by positivity)).mpr (by exact_mod_cast Nat.sqrt_le' N)
+  have h2 : (Nat.sqrt (Nat.sqrt N) : ℝ) ≤ Real.sqrt (Real.sqrt N) :=
+    (Real.le_sqrt (by positivity) (Real.sqrt_nonneg _)).mpr (by
+      have h := (by exact_mod_cast Nat.sqrt_le' (Nat.sqrt N) :
+        (Nat.sqrt (Nat.sqrt N) : ℝ) ^ 2 ≤ (Nat.sqrt N : ℝ))
+      linarith [h1])
+  have hcast : (greedyCount N : ℝ) ≤ (Nat.sqrt N : ℝ) + (Nat.sqrt (Nat.sqrt N) : ℝ) + 2 := by
+    exact_mod_cast hnat
+  linarith
+
+end Erdos340

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-01.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-01.json
@@ -13,7 +13,9 @@
     ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "`greedyCount_le_sqrt` / `greedyCount_bracket` (Erdos340GreedyCountUpper.lean, verified 0-axiom): the greedy Sidon counting function is bracketed `C·N^(1/3) ≤ greedyCount N ≤ √N + ⁴√N + 2`. Upper bound is the Erdős–Turán/Lindström bound `sidon_card_le_sqrt` applied to the (Sidon, ⊆[0,N]) value image of the counted indices; lower bound is the existing `greedyCount_rpow_lower`. The 1/3-vs-1/2 exponent gap between the two bookends IS Erdős #340."
+    ],
     "open": [],
     "goal": ""
   },
@@ -31,7 +33,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (verified, 0-axiom): the known direction of Erdős #340 now carries BOTH its discrete (greedy_count_ge) and analytic-density (greedy_count_omega_cubrt: ∃C>0, C·N^(1/3) ≤ A(N), uniform C) phrasings. Remaining: two parent axioms (def-bridge greedy_sidon_lower_bound; Erdős–Turán upper bound) and the OPEN 1/3→1/2 exponent improvement.",
+    "progressSummary": "PROGRESS (verified, 0-axiom): both bookends of the Erdős #340 growth bracket are now formalized — the analytic lower bound `greedyCount_rpow_lower` (∃C>0, C·N^(1/3) ≤ A(N)) and the Erdős–Turán upper bound `greedyCount_le_sqrt` (A(N) ≤ √N + ⁴√N + 2), combined in `greedyCount_bracket`. The upper bound follows from the window-inequality optimisation `sidon_card_le_sqrt` (Erdos340SidonErdosTuran.lean). Remaining OPEN: the 1/3→1/2 exponent improvement (the open problem itself) and the parent def-bridge axiom `greedy_sidon_lower_bound`.",
     "builtItems": [
       "Turnkey BUILD-PENDING draft: research/problems/erdos-340-greedy-sidon-oq-01/construction-draft.lean — forbidden set + forbidden_card_le (≤|A|^3) + forbidden_mono with real proofs; crux/existence/gSet recursion/covering/inversion/parent-axiom-rebuild as structured statements with sorry+precise proof comments. Only mem_forbidden_of_not_sidon_insert is genuinely technical (Aristotle target); rest is induction+omega+card arithmetic.",
       "PR #24965 (research label): corrected parent inline sketch O(n^2)→O(n^3) with covering argument + the 1/3-vs-1/2 OPEN-conjecture distinction. Comment-only, build-neutral.",
@@ -90,11 +92,12 @@
     "mathlib": []
   },
   "started": "2026-06-16T04:40:01.684Z",
-  "lastUpdate": "2026-06-19",
+  "lastUpdate": "2026-06-20",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     "proofs/Proofs/Erdos340GreedyGrowth.lean",
-    "proofs/Proofs/Erdos340GreedySidon.lean"
+    "proofs/Proofs/Erdos340GreedySidon.lean",
+    "proofs/Proofs/Erdos340GreedyCountUpper.lean"
   ]
 }


### PR DESCRIPTION
## Summary

Completes the **growth bracket** for the greedy (Mian–Chowla) Sidon sequence in Erdős #340, supplying the previously-missing **upper** bookend on the counting function `greedyCount N`.

New file `proofs/Proofs/Erdos340GreedyCountUpper.lean`:

- **`greedyCount_le_sqrt`** — `greedyCount N ≤ ⌊√N⌋ + ⌊⁴√N⌋ + 2`. The greedy terms `≤ N` are the image, under the injective greedy sequence, of the indices counted by `greedyCount`; that image is a Sidon set contained in `{0,…,N}`, so the Erdős–Turán/Lindström bound `Erdos340.sidon_card_le_sqrt` (from `Erdos340SidonErdosTuran.lean`, #27028) applies verbatim.
- **`greedyCount_bracket`** — the real-form bracket
  ```
  C · N^(1/3) ≤ greedyCount N ≤ √N + ⁴√N + 2
  ```
  combining the existing analytic lower bound `greedyCount_rpow_lower` (#27020) with the new upper bound.

## Why it matters

The two bookends pin down the exact location of the open problem: the verified **lower** bound has exponent `1/3`, the verified **upper** bound exponent `1/2`, and Erdős #340 asks whether the greedy sequence attains `N^(1/2−ε)`. The `1/3`-vs-`1/2` gap *is* the open problem; both bookends are now formalized and axiom-free.

## Verification

Both theorems compiled with `lake env lean` and `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` — **verified, 0-axiom** (no `sorryAx`, no `Lean.ofReduceBool`).

Also updates `src/data/research/problems/erdos-340-greedy-sidon-oq-01.json` (knownResults, progress summary, leanFiles) and the `Proofs.lean` aggregator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)