### PR TITLE
research(newton-power-sum-identities-oq-01): low-degree Newton's identities (p₁=e₁, p₂=e₁²−2e₂, p₃=e₁³−3e₁e₂+3e₃), verified 0-axiom

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2809,6 +2809,7 @@ import Proofs.NewtonInductiveStepOQ01Aristotle
 import Proofs.NewtonInductiveStepOQ02
 import Proofs.NewtonInductiveStepOQ03
 import Proofs.NewtonLogConcavity
+import Proofs.NewtonPowerSumIdentitiesOQ01
 import Proofs.NivenTheorem
 import Proofs.NivenTheoremOQ02
 import Proofs.NivenTheoremOQ03

--- a/proofs/Proofs/NewtonPowerSumIdentitiesOQ01.lean
+++ b/proofs/Proofs/NewtonPowerSumIdentitiesOQ01.lean
@@ -1,0 +1,73 @@
+import Mathlib
+
+/-
+# Newton's identities in low degree: power sums from elementary symmetric polynomials
+
+For the elementary symmetric polynomials `eₖ = esymm σ R k` and the power sums
+`pₖ = psum σ R k = ∑ᵢ Xᵢᵏ` in finitely many variables over a commutative ring,
+*Newton's identities* express each power sum as a polynomial in the elementary
+symmetric polynomials.  Mathlib proves the general recurrence
+
+  `pₖ = (-1)^{k+1}·k·eₖ - ∑_{0 < i < k} (-1)^i·eᵢ·p_{k-i}`
+
+(`MvPolynomial.psum_eq_mul_esymm_sub_sum`), but does **not** record the explicit
+closed forms in low degree.  This entry unrolls the recurrence for `k = 1, 2, 3`
+to obtain the three classical identities
+
+* `p₁ = e₁`
+* `p₂ = e₁² - 2 e₂`
+* `p₃ = e₁³ - 3 e₁ e₂ + 3 e₃`
+
+These hold as identities in `MvPolynomial σ R` for *any* finite index type `σ`
+and any commutative ring `R`; when `card σ < k` the higher `eₖ` simply vanish,
+so the formulas remain valid (e.g. with a single variable `e₂ = e₃ = 0`, giving
+`p₂ = e₁²` and `p₃ = e₁³`).
+
+The proof of `p₁` is immediate from `psum_one`/`esymm_one`.  For `p₂` and `p₃`
+we feed the Newton recurrence the explicit (finite) index sets of its inner sum,
+each computed once and for all by `omega`, and then close with `ring` after
+substituting the previously established lower identities.
+-/
+
+open Finset
+
+namespace NewtonPowerSum
+
+variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]
+
+/-- **Newton's identity, degree 1:** `p₁ = e₁`.
+Both sides equal `∑ᵢ Xᵢ`. -/
+theorem psum_one_eq : MvPolynomial.psum σ R 1 = MvPolynomial.esymm σ R 1 := by
+  rw [MvPolynomial.psum_one, MvPolynomial.esymm_one]
+
+/-- **Newton's identity, degree 2:** `p₂ = e₁² - 2 e₂`. -/
+theorem psum_two_eq :
+    MvPolynomial.psum σ R 2 = MvPolynomial.esymm σ R 1 ^ 2 - 2 * MvPolynomial.esymm σ R 2 := by
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 2 (by norm_num)]
+  -- The inner sum ranges over `{a ∈ antidiagonal 2 | 0 < a.1 < 2}`, i.e. just `(1, 1)`.
+  have hset : {a ∈ Finset.antidiagonal 2 | a.1 ∈ Set.Ioo 0 2} = {(1, 1)} := by
+    ext ⟨i, j⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo, Finset.mem_singleton,
+      Prod.mk.injEq]
+    omega
+  rw [hset, Finset.sum_singleton, psum_one_eq]
+  push_cast
+  ring
+
+/-- **Newton's identity, degree 3:** `p₃ = e₁³ - 3 e₁ e₂ + 3 e₃`. -/
+theorem psum_three_eq :
+    MvPolynomial.psum σ R 3 =
+      MvPolynomial.esymm σ R 1 ^ 3 - 3 * MvPolynomial.esymm σ R 1 * MvPolynomial.esymm σ R 2
+        + 3 * MvPolynomial.esymm σ R 3 := by
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 3 (by norm_num)]
+  -- The inner sum ranges over `{a ∈ antidiagonal 3 | 0 < a.1 < 3}`, i.e. `{(1, 2), (2, 1)}`.
+  have hset : {a ∈ Finset.antidiagonal 3 | a.1 ∈ Set.Ioo 0 3} = {(1, 2), (2, 1)} := by
+    ext ⟨i, j⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo, Finset.mem_insert,
+      Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  rw [hset, Finset.sum_pair (by decide), psum_two_eq, psum_one_eq]
+  push_cast
+  ring
+
+end NewtonPowerSum

--- a/src/data/proofs/newton-power-sum-identities-oq-01/meta.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01/meta.json
@@ -1,0 +1,156 @@
+{
+  "id": "newton-power-sum-identities-oq-01",
+  "title": "Newton's Identities in Low Degree: Power Sums from Elementary Symmetric Polynomials",
+  "slug": "newton-power-sum-identities-oq-01",
+  "description": "Newton's identities express the power sums pₖ = ∑ᵢ Xᵢᵏ of finitely many variables in terms of the elementary symmetric polynomials eⱼ. Mathlib proves the general recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum, namely pₖ = (-1)^{k+1}·k·eₖ - ∑_{0<i<k} (-1)^i·eᵢ·p_{k-i}, but does not record the explicit closed forms in low degree. This entry unrolls that recurrence for k = 1, 2, 3 to obtain the three classical identities p₁ = e₁, p₂ = e₁² - 2e₂, and p₃ = e₁³ - 3e₁e₂ + 3e₃, valid as identities in MvPolynomial σ R for any finite index type σ and any commutative ring R. The base case is immediate from psum_one/esymm_one; for k = 2, 3 the finite inner index sets of the recurrence ({(1,1)} and {(1,2),(2,1)}) are computed by omega and the result closed by ring after substituting the lower identities.",
+  "meta": {
+    "author": "Isaac Newton (Arithmetica Universalis, 1707) / classical theory of symmetric functions; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Newton%27s_identities",
+    "date": "1707",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "symmetric-functions",
+      "newton-identities",
+      "power-sums",
+      "elementary-symmetric-polynomials",
+      "mvpolynomial",
+      "commutative-ring",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/NewtonPowerSumIdentitiesOQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+        "description": "The Newton recurrence pₖ = (-1)^{k+1}·k·eₖ - ∑_{0<i<k}(-1)^i·eᵢ·p_{k-i} (for 0 < k); the engine that is unrolled at k = 2 and k = 3",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.NewtonIdentities"
+      },
+      {
+        "theorem": "MvPolynomial.psum_one",
+        "description": "psum σ R 1 = ∑ᵢ Xᵢ — used together with esymm_one to give the base identity p₁ = e₁",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      },
+      {
+        "theorem": "MvPolynomial.esymm_one",
+        "description": "esymm σ R 1 = ∑ᵢ Xᵢ — matches psum_one to establish p₁ = e₁",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      },
+      {
+        "theorem": "Finset.sum_pair / Finset.sum_singleton",
+        "description": "Evaluate the recurrence's finite inner sums over the explicit two-element and one-element index sets",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.mem_antidiagonal",
+        "description": "Membership in the ℕ-antidiagonal, reducing the inner index set {a ∈ antidiagonal k | 0 < a.1 < k} to a linear-arithmetic condition discharged by omega",
+        "module": "Mathlib.Algebra.Order.Antidiag.Nat"
+      }
+    ],
+    "originalContributions": [
+      "psum_one_eq: p₁ = e₁ — the degree-1 Newton identity",
+      "psum_two_eq: p₂ = e₁² - 2e₂ — the degree-2 Newton identity, unrolled from the Mathlib recurrence",
+      "psum_three_eq: p₃ = e₁³ - 3e₁e₂ + 3e₃ — the degree-3 Newton identity; these explicit closed forms are not stated in Mathlib, which carries only the general recurrence"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 73,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). The single use of decide proves the pair inequality (1,2) ≠ (2,1) by kernel reduction, not native_decide, so no Lean.ofReduceBool is introduced.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Newton's identities (also called the Newton–Girard formulae) relate the two most fundamental bases of the ring of symmetric functions: the power sums pₖ = ∑ xᵢᵏ and the elementary symmetric polynomials eⱼ = ∑_{i₁<···<iⱼ} xᵢ₁···xᵢⱼ. They were stated by Newton in his Arithmetica Universalis (1707) and earlier by Girard (1629), and are the computational backbone of Galois theory, the theory of resultants, and the conversion between the characteristic polynomial of a matrix and its traces of powers. The low-degree cases p₁ = e₁, p₂ = e₁² - 2e₂, p₃ = e₁³ - 3e₁e₂ + 3e₃ are the ones that appear constantly in practice — e.g. expressing ∑xᵢ², ∑xᵢ³ of the roots of a polynomial directly in its coefficients.",
+    "problemStatement": "**Open Question (newton-power-sum-identities-oq-01)**: Derive the explicit low-degree Newton identities for the power sums pₖ = ∑ᵢ Xᵢᵏ in terms of the elementary symmetric polynomials eⱼ over a commutative ring.\n\n**Result**: psum_one_eq (p₁ = e₁), psum_two_eq (p₂ = e₁² - 2e₂), and psum_three_eq (p₃ = e₁³ - 3e₁e₂ + 3e₃), obtained by unrolling Mathlib's general Newton recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum, which does not itself record these closed forms.",
+    "text": "Let σ be a finite index type and R a commutative ring. For the elementary symmetric polynomials eⱼ = MvPolynomial.esymm σ R j and power sums pₖ = MvPolynomial.psum σ R k = ∑ᵢ Xᵢᵏ in MvPolynomial σ R, one has p₁ = e₁, p₂ = e₁² - 2e₂, and p₃ = e₁³ - 3e₁e₂ + 3e₃. These hold for every finite σ; when card σ < k the higher eⱼ vanish, so e.g. with a single variable p₂ = e₁² and p₃ = e₁³.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. p₁ = e₁ (psum_one_eq): both sides equal ∑ᵢ Xᵢ, so rewrite by psum_one and esymm_one.\n\n2. p₂ = e₁² - 2e₂ (psum_two_eq): apply the Newton recurrence at k = 2. Its inner sum ranges over {a ∈ antidiagonal 2 | 0 < a.1 < 2}; an omega-discharged set equality shows this is the singleton {(1,1)}, so Finset.sum_singleton leaves the single term (-1)¹·e₁·p₁. Substitute p₁ = e₁ and close with push_cast; ring (which evaluates (-1)^{2+1} and the cast coefficient).\n\n3. p₃ = e₁³ - 3e₁e₂ + 3e₃ (psum_three_eq): apply the recurrence at k = 3. The inner index set {a ∈ antidiagonal 3 | 0 < a.1 < 3} is {(1,2),(2,1)} (again by omega), so Finset.sum_pair yields the two terms (-1)¹·e₁·p₂ and (-1)²·e₂·p₁. Substitute the degree-2 and degree-1 identities and finish with push_cast; ring.",
+    "keyInsights": [
+      "**The general recurrence specializes cleanly.** Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum gives Newton's law for all k; the explicit low-degree formulas come from evaluating its finite inner sum over a tiny, omega-computable index set.",
+      "**The index sets are pure linear arithmetic.** {a ∈ antidiagonal k | 0 < a.1 < k} reduces, via mem_antidiagonal and mem_Ioo, to {(i,j) | i+j=k, 0<i<k}, which omega resolves to {(1,1)} for k=2 and {(1,2),(2,1)} for k=3 — no Finset computation or decide on the polynomial ring is needed.",
+      "**Identities, not equalities of numbers.** The results live in MvPolynomial σ R, so they are universal symmetric-function identities; specializing the variables recovers the familiar relations among sums of powers and coefficients of any polynomial.",
+      "**New beyond Mathlib.** Mathlib records the recurrence but not the explicit closed forms p₂ = e₁² - 2e₂ and p₃ = e₁³ - 3e₁e₂ + 3e₃; this entry supplies them as reusable lemmas."
+    ],
+    "prerequisites": [
+      "The definitions MvPolynomial.psum and MvPolynomial.esymm (Symmetric/Defs.lean)",
+      "The Newton recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum (Symmetric/NewtonIdentities.lean)",
+      "Finset.antidiagonal over ℕ and the big-operator lemmas Finset.sum_singleton, Finset.sum_pair"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Module docstring stating Newton's recurrence, the three low-degree closed forms to be derived, and the validity for any finite σ (with higher eⱼ vanishing when card σ < k). The Mathlib import, the open Finset, the namespace, and the variables (σ finite, R a commutative ring).",
+      "mathContext": "$p_k = (-1)^{k+1} k\\,e_k - \\sum_{0<i<k} (-1)^i e_i\\, p_{k-i}$."
+    },
+    {
+      "id": "degree-one",
+      "title": "Degree 1: p₁ = e₁",
+      "startLine": 40,
+      "endLine": 42,
+      "summary": "psum_one_eq: both the power sum and the first elementary symmetric polynomial equal ∑ᵢ Xᵢ, so the identity is psum_one followed by esymm_one.",
+      "mathContext": "$p_1 = e_1 = \\sum_i X_i$."
+    },
+    {
+      "id": "degree-two",
+      "title": "Degree 2: p₂ = e₁² - 2e₂",
+      "startLine": 44,
+      "endLine": 56,
+      "summary": "psum_two_eq: apply the recurrence at k = 2, reduce its inner index set to the singleton {(1,1)} via an omega-proved set equality, evaluate by Finset.sum_singleton, substitute p₁ = e₁, and close with push_cast; ring.",
+      "mathContext": "$p_2 = e_1^2 - 2e_2$."
+    },
+    {
+      "id": "degree-three",
+      "title": "Degree 3: p₃ = e₁³ - 3e₁e₂ + 3e₃",
+      "startLine": 58,
+      "endLine": 73,
+      "summary": "psum_three_eq: apply the recurrence at k = 3, reduce its inner index set to {(1,2),(2,1)} via omega, evaluate by Finset.sum_pair, substitute the degree-2 and degree-1 identities, and close with push_cast; ring.",
+      "mathContext": "$p_3 = e_1^3 - 3e_1 e_2 + 3e_3$."
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) derivation of the three low-degree Newton identities p₁ = e₁, p₂ = e₁² - 2e₂, p₃ = e₁³ - 3e₁e₂ + 3e₃ as universal identities in MvPolynomial σ R, obtained by unrolling Mathlib's general Newton recurrence.",
+    "implications": "Supplies the explicit closed forms that Mathlib's general recurrence leaves implicit, giving reusable lemmas for converting between power sums and elementary symmetric polynomials (equivalently, between traces of powers and coefficients of a characteristic polynomial).",
+    "openQuestions": [
+      "Derive the degree-4 identity p₄ = e₁⁴ - 4e₁²e₂ + 4e₁e₃ + 2e₂² - 4e₄ by the same unrolling, and seek a uniform statement of the closed form.",
+      "Prove the dual (reverse) Newton identities expressing each eₖ as a polynomial in the power sums (k! eₖ = det of a Toeplitz matrix in the pᵢ), valid over a ℚ-algebra."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "NewtonPowerSum",
+    "lineCount": 73,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/NewtonPowerSumIdentitiesOQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Newton, Isaac",
+      "title": "Arithmetica Universalis",
+      "year": "1707",
+      "venue": "",
+      "note": "Classical source of the identities relating power sums and elementary symmetric polynomials"
+    },
+    {
+      "authors": "Mead, D. G.",
+      "title": "Newton's Identities",
+      "year": "1992",
+      "venue": "The American Mathematical Monthly 99(8), 749–751",
+      "note": "Modern exposition and proofs of the Newton–Girard formulae"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **newton-power-sum-identities-oq-01**: the three classical low-degree **Newton's identities** relating power sums to elementary symmetric polynomials, over an arbitrary commutative ring in finitely many variables.

- `psum_one_eq`:   **p₁ = e₁**
- `psum_two_eq`:   **p₂ = e₁² − 2e₂**
- `psum_three_eq`: **p₃ = e₁³ − 3e₁e₂ + 3e₃**

where `pₖ = MvPolynomial.psum σ R k = ∑ᵢ Xᵢᵏ` and `eⱼ = MvPolynomial.esymm σ R j`.

## Why this is new beyond Mathlib

Mathlib proves only the **general** Newton recurrence
`MvPolynomial.psum_eq_mul_esymm_sub_sum`
(`pₖ = (-1)^{k+1}·k·eₖ − ∑_{0<i<k} (-1)^i·eᵢ·p_{k-i}`),
but does **not** record the explicit closed forms in low degree. This entry unrolls that recurrence at `k = 1, 2, 3` to obtain the formulas that appear constantly in practice (sums of powers of roots in terms of polynomial coefficients).

These are universal identities in `MvPolynomial σ R` for any finite `σ`; when `card σ < k` the higher `eⱼ` vanish (e.g. one variable gives `p₂ = e₁²`, `p₃ = e₁³`).

## Proof technique

- `p₁ = e₁` is `psum_one` matched with `esymm_one` (both equal `∑ᵢ Xᵢ`).
- For `k = 2, 3`, the recurrence's inner index set `{a ∈ antidiagonal k | 0 < a.1 < k}` reduces (via `mem_antidiagonal`/`mem_Ioo`) to pure linear arithmetic, resolved by `omega` to `{(1,1)}` and `{(1,2),(2,1)}`. Evaluate by `Finset.sum_singleton`/`Finset.sum_pair`, substitute the lower identities, and close with `push_cast; ring`.

## Verification

- Builds against pinned Mathlib 4.26.0 via `docker-build.sh`.
- **0 axioms / 0 sorries**: `#print axioms` reports all three theorems depend only on `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool` (the one `decide` proves the pair inequality `(1,2) ≠ (2,1)` by kernel reduction, not `native_decide`).

## Not a duplicate

The gallery's existing `newton-*` entries (`newton-inductive-step*`, `newton-log-concavity`) concern Newton's **root-finding method** and the Newton inequalities — a different topic from these power-sum/symmetric-function identities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)