### PR TITLE
research(det-conjugate-transpose-oq-01): det Mᴴ = star(det M) + Hermitian/unitary corollaries [verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -734,6 +734,7 @@ import Proofs.DescartesRuleOfSignsOQ02OQ01OQ02
 import Proofs.DescartesRuleOfSignsOQ02Parity
 import Proofs.DescartesRuleOfSignsOQ03
 import Proofs.DescartesRuleOfSignsOQ04
+import Proofs.DetConjugateTransposeOQ01
 import Proofs.DilworthMirskyHardOQ01
 import Proofs.DilworthTheoremOQ01
 import Proofs.DirichletApproximation

--- a/proofs/Proofs/DetConjugateTransposeOQ01.lean
+++ b/proofs/Proofs/DetConjugateTransposeOQ01.lean
@@ -1,0 +1,113 @@
+/-
+  Determinant of the conjugate transpose: `det Mᴴ = star (det M)`.
+
+  Over a `StarRing R` — canonically `R = ℂ` with `star` the complex conjugate —
+  taking the conjugate transpose of a square matrix conjugates its determinant:
+
+      det Mᴴ = star (det M).
+
+  This base identity is `Matrix.det_conjTranspose`; the gallery had no entry on
+  it (it is distinct from `det_mul` / `det_transpose`).  The substantive content
+  here is the pair of structural corollaries it powers, which tie the
+  adjoint/spectral structure of complex matrices to a single scalar invariant:
+
+    * **Hermitian ⟹ self-adjoint determinant.**  If `Mᴴ = M` then
+      `star (det M) = det M`: the determinant is fixed by conjugation.  Over `ℂ`
+      this says the determinant of a Hermitian matrix is a *real* number
+      (`(det M).im = 0`, equivalently `det M = (r : ℂ)` for some `r : ℝ`) — the
+      scalar shadow of the fact that a Hermitian operator has real spectrum.
+
+    * **Unitary ⟹ determinant on the unit circle.**  If `Uᴴ * U = 1` then,
+      applying `det` to both sides, `star (det U) * det U = 1`, hence
+      `‖det U‖ = 1`: the determinant of a unitary matrix lies on the unit circle.
+      This is the `det : U(n) → U(1)` picture in one line.
+
+  Verified: 0 sorries, 0 axioms (only the foundational propext / Classical.choice
+  / Quot.sound; no native_decide, no Lean.ofReduceBool).
+-/
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.LinearAlgebra.Matrix.Hermitian
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+import Mathlib.Tactic
+
+open Matrix
+
+namespace DetConjugateTransposeOQ01
+
+/-! ### The base identity -/
+
+/-- **Determinant of the conjugate transpose**: over a `StarRing R`,
+`det Mᴴ = star (det M)`.  This re-exports `Matrix.det_conjTranspose`; the
+corollaries below are the original content. -/
+theorem det_conjTranspose {R : Type*} [CommRing R] [StarRing R]
+    {n : Type*} [Fintype n] [DecidableEq n] (M : Matrix n n R) :
+    (Mᴴ).det = star M.det :=
+  Matrix.det_conjTranspose M
+
+/-! ### Hermitian matrices: the determinant is self-adjoint -/
+
+/-- If `M` is Hermitian (`Mᴴ = M`) then its determinant is self-adjoint:
+`star (det M) = det M`.  The determinant is fixed by the conjugation `star`. -/
+theorem isSelfAdjoint_det_of_isHermitian {R : Type*} [CommRing R] [StarRing R]
+    {n : Type*} [Fintype n] [DecidableEq n] {M : Matrix n n R}
+    (hM : M.IsHermitian) : IsSelfAdjoint (det M) := by
+  -- `det Mᴴ = star (det M)`, and `Mᴴ = M`, so `det M = star (det M)`.
+  have h := Matrix.det_conjTranspose M
+  rw [hM.eq] at h
+  exact h.symm
+
+/-- Over `ℂ`, the determinant of a Hermitian matrix has zero imaginary part:
+`(det M).im = 0`.  (The scalar form of "Hermitian operators have real
+spectrum".) -/
+theorem isHermitian_det_im_zero {n : Type*} [Fintype n] [DecidableEq n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) : (det M).im = 0 := by
+  have h := isSelfAdjoint_det_of_isHermitian hM
+  rw [isSelfAdjoint_iff, ← starRingEnd_apply] at h
+  exact Complex.conj_eq_iff_im.mp h
+
+/-- Over `ℂ`, the determinant of a Hermitian matrix is real: it equals
+`(r : ℂ)` for some real `r`. -/
+theorem isHermitian_det_isReal {n : Type*} [Fintype n] [DecidableEq n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) : ∃ r : ℝ, det M = (r : ℂ) := by
+  have h := isSelfAdjoint_det_of_isHermitian hM
+  rw [isSelfAdjoint_iff, ← starRingEnd_apply] at h
+  exact Complex.conj_eq_iff_real.mp h
+
+/-! ### Unitary matrices: the determinant lies on the unit circle -/
+
+/-- If `Uᴴ * U = 1` (i.e. `U` is unitary) then `star (det U) * det U = 1`.
+Obtained by applying `det` to the unitarity relation and using `det_mul`,
+`det_conjTranspose`, `det_one`. -/
+theorem star_det_mul_det_of_unitary {n : Type*} [Fintype n] [DecidableEq n]
+    {U : Matrix n n ℂ} (hU : Uᴴ * U = 1) : star (det U) * det U = 1 := by
+  have h := congrArg det hU
+  rwa [det_mul, Matrix.det_conjTranspose, det_one] at h
+
+/-- **Unitary determinant has modulus one**: if `Uᴴ * U = 1` then `‖det U‖ = 1`,
+so `det U` lies on the unit circle.  This is `det : U(n) → U(1)`. -/
+theorem unitary_det_norm_one {n : Type*} [Fintype n] [DecidableEq n]
+    {U : Matrix n n ℂ} (hU : Uᴴ * U = 1) : ‖det U‖ = 1 := by
+  have hz : star (det U) * det U = 1 := star_det_mul_det_of_unitary hU
+  -- Take norms: `‖star z‖ * ‖z‖ = 1`, i.e. `‖z‖² = 1`.
+  have hsq : ‖det U‖ * ‖det U‖ = 1 := by
+    have h2 := congrArg norm hz
+    rwa [norm_mul, norm_star, norm_one] at h2
+  -- `(‖z‖ - 1)(‖z‖ + 1) = 0` and `‖z‖ ≥ 0` force `‖z‖ = 1`.
+  have hfac : (‖det U‖ - 1) * (‖det U‖ + 1) = 0 := by linear_combination hsq
+  rcases mul_eq_zero.mp hfac with h | h
+  · linarith
+  · linarith [norm_nonneg (det U)]
+
+/-! ### Worked instances -/
+
+/-- The identity matrix is Hermitian, so its determinant (which is `1`) is real:
+`(det 1).im = 0`. -/
+example : (det (1 : Matrix (Fin 2) (Fin 2) ℂ)).im = 0 :=
+  isHermitian_det_im_zero Matrix.isHermitian_one
+
+/-- The identity matrix is unitary, so its determinant lies on the unit circle:
+`‖det 1‖ = 1`. -/
+example : ‖det (1 : Matrix (Fin 2) (Fin 2) ℂ)‖ = 1 :=
+  unitary_det_norm_one (by simp)
+
+end DetConjugateTransposeOQ01

--- a/research/problems/det-conjugate-transpose-oq-01/problem.md
+++ b/research/problems/det-conjugate-transpose-oq-01/problem.md
@@ -1,0 +1,42 @@
+# Problem: Determinant of the conjugate transpose: det(Mᴴ) = conj(det M)
+
+## Statement
+
+### Plain Language
+AVAILABLE: over a StarRing R (canonically R = ℂ), for any square matrix M, det(Mᴴ) = star(det M) — the determinant of the conjugate transpose is the complex conjugate of the determinant.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: A
+significance: 7
+tractability: 7
+tags:
+  - linear-algebra
+  - matrix
+  - determinant
+  - conjugate-transpose
+  - hermitian
+  - unitary
+  - star-ring
+  - seeker-selected
+  - research
+```
+
+**Significance**: 7/10
+**Tractability**: 7/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE: over a StarRing R (canonically R = ℂ), for any square matrix M, det(Mᴴ) = star(det M) — the determinant of the conjugate transpose is the complex conjugate of the determinant
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/det-conjugate-transpose-oq-01/state.md
+++ b/research/problems/det-conjugate-transpose-oq-01/state.md
@@ -1,0 +1,28 @@
+# Current State
+
+**Phase**: COMPLETED
+**Since**: 2026-06-20
+**Iteration**: 2
+
+## Current Focus
+
+Solved. det Mᴴ = star (det M) packaged with Hermitian (real determinant) and
+unitary (unit-circle determinant) corollaries.
+
+## Active Approach
+
+DONE — see proofs/Proofs/DetConjugateTransposeOQ01.lean (verified, 0 sorries, 0 axioms).
+
+## Blockers
+
+None.
+
+## Next Action
+
+Shipped. Follow-ups: characterise SU(n) (det U = 1), or det O = ±1 for real orthogonal O.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/det-conjugate-transpose-oq-01/annotations.json
+++ b/src/data/proofs/det-conjugate-transpose-oq-01/annotations.json
@@ -1,0 +1,91 @@
+[
+  {
+    "id": "ann-base-identity",
+    "proofId": "det-conjugate-transpose-oq-01",
+    "range": {
+      "startLine": 37,
+      "endLine": 45
+    },
+    "type": "theorem",
+    "title": "The Base Identity (det_conjTranspose)",
+    "content": "det_conjTranspose states that over a commutative StarRing R, det Mᴴ = star (det M): the determinant of the conjugate transpose is the conjugate of the determinant. It re-exports Mathlib's Matrix.det_conjTranspose, anchored here as the building block for the Hermitian and unitary corollaries. Canonically R = ℂ and star is complex conjugation, so this reads det Mᴴ = conj(det M).",
+    "mathContext": "$\\det(M^{\\mathsf H}) = \\overline{\\det M}$.",
+    "prerequisites": [
+      "The conjugate transpose Mᴴ on matrices over a StarRing",
+      "Matrix.det and Matrix.det_conjTranspose"
+    ],
+    "relatedConcepts": [
+      "conjugate transpose / adjoint",
+      "determinant",
+      "star ring"
+    ],
+    "significance": "The single scalar equation from which both the Hermitian (real determinant) and unitary (unit-circle determinant) corollaries are read off, with no further matrix computation."
+  },
+  {
+    "id": "ann-hermitian-real-det",
+    "proofId": "det-conjugate-transpose-oq-01",
+    "range": {
+      "startLine": 47,
+      "endLine": 74
+    },
+    "type": "theorem",
+    "title": "Hermitian ⟹ Self-Adjoint, Real Determinant (isSelfAdjoint_det_of_isHermitian, isHermitian_det_im_zero, isHermitian_det_isReal)",
+    "content": "isSelfAdjoint_det_of_isHermitian takes the base identity det Mᴴ = star (det M) and rewrites it by the Hermitian relation Mᴴ = M (Matrix.IsHermitian.eq), giving det M = star (det M); symmetrised, this is IsSelfAdjoint (det M) — the determinant is fixed by the conjugation star. Over ℂ, where star is complex conjugation (starRingEnd ℂ via starRingEnd_apply), self-conjugacy means reality: isHermitian_det_im_zero applies Complex.conj_eq_iff_im to conclude (det M).im = 0, and isHermitian_det_isReal applies Complex.conj_eq_iff_real to produce a real r with det M = (r : ℂ). This is the determinant's share of the real-spectrum property of Hermitian operators: the product of the eigenvalues is real, obtained without spectral machinery.",
+    "mathContext": "$M^{\\mathsf H}=M \\Rightarrow \\overline{\\det M}=\\det M$, hence over $\\mathbb C$, $\\operatorname{Im}\\det M = 0$ and $\\det M = r$ for some $r\\in\\mathbb R$.",
+    "prerequisites": [
+      "Matrix.IsHermitian (Mᴴ = M) and IsHermitian.eq",
+      "IsSelfAdjoint and isSelfAdjoint_iff",
+      "Complex.conj_eq_iff_im, Complex.conj_eq_iff_real and starRingEnd_apply (star = starRingEnd ℂ)"
+    ],
+    "relatedConcepts": [
+      "Hermitian matrix",
+      "self-adjoint element",
+      "real spectrum"
+    ],
+    "significance": "Shows that the determinant of a Hermitian matrix is real — the scalar shadow of the spectral theorem — derived purely from how the determinant transforms under the adjoint."
+  },
+  {
+    "id": "ann-unitary-unit-circle",
+    "proofId": "det-conjugate-transpose-oq-01",
+    "range": {
+      "startLine": 76,
+      "endLine": 99
+    },
+    "type": "theorem",
+    "title": "Unitary ⟹ Determinant on the Unit Circle (star_det_mul_det_of_unitary, unitary_det_norm_one)",
+    "content": "star_det_mul_det_of_unitary applies det to the unitarity relation Uᴴ * U = 1: rewriting with Matrix.det_mul, Matrix.det_conjTranspose and Matrix.det_one turns det(Uᴴ * U) = det 1 into star (det U) * det U = 1. unitary_det_norm_one then takes norms of both sides — norm_mul, norm_star, norm_one collapse the left to ‖det U‖ · ‖det U‖ = 1, i.e. ‖det U‖² = 1 — and factors (‖det U‖ − 1)(‖det U‖ + 1) = 0 by linear_combination; since ‖det U‖ ≥ 0 (norm_nonneg) the factor ‖det U‖ + 1 is positive, forcing ‖det U‖ = 1. The determinant of a unitary matrix lies on the unit circle: this is the homomorphism det : U(n) → U(1), whose kernel is the special unitary group SU(n).",
+    "mathContext": "$U^{\\mathsf H}U=1 \\Rightarrow \\overline{\\det U}\\,\\det U = 1$, hence $\\lVert\\det U\\rVert = 1$.",
+    "prerequisites": [
+      "Matrix.det_mul, Matrix.det_conjTranspose, Matrix.det_one",
+      "The norm lemmas norm_mul, norm_star, norm_one, norm_nonneg on ℂ",
+      "The linear_combination tactic and mul_eq_zero"
+    ],
+    "relatedConcepts": [
+      "unitary matrix",
+      "unit circle / U(1)",
+      "special unitary group SU(n)"
+    ],
+    "significance": "Establishes the determinant homomorphism det : U(n) → U(1) in one line, the structural fact underlying the SU(n) ⊂ U(n) decomposition."
+  },
+  {
+    "id": "ann-worked-instances",
+    "proofId": "det-conjugate-transpose-oq-01",
+    "range": {
+      "startLine": 101,
+      "endLine": 112
+    },
+    "type": "example",
+    "title": "Worked Instances at the Identity Matrix",
+    "content": "The identity matrix 1 is both Hermitian (Matrix.isHermitian_one) and unitary (1ᴴ * 1 = 1 by simp), so both corollaries apply to it. The first example obtains (det 1).im = 0 from isHermitian_det_im_zero and the second obtains ‖det 1‖ = 1 from unitary_det_norm_one — concrete witnesses that det 1 = 1 is real and lies on the unit circle.",
+    "mathContext": "$(\\det \\mathbf 1).\\operatorname{Im} = 0$ and $\\lVert\\det \\mathbf 1\\rVert = 1$.",
+    "prerequisites": [
+      "Matrix.isHermitian_one",
+      "The corollaries isHermitian_det_im_zero and unitary_det_norm_one"
+    ],
+    "relatedConcepts": [
+      "identity matrix",
+      "worked example"
+    ],
+    "significance": "Grounds both abstract corollaries in the simplest concrete matrix, where the determinant is visibly 1."
+  }
+]

--- a/src/data/proofs/det-conjugate-transpose-oq-01/meta.json
+++ b/src/data/proofs/det-conjugate-transpose-oq-01/meta.json
@@ -1,0 +1,95 @@
+{
+  "id": "det-conjugate-transpose-oq-01",
+  "title": "Determinant of the Conjugate Transpose: det Mᴴ = star (det M), with the Hermitian and Unitary Corollaries",
+  "slug": "det-conjugate-transpose-oq-01",
+  "description": "Over a StarRing R — canonically R = ℂ with star the complex conjugate — taking the conjugate transpose of a square matrix conjugates its determinant: det Mᴴ = star (det M). This base identity is Mathlib's Matrix.det_conjTranspose (the gallery had no entry on it; it is distinct from det_mul / det_transpose). The substantive content is the pair of structural corollaries it powers, tying the adjoint/spectral structure of complex matrices to the single scalar invariant det. (1) Hermitian ⟹ self-adjoint determinant: if Mᴴ = M then star (det M) = det M, i.e. the determinant is fixed by conjugation; over ℂ this says the determinant of a Hermitian matrix is real — (det M).im = 0, equivalently det M = (r : ℂ) for some r : ℝ — the scalar shadow of the real-spectrum property of Hermitian operators. (2) Unitary ⟹ determinant on the unit circle: if Uᴴ * U = 1 then applying det to both sides gives star (det U) * det U = 1, hence ‖det U‖ = 1 — the det : U(n) → U(1) homomorphism in one line. The identity matrix witnesses both: det 1 = 1 is real and has modulus one.",
+  "leanFile": "Proofs/DetConjugateTransposeOQ01.lean",
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Conjugate_transpose",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DetConjugateTransposeOQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "matrix",
+      "determinant",
+      "conjugate-transpose",
+      "hermitian",
+      "unitary",
+      "star-ring"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "relatedProblems": [
+      {
+        "id": "cramers-rule-oq-05",
+        "relationship": "Sibling determinant invariants: cramers-rule-oq-05 studies det/trace/charpoly as similarity invariants (invariance under unit conjugation); this entry studies how the determinant transforms under the conjugate transpose (det Mᴴ = star det M) and the Hermitian/unitary consequences."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 113,
+    "assumptions": "0 axioms, 0 sorries, no native_decide, no Lean.ofReduceBool. All theorems depend only on the foundational propext / Classical.choice / Quot.sound. The base identity det Mᴴ = star (det M) re-exports Mathlib's Matrix.det_conjTranspose. The Hermitian corollary uses Matrix.IsHermitian.eq (Mᴴ = M) and, over ℂ, Complex.conj_eq_iff_im / Complex.conj_eq_iff_real to read off reality from self-conjugacy (star = starRingEnd ℂ via starRingEnd_apply). The unitary corollary applies det to Uᴴ * U = 1 using Matrix.det_mul, Matrix.det_conjTranspose, Matrix.det_one to get star (det U) * det U = 1, takes norms with norm_mul / norm_star / norm_one to obtain ‖det U‖² = 1, and concludes ‖det U‖ = 1 by factoring (‖det U‖−1)(‖det U‖+1)=0 (linear_combination) together with norm_nonneg. The genuine hypotheses are the domain conditions M.IsHermitian and Uᴴ * U = 1.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The conjugate transpose Mᴴ (adjoint) is the defining operation of the theory of complex matrices: Hermitian matrices (Mᴴ = M) are the complex analogue of real symmetric matrices and model observables in quantum mechanics, while unitary matrices (Uᴴ U = 1) are the complex analogue of orthogonal matrices and model reversible quantum evolution. The determinant is the basic scalar invariant of a matrix, and its behaviour under the adjoint — det Mᴴ = conj(det M) — is the bridge between these two worlds: it forces the determinant of a Hermitian matrix to be real (the scalar trace of the spectral theorem's real-eigenvalue conclusion) and confines the determinant of a unitary matrix to the unit circle (the determinant homomorphism U(n) → U(1) whose kernel is the special unitary group SU(n)).",
+    "problemStatement": "Over a StarRing R, prove that the determinant of the conjugate transpose is the conjugate of the determinant,\n\n$$\\det(M^{\\mathsf H}) = \\overline{\\det M},$$\n\nand derive its two structural corollaries: for a Hermitian matrix ($M^{\\mathsf H} = M$) the determinant is self-adjoint, so over $\\mathbb C$ it is real ($\\operatorname{Im}\\det M = 0$); and for a unitary matrix ($U^{\\mathsf H}U = 1$) the determinant lies on the unit circle ($\\lVert\\det U\\rVert = 1$).",
+    "text": "Mathlib records the base identity Matrix.det_conjTranspose : det Mᴴ = star (det M) but the gallery had no entry on it and no entry deriving its Hermitian/unitary consequences. This entry anchors the identity and proves the two corollaries that give it structural meaning: the determinant of a Hermitian matrix is real, and the determinant of a unitary matrix has modulus one.",
+    "proofStrategy": "The base identity det_conjTranspose re-exports Matrix.det_conjTranspose. The Hermitian corollary isSelfAdjoint_det_of_isHermitian rewrites det Mᴴ = star (det M) by the Hermitian relation Mᴴ = M (Matrix.IsHermitian.eq) to obtain det M = star (det M), i.e. IsSelfAdjoint (det M). Over ℂ this is specialised two ways: isHermitian_det_im_zero converts star to starRingEnd ℂ (starRingEnd_apply) and applies Complex.conj_eq_iff_im to conclude (det M).im = 0, while isHermitian_det_isReal applies Complex.conj_eq_iff_real to produce a real r with det M = (r : ℂ). The unitary corollary first establishes star_det_mul_det_of_unitary: applying det to Uᴴ * U = 1 and rewriting with Matrix.det_mul, Matrix.det_conjTranspose, Matrix.det_one gives star (det U) * det U = 1. Then unitary_det_norm_one takes norms — norm_mul, norm_star, norm_one collapse the left side to ‖det U‖ · ‖det U‖ = 1 — and factors (‖det U‖ − 1)(‖det U‖ + 1) = 0 by linear_combination; since ‖det U‖ ≥ 0 (norm_nonneg) the second factor is positive, forcing ‖det U‖ = 1. The two worked examples instantiate both corollaries at the identity matrix (Hermitian and unitary), recovering that det 1 = 1 is real and lies on the unit circle.",
+    "keyInsights": [
+      "**The adjoint acts on the determinant by a single scalar conjugation**: det Mᴴ = star (det M). All the structure that follows is read off this one equation by specialising the matrix relation between M and Mᴴ — there is no further matrix computation, only scalar algebra in the determinant.",
+      "**Hermitian self-adjointness of the scalar is the determinant's share of the real-spectrum theorem**: Mᴴ = M forces star (det M) = det M, so over ℂ the determinant — which is the product of the eigenvalues — has zero imaginary part. This is exactly what one expects from the spectral theorem (real eigenvalues ⟹ real product), obtained here without any spectral machinery.",
+      "**Unitarity confines the determinant to the unit circle**: from Uᴴ U = 1, taking determinants gives star (det U) · det U = 1, i.e. ‖det U‖² = 1. This is the determinant homomorphism det : U(n) → U(1); its kernel is the special unitary group SU(n). The proof needs only det_mul and the base identity, plus the elementary fact that a nonnegative real with square 1 equals 1.",
+      "**StarRing is the right generality for the base identity, ℂ for the payoff**: det Mᴴ = star (det M) holds over any commutative StarRing, but 'the determinant is real' and 'the determinant lies on the unit circle' are statements about ℂ, where star is complex conjugation and the norm measures distance to the unit circle. The entry separates the two layers."
+    ],
+    "prerequisites": [
+      "The conjugate transpose Mᴴ and the determinant det on square matrices (Matrix.det)",
+      "Matrix.det_conjTranspose, Matrix.det_mul, Matrix.det_one",
+      "The Hermitian predicate Matrix.IsHermitian (Mᴴ = M) and IsHermitian.eq",
+      "Over ℂ: star = starRingEnd ℂ (complex conjugation), Complex.conj_eq_iff_im / Complex.conj_eq_iff_real, and the norm lemmas norm_mul / norm_star / norm_one / norm_nonneg"
+    ]
+  },
+  "sections": [
+    {
+      "id": "base-identity",
+      "title": "The Base Identity det Mᴴ = star (det M)",
+      "startLine": 37,
+      "endLine": 45,
+      "mathContext": "$\\det(M^{\\mathsf H}) = \\overline{\\det M}$ over a StarRing.",
+      "summary": "det_conjTranspose re-exports Matrix.det_conjTranspose: over a commutative StarRing R, the determinant of the conjugate transpose equals the conjugate (star) of the determinant. This is the building block for the Hermitian and unitary corollaries."
+    },
+    {
+      "id": "hermitian-real-det",
+      "title": "Hermitian Matrices: the Determinant is Self-Adjoint (Real over ℂ)",
+      "startLine": 47,
+      "endLine": 74,
+      "mathContext": "$M^{\\mathsf H}=M \\Rightarrow \\overline{\\det M}=\\det M$; over $\\mathbb C$, $\\operatorname{Im}\\det M = 0$.",
+      "summary": "isSelfAdjoint_det_of_isHermitian rewrites the base identity by Mᴴ = M to conclude IsSelfAdjoint (det M) — the determinant is fixed by conjugation. Over ℂ, isHermitian_det_im_zero (via Complex.conj_eq_iff_im) gives (det M).im = 0 and isHermitian_det_isReal (via Complex.conj_eq_iff_real) gives det M = (r : ℂ) for a real r: the determinant of a Hermitian matrix is real."
+    },
+    {
+      "id": "unitary-unit-circle",
+      "title": "Unitary Matrices: the Determinant Lies on the Unit Circle",
+      "startLine": 76,
+      "endLine": 99,
+      "mathContext": "$U^{\\mathsf H}U=1 \\Rightarrow \\lVert\\det U\\rVert = 1$.",
+      "summary": "star_det_mul_det_of_unitary applies det to Uᴴ * U = 1 (det_mul, det_conjTranspose, det_one) to get star (det U) · det U = 1. unitary_det_norm_one takes norms — norm_mul, norm_star, norm_one give ‖det U‖² = 1 — and factors (‖det U‖−1)(‖det U‖+1)=0 with norm_nonneg to conclude ‖det U‖ = 1: the determinant of a unitary matrix lies on the unit circle (the det : U(n) → U(1) map)."
+    },
+    {
+      "id": "worked-instances",
+      "title": "Worked Instances",
+      "startLine": 101,
+      "endLine": 112,
+      "mathContext": "$(\\det \\mathbf 1).\\operatorname{Im} = 0$ and $\\lVert\\det \\mathbf 1\\rVert = 1$.",
+      "summary": "The identity matrix is both Hermitian (Matrix.isHermitian_one) and unitary, so the two corollaries apply to it: det 1 = 1 is real and lies on the unit circle, exhibiting both results concretely."
+    }
+  ],
+  "conclusion": "The conjugate-transpose determinant identity det Mᴴ = star (det M) and its two structural corollaries are formalised sorry-free and axiom-free. The base identity re-exports Mathlib's Matrix.det_conjTranspose; the original content is the pair of corollaries it powers: the determinant of a Hermitian matrix is self-adjoint, hence real over ℂ (the scalar form of the real-spectrum property), and the determinant of a unitary matrix lies on the unit circle (the det : U(n) → U(1) homomorphism, whose kernel is SU(n)). A natural follow-up is the special unitary group itself — characterising U with det U = 1 — or the multiplicativity ‖det (U · V)‖ = ‖det U‖ · ‖det V‖ giving det as a group homomorphism U(n) → U(1), and the analogous orthogonal statement det O = ±1 for Oᵀ O = 1 over ℝ.",
+  "crossReferences": [
+    "cramers-rule-oq-05"
+  ]
+}

--- a/src/data/research/problems/det-conjugate-transpose-oq-01.json
+++ b/src/data/research/problems/det-conjugate-transpose-oq-01.json
@@ -1,0 +1,71 @@
+{
+  "slug": "det-conjugate-transpose-oq-01",
+  "title": "Determinant of the conjugate transpose: det(Mᴴ) = conj(det M)",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "A",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: over a StarRing R (canonically R = ℂ), for any square matrix M, det(Mᴴ) = star(det M) — the determinant of the conjugate transpose is the complex conjugate of the determinant.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-06-20T18:12:04.131Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: verified 0-axiom gallery entry — base identity + Hermitian/unitary corollaries",
+    "builtItems": [
+      "DetConjugateTransposeOQ01.lean: det_conjTranspose, isSelfAdjoint_det_of_isHermitian, isHermitian_det_im_zero, isHermitian_det_isReal, star_det_mul_det_of_unitary, unitary_det_norm_one (5 theorems + 2 examples, verified 0-axiom)"
+    ],
+    "insights": [
+      "det Mᴴ = star (det M) (Matrix.det_conjTranspose) is the single scalar equation behind both the Hermitian-real-det and unitary-unit-circle facts; no further matrix computation is needed.",
+      "Hermitian Mᴴ=M gives star(det M)=det M (IsSelfAdjoint), so over ℂ det M is real ((det M).im=0): the determinant share of the real-spectrum theorem, with no spectral machinery.",
+      "Unitary Uᴴ U=1 gives star(det U)·det U=1, hence ‖det U‖=1: the det:U(n)→U(1) homomorphism, kernel SU(n)."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Characterise SU(n) = {U : det U = 1} ⊂ U(n)",
+      "Real orthogonal analogue det O = ±1 for Oᵀ O = 1",
+      "det as group homomorphism: ‖det(UV)‖=‖det U‖‖det V‖"
+    ]
+  },
+  "tags": [
+    "linear-algebra",
+    "matrix",
+    "determinant",
+    "conjugate-transpose",
+    "hermitian",
+    "unitary",
+    "star-ring",
+    "seeker-selected",
+    "research"
+  ],
+  "relatedProofs": [],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-20T18:12:04.131Z",
+  "lastUpdate": "2026-06-20T18:12:04.131Z",
+  "significance": 7,
+  "tractability": 7
+}


### PR DESCRIPTION
## Summary

Formalizes the determinant of the conjugate transpose, **det Mᴴ = star (det M)**, over a `StarRing R` (canonically `R = ℂ`), and derives its two structural corollaries. The base identity (`Matrix.det_conjTranspose`) was absent from the gallery and is distinct from the existing `det_mul` / `det_transpose` entries; the corollaries are the original content.

## Results (`proofs/Proofs/DetConjugateTransposeOQ01.lean`)

- `det_conjTranspose` — base identity `det Mᴴ = star (det M)` (re-export).
- **Hermitian ⟹ self-adjoint / real determinant:**
  - `isSelfAdjoint_det_of_isHermitian` — `Mᴴ = M ⟹ star (det M) = det M`.
  - `isHermitian_det_im_zero` — over ℂ, `(det M).im = 0`.
  - `isHermitian_det_isReal` — over ℂ, `∃ r : ℝ, det M = (r : ℂ)`.
  - The scalar shadow of the real-spectrum property of Hermitian operators (no spectral machinery used).
- **Unitary ⟹ determinant on the unit circle:**
  - `star_det_mul_det_of_unitary` — `Uᴴ U = 1 ⟹ star (det U) · det U = 1`.
  - `unitary_det_norm_one` — `‖det U‖ = 1`. The `det : U(n) → U(1)` homomorphism (kernel `SU(n)`), via `det_mul` + norm factoring.
- Two worked instances at the identity matrix (Hermitian and unitary).

## Verification

- **0 sorries, 0 axioms**, no `native_decide`, no `Lean.ofReduceBool` (only the foundational `propext` / `Classical.choice` / `Quot.sound`).
- Built via Docker: `./proofs/scripts/docker-build.sh Proofs.DetConjugateTransposeOQ01` — `✔ Built Proofs.DetConjugateTransposeOQ01`.
- Gallery integration: `meta.json` + `annotations.json` (status `verified`, badge `original`, `axiomCount` 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)