### PR TITLE
research(hilbert-10-oq-01-oq-02): affine-pullback closure for all four Σ/Π classes + affine invariance of the open question (verified)

### DIFF
--- a/proofs/Proofs/Hilbert10OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert10OQ01OQ02.lean
@@ -90,6 +90,11 @@ import Mathlib.Tactic.Ring
 -- Iter 17 (Path B): `Finset.toList` and `Finset.mem_toList` for Finset
 -- transports of the iter 10 / iter 14 / iter 15 list closures.
 import Mathlib.Data.Finset.Basic
+-- Iter 29 (Path B): `linear_combination` to discharge the affine-inverse
+-- identity `a·(a⁻¹·q − a⁻¹·b) + b = q` (needs `a ≠ 0`) in the affine-pullback
+-- invariance of the OPEN Σ₁ question. `mul_inv_cancel₀` comes transitively via
+-- `Mathlib.Algebra.GroupWithZero.Basic` (already imported above).
+import Mathlib.Tactic.LinearCombination
 
 namespace Hilbert10Rationals
 
@@ -2999,6 +3004,125 @@ theorem sdiff_pi2_sigma2_isUniversalExistentialDefinition
     IsUniversalExistentialDefinition (fun q => S q ∧ ¬ T q) :=
   pi2_intersection_isUniversalExistentialDefinition hS
     ((existentialUniversal_iff_universalExistential_complement T).mp hT)
+
+-- ============================================================
+-- Part VIII.33 (iter 29, Path B): closure of all four classes
+--   under affine pullback  q ↦ a·q + b
+-- ============================================================
+
+/-- The **affine pullback** of a subset `S ⊆ ℚ` along the map `q ↦ a·q + b`
+    (for fixed rationals `a b`):
+
+        `affinePullback a b S = { q : ℚ  |  a·q + b ∈ S }`.
+
+    This is the rational analogue of pulling a Diophantine set back along a
+    polynomial change of variables. The special cases are translation
+    (`a = 1`, `affinePullback 1 b S = { q | q + b ∈ S }`) and dilation
+    (`b = 0`, `affinePullback a 0 S = { q | a·q ∈ S }`). For `a ≠ 0` the map
+    `q ↦ a·q + b` is a bijection of `ℚ`, so the pullback is a genuine
+    affine reparametrization; for `a = 0` it is the constant predicate
+    `fun _ => S b`. -/
+def affinePullback (a b : Rat) (S : RatSubset) : RatSubset :=
+  fun q => S (a * q + b)
+
+/-- Iter 29, Path B: **Σ₁ (Diophantine) is closed under affine pullback**.
+
+    If `S` is Diophantine with parametric witness `P`, then
+    `affinePullback a b S` is Diophantine with witness
+    `Q q = P (a·q + b)`: substituting the parameter `q ↦ a·q + b` into a
+    polynomial leaves it polynomial, and
+        `q ∈ affinePullback a b S ⟺ a·q+b ∈ S ⟺ ∃ x, P (a·q+b) x = 0`.
+
+    Path A (zero new Mathlib): the witness is a pure substitution; no lemma
+    beyond the existing field structure of `ℚ` is needed. -/
+theorem affinePullback_isDiophantineDefinition (a b : Rat) {S : RatSubset}
+    (h : IsDiophantineDefinition S) :
+    IsDiophantineDefinition (affinePullback a b S) := by
+  obtain ⟨P, hP⟩ := h
+  refine ⟨fun q => P (a * q + b), fun q => ?_⟩
+  simpa only [affinePullback] using hP (a * q + b)
+
+/-- Iter 29, Path B: **Π₁ (co-Diophantine) is closed under affine pullback**.
+
+    Same substitution witness `Q q = P (a·q + b)` as the Σ₁ case; the
+    universal "no rational solution" reading is preserved pointwise. -/
+theorem affinePullback_isCoDiophantineDefinition (a b : Rat) {S : RatSubset}
+    (h : IsCoDiophantineDefinition S) :
+    IsCoDiophantineDefinition (affinePullback a b S) := by
+  obtain ⟨P, hP⟩ := h
+  refine ⟨fun q => P (a * q + b), fun q => ?_⟩
+  simpa only [affinePullback] using hP (a * q + b)
+
+/-- Iter 29, Path B: **Σ₂ (existential-universal) is closed under affine
+    pullback**.
+
+    Witness `Q q y = P (a·q + b) y`: the substitution acts only on the
+    parameter slot and commutes with the `∃ y, ¬ hasRationalSolution`
+    quantifier block. -/
+theorem affinePullback_isExistentialUniversalDefinition (a b : Rat)
+    {S : RatSubset} (h : IsExistentialUniversalDefinition S) :
+    IsExistentialUniversalDefinition (affinePullback a b S) := by
+  obtain ⟨P, hP⟩ := h
+  refine ⟨fun q y => P (a * q + b) y, fun q => ?_⟩
+  simpa only [affinePullback] using hP (a * q + b)
+
+/-- Iter 29, Path B: **Π₂ (universal-existential) is closed under affine
+    pullback**.
+
+    Witness `Q q y = P (a·q + b) y`, dual to the Σ₂ case; the substitution
+    commutes with the `∀ y, hasRationalSolution` block. -/
+theorem affinePullback_isUniversalExistentialDefinition (a b : Rat)
+    {S : RatSubset} (h : IsUniversalExistentialDefinition S) :
+    IsUniversalExistentialDefinition (affinePullback a b S) := by
+  obtain ⟨P, hP⟩ := h
+  refine ⟨fun q y => P (a * q + b) y, fun q => ?_⟩
+  simpa only [affinePullback] using hP (a * q + b)
+
+/-- **Affine pullback of ℤ is Π₂-definable** (corollary of Koenigsmann).
+
+    For any fixed `a b : ℚ`, the set `{ q : ℚ | a·q + b ∈ ℤ }` is
+    Π₂-definable in ℚ. Specializing: `{ q | a·q ∈ ℤ }` (a scaled copy of the
+    integer lattice, `b = 0`) and `{ q | q + b ∈ ℤ }` (a translate of ℤ,
+    `a = 1`) are both Π₂-definable. This is the affine-invariance of the
+    settled (Π₂) level of the ℤ ⊂ ℚ definability question. -/
+theorem affinePullback_int_isUniversalExistentialDefinition (a b : Rat) :
+    IsUniversalExistentialDefinition (affinePullback a b IntSubset) :=
+  affinePullback_isUniversalExistentialDefinition a b koenigsmann_2016_universal
+
+/-- **Affine pullback of ℚ \ ℤ is Σ₂-definable** (corollary of Koenigsmann
+    via the Σ₂/Π₂ duality).
+
+    Dual to `affinePullback_int_isUniversalExistentialDefinition`: for any
+    `a b : ℚ`, `{ q : ℚ | a·q + b ∉ ℤ }` is Σ₂-definable in ℚ. -/
+theorem affinePullback_notInt_isExistentialUniversalDefinition (a b : Rat) :
+    IsExistentialUniversalDefinition (affinePullback a b NotIntSubset) :=
+  affinePullback_isExistentialUniversalDefinition a b
+    koenigsmann_implies_complement_existentialUniversal
+
+/-- **Affine invariance of the OPEN question.** For `a ≠ 0`, the map
+    `q ↦ a·q + b` is a bijection of `ℚ`, so ℤ is Σ₁-definable over ℚ iff its
+    affine pullback `{ q | a·q + b ∈ ℤ }` is. (The forward direction is the
+    closure theorem `affinePullback_isDiophantineDefinition`; the converse
+    pulls back along the inverse map `q ↦ a⁻¹·q − a⁻¹·b`.) This records that
+    the Σ₁-definability question for ℤ ⊂ ℚ is invariant under affine
+    reparametrization — a structural sanity check on the open problem. -/
+theorem int_diophantine_iff_affinePullback_diophantine
+    (a b : Rat) (ha : a ≠ 0) :
+    IsDiophantineDefinition IntSubset ↔
+      IsDiophantineDefinition (affinePullback a b IntSubset) := by
+  constructor
+  · intro h
+    exact affinePullback_isDiophantineDefinition a b h
+  · intro h
+    -- pull the pullback back along the inverse map `q ↦ a⁻¹·q − a⁻¹·b`
+    have hback := affinePullback_isDiophantineDefinition a⁻¹ (-(a⁻¹ * b)) h
+    obtain ⟨P, hP⟩ := hback
+    refine ⟨P, fun q => ?_⟩
+    have hinv : a * a⁻¹ = 1 := mul_inv_cancel₀ ha
+    have hq : a * (a⁻¹ * q + -(a⁻¹ * b)) + b = q := by
+      linear_combination (q - b) * hinv
+    have hpq := hP q
+    simpa only [affinePullback, hq] using hpq
 
 -- ============================================================
 -- Part IX: The landscape, sharpened

--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -56,6 +56,11 @@
         "theorem": "Finset.mem_toList",
         "description": "a ∈ s.toList ↔ a ∈ s for s : Finset α; used in iter 17 (Path B) to transport iter 10's list-indexed singletons closure and iter 14/15's list-indexed arbitrary-subset closures to the Finset-indexed analogs via the iter 4 class congruence helpers (Σ₁/Π₁/Π₂/Σ₂). No new polynomial witnesses; the underlying construction is unchanged from the List versions.",
         "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "mul_inv_cancel₀",
+        "description": "a ≠ 0 → a * a⁻¹ = 1 in a GroupWithZero; ℚ is a field. Used (with the `linear_combination` tactic from Mathlib.Tactic.LinearCombination) in iter 29 to discharge the affine-inverse identity a·(a⁻¹·q − a⁻¹·b) + b = q, proving the affine invariance of the OPEN Σ₁ question (int_diophantine_iff_affinePullback_diophantine).",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
       }
     ],
     "originalContributions": [
@@ -129,11 +134,19 @@
       "sdiff_diophantine_codiophantine_isDiophantineDefinition: Σ₁ \\ Π₁ ⊆ Σ₁. The third Boolean operation (relative complement / set difference) joins the union and intersection closures of iters 9–25. Since S \\ T = S ∩ Tᶜ and the subtracted T is Π₁, its complement ¬T is Σ₁ via `codiophantine_iff_diophantine_complement`; `intersection_isDiophantineDefinition` then lands S \\ T back in Σ₁. No new axioms (iter 28 Part VIII.29)",
       "sdiff_codiophantine_diophantine_isCoDiophantineDefinition: Π₁ \\ Σ₁ ⊆ Π₁. Level-1 dual of the Σ₁ case: subtracting a Σ₁ set T from a Π₁ set S, the complement ¬T is Π₁ via `diophantine_iff_codiophantine_complement` and `intersection_isCoDiophantineDefinition` gives Π₁. No new axioms (iter 28 Part VIII.29)",
       "sdiff_sigma2_pi2_isExistentialUniversalDefinition: Σ₂ \\ Π₂ ⊆ Σ₂. Level-2 analog: subtracting a Π₂ set from a Σ₂ set, the complement is Σ₂ via `universalExistential_iff_existentialUniversal_complement` and `sigma2_intersection_isExistentialUniversalDefinition` closes it. No new axioms (iter 28 Part VIII.29)",
-      "sdiff_pi2_sigma2_isUniversalExistentialDefinition: Π₂ \\ Σ₂ ⊆ Π₂. Level-2 dual, completing the Boolean algebra (∪, ∩, \\) of all four definability levels. The complement of the subtracted Σ₂ set is Π₂ via `existentialUniversal_iff_universalExistential_complement` and `pi2_intersection_isUniversalExistentialDefinition` finishes. No new axioms (iter 28 Part VIII.29)"
+      "sdiff_pi2_sigma2_isUniversalExistentialDefinition: Π₂ \\ Σ₂ ⊆ Π₂. Level-2 dual, completing the Boolean algebra (∪, ∩, \\) of all four definability levels. The complement of the subtracted Σ₂ set is Π₂ via `existentialUniversal_iff_universalExistential_complement` and `pi2_intersection_isUniversalExistentialDefinition` finishes. No new axioms (iter 28 Part VIII.29)",
+      "affinePullback (def): the affine pullback {q : ℚ | a·q + b ∈ S} of a subset S along the map q ↦ a·q + b, for fixed rationals a, b. Specializes to translation (a=1) and dilation (b=0).",
+      "affinePullback_isDiophantineDefinition: Σ₁ (Diophantine) is closed under affine pullback. Witness Q q = P (a·q + b) — a pure polynomial substitution in the parameter slot.",
+      "affinePullback_isCoDiophantineDefinition: Π₁ (co-Diophantine) is closed under affine pullback, same substitution witness, dual reading.",
+      "affinePullback_isExistentialUniversalDefinition: Σ₂ (∃∀) is closed under affine pullback; the substitution commutes with the ∃y, ¬hasRationalSolution block.",
+      "affinePullback_isUniversalExistentialDefinition: Π₂ (∀∃) is closed under affine pullback; dual of the Σ₂ case.",
+      "affinePullback_int_isUniversalExistentialDefinition: for any a, b : ℚ the set {q | a·q + b ∈ ℤ} is Π₂-definable — affine invariance of the SETTLED (Koenigsmann) level. Specializes to scaled lattices {q | a·q ∈ ℤ} and translates {q | q + b ∈ ℤ}.",
+      "affinePullback_notInt_isExistentialUniversalDefinition: dual corollary — {q | a·q + b ∉ ℤ} is Σ₂-definable for any a, b : ℚ.",
+      "int_diophantine_iff_affinePullback_diophantine: for a ≠ 0, ℤ is Σ₁-definable over ℚ iff its affine pullback {q | a·q + b ∈ ℤ} is — the OPEN question is invariant under affine reparametrization (converse pulls back along the inverse map q ↦ a⁻¹·q − a⁻¹·b)."
     ],
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 3316,
+    "lineCount": 3445,
     "prerequisites": [
       "Hilbert's 10th problem over ℚ (companion file Hilbert10OQ01.lean)",
       "Arithmetic hierarchy (Σ_n / Π_n) at the level of polynomial formulas",
@@ -141,8 +154,8 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 100,
-    "definitionCount": 16
+    "theoremCount": 107,
+    "definitionCount": 17
   },
   "overview": {
     "historicalContext": "After MRDP (1970) settled H10/$\\mathbb{Z}$ negatively, attention turned to H10/$\\mathbb{Q}$ — open since at least Robinson 1949. The companion file `hilbert-10-oq-01` surveys the broad landscape; this file (OQ-01-OQ-02) zooms in on the precise model-theoretic content separating the OPEN question from Koenigsmann's celebrated 2016 Annals theorem.\n\nThe distinction is between two layers of the arithmetic hierarchy over $\\mathbb{Q}$:\n\n- **$\\Sigma_1$ (Diophantine, purely existential):** $\\mathbb{Z}$ is the projection of a rational-solution set of one polynomial equation. Equivalently, there exists $P \\in \\mathbb{Q}[t, x_1, \\ldots, x_k]$ with $t \\in \\mathbb{Z} \\iff \\exists x \\in \\mathbb{Q}^k, P(t,x) = 0$. **OPEN.**\n- **$\\Pi_2$ (universal-existential, $\\forall\\exists$):** there exists $P$ with $t \\in \\mathbb{Z} \\iff \\forall y \\in \\mathbb{Q}^n, \\exists z \\in \\mathbb{Q}^m, P(t,y,z) = 0$. **PROVED by Koenigsmann (2016).**\n\nThe Σ₁ direction is the substantive open question because it is precisely Σ₁ definability that yields the implication 'ℤ Diophantine over ℚ ⟹ H10/ℚ undecidable' (via MRDP). Π₂ definability does not carry this implication, so Koenigsmann's theorem leaves H10/ℚ untouched.\n\nMazur's conjecture (1992), a topological constraint on rational-point sets, would refute the $\\Sigma_1$ definition of $\\mathbb{Z}$ in $\\mathbb{Q}$ but is consistent with $\\Pi_2$.",
@@ -289,10 +302,10 @@
     ],
     "opens": [],
     "namespace": "Hilbert10Rationals",
-    "lineCount": 3321,
+    "lineCount": 3445,
     "axiomCount": 1,
-    "theoremCount": 100,
-    "definitionCount": 16,
+    "theoremCount": 107,
+    "definitionCount": 17,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Extends the Σ₁/Π₁/Σ₂/Π₂ definability calculus over ℚ (the sharpened Hilbert-10/ℚ definability question) with the **affine-pullback** closure suite — the missing "change of variables" closure complementing the existing Boolean grid (∪, ∩, \, top/bottom).

For fixed `a b : ℚ`, the affine pullback of `S ⊆ ℚ` along `q ↦ a·q + b` is
```
affinePullback a b S = { q : ℚ | a·q + b ∈ S }
```
(translation when `a = 1`, dilation when `b = 0`). Substituting `q ↦ a·q + b` into a parametric polynomial witness leaves it polynomial, so every definability class is closed under it.

## New results

**Closure (axiom-free, pure logic + substitution):**
- `affinePullback` (def)
- `affinePullback_isDiophantineDefinition` — Σ₁ closed under affine pullback
- `affinePullback_isCoDiophantineDefinition` — Π₁ closed
- `affinePullback_isExistentialUniversalDefinition` — Σ₂ closed
- `affinePullback_isUniversalExistentialDefinition` — Π₂ closed

**Corollaries of Koenigsmann (use the file's single axiom):**
- `affinePullback_int_isUniversalExistentialDefinition` — `{q | a·q + b ∈ ℤ}` is Π₂-definable; scaled lattices `{q | a·q ∈ ℤ}` and translates `{q | q + b ∈ ℤ}` are all Π₂.
- `affinePullback_notInt_isExistentialUniversalDefinition` — dual Σ₂ corollary for ℚ\ℤ.

**Affine invariance of the OPEN question:**
- `int_diophantine_iff_affinePullback_diophantine` — for `a ≠ 0`, ℤ is Σ₁-definable over ℚ **iff** its affine pullback `{q | a·q + b ∈ ℤ}` is. The converse pulls back along the inverse map `q ↦ a⁻¹·q − a⁻¹·b`, with the identity `a·(a⁻¹·q − a⁻¹·b) + b = q` discharged by `linear_combination`. A structural sanity check: the open Σ₁ question is invariant under affine reparametrization.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Hilbert10OQ01OQ02` → **859 jobs, success**.
- Diff is purely additive (no lines removed from the Lean file).
- Axiom budget **unchanged**: 1 (`koenigsmann_2016_universal`). The four closure theorems and the iff are axiom-free; the ℤ/ℚ\ℤ corollaries are pure logical consequences of the existing Koenigsmann axiom.
- `meta.json` counts synced (theoremCount +7, definitionCount +1, lineCount 3445; new `mul_inv_cancel₀` dependency disclosed; 8 originalContributions added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)