### PR TITLE
research(fibonacci-identities-oq-01): Cassini's identity Fₙ₊₂·Fₙ − Fₙ₊₁² = (−1)ⁿ⁺¹ (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2420,6 +2420,7 @@ import Proofs.FeuerbachsTheoremOQ01Aristotle
 import Proofs.FeuerbachsTheoremOQ01OQ03
 import Proofs.FeuerbachsTheoremOQ02
 import Proofs.FeuerbachsTheoremOQ02Aristotle
+import Proofs.FibonacciIdentitiesOQ01
 import Proofs.StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular
 import Proofs.FeuerbachsTheoremOQ05
 import Proofs.FiveColorTheorem

--- a/proofs/Proofs/FibonacciIdentitiesOQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ01.lean
@@ -1,0 +1,98 @@
+import Mathlib.Data.Nat.Fib.Basic
+import Mathlib.Tactic
+
+/-
+# Cassini's Identity for Fibonacci Numbers
+
+## What This Proves
+
+With `Fₙ = Nat.fib n` the Fibonacci sequence (`F₀ = 0, F₁ = 1, Fₙ₊₂ = Fₙ + Fₙ₊₁`),
+**Cassini's identity** is the exact relation
+
+    Fₙ₊₂ · Fₙ − Fₙ₊₁² = (−1)ⁿ⁺¹      (over ℤ).
+
+Equivalently, shifting the index, `Fₙ₋₁·Fₙ₊₁ − Fₙ² = (−1)ⁿ`.  It says that the
+"determinant" of three consecutive Fibonacci numbers is always `±1`: the
+product of the outer two differs from the square of the middle one by exactly
+one, with a sign that alternates with `n`.
+
+For example:
+- `n = 1`: `F₃·F₁ − F₂² = 2·1 − 1 = 1  = (−1)²`
+- `n = 2`: `F₄·F₂ − F₃² = 3·1 − 4 = −1 = (−1)³`
+- `n = 3`: `F₅·F₃ − F₄² = 5·2 − 9 = 1  = (−1)⁴`
+- `n = 4`: `F₆·F₄ − F₅² = 8·3 − 25 = −1 = (−1)⁵`
+
+## Approach
+
+Pure induction on `n`, cast to `ℤ` so the alternating sign `(−1)ⁿ⁺¹` is
+available.  The recurrence `Nat.fib_add_two : Fₙ₊₂ = Fₙ + Fₙ₊₁` (cast to ℤ)
+rewrites the three consecutive terms at step `n+1` into `Fₙ, Fₙ₊₁`, and a single
+`linear_combination` against the induction hypothesis closes the algebra — the
+key cancellation is `Fₙ₊₂·Fₙ − Fₙ₊₁² = −(Fₙ₊₃·Fₙ₊₁ − Fₙ₊₂²)`, i.e. the
+left-hand side simply negates each step, which is exactly `(−1)ⁿ⁺¹ → (−1)ⁿ⁺²`.
+
+No `decide`/`native_decide` is used, so the proof is axiom-free (only Mathlib's
+foundational axioms).
+
+## Distinctness
+
+Cassini's identity is **not** in Mathlib (`Mathlib.Data.Nat.Fib.Basic` has the
+recurrence, `fib_add`, `fib_two_mul`, `fib_gcd`, etc., but no `±1` determinant
+identity), and there is no Fibonacci-identity entry in the gallery.  This is the
+first of the `fibonacci-identities` family; `oq-02` (strong divisibility) and
+`oq-03` (doubling) cover different identities.
+
+## Status
+- [x] Complete proof, 0 sorries, 0 axioms (beyond Mathlib's foundational set)
+-/
+
+namespace FibonacciIdentitiesOQ01
+
+open Nat
+
+/-- **Cassini's identity.**  For every `n`, the integer determinant of three
+consecutive Fibonacci numbers is `(−1)ⁿ⁺¹`:
+
+    Fₙ₊₂ · Fₙ − Fₙ₊₁² = (−1)ⁿ⁺¹. -/
+theorem fib_cassini (n : ℕ) :
+    (Nat.fib (n + 2) : ℤ) * Nat.fib n - (Nat.fib (n + 1) : ℤ) ^ 2 = (-1) ^ (n + 1) := by
+  induction n with
+  | zero => norm_num [Nat.fib_zero, Nat.fib_one, Nat.fib_two]
+  | succ k ih =>
+    -- Recurrence, cast to ℤ, for the two terms introduced at the successor step.
+    have e2 : (Nat.fib (k + 2) : ℤ) = (Nat.fib k : ℤ) + Nat.fib (k + 1) := by
+      exact_mod_cast Nat.fib_add_two (n := k)
+    have e3 : (Nat.fib (k + 3) : ℤ) = (Nat.fib (k + 1) : ℤ) + Nat.fib (k + 2) := by
+      exact_mod_cast Nat.fib_add_two (n := k + 1)
+    -- Goal at `k+1`, with indices put in `k+3 / k+2` form (definitionally equal).
+    show (Nat.fib (k + 3) : ℤ) * Nat.fib (k + 1) - (Nat.fib (k + 2) : ℤ) ^ 2 = (-1) ^ (k + 2)
+    rw [e2] at ih
+    rw [e3, e2, pow_succ]
+    linear_combination (-1 : ℤ) * ih
+
+/-- **Cassini, index-shifted form.**  For `n ≥ 1`,
+
+    Fₙ₋₁ · Fₙ₊₁ − Fₙ² = (−1)ⁿ.
+
+Stated on `n + 1` to avoid natural-number subtraction:
+`Fₙ · Fₙ₊₂ − Fₙ₊₁² = (−1)ⁿ⁺¹`. -/
+theorem fib_cassini_shift (n : ℕ) :
+    (Nat.fib n : ℤ) * Nat.fib (n + 2) - (Nat.fib (n + 1) : ℤ) ^ 2 = (-1) ^ (n + 1) := by
+  have h := fib_cassini n
+  linear_combination h
+
+/-- The unsigned form: consecutive Fibonacci "determinants" have absolute value
+exactly `1`. -/
+theorem fib_cassini_abs (n : ℕ) :
+    |(Nat.fib (n + 2) : ℤ) * Nat.fib n - (Nat.fib (n + 1) : ℤ) ^ 2| = 1 := by
+  rw [fib_cassini n, abs_pow]
+  simp
+
+/-! ## Concrete examples (the first few determinants) -/
+
+example : (Nat.fib 3 : ℤ) * Nat.fib 1 - (Nat.fib 2 : ℤ) ^ 2 = 1 := by decide
+example : (Nat.fib 4 : ℤ) * Nat.fib 2 - (Nat.fib 3 : ℤ) ^ 2 = -1 := by decide
+example : (Nat.fib 5 : ℤ) * Nat.fib 3 - (Nat.fib 4 : ℤ) ^ 2 = 1 := by decide
+example : (Nat.fib 6 : ℤ) * Nat.fib 4 - (Nat.fib 5 : ℤ) ^ 2 = -1 := by decide
+
+end FibonacciIdentitiesOQ01

--- a/src/data/proofs/fibonacci-identities-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-01/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "fibonacci-identities-oq-01",
+  "title": "Cassini's Identity for Fibonacci Numbers",
+  "slug": "fibonacci-identities-oq-01",
+  "description": "Cassini's identity: with Fₙ = Nat.fib n, the integer determinant of three consecutive Fibonacci numbers is always ±1, with an alternating sign — Fₙ₊₂·Fₙ − Fₙ₊₁² = (−1)ⁿ⁺¹ over ℤ. Proved by a single induction on n: casting to ℤ exposes the alternating sign, the recurrence Nat.fib_add_two rewrites the successor step, and one linear_combination against the induction hypothesis closes the algebra, the left-hand side simply negating at each step. Includes the index-shifted form Fₙ·Fₙ₊₂ − Fₙ₊₁² = (−1)ⁿ⁺¹ and the unsigned absolute-value form |Fₙ₊₂·Fₙ − Fₙ₊₁²| = 1. Cassini's identity is absent from Mathlib (which has the recurrence, fib_add, fib_two_mul, fib_gcd, but no ±1 determinant identity) and is the first entry of the fibonacci-identities family.",
+  "meta": {
+    "author": "Jean-Dominique Cassini (1680); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cassini_and_Catalan_identities",
+    "date": "1680",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "cassini",
+      "recurrence",
+      "induction",
+      "determinant",
+      "integer-sequences",
+      "identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the defining Fibonacci recurrence, cast to ℤ to rewrite the two terms introduced at the successor step",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_zero / Nat.fib_one / Nat.fib_two",
+        "description": "fib 0 = 0, fib 1 = 1, fib 2 = 1 — base values discharging the n = 0 case by norm_num",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      }
+    ],
+    "originalContributions": [
+      "fib_cassini: ∀ n, (fib (n+2) : ℤ)·fib n − (fib (n+1) : ℤ)² = (−1)ⁿ⁺¹ — Cassini's identity, absent from Mathlib",
+      "fib_cassini_shift: ∀ n, (fib n : ℤ)·fib (n+2) − (fib (n+1) : ℤ)² = (−1)ⁿ⁺¹ — the index-shifted (Fₙ₋₁Fₙ₊₁ − Fₙ²) form, stated on n+1 to avoid ℕ-subtraction",
+      "fib_cassini_abs: ∀ n, |(fib (n+2) : ℤ)·fib n − (fib (n+1) : ℤ)²| = 1 — the unsigned 'determinant is a unit' form"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 98,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used in the main theorems.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Cassini's identity, named after Jean-Dominique Cassini who stated it in 1680 (and independently rediscovered by Robert Simson), is the most famous of the elementary Fibonacci identities. It asserts that the 2×2 determinant of consecutive terms — equivalently the product of the two terms surrounding Fₙ₊₁ minus its square — is always ±1, oscillating in sign. It is the n-th case of Catalan's identity Fₙ₋ᵣFₙ₊ᵣ − Fₙ² = (−1)ⁿ⁻ʳFᵣ² (here r = 1), and is the source of the classic 'missing square' dissection paradox, where a square is cut and rearranged into a rectangle whose area differs by exactly one unit. Matrix-theoretically it is det([[1,1],[1,0]]ⁿ) = (−1)ⁿ.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-01)**: Prove Cassini's identity for the Fibonacci numbers — the determinant of three consecutive terms is (−1)ⁿ⁺¹.\n\n**Result**: fib_cassini ((fib (n+2) : ℤ)·fib n − (fib (n+1) : ℤ)² = (−1)ⁿ⁺¹), together with the index-shifted form fib_cassini_shift and the absolute-value form fib_cassini_abs.",
+    "text": "For every n, working over ℤ, Fₙ₊₂·Fₙ − Fₙ₊₁² = (−1)ⁿ⁺¹, where Fₙ = Nat.fib n. The outer product of three consecutive Fibonacci numbers differs from the square of the middle by exactly one, with a sign alternating in n.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Cast the statement to ℤ so the alternating sign (−1)ⁿ⁺¹ is available and subtraction is genuine (no ℕ truncation).\n2. Induct on n. Base case n = 0: F₂·F₀ − F₁² = 1·0 − 1 = −1 = (−1)¹, discharged by norm_num on the base values fib_zero/fib_one/fib_two.\n3. Successor step at k+1: the goal is (fib (k+3) : ℤ)·fib (k+1) − (fib (k+2) : ℤ)² = (−1)ᵏ⁺². Cast the recurrence twice — e2: fib (k+2) = fib k + fib (k+1), e3: fib (k+3) = fib (k+1) + fib (k+2) — rewrite both, expand pow_succ on the right, and close with `linear_combination (-1) * ih`. Algebraically the left-hand side is exactly the negation of the previous step, matching (−1)ᵏ⁺¹ → (−1)ᵏ⁺².\n4. fib_cassini_shift is fib_cassini up to a commutation, closed by linear_combination; fib_cassini_abs rewrites by fib_cassini and simplifies |(−1)ⁿ⁺¹| = 1 via abs_pow.",
+    "keyInsights": [
+      "**Cast first, induct once.** Moving to ℤ before the induction makes the alternating sign a first-class object and turns the determinant into honest integer subtraction, so a single induction suffices.",
+      "**The step is a sign flip.** The crux cancellation Fₙ₊₂·Fₙ − Fₙ₊₁² = −(Fₙ₊₃·Fₙ₊₁ − Fₙ₊₂²) means each Cassini value is the negative of the next — precisely (−1)ⁿ⁺¹ ↦ (−1)ⁿ⁺², so one linear_combination with coefficient −1 against the hypothesis closes the algebra.",
+      "**Recurrence as the only input.** Beyond the base values, the proof uses nothing but Nat.fib_add_two cast to ℤ; no closed form, matrices, or Binet formula are needed.",
+      "**Not in Mathlib.** Mathlib carries the recurrence, fib_add, fib_two_mul, and fib_gcd, but no ±1 determinant identity, so Cassini (and its shifted and absolute-value forms) is an original contribution."
+    ],
+    "prerequisites": [
+      "The Fibonacci recurrence Nat.fib_add_two and base values",
+      "Induction over ℕ and casting ℕ → ℤ (exact_mod_cast)",
+      "The linear_combination tactic for closing polynomial identities against a hypothesis"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring stating Cassini's identity with worked numerical examples, the Fibonacci/tactic imports, namespace, and open Nat.",
+      "mathContext": "$F_{n+2} F_n - F_{n+1}^2 = (-1)^{n+1}$, with $F_0=0, F_1=1, F_{n+2}=F_n+F_{n+1}$."
+    },
+    {
+      "id": "cassini",
+      "title": "Cassini's Identity",
+      "startLine": 53,
+      "endLine": 71,
+      "summary": "fib_cassini: the main theorem, proved by induction on n — base case by norm_num, successor step by casting the recurrence twice and closing with linear_combination (-1)·ih.",
+      "mathContext": "$F_{n+2} F_n - F_{n+1}^2 = (-1)^{n+1}$ over $\\mathbb{Z}$."
+    },
+    {
+      "id": "shift",
+      "title": "Index-Shifted Form",
+      "startLine": 73,
+      "endLine": 82,
+      "summary": "fib_cassini_shift: the Fₙ₋₁Fₙ₊₁ − Fₙ² = (−1)ⁿ form, stated on n+1 to avoid natural-number subtraction, obtained from fib_cassini by linear_combination.",
+      "mathContext": "$F_n F_{n+2} - F_{n+1}^2 = (-1)^{n+1}$."
+    },
+    {
+      "id": "abs",
+      "title": "Unsigned (Absolute-Value) Form",
+      "startLine": 84,
+      "endLine": 98,
+      "summary": "fib_cassini_abs: the consecutive Fibonacci determinant has absolute value exactly 1, via abs_pow on (−1)ⁿ⁺¹; followed by concrete numeric examples.",
+      "mathContext": "$\\left| F_{n+2} F_n - F_{n+1}^2 \\right| = 1$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples-oq-05",
+      "relationship": "related",
+      "description": "The Brahmagupta–Fibonacci two-squares identity entry treats a different 'Fibonacci' identity (the two-squares product law); this entry is the Fibonacci-sequence determinant identity"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) proof of Cassini's identity Fₙ₊₂·Fₙ − Fₙ₊₁² = (−1)ⁿ⁺¹ over ℤ, together with its index-shifted form and the unsigned |·| = 1 form, by a single induction using only the Fibonacci recurrence.",
+    "implications": "Supplies the foundational ±1 determinant identity for consecutive Fibonacci numbers — the basis of the 'missing square' paradox and a stepping stone to Catalan's and d'Ocagne's identities — as a universally quantified theorem absent from Mathlib.",
+    "openQuestions": [
+      "Prove Catalan's identity Fₙ₋ᵣ·Fₙ₊ᵣ − Fₙ² = (−1)ⁿ⁻ʳ·Fᵣ², generalising Cassini (r = 1).",
+      "Prove d'Ocagne's identity Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ.",
+      "Derive Cassini matrix-theoretically as det([[1,1],[1,0]]ⁿ) = (−1)ⁿ."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Fib.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "FibonacciIdentitiesOQ01",
+    "lineCount": 98,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Vajda, S.",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section: Theory and Applications",
+      "year": "1989",
+      "venue": "Ellis Horwood / Dover",
+      "note": "Catalan's and Cassini's identities and their interrelations"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Cassini's identity (1680), Catalan's identity, and the missing-square dissection"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Cassini's Identity for Fibonacci Numbers

Proves **Cassini's identity** (1680): with `Fₙ = Nat.fib n`, the integer determinant of three consecutive Fibonacci numbers is always `±1`, with an alternating sign:

$$F_{n+2}\, F_n - F_{n+1}^2 = (-1)^{n+1} \quad\text{over } \mathbb{Z}.$$

The product of the two terms surrounding `Fₙ₊₁` differs from its square by exactly one — the basis of the classic "missing square" dissection paradox, and the `r=1` case of Catalan's identity.

### Theorems (all verified, 0 sorries, 0 axioms)
- `fib_cassini`: `(fib (n+2) : ℤ)·fib n − (fib (n+1) : ℤ)² = (−1)ⁿ⁺¹`
- `fib_cassini_shift`: `(fib n : ℤ)·fib (n+2) − (fib (n+1) : ℤ)² = (−1)ⁿ⁺¹` (the `Fₙ₋₁Fₙ₊₁ − Fₙ²` form, stated on `n+1` to avoid ℕ-subtraction)
- `fib_cassini_abs`: `|(fib (n+2) : ℤ)·fib n − (fib (n+1) : ℤ)²| = 1`

### Proof
A single induction on `n`, cast to ℤ so the alternating sign is first-class. Base case `n = 0` by `norm_num`. Successor step casts the recurrence `Nat.fib_add_two` twice and closes with `linear_combination (-1) * ih` — algebraically each Cassini value is the negation of the next, matching `(−1)ⁿ⁺¹ ↦ (−1)ⁿ⁺²`. The only Mathlib input beyond base values is the Fibonacci recurrence.

### Distinctness
Cassini's identity is **absent from Mathlib** (which has the recurrence, `fib_add`, `fib_two_mul`, `fib_gcd`, but no `±1` determinant identity) and from the gallery. First entry of the `fibonacci-identities` family. The existing `pythagorean-triples-oq-05` "Brahmagupta–Fibonacci" entry is a different (two-squares) identity.

### Verification
- `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` for all three theorems — no `sorryAx`, no `ofReduceBool`. The main theorems use no `decide`/`native_decide`.
- Verified via single-file `lake env lean Proofs/FibonacciIdentitiesOQ01.lean` (Docker daemon unavailable in this environment; file is standalone with no sibling-proof dependencies).

### Files
- `proofs/Proofs/FibonacciIdentitiesOQ01.lean` (98 lines)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/fibonacci-identities-oq-01/meta.json` (gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)