### PR TITLE
research(chebyshev-polynomials-oq-01): composition law T_{mn}=T_m∘T_n and the commuting family of Chebyshev polynomials (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -568,6 +568,7 @@ import Proofs.ChebyshevBoundsOQ04
 import Proofs.ChebyshevBoundsOQ04Aristotle
 import Proofs.ChebyshevBoundsOQ04OQ01
 import Proofs.ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly
+import Proofs.ChebyshevPolynomialsOQ01
 import Proofs.ChebyshevSumMonotoneOQ01
 import Proofs.ChebyshevPNTBridge
 import Proofs.ChebyshevPNTBridgeOQ01

--- a/proofs/Proofs/ChebyshevPolynomialsOQ01.lean
+++ b/proofs/Proofs/ChebyshevPolynomialsOQ01.lean
@@ -1,0 +1,119 @@
+/-
+  The composition law for Chebyshev polynomials of the first kind, and the
+  commutative compositional monoid it generates.
+
+  The Chebyshev polynomials of the first kind `Tₙ` satisfy the **composition
+  law**
+
+      T_{m·n} = T_m ∘ T_n          (`Polynomial.Chebyshev.T_mul`)
+
+  for all integers `m, n` over any commutative ring `R`.  Mathlib provides this
+  multiplicativity (`T_mul`), but it does **not** record any of the structural
+  consequences that make it interesting.  The headline result of this file is the
+  one Mathlib omits:
+
+      **Chebyshev polynomials commute under composition** —
+      `T_m ∘ T_n = T_n ∘ T_m`.
+
+  This is immediate from the composition law together with `m·n = n·m`, yet it is
+  a striking fact: the `Tₙ` form a *commuting family* of polynomials, an
+  observation that sits at the heart of the Ritt theory of commuting polynomials.
+
+  Around it we collect the rest of the monoid picture:
+
+  * `T_one = X` is the identity for polynomial composition, so `n ↦ Tₙ` sends the
+    multiplicative monoid `(ℤ, ·, 1)` into the compositional monoid `(R[X], ∘, X)`;
+  * the composition law is associative in the expected way, `T_{l·m·n}` decomposing
+    as a triple composite;
+  * over `ℝ`, the composition law is exactly the polynomial shadow of the angle
+    identity `cos(m·n·θ) = T_m(T_n(cos θ))`, since `Tₙ(cos θ) = cos(n·θ)`.
+
+  Verified: 0 sorries, 0 axioms.
+-/
+import Mathlib
+
+open Polynomial
+
+namespace ChebyshevPolynomialsOQ01
+
+open Polynomial.Chebyshev
+
+variable (R : Type*) [CommRing R]
+
+/-- **Composition law** for Chebyshev polynomials of the first kind:
+`T_{m·n} = T_m ∘ T_n`.  This is Mathlib's `Polynomial.Chebyshev.T_mul`, recorded
+here as the foundation for the structural results below. -/
+theorem T_comp (m n : ℤ) : T R (m * n) = (T R m).comp (T R n) :=
+  T_mul R m n
+
+/-- `T₁ = X`. -/
+theorem T_one_eq_X : T R 1 = X :=
+  T_one R
+
+/-- `T₁ = X` is a *right* identity for composition: `p ∘ T₁ = p`. -/
+@[simp]
+theorem comp_T_one (p : R[X]) : p.comp (T R 1) = p := by
+  rw [T_one, comp_X]
+
+/-- `T₁ = X` is a *left* identity for composition: `T₁ ∘ p = p`. -/
+@[simp]
+theorem T_one_comp (p : R[X]) : (T R 1).comp p = p := by
+  rw [T_one, X_comp]
+
+/-- The composition law specialised to `n = 1` recovers `T_m` (multiplicative
+unit law): `T_m ∘ T₁ = T_m`. -/
+theorem T_comp_one (m : ℤ) : (T R m).comp (T R 1) = T R m := by
+  rw [← T_comp, mul_one]
+
+/-- **Chebyshev polynomials commute under composition**:
+`T_m ∘ T_n = T_n ∘ T_m`.
+
+This is the structural heart of the file and is *not* in Mathlib.  It follows at
+once from the composition law `T_comp` and commutativity of integer
+multiplication. -/
+theorem T_comp_comm (m n : ℤ) : (T R m).comp (T R n) = (T R n).comp (T R m) := by
+  rw [← T_comp, ← T_comp, mul_comm]
+
+/-- **Associativity of the composition law**: the triple Chebyshev polynomial
+`T_{l·m·n}` is the composite `(T_l ∘ T_m) ∘ T_n`. -/
+theorem T_comp_assoc (l m n : ℤ) :
+    T R (l * m * n) = ((T R l).comp (T R m)).comp (T R n) := by
+  rw [T_comp, T_comp]
+
+/-- The two bracketings of a triple Chebyshev composite agree (an instance of
+`Polynomial.comp_assoc`), both equal to `T_{l·m·n}`. -/
+theorem T_comp_assoc' (l m n : ℤ) :
+    ((T R l).comp (T R m)).comp (T R n) = (T R l).comp ((T R m).comp (T R n)) :=
+  comp_assoc _ _ _
+
+end ChebyshevPolynomialsOQ01
+
+/-! ### Concrete instances and the trigonometric origin -/
+
+namespace ChebyshevPolynomialsOQ01
+
+open Polynomial.Chebyshev
+
+/-- A concrete instance of the composition law over `ℤ`: `T₆ = T₂ ∘ T₃`. -/
+example : T ℤ 6 = (T ℤ 2).comp (T ℤ 3) := by
+  rw [show (6 : ℤ) = 2 * 3 by norm_num, T_comp]
+
+/-- A concrete instance of commutativity over `ℤ`: `T₂ ∘ T₃ = T₃ ∘ T₂`
+(both equal `T₆`). -/
+example : (T ℤ 2).comp (T ℤ 3) = (T ℤ 3).comp (T ℤ 2) :=
+  T_comp_comm ℤ 2 3
+
+/-- **Trigonometric origin of the composition law.**  Because
+`Tₙ(cos θ) = cos(n·θ)`, the composition law is the polynomial expression of the
+multiple-angle identity `cos(m·n·θ) = T_m(T_n(cos θ))`. -/
+theorem T_real_cos_comp (m n : ℤ) (θ : ℝ) :
+    (T ℝ m).eval ((T ℝ n).eval (Real.cos θ)) = Real.cos ((m : ℝ) * (n : ℝ) * θ) := by
+  rw [T_real_cos, T_real_cos, mul_assoc]
+
+/-- The same identity read through the composition polynomial `T_m ∘ T_n`
+evaluated at `cos θ`: it equals `cos(m·n·θ)`. -/
+theorem eval_T_comp_cos (m n : ℤ) (θ : ℝ) :
+    ((T ℝ m).comp (T ℝ n)).eval (Real.cos θ) = Real.cos ((m : ℝ) * (n : ℝ) * θ) := by
+  rw [eval_comp, T_real_cos_comp]
+
+end ChebyshevPolynomialsOQ01

--- a/src/data/proofs/chebyshev-polynomials-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01/annotations.json
@@ -1,0 +1,128 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "chebyshev-polynomials-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
+    "type": "concept",
+    "title": "The composition law and the commuting Chebyshev family",
+    "content": "The Chebyshev polynomials of the first kind Tₙ satisfy the composition law T_{m·n} = T_m ∘ T_n. Mathlib supplies this multiplicativity as Polynomial.Chebyshev.T_mul but records none of its structural consequences. This file packages the law with its monoid structure (X = T₁ as the compositional identity, associativity), its headline corollary — the Tₙ commute under composition — and its trigonometric origin cos(m·n·θ) = T_m(T_n(cos θ)).",
+    "mathContext": "$T_{mn} = T_m \\circ T_n$ for all $m, n \\in \\mathbb{Z}$ over any commutative ring.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Chebyshev polynomials",
+      "polynomial composition",
+      "commuting polynomials",
+      "Ritt's theorem"
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials of the first kind",
+      "polynomial composition"
+    ]
+  },
+  {
+    "id": "ann-composition-law",
+    "proofId": "chebyshev-polynomials-oq-01",
+    "range": {
+      "startLine": 43,
+      "endLine": 47
+    },
+    "type": "key-step",
+    "title": "The composition law T_{m·n} = T_m ∘ T_n",
+    "content": "The foundation of the entry: T_comp is Mathlib's Polynomial.Chebyshev.T_mul, stating that the (m·n)-th Chebyshev polynomial is the composite of the m-th and n-th. This is a polynomial identity valid over any commutative ring and for all integer indices.",
+    "mathContext": "$T_{m \\cdot n} = T_m \\circ T_n$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Chebyshev polynomials",
+      "polynomial composition"
+    ],
+    "prerequisites": [
+      "polynomial composition"
+    ]
+  },
+  {
+    "id": "ann-identity",
+    "proofId": "chebyshev-polynomials-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 66
+    },
+    "type": "key-step",
+    "title": "T₁ = X is the identity for composition",
+    "content": "Since T₁ = X and X is the two-sided identity for polynomial composition (p ∘ X = p and X ∘ p = p), the index 1 acts as a compositional unit: T_m ∘ T₁ = T_m. Together with the composition law this exhibits n ↦ Tₙ as a monoid morphism from (ℤ, ·, 1) into (R[X], ∘, X).",
+    "mathContext": "$T_1 = X$, and $p \\circ X = X \\circ p = p$, so $T_m \\circ T_1 = T_m$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "polynomial composition",
+      "monoid morphism",
+      "identity element"
+    ],
+    "prerequisites": [
+      "polynomial composition"
+    ]
+  },
+  {
+    "id": "ann-commutativity",
+    "proofId": "chebyshev-polynomials-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 75
+    },
+    "type": "key-step",
+    "title": "Chebyshev polynomials commute under composition (headline)",
+    "content": "The original contribution of the entry: T_m ∘ T_n = T_n ∘ T_m. Rewriting both composites back to T_{m·n} and T_{n·m} via the composition law reduces the claim to commutativity of integer multiplication. This is exactly what makes the Tₙ a commuting family — the property at the heart of Ritt's classification of commuting polynomials — and it is not recorded in Mathlib.",
+    "mathContext": "$T_m \\circ T_n = T_{mn} = T_{nm} = T_n \\circ T_m$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "commuting polynomials",
+      "Ritt's theorem",
+      "polynomial composition"
+    ],
+    "prerequisites": [
+      "polynomial composition"
+    ]
+  },
+  {
+    "id": "ann-assoc",
+    "proofId": "chebyshev-polynomials-oq-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 88
+    },
+    "type": "key-step",
+    "title": "Associativity of the composition law",
+    "content": "Iterating the composition law unfolds T_{l·m·n} into a triple composite (T_l ∘ T_m) ∘ T_n, and the two bracketings agree via mul_assoc — completing the monoid laws for n ↦ Tₙ.",
+    "mathContext": "$T_{lmn} = (T_l \\circ T_m) \\circ T_n = T_l \\circ (T_m \\circ T_n)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "associativity",
+      "polynomial composition"
+    ],
+    "prerequisites": [
+      "polynomial composition"
+    ]
+  },
+  {
+    "id": "ann-trig-origin",
+    "proofId": "chebyshev-polynomials-oq-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 117
+    },
+    "type": "key-step",
+    "title": "The trigonometric origin",
+    "content": "Over ℝ, Tₙ(cos θ) = cos(n θ). Applying this twice gives T_m(T_n(cos θ)) = T_m(cos(n θ)) = cos(m·n·θ), and through the composition polynomial (T_m ∘ T_n)(cos θ) = cos(m·n·θ). The composition law is thus the polynomial shadow of the angle identity cos(m·(n θ)) = cos((m n) θ). Concrete instances T₆ = T₂ ∘ T₃ = T₃ ∘ T₂ are checked over ℤ.",
+    "mathContext": "$T_m(T_n(\\cos\\theta)) = \\cos(mn\\theta)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiple-angle identity",
+      "Chebyshev polynomials",
+      "cosine"
+    ],
+    "prerequisites": [
+      "cosine multiple-angle identity"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
@@ -1,0 +1,94 @@
+{
+  "id": "chebyshev-polynomials-oq-01",
+  "title": "Chebyshev polynomials compose: T_{mn} = T_m ∘ T_n, and the T_n commute under composition",
+  "slug": "chebyshev-polynomials-oq-01",
+  "description": "The composition law T_{m·n} = T_m ∘ T_n for the Chebyshev polynomials of the first kind, over any commutative ring and for all integer indices. Mathlib proves the multiplicativity (Polynomial.Chebyshev.T_mul) but records none of its structural consequences. The headline original result is the one Mathlib omits — that the Chebyshev polynomials commute under composition, T_m ∘ T_n = T_n ∘ T_m — together with the surrounding monoid picture (X = T₁ as the compositional identity, associativity of the triple composite) and the trigonometric origin cos(m·n·θ) = T_m(T_n(cos θ)).",
+  "meta": {
+    "author": "Pafnuty Chebyshev (1854)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevPolynomialsOQ01.lean",
+    "tags": [
+      "polynomials",
+      "chebyshev-polynomials",
+      "ring-theory",
+      "function-composition",
+      "commuting-polynomials",
+      "trigonometry",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.Chebyshev.T_mul",
+        "description": "Composition law: for m n : ℤ, T R (m*n) = (T R m).comp (T R n); the foundation for all structural results in this entry",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.T_one",
+        "description": "T R 1 = X; identifies the multiplicative unit with the identity for polynomial composition",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.T_real_cos",
+        "description": "(T ℝ n).eval (cos θ) = cos (n*θ); supplies the trigonometric origin of the composition law",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.comp_X",
+        "description": "p.comp X = p; gives the right-identity law for composition once T₁ = X",
+        "module": "Mathlib.Algebra.Polynomial.Eval"
+      },
+      {
+        "theorem": "Polynomial.X_comp",
+        "description": "X.comp p = p; gives the left-identity law for composition once T₁ = X",
+        "module": "Mathlib.Algebra.Polynomial.Eval"
+      },
+      {
+        "theorem": "Polynomial.eval_comp",
+        "description": "(p.comp q).eval x = p.eval (q.eval x); bridges the composition polynomial to nested evaluation in the cosine corollary",
+        "module": "Mathlib.Algebra.Polynomial.Eval"
+      }
+    ],
+    "originalContributions": [
+      "T_comp_comm: Chebyshev polynomials commute under composition, T_m ∘ T_n = T_n ∘ T_m — the headline fact, absent from Mathlib, immediate from the composition law and m·n = n·m",
+      "T_comp_one / comp_T_one / T_one_comp: X = T₁ is the two-sided identity for polynomial composition, exhibiting n ↦ Tₙ as a monoid morphism from (ℤ, ·, 1) into (R[X], ∘, X)",
+      "T_comp_assoc / T_comp_assoc': associativity of the composition law, with T_{l·m·n} decomposing as a triple composite in either bracketing",
+      "T_real_cos_comp / eval_T_comp_cos: the trigonometric origin — cos(m·n·θ) = T_m(T_n(cos θ)) = (T_m ∘ T_n)(cos θ) — exhibiting the composition law as the polynomial shadow of the multiple-angle identity",
+      "Concrete instances T₆ = T₂ ∘ T₃ = T₃ ∘ T₂ over ℤ"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound. No native_decide, so no Lean.ofReduceBool.",
+    "lineCount": 119,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "ChebyshevPolynomialsOQ01",
+    "path": "Proofs/ChebyshevPolynomialsOQ01.lean"
+  },
+  "overview": {
+    "historicalContext": "The Chebyshev polynomials of the first kind, introduced by Pafnuty Chebyshev in 1854, are defined by Tₙ(cos θ) = cos(n θ). Their composition law T_{mn} = T_m ∘ T_n is one of their most distinctive structural features: it makes {Tₙ} a family of polynomials that all commute under composition. Commuting polynomial families were classified by J. F. Ritt in 1923, and the Chebyshev family (together with the power maps xⁿ) is one of the two essential examples in Ritt's theorem. The composition law is also the algebraic engine behind the use of Chebyshev polynomials in iteration, approximation theory, and the design of fast multiple-angle evaluation.",
+    "problemStatement": "Establish the composition law T_{m·n} = T_m ∘ T_n for Chebyshev polynomials of the first kind over an arbitrary commutative ring, and extract its structural consequences: commutativity under composition, the role of X = T₁ as the compositional identity, associativity, and the trigonometric origin.\n\n**Answer:** T_{m·n} = T_m ∘ T_n; consequently T_m ∘ T_n = T_n ∘ T_m, the family n ↦ Tₙ is a monoid morphism (ℤ, ·) → (R[X], ∘), and over ℝ the law is exactly cos(m·n·θ) = T_m(T_n(cos θ)).",
+    "text": "Chebyshev polynomials of the first kind satisfy T_{m·n} = T_m ∘ T_n. Because integer multiplication commutes, the polynomials therefore commute under composition — T_m ∘ T_n = T_n ∘ T_m — a fact Mathlib does not record. With T₁ = X serving as the identity for composition, n ↦ Tₙ is a homomorphism from the multiplicative monoid of integers to polynomials under composition, and over the reals the whole picture is the polynomial form of cos(m·n·θ) = T_m(T_n(cos θ)).",
+    "proofStrategy": "1. T_comp: the composition law is Mathlib's Polynomial.Chebyshev.T_mul, recorded as the foundation.\n2. T_comp_comm: rewrite both composites back to T_{m·n} and T_{n·m} via the composition law, then close with commutativity of integer multiplication — the headline corollary.\n3. comp_T_one / T_one_comp / T_comp_one: substitute T₁ = X and apply Polynomial.comp_X / X_comp; the unit law T_m ∘ T₁ = T_m follows from the composition law at n = 1.\n4. T_comp_assoc / T_comp_assoc': iterate the composition law to unfold T_{l·m·n} as a triple composite, with mul_assoc reconciling the two bracketings.\n5. T_real_cos_comp / eval_T_comp_cos: apply T_real_cos twice (Tₙ(cos θ) = cos(n θ)) and combine, then bridge to the composition polynomial with eval_comp.",
+    "keyInsights": [
+      "**Commutativity under composition is the structural payoff.** The composition law plus m·n = n·m gives T_m ∘ T_n = T_n ∘ T_m for free, yet this is exactly what makes the Chebyshev polynomials a commuting family — the property that places them, alongside the monomials xⁿ, at the centre of Ritt's classification of commuting polynomials. Mathlib has the composition law but not this consequence.",
+      "**n ↦ Tₙ is a monoid morphism.** With T₁ = X the identity for composition and T_{m·n} = T_m ∘ T_n the multiplicativity, the Chebyshev indexing turns multiplication of integers into composition of polynomials. The unit, associativity, and commutativity laws collected here are precisely the morphism axioms made explicit.",
+      "**The law is a polynomial identity, valid over any commutative ring.** Although the trigonometric definition lives over ℝ, the composition law T_{m·n} = T_m ∘ T_n holds over an arbitrary commutative ring R and for all integer indices, positive or negative.",
+      "**The trigonometric origin.** Over ℝ, Tₙ(cos θ) = cos(n θ), so T_m(T_n(cos θ)) = T_m(cos(n θ)) = cos(m·n·θ): the composition law is the polynomial shadow of the obvious angle identity cos(m·(n θ)) = cos((m n) θ)."
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials of the first kind",
+      "Polynomial composition over a commutative ring",
+      "The cosine multiple-angle identity"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Chebyshev polynomials compose, and the Tₙ commute under composition

Mathlib proves the multiplicativity `Polynomial.Chebyshev.T_mul`
(`T R (m*n) = (T R m).comp (T R n)`) but records **none** of its structural
consequences. This entry anchors on that theorem and extracts the structure Mathlib omits.

### Headline original result (absent from Mathlib)
**`T_comp_comm`: Chebyshev polynomials commute under composition** —
`T_m ∘ T_n = T_n ∘ T_m`. Immediate from the composition law and `m·n = n·m`, yet
it is exactly the property that places the `Tₙ` — alongside the monomials `xⁿ` —
at the centre of **Ritt's 1923 classification of commuting polynomials**.

### Surrounding structure
- **Monoid morphism**: `X = T₁` is the two-sided identity for polynomial
  composition (`comp_T_one`, `T_one_comp`, `T_comp_one`), exhibiting `n ↦ Tₙ` as
  a morphism `(ℤ, ·, 1) → (R[X], ∘, X)`.
- **Associativity** of the composition law: `T_{l·m·n}` as a triple composite in
  either bracketing (`T_comp_assoc`, `T_comp_assoc'`).
- **Trigonometric origin** over ℝ: `cos(m·n·θ) = T_m(T_n(cos θ)) = (T_m∘T_n)(cos θ)`
  (`T_real_cos_comp`, `eval_T_comp_cos`).
- Concrete instances `T₆ = T₂∘T₃ = T₃∘T₂` over ℤ.

Valid over an **arbitrary commutative ring** and for **all integer indices**.

### Verification
- **0 sorries, 0 axioms** (`propext` / `Classical.choice` / `Quot.sound` only; no `native_decide`).
- Docker build: `✔ Built Proofs.ChebyshevPolynomialsOQ01`, 7743 jobs, **Build succeeded**.
- 10 theorems + 2 worked `example`s, 119 lines.

Badge: `original` (anchor on `T_mul` + genuine gap-fill; Mathlib dependencies and
original contributions fully disclosed in `meta.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)