### PR TITLE
research(dirichlet-approximation-theorem-oq-04): Kronecker density — multiples of an irrational are dense mod 1 (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -690,6 +690,7 @@ import Proofs.DirichletApproximation
 import Proofs.DirichletApproximationOQ01
 import Proofs.DirichletApproximationOQ02
 import Proofs.DirichletApproximationOQ03
+import Proofs.DirichletApproximationOQ04
 import Proofs.DirichletApproximationOQ05
 import Proofs.DirichletsTheorem
 import Proofs.DirichletsTheoremOQ01

--- a/proofs/Proofs/DirichletApproximationOQ04.lean
+++ b/proofs/Proofs/DirichletApproximationOQ04.lean
@@ -1,0 +1,107 @@
+/-
+  Kronecker's Density Theorem: Integer Multiples of an Irrational are Dense mod 1
+  (research problem: dirichlet-approximation-theorem-oq-04)
+
+  The parent entry `dirichlet-approximation-theorem` and its open-question siblings study the
+  EXISTENCE and COUNTING of good rational approximations p/q to a real number (oq-01 counts the
+  ~1/q² good approximations; oq-03 re-derives Dirichlet's bound via Minkowski's geometry of
+  numbers; oq-05 proves the dual sharpness statement for the golden ratio).  This file proves the
+  TOPOLOGICAL precursor of equidistribution that underlies all of them:
+
+  **Main result (Kronecker / Weyl, qualitative form).**  For a real number `a`, the integer
+  multiples `{n • a : n ∈ ℤ}`, viewed on the circle `ℝ/ℤ = AddCircle 1`, are *dense* iff `a` is
+  irrational:
+
+        DenseRange (fun n : ℤ => (n • a : AddCircle 1))  ↔  Irrational a.
+
+  Equivalently: an irrational rotation of the circle has every orbit dense (it is *minimal*),
+  while a rational `a = p/q` produces a finite, evenly-spaced orbit of `q` points.
+
+  **Diophantine corollary (homogeneous one-sided approximation).**  Density at the point `0`
+  gives the homogeneous form of Dirichlet's approximation theorem: for irrational `a` and every
+  `ε > 0` there is a *positive integer* `n` whose multiple `n·a` lands within `ε` of an integer,
+
+        ∃ n > 0,  |n·a − round (n·a)|  <  ε.
+
+  Here `|x − round x|` is exactly the distance from `x` to the nearest integer, i.e. the norm of
+  `x` on the circle `AddCircle 1` (`AddCircle.norm_eq` specialised to period `1`).  This is the
+  statement that the fractional parts `{n·a}` accumulate at `0`, the qualitative seed of Weyl's
+  equidistribution theorem.
+
+  **Proof idea.**  The density iff is the period-`1` specialisation of Mathlib's
+  `AddCircle.denseRange_zsmul_coe_iff` (multiples of `a` are dense on the circle of length `p` iff
+  `a/p` is irrational), using `a/1 = a`.  For the corollary we feed density a small *punctured*
+  ball `B(0,ε) ∖ {0}` (nonempty because the circle contains genuine nonzero points arbitrarily
+  close to `0`): density meets it at some `k • a` with `0 < ‖k•a‖ < ε`, forcing `k ≠ 0`.  Taking
+  `n = |k|` and reading the circle norm back as distance-to-nearest-integer gives the bound.
+
+  No new axioms; everything reduces to Mathlib's `AddCircle` API.
+-/
+import Mathlib
+
+open Metric
+
+namespace DirichletApproximationOQ04
+
+/-- **Kronecker's density theorem.**  The integer multiples of `a`, taken on the circle
+`ℝ/ℤ = AddCircle 1`, are dense if and only if `a` is irrational.  This is the period-`1` case of
+`AddCircle.denseRange_zsmul_coe_iff` (`a / 1 = a`). -/
+theorem denseRange_iff_irrational (a : ℝ) :
+    DenseRange (fun n : ℤ => (↑(n • a) : AddCircle (1 : ℝ))) ↔ Irrational a := by
+  have h := AddCircle.denseRange_zsmul_coe_iff (a := a) (p := (1 : ℝ))
+  rwa [div_one] at h
+
+/-- **Homogeneous Dirichlet / Kronecker approximation.**  If `a` is irrational then its integer
+multiples come arbitrarily close to integers: for every `ε > 0` there is a positive integer `n`
+with `|n·a − round (n·a)| < ε`.  The quantity `|x − round x|` is the distance from `x` to the
+nearest integer, equivalently the circle-norm `‖(x : AddCircle 1)‖`. -/
+theorem exists_pos_nat_mul_sub_round_lt {a : ℝ} (ha : Irrational a) {ε : ℝ} (hε : 0 < ε) :
+    ∃ n : ℕ, 0 < n ∧ |(n : ℝ) * a - round ((n : ℝ) * a)| < ε := by
+  -- The orbit of `a` is dense on the circle.
+  have hd : DenseRange (fun n : ℤ => (↑(n • a) : AddCircle (1 : ℝ))) :=
+    (denseRange_iff_irrational a).mpr ha
+  -- A small, genuinely nonzero point of the circle, sitting within `ε` of `0`.
+  set δ : ℝ := min ε 1 / 2 with hδdef
+  have hminpos : 0 < min ε 1 := lt_min hε one_pos
+  have hδpos : 0 < δ := by rw [hδdef]; linarith
+  have hδle : δ ≤ 1 / 2 := by rw [hδdef]; linarith [min_le_right ε 1]
+  have hδlt : δ < ε := by rw [hδdef]; linarith [min_le_left ε 1]
+  -- Its circle-norm equals `δ` because `0 ≤ δ ≤ 1/2`.
+  have hδabs : |δ| ≤ |(1 : ℝ)| / 2 := by rw [abs_of_nonneg hδpos.le, abs_one]; linarith
+  have hnormδ : ‖(↑δ : AddCircle (1 : ℝ))‖ = δ := by
+    rw [(AddCircle.norm_coe_eq_abs_iff (p := (1 : ℝ)) (by norm_num)).mpr hδabs,
+      abs_of_nonneg hδpos.le]
+  -- The punctured ball `B(0, ε) ∖ {0}` is open and nonempty.
+  have hUopen : IsOpen ((ball (0 : AddCircle (1 : ℝ)) ε) \ {0}) :=
+    isOpen_ball.sdiff isClosed_singleton
+  have hδne : (↑δ : AddCircle (1 : ℝ)) ≠ 0 := by
+    rw [← norm_ne_zero_iff, hnormδ]; exact ne_of_gt hδpos
+  have hUne : ((ball (0 : AddCircle (1 : ℝ)) ε) \ {0}).Nonempty := by
+    refine ⟨(↑δ : AddCircle (1 : ℝ)), ?_, ?_⟩
+    · rw [mem_ball, dist_zero_right, hnormδ]; exact hδlt
+    · simpa using hδne
+  -- Density meets the punctured ball: some `k • a` is within `ε` of `0` but not `0`.
+  obtain ⟨k, hk⟩ := hd.exists_mem_open hUopen hUne
+  have hbound : ‖(↑((k : ℝ) * a) : AddCircle (1 : ℝ))‖ < ε := by
+    have hmem := hk.1
+    simp only [mem_ball, dist_zero_right] at hmem
+    rwa [zsmul_eq_mul] at hmem
+  have hkne : (↑(k • a) : AddCircle (1 : ℝ)) ≠ 0 := by simpa using hk.2
+  have hk0 : k ≠ 0 := by rintro rfl; exact hkne (by simp)
+  -- Take `n = |k| > 0` and read the circle-norm back as distance to the nearest integer.
+  refine ⟨k.natAbs, Int.natAbs_pos.mpr hk0, ?_⟩
+  have key : ‖(↑((k.natAbs : ℝ) * a) : AddCircle (1 : ℝ))‖
+      = |(k.natAbs : ℝ) * a - round ((k.natAbs : ℝ) * a)| := by
+    rw [AddCircle.norm_eq, inv_one, one_mul, mul_one]
+  have hnorm_match : ‖(↑((k.natAbs : ℝ) * a) : AddCircle (1 : ℝ))‖
+      = ‖(↑((k : ℝ) * a) : AddCircle (1 : ℝ))‖ := by
+    rw [Nat.cast_natAbs]
+    rcases abs_choice k with h | h
+    · rw [h]
+    · rw [h]
+      push_cast
+      rw [neg_mul, AddCircle.coe_neg, norm_neg]
+  rw [← key, hnorm_match]
+  exact hbound
+
+end DirichletApproximationOQ04

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-04/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-04/annotations.json
@@ -1,0 +1,48 @@
+[
+  {
+    "id": "ann-kronecker-density",
+    "proofId": "dirichlet-approximation-theorem-oq-04",
+    "range": {
+      "startLine": 46,
+      "endLine": 52
+    },
+    "type": "theorem",
+    "title": "Kronecker Density: DenseRange (n ↦ n·a) ↔ Irrational a",
+    "content": "The integer multiples of a, viewed on the circle ℝ/ℤ = AddCircle 1, are dense if and only if a is irrational. This is the period-1 case of Mathlib's AddCircle.denseRange_zsmul_coe_iff, which states that the multiples of a are dense on the circle of length p iff a/p is irrational; substituting p = 1 and a/1 = a gives the classical Kronecker statement. Dynamically it says the irrational rotation x ↦ x + a of the circle is minimal — every orbit is dense — whereas a rational a = p/q produces a finite, periodic orbit of q evenly spaced points.",
+    "mathContext": "$\\operatorname{DenseRange}\\,\\bigl(n \\mapsto n \\cdot a : \\mathbb{Z} \\to \\mathbb{R}/\\mathbb{Z}\\bigr) \\iff a \\notin \\mathbb{Q}$.",
+    "prerequisites": [
+      "The circle ℝ/ℤ as AddCircle 1 and the action of ℤ by multiples of a",
+      "Density of a subgroup / orbit in a topological group"
+    ],
+    "relatedConcepts": [
+      "Kronecker's theorem",
+      "irrational rotation",
+      "minimal dynamical system",
+      "equidistribution"
+    ],
+    "significance": "The qualitative orbit-density statement that the entire dirichlet-approximation family quantifies — the topological seed of Weyl equidistribution and of the homogeneous Diophantine approximation that follows."
+  },
+  {
+    "id": "ann-homogeneous-approximation",
+    "proofId": "dirichlet-approximation-theorem-oq-04",
+    "range": {
+      "startLine": 54,
+      "endLine": 106
+    },
+    "type": "theorem",
+    "title": "Homogeneous Dirichlet Approximation: ∃ n > 0, |n·a − round(n·a)| < ε",
+    "content": "For irrational a and any ε > 0 there is a positive integer n whose multiple n·a lands within ε of an integer. The proof turns orbit density into a concrete witness. First it builds a genuinely nonzero point of the circle within ε of 0: with δ = min(ε,1)/2 ∈ (0,1/2], the bound 0 ≤ δ ≤ 1/2 lets AddCircle.norm_coe_eq_abs_iff compute ‖(↑δ : AddCircle 1)‖ = δ, so ↑δ ≠ 0 sits in the open punctured ball B(0,ε) ∖ {0}. DenseRange.exists_mem_open meets that ball at some ↑(k·a) with ‖↑(k·a)‖ < ε and ↑(k·a) ≠ 0, which forces k ≠ 0. Taking n = |k| > 0 (Int.natAbs_pos) and rewriting the goal via AddCircle.norm_eq — at period 1, ‖(x : AddCircle 1)‖ = |x − round x|, the distance from x to the nearest integer — reduces it to ‖↑(n·a)‖ < ε; a sign case-split (Nat.cast_natAbs, abs_choice, AddCircle.coe_neg, norm_neg) aligns n·a with k·a, closing the bound.",
+    "mathContext": "Punctured-ball extraction: $\\uparrow\\!\\delta \\in B(0,\\varepsilon)\\setminus\\{0\\}$ with $\\delta = \\tfrac12\\min(\\varepsilon,1)$, then $\\|(x : \\mathbb{R}/\\mathbb{Z})\\| = |x - \\operatorname{round} x|$.",
+    "prerequisites": [
+      "DenseRange.exists_mem_open: a dense-range map hits every nonempty open set",
+      "AddCircle.norm_eq and AddCircle.norm_coe_eq_abs_iff for the circle norm",
+      "Int.natAbs, abs_choice and AddCircle.coe_neg for the sign normalisation"
+    ],
+    "relatedConcepts": [
+      "Dirichlet's approximation theorem (homogeneous form)",
+      "distance to the nearest integer",
+      "fractional parts accumulating at 0"
+    ],
+    "significance": "Converts the abstract density statement into the recognizable homogeneous Diophantine bound — the existence of arbitrarily good integer multiples near 0 — by reading the circle norm as distance to ℤ."
+  }
+]

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-04/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-04/meta.json
@@ -1,0 +1,85 @@
+{
+  "id": "dirichlet-approximation-theorem-oq-04",
+  "title": "Dirichlet Approximation OQ-04: Kronecker's Density Theorem",
+  "slug": "dirichlet-approximation-theorem-oq-04",
+  "description": "Kronecker's density theorem and its homogeneous Diophantine corollary. For a real number a, the integer multiples {n·a : n ∈ ℤ}, viewed on the circle ℝ/ℤ = AddCircle 1, are dense if and only if a is irrational: DenseRange (n ↦ n • a) ↔ Irrational a. Equivalently, an irrational rotation of the circle is minimal (every orbit dense), while a rational a = p/q gives a finite, evenly spaced orbit of q points. The topological statement is the qualitative precursor of equidistribution underlying the whole dirichlet-approximation family — oq-01 counts the ~1/q² good approximations, oq-03 re-derives Dirichlet's bound via Minkowski's geometry of numbers, oq-05 proves the dual sharpness statement for the golden ratio, and this entry supplies the orbit-density seed. From density at the point 0 the entry derives the homogeneous form of Dirichlet's approximation theorem: for irrational a and every ε > 0 there is a positive integer n with |n·a − round(n·a)| < ε, i.e. the fractional parts {n·a} accumulate at 0. The density iff is the period-1 specialisation of Mathlib's AddCircle.denseRange_zsmul_coe_iff (multiples of a dense on the circle of length p iff a/p irrational), using a/1 = a; the corollary feeds density a punctured ball B(0,ε) ∖ {0}, reads the circle-norm ‖(x : AddCircle 1)‖ back as distance-to-nearest-integer |x − round x| (AddCircle.norm_eq), and handles the sign so the witness multiplier is a positive natural.",
+  "leanFile": "Proofs/DirichletApproximationOQ04.lean",
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Equidistribution_theorem",
+    "date": "1884",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DirichletApproximationOQ04.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-approximation",
+      "kronecker-density",
+      "equidistribution",
+      "irrationality",
+      "circle-rotation",
+      "topological-dynamics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "relatedProblems": [
+      {
+        "id": "dirichlet-approximation-theorem",
+        "relationship": "Parent entry: proves the EXISTENCE of good approximations |qα − p| < 1/N (1 ≤ q ≤ N) by pigeonhole. This OQ-04 proves the underlying TOPOLOGICAL fact — that the orbit {n·a} is dense mod 1 exactly when a is irrational — from which the homogeneous approximation statement (arbitrarily good {n·a} near 0) follows directly."
+      },
+      {
+        "id": "dirichlet-approximation-theorem-oq-05",
+        "relationship": "Sibling entry: the dual SHARPNESS lower bound, showing the golden ratio is badly approximable. OQ-04 shows every irrational's multiples come arbitrarily close to integers (density); OQ-05 shows that for φ they cannot come too close too fast. Together they bound the orbit behaviour of an irrational rotation from both the qualitative and quantitative sides."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 107,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational propext / Classical.choice / Quot.sound are used (no Lean.ofReduceBool, no native_decide; verifiable with #print axioms denseRange_iff_irrational and #print axioms exists_pos_nat_mul_sub_round_lt). Both results are unconditional. Mathlib supplies AddCircle.denseRange_zsmul_coe_iff (density of multiples on a circle ⟺ irrationality of a/p), the AddCircle normed-group API (AddCircle.norm_eq giving ‖(x : AddCircle 1)‖ = |x − round x|, AddCircle.norm_coe_eq_abs_iff, AddCircle.coe_neg), and DenseRange.exists_mem_open; the original in-file content is the period-1 specialisation, the construction of a nonzero circle point of small norm, the punctured-ball density extraction, and the sign normalisation turning the integer witness into a positive natural with the circle-norm read back as distance to the nearest integer.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Kronecker's theorem (1884), in its one-dimensional form, states that the integer multiples of an irrational number are dense modulo 1. It is the qualitative heart of the theory of uniform distribution: Weyl's equidistribution theorem (1916) refines 'dense' to 'equidistributed', giving the exact asymptotic frequency with which {n·a} visits any subinterval. Dynamically, the map x ↦ x + a on the circle ℝ/ℤ is an irrational rotation; Kronecker's theorem says precisely that an irrational rotation is minimal — every orbit is dense — while a rational rotation a = p/q is periodic with finite orbit of q evenly spaced points. The same density is the homogeneous case of Dirichlet's approximation theorem: that {n·a} accumulates at 0 means n·a can be made arbitrarily close to an integer, the existence statement at the root of metric Diophantine approximation.",
+    "problemStatement": "Show that for a real number $a$, the integer multiples $\\{n a : n \\in \\mathbb{Z}\\}$ are dense in the circle $\\mathbb{R}/\\mathbb{Z}$ if and only if $a$ is irrational, and deduce the homogeneous approximation statement: if $a$ is irrational then for every $\\varepsilon > 0$ there is a positive integer $n$ with\n\n$$\\left| n a - \\operatorname{round}(n a) \\right| < \\varepsilon,$$\n\ni.e. the fractional parts $\\{n a\\}$ come within $\\varepsilon$ of $0$.",
+    "text": "Mathlib's AddCircle.DenseSubgroup file proves the general AddCircle.denseRange_zsmul_coe_iff — the multiples of a are dense on the circle of length p iff a/p is irrational — but never specialises it to the unit circle nor connects it to Diophantine approximation. This entry supplies the period-1 specialisation (a/1 = a) and turns orbit density into the concrete homogeneous bound, reading the circle norm ‖(x : AddCircle 1)‖ back as the distance |x − round x| from x to the nearest integer.",
+    "proofStrategy": "denseRange_iff_irrational is AddCircle.denseRange_zsmul_coe_iff at p = 1, rewritten with a/1 = a. For exists_pos_nat_mul_sub_round_lt: density gives DenseRange (n ↦ ↑(n • a)) on AddCircle 1. Build a genuinely nonzero circle point of small norm by taking δ = min(ε,1)/2 ∈ (0, 1/2]; since 0 ≤ δ ≤ 1/2, AddCircle.norm_coe_eq_abs_iff gives ‖(↑δ : AddCircle 1)‖ = δ, so ↑δ ≠ 0 and ↑δ lies in the open punctured ball B(0,ε) ∖ {0}. DenseRange.exists_mem_open meets this ball at some ↑(k • a) with ‖↑(k·a)‖ < ε and ↑(k·a) ≠ 0, forcing k ≠ 0. Take n = |k| > 0 (Int.natAbs_pos); rewrite the goal |n·a − round(n·a)| via AddCircle.norm_eq (period 1: ‖(x : AddCircle 1)‖ = |x − round x|) as ‖↑(n·a)‖, match it to ‖↑(k·a)‖ by a sign case-split (Nat.cast_natAbs, abs_choice, AddCircle.coe_neg, norm_neg), and conclude with the density bound.",
+    "keyInsights": [
+      "**Density ⟺ irrationality is the qualitative seed of equidistribution**: it says the irrational rotation x ↦ x + a is minimal, the dynamical statement that every other dirichlet-approximation entry quantifies — counting (oq-01), geometry of numbers (oq-03), or sharp lower bounds (oq-05)",
+      "**The circle norm IS distance to the nearest integer**: on AddCircle 1, AddCircle.norm_eq specialises to ‖(x : AddCircle 1)‖ = |x − round x|, so a metric statement about the circle is literally a Diophantine statement about how close n·a gets to ℤ",
+      "**Density is fed a PUNCTURED ball**: to extract a NONtrivial approximation one intersects the orbit with B(0,ε) ∖ {0}, not B(0,ε) — the removed point 0 is what forces the witness multiplier k to be nonzero, hence a genuine positive-integer approximation rather than the empty n = 0",
+      "**Rational vs irrational is a finite/dense dichotomy**: the same iff says a rational rotation has a finite orbit (q evenly spaced points), so density exactly detects irrationality — the topological mirror of the arithmetic fact that a/q ∈ ℤ has bounded denominators"
+    ],
+    "prerequisites": [
+      "Mathlib's AddCircle API: AddCircle.denseRange_zsmul_coe_iff (multiples dense on the length-p circle ⟺ a/p irrational), the normed-group structure on AddCircle, AddCircle.norm_eq (‖(x:AddCircle p)‖ = |x − round(p⁻¹x)·p|), AddCircle.norm_coe_eq_abs_iff, and AddCircle.coe_neg",
+      "DenseRange.exists_mem_open: a dense-range map meets every nonempty open set — the bridge from density to the concrete witness",
+      "Elementary facts: round x as the nearest integer, Int.natAbs and abs_choice for the sign normalisation, and that a nonzero element of a normed group has positive norm"
+    ]
+  },
+  "sections": [
+    {
+      "id": "kronecker-density",
+      "title": "Kronecker Density: Multiples of an Irrational are Dense mod 1",
+      "startLine": 46,
+      "endLine": 52,
+      "mathContext": "$\\operatorname{DenseRange}\\,(n \\mapsto n \\cdot a : \\mathbb{Z} \\to \\mathbb{R}/\\mathbb{Z}) \\iff a \\notin \\mathbb{Q}$.",
+      "summary": "denseRange_iff_irrational specialises Mathlib's AddCircle.denseRange_zsmul_coe_iff to the unit circle AddCircle 1. The general lemma says the multiples of a are dense on the circle of length p iff a/p is irrational; at p = 1 the side condition a/1 = a collapses to Irrational a, giving the clean Kronecker statement that the orbit {n·a} is dense mod 1 exactly when a is irrational."
+    },
+    {
+      "id": "homogeneous-approximation",
+      "title": "Homogeneous Dirichlet Approximation from Orbit Density",
+      "startLine": 54,
+      "endLine": 106,
+      "mathContext": "For irrational $a$ and $\\varepsilon > 0$: $\\exists\\, n > 0,\\ |n a - \\operatorname{round}(n a)| < \\varepsilon$.",
+      "summary": "exists_pos_nat_mul_sub_round_lt turns density into a concrete approximation. A nonzero circle point ↑δ with δ = min(ε,1)/2 ∈ (0,1/2] has norm exactly δ (AddCircle.norm_coe_eq_abs_iff), so it populates the open punctured ball B(0,ε) ∖ {0}. DenseRange.exists_mem_open meets this ball at some ↑(k·a) with ‖↑(k·a)‖ < ε and ↑(k·a) ≠ 0, forcing k ≠ 0. Setting n = |k| > 0 and reading the circle norm back as distance to the nearest integer (AddCircle.norm_eq at period 1, ‖(x:AddCircle 1)‖ = |x − round x|) — with a short sign case-split via Nat.cast_natAbs / abs_choice / AddCircle.coe_neg / norm_neg to align n·a with k·a — yields |n·a − round(n·a)| < ε."
+    }
+  ],
+  "conclusion": "Kronecker's density theorem is formalised sorry-free and axiom-free: the integer multiples of a are dense on ℝ/ℤ iff a is irrational, the period-1 case of Mathlib's general AddCircle density criterion. Density at 0 yields the homogeneous form of Dirichlet's approximation theorem — for irrational a and any ε > 0 a positive integer n makes n·a within ε of an integer — by reading the circle norm as distance to the nearest integer. This supplies the topological/equidistribution precursor that the rest of the dirichlet-approximation family quantifies; sharpening 'dense' to 'equidistributed' (Weyl's theorem) is the natural follow-up.",
+  "crossReferences": [
+    "dirichlet-approximation-theorem",
+    "dirichlet-approximation-theorem-oq-01",
+    "dirichlet-approximation-theorem-oq-03",
+    "dirichlet-approximation-theorem-oq-05"
+  ]
+}

--- a/src/data/research/problems/dirichlet-approximation-theorem-oq-04.json
+++ b/src/data/research/problems/dirichlet-approximation-theorem-oq-04.json
@@ -1,0 +1,59 @@
+{
+  "slug": "dirichlet-approximation-theorem-oq-04",
+  "title": "Kronecker density: integer multiples of an irrational are dense mod 1",
+  "status": "active",
+  "tier": "B",
+  "phase": "VERIFICATION",
+  "tractability": 8,
+  "started": "2026-06-20",
+  "lastUpdate": "2026-06-20",
+  "path": "full",
+  "problemStatement": "The dirichlet-approximation family proves the EXISTENCE and COUNTING of good rational approximations (oq-01 counts the ~1/q² approximations, oq-03 re-derives Dirichlet via Minkowski, oq-05 proves the dual sharpness for the golden ratio). Prove the underlying TOPOLOGICAL precursor — Kronecker's density theorem: for a real a, the integer multiples {n·a : n ∈ ℤ}, viewed on the circle ℝ/ℤ = AddCircle 1, are dense iff a is irrational. Equivalently, an irrational rotation of the circle is minimal. Deduce the homogeneous form of Dirichlet's approximation theorem: for irrational a and every ε>0 there is a positive integer n with |n·a − round(n·a)| < ε, i.e. the fractional parts {n·a} accumulate at 0.",
+  "significance": 7,
+  "tags": [
+    "number-theory",
+    "diophantine-approximation",
+    "kronecker-density",
+    "equidistribution",
+    "irrationality",
+    "topological-dynamics"
+  ],
+  "approaches": [
+    {
+      "name": "AddCircle.denseRange_zsmul_coe_iff at p = 1, then punctured-ball density extraction",
+      "outcome": "success (build-verified)",
+      "notes": "Two theorems, sorry-free and axiom-free. (1) denseRange_iff_irrational: DenseRange (n ↦ ↑(n • a) : ℤ → AddCircle 1) ↔ Irrational a is the period-1 specialisation of Mathlib's AddCircle.denseRange_zsmul_coe_iff (multiples of a dense on the circle of length p ⟺ Irrational (a/p)), using a/1 = a (div_one). (2) exists_pos_nat_mul_sub_round_lt: from density, build a nonzero circle point ↑δ with δ = min(ε,1)/2 ∈ (0,1/2]; AddCircle.norm_coe_eq_abs_iff gives ‖↑δ‖ = δ so ↑δ ∈ B(0,ε) ∖ {0} (open, nonempty). DenseRange.exists_mem_open meets it at ↑(k·a) with ‖↑(k·a)‖ < ε and ↑(k·a) ≠ 0 ⇒ k ≠ 0. Take n = |k| > 0 (Int.natAbs_pos); rewrite |n·a − round(n·a)| via AddCircle.norm_eq (period 1: ‖(x:AddCircle 1)‖ = |x − round x|) and align n·a with k·a by a sign case-split (Nat.cast_natAbs, abs_choice, AddCircle.coe_neg, norm_neg)."
+    },
+    {
+      "name": "Three-distance / equidistribution (Weyl) route",
+      "outcome": "not pursued",
+      "notes": "Weyl's criterion would upgrade 'dense' to 'equidistributed' (the quantitative refinement), and the three-distance theorem describes the gap structure of {n·a : n < N}. Both are heavier than needed for the qualitative density statement, which falls straight out of Mathlib's AddCircle subgroup-density API. Equidistribution is the natural follow-up."
+    }
+  ],
+  "knownResults": [
+    "Kronecker (1884): the multiples of an irrational are dense modulo 1; the irrational rotation x ↦ x + a on ℝ/ℤ is minimal.",
+    "Weyl (1916): {n·a} is in fact equidistributed in [0,1) for irrational a — the quantitative refinement of density.",
+    "Mathlib AddCircle.denseRange_zsmul_coe_iff: DenseRange (· • a : ℤ → AddCircle p) ↔ Irrational (a / p); and AddCircle.denseRange_zsmul_iff via addOrderOf = 0.",
+    "Mathlib AddCircle normed-group API: AddCircle.norm_eq (‖(x:AddCircle p)‖ = |x − round(p⁻¹·x)·p|), AddCircle.norm_coe_eq_abs_iff, AddCircle.coe_neg."
+  ],
+  "relatedProofs": [
+    "dirichlet-approximation-theorem (parent, existence of good approximations by pigeonhole)",
+    "dirichlet-approximation-theorem-oq-01 (sibling, infinitude/counting of good approximations)",
+    "dirichlet-approximation-theorem-oq-03 (sibling, Minkowski geometry-of-numbers re-derivation)",
+    "dirichlet-approximation-theorem-oq-05 (sibling, dual sharpness lower bound for the golden ratio)"
+  ],
+  "currentState": {
+    "summary": "Kronecker's density theorem formalised at period 1 (denseRange_iff_irrational) plus its homogeneous Diophantine corollary (exists_pos_nat_mul_sub_round_lt: ∃ n>0, |n·a − round(n·a)| < ε for irrational a). Sorry-free and axiom-free. The density iff specialises Mathlib's general AddCircle criterion; the corollary turns orbit density into a concrete approximation by reading the circle norm as distance to the nearest integer. This supplies the topological/equidistribution precursor that the rest of the family quantifies.",
+    "leanFile": "proofs/Proofs/DirichletApproximationOQ04.lean",
+    "sorries": 0,
+    "axioms": 0,
+    "buildVerified": true
+  },
+  "references": [
+    "Mathlib/Topology/Instances/AddCircle/DenseSubgroup.lean (denseRange_zsmul_coe_iff, denseRange_zsmul_iff)",
+    "Mathlib/Analysis/Normed/Group/AddCircle.lean (norm_eq, norm_coe_eq_abs_iff)",
+    "Mathlib/Topology/Instances/AddCircle/Defs.lean (coe_neg, coe_zsmul)",
+    "https://en.wikipedia.org/wiki/Equidistribution_theorem",
+    "https://en.wikipedia.org/wiki/Kronecker%27s_theorem"
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes **Kronecker's density theorem** and its homogeneous Diophantine corollary — the topological/equidistribution precursor underlying the whole `dirichlet-approximation-theorem` family. Verified, sorry-free, 0-axiom.

**`denseRange_iff_irrational`** — for a real `a`, the integer multiples `{n·a : n ∈ ℤ}` on the circle `ℝ/ℤ = AddCircle 1` are dense iff `a` is irrational:
```
DenseRange (fun n : ℤ => (↑(n • a) : AddCircle 1)) ↔ Irrational a
```
This is the period-`1` specialisation of Mathlib's `AddCircle.denseRange_zsmul_coe_iff` (multiples dense on the circle of length `p` ⟺ `Irrational (a/p)`), using `a/1 = a`. Dynamically: an irrational rotation of the circle is minimal; a rational `a = p/q` gives a finite, evenly-spaced orbit.

**`exists_pos_nat_mul_sub_round_lt`** — homogeneous Dirichlet approximation: for irrational `a` and every `ε > 0`,
```
∃ n : ℕ, 0 < n ∧ |n·a − round (n·a)| < ε
```
i.e. the fractional parts `{n·a}` accumulate at `0`. The proof feeds density a punctured ball `B(0,ε) ∖ {0}` (nonempty via a nonzero circle point of norm `δ = min(ε,1)/2`), extracts `k ≠ 0` with `‖↑(k·a)‖ < ε`, takes `n = |k|`, and reads the circle norm back as distance-to-nearest-integer via `AddCircle.norm_eq` (`‖(x:AddCircle 1)‖ = |x − round x|`), with a short sign case-split.

## Relationship to the family

The siblings quantify the orbit of an irrational rotation; this entry supplies the qualitative seed:
- oq-01 counts the ~`1/q²` good approximations
- oq-03 re-derives Dirichlet via Minkowski's geometry of numbers
- oq-05 proves the dual sharpness lower bound for the golden ratio

## Verification

`#print axioms` on both theorems lists only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`. Type-checks against pinned Mathlib 4.26.0 (`lake env lean Proofs/DirichletApproximationOQ04.lean`, exit 0).

## Files
- `proofs/Proofs/DirichletApproximationOQ04.lean` (new, 107 lines, 2 theorems)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/dirichlet-approximation-theorem-oq-04/{meta,annotations}.json` (gallery)
- `src/data/research/problems/dirichlet-approximation-theorem-oq-04.json` (research record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)