### PR TITLE
research(area-of-circle reparam OQ): pin change-of-variables API + lift harness blackout (ORIENT)

### DIFF
--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md
@@ -99,11 +99,39 @@ This is an OBSERVE/ORIENT survey only — no proof was attempted or claimed.
 
 ---
 
+### Session 2026-06-20 (s02, ORIENT, researcher-12) — harness up; change-of-variables API pinned
+
+**Outcome: surveyed (held).** Re-confirmed S1's analysis against the live pin and parent file,
+and de-risked the eventual build by locating the exact Mathlib lemmas.
+
+- **Parent re-verified:** `AreaOfCircleOQ01OQ02OQ02OQ01.lean` is registered and proves
+  `isoperimetric_inequality` (line 368) from **5 disclosed axioms** — `fourier_decomp_exists`,
+  `exists_nice_reparam`, `wirtinger_sum_bound`, `area_cauchy_schwarz_bound`,
+  `integral_cauchy_schwarz_sq`. This is a properly-`axiomatized` entry (not an integrity
+  violation); the OQ targets discharging just `exists_nice_reparam`. The Lean proof routes
+  through the reparam axiom **plus** the Wirtinger/Cauchy–Schwarz axioms (line 372 onward), so
+  the Gap-2 circularity is a statement about the axiom's *logical strength*, not a literal
+  one-line collapse inside the file — but S1's point stands: as written, the witness is only
+  required to *share* `γ`'s area/circumference, not to *be* a reparametrization of `γ`.
+- **Harness now UP:** Docker build verified working this session (used it on a sibling entry),
+  lifting S1's "build blackout" caveat. The build is now *attemptable*, just large.
+- **Change-of-variables API located (was an S1 assumption):** Mathlib provides
+  `intervalIntegral.integral_comp_mul_deriv` / `integral_comp_smul_deriv` (and primed variants)
+  in `Mathlib/MeasureTheory/Integral/IntervalIntegral/IntegrationByParts.lean:317–387`. These
+  are exactly the substitution lemmas needed to prove reparametrization-invariance of arc length
+  and signed area once the structure is amended — confirming the ~400–800 LOC estimate is
+  API-supported, not blocked on a missing change-of-variables theorem.
+
 ## Next Steps
 
 1. Propose amending the parent proof: add `regular` field to `SmoothClosedCurve` and restate
-   `exists_nice_reparam` as a genuine reparametrization (`γ' = γ ∘ φ`).
-2. Only then attempt the IFT-based arc-length construction (needs Mathlib FTC +
-   inverse-function-theorem APIs; ~400–800 lines).
-3. Revisit once the verification harness (Docker / Aristotle) is back — the construction is
-   build-heavy and unverifiable during the current blackout.
+   `exists_nice_reparam` as a genuine reparametrization (`γ' = γ ∘ φ`). **(Touches a verified
+   gallery entry — do via a separate companion + a deliberate parent-edit PR, not in-place
+   blindly.)**
+2. Build the reparametrization-invariance lemmas FIRST as a standalone companion using
+   `intervalIntegral.integral_comp_mul_deriv` (located this session): for a `C¹` increasing
+   `φ` with `φ(2π)−φ(0)=2π`, both `circumference` and signed `area` are invariant. This is the
+   mathematical heart of Gap 2 and is verifiable in isolation without risking the parent.
+3. Then attempt the IFT-based arc-length construction (Mathlib FTC + inverse-function-theorem;
+   the regular-curve hypothesis from step 1 makes `s'(t)=|γ'(t)|>0`, enabling the `C¹` inverse).
+   ~400–800 lines total; harness is up, so it is now attemptable.

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md
@@ -2,17 +2,19 @@
 
 ## Current State
 **Phase**: ORIENT
-**Status**: BLOCKED
+**Status**: BLOCKED (large build) — harness now UP
 **Path**: full
 **Since**: 2026-06-13
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 Feasibility of discharging the `exists_nice_reparam` axiom via the inverse function theorem.
-ORIENT survey complete — see knowledge.md (session 2026-06-13 s01). Flagged BLOCKED: the
-only remaining route is a ~400-800 line build-gated construction that also requires amending
-the parent proof's `SmoothClosedCurve` definition first (see Blockers). Not actionable during
-the current verification blackout (Docker down + Aristotle 404). Do not re-survey.
+S1 (2026-06-13) survey + s02 (2026-06-20, r12) refinement — see knowledge.md. Still
+BLOCKED only by the *size* of the construction (~400-800 LOC + a parent-definition amendment),
+not by missing infrastructure: s02 confirmed the **harness is back up** and located the exact
+Mathlib change-of-variables lemmas (`intervalIntegral.integral_comp_mul_deriv`) needed for the
+reparametrization-invariance step. Recommended first concrete deliverable: a **standalone
+reparam-invariance companion** (no parent risk).
 
 ## Active Approach
 None viable as-stated. The IFT route is blocked by two specification gaps in the parent


### PR DESCRIPTION
## Summary

Knowledge-only ORIENT refinement of `area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01` — discharging the `exists_nice_reparam` axiom in the Fourier/Hurwitz isoperimetric proof via the inverse function theorem. No Lean is shipped; the problem remains gated on a large build, but this session **de-risks the eventual attempt** and corrects an S1 assumption.

- **Parent re-verified:** `AreaOfCircleOQ01OQ02OQ02OQ01.lean` proves `isoperimetric_inequality` from **5 disclosed axioms** (properly `axiomatized`); the OQ targets discharging just `exists_nice_reparam`. S1's two gaps re-confirmed — the structure has no regularity field (`|γ'|>0`, needed for the IFT), and the axiom only requires the witness to *share* γ's area/circumference, not to *be* a reparametrization of γ.
- **Harness now UP:** Docker build verified working this session, lifting S1's "build blackout" caveat — the ~400–800 LOC construction is now attemptable.
- **Change-of-variables API located** (S1 had only assumed it): `intervalIntegral.integral_comp_mul_deriv` / `integral_comp_smul_deriv` in `MeasureTheory/Integral/IntervalIntegral/IntegrationByParts.lean:317–387` — exactly the substitution lemmas for proving reparametrization-invariance of arc length and signed area.

**Recommended next deliverable:** a standalone reparam-invariance companion (circumference + signed area invariant under a $C^1$ increasing $φ$ with $φ(2π)-φ(0)=2π$), verifiable in isolation without touching the verified parent — this is the mathematical heart of Gap 2.

Status held **`surveyed`** (blocked only by build size, not infrastructure).

## Files
- `research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md` — session s02
- `research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md` — status refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)