### PR TITLE
research(burnside-counting-oq-05): reflection-fixed colorings of an odd cycle = k^((n+1)/2) (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -394,6 +394,7 @@ import Proofs.BurnsideCounting
 import Proofs.BurnsideCountingOQ03
 import Proofs.BurnsideCountingOQ03Aristotle
 import Proofs.BurnsideCountingOQ03OQ03
+import Proofs.BurnsideCountingOQ05
 import Proofs.CantorDiagonalization
 import Proofs.CantorDiagonalizationOQ01
 import Proofs.CantorDiagonalizationOQ01OQ01

--- a/proofs/Proofs/BurnsideCountingOQ05.lean
+++ b/proofs/Proofs/BurnsideCountingOQ05.lean
@@ -1,0 +1,137 @@
+import Mathlib
+
+/-
+# Burnside Counting: Colorings Fixed by a Reflection of a Cycle
+
+For the dihedral group `D_n` acting on the `n` positions of a cycle, this file counts
+the `k`-colorings fixed by a **reflection**. We model the positions as `ZMod n` and the
+reflection through position `0` as negation `i ↦ -i` (an involution).
+
+A coloring `c : ZMod n → Fin k` is fixed by the reflection iff `c (-i) = c i` for all `i`,
+i.e. `c` is constant on each reflection orbit `{i, -i}`. For **odd** `n = 2m+1` the only
+fixed point of the reflection is `0`, so the orbits are `{0}` together with the `m` pairs
+`{j, -j}` for `1 ≤ j ≤ m`; there are `m + 1 = (n+1)/2` orbits, and a fixed coloring assigns
+one of `k` colors freely to each orbit. Hence the count is `k^((n+1)/2)`.
+
+## Main results
+
+* `reflect_involutive` — the reflection is an involution.
+* `reflect_fixed_iff_zero` — for odd `n` the reflection fixes only `0`.
+* `card_reflectionInvariant` — there are exactly `k^(m+1)` colorings of `ZMod (2m+1)`
+  invariant under negation.
+* `card_reflectionInvariant_odd` — restated for any odd `n` as `k^((n+1)/2)`.
+
+The proof is a fully explicit bijection: a reflection-invariant coloring is determined by
+its values on the fundamental domain `{0, 1, …, m}`, which it reconstructs by *folding*
+each position `i` to `min(i.val, n - i.val)`.
+
+This is the reflection (parity-dependent) counterpart of the rotation count
+`k^gcd(n,r)` in `BurnsideCountingOQ03.lean`; the two reflection/rotation pieces together
+feed Burnside's lemma for the full dihedral necklace count. Absent from Mathlib.
+-/
+
+namespace BurnsideCountingOQ05
+
+variable {k : ℕ}
+
+/-- The reflection of the `n`-cycle through position `0`, modelled as negation on `ZMod n`. -/
+def reflect {n : ℕ} (i : ZMod n) : ZMod n := -i
+
+theorem reflect_involutive {n : ℕ} : Function.Involutive (reflect (n := n)) := by
+  intro i; simp [reflect]
+
+/-- For odd `n = 2m+1`, the reflection `i ↦ -i` fixes only the position `0`. -/
+theorem reflect_fixed_iff_zero (m : ℕ) (i : ZMod (2 * m + 1)) :
+    reflect i = i ↔ i = 0 := by
+  constructor
+  · intro h
+    -- `-i = i` gives `2 • i = 0`; since `2` is a unit mod the odd number `2m+1`, `i = 0`.
+    have h2 : (2 : ZMod (2 * m + 1)) * i = 0 := by
+      have hii : i + i = 0 := by
+        have := h; simp only [reflect] at this; linear_combination -this
+      linear_combination hii
+    have hcop : Nat.Coprime 2 (2 * m + 1) := by
+      rw [Nat.coprime_two_left]; exact ⟨m, rfl⟩
+    have hu : IsUnit (2 : ZMod (2 * m + 1)) := by
+      have := (ZMod.isUnit_iff_coprime 2 (2 * m + 1)).mpr hcop
+      rwa [Nat.cast_ofNat] at this
+    exact (hu.mul_right_eq_zero).mp h2
+  · rintro rfl; simp [reflect]
+
+/-- Inclusion of the fundamental domain `{0,…,m}` (as `Fin (m+1)`) into the cycle. -/
+def incl (m : ℕ) (j : Fin (m + 1)) : ZMod (2 * m + 1) := (j.val : ZMod (2 * m + 1))
+
+/-- Fold a position to its representative in `{0,…,m}` by `i ↦ min(i.val, n - i.val)`. -/
+def fold (m : ℕ) (i : ZMod (2 * m + 1)) : Fin (m + 1) :=
+  ⟨min i.val (2 * m + 1 - i.val), by have h := ZMod.val_lt i; omega⟩
+
+theorem fold_incl (m : ℕ) (j : Fin (m + 1)) : fold m (incl m j) = j := by
+  have hj : j.val < 2 * m + 1 := by omega
+  apply Fin.ext
+  simp only [fold, incl, ZMod.val_natCast_of_lt hj]
+  have : j.val ≤ m := by omega
+  omega
+
+theorem fold_neg (m : ℕ) (i : ZMod (2 * m + 1)) : fold m (-i) = fold m i := by
+  apply Fin.ext
+  simp only [fold]
+  rcases eq_or_ne i 0 with hi | hi
+  · subst hi; simp
+  · have hv := ZMod.val_lt i
+    have hpos : 0 < i.val := by
+      rcases Nat.eq_zero_or_pos i.val with h0 | h0
+      · exact absurd ((ZMod.val_eq_zero i).mp h0) hi
+      · exact h0
+    rw [ZMod.neg_val, if_neg hi]
+    omega
+
+theorem incl_fold (m : ℕ) (i : ZMod (2 * m + 1)) :
+    incl m (fold m i) = i ∨ incl m (fold m i) = -i := by
+  have hv := ZMod.val_lt i
+  rcases le_total i.val (2 * m + 1 - i.val) with h | h
+  · left
+    have hmin : min i.val (2 * m + 1 - i.val) = i.val := by omega
+    simp only [incl, fold, hmin, ZMod.natCast_zmod_val]
+  · right
+    have hmin : min i.val (2 * m + 1 - i.val) = 2 * m + 1 - i.val := by omega
+    simp only [incl, fold, hmin]
+    have hle : i.val ≤ 2 * m + 1 := le_of_lt hv
+    rw [Nat.cast_sub hle, ZMod.natCast_self, ZMod.natCast_zmod_val, zero_sub]
+
+/-- The explicit bijection: a reflection-invariant coloring of `ZMod (2m+1)` is the same
+data as an arbitrary coloring of the fundamental domain `Fin (m+1)`. -/
+def reflectionInvariantEquiv (m k : ℕ) :
+    {c : ZMod (2 * m + 1) → Fin k // ∀ i, c (-i) = c i} ≃ (Fin (m + 1) → Fin k) where
+  toFun c j := c.1 (incl m j)
+  invFun g := ⟨fun i => g (fold m i), by intro i; show g (fold m (-i)) = g (fold m i); rw [fold_neg]⟩
+  left_inv := by
+    rintro ⟨c, hc⟩
+    apply Subtype.ext
+    funext i
+    show c (incl m (fold m i)) = c i
+    rcases incl_fold m i with h | h
+    · rw [h]
+    · rw [h]; exact hc i
+  right_inv := by
+    intro g
+    funext j
+    show g (fold m (incl m j)) = g j
+    rw [fold_incl]
+
+/-- **Reflection-fixed colorings of an odd cycle.** For `n = 2m+1`, exactly `k^(m+1)`
+colorings are invariant under the reflection `i ↦ -i`. -/
+theorem card_reflectionInvariant (m k : ℕ) :
+    Fintype.card {c : ZMod (2 * m + 1) → Fin k // ∀ i, c (-i) = c i} = k ^ (m + 1) := by
+  rw [Fintype.card_congr (reflectionInvariantEquiv m k), Fintype.card_fun,
+    Fintype.card_fin, Fintype.card_fin]
+
+/-- **Reflection count, odd case.** For any odd `n`, the number of `k`-colorings of the
+`n`-cycle fixed by a reflection is `k^((n+1)/2)`. -/
+theorem card_reflectionInvariant_odd (n k : ℕ) [NeZero n] (hn : Odd n) :
+    Fintype.card {c : ZMod n → Fin k // ∀ i, c (-i) = c i} = k ^ ((n + 1) / 2) := by
+  obtain ⟨m, rfl⟩ := hn
+  rw [card_reflectionInvariant]
+  congr 1
+  omega
+
+end BurnsideCountingOQ05

--- a/src/data/proofs/burnside-counting-oq-05/meta.json
+++ b/src/data/proofs/burnside-counting-oq-05/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "burnside-counting-oq-05",
+  "title": "Reflection-Fixed Colorings of an Odd Cycle: k^((n+1)/2)",
+  "slug": "burnside-counting-oq-05",
+  "description": "For the dihedral group acting on the n positions of a cycle, the number of k-colorings fixed by a reflection is counted. Modelling positions as ZMod n and the reflection through position 0 as negation i ↦ −i (an involution), a coloring is fixed iff it is constant on each orbit {i, −i}. For odd n = 2m+1 the reflection fixes only 0, so the orbits are {0} together with the m pairs {j, −j}; there are m+1 = (n+1)/2 orbits and each receives a free color, giving exactly k^((n+1)/2) fixed colorings. The count is established by an explicit bijection with colorings of the fundamental domain {0,…,m}, reconstructed by folding each position i to min(i.val, n−i.val).",
+  "meta": {
+    "author": "Burnside / Pólya theory; formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ05.lean",
+    "tags": [
+      "combinatorics",
+      "group-action",
+      "burnside",
+      "dihedral-group",
+      "necklaces",
+      "fixed-points",
+      "zmod",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.card_fun",
+        "description": "card (α → β) = card β ^ card α — turns the bijection with colorings of the (m+1)-element fundamental domain into the power k^(m+1)",
+        "module": "Mathlib.Data.Fintype.BigOperators"
+      },
+      {
+        "theorem": "ZMod.neg_val",
+        "description": "(−a).val = if a = 0 then 0 else n − a.val — the value-level description of the reflection used to prove the fold is reflection-invariant",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_zmod_val",
+        "description": "(↑a.val : ZMod n) = a — recovers a position from its representative, the inverse half of the fundamental-domain bijection",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.isUnit_iff_coprime",
+        "description": "IsUnit (↑a : ZMod n) ↔ a.Coprime n — shows 2 is a unit mod the odd number 2m+1, so the reflection fixes only 0",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "reflect / reflect_involutive: the reflection of the n-cycle through position 0, modelled as negation on ZMod n, is an involution",
+      "reflect_fixed_iff_zero: for odd n = 2m+1 the reflection fixes only the position 0 (2 is a unit modulo the odd modulus)",
+      "fold / incl / fold_incl / fold_neg / incl_fold: an explicit fundamental domain {0,…,m} with the folding map i ↦ min(i.val, n−i.val), shown invariant under the reflection and a section of the inclusion",
+      "reflectionInvariantEquiv: the explicit bijection {c : ZMod (2m+1) → Fin k // ∀ i, c(−i)=c i} ≃ (Fin (m+1) → Fin k)",
+      "card_reflectionInvariant: exactly k^(m+1) colorings of ZMod (2m+1) are invariant under the reflection",
+      "card_reflectionInvariant_odd: restated for any odd n as k^((n+1)/2)"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 137,
+    "theoremCount": 7,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Counting colorings up to symmetry is the province of the Burnside (Cauchy–Frobenius) lemma and its refinement, the Pólya enumeration theorem: the number of inequivalent colorings equals the average over the group of the number of colorings each symmetry fixes. For the dihedral group D_n acting on a cycle of n beads, the symmetries split into rotations and reflections. The rotation contributions are the gcd-counts k^gcd(n,r) (cf. oq-03); the reflection contributions, computed here, depend on the parity of n and on whether the axis passes through vertices or edge-midpoints. For odd n every reflection axis passes through one vertex and the midpoint of the opposite edge, fixing a single bead, and each reflection fixes exactly k^((n+1)/2) colorings.",
+    "problemStatement": "How many k-colorings of an n-cycle are fixed by a reflection?\n\n**Answer (odd n = 2m+1): k^((n+1)/2).** Modelling positions as ZMod n with the reflection i ↦ −i, a coloring is fixed iff it is constant on each orbit {i, −i}. For odd n the only fixed point is 0, so there are m+1 = (n+1)/2 orbits, each freely colored, giving k^((n+1)/2).",
+    "text": "A reflection of an odd n-cycle fixes exactly k^((n+1)/2) of the k-colorings.",
+    "proofStrategy": "Model the reflection as negation on ZMod (2m+1); it is an involution whose only fixed point is 0 (since 2 is a unit modulo the odd modulus). Build a fundamental domain Fin (m+1) ≅ {0,…,m} with inclusion incl j = (j : ZMod n) and folding map fold i = min(i.val, n−i.val). Prove fold ∘ incl = id (fold_incl), fold(−i) = fold i (fold_neg, via ZMod.neg_val and omega), and that incl(fold i) is either i or −i (incl_fold). These assemble into an explicit Equiv between reflection-invariant colorings and arbitrary colorings of the fundamental domain; Fintype.card_fun then evaluates the count as k^(m+1) = k^((n+1)/2).",
+    "keyInsights": [
+      "A reflection-invariant coloring is exactly a coloring of the orbit space, and for the negation involution on an odd ZMod n the orbit space is the fundamental domain {0,…,m}",
+      "Folding by i ↦ min(i.val, n−i.val) is a clean, computable section that turns the orbit structure into an explicit bijection — no abstract quotient or orbit-counting lemma is needed",
+      "Oddness enters in exactly one place: 2 is a unit modulo 2m+1, so the reflection fixes only 0; this is what makes the orbit count (n+1)/2 rather than a parity-split formula",
+      "The count k^((n+1)/2) is the reflection half of the dihedral Burnside average, complementary to the rotation count k^gcd(n,r)"
+    ],
+    "prerequisites": [
+      "Group actions and the Burnside/Cauchy–Frobenius counting philosophy",
+      "The ring ZMod n and its value function (ZMod.val, ZMod.neg_val)",
+      "Counting functions on a finite type: card (α → β) = card β ^ card α"
+    ]
+  },
+  "sections": [
+    {
+      "id": "reflection",
+      "title": "The Reflection as an Involution",
+      "startLine": 40,
+      "endLine": 64,
+      "summary": "reflect i = −i on ZMod n is an involution; for odd n = 2m+1 it fixes only 0, because 2 is a unit modulo the odd modulus.",
+      "mathContext": "$\\mathrm{reflect}(i) = -i$, and for odd $n$, $-i = i \\iff i = 0$."
+    },
+    {
+      "id": "fundamental-domain",
+      "title": "Fundamental Domain and Folding",
+      "startLine": 66,
+      "endLine": 113,
+      "summary": "incl includes {0,…,m} into ZMod n; fold i = min(i.val, n−i.val) returns each position to its representative. fold∘incl=id, fold(−i)=fold i, and incl(fold i) ∈ {i, −i}.",
+      "mathContext": "$\\mathrm{fold}(i) = \\min(i.\\mathrm{val},\\, n - i.\\mathrm{val})$, with $\\mathrm{fold}(-i) = \\mathrm{fold}(i)$."
+    },
+    {
+      "id": "bijection",
+      "title": "The Counting Bijection",
+      "startLine": 115,
+      "endLine": 131,
+      "summary": "An explicit Equiv between reflection-invariant colorings of ZMod (2m+1) and arbitrary colorings of Fin (m+1).",
+      "mathContext": "$\\{c : \\mathbb{Z}/(2m{+}1) \\to \\mathrm{Fin}\\,k \\mid c(-i)=c(i)\\} \\simeq (\\mathrm{Fin}(m{+}1) \\to \\mathrm{Fin}\\,k)$."
+    },
+    {
+      "id": "count",
+      "title": "The Count k^((n+1)/2)",
+      "startLine": 133,
+      "endLine": 137,
+      "summary": "Fintype.card_fun evaluates the bijection to k^(m+1) = k^((n+1)/2) for any odd n.",
+      "mathContext": "$\\#\\{\\text{reflection-fixed colorings}\\} = k^{(n+1)/2}$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Burnside, W.",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "note": "The orbit-counting (Cauchy–Frobenius) lemma underlying necklace enumeration"
+    },
+    {
+      "authors": "Pólya, G.",
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "note": "Enumeration under group actions; dihedral necklace counts"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "burnside-counting-oq-03",
+      "relationship": "related",
+      "description": "oq-03 counts rotation-fixed colorings as k^gcd(n,r); this entry counts the orthogonal reflection-fixed colorings as k^((n+1)/2) for odd n. Together they supply the two families of terms in the dihedral Burnside average."
+    },
+    {
+      "targetId": "burnside-counting",
+      "relationship": "extends",
+      "description": "Extends the base Burnside fixed-point counting to the reflection symmetries of the dihedral group on an odd cycle."
+    }
+  ],
+  "conclusion": {
+    "summary": "For odd n = 2m+1, exactly k^((n+1)/2) of the k-colorings of an n-cycle are fixed by a reflection, proved by an explicit fundamental-domain bijection with 0 axioms: the negation involution on ZMod n has the single fixed point 0, and folding each position to min(i.val, n−i.val) realises the orbit space as {0,…,m}.",
+    "implications": "Supplies the reflection contribution to the dihedral Burnside/Pólya necklace count in fully verified form, using a concrete computable section instead of abstract orbit-quotient machinery — a reusable template for counting fixtures of involutions on ZMod n.",
+    "openQuestions": [
+      "What is the analogous count for even n, where reflections split into vertex-axis (k^(n/2+1)) and edge-axis (k^(n/2)) types?",
+      "Can the reflection and rotation counts be assembled into a fully formalized closed form for the number of inequivalent dihedral necklaces via Burnside's lemma?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "BurnsideCountingOQ05",
+    "lineCount": 137,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 4,
+    "path": "Proofs/BurnsideCountingOQ05.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Counts the **k-colorings of an n-cycle fixed by a dihedral reflection**, for odd `n`. Positions are modelled as `ZMod n` and the reflection through position `0` as negation `i ↦ -i` (an involution). A coloring is fixed iff it is constant on each orbit `{i, -i}`.

For odd `n = 2m+1` the reflection fixes only `0` (since `2` is a unit modulo the odd modulus), so the orbits are `{0}` together with the `m` pairs `{j, -j}`, giving `m+1 = (n+1)/2` orbits and

$$\#\{\text{reflection-fixed } k\text{-colorings}\} = k^{(n+1)/2}.$$

Absent from Mathlib; the reflection counterpart to the rotation count `k^gcd(n,r)` (oq-03).

## Approach — explicit fundamental-domain bijection (no abstract quotient)

`fold i = min(i.val, n - i.val)` returns each position to its representative in `{0,…,m}`. The key lemmas (`fold_incl`, `fold_neg`, `incl_fold`) assemble into an explicit equivalence

$$\{c : \mathbb{Z}/(2m{+}1) \to \mathrm{Fin}\,k \mid \forall i,\ c(-i)=c(i)\} \;\simeq\; (\mathrm{Fin}(m{+}1) \to \mathrm{Fin}\,k),$$

and `Fintype.card_fun` evaluates the count as `k^(m+1) = k^((n+1)/2)`.

## Results
- `reflect_involutive`, `reflect_fixed_iff_zero` — the reflection is an involution fixing only `0` for odd `n`.
- `reflectionInvariantEquiv` — the counting bijection.
- `card_reflectionInvariant` / `card_reflectionInvariant_odd` — the count `k^(m+1)` / `k^((n+1)/2)`.

## Verification
- 7 theorems, 4 defs, 0 sorries, **0 axioms** (`#print axioms` → `propext`, `Classical.choice`, `Quot.sound` only; no `decide`/`native_decide`).
- Mathlib 4.26.0.

## Files
- `proofs/Proofs/BurnsideCountingOQ05.lean` (new, 137 lines)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/burnside-counting-oq-05/meta.json` (gallery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)