### PR TITLE
Fix: re-badge frobenius-endomorphism-oq-01 original→mathlib (#27107)

### DIFF
--- a/src/data/proofs/frobenius-endomorphism-oq-01/meta.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01/meta.json
@@ -17,16 +17,49 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/FrobeniusEndomorphismOQ01.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All 7 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). The concrete checks in ZMod 5 / ZMod 3 use decide, not native_decide, so no Lean.ofReduceBool is introduced.",
     "originalContributions": [
-      "freshmans_dream: the additivity (x+y)^p = x^p + y^p in prime characteristic — the non-obvious half of the Frobenius being a ring homomorphism",
-      "frobenius_apply / frobenius_mul: the Frobenius as x ↦ x^p, multiplicative as well as additive (a genuine ring endomorphism)",
-      "frobenius_zmod_eq_id / fermat_little: over ZMod p the Frobenius is the identity ring hom, i.e. a^p = a for all a — Fermat's little theorem as a fixed-point statement",
-      "finite_field_pow_card / finite_field_iterate: over a finite field K with q = |K|, x^q = x and every iterate x^(q^n) = x",
+      "Packaging only — every substantive theorem is a one-line re-export of a single named Mathlib lemma; there is no bridge lemma or content absent from Mathlib. The contribution is the curated gallery presentation, not independent proof.",
+      "freshmans_dream: the additivity (x+y)^p = x^p + y^p in prime characteristic, exposed directly via Mathlib's add_pow_expChar",
+      "frobenius_apply (rfl) / frobenius_mul (mul_pow): the Frobenius as x ↦ x^p, multiplicative as well as additive",
+      "frobenius_zmod_eq_id (ZMod.frobenius_zmod) / fermat_little (ZMod.pow_card): over ZMod p the Frobenius is the identity ring hom, i.e. a^p = a for all a — Fermat's little theorem as a fixed-point statement",
+      "finite_field_pow_card (FiniteField.pow_card) / finite_field_iterate (FiniteField.pow_card_pow): over a finite field K with q = |K|, x^q = x and every iterate x^(q^n) = x",
       "frobenius_fixes_zmod_five / freshmans_dream_zmod_three: concrete decide-checks — every residue mod 5 satisfies a^5 = a, and (x+y)^3 = x^3 + y^3 holds for all x,y in ZMod 3"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "add_pow_expChar",
+        "description": "The freshman's dream (x+y)^p = x^p + y^p in (exponential) characteristic p. freshmans_dream is exactly this lemma.",
+        "module": "Mathlib.Algebra.CharP.ExpChar"
+      },
+      {
+        "theorem": "mul_pow",
+        "description": "(x*y)^p = x^p * y^p in a commutative monoid; gives frobenius_mul (characteristic-independent).",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "ZMod.frobenius_zmod",
+        "description": "The Frobenius ring homomorphism of ZMod p equals the identity. frobenius_zmod_eq_id is this lemma.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "ZMod.pow_card",
+        "description": "a^p = a for all a : ZMod p (Fermat's little theorem, all-elements form). fermat_little is this lemma.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "FiniteField.pow_card",
+        "description": "x^q = x over a finite field of order q. finite_field_pow_card is this lemma.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "FiniteField.pow_card_pow",
+        "description": "x^(q^n) = x, the iterated q-power map. finite_field_iterate is this lemma.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      }
     ],
     "dateAdded": "2026-06-20",
     "lineCount": 101,


### PR DESCRIPTION
Closes #27107.

## Issue
Gallery integrity audit found `frobenius-endomorphism-oq-01` badged `original`, but every substantive theorem is a one-line re-export of a single named Mathlib lemma — a Tier B Mathlib wrapper, not independent work.

## Fix (metadata only)
- `badge`: `original` → `mathlib`. Status stays `verified` (0 sorries, 0 axioms, no `native_decide`).
- `originalContributions`: rescoped to packaging/curation; leading entry now states explicitly there is no bridge lemma or content absent from Mathlib, and each entry names its Mathlib source.
- `mathlibDependencies`: populated with the six source theorems (`add_pow_expChar`, `mul_pow`, `ZMod.frobenius_zmod`, `ZMod.pow_card`, `FiniteField.pow_card`, `FiniteField.pow_card_pow`).

No Lean source changes — the proof was already correct and fully verified; only the badge/credit framing overclaimed.

Parallels banach-fixed-point-oq-01 (#27087/#27090) and legendre-factorial-formula-oq-01 (#27102/#27104).

🤖 Generated with [Claude Code](https://claude.com/claude-code)