### PR TITLE
research(amgm-inequality-oq-05): Young's inequality equality case via strict convexity of exp

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -67,6 +67,7 @@ import Proofs.AmgmInequalityOQ04OQ02
 import Proofs.AmgmInequalityOQ04OQ03
 import Proofs.AmgmInequalityOQ04OQ03Wallis
 import Proofs.AmgmInequalityOQ04OQ05
+import Proofs.AmgmInequalityOQ05
 import Proofs.AmgmInequalityPowerMeanLimits
 import Proofs.AngleTrisection
 import Proofs.AngleTrisectionAristotle

--- a/proofs/Proofs/AmgmInequalityOQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ05.lean
@@ -1,0 +1,111 @@
+/-
+  Young's inequality and its equality case.
+
+  For Hölder-conjugate exponents `p, q > 1` (i.e. `p⁻¹ + q⁻¹ = 1`) and
+  nonnegative reals `a, b`, Young's inequality states
+
+      a * b ≤ a ^ p / p + b ^ q / q.
+
+  This is the conjugate-exponent root of Hölder's inequality.  Mathlib provides
+  the inequality itself (`Real.young_inequality_of_nonneg`), but **not** the
+  characterisation of its equality case.  The headline result of this file is
+
+      a * b = a ^ p / p + b ^ q / q  ↔  a ^ p = b ^ q       (for `a, b > 0`),
+
+  the sharp boundary of Young's inequality.  The interesting direction follows
+  from the *strict* convexity of `exp`: writing `a*b` and the right-hand side as
+  the two endpoints of a `(p⁻¹, q⁻¹)`-weighted combination of `exp` evaluated at
+  `log (a^p)` and `log (b^q)`, equality in the convex estimate forces the two
+  arguments to coincide, i.e. `a^p = b^q`.
+
+  We also record the classical specialisation `p = q = 2`, namely
+  `2 * a * b ≤ a^2 + b^2` with equality iff `a = b`.
+
+  All exponents are real, so `^` denotes `Real.rpow` throughout.
+
+  Verified: 0 sorries, 0 axioms.
+-/
+import Mathlib
+
+open Real
+
+namespace AmgmInequalityOQ05
+
+/-- **Young's inequality** (nonnegative form): for Hölder-conjugate exponents
+`p, q` and `a, b ≥ 0`, `a * b ≤ a ^ p / p + b ^ q / q`. -/
+theorem young_inequality {a b p q : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b)
+    (hpq : p.HolderConjugate q) :
+    a * b ≤ a ^ p / p + b ^ q / q :=
+  Real.young_inequality_of_nonneg ha hb hpq
+
+/-- A convenient factorisation used in both directions of the equality case:
+for `a, b > 0`, `a * b = (a ^ p) ^ p⁻¹ * (b ^ q) ^ q⁻¹`. -/
+private theorem mul_eq_rpow_inv_mul_rpow_inv {a b p q : ℝ} (ha : 0 < a) (hb : 0 < b)
+    (hpq : p.HolderConjugate q) :
+    a * b = (a ^ p) ^ p⁻¹ * (b ^ q) ^ q⁻¹ := by
+  have hp : (0 : ℝ) < p := hpq.pos
+  have hq : (0 : ℝ) < q := hpq.symm.pos
+  have hPA : (a ^ p) ^ p⁻¹ = a := by
+    rw [← Real.rpow_mul ha.le, mul_inv_cancel₀ hp.ne', Real.rpow_one]
+  have hQB : (b ^ q) ^ q⁻¹ = b := by
+    rw [← Real.rpow_mul hb.le, mul_inv_cancel₀ hq.ne', Real.rpow_one]
+  rw [hPA, hQB]
+
+/-- **Equality case of Young's inequality.**  For `a, b > 0` and Hölder-conjugate
+exponents `p, q`, equality `a * b = a ^ p / p + b ^ q / q` holds **iff**
+`a ^ p = b ^ q`.  The forward direction uses strict convexity of `exp`. -/
+theorem young_inequality_eq_iff {a b p q : ℝ} (ha : 0 < a) (hb : 0 < b)
+    (hpq : p.HolderConjugate q) :
+    a * b = a ^ p / p + b ^ q / q ↔ a ^ p = b ^ q := by
+  have hp : (0 : ℝ) < p := hpq.pos
+  have hq : (0 : ℝ) < q := hpq.symm.pos
+  have hxp : 0 < a ^ p := Real.rpow_pos_of_pos ha p
+  have hyq : 0 < b ^ q := Real.rpow_pos_of_pos hb q
+  have hinv : p⁻¹ + q⁻¹ = 1 := hpq.inv_add_inv_eq_one
+  have hab_eq : a * b = (a ^ p) ^ p⁻¹ * (b ^ q) ^ q⁻¹ :=
+    mul_eq_rpow_inv_mul_rpow_inv ha hb hpq
+  constructor
+  · -- forward direction: equality forces `a^p = b^q`, via strict convexity of exp
+    intro h
+    by_contra hne
+    -- `log` is injective on positives, so the two arguments differ
+    have hlog : Real.log (a ^ p) ≠ Real.log (b ^ q) := by
+      intro hc
+      apply hne
+      rw [← Real.exp_log hxp, ← Real.exp_log hyq, hc]
+    have hstrict :=
+      strictConvexOn_exp.2 (Set.mem_univ (Real.log (a ^ p)))
+        (Set.mem_univ (Real.log (b ^ q))) hlog hpq.inv_pos hpq.symm.inv_pos hinv
+    -- rewrite both sides of the strict estimate into closed form
+    have hab_exp :
+        a * b = Real.exp (p⁻¹ * Real.log (a ^ p) + q⁻¹ * Real.log (b ^ q)) := by
+      rw [Real.exp_add, mul_comm p⁻¹ (Real.log (a ^ p)),
+        mul_comm q⁻¹ (Real.log (b ^ q)), ← Real.rpow_def_of_pos hxp,
+        ← Real.rpow_def_of_pos hyq, ← hab_eq]
+    rw [smul_eq_mul, smul_eq_mul, smul_eq_mul, Real.exp_log hxp, Real.exp_log hyq,
+      ← hab_exp, h] at hstrict
+    -- `hstrict : a^p/p + b^q/q < p⁻¹ * a^p + q⁻¹ * b^q`, but the two sides are equal
+    rw [div_eq_mul_inv, div_eq_mul_inv, mul_comm (a ^ p) p⁻¹,
+      mul_comm (b ^ q) q⁻¹] at hstrict
+    exact lt_irrefl _ hstrict
+  · -- reverse direction: if `a^p = b^q` both sides equal that common value
+    intro h
+    have hL : a * b = b ^ q := by
+      rw [hab_eq, h, ← Real.rpow_add hyq, hinv, Real.rpow_one]
+    have hR : a ^ p / p + b ^ q / q = b ^ q := by
+      rw [h, div_eq_mul_inv, div_eq_mul_inv, ← mul_add, hinv, mul_one]
+    rw [hL, hR]
+
+/-- The classical `p = q = 2` specialisation: `2 * a * b ≤ a ^ 2 + b ^ 2`
+(here `^` is the natural-number power), with equality iff `a = b`. -/
+theorem two_mul_le_sq_add_sq (a b : ℝ) :
+    2 * a * b ≤ a ^ 2 + b ^ 2 ∧ (2 * a * b = a ^ 2 + b ^ 2 ↔ a = b) := by
+  refine ⟨by nlinarith [sq_nonneg (a - b)], ?_, ?_⟩
+  · intro h
+    have : (a - b) ^ 2 = 0 := by nlinarith [h]
+    have : a - b = 0 := by
+      exact pow_eq_zero_iff (by norm_num) |>.mp this
+    linarith
+  · rintro rfl; ring
+
+end AmgmInequalityOQ05

--- a/src/data/proofs/amgm-inequality-oq-05/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-05/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-young-inequality",
+    "proofId": "amgm-inequality-oq-05",
+    "range": {
+      "startLine": 34,
+      "endLine": 41
+    },
+    "type": "theorem",
+    "title": "young_inequality: a·b ≤ aᵖ/p + b^q/q",
+    "content": "Young's inequality for products in nonnegative form. For Hölder-conjugate exponents p, q (Real.HolderConjugate q, i.e. p,q > 1 with p⁻¹ + q⁻¹ = 1) and a, b ≥ 0, the product a·b is bounded by the conjugate-weighted sum of powers aᵖ/p + b^q/q. This is a direct application of Mathlib's Real.young_inequality_of_nonneg and serves as the inequality half of the entry, against which the equality case is sharp.",
+    "mathContext": "$ab \\leq \\frac{a^p}{p} + \\frac{b^q}{q}$ for $\\frac{1}{p} + \\frac{1}{q} = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Young's inequality",
+      "Hölder conjugate exponents",
+      "Real.rpow"
+    ],
+    "prerequisites": [
+      "Real.young_inequality_of_nonneg",
+      "Real.HolderConjugate"
+    ]
+  },
+  {
+    "id": "ann-mul-factorization",
+    "proofId": "amgm-inequality-oq-05",
+    "range": {
+      "startLine": 43,
+      "endLine": 54
+    },
+    "type": "insight",
+    "title": "Factorization a·b = (aᵖ)^(1/p)·(b^q)^(1/q)",
+    "content": "The bridge identity for the equality case. For a, b > 0, a·b equals (aᵖ)^(p⁻¹)·(b^q)^(q⁻¹). Each factor collapses by rpow arithmetic: (aᵖ)^(p⁻¹) = a^(p·p⁻¹) = a^1 = a, using Real.rpow_mul (which requires the base ≥ 0) and mul_inv_cancel₀ (which requires p ≠ 0). This rewriting is what lets a·b be recognized as exp of the (p⁻¹, q⁻¹)-weighted average of log(aᵖ) and log(b^q), the form on which strict convexity of exp acts.",
+    "mathContext": "$ab = (a^p)^{1/p}(b^q)^{1/q}$ since $(a^p)^{1/p} = a^{p \\cdot p^{-1}} = a$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.rpow_mul",
+      "mul_inv_cancel₀",
+      "weighted geometric mean"
+    ],
+    "prerequisites": [
+      "Real power arithmetic",
+      "positivity of a, b"
+    ]
+  },
+  {
+    "id": "ann-equality-case",
+    "proofId": "amgm-inequality-oq-05",
+    "range": {
+      "startLine": 56,
+      "endLine": 99
+    },
+    "type": "theorem",
+    "title": "young_inequality_eq_iff: equality ⟺ aᵖ = b^q",
+    "content": "The headline result. For a, b > 0, a·b = aᵖ/p + b^q/q holds iff aᵖ = b^q. Forward (⟹): by contradiction. If aᵖ ≠ b^q then log(aᵖ) ≠ log(b^q) (log is injective on positives, via exp_log). strictConvexOn_exp.2 with weights p⁻¹, q⁻¹ (positive, summing to 1) then gives a STRICT inequality exp(p⁻¹·log(aᵖ) + q⁻¹·log(b^q)) < p⁻¹·aᵖ + q⁻¹·b^q. The left side is exactly a·b (via the factorization and rpow_def_of_pos) and the right side is aᵖ/p + b^q/q, so a·b < aᵖ/p + b^q/q contradicts the assumed equality. Reverse (⟸): if aᵖ = b^q =: t, both sides equal t — the left via rpow_add and p⁻¹ + q⁻¹ = 1, the right via the same exponent identity. This is the sharp boundary of Young's inequality, absent from Mathlib.",
+    "mathContext": "$ab = \\frac{a^p}{p} + \\frac{b^q}{q} \\iff a^p = b^q$ (for $a, b > 0$), by strict convexity of $\\exp$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "strictConvexOn_exp",
+      "StrictConvexOn",
+      "Real.exp_log",
+      "Real.rpow_def_of_pos",
+      "equality case of a convex inequality"
+    ],
+    "prerequisites": [
+      "strict convexity of exp",
+      "injectivity of log on positives",
+      "Real.rpow_add"
+    ]
+  },
+  {
+    "id": "ann-two-mul-le-sq",
+    "proofId": "amgm-inequality-oq-05",
+    "range": {
+      "startLine": 101,
+      "endLine": 110
+    },
+    "type": "theorem",
+    "title": "two_mul_le_sq_add_sq: 2ab ≤ a² + b², equality ⟺ a = b",
+    "content": "The classical p = q = 2 specialization (2 is its own Hölder conjugate). 2·a·b ≤ a² + b² for all real a, b, with equality iff a = b. The inequality is nlinarith [sq_nonneg (a - b)] — it is equivalent to (a − b)² ≥ 0. For equality, 2ab = a² + b² forces (a − b)² = 0, hence a = b; conversely a = b gives equality by ring. This is the two-term AM-GM inequality and the inequality behind Cauchy–Schwarz.",
+    "mathContext": "$2ab \\leq a^2 + b^2$, equality iff $a = b$; equivalently $(a-b)^2 \\geq 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "AM-GM inequality",
+      "Cauchy–Schwarz",
+      "sq_nonneg"
+    ],
+    "prerequisites": [
+      "nlinarith",
+      "pow_eq_zero_iff"
+    ]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-05/meta.json
@@ -1,0 +1,106 @@
+{
+  "id": "amgm-inequality-oq-05",
+  "title": "Young's Inequality and Its Equality Case",
+  "slug": "amgm-inequality-oq-05",
+  "description": "For Hölder-conjugate exponents p, q > 1 (1/p + 1/q = 1) and nonnegative reals a, b, Young's inequality states a·b ≤ aᵖ/p + b^q/q. Mathlib provides the inequality but not the sharp characterization of its equality case. This entry proves equality holds iff aᵖ = b^q (for a, b > 0), via the strict convexity of the exponential function, and records the classical p = q = 2 specialization 2ab ≤ a² + b² with equality iff a = b.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Young%27s_inequality_for_products",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ05.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "young-inequality",
+      "holder-conjugate",
+      "convexity",
+      "equality-case",
+      "amgm",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 111,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-checked from Mathlib with 0 sorries and 0 axioms beyond Lean's foundational propext / Classical.choice / Quot.sound (which all Mathlib developments use). The inequality direction wraps Real.young_inequality_of_nonneg; the equality characterization is proved from strictConvexOn_exp.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Young's inequality for products, ab ≤ aᵖ/p + b^q/q for conjugate exponents 1/p + 1/q = 1, is named after William Henry Young (1912), who established it as part of his work on Fourier series and the theory of integration. It is the pointwise inequality underlying Hölder's inequality (the case p = q = 2 recovers the inequality 2ab ≤ a² + b² equivalent to the AM-GM inequality for two terms, and underlies the Cauchy–Schwarz inequality). Conceptually, Young's inequality is the statement that the chord of the convex function t ↦ tᵖ/p lies above the graph; equivalently, it expresses the duality between the power function and its convex conjugate (Legendre transform) x ↦ x^q/q. The sharp equality case — equality holds precisely when aᵖ = b^q — is the geometric statement that the supporting line touches the graph at a single point, a manifestation of the *strict* convexity of the exponential. While Mathlib carries the inequality (Real.young_inequality_of_nonneg, used internally to bootstrap Hölder's inequality), the equality characterization had not been formalized.",
+    "problemStatement": "Let p, q > 1 satisfy 1/p + 1/q = 1 (Hölder-conjugate exponents). For a, b ≥ 0, prove a·b ≤ aᵖ/p + b^q/q, and characterize when equality holds: for a, b > 0, a·b = aᵖ/p + b^q/q iff aᵖ = b^q. Specialize to p = q = 2 to recover 2ab ≤ a² + b² with equality iff a = b.",
+    "text": "Young's inequality a·b ≤ aᵖ/p + b^q/q is the conjugate-exponent root of Hölder's inequality. The sharp equality case aᵖ = b^q follows from strict convexity of exp.",
+    "proofStrategy": "The inequality (young_inequality) is a direct wrapper of Mathlib's Real.young_inequality_of_nonneg. The equality case (young_inequality_eq_iff) is the substantive contribution. Write x = aᵖ > 0, y = b^q > 0. The factorization a·b = (aᵖ)^(1/p)·(b^q)^(1/q) (proved by rpow arithmetic, since (aᵖ)^(1/p) = a^(p·p⁻¹) = a) realizes a·b and the right-hand side aᵖ/p + b^q/q as the two endpoints of a (p⁻¹, q⁻¹)-weighted convex combination of exp evaluated at log x and log y: a·b = exp(p⁻¹·log x + q⁻¹·log y) and aᵖ/p + b^q/q = p⁻¹·exp(log x) + q⁻¹·exp(log y). Strict convexity of exp (strictConvexOn_exp) gives strict inequality whenever log x ≠ log y, i.e. whenever x ≠ y; since log is injective on the positives, the equality case forces x = y, that is aᵖ = b^q. The reverse direction is a computation: if aᵖ = b^q =: t, both sides equal t (using p⁻¹ + q⁻¹ = 1). The p = q = 2 corollary is elementary (nlinarith with sq_nonneg (a - b); equality extracts (a-b)² = 0).",
+    "keyInsights": [
+      "**Strict convexity is the equality engine.** Young's inequality is weighted AM-GM with weights (1/p, 1/q); the ordinary (non-strict) inequality holds because exp is convex, but the *sharp* equality case requires *strict* convexity. Mathlib's strictConvexOn_exp gives exactly f(a•x + b•y) < a•f(x) + b•f(y) for x ≠ y, positive weights summing to 1, which translates directly into the strict form of Young whenever aᵖ ≠ b^q.",
+      "**Logarithmic coordinates linearize the weights.** Setting x = aᵖ, y = b^q and passing to u = log x, v = log y converts the multiplicative endpoint a·b = x^(1/p)·y^(1/q) into exp(p⁻¹u + q⁻¹v), an honest convex combination inside exp. The bridge identity (aᵖ)^(1/p) = a, proved by a^(p·p⁻¹) = a^1 = a, is what makes a·b coincide with the exp of the weighted average of the logs.",
+      "**Injectivity of log closes the equality direction.** Strict convexity yields the contrapositive (aᵖ ≠ b^q ⟹ strict inequality). Converting back from u = v to x = y uses that log is injective on the positive reals (exp ∘ log = id there), so log x = log y forces x = y.",
+      "**p = q = 2 recovers AM-GM for two terms.** The specialization 2ab ≤ a² + b² (equality iff a = b) is the most familiar instance: it is equivalent to (a − b)² ≥ 0, and it is the inequality behind Cauchy–Schwarz. This ties the general conjugate-exponent statement back to the AM-GM family."
+    ],
+    "prerequisites": [
+      "Hölder-conjugate exponents: Real.HolderConjugate (1/p + 1/q = 1, p,q > 1)",
+      "Real powers Real.rpow and their arithmetic (rpow_mul, rpow_add, rpow_def_of_pos)",
+      "Strict convexity of the exponential (strictConvexOn_exp) and the StrictConvexOn definition",
+      "Young's inequality (Real.young_inequality_of_nonneg)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Young's inequality and — the new content — its sharp equality case are fully verified: 4 theorems, 0 definitions, 0 axioms, 0 sorries. The inequality wraps Mathlib's Real.young_inequality_of_nonneg; the equality characterization aᵖ = b^q (for a, b > 0) is proved from the strict convexity of exp via a logarithmic change of coordinates, and the p = q = 2 corollary recovers 2ab ≤ a² + b² with equality iff a = b.",
+    "implications": "The equality case sharpens every downstream use of Young's inequality: in Hölder's inequality it pins down when the Hölder estimate is tight (proportional power-normalized vectors), and in the Cauchy–Schwarz specialization it recovers the linear-dependence equality condition. The proof illustrates the standard route from a convexity inequality to its equality case: replace convexity by strict convexity, linearize the weights in logarithmic coordinates, and use injectivity to transport equality back.",
+    "openQuestions": [
+      "Formalize the equality case of Hölder's inequality for finite sums / Lᵖ from the pointwise Young equality case proved here: equality in ∑ aᵢbᵢ ≤ (∑ aᵢᵖ)^(1/p)(∑ bᵢ^q)^(1/q) holds iff the sequences (aᵢᵖ) and (bᵢ^q) are proportional.",
+      "Prove the weighted AM-GM equality case for n terms: ∏ xᵢ^{wᵢ} = ∑ wᵢxᵢ (with ∑ wᵢ = 1, wᵢ > 0) iff all xᵢ with positive weight are equal, again via strict convexity of exp."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "extends",
+      "description": "The p = q = 2 case 2ab ≤ a² + b² (equality iff a = b) is the two-term AM-GM inequality. Young's inequality is the conjugate-exponent generalization, replacing the equal weights (1/2, 1/2) by (1/p, 1/q)."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-03-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Young's inequality is the pointwise root of Hölder's inequality; that entry studies reverse Hölder/Minkowski for 0 < p < 1, all gated on Real.HolderConjugate. The equality case proved here is the missing companion characterizing tightness in the forward Hölder estimate."
+    },
+    {
+      "targetId": "amgm-inequality-oq-04",
+      "relationship": "related",
+      "description": "Both entries are rooted in two-term AM-GM. There the inequality drives the AGM iteration's convergence; here its conjugate-exponent generalization (Young) is sharpened with an equality characterization via strict convexity of exp."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "AmgmInequalityOQ05",
+    "lineCount": 111,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/AmgmInequalityOQ05.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Young, William Henry",
+      "title": "On classes of summable functions and their Fourier series",
+      "year": "1912",
+      "venue": "Proceedings of the Royal Society A, vol. 87, no. 594, pp. 225-229",
+      "note": "Original source of Young's inequality for products."
+    },
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Classical reference for Young's inequality, Hölder's inequality, and their equality cases (Theorem 24 and surrounding discussion)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds **amgm-inequality-oq-05**: Young's inequality and the **sharp characterization of its equality case** — genuinely new content, since Mathlib carries the inequality (`Real.young_inequality_of_nonneg`) but not its equality condition.

For Hölder-conjugate exponents `p, q > 1` (`1/p + 1/q = 1`) and `a, b > 0`:

> `a·b = aᵖ/p + b^q/q  ⟺  aᵖ = b^q`

## Proof

The factorization `a·b = (aᵖ)^(1/p)·(b^q)^(1/q)` realizes `a·b` and the right-hand side as the two endpoints of a `(p⁻¹, q⁻¹)`-weighted convex combination of `exp` evaluated at `log(aᵖ)` and `log(b^q)`:

- `a·b = exp(p⁻¹·log(aᵖ) + q⁻¹·log(b^q))`
- `aᵖ/p + b^q/q = p⁻¹·exp(log(aᵖ)) + q⁻¹·exp(log(b^q))`

`strictConvexOn_exp` then gives a **strict** inequality whenever `log(aᵖ) ≠ log(b^q)`, i.e. whenever `aᵖ ≠ b^q`; injectivity of `log` on the positives transports equality back to `aᵖ = b^q`. The reverse direction is a computation using `p⁻¹ + q⁻¹ = 1`.

Also records the classical `p = q = 2` corollary `2ab ≤ a² + b²` with equality iff `a = b`.

## Verification

- 4 theorems, 0 definitions, **0 axioms, 0 sorries**
- `#print axioms`: only `propext` / `Classical.choice` / `Quot.sound`
- Compiles against pinned Mathlib 4.26.0

## Files
- `proofs/Proofs/AmgmInequalityOQ05.lean` (new, 111 lines)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/amgm-inequality-oq-05/{meta,annotations}.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)