### PR TITLE
research(cayleys-theorem-oq-01): Cayley's theorem — every group embeds in Sym(G) (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -521,6 +521,7 @@ import Proofs.CayleyHamiltonReductionOQ02
 import Proofs.CayleyHamiltonReductionOQ02OQ01
 import Proofs.CayleyHamiltonReductionOQ02OQ01Aristotle
 import Proofs.CayleyMengerHeronOQ05
+import Proofs.CayleysTheoremOQ01
 import Proofs.CentralLimitTheorem
 import Proofs.CentralLimitTheoremOQ01
 import Proofs.CentralLimitTheoremOQ01OQ01

--- a/proofs/Proofs/CayleysTheoremOQ01.lean
+++ b/proofs/Proofs/CayleysTheoremOQ01.lean
@@ -1,0 +1,89 @@
+import Mathlib.Algebra.Group.Action.End
+import Mathlib.Algebra.Group.Action.Basic
+import Mathlib.Algebra.Group.Subgroup.Ker
+import Mathlib.Tactic
+
+/-
+# Cayley's Theorem
+
+## What This Proves
+
+**Cayley's theorem** is the foundational result of group theory that says every
+abstract group is "concrete": it can be realised as a group of permutations.
+
+Precisely, for any group `G` the **left-regular representation**
+
+    λ : G → Equiv.Perm G,   λ(g) = (x ↦ g * x)
+
+is an injective group homomorphism.  Each `g` acts on the underlying set of `G`
+by left multiplication; this is a bijection (with inverse left multiplication by
+`g⁻¹`), the assignment respects the group law (`λ(g·h) = λ(g) ∘ λ(h)`), and it is
+injective because `λ(g) = λ(h)` evaluated at the identity gives `g·1 = h·1`,
+i.e. `g = h`.
+
+Consequently `G` is isomorphic to its image — a **subgroup of the symmetric
+group** `Sym(G) = Equiv.Perm G`.  In other words, every group embeds into a
+symmetric group.
+
+## Approach
+
+The entire content is already available in Mathlib through the regular
+self-action of a group:
+
+* `MulAction.toPermHom G G : G →* Equiv.Perm G` is the bundled left-regular
+  representation (the self-action `g • x = g * x` comes from `Mul.toSMul`).
+* `MulAction.toPerm_injective` shows the underlying map is injective for any
+  *faithful* action, and the self-action of a group is faithful via
+  `RightCancelMonoid.faithfulSMul` (a group is right-cancellative).
+* `MulEquiv.ofInjective` upgrades the injective hom to an isomorphism onto its
+  range, giving the "isomorphic to a subgroup of `Sym(G)`" form.
+
+No `decide`/`native_decide` is used, so the proof is axiom-free (only Mathlib's
+foundational `propext`/`Classical.choice`/`Quot.sound`).
+
+## Distinctness
+
+Despite the shared name, this is **not** the Cayley–Hamilton theorem (a matrix
+identity, of which the gallery has many entries).  The group-theoretic Cayley
+theorem — every group is a permutation group — is absent from the gallery.
+-/
+
+namespace CayleysTheoremOQ01
+
+variable (G : Type*) [Group G]
+
+/-- **The left-regular representation** as a bundled group homomorphism
+`G →* Equiv.Perm G`.  It sends `g` to the permutation of (the underlying set of)
+`G` given by left multiplication `x ↦ g * x`.  This is exactly the regular
+self-action `MulAction.toPermHom G G`. -/
+abbrev leftRegular : G →* Equiv.Perm G := MulAction.toPermHom G G
+
+/-- The left-regular representation sends `g` to left multiplication `x ↦ g * x`. -/
+theorem leftRegular_apply (g x : G) : leftRegular G g x = g * x := rfl
+
+/-- **Cayley's theorem (injectivity form).** The left-regular representation
+`G →* Equiv.Perm G` is injective: distinct group elements act as distinct
+permutations.  This is the heart of Cayley's theorem. -/
+theorem leftRegular_injective : Function.Injective (leftRegular G) := by
+  simpa only [leftRegular, MulAction.coe_toPermHom] using
+    (MulAction.toPerm_injective (α := G) (β := G))
+
+/-- **Cayley's theorem (existence form).** Every group `G` admits an injective
+homomorphism into the symmetric group `Equiv.Perm G` on its own underlying set —
+equivalently, `G` is (isomorphic to) a permutation group. -/
+theorem cayley : ∃ f : G →* Equiv.Perm G, Function.Injective f :=
+  ⟨leftRegular G, leftRegular_injective G⟩
+
+/-- **Cayley's theorem (subgroup-embedding form).** `G` is isomorphic to a
+subgroup of the symmetric group `Equiv.Perm G`, namely the range of its
+left-regular representation. -/
+noncomputable def cayleyEquivRange : G ≃* (leftRegular G).range :=
+  MonoidHom.ofInjective (leftRegular_injective G)
+
+/-- The embedding `cayleyEquivRange` is given on elements by `g ↦ left-regular g`,
+realising `G` concretely as the subgroup of permutations of the form `x ↦ g * x`. -/
+theorem cayleyEquivRange_apply (g : G) :
+    (cayleyEquivRange G g : Equiv.Perm G) = leftRegular G g :=
+  MonoidHom.ofInjective_apply (leftRegular_injective G)
+
+end CayleysTheoremOQ01

--- a/src/data/proofs/cayleys-theorem-oq-01/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "cayleys-theorem-oq-01",
+  "title": "Cayley's Theorem",
+  "slug": "cayleys-theorem-oq-01",
+  "description": "Cayley's theorem: every group G is isomorphic to a group of permutations. The left-regular representation λ : G →* Equiv.Perm G, λ(g) = (x ↦ g·x), is an injective group homomorphism, so G embeds into the symmetric group Sym(G) on its own underlying set and is isomorphic to a subgroup of it (the range of λ). The proof routes through Mathlib's regular self-action: leftRegular = MulAction.toPermHom G G, injectivity from MulAction.toPerm_injective under the faithful self-action RightCancelMonoid.faithfulSMul (a group is right-cancellative), and the subgroup embedding from MonoidHom.ofInjective. Three theorems — the injectivity form, the existence form (∃ injective f : G →* Equiv.Perm G), and the subgroup-embedding isomorphism G ≃* (leftRegular G).range — plus the explicit action description λ(g)(x) = g·x. Despite the shared name this is NOT Cayley–Hamilton (the matrix identity); the group-theoretic Cayley theorem is absent from the gallery.",
+  "meta": {
+    "author": "Arthur Cayley (1854); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cayley%27s_theorem",
+    "date": "1854",
+    "status": "verified",
+    "tags": [
+      "group-theory",
+      "cayley",
+      "permutation-group",
+      "symmetric-group",
+      "regular-representation",
+      "group-action",
+      "embedding",
+      "algebra",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CayleysTheoremOQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.toPermHom",
+        "description": "G →* Equiv.Perm G for a group acting on a set — instantiated at the regular self-action (g • x = g * x from Mul.toSMul) to give the left-regular representation",
+        "module": "Mathlib.Algebra.Group.Action.End"
+      },
+      {
+        "theorem": "MulAction.toPerm_injective",
+        "description": "the underlying map G → Equiv.Perm G of a faithful action is injective — supplies the heart of Cayley's theorem",
+        "module": "Mathlib.Algebra.Group.Action.Basic"
+      },
+      {
+        "theorem": "RightCancelMonoid.faithfulSMul",
+        "description": "the regular self-action of a right-cancellative monoid (in particular a group) is faithful — discharges the FaithfulSMul G G hypothesis automatically by instance resolution",
+        "module": "Mathlib.Algebra.Group.Action.Faithful"
+      },
+      {
+        "theorem": "MonoidHom.ofInjective",
+        "description": "an injective group hom f : G →* N yields an isomorphism G ≃* f.range — upgrades injectivity to the subgroup-embedding form",
+        "module": "Mathlib.Algebra.Group.Subgroup.Ker"
+      }
+    ],
+    "originalContributions": [
+      "leftRegular_injective: Function.Injective (MulAction.toPermHom G G) — Cayley's theorem in injectivity form, the left-regular representation distinguishes group elements",
+      "cayley: ∃ f : G →* Equiv.Perm G, Function.Injective f — the textbook existence statement that every group embeds in a symmetric group",
+      "cayleyEquivRange: G ≃* (leftRegular G).range — G is isomorphic to a subgroup of Sym(G), namely the image of the left-regular representation",
+      "leftRegular_apply / cayleyEquivRange_apply: the embedding is concretely g ↦ (x ↦ g·x)"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 89,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Cayley's theorem, published by Arthur Cayley in 1854 in his work on the theory of groups, was one of the first results to make precise the modern, abstract notion of a group. By exhibiting every group as a group of permutations of its own elements, it showed that the axiomatic 'abstract group' is no more general than the concrete permutation groups studied by Galois and Cauchy — the abstract and concrete viewpoints coincide. It is the prototypical 'representation theorem': it represents an arbitrary group faithfully inside a symmetric group, foreshadowing later representation theory (where one represents groups by matrices rather than permutations).",
+    "problemStatement": "**Open Question (cayleys-theorem-oq-01)**: Formalize Cayley's theorem — every group G is isomorphic to a group of permutations of G.\n\n**Result**: leftRegular_injective (the left-regular representation G →* Equiv.Perm G is injective), cayley (∃ injective f : G →* Equiv.Perm G), and cayleyEquivRange (G ≃* (leftRegular G).range, the subgroup-embedding form), with the explicit description λ(g)(x) = g·x.",
+    "text": "For any group G, the map sending g to the permutation x ↦ g·x of G is an injective group homomorphism G →* Equiv.Perm G. Hence G is isomorphic to its image, a subgroup of the symmetric group Sym(G): every group is (concretely) a permutation group.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. The left-regular representation is Mathlib's regular self-action homomorphism: leftRegular G := MulAction.toPermHom G G, where the action g • x = g * x comes from Mul.toSMul. By construction it is a MonoidHom (map_one = one_smul, map_mul = mul_smul) and leftRegular G g x = g * x by rfl.\n2. Injectivity (the heart of the theorem): MulAction.toPerm_injective shows the underlying map of a faithful action is injective. The self-action of a group is faithful — RightCancelMonoid.faithfulSMul gives FaithfulSMul G G because g·1 = h·1 ⟹ g = h by right cancellation — so the hypothesis is discharged by instance resolution. After rewriting the bundled-hom coercion with MulAction.coe_toPermHom, simpa closes leftRegular_injective.\n3. The existence form cayley packages ⟨leftRegular G, leftRegular_injective G⟩.\n4. The subgroup-embedding form cayleyEquivRange applies MonoidHom.ofInjective to the injective hom, producing the isomorphism G ≃* (leftRegular G).range; MonoidHom.ofInjective_apply records that on elements it is still g ↦ leftRegular g.",
+    "keyInsights": [
+      "**Faithfulness is the whole content.** Once the left-regular representation is recognised as a group action, Cayley's theorem reduces to a single fact: the regular self-action is faithful, i.e. g·1 = h·1 forces g = h. Mathlib packages this as RightCancelMonoid.faithfulSMul, found automatically by typeclass resolution.",
+      "**Reuse the bundled action.** Rather than hand-build the homomorphism and check map_one/map_mul, the proof instantiates MulAction.toPermHom G G at the self-action, inheriting the homomorphism structure for free.",
+      "**Three faces of one theorem.** Injectivity of a hom, existence of an embedding, and isomorphism onto a subgroup are equivalent packagings; MonoidHom.ofInjective converts the first into the last (G ≃* range), which is the form 'isomorphic to a subgroup of a permutation group'.",
+      "**Not Cayley–Hamilton.** The gallery has many Cayley–Hamilton (matrix) entries; the group-theoretic Cayley theorem — every group is a permutation group — is a distinct result and was absent."
+    ],
+    "prerequisites": [
+      "Group actions and the bundled permutation representation MulAction.toPermHom",
+      "Faithful actions and FaithfulSMul, with the cancellation property of groups",
+      "First-isomorphism-style packaging MonoidHom.ofInjective : injective f ↦ (G ≃* f.range)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Module docstring stating Cayley's theorem and the left-regular representation, imports for the regular self-action / injectivity / range-isomorphism lemmas, and the namespace with the group variable G.",
+      "mathContext": "$\\lambda : G \\to \\operatorname{Sym}(G),\\ \\lambda(g) = (x \\mapsto g x)$ is an injective homomorphism."
+    },
+    {
+      "id": "left-regular",
+      "title": "The Left-Regular Representation",
+      "startLine": 62,
+      "endLine": 70,
+      "summary": "leftRegular G := MulAction.toPermHom G G, the bundled homomorphism G →* Equiv.Perm G, with leftRegular_apply : leftRegular G g x = g * x (by rfl) pinning down the explicit action.",
+      "mathContext": "$\\lambda(g)(x) = g \\cdot x$."
+    },
+    {
+      "id": "injective",
+      "title": "Cayley's Theorem (Injectivity Form)",
+      "startLine": 72,
+      "endLine": 78,
+      "summary": "leftRegular_injective: the left-regular representation is injective, via MulAction.toPerm_injective under the faithful self-action (RightCancelMonoid.faithfulSMul), after rewriting the coercion with MulAction.coe_toPermHom.",
+      "mathContext": "$\\lambda(g) = \\lambda(h) \\Rightarrow g = h$ (evaluate at the identity)."
+    },
+    {
+      "id": "embedding",
+      "title": "Existence and Subgroup-Embedding Forms",
+      "startLine": 80,
+      "endLine": 89,
+      "summary": "cayley: ∃ injective f : G →* Equiv.Perm G; cayleyEquivRange: G ≃* (leftRegular G).range via MonoidHom.ofInjective; cayleyEquivRange_apply records that the iso is still g ↦ leftRegular g.",
+      "mathContext": "$G \\cong \\operatorname{im}(\\lambda) \\le \\operatorname{Sym}(G)$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "Shares the name Cayley but is a different theorem: Cayley–Hamilton is the matrix identity p_A(A) = 0, whereas this is the group-theoretic Cayley theorem that every group is a permutation group"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) proof of Cayley's theorem: the left-regular representation G →* Equiv.Perm G is injective (leftRegular_injective), every group therefore embeds in a symmetric group (cayley), and G is isomorphic to a subgroup of Sym(G), namely the range of the representation (cayleyEquivRange).",
+    "implications": "Realises every abstract group concretely as a permutation group — the prototypical faithful representation theorem — by reducing the statement to faithfulness of the regular self-action, a single cancellation fact supplied by Mathlib's typeclass infrastructure.",
+    "openQuestions": [
+      "Refine the codomain: when G is finite of order n, exhibit the embedding into the finite symmetric group Equiv.Perm (Fin n) (G ↪ Sₙ), the classical finite form of Cayley's theorem.",
+      "Prove the right-regular / conjugation companions and the regular representation's image is a regular (sharply transitive) subgroup of Sym(G)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.Group.Action.End",
+      "Mathlib.Algebra.Group.Action.Basic",
+      "Mathlib.Algebra.Group.Subgroup.Ker",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "CayleysTheoremOQ01",
+    "lineCount": 89,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/CayleysTheoremOQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cayley, Arthur",
+      "title": "On the theory of groups, as depending on the symbolic equation θⁿ = 1",
+      "year": "1854",
+      "venue": "Philosophical Magazine, Series 4, 7(42)",
+      "note": "Original statement that every group can be represented as a group of permutations"
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley (3rd ed.)",
+      "note": "Cayley's theorem via the left-regular representation and the action on cosets"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Cayley's Theorem (group-theoretic) — `cayleys-theorem-oq-01`

Formalizes **Cayley's theorem**: every group `G` is isomorphic to a group of permutations of its own elements. The left-regular representation

```
λ : G →* Equiv.Perm G,   λ(g) = (x ↦ g * x)
```

is an injective group homomorphism, so `G` embeds into the symmetric group `Sym(G)` and is isomorphic to a subgroup of it.

**This is NOT Cayley–Hamilton** (the matrix identity, of which the gallery has many entries). The group-theoretic Cayley theorem was absent from the gallery.

### Results (`Proofs/CayleysTheoremOQ01.lean`)
- `leftRegular_apply` — the representation is explicitly `g ↦ (x ↦ g·x)`
- `leftRegular_injective` — `Function.Injective (MulAction.toPermHom G G)` (the heart of the theorem)
- `cayley` — `∃ f : G →* Equiv.Perm G, Function.Injective f` (textbook existence form)
- `cayleyEquivRange` — `G ≃* (leftRegular G).range` (subgroup-embedding form)
- `cayleyEquivRange_apply` — the iso is still `g ↦ leftRegular g`

### Proof route
Mathlib's regular self-action: `MulAction.toPermHom G G` is the bundled hom; faithfulness of the self-action via `RightCancelMonoid.faithfulSMul` discharges `FaithfulSMul G G` by instance resolution; injectivity from `MulAction.toPerm_injective`; range isomorphism from `MonoidHom.ofInjective`.

### Verification
- **0 sorries, 0 axioms** — `#print axioms` on all 5 declarations lists only foundational `propext` / `Classical.choice` / `Quot.sound`.
- No `decide`/`native_decide`.
- Compiles against pinned Mathlib 4.26.0 (`lake env lean Proofs/CayleysTheoremOQ01.lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)