### PR TITLE
research(mean-value-theorem-oq-05): Darboux's theorem — intermediate value property of derivatives (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2764,6 +2764,7 @@ import Proofs.MeanValueTheoremOQ02OQ04
 import Proofs.MeanValueTheoremOQ02OQ04OQ01
 import Proofs.MeanValueTheoremOQ03
 import Proofs.MeanValueTheoremOQ04
+import Proofs.MeanValueTheoremOQ05
 import Proofs.MidyTheorem
 import Proofs.MinkowskiFundamentalTheorem
 import Proofs.MinkowskiFundamentalTheoremOQ02

--- a/proofs/Proofs/MeanValueTheoremOQ05.lean
+++ b/proofs/Proofs/MeanValueTheoremOQ05.lean
@@ -1,0 +1,120 @@
+import Mathlib
+
+/-!
+# Darboux's Theorem — the Intermediate Value Property of Derivatives
+
+This file formalizes **Darboux's theorem**: a derivative satisfies the
+intermediate value property *even when it is not continuous*. If `f` is
+differentiable on `[a, b]`, then `f'` takes every value between `f'(a)` and
+`f'(b)` on `[a, b]`. Equivalently, the image of an order-connected set under a
+derivative is again order-connected — derivatives have **no jump
+discontinuities**.
+
+This is a genuinely different phenomenon from the ordinary Mean Value Theorem
+(Rolle / Lagrange / Cauchy) and from the FTC: it constrains the *range* of `f'`
+without assuming `f'` is continuous. A classic consequence is that a function
+like `sgn` can never be a derivative.
+
+## Key Results
+
+1. `darboux_ivp` — closed form: if `m ∈ [[f'(a), f'(b)]]` then `f' c = m` for
+   some `c ∈ [a, b]` (no continuity of `f'` required).
+2. `darboux_ivp_open` — strict form: if `m` is strictly between `f'(a)` and
+   `f'(b)` then `f' c = m` for some `c` in the **open** interval `(a, b)`.
+3. `darboux_ivp_deriv` — the same stated directly for `deriv f`.
+4. `deriv_range_ordConnected` — the range of `deriv f` over an order-connected
+   set is order-connected (no jumps).
+5. `deriv_range_convex` — the convex repackaging of the same fact.
+6. `not_deriv_of_jump` — a function whose putative "derivative" skips a value
+   strictly between two attained values cannot be a derivative.
+7. `darboux_sq_example` — a concrete witness: `deriv (·²)` hits `1` on `[0, 2]`.
+
+## Context
+
+This answers OQ-05 for the MVT gallery. The existing entries cover Rolle /
+Lagrange / Cauchy (base), monotonicity from the derivative (oq-03), Taylor
+(oq-02), and the FTC (oq-04). None of them state the intermediate value
+property *of the derivative itself*, which is the orthogonal "shape of `f'`"
+result. The Mathlib vehicle is `Mathlib.Analysis.Calculus.Darboux`.
+-/
+
+namespace MeanValueTheoremOQ05
+
+open Set
+
+variable {f f' : ℝ → ℝ} {a b : ℝ}
+
+/-- **Darboux's theorem (closed form).** If `f` is differentiable on `[a, b]`
+with derivative `f'`, then `f'` attains every value in the closed interval
+`[[f'(a), f'(b)]]` somewhere on `[a, b]` — *without* assuming `f'` is
+continuous. -/
+theorem darboux_ivp (hab : a ≤ b)
+    (hf : ∀ x ∈ Icc a b, HasDerivWithinAt f (f' x) (Icc a b) x)
+    {m : ℝ} (hm : m ∈ uIcc (f' a) (f' b)) :
+    ∃ c ∈ Icc a b, f' c = m := by
+  have hoc : OrdConnected (f' '' Icc a b) := ordConnected_Icc.image_hasDerivWithinAt hf
+  have ha : f' a ∈ f' '' Icc a b := mem_image_of_mem _ (left_mem_Icc.2 hab)
+  have hb : f' b ∈ f' '' Icc a b := mem_image_of_mem _ (right_mem_Icc.2 hab)
+  exact hoc.uIcc_subset ha hb hm
+
+/-- **Darboux's theorem (strict / open form).** If `m` lies strictly between
+`f'(a)` and `f'(b)`, the value is attained in the *open* interval `(a, b)`. -/
+theorem darboux_ivp_open (hab : a ≤ b)
+    (hf : ∀ x ∈ Icc a b, HasDerivWithinAt f (f' x) (Icc a b) x)
+    {m : ℝ} (hm : m ∈ Ioo (min (f' a) (f' b)) (max (f' a) (f' b))) :
+    ∃ c ∈ Ioo a b, f' c = m := by
+  rcases le_total (f' a) (f' b) with h | h
+  · rw [min_eq_left h, max_eq_right h] at hm
+    exact exists_hasDerivWithinAt_eq_of_gt_of_lt hab hf hm.1 hm.2
+  · rw [min_eq_right h, max_eq_left h] at hm
+    exact exists_hasDerivWithinAt_eq_of_lt_of_gt hab hf hm.2 hm.1
+
+/-- Darboux's theorem stated directly for `deriv f`, assuming `f` is
+differentiable at each point of `[a, b]`. -/
+theorem darboux_ivp_deriv (hab : a ≤ b)
+    (hf : ∀ x ∈ Icc a b, DifferentiableAt ℝ f x)
+    {m : ℝ} (hm : m ∈ uIcc (deriv f a) (deriv f b)) :
+    ∃ c ∈ Icc a b, deriv f c = m :=
+  darboux_ivp hab (fun x hx => (hf x hx).hasDerivAt.hasDerivWithinAt) hm
+
+/-- **No jump discontinuities.** The image of an order-connected set under
+`deriv f` is order-connected. This is the structural form of Darboux's
+theorem: a derivative cannot skip values. -/
+theorem deriv_range_ordConnected {s : Set ℝ} (hs : OrdConnected s)
+    (hf : ∀ x ∈ s, DifferentiableAt ℝ f x) :
+    OrdConnected (deriv f '' s) :=
+  hs.image_deriv hf
+
+/-- Convex repackaging: the image of a convex set under `deriv f` is convex. -/
+theorem deriv_range_convex {s : Set ℝ} (hs : Convex ℝ s)
+    (hf : ∀ x ∈ s, DifferentiableAt ℝ f x) :
+    Convex ℝ (deriv f '' s) :=
+  hs.image_deriv hf
+
+/-- **Consequence: a function with a gap is not a derivative.** Suppose `g`
+takes the values `g(a)` and `g(b)` (with `a ≤ b`) but never takes some value
+`m` strictly between them on `[a, b]`. Then `g` is not the derivative of any
+function on `[a, b]`. (Stated contrapositively to Darboux.) -/
+theorem not_deriv_of_jump (hab : a ≤ b) {g : ℝ → ℝ} {m : ℝ}
+    (hm : m ∈ uIcc (g a) (g b)) (hgap : ∀ x ∈ Icc a b, g x ≠ m) :
+    ¬ ∀ x ∈ Icc a b, HasDerivWithinAt f (g x) (Icc a b) x := by
+  intro hf
+  obtain ⟨c, hc, hcm⟩ := darboux_ivp hab hf hm
+  exact hgap c hc hcm
+
+/-- A concrete witness for Darboux's theorem: the derivative of `x ↦ x²` runs
+from `0` to `4` on `[0, 2]`, so it must hit the intermediate value `1` — and
+indeed `deriv (·²) (1/2) = 1`. -/
+theorem darboux_sq_example :
+    ∃ c ∈ Icc (0 : ℝ) 2, (fun x => 2 * x) c = 1 := by
+  have hf : ∀ x ∈ Icc (0 : ℝ) 2,
+      HasDerivWithinAt (fun x => x ^ 2) ((fun x => 2 * x) x) (Icc 0 2) x := by
+    intro x _
+    have h : HasDerivAt (fun x : ℝ => x ^ 2) (2 * x) x := by
+      simpa using hasDerivAt_pow 2 x
+    exact h.hasDerivWithinAt
+  refine darboux_ivp (by norm_num) hf ?_
+  rw [uIcc_of_le (by norm_num)]
+  constructor <;> norm_num
+
+end MeanValueTheoremOQ05

--- a/src/data/proofs/mean-value-theorem-oq-05/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-05/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-darboux-ivp",
+    "proofId": "mean-value-theorem-oq-05",
+    "range": { "startLine": 47, "endLine": 58 },
+    "type": "theorem",
+    "title": "darboux_ivp: Darboux's Theorem (Closed Form)",
+    "content": "If f is differentiable on [a,b] with derivative f', then f' attains every value m in the closed interval [[f'(a), f'(b)]] somewhere on [a,b] — with NO continuity assumption on f'. The proof routes through order-connectedness: ordConnected_Icc.image_hasDerivWithinAt shows the image f'(Icc a b) is order-connected; both endpoints f'(a) and f'(b) lie in it (mem_image_of_mem at the left/right endpoints); and OrdConnected.uIcc_subset then places the whole interval [[f'(a),f'(b)]] inside the image. The uIcc formulation handles both orientations of f'(a) vs f'(b) automatically.",
+    "mathContext": "$m \\in [[f'(a), f'(b)]] \\Rightarrow \\exists c \\in [a,b],\\; f'(c) = m$, the intermediate value property of derivatives without continuity.",
+    "significance": "critical",
+    "relatedConcepts": ["Set.OrdConnected.image_hasDerivWithinAt", "Set.OrdConnected.uIcc_subset", "HasDerivWithinAt", "intermediate value property"],
+    "prerequisites": ["Mathlib.Analysis.Calculus.Darboux", "Set.OrdConnected", "Set.uIcc"]
+  },
+  {
+    "id": "ann-darboux-ivp-open",
+    "proofId": "mean-value-theorem-oq-05",
+    "range": { "startLine": 60, "endLine": 70 },
+    "type": "theorem",
+    "title": "darboux_ivp_open: Darboux's Theorem (Strict / Open Form)",
+    "content": "When m lies strictly between f'(a) and f'(b), the witness c can be taken in the OPEN interval (a,b). The proof case-splits on le_total (f' a) (f' b), rewrites min/max accordingly, and applies exists_hasDerivWithinAt_eq_of_gt_of_lt (resp. _lt_of_gt) — Mathlib's open-interval Darboux witnesses, which extremize g(x)=f(x)-m·x on the compact [a,b] and show the extremum is interior. This is the substantive analytic core that the closed form repackages.",
+    "mathContext": "$m \\in (\\min(f'(a),f'(b)), \\max(f'(a),f'(b))) \\Rightarrow \\exists c \\in (a,b),\\; f'(c) = m$.",
+    "significance": "critical",
+    "relatedConcepts": ["exists_hasDerivWithinAt_eq_of_gt_of_lt", "exists_hasDerivWithinAt_eq_of_lt_of_gt", "Set.Ioo", "interior extremum"],
+    "prerequisites": ["Mathlib.Analysis.Calculus.Darboux", "min_eq_left", "max_eq_right"]
+  },
+  {
+    "id": "ann-darboux-ivp-deriv",
+    "proofId": "mean-value-theorem-oq-05",
+    "range": { "startLine": 72, "endLine": 78 },
+    "type": "theorem",
+    "title": "darboux_ivp_deriv: Darboux Stated for deriv f",
+    "content": "The closed form restated directly in terms of deriv f, assuming only DifferentiableAt ℝ f x at each point of [a,b]. Bridges from DifferentiableAt to HasDerivWithinAt via (hf x hx).hasDerivAt.hasDerivWithinAt and reuses darboux_ivp. This is the form most convenient when working with Mathlib's deriv function rather than explicit HasDerivWithinAt witnesses.",
+    "mathContext": "$m \\in [[\\operatorname{deriv} f\\,a,\\ \\operatorname{deriv} f\\,b]] \\Rightarrow \\exists c \\in [a,b],\\; \\operatorname{deriv} f\\,c = m$.",
+    "significance": "important",
+    "relatedConcepts": ["deriv", "DifferentiableAt", "HasDerivAt.hasDerivWithinAt"],
+    "prerequisites": ["deriv", "DifferentiableAt"]
+  },
+  {
+    "id": "ann-deriv-range-ordconnected",
+    "proofId": "mean-value-theorem-oq-05",
+    "range": { "startLine": 80, "endLine": 92 },
+    "type": "theorem",
+    "title": "deriv_range_ordConnected / deriv_range_convex: No Jump Discontinuities",
+    "content": "The structural form of Darboux's theorem: deriv f maps an order-connected set s to an order-connected set (wrapper of Set.OrdConnected.image_deriv), and the convex repackaging deriv_range_convex (wrapper of Convex.image_deriv). These say a derivative cannot skip values — its range over an interval is again an interval. On ℝ order-connected and convex coincide, so the two are equivalent.",
+    "mathContext": "$s$ order-connected $\\Rightarrow \\operatorname{deriv} f\\,(s)$ order-connected; $s$ convex $\\Rightarrow \\operatorname{deriv} f\\,(s)$ convex.",
+    "significance": "important",
+    "relatedConcepts": ["Set.OrdConnected.image_deriv", "Convex.image_deriv", "Set.OrdConnected", "Convex"],
+    "prerequisites": ["Set.OrdConnected", "Convex", "deriv"]
+  },
+  {
+    "id": "ann-not-deriv-of-jump",
+    "proofId": "mean-value-theorem-oq-05",
+    "range": { "startLine": 94, "endLine": 103 },
+    "type": "theorem",
+    "title": "not_deriv_of_jump: Value-Skipping Functions Are Not Derivatives",
+    "content": "The obstruction corollary, the contrapositive of darboux_ivp. If g takes its boundary values g(a), g(b) but skips some intermediate value m (g(x) ≠ m for all x ∈ [a,b]), then g cannot be the derivative of any function on [a,b]. The proof assumes the contrary, extracts a Darboux witness c with g(c) = m, and contradicts the gap hypothesis. This rules out step functions — the sign function, the floor function — as derivatives.",
+    "mathContext": "$m \\in [[g(a),g(b)]]$ and $g$ omits $m$ on $[a,b]$ $\\Rightarrow$ $g$ is not the derivative of any $f$ on $[a,b]$.",
+    "significance": "important",
+    "relatedConcepts": ["contrapositive", "step function", "sign function", "HasDerivWithinAt"],
+    "prerequisites": ["darboux_ivp"]
+  },
+  {
+    "id": "ann-darboux-sq-example",
+    "proofId": "mean-value-theorem-oq-05",
+    "range": { "startLine": 105, "endLine": 119 },
+    "type": "theorem",
+    "title": "darboux_sq_example: A Concrete Witness",
+    "content": "Darboux's theorem applied to f(x)=x²: its derivative 2x runs from 0 to 4 on [0,2], so it must attain the intermediate value 1, realized at c=1/2. The HasDerivWithinAt hypothesis is built from hasDerivAt_pow 2 x (simplified to 2x) and .hasDerivWithinAt; the membership 1 ∈ [[0,4]] is discharged by uIcc_of_le and norm_num. Demonstrates the abstract theorem on an explicit function.",
+    "mathContext": "$\\operatorname{deriv}(x^2) = 2x$ ranges over $[0,4]$ on $[0,2]$, hence hits $1$ at $x=1/2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["hasDerivAt_pow", "Set.uIcc_of_le", "concrete example"],
+    "prerequisites": ["darboux_ivp", "hasDerivAt_pow"]
+  }
+]

--- a/src/data/proofs/mean-value-theorem-oq-05/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-05/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "mean-value-theorem-oq-05",
+  "title": "Darboux's Theorem — the Intermediate Value Property of Derivatives",
+  "slug": "mean-value-theorem-oq-05",
+  "description": "Darboux's theorem: a derivative satisfies the intermediate value property even when it is not continuous. If f is differentiable on [a,b], then f' attains every value between f'(a) and f'(b) on [a,b] (closed form), and every value strictly between them in the open interval (a,b) (strict form). Equivalently, the image of an order-connected set under a derivative is order-connected — derivatives have no jump discontinuities. A consequence: a function that skips a value between two of its attained values (such as a step function) cannot be a derivative.",
+  "meta": {
+    "status": "verified",
+    "proofRepoPath": "Proofs/MeanValueTheoremOQ05.lean",
+    "badge": "original",
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "lineCount": 120,
+    "imports": [
+      "Mathlib"
+    ],
+    "tags": [
+      "calculus",
+      "mean-value-theorem",
+      "darboux",
+      "intermediate-value-theorem",
+      "derivatives",
+      "analysis"
+    ],
+    "assumptions": [],
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Header: Darboux's Theorem and the Shape of f'",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring introducing Darboux's theorem — the intermediate value property of derivatives — and contrasting it with the Mean Value Theorem and FTC: it constrains the range of f' without assuming f' is continuous. Lists the 7 headline results and opens the `Set` namespace.",
+      "mathContext": "A derivative $f'$ need not be continuous, yet it cannot have jump discontinuities: if $m$ lies between $f'(a)$ and $f'(b)$ then $f'(c)=m$ for some $c\\in[a,b]$. Equivalently, $f'$ maps order-connected sets to order-connected sets."
+    },
+    {
+      "id": "darboux-core",
+      "title": "Darboux's Theorem: Closed and Strict Forms",
+      "startLine": 47,
+      "endLine": 78,
+      "summary": "darboux_ivp: closed form — for m in the closed interval [[f'(a), f'(b)]] there is c ∈ [a,b] with f'(c)=m, proved by observing that the image f'(Icc a b) is order-connected (Set.OrdConnected.image_hasDerivWithinAt) and contains both endpoints, hence contains their uIcc. darboux_ivp_open: strict form — for m strictly between f'(a) and f'(b) the value is attained in the open interval (a,b), via exists_hasDerivWithinAt_eq_of_gt_of_lt / _lt_of_gt with a min/max case split. darboux_ivp_deriv: the closed form restated for deriv f given differentiability at each point.",
+      "mathContext": "Mathlib's `Set.OrdConnected.image_hasDerivWithinAt` states $f'(\\,[a,b]\\,)$ is order-connected. Since $f'(a),f'(b)$ are in the image, $[[f'(a),f'(b)]]\\subseteq f'([a,b])$ by `OrdConnected.uIcc_subset`. The strict form uses the open-interval witnesses $f'(c)=m\\in(a,b)$."
+    },
+    {
+      "id": "no-jumps",
+      "title": "No Jump Discontinuities: the Range of a Derivative",
+      "startLine": 80,
+      "endLine": 92,
+      "summary": "deriv_range_ordConnected: the image of an order-connected set under deriv f is order-connected (wrapper of Set.OrdConnected.image_deriv). deriv_range_convex: the convex repackaging — the image of a convex set under deriv f is convex. These are the structural statements of Darboux's theorem: a derivative cannot skip values.",
+      "mathContext": "Order-connectedness of $\\{f'(x) : x\\in s\\}$ for order-connected $s$. On $\\mathbb{R}$, order-connected and convex coincide, so the range of $f'$ over an interval is an interval."
+    },
+    {
+      "id": "consequences",
+      "title": "Consequences and a Concrete Witness",
+      "startLine": 94,
+      "endLine": 119,
+      "summary": "not_deriv_of_jump: contrapositive form — a function g that takes values g(a) and g(b) but skips some m strictly between them on [a,b] cannot be the derivative of any function (rules out step functions like sgn as derivatives). darboux_sq_example: a concrete instance — deriv(x²) ranges over [0,4] on [0,2], so it must hit 1, witnessed by deriv(x²)(1/2)=1.",
+      "mathContext": "Classic corollary: $\\operatorname{sgn}$ is not a derivative, because it omits values in $(-1,1)$ that lie between its attained values $\\pm1$. The square example exhibits $f'(x)=2x$ hitting the intermediate value $1$ at $x=1/2$."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Jean-Gaston Darboux proved this theorem in his 1875 memoir 'Mémoire sur les fonctions discontinues'. It is striking because derivatives need not be continuous — Volterra and others constructed differentiable functions whose derivatives are discontinuous on dense sets — yet Darboux showed that every derivative still has the intermediate value property, the defining feature of continuous functions in the IVT. The theorem implies that the discontinuities of a derivative can never be simple jumps; they must be essential (oscillatory) discontinuities, like that of x²·sin(1/x) at 0. A standard corollary is that no step function (for instance the sign function) can be a derivative. The result sharpens the classical Mean Value Theorem chain (Rolle 1691, Lagrange 1797, Cauchy 1823) by describing not just the existence of a single mean-value point but the entire range of f'.",
+    "problemStatement": "Prove Darboux's theorem and its structural consequences: (1) closed form — if f is differentiable on [a,b] with derivative f', then for every m in the closed interval between f'(a) and f'(b) there exists c ∈ [a,b] with f'(c)=m, without assuming f' continuous; (2) strict form — if m lies strictly between f'(a) and f'(b), the witness c can be taken in the open interval (a,b); (3) the range of deriv f over an order-connected (resp. convex) set is order-connected (resp. convex); (4) a function that skips an intermediate value cannot be a derivative; (5) exhibit a concrete witness.",
+    "proofStrategy": "All results build on Mathlib's `Mathlib.Analysis.Calculus.Darboux`. The closed form is obtained cleanly from the order-connectedness of the image: `Set.OrdConnected.image_hasDerivWithinAt` gives that f'(Icc a b) is order-connected, both endpoints f'(a), f'(b) lie in it, and `Set.OrdConnected.uIcc_subset` then places the whole interval [[f'(a),f'(b)]] inside the image. The strict form dispatches the two orientations of f'(a) vs f'(b) via `exists_hasDerivWithinAt_eq_of_gt_of_lt` and `exists_hasDerivWithinAt_eq_of_lt_of_gt`, which return witnesses in the open interval Ioo a b. The no-jump corollaries are direct wrappers of `Set.OrdConnected.image_deriv` and `Convex.image_deriv`. The 'not a derivative' consequence is the contrapositive of the closed form, and the concrete witness applies the closed form to f(x)=x² using `hasDerivAt_pow`.",
+    "keyInsights": [
+      "Darboux's theorem decouples the intermediate value property from continuity. The IVT is usually taught as a property of continuous functions, but derivatives — which can be wildly discontinuous — satisfy it too. The reason is not continuity of f' but the fact that f' is a derivative: it arises as a pointwise limit of the order-preserving difference quotients of f.",
+      "The cleanest route to the closed (uIcc) form is through order-connectedness rather than a direct case split. Mathlib packages Darboux as 'f' maps order-connected sets to order-connected sets' (Set.OrdConnected.image_hasDerivWithinAt). Once the image of [a,b] is known order-connected and to contain both endpoints, OrdConnected.uIcc_subset delivers every intermediate value in one line — handling both orientations of f'(a) vs f'(b) automatically.",
+      "The strict form genuinely lives in the open interval. Mathlib's exists_hasDerivWithinAt_eq_of_gt_of_lt returns membership in f'(Ioo a b), proved by extremizing the auxiliary function g(x)=f(x)-m·x on the compact [a,b] and showing the extremum is interior. This is the substantive analytic core; the closed form is its order-connected packaging.",
+      "Darboux's theorem is an obstruction theorem: it tells you which functions are NOT derivatives. Any function with a jump discontinuity (a step function, the sign function, the floor function) fails the intermediate value property and is therefore not the derivative of anything. not_deriv_of_jump makes this precise as the contrapositive.",
+      "On ℝ the notions of order-connected set and convex set coincide, so 'the range of f' is order-connected' and 'the range of f' is convex' say the same thing — both assert that the range is an interval. Mathlib distinguishes them because order-connectedness is the order-theoretic primitive while convexity is the linear-algebraic one; Darboux.lean proves the order version and derives the convex one."
+    ]
+  },
+  "conclusion": {
+    "summary": "Seven machine-checked theorems establishing Darboux's theorem — the intermediate value property of derivatives — in closed and strict forms, its structural restatement that derivatives map order-connected (and convex) sets to order-connected (convex) sets, the obstruction corollary that value-skipping functions are not derivatives, and a concrete witness. All verified against Mathlib's Analysis.Calculus.Darboux with zero axioms and zero sorries.",
+    "implications": "Darboux's theorem is the reason the classification of derivatives is subtle: it forbids the easy discontinuities. It underlies the theory of which functions admit antiderivatives (a Riemann-integrable function with a jump cannot be a derivative even where its integral is differentiable), informs the construction of pathological examples in real analysis, and is the prototype for 'IVP without continuity' phenomena that recur for connected-graph functions and for the derivatives of convex functions. The order-connected formulation also connects to the topological fact that continuous images of connected sets are connected.",
+    "openQuestions": [
+      "Can the Volterra-type construction of a differentiable function whose derivative is discontinuous on a set of positive measure be formalized, exhibiting a concrete derivative that fails to be Riemann integrable while still satisfying Darboux's property?",
+      "Does Mathlib support the converse-flavoured characterization of Baire class one for derivatives — every derivative is of Baire class 1 — and can Darboux's theorem be combined with it to characterize the discontinuity sets of derivatives?",
+      "Can the Darboux property be stated and proved for derivatives valued in a general ordered or normed setting (e.g. the components of a vector-valued derivative), and where does the order-connected packaging break down?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "mean-value-theorem",
+      "relationship": "extends",
+      "description": "Complements the base Mean Value Theorem: where the MVT asserts the existence of a single point with a prescribed derivative value, Darboux's theorem describes the entire range of the derivative."
+    },
+    {
+      "proofId": "mean-value-theorem-oq-03",
+      "relationship": "related",
+      "description": "OQ-03 derives monotonicity from the sign of the derivative; Darboux's theorem complements it by constraining the range of the derivative itself, independently of continuity."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/MeanValueTheoremOQ05.lean",
+    "lineCount": 120,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "imports": [
+      "import Mathlib"
+    ],
+    "opens": [
+      "Set"
+    ],
+    "namespace": "MeanValueTheoremOQ05"
+  },
+  "mainTheorems": [
+    {
+      "name": "darboux_ivp",
+      "type": "core",
+      "statement": "$a\\le b$, $f$ differentiable on $[a,b]$ with derivative $f'$, $m\\in[[f'(a),f'(b)]] \\Rightarrow \\exists c\\in[a,b],\\; f'(c)=m$",
+      "significance": "Darboux's theorem in closed form. Proved through order-connectedness: `ordConnected_Icc.image_hasDerivWithinAt hf` shows f'(Icc a b) is order-connected, both endpoints f'(a), f'(b) belong to it, and `OrdConnected.uIcc_subset` places the whole closed interval [[f'(a),f'(b)]] inside the image. No continuity of f' is assumed — this is the defining feature of the theorem.",
+      "description": "A derivative attains every value between f'(a) and f'(b), with no continuity hypothesis."
+    },
+    {
+      "name": "darboux_ivp_open",
+      "type": "core",
+      "statement": "$a\\le b$, $m\\in(\\min(f'(a),f'(b)),\\,\\max(f'(a),f'(b))) \\Rightarrow \\exists c\\in(a,b),\\; f'(c)=m$",
+      "significance": "The strict form: when m is strictly between the endpoint derivatives, the witness lies in the open interval. Dispatches the two orientations via `exists_hasDerivWithinAt_eq_of_gt_of_lt` and `exists_hasDerivWithinAt_eq_of_lt_of_gt`, whose proofs extremize g(x)=f(x)-m·x on the compact interval and locate the extremum in the interior — the analytic heart of Darboux's theorem.",
+      "description": "The strict intermediate value is attained in the open interval (a,b)."
+    },
+    {
+      "name": "deriv_range_ordConnected",
+      "type": "core",
+      "statement": "$s$ order-connected, $f$ differentiable on $s \\Rightarrow$ $\\operatorname{deriv} f\\,(s)$ is order-connected",
+      "significance": "The structural form of Darboux's theorem: derivatives have no jump discontinuities because they map order-connected sets to order-connected sets. Wrapper of `Set.OrdConnected.image_deriv`. On ℝ this says the range of f' over an interval is an interval.",
+      "description": "The image of an order-connected set under a derivative is order-connected."
+    },
+    {
+      "name": "not_deriv_of_jump",
+      "type": "supporting",
+      "statement": "$a\\le b$, $m\\in[[g(a),g(b)]]$, $\\forall x\\in[a,b],\\,g(x)\\ne m \\Rightarrow \\neg\\,(\\forall x\\in[a,b],\\,\\mathrm{HasDerivWithinAt}\\,f\\,(g\\,x)\\,[a,b]\\,x)$",
+      "significance": "The obstruction corollary, the contrapositive of darboux_ivp. A function that takes the boundary values g(a), g(b) but skips some intermediate value m cannot be the derivative of any function on [a,b]. This rules out step functions — the sign function, the floor function — as derivatives, a standard application of Darboux's theorem.",
+      "description": "A function that skips an intermediate value cannot be a derivative."
+    },
+    {
+      "name": "darboux_sq_example",
+      "type": "supporting",
+      "statement": "$\\exists c\\in[0,2],\\; 2c = 1$ as a witness of Darboux applied to $f(x)=x^2$",
+      "significance": "A concrete instance: the derivative of x² is 2x, which runs from 0 to 4 on [0,2], so Darboux forces it to hit the intermediate value 1, realized at c=1/2. Built from `hasDerivAt_pow` and the closed form darboux_ivp, demonstrating the theorem on an explicit function.",
+      "description": "A concrete witness: deriv(x²) attains the intermediate value 1 on [0,2]."
+    }
+  ],
+  "references": [
+    {
+      "text": "Darboux, G. (1875). Mémoire sur les fonctions discontinues. Annales scientifiques de l'École Normale Supérieure, 2e série, 4, 57–112. The original source of the intermediate value property of derivatives.",
+      "url": "https://en.wikipedia.org/wiki/Darboux%27s_theorem_(analysis)"
+    },
+    {
+      "text": "Rudin, W. (1976). Principles of Mathematical Analysis (3rd ed.). McGraw-Hill. Theorem 5.12 states and proves Darboux's theorem as a corollary of the existence of interior extrema.",
+      "url": "https://en.wikipedia.org/wiki/Darboux%27s_theorem_(analysis)"
+    },
+    {
+      "text": "Mathlib4: Mathlib.Analysis.Calculus.Darboux — exists_hasDerivWithinAt_eq_of_gt_of_lt, Set.OrdConnected.image_hasDerivWithinAt, Set.OrdConnected.image_deriv, Convex.image_deriv.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Calculus/Darboux.html"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **Darboux's theorem** — a derivative satisfies the intermediate value property *even when it is not continuous*. This is the orthogonal "shape of $f'$" result missing from the MVT gallery (which covers Rolle/Lagrange/Cauchy, monotonicity, Taylor, and the FTC, but never the IVP of the derivative itself).

Seven theorems, all **verified, 0-axiom** (only `propext`/`Classical.choice`/`Quot.sound`; no `sorry`, no `native_decide`, no `Lean.ofReduceBool`), built on `Mathlib.Analysis.Calculus.Darboux`:

- **`darboux_ivp`** — closed form: $m \in [[f'(a), f'(b)]] \Rightarrow \exists c \in [a,b],\ f'(c)=m$, via order-connectedness of the derivative image (`OrdConnected.uIcc_subset`), no continuity of $f'$ assumed.
- **`darboux_ivp_open`** — strict form: the witness lies in the open interval $(a,b)$.
- **`darboux_ivp_deriv`** — closed form restated for `deriv f`.
- **`deriv_range_ordConnected`** / **`deriv_range_convex`** — no jump discontinuities: a derivative maps order-connected (resp. convex) sets to order-connected (resp. convex) sets.
- **`not_deriv_of_jump`** — obstruction corollary: a value-skipping function (e.g. `sgn`) cannot be a derivative.
- **`darboux_sq_example`** — concrete witness: $\operatorname{deriv}(x^2)=2x$ hits the intermediate value $1$ on $[0,2]$.

## Verification

`LAKE_UNSAFE=1 lake env lean Proofs/MeanValueTheoremOQ05.lean` compiles cleanly; `#print axioms` on all 7 theorems lists only the three standard foundational axioms.

## Files
- `proofs/Proofs/MeanValueTheoremOQ05.lean` (new, 120 lines, 7 theorems)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/mean-value-theorem-oq-05/{meta,annotations}.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)