### PR TITLE
research(cyclotomic-polynomials-oq-01): degree φ(n), prime form, divisor product, and Gauss's totient-divisor-sum identity

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -635,6 +635,7 @@ import Proofs.CubeRoot5Irrational
 import Proofs.CubeRoot6Irrational
 import Proofs.CubeRoot7Irrational
 import Proofs.CubeRoot9Irrational
+import Proofs.CyclotomicPolynomialsOQ01
 import Proofs.DeGuaTheorem
 import Proofs.DeMoivre
 import Proofs.DeMoivreOQ01

--- a/proofs/Proofs/CyclotomicPolynomialsOQ01.lean
+++ b/proofs/Proofs/CyclotomicPolynomialsOQ01.lean
@@ -1,0 +1,121 @@
+/-
+Cyclotomic Polynomials OQ-01: Degree, Prime Form, and the Divisor Product
+
+The n-th cyclotomic polynomial Φ_n is the minimal monic polynomial whose roots
+are the primitive n-th roots of unity. Three of its most fundamental structural
+facts are:
+
+  • Degree.        deg Φ_n = φ(n)   (Euler's totient), so Φ_n has exactly φ(n)
+                   primitive-root coefficients.
+  • Prime form.    For a prime p,  Φ_p = 1 + X + X² + ⋯ + X^{p-1}  (the p-term
+                   geometric sum), hence deg Φ_p = p − 1 and Φ_p(1) = p.
+  • Divisor product.  ∏_{d ∣ n} Φ_d = Xⁿ − 1, the factorization of Xⁿ − 1 into
+                   cyclotomic factors indexed by the divisors of n.
+
+This entry packages these facts from Mathlib's cyclotomic library into a single
+coherent topic entry (the gallery previously used `cyclotomic` only as machinery
+inside Galois/trisection proofs, never as a subject in its own right) and derives
+a genuine structural consequence:
+
+  • Gauss's identity.  Taking degrees of the divisor product gives
+                   ∑_{d ∣ n} φ(d) = n
+                   — the classical totient-divisor-sum identity, obtained here
+                   purely from the cyclotomic factorization of Xⁿ − 1.
+
+Main results:
+  • `cyclotomic_natDegree`         — deg Φ_n = φ(n) over any nontrivial ring.
+  • `cyclotomic_prime_natDegree`   — deg Φ_p = p − 1 for prime p.
+  • `cyclotomic_prime_geom_sum`    — Φ_p = ∑_{i<p} Xⁱ for prime p.
+  • `cyclotomic_prime_eval_one`    — Φ_p(1) = p for prime p.
+  • `prod_cyclotomic_divisors`     — ∏_{d ∣ n} Φ_d = Xⁿ − 1 for n > 0.
+  • `sum_totient_divisors`         — ∑_{d ∣ n} φ(d) = n (Gauss), via degrees.
+  Plus concrete witnesses Φ₁, Φ₂, Φ₃ and sample degree/eval computations.
+
+All proofs are `sorry`-free and axiom-free (no `native_decide`).
+
+References:
+- Mathlib `Mathlib/RingTheory/Polynomial/Cyclotomic/Basic.lean` and `Eval.lean`.
+- Gauss's totient-divisor-sum identity ∑_{d∣n} φ(d) = n.
+-/
+
+import Mathlib
+
+open Polynomial Finset Nat
+
+namespace CyclotomicPolynomialsOQ01
+
+/-! ### Degree of the cyclotomic polynomial -/
+
+/-- The degree of the n-th cyclotomic polynomial is Euler's totient φ(n). -/
+theorem cyclotomic_natDegree (n : ℕ) (R : Type*) [Ring R] [Nontrivial R] :
+    (cyclotomic n R).natDegree = Nat.totient n :=
+  natDegree_cyclotomic n R
+
+/-- For a prime p, the cyclotomic polynomial Φ_p has degree p − 1. -/
+theorem cyclotomic_prime_natDegree (p : ℕ) (hp : p.Prime) (R : Type*) [Ring R] [Nontrivial R] :
+    (cyclotomic p R).natDegree = p - 1 := by
+  rw [natDegree_cyclotomic, Nat.totient_prime hp]
+
+/-! ### Prime cyclotomic polynomials are geometric sums -/
+
+/-- For a prime p, `Φ_p = 1 + X + X² + ⋯ + X^{p-1}`, the p-term geometric sum. -/
+theorem cyclotomic_prime_geom_sum (R : Type*) [Ring R] (p : ℕ) [Fact p.Prime] :
+    cyclotomic p R = ∑ i ∈ range p, X ^ i :=
+  cyclotomic_prime R p
+
+/-- Evaluating a prime cyclotomic polynomial at 1 gives the prime: `Φ_p(1) = p`. -/
+theorem cyclotomic_prime_eval_one (R : Type*) [CommRing R] (p : ℕ) [Fact p.Prime] :
+    (cyclotomic p R).eval 1 = p :=
+  eval_one_cyclotomic_prime
+
+/-! ### The divisor product Xⁿ − 1 = ∏_{d ∣ n} Φ_d -/
+
+/-- The factorization of `Xⁿ − 1` into cyclotomic polynomials indexed by the
+divisors of n. -/
+theorem prod_cyclotomic_divisors (n : ℕ) (hn : 0 < n) (R : Type*) [CommRing R] :
+    ∏ d ∈ n.divisors, cyclotomic d R = X ^ n - 1 :=
+  prod_cyclotomic_eq_X_pow_sub_one hn R
+
+/-! ### Gauss's totient-divisor-sum identity, via cyclotomic degrees -/
+
+/-- **Gauss's identity** `∑_{d ∣ n} φ(d) = n`, obtained by taking degrees in the
+cyclotomic factorization `∏_{d ∣ n} Φ_d = Xⁿ − 1` over `ℤ`. The product's degree
+is the sum of the factor degrees (each `Φ_d ≠ 0` in the domain `ℤ`), and each
+factor contributes `deg Φ_d = φ(d)`; the right-hand side `Xⁿ − 1` has degree `n`. -/
+theorem sum_totient_divisors (n : ℕ) (hn : 0 < n) :
+    ∑ d ∈ n.divisors, Nat.totient d = n := by
+  have key : ∏ d ∈ n.divisors, cyclotomic d ℤ = X ^ n - 1 :=
+    prod_cyclotomic_eq_X_pow_sub_one hn ℤ
+  have hdeg := congrArg natDegree key
+  rw [natDegree_prod _ _ (fun d _ => cyclotomic_ne_zero d ℤ)] at hdeg
+  simp only [natDegree_cyclotomic] at hdeg
+  rwa [show (X : ℤ[X]) ^ n - 1 = X ^ n - C 1 by simp, natDegree_X_pow_sub_C] at hdeg
+
+/-! ### Concrete witnesses -/
+
+/-- `Φ₁ = X − 1`. -/
+example : cyclotomic 1 ℤ = X - 1 := cyclotomic_one ℤ
+
+/-- `Φ₂ = X + 1`. -/
+example : cyclotomic 2 ℤ = X + 1 := cyclotomic_two ℤ
+
+/-- `Φ₃ = 1 + X + X²`. -/
+theorem cyclotomic_three : cyclotomic 3 ℤ = 1 + X + X ^ 2 := by
+  haveI : Fact (Nat.Prime 3) := ⟨by norm_num⟩
+  rw [cyclotomic_prime ℤ 3]
+  simp [Finset.sum_range_succ]
+
+/-- Sample degree computation: `deg Φ₇ = 6`. -/
+theorem cyclotomic_seven_natDegree : (cyclotomic 7 ℤ).natDegree = 6 :=
+  cyclotomic_prime_natDegree 7 (by norm_num) ℤ
+
+/-- Sample evaluation: `Φ₅(1) = 5`. -/
+theorem cyclotomic_five_eval_one : (cyclotomic 5 ℤ).eval 1 = 5 := by
+  haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+  exact cyclotomic_prime_eval_one ℤ 5
+
+/-- Sample Gauss identity: `∑_{d ∣ 12} φ(d) = 12`. -/
+theorem sum_totient_twelve : ∑ d ∈ (12 : ℕ).divisors, Nat.totient d = 12 :=
+  sum_totient_divisors 12 (by norm_num)
+
+end CyclotomicPolynomialsOQ01

--- a/src/data/research/problems/cyclotomic-polynomials-oq-01.json
+++ b/src/data/research/problems/cyclotomic-polynomials-oq-01.json
@@ -1,0 +1,88 @@
+{
+  "slug": "cyclotomic-polynomials-oq-01",
+  "title": "Cyclotomic Polynomials: Degree φ(n), Prime Form, and the Divisor Product",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "started": "2026-06-20T08:00:00Z",
+  "lastUpdate": "2026-06-20T08:00:00Z",
+  "tags": [
+    "number-theory",
+    "algebra",
+    "cyclotomic-polynomials",
+    "roots-of-unity",
+    "totient",
+    "polynomial",
+    "seeker-selected",
+    "research"
+  ],
+  "tractability": 9,
+  "significance": 5,
+  "problemStatement": {
+    "formal": "Establish the fundamental structural facts of the cyclotomic polynomials $\\Phi_n$: (1) $\\deg \\Phi_n = \\varphi(n)$; (2) for prime $p$, $\\Phi_p = 1 + X + \\cdots + X^{p-1}$, hence $\\deg\\Phi_p = p-1$ and $\\Phi_p(1)=p$; (3) $\\prod_{d\\mid n}\\Phi_d = X^n-1$; and (4) as a consequence of taking degrees in (3), Gauss's identity $\\sum_{d\\mid n}\\varphi(d) = n$.",
+    "plain": "The n-th cyclotomic polynomial Φ_n is the monic polynomial whose roots are the primitive n-th roots of unity. Its degree is Euler's totient φ(n); for a prime p it is the geometric sum 1+X+⋯+X^{p-1}; and the polynomials over all divisors of n multiply to Xⁿ−1. Reading off the degree of that product factorization recovers the classical totient-divisor-sum identity ∑_{d∣n} φ(d) = n.",
+    "whyMatters": [
+      "Cyclotomic polynomials are central to algebraic number theory (roots of unity, abelian extensions) and Galois theory; the gallery previously used Mathlib's `cyclotomic` only as machinery inside Galois/trisection proofs, never as a topic in its own right.",
+      "The divisor product ∏_{d∣n} Φ_d = Xⁿ−1 is the canonical factorization linking cyclotomic polynomials to the structure of roots of unity, and is the gateway to irreducibility and the construction of cyclotomic field extensions.",
+      "Deriving Gauss's identity ∑_{d∣n} φ(d) = n from cyclotomic degrees shows how a polynomial-factorization fact specializes to a purely arithmetic identity — a clean degree-counting bridge between algebra and number theory."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "cyclotomic_natDegree: deg Φ_n = φ(n) over any nontrivial ring (Mathlib natDegree_cyclotomic).",
+      "cyclotomic_prime_natDegree: deg Φ_p = p − 1 for prime p (combining natDegree_cyclotomic with Nat.totient_prime).",
+      "cyclotomic_prime_geom_sum: Φ_p = ∑_{i<p} Xⁱ for prime p; cyclotomic_prime_eval_one: Φ_p(1) = p.",
+      "prod_cyclotomic_divisors: ∏_{d∣n} Φ_d = Xⁿ−1 for n > 0.",
+      "sum_totient_divisors: Gauss's identity ∑_{d∣n} φ(d) = n, derived by taking natDegree of the divisor product over ℤ. Plus concrete witnesses Φ₁=X−1, Φ₂=X+1, Φ₃=1+X+X² and sample computations. Axiom-free, no native_decide."
+    ],
+    "open": [
+      "Irreducibility of Φ_n over ℚ (Mathlib has cyclotomic.irreducible_rat) packaged as a topic entry.",
+      "The minimal-polynomial characterization: Φ_n is the minimal polynomial of any primitive n-th root of unity.",
+      "Φ_n(1) for non-prime n (equals p when n is a prime power pᵏ, and 1 otherwise)."
+    ],
+    "goal": "Package the core structural facts of cyclotomic polynomials (degree, prime form, divisor product) as a coherent gallery entry and derive Gauss's totient-divisor-sum identity from the cyclotomic factorization of Xⁿ−1, axiom-free."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-20T08:00:00Z",
+    "iteration": 1,
+    "focus": "ACT: shipped Proofs/CyclotomicPolynomialsOQ01.lean — degree φ(n), prime geometric-sum form, eval at 1, divisor product, and the derived Gauss identity (axiom-free, sorry-free).",
+    "blockers": [],
+    "nextAction": "Optional: add irreducibility over ℚ, or Φ_n(1) for prime powers. Core structural entry is complete and verified.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 ACT (researcher-9, 2026-06-20): Built Proofs/CyclotomicPolynomialsOQ01.lean from scratch — a coherent topic entry for cyclotomic polynomials packaging four Mathlib structural facts and deriving one genuine consequence. (1) cyclotomic_natDegree restates natDegree_cyclotomic (deg Φ_n = φ(n)); (2) cyclotomic_prime_natDegree combines it with Nat.totient_prime for deg Φ_p = p−1; (3) cyclotomic_prime_geom_sum / cyclotomic_prime_eval_one give the prime geometric-sum form and Φ_p(1)=p; (4) prod_cyclotomic_divisors restates the divisor product ∏_{d∣n}Φ_d = Xⁿ−1. The substantive new result is sum_totient_divisors: Gauss's ∑_{d∣n}φ(d)=n, proved by taking natDegree of the divisor product over ℤ — natDegree_prod (each Φ_d≠0 in the domain ℤ) turns the LHS into ∑ deg Φ_d = ∑ φ(d), while natDegree_X_pow_sub_C gives deg(Xⁿ−1)=n. Concrete witnesses Φ₁,Φ₂,Φ₃ and sample degree/eval/Gauss computations. No native_decide → 0 axioms. The gallery previously used cyclotomic only as Galois/trisection machinery; this is the first dedicated cyclotomic topic entry."
+  },
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Cyclotomic_polynomial",
+      "https://en.wikipedia.org/wiki/Euler%27s_totient_function#Divisor_sum"
+    ],
+    "mathlib": [
+      "Polynomial.natDegree_cyclotomic (RingTheory/Polynomial/Cyclotomic/Basic.lean)",
+      "Polynomial.cyclotomic_prime, Polynomial.eval_one_cyclotomic_prime",
+      "Polynomial.prod_cyclotomic_eq_X_pow_sub_one",
+      "Polynomial.natDegree_prod, Polynomial.natDegree_X_pow_sub_C, Nat.totient_prime"
+    ]
+  },
+  "relatedProofs": [
+    "euler-totient",
+    "primitive-roots"
+  ],
+  "leanFiles": [
+    {
+      "path": "proofs/Proofs/CyclotomicPolynomialsOQ01.lean",
+      "status": "verified",
+      "axiomCount": 0,
+      "sorryCount": 0
+    }
+  ],
+  "significanceNote": "First dedicated cyclotomic-polynomial topic entry; derives Gauss's ∑_{d∣n}φ(d)=n from the cyclotomic factorization of Xⁿ−1."
+}


### PR DESCRIPTION
## Cyclotomic Polynomials OQ-01 — degree, prime form, divisor product, and Gauss's identity

First dedicated **cyclotomic-polynomial topic entry** in the gallery (previously `cyclotomic` appeared only as machinery inside Galois/trisection proofs). Packages four fundamental Mathlib structural facts and derives one genuine arithmetic consequence.

### Results (`proofs/Proofs/CyclotomicPolynomialsOQ01.lean`)
- `cyclotomic_natDegree` — `deg Φ_n = φ(n)` over any nontrivial ring.
- `cyclotomic_prime_natDegree` — `deg Φ_p = p − 1` for prime `p`.
- `cyclotomic_prime_geom_sum` — `Φ_p = 1 + X + ⋯ + X^{p-1}`.
- `cyclotomic_prime_eval_one` — `Φ_p(1) = p`.
- `prod_cyclotomic_divisors` — `∏_{d∣n} Φ_d = Xⁿ − 1`.
- **`sum_totient_divisors`** — Gauss's identity `∑_{d∣n} φ(d) = n`, obtained by taking `natDegree` of the divisor product over `ℤ`: `natDegree_prod` (each `Φ_d ≠ 0` in the domain) turns the LHS into `∑ deg Φ_d = ∑ φ(d)`, while `natDegree_X_pow_sub_C` gives `deg(Xⁿ−1) = n`.
- Concrete witnesses `Φ₁ = X−1`, `Φ₂ = X+1`, `Φ₃ = 1+X+X²`, and sample degree/eval/Gauss computations.

### Verification
- Compiles clean against pinned Mathlib (`lake env lean`).
- `#print axioms`: only `propext`, `Classical.choice`, `Quot.sound` — **verified, 0-axiom**, no `sorry`, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)