### PR TITLE
research(denumerability-rationals-oq-07): algebraic reals as Σ over ℚ[X], #{x:ℝ//IsAlgebraic ℚ x}=ℵ₀ (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -655,6 +655,7 @@ import Proofs.DenumerabilityRationalsOQ03
 import Proofs.DenumerabilityRationalsOQ04
 import Proofs.DenumerabilityRationalsOQ05
 import Proofs.DenumerabilityRationalsOQ06
+import Proofs.DenumerabilityRationalsOQ07
 import Proofs.Derangements
 import Proofs.DerangementsConvergence
 import Proofs.DerangementsConvergenceOQ01

--- a/proofs/Proofs/DenumerabilityRationalsOQ07.lean
+++ b/proofs/Proofs/DenumerabilityRationalsOQ07.lean
@@ -1,0 +1,127 @@
+import Mathlib
+
+/-!
+# Denumerability of Rationals OQ-07: the algebraic reals as a `Σ` over `ℚ[X]`
+
+OQ-06 isolated the cardinal fact behind algebraic countability: the polynomial
+ring is countably infinite, `#(ℚ[X]) = ℵ₀`.  This entry turns that fact into the
+*explicit* mechanism that makes the **algebraic real numbers** countable.
+
+The gallery already records `#{x : ℝ // IsAlgebraic ℚ x} = ℵ₀` once, but only as a
+black-box one-liner (`Algebraic.cardinalMk_of_countable_of_charZero`).  What is
+*not* recorded anywhere is the structural reason: every algebraic real is a root of
+some `p ∈ ℚ[X]`, each such `p` has only finitely many roots, and there are only
+`ℵ₀`-many polynomials.  Concretely there is an injection
+
+`{x : ℝ // IsAlgebraic ℚ x}  ↪  Σ p : ℚ[X], (p.rootSet ℝ)`            (sending `x ↦ (minpoly ℚ x, x)`),
+
+and the right-hand `Σ` is a countable union (indexed by `ℚ[X]`, an `ℵ₀` set) of the
+*finite* root fibers `p.rootSet ℝ`, hence itself has cardinality `≤ ℵ₀`.
+
+This file makes both halves explicit:
+
+* `cardinalMk_sigma_rootSet_le` : `#(Σ p : ℚ[X], p.rootSet ℝ) ≤ ℵ₀`
+  — the finite-fiber/`ℵ₀`-many-polynomials count, feeding `#(ℚ[X]) = ℵ₀` (OQ-06).
+* `algebraicReal_inject_sigma` : the injection of the algebraic reals into that `Σ`.
+* `cardinalMk_algebraic_reals_le_sigma` : `#{x // IsAlgebraic ℚ x} ≤ #(Σ …)`.
+* `cardinalMk_algebraic_reals` : `#{x : ℝ // IsAlgebraic ℚ x} = ℵ₀`, derived from the
+  explicit `Σ` bound together with the lower bound `ℵ₀ ≤ #(algebraic reals)`.
+
+The same `Σ`-over-`ℚ[X]` decomposition works verbatim for `ℂ`; we record the complex
+count as well.  No axioms beyond Lean's foundational core, no sorries.
+-/
+
+namespace DenumerabilityRationalsOQ07
+
+open Cardinal Polynomial
+
+/-- **`#(ℚ[X]) = ℵ₀`** (the OQ-06 fact, reproved inline so this entry is standalone).
+By `Polynomial.cardinalMk_eq_max`, `#(ℚ[X]) = max #ℚ ℵ₀`, and `#ℚ = ℵ₀`. -/
+theorem cardinalMk_polynomial_rat : #(ℚ[X]) = ℵ₀ := by
+  rw [Polynomial.cardinalMk_eq_max, mk_eq_aleph0 ℚ, max_self]
+
+/-- The `Σ`-over-`ℚ[X]` of root fibers in a field `K` algebraic-friendly over `ℚ`
+has cardinality `≤ ℵ₀`: it is a sum, indexed by the countable set `ℚ[X]`, of the
+**finite** root sets `p.rootSet K`.  This is the structural count behind algebraic
+countability. -/
+theorem cardinalMk_sigma_rootSet_le
+    (K : Type) [Field K] [CharZero K] :
+    #(Σ p : ℚ[X], (p.rootSet K)) ≤ ℵ₀ := by
+  -- `#(Σ p, p.rootSet K) = ∑_{p : ℚ[X]} #(p.rootSet K)`.
+  rw [mk_sigma]
+  -- Each fiber is finite, so `#(p.rootSet K) ≤ ℵ₀`; bound the sum by the constant `ℵ₀`.
+  calc
+    (sum fun p : ℚ[X] => #(p.rootSet K))
+        ≤ sum fun _ : ℚ[X] => ℵ₀ :=
+          sum_le_sum _ _ fun p => ((p.rootSet_finite K).lt_aleph0).le
+    _ = #(ℚ[X]) * ℵ₀ := sum_const' _ _
+    _ = ℵ₀ * ℵ₀ := by rw [cardinalMk_polynomial_rat]
+    _ = ℵ₀ := aleph0_mul_aleph0
+
+/-- The injection of algebraic reals into the `Σ`-over-`ℚ[X]`: an algebraic `x`
+is a root of its minimal polynomial `minpoly ℚ x`, so `x ↦ (minpoly ℚ x, x)` lands in
+the fiber over `minpoly ℚ x` and is injective (the second coordinate recovers `x`). -/
+theorem algebraicReal_inject_sigma :
+    ∃ f : {x : ℝ // IsAlgebraic ℚ x} → Σ p : ℚ[X], (p.rootSet ℝ),
+      Function.Injective f := by
+  refine ⟨fun x => ⟨minpoly ℚ (x : ℝ), (x : ℝ), ?_⟩, ?_⟩
+  · -- `x ∈ (minpoly ℚ x).rootSet ℝ`.
+    have hInt : IsIntegral ℚ (x : ℝ) := (isAlgebraic_iff_isIntegral.mp x.2)
+    exact mem_rootSet.mpr ⟨minpoly.ne_zero hInt, minpoly.aeval ℚ (x : ℝ)⟩
+  · -- Injective: the underlying real value is recovered from the second coordinate.
+    intro a b h
+    have h2 := congrArg (fun s : Σ p : ℚ[X], (p.rootSet ℝ) => (s.2 : ℝ)) h
+    exact Subtype.ext h2
+
+/-- `#{x : ℝ // IsAlgebraic ℚ x} ≤ #(Σ p : ℚ[X], p.rootSet ℝ)` from the injection. -/
+theorem cardinalMk_algebraic_reals_le_sigma :
+    #{x : ℝ // IsAlgebraic ℚ x} ≤ #(Σ p : ℚ[X], (p.rootSet ℝ)) := by
+  obtain ⟨f, hf⟩ := algebraicReal_inject_sigma
+  exact mk_le_of_injective hf
+
+/-- **Lower bound `ℵ₀ ≤ #{x : K // IsAlgebraic ℚ x}`** for any characteristic-zero
+field `K`: the natural numbers inject into the algebraic elements via `n ↦ (n : K)`
+(each natural is algebraic, being a root of `X - n`), and `Nat.cast` is injective in
+characteristic zero, so `ℵ₀ = #ℕ ≤ #(algebraic elements)`. -/
+theorem aleph0_le_cardinalMk_algebraic
+    (K : Type) [Field K] [CharZero K] :
+    ℵ₀ ≤ #{x : K // IsAlgebraic ℚ x} := by
+  rw [← mk_nat]
+  refine mk_le_of_injective (f := fun n : ℕ => ⟨(n : K), isAlgebraic_nat n⟩) ?_
+  intro a b h
+  have h2 : (a : K) = (b : K) :=
+    congrArg (fun s : {x : K // IsAlgebraic ℚ x} => (s : K)) h
+  exact_mod_cast h2
+
+/-- **The algebraic reals are countable through the explicit `Σ`-over-`ℚ[X]`:**
+`#{x : ℝ // IsAlgebraic ℚ x} ≤ ℵ₀`. -/
+theorem cardinalMk_algebraic_reals_le :
+    #{x : ℝ // IsAlgebraic ℚ x} ≤ ℵ₀ :=
+  cardinalMk_algebraic_reals_le_sigma.trans (cardinalMk_sigma_rootSet_le ℝ)
+
+/-- **`#{x : ℝ // IsAlgebraic ℚ x} = ℵ₀`.** The explicit `Σ` bound gives `≤ ℵ₀`; the
+algebraic reals contain `ℚ` (indeed all of `ℕ`), giving the reverse `ℵ₀ ≤`. -/
+theorem cardinalMk_algebraic_reals :
+    #{x : ℝ // IsAlgebraic ℚ x} = ℵ₀ :=
+  le_antisymm cardinalMk_algebraic_reals_le (aleph0_le_cardinalMk_algebraic ℝ)
+
+/-- The complex algebraic numbers satisfy the same `Σ`-over-`ℚ[X]` bound. -/
+theorem cardinalMk_algebraic_complex_le :
+    #{x : ℂ // IsAlgebraic ℚ x} ≤ ℵ₀ := by
+  -- Same injection (into the complex root fibers) and the same finite-fiber count.
+  have hsig :
+      #{x : ℂ // IsAlgebraic ℚ x} ≤ #(Σ p : ℚ[X], (p.rootSet ℂ)) := by
+    refine mk_le_of_injective (f := fun x => ⟨minpoly ℚ (x : ℂ), (x : ℂ), ?_⟩) ?_
+    · have hInt : IsIntegral ℚ (x : ℂ) := (isAlgebraic_iff_isIntegral.mp x.2)
+      exact mem_rootSet.mpr ⟨minpoly.ne_zero hInt, minpoly.aeval ℚ (x : ℂ)⟩
+    · intro a b h
+      have h2 := congrArg (fun s : Σ p : ℚ[X], (p.rootSet ℂ) => (s.2 : ℂ)) h
+      exact Subtype.ext h2
+  exact hsig.trans (cardinalMk_sigma_rootSet_le ℂ)
+
+/-- **`#{x : ℂ // IsAlgebraic ℚ x} = ℵ₀`.** -/
+theorem cardinalMk_algebraic_complex :
+    #{x : ℂ // IsAlgebraic ℚ x} = ℵ₀ :=
+  le_antisymm cardinalMk_algebraic_complex_le (aleph0_le_cardinalMk_algebraic ℂ)
+
+end DenumerabilityRationalsOQ07

--- a/src/data/proofs/denumerability-rationals-oq-07/annotations.json
+++ b/src/data/proofs/denumerability-rationals-oq-07/annotations.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": "ann-polynomial-count",
+    "proofId": "denumerability-rationals-oq-07",
+    "range": {
+      "startLine": 46,
+      "endLine": 50
+    },
+    "type": "key-step",
+    "title": "The Index Set: #(ℚ[X]) = ℵ₀",
+    "content": "cardinalMk_polynomial_rat reproves OQ-06's fact inline so this entry stands alone: rewriting with Polynomial.cardinalMk_eq_max turns the goal into max #ℚ ℵ₀, mk_eq_aleph0 ℚ substitutes #ℚ = ℵ₀, and max_self collapses max ℵ₀ ℵ₀ to ℵ₀. This ℵ₀-sized polynomial ring is the index over which the algebraic numbers are organised in the rest of the file.",
+    "mathContext": "$\\#(\\mathbb{Q}[X]) = \\max(\\#\\mathbb{Q}, \\aleph_0) = \\aleph_0$ — the countable index set of the Cantor argument.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Polynomial.cardinalMk_eq_max",
+      "max_self",
+      "ℵ₀",
+      "polynomial rings"
+    ],
+    "prerequisites": [
+      "cardinality of a type",
+      "cardinal maximum"
+    ]
+  },
+  {
+    "id": "ann-sigma-bound",
+    "proofId": "denumerability-rationals-oq-07",
+    "range": {
+      "startLine": 56,
+      "endLine": 67
+    },
+    "type": "theorem",
+    "title": "Countable Union of Finite Fibers: #(Σ p, p.rootSet K) ≤ ℵ₀",
+    "content": "cardinalMk_sigma_rootSet_le is the structural heart. By Cardinal.mk_sigma, #(Σ p : ℚ[X], p.rootSet K) equals Cardinal.sum (fun p => #(p.rootSet K)). Each root set p.rootSet K is finite (Polynomial.rootSet_finite), so #(p.rootSet K) < ℵ₀ and a fortiori ≤ ℵ₀; sum_le_sum bounds the whole sum by the constant sum (fun _ => ℵ₀), which sum_const' evaluates to #(ℚ[X]) · ℵ₀. Feeding #(ℚ[X]) = ℵ₀ and aleph0_mul_aleph0 collapses this to ℵ₀. This is the textbook 'countable union of finite sets is countable', made literal as a Cardinal.sum inequality and valid for any characteristic-zero field K.",
+    "mathContext": "$\\#\\big(\\Sigma_{p\\in\\mathbb{Q}[X]} \\mathrm{rootSet}(p)\\big) = \\sum_{p} \\#\\mathrm{rootSet}(p) \\le \\#(\\mathbb{Q}[X])\\cdot\\aleph_0 = \\aleph_0\\cdot\\aleph_0 = \\aleph_0.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Cardinal.mk_sigma",
+      "Cardinal.sum_le_sum",
+      "Cardinal.sum_const'",
+      "Polynomial.rootSet_finite",
+      "Cardinal.aleph0_mul_aleph0"
+    ],
+    "prerequisites": [
+      "Cardinal.sum",
+      "finiteness of root sets",
+      "ℵ₀ arithmetic"
+    ]
+  },
+  {
+    "id": "ann-injection-and-count",
+    "proofId": "denumerability-rationals-oq-07",
+    "range": {
+      "startLine": 64,
+      "endLine": 126
+    },
+    "type": "theorem",
+    "title": "The Injection x ↦ (minpoly ℚ x, x) and the ℵ₀ Count",
+    "content": "algebraicReal_inject_sigma maps each algebraic real x to the pair (minpoly ℚ x, x): membership x ∈ (minpoly ℚ x).rootSet ℝ follows from isAlgebraic_iff_isIntegral (giving IsIntegral, hence a nonzero minimal polynomial via minpoly.ne_zero) together with minpoly.aeval, packaged by mem_rootSet; injectivity is immediate because the second coordinate is literally x. Composing this injection's cardinal bound (mk_le_of_injective) with cardinalMk_sigma_rootSet_le gives cardinalMk_algebraic_reals_le : #{x : ℝ // IsAlgebraic ℚ x} ≤ ℵ₀, and cardinalMk_algebraic_reals closes the equality by antisymmetry against aleph0_le_cardinalMk_algebraic — the self-contained lower bound ℵ₀ ≤ #{x : K // IsAlgebraic ℚ x} built from the ℕ-injection n ↦ (n : K) (every natural is algebraic, isAlgebraic_nat). The complex analogues reuse the identical argument.",
+    "mathContext": "$x \\mapsto (\\mathrm{minpoly}_\\mathbb{Q} x, x)$ injects the algebraic reals into the $\\Sigma$, so $\\#\\{x:\\mathbb{R}\\mid \\text{alg}\\} \\le \\aleph_0$; with $\\aleph_0 \\le \\#\\{\\cdots\\}$ the count is exactly $\\aleph_0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "minpoly.aeval",
+      "minpoly.ne_zero",
+      "isAlgebraic_iff_isIntegral",
+      "Polynomial.mem_rootSet",
+      "Cardinal.mk_le_of_injective",
+      "isAlgebraic_nat"
+    ],
+    "prerequisites": [
+      "minimal polynomials",
+      "injections and cardinal comparison",
+      "antisymmetry of ≤ on cardinals"
+    ]
+  }
+]

--- a/src/data/proofs/denumerability-rationals-oq-07/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-07/meta.json
@@ -1,0 +1,180 @@
+{
+  "id": "denumerability-rationals-oq-07",
+  "title": "The Algebraic Reals as a Σ over ℚ[X]: #{x : ℝ // IsAlgebraic ℚ x} = ℵ₀",
+  "slug": "denumerability-rationals-oq-07",
+  "description": "Turns OQ-06's #(ℚ[X]) = ℵ₀ into the explicit mechanism behind the countability of the algebraic numbers: every algebraic real is a root of its minimal polynomial, giving an injection {x : ℝ // IsAlgebraic ℚ x} ↪ Σ p : ℚ[X], p.rootSet ℝ. That Σ is a countable (indexed by ℚ[X]) union of finite root fibers, so #(Σ) ≤ ℵ₀, whence #{x : ℝ // IsAlgebraic ℚ x} = ℵ₀ (and likewise for ℂ). Exposes the Σ-over-polynomials/finite-fiber decomposition that the gallery previously only invoked through the black-box one-liner Algebraic.cardinalMk_of_countable_of_charZero.",
+  "meta": {
+    "author": "Georg Cantor (1874, countability of algebraic numbers)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ07.lean",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "countability",
+      "algebraic-numbers",
+      "polynomials",
+      "aleph-null",
+      "classic"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.cardinalMk_eq_max",
+        "description": "For a nontrivial semiring R, #(R[X]) = max #R ℵ₀",
+        "module": "Mathlib.Algebra.Polynomial.Cardinal"
+      },
+      {
+        "theorem": "Polynomial.rootSet_finite",
+        "description": "The set of roots of a polynomial in an algebra is finite",
+        "module": "Mathlib.Algebra.Polynomial.Roots"
+      },
+      {
+        "theorem": "Polynomial.mem_rootSet",
+        "description": "a ∈ p.rootSet S ↔ p ≠ 0 ∧ aeval a p = 0 (under NoZeroSMulDivisors)",
+        "module": "Mathlib.Algebra.Polynomial.Roots"
+      },
+      {
+        "theorem": "Cardinal.mk_sigma",
+        "description": "#(Σ i, f i) = Cardinal.sum (fun i => #(f i))",
+        "module": "Mathlib.SetTheory.Cardinal.Defs"
+      },
+      {
+        "theorem": "Cardinal.sum_le_sum",
+        "description": "Monotonicity of Cardinal.sum under pointwise ≤",
+        "module": "Mathlib.SetTheory.Cardinal.Order"
+      },
+      {
+        "theorem": "Cardinal.sum_const'",
+        "description": "Cardinal.sum (fun _ : ι => a) = #ι * a (same universe)",
+        "module": "Mathlib.SetTheory.Cardinal.Defs"
+      },
+      {
+        "theorem": "Cardinal.aleph0_mul_aleph0",
+        "description": "ℵ₀ * ℵ₀ = ℵ₀",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "isAlgebraic_nat",
+        "description": "Every natural number (n : A) is algebraic over a nontrivial base ring R — used to build the ℕ-injection giving the lower bound ℵ₀ ≤ #{x // IsAlgebraic ℚ x}",
+        "module": "Mathlib.RingTheory.Algebraic.Basic"
+      },
+      {
+        "theorem": "minpoly.aeval / minpoly.ne_zero",
+        "description": "The minimal polynomial of an integral element annihilates it and is nonzero",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "isAlgebraic_iff_isIntegral",
+        "description": "Over a field, IsAlgebraic ↔ IsIntegral (so minpoly is available)",
+        "module": "Mathlib.RingTheory.Algebraic.Integral"
+      }
+    ],
+    "originalContributions": [
+      "cardinalMk_polynomial_rat: #(ℚ[X]) = ℵ₀ reproved inline (the OQ-06 fact), keeping the entry standalone",
+      "cardinalMk_sigma_rootSet_le: #(Σ p : ℚ[X], p.rootSet K) ≤ ℵ₀ for any char-zero field K — the finite-fiber/ℵ₀-many-polynomials count made explicit",
+      "algebraicReal_inject_sigma: the injection x ↦ (minpoly ℚ x, x) of the algebraic reals into the Σ-over-ℚ[X]",
+      "aleph0_le_cardinalMk_algebraic: ℵ₀ ≤ #{x : K // IsAlgebraic ℚ x} for any char-zero field K, built explicitly from the ℕ-injection n ↦ (n : K) (no black-box Mathlib lower-bound lemma)",
+      "cardinalMk_algebraic_reals_le_sigma + cardinalMk_algebraic_reals_le: #{x : ℝ // IsAlgebraic ℚ x} ≤ #(Σ …) ≤ ℵ₀ via the explicit decomposition",
+      "cardinalMk_algebraic_reals: #{x : ℝ // IsAlgebraic ℚ x} = ℵ₀ from the Σ bound plus the char-zero lower bound",
+      "cardinalMk_algebraic_complex_le + cardinalMk_algebraic_complex: the same Σ-over-ℚ[X] decomposition for ℂ"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound.",
+    "lineCount": 127,
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Cantor's 1874 proof that the algebraic numbers are countable runs in two stages: there are only countably many polynomials over ℚ, and each contributes finitely many roots. OQ-06 supplied the first stage as a clean cardinal fact, #(ℚ[X]) = ℵ₀. This entry supplies the second stage and the assembly: it indexes the algebraic numbers by the polynomial that witnesses them and bounds the resulting countable union of finite fibers. The gallery already states #{x : ℝ // IsAlgebraic ℚ x} = ℵ₀ once, but only through Mathlib's black-box Algebraic.cardinalMk_of_countable_of_charZero; here the Σ-over-ℚ[X]/finite-fiber structure that makes the statement true is laid bare.",
+    "problemStatement": "Make the countability of the algebraic real numbers explicit through the polynomial decomposition: exhibit an injection {x : ℝ // IsAlgebraic ℚ x} ↪ Σ p : ℚ[X], p.rootSet ℝ, bound that Σ by ℵ₀, and conclude #{x : ℝ // IsAlgebraic ℚ x} = ℵ₀ (and the same for ℂ).\n\n**Answer:** The map x ↦ (minpoly ℚ x, x) is a well-defined injection into the Σ; the Σ is Cardinal.sum over ℚ[X] of the finite cardinals #(p.rootSet ℝ), hence ≤ #(ℚ[X]) · ℵ₀ = ℵ₀ · ℵ₀ = ℵ₀; the lower bound ℵ₀ ≤ #(algebraic reals) comes from ℕ ↪ algebraic reals in characteristic zero.",
+    "text": "The algebraic real numbers are countable, made explicit as a Σ over ℚ[X] of finite root fibers: #{x : ℝ // IsAlgebraic ℚ x} = ℵ₀.",
+    "proofStrategy": "1. cardinalMk_polynomial_rat: reprove #(ℚ[X]) = ℵ₀ inline (OQ-06).\n2. cardinalMk_sigma_rootSet_le: #(Σ p : ℚ[X], p.rootSet K) = Cardinal.sum (fun p => #(p.rootSet K)) by mk_sigma; each fiber is finite so #(p.rootSet K) ≤ ℵ₀; sum_le_sum bounds the sum by sum (fun _ => ℵ₀) = #(ℚ[X]) · ℵ₀ = ℵ₀ · ℵ₀ = ℵ₀.\n3. algebraicReal_inject_sigma: x ↦ (minpoly ℚ x, x); membership x ∈ (minpoly ℚ x).rootSet ℝ via isAlgebraic_iff_isIntegral + minpoly.ne_zero + minpoly.aeval; injectivity because the second coordinate recovers x.\n4. cardinalMk_algebraic_reals_le: compose the injection bound with the Σ bound to get ≤ ℵ₀.\n5. cardinalMk_algebraic_reals: le_antisymm with aleph0_le_cardinalMk_algebraic (built from the ℕ-injection n ↦ (n : ℝ) via isAlgebraic_nat) for the reverse.\n6. The ℂ versions reuse the identical decomposition.",
+    "keyInsights": [
+      "**The proof is an injection into a labelled disjoint union**: an algebraic number carries no canonical name, but its minimal polynomial does — pairing x with (minpoly ℚ x, x) records exactly the witness that organises the algebraic numbers into ℚ[X]-indexed fibers.",
+      "**Countable union of finite sets**: each fiber p.rootSet ℝ is finite (a polynomial has finitely many roots), and the index ℚ[X] is ℵ₀ (OQ-06), so the whole Σ is a countable union of finite sets — the textbook shape of a countability argument, here made literal as a Cardinal.sum bound.",
+      "**Separating mechanism from black box**: the gallery's prior #{algebraic reals} = ℵ₀ used Mathlib's one-line Algebraic.cardinalMk_of_countable_of_charZero; this entry rebuilds the same conclusion through the explicit Σ so the polynomial/finite-fiber structure is visible and reusable.",
+      "**Char-zero supplies the lower bound for free**: ℵ₀ ≤ #{x // IsAlgebraic ℚ x} holds because ℕ embeds into the algebraic numbers (every natural is algebraic, isAlgebraic_nat), proved here as the explicit lemma aleph0_le_cardinalMk_algebraic so the antisymmetry closing the equality is fully self-contained.",
+      "**ℝ and ℂ are interchangeable here**: nothing in the decomposition uses order or completeness of ℝ — only that the target is a char-zero field — so the ℂ count is the same proof verbatim."
+    ],
+    "prerequisites": [
+      "Cardinal numbers, ℵ₀, and Cardinal.sum",
+      "Countable union of finite sets is countable",
+      "Minimal polynomials and root sets",
+      "Algebraic vs. integral elements over a field"
+    ]
+  },
+  "sections": [
+    {
+      "id": "polynomial-count",
+      "title": "The Index Set: #(ℚ[X]) = ℵ₀",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "File docstring laying out the two-stage Cantor argument and the injection x ↦ (minpoly ℚ x, x). cardinalMk_polynomial_rat reproves #(ℚ[X]) = ℵ₀ inline (the OQ-06 fact) via Polynomial.cardinalMk_eq_max and max_self, so the entry is standalone.",
+      "mathContext": "#(ℚ[X]) = ℵ₀ is the ℵ₀-sized index over which the algebraic numbers are organised."
+    },
+    {
+      "id": "sigma-bound",
+      "title": "The Σ-over-ℚ[X] of Finite Root Fibers is ≤ ℵ₀",
+      "startLine": 51,
+      "endLine": 67,
+      "summary": "cardinalMk_sigma_rootSet_le: rewrites #(Σ p : ℚ[X], p.rootSet K) as Cardinal.sum of the fiber cardinals via mk_sigma, bounds each finite fiber by ℵ₀ (rootSet_finite), and collapses the constant sum #(ℚ[X]) · ℵ₀ = ℵ₀ · ℵ₀ = ℵ₀.",
+      "mathContext": "A countable union (over ℚ[X]) of finite sets (p.rootSet K) is countable: Cardinal.sum ≤ #(ℚ[X]) · ℵ₀ = ℵ₀."
+    },
+    {
+      "id": "injection-and-count",
+      "title": "Injecting the Algebraic Reals and the ℵ₀ Count",
+      "startLine": 64,
+      "endLine": 127,
+      "summary": "algebraicReal_inject_sigma builds x ↦ (minpoly ℚ x, x) and proves membership and injectivity; cardinalMk_algebraic_reals_le_sigma and cardinalMk_algebraic_reals_le give ≤ ℵ₀; cardinalMk_algebraic_reals closes the equality with the char-zero lower bound. The ℂ analogues (cardinalMk_algebraic_complex_le, cardinalMk_algebraic_complex) reuse the same decomposition.",
+      "mathContext": "Injection + Σ bound gives #{x : ℝ // IsAlgebraic ℚ x} ≤ ℵ₀; with ℵ₀ ≤ #(algebraic reals) the count is exactly ℵ₀, and identically for ℂ."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "note": "The original countability of the algebraic numbers via countability of polynomials and finiteness of root sets"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-06",
+      "relationship": "extends",
+      "description": "OQ-06 proved #(ℚ[X]) = ℵ₀; OQ-07 feeds it through the explicit Σ-over-ℚ[X] decomposition to count the algebraic numbers"
+    },
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "related",
+      "description": "Rebuilds the algebraic-reals count #{x : ℝ // IsAlgebraic ℚ x} = ℵ₀ through the explicit polynomial/finite-fiber mechanism rather than the black-box one-liner"
+    }
+  ],
+  "conclusion": {
+    "summary": "The algebraic real (and complex) numbers are countable, made explicit as a Σ over ℚ[X] of finite root fibers: the injection x ↦ (minpoly ℚ x, x) lands in Σ p : ℚ[X], p.rootSet ℝ, which has cardinality ≤ #(ℚ[X]) · ℵ₀ = ℵ₀, giving #{x : ℝ // IsAlgebraic ℚ x} = ℵ₀.",
+    "implications": "Exposes the Σ-over-polynomials/finite-fiber structure behind algebraic countability as directly citable lemmas, complementing the gallery's previous black-box statement and OQ-06's #(ℚ[X]) = ℵ₀.",
+    "openQuestions": [
+      "Grade the algebraic numbers by the degree of their minimal polynomial and show each degree-d stratum is ℵ₀, refining the single Σ bound into a height/degree filtration.",
+      "Replace ℚ[X] by ℤ[X] (or by MvPolynomial (Fin n) ℚ) as the index and recover the same count, linking to OQ-06's #(ℤ[X]) = ℵ₀."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal",
+      "Polynomial"
+    ],
+    "namespace": "DenumerabilityRationalsOQ07",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/DenumerabilityRationalsOQ07.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Makes the countability of the algebraic numbers **explicit** through the polynomial decomposition that OQ-06 set up, rather than the gallery's prior black-box one-liner (`Algebraic.cardinalMk_of_countable_of_charZero`).

The two-stage Cantor (1874) argument, made literal:
- **Index** `ℚ[X]` is `ℵ₀` (OQ-06's `#(ℚ[X])=ℵ₀`, reproved inline so the entry stands alone).
- **Fibers** `p.rootSet ℝ` are finite (a polynomial has finitely many roots).
- The injection `x ↦ (minpoly ℚ x, x)` embeds `{x:ℝ // IsAlgebraic ℚ x}` into `Σ p:ℚ[X], p.rootSet ℝ`, a countable union of finite sets:

  `#(Σ p:ℚ[X], p.rootSet ℝ) ≤ #(ℚ[X])·ℵ₀ = ℵ₀·ℵ₀ = ℵ₀`.

- Lower bound `ℵ₀ ≤ #(algebraic reals)` is built **self-contained** from the ℕ-injection `n ↦ (n:K)` (every natural is algebraic, `isAlgebraic_nat`) — no black-box Mathlib lower-bound lemma — giving `#{x:ℝ // IsAlgebraic ℚ x} = ℵ₀`, and identically for `ℂ`.

## Theorems (9)
- `cardinalMk_polynomial_rat : #(ℚ[X]) = ℵ₀`
- `cardinalMk_sigma_rootSet_le : #(Σ p:ℚ[X], p.rootSet K) ≤ ℵ₀` (any char-zero field `K`)
- `algebraicReal_inject_sigma` — the `x ↦ (minpoly ℚ x, x)` injection
- `aleph0_le_cardinalMk_algebraic : ℵ₀ ≤ #{x:K // IsAlgebraic ℚ x}` (ℕ-injection)
- `cardinalMk_algebraic_reals : #{x:ℝ // IsAlgebraic ℚ x} = ℵ₀` (+ `_le`, `_le_sigma`)
- `cardinalMk_algebraic_complex : #{x:ℂ // IsAlgebraic ℚ x} = ℵ₀` (+ `_le`)

## Verification
- 0 sorries, **0 axioms** (`#print axioms`: only `propext`, `Classical.choice`, `Quot.sound`).
- Typechecks against pinned Mathlib 4.26.0.

Extends `denumerability-rationals-oq-06` (`#(ℚ[X])=ℵ₀`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)