### PR TITLE
research(pythagorean-triples-oq-08): 60 ∣ x·y·z for every Pythagorean triple (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3030,6 +3030,7 @@ import Proofs.PythagoreanTriplesOQ04
 import Proofs.PythagoreanTriplesOQ05
 import Proofs.PythagoreanTriplesOQ06
 import Proofs.PythagoreanTriplesOQ07
+import Proofs.PythagoreanTriplesOQ08
 import Proofs.PythagoreanTriplesOQ09
 import Proofs.QuadraticGaussSumDiagonal
 import Proofs.QuadraticGaussSumNormParseval

--- a/proofs/Proofs/PythagoreanTriplesOQ08.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ08.lean
@@ -1,0 +1,148 @@
+/-
+  # Sixty Divides the Product of a Pythagorean Triple's Sides
+  # (pythagorean-triples-oq-08)
+
+  ## The Open Question
+
+  For every Pythagorean triple `x² + y² = z²` in integers, the product `x · y · z`
+  of the three sides is divisible by `60 = 4 · 3 · 5`. No primitivity (coprimality)
+  hypothesis is required: the divisibility holds for *all* triples, scaled or not.
+
+  ## What is proved
+
+  The result splits into three independent residue obstructions, each verified by a
+  finite `decide` over `ZMod n` and then transported to `ℤ` through
+  `ZMod.intCast_zmod_eq_zero_iff_dvd`:
+
+  * **`3 ∣ x · y`** — modulo 3 every square is `0` or `1`, so `x² + y² = z²` forces a
+    leg to vanish mod 3 (otherwise `z² ≡ 2`, impossible). One *leg* is divisible by 3.
+
+  * **`4 ∣ x · y`** — modulo 4 alone this *fails* (e.g. `(2,1,1)` satisfies the equation
+    yet `x·y ≡ 2`); the genuine obstruction lives mod 8. Over `ZMod 8` every solution
+    has `x · y ∈ {0, 4}`, which gives `4 ∣ x · y`. One *leg* is divisible by 4.
+
+  * **`5 ∣ x · y · z`** — modulo 5 squares are `0, 1, 4`, and the only way to solve
+    `x² + y² = z²` is for some *side* (leg or hypotenuse) to vanish mod 5.
+
+  Combining the coprime factors `3`, `4`, `5` yields the headline `12 ∣ x · y` and
+  `60 ∣ x · y · z`.
+
+  ## Why this is new
+
+  The sibling files cover the parametrization (`oq-06`), the parity dichotomy
+  (`oq-07`, exactly one even leg), and lattice density (`oq-01`). The 3-, 4- and
+  5-divisibility of the product — and especially the mod-8 sharpening that the naive
+  mod-4 argument cannot reach — appear nowhere else in the gallery.
+
+  ## Axiom count: 0  (all `decide`, no `native_decide`)
+-/
+
+import Mathlib
+
+namespace PythagoreanTriplesSixty
+
+open PythagoreanTriple
+
+variable {x y z : ℤ}
+
+/-! ## Part I: Finite residue obstructions
+
+Each of the following is a complete finite check over the residues `ZMod n`. The
+equation `a * a + b * b = c * c` is the image of the integer Pythagorean equation
+under the ring map `ℤ → ZMod n`. -/
+
+/-- Mod 3, a leg vanishes: every solution of `a² + b² = c²` has `a · b = 0`.
+Squares are `0, 1` mod 3, so two nonzero legs give `c² ≡ 2`, impossible. -/
+theorem ab_zero_mod3 : ∀ a b c : ZMod 3, a * a + b * b = c * c → a * b = 0 := by
+  decide
+
+/-- Mod 8, a leg is divisible by 4: every solution has `a · b ∈ {0, 4}`.
+Modulo 4 alone is insufficient — `(2,1,1)` is a spurious solution with `a·b ≡ 2` —
+so the sharp obstruction must be read off mod 8. -/
+theorem ab_quarter_mod8 :
+    ∀ a b c : ZMod 8, a * a + b * b = c * c → a * b = 0 ∨ a * b = 4 := by
+  decide
+
+/-- Mod 5, a side vanishes: every solution of `a² + b² = c²` has `a · b · c = 0`.
+Squares are `0, 1, 4` mod 5, and no sum of two nonzero squares is a nonzero square. -/
+theorem abc_zero_mod5 : ∀ a b c : ZMod 5, a * a + b * b = c * c → a * b * c = 0 := by
+  decide
+
+/-! ## Part II: Casting the equation into `ZMod n`
+
+The Pythagorean equation in `ℤ` maps to the corresponding equation in any `ZMod n`. -/
+
+/-- The Pythagorean equation reduced mod `n`. -/
+theorem cast_eq (h : PythagoreanTriple x y z) (n : ℕ) :
+    (x : ZMod n) * x + y * y = z * z := by
+  have he : x * x + y * y = z * z := h
+  have h' : ((x * x + y * y : ℤ) : ZMod n) = ((z * z : ℤ) : ZMod n) := by rw [he]
+  push_cast at h'
+  exact h'
+
+/-! ## Part III: Integer divisibility of the product -/
+
+/-- A leg of any Pythagorean triple is divisible by 3: `3 ∣ x · y`. -/
+theorem three_dvd_legs (h : PythagoreanTriple x y z) : (3 : ℤ) ∣ x * y := by
+  have hz : ((x * y : ℤ) : ZMod 3) = 0 := by
+    push_cast
+    exact ab_zero_mod3 _ _ _ (cast_eq h 3)
+  exact_mod_cast (ZMod.intCast_zmod_eq_zero_iff_dvd (x * y) 3).mp hz
+
+/-- A leg of any Pythagorean triple is divisible by 4: `4 ∣ x · y`.
+The proof goes through `ZMod 8`, since mod 4 alone does not force this. -/
+theorem four_dvd_legs (h : PythagoreanTriple x y z) : (4 : ℤ) ∣ x * y := by
+  rcases ab_quarter_mod8 _ _ _ (cast_eq h 8) with h0 | h4
+  · -- x·y ≡ 0 (mod 8) ⟹ 8 ∣ x·y ⟹ 4 ∣ x·y
+    have hz : ((x * y : ℤ) : ZMod 8) = 0 := by push_cast; exact h0
+    have h8 : (8 : ℤ) ∣ x * y := by
+      exact_mod_cast (ZMod.intCast_zmod_eq_zero_iff_dvd (x * y) 8).mp hz
+    omega
+  · -- x·y ≡ 4 (mod 8) ⟹ 8 ∣ (x·y − 4) ⟹ 4 ∣ x·y
+    have hz : ((x * y - 4 : ℤ) : ZMod 8) = 0 := by push_cast; rw [h4]; ring
+    have h8 : (8 : ℤ) ∣ (x * y - 4) := by
+      exact_mod_cast (ZMod.intCast_zmod_eq_zero_iff_dvd (x * y - 4) 8).mp hz
+    omega
+
+/-- A side of any Pythagorean triple is divisible by 5: `5 ∣ x · y · z`. -/
+theorem five_dvd_sides (h : PythagoreanTriple x y z) : (5 : ℤ) ∣ x * y * z := by
+  have hz : ((x * y * z : ℤ) : ZMod 5) = 0 := by
+    push_cast
+    exact abc_zero_mod5 _ _ _ (cast_eq h 5)
+  exact_mod_cast (ZMod.intCast_zmod_eq_zero_iff_dvd (x * y * z) 5).mp hz
+
+/-! ## Part IV: The headline divisibilities
+
+`12 ∣ x · y` from the coprime factors `3` and `4`; then `60 ∣ x · y · z`. -/
+
+/-- **Twelve divides the product of the legs**: `12 ∣ x · y`. -/
+theorem twelve_dvd_legs (h : PythagoreanTriple x y z) : (12 : ℤ) ∣ x * y := by
+  have cop : IsCoprime (3 : ℤ) 4 := by
+    rw [Int.isCoprime_iff_gcd_eq_one]; decide
+  have h12 := cop.mul_dvd (three_dvd_legs h) (four_dvd_legs h)
+  norm_num at h12
+  exact h12
+
+/-- **Sixty divides the product of the three sides**: `60 ∣ x · y · z`,
+for every Pythagorean triple, with no coprimality hypothesis. -/
+theorem sixty_dvd_product (h : PythagoreanTriple x y z) : (60 : ℤ) ∣ x * y * z := by
+  -- 12 ∣ x·y ⟹ 12 ∣ x·y·z
+  have h12 : (12 : ℤ) ∣ x * y * z := (twelve_dvd_legs h).mul_right z
+  have cop : IsCoprime (12 : ℤ) 5 := by
+    rw [Int.isCoprime_iff_gcd_eq_one]; decide
+  have h60 := cop.mul_dvd h12 (five_dvd_sides h)
+  norm_num at h60
+  exact h60
+
+/-! ## Part V: A concrete instance
+
+The smallest triple `(3, 4, 5)` has product `60`, exactly divisible by `60`. -/
+
+/-- `(3, 4, 5)` is a Pythagorean triple. -/
+theorem triple_345 : PythagoreanTriple 3 4 5 := by
+  unfold PythagoreanTriple; norm_num
+
+/-- The witness: `60 ∣ 3 · 4 · 5`. -/
+example : (60 : ℤ) ∣ 3 * 4 * 5 := sixty_dvd_product triple_345
+
+end PythagoreanTriplesSixty

--- a/src/data/proofs/pythagorean-triples-oq-08/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-08/meta.json
@@ -1,0 +1,174 @@
+{
+  "id": "pythagorean-triples-oq-08",
+  "title": "Sixty Divides the Product of a Pythagorean Triple's Sides",
+  "slug": "pythagorean-triples-oq-08",
+  "description": "For every Pythagorean triple x²+y²=z² in integers, 60 = 4·3·5 divides the product x·y·z, with no coprimality hypothesis. A leg is divisible by 3, a leg is divisible by 4 (a fact that requires a mod-8 argument, not mod-4), and some side is divisible by 5; combining the coprime factors gives 12 ∣ x·y and 60 ∣ x·y·z.",
+  "meta": {
+    "author": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ08.lean",
+    "tags": [
+      "number-theory",
+      "pythagorean-triples",
+      "divisibility",
+      "modular-arithmetic",
+      "diophantine",
+      "classic"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-19",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "PythagoreanTriple",
+        "description": "The predicate x*x + y*y = z*z over ℤ",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      },
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "(↑a : ZMod b) = 0 ↔ (b : ℤ) ∣ a — transports residue facts to integer divisibility",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Int.isCoprime_iff_gcd_eq_one",
+        "description": "IsCoprime m n ↔ Int.gcd m n = 1",
+        "module": "Mathlib.RingTheory.Int.Basic"
+      },
+      {
+        "theorem": "IsCoprime.mul_dvd",
+        "description": "IsCoprime a b → a ∣ n → b ∣ n → a * b ∣ n — combines coprime divisors",
+        "module": "Mathlib.RingTheory.Coprime.Basic"
+      }
+    ],
+    "originalContributions": [
+      "ab_zero_mod3: every solution of a²+b²=c² over ZMod 3 has a·b = 0 (a leg is divisible by 3) — finite decide",
+      "ab_quarter_mod8: every solution over ZMod 8 has a·b ∈ {0,4} (a leg is divisible by 4); mod 4 alone fails because (2,1,1) is a spurious solution",
+      "abc_zero_mod5: every solution over ZMod 5 has a·b·c = 0 (a side is divisible by 5) — finite decide",
+      "cast_eq: reduction of the integer Pythagorean equation into ZMod n",
+      "three_dvd_legs / four_dvd_legs / five_dvd_sides: integer divisibility 3 ∣ xy, 4 ∣ xy, 5 ∣ xyz",
+      "twelve_dvd_legs: 12 ∣ x·y for every triple",
+      "sixty_dvd_product: 60 ∣ x·y·z for every triple (no coprimality), via coprimality of 12 and 5"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. The residue lemmas use `decide` (kernel reduction, not `native_decide`), so no Lean.ofReduceBool. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 148,
+    "theoremCount": 10,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That 60 divides the product of the three sides of any Pythagorean triangle is a classical elementary number-theory exercise (it appears in Sierpiński's 'Pythagorean Triangles' and countless problem collections). It packages three separate residue facts — one leg divisible by 3, one leg divisible by 4, one side divisible by 5 — into a single statement about x·y·z. The result holds for all triples, not just primitive ones, because scaling a primitive triple only multiplies the product.",
+    "problemStatement": "Can we machine-check that 60 divides the product of the sides of every Pythagorean triple?\n\n**Answer: Yes.** Reduce x²+y²=z² modulo 3, 8, and 5; each finite check (decide) forces a factor of 3, 4, and 5 respectively into the product. Coprimality of 3, 4, 5 combines them into 60 ∣ x·y·z.",
+    "text": "60 divides the product of the three sides of every Pythagorean triple — the combined 3-, 4-, and 5-divisibility obstruction.",
+    "proofStrategy": "For each modulus, cast the integer equation x·x+y·y=z·z into ZMod n (cast_eq) and run a finite decide over all residues: mod 3 forces a·b=0, mod 8 forces a·b∈{0,4}, mod 5 forces a·b·c=0. Transport each to integer divisibility through ZMod.intCast_zmod_eq_zero_iff_dvd (the mod-8 case splits on the two residues and finishes with omega). Finally combine 3 ∣ xy and 4 ∣ xy via IsCoprime.mul_dvd to get 12 ∣ xy, then 12 ∣ xyz with 5 ∣ xyz to get 60 ∣ xyz.",
+    "keyInsights": [
+      "The divisibility by 4 cannot be seen modulo 4: (2,1,1) satisfies a²+b²=c² in ZMod 4 yet a·b ≡ 2. The sharp obstruction lives mod 8, where every solution has a·b ∈ {0,4}",
+      "Each residue obstruction is a complete finite verification via decide (not native_decide), keeping the proof at 0 axioms",
+      "The divisibility by 3 and by 4 land on the LEGS (x·y), while divisibility by 5 may use the hypotenuse — only the product x·y·z is guaranteed for the factor 5 (e.g. in (3,4,5) it is z that carries the 5)",
+      "Coprimality of the prime-power factors 3, 4, 5 is what lets the three obstructions multiply into 60 = 12 · 5",
+      "No primitivity hypothesis is needed anywhere: the statement is about all triples"
+    ],
+    "prerequisites": [
+      "Modular arithmetic and residues (ZMod n)",
+      "Divisibility and coprimality over ℤ",
+      "Pythagorean triples"
+    ]
+  },
+  "sections": [
+    {
+      "id": "residue-obstructions",
+      "title": "Finite Residue Obstructions",
+      "startLine": 48,
+      "endLine": 69,
+      "summary": "Three decide lemmas: mod 3 forces a·b=0, mod 8 forces a·b∈{0,4}, mod 5 forces a·b·c=0.",
+      "mathContext": "Squares are $\\{0,1\\}$ mod 3, $\\{0,1,4\\}$ mod 8, $\\{0,1,4\\}$ mod 5; $a^2+b^2=c^2$ pins a side to $0$."
+    },
+    {
+      "id": "casting",
+      "title": "Casting the Equation into ZMod n",
+      "startLine": 71,
+      "endLine": 82,
+      "summary": "The integer Pythagorean equation maps to the corresponding equation in any ZMod n.",
+      "mathContext": "$x^2+y^2=z^2 \\Rightarrow (\\bar x)^2+(\\bar y)^2=(\\bar z)^2$ in $\\mathbb{Z}/n$."
+    },
+    {
+      "id": "integer-divisibility",
+      "title": "Integer Divisibility of the Product",
+      "startLine": 83,
+      "endLine": 112,
+      "summary": "3 ∣ x·y, 4 ∣ x·y (via mod 8 + omega), 5 ∣ x·y·z, transported from the residue lemmas.",
+      "mathContext": "$3 \\mid xy,\\; 4 \\mid xy,\\; 5 \\mid xyz$."
+    },
+    {
+      "id": "headline",
+      "title": "Twelve and Sixty Divide the Product",
+      "startLine": 114,
+      "endLine": 135,
+      "summary": "Combine coprime factors: 12 ∣ x·y, then 60 ∣ x·y·z for every triple.",
+      "mathContext": "$\\gcd(3,4)=1 \\Rightarrow 12 \\mid xy$; $\\gcd(12,5)=1 \\Rightarrow 60 \\mid xyz$."
+    },
+    {
+      "id": "instance",
+      "title": "A Concrete Instance",
+      "startLine": 137,
+      "endLine": 146,
+      "summary": "The smallest triple (3,4,5) has product 60, exactly divisible by 60.",
+      "mathContext": "$3 \\cdot 4 \\cdot 5 = 60$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Sierpiński, Wacław",
+      "title": "Pythagorean Triangles",
+      "year": "1962",
+      "note": "Classical treatment of divisibility properties of Pythagorean triangles, including 60 ∣ abc"
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1938",
+      "note": "Standard reference on Pythagorean triples and modular arithmetic"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "extends",
+      "description": "Adds the divisibility structure (3, 4, 5 and combined 60) of the product of the sides to the base classification."
+    },
+    {
+      "targetId": "pythagorean-triples-oq-07",
+      "relationship": "related",
+      "description": "oq-07 proves exactly one leg is even and asks (open question) whether the even leg is divisible by 4; this entry proves 4 ∣ x·y for every triple, the product-level form of that 4-divisibility."
+    },
+    {
+      "targetId": "pythagorean-triples-oq-06",
+      "relationship": "related",
+      "description": "oq-06 gives the m,n parametrization of primitive triples; this entry establishes divisibility consequences that hold for all triples without using the parametrization."
+    }
+  ],
+  "conclusion": {
+    "summary": "Sixty divides the product of the sides of every Pythagorean triple, machine-checked at 0 axioms: a leg is divisible by 3, a leg by 4 (a mod-8 fact), a side by 5, and coprimality combines them into 60 ∣ x·y·z.",
+    "implications": "Demonstrates the reduction of integer divisibility statements to finite ZMod checks via ZMod.intCast_zmod_eq_zero_iff_dvd, and isolates the mod-8 sharpening that the naive mod-4 argument cannot reach for the factor of 4.",
+    "openQuestions": [
+      "Sharpen the leg-divisibility: in a primitive triple exactly one leg is divisible by 4 and exactly one leg by 3 (not merely the product) — can the per-leg statement be formalised?",
+      "Generalise to other small moduli: which n have the property that n divides the product of the sides of every Pythagorean triple (n ∈ {1,2,3,4,5,6,10,12,15,20,30,60} and divisors thereof)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "PythagoreanTriple"
+    ],
+    "namespace": "PythagoreanTriplesSixty",
+    "lineCount": 148,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/PythagoreanTriplesOQ08.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

For every Pythagorean triple `x² + y² = z²` in ℤ, the product `x·y·z` of the three sides is divisible by **60 = 4·3·5** — with **no coprimality/primitivity hypothesis**. Holds for all triples, scaled or not.

## What is proved

Three independent residue obstructions, each a finite `decide` over `ZMod n` transported to ℤ via `ZMod.intCast_zmod_eq_zero_iff_dvd`:

| Obstruction | Modulus | Statement |
|---|---|---|
| `three_dvd_legs` | mod 3 | `3 ∣ x·y` (a leg vanishes) |
| `four_dvd_legs` | **mod 8** | `4 ∣ x·y` |
| `five_dvd_sides` | mod 5 | `5 ∣ x·y·z` (a side vanishes) |

Coprimality of `3, 4, 5` (`IsCoprime.mul_dvd`) combines them:
- `twelve_dvd_legs`: `12 ∣ x·y`
- `sixty_dvd_product`: `60 ∣ x·y·z`

## Key insight

The factor of **4 cannot be seen modulo 4**: `(2,1,1)` satisfies `a²+b²=c²` in `ZMod 4` yet `a·b ≡ 2`. The sharp obstruction lives **mod 8**, where every solution has `a·b ∈ {0,4}`.

## Distinctness

Siblings cover the `m,n` parametrization (oq-06), the parity dichotomy (oq-07), and lattice density (oq-01). The 3-/5-divisibility of the product and the mod-8 sharpening for the factor 4 appear nowhere else in the gallery (`grep` for `60 ∣`/`three_dvd` in `PythagoreanTriples*` is empty).

## Verification

- Builds: `✔ Built Proofs.PythagoreanTriplesOQ08` (docker-build.sh, Mathlib v4.26.0)
- **0 axioms**: `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`
- Uses `decide` (kernel reduction), **not** `native_decide` → no `Lean.ofReduceBool`
- 0 sorries, 148 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)