### PR TITLE
research(sum-of-kth-powers-oq-05): power sums over a finite field ∑ₓ xᵏ = −1 ⟺ (q−1)∣k (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3072,6 +3072,7 @@ import Proofs.SumOfKthPowersOQ02
 import Proofs.SumOfKthPowersOQ03
 import Proofs.SumOfKthPowersOQ04
 import Proofs.SumOfKthPowersOQ04Aristotle
+import Proofs.SumOfKthPowersOQ05
 import Proofs.SylowTheorem
 import Proofs.SylowTheoremOQ01
 import Proofs.SylowTheoremOQ02

--- a/proofs/Proofs/SumOfKthPowersOQ05.lean
+++ b/proofs/Proofs/SumOfKthPowersOQ05.lean
@@ -1,0 +1,110 @@
+import Mathlib
+
+/-
+# Power Sums over a Finite Field (Sum of k-th Powers, OQ-05)
+
+The "sum of k-th powers" family in the gallery collects integer closed forms and
+asymptotics for `∑_{i<n} i^k` (Faulhaber / Bernoulli / Nicomachus / Euler–Maclaurin).
+This entry develops the orthogonal **modular** face of power sums: the value of the
+complete power sum
+
+  `∑_{x ∈ 𝔽_q} x^k`
+
+over an entire finite field of cardinality `q`.  The answer is a clean dichotomy:
+
+  `∑_{x : K} x^k = -1`  if `k ≠ 0` and `(q-1) ∣ k`,   and `0` otherwise.
+
+Mathlib provides `FiniteField.sum_pow_units`, the sum over the *units* `Kˣ`.  The
+headline result here extends that to the **whole** field, which requires handling the
+`x = 0` term and — crucially — the `k = 0` edge case, where every summand is `1` and the
+sum collapses to `q · 1 = 0` in characteristic `p`.  This is exactly the mechanism behind
+Fermat's little theorem and the von Staudt–Clausen congruences (the residues `0,1,…,p-1`
+sum to `0`, and more generally `∑ i^k ≡ -1 (mod p)` precisely when `(p-1) ∣ k`).
+
+All results are `0`-axiom; the concrete examples use kernel `decide` (not the
+compiler-trusting variant), so no `Lean.ofReduceBool` dependency is incurred.
+-/
+
+namespace SumOfKthPowersOQ05
+
+open Finset
+open scoped BigOperators
+
+variable {K : Type*} [Field K] [Fintype K] [DecidableEq K]
+
+/-- **Complete power sum over a finite field.**
+For a finite field `K` of cardinality `q = Fintype.card K`,
+`∑_{x : K} x^k = -1` when `k ≠ 0` and `(q-1) ∣ k`, and `0` otherwise.
+
+This extends `FiniteField.sum_pow_units` (the sum over the units `Kˣ`) to the full field:
+the `x = 0` term vanishes when `k ≠ 0`, and when `k = 0` every term equals `1`, so the
+sum is `q · 1 = 0` in characteristic `p`. -/
+theorem sum_pow_eq (k : ℕ) :
+    (∑ x : K, x ^ k) = if k ≠ 0 ∧ (Fintype.card K - 1) ∣ k then -1 else 0 := by
+  rcases eq_or_ne k 0 with hk | hk
+  · -- k = 0 : every summand is 1, so the sum is `(card K) · 1 = 0` in char p.
+    subst hk
+    simp only [pow_zero, sum_const, card_univ, nsmul_eq_mul, mul_one]
+    rw [FiniteField.cast_card_eq_zero, if_neg]
+    rintro ⟨h, -⟩
+    exact h rfl
+  · -- k ≠ 0 : drop the zero term and reduce to the sum over units.
+    have key : (∑ x : K, x ^ k) = ∑ x : Kˣ, (x ^ k : K) := by
+      let φ : Kˣ ↪ K := ⟨fun x ↦ x, Units.val_injective⟩
+      have himg : univ.map φ = univ \ {0} := by
+        ext x
+        simpa only [mem_map, mem_univ, Function.Embedding.coeFn_mk, true_and, mem_sdiff,
+          mem_singleton, φ] using isUnit_iff_ne_zero
+      calc
+        (∑ x : K, x ^ k) = ∑ x ∈ univ \ {(0 : K)}, x ^ k := by
+            rw [← sum_sdiff ({0} : Finset K).subset_univ, sum_singleton, zero_pow hk, add_zero]
+        _ = ∑ x : Kˣ, (x ^ k : K) := by simp [φ, ← himg, univ.sum_map φ]
+    rw [key, FiniteField.sum_pow_units]
+    simp only [hk, ne_eq, not_false_eq_true, true_and]
+
+/-- **Power sum over `ZMod p`.** For a prime `p`,
+`∑_{x : ZMod p} x^k = -1` when `k ≠ 0` and `(p-1) ∣ k`, and `0` otherwise. -/
+theorem sum_pow_zmod (p : ℕ) [Fact p.Prime] (k : ℕ) :
+    (∑ x : ZMod p, x ^ k) = if k ≠ 0 ∧ (p - 1) ∣ k then -1 else 0 := by
+  have h := sum_pow_eq (K := ZMod p) k
+  rwa [ZMod.card] at h
+
+/-- The complete power sum equals `-1` exactly when `k ≠ 0` and `(p-1) ∣ k`. -/
+theorem sum_pow_zmod_eq_neg_one_iff (p : ℕ) [Fact p.Prime] (k : ℕ) :
+    (∑ x : ZMod p, x ^ k) = -1 ↔ k ≠ 0 ∧ (p - 1) ∣ k := by
+  rw [sum_pow_zmod]
+  constructor
+  · intro h
+    by_contra hcon
+    rw [if_neg hcon] at h
+    -- `0 = -1` forces `1 = 0`, impossible in the field `ZMod p`.
+    exact one_ne_zero (by linear_combination h)
+  · intro h
+    rw [if_pos h]
+
+/-- **Sum of all residues.** For an odd prime `p`, the residues `0, 1, …, p-1`
+sum to `0` in `ZMod p` (the `k = 1` case: `(p-1) ∤ 1` once `p > 2`). -/
+theorem sum_residues_eq_zero (p : ℕ) [Fact p.Prime] (hp : 2 < p) :
+    (∑ x : ZMod p, x) = 0 := by
+  have h := sum_pow_zmod p 1
+  simp only [pow_one] at h
+  rw [h, if_neg]
+  rintro ⟨-, hdvd⟩
+  have : p - 1 ≤ 1 := Nat.le_of_dvd one_pos hdvd
+  omega
+
+/-! ### Concrete instances (verified by `decide`, hence `0`-axiom) -/
+
+/-- `∑_{x : ZMod 5} x^4 = -1 = 4`, since `(5-1) ∣ 4`. -/
+example : (∑ x : ZMod 5, x ^ 4) = 4 := by decide
+
+/-- `∑_{x : ZMod 5} x^2 = 0`, since `(5-1) ∤ 2`. -/
+example : (∑ x : ZMod 5, x ^ 2) = 0 := by decide
+
+/-- `∑_{x : ZMod 7} x^6 = -1 = 6`, since `(7-1) ∣ 6`. -/
+example : (∑ x : ZMod 7, x ^ 6) = 6 := by decide
+
+/-- Sum of residues of `ZMod 5` is `0` (instance of `sum_residues_eq_zero`). -/
+example : (∑ x : ZMod 5, x) = 0 := by decide
+
+end SumOfKthPowersOQ05

--- a/src/data/proofs/sum-of-kth-powers-oq-05/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-05/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "sum-of-kth-powers-oq-05",
+  "title": "Power Sums over a Finite Field: ∑ₓ xᵏ = −1 iff (q−1)∣k",
+  "slug": "sum-of-kth-powers-oq-05",
+  "description": "The modular face of power sums. Over a finite field K of cardinality q, the complete power sum ∑_{x∈K} xᵏ equals −1 when k ≠ 0 and (q−1)∣k, and 0 otherwise. This extends Mathlib's FiniteField.sum_pow_units (the sum over the units Kˣ) to the whole field: the x=0 term vanishes for k≠0, and for k=0 every summand is 1, so the sum collapses to q·1 = 0 in characteristic p. Specialized to ZMod p and applied to recover that the residues 0,1,…,p−1 sum to 0 for odd primes. The orthogonal complement to the family's integer closed forms (Faulhaber/Bernoulli/Nicomachus/Euler–Maclaurin) — this is the Fermat-little-theorem / von Staudt–Clausen congruence mechanism. Verified, 0 axioms.",
+  "meta": {
+    "author": "classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fermat%27s_little_theorem",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "finite-fields",
+      "power-sums",
+      "fermat-little-theorem",
+      "von-staudt-clausen",
+      "modular-arithmetic",
+      "zmod",
+      "character-sums",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SumOfKthPowersOQ05.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "FiniteField.sum_pow_units",
+        "description": "∑_{x : Kˣ} xⁱ = if (q−1)∣i then −1 else 0 — the power sum over the units of a finite field; the engine for the nonzero terms",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "FiniteField.cast_card_eq_zero",
+        "description": "(q : K) = 0 — the cardinality of a finite field vanishes in its own characteristic; gives the k=0 collapse ∑ 1 = q·1 = 0",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "ZMod.card",
+        "description": "Fintype.card (ZMod n) = n — identifies q−1 with p−1 in the ZMod p specialization",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.sum_sdiff",
+        "description": "splits the full-field sum into the {0} term and the units; combined with zero_pow to drop the x=0 contribution when k≠0",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "isUnit_iff_ne_zero",
+        "description": "in a field x is a unit iff x ≠ 0 — identifies univ \\ {0} with the image of Kˣ to bridge to sum_pow_units",
+        "module": "Mathlib.Algebra.GroupWithZero.Units.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "sum_pow_eq: ∑_{x : K} xᵏ = if k≠0 ∧ (q−1)∣k then −1 else 0 — the complete power sum over an entire finite field, extending Mathlib's units-only sum_pow_units (handles the x=0 term and the k=0 edge case)",
+      "sum_pow_zmod: the ZMod p specialization ∑_{x : ZMod p} xᵏ = if k≠0 ∧ (p−1)∣k then −1 else 0",
+      "sum_pow_zmod_eq_neg_one_iff: the sum equals −1 exactly when k≠0 and (p−1)∣k — the precise congruence criterion",
+      "sum_residues_eq_zero: for an odd prime p, ∑_{x : ZMod p} x = 0 (the k=1 case, since (p−1)∤1 once p>2)",
+      "Concrete decide-checked instances over ZMod 5 and ZMod 7 (0-axiom, no native_decide)"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 109,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Concrete instances use decide (not native_decide), so no Lean.ofReduceBool dependency.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The integer power sum ∑_{i<n} iᵏ has a long history of closed forms — Faulhaber's polynomials (1631), Bernoulli's 'Ars Conjectandi' (1713), and the Euler–Maclaurin asymptotics. A parallel, equally classical story lives mod p. Fermat's little theorem (a^{p−1} ≡ 1 for p∤a) says the nonzero residues are (p−1)-th roots of unity in 𝔽_p, and summing powers of a generator of the cyclic group 𝔽_p^× yields a geometric-series dichotomy: ∑_{x≠0} xᵏ is −1 when (p−1)∣k and 0 otherwise. Adding the x=0 term and the degenerate k=0 case (where the sum becomes the cardinality, which vanishes in characteristic p) gives the complete statement. This congruence is the combinatorial heart of the von Staudt–Clausen theorem on the denominators of Bernoulli numbers, where ∑ i^k mod p controls the p-integrality of B_k.",
+    "problemStatement": "**Open Question (sum-of-kth-powers-oq-05)**: Determine the complete power sum ∑_{x∈K} xᵏ over a finite field, and its arithmetic specialization over ZMod p.\n\n**Result**: sum_pow_eq — ∑_{x : K} xᵏ = −1 if k ≠ 0 and (q−1)∣k, else 0 — together with the ZMod p form sum_pow_zmod and the residue-sum corollary sum_residues_eq_zero.",
+    "text": "For a finite field K of cardinality q, the complete power sum ∑_{x : K} xᵏ equals −1 precisely when k ≠ 0 and (q−1) divides k, and 0 in every other case.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `sum_pow_eq` splits on whether k = 0. When k = 0, every summand is x⁰ = 1, so the sum is (card K)·1, which is 0 by `FiniteField.cast_card_eq_zero`; the if-condition k≠0 is false, matching 0.\n2. When k ≠ 0, the x = 0 term is 0^k = 0 and is dropped via `Finset.sum_sdiff` and `zero_pow`. The remaining sum over univ \\ {0} is identified with the sum over the units Kˣ using `isUnit_iff_ne_zero` and an injective embedding Kˣ ↪ K, then evaluated by `FiniteField.sum_pow_units` to `if (q−1)∣k then −1 else 0`. With k≠0 the conjunctive condition simplifies to (q−1)∣k.\n3. `sum_pow_zmod` substitutes `ZMod.card` (q = p) into the general theorem.\n4. `sum_pow_zmod_eq_neg_one_iff` reads off the −1 case: it holds iff the if-condition does, since 0 ≠ −1 in the field ZMod p.\n5. `sum_residues_eq_zero` instantiates k = 1: (p−1)∣1 forces p−1 ≤ 1, contradicting p > 2, so the sum is 0.",
+    "keyInsights": [
+      "**Extending units to the whole field.** Mathlib stops at ∑ over Kˣ. The full-field sum needs two extra ingredients: the x=0 term (handled by zero_pow when k≠0) and the k=0 collapse, where the answer is the cardinality q — which is 0 in characteristic p. This is exactly where the field characteristic enters.",
+      "**A geometric series in disguise.** ∑_{x≠0} xᵏ runs over the cyclic group 𝔽_q^×; writing x = gⁱ for a generator g turns it into a geometric series in gᵏ that sums to 0 unless gᵏ = 1, i.e. (q−1)∣k, where it counts the q−1 ≡ −1 group elements.",
+      "**The Fermat / von Staudt–Clausen face of power sums.** Where the rest of the family gives integer closed forms (Faulhaber, Bernoulli, Nicomachus), this entry gives the mod-p congruence ∑ i^k ≡ −1 (mod p) iff (p−1)∣k — the mechanism behind the p-integrality of Bernoulli numbers.",
+      "**Residues sum to zero.** The k=1 instance recovers the familiar fact that 0+1+⋯+(p−1) ≡ 0 (mod p) for odd p — immediate once one notes (p−1) cannot divide 1."
+    ],
+    "prerequisites": [
+      "Finite field theory: the multiplicative group 𝔽_q^× is cyclic of order q−1",
+      "Mathlib's FiniteField.sum_pow_units and cast_card_eq_zero",
+      "Basic ZMod p API and the divisor relation (q−1)∣k"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Module docstring framing the modular face of power sums, the Mathlib import, namespace, and the finite-field variable setup.",
+      "mathContext": "$\\sum_{x \\in K} x^k$ over a finite field $K$ of cardinality $q = \\#K$."
+    },
+    {
+      "id": "main",
+      "title": "Complete Power Sum over a Finite Field",
+      "startLine": 34,
+      "endLine": 62,
+      "summary": "sum_pow_eq: ∑_{x : K} xᵏ = if k≠0 ∧ (q−1)∣k then −1 else 0, by splitting on k=0 (cardinality collapse) and reducing the nonzero terms to FiniteField.sum_pow_units.",
+      "mathContext": "$\\sum_{x : K} x^k = \\begin{cases} -1 & k \\neq 0 \\text{ and } (q-1) \\mid k \\\\ 0 & \\text{otherwise} \\end{cases}$"
+    },
+    {
+      "id": "zmod",
+      "title": "Specialization to ZMod p",
+      "startLine": 64,
+      "endLine": 82,
+      "summary": "sum_pow_zmod and sum_pow_zmod_eq_neg_one_iff: the prime-field form via ZMod.card, and the precise criterion for the sum to equal −1.",
+      "mathContext": "$\\sum_{x : \\mathbb{Z}/p} x^k = -1 \\iff k \\neq 0 \\text{ and } (p-1) \\mid k$."
+    },
+    {
+      "id": "residues",
+      "title": "Sum of Residues and Instances",
+      "startLine": 84,
+      "endLine": 109,
+      "summary": "sum_residues_eq_zero (∑ residues = 0 for odd primes, the k=1 case) and concrete decide-verified instances over ZMod 5 and ZMod 7.",
+      "mathContext": "$\\sum_{x : \\mathbb{Z}/p} x = 0$ for odd $p$; e.g. $\\sum_{x : \\mathbb{Z}/5} x^4 = -1$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sum-of-kth-powers-oq-04",
+      "relationship": "related",
+      "description": "OQ-04 gives the Euler–Maclaurin asymptotics for integer power sums ∑ iᵏ/n^{k+1} → 1/(k+1); this entry develops the orthogonal modular face ∑_{x∈𝔽_p} xᵏ, a congruence rather than an integer/asymptotic closed form"
+    },
+    {
+      "targetId": "sum-of-kth-powers",
+      "relationship": "extends",
+      "description": "Extends the base power-sum entry with the finite-field / mod-p evaluation, complementing its Faulhaber and Nicomachus integer identities"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) evaluation of the power sum over a finite field: ∑_{x : K} xᵏ = −1 when k ≠ 0 and (q−1)∣k and 0 otherwise, extending Mathlib's units-only sum_pow_units to the whole field, specialized to ZMod p, and applied to recover that the residues sum to 0 for odd primes.",
+    "implications": "Supplies the mod-p congruence face of the power-sum family — the Fermat-little-theorem / von Staudt–Clausen evaluation — as a clean universally quantified theorem over arbitrary finite fields, with the x=0 and k=0 boundary cases that the standard units-only lemma omits.",
+    "openQuestions": [
+      "Derive the Nat-congruence corollary ∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) (mod p) by casting the ZMod p sum back to ℕ via Nat.ModEq.",
+      "Use the power-sum dichotomy to give a finite-field proof of the von Staudt–Clausen congruence on the p-integral part of Bernoulli numbers B_k for (p−1)∣k."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "SumOfKthPowersOQ05",
+    "lineCount": 109,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/SumOfKthPowersOQ05.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Ireland, Kenneth and Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "Springer Graduate Texts in Mathematics 84, 2nd ed.",
+      "note": "Chapter 4: sums of powers of residues mod p and their role in Bernoulli number congruences"
+    },
+    {
+      "authors": "Lidl, Rudolf and Niederreiter, Harald",
+      "title": "Finite Fields",
+      "year": "1997",
+      "venue": "Cambridge University Press, Encyclopedia of Mathematics and its Applications 20",
+      "note": "Power sums ∑_{x∈𝔽_q} xᵏ and character sums over finite fields"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds **sum-of-kth-powers-oq-05**, the *modular* face of power sums — complementing the family's integer closed forms (Faulhaber/Bernoulli/Nicomachus) and the Euler–Maclaurin asymptotics of OQ-04.

**Headline theorem** (`sum_pow_eq`), over any finite field `K` of cardinality `q`:
$$\sum_{x \in K} x^k = \begin{cases} -1 & k \neq 0 \text{ and } (q-1) \mid k \\ 0 & \text{otherwise.}\end{cases}$$

This **extends** Mathlib's `FiniteField.sum_pow_units` (the sum over the units `Kˣ`) to the *whole* field. Two ingredients are needed beyond the units lemma:
- the `x = 0` term, dropped via `zero_pow` when `k ≠ 0`;
- the `k = 0` edge case, where every summand is `1`, so the sum is `q · 1 = 0` in characteristic `p` (`FiniteField.cast_card_eq_zero`) — this is exactly where the field characteristic enters.

## Deliverables (4 theorems, 0 definitions, 4 `decide`-checked instances)

- `sum_pow_eq` — complete power sum over a finite field (headline)
- `sum_pow_zmod` — the `ZMod p` specialization via `ZMod.card`
- `sum_pow_zmod_eq_neg_one_iff` — the precise criterion for the sum to equal `−1`
- `sum_residues_eq_zero` — for an odd prime `p`, `∑_{x : ZMod p} x = 0` (the `k=1` case)
- Concrete instances over `ZMod 5` / `ZMod 7` by kernel `decide`

This is the Fermat-little-theorem / von Staudt–Clausen congruence mechanism (`∑ iᵏ ≡ −1 (mod p)` iff `(p−1)∣k`), the combinatorial heart of Bernoulli-number `p`-integrality. Absent from both Mathlib (units-only) and the gallery.

## Verification

- ✅ Compiles against pinned Mathlib (`lake env lean`)
- ✅ **0 axioms**: `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` for all four theorems — no `sorryAx`, no `Lean.ofReduceBool` (examples use kernel `decide`, not `native_decide`)
- ✅ 0 sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)