### PR TITLE
research(erdos-340): discharge 2 structural axioms + repair for current Mathlib

### DIFF
--- a/proofs/Proofs/Erdos340Problem.lean
+++ b/proofs/Proofs/Erdos340Problem.lean
@@ -17,7 +17,9 @@ Reference: https://erdosproblems.com/340
 
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Nat.Basic
-import Mathlib.Order.Filter.AtTopBot
+import Mathlib.Data.Nat.Lattice
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.SpecialFunctions.Sqrt
 import Mathlib.Tactic
 
 open Filter Finset
@@ -34,7 +36,10 @@ def IsSidonSet (S : Finset ℕ) : Prop :=
 noncomputable def greedySidon : ℕ → ℕ
   | 0 => 1
   | n + 1 => sInf { m : ℕ | m > greedySidon n ∧
-      IsSidonSet (Finset.image greedySidon (Finset.range (n + 1)) ∪ {m}) }
+      IsSidonSet ((Finset.range (n + 1)).attach.image (fun k => greedySidon k.1) ∪ {m}) }
+  decreasing_by
+    · exact Nat.lt_succ_self n
+    · exact Finset.mem_range.mp k.2
 
 /-- The counting function: |A ∩ {1,...,N}|. -/
 noncomputable def greedySidonCount (N : ℕ) : ℕ :=
@@ -50,15 +55,111 @@ axiom greedy_sidon_values :
     greedySidon 6 = 31 ∧ greedySidon 7 = 45 ∧ greedySidon 8 = 66 ∧
     greedySidon 9 = 81 ∧ greedySidon 10 = 97
 
-/- ## Basic Properties -/
+/- ## Basic Properties
 
-/-- The greedy Sidon sequence is strictly increasing:
-    each element is larger than the preceding one. -/
-axiom greedy_sidon_strict_mono : StrictMono greedySidon
+The two structural facts — that the greedy sequence is **strictly increasing** and
+that every prefix is a **Sidon set** — used to be axioms here.  They are in fact
+*theorems* about the `sInf`-based definition above, the only ingredient being that the
+defining set is always nonempty, i.e. a finite Sidon set can always be extended.  We
+prove this with the explicit witness `m = 2 · (sup A) + 1`: it lies strictly above
+every element of `A`, so on each side of a putative collision `a + b = c + d` the new
+element (if present) is the larger summand, and a band/parity count forces both sides
+to use `m` equally often — after which `Nat` cancellation and the original Sidon
+property close the gap.  (Same witness as the constructive existence kernel in
+`Erdos340GreedySidonExtension.lean`.)
 
-/-- Every prefix of the greedy sequence forms a valid Sidon set. -/
-axiom greedy_sidon_is_sidon : ∀ n : ℕ,
-    IsSidonSet (Finset.image greedySidon (Finset.range (n + 1)))
+The recursion uses `(range (n+1)).attach.image (fun k => greedySidon k.1)` so that the
+self-reference is visibly applied to indices `k.1 < n + 1` (this is what lets Lean's
+termination checker accept the well-founded recursion); `attach_image_eq` identifies
+this with the cleaner `Finset.image greedySidon (range (n+1))`, and
+`greedySidon_succ_eq` is the resulting unfolding lemma for `greedySidon (n + 1)`. -/
+
+/-- The `attach`-guarded prefix image used inside the definition coincides with the
+ordinary `Finset.image greedySidon (range (n+1))`. -/
+theorem attach_image_eq (n : ℕ) :
+    (Finset.range (n + 1)).attach.image (fun k => greedySidon k.1)
+      = Finset.image greedySidon (Finset.range (n + 1)) := by
+  conv_rhs => rw [← Finset.attach_image_val (s := Finset.range (n + 1))]
+  rw [Finset.image_image]
+  rfl
+
+/-- Unfolding lemma for the successor step, stated with the clean prefix image. -/
+theorem greedySidon_succ_eq (n : ℕ) :
+    greedySidon (n + 1) = sInf { m : ℕ | m > greedySidon n ∧
+      IsSidonSet (Finset.image greedySidon (Finset.range (n + 1)) ∪ {m}) } := by
+  conv_lhs => rw [greedySidon]
+  rw [attach_image_eq]
+
+/-- **Extension lemma.** Inserting the explicit witness `2 · sup A + 1` into a Sidon
+set keeps it Sidon: the witness sits strictly above every element of `A`. -/
+theorem isSidonSet_insert_two_sup_add_one {A : Finset ℕ} (hA : IsSidonSet A) :
+    IsSidonSet (insert (2 * A.sup id + 1) A) := by
+  set S := A.sup id with hS
+  set m := 2 * S + 1 with hm
+  have hbound : ∀ x ∈ A, x ≤ S := fun x hx => Finset.le_sup (f := id) hx
+  intro a ha b hb c hc d hd hab hcd hsum
+  simp only [Finset.mem_insert] at ha hb hc hd
+  rcases ha with rfl | ha <;> rcases hb with rfl | hb <;>
+    rcases hc with rfl | hc <;> rcases hd with rfl | hd <;>
+  first
+    | exact hA a ha b hb c hc d hd hab hcd hsum
+    | (try have ba := hbound _ ha
+       try have bb := hbound _ hb
+       try have bc := hbound _ hc
+       try have bd := hbound _ hd
+       omega)
+
+/-- The set of admissible next values for the greedy sequence — the one whose `sInf`
+defines `greedySidon (n + 1)` — is nonempty, witnessed by `2 · sup(prefix) + 1`. -/
+theorem greedy_defining_set_nonempty (n : ℕ)
+    (hP : IsSidonSet (Finset.image greedySidon (Finset.range (n + 1)))) :
+    { m : ℕ | m > greedySidon n ∧
+      IsSidonSet (Finset.image greedySidon (Finset.range (n + 1)) ∪ {m}) }.Nonempty := by
+  set P := Finset.image greedySidon (Finset.range (n + 1)) with hPdef
+  refine ⟨2 * P.sup id + 1, ?_, ?_⟩
+  · have hmem : greedySidon n ∈ P := by
+      rw [hPdef]; exact Finset.mem_image_of_mem _ (Finset.self_mem_range_succ n)
+    have hle : greedySidon n ≤ P.sup id := Finset.le_sup (f := id) hmem
+    omega
+  · have heq : P ∪ {2 * P.sup id + 1} = insert (2 * P.sup id + 1) P := by
+      rw [Finset.union_comm, Finset.insert_eq]
+    rw [heq]
+    exact isSidonSet_insert_two_sup_add_one hP
+
+/-- The defining `sInf` is attained: `greedySidon (n + 1)` lies in its admissible set,
+hence it is `> greedySidon n` and extends the prefix to a Sidon set. -/
+theorem greedySidon_succ_spec (n : ℕ)
+    (hP : IsSidonSet (Finset.image greedySidon (Finset.range (n + 1)))) :
+    greedySidon (n + 1) > greedySidon n ∧
+      IsSidonSet (Finset.image greedySidon (Finset.range (n + 1)) ∪ {greedySidon (n + 1)}) := by
+  have h := Nat.sInf_mem (greedy_defining_set_nonempty n hP)
+  rw [Set.mem_setOf_eq] at h
+  rw [greedySidon_succ_eq]
+  exact h
+
+/-- Every prefix of the greedy sequence forms a valid Sidon set.  (Was an axiom.) -/
+theorem greedy_sidon_is_sidon : ∀ n : ℕ,
+    IsSidonSet (Finset.image greedySidon (Finset.range (n + 1))) := by
+  intro n
+  induction n with
+  | zero =>
+      have hsingle : Finset.image greedySidon (Finset.range (0 + 1)) = {greedySidon 0} := by
+        simp [Finset.range_one]
+      rw [hsingle]
+      intro a ha b hb c hc d hd _ _ _
+      simp only [Finset.mem_singleton] at ha hb hc hd
+      subst ha hb hc hd
+      exact ⟨rfl, rfl⟩
+  | succ n ih =>
+      have hspec := greedySidon_succ_spec n ih
+      -- `range (n+1+1) = insert (n+1) (range (n+1))`, so the prefix image is
+      -- `insert (greedySidon (n+1)) (image … range (n+1)) = image … ∪ {greedySidon (n+1)}`.
+      rw [Finset.range_add_one, Finset.image_insert, Finset.insert_eq, Finset.union_comm]
+      exact hspec.2
+
+/-- The greedy Sidon sequence is strictly increasing.  (Was an axiom.) -/
+theorem greedy_sidon_strict_mono : StrictMono greedySidon :=
+  strictMono_nat_of_lt_succ fun n => (greedySidon_succ_spec n (greedy_sidon_is_sidon n)).1
 
 /- ## Known Lower Bound -/
 

--- a/src/data/proofs/erdos-340/meta.json
+++ b/src/data/proofs/erdos-340/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/340",
     "erdosProblemStatus": "open",
     "dateAdded": "2026-01-19",
-    "axiomCount": 7,
-    "assumptions": "7 axioms: greedy_sidon_values (first 11 OEIS A005282 terms), greedy_sidon_strict_mono (StrictMono), greedy_sidon_is_sidon (Sidon invariant at every prefix), greedy_sidon_lower_bound (Ω(N^{1/3}) growth), erdos_turan_upper_bound (O(√N + N^{1/4}) upper bound), greedy_sidon_growth_conjecture (open: Ω(N^{1/2-ε}) for all ε>0), greedy_sidon_diffset_pos_density (open: A-A has positive upper density).",
-    "lineCount": 101,
-    "theoremCount": 0,
+    "axiomCount": 5,
+    "assumptions": "5 axioms: greedy_sidon_values (first 11 OEIS A005282 terms), greedy_sidon_lower_bound (Ω(N^{1/3}) growth), erdos_turan_upper_bound (O(√N + N^{1/4}) upper bound), greedy_sidon_growth_conjecture (open: Ω(N^{1/2-ε}) for all ε>0), greedy_sidon_diffset_pos_density (open: A-A has positive upper density). The former axioms greedy_sidon_strict_mono and greedy_sidon_is_sidon are now PROVED as theorems from the sInf-based definition, via the explicit Sidon-extension witness m = 2·sup(prefix)+1 and induction over prefixes (axiomCount reduced 7→5). This revision also repairs the file against current Mathlib (4.26.0): the obsolete `Mathlib.Order.Filter.AtTopBot` umbrella import was replaced by the analysis modules that actually supply √ and rpow, and the `greedySidon` recursion was made to pass the termination checker by guarding its self-reference with `Finset.attach` so each recursive call is visibly applied to an index `< n+1`.",
+    "lineCount": 202,
+    "theoremCount": 7,
     "mathlib_version": "4.26.0",
     "definitionCount": 4
   },
@@ -33,7 +33,7 @@
     "historicalContext": "The Mian-Chowla sequence was introduced independently by Abdul Majid Mian and S.D. Chowla in 1944 as the natural greedy construction for Sidon sets. Erdős and Graham asked about its growth rate in their 1980 monograph, noting the striking gap between the known $\\Omega(N^{1/3})$ lower bound and the theoretical $O(\\sqrt{N})$ upper bound for any Sidon set. The problem is a fundamental test case for whether greedy algorithms in additive combinatorics can achieve near-optimal density. In many combinatorial settings (graph colouring, independent sets), greedy constructions are provably suboptimal by polynomial factors. But numerical evidence for the Mian-Chowla sequence is remarkably encouraging: computations up to $N \\approx 10^{15}$ show $|A \\cap [1,N]| \\approx N^{0.497...}$, extremely close to $\\sqrt{N}$. The $N^{1/3}$ lower bound comes from a simple forbidden-sum counting argument: each of the $O(k^2)$ existing pairwise sums blocks at most one future candidate per step, so the $k$-th element is at most $O(k^3)$. Improving this to $N^{1/3+\\delta}$ for any $\\delta > 0$ would be significant. The separate question about the density of the difference set $A - A$ connects to the theory of return times and recurrence in additive number theory.",
     "problemStatement": "Let A be the greedy Sidon sequence starting from 1. Is |A ∩ [1,N]| >> N^{1/2-ε} for all ε > 0?",
     "text": "The Mian-Chowla sequence {1,2,4,8,13,21,...} is the greedy Sidon set. Is |A ∩ [1,N]| >> N^{1/2-ε}? Known lower bound: Ω(N^{1/3}). Also: does A-A have positive density? Status: OPEN.",
-    "proofStrategy": "We formalize `IsSidonSet` via the uniqueness of sum representations, `greedySidon` as a recursive noncomputable function using `sInf`, and `greedySidonCount N` as the counting function. Known initial values (OEIS A005282), strict monotonicity, and the Sidon invariant are axiomatized. The $N^{1/3}$ lower bound and Erdős-Turan $\\sqrt{N} + O(N^{1/4})$ upper bound frame the problem. The main conjecture and the difference set density question are stated as separate axioms.",
+    "proofStrategy": "We formalize `IsSidonSet` via the uniqueness of sum representations, `greedySidon` as a recursive noncomputable function using `sInf`, and `greedySidonCount N` as the counting function. Strict monotonicity (`greedy_sidon_strict_mono`) and the prefix Sidon invariant (`greedy_sidon_is_sidon`) — formerly axioms — are now PROVED: the only fact needed is that the defining `sInf` set is nonempty, which holds because every finite Sidon set extends by the explicit witness $m = 2\\cdot\\sup(A)+1$ (it sits strictly above $A$, so a band/parity count forces both sides of any collision to use $m$ equally often, after which $\\mathbb{N}$-cancellation and the original Sidon property close the gap). `Nat.sInf_mem` then attains the defining infimum, and an induction over prefixes propagates the Sidon invariant; `strictMono_nat_of_lt_succ` upgrades $a(n+1)>a(n)$ to `StrictMono`. Known initial values (OEIS A005282) remain axiomatized. The $N^{1/3}$ lower bound and Erdős-Turan $\\sqrt{N} + O(N^{1/4})$ upper bound frame the problem. The main conjecture and the difference set density question are stated as separate axioms.",
     "keyInsights": [
       "Any Sidon set in [1,N] has at most ~sqrt(N) elements (Erdos-Turan), so N^{1/2} is the natural target for the greedy sequence",
       "The known lower bound N^{1/3} comes from counting forbidden sums: O(k^2) blocked values per step gives the k-th element at most O(k^3), so k >= Omega(N^{1/3})",
@@ -67,32 +67,32 @@
     {
       "id": "initial-values",
       "title": "Known Initial Values and Basic Properties",
-      "startLine": 43,
-      "endLine": 62,
-      "summary": "Axiom greedy_sidon_values: first 11 terms (1,2,4,8,13,21,31,45,66,81,97). Axioms: StrictMono greedySidon and Sidon invariant at every prefix.",
-      "mathContext": "OEIS A005282: $a(0)=1, a(1)=2, a(2)=4, a(3)=8, a(4)=13, a(5)=21, a(6)=31, a(7)=45, a(8)=66, a(9)=81, a(10)=97$. Monotonicity and Sidon invariant are definitional properties of the greedy construction."
+      "startLine": 48,
+      "endLine": 163,
+      "summary": "Axiom greedy_sidon_values: first 11 terms (1,2,4,8,13,21,31,45,66,81,97). Then seven theorems (no longer axioms): attach_image_eq + greedySidon_succ_eq (unfold the attach-guarded recursion to the clean prefix image), isSidonSet_insert_two_sup_add_one (extension lemma), greedy_defining_set_nonempty (the sInf set is nonempty), greedySidon_succ_spec (the sInf is attained), greedy_sidon_is_sidon (prefix Sidon invariant) and greedy_sidon_strict_mono (StrictMono greedySidon) — discharging the two former structural axioms.",
+      "mathContext": "OEIS A005282: $a(0)=1, a(1)=2, a(2)=4, a(3)=8, a(4)=13, a(5)=21, a(6)=31, a(7)=45, a(8)=66, a(9)=81, a(10)=97$. Strict monotonicity and the prefix Sidon invariant are now machine-checked consequences of the `sInf` definition: the witness $2\\cdot\\sup(A)+1$ shows the admissible-next-value set is nonempty, `Nat.sInf_mem` attains it, and induction over prefixes propagates the Sidon property."
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds: Omega(N^{1/3}) and O(sqrt(N))",
-      "startLine": 63,
-      "endLine": 76,
+      "startLine": 164,
+      "endLine": 177,
       "summary": "Axiom greedy_sidon_lower_bound (Omega(N^{1/3}) from forbidden-sum counting) and erdos_turan_upper_bound (O(sqrt(N) + N^{1/4}) from Erdos-Turan 1941).",
       "mathContext": "Lower bound: each of $k$ greedy elements blocks $O(k^2)$ future candidates, so the $k$-th element is $O(k^3)$, giving $k \\geq \\Omega(N^{1/3})$. Upper bound: any Sidon set in $[1,N]$ has $\\leq \\sqrt{N} + O(N^{1/4})$ elements."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture: Near-Optimal Greedy Growth",
-      "startLine": 77,
-      "endLine": 85,
+      "startLine": 178,
+      "endLine": 186,
       "summary": "Open conjecture: for all epsilon>0, |A intersect [1,N]| >= C_eps * N^{1/2-eps} for large N.",
       "mathContext": "$\\forall \\varepsilon > 0,\\; \\exists C_\\varepsilon > 0,\\; \\exists N_0,\\; \\forall N \\geq N_0: f(N) \\geq C_\\varepsilon \\cdot N^{1/2-\\varepsilon}$. Computations up to $N \\approx 10^{15}$ show $f(N) \\approx N^{0.497}$, very close to $\\sqrt{N}$."
     },
     {
       "id": "diff-set",
       "title": "Difference Set and Open Density Question",
-      "startLine": 86,
-      "endLine": 101,
+      "startLine": 187,
+      "endLine": 202,
       "summary": "Definition greedySidonDiffSet = {a(m)-a(n) : m>n}. Open conjecture: A-A has positive upper density. Comparison with random Sidon set.",
       "mathContext": "$A - A = \\{a(m) - a(n) : m > n\\}$. Positive density: $\\exists \\delta > 0$ such that infinitely many $N$ satisfy $|A-A \\cap [1,N]| \\geq \\delta N$. Connected to Erdős Problem #332."
     }
@@ -176,18 +176,21 @@
     "imports": [
       "Mathlib.Data.Finset.Card",
       "Mathlib.Data.Nat.Basic",
-      "Mathlib.Order.Filter.AtTopBot",
+      "Mathlib.Data.Nat.Lattice",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Analysis.SpecialFunctions.Sqrt",
       "Mathlib.Tactic"
     ],
     "opens": [
-      "Filter"
+      "Filter",
+      "Finset"
     ],
     "namespace": null,
-    "lineCount": 101,
-    "axiomCount": 7,
+    "lineCount": 202,
+    "axiomCount": 5,
     "sorries": 0,
     "definitionCount": 4,
-    "theoremCount": 0
+    "theoremCount": 7
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Erdős Problem #340 — Growth of the Greedy Sidon (Mian–Chowla) Sequence

Two intertwined changes to `Proofs/Erdos340Problem.lean`, **both machine-verified** (0 sorries; the new theorems depend only on `propext` / `Classical.choice` / `Quot.sound` — confirmed with `#print axioms`).

### 1. Discharge two structural axioms (axiomCount 7 → 5)

`greedy_sidon_is_sidon` (every prefix is a Sidon set) and `greedy_sidon_strict_mono` (`StrictMono greedySidon`) were axioms; they are in fact **theorems** about the `sInf`-based definition. The only ingredient is that the admissible-next-value set is nonempty, witnessed by the explicit Sidon extension `m = 2·sup(prefix) + 1`:

- `isSidonSet_insert_two_sup_add_one` — the witness sits strictly above the set, so a band/cancellation argument keeps it Sidon (case bash closed by `omega`);
- `greedy_defining_set_nonempty` → `Nat.sInf_mem` attains the infimum (`greedySidon_succ_spec`);
- induction over prefixes propagates the invariant; `strictMono_nat_of_lt_succ` upgrades `a(n+1) > a(n)`.

### 2. Repair the entry against pinned Mathlib 4.26.0

The committed entry (also on `main`) no longer compiled against the current pinned Mathlib:

- the umbrella module `Mathlib.Order.Filter.AtTopBot` was split into a directory and removed — replaced with `Mathlib.Analysis.SpecialFunctions.Pow.Real` + `.Sqrt`, which actually supply `√` and rpow used by the bound axioms;
- `greedySidon`'s recursion failed the termination checker (the self-reference `Finset.image greedySidon …` is higher-order). Guarding it with `Finset.attach` makes each recursive call visibly applied to an index `< n+1`; `attach_image_eq` / `greedySidon_succ_eq` bridge back to the clean `Finset.image greedySidon (range (n+1))` form used everywhere downstream.

### Remaining 5 axioms (status stays `axiomatized`)

`greedy_sidon_values` (OEIS A005282 initial terms), `greedy_sidon_lower_bound` (Ω(N^{1/3})), `erdos_turan_upper_bound` (O(√N + N^{1/4})), and the two open conjectures `greedy_sidon_growth_conjecture` and `greedy_sidon_diffset_pos_density`.

> Note: the same `AtTopBot` import + termination breakage affects several other gallery `Erdos*` files on `main` (they share the obsolete import); those are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)