### PR TITLE
Fix: register composition-parts-choose-oq-01 in Proofs.lean (#27140)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -643,6 +643,7 @@ import Proofs.CombinationsFormulaOQ08
 import Proofs.CombinationsFormulaOQ09
 import Proofs.ComplexityCore
 import Proofs.CompositionCard2PowOQ01
+import Proofs.CompositionPartsChooseOQ01
 import Proofs.ConjugacyClassEquationOQ01
 import Proofs.ContinuumHypothesis
 import Proofs.ContinuumHypothesisOQ01


### PR DESCRIPTION
## Fix

Adds the missing `import Proofs.CompositionPartsChooseOQ01` to `proofs/Proofs.lean` so the verified-badge module becomes reachable from the default build target and is compiled by CI.

## Evidence

**Before**: `Proofs.CompositionPartsChooseOQ01` (merged in #27133, badged `verified`/`original`/`axiomCount: 0`) was absent from `proofs/Proofs.lean` and not imported transitively — outside the default build target, never machine-checked.

```
$ comm -23 <(ls proofs/Proofs/*.lean | sed 's#.*/##;s#.lean##' | sort) \
           <(grep '^import Proofs\.' proofs/Proofs.lean | sed 's#import Proofs\.##' | sort)
CompositionPartsChooseOQ01
```

**After**: the single sorted import line is added (3393 → 3394 imports). Purely a reachability/registration gap; proof content is unchanged (auditor confirmed 0 `sorry`, 0 `axiom`, 0 `native_decide`, no stubs).

Minimal one-line diff; verified locally via the Docker build wrapper for `Proofs.CompositionPartsChooseOQ01`.

Closes #27140

---
Automated fix by lean-mechanic agent.