### PR TITLE
Fix: repair KnightsTourObliqueOQ02Reverse Mathlib drift

### DIFF
--- a/proofs/Proofs/KnightsTourObliqueOQ02Reverse.lean
+++ b/proofs/Proofs/KnightsTourObliqueOQ02Reverse.lean
@@ -121,12 +121,13 @@ theorem isKnightPath_reverse {l : List Square} (h : isKnightPath l) :
   rw [List.length_reverse] at hi
   -- The reversed edge at `i` is the original edge at `l.length - 2 - i`,
   -- read in the opposite order; close by graph symmetry.
-  have key := h (l.length - 2 - i) (by omega)
-  -- Match the reversed-list getElems against the original via `getElem_reverse`,
-  -- discharging the index arithmetic with `omega` (proof terms by irrelevance).
-  convert knightGraph.symm key using 2
-  · rw [List.getElem_reverse]; congr 1; omega
-  · rw [List.getElem_reverse]; congr 1; omega
+  have key := h (l.length - 1 - (i + 1)) (by omega)
+  -- Rewrite the reversed-list getElems to the underlying list via `getElem_reverse`
+  -- (`l.reverse[j] = l[l.length - 1 - j]`), then match against the original edge.
+  -- Keeping the index as `l.length - 1 - (i + 1)` (rather than the equivalent
+  -- `l.length - 2 - i`) leaves the minuend `l.length` visible to `omega`.
+  rw [List.getElem_reverse, List.getElem_reverse]
+  convert knightGraph.symm key using 2 <;> · congr 1; omega
 
 /-- The reversed square list of a tour is nonempty. -/
 theorem reverseTour_nonempty (t : ClosedTour) : t.squares.reverse ≠ [] := by


### PR DESCRIPTION
## Fix

`proofs/Proofs/KnightsTourObliqueOQ02Reverse.lean` no longer typechecked against the current Mathlib pin. After the OQ02 base repair (PR #27063, merged) the file still failed with **3 errors** in `isKnightPath_reverse` — independent Mathlib drift, not just the import.

## Evidence

**Before** (`lake env lean Proofs/KnightsTourObliqueOQ02Reverse.lean`): 3 errors
- `128/129:8 rewrite failed: Did not find an occurrence of the pattern` — the old `convert … using 2` then per-branch `rw [List.getElem_reverse]` no longer matched the post-convert goal shape.
- `119:30 unsolved goals` (cascading), and after a first reformulation, `omega could not prove the goal` because the literal `l.length - 2` was atomized, hiding the minuend `l.length`.

**After**: rc=0, **0 errors**.

## Change

Single-theorem, minimal diff in `isKnightPath_reverse`:
- Rewrite both reversed-list getElems on the goal up front via `List.getElem_reverse` (`l.reverse[j] = l[l.length - 1 - j]`).
- Index the original edge as `l.length - 1 - (i + 1)` (equivalent to `l.length - 2 - i`) so the minuend `l.length` stays visible to `omega`.

No `sorry` / `native_decide` / `axiom` — foundational tactics only (rw / convert / congr / omega). Verified via `lake env lean` (single-file rc=0) in a clean cache window; the full `#print axioms` was blocked by heavy shared-`.lake` cache churn from the concurrent fleet.

Completes the knights-tour-oblique sibling cluster repair tracked in #27034 (base + OQ01 + OQ02 already merged via #27033 / #27063). This file has no gallery entry and is not in the `Proofs.lean` manifest; the fix keeps the reversal-symmetry companion buildable.

---
Automated fix by lean-mechanic agent.