### PR TITLE
research(pythagorean-triples-oq-09): integer inradius of a Pythagorean right triangle

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2894,6 +2894,7 @@ import Proofs.PythagoreanTriplesOQ01Aristotle
 import Proofs.PythagoreanTriplesOQ02
 import Proofs.PythagoreanTriplesOQ05
 import Proofs.PythagoreanTriplesOQ07
+import Proofs.PythagoreanTriplesOQ09
 import Proofs.QuadraticGaussSumDiagonal
 import Proofs.QuadraticGaussSumSquare
 import Proofs.QuadraticGaussSumSquareOQ01

--- a/proofs/Proofs/PythagoreanTriplesOQ09.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ09.lean
@@ -1,0 +1,132 @@
+/-
+Integer Inradius of a Pythagorean Right Triangle
+
+Source: Open question from pythagorean-triples gallery proof
+Status: VERIFIED (0 axioms, 0 sorries)
+
+A right triangle whose legs `x, y` and hypotenuse `z` form a Pythagorean triple
+(`x² + y² = z²`) has an inradius
+
+        r = (x + y − z) / 2
+
+that is a *non-negative integer*. This is a small but genuinely geometric
+integrality phenomenon: the radius of the inscribed circle of an integer right
+triangle is itself an integer. Three ingredients:
+
+  * **Parity** — `2 ∣ (x + y − z)` for ANY Pythagorean triple. Reducing
+    `x² + y² = z²` modulo 2 and using `a² = a` in `ZMod 2` gives `x + y ≡ z`,
+    so `x + y − z` is even. (No coprimality or mod-4 case split is needed; this
+    is cleaner than the mod-4 obstruction used for the single-leg parity in
+    `PythagoreanTriplesOQ07`.)
+
+  * **Positivity** — `z ≤ x + y` for non-negative legs, since
+    `(x + y)² = z² + 2xy ≥ z²`. Hence `r = (x + y − z)/2 ≥ 0`.
+
+  * **Area identity** — `(x + y − z)(x + y + z) = 2xy`, obtained by expanding
+    `(x + y)² − z² = 2xy`. Writing `x + y − z = 2r` and `x + y + z = 2s` (the
+    semiperimeter is `s`), this becomes `2·r·s = xy`, i.e. `r·s = xy/2 = Area`.
+    This is the classical `Area = r·s` for a right triangle.
+
+Distinct from `PythagoreanTriplesOQ07` (single-leg parity dichotomy under
+coprimality): here we extract a geometric integrality invariant valid for every
+triple, plus the inradius–semiperimeter–area relation.
+-/
+
+import Mathlib
+
+namespace PythagoreanTriplesInradius
+
+open PythagoreanTriple
+
+variable {x y z : ℤ}
+
+/-! ## Part I: Parity — `2 ∣ (x + y − z)`
+
+Reduce `x² + y² = z²` modulo 2. In `ZMod 2` every element satisfies `a² = a`,
+so the equation collapses to `x + y = z`, i.e. `x + y − z ≡ 0 (mod 2)`. -/
+
+/-- For ANY Pythagorean triple, `x + y − z` is even. No coprimality needed. -/
+theorem dvd_two_add_sub (h : PythagoreanTriple x y z) : (2 : ℤ) ∣ (x + y - z) := by
+  have he : x * x + y * y = z * z := h
+  have key : ∀ a : ZMod 2, a * a = a := by decide
+  -- push the triple equation into `ZMod 2`
+  have hcast : (x : ZMod 2) * x + (y : ZMod 2) * y = (z : ZMod 2) * z := by
+    have := congrArg (fun t : ℤ => (t : ZMod 2)) he
+    push_cast at this
+    exact this
+  rw [key, key, key] at hcast
+  -- now `x + y = z` in `ZMod 2`, so `x + y − z = 0`
+  have hzero : ((x + y - z : ℤ) : ZMod 2) = 0 := by
+    push_cast
+    rw [hcast]; ring
+  exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ 2).mp hzero
+
+/-- Corollary: `x + y + z` is also even (it differs from `x + y − z` by `2z`). -/
+theorem dvd_two_add_add (h : PythagoreanTriple x y z) : (2 : ℤ) ∣ (x + y + z) := by
+  obtain ⟨r, hr⟩ := dvd_two_add_sub h
+  exact ⟨r + z, by linarith [hr]⟩
+
+/-! ## Part II: The area identity
+
+`(x + y − z)(x + y + z) = (x + y)² − z² = 2xy`, using `x² + y² = z²`. -/
+
+/-- **Area identity.** `(x + y − z)(x + y + z) = 2xy` for any Pythagorean triple. -/
+theorem inradius_identity (h : PythagoreanTriple x y z) :
+    (x + y - z) * (x + y + z) = 2 * (x * y) := by
+  have he : x * x + y * y = z * z := h
+  linear_combination he
+
+/-! ## Part III: Positivity — `z ≤ x + y`
+
+For non-negative legs, `(x + y)² = z² + 2xy ≥ z²`, hence `z ≤ x + y`, so the
+inradius `(x + y − z)/2` is non-negative. -/
+
+/-- For a triple with non-negative entries, the hypotenuse is at most the sum of
+the legs (the triangle inequality, here forced by `x² + y² = z²`). -/
+theorem hyp_le_add (h : PythagoreanTriple x y z)
+    (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) : z ≤ x + y := by
+  have he : x * x + y * y = z * z := h
+  nlinarith [mul_nonneg hx hy, mul_nonneg (add_nonneg hx hy) hz,
+    mul_nonneg hx hz, mul_nonneg hy hz, sq_nonneg (x + y - z)]
+
+/-! ## Part IV: The inradius is a non-negative integer
+
+Packaging the facts: there is a *non-negative integer* `r` (the inradius) with
+`x + y − z = 2r`, and it satisfies the area relation `r·(x + y + z) = x·y`,
+i.e. `r·s = Area` where `s = (x + y + z)/2` is the semiperimeter and the area is
+`x·y/2`. -/
+
+/-- The area relation: if `x + y − z = 2r` then `r·(x + y + z) = x·y`.
+Since the perimeter is `x + y + z = 2s` and the area is `x·y/2`, this is exactly
+`r·s = Area`. -/
+theorem inradius_area (h : PythagoreanTriple x y z) {r : ℤ}
+    (hr : x + y - z = 2 * r) : r * (x + y + z) = x * y := by
+  have hid := inradius_identity h
+  rw [hr] at hid
+  -- hid : (2 * r) * (x + y + z) = 2 * (x * y)
+  have h2 : 2 * (r * (x + y + z)) = 2 * (x * y) := by linear_combination hid
+  exact mul_left_cancel₀ (by norm_num : (2 : ℤ) ≠ 0) h2
+
+/-- **Inradius integrality + area relation.** For an integer right triangle with
+non-negative sides there is a *non-negative integer* `r` (the inradius) with
+`x + y − z = 2r` and `r·(x + y + z) = x·y` (the classical `Area = r·s`). -/
+theorem inradius (h : PythagoreanTriple x y z)
+    (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) :
+    ∃ r : ℤ, 0 ≤ r ∧ x + y - z = 2 * r ∧ r * (x + y + z) = x * y := by
+  obtain ⟨r, hr⟩ := dvd_two_add_sub h
+  have hle := hyp_le_add h hx hy hz
+  exact ⟨r, by omega, hr, inradius_area h hr⟩
+
+/-! ## Part V: The inradius of a primitive triple
+
+For a primitively-classified triple with the standard parametrisation
+`x = m² − n²`, `y = 2mn`, `z = m² + n²`, the inradius is `r = n(m − n)`. -/
+
+/-- For the standard parametrisation of a primitive triple
+`x = m² − n²`, `y = 2mn`, `z = m² + n²`, the inradius equals `n(m − n)`:
+explicitly `x + y − z = 2·n·(m − n)`. -/
+theorem inradius_param (m n : ℤ) :
+    (m ^ 2 - n ^ 2) + 2 * m * n - (m ^ 2 + n ^ 2) = 2 * (n * (m - n)) := by
+  ring
+
+end PythagoreanTriplesInradius

--- a/src/data/proofs/pythagorean-triples-oq-09/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-09/meta.json
@@ -1,0 +1,156 @@
+{
+  "id": "pythagorean-triples-oq-09",
+  "title": "The Inradius of an Integer Right Triangle is a Non-Negative Integer",
+  "slug": "pythagorean-triples-oq-09",
+  "description": "A right triangle whose legs x, y and hypotenuse z form a Pythagorean triple (x²+y²=z²) has inradius r=(x+y−z)/2, and this is a non-negative integer. Parity: 2∣(x+y−z) for ANY triple, since a²=a in ZMod 2 collapses x²+y²=z² to x+y≡z. Positivity: z≤x+y for non-negative legs. Area: (x+y−z)(x+y+z)=2xy gives r·(x+y+z)=xy, the classical Area=r·s.",
+  "meta": {
+    "author": "classical (Heron / Euclid); formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ09.lean",
+    "tags": [
+      "number-theory",
+      "pythagorean-triples",
+      "geometry",
+      "inradius",
+      "diophantine",
+      "modular-arithmetic",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "PythagoreanTriple",
+        "description": "The Pythagorean triple predicate x*x + y*y = z*z",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      },
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "(↑a : ZMod n) = 0 ↔ (n:ℤ) ∣ a — bridges the ZMod 2 parity computation back to divisibility",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "mul_left_cancel₀",
+        "description": "Cancellation of a nonzero factor, used to halve the area identity over ℤ",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      }
+    ],
+    "originalContributions": [
+      "dvd_two_add_sub: 2 ∣ (x+y−z) for ANY Pythagorean triple, proved by reducing x²+y²=z² in ZMod 2 where a²=a (cleaner than the mod-4 split of oq-07; no coprimality needed)",
+      "dvd_two_add_add: 2 ∣ (x+y+z), so the semiperimeter is an integer",
+      "inradius_identity: (x+y−z)(x+y+z) = 2xy, the algebraic core of Area = r·s",
+      "hyp_le_add: z ≤ x+y for non-negative legs (triangle inequality forced by x²+y²=z²)",
+      "inradius_area: r·(x+y+z) = xy whenever x+y−z = 2r — the classical Area = r·s",
+      "inradius: the inradius r=(x+y−z)/2 is a non-negative integer satisfying the area relation",
+      "inradius_param: for the standard parametrisation (m²−n², 2mn, m²+n²) the inradius is n(m−n)"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 132,
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The inradius of a right triangle has the strikingly simple closed form r = (a+b−c)/2, where a, b are the legs and c the hypotenuse — a fact already implicit in Heron's work on triangle areas and the relation Area = r·s between the inradius and the semiperimeter s. For Pythagorean (integer-sided) right triangles this means the inscribed circle has integer radius, an elementary but appealing integrality phenomenon: e.g. the (3,4,5) triangle has inradius 1, the (5,12,13) triangle has inradius 2, and the (8,15,17) triangle has inradius 3. The result sits alongside the parity dichotomy (oq-07) as a structural invariant of integer right triangles.",
+    "problemStatement": "Is the inradius of an integer right triangle always a non-negative integer, and does it satisfy the classical Area = r·s?\n\n**Answer: Yes.** For any Pythagorean triple, x+y−z is even (a ZMod 2 computation), so r = (x+y−z)/2 ∈ ℤ; for non-negative sides z ≤ x+y forces r ≥ 0; and the identity (x+y−z)(x+y+z) = 2xy yields r·(x+y+z) = xy, i.e. r·s = Area.",
+    "text": "The inscribed circle of an integer right triangle has integer radius r = (x+y−z)/2, and r·s equals the area.",
+    "proofStrategy": "Reduce x²+y²=z² modulo 2: in ZMod 2 every element satisfies a²=a, so the equation collapses to x+y=z, proving 2∣(x+y−z) (and likewise 2∣(x+y+z)). Expand (x+y−z)(x+y+z)=(x+y)²−z²=2xy for the area identity. Bound z≤x+y from (x+y)²=z²+2xy≥z² with non-negative sides. Combine: r=(x+y−z)/2 is a non-negative integer with r·(x+y+z)=xy.",
+    "keyInsights": [
+      "The parity 2∣(x+y−z) needs neither coprimality nor a mod-4 case split: in ZMod 2 the squares vanish (a²=a), so x²+y²=z² becomes x+y=z directly",
+      "The integrality of the inradius is purely arithmetic, while its non-negativity is the geometric triangle inequality z ≤ x+y, here forced algebraically by x²+y²=z²",
+      "(x+y−z)(x+y+z) = 2xy packages the entire Area = r·s relation in one ring identity; with x+y−z=2r it halves (over ℤ via mul_left_cancel₀) to r·(x+y+z)=xy",
+      "For the Euclidean parametrisation (m²−n², 2mn, m²+n²) the inradius is exactly n(m−n)"
+    ],
+    "prerequisites": [
+      "Pythagorean triples (x²+y²=z²)",
+      "Modular arithmetic and the ring ZMod 2",
+      "Inradius and semiperimeter of a triangle; Area = r·s"
+    ]
+  },
+  "sections": [
+    {
+      "id": "parity",
+      "title": "Parity: 2 ∣ (x+y−z)",
+      "startLine": 43,
+      "endLine": 68,
+      "summary": "Reducing x²+y²=z² in ZMod 2 (where a²=a) gives x+y≡z, so x+y−z and x+y+z are both even.",
+      "mathContext": "In $\\mathbb{Z}/2$, $a^2=a$, so $x^2+y^2=z^2$ becomes $x+y=z$, hence $2\\mid x+y-z$."
+    },
+    {
+      "id": "area-identity",
+      "title": "The Area Identity",
+      "startLine": 69,
+      "endLine": 78,
+      "summary": "(x+y−z)(x+y+z) = 2xy, from (x+y)²−z²=2xy using x²+y²=z².",
+      "mathContext": "$(x+y-z)(x+y+z) = (x+y)^2 - z^2 = 2xy$."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity: z ≤ x+y",
+      "startLine": 79,
+      "endLine": 91,
+      "summary": "For non-negative legs, (x+y)²=z²+2xy≥z² gives z≤x+y, so the inradius is non-negative.",
+      "mathContext": "$(x+y)^2 = z^2 + 2xy \\ge z^2 \\Rightarrow z \\le x+y$."
+    },
+    {
+      "id": "inradius",
+      "title": "The Inradius is a Non-Negative Integer",
+      "startLine": 92,
+      "endLine": 132,
+      "summary": "r=(x+y−z)/2 is a non-negative integer satisfying r·(x+y+z)=xy (Area=r·s); for the standard parametrisation r=n(m−n).",
+      "mathContext": "$r=\\tfrac{x+y-z}{2}\\in\\mathbb{Z}_{\\ge 0}$, $\\;r\\cdot s = \\text{Area}$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Heron of Alexandria",
+      "title": "Metrica",
+      "year": "c. 60 CE",
+      "note": "Area of a triangle and the relation Area = r·s with the inradius"
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1938",
+      "note": "Parametrisation and arithmetic of Pythagorean triples"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "extends",
+      "description": "Adds a geometric integrality invariant — the inradius — to the structure of Pythagorean triples."
+    },
+    {
+      "targetId": "pythagorean-triples-oq-07",
+      "relationship": "related",
+      "description": "Both extract structural invariants from x²+y²=z²: oq-07 the leg/hypotenuse parity dichotomy, oq-09 the integer inradius. oq-09's parity step (a²=a in ZMod 2) is a cleaner alternative to oq-07's mod-4 obstruction."
+    }
+  ],
+  "conclusion": {
+    "summary": "The inradius of an integer right triangle is a non-negative integer r=(x+y−z)/2 satisfying r·(x+y+z)=xy (Area=r·s), machine-checked with 0 axioms: parity via a ZMod 2 computation, positivity via z≤x+y, and the area relation via one ring identity.",
+    "implications": "Demonstrates an elementary geometric integrality invariant of Pythagorean triples and packages the classical Area = r·s relation; the ZMod 2 parity step gives a coprimality-free, case-split-free route to evenness of x+y−z.",
+    "openQuestions": [
+      "Can the exradii of an integer right triangle be shown integral as well, with the identity r·r_a·r_b·r_c = Area²?",
+      "Does r = n(m−n) for primitive triples combine with gcd conditions to characterise which integers occur as inradii of primitive Pythagorean triangles?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "PythagoreanTriple"
+    ],
+    "namespace": "PythagoreanTriplesInradius",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/PythagoreanTriplesOQ09.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

A right triangle whose legs `x, y` and hypotenuse `z` form a Pythagorean triple (`x²+y²=z²`) has inradius **r = (x+y−z)/2**, and this is a **non-negative integer** satisfying the classical `Area = r·s`. Verified, **0 axioms, 0 sorries**.

Three ingredients:

- **Parity** — `2 ∣ (x+y−z)` for *any* Pythagorean triple. Reducing `x²+y²=z²` in `ZMod 2`, where every element satisfies `a²=a`, collapses the equation to `x+y≡z`. This is cleaner than the mod-4 obstruction of the sibling oq-07 — no coprimality and no case split.
- **Positivity** — `z ≤ x+y` for non-negative legs, since `(x+y)² = z² + 2xy ≥ z²`. Hence `r ≥ 0`.
- **Area identity** — `(x+y−z)(x+y+z) = 2xy`, giving `r·(x+y+z) = xy`, i.e. `r·s = Area`.

## Theorems (7, namespace `PythagoreanTriplesInradius`)

- `dvd_two_add_sub` : `2 ∣ (x+y−z)` (ZMod 2 parity, any triple)
- `dvd_two_add_add` : `2 ∣ (x+y+z)` (semiperimeter is an integer)
- `inradius_identity` : `(x+y−z)(x+y+z) = 2xy`
- `hyp_le_add` : `z ≤ x+y` for non-negative sides
- `inradius_area` : `r·(x+y+z) = xy` when `x+y−z = 2r`
- `inradius` : the inradius `(x+y−z)/2` is a non-negative integer with the area relation
- `inradius_param` : for `(m²−n², 2mn, m²+n²)` the inradius is `n(m−n)`

## Verification

`#print axioms` on all theorems lists only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Builds against Mathlib 4.26.0.

Distinct from oq-07 (single-leg parity dichotomy under coprimality): this extracts a geometric integrality invariant valid for every triple, plus the inradius–semiperimeter–area relation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)