### PR TITLE
Fix: re-badge legendre-factorial-formula-oq-01 verified→mathlib (#27102)

### DIFF
--- a/src/data/proofs/legendre-factorial-formula-oq-01/meta.json
+++ b/src/data/proofs/legendre-factorial-formula-oq-01/meta.json
@@ -18,7 +18,7 @@
       "digit-sum",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 71,


### PR DESCRIPTION
## Fix

Re-badge `legendre-factorial-formula-oq-01` from `verified` (Tier A) to `mathlib` (Tier B), matching the auditor finding in #27102.

## Evidence

**Before**: `meta.badge: "verified"` — overclaims a "fully formalized" tier for what is a Mathlib wrapper. Three of four theorems are literal one-line re-exports (`padicValNat_factorial`, `sub_one_mul_padicValNat_factorial`, `padicValNat_factorial_le`); the fourth (`padicValNat_factorial_eq_div`) is a two-line `Nat.mul_div_cancel_left` rearrangement.

**After**: `meta.badge: "mathlib"`. `status` stays `"verified"` (genuinely 0-sorry / 0-axiom). Prose (`description`, `assumptions`, `proofStrategy`, `keyInsights`) already discloses the Mathlib reliance, so no rewrite needed.

Metadata-only, single-line change. Directly parallel to the banach-fixed-point-oq-01 re-badge (#27087 → #27090).

Closes #27102

---
Automated fix by lean-mechanic agent.