### PR TITLE
research(infinitude-primes-4k3-oq-02): survey update — M1 orthogonality now a Mathlib one-liner; problem purely gated on absent PNT-AP crux

### DIFF
--- a/research/problems/infinitude-primes-4k3-oq-02/knowledge.md
+++ b/research/problems/infinitude-primes-4k3-oq-02/knowledge.md
@@ -63,6 +63,32 @@ transfer that upgrades `L(1,χ)≠0` to the density asymptotic is the missing pi
 until M2 lands. M1 is buildable but non-advancing alone, and is itself currently
 gated by the Docker build blackout.
 
+### S2 (2026-06-20, ORIENT re-grep) — M1 scaffold collapses to a Mathlib one-liner
+
+**Mode**: continuation (claimed from pool, WEAK). Docker UP; re-grepped the live
+Mathlib checkout at `proofs/.lake/packages/mathlib/`.
+
+**Finding**: the M1 character-orthogonality indicator decomposition that S1 listed
+as "BUILDABLE, ~80–150 LOC" is now a **direct Mathlib citation**, not buildable
+content. `Mathlib/NumberTheory/DirichletCharacter/Orthogonality.lean` provides:
+
+- `DirichletCharacter.sum_characters_eq (a : ZMod n) :`
+  `∑ χ : DirichletCharacter R n, χ a = if a = 1 then (n.totient : R) else 0`
+- `DirichletCharacter.sum_char_inv_mul_char_eq (ha : IsUnit a) (b : ZMod n) :`
+  `∑ χ, χ a⁻¹ * χ b = if a = b then (n.totient : R) else 0`
+
+The second lemma **is exactly** the orthogonality relation underlying M1. The
+"indicator decomposition" `𝟙[n≡a] = (1/φ(d)) Σ_χ χ̄(a) χ(n)` is just this lemma
+divided by `φ(d)` (over `R = ℂ`, using `χ(a⁻¹)=χ̄(a)` for the unit `a`). That is a
+one-line rearrangement — an auditor would (correctly) classify a standalone entry
+built on it as a thin Mathlib re-export, badge `mathlib`, not original research.
+
+**Consequence**: this problem now has **zero buildable sub-content**. It is purely
+gated on M2 (the PNT-AP analytic asymptotic `Σ_{p≤x} χ(p)=o(π(x))` for `χ≠χ₀`),
+still absent from Mathlib (PNT+ future goal). S1's hedge — "M1 buildable but
+non-advancing" — is now sharper: M1 isn't even worth building. Correct status
+remains `surveyed`; nothing ships until PNT+ lands M2.
+
 ---
 
 ## Dead Ends

--- a/research/problems/infinitude-primes-4k3-oq-02/state.md
+++ b/research/problems/infinitude-primes-4k3-oq-02/state.md
@@ -4,31 +4,39 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-06-14T20:50:00-07:00
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-Mathlib-API-grounded feasibility survey complete. Approach pinned (character
-orthogonality + per-character analytic asymptotic). Crux lemma M2 is gated.
+Survey re-confirmed against the live Mathlib checkout (Docker UP). The M1
+orthogonality scaffold has **collapsed to a Mathlib one-liner** — it is no longer
+even buildable "progress" — and the problem is now purely gated on the M2 analytic
+crux, which remains absent. Status held `surveyed`.
 
 ## Active Approach
-Davenport-style PNT-AP: indicator-decomposition by Dirichlet characters (M1,
-buildable) + per-character prime asymptotic `Σ_{p≤x} χ(p)=o(π(x))` (M2, gated).
+Davenport-style PNT-AP: indicator-decomposition by Dirichlet characters (M1, now a
+direct Mathlib citation) + per-character prime asymptotic `Σ_{p≤x} χ(p)=o(π(x))`
+(M2, gated, absent from Mathlib).
 
 ## Attempt Count
-- Total attempts: 0 (no build — Docker DOWN)
+- Total attempts: 0 (nothing buildable advances the target)
 - Current approach attempts: 0
-- Approaches tried: 1 (literature/API survey, ORIENT)
+- Approaches tried: 1 (literature/API survey, ORIENT) + 1 live Mathlib re-grep
 
 ## Blockers
 - **M2 analytic crux absent from Mathlib**: the quantitative PNT-AP asymptotic
   `π(x;d,a)=(1/φ(d))Li(x)+o(·)` / `Σ_{p≤x}χ(p)=o(π(x))` for `χ≠χ₀` is an explicit
   **future** goal of the PNT+ project, not yet merged. Building from scratch is
   >1000 LOC / multi-month. This gates even the `d=4` milestone.
-- **Docker build blackout**: cannot build the M1 orthogonality scaffold this session.
+- **M1 has no formalization value**: see S2 below. Mathlib's
+  `DirichletCharacter.sum_char_inv_mul_char_eq` already IS the orthogonality
+  relation `∑_χ χ(a⁻¹)χ(b) = if a=b then φ(n) else 0`. The indicator
+  decomposition is a trivial rearrangement of it (divide by `φ(d)` in `ℂ`),
+  so a standalone "M1 scaffold" entry would be an auditor-flagged thin re-export,
+  not progress toward the density target.
 
 ## Next Action
-- Hold `surveyed` (stated cleanly; not provable until M2 lands).
-- When Docker returns: build M1 (character-orthogonality indicator decomposition,
-  ~80–150 LOC) citing Mathlib's `MulChar` orthogonality lemma.
-- Watch PNT+ for the merged PNT-AP asymptotic; that unblocks M2 and the `d=4`
-  milestone (`π(x;4,1) ∼ π(x;4,3) ∼ ½π(x)`).
+- Hold `surveyed` (stated cleanly; not provable until M2 lands; M1 is a citation).
+- Watch the **PNT+ project** for the merged PNT-AP asymptotic
+  (`Σ_{p≤x} χ(p)=o(π(x))`). That single import unblocks M2 and makes the `d=4`
+  milestone (`π(x;4,1) ∼ π(x;4,3) ∼ ½π(x)`) the first provable deliverable.
+- Do NOT build an "M1 only" entry — it is now a Mathlib wrapper (S2).


### PR DESCRIPTION
## Summary

Research-progress update (no Lean entry — this problem is correctly **not** shippable as verified yet).

Re-surveyed `infinitude-primes-4k3-oq-02` (PNT-AP / Dirichlet density `π(x;d,a)/π(x) → 1/φ(d)`) against the **live Mathlib checkout** (Docker up this session). The prior orientation (S1, 2026-06-14) classified the proof as:

- **M1** — character-orthogonality indicator decomposition `𝟙[n≡a] = (1/φ(d)) Σ_χ χ̄(a)χ(n)` — *buildable scaffold, ~80–150 LOC*
- **M2** — per-character prime asymptotic `Σ_{p≤x} χ(p)=o(π(x))` for `χ≠χ₀` — *gated, multi-month, absent from Mathlib*

### New finding (S2)

M1 has **collapsed to a direct Mathlib citation**. `Mathlib/NumberTheory/DirichletCharacter/Orthogonality.lean` now provides:

- `DirichletCharacter.sum_characters_eq : ∑ χ, χ a = if a = 1 then (n.totient : R) else 0`
- `DirichletCharacter.sum_char_inv_mul_char_eq : ∑ χ, χ a⁻¹ * χ b = if a = b then (n.totient : R) else 0`

The second lemma **is** the orthogonality relation underlying M1; the indicator decomposition is a one-line rearrangement (divide by `φ(d)` over ℂ). A standalone 'M1 scaffold' entry would therefore be an auditor-flagged thin Mathlib re-export, not original research.

**Consequence:** this problem now has *zero* buildable sub-content. It is purely gated on M2, which remains a PNT+ future goal not yet in Mathlib. Status held `surveyed`; the `d=4` milestone (`π(x;4,1)∼π(x;4,3)∼½π(x)`) becomes the first provable deliverable only once PNT+ lands the asymptotic.

## Changes
- `research/problems/infinitude-primes-4k3-oq-02/knowledge.md`: add insight **S2** + dead-end note.
- `research/problems/infinitude-primes-4k3-oq-02/state.md`: bump to iteration 3; record M1→Mathlib-wrapper collapse; sharpen blockers and next-action.

No Lean source, no gallery meta, no axioms — documentation/knowledge-base only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)