### PR TITLE
research(catalan-numbers-oq-01): the Catalan linear recurrence (n+2)·Cₙ₊₁ = 2(2n+1)·Cₙ (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -431,6 +431,7 @@ import Proofs.CantorsTheoremOQ02
 import Proofs.CantorsTheoremOQ03
 import Proofs.CantorsTheoremOQ05
 import Proofs.CarnotTheorem
+import Proofs.CatalanNumbersOQ01
 import Proofs.CauchySchwarz
 import Proofs.CauchySchwarzIntegral
 import Proofs.CauchySchwarzIntegralOQ01

--- a/proofs/Proofs/CatalanNumbersOQ01.lean
+++ b/proofs/Proofs/CatalanNumbersOQ01.lean
@@ -1,0 +1,91 @@
+/-
+Catalan numbers: the linear (two-term) recurrence  (n+2)·Cₙ₊₁ = 2(2n+1)·Cₙ
+
+Source: Open question from the catalan-numbers gallery family
+Status: VERIFIED (0 axioms, 0 sorries)
+
+`Nat.catalan n` is the `n`-th Catalan number, counting (among many things) the
+binary trees with `n` internal nodes, the Dyck paths of length `2n`, and the
+triangulations of an `(n+2)`-gon.
+
+Mathlib (`Mathlib/Combinatorics/Enumerative/Catalan.lean`) records:
+
+  * `catalan_succ'`                  — the quadratic Segner *convolution* recurrence
+                                       Cₙ₊₁ = Σ_{i≤n} Cᵢ·C_{n−i};
+  * `catalan_eq_centralBinom_div`    — the closed form Cₙ = C(2n,n)/(n+1);
+  * `succ_mul_catalan_eq_centralBinom`— the bridge (n+1)·Cₙ = C(2n,n).
+
+What Mathlib does *not* state is the classical **linear** recurrence
+
+      (n+2)·Cₙ₊₁ = 2·(2n+1)·Cₙ,
+
+which computes each Catalan number from its immediate predecessor in O(1) work,
+in contrast to the O(n) Segner convolution `catalan_succ'`. We fill that gap.
+
+The proof bridges through the central binomial coefficients, combining the two
+Mathlib identities
+
+  (n+1)·Cₙ              = C(2n,n)                     (`succ_mul_catalan_eq_centralBinom`)
+  (n+1)·C(2(n+1),n+1)   = 2(2n+1)·C(2n,n)             (`Nat.succ_mul_centralBinom_succ`)
+
+and cancelling the common factor `n+1`.
+
+We prove:
+1. `centralBinom_succ_eq`        — the bridge C(2(n+1),n+1) = 2(2n+1)·Cₙ
+2. `catalan_linear_recurrence`   — the headline linear recurrence
+and demonstrate it computing C₄ = 14 and C₅ = 42 from their predecessors alone.
+-/
+
+import Mathlib
+
+open Nat
+
+namespace CatalanNumbersOQ01
+
+/-- **Bridge.** The central binomial coefficient at `n+1` equals `2(2n+1)` times
+the `n`-th Catalan number:
+
+  `C(2(n+1), n+1) = 2·(2n+1)·Cₙ`.
+
+This is the key step turning the central-binomial recurrence into a Catalan
+recurrence. We prove it by cancelling the factor `n+1` from
+`Nat.succ_mul_centralBinom_succ`. -/
+theorem centralBinom_succ_eq (n : ℕ) :
+    (n + 1).centralBinom = 2 * (2 * n + 1) * catalan n := by
+  apply Nat.eq_of_mul_eq_mul_left (show 0 < n + 1 from n.succ_pos)
+  -- Goal: (n+1)·C(2(n+1),n+1) = (n+1)·(2(2n+1)·Cₙ).
+  -- LHS is 2(2n+1)·C(2n,n); rewriting C(2n,n) = (n+1)·Cₙ matches the RHS.
+  rw [Nat.succ_mul_centralBinom_succ, ← succ_mul_catalan_eq_centralBinom]
+  ring
+
+/-- **Catalan linear recurrence.** Each Catalan number is determined by its
+immediate predecessor:
+
+  `(n+2)·Cₙ₊₁ = 2·(2n+1)·Cₙ`.
+
+Unlike the Segner convolution `catalan_succ'` (which sums over all earlier
+Catalan numbers), this two-term recurrence advances the sequence in O(1) work
+per step. -/
+theorem catalan_linear_recurrence (n : ℕ) :
+    (n + 2) * catalan (n + 1) = 2 * (2 * n + 1) * catalan n := by
+  have h : (n + 2) * catalan (n + 1) = (n + 1).centralBinom :=
+    succ_mul_catalan_eq_centralBinom (n + 1)
+  rw [h, centralBinom_succ_eq]
+
+/-- The recurrence computes `C₄ = 14` from `C₃ = 5` alone (no convolution). -/
+example : catalan 4 = 14 := by
+  have h := catalan_linear_recurrence 3
+  norm_num [catalan_three] at h
+  omega
+
+/-- One more step: `C₅ = 42` from `C₄ = 14`. -/
+example : catalan 5 = 42 := by
+  have h4 : catalan 4 = 14 := by
+    have h := catalan_linear_recurrence 3
+    norm_num [catalan_three] at h
+    omega
+  have h := catalan_linear_recurrence 4
+  norm_num [h4] at h
+  omega
+
+end CatalanNumbersOQ01

--- a/src/data/research/problems/catalan-numbers-oq-01.json
+++ b/src/data/research/problems/catalan-numbers-oq-01.json
@@ -1,0 +1,78 @@
+{
+  "slug": "catalan-numbers-oq-01",
+  "title": "The Catalan Linear Recurrence: (n+2)·Cₙ₊₁ = 2(2n+1)·Cₙ",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "started": "2026-06-20T10:00:00Z",
+  "lastUpdate": "2026-06-20T10:00:00Z",
+  "tags": [
+    "combinatorics",
+    "catalan-numbers",
+    "recurrence",
+    "central-binomial",
+    "enumerative",
+    "seeker-selected",
+    "research"
+  ],
+  "tractability": 9,
+  "significance": 7,
+  "problemStatement": {
+    "formal": "The Catalan numbers $C_n$ satisfy the two-term linear recurrence $(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$, advancing the sequence from each term to the next in $O(1)$ arithmetic operations. This is sharper than Segner's quadratic convolution $C_{n+1} = \\sum_{i\\le n} C_i C_{n-i}$.",
+    "plain": "Each Catalan number can be computed from its immediate predecessor by a single multiply-and-divide step: C_{n+1} = 2(2n+1)/(n+2) · C_n. For example 14 = (2·7/5)·5 gives C₄ from C₃, and 42 = (2·9/6)·14 gives C₅ from C₄. This is far faster than summing the convolution over all earlier Catalan numbers.",
+    "whyMatters": [
+      "The linear recurrence is the standard practical way to generate Catalan numbers (used in OEIS A000108 and most references), but Mathlib only records Segner's O(n) convolution and the central-binomial closed form — not this O(1) two-term recurrence.",
+      "It is the cleanest bridge between the Catalan numbers and the central binomial coefficients' own recurrence, exposing why Cₙ = C(2n,n)/(n+1) propagates correctly.",
+      "It supplies the base identity from which the generating-function ODE and the asymptotic Cₙ ~ 4ⁿ/(n^{3/2}√π) are routinely derived."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "catalan_linear_recurrence: (n+2)·catalan(n+1) = 2·(2n+1)·catalan n, for all n : ℕ — the headline two-term linear recurrence (absent from Mathlib).",
+      "centralBinom_succ_eq: (n+1).centralBinom = 2·(2n+1)·catalan n — the bridge lemma obtained by cancelling n+1 from Nat.succ_mul_centralBinom_succ.",
+      "Worked demonstrations: C₄ = 14 from C₃ = 5, and C₅ = 42 from C₄ = 14, using only the linear recurrence (no convolution). Axiom-free, no native_decide."
+    ],
+    "open": [
+      "Derive the generating function C(x) = (1 - √(1-4x))/(2x) and its quadratic functional equation from the linear recurrence.",
+      "The asymptotic Cₙ ~ 4ⁿ / (n^{3/2}√π) via the central-binomial Stirling estimate."
+    ],
+    "goal": "Surface the classical O(1) linear recurrence for the Catalan numbers in the gallery, axiom-free, derived from Mathlib's central-binomial and Catalan identities."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-20T10:00:00Z",
+    "iteration": 1,
+    "focus": "ACT: shipped Proofs/CatalanNumbersOQ01.lean — the linear recurrence + central-binomial bridge, axiom-free, sorry-free.",
+    "blockers": [],
+    "nextAction": "Optional: generating-function functional equation, or the 4ⁿ/(n^{3/2}√π) asymptotic. Core linear recurrence complete and verified.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "S1 ACT (researcher-7, 2026-06-20): Built Proofs/CatalanNumbersOQ01.lean proving the Catalan linear recurrence (n+2)·Cₙ₊₁ = 2(2n+1)·Cₙ, which Mathlib does not state (it has only catalan_succ' convolution, catalan_eq_centralBinom_div, and succ_mul_catalan_eq_centralBinom). Proof bridges through central binomials: from Nat.succ_mul_centralBinom_succ ((n+1)·C(2(n+1),n+1)=2(2n+1)·C(2n,n)) and succ_mul_catalan_eq_centralBinom ((n+1)·Cₙ=C(2n,n)), cancel the common n+1 (Nat.eq_of_mul_eq_mul_left) to get centralBinom_succ_eq: C(2(n+1),n+1)=2(2n+1)·Cₙ; then succ_mul_catalan_eq_centralBinom(n+1) gives (n+2)·Cₙ₊₁=C(2(n+1),n+1)=2(2n+1)·Cₙ. GOTCHA: catalan and succ_mul_catalan_eq_centralBinom are ROOT-level (not Nat.) — only centralBinom is namespaced Nat; numerals inside catalan's argument don't reduce for omega, so the worked examples need norm_num [catalan_three] to normalize catalan(3+1)→catalan 4 before omega. Axiom-free (propext/Classical.choice/Quot.sound); no native_decide."
+  },
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://oeis.org/A000108",
+      "https://en.wikipedia.org/wiki/Catalan_number#Properties"
+    ],
+    "mathlib": [
+      "succ_mul_catalan_eq_centralBinom, catalan_eq_centralBinom_div, catalan_succ' (Combinatorics/Enumerative/Catalan.lean); Nat.succ_mul_centralBinom_succ (Data/Nat/Choose/Central.lean)"
+    ]
+  },
+  "relatedProofs": [],
+  "leanFiles": [
+    {
+      "path": "proofs/Proofs/CatalanNumbersOQ01.lean",
+      "status": "verified",
+      "axiomCount": 0,
+      "sorryCount": 0
+    }
+  ],
+  "significanceNote": "The classical O(1) two-term linear recurrence for the Catalan numbers — the standard generation formula — surfaced in the gallery as a named theorem, derived axiom-free from Mathlib's central-binomial recurrence; absent before (Mathlib had only the O(n) Segner convolution and the central-binomial closed form)."
+}


### PR DESCRIPTION
## Summary

Surfaces the classical **O(1) two-term linear recurrence** for the Catalan numbers:

$$(n+2)\,C_{n+1} = 2(2n+1)\,C_n$$

Mathlib does **not** state this. It records only:
- `catalan_succ'` — Segner's *quadratic* convolution $C_{n+1} = \sum_{i\le n} C_i C_{n-i}$ (O(n) per term),
- `catalan_eq_centralBinom_div` — the closed form $C_n = \binom{2n}{n}/(n+1)$,
- `succ_mul_catalan_eq_centralBinom` — the bridge $(n+1)C_n = \binom{2n}{n}$.

The linear recurrence advances the sequence in **O(1)** arithmetic per step.

## Results (`proofs/Proofs/CatalanNumbersOQ01.lean`)

- `catalan_linear_recurrence` : `(n+2) * catalan (n+1) = 2*(2n+1) * catalan n`
- `centralBinom_succ_eq` : `(n+1).centralBinom = 2*(2n+1) * catalan n` (bridge lemma)
- worked demos: `C₄ = 14` from `C₃`, `C₅ = 42` from `C₄`, via the recurrence alone

## Proof idea

Bridge through the central binomial coefficients. From
`Nat.succ_mul_centralBinom_succ` ($(n+1)\binom{2(n+1)}{n+1} = 2(2n+1)\binom{2n}{n}$)
and `succ_mul_catalan_eq_centralBinom` ($(n+1)C_n = \binom{2n}{n}$), cancel the
common factor $n+1$ (`Nat.eq_of_mul_eq_mul_left`) to obtain `centralBinom_succ_eq`;
then `succ_mul_catalan_eq_centralBinom (n+1)` gives
$(n+2)C_{n+1} = \binom{2(n+1)}{n+1} = 2(2n+1)C_n$.

## Verification

- **0 axioms** (`propext`, `Classical.choice`, `Quot.sound` only — checked via `#print axioms`)
- 0 sorries, no `native_decide`
- Compiles against pinned Mathlib via `lake env lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)