### PR TITLE
research(general-quartic-oq-02): eliminate final 3 axioms — fully verified 0-axiom Ferrari quartic

### DIFF
--- a/proofs/Proofs/GeneralQuartic.lean
+++ b/proofs/Proofs/GeneralQuartic.lean
@@ -21,16 +21,19 @@ can be solved by radicals using Ferrari's method (1540).
   2. Introduce auxiliary parameter m and rewrite as difference of squares
   3. Solve the resolvent cubic for m
   4. Factor quartic into two quadratics and apply quadratic formula
-- **Status:** The algebraic manipulations are verified. The connection to the
-  resolvent cubic formula (Wiedijk #37) is shown. Proof gaps are captured via
-  documented axioms pending formal verification of algebraic identities.
+- **Status:** Axiom-free. All algebraic manipulations are verified, and the
+  three former structural axioms (`quartic_has_four_roots`, `biquadratic_forward`,
+  `biquadratic_backward`) are now discharged as theorems from Mathlib's FTA
+  infrastructure and the complex quadratic formula. The connection to the
+  resolvent cubic formula (Wiedijk #37) is shown.
 
 ## Status
 - [x] Depressed quartic reduction theorem
 - [x] Ferrari's resolvent cubic derivation
 - [x] Factorization into quadratics (given m)
-- [ ] Explicit solution using cubic formula (depends on #244)
-- [ ] Complete verification of all four roots
+- [x] Four-roots existence via FTA (`quartic_has_four_roots`, no axiom)
+- [x] Biquadratic (q = 0) case solved by radicals (no axiom)
+- [x] 0 axioms, 0 sorries — fully machine-checked
 
 ## Mathematical Background
 
@@ -96,11 +99,13 @@ noncomputable def depressionCoeffs (a b c d : ℂ) : ℂ × ℂ × ℂ :=
   let r := d - a * c / 4 + a^2 * b / 16 - 3 * a^4 / 256
   (p, q, r)
 
-/-! ## Proved Results and Remaining Axioms
+/-! ## Proved Results (formerly Axioms)
 
 The depressed quartic forward/backward transformations and the resolvent cubic existence
-have been fully proved. The remaining axioms capture Ferrari's factorization and the
-biquadratic special case, which require more intricate algebraic manipulation. -/
+are proved by ring identities and the Fundamental Theorem of Algebra. The structural
+results that were once axioms — `quartic_has_four_roots` (FTA), `biquadratic_forward`,
+and `biquadratic_backward` (the complex quadratic formula) — are now all discharged as
+theorems, so this file is axiom-free. -/
 
 /-- **Depressed Quartic Forward** (formerly axiom, now proved)
 The substitution y = x + a/4 transforms the general quartic x^4 + ax^3 + bx^2 + cx + d = 0
@@ -261,29 +266,76 @@ theorem resolvent_cubic_has_root (p q r : ℂ) :
   intro h0
   exact hcoeff (by rw [Polynomial.eq_C_of_degree_le_zero (le_of_eq h0)]; simp [Polynomial.coeff_C])
 
-/-- **Axiom: Quartic Has Four Roots**
-By the Fundamental Theorem of Algebra, a degree 4 polynomial over ℂ has exactly 4 roots
-(counted with multiplicity). These roots can be expressed in terms of radicals via
-Ferrari's method. -/
-axiom quartic_has_four_roots (a b c d : ℂ) :
+/-- **Theorem: Quartic Has Four Roots**
+By the Fundamental Theorem of Algebra (ℂ is algebraically closed), the monic
+degree-4 polynomial `quarticPoly a b c d` has a root multiset of cardinality 4.
+Listing its (not necessarily distinct) roots `r₁,r₂,r₃,r₄`, a complex number is a
+root of the quartic iff it equals one of them. Previously an axiom; now discharged
+from Mathlib's FTA infrastructure (`splits_iff_card_roots`, `mem_roots`). -/
+theorem quartic_has_four_roots (a b c d : ℂ) :
     ∃ (r₁ r₂ r₃ r₄ : ℂ),
-      ∀ x : ℂ, (quarticPoly a b c d).eval x = 0 ↔ (x = r₁ ∨ x = r₂ ∨ x = r₃ ∨ x = r₄)
+      ∀ x : ℂ, (quarticPoly a b c d).eval x = 0 ↔ (x = r₁ ∨ x = r₂ ∨ x = r₃ ∨ x = r₄) := by
+  have hmonic : (quarticPoly a b c d).Monic := by unfold quarticPoly; monicity!
+  have hdeg : (quarticPoly a b c d).natDegree = 4 := by unfold quarticPoly; compute_degree!
+  set P := quarticPoly a b c d with hP
+  have hPne : P ≠ 0 := hmonic.ne_zero
+  have hsplits : P.Splits := IsAlgClosed.splits P
+  have hcard4 : Multiset.card P.roots = 4 := by
+    rw [Polynomial.splits_iff_card_roots.mp hsplits, hdeg]
+  obtain ⟨r₁, hr₁mem⟩ := Multiset.card_pos_iff_exists_mem.mp (by rw [hcard4]; norm_num)
+  have hcard3 : Multiset.card (P.roots.erase r₁) = 3 := by
+    rw [Multiset.card_erase_of_mem hr₁mem, hcard4]; rfl
+  obtain ⟨r₂, r₃, r₄, herase⟩ := Multiset.card_eq_three.mp hcard3
+  refine ⟨r₁, r₂, r₃, r₄, fun x => ?_⟩
+  constructor
+  · intro hx
+    have hmem : x ∈ P.roots := (Polynomial.mem_roots hPne).mpr hx
+    rw [← Multiset.cons_erase hr₁mem, herase] at hmem
+    simp only [Multiset.insert_eq_cons, Multiset.mem_cons, Multiset.mem_singleton] at hmem
+    tauto
+  · intro hx
+    have hmem : x ∈ P.roots := by
+      rw [← Multiset.cons_erase hr₁mem, herase]
+      simp only [Multiset.insert_eq_cons, Multiset.mem_cons, Multiset.mem_singleton]
+      tauto
+    exact (Polynomial.mem_roots hPne).mp hmem
 
-/-- **Axiom: Biquadratic Forward**
-When q = 0, the depressed quartic y^4 + py^2 + r = 0 reduces to a quadratic in z = y^2.
-The solutions z = y^2 are given by the quadratic formula. -/
-axiom biquadratic_forward (p r y : ℂ)
+/-- **Theorem: Biquadratic Forward**
+When q = 0, the depressed quartic y⁴ + py² + r = 0 reduces to a quadratic in z = y².
+Setting `s = √(p²−4r)` (the principal complex square root, `s² = p²−4r` even when the
+radicand is 0), the identity `(2y²+p−s)(2y²+p+s) = 4(y⁴+py²+r) + (p²−4r−s²)` shows the
+product vanishes, so `y²` equals one of `(−p±s)/2`. Previously an axiom. -/
+theorem biquadratic_forward (p r y : ℂ)
     (h : y^4 + p * y^2 + 0 * y + r = 0) :
     (y^2 = (-p + Complex.cpow (p^2 - 4*r) (1/2 : ℂ)) / 2) ∨
-    (y^2 = (-p - Complex.cpow (p^2 - 4*r) (1/2 : ℂ)) / 2)
+    (y^2 = (-p - Complex.cpow (p^2 - 4*r) (1/2 : ℂ)) / 2) := by
+  have hs2 : (Complex.cpow (p^2 - 4*r) (1/2 : ℂ)) ^ 2 = p^2 - 4*r := by
+    have hh := Complex.cpow_nat_inv_pow (p^2 - 4*r) (n := 2) (by norm_num)
+    rwa [show ((2 : ℕ) : ℂ)⁻¹ = (1/2 : ℂ) by norm_num] at hh
+  set s := Complex.cpow (p^2 - 4*r) (1/2 : ℂ)
+  have key : (2 * y^2 + p - s) * (2 * y^2 + p + s) = 0 := by
+    have hexp : (2 * y^2 + p - s) * (2 * y^2 + p + s)
+        = 4 * (y^4 + p * y^2 + 0 * y + r) + (p^2 - 4*r - s^2) := by ring
+    rw [hexp, h, hs2]; ring
+  rcases mul_eq_zero.mp key with h1 | h1
+  · left; linear_combination h1 / 2
+  · right; linear_combination h1 / 2
 
-/-- **Axiom: Biquadratic Backward**
-If y^2 equals one of the two solutions from the quadratic formula, then y is a root
-of the biquadratic y^4 + py^2 + r = 0. -/
-axiom biquadratic_backward (p r y : ℂ)
+/-- **Theorem: Biquadratic Backward**
+If `y²` equals one of `(−p±√(p²−4r))/2`, then `y` is a root of the biquadratic
+y⁴ + py² + r = 0. The converse of `biquadratic_forward`; proved by substituting each
+value and using `s² = p²−4r`. Previously an axiom. -/
+theorem biquadratic_backward (p r y : ℂ)
     (h : (y^2 = (-p + Complex.cpow (p^2 - 4*r) (1/2 : ℂ)) / 2) ∨
          (y^2 = (-p - Complex.cpow (p^2 - 4*r) (1/2 : ℂ)) / 2)) :
-    y^4 + p * y^2 + 0 * y + r = 0
+    y^4 + p * y^2 + 0 * y + r = 0 := by
+  have hs2 : (Complex.cpow (p^2 - 4*r) (1/2 : ℂ)) ^ 2 = p^2 - 4*r := by
+    have hh := Complex.cpow_nat_inv_pow (p^2 - 4*r) (n := 2) (by norm_num)
+    rwa [show ((2 : ℕ) : ℂ)⁻¹ = (1/2 : ℂ) by norm_num] at hh
+  set s := Complex.cpow (p^2 - 4*r) (1/2 : ℂ)
+  have hy4 : y^4 + p * y^2 + 0 * y + r = (y^2)^2 + p * (y^2) + r := by ring
+  rw [hy4]
+  rcases h with h1 | h1 <;> rw [h1] <;> linear_combination hs2 / 4
 
 /-- Any general quartic can be reduced to depressed form via substitution. -/
 theorem quartic_to_depressed (a b c d : ℂ) :
@@ -297,12 +349,12 @@ theorem quartic_to_depressed (a b c d : ℂ) :
              eval_pow, eval_X, eval_C]
   constructor
   · intro h
-    -- Apply axiom for forward direction
+    -- Apply forward direction
     have := depressed_quartic_forward a b c d x
     simp only [quarticPoly, eval_add, eval_mul, eval_pow, eval_X, eval_C] at this
     exact this h
   · intro h
-    -- Apply axiom for backward direction
+    -- Apply backward direction
     have := depressed_quartic_backward a b c d (x + a / 4)
     simp only [depressedQuartic, depressionCoeffs, eval_add, eval_mul, eval_pow, eval_X, eval_C] at this
     have h2 := this h
@@ -475,10 +527,10 @@ theorem biquadratic_simple (p r : ℂ) :
   simp only [depressedQuartic, eval_add, eval_mul, eval_pow, eval_X, eval_C]
   constructor
   · intro h
-    -- Apply axiom for forward direction (biquadratic case is q = 0)
+    -- Apply forward direction (biquadratic case is q = 0)
     exact biquadratic_forward p r y h
   · intro h
-    -- Apply axiom for backward direction
+    -- Apply backward direction
     exact biquadratic_backward p r y h
 
 /-! ## Part VI.5: Biquadratic-Limit Removable Singularity (OQ-02.c)

--- a/src/data/proofs/general-quartic/annotations.json
+++ b/src/data/proofs/general-quartic/annotations.json
@@ -123,7 +123,7 @@
     },
     "type": "concept",
     "title": "Explicit Root Formulas",
-    "content": "**Ferrari's Four Roots**:\n\nWith $\\alpha = \\sqrt{2m + p}$, $\\beta = q/(2\\alpha)$:\n\n$$y_{1,2} = \\frac{-\\alpha \\pm \\sqrt{\\alpha^2 - 4(p/2 + m + \\beta)}}{2}$$\n$$y_{3,4} = \\frac{\\alpha \\pm \\sqrt{\\alpha^2 - 4(p/2 + m - \\beta)}}{2}$$\n\n**For general quartic**: Subtract $a/4$ from each $y_i$.\n\n**Lean Implementation**:\n```lean\ndef ferrariRoots (p q r m : ℂ) : ℂ × ℂ × ℂ × ℂ := ...\n```\n\nThe axiom `ferrari_roots_verify` ensures these satisfy the equation.",
+    "content": "**Ferrari's Four Roots**:\n\nWith $\\alpha = \\sqrt{2m + p}$, $\\beta = q/(2\\alpha)$:\n\n$$y_{1,2} = \\frac{-\\alpha \\pm \\sqrt{\\alpha^2 - 4(p/2 + m + \\beta)}}{2}$$\n$$y_{3,4} = \\frac{\\alpha \\pm \\sqrt{\\alpha^2 - 4(p/2 + m - \\beta)}}{2}$$\n\n**For general quartic**: Subtract $a/4$ from each $y_i$.\n\n**Lean Implementation**:\n```lean\ndef ferrariRoots (p q r m : ℂ) : ℂ × ℂ × ℂ × ℂ := ...\n```\n\nThe theorem `ferrari_roots_verify_ne` (proved, under the non-degeneracy hypothesis `2m + p ≠ 0`) ensures these satisfy the equation.",
     "mathContext": "explicit radical expressions",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -7,7 +7,7 @@
     "author": "Lodovico Ferrari (1540), published by Cardano (1545)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Quartic_equation",
     "date": "1540",
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "algebra",
       "polynomial",
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/GeneralQuartic.lean",
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -35,21 +35,23 @@
       "Ferrari's resolvent cubic derivation",
       "Factorization into quadratics framework",
       "Explicit Ferrari root formulas",
-      "Biquadratic special case simplification"
+      "Biquadratic special case simplification",
+      "Four-roots existence discharged from Mathlib FTA (quartic_has_four_roots)",
+      "Biquadratic forward/backward solved by radicals via the complex quadratic formula (no axioms)"
     ],
     "dateAdded": "2025-12-28",
     "wiedijkNumber": 46,
-    "axiomCount": 3,
-    "lineCount": 758,
+    "axiomCount": 0,
+    "lineCount": 814,
     "prerequisites": [
       "Complex numbers and polynomial evaluation",
       "Cubic equation solution (Cardano's formula)",
       "Quadratic formula for complex coefficients",
       "Completing the square and factorization techniques"
     ],
-    "assumptions": "3 axioms (all FTA / quadratic-formula level): quartic_has_four_roots, biquadratic_forward, biquadratic_backward. Previously-axiomatized results now proved: depressed_quartic_forward/backward (ring identity), resolvent_cubic_has_root (FTA), ferrari_factorization_forward/backward (S8: deleted, ferrari_factorization delegates to S7 `*_ne` proofs), ferrari_roots_verify (S8: replaced by proved `ferrari_roots_verify_ne` under `2m+p ≠ 0`). S3 (OQ-02.c) discharges `ferrari_biquad_limit` (was the file's only sorry) without introducing new axioms. S5a (OQ-02.a substrate) adds `resolvent_cubic_eval_s_form` (Newton-polygon-cleaned resolvent identity `R\u0303(s) = s\u00b3 + 2p\u00b7s\u00b2 + (p\u00b2 \u2212 4r)\u00b7s \u2212 q\u00b2` via `m \u21a6 (s \u2212 p)/2`; ring-discharged). S5b SCAFFOLD-1 specializes Lemma 1 to the Pan witness `(-1, t\u00b2, 1/4 \u2212 t\u00b2 + t\u2074/4)`: `pan_witness_cleaned_resolvent` proves `R\u0303(s; -1, t\u00b2, ...) = s\u00b3 \u2212 2s\u00b2 + (4t\u00b2 \u2212 t\u2074)s \u2212 t\u2074` (ring-discharged via S5a). At `t=0` this is `s\u00b2(s\u22122)`, exposing the double-root tangency that drives the `\u03b1(t)=\u0398(t)` first-order cancellation. S5b SCAFFOLD-3 (this commit) adds `pan_witness_t_zero_nondegenerate_root`: at the Pan witness's `t=0` boundary `(p,q,r) = (-1,0,1/4)`, `m = 3/2` is the explicit non-degenerate (`2m+p = 2 \u2260 0`) resolvent root, the s=2 root of the factored form `s\u00b2(s-2)` translated back to m-coordinates via m=(s+1)/2. Makes `ferrari_biquad_limit (-1) (1/4) hpr` concrete and fixes the third root location for the future `pan_witness_k1_tangency` perturbation analysis. S6 BUGFIX (2026-06-04) repaired `p+m` vs `p/2+m` factor-constant convention in `ferrari_factorization_forward/backward` axioms and the `ferrariRoots` def. S7 SOUND DISCHARGE (2026-06-09) ships 3 proved theorems + 1 helper: `ferrari_factorization_id` (polynomial identity `F₁·F₂ = y⁴ + py² + qy + r` given Vieta-completion hypotheses `α² = 2m+p`, `2αβ = q`, `(p+m)² − β² = r`; ring-discharged), `ferrari_hβ₂_of_resolvent` (with `α ≠ 0`, the resolvent cubic gives `(p+m)² − β² = r` after multiplying through 4α² and cancelling), and `ferrari_factorization_backward_ne / _forward_ne` (sound theorems under `α ≠ 0`, replacing the existing axioms in all downstream uses). Identifies residual S6 gap: legacy `*_forward/backward` axioms remain unsound at `α = 0` (β unconstrained by vacuous `hβ`), but the gap is **latent** — never exercised, since `ferrari_biquad_limit` always selects `2m+p ≠ 0`. Axiom count steady at 6, but 2 axioms now superseded by sound theorems in their actual usage range; clean axiom-elimination PR queued for next session. S8 AXIOM ELIMINATION (2026-06-13) cuts axiom count 6 → 3: deletes `ferrari_factorization_forward/backward` (theorem `ferrari_factorization` now delegates to S7's `*_ne` proofs, gaining hypothesis `α ≠ 0`), and replaces `ferrari_roots_verify` — found latently FALSE at `α = 0` (counterexample `(p,q,r,m) = (0,0,1,0)` makes it prove `1 = 0`, the same `α = 0` soundness gap S7 found for factorization) — with the proved theorem `ferrari_roots_verify_ne` under hypothesis `2m + p ≠ 0`, proved via per-root Ferrari-factor membership (`(√·)² = ·` identity) plus `ferrari_factorization_backward_ne`. `ferrari_roots_are_roots` and `ferrari_biquad_limit`'s `hsub_B` thread the non-degeneracy hypothesis (both call sites already establish `2m+p ≠ 0`). Remaining 3 axioms are all genuinely hard FTA / quadratic-formula results. Docker build verified (3058 jobs, success); 0 sorries.",
+    "assumptions": "3 axioms (all FTA / quadratic-formula level): quartic_has_four_roots, biquadratic_forward, biquadratic_backward. Previously-axiomatized results now proved: depressed_quartic_forward/backward (ring identity), resolvent_cubic_has_root (FTA), ferrari_factorization_forward/backward (S8: deleted, ferrari_factorization delegates to S7 `*_ne` proofs), ferrari_roots_verify (S8: replaced by proved `ferrari_roots_verify_ne` under `2m+p ≠ 0`). S3 (OQ-02.c) discharges `ferrari_biquad_limit` (was the file's only sorry) without introducing new axioms. S5a (OQ-02.a substrate) adds `resolvent_cubic_eval_s_form` (Newton-polygon-cleaned resolvent identity `R\u0303(s) = s\u00b3 + 2p\u00b7s\u00b2 + (p\u00b2 \u2212 4r)\u00b7s \u2212 q\u00b2` via `m \u21a6 (s \u2212 p)/2`; ring-discharged). S5b SCAFFOLD-1 specializes Lemma 1 to the Pan witness `(-1, t\u00b2, 1/4 \u2212 t\u00b2 + t\u2074/4)`: `pan_witness_cleaned_resolvent` proves `R\u0303(s; -1, t\u00b2, ...) = s\u00b3 \u2212 2s\u00b2 + (4t\u00b2 \u2212 t\u2074)s \u2212 t\u2074` (ring-discharged via S5a). At `t=0` this is `s\u00b2(s\u22122)`, exposing the double-root tangency that drives the `\u03b1(t)=\u0398(t)` first-order cancellation. S5b SCAFFOLD-3 (this commit) adds `pan_witness_t_zero_nondegenerate_root`: at the Pan witness's `t=0` boundary `(p,q,r) = (-1,0,1/4)`, `m = 3/2` is the explicit non-degenerate (`2m+p = 2 \u2260 0`) resolvent root, the s=2 root of the factored form `s\u00b2(s-2)` translated back to m-coordinates via m=(s+1)/2. Makes `ferrari_biquad_limit (-1) (1/4) hpr` concrete and fixes the third root location for the future `pan_witness_k1_tangency` perturbation analysis. S6 BUGFIX (2026-06-04) repaired `p+m` vs `p/2+m` factor-constant convention in `ferrari_factorization_forward/backward` axioms and the `ferrariRoots` def. S7 SOUND DISCHARGE (2026-06-09) ships 3 proved theorems + 1 helper: `ferrari_factorization_id` (polynomial identity `F₁·F₂ = y⁴ + py² + qy + r` given Vieta-completion hypotheses `α² = 2m+p`, `2αβ = q`, `(p+m)² − β² = r`; ring-discharged), `ferrari_hβ₂_of_resolvent` (with `α ≠ 0`, the resolvent cubic gives `(p+m)² − β² = r` after multiplying through 4α² and cancelling), and `ferrari_factorization_backward_ne / _forward_ne` (sound theorems under `α ≠ 0`, replacing the existing axioms in all downstream uses). Identifies residual S6 gap: legacy `*_forward/backward` axioms remain unsound at `α = 0` (β unconstrained by vacuous `hβ`), but the gap is **latent** — never exercised, since `ferrari_biquad_limit` always selects `2m+p ≠ 0`. Axiom count steady at 6, but 2 axioms now superseded by sound theorems in their actual usage range; clean axiom-elimination PR queued for next session. S8 AXIOM ELIMINATION (2026-06-13) cuts axiom count 6 → 3: deletes `ferrari_factorization_forward/backward` (theorem `ferrari_factorization` now delegates to S7's `*_ne` proofs, gaining hypothesis `α ≠ 0`), and replaces `ferrari_roots_verify` — found latently FALSE at `α = 0` (counterexample `(p,q,r,m) = (0,0,1,0)` makes it prove `1 = 0`, the same `α = 0` soundness gap S7 found for factorization) — with the proved theorem `ferrari_roots_verify_ne` under hypothesis `2m + p ≠ 0`, proved via per-root Ferrari-factor membership (`(√·)² = ·` identity) plus `ferrari_factorization_backward_ne`. `ferrari_roots_are_roots` and `ferrari_biquad_limit`'s `hsub_B` thread the non-degeneracy hypothesis (both call sites already establish `2m+p ≠ 0`). Remaining 3 axioms are all genuinely hard FTA / quadratic-formula results. Docker build verified (3058 jobs, success); 0 sorries. S9 FINAL AXIOM ELIMINATION (2026-06-20) cuts axiom count 3 → 0, making the file fully machine-checked: `quartic_has_four_roots` is now proved from Mathlib's FTA infrastructure (`IsAlgClosed.splits`, `splits_iff_card_roots`, `Multiset.card_eq_three`, `mem_roots`) — the monic degree-4 quartic splits over ℂ, its root multiset has cardinality 4, and membership is reduced to equality with one of the four listed roots. `biquadratic_forward` and `biquadratic_backward` are proved from the complex quadratic formula: with `s = (p²−4r)^(1/2)` satisfying `s² = p²−4r` (via `Complex.cpow_nat_inv_pow`, valid even when the radicand is 0), the identity `(2y²+p−s)(2y²+p+s) = 4(y⁴+py²+r) + (p²−4r−s²)` gives both directions by `mul_eq_zero` and `linear_combination`. `#print axioms` on all three confirms dependence only on `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`). Docker build verified (3058 jobs, success); 0 axioms, 0 sorries — entry re-badged axiomatized→verified.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 21,
+    "theoremCount": 24,
     "definitionCount": 5
   },
   "overview": {
@@ -89,10 +91,10 @@
     },
     {
       "id": "proved-results-and-axioms",
-      "title": "Proved Results and Remaining Axioms",
+      "title": "Proved Results (formerly Remaining Axioms)",
       "startLine": 93,
       "endLine": 306,
-      "summary": "The depressed-quartic forward/backward transforms (proved via `linear_combination`), the sound Ferrari-factorization substrate `ferrari_factorization_id` and `ferrari_hβ2_of_resolvent`, the α≠0 (non-degenerate) factorization directions `ferrari_factorization_forward_ne`/`backward_ne`, `resolvent_cubic_has_root` (FTA), `quartic_to_depressed`, and the 3 remaining axioms `quartic_has_four_roots`, `biquadratic_forward`, `biquadratic_backward`."
+      "summary": "The depressed-quartic forward/backward transforms (proved via `linear_combination`), the sound Ferrari-factorization substrate `ferrari_factorization_id` and `ferrari_hβ2_of_resolvent`, the α≠0 (non-degenerate) factorization directions `ferrari_factorization_forward_ne`/`backward_ne`, `resolvent_cubic_has_root` (FTA), `quartic_to_depressed`, and the three formerly-axiomatic results now proved as theorems: `quartic_has_four_roots` (from Mathlib FTA: `IsAlgClosed.splits`, `splits_iff_card_roots`, `Multiset.card_eq_three`), `biquadratic_forward`, `biquadratic_backward` (complex quadratic formula via `Complex.cpow_nat_inv_pow` and `linear_combination`)."
     },
     {
       "id": "ferrari-method",
@@ -213,9 +215,9 @@
       "Complex"
     ],
     "namespace": "GeneralQuartic",
-    "lineCount": 758,
-    "axiomCount": 3,
-    "theoremCount": 21,
+    "lineCount": 814,
+    "axiomCount": 0,
+    "theoremCount": 24,
     "definitionCount": 5,
     "path": "Proofs/GeneralQuartic.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Discharges the **last three structural axioms** in `proofs/Proofs/GeneralQuartic.lean`, making the formalization of Ferrari's solution of the general quartic (Wiedijk #46) **fully machine-checked: 0 axioms, 0 sorries**.

This completes the multi-session axiom-elimination arc for this entry (6 → 3 → **0**).

## What changed

| Former axiom | Now proved from |
|---|---|
| `quartic_has_four_roots` | Mathlib FTA: `IsAlgClosed.splits`, `Polynomial.splits_iff_card_roots`, `Multiset.card_eq_three`, `Polynomial.mem_roots`. The monic degree-4 quartic splits over ℂ, its root multiset has cardinality 4, and root membership reduces to equality with one of the four listed roots. |
| `biquadratic_forward` | Complex quadratic formula. With `s = (p²−4r)^(1/2)` (so `s² = p²−4r` via `Complex.cpow_nat_inv_pow`, valid even at radicand 0), the identity `(2y²+p−s)(2y²+p+s) = 4(y⁴+py²+r) + (p²−4r−s²)` + `mul_eq_zero` + `linear_combination`. |
| `biquadratic_backward` | Converse of the above; substitute each root value and use `s² = p²−4r`. |

## Verification

- **`#print axioms`** on all three theorems reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Genuinely 0-axiom in the credibility sense.
- **Docker build**: `lake build Proofs.GeneralQuartic` succeeds (3058 jobs).
- `grep -c '^axiom '` = 0, `grep -c sorry` = 0.

## Metadata

- `meta.json` / gallery listings re-badged `axiomatized` → `verified` (badge `axiom` → `verified`), `axiomCount` 3 → 0.
- Updated line/theorem counts (758→814 lines, 21→24 theorems), `assumptions` field (S9 step), `originalContributions`, section summaries, and one stale annotation (`ferrari_roots_verify` → `ferrari_roots_verify_ne`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)