### PR TITLE
research(quadratic-gauss-sum-square-oq-02): equidistribution of quadratic residues and non-residues mod p

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2902,6 +2902,7 @@ import Proofs.PythagoreanTriplesOQ07
 import Proofs.QuadraticGaussSumDiagonal
 import Proofs.QuadraticGaussSumSquare
 import Proofs.QuadraticGaussSumSquareOQ01
+import Proofs.QuadraticGaussSumSquareOQ02
 import Proofs.QuadraticGaussSumNormParseval
 import Proofs.QuadraticGaussSumSignReduction
 import Proofs.QuadraticGaussSumSignSmall

--- a/proofs/Proofs/QuadraticGaussSumSquareOQ02.lean
+++ b/proofs/Proofs/QuadraticGaussSumSquareOQ02.lean
@@ -1,0 +1,134 @@
+/-
+  Equidistribution of quadratic residues and non-residues mod an odd prime.
+
+  For an odd prime `p`, let `χ = quadraticChar (ZMod p)` be the quadratic
+  (Legendre) character: `χ 0 = 0`, `χ a = 1` when `a ≠ 0` is a square, and
+  `χ a = -1` when `a` is a non-square.  Mathlib's `quadraticChar_sum_zero`
+  records the orthogonality fact that the full character sum vanishes:
+
+      ∑ a : ZMod p, χ a = 0.
+
+  This file extracts the elementary *counting* consequence:  the nonzero
+  squares (quadratic residues) and the non-squares (non-residues) are
+  **equinumerous**, each class containing exactly `(p-1)/2` elements.
+
+  The argument is a pure sign count.  Since `χ` is quadratic it takes only the
+  values `0, 1, -1`, so
+
+      ∑ a, χ a  =  #{a : χ a = 1}  −  #{a : χ a = -1}.
+
+  The left side is `0` by `quadraticChar_sum_zero`, giving
+  `#{χ = 1} = #{χ = -1}`.  Separately `χ a = 0 ↔ a = 0`, so the two classes
+  exhaust the `p - 1` nonzero elements; together this pins each count at
+  `(p-1)/2`.
+
+  This is logically independent of the parent's square identity
+  `g² = (-1)^((p-1)/2)·p` — it is the orthogonality/Parseval side of the
+  Gauss-sum story rather than the algebraic-square side.
+-/
+import Mathlib
+
+open scoped BigOperators
+open Finset
+
+namespace QuadraticGaussSumSquareOQ02
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-- The quadratic character of `ZMod p` (`p` odd) has a vanishing total sum:
+`∑ a, χ a = 0`.  This is `quadraticChar_sum_zero` specialised to `ZMod p`,
+with the characteristic hypothesis discharged from `p ≠ 2`. -/
+theorem quadraticChar_sum_eq_zero (hp : p ≠ 2) :
+    ∑ a : ZMod p, quadraticChar (ZMod p) a = 0 := by
+  refine quadraticChar_sum_zero ?_
+  rw [ZMod.ringChar_zmod_n]
+  exact hp
+
+/-- The squares filter: nonzero quadratic residues are exactly `{a : χ a = 1}`. -/
+private def residues (p : ℕ) [Fact p.Prime] : Finset (ZMod p) :=
+  univ.filter (fun a => quadraticChar (ZMod p) a = 1)
+
+/-- The non-residues filter: non-squares are exactly `{a : χ a = -1}`. -/
+private def nonresidues (p : ℕ) [Fact p.Prime] : Finset (ZMod p) :=
+  univ.filter (fun a => quadraticChar (ZMod p) a = -1)
+
+/-- The character sum splits as `#residues − #nonresidues`, because the quadratic
+character takes only the values `0, 1, -1`. -/
+theorem sum_eq_card_sub_card :
+    (∑ a : ZMod p, quadraticChar (ZMod p) a)
+      = (residues p).card - (nonresidues p).card := by
+  have hval : ∀ a : ZMod p,
+      (quadraticChar (ZMod p) a : ℤ)
+        = (if quadraticChar (ZMod p) a = 1 then (1 : ℤ) else 0)
+          - (if quadraticChar (ZMod p) a = -1 then (1 : ℤ) else 0) := by
+    intro a
+    rcases quadraticChar_isQuadratic (ZMod p) a with h | h | h <;> rw [h] <;> simp
+  calc
+    (∑ a : ZMod p, quadraticChar (ZMod p) a)
+        = ∑ a : ZMod p,
+            ((if quadraticChar (ZMod p) a = 1 then (1 : ℤ) else 0)
+              - (if quadraticChar (ZMod p) a = -1 then (1 : ℤ) else 0)) :=
+          Finset.sum_congr rfl (fun a _ => hval a)
+    _ = (∑ a : ZMod p, if quadraticChar (ZMod p) a = 1 then (1 : ℤ) else 0)
+          - (∑ a : ZMod p, if quadraticChar (ZMod p) a = -1 then (1 : ℤ) else 0) := by
+          rw [Finset.sum_sub_distrib]
+    _ = (residues p).card - (nonresidues p).card := by
+          rw [Finset.sum_boole, Finset.sum_boole]; rfl
+
+/-- **Equidistribution.** The number of quadratic residues equals the number of
+non-residues mod an odd prime `p`. -/
+theorem card_residues_eq_card_nonresidues (hp : p ≠ 2) :
+    (residues p).card = (nonresidues p).card := by
+  have h := sum_eq_card_sub_card (p := p)
+  rw [quadraticChar_sum_eq_zero hp] at h
+  have : ((residues p).card : ℤ) = (nonresidues p).card := by linarith
+  exact_mod_cast this
+
+/-- The residues and non-residues together exhaust the `p - 1` nonzero elements. -/
+theorem card_residues_add_card_nonresidues :
+    (residues p).card + (nonresidues p).card = p - 1 := by
+  classical
+  -- the two classes are disjoint (`χ a` cannot be both `1` and `-1`)
+  have hdisj : Disjoint (residues p) (nonresidues p) := by
+    rw [residues, nonresidues, Finset.disjoint_filter]
+    intro a _ h1 h2
+    rw [h1] at h2
+    exact (by decide : ¬ (1 : ℤ) = -1) h2
+  -- their union is exactly the set of nonzero elements
+  have hunion : residues p ∪ nonresidues p = univ.filter (fun a : ZMod p => a ≠ 0) := by
+    rw [residues, nonresidues, ← Finset.filter_or]
+    apply Finset.filter_congr
+    intro a _
+    constructor
+    · rintro (h | h) hz
+      · rw [(quadraticChar_eq_zero_iff.mpr hz)] at h; exact (by decide : ¬ (0 : ℤ) = 1) h
+      · rw [(quadraticChar_eq_zero_iff.mpr hz)] at h; exact (by decide : ¬ (0 : ℤ) = -1) h
+    · intro hz
+      rcases quadraticChar_isQuadratic (ZMod p) a with h | h | h
+      · exact absurd (quadraticChar_eq_zero_iff.mp h) hz
+      · exact Or.inl h
+      · exact Or.inr h
+  -- count the nonzero elements: `p - 1`
+  have hcard_nonzero : (univ.filter (fun a : ZMod p => a ≠ 0)).card = p - 1 := by
+    have : (univ.filter (fun a : ZMod p => a ≠ 0)) = univ.erase (0 : ZMod p) := by
+      ext a; simp [Finset.mem_erase]
+    rw [this, Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, ZMod.card]
+  rw [← Finset.card_union_of_disjoint hdisj, hunion, hcard_nonzero]
+
+/-- **Count of quadratic residues.** For an odd prime `p`, exactly `(p-1)/2` of
+the elements of `ZMod p` are nonzero squares. -/
+theorem card_residues_eq (hp : p ≠ 2) :
+    (residues p).card = (p - 1) / 2 := by
+  have heq := card_residues_eq_card_nonresidues (p := p) hp
+  have hsum := card_residues_add_card_nonresidues (p := p)
+  rw [← heq] at hsum
+  omega
+
+/-- **Count of non-residues.** Symmetrically, exactly `(p-1)/2` elements are
+non-squares. -/
+theorem card_nonresidues_eq (hp : p ≠ 2) :
+    (nonresidues p).card = (p - 1) / 2 := by
+  rw [← card_residues_eq_card_nonresidues (p := p) hp]
+  exact card_residues_eq (p := p) hp
+
+end QuadraticGaussSumSquareOQ02

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-02/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-02/meta.json
@@ -1,0 +1,64 @@
+{
+  "id": "quadratic-gauss-sum-square-oq-02",
+  "title": "Equidistribution of Quadratic Residues and Non-Residues mod p",
+  "slug": "quadratic-gauss-sum-square-oq-02",
+  "description": "For an odd prime p, the quadratic (Legendre) character χ = quadraticChar (ZMod p) satisfies the orthogonality identity ∑ₐ χ(a) = 0 (Mathlib's quadraticChar_sum_zero). This entry draws the elementary counting consequence: the nonzero quadratic residues {a : χ(a) = 1} and the non-residues {a : χ(a) = -1} are equinumerous, each class containing exactly (p−1)/2 elements. Because χ is a quadratic character it takes only the values 0, 1, −1, so the character sum equals #{χ = 1} − #{χ = -1}; vanishing of the sum forces the two counts to agree, and χ(a) = 0 ⟺ a = 0 means they partition the p−1 nonzero elements. This is the orthogonality/equidistribution side of the Gauss-sum story, logically independent of the parent's algebraic square identity g² = (−1)^((p−1)/2)·p.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticGaussSumSquareOQ02.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-residue",
+      "legendre-symbol",
+      "quadratic-character",
+      "gauss-sum",
+      "counting",
+      "zmod"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 134,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "assumptions": ""
+  },
+  "overview": {
+    "historicalContext": "That exactly half of the nonzero residues mod an odd prime are squares is one of the oldest facts in number theory, classically proved by pairing $a$ with $-a$ or by noting the squaring map $x \\mapsto x^2$ on $(\\mathbb{Z}/p)^\\times$ is two-to-one onto its image. The quadratic character $\\chi$ packages this: $\\chi(a) = +1$ on residues, $-1$ on non-residues, $0$ at zero. Its total sum $\\sum_a \\chi(a) = 0$ is the simplest instance of character orthogonality — the same orthogonality that underlies the evaluation of Gauss sums and the functional equations of Dirichlet $L$-functions. This entry isolates the counting content of that vanishing sum, separate from the deeper algebraic identity $g^2 = (-1)^{(p-1)/2} p$ studied in the parent.",
+    "problemStatement": "Let $p$ be an odd prime and $\\chi = \\operatorname{quadraticChar}(\\mathbb{Z}/p\\mathbb{Z})$ the quadratic character. Granting the orthogonality identity $\\sum_{a \\in \\mathbb{Z}/p} \\chi(a) = 0$, prove that the set of nonzero quadratic residues $\\{a : \\chi(a) = 1\\}$ and the set of non-residues $\\{a : \\chi(a) = -1\\}$ have equal cardinality, and that this common cardinality is exactly $(p-1)/2$.",
+    "proofStrategy": "Three steps. (1) `quadraticChar_sum_eq_zero` specialises Mathlib's `quadraticChar_sum_zero` to $\\mathbb{Z}/p$, discharging the characteristic hypothesis $\\operatorname{ringChar} \\ne 2$ from $p \\ne 2$ via `ZMod.ringChar_zmod_n`. (2) `sum_eq_card_sub_card` rewrites each value $\\chi(a)$ as $[\\chi(a)=1] - [\\chi(a)=-1]$ — valid because `quadraticChar_isQuadratic` says $\\chi(a) \\in \\{0,1,-1\\}$ — and applies `Finset.sum_boole` to turn the two indicator sums into the cardinalities of the residue and non-residue filters; so $\\sum_a \\chi(a) = \\#\\text{residues} - \\#\\text{nonresidues}$. Combining (1) and (2), `card_residues_eq_card_nonresidues` concludes the two counts are equal. (3) `card_residues_add_card_nonresidues` shows the two filters are disjoint and their union is exactly the nonzero elements (using $\\chi(a) = 0 \\iff a = 0$, `quadraticChar_eq_zero_iff`), whose count is $p-1$ by `ZMod.card` and `Finset.card_erase_of_mem`. Equal halves summing to $p-1$ give $(p-1)/2$ each by `omega`.",
+    "keyInsights": [
+      "The vanishing character sum $\\sum_a \\chi(a) = 0$ is exactly a signed count: residues contribute $+1$, non-residues $-1$, and zero contributes $0$, so the sum literally equals $\\#\\text{residues} - \\#\\text{nonresidues}$. Equidistribution is therefore not an extra theorem but a direct reading of orthogonality.",
+      "`quadraticChar_isQuadratic` — the statement that $\\chi$ takes only the values $0, 1, -1$ — is the structural fact that lets each summand be replaced by a difference of Boolean indicators, after which `Finset.sum_boole` converts indicator sums to filter cardinalities mechanically.",
+      "The partition into residues, non-residues, and $\\{0\\}$ rests on two clean iff-lemmas: $\\chi(a) = 0 \\iff a = 0$ pins the single excluded element, and quadraticity forbids any fourth value, so the nonzero elements split exactly into the two $\\pm 1$ classes.",
+      "The result is logically independent of the parent's square identity $g^2 = (-1)^{(p-1)/2} p$: that identity is the algebraic-square side of Gauss sums, whereas equidistribution is the orthogonality side, requiring only that the total character sum vanishes."
+    ]
+  },
+  "conclusion": {
+    "summary": "For every odd prime $p$, the nonzero quadratic residues and the non-residues mod $p$ are machine-verified to be equinumerous, each class having exactly $(p-1)/2$ elements. The proof reads the count off Mathlib's vanishing quadratic-character sum $\\sum_a \\chi(a) = 0$ together with the quadraticity of $\\chi$, with no axioms and no sorries.",
+    "implications": "Equidistribution of residues is the input to many elementary arguments: the existence of non-residues, the multiplicativity bookkeeping behind the Legendre symbol, and the $\\pm 1$ balance that makes character sums tractable. Here it is derived purely from orthogonality, complementing the parent's algebraic square identity and giving a self-contained counting companion to the Gauss-sum family.",
+    "openQuestions": [
+      "Can the same vanishing-sum/quadraticity mechanism be used to count residues in a class field $\\mathbb{F}_q$ with $q$ an odd prime power, giving $(q-1)/2$ nonzero squares directly from `quadraticChar_sum_zero` over $\\mathbb{F}_q$?",
+      "Does the signed-indicator decomposition extend to higher-order characters (cubic, quartic) to count the fibres of $x \\mapsto x^k$ from the corresponding character orthogonality relations?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "quadratic-gauss-sum-square",
+      "relationship": "related",
+      "description": "The parent establishes the algebraic square identity g² = (-1)^((p-1)/2)·p for the quadratic Gauss sum. This entry develops the complementary orthogonality side — the vanishing total character sum and its counting consequence — independently of the square identity."
+    },
+    {
+      "proofId": "quadratic-gauss-sum-square-oq-01",
+      "relationship": "related",
+      "description": "The sibling oq-01 extracts the real/imaginary dichotomy and magnitude ‖g‖²=p from the square identity. This entry instead uses the character sum ∑ₐ χ(a)=0 to count residues, a parallel elementary consequence of the same quadratic character."
+    },
+    {
+      "proofId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Equidistribution of residues and non-residues is part of the elementary theory of the Legendre symbol that underlies quadratic reciprocity."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

For an odd prime `p`, the nonzero **quadratic residues** `{a : χ(a) = 1}` and the **non-residues** `{a : χ(a) = -1}` mod `p` are equinumerous, each class containing exactly `(p−1)/2` elements. Here `χ = quadraticChar (ZMod p)` is the Legendre character.

The result is read directly off Mathlib's orthogonality identity `quadraticChar_sum_zero`:
```
∑ a : ZMod p, χ(a) = 0.
```
Since `χ` is a quadratic character (`quadraticChar_isQuadratic`) it takes only the values `0, 1, -1`, so the character sum is a signed count:
```
∑ a, χ(a) = #{χ = 1} − #{χ = -1}.
```
Vanishing forces `#{χ = 1} = #{χ = -1}`. Combined with `χ(a) = 0 ⟺ a = 0` (so the two classes partition the `p−1` nonzero elements), each count is `(p−1)/2`.

This is the **orthogonality / equidistribution side** of the Gauss-sum story — logically independent of the parent's algebraic square identity `g² = (−1)^((p−1)/2)·p` and of the sibling oq-01 (real/imaginary dichotomy).

## Theorems (`Proofs/QuadraticGaussSumSquareOQ02.lean`)
- `quadraticChar_sum_eq_zero` — specialises `quadraticChar_sum_zero` to `ZMod p` (ringChar discharged from `p ≠ 2`)
- `sum_eq_card_sub_card` — `∑ χ(a) = #residues − #nonresidues` via `quadraticChar_isQuadratic` + `Finset.sum_boole`
- `card_residues_eq_card_nonresidues` — the two classes are equinumerous
- `card_residues_add_card_nonresidues` — they partition the `p−1` nonzero elements
- `card_residues_eq`, `card_nonresidues_eq` — each count is `(p−1)/2`

## Verification
- Compiles against pinned Mathlib (`lake env lean`)
- `#print axioms card_residues_eq` → `[propext, Classical.choice, Quot.sound]` only — **0 axioms**, no `sorry`, no `native_decide`
- `grep quadraticChar_sum_zero proofs/Proofs` was previously empty — first use in the gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)