### PR TITLE
research(liouville-theorem-oq-05): Liouville numbers are Lebesgue-null + the measure–category duality (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2750,6 +2750,7 @@ import Proofs.LeibnizPiOQ02Aristotle
 import Proofs.LeibnizPiOQ03
 import Proofs.LiouvilleTheorem
 import Proofs.LiouvilleTheoremOQ04
+import Proofs.LiouvilleTheoremOQ05
 import Proofs.LovaszLocalLemma
 import Proofs.LovaszLocalLemmaOQ02
 import Proofs.LovaszLocalLemmaOQ02Aristotle

--- a/proofs/Proofs/LiouvilleTheoremOQ05.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ05.lean
@@ -1,0 +1,100 @@
+/-
+Liouville's Theorem OQ-05: The Measure–Category Duality of Liouville Numbers
+
+The parent Liouville family establishes that Liouville numbers are transcendental,
+form an *uncountable*, indeed *residual* (comeagre, topologically "large") subset
+of ℝ, and is closed under translation/scaling by rationals. What it states only as
+prose (PART VI, "Borel, 1909") is the measure-theoretic counterpoint:
+
+  • Borel's theorem.   The set of Liouville numbers has **Lebesgue measure zero**.
+  • Typicality.        **Almost every** real number fails to be Liouville.
+
+Putting these alongside the topological facts produces one of the cleanest
+instances of the **measure–category duality**: the real line splits into two
+complementary pieces, each "large" in one sense and "small" in the other.
+
+  • The Liouville numbers are residual (comeagre) yet Lebesgue-null.
+  • Dually, the non-Liouville numbers are meagre yet of full measure.
+
+So "topologically generic" (residual) and "measure-typical" (almost-everywhere)
+are genuinely different notions of largeness: the two filters `residual ℝ` and
+`ae volume` are **disjoint**. The same dichotomy underlies the Erdős–Sierpiński
+duality; the Liouville set is the textbook witness.
+
+Main results:
+  • `volume_liouville_eq_zero`   — Borel: `volume {x | Liouville x} = 0`.
+  • `ae_not_liouville'`          — almost every real number is not Liouville.
+  • `exists_residual_null`       — a residual set of measure zero exists (Liouville).
+  • `exists_meagre_conull`       — dually, a meagre set whose complement is null.
+  • `residual_ae_disjoint`       — `Disjoint (residual ℝ) (ae volume)` (the duality).
+  Plus the explicit "large yet null" packaging `liouville_residual_and_null`.
+
+All results are `sorry`-free and axiom-free (no `native_decide`); they assemble
+Mathlib's `volume_setOf_liouville`, `ae_not_liouville`, `eventually_residual_liouville`,
+and `Real.disjoint_residual_ae` into the duality statement, formalizing the
+measure-zero claim the gallery previously carried only as a comment.
+
+References:
+- Mathlib `Mathlib/NumberTheory/Transcendental/Liouville/Measure.lean` and `Residual.lean`.
+- É. Borel, *Les probabilités dénombrables et leurs applications arithmétiques* (1909).
+- Oxtoby, *Measure and Category* (measure–category duality).
+-/
+
+import Mathlib.NumberTheory.Transcendental.Liouville.Measure
+import Mathlib.NumberTheory.Transcendental.Liouville.Residual
+import Mathlib.Tactic
+
+open MeasureTheory Filter Set
+
+namespace LiouvilleTheoremOQ05
+
+/-! ### Borel's theorem: the Liouville set is Lebesgue-null -/
+
+/-- **Borel (1909).** The set of Liouville numbers has Lebesgue measure zero. This
+is the measure-theoretic counterpart to the parent entry's topological results, and
+formalizes the claim previously stated only as prose. -/
+theorem volume_liouville_eq_zero : volume {x : ℝ | Liouville x} = 0 :=
+  volume_setOf_liouville
+
+/-- **Almost every real number is not a Liouville number.** Equivalently, the
+non-Liouville reals are co-null (form a set of full measure). -/
+theorem ae_not_liouville' : ∀ᵐ x : ℝ, ¬ Liouville x :=
+  ae_not_liouville
+
+/-! ### The Liouville set: residual yet null -/
+
+/-- The Liouville numbers are *both* residual (comeagre — topologically generic)
+*and* Lebesgue-null. This is the key tension exploited below. -/
+theorem liouville_residual_and_null :
+    {x : ℝ | Liouville x} ∈ residual ℝ ∧ volume {x : ℝ | Liouville x} = 0 :=
+  ⟨eventually_residual_liouville, volume_setOf_liouville⟩
+
+/-- **A residual set of measure zero exists.** Topological genericity does not
+imply measure-typicality: the Liouville numbers are comeagre yet null. -/
+theorem exists_residual_null : ∃ S : Set ℝ, S ∈ residual ℝ ∧ volume S = 0 :=
+  ⟨{x : ℝ | Liouville x}, eventually_residual_liouville, volume_setOf_liouville⟩
+
+/-! ### The dual: a meagre set of full measure -/
+
+/-- **A meagre set whose complement is null exists** (equivalently, a meagre set of
+full measure). Dually to `exists_residual_null`, measure-typicality does not imply
+topological genericity: the non-Liouville reals are meagre yet co-null. The witness
+is the complement of the Liouville set. -/
+theorem exists_meagre_conull : ∃ S : Set ℝ, IsMeagre S ∧ volume Sᶜ = 0 := by
+  refine ⟨{x : ℝ | Liouville x}ᶜ, ?_, ?_⟩
+  · -- `IsMeagre Sᶜ` unfolds to `Sᶜᶜ ∈ residual ℝ`, i.e. `{Liouville} ∈ residual ℝ`.
+    rw [IsMeagre, compl_compl]
+    exact eventually_residual_liouville
+  · rw [compl_compl]
+    exact volume_setOf_liouville
+
+/-! ### Measure–category duality -/
+
+/-- **Measure–category duality.** The filters `residual ℝ` (topological genericity)
+and `ae volume` (measure-typicality) are *disjoint*: no nonempty property can be both
+comeagre and almost-everywhere. The disjointness is witnessed concretely by the
+Liouville set, which is residual while its complement is co-null. -/
+theorem residual_ae_disjoint : Disjoint (residual ℝ) (ae volume) :=
+  Real.disjoint_residual_ae
+
+end LiouvilleTheoremOQ05

--- a/src/data/proofs/liouville-theorem-oq-05/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-05/meta.json
@@ -1,0 +1,184 @@
+{
+  "id": "liouville-theorem-oq-05",
+  "title": "Liouville Numbers: Measure Zero and the Measure–Category Duality",
+  "slug": "liouville-theorem-oq-05",
+  "description": "The parent Liouville family proves that Liouville numbers are transcendental, uncountable, residual (comeagre), and stable under rational translation/scaling, but it states the measure-theoretic counterpart only as prose ('Borel, 1909'). This entry formalizes it: the set of Liouville numbers has Lebesgue measure zero (volume_setOf_liouville), so almost every real number fails to be Liouville (ae_not_liouville). Placed alongside the topological facts, this yields a sharp instance of the measure–category duality. The Liouville numbers are residual yet Lebesgue-null (exists_residual_null), and dually the non-Liouville numbers are meagre yet of full measure (exists_meagre_conull). The two notions of largeness are genuinely incompatible: the filters residual ℝ and ae volume are disjoint (Real.disjoint_residual_ae). All results are 0-axiom, 0-sorry, assembling Mathlib's measure and residual lemmas into the duality statement the gallery previously carried only as a comment.",
+  "meta": {
+    "author": "É. Borel (1909) / J. C. Oxtoby (measure–category); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Liouville_number",
+    "date": "1909",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "measure-theory",
+      "liouville",
+      "transcendental",
+      "diophantine",
+      "baire-category",
+      "measure-category-duality",
+      "lebesgue-measure",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/LiouvilleTheoremOQ05.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "volume_setOf_liouville",
+        "description": "volume {x : ℝ | Liouville x} = 0 — Borel's theorem that the Liouville set is Lebesgue-null; the measure-theoretic core of this entry",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Measure"
+      },
+      {
+        "theorem": "ae_not_liouville",
+        "description": "∀ᵐ x : ℝ, ¬ Liouville x — almost every real number is not a Liouville number (the conull complement)",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Measure"
+      },
+      {
+        "theorem": "eventually_residual_liouville",
+        "description": "∀ᶠ x in residual ℝ, Liouville x — the Liouville set is residual (comeagre); definitionally {x | Liouville x} ∈ residual ℝ",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Residual"
+      },
+      {
+        "theorem": "Real.disjoint_residual_ae",
+        "description": "Disjoint (residual ℝ) (ae volume) — the measure–category duality: topological genericity and measure-typicality are incompatible filters",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Measure"
+      },
+      {
+        "theorem": "IsMeagre",
+        "description": "IsMeagre s := sᶜ ∈ residual X — used to phrase the dual meagre-yet-conull statement; compl_compl bridges {Liouville}ᶜ back to the residual Liouville set",
+        "module": "Mathlib.Topology.GDelta.Basic"
+      }
+    ],
+    "originalContributions": [
+      "volume_liouville_eq_zero: volume {x : ℝ | Liouville x} = 0 — formalizes the measure-zero claim the gallery's parent entry stated only as a prose comment ('Borel 1909')",
+      "ae_not_liouville': ∀ᵐ x : ℝ, ¬ Liouville x — almost every real is not Liouville (the measure-typical side)",
+      "liouville_residual_and_null: the Liouville set is simultaneously residual and Lebesgue-null — the explicit tension at the heart of the duality",
+      "exists_residual_null: ∃ S, S ∈ residual ℝ ∧ volume S = 0 — a residual (topologically large) set of measure zero exists, witnessed by the Liouville numbers",
+      "exists_meagre_conull: ∃ S, IsMeagre S ∧ volume Sᶜ = 0 — dually, a meagre set of full measure exists (the non-Liouville reals)",
+      "residual_ae_disjoint: Disjoint (residual ℝ) (ae volume) — the measure–category duality stated as filter disjointness"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 100,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which are not counted). No decide/native_decide is used.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Liouville (1844) constructed the first explicit transcendental numbers; the set of all such 'Liouville numbers' was later shown to be both topologically large and measure-theoretically negligible. Baire-category theory makes the Liouville set residual (comeagre, hence 'generic' in ℝ), while Borel (1909) showed it has Lebesgue measure zero. The coexistence of these two facts is the classic illustration that Baire category and Lebesgue measure are inequivalent notions of 'almost all' — the theme of Oxtoby's monograph *Measure and Category* and the Erdős–Sierpiński duality. The parent gallery entry establishes the topological side (uncountable, residual) and remarks on the measure side only in prose; this entry formalizes the measure side and packages the duality.",
+    "problemStatement": "**Open Question (liouville-theorem-oq-05)**: Formalize that the set of Liouville numbers has Lebesgue measure zero, and combine it with the known residuality to state the measure–category duality.\n\n**Result**: volume_liouville_eq_zero (volume {x | Liouville x} = 0) and ae_not_liouville', together with exists_residual_null, exists_meagre_conull, and residual_ae_disjoint expressing the duality.",
+    "text": "The set {x : ℝ | Liouville x} has Lebesgue measure zero, so almost every real number is not Liouville. Yet the same set is residual (comeagre). Hence there is a residual set of measure zero, and dually a meagre set of full measure; the filters residual ℝ and ae volume are disjoint.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. The measure-zero core is Mathlib's volume_setOf_liouville (proved from ae_not_liouville via ae_iff). volume_liouville_eq_zero and ae_not_liouville' re-expose these as the entry's headline facts.\n2. Residuality is Mathlib's eventually_residual_liouville, which is definitionally the membership {x | Liouville x} ∈ residual ℝ.\n3. exists_residual_null packages residuality together with measure-zero as a witnessing existential: the Liouville set is the explicit residual null set.\n4. exists_meagre_conull is the dual. Taking S = {x | Liouville x}ᶜ, unfolding IsMeagre to Sᶜ ∈ residual ℝ and rewriting Sᶜ = {x | Liouville x} by compl_compl reduces the first goal to eventually_residual_liouville; the second goal volume Sᶜ = 0 is volume_setOf_liouville after the same compl_compl.\n5. residual_ae_disjoint is Mathlib's Real.disjoint_residual_ae, the filter-level statement of the duality, whose very existence is witnessed by the Liouville set produced in the previous steps.",
+    "keyInsights": [
+      "**Two largenesses, one set.** The Liouville numbers are residual (Baire-generic) and simultaneously Lebesgue-null — a single set that is 'large' topologically and 'small' measure-theoretically.",
+      "**Borel's theorem, formalized.** The parent entry asserts 'measure zero (Borel, 1909)' only in a comment; volume_liouville_eq_zero turns that prose into a checked theorem.",
+      "**Disjoint filters.** residual ℝ and ae volume share no common large set: this is exactly why 'comeagre' and 'almost everywhere' are independent notions, and the Liouville set is the standard witness.",
+      "**The dual is automatic.** Complementation turns the residual null Liouville set into a meagre conull set of non-Liouville reals, via the definitional IsMeagre s := sᶜ ∈ residual and compl_compl."
+    ],
+    "prerequisites": [
+      "The Liouville predicate and the fact (Mathlib) that the Liouville set is residual and Lebesgue-null",
+      "Baire category vocabulary: residual (comeagre) sets and IsMeagre s := sᶜ ∈ residual",
+      "The almost-everywhere filter ae volume and the meaning of Disjoint for filters"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring framing the measure–category duality, contrasting the parent entry's topological results with the measure-zero counterpart, and the targeted Liouville Measure/Residual imports plus the open MeasureTheory Filter Set setup.",
+      "mathContext": "$\\mathrm{volume}\\,\\{x\\in\\mathbb{R}\\mid \\text{Liouville } x\\}=0$ versus residuality of the same set."
+    },
+    {
+      "id": "measure-zero",
+      "title": "Borel's Theorem: Measure Zero",
+      "startLine": 51,
+      "endLine": 62,
+      "summary": "volume_liouville_eq_zero (the Liouville set is Lebesgue-null) and ae_not_liouville' (almost every real is not Liouville), re-exposing Mathlib's volume_setOf_liouville and ae_not_liouville as headline facts.",
+      "mathContext": "$\\mathrm{volume}\\,\\{x\\mid \\text{Liouville } x\\}=0$ and $\\forall^{\\mathrm{ae}} x,\\ \\neg\\,\\text{Liouville } x$."
+    },
+    {
+      "id": "residual-null",
+      "title": "Residual yet Null",
+      "startLine": 64,
+      "endLine": 75,
+      "summary": "liouville_residual_and_null records that the Liouville set is both residual and null; exists_residual_null packages this as an existential witness — a topologically large set of Lebesgue measure zero.",
+      "mathContext": "$\\exists S,\\ S\\in\\mathrm{residual}\\,\\mathbb{R}\\ \\wedge\\ \\mathrm{volume}\\,S=0$."
+    },
+    {
+      "id": "meagre-conull",
+      "title": "The Dual: Meagre yet Full Measure",
+      "startLine": 77,
+      "endLine": 89,
+      "summary": "exists_meagre_conull: the non-Liouville reals form a meagre set whose complement is null. Proof unfolds IsMeagre to Sᶜ ∈ residual and uses compl_compl to reduce to eventually_residual_liouville and volume_setOf_liouville.",
+      "mathContext": "$\\exists S,\\ \\mathrm{IsMeagre}\\,S\\ \\wedge\\ \\mathrm{volume}\\,S^{c}=0$."
+    },
+    {
+      "id": "duality",
+      "title": "Measure–Category Duality",
+      "startLine": 91,
+      "endLine": 99,
+      "summary": "residual_ae_disjoint: the filters residual ℝ and ae volume are disjoint (Mathlib's Real.disjoint_residual_ae), the filter-level statement of the duality witnessed concretely by the Liouville set.",
+      "mathContext": "$\\mathrm{Disjoint}\\,(\\mathrm{residual}\\,\\mathbb{R})\\,(\\mathrm{ae}\\,\\mathrm{volume})$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "liouville-theorem",
+      "relationship": "complements",
+      "description": "The parent Liouville entry proves transcendence, uncountability, and residuality of the Liouville set and states measure-zero only as a prose comment; this entry formalizes the measure-zero theorem and the measure–category duality."
+    },
+    {
+      "targetId": "liouville-theorem-oq-04",
+      "relationship": "sibling",
+      "description": "OQ-04 extends Liouville approximation to the p-adic setting; this OQ-05 entry stays over ℝ and develops the measure-theoretic / Baire-category dimension absent from the rest of the family."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization that the Liouville set is Lebesgue-null, together with the measure–category duality: a residual set of measure zero and, dually, a meagre set of full measure, with the filters residual ℝ and ae volume disjoint.",
+    "implications": "Adds the measure-theoretic half of the Liouville story to the formalized record — previously present only as prose — and exhibits the standard witness separating Baire category from Lebesgue measure.",
+    "openQuestions": [
+      "Formalize that almost every real number is transcendental (the algebraic numbers are Lebesgue-null), giving the measure-theoretic companion to the residuality of transcendentals.",
+      "State and prove a quantitative version: for s > 0 the set of s-Liouville (well-approximable to order 2+s) numbers is null, via the volume_iUnion_setOf_liouvilleWith bound.",
+      "Formalize the Erdős–Sierpiński duality as an explicit measure-preserving/category-preserving involution swapping the two notions of largeness."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Transcendental.Liouville.Measure",
+      "Mathlib.NumberTheory.Transcendental.Liouville.Residual",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Filter",
+      "Set"
+    ],
+    "namespace": "LiouvilleTheoremOQ05",
+    "lineCount": 100,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/LiouvilleTheoremOQ05.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Borel, É.",
+      "title": "Les probabilités dénombrables et leurs applications arithmétiques",
+      "year": "1909",
+      "venue": "Rendiconti del Circolo Matematico di Palermo",
+      "note": "The set of Liouville numbers has Lebesgue measure zero"
+    },
+    {
+      "authors": "Oxtoby, J. C.",
+      "title": "Measure and Category",
+      "year": "1980",
+      "venue": "Springer GTM 2",
+      "note": "The duality between Baire category and Lebesgue measure; Liouville numbers as the standard witness"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/liouville-theorem-oq-05.json
+++ b/src/data/research/problems/liouville-theorem-oq-05.json
@@ -1,0 +1,66 @@
+{
+  "slug": "liouville-theorem-oq-05",
+  "title": "Liouville Numbers Have Lebesgue Measure Zero",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "tractability": 8,
+  "significance": 7,
+  "tags": [
+    "number-theory",
+    "measure-theory",
+    "liouville",
+    "transcendence",
+    "baire-category",
+    "research"
+  ],
+  "started": "2026-06-20",
+  "lastUpdate": "2026-06-20",
+  "path": "Proofs/LiouvilleTheoremOQ05.lean",
+  "leanFiles": [
+    "Proofs/LiouvilleTheoremOQ05.lean"
+  ],
+  "problemStatement": "Formalize that the set of Liouville numbers has Lebesgue measure zero (the parent family states this only as prose, 'Borel 1909'), and combine it with the known residuality to state the measure-category duality: a residual set of measure zero exists, dually a meagre set of full measure, and the filters residual ℝ and ae volume are disjoint.",
+  "currentState": "SOLVED. Six 0-axiom, 0-sorry theorems compiled against pinned Mathlib 4.26.0 via `lake env lean`: volume_liouville_eq_zero, ae_not_liouville', liouville_residual_and_null, exists_residual_null, exists_meagre_conull, residual_ae_disjoint.",
+  "knowledge": {
+    "insights": [
+      "The measure-zero result was present in the gallery ONLY as a prose comment ('Borel 1909, measure zero') in LiouvilleTheorem.lean PART VI; no formal theorem existed. The family had zero measure-theoretic declarations.",
+      "Mathlib's volume_setOf_liouville, ae_not_liouville, eventually_residual_liouville, and Real.disjoint_residual_ae are all in root namespace (module NumberTheory.Transcendental.Liouville.Measure/Residual) and require no Fact instances.",
+      "eventually_residual_liouville : ∀ᶠ x in residual ℝ, Liouville x is DEFINITIONALLY {x | Liouville x} ∈ residual ℝ, so it slots directly into existential witnesses needing residual membership.",
+      "IsMeagre s := sᶜ ∈ residual X (Topology.GDelta.Basic). The dual meagre-yet-conull statement is obtained from the residual null Liouville set purely by compl_compl, no new mathematics.",
+      "The entry is mostly an assembly/wrapper around Mathlib lemmas; its value is (a) formalizing the prose measure-zero claim and (b) packaging the measure-category duality as explicit existentials — honest framing, not a deep new proof."
+    ],
+    "builtItems": [
+      "volume_liouville_eq_zero (Proofs/LiouvilleTheoremOQ05.lean:56) — volume {x | Liouville x} = 0",
+      "ae_not_liouville' (:61) — ∀ᵐ x, ¬ Liouville x",
+      "liouville_residual_and_null (:68) — residual ∧ null",
+      "exists_residual_null (:74) — ∃ S ∈ residual ℝ, volume S = 0",
+      "exists_meagre_conull (:83) — ∃ S, IsMeagre S ∧ volume Sᶜ = 0 (via compl_compl)",
+      "residual_ae_disjoint (:97) — Disjoint (residual ℝ) (ae volume)"
+    ],
+    "mathlibGaps": [
+      "None blocking. All ingredients exist in Mathlib 4.26.0; the gap was purely in the gallery (no formalized measure statement)."
+    ],
+    "nextSteps": [
+      "Formalize that the algebraic reals are Lebesgue-null ⇒ a.e. real is transcendental, the measure companion to residuality of transcendentals.",
+      "Quantitative version: for s>0 the s-Liouville (well-approximable to order 2+s) reals are null, via volume_iUnion_setOf_liouvilleWith.",
+      "Erdős–Sierpiński duality as an explicit involution swapping category and measure."
+    ],
+    "progressSummary": "COMPLETE: measure-zero + measure-category duality formalized, 0 axioms / 0 sorries."
+  },
+  "knownResults": [
+    "Liouville numbers are residual/comeagre (eventually_residual_liouville).",
+    "Liouville numbers are Lebesgue-null (Borel 1909; Mathlib volume_setOf_liouville).",
+    "residual ℝ and ae volume are disjoint filters (Real.disjoint_residual_ae)."
+  ],
+  "references": [
+    "É. Borel, Les probabilités dénombrables et leurs applications arithmétiques (1909)",
+    "J. C. Oxtoby, Measure and Category, Springer GTM 2 (1980)"
+  ],
+  "relatedProofs": [
+    "liouville-theorem",
+    "liouville-theorem-oq-04"
+  ],
+  "significanceNote": "Supplies the measure-theoretic half of the Liouville story (previously prose only) and the standard witness separating Baire category from Lebesgue measure.",
+  "tractabilityNote": "Assembly of existing Mathlib lemmas; the only non-trivial step is the compl_compl manipulation for the meagre-conull dual."
+}


### PR DESCRIPTION
## Summary

Formalizes the **measure-theoretic** half of the Liouville story, which the parent gallery family (`liouville-theorem`) carried only as a **prose comment** ("Borel, 1909 — measure zero"). The family previously had **zero** measure-theoretic declarations; OQ-04 is p-adic.

Six 0-axiom, 0-sorry theorems in `Proofs/LiouvilleTheoremOQ05.lean`:

| Theorem | Statement |
|---|---|
| `volume_liouville_eq_zero` | `volume {x : ℝ \| Liouville x} = 0` (Borel) |
| `ae_not_liouville'` | `∀ᵐ x, ¬ Liouville x` |
| `liouville_residual_and_null` | the Liouville set is residual **and** null |
| `exists_residual_null` | `∃ S, S ∈ residual ℝ ∧ volume S = 0` |
| `exists_meagre_conull` | `∃ S, IsMeagre S ∧ volume Sᶜ = 0` (dual) |
| `residual_ae_disjoint` | `Disjoint (residual ℝ) (ae volume)` |

The Liouville set is the textbook witness separating **Baire category** from **Lebesgue measure** (Oxtoby, *Measure and Category*): residual (topologically generic) yet Lebesgue-null. The dual — a meagre set of full measure — is the non-Liouville reals, obtained from the residual null set by `compl_compl`.

## Method

Assembles Mathlib's `volume_setOf_liouville`, `ae_not_liouville`, `eventually_residual_liouville`, and `Real.disjoint_residual_ae`. The only non-trivial step is the `IsMeagre`/`compl_compl` manipulation for the meagre-conull dual. Honest framing: this is an assembly that formalizes a previously-prose claim and packages the duality, not a deep new proof.

## Verification

- Compiled with `lake env lean Proofs/LiouvilleTheoremOQ05.lean` against pinned **Mathlib 4.26.0** — clean.
- `#print axioms` on all six theorems shows only `propext, Classical.choice, Quot.sound` (not counted). No `sorry`, no `decide`/`native_decide`.

## Gallery

- `proofs/Proofs/LiouvilleTheoremOQ05.lean` (new, 100 lines)
- `proofs/Proofs.lean` (+1 import)
- `src/data/proofs/liouville-theorem-oq-05/meta.json` (new)
- `src/data/research/problems/liouville-theorem-oq-05.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)