### PR TITLE
research(lifting-the-exponent-oq-01): Lifting the Exponent in padicValNat form (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2748,6 +2748,7 @@ import Proofs.LeibnizPiOQ01OQ01
 import Proofs.LeibnizPiOQ02
 import Proofs.LeibnizPiOQ02Aristotle
 import Proofs.LeibnizPiOQ03
+import Proofs.LiftingTheExponentOQ01
 import Proofs.LiouvilleTheorem
 import Proofs.LiouvilleTheoremOQ04
 import Proofs.LovaszLocalLemma

--- a/proofs/Proofs/LiftingTheExponentOQ01.lean
+++ b/proofs/Proofs/LiftingTheExponentOQ01.lean
@@ -1,0 +1,116 @@
+import Mathlib.NumberTheory.Multiplicity
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
+import Mathlib.Tactic
+
+/-
+# Lifting the Exponent (LTE) in `padicValNat` form
+
+## What This Proves
+
+The **Lifting the Exponent Lemma** (LTE) is the workhorse behind a huge swath of
+olympiad and analytic-number-theory `p`-adic valuation computations.  For an odd
+prime `p` and integers `x, y` with `p ∣ x - y` but `p ∤ x`, it states
+
+    v_p(xⁿ - yⁿ) = v_p(x - y) + v_p(n)       for every `n ≥ 1`,
+
+and dually, for **odd** exponents `n`,
+
+    v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n).
+
+Here `v_p` is the `p`-adic valuation: the exponent of the highest power of `p`
+dividing its argument.
+
+## Why this is not already in Mathlib
+
+Mathlib proves LTE only in the `emultiplicity` form
+(`Nat.emultiplicity_pow_sub_pow`), where both sides live in the extended naturals
+`ℕ∞` and "valuation of `0`" is `⊤`.  That is the right home for the abstract
+statement, but it is *not* the form a working number theorist uses: the standard
+textbook statement is an honest equation of natural numbers built from
+`padicValNat`.
+
+Bridging the two requires discharging genuine *finiteness* side conditions —
+every argument (`xⁿ - yⁿ`, `x - y`, and `n`) must be nonzero, otherwise its
+`emultiplicity` is `⊤` and the natural-number `padicValNat` equation is simply
+false.  This file does that bridging once and packages the textbook statements,
+together with the most common specialisation `v_p(aⁿ - 1) = v_p(a - 1) + v_p(n)`.
+
+## Approach
+
+The single bridge is `padicValNat_eq_emultiplicity`, which says
+`(padicValNat p m : ℕ∞) = emultiplicity p m` *whenever `m ≠ 0`*.  We:
+
+1. establish the three nonzero side conditions from `y < x` (resp. `0 < x`) and
+   `0 < n`;
+2. cast the target into `ℕ∞`, rewrite each `padicValNat` to an `emultiplicity`;
+3. close with Mathlib's `emultiplicity` LTE;
+4. pull the equality back across the (injective) cast `ℕ ↪ ℕ∞`.
+
+Everything is fully `0`-axiom: no `sorry`, no `axiom`, no `native_decide`.
+-/
+
+namespace LiftingTheExponentOQ01
+
+open scoped Classical
+
+/-- **Lifting the Exponent (subtraction form).**
+For an odd prime `p` with `p ∣ x - y` and `p ∤ x`, and naturals `y < x`, `0 < n`,
+the `p`-adic valuation of `xⁿ - yⁿ` splits as
+`v_p(xⁿ - yⁿ) = v_p(x - y) + v_p(n)`. -/
+theorem padicValNat_pow_sub_pow {p x y n : ℕ} (hp : p.Prime) (hodd : Odd p)
+    (hxy : p ∣ x - y) (hx : ¬ p ∣ x) (hyx : y < x) (hn : 0 < n) :
+    padicValNat p (x ^ n - y ^ n) = padicValNat p (x - y) + padicValNat p n := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hxy0 : x - y ≠ 0 := Nat.sub_ne_zero_of_lt hyx
+  have hpow : y ^ n < x ^ n := Nat.pow_lt_pow_left hyx hn.ne'
+  have hpow0 : x ^ n - y ^ n ≠ 0 := Nat.sub_ne_zero_of_lt hpow
+  have key : (↑(padicValNat p (x ^ n - y ^ n)) : ℕ∞)
+      = ↑(padicValNat p (x - y) + padicValNat p n) := by
+    rw [padicValNat_eq_emultiplicity hpow0, Nat.cast_add,
+        padicValNat_eq_emultiplicity hxy0, padicValNat_eq_emultiplicity hn.ne']
+    exact Nat.emultiplicity_pow_sub_pow hp hodd hxy hx n
+  exact_mod_cast key
+
+/-- **Lifting the Exponent (addition form, odd exponent).**
+For an odd prime `p` with `p ∣ x + y` and `p ∤ x`, and `0 < x`, `Odd n`,
+the `p`-adic valuation of `xⁿ + yⁿ` splits as
+`v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n)`. -/
+theorem padicValNat_pow_add_pow {p x y n : ℕ} (hp : p.Prime) (hodd : Odd p)
+    (hn : Odd n) (hxy : p ∣ x + y) (hx : ¬ p ∣ x) (hx0 : 0 < x) :
+    padicValNat p (x ^ n + y ^ n) = padicValNat p (x + y) + padicValNat p n := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hn0 : n ≠ 0 := hn.pos.ne'
+  have hxn : 0 < x ^ n := pow_pos hx0 n
+  have hxy0 : x + y ≠ 0 := by omega
+  have hpow0 : x ^ n + y ^ n ≠ 0 := by omega
+  have key : (↑(padicValNat p (x ^ n + y ^ n)) : ℕ∞)
+      = ↑(padicValNat p (x + y) + padicValNat p n) := by
+    rw [padicValNat_eq_emultiplicity hpow0, Nat.cast_add,
+        padicValNat_eq_emultiplicity hxy0, padicValNat_eq_emultiplicity hn0]
+    exact Nat.emultiplicity_pow_add_pow hp hodd hxy hx hn
+  exact_mod_cast key
+
+/-- **The workhorse specialisation.**
+For an odd prime `p` dividing `a - 1` with `1 < a`, and `0 < n`,
+`v_p(aⁿ - 1) = v_p(a - 1) + v_p(n)`.  This is the form used to read off the order
+of `p` in numbers like `2ⁿ - 1` or repunits.  Note `p ∤ a` is *automatic*: if
+`p ∣ a` and `p ∣ a - 1` then `p ∣ 1`, impossible for a prime. -/
+theorem padicValNat_pow_sub_one {p a n : ℕ} (hp : p.Prime) (hodd : Odd p)
+    (ha : p ∣ a - 1) (ha1 : 1 < a) (hn : 0 < n) :
+    padicValNat p (a ^ n - 1) = padicValNat p (a - 1) + padicValNat p n := by
+  have hx : ¬ p ∣ a := by
+    intro h
+    have h1 : p ∣ a - (a - 1) := Nat.dvd_sub h ha
+    rw [show a - (a - 1) = 1 from by omega] at h1
+    exact absurd (Nat.le_of_dvd one_pos h1) (Nat.not_le.mpr hp.one_lt)
+  have := padicValNat_pow_sub_pow hp hodd ha hx ha1 hn
+  simpa using this
+
+/-- Concrete check that the corollary computes correctly: with `p = 3`, `a = 4`,
+`n = 6` we have `4⁶ - 1 = 4095 = 3² · 5 · 7 · 13`, so `v_3(4⁶ - 1) = 2`, matching
+`v_3(4 - 1) + v_3(6) = 1 + 1`.  Proved *through the theorem*, not by raw
+computation, so it stays fully axiom-free. -/
+example : padicValNat 3 (4 ^ 6 - 1) = padicValNat 3 (4 - 1) + padicValNat 3 6 :=
+  padicValNat_pow_sub_one (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+
+end LiftingTheExponentOQ01

--- a/src/data/proofs/lifting-the-exponent-oq-01/meta.json
+++ b/src/data/proofs/lifting-the-exponent-oq-01/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "lifting-the-exponent-oq-01",
+  "title": "Lifting the Exponent (LTE) in padicValNat form",
+  "slug": "lifting-the-exponent-oq-01",
+  "description": "The Lifting the Exponent Lemma (LTE) stated as an honest equation of p-adic valuations. For an odd prime p with p | x - y and p ∤ x, v_p(xⁿ - yⁿ) = v_p(x - y) + v_p(n) for every n ≥ 1 (padicValNat_pow_sub_pow); dually for odd exponents n, v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n) (padicValNat_pow_add_pow); and the workhorse specialisation v_p(aⁿ - 1) = v_p(a - 1) + v_p(n) when p | a - 1 (padicValNat_pow_sub_one), where p ∤ a is automatic. Mathlib only proves LTE in emultiplicity (ℕ∞) form (Nat.emultiplicity_pow_sub_pow / Nat.emultiplicity_pow_add_pow); the standard textbook padicValNat form is absent. The value added is the bridge: the nonzero side conditions on xⁿ - yⁿ, x - y, and n are discharged (from y < x resp. 0 < x and 0 < n), the target is cast into ℕ∞ and each padicValNat rewritten to emultiplicity via padicValNat_eq_emultiplicity, Mathlib's emultiplicity LTE closes it, and the equality is pulled back across the injective cast ℕ ↪ ℕ∞. Fully verified, 0 axioms, 0 sorries, no decide/native_decide.",
+  "meta": {
+    "author": "Édouard Lucas / classical olympiad folklore; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lifting-the-exponent_lemma",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "p-adic-valuation",
+      "lifting-the-exponent",
+      "lte",
+      "padic",
+      "multiplicity",
+      "valuation",
+      "olympiad",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/LiftingTheExponentOQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.emultiplicity_pow_sub_pow",
+        "description": "LTE for odd primes in emultiplicity form over ℕ: emultiplicity p (xⁿ - yⁿ) = emultiplicity p (x - y) + emultiplicity p n, given Prime p, Odd p, p ∣ x - y, ¬ p ∣ x. The abstract core of the subtraction form.",
+        "module": "Mathlib.NumberTheory.Multiplicity"
+      },
+      {
+        "theorem": "Nat.emultiplicity_pow_add_pow",
+        "description": "LTE for odd primes and odd exponents in emultiplicity form: emultiplicity p (xⁿ + yⁿ) = emultiplicity p (x + y) + emultiplicity p n, given Prime p, Odd p, Odd n, p ∣ x + y, ¬ p ∣ x. The abstract core of the addition form.",
+        "module": "Mathlib.NumberTheory.Multiplicity"
+      },
+      {
+        "theorem": "padicValNat_eq_emultiplicity",
+        "description": "The finiteness bridge: for Fact p.Prime and m ≠ 0, (padicValNat p m : ℕ∞) = emultiplicity p m. Lets the abstract emultiplicity identity be transported to a natural-number padicValNat identity once nonzeroness is established.",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Defs"
+      },
+      {
+        "theorem": "Nat.pow_lt_pow_left",
+        "description": "y < x and n ≠ 0 give yⁿ < xⁿ, supplying xⁿ - yⁿ ≠ 0 (a side condition the emultiplicity statement hides but the padicValNat statement requires).",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.dvd_sub",
+        "description": "p ∣ a and p ∣ a - 1 give p ∣ a - (a - 1) = 1, used to derive ¬ p ∣ a automatically in the v_p(aⁿ - 1) specialisation.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "padicValNat_pow_sub_pow: v_p(xⁿ - yⁿ) = v_p(x - y) + v_p(n) for odd prime p, p ∣ x - y, ¬ p ∣ x, y < x, 0 < n — the textbook subtraction form of LTE as a natural-number equation (Mathlib has only the emultiplicity/ℕ∞ form)",
+      "padicValNat_pow_add_pow: v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n) for odd prime p, Odd n, p ∣ x + y, ¬ p ∣ x, 0 < x — the addition form",
+      "padicValNat_pow_sub_one: v_p(aⁿ - 1) = v_p(a - 1) + v_p(n) for odd prime p ∣ a - 1, 1 < a, 0 < n — the most-used specialisation, with ¬ p ∣ a derived internally",
+      "The finiteness bridge itself: discharging xⁿ - yⁿ ≠ 0, x - y ≠ 0, n ≠ 0 and transporting the equality across ℕ ↪ ℕ∞ — the work that makes the textbook statement well-posed"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 116,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used; the worked numeric example is proved through the theorem, not by kernel computation.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Lifting the Exponent Lemma is a staple of competition number theory and a packaging of much older p-adic valuation facts going back to work on cyclotomic factors and Lucas sequences. It compresses an entire induction on the exponent into a single additive formula for v_p, and is the standard tool for problems about the highest power of a prime dividing aⁿ ± bⁿ (orders of elements, Zsygmondy-style questions, Mersenne and repunit divisibility). Its sharp split into 'base contribution v_p(x ± y)' plus 'exponent contribution v_p(n)' is exactly what makes such computations mechanical.",
+    "problemStatement": "**Open Question (lifting-the-exponent-oq-01)**: Formalize the Lifting the Exponent Lemma in the standard p-adic valuation form, i.e. as an equation of natural numbers v_p(xⁿ - yⁿ) = v_p(x - y) + v_p(n) (and the odd-exponent additive companion), bridging Mathlib's emultiplicity-valued statement to padicValNat.\n\n**Result**: padicValNat_pow_sub_pow, padicValNat_pow_add_pow, and the specialisation padicValNat_pow_sub_one, all fully verified with 0 axioms.",
+    "text": "For an odd prime p with p dividing x - y but not x, the p-adic valuation of xⁿ - yⁿ equals v_p(x - y) + v_p(n) for every positive n. Dually, for odd n, v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n). In particular v_p(aⁿ - 1) = v_p(a - 1) + v_p(n) whenever p divides a - 1.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Mathlib supplies the abstract identity in extended-natural form: Nat.emultiplicity_pow_sub_pow gives emultiplicity p (xⁿ - yⁿ) = emultiplicity p (x - y) + emultiplicity p n under Prime p, Odd p, p ∣ x - y, ¬ p ∣ x. There is no nonzeroness hypothesis there because emultiplicity 0 = ⊤ makes both sides well-defined even in degenerate cases.\n\n2. To restate it with padicValNat (an honest ℕ) the degenerate cases must be excluded. From y < x and 0 < n we get xⁿ - yⁿ ≠ 0 (via Nat.pow_lt_pow_left) and x - y ≠ 0, and n ≠ 0 from 0 < n.\n\n3. With Fact p.Prime in scope, padicValNat_eq_emultiplicity rewrites each (padicValNat p m : ℕ∞) to emultiplicity p m for the three nonzero arguments. The goal, cast into ℕ∞, becomes exactly the Mathlib emultiplicity identity, which discharges it.\n\n4. The cast ℕ ↪ ℕ∞ is injective, so exact_mod_cast pulls the ℕ∞ equality back to the desired ℕ equality.\n\n5. The addition form is identical but routed through Nat.emultiplicity_pow_add_pow with the Odd n hypothesis; nonzeroness comes from 0 < x. The specialisation padicValNat_pow_sub_one applies the subtraction form at y = 1, deriving ¬ p ∣ a from p ∣ a and p ∣ a - 1 forcing p ∣ 1.",
+    "keyInsights": [
+      "**The valuation form is not a cosmetic restatement of Mathlib's lemma.** emultiplicity lives in ℕ∞ and silently absorbs the degenerate cases (valuation of 0 is ⊤); padicValNat is a genuine natural number, so the textbook equation is only true once xⁿ - yⁿ, x - y, and n are known nonzero. Establishing those side conditions and transporting across the cast is the entire content of the bridge.",
+      "**Nonzeroness is geometric, not algebraic.** xⁿ - yⁿ ≠ 0 reduces to yⁿ < xⁿ, i.e. y < x with n ≥ 1 — exactly the hypotheses already needed to make truncated natural subtraction behave like real subtraction.",
+      "**¬ p ∣ x is free in the repunit form.** In v_p(aⁿ - 1) the hypothesis p ∤ a need not be assumed: p ∣ a together with p ∣ a - 1 would give p ∣ 1, impossible for a prime, so the specialisation has one fewer hypothesis than the general theorem.",
+      "**Reuse over reproof.** All three forms delegate the hard p-adic induction to Mathlib's emultiplicity LTE; the file adds only the finiteness plumbing, keeping the proofs short and fully axiom-free (no native_decide even for the numeric sanity check)."
+    ],
+    "prerequisites": [
+      "The p-adic valuation padicValNat and its relation to multiplicity/emultiplicity",
+      "Mathlib's emultiplicity Lifting the Exponent lemmas for odd primes",
+      "Truncated natural subtraction and the nonzeroness conditions it requires"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring stating LTE in padicValNat form, explaining why Mathlib's emultiplicity statement is not the textbook form and what finiteness bridging is required; imports for the emultiplicity LTE lemmas and the padicValNat/emultiplicity bridge; namespace.",
+      "mathContext": "$v_p(x^n - y^n) = v_p(x - y) + v_p(n)$ for an odd prime $p \\mid x-y$, $p \\nmid x$."
+    },
+    {
+      "id": "sub-form",
+      "title": "LTE — Subtraction Form",
+      "startLine": 56,
+      "endLine": 72,
+      "summary": "padicValNat_pow_sub_pow: establishes x - y ≠ 0 and xⁿ - yⁿ ≠ 0 from y < x, 0 < n, casts the goal into ℕ∞, rewrites each padicValNat to emultiplicity, and closes with Nat.emultiplicity_pow_sub_pow; exact_mod_cast returns to ℕ.",
+      "mathContext": "$v_p(x^n - y^n) = v_p(x - y) + v_p(n)$."
+    },
+    {
+      "id": "add-form",
+      "title": "LTE — Addition Form (Odd Exponent)",
+      "startLine": 74,
+      "endLine": 91,
+      "summary": "padicValNat_pow_add_pow: the dual statement for odd n, with nonzeroness from 0 < x, routed through Nat.emultiplicity_pow_add_pow.",
+      "mathContext": "$v_p(x^n + y^n) = v_p(x + y) + v_p(n)$ for odd $n$."
+    },
+    {
+      "id": "repunit",
+      "title": "Specialisation v_p(aⁿ - 1) and Numeric Check",
+      "startLine": 93,
+      "endLine": 116,
+      "summary": "padicValNat_pow_sub_one: applies the subtraction form at y = 1, deriving ¬ p ∣ a internally from p ∣ a ∧ p ∣ a - 1 ⟹ p ∣ 1; followed by a worked example v_3(4⁶ - 1) = v_3(3) + v_3(6) = 2 proved through the theorem (axiom-free).",
+      "mathContext": "$v_p(a^n - 1) = v_p(a - 1) + v_p(n)$ when $p \\mid a - 1$."
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the Lifting the Exponent Lemma in the standard padicValNat form: the subtraction form v_p(xⁿ - yⁿ) = v_p(x - y) + v_p(n), the odd-exponent addition form v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n), and the specialisation v_p(aⁿ - 1) = v_p(a - 1) + v_p(n).",
+    "implications": "Provides the working number theorist's form of LTE — an honest natural-number valuation equation — which Mathlib previously offered only in the abstract emultiplicity/ℕ∞ form. The reduction makes p-adic valuation computations on aⁿ ± bⁿ mechanical (orders, Mersenne/repunit divisibility, Zsygmondy-style arguments).",
+    "openQuestions": [
+      "Prove the p = 2 companion (the special two-cases form v_2(xⁿ - yⁿ) for even n needs the extra term v_2(x + y) - 1), bridging Mathlib's Int.two_pow_sub_pow to padicValNat.",
+      "Derive a multiplicative-order corollary: for p ∤ a, the order of p in aⁿ - 1 jumps exactly when ord_p(a) ∣ n, packaging LTE with the order of a modulo p."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Multiplicity",
+      "Mathlib.NumberTheory.Padics.PadicVal.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "scoped Classical"
+    ],
+    "namespace": "LiftingTheExponentOQ01",
+    "lineCount": 116,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/LiftingTheExponentOQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Santos, Amir Hossein Parvardi (compiler)",
+      "title": "Lifting The Exponent Lemma (LTE)",
+      "year": "2011",
+      "venue": "AoPS / olympiad notes",
+      "note": "Standard exposition of the subtraction, addition, and p = 2 cases of LTE"
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.NumberTheory.Multiplicity",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Source of the emultiplicity-valued LTE lemmas bridged here to padicValNat"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Lifting the Exponent (LTE) in `padicValNat` form

Formalizes the **Lifting the Exponent Lemma** as an honest equation of `p`-adic valuations — the form a working number theorist actually uses — which Mathlib previously offered only in the abstract `emultiplicity` (`ℕ∞`) form.

### Theorems (all `0`-axiom, `0`-sorry)

- `padicValNat_pow_sub_pow` — for an odd prime `p` with `p ∣ x - y`, `p ∤ x`, `y < x`, `0 < n`:
  `v_p(xⁿ - yⁿ) = v_p(x - y) + v_p(n)`
- `padicValNat_pow_add_pow` — for an odd prime `p` with `p ∣ x + y`, `p ∤ x`, `0 < x`, `Odd n`:
  `v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n)`
- `padicValNat_pow_sub_one` — the workhorse specialisation `v_p(aⁿ - 1) = v_p(a - 1) + v_p(n)` when `p ∣ a - 1` (`p ∤ a` is derived internally)

Plus a worked numeric check `v_3(4⁶ - 1) = v_3(3) + v_3(6) = 2`, proved *through* the theorem (not by `native_decide`), so the file stays axiom-free.

### Why this is not already in Mathlib

Mathlib proves LTE only via `Nat.emultiplicity_pow_sub_pow` / `Nat.emultiplicity_pow_add_pow`, where both sides live in `ℕ∞` and "valuation of `0`" is `⊤`. The textbook natural-number statement requires discharging genuine **finiteness** side conditions (`xⁿ - yⁿ`, `x - y`, `n` all nonzero) — otherwise the `padicValNat` equation is false. The contribution is that bridge: establish nonzeroness from `y < x` / `0 < x` / `0 < n`, cast into `ℕ∞`, rewrite each `padicValNat` to `emultiplicity` via `padicValNat_eq_emultiplicity`, close with Mathlib's LTE, and pull back across the injective cast `ℕ ↪ ℕ∞`.

### Verification

- `#print axioms` on all three theorems: only `propext`, `Classical.choice`, `Quot.sound` (foundational — do not count).
- No `sorry`, no `axiom`, no `decide`/`native_decide`.
- Compiles against pinned Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)