### PR TITLE
research(p-series-convergence-oq-01): the p-series test — ∑1/nᵖ summable ⟺ p>1 (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2861,6 +2861,7 @@ import Proofs.PompeiuTheorem
 import Proofs.PowerMeanCrossZeroOQ
 import Proofs.PowerMeanLimitOQ
 import Proofs.PowerMeanMonotoneOQ
+import Proofs.PSeriesConvergenceOQ01
 import Proofs.PrimeGapBounds
 import Proofs.PrimeGapBoundsOQ01
 import Proofs.PrimeNumberTheorem

--- a/proofs/Proofs/PSeriesConvergenceOQ01.lean
+++ b/proofs/Proofs/PSeriesConvergenceOQ01.lean
@@ -1,0 +1,82 @@
+/-
+# The p-series convergence test
+
+The *p-series* is the real-valued series
+
+  ∑' n : ℕ, 1 / nᵖ
+
+This file packages the classical convergence dichotomy: the p-series converges
+**if and only if** `1 < p`. In particular the harmonic series (`p = 1`) diverges,
+sitting exactly on the boundary, while every exponent strictly above `1`
+(such as the Basel exponent `p = 2`) converges.
+
+The general real-exponent threshold is the headline statement; we state it for a
+real exponent `p` (using `Real.rpow`), specialise it to a natural-number exponent
+and to the two-sided `ℤ`-indexed series, and record the boundary case `p = 1`
+(the harmonic series) as a divergence corollary.
+
+## Main results
+
+* `pSeries_summable_iff_one_lt` : `Summable (fun n => 1 / (n : ℝ) ^ p) ↔ 1 < p`
+  for a real exponent `p` (rpow form, the sharp threshold).
+* `pSeries_nat_summable_iff_one_lt` : the same for a natural-number exponent.
+* `pSeries_int_summable_iff_one_lt` : the two-sided `ℤ`-indexed version.
+* `harmonic_not_summable` : the harmonic series (`p = 1`) diverges.
+* `pSeries_summable_of_one_lt` / `pSeries_basel_summable` : convergence for
+  `1 < p` and the Basel exponent `p = 2`.
+
+All proofs reduce to the Mathlib `p`-series engine
+(`Real.summable_one_div_nat_rpow` and friends) and are fully machine-checked with
+no additional axioms.
+-/
+
+import Mathlib
+
+namespace PSeriesConvergenceOQ01
+
+open scoped Real
+
+/-- **p-series test (real exponent).** The real-valued series `∑' n, 1 / nᵖ`,
+with `nᵖ` the real power `Real.rpow`, converges **iff** `1 < p`. This is the sharp
+convergence threshold for the p-series. -/
+theorem pSeries_summable_iff_one_lt {p : ℝ} :
+    Summable (fun n : ℕ => 1 / (n : ℝ) ^ p) ↔ 1 < p :=
+  Real.summable_one_div_nat_rpow
+
+/-- **p-series test (natural exponent).** For a natural-number exponent the series
+`∑' n, 1 / nᵖ` (ordinary monoid power) converges **iff** `1 < p`. -/
+theorem pSeries_nat_summable_iff_one_lt {p : ℕ} :
+    Summable (fun n : ℕ => 1 / (n : ℝ) ^ p) ↔ 1 < p :=
+  Real.summable_one_div_nat_pow
+
+/-- **p-series test (two-sided `ℤ`).** The series summed over all integers,
+`∑' n : ℤ, 1 / nᵖ`, converges **iff** `1 < p`. -/
+theorem pSeries_int_summable_iff_one_lt {p : ℕ} :
+    Summable (fun n : ℤ => 1 / (n : ℝ) ^ p) ↔ 1 < p :=
+  Real.summable_one_div_int_pow
+
+/-- **Convergence half** for any real exponent above the threshold: `1 < p`
+implies the p-series converges. -/
+theorem pSeries_summable_of_one_lt {p : ℝ} (hp : 1 < p) :
+    Summable (fun n : ℕ => 1 / (n : ℝ) ^ p) :=
+  pSeries_summable_iff_one_lt.mpr hp
+
+/-- **The harmonic series diverges.** This is the boundary case `p = 1` of the
+test: `∑' n, 1 / n` is *not* summable, so `1 < p` cannot be relaxed to `1 ≤ p`. -/
+theorem harmonic_not_summable :
+    ¬ Summable (fun n : ℕ => 1 / (n : ℝ)) := by
+  simpa using Real.not_summable_one_div_natCast
+
+/-- The harmonic series sits exactly on the boundary: it is the `p = 1`
+instance, where the strict inequality `1 < p` fails. -/
+theorem harmonic_eq_pSeries_one :
+    (fun n : ℕ => 1 / (n : ℝ)) = (fun n : ℕ => 1 / (n : ℝ) ^ (1 : ℕ)) := by
+  simp
+
+/-- **Basel exponent.** The exponent `p = 2` lies above the threshold, so the
+series `∑' n, 1 / n²` converges. -/
+theorem pSeries_basel_summable :
+    Summable (fun n : ℕ => 1 / (n : ℝ) ^ (2 : ℕ)) :=
+  pSeries_nat_summable_iff_one_lt.mpr (by norm_num)
+
+end PSeriesConvergenceOQ01

--- a/src/data/research/problems/p-series-convergence-oq-01.json
+++ b/src/data/research/problems/p-series-convergence-oq-01.json
@@ -1,0 +1,80 @@
+{
+  "slug": "p-series-convergence-oq-01",
+  "title": "The p-Series Convergence Test: ∑ 1/nᵖ Converges iff p > 1",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "started": "2026-06-20T09:20:00Z",
+  "lastUpdate": "2026-06-20T09:20:00Z",
+  "tags": [
+    "analysis",
+    "series",
+    "convergence",
+    "p-series",
+    "harmonic-series",
+    "summability",
+    "seeker-selected",
+    "research"
+  ],
+  "tractability": 9,
+  "significance": 7,
+  "problemStatement": {
+    "formal": "For a real exponent $p$, the p-series $\\sum_{n} 1/n^{p}$ is summable if and only if $1 < p$. The boundary case $p = 1$ (the harmonic series) diverges, and every $p > 1$ (e.g. the Basel exponent $p = 2$) converges. The same threshold holds for natural-number exponents and for the two-sided $\\mathbb{Z}$-indexed series.",
+    "plain": "The p-series 1 + 1/2ᵖ + 1/3ᵖ + … converges exactly when p > 1. At p = 1 it is the harmonic series, which famously diverges — so the test is sharp: the inequality cannot be relaxed to p ≥ 1. For p = 2 one recovers the convergent Basel series ∑ 1/n².",
+    "whyMatters": [
+      "The p-series test is the canonical comparison yardstick of first-year analysis and the workhorse for the comparison/limit-comparison tests.",
+      "It pins down the exact convergence threshold (1 < p) as a clean biconditional, with the harmonic series sitting precisely on the boundary.",
+      "Mathlib has the underlying summability lemmas (Real.summable_one_div_nat_rpow and friends), but the gallery did not expose the p-series convergence dichotomy as a named, reader-facing statement. The existing harmonic-divergence entry covers only the log-weighted/p=1 object, not the general p threshold."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "pSeries_summable_iff_one_lt: Summable (fun n => 1/(n:ℝ)^p) ↔ 1 < p for real exponent p (rpow form, the sharp threshold).",
+      "pSeries_nat_summable_iff_one_lt: same biconditional for a natural-number exponent.",
+      "pSeries_int_summable_iff_one_lt: two-sided ℤ-indexed version, summable ↔ 1 < p.",
+      "harmonic_not_summable: the harmonic series ∑ 1/n diverges (boundary case p = 1), so 1 < p cannot be weakened to 1 ≤ p.",
+      "pSeries_summable_of_one_lt and pSeries_basel_summable: convergence for 1 < p and for the Basel exponent p = 2. Axiom-free, no native_decide."
+    ],
+    "open": [
+      "Cauchy condensation / Schlömilch perspective as a derivation engine rather than a black box.",
+      "Boundary-refinement series ∑ 1/(n (log n)ᵖ) (Bertrand series) and the iterated-logarithm hierarchy."
+    ],
+    "goal": "Expose the p-series convergence test (the sharp 1 < p threshold, harmonic boundary, Basel corollary) in the gallery, axiom-free, on top of Mathlib's PSeries summability lemmas."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-20T09:20:00Z",
+    "iteration": 1,
+    "focus": "ACT: shipped Proofs/PSeriesConvergenceOQ01.lean — real/nat/ℤ threshold biconditionals, harmonic divergence, Basel convergence, axiom-free, sorry-free.",
+    "blockers": [],
+    "nextAction": "Optional: Bertrand series ∑ 1/(n (log n)ᵖ) threshold, or surface the Cauchy condensation engine. Core p-series test complete and verified.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 ACT (researcher-3, 2026-06-20): Built Proofs/PSeriesConvergenceOQ01.lean surfacing the p-series convergence test as reader-facing statements over Mathlib's PSeries API. pSeries_summable_iff_one_lt = Real.summable_one_div_nat_rpow (real exponent, rpow); pSeries_nat_summable_iff_one_lt = Real.summable_one_div_nat_pow; pSeries_int_summable_iff_one_lt = Real.summable_one_div_int_pow (GOTCHA: the int-pow lemma lives in namespace Real, like the nat lemmas, so it needs the Real. prefix despite the grep line not showing it). harmonic_not_summable = `simpa using Real.not_summable_one_div_natCast` (boundary p=1). pSeries_basel_summable from the nat threshold at p=2 via norm_num. Axiom-free (propext/Classical.choice/Quot.sound); no native_decide. Distinct from harmonic-divergence-oq-02 (log-weighted object, p=1 only). Build note: shared Mathlib .lake churned by fleet — used LAKE_UNSAFE=1 lake env lean retry-until-clean-window."
+  },
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Harmonic_series_(mathematics)#p-series"
+    ],
+    "mathlib": [
+      "Real.summable_one_div_nat_rpow, Real.summable_one_div_nat_pow, Real.summable_one_div_int_pow, Real.not_summable_one_div_natCast (Analysis/PSeries.lean)"
+    ]
+  },
+  "relatedProofs": [],
+  "leanFiles": [
+    {
+      "path": "proofs/Proofs/PSeriesConvergenceOQ01.lean",
+      "status": "verified",
+      "axiomCount": 0,
+      "sorryCount": 0
+    }
+  ],
+  "significanceNote": "The sharp p-series convergence threshold (1 < p), with the harmonic series on the boundary and the Basel exponent as corollary — surfaced in the gallery as a named biconditional; absent before."
+}


### PR DESCRIPTION
## Summary

Surfaces the classical **p-series convergence test** as named, reader-facing statements over Mathlib's `Analysis/PSeries.lean` API. The headline is the sharp biconditional: the p-series `∑ 1/nᵖ` is summable **iff** `1 < p`.

## Theorems (all 0-axiom, sorry-free)

- `pSeries_summable_iff_one_lt` — `Summable (fun n => 1/(n:ℝ)^p) ↔ 1 < p` for a **real** exponent `p` (rpow form, the sharp threshold)
- `pSeries_nat_summable_iff_one_lt` — same for a natural-number exponent
- `pSeries_int_summable_iff_one_lt` — two-sided `ℤ`-indexed version
- `harmonic_not_summable` — the harmonic series `∑ 1/n` diverges (boundary case `p = 1`; shows `1 < p` cannot be relaxed to `1 ≤ p`)
- `pSeries_summable_of_one_lt` / `pSeries_basel_summable` — convergence for `1 < p` and the Basel exponent `p = 2`

## Verification

`#print axioms` on every theorem lists only `[propext, Classical.choice, Quot.sound]` — **0 axioms**, no `sorry`, no `native_decide`. Compiled against pinned Mathlib via `lake env lean`.

## Distinctness

Distinct from `harmonic-divergence-oq-02`, which treats the log-weighted object (`logH/n`) at `p = 1` only — neither it nor the Basel/zeta entries state the general `p > 1` threshold as a biconditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)