### PR TITLE
research(minkowski-theorem-oq-05): power-sum convexity bound + optimality of 2^(p−1) [BUILD PENDING — harness blackout]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2876,6 +2876,7 @@ import Proofs.MinkowskiTheoremOQ02OQ01
 import Proofs.MinkowskiTheoremOQ02OQ03
 import Proofs.MinkowskiTheoremOQ03
 import Proofs.MinkowskiTheoremOQ04
+import Proofs.MinkowskiTheoremOQ05
 import Proofs.MinpolyCharpoly
 import Proofs.MinpolyCharpolyOQ01
 import Proofs.MinpolyCharpolyOQ02

--- a/proofs/Proofs/MinkowskiTheoremOQ05.lean
+++ b/proofs/Proofs/MinkowskiTheoremOQ05.lean
@@ -1,0 +1,121 @@
+/-
+# Power-Sum Convexity Bound and the Optimality of `2^(p-1)` (OQ-05)
+
+## What This Proves
+
+For a real exponent `p ≥ 1` and nonnegative reals `a, b`,
+```
+(a + b) ^ p ≤ 2 ^ (p - 1) · (a ^ p + b ^ p),
+```
+and the constant `2 ^ (p - 1)` is the **best possible**: equality holds at `a = b`,
+and any constant `C` for which the inequality holds for all nonnegative `a, b`
+must satisfy `C ≥ 2 ^ (p - 1)`. We package this as the statement that
+`2 ^ (p - 1)` is the *least* element of the set of admissible constants:
+```
+IsLeast { C | ∀ a b ≥ 0, (a + b) ^ p ≤ C · (a ^ p + b ^ p) } (2 ^ (p - 1)).
+```
+
+This is the two-variable power-mean / convexity scaling bound underlying the `ℓ^p`
+quasi-norm comparison constants: it is the reverse companion (for `p ≥ 1`) of the
+sub-additivity `(a + b)^p ≥ a^p + b^p`, and it sharpens to an exact equality on the
+diagonal `a = b`.
+
+## Relation to Mathlib
+
+Mathlib proves the inequality only for `ℝ≥0` (`NNReal.rpow_add_le_mul_rpow_add_rpow`,
+`Mathlib/Analysis/MeanInequalitiesPow.lean`) and for `ℝ≥0∞`. The **real-valued
+nonnegative** formulation — the one used directly when comparing `ℓ^p` constants over
+`ℝ` — is absent, as is any statement that `2 ^ (p - 1)` is the optimal constant.
+Here we:
+
+1. Transport the `ℝ≥0` inequality to `ℝ` via the coercion
+   (`rpow_add_le_two_rpow_sub_one_mul`).
+2. Prove the diagonal equality `(a + a) ^ p = 2 ^ (p - 1) · (a ^ p + a ^ p)`
+   (`rpow_add_self_eq`), the sharpness witness — note this holds for *every* real `p`.
+3. Prove the lower bound on any admissible constant
+   (`two_rpow_sub_one_le_of_forall`); the test point `a = b = 1` forces `C ≥ 2^(p-1)`.
+4. Combine (1) and (3) into the optimality statement `isLeast_two_rpow_sub_one`.
+
+## Key Techniques
+
+- **NNReal → ℝ transport**: `lift _ to ℝ≥0` plus `exact_mod_cast` carries the
+  Mathlib `ℝ≥0` inequality across the order-embedding coercion.
+- **rpow arithmetic**: `Real.mul_rpow`, `Real.rpow_add`, `Real.rpow_sub`,
+  `Real.rpow_one` to manipulate `2 ^ p = 2 · 2 ^ (p - 1)` and the diagonal equality.
+- **Optimality via a test point**: evaluating the universal hypothesis at
+  `a = b = 1` gives `2 ^ p ≤ 2 C`, hence `2 ^ (p - 1) ≤ C`.
+-/
+
+import Mathlib
+
+open scoped NNReal
+
+namespace MinkowskiTheoremOQ05
+
+/-- **Power-sum convexity bound (real-valued form).** For `p ≥ 1` and nonnegative
+reals `a, b`,
+`(a + b) ^ p ≤ 2 ^ (p - 1) · (a ^ p + b ^ p)`.
+
+This is the real-valued nonnegative version of Mathlib's
+`NNReal.rpow_add_le_mul_rpow_add_rpow`, obtained by transporting the `ℝ≥0`
+inequality through the coercion `ℝ≥0 → ℝ`. -/
+theorem rpow_add_le_two_rpow_sub_one_mul (a b : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b)
+    {p : ℝ} (hp : 1 ≤ p) :
+    (a + b) ^ p ≤ (2 : ℝ) ^ (p - 1) * (a ^ p + b ^ p) := by
+  lift a to ℝ≥0 using ha with a
+  lift b to ℝ≥0 using hb with b
+  have h := NNReal.rpow_add_le_mul_rpow_add_rpow a b hp
+  exact_mod_cast h
+
+/-- **Sharpness on the diagonal.** At `a = b` the inequality is an exact equality:
+`(a + a) ^ p = 2 ^ (p - 1) · (a ^ p + a ^ p)`.
+
+Together with `two_rpow_sub_one_le_of_forall` this shows the constant `2 ^ (p - 1)`
+cannot be lowered. The identity holds for *every* real exponent `p` (it is pure
+`rpow` arithmetic: both sides equal `2 ^ p · a ^ p`). -/
+theorem rpow_add_self_eq (a : ℝ) (ha : 0 ≤ a) (p : ℝ) :
+    (a + a) ^ p = (2 : ℝ) ^ (p - 1) * (a ^ p + a ^ p) := by
+  have e1 : a + a = 2 * a := by ring
+  have key : (2 : ℝ) ^ (p - 1) * (a ^ p + a ^ p)
+      = (2 : ℝ) ^ (p - 1) * (2 : ℝ) ^ (1 : ℝ) * a ^ p := by
+    rw [Real.rpow_one]; ring
+  have hp1 : (p - 1) + 1 = p := by ring
+  rw [e1, Real.mul_rpow (by norm_num) ha, key,
+    ← Real.rpow_add (by norm_num : (0:ℝ) < 2), hp1]
+
+/-- **Optimality of the constant.** If `C` is any constant for which
+`(a + b) ^ p ≤ C · (a ^ p + b ^ p)` holds for all nonnegative `a, b`, then
+`2 ^ (p - 1) ≤ C`.
+
+The test point `a = b = 1` gives `2 ^ p ≤ 2 C`, and `2 ^ (p - 1) = 2 ^ p / 2`. -/
+theorem two_rpow_sub_one_le_of_forall (C : ℝ) {p : ℝ}
+    (h : ∀ a b : ℝ, 0 ≤ a → 0 ≤ b → (a + b) ^ p ≤ C * (a ^ p + b ^ p)) :
+    (2 : ℝ) ^ (p - 1) ≤ C := by
+  have hbase := h 1 1 (by norm_num) (by norm_num)
+  simp only [Real.one_rpow] at hbase
+  have e11 : (1 : ℝ) + 1 = 2 := by norm_num
+  rw [e11] at hbase
+  -- hbase : (2 : ℝ) ^ p ≤ C * 2
+  have e : (2 : ℝ) ^ (p - 1) = (2 : ℝ) ^ p / 2 := by
+    rw [Real.rpow_sub (by norm_num : (0:ℝ) < 2), Real.rpow_one]
+  rw [e]
+  linarith
+
+/-- **The optimal constant is `2 ^ (p - 1)`.** For `p ≥ 1`, the constant
+`2 ^ (p - 1)` is the least element of the set of constants `C` for which the
+power-sum bound `(a + b) ^ p ≤ C · (a ^ p + b ^ p)` holds for all nonnegative
+`a, b`.
+
+This is the precise sense in which `2 ^ (p - 1)` is sharp: it is admissible
+(`rpow_add_le_two_rpow_sub_one_mul`) and no smaller constant is
+(`two_rpow_sub_one_le_of_forall`). -/
+theorem isLeast_two_rpow_sub_one {p : ℝ} (hp : 1 ≤ p) :
+    IsLeast {C : ℝ | ∀ a b : ℝ, 0 ≤ a → 0 ≤ b → (a + b) ^ p ≤ C * (a ^ p + b ^ p)}
+      ((2 : ℝ) ^ (p - 1)) := by
+  constructor
+  · intro a b ha hb
+    exact rpow_add_le_two_rpow_sub_one_mul a b ha hb hp
+  · intro C hC
+    exact two_rpow_sub_one_le_of_forall C hC
+
+end MinkowskiTheoremOQ05

--- a/research/problems/minkowski-theorem-oq-05/knowledge.md
+++ b/research/problems/minkowski-theorem-oq-05/knowledge.md
@@ -1,0 +1,78 @@
+# minkowski-theorem-oq-05 — Power-sum convexity bound and the optimal constant
+
+## Summary
+
+For a real exponent `p ≥ 1` and nonnegative reals `a, b`:
+```
+(a + b) ^ p ≤ 2 ^ (p - 1) · (a ^ p + b ^ p),
+```
+and `2 ^ (p - 1)` is the **optimal** constant: equality holds at `a = b`, and any
+constant `C` valid for all nonnegative `a, b` satisfies `C ≥ 2 ^ (p - 1)`. The
+headline result packages this as
+```
+2 ^ (p - 1) = IsLeast { C | ∀ a b ≥ 0, (a + b) ^ p ≤ C · (a ^ p + b ^ p) }.
+```
+
+Mathlib has the inequality only for `ℝ≥0` (`NNReal.rpow_add_le_mul_rpow_add_rpow`)
+and `ℝ≥0∞`; the real-valued nonnegative form and the optimality of the constant are
+both absent.
+
+## Files
+
+- `proofs/Proofs/MinkowskiTheoremOQ05.lean` — 4 theorems, 0 def, 0 sorry, 0 axiom
+  (by construction). Registered in `proofs/Proofs.lean`.
+- `src/data/proofs/minkowski-theorem-oq-05/{meta.json,annotations.json}` — gallery
+  entry, held at `formalized`/`wip` pending a green build.
+
+---
+
+## Session 2026-06-20 (Session 1) — Full proof written, build blocked by harness blackout
+
+**Mode**: FRESH
+**Outcome**: progress (proof complete; machine-verification pending)
+
+### What I Did
+- Triaged the 16 available pool problems (all EMPTY knowledge tier). Found most are
+  verbatim Mathlib re-exports (chebyshev-oq-02 = `T_mul_T`, uniformbell = `uniformBell_mul_eq`,
+  dyck-catalan = `card_dyckWord_semilength_eq_catalan`, three-subgroups = `three_subgroups_lemma`,
+  spectral = `det_eq_prod_roots_charpoly`/`trace_eq_sum_roots_charpoly`).
+- Selected minkowski-theorem-oq-05: the **ℝ≥0** bound is verbatim in Mathlib, but the
+  **real-valued** form and the **optimality** of `2^(p−1)` are not — genuine, tractable content.
+- Wrote `MinkowskiTheoremOQ05.lean`:
+  1. `rpow_add_le_two_rpow_sub_one_mul` — real-valued bound via `lift … to ℝ≥0` + `exact_mod_cast`.
+  2. `rpow_add_self_eq` — diagonal equality (sharpness witness), all real `p`.
+  3. `two_rpow_sub_one_le_of_forall` — optimality lower bound from test point `a=b=1`.
+  4. `isLeast_two_rpow_sub_one` — `2^(p−1)` is the least admissible constant.
+- Registered the module in `proofs/Proofs.lean`; drafted gallery `meta.json` + `annotations.json`.
+
+### Key Findings
+- The genuine content is **optimality**, not the bare inequality (a one-line ℝ≥0 transport).
+- The diagonal equality needs no `p ≥ 1` hypothesis (both sides are `2^p·a^p`).
+- A single test point `a=b=1` pins the optimal constant: `2^p ≤ 2C ⇒ C ≥ 2^(p−1)`.
+
+### Blockers
+- **Docker harness blackout (2026-06-20):** `docker info` unreachable from host all
+  session (VM internally up — volume/forward IPC responds — but `dockerd` not exposed).
+  Tried `open -a Docker`, a full quit+relaunch, and ~10 min of polling; never recovered.
+  So `docker-build.sh Proofs.MinkowskiTheoremOQ05` was NOT run; the file is **not yet
+  kernel-checked**. Status held at `formalized`/`wip`, NOT `verified` (gallery-integrity:
+  never claim verified without a real build).
+- Aristotle MCP fills sorries only — useless for build-verifying a complete file.
+
+### Self-review (in lieu of a build)
+Logic checked by hand: thm 1 is a standard `exact_mod_cast` over `NNReal.coe_rpow`;
+thm 2 is an `rw` chain reducing both sides to `2^p·a^p`; thm 3 instantiates at `1,1`
+and divides via `2^(p−1)=2^p/2`; thm 4 is `⟨thm1, thm3⟩` over `IsLeast`. Residual risk
+is only elaboration detail (the `exact_mod_cast` cast set; `intro` through `Set.mem_setOf`
+in the `IsLeast` membership goal) — exactly what the pending build will confirm.
+
+### Files Modified
+- `proofs/Proofs/MinkowskiTheoremOQ05.lean` (new)
+- `proofs/Proofs.lean` (import)
+- `src/data/proofs/minkowski-theorem-oq-05/meta.json` (new)
+- `src/data/proofs/minkowski-theorem-oq-05/annotations.json` (new)
+- `src/data/research/problems/minkowski-theorem-oq-05.json` (new)
+
+### Next Steps
+- Build via Docker once the harness recovers; on green, promote to `verified`/`original`.
+- Follow-up veins: reverse bound for `0 < p ≤ 1` (constant 1); n-term form with `n^(p−1)` optimal.

--- a/src/data/proofs/minkowski-theorem-oq-05/annotations.json
+++ b/src/data/proofs/minkowski-theorem-oq-05/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "minkowski-theorem-oq-05",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "Power-sum convexity bound and the optimal constant",
+    "content": "For p ≥ 1 and nonnegative reals a, b, (a+b)^p ≤ 2^(p−1)(a^p+b^p). Mathlib proves this only for ℝ≥0 and ℝ≥0∞; the real-valued nonnegative form and the optimality of the constant 2^(p−1) are both absent. This file transports the inequality to ℝ, proves equality on the diagonal a = b, shows any universally-valid constant C satisfies C ≥ 2^(p−1), and packages these as the statement that 2^(p−1) is the least admissible constant.",
+    "mathContext": "$(a+b)^p \\le 2^{p-1}(a^p+b^p)$ for $a,b \\ge 0,\\ p \\ge 1$, with $2^{p-1}$ optimal.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "power-mean inequality",
+      "convexity of x^p",
+      "Jensen inequality",
+      "optimal constants"
+    ],
+    "prerequisites": [
+      "real power function (rpow)",
+      "convexity / power means"
+    ]
+  },
+  {
+    "id": "ann-bound",
+    "proofId": "minkowski-theorem-oq-05",
+    "range": { "startLine": 56, "endLine": 74 },
+    "type": "technique",
+    "title": "Real-valued bound via ℝ≥0 transport",
+    "content": "The real-valued nonnegative form is obtained by lifting a, b to ℝ≥0 (using their nonnegativity), applying Mathlib's NNReal.rpow_add_le_mul_rpow_add_rpow, and carrying the inequality back to ℝ with exact_mod_cast. The norm_cast lemma NNReal.coe_rpow bridges (↑(x^p)) and (↑x)^p, so the whole inequality transports across the order-embedding coercion in one step.",
+    "mathContext": "$\\mathbb{R}_{\\ge 0} \\hookrightarrow \\mathbb{R}$ is an order embedding, so a $\\ge 0$ inequality lifts verbatim.",
+    "significance": "key",
+    "relatedConcepts": [
+      "NNReal coercion",
+      "norm_cast",
+      "order embedding"
+    ],
+    "prerequisites": [
+      "ℝ≥0 → ℝ coercion",
+      "rpow on nonnegative reals"
+    ]
+  },
+  {
+    "id": "ann-equality",
+    "proofId": "minkowski-theorem-oq-05",
+    "range": { "startLine": 76, "endLine": 89 },
+    "type": "insight",
+    "title": "Sharpness witness: equality on the diagonal",
+    "content": "At a = b the bound is an exact equality, because both (a+a)^p and 2^(p−1)(a^p+a^p) equal 2^p·a^p. The proof rewrites a+a = 2·a, splits (2a)^p = 2^p·a^p via Real.mul_rpow, and recombines 2^(p−1)·2^1 = 2^p via Real.rpow_add. Notably this needs no hypothesis on p — the diagonal equality is pure rpow arithmetic, valid for every real exponent.",
+    "mathContext": "$(2a)^p = 2^p a^p = 2^{p-1}(a^p+a^p)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sharp constants",
+      "equality case",
+      "rpow arithmetic"
+    ],
+    "prerequisites": [
+      "Real.mul_rpow",
+      "Real.rpow_add"
+    ]
+  },
+  {
+    "id": "ann-optimality",
+    "proofId": "minkowski-theorem-oq-05",
+    "range": { "startLine": 91, "endLine": 110 },
+    "type": "insight",
+    "title": "Optimality from a single test point",
+    "content": "Any constant C for which (a+b)^p ≤ C(a^p+b^p) holds for all nonnegative a, b must satisfy C ≥ 2^(p−1). Evaluating the hypothesis at a = b = 1 gives 2^p ≤ 2C; dividing by 2 (using 2^(p−1) = 2^p/2 from Real.rpow_sub) yields the bound. A single evaluation pins the optimal constant — no variational argument.",
+    "mathContext": "$a=b=1 \\Rightarrow 2^p \\le 2C \\Rightarrow C \\ge 2^{p-1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "optimal constant",
+      "test point",
+      "lower bound"
+    ],
+    "prerequisites": [
+      "Real.rpow_sub",
+      "linarith"
+    ]
+  },
+  {
+    "id": "ann-isleast",
+    "proofId": "minkowski-theorem-oq-05",
+    "range": { "startLine": 112, "endLine": 120 },
+    "type": "concept",
+    "title": "The optimal constant is 2^(p−1)",
+    "content": "Combining admissibility (the bound holds with C = 2^(p−1)) and the lower bound (no smaller constant works), 2^(p−1) is the least element of the set { C | ∀ a b ≥ 0, (a+b)^p ≤ C(a^p+b^p) }. This IsLeast statement is the precise, single-theorem characterization of the sharp constant in the two-term power-sum convexity bound.",
+    "mathContext": "$2^{p-1} = \\operatorname{IsLeast}\\{ C \\mid \\forall a,b \\ge 0,\\ (a+b)^p \\le C(a^p+b^p) \\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsLeast",
+      "optimal constant",
+      "lower bounds"
+    ],
+    "prerequisites": [
+      "IsLeast / lowerBounds",
+      "the bound and optimality lemmas above"
+    ]
+  }
+]

--- a/src/data/proofs/minkowski-theorem-oq-05/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-05/meta.json
@@ -1,0 +1,88 @@
+{
+  "id": "minkowski-theorem-oq-05",
+  "title": "Power-sum convexity bound (a+b)^p ≤ 2^(p−1)(a^p+b^p), with 2^(p−1) the optimal constant",
+  "slug": "minkowski-theorem-oq-05",
+  "description": "For a real exponent p ≥ 1 and nonnegative reals a, b, the power-sum convexity bound (a+b)^p ≤ 2^(p−1)(a^p+b^p), together with the sharpness statement that 2^(p−1) is the best possible constant: equality holds on the diagonal a = b, and any constant C valid for all nonnegative a, b satisfies C ≥ 2^(p−1). Mathlib proves the inequality only for ℝ≥0 (NNReal.rpow_add_le_mul_rpow_add_rpow) and ℝ≥0∞; the real-valued nonnegative formulation and the optimality of the constant are both absent. The headline result is the characterization 2^(p−1) = IsLeast of the admissible-constant set.",
+  "meta": {
+    "author": "Classical (power-mean / Jensen convexity)",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/MinkowskiTheoremOQ05.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "power-means",
+      "convexity",
+      "rpow",
+      "minkowski",
+      "optimal-constant"
+    ],
+    "badge": "wip",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "NNReal.rpow_add_le_mul_rpow_add_rpow",
+        "description": "The ℝ≥0 power-sum bound (z₁+z₂)^p ≤ 2^(p−1)(z₁^p+z₂^p) for p ≥ 1; transported across the ℝ≥0 → ℝ coercion to obtain the real-valued nonnegative form",
+        "module": "Mathlib.Analysis.MeanInequalitiesPow"
+      },
+      {
+        "theorem": "Real.mul_rpow",
+        "description": "(x·y)^z = x^z·y^z for x,y ≥ 0; used for (2a)^p = 2^p·a^p in the diagonal equality",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_add",
+        "description": "x^(y+z) = x^y·x^z for x > 0; recombines 2^(p−1)·2^1 = 2^p in the diagonal equality",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_sub",
+        "description": "x^(y−z) = x^y/x^z for x > 0; rewrites 2^(p−1) = 2^p/2 in the optimality argument",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "NNReal.coe_rpow",
+        "description": "((x^y : ℝ≥0) : ℝ) = (x:ℝ)^y; the norm_cast lemma carrying the NNReal inequality to ℝ",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      }
+    ],
+    "originalContributions": [
+      "rpow_add_le_two_rpow_sub_one_mul: the real-valued nonnegative form (a+b)^p ≤ 2^(p−1)(a^p+b^p) for a,b ≥ 0, p ≥ 1 — absent from Mathlib, which states the bound only for ℝ≥0 and ℝ≥0∞; obtained by lifting to ℝ≥0 and transporting NNReal.rpow_add_le_mul_rpow_add_rpow through the coercion",
+      "rpow_add_self_eq: the diagonal equality (a+a)^p = 2^(p−1)(a^p+a^p), valid for every real exponent p (both sides equal 2^p·a^p) — the sharpness witness showing the constant is attained at a = b",
+      "two_rpow_sub_one_le_of_forall: optimality lower bound — any constant C with (a+b)^p ≤ C(a^p+b^p) for all nonnegative a, b satisfies 2^(p−1) ≤ C, proved by evaluating at the test point a = b = 1 (giving 2^p ≤ 2C)",
+      "isLeast_two_rpow_sub_one: the headline characterization — 2^(p−1) is the least element of { C | ∀ a b ≥ 0, (a+b)^p ≤ C(a^p+b^p) }, packaging admissibility and the lower bound into a single optimal-constant statement"
+    ],
+    "axiomCount": 0,
+    "assumptions": "Proof is complete by construction — 0 sorries, 0 `axiom` declarations, no native_decide (so no Lean.ofReduceBool), no structure-encoded assumptions. BUILD VERIFICATION PENDING: the local Docker build (`./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ05`) was NOT run this session due to a Docker-daemon harness blackout on 2026-06-20. Status is held at `formalized`/`wip` rather than `verified`/`original` until a green Docker/CI build confirms machine-checking; promote to verified + badge original once the build passes (expected to depend only on propext, Classical.choice, Quot.sound).",
+    "lineCount": 121,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "scoped NNReal"
+    ],
+    "namespace": "MinkowskiTheoremOQ05",
+    "path": "Proofs/MinkowskiTheoremOQ05.lean"
+  },
+  "overview": {
+    "historicalContext": "The bound (a+b)^p ≤ 2^(p−1)(a^p+b^p) for p ≥ 1 is the two-term case of the convexity (Jensen) inequality for the power function x ↦ x^p, equivalently the power-mean inequality M₁ ≤ M_p between the arithmetic mean and the p-th power mean. It is the elementary engine behind the comparison constants relating the ℓ^p and ℓ^1 quasi-norms on a two-point space, and the reverse companion (for p ≥ 1) of the super-additivity a^p + b^p ≤ (a+b)^p. The constant 2^(p−1) is classical and sharp; this entry makes both the real-valued statement and the optimality of the constant explicit.",
+    "problemStatement": "Establish, over the reals, the power-sum convexity bound (a+b)^p ≤ 2^(p−1)(a^p+b^p) for nonnegative a, b and exponent p ≥ 1, and determine the optimal constant.\n\n**Answer:** the bound holds, equality is attained at a = b, and 2^(p−1) is the least constant for which the bound holds universally — i.e. 2^(p−1) = IsLeast { C | ∀ a b ≥ 0, (a+b)^p ≤ C(a^p+b^p) }.",
+    "text": "For p ≥ 1 and nonnegative reals a, b one has (a+b)^p ≤ 2^(p−1)(a^p+b^p). Mathlib records this only for ℝ≥0 and ℝ≥0∞; here it is transported to the real-valued nonnegative setting and, more substantially, the constant 2^(p−1) is shown to be optimal: it is attained on the diagonal a = b and no smaller constant works (test a = b = 1). The two facts combine into the statement that 2^(p−1) is the least admissible constant.",
+    "proofStrategy": "1. rpow_add_le_two_rpow_sub_one_mul: lift a, b to ℝ≥0 (using nonnegativity), apply Mathlib's NNReal.rpow_add_le_mul_rpow_add_rpow, and transport the inequality back to ℝ with exact_mod_cast (NNReal.coe_rpow et al.).\n2. rpow_add_self_eq: rewrite a + a = 2·a, use Real.mul_rpow to get (2a)^p = 2^p·a^p, and recombine 2^(p−1)·2^1 = 2^p via Real.rpow_add; both sides reduce to 2^p·a^p.\n3. two_rpow_sub_one_le_of_forall: instantiate the universal hypothesis at a = b = 1 to get 2^p ≤ 2C, then divide using 2^(p−1) = 2^p/2 (Real.rpow_sub).\n4. isLeast_two_rpow_sub_one: combine (1) for membership and (3) for the lower bound into the IsLeast statement.",
+    "keyInsights": [
+      "**Optimality is the structural payoff.** The bare inequality is a routine transport of a Mathlib ℝ≥0 lemma; the genuine content is that 2^(p−1) is the *best* constant — attained at a = b and forced from below by the test point a = b = 1. Mathlib records neither the real-valued form nor the optimality.",
+      "**The diagonal equality holds for every exponent.** rpow_add_self_eq needs no hypothesis on p: both (a+a)^p and 2^(p−1)(a^p+a^p) equal 2^p·a^p identically, so equality on the diagonal is pure rpow arithmetic, not a p ≥ 1 phenomenon.",
+      "**A one-point test pins the constant.** Optimality of 2^(p−1) follows from a single evaluation at a = b = 1: the universal bound gives 2^p ≤ 2C, hence C ≥ 2^(p−1). No variational argument is needed.",
+      "**ℝ≥0 → ℝ transport is the right tool for nonnegative real inequalities.** Lifting nonnegative reals to ℝ≥0 and pushing a Mathlib NNReal inequality back through the order-embedding coercion (exact_mod_cast) is a clean, reusable pattern for real-valued nonnegative statements absent from Mathlib."
+    ],
+    "prerequisites": [
+      "Real power function x ↦ x^p (rpow) and its basic algebra",
+      "Convexity / power-mean inequalities (two-term case)",
+      "The nonnegative-reals coercion ℝ≥0 → ℝ and norm_cast"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/minkowski-theorem-oq-05.json
+++ b/src/data/research/problems/minkowski-theorem-oq-05.json
@@ -1,0 +1,71 @@
+{
+  "slug": "minkowski-theorem-oq-05",
+  "title": "Power-sum convexity bound: (a+b)^p ≤ 2^(p−1)(a^p+b^p) for p ≥ 1",
+  "status": "active",
+  "phase": "ACT",
+  "tier": "B",
+  "tractability": 9,
+  "significance": 6,
+  "started": "2026-06-20",
+  "lastUpdate": "2026-06-20",
+  "path": "full",
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-20",
+    "iteration": 1,
+    "focus": "Proof written in full (4 theorems, 0 sorries, 0 axioms by construction); machine-build held pending Docker harness blackout.",
+    "blockers": [
+      "Docker daemon unreachable from host on 2026-06-20 (VM internally up, dockerd not exposed) — could not run docker-build.sh to kernel-check the file this session.",
+      "Aristotle only fills sorries; cannot be used to build-verify a complete (sorry-free) file."
+    ],
+    "nextAction": "Run `./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ05` once the Docker harness recovers; on green, promote meta.json status formalized/wip -> verified/original.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROOF COMPLETE, BUILD PENDING. MinkowskiTheoremOQ05.lean (4 theorems, 0 def, 0 sorry, 0 axiom by construction) written and registered in Proofs.lean; gallery meta.json + annotations.json drafted at formalized/wip. Headline: 2^(p−1) = IsLeast { C | ∀ a b ≥ 0, (a+b)^p ≤ C(a^p+b^p) } — i.e. the optimal constant in the two-term power-sum convexity bound. Build verification blocked by the 2026-06-20 Docker harness blackout.",
+    "builtItems": [
+      "MinkowskiTheoremOQ05.rpow_add_le_two_rpow_sub_one_mul — real-valued bound (a+b)^p ≤ 2^(p−1)(a^p+b^p) for a,b ≥ 0, p ≥ 1, via ℝ≥0 transport (MinkowskiTheoremOQ05.lean:62)",
+      "MinkowskiTheoremOQ05.rpow_add_self_eq — diagonal equality (a+a)^p = 2^(p−1)(a^p+a^p), all real p (MinkowskiTheoremOQ05.lean:76)",
+      "MinkowskiTheoremOQ05.two_rpow_sub_one_le_of_forall — optimality lower bound C ≥ 2^(p−1) from test point a=b=1 (MinkowskiTheoremOQ05.lean:91)",
+      "MinkowskiTheoremOQ05.isLeast_two_rpow_sub_one — 2^(p−1) is the least admissible constant (MinkowskiTheoremOQ05.lean:112)"
+    ],
+    "insights": [
+      "The ℝ≥0 inequality itself is verbatim in Mathlib (NNReal.rpow_add_le_mul_rpow_add_rpow, MeanInequalitiesPow.lean:117); the genuine content is the real-valued nonnegative form (absent) plus the optimality of the constant 2^(p−1) (absent).",
+      "Transport ℝ≥0 -> ℝ: `lift a to ℝ≥0 using ha` then `exact_mod_cast` carries the whole inequality through the order-embedding coercion in one line (NNReal.coe_rpow is norm_cast).",
+      "The diagonal equality (a+a)^p = 2^(p−1)(a^p+a^p) needs NO hypothesis on p — both sides equal 2^p·a^p — so sharpness is pure rpow arithmetic, not a p ≥ 1 phenomenon.",
+      "Optimality is pinned by a single test point a=b=1: the universal bound gives 2^p ≤ 2C, hence C ≥ 2^(p−1) = 2^p/2. No variational argument needed.",
+      "Packaging admissibility + lower bound as IsLeast gives a single-theorem characterization of the sharp constant, which is the real headline (and what Mathlib lacks)."
+    ],
+    "mathlibGaps": [
+      "No real-valued (ℝ, nonneg) form of the two-term power-sum bound; Mathlib has only the ℝ≥0 and ℝ≥0∞ versions (NNReal/ENNReal.rpow_add_le_mul_rpow_add_rpow).",
+      "No statement that 2^(p−1) is the optimal constant (neither the diagonal equality nor the lower bound on admissible constants is recorded)."
+    ],
+    "nextSteps": [
+      "Kernel-check via Docker once the harness recovers; promote to verified/original.",
+      "Possible follow-up: the reverse bound for 0 < p ≤ 1 (constant 1, sub-additivity direction) and its optimal-constant characterization; the n-term generalization (a₁+…+aₙ)^p ≤ n^(p−1) Σ aᵢ^p with n^(p−1) optimal."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Mathlib: NNReal.rpow_add_le_mul_rpow_add_rpow — (z₁+z₂)^p ≤ 2^(p−1)(z₁^p+z₂^p) for z₁,z₂ : ℝ≥0, p ≥ 1.",
+      "Mathlib: NNReal.rpow_arith_mean_le_arith_mean2_rpow — the weighted two-element power-mean inequality this rests on.",
+      "This entry: the real-valued nonnegative form, the diagonal equality, the optimality lower bound, and the IsLeast characterization of 2^(p−1)."
+    ],
+    "open": [
+      "Reverse direction and optimal constant for 0 < p ≤ 1.",
+      "n-term form (a₁+…+aₙ)^p ≤ n^(p−1) Σ aᵢ^p with n^(p−1) shown optimal."
+    ]
+  },
+  "tags": [
+    "analysis",
+    "inequalities",
+    "minkowski",
+    "power-means",
+    "convexity",
+    "research"
+  ]
+}


### PR DESCRIPTION
## Summary

For a real exponent `p ≥ 1` and nonnegative reals `a, b`:
```
(a + b) ^ p ≤ 2 ^ (p − 1) · (a ^ p + b ^ p),
```
and **`2 ^ (p − 1)` is the optimal constant**:
```
2 ^ (p − 1) = IsLeast { C | ∀ a b ≥ 0, (a + b) ^ p ≤ C · (a ^ p + b ^ p) }.
```

Mathlib proves the inequality only for `ℝ≥0` (`NNReal.rpow_add_le_mul_rpow_add_rpow`)
and `ℝ≥0∞`; the **real-valued nonnegative form** and the **optimality of the constant**
are both absent. That optimality (diagonal equality + lower bound on admissible constants)
is the genuine, non-wrapper content here.

## New file `proofs/Proofs/MinkowskiTheoremOQ05.lean` (4 theorems, 0 sorry, 0 axiom by construction)

- `rpow_add_le_two_rpow_sub_one_mul` — real-valued bound, by lifting `a, b` to `ℝ≥0` and
  transporting the Mathlib `ℝ≥0` inequality back with `exact_mod_cast`.
- `rpow_add_self_eq` — diagonal equality `(a+a)^p = 2^(p−1)(a^p+a^p)`, valid for **every**
  real `p` (both sides are `2^p·a^p`) — the sharpness witness.
- `two_rpow_sub_one_le_of_forall` — any constant `C` valid for all nonnegative `a, b`
  satisfies `C ≥ 2^(p−1)`, from the single test point `a = b = 1`.
- `isLeast_two_rpow_sub_one` — the headline: `2^(p−1)` is the least admissible constant.

Registered in `proofs/Proofs.lean`. Gallery `meta.json` + `annotations.json` and research
knowledge included.

## ⚠️ BUILD VERIFICATION PENDING — DO NOT PROMOTE TO `verified` UNTIL GREEN

`./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ05` was **NOT run** this session:
the Docker daemon was unreachable from the host the entire session (harness blackout,
2026-06-20 — VM internally up but `dockerd` not exposed; tried relaunch + ~10 min polling).

Per the gallery-integrity policy, the gallery entry is held at **`status: formalized` /
`badge: wip`**, NOT `verified`/`original`. **Before merging / promoting:**

1. Run `./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ05` (must be green).
2. On success, set `meta.json` `status → verified`, `badge → original`, and clear the
   build-pending note in `assumptions`.

The proof was hand-reviewed (logic sound); residual risk is elaboration-only
(`exact_mod_cast` cast set; `intro` through `Set.mem_setOf` in the `IsLeast` goal) — exactly
what the build will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)