### PR TITLE
research(schroder-numbers-oq-01): large Schröder growth theory — positivity, doubling step, strict monotonicity, exponential lower bound

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2979,6 +2979,7 @@ import Proofs.SchroederBernsteinOQ02
 import Proofs.SchroederBernsteinOQ03
 import Proofs.SchroederBernsteinOQ03Aristotle
 import Proofs.SchroederBernsteinOQ04
+import Proofs.SchroderNumbersOQ01
 import Proofs.SchursTheorem
 import Proofs.SearchMathlib
 import Proofs.ShannonChannelCoding

--- a/proofs/Proofs/SchroderNumbersOQ01.lean
+++ b/proofs/Proofs/SchroderNumbersOQ01.lean
@@ -1,0 +1,123 @@
+/-
+Large Schröder numbers: positivity, strict growth, and an exponential lower bound
+
+Source: Open question from the schroder-numbers gallery family
+Status: VERIFIED (0 axioms, 0 sorries)
+
+The large Schröder numbers `Nat.largeSchroder` (OEIS A006318: 1, 2, 6, 22, 90, …)
+are defined in Mathlib (`Mathlib/Combinatorics/Enumerative/Schroder.lean`) by the
+convolution recurrence
+
+    L 0       = 1
+    L (n + 1) = L n + ∑ i ≤ n, L i * L (n - i).
+
+Mathlib records the base values, the recurrence (`largeSchroder_succ`), the parity
+fact `even_largeSchroder`, and the small/large bridge `two_mul_smallSchroder_succ`.
+It does **not** record any *order* information: positivity, monotonicity, or growth.
+We fill that gap with elementary consequences of the recurrence:
+
+  * `largeSchroder_pos`            :  0 < L n
+  * `two_mul_largeSchroder_le_succ`:  2 * L n ≤ L (n + 1)        (the doubling step)
+  * `largeSchroder_lt_succ`        :  L n < L (n + 1)
+  * `strictMono_largeSchroder`     :  StrictMono L
+  * `two_pow_le_largeSchroder`     :  2 ^ n ≤ L n                (exponential lower bound)
+
+The doubling step is the crux: in `L (n + 1) = L n + ∑ i ≤ n, L i * L (n - i)` the
+single `i = 0` term already equals `L 0 * L n = L n`, so the whole sum is `≥ L n`
+and hence `L (n + 1) ≥ L n + L n = 2 * L n`. Strict monotonicity and the `2 ^ n`
+bound then follow by induction. We also record positivity for the small Schröder
+numbers as a companion.
+
+All proofs are kernel-checked with no `axiom`, `sorry`, or `native_decide`.
+-/
+import Mathlib
+
+namespace SchroderNumbersOQ01
+
+open Finset
+open Nat (largeSchroder smallSchroder)
+
+/-- The large Schröder numbers are strictly positive. -/
+theorem largeSchroder_pos : ∀ n, 0 < largeSchroder n
+  | 0 => by simp
+  | n + 1 => by
+      rw [Nat.largeSchroder_succ]
+      exact lt_of_lt_of_le (largeSchroder_pos n) (Nat.le_add_right _ _)
+
+/-- The single `i = 0` term of the convolution sum equals `L n`, so the whole sum
+is at least `L n`. -/
+theorem largeSchroder_le_sum (n : ℕ) :
+    largeSchroder n ≤ ∑ i ≤ n, largeSchroder i * largeSchroder (n - i) := by
+  have h0 : largeSchroder n
+      = largeSchroder 0 * largeSchroder (n - 0) := by simp
+  rw [h0]
+  exact Finset.single_le_sum
+    (f := fun i => largeSchroder i * largeSchroder (n - i))
+    (fun i _ => Nat.zero_le _) (Finset.mem_Iic.mpr (Nat.zero_le n))
+
+/-- The **doubling step**: each large Schröder number is at least twice its
+predecessor. This is the engine behind both monotonicity and exponential growth. -/
+theorem two_mul_largeSchroder_le_succ (n : ℕ) :
+    2 * largeSchroder n ≤ largeSchroder (n + 1) := by
+  rw [Nat.largeSchroder_succ, two_mul]
+  gcongr
+  exact largeSchroder_le_sum n
+
+/-- The large Schröder numbers are strictly increasing along the recurrence. -/
+theorem largeSchroder_lt_succ (n : ℕ) :
+    largeSchroder n < largeSchroder (n + 1) := by
+  have hpos := largeSchroder_pos n
+  have hdbl := two_mul_largeSchroder_le_succ n
+  omega
+
+/-- The large Schröder sequence is strictly monotone. -/
+theorem strictMono_largeSchroder : StrictMono largeSchroder :=
+  strictMono_nat_of_lt_succ largeSchroder_lt_succ
+
+/-- **Exponential lower bound**: `2 ^ n ≤ L n`. In particular the large Schröder
+numbers grow at least geometrically. -/
+theorem two_pow_le_largeSchroder (n : ℕ) : 2 ^ n ≤ largeSchroder n := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      calc 2 ^ (n + 1) = 2 * 2 ^ n := by ring
+        _ ≤ 2 * largeSchroder n := by gcongr
+        _ ≤ largeSchroder (n + 1) := two_mul_largeSchroder_le_succ n
+
+/-- The large Schröder numbers tend to infinity. -/
+theorem largeSchroder_atTop : Filter.Tendsto largeSchroder Filter.atTop Filter.atTop :=
+  strictMono_largeSchroder.tendsto_atTop
+
+/-- Companion: the small Schröder numbers are also strictly positive. For `n ≥ 1`,
+`S (n+1) = L n / 2` with `L n` positive and even, so the quotient is `≥ 1`. -/
+theorem smallSchroder_pos : ∀ n, 0 < smallSchroder n
+  | 0 => by simp
+  | 1 => by simp
+  | n + 2 => by
+      have h2 : 2 * smallSchroder (n + 2) = largeSchroder (n + 1) :=
+        Nat.two_mul_smallSchroder_succ (Nat.succ_ne_zero n)
+      have hpos := largeSchroder_pos (n + 1)
+      omega
+
+/-! ### Concrete values
+
+The first few large Schröder numbers are `1, 2, 6, 22, 90` and the small ones are
+`1, 1, 3, 11, 45`. -/
+
+theorem largeSchroder_three : largeSchroder 3 = 22 := by
+  have hset : Finset.Iic 2 = {0, 1, 2} := by decide
+  rw [Nat.largeSchroder_succ 2, hset,
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_singleton]
+  norm_num [Nat.largeSchroder_zero, Nat.largeSchroder_one, Nat.largeSchroder_two]
+
+theorem largeSchroder_four : largeSchroder 4 = 90 := by
+  have hset : Finset.Iic 3 = {0, 1, 2, 3} := by decide
+  rw [Nat.largeSchroder_succ 3, hset, Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_singleton]
+  norm_num [largeSchroder_three, Nat.largeSchroder_zero, Nat.largeSchroder_one,
+    Nat.largeSchroder_two]
+
+/-- Sanity check against the doubling bound at a concrete value: `2 * L 3 = 44 ≤ 90 = L 4`. -/
+example : 2 * largeSchroder 3 ≤ largeSchroder 4 := two_mul_largeSchroder_le_succ 3
+
+end SchroderNumbersOQ01

--- a/src/data/proofs/schroder-numbers-oq-01/meta.json
+++ b/src/data/proofs/schroder-numbers-oq-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "schroder-numbers-oq-01",
+  "title": "Large Schröder numbers: positivity, strict growth, and an exponential lower bound",
+  "slug": "schroder-numbers-oq-01",
+  "description": "The large Schröder numbers (OEIS A006318: 1, 2, 6, 22, 90, …) are defined in Mathlib by the convolution recurrence L(n+1) = L(n) + ∑_{i≤n} L(i)·L(n−i). Mathlib records the base values, the recurrence, the parity fact, and the small/large bridge, but no order information. This entry supplies the missing growth theory: positivity 0 < L(n), the doubling step 2·L(n) ≤ L(n+1), strict monotonicity, and the exponential lower bound 2^n ≤ L(n).",
+  "meta": {
+    "author": "Ernst Schröder (1870)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SchroderNumbersOQ01.lean",
+    "tags": [
+      "combinatorics",
+      "schroder-numbers",
+      "enumerative",
+      "recurrence",
+      "growth-bound",
+      "monotonicity"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.largeSchroder_succ",
+        "description": "The convolution recurrence L(n+1) = L(n) + ∑_{i≤n} L(i)·L(n−i) for the large Schröder numbers",
+        "module": "Mathlib.Combinatorics.Enumerative.Schroder"
+      },
+      {
+        "theorem": "Nat.even_largeSchroder",
+        "description": "The large Schröder numbers are even for n > 0, used (together with positivity) to deduce positivity of the small Schröder numbers",
+        "module": "Mathlib.Combinatorics.Enumerative.Schroder"
+      },
+      {
+        "theorem": "Nat.two_mul_smallSchroder_succ",
+        "description": "The bridge 2·S(n+1) = L(n) for n ≥ 1, used to transfer positivity from large to small Schröder numbers",
+        "module": "Mathlib.Combinatorics.Enumerative.Schroder"
+      },
+      {
+        "theorem": "Finset.single_le_sum",
+        "description": "A single nonnegative summand lower-bounds a finite sum; used to extract the i=0 term L(0)·L(n)=L(n) from the convolution",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "strictMono_nat_of_lt_succ",
+        "description": "A sequence with a(n) < a(n+1) for all n is strictly monotone",
+        "module": "Mathlib.Order.Monotone.Basic"
+      }
+    ],
+    "originalContributions": [
+      "largeSchroder_pos: 0 < L(n) for all n, by induction on the recurrence",
+      "largeSchroder_le_sum: the convolution sum is at least L(n) (the lone i=0 term L(0)·L(n) already equals L(n))",
+      "two_mul_largeSchroder_le_succ: the doubling step 2·L(n) ≤ L(n+1), the engine of the growth results",
+      "largeSchroder_lt_succ and strictMono_largeSchroder: the large Schröder sequence is strictly increasing",
+      "two_pow_le_largeSchroder: the exponential lower bound 2^n ≤ L(n)",
+      "largeSchroder_atTop: L(n) → ∞",
+      "smallSchroder_pos: the small Schröder numbers are also strictly positive"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound. The concrete values L(3)=22, L(4)=90 are proved from the recurrence via an explicit Iic-sum expansion (kernel `decide` only on the finite-set equality Iic 2 = {0,1,2}); no `native_decide`, so no `Lean.ofReduceBool`.",
+    "lineCount": 123,
+    "theoremCount": 10,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The large Schröder numbers L(n) = 1, 2, 6, 22, 90, 394, … (OEIS A006318) count, among many things, the lattice paths from (0,0) to (n,n) using steps (1,0), (0,1), (1,1) that never rise above the diagonal — Schröder paths. They were studied by Ernst Schröder in 1870 in connection with the bracketing problem of Hipparchus, and are twice the small Schröder numbers S(n) = 1, 1, 3, 11, 45, … for n ≥ 1. Mathlib's Combinatorics.Enumerative.Schroder file defines both sequences by the convolution recurrence and proves the parity fact and the small/large bridge, but it records nothing about how fast the sequence grows.",
+    "problemStatement": "Establish the basic order-theoretic behaviour of the large Schröder numbers directly from their convolution recurrence: that they are positive, strictly increasing, and grow at least geometrically.",
+    "text": "From the convolution recurrence L(n+1) = L(n) + ∑_{i≤n} L(i)·L(n−i), the lone i=0 term equals L(n), forcing L(n+1) ≥ 2·L(n); positivity, strict monotonicity, and the bound 2^n ≤ L(n) follow.",
+    "proofStrategy": "1. largeSchroder_pos: induction. L(0)=1>0; and L(n+1) = L(n) + (nonnegative sum) ≥ L(n) > 0.\n2. largeSchroder_le_sum: the i=0 summand of ∑_{i≤n} L(i)·L(n−i) is L(0)·L(n) = L(n), so Finset.single_le_sum gives L(n) ≤ ∑.\n3. two_mul_largeSchroder_le_succ: rewrite by the recurrence and 2·L(n) = L(n)+L(n); gcongr reduces to L(n) ≤ ∑, discharged by step 2.\n4. largeSchroder_lt_succ / strictMono_largeSchroder: from 2·L(n) ≤ L(n+1) and L(n) > 0, omega gives L(n) < L(n+1); strictMono_nat_of_lt_succ packages it.\n5. two_pow_le_largeSchroder: induction; 2^(n+1) = 2·2^n ≤ 2·L(n) ≤ L(n+1).\n6. smallSchroder_pos: from 2·S(n+1) = L(n) > 0 (the Mathlib bridge), omega gives S(n+1) > 0; the small cases S(0)=S(1)=1 are immediate.",
+    "keyInsights": [
+      "**One term carries the bound**: in the full convolution ∑_{i≤n} L(i)·L(n−i) only the i=0 term L(0)·L(n) is needed for monotonicity — it already equals L(n), so the sequence at least doubles each step without any finer analysis of the remaining summands.",
+      "**Doubling is the engine**: every growth statement here (strict monotonicity, the 2^n lower bound, divergence to infinity) is a corollary of the single inequality 2·L(n) ≤ L(n+1).",
+      "**Filling a real Mathlib gap**: Mathlib proves the recurrence and parity for Schröder numbers but no positivity, monotonicity, or growth — this is the founding order-theoretic entry for the sequence.",
+      "**Positivity for free downstream**: combining 0 < L(n) with Mathlib's parity (L(n) even) and bridge (2·S(n+1) = L(n)) immediately yields positivity of the small Schröder numbers, with no separate recurrence analysis."
+    ],
+    "prerequisites": [
+      "The large and small Schröder numbers and their convolution recurrence",
+      "Induction on the natural numbers",
+      "Lower-bounding a finite sum by a single summand (Finset.single_le_sum)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "File-level docstring stating the convolution recurrence, what Mathlib already provides, and the five growth lemmas this entry adds. Imports Mathlib and brings Nat.largeSchroder / Nat.smallSchroder into scope.",
+      "mathContext": "L(n) is the nth large Schröder number; Mathlib supplies the recurrence largeSchroder_succ, parity even_largeSchroder, and the bridge two_mul_smallSchroder_succ."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity of the Large Schröder Numbers",
+      "startLine": 40,
+      "endLine": 47,
+      "summary": "largeSchroder_pos: induction on n. Base L(0)=1>0; step uses the recurrence and L(n) ≤ L(n)+sum to keep positivity.",
+      "mathContext": "0 < L(n): needed to turn the doubling bound into a strict inequality."
+    },
+    {
+      "id": "doubling-step",
+      "title": "The Doubling Step",
+      "startLine": 48,
+      "endLine": 65,
+      "summary": "largeSchroder_le_sum extracts the i=0 term L(0)·L(n)=L(n) from the convolution via Finset.single_le_sum; two_mul_largeSchroder_le_succ rewrites the recurrence as L(n)+L(n) ≤ L(n)+sum and reduces by gcongr to that bound.",
+      "mathContext": "2·L(n) ≤ L(n+1): the lone i=0 summand already doubles the sequence."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Strict Monotonicity",
+      "startLine": 66,
+      "endLine": 77,
+      "summary": "largeSchroder_lt_succ derives L(n) < L(n+1) from the doubling bound and positivity (omega); strictMono_largeSchroder packages it via strictMono_nat_of_lt_succ.",
+      "mathContext": "L(n) < L(n+1) for all n; the sequence is strictly increasing."
+    },
+    {
+      "id": "growth",
+      "title": "Exponential Lower Bound and Divergence",
+      "startLine": 78,
+      "endLine": 90,
+      "summary": "two_pow_le_largeSchroder: induction, 2^(n+1) = 2·2^n ≤ 2·L(n) ≤ L(n+1). largeSchroder_atTop concludes L(n) → ∞ from strict monotonicity.",
+      "mathContext": "2^n ≤ L(n), so the large Schröder numbers grow at least geometrically and tend to infinity."
+    },
+    {
+      "id": "small-schroder",
+      "title": "Positivity of the Small Schröder Numbers",
+      "startLine": 91,
+      "endLine": 105,
+      "summary": "smallSchroder_pos: cases S(0)=S(1)=1; for n+2, the Mathlib bridge 2·S(n+2) = L(n+1) > 0 forces S(n+2) > 0 by omega.",
+      "mathContext": "0 < S(n) for the small Schröder numbers, transferred from large-Schröder positivity through the doubling bridge."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Concrete Values",
+      "startLine": 106,
+      "endLine": 123,
+      "summary": "largeSchroder_three (=22) and largeSchroder_four (=90), proved from the recurrence by expanding the Iic sum explicitly, plus a sanity check that 2·L(3)=44 ≤ 90=L(4).",
+      "mathContext": "The first interesting values of A006318, verified from the recurrence rather than by reflection."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Schröder, Ernst",
+      "title": "Vier combinatorische Probleme",
+      "year": "1870",
+      "note": "Origin of the Schröder numbers, in connection with bracketings and lattice paths"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 2",
+      "year": "1999",
+      "note": "Develops the Schröder numbers, their lattice-path interpretation, and the large/small relationship"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "catalan-numbers-oq-01",
+      "relationship": "related",
+      "description": "Catalan and Schröder numbers are neighbouring enumerative families counting lattice paths with restricted steps; the large Schröder numbers dominate the Catalan numbers"
+    }
+  ],
+  "conclusion": {
+    "summary": "Directly from the convolution recurrence, the large Schröder numbers are positive (largeSchroder_pos), satisfy the doubling bound 2·L(n) ≤ L(n+1) (two_mul_largeSchroder_le_succ), are strictly increasing (strictMono_largeSchroder), and satisfy the exponential lower bound 2^n ≤ L(n) (two_pow_le_largeSchroder), hence diverge to infinity. Positivity transfers to the small Schröder numbers through Mathlib's bridge. All ten theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies the first order-theoretic facts about the Schröder sequence to complement Mathlib's recurrence and parity results, giving directly citable positivity, monotonicity, and growth bounds.",
+    "openQuestions": [
+      "Can the sharper step 3·L(n) ≤ L(n+1) for n ≥ 1 (using both the i=0 and i=n terms of the convolution) be formalized, yielding the lower bound L(n) ≥ 2·3^(n-1)?",
+      "Can the dominance L(n) ≥ catalan(n) over the Catalan numbers be proved by comparing their recurrences, formalizing the lattice-path inclusion of Dyck paths into Schröder paths?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "SchroderNumbersOQ01",
+    "lineCount": 123,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/SchroderNumbersOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Founding **order-theoretic** entry for the large Schröder numbers (OEIS A006318: 1, 2, 6, 22, 90, …). Mathlib's `Combinatorics.Enumerative.Schroder` defines the sequence by the convolution recurrence

    L(n+1) = L(n) + ∑_{i≤n} L(i)·L(n−i)

and proves the base values, the recurrence (`largeSchroder_succ`), parity (`even_largeSchroder`), and the small/large bridge (`two_mul_smallSchroder_succ`) — but **no order information at all**: no positivity, monotonicity, or growth. This PR fills that gap.

## Theorems (all 0-axiom, 0-sorry)

| Theorem | Statement |
|---|---|
| `largeSchroder_pos` | `0 < L(n)` |
| `largeSchroder_le_sum` | `L(n) ≤ ∑_{i≤n} L(i)·L(n−i)` (the lone `i=0` term) |
| `two_mul_largeSchroder_le_succ` | `2·L(n) ≤ L(n+1)` — the doubling step |
| `largeSchroder_lt_succ` / `strictMono_largeSchroder` | strict monotonicity |
| `two_pow_le_largeSchroder` | `2^n ≤ L(n)` — exponential lower bound |
| `largeSchroder_atTop` | `L(n) → ∞` |
| `smallSchroder_pos` | `0 < S(n)` for small Schröder numbers |
| `largeSchroder_three` / `largeSchroder_four` | `L(3)=22`, `L(4)=90` from the recurrence |

## Key idea

In the full convolution only the **`i=0` summand** `L(0)·L(n) = L(n)` is needed: it already forces `L(n+1) ≥ 2·L(n)`. Every growth statement (strict monotonicity, the `2^n` bound, divergence) is a corollary of that single doubling inequality. Positivity of the small Schröder numbers then falls out of Mathlib's parity + bridge with no extra recurrence analysis.

## Verification

- `LAKE_UNSAFE=1 lake env lean Proofs/SchroderNumbersOQ01.lean` — compiles clean, no warnings.
- `#print axioms` on every result: only `propext`, `Classical.choice`, `Quot.sound`. No `native_decide`, hence no `Lean.ofReduceBool`. **0 axioms.**
- Concrete values proved from the recurrence via explicit `Iic`-sum expansion (kernel `decide` only on the finite-set equality `Iic 2 = {0,1,2}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)