### PR TITLE
research(gamma-log-convexity-oq-01): Gautschi double inequality for Γ-ratios from log-convexity (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2501,6 +2501,7 @@ import Proofs.GaussWilsonNonCyclicOQ01
 import Proofs.GaussWilsonNonCyclicOQ01A
 import Proofs.GaussWilsonNonCyclicOQ01B
 import Proofs.GaussWilsonNonCyclicOQ03
+import Proofs.GammaLogConvexityOQ01
 import Proofs.GcdAlgorithmOQ02
 import Proofs.GcdAlgorithmOQ04
 import Proofs.GelfondSchneider

--- a/proofs/Proofs/GammaLogConvexityOQ01.lean
+++ b/proofs/Proofs/GammaLogConvexityOQ01.lean
@@ -1,0 +1,149 @@
+/-
+# Gautschi-Type Ratio Bounds for the Gamma Function
+
+The Gamma function `Γ` is **logarithmically convex** on `(0, ∞)` — a fact recorded
+in Mathlib as `Real.convexOn_log_Gamma`. From this single structural input, together
+with the functional equation `Γ(x+1) = x · Γ(x)`, we derive the classical
+**Gautschi double inequality** for the ratio of Gamma values at unit-shifted points:
+
+  for `x > 0` and `0 < s < 1`,    `x^(1-s) ≤ Γ(x+1) / Γ(x+s) ≤ (x+1)^(1-s)`.
+
+These ratio bounds are *not* in Mathlib (which records the convexity but none of the
+Gautschi/Kershaw ratio estimates). Both directions follow purely from log-convexity,
+applied to two different convex decompositions:
+
+* lower bound: `x+s = (1-s)·x + s·(x+1)`  (convexity gives `Γ(x+s) ≤ Γ(x)·x^s`);
+* upper bound: `x+1 = (1/(2-s))·(x+s) + ((1-s)/(2-s))·(x+2)`.
+
+We also package the multiplicative midpoint inequality `Γ((a+b)/2)^2 ≤ Γ(a)·Γ(b)`,
+the cleanest direct consequence of midpoint log-convexity.
+
+All results are fully verified (0 sorries, 0 axioms beyond Lean's foundations).
+-/
+import Mathlib
+
+open Real Set
+
+namespace GammaLogConvexityOQ01
+
+/-- Functional-equation form of `log ∘ Γ`: `log Γ(x+1) = log x + log Γ(x)` for `x > 0`. -/
+lemma logGamma_add_one {x : ℝ} (hx : 0 < x) :
+    Real.log (Real.Gamma (x + 1)) = Real.log x + Real.log (Real.Gamma x) := by
+  rw [Real.Gamma_add_one hx.ne', Real.log_mul hx.ne' (Real.Gamma_pos_of_pos hx).ne']
+
+/-- Core convexity estimate (lower side): for `x > 0`, `0 ≤ s ≤ 1`,
+`log Γ(x+s) ≤ log Γ(x) + s · log x`. Obtained from log-convexity using the convex
+combination `x + s = (1-s)·x + s·(x+1)`. -/
+lemma logGamma_le_lower {x s : ℝ} (hx : 0 < x) (hs0 : 0 ≤ s) (hs1 : s ≤ 1) :
+    Real.log (Real.Gamma (x + s)) ≤ Real.log (Real.Gamma x) + s * Real.log x := by
+  have h := convexOn_log_Gamma.2 (Set.mem_Ioi.mpr hx)
+    (Set.mem_Ioi.mpr (by linarith : (0 : ℝ) < x + 1))
+    (by linarith : (0 : ℝ) ≤ 1 - s) hs0 (by ring)
+  simp only [Function.comp_apply, smul_eq_mul] at h
+  rw [show (1 - s) * x + s * (x + 1) = x + s by ring, logGamma_add_one hx] at h
+  have e : (1 - s) * Real.log (Real.Gamma x)
+      + s * (Real.log x + Real.log (Real.Gamma x))
+      = Real.log (Real.Gamma x) + s * Real.log x := by ring
+  rw [e] at h
+  exact h
+
+/-- **Gautschi lower bound.** For `x > 0` and `0 < s < 1`,
+`x^(1-s) ≤ Γ(x+1) / Γ(x+s)`. -/
+theorem gautschi_lower {x s : ℝ} (hx : 0 < x) (hs0 : 0 < s) (hs1 : s < 1) :
+    x ^ (1 - s) ≤ Real.Gamma (x + 1) / Real.Gamma (x + s) := by
+  have hxs : 0 < x + s := by linarith
+  have hGxs : 0 < Real.Gamma (x + s) := Real.Gamma_pos_of_pos hxs
+  have hGx : 0 < Real.Gamma x := Real.Gamma_pos_of_pos hx
+  -- log Γ(x+s) ≤ log Γ x + s · log x
+  have hlog := logGamma_le_lower hx hs0.le hs1.le
+  -- exponentiate to Γ(x+s) ≤ Γ x · x^s
+  have hGxs_le : Real.Gamma (x + s) ≤ Real.Gamma x * x ^ s := by
+    have hb : 0 < Real.Gamma x * x ^ s := by positivity
+    have hlog2 : Real.log (Real.Gamma (x + s)) ≤ Real.log (Real.Gamma x * x ^ s) := by
+      rw [Real.log_mul hGx.ne' (by positivity), Real.log_rpow hx]
+      exact hlog
+    have := Real.exp_le_exp.mpr hlog2
+    rwa [Real.exp_log hGxs, Real.exp_log hb] at this
+  -- assemble the ratio bound
+  rw [le_div_iff₀ hGxs, Real.Gamma_add_one hx.ne']
+  have hxpow : x ^ (1 - s) * x ^ s = x := by
+    rw [← Real.rpow_add hx, show (1 : ℝ) - s + s = 1 by ring, Real.rpow_one]
+  calc
+    x ^ (1 - s) * Real.Gamma (x + s)
+        ≤ x ^ (1 - s) * (Real.Gamma x * x ^ s) :=
+          mul_le_mul_of_nonneg_left hGxs_le (by positivity)
+    _ = (x ^ (1 - s) * x ^ s) * Real.Gamma x := by ring
+    _ = x * Real.Gamma x := by rw [hxpow]
+
+/-- **Gautschi upper bound.** For `x > 0` and `0 < s < 1`,
+`Γ(x+1) / Γ(x+s) ≤ (x+1)^(1-s)`. -/
+theorem gautschi_upper {x s : ℝ} (hx : 0 < x) (hs0 : 0 < s) (hs1 : s < 1) :
+    Real.Gamma (x + 1) / Real.Gamma (x + s) ≤ (x + 1) ^ (1 - s) := by
+  have hxs : 0 < x + s := by linarith
+  have hx1 : 0 < x + 1 := by linarith
+  have hx2 : 0 < x + 2 := by linarith
+  have h2s : 0 < 2 - s := by linarith
+  have hGxs : 0 < Real.Gamma (x + s) := Real.Gamma_pos_of_pos hxs
+  have hGx1 : 0 < Real.Gamma (x + 1) := Real.Gamma_pos_of_pos hx1
+  -- convexity via x+1 = (1/(2-s))·(x+s) + ((1-s)/(2-s))·(x+2)
+  have h := convexOn_log_Gamma.2 (Set.mem_Ioi.mpr hxs) (Set.mem_Ioi.mpr hx2)
+    (div_nonneg (by norm_num) (by linarith) : (0 : ℝ) ≤ 1 / (2 - s))
+    (div_nonneg (by linarith) (by linarith) : (0 : ℝ) ≤ (1 - s) / (2 - s))
+    (by field_simp; ring)
+  simp only [Function.comp_apply, smul_eq_mul] at h
+  rw [show 1 / (2 - s) * (x + s) + (1 - s) / (2 - s) * (x + 2) = x + 1 by
+    field_simp; ring] at h
+  -- log Γ(x+2) = log(x+1) + log Γ(x+1)
+  have hG2 : Real.log (Real.Gamma (x + 2))
+      = Real.log (x + 1) + Real.log (Real.Gamma (x + 1)) := by
+    rw [show (x : ℝ) + 2 = (x + 1) + 1 by ring, logGamma_add_one hx1]
+  rw [hG2] at h
+  -- clear the denominator (2-s) and simplify
+  have h' := mul_le_mul_of_nonneg_left h h2s.le
+  have hsimp : (2 - s) * (1 / (2 - s) * Real.log (Real.Gamma (x + s))
+      + (1 - s) / (2 - s) * (Real.log (x + 1) + Real.log (Real.Gamma (x + 1))))
+      = Real.log (Real.Gamma (x + s))
+        + (1 - s) * (Real.log (x + 1) + Real.log (Real.Gamma (x + 1))) := by
+    field_simp
+  rw [hsimp] at h'
+  -- linear rearrangement: log Γ(x+1) − log Γ(x+s) ≤ (1-s) log(x+1)
+  have hmul : Real.log (Real.Gamma (x + 1)) - Real.log (Real.Gamma (x + s))
+      ≤ (1 - s) * Real.log (x + 1) := by nlinarith [h']
+  -- exponentiate
+  have hlogdiv : Real.log (Real.Gamma (x + 1) / Real.Gamma (x + s))
+      ≤ Real.log ((x + 1) ^ (1 - s)) := by
+    rw [Real.log_div hGx1.ne' hGxs.ne', Real.log_rpow hx1]
+    exact hmul
+  have hpos : 0 < Real.Gamma (x + 1) / Real.Gamma (x + s) := div_pos hGx1 hGxs
+  have := Real.exp_le_exp.mpr hlogdiv
+  rwa [Real.exp_log hpos, Real.exp_log (by positivity : (0 : ℝ) < (x + 1) ^ (1 - s))] at this
+
+/-- **Gautschi double inequality** (combined two-sided form). For `x > 0` and
+`0 < s < 1`, the unit-shift ratio of Gamma values is bracketed by powers:
+`x^(1-s) ≤ Γ(x+1)/Γ(x+s) ≤ (x+1)^(1-s)`. -/
+theorem gautschi_bracket {x s : ℝ} (hx : 0 < x) (hs0 : 0 < s) (hs1 : s < 1) :
+    x ^ (1 - s) ≤ Real.Gamma (x + 1) / Real.Gamma (x + s)
+      ∧ Real.Gamma (x + 1) / Real.Gamma (x + s) ≤ (x + 1) ^ (1 - s) :=
+  ⟨gautschi_lower hx hs0 hs1, gautschi_upper hx hs0 hs1⟩
+
+/-- **Multiplicative midpoint inequality.** For `a, b > 0`,
+`Γ((a+b)/2)^2 ≤ Γ(a) · Γ(b)`, the direct multiplicative form of midpoint
+log-convexity of `Γ`. -/
+theorem gamma_midpoint_sq_le {a b : ℝ} (ha : 0 < a) (hb : 0 < b) :
+    Real.Gamma ((a + b) / 2) ^ 2 ≤ Real.Gamma a * Real.Gamma b := by
+  have hmid : 0 < (a + b) / 2 := by linarith
+  have hGa : 0 < Real.Gamma a := Real.Gamma_pos_of_pos ha
+  have hGb : 0 < Real.Gamma b := Real.Gamma_pos_of_pos hb
+  have h := convexOn_log_Gamma.2 (Set.mem_Ioi.mpr ha) (Set.mem_Ioi.mpr hb)
+    (by norm_num : (0 : ℝ) ≤ 1 / 2) (by norm_num : (0 : ℝ) ≤ 1 / 2) (by norm_num)
+  simp only [Function.comp_apply, smul_eq_mul] at h
+  rw [show 1 / 2 * a + 1 / 2 * b = (a + b) / 2 by ring] at h
+  have hlog : Real.log (Real.Gamma ((a + b) / 2) ^ 2)
+      ≤ Real.log (Real.Gamma a * Real.Gamma b) := by
+    rw [Real.log_pow, Real.log_mul hGa.ne' hGb.ne']
+    push_cast
+    linarith [h]
+  have := Real.exp_le_exp.mpr hlog
+  rwa [Real.exp_log (by positivity), Real.exp_log (by positivity)] at this
+
+end GammaLogConvexityOQ01

--- a/src/data/proofs/gamma-log-convexity-oq-01/meta.json
+++ b/src/data/proofs/gamma-log-convexity-oq-01/meta.json
@@ -1,0 +1,174 @@
+{
+  "id": "gamma-log-convexity-oq-01",
+  "title": "Log-Convexity of Gamma: the Gautschi Double Inequality x^(1−s) ≤ Γ(x+1)/Γ(x+s) ≤ (x+1)^(1−s)",
+  "slug": "gamma-log-convexity-oq-01",
+  "description": "The Gamma function is logarithmically convex on (0,∞) — Mathlib records this as `Real.convexOn_log_Gamma` but derives none of its functional-inequality consequences. From log-convexity alone, together with the functional equation Γ(x+1)=x·Γ(x), this entry proves the classical Gautschi double inequality for the unit-shift ratio, x^(1−s) ≤ Γ(x+1)/Γ(x+s) ≤ (x+1)^(1−s) for x>0 and 0<s<1, plus the multiplicative midpoint inequality Γ((a+b)/2)² ≤ Γ(a)·Γ(b). None of these ratio bounds are in Mathlib.",
+  "meta": {
+    "author": "Walter Gautschi (1959)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GammaLogConvexityOQ01.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "convexity",
+      "gamma-function",
+      "inequalities",
+      "gautschi"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.convexOn_log_Gamma",
+        "description": "log ∘ Γ is convex on (0,∞); the single structural input from which every bound here is derived",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup"
+      },
+      {
+        "theorem": "Real.Gamma_add_one",
+        "description": "Functional equation Γ(x+1) = x·Γ(x) for x ≠ 0, used to turn shifted Gamma values into elementary factors",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Real.Gamma_pos_of_pos",
+        "description": "Γ(x) > 0 for x > 0, supplying positivity needed to take and undo logarithms",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Real.log_rpow",
+        "description": "log(x^y) = y·log x for x > 0, converting power bounds to linear bounds on logarithms",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.exp_log",
+        "description": "exp(log x) = x for x > 0, used with monotonicity of exp to exponentiate log inequalities back to the originals",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "gautschi_lower: x^(1−s) ≤ Γ(x+1)/Γ(x+s) for x>0, 0<s<1, from the convex decomposition x+s = (1−s)·x + s·(x+1)",
+      "gautschi_upper: Γ(x+1)/Γ(x+s) ≤ (x+1)^(1−s), from the convex decomposition x+1 = (1/(2−s))·(x+s) + ((1−s)/(2−s))·(x+2)",
+      "gautschi_bracket: the combined two-sided Gautschi double inequality",
+      "gamma_midpoint_sq_le: Γ((a+b)/2)² ≤ Γ(a)·Γ(b), the multiplicative form of midpoint log-convexity",
+      "logGamma_le_lower: the reusable core estimate log Γ(x+s) ≤ log Γ(x) + s·log x"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. All theorems depend only on propext, Classical.choice, Quot.sound (Lean's foundational axioms). No native_decide, so no Lean.ofReduceBool.",
+    "lineCount": 149,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Walter Gautschi's 1959 paper *Some elementary inequalities relating to the gamma and incomplete gamma function* gave sharp two-sided bounds for the ratio Γ(x+1)/Γ(x+s) of Gamma values at points differing by less than one. Such ratios pervade asymptotics, special-function theory, and numerical analysis (e.g. error estimates for the incomplete Gamma function). The bounds are the prototypical application of the Bohr–Mollerup principle that Γ is logarithmically convex: every Gautschi-type estimate is, at bottom, a convexity inequality for log Γ combined with the recurrence Γ(x+1)=x·Γ(x). Mathlib formalizes the log-convexity (it needs it to characterize Γ via Bohr–Mollerup) but stops there, deriving none of the downstream functional inequalities.",
+    "problemStatement": "Using only the log-convexity of Γ on (0,∞) and its functional equation, establish sharp power bounds for the unit-shift ratio of Gamma values.\n\n**Result:** for x>0 and 0<s<1,  x^(1−s) ≤ Γ(x+1)/Γ(x+s) ≤ (x+1)^(1−s); and for a,b>0,  Γ((a+b)/2)² ≤ Γ(a)·Γ(b).",
+    "text": "From log-convexity of the Gamma function this entry derives the Gautschi double inequality x^(1−s) ≤ Γ(x+1)/Γ(x+s) ≤ (x+1)^(1−s) and the multiplicative midpoint inequality, all verified in Lean with no axioms.",
+    "proofStrategy": "Every bound is an instance of the two-point convexity inequality `convexOn_log_Gamma.2`, applied at a tailored convex decomposition of the target point, then exponentiated (exp is monotone, Γ>0 so logs are reversible).\n1. logGamma_le_lower: write x+s = (1−s)·x + s·(x+1). Convexity gives log Γ(x+s) ≤ (1−s)log Γ(x) + s·log Γ(x+1); the functional equation log Γ(x+1) = log x + log Γ(x) collapses the right side to log Γ(x) + s·log x.\n2. gautschi_lower: exponentiate step 1 to Γ(x+s) ≤ Γ(x)·x^s, then since Γ(x+1)=x·Γ(x) and x^(1−s)·x^s = x, rearrange to x^(1−s) ≤ Γ(x+1)/Γ(x+s).\n3. gautschi_upper: write x+1 = (1/(2−s))·(x+s) + ((1−s)/(2−s))·(x+2). Convexity, after clearing the denominator (2−s) and substituting log Γ(x+2) = log(x+1) + log Γ(x+1), gives log Γ(x+1) − log Γ(x+s) ≤ (1−s)·log(x+1); exponentiating yields Γ(x+1)/Γ(x+s) ≤ (x+1)^(1−s).\n4. gamma_midpoint_sq_le: midpoint convexity (weights 1/2, 1/2) gives log Γ((a+b)/2) ≤ ½(log Γ(a)+log Γ(b)); doubling and exponentiating gives the squared multiplicative form.",
+    "keyInsights": [
+      "**One structural input, two decompositions.** Both Gautschi bounds come from the *same* convexity inequality for log Γ; only the convex combination of points differs — x+s split toward (x, x+1) for the lower bound, x+1 split toward (x+s, x+2) for the upper. No derivative or integral estimates are needed.",
+      "**The functional equation does the bookkeeping.** Γ(x+1)=x·Γ(x) is what turns an abstract convexity bound into an explicit power of x (or x+1): log Γ(x+1)−log Γ(x) = log x is exactly the linear term that produces x^s and (x+1)^(1−s).",
+      "**Filling a real Mathlib gap.** Mathlib carries `convexOn_log_Gamma` solely as a lemma inside the Bohr–Mollerup uniqueness proof; it never exposes a single ratio or midpoint inequality. This entry packages the classical consequences as directly citable theorems.",
+      "**Avoiding the secant-slope machinery.** The upper bound is usually phrased via monotonicity of secant slopes of a convex function. Recasting it as a single convex combination x+1 = (1/(2−s))(x+s) + ((1−s)/(2−s))(x+2) keeps the whole development inside the elementary two-point convexity API and avoids division-by-slope side conditions."
+    ],
+    "prerequisites": [
+      "Convex functions and the two-point (Jensen) inequality",
+      "Logarithmic convexity and the Bohr–Mollerup characterization of Γ",
+      "The Gamma functional equation Γ(x+1) = x·Γ(x)",
+      "Real powers (rpow) and the laws log(x^y)=y·log x, exp∘log = id on (0,∞)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-setup",
+      "title": "Imports and the Functional-Equation Lemma",
+      "startLine": 1,
+      "endLine": 34,
+      "summary": "File docstring describing the Gautschi inequality and its derivation from log-convexity. logGamma_add_one packages the log form of the functional equation: log Γ(x+1) = log x + log Γ(x) for x>0.",
+      "mathContext": "Γ(x+1)=x·Γ(x) with Γ(x)>0 gives, after taking logs, the linear increment log Γ(x+1)−log Γ(x) = log x."
+    },
+    {
+      "id": "core-lower-estimate",
+      "title": "Core Convexity Estimate",
+      "startLine": 36,
+      "endLine": 51,
+      "summary": "logGamma_le_lower: applying convexOn_log_Gamma.2 at the convex combination x+s = (1−s)·x + s·(x+1) and simplifying with the functional equation yields log Γ(x+s) ≤ log Γ(x) + s·log x.",
+      "mathContext": "The single convexity inequality underlying the lower Gautschi bound; s∈[0,1] is exactly the weight constraint."
+    },
+    {
+      "id": "lower-bound",
+      "title": "Gautschi Lower Bound",
+      "startLine": 53,
+      "endLine": 82,
+      "summary": "gautschi_lower: exponentiating the core estimate gives Γ(x+s) ≤ Γ(x)·x^s; combined with Γ(x+1)=x·Γ(x) and x^(1−s)·x^s = x, rearrangement yields x^(1−s) ≤ Γ(x+1)/Γ(x+s).",
+      "mathContext": "Lower bound of the Gautschi double inequality, sharp as s→0 and s→1."
+    },
+    {
+      "id": "upper-bound",
+      "title": "Gautschi Upper Bound",
+      "startLine": 84,
+      "endLine": 122,
+      "summary": "gautschi_upper: convexity at x+1 = (1/(2−s))·(x+s) + ((1−s)/(2−s))·(x+2), after clearing the (2−s) denominator and using log Γ(x+2)=log(x+1)+log Γ(x+1), gives log Γ(x+1)−log Γ(x+s) ≤ (1−s)·log(x+1); exponentiating gives Γ(x+1)/Γ(x+s) ≤ (x+1)^(1−s).",
+      "mathContext": "Upper bound of the Gautschi double inequality, using a forward convex combination toward x+2."
+    },
+    {
+      "id": "bracket-and-midpoint",
+      "title": "Combined Bracket and Midpoint Inequality",
+      "startLine": 124,
+      "endLine": 149,
+      "summary": "gautschi_bracket bundles the two bounds into the two-sided statement. gamma_midpoint_sq_le derives Γ((a+b)/2)² ≤ Γ(a)·Γ(b) from midpoint convexity (weights 1/2, 1/2) by doubling the log inequality and exponentiating.",
+      "mathContext": "The two-sided Gautschi inequality and the multiplicative midpoint log-convexity inequality."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Gautschi, Walter",
+      "title": "Some elementary inequalities relating to the gamma and incomplete gamma function",
+      "year": "1959",
+      "note": "Original source of the double inequality x^(1−s) ≤ Γ(x+1)/Γ(x+s) ≤ (x+1)^(1−s)"
+    },
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "note": "Develops the Bohr–Mollerup theorem and log-convexity as the defining property of Γ"
+    },
+    {
+      "authors": "Qi, Feng",
+      "title": "Bounds for the ratio of two gamma functions",
+      "year": "2010",
+      "note": "Survey placing Gautschi's inequality within the broader theory of Gamma-ratio bounds (Kershaw, Wendel, etc.)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-05",
+      "relationship": "related",
+      "description": "Both extract sharp functional inequalities from strict/ordinary convexity of a transcendental function (exp there, log∘Γ here)"
+    }
+  ],
+  "conclusion": {
+    "summary": "From the single fact that log∘Γ is convex on (0,∞), together with the recurrence Γ(x+1)=x·Γ(x), the Gautschi double inequality x^(1−s) ≤ Γ(x+1)/Γ(x+s) ≤ (x+1)^(1−s) (gautschi_lower, gautschi_upper, gautschi_bracket) and the multiplicative midpoint inequality Γ((a+b)/2)² ≤ Γ(a)·Γ(b) (gamma_midpoint_sq_le) are derived. Each is a two-point convexity inequality at a tailored decomposition, exponentiated. All five results are verified with 0 axioms and 0 sorries.",
+    "implications": "Exposes the classical Gamma-ratio bounds as directly citable theorems, turning Mathlib's internal-only log-convexity lemma into usable functional inequalities for asymptotics and special-function estimates.",
+    "openQuestions": [
+      "Can the sharper Kershaw bound (x + s/2)^(1−s) ≤ Γ(x+1)/Γ(x+s), which interpolates between the two Gautschi endpoints, be obtained by the same convex-decomposition method with a shifted midpoint?",
+      "Does strict convexity of log∘Γ (available via strict log-convexity of Γ) upgrade these to strict inequalities for 0<s<1, with equality characterized only in the degenerate limits?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Set"
+    ],
+    "namespace": "GammaLogConvexityOQ01",
+    "lineCount": 149,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/GammaLogConvexityOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Derives the classical **Gautschi double inequality** and the multiplicative midpoint inequality for the Gamma function from a single structural input — the log-convexity of Γ on (0,∞) (`Real.convexOn_log_Gamma`) — together with the functional equation Γ(x+1)=x·Γ(x).

For `x > 0` and `0 < s < 1`:
```
x^(1−s)  ≤  Γ(x+1) / Γ(x+s)  ≤  (x+1)^(1−s)
```
and for `a, b > 0`:
```
Γ((a+b)/2)²  ≤  Γ(a) · Γ(b)
```

**Why this is not a wrapper:** Mathlib carries `convexOn_log_Gamma` *only* as an internal lemma in the Bohr–Mollerup uniqueness proof. It exposes none of the Gautschi/Kershaw ratio bounds nor the midpoint inequality. This entry packages those classical consequences as directly citable theorems.

## Theorems (all 0-axiom, 0-sorry)

- `logGamma_le_lower` — core estimate `log Γ(x+s) ≤ log Γ(x) + s·log x`
- `gautschi_lower` — `x^(1−s) ≤ Γ(x+1)/Γ(x+s)`
- `gautschi_upper` — `Γ(x+1)/Γ(x+s) ≤ (x+1)^(1−s)`
- `gautschi_bracket` — combined two-sided form
- `gamma_midpoint_sq_le` — `Γ((a+b)/2)² ≤ Γ(a)·Γ(b)`

## Proof method

Each bound is the two-point convexity inequality `convexOn_log_Gamma.2` at a tailored convex decomposition, then exponentiated (exp monotone, Γ>0 so logs reverse):
- lower: `x+s = (1−s)·x + s·(x+1)`
- upper: `x+1 = (1/(2−s))·(x+s) + ((1−s)/(2−s))·(x+2)` — recasts the usual secant-slope argument as one convex combination, staying inside the elementary two-point API.

## Verification

```
#print axioms gautschi_lower   -- [propext, Classical.choice, Quot.sound]
#print axioms gautschi_upper   -- [propext, Classical.choice, Quot.sound]
#print axioms gamma_midpoint_sq_le -- [propext, Classical.choice, Quot.sound]
```
Compiles clean against pinned Mathlib 4.26.0 (`lake env lean`, exit 0). No `native_decide`; no `Lean.ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)