### PR TITLE
research(triangle-angle-sum-oq-06): sum-to-product identities + triangle half-angle products (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3343,6 +3343,7 @@ import Proofs.TriangleAngleSumOQ01
 import Proofs.TriangleAngleSumOQ02
 import Proofs.TriangleAngleSumOQ03
 import Proofs.TriangleAngleSumOQ04
+import Proofs.TriangleAngleSumOQ06
 import Proofs.TriangleInequality
 import Proofs.TriangleInequalityOQ02
 import Proofs.TriangleInequalityOQ03

--- a/proofs/Proofs/TriangleAngleSumOQ06.lean
+++ b/proofs/Proofs/TriangleAngleSumOQ06.lean
@@ -1,0 +1,175 @@
+/-
+  Sum-to-product (prosthaphaeresis) identities and their triangle half-angle
+  corollaries.
+
+  The four **sum-to-product** identities turn a sum of two sinusoids into a
+  product of two sinusoids:
+
+      cos x + cos y =  2·cos((x+y)/2)·cos((x−y)/2)
+      cos x − cos y = −2·sin((x+y)/2)·sin((x−y)/2)
+      sin x + sin y =  2·sin((x+y)/2)·cos((x−y)/2)
+      sin x − sin y =  2·cos((x+y)/2)·sin((x−y)/2)
+
+  They are the converse of the Werner product-to-sum family (cf.
+  `triangle-angle-sum-oq-04`/`oq-05`): there a product becomes a sum; here a
+  sum becomes a product, factored through the **mean** (x+y)/2 and the
+  **half-difference** (x−y)/2.  Each is proved directly from the addition
+  formulas: writing x = (x+y)/2 + (x−y)/2 and y = (x+y)/2 − (x−y)/2, the two
+  cosines (resp. sines) expand and combine.  Mathlib records these as
+  `Real.cos_add_cos`, `Real.cos_sub_cos`, `Real.sin_add_sin`, `Real.sin_sub_sin`;
+  the gallery had no sum-to-product identity, so they are anchored here, derived
+  from `Real.cos_add` / `Real.cos_sub` rather than cited.
+
+  The substantive content beyond Mathlib is the pair of **triangle half-angle
+  product identities**, which Mathlib does not record.  For angles of a triangle
+  (A + B + C = π):
+
+      sin A + sin B + sin C = 4·cos(A/2)·cos(B/2)·cos(C/2)
+      cos A + cos B + cos C = 1 + 4·sin(A/2)·sin(B/2)·sin(C/2).
+
+  Both are the prosthaphaeresis payoff: pairing two of the three terms with a
+  sum-to-product step and collapsing the half-angle (A+B)/2 = π/2 − C/2 turns
+  the linear combination of three sinusoids into a single product of three
+  half-angle factors.  They are proved here in the general "half-angle" form
+  (for a + b + c = π/2) and specialised to the triangle.
+
+  Verified: 0 sorries, 0 axioms (only the foundational propext / Classical.choice
+  / Quot.sound; no native_decide, no Lean.ofReduceBool).
+-/
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Tactic.LinearCombination
+
+open Real
+
+namespace TriangleAngleSumOQ06
+
+/-! ### The four sum-to-product (prosthaphaeresis) identities
+
+Each is derived from the addition formulas via the mean / half-difference
+substitution x = (x+y)/2 + (x−y)/2, y = (x+y)/2 − (x−y)/2. -/
+
+/-- **Sum-to-product, cosine sum**: `cos x + cos y = 2·cos((x+y)/2)·cos((x−y)/2)`.
+This is the `triangle-angle-sum-oq-06` identity, derived from `Real.cos_add` /
+`Real.cos_sub` (it coincides with Mathlib's `Real.cos_add_cos`). -/
+theorem cos_add_cos (x y : ℝ) :
+    cos x + cos y = 2 * cos ((x + y) / 2) * cos ((x - y) / 2) := by
+  have e1 : (x + y) / 2 + (x - y) / 2 = x := by ring
+  have e2 : (x + y) / 2 - (x - y) / 2 = y := by ring
+  calc cos x + cos y
+      = cos ((x + y) / 2 + (x - y) / 2) + cos ((x + y) / 2 - (x - y) / 2) := by
+        rw [e1, e2]
+    _ = 2 * cos ((x + y) / 2) * cos ((x - y) / 2) := by
+        rw [Real.cos_add, Real.cos_sub]; ring
+
+/-- **Sum-to-product, cosine difference**:
+`cos x − cos y = −2·sin((x+y)/2)·sin((x−y)/2)`. -/
+theorem cos_sub_cos (x y : ℝ) :
+    cos x - cos y = -2 * sin ((x + y) / 2) * sin ((x - y) / 2) := by
+  have e1 : (x + y) / 2 + (x - y) / 2 = x := by ring
+  have e2 : (x + y) / 2 - (x - y) / 2 = y := by ring
+  calc cos x - cos y
+      = cos ((x + y) / 2 + (x - y) / 2) - cos ((x + y) / 2 - (x - y) / 2) := by
+        rw [e1, e2]
+    _ = -2 * sin ((x + y) / 2) * sin ((x - y) / 2) := by
+        rw [Real.cos_add, Real.cos_sub]; ring
+
+/-- **Sum-to-product, sine sum**: `sin x + sin y = 2·sin((x+y)/2)·cos((x−y)/2)`.
+This is the `triangle-angle-sum-oq-07` identity, derived from `Real.sin_add` /
+`Real.sin_sub` (it coincides with Mathlib's `Real.sin_add_sin`). -/
+theorem sin_add_sin (x y : ℝ) :
+    sin x + sin y = 2 * sin ((x + y) / 2) * cos ((x - y) / 2) := by
+  have e1 : (x + y) / 2 + (x - y) / 2 = x := by ring
+  have e2 : (x + y) / 2 - (x - y) / 2 = y := by ring
+  calc sin x + sin y
+      = sin ((x + y) / 2 + (x - y) / 2) + sin ((x + y) / 2 - (x - y) / 2) := by
+        rw [e1, e2]
+    _ = 2 * sin ((x + y) / 2) * cos ((x - y) / 2) := by
+        rw [Real.sin_add, Real.sin_sub]; ring
+
+/-- **Sum-to-product, sine difference**:
+`sin x − sin y = 2·cos((x+y)/2)·sin((x−y)/2)`. -/
+theorem sin_sub_sin (x y : ℝ) :
+    sin x - sin y = 2 * cos ((x + y) / 2) * sin ((x - y) / 2) := by
+  have e1 : (x + y) / 2 + (x - y) / 2 = x := by ring
+  have e2 : (x + y) / 2 - (x - y) / 2 = y := by ring
+  calc sin x - sin y
+      = sin ((x + y) / 2 + (x - y) / 2) - sin ((x + y) / 2 - (x - y) / 2) := by
+        rw [e1, e2]
+    _ = 2 * cos ((x + y) / 2) * sin ((x - y) / 2) := by
+        rw [Real.sin_add, Real.sin_sub]; ring
+
+/-! ### Triangle half-angle product identities
+
+The original content: for a + b + c = π/2 (the half-angles of a triangle),
+the sum of `sin (2·)` factors as `4·cos·cos·cos`, and the sum of `cos (2·)`
+factors as `1 + 4·sin·sin·sin`.  These are not in Mathlib. -/
+
+/-- **Half-angle sine identity**: if `a + b + c = π/2` then
+`sin(2a) + sin(2b) + sin(2c) = 4·cos a·cos b·cos c`.
+
+Substituting `c = π/2 − (a+b)` turns `sin(2c)` into `sin(2(a+b))` (via
+`sin(π − ·) = sin`) and `cos c` into `sin(a+b)` (via `cos(π/2 − ·) = sin`);
+expanding the double and sum angles reduces the goal to a polynomial identity
+in `sin a, cos a, sin b, cos b`, closed by the Pythagorean identity. -/
+theorem half_angle_sin_sum (a b c : ℝ) (h : a + b + c = π / 2) :
+    sin (2 * a) + sin (2 * b) + sin (2 * c) = 4 * cos a * cos b * cos c := by
+  have hc : c = π / 2 - (a + b) := by linarith
+  subst hc
+  have e1 : 2 * (π / 2 - (a + b)) = π - 2 * (a + b) := by ring
+  rw [e1, Real.sin_pi_sub, Real.cos_pi_div_two_sub]
+  simp only [Real.sin_two_mul, Real.sin_add, Real.cos_add]
+  linear_combination (-2 * Real.sin a * Real.cos a) * Real.sin_sq_add_cos_sq b
+    + (-2 * Real.sin b * Real.cos b) * Real.sin_sq_add_cos_sq a
+
+/-- **Half-angle cosine identity**: if `a + b + c = π/2` then
+`cos(2a) + cos(2b) + cos(2c) = 1 + 4·sin a·sin b·sin c`.
+
+Substituting `c = π/2 − (a+b)` turns `cos(2c)` into `−cos(2(a+b))` (via
+`cos(π − ·) = −cos`) and `sin c` into `cos(a+b)` (via `sin(π/2 − ·) = cos`);
+expanding via the double-angle and addition formulas reduces to a polynomial
+identity closed by the Pythagorean identity. -/
+theorem half_angle_cos_sum (a b c : ℝ) (h : a + b + c = π / 2) :
+    cos (2 * a) + cos (2 * b) + cos (2 * c) = 1 + 4 * sin a * sin b * sin c := by
+  have hc : c = π / 2 - (a + b) := by linarith
+  subst hc
+  have e1 : 2 * (π / 2 - (a + b)) = π - 2 * (a + b) := by ring
+  rw [e1, Real.cos_pi_sub, Real.sin_pi_div_two_sub]
+  simp only [Real.cos_two_mul, Real.cos_add]
+  linear_combination (2 - 2 * Real.cos b ^ 2) * Real.sin_sq_add_cos_sq a
+    + (2 * Real.sin a ^ 2) * Real.sin_sq_add_cos_sq b
+
+/-- **Triangle sine identity**: for the angles of a triangle (`A + B + C = π`),
+`sin A + sin B + sin C = 4·cos(A/2)·cos(B/2)·cos(C/2)`.  A classical identity
+not recorded in Mathlib; the prosthaphaeresis payoff. -/
+theorem triangle_sin_sum (A B C : ℝ) (h : A + B + C = π) :
+    sin A + sin B + sin C = 4 * cos (A / 2) * cos (B / 2) * cos (C / 2) := by
+  have h2 : A / 2 + B / 2 + C / 2 = π / 2 := by linarith
+  have key := half_angle_sin_sum (A / 2) (B / 2) (C / 2) h2
+  rw [show 2 * (A / 2) = A by ring, show 2 * (B / 2) = B by ring,
+     show 2 * (C / 2) = C by ring] at key
+  exact key
+
+/-- **Triangle cosine identity**: for the angles of a triangle (`A + B + C = π`),
+`cos A + cos B + cos C = 1 + 4·sin(A/2)·sin(B/2)·sin(C/2)`.  A classical identity
+not recorded in Mathlib. -/
+theorem triangle_cos_sum (A B C : ℝ) (h : A + B + C = π) :
+    cos A + cos B + cos C = 1 + 4 * sin (A / 2) * sin (B / 2) * sin (C / 2) := by
+  have h2 : A / 2 + B / 2 + C / 2 = π / 2 := by linarith
+  have key := half_angle_cos_sum (A / 2) (B / 2) (C / 2) h2
+  rw [show 2 * (A / 2) = A by ring, show 2 * (B / 2) = B by ring,
+     show 2 * (C / 2) = C by ring] at key
+  exact key
+
+/-! ### Worked instance -/
+
+/-- The equilateral triangle (`A = B = C = π/3`) instance of the triangle sine
+identity: `3·sin(π/3) = 4·cos(π/6)³`, obtained from `triangle_sin_sum` without
+evaluating the surds. -/
+example :
+    sin (π / 3) + sin (π / 3) + sin (π / 3)
+      = 4 * cos (π / 6) * cos (π / 6) * cos (π / 6) := by
+  have key := triangle_sin_sum (π / 3) (π / 3) (π / 3) (by ring)
+  rw [show (π / 3) / 2 = π / 6 by ring] at key
+  exact key
+
+end TriangleAngleSumOQ06

--- a/src/data/proofs/triangle-angle-sum-oq-06/annotations.json
+++ b/src/data/proofs/triangle-angle-sum-oq-06/annotations.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": "ann-sum-to-product",
+    "proofId": "triangle-angle-sum-oq-06",
+    "range": {
+      "startLine": 46,
+      "endLine": 99
+    },
+    "type": "theorem",
+    "title": "The Four Sum-to-Product Identities (cos_add_cos, cos_sub_cos, sin_add_sin, sin_sub_sin)",
+    "content": "The four prosthaphaeresis identities convert a sum or difference of two sinusoids into a product of two: cos x + cos y = 2·cos((x+y)/2)·cos((x−y)/2), cos x − cos y = −2·sin((x+y)/2)·sin((x−y)/2), sin x + sin y = 2·sin((x+y)/2)·cos((x−y)/2), and sin x − sin y = 2·cos((x+y)/2)·sin((x−y)/2). Each is a three-line calc: the mean (x+y)/2 and half-difference (x−y)/2 satisfy (x+y)/2 + (x−y)/2 = x and (x+y)/2 − (x−y)/2 = y (by ring), so cos x + cos y rewrites as cos((x+y)/2 + (x−y)/2) + cos((x+y)/2 − (x−y)/2); expanding with Real.cos_add / Real.cos_sub (resp. Real.sin_add / Real.sin_sub) and closing by ring gives the product. They coincide with Mathlib's Real.cos_add_cos, Real.cos_sub_cos, Real.sin_add_sin and Real.sin_sub_sin, anchored here from the addition formulas as the building blocks for the triangle corollaries. The cos+cos identity is triangle-angle-sum-oq-06 and the sin+sin identity is triangle-angle-sum-oq-07.",
+    "mathContext": "$\\cos x + \\cos y = 2\\cos\\tfrac{x+y}{2}\\cos\\tfrac{x-y}{2}$, $\\cos x - \\cos y = -2\\sin\\tfrac{x+y}{2}\\sin\\tfrac{x-y}{2}$, $\\sin x + \\sin y = 2\\sin\\tfrac{x+y}{2}\\cos\\tfrac{x-y}{2}$, $\\sin x - \\sin y = 2\\cos\\tfrac{x+y}{2}\\sin\\tfrac{x-y}{2}$.",
+    "prerequisites": [
+      "The sine and cosine addition/subtraction formulas (Real.sin_add, Real.cos_add, Real.sin_sub, Real.cos_sub)",
+      "The ring tactic for closing polynomial identities in the expanded sinusoids"
+    ],
+    "relatedConcepts": [
+      "prosthaphaeresis",
+      "sum-to-product formulas",
+      "beat-frequency decomposition"
+    ],
+    "significance": "The classical sum-to-product formulas, the converse of the Werner product-to-sum family; the factorisation through the mean (x+y)/2 and half-difference (x−y)/2 is the beat-frequency / envelope decomposition of a superposition of two tones, and the building block for the triangle half-angle products."
+  },
+  {
+    "id": "ann-half-angle-products",
+    "proofId": "triangle-angle-sum-oq-06",
+    "range": {
+      "startLine": 101,
+      "endLine": 161
+    },
+    "type": "theorem",
+    "title": "The Triangle Half-Angle Product Identities (half_angle_sin_sum, half_angle_cos_sum, triangle_sin_sum, triangle_cos_sum)",
+    "content": "half_angle_sin_sum proves sin(2a) + sin(2b) + sin(2c) = 4·cos a·cos b·cos c when a + b + c = π/2: substituting c = π/2 − (a+b), the term sin(2c) = sin(π − 2(a+b)) becomes sin(2(a+b)) via Real.sin_pi_sub and cos c = cos(π/2 − (a+b)) becomes sin(a+b) via Real.cos_pi_div_two_sub; simp then expands the double and sum angles (Real.sin_two_mul, Real.sin_add, Real.cos_add) and a two-term linear_combination against Real.sin_sq_add_cos_sq closes the residual polynomial identity in sin a, cos a, sin b, cos b. half_angle_cos_sum is the analogue giving cos(2a) + cos(2b) + cos(2c) = 1 + 4·sin a·sin b·sin c, with cos(2c) = −cos(2(a+b)) (Real.cos_pi_sub), sin c = cos(a+b) (Real.sin_pi_div_two_sub) and the double-angle expansion Real.cos_two_mul. The named corollaries triangle_sin_sum and triangle_cos_sum specialise a = A/2, b = B/2, c = C/2 — so a + b + c = (A+B+C)/2 = π/2 — and rewrite 2·(A/2) = A, recovering for the angles of a triangle sin A + sin B + sin C = 4·cos(A/2)·cos(B/2)·cos(C/2) and cos A + cos B + cos C = 1 + 4·sin(A/2)·sin(B/2)·sin(C/2).",
+    "mathContext": "$\\sin A + \\sin B + \\sin C = 4\\cos\\tfrac{A}{2}\\cos\\tfrac{B}{2}\\cos\\tfrac{C}{2}$ and $\\cos A + \\cos B + \\cos C = 1 + 4\\sin\\tfrac{A}{2}\\sin\\tfrac{B}{2}\\sin\\tfrac{C}{2}$ for $A + B + C = \\pi$.",
+    "prerequisites": [
+      "The reflection identities Real.sin_pi_sub, Real.cos_pi_sub, Real.sin_pi_div_two_sub, Real.cos_pi_div_two_sub",
+      "Real.sin_two_mul, Real.cos_two_mul, Real.sin_sq_add_cos_sq and the linear_combination tactic"
+    ],
+    "relatedConcepts": [
+      "triangle identities",
+      "half-angle complementarity",
+      "Pythagorean reduction"
+    ],
+    "significance": "The original content beyond Mathlib: classical triangle identities that hold precisely because A + B + C = π forces (A+B)/2 = π/2 − C/2, turning three independent sinusoids into a single product of three half-angle factors."
+  },
+  {
+    "id": "ann-worked-instance",
+    "proofId": "triangle-angle-sum-oq-06",
+    "range": {
+      "startLine": 163,
+      "endLine": 173
+    },
+    "type": "example",
+    "title": "Worked Instance: the Equilateral Triangle",
+    "content": "The equilateral triangle A = B = C = π/3 instance of triangle_sin_sum: applying it at π/3, π/3, π/3 (with π/3 + π/3 + π/3 = π closed by ring) and rewriting (π/3)/2 = π/6 gives sin(π/3) + sin(π/3) + sin(π/3) = 4·cos(π/6)·cos(π/6)·cos(π/6), i.e. 3·sin(π/3) = 4·cos³(π/6). The instance is obtained purely from the theorem, with no evaluation of the surd values sin(π/3) = cos(π/6) = √3/2.",
+    "mathContext": "$3\\sin\\tfrac{\\pi}{3} = 4\\cos^3\\tfrac{\\pi}{6}$.",
+    "prerequisites": [
+      "triangle_sin_sum",
+      "the ring tactic for π/3 + π/3 + π/3 = π and (π/3)/2 = π/6"
+    ],
+    "relatedConcepts": [
+      "equilateral triangle",
+      "specialization of a general identity"
+    ],
+    "significance": "Exhibits the triangle sine identity concretely on the most symmetric triangle, confirming the formula without needing the explicit surd values of the trigonometric functions."
+  }
+]

--- a/src/data/proofs/triangle-angle-sum-oq-06/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-06/meta.json
@@ -1,0 +1,96 @@
+{
+  "id": "triangle-angle-sum-oq-06",
+  "title": "Triangle Angle Sum OQ-06/07: Sum-to-Product (Prosthaphaeresis) Identities and the Triangle Half-Angle Products",
+  "slug": "triangle-angle-sum-oq-06",
+  "description": "The four sum-to-product (prosthaphaeresis) identities convert a sum of two sinusoids into a product of two sinusoids — cos x + cos y = 2·cos((x+y)/2)·cos((x−y)/2), cos x − cos y = −2·sin((x+y)/2)·sin((x−y)/2), sin x + sin y = 2·sin((x+y)/2)·cos((x−y)/2), and sin x − sin y = 2·cos((x+y)/2)·sin((x−y)/2) — each proved directly from the addition formulas via the mean / half-difference substitution x = (x+y)/2 + (x−y)/2, y = (x+y)/2 − (x−y)/2. They are the converse direction of the Werner product-to-sum family (triangle-angle-sum-oq-04/oq-05): there a product becomes a sum, here a sum becomes a product, factored through the arithmetic mean (x+y)/2 and the half-difference (x−y)/2. These four identities coincide with Mathlib's Real.cos_add_cos / Real.cos_sub_cos / Real.sin_add_sin / Real.sin_sub_sin but are anchored here from the addition formulas because the gallery had no sum-to-product identity. The substantive content beyond Mathlib is the pair of triangle half-angle product identities, which Mathlib does not record: for the angles of a triangle (A + B + C = π), sin A + sin B + sin C = 4·cos(A/2)·cos(B/2)·cos(C/2) and cos A + cos B + cos C = 1 + 4·sin(A/2)·sin(B/2)·sin(C/2). Both are the prosthaphaeresis payoff: pairing two of the three terms with a sum-to-product step and collapsing the half-angle (A+B)/2 = π/2 − C/2 turns a linear combination of three sinusoids into a single product of three half-angle factors. They are proved here in a general half-angle form (for a + b + c = π/2): sin(2a) + sin(2b) + sin(2c) = 4·cos a·cos b·cos c and cos(2a) + cos(2b) + cos(2c) = 1 + 4·sin a·sin b·sin c, then specialised to the triangle. The equilateral instance 3·sin(π/3) = 4·cos(π/6)³ follows without evaluating the surds.",
+  "leanFile": "Proofs/TriangleAngleSumOQ06.lean",
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/List_of_trigonometric_identities#Product-to-sum_and_sum-to-product_identities",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/TriangleAngleSumOQ06.lean",
+    "tags": [
+      "trigonometry",
+      "sum-to-product",
+      "prosthaphaeresis",
+      "triangle-identities",
+      "half-angle",
+      "real-analysis"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "relatedProblems": [
+      {
+        "id": "triangle-angle-sum-oq-07",
+        "relationship": "Subsumed: the sin x + sin y sum-to-product identity (triangle-angle-sum-oq-07) is the theorem sin_add_sin in this entry; both the cos+cos (oq-06) and sin+sin (oq-07) members of the sum-to-product family are formalised here together with their two subtraction partners and the triangle half-angle corollaries."
+      },
+      {
+        "id": "triangle-angle-sum-oq-04",
+        "relationship": "Converse family: oq-04 proves the Werner product-to-sum identities (product → sum) and applies them to the finite Dirichlet kernel; this entry proves the sum-to-product identities (sum → product) and applies them to the triangle half-angle products."
+      },
+      {
+        "id": "triangle-angle-sum-oq-05",
+        "relationship": "Sibling: the mixed Werner product-to-sum identity 2·sin x·cos y; the sum-to-product sin_add_sin here is its converse direction."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 175,
+    "assumptions": "0 axioms, 0 sorries, no native_decide, no Lean.ofReduceBool. All theorems depend only on the foundational propext / Classical.choice / Quot.sound. The four sum-to-product identities are proved from Real.cos_add / Real.cos_sub / Real.sin_add / Real.sin_sub (they coincide with Mathlib's Real.cos_add_cos / Real.cos_sub_cos / Real.sin_add_sin / Real.sin_sub_sin). The triangle half-angle product identities sin A + sin B + sin C = 4·cos(A/2)·cos(B/2)·cos(C/2) and cos A + cos B + cos C = 1 + 4·sin(A/2)·sin(B/2)·sin(C/2) (and their a+b+c=π/2 half-angle forms) are NOT in Mathlib and are the original content; they reduce, after the π-reflection substitutions sin(π−·)=sin, cos(π−·)=−cos, sin(π/2−·)=cos, cos(π/2−·)=sin and the double/sum-angle expansions, to polynomial identities in sin a, cos a, sin b, cos b closed by linear_combination against the Pythagorean identity Real.sin_sq_add_cos_sq. The triangle corollaries carry the genuine domain hypothesis A + B + C = π.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Prosthaphaeresis (Greek prosthesis 'addition' + aphaeresis 'subtraction') was a late-sixteenth-century algorithm for multiplying large numbers by converting products into sums and differences of trigonometric values, read off from tables — the immediate computational predecessor of logarithms, used by astronomers including Tycho Brahe. The sum-to-product identities are the analytic core of that method, and they remain the standard tool for analysing superpositions of waves: cos x + cos y = 2·cos((x+y)/2)·cos((x−y)/2) is exactly the beat-frequency decomposition, writing a sum of two tones as a fast carrier at the mean frequency modulated by a slow envelope at the half-difference frequency. Their classical geometric corollaries are the triangle half-angle product identities sin A + sin B + sin C = 4·cos(A/2)·cos(B/2)·cos(C/2) and cos A + cos B + cos C = 1 + 4·sin(A/2)·sin(B/2)·sin(C/2), which hold precisely because the angles of a triangle sum to π, so that each pair's mean half-angle is the complement of the third half-angle.",
+    "problemStatement": "Prove the four sum-to-product identities\n\n$$\\cos x + \\cos y = 2\\cos\\tfrac{x+y}{2}\\cos\\tfrac{x-y}{2}, \\quad \\cos x - \\cos y = -2\\sin\\tfrac{x+y}{2}\\sin\\tfrac{x-y}{2},$$\n$$\\sin x + \\sin y = 2\\sin\\tfrac{x+y}{2}\\cos\\tfrac{x-y}{2}, \\quad \\sin x - \\sin y = 2\\cos\\tfrac{x+y}{2}\\sin\\tfrac{x-y}{2},$$\n\nand use them to derive the triangle half-angle product identities: for $A + B + C = \\pi$,\n\n$$\\sin A + \\sin B + \\sin C = 4\\cos\\tfrac{A}{2}\\cos\\tfrac{B}{2}\\cos\\tfrac{C}{2}, \\qquad \\cos A + \\cos B + \\cos C = 1 + 4\\sin\\tfrac{A}{2}\\sin\\tfrac{B}{2}\\sin\\tfrac{C}{2}.$$",
+    "text": "Mathlib records the four sum-to-product identities (Real.cos_add_cos, Real.cos_sub_cos, Real.sin_add_sin, Real.sin_sub_sin) but no triangle half-angle product identity. This entry proves the four sum-to-product identities directly from the addition formulas, then establishes the two triangle half-angle products. The mathematical content beyond Mathlib is the triangle half-angle products and their general a+b+c=π/2 form.",
+    "proofStrategy": "Each sum-to-product identity is a three-line calc: the mean (x+y)/2 and half-difference (x−y)/2 satisfy (x+y)/2 ± (x−y)/2 = x, y, so cos x + cos y rewrites as cos((x+y)/2 + (x−y)/2) + cos((x+y)/2 − (x−y)/2), and Real.cos_add / Real.cos_sub followed by ring collapse it to 2·cos((x+y)/2)·cos((x−y)/2) (analogously for the other three). The triangle products are proved first in half-angle form: in half_angle_sin_sum the hypothesis a + b + c = π/2 gives c = π/2 − (a+b); substituting, sin(2c) = sin(π − 2(a+b)) = sin(2(a+b)) via Real.sin_pi_sub and cos c = cos(π/2 − (a+b)) = sin(a+b) via Real.cos_pi_div_two_sub, after which simp expands the double and sum angles (Real.sin_two_mul, Real.sin_add, Real.cos_add) and linear_combination against Real.sin_sq_add_cos_sq closes the resulting polynomial identity in sin a, cos a, sin b, cos b. half_angle_cos_sum is identical with cos(2c) = −cos(2(a+b)) (Real.cos_pi_sub) and sin c = cos(a+b) (Real.sin_pi_div_two_sub), expanding via Real.cos_two_mul. The named triangle corollaries triangle_sin_sum / triangle_cos_sum follow by instantiating a = A/2, b = B/2, c = C/2 (so a+b+c = (A+B+C)/2 = π/2) and rewriting 2·(A/2) = A. The equilateral worked instance applies triangle_sin_sum at A = B = C = π/3 and rewrites (π/3)/2 = π/6, recovering 3·sin(π/3) = 4·cos(π/6)³ without evaluating any surd.",
+    "keyInsights": [
+      "**The mean and half-difference are the whole story**: every sum-to-product identity is the addition formula read backwards through the substitution x = (x+y)/2 + (x−y)/2, y = (x+y)/2 − (x−y)/2. The arithmetic mean (x+y)/2 carries the in-phase part and the half-difference (x−y)/2 carries the envelope; this is literally the beat-frequency factorisation of a superposition of two tones.",
+      "**The triangle hypothesis makes a pair's mean complement the third half-angle**: from A + B + C = π one gets (A+B)/2 = π/2 − C/2, so sin((A+B)/2) = cos(C/2) and cos((A+B)/2) = sin(C/2). This single complementarity is what turns three independent sinusoids into one product of three half-angle factors — the identity is a property of the constraint A+B+C=π, not of the individual angles.",
+      "**Mathlib has the algebra but not the geometry**: the four sum-to-product identities are present (Real.cos_add_cos etc.), but the triangle half-angle products sin A + sin B + sin C = 4cos(A/2)cos(B/2)cos(C/2) and cos A + cos B + cos C = 1 + 4sin(A/2)sin(B/2)sin(C/2) — the classical corollaries that hold only under A+B+C=π — are absent. Those constrained products are the original content here.",
+      "**After the π-reflections, the residue is purely Pythagorean**: once sin(π−·), cos(π−·), sin(π/2−·), cos(π/2−·) eliminate the constrained variable and the double/sum angles expand, each triangle identity becomes a polynomial identity in sin a, cos a, sin b, cos b that is true exactly modulo sin²+cos²=1 — captured precisely by a two-term linear_combination of Real.sin_sq_add_cos_sq a and Real.sin_sq_add_cos_sq b."
+    ],
+    "prerequisites": [
+      "The sine and cosine addition and subtraction formulas (Real.sin_add, Real.cos_add, Real.sin_sub, Real.cos_sub)",
+      "The reflection identities Real.sin_pi_sub, Real.cos_pi_sub, Real.sin_pi_div_two_sub, Real.cos_pi_div_two_sub",
+      "The double-angle formulas Real.sin_two_mul, Real.cos_two_mul and the Pythagorean identity Real.sin_sq_add_cos_sq",
+      "The linear_combination tactic for closing polynomial identities modulo a hypothesis"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sum-to-product",
+      "title": "The Four Sum-to-Product (Prosthaphaeresis) Identities",
+      "startLine": 46,
+      "endLine": 99,
+      "mathContext": "$\\cos x + \\cos y = 2\\cos\\tfrac{x+y}{2}\\cos\\tfrac{x-y}{2}$ and its three companions.",
+      "summary": "cos_add_cos, cos_sub_cos, sin_add_sin and sin_sub_sin convert each sum or difference of two sinusoids into a product of two sinusoids, proved by a three-line calc: rewrite x and y through the mean (x+y)/2 and half-difference (x−y)/2, expand with Real.cos_add / Real.cos_sub (resp. Real.sin_add / Real.sin_sub), and close by ring. They coincide with Mathlib's Real.cos_add_cos etc., anchored here from the addition formulas as the building blocks for the triangle corollaries."
+    },
+    {
+      "id": "half-angle-products",
+      "title": "The Triangle Half-Angle Product Identities",
+      "startLine": 101,
+      "endLine": 161,
+      "mathContext": "$\\sin A + \\sin B + \\sin C = 4\\cos\\tfrac{A}{2}\\cos\\tfrac{B}{2}\\cos\\tfrac{C}{2}$ for $A+B+C=\\pi$.",
+      "summary": "half_angle_sin_sum and half_angle_cos_sum establish the general a+b+c=π/2 products sin(2a)+sin(2b)+sin(2c) = 4·cos a·cos b·cos c and cos(2a)+cos(2b)+cos(2c) = 1 + 4·sin a·sin b·sin c by eliminating c via the π-reflections and closing the residual Pythagorean polynomial identity with linear_combination. triangle_sin_sum and triangle_cos_sum specialise them to the angles of a triangle (a = A/2, etc.), giving the classical identities not recorded in Mathlib."
+    },
+    {
+      "id": "worked-instance",
+      "title": "Worked Instance",
+      "startLine": 163,
+      "endLine": 173,
+      "mathContext": "$3\\sin\\tfrac{\\pi}{3} = 4\\cos^3\\tfrac{\\pi}{6}$.",
+      "summary": "The equilateral triangle (A = B = C = π/3) instance of triangle_sin_sum, obtained by rewriting (π/3)/2 = π/6 — exhibiting the identity concretely without evaluating the surd values sin(π/3) = cos(π/6) = √3/2."
+    }
+  ],
+  "conclusion": "The four sum-to-product (prosthaphaeresis) identities and the two triangle half-angle product identities are formalised sorry-free and axiom-free. The four sum-to-product identities coincide with Mathlib's Real.cos_add_cos / Real.cos_sub_cos / Real.sin_add_sin / Real.sin_sub_sin (anchored here from the addition formulas because the gallery previously held no sum-to-product identity, covering both triangle-angle-sum-oq-06 and oq-07). The mathematical content beyond Mathlib is the triangle half-angle products sin A + sin B + sin C = 4cos(A/2)cos(B/2)cos(C/2) and cos A + cos B + cos C = 1 + 4sin(A/2)sin(B/2)sin(C/2), which hold precisely under A+B+C=π and which Mathlib does not record. The proof reduces each to a single complementarity, (A+B)/2 = π/2 − C/2, after which the residue is purely Pythagorean. A natural follow-up is the tangent form tan A + tan B + tan C = tan A·tan B·tan C for a triangle, or the product side of Mollweide's / Newton's formulas relating the sides and half-angles.",
+  "crossReferences": [
+    "triangle-angle-sum-oq-04",
+    "triangle-angle-sum-oq-05",
+    "triangle-angle-sum-oq-07"
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes the **four sum-to-product (prosthaphaeresis) identities** and their two **triangle half-angle product** corollaries — covering both `triangle-angle-sum-oq-06` (cos+cos) and `triangle-angle-sum-oq-07` (sin+sin).

```
cos x + cos y =  2·cos((x+y)/2)·cos((x−y)/2)
cos x − cos y = −2·sin((x+y)/2)·sin((x−y)/2)
sin x + sin y =  2·sin((x+y)/2)·cos((x−y)/2)
sin x − sin y =  2·cos((x+y)/2)·sin((x−y)/2)
```

The substantive content beyond Mathlib is the pair of triangle half-angle products (Mathlib records the four sum-to-product identities but **not** these), for `A + B + C = π`:

```
sin A + sin B + sin C = 4·cos(A/2)·cos(B/2)·cos(C/2)
cos A + cos B + cos C = 1 + 4·sin(A/2)·sin(B/2)·sin(C/2)
```

proved first in general `a+b+c=π/2` half-angle form, then specialised to the triangle, with the equilateral instance `3·sin(π/3) = 4·cos(π/6)³` as a worked example.

## Verification
- **8 theorems, 0 sorry, 0 axiom declarations, 0 native_decide**
- Docker build verified green (1855 jobs, 0 warnings)
- Depends only on foundational `propext` / `Classical.choice` / `Quot.sound`; no `Lean.ofReduceBool`
- `status: verified`, `badge: original`

## Files
- `proofs/Proofs/TriangleAngleSumOQ06.lean` (175 lines)
- `src/data/proofs/triangle-angle-sum-oq-06/{meta.json,annotations.json}`
- registered in `proofs/Proofs.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)