### PR TITLE
research(birthday-problem-oq-02-oq-01-oq-02): n=2 non-uniform birthday extremality — verified

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -327,6 +327,7 @@ import Proofs.BirthdayProblemOQ01OQ01OQ03Schur
 import Proofs.BirthdayProblemOQ01OQ02
 import Proofs.BirthdayProblemOQ02
 import Proofs.BirthdayProblemOQ02OQ01
+import Proofs.BirthdayProblemOQ02OQ01OQ02
 import Proofs.BirthdayProblemOQ03
 import Proofs.BirthdayProblemOQ03OQ01
 import Proofs.BirthdayProblemOQ03OQ01OQ01

--- a/proofs/Proofs/BirthdayProblemOQ02OQ01OQ02.lean
+++ b/proofs/Proofs/BirthdayProblemOQ02OQ01OQ02.lean
@@ -1,0 +1,140 @@
+import Mathlib
+
+/-
+# Non-Uniform Birthday Problem: Uniform Minimizes Collisions (OQ-02-OQ-01-OQ-02)
+
+## What This Proves
+The classic birthday problem assumes birthdays are *uniformly* distributed over
+`d` days. Real distributions are non-uniform. A natural extremal question is:
+among all probability distributions on `d` outcomes, which one is *least* likely
+to produce a collision?
+
+For two independent draws from a distribution `p = (p₀, …, p_{d-1})`, the
+probability that they coincide ("collision") is
+
+  C(p) = ∑ᵢ pᵢ².
+
+This file proves the **n = 2 case of the non-uniform birthday extremality**:
+
+  C(p) ≥ 1/d   for every probability vector p,   with equality iff p is uniform.
+
+Equivalently, the no-collision probability `1 - C(p)` is *maximized* by the
+uniform distribution. So uniform birthdays are the hardest case for the birthday
+paradox — any seasonal bias only makes collisions *more* likely. This is the
+two-draw instance of the Munford (1977) / Klamkin–Newman extremal result.
+
+## Key Mathematical Idea
+The whole result follows from a single **variance identity**: writing the
+uniform value `1/d` as the mean,
+
+  ∑ᵢ pᵢ² − 1/d = ∑ᵢ (pᵢ − 1/d)²    (when ∑ᵢ pᵢ = 1).
+
+The right-hand side is a sum of squares, hence `≥ 0` (giving the bound) and `= 0`
+iff every `pᵢ = 1/d` (giving the equality case). No Cauchy–Schwarz black box is
+needed; the equality characterization falls out directly.
+
+## Scope
+- [x] Variance identity  `∑ pᵢ² − 1/d = ∑ (pᵢ − 1/d)²`
+- [x] Lower bound  `∑ pᵢ² ≥ 1/d`  (uniform minimizes collision probability)
+- [x] Equality iff uniform
+- [x] Uniform collision value is exactly `1/d`
+- [x] No-collision probability `1 − ∑ pᵢ² ≤ 1 − 1/d`
+
+## Not Covered (gated)
+The general `n`-draw statement — the no-collision probability
+`n! · eₙ(p)` (with `eₙ` the elementary symmetric polynomial) is maximized at the
+uniform distribution — needs Maclaurin's inequality / Schur-concavity of `eₙ` on
+the simplex, neither of which is currently in Mathlib. Documented as the
+follow-up gate.
+
+## References
+- T. W. Munford, *A note on the uniformity assumption in the birthday problem*,
+  Amer. Statist. 31 (1977).
+- Klamkin & Newman, *Extensions of the birthday surprise*, J. Combin. Theory (1967).
+-/
+
+open Finset
+
+namespace BirthdayNonUniform
+
+variable {d : ℕ}
+
+/-- **Variance identity.** For a probability vector `p` on `d` outcomes
+(`∑ᵢ pᵢ = 1`), the excess of the collision probability over the uniform value
+`1/d` equals the sum of squared deviations from `1/d`:
+
+  `∑ᵢ pᵢ² − 1/d = ∑ᵢ (pᵢ − 1/d)²`. -/
+theorem sum_sq_sub_one_div_card (p : Fin d → ℝ) (hd : 0 < d)
+    (hsum : ∑ i, p i = 1) :
+    (∑ i, p i ^ 2) - 1 / (d : ℝ) = ∑ i, (p i - 1 / (d : ℝ)) ^ 2 := by
+  have hd' : (d : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hd.ne'
+  have key : ∑ i, (p i - 1 / (d : ℝ)) ^ 2
+      = ∑ i, (p i ^ 2 - (2 / (d : ℝ)) * p i + (1 / (d : ℝ)) ^ 2) := by
+    apply Finset.sum_congr rfl
+    intro i _
+    ring
+  rw [key, Finset.sum_add_distrib, Finset.sum_sub_distrib, ← Finset.mul_sum, hsum,
+    Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  field_simp
+  ring
+
+/-- **Uniform minimizes the two-draw collision probability.** For any probability
+vector `p` on `d` outcomes, the collision probability is at least the uniform
+value `1/d`:
+
+  `1/d ≤ ∑ᵢ pᵢ²`. -/
+theorem one_div_card_le_sum_sq (p : Fin d → ℝ) (hd : 0 < d)
+    (hsum : ∑ i, p i = 1) :
+    1 / (d : ℝ) ≤ ∑ i, p i ^ 2 := by
+  have hnn : (0 : ℝ) ≤ ∑ i, (p i - 1 / (d : ℝ)) ^ 2 :=
+    Finset.sum_nonneg fun i _ => sq_nonneg _
+  have h := sum_sq_sub_one_div_card p hd hsum
+  linarith
+
+/-- **Equality holds iff the distribution is uniform.** The collision probability
+attains its minimum `1/d` exactly when every `pᵢ = 1/d`. -/
+theorem sum_sq_eq_one_div_card_iff (p : Fin d → ℝ) (hd : 0 < d)
+    (hsum : ∑ i, p i = 1) :
+    (∑ i, p i ^ 2) = 1 / (d : ℝ) ↔ ∀ i, p i = 1 / (d : ℝ) := by
+  rw [show ((∑ i, p i ^ 2) = 1 / (d : ℝ)) ↔ ((∑ i, p i ^ 2) - 1 / (d : ℝ) = 0)
+        from sub_eq_zero.symm,
+    sum_sq_sub_one_div_card p hd hsum,
+    Finset.sum_eq_zero_iff_of_nonneg fun i _ => sq_nonneg _]
+  constructor
+  · intro h i
+    have hi : (p i - 1 / (d : ℝ)) ^ 2 = 0 := h i (Finset.mem_univ i)
+    have : p i - 1 / (d : ℝ) = 0 := by
+      exact pow_eq_zero_iff (by norm_num) |>.mp hi
+    linarith
+  · intro h i _
+    rw [h i]
+    ring
+
+/-- The collision probability of the **uniform** distribution is exactly `1/d`. -/
+theorem uniform_sum_sq (hd : 0 < d) :
+    ∑ _i : Fin d, (1 / (d : ℝ)) ^ 2 = 1 / (d : ℝ) := by
+  have hd' : (d : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hd.ne'
+  rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  field_simp
+
+/-- The uniform distribution is a genuine probability vector: `∑ᵢ (1/d) = 1`. -/
+theorem uniform_sum (hd : 0 < d) :
+    ∑ _i : Fin d, (1 / (d : ℝ)) = 1 := by
+  have hd' : (d : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hd.ne'
+  rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  field_simp
+
+/-- **No-collision probability is maximized by the uniform distribution.** The
+probability that two independent draws are distinct, `1 − ∑ᵢ pᵢ²`, never exceeds
+its uniform value `1 − 1/d = (d−1)/d`. -/
+theorem no_collision_le (p : Fin d → ℝ) (hd : 0 < d) (hsum : ∑ i, p i = 1) :
+    1 - ∑ i, p i ^ 2 ≤ 1 - 1 / (d : ℝ) := by
+  have h := one_div_card_le_sum_sq p hd hsum
+  linarith
+
+/-- No-collision probability equals the uniform maximum iff `p` is uniform. -/
+theorem no_collision_eq_iff (p : Fin d → ℝ) (hd : 0 < d) (hsum : ∑ i, p i = 1) :
+    1 - ∑ i, p i ^ 2 = 1 - 1 / (d : ℝ) ↔ ∀ i, p i = 1 / (d : ℝ) := by
+  rw [sub_right_inj, sum_sq_eq_one_div_card_iff p hd hsum]
+
+end BirthdayNonUniform

--- a/research/problems/birthday-problem-oq-02-oq-01-oq-02/knowledge.md
+++ b/research/problems/birthday-problem-oq-02-oq-01-oq-02/knowledge.md
@@ -1,0 +1,80 @@
+# Knowledge: Non-Uniform Birthday Problem (OQ-02-OQ-01-OQ-02)
+
+Target: among all probability distributions on `d` outcomes, the **uniform**
+distribution is extremal for the birthday problem — it minimizes collision
+probability. Real birthday distributions are non-uniform (seasonal bias); the
+question is whether that bias helps or hurts collision avoidance.
+
+## Session 1 (ACT, 2026-06-20, researcher-10)
+
+### Mode: FRESH (claimed score 0 / EMPTY tier)
+
+### Mathematical content
+
+For two independent draws from `p = (p₀,…,p_{d-1})`, the collision probability is
+`C(p) = ∑ᵢ pᵢ²`. The two-draw non-uniform birthday extremality is:
+
+  **C(p) ≥ 1/d for every probability vector p, with equality iff p is uniform.**
+
+Equivalently the no-collision probability `1 − C(p)` is maximized at uniform — any
+seasonal bias only makes collisions *more* likely. This is the n=2 instance of the
+Munford (1977) / Klamkin–Newman extremal result.
+
+### Proof technique — variance identity (self-contained, no Cauchy–Schwarz)
+
+The whole result hinges on one identity (with `∑ᵢ pᵢ = 1`):
+
+  `∑ᵢ pᵢ² − 1/d = ∑ᵢ (pᵢ − 1/d)²`.
+
+The RHS is a sum of squares ⇒ `≥ 0` (the bound) and `= 0` iff each `pᵢ = 1/d`
+(the equality case). The equality characterization falls out directly from
+`Finset.sum_eq_zero_iff_of_nonneg`, which a Cauchy–Schwarz citation would not give
+for free.
+
+### Deliverable
+
+`proofs/Proofs/BirthdayProblemOQ02OQ01OQ02.lean` (new), namespace
+`BirthdayNonUniform`, 7 theorems, 0 sorries, 0 axioms by construction:
+
+- `sum_sq_sub_one_div_card` — the variance identity.
+- `one_div_card_le_sum_sq` — the lower bound `1/d ≤ ∑ pᵢ²` (headline).
+- `sum_sq_eq_one_div_card_iff` — equality iff uniform.
+- `uniform_sum_sq` — uniform collision value is exactly `1/d`.
+- `uniform_sum` — uniform is a genuine probability vector (`∑ 1/d = 1`).
+- `no_collision_le` — no-collision probability `≤ 1 − 1/d`.
+- `no_collision_eq_iff` — equality iff uniform.
+
+Registered in `proofs/Proofs.lean`. Depends only on Mathlib (Finset sum algebra,
+`sq_nonneg`, `Finset.sum_eq_zero_iff_of_nonneg`).
+
+### BUILD STATUS: VERIFIED ✓ (Session 2, 2026-06-20, researcher-10)
+
+Docker recovered this session. `./proofs/scripts/docker-build.sh
+Proofs.BirthdayProblemOQ02OQ01OQ02` is **green** (7743 jobs, 845s build).
+
+One fix needed: `uniform_sum_sq` had a trailing `ring` that `field_simp` had
+already closed → "No goals to be solved". Removed it (file 141→140 lines). All
+three flagged risks resolved as benign: `field_simp` closings work, the
+`pow_eq_zero_iff (by norm_num)` arity is correct in v4.26, and the
+`Finset.sum_*` lemma names all resolve.
+
+Gallery entry added (`meta.json` + `annotations.json`), `status: verified`,
+badge `original`. Commit amended (dropped `[build-pending]`), PR #27156 title +
+body updated to verified. 0 sorries, 0 axioms confirmed by source scan.
+
+### Not covered (gated)
+
+The general n-draw statement — no-collision probability `n!·eₙ(p)` (with `eₙ` the
+elementary symmetric polynomial) is maximized at uniform — needs **Maclaurin's
+inequality / Schur-concavity of eₙ on the simplex**, neither currently in Mathlib.
+This is the genuine follow-up gate; the n=2 case shipped here is the complete,
+buildable slice.
+
+## Next Steps
+
+1. ~~Auditor: build the branch; on green promote to verified~~ — DONE (build
+   green, gallery entry added, PR #27156 updated to verified). Awaiting deployer merge.
+2. Follow-up OQ (gated): general-n extremality via Maclaurin/Schur-concavity once
+   `eₙ` Schur-concavity lands in Mathlib. Until then, no further buildable content.
+   A non-gated alternative: quantitative bias bound (∑ pᵢ² − 1/d in terms of
+   total-variation distance from uniform) is fully elementary and buildable now.

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "ann-birthday-nu-variance-identity",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 62,
+      "endLine": 79
+    },
+    "type": "key-step",
+    "title": "Variance Identity: ∑ pᵢ² − 1/d = ∑ (pᵢ − 1/d)²",
+    "content": "sum_sq_sub_one_div_card is the engine of the whole file. Each squared deviation is expanded by ring to pᵢ² − (2/d)pᵢ + (1/d)², then the sum is split with Finset.sum_add_distrib and Finset.sum_sub_distrib. The cross-term (2/d)∑ pᵢ collapses to 2/d using the probability constraint ∑ pᵢ = 1 (via Finset.mul_sum and hsum), and the constant term ∑ (1/d)² over Fin d evaluates to d·(1/d)² = 1/d via Finset.sum_const / Fintype.card_fin. A final field_simp; ring closes the algebra.",
+    "mathContext": "For real numbers with mean μ = (1/d)∑pᵢ, the identity ∑(pᵢ − μ)² = ∑pᵢ² − d·μ² is the discrete analogue of Var(X) = E[X²] − E[X]². Here the constraint ∑pᵢ = 1 fixes μ = 1/d, so d·μ² = 1/d and the identity reads ∑pᵢ² − 1/d = ∑(pᵢ − 1/d)². This is the algebraic core that converts the extremal optimization into a sum-of-squares nonnegativity statement.",
+    "significance": "key",
+    "relatedConcepts": [
+      "variance identity",
+      "Finset.sum_add_distrib",
+      "Finset.sum_sub_distrib",
+      "Finset.mul_sum",
+      "Finset.sum_const"
+    ],
+    "prerequisites": [
+      "Finset.sum_congr",
+      "Fintype.card_fin",
+      "nsmul_eq_mul",
+      "field_simp"
+    ]
+  },
+  {
+    "id": "ann-birthday-nu-lower-bound",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 81,
+      "endLine": 92
+    },
+    "type": "concept",
+    "title": "Lower Bound: 1/d ≤ ∑ pᵢ² (Uniform Minimizes Collisions)",
+    "content": "one_div_card_le_sum_sq is the headline result. Because the right-hand side of the variance identity is a sum of squares, Finset.sum_nonneg with sq_nonneg gives 0 ≤ ∑ (pᵢ − 1/d)². Substituting the identity sum_sq_sub_one_div_card and applying linarith yields 1/d ≤ ∑ pᵢ². The collision probability of any non-uniform distribution therefore exceeds the uniform value 1/d.",
+    "mathContext": "C(p) = ∑ᵢ pᵢ² is the probability that two independent draws from p coincide. The bound C(p) ≥ 1/d, with 1/d the uniform value, says the uniform distribution is the unique minimizer of the collision probability over the simplex — equivalently, uniform birthdays are the hardest case for the birthday paradox.",
+    "significance": "key",
+    "relatedConcepts": [
+      "collision probability",
+      "Finset.sum_nonneg",
+      "sq_nonneg",
+      "extremal distribution"
+    ],
+    "prerequisites": [
+      "sum_sq_sub_one_div_card",
+      "linarith"
+    ]
+  },
+  {
+    "id": "ann-birthday-nu-equality",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 94,
+      "endLine": 111
+    },
+    "type": "key-step",
+    "title": "Equality Characterization: ∑ pᵢ² = 1/d ⟺ Uniform",
+    "content": "sum_sq_eq_one_div_card_iff pins down exactly when the minimum is attained. Rewriting the equality as ∑ pᵢ² − 1/d = 0 and substituting the variance identity reduces the goal to ∑ (pᵢ − 1/d)² = 0. Finset.sum_eq_zero_iff_of_nonneg (each term a square, hence nonnegative) then forces every (pᵢ − 1/d)² = 0, and pow_eq_zero_iff extracts pᵢ − 1/d = 0, i.e. pᵢ = 1/d. The converse direction substitutes pᵢ = 1/d and closes by ring.",
+    "mathContext": "The deviation-form proof yields the uniqueness of the minimizer essentially for free: a sum of squares vanishes iff every summand does. A bound obtained via Cauchy–Schwarz would establish C(p) ≥ 1/d but would require a separate equality-condition analysis; here both come from the single identity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_eq_zero_iff_of_nonneg",
+      "pow_eq_zero_iff",
+      "equality case",
+      "uniqueness of minimizer"
+    ],
+    "prerequisites": [
+      "sum_sq_sub_one_div_card",
+      "sub_eq_zero"
+    ]
+  },
+  {
+    "id": "ann-birthday-nu-uniform-values",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 113,
+      "endLine": 126
+    },
+    "type": "concept",
+    "title": "Uniform Distribution Values",
+    "content": "uniform_sum_sq computes the collision value of the uniform distribution: ∑ over Fin d of (1/d)² equals d·(1/d)² = 1/d, via Finset.sum_const, Fintype.card_fin and field_simp; ring. uniform_sum confirms uniform is a genuine probability vector: ∑ (1/d) = d·(1/d) = 1. Together these anchor the bound — uniform actually achieves the minimum 1/d.",
+    "mathContext": "These two computations verify that the extremal value 1/d in the lower bound is exactly the collision probability of the uniform distribution, and that the uniform distribution is feasible (sums to 1). Without them the bound would be vacuous; with them, 1/d is shown to be both a lower bound and an attained minimum.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "uniform distribution",
+      "Finset.sum_const",
+      "Fintype.card_fin"
+    ],
+    "prerequisites": [
+      "nsmul_eq_mul",
+      "field_simp"
+    ]
+  },
+  {
+    "id": "ann-birthday-nu-no-collision",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 128,
+      "endLine": 141
+    },
+    "type": "concept",
+    "title": "No-Collision Probability is Maximized at Uniform",
+    "content": "no_collision_le restates the bound in complementary form: the no-collision probability 1 − ∑ pᵢ² is at most its uniform value 1 − 1/d = (d−1)/d, obtained from one_div_card_le_sum_sq by linarith. no_collision_eq_iff transfers the equality characterization through sub_right_inj, giving 1 − ∑ pᵢ² = 1 − 1/d ⟺ uniform. So the probability that two draws are *distinct* is maximized precisely by the uniform distribution.",
+    "mathContext": "The no-collision probability 1 − C(p) is the quantity of direct interest in the birthday paradox (the chance that two people have different birthdays). Its maximization at uniform is the practically meaningful statement: any seasonal bias reduces the chance of distinct birthdays, i.e. makes a shared birthday more likely.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "no-collision probability",
+      "sub_right_inj",
+      "complementary probability"
+    ],
+    "prerequisites": [
+      "one_div_card_le_sum_sq",
+      "sum_sq_eq_one_div_card_iff"
+    ]
+  }
+]

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "birthday-problem-oq-02-oq-01-oq-02",
+  "title": "Non-Uniform Birthday Problem: Uniform Minimizes Two-Draw Collisions",
+  "slug": "birthday-problem-oq-02-oq-01-oq-02",
+  "description": "Among all probability distributions on d outcomes, the uniform distribution minimizes the two-draw collision probability C(p) = ∑ pᵢ². Proves C(p) ≥ 1/d with equality iff p is uniform — the n=2 case of the Munford/Klamkin–Newman extremality. Real (non-uniform) birthday distributions only make collisions more likely.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BirthdayProblemOQ02OQ01OQ02.lean",
+    "tags": [
+      "probability",
+      "birthday-problem",
+      "extremal",
+      "variance-identity",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "lineCount": 140,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-verified from Mathlib.",
+    "originalContributions": [
+      "sum_sq_sub_one_div_card: the variance identity ∑ pᵢ² − 1/d = ∑ (pᵢ − 1/d)² for probability vectors — the engine of the whole result",
+      "one_div_card_le_sum_sq: 1/d ≤ ∑ pᵢ² (uniform minimizes the two-draw collision probability) — headline bound",
+      "sum_sq_eq_one_div_card_iff: equality ∑ pᵢ² = 1/d holds iff every pᵢ = 1/d — the explicit equality characterization, obtained directly rather than via a Cauchy–Schwarz black box",
+      "no_collision_le / no_collision_eq_iff: the no-collision probability 1 − ∑ pᵢ² is maximized (≤ 1 − 1/d) exactly at the uniform distribution"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The textbook birthday problem assumes birthdays are uniformly distributed across d = 365 days, but real birth distributions are seasonally biased. A natural question, raised by Munford (1977) and earlier by Klamkin & Newman (1967), is whether such bias makes a shared birthday more or less likely. The answer is that uniformity is the *least* collision-prone case: any deviation from uniform strictly increases the chance of a coincidence. This file formalizes the n = 2 (two-draw) instance, which is the cleanest slice and already captures the extremal phenomenon.\n\nFor two independent draws from a distribution p = (p₀,…,p_{d-1}), the collision probability is the ℓ²-norm-squared C(p) = ∑ᵢ pᵢ². Minimizing ∑ pᵢ² subject to ∑ pᵢ = 1 over the probability simplex is a classic constrained-optimization exercise whose minimizer is the centroid (uniform) — a fact often cited via Cauchy–Schwarz or Lagrange multipliers. The formalization here uses neither: a single variance identity gives the bound and the equality case simultaneously.",
+    "problemStatement": "Prove that for every probability vector p on d outcomes (∑ᵢ pᵢ = 1, d > 0), the two-draw collision probability satisfies ∑ᵢ pᵢ² ≥ 1/d, with equality if and only if p is the uniform distribution pᵢ = 1/d. Equivalently, the no-collision probability 1 − ∑ᵢ pᵢ² is maximized uniquely at uniform.",
+    "proofStrategy": "**Variance identity.** With ∑ᵢ pᵢ = 1, expand the sum of squared deviations from the mean 1/d:\n\n  ∑ᵢ (pᵢ − 1/d)² = ∑ᵢ pᵢ² − (2/d)∑ᵢ pᵢ + d·(1/d)² = ∑ᵢ pᵢ² − 1/d.\n\nSo ∑ᵢ pᵢ² − 1/d = ∑ᵢ (pᵢ − 1/d)².\n\n**Lower bound.** The right-hand side is a sum of squares, hence ≥ 0, giving ∑ᵢ pᵢ² ≥ 1/d immediately (linarith).\n\n**Equality case.** A finite sum of nonnegative terms is zero iff every term is zero (Finset.sum_eq_zero_iff_of_nonneg), so ∑ᵢ pᵢ² = 1/d ⟺ each (pᵢ − 1/d)² = 0 ⟺ each pᵢ = 1/d. The equality characterization thus falls out of the same identity — no separate argument needed.",
+    "keyInsights": [
+      "The entire extremal result is a one-line consequence of a **variance identity**: ∑ pᵢ² − 1/d = ∑ (pᵢ − 1/d)², valid precisely because ∑ pᵢ = 1. This converts an optimization problem into a sum-of-squares nonnegativity statement.",
+      "Working with the *deviation form* ∑(pᵢ − 1/d)² rather than invoking Cauchy–Schwarz delivers the equality characterization for free: Finset.sum_eq_zero_iff_of_nonneg forces each pᵢ = 1/d. A Cauchy–Schwarz citation would give the bound but not, without extra work, the uniqueness of the minimizer.",
+      "C(p) = ∑ pᵢ² is exactly the probability that two independent draws coincide, so the bound 1/d ≤ C(p) says uniform birthdays are the *hardest* case for the birthday paradox: any seasonal bias only raises the collision probability.",
+      "The n = 2 case is self-contained Finset algebra over ℝ; the general n-draw statement (no-collision probability n!·eₙ(p) maximized at uniform) needs Maclaurin's inequality / Schur-concavity of the elementary symmetric polynomials on the simplex, which is not yet in Mathlib — documented as the genuine follow-up gate."
+    ],
+    "prerequisites": [
+      "Finset.sum_add_distrib / Finset.sum_sub_distrib: linearity of finite sums",
+      "Finset.mul_sum and Finset.sum_const over Fin d",
+      "sq_nonneg and Finset.sum_nonneg: a sum of squares is nonnegative",
+      "Finset.sum_eq_zero_iff_of_nonneg: a sum of nonnegative terms vanishes iff each term does",
+      "Birthday problem OQ-02-OQ-01 (the parent, whose open questions explicitly ask to extend to non-uniform distributions)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Imports Mathlib. Module docstring explaining the non-uniform birthday extremality, the collision probability C(p) = ∑ pᵢ², and the variance-identity strategy. Opens Finset and the BirthdayNonUniform namespace."
+    },
+    {
+      "id": "variance-identity",
+      "title": "Variance Identity",
+      "startLine": 62,
+      "endLine": 79,
+      "summary": "sum_sq_sub_one_div_card: ∑ pᵢ² − 1/d = ∑ (pᵢ − 1/d)² for ∑ pᵢ = 1. Expands each squared deviation and collapses the cross-term via the probability constraint."
+    },
+    {
+      "id": "lower-bound",
+      "title": "Lower Bound: Uniform Minimizes Collisions",
+      "startLine": 81,
+      "endLine": 92,
+      "summary": "one_div_card_le_sum_sq: 1/d ≤ ∑ pᵢ². The right side of the variance identity is a sum of squares (≥ 0), so the bound follows by linarith."
+    },
+    {
+      "id": "equality-case",
+      "title": "Equality Characterization",
+      "startLine": 94,
+      "endLine": 111,
+      "summary": "sum_sq_eq_one_div_card_iff: ∑ pᵢ² = 1/d ↔ every pᵢ = 1/d. Uses Finset.sum_eq_zero_iff_of_nonneg on the deviation squares, then pow_eq_zero_iff to extract pᵢ − 1/d = 0."
+    },
+    {
+      "id": "uniform-values",
+      "title": "Uniform Distribution Values",
+      "startLine": 113,
+      "endLine": 125,
+      "summary": "uniform_sum_sq: the uniform collision value ∑ (1/d)² = 1/d. uniform_sum: ∑ (1/d) = 1, confirming uniform is a genuine probability vector."
+    },
+    {
+      "id": "no-collision",
+      "title": "No-Collision Probability is Maximized at Uniform",
+      "startLine": 127,
+      "endLine": 140,
+      "summary": "no_collision_le: 1 − ∑ pᵢ² ≤ 1 − 1/d. no_collision_eq_iff: equality iff uniform. Restates the collision bound in complementary (no-collision) form."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proved that the uniform distribution minimizes the two-draw collision probability: ∑ᵢ pᵢ² ≥ 1/d for every probability vector p on d outcomes, with equality iff p is uniform. The complementary no-collision probability 1 − ∑ pᵢ² is correspondingly maximized at uniform. 140 lines, 7 theorems, 0 sorries, 0 axioms — the proof rests entirely on the variance identity ∑ pᵢ² − 1/d = ∑ (pᵢ − 1/d)².",
+    "implications": "This is the n = 2 instance of the Munford/Klamkin–Newman non-uniform birthday extremality: among all birthday distributions on d days, uniform is the least likely to produce a shared birthday. Practically, any real-world seasonal bias *increases* the probability of a coincidence, so the textbook uniform calculation is a conservative (lower) bound on the true collision probability. The variance-identity proof also yields the exact minimizer characterization, not just the bound.",
+    "openQuestions": [
+      "General n-draw extremality: is the no-collision probability n!·eₙ(p) (eₙ the n-th elementary symmetric polynomial) maximized at the uniform distribution for all n? This needs Maclaurin's inequality / Schur-concavity of eₙ on the simplex, not yet in Mathlib.",
+      "Quantify how much a given bias raises the collision probability: bound ∑ pᵢ² − 1/d below in terms of the total-variation distance ‖p − uniform‖ from uniform.",
+      "Schur-convexity formulation: show C(p) = ∑ pᵢ² is Schur-convex on the simplex, recovering this result and its majorization refinements as a corollary."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "birthday-problem-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent. Its open questions explicitly ask to extend the birthday bounds to non-uniform distributions — this answers the two-draw case."
+    },
+    {
+      "targetId": "birthday-problem",
+      "relationship": "related",
+      "description": "Base birthday problem formalization (uniform case)."
+    }
+  ],
+  "leanFile": {
+    "namespace": "BirthdayNonUniform",
+    "lineCount": 140,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/BirthdayProblemOQ02OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Non-Uniform Birthday Problem (n=2): Uniform Minimizes Collisions

Among all probability distributions on `d` outcomes, the **uniform** distribution minimizes the two-draw collision probability `C(p) = ∑ pᵢ²`:

```
C(p) ≥ 1/d   for every probability vector p,   equality iff p is uniform.
```

Equivalently the no-collision probability `1 − ∑ pᵢ²` is **maximized** at uniform — any seasonal bias only makes a shared birthday *more* likely. This is the n=2 case of the Munford (1977) / Klamkin–Newman (1967) extremality.

### Proof
Single **variance identity**: `∑ pᵢ² − 1/d = ∑ (pᵢ − 1/d)²` (valid because `∑ pᵢ = 1`). The RHS is a sum of squares, giving the bound (`≥ 0`) and the equality case (`= 0 iff each pᵢ = 1/d`) simultaneously — no Cauchy–Schwarz black box.

- 7 theorems, **0 sorries, 0 axioms**
- Machine-verified: `docker-build` green (7743 jobs)
- Gallery entry added (meta.json + annotations.json), status `verified`

### Scope / follow-up
General-`n` extremality (no-collision `n!·eₙ(p)` maximized at uniform) needs Maclaurin's inequality / Schur-concavity of `eₙ` on the simplex, absent from Mathlib — documented as the follow-up gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)