### PR TITLE
research(amgm-inequality-oq-05-oq-01): equality case of Hölder's inequality for finite sums (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -76,6 +76,7 @@ import Proofs.AmgmInequalityOQ04OQ03
 import Proofs.AmgmInequalityOQ04OQ03Wallis
 import Proofs.AmgmInequalityOQ04OQ05
 import Proofs.AmgmInequalityOQ05
+import Proofs.AmgmInequalityOQ05OQ01
 import Proofs.AmgmInequalityPowerMeanLimits
 import Proofs.AngleTrisection
 import Proofs.AngleTrisectionAristotle

--- a/proofs/Proofs/AmgmInequalityOQ05OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ05OQ01.lean
@@ -1,0 +1,200 @@
+/-
+  The equality case of Hölder's inequality for finite sums.
+
+  For Hölder-conjugate exponents `p, q > 1` (`p⁻¹ + q⁻¹ = 1`) and nonnegative
+  functions `f, g` on a finite index set `s`, Hölder's inequality states
+
+      ∑ i, f i * g i ≤ (∑ i, f i ^ p) ^ (1/p) * (∑ i, g i ^ q) ^ (1/q).
+
+  Mathlib provides this inequality (`Real.inner_le_Lp_mul_Lq_of_nonneg`) but does
+  **not** characterise when equality holds.  This file fills that gap.  Writing
+  `F = ∑ f i ^ p` and `G = ∑ g i ^ q`, the headline result is
+
+      ∑ i, f i * g i = F ^ (1/p) * G ^ (1/q)
+        ↔  ∀ i ∈ s,  G * f i ^ p = F * g i ^ q,
+
+  i.e. equality holds **iff the vectors `(f i ^ p)` and `(g i ^ q)` are
+  proportional** (the cross-multiplied form `G·fᵢᵖ = F·gᵢᵍ` is the proportionality
+  condition, stated so that it degenerates gracefully when `F = 0` or `G = 0`).
+
+  The proof rests on the *equality case of Young's inequality*
+  `a*b = aᵖ/p + bᵍ/q ↔ aᵖ = bᵍ` (proved for `a, b > 0` in the parent entry
+  `AmgmInequalityOQ05`; here extended to `a, b ≥ 0`).  Summing Young pointwise on
+  unit-normalised vectors turns the slack `∑ (aᵖ/p + bᵍ/q − a·b)` into a sum of
+  nonnegative terms which vanishes iff each term does — that is the equality case.
+
+  All exponents are real, so `^` denotes `Real.rpow` throughout.
+
+  Verified: 0 sorries, 0 axioms.
+-/
+import Mathlib
+import Proofs.AmgmInequalityOQ05
+
+open Real
+
+namespace AmgmInequalityOQ05OQ01
+
+/-- **Equality case of Young's inequality (nonnegative form).**  For
+Hölder-conjugate exponents `p, q` and `a, b ≥ 0`,
+`a * b = a ^ p / p + b ^ q / q ↔ a ^ p = b ^ q`.  This extends the parent entry's
+`young_inequality_eq_iff` (stated for `a, b > 0`) to cover the boundary `a = 0`
+or `b = 0`, where both sides reduce to "the other variable is `0`". -/
+theorem young_eq_iff_nonneg {a b p q : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b)
+    (hpq : p.HolderConjugate q) :
+    a * b = a ^ p / p + b ^ q / q ↔ a ^ p = b ^ q := by
+  have hp : (0 : ℝ) < p := hpq.pos
+  have hq : (0 : ℝ) < q := hpq.symm.pos
+  rcases ha.lt_or_eq with ha' | ha0
+  · rcases hb.lt_or_eq with hb' | hb0
+    · -- both positive: parent result
+      exact AmgmInequalityOQ05.young_inequality_eq_iff ha' hb' hpq
+    · -- b = 0
+      subst hb0
+      rw [mul_zero, Real.zero_rpow hq.ne', zero_div, add_zero, eq_comm, div_eq_zero_iff]
+      simp [hp.ne']
+  · -- a = 0
+    subst ha0
+    rw [zero_mul, Real.zero_rpow hp.ne', zero_div, zero_add, eq_comm, div_eq_zero_iff]
+    simp [hq.ne', eq_comm]
+
+/-- **Hölder's inequality for finite sums** (Mathlib re-export, ℝ-valued
+nonnegative version), recorded here so the entry is self-contained. -/
+theorem holder_sum_le {ι : Type*} (s : Finset ι) (f g : ι → ℝ) {p q : ℝ}
+    (hpq : p.HolderConjugate q) (hf : ∀ i ∈ s, 0 ≤ f i) (hg : ∀ i ∈ s, 0 ≤ g i) :
+    ∑ i ∈ s, f i * g i ≤ (∑ i ∈ s, f i ^ p) ^ (1 / p) * (∑ i ∈ s, g i ^ q) ^ (1 / q) :=
+  Real.inner_le_Lp_mul_Lq_of_nonneg s hpq hf hg
+
+/-- **Equality case of Hölder's inequality — normalised form.**  When the
+`Lᵖ`/`Lᵍ` norms are both `1` (`∑ f i ^ p = 1`, `∑ g i ^ q = 1`), equality in
+Hölder `∑ f i * g i = 1` holds **iff** `f i ^ p = g i ^ q` for every `i ∈ s`.
+This is the heart of the equality case: summing the pointwise Young inequality,
+the slack is a sum of nonnegative terms, so it vanishes iff each Young inequality
+is itself an equality. -/
+theorem holder_sum_eq_iff_of_normalized {ι : Type*} (s : Finset ι) (f g : ι → ℝ)
+    {p q : ℝ} (hpq : p.HolderConjugate q)
+    (hf : ∀ i ∈ s, 0 ≤ f i) (hg : ∀ i ∈ s, 0 ≤ g i)
+    (hfp : ∑ i ∈ s, f i ^ p = 1) (hgq : ∑ i ∈ s, g i ^ q = 1) :
+    ∑ i ∈ s, f i * g i = 1 ↔ ∀ i ∈ s, f i ^ p = g i ^ q := by
+  have hp : (0 : ℝ) < p := hpq.pos
+  have hq : (0 : ℝ) < q := hpq.symm.pos
+  -- slack of Young at each index
+  set d : ι → ℝ := fun i => (f i ^ p / p + g i ^ q / q) - f i * g i with hd
+  have hd_nonneg : ∀ i ∈ s, 0 ≤ d i := by
+    intro i hi
+    have := Real.young_inequality_of_nonneg (hf i hi) (hg i hi) hpq
+    simp only [hd]; linarith
+  have hsum_rhs : ∑ i ∈ s, (f i ^ p / p + g i ^ q / q) = 1 := by
+    rw [Finset.sum_add_distrib, ← Finset.sum_div, ← Finset.sum_div, hfp, hgq, one_div, one_div,
+      hpq.inv_add_inv_eq_one]
+  have hsum_d : ∑ i ∈ s, d i = 1 - ∑ i ∈ s, f i * g i := by
+    simp only [hd, Finset.sum_sub_distrib, hsum_rhs]
+  constructor
+  · intro h
+    have hd0 : ∑ i ∈ s, d i = 0 := by rw [hsum_d, h]; ring
+    have hall := (Finset.sum_eq_zero_iff_of_nonneg hd_nonneg).mp hd0
+    intro i hi
+    have heq : f i * g i = f i ^ p / p + g i ^ q / q := by
+      have := hall i hi; simp only [hd] at this; linarith
+    exact (young_eq_iff_nonneg (hf i hi) (hg i hi) hpq).mp heq
+  · intro h
+    have hd0 : ∑ i ∈ s, d i = 0 := by
+      apply Finset.sum_eq_zero
+      intro i hi
+      have heq : f i * g i = f i ^ p / p + g i ^ q / q :=
+        (young_eq_iff_nonneg (hf i hi) (hg i hi) hpq).mpr (h i hi)
+      simp only [hd]; linarith
+    rw [hsum_d] at hd0; linarith
+
+/-- **Equality case of Hölder's inequality for finite sums (general form).**
+For Hölder-conjugate `p, q` and nonnegative `f, g` on a finite set `s`, equality
+
+    ∑ i, f i * g i = (∑ i, f i ^ p) ^ (1/p) * (∑ i, g i ^ q) ^ (1/q)
+
+holds **iff** the vectors `(f i ^ p)` and `(g i ^ q)` are proportional:
+
+    ∀ i ∈ s,  (∑ j, g j ^ q) * f i ^ p = (∑ j, f j ^ p) * g i ^ q.
+
+The cross-multiplied statement degenerates correctly when one of the sums is `0`
+(then every `f i = 0`, resp. `g i = 0`, and both sides hold trivially). -/
+theorem holder_sum_eq_iff {ι : Type*} (s : Finset ι) (f g : ι → ℝ) {p q : ℝ}
+    (hpq : p.HolderConjugate q) (hf : ∀ i ∈ s, 0 ≤ f i) (hg : ∀ i ∈ s, 0 ≤ g i) :
+    ∑ i ∈ s, f i * g i = (∑ i ∈ s, f i ^ p) ^ (1 / p) * (∑ i ∈ s, g i ^ q) ^ (1 / q)
+      ↔ ∀ i ∈ s, (∑ j ∈ s, g j ^ q) * f i ^ p = (∑ j ∈ s, f j ^ p) * g i ^ q := by
+  have hp : (0 : ℝ) < p := hpq.pos
+  have hq : (0 : ℝ) < q := hpq.symm.pos
+  have hF : 0 ≤ ∑ i ∈ s, f i ^ p := Finset.sum_nonneg (fun i hi => Real.rpow_nonneg (hf i hi) p)
+  have hG : 0 ≤ ∑ i ∈ s, g i ^ q := Finset.sum_nonneg (fun i hi => Real.rpow_nonneg (hg i hi) q)
+  rcases eq_or_lt_of_le hF with hF0 | hFpos
+  · -- F = 0
+    have hfp0 : ∀ i ∈ s, f i ^ p = 0 :=
+      (Finset.sum_eq_zero_iff_of_nonneg (fun i hi => Real.rpow_nonneg (hf i hi) p)).mp hF0.symm
+    have hlhs : ∑ i ∈ s, f i * g i = 0 := by
+      apply Finset.sum_eq_zero; intro i hi
+      have hfi : f i = 0 := by
+        by_contra hne
+        exact (Real.rpow_pos_of_pos (lt_of_le_of_ne (hf i hi) (Ne.symm hne)) p).ne' (hfp0 i hi)
+      rw [hfi, zero_mul]
+    have hrhs : (∑ i ∈ s, f i ^ p) ^ (1 / p) * (∑ i ∈ s, g i ^ q) ^ (1 / q) = 0 := by
+      rw [← hF0, Real.zero_rpow (one_div_ne_zero hp.ne'), zero_mul]
+    constructor
+    · intro _ i hi; rw [hfp0 i hi, ← hF0]; ring
+    · intro _; rw [hlhs, hrhs]
+  · rcases eq_or_lt_of_le hG with hG0 | hGpos
+    · -- G = 0
+      have hgq0 : ∀ i ∈ s, g i ^ q = 0 :=
+        (Finset.sum_eq_zero_iff_of_nonneg (fun i hi => Real.rpow_nonneg (hg i hi) q)).mp hG0.symm
+      have hlhs : ∑ i ∈ s, f i * g i = 0 := by
+        apply Finset.sum_eq_zero; intro i hi
+        have hgi : g i = 0 := by
+          by_contra hne
+          exact (Real.rpow_pos_of_pos (lt_of_le_of_ne (hg i hi) (Ne.symm hne)) q).ne' (hgq0 i hi)
+        rw [hgi, mul_zero]
+      have hrhs : (∑ i ∈ s, f i ^ p) ^ (1 / p) * (∑ i ∈ s, g i ^ q) ^ (1 / q) = 0 := by
+        rw [← hG0, Real.zero_rpow (one_div_ne_zero hq.ne'), mul_zero]
+      constructor
+      · intro _ i hi; rw [hgq0 i hi, ← hG0]; ring
+      · intro _; rw [hlhs, hrhs]
+    · -- F > 0 and G > 0: rescale to the normalised case
+      set cF := (∑ i ∈ s, f i ^ p) ^ (1 / p) with hcF
+      set cG := (∑ i ∈ s, g i ^ q) ^ (1 / q) with hcG
+      have hcFpos : 0 < cF := Real.rpow_pos_of_pos hFpos _
+      have hcGpos : 0 < cG := Real.rpow_pos_of_pos hGpos _
+      have hcFp : cF ^ p = ∑ i ∈ s, f i ^ p := by
+        rw [hcF, ← Real.rpow_mul hF, one_div, inv_mul_cancel₀ hp.ne', Real.rpow_one]
+      have hcGq : cG ^ q = ∑ i ∈ s, g i ^ q := by
+        rw [hcG, ← Real.rpow_mul hG, one_div, inv_mul_cancel₀ hq.ne', Real.rpow_one]
+      have hf' : ∀ i ∈ s, 0 ≤ f i / cF := fun i hi => div_nonneg (hf i hi) hcFpos.le
+      have hg' : ∀ i ∈ s, 0 ≤ g i / cG := fun i hi => div_nonneg (hg i hi) hcGpos.le
+      have hfp' : ∑ i ∈ s, (f i / cF) ^ p = 1 := by
+        have hpt : ∀ i ∈ s, (f i / cF) ^ p = f i ^ p / cF ^ p :=
+          fun i hi => Real.div_rpow (hf i hi) hcFpos.le p
+        rw [Finset.sum_congr rfl hpt, ← Finset.sum_div, hcFp, div_self hFpos.ne']
+      have hgq' : ∑ i ∈ s, (g i / cG) ^ q = 1 := by
+        have hpt : ∀ i ∈ s, (g i / cG) ^ q = g i ^ q / cG ^ q :=
+          fun i hi => Real.div_rpow (hg i hi) hcGpos.le q
+        rw [Finset.sum_congr rfl hpt, ← Finset.sum_div, hcGq, div_self hGpos.ne']
+      have hnorm := holder_sum_eq_iff_of_normalized s (fun i => f i / cF) (fun i => g i / cG)
+        hpq hf' hg' hfp' hgq'
+      have hsum' : ∑ i ∈ s, (f i / cF) * (g i / cG) = (∑ i ∈ s, f i * g i) / (cF * cG) := by
+        rw [Finset.sum_div]; apply Finset.sum_congr rfl; intro i hi; rw [div_mul_div_comm]
+      have hcFcG : cF * cG ≠ 0 := (mul_pos hcFpos hcGpos).ne'
+      constructor
+      · intro heq i hi
+        have h1 : ∑ i ∈ s, (f i / cF) * (g i / cG) = 1 := by
+          rw [hsum', heq, div_self hcFcG]
+        have h2 := hnorm.mp h1 i hi
+        dsimp only at h2
+        rw [Real.div_rpow (hf i hi) hcFpos.le p, Real.div_rpow (hg i hi) hcGpos.le q,
+          hcFp, hcGq, div_eq_div_iff hFpos.ne' hGpos.ne'] at h2
+        linear_combination h2
+      · intro hcond
+        have h2 : ∀ i ∈ s, (f i / cF) ^ p = (g i / cG) ^ q := by
+          intro i hi
+          rw [Real.div_rpow (hf i hi) hcFpos.le p, Real.div_rpow (hg i hi) hcGpos.le q,
+            hcFp, hcGq, div_eq_div_iff hFpos.ne' hGpos.ne']
+          linear_combination hcond i hi
+        have h1 := hnorm.mpr h2
+        rw [hsum', div_eq_one_iff_eq hcFcG] at h1
+        exact h1
+
+end AmgmInequalityOQ05OQ01

--- a/src/data/proofs/amgm-inequality-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-young-eq-iff-nonneg",
+    "proofId": "amgm-inequality-oq-05-oq-01",
+    "range": {
+      "startLine": 42,
+      "endLine": 58
+    },
+    "type": "theorem",
+    "title": "young_eq_iff_nonneg: Young equality case for a, b ≥ 0",
+    "content": "Extends the parent entry's Young equality case from a, b > 0 to a, b ≥ 0: a·b = aᵖ/p + b^q/q ↔ aᵖ = b^q. The interior case a, b > 0 delegates to AmgmInequalityOQ05.young_inequality_eq_iff; the boundary cases a = 0 and b = 0 are dispatched directly, where both sides collapse to 'the other variable is 0' (via zero_rpow and div_eq_zero_iff). This full-range version is what is summed in the Hölder argument, since normalized vectors may have zero entries."
+  },
+  {
+    "id": "ann-holder-sum-le",
+    "proofId": "amgm-inequality-oq-05-oq-01",
+    "range": {
+      "startLine": 62,
+      "endLine": 65
+    },
+    "type": "theorem",
+    "title": "holder_sum_le: Hölder's inequality for finite sums",
+    "content": "The Hölder inequality itself, ∑ fᵢgᵢ ≤ (∑ fᵢᵖ)^(1/p)(∑ gᵢ^q)^(1/q) for nonnegative ℝ-valued f, g, recorded as a re-export of Mathlib's Real.inner_le_Lp_mul_Lq_of_nonneg so the entry is self-contained alongside its equality case."
+  },
+  {
+    "id": "ann-holder-eq-normalized",
+    "proofId": "amgm-inequality-oq-05-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 106
+    },
+    "type": "theorem",
+    "title": "holder_sum_eq_iff_of_normalized: the heart of the equality case",
+    "content": "For unit-norm vectors (∑ fᵢᵖ = ∑ gᵢ^q = 1), Hölder equality ∑ fᵢgᵢ = 1 holds iff fᵢᵖ = gᵢ^q for every i ∈ s. Proof: the slack dᵢ = (fᵢᵖ/p + gᵢ^q/q) − fᵢgᵢ is nonnegative by pointwise Young, and ∑(fᵢᵖ/p + gᵢ^q/q) = 1/p + 1/q = 1, so ∑ dᵢ = 1 − ∑ fᵢgᵢ. Hence ∑ fᵢgᵢ = 1 iff ∑ dᵢ = 0 iff every dᵢ = 0 (Finset.sum_eq_zero_iff_of_nonneg) iff each Young inequality is tight iff fᵢᵖ = gᵢ^q (young_eq_iff_nonneg). This localizes the aggregate equality to a pointwise one — the standard nonnegative-slack device."
+  },
+  {
+    "id": "ann-holder-eq-general",
+    "proofId": "amgm-inequality-oq-05-oq-01",
+    "range": {
+      "startLine": 119,
+      "endLine": 199
+    },
+    "type": "theorem",
+    "title": "holder_sum_eq_iff: equality iff power-vectors are proportional",
+    "content": "The headline result. With F = ∑ fᵢᵖ and G = ∑ gᵢ^q, equality ∑ fᵢgᵢ = F^(1/p)·G^(1/q) holds iff (∑ gⱼ^q)·fᵢᵖ = (∑ fⱼᵖ)·gᵢ^q for all i — i.e. (fᵢᵖ) and (gᵢ^q) are proportional. When F, G > 0 the proof rescales by cF = F^(1/p), cG = G^(1/q): the identity (cF)ᵖ = F (rpow arithmetic) makes f/cF, g/cG unit-norm, the normalized theorem applies, and div_eq_div_iff converts fᵢᵖ/F = gᵢ^q/G into the cross-multiplied form. The degenerate F = 0 (all fᵢ = 0) and G = 0 cases hold trivially on both sides; cross-multiplication keeps the condition well-posed there."
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-05-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-01/meta.json
@@ -1,0 +1,109 @@
+{
+  "id": "amgm-inequality-oq-05-oq-01",
+  "title": "Equality Case of Hölder's Inequality for Finite Sums",
+  "slug": "amgm-inequality-oq-05-oq-01",
+  "description": "For Hölder-conjugate exponents p, q > 1 (1/p + 1/q = 1) and nonnegative functions f, g on a finite index set, Hölder's inequality bounds ∑ fᵢgᵢ ≤ (∑ fᵢᵖ)^(1/p)(∑ gᵢ^q)^(1/q). Mathlib provides the inequality but not the characterization of its equality case. This entry proves that equality holds iff the vectors (fᵢᵖ) and (gᵢ^q) are proportional — in cross-multiplied form (∑ gⱼ^q)·fᵢᵖ = (∑ fⱼᵖ)·gᵢ^q for all i — by summing the pointwise equality case of Young's inequality over unit-normalized vectors. It is the finite-sum companion to the parent entry's Young equality case.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/H%C3%B6lder%27s_inequality",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ05OQ01.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "holder-inequality",
+      "young-inequality",
+      "holder-conjugate",
+      "equality-case",
+      "amgm",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 200,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-checked from Mathlib with 0 sorries and 0 axioms beyond Lean's foundational propext / Classical.choice / Quot.sound (which all Mathlib developments use). The inequality direction re-exports Real.inner_le_Lp_mul_Lq_of_nonneg; the equality characterization is proved from the pointwise Young equality case (parent entry amgm-inequality-oq-05) summed over rescaled vectors.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Hölder's inequality (Otto Hölder, 1889; the sum form due to Leonard James Rogers, 1888) is the cornerstone inequality of Lᵖ analysis: for conjugate exponents 1/p + 1/q = 1 it bounds the inner product ∑ fᵢgᵢ by the product of the Lᵖ and Lᵍ norms. Its equality case is the discrete analogue of the statement that Lᵖ and Lᵍ are dual: equality ∑ fᵢgᵢ = ‖f‖_p ‖g‖_q holds precisely when the power-vectors (fᵢᵖ) and (gᵢ^q) are proportional (linearly dependent). The p = q = 2 instance is the Cauchy–Schwarz inequality, whose equality case is the familiar linear-dependence condition. Mathlib carries the inequality (Real.inner_le_Lp_mul_Lq_of_nonneg, and the ℝ≥0 / ℝ≥0∞ versions) but not its equality characterization; this entry supplies it, completing the equality-case program begun in the parent entry on Young's inequality.",
+    "problemStatement": "Let p, q > 1 satisfy 1/p + 1/q = 1, and let f, g : ι → ℝ be nonnegative on a finite set s. Writing F = ∑ fᵢᵖ and G = ∑ gᵢ^q, characterize equality in Hölder's inequality: prove ∑ fᵢgᵢ = F^(1/p)·G^(1/q) holds iff (fᵢᵖ) and (gᵢ^q) are proportional, i.e. G·fᵢᵖ = F·gᵢ^q for every i ∈ s.",
+    "text": "Hölder's inequality is sharp exactly when the power-normalized vectors are proportional. The characterization is obtained by summing the pointwise Young equality case over unit-normalized vectors and using that a sum of nonnegative slack terms vanishes iff each term does.",
+    "proofStrategy": "Three layers build to the result. (1) young_eq_iff_nonneg extends the parent entry's Young equality case (a·b = aᵖ/p + b^q/q ↔ aᵖ = b^q) from a,b > 0 to a,b ≥ 0, handling the boundary a = 0 or b = 0 directly. (2) holder_sum_eq_iff_of_normalized is the heart: for unit vectors (∑ fᵢᵖ = ∑ gᵢ^q = 1), summing the pointwise Young inequality gives ∑ fᵢgᵢ ≤ ∑(fᵢᵖ/p + gᵢ^q/q) = 1/p + 1/q = 1; the slack dᵢ = (fᵢᵖ/p + gᵢ^q/q) − fᵢgᵢ is nonnegative, so ∑ fᵢgᵢ = 1 iff ∑ dᵢ = 0 iff every dᵢ = 0 (Finset.sum_eq_zero_iff_of_nonneg), iff each Young inequality is an equality, iff fᵢᵖ = gᵢ^q for all i. (3) holder_sum_eq_iff handles the general case by rescaling: when F, G > 0, set cF = F^(1/p), cG = G^(1/q); the vectors f/cF and g/cG have unit Lᵖ/Lᵍ norms (using (cF)ᵖ = F via rpow arithmetic), so the normalized result applies and unwinds — via div_eq_div_iff — to the cross-multiplied proportionality G·fᵢᵖ = F·gᵢ^q. The degenerate cases F = 0 (forcing every fᵢ = 0) and G = 0 are dispatched separately, where the cross-multiplied form holds trivially on both sides.",
+    "keyInsights": [
+      "**The equality case is Young, summed.** Hölder's inequality for finite sums is, after unit normalization, nothing but the pointwise Young inequality fᵢgᵢ ≤ fᵢᵖ/p + gᵢ^q/q summed over i (the right side telescopes to 1/p + 1/q = 1). Consequently the *equality* case is the pointwise Young equality case holding simultaneously at every index — the whole difficulty is localized to the single-variable statement proved in the parent entry.",
+      "**A nonnegative sum vanishes iff each term does.** The slack dᵢ = fᵢᵖ/p + gᵢ^q/q − fᵢgᵢ ≥ 0 turns ‘equality in a sum-of-inequalities’ into ‘a sum of nonnegative numbers is zero’, which forces each dᵢ = 0 (Finset.sum_eq_zero_iff_of_nonneg). This is the standard, robust device for promoting an aggregate equality to a pointwise one.",
+      "**Normalization is the only nonlinear step.** Reducing the general inequality to the unit-norm case requires rescaling f ↦ f/F^(1/p), and the identity (F^(1/p))ᵖ = F (i.e. F^(p⁻¹·p) = F^1) is what makes the rescaled vector have unit Lᵖ norm. Real-power arithmetic (Real.div_rpow, Real.rpow_mul) carries this through; everything else is linear bookkeeping.",
+      "**Cross-multiplication makes the condition degeneracy-proof.** Stated as G·fᵢᵖ = F·gᵢ^q rather than fᵢᵖ/F = gᵢ^q/G, the proportionality condition remains meaningful and automatically true when F = 0 or G = 0 (where every fᵢ, resp. gᵢ, vanishes and Hölder is the trivial 0 ≤ 0). This avoids carving out the zero vectors as exceptional cases in the statement.",
+      "**p = q = 2 is Cauchy–Schwarz.** The result specializes to the equality case of Cauchy–Schwarz for nonnegative reals: ∑ fᵢgᵢ = √(∑ fᵢ²)·√(∑ gᵢ²) iff (fᵢ²) and (gᵢ²) are proportional, the discrete linear-dependence condition."
+    ],
+    "prerequisites": [
+      "Hölder-conjugate exponents: Real.HolderConjugate (1/p + 1/q = 1, p,q > 1)",
+      "Equality case of Young's inequality (parent entry amgm-inequality-oq-05: AmgmInequalityOQ05.young_inequality_eq_iff)",
+      "Hölder's inequality for finite sums (Real.inner_le_Lp_mul_Lq_of_nonneg)",
+      "Real powers Real.rpow and their arithmetic (rpow_mul, div_rpow, rpow_pos_of_pos)",
+      "Finset.sum_eq_zero_iff_of_nonneg: a finite sum of nonnegative terms is zero iff each term is zero"
+    ]
+  },
+  "conclusion": {
+    "summary": "The equality case of Hölder's inequality for finite sums is fully verified: 4 theorems, 0 definitions, 0 axioms, 0 sorries. The inequality is re-exported from Mathlib; the new content is the equality characterization — ∑ fᵢgᵢ = (∑ fᵢᵖ)^(1/p)(∑ gᵢ^q)^(1/q) iff the power-vectors (fᵢᵖ), (gᵢ^q) are proportional — proved by summing the parent entry's pointwise Young equality case over rescaled (unit-norm) vectors, with the degenerate zero-norm cases dispatched directly.",
+    "implications": "This completes, for finite sums, the equality-case program initiated for Young's inequality: it pins down exactly when the Hölder estimate is tight, recovering the Cauchy–Schwarz linear-dependence condition at p = q = 2. The normalized form holder_sum_eq_iff_of_normalized is reusable infrastructure for any tightness analysis of Hölder-type bounds, and the proof exhibits the canonical pattern (sum a pointwise sharp inequality; a vanishing nonnegative slack-sum localizes equality to every index).",
+    "openQuestions": [
+      "Extend the equality characterization from finite sums to the Lᵖ/ℓᵖ setting (tsum / MeasureTheory.Lp): equality in the integral/series Hölder inequality holds iff |f|ᵖ and |g|^q are proportional almost everywhere.",
+      "Derive the equality case of Minkowski's inequality for finite sums (the triangle inequality in ℓᵖ) from this Hölder equality case via the standard duality argument."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-05",
+      "relationship": "extends",
+      "description": "The parent entry proves the pointwise equality case of Young's inequality (a·b = aᵖ/p + b^q/q ↔ aᵖ = b^q) and lists this finite-sum Hölder equality case as its first open question. This entry reuses that result (AmgmInequalityOQ05.young_inequality_eq_iff) as the per-index engine and resolves the open question."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-03-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Hölder's inequality is the conjugate-exponent generalization of Cauchy–Schwarz; the p = q = 2 case of the equality characterization here recovers the Cauchy–Schwarz linear-dependence equality condition for nonnegative vectors."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "Both rest on two-term AM-GM / weighted AM-GM. Hölder's equality case is, after normalization, the simultaneous equality of every pointwise weighted-AM-GM (Young) estimate."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AmgmInequalityOQ05"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "AmgmInequalityOQ05OQ01",
+    "lineCount": 200,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/AmgmInequalityOQ05OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Hölder, Otto",
+      "title": "Über einen Mittelwertssatz",
+      "year": "1889",
+      "venue": "Nachrichten von der Königl. Gesellschaft der Wissenschaften zu Göttingen, pp. 38-47",
+      "note": "Original source of Hölder's inequality."
+    },
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Classical reference for Hölder's inequality and its equality case (Theorems 13-15 and surrounding discussion of the proportionality condition)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **equality case of Hölder's inequality for finite sums**. For Hölder-conjugate exponents `p, q > 1` (`1/p + 1/q = 1`) and nonnegative `f, g` on a finite set `s`, Mathlib provides the inequality (`Real.inner_le_Lp_mul_Lq_of_nonneg`) but **not** the characterization of equality. This entry proves:

```
∑ᵢ fᵢgᵢ = (∑ᵢ fᵢᵖ)^(1/p)·(∑ᵢ gᵢ^q)^(1/q)
   ↔  ∀ i,  (∑ⱼ gⱼ^q)·fᵢᵖ = (∑ⱼ fⱼᵖ)·gᵢ^q
```

i.e. equality holds **iff the power-vectors `(fᵢᵖ)` and `(gᵢ^q)` are proportional**. The cross-multiplied form degenerates gracefully when either sum is `0`.

## Approach

Equality in Hölder is the pointwise **Young** equality case holding simultaneously at every index. Three layers:

1. `young_eq_iff_nonneg` — extends the parent entry's Young equality case (`a·b = aᵖ/p + b^q/q ↔ aᵖ = b^q`) from `a,b > 0` to `a,b ≥ 0`.
2. `holder_sum_eq_iff_of_normalized` — the heart: for unit vectors, summing pointwise Young makes the slack a sum of nonnegative terms, zero iff each term is zero (`Finset.sum_eq_zero_iff_of_nonneg`).
3. `holder_sum_eq_iff` — general case by rescaling `f ↦ f/F^(1/p)` to unit norm, unwinding to the cross-multiplied proportionality; degenerate `F=0` / `G=0` dispatched directly.

`p = q = 2` recovers the Cauchy–Schwarz linear-dependence equality condition.

## Verification

- **4 theorems, 0 definitions, 0 sorries, 0 axioms** (beyond Lean's foundational `propext`/`Classical.choice`/`Quot.sound`)
- Builds via `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ05OQ01` — `Built Proofs.AmgmInequalityOQ05OQ01` ✔
- Extends parent entry `amgm-inequality-oq-05` (resolves its first listed open question)

🤖 Generated with [Claude Code](https://claude.com/claude-code)