### PR TITLE
research(law-of-cosines-oq-07): Apollonius's theorem + median-length formula (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2713,6 +2713,7 @@ import Proofs.LawOfCosinesOQ04OQ01Bisector
 import Proofs.LawOfCosinesOQ04OQ02
 import Proofs.LawOfCosinesOQ04OQ02OQ01
 import Proofs.LawOfCosinesOQ05
+import Proofs.LawOfCosinesOQ07
 import Proofs.LawOfSinesOQ06
 import Proofs.LawsOfLargeNumbers
 import Proofs.LawsOfLargeNumbersOQ01

--- a/proofs/Proofs/LawOfCosinesOQ07.lean
+++ b/proofs/Proofs/LawOfCosinesOQ07.lean
@@ -1,0 +1,72 @@
+/-
+Law of Cosines OQ-07: Apollonius's Theorem (the Median Length Formula)
+
+For a triangle with vertices `a, b, c` in a real inner-product (Euclidean) affine
+space, **Apollonius's theorem** relates the two sides through the vertex `a` to the
+median from `a` to the midpoint `m` of the opposite side `bc`:
+
+    |ab|² + |ac|² = 2·(|am|² + (|bc|/2)²).
+
+Equivalently, the squared median length is
+
+    |am|² = (2|ab|² + 2|ac|² − |bc|²) / 4.
+
+This is the affine/Euclidean-geometry counterpart of the parallelogram law and a
+direct consequence of the law of cosines applied to the supplementary angles at the
+midpoint (`∠ a m b + ∠ a m c = π`). Mathlib proves the identity as
+`EuclideanGeometry.dist_sq_add_dist_sq_eq_two_mul_dist_midpoint_sq_add_half_dist_sq`
+but the gallery did not yet expose it; here it is packaged with the explicit
+median-length corollary and the parallelogram-law reading.
+
+Main results:
+  • `apollonius_theorem`      — |ab|² + |ac|² = 2·(|am|² + (|bc|/2)²).
+  • `median_length_sq`        — |am|² = (2|ab|² + 2|ac|² − |bc|²)/4 (classical median formula).
+  • `sum_sq_sides_eq`         — |ab|² + |ac|² = 2|am|² + |bc|²/2 (cleared denominators).
+
+All proofs are `sorry`-free and axiom-free (pure Mathlib geometry, no `native_decide`).
+
+References:
+- Apollonius of Perga; the median-length / Stewart's-theorem circle of identities.
+- Mathlib `EuclideanGeometry.dist_sq_add_dist_sq_eq_two_mul_dist_midpoint_sq_add_half_dist_sq`
+  (Geometry/Euclidean/Triangle.lean).
+- Sibling entry `law-of-cosines-oq-04` (scalar median-length identity, no points/midpoint).
+-/
+
+import Mathlib
+
+namespace LawOfCosinesOQ07
+
+open EuclideanGeometry
+
+variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+  [MetricSpace P] [NormedAddTorsor V P]
+
+/-- **Apollonius's Theorem.** For vertices `a, b, c` of a triangle, the sum of the
+    squares of the two sides at `a` equals twice the square of the median to the
+    midpoint of `bc` plus twice the square of half the third side. -/
+theorem apollonius_theorem (a b c : P) :
+    dist a b ^ 2 + dist a c ^ 2 = 2 * (dist a (midpoint ℝ b c) ^ 2 + (dist b c / 2) ^ 2) :=
+  dist_sq_add_dist_sq_eq_two_mul_dist_midpoint_sq_add_half_dist_sq a b c
+
+/-- **Median length formula.** The square of the median from `a` to the midpoint of
+    `bc` is `(2|ab|² + 2|ac|² − |bc|²)/4`. Solved directly from Apollonius's theorem. -/
+theorem median_length_sq (a b c : P) :
+    dist a (midpoint ℝ b c) ^ 2 = (2 * dist a b ^ 2 + 2 * dist a c ^ 2 - dist b c ^ 2) / 4 := by
+  have h := apollonius_theorem a b c
+  have hbc : (dist b c / 2) ^ 2 = dist b c ^ 2 / 4 := by ring
+  rw [hbc] at h
+  linarith
+
+/-- Cleared-denominator form: `|ab|² + |ac|² = 2|am|² + |bc|²/2`. -/
+theorem sum_sq_sides_eq (a b c : P) :
+    dist a b ^ 2 + dist a c ^ 2 = 2 * dist a (midpoint ℝ b c) ^ 2 + dist b c ^ 2 / 2 := by
+  have h := apollonius_theorem a b c
+  have hbc : (dist b c / 2) ^ 2 = dist b c ^ 2 / 4 := by ring
+  rw [hbc] at h
+  linarith
+
+#check @apollonius_theorem
+#check @median_length_sq
+#check @sum_sq_sides_eq
+
+end LawOfCosinesOQ07

--- a/src/data/research/problems/law-of-cosines-oq-07.json
+++ b/src/data/research/problems/law-of-cosines-oq-07.json
@@ -1,0 +1,80 @@
+{
+  "slug": "law-of-cosines-oq-07",
+  "title": "Apollonius's Theorem: the Median Length Formula in a Euclidean Affine Space",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "started": "2026-06-20T08:40:00Z",
+  "lastUpdate": "2026-06-20T08:40:00Z",
+  "tags": [
+    "geometry",
+    "euclidean-geometry",
+    "law-of-cosines",
+    "apollonius-theorem",
+    "median-length",
+    "seeker-selected",
+    "research"
+  ],
+  "tractability": 8,
+  "significance": 5,
+  "problemStatement": {
+    "formal": "For points $a,b,c$ in a real inner-product affine space and $m=\\operatorname{midpoint}(b,c)$: $\\;|ab|^2+|ac|^2 = 2\\,(|am|^2+(|bc|/2)^2)$, equivalently $|am|^2=(2|ab|^2+2|ac|^2-|bc|^2)/4$.",
+    "plain": "Apollonius's theorem: the sum of the squares of two sides of a triangle equals twice the square of the median to the third side plus twice the square of half the third side. It is the affine/Euclidean form of the parallelogram law and follows from the law of cosines at the supplementary angles ∠amb + ∠amc = π. Gives the classical median-length formula.",
+    "whyMatters": [
+      "Apollonius's theorem is a named classical result (the median-length / Stewart's-theorem circle of identities) that the gallery did not yet expose, though Mathlib proves the core identity.",
+      "Point/midpoint (affine) formulation, distinct from sibling law-of-cosines-oq-04 which is the scalar algebraic median identity with no points or midpoint.",
+      "Surfaces an unused Mathlib geometry lemma (dist_sq_add_dist_sq_eq_two_mul_dist_midpoint_sq_add_half_dist_sq) with the explicit median-length corollary."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "apollonius_theorem: |ab|²+|ac|² = 2(|am|²+(|bc|/2)²), re-exporting Mathlib's EuclideanGeometry.dist_sq_add_dist_sq_eq_two_mul_dist_midpoint_sq_add_half_dist_sq.",
+      "median_length_sq: |am|² = (2|ab|²+2|ac|²−|bc|²)/4, derived by linarith from Apollonius.",
+      "sum_sq_sides_eq: cleared-denominator form |ab|²+|ac|² = 2|am|²+|bc|²/2. Axiom-free, no native_decide."
+    ],
+    "open": [
+      "Stewart's theorem (cevian of arbitrary ratio, not just the median).",
+      "The full parallelogram law for four points / a parallelogram witness."
+    ],
+    "goal": "Expose Apollonius's theorem in the gallery with the median-length corollary, in a general real inner-product affine space, axiom-free."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-20T08:40:00Z",
+    "iteration": 1,
+    "focus": "ACT: shipped Proofs/LawOfCosinesOQ07.lean — Apollonius's theorem + median-length corollary, axiom-free, sorry-free.",
+    "blockers": [],
+    "nextAction": "Optional: Stewart's theorem (general cevian). Core Apollonius + median formula complete and verified.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 ACT (researcher-3, 2026-06-20): Built Proofs/LawOfCosinesOQ07.lean exposing Apollonius's theorem in a general real inner-product affine space ([NormedAddCommGroup V][InnerProductSpace ℝ V][MetricSpace P][NormedAddTorsor V P]). apollonius_theorem re-exports Mathlib EuclideanGeometry.dist_sq_add_dist_sq_eq_two_mul_dist_midpoint_sq_add_half_dist_sq (grep-confirmed UNUSED in gallery). median_length_sq and sum_sq_sides_eq derive the classical median-length formula |am|²=(2|ab|²+2|ac|²−|bc|²)/4 by `have hbc:(dist b c/2)^2=dist b c^2/4 := by ring; rw; linarith`. Distinct from sibling law-of-cosines-oq-04 (scalar identity, no points/midpoint). Axiom-free (propext/Classical.choice/Quot.sound); no native_decide. Build note: shared Mathlib .lake cache heavily churned by fleet (segfaults + .ir invalid-header + 'compiled configuration invalid' on import Mathlib); retry-until-clean-window verified."
+  },
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Apollonius%27s_theorem"
+    ],
+    "mathlib": [
+      "EuclideanGeometry.dist_sq_add_dist_sq_eq_two_mul_dist_midpoint_sq_add_half_dist_sq (Geometry/Euclidean/Triangle.lean)"
+    ]
+  },
+  "relatedProofs": [
+    "law-of-cosines",
+    "law-of-cosines-oq-04"
+  ],
+  "leanFiles": [
+    {
+      "path": "proofs/Proofs/LawOfCosinesOQ07.lean",
+      "status": "verified",
+      "axiomCount": 0,
+      "sorryCount": 0
+    }
+  ],
+  "significanceNote": "Named classical theorem (Apollonius) surfaced in the gallery with the median-length corollary; affine form distinct from the scalar oq-04."
+}


### PR DESCRIPTION
## Summary

Exposes **Apollonius's theorem** in the gallery for a general real inner-product affine space, with the classical median-length corollary. Mathlib proves the core identity but the gallery did not yet surface it.

## Mathematical content

For triangle vertices $a, b, c$ and $m = \operatorname{midpoint}(b,c)$:
$$|ab|^2 + |ac|^2 = 2\bigl(|am|^2 + (|bc|/2)^2\bigr),$$
the affine/Euclidean form of the parallelogram law (law of cosines at the supplementary angles $\angle amb + \angle amc = \pi$). Solving for the median gives the classical formula
$$|am|^2 = \frac{2|ab|^2 + 2|ac|^2 - |bc|^2}{4}.$$

## Theorems (all `sorry`-free, axiom-free)

- `apollonius_theorem` — $|ab|^2+|ac|^2 = 2(|am|^2+(|bc|/2)^2)$, re-exporting the unused Mathlib lemma `EuclideanGeometry.dist_sq_add_dist_sq_eq_two_mul_dist_midpoint_sq_add_half_dist_sq`.
- `median_length_sq` — $|am|^2 = (2|ab|^2+2|ac|^2-|bc|^2)/4$ (derived by `linarith`).
- `sum_sq_sides_eq` — cleared-denominator form $|ab|^2+|ac|^2 = 2|am|^2 + |bc|^2/2$.

Works in any `[NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P] [NormedAddTorsor V P]`. Distinct from sibling `law-of-cosines-oq-04` (scalar identity, no points/midpoint).

## Verification

`#print axioms median_length_sq` → `[propext, Classical.choice, Quot.sound]` (foundational only — **no `native_decide`**). Type-checked against the pinned Mathlib via `lake env lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)