### PR TITLE
research(euler-identity-oq-05): four-square multiplicative closure (IsSumFourSq monoid)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2386,6 +2386,7 @@ import Proofs.EulerIdentityOQ01OQ01
 import Proofs.EulerIdentityOQ01OQ01OQ01
 import Proofs.EulerIdentityOQ01OQ01OQ01OQ01
 import Proofs.EulerIdentityOQ01OQ04
+import Proofs.EulerIdentityOQ05
 import Proofs.EulerPolyhedralFormula
 import Proofs.EulerPolyhedralFormulaOQ01OQ02
 import Proofs.EulerPolyhedralOQ01

--- a/proofs/Proofs/EulerIdentityOQ05.lean
+++ b/proofs/Proofs/EulerIdentityOQ05.lean
@@ -1,0 +1,145 @@
+import Mathlib.NumberTheory.SumFourSquares
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Tactic
+
+/-
+# Euler's Four-Square Identity and Multiplicative Closure of Sums of Four Squares
+
+## What This Proves
+
+Euler's four-square identity expresses the product of two sums of four squares as
+*itself* a sum of four squares, via explicit bilinear forms:
+
+  (x₁² + x₂² + x₃² + x₄²)(y₁² + y₂² + y₃² + y₄²)
+    = (x₁y₁ − x₂y₂ − x₃y₃ − x₄y₄)²
+    + (x₁y₂ + x₂y₁ + x₃y₄ − x₄y₃)²
+    + (x₁y₃ − x₂y₄ + x₃y₁ + x₄y₂)²
+    + (x₁y₄ + x₂y₃ − x₃y₂ + x₄y₁)².
+
+This is the algebraic engine behind Lagrange's four-square theorem: it reduces the
+theorem to the prime case, because the identity shows that the set of sums of four
+squares is closed under multiplication.
+
+## What Mathlib Already Has — and the Gap This Fills
+
+Mathlib proves the bare polynomial identity (`euler_four_squares`,
+`sum_four_sq_mul_sum_four_sq`, both discharged by `ring`) and Lagrange's theorem
+(`Nat.sum_four_squares`). For TWO squares it additionally packages the
+*multiplicative closure* as `sq_add_sq_mul`:
+
+  a = x²+y² → b = u²+v² → ∃ r s, a*b = r²+s².
+
+But there is **no four-square analogue** of that closure lemma. This file supplies it:
+a predicate `IsSumFourSq` together with the proof that it is closed under
+multiplication (and that it contains `0` and `1`), making the "sums of four squares
+form a multiplicative submonoid" structure explicit over any commutative ring — the
+conceptual content Euler's identity provides, beyond the raw `ring` equation.
+
+We also record the embedding of two-square sums into four-square sums, and concrete
+worked examples with explicit witnesses.
+
+## Status
+- [x] Complete proof (0 sorries, 0 axioms)
+- [x] Uses Mathlib for the underlying bilinear identity
+- [x] Proves an original closure corollary absent from Mathlib
+- [x] Pedagogical / worked examples
+-/
+
+namespace EulerIdentityOQ05
+
+variable {R : Type*} [CommRing R]
+
+/-! ## The bilinear identity (self-contained restatement) -/
+
+/-- Euler's four-square identity, restated and discharged by `ring`. The product of two
+sums of four squares equals a sum of four explicit bilinear squares. -/
+theorem four_square_identity (x₁ x₂ x₃ x₄ y₁ y₂ y₃ y₄ : R) :
+    (x₁ ^ 2 + x₂ ^ 2 + x₃ ^ 2 + x₄ ^ 2) * (y₁ ^ 2 + y₂ ^ 2 + y₃ ^ 2 + y₄ ^ 2) =
+      (x₁ * y₁ - x₂ * y₂ - x₃ * y₃ - x₄ * y₄) ^ 2 +
+        (x₁ * y₂ + x₂ * y₁ + x₃ * y₄ - x₄ * y₃) ^ 2 +
+        (x₁ * y₃ - x₂ * y₄ + x₃ * y₁ + x₄ * y₂) ^ 2 +
+        (x₁ * y₄ + x₂ * y₃ - x₃ * y₂ + x₄ * y₁) ^ 2 := by
+  ring
+
+/-! ## The predicate and its multiplicative-monoid structure -/
+
+/-- `IsSumFourSq a` means `a` is a sum of four squares in `R`. -/
+def IsSumFourSq (a : R) : Prop :=
+  ∃ x y z w : R, a = x ^ 2 + y ^ 2 + z ^ 2 + w ^ 2
+
+/-- `0` is a sum of four squares. -/
+theorem isSumFourSq_zero : IsSumFourSq (0 : R) :=
+  ⟨0, 0, 0, 0, by ring⟩
+
+/-- `1` is a sum of four squares. -/
+theorem isSumFourSq_one : IsSumFourSq (1 : R) :=
+  ⟨1, 0, 0, 0, by ring⟩
+
+/-- Every square is a sum of four squares. -/
+theorem isSumFourSq_sq (a : R) : IsSumFourSq (a ^ 2) :=
+  ⟨a, 0, 0, 0, by ring⟩
+
+/-- **Multiplicative closure** (the gap Mathlib leaves): the product of two sums of
+four squares is a sum of four squares. The witnesses come directly from Euler's
+identity. This is the four-square analogue of Mathlib's two-square `sq_add_sq_mul`. -/
+theorem IsSumFourSq.mul {a b : R} (ha : IsSumFourSq a) (hb : IsSumFourSq b) :
+    IsSumFourSq (a * b) := by
+  obtain ⟨x₁, x₂, x₃, x₄, rfl⟩ := ha
+  obtain ⟨y₁, y₂, y₃, y₄, rfl⟩ := hb
+  exact ⟨x₁ * y₁ - x₂ * y₂ - x₃ * y₃ - x₄ * y₄,
+        x₁ * y₂ + x₂ * y₁ + x₃ * y₄ - x₄ * y₃,
+        x₁ * y₃ - x₂ * y₄ + x₃ * y₁ + x₄ * y₂,
+        x₁ * y₄ + x₂ * y₃ - x₃ * y₂ + x₄ * y₁,
+        four_square_identity x₁ x₂ x₃ x₄ y₁ y₂ y₃ y₄⟩
+
+/-- A finite product of sums of four squares is a sum of four squares. -/
+theorem isSumFourSq_prod {ι : Type*} (s : Finset ι) (f : ι → R)
+    (hf : ∀ i ∈ s, IsSumFourSq (f i)) : IsSumFourSq (∏ i ∈ s, f i) := by
+  classical
+  induction s using Finset.induction with
+  | empty => simpa using isSumFourSq_one
+  | insert a s ha ih =>
+    rw [Finset.prod_insert ha]
+    exact (hf a (Finset.mem_insert_self a s)).mul
+      (ih fun i hi => hf i (Finset.mem_insert_of_mem hi))
+
+/-- A power of a sum of four squares is a sum of four squares. -/
+theorem IsSumFourSq.pow {a : R} (ha : IsSumFourSq a) (n : ℕ) : IsSumFourSq (a ^ n) := by
+  induction n with
+  | zero => simpa using isSumFourSq_one
+  | succ k ih => rw [pow_succ]; exact ih.mul ha
+
+/-! ## Relation to sums of two squares -/
+
+/-- A sum of two squares is in particular a sum of four squares (pad with two zeros). -/
+theorem isSumFourSq_of_isSumTwoSq {a : R} (h : ∃ x y : R, a = x ^ 2 + y ^ 2) :
+    IsSumFourSq a := by
+  obtain ⟨x, y, rfl⟩ := h
+  exact ⟨x, y, 0, 0, by ring⟩
+
+/-! ## Worked numeric examples over ℤ -/
+
+/-- `3 = 1² + 1² + 1² + 0²` is a sum of four squares. -/
+example : IsSumFourSq (3 : ℤ) := ⟨1, 1, 1, 0, by ring⟩
+
+/-- `7 = 2² + 1² + 1² + 1²` is a sum of four squares. -/
+example : IsSumFourSq (7 : ℤ) := ⟨2, 1, 1, 1, by ring⟩
+
+/-- The product `3 * 7 = 21` is a sum of four squares, with witnesses obtained
+mechanically from the closure theorem (no guessing of the representation). -/
+example : IsSumFourSq (21 : ℤ) := by
+  have h : (21 : ℤ) = 3 * 7 := by norm_num
+  rw [h]
+  exact IsSumFourSq.mul (⟨1, 1, 1, 0, by ring⟩ : IsSumFourSq (3 : ℤ))
+    (⟨2, 1, 1, 1, by ring⟩ : IsSumFourSq (7 : ℤ))
+
+/-- Sanity check: the explicit witnesses produced by Euler's identity for `3 * 7`
+indeed sum to `21`. Here `x = (1,1,1,0)`, `y = (2,1,1,1)`, giving
+`(1·2−1·1−1·1−0·1)² + (1·1+1·2+1·1−0·1)² + (1·1−1·1+1·2+0·1)² + (1·1+1·1−1·1+0·2)²
+ = 0² + 4² + 2² + 1² = 21`. -/
+example : ((1 * 2 - 1 * 1 - 1 * 1 - (0 : ℤ) * 1) ^ 2 +
+    (1 * 1 + 1 * 2 + 1 * 1 - 0 * 1) ^ 2 +
+    (1 * 1 - 1 * 1 + 1 * 2 + 0 * 1) ^ 2 +
+    (1 * 1 + 1 * 1 - 1 * 1 + 0 * 2) ^ 2) = 21 := by norm_num
+
+end EulerIdentityOQ05

--- a/src/data/proofs/euler-identity-oq-05/annotations.json
+++ b/src/data/proofs/euler-identity-oq-05/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-four-square-identity",
+    "proofId": "euler-identity-oq-05",
+    "range": {
+      "startLine": 56,
+      "endLine": 64
+    },
+    "type": "theorem",
+    "title": "Euler's Four-Square Identity (four_square_identity)",
+    "content": "The product of two sums of four squares equals a sum of four explicit bilinear squares. The four right-hand forms z₁ = x₁y₁−x₂y₂−x₃y₃−x₄y₄, z₂ = x₁y₂+x₂y₁+x₃y₄−x₄y₃, z₃ = x₁y₃−x₂y₄+x₃y₁+x₄y₂, z₄ = x₁y₄+x₂y₃−x₃y₂+x₄y₁ are exactly the components of the Hamilton quaternion product, so the identity is the multiplicativity N(q)N(q′)=N(qq′) of the quaternion norm N(x₁+x₂i+x₃j+x₄k)=x₁²+x₂²+x₃²+x₄². The statement is restated over an arbitrary commutative ring and discharged by ring, keeping the file self-contained (Mathlib's euler_four_squares / sum_four_sq_mul_sum_four_sq prove the same identity).",
+    "mathContext": "$(x_1^2+x_2^2+x_3^2+x_4^2)(y_1^2+y_2^2+y_3^2+y_4^2)=z_1^2+z_2^2+z_3^2+z_4^2$.",
+    "prerequisites": [
+      "Polynomial identities over a commutative ring and the ring tactic",
+      "The Hamilton quaternions and their norm form"
+    ],
+    "relatedConcepts": [
+      "Euler's four-square identity",
+      "quaternion norm multiplicativity",
+      "Brahmagupta–Fibonacci two-square identity",
+      "Degen eight-square identity",
+      "Hurwitz's 1-2-4-8 theorem"
+    ],
+    "significance": "The algebraic certificate behind Lagrange's four-square theorem: it shows that the product of two sums of four squares is again such, reducing the theorem to the prime case."
+  },
+  {
+    "id": "ann-issumfoursq-mul",
+    "proofId": "euler-identity-oq-05",
+    "range": {
+      "startLine": 66,
+      "endLine": 94
+    },
+    "type": "theorem",
+    "title": "Multiplicative Closure of Sums of Four Squares (IsSumFourSq.mul)",
+    "content": "IsSumFourSq a is defined as ∃ x y z w, a = x²+y²+z²+w² over any commutative ring. IsSumFourSq.mul proves that the product of two sums of four squares is a sum of four squares: it destructures the witnesses of a and b and returns the four bilinear forms of Euler's identity as the witnesses for a·b, so the closure is witness-explicit rather than merely existential. This is the faithful four-square analogue of Mathlib's two-square closure sq_add_sq_mul — Mathlib packages the closure for two squares but provides no four-square counterpart, which is the gap this entry fills.",
+    "mathContext": "$\\mathrm{IsSumFourSq}\\,a \\wedge \\mathrm{IsSumFourSq}\\,b \\Rightarrow \\mathrm{IsSumFourSq}\\,(a\\cdot b)$.",
+    "prerequisites": [
+      "Euler's four-square identity (four_square_identity)",
+      "Existential witnesses and anonymous constructor notation in Lean"
+    ],
+    "relatedConcepts": [
+      "multiplicative closure",
+      "sums of four squares",
+      "Lagrange four-square theorem",
+      "norm-multiplicative sets"
+    ],
+    "significance": "The mathematically load-bearing statement of the entry: the sums of four squares are closed under multiplication, the exact step by which Euler reduced Lagrange's theorem to primes — and the four-square sibling of Mathlib's two-square sq_add_sq_mul."
+  },
+  {
+    "id": "ann-monoid-structure",
+    "proofId": "euler-identity-oq-05",
+    "range": {
+      "startLine": 96,
+      "endLine": 113
+    },
+    "type": "theorem",
+    "title": "Submonoid Structure: Products, Powers, and Generators",
+    "content": "From IsSumFourSq.mul together with isSumFourSq_one the entry derives that sums of four squares are closed under finite products (isSumFourSq_prod, by Finset.induction: empty ↦ 1, insert ↦ mul) and under powers (IsSumFourSq.pow, by induction on the exponent). isSumFourSq_zero, isSumFourSq_one, and isSumFourSq_sq record that 0, 1, and every square are sums of four squares. Together these exhibit the sums of four squares as a multiplicative submonoid containing every square.",
+    "mathContext": "Closure under $\\prod_{i\\in s} f_i$ and $a^n$; $0,1,a^2 \\in \\mathrm{IsSumFourSq}$.",
+    "prerequisites": [
+      "Finset.induction and Finset.prod_insert",
+      "Induction on natural-number exponents and pow_succ"
+    ],
+    "relatedConcepts": [
+      "multiplicative submonoid",
+      "finite products",
+      "closure properties"
+    ],
+    "significance": "Packages the closure as genuine algebraic structure: the sums of four squares form a multiplicative submonoid, so any finite product of them — e.g. a product of primes each a sum of four squares — is again a sum of four squares."
+  },
+  {
+    "id": "ann-embedding-and-examples",
+    "proofId": "euler-identity-oq-05",
+    "range": {
+      "startLine": 115,
+      "endLine": 143
+    },
+    "type": "example",
+    "title": "Two-Square Embedding and Worked Closure Examples",
+    "content": "isSumFourSq_of_isSumTwoSq embeds a sum of two squares into the four-square world by padding with two zeros. The worked examples certify 3 = 1²+1²+1²+0² and 7 = 2²+1²+1²+1², then obtain a four-square representation of 21 = 3·7 by applying IsSumFourSq.mul — the witnesses are produced mechanically by the closure theorem, not guessed — and a final numeric check confirms the resulting bilinear forms (0,4,2,1) indeed satisfy 0²+4²+2²+1² = 21.",
+    "mathContext": "$21 = 3\\cdot 7 = 0^2+4^2+2^2+1^2$ via IsSumFourSq.mul.",
+    "prerequisites": [
+      "The closure theorem IsSumFourSq.mul",
+      "norm_num for numeric verification"
+    ],
+    "relatedConcepts": [
+      "constructive existence",
+      "two-square vs four-square sums",
+      "worked representation"
+    ],
+    "significance": "Demonstrates the closure constructively: products of sums of four squares get an explicit representation with no search, illustrating the constructive nature of Euler's reduction."
+  }
+]

--- a/src/data/proofs/euler-identity-oq-05/meta.json
+++ b/src/data/proofs/euler-identity-oq-05/meta.json
@@ -1,0 +1,88 @@
+{
+  "id": "euler-identity-oq-05",
+  "title": "Euler Identity OQ-05: Four-Square Identity and Multiplicative Closure",
+  "slug": "euler-identity-oq-05",
+  "description": "Euler's four-square identity and the multiplicative closure of sums of four squares. The identity (x₁²+x₂²+x₃²+x₄²)(y₁²+y₂²+y₃²+y₄²) = (x₁y₁−x₂y₂−x₃y₃−x₄y₄)² + (x₁y₂+x₂y₁+x₃y₄−x₄y₃)² + (x₁y₃−x₂y₄+x₃y₁+x₄y₂)² + (x₁y₄+x₂y₃−x₃y₂+x₄y₁)² expresses the product of two sums of four squares as itself a sum of four squares — the algebraic engine that reduces Lagrange's four-square theorem to the prime case. Mathlib proves the bare polynomial identity (euler_four_squares, sum_four_sq_mul_sum_four_sq, both by ring) and Lagrange's theorem (Nat.sum_four_squares), and for TWO squares it additionally packages the multiplicative closure as sq_add_sq_mul; but it provides no four-square analogue of that closure lemma. This entry supplies it: a predicate IsSumFourSq a := ∃ x y z w, a = x²+y²+z²+w² over an arbitrary commutative ring, together with the proof that the sums of four squares are closed under multiplication (IsSumFourSq.mul, witnesses read straight off Euler's identity), contain 0 and 1 and every square, and are closed under finite products and powers — i.e. they form a multiplicative submonoid. It also records the embedding of two-square sums into four-square sums and concrete worked examples (3 = 1²+1²+1², 7 = 2²+1²+1²+1², and 21 = 3·7 with witnesses produced mechanically by the closure theorem). The conceptual content Euler's identity provides — multiplicative structure — is thereby made explicit beyond the raw ring equation.",
+  "leanFile": "Proofs/EulerIdentityOQ05.lean",
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_four-square_identity",
+    "date": "1748",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerIdentityOQ05.lean",
+    "tags": [
+      "number-theory",
+      "algebra",
+      "four-square-identity",
+      "sums-of-squares",
+      "lagrange-four-square",
+      "ring-identity",
+      "quaternions",
+      "multiplicative-closure"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "relatedProblems": [
+      {
+        "id": "euler-identity",
+        "relationship": "Parent family entry (the analytic Euler identity e^(iπ)+1=0). This OQ-05 concerns a different theorem also due to Euler — the four-square identity — and develops its algebraic consequence: that sums of four squares are closed under multiplication."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 145,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational propext / Classical.choice / Quot.sound may appear (no Lean.ofReduceBool, no native_decide; verifiable with #print axioms EulerIdentityOQ05.IsSumFourSq.mul). The result is unconditional over any commutative ring. Mathlib supplies the bilinear identity (euler_four_squares / sum_four_sq_mul_sum_four_sq, both ring identities) and Lagrange's four-square theorem; the original in-file content is the four-square sum-of-squares PREDICATE IsSumFourSq and its multiplicative-monoid structure — closure under multiplication (the four-square analogue of Mathlib's two-square sq_add_sq_mul, which has no four-square counterpart), under finite products and powers, membership of 0/1/squares, and the two-square embedding — together with the worked closure examples over ℤ. The identity itself is restated and re-discharged by ring so the file is self-contained.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The identity that the product of two sums of four squares is again a sum of four squares was discovered by Leonhard Euler in 1748, in a letter to Goldbach — predating Lagrange's four-square theorem (1770) and providing its crucial multiplicative step. Euler could not himself prove that every positive integer is a sum of four squares, but his identity reduced the problem to primes: if every prime is a sum of four squares, then so is every product of primes, hence every integer. Lagrange completed the argument; Euler later simplified it. In modern language the identity is the multiplicativity of the norm form on the Hamilton quaternions ℍ: writing q = x₁ + x₂i + x₃j + x₄k, one has N(q)N(q') = N(qq') where N(q) = x₁²+x₂²+x₃²+x₄², and the four bilinear forms are exactly the components of the quaternion product. The sign conventions in the identity are precisely those of quaternion multiplication. The analogous two-square identity (Brahmagupta–Fibonacci) reflects the multiplicativity of the complex modulus, and Degen's eight-square identity that of the octonion norm; by Hurwitz's theorem these are the only dimensions (1, 2, 4, 8) in which such an identity exists.",
+    "problemStatement": "Establish Euler's four-square identity\n\n$$(x_1^2+x_2^2+x_3^2+x_4^2)(y_1^2+y_2^2+y_3^2+y_4^2) = z_1^2 + z_2^2 + z_3^2 + z_4^2,$$\n\nwhere\n\n$$\\begin{aligned} z_1 &= x_1y_1 - x_2y_2 - x_3y_3 - x_4y_4, & z_2 &= x_1y_2 + x_2y_1 + x_3y_4 - x_4y_3,\\\\ z_3 &= x_1y_3 - x_2y_4 + x_3y_1 + x_4y_2, & z_4 &= x_1y_4 + x_2y_3 - x_3y_2 + x_4y_1,\\end{aligned}$$\n\nand deduce its structural meaning: over any commutative ring the set of sums of four squares is closed under multiplication (and contains 0, 1, and every square), so it forms a multiplicative submonoid — the property that powers Lagrange's reduction of the four-square theorem to primes.",
+    "text": "Mathlib already proves the bare polynomial identity (euler_four_squares and sum_four_sq_mul_sum_four_sq, each discharged by ring) and Lagrange's four-square theorem (Nat.sum_four_squares). For sums of TWO squares it goes one step further and packages the multiplicative closure as sq_add_sq_mul: from a = x²+y² and b = u²+v² it produces an explicit representation of a·b as a sum of two squares. There is, however, no four-square analogue of that closure lemma anywhere in Mathlib. This entry fills that precise gap by introducing the predicate IsSumFourSq and proving its monoid structure, reading the product witnesses directly off Euler's identity.",
+    "proofStrategy": "four_square_identity restates the bilinear identity over an arbitrary commutative ring and discharges it by ring, keeping the file self-contained. The predicate IsSumFourSq a is defined as ∃ x y z w, a = x²+y²+z²+w². The headline result IsSumFourSq.mul destructures the witnesses of a and b, then supplies the four bilinear forms z₁,z₂,z₃,z₄ as the witnesses for a·b, the equality being exactly four_square_identity — so the closure is witness-explicit, not merely existential. From multiplication plus isSumFourSq_one the finite-product version isSumFourSq_prod follows by Finset.induction (empty ↦ 1, insert ↦ mul), and IsSumFourSq.pow by induction on the exponent. isSumFourSq_zero/one/sq record the unit and generators, and isSumFourSq_of_isSumTwoSq embeds two-square sums by padding with two zeros. The worked example 21 = 3·7 obtains its four-square representation by applying IsSumFourSq.mul to 3 = 1²+1²+1²+0² and 7 = 2²+1²+1²+1², and a numeric check confirms the resulting witnesses (0,4,2,1) sum to 21.",
+    "keyInsights": [
+      "**Euler's identity is multiplicativity of a norm**: the four bilinear forms z₁,…,z₄ are exactly the components of the quaternion product, so the identity says N(q)N(q') = N(qq') for the quaternion norm N(x₁+x₂i+x₃j+x₄k) = x₁²+x₂²+x₃²+x₄² — the sign pattern is the quaternion multiplication table, not an accident",
+      "**Closure is the real theorem, the ring equation is just its certificate**: Mathlib stops at the polynomial identity for four squares; the mathematically load-bearing statement is that sums of four squares form a multiplicative submonoid, which is what actually reduces Lagrange's theorem to the prime case",
+      "**The four-square closure was the missing sibling of a two-square one**: Mathlib packages exactly this closure for two squares (sq_add_sq_mul) but never for four; IsSumFourSq.mul is the faithful four-square analogue, with witnesses produced mechanically rather than guessed",
+      "**Witness-explicit existence**: IsSumFourSq.mul does not merely assert a·b is a sum of four squares — it returns the representation, so e.g. 21 = 3·7 is certified as 0²+4²+2²+1² with no search, illustrating how Euler's reduction is constructive"
+    ],
+    "prerequisites": [
+      "Euler's four-square identity as a polynomial identity over a commutative ring (Mathlib's euler_four_squares / sum_four_sq_mul_sum_four_sq, discharged by ring)",
+      "The quaternion interpretation: the identity is multiplicativity of the quaternion norm form, with the four bilinear forms the components of the quaternion product",
+      "Lagrange's four-square theorem and Euler's reduction of it to the prime case via multiplicative closure",
+      "Basic Finset induction for the finite-product generalisation"
+    ]
+  },
+  "sections": [
+    {
+      "id": "four-square-identity",
+      "title": "Euler's Four-Square Identity",
+      "startLine": 56,
+      "endLine": 64,
+      "mathContext": "$(x_1^2+x_2^2+x_3^2+x_4^2)(y_1^2+y_2^2+y_3^2+y_4^2) = z_1^2+z_2^2+z_3^2+z_4^2$ with $z_i$ the four bilinear forms.",
+      "summary": "four_square_identity restates the bilinear identity over an arbitrary commutative ring and discharges it by ring, making the file self-contained. The four right-hand-side forms are the components of the Hamilton quaternion product, so the identity is the multiplicativity N(q)N(q')=N(qq') of the quaternion norm."
+    },
+    {
+      "id": "predicate-and-closure",
+      "title": "The Predicate IsSumFourSq and Multiplicative Closure",
+      "startLine": 66,
+      "endLine": 113,
+      "mathContext": "$\\mathrm{IsSumFourSq}\\,a := \\exists x y z w,\\ a = x^2+y^2+z^2+w^2$; closed under $\\times$, containing $0,1$, every square, finite products and powers.",
+      "summary": "IsSumFourSq packages 'a is a sum of four squares' over any commutative ring. IsSumFourSq.mul — the four-square analogue of Mathlib's two-square sq_add_sq_mul, which it lacks — destructures the witnesses and returns the four bilinear forms as the product's witnesses, the equality being four_square_identity. With isSumFourSq_one this yields closure under finite products (isSumFourSq_prod, by Finset.induction) and powers (IsSumFourSq.pow); isSumFourSq_zero/one/sq give the unit and generators. Together they exhibit the sums of four squares as a multiplicative submonoid."
+    },
+    {
+      "id": "two-square-embedding-and-examples",
+      "title": "Two-Square Embedding and Worked Examples",
+      "startLine": 115,
+      "endLine": 143,
+      "mathContext": "Two-square sums embed into four-square sums; $21 = 3\\cdot 7 = 0^2+4^2+2^2+1^2$ via the closure theorem.",
+      "summary": "isSumFourSq_of_isSumTwoSq pads a two-square sum with two zeros. The examples certify 3 = 1²+1²+1²+0² and 7 = 2²+1²+1²+1², then obtain a four-square representation of 21 = 3·7 by applying IsSumFourSq.mul — witnesses are produced mechanically, not guessed — and a numeric check confirms the resulting forms (0,4,2,1) sum to 21."
+    }
+  ],
+  "conclusion": "Euler's four-square identity is formalised sorry-free and axiom-free over an arbitrary commutative ring, and — going beyond Mathlib's bare ring identity and Lagrange's theorem — its structural payload is made explicit: the sums of four squares form a multiplicative submonoid (closed under multiplication, finite products, and powers, containing 0, 1, and every square). The multiplicative-closure lemma IsSumFourSq.mul is the faithful four-square analogue of Mathlib's two-square sq_add_sq_mul, with witnesses read straight off the identity, certifying products like 21 = 3·7 = 0²+4²+2²+1² constructively. This is precisely the step by which Euler reduced Lagrange's four-square theorem to the prime case. Strengthening the worked examples to the full prime case (every prime is a sum of four squares) and assembling Lagrange's theorem from closure plus the prime case is the natural follow-up.",
+  "crossReferences": [
+    "euler-identity"
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes **Euler's four-square identity** and its load-bearing structural consequence: over any commutative ring, **sums of four squares are closed under multiplication** — forming a multiplicative submonoid. This is the four-square analogue of Mathlib's two-square `sq_add_sq_mul`, which has **no four-square counterpart** in Mathlib.

Mathlib provides the bare polynomial identity (`euler_four_squares`, `sum_four_sq_mul_sum_four_sq`, both by `ring`) and Lagrange's theorem (`Nat.sum_four_squares`), but stops short of packaging the multiplicative closure for four squares. This entry fills that precise gap.

## Contents (`proofs/Proofs/EulerIdentityOQ05.lean`)

- `IsSumFourSq a` — predicate "`a` is a sum of four squares" over an arbitrary `CommRing`.
- `IsSumFourSq.mul` — **the headline result**: the product of two sums of four squares is a sum of four squares, with witnesses read directly off Euler's identity (witness-explicit, not merely existential).
- `four_square_identity` — the bilinear identity restated and re-discharged by `ring` for self-containment.
- `isSumFourSq_prod` / `IsSumFourSq.pow` — closure under finite products and powers.
- `isSumFourSq_zero` / `_one` / `_sq` — unit and generators.
- `isSumFourSq_of_isSumTwoSq` — two-square sums embed into four-square sums.
- Worked examples over ℤ: `3`, `7`, and `21 = 3·7` with witnesses produced mechanically by the closure theorem (`0²+4²+2²+1²`).

## Verification

- 0 sorries, 0 `axiom` declarations, no `native_decide` (kernel-checked `ring`/`norm_num`/induction only).
- Builds via `./proofs/scripts/docker-build.sh Proofs.EulerIdentityOQ05` ✅
- Status: `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)