### PR TITLE
research(ptolemys-theorem-oq-04): Power of a Point — coordinate-free chords, secants, power invariant & equal tangents (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2908,6 +2908,7 @@ import Proofs.PtolemysTheoremOQ01
 import Proofs.PtolemysTheoremOQ01Incomplete01
 import Proofs.PtolemysTheoremOQ01OQ01
 import Proofs.PtolemysTheoremOQ01OQ02
+import Proofs.PtolemysTheoremOQ04
 import Proofs.PuiseuxTheorem
 import Proofs.PuiseuxTheoremOQ02
 import Proofs.PvsNP

--- a/proofs/Proofs/PtolemysTheoremOQ04.lean
+++ b/proofs/Proofs/PtolemysTheoremOQ04.lean
@@ -1,0 +1,165 @@
+import Mathlib.Geometry.Euclidean.Sphere.Power
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Tactic
+
+/-!
+# Power of a Point: Intersecting Chords, Secants, and the Power Invariant
+
+This file assembles a coordinate-free **Power of a Point** package, working in an
+arbitrary real inner-product space (any dimension, via `NormedAddTorsor`), and built
+on Mathlib's `EuclideanGeometry.Sphere.power` API.
+
+For a point `P` and a sphere, the *power* of `P` is `dist P center ^ 2 - radius ^ 2`.
+The central fact is that for **any** line through `P` meeting the sphere at two points
+`A, B`, the product `PA · PB` equals `|power|` — in particular it is independent of the
+chosen line.  This single invariant unifies several classical theorems:
+
+* **Intersecting Chords** (Wiedijk / Freek No. 55): two chords of a circle crossing at an
+  interior point `P` satisfy `PA · PB = PC · PD`.
+* **Intersecting Secants**: two secants from an exterior point `P` satisfy the same.
+* **Tangent–Secant**: the squared tangent length equals the secant product.
+* **Equal Tangents**: the two tangent segments from an exterior point have equal length.
+
+## Relation to the existing gallery
+
+The gallery already contains Ptolemy's theorem (the *additive* relation
+`AC·BD = AB·CD + AD·BC`, via `mul_dist_add_mul_dist_eq_mul_dist_of_cospherical`) and a
+2-dimensional coordinate (`Vec2`) proof of the chord product in
+`ProductOfSegmentsOfChords`.  This file is distinct on both counts: it uses the
+*product / power* family of Mathlib lemmas (`mul_dist_eq_mul_dist_of_cospherical_*`,
+`Sphere.mul_dist_eq_abs_power`, `Sphere.IsTangentAt.power_eq_dist_sq`), all of which were
+previously **unused** anywhere in the gallery, and it works coordinate-free in any
+dimension.
+
+## Main results
+
+* `intersecting_chords`, `intersecting_secants` — the two classical product theorems.
+* `mul_dist_eq_abs_power` — the unifying invariant `PA · PB = |power P|`.
+* `mul_dist_eq_mul_dist_of_mem_sphere` — line-independence of the product (derived).
+* `mul_dist_eq_power_outside`, `mul_dist_eq_neg_power_inside` — signed forms.
+* `tangent_sq_eq_secant_product` — the tangent–secant relation.
+* `dist_tangent_eq_of_tangent` — the equal-tangents theorem (derived).
+* `concrete_intersecting_chords` — a worked instance: two perpendicular diameters of the
+  unit circle in `ℂ` crossing at the centre.
+
+All results are fully verified with no axioms and no `sorry`.
+-/
+
+open scoped EuclideanGeometry RealInnerProductSpace Real
+open EuclideanGeometry
+
+namespace PowerOfPointOQ04
+
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+variable {P : Type*} [MetricSpace P] [NormedAddTorsor V P]
+
+/-! ## The classical product theorems -/
+
+/-- **Intersecting Chords Theorem** (Freek No. 55).  If `A, B, C, D` are cospherical and
+the point `P` lies *between* `A, B` and between `C, D` (both straight angles), then the
+products of the two chord segments agree. -/
+theorem intersecting_chords {a b c d p : P}
+    (h : Cospherical ({a, b, c, d} : Set P))
+    (hapb : ∠ a p b = π) (hcpd : ∠ c p d = π) :
+    dist a p * dist b p = dist c p * dist d p :=
+  mul_dist_eq_mul_dist_of_cospherical_of_angle_eq_pi h hapb hcpd
+
+/-- **Intersecting Secants Theorem**.  If `A, B, C, D` are cospherical and `P` lies on the
+two secant lines on the *same side* (both zero angles), the products agree. -/
+theorem intersecting_secants {a b c d p : P}
+    (h : Cospherical ({a, b, c, d} : Set P)) (hab : a ≠ b) (hcd : c ≠ d)
+    (hapb : ∠ a p b = 0) (hcpd : ∠ c p d = 0) :
+    dist a p * dist b p = dist c p * dist d p :=
+  mul_dist_eq_mul_dist_of_cospherical_of_angle_eq_zero h hab hcd hapb hcpd
+
+/-! ## The power invariant -/
+
+/-- The **power invariant**: for any line through `P` meeting the sphere `s` at `A, B`, the
+product of the segment lengths equals the absolute value of the power of `P`. -/
+theorem mul_dist_eq_abs_power {s : Sphere P} {p a b : P}
+    (hp : p ∈ line[ℝ, a, b]) (ha : a ∈ s) (hb : b ∈ s) :
+    dist p a * dist p b = |s.power p| :=
+  Sphere.mul_dist_eq_abs_power hp ha hb
+
+/-- **Line-independence of the power of a point.**  Any two lines through `P`, each meeting
+the sphere `s` in two points, yield the same product of segment lengths.  This is the
+sphere-based form of the chord/secant product, derived from the power invariant applied
+to each line. -/
+theorem mul_dist_eq_mul_dist_of_mem_sphere {s : Sphere P} {p a b c d : P}
+    (hab : p ∈ line[ℝ, a, b]) (hcd : p ∈ line[ℝ, c, d])
+    (ha : a ∈ s) (hb : b ∈ s) (hc : c ∈ s) (hd : d ∈ s) :
+    dist p a * dist p b = dist p c * dist p d := by
+  rw [Sphere.mul_dist_eq_abs_power hab ha hb, Sphere.mul_dist_eq_abs_power hcd hc hd]
+
+/-- For an exterior (or boundary) point, the secant product equals the (nonnegative) power. -/
+theorem mul_dist_eq_power_outside {s : Sphere P} {p a b : P}
+    (hr : 0 ≤ s.radius) (hp : p ∈ line[ℝ, a, b]) (ha : a ∈ s) (hb : b ∈ s)
+    (hle : s.radius ≤ dist p s.center) :
+    dist p a * dist p b = s.power p :=
+  Sphere.mul_dist_eq_power_of_radius_le_dist_center hr hp ha hb hle
+
+/-- For an interior (or boundary) point, the chord product equals the negative of the
+(nonpositive) power. -/
+theorem mul_dist_eq_neg_power_inside {s : Sphere P} {p a b : P}
+    (hr : 0 ≤ s.radius) (hp : p ∈ line[ℝ, a, b]) (ha : a ∈ s) (hb : b ∈ s)
+    (hle : dist p s.center ≤ s.radius) :
+    dist p a * dist p b = -s.power p :=
+  Sphere.mul_dist_eq_neg_power_of_dist_center_le_radius hr hp ha hb hle
+
+/-! ## Tangents -/
+
+/-- **Tangent–Secant Theorem**.  The squared tangent length from `P` equals the product of
+the two secant segments. -/
+theorem tangent_sq_eq_secant_product {a b t p : P} {s : Sphere P}
+    (ha : a ∈ s) (hb : b ∈ s) (hp : p ∈ line[ℝ, a, b])
+    (h_tangent : s.IsTangentAt t (line[ℝ, p, t])) :
+    dist p t ^ 2 = dist p a * dist p b :=
+  Sphere.dist_sq_eq_mul_dist_of_tangent_and_secant ha hb hp h_tangent
+
+/-- **Equal Tangents Theorem.**  The two tangent segments drawn from a common external
+point `P` to a sphere have equal length.  Both squared lengths equal the power of `P`, and
+distances are nonnegative.  (Derived; this statement is not a single Mathlib lemma.) -/
+theorem dist_tangent_eq_of_tangent {s : Sphere P} {t₁ t₂ p : P}
+    (h₁ : s.IsTangentAt t₁ (line[ℝ, p, t₁]))
+    (h₂ : s.IsTangentAt t₂ (line[ℝ, p, t₂])) :
+    dist p t₁ = dist p t₂ := by
+  have hsq : dist p t₁ ^ 2 = dist p t₂ ^ 2 := by
+    rw [← h₁.power_eq_dist_sq, ← h₂.power_eq_dist_sq]
+  exact (pow_left_inj₀ dist_nonneg dist_nonneg two_ne_zero).mp hsq
+
+/-! ## A concrete witness
+
+The unit circle in the Euclidean plane `ℂ`, with the two perpendicular diameters
+`[1, -1]` and `[I, -I]` crossing at the centre `0`.  Each segment has length `1`, so both
+products equal `1`. -/
+
+/-- The four points `1, -1, I, -I` lie on the unit circle (centre `0`, radius `1`). -/
+theorem cospherical_unit : Cospherical ({1, -1, Complex.I, -Complex.I} : Set ℂ) := by
+  refine ⟨0, 1, ?_⟩
+  intro x hx
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+  rcases hx with h | h | h | h <;> subst h <;> simp
+
+/-- The centre `0` lies on the diameter `[1, -1]`. -/
+theorem center_mem_diam_re : (0 : ℂ) ∈ line[ℝ, (1 : ℂ), -1] := by
+  have h : (0 : ℂ) = AffineMap.lineMap (1 : ℂ) (-1 : ℂ) (1 / 2 : ℝ) := by
+    rw [AffineMap.lineMap_apply, vsub_eq_sub, vadd_eq_add, Complex.real_smul]
+    push_cast; ring
+  rw [h]
+  exact AffineMap.lineMap_mem_affineSpan_pair _ _ _
+
+/-- The centre `0` lies on the diameter `[I, -I]`. -/
+theorem center_mem_diam_im : (0 : ℂ) ∈ line[ℝ, Complex.I, -Complex.I] := by
+  have h : (0 : ℂ) = AffineMap.lineMap Complex.I (-Complex.I) (1 / 2 : ℝ) := by
+    rw [AffineMap.lineMap_apply, vsub_eq_sub, vadd_eq_add, Complex.real_smul]
+    push_cast; ring
+  rw [h]
+  exact AffineMap.lineMap_mem_affineSpan_pair _ _ _
+
+/-- **Concrete intersecting chords**: the two perpendicular diameters of the unit circle in
+`ℂ` give equal products `1 · 1 = 1 · 1`. -/
+theorem concrete_intersecting_chords :
+    dist (1 : ℂ) 0 * dist (-1 : ℂ) 0 = dist Complex.I 0 * dist (-Complex.I) 0 :=
+  mul_dist_eq_mul_dist_of_cospherical cospherical_unit center_mem_diam_re center_mem_diam_im
+
+end PowerOfPointOQ04

--- a/src/data/proofs/ptolemys-theorem-oq-04/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-04/meta.json
@@ -1,0 +1,73 @@
+{
+  "id": "ptolemys-theorem-oq-04",
+  "title": "Power of a Point: Intersecting Chords, Secants, and the Power Invariant",
+  "slug": "ptolemys-theorem-oq-04",
+  "description": "A coordinate-free Power of a Point package over an arbitrary real inner-product space, built on Mathlib's Sphere.power API. For a point P and a sphere, the power of P is dist(P,center)² − radius²; for any line through P meeting the sphere at A, B the product PA·PB equals |power P|, hence is independent of the chosen line. This single invariant unifies the Intersecting Chords Theorem (Freek No. 55), the Intersecting Secants Theorem, the Tangent–Secant relation, and the Equal Tangents Theorem. Distinct from the gallery's additive Ptolemy entry and its 2D-coordinate (Vec2) chord-product proof: it uses the product/power family of Mathlib lemmas (previously unused in the gallery) and works in any dimension. Includes a concrete witness: two perpendicular diameters of the unit circle in ℂ crossing at the centre.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Power_of_a_point",
+    "date": "2026-06-20",
+    "status": "verified",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "power-of-a-point",
+      "intersecting-chords",
+      "intersecting-secants",
+      "cospherical",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/PtolemysTheoremOQ04.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "EuclideanGeometry.mul_dist_eq_mul_dist_of_cospherical_of_angle_eq_pi",
+        "description": "Intersecting Chords Theorem (Freek No. 55): cospherical points with straight angles at P give equal chord products",
+        "module": "Mathlib.Geometry.Euclidean.Sphere.Power"
+      },
+      {
+        "theorem": "EuclideanGeometry.mul_dist_eq_mul_dist_of_cospherical_of_angle_eq_zero",
+        "description": "Intersecting Secants Theorem: cospherical points with zero angles at P give equal secant products",
+        "module": "Mathlib.Geometry.Euclidean.Sphere.Power"
+      },
+      {
+        "theorem": "EuclideanGeometry.Sphere.mul_dist_eq_abs_power",
+        "description": "The product of segment lengths along any line through P equals |power P| — the power invariant",
+        "module": "Mathlib.Geometry.Euclidean.Sphere.Power"
+      },
+      {
+        "theorem": "EuclideanGeometry.Sphere.dist_sq_eq_mul_dist_of_tangent_and_secant",
+        "description": "Tangent–Secant relation: the squared tangent length equals the secant segment product",
+        "module": "Mathlib.Geometry.Euclidean.Sphere.Power"
+      },
+      {
+        "theorem": "EuclideanGeometry.Sphere.IsTangentAt.power_eq_dist_sq",
+        "description": "The power of a point equals the square of its tangent length, used to derive the Equal Tangents Theorem",
+        "module": "Mathlib.Geometry.Euclidean.Sphere.Power"
+      },
+      {
+        "theorem": "AffineMap.lineMap_mem_affineSpan_pair",
+        "description": "lineMap p₁ p₂ r lies on the line through p₁, p₂, used to place the centre on each diameter in the concrete witness",
+        "module": "Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Basic"
+      }
+    ],
+    "originalContributions": [
+      "mul_dist_eq_mul_dist_of_mem_sphere: line-independence of the power of a point — any two lines through P meeting the sphere give equal segment products — derived from the power invariant applied to each line",
+      "dist_tangent_eq_of_tangent: the Equal Tangents Theorem (two tangent segments from an external point are equal length), derived from IsTangentAt.power_eq_dist_sq and nonnegativity of distance; not a single Mathlib lemma",
+      "Unified packaging of Intersecting Chords, Intersecting Secants, Tangent–Secant, and the signed power forms, coordinate-free in any dimension, using the product/power Mathlib family previously unused in the gallery",
+      "concrete_intersecting_chords: a fully verified worked instance over ℂ (unit circle, two perpendicular diameters through the centre), establishing cospherical and on-line membership explicitly"
+    ],
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "lineCount": 165,
+    "assumptions": "None. All results fully verified from Mathlib with 0 sorries and 0 axioms (only the foundational propext / Classical.choice / Quot.sound).",
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Power of a Point, studied systematically by Jakob Steiner in the 19th century, assigns to each point P and circle (or sphere) the scalar dist(P,center)² − radius². Its sign tells whether P is inside, on, or outside the circle, and its magnitude controls the products of distances along secant lines through P. Classical consequences — the Intersecting Chords Theorem (Euclid, Elements III.35; Freek/Wiedijk No. 55), the Intersecting Secants Theorem, and the Tangent–Secant relation — all fall out of the single fact that PA·PB is the same for every line through P.",
+    "problemStatement": "**Open Question (oq-04)**: Beyond Ptolemy's additive relation AC·BD = AB·CD + AD·BC for a cyclic quadrilateral, what is the multiplicative theory of distances from a fixed point to a circle? This entry answers it via the Power of a Point: PA·PB = |power P| for any chord/secant, giving Intersecting Chords, Intersecting Secants, Tangent–Secant, and Equal Tangents as corollaries — coordinate-free and in any dimension.",
+    "text": "Working over an arbitrary real inner-product space, the file proves PA·PB = |power P| for any line through P meeting the sphere at A, B (mul_dist_eq_abs_power), from which line-independence (mul_dist_eq_mul_dist_of_mem_sphere) follows immediately. The Intersecting Chords and Secants theorems are obtained via Mathlib's cospherical-angle lemmas; the signed forms record PA·PB = power for exterior points and = −power for interior points. The Tangent–Secant relation gives tangent² = PA·PB, and the Equal Tangents Theorem — both tangents from an external point have equal length — is derived since each squared tangent length equals the power. A concrete witness in ℂ verifies the chord product for two perpendicular diameters of the unit circle meeting at the centre."
+  }
+}


### PR DESCRIPTION
## Summary

Adds a coordinate-free **Power of a Point** gallery entry (`ptolemys-theorem-oq-04`), working over an arbitrary real inner-product space (any dimension) on Mathlib's `EuclideanGeometry.Sphere.power` API.

For a point P and a sphere, the *power* of P is `dist(P,center)² − radius²`. The central fact is that for **any** line through P meeting the sphere at A, B, the product `PA·PB = |power P|` — independent of the chosen line. This single invariant unifies several classical theorems.

## Results (`Proofs/PtolemysTheoremOQ04.lean`, 12 theorems, 0 sorries, 0 axioms)

- `intersecting_chords` — Intersecting Chords Theorem (Freek/Wiedijk No. 55)
- `intersecting_secants` — Intersecting Secants Theorem
- `mul_dist_eq_abs_power` — the unifying power invariant `PA·PB = |power P|`
- **`mul_dist_eq_mul_dist_of_mem_sphere`** *(derived)* — line-independence of the power of a point
- `mul_dist_eq_power_outside` / `mul_dist_eq_neg_power_inside` — signed forms
- `tangent_sq_eq_secant_product` — Tangent–Secant relation
- **`dist_tangent_eq_of_tangent`** *(derived)* — Equal Tangents Theorem (not a single Mathlib lemma)
- `concrete_intersecting_chords` — worked witness: two perpendicular diameters of the unit circle in ℂ through the centre

## Distinctness

The gallery's existing Ptolemy entry uses the *additive* relation (`mul_dist_add_mul_dist_eq_mul_dist_of_cospherical`), and `ProductOfSegmentsOfChords` proves the chord product in 2D `Vec2` coordinates. This entry is distinct on both counts: it uses the *product/power* Mathlib family (`mul_dist_eq_mul_dist_of_cospherical_*`, `Sphere.mul_dist_eq_abs_power`, `Sphere.IsTangentAt.power_eq_dist_sq`) — all previously **unused** anywhere in the gallery — and works coordinate-free in any dimension.

## Verification

- Built via `./proofs/scripts/docker-build.sh Proofs.PtolemysTheoremOQ04` — `✔ Built` (3078 jobs).
- `#print axioms` on the headline theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. Genuinely 0-axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)