### PR TITLE
research(jacobi-symbol-oq-01): the Jacobi symbol — bimultiplicative one-sided residue test (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2650,6 +2650,7 @@ import Proofs.IsoperimetricTheoremOQ01
 import Proofs.IsoperimetricTheoremOQ02
 import Proofs.IsoscelesTriangle
 import Proofs.IsoscelesTriangleOQ01
+import Proofs.JacobiSymbolOQ01
 import Proofs.KaprekarConstantOQ01
 import Proofs.KeithNumberOQ01
 import Proofs.KeplerConjecture

--- a/proofs/Proofs/JacobiSymbolOQ01.lean
+++ b/proofs/Proofs/JacobiSymbolOQ01.lean
@@ -1,0 +1,73 @@
+/-
+  The Jacobi symbol: a bimultiplicative, one-sided residue test.
+
+  The **Jacobi symbol** `J(a | n)` extends the Legendre symbol to all odd
+  moduli `n` by multiplying the Legendre symbols over the prime factors of `n`:
+  `J(a | n) = ∏_{p ∣ n} (a | p)` (with multiplicity).  Its key properties:
+
+    * **bimultiplicativity** in both arguments,
+        `J(ab | n) = J(a | n) J(b | n)`,  `J(a | mn) = J(a | m) J(a | n)`;
+    * the **trichotomy** `J(a | n) ∈ {−1, 0, 1}`, with `J(a | n) = 0` exactly
+      when `gcd(a, n) ≠ 1`;
+    * a **one-sided obstruction**: `J(a | n) = −1 ⟹ a is a non-residue mod n`.
+
+  Crucially the obstruction is ONE-SIDED: unlike the Legendre symbol, the
+  converse FAILS for composite `n`.  We exhibit `J(2 | 15) = 1` even though `2`
+  is a quadratic non-residue mod 15 — so `J(a | n) = 1` does NOT certify that
+  `a` is a square.  (This one-sidedness is exactly why the Jacobi symbol speeds
+  up the Legendre-symbol computation in reciprocity without itself detecting
+  residues.)
+
+  Vehicles are Mathlib's `jacobiSym` API; the concrete `J(2 | 15) = 1` and the
+  non-residue are checked by `decide`.  Fully verified: 0 sorries, 0 axioms, no
+  `native_decide`.
+-/
+import Mathlib
+
+namespace JacobiSymbolOQ01
+
+/-! ### Bimultiplicativity and the trichotomy -/
+
+/-- **Multiplicativity in the numerator**: `J(a₁a₂ | n) = J(a₁ | n) J(a₂ | n)`. -/
+theorem jacobi_mul_left (a₁ a₂ : ℤ) (n : ℕ) :
+    jacobiSym (a₁ * a₂) n = jacobiSym a₁ n * jacobiSym a₂ n :=
+  jacobiSym.mul_left a₁ a₂ n
+
+/-- **Multiplicativity in the modulus**: `J(a | m·n) = J(a | m) J(a | n)`. -/
+theorem jacobi_mul_right (a : ℤ) (m n : ℕ) [NeZero m] [NeZero n] :
+    jacobiSym a (m * n) = jacobiSym a m * jacobiSym a n :=
+  jacobiSym.mul_right a m n
+
+/-- **Trichotomy** for coprime arguments: `J(a | n) = ±1`. -/
+theorem jacobi_eq_one_or_neg_one {a : ℤ} {n : ℕ} (h : a.gcd n = 1) :
+    jacobiSym a n = 1 ∨ jacobiSym a n = -1 :=
+  jacobiSym.eq_one_or_neg_one h
+
+/-- `J(a | n) = 0` exactly when `a` and `n` are NOT coprime. -/
+theorem jacobi_eq_zero_iff {a : ℤ} {n : ℕ} [NeZero n] :
+    jacobiSym a n = 0 ↔ a.gcd n ≠ 1 :=
+  jacobiSym.eq_zero_iff_not_coprime
+
+/-! ### The one-sided obstruction, and the failure of its converse -/
+
+/-- **Non-residue obstruction**: if `J(a | n) = −1` then `a` is a quadratic
+non-residue modulo `n`. -/
+theorem not_isSquare_of_jacobi_eq_neg_one {a : ℤ} {n : ℕ} (h : jacobiSym a n = -1) :
+    ¬ IsSquare (a : ZMod n) :=
+  ZMod.nonsquare_of_jacobiSym_eq_neg_one h
+
+/-- `J(2 | 15) = 1` — the Jacobi symbol is `(2 | 3)(2 | 5) = (−1)(−1) = 1`. -/
+theorem jacobi_two_fifteen : jacobiSym 2 15 = 1 := by norm_num
+
+/-- Yet `2` is a quadratic NON-residue mod 15 (the squares mod 15 are
+`{0, 1, 4, 6, 9, 10}`). -/
+theorem not_isSquare_two_mod_fifteen : ¬ IsSquare (2 : ZMod 15) := by decide
+
+/-- **The converse fails for composite moduli.** There exist `a, n` with
+`J(a | n) = 1` yet `a` a non-residue mod `n`: the Jacobi symbol is a one-sided
+witness, not a residue test (unlike the Legendre symbol). -/
+theorem jacobi_one_not_isSquare :
+    ∃ (a : ℤ) (n : ℕ), jacobiSym a n = 1 ∧ ¬ IsSquare (a : ZMod n) :=
+  ⟨2, 15, jacobi_two_fifteen, not_isSquare_two_mod_fifteen⟩
+
+end JacobiSymbolOQ01

--- a/src/data/proofs/jacobi-symbol-oq-01/annotations.json
+++ b/src/data/proofs/jacobi-symbol-oq-01/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "jacobi-symbol-oq-01-module-header",
+    "proofId": "jacobi-symbol-oq-01",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 28
+    },
+    "title": "Module Header: The Jacobi Symbol",
+    "content": "The **Jacobi symbol** $J(a \\mid n) = \\prod_{p \\mid n} (a \\mid p)$ extends the Legendre symbol to all odd moduli by multiplying over the prime factors of $n$ (with multiplicity). It is **bimultiplicative**, satisfies the **trichotomy** $J(a\\mid n) \\in \\{-1,0,1\\}$ (with $0$ exactly when $\\gcd(a,n) \\ne 1$), and gives a **one-sided obstruction**: $J(a\\mid n) = -1 \\Rightarrow a$ is a non-residue. But the converse FAILS for composite $n$: $J(2 \\mid 15) = 1$ while $2$ is a non-residue mod $15$. This one-sidedness is the price of computing the symbol fast (by reciprocity, without factoring)."
+  },
+  {
+    "id": "jacobi-symbol-oq-01-bimultiplicative",
+    "proofId": "jacobi-symbol-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 32,
+      "endLine": 56
+    },
+    "title": "Bimultiplicativity and Trichotomy",
+    "content": "`jacobi_mul_left`: $J(a_1 a_2 \\mid n) = J(a_1\\mid n)\\,J(a_2\\mid n)$ — multiplicative in the numerator.\n\n`jacobi_mul_right`: $J(a \\mid mn) = J(a\\mid m)\\,J(a\\mid n)$ — multiplicative in the modulus, the defining extension over the factorization of $n$.\n\n`jacobi_eq_one_or_neg_one`: for coprime arguments $J(a\\mid n) = \\pm 1$; `jacobi_eq_zero_iff`: $J(a\\mid n) = 0 \\iff \\gcd(a,n) \\ne 1$. Together these give the $\\{-1,0,1\\}$ trichotomy. (Restatements of Mathlib's `jacobiSym.mul_left/.mul_right/.eq_one_or_neg_one/.eq_zero_iff_not_coprime`.)"
+  },
+  {
+    "id": "jacobi-symbol-oq-01-onesided",
+    "proofId": "jacobi-symbol-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 58,
+      "endLine": 73
+    },
+    "title": "The One-Sided Obstruction and Its Failed Converse",
+    "content": "`not_isSquare_of_jacobi_eq_neg_one`: $J(a\\mid n) = -1 \\Rightarrow \\neg\\,\\mathrm{IsSquare}\\,(a : \\mathbb{Z}/n)$ — a Jacobi value of $-1$ always proves non-residuosity (`ZMod.nonsquare_of_jacobiSym_eq_neg_one`).\n\nThe converse fails for composite $n$. `jacobi_two_fifteen`: $J(2\\mid 15) = (2\\mid 3)(2\\mid 5) = (-1)(-1) = 1$, computed by the `norm_num` Legendre extension. `not_isSquare_two_mod_fifteen`: yet $2$ is a non-residue mod $15$ (squares $= \\{0,1,4,6,9,10\\}$), by `decide`. `jacobi_one_not_isSquare` packages these into $\\exists a, n,\\ J(a\\mid n) = 1 \\wedge \\neg\\,\\mathrm{IsSquare}\\,a$ — the Jacobi symbol is a one-sided witness, not a residue test."
+  }
+]

--- a/src/data/proofs/jacobi-symbol-oq-01/meta.json
+++ b/src/data/proofs/jacobi-symbol-oq-01/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "jacobi-symbol-oq-01",
+  "title": "The Jacobi Symbol: A Bimultiplicative One-Sided Residue Test",
+  "slug": "jacobi-symbol-oq-01",
+  "description": "The Jacobi symbol J(a|n) extends the Legendre symbol to all odd moduli by multiplying Legendre symbols over the prime factors of n. It is bimultiplicative (J(ab|n) = J(a|n)J(b|n) and J(a|mn) = J(a|m)J(a|n)), satisfies the trichotomy J(a|n) ∈ {−1,0,1} with J(a|n) = 0 iff gcd(a,n) ≠ 1, and gives a one-sided obstruction: J(a|n) = −1 ⟹ a is a non-residue mod n. Crucially the converse FAILS for composite n — J(2|15) = 1 yet 2 is a non-residue mod 15 — so the Jacobi symbol is a witness, not a residue test. 8 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Jacobi_symbol",
+    "date": "Carl Gustav Jacob Jacobi, 1837",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "quadratic-residues",
+      "jacobi-symbol",
+      "legendre-symbol",
+      "modular-arithmetic",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/JacobiSymbolOQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 8 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). The concrete value J(2|15) = 1 is proved by the norm_num Legendre-symbol extension (a kernel-checked proof) and the non-residue by decide — no native_decide, so no Lean.ofReduceBool.",
+    "originalContributions": [
+      "jacobi_mul_left / jacobi_mul_right: bimultiplicativity of the Jacobi symbol in both the numerator and the modulus",
+      "jacobi_eq_one_or_neg_one: the trichotomy J(a|n) = ±1 for coprime arguments; jacobi_eq_zero_iff: J(a|n) = 0 ↔ ¬coprime",
+      "not_isSquare_of_jacobi_eq_neg_one: the one-sided non-residue obstruction J(a|n) = −1 ⟹ ¬IsSquare (a : ZMod n)",
+      "jacobi_two_fifteen / not_isSquare_two_mod_fifteen: J(2|15) = 1 while 2 is a non-residue mod 15",
+      "jacobi_one_not_isSquare: the packaged statement that the converse FAILS for composite n — ∃ a n, J(a|n) = 1 ∧ ¬IsSquare a — so the Jacobi symbol is a one-sided witness, not a residue test"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 73,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Carl Gustav Jacob Jacobi introduced his symbol in 1837 as a multiplicative extension of the Legendre symbol to composite (odd) moduli. Its decisive feature is that it can be computed rapidly by the quadratic-reciprocity recursion WITHOUT factoring the modulus — which is exactly why it appears in primality tests (Solovay–Strassen) and in fast evaluation of Legendre symbols. The price of that efficiency is that the Jacobi symbol no longer detects quadratic residues: J(a|n) = 1 does not imply a is a square mod composite n.",
+    "problemStatement": "**Open Question (OQ-01, Jacobi symbol)**: Assemble a self-contained Jacobi-symbol package — bimultiplicativity, the {−1,0,1} trichotomy with the coprimality criterion for 0, and the one-sided non-residue obstruction — and demonstrate that the converse of the obstruction fails for composite moduli.\n\n**Formalized**: jacobi_mul_left, jacobi_mul_right, jacobi_eq_one_or_neg_one, jacobi_eq_zero_iff, not_isSquare_of_jacobi_eq_neg_one, and the witness J(2|15) = 1 with 2 a non-residue mod 15 (jacobi_one_not_isSquare).",
+    "text": "A 73-line formalization built on Mathlib's jacobiSym. The bimultiplicativity (jacobi_mul_left, jacobi_mul_right), the trichotomy (jacobi_eq_one_or_neg_one, jacobi_eq_zero_iff), and the non-residue obstruction (not_isSquare_of_jacobi_eq_neg_one) are stated cleanly. The headline contrast with the Legendre symbol is then proved concretely: J(2|15) = 1 (the norm_num Legendre extension computes (2|3)(2|5) = (−1)(−1) = 1) while 2 is a non-residue mod 15 (decide over ZMod 15), packaged as jacobi_one_not_isSquare. All 8 theorems compile with 0 sorries and 0 axioms; no native_decide is used.",
+    "proofStrategy": "**Bimultiplicativity / trichotomy / obstruction**: direct restatements of jacobiSym.mul_left, jacobiSym.mul_right, jacobiSym.eq_one_or_neg_one, jacobiSym.eq_zero_iff_not_coprime, and ZMod.nonsquare_of_jacobiSym_eq_neg_one.\n\n**Converse fails**: jacobi_two_fifteen evaluates J(2|15) = 1 with the norm_num Legendre-symbol extension (kernel-checked, not native). not_isSquare_two_mod_fifteen checks ¬IsSquare (2 : ZMod 15) by decide over the finite type (the squares mod 15 are {0,1,4,6,9,10}, missing 2). jacobi_one_not_isSquare bundles these into ∃ a n, J(a|n) = 1 ∧ ¬IsSquare a.",
+    "keyInsights": [
+      "**Bimultiplicative in both slots**: J(·|n) and J(a|·) are both completely multiplicative, so the Jacobi symbol is determined by its values on prime numerators and prime moduli — this is what powers the reciprocity recursion.",
+      "**One-sided, by design**: J(a|n) = −1 still PROVES non-residuosity (a square would be a square modulo every prime factor, forcing each Legendre factor to be +1), but J(a|n) = 1 only means an EVEN number of prime factors see a as a non-residue — not that a is a square.",
+      "**The witness J(2|15) = 1**: 2 is a non-residue mod 3 and mod 5, so the two −1's multiply to +1, yet 2 is a non-residue mod 15. This single example separates the Jacobi symbol from the Legendre symbol as a residue test.",
+      "**Why it is still useful**: precisely because it ignores factorization, the Jacobi symbol can be evaluated fast by reciprocity; the lost residue-detection is recovered probabilistically in the Solovay–Strassen primality test.",
+      "**0-axiom numerics**: the value J(2|15) = 1 is produced by norm_num's Legendre extension as an ordinary kernel proof, and the non-residue by decide — so no native_decide and no Lean.ofReduceBool enter."
+    ],
+    "prerequisites": [
+      "The Legendre symbol (a | p) for prime p and its multiplicativity (see euler-criterion-squares)",
+      "The Jacobi symbol jacobiSym a n = ∏_{p ∣ n} (a | p) over the prime factors of n (Mathlib jacobiSym)",
+      "Quadratic residues / IsSquare in ZMod n, and gcd / coprimality",
+      "jacobiSym.mul_left, jacobiSym.mul_right, jacobiSym.eq_one_or_neg_one, jacobiSym.eq_zero_iff_not_coprime, ZMod.nonsquare_of_jacobiSym_eq_neg_one",
+      "norm_num evaluation of Legendre/Jacobi symbols and decidability over finite ZMod n"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "euler-criterion-squares-oq-01",
+      "relationship": "extends",
+      "description": "Euler's criterion and the Legendre symbol decide residuosity modulo a prime (J(a|p) = 1 ↔ a is a square). The Jacobi symbol extends the Legendre symbol multiplicatively to composite odd moduli but LOSES the residue-detection: J(a|n) = 1 no longer implies a is a square, as J(2|15) = 1 with 2 a non-residue mod 15 shows."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "JacobiSymbolOQ01",
+    "lineCount": 73,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/JacobiSymbolOQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "jacobi_one_not_isSquare",
+      "type": "core",
+      "statement": "$\\exists a, n,\\ J(a \\mid n) = 1 \\wedge \\neg\\,\\mathrm{IsSquare}\\,(a : \\mathbb{Z}/n)$",
+      "significance": "The headline: the converse of the obstruction FAILS for composite moduli. Unlike the Legendre symbol, J(a|n) = 1 does NOT certify that a is a quadratic residue — witnessed by J(2|15) = 1 with 2 a non-residue mod 15.",
+      "description": "J(a|n) = 1 does not imply a is a square."
+    },
+    {
+      "name": "not_isSquare_of_jacobi_eq_neg_one",
+      "type": "core",
+      "statement": "$J(a \\mid n) = -1 \\Rightarrow \\neg\\,\\mathrm{IsSquare}\\,(a : \\mathbb{Z}/n)$",
+      "significance": "The one-sided obstruction: a Jacobi value of −1 still proves non-residuosity (a square would be a square mod every prime factor). This direction always holds; only the converse fails.",
+      "description": "J(a|n) = −1 forces a to be a non-residue."
+    },
+    {
+      "name": "jacobi_mul_left",
+      "type": "core",
+      "statement": "$J(a_1 a_2 \\mid n) = J(a_1 \\mid n)\\,J(a_2 \\mid n)$",
+      "significance": "Multiplicativity in the numerator — half of the bimultiplicativity that makes the Jacobi symbol computable by reciprocity.",
+      "description": "Multiplicative in the numerator."
+    },
+    {
+      "name": "jacobi_mul_right",
+      "type": "core",
+      "statement": "$J(a \\mid mn) = J(a \\mid m)\\,J(a \\mid n)$",
+      "significance": "Multiplicativity in the modulus — the defining extension of the Legendre symbol over the prime factorization of n.",
+      "description": "Multiplicative in the modulus."
+    },
+    {
+      "name": "jacobi_eq_one_or_neg_one",
+      "type": "supporting",
+      "statement": "$\\gcd(a, n) = 1 \\Rightarrow J(a \\mid n) = \\pm 1$",
+      "significance": "The trichotomy for coprime arguments: away from common factors the Jacobi symbol is ±1.",
+      "description": "J(a|n) = ±1 when coprime."
+    },
+    {
+      "name": "jacobi_eq_zero_iff",
+      "type": "supporting",
+      "statement": "$J(a \\mid n) = 0 \\iff \\gcd(a, n) \\ne 1$",
+      "significance": "The zero case is exactly non-coprimality — completing the {−1, 0, 1} trichotomy.",
+      "description": "J(a|n) = 0 iff a, n not coprime."
+    },
+    {
+      "name": "jacobi_two_fifteen",
+      "type": "supporting",
+      "statement": "$J(2 \\mid 15) = 1$",
+      "significance": "The concrete value driving the converse-failure: (2|3)(2|5) = (−1)(−1) = 1, computed by the norm_num Legendre extension.",
+      "description": "J(2|15) = 1."
+    },
+    {
+      "name": "not_isSquare_two_mod_fifteen",
+      "type": "supporting",
+      "statement": "$\\neg\\,\\mathrm{IsSquare}\\,(2 : \\mathbb{Z}/15)$",
+      "significance": "2 is a non-residue mod 15 (the squares are {0,1,4,6,9,10}); with J(2|15) = 1 this is the counterexample to the converse.",
+      "description": "2 is a non-residue mod 15."
+    }
+  ],
+  "references": [
+    {
+      "text": "Jacobi, C. G. J. (1837). Über die Kreisteilung und ihre Anwendung auf die Zahlentheorie. The Jacobi symbol as a multiplicative extension of the Legendre symbol.",
+      "url": "https://en.wikipedia.org/wiki/Jacobi_symbol"
+    },
+    {
+      "text": "Solovay, R. & Strassen, V. (1977). A fast Monte-Carlo test for primality. Uses the Jacobi symbol's efficient computation and its one-sided residue behaviour.",
+      "url": "https://en.wikipedia.org/wiki/Solovay%E2%80%93Strassen_primality_test"
+    },
+    {
+      "text": "Mathlib4: jacobiSym.mul_left, jacobiSym.mul_right, jacobiSym.eq_one_or_neg_one, jacobiSym.eq_zero_iff_not_coprime, ZMod.nonsquare_of_jacobiSym_eq_neg_one (NumberTheory/LegendreSymbol/JacobiSymbol.lean).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Assembles the Jacobi symbol's core theory: bimultiplicativity (jacobi_mul_left, jacobi_mul_right), the {−1,0,1} trichotomy with J = 0 ⟺ ¬coprime (jacobi_eq_one_or_neg_one, jacobi_eq_zero_iff), and the one-sided non-residue obstruction J(a|n) = −1 ⟹ ¬IsSquare (not_isSquare_of_jacobi_eq_neg_one). The defining contrast with the Legendre symbol is proved concretely: J(2|15) = 1 while 2 is a non-residue mod 15, so the converse fails (jacobi_one_not_isSquare). All 8 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "The Jacobi symbol's bimultiplicativity makes it computable by quadratic reciprocity without factoring — the basis of the Solovay–Strassen primality test and of fast Legendre-symbol evaluation. Its one-sidedness (J = −1 proves non-residuosity, J = 1 proves nothing about residuosity for composite moduli) is the essential trade-off, recovered probabilistically in primality testing.",
+    "openQuestions": [
+      "Formalize quadratic reciprocity for the Jacobi symbol itself (jacobiSym.quadratic_reciprocity) and the supplementary laws for −1 and 2",
+      "Build the Solovay–Strassen Euler-witness predicate a^((n−1)/2) ≡ J(a|n) (mod n) and its failure rate for composite n",
+      "Characterize exactly when J(a|n) = 1 yet a is a non-residue, in terms of the number of prime factors p ∣ n with (a|p) = −1"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Assembles the **Jacobi symbol** `J(a|n)` — the multiplicative extension of the Legendre symbol to composite odd moduli — and pinpoints what it loses. New gallery topic.

- **jacobi_mul_left / jacobi_mul_right** — bimultiplicativity, `J(ab|n)=J(a|n)J(b|n)` and `J(a|mn)=J(a|m)J(a|n)`
- **jacobi_eq_one_or_neg_one / jacobi_eq_zero_iff** — the `{−1,0,1}` trichotomy, with `J=0 ⟺ ¬coprime`
- **not_isSquare_of_jacobi_eq_neg_one** — the one-sided obstruction: `J(a|n)=−1 ⟹ a` is a non-residue mod `n`
- **jacobi_two_fifteen / not_isSquare_two_mod_fifteen / jacobi_one_not_isSquare** — the **converse fails** for composite `n`: `J(2|15)=1` yet `2` is a non-residue mod 15, so `J=1` is *not* a residue test (unlike Legendre)

## Verification

- **8 theorems, 73 lines**, 0 sorries, **0 axioms**
- `#print axioms` on all theorems shows only `propext / Classical.choice / Quot.sound` — `J(2|15)=1` is proved by the `norm_num` Legendre-symbol extension (kernel-checked) and the non-residue by `decide`; **no `native_decide`**, no `Lean.ofReduceBool`
- Compiles clean against pinned Mathlib 4.26.0 (`lake env lean`)

## Files

- `proofs/Proofs/JacobiSymbolOQ01.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/jacobi-symbol-oq-01/{meta,annotations}.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)