### PR TITLE
research(gauss-lemma-primitive-oq-01): Gauss's Lemma for ℤ[X] — irreducible over ℤ iff over ℚ (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2500,6 +2500,7 @@ import Proofs.FurstenbergCorrespondenceOQ02
 import Proofs.GCDAlgorithm
 import Proofs.GCDAlgorithmOQ01
 import Proofs.GCDAlgorithmOQ01OQ03
+import Proofs.GaussLemmaPrimitiveOQ01
 import Proofs.GaussWilsonNonCyclic
 import Proofs.GaussWilsonNonCyclicOQ01
 import Proofs.GaussWilsonNonCyclicOQ01A

--- a/proofs/Proofs/GaussLemmaPrimitiveOQ01.lean
+++ b/proofs/Proofs/GaussLemmaPrimitiveOQ01.lean
@@ -1,0 +1,95 @@
+/-
+Gauss's Lemma: a primitive integer polynomial is irreducible over ℤ iff over ℚ
+
+Source: Open question from the gauss-lemma gallery family
+Status: VERIFIED (0 axioms, 0 sorries)
+
+**Gauss's Lemma** (irreducibility form) states that for a *primitive* polynomial
+`p ∈ ℤ[X]` — one whose coefficients share no common prime factor — irreducibility
+over ℤ is equivalent to irreducibility of its image in ℚ[X]:
+
+      p primitive  ⟹  ( Irreducible p  ↔  Irreducible (p over ℚ) ).
+
+Mathlib provides this as `Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast`
+(in `Mathlib/RingTheory/Polynomial/GaussLemma.lean`), but the gallery had no
+entry assembling the statement together with the two facts that give it teeth:
+
+  * the **monic specialization**, where primitivity is automatic, so the
+    biconditional holds with no side condition; and
+  * a **worked witness that primitivity is essential** — the non-primitive
+    polynomial `2X`, which is *reducible* over ℤ yet *irreducible* over ℚ.
+
+We package all three.
+
+We prove:
+1. `gauss_lemma_int`        — the biconditional for a primitive `p : ℤ[X]`
+2. `gauss_lemma_int_monic`  — the unconditional biconditional for monic `p`
+3. `two_mul_X_not_primitive`     — `2X` is not primitive (content 2)
+4. `two_mul_X_reducible_over_int`— `2X = (C 2)·X` is reducible over ℤ
+5. `two_mul_X_irreducible_over_rat` — its image `2X` is irreducible over ℚ (degree 1)
+6. `primitivity_necessary`   — the existential tying 3–5 together: there is a
+   polynomial reducible over ℤ but irreducible over ℚ, hence non-primitive, so
+   the primitivity hypothesis of Gauss's Lemma cannot be dropped.
+-/
+
+import Mathlib
+
+open Polynomial
+
+namespace GaussLemmaPrimitiveOQ01
+
+/-- **Gauss's Lemma over ℤ.** A *primitive* integer polynomial is irreducible over
+ℤ if and only if its image in ℚ[X] is irreducible. This is the headline of the
+entry; the proof is Mathlib's `IsPrimitive.Int.irreducible_iff_irreducible_map_cast`. -/
+theorem gauss_lemma_int {p : ℤ[X]} (hp : p.IsPrimitive) :
+    Irreducible p ↔ Irreducible (p.map (Int.castRingHom ℚ)) :=
+  IsPrimitive.Int.irreducible_iff_irreducible_map_cast hp
+
+/-- **Monic specialization.** A monic polynomial is automatically primitive
+(`Monic.isPrimitive`), so for monic `p : ℤ[X]` irreducibility over ℤ and over ℚ
+coincide with no extra hypothesis — the most useful everyday form of Gauss's Lemma
+(e.g. for checking irreducibility of a monic integer polynomial by working over ℚ). -/
+theorem gauss_lemma_int_monic {p : ℤ[X]} (hp : p.Monic) :
+    Irreducible p ↔ Irreducible (p.map (Int.castRingHom ℚ)) :=
+  IsPrimitive.Int.irreducible_iff_irreducible_map_cast hp.isPrimitive
+
+/-- The polynomial `2X = (C 2)·X` is **not primitive**: `C 2` divides it but `2` is
+not a unit of ℤ, so its coefficients share the common factor `2`. -/
+theorem two_mul_X_not_primitive : ¬ (C 2 * X : ℤ[X]).IsPrimitive := by
+  intro h
+  have h2 : IsUnit (2 : ℤ) :=
+    (isPrimitive_iff_isUnit_of_C_dvd.mp h) 2 (dvd_mul_right (C 2) X)
+  simp [Int.isUnit_iff] at h2
+
+/-- `2X` is **reducible over ℤ**: it factors as `(C 2)·X` with neither factor a
+unit (`C 2` is not a unit because `2` is not a unit of ℤ; `X` is not a unit because
+it has positive degree). -/
+theorem two_mul_X_reducible_over_int : ¬ Irreducible (C 2 * X : ℤ[X]) := by
+  intro hirr
+  rcases hirr.isUnit_or_isUnit rfl with h | h
+  · -- `IsUnit (C 2)` would make `2` a unit of ℤ
+    rw [Polynomial.isUnit_C, Int.isUnit_iff] at h
+    omega
+  · -- `IsUnit X` would force `natDegree X = 0`, but it is `1`
+    have := Polynomial.natDegree_eq_zero_of_isUnit h
+    simp [Polynomial.natDegree_X] at this
+
+/-- The image of `2X` in ℚ[X] is `2X`, which is **irreducible over ℚ**: it has
+degree one over a field. -/
+theorem two_mul_X_irreducible_over_rat :
+    Irreducible ((C 2 * X : ℤ[X]).map (Int.castRingHom ℚ)) := by
+  apply Polynomial.irreducible_of_degree_eq_one
+  rw [Polynomial.degree_map_eq_of_injective (Int.castRingHom ℚ).injective_int]
+  compute_degree!
+
+/-- **Primitivity is essential.** There is an integer polynomial — namely `2X` —
+that is reducible over ℤ yet irreducible over ℚ, and it fails to be primitive.
+Hence the primitivity hypothesis in `gauss_lemma_int` genuinely cannot be removed:
+without it the irreducibility biconditional is false. -/
+theorem primitivity_necessary :
+    ∃ p : ℤ[X], ¬ Irreducible p ∧ Irreducible (p.map (Int.castRingHom ℚ)) ∧
+      ¬ p.IsPrimitive :=
+  ⟨C 2 * X, two_mul_X_reducible_over_int, two_mul_X_irreducible_over_rat,
+    two_mul_X_not_primitive⟩
+
+end GaussLemmaPrimitiveOQ01

--- a/src/data/proofs/gauss-lemma-primitive-oq-01/annotations.json
+++ b/src/data/proofs/gauss-lemma-primitive-oq-01/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-imports-docstring",
+    "proofId": "gauss-lemma-primitive-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 39
+    },
+    "type": "concept",
+    "title": "Gauss's Lemma in its Irreducibility Form",
+    "content": "Gauss's Lemma (irreducibility form) states that a primitive polynomial p ∈ ℤ[X] — one whose coefficients have no common prime factor — is irreducible over ℤ exactly when its image in ℚ[X] is irreducible. Mathlib supplies the biconditional as IsPrimitive.Int.irreducible_iff_irreducible_map_cast; this file packages it with the monic specialization and a counterexample certifying that primitivity is essential. The header lists the six results.",
+    "mathContext": "For primitive $p \\in \\mathbb{Z}[X]$: $\\text{Irreducible } p \\iff \\text{Irreducible } (p \\bmod \\mathbb{Q})$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gauss's Lemma",
+      "primitive polynomial",
+      "irreducibility",
+      "content of a polynomial"
+    ],
+    "prerequisites": [
+      "polynomials over ℤ and ℚ",
+      "irreducible elements and units"
+    ]
+  },
+  {
+    "id": "ann-biconditional",
+    "proofId": "gauss-lemma-primitive-oq-01",
+    "range": {
+      "startLine": 41,
+      "endLine": 54
+    },
+    "type": "theorem",
+    "title": "The Biconditional and its Monic Specialization",
+    "content": "gauss_lemma_int is the headline: for primitive p : ℤ[X], Irreducible p ↔ Irreducible (p.map (Int.castRingHom ℚ)), a direct application of Mathlib's IsPrimitive.Int.irreducible_iff_irreducible_map_cast. gauss_lemma_int_monic feeds it Monic.isPrimitive: since every monic polynomial is primitive, irreducibility over ℤ and over ℚ coincide for monic p with no side condition — the form used in practice, e.g. to check a monic integer polynomial's irreducibility by working over the field ℚ.",
+    "mathContext": "Monic $\\Rightarrow$ primitive, so for monic $p$ the biconditional holds unconditionally.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
+      "Monic.isPrimitive",
+      "rational-root test",
+      "Eisenstein's criterion"
+    ],
+    "prerequisites": [
+      "primitive and monic polynomials"
+    ]
+  },
+  {
+    "id": "ann-not-primitive-reducible",
+    "proofId": "gauss-lemma-primitive-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 75
+    },
+    "type": "key-step",
+    "title": "2X is Non-Primitive and Reducible over ℤ",
+    "content": "two_mul_X_not_primitive: were 2X primitive, isPrimitive_iff_isUnit_of_C_dvd applied to the divisor C 2 ∣ 2X would force 2 to be a unit of ℤ, refuted by Int.isUnit_iff. two_mul_X_reducible_over_int: were 2X irreducible, Irreducible.isUnit_or_isUnit on the factorization 2X = (C 2)·X would make either C 2 a unit (impossible — 2 is not a unit of ℤ, via isUnit_C and Int.isUnit_iff) or X a unit (impossible — natDegree_eq_zero_of_isUnit would give natDegree X = 0, but natDegree X = 1). Both impossibilities are discharged mechanically.",
+    "mathContext": "$2X = (C\\,2)\\cdot X$ with $C\\,2$ and $X$ both non-units, so $2X$ is reducible over $\\mathbb{Z}$ and has content $2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "isPrimitive_iff_isUnit_of_C_dvd",
+      "Irreducible.isUnit_or_isUnit",
+      "isUnit_C",
+      "natDegree_eq_zero_of_isUnit"
+    ],
+    "prerequisites": [
+      "units in ℤ and in ℤ[X]",
+      "natDegree of X"
+    ]
+  },
+  {
+    "id": "ann-irreducible-over-rat",
+    "proofId": "gauss-lemma-primitive-oq-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 83
+    },
+    "type": "key-step",
+    "title": "The Image 2X is Irreducible over ℚ",
+    "content": "two_mul_X_irreducible_over_rat shows the ℚ-image is irreducible by reducing to a degree computation. Since ℤ ↪ ℚ is injective (RingHom.injective_int at Int.castRingHom ℚ), degree_map_eq_of_injective gives degree of the image = degree of 2X over ℤ; compute_degree! evaluates that to 1; and irreducible_of_degree_eq_one (degree-one polynomials over a field are irreducible) concludes. No genuinely rational reasoning is needed — degree is the only invariant that matters.",
+    "mathContext": "$\\deg(2X) = 1$ over $\\mathbb{Q}$, and degree-one polynomials over a field are irreducible.",
+    "significance": "key",
+    "relatedConcepts": [
+      "degree_map_eq_of_injective",
+      "RingHom.injective_int",
+      "irreducible_of_degree_eq_one",
+      "compute_degree!"
+    ],
+    "prerequisites": [
+      "degree of a polynomial",
+      "irreducibility over a field"
+    ]
+  },
+  {
+    "id": "ann-primitivity-necessary",
+    "proofId": "gauss-lemma-primitive-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 95
+    },
+    "type": "theorem",
+    "title": "Primitivity is Essential",
+    "content": "primitivity_necessary bundles the three facts about 2X into the existential ∃ p : ℤ[X], ¬Irreducible p ∧ Irreducible (p.map (Int.castRingHom ℚ)) ∧ ¬p.IsPrimitive. The witness 2X is reducible over ℤ yet irreducible over ℚ, so the irreducibility biconditional of gauss_lemma_int is false for it — and it is precisely the failure of primitivity that allows this. The hypothesis in Gauss's Lemma genuinely cannot be dropped.",
+    "mathContext": "$2X$ realizes $\\neg\\text{Irreducible} \\wedge \\text{Irreducible over } \\mathbb{Q} \\wedge \\neg\\text{primitive}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "sharpness of hypotheses",
+      "counterexample",
+      "primitive polynomial"
+    ],
+    "prerequisites": [
+      "the preceding three lemmas about 2X"
+    ]
+  }
+]

--- a/src/data/proofs/gauss-lemma-primitive-oq-01/meta.json
+++ b/src/data/proofs/gauss-lemma-primitive-oq-01/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "gauss-lemma-primitive-oq-01",
+  "title": "Gauss's Lemma: a primitive integer polynomial is irreducible over ℤ iff over ℚ",
+  "slug": "gauss-lemma-primitive-oq-01",
+  "description": "Gauss's Lemma (irreducibility form): a primitive polynomial p ∈ ℤ[X] is irreducible over ℤ if and only if its image in ℚ[X] is irreducible. Mathlib proves the biconditional (IsPrimitive.Int.irreducible_iff_irreducible_map_cast) but the gallery had no entry packaging it with the monic specialization (where primitivity is automatic) and a fully-formalized witness that primitivity is essential — the non-primitive polynomial 2X, reducible over ℤ yet irreducible over ℚ.",
+  "meta": {
+    "author": "Carl Friedrich Gauss (1801)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GaussLemmaPrimitiveOQ01.lean",
+    "tags": [
+      "ring-theory",
+      "polynomials",
+      "irreducibility",
+      "gauss-lemma",
+      "primitive-polynomial",
+      "classic"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
+        "description": "Gauss's Lemma: for primitive p : ℤ[X], Irreducible p ↔ Irreducible (p.map (Int.castRingHom ℚ))",
+        "module": "Mathlib.RingTheory.Polynomial.GaussLemma"
+      },
+      {
+        "theorem": "Polynomial.Monic.isPrimitive",
+        "description": "Every monic polynomial is primitive, used to drop the primitivity hypothesis in the monic specialization",
+        "module": "Mathlib.RingTheory.Polynomial.Content"
+      },
+      {
+        "theorem": "Polynomial.isPrimitive_iff_isUnit_of_C_dvd",
+        "description": "p is primitive iff every constant C r dividing p has r a unit; used to show 2X is not primitive",
+        "module": "Mathlib.RingTheory.Polynomial.Content"
+      },
+      {
+        "theorem": "Polynomial.irreducible_of_degree_eq_one",
+        "description": "Over a field, a polynomial of degree one is irreducible; gives irreducibility of the ℚ-image 2X",
+        "module": "Mathlib.Algebra.Polynomial.FieldDivision"
+      },
+      {
+        "theorem": "Polynomial.degree_map_eq_of_injective",
+        "description": "An injective ring-hom map preserves degree; transfers deg(2X over ℤ) = 1 to the ℚ-image",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Lemmas"
+      },
+      {
+        "theorem": "RingHom.injective_int",
+        "description": "Any ring hom out of ℤ into a char-zero ring is injective; instantiated at Int.castRingHom ℚ",
+        "module": "Mathlib.Data.Int.CharZero"
+      }
+    ],
+    "originalContributions": [
+      "gauss_lemma_int: the Gauss's Lemma biconditional restated as the entry headline for primitive p : ℤ[X]",
+      "gauss_lemma_int_monic: the unconditional monic specialization (primitivity automatic via Monic.isPrimitive)",
+      "two_mul_X_not_primitive / two_mul_X_reducible_over_int / two_mul_X_irreducible_over_rat: a fully-formalized counterexample showing 2X is non-primitive, reducible over ℤ, but irreducible over ℚ",
+      "primitivity_necessary: the existential ∃ p, ¬Irreducible p ∧ Irreducible (p over ℚ) ∧ ¬p.IsPrimitive, proving the primitivity hypothesis of Gauss's Lemma cannot be dropped"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound. No native_decide, so no Lean.ofReduceBool.",
+    "lineCount": 95,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Gauss's Lemma, from the Disquisitiones Arithmeticae (1801), is the cornerstone fact connecting factorization over ℤ to factorization over ℚ. In its content form it says the product of two primitive polynomials is primitive; in its irreducibility form it says a primitive integer polynomial is irreducible over ℤ exactly when it is irreducible over ℚ. The lemma is what makes the rational-root test and integer-coefficient irreducibility criteria (Eisenstein, reduction mod p) actually certify irreducibility over ℚ, and it underlies the theorem that ℤ[X] (and more generally R[X] over a UFD) is a UFD.",
+    "problemStatement": "Package Gauss's Lemma in its irreducibility form, its monic specialization, and a concrete demonstration that the primitivity hypothesis is necessary.\n\n**Answer:** For primitive p : ℤ[X], Irreducible p ↔ Irreducible (p over ℚ); for monic p the hypothesis is automatic; and 2X witnesses that without primitivity the biconditional fails.",
+    "text": "A primitive integer polynomial is irreducible over ℤ iff its image in ℚ[X] is irreducible. For monic polynomials the primitivity hypothesis is free, and the non-primitive polynomial 2X — reducible over ℤ but irreducible over ℚ — shows the hypothesis cannot be dropped.",
+    "proofStrategy": "1. gauss_lemma_int / gauss_lemma_int_monic: direct applications of Mathlib's IsPrimitive.Int.irreducible_iff_irreducible_map_cast, the second feeding it Monic.isPrimitive so no primitivity side-condition is needed.\n2. two_mul_X_not_primitive: from isPrimitive_iff_isUnit_of_C_dvd, primitivity of 2X would force 2 to be a unit of ℤ (since C 2 ∣ 2X); Int.isUnit_iff refutes this.\n3. two_mul_X_reducible_over_int: an Irreducible 2X would, via isUnit_or_isUnit on the factorization 2X = (C 2)·X, make either C 2 a unit (impossible: 2 is not a unit of ℤ) or X a unit (impossible: natDegree X = 1 ≠ 0).\n4. two_mul_X_irreducible_over_rat: the ℚ-image has the same degree as 2X over ℤ (degree_map_eq_of_injective, injectivity of Int.castRingHom ℚ from RingHom.injective_int), namely 1 (compute_degree!), and degree-one polynomials over a field are irreducible.\n5. primitivity_necessary: bundle 2–4 into the existential witness.",
+    "keyInsights": [
+      "**The irreducibility form is the working version.** Reduction mod p, Eisenstein's criterion, and the rational-root test all establish irreducibility over ℤ; Gauss's Lemma is precisely what upgrades that to irreducibility over ℚ, the field one usually cares about.",
+      "**Monic ⟹ primitive makes the lemma hypothesis-free in practice.** Most irreducibility questions are about monic polynomials, and for those the primitivity condition is automatic — gauss_lemma_int_monic states exactly this clean form.",
+      "**Primitivity is not decoration.** The polynomial 2X is reducible over ℤ (it is C 2 times X, neither a unit) but its image 2X is irreducible over ℚ (degree one over a field). This single witness shows the biconditional is false without the primitivity hypothesis — the content of primitivity_necessary.",
+      "**Degree is the only invariant needed for the ℚ-side.** Because ℤ ↪ ℚ is injective, the map preserves degree, so the irreducibility of the image reduces to a degree-one computation rather than any genuinely rational reasoning."
+    ],
+    "prerequisites": [
+      "Polynomials over ℤ and ℚ",
+      "Primitive polynomials and content",
+      "Irreducible elements and units in a ring"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "eisenstein-criterion-oq-01",
+      "relationship": "related",
+      "description": "Eisenstein's criterion certifies irreducibility over ℤ; Gauss's Lemma is what lifts such ℤ-irreducibility to irreducibility over ℚ"
+    }
+  ],
+  "conclusion": {
+    "summary": "Gauss's Lemma (irreducibility form) is packaged for ℤ/ℚ: a primitive integer polynomial is irreducible over ℤ iff over ℚ (gauss_lemma_int), with the hypothesis automatic for monic polynomials (gauss_lemma_int_monic). The polynomial 2X — non-primitive, reducible over ℤ, irreducible over ℚ — is fully formalized and bundled as primitivity_necessary, proving the primitivity hypothesis is indispensable. All six theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies a citable, self-contained statement of Gauss's Lemma in its working irreducibility form together with the sharpness witness, complementing the integer-coefficient irreducibility criteria (e.g. Eisenstein) that rely on it.",
+    "openQuestions": [
+      "Can the same packaging be given over an arbitrary UFD R with fraction field K (Mathlib's Monic.irreducible_iff_irreducible_map_fraction_map), with a worked non-UFD-free example?",
+      "Does a worked positive case — a specific monic cubic shown irreducible over ℚ by transferring an integer-side argument through gauss_lemma_int_monic — add pedagogical value beyond the counterexample?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "GaussLemmaPrimitiveOQ01",
+    "lineCount": 95,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/GaussLemmaPrimitiveOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Packages **Gauss's Lemma** in its irreducibility form for ℤ/ℚ — a genuine gallery gap. Mathlib proves the biconditional (`Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast`) but no entry assembled it with the everyday monic form and a sharpness witness.

Six theorems, all **0-axiom verified** against pinned Mathlib 4.26.0:

1. `gauss_lemma_int` — for primitive `p : ℤ[X]`, `Irreducible p ↔ Irreducible (p.map (Int.castRingHom ℚ))`
2. `gauss_lemma_int_monic` — the unconditional monic form (primitivity automatic via `Monic.isPrimitive`)
3. `two_mul_X_not_primitive` — `2X` is not primitive (content 2)
4. `two_mul_X_reducible_over_int` — `2X = (C 2)·X` is reducible over ℤ
5. `two_mul_X_irreducible_over_rat` — its image `2X` is irreducible over ℚ (degree 1 over a field)
6. `primitivity_necessary` — `∃ p, ¬Irreducible p ∧ Irreducible (p over ℚ) ∧ ¬p.IsPrimitive`, proving the primitivity hypothesis **cannot be dropped**

## Why it matters

Eisenstein, reduction-mod-p, and the rational-root test all certify irreducibility *over ℤ*; Gauss's Lemma is exactly what upgrades that to irreducibility *over ℚ*. The monic specialization is the form used in practice, and the `2X` witness shows primitivity is not decoration.

## Verification

```
#print axioms gauss_lemma_int        -- [propext, Classical.choice, Quot.sound]
#print axioms gauss_lemma_int_monic  -- [propext, Classical.choice, Quot.sound]
#print axioms primitivity_necessary  -- [propext, Classical.choice, Quot.sound]
```

0 sorries, 0 `axiom` declarations, no `native_decide`. Built via `docker-build.sh Proofs.GaussLemmaPrimitiveOQ01` (7743 jobs, success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)