### PR TITLE
research(perfect-numbers-oq-06): every even perfect number is triangular (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2833,6 +2833,7 @@ import Proofs.PellEquationOQ01
 import Proofs.PentagonalNumberTheoremOQ01
 import Proofs.PerfectNumbers
 import Proofs.PerfectNumbersOQ03
+import Proofs.PerfectNumbersOQ06
 import Proofs.PiTranscendental
 import Proofs.PicksTheorem
 import Proofs.PicksTheoremOQ01

--- a/proofs/Proofs/PerfectNumbersOQ06.lean
+++ b/proofs/Proofs/PerfectNumbersOQ06.lean
@@ -1,0 +1,104 @@
+import Archive.Wiedijk100Theorems.PerfectNumbers
+import Mathlib.Tactic
+
+/-
+# Every Even Perfect Number is Triangular
+
+## What This Proves
+
+A *triangular number* is one of the form `Tₘ = m(m+1)/2` (the count of dots
+in a triangular arrangement): `1, 3, 6, 10, 15, 21, 28, …`.
+
+A number is *perfect* if it equals the sum of its proper divisors
+(`6 = 1+2+3`, `28 = 1+2+4+7+14`).
+
+**Main result.** Every even perfect number is a triangular number.  More
+precisely, if `n` is even and perfect then `n = T_{2^{p}-1}` where
+`2^{p}-1` is the Mersenne prime occurring in the Euclid–Euler factorization
+`n = 2^{p-1}(2^{p}-1)`.  So the triangulating index is the Mersenne prime
+itself.
+
+For example:
+- `6  = T₃   = 3·4/2`      (Mersenne prime `3`)
+- `28 = T₇   = 7·8/2`      (Mersenne prime `7`)
+- `496 = T₃₁ = 31·32/2`    (Mersenne prime `31`)
+- `8128 = T₁₂₇ = 127·128/2` (Mersenne prime `127`)
+
+## Approach
+
+The Euclid–Euler theorem (`Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`,
+from Mathlib's Archive) gives `n = 2^k · m` with `m = mersenne (k+1) = 2^{k+1}-1`
+a Mersenne prime.  The key arithmetic identity is then purely algebraic:
+`2·n = 2 · 2^k · (2^{k+1}-1) = 2^{k+1} · (2^{k+1}-1) = m · (m+1)`,
+using `m + 1 = 2^{k+1}`.  Hence `n = m(m+1)/2 = T_m`.  Working with the
+*doubled* form `2·n = m·(m+1)` keeps the whole argument free of natural-number
+division.
+
+## Distinctness
+
+The parent `PerfectNumbers.lean` proves the Euclid–Euler characterization
+(the Mersenne *form*) but never the triangular consequence.  `PerfectNumbersOQ03`
+covers a different angle.  This file closes the form → triangular gap.
+
+## Status
+- [x] Complete proof, 0 sorries, 0 axioms (beyond Mathlib's foundational set)
+-/
+
+namespace PerfectNumbersOQ06
+
+open scoped ArithmeticFunction
+
+/-- `IsTriangular n` means `n` is the `m`-th triangular number `m(m+1)/2`
+for some `m`. -/
+def IsTriangular (n : ℕ) : Prop := ∃ m : ℕ, n = m * (m + 1) / 2
+
+/-- The doubled form: `n` is triangular as soon as `2 * n = m * (m + 1)`.
+This is the division-free certificate of triangularity. -/
+theorem isTriangular_of_two_mul {n m : ℕ} (h : 2 * n = m * (m + 1)) :
+    IsTriangular n := by
+  refine ⟨m, ?_⟩
+  rw [← h, Nat.mul_div_cancel_left n (by norm_num)]
+
+/-- Every triangular number `m(m+1)/2` satisfies `2 * Tₘ = m(m+1)`
+(consecutive integers have an even product, so the division is exact). -/
+theorem two_mul_triangular (m : ℕ) : 2 * (m * (m + 1) / 2) = m * (m + 1) := by
+  have h2 : 2 ∣ m * (m + 1) := (Nat.even_mul_succ_self m).two_dvd
+  rw [Nat.mul_div_cancel' h2]
+
+/-- **Core identity.** For the Euclid–Euler factor `n = 2^k · (2^{k+1}-1)`,
+the doubled value equals `m·(m+1)` with `m = 2^{k+1}-1`, since
+`m + 1 = 2^{k+1}`. -/
+theorem two_mul_euclid_factor (k : ℕ) :
+    2 * (2 ^ k * mersenne (k + 1)) = mersenne (k + 1) * (mersenne (k + 1) + 1) := by
+  have hm1 : mersenne (k + 1) + 1 = 2 ^ (k + 1) := by
+    rw [mersenne, Nat.sub_add_cancel Nat.one_le_two_pow]
+  -- Keep `mersenne (k+1)` opaque; only `m + 1 = 2^{k+1} = 2·2^k` is needed.
+  rw [hm1, pow_succ]
+  ring
+
+/-- **Main theorem.** Every even perfect number is triangular; the triangulating
+index is the Mersenne prime from its Euclid–Euler factorization. -/
+theorem even_perfect_isTriangular {n : ℕ} (hev : Even n) (hperf : n.Perfect) :
+    IsTriangular n := by
+  obtain ⟨k, _hprime, rfl⟩ :=
+    Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect hev hperf
+  exact isTriangular_of_two_mul (two_mul_euclid_factor k)
+
+/-- Strengthened form: an even perfect number `n` equals `T_m` where `m` is a
+Mersenne prime (so the triangulating index is itself prime). -/
+theorem even_perfect_triangular_mersenne_prime {n : ℕ} (hev : Even n) (hperf : n.Perfect) :
+    ∃ m : ℕ, m.Prime ∧ n = m * (m + 1) / 2 := by
+  obtain ⟨k, hprime, rfl⟩ :=
+    Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect hev hperf
+  refine ⟨mersenne (k + 1), hprime, ?_⟩
+  have h := two_mul_euclid_factor k
+  rw [← h, Nat.mul_div_cancel_left _ (by norm_num)]
+
+/-! ## Concrete examples (the first four perfect numbers) -/
+
+example : IsTriangular 6 := ⟨3, by norm_num⟩      -- 6 = T₃
+example : IsTriangular 28 := ⟨7, by norm_num⟩      -- 28 = T₇
+example : IsTriangular 496 := ⟨31, by norm_num⟩    -- 496 = T₃₁
+example : IsTriangular 8128 := ⟨127, by norm_num⟩  -- 8128 = T₁₂₇
+
+end PerfectNumbersOQ06

--- a/src/data/research/problems/perfect-numbers-oq-06.json
+++ b/src/data/research/problems/perfect-numbers-oq-06.json
@@ -1,0 +1,106 @@
+{
+  "slug": "perfect-numbers-oq-06",
+  "title": "Every Even Perfect Number is Triangular",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "proof",
+  "problemStatement": {
+    "formal": "n \\text{ even} \\wedge n \\text{ perfect} \\implies \\exists m,\\ n = \\tfrac{m(m+1)}{2}",
+    "plain": "Every even perfect number is a triangular number. More precisely, if n is even and perfect then n = T_{2^p-1} where 2^p-1 is the Mersenne prime in the Euclid–Euler factorization n = 2^{p-1}(2^p-1); so the triangulating index is itself a Mersenne prime.",
+    "whyMatters": [
+      "Classical consequence of Euclid–Euler: all known perfect numbers are triangular",
+      "Links two of the most famous figurate/number-theoretic families",
+      "Examples: 6=T_3, 28=T_7, 496=T_31, 8128=T_127 — the index is the Mersenne prime",
+      "Closes the form → triangular gap left open by the parent Euclid–Euler entry"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "even_perfect_isTriangular: Even n ∧ n.Perfect → IsTriangular n",
+      "even_perfect_triangular_mersenne_prime: even perfect n = T_m with m = mersenne(k+1) prime",
+      "two_mul_euclid_factor: 2·(2^k·mersenne(k+1)) = mersenne(k+1)·(mersenne(k+1)+1) (division-free core identity)",
+      "isTriangular_of_two_mul / two_mul_triangular: division-free certificate for triangularity",
+      "Concrete examples: 6, 28, 496, 8128 all IsTriangular"
+    ],
+    "open": [],
+    "goal": "Prove every even perfect number is triangular, 0 sorries, 0 axioms beyond Mathlib's foundational set."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-19T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Proof complete and machine-checked. Uses Mathlib Archive Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect for the Euclid–Euler factorization, then the division-free identity 2n = m(m+1) with m = mersenne(k+1). Verified 0 axioms.",
+    "blockers": [],
+    "nextAction": "None. Lean obligations fully discharged.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE. Every even perfect number is triangular, with triangulating index equal to the Mersenne prime from its Euclid–Euler factorization. Verified 0 sorries / 0 axioms.",
+    "builtItems": [
+      "PerfectNumbersOQ06.lean: even-perfect → triangular (~105 lines)",
+      "IsTriangular (n : ℕ) := ∃ m, n = m*(m+1)/2: triangular-number predicate",
+      "isTriangular_of_two_mul: 2n = m(m+1) → IsTriangular n (division-free certificate)",
+      "two_mul_triangular: 2·T_m = m(m+1) via Nat.even_mul_succ_self",
+      "two_mul_euclid_factor: 2·(2^k·mersenne(k+1)) = mersenne(k+1)·(mersenne(k+1)+1)",
+      "even_perfect_isTriangular: main theorem",
+      "even_perfect_triangular_mersenne_prime: strengthened (index is a Mersenne prime)"
+    ],
+    "insights": [
+      "Working with the doubled form 2n = m(m+1) sidesteps all natural-number division",
+      "m + 1 = 2^{k+1} follows from mersenne (k+1) = 2^{k+1} - 1 via Nat.sub_add_cancel Nat.one_le_two_pow",
+      "After rw [hm1, pow_succ], the identity 2·2^k·m = m·(2·2^k) is pure ring",
+      "Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect returns ∃ k, Prime (mersenne (k+1)) ∧ n = 2^k · mersenne (k+1)",
+      "Nat.even_mul_succ_self m gives 2 ∣ m(m+1); Nat.mul_div_cancel' makes 2·(m(m+1)/2)=m(m+1) exact",
+      "Keeping mersenne (k+1) opaque (only using m+1 = 2^{k+1}) avoids unfolding subtraction"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the Euclid–Euler theorem but no statement that even perfect numbers are triangular"
+    ],
+    "nextSteps": []
+  },
+  "tags": [
+    "number-theory",
+    "perfect-numbers",
+    "triangular-numbers",
+    "mersenne-primes",
+    "euclid-euler"
+  ],
+  "relatedProofs": [
+    "perfect-numbers",
+    "perfect-numbers-oq-03",
+    "triangular-reciprocals"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect",
+      "mersenne",
+      "Nat.even_mul_succ_self",
+      "Nat.mul_div_cancel'",
+      "Nat.sub_add_cancel"
+    ]
+  },
+  "started": "2026-06-19T00:00:00.000Z",
+  "lastUpdate": "2026-06-19T00:00:00.000Z",
+  "significance": 6,
+  "tractability": 8,
+  "leanFiles": [
+    {
+      "path": "Proofs/PerfectNumbersOQ06.lean",
+      "filename": "PerfectNumbersOQ06.lean",
+      "lineCount": 105,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PerfectNumbersOQ06.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Every Even Perfect Number is Triangular

Closes the **form → triangular** gap left open by the Euclid–Euler entry: Mathlib has the Euclid–Euler characterization of even perfect numbers but never states that they are triangular numbers.

### Result
Every even perfect number `n` is a triangular number `T_m = m(m+1)/2`, and the triangulating index `m = mersenne(k+1)` is precisely the **Mersenne prime** from the factorization `n = 2^k·(2^{k+1}-1)`.

| n | = | index (Mersenne prime) |
|---|---|---|
| 6 | T₃ | 3 |
| 28 | T₇ | 7 |
| 496 | T₃₁ | 31 |
| 8128 | T₁₂₇ | 127 |

### Approach
Reduce via `Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`, then prove the purely algebraic identity in the **division-free doubled form**
`2n = 2·2^k·(2^{k+1}-1) = m·(m+1)` with `m = mersenne(k+1)`, using `m + 1 = 2^{k+1}`. Working with `2n = m(m+1)` sidesteps all natural-number division.

### Key declarations
- `even_perfect_isTriangular : Even n ∧ n.Perfect → IsTriangular n`
- `even_perfect_triangular_mersenne_prime` — strengthened: the index is a Mersenne prime
- `two_mul_euclid_factor` — division-free core identity
- `isTriangular_of_two_mul` / `two_mul_triangular` — division-free triangularity certificate

### Verification
- Docker build succeeds: `Built Proofs.PerfectNumbersOQ06`
- 0 sorries, 0 `axiom` declarations
- `#print axioms` on both main theorems: only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `ofReduceBool`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)