### PR TITLE
research(catalan-numbers-oq-01): O(1) linear recurrence for Catalan numbers (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -431,6 +431,7 @@ import Proofs.CantorsTheoremOQ02
 import Proofs.CantorsTheoremOQ03
 import Proofs.CantorsTheoremOQ05
 import Proofs.CarnotTheorem
+import Proofs.CatalanNumbersOQ01
 import Proofs.CauchySchwarz
 import Proofs.CauchySchwarzIntegral
 import Proofs.CauchySchwarzIntegralOQ01

--- a/proofs/Proofs/CatalanNumbersOQ01.lean
+++ b/proofs/Proofs/CatalanNumbersOQ01.lean
@@ -1,0 +1,63 @@
+import Mathlib
+
+/-!
+# Catalan Numbers: the O(1) Linear Recurrence
+
+Mathlib (`Mathlib/Combinatorics/Enumerative/Catalan.lean`) provides the Catalan
+numbers `catalan` together with the quadratic **Segner convolution recurrence**
+`catalan_succ'` and the closed form `catalan_eq_centralBinom_div`.  It does *not*
+state the first-order ("holonomic") **linear recurrence**
+
+  `(n + 2) * catalan (n + 1) = 2 * (2 * n + 1) * catalan n`,
+
+which computes `catalan (n + 1)` from `catalan n` in `O(1)` arithmetic operations
+rather than the `O(n)` Segner convolution sum.
+
+We derive it from the central-binomial bridge.  Writing `C n` for `catalan n`
+and `B n` for `Nat.centralBinom n`, Mathlib provides
+* `succ_mul_catalan_eq_centralBinom : (n + 1) * C n = B n`, and
+* `Nat.succ_mul_centralBinom_succ : (n + 1) * B (n + 1) = 2 * (2 * n + 1) * B n`.
+
+Multiplying the target by `n + 1` and substituting both identities turns it into a
+ring identity in the central binomial coefficients; cancelling the positive factor
+`n + 1` gives the result.  Everything is over `ℕ`, fully machine-checked, 0-axiom.
+-/
+
+/-- **The linear (holonomic) recurrence for Catalan numbers.**
+`(n + 2) · C(n+1) = 2·(2n+1) · C(n)`.  This is the first-order recurrence
+satisfied by the Catalan numbers — strictly stronger as a *computational* tool
+than the quadratic Segner convolution `catalan_succ'`, since it determines
+`catalan (n + 1)` from the single previous value `catalan n`. -/
+theorem catalan_linear_recurrence (n : ℕ) :
+    (n + 2) * catalan (n + 1) = 2 * (2 * n + 1) * catalan n := by
+  -- Bridge to central binomial coefficients (`n + 1 + 1` is `n + 2` definitionally).
+  have h1 : (n + 2) * catalan (n + 1) = (n + 1).centralBinom :=
+    succ_mul_catalan_eq_centralBinom (n + 1)
+  have h2 : (n + 1) * (n + 1).centralBinom = 2 * (2 * n + 1) * n.centralBinom :=
+    Nat.succ_mul_centralBinom_succ n
+  have h3 : (n + 1) * catalan n = n.centralBinom :=
+    succ_mul_catalan_eq_centralBinom n
+  -- Prove the goal after multiplying through by the positive factor `n + 1`,
+  -- then cancel it.
+  refine Nat.eq_of_mul_eq_mul_left (show 0 < n + 1 by omega) ?_
+  calc
+    (n + 1) * ((n + 2) * catalan (n + 1))
+        = (n + 1) * (n + 1).centralBinom := by rw [h1]
+    _   = 2 * (2 * n + 1) * n.centralBinom := h2
+    _   = 2 * (2 * n + 1) * ((n + 1) * catalan n) := by rw [h3]
+    _   = (n + 1) * (2 * (2 * n + 1) * catalan n) := by ring
+
+/-- The linear recurrence solved for the next Catalan number, exhibiting the
+exact `O(1)` step `C(n+1) = 2·(2n+1)·C(n) / (n + 2)` over `ℕ` (the division is
+exact because `n + 2` divides the left-hand side). -/
+theorem catalan_succ_eq_div (n : ℕ) :
+    catalan (n + 1) = 2 * (2 * n + 1) * catalan n / (n + 2) := by
+  rw [← catalan_linear_recurrence, Nat.mul_div_cancel_left]
+  omega
+
+/-- Sanity check: the linear recurrence reproduces `catalan 4 = 14` from
+`catalan 3 = 5` in one step. -/
+example : catalan 4 = 14 := by
+  have h := catalan_linear_recurrence 3
+  norm_num [catalan_three] at h
+  omega

--- a/src/data/proofs/catalan-numbers-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01/meta.json
@@ -1,0 +1,145 @@
+{
+  "id": "catalan-numbers-oq-01",
+  "title": "Catalan Numbers: the O(1) Linear Recurrence",
+  "slug": "catalan-numbers-oq-01",
+  "description": "The first-order ('holonomic') linear recurrence for the Catalan numbers, (n + 2)·C(n+1) = 2·(2n+1)·C(n), proved over ℕ. Mathlib's Catalan file (Combinatorics/Enumerative/Catalan.lean) provides only the quadratic Segner convolution recurrence catalan_succ' (catalan (n+1) = Σ catalan i · catalan (n-i)) and the closed form catalan_eq_centralBinom_div; the linear recurrence — the form that computes catalan (n+1) from the single previous value in O(1) operations — is absent. The proof bridges through central binomial coefficients: succ_mul_catalan_eq_centralBinom gives (n+1)·catalan n = centralBinom n, and Nat.succ_mul_centralBinom_succ gives (n+1)·centralBinom (n+1) = 2·(2n+1)·centralBinom n. Multiplying the target by n+1 collapses it to a ring identity in the central binomials; cancelling the positive factor n+1 yields the recurrence. A corollary catalan_succ_eq_div exhibits the exact ℕ-division step catalan (n+1) = 2·(2n+1)·catalan n / (n+2). Fully verified, 0 axioms, 0 sorries, no decide/native_decide.",
+  "meta": {
+    "author": "Classical (Euler / Segner); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "recurrence",
+      "holonomic",
+      "central-binomial",
+      "enumerative-combinatorics",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CatalanNumbersOQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "succ_mul_catalan_eq_centralBinom",
+        "description": "The Catalan/central-binomial bridge: (n + 1) * catalan n = n.centralBinom. Both directions of substitution in the proof rest on this identity, at index n and at index n+1.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "Nat.succ_mul_centralBinom_succ",
+        "description": "The first-order recurrence for central binomial coefficients: (n + 1) * centralBinom (n + 1) = 2 * (2 * n + 1) * centralBinom n. This is the analytic heart of the Catalan recurrence; the Catalan version is its image under the bridge.",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.eq_of_mul_eq_mul_left",
+        "description": "Left cancellation of a positive natural-number factor: from 0 < a and a * b = a * c conclude b = c. Used to cancel the factor n + 1 introduced to clear denominators.",
+        "module": "Mathlib.Algebra.Order.Group.Nat"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel_left",
+        "description": "b * a / b = a for 0 < b. Turns the linear recurrence into the explicit exact-division step catalan (n+1) = 2·(2n+1)·catalan n / (n+2).",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "catalan_three",
+        "description": "catalan 3 = 5, used in the worked numeric check that the recurrence reproduces catalan 4 = 14 in one step.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      }
+    ],
+    "originalContributions": [
+      "catalan_linear_recurrence: (n + 2)·catalan (n+1) = 2·(2n+1)·catalan n — the first-order (holonomic) recurrence for the Catalan numbers as a natural-number identity, absent from Mathlib which states only the quadratic Segner convolution and the closed form",
+      "catalan_succ_eq_div: catalan (n+1) = 2·(2n+1)·catalan n / (n+2), the recurrence solved for the next term, exhibiting the exact O(1) division step over ℕ (the division being exact because n+2 divides the numerator)",
+      "The derivation itself: routing the Catalan recurrence through the central-binomial recurrence via the catalan/centralBinom bridge, with the (n+1)-cancellation that makes the natural-number statement well-posed"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 63,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used; the numeric sanity check catalan 4 = 14 is derived through the recurrence theorem, not by kernel computation.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Catalan numbers count an enormous family of combinatorial objects — binary trees, balanced parenthesizations, triangulations of a polygon, lattice paths below the diagonal, and many more. Euler discovered them counting polygon triangulations, and Segner gave the quadratic convolution recurrence C(n+1) = Σ C(i)·C(n−i) in 1758. The first-order recurrence (n+2)·C(n+1) = 2(2n+1)·C(n) is the modern computational form: it makes the sequence holonomic (P-recursive) of order one, so each term follows from its single predecessor in constant time, in contrast to the O(n) convolution sum.",
+    "problemStatement": "**Open Question (catalan-numbers-oq-01)**: Formalize the linear (first-order) recurrence for the Catalan numbers, (n + 2)·C(n+1) = 2·(2n+1)·C(n), which Mathlib does not state — it provides only the quadratic Segner convolution recurrence and the central-binomial closed form.\n\n**Result**: catalan_linear_recurrence and its exact-division corollary catalan_succ_eq_div, both fully verified with 0 axioms.",
+    "text": "For every natural number n, the Catalan numbers satisfy (n + 2)·C(n+1) = 2·(2n+1)·C(n). Equivalently C(n+1) = 2·(2n+1)·C(n) / (n+2), an exact division over ℕ. This first-order recurrence computes each Catalan number from its immediate predecessor.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Mathlib relates Catalan numbers to central binomial coefficients via succ_mul_catalan_eq_centralBinom: (n+1)·catalan n = centralBinom n. Instantiated at n+1 this gives (n+2)·catalan (n+1) = centralBinom (n+1).\n\n2. Central binomial coefficients satisfy their own first-order recurrence, Nat.succ_mul_centralBinom_succ: (n+1)·centralBinom (n+1) = 2·(2n+1)·centralBinom n.\n\n3. Multiply the goal by the positive factor n+1. The left side (n+1)·(n+2)·catalan (n+1) equals (n+1)·centralBinom (n+1) by step 1, then 2·(2n+1)·centralBinom n by step 2, then 2·(2n+1)·(n+1)·catalan n by step 1 again at index n; this matches (n+1)·(2·(2n+1)·catalan n) by ring.\n\n4. Cancel the common factor n+1 with Nat.eq_of_mul_eq_mul_left (0 < n+1) to obtain the recurrence.\n\n5. The corollary catalan_succ_eq_div rewrites the recurrence backwards into the numerator and applies Nat.mul_div_cancel_left, giving the exact O(1) division step.",
+    "keyInsights": [
+      "**The linear recurrence is a genuine gap, not a restatement.** Mathlib has the quadratic Segner convolution catalan_succ' and the closed form catalan_eq_centralBinom_div, but neither is the first-order recurrence. The convolution costs O(n) multiplications per term; the linear recurrence costs O(1), and it is the standard way to generate the sequence and to prove holonomicity.",
+      "**The recurrence is inherited from the central binomial coefficients.** Under the bridge (n+1)·C(n) = centralBinom n, the Catalan recurrence is exactly the image of Nat.succ_mul_centralBinom_succ. The whole proof is two substitutions and a cancellation — no induction is needed because Mathlib already did it for the central binomials.",
+      "**Clearing denominators is the crux over ℕ.** The natural statement (n+2)·C(n+1) = 2(2n+1)·C(n) has no division, but linking the two indices of the bridge forces a spare factor n+1; multiplying through by it and cancelling afterwards (Nat.eq_of_mul_eq_mul_left) keeps everything in ℕ and avoids casting to ℚ.",
+      "**Exact division is provable, not assumed.** catalan_succ_eq_div states C(n+1) = 2(2n+1)·C(n)/(n+2) with truncating ℕ division; it is correct precisely because n+2 divides the numerator (equal to (n+2)·C(n+1)), which Nat.mul_div_cancel_left certifies."
+    ],
+    "prerequisites": [
+      "The Catalan numbers and their definition via the Segner convolution recurrence",
+      "Central binomial coefficients and their first-order recurrence in Mathlib",
+      "Left cancellation of positive factors and exact truncating division over ℕ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Module docstring stating the linear recurrence, explaining why Mathlib's convolution and closed-form lemmas are not the first-order recurrence, and outlining the central-binomial bridge; import of Mathlib.",
+      "mathContext": "$(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$ versus the quadratic Segner convolution."
+    },
+    {
+      "id": "linear-recurrence",
+      "title": "The Linear Recurrence",
+      "startLine": 31,
+      "endLine": 53,
+      "summary": "catalan_linear_recurrence: instantiates succ_mul_catalan_eq_centralBinom at n and n+1 and Nat.succ_mul_centralBinom_succ at n, multiplies the goal by n+1, runs the calc chain through the central binomials, and cancels n+1 with Nat.eq_of_mul_eq_mul_left.",
+      "mathContext": "$(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$."
+    },
+    {
+      "id": "division-form",
+      "title": "Exact-Division Corollary and Numeric Check",
+      "startLine": 55,
+      "endLine": 63,
+      "summary": "catalan_succ_eq_div: the recurrence solved for catalan (n+1) as an exact ℕ division via Nat.mul_div_cancel_left; followed by a worked example deriving catalan 4 = 14 from catalan 3 = 5 through the recurrence (axiom-free, no native_decide).",
+      "mathContext": "$C_{n+1} = 2(2n+1)\\,C_n / (n+2)$."
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the first-order linear recurrence for the Catalan numbers: (n + 2)·C(n+1) = 2·(2n+1)·C(n), together with its exact-division corollary C(n+1) = 2·(2n+1)·C(n)/(n+2).",
+    "implications": "Supplies the O(1) computational recurrence for Catalan numbers, which Mathlib previously offered only as the O(n) Segner convolution or the central-binomial closed form. It exhibits the Catalan sequence as holonomic of order one and makes single-step generation and induction on consecutive Catalan numbers straightforward.",
+    "openQuestions": [
+      "Derive the closed ratio C(n+1)/C(n) = 2(2n+1)/(n+2) over ℚ and use it to prove the asymptotic growth C(n+1)/C(n) → 4.",
+      "Prove the analogous first-order recurrence for the central Delannoy or Motzkin numbers, identifying which combinatorial sequences are holonomic of order one versus two."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "",
+    "lineCount": 63,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/CatalanNumbersOQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Richard P. Stanley",
+      "title": "Catalan Numbers",
+      "year": "2015",
+      "venue": "Cambridge University Press",
+      "note": "Comprehensive reference; gives the first-order recurrence and the closed form C(n) = binom(2n,n)/(n+1)"
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.Combinatorics.Enumerative.Catalan and Mathlib.Data.Nat.Choose.Central",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Sources of the Catalan/central-binomial bridge and the central-binomial first-order recurrence bridged here"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **first-order (holonomic) linear recurrence** for the Catalan numbers:

$$(n + 2)\cdot C_{n+1} = 2(2n+1)\cdot C_n$$

over `ℕ`, fully verified and **0-axiom** (no `sorry`, no `decide`/`native_decide`).

**Genuine gap:** pinned Mathlib (`Combinatorics/Enumerative/Catalan.lean`) provides only the quadratic **Segner convolution** `catalan_succ'` and the closed form `catalan_eq_centralBinom_div`. The first-order recurrence — the form that computes `catalan (n+1)` from its single predecessor in `O(1)` operations — is not stated.

## Theorems

- `catalan_linear_recurrence : (n + 2) * catalan (n + 1) = 2 * (2 * n + 1) * catalan n`
- `catalan_succ_eq_div : catalan (n + 1) = 2 * (2 * n + 1) * catalan n / (n + 2)` (exact ℕ-division step)
- worked check: `catalan 4 = 14` derived through the recurrence (no kernel computation)

## Proof

Bridges through central binomial coefficients. Mathlib gives
`succ_mul_catalan_eq_centralBinom : (n+1)·catalan n = centralBinom n` and
`Nat.succ_mul_centralBinom_succ : (n+1)·centralBinom (n+1) = 2(2n+1)·centralBinom n`.
Multiplying the target by `n+1` collapses it to a ring identity in the central binomials; cancelling the positive factor `n+1` (`Nat.eq_of_mul_eq_mul_left`) yields the recurrence. No induction needed — Mathlib already proved it for the central binomials.

## Verification

- `#print axioms` on both theorems: only `propext`, `Classical.choice`, `Quot.sound` (foundational)
- 0 `sorry`, 0 `axiom`, no `native_decide`
- Compiles against pinned Mathlib 4.26.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)