### PR TITLE
research(order-one-add-mul-prime-oq-01): order of 1+p·a mod odd prime power = p^n (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2921,6 +2921,7 @@ import Proofs.NthRootIrrationalOQ02
 import Proofs.OSBridge
 import Proofs.OnePlusOne
 import Proofs.OnePlusOneOQ04
+import Proofs.OrderOneAddMulPrimeOQ01
 import Proofs.PACLearning
 import Proofs.PACLearningOQ01
 import Proofs.PACLearningOQ01OQ01

--- a/proofs/Proofs/OrderOneAddMulPrimeOQ01.lean
+++ b/proofs/Proofs/OrderOneAddMulPrimeOQ01.lean
@@ -1,0 +1,102 @@
+import Mathlib
+
+/-
+# The Multiplicative Order of `1 + p·a` modulo an Odd Prime Power
+
+Fix an odd prime `p` and an integer `a` not divisible by `p`. In the ring `ZMod (p^(n+1))`
+the element `1 + p·a` is a unit, and its multiplicative order is exactly `p^n`:
+
+`orderOf (1 + p·a) = p^n`.
+
+This is the arithmetic engine behind the structure of `(ZMod (p^k))ˣ`: the "principal
+units" `1 + p·ℤ` form a cyclic `p`-group of order `p^n`, which combines with the cyclic
+group of order `p-1` coming from reduction mod `p` to make the whole unit group cyclic for
+odd prime powers. Every element of the shape `1 + p·a` with `p ∤ a` already attains the
+maximal `p`-power order `p^n`.
+
+Mathlib proves the order computation as `ZMod.orderOf_one_add_mul_prime` (and the prime-power
+generalisation `ZMod.orderOf_one_add_mul_prime_pow`). What it does **not** package is the
+collection of immediate structural consequences:
+
+* the order is *independent of the residue* `a` (every admissible `a` gives the same order);
+* the order is a power of `p`, so `1 + p·a` is a `p`-element of the unit group;
+* the order equals `1` exactly modulo `p` itself (the `n = 0` case);
+* concrete numeric instances such as `orderOf (4 : ZMod 9) = 3`, `orderOf (4 : ZMod 27) = 9`
+  and `orderOf (6 : ZMod 25) = 5`.
+
+This file collects these, deriving each from the single Mathlib result, with no axioms and no
+`native_decide` (the concrete orders are obtained from the theorem, not by kernel evaluation).
+
+The core order computation is re-exported from Mathlib; the "independent of `a`" statement
+and the structural corollaries are assembled here.
+-/
+
+namespace OrderOneAddMulPrimeOQ01
+
+/-- **Order of `1 + p·a` modulo `p^(n+1)`** (re-export of `ZMod.orderOf_one_add_mul_prime`).
+For an odd prime `p` and an integer `a` with `p ∤ a`, the multiplicative order of `1 + p·a`
+in `ZMod (p^(n+1))` is `p^n`. -/
+theorem orderOf_one_add_mul_prime {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) (a : ℤ)
+    (ha : ¬ (p : ℤ) ∣ a) (n : ℕ) :
+    orderOf (1 + p * a : ZMod (p ^ (n + 1))) = p ^ n :=
+  ZMod.orderOf_one_add_mul_prime hp hp2 a ha n
+
+/-- **The order does not depend on the residue `a`.** Any two integers coprime to the odd
+prime `p` produce elements `1 + p·a` of the same multiplicative order `p^n`. -/
+theorem orderOf_one_add_mul_prime_eq {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) (a b : ℤ)
+    (ha : ¬ (p : ℤ) ∣ a) (hb : ¬ (p : ℤ) ∣ b) (n : ℕ) :
+    orderOf (1 + p * a : ZMod (p ^ (n + 1))) = orderOf (1 + p * b : ZMod (p ^ (n + 1))) := by
+  rw [orderOf_one_add_mul_prime hp hp2 a ha n, orderOf_one_add_mul_prime hp hp2 b hb n]
+
+/-- **The order is a power of `p`**, so `1 + p·a` is a `p`-element of the unit group. -/
+theorem exists_orderOf_eq_prime_pow {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) (a : ℤ)
+    (ha : ¬ (p : ℤ) ∣ a) (n : ℕ) :
+    ∃ k, orderOf (1 + p * a : ZMod (p ^ (n + 1))) = p ^ k :=
+  ⟨n, orderOf_one_add_mul_prime hp hp2 a ha n⟩
+
+/-- **Textbook specialisation `a = 1`:** the order of `1 + p` modulo `p^(n+1)` is `p^n`
+(re-export of `ZMod.orderOf_one_add_prime`). -/
+theorem orderOf_one_add_prime {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) (n : ℕ) :
+    orderOf (1 + p : ZMod (p ^ (n + 1))) = p ^ n :=
+  ZMod.orderOf_one_add_prime hp hp2 n
+
+/-- The order is `1` exactly when `n = 0`, i.e. modulo `p` itself (where `1 + p·a = 1`). -/
+theorem orderOf_eq_one_iff {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) (a : ℤ)
+    (ha : ¬ (p : ℤ) ∣ a) (n : ℕ) :
+    orderOf (1 + p * a : ZMod (p ^ (n + 1))) = 1 ↔ n = 0 := by
+  rw [orderOf_one_add_mul_prime hp hp2 a ha n]
+  constructor
+  · intro h
+    by_contra hn
+    have hle : p ≤ p ^ n := le_self_pow hp.one_lt.le hn
+    have := hp.two_le
+    omega
+  · rintro rfl; rfl
+
+/-! ### Concrete numeric instances (axiom-free, derived from the theorem) -/
+
+/-- `1 + 3·1 = 4` has order `3 = 3^1` modulo `9 = 3^2`. -/
+theorem orderOf_four_zmod_nine : orderOf (4 : ZMod 9) = 3 := by
+  have h := orderOf_one_add_mul_prime (p := 3) (by norm_num) (by norm_num) (a := 1)
+    (by norm_num) (n := 1)
+  have e : (1 + (3 : ℕ) * (1 : ℤ) : ZMod (3 ^ (1 + 1))) = 4 := by push_cast; ring
+  rw [e] at h
+  exact h
+
+/-- `1 + 3·1 = 4` has order `9 = 3^2` modulo `27 = 3^3`. -/
+theorem orderOf_four_zmod_twentyseven : orderOf (4 : ZMod 27) = 9 := by
+  have h := orderOf_one_add_mul_prime (p := 3) (by norm_num) (by norm_num) (a := 1)
+    (by norm_num) (n := 2)
+  have e : (1 + (3 : ℕ) * (1 : ℤ) : ZMod (3 ^ (2 + 1))) = 4 := by push_cast; ring
+  rw [e] at h
+  exact h
+
+/-- `1 + 5·1 = 6` has order `5 = 5^1` modulo `25 = 5^2`. -/
+theorem orderOf_six_zmod_twentyfive : orderOf (6 : ZMod 25) = 5 := by
+  have h := orderOf_one_add_mul_prime (p := 5) (by norm_num) (by norm_num) (a := 1)
+    (by norm_num) (n := 1)
+  have e : (1 + (5 : ℕ) * (1 : ℤ) : ZMod (5 ^ (1 + 1))) = 6 := by push_cast; ring
+  rw [e] at h
+  exact h
+
+end OrderOneAddMulPrimeOQ01

--- a/src/data/proofs/order-one-add-mul-prime-oq-01/meta.json
+++ b/src/data/proofs/order-one-add-mul-prime-oq-01/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "order-one-add-mul-prime-oq-01",
+  "title": "The Multiplicative Order of 1 + p·a modulo an Odd Prime Power",
+  "slug": "order-one-add-mul-prime-oq-01",
+  "description": "For an odd prime p and an integer a with p ∤ a, the element 1 + p·a is a unit of ZMod (p^(n+1)) and its multiplicative order is exactly p^n. This is the arithmetic engine behind the cyclicity of (ZMod p^k)ˣ: the principal units 1 + p·ℤ form a cyclic p-group of order p^n. This entry re-exports Mathlib's order computation (ZMod.orderOf_one_add_mul_prime) and packages its immediate structural consequences — that the order is independent of the residue a, that it is a power of p, that it equals 1 exactly modulo p itself — together with concrete axiom-free numeric instances such as orderOf (4 : ZMod 9) = 3.",
+  "meta": {
+    "author": "classical number theory; formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/OrderOneAddMulPrimeOQ01.lean",
+    "tags": [
+      "number-theory",
+      "group-theory",
+      "modular-arithmetic",
+      "multiplicative-order",
+      "prime-powers",
+      "ZMod",
+      "cyclic-groups",
+      "units",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.orderOf_one_add_mul_prime",
+        "description": "For an odd prime p and p ∤ a, orderOf (1 + p·a : ZMod (p^(n+1))) = p^n — the core order computation",
+        "module": "Mathlib.RingTheory.ZMod.UnitsCyclic"
+      },
+      {
+        "theorem": "ZMod.orderOf_one_add_prime",
+        "description": "Specialisation a = 1: orderOf (1 + p : ZMod (p^(n+1))) = p^n",
+        "module": "Mathlib.RingTheory.ZMod.UnitsCyclic"
+      },
+      {
+        "theorem": "le_self_pow",
+        "description": "1 ≤ a → n ≠ 0 → a ≤ a^n, used to show the order is 1 only when n = 0",
+        "module": "Mathlib.Algebra.Order.Monoid.Unbundled.Pow"
+      }
+    ],
+    "originalContributions": [
+      "orderOf_one_add_mul_prime_eq: the multiplicative order is independent of the residue a — every integer coprime to p produces an element 1 + p·a of the same order p^n",
+      "exists_orderOf_eq_prime_pow: the order is a power of p, so 1 + p·a is a p-element of the unit group",
+      "orderOf_eq_one_iff: the order equals 1 exactly when n = 0, i.e. modulo p itself (where 1 + p·a reduces to 1)",
+      "orderOf_four_zmod_nine, orderOf_four_zmod_twentyseven, orderOf_six_zmod_twentyfive: concrete numeric instances (orderOf (4:ZMod 9)=3, orderOf (4:ZMod 27)=9, orderOf (6:ZMod 25)=5) derived from the theorem, axiom-free (no native_decide)"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. The core order computation is re-exported from Mathlib's ZMod.orderOf_one_add_mul_prime; depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 102,
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The structure of the unit group (ZMod (p^k))ˣ is a cornerstone of elementary number theory. For an odd prime p this group is cyclic of order p^(k-1)(p-1), a theorem going back to Gauss. The proof splits the group as a product of the order-(p-1) part (coming from reduction modulo p, where (ZMod p)ˣ is cyclic) and the order-p^(k-1) part of principal units 1 + p·ℤ. The key quantitative fact is that 1 + p (more generally 1 + p·a with p ∤ a) has multiplicative order exactly p^(k-1) — it generates the whole p-Sylow subgroup. This computation rests on the lifting-the-exponent estimate v_p((1+p·a)^{p^j} − 1) = j + 1.",
+    "problemStatement": "Fix an odd prime p, an integer a not divisible by p, and n ≥ 0. What is the multiplicative order of 1 + p·a in the ring ZMod (p^(n+1))?\n\n**Answer:** exactly p^n. The order does not depend on which residue a (coprime to p) is chosen, it is always a power of p, and it collapses to 1 precisely in the degenerate case n = 0 (reduction modulo p).",
+    "text": "For an odd prime p with p ∤ a, the element 1 + p·a has multiplicative order p^n in ZMod (p^(n+1)).",
+    "proofStrategy": "The order computation is Mathlib's ZMod.orderOf_one_add_mul_prime, itself the n = 1 case of the prime-power lemma orderOf_one_add_mul_prime_pow, proved via the lifting-the-exponent / binomial estimate on (1 + p·a)^{p^j}. From this single fact the structural corollaries follow formally: independence of a by rewriting both orders to p^n; the p-power statement by exhibiting the exponent n; the order-one characterisation from p ≥ 2 forcing p^n > 1 whenever n ≥ 1 (le_self_pow). The concrete instances instantiate p, a, n and rewrite the element 1 + p·a to a literal — note 1 + p·a = (literal) is a pure ring identity requiring no modular reduction, so it is discharged by push_cast/ring rather than native_decide, keeping the entry axiom-free.",
+    "keyInsights": [
+      "Every element of the shape 1 + p·a with p ∤ a already attains the maximal p-power order p^n; the residue a is irrelevant to the order",
+      "The order is intrinsically a power of p, identifying 1 + p·a as living in the p-Sylow (principal-unit) part of the unit group",
+      "The numeric instances are obtained from the general theorem, not by kernel evaluation: 1 + p·a equals its literal value as a ring identity, so no native_decide (and hence no Lean.ofReduceBool axiom) is needed",
+      "orderOf here is the order in the multiplicative monoid of the ring ZMod (p^(n+1)); since 1 + p·a is a unit, it coincides with its order in the unit group"
+    ],
+    "prerequisites": [
+      "Modular arithmetic and the ring ZMod m",
+      "Multiplicative order of an element (orderOf) in a monoid",
+      "Prime powers and the cyclic structure of (ZMod p^k)ˣ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "core",
+      "title": "The Order Computation",
+      "startLine": 38,
+      "endLine": 47,
+      "summary": "Re-export of ZMod.orderOf_one_add_mul_prime: orderOf (1 + p·a) = p^n for odd prime p, p ∤ a.",
+      "mathContext": "$\\operatorname{ord}_{p^{n+1}}(1 + p a) = p^{n}$ for $p$ an odd prime, $p \\nmid a$."
+    },
+    {
+      "id": "structure",
+      "title": "Structural Corollaries",
+      "startLine": 49,
+      "endLine": 79,
+      "summary": "Independence of the residue a, the order being a power of p, the a = 1 specialisation, and the characterisation order = 1 ↔ n = 0.",
+      "mathContext": "$\\operatorname{ord}(1+pa) = \\operatorname{ord}(1+pb)$; $\\operatorname{ord}(1+pa) = p^{k}$; $\\operatorname{ord}(1+pa)=1 \\iff n=0$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Numeric Instances",
+      "startLine": 81,
+      "endLine": 100,
+      "summary": "Axiom-free numeric orders derived from the theorem: orderOf (4:ZMod 9)=3, orderOf (4:ZMod 27)=9, orderOf (6:ZMod 25)=5.",
+      "mathContext": "$\\operatorname{ord}_{9}(4)=3,\\ \\operatorname{ord}_{27}(4)=9,\\ \\operatorname{ord}_{25}(6)=5$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Ireland, K.; Rosen, M.",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "note": "Structure of (Z/p^k Z)*; order of principal units"
+    },
+    {
+      "authors": "Apostol, T. M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "note": "Primitive roots and the cyclicity of (Z/p^k Z)* for odd primes"
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": {
+    "summary": "The multiplicative order of 1 + p·a modulo an odd prime power p^(n+1) is exactly p^n, re-exported from Mathlib and packaged with its structural consequences — independence of the residue, the p-power property, the order-one characterisation — plus axiom-free concrete instances.",
+    "implications": "Isolates the quantitative core of the cyclicity of (ZMod p^k)ˣ for odd primes: the principal units form a cyclic p-group generated by 1 + p. The 'independent of a' statement makes precise that any p ∤ a gives a generator of the maximal p-power-order cyclic subgroup.",
+    "openQuestions": [
+      "What is the corresponding order for the prime 2, where (ZMod 2^k)ˣ is not cyclic for k ≥ 3 and 1 + 2·a behaves differently?",
+      "Can this order computation be repackaged to give an explicit isomorphism (ZMod p^k)ˣ ≃ ZMod (p^(k-1)) × ZMod (p-1) for odd p?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "OrderOneAddMulPrimeOQ01",
+    "lineCount": 102,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/OrderOneAddMulPrimeOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds gallery entry **order-one-add-mul-prime-oq-01**: for an odd prime `p` and integer `a` with `p ∤ a`, the multiplicative order of `1 + p·a` in `ZMod (p^(n+1))` is exactly `p^n`.

This is the arithmetic engine behind the cyclicity of `(ZMod p^k)ˣ` for odd primes — the principal units `1 + p·ℤ` form a cyclic `p`-group of order `p^n`.

## What's here

The core order computation **re-exports** Mathlib's `ZMod.orderOf_one_add_mul_prime` (badge: `mathlib`, framed honestly as a re-export). The entry's own content is the structural consequences Mathlib does not package:

- `orderOf_one_add_mul_prime_eq` — the order is **independent of the residue** `a`
- `exists_orderOf_eq_prime_pow` — the order is a **power of `p`** (`1+p·a` is a `p`-element of the unit group)
- `orderOf_eq_one_iff` — order `= 1 ⟺ n = 0` (reduction mod `p`)
- concrete axiom-free instances: `ord₉(4)=3`, `ord₂₇(4)=9`, `ord₂₅(6)=5`, derived from the theorem via `push_cast`/`ring` (**not** `native_decide`)

## Verification

- Docker-build verified: **7743 jobs OK**, 0 sorries
- `#print axioms` confirms `[propext, Classical.choice, Quot.sound]` only — no `Lean.ofReduceBool`, no `sorryAx`
- `status: verified`, `axiomCount: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)