### PR TITLE
research(triangular-reciprocals-oq-04): tetrahedral reciprocals sum to 3/2 — depth-2 telescoping (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3204,6 +3204,7 @@ import Proofs.TriangularReciprocalGeneralized
 import Proofs.TriangularReciprocalsFigurate
 import Proofs.TriangularReciprocalsOQ02
 import Proofs.TriangularReciprocalsOQ02Aristotle
+import Proofs.TriangularReciprocalsOQ04
 import Proofs.TuranEdgeBound
 import Proofs.TwinPrimes
 import Proofs.TwinPrimesSpecialOQ01

--- a/proofs/Proofs/TriangularReciprocalsOQ04.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ04.lean
@@ -1,0 +1,149 @@
+/-
+  Tetrahedral Reciprocals — Depth-2 Telescoping
+
+  Result:  ∑_{n=1}^∞ 1/Tet_n = 3/2,  where  Tet_n = n(n+1)(n+2)/6  is the n-th
+  tetrahedral number.  Equivalently, with the index shifted to n : ℕ (running term
+  being n+1, n+2, n+3),
+
+      ∑_{n=0}^∞ 6/((n+1)(n+2)(n+3)) = 3/2.
+
+  This is the depth-2 analogue of the classical depth-1 triangular-reciprocal sum
+  ∑ 2/(n(n+1)) = 2  (`TriangularNumberReciprocals.lean`).  Where the depth-1 sum
+  telescopes via 2/(n(n+1)) = 2/n - 2/(n+1), the tetrahedral sum telescopes via the
+  depth-2 partial fraction
+
+      6/((n+1)(n+2)(n+3)) = 3/((n+1)(n+2)) - 3/((n+2)(n+3)),
+
+  i.e. f(n) = g(n) - g(n+1) with g(n) = 3/((n+1)(n+2)).  Hence the partial sum is
+
+      ∑_{i<N} f(i) = g(0) - g(N) = 3/2 - 3/((N+1)(N+2))  →  3/2.
+
+  Proof outline:
+    1. tetrahedral_partial_fraction : the depth-2 telescoping identity (field_simp/ring).
+    2. partial_sum_closed_form      : ∑_{i<N} f i = 3/2 - 3/((N+1)(N+2))  (induction on N).
+    3. tail_to_zero                 : 3/((N+1)(N+2)) → 0  (squeeze by 3/(N+1)).
+    4. tetrahedral_reciprocals      : HasSum f (3/2)  via hasSum_iff_tendsto_nat_of_nonneg.
+
+  No axioms, no sorries.
+-/
+
+import Mathlib
+
+set_option linter.unusedVariables false
+
+open Finset BigOperators Filter Topology Real
+
+namespace TriangularReciprocalsOQ04
+
+/-- The shifted summand 6/((n+1)(n+2)(n+3)) = 1/Tet_{n+1}. -/
+noncomputable def tetReciprocal (n : ℕ) : ℝ :=
+  6 / (((n : ℝ) + 1) * ((n : ℝ) + 2) * ((n : ℝ) + 3))
+
+/-- The telescoping antiderivative g(n) = 3/((n+1)(n+2)). -/
+noncomputable def gTele (n : ℕ) : ℝ :=
+  3 / (((n : ℝ) + 1) * ((n : ℝ) + 2))
+
+-- ═══════════════════════════════════════════════════
+-- Lemma 1: Depth-2 telescoping partial fraction
+-- ═══════════════════════════════════════════════════
+
+/-- 6/((n+1)(n+2)(n+3)) = 3/((n+1)(n+2)) - 3/((n+2)(n+3)) = g(n) - g(n+1). -/
+theorem tetrahedral_partial_fraction (n : ℕ) :
+    tetReciprocal n = gTele n - gTele (n + 1) := by
+  unfold tetReciprocal gTele
+  have h1 : ((n : ℝ) + 1) ≠ 0 := by positivity
+  have h2 : ((n : ℝ) + 2) ≠ 0 := by positivity
+  have h3 : ((n : ℝ) + 3) ≠ 0 := by positivity
+  have hcast : (((n : ℝ) + 1) + 1) = (n : ℝ) + 2 := by ring
+  have hcast2 : (((n : ℝ) + 1) + 2) = (n : ℝ) + 3 := by ring
+  push_cast
+  rw [hcast, hcast2]
+  field_simp
+  ring
+
+-- ═══════════════════════════════════════════════════
+-- Lemma 2: Closed form for the partial sum
+-- ═══════════════════════════════════════════════════
+
+/-- ∑_{i<N} 6/((i+1)(i+2)(i+3)) = 3/2 - 3/((N+1)(N+2)). -/
+theorem partial_sum_closed_form (N : ℕ) :
+    ∑ i ∈ Finset.range N, tetReciprocal i =
+      3 / 2 - 3 / (((N : ℝ) + 1) * ((N : ℝ) + 2)) := by
+  induction N with
+  | zero => simp [tetReciprocal]
+  | succ M ih =>
+    rw [Finset.sum_range_succ, ih]
+    -- After adding the (M)-th term, telescoping collapses to the M+1 closed form.
+    unfold tetReciprocal
+    have h1 : ((M : ℝ) + 1) ≠ 0 := by positivity
+    have h2 : ((M : ℝ) + 2) ≠ 0 := by positivity
+    have h3 : ((M : ℝ) + 3) ≠ 0 := by positivity
+    push_cast
+    field_simp
+    ring
+
+-- ═══════════════════════════════════════════════════
+-- Lemma 3: Tail 3/((N+1)(N+2)) → 0
+-- ═══════════════════════════════════════════════════
+
+/-- 3/((N+1)(N+2)) → 0 as N → ∞ (squeezed below 3/(N+1)). -/
+theorem tail_to_zero :
+    Tendsto (fun N : ℕ => 3 / (((N : ℝ) + 1) * ((N : ℝ) + 2)))
+      atTop (𝓝 0) := by
+  have h0 : Tendsto (fun N : ℕ => (1 : ℝ) / ((N : ℝ) + 1)) atTop (𝓝 0) :=
+    tendsto_one_div_add_atTop_nhds_zero_nat
+  have hg : Tendsto (fun N : ℕ => 3 * ((1 : ℝ) / ((N : ℝ) + 1))) atTop (𝓝 (3 * 0)) :=
+    h0.const_mul 3
+  rw [mul_zero] at hg
+  apply squeeze_zero (g := fun N : ℕ => 3 * ((1 : ℝ) / ((N : ℝ) + 1)))
+  · intro N; positivity
+  · intro N
+    have hb : ((N : ℝ) + 1) ≤ ((N : ℝ) + 1) * ((N : ℝ) + 2) := by
+      nlinarith [Nat.cast_nonneg (α := ℝ) N]
+    rw [mul_one_div]
+    gcongr
+  · exact hg
+
+-- ═══════════════════════════════════════════════════
+-- Main Theorem
+-- ═══════════════════════════════════════════════════
+
+/-- **Tetrahedral Reciprocals.**  The reciprocals of the tetrahedral numbers sum to 3/2:
+
+      ∑_{n=0}^∞ 6/((n+1)(n+2)(n+3)) = 3/2.
+
+    Since 1/Tet_m = 6/(m(m+1)(m+2)), with the running tetrahedral index m = n+1 this is
+    exactly ∑_{m=1}^∞ 1/Tet_m = 3/2. -/
+theorem tetrahedral_reciprocals : HasSum tetReciprocal (3 / 2 : ℝ) := by
+  have h_nonneg : ∀ n : ℕ, 0 ≤ tetReciprocal n := by
+    intro n; unfold tetReciprocal; positivity
+  rw [hasSum_iff_tendsto_nat_of_nonneg h_nonneg]
+  -- Partial sums equal 3/2 - 3/((N+1)(N+2)).
+  rw [show (fun N : ℕ => ∑ i ∈ Finset.range N, tetReciprocal i) =
+        fun N : ℕ => 3 / 2 - 3 / (((N : ℝ) + 1) * ((N : ℝ) + 2)) from
+      funext partial_sum_closed_form]
+  -- 3/2 - (3/((N+1)(N+2))) → 3/2 - 0 = 3/2.
+  have h_lim : Tendsto
+      (fun N : ℕ => (3 / 2 : ℝ) - 3 / (((N : ℝ) + 1) * ((N : ℝ) + 2)))
+      atTop (𝓝 ((3 / 2 : ℝ) - 0)) :=
+    tendsto_const_nhds.sub tail_to_zero
+  rw [sub_zero] at h_lim
+  exact h_lim
+
+/-- tsum version of the tetrahedral reciprocal sum. -/
+theorem tetrahedral_reciprocals_tsum :
+    ∑' n : ℕ, tetReciprocal n = (3 / 2 : ℝ) :=
+  tetrahedral_reciprocals.tsum_eq
+
+-- ═══════════════════════════════════════════════════
+-- Sanity checks of the closed form
+-- ═══════════════════════════════════════════════════
+
+/-- First term (n = 0): 6/(1·2·3) = 1 = 1/Tet_1. -/
+example : tetReciprocal 0 = 1 := by unfold tetReciprocal; norm_num
+
+/-- Partial sum of the first two terms is 5/4. -/
+example : ∑ i ∈ Finset.range 2, tetReciprocal i = 5 / 4 := by
+  rw [partial_sum_closed_form]; norm_num
+
+end TriangularReciprocalsOQ04

--- a/src/data/proofs/triangular-reciprocals-oq-04/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-04/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "triangular-reciprocals-oq-04",
+  "title": "Reciprocals of Tetrahedral Numbers Sum to 3/2",
+  "slug": "triangular-reciprocals-oq-04",
+  "description": "The reciprocals of the tetrahedral numbers sum to 3/2: ∑_{n=1}^∞ 1/Tet_n = 3/2, where Tet_n = n(n+1)(n+2)/6. Equivalently ∑_{n=0}^∞ 6/((n+1)(n+2)(n+3)) = 3/2, proved by depth-2 telescoping.",
+  "meta": {
+    "author": "Classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Tetrahedral_number",
+    "date": "Classical",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "series",
+      "figurate-numbers",
+      "telescoping",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/TriangularReciprocalsOQ04.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions.",
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_iff_tendsto_nat_of_nonneg",
+        "description": "A nonnegative series HasSum its limit iff the partial sums converge",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Order"
+      },
+      {
+        "theorem": "tendsto_one_div_add_atTop_nhds_zero_nat",
+        "description": "1/(n+1) → 0 as n → ∞",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      },
+      {
+        "theorem": "squeeze_zero",
+        "description": "Squeeze theorem for convergence to zero",
+        "module": "Mathlib.Topology.Order.Bornology"
+      }
+    ],
+    "originalContributions": [
+      "Tetrahedral reciprocals ∑ 6/((n+1)(n+2)(n+3)) = 3/2 via depth-2 telescoping",
+      "Depth-2 partial fraction 6/((n+1)(n+2)(n+3)) = g(n) - g(n+1) with g(n) = 3/((n+1)(n+2))",
+      "Closed-form partial sum 3/2 - 3/((N+1)(N+2)) by induction",
+      "tsum form of the tetrahedral reciprocal sum"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 149,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The tetrahedral numbers Tet_n = n(n+1)(n+2)/6 = C(n+2,3) count points in a triangular pyramid and are the third column of Pascal's triangle (figurate numbers of dimension 3). They were studied by the Pythagoreans and appear in Nicomachus's *Introduction to Arithmetic* (c. 100 CE). The reciprocal sum ∑ 1/Tet_n = 3/2 is the depth-2 analogue of the classical triangular-reciprocal identity ∑ 2/(n(n+1)) = 2 (Leibniz, 1673, via telescoping). The general fact that ∑_{n≥1} 1/C(n+k-1,k) = k/(k-1) for k ≥ 2 was known to Leibniz and the Bernoullis; the case k = 3 gives 3/2. The telescoping technique was systematized by Johann Bernoulli around 1702.",
+    "problemStatement": "**Tetrahedral Reciprocals**:\n\n$$\\sum_{n=1}^{\\infty} \\frac{1}{\\mathrm{Tet}_n} = \\sum_{n=1}^{\\infty} \\frac{6}{n(n+1)(n+2)} = \\frac{3}{2}, \\qquad \\mathrm{Tet}_n = \\frac{n(n+1)(n+2)}{6}.$$",
+    "text": "The reciprocals of the tetrahedral numbers sum to 3/2: ∑_{n=1}^∞ 1/Tet_n = 3/2, where Tet_n = n(n+1)(n+2)/6.",
+    "proofStrategy": "Shift the index so the running summand is f(n) = 6/((n+1)(n+2)(n+3)) = 1/Tet_{n+1}. Use the depth-2 partial fraction f(n) = 3/((n+1)(n+2)) - 3/((n+2)(n+3)) = g(n) - g(n+1) with g(n) = 3/((n+1)(n+2)). The partial sum telescopes to g(0) - g(N) = 3/2 - 3/((N+1)(N+2)). Since 3/((N+1)(N+2)) → 0 (squeezed below 3/(N+1)), the series HasSum 3/2 via hasSum_iff_tendsto_nat_of_nonneg.",
+    "keyInsights": [
+      "1/Tet_n = 6/(n(n+1)(n+2)) because Tet_n = n(n+1)(n+2)/6 — the factor 6 is exactly what makes the partial fraction telescope cleanly.",
+      "The depth-2 telescoping g(n) - g(n+1) with g(n) = 3/((n+1)(n+2)) generalizes the depth-1 triangular case g(n) = 2/(n+1); the antiderivative is one figurate dimension lower than the summand.",
+      "The numerator 3 in g comes from 6/2: the partial-fraction coefficient for a product of three consecutive integers is half the leading numerator, mirroring the 1/2 in 1/(n(n+1)(n+2)) = (1/2)[1/(n(n+1)) - 1/((n+1)(n+2))].",
+      "The closed-form partial sum 3/2 - 3/((N+1)(N+2)) makes the limit transparent and gives exact finite truncation error, e.g. S_2 = 5/4, S_∞ = 3/2.",
+      "Unlike the alternating triangular reciprocals (oq-03, value 4·ln 2 - 2, transcendental and axiom-dependent), this sum is rational (3/2) and fully verified with zero axioms — telescoping needs no boundary/Abel analysis."
+    ],
+    "prerequisites": [
+      "Real analysis (series convergence, telescoping sums)",
+      "Partial fractions over a product of consecutive integers",
+      "Figurate numbers (triangular and tetrahedral numbers)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Summand and Telescoping Antiderivative",
+      "startLine": 38,
+      "endLine": 44,
+      "summary": "Defines tetReciprocal n = 6/((n+1)(n+2)(n+3)) = 1/Tet_{n+1} and the telescoping antiderivative gTele n = 3/((n+1)(n+2)).",
+      "mathContext": "The shifted summand $f(n) = 6/((n+1)(n+2)(n+3))$ and antiderivative $g(n) = 3/((n+1)(n+2))$, chosen so that $f(n) = g(n) - g(n+1)$."
+    },
+    {
+      "id": "partial-fraction",
+      "title": "Depth-2 Telescoping Partial Fraction",
+      "startLine": 51,
+      "endLine": 62,
+      "summary": "Proves 6/((n+1)(n+2)(n+3)) = g(n) - g(n+1) via field_simp and ring.",
+      "mathContext": "$\\frac{6}{(n+1)(n+2)(n+3)} = \\frac{3}{(n+1)(n+2)} - \\frac{3}{(n+2)(n+3)}$, the depth-2 analogue of $\\frac{2}{n(n+1)} = \\frac{2}{n} - \\frac{2}{n+1}$."
+    },
+    {
+      "id": "partial-sum",
+      "title": "Closed Form for the Partial Sum",
+      "startLine": 69,
+      "endLine": 83,
+      "summary": "Induction on N proving ∑_{i<N} f(i) = 3/2 - 3/((N+1)(N+2)).",
+      "mathContext": "$\\sum_{i<N} \\frac{6}{(i+1)(i+2)(i+3)} = \\frac{3}{2} - \\frac{3}{(N+1)(N+2)}$, the telescoped collapse $g(0) - g(N)$."
+    },
+    {
+      "id": "tail",
+      "title": "Tail Vanishes",
+      "startLine": 90,
+      "endLine": 106,
+      "summary": "Proves 3/((N+1)(N+2)) → 0 by squeezing below 3·(1/(N+1)).",
+      "mathContext": "$\\frac{3}{(N+1)(N+2)} \\to 0$ as $N \\to \\infty$, squeezed between $0$ and $\\frac{3}{N+1}$."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem",
+      "startLine": 118,
+      "endLine": 137,
+      "summary": "Combines the closed form and vanishing tail into HasSum tetReciprocal (3/2), plus the tsum form.",
+      "mathContext": "$\\sum_{n=0}^{\\infty} \\frac{6}{(n+1)(n+2)(n+3)} = \\frac{3}{2}$ via `hasSum_iff_tendsto_nat_of_nonneg`, equivalently $\\sum_{m=1}^{\\infty} 1/\\mathrm{Tet}_m = 3/2$."
+    },
+    {
+      "id": "examples",
+      "title": "Sanity Checks",
+      "startLine": 143,
+      "endLine": 148,
+      "summary": "Verifies the first term tetReciprocal 0 = 1 = 1/Tet_1 and the two-term partial sum = 5/4.",
+      "mathContext": "$f(0) = 6/(1\\cdot2\\cdot3) = 1 = 1/\\mathrm{Tet}_1$ and $\\sum_{i<2} f(i) = 3/2 - 3/(3\\cdot4) = 5/4$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "triangular-reciprocals",
+      "relationship": "extends",
+      "description": "Extends the depth-1 triangular-reciprocal sum ∑2/(n(n+1)) = 2 to the depth-2 tetrahedral sum ∑6/(n(n+1)(n+2)) = 3/2 — one figurate dimension up, same telescoping technique."
+    },
+    {
+      "targetId": "triangular-reciprocals-oq-02",
+      "relationship": "related",
+      "description": "The shifted reciprocal product sum ∑1/(n(n+k)) = H_k/k uses depth-1 partial fractions with an arbitrary shift; this proof instead increases the depth (three consecutive factors) at shift 1."
+    },
+    {
+      "targetId": "triangular-reciprocals-oq-03",
+      "relationship": "related",
+      "description": "The alternating triangular reciprocals ∑(-1)^{n+1}·2/(n(n+1)) = 4·ln2 - 2 yield a transcendental, axiom-dependent value; the tetrahedral sum is rational (3/2) and fully verified with zero axioms."
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "related",
+      "description": "Tet_n = C(n+2,3) is a binomial coefficient (third column of Pascal's triangle); the reciprocal-binomial sum ∑1/C(n+2,3) = 3/2 is the k=3 case of ∑1/C(n+k-1,k) = k/(k-1)."
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "Both evaluate reciprocal series over structured integer sequences in closed form; Basel computes ∑1/n² = π²/6 while this computes ∑1/Tet_n = 3/2."
+    }
+  ],
+  "conclusion": {
+    "summary": "The tetrahedral reciprocal sum ∑1/Tet_n = 3/2 is fully machine-verified with zero axioms and zero sorries. The proof is the depth-2 analogue of the classical triangular-reciprocal telescoping, using the partial fraction 6/((n+1)(n+2)(n+3)) = 3/((n+1)(n+2)) - 3/((n+2)(n+3)).",
+    "implications": "The same depth-d telescoping proves ∑_{n≥1} 1/C(n+d-1,d) = d/(d-1) for every d ≥ 2: each summand is a difference of consecutive depth-(d-1) figurate reciprocals, so the partial sum collapses to the first term d/(d-1). Tetrahedral (d=3) gives 3/2; pentatope (d=4) gives 4/3; the limit as d→∞ is 1.",
+    "openQuestions": [
+      "Prove the general figurate-reciprocal identity ∑_{n≥1} 1/C(n+d-1,d) = d/(d-1) for arbitrary d ≥ 2 by induction on the telescoping depth.",
+      "Formalize the pentatope (4-simplex) reciprocal sum ∑ 24/(n(n+1)(n+2)(n+3)) = 4/3 as the next depth-3 telescoping case."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators",
+      "Filter",
+      "Topology",
+      "Real"
+    ],
+    "namespace": "TriangularReciprocalsOQ04",
+    "lineCount": 149,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "path": "Proofs/TriangularReciprocalsOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/triangular-reciprocals-oq-04.json
+++ b/src/data/research/problems/triangular-reciprocals-oq-04.json
@@ -1,0 +1,103 @@
+{
+  "slug": "triangular-reciprocals-oq-04",
+  "title": "Reciprocals of Tetrahedral Numbers Sum to 3/2",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\sum_{n=1}^{\\infty} \\frac{1}{\\mathrm{Tet}_n} = \\sum_{n=1}^{\\infty} \\frac{6}{n(n+1)(n+2)} = \\frac{3}{2}, \\quad \\mathrm{Tet}_n = \\frac{n(n+1)(n+2)}{6}.",
+    "plain": "Prove that the sum of the reciprocals of the tetrahedral numbers equals 3/2, by depth-2 telescoping — the figurate-dimension-3 analogue of the triangular reciprocal sum ∑2/(n(n+1)) = 2.",
+    "whyMatters": [
+      "Extends the triangular-reciprocals gallery one figurate dimension up (degree-3 figurate numbers).",
+      "Rational, axiom-free closed form 3/2 contrasts with the transcendental, axiom-dependent alternating sibling (oq-03).",
+      "Establishes the depth-2 telescoping skeleton that generalizes to all simplex-number reciprocal sums ∑1/C(n+d-1,d) = d/(d-1)."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Main identity HasSum (fun n => 6/((n+1)(n+2)(n+3))) (3/2) is fully formalized and machine-checked in Proofs/TriangularReciprocalsOQ04.lean (0 sorries, 0 axioms) via depth-2 telescoping.",
+      "Depth-1 base proof triangular-reciprocals (∑2/(n(n+1)) = 2) and shifted variant triangular-reciprocals-oq-02 (∑1/(n(n+k)) = H_k/k) are completed siblings.",
+      "Alternating sibling triangular-reciprocals-oq-03 (∑(-1)^{n+1}·2/(n(n+1)) = 4·ln2 - 2) is a completed (axiomatized) sibling."
+    ],
+    "open": [
+      "Generalize to the full simplex-number reciprocal identity ∑_{n≥1} 1/C(n+d-1,d) = d/(d-1) for arbitrary d ≥ 2 (tracked as a possible follow-up)."
+    ],
+    "goal": "Formalize ∑ 1/Tet_n = 3/2 with zero axioms via depth-2 partial-fraction telescoping."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-20T00:05:00-07:00",
+    "iteration": 1,
+    "focus": "Core identity fully proved and Docker-verified (Mathlib v4.26.0). Depth-2 telescoping skeleton reused from the depth-1 triangular reciprocal proof.",
+    "blockers": [],
+    "nextAction": "None for the core identity. Optional: formalize the general simplex-reciprocal identity ∑1/C(n+d-1,d) = d/(d-1) as a separate problem.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE. ∑_{n≥1} 1/Tet_n = 3/2 is fully formalized and machine-checked in Proofs/TriangularReciprocalsOQ04.lean (0 sorries, 0 axioms, status verified). Approach: shift index so summand f(n) = 6/((n+1)(n+2)(n+3)) = 1/Tet_{n+1}; depth-2 partial fraction f(n) = 3/((n+1)(n+2)) - 3/((n+2)(n+3)) = g(n) - g(n+1); telescoped closed-form partial sum 3/2 - 3/((N+1)(N+2)) by induction; tail → 0 by squeeze below 3/(N+1); combine via hasSum_iff_tendsto_nat_of_nonneg. Docker build succeeds (Mathlib v4.26.0).",
+    "builtItems": [
+      "tetReciprocal / gTele: summand 6/((n+1)(n+2)(n+3)) and telescoping antiderivative 3/((n+1)(n+2)).",
+      "tetrahedral_partial_fraction: 6/((n+1)(n+2)(n+3)) = gTele n - gTele (n+1) (field_simp; ring).",
+      "partial_sum_closed_form: ∑_{i<N} f i = 3/2 - 3/((N+1)(N+2)) by induction on N.",
+      "tail_to_zero: 3/((N+1)(N+2)) → 0, squeezed below 3·(1/(N+1)) via tendsto_one_div_add_atTop_nhds_zero_nat.",
+      "tetrahedral_reciprocals: HasSum tetReciprocal (3/2) via hasSum_iff_tendsto_nat_of_nonneg; tetrahedral_reciprocals_tsum: tsum form.",
+      "Sanity checks: tetReciprocal 0 = 1 = 1/Tet_1, two-term partial sum = 5/4."
+    ],
+    "insights": [
+      "1/Tet_n = 6/(n(n+1)(n+2)); the factor 6 is exactly what makes the depth-2 partial fraction telescope with integer-numerator antiderivative g(n) = 3/((n+1)(n+2)).",
+      "The depth-2 telescoping antiderivative is one figurate dimension lower than the summand: g is a triangular-reciprocal-shaped term, f a tetrahedral-reciprocal-shaped term — mirroring the depth-1 case where the antiderivative 2/(n+1) is reciprocal-of-linear.",
+      "Telescoping gives a rational, axiom-free value (3/2) whereas the alternating variant (oq-03) needs Abel-boundary analysis and is only axiomatized (4·ln2 - 2). Depth, not alternation, keeps the proof elementary.",
+      "The closed form 3/2 - 3/((N+1)(N+2)) gives exact truncation error and makes the limit transparent."
+    ],
+    "mathlibGaps": [
+      "None blocking. Mathlib has hasSum_iff_tendsto_nat_of_nonneg, tendsto_one_div_add_atTop_nhds_zero_nat, and squeeze_zero — sufficient for the whole proof. No tetrahedral/simplex-reciprocal lemma exists in Mathlib (grep empty), so the result is original to the gallery."
+    ],
+    "nextSteps": [
+      "Core identity complete; no further work required.",
+      "Optional follow-up: the general simplex identity ∑1/C(n+d-1,d) = d/(d-1) by induction on telescoping depth, or the pentatope case ∑24/(n(n+1)(n+2)(n+3)) = 4/3."
+    ],
+    "markdown": "# Knowledge Base: triangular-reciprocals-oq-04\n\n**Status: COMPLETE.** The tetrahedral reciprocal identity \\(\\sum_{n\\ge1} 1/\\mathrm{Tet}_n = 3/2\\) is fully formalized and machine-checked in `Proofs/TriangularReciprocalsOQ04.lean` (0 sorries, 0 axioms).\n\n---\n\n## Result\n\n\\(\\mathrm{Tet}_n = n(n+1)(n+2)/6\\), so \\(1/\\mathrm{Tet}_n = 6/(n(n+1)(n+2))\\). With the running index shifted by 1,\n\\[\\sum_{n=0}^{\\infty} \\frac{6}{(n+1)(n+2)(n+3)} = \\frac{3}{2} = \\sum_{m=1}^{\\infty} \\frac{1}{\\mathrm{Tet}_m}.\\]\n\n## Proof Architecture (depth-2 telescoping)\n\n1. **tetrahedral_partial_fraction** — \\(\\frac{6}{(n+1)(n+2)(n+3)} = \\frac{3}{(n+1)(n+2)} - \\frac{3}{(n+2)(n+3)} = g(n) - g(n+1)\\).\n2. **partial_sum_closed_form** — \\(\\sum_{i<N} f(i) = \\frac{3}{2} - \\frac{3}{(N+1)(N+2)}\\) by induction on \\(N\\).\n3. **tail_to_zero** — \\(\\frac{3}{(N+1)(N+2)} \\to 0\\), squeezed below \\(3/(N+1)\\).\n4. **tetrahedral_reciprocals** — combine into `HasSum f (3/2)` via `hasSum_iff_tendsto_nat_of_nonneg`; tsum form follows.\n\nSanity checks: \\(f(0) = 1 = 1/\\mathrm{Tet}_1\\), \\(\\sum_{i<2} f(i) = 5/4\\). Docker build succeeds (Mathlib v4.26.0).\n\n---\n\n## Relation to siblings\n\n- **triangular-reciprocals** (depth 1): \\(\\sum 2/(n(n+1)) = 2\\) — same telescoping, one dimension down.\n- **oq-02**: \\(\\sum 1/(n(n+k)) = H_k/k\\) — depth 1 with arbitrary shift.\n- **oq-03** (alternating): \\(\\sum (-1)^{n+1} 2/(n(n+1)) = 4\\ln2 - 2\\) — transcendental, axiomatized.\n\n## Generalization\n\nThe same depth-\\(d\\) telescoping gives \\(\\sum_{n\\ge1} 1/\\binom{n+d-1}{d} = d/(d-1)\\) for every \\(d \\ge 2\\); \\(d=3\\) is this result (\\(3/2\\)), \\(d=4\\) gives \\(4/3\\), and the limit as \\(d\\to\\infty\\) is \\(1\\).\n"
+  },
+  "tags": [
+    "analysis",
+    "series",
+    "figurate-numbers",
+    "telescoping",
+    "tetrahedral-numbers"
+  ],
+  "relatedProofs": [
+    "triangular-reciprocals",
+    "triangular-reciprocals-oq-01",
+    "triangular-reciprocals-oq-02",
+    "triangular-reciprocals-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Tetrahedral_number"
+    ],
+    "mathlib": []
+  },
+  "started": "2026-06-20T00:00:00-07:00",
+  "lastUpdate": "2026-06-20T00:05:00-07:00",
+  "significance": 6,
+  "tractability": 8,
+  "leanFiles": [
+    {
+      "path": "Proofs/TriangularReciprocalsOQ04.lean",
+      "filename": "TriangularReciprocalsOQ04.lean",
+      "lineCount": 151,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangularReciprocalsOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Tetrahedral Reciprocals Sum to 3/2

Proves $\sum_{n=1}^{\infty} \frac{1}{\mathrm{Tet}_n} = \sum_{n=1}^{\infty} \frac{6}{n(n+1)(n+2)} = \frac{3}{2}$, where $\mathrm{Tet}_n = \binom{n+2}{3} = \frac{n(n+1)(n+2)}{6}$.

This is the **depth-2 analogue** of the classical triangular-reciprocal identity $\sum \frac{2}{n(n+1)} = 2$. Where the depth-1 sum telescopes via $\frac{2}{n(n+1)} = \frac{2}{n} - \frac{2}{n+1}$, the tetrahedral sum telescopes via the depth-2 partial fraction:

$$\frac{6}{(n+1)(n+2)(n+3)} = \frac{3}{(n+1)(n+2)} - \frac{3}{(n+2)(n+3)} = g(n) - g(n+1).$$

### Proof structure
1. `tetrahedral_partial_fraction` — the depth-2 telescoping identity (`field_simp`/`ring`)
2. `partial_sum_closed_form` — $\sum_{i<N} f(i) = \frac{3}{2} - \frac{3}{(N+1)(N+2)}$ by induction
3. `tail_to_zero` — $\frac{3}{(N+1)(N+2)} \to 0$ by squeezing below $\frac{3}{N+1}$
4. `tetrahedral_reciprocals` — `HasSum tetReciprocal (3/2)`, plus `tetrahedral_reciprocals_tsum`

### Why this is a genuine gap
The gallery has `TriangularReciprocalsFigurate` (2D $k$-gonal numbers, convergence only) and `TriangularReciprocalGeneralized` (alternating sums). Neither evaluates the **3D tetrahedral** reciprocal sum in closed form. Unlike the alternating oq-03 result ($4\ln 2 - 2$, transcendental, axiom-dependent), this value is rational and fully verified.

### Verification
- **0 sorries, 0 axiom declarations** — `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`
- Compiles clean against current `main` (Mathlib 4.26.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)