### PR TITLE
research(halls-theorem-oq-01): necessity direction of Hall's marriage theorem + full biconditionals (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2556,6 +2556,7 @@ import Proofs.GreensTheoremOQ03
 import Proofs.GreensTheoremOQ03OQ04
 import Proofs.GreensTheoremOQ04
 import Proofs.HadamardThreeLines
+import Proofs.HallsTheoremOQ01
 import Proofs.HaltingProblem
 import Proofs.HarmonicDivergence
 import Proofs.HarmonicDivergenceOQ01

--- a/proofs/Proofs/HallsTheoremOQ01.lean
+++ b/proofs/Proofs/HallsTheoremOQ01.lean
@@ -1,0 +1,127 @@
+/-
+Hall's Marriage Theorem for bipartite graphs: the full biconditional
+
+Source: Open question from the halls-theorem gallery family
+Status: VERIFIED (0 axioms, 0 sorries)
+
+Hall's marriage theorem characterises exactly when a (locally finite) bipartite
+graph `G` with parts `p₁`, `p₂` admits a matching saturating one side `p₁`: such a
+matching exists **iff** Hall's condition holds, i.e. every subset `s ⊆ p₁` has at
+least as many neighbours as it has vertices,
+
+    s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard.
+
+Mathlib proves only the hard, *sufficiency* direction
+(`SimpleGraph.exists_isMatching_of_forall_ncard_le` : Hall's condition ⟹ a matching,
+and the perfect-matching analogue `exists_isPerfectMatching_of_forall_ncard_le`).
+The *necessity* direction — that any saturating matching forces Hall's condition —
+is absent from Mathlib. We supply it as a standalone, graph-agnostic fact and
+assemble the textbook biconditionals.
+
+Novel content (absent from Mathlib):
+
+  * `ncard_le_ncard_biUnion_neighborSet_of_isMatching` :
+        a matching saturating `s` injects `s` into its neighbourhood, hence
+        `s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard`  (necessity of Hall's condition)
+  * `ncard_le_of_isPerfectMatching` : the global form, for a perfect matching
+  * `hall_marriage`  : Hall's condition ↔ ∃ a matching saturating `p₁`
+  * `hall_perfect`   : the global Hall condition ↔ ∃ a perfect matching
+  * `exists_violating_of_no_matching` : the contrapositive "deficiency" form —
+        no saturating matching ⟹ some `s ⊆ p₁` violates Hall's condition
+
+The necessity argument is the elementary half of Hall's theorem: send each `v ∈ s`
+to its unique matched partner `φ v`. Distinct vertices receive distinct partners
+(the matching axiom), and a partner of `v` is a `G`-neighbour of `v` (the matching
+is a subgraph), so `φ` injects `s` into `⋃ x ∈ s, G.neighborSet x`; an injection
+into a finite set does not increase `ncard`. (For an infinite `s` the bound is
+vacuous: `s.ncard = 0`.)
+-/
+import Mathlib
+
+open Set Function
+
+namespace HallsTheoremOQ01
+
+open SimpleGraph
+
+variable {V : Type*} {G : SimpleGraph V} {p₁ p₂ : Set V}
+
+/-- **Necessity of Hall's condition.** If `M` is a matching whose vertex set contains
+`s`, then `s` injects into its `G`-neighbourhood via the matched-partner map, so
+`s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard`. This holds in *any* graph (no
+bipartiteness needed) and is the easy converse to Mathlib's
+`exists_isMatching_of_forall_ncard_le`. -/
+theorem ncard_le_ncard_biUnion_neighborSet_of_isMatching
+    [G.LocallyFinite] {M : G.Subgraph} (hM : M.IsMatching)
+    {s : Set V} (hs : s ⊆ M.verts) :
+    s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard := by
+  classical
+  -- the matched-partner function: each `v ∈ M.verts` has a unique `M`-neighbour `φ v`
+  let φ : V → V := fun v => if h : v ∈ M.verts then (hM h).choose else v
+  have hadj : ∀ v ∈ M.verts, M.Adj v (φ v) := by
+    intro v hv
+    show M.Adj v (if h : v ∈ M.verts then (hM h).choose else v)
+    rw [dif_pos hv]
+    exact (hM hv).choose_spec.1
+  -- `φ v` is a `G`-neighbour of `v`, hence lands in the neighbourhood of `s`
+  have hmem : ∀ v ∈ s, φ v ∈ ⋃ x ∈ s, G.neighborSet x := by
+    intro v hv
+    exact Set.mem_biUnion hv ((G.mem_neighborSet v (φ v)).mpr (M.adj_sub (hadj v (hs hv))))
+  -- distinct vertices get distinct partners: `φ` is injective on `s`
+  have hinj : Set.InjOn φ s := by
+    intro u hu v hv huv
+    have hu' := hadj u (hs hu)
+    have hv' := hadj v (hs hv)
+    rw [huv] at hu'
+    exact hM.eq_of_adj_right hu' hv'
+  rcases Set.finite_or_infinite s with hsfin | hsinf
+  · exact Set.ncard_le_ncard_of_injOn φ hmem hinj
+      (hsfin.biUnion fun x _ => (G.neighborSet x).toFinite)
+  · simp [hsinf.ncard]
+
+/-- The global form of necessity: a **perfect** matching forces Hall's condition for
+*every* set `s` (a perfect matching saturates all of `V`). -/
+theorem ncard_le_of_isPerfectMatching
+    [G.LocallyFinite] {M : G.Subgraph} (hM : M.IsPerfectMatching) (s : Set V) :
+    s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard :=
+  ncard_le_ncard_biUnion_neighborSet_of_isMatching hM.1
+    (by rw [Subgraph.isSpanning_iff.mp hM.2]; exact subset_univ s)
+
+/-- **Hall's Marriage Theorem (bipartite form).** For a locally finite bipartite graph
+`G` with parts `p₁`, `p₂`, a matching saturating `p₁` exists **iff** Hall's condition
+holds on `p₁`. The forward direction is Mathlib's
+`exists_isMatching_of_forall_ncard_le`; the converse is the necessity lemma above. -/
+theorem hall_marriage [G.LocallyFinite] (h₁ : G.IsBipartiteWith p₁ p₂) :
+    (∀ s ⊆ p₁, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) ↔
+      ∃ M : G.Subgraph, p₁ ⊆ M.verts ∧ M.IsMatching := by
+  constructor
+  · intro h₂
+    exact exists_isMatching_of_forall_ncard_le h₁ h₂
+  · rintro ⟨M, hp, hM⟩ s hs
+    exact ncard_le_ncard_biUnion_neighborSet_of_isMatching hM (hs.trans hp)
+
+/-- **Hall's Marriage Theorem (perfect-matching form).** For a locally finite bipartite
+graph, a perfect matching exists **iff** the global Hall condition holds (`s.ncard ≤
+neighbourhood.ncard` for every `s`). Forward is Mathlib's
+`exists_isPerfectMatching_of_forall_ncard_le`; the converse is `ncard_le_of_isPerfectMatching`. -/
+theorem hall_perfect [G.LocallyFinite] (h₁ : G.IsBipartiteWith p₁ p₂) :
+    (∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) ↔
+      ∃ M : G.Subgraph, M.IsPerfectMatching := by
+  constructor
+  · intro h₂
+    exact exists_isPerfectMatching_of_forall_ncard_le h₁ h₂
+  · rintro ⟨M, hM⟩ s
+    exact ncard_le_of_isPerfectMatching hM s
+
+/-- **Deficiency / contrapositive form.** If `G` admits *no* matching saturating `p₁`,
+then Hall's condition must fail somewhere: some `s ⊆ p₁` has strictly fewer neighbours
+than vertices. This is the practical "obstruction" certificate complementing the
+existence statement. -/
+theorem exists_violating_of_no_matching [G.LocallyFinite] (h₁ : G.IsBipartiteWith p₁ p₂)
+    (hno : ¬ ∃ M : G.Subgraph, p₁ ⊆ M.verts ∧ M.IsMatching) :
+    ∃ s ⊆ p₁, (⋃ x ∈ s, G.neighborSet x).ncard < s.ncard := by
+  by_contra hcon
+  push_neg at hcon
+  exact hno ((hall_marriage h₁).mp hcon)
+
+end HallsTheoremOQ01

--- a/src/data/proofs/halls-theorem-oq-01/meta.json
+++ b/src/data/proofs/halls-theorem-oq-01/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "halls-theorem-oq-01",
+  "title": "Hall's Marriage Theorem: the Full Biconditional (Necessity Direction)",
+  "slug": "halls-theorem-oq-01",
+  "description": "Mathlib proves only the hard sufficiency direction of Hall's marriage theorem (exists_isMatching_of_forall_ncard_le: Hall's condition ⟹ a matching saturating one side, and the perfect-matching analogue). The easy but essential converse — that any saturating matching forces Hall's condition s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard — is absent. We supply the necessity lemma as a standalone, graph-agnostic fact (the matched-partner map injects s into its neighbourhood) and assemble the textbook biconditionals: a matching saturating p₁ exists iff Hall's condition holds on p₁, the perfect-matching analogue, and the contrapositive deficiency certificate (no saturating matching ⟹ some subset violates Hall's condition).",
+  "meta": {
+    "author": "Philip Hall (1935); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Combinatorics/SimpleGraph/Hall.html",
+    "date": "1935",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "matching",
+      "halls-marriage-theorem",
+      "bipartite"
+    ],
+    "proofRepoPath": "Proofs/HallsTheoremOQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 127,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.exists_isMatching_of_forall_ncard_le",
+        "description": "Mathlib's sufficiency direction of Hall's theorem: Hall's condition on p₁ ⟹ a matching saturating p₁. The forward half of our biconditional.",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Hall"
+      },
+      {
+        "theorem": "SimpleGraph.exists_isPerfectMatching_of_forall_ncard_le",
+        "description": "Mathlib's sufficiency direction for perfect matchings: the global Hall condition ⟹ a perfect matching. The forward half of the perfect-matching biconditional.",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Hall"
+      },
+      {
+        "theorem": "SimpleGraph.Subgraph.IsMatching",
+        "description": "A matching: each vertex of M.verts has a unique M-neighbour. Supplies the matched-partner choice function and the injectivity (eq_of_adj_right) that powers necessity.",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Matching"
+      },
+      {
+        "theorem": "Set.ncard_le_ncard_of_injOn",
+        "description": "An injection from s into a finite set t does not increase ncard — the counting step turning the matched-partner injection into the neighbourhood bound.",
+        "module": "Mathlib.Data.Set.Card"
+      }
+    ],
+    "originalContributions": [
+      "ncard_le_ncard_biUnion_neighborSet_of_isMatching: necessity of Hall's condition — any matching whose vertex set contains s injects s into ⋃ x ∈ s, G.neighborSet x via the matched-partner map, so s.ncard ≤ (neighbourhood).ncard. Holds in any graph (no bipartiteness needed); absent from Mathlib.",
+      "ncard_le_of_isPerfectMatching: the global form — a perfect matching forces Hall's condition for every set s.",
+      "hall_marriage: the full biconditional — Hall's condition on p₁ ↔ ∃ a matching saturating p₁ — assembling Mathlib's sufficiency with the new necessity lemma.",
+      "hall_perfect: the perfect-matching biconditional — the global Hall condition ↔ ∃ a perfect matching.",
+      "exists_violating_of_no_matching: the contrapositive deficiency certificate — no matching saturating p₁ ⟹ some s ⊆ p₁ has strictly fewer neighbours than vertices."
+    ],
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Philip Hall's marriage theorem (1935) characterises exactly when a bipartite graph admits a matching saturating one side: such a matching exists if and only if every subset of that side has at least as many neighbours as it has vertices (Hall's condition). The 'marriage' framing pictures a set of people who can each be matched to an acceptable partner precisely when no group of k people collectively finds fewer than k acceptable partners. The hard direction — that the counting condition suffices — is the substance of the theorem and is formalised in Mathlib. The converse — that a matching forces the counting condition — is elementary but indispensable for the 'if and only if', and Mathlib does not state it.",
+    "problemStatement": "Let $G$ be a locally finite bipartite graph with parts $p_1, p_2$. A matching saturating $p_1$ exists if and only if Hall's condition holds:\n\n$$\\forall\\, s \\subseteq p_1, \\quad |s| \\le \\Big| \\bigcup_{x \\in s} N(x) \\Big|.$$\n\nMathlib supplies the ($\\Leftarrow$) direction. Provide the ($\\Rightarrow$) direction (necessity), the perfect-matching analogue, and the contrapositive deficiency form.",
+    "proofStrategy": "Necessity is the elementary half. Given a matching M whose vertex set contains s, define the matched-partner function φ sending each v ∈ M.verts to its unique M-neighbour (via the IsMatching choice function). Three facts combine:\n\n1. φ v is a G-neighbour of v (the matching is a subgraph, M.adj_sub), so φ maps s into ⋃ x ∈ s, G.neighborSet x (Set.mem_biUnion).\n\n2. φ is injective on s: if φ u = φ v then u and v are both M-adjacent to the same vertex, and the matching axiom (eq_of_adj_right) forces u = v.\n\n3. An injection into a finite set does not increase ncard (Set.ncard_le_ncard_of_injOn); the neighbourhood is finite by local finiteness. For an infinite s the bound is vacuous since s.ncard = 0.\n\nThe biconditionals then pair this with Mathlib's exists_isMatching_of_forall_ncard_le / exists_isPerfectMatching_of_forall_ncard_le, and the deficiency form is a by_contra/push_neg contrapositive of the marriage biconditional.",
+    "keyInsights": [
+      "The necessity direction needs no bipartiteness at all — it is a fact about any matching in any locally finite graph, stated and proved graph-agnostically and only specialised to the bipartite setting when assembling the biconditional.",
+      "The whole content is the matched-partner map: a matching is precisely an injective choice of neighbour, so 'matching saturating s' literally is 'injection of s into its neighbourhood', which is exactly Hall's counting bound.",
+      "The infinite case is handled by ncard's convention s.ncard = 0 for infinite s, making the bound vacuously true rather than a separate finiteness hypothesis.",
+      "The deficiency certificate exists_violating_of_no_matching repackages the biconditional as the practically useful obstruction statement: the failure of a matching is always witnessed by a concrete Hall-violating subset.",
+      "Mathlib states the sufficiency direction and the supporting one-directional lemmas (union_eq_univ_of_forall_ncard_le, exists_bijective_of_forall_ncard_le) but never the converse or the iff — this entry closes the gap to the full textbook theorem."
+    ],
+    "prerequisites": [
+      "Simple graphs, subgraphs, and matchings (SimpleGraph.Subgraph.IsMatching, IsPerfectMatching)",
+      "Bipartite graphs (SimpleGraph.IsBipartiteWith) and neighbour sets",
+      "Set cardinality ncard and injections on sets (Set.ncard_le_ncard_of_injOn)",
+      "Hall's marriage theorem and its standard textbook statement"
+    ]
+  },
+  "conclusion": {
+    "summary": "We supplied the necessity direction of Hall's marriage theorem — missing from Mathlib, which proves only sufficiency — as a standalone graph-agnostic lemma (the matched-partner map injects any saturated set into its neighbourhood) and assembled the full textbook biconditionals: matching ↔ Hall's condition, perfect matching ↔ global Hall's condition, and the contrapositive deficiency certificate. All five results are fully machine-checked with 0 sorries and 0 axioms.",
+    "implications": "Mathlib users can now invoke Hall's theorem as an honest 'if and only if' rather than a one-way implication, and can extract a concrete Hall-violating subset whenever no matching exists. The necessity lemma is reusable beyond the bipartite setting since it assumes nothing about bipartiteness.",
+    "openQuestions": [
+      "Derive the defect (deficiency) version of Hall's theorem quantitatively: the maximum matching size equals |p₁| minus the maximum Hall deficiency maxₛ(|s| − |N(s)|).",
+      "Specialise to the finite Finset formulation to connect with the combinatorial Hall.Basic statement and König's theorem.",
+      "Formalise the systems-of-distinct-representatives corollary directly from the biconditional."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Imports, an expository docstring contrasting Mathlib's sufficiency-only formulation with the full biconditional, and namespace/variable setup."
+    },
+    {
+      "id": "necessity",
+      "title": "Necessity of Hall's Condition",
+      "startLine": 49,
+      "endLine": 88,
+      "summary": "ncard_le_ncard_biUnion_neighborSet_of_isMatching (the matched-partner injection bound, graph-agnostic) and ncard_le_of_isPerfectMatching (its global form for a perfect matching)."
+    },
+    {
+      "id": "biconditionals",
+      "title": "The Marriage Biconditionals",
+      "startLine": 90,
+      "endLine": 114,
+      "summary": "hall_marriage and hall_perfect — the full 'iff' statements pairing Mathlib's sufficiency with the necessity lemma."
+    },
+    {
+      "id": "deficiency",
+      "title": "Deficiency / Obstruction Form",
+      "startLine": 116,
+      "endLine": 127,
+      "summary": "exists_violating_of_no_matching — the contrapositive certificate: no saturating matching ⟹ some subset violates Hall's condition."
+    }
+  ],
+  "crossReferences": [],
+  "references": [
+    {
+      "text": "Hall, P. (1935). On Representatives of Subsets. Journal of the London Mathematical Society, 10(1), 26–30.",
+      "url": "https://doi.org/10.1112/jlms/s1-10.37.26"
+    },
+    {
+      "text": "Hall's marriage theorem.",
+      "url": "https://en.wikipedia.org/wiki/Hall%27s_marriage_theorem"
+    },
+    {
+      "text": "Mathlib4: Combinatorics.SimpleGraph.Hall (sufficiency direction).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Combinatorics/SimpleGraph/Hall.html"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Function",
+      "SimpleGraph"
+    ],
+    "namespace": "HallsTheoremOQ01",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/HallsTheoremOQ01.lean",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Mathlib formalizes only the hard **sufficiency** direction of Hall's marriage theorem (`exists_isMatching_of_forall_ncard_le` and the perfect-matching analogue `exists_isPerfectMatching_of_forall_ncard_le`). The elementary but essential **necessity** converse — that any matching saturating `s` forces Hall's counting condition `s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard` — is absent from Mathlib.

This entry supplies necessity as a standalone, graph-agnostic lemma (the matched-partner map injects `s` into its neighbourhood) and assembles the textbook biconditionals.

## Results (`proofs/Proofs/HallsTheoremOQ01.lean`, 127 L, 5 theorems)

- `ncard_le_ncard_biUnion_neighborSet_of_isMatching` — **necessity** of Hall's condition; holds in *any* locally finite graph (no bipartiteness needed).
- `ncard_le_of_isPerfectMatching` — the global form for a perfect matching.
- `hall_marriage` — the full biconditional: Hall's condition on `p₁` ↔ ∃ a matching saturating `p₁`.
- `hall_perfect` — the perfect-matching biconditional.
- `exists_violating_of_no_matching` — the contrapositive deficiency certificate: no saturating matching ⟹ some `s ⊆ p₁` violates Hall's condition.

## Proof sketch

Given a matching `M` whose vertex set contains `s`, the matched-partner function `φ` sends each `v` to its unique `M`-neighbour. Then (1) `φ v` is a `G`-neighbour of `v` (the matching is a subgraph), so `φ` maps `s` into the neighbourhood; (2) `φ` is injective on `s` (the matching axiom `eq_of_adj_right`); (3) an injection into a finite set does not increase `ncard`. The infinite case is vacuous via `ncard`'s convention. The biconditionals pair this with Mathlib's sufficiency direction.

## Verification

- Docker build **green**: `Build completed successfully (7743 jobs)`.
- 0 sorries, 0 `axiom` declarations, no `native_decide`/`decide`.
- Status `verified`, badge `original` — the necessity lemma and biconditionals are new content; Mathlib provides only the forward implications, used as dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)