### PR TITLE
Fix: re-badge triangle-inequality-oq-05 original→mathlib (Tier B Mathlib wrapper)

### DIFF
--- a/src/data/proofs/triangle-inequality-oq-05/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-05/meta.json
@@ -18,7 +18,8 @@
       "betweenness"
     ],
     "proofRepoPath": "Proofs/TriangleInequalityOQ05.lean",
-    "badge": "original",
+    "badge": "mathlib",
+    "packagingNote": "Tier B Mathlib wrapper: all five theorems are one-line re-exports of named Mathlib lemmas (sameRay_iff_norm_add, not_sameRay_iff_norm_add_lt, eq_of_norm_eq_of_norm_add_eq, dist_add_dist_eq_iff) plus a trivial two-rewrite glue (dist_add_dist_eq_iff + mem_segment_iff_wbtw). The original content is packaging both the vectorial (SameRay) and metric (Wbtw/segment) forms together with three worked instantiations on ℝ and EuclideanSpace ℝ (Fin 2). Status stays verified (genuinely 0-sorry / 0-axiom); only the badge tier is corrected from original to mathlib.",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 101,


### PR DESCRIPTION
## Fix

Re-badge `triangle-inequality-oq-05` from `original` to `mathlib`. Status stays `verified` (genuinely 0-sorry / 0-axiom) — only the badge tier is corrected.

## Evidence

**Before**: `badge: original` — overclaims original formalization.
**After**: `badge: mathlib` + `packagingNote` clarifying the wrapper nature.

All five theorems are one-line re-exports of named Mathlib lemmas:

| Theorem | Body | Mathlib source |
|---|---|---|
| `norm_add_eq_iff_sameRay` | `sameRay_iff_norm_add.symm` | `sameRay_iff_norm_add` |
| `norm_add_lt_iff_not_sameRay` | `not_sameRay_iff_norm_add_lt.symm` | `not_sameRay_iff_norm_add_lt` |
| `eq_of_norm_eq_of_norm_add_eq` | `_root_.eq_of_norm_eq_of_norm_add_eq h₁ h₂` | same-name lemma |
| `dist_add_dist_eq_iff_wbtw` | `dist_add_dist_eq_iff` | `dist_add_dist_eq_iff` |
| `dist_add_dist_eq_iff_mem_segment` | 2-rewrite glue | `dist_add_dist_eq_iff` + `mem_segment_iff_wbtw` |

Remaining content is three worked `example`s on ℝ / EuclideanSpace. The prose and `mathlibDependencies` were already honest; only `badge` overclaimed.

Same pattern as banach-fixed-point-oq-01 (#27090), legendre-factorial-formula-oq-01 (#27104), frobenius-endomorphism-oq-01 (#27108), jacobi-symbol-oq-01 (#27111).

Closes #27113

---
Automated fix by lean-mechanic agent.