### PR TITLE
Fix: re-badge denumerability-rationals-oq-06 verified→mathlib (Tier B Mathlib wrapper)

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-06/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-06/meta.json
@@ -15,7 +15,8 @@
       "aleph-null",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
+    "packagingNote": "Tier B Mathlib wrapper: every theorem is a one-line application of Polynomial.cardinalMk_eq_max (#(R[X]) = max #R ℵ₀) collapsed against #ℚ = #ℤ = ℵ₀ via max_self. The result #(ℚ[X]) = ℵ₀ is supplied directly by Mathlib; this entry packages it as a citable gallery object (with the ℤ[X] companion and an extracted bijection ℕ ≃ ℚ[X]). Status remains verified (0 sorries, 0 axioms); the badge is mathlib because no genuine gap, glue, induction, or worked example is contributed beyond the single Mathlib lemma.",
     "sorries": 0,
     "dateAdded": "2026-06-19",
     "mathlib_version": "4.26.0",


### PR DESCRIPTION
## Fix

Re-badge `denumerability-rationals-oq-06` from `verified` → `mathlib`. Meta-only; status stays `verified` (0 sorries, 0 axioms).

## Evidence

**Before**: `badge: verified` — claims original verification.
**After**: `badge: mathlib` + `packagingNote` — accurately marks a Tier B Mathlib wrapper.

Every theorem is a one-line application of a single Mathlib lemma:

| Theorem | Proof |
|---|---|
| `mk_rat` | `mk_eq_aleph0 ℚ` |
| `cardinalMk_polynomial_rat` | `rw [Polynomial.cardinalMk_eq_max, mk_rat, max_self]` |
| `cardinalMk_polynomial_int` | `rw [Polynomial.cardinalMk_eq_max, mk_int, max_self]` |
| `cardinalMk_polynomial_rat_eq_int` | trivial composition |
| `nonempty_nat_equiv_polynomial_rat` | `Cardinal.eq.mp (by rw …)` |

The result `#(ℚ[X]) = ℵ₀` is supplied directly by `Polynomial.cardinalMk_eq_max` + `max_self`; no gap, glue, induction, or worked example is contributed. Prose and `mathlibDependencies` already honestly credit Mathlib; only the badge overclaimed. Same pattern as the previously re-badged banach/legendre/frobenius/jacobi/triangle wrappers.

No Lean source change. JSON validated.

Closes #27115

---
Automated fix by lean-mechanic agent.