### PR TITLE
research(stirling-first-kind-oq-02): rising-factorial generating identity c(n,k)=[Xᵏ]ascPochhammer ℤ n + row sum via eval at X=1 (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3089,6 +3089,7 @@ import Proofs.StirlingFormula
 import Proofs.StirlingFormulaOQ02
 import Proofs.StirlingFormulaOQ03
 import Proofs.StirlingFirstKindOQ01
+import Proofs.StirlingFirstKindOQ02
 import Proofs.StirlingSecondKindOQ01
 import Proofs.SubsetCount
 import Proofs.SubsetCountMultisetOQ01

--- a/proofs/Proofs/StirlingFirstKindOQ02.lean
+++ b/proofs/Proofs/StirlingFirstKindOQ02.lean
@@ -1,0 +1,107 @@
+/-
+Stirling Numbers of the First Kind, II: the rising-factorial generating identity
+  c(n,k) = [Xᵏ] X(X+1)⋯(X+n−1) = (ascPochhammer ℤ n).coeff k,
+and the row sum ∑ₖ c(n,k) = n! recovered from it by evaluation at X = 1.
+
+Source: Follow-up open question to stirling-first-kind-oq-01 (the row sum)
+Status: VERIFIED (0 axioms, 0 sorries)
+
+`Nat.stirlingFirst n k` is the unsigned Stirling number of the first kind: the
+number of permutations of an `n`-element set with exactly `k` disjoint cycles.
+Mathlib (`Mathlib/Combinatorics/Enumerative/Stirling.lean`, 2025) provides the
+Pascal recurrence `c(n+1,k+1) = n·c(n,k+1) + c(n,k)` and the boundary columns, and
+the companion gallery entry `stirling-first-kind-oq-01` proves the row sum
+`∑ₖ c(n,k) = n!` by a direct combinatorial induction.
+
+What is recorded NOWHERE — neither in Mathlib nor in oq-01 — is the *defining
+generating-function identity* of these numbers:
+
+      X(X+1)(X+2)⋯(X+n−1)  =  ∑ₖ c(n,k)·Xᵏ.
+
+The product on the left is exactly Mathlib's rising factorial `ascPochhammer ℤ n`,
+so the identity says precisely that
+
+      (ascPochhammer ℤ n).coeff k  =  c(n,k).
+
+This is the most structural fact about the first-kind triangle: the entire row is
+the coefficient list of one polynomial. We prove it (theorem 1), and then *recover
+the row sum as a corollary* (theorem 2) by a route entirely different from oq-01:
+setting `X = 1` sends `Xᵏ ↦ 1`, collapsing the coefficient list to its sum, while
+the polynomial value there is `(ascPochhammer ℤ n).eval 1 = n!`
+(`ascPochhammer_eval_one`). So the same `n!` is reached through the generating
+function rather than through a bespoke induction.
+
+We prove:
+1. `stirlingFirst_eq_ascPochhammer_coeff` — c(n,k) is the Xᵏ-coefficient of the
+   rising factorial `ascPochhammer ℤ n`  (the generating identity)
+2. `stirlingFirst_row_sum`               — ∑ₖ c(n,k) = n!, derived from (1) by
+   evaluating the generating polynomial at X = 1
+3. `stirlingFirst_row_four`              — numeric sanity check: row 4 sums to 24
+-/
+
+import Mathlib
+
+open Nat Polynomial
+
+namespace StirlingFirstKindOQ02
+
+/-- **Generating identity for the first kind.** The unsigned Stirling number
+`c(n,k)` is the coefficient of `Xᵏ` in the rising factorial
+`X(X+1)⋯(X+n−1) = ascPochhammer ℤ n`.
+
+Proof by induction on `n`. The step uses
+`ascPochhammer ℤ (n+1) = ascPochhammer ℤ n · (X + n)` (`ascPochhammer_succ_right`):
+extracting the `Xᵏ`-coefficient of the product — `coeff_mul_X` for the `X` factor
+(an index shift) and `coeff_mul_C` for the constant `n` — reproduces exactly the
+Pascal recurrence `c(n+1,k+1) = n·c(n,k+1) + c(n,k)`, while the `k = 0` case yields
+`c(n+1,0) = 0`. -/
+theorem stirlingFirst_eq_ascPochhammer_coeff (n k : ℕ) :
+    (ascPochhammer ℤ n).coeff k = (Nat.stirlingFirst n k : ℤ) := by
+  induction n generalizing k with
+  | zero =>
+    rw [ascPochhammer_zero, Polynomial.coeff_one]
+    cases k with
+    | zero => simp
+    | succ k => simp [Nat.stirlingFirst_zero_succ]
+  | succ n ih =>
+    rw [ascPochhammer_succ_right, ← Polynomial.C_eq_natCast, mul_add,
+      Polynomial.coeff_add, Polynomial.coeff_mul_C]
+    cases k with
+    | zero =>
+      rw [Polynomial.coeff_mul_X_zero, zero_add, ih, Nat.stirlingFirst_succ_zero]
+      have hz : Nat.stirlingFirst n 0 * n = 0 := by
+        cases n with
+        | zero => simp
+        | succ m => simp [Nat.stirlingFirst_succ_zero]
+      push_cast
+      exact_mod_cast hz
+    | succ j =>
+      rw [Polynomial.coeff_mul_X, ih, ih, Nat.stirlingFirst_succ_succ]
+      push_cast
+      ring
+
+/-- **Row sum via the generating function.** `∑_{k=0}^{n} c(n,k) = n!`, obtained
+from the generating identity by evaluating at `X = 1`.
+
+`(ascPochhammer ℤ n).eval 1 = n!` (`ascPochhammer_eval_one`); expanding the
+evaluation as a sum of coefficients over `range (natDegree + 1) = range (n+1)`
+(`eval_eq_sum_range`, `ascPochhammer_natDegree`) and replacing each coefficient by
+`c(n,k)` via theorem 1 gives `∑ₖ (c(n,k) : ℤ) = n!`, which descends to ℕ. This is a
+generating-function proof of the row sum, distinct from the direct induction of
+`stirling-first-kind-oq-01`. -/
+theorem stirlingFirst_row_sum (n : ℕ) :
+    ∑ k ∈ Finset.range (n + 1), Nat.stirlingFirst n k = n ! := by
+  have h1 : (ascPochhammer ℤ n).eval 1 = (n ! : ℤ) := ascPochhammer_eval_one ℤ n
+  rw [Polynomial.eval_eq_sum_range, ascPochhammer_natDegree ℤ n] at h1
+  simp only [one_pow, mul_one] at h1
+  rw [Finset.sum_congr rfl (fun k _ => stirlingFirst_eq_ascPochhammer_coeff n k),
+    ← Nat.cast_sum] at h1
+  exact_mod_cast h1
+
+/-- **Numeric sanity check.** Row `4` is `c(4,0..4) = 0, 6, 11, 6, 1`, summing to
+`24 = 4!`, matching `stirlingFirst_row_sum`. -/
+theorem stirlingFirst_row_four :
+    ∑ k ∈ Finset.range 5, Nat.stirlingFirst 4 k = 24 := by
+  simp [Finset.sum_range_succ, Nat.stirlingFirst]
+
+end StirlingFirstKindOQ02

--- a/src/data/proofs/stirling-first-kind-oq-02/annotations.json
+++ b/src/data/proofs/stirling-first-kind-oq-02/annotations.json
@@ -1,0 +1,91 @@
+[
+  {
+    "id": "ann-imports-docstring",
+    "proofId": "stirling-first-kind-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 46
+    },
+    "type": "concept",
+    "title": "The Generating Function of the First-Kind Numbers",
+    "content": "Nat.stirlingFirst n k counts permutations of an n-element set with exactly k disjoint cycles, but the numbers enter mathematics through a polynomial: the rising factorial X(X+1)⋯(X+n−1) expands as ∑ₖ c(n,k) Xᵏ. Mathlib formalizes the rising factorial as ascPochhammer ℤ n and the Stirling recurrence separately, with no theorem linking them; the companion entry stirling-first-kind-oq-01 proves the row sum without the polynomial. This file supplies the missing bridge — c(n,k) = [Xᵏ] ascPochhammer ℤ n — and recovers the row sum from it.",
+    "mathContext": "$X(X+1)\\cdots(X+n-1) = \\sum_k c(n,k)X^k$, i.e. $c(n,k) = (\\text{ascPochhammer}\\,\\mathbb{Z}\\,n).\\mathrm{coeff}\\,k$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Stirling numbers of the first kind",
+      "rising factorial (ascPochhammer)",
+      "generating functions",
+      "Nat.stirlingFirst"
+    ],
+    "prerequisites": [
+      "polynomials and their coefficients",
+      "permutations and cycles"
+    ]
+  },
+  {
+    "id": "ann-generating-identity",
+    "proofId": "stirling-first-kind-oq-02",
+    "range": {
+      "startLine": 48,
+      "endLine": 81
+    },
+    "type": "theorem",
+    "title": "c(n,k) is the Xᵏ-Coefficient of the Rising Factorial",
+    "content": "stirlingFirst_eq_ascPochhammer_coeff proves c(n,k) = [Xᵏ] ascPochhammer ℤ n by induction on n (generalizing k). The base case uses ascPochhammer ℤ 0 = 1, whose coefficients (1 at k=0, else 0) match c(0,k). The step rewrites ascPochhammer ℤ (n+1) = ascPochhammer ℤ n · (X + C n) and takes the Xᵏ-coefficient: Polynomial.coeff_mul_X handles the X factor by shifting the index (yielding c(n,k−1)) and Polynomial.coeff_mul_C handles the constant n (yielding n·c(n,k)). Their sum is exactly the Pascal recurrence c(n+1,k+1) = n·c(n,k+1) + c(n,k); the k=0 case gives 0 = c(n+1,0), since coeff (p·X) 0 = 0 and n·c(n,0) = 0.",
+    "mathContext": "Extracting the coefficient of $X^k$ from the factor $(X+n)$ reproduces the recurrence $c(n+1,k+1) = n\\,c(n,k+1) + c(n,k)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ascPochhammer_succ_right",
+      "Polynomial.coeff_mul_X",
+      "Polynomial.coeff_mul_C",
+      "Nat.stirlingFirst_succ_succ"
+    ],
+    "prerequisites": [
+      "polynomial coefficient lemmas",
+      "the rising-factorial recurrence in Mathlib"
+    ]
+  },
+  {
+    "id": "ann-row-sum",
+    "proofId": "stirling-first-kind-oq-02",
+    "range": {
+      "startLine": 83,
+      "endLine": 99
+    },
+    "type": "key-step",
+    "title": "The Row Sum as the Value at X = 1",
+    "content": "stirlingFirst_row_sum derives ∑ₖ c(n,k) = n! from the generating identity. Mathlib's ascPochhammer_eval_one gives (ascPochhammer ℤ n).eval 1 = n!. Expanding the evaluation with Polynomial.eval_eq_sum_range writes it as ∑_{k < natDegree+1} coeff k · 1ᵏ; ascPochhammer_natDegree fixes natDegree = n (over the domain ℤ), so the range is range (n+1) and the 1ᵏ factors vanish. Substituting coeff k = (c(n,k):ℤ) from the generating identity yields ∑ₖ (c(n,k):ℤ) = n!, which descends to ℕ via Nat.cast_sum. This is a generating-function proof of the row sum, complementary to the direct induction in oq-01.",
+    "mathContext": "$\\sum_k c(n,k) = \\left.\\sum_k c(n,k)X^k\\right|_{X=1} = (\\text{ascPochhammer}\\,\\mathbb{Z}\\,n)(1) = n!$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ascPochhammer_eval_one",
+      "Polynomial.eval_eq_sum_range",
+      "ascPochhammer_natDegree",
+      "Nat.cast_sum"
+    ],
+    "prerequisites": [
+      "polynomial evaluation as a sum over coefficients",
+      "natDegree of the rising factorial"
+    ]
+  },
+  {
+    "id": "ann-numeric-check",
+    "proofId": "stirling-first-kind-oq-02",
+    "range": {
+      "startLine": 101,
+      "endLine": 107
+    },
+    "type": "observation",
+    "title": "Numeric Sanity Check: Row 4",
+    "content": "stirlingFirst_row_four verifies row 4 of the triangle, (c(4,0),…,c(4,4)) = (0,6,11,6,1), sums to 24 = 4!, a concrete instance of stirlingFirst_row_sum. It is closed by simp unfolding the recursive definition (kernel reduction, no native_decide).",
+    "mathContext": "$0+6+11+6+1 = 24 = 4!$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "concrete evaluation",
+      "Finset.sum_range_succ"
+    ],
+    "prerequisites": [
+      "evaluating the Stirling recurrence"
+    ]
+  }
+]

--- a/src/data/proofs/stirling-first-kind-oq-02/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-02/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "stirling-first-kind-oq-02",
+  "title": "Stirling Numbers of the First Kind, II: the rising-factorial generating identity c(n,k) = [Xᵏ] ascPochhammer ℤ n",
+  "slug": "stirling-first-kind-oq-02",
+  "description": "The defining generating-function identity of the unsigned Stirling numbers of the first kind: c(n,k) is exactly the coefficient of Xᵏ in the rising factorial X(X+1)⋯(X+n−1) = ascPochhammer ℤ n. Neither Mathlib nor the companion row-sum entry (oq-01) records it. As a corollary, evaluating the polynomial at X=1 recovers the row sum ∑ₖ c(n,k) = n! by a generating-function route distinct from oq-01's combinatorial induction.",
+  "meta": {
+    "author": "James Stirling (1730)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StirlingFirstKindOQ02.lean",
+    "tags": [
+      "combinatorics",
+      "stirling-numbers",
+      "permutations",
+      "cycles",
+      "enumerative",
+      "generating-functions",
+      "rising-factorial",
+      "ascPochhammer",
+      "classic"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.stirlingFirst_succ_succ",
+        "description": "Pascal recurrence c(n+1,k+1) = n·c(n,k+1) + c(n,k); reproduced by extracting the Xᵏ-coefficient of the rising-factorial recurrence",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "ascPochhammer_succ_right",
+        "description": "ascPochhammer S (n+1) = ascPochhammer S n · (X + n), the rising-factorial recurrence driving the induction",
+        "module": "Mathlib.RingTheory.Polynomial.Pochhammer"
+      },
+      {
+        "theorem": "Polynomial.coeff_mul_X",
+        "description": "coeff (p·X) (k+1) = coeff p k, the index shift giving the c(n,k) term",
+        "module": "Mathlib.Algebra.Polynomial.Coeff"
+      },
+      {
+        "theorem": "Polynomial.coeff_mul_C",
+        "description": "coeff (p·C a) k = coeff p k · a, giving the n·c(n,k+1) term",
+        "module": "Mathlib.Algebra.Polynomial.Coeff"
+      },
+      {
+        "theorem": "ascPochhammer_eval_one",
+        "description": "(ascPochhammer S n).eval 1 = n!, the value collapsing the coefficient list to the row sum",
+        "module": "Mathlib.RingTheory.Polynomial.Pochhammer"
+      },
+      {
+        "theorem": "Polynomial.eval_eq_sum_range",
+        "description": "p.eval x = ∑_{i<natDegree+1} coeff i · xⁱ, expanding eval 1 as the sum of coefficients",
+        "module": "Mathlib.Algebra.Polynomial.Eval.Degree"
+      },
+      {
+        "theorem": "ascPochhammer_natDegree",
+        "description": "(ascPochhammer S n).natDegree = n over a nontrivial domain, fixing the summation range as range (n+1)",
+        "module": "Mathlib.RingTheory.Polynomial.Pochhammer"
+      }
+    ],
+    "originalContributions": [
+      "stirlingFirst_eq_ascPochhammer_coeff: the generating identity c(n,k) = [Xᵏ] ascPochhammer ℤ n, proved by induction extracting coefficients of ascPochhammer (n+1) = ascPochhammer n · (X + n) — absent from both Mathlib and oq-01",
+      "stirlingFirst_row_sum: a generating-function proof of ∑ₖ c(n,k) = n!, obtained by evaluating the generating polynomial at X=1 (distinct from oq-01's direct combinatorial induction)",
+      "stirlingFirst_row_four: numeric sanity check that row 4 = (0,6,11,6,1) sums to 24 = 4!"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound. No `decide` or `native_decide` is used (so no Lean.ofReduceBool); the numeric check is closed by `simp` unfolding the recursive definition.",
+    "lineCount": 107,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The unsigned Stirling numbers of the first kind c(n,k) count the permutations of n elements that decompose into exactly k disjoint cycles. Historically they enter mathematics not through that count but through a polynomial: in James Stirling's 1730 Methodus Differentialis they are the connection coefficients between the factorial and monomial bases. In unsigned form the statement is that the rising factorial x(x+1)⋯(x+n−1) expands as ∑ₖ c(n,k) xᵏ; the signed version with descending factorial carries the (−1)^{n−k}. This generating identity, not the recurrence, is the conceptual heart of the triangle — the whole row is the coefficient sequence of one polynomial. Mathlib formalizes the rising factorial as ascPochhammer and the Stirling recurrence separately, but never connects them; the companion entry stirling-first-kind-oq-01 proves the row sum by a self-contained induction without the polynomial.",
+    "problemStatement": "Establish the rising-factorial generating identity for the unsigned Stirling numbers of the first kind, c(n,k) = [Xᵏ] (X(X+1)⋯(X+n−1)) = (ascPochhammer ℤ n).coeff k, and use it to recover the row sum ∑ₖ c(n,k) = n!.",
+    "text": "The unsigned Stirling numbers of the first kind are the coefficients of the rising factorial: c(n,k) = [Xᵏ] ascPochhammer ℤ n. Evaluating that polynomial at X=1 sends every Xᵏ to 1 and yields n!, giving the row sum ∑ₖ c(n,k) = n! through the generating function. Both are verified in Lean with no axioms.",
+    "proofStrategy": "1. stirlingFirst_eq_ascPochhammer_coeff: induct on n (generalizing k). Base: ascPochhammer ℤ 0 = 1, whose coefficient at k matches c(0,k). Step: rewrite ascPochhammer ℤ (n+1) = ascPochhammer ℤ n · (X + C n) and take the Xᵏ-coefficient. Polynomial.coeff_mul_X handles the X factor (shifting the index, giving c(n,k−1)) and Polynomial.coeff_mul_C handles the constant n (giving n·c(n,k)); together this is the Pascal recurrence c(n+1,k+1) = n·c(n,k+1) + c(n,k), and the k=0 case gives c(n+1,0) = 0 (since coeff (p·X) 0 = 0 and n·c(n,0) = 0).\n2. stirlingFirst_row_sum: from ascPochhammer_eval_one, (ascPochhammer ℤ n).eval 1 = n!. Expand the left side by eval_eq_sum_range over range (natDegree+1); ascPochhammer_natDegree fixes the range as range (n+1) and the 1ⁱ factors drop. Replacing each coefficient by c(n,k) via theorem 1 gives ∑ₖ (c(n,k):ℤ) = n!, which descends to ℕ by Nat.cast_sum.\n3. stirlingFirst_row_four: simp unfolds the recursive definition to check 0+6+11+6+1 = 24.",
+    "keyInsights": [
+      "**The row is a polynomial's coefficient list**: c(n,k) = [Xᵏ] X(X+1)⋯(X+n−1). This single identity is the structural definition of the first-kind triangle; the recurrence and every closed value are downstream of it.",
+      "**Coefficient extraction IS the recurrence**: taking the Xᵏ-coefficient of the product ascPochhammer n · (X + n) splits into the X-shift term c(n,k−1) and the constant term n·c(n,k) — literally Mathlib's Pascal recurrence. No new combinatorial input is needed beyond ascPochhammer_succ_right.",
+      "**Evaluation at X=1 is summation**: setting X=1 turns the generating function into the row sum, since 1ᵏ = 1 for all k. Because (ascPochhammer ℤ n).eval 1 = n!, the row sum drops out as n! — a proof by generating function, complementary to oq-01's bespoke induction.",
+      "**Filling a real gap between Mathlib modules**: Mathlib has both the rising factorial (ascPochhammer) and the Stirling numbers, but no theorem relating them; this entry supplies the bridge that the classical theory takes as the definition."
+    ],
+    "prerequisites": [
+      "Stirling numbers of the first kind and the cycle decomposition of permutations",
+      "The rising factorial / Pochhammer polynomial (ascPochhammer)",
+      "Polynomial coefficients, degree, and evaluation",
+      "Induction on the natural numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "File-level docstring stating the generating identity c(n,k) = [Xᵏ] ascPochhammer ℤ n, its place as the defining property of the first-kind numbers, and the X=1 corollary recovering the row sum. Notes the gap vs Mathlib and vs the companion oq-01. Imports Mathlib and opens Nat and Polynomial.",
+      "mathContext": "X(X+1)⋯(X+n−1) = ∑ₖ c(n,k) Xᵏ; the rising factorial is Mathlib's ascPochhammer ℤ n."
+    },
+    {
+      "id": "generating-identity",
+      "title": "The Generating Identity c(n,k) = [Xᵏ] ascPochhammer ℤ n",
+      "startLine": 48,
+      "endLine": 81,
+      "summary": "stirlingFirst_eq_ascPochhammer_coeff: induction on n (generalizing k). Rewriting ascPochhammer ℤ (n+1) = ascPochhammer ℤ n · (X + C n) and taking the Xᵏ-coefficient (coeff_mul_X, coeff_mul_C) reproduces the Stirling recurrence c(n+1,k+1) = n·c(n,k+1) + c(n,k); the k=0 case gives c(n+1,0)=0.",
+      "mathContext": "Coefficient extraction from the factor (X+n) is exactly the Pascal recurrence for the first-kind numbers."
+    },
+    {
+      "id": "row-sum",
+      "title": "The Row Sum via Evaluation at X = 1",
+      "startLine": 83,
+      "endLine": 99,
+      "summary": "stirlingFirst_row_sum: from ascPochhammer_eval_one ((ascPochhammer ℤ n).eval 1 = n!), expand eval as ∑_{k<natDegree+1} coeff k · 1ᵏ (eval_eq_sum_range), fix the range to range (n+1) via ascPochhammer_natDegree, replace each coefficient by c(n,k) using theorem 1, and descend ∑ₖ (c(n,k):ℤ) = n! to ℕ via Nat.cast_sum.",
+      "mathContext": "∑ₖ c(n,k) = (∑ₖ c(n,k) Xᵏ)|_{X=1} = (ascPochhammer ℤ n)(1) = n!."
+    },
+    {
+      "id": "numeric-check",
+      "title": "Numeric Sanity Check",
+      "startLine": 101,
+      "endLine": 107,
+      "summary": "stirlingFirst_row_four: row 4 is (0,6,11,6,1), summing to 24 = 4!. Closed by simp unfolding the recursive definition.",
+      "mathContext": "Concrete instance of stirlingFirst_row_sum at n = 4."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stirling, James",
+      "title": "Methodus Differentialis",
+      "year": "1730",
+      "note": "Introduces the first-kind numbers as connection coefficients between the factorial and monomial bases — i.e. via the generating identity proved here"
+    },
+    {
+      "authors": "Graham, Knuth, Patashnik",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "note": "Chapter 6: the rising-factorial generating function xⁿ̄ = ∑ₖ [n;k] xᵏ for the unsigned first-kind numbers, and the row sum as its value at x=1"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "stirling-first-kind-oq-01",
+      "relationship": "extends",
+      "description": "Companion entry: oq-01 proves the row sum ∑ₖ c(n,k) = n! by a direct combinatorial induction; this entry proves the underlying generating identity and re-derives the same row sum from it by evaluating at X=1"
+    },
+    {
+      "targetId": "stirling-second-kind-oq-01",
+      "relationship": "related",
+      "description": "Companion second-kind entry (the column closed form S(n,2) = 2^(n-1)−1); the second-kind numbers are connection coefficients in the opposite direction (powers in terms of falling factorials)"
+    }
+  ],
+  "conclusion": {
+    "summary": "The unsigned Stirling numbers of the first kind are exactly the coefficients of the rising factorial: c(n,k) = [Xᵏ] ascPochhammer ℤ n (stirlingFirst_eq_ascPochhammer_coeff). This is their defining generating identity, recorded in neither Mathlib nor the companion row-sum entry. Evaluating the polynomial at X=1 recovers the row sum ∑ₖ c(n,k) = n! (stirlingFirst_row_sum) by a generating-function route distinct from oq-01. Both results are verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies the bridge between two existing Mathlib developments — the rising factorial (ascPochhammer) and the Stirling numbers — as a directly citable, machine-checked identity, and demonstrates the row sum as a one-line consequence of it.",
+    "openQuestions": [
+      "Can the signed identity x(x−1)⋯(x−n+1) = ∑ₖ (−1)^{n−k} c(n,k) xᵏ be formalized via descPochhammer in the same coefficient-extraction style?",
+      "Does the generating identity give a clean Lean proof of the alternating row sum ∑ₖ (−1)ᵏ c(n,k) = 0 for n ≥ 2 (the value of the polynomial at X = −1)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat",
+      "Polynomial"
+    ],
+    "namespace": "StirlingFirstKindOQ02",
+    "lineCount": 107,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/StirlingFirstKindOQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up to the shipped **stirling-first-kind-oq-01** (row sum, #27089). This entry supplies the **defining generating-function identity** of the unsigned Stirling numbers of the first kind — recorded in **neither Mathlib nor oq-01**:

> `c(n,k) = [Xᵏ] X(X+1)⋯(X+n−1) = (ascPochhammer ℤ n).coeff k`

The rising factorial is Mathlib's `ascPochhammer`, but Mathlib has **no theorem relating it to `Nat.stirlingFirst`**. This is the structural definition of the first-kind triangle: the whole row is the coefficient list of one polynomial.

## Theorems (3, 0 sorries)

1. **`stirlingFirst_eq_ascPochhammer_coeff`** — the generating identity. Induction on `n`: extracting the `Xᵏ`-coefficient of `ascPochhammer ℤ (n+1) = ascPochhammer ℤ n · (X + n)` via `coeff_mul_X` (index shift → `c(n,k−1)`) and `coeff_mul_C` (constant → `n·c(n,k)`) reproduces *exactly* Mathlib's Pascal recurrence `c(n+1,k+1) = n·c(n,k+1) + c(n,k)`.
2. **`stirlingFirst_row_sum`** — `∑ₖ c(n,k) = n!`, derived from (1) by evaluating at `X=1`: `(ascPochhammer ℤ n).eval 1 = n!` (`ascPochhammer_eval_one`), expanded over `range (natDegree+1) = range (n+1)` (`eval_eq_sum_range` + `ascPochhammer_natDegree`). This is a **generating-function proof** of the row sum, distinct from oq-01's combinatorial induction.
3. **`stirlingFirst_row_four`** — numeric check: row 4 = (0,6,11,6,1) sums to 24 = 4!.

## Verification

Verified **0-axiom**: all three theorems depend only on `[propext, Classical.choice, Quot.sound]` (confirmed via `#print axioms`). No `Lean.ofReduceBool`, no `native_decide`, no `sorry`.

Relationship to oq-01: `extends` — oq-01 proves the row sum directly; this proves the underlying generating identity and re-derives the same `n!` from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)