### PR TITLE
research(eisenstein-criterion-oq-01): Eisenstein's criterion + irreducibility of Xⁿ − p over ℤ (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -742,6 +742,7 @@ import Proofs.EhrhartCubeProvenOQ05
 import Proofs.EhrhartPolynomialOQ03
 import Proofs.EhrhartPolynomials
 import Proofs.EhrhartSimplexProven
+import Proofs.EisensteinCriterionOQ01
 import Proofs.ElementaryQuadraticReciprocity
 import Proofs.ElementaryQuadraticReciprocityOQ01
 import Proofs.ElementaryQuadraticReciprocityOQ01OQ01

--- a/proofs/Proofs/EisensteinCriterionOQ01.lean
+++ b/proofs/Proofs/EisensteinCriterionOQ01.lean
@@ -1,0 +1,102 @@
+/-
+  Eisenstein's irreducibility criterion, and the irreducibility of `Xⁿ − p`.
+
+  **Eisenstein's criterion.**  Let `R` be an integral domain, `P ⊂ R` a prime
+  ideal, and `f ∈ R[X]` a primitive polynomial of positive degree whose
+
+    * leading coefficient lies OUTSIDE `P`,
+    * all lower coefficients lie IN `P`,
+    * constant coefficient lies OUTSIDE `P²`.
+
+  Then `f` is irreducible.
+
+  The flagship consequence over `ℤ`: for every prime `p` and every `n ≥ 1` the
+  polynomial `Xⁿ − p` is irreducible.  Taking `P = (p)` the Eisenstein
+  hypotheses read off the coefficients `1, 0, …, 0, −p`:
+
+    * leading coefficient `1 ∉ (p)`        (else `p ∣ 1`, impossible),
+    * the only nonzero lower coefficient is `−p ∈ (p)`,
+    * the constant coefficient `−p ∉ (p²)`  (else `p² ∣ p`, i.e. `p ∣ 1`).
+
+  In particular `X² − 2`, `X³ − 2`, `X⁵ − 3`, … are all irreducible over `ℤ`,
+  so `ⁿ√p` has minimal polynomial of degree `n` — the standard supply of
+  algebraic numbers of every degree.
+
+  Mathlib provides the general criterion as
+  `Polynomial.irreducible_of_eisenstein_criterion`; this file restates it and
+  carries out the concrete coefficient bookkeeping for the `Xⁿ − p` family.
+  Everything is fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+open Polynomial
+
+namespace EisensteinCriterionOQ01
+
+/-! ### Eisenstein's criterion (general form) -/
+
+/-- **Eisenstein's irreducibility criterion.** A primitive polynomial `f` of
+positive degree over an integral domain, with leading coefficient outside a
+prime ideal `P`, all lower coefficients inside `P`, and constant coefficient
+outside `P²`, is irreducible. -/
+theorem irreducible_of_eisenstein {R : Type*} [CommRing R] [IsDomain R]
+    {f : R[X]} {P : Ideal R} (hP : P.IsPrime)
+    (hlead : f.leadingCoeff ∉ P)
+    (hlow : ∀ k : ℕ, (k : WithBot ℕ) < f.degree → f.coeff k ∈ P)
+    (hdeg : 0 < f.degree)
+    (hconst : f.coeff 0 ∉ P ^ 2)
+    (hprim : f.IsPrimitive) : Irreducible f :=
+  irreducible_of_eisenstein_criterion hP hlead hlow hdeg hconst hprim
+
+/-! ### The Eisenstein polynomials `Xⁿ − p` over ℤ -/
+
+/-- **`Xⁿ − p` is irreducible over `ℤ`** for every prime `p` and every `n ≥ 1`.
+The canonical Eisenstein family: applying the criterion with `P = (p)`. -/
+theorem irreducible_X_pow_sub_C_prime {p : ℤ} (hp : Prime p) {n : ℕ} (hn : 0 < n) :
+    Irreducible ((X : ℤ[X]) ^ n - C p) := by
+  have hP : (Ideal.span {p}).IsPrime := (Ideal.span_singleton_prime hp.ne_zero).mpr hp
+  have hmonic : ((X : ℤ[X]) ^ n - C p).Monic := monic_X_pow_sub_C p hn.ne'
+  have hdeg : ((X : ℤ[X]) ^ n - C p).degree = (n : WithBot ℕ) := degree_X_pow_sub_C hn p
+  -- coefficient bookkeeping: coeff k = (if k = n then 1 else 0) − (if k = 0 then p else 0)
+  have hcoeff : ∀ k : ℕ, ((X : ℤ[X]) ^ n - C p).coeff k
+      = (if k = n then 1 else 0) - (if k = 0 then p else 0) := by
+    intro k
+    rw [coeff_sub, coeff_X_pow, coeff_C]
+  refine irreducible_of_eisenstein hP ?_ ?_ ?_ ?_ hmonic.isPrimitive
+  · -- leading coefficient 1 ∉ (p)
+    rw [hmonic.leadingCoeff, Ideal.mem_span_singleton]
+    exact fun h => hp.not_unit (isUnit_of_dvd_one h)
+  · -- every lower coefficient lies in (p)
+    intro k hk
+    rw [hdeg] at hk
+    have hkn : k < n := by exact_mod_cast hk
+    rw [Ideal.mem_span_singleton, hcoeff, if_neg (by omega : k ≠ n)]
+    by_cases hk0 : k = 0
+    · simp [hk0]
+    · simp [hk0]
+  · -- positive degree
+    rw [hdeg]; exact_mod_cast hn
+  · -- constant coefficient −p ∉ (p²)
+    rw [hcoeff, if_neg (by omega : (0 : ℕ) ≠ n), if_pos rfl,
+      Ideal.span_singleton_pow, Ideal.mem_span_singleton]
+    simp only [zero_sub, dvd_neg]
+    intro h
+    -- p² ∣ p forces p ∣ 1
+    have : p * p ∣ p * 1 := by rwa [mul_one, ← sq]
+    exact hp.not_unit (isUnit_of_dvd_one ((mul_dvd_mul_iff_left hp.ne_zero).mp this))
+
+/-! ### Concrete instances -/
+
+/-- `X² − 2` is irreducible over `ℤ`. -/
+theorem irreducible_X_sq_sub_two : Irreducible ((X : ℤ[X]) ^ 2 - C 2) :=
+  irreducible_X_pow_sub_C_prime Int.prime_two (by norm_num)
+
+/-- `X³ − 2` is irreducible over `ℤ`. -/
+theorem irreducible_X_cube_sub_two : Irreducible ((X : ℤ[X]) ^ 3 - C 2) :=
+  irreducible_X_pow_sub_C_prime Int.prime_two (by norm_num)
+
+/-- `X⁵ − 3` is irreducible over `ℤ`. -/
+theorem irreducible_X_pow_five_sub_three : Irreducible ((X : ℤ[X]) ^ 5 - C 3) :=
+  irreducible_X_pow_sub_C_prime Int.prime_three (by norm_num)
+
+end EisensteinCriterionOQ01

--- a/src/data/proofs/eisenstein-criterion-oq-01/annotations.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "eisenstein-criterion-oq-01-module-header",
+    "proofId": "eisenstein-criterion-oq-01",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 34
+    },
+    "title": "Module Header: Eisenstein's Criterion",
+    "content": "**Eisenstein's criterion** is the most-used elementary irreducibility test. Over an integral domain with a prime ideal $P$, a primitive polynomial $f$ of positive degree is irreducible whenever\n\n- its **leading** coefficient lies *outside* $P$,\n- all **lower** coefficients lie *inside* $P$,\n- its **constant** coefficient lies *outside* $P^2$.\n\nThe archetypal consequence over $\\mathbb{Z}$: $X^n - p$ is irreducible for every prime $p$ and $n \\ge 1$. Taking $P = (p)$, the coefficients $1, 0, \\dots, 0, -p$ satisfy the three conditions, so $\\sqrt[n]{p}$ has minimal polynomial of degree exactly $n$ — algebraic numbers of every degree, on demand."
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-general",
+    "proofId": "eisenstein-criterion-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 38,
+      "endLine": 53
+    },
+    "title": "The General Criterion",
+    "content": "`irreducible_of_eisenstein`: the criterion in clean ideal-theoretic form, over a commutative integral domain $R$ with a prime ideal $P$. The hypotheses are named — `hlead` (leading coefficient $\\notin P$), `hlow` (every coefficient below the degree $\\in P$), `hdeg` (positive degree), `hconst` (constant coefficient $\\notin P^2$), `hprim` (primitive) — and the conclusion is `Irreducible f`. It is a direct restatement of Mathlib's `Polynomial.irreducible_of_eisenstein_criterion`, packaged for the application that follows."
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-xn-minus-p",
+    "proofId": "eisenstein-criterion-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 55,
+      "endLine": 92
+    },
+    "title": "Xⁿ − p Is Irreducible over ℤ",
+    "content": "`irreducible_X_pow_sub_C_prime`: the flagship family. With $P = (p) = $ `Ideal.span {p}` (prime by `Ideal.span_singleton_prime`), the polynomial $X^n - p$ is monic of degree $n$. Its coefficients are computed once,\n$$\\mathrm{coeff}\\,k = [k = n] \\cdot 1 - [k = 0]\\cdot p,$$\nso the five Eisenstein conditions become elementary divisibility facts: the leading $1 \\notin (p)$ (else $p \\mid 1$); each lower coefficient is $0$ or $-p$, both in $(p)$; the degree is $n > 0$; and the constant $-p \\notin (p^2)$ — because $p^2 \\mid p$ would force $p \\mid 1$ after cancelling one factor of $p$ (`mul_dvd_mul_iff_left`). Primitivity comes from `Monic.isPrimitive`."
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-instances",
+    "proofId": "eisenstein-criterion-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 94,
+      "endLine": 102
+    },
+    "title": "Concrete Instances",
+    "content": "Specializing the family gives `irreducible_X_sq_sub_two` ($X^2 - 2$, the minimal polynomial of $\\sqrt 2$), `irreducible_X_cube_sub_two` ($X^3 - 2$, for $\\sqrt[3]{2}$), and `irreducible_X_pow_five_sub_three` ($X^5 - 3$). Each is a one-line application of `irreducible_X_pow_sub_C_prime` to `Int.prime_two` or `Int.prime_three` with the relevant exponent — concrete witnesses that the criterion runs end-to-end."
+  }
+]

--- a/src/data/proofs/eisenstein-criterion-oq-01/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "eisenstein-criterion-oq-01",
+  "title": "Eisenstein's Criterion and the Irreducibility of Xⁿ − p",
+  "slug": "eisenstein-criterion-oq-01",
+  "description": "Eisenstein's irreducibility criterion: a primitive polynomial f of positive degree over an integral domain, whose leading coefficient lies outside a prime ideal P, all lower coefficients inside P, and constant coefficient outside P², is irreducible. The flagship consequence over ℤ is that Xⁿ − p is irreducible for every prime p and every n ≥ 1 (with P = (p), the coefficients 1, 0, …, 0, −p satisfy the hypotheses), giving algebraic numbers ⁿ√p of every degree n. Concrete corollaries X² − 2, X³ − 2, X⁵ − 3 are derived. 5 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Eisenstein%27s_criterion",
+    "date": "Gotthold Eisenstein, 1850 (Theodor Schönemann, 1846)",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "irreducibility",
+      "number-theory",
+      "ring-theory",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/EisensteinCriterionOQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 5 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide is used anywhere.",
+    "originalContributions": [
+      "irreducible_of_eisenstein: Eisenstein's criterion in clean form over an integral domain with a prime ideal P (leading coeff ∉ P, lower coeffs ∈ P, constant ∉ P², primitive ⇒ irreducible)",
+      "irreducible_X_pow_sub_C_prime: the flagship family — Xⁿ − p is irreducible over ℤ for every prime p and n ≥ 1, with full coefficient bookkeeping (P = (p), 1 ∉ (p), only −p among lower coeffs lies in (p), −p ∉ (p²) since p² ∤ p)",
+      "irreducible_X_sq_sub_two / irreducible_X_cube_sub_two / irreducible_X_pow_five_sub_three: concrete instances X² − 2, X³ − 2, X⁵ − 3, all irreducible over ℤ"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 102,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Eisenstein's criterion was published by Gotthold Eisenstein in 1850 (and earlier, in 1846, by Theodor Schönemann). It is the most widely used elementary irreducibility test: given a single prime p dividing the lower coefficients but not the leading one, and with p² not dividing the constant term, the polynomial is irreducible over the fraction field. Its archetypal use is to show Xⁿ − p is irreducible, exhibiting algebraic numbers of every degree, and to prove the irreducibility of the p-th cyclotomic polynomial after the substitution X ↦ X + 1.",
+    "problemStatement": "**Open Question (OQ-01, Eisenstein criterion)**: Formalize Eisenstein's irreducibility criterion over an integral domain in terms of a prime ideal, and apply it to establish the irreducibility of the family Xⁿ − p over ℤ for prime p.\n\n**Formalized**: irreducible_of_eisenstein (the general criterion), irreducible_X_pow_sub_C_prime (Xⁿ − p irreducible over ℤ), and the concrete instances X² − 2, X³ − 2, X⁵ − 3.",
+    "text": "A 102-line formalization. The general criterion is stated over an integral domain R with a prime ideal P, mirroring Mathlib's Polynomial.irreducible_of_eisenstein_criterion. The substance is the concrete application to Xⁿ − p over ℤ: choosing P = (p) = Ideal.span {p}, the five Eisenstein hypotheses are discharged by computing the coefficients of Xⁿ − p (which are 1 at degree n, −p at degree 0, and 0 elsewhere) and reasoning about divisibility by p and p². Three concrete polynomials are then certified irreducible. All 5 theorems compile with 0 sorries and 0 axioms, with no native_decide.",
+    "proofStrategy": "**General criterion (irreducible_of_eisenstein)**: a direct restatement of Mathlib's irreducible_of_eisenstein_criterion with the hypotheses named for readability.\n\n**Xⁿ − p (irreducible_X_pow_sub_C_prime)**: Take P = Ideal.span {p}; it is prime via Ideal.span_singleton_prime (using p ≠ 0 from Prime p). The polynomial is monic (monic_X_pow_sub_C) with degree n (degree_X_pow_sub_C). The coefficient formula coeff k = (if k = n then 1 else 0) − (if k = 0 then p else 0) is obtained from coeff_sub, coeff_X_pow, coeff_C, then: (i) leading coefficient 1 ∉ (p) since p ∤ 1 (else p is a unit); (ii) for k < n the coefficient is 0 or −p, both in (p); (iii) degree n > 0; (iv) constant coefficient −p ∉ (p²) — via Ideal.span_singleton_pow this is ¬ p² ∣ p, which would force p ∣ 1 by cancelling one factor of p (mul_dvd_mul_iff_left); (v) primitivity from Monic.isPrimitive.\n\n**Concrete instances**: specialize irreducible_X_pow_sub_C_prime to Int.prime_two and Int.prime_three with the relevant exponents.",
+    "keyInsights": [
+      "**One prime decides irreducibility**: a single prime p, dividing the lower coefficients but not the leader, with p² not dividing the constant term, is enough to force irreducibility — a remarkably cheap, purely arithmetic test.",
+      "**The role of P²**: the constant term must avoid P² (not just lie in P). This is exactly what rules out a factorization into two lower-degree polynomials whose constant terms would each contribute one factor of p — without it, X² − p² = (X − p)(X + p) would be a false positive.",
+      "**Algebraic numbers of every degree**: because Xⁿ − p is irreducible, it is the minimal polynomial of ⁿ√p, so ⁿ√p has degree exactly n over ℚ. Eisenstein thus furnishes algebraic numbers of arbitrarily large degree on demand.",
+      "**Coefficients are the whole proof**: for Xⁿ − p the Eisenstein conditions reduce to elementary divisibility facts about the explicit coefficients 1, 0, …, 0, −p — the criterion converts an irreducibility question into bookkeeping over p and p².",
+      "**0-axiom, no native_decide**: every result, including the concrete instances, is kernel-checked, depending only on propext / Classical.choice / Quot.sound, which do not count as assumptions."
+    ],
+    "prerequisites": [
+      "Polynomial rings R[X], coefficients, degree, and leading coefficient (Mathlib Polynomial)",
+      "Prime ideals and ideal powers; Ideal.span {p} and membership x ∈ (p) ↔ p ∣ x (Ideal.mem_span_singleton)",
+      "Primitive polynomials and the content; monic ⇒ primitive (Polynomial.Monic.isPrimitive)",
+      "Irreducibility in a polynomial ring over an integral domain",
+      "Basic divisibility in ℤ: p ∣ 1 ↔ IsUnit p, and cancelling a factor of p (mul_dvd_mul_iff_left)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "cyclotomic-polynomials-oq-01",
+      "relationship": "related",
+      "description": "The irreducibility of the p-th cyclotomic polynomial Φ_p is the other classical application of Eisenstein's criterion (after the substitution X ↦ X + 1). This entry establishes the criterion and the companion Xⁿ − p family; the cyclotomic entry studies Φ_n's degree and divisor-product structure."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "EisensteinCriterionOQ01",
+    "lineCount": 102,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/EisensteinCriterionOQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "irreducible_X_pow_sub_C_prime",
+      "type": "core",
+      "statement": "$p$ prime, $n \\ge 1$ $\\Rightarrow$ $X^n - p$ is irreducible over $\\mathbb{Z}$",
+      "significance": "The headline: the canonical Eisenstein family. With P = (p), the coefficients of Xⁿ − p (namely 1, 0, …, 0, −p) satisfy all Eisenstein hypotheses, so the polynomial is irreducible. This is the standard source of algebraic numbers ⁿ√p of every degree n.",
+      "description": "Xⁿ − p is irreducible over ℤ for prime p."
+    },
+    {
+      "name": "irreducible_of_eisenstein",
+      "type": "core",
+      "statement": "$f$ primitive, $\\deg f > 0$, $\\mathrm{lead}(f) \\notin P$, lower coeffs $\\in P$, $f(0) \\notin P^2$, $P$ prime $\\Rightarrow$ $f$ irreducible",
+      "significance": "Eisenstein's criterion in clean ideal-theoretic form over an integral domain. The general engine behind the concrete results; a named restatement of Mathlib's irreducible_of_eisenstein_criterion.",
+      "description": "Eisenstein's irreducibility criterion."
+    },
+    {
+      "name": "irreducible_X_sq_sub_two",
+      "type": "supporting",
+      "statement": "$X^2 - 2$ is irreducible over $\\mathbb{Z}$",
+      "significance": "Concrete instance with p = 2, n = 2 — the minimal polynomial of √2, of degree 2.",
+      "description": "X² − 2 is irreducible."
+    },
+    {
+      "name": "irreducible_X_cube_sub_two",
+      "type": "supporting",
+      "statement": "$X^3 - 2$ is irreducible over $\\mathbb{Z}$",
+      "significance": "Concrete instance with p = 2, n = 3 — the minimal polynomial of ∛2, of degree 3.",
+      "description": "X³ − 2 is irreducible."
+    },
+    {
+      "name": "irreducible_X_pow_five_sub_three",
+      "type": "supporting",
+      "statement": "$X^5 - 3$ is irreducible over $\\mathbb{Z}$",
+      "significance": "Concrete instance with p = 3, n = 5 — a degree-5 example, illustrating the criterion for a different prime and a prime exponent.",
+      "description": "X⁵ − 3 is irreducible."
+    }
+  ],
+  "references": [
+    {
+      "text": "Eisenstein, G. (1850). Über die Irreductibilität und einige andere Eigenschaften der Gleichung, von welcher die Theilung der ganzen Lemniscate abhängt. Crelle's Journal. (Schönemann gave an equivalent criterion in 1846.)",
+      "url": "https://en.wikipedia.org/wiki/Eisenstein%27s_criterion"
+    },
+    {
+      "text": "Dummit, D. & Foote, R. Abstract Algebra. Eisenstein's criterion and the irreducibility of Xⁿ − p and the cyclotomic polynomials.",
+      "url": "https://en.wikipedia.org/wiki/Irreducible_polynomial"
+    },
+    {
+      "text": "Mathlib4: Polynomial.irreducible_of_eisenstein_criterion (RingTheory/Polynomial/Eisenstein/Criterion.lean), monic_X_pow_sub_C, degree_X_pow_sub_C, Ideal.span_singleton_prime, Ideal.mem_span_singleton, Ideal.span_singleton_pow, Polynomial.Monic.isPrimitive.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalizes Eisenstein's irreducibility criterion (irreducible_of_eisenstein) and applies it to the canonical family: Xⁿ − p is irreducible over ℤ for every prime p and n ≥ 1 (irreducible_X_pow_sub_C_prime), with the concrete instances X² − 2, X³ − 2, X⁵ − 3. The application uses P = (p) and reduces the five Eisenstein hypotheses to elementary divisibility facts about the coefficients 1, 0, …, 0, −p. All 5 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "Eisenstein's criterion is the standard elementary irreducibility test in algebra and number theory. The Xⁿ − p family it certifies supplies algebraic numbers of every degree (the minimal polynomial of ⁿ√p), underpins field-extension and Galois-theory examples, and — via the substitution X ↦ X + 1 — gives the classical proof that the p-th cyclotomic polynomial is irreducible.",
+    "openQuestions": [
+      "Derive the irreducibility of the p-th cyclotomic polynomial Φ_p by applying the criterion to Φ_p(X + 1)",
+      "State the consequence for field degrees: ⁿ√p has minimal polynomial Xⁿ − p, hence [ℚ(ⁿ√p) : ℚ] = n",
+      "Generalize the coefficient bookkeeping to Eisenstein-at-p polynomials with arbitrary lower coefficients divisible by p (general IsEisensteinAt instances)"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **Eisenstein's irreducibility criterion** and its flagship application — the irreducibility of `Xⁿ − p` over ℤ. New gallery topic (no prior eisenstein entry).

- **irreducible_of_eisenstein** — the criterion in clean ideal-theoretic form: over an integral domain with a prime ideal `P`, a primitive polynomial `f` of positive degree with `lead(f) ∉ P`, lower coeffs `∈ P`, and `f(0) ∉ P²` is irreducible.
- **irreducible_X_pow_sub_C_prime** — the headline: `Xⁿ − p` is irreducible over ℤ for every prime `p` and `n ≥ 1`. With `P = (p)`, the coefficients `1, 0, …, 0, −p` discharge the five hypotheses; the constant `−p ∉ (p²)` because `p² ∣ p` would force `p ∣ 1`.
- **irreducible_X_sq_sub_two / irreducible_X_cube_sub_two / irreducible_X_pow_five_sub_three** — concrete instances `X² − 2`, `X³ − 2`, `X⁵ − 3` (the minimal polynomials of `√2`, `∛2`, and a degree-5 example).

These give algebraic numbers `ⁿ√p` of every degree `n`.

## Verification

- **5 theorems, 102 lines**, 0 sorries, **0 axioms**
- `#print axioms` on all theorems shows only `propext / Classical.choice / Quot.sound` — **no native_decide**, no `sorryAx`
- Compiles clean against pinned Mathlib 4.26.0 (`lake env lean`)

## Files

- `proofs/Proofs/EisensteinCriterionOQ01.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/eisenstein-criterion-oq-01/{meta,annotations}.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)