### PR TITLE
research(primitive-roots-oq-04): cyclotomic vertex-product identity ∏(1−μᵏ)=m and its regular-polygon chord reading (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2993,6 +2993,7 @@ import Proofs.PrimeReciprocalDivergenceOQ03
 import Proofs.PrimitiveRoots
 import Proofs.PrimitiveRootsOQ02
 import Proofs.PrimitiveRootsOQ03
+import Proofs.PrimitiveRootsOQ04
 import Proofs.ProbMethodAlteration
 import Proofs.ProbMethodAlterationOQ02
 import Proofs.ProbMethodApplications

--- a/proofs/Proofs/PrimitiveRootsOQ04.lean
+++ b/proofs/Proofs/PrimitiveRootsOQ04.lean
@@ -1,0 +1,114 @@
+/-
+  The primitive-root vertex-product identity and its geometric reading
+  ====================================================================
+
+  For a primitive `m`-th root of unity `μ` in an integral domain,
+                ∏_{k=1}^{m-1} (1 - μ^k) = m.
+  Mathlib proves this (`IsPrimitiveRoot.prod_one_sub_pow_eq_order`, stated with
+  `m = n+1` to dodge the side condition `m ≠ 0`) together with its sign-flipped
+  companion `∏ (μ^k - 1)` and the divisibility `(μ-1)^k ∣ m`. What Mathlib does
+  *not* record is the analytic/geometric reading of the identity over `ℂ`.
+
+  This entry supplies it:
+
+  * `prod_one_sub_pow`          — the order identity (re-export, attributed).
+  * `neg_one_pow_mul_prod_pow_sub` — the sign companion (re-export, attributed).
+  * `prod_norm_one_sub_pow`     — **new**: taking moduli over `ℂ`,
+        ∏_{k=1}^{m-1} ‖1 - μ^k‖ = m.
+      Geometrically: the product of the distances from one vertex of a regular
+      `m`-gon inscribed in the unit circle to the other `m-1` vertices is `m`.
+      (Not stated in Mathlib.)
+  * `prod_one_sub_exp`          — **new**: the explicit instantiation at the
+      standard primitive root `μ = exp(2πi/m)`,
+        ∏_{k=0}^{m-2} (1 - exp(2πi(k+1)/m)) = m.
+  * `prod_norm_one_sub_exp`     — **new**: the regular-polygon chord product in
+      fully explicit form.
+
+  Concrete checks `m = 2, 3` close the file.
+-/
+import Mathlib
+
+open Finset Complex Real
+
+namespace PrimitiveRootsOQ04
+
+variable {R : Type*} [CommRing R] [IsDomain R]
+
+/-! ### The order identity over an integral domain (Mathlib core) -/
+
+/-- **Vertex product identity.** For a primitive `(n+1)`-th root of unity `μ`,
+`∏_{k=0}^{n-1} (1 - μ^{k+1}) = n+1`; equivalently `∏_{j=1}^{m-1}(1 - μ^j) = m`
+with `m = n+1`. Direct re-export of `IsPrimitiveRoot.prod_one_sub_pow_eq_order`;
+the `n+1` form avoids the side condition `m ≠ 0`. -/
+theorem prod_one_sub_pow {n : ℕ} {μ : R} (hμ : IsPrimitiveRoot μ (n + 1)) :
+    ∏ k ∈ range n, (1 - μ ^ (k + 1)) = (n + 1 : R) :=
+  hμ.prod_one_sub_pow_eq_order
+
+/-- **Sign companion.** `(-1)^n · ∏_{k=0}^{n-1} (μ^{k+1} - 1) = n+1`. Re-export of
+`IsPrimitiveRoot.prod_pow_sub_one_eq_order`. -/
+theorem neg_one_pow_mul_prod_pow_sub {n : ℕ} {μ : R} (hμ : IsPrimitiveRoot μ (n + 1)) :
+    (-1) ^ n * ∏ k ∈ range n, (μ ^ (k + 1) - 1) = (n + 1 : R) :=
+  hμ.prod_pow_sub_one_eq_order
+
+/-! ### The geometric corollary over `ℂ` (new) -/
+
+/-- **Regular-polygon chord product.** Over `ℂ`, taking moduli in the vertex-product
+identity: for a primitive `(n+1)`-th root of unity `μ`,
+`∏_{k=0}^{n-1} ‖1 - μ^{k+1}‖ = n+1`.
+
+Geometrically, the `m = n+1` points `μ^0, μ^1, …, μ^{m-1}` are the vertices of a
+regular `m`-gon inscribed in the unit circle; the product of the distances from the
+vertex `1 = μ^0` to all `m-1` other vertices equals `m`. This norm form is not
+stated in Mathlib. -/
+theorem prod_norm_one_sub_pow {n : ℕ} {μ : ℂ} (hμ : IsPrimitiveRoot μ (n + 1)) :
+    ∏ k ∈ range n, ‖1 - μ ^ (k + 1)‖ = (n + 1 : ℝ) := by
+  rw [← norm_prod, hμ.prod_one_sub_pow_eq_order]
+  rw [show ((n : ℂ) + 1) = ((n + 1 : ℕ) : ℂ) by push_cast; ring]
+  rw [Complex.norm_natCast]
+  push_cast; ring
+
+/-! ### Explicit instantiation at `exp(2πi/m)` (new) -/
+
+/-- **Explicit vertex product.** With the standard primitive `(n+1)`-th root
+`μ = exp(2πi/(n+1))`, the identity reads
+`∏_{k=0}^{n-1} (1 - exp(2πi(k+1)/(n+1))) = n+1`. -/
+theorem prod_one_sub_exp (n : ℕ) :
+    ∏ k ∈ range n, (1 - Complex.exp (2 * π * I * (k + 1) / (n + 1))) = (n + 1 : ℂ) := by
+  have hμ := Complex.isPrimitiveRoot_exp (n + 1) (Nat.succ_ne_zero n)
+  -- Rewrite each factor as `1 - μ^(k+1)` with `μ = exp(2πi/(n+1))` *before* applying the
+  -- order identity, so the `n+1` in the exponent's denominator is not touched.
+  have step : ∏ k ∈ range n, (1 - Complex.exp (2 * π * I * (k + 1) / (n + 1)))
+      = ∏ k ∈ range n, (1 - Complex.exp (2 * ↑π * I / ↑(n + 1)) ^ (k + 1)) := by
+    refine Finset.prod_congr rfl (fun k _ => ?_)
+    have hk : Complex.exp (2 * π * I * (k + 1) / (n + 1))
+        = Complex.exp (2 * ↑π * I / ↑(n + 1)) ^ (k + 1) := by
+      rw [← Complex.exp_nat_mul]
+      congr 1
+      push_cast
+      ring
+    rw [hk]
+  rw [step]
+  exact hμ.prod_one_sub_pow_eq_order
+
+/-- **Explicit regular-polygon chord product.** With `μ = exp(2πi/(n+1))`,
+`∏_{k=0}^{n-1} ‖1 - exp(2πi(k+1)/(n+1))‖ = n+1`: the product of the chord lengths
+from one vertex of a regular `(n+1)`-gon to the others. -/
+theorem prod_norm_one_sub_exp (n : ℕ) :
+    ∏ k ∈ range n, ‖1 - Complex.exp (2 * π * I * (k + 1) / (n + 1))‖ = (n + 1 : ℝ) := by
+  rw [← norm_prod, prod_one_sub_exp n]
+  rw [show ((n : ℂ) + 1) = ((n + 1 : ℕ) : ℂ) by push_cast; ring]
+  rw [Complex.norm_natCast]
+  push_cast; ring
+
+/-! ### Concrete values -/
+
+/-- `m = 2`: the two square roots of unity are `±1`, and `1 - (-1) = 2`. -/
+example {μ : R} (hμ : IsPrimitiveRoot μ 2) : ∏ k ∈ range 1, (1 - μ ^ (k + 1)) = (2 : R) := by
+  rw [prod_one_sub_pow (n := 1) hμ]; norm_num
+
+/-- `m = 3`: `(1 - μ)(1 - μ²) = 3` for a primitive cube root of unity. -/
+example {μ : R} (hμ : IsPrimitiveRoot μ 3) :
+    ∏ k ∈ range 2, (1 - μ ^ (k + 1)) = (3 : R) := by
+  rw [prod_one_sub_pow (n := 2) hμ]; norm_num
+
+end PrimitiveRootsOQ04

--- a/src/data/proofs/primitive-roots-oq-04/meta.json
+++ b/src/data/proofs/primitive-roots-oq-04/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "primitive-roots-oq-04",
+  "title": "The primitive-root vertex-product identity ∏(1 − μᵏ) = m and its regular-polygon chord reading",
+  "slug": "primitive-roots-oq-04",
+  "description": "For a primitive m-th root of unity μ in an integral domain, ∏_{k=1}^{m-1}(1 − μ^k) = m. Mathlib proves this algebraic identity (IsPrimitiveRoot.prod_one_sub_pow_eq_order) along with its sign companion, but records no analytic reading. This entry adds the geometric corollary over ℂ: taking moduli, ∏_{k=1}^{m-1}‖1 − μ^k‖ = m — the product of the distances from one vertex of a regular m-gon inscribed in the unit circle to the other m−1 vertices equals m — together with the explicit instantiation at μ = exp(2πi/m).",
+  "meta": {
+    "author": "classical (Gauss / cyclotomy)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PrimitiveRootsOQ04.lean",
+    "tags": [
+      "algebra",
+      "number-theory",
+      "primitive-roots",
+      "roots-of-unity",
+      "cyclotomic",
+      "complex-analysis",
+      "regular-polygon"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "IsPrimitiveRoot.prod_one_sub_pow_eq_order",
+        "description": "The order identity ∏_{k∈range n}(1 − μ^{k+1}) = n+1 for a primitive (n+1)-th root of unity in an integral domain — the algebraic core re-exported here and taken moduli of for the geometric corollary",
+        "module": "Mathlib.RingTheory.RootsOfUnity.Lemmas"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.prod_pow_sub_one_eq_order",
+        "description": "The sign-flipped companion (-1)^n·∏(μ^{k+1} − 1) = n+1, re-exported",
+        "module": "Mathlib.RingTheory.RootsOfUnity.Lemmas"
+      },
+      {
+        "theorem": "Complex.isPrimitiveRoot_exp",
+        "description": "exp(2πi/m) is a primitive m-th root of unity in ℂ, used to instantiate the identity at the standard root",
+        "module": "Mathlib.RingTheory.RootsOfUnity.Complex"
+      },
+      {
+        "theorem": "norm_prod",
+        "description": "The norm of a finite product is the product of the norms (multiplicativity of ‖·‖ on ℂ), used to pass from the algebraic identity to the chord-length product",
+        "module": "Mathlib.Analysis.Normed.Ring.Basic"
+      },
+      {
+        "theorem": "Complex.exp_nat_mul",
+        "description": "exp(n·z) = exp(z)^n, used to rewrite exp(2πi(k+1)/m) as the (k+1)-th power of the standard primitive root",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Circle"
+      }
+    ],
+    "originalContributions": [
+      "prod_norm_one_sub_pow: over ℂ, ∏_{k=0}^{n-1}‖1 − μ^{k+1}‖ = n+1 — the modulus (regular-polygon chord-product) reading of the order identity, absent from Mathlib",
+      "prod_one_sub_exp: the explicit instantiation ∏_{k=0}^{n-1}(1 − exp(2πi(k+1)/(n+1))) = n+1 at the standard primitive root μ = exp(2πi/(n+1))",
+      "prod_norm_one_sub_exp: the fully explicit regular-polygon chord product ∏‖1 − exp(2πi(k+1)/(n+1))‖ = n+1",
+      "prod_one_sub_pow and neg_one_pow_mul_prod_pow_sub: clean namespaced re-exports of the Mathlib order identity and its sign companion, with concrete m = 2, 3 checks"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound. No native_decide, so no Lean.ofReduceBool.",
+    "lineCount": 114,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That the product of the distances from one vertex of a regular m-gon (inscribed in the unit circle) to the other m−1 vertices equals m is a classical fact of cyclotomy, equivalent to evaluating the derivative of X^m − 1 at the root 1, or to specializing the factorization X^m − 1 = ∏_{k=0}^{m-1}(X − μ^k) after dividing out the factor (X − 1). Algebraically it is the statement ∏_{k=1}^{m-1}(1 − μ^k) = m for a primitive m-th root of unity μ. The identity underlies discriminant computations for cyclotomic fields and the evaluation of Gauss sums.",
+    "problemStatement": "Expose the cyclotomic vertex-product identity ∏_{k=1}^{m-1}(1 − μ^k) = m in the gallery and supply its analytic/geometric reading over ℂ, which Mathlib does not state.",
+    "text": "Mathlib's IsPrimitiveRoot.prod_one_sub_pow_eq_order gives the algebraic identity (in the form ∏_{k∈range n}(1 − μ^{k+1}) = n+1, with m = n+1). Passing to ℂ and taking moduli — using multiplicativity of the norm — turns it into the regular-polygon chord product ∏‖1 − μ^{k+1}‖ = n+1; instantiating μ = exp(2πi/(n+1)) makes both forms fully explicit.",
+    "proofStrategy": "1. prod_one_sub_pow / neg_one_pow_mul_prod_pow_sub: direct re-exports of the Mathlib order identity and its sign companion.\n2. prod_norm_one_sub_pow: rewrite ∏‖·‖ = ‖∏·‖ (norm_prod), apply the order identity inside the norm, then ‖(↑(n+1) : ℂ)‖ = n+1 (Complex.norm_natCast).\n3. prod_one_sub_exp: take μ = exp(2πi/(n+1)) (Complex.isPrimitiveRoot_exp), then match factors via exp(2πi(k+1)/(n+1)) = exp(2πi/(n+1))^{k+1} (Complex.exp_nat_mul).\n4. prod_norm_one_sub_exp: combine steps 2 and 3.\n5. Concrete m = 2 ((1 − (−1)) = 2) and m = 3 ((1 − μ)(1 − μ²) = 3) checks.",
+    "keyInsights": [
+      "**Norm multiplicativity is the whole bridge**: the geometric corollary is just the algebraic identity read through ‖∏ aᵢ‖ = ∏‖aᵢ‖; no separate analysis of the chord lengths is needed.",
+      "**The constant is the order**: the right-hand side m = n+1 is exactly the order of the root, so the chord product equals the number of vertices of the polygon.",
+      "**Filling a real Mathlib gap**: Mathlib has the algebraic identity and its sign/divisibility companions, but not the modulus form or the explicit exp instantiation — this entry adds both.",
+      "**`n+1` indexing avoids a side condition**: stating the order as n+1 removes the hypothesis m ≠ 0 throughout, matching the Mathlib convention."
+    ],
+    "prerequisites": [
+      "Primitive roots of unity and the factorization X^m − 1 = ∏(X − μ^k)",
+      "The complex modulus and its multiplicativity",
+      "The standard primitive root exp(2πi/m)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "File-level docstring stating the vertex-product identity, what Mathlib already provides (order identity, sign companion, divisibility), and the new analytic/geometric content added here. Imports Mathlib; opens Finset, Complex, Real.",
+      "mathContext": "μ is a primitive (n+1)-th root of unity; m = n+1 is its order."
+    },
+    {
+      "id": "order-identity",
+      "title": "The Order Identity (Mathlib core)",
+      "startLine": 37,
+      "endLine": 51,
+      "summary": "prod_one_sub_pow re-exports IsPrimitiveRoot.prod_one_sub_pow_eq_order: ∏_{k∈range n}(1 − μ^{k+1}) = n+1. neg_one_pow_mul_prod_pow_sub re-exports the sign companion (-1)^n·∏(μ^{k+1} − 1) = n+1.",
+      "mathContext": "∏_{k=1}^{m-1}(1 − μ^k) = m over any integral domain."
+    },
+    {
+      "id": "norm-form",
+      "title": "The Regular-Polygon Chord Product",
+      "startLine": 53,
+      "endLine": 68,
+      "summary": "prod_norm_one_sub_pow: over ℂ, ∏‖1 − μ^{k+1}‖ = n+1 via norm_prod and Complex.norm_natCast.",
+      "mathContext": "The product of distances from vertex 1 to the other vertices of a regular m-gon equals m."
+    },
+    {
+      "id": "explicit-exp",
+      "title": "Explicit Instantiation at exp(2πi/m)",
+      "startLine": 70,
+      "endLine": 101,
+      "summary": "prod_one_sub_exp instantiates μ = exp(2πi/(n+1)) via Complex.isPrimitiveRoot_exp, matching factors with Complex.exp_nat_mul; prod_norm_one_sub_exp gives the explicit chord product.",
+      "mathContext": "∏(1 − exp(2πi(k+1)/m)) = m and its modulus form, fully explicit."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Concrete Values",
+      "startLine": 103,
+      "endLine": 114,
+      "summary": "m = 2 (1 − (−1) = 2) and m = 3 ((1 − μ)(1 − μ²) = 3) checks, specializing the order identity.",
+      "mathContext": "The first nontrivial cases of the vertex-product identity."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "note": "Cyclotomy and the factorization of X^m − 1 over the roots of unity"
+    },
+    {
+      "authors": "Washington, Lawrence C.",
+      "title": "Introduction to Cyclotomic Fields",
+      "year": "1997",
+      "note": "Develops cyclotomic units and products of (1 − ζ^k), including the order identity used here"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-04",
+      "relationship": "related",
+      "description": "Identifies the m-th roots of unity as the powers of ω = exp(2πi/m); this entry forms the product ∏(1 − μ^k) over exactly those roots and reads it geometrically as a regular-polygon chord product"
+    }
+  ],
+  "conclusion": {
+    "summary": "The cyclotomic vertex-product identity ∏_{k=1}^{m-1}(1 − μ^k) = m is re-exported from Mathlib (prod_one_sub_pow) together with its sign companion, and is given its analytic reading over ℂ: the regular-polygon chord product ∏‖1 − μ^k‖ = m (prod_norm_one_sub_pow) and the explicit instantiation at μ = exp(2πi/m) (prod_one_sub_exp, prod_norm_one_sub_exp). All five theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies the modulus/geometric form of a standard cyclotomic identity — the regular-polygon chord product — which Mathlib states only algebraically, giving a directly citable analytic statement.",
+    "openQuestions": [
+      "Can the related chord product from a non-vertex point, ∏_{k=0}^{m-1}|z − μ^k| = |z^m − 1| for arbitrary z on the unit circle, be formalized as the evaluation of the cyclotomic factorization?",
+      "Does the discriminant of the m-th cyclotomic polynomial follow cleanly from the sign companion (-1)^n·∏(μ^k − 1) = m together with the conjugate-pair structure of the roots?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Complex",
+      "Real"
+    ],
+    "namespace": "PrimitiveRootsOQ04",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/PrimitiveRootsOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds gallery entry **primitive-roots-oq-04**: the cyclotomic vertex-product identity ∏_{k=1}^{m-1}(1 − μ^k) = m for a primitive m-th root of unity μ, together with the analytic/geometric reading over ℂ that Mathlib does not state.

Mathlib already proves the algebraic identity (`IsPrimitiveRoot.prod_one_sub_pow_eq_order`, in the form ∏_{k∈range n}(1 − μ^{k+1}) = n+1) and its sign companion. This entry re-exports those and supplies:

- **`prod_norm_one_sub_pow`** *(new)* — over ℂ, ∏_{k=0}^{n-1}‖1 − μ^{k+1}‖ = n+1. Geometrically: the product of the distances from one vertex of a regular (n+1)-gon inscribed in the unit circle to the other n vertices equals n+1. Proved by norm multiplicativity (`norm_prod`) + `Complex.norm_natCast`.
- **`prod_one_sub_exp`** *(new)* — explicit instantiation at the standard root μ = exp(2πi/(n+1)).
- **`prod_norm_one_sub_exp`** *(new)* — the fully explicit regular-polygon chord product.

Concrete `m = 2, 3` checks close the file.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.PrimitiveRootsOQ04` → **Build completed successfully** (Mathlib 4.26.0).
- 5 theorems, 0 definitions, **0 sorries, 0 axioms** (depends only on `propext`/`Classical.choice`/`Quot.sound`; no `native_decide`, so no `Lean.ofReduceBool`).
- Status: `verified` / badge `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)