### PR TITLE
research(jordan-block): single Jordan block J_n(μ) and its minimal polynomial — verified, 0-axiom

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -520,6 +520,7 @@ import Proofs.CayleyHamiltonMinpolyOQ02
 import Proofs.CayleyHamiltonMinpolyOQ02OQ01
 import Proofs.CayleyHamiltonMinpolyOQ02OQ01OQ02
 import Proofs.CayleyHamiltonMinpolyOQ02OQ02
+import Proofs.CayleyHamiltonMinpolyOQ02OQ02OQ02
 import Proofs.CayleyHamiltonMinpolyOQ02OQ03
 import Proofs.CayleyHamiltonMinpolyOQ03
 import Proofs.CayleyHamiltonMinpolyOQ03Aristotle

--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02OQ02.lean
@@ -1,0 +1,268 @@
+/-
+Jordan Block Infrastructure: Nilpotent Shift and the Single Jordan Block
+(cayley-hamilton-minpoly-oq-02-oq-02-oq-02)
+
+Open Question from cayley-hamilton-minpoly-oq-02-oq-02:
+"Formalize Jordan normal form over algebraically closed fields."
+
+Full Jordan normal form (every matrix over an algebraically closed field is
+similar to a direct sum of Jordan blocks) is a substantial formalization that
+Mathlib does not yet provide. Mathlib *does* provide the two deep ingredients:
+
+  * `Mathlib.LinearAlgebra.JordanChevalley` — the Jordan–Chevalley–Dunford
+    decomposition `f = s + n` (semisimple + nilpotent, both polynomials in `f`).
+  * Generalized eigenspaces span the whole space over an algebraically closed
+    field (`Module.End.iSup_genEigenspace_eq_top`).
+
+What is still missing is the *building block itself*: a clean, reusable Jordan
+block `J_n(μ)` together with its spectral invariants. This file supplies that
+piece, generalizing the specific 4×4 nilpotent computation in
+`CayleyHamiltonMinpolyOQ02OQ02.lean` to an arbitrary size `n`.
+
+## What is proved here (0 axioms, 0 sorries)
+
+Let `N = shift n` be the `n × n` nilpotent shift (ones on the superdiagonal),
+i.e. the nilpotent Jordan block `J_n(0)`, and let `J_n(μ) = μ•I + N`.
+
+  * `shift_pow_apply`   : the closed form `(Nᵏ) i j = [j = i + k]` (Iverson).
+  * `shift_pow_eq_zero` : `Nⁿ = 0`        (nilpotency).
+  * `shift_pow_pred_ne_zero` : `Nⁿ⁻¹ ≠ 0` (the nilpotency order is *exactly* n).
+  * `minpoly_shift`     : `minpoly K (J_n(0)) = Xⁿ`.
+  * `minpoly_jordanBlock` : `minpoly K (J_n(μ)) = (X - C μ)ⁿ`.
+
+The minimal-polynomial results are what make a Jordan block "the" model for a
+single elementary divisor: each block contributes exactly the elementary
+divisor `(X - μ)ⁿ`. Assembling blocks into a normal form (and proving the
+similarity classification) remains open and is noted at the end of the file.
+
+References:
+- Hoffman & Kunze, "Linear Algebra" (1971), Chapter 7
+- Horn & Johnson, "Matrix Analysis" (2013), §3.1, §3.2
+-/
+
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+set_option linter.unusedTactic false
+set_option maxHeartbeats 800000
+
+open Matrix Polynomial
+
+namespace JordanBlock
+
+variable {K : Type*} [Field K] [DecidableEq K]
+
+-- ============================================================
+-- PART 1: The Nilpotent Shift (Jordan block for eigenvalue 0)
+-- ============================================================
+
+/-- The `n × n` nilpotent shift matrix: ones on the superdiagonal, zeros
+    elsewhere. This is the Jordan block `J_n(0)`:
+    `[[0,1,0,…],[0,0,1,…],…,[0,…,0,1],[0,…,0,0]]`. -/
+def shift (n : ℕ) : Matrix (Fin n) (Fin n) K :=
+  Matrix.of fun i j => if (j : ℕ) = (i : ℕ) + 1 then 1 else 0
+
+@[simp] theorem shift_apply (n : ℕ) (i j : Fin n) :
+    (shift n : Matrix (Fin n) (Fin n) K) i j =
+      if (j : ℕ) = (i : ℕ) + 1 then 1 else 0 := rfl
+
+/-- Closed form for the powers of the shift matrix:
+    `(Nᵏ) i j = 1` exactly when `j = i + k` (and `0` otherwise). Because the
+    column index `j` lives in `Fin n`, the entry is automatically `0` once
+    `i + k ≥ n`, which is the source of nilpotency. -/
+theorem shift_pow_apply (n k : ℕ) (i j : Fin n) :
+    ((shift n : Matrix (Fin n) (Fin n) K) ^ k) i j =
+      if (j : ℕ) = (i : ℕ) + k then 1 else 0 := by
+  induction k generalizing i j with
+  | zero =>
+    simp only [pow_zero, Matrix.one_apply, Nat.add_zero]
+    by_cases h : i = j
+    · subst h; simp
+    · rw [if_neg h, if_neg]
+      intro hc; exact h (Fin.ext hc.symm)
+  | succ k ih =>
+    rw [pow_succ, Matrix.mul_apply]
+    by_cases hjk : (j : ℕ) = (i : ℕ) + (k + 1)
+    · rw [if_pos hjk]
+      have hik : (i : ℕ) + k < n := by have hj := j.isLt; omega
+      rw [Finset.sum_eq_single_of_mem (⟨(i : ℕ) + k, hik⟩ : Fin n) (Finset.mem_univ _)]
+      · rw [ih i (⟨(i : ℕ) + k, hik⟩ : Fin n)]
+        rw [if_pos (rfl : ((⟨(i : ℕ) + k, hik⟩ : Fin n) : ℕ) = (i : ℕ) + k)]
+        rw [one_mul, shift_apply]
+        rw [if_pos (show (j : ℕ) = (i : ℕ) + k + 1 by omega)]
+      · intro b _ hb
+        rw [ih i b, if_neg, zero_mul]
+        intro hcon
+        exact hb (Fin.ext hcon)
+    · rw [if_neg hjk]
+      apply Finset.sum_eq_zero
+      intro l _
+      by_cases hl : (l : ℕ) = (i : ℕ) + k
+      · rw [ih i l, if_pos hl, one_mul, shift_apply]
+        rw [if_neg (by intro hcon; apply hjk; omega)]
+      · rw [ih i l, if_neg hl, zero_mul]
+
+/-- `Nⁿ = 0`: the shift matrix is nilpotent. Every entry `(Nⁿ) i j` would
+    require `j = i + n`, impossible since `j < n ≤ i + n`. -/
+theorem shift_pow_eq_zero (n : ℕ) :
+    (shift n : Matrix (Fin n) (Fin n) K) ^ n = 0 := by
+  ext i j
+  rw [shift_pow_apply, Matrix.zero_apply, if_neg]
+  intro h
+  have := j.isLt
+  omega
+
+/-- `Nⁿ⁻¹ ≠ 0`: the nilpotency order is *exactly* `n`. The entry in row `0`,
+    column `n-1` equals `1`, witnessing `j = i + (n-1)` with `i = 0`. -/
+theorem shift_pow_pred_ne_zero (n : ℕ) (hn : 1 ≤ n) :
+    (shift n : Matrix (Fin n) (Fin n) K) ^ (n - 1) ≠ 0 := by
+  intro h
+  have key := shift_pow_apply (K := K) n (n - 1)
+    (⟨0, by omega⟩ : Fin n) (⟨n - 1, by omega⟩ : Fin n)
+  rw [h, Matrix.zero_apply] at key
+  simp at key
+
+-- ============================================================
+-- PART 2: Minimal polynomial of the nilpotent block is Xⁿ
+-- ============================================================
+
+/-- The minimal polynomial of the nilpotent Jordan block `J_n(0) = shift n`
+    is `Xⁿ` (for `n ≥ 1`).
+
+    `Xⁿ` annihilates `N` (since `Nⁿ = 0`), so `minpoly ∣ Xⁿ`; as `X` is prime
+    this forces `minpoly = Xʲ` for some `j ≤ n`. If `j < n` then `Nʲ = 0`,
+    hence `Nⁿ⁻¹ = Nⁿ⁻¹⁻ʲ · Nʲ = 0`, contradicting `shift_pow_pred_ne_zero`.
+    Therefore `j = n`. -/
+theorem minpoly_shift (n : ℕ) (hn : 1 ≤ n) :
+    minpoly K (shift n : Matrix (Fin n) (Fin n) K) = X ^ n := by
+  have h_int := Matrix.isIntegral (R := K) (shift n)
+  have h_ann : (Polynomial.aeval (shift n : Matrix (Fin n) (Fin n) K)) (X ^ n : K[X]) = 0 := by
+    rw [map_pow, aeval_X, shift_pow_eq_zero]
+  have h_dvd : minpoly K (shift n : Matrix (Fin n) (Fin n) K) ∣ X ^ n :=
+    minpoly.dvd K _ h_ann
+  have h_monic := minpoly.monic h_int
+  have hX_prime : Prime (X : K[X]) := Polynomial.prime_X
+  rw [dvd_prime_pow hX_prime] at h_dvd
+  obtain ⟨j, hj_le, hassoc⟩ := h_dvd
+  have heq : minpoly K (shift n : Matrix (Fin n) (Fin n) K) = X ^ j :=
+    eq_of_monic_of_associated h_monic (monic_X_pow j) hassoc
+  have hj_eq : j = n := by
+    rcases lt_or_eq_of_le hj_le with hlt | heqn
+    · exfalso
+      have hsj : (shift n : Matrix (Fin n) (Fin n) K) ^ j = 0 := by
+        have hae := minpoly.aeval K (shift n : Matrix (Fin n) (Fin n) K)
+        rw [heq, map_pow, aeval_X] at hae
+        exact hae
+      have hpred : (shift n : Matrix (Fin n) (Fin n) K) ^ (n - 1) = 0 := by
+        calc (shift n : Matrix (Fin n) (Fin n) K) ^ (n - 1)
+            = (shift n) ^ (n - 1 - j) * (shift n) ^ j := by
+                rw [← pow_add]; congr 1; omega
+          _ = (shift n) ^ (n - 1 - j) * 0 := by rw [hsj]
+          _ = 0 := mul_zero _
+      exact shift_pow_pred_ne_zero n hn hpred
+    · exact heqn
+  rw [heq, hj_eq]
+
+-- ============================================================
+-- PART 3: The general Jordan block J_n(μ) = μ•I + N
+-- ============================================================
+
+/-- The Jordan block `J_n(μ)`: eigenvalue `μ` on the diagonal, ones on the
+    superdiagonal. Defined as `μ•I + N`, where `μ•I` is realized through the
+    algebra map so that `aeval (J_n μ) (C μ) = μ•I` holds definitionally. -/
+def jordanBlock (n : ℕ) (μ : K) : Matrix (Fin n) (Fin n) K :=
+  algebraMap K (Matrix (Fin n) (Fin n) K) μ + shift n
+
+/-- Evaluating `X - C μ` at the Jordan block recovers the nilpotent part:
+    `aeval (J_n μ) (X - C μ) = N`. -/
+theorem aeval_jordanBlock_X_sub_C (n : ℕ) (μ : K) :
+    (Polynomial.aeval (jordanBlock n μ)) (X - C μ) = shift n := by
+  rw [map_sub, aeval_X, aeval_C, jordanBlock]
+  abel
+
+/-- `(X - C μ)ⁿ` annihilates `J_n(μ)`, since it evaluates to `Nⁿ = 0`. -/
+theorem jordanBlock_sub_pow_eq_zero (n : ℕ) (μ : K) :
+    (Polynomial.aeval (jordanBlock n μ)) ((X - C μ) ^ n) = 0 := by
+  rw [map_pow, aeval_jordanBlock_X_sub_C, shift_pow_eq_zero]
+
+/-- **The minimal polynomial of the Jordan block** `J_n(μ)` is `(X - C μ)ⁿ`
+    (for `n ≥ 1`).
+
+    Same divisor argument as `minpoly_shift`, now with the prime `X - C μ` in
+    place of `X`: `minpoly ∣ (X - C μ)ⁿ` forces `minpoly = (X - C μ)ʲ`, and
+    `aeval (J_n μ) ((X - C μ)ʲ) = Nʲ`, so `j < n` would give `Nⁿ⁻¹ = 0`,
+    contradicting `shift_pow_pred_ne_zero`. Hence `j = n`.
+
+    This is the key fact behind Jordan normal form: a single block contributes
+    exactly the elementary divisor `(X - μ)ⁿ`. -/
+theorem minpoly_jordanBlock (n : ℕ) (hn : 1 ≤ n) (μ : K) :
+    minpoly K (jordanBlock n μ) = (X - C μ) ^ n := by
+  have h_int := Matrix.isIntegral (R := K) (jordanBlock n μ)
+  have h_ann : (Polynomial.aeval (jordanBlock n μ)) ((X - C μ) ^ n) = 0 :=
+    jordanBlock_sub_pow_eq_zero n μ
+  have h_dvd : minpoly K (jordanBlock n μ) ∣ (X - C μ) ^ n := minpoly.dvd K _ h_ann
+  have h_monic := minpoly.monic h_int
+  have hP_prime : Prime (X - C μ : K[X]) := prime_X_sub_C μ
+  rw [dvd_prime_pow hP_prime] at h_dvd
+  obtain ⟨j, hj_le, hassoc⟩ := h_dvd
+  have hmonic_pow : (((X - C μ) ^ j : K[X])).Monic := (monic_X_sub_C μ).pow j
+  have heq : minpoly K (jordanBlock n μ) = (X - C μ) ^ j :=
+    eq_of_monic_of_associated h_monic hmonic_pow hassoc
+  have hj_eq : j = n := by
+    rcases lt_or_eq_of_le hj_le with hlt | heqn
+    · exfalso
+      have hsj : (shift n : Matrix (Fin n) (Fin n) K) ^ j = 0 := by
+        have hae := minpoly.aeval K (jordanBlock n μ)
+        rw [heq, map_pow, aeval_jordanBlock_X_sub_C] at hae
+        exact hae
+      have hpred : (shift n : Matrix (Fin n) (Fin n) K) ^ (n - 1) = 0 := by
+        calc (shift n : Matrix (Fin n) (Fin n) K) ^ (n - 1)
+            = (shift n) ^ (n - 1 - j) * (shift n) ^ j := by
+                rw [← pow_add]; congr 1; omega
+          _ = (shift n) ^ (n - 1 - j) * 0 := by rw [hsj]
+          _ = 0 := mul_zero _
+      exact shift_pow_pred_ne_zero n hn hpred
+    · exact heqn
+  rw [heq, hj_eq]
+
+-- ============================================================
+-- PART 4: Summary and Open Work
+-- ============================================================
+
+/-
+## Summary
+
+This file provides the *single Jordan block* as a first-class object with its
+spectral invariants fully verified (0 axioms, 0 sorries):
+
+  * `shift n` is the nilpotent Jordan block `J_n(0)`; its powers have the
+    closed form `(Nᵏ) i j = [j = i + k]`, giving `Nⁿ = 0` and `Nⁿ⁻¹ ≠ 0`.
+  * `minpoly_shift`        : `minpoly (J_n 0) = Xⁿ`.
+  * `jordanBlock n μ = μ•I + N` is the general block `J_n(μ)`.
+  * `minpoly_jordanBlock`  : `minpoly (J_n μ) = (X - C μ)ⁿ`.
+
+So each Jordan block contributes exactly the elementary divisor `(X - μ)ⁿ`,
+which is precisely the role it plays in the rational/Jordan canonical form.
+
+This generalizes the bespoke 4×4 nilpotent computation in
+`CayleyHamiltonMinpolyOQ02OQ02.lean` (where `minpoly = X²` was established for
+two specific 4×4 nilpotents) to a Jordan block of arbitrary size and arbitrary
+eigenvalue.
+
+## Open Work (toward full Jordan normal form)
+
+1. Characteristic polynomial of a block: `charpoly (J_n μ) = (X - C μ)ⁿ`
+   (the block is upper-triangular with constant diagonal `μ`).
+2. Block-diagonal assembly: for `M = blockDiagonal (J_{n₁}(μ₁), …)`,
+   `charpoly = ∏ (X - C μₖ)^{nₖ}` and `minpoly = lcm` of the block minpolys.
+3. Existence: every matrix over an algebraically closed field is similar to a
+   block-diagonal sum of Jordan blocks (uses `Module.End.iSup_genEigenspace_eq_top`
+   plus a cyclic decomposition of each nilpotent generalized-eigenspace part —
+   the latter is the genuinely missing ingredient in Mathlib).
+4. Uniqueness / classification: two matrices are similar iff they have the same
+   list of elementary divisors (Jordan type). The converse failure is already
+   formalized in `CayleyHamiltonMinpolyOQ02OQ02.lean`.
+-/
+
+end JordanBlock

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02-oq-02/annotations.json
@@ -1,0 +1,139 @@
+[
+  {
+    "id": "ann-shift-def",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 60,
+      "endLine": 70
+    },
+    "type": "definition",
+    "title": "The Nilpotent Shift J_n(0)",
+    "content": "Defines `shift n` as the $n \\times n$ matrix with ones on the superdiagonal and zeros elsewhere ($N_{ij} = 1$ iff $j = i+1$), which is exactly the Jordan block for eigenvalue $0$. An `@[simp]` entry lemma exposes the entrywise definition for the power-law induction. This is the nilpotent atom from which every Jordan block is built: $J_n(\\mu) = \\mu I + N$.",
+    "mathContext": "$N_{ij} = [\\,j = i+1\\,]$; e.g. for $n=3$, $N = \\begin{pmatrix} 0&1&0\\\\0&0&1\\\\0&0&0 \\end{pmatrix}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Jordan block",
+      "nilpotent matrix",
+      "shift operator",
+      "superdiagonal"
+    ],
+    "prerequisites": [
+      "matrix definition via Matrix.of",
+      "Fin n indexing"
+    ]
+  },
+  {
+    "id": "ann-power-law",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 71,
+      "endLine": 109
+    },
+    "type": "theorem",
+    "title": "Closed-Form Power Law (N^k)_{ij} = [j = i+k]",
+    "content": "The key combinatorial lemma: the $k$-th power of the shift has a single shifted diagonal of ones, $(N^k)_{ij} = 1$ exactly when $j = i+k$. Proved by induction on $k$. The base case is the identity matrix. The step expands $(N^{k+1})_{ij} = \\sum_l (N^k)_{il} N_{lj}$ and splits on whether the witness index $i+k$ fits inside `Fin n`: when $j = i+k+1$ the unique surviving term is extracted with `Finset.sum_eq_single_of_mem`; otherwise the sum is identically zero. Because column indices live in `Fin n`, the entry vanishes automatically once $i+k \\ge n$ -- this is the structural source of nilpotency.",
+    "mathContext": "$(N^k)_{ij} = [\\,j = i+k\\,]$. The diagonal of ones moves $k$ steps toward the upper-right corner with each power.",
+    "significance": "key",
+    "relatedConcepts": [
+      "matrix power",
+      "induction",
+      "Leibniz / matrix-multiply formula",
+      "single-term sum extraction"
+    ],
+    "prerequisites": [
+      "matrix multiplication formula",
+      "Finset.sum_eq_single_of_mem",
+      "Fin.val arithmetic"
+    ]
+  },
+  {
+    "id": "ann-nilpotency-order",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 110,
+      "endLine": 134
+    },
+    "type": "theorem",
+    "title": "Nilpotency of Exact Order n",
+    "content": "From the power law: $N^n = 0$ because every entry would require $j = i+n$, impossible as $j < n \\le i+n$; and $N^{n-1} \\neq 0$ because the entry in row $0$, column $n-1$ equals $1$ (witnessing $j = i + (n-1)$ with $i=0$). Together these pin the nilpotency order at exactly $n$, which is what forces the minimal polynomial to have full degree $n$.",
+    "mathContext": "$N^n = 0$ and $N^{n-1} \\neq 0$: the shift is nilpotent of order exactly $n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "nilpotent order",
+      "index of nilpotency"
+    ],
+    "prerequisites": [
+      "power law for the shift"
+    ]
+  },
+  {
+    "id": "ann-minpoly-nilpotent",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 135,
+      "endLine": 187
+    },
+    "type": "theorem",
+    "title": "Minimal Polynomial of J_n(0) is X^n",
+    "content": "Computes $\\mathrm{minpoly}_K(J_n(0)) = X^n$ for $n \\ge 1$. Since $N^n = 0$, the polynomial $X^n$ annihilates $N$, so $\\mathrm{minpoly} \\mid X^n$. As $X$ is prime in $K[X]$, divisor classification (`dvd_prime_pow`) gives $\\mathrm{minpoly} = X^j$ for some $j \\le n$ (monic, hence the unit factor is $1$). If $j < n$ then $N^j = 0$, whence $N^{n-1} = N^{n-1-j} \\cdot N^j = 0$, contradicting $N^{n-1} \\neq 0$. Therefore $j = n$.",
+    "mathContext": "$\\mathrm{minpoly}(N) \\mid X^n$, $X$ prime $\\Rightarrow \\mathrm{minpoly}(N) = X^j$; $j<n \\Rightarrow N^{n-1}=0$ (contradiction) $\\Rightarrow j=n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "minimal polynomial",
+      "unique factorization in K[X]",
+      "prime element X",
+      "monic associate"
+    ],
+    "prerequisites": [
+      "minpoly.dvd, minpoly.monic, minpoly.aeval",
+      "dvd_prime_pow",
+      "nilpotency of exact order n"
+    ]
+  },
+  {
+    "id": "ann-general-block",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 188,
+      "endLine": 254
+    },
+    "type": "theorem",
+    "title": "General Jordan Block J_n(mu): minpoly = (X - C mu)^n",
+    "content": "Defines `jordanBlock n mu = algebraMap mu + shift n`, the block $J_n(\\mu) = \\mu I + N$. Choosing the algebra-map form makes $\\mathrm{aeval}_{J_n(\\mu)}(X - C\\mu) = J_n(\\mu) - \\mu I = N$ hold by `add_sub_cancel_left`. Hence $(X - C\\mu)^n$ evaluates to $N^n = 0$ and annihilates the block. The minimal polynomial is then $(X - C\\mu)^n$ by the identical UFD argument as the nilpotent case, now over the prime $X - C\\mu$: $\\mathrm{minpoly} = (X - C\\mu)^j$, and $j < n$ would give $N^j = 0$ hence $N^{n-1} = 0$, a contradiction. So each Jordan block contributes exactly the elementary divisor $(X-\\mu)^n$.",
+    "mathContext": "$\\mathrm{aeval}_{J_n(\\mu)}(X - C\\mu) = N$, so $\\mathrm{minpoly}(J_n(\\mu)) = (X - C\\mu)^n$ -- the elementary divisor of the block.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Jordan block",
+      "elementary divisor",
+      "algebra map / scalar matrix",
+      "translation by a scalar"
+    ],
+    "prerequisites": [
+      "aeval of X - C mu",
+      "prime_X_sub_C, monic_X_sub_C",
+      "minimal polynomial of the nilpotent block"
+    ]
+  },
+  {
+    "id": "ann-open-work",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 255,
+      "endLine": 286
+    },
+    "type": "concept",
+    "title": "Scope and Open Work Toward Full Jordan Normal Form",
+    "content": "The file is explicit that full Jordan normal form is NOT claimed. Verified here: the single block and its minimal polynomial. Remaining: (1) the block's characteristic polynomial $(X - C\\mu)^n$; (2) block-diagonal assembly (charpoly = product, minpoly = lcm); (3) existence of the decomposition over an algebraically closed field, whose missing ingredient is a cyclic decomposition of nilpotent endomorphisms (not yet in Mathlib, which does provide Jordan-Chevalley and the generalized-eigenspace decomposition); (4) the similarity classification by Jordan type.",
+    "mathContext": "Each block gives one elementary divisor; assembling blocks and proving existence/uniqueness of the normal form is the open continuation.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Jordan normal form",
+      "Jordan-Chevalley decomposition",
+      "generalized eigenspaces",
+      "elementary divisors"
+    ],
+    "prerequisites": [
+      "Jordan canonical form (motivation)"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02-oq-02/meta.json
@@ -1,0 +1,190 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-02-oq-02-oq-02",
+  "title": "The Jordan Block: Nilpotent Shift and Its Minimal Polynomial",
+  "slug": "cayley-hamilton-minpoly-oq-02-oq-02-oq-02",
+  "description": "Jordan block infrastructure toward Jordan normal form: the n x n nilpotent shift J_n(0) has the closed-form power law (N^k)_{ij} = [j = i+k], giving N^n = 0 and N^{n-1} != 0, so minpoly(J_n(0)) = X^n; and the general Jordan block J_n(mu) = mu*I + N has minpoly(J_n(mu)) = (X - C mu)^n. This generalizes the bespoke 4x4 nilpotent computation of the parent entry to arbitrary size and eigenvalue.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Jordan_normal_form",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ02OQ02OQ02.lean",
+    "tags": [
+      "linear-algebra",
+      "matrices",
+      "jordan-form",
+      "jordan-block",
+      "minimal-polynomial",
+      "nilpotent",
+      "elementary-divisors",
+      "extension",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "minpoly.dvd",
+        "description": "If aeval x p = 0, then minpoly K x divides p",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "minpoly.aeval",
+        "description": "The minimal polynomial annihilates the element",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "Matrix.isIntegral",
+        "description": "All matrices over a field are integral elements",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly"
+      },
+      {
+        "theorem": "dvd_prime_pow",
+        "description": "Divisors of a prime power p^n are associated to p^i for some i <= n",
+        "module": "Mathlib.Algebra.GroupWithZero.Associated"
+      },
+      {
+        "theorem": "prime_X_sub_C",
+        "description": "X - C r is a prime element of the polynomial ring",
+        "module": "Mathlib.Algebra.Polynomial.RingDivision"
+      }
+    ],
+    "originalContributions": [
+      "Closed-form power law for the nilpotent shift: (N^k)_{ij} = 1 iff j = i + k (proved by induction with a single-nonzero-term sum extraction)",
+      "Exact nilpotency order: N^n = 0 and N^{n-1} != 0 for the n x n shift",
+      "Minimal polynomial of the nilpotent Jordan block J_n(0) is X^n (UFD divisor classification over the prime X)",
+      "Minimal polynomial of the general Jordan block J_n(mu) = mu*I + N is (X - C mu)^n (same argument over the prime X - C mu, via aeval(J_n mu)(X - C mu) = N)"
+    ],
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "lineCount": 268,
+    "assumptions": "None. All theorems fully machine-checked (0 axioms, 0 sorries). Results require n >= 1 where stated (the minimal-polynomial claims). Full Jordan normal form (existence of the block decomposition and the similarity classification) is NOT claimed and is documented as open in the file.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The Jordan normal form (Camille Jordan, 1870) states that every matrix over an algebraically closed field is similar to a block-diagonal matrix whose blocks are Jordan blocks J_n(mu) -- an eigenvalue mu on the diagonal and ones on the superdiagonal. Each block corresponds to one elementary divisor (X - mu)^n. Mathlib provides the deep adjacent results (the Jordan-Chevalley-Dunford decomposition in Mathlib.LinearAlgebra.JordanChevalley, and the fact that generalized eigenspaces span the space over an algebraically closed field) but does not provide the Jordan block as a first-class object with its spectral invariants.",
+    "problemStatement": "**Open Question** (from cayley-hamilton-minpoly-oq-02-oq-02): Formalize Jordan normal form over algebraically closed fields.\n\nFull JNF is a large formalization. This entry supplies its irreducible building block: the single Jordan block J_n(mu), with its minimal polynomial computed for arbitrary size n and eigenvalue mu. It generalizes the parent entry's specific 4x4 nilpotent minpoly = X^2 computation.",
+    "text": "The n x n nilpotent shift N (ones on the superdiagonal) is the Jordan block J_n(0). Its powers obey (N^k)_{ij} = [j = i+k], so N is nilpotent of order exactly n, and minpoly(J_n(0)) = X^n. The general block J_n(mu) = mu*I + N then has minpoly (X - C mu)^n -- exactly the elementary divisor it contributes.",
+    "proofStrategy": "**Power law by induction.** (N^0)_{ij} = [i=j] = [j = i+0]. For the step, expand (N^{k+1})_{ij} = sum_l (N^k)_{il} N_{lj} via the Leibniz/matrix-multiply formula; by the inductive closed form only l with l = i+k contributes, and N_{lj} = [j = l+1] = [j = i+k+1]. Case-splitting on whether i+k < n (so the witness index exists) versus not (sum is empty) gives the result; a single-term extraction (Finset.sum_eq_single_of_mem) handles the nonzero case.\n\n**Minimal polynomial by UFD classification.** X^n annihilates N (since N^n = 0), so minpoly | X^n; as X is prime, minpoly = X^j with j <= n. If j < n then N^j = 0 forces N^{n-1} = N^{n-1-j} * N^j = 0, contradicting N^{n-1} != 0. Hence j = n. The general block reuses the identical argument with the prime X - C mu, using aeval(J_n mu)(X - C mu) = (J_n mu) - mu*I = N.",
+    "keyInsights": [
+      "The superdiagonal shift's k-th power moves the diagonal of ones k steps up: (N^k)_{ij} = [j = i+k]. Nilpotency is then automatic because column indices live in Fin n.",
+      "The nilpotency order is exactly n: N^{n-1} has a single 1 in the top-right corner, witnessing N^{n-1} != 0.",
+      "A Jordan block contributes exactly one elementary divisor: minpoly(J_n(mu)) = (X - mu)^n.",
+      "Defining J_n(mu) as algebraMap mu + shift makes aeval(J_n mu)(X - C mu) = shift hold by add_sub_cancel_left, so the eigenvalue-mu case reduces verbatim to the nilpotent case."
+    ],
+    "prerequisites": [
+      "Matrix multiplication and the entrywise power formula",
+      "Minimal polynomial theory (divisibility, monic uniqueness)",
+      "Unique factorization in K[X]; primality of X and X - C mu",
+      "Nilpotent matrices and Jordan blocks (motivation)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header: Scope and What Mathlib Already Provides",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "States the open question (formalize Jordan normal form) and scopes this file to the single Jordan block. Notes that Mathlib supplies Jordan-Chevalley-Dunford and the generalized-eigenspace decomposition but not the Jordan block itself, and lists exactly what is proved here.",
+      "mathContext": "Jordan block $J_n(\\mu)$ has eigenvalue $\\mu$ on the diagonal and $1$ on the superdiagonal; it contributes the elementary divisor $(X-\\mu)^n$."
+    },
+    {
+      "id": "shift-def",
+      "title": "The Nilpotent Shift J_n(0)",
+      "startLine": 53,
+      "endLine": 70,
+      "summary": "Defines shift n as the n x n matrix with ones on the superdiagonal (entry (i,j) = 1 iff j = i+1), i.e. the Jordan block for eigenvalue 0, plus its entry simp lemma.",
+      "mathContext": "$N_{ij} = [\\,j = i+1\\,]$, the nilpotent Jordan block $J_n(0)$."
+    },
+    {
+      "id": "power-law",
+      "title": "Closed-Form Powers and Nilpotency",
+      "startLine": 71,
+      "endLine": 134,
+      "summary": "Proves the power law (N^k)_{ij} = [j = i+k] by induction, then derives N^n = 0 (nilpotency) and N^{n-1} != 0 (nilpotency order exactly n).",
+      "mathContext": "$(N^k)_{ij} = [\\,j = i+k\\,]$; hence $N^n = 0$ since $j < n \\le i+n$, while $(N^{n-1})_{0,n-1} = 1 \\neq 0$."
+    },
+    {
+      "id": "minpoly-nilpotent",
+      "title": "Minimal Polynomial of J_n(0) is X^n",
+      "startLine": 135,
+      "endLine": 187,
+      "summary": "Computes minpoly(shift n) = X^n for n >= 1 via UFD divisor classification: minpoly | X^n with X prime gives minpoly = X^j; j < n would force N^{n-1} = 0, a contradiction.",
+      "mathContext": "$X^n$ annihilates $N$ and $X$ is prime, so $\\mathrm{minpoly}(N) = X^j$ with $j \\le n$; $j<n \\Rightarrow N^{n-1}=0$, contradiction, so $j=n$."
+    },
+    {
+      "id": "general-block",
+      "title": "The General Jordan Block J_n(mu) and Its Minimal Polynomial",
+      "startLine": 188,
+      "endLine": 254,
+      "summary": "Defines jordanBlock n mu = algebraMap mu + shift n, proves aeval(J_n mu)(X - C mu) = shift and (X - C mu)^n annihilates the block, then computes minpoly(J_n mu) = (X - C mu)^n by the same divisor argument over the prime X - C mu.",
+      "mathContext": "$\\mathrm{aeval}_{J_n(\\mu)}(X - C\\mu) = J_n(\\mu) - \\mu I = N$, so $\\mathrm{minpoly}(J_n(\\mu)) = (X - C\\mu)^n$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary and Open Work",
+      "startLine": 255,
+      "endLine": 286,
+      "summary": "Recaps the verified results and lists the remaining steps toward full Jordan normal form: block characteristic polynomial, block-diagonal assembly, existence of the decomposition, and the similarity classification.",
+      "mathContext": "Each block gives one elementary divisor; assembling blocks and proving existence/uniqueness of the normal form remains open (the cyclic decomposition of a nilpotent generalized-eigenspace part is the genuinely missing Mathlib ingredient)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The single Jordan block is formalized as a first-class object with its spectral invariants fully verified (0 axioms, 0 sorries): the nilpotent shift J_n(0) has minimal polynomial X^n, and the general block J_n(mu) has minimal polynomial (X - C mu)^n. This is the irreducible building block of Jordan normal form, generalizing the parent entry's specific 4x4 minpoly = X^2 computation to arbitrary size and eigenvalue.",
+    "implications": "1. **Reusable block object**: J_n(mu) is now available with its closed-form power law and minimal polynomial, ready to be assembled into a block-diagonal normal form.\n\n2. **One block = one elementary divisor**: minpoly(J_n(mu)) = (X - mu)^n makes precise the role a Jordan block plays in the elementary-divisor / invariant-factor description of the similarity class.\n\n3. **Honest scope**: full Jordan normal form (existence and the similarity classification) is NOT claimed. The missing ingredient -- a cyclic decomposition of each nilpotent generalized-eigenspace component -- is documented as open.",
+    "openQuestions": [
+      "Characteristic polynomial of the block: charpoly(J_n(mu)) = (X - C mu)^n (upper-triangular with constant diagonal).",
+      "Block-diagonal assembly: for M a direct sum of Jordan blocks, charpoly = product of (X - mu_k)^{n_k} and minpoly = lcm of the block minimal polynomials.",
+      "Existence: every matrix over an algebraically closed field is similar to a sum of Jordan blocks (needs a cyclic decomposition of nilpotent endomorphisms, not yet in Mathlib).",
+      "Uniqueness / classification: two matrices are similar iff they have the same Jordan type (elementary divisors)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial"
+    ],
+    "namespace": "JordanBlock",
+    "lineCount": 268,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry proves a specific 4x4 nilpotent counterexample with minpoly = X^2. This entry generalizes that computation to the Jordan block of arbitrary size n and eigenvalue mu, and supplies the block object explicitly listed as open work item #2 there."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly",
+      "relationship": "related",
+      "description": "Grandparent formalization of the minimal polynomial of a matrix. The Jordan block's minimal polynomial (X - mu)^n is the model case for a single elementary divisor."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Hoffman, Kenneth; Kunze, Ray",
+      "title": "Linear Algebra",
+      "year": "1971",
+      "venue": "Prentice-Hall, 2nd edition",
+      "note": "Chapter 7: rational canonical form, elementary divisors, and the Jordan form. The minimal polynomial of a single Jordan block J_n(mu) is (X - mu)^n."
+    },
+    {
+      "authors": "Horn, Roger A.; Johnson, Charles R.",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd edition",
+      "note": "Sections 3.1-3.2: Jordan blocks, Jordan canonical form, and elementary divisors."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Supplies the missing reusable **single Jordan block** as a first-class object with its spectral invariants fully verified, generalizing the bespoke 4×4 nilpotent computation in `CayleyHamiltonMinpolyOQ02OQ02.lean` to an arbitrary-size block over an arbitrary field. This is a building block toward Jordan normal form, which Mathlib does not yet provide.

## What is proved (0 axioms, 0 sorries)

Let `N = shift n` be the `n×n` nilpotent shift (ones on the superdiagonal), i.e. `J_n(0)`, and `J_n(μ) = μ•I + N`:

| Theorem | Statement |
|---|---|
| `shift_pow_apply` | `(Nᵏ) i j = [j = i + k]` (closed form) |
| `shift_pow_eq_zero` | `Nⁿ = 0` |
| `shift_pow_pred_ne_zero` | `Nⁿ⁻¹ ≠ 0` (nilpotency order exactly `n`) |
| `minpoly_shift` | `minpoly(J_n(0)) = Xⁿ` |
| `minpoly_jordanBlock` | `minpoly(J_n(μ)) = (X - C μ)ⁿ` |

Each block contributes exactly the elementary divisor `(X - μ)ⁿ`. The minimal-polynomial results use the UFD divisor classification over the primes `X` and `X - C μ` (`dvd_prime_pow` + `eq_of_monic_of_associated`).

## Scope / honesty

Full Jordan normal form (existence of the block decomposition and the similarity classification) is **NOT** claimed; it is documented as open at the end of the file. `meta.json`: `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonMinpolyOQ02OQ02OQ02` → **Build succeeded (3058 jobs)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)