### PR TITLE
research(pell-equation-oq-06): negative Pell x²−2y²=−1 has infinitely many ℤ solutions (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2830,6 +2830,7 @@ import Proofs.PascalsHexagonOQ02
 import Proofs.PascalsHexagonOQ03
 import Proofs.PellEquation
 import Proofs.PellEquationOQ01
+import Proofs.PellEquationOQ06
 import Proofs.PentagonalNumberTheoremOQ01
 import Proofs.PerfectNumbers
 import Proofs.PerfectNumbersOQ03

--- a/proofs/Proofs/PellEquationOQ06.lean
+++ b/proofs/Proofs/PellEquationOQ06.lean
@@ -1,0 +1,146 @@
+/-
+Pell's Equation OQ-06: The Negative Pell Equation x² − 2y² = −1
+
+The classical Pell equation x² − Dy² = 1 (the norm-one equation for ℚ(√D)) is
+the rank-1 case of Dirichlet's unit theorem and always has infinitely many
+integer solutions for non-square D > 0. The *negative* Pell equation
+
+    x² − D y² = −1
+
+is more delicate: it is solvable only for special D (e.g. D = 2, 5, 10, …, those
+whose continued-fraction period is odd), and Mathlib's `Pell.Solution₁ d` type is
+restricted to the norm `+1` equation — the norm `−1` case is listed as future work
+in `Mathlib/NumberTheory/Pell.lean`. This entry treats the smallest interesting
+instance D = 2 from scratch.
+
+The equation x² − 2y² = −1 has the fundamental solution (1, 1), and the
+automorphism of the form induced by the fundamental *unit* 3 + 2√2 of norm +1,
+
+    (x, y) ↦ (3x + 4y, 2x + 3y),
+
+preserves the value x² − 2y² exactly (it is multiplication by 3 + 2√2 in
+ℤ[√2]). Iterating it from (1, 1) produces the strictly increasing chain
+
+    (1, 1) → (7, 5) → (41, 29) → (239, 169) → …
+
+of solutions to x² − 2y² = −1. Distinctness (forced by strict monotonicity of the
+first coordinate) gives **infinitely many integer solutions** — the analogue, for
+the norm `−1` form, of the standard Pell-chain argument.
+
+Main results:
+  • `negPell_step`            — the map preserves the value x² − 2y² = −1 (exact ring identity).
+  • `negPellSeq`              — the explicit solution chain from (1, 1).
+  • `negPellSeq_norm`         — every term satisfies x² − 2y² = −1.
+  • `negPellSeq_fst_strictMono` — the first coordinates are strictly increasing.
+  • `negPell_solutions_infinite` — the integer solution set of x² − 2y² = −1 is infinite.
+
+All proofs are `sorry`-free and axiom-free (no `native_decide`).
+
+References:
+- https://erdosproblems.com / Dirichlet's unit theorem
+- Parent entry: `pell-equation` (the norm `+1`, real-quadratic special case).
+- Mathlib `Pell.Solution₁` covers only the norm `+1` equation; norm `−1` is future work.
+-/
+
+import Mathlib
+
+namespace PellEquationOQ06
+
+/-
+## The norm form and its automorphism
+-/
+
+/-- **Step map preserves the negative-Pell form.** The substitution
+    `(x, y) ↦ (3x + 4y, 2x + 3y)` (multiplication by the fundamental unit
+    `3 + 2√2` of ℤ[√2]) keeps the value of `x² − 2y²` unchanged; in particular
+    it sends solutions of `x² − 2y² = −1` to solutions. -/
+theorem negPell_step (x y : ℤ) (h : x ^ 2 - 2 * y ^ 2 = -1) :
+    (3 * x + 4 * y) ^ 2 - 2 * (2 * x + 3 * y) ^ 2 = -1 := by
+  have key : (3 * x + 4 * y) ^ 2 - 2 * (2 * x + 3 * y) ^ 2 = x ^ 2 - 2 * y ^ 2 := by ring
+  rw [key, h]
+
+/-- The explicit chain of solutions to `x² − 2y² = −1`, starting from the
+    fundamental solution `(1, 1)` and iterating the form automorphism. -/
+def negPellSeq : ℕ → ℤ × ℤ
+  | 0 => (1, 1)
+  | (n + 1) => (3 * (negPellSeq n).1 + 4 * (negPellSeq n).2,
+                2 * (negPellSeq n).1 + 3 * (negPellSeq n).2)
+
+@[simp] theorem negPellSeq_zero : negPellSeq 0 = (1, 1) := rfl
+
+theorem negPellSeq_succ (n : ℕ) :
+    negPellSeq (n + 1) =
+      (3 * (negPellSeq n).1 + 4 * (negPellSeq n).2,
+       2 * (negPellSeq n).1 + 3 * (negPellSeq n).2) := rfl
+
+/-- Both coordinates of the chain are positive (in fact `≥ 1`). -/
+theorem negPellSeq_pos : ∀ n, 1 ≤ (negPellSeq n).1 ∧ 1 ≤ (negPellSeq n).2
+  | 0 => by constructor <;> norm_num
+  | (n + 1) => by
+    obtain ⟨hx, hy⟩ := negPellSeq_pos n
+    rw [negPellSeq_succ]
+    constructor <;> dsimp <;> linarith
+
+/-- **Every term of the chain solves the negative Pell equation** `x² − 2y² = −1`. -/
+theorem negPellSeq_norm : ∀ n, (negPellSeq n).1 ^ 2 - 2 * (negPellSeq n).2 ^ 2 = -1
+  | 0 => by norm_num
+  | (n + 1) => by
+    have ih := negPellSeq_norm n
+    rw [negPellSeq_succ]
+    dsimp
+    have key :
+        (3 * (negPellSeq n).1 + 4 * (negPellSeq n).2) ^ 2
+          - 2 * (2 * (negPellSeq n).1 + 3 * (negPellSeq n).2) ^ 2
+        = (negPellSeq n).1 ^ 2 - 2 * (negPellSeq n).2 ^ 2 := by ring
+    rw [key, ih]
+
+/-- The first coordinates are strictly increasing along the chain. -/
+theorem negPellSeq_fst_strictMono : StrictMono (fun n => (negPellSeq n).1) := by
+  apply strictMono_nat_of_lt_succ
+  intro n
+  obtain ⟨hx, hy⟩ := negPellSeq_pos n
+  rw [negPellSeq_succ]
+  dsimp
+  linarith
+
+/-- The chain `n ↦ negPellSeq n` is injective (strict monotonicity of the first
+    coordinate forces distinct terms). -/
+theorem negPellSeq_injective : Function.Injective negPellSeq := by
+  intro a b hab
+  exact negPellSeq_fst_strictMono.injective (congrArg Prod.fst hab)
+
+/-
+## Infinitely many solutions
+-/
+
+/-- **The negative Pell equation `x² − 2y² = −1` has infinitely many integer
+    solutions.** The chain `(1,1) → (7,5) → (41,29) → …` consists of pairwise
+    distinct solutions, so the solution set is infinite. This is the norm `−1`
+    analogue of the standard Pell-chain argument; Mathlib's `Pell.Solution₁`
+    machinery covers only the norm `+1` equation. -/
+theorem negPell_solutions_infinite :
+    {p : ℤ × ℤ | p.1 ^ 2 - 2 * p.2 ^ 2 = -1}.Infinite := by
+  apply Set.infinite_of_injective_forall_mem
+    (f := negPellSeq) negPellSeq_injective
+  intro n
+  exact negPellSeq_norm n
+
+/-
+## Explicit small solutions (sanity checks)
+-/
+
+example : negPellSeq 0 = (1, 1) := rfl
+example : negPellSeq 1 = (7, 5) := rfl
+example : negPellSeq 2 = (41, 29) := rfl
+example : negPellSeq 3 = (239, 169) := rfl
+
+example : (1 : ℤ) ^ 2 - 2 * 1 ^ 2 = -1 := by norm_num
+example : (7 : ℤ) ^ 2 - 2 * 5 ^ 2 = -1 := by norm_num
+example : (41 : ℤ) ^ 2 - 2 * 29 ^ 2 = -1 := by norm_num
+
+#check @negPell_step
+#check @negPellSeq_norm
+#check @negPellSeq_fst_strictMono
+#check @negPell_solutions_infinite
+
+end PellEquationOQ06

--- a/src/data/research/problems/pell-equation-oq-06.json
+++ b/src/data/research/problems/pell-equation-oq-06.json
@@ -1,0 +1,84 @@
+{
+  "slug": "pell-equation-oq-06",
+  "title": "The Negative Pell Equation x² − 2y² = −1 Has Infinitely Many Solutions",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "started": "2026-06-20T07:30:00Z",
+  "lastUpdate": "2026-06-20T07:30:00Z",
+  "tags": [
+    "number-theory",
+    "pell-equation",
+    "negative-pell",
+    "diophantine",
+    "norm-form",
+    "seeker-selected",
+    "research"
+  ],
+  "tractability": 8,
+  "significance": 5,
+  "problemStatement": {
+    "formal": "Show that $x^2 - 2y^2 = -1$ has infinitely many solutions $(x,y)\\in\\mathbb{Z}^2$. The map $(x,y)\\mapsto(3x+4y,\\,2x+3y)$ — multiplication by the fundamental unit $3+2\\sqrt2$ of $\\mathbb{Z}[\\sqrt2]$ — preserves $x^2-2y^2$; iterating it from $(1,1)$ gives the strictly increasing chain $(1,1)\\to(7,5)\\to(41,29)\\to(239,169)\\to\\cdots$ of solutions.",
+    "plain": "The negative Pell equation x²−2y²=−1 (the norm −1 equation for ℚ(√2)) is solvable, and once one solution exists there are infinitely many: applying the automorphism of the form induced by the fundamental unit of ℤ[√2] generates an unbounded strictly increasing chain of distinct solutions. This is the norm −1 analogue of the classical Pell-chain argument.",
+    "whyMatters": [
+      "Mathlib's Pell.Solution₁ type is restricted to the norm +1 equation x²−Dy²=1; the norm −1 case is listed as future work in Mathlib/NumberTheory/Pell.lean. This entry treats the smallest solvable instance D=2 from scratch.",
+      "The negative Pell equation is solvable only for special D (continued-fraction period odd), making it a more delicate object than the always-solvable positive case — a clean example of a norm equation whose solvability is non-trivial.",
+      "Demonstrates the unit-orbit mechanism (fundamental unit of norm +1 acting on a norm −1 solution) that underlies the infinitude of solutions to general Pell-type norm equations."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "negPell_step: the substitution (x,y)↦(3x+4y,2x+3y) preserves the value x²−2y² exactly (ring identity), hence maps solutions of x²−2y²=−1 to solutions.",
+      "negPellSeq: the explicit solution chain from (1,1); negPellSeq_norm shows every term satisfies x²−2y²=−1.",
+      "negPellSeq_fst_strictMono: the first coordinates are strictly increasing, hence the chain n↦negPellSeq n is injective.",
+      "negPell_solutions_infinite: the integer solution set {(x,y) : x²−2y²=−1} is Infinite (via Set.infinite_of_injective_forall_mem). Axiom-free, no native_decide."
+    ],
+    "open": [
+      "General D: characterize exactly which D admit x²−Dy²=−1 (odd continued-fraction period of √D); formalize the connection to the fundamental unit having norm −1.",
+      "A Mathlib Solution₋₁ type analogous to Pell.Solution₁ for the norm −1 equation."
+    ],
+    "goal": "Formalize, axiom-free, that the negative Pell equation x²−2y²=−1 has infinitely many integer solutions via the fundamental-unit orbit, filling the gap left by Mathlib's norm +1-only Pell machinery."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-20T07:30:00Z",
+    "iteration": 1,
+    "focus": "ACT: shipped Proofs/PellEquationOQ06.lean — the full negative-Pell infinitude proof (5 main theorems, axiom-free, sorry-free).",
+    "blockers": [],
+    "nextAction": "Optional: generalize to other solvable D (e.g. D=5) or package a Solution₋₁ abstraction. Core D=2 result is complete and verified.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 ACT (researcher-3, 2026-06-20): Built Proofs/PellEquationOQ06.lean from scratch — a self-contained, axiom-free proof that x²−2y²=−1 has infinitely many integer solutions. Strategy mirrors PellEquationOQ05's distinctness⟹infinite pattern but in the elementary ℤ setting: (1) negPell_step proves the form automorphism (x,y)↦(3x+4y,2x+3y) [mult by 3+2√2] preserves x²−2y² by a one-line ring identity; (2) negPellSeq is the explicit chain from (1,1); (3) negPellSeq_norm (induction + ring) shows every term solves the equation; (4) negPellSeq_pos (induction) gives both coords ≥1, feeding negPellSeq_fst_strictMono (strictMono_nat_of_lt_succ); (5) injectivity from StrictMono.injective on first coordinate; (6) negPell_solutions_infinite via Set.infinite_of_injective_forall_mem. Verified small terms (1,1)→(7,5)→(41,29)→(239,169) by rfl. No native_decide → 0 axioms. Gap filled: Mathlib's Pell.Solution₁ is norm +1 only; negative Pell is future work upstream."
+  },
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://erdosproblems.com",
+      "https://en.wikipedia.org/wiki/Pell%27s_equation#The_negative_Pell_equation"
+    ],
+    "mathlib": [
+      "Pell.Solution₁ (Mathlib/NumberTheory/Pell.lean) — norm +1 only; norm −1 is future work",
+      "Set.infinite_of_injective_forall_mem",
+      "strictMono_nat_of_lt_succ"
+    ]
+  },
+  "relatedProofs": [
+    "pell-equation",
+    "pell-equation-oq-01"
+  ],
+  "leanFiles": [
+    {
+      "path": "proofs/Proofs/PellEquationOQ06.lean",
+      "status": "verified",
+      "axiomCount": 0,
+      "sorryCount": 0
+    }
+  ],
+  "significanceNote": "Norm −1 analogue of the classical Pell chain; fills a Mathlib gap (Solution₁ covers only norm +1)."
+}


### PR DESCRIPTION
## Summary

Formalizes that the **negative Pell equation** $x^2 - 2y^2 = -1$ has **infinitely many integer solutions** — a genuine gap in Mathlib, whose `Pell.Solution₁` type covers only the norm $+1$ equation (`Mathlib/NumberTheory/Pell.lean` lists norm $-1$ as future work).

## Mathematical content

The fundamental unit $3 + 2\sqrt2$ of $\mathbb{Z}[\sqrt2]$ (norm $+1$) induces the form automorphism
$$(x,y) \mapsto (3x + 4y,\ 2x + 3y),$$
which preserves $x^2 - 2y^2$ **exactly** (one-line ring identity). Iterating it from the fundamental solution $(1,1)$ produces the strictly increasing chain
$$(1,1) \to (7,5) \to (41,29) \to (239,169) \to \cdots$$
of solutions to $x^2 - 2y^2 = -1$. Strict monotonicity of the first coordinate forces the terms to be pairwise distinct, so the solution set is infinite.

## Theorems (all `sorry`-free, axiom-free)

- `negPell_step` — the map preserves the value $x^2-2y^2$, hence sends solutions to solutions.
- `negPellSeq` / `negPellSeq_norm` — the explicit chain; every term satisfies $x^2-2y^2=-1$ (induction + ring).
- `negPellSeq_fst_strictMono` — first coordinates strictly increasing ⟹ chain injective.
- `negPell_solutions_infinite` — `{p : ℤ × ℤ | p.1^2 - 2·p.2^2 = -1}.Infinite` via `Set.infinite_of_injective_forall_mem`.

## Verification

`#print axioms negPell_solutions_infinite` → `[propext, Classical.choice, Quot.sound]` (foundational only — **no `native_decide`, no `sorryAx`**). Type-checked against the pinned Mathlib via `lake env lean`.

This is the norm $-1$ analogue of the standard Pell-chain argument and the sibling of the cubic-norm entry `pell-equation-oq-05`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)