### PR TITLE
research(alternating-series-test-oq-01): two-sided error bound |S_N − l| ≤ f N (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -42,6 +42,7 @@ import Proofs.AlgebraicNumbersCountableOQ02OQ04
 import Proofs.AlgebraicNumbersCountableOQ04
 import Proofs.AlgebraicNumbersCountableOQ05
 import Proofs.AlgebraicRealsMeager
+import Proofs.AlternatingSeriesTestOQ01
 import Proofs.AmgmInequalityOQ02
 import Proofs.AmgmInequalityOQ02Aristotle
 import Proofs.AmgmInequalityOQ02Defs

--- a/proofs/Proofs/AlternatingSeriesTestOQ01.lean
+++ b/proofs/Proofs/AlternatingSeriesTestOQ01.lean
@@ -1,0 +1,88 @@
+import Mathlib
+
+/-
+# The Alternating Series Test with a Two-Sided Error Bound
+
+Mathlib provides the convergence of an alternating series `∑ (-1)^i • f i` for an antitone
+`f → 0`, and the one-directional bracketing lemmas (even partial sums underestimate the
+limit, odd partial sums overestimate it). It does **not** package the symmetric *remainder
+estimate* that makes the alternating series test so useful in practice:
+
+`|S_N - l| ≤ f N`,    where `S_N = ∑_{i<N} (-1)^i f i` and `l = lim S_N`.
+
+This file proves that bound (`abs_partialSum_sub_limit_le`) by combining the two
+bracketing lemmas with the one-step recurrence `S_{N+1} = S_N + (-1)^N f N`, splitting on
+the parity of `N`. As a capstone it specialises to the **alternating harmonic series**
+`∑ (-1)^i/(i+1)`: the series converges and the partial sums approximate the limit with
+error at most `1/(N+1)` (`abs_alternatingHarmonic_sub_limit_le`).
+
+All results are over `ℝ`. The limit value (here `log 2`) is not needed for the estimate.
+Absent from Mathlib.
+-/
+
+namespace AlternatingSeriesTestOQ01
+
+open Finset Filter Topology
+
+variable {f : ℕ → ℝ} {l : ℝ}
+
+/-- The partial sums of an alternating series satisfy the one-step recurrence
+`S_{n+1} = S_n + (-1)^n f n`. -/
+theorem partialSum_succ (n : ℕ) :
+    (∑ i ∈ range (n + 1), (-1) ^ i * f i)
+      = (∑ i ∈ range n, (-1) ^ i * f i) + (-1) ^ n * f n := by
+  rw [Finset.sum_range_succ]
+
+/-- **Two-sided remainder bound for the alternating series test.** If `f` is antitone and
+tends to `0`, and the alternating series `S_N = ∑_{i<N} (-1)^i f i` converges to `l`, then
+the `N`-th partial sum approximates `l` with error at most `f N`:
+`|S_N - l| ≤ f N`. -/
+theorem abs_partialSum_sub_limit_le (hfa : Antitone f) (hf0 : Tendsto f atTop (𝓝 0))
+    (hl : Tendsto (fun n => ∑ i ∈ range n, (-1) ^ i * f i) atTop (𝓝 l)) (N : ℕ) :
+    |(∑ i ∈ range N, (-1) ^ i * f i) - l| ≤ f N := by
+  set S : ℕ → ℝ := fun n => ∑ i ∈ range n, (-1) ^ i * f i with hS
+  rcases Nat.even_or_odd N with ⟨k, hk⟩ | ⟨k, hk⟩
+  · -- N = 2k : even number of terms, `S N ≤ l ≤ S N + f N`
+    have hN : N = 2 * k := by omega
+    have h1 : S (2 * k) ≤ l := hfa.alternating_series_le_tendsto hl k
+    have h2 : l ≤ S (2 * k + 1) := hfa.tendsto_le_alternating_series hl k
+    have h3 : S (2 * k + 1) = S (2 * k) + f (2 * k) := by
+      have := partialSum_succ (f := f) (2 * k)
+      rw [show (-1 : ℝ) ^ (2 * k) = 1 by rw [pow_mul, neg_one_sq, one_pow], one_mul] at this
+      exact this
+    rw [hN, abs_of_nonpos (by linarith)]
+    linarith
+  · -- N = 2k+1 : odd number of terms, `S N - f N ≤ l ≤ S N`
+    have hN : N = 2 * k + 1 := by omega
+    have h1 : S (2 * (k + 1)) ≤ l := hfa.alternating_series_le_tendsto hl (k + 1)
+    have h1' : S (2 * k + 2) ≤ l := by rwa [show 2 * (k + 1) = 2 * k + 2 by ring] at h1
+    have h2 : l ≤ S (2 * k + 1) := hfa.tendsto_le_alternating_series hl k
+    have h3 : S (2 * k + 2) = S (2 * k + 1) - f (2 * k + 1) := by
+      have := partialSum_succ (f := f) (2 * k + 1)
+      rw [show (-1 : ℝ) ^ (2 * k + 1) = -1 by
+        rw [pow_succ, pow_mul, neg_one_sq, one_pow, one_mul]] at this
+      rw [show 2 * k + 1 + 1 = 2 * k + 2 by ring] at this
+      linarith [this]
+    rw [hN, abs_of_nonneg (by linarith)]
+    linarith
+
+/-- The alternating harmonic coefficients `f i = 1/(i+1)` are antitone. -/
+theorem antitone_one_div_succ : Antitone (fun i : ℕ => 1 / ((i : ℝ) + 1)) := by
+  intro i j hij
+  have hi : (0 : ℝ) < (i : ℝ) + 1 := by positivity
+  apply one_div_le_one_div_of_le hi
+  exact_mod_cast by simpa using hij
+
+/-- **Alternating harmonic series with error bound.** The alternating harmonic series
+`∑ (-1)^i/(i+1)` converges to a limit `l` (namely `log 2`), and its `N`-th partial sum
+approximates `l` with error at most `1/(N+1)`. -/
+theorem abs_alternatingHarmonic_sub_limit_le :
+    ∃ l : ℝ, Tendsto (fun n => ∑ i ∈ range n, (-1) ^ i * (1 / ((i : ℝ) + 1))) atTop (𝓝 l) ∧
+      ∀ N : ℕ, |(∑ i ∈ range N, (-1) ^ i * (1 / ((i : ℝ) + 1))) - l| ≤ 1 / ((N : ℝ) + 1) := by
+  have hfa : Antitone (fun i : ℕ => 1 / ((i : ℝ) + 1)) := antitone_one_div_succ
+  have hf0 : Tendsto (fun i : ℕ => 1 / ((i : ℝ) + 1)) atTop (𝓝 0) :=
+    tendsto_one_div_add_atTop_nhds_zero_nat
+  obtain ⟨l, hl⟩ := hfa.tendsto_alternating_series_of_tendsto_zero hf0
+  exact ⟨l, hl, fun N => abs_partialSum_sub_limit_le hfa hf0 hl N⟩
+
+end AlternatingSeriesTestOQ01

--- a/src/data/proofs/alternating-series-test-oq-01/meta.json
+++ b/src/data/proofs/alternating-series-test-oq-01/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "alternating-series-test-oq-01",
+  "title": "The Alternating Series Test with a Two-Sided Error Bound",
+  "slug": "alternating-series-test-oq-01",
+  "description": "For an antitone sequence f : ℕ → ℝ tending to 0, the alternating series S_N = ∑_{i<N} (-1)^i f i converges to a limit l, and the N-th partial sum approximates l with error at most f N: |S_N − l| ≤ f N. Mathlib supplies the convergence and the one-directional bracketing lemmas (even partial sums underestimate l, odd partial sums overestimate it) but not this symmetric remainder estimate. The bound is obtained by combining the two bracketing lemmas with the recurrence S_{N+1} = S_N + (-1)^N f N and splitting on the parity of N. As a capstone the result is specialised to the alternating harmonic series ∑ (-1)^i/(i+1), whose partial sums approximate its limit (log 2) with error at most 1/(N+1).",
+  "meta": {
+    "author": "Leibniz (alternating series test); formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlternatingSeriesTestOQ01.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "convergence",
+      "alternating-series",
+      "error-bound",
+      "alternating-harmonic",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Antitone.tendsto_alternating_series_of_tendsto_zero",
+        "description": "Convergence of the alternating series for an antitone f → 0 — supplies the limit l",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Antitone.alternating_series_le_tendsto",
+        "description": "Even partial sums underestimate the limit: ∑_{i<2k} (-1)^i f i ≤ l — one side of the bracket",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Antitone.tendsto_le_alternating_series",
+        "description": "Odd partial sums overestimate the limit: l ≤ ∑_{i<2k+1} (-1)^i f i — the other side of the bracket",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "tendsto_one_div_add_atTop_nhds_zero_nat",
+        "description": "1/(n+1) → 0, giving the hypothesis for the alternating harmonic specialisation",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      }
+    ],
+    "originalContributions": [
+      "partialSum_succ: the one-step recurrence S_{N+1} = S_N + (-1)^N f N for alternating partial sums",
+      "abs_partialSum_sub_limit_le: the two-sided remainder bound |S_N − l| ≤ f N for the alternating series test — the symmetric estimate Mathlib does not package",
+      "antitone_one_div_succ: the alternating harmonic coefficients 1/(i+1) are antitone",
+      "abs_alternatingHarmonic_sub_limit_le: the alternating harmonic series converges, with partial-sum error at most 1/(N+1)"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 88,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The alternating series test — that ∑ (-1)^n a_n converges whenever a_n decreases monotonically to 0 — is due to Leibniz and is among the first convergence criteria a student meets. Its practical power comes less from the bare convergence statement than from the accompanying error estimate: the truncation error after N terms is bounded by the first omitted term, |S_N − l| ≤ a_N. This makes alternating series ideal for numerical approximation, the alternating harmonic series ∑(-1)^n/(n+1) = log 2 being the textbook example.",
+    "problemStatement": "Given an antitone f : ℕ → ℝ with f → 0, the alternating series ∑ (-1)^i f i converges to some l. How well does the N-th partial sum approximate l?\n\n**Answer: |S_N − l| ≤ f N.** The limit always lies between consecutive partial sums S_N and S_{N+1}, which differ by exactly (-1)^N f N, so the partial sum is within f N of the limit. For the alternating harmonic series this gives error ≤ 1/(N+1).",
+    "text": "The N-th partial sum of an alternating series with antitone terms approximates the limit with error at most the first omitted term.",
+    "proofStrategy": "Fix the limit l from Mathlib's convergence lemma. Mathlib's bracketing lemmas give, for antitone f, S_{2k} ≤ l (even number of terms underestimates) and l ≤ S_{2k+1} (odd number of terms overestimates). Split on the parity of N. For even N = 2k: S_N ≤ l ≤ S_{N+1} = S_N + f N (since (-1)^{2k} = 1), so 0 ≤ l − S_N ≤ f N. For odd N = 2k+1: S_{N+1} = S_N − f N ≤ l ≤ S_N (since (-1)^{2k+1} = -1), so 0 ≤ S_N − l ≤ f N. In both cases |S_N − l| ≤ f N. The recurrence S_{N+1} = S_N + (-1)^N f N is `Finset.sum_range_succ`. Specialise to f i = 1/(i+1) (antitone, → 0) for the alternating harmonic bound.",
+    "keyInsights": [
+      "The limit of an alternating series with antitone terms is always trapped between two consecutive partial sums; the whole estimate follows from the gap between them being exactly the next term",
+      "Parity is the only case split needed: it fixes the sign (-1)^N and hence which side of l the partial sum falls on",
+      "Mathlib already proves both one-sided bracket inequalities; the contribution is assembling them into the symmetric |S_N − l| ≤ f N that is what one actually uses",
+      "The alternating harmonic series is the canonical instance: error ≤ 1/(N+1) makes the slow convergence to log 2 quantitative"
+    ],
+    "prerequisites": [
+      "Convergence of sequences and series in ℝ",
+      "Monotone/antitone sequences and the alternating series (Leibniz) test",
+      "Finite sums: Finset.sum_range_succ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "recurrence",
+      "title": "The Partial-Sum Recurrence",
+      "startLine": 33,
+      "endLine": 39,
+      "summary": "S_{N+1} = S_N + (-1)^N f N, from Finset.sum_range_succ.",
+      "mathContext": "$S_{N+1} = S_N + (-1)^N f_N$."
+    },
+    {
+      "id": "error-bound",
+      "title": "The Two-Sided Error Bound",
+      "startLine": 41,
+      "endLine": 76,
+      "summary": "|S_N − l| ≤ f N, by trapping l between S_N and S_{N+1} and splitting on the parity of N.",
+      "mathContext": "$|S_N - l| \\le f_N$."
+    },
+    {
+      "id": "alternating-harmonic",
+      "title": "Alternating Harmonic Series",
+      "startLine": 78,
+      "endLine": 88,
+      "summary": "f i = 1/(i+1) is antitone and tends to 0, so ∑ (-1)^i/(i+1) converges with partial-sum error at most 1/(N+1).",
+      "mathContext": "$\\left|\\sum_{i<N}\\frac{(-1)^i}{i+1} - l\\right| \\le \\frac{1}{N+1}$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Leibniz, G. W.",
+      "title": "Letter to Johann Bernoulli",
+      "year": "1714",
+      "note": "The alternating series convergence criterion"
+    },
+    {
+      "authors": "Rudin, W.",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "note": "Alternating series test and the truncation error bound (Theorem 3.43)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "p-series-convergence",
+      "relationship": "related",
+      "description": "The harmonic series ∑ 1/n diverges (p-series at p=1), yet its alternating counterpart ∑ (-1)^n/n converges — this entry quantifies how fast, with error ≤ 1/(N+1)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The alternating series test is upgraded from bare convergence to the quantitative remainder estimate |S_N − l| ≤ f N, proved with 0 axioms by trapping the limit between consecutive partial sums and splitting on parity; specialising to 1/(i+1) bounds the alternating harmonic truncation error by 1/(N+1).",
+    "implications": "Supplies the practically essential error bound that Mathlib's one-directional bracketing lemmas stop short of, in reusable form; the alternating harmonic instance is a ready quantitative approximation of log 2.",
+    "openQuestions": [
+      "Can the bound be sharpened to a two-term estimate using S_{N+1} as well, giving |S_N − l| between f_{N+1} and f_N?",
+      "Does the same trapping argument yield Abel-summation error bounds for Dirichlet-type alternating series with non-monotone but bounded-variation coefficients?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "AlternatingSeriesTestOQ01",
+    "lineCount": 88,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/AlternatingSeriesTestOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Upgrades the **alternating series (Leibniz) test** from bare convergence to the quantitative remainder estimate Mathlib does not package. For an antitone `f : ℕ → ℝ` with `f → 0`, the alternating series `S_N = ∑_{i<N} (-1)^i f i` converges to `l`, and

$$|S_N - l| \le f\,N.$$

Mathlib supplies the convergence (`Antitone.tendsto_alternating_series_of_tendsto_zero`) and the **one-directional** bracket lemmas (`Antitone.alternating_series_le_tendsto`, `Antitone.tendsto_le_alternating_series`), but not this symmetric two-sided bound.

## Approach

The limit always lies between consecutive partial sums, which differ by exactly `(-1)^N f N` (`partialSum_succ`):

- **N even (= 2k):** `S_N ≤ l ≤ S_N + f N`, so `0 ≤ l - S_N ≤ f N`.
- **N odd (= 2k+1):** `S_N - f N ≤ l ≤ S_N`, so `0 ≤ S_N - l ≤ f N`.

Either way `|S_N - l| ≤ f N`. A parity split is the only case analysis needed.

## Capstone — alternating harmonic series

`abs_alternatingHarmonic_sub_limit_le`: `∑ (-1)^i/(i+1)` converges (to `log 2`) and its `N`-th partial sum approximates the limit with error at most `1/(N+1)`.

## Verification

- 4 theorems, 0 sorries, **0 axioms** (`#print axioms` → `propext`, `Classical.choice`, `Quot.sound` only; no `decide`/`native_decide`).
- Mathlib 4.26.0.

## Files
- `proofs/Proofs/AlternatingSeriesTestOQ01.lean` (new, 88 lines)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/alternating-series-test-oq-01/meta.json` (gallery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)