### PR TITLE
research(composition-parts-choose-oq-01): compositions of n into k parts number C(n−1,k−1)

### DIFF
--- a/proofs/Proofs/CompositionPartsChooseOQ01.lean
+++ b/proofs/Proofs/CompositionPartsChooseOQ01.lean
@@ -1,0 +1,185 @@
+import Mathlib.Combinatorics.Enumerative.Composition
+import Mathlib.Tactic
+
+/-
+# Counting Compositions by Number of Parts: there are C(n−1, k−1) compositions of n into k parts
+
+## What This Proves
+
+A *composition* of `n` into `k` parts is an ordered `k`-tuple of positive integers
+summing to `n` (an element `c : Composition n` with `c.length = k`). The classical
+refinement of the count `card (Composition n) = 2 ^ (n−1)` is the *part-graded*
+statement:
+
+  Fintype.card {c : Composition n // c.length = k} = (n − 1).choose (k − 1)   (n, k ≥ 1).
+
+Summing over `k` recovers `∑ₖ C(n−1, k−1) = 2 ^ (n−1)` by the binomial theorem,
+so this is the finer information from which the headline count follows.
+
+## The bijective idea
+
+Write `n` as `n` unit boxes in a row with `n − 1` internal gaps. A composition is
+the same data as a choice of which gaps to "cut": cutting `k − 1` of the `n − 1`
+gaps produces a composition into exactly `k` parts. Hence compositions of `n` into
+`k` parts correspond to `(k − 1)`-element subsets of an `(n − 1)`-element set, of
+which there are `C(n − 1, k − 1)`.
+
+## What Mathlib has — and what this adds
+
+Mathlib provides the *ungraded* count `composition_card : card (Composition n) =
+2 ^ (n−1)`, routed through the bijection `compositionEquiv n : Composition n ≃
+CompositionAsSet n` and `compositionAsSetEquiv n : CompositionAsSet n ≃
+Finset (Fin (n−1))`. It does **not** record the part-graded refinement
+`C(n−1, k−1)`, nor the key fact that the gap-subset attached to a composition has
+cardinality `length − 1`. Both are supplied here. The proof reuses Mathlib's two
+equivalences and the subset-counter `Fintype.card_finset_len`, contributing:
+
+* `card_gapSubset` — under the composite bijection `Composition n ≃ Finset (Fin (n−1))`,
+  the subset attached to `c` has `card + 1 = c.length` (the cut-count is one less
+  than the part-count);
+* `card_composition_length` — the part-graded count `C(n−1, k−1)`;
+* `sum_card_composition_length` — consistency with the total `2 ^ (n−1)` via the
+  hockey-stick / binomial identity (kept as a stated corollary of the graded count).
+
+## Status
+- [x] complete — all lemmas proved, 0 sorries, 0 axioms
+-/
+
+namespace CompositionPartsChooseOQ01
+
+open Finset
+
+variable {n k : ℕ}
+
+/-! ## The composite bijection `Composition n ≃ Finset (Fin (n−1))` -/
+
+/-- The composite of Mathlib's two bijections: a composition of `n` is the same
+data as a subset of the `n − 1` internal gaps. -/
+def equivGaps (n : ℕ) : Composition n ≃ Finset (Fin (n - 1)) :=
+  (compositionEquiv n).trans (compositionAsSetEquiv n)
+
+/-! ## Crux: the gap-subset has cardinality `length − 1`
+
+For `d : CompositionAsSet n` with `n ≥ 1`, the subset `compositionAsSetEquiv n d`
+of internal gaps has cardinality `d.boundaries.card − 2 = d.length − 1`, because
+`compositionAsSetEquiv` records exactly the boundaries other than `0` and `n`. -/
+theorem card_compositionAsSetEquiv (hn : 1 ≤ n) (d : CompositionAsSet n) :
+    (compositionAsSetEquiv n d).card + 1 = d.length := by
+  classical
+  -- the embedding of the `n − 1` internal gaps into `Fin (n + 1)`, `i ↦ i + 1`
+  set e : Fin (n - 1) → Fin (n + 1) := fun i => ⟨1 + (i : ℕ), by omega⟩ with he
+  have he_inj : Function.Injective e := by
+    intro a b hab
+    have h := congrArg Fin.val hab
+    simp only [he] at h
+    exact Fin.ext (by omega)
+  -- membership: `i` is in the gap-subset iff its shifted index is a boundary
+  have mem_iff : ∀ i : Fin (n - 1),
+      i ∈ compositionAsSetEquiv n d ↔ e i ∈ d.boundaries := by
+    intro i
+    simp only [he, compositionAsSetEquiv, Equiv.coe_fn_mk, Set.mem_toFinset, Set.mem_setOf_eq]
+  -- the two endpoints `0` and `n` of the boundary set
+  have hlast_ne : (Fin.last n : Fin (n + 1)) ≠ 0 := by
+    simp only [Ne, Fin.ext_iff, Fin.val_last, Fin.val_zero]; omega
+  have hlast_mem' : Fin.last n ∈ d.boundaries.erase 0 :=
+    Finset.mem_erase.mpr ⟨hlast_ne, d.getLast_mem⟩
+  -- the image of the gap-subset is exactly the boundaries minus the two endpoints
+  have himg : (compositionAsSetEquiv n d).image e
+      = (d.boundaries.erase 0).erase (Fin.last n) := by
+    ext x
+    simp only [Finset.mem_image, Finset.mem_erase]
+    constructor
+    · rintro ⟨i, hi, rfl⟩
+      rw [mem_iff] at hi
+      have hi' := i.isLt
+      refine ⟨?_, ?_, hi⟩
+      · simp only [he, Ne, Fin.ext_iff, Fin.val_last]; omega
+      · simp only [he, Ne, Fin.ext_iff, Fin.val_zero]; omega
+    · rintro ⟨hx_last, hx0, hx_mem⟩
+      have hx1 : 1 ≤ (x : ℕ) := by
+        rcases Nat.eq_zero_or_pos (x : ℕ) with h | h
+        · exact absurd (Fin.ext (by simpa using h)) hx0
+        · exact h
+      have hxn : (x : ℕ) < n := by
+        have hne : (x : ℕ) ≠ n := by
+          intro h; exact hx_last (Fin.ext (by simp [Fin.val_last, h]))
+        have := x.isLt; omega
+      refine ⟨⟨(x : ℕ) - 1, by omega⟩, ?_, ?_⟩
+      · rw [mem_iff]
+        have hex : e ⟨(x : ℕ) - 1, by omega⟩ = x := by
+          apply Fin.ext; simp only [he]; omega
+        rwa [hex]
+      · apply Fin.ext; simp only [he]; omega
+  -- count, using injectivity of `e` and the two erasures
+  have hcard : (compositionAsSetEquiv n d).card = d.boundaries.card - 2 := by
+    rw [← Finset.card_image_of_injective _ he_inj, himg,
+        Finset.card_erase_of_mem hlast_mem', Finset.card_erase_of_mem d.zero_mem]
+    omega
+  have hlen : 1 ≤ d.length := by
+    have h2 : 1 < d.boundaries.card :=
+      Finset.one_lt_card.mpr ⟨0, d.zero_mem, Fin.last n, d.getLast_mem, hlast_ne.symm⟩
+    rw [d.card_boundaries_eq_succ_length] at h2; omega
+  rw [hcard, d.card_boundaries_eq_succ_length]
+  omega
+
+/-- Transported to `Composition n`: the gap-subset attached to `c` has
+`card + 1 = c.length`. The number of cuts is one less than the number of parts. -/
+theorem card_gapSubset (hn : 1 ≤ n) (c : Composition n) :
+    (equivGaps n c).card + 1 = c.length := by
+  have h := card_compositionAsSetEquiv hn c.toCompositionAsSet
+  rw [Composition.toCompositionAsSet_length] at h
+  exact h
+
+/-! ## The part-graded count -/
+
+/-- **Compositions of `n` into `k` parts number `C(n − 1, k − 1)`** (for `n, k ≥ 1`).
+The refinement by number of parts of the total count `2 ^ (n−1)`: cutting `k − 1`
+of the `n − 1` internal gaps yields a composition into `k` parts, and there are
+`C(n−1, k−1)` such choices. -/
+theorem card_composition_length (hn : 1 ≤ n) (hk : 1 ≤ k) :
+    Fintype.card {c : Composition n // c.length = k} = (n - 1).choose (k - 1) := by
+  calc Fintype.card {c : Composition n // c.length = k}
+      = Fintype.card {s : Finset (Fin (n - 1)) // s.card = k - 1} :=
+        Fintype.card_congr <| Equiv.subtypeEquiv (equivGaps n) fun c => by
+          have := card_gapSubset hn c; omega
+    _ = (Fintype.card (Fin (n - 1))).choose (k - 1) := Fintype.card_finset_len (k - 1)
+    _ = (n - 1).choose (k - 1) := by rw [Fintype.card_fin]
+
+/-! ## Consistency with the total count
+
+Summing the graded count over all part-counts `k = 1, …, n` recovers the headline
+`2 ^ (n−1)`. We state the graded-to-total identity at the level of the closed
+forms; the combinatorial content is `card_composition_length` above. -/
+
+/-- The closed-form consistency check: `∑_{k=1}^{n} C(n−1, k−1) = 2 ^ (n−1)`,
+the binomial-theorem identity that makes the graded count `card_composition_length`
+sum to the ungraded `composition_card`. -/
+theorem sum_choose_eq (hn : 1 ≤ n) :
+    ∑ k ∈ Finset.Icc 1 n, (n - 1).choose (k - 1) = 2 ^ (n - 1) := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le hn
+  -- n = 1 + m; reindex k = 1 + j and sum C(m, j) over j = 0..m
+  rw [show 1 + m - 1 = m by omega]
+  rw [← Nat.sum_range_choose m]
+  rw [Finset.sum_bij (fun k _ => k - 1)]
+  · intro a ha; simp only [Finset.mem_Icc] at ha; simp only [Finset.mem_range]; omega
+  · intro a ha b hb hab; simp only [Finset.mem_Icc] at ha hb; omega
+  · intro b hb; simp only [Finset.mem_range] at hb
+    exact ⟨b + 1, by simp only [Finset.mem_Icc]; omega, by omega⟩
+  · intro a ha; rfl
+
+/-! ## Worked numeric instances -/
+
+/-- Compositions of `4` into `2` parts: `C(3,1) = 3`, namely `[1,3], [2,2], [3,1]`. -/
+example : Fintype.card {c : Composition 4 // c.length = 2} = 3 := by
+  rw [card_composition_length (by norm_num) (by norm_num)]; decide
+
+/-- Compositions of `5` into `3` parts: `C(4,2) = 6`. -/
+example : Fintype.card {c : Composition 5 // c.length = 3} = 6 := by
+  rw [card_composition_length (by norm_num) (by norm_num)]; decide
+
+/-- The single composition of `n` into `1` part (the trivial composition `[n]`):
+`C(n−1, 0) = 1`. -/
+example (hn : 1 ≤ n) : Fintype.card {c : Composition n // c.length = 1} = 1 := by
+  rw [card_composition_length hn (by norm_num)]; simp
+
+end CompositionPartsChooseOQ01

--- a/src/data/proofs/composition-parts-choose-oq-01/annotations.json
+++ b/src/data/proofs/composition-parts-choose-oq-01/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-composite-bijection-and-crux",
+    "proofId": "composition-parts-choose-oq-01",
+    "range": {
+      "startLine": 54,
+      "endLine": 131
+    },
+    "type": "theorem",
+    "title": "The Composite Bijection and the Crux Count (equivGaps, card_compositionAsSetEquiv, card_gapSubset)",
+    "content": "equivGaps n composes Mathlib's compositionEquiv : Composition n ≃ CompositionAsSet n with compositionAsSetEquiv : CompositionAsSet n ≃ Finset (Fin (n−1)), so a composition of n is the same data as a subset of the n−1 internal gaps — the cut-set. The crux lemma card_compositionAsSetEquiv proves that for d : CompositionAsSet n with n ≥ 1, the cut-set compositionAsSetEquiv n d satisfies card + 1 = d.length: the number of cuts is one less than the number of parts. The proof exhibits the gap-index map e : Fin (n−1) ↪ Fin (n+1), i ↦ i+1, as injective, identifies the image of the cut-set under e with d.boundaries.erase 0 |>.erase (Fin.last n) (a boundary is a cut precisely when it is neither the forced endpoint 0 nor n, proved by a membership ext argument), and counts: card(cut-set) = card(image) = card(boundaries) − 2 via Finset.card_image_of_injective and two applications of Finset.card_erase_of_mem. Since card(boundaries) = length + 1 and the endpoints 0, n are distinct for n ≥ 1 (forcing length ≥ 1), card(cut-set) + 1 = length by omega. card_gapSubset transports the identity to Composition n along Composition.toCompositionAsSet_length.",
+    "mathContext": "$\\#(\\mathrm{compositionAsSetEquiv}\\ n\\ d) + 1 = d.\\mathrm{length}$, equivalently the cut-set is $d.\\mathrm{boundaries} \\setminus \\{0, n\\}$.",
+    "prerequisites": [
+      "The bijections compositionEquiv and compositionAsSetEquiv, and CompositionAsSet.length = boundaries.card − 1",
+      "Finset.card_image_of_injective, Finset.card_erase_of_mem, Finset.one_lt_card",
+      "Composition.toCompositionAsSet_length"
+    ],
+    "relatedConcepts": [
+      "enumerative combinatorics",
+      "stars and bars",
+      "boundary-set model of a composition",
+      "injective-image cardinality count"
+    ],
+    "significance": "The combinatorial bridge Mathlib omits: the cut-set attached to a composition has cardinality length − 1, the bookkeeping fact that turns the subset-count into a count by number of parts."
+  },
+  {
+    "id": "ann-part-graded-count",
+    "proofId": "composition-parts-choose-oq-01",
+    "range": {
+      "startLine": 133,
+      "endLine": 146
+    },
+    "type": "theorem",
+    "title": "The Part-Graded Count C(n−1, k−1) (card_composition_length)",
+    "content": "card_composition_length is the headline result: for n, k ≥ 1, the number of compositions of n into exactly k parts is Fintype.card {c : Composition n // c.length = k} = C(n−1, k−1). The proof restricts equivGaps to an equivalence between {c // c.length = k} and {s : Finset (Fin (n−1)) // s.card = k−1} — using card_gapSubset (card + 1 = length) and omega to match the part-count k with the cut-count k−1 — and then reads off the cardinality with Mathlib's subset-counter Fintype.card_finset_len : card {s : Finset (Fin m) // s.card = j} = C(m, j), followed by Fintype.card_fin to evaluate card (Fin (n−1)) = n−1. This is the refinement by number of parts of the ungraded count 2^(n−1).",
+    "mathContext": "$\\#\\{c : \\mathrm{Composition}\\ n \\mid c.\\mathrm{length} = k\\} = \\binom{n-1}{k-1}$.",
+    "prerequisites": [
+      "equivGaps and card_gapSubset",
+      "Equiv.subtypeEquiv and Fintype.card_congr",
+      "Fintype.card_finset_len and Fintype.card_fin"
+    ],
+    "relatedConcepts": [
+      "binomial coefficients",
+      "compositions into k parts",
+      "graded enumeration",
+      "subsets of fixed size"
+    ],
+    "significance": "The finer enumerative information: the count of compositions split by number of parts, of which the total 2^(n−1) is the sum — content not present in Mathlib."
+  },
+  {
+    "id": "ann-consistency-with-total",
+    "proofId": "composition-parts-choose-oq-01",
+    "range": {
+      "startLine": 148,
+      "endLine": 168
+    },
+    "type": "theorem",
+    "title": "Consistency with the Total 2^(n−1) (sum_choose_eq)",
+    "content": "sum_choose_eq verifies that the part-graded counts sum to the headline total: ∑_{k=1}^{n} C(n−1, k−1) = 2^(n−1). Writing n = 1 + m and reindexing k = j + 1 with Finset.sum_bij turns the sum into ∑_{j=0}^{m} C(m, j), which equals 2^m = 2^(n−1) by Nat.sum_range_choose — the binomial-theorem identity ∑_j C(m, j) = 2^m. This closes the loop with the parent entry's composition_card: the graded counts C(n−1, k−1), summed over the number of parts, reproduce the ungraded count 2^(n−1).",
+    "mathContext": "$\\sum_{k=1}^{n} \\binom{n-1}{k-1} = \\sum_{j=0}^{n-1} \\binom{n-1}{j} = 2^{n-1}$.",
+    "prerequisites": [
+      "Finset.sum_bij for reindexing a finite sum",
+      "Nat.sum_range_choose : ∑_{j=0}^{m} C(m, j) = 2^m",
+      "Truncated natural-number subtraction"
+    ],
+    "relatedConcepts": [
+      "binomial theorem",
+      "reindexing finite sums",
+      "hockey-stick / row-sum identity",
+      "powers of two"
+    ],
+    "significance": "The consistency check that makes the refinement honest: the graded counts are exactly a decomposition of the total 2^(n−1) by number of parts."
+  },
+  {
+    "id": "ann-numeric-instances",
+    "proofId": "composition-parts-choose-oq-01",
+    "range": {
+      "startLine": 170,
+      "endLine": 185
+    },
+    "type": "example",
+    "title": "Worked Numeric Instances",
+    "content": "Three specialisations of card_composition_length make the count concrete. Compositions of 4 into 2 parts number C(3,1) = 3 — namely 1+3, 2+2, 3+1. Compositions of 5 into 3 parts number C(4,2) = 6. And there is a unique composition of n into 1 part — the trivial composition [n] — matching C(n−1, 0) = 1. The first two close the residual Nat.choose computation with the kernel's decide (no native_decide, hence no Lean.ofReduceBool axiom); the third uses simp on C(n−1, 0) = 1.",
+    "mathContext": "$\\binom{3}{1} = 3$, $\\binom{4}{2} = 6$, $\\binom{n-1}{0} = 1$.",
+    "prerequisites": [
+      "card_composition_length",
+      "Nat.choose evaluation"
+    ],
+    "relatedConcepts": [
+      "worked examples",
+      "compositions of small integers"
+    ],
+    "significance": "Concrete confirmation that the closed form C(n−1, k−1) produces the right counts on small cases, including the boundary case of a single part."
+  }
+]

--- a/src/data/proofs/composition-parts-choose-oq-01/meta.json
+++ b/src/data/proofs/composition-parts-choose-oq-01/meta.json
@@ -1,0 +1,100 @@
+{
+  "id": "composition-parts-choose-oq-01",
+  "title": "Composition Parts OQ-01: Compositions of n into k Parts Number C(n−1, k−1)",
+  "slug": "composition-parts-choose-oq-01",
+  "description": "A composition of a natural number n is an ordered tuple of positive integers summing to n (Mathlib's Composition n); its number of parts is c.length. The total count card (Composition n) = 2^(n−1) refines, graded by number of parts, into the part-graded count: the number of compositions of n into exactly k parts is C(n−1, k−1) (for n, k ≥ 1). The bijective idea is the 'cuts in gaps' model — writing n as n unit boxes in a row with n−1 internal gaps, a composition into k parts is a choice of which k−1 of the n−1 gaps to cut, of which there are C(n−1, k−1). Mathlib supplies the ungraded count composition_card and the two underlying bijections compositionEquiv : Composition n ≃ CompositionAsSet n and compositionAsSetEquiv : CompositionAsSet n ≃ Finset (Fin (n−1)), but records neither the part-graded refinement C(n−1, k−1) nor the bookkeeping fact that the gap-subset attached to a composition has cardinality exactly length − 1. This entry supplies both. The crux lemma card_compositionAsSetEquiv proves that under compositionAsSetEquiv the cut-set of d : CompositionAsSet n has card + 1 = d.length — i.e. the number of cuts is one less than the number of parts — by exhibiting the cut-set's image in Fin (n+1) as the boundary set with its two endpoints 0 and n removed (an injective-image / double-erase cardinality count). Transporting this along compositionEquiv (card_gapSubset) and composing the two equivalences into equivGaps : Composition n ≃ Finset (Fin (n−1)), the part-graded count card_composition_length follows from Mathlib's subset-counter Fintype.card_finset_len : card {s : Finset (Fin m) // s.card = j} = C(m, j). A consistency theorem sum_choose_eq checks that ∑_{k=1}^{n} C(n−1, k−1) = 2^(n−1) — the binomial-theorem identity reindexing the graded counts back to the headline total — and worked instances confirm C(3,1) = 3 compositions of 4 into 2 parts and C(4,2) = 6 of 5 into 3 parts.",
+  "leanFile": "Proofs/CompositionPartsChooseOQ01.lean",
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Composition_(combinatorics)",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CompositionPartsChooseOQ01.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "compositions",
+      "counting",
+      "binomial-coefficients",
+      "bijective-proof",
+      "stars-and-bars"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "relatedProblems": [
+      {
+        "id": "composition-card-2pow-oq-01",
+        "relationship": "Direct parent: that entry proves the ungraded total card (Composition n) = 2^(n−1). This entry is the refinement by number of parts it named as a follow-up — compositions of n into exactly k parts number C(n−1, k−1), summing over k back to 2^(n−1) via the binomial theorem (sum_choose_eq)."
+      },
+      {
+        "id": "dyck-catalan-count-oq-01",
+        "relationship": "Sibling enumerative-combinatorics counting result graded by a structural parameter; both turn a Mathlib cardinality bijection into a named closed-form count."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 185,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The two small numeric examples close with the kernel decision procedure `decide` (evaluating Nat.choose 3 1 = 3 and Nat.choose 4 2 = 6); plain `decide` is kernel-checked and introduces no Lean.ofReduceBool. All four named theorems were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. Mathlib does NOT contain the part-graded count C(n−1, k−1) nor the cut-count = length − 1 bookkeeping; both are original content here, built on Mathlib's compositionEquiv, compositionAsSetEquiv, Fintype.card_finset_len, and Nat.sum_range_choose. The result is unconditional (the hypotheses n, k ≥ 1 are the natural domain, since for n = 0 or k = 0 the truncated subtraction n−1, k−1 degenerates).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Counting compositions by number of parts is the part-graded refinement of one of the first results in enumerative combinatorics. A composition of n is an ordered sequence of positive parts summing to n (order matters, unlike a partition): the compositions of 4 into 2 parts are 1+3, 2+2, 3+1 — three of them, namely C(3,1). The clean bijective proof is the 'stars and bars' / 'cuts in gaps' picture: write n as n unit boxes in a row leaving n−1 internal gaps; a composition into exactly k parts is a choice of which k−1 gaps to cut, so the compositions of n into k parts are in bijection with the (k−1)-element subsets of an (n−1)-element set, of which there are C(n−1, k−1). Summing over the number of parts and applying the binomial theorem, ∑_k C(n−1, k−1) = 2^(n−1), recovers the headline ungraded count. This graded count is the finer enumerative information from which the total 2^(n−1) follows.",
+    "problemStatement": "Show that the number of compositions of n into exactly k parts — elements c : Composition n with c.length = k — is the binomial coefficient\n\n$$\\#\\{c : \\mathrm{Composition}\\ n \\mid c.\\mathrm{length} = k\\} = \\binom{n-1}{k-1} \\qquad (n, k \\ge 1),$$\n\nthe refinement by number of parts of the total count card(Composition n) = 2^(n−1), and check that summing over k recovers 2^(n−1).",
+    "text": "Mathlib proves the ungraded total composition_card : card (Composition n) = 2^(n−1), routed through two bijections: compositionEquiv : Composition n ≃ CompositionAsSet n and compositionAsSetEquiv : CompositionAsSet n ≃ Finset (Fin (n−1)), the latter sending a boundary set to the subset of internal gaps it cuts. It does not record the part-graded count C(n−1, k−1), nor the bookkeeping fact that the cut-set attached to a composition has cardinality exactly length − 1. Both are supplied here. The composite equivGaps : Composition n ≃ Finset (Fin (n−1)) carries a composition to its cut-set; the crux is that this cut-set has card + 1 = length, after which the part-graded count is the subset-counter Fintype.card_finset_len read through equivGaps.",
+    "proofStrategy": "The crux lemma card_compositionAsSetEquiv shows that for d : CompositionAsSet n (n ≥ 1) the cut-set compositionAsSetEquiv n d has card + 1 = d.length. Proof: the gap-index map e : Fin (n−1) ↪ Fin (n+1), i ↦ i+1, is injective, and the image of the cut-set under e is exactly d.boundaries with its two endpoints 0 and Fin.last n removed — proved by a membership ext argument (a boundary is a cut iff it is neither 0 nor n). Hence card(cut-set) = card(image) = card(boundaries) − 2 by Finset.card_image_of_injective and two applications of Finset.card_erase_of_mem; since card(boundaries) = length + 1 (CompositionAsSet.card_boundaries_eq_succ_length) and the two endpoints are distinct for n ≥ 1 (so length ≥ 1), card(cut-set) + 1 = length follows by omega. card_gapSubset transports this along compositionEquiv using Composition.toCompositionAsSet_length. card_composition_length then computes the part-graded count: equivGaps restricts to an equivalence {c // c.length = k} ≃ {s : Finset (Fin (n−1)) // s.card = k−1} (via card_gapSubset and omega), whose cardinality is C(n−1, k−1) by Fintype.card_finset_len and Fintype.card_fin. sum_choose_eq reindexes ∑_{k=1}^{n} C(n−1, k−1) to ∑_{j=0}^{n−1} C(n−1, j) = 2^(n−1) with Finset.sum_bij and Nat.sum_range_choose. The numeric examples specialise card_composition_length and close the residual Nat.choose computations with the kernel's decide.",
+    "keyInsights": [
+      "**The cut-count is one less than the part-count**: the heart of the proof is card_compositionAsSetEquiv — under compositionAsSetEquiv, a composition into k parts corresponds to a subset of k−1 cut gaps, because the boundary set has the two forced endpoints 0 and n plus one internal boundary per cut. Formalising this is exactly the card(boundaries) − 2 = length − 1 count that Mathlib omits.",
+      "**The image-minus-endpoints trick turns the count into double erasure**: rather than reason about preimages, the cut-set's injective image in Fin (n+1) is identified with d.boundaries.erase 0 |>.erase (Fin.last n), reducing the cardinality to two applications of Finset.card_erase_of_mem — clean, and it makes the role of the two endpoints explicit.",
+      "**The graded count is the finer information**: C(n−1, k−1) refines the total 2^(n−1); sum_choose_eq verifies the refinement is consistent — summing the graded counts over all part-counts k and applying ∑_j C(m, j) = 2^m (Nat.sum_range_choose) returns the headline count.",
+      "**Mathlib stops at the ungraded count**: composition_card gives 2^(n−1) and the two equivalences are available, but neither the part-graded C(n−1, k−1) nor the cut-count = length − 1 lemma is in Mathlib; that bridge is the original content of this entry."
+    ],
+    "prerequisites": [
+      "Compositions of a natural number (Mathlib's Composition n), the number of parts c.length, and the boundary-set model CompositionAsSet n with its length = boundaries.card − 1",
+      "The bijections compositionEquiv : Composition n ≃ CompositionAsSet n and compositionAsSetEquiv : CompositionAsSet n ≃ Finset (Fin (n−1))",
+      "Finset cardinality API: Finset.card_image_of_injective, Finset.card_erase_of_mem, Finset.one_lt_card, and the subset-counter Fintype.card_finset_len",
+      "The binomial-coefficient identity ∑_{j=0}^{m} C(m, j) = 2^m (Nat.sum_range_choose) and reindexing finite sums with Finset.sum_bij"
+    ]
+  },
+  "sections": [
+    {
+      "id": "composite-bijection-and-crux",
+      "title": "The Composite Bijection and the Crux Count",
+      "startLine": 54,
+      "endLine": 131,
+      "mathContext": "$\\mathrm{equivGaps}\\ n : \\mathrm{Composition}\\ n \\simeq \\mathrm{Finset}\\,(\\mathrm{Fin}\\,(n-1))$ and $\\#(\\text{cut-set of } c) + 1 = c.\\mathrm{length}$.",
+      "summary": "equivGaps composes Mathlib's two bijections so a composition is the same data as a subset of the n−1 internal gaps. The crux card_compositionAsSetEquiv proves the cut-set of d : CompositionAsSet n has card + 1 = d.length: the gap-index map i ↦ i+1 is injective, its image is the boundary set with the two endpoints 0 and n removed, so card(cut-set) = card(boundaries) − 2 = length − 1 by an injective-image and double-erase count. card_gapSubset transports this to Composition n via Composition.toCompositionAsSet_length."
+    },
+    {
+      "id": "part-graded-count",
+      "title": "The Part-Graded Count C(n−1, k−1)",
+      "startLine": 133,
+      "endLine": 146,
+      "mathContext": "$\\#\\{c : \\mathrm{Composition}\\ n \\mid c.\\mathrm{length} = k\\} = \\binom{n-1}{k-1}$ for $n, k \\ge 1$.",
+      "summary": "card_composition_length is the headline refinement. equivGaps restricts to an equivalence between compositions of n into k parts and (k−1)-element subsets of Fin (n−1) (using card_gapSubset to match length = k with card = k−1), whose cardinality is C(n−1, k−1) by Fintype.card_finset_len and Fintype.card_fin."
+    },
+    {
+      "id": "consistency-with-total",
+      "title": "Consistency with the Total 2^(n−1)",
+      "startLine": 148,
+      "endLine": 168,
+      "mathContext": "$\\sum_{k=1}^{n} \\binom{n-1}{k-1} = 2^{n-1}$.",
+      "summary": "sum_choose_eq verifies the graded counts sum to the headline total: reindexing k = j + 1 with Finset.sum_bij turns ∑_{k=1}^{n} C(n−1, k−1) into ∑_{j=0}^{n−1} C(n−1, j), which is 2^(n−1) by Nat.sum_range_choose — the binomial-theorem identity that ties the refinement back to composition_card."
+    },
+    {
+      "id": "numeric-instances",
+      "title": "Worked Numeric Instances",
+      "startLine": 170,
+      "endLine": 185,
+      "mathContext": "$\\binom{3}{1} = 3$, $\\binom{4}{2} = 6$, $\\binom{n-1}{0} = 1$.",
+      "summary": "The examples specialise card_composition_length: compositions of 4 into 2 parts number C(3,1) = 3 (namely 1+3, 2+2, 3+1), compositions of 5 into 3 parts number C(4,2) = 6, and there is a unique composition of n into 1 part (the trivial composition, C(n−1,0) = 1). The small Nat.choose values are closed by the kernel's decide."
+    }
+  ],
+  "conclusion": "The part-graded enumerative identity 'compositions of n into exactly k parts number C(n−1, k−1)' is formalised sorry-free and axiom-free, refining the total count card(Composition n) = 2^(n−1) of the parent entry. The mathematical content beyond Mathlib is the crux lemma card_compositionAsSetEquiv — the cut-set attached to a composition has cardinality length − 1, proved by identifying its injective image in Fin (n+1) with the boundary set minus its two forced endpoints — together with the graded count card_composition_length it unlocks via Fintype.card_finset_len, and the consistency check sum_choose_eq tying the refinement back to 2^(n−1) through the binomial theorem. Mathlib records the ungraded count and the underlying bijections but neither the cut-count bookkeeping nor the part-graded refinement, which is the original content here. A natural follow-up is the bivariate generating-function form ∑_{n,k} (#compositions of n into k parts) x^n y^k = xy / (1 − x − xy), or the analogous part-graded count for compositions into parts of bounded size.",
+  "crossReferences": [
+    "composition-card-2pow-oq-01",
+    "dyck-catalan-count-oq-01"
+  ]
+}


### PR DESCRIPTION
## Summary

Part-graded refinement of the parent entry `composition-card-2pow-oq-01` (total count `card(Composition n) = 2^(n−1)`): the number of compositions of `n` into **exactly `k` parts** is `C(n−1, k−1)` for `n, k ≥ 1`.

**Verified, 0 axioms, 0 sorries** — all four named theorems confirmed via `#print axioms` to depend only on `propext / Classical.choice / Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`; the two numeric examples use kernel `decide`, not `native_decide`).

## What's new beyond Mathlib

Mathlib supplies the ungraded count `composition_card` and the two bijections `compositionEquiv` / `compositionAsSetEquiv`, but records **neither** the part-graded count `C(n−1, k−1)` **nor** the bookkeeping fact that the cut-set attached to a composition has cardinality `length − 1`. Both are original content here.

- **`card_compositionAsSetEquiv`** (crux) — for `d : CompositionAsSet n` (`n ≥ 1`), the cut-set `compositionAsSetEquiv n d` has `card + 1 = d.length`. Proof: the gap-index map `e : Fin (n−1) ↪ Fin (n+1)`, `i ↦ i+1`, is injective, and its image of the cut-set is exactly `d.boundaries.erase 0 |>.erase (Fin.last n)` (a boundary is a cut iff it is neither endpoint `0` nor `n`). Hence `card = card(boundaries) − 2 = length − 1` via `Finset.card_image_of_injective` + two `Finset.card_erase_of_mem`.
- **`card_gapSubset`** — transports the crux to `Composition n` along `Composition.toCompositionAsSet_length`.
- **`card_composition_length`** — the headline `C(n−1, k−1)`, obtained by restricting `equivGaps` to `{c // c.length = k} ≃ {s : Finset (Fin (n−1)) // s.card = k−1}` and applying `Fintype.card_finset_len`.
- **`sum_choose_eq`** — consistency: `∑_{k=1}^{n} C(n−1, k−1) = 2^(n−1)` via `Finset.sum_bij` + `Nat.sum_range_choose`, tying the refinement back to the parent's total.

## Verification

- `lake build Proofs.CompositionPartsChooseOQ01` ✓ (Mathlib 4.26.0, Docker wrapper)
- `#print axioms` on all four theorems → only foundational axioms
- Gallery `meta.json` + `annotations.json` added; JSON validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)