### PR TITLE
research(stirling-second-kind-oq-01): closed form S(n,2)=2ⁿ⁻¹−1 for the two-block column (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3063,6 +3063,7 @@ import Proofs.StirlingExpansionAristotle
 import Proofs.StirlingFormula
 import Proofs.StirlingFormulaOQ02
 import Proofs.StirlingFormulaOQ03
+import Proofs.StirlingSecondKindOQ01
 import Proofs.SubsetCount
 import Proofs.SubsetCountMultisetOQ01
 import Proofs.SubsetCountOQ02

--- a/proofs/Proofs/StirlingSecondKindOQ01.lean
+++ b/proofs/Proofs/StirlingSecondKindOQ01.lean
@@ -1,0 +1,80 @@
+/-
+Stirling Numbers of the Second Kind: the two-block column  S(n,2) = 2^(n-1) − 1
+
+Source: Open question from the stirling-second-kind gallery family
+Status: VERIFIED (0 axioms, 0 sorries)
+
+`Nat.stirlingSecond n k` counts the partitions of an `n`-element set into exactly
+`k` nonempty, unlabeled blocks. Mathlib (`Mathlib/Combinatorics/Enumerative/Stirling.lean`)
+provides the Pascal-style recurrences together with the boundary columns
+
+  S(n,n)   = 1                      (`stirlingSecond_self`)
+  S(n+1,1) = 1                      (`stirlingSecond_one_right`)
+  S(n+1,n) = C(n+1,2)               (`stirlingSecond_succ_self_left`)
+
+but it does NOT record the classical closed form for the `k = 2` column. We fill
+that gap:
+
+      S(n, 2) = 2^(n-1) − 1     for n ≥ 2.
+
+Combinatorial meaning: an unordered split of an `n`-set into two nonempty parts is
+obtained from one of the `2^n` subsets by discarding the two improper subsets
+(∅ and the whole set) and then identifying a part with its complement — giving
+`(2^n − 2)/2 = 2^(n-1) − 1`. We prove it purely from the recurrence
+
+      S(n+1, 2) = 2·S(n, 2) + S(n, 1) = 2·S(n, 2) + 1,
+
+which is the inhomogeneous geometric recursion solved by `2^(n-1) − 1`.
+
+We prove:
+1. `stirlingSecond_two_add` — the shifted form S(n+2,2) = 2^(n+1) − 1 (induction-friendly)
+2. `stirlingSecond_two`     — the textbook form S(n,2) = 2^(n-1) − 1 for n ≥ 2
+3. `stirlingSecond_two_pos` — there is always at least one two-block partition (n ≥ 2)
+-/
+
+import Mathlib
+
+open Nat
+
+namespace StirlingSecondKindOQ01
+
+/-- **Two-block column, shifted form.** The number of partitions of an
+`(n+2)`-element set into two nonempty blocks is `2^(n+1) − 1`.
+
+Proof by induction using the Pascal recurrence
+`S(m+1,2) = 2·S(m,2) + S(m,1)` together with `S(m,1) = 1`. The recursion
+`a(n+1) = 2·a(n) + 1` with `a(0) = 1` solves to `a(n) = 2^(n+1) − 1`. -/
+theorem stirlingSecond_two_add (n : ℕ) :
+    Nat.stirlingSecond (n + 2) 2 = 2 ^ (n + 1) - 1 := by
+  induction n with
+  | zero => decide
+  | succ n ih =>
+    -- Pascal recurrence specialised to the second column.
+    have key : Nat.stirlingSecond (n + 1 + 2) 2
+        = 2 * Nat.stirlingSecond (n + 2) 2 + Nat.stirlingSecond (n + 2) 1 :=
+      Nat.stirlingSecond_succ_succ (n + 2) 1
+    have hone : Nat.stirlingSecond (n + 2) 1 = 1 := Nat.stirlingSecond_one_right (n + 1)
+    rw [key, ih, hone]
+    have h1 : 1 ≤ 2 ^ (n + 1) := Nat.one_le_two_pow
+    have h2 : 2 ^ (n + 1 + 1) = 2 * 2 ^ (n + 1) := by ring
+    omega
+
+/-- **Two-block column, textbook form.** For `n ≥ 2`, the number of partitions of
+an `n`-element set into exactly two nonempty blocks is `2^(n-1) − 1`. -/
+theorem stirlingSecond_two {n : ℕ} (hn : 2 ≤ n) :
+    Nat.stirlingSecond n 2 = 2 ^ (n - 1) - 1 := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 2 := ⟨n - 2, by omega⟩
+  -- `m + 2 - 1` is definitionally `m + 1`.
+  exact stirlingSecond_two_add m
+
+/-- **Existence of a two-block partition.** Any set with at least two elements can
+be split into two nonempty blocks, i.e. `S(n,2) > 0` for `n ≥ 2`. -/
+theorem stirlingSecond_two_pos {n : ℕ} (hn : 2 ≤ n) :
+    0 < Nat.stirlingSecond n 2 := by
+  rw [stirlingSecond_two hn]
+  have h2 : 2 ≤ 2 ^ (n - 1) := by
+    calc (2 : ℕ) = 2 ^ 1 := (pow_one 2).symm
+      _ ≤ 2 ^ (n - 1) := Nat.pow_le_pow_right (by norm_num) (by omega)
+  omega
+
+end StirlingSecondKindOQ01

--- a/src/data/proofs/stirling-second-kind-oq-01/annotations.json
+++ b/src/data/proofs/stirling-second-kind-oq-01/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "ann-imports-docstring",
+    "proofId": "stirling-second-kind-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 39
+    },
+    "type": "concept",
+    "title": "Stirling Numbers of the Second Kind",
+    "content": "Nat.stirlingSecond n k counts the partitions of an n-element set into exactly k nonempty, unlabeled blocks. Mathlib develops the Pascal-style recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k) together with the boundary columns S(n,1) = 1, S(n,n) = 1, and S(n,n-1) = C(n,2). The one column it omits is k = 2, the first with a genuinely nontrivial closed form, 2^(n-1) − 1. This file supplies it. The header records both the algebraic route (solving the recurrence) and the combinatorial meaning of the count.",
+    "mathContext": "$S(n,k)$ = number of partitions of an $n$-set into $k$ nonempty blocks; $S(n,2) = 2^{n-1}-1$ for $n \\ge 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Stirling numbers of the second kind",
+      "set partitions",
+      "Pascal recurrence",
+      "Nat.stirlingSecond"
+    ],
+    "prerequisites": [
+      "natural-number recursion",
+      "finite set partitions"
+    ]
+  },
+  {
+    "id": "ann-shifted-form",
+    "proofId": "stirling-second-kind-oq-01",
+    "range": {
+      "startLine": 47,
+      "endLine": 60
+    },
+    "type": "key-step",
+    "title": "Solving the Second-Column Recurrence by Induction",
+    "content": "stirlingSecond_two_add proves the shifted form S(n+2,2) = 2^(n+1) − 1 by induction on n. The base case S(2,2) = 1 = 2^1 − 1 is closed by kernel `decide`. In the step, Mathlib's Pascal recurrence specialised to k = 1 gives S(n+3,2) = 2·S(n+2,2) + S(n+2,1); substituting S(n+2,1) = 1 (stirlingSecond_one_right) and the induction hypothesis S(n+2,2) = 2^(n+1) − 1 reduces the goal to 2·(2^(n+1) − 1) + 1 = 2^(n+2) − 1. Over ℕ this is handled by `omega` once the facts 1 ≤ 2^(n+1) and 2^(n+2) = 2·2^(n+1) are in context — the only care needed for the truncated subtraction.",
+    "mathContext": "The second column satisfies $a(n+1) = 2a(n) + 1$ with $a(0)=1$, whose solution is $a(n) = 2^{n+1}-1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "induction",
+      "inhomogeneous linear recurrence",
+      "Nat.stirlingSecond_succ_succ",
+      "natural subtraction"
+    ],
+    "prerequisites": [
+      "Pascal recurrence for Stirling numbers",
+      "omega for linear arithmetic over ℕ"
+    ]
+  },
+  {
+    "id": "ann-textbook-form",
+    "proofId": "stirling-second-kind-oq-01",
+    "range": {
+      "startLine": 62,
+      "endLine": 68
+    },
+    "type": "theorem",
+    "title": "The Closed Form S(n,2) = 2^(n-1) − 1",
+    "content": "stirlingSecond_two restates the result in its standard textbook indexing: for n ≥ 2, S(n,2) = 2^(n-1) − 1. Writing n = m + 2 (possible since n ≥ 2) turns the goal into the shifted form, and because m + 2 − 1 reduces definitionally to m + 1, the proof is exactly stirlingSecond_two_add m with no further rewriting. This is the first nontrivial entry of the Stirling-second-kind triangle expressed as a closed form.",
+    "mathContext": "$S(n,2) = 2^{n-1} - 1$ for $n \\ge 2$ — e.g. $S(3,2)=3$, $S(4,2)=7$, $S(5,2)=15$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "closed-form enumeration",
+      "Stirling triangle",
+      "set partitions into two blocks"
+    ],
+    "prerequisites": [
+      "definitional reduction of natural subtraction",
+      "reindexing n = m + 2"
+    ]
+  },
+  {
+    "id": "ann-existence",
+    "proofId": "stirling-second-kind-oq-01",
+    "range": {
+      "startLine": 70,
+      "endLine": 80
+    },
+    "type": "key-step",
+    "title": "Two-Block Partitions Always Exist",
+    "content": "stirlingSecond_two_pos records the qualitative consequence: for n ≥ 2 there is at least one way to split an n-set into two nonempty blocks, i.e. S(n,2) > 0. Rewriting by the closed form, the claim becomes 2^(n-1) − 1 > 0, which follows from 2 ≤ 2^(n-1) (because n − 1 ≥ 1) via `omega`. A small but honest corollary confirming the closed form is consistent with the obvious combinatorial fact.",
+    "mathContext": "For $n \\ge 2$, $2^{n-1} - 1 \\ge 1 > 0$, so a two-block partition always exists.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "positivity",
+      "monotonicity of 2^n",
+      "existence of partitions"
+    ],
+    "prerequisites": [
+      "Nat.pow_le_pow_right",
+      "omega"
+    ]
+  }
+]

--- a/src/data/proofs/stirling-second-kind-oq-01/meta.json
+++ b/src/data/proofs/stirling-second-kind-oq-01/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "stirling-second-kind-oq-01",
+  "title": "Stirling Numbers of the Second Kind: the two-block column S(n,2) = 2ⁿ⁻¹ − 1",
+  "slug": "stirling-second-kind-oq-01",
+  "description": "The classical closed form for the second column of Stirling's triangle: the number of ways to partition an n-element set into exactly two nonempty blocks is 2^(n-1) − 1. Mathlib records the Pascal recurrences and the boundary columns S(n,n)=1, S(n+1,1)=1, S(n+1,n)=C(n+1,2), but not the k=2 column — this entry fills that gap.",
+  "meta": {
+    "author": "James Stirling (1730)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StirlingSecondKindOQ01.lean",
+    "tags": [
+      "combinatorics",
+      "stirling-numbers",
+      "set-partitions",
+      "enumerative",
+      "closed-form",
+      "classic"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.stirlingSecond_succ_succ",
+        "description": "Pascal recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k) for the Stirling numbers of the second kind",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.stirlingSecond_one_right",
+        "description": "First-column value S(n+1,1) = 1 (a nonempty set has exactly one one-block partition)",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.stirlingSecond_self",
+        "description": "Diagonal value S(n,n) = 1, used for the base case S(2,2) = 1",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.one_le_two_pow",
+        "description": "1 ≤ 2^n, used to discharge the natural-subtraction arithmetic in the inductive step",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "stirlingSecond_two_add: the shifted closed form S(n+2,2) = 2^(n+1) − 1, proved by induction on the Pascal recurrence",
+      "stirlingSecond_two: the textbook closed form S(n,2) = 2^(n-1) − 1 for n ≥ 2",
+      "stirlingSecond_two_pos: every set with at least two elements admits a two-block partition, i.e. S(n,2) > 0 for n ≥ 2"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound. The base case uses kernel `decide` (no `native_decide`, so no `Lean.ofReduceBool`).",
+    "lineCount": 80,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Stirling numbers of the second kind S(n,k) count the partitions of an n-element set into k nonempty, unlabeled blocks; they appear in James Stirling's 1730 *Methodus Differentialis* and are the connection coefficients expressing ordinary powers x^n in terms of falling factorials. Their triangle obeys the Pascal-like recurrence S(n+1,k) = k·S(n,k) + S(n,k-1). The boundary columns are elementary — S(n,1) = 1, S(n,n) = 1, S(n,n-1) = C(n,2) — and Mathlib formalizes all of these. The very next column, k = 2, already has a clean closed form, 2^(n-1) − 1, the first nontrivial entry of the triangle, but it is absent from Mathlib's development.",
+    "problemStatement": "Determine and verify the number of partitions of an n-element set into exactly two nonempty blocks.\n\n**Answer:** S(n,2) = 2^(n-1) − 1 for every n ≥ 2.",
+    "text": "The second column of Stirling's triangle of the second kind has the closed form S(n,2) = 2^(n-1) − 1, derived from the Pascal recurrence and verified in Lean with no axioms.",
+    "proofStrategy": "1. stirlingSecond_two_add: induct on n. The base case S(2,2) = 1 = 2^1 − 1 is `decide`. The step uses Mathlib's Pascal recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k) specialised to k = 1: S(n+3,2) = 2·S(n+2,2) + S(n+2,1). Substituting S(n+2,1) = 1 (stirlingSecond_one_right) and the induction hypothesis S(n+2,2) = 2^(n+1) − 1 gives 2·(2^(n+1) − 1) + 1, which equals 2^(n+2) − 1 by `omega` once 1 ≤ 2^(n+1) and 2^(n+2) = 2·2^(n+1) are supplied.\n2. stirlingSecond_two: rewrite n = m + 2 and read off the textbook form; m + 2 − 1 is definitionally m + 1, so the shifted lemma applies directly.\n3. stirlingSecond_two_pos: from S(n,2) = 2^(n-1) − 1 with 2 ≤ 2^(n-1) (since n − 1 ≥ 1), conclude positivity by `omega`.",
+    "keyInsights": [
+      "**The combinatorial count**: an unordered split of an n-set into two nonempty parts comes from one of the 2^n subsets, after discarding the two improper subsets (∅ and the whole set) and identifying each part with its complement — giving (2^n − 2)/2 = 2^(n-1) − 1.",
+      "**An inhomogeneous geometric recursion**: specialising Pascal's rule to the second column collapses it to a(n+1) = 2·a(n) + 1 (because S(n,1) = 1), the standard recurrence whose solution is 2^(n-1) − 1.",
+      "**Filling a real Mathlib gap**: Mathlib's Stirling file proves the recurrences and the columns S(n,1), S(n,n), and S(n,n-1) = C(n,2), but stops short of the k = 2 closed form. This is the first genuinely nontrivial column value.",
+      "**Natural subtraction handled cleanly**: working over ℕ, the 2^(n-1) − 1 form needs 1 ≤ 2^(n-1); supplying this single fact lets `omega` close every subtraction step without moving to ℤ."
+    ],
+    "prerequisites": [
+      "Stirling numbers of the second kind and set partitions",
+      "Induction on the natural numbers",
+      "The Pascal recurrence for Stirling numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "File-level docstring stating S(n,2) = 2^(n-1) − 1, the combinatorial meaning, and the recurrence used. Imports Mathlib and opens the Nat namespace so the stirlingSecond lemmas are in scope.",
+      "mathContext": "S(n,2) counts partitions of an n-set into two nonempty unlabeled blocks; Mathlib's Nat.stirlingSecond supplies the recurrences and boundary columns."
+    },
+    {
+      "id": "shifted-form",
+      "title": "The Shifted Closed Form S(n+2,2) = 2^(n+1) − 1",
+      "startLine": 41,
+      "endLine": 60,
+      "summary": "stirlingSecond_two_add: induction on n. Base S(2,2)=1 by decide. Step specialises the Pascal recurrence to the second column (S(n+3,2) = 2·S(n+2,2) + S(n+2,1)), substitutes S(n+2,1)=1 and the IH, and closes the natural-subtraction arithmetic with omega given 1 ≤ 2^(n+1).",
+      "mathContext": "a(n+1) = 2·a(n) + 1, a(0) = 1 ⟹ a(n) = 2^(n+1) − 1; here a(n) = S(n+2,2)."
+    },
+    {
+      "id": "textbook-form",
+      "title": "The Textbook Form S(n,2) = 2^(n-1) − 1",
+      "startLine": 62,
+      "endLine": 68,
+      "summary": "stirlingSecond_two: for n ≥ 2, write n = m + 2 and apply the shifted lemma. Since m + 2 − 1 is definitionally m + 1, the result is exactly stirlingSecond_two_add m.",
+      "mathContext": "The standard statement of the result: for n ≥ 2, S(n,2) = 2^(n-1) − 1."
+    },
+    {
+      "id": "existence",
+      "title": "Existence of a Two-Block Partition",
+      "startLine": 70,
+      "endLine": 80,
+      "summary": "stirlingSecond_two_pos: S(n,2) > 0 for n ≥ 2. From the closed form and 2 ≤ 2^(n-1) (as n − 1 ≥ 1), omega gives 2^(n-1) − 1 > 0.",
+      "mathContext": "Any set of size ≥ 2 can be split into two nonempty parts, so the count is strictly positive."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stirling, James",
+      "title": "Methodus Differentialis",
+      "year": "1730",
+      "note": "Origin of the Stirling numbers; S(n,k) as connection coefficients between powers and falling factorials"
+    },
+    {
+      "authors": "Graham, Knuth, Patashnik",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "note": "Chapter 6 develops the Stirling triangle, including the closed form S(n,2) = 2^(n-1) − 1"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "stirling-formula",
+      "relationship": "related",
+      "description": "Shares the Stirling name but concerns a distinct object: Stirling numbers (combinatorial) versus Stirling's asymptotic factorial formula (analytic)"
+    }
+  ],
+  "conclusion": {
+    "summary": "The second column of Stirling's triangle of the second kind has the closed form S(n,2) = 2^(n-1) − 1 (stirlingSecond_two), obtained by solving the inhomogeneous geometric recurrence that Pascal's rule induces on that column. The shifted form (stirlingSecond_two_add) carries the induction and the existence corollary (stirlingSecond_two_pos) records that the count is always positive. All three are verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies the first nontrivial column value of the Stirling-second-kind triangle as a directly citable closed form, complementing Mathlib's recurrences and boundary columns.",
+    "openQuestions": [
+      "Is there a comparably clean closed form for the third column S(n,3) = (3^(n-1) + 1)/2 − 2^(n-1), and can it be derived by the same recurrence-to-geometric-sum method?",
+      "Can the general finite-difference formula S(n,k) = (1/k!)·∑_{j=0}^{k} (−1)^j C(k,j)(k−j)^n be formalized and shown to recover the k = 2 column?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "StirlingSecondKindOQ01",
+    "lineCount": 80,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/StirlingSecondKindOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Fills a genuine gap in Mathlib's Stirling-number development: the **closed form for the second column** of the Stirling triangle of the second kind.

$$S(n,2) = 2^{\,n-1} - 1 \qquad (n \ge 2)$$

where `Nat.stirlingSecond n k` counts the partitions of an $n$-set into $k$ nonempty unlabeled blocks. Mathlib (`Mathlib/Combinatorics/Enumerative/Stirling.lean`) proves the Pascal recurrences and the boundary columns $S(n,1)=1$, $S(n,n)=1$, $S(n,n-1)=\binom{n+1}{2}$ — but **not** the $k=2$ column, the first nontrivial entry of the triangle.

## Theorems (all verified, 0 axioms, 0 sorries)

1. `stirlingSecond_two_add` — shifted form $S(n+2,2) = 2^{n+1}-1$, by induction on the Pascal recurrence.
2. `stirlingSecond_two` — textbook form $S(n,2) = 2^{n-1}-1$ for $n \ge 2$.
3. `stirlingSecond_two_pos` — every set of size $\ge 2$ has a two-block partition ($S(n,2) > 0$).

## Proof idea

Specialising Pascal's rule $S(n+1,k+1) = (k+1)S(n,k+1)+S(n,k)$ to $k=1$ and using $S(n,1)=1$ collapses the second column to the inhomogeneous geometric recursion $a(n+1) = 2a(n)+1$, $a(0)=1$, whose solution is $2^{n-1}-1$. Natural subtraction is discharged by `omega` after supplying $1 \le 2^{n+1}$.

Combinatorially: an unordered split of an $n$-set into two nonempty parts is one of $2^n$ subsets minus the two improper ones, with each part identified with its complement: $(2^n-2)/2 = 2^{n-1}-1$.

## Verification

- Compiles clean against pinned Mathlib 4.26.0 (`lake env lean`).
- `#print axioms`: only `propext`, `Classical.choice`, `Quot.sound`. Base case uses kernel `decide` (no `native_decide`, hence no `Lean.ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)