### PR TITLE
research(cyclotomic-polynomials-oq-02): prime-power cyclotomics + eval-at-one dichotomy Φ_n(1)∈{p,1} (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -179,6 +179,7 @@ import Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03
 import Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02
 import Proofs.ArithmeticSeriesOQ04
 import Proofs.ArithmeticSeriesOQ04OQ01
+import Proofs.ArsinhLogFormulaOQ01
 import Proofs.AutomorphicNumberOQ01
 import Proofs.BallotProblem
 import Proofs.BallotProblemOQ01
@@ -237,6 +238,7 @@ import Proofs.BertrandsPostulateOQ03OQ04
 import Proofs.BertrandsPostulateOQ03OQ04Aristotle
 import Proofs.BertrandsPostulateOQ03OQ04OQ01
 import Proofs.BertrandsPostulateOQ03OQ04OQ03
+import Proofs.BetaIntegralRecurrence
 import Proofs.BezoutIdentity
 import Proofs.BezoutIdentityOQ01
 import Proofs.BezoutIdentityOQ01Aristotle
@@ -684,6 +686,7 @@ import Proofs.CubeRoot6Irrational
 import Proofs.CubeRoot7Irrational
 import Proofs.CubeRoot9Irrational
 import Proofs.CyclotomicPolynomialsOQ01
+import Proofs.CyclotomicPolynomialsOQ02
 import Proofs.DeGuaTheorem
 import Proofs.DeMoivre
 import Proofs.DeMoivreOQ01
@@ -754,6 +757,7 @@ import Proofs.DirichletsTheoremOQ03Incomplete01
 import Proofs.DissectionOfCubes
 import Proofs.DissectionOfCubesOQ01
 import Proofs.DissectionOfCubesOQ01OQ01
+import Proofs.DissectionOfCubesOQ01OQ01OQ01
 import Proofs.DissectionOfCubesOQ01OQ03
 import Proofs.DissectionOfCubesOQ02
 import Proofs.DissectionOfCubesOQ02OQ02
@@ -783,6 +787,7 @@ import Proofs.DivisibilityTruncationGeneral
 import Proofs.DivisibilityTruncationGeneralOQ01
 import Proofs.DivisibilityTruncationGeneralOQ01OQ01
 import Proofs.DivisibilityTruncationGeneralOQ03
+import Proofs.DyckCatalanCountOQ01
 import Proofs.ETranscendentalOQ01
 import Proofs.ETranscendentalOQ01OQ01
 import Proofs.ETranscendentalOQ02
@@ -2563,6 +2568,7 @@ import Proofs.GCDAlgorithm
 import Proofs.GCDAlgorithmOQ01
 import Proofs.GCDAlgorithmOQ01OQ03
 import Proofs.GammaLogConvexityOQ01
+import Proofs.GammaReflectionFormulaOQ01
 import Proofs.GaussLemmaPrimitiveOQ01
 import Proofs.GaussWilsonNonCyclic
 import Proofs.GaussWilsonNonCyclicOQ01
@@ -3330,6 +3336,7 @@ import Proofs.ThreePlaceIdentity
 import Proofs.ThreePlaceIdentityOQ02
 import Proofs.ThreeSquares
 import Proofs.ThreeSquaresDavenportCassels
+import Proofs.ThreeSquaresRationalBridge
 import Proofs.ThreeSquaresResidue3
 import Proofs.ThreeSquaresResidue3Obstruction
 import Proofs.ThreeSquaresSingleAP

--- a/proofs/Proofs/CyclotomicPolynomialsOQ02.lean
+++ b/proofs/Proofs/CyclotomicPolynomialsOQ02.lean
@@ -1,0 +1,144 @@
+/-
+Cyclotomic Polynomials OQ-02: Prime-Power Cyclotomics and the Eval-at-One Law
+
+The companion entry OQ-01 packaged the basic structural facts of Φ_n (degree
+φ(n), the prime form Φ_p = 1 + X + ⋯ + X^{p-1}, and the divisor product
+∏_{d∣n} Φ_d = Xⁿ − 1). This entry zooms in on the prime-power case Φ_{p^k} and
+on the value Φ_n(1), which exhibits a striking dichotomy.
+
+  • Prime-power form.   For a prime p and k ≥ 1,
+                        Φ_{p^k}(X) = ∑_{i<p} X^{i·p^{k-1}}
+                        — the p-term geometric sum in the variable X^{p^{k-1}}.
+  • Prime-power degree. deg Φ_{p^k} = φ(p^k) = p^{k-1}(p − 1).
+  • Eval-at-one law.    Φ_{p^k}(1) = p, whereas Φ_n(1) = 1 as soon as n has at
+                        least two distinct prime factors.
+
+The eval-at-one dichotomy {p, 1} is the polynomial shadow of the von Mangoldt
+function: Φ_n(1) = e^{Λ(n)}, equal to the prime p exactly when n is a prime
+power p^k (k ≥ 1), and equal to 1 otherwise. Here we prove the two clean ends of
+that statement: the prime-power value p, and the value 1 for any n with ≥ 2
+distinct prime factors.
+
+Main results:
+  • `cyclotomic_prime_pow_geom_sum`  — Φ_{p^{k+1}} = ∑_{i<p} (X^{p^k})^i.
+  • `cyclotomic_prime_pow_natDegree` — deg Φ_{p^{k+1}} = p^k·(p − 1).
+  • `cyclotomic_prime_pow_eval_one`  — Φ_{p^{k+1}}(1) = p.
+  • `cyclotomic_eval_one_eq_one_of_two_le_primeFactors`
+                                      — Φ_n(1) = 1 when n has ≥ 2 distinct primes.
+  Plus concrete witnesses Φ₄, Φ₈, Φ₉ and sample degree/eval computations
+  illustrating both ends of the dichotomy (Φ₈(1)=2 vs Φ₁₅(1)=1).
+
+All proofs are `sorry`-free and axiom-free (no `native_decide`).
+
+References:
+- Mathlib `Mathlib/RingTheory/Polynomial/Cyclotomic/Basic.lean` and `Eval.lean`.
+- The value Φ_n(1) and its connection to the von Mangoldt function Λ(n).
+-/
+
+import Mathlib
+
+open Polynomial Finset Nat
+
+namespace CyclotomicPolynomialsOQ02
+
+/-! ### The prime-power cyclotomic polynomial as a geometric sum -/
+
+/-- For a prime `p`, the prime-power cyclotomic polynomial is a geometric sum in
+the variable `X^{p^k}`:  `Φ_{p^{k+1}} = ∑_{i<p} (X^{p^k})^i`.  Equivalently the
+exponents are the multiples `0, p^k, 2·p^k, …, (p−1)·p^k`. -/
+theorem cyclotomic_prime_pow_geom_sum (R : Type*) [CommRing R] {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    cyclotomic (p ^ (k + 1)) R = ∑ i ∈ range p, (X ^ p ^ k) ^ i :=
+  cyclotomic_prime_pow_eq_geom_sum hp
+
+/-! ### Degree of the prime-power cyclotomic polynomial -/
+
+/-- The degree of `Φ_{p^{k+1}}` is Euler's totient `φ(p^{k+1}) = p^k·(p − 1)`. -/
+theorem cyclotomic_prime_pow_natDegree (R : Type*) [Ring R] [Nontrivial R] {p : ℕ} (hp : p.Prime)
+    (k : ℕ) : (cyclotomic (p ^ (k + 1)) R).natDegree = p ^ k * (p - 1) := by
+  rw [natDegree_cyclotomic, totient_prime_pow_succ hp]
+
+/-! ### The eval-at-one law: prime powers evaluate to the prime -/
+
+/-- **Prime-power value.** Evaluating `Φ_{p^{k+1}}` at `1` gives the prime `p`. -/
+theorem cyclotomic_prime_pow_eval_one (R : Type*) [CommRing R] (p : ℕ) [Fact p.Prime] (k : ℕ) :
+    (cyclotomic (p ^ (k + 1)) R).eval 1 = p :=
+  eval_one_cyclotomic_prime_pow k
+
+/-! ### The eval-at-one law: the value 1 for ≥ 2 distinct prime factors -/
+
+/-- **Composite value.** If `n` has at least two distinct prime factors then it is
+not a prime power, so `Φ_n(1) = 1`.  Together with `cyclotomic_prime_pow_eval_one`
+(value `p` on prime powers) this is the eval-at-one dichotomy `Φ_n(1) ∈ {p, 1}`. -/
+theorem cyclotomic_eval_one_eq_one_of_two_le_primeFactors (R : Type*) [Ring R] {n : ℕ}
+    (hn : 2 ≤ n.primeFactors.card) : (cyclotomic n R).eval 1 = 1 := by
+  apply eval_one_cyclotomic_not_prime_pow
+  intro p hp k hpk
+  -- From `p ^ k = n` derive that `n` has at most one prime factor, contradicting `hn`.
+  apply absurd hn
+  rw [← hpk]
+  rcases eq_or_ne k 0 with rfl | hk
+  · simp
+  · rw [Nat.primeFactors_prime_pow hk hp]
+    simp
+
+/-- Helper: two distinct prime factors witness `2 ≤ n.primeFactors.card`. -/
+private theorem two_le_primeFactors_card {n a b : ℕ} (hab : a ≠ b)
+    (ha : a ∈ n.primeFactors) (hb : b ∈ n.primeFactors) : 2 ≤ n.primeFactors.card := by
+  have hsub : ({a, b} : Finset ℕ) ⊆ n.primeFactors := by
+    intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl <;> assumption
+  calc (2 : ℕ) = ({a, b} : Finset ℕ).card := (Finset.card_pair hab).symm
+    _ ≤ n.primeFactors.card := Finset.card_le_card hsub
+
+/-! ### Concrete witnesses: prime-power geometric form -/
+
+/-- `Φ₄ = X² + 1`  (the case `p = 2, k = 2`: `Φ_{2²} = 1 + (X²)`). -/
+theorem cyclotomic_four : cyclotomic 4 ℤ = 1 + X ^ 2 := by
+  have h : (4 : ℕ) = 2 ^ (1 + 1) := by norm_num
+  rw [h, cyclotomic_prime_pow_geom_sum ℤ (by norm_num) 1]
+  simp [Finset.sum_range_succ]
+
+/-- `Φ₉ = 1 + X³ + X⁶`  (the case `p = 3, k = 2`: `Φ_{3²} = 1 + X³ + (X³)²`). -/
+theorem cyclotomic_nine : cyclotomic 9 ℤ = 1 + X ^ 3 + X ^ 6 := by
+  have h : (9 : ℕ) = 3 ^ (1 + 1) := by norm_num
+  rw [h, cyclotomic_prime_pow_geom_sum ℤ (by norm_num) 1]
+  simp [Finset.sum_range_succ]
+  ring
+
+/-! ### Concrete witnesses: degree -/
+
+/-- Sample degree: `deg Φ₈ = φ(8) = 4`  (`p = 2, k = 3`). -/
+theorem cyclotomic_eight_natDegree : (cyclotomic 8 ℤ).natDegree = 4 := by
+  have h : (8 : ℕ) = 2 ^ (2 + 1) := by norm_num
+  rw [h, cyclotomic_prime_pow_natDegree ℤ (by norm_num) 2]
+  norm_num
+
+/-- Sample degree: `deg Φ₂₇ = φ(27) = 18`  (`p = 3, k = 3`). -/
+theorem cyclotomic_twentyseven_natDegree : (cyclotomic 27 ℤ).natDegree = 18 := by
+  have h : (27 : ℕ) = 3 ^ (2 + 1) := by norm_num
+  rw [h, cyclotomic_prime_pow_natDegree ℤ (by norm_num) 2]
+  norm_num
+
+/-! ### Concrete witnesses: the eval-at-one dichotomy -/
+
+/-- Prime-power end of the dichotomy: `Φ₈(1) = 2`. -/
+theorem cyclotomic_eight_eval_one : (cyclotomic 8 ℤ).eval 1 = 2 := by
+  haveI : Fact (Nat.Prime 2) := ⟨by norm_num⟩
+  have h : (8 : ℕ) = 2 ^ (2 + 1) := by norm_num
+  rw [h]
+  exact cyclotomic_prime_pow_eval_one ℤ 2 2
+
+/-- Composite end of the dichotomy: `Φ₁₅(1) = 1`  (`15 = 3·5`, two prime factors). -/
+theorem cyclotomic_fifteen_eval_one : (cyclotomic 15 ℤ).eval 1 = 1 := by
+  apply cyclotomic_eval_one_eq_one_of_two_le_primeFactors
+  exact two_le_primeFactors_card (a := 3) (b := 5) (by norm_num)
+    (by rw [Nat.mem_primeFactors]; norm_num) (by rw [Nat.mem_primeFactors]; norm_num)
+
+/-- Composite end of the dichotomy: `Φ₆(1) = 1`  (`6 = 2·3`, two prime factors). -/
+theorem cyclotomic_six_eval_one : (cyclotomic 6 ℤ).eval 1 = 1 := by
+  apply cyclotomic_eval_one_eq_one_of_two_le_primeFactors
+  exact two_le_primeFactors_card (a := 2) (b := 3) (by norm_num)
+    (by rw [Nat.mem_primeFactors]; norm_num) (by rw [Nat.mem_primeFactors]; norm_num)
+
+end CyclotomicPolynomialsOQ02

--- a/src/data/research/problems/cyclotomic-polynomials-oq-02.json
+++ b/src/data/research/problems/cyclotomic-polynomials-oq-02.json
@@ -1,0 +1,90 @@
+{
+  "slug": "cyclotomic-polynomials-oq-02",
+  "title": "Cyclotomic Polynomials at a Prime Power and the Eval-at-One Law",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "started": "2026-06-20T09:00:00Z",
+  "lastUpdate": "2026-06-20T09:00:00Z",
+  "tags": [
+    "number-theory",
+    "algebra",
+    "cyclotomic-polynomials",
+    "roots-of-unity",
+    "totient",
+    "polynomial",
+    "von-mangoldt",
+    "seeker-selected",
+    "research"
+  ],
+  "tractability": 9,
+  "significance": 5,
+  "problemStatement": {
+    "formal": "For a prime $p$ and $k \\ge 1$: (1) $\\Phi_{p^k}(X) = \\sum_{i<p} X^{i\\,p^{k-1}}$, the $p$-term geometric sum in $X^{p^{k-1}}$; (2) $\\deg \\Phi_{p^k} = \\varphi(p^k) = p^{k-1}(p-1)$; (3) $\\Phi_{p^k}(1) = p$. Moreover (4) $\\Phi_n(1) = 1$ whenever $n$ has at least two distinct prime factors, giving the eval-at-one dichotomy $\\Phi_n(1) \\in \\{p, 1\\}$.",
+    "plain": "Zooming in on the prime-power cyclotomic polynomial Φ_{p^k}: it is the geometric sum ∑_{i<p} X^{i·p^{k-1}}, has degree φ(p^k)=p^{k-1}(p−1), and evaluates at 1 to the prime p. By contrast, Φ_n(1)=1 as soon as n has at least two distinct prime factors. So the value Φ_n(1) follows a strict dichotomy: it equals the prime p exactly when n is a prime power pᵏ (k≥1), and equals 1 otherwise — the polynomial shadow of the von Mangoldt function Λ(n).",
+    "whyMatters": [
+      "The prime-power cyclotomic polynomial Φ_{p^k} = ∑_{i<p} X^{i·p^{k-1}} is the building block from which all cyclotomic polynomials are assembled (via Φ_{mp} relations); its explicit geometric form is the workhorse behind Eisenstein-style irreducibility proofs for Φ_{p^k}.",
+      "The eval-at-one law Φ_n(1) ∈ {p, 1} is the polynomial avatar of the von Mangoldt function: Φ_n(1) = e^{Λ(n)} detects exactly the prime powers, connecting cyclotomic factorization to the prime-detecting arithmetic of analytic number theory.",
+      "Together with OQ-01 (degree φ(n), prime form, divisor product, Gauss's identity) this completes the elementary structural picture of cyclotomic polynomials in the gallery: OQ-01 handled the general degree and the squarefree-prime base case; OQ-02 handles the prime-power tower and the value at 1."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "cyclotomic_prime_pow_geom_sum: Φ_{p^{k+1}} = ∑_{i<p} (X^{p^k})^i for prime p (Mathlib cyclotomic_prime_pow_eq_geom_sum).",
+      "cyclotomic_prime_pow_natDegree: deg Φ_{p^{k+1}} = p^k·(p−1) (natDegree_cyclotomic with Nat.totient_prime_pow_succ).",
+      "cyclotomic_prime_pow_eval_one: Φ_{p^{k+1}}(1) = p (Mathlib eval_one_cyclotomic_prime_pow).",
+      "cyclotomic_eval_one_eq_one_of_two_le_primeFactors: Φ_n(1) = 1 when n has ≥ 2 distinct prime factors, via eval_one_cyclotomic_not_prime_pow plus Nat.primeFactors_prime_pow (a prime power has a single prime factor).",
+      "Concrete witnesses Φ₄=1+X², Φ₉=1+X³+X⁶, deg Φ₈=4, deg Φ₂₇=18, and both ends of the dichotomy Φ₈(1)=2 vs Φ₁₅(1)=Φ₆(1)=1. Axiom-free, no native_decide."
+    ],
+    "open": [
+      "Eisenstein irreducibility of Φ_{p^k} over ℚ via the substitution X ↦ X+1 (Mathlib has cyclotomic.irreducible_rat).",
+      "The full von Mangoldt identity: Φ_n(1) = e^{Λ(n)} as a uniform statement over all n ≥ 2 (the prime-power value p was proved here; only the 1-value for ≥2 prime factors was packaged for the dichotomy).",
+      "Φ_{p^k} evaluated at other small points, e.g. Φ_{p^k}(0) = 1 and the constant-term pattern."
+    ],
+    "goal": "Establish the prime-power cyclotomic polynomial's geometric-sum form, degree p^{k-1}(p−1), and value p at 1, together with the complementary fact Φ_n(1)=1 for n with ≥2 distinct prime factors, packaging the eval-at-one dichotomy Φ_n(1) ∈ {p,1}. Axiom-free."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-20T09:00:00Z",
+    "iteration": 1,
+    "focus": "ACT: shipped Proofs/CyclotomicPolynomialsOQ02.lean — prime-power geometric-sum form, degree p^{k-1}(p−1), Φ_{p^k}(1)=p, and Φ_n(1)=1 for ≥2 distinct prime factors (axiom-free, sorry-free).",
+    "blockers": [],
+    "nextAction": "Optional: Eisenstein irreducibility of Φ_{p^k}, or the uniform von Mangoldt identity Φ_n(1)=e^{Λ(n)}. Prime-power + eval-at-one entry is complete and verified.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 ACT (researcher-11, 2026-06-20): Built Proofs/CyclotomicPolynomialsOQ02.lean — the prime-power companion to OQ-01. (1) cyclotomic_prime_pow_geom_sum restates Mathlib cyclotomic_prime_pow_eq_geom_sum: Φ_{p^{k+1}} = ∑_{i<p}(X^{p^k})^i, the geometric sum in the variable X^{p^k}. (2) cyclotomic_prime_pow_natDegree combines natDegree_cyclotomic with Nat.totient_prime_pow_succ for deg Φ_{p^{k+1}} = p^k·(p−1). (3) cyclotomic_prime_pow_eval_one restates eval_one_cyclotomic_prime_pow: Φ_{p^{k+1}}(1)=p. The substantive packaging is the eval-at-one dichotomy: cyclotomic_eval_one_eq_one_of_two_le_primeFactors proves Φ_n(1)=1 when 2 ≤ n.primeFactors.card, by feeding eval_one_cyclotomic_not_prime_pow the fact that any prime power p^k has at most one prime factor (Nat.primeFactors_prime_pow), so an n with ≥2 distinct primes cannot be a prime power. A private helper two_le_primeFactors_card witnesses the card bound from two explicit distinct prime members (Finset.card_pair + card_le_card), avoiding native_decide on primeFactors. Concrete witnesses Φ₄,Φ₉, deg Φ₈,Φ₂₇, and both ends of the dichotomy Φ₈(1)=2 vs Φ₁₅(1)=Φ₆(1)=1. #print axioms → only propext/Classical.choice/Quot.sound, i.e. 0 axioms, no native_decide. Complements OQ-01 by handling the prime-power tower and the value Φ_n(1)."
+  },
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Cyclotomic_polynomial",
+      "https://en.wikipedia.org/wiki/Von_Mangoldt_function"
+    ],
+    "mathlib": [
+      "Polynomial.cyclotomic_prime_pow_eq_geom_sum (RingTheory/Polynomial/Cyclotomic/Basic.lean)",
+      "Polynomial.eval_one_cyclotomic_prime_pow, Polynomial.eval_one_cyclotomic_not_prime_pow (RingTheory/Polynomial/Cyclotomic/Eval.lean)",
+      "Polynomial.natDegree_cyclotomic, Nat.totient_prime_pow_succ",
+      "Nat.primeFactors_prime_pow, Nat.mem_primeFactors, Finset.card_pair, Finset.card_le_card"
+    ]
+  },
+  "relatedProofs": [
+    "cyclotomic-polynomials-oq-01",
+    "euler-totient",
+    "primitive-roots"
+  ],
+  "leanFiles": [
+    {
+      "path": "proofs/Proofs/CyclotomicPolynomialsOQ02.lean",
+      "status": "verified",
+      "axiomCount": 0,
+      "sorryCount": 0
+    }
+  ],
+  "significanceNote": "Prime-power companion to the cyclotomic topic entry: geometric-sum form Φ_{p^k}=∑X^{i·p^{k-1}}, degree p^{k-1}(p−1), and the eval-at-one dichotomy Φ_n(1) ∈ {p,1} (the von Mangoldt prime-power detector)."
+}


### PR DESCRIPTION
## Summary

Prime-power companion to **cyclotomic-polynomials-oq-01** (#27046). Where OQ-01 packaged the general degree φ(n), the squarefree prime form, the divisor product, and Gauss's identity, **OQ-02 handles the prime-power tower Φ_{p^k} and the value Φ_n(1)**.

For a prime `p` and `k ≥ 1`:

- **Geometric-sum form** — `Φ_{p^k}(X) = ∑_{i<p} X^{i·p^{k-1}}` (geometric sum in the variable `X^{p^{k-1}}`).
- **Degree** — `deg Φ_{p^k} = φ(p^k) = p^{k-1}(p − 1)`.
- **Value at 1** — `Φ_{p^k}(1) = p`.

and the complementary

- **Composite value** — `Φ_n(1) = 1` whenever `n` has at least two distinct prime factors.

Together these give the **eval-at-one dichotomy** `Φ_n(1) ∈ {p, 1}` — equal to the prime `p` exactly when `n` is a prime power `pᵏ` (`k ≥ 1`), and `1` otherwise. This is the polynomial shadow of the von Mangoldt function: `Φ_n(1) = e^{Λ(n)}`.

## Main results

| Theorem | Statement |
|---|---|
| `cyclotomic_prime_pow_geom_sum` | `Φ_{p^{k+1}} = ∑_{i<p} (X^{p^k})^i` |
| `cyclotomic_prime_pow_natDegree` | `deg Φ_{p^{k+1}} = p^k·(p−1)` |
| `cyclotomic_prime_pow_eval_one` | `Φ_{p^{k+1}}(1) = p` |
| `cyclotomic_eval_one_eq_one_of_two_le_primeFactors` | `Φ_n(1) = 1` for `n` with ≥2 distinct primes |

Plus concrete witnesses `Φ₄ = 1+X²`, `Φ₉ = 1+X³+X⁶`, `deg Φ₈ = 4`, `deg Φ₂₇ = 18`, and both ends of the dichotomy `Φ₈(1) = 2` vs `Φ₁₅(1) = Φ₆(1) = 1`.

## Proof notes

- The `Φ_n(1)=1` direction feeds `eval_one_cyclotomic_not_prime_pow` the fact that any prime power `p^k` has a single prime factor (`Nat.primeFactors_prime_pow`), so an `n` with ≥2 distinct primes cannot be a prime power.
- A private helper `two_le_primeFactors_card` witnesses `2 ≤ n.primeFactors.card` from two explicit distinct prime members (`Finset.card_pair` + `Finset.card_le_card`), avoiding `native_decide` on `primeFactors`.

## Verification

- `lake env lean Proofs/CyclotomicPolynomialsOQ02.lean` — compiles, `sorry`-free.
- `#print axioms` on all main results → `[propext, Classical.choice, Quot.sound]` only. **0 axioms, no `native_decide`.**

## Footprint

Mirrors OQ-01: `import` line in `proofs/Proofs.lean`, the Lean file, and the research JSON. No separate gallery dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)