### PR TITLE
research(law-of-cosines-oq-07): Apollonius's theorem (metric/median form) + parallelogram law (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2712,6 +2712,7 @@ import Proofs.LawOfCosinesOQ04OQ01Bisector
 import Proofs.LawOfCosinesOQ04OQ02
 import Proofs.LawOfCosinesOQ04OQ02OQ01
 import Proofs.LawOfCosinesOQ05
+import Proofs.LawOfCosinesOQ07
 import Proofs.LawOfSinesOQ06
 import Proofs.LawsOfLargeNumbers
 import Proofs.LawsOfLargeNumbersOQ01

--- a/proofs/Proofs/LawOfCosinesOQ07.lean
+++ b/proofs/Proofs/LawOfCosinesOQ07.lean
@@ -1,0 +1,106 @@
+import Mathlib
+
+/-
+# Law of Cosines — OQ-07: Apollonius's Theorem (metric / median form) and the Parallelogram Law
+
+## Research Problem: law-of-cosines-oq-07
+
+OQ: State and prove **Apollonius's theorem** in its coordinate-free metric form,
+in an arbitrary real inner-product affine space, and derive the parallelogram
+law from it.
+
+Apollonius's theorem (median identity): for points `a b c` of a Euclidean
+affine space,
+
+    dist a b ² + dist a c ² = 2 · (dist a (midpoint ℝ b c) ² + (dist b c / 2)²)
+
+i.e. the sum of the squares of two sides of a triangle equals twice the square
+of the median to the third side plus twice the square of half that side.
+
+This is a *coordinate-free* statement: the objects are genuine points `a b c`
+of a `NormedAddTorsor` over a real inner product space, and `midpoint ℝ b c` is
+the actual midpoint of the segment `[b, c]`.
+
+DISTINCT from `law-of-cosines-oq-04` (`median_length_formula`), which is a
+**scalar** identity in ℝ-valued side lengths `a b c d : ℝ` derived from
+Stewart's algebraic identity. Here nothing is parameterised by scalar side
+lengths — the theorem speaks directly about points and midpoints, and the
+parallelogram law drops out as a vector-space special case.
+
+We package three results:
+  1. `apollonius`         — the median identity (the metric Apollonius theorem).
+  2. `median_length`      — explicit median length: 4·mₐ² = 2·b² + 2·c² − a².
+  3. `parallelogram_law`  — ‖x + y‖² + ‖x − y‖² = 2(‖x‖² + ‖y‖²), derived FROM
+                            Apollonius (a parallelogram's diagonals bisect each
+                            other, so their crossing is the common midpoint).
+
+Tags: geometry, apollonius, median, parallelogram-law, law-of-cosines
+-/
+
+open EuclideanGeometry
+
+namespace LawOfCosinesOQ07
+
+variable {V P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+  [MetricSpace P] [NormedAddTorsor V P]
+
+/-- **Apollonius's theorem** (metric / median form).
+
+For points `a b c` of a real inner-product affine space, the sum of the squares
+of the sides `ab` and `ac` equals twice the square of the median from `a` to the
+midpoint of `bc`, plus twice the square of half of `bc`.
+
+This is a thin packaging of `EuclideanGeometry.dist_sq_add_dist_sq_eq_two_mul_-
+dist_midpoint_sq_add_half_dist_sq`, exposed here as a standalone gallery entry. -/
+theorem apollonius (a b c : P) :
+    dist a b ^ 2 + dist a c ^ 2
+      = 2 * (dist a (midpoint ℝ b c) ^ 2 + (dist b c / 2) ^ 2) :=
+  dist_sq_add_dist_sq_eq_two_mul_dist_midpoint_sq_add_half_dist_sq a b c
+
+/-- **Median length formula** (metric form): if `mₐ = dist a (midpoint ℝ b c)`
+is the length of the median from `a`, then
+
+    4 · mₐ² = 2 · (dist a b)² + 2 · (dist a c)² − (dist b c)².
+
+A direct rearrangement of `apollonius`. -/
+theorem median_length (a b c : P) :
+    4 * dist a (midpoint ℝ b c) ^ 2
+      = 2 * dist a b ^ 2 + 2 * dist a c ^ 2 - dist b c ^ 2 := by
+  have h := apollonius a b c
+  linear_combination -2 * h
+
+/-- **Parallelogram law**, derived from Apollonius's theorem.
+
+In a real inner product space, the sum of the squares of the two diagonals of a
+parallelogram equals twice the sum of the squares of two adjacent sides:
+
+    ‖x + y‖² + ‖x − y‖² = 2 · (‖x‖² + ‖y‖²).
+
+We obtain it by applying Apollonius to the triangle with vertices `x`, `-y`, `y`
+(viewing `V` as a torsor over itself). The diagonals are the sides `dist x (-y)
+= ‖x + y‖` and `dist x y = ‖x − y‖`; the midpoint of `[-y, y]` is the origin, so
+the median is `‖x‖`, and `dist (-y) y = 2‖y‖`. -/
+theorem parallelogram_law (x y : V) :
+    ‖x + y‖ ^ 2 + ‖x - y‖ ^ 2 = 2 * (‖x‖ ^ 2 + ‖y‖ ^ 2) := by
+  have h := apollonius (P := V) x (-y) y
+  have hmid : midpoint ℝ (-y) y = (0 : V) := midpoint_neg_self ℝ y
+  rw [hmid] at h
+  rw [dist_eq_norm, sub_neg_eq_add] at h          -- dist x (-y) = ‖x + y‖
+  rw [dist_eq_norm] at h                           -- dist x y = ‖x - y‖
+  rw [dist_eq_norm, sub_zero] at h                 -- dist x 0 = ‖x‖
+  rw [dist_eq_norm] at h                           -- dist (-y) y = ‖-y - y‖
+  have hy : ‖(-y) - y‖ = 2 * ‖y‖ := by
+    rw [show (-y) - y = (-2 : ℝ) • y by module, norm_smul, Real.norm_eq_abs]
+    norm_num
+  rw [hy] at h
+  linear_combination h
+
+/-- Concrete instantiation: the median identity specialises to the Euclidean
+plane `EuclideanSpace ℝ (Fin 2)`, confirming the abstract theorem applies to the
+standard model of plane geometry. -/
+example (a b c : EuclideanSpace ℝ (Fin 2)) :
+    dist a b ^ 2 + dist a c ^ 2
+      = 2 * (dist a (midpoint ℝ b c) ^ 2 + (dist b c / 2) ^ 2) :=
+  apollonius a b c
+
+end LawOfCosinesOQ07

--- a/src/data/proofs/law-of-cosines-oq-07/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-07/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-apollonius",
+    "proofId": "law-of-cosines-oq-07",
+    "range": {
+      "startLine": 55,
+      "endLine": 58
+    },
+    "type": "insight",
+    "title": "Apollonius's Theorem, Coordinate-Free",
+    "content": "apollonius states the median identity for genuine points a, b, c of a NormedAddTorsor over a real inner product space, using midpoint ℝ b c as the actual midpoint of the segment [b, c]. This is the metric (coordinate-free) form, sharper than a scalar identity in side lengths because it commits to the affine-geometric objects rather than a chosen coordinatisation. The proof is a thin packaging of Mathlib's dist_sq_add_dist_sq_eq_two_mul_dist_midpoint_sq_add_half_dist_sq, which Mathlib in turn derives from Stewart's theorem and the supplementary-angle relation at the foot of the median.",
+    "mathContext": "For points $a, b, c$: $\\operatorname{dist}(a,b)^2 + \\operatorname{dist}(a,c)^2 = 2\\left(\\operatorname{dist}(a,\\operatorname{midpoint}(b,c))^2 + (\\operatorname{dist}(b,c)/2)^2\\right)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "inner-product affine space",
+      "NormedAddTorsor",
+      "median of a triangle",
+      "Stewart's theorem"
+    ],
+    "prerequisites": [
+      "inner product spaces",
+      "midpoint in an affine space"
+    ]
+  },
+  {
+    "id": "ann-median-length",
+    "proofId": "law-of-cosines-oq-07",
+    "range": {
+      "startLine": 66,
+      "endLine": 72
+    },
+    "type": "insight",
+    "title": "Explicit Median Length via linear_combination",
+    "content": "median_length rearranges Apollonius into the familiar 4·mₐ² = 2b² + 2c² − a², where mₐ = dist a (midpoint ℝ b c). The rearrangement is purely algebraic over the reals: expanding (dist b c / 2)² = dist b c²/4 and solving for the median square. linear_combination -2 * h closes it in one step (the factor −2 cancels the 2·(…/4) term against the explicit coefficients).",
+    "mathContext": "From $b^2 + c^2 = 2m_a^2 + a^2/2$ we get $2m_a^2 = b^2 + c^2 - a^2/2$, hence $4 m_a^2 = 2b^2 + 2c^2 - a^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "linear_combination tactic",
+      "median length formula"
+    ],
+    "prerequisites": [
+      "linear_combination tactic"
+    ]
+  },
+  {
+    "id": "ann-parallelogram",
+    "proofId": "law-of-cosines-oq-07",
+    "range": {
+      "startLine": 83,
+      "endLine": 99
+    },
+    "type": "insight",
+    "title": "Parallelogram Law as a Corollary of Apollonius",
+    "content": "parallelogram_law derives ‖x+y‖² + ‖x−y‖² = 2(‖x‖²+‖y‖²) by applying Apollonius to the triangle with vertices x, −y, y in the vector space V (viewed as a torsor over itself). The midpoint of [−y, y] is the origin (midpoint_neg_self), so the median from x has length ‖x‖; the two sides become the diagonals x+y and x−y of the parallelogram spanned by x and y; and dist(−y, y) = 2‖y‖. This exhibits the parallelogram law — the cornerstone of the inner-product characterisation of norms — as a direct consequence of the median theorem rather than a separate inner-product computation.",
+    "mathContext": "With $a = x$, $b = -y$, $c = y$: $\\operatorname{dist}(x,-y) = \\lVert x+y\\rVert$, $\\operatorname{dist}(x,y) = \\lVert x-y\\rVert$, $\\operatorname{midpoint}(-y,y) = 0$ so the median is $\\lVert x\\rVert$, and $\\operatorname{dist}(-y,y) = 2\\lVert y\\rVert$. Apollonius gives $\\lVert x+y\\rVert^2 + \\lVert x-y\\rVert^2 = 2(\\lVert x\\rVert^2 + \\lVert y\\rVert^2)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "parallelogram law",
+      "Jordan–von Neumann theorem",
+      "midpoint_neg_self",
+      "diagonals of a parallelogram"
+    ],
+    "prerequisites": [
+      "norm and inner product",
+      "module / norm_smul tactics"
+    ]
+  }
+]

--- a/src/data/proofs/law-of-cosines-oq-07/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-07/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "law-of-cosines-oq-07",
+  "title": "Apollonius's Theorem and the Parallelogram Law",
+  "slug": "law-of-cosines-oq-07",
+  "description": "Apollonius's theorem (the median identity) in its coordinate-free metric form for an arbitrary real inner-product affine space: dist a b² + dist a c² = 2·(dist a (midpoint b c)² + (dist b c / 2)²). The parallelogram law ‖x+y‖² + ‖x−y‖² = 2(‖x‖²+‖y‖²) is derived as a vector-space special case.",
+  "meta": {
+    "author": "Apollonius of Perga (c. 200 BC)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawOfCosinesOQ07.lean",
+    "tags": [
+      "geometry",
+      "apollonius",
+      "median",
+      "parallelogram-law",
+      "law-of-cosines",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 106,
+    "assumptions": "No axioms or sorries. Theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (the Lean/Mathlib standard, which do not count as assumptions).",
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Apollonius's theorem stated coordinate-free for an arbitrary NormedAddTorsor over a real inner product space (points and genuine midpoints, not scalar side lengths)",
+      "Explicit median length formula 4·mₐ² = 2b² + 2c² − a² in metric form",
+      "Parallelogram law ‖x+y‖² + ‖x−y‖² = 2(‖x‖²+‖y‖²) derived directly from Apollonius via the triangle with vertices x, −y, y"
+    ],
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Apollonius's theorem — the relation between the sides of a triangle and the length of a median — is attributed to Apollonius of Perga (c. 262–190 BC) and appears classically as the median-length / parallelogram identity. In a triangle the sum of the squares of two sides equals twice the square of the median to the third side plus twice the square of half that side. Restricted to a parallelogram it becomes the parallelogram law, which in modern functional analysis characterises exactly those normed spaces whose norm comes from an inner product (the Jordan–von Neumann theorem). Here we give the coordinate-free form valid in any real inner-product affine space (a NormedAddTorsor over a real inner product space), built on Mathlib's Euclidean geometry layer, and then recover the parallelogram law as the special case where the affine space is a vector space.",
+    "problemStatement": "State and prove **Apollonius's theorem** in its coordinate-free metric form: for points $a, b, c$ of a real inner-product affine space, $\\operatorname{dist}(a,b)^2 + \\operatorname{dist}(a,c)^2 = 2\\left(\\operatorname{dist}(a, \\operatorname{midpoint}(b,c))^2 + (\\operatorname{dist}(b,c)/2)^2\\right)$. Derive the explicit median length $4 m_a^2 = 2b^2 + 2c^2 - a^2$ and the **parallelogram law** $\\lVert x+y\\rVert^2 + \\lVert x-y\\rVert^2 = 2(\\lVert x\\rVert^2 + \\lVert y\\rVert^2)$.",
+    "text": "Packages Apollonius's median identity (via Mathlib's Stewart/Apollonius lemma), the explicit median-length rearrangement, and the parallelogram law obtained by applying Apollonius to the triangle with vertices x, −y, y.",
+    "proofStrategy": "1. apollonius: thin packaging of EuclideanGeometry.dist_sq_add_dist_sq_eq_two_mul_dist_midpoint_sq_add_half_dist_sq, exposing the median identity for points a b c in a NormedAddTorsor over a real inner product space. 2. median_length: rearrange Apollonius algebraically (linear_combination) into 4·mₐ² = 2b² + 2c² − a². 3. parallelogram_law: apply Apollonius in the vector space V to the triangle with vertices x, −y, y; the midpoint of [−y, y] is the origin (midpoint_neg_self), so the median is ‖x‖, the two sides become the diagonals ‖x+y‖ and ‖x−y‖, and dist(−y, y) = 2‖y‖; conclude via linear_combination.",
+    "keyInsights": [
+      "The metric / coordinate-free framing is the distinguishing feature: the objects are genuine points of an affine space and midpoint ℝ b c is the actual midpoint of a segment, not a scalar parameter. This is sharper than a scalar identity in side lengths because it commits to the geometry rather than a chosen coordinatisation.",
+      "Apollonius is the median (m = n) special case of Stewart's theorem; Mathlib derives it from Stewart via the supplementary-angle relation ∠(b, midpoint, c) = π. Reusing the packaged lemma keeps the proof to a one-liner.",
+      "The parallelogram law is exactly Apollonius applied to the degenerate triangle x, −y, y: the median to the side [−y, y] lands on the origin (its midpoint), making the two 'sides' of the triangle the diagonals x+y and x−y of the parallelogram spanned by x and y. This exhibits the parallelogram law as a corollary of the median theorem rather than an independent inner-product computation.",
+      "The whole development is axiom-clean (only propext / Classical.choice / Quot.sound) and uses no decision procedures: the median rearrangement and the parallelogram derivation are both closed by linear_combination over the reals."
+    ],
+    "prerequisites": [
+      "Inner product spaces and inner-product affine spaces (NormedAddTorsor)",
+      "Midpoint of a segment and its basic identities (midpoint_neg_self)",
+      "Stewart's / Apollonius's theorem in Euclidean geometry",
+      "Lean 4 tactics: linear_combination, module, norm_smul"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part1-apollonius",
+      "title": "Part I: Apollonius's Theorem (median identity)",
+      "startLine": 44,
+      "endLine": 58,
+      "summary": "The coordinate-free metric Apollonius identity dist a b² + dist a c² = 2·(dist a (midpoint b c)² + (dist b c / 2)²), packaged from Mathlib's Euclidean geometry."
+    },
+    {
+      "id": "part2-median",
+      "title": "Part II: Explicit Median Length",
+      "startLine": 60,
+      "endLine": 72,
+      "summary": "Rearrangement of Apollonius into the explicit median length 4·mₐ² = 2·dist a b² + 2·dist a c² − dist b c²."
+    },
+    {
+      "id": "part3-parallelogram",
+      "title": "Part III: Parallelogram Law from Apollonius",
+      "startLine": 74,
+      "endLine": 99,
+      "summary": "Derivation of the parallelogram law ‖x+y‖² + ‖x−y‖² = 2(‖x‖²+‖y‖²) by applying Apollonius to the triangle with vertices x, −y, y."
+    },
+    {
+      "id": "part4-instantiation",
+      "title": "Part IV: Euclidean Plane Instantiation",
+      "startLine": 100,
+      "endLine": 106,
+      "summary": "Specialisation of the median identity to the standard Euclidean plane EuclideanSpace ℝ (Fin 2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Apollonius's theorem is proved coordinate-free in an arbitrary real inner-product affine space, the explicit median length is extracted, and the parallelogram law is recovered as the vector-space special case where the median to [−y, y] passes through the origin. Verified, 0 axioms, 0 sorries, no decision procedures.",
+    "openQuestions": [
+      "The parallelogram law characterises inner-product norms among all norms (Jordan–von Neumann theorem). Can the converse — a normed space satisfying the parallelogram law admits a compatible inner product — be formalised on top of this entry using Mathlib's InnerProductSpace.ofNorm?",
+      "Apollonius generalises to the sum over all three medians: 4(mₐ² + m_b² + m_c²) = 3(a² + b² + c²). Can this 'sum of squares of medians' identity be derived from three applications of the median length formula?"
+    ],
+    "implications": "Casting Apollonius's theorem in coordinate-free metric form shows that a classical triangle identity lives naturally at the level of inner-product affine spaces, and that the parallelogram law — the cornerstone of the inner-product characterisation of norms — is a direct corollary. The proof avoids any explicit coordinatisation or decision procedure."
+  },
+  "crossReferences": [
+    {
+      "targetId": "law-of-cosines-oq-04",
+      "relationship": "related",
+      "description": "Stewart's theorem (oq-04) is the scalar algebraic identity b²m + c²n = a(d²+mn) in ℝ-valued side lengths; Apollonius is its median special case. This entry gives the coordinate-free metric form with genuine points and midpoints rather than scalar parameters, and derives the parallelogram law from it."
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "parent-problem",
+      "description": "Apollonius's theorem is part of the law-of-cosines circle of triangle metric identities; Mathlib derives it from the law of cosines via Stewart's theorem and the supplementary-angle relation at the foot of the median."
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "When the median is to the hypotenuse of a right triangle, Apollonius collapses to the Pythagorean relation; the parallelogram law generalises Pythagoras from the right-angle case to arbitrary x, y."
+    }
+  ],
+  "references": [
+    {
+      "author": "Apollonius of Perga",
+      "title": "Conics (and classical median theorem attributed to Apollonius)",
+      "year": -200,
+      "note": "Classical source of the median / Apollonius identity"
+    },
+    {
+      "author": "Jordan, P. and von Neumann, J.",
+      "title": "On Inner Products in Linear, Metric Spaces",
+      "year": 1935,
+      "note": "Parallelogram law characterises norms induced by an inner product"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "LawOfCosinesOQ07",
+    "lineCount": 106,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/LawOfCosinesOQ07.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds **law-of-cosines-oq-07**: Apollonius's theorem in its coordinate-free metric form, plus the explicit median-length formula and the parallelogram law derived from it. Verified, **0 axioms**, 0 sorries, no decision procedures.

### Results (`proofs/Proofs/LawOfCosinesOQ07.lean`, 106 lines, 3 theorems)

1. **`apollonius`** — the median identity for points `a b c` of an arbitrary real inner-product affine space (`NormedAddTorsor` over a real `InnerProductSpace ℝ V`):
   ```
   dist a b² + dist a c² = 2·(dist a (midpoint ℝ b c)² + (dist b c / 2)²)
   ```
2. **`median_length`** — explicit median length `4·mₐ² = 2·dist a b² + 2·dist a c² − dist b c²`.
3. **`parallelogram_law`** — `‖x+y‖² + ‖x−y‖² = 2(‖x‖²+‖y‖²)`, derived **from** Apollonius by applying it to the triangle with vertices `x, −y, y` (the midpoint of `[−y, y]` is the origin, so the median is `‖x‖` and the two sides are the parallelogram diagonals).

Plus a concrete instantiation on `EuclideanSpace ℝ (Fin 2)`.

### Distinctness

Distinct from `law-of-cosines-oq-04` (Stewart's theorem), which is a **scalar** algebraic identity in ℝ-valued side lengths. This entry is **coordinate-free**: genuine points and midpoints in an affine space, with the parallelogram law (cornerstone of the inner-product characterisation of norms) as a corollary. The Mathlib vehicle `EuclideanGeometry.dist_sq_add_dist_sq_eq_two_mul_dist_midpoint_sq_add_half_dist_sq` was previously unused in the gallery.

### Verification

- `./proofs/scripts/docker-build.sh Proofs.LawOfCosinesOQ07` → `✔ Built Proofs.LawOfCosinesOQ07`
- `#print axioms` on all three theorems → only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)