### PR TITLE
research(gamma-reflection-formula-oq-01): Euler reflection formula + special-value products (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs/GammaReflectionFormulaOQ01.lean
+++ b/proofs/Proofs/GammaReflectionFormulaOQ01.lean
@@ -1,0 +1,108 @@
+import Mathlib
+
+/-!
+# Euler's reflection formula and its special-value products
+
+Euler's reflection formula states that for all real (and complex) `s`,
+`Γ(s) · Γ(1 - s) = π / sin(π s)`.
+
+The core identity is Mathlib's `Real.Gamma_mul_Gamma_one_sub` /
+`Complex.Gamma_mul_Gamma_one_sub`; this file re-exports it under a stable name and
+then derives the genuine new content absent from Mathlib:
+
+* the **concrete special-value products** obtained by feeding rational arguments into
+  the reflection formula and evaluating `sin` at the corresponding special angles —
+  `Γ(1/2)² = π`, `Γ(1/4)·Γ(3/4) = π√2`, `Γ(1/3)·Γ(2/3) = 2π/√3`,
+  `Γ(1/6)·Γ(5/6) = 2π`. Reflection evaluates these products exactly even though the
+  individual values `Γ(1/4)`, `Γ(1/3)`, … are not elementary.
+* the **non-vanishing corollary**: whenever `sin(π s) ≠ 0` (in particular when `s` is
+  not an integer), `Γ s ≠ 0`, read off directly from the reflection identity.
+
+All results are fully machine-checked. The headline reflection identity is delegated
+to Mathlib (hence the `mathlib` badge); the special-value products and the
+sin-based non-vanishing argument are derived here.
+-/
+
+namespace GammaReflectionFormulaOQ01
+
+open Real
+
+/-! ## The reflection formula (re-exported) -/
+
+/-- **Euler's reflection formula** for the real Gamma function:
+`Γ(s) · Γ(1 - s) = π / sin(π s)`. -/
+theorem gamma_reflection (s : ℝ) :
+    Gamma s * Gamma (1 - s) = π / sin (π * s) :=
+  Real.Gamma_mul_Gamma_one_sub s
+
+/-- **Euler's reflection formula** for the complex Gamma function. -/
+theorem gamma_reflection_complex (z : ℂ) :
+    Complex.Gamma z * Complex.Gamma (1 - z) = (π : ℂ) / Complex.sin ((π : ℂ) * z) :=
+  Complex.Gamma_mul_Gamma_one_sub z
+
+/-! ## Concrete special-value products
+
+These are obtained by specializing the reflection formula at rational `s` and
+evaluating `sin` at the resulting special angle. None of these product evaluations
+are in Mathlib. -/
+
+/-- `Γ(1/2)² = π`, recovered from reflection at `s = 1/2` (where `sin(π/2) = 1`).
+This is the squared form of `Γ(1/2) = √π`, here obtained purely from the reflection
+identity without the Gaussian integral. -/
+theorem gamma_half_sq : Gamma (1 / 2) ^ 2 = π := by
+  have h := Real.Gamma_mul_Gamma_one_sub (1 / 2)
+  rw [show (1 : ℝ) - 1 / 2 = 1 / 2 by norm_num, show π * (1 / 2) = π / 2 by ring,
+    Real.sin_pi_div_two] at h
+  rw [pow_two, h, div_one]
+
+/-- `Γ(1/4) · Γ(3/4) = π√2`, from reflection at `s = 1/4` (where `sin(π/4) = √2/2`). -/
+theorem gamma_quarter_mul : Gamma (1 / 4) * Gamma (3 / 4) = π * Real.sqrt 2 := by
+  have h := Real.Gamma_mul_Gamma_one_sub (1 / 4)
+  rw [show (1 : ℝ) - 1 / 4 = 3 / 4 by norm_num, show π * (1 / 4) = π / 4 by ring,
+    Real.sin_pi_div_four] at h
+  rw [h, div_div_eq_mul_div, div_eq_iff (show Real.sqrt 2 ≠ 0 by positivity),
+    mul_assoc, Real.mul_self_sqrt (show (0 : ℝ) ≤ 2 by norm_num)]
+
+/-- `Γ(1/3) · Γ(2/3) = 2π/√3`, from reflection at `s = 1/3` (where `sin(π/3) = √3/2`). -/
+theorem gamma_third_mul : Gamma (1 / 3) * Gamma (2 / 3) = 2 * π / Real.sqrt 3 := by
+  have h := Real.Gamma_mul_Gamma_one_sub (1 / 3)
+  rw [show (1 : ℝ) - 1 / 3 = 2 / 3 by norm_num, show π * (1 / 3) = π / 3 by ring,
+    Real.sin_pi_div_three] at h
+  rw [h, div_div_eq_mul_div]
+  ring
+
+/-- `Γ(1/6) · Γ(5/6) = 2π`, from reflection at `s = 1/6` (where `sin(π/6) = 1/2`). -/
+theorem gamma_sixth_mul : Gamma (1 / 6) * Gamma (5 / 6) = 2 * π := by
+  have h := Real.Gamma_mul_Gamma_one_sub (1 / 6)
+  rw [show (1 : ℝ) - 1 / 6 = 5 / 6 by norm_num, show π * (1 / 6) = π / 6 by ring,
+    Real.sin_pi_div_six] at h
+  rw [h]
+  ring
+
+/-! ## Non-vanishing via reflection -/
+
+/-- If `sin(π s) ≠ 0` then `Γ s ≠ 0`: the reflection identity forces the product
+`Γ(s) · Γ(1 - s)` to equal the nonzero quantity `π / sin(π s)`, so neither factor can
+vanish. -/
+theorem gamma_ne_zero_of_sin_ne_zero {s : ℝ} (hs : sin (π * s) ≠ 0) :
+    Gamma s ≠ 0 := by
+  intro hz
+  have h := Real.Gamma_mul_Gamma_one_sub s
+  rw [hz, zero_mul] at h
+  exact div_ne_zero pi_ne_zero hs h.symm
+
+/-- The Gamma function does not vanish at any non-integer real argument, derived from
+reflection: a non-integer argument makes `sin(π s) ≠ 0`. -/
+theorem gamma_ne_zero_of_not_int {s : ℝ} (hs : ∀ n : ℤ, (n : ℝ) ≠ s) :
+    Gamma s ≠ 0 := by
+  apply gamma_ne_zero_of_sin_ne_zero
+  intro hsin
+  rw [Real.sin_eq_zero_iff] at hsin
+  obtain ⟨n, hn⟩ := hsin
+  -- `hn : (n : ℝ) * π = π * s`
+  apply hs n
+  have hpi : (π : ℝ) ≠ 0 := pi_ne_zero
+  have h2 : (n : ℝ) * π = s * π := by linear_combination hn
+  exact mul_right_cancel₀ hpi h2
+
+end GammaReflectionFormulaOQ01

--- a/research/problems/gamma-reflection-formula-oq-01/knowledge.md
+++ b/research/problems/gamma-reflection-formula-oq-01/knowledge.md
@@ -1,0 +1,48 @@
+# Euler's reflection formula: Γ(s)·Γ(1−s) = π / sin(πs)
+
+## Summary
+
+Reflection formula as a gallery entry. The core identity is Mathlib's
+`Real.Gamma_mul_Gamma_one_sub` / `Complex.Gamma_mul_Gamma_one_sub`. Mathlib already
+has the identity, the non-vanishing lemma `Real.Gamma_ne_zero` (for arguments avoiding
+non-positive integers), and `Real.Gamma_one_half_eq : Γ(1/2) = √π`. The genuine new
+content is the set of **concrete special-value products** that reflection evaluates
+exactly even though the individual values are non-elementary, plus a clean sin-based
+non-vanishing derivation.
+
+## Session 2026-06-20 (Session 1) — FRESH
+
+**Mode**: FRESH
+**Outcome**: completed (build pending at time of writing)
+
+### What I Did
+- Claimed the problem; verified all vehicle/support lemmas against Mathlib v4.x source
+  before building (expensive cold-cache full-Mathlib build).
+- Wrote `proofs/Proofs/GammaReflectionFormulaOQ01.lean` (108 lines, 8 theorems, 0 sorry,
+  0 axiom declarations).
+
+### Key Findings
+- Mathlib already provides reflection (real + complex), the non-vanishing lemma
+  `Real.Gamma_ne_zero {s} (∀ m:ℕ, s ≠ -m)`, and `Real.Gamma_one_half_eq`. So a bare
+  re-export would be a thin wrapper. The honest novel content is the concrete product
+  evaluations, absent from Mathlib:
+  - `Γ(1/2)² = π`  (sin(π/2)=1)
+  - `Γ(1/4)·Γ(3/4) = π√2`  (sin(π/4)=√2/2)
+  - `Γ(1/3)·Γ(2/3) = 2π/√3`  (sin(π/3)=√3/2)
+  - `Γ(1/6)·Γ(5/6) = 2π`  (sin(π/6)=1/2)
+- The deterministic proof pattern for each: specialize `Real.Gamma_mul_Gamma_one_sub`,
+  `rw` the `1 - s` and `π * s` numerals, rewrite the special sin value, then close with
+  `div_div_eq_mul_div` + (`ring` | `div_eq_iff` + `mul_assoc` + `Real.mul_self_sqrt`).
+- Non-vanishing read straight off reflection: if `sin(π s) ≠ 0` the product equals the
+  nonzero `π/sin(π s)`, so `Γ s ≠ 0` (`gamma_ne_zero_of_sin_ne_zero`); specialized to
+  non-integer `s` via `Real.sin_eq_zero_iff` (`gamma_ne_zero_of_not_int`).
+
+### Files Modified
+- proofs/Proofs/GammaReflectionFormulaOQ01.lean (new)
+- src/data/proofs/gamma-reflection-formula-oq-01/meta.json (new)
+
+### Next Steps
+- If build green: `#print axioms`, finalize meta, open PR.
+- Follow-ups: Beta-function value B(1/2,1/2)=π via reflection; the `1/Γ` entire-function
+  picture; Γ(1/4) individual value via the lemniscate constant (much harder, likely not
+  in Mathlib).

--- a/src/data/proofs/gamma-reflection-formula-oq-01/meta.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01/meta.json
@@ -1,0 +1,121 @@
+{
+  "id": "gamma-reflection-formula-oq-01",
+  "slug": "gamma-reflection-formula-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "GammaReflectionFormulaOQ01",
+    "lineCount": 108,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/GammaReflectionFormulaOQ01.lean",
+    "sorries": 0
+  },
+  "title": "Euler's Reflection Formula and its Special-Value Products",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GammaReflectionFormulaOQ01.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "gamma-function",
+      "reflection-formula",
+      "euler-gamma",
+      "trigonometry",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 108,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "gamma_reflection / gamma_reflection_complex: stable re-export of Euler's reflection formula Γ(s)·Γ(1−s) = π / sin(π s) for the real and complex Gamma function (Mathlib's Real./Complex.Gamma_mul_Gamma_one_sub)",
+      "gamma_half_sq: Γ(1/2)² = π, recovered purely from reflection at s = 1/2 (sin(π/2) = 1), independent of the Gaussian-integral route Mathlib uses for Γ(1/2) = √π",
+      "gamma_quarter_mul: Γ(1/4)·Γ(3/4) = π√2, from reflection at s = 1/4 (sin(π/4) = √2/2) — the product is elementary even though the individual factors are not",
+      "gamma_third_mul: Γ(1/3)·Γ(2/3) = 2π/√3, from reflection at s = 1/3 (sin(π/3) = √3/2)",
+      "gamma_sixth_mul: Γ(1/6)·Γ(5/6) = 2π, from reflection at s = 1/6 (sin(π/6) = 1/2)",
+      "gamma_ne_zero_of_sin_ne_zero: if sin(π s) ≠ 0 then Γ s ≠ 0, read directly off the reflection identity (the product equals the nonzero π / sin(π s), so neither factor vanishes)",
+      "gamma_ne_zero_of_not_int: Γ does not vanish at any non-integer real argument, derived from the previous lemma via Real.sin_eq_zero_iff"
+    ],
+    "prerequisites": [
+      "Euler Gamma function Real.Gamma / Complex.Gamma",
+      "Mathlib's reflection formula Real.Gamma_mul_Gamma_one_sub and Complex.Gamma_mul_Gamma_one_sub",
+      "Special sine values sin(π/2), sin(π/4), sin(π/3), sin(π/6)",
+      "Real.sin_eq_zero_iff for the non-integer non-vanishing corollary"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.Gamma_mul_Gamma_one_sub",
+        "description": "Γ(s)·Γ(1−s) = π / sin(π s) for real s — Euler's reflection formula, the headline identity re-exported here.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Complex.Gamma_mul_Gamma_one_sub",
+        "description": "The complex form Γ(z)·Γ(1−z) = π / sin(π z).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Real.sin_pi_div_four / sin_pi_div_three / sin_pi_div_six / sin_pi_div_two",
+        "description": "The special sine values √2/2, √3/2, 1/2, 1 used to evaluate the reflection denominator at the rational arguments 1/4, 1/3, 1/6, 1/2.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sin_eq_zero_iff",
+        "description": "sin x = 0 ↔ ∃ n : ℤ, (n:ℝ)·π = x, used to translate 'non-integer argument' into 'sin(π s) ≠ 0' for the non-vanishing corollary.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "gamma-reflection-formula-oq-01-oq-01",
+      "question": "Derive the Beta-function value B(1/2,1/2) = π from Γ(1/2)² = π via Mathlib's Beta–Gamma relation, exhibiting the same π reflection produces as the total mass of the arcsine density on [0,1].",
+      "significance": "medium"
+    },
+    {
+      "id": "gamma-reflection-formula-oq-01-oq-02",
+      "question": "Use the non-vanishing corollary to record that 1/Γ is an entire function with zeros exactly at the non-positive integers, the analytic picture dual to reflection.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07-oq-03",
+      "relationship": "related",
+      "description": "That entry proves Γ(1/2) = √π via the Gaussian integral; here Γ(1/2)² = π is recovered independently from reflection at s = 1/2, and the special-value products extend the single √π special value to a family Γ(1/4)Γ(3/4), Γ(1/3)Γ(2/3), Γ(1/6)Γ(5/6)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gamma.Beta",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.Gamma_mul_Gamma_one_sub and Complex.Gamma_mul_Gamma_one_sub, Euler's reflection formula for the Gamma function."
+    },
+    {
+      "title": "Leonhard Euler and the Gamma function",
+      "author": "Leonhard Euler",
+      "year": "1771",
+      "venue": "historical",
+      "description": "Euler's reflection formula Γ(s)Γ(1−s) = π/sin(πs) links the Gamma function to the sine and underlies its non-vanishing and the 1/Γ entire-function picture."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Euler's reflection formula Γ(s)·Γ(1−s) = π/sin(πs) is re-exported for the real and complex Gamma function from Mathlib's Real./Complex.Gamma_mul_Gamma_one_sub. Specializing at rational arguments and evaluating the sine at the corresponding special angle yields four concrete product evaluations — Γ(1/2)² = π, Γ(1/4)·Γ(3/4) = π√2, Γ(1/3)·Γ(2/3) = 2π/√3, Γ(1/6)·Γ(5/6) = 2π — none of which are in Mathlib, where the products are elementary even though the individual factors are transcendental. Two non-vanishing results (gamma_ne_zero_of_sin_ne_zero and gamma_ne_zero_of_not_int) are read directly off the reflection identity. 108 lines, 8 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The headline reflection identity is delegated to Mathlib (hence the mathlib badge); the genuine new content is the family of concrete special-value products and the sin-based non-vanishing argument, which Mathlib does not record. The entry packages the textbook special values of the Gamma function in machine-checked form and exhibits reflection as the mechanism that evaluates non-elementary factors' products exactly.",
+    "openQuestions": [
+      "Derive B(1/2,1/2) = π from Γ(1/2)² = π via the Beta–Gamma relation.",
+      "Record 1/Γ as an entire function with zeros exactly at the non-positive integers."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Euler's reflection formula `Γ(s)·Γ(1−s) = π / sin(π s)` as a gallery entry. The headline identity is delegated to Mathlib's `Real./Complex.Gamma_mul_Gamma_one_sub` (re-exported under stable names, hence the `mathlib` badge). The **genuine new content absent from Mathlib** is:

### Concrete special-value products
Reflection evaluates these exactly even though the individual factors are transcendental:

| product | special angle |
|---|---|
| `Γ(1/2)² = π` | `sin(π/2) = 1` |
| `Γ(1/4)·Γ(3/4) = π√2` | `sin(π/4) = √2/2` |
| `Γ(1/3)·Γ(2/3) = 2π/√3` | `sin(π/3) = √3/2` |
| `Γ(1/6)·Γ(5/6) = 2π` | `sin(π/6) = 1/2` |

`Γ(1/2)² = π` is recovered purely from reflection, independent of the Gaussian-integral route Mathlib uses for `Γ(1/2) = √π`.

### Non-vanishing via reflection
- `gamma_ne_zero_of_sin_ne_zero`: `sin(π s) ≠ 0 ⟹ Γ s ≠ 0`, read directly off the identity.
- `gamma_ne_zero_of_not_int`: `Γ` does not vanish at any non-integer real argument, via `Real.sin_eq_zero_iff`.

## Verification
- 108 lines, 8 theorems, 0 definitions, **0 sorries, 0 axiom declarations**.
- No `native_decide`; only standard Mathlib lemmas → axiomCount = 0.
- Docker build green (7743 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)