### PR TITLE
Fix: repair KnightsTourObliqueOQ01 + OQ02 Mathlib drift (#27034)

### DIFF
--- a/proofs/Proofs/KnightsTourObliqueOQ01.lean
+++ b/proofs/Proofs/KnightsTourObliqueOQ01.lean
@@ -106,12 +106,12 @@ structure ClosedTourN (n : ℕ) where
   squares : List (SquareN n)
   length_eq : squares.length = n * n
   nodup : squares.Nodup
-  path : ∀ i, i + 1 < squares.length →
-    (knightGraphN n).Adj (squares[i]'(by omega)) (squares[i + 1]'(by omega))
-  closes : (knightGraphN n).Adj
-    (squares.getLast (by rw [length_eq]; omega))
-    (squares.head (by rw [length_eq]; omega))
   nonempty : squares ≠ []
+  path : ∀ i (hi : i + 1 < squares.length),
+    (knightGraphN n).Adj (squares[i]'(by omega)) (squares[i + 1]'hi)
+  closes : (knightGraphN n).Adj
+    (squares.getLast nonempty)
+    (squares.head nonempty)
 
 /-! ## Section 4: Corner Analysis for General n -/
 
@@ -129,11 +129,10 @@ theorem corners_distinct (n : ℕ) (hn : n ≥ 2) :
     cornerTR n (by omega) ≠ cornerBL n (by omega) ∧
     cornerTR n (by omega) ≠ cornerBR n (by omega) ∧
     cornerBL n (by omega) ≠ cornerBR n (by omega) := by
-  simp only [cornerTL, cornerTR, cornerBL, cornerBR, ne_eq, Prod.mk.injEq, not_and]
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
-  all_goals intro h
-  all_goals simp only [Fin.mk.injEq] at h
-  all_goals omega
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    simp only [cornerTL, cornerTR, cornerBL, cornerBR, ne_eq, Prod.mk.injEq,
+      Fin.mk.injEq, not_and] <;>
+    omega
 
 /-- For n ≥ 5, corner (0,0) has exactly neighbors (1,2) and (2,1) -/
 theorem cornerTL_neighbors (n : ℕ) (hn : n ≥ 5) (s : SquareN n)
@@ -141,17 +140,17 @@ theorem cornerTL_neighbors (n : ℕ) (hn : n ≥ 5) (s : SquareN n)
     s = (⟨1, by omega⟩, ⟨2, by omega⟩) ∨ s = (⟨2, by omega⟩, ⟨1, by omega⟩) := by
   simp only [knightGraphN, SimpleGraph.Adj, knightAdjN, cornerTL] at hadj
   simp only [isKnightOffset, knightOffsets, List.mem_cons, Prod.mk.injEq,
-    List.mem_singleton, List.mem_nil_iff, decide_eq_true_eq] at hadj
+    List.mem_singleton, List.mem_nil_iff, decide_eq_true_eq, or_false] at hadj
   rcases hadj with ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ |
                    ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩
   · left; ext <;> simp_all [Fin.ext_iff] <;> omega
   · right; ext <;> simp_all [Fin.ext_iff] <;> omega
-  · exfalso; have := s.2.val_lt_last (by omega); omega
-  · exfalso; have := s.2.val_lt_last (by omega); omega
-  · exfalso; have := s.1.val_lt_last (by omega); omega
-  · exfalso; have := s.1.val_lt_last (by omega); omega
-  · exfalso; have := s.1.val_lt_last (by omega); omega
-  · exfalso; have := s.1.val_lt_last (by omega); omega
+  · exfalso; have := s.2.isLt; omega
+  · exfalso; have := s.2.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
 
 /-- For n ≥ 5, corner (0,n-1) has exactly neighbors (1,n-3) and (2,n-2) -/
 theorem cornerTR_neighbors (n : ℕ) (hn : n ≥ 5) (s : SquareN n)
@@ -159,7 +158,7 @@ theorem cornerTR_neighbors (n : ℕ) (hn : n ≥ 5) (s : SquareN n)
     s = (⟨1, by omega⟩, ⟨n - 3, by omega⟩) ∨ s = (⟨2, by omega⟩, ⟨n - 2, by omega⟩) := by
   simp only [knightGraphN, SimpleGraph.Adj, knightAdjN, cornerTR] at hadj
   simp only [isKnightOffset, knightOffsets, List.mem_cons, Prod.mk.injEq,
-    List.mem_singleton, List.mem_nil_iff, decide_eq_true_eq] at hadj
+    List.mem_singleton, List.mem_nil_iff, decide_eq_true_eq, or_false] at hadj
   rcases hadj with ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ |
                    ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩
   · exfalso; have := s.2.isLt; omega
@@ -177,7 +176,7 @@ theorem cornerBL_neighbors (n : ℕ) (hn : n ≥ 5) (s : SquareN n)
     s = (⟨n - 3, by omega⟩, ⟨1, by omega⟩) ∨ s = (⟨n - 2, by omega⟩, ⟨2, by omega⟩) := by
   simp only [knightGraphN, SimpleGraph.Adj, knightAdjN, cornerBL] at hadj
   simp only [isKnightOffset, knightOffsets, List.mem_cons, Prod.mk.injEq,
-    List.mem_singleton, List.mem_nil_iff, decide_eq_true_eq] at hadj
+    List.mem_singleton, List.mem_nil_iff, decide_eq_true_eq, or_false] at hadj
   rcases hadj with ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ |
                    ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩
   · exfalso; have := s.1.isLt; omega
@@ -195,7 +194,7 @@ theorem cornerBR_neighbors (n : ℕ) (hn : n ≥ 5) (s : SquareN n)
     s = (⟨n - 3, by omega⟩, ⟨n - 2, by omega⟩) ∨ s = (⟨n - 2, by omega⟩, ⟨n - 3, by omega⟩) := by
   simp only [knightGraphN, SimpleGraph.Adj, knightAdjN, cornerBR] at hadj
   simp only [isKnightOffset, knightOffsets, List.mem_cons, Prod.mk.injEq,
-    List.mem_singleton, List.mem_nil_iff, decide_eq_true_eq] at hadj
+    List.mem_singleton, List.mem_nil_iff, decide_eq_true_eq, or_false] at hadj
   rcases hadj with ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ |
                    ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩
   · exfalso; have := s.1.isLt; omega
@@ -233,12 +232,12 @@ theorem cornerTL_oblique (n : ℕ) (hn : n ≥ 5) (prev next : SquareN n)
   · exact absurd rfl hne
   · -- prev=(1,2), next=(2,1): dot = (-1)*2+(-2)*1 = -4
     show MoveVector.dot _ _ < 0
-    simp [getMoveVector, MoveVector.dot, cornerTL]
-    omega
+    simp only [getMoveVector, MoveVector.dot, cornerTL, Fin.val_mk]
+    ring_nf; omega
   · -- prev=(2,1), next=(1,2): dot = (-2)*1+(-1)*2 = -4
     show MoveVector.dot _ _ < 0
-    simp [getMoveVector, MoveVector.dot, cornerTL]
-    omega
+    simp only [getMoveVector, MoveVector.dot, cornerTL, Fin.val_mk]
+    ring_nf; omega
   · exact absurd rfl hne
 
 /-- At corner (0,n-1), both possible turns are oblique.
@@ -254,11 +253,15 @@ theorem cornerTR_oblique (n : ℕ) (hn : n ≥ 5) (prev next : SquareN n)
   rcases hp with rfl | rfl <;> rcases hn' with rfl | rfl
   · exact absurd rfl hne
   · show MoveVector.dot _ _ < 0
-    simp [getMoveVector, MoveVector.dot, cornerTR]
-    omega
+    simp only [getMoveVector, MoveVector.dot, cornerTR, Fin.val_mk]
+    push_cast [Nat.cast_sub (show 1 ≤ n by omega), Nat.cast_sub (show 2 ≤ n by omega),
+      Nat.cast_sub (show 3 ≤ n by omega)]
+    ring_nf; omega
   · show MoveVector.dot _ _ < 0
-    simp [getMoveVector, MoveVector.dot, cornerTR]
-    omega
+    simp only [getMoveVector, MoveVector.dot, cornerTR, Fin.val_mk]
+    push_cast [Nat.cast_sub (show 1 ≤ n by omega), Nat.cast_sub (show 2 ≤ n by omega),
+      Nat.cast_sub (show 3 ≤ n by omega)]
+    ring_nf; omega
   · exact absurd rfl hne
 
 /-- At corner (n-1,0), both possible turns are oblique.
@@ -274,11 +277,15 @@ theorem cornerBL_oblique (n : ℕ) (hn : n ≥ 5) (prev next : SquareN n)
   rcases hp with rfl | rfl <;> rcases hn' with rfl | rfl
   · exact absurd rfl hne
   · show MoveVector.dot _ _ < 0
-    simp [getMoveVector, MoveVector.dot, cornerBL]
-    omega
+    simp only [getMoveVector, MoveVector.dot, cornerBL, Fin.val_mk]
+    push_cast [Nat.cast_sub (show 1 ≤ n by omega), Nat.cast_sub (show 2 ≤ n by omega),
+      Nat.cast_sub (show 3 ≤ n by omega)]
+    ring_nf; omega
   · show MoveVector.dot _ _ < 0
-    simp [getMoveVector, MoveVector.dot, cornerBL]
-    omega
+    simp only [getMoveVector, MoveVector.dot, cornerBL, Fin.val_mk]
+    push_cast [Nat.cast_sub (show 1 ≤ n by omega), Nat.cast_sub (show 2 ≤ n by omega),
+      Nat.cast_sub (show 3 ≤ n by omega)]
+    ring_nf; omega
   · exact absurd rfl hne
 
 /-- At corner (n-1,n-1), both possible turns are oblique.
@@ -294,11 +301,15 @@ theorem cornerBR_oblique (n : ℕ) (hn : n ≥ 5) (prev next : SquareN n)
   rcases hp with rfl | rfl <;> rcases hn' with rfl | rfl
   · exact absurd rfl hne
   · show MoveVector.dot _ _ < 0
-    simp [getMoveVector, MoveVector.dot, cornerBR]
-    omega
+    simp only [getMoveVector, MoveVector.dot, cornerBR, Fin.val_mk]
+    push_cast [Nat.cast_sub (show 1 ≤ n by omega), Nat.cast_sub (show 2 ≤ n by omega),
+      Nat.cast_sub (show 3 ≤ n by omega)]
+    ring_nf; omega
   · show MoveVector.dot _ _ < 0
-    simp [getMoveVector, MoveVector.dot, cornerBR]
-    omega
+    simp only [getMoveVector, MoveVector.dot, cornerBR, Fin.val_mk]
+    push_cast [Nat.cast_sub (show 1 ≤ n by omega), Nat.cast_sub (show 2 ≤ n by omega),
+      Nat.cast_sub (show 3 ≤ n by omega)]
+    ring_nf; omega
   · exact absurd rfl hne
 
 /-- At any corner of the n×n board, the turn is oblique -/
@@ -334,21 +345,23 @@ theorem tour_visits_all (n : ℕ) (t : ClosedTourN n) (s : SquareN n) :
 theorem tour_cyclic_adj (n : ℕ) (t : ClosedTourN n) (i : Fin (n * n)) :
     (knightGraphN n).Adj
       (t.squares[i.val]'(by rw [t.length_eq]; exact i.isLt))
-      (t.squares[(i.val + 1) % (n * n)]'(by rw [t.length_eq]; omega)) := by
+      (t.squares[(i.val + 1) % (n * n)]'(by
+        rw [t.length_eq]; exact Nat.mod_lt _ (by have := i.isLt; omega))) := by
   by_cases h : i.val + 1 < n * n
   · simp only [Nat.mod_eq_of_lt h]
-    exact t.path i.val h
+    exact t.path i.val (by rw [t.length_eq]; exact h)
   · have hi : i.val = n * n - 1 := by omega
-    simp only [hi]
-    have hmod : (n * n - 1 + 1) % (n * n) = 0 := by omega
-    rw [hmod]
-    have hlast : t.squares.getLast t.nonempty =
-        t.squares[n * n - 1]'(by rw [t.length_eq]; omega) := by
-      simp only [List.getLast_eq_getElem, t.length_eq]
-    have hhead : t.squares.head t.nonempty =
-        t.squares[0]'(by rw [t.length_eq]; omega) := by
-      simp only [List.head_eq_getElem, t.length_eq]
-    rw [← hlast, ← hhead]
+    have hkey : (i.val + 1) % (n * n) = 0 := by
+      rw [hi, Nat.sub_add_cancel (by have := i.isLt; omega), Nat.mod_self]
+    have hlast : t.squares[i.val]'(by rw [t.length_eq]; exact i.isLt)
+        = t.squares.getLast t.nonempty := by
+      rw [List.getLast_eq_getElem]; congr 1
+      rw [t.length_eq]; omega
+    have hhead : t.squares[(i.val + 1) % (n * n)]'(by
+          rw [t.length_eq]; exact Nat.mod_lt _ (by have := i.isLt; omega))
+        = t.squares.head t.nonempty := by
+      rw [List.head_eq_getElem]; congr 1
+    rw [hlast, hhead]
     exact t.closes
 
 /-- Distinct positions in a tour have distinct squares -/
@@ -356,12 +369,8 @@ theorem tour_index_neq (n : ℕ) (t : ClosedTourN n) (i j : ℕ)
     (hi : i < n * n) (hj : j < n * n) (hne : i ≠ j) :
     t.squares[i]'(by rw [t.length_eq]; exact hi) ≠
     t.squares[j]'(by rw [t.length_eq]; exact hj) := by
-  intro heq
-  have := List.Nodup.get_inj_iff t.nodup
-  have h : (⟨i, by rw [t.length_eq]; exact hi⟩ : Fin t.squares.length) =
-           ⟨j, by rw [t.length_eq]; exact hj⟩ := this.mp heq
-  simp at h
-  exact hne h
+  rw [ne_eq, t.nodup.getElem_inj_iff]
+  exact hne
 
 /-! ## Section 7: Main Theorem
 
@@ -383,24 +392,61 @@ theorem four_oblique_corners (n : ℕ) (hn : n ≥ 5) (t : ClosedTourN n) :
       i₁.val ≠ i₂.val ∧ i₁.val ≠ i₃.val ∧ i₁.val ≠ i₄.val ∧
       i₂.val ≠ i₃.val ∧ i₂.val ≠ i₄.val ∧ i₃.val ≠ i₄.val ∧
       -- At each corner position, the turn is oblique
-      (let prev₁ := t.squares[(i₁.val + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; omega)
-       let next₁ := t.squares[(i₁.val + 1) % (n*n)]'(by rw [t.length_eq]; omega)
+      (let prev₁ := t.squares[(i₁.val + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
+       let next₁ := t.squares[(i₁.val + 1) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
        let c₁ := t.squares[i₁.val]'(by rw [t.length_eq]; exact i₁.isLt)
        isOblique (getMoveVector prev₁ c₁) (getMoveVector c₁ next₁)) ∧
-      (let prev₂ := t.squares[(i₂.val + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; omega)
-       let next₂ := t.squares[(i₂.val + 1) % (n*n)]'(by rw [t.length_eq]; omega)
+      (let prev₂ := t.squares[(i₂.val + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
+       let next₂ := t.squares[(i₂.val + 1) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
        let c₂ := t.squares[i₂.val]'(by rw [t.length_eq]; exact i₂.isLt)
        isOblique (getMoveVector prev₂ c₂) (getMoveVector c₂ next₂)) ∧
-      (let prev₃ := t.squares[(i₃.val + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; omega)
-       let next₃ := t.squares[(i₃.val + 1) % (n*n)]'(by rw [t.length_eq]; omega)
+      (let prev₃ := t.squares[(i₃.val + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
+       let next₃ := t.squares[(i₃.val + 1) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
        let c₃ := t.squares[i₃.val]'(by rw [t.length_eq]; exact i₃.isLt)
        isOblique (getMoveVector prev₃ c₃) (getMoveVector c₃ next₃)) ∧
-      (let prev₄ := t.squares[(i₄.val + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; omega)
-       let next₄ := t.squares[(i₄.val + 1) % (n*n)]'(by rw [t.length_eq]; omega)
+      (let prev₄ := t.squares[(i₄.val + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
+       let next₄ := t.squares[(i₄.val + 1) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
        let c₄ := t.squares[i₄.val]'(by rw [t.length_eq]; exact i₄.isLt)
        isOblique (getMoveVector prev₄ c₄) (getMoveVector c₄ next₄)) := by
   -- Get corner positions in the tour
   have hnn : n * n ≥ 25 := by nlinarith
+  have hpos : 0 < n * n := by omega
+  -- Cyclic predecessor-then-successor returns the original index (symbolic modulus,
+  -- so omega cannot do this directly — proved via explicit modular lemmas).
+  have hcyc : ∀ (k : ℕ), k < n * n →
+      ((k + (n * n - 1)) % (n * n) + 1) % (n * n) = k := by
+    intro k hk
+    rcases Nat.eq_zero_or_pos k with h0 | hpk
+    · subst h0
+      have hinner : (0 + (n * n - 1)) % (n * n) = n * n - 1 := by
+        rw [Nat.zero_add]; exact Nat.mod_eq_of_lt (by omega)
+      rw [hinner, Nat.sub_add_cancel (by omega), Nat.mod_self]
+    · have hinner : (k + (n * n - 1)) % (n * n) = k - 1 := by
+        rw [show k + (n * n - 1) = n * n + (k - 1) by omega, Nat.add_mod_left]
+        exact Nat.mod_eq_of_lt (by omega)
+      rw [hinner, Nat.sub_add_cancel hpk, Nat.mod_eq_of_lt hk]
+  -- Cyclic predecessor and successor of an index are distinct (board size ≥ 25 ≥ 3).
+  have hpn : ∀ (k : ℕ), k < n * n →
+      (k + (n * n - 1)) % (n * n) ≠ (k + 1) % (n * n) := by
+    intro k hk
+    rcases Nat.eq_zero_or_pos k with h0 | hpk
+    · subst h0
+      have e1 : (0 + (n * n - 1)) % (n * n) = n * n - 1 := by
+        rw [Nat.zero_add, Nat.mod_eq_of_lt (by omega)]
+      have e2 : (0 + 1) % (n * n) = 1 := by rw [Nat.zero_add, Nat.mod_eq_of_lt (by omega)]
+      rw [e1, e2]; omega
+    · have hsplit : k + (n * n - 1) = n * n + (k - 1) := by omega
+      have e1 : (k + (n * n - 1)) % (n * n) = k - 1 := by
+        rw [hsplit, Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
+      by_cases hkm : k + 1 < n * n
+      · rw [e1, Nat.mod_eq_of_lt hkm]; omega
+      · have e2 : (k + 1) % (n * n) = 0 := by rw [show k + 1 = n * n by omega, Nat.mod_self]
+        rw [e1, e2]; omega
+  -- getElem at provably-equal indices yields equal elements (motive-safe substitute for
+  -- rewriting an index inside a dependent `t.squares[·]`).
+  have hsqcong : ∀ {a b : ℕ} (ha : a < t.squares.length) (hb : b < t.squares.length),
+      a = b → t.squares[a]'ha = t.squares[b]'hb := by
+    intro a b ha hb hab; subst hab; rfl
 
   have hcTL : cornerTL n (by omega) ∈ t.squares := tour_visits_all n t _
   have hcTR : cornerTR n (by omega) ∈ t.squares := tour_visits_all n t _
@@ -420,18 +466,21 @@ theorem four_oblique_corners (n : ℕ) (hn : n ≥ 5) (t : ClosedTourN n) :
 
   -- Corner indices are pairwise distinct
   have hdist := corners_distinct n (by omega)
+  have hmkeq : ∀ {a b : ℕ} (ha : a < t.squares.length) (hb : b < t.squares.length),
+      a = b → t.squares.get ⟨a, ha⟩ = t.squares.get ⟨b, hb⟩ := by
+    intro a b ha hb hab; congr 1; exact Fin.ext hab
   have hne12 : iTL ≠ iTR := by
-    intro h; exact hdist.1 (heqTL.symm.trans (by rw [show iTL = iTR from h]; exact heqTR))
+    intro h; apply hdist.1; rw [← heqTL, ← heqTR]; exact hmkeq hiTL hiTR h
   have hne13 : iTL ≠ iBL := by
-    intro h; exact hdist.2.1 (heqTL.symm.trans (by rw [show iTL = iBL from h]; exact heqBL))
+    intro h; apply hdist.2.1; rw [← heqTL, ← heqBL]; exact hmkeq hiTL hiBL h
   have hne14 : iTL ≠ iBR := by
-    intro h; exact hdist.2.2.1 (heqTL.symm.trans (by rw [show iTL = iBR from h]; exact heqBR))
+    intro h; apply hdist.2.2.1; rw [← heqTL, ← heqBR]; exact hmkeq hiTL hiBR h
   have hne23 : iTR ≠ iBL := by
-    intro h; exact hdist.2.2.2.1 (heqTR.symm.trans (by rw [show iTR = iBL from h]; exact heqBL))
+    intro h; apply hdist.2.2.2.1; rw [← heqTR, ← heqBL]; exact hmkeq hiTR hiBL h
   have hne24 : iTR ≠ iBR := by
-    intro h; exact hdist.2.2.2.2.1 (heqTR.symm.trans (by rw [show iTR = iBR from h]; exact heqBR))
+    intro h; apply hdist.2.2.2.2.1; rw [← heqTR, ← heqBR]; exact hmkeq hiTR hiBR h
   have hne34 : iBL ≠ iBR := by
-    intro h; exact hdist.2.2.2.2.2 (heqBL.symm.trans (by rw [show iBL = iBR from h]; exact heqBR))
+    intro h; apply hdist.2.2.2.2.2; rw [← heqBL, ← heqBR]; exact hmkeq hiBL hiBR h
 
   -- Use the corner indices
   refine ⟨⟨iTL, hiTL_lt⟩, ⟨iTR, hiTR_lt⟩, ⟨iBL, hiBL_lt⟩, ⟨iBR, hiBR_lt⟩,
@@ -443,70 +492,70 @@ theorem four_oblique_corners (n : ℕ) (hn : n ≥ 5) (t : ClosedTourN n) :
 
   · -- Corner TL at position iTL
     have hadj_prev : (knightGraphN n).Adj
-        (t.squares[(iTL + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; omega))
+        (t.squares[(iTL + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega))))
         (t.squares[iTL]'(by rw [t.length_eq]; exact hiTL_lt)) := by
-      have h := tour_cyclic_adj n t ⟨(iTL + (n*n - 1)) % (n*n), by omega⟩
-      have hmod : ((iTL + (n*n - 1)) % (n*n) + 1) % (n*n) = iTL := by omega
-      rw [hmod] at h; exact h
+      have h := tour_cyclic_adj n t ⟨(iTL + (n*n - 1)) % (n*n), Nat.mod_lt _ hpos⟩
+      rw [hsqcong (a := ((iTL + (n*n - 1)) % (n*n) + 1) % (n*n)) (b := iTL)
+        (by rw [t.length_eq]; exact Nat.mod_lt _ hpos) (by rw [t.length_eq]; exact hiTL_lt)
+        (hcyc iTL hiTL_lt)] at h
+      exact h
     have hadj_next : (knightGraphN n).Adj
         (t.squares[iTL]'(by rw [t.length_eq]; exact hiTL_lt))
-        (t.squares[(iTL + 1) % (n*n)]'(by rw [t.length_eq]; omega)) := by
+        (t.squares[(iTL + 1) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))) := by
       exact tour_cyclic_adj n t ⟨iTL, hiTL_lt⟩
-    have hpn_ne : (iTL + (n*n - 1)) % (n*n) ≠ (iTL + 1) % (n*n) := by omega
-    have hsq_ne := tour_index_neq n t _ _ (by omega) (by omega) hpn_ne
-    rw [← heqTL] at hadj_prev hadj_next
-    exact corner_forces_oblique n hn _ (Or.inl heqTL) _ _
-      (heqTL ▸ hadj_prev) (heqTL ▸ hadj_next) hsq_ne
+    have hpn_ne := hpn iTL hiTL_lt
+    have hsq_ne := tour_index_neq n t _ _ (Nat.mod_lt _ hpos) (Nat.mod_lt _ hpos) hpn_ne
+    exact corner_forces_oblique n hn _ (Or.inl heqTL) _ _ hadj_prev hadj_next hsq_ne
 
   · -- Corner TR at position iTR
     have hadj_prev : (knightGraphN n).Adj
-        (t.squares[(iTR + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; omega))
+        (t.squares[(iTR + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega))))
         (t.squares[iTR]'(by rw [t.length_eq]; exact hiTR_lt)) := by
-      have h := tour_cyclic_adj n t ⟨(iTR + (n*n - 1)) % (n*n), by omega⟩
-      have hmod : ((iTR + (n*n - 1)) % (n*n) + 1) % (n*n) = iTR := by omega
-      rw [hmod] at h; exact h
+      have h := tour_cyclic_adj n t ⟨(iTR + (n*n - 1)) % (n*n), Nat.mod_lt _ hpos⟩
+      rw [hsqcong (a := ((iTR + (n*n - 1)) % (n*n) + 1) % (n*n)) (b := iTR)
+        (by rw [t.length_eq]; exact Nat.mod_lt _ hpos) (by rw [t.length_eq]; exact hiTR_lt)
+        (hcyc iTR hiTR_lt)] at h
+      exact h
     have hadj_next : (knightGraphN n).Adj
         (t.squares[iTR]'(by rw [t.length_eq]; exact hiTR_lt))
-        (t.squares[(iTR + 1) % (n*n)]'(by rw [t.length_eq]; omega)) := by
+        (t.squares[(iTR + 1) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))) := by
       exact tour_cyclic_adj n t ⟨iTR, hiTR_lt⟩
-    have hpn_ne : (iTR + (n*n - 1)) % (n*n) ≠ (iTR + 1) % (n*n) := by omega
-    have hsq_ne := tour_index_neq n t _ _ (by omega) (by omega) hpn_ne
-    rw [← heqTR] at hadj_prev hadj_next
-    exact corner_forces_oblique n hn _ (Or.inr (Or.inl heqTR)) _ _
-      (heqTR ▸ hadj_prev) (heqTR ▸ hadj_next) hsq_ne
+    have hpn_ne := hpn iTR hiTR_lt
+    have hsq_ne := tour_index_neq n t _ _ (Nat.mod_lt _ hpos) (Nat.mod_lt _ hpos) hpn_ne
+    exact corner_forces_oblique n hn _ (Or.inr (Or.inl heqTR)) _ _ hadj_prev hadj_next hsq_ne
 
   · -- Corner BL at position iBL
     have hadj_prev : (knightGraphN n).Adj
-        (t.squares[(iBL + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; omega))
+        (t.squares[(iBL + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega))))
         (t.squares[iBL]'(by rw [t.length_eq]; exact hiBL_lt)) := by
-      have h := tour_cyclic_adj n t ⟨(iBL + (n*n - 1)) % (n*n), by omega⟩
-      have hmod : ((iBL + (n*n - 1)) % (n*n) + 1) % (n*n) = iBL := by omega
-      rw [hmod] at h; exact h
+      have h := tour_cyclic_adj n t ⟨(iBL + (n*n - 1)) % (n*n), Nat.mod_lt _ hpos⟩
+      rw [hsqcong (a := ((iBL + (n*n - 1)) % (n*n) + 1) % (n*n)) (b := iBL)
+        (by rw [t.length_eq]; exact Nat.mod_lt _ hpos) (by rw [t.length_eq]; exact hiBL_lt)
+        (hcyc iBL hiBL_lt)] at h
+      exact h
     have hadj_next : (knightGraphN n).Adj
         (t.squares[iBL]'(by rw [t.length_eq]; exact hiBL_lt))
-        (t.squares[(iBL + 1) % (n*n)]'(by rw [t.length_eq]; omega)) := by
+        (t.squares[(iBL + 1) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))) := by
       exact tour_cyclic_adj n t ⟨iBL, hiBL_lt⟩
-    have hpn_ne : (iBL + (n*n - 1)) % (n*n) ≠ (iBL + 1) % (n*n) := by omega
-    have hsq_ne := tour_index_neq n t _ _ (by omega) (by omega) hpn_ne
-    rw [← heqBL] at hadj_prev hadj_next
-    exact corner_forces_oblique n hn _ (Or.inr (Or.inr (Or.inl heqBL))) _ _
-      (heqBL ▸ hadj_prev) (heqBL ▸ hadj_next) hsq_ne
+    have hpn_ne := hpn iBL hiBL_lt
+    have hsq_ne := tour_index_neq n t _ _ (Nat.mod_lt _ hpos) (Nat.mod_lt _ hpos) hpn_ne
+    exact corner_forces_oblique n hn _ (Or.inr (Or.inr (Or.inl heqBL))) _ _ hadj_prev hadj_next hsq_ne
 
   · -- Corner BR at position iBR
     have hadj_prev : (knightGraphN n).Adj
-        (t.squares[(iBR + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; omega))
+        (t.squares[(iBR + (n*n - 1)) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega))))
         (t.squares[iBR]'(by rw [t.length_eq]; exact hiBR_lt)) := by
-      have h := tour_cyclic_adj n t ⟨(iBR + (n*n - 1)) % (n*n), by omega⟩
-      have hmod : ((iBR + (n*n - 1)) % (n*n) + 1) % (n*n) = iBR := by omega
-      rw [hmod] at h; exact h
+      have h := tour_cyclic_adj n t ⟨(iBR + (n*n - 1)) % (n*n), Nat.mod_lt _ hpos⟩
+      rw [hsqcong (a := ((iBR + (n*n - 1)) % (n*n) + 1) % (n*n)) (b := iBR)
+        (by rw [t.length_eq]; exact Nat.mod_lt _ hpos) (by rw [t.length_eq]; exact hiBR_lt)
+        (hcyc iBR hiBR_lt)] at h
+      exact h
     have hadj_next : (knightGraphN n).Adj
         (t.squares[iBR]'(by rw [t.length_eq]; exact hiBR_lt))
-        (t.squares[(iBR + 1) % (n*n)]'(by rw [t.length_eq]; omega)) := by
+        (t.squares[(iBR + 1) % (n*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))) := by
       exact tour_cyclic_adj n t ⟨iBR, hiBR_lt⟩
-    have hpn_ne : (iBR + (n*n - 1)) % (n*n) ≠ (iBR + 1) % (n*n) := by omega
-    have hsq_ne := tour_index_neq n t _ _ (by omega) (by omega) hpn_ne
-    rw [← heqBR] at hadj_prev hadj_next
-    exact corner_forces_oblique n hn _ (Or.inr (Or.inr (Or.inr heqBR))) _ _
-      (heqBR ▸ hadj_prev) (heqBR ▸ hadj_next) hsq_ne
+    have hpn_ne := hpn iBR hiBR_lt
+    have hsq_ne := tour_index_neq n t _ _ (Nat.mod_lt _ hpos) (Nat.mod_lt _ hpos) hpn_ne
+    exact corner_forces_oblique n hn _ (Or.inr (Or.inr (Or.inr heqBR))) _ _ hadj_prev hadj_next hsq_ne
 
 end KnightsTourObliqueGeneral

--- a/proofs/Proofs/KnightsTourObliqueOQ02.lean
+++ b/proofs/Proofs/KnightsTourObliqueOQ02.lean
@@ -129,7 +129,7 @@ theorem obliqueDistribution_support_le_three :
     ∀ k, k ≤ 3 → obliqueDistribution k = 0 := fun k hk =>
   obliqueDistribution_zero_below_four k (Nat.lt_succ_of_le hk)
 
-/-- The unique minimum tour from Knuth's classification (combined with
+/- The unique minimum tour from Knuth's classification (combined with
     `oblique_lower_bound`) shows the support is non-empty at `k = 4`. The
     concrete value `obliqueDistribution 4` is determined by the D4-orbit
     of `minimalObliqueTour` (the parent's canonical witness) and is at
@@ -427,6 +427,7 @@ theorem mem_d4Orbit_iff (t u : ClosedTour) :
   unfold d4Orbit d4Equiv
   simp only [Finset.mem_image, Finset.mem_univ, true_and]
 
+open Classical in
 /-- Bridge: the D4 orbit `Finset` is the filter of `Finset.univ` by the
     equivalence relation `d4Equiv t ·`. -/
 theorem d4Orbit_eq_filter_d4Equiv (t : ClosedTour) :
@@ -645,11 +646,9 @@ theorem d4Mul_assoc (g₃ g₂ g₁ : Bool × Fin 4) :
   obtain ⟨b₂, k₂⟩ := g₂
   obtain ⟨b₁, k₁⟩ := g₁
   cases b₃ <;> cases b₂ <;> cases b₁ <;>
-    (simp only [d4Mul, Bool.not_false, Bool.not_true]
-     refine Prod.mk.injEq.mpr ⟨rfl, ?_⟩
-     apply Fin.ext
-     simp only [Fin.val_mk]
-     omega)
+    simp only [d4Mul, Bool.not_false, Bool.not_true, Prod.mk.injEq, Fin.ext_iff,
+      Fin.val_mk, true_and] <;>
+    omega
 
 /-- **Left identity**: `(false, 0)` is a left unit for `d4Mul`. Single
     pattern match on the second argument; `(k.val + 0) % 4 = k.val`
@@ -657,10 +656,7 @@ theorem d4Mul_assoc (g₃ g₂ g₁ : Bool × Fin 4) :
 theorem d4Mul_one_left (g : Bool × Fin 4) :
     d4Mul (false, 0) g = g := by
   obtain ⟨b, k⟩ := g
-  simp only [d4Mul]
-  refine Prod.mk.injEq.mpr ⟨rfl, ?_⟩
-  apply Fin.ext
-  simp only [Fin.val_mk]
+  simp only [d4Mul, Prod.mk.injEq, Fin.ext_iff, Fin.val_mk, true_and]
   omega
 
 /-- **Right identity**: `(false, 0)` is a right unit for `d4Mul`.
@@ -669,11 +665,8 @@ theorem d4Mul_one_right (g : Bool × Fin 4) :
     d4Mul g (false, 0) = g := by
   obtain ⟨b, k⟩ := g
   cases b <;>
-    (simp only [d4Mul, Bool.not_false]
-     refine Prod.mk.injEq.mpr ⟨rfl, ?_⟩
-     apply Fin.ext
-     simp only [Fin.val_mk]
-     omega)
+    simp only [d4Mul, Bool.not_false, Prod.mk.injEq, Fin.ext_iff, Fin.val_mk, true_and] <;>
+    omega
 
 /-- **Left inverse**: `d4Inv g` is a left inverse of `g` under `d4Mul`.
     Case-split on the reflection bit. For pure rotations
@@ -685,11 +678,9 @@ theorem d4Mul_inv_left (g : Bool × Fin 4) :
     d4Mul (d4Inv g) g = (false, 0) := by
   obtain ⟨b, k⟩ := g
   cases b <;>
-    (simp only [d4Inv, d4Mul, Bool.not_true, ↓reduceIte]
-     refine Prod.mk.injEq.mpr ⟨rfl, ?_⟩
-     apply Fin.ext
-     simp only [Fin.val_mk]
-     omega)
+    simp only [d4Inv, d4Mul, Bool.not_true, Bool.false_eq_true, if_false, ↓reduceIte,
+      Prod.mk.injEq, Fin.ext_iff, Fin.val_mk, true_and] <;>
+    omega
 
 /-- **Right inverse**: `d4Inv g` is a right inverse of `g` under
     `d4Mul`. Symmetric to `d4Mul_inv_left`. -/
@@ -697,10 +688,8 @@ theorem d4Mul_inv_right (g : Bool × Fin 4) :
     d4Mul g (d4Inv g) = (false, 0) := by
   obtain ⟨b, k⟩ := g
   cases b <;>
-    (simp only [d4Inv, d4Mul, Bool.not_true, ↓reduceIte]
-     refine Prod.mk.injEq.mpr ⟨rfl, ?_⟩
-     apply Fin.ext
-     simp only [Fin.val_mk]
-     omega)
+    simp only [d4Inv, d4Mul, Bool.not_true, Bool.false_eq_true, if_false, ↓reduceIte,
+      Prod.mk.injEq, Fin.ext_iff, Fin.val_mk, true_and] <;>
+    omega
 
 end KnightsTourOblique

--- a/src/data/proofs/knights-tour-oblique-oq-01/meta.json
+++ b/src/data/proofs/knights-tour-oblique-oq-01/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None (purely algebraic). The theorem four_oblique_corners is complete: it exhibits 4 distinct tour positions where the turn is oblique. The proof does not depend on native_decide or computational enumeration, unlike the 8×8 case.",
     "dateAdded": "2026-03-30",
-    "lineCount": 512,
+    "lineCount": 561,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Basic",
@@ -147,7 +147,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 512,
+    "lineCount": 561,
     "path": "Proofs/KnightsTourObliqueOQ01.lean",
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/proofs/knights-tour-oblique-oq-02/meta.json
+++ b/src/data/proofs/knights-tour-oblique-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Donald E. Knuth (8×8 oblique result), structural formalization by Lean Genius",
     "sourceUrl": "https://online.stanford.edu/events/202412/donald-knuths-annual-christmas-lecture-2025",
     "date": "2025",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/KnightsTourObliqueOQ02.lean",
     "additionalFiles": [
       "Proofs/KnightsTourObliqueOQ02Reverse.lean"
@@ -20,12 +20,12 @@
       "Knuth",
       "symmetry"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "None beyond Lean's foundational axioms. The Fintype and DecidableEq instances for ClosedTour are noncomputable (built via Fintype.ofInjective / Classical.decEq), so the development uses Classical.choice — a standard foundational axiom (like propext and Quot.sound) that does not count toward axiomCount under the project's axiom-integrity policy. No native_decide is used in either file; every distribution, group-action, and reversal result is proved algebraically (omega, fin_cases, simp, List lemmas). The companion file's reversal results (reverseTour involution, isOblique_comm, isOblique_neg_neg) are fully verified; the full count-invariance capstone obliqueCount (reverseTour t) = obliqueCount t is the documented next step (see open questions).",
+    "axiomCount": 1,
+    "assumptions": "1 effective assumption: Lean.ofReduceBool. The support lower bound obliqueDistribution_zero_below_four lifts the parent's oblique_lower_bound (obliqueCount t ≥ 4), which is established in the base file KnightsTourOblique.lean via native_decide (corner-adjacency case analysis). native_decide trusts the compiler's kernel reduction and therefore depends on Lean.ofReduceBool (confirmed by #print axioms), so this entry transitively carries that assumption and is classified axiomatized per the project's axiom-integrity policy. It does NOT depend on the base file's knuth_unique_four_oblique axiom. The Fintype and DecidableEq instances for ClosedTour are noncomputable (built via Fintype.ofInjective / Classical.decEq), so the development also uses Classical.choice — a standard foundational axiom (like propext and Quot.sound) that does not count toward axiomCount. The D4 group-action results (composition, associativity, identities, inverses) and the companion file's reversal results (reverseTour involution, isOblique_comm, isOblique_neg_neg) are proved algebraically (omega, fin_cases, simp, List lemmas) and are ofReduceBool-free; the full count-invariance capstone obliqueCount (reverseTour t) = obliqueCount t is the documented next step (see open questions).",
     "dateAdded": "2026-06-19",
-    "lineCount": 706,
+    "lineCount": 695,
     "mathlibDependencies": [
       {
         "theorem": "Fintype.ofInjective",
@@ -183,7 +183,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 706,
+    "lineCount": 695,
     "path": "Proofs/KnightsTourObliqueOQ02.lean",
     "axiomCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Repairs the **independent, pre-existing Mathlib drift** in the two
knight's-tour-oblique sibling proofs surfaced by the auditor in #27034.
These are distinct from the base-file regression (#26978, fixed by #27033);
OQ01 is standalone and OQ02's drift is its own.

## Evidence

**Before** (against current Mathlib pin, base olean present):
- `KnightsTourObliqueOQ01.lean` → **73 errors**
- `KnightsTourObliqueOQ02.lean` → **32 errors** (issue reported 17; the merged
  base fix shifted some APIs)

**After**: both `lake env lean …` report **0 errors, 0 sorries**.

`#print axioms KnightsTourObliqueGeneral.four_oblique_corners` →
`[propext, Classical.choice, Quot.sound]` only (no `native_decide` /
`Lean.ofReduceBool`), matching OQ01's `verified` / `mathlib` / `axiomCount: 0`.

## What changed

OQ01 — pure Mathlib-drift repair, **declaration set unchanged**:
- structure field reorder + `getLast`/`head` `≠ []` API; `Fin.val_lt_last` →
  `Fin.isLt`; `or_false` for the trailing `mem_nil` case; `Nodup.get_inj_iff`
  → `getElem_inj_iff`; oblique dot-products via `push_cast`+`ring_nf`.
- The main theorem's **symbolic** modulus `% (n*n)` is beyond `omega` (literal
  divisors only); added reusable `hcyc`/`hpn` modular lemmas + a motive-safe
  `hsqcong` getElem-congruence helper to replace the broken dependent-index
  rewrites.

OQ02 — reuses the previously-reviewed sibling fix (doc-comment/parse, D4 group
laws, `open Classical`) and corrects metadata to `axiomatized` / badge `axiom`
/ `axiomCount: 1` (transitive `Lean.ofReduceBool` from the base file's
`native_decide`, per the axiom-integrity policy).

`lineCount` refreshed for both entries.

Closes #27034

---
Automated fix by lean-mechanic agent.