### PR TITLE
research(composition-card-2pow-oq-01): 2^(n−1) compositions of n + derived corollaries

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -612,6 +612,7 @@ import Proofs.CombinationsFormulaOQ03OQ06
 import Proofs.CombinationsFormulaOQ06
 import Proofs.CombinationsFormulaOQ09
 import Proofs.ComplexityCore
+import Proofs.CompositionCard2PowOQ01
 import Proofs.ConjugacyClassEquationOQ01
 import Proofs.ContinuumHypothesis
 import Proofs.ContinuumHypothesisOQ01

--- a/proofs/Proofs/CompositionCard2PowOQ01.lean
+++ b/proofs/Proofs/CompositionCard2PowOQ01.lean
@@ -1,0 +1,134 @@
+import Mathlib.Combinatorics.Enumerative.Composition
+import Mathlib.Tactic
+
+/-
+# Counting Compositions: there are 2^(n−1) compositions of n
+
+## What This Proves
+
+A *composition* of a natural number `n` is an ordered tuple of positive integers
+summing to `n` (Mathlib's `Composition n`). The classical enumerative fact is that
+the number of compositions of `n` is `2 ^ (n − 1)`:
+
+  Fintype.card (Composition n) = 2 ^ (n − 1).
+
+The standard bijective proof inserts a "bar or no bar" into each of the `n − 1`
+gaps between `n` unit boxes `□|□ □|□ …`, so a composition is the same data as a
+subset of the `n − 1` internal gaps — hence `2 ^ (n − 1)` of them.
+
+## What Mathlib Already Has — and What This Adds
+
+Mathlib supplies the headline count as `composition_card`, proved through the
+chain `Composition n ≃ CompositionAsSet n` (`compositionEquiv`) and
+`compositionAsSet_card : Fintype.card (CompositionAsSet n) = 2 ^ (n − 1)`. That
+single equation is re-exported here as `card_composition_eq` so the result has a
+named home in the gallery.
+
+Beyond the re-export, Mathlib does **not** record the structural consequences of
+the closed form, which is what this file derives:
+
+* the **doubling recurrence** `card (Composition (n+2)) = 2 · card (Composition (n+1))`
+  — each additional unit of `n` doubles the number of compositions (for `n ≥ 1`);
+* **positivity** `0 < card (Composition n)` — every `n` (including `0`) has at
+  least one composition;
+* the count as a genuine **bijective** statement `card (Composition n) =
+  card (CompositionAsSet n)`, exposing the "subset of the gaps" model; and
+* concrete cardinalities for `n = 1, …, 5` (`1, 2, 4, 8, 16`).
+
+The doubling recurrence is the combinatorial heart of `2 ^ (n−1)`: it is exactly
+the statement "splitting the last box off either starts a new part or extends the
+current one", and it is the recurrence one would use to prove the count from
+scratch. Note it genuinely requires `n ≥ 1`: the step from `0` to `1` does *not*
+double (`card (Composition 1) = 1 ≠ 2 = 2 · card (Composition 0)` would be false,
+since `card (Composition 0) = 2 ^ (0−1) = 2 ^ 0 = 1` because subtraction on ℕ is
+truncated). The `n+2` phrasing below sidesteps the edge case cleanly.
+
+## Status
+- [x] Complete proof (0 sorries, 0 axiom declarations)
+- [x] Headline count re-exported from Mathlib (`composition_card`)
+- [x] Original derived corollaries: doubling recurrence, positivity, bijection form
+- [x] Pedagogical / worked numeric instances
+-/
+
+namespace CompositionCard2PowOQ01
+
+/-! ## The headline count (re-exported from Mathlib) -/
+
+/-- **The number of compositions of `n` is `2 ^ (n − 1)`.** This is Mathlib's
+`composition_card`, given a named home here. A composition of `n` is an ordered
+tuple of positive parts summing to `n`; the count follows from the bijection with
+subsets of the `n − 1` internal gaps. -/
+theorem card_composition_eq (n : ℕ) :
+    Fintype.card (Composition n) = 2 ^ (n - 1) :=
+  composition_card n
+
+/-- The "set" model of compositions is equinumerous with `2 ^ (n − 1)` as well
+(`compositionAsSet_card`). `CompositionAsSet n` records a composition by the subset
+of internal boundaries it cuts, making the `2 ^ (n−1)` count manifest. -/
+theorem card_compositionAsSet_eq (n : ℕ) :
+    Fintype.card (CompositionAsSet n) = 2 ^ (n - 1) :=
+  compositionAsSet_card n
+
+/-! ## The bijective content -/
+
+/-- The count is genuinely bijective: compositions of `n` correspond exactly to
+their boundary sets. This packages Mathlib's `compositionEquiv` into a cardinality
+equality, exposing the "subset of the `n−1` gaps" combinatorial model that explains
+the `2 ^ (n−1)`. -/
+theorem card_composition_eq_card_compositionAsSet (n : ℕ) :
+    Fintype.card (Composition n) = Fintype.card (CompositionAsSet n) :=
+  Fintype.card_congr (compositionEquiv n)
+
+/-! ## Derived structural facts (absent from Mathlib) -/
+
+/-- **Positivity**: every `n` has at least one composition (the trivial one). In
+particular the count is never zero — including `n = 0`, whose only composition is
+the empty tuple, giving `2 ^ (0−1) = 2 ^ 0 = 1`. -/
+theorem card_composition_pos (n : ℕ) : 0 < Fintype.card (Composition n) := by
+  rw [card_composition_eq]
+  positivity
+
+/-- **Doubling recurrence**: increasing `n` by one doubles the number of
+compositions, stated cleanly for `n + 2` to avoid the truncated-subtraction edge
+case at `n = 0`. Combinatorially: detaching the final unit box from a composition
+of `n+2` either opens a new singleton part or lengthens the last part — the two choices
+that account for the factor of `2`. This is the recurrence behind `2 ^ (n−1)`. -/
+theorem card_composition_two_mul (n : ℕ) :
+    Fintype.card (Composition (n + 2)) = 2 * Fintype.card (Composition (n + 1)) := by
+  rw [card_composition_eq, card_composition_eq]
+  show 2 ^ (n + 1) = 2 * 2 ^ n
+  ring
+
+/-- The hypothesis form of the doubling recurrence: for `n ≥ 1`, passing from `n`
+to `n + 1` doubles the count. (Equivalent to `card_composition_two_mul` after
+writing `n = m + 1`.) -/
+theorem card_composition_succ_of_pos {n : ℕ} (hn : 1 ≤ n) :
+    Fintype.card (Composition (n + 1)) = 2 * Fintype.card (Composition n) := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le hn
+  -- n = 1 + m; reduce the truncated subtractions and finish by `pow_add`
+  rw [card_composition_eq, card_composition_eq, Nat.add_sub_cancel, Nat.add_sub_cancel_left]
+  ring
+
+/-! ## Worked numeric instances -/
+
+/-- `n = 1`: the single composition `[1]`. -/
+example : Fintype.card (Composition 1) = 1 := by norm_num [card_composition_eq]
+
+/-- `n = 2`: the `2` compositions `[2]`, `[1,1]`. -/
+example : Fintype.card (Composition 2) = 2 := by norm_num [card_composition_eq]
+
+/-- `n = 3`: the `4` compositions `[3]`, `[1,2]`, `[2,1]`, `[1,1,1]`. -/
+example : Fintype.card (Composition 3) = 4 := by norm_num [card_composition_eq]
+
+/-- `n = 4`: `8` compositions. -/
+example : Fintype.card (Composition 4) = 8 := by norm_num [card_composition_eq]
+
+/-- `n = 5`: `16` compositions. -/
+example : Fintype.card (Composition 5) = 16 := by norm_num [card_composition_eq]
+
+/-- Sanity check on the doubling recurrence at a concrete value:
+`card (Composition 5) = 2 · card (Composition 4)`, i.e. `16 = 2 · 8`. -/
+example : Fintype.card (Composition 5) = 2 * Fintype.card (Composition 4) :=
+  card_composition_two_mul 3
+
+end CompositionCard2PowOQ01

--- a/src/data/proofs/composition-card-2pow-oq-01/annotations.json
+++ b/src/data/proofs/composition-card-2pow-oq-01/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "ann-headline-count",
+    "proofId": "composition-card-2pow-oq-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 71
+    },
+    "type": "theorem",
+    "title": "The Count 2^(n−1) (card_composition_eq, card_compositionAsSet_eq)",
+    "content": "card_composition_eq states Fintype.card (Composition n) = 2^(n−1), re-exporting Mathlib's composition_card so the classical count has a named home. card_compositionAsSet_eq records the same count for CompositionAsSet n, the boundary-set model in which a composition of n is encoded by the subset of internal boundaries it cuts — making the power-of-two count manifest. A composition of n is an ordered tuple of positive integers summing to n, so order matters (the compositions of 3 are 3, 1+2, 2+1, 1+1+1).",
+    "mathContext": "$\\mathrm{card}\\,(\\mathrm{Composition}\\ n) = 2^{n-1}$.",
+    "prerequisites": [
+      "Compositions of a natural number (Mathlib's Composition n)",
+      "The boundary-set model CompositionAsSet n and compositionAsSet_card"
+    ],
+    "relatedConcepts": [
+      "enumerative combinatorics",
+      "compositions of an integer",
+      "stars and bars",
+      "powers of two"
+    ],
+    "significance": "The headline enumerative identity: the number of ordered compositions of n is 2^(n−1), one of the foundational counts of enumerative combinatorics."
+  },
+  {
+    "id": "ann-bijective-content",
+    "proofId": "composition-card-2pow-oq-01",
+    "range": {
+      "startLine": 72,
+      "endLine": 81
+    },
+    "type": "theorem",
+    "title": "The Count as a Bijection (card_composition_eq_card_compositionAsSet)",
+    "content": "card_composition_eq_card_compositionAsSet proves Fintype.card (Composition n) = Fintype.card (CompositionAsSet n) by packaging Mathlib's compositionEquiv : Composition n ≃ CompositionAsSet n into a cardinality equality via Fintype.card_congr. This exposes the combinatorial model behind the formula: a composition is the same data as a subset of the n−1 internal gaps between n unit boxes, so the count is 2^(n−1) precisely because there are that many subsets of an (n−1)-element set.",
+    "mathContext": "$\\mathrm{card}\\,(\\mathrm{Composition}\\ n) = \\mathrm{card}\\,(\\mathrm{CompositionAsSet}\\ n)$.",
+    "prerequisites": [
+      "The equivalence compositionEquiv : Composition n ≃ CompositionAsSet n",
+      "Fintype.card_congr (equivalences preserve cardinality)"
+    ],
+    "relatedConcepts": [
+      "bijective proof",
+      "subset-of-gaps model",
+      "cardinality of equivalent types"
+    ],
+    "significance": "Makes the proof bijective rather than merely numeric: the 2^(n−1) count is the number of subsets of the n−1 internal gaps, surfaced explicitly at the level of cardinalities."
+  },
+  {
+    "id": "ann-doubling-recurrence",
+    "proofId": "composition-card-2pow-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 111
+    },
+    "type": "theorem",
+    "title": "Positivity and the Doubling Recurrence (card_composition_pos, card_composition_two_mul)",
+    "content": "card_composition_pos proves 0 < Fintype.card (Composition n) — every n has at least the trivial composition, including n = 0 whose only composition is the empty tuple (count 2^(0−1) = 2^0 = 1). card_composition_two_mul is the doubling recurrence card (Composition (n+2)) = 2 · card (Composition (n+1)): after rewriting both sides to powers of two and reducing the truncated subtractions by definitional equality (n+2−1 ≡ n+1, n+1−1 ≡ n), it reduces to 2^(n+1) = 2·2^n, closed by ring. card_composition_succ_of_pos restates the recurrence in hypothesis form for n ≥ 1. Neither the recurrence nor positivity is recorded in Mathlib.",
+    "mathContext": "$\\mathrm{card}\\,(\\mathrm{Composition}\\ (n+2)) = 2\\,\\mathrm{card}\\,(\\mathrm{Composition}\\ (n+1))$.",
+    "prerequisites": [
+      "positivity for 0 < 2^(n−1)",
+      "Truncated ℕ-subtraction and Nat.add_sub_cancel / Nat.add_sub_cancel_left",
+      "pow_add via the ring tactic"
+    ],
+    "relatedConcepts": [
+      "linear recurrence",
+      "dynamic-programming counting",
+      "truncated subtraction edge case"
+    ],
+    "significance": "The doubling recurrence is the combinatorial engine of 2^(n−1): each additional unit of n either opens a new singleton part or extends the last, the two choices producing the factor of two. Its genuine dependence on n ≥ 1 (the n = 0 edge case under truncated subtraction) is made explicit."
+  },
+  {
+    "id": "ann-numeric-instances",
+    "proofId": "composition-card-2pow-oq-01",
+    "range": {
+      "startLine": 112,
+      "endLine": 132
+    },
+    "type": "example",
+    "title": "Worked Numeric Instances (n = 1, …, 5)",
+    "content": "The examples specialise card_composition_eq to n = 1,…,5 and compute 2^(n−1) = 1, 2, 4, 8, 16 by norm_num: one composition of 1 ([1]); two of 2 ([2], [1,1]); four of 3 ([3], [1,2], [2,1], [1,1,1]); eight of 4; sixteen of 5. A final example checks the doubling recurrence at a concrete value, card (Composition 5) = 2 · card (Composition 4) i.e. 16 = 2·8, by invoking card_composition_two_mul 3 directly.",
+    "mathContext": "$1,2,4,8,16$ for $n=1,\\dots,5$.",
+    "prerequisites": [
+      "card_composition_eq specialised to concrete n",
+      "norm_num for computing 2^(n−1)"
+    ],
+    "relatedConcepts": [
+      "small-case enumeration",
+      "sanity checks",
+      "powers of two"
+    ],
+    "significance": "Grounds the abstract count in concrete cardinalities and verifies the doubling recurrence numerically, confirming the formula and recurrence agree on small cases."
+  }
+]

--- a/src/data/proofs/composition-card-2pow-oq-01/meta.json
+++ b/src/data/proofs/composition-card-2pow-oq-01/meta.json
@@ -1,0 +1,95 @@
+{
+  "id": "composition-card-2pow-oq-01",
+  "title": "Composition Card OQ-01: There Are 2^(n−1) Compositions of n",
+  "slug": "composition-card-2pow-oq-01",
+  "description": "A composition of a natural number n is an ordered tuple of positive integers summing to n (Mathlib's Composition n). The classical enumerative fact is that the number of compositions of n equals 2^(n−1): Fintype.card (Composition n) = 2^(n−1). The standard bijective proof places a 'bar or no bar' in each of the n−1 gaps between n unit boxes, so a composition is the same data as a subset of the n−1 internal gaps — giving 2^(n−1) of them. Mathlib supplies the headline count as composition_card (proved via Composition n ≃ CompositionAsSet n and compositionAsSet_card = 2^(n−1)); this entry re-exports it as card_composition_eq and then derives the structural consequences Mathlib does not record: the doubling recurrence card (Composition (n+2)) = 2 · card (Composition (n+1)) — each extra unit of n doubles the count, the recurrence at the heart of 2^(n−1) — together with its hypothesis form for n ≥ 1; positivity 0 < card (Composition n) (every n, including 0, has at least one composition); the count expressed as a genuine bijection card (Composition n) = card (CompositionAsSet n) exposing the subset-of-gaps model; and concrete cardinalities for n = 1,…,5 (1, 2, 4, 8, 16). The doubling recurrence genuinely requires n ≥ 1: the step from 0 to 1 does not double, since card (Composition 0) = 2^(0−1) = 2^0 = 1 because subtraction on ℕ is truncated; the n+2 phrasing sidesteps the edge case.",
+  "leanFile": "Proofs/CompositionCard2PowOQ01.lean",
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Composition_(combinatorics)",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CompositionCard2PowOQ01.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "compositions",
+      "counting",
+      "powers-of-two",
+      "bijective-proof",
+      "recurrence"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "relatedProblems": [
+      {
+        "id": "dyck-catalan-count-oq-01",
+        "relationship": "Sibling enumerative-combinatorics counting result: Dyck words of semilength n are counted by the n-th Catalan number. Both package a Mathlib cardinality bijection (DyckWord / Composition) into a named closed-form count."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 135,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. Only the foundational propext / Classical.choice / Quot.sound may appear (verifiable with #print axioms). The headline count card_composition_eq is a re-export of Mathlib's composition_card (whence the 'mathlib' badge); the in-file derived content absent from Mathlib is the doubling recurrence card_composition_two_mul and its hypothesis form card_composition_succ_of_pos, positivity card_composition_pos, the bijective restatement card_composition_eq_card_compositionAsSet (packaging compositionEquiv into a cardinality equality), and the worked cardinalities for n = 1..5. The result is unconditional.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Counting compositions is one of the first results in enumerative combinatorics. A composition of n is an ordered sequence of positive parts summing to n (unlike a partition, order matters): the compositions of 3 are 3, 1+2, 2+1, 1+1+1. The count 2^(n−1) has a clean bijective proof attributed to the 'stars and bars' viewpoint: write n as n unit boxes in a row, leaving n−1 internal gaps; choosing a subset of those gaps to 'cut' splits the row into the parts of a composition, and every composition arises exactly once, so the compositions of n are in bijection with the 2^(n−1) subsets of an (n−1)-element set. Equivalently, the number of compositions of n into exactly k parts is C(n−1, k−1), and summing over k via the binomial theorem gives ∑_k C(n−1,k−1) = 2^(n−1). The recurrence form — each additional unit either starts a new part or extends the last one, doubling the number of compositions — is the dynamic-programming view of the same fact.",
+    "problemStatement": "Show that the number of compositions of a natural number n (ordered tuples of positive integers summing to n, Mathlib's Composition n) is\n\n$$\\#\\{\\text{compositions of } n\\} = \\mathrm{card}\\,(\\mathrm{Composition}\\ n) = 2^{n-1},$$\n\nand expose its structural content: the bijection with subsets of the n−1 internal gaps, the doubling recurrence card(Composition (n+2)) = 2·card(Composition (n+1)), and positivity of the count.",
+    "text": "Mathlib already proves the headline count as composition_card, routed through the equivalence Composition n ≃ CompositionAsSet n (compositionEquiv) and the set-model count compositionAsSet_card : card (CompositionAsSet n) = 2^(n−1). This entry gives that count a named gallery home (card_composition_eq) and then derives the consequences Mathlib leaves unstated: the doubling recurrence and its n ≥ 1 hypothesis form, positivity, the bijective restatement card(Composition n) = card(CompositionAsSet n), and concrete cardinalities for small n.",
+    "proofStrategy": "card_composition_eq and card_compositionAsSet_eq re-export Mathlib's composition_card and compositionAsSet_card. card_composition_eq_card_compositionAsSet packages compositionEquiv into a cardinality equality via Fintype.card_congr, exposing the subset-of-gaps bijection. card_composition_pos rewrites to 0 < 2^(n−1) and closes by positivity. card_composition_two_mul rewrites both sides to powers of 2 and, after reducing the truncated subtractions (n+2−1 ≡ n+1, n+1−1 ≡ n by defeq), proves 2^(n+1) = 2·2^n by ring; card_composition_succ_of_pos writes n = 1+m and reduces the subtractions with Nat.add_sub_cancel / Nat.add_sub_cancel_left before ring. The numeric examples specialise card_composition_eq and discharge 2^(k−1) by norm_num, and a final example checks the recurrence at n=5 (16 = 2·8) by invoking card_composition_two_mul directly.",
+    "keyInsights": [
+      "**The count is bijective, not just numeric**: compositions of n correspond exactly to subsets of the n−1 internal gaps between unit boxes, which is why the answer is 2^(n−1); card_composition_eq_card_compositionAsSet makes this bijection (compositionEquiv) explicit at the level of cardinalities",
+      "**The doubling recurrence is the combinatorial heart of the formula**: card(Composition (n+2)) = 2·card(Composition (n+1)) says each extra unit of n either opens a new singleton part or extends the last part — the two choices that produce the factor of 2, and the recurrence one would use to prove 2^(n−1) from scratch",
+      "**The edge case is real, not cosmetic**: the doubling genuinely fails from 0 to 1 because ℕ-subtraction is truncated — card(Composition 0) = 2^(0−1) = 2^0 = 1, so 1 ≠ 2·1; the n+2 / 'n ≥ 1' phrasings are what make the recurrence true",
+      "**Mathlib stops at the closed form**: composition_card gives 2^(n−1) but Mathlib records neither the recurrence nor positivity nor the count-as-bijection statement, which is the value this entry adds beyond the re-export"
+    ],
+    "prerequisites": [
+      "Compositions of a natural number (Mathlib's Composition n) and the set model CompositionAsSet n",
+      "The equivalence compositionEquiv : Composition n ≃ CompositionAsSet n and compositionAsSet_card : card (CompositionAsSet n) = 2^(n−1)",
+      "Fintype.card_congr (cardinality is preserved by equivalences)",
+      "Truncated natural-number subtraction and the lemmas Nat.add_sub_cancel / Nat.add_sub_cancel_left, plus pow_add via ring"
+    ]
+  },
+  "sections": [
+    {
+      "id": "headline-count",
+      "title": "The Headline Count (re-exported from Mathlib)",
+      "startLine": 61,
+      "endLine": 71,
+      "mathContext": "$\\mathrm{card}\\,(\\mathrm{Composition}\\ n) = 2^{n-1}$ and $\\mathrm{card}\\,(\\mathrm{CompositionAsSet}\\ n) = 2^{n-1}$.",
+      "summary": "card_composition_eq re-exports Mathlib's composition_card, giving the count 2^(n−1) a named home; card_compositionAsSet_eq records the same count for the boundary-set model CompositionAsSet n, in which a composition is encoded by the subset of internal boundaries it cuts."
+    },
+    {
+      "id": "bijective-content",
+      "title": "The Bijective Content",
+      "startLine": 72,
+      "endLine": 81,
+      "mathContext": "$\\mathrm{card}\\,(\\mathrm{Composition}\\ n) = \\mathrm{card}\\,(\\mathrm{CompositionAsSet}\\ n)$ via compositionEquiv.",
+      "summary": "card_composition_eq_card_compositionAsSet packages Mathlib's compositionEquiv into a cardinality equality with Fintype.card_congr, exposing the 'subset of the n−1 gaps' model that explains why the count is a power of two."
+    },
+    {
+      "id": "derived-structural-facts",
+      "title": "Derived Structural Facts (absent from Mathlib)",
+      "startLine": 82,
+      "endLine": 111,
+      "mathContext": "$0 < \\mathrm{card}\\,(\\mathrm{Composition}\\ n)$ and $\\mathrm{card}\\,(\\mathrm{Composition}\\ (n+2)) = 2\\,\\mathrm{card}\\,(\\mathrm{Composition}\\ (n+1))$.",
+      "summary": "card_composition_pos proves the count is always positive (every n has the trivial composition). card_composition_two_mul is the doubling recurrence, proved by reducing to 2^(n+1) = 2·2^n via ring; card_composition_succ_of_pos restates it in hypothesis form for n ≥ 1. These are the structural consequences of the closed form that Mathlib does not record."
+    },
+    {
+      "id": "numeric-instances",
+      "title": "Worked Numeric Instances",
+      "startLine": 112,
+      "endLine": 132,
+      "mathContext": "$\\mathrm{card}\\,(\\mathrm{Composition}\\ n) = 1,2,4,8,16$ for $n=1,\\dots,5$.",
+      "summary": "The examples specialise card_composition_eq to n = 1,…,5, computing 2^(n−1) = 1, 2, 4, 8, 16 by norm_num, and a final example checks the doubling recurrence concretely at n = 5 (16 = 2·8) by invoking card_composition_two_mul."
+    }
+  ],
+  "conclusion": "The enumerative identity 'there are 2^(n−1) compositions of n' is formalised sorry-free and axiom-free. The headline count is Mathlib's composition_card (hence the mathlib badge), given a named gallery home; beyond the re-export the entry derives the structural content Mathlib omits — the doubling recurrence card(Composition (n+2)) = 2·card(Composition (n+1)) and its n ≥ 1 form, positivity of the count, the count as an explicit bijection with the boundary-set model, and the cardinalities 1,2,4,8,16 for n = 1..5. The doubling recurrence is the combinatorial engine of the closed form, and its genuine dependence on n ≥ 1 (the truncated-subtraction edge case at n = 0) is made explicit. A natural follow-up is the refinement by number of parts — that compositions of n into exactly k parts number C(n−1,k−1), summing to 2^(n−1) via the binomial theorem.",
+  "crossReferences": [
+    "dyck-catalan-count-oq-01"
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **composition-card-2pow-oq-01**: the number of compositions of `n` is `2^(n−1)`.

A *composition* of `n` is an ordered tuple of positive integers summing to `n` (Mathlib's `Composition n`). The headline count is re-exported from Mathlib's `composition_card`; the file then derives structural consequences that Mathlib does **not** record:

- **Doubling recurrence** `card (Composition (n+2)) = 2 · card (Composition (n+1))` — the combinatorial heart of `2^(n−1)` (and its hypothesis form for `n ≥ 1`).
- **Positivity** `0 < card (Composition n)` for all `n` (including `n = 0`).
- **Bijective form** `card (Composition n) = card (CompositionAsSet n)` — exposes the "subset of the `n−1` gaps" model.
- Worked numeric instances `n = 1..5` → `1, 2, 4, 8, 16`.

## Verification

- `lake build Proofs.CompositionCard2PowOQ01` succeeds (built against prebuilt Mathlib, 0 errors).
- 0 sorries, 0 `axiom` declarations, no `native_decide`.
- All cited Mathlib lemmas confirmed present: `composition_card`, `compositionAsSet_card`, `compositionEquiv`.

## Badging

`status: verified`, `badge: mathlib`, `axiomCount: 0` — Tier B, honest because the headline equation is a Mathlib re-export; the derived corollaries are the original content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)