### PR TITLE
research(infinitude-primes-4k3-oq-02): exact finite equipartition of coprime integers [verified]

### DIFF
--- a/proofs/Proofs/InfinitudePrimes4k3OQ02.lean
+++ b/proofs/Proofs/InfinitudePrimes4k3OQ02.lean
@@ -35,6 +35,30 @@ integers to the primes among them.
 * `InfinitudePrimes4k3OQ02.reduced_class_density` — the exact relative density: for
   `0 < d`, `1 ≤ N` and any residue `v`, the proportion of coprime integers in `[0, N·d)`
   lying in class `v` equals `1/φ(d)` (as a rational number).
+
+## Exact finite equipartition (this session)
+
+`reduced_class_density` divides the count of *all* integers `≡ v` by the count of
+*coprime* integers — an honest ratio of `1/φ(d)` numerically, but the numerator ranges
+over integers that need not be coprime when `v` is not. The genuinely sharper statement
+is that the coprime integers are **exactly equipartitioned** among the `φ(d)` reduced
+classes — each reduced class carries *exactly* `N` coprime integers — for every finite
+`N`. This is the true finite skeleton of equidistribution.
+
+* `InfinitudePrimes4k3OQ02.coprime_class_card_eq` — **the headline.** For `0 < d` and
+  `gcd(v, d) = 1`, exactly `N` of the integers in `[0, N·d)` are *both* coprime to `d`
+  *and* `≡ v [MOD d]`. Every reduced class is equally populated by coprimes.
+* `InfinitudePrimes4k3OQ02.coprime_partition_card` — the coprime integers in `[0, N·d)`
+  decompose as the disjoint union over the `φ(d)` reduced residues `v (mod d)` of the
+  per-class coprime counts (a `card_eq_sum_card_fiberwise` partition along `x ↦ x % d`).
+* `InfinitudePrimes4k3OQ02.coprime_card_eq_totient_mul` — combining the two: the coprime
+  count `= φ(d) · N`, re-derived *independently* of `count_coprime_eq`'s block induction,
+  via the equipartition (`φ(d)` classes × `N` coprimes each).
+* `InfinitudePrimes4k3OQ02.reduced_class_density_coprime` — the **honest** relative
+  density: restricting the numerator to coprime integers in class `v` (with
+  `gcd(v, d) = 1`), the proportion of coprimes lying in class `v` is exactly `1/φ(d)`.
+* `InfinitudePrimes4k3OQ02.count_class_card_eq` — `Finset.card` form of `count_class_eq`,
+  bridging `Nat.count` to filtered-`range` cardinalities.
 -/
 import Mathlib
 
@@ -50,11 +74,13 @@ the count of integers in `[0, N·d)` congruent to `v` modulo `d` is exactly `N`,
 *every* residue `v` — every class is hit equally often over a whole number of periods. -/
 theorem count_class_eq {d : ℕ} (hd : 0 < d) (v N : ℕ) :
     Nat.count (· ≡ v [MOD d]) (N * d) = N := by
-  rw [Nat.count_modEq_card hd v]
+  rw [Nat.count_modEq_card (N * d) hd v]
   -- `(N*d) % d = 0`, so the Iverson correction term vanishes and `N*d / d = N`.
   have hmod : (N * d) % d = 0 := Nat.mul_mod_left N d
-  rw [hmod, Nat.mul_div_cancel _ hd]
-  simp [Nat.not_lt_zero]
+  have hdiv : (N * d) / d = N := by
+    rw [Nat.mul_div_assoc N (dvd_refl d), Nat.div_self hd, Nat.mul_one]
+  rw [hmod, hdiv]
+  simp
 
 /-- **Exact count of coprime integers.** For a positive modulus `d`, exactly `N · φ(d)`
 of the integers in `[0, N·d)` are coprime to `d`: each of the `N` length-`d` blocks
@@ -66,9 +92,11 @@ theorem count_coprime_eq {d : ℕ} (hd : 0 < d) (N : ℕ) :
   | succ N ih =>
     -- Split `[0, (N+1)·d)` into the prefix `[0, N·d)` and the final block `[N·d, N·d+d)`.
     have hsplit : range ((N + 1) * d) = range (N * d) ∪ Ico (N * d) (N * d + d) := by
-      rw [range_eq_Ico, range_eq_Ico, Ico_union_Ico_eq_Ico (Nat.zero_le _)
-        (by nlinarith)]
-      congr 1; ring
+      have he : (N + 1) * d = N * d + d := by ring
+      rw [he]
+      ext x
+      simp only [mem_union, mem_range, mem_Ico]
+      omega
     have hdisj : Disjoint (range (N * d)) (Ico (N * d) (N * d + d)) := by
       rw [range_eq_Ico]
       exact Ico_disjoint_Ico_consecutive 0 (N * d) (N * d + d)
@@ -99,11 +127,117 @@ theorem reduced_class_density {d : ℕ} (hd : 0 < d) {N : ℕ} (hN : 1 ≤ N) (v
         / (#{x ∈ range (N * d) | d.Coprime x} : ℚ) = 1 / totient d := by
   have hφ : 0 < totient d := Nat.totient_pos.mpr hd
   rw [count_class_eq hd v N, count_coprime_eq hd N]
-  have hN0 : (N : ℚ) ≠ 0 := by exact_mod_cast Nat.pos_iff.mp hN |>.ne'
+  have hN0 : (N : ℚ) ≠ 0 := by
+    have hNpos : 0 < N := hN
+    exact_mod_cast hNpos.ne'
   have hφ0 : (totient d : ℚ) ≠ 0 := by exact_mod_cast hφ.ne'
   rw [Nat.cast_mul]
   field_simp
-  ring
+
+/-! ### Exact finite equipartition of the coprime integers
+
+The results above give the count of *all* integers in each class and the count of *all*
+coprime integers. We now combine them into the sharp statement: each *reduced* residue
+class contains **exactly** `N` coprime integers, and the `φ(d)` reduced classes partition
+the coprimes. This is the honest finite form of "equidistribution `1/φ(d)`". -/
+
+/-- `Finset.card` form of `count_class_eq`: exactly `N` integers in `[0, N·d)` are
+`≡ v [MOD d]`, expressed as a filtered-`range` cardinality. -/
+theorem count_class_card_eq {d : ℕ} (hd : 0 < d) (v N : ℕ) :
+    #{x ∈ range (N * d) | x ≡ v [MOD d]} = N := by
+  rw [← Nat.count_eq_card_filter_range, count_class_eq hd v N]
+
+/-- **Exact equipartition of the coprime integers (per class).** For `0 < d` and
+`gcd(v, d) = 1`, exactly `N` of the integers in `[0, N·d)` are *both* coprime to `d` and
+congruent to `v` modulo `d`. Since a reduced class lies entirely inside the coprime
+integers (`class_subset_coprime`), the coprime constraint is automatic, so each reduced
+class is populated by exactly the same number `N` of coprimes. -/
+theorem coprime_class_card_eq {d : ℕ} (hd : 0 < d) {v : ℕ} (hv : d.Coprime v) (N : ℕ) :
+    #{x ∈ range (N * d) | d.Coprime x ∧ x ≡ v [MOD d]} = N := by
+  -- On a reduced class (`gcd(v,d)=1`) the coprime conjunct is automatic, so the filtered
+  -- set coincides with the plain residue class; count it via `count_class_card_eq`.
+  have hset : {x ∈ range (N * d) | d.Coprime x ∧ x ≡ v [MOD d]}
+            = {x ∈ range (N * d) | x ≡ v [MOD d]} := by
+    ext x
+    simp only [mem_filter]
+    constructor
+    · rintro ⟨hr, _, hxv⟩
+      exact ⟨hr, hxv⟩
+    · rintro ⟨hr, hxv⟩
+      refine ⟨hr, ?_, hxv⟩
+      -- coprimality of `x` follows from `x ≡ v [MOD d]` and `gcd(v, d) = 1`.
+      show Nat.gcd d x = 1
+      have hxv' : x % d = v % d := hxv
+      rw [Nat.gcd_rec d x, hxv', ← Nat.gcd_rec d v]
+      exact hv
+  rw [hset, count_class_card_eq hd v N]
+
+/-- **The coprime integers partition into reduced residue classes.** The coprime integers
+in `[0, N·d)` are the disjoint union, over the `φ(d)` reduced residues `v (mod d)`, of the
+integers that are coprime and `≡ v [MOD d]`. Fiberwise count along the map `x ↦ x % d`. -/
+theorem coprime_partition_card {d : ℕ} (hd : 0 < d) (N : ℕ) :
+    #{x ∈ range (N * d) | d.Coprime x}
+      = ∑ v ∈ {v ∈ range d | d.Coprime v},
+          #{x ∈ range (N * d) | d.Coprime x ∧ x ≡ v [MOD d]} := by
+  have hmaps : Set.MapsTo (· % d) (↑{x ∈ range (N * d) | d.Coprime x})
+      (↑{v ∈ range d | d.Coprime v}) := by
+    intro x hx
+    simp only [coe_filter, mem_range, Set.mem_setOf_eq] at hx
+    simp only [coe_filter, mem_range, Set.mem_setOf_eq]
+    refine ⟨Nat.mod_lt x hd, ?_⟩
+    -- residues preserve coprimality: `gcd d (x % d) = gcd d x = 1`.
+    show Nat.gcd d (x % d) = 1
+    rw [Nat.gcd_comm d (x % d), ← Nat.gcd_rec d x]
+    exact hx.2
+  rw [card_eq_sum_card_fiberwise hmaps]
+  apply Finset.sum_congr rfl
+  intro v hv
+  rw [mem_filter, mem_range] at hv
+  rw [filter_filter]
+  refine congrArg Finset.card (filter_congr ?_)
+  intro x _
+  -- for `v < d`, `x ≡ v [MOD d] ↔ x % d = v`.
+  have hvv : v % d = v := Nat.mod_eq_of_lt hv.1
+  constructor
+  · rintro ⟨hc, he⟩
+    exact ⟨hc, show x % d = v % d by rw [hvv]; exact he⟩
+  · rintro ⟨hc, he⟩
+    refine ⟨hc, ?_⟩
+    have hx2 : x % d = v % d := he
+    rw [hvv] at hx2
+    exact hx2
+
+/-- **Coprime count via equipartition.** Combining `coprime_partition_card` (the coprimes
+split into reduced classes) with `coprime_class_card_eq` (each reduced class has exactly
+`N` coprimes) gives `#coprime = φ(d) · N` — an independent re-derivation of the count in
+`count_coprime_eq`, here via the `φ(d)`-fold equipartition rather than block induction. -/
+theorem coprime_card_eq_totient_mul {d : ℕ} (hd : 0 < d) (N : ℕ) :
+    #{x ∈ range (N * d) | d.Coprime x} = totient d * N := by
+  rw [coprime_partition_card hd N]
+  have hterm : ∀ v ∈ {v ∈ range d | d.Coprime v},
+      #{x ∈ range (N * d) | d.Coprime x ∧ x ≡ v [MOD d]} = N := by
+    intro v hv
+    rw [mem_filter] at hv
+    exact coprime_class_card_eq hd hv.2 N
+  rw [Finset.sum_congr rfl hterm, Finset.sum_const, smul_eq_mul, Nat.totient_eq_card_coprime]
+
+/-- **Exact relative density `1/φ(d)` (honest numerator).** Restricting the numerator to
+the integers that are *both* coprime to `d` and `≡ v [MOD d]` (with `gcd(v, d) = 1`), the
+proportion of coprime integers in `[0, N·d)` lying in reduced class `v` is exactly
+`1/φ(d)`. This sharpens `reduced_class_density`, whose numerator counted all integers in
+class `v` regardless of coprimality. -/
+theorem reduced_class_density_coprime {d : ℕ} (hd : 0 < d) {N : ℕ} (hN : 1 ≤ N)
+    {v : ℕ} (hv : d.Coprime v) :
+    (#{x ∈ range (N * d) | d.Coprime x ∧ x ≡ v [MOD d]} : ℚ)
+        / (#{x ∈ range (N * d) | d.Coprime x} : ℚ) = 1 / totient d := by
+  have hφ : 0 < totient d := Nat.totient_pos.mpr hd
+  rw [coprime_class_card_eq hd hv N, count_coprime_eq hd N]
+  have hN0 : (N : ℚ) ≠ 0 := by
+    have hNpos : 0 < N := hN
+    exact_mod_cast hNpos.ne'
+  have hφ0 : (totient d : ℚ) ≠ 0 := by exact_mod_cast hφ.ne'
+  rw [Nat.cast_mul]
+  field_simp
 
 /-! ### Worked example: modulus `d = 4` (the `infinitude-primes-4k3` setting)
 
@@ -124,5 +258,16 @@ example : #{x ∈ range (5 * 4) | (4).Coprime x} = 5 * totient 4 :=
 example : (Nat.count (· ≡ 3 [MOD 4]) (5 * 4) : ℚ)
     / (#{x ∈ range (5 * 4) | (4).Coprime x} : ℚ) = 1 / totient 4 :=
   reduced_class_density (by norm_num) (by norm_num) 3
+
+-- Equipartition: class `3 (mod 4)` contains exactly `N = 5` integers that are *both*
+-- coprime to `4` and `≡ 3 (mod 4)` in `[0, 20)` — namely `3, 7, 11, 15, 19`.
+example : #{x ∈ range (5 * 4) | (4).Coprime x ∧ x ≡ 3 [MOD 4]} = 5 :=
+  coprime_class_card_eq (by norm_num) (by decide) 5
+
+-- Honest relative density `1/φ(4) = 1/2`: among the `10` coprimes in `[0, 20)`, exactly
+-- `5` lie in reduced class `3 (mod 4)`.
+example : (#{x ∈ range (5 * 4) | (4).Coprime x ∧ x ≡ 3 [MOD 4]} : ℚ)
+    / (#{x ∈ range (5 * 4) | (4).Coprime x} : ℚ) = 1 / totient 4 :=
+  reduced_class_density_coprime (by norm_num) (by norm_num) (by decide)
 
 end InfinitudePrimes4k3OQ02

--- a/src/data/proofs/infinitude-primes-4k3-oq-02/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "infinitude-primes-4k3-oq-02",
   "title": "Exact Equidistribution of Reduced Residues — the Elementary Skeleton of Density 1/φ(d)",
   "slug": "infinitude-primes-4k3-oq-02",
-  "description": "Addresses OQ-02 from infinitude-primes-4k3 (equidistribution: primes ≡ a mod d have density 1/φ(d) among all primes). The full prime statement is the Prime Number Theorem for arithmetic progressions and is not available in Mathlib. This entry formalizes the exact, elementary skeleton it refines: over any whole number N of periods [0, N·d), every residue class mod d contains exactly N integers, the integers coprime to d number exactly N·φ(d), and hence each reduced residue class carries the exact relative density 1/φ(d) — for every finite N, not merely asymptotically. 4 theorems, 0 axioms, 0 sorries.",
+  "description": "Addresses OQ-02 from infinitude-primes-4k3 (equidistribution: primes ≡ a mod d have density 1/φ(d) among all primes). The full prime statement is the Prime Number Theorem for arithmetic progressions and is not available in Mathlib. This entry formalizes the exact, elementary skeleton it refines: over any whole number N of periods [0, N·d), every residue class mod d contains exactly N integers, the integers coprime to d number exactly N·φ(d), and hence each reduced residue class carries the exact relative density 1/φ(d) — for every finite N, not merely asymptotically. The session adds the sharp equipartition: each *reduced* class contains exactly N integers that are *both* coprime to d and in that class, the coprime integers partition (disjointly, via fiberwise count along x ↦ x % d) into the φ(d) reduced classes, the coprime count N·φ(d) is re-derived independently of the block induction, and the honest relative density 1/φ(d) is obtained with the numerator restricted to coprime integers. 9 theorems, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_theorem_on_arithmetic_progressions",
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 9,
     "newAxiomCount": 0,
     "mathlibDependencies": [
       {
@@ -38,11 +38,16 @@
       "count_class_eq: for 0 < d, exactly N of the integers in [0, N·d) are ≡ v (mod d), for EVERY residue v — exact equidistribution of single classes over whole periods",
       "count_coprime_eq: for 0 < d, exactly N·φ(d) of the integers in [0, N·d) are coprime to d — proved by induction assembling the per-block totient count over N blocks",
       "class_subset_coprime: when gcd(v,d)=1, the residue class v within the window consists entirely of integers coprime to d (residue-invariance of coprimality)",
-      "reduced_class_density: the exact relative density — for 0 < d, N ≥ 1, the proportion of coprime integers in [0, N·d) lying in a fixed class v equals 1/φ(d) (as a rational), independent of N and v"
+      "reduced_class_density: the exact relative density — for 0 < d, N ≥ 1, the proportion of coprime integers in [0, N·d) lying in a fixed class v equals 1/φ(d) (as a rational), independent of N and v",
+      "coprime_class_card_eq: the sharp equipartition — for 0 < d and gcd(v,d)=1, exactly N of the integers in [0, N·d) are BOTH coprime to d AND ≡ v (mod d); every reduced class is equally populated by coprimes (the coprime constraint is automatic on a reduced class, via class_subset_coprime)",
+      "coprime_partition_card: the coprime integers in [0, N·d) decompose as the disjoint union over the φ(d) reduced residues v (mod d) of the per-class coprime counts — a card_eq_sum_card_fiberwise partition along x ↦ x % d",
+      "coprime_card_eq_totient_mul: #coprime = φ(d)·N re-derived INDEPENDENTLY of count_coprime_eq's block induction, via the equipartition (φ(d) classes × N coprimes each)",
+      "reduced_class_density_coprime: the HONEST relative density — restricting the numerator to integers that are both coprime to d and ≡ v (mod d), the proportion of coprimes in class v is exactly 1/φ(d), sharpening reduced_class_density whose numerator counted all integers in class v regardless of coprimality",
+      "count_class_card_eq: Finset.card form of count_class_eq, bridging Nat.count to filtered-range cardinalities"
     ],
     "dateAdded": "2026-06-20",
-    "lineCount": 128,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (the example `decide` is absent; all examples discharge by applying the proved theorems). Builds on two Mathlib counting lemmas (Nat.count_modEq_card, Nat.filter_coprime_Ico_eq_totient); the synthesis into exact equidistribution and the relative density 1/φ(d) is the original content. The DEEP statement of OQ-02 — that the PRIMES (not all coprime integers) ≡ a mod d have density 1/φ(d), i.e. the Prime Number Theorem for arithmetic progressions — is NOT proved here and is not available in Mathlib; this entry formalizes the elementary combinatorial skeleton it refines and states the gap explicitly.",
+    "lineCount": 264,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The theorems are axiom-free; the worked examples discharge by applying the proved theorems, with `decide` used only on small closed coprimality side-goals like `(4).Coprime 3` (kernel `decide`, NOT `native_decide`, so no Lean.ofReduceBool — the entry remains axiom-free). Builds on Mathlib counting/partition lemmas (Nat.count_modEq_card, Nat.filter_coprime_Ico_eq_totient, Finset.card_eq_sum_card_fiberwise, Nat.gcd_rec); the synthesis into exact equidistribution, the sharp coprime equipartition (each reduced class carries exactly N coprimes), and the relative density 1/φ(d) is the original content. The DEEP statement of OQ-02 — that the PRIMES (not all coprime integers) ≡ a mod d have density 1/φ(d), i.e. the Prime Number Theorem for arithmetic progressions — is NOT proved here and is not available in Mathlib; this entry formalizes the elementary combinatorial skeleton it refines and states the gap explicitly.",
     "definitionCount": 0
   },
   "overview": {
@@ -94,6 +99,34 @@
       "statement": "0 < d → 1 ≤ N → ∀ v, (count (· ≡ v [MOD d]) (N·d) : ℚ) / (#{x ∈ range (N·d) | d.Coprime x} : ℚ) = 1 / φ(d)",
       "significance": "The headline result: the exact relative density 1/φ(d) of a residue class among the coprime integers, valid for EVERY finite N ≥ 1 and every v — independent of both. Obtained by substituting the two counts (N and N·φ(d)) and cancelling N. This is the precise, elementary, machine-checked meaning of 'density 1/φ(d)' for coprime integers; the OQ-02 prime statement is the same density with 'coprime integers' replaced by 'primes', which requires the unformalized analytic input.",
       "description": "Each reduced class has exact relative density 1/φ(d) among coprimes, for all finite N."
+    },
+    {
+      "name": "coprime_class_card_eq",
+      "type": "core",
+      "statement": "0 < d → gcd(d,v) = 1 → ∀ N, #{x ∈ range (N·d) | d.Coprime x ∧ x ≡ v [MOD d]} = N",
+      "significance": "The sharp equipartition: for a REDUCED residue v, exactly N of the integers in [0, N·d) are both coprime to d and ≡ v (mod d). Because a reduced class lies entirely inside the coprime integers (class_subset_coprime), the extra coprimality conjunct is automatic, so the count reduces to count_class_card_eq = N. Every reduced class is populated by exactly the same number N of coprimes — the honest 'equal pieces' statement that reduced_class_density only expressed as a ratio.",
+      "description": "Each reduced class contains exactly N integers that are both coprime to d and in the class."
+    },
+    {
+      "name": "coprime_partition_card",
+      "type": "core",
+      "statement": "0 < d → ∀ N, #{x ∈ range (N·d) | d.Coprime x} = ∑ v ∈ {v ∈ range d | d.Coprime v}, #{x ∈ range (N·d) | d.Coprime x ∧ x ≡ v [MOD d]}",
+      "significance": "The coprime integers in [0, N·d) decompose as the disjoint union, over the φ(d) reduced residues v (mod d), of the integers coprime and ≡ v (mod d). Proved by Finset.card_eq_sum_card_fiberwise along the map x ↦ x % d (residues preserve coprimality, gcd d (x%d) = gcd d x), then matching each fiber x % d = v to the congruence x ≡ v (mod d) for v < d. This packages count_class_eq, class_subset_coprime and count_coprime_eq into a single partition — directly answering the open question posed in the original entry.",
+      "description": "The coprime integers partition into the φ(d) reduced residue classes (fiberwise along x ↦ x % d)."
+    },
+    {
+      "name": "coprime_card_eq_totient_mul",
+      "type": "supporting",
+      "statement": "0 < d → ∀ N, #{x ∈ range (N·d) | d.Coprime x} = φ(d) · N",
+      "significance": "An INDEPENDENT re-derivation of the coprime count N·φ(d): combining coprime_partition_card (split into reduced classes) with coprime_class_card_eq (each class has exactly N) gives a constant sum φ(d) × N — totient_eq_card_coprime supplying the φ(d) count of summands. This recovers count_coprime_eq's result via the φ(d)-fold equipartition rather than the block induction, a cross-check by an essentially different route.",
+      "description": "#coprime = φ(d)·N, re-derived via equipartition (φ(d) classes × N each)."
+    },
+    {
+      "name": "reduced_class_density_coprime",
+      "type": "core",
+      "statement": "0 < d → 1 ≤ N → gcd(d,v) = 1 → (#{x ∈ range (N·d) | d.Coprime x ∧ x ≡ v [MOD d]} : ℚ) / (#{x ∈ range (N·d) | d.Coprime x} : ℚ) = 1 / φ(d)",
+      "significance": "The HONEST relative density: restricting the numerator to integers that are both coprime to d AND ≡ v (mod d) (with gcd(v,d)=1), the proportion of coprimes lying in reduced class v is exactly 1/φ(d). This sharpens reduced_class_density, whose numerator counted ALL integers in class v regardless of coprimality — here numerator and denominator both range over coprimes, the mathematically faithful form of 'fraction of the coprime integers landing in class v'.",
+      "description": "Honest relative density 1/φ(d): both numerator and denominator restricted to coprime integers."
     }
   ],
   "references": [
@@ -170,11 +203,19 @@
       "mathContext": "(N : ℚ)/(N·φ(d)) = 1/φ(d); exact for every finite N, the elementary form of OQ-02's density for coprime integers."
     },
     {
+      "id": "coprime-equipartition",
+      "title": "Exact Finite Equipartition of the Coprime Integers",
+      "startLine": 132,
+      "endLine": 231,
+      "summary": "Sharpens the density ratio into the equal-pieces statement. count_class_card_eq: Finset.card form of count_class_eq. coprime_class_card_eq: for gcd(v,d)=1, exactly N integers in [0,N·d) are both coprime and ≡ v (mod d) (the coprimality conjunct is automatic on a reduced class). coprime_partition_card: the coprimes partition over the φ(d) reduced residues via card_eq_sum_card_fiberwise along x ↦ x%d. coprime_card_eq_totient_mul: #coprime = φ(d)·N re-derived from the equipartition. reduced_class_density_coprime: honest density 1/φ(d) with the numerator restricted to coprimes.",
+      "mathContext": "Each reduced class carries EXACTLY N coprimes; the coprime integers split into φ(d) equinumerous classes — the finite, exact avatar of 'density 1/φ(d)', resolving the partition open question of the original entry."
+    },
+    {
       "id": "worked-examples",
       "title": "Worked Examples: modulus d = 4",
-      "startLine": 118,
-      "endLine": 128,
-      "summary": "Modulus 4 (φ(4)=2, reduced residues 1,3): class 3 (mod 4) has exactly 5 members in [0,20); 10 coprime integers total; relative density 1/φ(4)=1/2. Each example discharges by applying the proved theorems.",
+      "startLine": 233,
+      "endLine": 264,
+      "summary": "Modulus 4 (φ(4)=2, reduced residues 1,3): class 3 (mod 4) has exactly 5 members in [0,20); 10 coprime integers total; relative density 1/φ(4)=1/2; and the equipartition form — exactly 5 integers in [0,20) are both coprime to 4 and ≡ 3 (mod 4) (namely 3,7,11,15,19), honest density 1/2. Examples discharge by applying the proved theorems (small coprimality side-goals by kernel `decide`).",
       "mathContext": "The two reduced classes ≡ 1, 3 (mod 4) of the parent entry each carry density 1/2 among coprime integers; the prime analogue is the deep PNT-for-APs statement."
     }
   ],
@@ -185,7 +226,7 @@
       "The deep statement of OQ-02 itself: formalize that the PRIMES ≡ a (mod d) have asymptotic density 1/φ(d) among primes (PNT for arithmetic progressions). This requires Dirichlet L-functions, their non-vanishing on Re(s) = 1, and a Tauberian theorem — substantial analytic infrastructure not yet assembled in Mathlib for the AP case.",
       "An intermediate target: formalize the Dirichlet (analytic / logarithmic) density 1/φ(d) of primes ≡ a (mod d), which follows from L(1, χ) ≠ 0 alone (Mathlib's Dirichlet-theorem proof already establishes this non-vanishing) without the full Tauberian PNT — a strictly easier milestone than natural density.",
       "Quantify the prefix/window dependence: give explicit elementary bounds on #{p ≤ x prime, p ≡ a (mod d)} purely from the coprime-integer skeleton (e.g. a Brun–Titchmarsh-style upper bound), isolating how much can be said about primes without L-functions.",
-      "Generalize count_coprime_eq to a sum-over-reduced-classes partition theorem: prove directly that the coprime integers in [0, N·d) decompose as a disjoint union of exactly φ(d) classes each of size N, packaging count_class_eq, class_subset_coprime, and count_coprime_eq into a single equidistribution statement."
+      "RESOLVED this session: the sum-over-reduced-classes partition theorem. coprime_partition_card decomposes the coprime integers in [0, N·d) as the disjoint union of the φ(d) reduced classes (fiberwise along x ↦ x % d), coprime_class_card_eq shows each carries exactly N, and coprime_card_eq_totient_mul re-derives #coprime = φ(d)·N from the equipartition — packaging count_class_eq, class_subset_coprime and count_coprime_eq into a single statement."
     ]
   },
   "crossReferences": [
@@ -207,9 +248,9 @@
   ],
   "leanFile": {
     "namespace": "InfinitudePrimes4k3OQ02",
-    "lineCount": 128,
+    "lineCount": 264,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/InfinitudePrimes4k3OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Exact finite equipartition of the coprime integers

Extends the merged OQ-02 skeleton (#27144) with the **sharp finite equipartition**,
resolving the open question posed in that entry: the coprime integers in `[0, N·d)`
are **exactly** equipartitioned among the `φ(d)` reduced residue classes — each
reduced class carries exactly `N` coprimes, for *every* finite `N` — not merely
asymptotically. This is the honest elementary skeleton of "density `1/φ(d)`"; the
only remaining gap to full OQ-02 is the deep analytic input restricting attention
from all coprime integers to the primes among them.

### New theorems (file now 9 thm, 0 sorry, 0 axiom, 0 native_decide)
- `count_class_card_eq` — `Finset.card` form of `count_class_eq`.
- `coprime_class_card_eq` — **headline.** For `gcd(v,d)=1`, exactly `N` integers in
  `[0,N·d)` are both coprime to `d` and `≡ v [MOD d]`; coprimality is automatic on a
  reduced class (residue-only `gcd` computation).
- `coprime_partition_card` — coprimes partition over the `φ(d)` reduced residues via
  `card_eq_sum_card_fiberwise` along `x ↦ x % d`.
- `coprime_card_eq_totient_mul` — `#coprime = φ(d)·N`, re-derived **independently** of
  `count_coprime_eq`'s block induction via the equipartition.
- `reduced_class_density_coprime` — honest relative density `1/φ(d)` with a
  coprime-restricted numerator.

### Verification
Built green via `docker-build.sh Proofs.InfinitudePrimes4k3OQ02` (7743 jobs, EXIT=0).
Pre-existing skeleton proofs repaired for current-Mathlib API drift (explicit bound for
`Nat.count_modEq_card`; `N≠0` from `1≤N` defeq `0<N` replacing removed `Nat.pos_iff`;
`field_simp` now closes the density goals). Worked example `d=4` uses kernel `decide`
only — axiom-free (`status: verified`, `badge: original`, `axiomCount: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)