### PR TITLE
research(fibonacci-identities-oq-02): Fibonacci strong divisibility sequence — fib(gcd m n)=gcd(fib m,fib n) + full characterization fib m∣fib n ↔ m∣n (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2424,6 +2424,7 @@ import Proofs.FeuerbachsTheoremOQ01OQ03
 import Proofs.FeuerbachsTheoremOQ02
 import Proofs.FeuerbachsTheoremOQ02Aristotle
 import Proofs.FibonacciIdentitiesOQ01
+import Proofs.FibonacciIdentitiesOQ02
 import Proofs.FibonacciIdentitiesOQ04
 import Proofs.StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular
 import Proofs.FeuerbachsTheoremOQ05

--- a/proofs/Proofs/FibonacciIdentitiesOQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ02.lean
@@ -1,0 +1,109 @@
+import Mathlib
+
+/-
+# The Fibonacci numbers form a strong divisibility sequence
+
+The Fibonacci sequence enjoys the remarkable *strong divisibility* property
+
+  `fib (gcd m n) = gcd (fib m) (fib n)`,
+
+i.e. the index-gcd commutes with the value-gcd.  Mathlib records this as
+`Nat.fib_gcd` (Data/Nat/Fib/Basic.lean), together with the one-directional
+divisibility corollary `Nat.fib_dvd : m ∣ n → fib m ∣ fib n`.
+
+This entry packages the strong-divisibility law and draws out two consequences
+that Mathlib does **not** state directly:
+
+* **Coprimality transfer** — coprime indices give coprime Fibonacci values:
+  `Nat.Coprime m n → Nat.Coprime (fib m) (fib n)`.  Immediate from the gcd law
+  since `fib 1 = 1`.
+
+* **The full divisibility characterization** — for `3 ≤ m`,
+  `fib m ∣ fib n ↔ m ∣ n`.  Mathlib only has the `←` direction (`Nat.fib_dvd`);
+  the forward direction is the genuinely new content here.  It says the Fibonacci
+  numbers detect divisibility of indices *exactly* (away from the degenerate
+  small indices `fib 1 = fib 2 = 1`).  The proof reduces `fib m ∣ fib n` to
+  `fib (gcd m n) = fib m` via the strong-divisibility law, then uses strict
+  monotonicity of `fib` on `Set.Ici 2` (`Nat.fib_lt_fib`) to conclude
+  `gcd m n = m`, i.e. `m ∣ n`.
+
+The hypothesis `3 ≤ m` is sharp: `fib 2 = 1` divides every `fib n`, yet `2 ∣ n`
+fails for odd `n`, so the characterization genuinely needs `m ≥ 3`.
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+
+namespace FibonacciIdentitiesOQ02
+
+/-- **Strong divisibility law** for the Fibonacci numbers:
+`fib (gcd m n) = gcd (fib m) (fib n)`.  The headline of the family. -/
+theorem fib_gcd (m n : ℕ) :
+    Nat.fib (Nat.gcd m n) = Nat.gcd (Nat.fib m) (Nat.fib n) :=
+  Nat.fib_gcd m n
+
+/-- Divisibility of indices propagates to Fibonacci values:
+`m ∣ n → fib m ∣ fib n`. -/
+theorem fib_dvd_of_dvd {m n : ℕ} (h : m ∣ n) : Nat.fib m ∣ Nat.fib n :=
+  Nat.fib_dvd m n h
+
+/-- **Coprimality transfer**: coprime indices yield coprime Fibonacci values.
+Immediate from the strong-divisibility law together with `fib 1 = 1`. -/
+theorem fib_coprime_of_coprime {m n : ℕ} (h : Nat.Coprime m n) :
+    Nat.Coprime (Nat.fib m) (Nat.fib n) := by
+  unfold Nat.Coprime at h ⊢
+  rw [← Nat.fib_gcd, h, Nat.fib_one]
+
+/-- **Full divisibility characterization** (new beyond Mathlib's one direction):
+for `3 ≤ m`, `fib m ∣ fib n ↔ m ∣ n`.
+
+The Fibonacci numbers detect index-divisibility exactly once we are past the
+degenerate equal values `fib 1 = fib 2 = 1`. -/
+theorem fib_dvd_iff {m n : ℕ} (hm : 3 ≤ m) :
+    Nat.fib m ∣ Nat.fib n ↔ m ∣ n := by
+  constructor
+  · intro hdvd
+    -- `fib m ∣ fib n` rephrases as `gcd (fib m) (fib n) = fib m`, which via the
+    -- strong-divisibility law is `fib (gcd m n) = fib m`.
+    have hg : Nat.fib (Nat.gcd m n) = Nat.fib m := by
+      rw [Nat.fib_gcd]; exact Nat.gcd_eq_left hdvd
+    -- `gcd m n` divides `m`, hence is at most `m`.
+    have hdm : Nat.gcd m n ∣ m := Nat.gcd_dvd_left m n
+    have hle : Nat.gcd m n ≤ m := Nat.le_of_dvd (by omega) hdm
+    -- `fib m ≥ fib 3 = 2` since `fib` is monotone and `3 ≤ m`.
+    have hfm : 2 ≤ Nat.fib m := by
+      have := Nat.fib_mono hm
+      simpa using this
+    -- Rule out the degenerate gcd values `0` and `1`: both force `fib (gcd) ≤ 1`,
+    -- contradicting `fib (gcd m n) = fib m ≥ 2`.
+    have hd2 : 2 ≤ Nat.gcd m n := by
+      rcases Nat.lt_or_ge (Nat.gcd m n) 2 with h | h
+      · exfalso
+        have hfib_le : Nat.fib (Nat.gcd m n) ≤ 1 := by
+          interval_cases (Nat.gcd m n) <;> decide
+        omega
+      · exact h
+    -- Strict monotonicity of `fib` on `Ici 2` upgrades `fib (gcd) = fib m`,
+    -- `gcd ≤ m` to `gcd = m`.
+    have hgm : Nat.gcd m n = m := by
+      rcases Nat.lt_or_ge (Nat.gcd m n) m with hlt | hge
+      · have := (Nat.fib_lt_fib hd2).mpr hlt
+        omega
+      · omega
+    exact (Nat.gcd_eq_left_iff_dvd).mp hgm
+  · intro h
+    exact Nat.fib_dvd m n h
+
+/-- Worked instance of the strong-divisibility law:
+`gcd 12 8 = 4`, and `fib 4 = 3 = gcd (fib 12) (fib 8) = gcd 144 21`. -/
+example : Nat.fib (Nat.gcd 12 8) = Nat.gcd (Nat.fib 12) (Nat.fib 8) :=
+  fib_gcd 12 8
+
+/-- Concrete numerical check of the value gcd: `gcd (fib 12) (fib 8) = 3`. -/
+example : Nat.gcd (Nat.fib 12) (Nat.fib 8) = 3 := by decide
+
+/-- The characterization in action: `fib 3 = 2 ∣ fib n` exactly when `3 ∣ n`
+(the "every third Fibonacci number is even" pattern). -/
+example (n : ℕ) : Nat.fib 3 ∣ Nat.fib n ↔ 3 ∣ n :=
+  fib_dvd_iff (le_refl 3)
+
+end FibonacciIdentitiesOQ02

--- a/src/data/proofs/fibonacci-identities-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "fibonacci-identities-oq-02",
+  "title": "Fibonacci Numbers as a Strong Divisibility Sequence",
+  "slug": "fibonacci-identities-oq-02",
+  "description": "The Fibonacci sequence is a strong divisibility sequence: fib (gcd m n) = gcd (fib m) (fib n), so the index-gcd commutes with the value-gcd (Mathlib's Nat.fib_gcd). From this the entry draws two consequences Mathlib does not state directly. (1) Coprimality transfer: coprime indices give coprime Fibonacci values, Nat.Coprime m n → Nat.Coprime (fib m) (fib n), immediate from the gcd law and fib 1 = 1. (2) The full divisibility characterization: for 3 ≤ m, fib m ∣ fib n ↔ m ∣ n — Mathlib only carries the ← direction (Nat.fib_dvd); the forward direction is the new content. It is proved by reducing fib m ∣ fib n to fib (gcd m n) = fib m via the strong-divisibility law, then using strict monotonicity of fib on Set.Ici 2 (Nat.fib_lt_fib) to force gcd m n = m. The hypothesis 3 ≤ m is sharp, since fib 2 = 1 divides every fib n while 2 ∣ n fails for odd n.",
+  "meta": {
+    "author": "Édouard Lucas / classical Fibonacci theory; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Divisibility_properties",
+    "date": "1876",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "gcd",
+      "divisibility",
+      "strong-divisibility-sequence",
+      "coprime",
+      "monotonicity",
+      "integer-sequences",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_gcd",
+        "description": "fib (gcd m n) = gcd (fib m) (fib n) — the strong-divisibility law, the headline identity and the engine of every consequence",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_dvd",
+        "description": "m ∣ n → fib m ∣ fib n — the easy (←) direction of the divisibility characterization",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_lt_fib",
+        "description": "for 2 ≤ m, fib m < fib n ↔ m < n — strict monotonicity of fib on Set.Ici 2, used to upgrade fib (gcd m n) = fib m and gcd m n ≤ m to gcd m n = m",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_mono",
+        "description": "Monotone fib — gives fib 3 ≤ fib m, i.e. 2 ≤ fib m for 3 ≤ m, ruling out the degenerate gcd values 0 and 1",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.gcd_eq_left / Nat.gcd_eq_left_iff_dvd",
+        "description": "gcd (fib m) (fib n) = fib m from fib m ∣ fib n, and gcd m n = m ↔ m ∣ n to translate the gcd equality back to divisibility",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      }
+    ],
+    "originalContributions": [
+      "fib_gcd: fib (gcd m n) = gcd (fib m) (fib n) — the strong-divisibility law packaged as the family headline (Nat.fib_gcd)",
+      "fib_coprime_of_coprime: Nat.Coprime m n → Nat.Coprime (fib m) (fib n) — coprimality transfer, not stated directly in Mathlib",
+      "fib_dvd_iff: for 3 ≤ m, fib m ∣ fib n ↔ m ∣ n — the full divisibility characterization; the forward direction is new beyond Mathlib's one-directional Nat.fib_dvd"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 109,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). The numerical example uses decide (kernel evaluation), not native_decide, so no Lean.ofReduceBool is introduced.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That the Fibonacci numbers form a strong divisibility sequence — gcd(Fₘ, Fₙ) = F_{gcd(m,n)} — is one of the deepest elementary facts about the sequence, going back to Lucas in the 1870s. Its corollary 'Fₘ divides Fₙ whenever m divides n' is often quoted on its own, but the gcd identity is strictly stronger: it pins the greatest common divisor of two Fibonacci numbers to a single Fibonacci number determined entirely by the indices. The phenomenon recurs across Lucas sequences and elliptic divisibility sequences, where 'strong divisibility' is the defining structural property.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-02)**: Establish the strong-divisibility law fib (gcd m n) = gcd (fib m) (fib n) and its arithmetic consequences for Fibonacci divisibility.\n\n**Result**: fib_gcd (the strong-divisibility law), fib_coprime_of_coprime (coprime indices ⇒ coprime values), and fib_dvd_iff (for 3 ≤ m, fib m ∣ fib n ↔ m ∣ n — the full characterization, whose forward direction is absent from Mathlib).",
+    "text": "For all m, n, F_{gcd(m,n)} = gcd(Fₘ, Fₙ), where Fₖ = Nat.fib k. Consequently coprime indices yield coprime Fibonacci values, and — past the degenerate small indices where F₁ = F₂ = 1 — divisibility of Fibonacci values detects divisibility of indices exactly: for m ≥ 3, Fₘ ∣ Fₙ ⟺ m ∣ n.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. fib_gcd is Mathlib's Nat.fib_gcd, packaged as the family headline.\n\n2. fib_coprime_of_coprime: unfold Nat.Coprime to gcd m n = 1; rewrite gcd (fib m) (fib n) backwards through Nat.fib_gcd to fib (gcd m n), substitute gcd m n = 1, and use fib 1 = 1.\n\n3. fib_dvd_iff (3 ≤ m), forward direction: from fib m ∣ fib n, Nat.gcd_eq_left gives gcd (fib m) (fib n) = fib m, which Nat.fib_gcd turns into fib (gcd m n) = fib m. Since gcd m n ∣ m we have gcd m n ≤ m. Monotonicity (fib 3 ≤ fib m) gives 2 ≤ fib m, so the gcd cannot be 0 or 1 (both force fib (gcd m n) ≤ 1), i.e. 2 ≤ gcd m n. Strict monotonicity on Set.Ici 2 (Nat.fib_lt_fib) then rules out gcd m n < m, so gcd m n = m, i.e. m ∣ n. The reverse direction is Nat.fib_dvd.\n\n4. The hypothesis 3 ≤ m is sharp: fib 2 = 1 divides every fib n, but 2 ∣ n fails for odd n, so m = 2 breaks the characterization.",
+    "keyInsights": [
+      "**Strong divisibility is stronger than the divisibility corollary.** fib (gcd m n) = gcd (fib m) (fib n) determines the exact gcd of two Fibonacci numbers, not merely the one-way implication m ∣ n ⇒ fib m ∣ fib n.",
+      "**Monotonicity converts the gcd equality into an index equality.** Once fib m ∣ fib n is reduced to fib (gcd m n) = fib m, strict monotonicity of fib on indices ≥ 2 forces gcd m n = m — this is exactly what upgrades Mathlib's one direction to a full characterization.",
+      "**The degenerate indices are the only obstruction.** F₁ = F₂ = 1 are the sole repeated values; ruling out gcd ∈ {0,1} (which would make fib (gcd) ≤ 1 < fib m) is what the 3 ≤ m hypothesis buys, and it is sharp.",
+      "**New beyond Mathlib.** Mathlib has Nat.fib_gcd and the one-directional Nat.fib_dvd, but neither the coprimality-transfer statement nor the biconditional fib m ∣ fib n ↔ m ∣ n."
+    ],
+    "prerequisites": [
+      "The strong-divisibility law Nat.fib_gcd and the recurrence/base values",
+      "Strict monotonicity of fib on Set.Ici 2 (Nat.fib_lt_fib) and Nat.fib_mono",
+      "Basic gcd manipulation: Nat.gcd_eq_left, Nat.gcd_eq_left_iff_dvd, Nat.gcd_dvd_left"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring stating the strong-divisibility law and its two consequences (coprimality transfer, the full divisibility characterization with sharp 3 ≤ m hypothesis), the Mathlib import, and the namespace.",
+      "mathContext": "$F_{\\gcd(m,n)} = \\gcd(F_m, F_n)$, with $F_0=0, F_1=F_2=1, F_{n+2}=F_n+F_{n+1}$."
+    },
+    {
+      "id": "strong-divisibility",
+      "title": "The Strong Divisibility Law",
+      "startLine": 38,
+      "endLine": 47,
+      "summary": "fib_gcd (the headline identity fib (gcd m n) = gcd (fib m) (fib n)) and fib_dvd_of_dvd (m ∣ n → fib m ∣ fib n), both from Mathlib's Nat.fib_gcd / Nat.fib_dvd.",
+      "mathContext": "$F_{\\gcd(m,n)} = \\gcd(F_m, F_n)$ and $m \\mid n \\Rightarrow F_m \\mid F_n$."
+    },
+    {
+      "id": "coprime",
+      "title": "Coprimality Transfer",
+      "startLine": 49,
+      "endLine": 54,
+      "summary": "fib_coprime_of_coprime: coprime indices give coprime Fibonacci values, by rewriting through Nat.fib_gcd and using fib 1 = 1.",
+      "mathContext": "$\\gcd(m,n)=1 \\Rightarrow \\gcd(F_m, F_n)=1$."
+    },
+    {
+      "id": "characterization",
+      "title": "Full Divisibility Characterization",
+      "startLine": 56,
+      "endLine": 90,
+      "summary": "fib_dvd_iff: for 3 ≤ m, fib m ∣ fib n ↔ m ∣ n. Forward direction reduces to fib (gcd m n) = fib m, rules out gcd ∈ {0,1} via monotonicity, and applies strict monotonicity (Nat.fib_lt_fib) to force gcd m n = m. Reverse is Nat.fib_dvd.",
+      "mathContext": "For $m \\ge 3$: $F_m \\mid F_n \\iff m \\mid n$."
+    },
+    {
+      "id": "examples",
+      "title": "Worked Examples",
+      "startLine": 92,
+      "endLine": 109,
+      "summary": "Concrete instances: fib (gcd 12 8) = gcd (fib 12) (fib 8), the numeric check gcd 144 21 = 3 = fib 4 (by decide), and the 'every third Fibonacci number is even' instance fib 3 ∣ fib n ↔ 3 ∣ n.",
+      "mathContext": "$F_{\\gcd(12,8)} = F_4 = 3 = \\gcd(144,21)$; $2 = F_3 \\mid F_n \\iff 3 \\mid n$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-01",
+      "relationship": "related",
+      "description": "Cassini's identity is the product-identity headline of the fibonacci-identities family; this entry is the divisibility-theoretic headline (strong divisibility sequence)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) treatment of Fibonacci strong divisibility: the law fib (gcd m n) = gcd (fib m) (fib n), the coprimality-transfer corollary, and the full divisibility characterization fib m ∣ fib n ↔ m ∣ n for m ≥ 3 (forward direction new beyond Mathlib).",
+    "implications": "Promotes Mathlib's one-directional Nat.fib_dvd to a biconditional and supplies the coprimality-transfer statement, completing the elementary divisibility theory of the Fibonacci numbers as universally quantified theorems.",
+    "openQuestions": [
+      "Prove the analogous strong-divisibility law for the Lucas numbers, or characterize exactly when Lₘ ∣ Lₙ.",
+      "Extend the characterization to general Lucas sequences Uₙ(P,Q), identifying the hypotheses under which Uₘ ∣ Uₙ ↔ m ∣ n holds."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "FibonacciIdentitiesOQ02",
+    "lineCount": 109,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Lucas, Édouard",
+      "title": "Théorie des fonctions numériques simplement périodiques",
+      "year": "1878",
+      "venue": "American Journal of Mathematics",
+      "note": "Origin of the strong-divisibility property of Lucas sequences, of which the Fibonacci gcd law is the special case"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "gcd(Fₘ, Fₙ) = F_{gcd(m,n)} and the divisibility corollary"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **strong divisibility property** of the Fibonacci numbers and two arithmetic consequences Mathlib does not state directly. New gallery entry `fibonacci-identities-oq-02`.

**Results** (`proofs/Proofs/FibonacciIdentitiesOQ02.lean`, namespace `FibonacciIdentitiesOQ02`):

- `fib_gcd` — the strong-divisibility law `fib (gcd m n) = gcd (fib m) (fib n)` (headline; Mathlib's `Nat.fib_gcd`).
- `fib_dvd_of_dvd` — `m ∣ n → fib m ∣ fib n` (`Nat.fib_dvd`).
- `fib_coprime_of_coprime` — **new**: coprime indices give coprime values, `Nat.Coprime m n → Nat.Coprime (fib m) (fib n)`.
- `fib_dvd_iff` — **new**: for `3 ≤ m`, `fib m ∣ fib n ↔ m ∣ n`. Mathlib only carries the `←` direction; the forward direction is the genuine contribution.

## Proof idea (forward direction of the characterization)

From `fib m ∣ fib n`, `Nat.gcd_eq_left` gives `gcd (fib m) (fib n) = fib m`, which `Nat.fib_gcd` turns into `fib (gcd m n) = fib m`. Since `gcd m n ∣ m` we get `gcd m n ≤ m`; monotonicity (`fib 3 ≤ fib m`, so `2 ≤ fib m`) rules out the degenerate `gcd ∈ {0,1}`; then strict monotonicity of `fib` on `Set.Ici 2` (`Nat.fib_lt_fib`) forces `gcd m n = m`, i.e. `m ∣ n`.

The hypothesis `3 ≤ m` is **sharp**: `fib 2 = 1` divides every `fib n` while `2 ∣ n` fails for odd `n`.

## Verification

- Verified **0-axiom**: `#print axioms` lists only `propext` / `Classical.choice` / `Quot.sound`. No `sorry`, no `native_decide` (the one numeric example uses `decide`).
- Full docker build of `Proofs.FibonacciIdentitiesOQ02` succeeds (`✔ Built Proofs.FibonacciIdentitiesOQ02`).

## Files

- `proofs/Proofs/FibonacciIdentitiesOQ02.lean` (new, 109 lines)
- `proofs/Proofs.lean` (one import line)
- `src/data/proofs/fibonacci-identities-oq-02/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)