### PR TITLE
Fix: re-badge frobenius-number-oq-04 verified→mathlib (Tier B Mathlib wrapper) (#27118)

### DIFF
--- a/src/data/proofs/frobenius-number-oq-04/meta.json
+++ b/src/data/proofs/frobenius-number-oq-04/meta.json
@@ -16,7 +16,8 @@
       "additive-submonoid",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
+    "packagingNote": "Tier B Mathlib wrapper. Every theorem is a one-line re-export, trivial unpacking, or numeric specialization of existing named Mathlib results — principally `frobeniusNumber_pair` (the two-coin Sylvester–Frobenius theorem) and `AddSubmonoid.mem_closure_pair` (closure-membership as a ℕ-linear combination), split via `frobeniusNumber_iff`. The mathematical substance lives entirely in Mathlib; this entry restates it on the canonical `FrobeniusNumber`/`AddSubmonoid.closure` footing and bridges back to the elementary `a*m + b*n` form. Badge is `mathlib` (faithful re-export), not `verified`/original — there is no novel derivation. Status remains `verified` (0 sorries, 0 axioms, builds clean).",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 122,


### PR DESCRIPTION
## Summary

Resolves auditor issue #27118 (MEDIUM, gallery-integrity badge overclaim).

`frobenius-number-oq-04` ("Sylvester–Frobenius via Mathlib's Canonical Predicate / Chicken McNugget") is a **Tier B Mathlib wrapper**. Every theorem in `Proofs/FrobeniusNumberOQ04.lean` is a one-line re-export, trivial unpacking, or numeric specialization of existing named Mathlib results:

| Theorem | Substance |
|---|---|
| `sylvester_frobenius_canonical` | literal `frobeniusNumber_pair` re-export |
| `frobenius_not_in_closure` / `above_frobenius_in_closure` | `frobeniusNumber_iff` unpacking |
| `mem_closure_pair_iff` | `AddSubmonoid.mem_closure_pair` + `smul_eq_mul` bridge |
| `frobenius_not_representable` / `above_frobenius_representable` | 2-line composition of the above |
| `mcnugget_*` / `seven_*` | g(3,5)=7 numeric specialization |

The file's own prose already credits Mathlib honestly; only the rendered badge overclaimed novelty.

## Change (meta-only)

- `badge`: `verified` → `mathlib`
- Added `packagingNote` crediting `frobeniusNumber_pair` / `AddSubmonoid.mem_closure_pair`
- `mathlibDependencies` already lists the underlying results

**No Lean changes.** Proof is correct and builds; `status` stays `verified` (0 sorries, 0 axioms). Credibility/badge correction only.

Consistent with prior wrapper-badge corrections: banach (#27090), legendre (#27104), frobenius-endomorphism (#27108), jacobi (#27111), triangle (#27114), denumerability (#27116).

Closes #27118

🤖 Generated with [Claude Code](https://claude.com/claude-code)