### PR TITLE
research(legendre-factorial-formula-oq-01): Legendre's formula for the p-adic valuation of n!

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2740,6 +2740,7 @@ import Proofs.LebesgueMeasureOQ03OQ01
 import Proofs.LebesgueMeasureOQ05
 import Proofs.LebesgueMeasureOQ06
 import Proofs.LebesgueMeasureOQ06Aristotle
+import Proofs.LegendreFactorialFormulaOQ01
 import Proofs.LegendreGapEquivalence
 import Proofs.LegendrePartial
 import Proofs.LegendrePrimeGapSqrtBoundSuffices

--- a/proofs/Proofs/LegendreFactorialFormulaOQ01.lean
+++ b/proofs/Proofs/LegendreFactorialFormulaOQ01.lean
@@ -1,0 +1,71 @@
+/-
+# Legendre's Formula for the p-adic Valuation of a Factorial
+
+Legendre's theorem gives a closed form for the exact power of a prime `p`
+dividing `n!`.  Classically it is stated in two equivalent ways:
+
+* **Floor-sum form**:  `vₚ(n!) = ∑_{i ≥ 1} ⌊n / pⁱ⌋`.
+* **Digit-sum form**:  `(p − 1) · vₚ(n!) = n − Sₚ(n)`, where `Sₚ(n)` is the sum
+  of the base-`p` digits of `n`.
+
+Mathlib supplies both forms (`padicValNat_factorial`,
+`sub_one_mul_padicValNat_factorial`) and the bound `vₚ(n!) ≤ n`.  This entry
+packages them as a self-contained statement of Legendre's theorem and adds the
+**solved form**
+
+  `vₚ(n!) = (n − Sₚ(n)) / (p − 1)`,
+
+which expresses the valuation directly (Mathlib only records the `(p − 1)·`
+multiple).  We close with a worked numerical instance, `v₂(10!) = 8`.
+
+All results are fully verified with no `sorry` and no extra axioms.
+-/
+
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
+
+open Nat Finset
+
+namespace LegendreFactorialFormulaOQ01
+
+variable {p : ℕ}
+
+/-- **Legendre's theorem (floor-sum form).**
+For a prime `p` and any bound `b` strictly above `log p n`, the `p`-adic
+valuation of `n!` is the finite sum of the quotients `⌊n / pⁱ⌋`. -/
+theorem padicValNat_factorial_eq_sum [hp : Fact p.Prime] {n b : ℕ}
+    (hnb : Nat.log p n < b) :
+    padicValNat p (n !) = ∑ i ∈ Finset.Ico 1 b, n / p ^ i :=
+  padicValNat_factorial hnb
+
+/-- **Legendre's theorem (digit-sum form).**
+`(p − 1)` times the `p`-adic valuation of `n!` equals `n` minus the sum of the
+base-`p` digits of `n`. -/
+theorem sub_one_mul_padicValNat_factorial_eq [hp : Fact p.Prime] (n : ℕ) :
+    (p - 1) * padicValNat p (n !) = n - (p.digits n).sum :=
+  sub_one_mul_padicValNat_factorial n
+
+/-- **Solved form of Legendre's theorem.**
+The `p`-adic valuation of `n!` is exactly `(n − Sₚ(n)) / (p − 1)`, where
+`Sₚ(n)` is the base-`p` digit sum.  This isolates `vₚ(n!)` itself, whereas
+Mathlib records only the `(p − 1)`-multiple. -/
+theorem padicValNat_factorial_eq_div [hp : Fact p.Prime] (n : ℕ) :
+    padicValNat p (n !) = (n - (p.digits n).sum) / (p - 1) := by
+  have hp1 : 0 < p - 1 := Nat.sub_pos_of_lt hp.out.one_lt
+  have h := sub_one_mul_padicValNat_factorial (p := p) n
+  -- From `(p-1) * v = n - S`, divide both sides by `p - 1`.
+  rw [← h, Nat.mul_div_cancel_left _ hp1]
+
+/-- **Legendre's bound.**  The `p`-adic valuation of `n!` never exceeds `n`. -/
+theorem padicValNat_factorial_le [hp : Fact p.Prime] (n : ℕ) :
+    padicValNat p (n !) ≤ n :=
+  _root_.padicValNat_factorial_le p n
+
+/-- Worked instance: the exact power of `2` dividing `10!` is `2⁸`.
+Via the floor-sum form, `v₂(10!) = ⌊10/2⌋ + ⌊10/4⌋ + ⌊10/8⌋ = 5 + 2 + 1 = 8`. -/
+example : padicValNat 2 (10 !) = 8 := by
+  have : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  rw [padicValNat_factorial_eq_sum (p := 2) (n := 10) (b := 4)
+    (Nat.log_lt_of_lt_pow (by norm_num) (by norm_num))]
+  decide
+
+end LegendreFactorialFormulaOQ01

--- a/src/data/proofs/legendre-factorial-formula-oq-01/meta.json
+++ b/src/data/proofs/legendre-factorial-formula-oq-01/meta.json
@@ -1,0 +1,96 @@
+{
+  "id": "legendre-factorial-formula-oq-01",
+  "title": "Legendre's Formula for the p-adic Valuation of a Factorial",
+  "slug": "legendre-factorial-formula-oq-01",
+  "description": "Legendre's theorem gives the exact power of a prime p dividing n!. Classically it has two equivalent forms: the floor-sum form vₚ(n!) = ∑_{i≥1} ⌊n/pⁱ⌋, and the digit-sum form (p−1)·vₚ(n!) = n − Sₚ(n), where Sₚ(n) is the sum of the base-p digits of n. Mathlib supplies both forms and the bound vₚ(n!) ≤ n; this entry packages them as a self-contained statement of Legendre's theorem and adds the solved form vₚ(n!) = (n − Sₚ(n))/(p−1), which expresses the valuation itself rather than its (p−1)-multiple. A worked instance verifies v₂(10!) = 8.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Legendre%27s_formula",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LegendreFactorialFormulaOQ01.lean",
+    "tags": [
+      "number-theory",
+      "p-adic-valuation",
+      "factorial",
+      "legendre-formula",
+      "prime",
+      "digit-sum",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 71,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-checked from Mathlib with 0 sorries and 0 axioms beyond Lean's foundational propext / Classical.choice / Quot.sound (which all Mathlib developments use). The floor-sum, digit-sum, and bound forms wrap Mathlib's padicValNat_factorial, sub_one_mul_padicValNat_factorial, and padicValNat_factorial_le; the solved form vₚ(n!) = (n − Sₚ(n))/(p−1) is derived from the digit-sum form by exact natural-number division. The numerical instance v₂(10!) = 8 is closed by decide on the finite floor sum (kernel reduction, not native_decide).",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Legendre's formula, due to Adrien-Marie Legendre (1808), determines the exact exponent of a prime p in the factorization of n!. It is one of the oldest explicit results in elementary number theory and a workhorse in the study of binomial coefficients, p-adic analysis, and the distribution of prime powers. The two classical formulations — the floor-sum vₚ(n!) = ⌊n/p⌋ + ⌊n/p²⌋ + ⌊n/p³⌋ + ⋯ and the digit-sum (p−1)·vₚ(n!) = n − Sₚ(n) — are connected by summing the base-p digit expansion. The floor sum counts, level by level, how many of 1,…,n are divisible by each power pⁱ; the digit-sum form reorganizes the same count by base-p digits and is the cleaner statement for many estimates (for instance it makes vₚ(n!) ≤ (n−1)/(p−1) immediate). Kummer's theorem on the valuation of binomial coefficients is the natural sequel. Mathlib carries all three statements (under the names padicValNat_factorial, sub_one_mul_padicValNat_factorial, and padicValNat_factorial_le); the gallery's existing 'legendre-partial' entry concerns the unrelated Legendre conjecture on primes between consecutive squares.",
+    "problemStatement": "Fix a prime p. (1) Floor-sum form: for any bound b with log_p n < b, vₚ(n!) = ∑_{i ∈ [1,b)} ⌊n/pⁱ⌋. (2) Digit-sum form: (p−1)·vₚ(n!) = n − Sₚ(n), where Sₚ(n) is the sum of the base-p digits of n. (3) Solved form: vₚ(n!) = (n − Sₚ(n))/(p−1). (4) Bound: vₚ(n!) ≤ n. Verify the instance v₂(10!) = 8.",
+    "text": "Legendre's formula computes the exact power of a prime dividing a factorial, in both floor-sum and digit-sum forms, plus the solved form isolating the valuation.",
+    "proofStrategy": "The floor-sum and digit-sum forms wrap Mathlib's padicValNat_factorial and sub_one_mul_padicValNat_factorial directly, and the bound wraps padicValNat_factorial_le. The value-add is the solved form: starting from (p−1)·vₚ(n!) = n − Sₚ(n) and 0 < p−1 (since p ≥ 2), divide both sides by p−1 using Nat.mul_div_cancel_left to obtain vₚ(n!) = (n − Sₚ(n))/(p−1) as an exact natural-number quotient (no rounding, since p−1 genuinely divides n − Sₚ(n)). The worked instance v₂(10!) = 8 is closed via the floor-sum form with bound b = 4 (justified by log₂ 10 < 4 = Nat.log_lt_of_lt_pow with 10 < 2⁴), reducing the goal to the finite sum ⌊10/2⌋ + ⌊10/4⌋ + ⌊10/8⌋ = 5 + 2 + 1 = 8, which decide evaluates by kernel reduction.",
+    "keyInsights": [
+      "**Two faces of the same count.** The floor sum ∑⌊n/pⁱ⌋ counts multiples of each prime power among 1,…,n; the digit-sum identity (p−1)·vₚ(n!) = n − Sₚ(n) reorganizes that count by base-p digits. The two are equivalent, but each is sharper for different purposes — the digit form gives the clean bound vₚ(n!) ≤ (n−1)/(p−1) at a glance.",
+      "**Isolating the valuation needs exact divisibility.** Mathlib records only the (p−1)-multiple (p−1)·vₚ(n!) = n − Sₚ(n). Solving for vₚ(n!) itself requires knowing p−1 divides n − Sₚ(n) exactly; this is automatic because the left side is literally (p−1) times an integer, so Nat.mul_div_cancel_left recovers the quotient with no remainder.",
+      "**The bound b is a convenience, not a truncation.** The infinite floor sum is finite because ⌊n/pⁱ⌋ = 0 once pⁱ > n; any bound b above log_p n captures every nonzero term, so the choice b = 4 for n = 10, p = 2 is exact, not approximate.",
+      "**Digit/log functions resist kernel evaluation; the floor sum does not.** Nat.digits and Nat.log are defined by well-founded recursion and do not reduce under decide, so the numerical instance is verified through the floor-sum form (a plain Finset sum of divisions), where decide reduces cleanly — keeping the proof axiom-free (no native_decide)."
+    ],
+    "prerequisites": [
+      "p-adic valuation on the naturals: padicValNat, and the Fact p.Prime instance convention",
+      "Base-p digits and their sum: Nat.digits and Nat.log",
+      "Mathlib's Legendre lemmas: padicValNat_factorial (floor sum), sub_one_mul_padicValNat_factorial (digit sum), padicValNat_factorial_le (bound)",
+      "Exact natural-number division: Nat.mul_div_cancel_left"
+    ]
+  },
+  "conclusion": {
+    "summary": "Legendre's formula is presented in full: the floor-sum form, the digit-sum form, the bound vₚ(n!) ≤ n, and — the new content — the solved form vₚ(n!) = (n − Sₚ(n))/(p−1) isolating the valuation itself. All 4 theorems are fully verified with 0 axioms and 0 sorries, and the instance v₂(10!) = 8 is checked by kernel reduction on the floor sum.",
+    "implications": "The solved form turns Legendre's identity into a direct formula for the valuation, convenient when vₚ(n!) is needed as a value rather than as a side of an equation (e.g. in estimating binomial coefficients or trailing zeros of n!). Packaging both classical forms together makes the entry a reusable reference for downstream p-adic and factorial-divisibility arguments.",
+    "openQuestions": [
+      "Formalize Kummer's theorem in the same packaged style: vₚ(C(n,k)) equals the number of carries when adding k and n−k in base p, and derive the standard corollary that C(2n,n) is divisible by exactly the primes p ≤ 2n with a carry.",
+      "Derive the trailing-zero count of n! in base 10 as min(v₂(n!), v₅(n!)) = v₅(n!) and express it via the digit-sum form, giving a closed expression for the number of terminal zeros of n!."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "legendre-partial",
+      "relationship": "related",
+      "description": "Shares Legendre's name but is mathematically unrelated: 'legendre-partial' concerns the Legendre conjecture (a prime between consecutive squares), whereas this entry is Legendre's factorial formula for p-adic valuations."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "LegendreFactorialFormulaOQ01",
+    "lineCount": 71,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/LegendreFactorialFormulaOQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Legendre, Adrien-Marie",
+      "title": "Essai sur la théorie des nombres",
+      "year": "1808",
+      "venue": "Courcier, Paris (2nd edition)",
+      "note": "Original source of the formula for the exponent of a prime in n!."
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition",
+      "note": "Standard reference for Legendre's formula and base-p digit-sum identities (§6)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **Legendre's formula** for the exact power of a prime `p` dividing `n!`, packaged as a self-contained gallery entry with a genuine value-add beyond Mathlib's existing lemmas.

Four theorems (all verified, **0 axioms**, 0 sorries):

1. **Floor-sum form** — `vₚ(n!) = ∑_{i∈[1,b)} ⌊n/pⁱ⌋` (wraps `padicValNat_factorial`).
2. **Digit-sum form** — `(p−1)·vₚ(n!) = n − Sₚ(n)` (wraps `sub_one_mul_padicValNat_factorial`).
3. **Solved form** — `vₚ(n!) = (n − Sₚ(n))/(p−1)` *(new: isolates the valuation itself; Mathlib records only the `(p−1)`-multiple, derived here via exact `Nat.mul_div_cancel_left`).*
4. **Bound** — `vₚ(n!) ≤ n` (wraps `padicValNat_factorial_le`).

Plus a worked instance `v₂(10!) = 8`, closed by `decide` on the finite floor sum (kernel reduction — **not** `native_decide`, so still axiom-free).

## Verification

- `lake env lean Proofs/LegendreFactorialFormulaOQ01.lean` — exit 0, clean.
- `#print axioms` on the derived `solved form` lists only `propext`, `Classical.choice`, `Quot.sound` (foundational).
- No `sorry`, no `axiom` declarations, no structure-encoded assumptions, no `native_decide`.

## Notes

- Distinct from the existing `legendre-partial` gallery entry, which concerns the unrelated **Legendre conjecture** (a prime between consecutive squares).
- Mathlib gotcha: the source lemmas live at *top level* inside a `section padicValNat` (not a namespace), and `Nat.digits`/`Nat.log` do not kernel-reduce, so the numerical example uses the floor-sum form where `decide` reduces cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)