### PR TITLE
research(banach-fixed-point-oq-01): quantitative contraction mapping principle (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -190,6 +190,7 @@ import Proofs.BallotProblemOQ03OQ01OQ02Helpers
 import Proofs.BallotProblemOQ03OQ01OQ04
 import Proofs.BallotProblemOQ03OQ02
 import Proofs.BallotProblemOQ03OQ03
+import Proofs.BanachFixedPointOQ01
 import Proofs.BaselProblem
 import Proofs.BaselProblemOQ01OQ01
 import Proofs.BaselProblemOQ01OQ01OQ02

--- a/proofs/Proofs/BanachFixedPointOQ01.lean
+++ b/proofs/Proofs/BanachFixedPointOQ01.lean
@@ -1,0 +1,121 @@
+/-
+  Banach Fixed-Point Theorem (the Contraction Mapping Principle), with an
+  explicit geometric convergence rate, plus a concrete worked instance on ℝ.
+
+  Let `(α, d)` be a NONEMPTY COMPLETE metric space and `f : α → α` a
+  CONTRACTION: there is a constant `K < 1` with `d(f x, f y) ≤ K · d(x, y)`
+  for all `x, y`.  The Banach fixed-point theorem then asserts:
+
+    * (existence)      `f` has a fixed point `p`  (`f p = p`);
+    * (uniqueness)     the fixed point is unique;
+    * (Picard)         from ANY seed `x` the iterates `fⁿ x → p`;
+    * (a-priori)       `d(fⁿ x, p) ≤ d(x, f x) · Kⁿ / (1 − K)` — a GEOMETRIC
+                       error bound computable before iterating;
+    * (a-posteriori)   `d(x, p) ≤ d(x, f x) / (1 − K)` — a bound from a single
+                       step.
+
+  Mathlib packages the contraction hypothesis as `ContractingWith K f`
+  (`K < 1 ∧ LipschitzWith K f`) over an `EMetricSpace`, and provides the fixed
+  point `ContractingWith.fixedPoint` together with all of the estimates above.
+  This file restates the theorem in textbook form and then VERIFIES the
+  hypotheses for a concrete map — the affine contraction `x ↦ x/2 + c` on ℝ,
+  whose unique fixed point is `2c` and whose Picard iterates converge to it
+  geometrically at rate `1/2`.
+
+  The gallery's existing fixed-point entries are topological (Brouwer) and
+  Banach-space-compact (Schauder); the METRIC contraction principle with an
+  explicit geometric rate was previously absent.  Everything is fully verified:
+  0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+open scoped NNReal
+open Filter Topology Function
+
+namespace BanachFixedPointOQ01
+
+/-! ### The abstract contraction mapping principle
+
+`ContractingWith K f` is Mathlib's bundling of "`K < 1` and `f` is
+`K`-Lipschitz".  Over a nonempty complete metric space these five statements
+are the full Banach fixed-point theorem. -/
+
+variable {α : Type*} [MetricSpace α] [CompleteSpace α] [Nonempty α]
+variable {K : ℝ≥0} {f : α → α}
+
+/-- **Existence.** A contraction on a nonempty complete metric space has a
+fixed point. -/
+theorem exists_fixedPoint (hf : ContractingWith K f) : ∃ p, IsFixedPt f p :=
+  ⟨ContractingWith.fixedPoint f hf, hf.fixedPoint_isFixedPt⟩
+
+omit [CompleteSpace α] [Nonempty α] in
+/-- **Uniqueness.** Any two fixed points of a contraction coincide. -/
+theorem fixedPoint_unique_of_isFixedPt (hf : ContractingWith K f) {x y : α}
+    (hx : IsFixedPt f x) (hy : IsFixedPt f y) : x = y :=
+  hf.fixedPoint_unique' hx hy
+
+/-- **Picard iteration converges.** From any seed `x`, the iterates `fⁿ x`
+converge to the fixed point. -/
+theorem tendsto_iterate (hf : ContractingWith K f) (x : α) :
+    Tendsto (fun n => f^[n] x) atTop (𝓝 (ContractingWith.fixedPoint f hf)) :=
+  hf.tendsto_iterate_fixedPoint x
+
+/-- **A-priori geometric error estimate.**
+`d(fⁿ x, p) ≤ d(x, f x) · Kⁿ / (1 − K)` — the error decays geometrically with
+ratio `K`, with a bound known in advance of iterating. -/
+theorem apriori_estimate (hf : ContractingWith K f) (x : α) (n : ℕ) :
+    dist (f^[n] x) (ContractingWith.fixedPoint f hf)
+      ≤ dist x (f x) * (K : ℝ) ^ n / (1 - K) :=
+  hf.apriori_dist_iterate_fixedPoint_le x n
+
+/-- **A-posteriori error estimate.** A single application bounds the distance to
+the fixed point: `d(x, p) ≤ d(x, f x) / (1 − K)`. -/
+theorem aposteriori_estimate (hf : ContractingWith K f) (x : α) :
+    dist x (ContractingWith.fixedPoint f hf) ≤ dist x (f x) / (1 - K) :=
+  hf.dist_fixedPoint_le x
+
+/-! ### A concrete contraction on ℝ
+
+The affine map `x ↦ x/2 + c` is `(1/2)`-Lipschitz, hence a contraction; its
+unique fixed point is `2c`, reached geometrically from any starting point. -/
+
+/-- The affine map `x ↦ x/2 + c` on the real line. -/
+noncomputable def contractAffine (c : ℝ) : ℝ → ℝ := fun x => x / 2 + c
+
+/-- `x ↦ x/2 + c` is a contraction with ratio `1/2`. -/
+theorem contractAffine_contracting (c : ℝ) :
+    ContractingWith (1 / 2 : ℝ≥0) (contractAffine c) := by
+  refine ⟨by norm_num, LipschitzWith.of_dist_le_mul fun x y => ?_⟩
+  have hK : ((1 / 2 : ℝ≥0) : ℝ) = 1 / 2 := by push_cast; ring
+  rw [hK, Real.dist_eq, Real.dist_eq,
+    show contractAffine c x - contractAffine c y = (x - y) / 2 from by
+      simp only [contractAffine]; ring,
+    abs_div, show |(2 : ℝ)| = 2 from by norm_num]
+  linarith [abs_nonneg (x - y)]
+
+/-- The unique fixed point of `x ↦ x/2 + c` is `2c`. -/
+theorem contractAffine_fixedPoint (c : ℝ) :
+    ContractingWith.fixedPoint (contractAffine c) (contractAffine_contracting c) = 2 * c := by
+  have hfix : IsFixedPt (contractAffine c) (2 * c) := by
+    show contractAffine c (2 * c) = 2 * c
+    simp only [contractAffine]; ring
+  exact ((contractAffine_contracting c).fixedPoint_unique hfix).symm
+
+/-- Picard iteration for the concrete map converges to `2c` from any start. -/
+theorem contractAffine_tendsto (c x : ℝ) :
+    Tendsto (fun n => (contractAffine c)^[n] x) atTop (𝓝 (2 * c)) := by
+  rw [← contractAffine_fixedPoint c]
+  exact (contractAffine_contracting c).tendsto_iterate_fixedPoint x
+
+/-- Explicit geometric error bound for the concrete iteration:
+`|fⁿ x − 2c| ≤ |x − (x/2 + c)| · (1/2)ⁿ / (1 − 1/2)`. -/
+theorem contractAffine_apriori (c x : ℝ) (n : ℕ) :
+    dist ((contractAffine c)^[n] x) (2 * c)
+      ≤ dist x (contractAffine c x) * (1 / 2 : ℝ) ^ n / (1 - 1 / 2 : ℝ) := by
+  rw [← contractAffine_fixedPoint c]
+  have h := (contractAffine_contracting c).apriori_dist_iterate_fixedPoint_le x n
+  have hK : ((1 / 2 : ℝ≥0) : ℝ) = 1 / 2 := by push_cast; ring
+  rw [hK] at h
+  exact h
+
+end BanachFixedPointOQ01

--- a/src/data/proofs/banach-fixed-point-oq-01/annotations.json
+++ b/src/data/proofs/banach-fixed-point-oq-01/annotations.json
@@ -1,0 +1,64 @@
+[
+  {
+    "title": "From 'a fixed point exists' to a quantitative theorem",
+    "mathContext": "Mathlib's `ContractingWith K f` bundles `K < 1` with `LipschitzWith K f`. Over a nonempty complete metric space, `ContractingWith.fixedPoint f hf` is THE fixed point, `fixedPoint_isFixedPt` proves `f p = p`, and `fixedPoint_unique'` proves any two fixed points coincide. The uniqueness lemma `fixedPoint_unique_of_isFixedPt` carries `omit [CompleteSpace α] [Nonempty α]` because uniqueness is a pure consequence of the contraction inequality — two fixed points x,y satisfy d(x,y) = d(fx,fy) ≤ K·d(x,y) with K<1, forcing d(x,y)=0.",
+    "significance": "core",
+    "relatedConcepts": [
+      "ContractingWith.fixedPoint and fixedPoint_isFixedPt in Mathlib",
+      "ContractingWith.fixedPoint_unique'",
+      "the contraction inequality d(fx,fy) ≤ K·d(x,y)"
+    ],
+    "prerequisites": [
+      "metric spaces and completeness",
+      "Lipschitz maps and contraction constants",
+      "the definition of a fixed point IsFixedPt f x ↔ f x = x"
+    ],
+    "proofId": "banach-fixed-point-oq-01",
+    "range": { "startLine": 46, "endLine": 55 },
+    "id": "ann-banach-oq01-existence-uniqueness",
+    "type": "insight",
+    "content": "Existence and uniqueness are the foundation. `exists_fixedPoint` packages Mathlib's `ContractingWith.fixedPoint f hf` together with `fixedPoint_isFixedPt` to produce `∃ p, IsFixedPt f p`. `fixedPoint_unique_of_isFixedPt` shows any two fixed points coincide via `fixedPoint_unique'`. Crucially this uniqueness statement omits the `CompleteSpace` and `Nonempty` instances: uniqueness needs neither — it follows purely from the contraction inequality, since if f x = x and f y = y then d(x,y) = d(f x, f y) ≤ K·d(x,y) with K < 1, which forces d(x,y) = 0. Completeness and nonemptiness are only needed to guarantee a fixed point actually exists (the Picard iterates form a Cauchy sequence whose limit must lie in the space)."
+  },
+  {
+    "title": "Constructive convergence with a geometric rate",
+    "mathContext": "`tendsto_iterate_fixedPoint` states f^[n] x → p in the neighborhood filter 𝓝 p. The a-priori estimate `apriori_dist_iterate_fixedPoint_le` gives dist (f^[n] x) p ≤ dist x (f x) · Kⁿ / (1 − K): the right-hand side is computable from the very first step x, f x and decays geometrically. The a-posteriori estimate `dist_fixedPoint_le` is the n = 0 specialization, dist x p ≤ dist x (f x)/(1 − K). The denominator 1 − K is the sum of the geometric tail Σ_{k≥0} Kᵏ.",
+    "significance": "core",
+    "relatedConcepts": [
+      "ContractingWith.tendsto_iterate_fixedPoint",
+      "ContractingWith.apriori_dist_iterate_fixedPoint_le",
+      "ContractingWith.dist_fixedPoint_le",
+      "geometric series Σ Kⁿ = 1/(1−K)"
+    ],
+    "prerequisites": [
+      "function iteration f^[n] and its convergence",
+      "Filter.Tendsto and the neighborhood filter",
+      "geometric series and their tails"
+    ],
+    "proofId": "banach-fixed-point-oq-01",
+    "range": { "startLine": 57, "endLine": 75 },
+    "id": "ann-banach-oq01-rate",
+    "type": "insight",
+    "content": "What distinguishes Banach's theorem from purely existential fixed point theorems (Brouwer, Schauder) is that it is constructive AND quantitative. `tendsto_iterate` says the Picard iterates f^[n] x converge to p from ANY starting point x — the fixed point is the limit of an explicit algorithm. `apriori_estimate` then bounds the error before you iterate: d(fⁿx,p) ≤ d(x,fx)·Kⁿ/(1−K), geometric decay with ratio K. The factor 1/(1−K) is exactly the geometric series sum Σ Kᵏ that accumulates the contraction over the infinite tail of remaining steps. `aposteriori_estimate` is the n=0 instance and is the practically useful one: after a single application of f you can already certify d(x,p) ≤ d(x,fx)/(1−K), which is the standard stopping criterion in numerical fixed-point iteration."
+  },
+  {
+    "title": "A worked example: x ↦ x/2 + c has fixed point 2c",
+    "mathContext": "`contractAffine c = fun x => x/2 + c`. To apply the abstract theorem we must discharge `ContractingWith (1/2) (contractAffine c)`. The Lipschitz half is proved by `LipschitzWith.of_dist_le_mul`: |f(x)−f(y)| = |(x−y)/2| = |x−y|/2, so distances scale by exactly 1/2. Then `contractAffine_fixedPoint` exhibits 2c as a fixed point (2c/2 + c = 2c) and pins it down as THE fixed point via `fixedPoint_unique`. The convergence and rate theorems are instantiated at this map by rewriting with the computed fixed point 2c.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "LipschitzWith.of_dist_le_mul",
+      "Real.dist_eq and abs_div",
+      "ContractingWith.fixedPoint_unique for identifying the fixed point",
+      "NNReal coercion of the constant 1/2"
+    ],
+    "prerequisites": [
+      "affine maps on ℝ and their Lipschitz constants",
+      "solving x = x/2 + c for the fixed point",
+      "real absolute value and the metric dist x y = |x − y|"
+    ],
+    "proofId": "banach-fixed-point-oq-01",
+    "range": { "startLine": 77, "endLine": 121 },
+    "id": "ann-banach-oq01-concrete",
+    "type": "example",
+    "content": "The abstract theorem is only useful once you can recognize contractions in the wild, so the file closes with a fully worked instance: the affine map f(x) = x/2 + c on ℝ. `contractAffine_contracting` verifies it is (1/2)-Lipschitz — distances scale by exactly 1/2 — which combined with 1/2 < 1 gives `ContractingWith (1/2) f`. `contractAffine_fixedPoint` then computes the fixed point in closed form: solving x = x/2 + c gives x = 2c, and uniqueness from the contraction property guarantees there is no other. Finally `contractAffine_tendsto` and `contractAffine_apriori` specialize the abstract Picard convergence and geometric error bound to this map, so from any real starting point the iterates x, x/2+c, x/4+3c/2, … converge to 2c at rate (1/2)ⁿ. This is the simplest nontrivial contraction and makes every part of the abstract theorem concrete and checkable."
+  }
+]

--- a/src/data/proofs/banach-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "banach-fixed-point-oq-01",
+  "title": "Banach Fixed Point Theorem: Quantitative Contraction Mapping Principle",
+  "slug": "banach-fixed-point-oq-01",
+  "description": "The Banach (contraction mapping) fixed point theorem in quantitative form: a contraction f with ratio K<1 on a nonempty complete metric space has a unique fixed point p, the Picard iterates fⁿx converge to p from any seed, and the convergence is geometric — an a-priori bound d(fⁿx,p) ≤ d(x,fx)·Kⁿ/(1−K) and an a-posteriori bound d(x,p) ≤ d(x,fx)/(1−K). Closes with a fully worked instance on ℝ: the affine contraction x↦x/2+c with ratio 1/2 and unique fixed point 2c. 9 theorems, 1 definition, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BanachFixedPointOQ01.lean",
+    "tags": [
+      "analysis",
+      "metric-spaces",
+      "fixed-point",
+      "banach",
+      "contraction-mapping",
+      "picard-iteration",
+      "geometric-convergence"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified using Mathlib's ContractingWith API over complete metric spaces.",
+    "lineCount": 121,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "originalContributions": [
+      "banach_fixed_point_quantitative-style package: existence + uniqueness + Picard convergence + a-priori geometric rate + a-posteriori bound, assembled in textbook form",
+      "exists_fixedPoint / fixedPoint_unique_of_isFixedPt: existence and uniqueness via ContractingWith.fixedPoint and fixedPoint_unique'",
+      "tendsto_iterate: Picard iterates fⁿx → p from any seed x",
+      "apriori_estimate: d(fⁿx,p) ≤ d(x,fx)·Kⁿ/(1−K) — geometric error bound known before iterating",
+      "aposteriori_estimate: d(x,p) ≤ d(x,fx)/(1−K) — bound from a single step",
+      "contractAffine x↦x/2+c: concrete ℝ contraction, ratio 1/2, with verified Lipschitz bound",
+      "contractAffine_fixedPoint: the unique fixed point of x↦x/2+c is exactly 2c",
+      "contractAffine_tendsto / contractAffine_apriori: concrete geometric convergence of the iterates to 2c"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Stefan Banach proved the contraction mapping principle in his 1922 doctoral thesis. It is one of the most widely applied fixed point theorems in analysis: unlike Brouwer's theorem (existence only, via topology) or Schauder's (existence on compact convex sets in Banach spaces), Banach's theorem is constructive — the fixed point is the limit of the Picard iterates x, f(x), f(f(x)), …, and the convergence rate is explicitly geometric. It underlies the Picard–Lindelöf existence theorem for ODEs, the inverse and implicit function theorems, Newton-type iterations, and countless numerical schemes. Mathlib bundles the contraction hypothesis as `ContractingWith K f` (i.e. `K < 1 ∧ LipschitzWith K f`) and provides the fixed point together with the convergence and error estimates.",
+    "problemStatement": "State the Banach fixed point theorem in quantitative form — not merely 'a unique fixed point exists', but with the constructive Picard-iteration convergence and explicit geometric error bounds — and verify it on a concrete contraction whose fixed point is known in closed form.",
+    "text": "Let (α,d) be a nonempty complete metric space and f:α→α a contraction: there is K<1 with d(fx,fy) ≤ K·d(x,y). Then f has a unique fixed point p, and for every seed x the iterates fⁿx converge to p with d(fⁿx,p) ≤ d(x,fx)·Kⁿ/(1−K). The a-posteriori form d(x,p) ≤ d(x,fx)/(1−K) bounds the error from a single application of f. On ℝ, the affine map x↦x/2+c is (1/2)-Lipschitz, hence a contraction, and its unique fixed point is 2c (the solution of x = x/2 + c).",
+    "proofStrategy": "Restate Mathlib's ContractingWith fixed-point API in textbook form: existence (ContractingWith.fixedPoint + fixedPoint_isFixedPt), uniqueness (fixedPoint_unique'), Picard convergence (tendsto_iterate_fixedPoint), the a-priori geometric bound (apriori_dist_iterate_fixedPoint_le), and the a-posteriori bound (dist_fixedPoint_le). Then verify the hypotheses for the concrete affine map x↦x/2+c: prove it is (1/2)-Lipschitz via LipschitzWith.of_dist_le_mul (distances scale exactly by 1/2), identify its fixed point 2c by exhibiting it as a fixed point and invoking uniqueness, and instantiate the convergence/rate theorems at this map.",
+    "keyInsights": [
+      "Banach's theorem is constructive: the fixed point is computed, not just shown to exist — the Picard iterates converge to it",
+      "The convergence is geometric with ratio K: d(fⁿx,p) ≤ d(x,fx)·Kⁿ/(1−K), an error bound available before any iteration",
+      "The a-posteriori bound d(x,p) ≤ d(x,fx)/(1−K) turns a single step's displacement into a guaranteed accuracy — the basis of practical stopping rules",
+      "Completeness is essential (the iterates form a Cauchy sequence whose limit must exist); contraction K<1 forces both existence AND uniqueness, unlike Brouwer's mere continuity",
+      "For the affine map x↦x/2+c the fixed point 2c is found by solving x = x/2 + c; uniqueness from the contraction property pins it down"
+    ],
+    "prerequisites": [
+      "Metric spaces, completeness, and the notion of a Cauchy sequence",
+      "Lipschitz maps and contraction constants (LipschitzWith, ContractingWith)",
+      "Function iteration f^[n] and convergence of sequences (Filter.Tendsto, nhds)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header: The Contraction Mapping Principle",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Docstring stating the Banach fixed point theorem in textbook form (existence, uniqueness, Picard convergence, a-priori and a-posteriori estimates) and explaining the novelty relative to the gallery's existing fixed-point entries: Brouwer (topological) and Schauder (compact convex in Banach spaces) cover existence on different hypotheses, but the metric contraction principle with an explicit geometric rate was previously absent. Imports Mathlib's ContractingWith API.",
+      "mathContext": "Mathlib encodes the contraction hypothesis as `ContractingWith K f := K < 1 ∧ LipschitzWith K f` over an (e)metric space. Over a nonempty complete metric space this yields the fixed point `ContractingWith.fixedPoint f hf` and its convergence/error estimates."
+    },
+    {
+      "id": "abstract-principle",
+      "title": "The Abstract Contraction Mapping Principle",
+      "startLine": 37,
+      "endLine": 75,
+      "summary": "Five theorems assembling the quantitative Banach theorem: `exists_fixedPoint` (existence), `fixedPoint_unique_of_isFixedPt` (any two fixed points coincide — note this needs neither completeness nor nonemptiness, so those instances are omitted), `tendsto_iterate` (Picard iterates converge to p from any seed), `apriori_estimate` (geometric error bound d(fⁿx,p) ≤ d(x,fx)·Kⁿ/(1−K)), and `aposteriori_estimate` (d(x,p) ≤ d(x,fx)/(1−K)).",
+      "mathContext": "For a K-contraction on a complete metric space, the Picard sequence fⁿx is Cauchy with ratio K, hence converges to the unique fixed point p. The a-priori bound sums the geometric tail Σ_{k≥n} Kᵏ = Kⁿ/(1−K); the a-posteriori bound is the n=0 instance, dist x p ≤ dist x (f x)/(1−K)."
+    },
+    {
+      "id": "concrete-affine",
+      "title": "A Concrete Contraction on ℝ: x ↦ x/2 + c",
+      "startLine": 77,
+      "endLine": 121,
+      "summary": "Verifies the hypotheses for the affine map `contractAffine c = fun x => x/2 + c`. `contractAffine_contracting` shows it is (1/2)-Lipschitz (distances scale exactly by 1/2, via LipschitzWith.of_dist_le_mul). `contractAffine_fixedPoint` identifies the unique fixed point as 2c (exhibit 2c as a fixed point, then invoke uniqueness). `contractAffine_tendsto` and `contractAffine_apriori` instantiate the Picard convergence and geometric error bound at this map.",
+      "mathContext": "For f(x)=x/2+c, |f(x)−f(y)| = |x−y|/2 = (1/2)|x−y|, so K=1/2<1. The fixed point solves x = x/2 + c, i.e. x/2 = c, x = 2c. The a-priori bound becomes |fⁿx − 2c| ≤ |x − (x/2+c)|·(1/2)ⁿ/(1−1/2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Banach fixed point theorem is formalized in quantitative form — existence, uniqueness, Picard convergence, and explicit a-priori geometric / a-posteriori error bounds — and verified on the concrete affine contraction x↦x/2+c with fixed point 2c. 9 theorems, 1 definition, 121 lines, 0 axioms.",
+    "implications": "This complements the gallery's topological (Brouwer) and compact-convex (Schauder) fixed point entries with the constructive metric principle: the fixed point is computed as a limit, with quantitative error control. The same ContractingWith machinery underlies the Picard–Lindelöf ODE theorem and Newton-type schemes.",
+    "openQuestions": [
+      "Apply the contraction principle to prove Picard–Lindelöf: local existence/uniqueness for y'=F(t,y) with F Lipschitz in y, via the integral-operator contraction on a complete function space",
+      "Formalize the global Newton/Banach perturbation result: if g is a small Lipschitz perturbation of the identity, then id+g is a homeomorphism (a step toward the inverse function theorem)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "brouwer-fixed-point-oq-01",
+      "relationship": "related",
+      "description": "Brouwer's theorem gives existence from continuity alone (topological); Banach's adds the contraction hypothesis to get uniqueness plus a constructive, geometrically convergent iteration. The Brouwer OQ-01 entry uses ContractingWith only as a comparison sub-lemma."
+    },
+    {
+      "targetId": "schauder-fixed-point",
+      "relationship": "related",
+      "description": "Schauder extends existence to compact convex sets in Banach spaces (no uniqueness); Banach's contraction principle trades that generality for uniqueness and an explicit convergence rate."
+    }
+  ],
+  "leanFile": {
+    "namespace": "BanachFixedPointOQ01",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/BanachFixedPointOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry: the **Banach fixed point theorem** (contraction mapping principle) in **quantitative** form. The bare existence/uniqueness statement already appears in the gallery only as a *supporting sub-lemma* of the Brouwer and Schauder entries; this entry headlines the constructive, quantitative package those entries do not expose.

**Abstract principle** (`ContractingWith K f` on a nonempty complete metric space):
- `exists_fixedPoint` — existence
- `fixedPoint_unique_of_isFixedPt` — uniqueness (needs neither completeness nor nonemptiness; omitted via `omit`)
- `tendsto_iterate` — Picard iterates `fⁿx → p` from any seed
- `apriori_estimate` — `d(fⁿx,p) ≤ d(x,fx)·Kⁿ/(1−K)` (geometric error bound, known before iterating)
- `aposteriori_estimate` — `d(x,p) ≤ d(x,fx)/(1−K)` (single-step stopping rule)

**Concrete ℝ instance** — affine contraction `x ↦ x/2 + c`:
- `contractAffine_contracting` — `(1/2)`-Lipschitz hence a contraction
- `contractAffine_fixedPoint` — unique fixed point is exactly `2c`
- `contractAffine_tendsto` / `contractAffine_apriori` — concrete geometric convergence to `2c`

## Verification

- Compiles against pinned Mathlib (`lake env lean Proofs/BanachFixedPointOQ01.lean`, rc=0)
- `#print axioms` on the main results: only `propext, Classical.choice, Quot.sound` — **0 axioms**, 0 sorries, no `native_decide`
- 9 theorems, 1 definition, 121 lines

## Novelty

Distinct from the gallery's existing fixed-point entries: Brouwer (topological existence) and Schauder (compact convex in Banach spaces). The metric contraction principle with an explicit geometric convergence rate was previously absent (`grep ContractingWith.fixedPoint proofs/Proofs` only finds it used as a comparison sub-lemma in Brouwer/Schauder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)