### PR TITLE
research(matrix-posdef-sqrt-oq-01): positive semidefinite square root — existence, structure, uniqueness [verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -734,6 +734,7 @@ import Proofs.DescartesRuleOfSignsOQ02OQ01OQ02
 import Proofs.DescartesRuleOfSignsOQ02Parity
 import Proofs.DescartesRuleOfSignsOQ03
 import Proofs.DescartesRuleOfSignsOQ04
+import Proofs.DetConjugateTransposeOQ01
 import Proofs.DilworthMirskyHardOQ01
 import Proofs.DilworthTheoremOQ01
 import Proofs.DirichletApproximation

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2862,6 +2862,7 @@ import Proofs.MantelTheoremUniqueness
 import Proofs.MathematicalInduction
 import Proofs.MathematicalInductionOQ01
 import Proofs.MathematicalInductionOQ03
+import Proofs.MatrixPosDefSqrtOQ01
 import Proofs.MatrixSimilarityInvariantsOQ01
 import Proofs.MeanValueTheorem
 import Proofs.MeanValueTheoremOQ02

--- a/proofs/Proofs/DetConjugateTransposeOQ01.lean
+++ b/proofs/Proofs/DetConjugateTransposeOQ01.lean
@@ -1,0 +1,113 @@
+/-
+  Determinant of the conjugate transpose: `det Mᴴ = star (det M)`.
+
+  Over a `StarRing R` — canonically `R = ℂ` with `star` the complex conjugate —
+  taking the conjugate transpose of a square matrix conjugates its determinant:
+
+      det Mᴴ = star (det M).
+
+  This base identity is `Matrix.det_conjTranspose`; the gallery had no entry on
+  it (it is distinct from `det_mul` / `det_transpose`).  The substantive content
+  here is the pair of structural corollaries it powers, which tie the
+  adjoint/spectral structure of complex matrices to a single scalar invariant:
+
+    * **Hermitian ⟹ self-adjoint determinant.**  If `Mᴴ = M` then
+      `star (det M) = det M`: the determinant is fixed by conjugation.  Over `ℂ`
+      this says the determinant of a Hermitian matrix is a *real* number
+      (`(det M).im = 0`, equivalently `det M = (r : ℂ)` for some `r : ℝ`) — the
+      scalar shadow of the fact that a Hermitian operator has real spectrum.
+
+    * **Unitary ⟹ determinant on the unit circle.**  If `Uᴴ * U = 1` then,
+      applying `det` to both sides, `star (det U) * det U = 1`, hence
+      `‖det U‖ = 1`: the determinant of a unitary matrix lies on the unit circle.
+      This is the `det : U(n) → U(1)` picture in one line.
+
+  Verified: 0 sorries, 0 axioms (only the foundational propext / Classical.choice
+  / Quot.sound; no native_decide, no Lean.ofReduceBool).
+-/
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.LinearAlgebra.Matrix.Hermitian
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+import Mathlib.Tactic
+
+open Matrix
+
+namespace DetConjugateTransposeOQ01
+
+/-! ### The base identity -/
+
+/-- **Determinant of the conjugate transpose**: over a `StarRing R`,
+`det Mᴴ = star (det M)`.  This re-exports `Matrix.det_conjTranspose`; the
+corollaries below are the original content. -/
+theorem det_conjTranspose {R : Type*} [CommRing R] [StarRing R]
+    {n : Type*} [Fintype n] [DecidableEq n] (M : Matrix n n R) :
+    (Mᴴ).det = star M.det :=
+  Matrix.det_conjTranspose M
+
+/-! ### Hermitian matrices: the determinant is self-adjoint -/
+
+/-- If `M` is Hermitian (`Mᴴ = M`) then its determinant is self-adjoint:
+`star (det M) = det M`.  The determinant is fixed by the conjugation `star`. -/
+theorem isSelfAdjoint_det_of_isHermitian {R : Type*} [CommRing R] [StarRing R]
+    {n : Type*} [Fintype n] [DecidableEq n] {M : Matrix n n R}
+    (hM : M.IsHermitian) : IsSelfAdjoint (det M) := by
+  -- `det Mᴴ = star (det M)`, and `Mᴴ = M`, so `det M = star (det M)`.
+  have h := Matrix.det_conjTranspose M
+  rw [hM.eq] at h
+  exact h.symm
+
+/-- Over `ℂ`, the determinant of a Hermitian matrix has zero imaginary part:
+`(det M).im = 0`.  (The scalar form of "Hermitian operators have real
+spectrum".) -/
+theorem isHermitian_det_im_zero {n : Type*} [Fintype n] [DecidableEq n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) : (det M).im = 0 := by
+  have h := isSelfAdjoint_det_of_isHermitian hM
+  rw [isSelfAdjoint_iff, ← starRingEnd_apply] at h
+  exact Complex.conj_eq_iff_im.mp h
+
+/-- Over `ℂ`, the determinant of a Hermitian matrix is real: it equals
+`(r : ℂ)` for some real `r`. -/
+theorem isHermitian_det_isReal {n : Type*} [Fintype n] [DecidableEq n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) : ∃ r : ℝ, det M = (r : ℂ) := by
+  have h := isSelfAdjoint_det_of_isHermitian hM
+  rw [isSelfAdjoint_iff, ← starRingEnd_apply] at h
+  exact Complex.conj_eq_iff_real.mp h
+
+/-! ### Unitary matrices: the determinant lies on the unit circle -/
+
+/-- If `Uᴴ * U = 1` (i.e. `U` is unitary) then `star (det U) * det U = 1`.
+Obtained by applying `det` to the unitarity relation and using `det_mul`,
+`det_conjTranspose`, `det_one`. -/
+theorem star_det_mul_det_of_unitary {n : Type*} [Fintype n] [DecidableEq n]
+    {U : Matrix n n ℂ} (hU : Uᴴ * U = 1) : star (det U) * det U = 1 := by
+  have h := congrArg det hU
+  rwa [det_mul, Matrix.det_conjTranspose, det_one] at h
+
+/-- **Unitary determinant has modulus one**: if `Uᴴ * U = 1` then `‖det U‖ = 1`,
+so `det U` lies on the unit circle.  This is `det : U(n) → U(1)`. -/
+theorem unitary_det_norm_one {n : Type*} [Fintype n] [DecidableEq n]
+    {U : Matrix n n ℂ} (hU : Uᴴ * U = 1) : ‖det U‖ = 1 := by
+  have hz : star (det U) * det U = 1 := star_det_mul_det_of_unitary hU
+  -- Take norms: `‖star z‖ * ‖z‖ = 1`, i.e. `‖z‖² = 1`.
+  have hsq : ‖det U‖ * ‖det U‖ = 1 := by
+    have h2 := congrArg norm hz
+    rwa [norm_mul, norm_star, norm_one] at h2
+  -- `(‖z‖ - 1)(‖z‖ + 1) = 0` and `‖z‖ ≥ 0` force `‖z‖ = 1`.
+  have hfac : (‖det U‖ - 1) * (‖det U‖ + 1) = 0 := by linear_combination hsq
+  rcases mul_eq_zero.mp hfac with h | h
+  · linarith
+  · linarith [norm_nonneg (det U)]
+
+/-! ### Worked instances -/
+
+/-- The identity matrix is Hermitian, so its determinant (which is `1`) is real:
+`(det 1).im = 0`. -/
+example : (det (1 : Matrix (Fin 2) (Fin 2) ℂ)).im = 0 :=
+  isHermitian_det_im_zero Matrix.isHermitian_one
+
+/-- The identity matrix is unitary, so its determinant lies on the unit circle:
+`‖det 1‖ = 1`. -/
+example : ‖det (1 : Matrix (Fin 2) (Fin 2) ℂ)‖ = 1 :=
+  unitary_det_norm_one (by simp)
+
+end DetConjugateTransposeOQ01

--- a/proofs/Proofs/MatrixPosDefSqrtOQ01.lean
+++ b/proofs/Proofs/MatrixPosDefSqrtOQ01.lean
@@ -1,0 +1,140 @@
+/-
+  The positive semidefinite square root of a matrix: existence, structure,
+  and uniqueness.
+
+  Every positive semidefinite matrix `A` over `𝕜 = ℝ` or `ℂ` (`RCLike 𝕜`) has a
+  positive semidefinite square root.  Modern Mathlib supplies it through the
+  continuous functional calculus as `CFC.sqrt A` (the matrix-specific
+  `Matrix.PosSemidef.sqrt` was deprecated in favour of this C⋆-algebra version),
+  and the relevant Loewner-order instances on `Matrix n n 𝕜` are the scoped
+  `MatrixOrder` instances, under which `0 ≤ A ↔ A.PosSemidef`.
+
+  The gallery had no entry on the operator square root (it is a different object
+  from the Gram/positive-definite material and from the determinant identities).
+  The substantive content packaged here is the full characterization:
+
+    * **Defining property.**  `√A · √A = A` (equivalently `(√A)^2 = A`).
+
+    * **Structure.**  `√A` is again positive semidefinite, and in particular
+      Hermitian — the square root stays inside the cone.
+
+    * **Uniqueness.**  `√A` is the *only* positive semidefinite `B` with
+      `B · B = A`.  This is the non-trivial half: it is what makes "the" square
+      root well defined and powers the corollaries below.
+
+    * **Corollaries from uniqueness.**  `√0 = 0`, `√1 = 1`, and `√(A^2) = A`
+      for PSD `A` — each is the uniqueness statement applied to an obvious
+      candidate.
+
+    * **Determinant shadow.**  `det(√A)^2 = det A`: the square root halves the
+      determinant in the multiplicative sense (so `det A ≥ 0` is visible as a
+      square).
+
+    * **Concrete instance.**  `√ diag(4, 9) = diag(2, 3)`, computed from
+      uniqueness, cross-checking the abstract functional-calculus definition
+      against an elementary entrywise square root.
+
+  The PSD square root underlies the polar decomposition `A = (PSD)·(unitary)`,
+  the operator absolute value `|A| = √(Aᴴ A)`, and the whitening transform in
+  statistics.
+
+  Verified: 0 sorries, 0 axioms beyond the foundational `propext` /
+  `Classical.choice` / `Quot.sound`; no `native_decide`, no `Lean.ofReduceBool`.
+-/
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.Tactic
+
+open Matrix
+open scoped MatrixOrder ComplexOrder
+
+namespace MatrixPosDefSqrtOQ01
+
+variable {𝕜 : Type*} [RCLike 𝕜] {n : Type*} [Fintype n] [DecidableEq n]
+
+/-! ### Defining property: `√A` is a square root of `A` -/
+
+/-- The defining property of the square root: `√A · √A = A` for PSD `A`. -/
+theorem sqrt_mul_self (A : Matrix n n 𝕜) (hA : A.PosSemidef) :
+    CFC.sqrt A * CFC.sqrt A = A :=
+  CFC.sqrt_mul_sqrt_self A hA.nonneg
+
+/-- Equivalent statement of the defining property as a power: `(√A)^2 = A`. -/
+theorem sq_sqrt (A : Matrix n n 𝕜) (hA : A.PosSemidef) :
+    CFC.sqrt A ^ 2 = A :=
+  CFC.sq_sqrt A hA.nonneg
+
+/-! ### Structure: the square root stays in the PSD cone -/
+
+/-- The square root of any matrix is positive semidefinite.  (No hypothesis on
+`A` is needed: `CFC.sqrt` is defined via the `ℝ≥0` functional calculus, so its
+output is unconditionally nonnegative.) -/
+theorem sqrt_posSemidef (A : Matrix n n 𝕜) :
+    (CFC.sqrt A).PosSemidef :=
+  (CFC.sqrt_nonneg A).posSemidef
+
+/-- The square root is Hermitian (a special case of being positive
+semidefinite). -/
+theorem sqrt_isHermitian (A : Matrix n n 𝕜) :
+    (CFC.sqrt A).IsHermitian :=
+  (sqrt_posSemidef A).isHermitian
+
+/-! ### Uniqueness: `√A` is the unique PSD square root -/
+
+/-- **Uniqueness of the positive semidefinite square root.**  If `B` is positive
+semidefinite and `B · B = A`, then `B` *is* the square root `√A`.  Combined with
+`sqrt_mul_self` and `sqrt_posSemidef`, this says the PSD square root exists and
+is unique. -/
+theorem sqrt_unique (A B : Matrix n n 𝕜) (hB : B.PosSemidef) (h : B * B = A) :
+    CFC.sqrt A = B :=
+  CFC.sqrt_unique h hB.nonneg
+
+/-! ### Corollaries from uniqueness -/
+
+/-- `√0 = 0`: apply uniqueness to the candidate `B = 0`. -/
+theorem sqrt_zero : CFC.sqrt (0 : Matrix n n 𝕜) = 0 :=
+  sqrt_unique 0 0 .zero (by simp)
+
+/-- `√1 = 1`: apply uniqueness to the candidate `B = 1`. -/
+theorem sqrt_one : CFC.sqrt (1 : Matrix n n 𝕜) = 1 :=
+  sqrt_unique 1 1 .one (by simp)
+
+/-- `√(A^2) = A` for positive semidefinite `A`: the square root inverts squaring
+on the PSD cone.  This is uniqueness applied to the candidate `B = A`. -/
+theorem sqrt_sq (A : Matrix n n 𝕜) (hA : A.PosSemidef) :
+    CFC.sqrt (A ^ 2) = A :=
+  sqrt_unique (A ^ 2) A hA (by rw [pow_two])
+
+/-! ### Determinant shadow -/
+
+/-- The determinant of the square root squares back to the determinant of `A`:
+`det(√A)^2 = det A`.  In particular `det A` is a square of `det √A`, exhibiting
+`det A ≥ 0` for real PSD matrices. -/
+theorem det_sqrt_sq (A : Matrix n n 𝕜) (hA : A.PosSemidef) :
+    (CFC.sqrt A).det ^ 2 = A.det := by
+  rw [← Matrix.det_pow, sq_sqrt A hA]
+
+/-! ### Concrete instance -/
+
+/-- The candidate square root `diag(2, 3)` is positive semidefinite. -/
+theorem diag_two_three_posSemidef :
+    (diagonal ![(2 : ℝ), 3]).PosSemidef :=
+  Matrix.PosSemidef.diagonal (by
+    rw [Pi.le_def]
+    intro i
+    fin_cases i <;> norm_num [cons_val_zero, cons_val_one, head_cons])
+
+/-- **Concrete computation.**  The square root of the diagonal matrix
+`diag(4, 9)` is `diag(2, 3)`, obtained from uniqueness: `diag(2,3)` is PSD and
+squares to `diag(4,9)`.  This cross-checks the abstract `CFC.sqrt` against the
+elementary entrywise square root `√4 = 2`, `√9 = 3`. -/
+theorem sqrt_diag_four_nine :
+    CFC.sqrt (diagonal ![(4 : ℝ), 9]) = diagonal ![(2 : ℝ), 3] :=
+  sqrt_unique _ _ diag_two_three_posSemidef (by
+    rw [diagonal_mul_diagonal]
+    congr 1
+    funext i
+    fin_cases i <;> norm_num [Pi.mul_apply, cons_val_zero, cons_val_one, head_cons])
+
+end MatrixPosDefSqrtOQ01

--- a/research/problems/det-conjugate-transpose-oq-01/problem.md
+++ b/research/problems/det-conjugate-transpose-oq-01/problem.md
@@ -1,0 +1,42 @@
+# Problem: Determinant of the conjugate transpose: det(Mᴴ) = conj(det M)
+
+## Statement
+
+### Plain Language
+AVAILABLE: over a StarRing R (canonically R = ℂ), for any square matrix M, det(Mᴴ) = star(det M) — the determinant of the conjugate transpose is the complex conjugate of the determinant.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: A
+significance: 7
+tractability: 7
+tags:
+  - linear-algebra
+  - matrix
+  - determinant
+  - conjugate-transpose
+  - hermitian
+  - unitary
+  - star-ring
+  - seeker-selected
+  - research
+```
+
+**Significance**: 7/10
+**Tractability**: 7/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE: over a StarRing R (canonically R = ℂ), for any square matrix M, det(Mᴴ) = star(det M) — the determinant of the conjugate transpose is the complex conjugate of the determinant
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/det-conjugate-transpose-oq-01/state.md
+++ b/research/problems/det-conjugate-transpose-oq-01/state.md
@@ -1,0 +1,28 @@
+# Current State
+
+**Phase**: COMPLETED
+**Since**: 2026-06-20
+**Iteration**: 2
+
+## Current Focus
+
+Solved. det Mᴴ = star (det M) packaged with Hermitian (real determinant) and
+unitary (unit-circle determinant) corollaries.
+
+## Active Approach
+
+DONE — see proofs/Proofs/DetConjugateTransposeOQ01.lean (verified, 0 sorries, 0 axioms).
+
+## Blockers
+
+None.
+
+## Next Action
+
+Shipped. Follow-ups: characterise SU(n) (det U = 1), or det O = ±1 for real orthogonal O.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/research/problems/matrix-posdef-sqrt-oq-01/problem.md
+++ b/research/problems/matrix-posdef-sqrt-oq-01/problem.md
@@ -1,0 +1,51 @@
+# Problem: Positive semidefinite square root: the unique PSD √A with √A·√A = A
+
+## Statement
+
+### Plain Language
+AVAILABLE: every positive semidefinite matrix A over RCLike (ℝ or ℂ) has a unique positive semidefinite square root √A satisfying √A * √A = A; √A is itself Hermitian and PSD, and the square root is unique among PSD matrices.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: A
+significance: 8
+tractability: 6
+tags:
+  - linear-algebra
+  - matrix
+  - positive-semidefinite
+  - square-root
+  - hermitian
+  - spectral-theorem
+  - polar-decomposition
+  - seeker-selected
+  - research
+```
+
+**Significance**: 8/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE: every positive semidefinite matrix A over RCLike (ℝ or ℂ) has a unique positive semidefinite square root √A satisfying √A * √A = A; √A is itself Hermitian and PSD, and the square root is unique among PSD matrices
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| det-conjugate-transpose-oq-01 | Sibling complex-matrix structure (adjoint/determinant); this entry's det shadow det(√A)² = det A connects the PSD square root to the determinant invariant. |
+
+## Status
+
+**COMPLETED** — verified 0-axiom gallery entry `proofs/Proofs/MatrixPosDefSqrtOQ01.lean`
+(9 theorems, 0 sorries, 0 axioms, no `native_decide`). Vehicle: `CFC.sqrt`
+(modern continuous-functional-calculus square root; `Matrix.PosSemidef.sqrt`
+deprecated 2025-09-22). Content: existence/defining property, structure
+(PSD/Hermitian), uniqueness, corollaries (√0, √1, √(A²)), determinant shadow,
+concrete instance √diag(4,9) = diag(2,3).

--- a/research/problems/matrix-posdef-sqrt-oq-01/state.md
+++ b/research/problems/matrix-posdef-sqrt-oq-01/state.md
@@ -1,0 +1,32 @@
+# Current State
+
+**Phase**: COMPLETED
+**Since**: 2026-06-20
+**Iteration**: 1
+
+## Current Focus
+
+Verified 0-axiom gallery entry shipped: `proofs/Proofs/MatrixPosDefSqrtOQ01.lean`.
+
+## Active Approach
+
+Package the positive semidefinite square root `CFC.sqrt` (modern Mathlib; the
+bespoke `Matrix.PosSemidef.sqrt` was deprecated 2025-09-22) as a triad —
+existence/defining property, structure (PSD/Hermitian), uniqueness — and read
+the corollaries (√0 = 0, √1 = 1, √(A²) = A), the determinant shadow
+det(√A)² = det A, and the concrete instance √diag(4,9) = diag(2,3) off uniqueness.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Follow-ups: polar decomposition A = P·U with P = √(AᴴA); operator absolute value
+|A| = √(AᴴA); Loewner monotonicity 0 ⪯ A ⪯ B ⟹ √A ⪯ √B.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/det-conjugate-transpose-oq-01/annotations.json
+++ b/src/data/proofs/det-conjugate-transpose-oq-01/annotations.json
@@ -1,0 +1,91 @@
+[
+  {
+    "id": "ann-base-identity",
+    "proofId": "det-conjugate-transpose-oq-01",
+    "range": {
+      "startLine": 37,
+      "endLine": 45
+    },
+    "type": "theorem",
+    "title": "The Base Identity (det_conjTranspose)",
+    "content": "det_conjTranspose states that over a commutative StarRing R, det Mᴴ = star (det M): the determinant of the conjugate transpose is the conjugate of the determinant. It re-exports Mathlib's Matrix.det_conjTranspose, anchored here as the building block for the Hermitian and unitary corollaries. Canonically R = ℂ and star is complex conjugation, so this reads det Mᴴ = conj(det M).",
+    "mathContext": "$\\det(M^{\\mathsf H}) = \\overline{\\det M}$.",
+    "prerequisites": [
+      "The conjugate transpose Mᴴ on matrices over a StarRing",
+      "Matrix.det and Matrix.det_conjTranspose"
+    ],
+    "relatedConcepts": [
+      "conjugate transpose / adjoint",
+      "determinant",
+      "star ring"
+    ],
+    "significance": "The single scalar equation from which both the Hermitian (real determinant) and unitary (unit-circle determinant) corollaries are read off, with no further matrix computation."
+  },
+  {
+    "id": "ann-hermitian-real-det",
+    "proofId": "det-conjugate-transpose-oq-01",
+    "range": {
+      "startLine": 47,
+      "endLine": 74
+    },
+    "type": "theorem",
+    "title": "Hermitian ⟹ Self-Adjoint, Real Determinant (isSelfAdjoint_det_of_isHermitian, isHermitian_det_im_zero, isHermitian_det_isReal)",
+    "content": "isSelfAdjoint_det_of_isHermitian takes the base identity det Mᴴ = star (det M) and rewrites it by the Hermitian relation Mᴴ = M (Matrix.IsHermitian.eq), giving det M = star (det M); symmetrised, this is IsSelfAdjoint (det M) — the determinant is fixed by the conjugation star. Over ℂ, where star is complex conjugation (starRingEnd ℂ via starRingEnd_apply), self-conjugacy means reality: isHermitian_det_im_zero applies Complex.conj_eq_iff_im to conclude (det M).im = 0, and isHermitian_det_isReal applies Complex.conj_eq_iff_real to produce a real r with det M = (r : ℂ). This is the determinant's share of the real-spectrum property of Hermitian operators: the product of the eigenvalues is real, obtained without spectral machinery.",
+    "mathContext": "$M^{\\mathsf H}=M \\Rightarrow \\overline{\\det M}=\\det M$, hence over $\\mathbb C$, $\\operatorname{Im}\\det M = 0$ and $\\det M = r$ for some $r\\in\\mathbb R$.",
+    "prerequisites": [
+      "Matrix.IsHermitian (Mᴴ = M) and IsHermitian.eq",
+      "IsSelfAdjoint and isSelfAdjoint_iff",
+      "Complex.conj_eq_iff_im, Complex.conj_eq_iff_real and starRingEnd_apply (star = starRingEnd ℂ)"
+    ],
+    "relatedConcepts": [
+      "Hermitian matrix",
+      "self-adjoint element",
+      "real spectrum"
+    ],
+    "significance": "Shows that the determinant of a Hermitian matrix is real — the scalar shadow of the spectral theorem — derived purely from how the determinant transforms under the adjoint."
+  },
+  {
+    "id": "ann-unitary-unit-circle",
+    "proofId": "det-conjugate-transpose-oq-01",
+    "range": {
+      "startLine": 76,
+      "endLine": 99
+    },
+    "type": "theorem",
+    "title": "Unitary ⟹ Determinant on the Unit Circle (star_det_mul_det_of_unitary, unitary_det_norm_one)",
+    "content": "star_det_mul_det_of_unitary applies det to the unitarity relation Uᴴ * U = 1: rewriting with Matrix.det_mul, Matrix.det_conjTranspose and Matrix.det_one turns det(Uᴴ * U) = det 1 into star (det U) * det U = 1. unitary_det_norm_one then takes norms of both sides — norm_mul, norm_star, norm_one collapse the left to ‖det U‖ · ‖det U‖ = 1, i.e. ‖det U‖² = 1 — and factors (‖det U‖ − 1)(‖det U‖ + 1) = 0 by linear_combination; since ‖det U‖ ≥ 0 (norm_nonneg) the factor ‖det U‖ + 1 is positive, forcing ‖det U‖ = 1. The determinant of a unitary matrix lies on the unit circle: this is the homomorphism det : U(n) → U(1), whose kernel is the special unitary group SU(n).",
+    "mathContext": "$U^{\\mathsf H}U=1 \\Rightarrow \\overline{\\det U}\\,\\det U = 1$, hence $\\lVert\\det U\\rVert = 1$.",
+    "prerequisites": [
+      "Matrix.det_mul, Matrix.det_conjTranspose, Matrix.det_one",
+      "The norm lemmas norm_mul, norm_star, norm_one, norm_nonneg on ℂ",
+      "The linear_combination tactic and mul_eq_zero"
+    ],
+    "relatedConcepts": [
+      "unitary matrix",
+      "unit circle / U(1)",
+      "special unitary group SU(n)"
+    ],
+    "significance": "Establishes the determinant homomorphism det : U(n) → U(1) in one line, the structural fact underlying the SU(n) ⊂ U(n) decomposition."
+  },
+  {
+    "id": "ann-worked-instances",
+    "proofId": "det-conjugate-transpose-oq-01",
+    "range": {
+      "startLine": 101,
+      "endLine": 112
+    },
+    "type": "example",
+    "title": "Worked Instances at the Identity Matrix",
+    "content": "The identity matrix 1 is both Hermitian (Matrix.isHermitian_one) and unitary (1ᴴ * 1 = 1 by simp), so both corollaries apply to it. The first example obtains (det 1).im = 0 from isHermitian_det_im_zero and the second obtains ‖det 1‖ = 1 from unitary_det_norm_one — concrete witnesses that det 1 = 1 is real and lies on the unit circle.",
+    "mathContext": "$(\\det \\mathbf 1).\\operatorname{Im} = 0$ and $\\lVert\\det \\mathbf 1\\rVert = 1$.",
+    "prerequisites": [
+      "Matrix.isHermitian_one",
+      "The corollaries isHermitian_det_im_zero and unitary_det_norm_one"
+    ],
+    "relatedConcepts": [
+      "identity matrix",
+      "worked example"
+    ],
+    "significance": "Grounds both abstract corollaries in the simplest concrete matrix, where the determinant is visibly 1."
+  }
+]

--- a/src/data/proofs/det-conjugate-transpose-oq-01/meta.json
+++ b/src/data/proofs/det-conjugate-transpose-oq-01/meta.json
@@ -1,0 +1,95 @@
+{
+  "id": "det-conjugate-transpose-oq-01",
+  "title": "Determinant of the Conjugate Transpose: det Mᴴ = star (det M), with the Hermitian and Unitary Corollaries",
+  "slug": "det-conjugate-transpose-oq-01",
+  "description": "Over a StarRing R — canonically R = ℂ with star the complex conjugate — taking the conjugate transpose of a square matrix conjugates its determinant: det Mᴴ = star (det M). This base identity is Mathlib's Matrix.det_conjTranspose (the gallery had no entry on it; it is distinct from det_mul / det_transpose). The substantive content is the pair of structural corollaries it powers, tying the adjoint/spectral structure of complex matrices to the single scalar invariant det. (1) Hermitian ⟹ self-adjoint determinant: if Mᴴ = M then star (det M) = det M, i.e. the determinant is fixed by conjugation; over ℂ this says the determinant of a Hermitian matrix is real — (det M).im = 0, equivalently det M = (r : ℂ) for some r : ℝ — the scalar shadow of the real-spectrum property of Hermitian operators. (2) Unitary ⟹ determinant on the unit circle: if Uᴴ * U = 1 then applying det to both sides gives star (det U) * det U = 1, hence ‖det U‖ = 1 — the det : U(n) → U(1) homomorphism in one line. The identity matrix witnesses both: det 1 = 1 is real and has modulus one.",
+  "leanFile": "Proofs/DetConjugateTransposeOQ01.lean",
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Conjugate_transpose",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DetConjugateTransposeOQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "matrix",
+      "determinant",
+      "conjugate-transpose",
+      "hermitian",
+      "unitary",
+      "star-ring"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "relatedProblems": [
+      {
+        "id": "cramers-rule-oq-05",
+        "relationship": "Sibling determinant invariants: cramers-rule-oq-05 studies det/trace/charpoly as similarity invariants (invariance under unit conjugation); this entry studies how the determinant transforms under the conjugate transpose (det Mᴴ = star det M) and the Hermitian/unitary consequences."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 113,
+    "assumptions": "0 axioms, 0 sorries, no native_decide, no Lean.ofReduceBool. All theorems depend only on the foundational propext / Classical.choice / Quot.sound. The base identity det Mᴴ = star (det M) re-exports Mathlib's Matrix.det_conjTranspose. The Hermitian corollary uses Matrix.IsHermitian.eq (Mᴴ = M) and, over ℂ, Complex.conj_eq_iff_im / Complex.conj_eq_iff_real to read off reality from self-conjugacy (star = starRingEnd ℂ via starRingEnd_apply). The unitary corollary applies det to Uᴴ * U = 1 using Matrix.det_mul, Matrix.det_conjTranspose, Matrix.det_one to get star (det U) * det U = 1, takes norms with norm_mul / norm_star / norm_one to obtain ‖det U‖² = 1, and concludes ‖det U‖ = 1 by factoring (‖det U‖−1)(‖det U‖+1)=0 (linear_combination) together with norm_nonneg. The genuine hypotheses are the domain conditions M.IsHermitian and Uᴴ * U = 1.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The conjugate transpose Mᴴ (adjoint) is the defining operation of the theory of complex matrices: Hermitian matrices (Mᴴ = M) are the complex analogue of real symmetric matrices and model observables in quantum mechanics, while unitary matrices (Uᴴ U = 1) are the complex analogue of orthogonal matrices and model reversible quantum evolution. The determinant is the basic scalar invariant of a matrix, and its behaviour under the adjoint — det Mᴴ = conj(det M) — is the bridge between these two worlds: it forces the determinant of a Hermitian matrix to be real (the scalar trace of the spectral theorem's real-eigenvalue conclusion) and confines the determinant of a unitary matrix to the unit circle (the determinant homomorphism U(n) → U(1) whose kernel is the special unitary group SU(n)).",
+    "problemStatement": "Over a StarRing R, prove that the determinant of the conjugate transpose is the conjugate of the determinant,\n\n$$\\det(M^{\\mathsf H}) = \\overline{\\det M},$$\n\nand derive its two structural corollaries: for a Hermitian matrix ($M^{\\mathsf H} = M$) the determinant is self-adjoint, so over $\\mathbb C$ it is real ($\\operatorname{Im}\\det M = 0$); and for a unitary matrix ($U^{\\mathsf H}U = 1$) the determinant lies on the unit circle ($\\lVert\\det U\\rVert = 1$).",
+    "text": "Mathlib records the base identity Matrix.det_conjTranspose : det Mᴴ = star (det M) but the gallery had no entry on it and no entry deriving its Hermitian/unitary consequences. This entry anchors the identity and proves the two corollaries that give it structural meaning: the determinant of a Hermitian matrix is real, and the determinant of a unitary matrix has modulus one.",
+    "proofStrategy": "The base identity det_conjTranspose re-exports Matrix.det_conjTranspose. The Hermitian corollary isSelfAdjoint_det_of_isHermitian rewrites det Mᴴ = star (det M) by the Hermitian relation Mᴴ = M (Matrix.IsHermitian.eq) to obtain det M = star (det M), i.e. IsSelfAdjoint (det M). Over ℂ this is specialised two ways: isHermitian_det_im_zero converts star to starRingEnd ℂ (starRingEnd_apply) and applies Complex.conj_eq_iff_im to conclude (det M).im = 0, while isHermitian_det_isReal applies Complex.conj_eq_iff_real to produce a real r with det M = (r : ℂ). The unitary corollary first establishes star_det_mul_det_of_unitary: applying det to Uᴴ * U = 1 and rewriting with Matrix.det_mul, Matrix.det_conjTranspose, Matrix.det_one gives star (det U) * det U = 1. Then unitary_det_norm_one takes norms — norm_mul, norm_star, norm_one collapse the left side to ‖det U‖ · ‖det U‖ = 1 — and factors (‖det U‖ − 1)(‖det U‖ + 1) = 0 by linear_combination; since ‖det U‖ ≥ 0 (norm_nonneg) the second factor is positive, forcing ‖det U‖ = 1. The two worked examples instantiate both corollaries at the identity matrix (Hermitian and unitary), recovering that det 1 = 1 is real and lies on the unit circle.",
+    "keyInsights": [
+      "**The adjoint acts on the determinant by a single scalar conjugation**: det Mᴴ = star (det M). All the structure that follows is read off this one equation by specialising the matrix relation between M and Mᴴ — there is no further matrix computation, only scalar algebra in the determinant.",
+      "**Hermitian self-adjointness of the scalar is the determinant's share of the real-spectrum theorem**: Mᴴ = M forces star (det M) = det M, so over ℂ the determinant — which is the product of the eigenvalues — has zero imaginary part. This is exactly what one expects from the spectral theorem (real eigenvalues ⟹ real product), obtained here without any spectral machinery.",
+      "**Unitarity confines the determinant to the unit circle**: from Uᴴ U = 1, taking determinants gives star (det U) · det U = 1, i.e. ‖det U‖² = 1. This is the determinant homomorphism det : U(n) → U(1); its kernel is the special unitary group SU(n). The proof needs only det_mul and the base identity, plus the elementary fact that a nonnegative real with square 1 equals 1.",
+      "**StarRing is the right generality for the base identity, ℂ for the payoff**: det Mᴴ = star (det M) holds over any commutative StarRing, but 'the determinant is real' and 'the determinant lies on the unit circle' are statements about ℂ, where star is complex conjugation and the norm measures distance to the unit circle. The entry separates the two layers."
+    ],
+    "prerequisites": [
+      "The conjugate transpose Mᴴ and the determinant det on square matrices (Matrix.det)",
+      "Matrix.det_conjTranspose, Matrix.det_mul, Matrix.det_one",
+      "The Hermitian predicate Matrix.IsHermitian (Mᴴ = M) and IsHermitian.eq",
+      "Over ℂ: star = starRingEnd ℂ (complex conjugation), Complex.conj_eq_iff_im / Complex.conj_eq_iff_real, and the norm lemmas norm_mul / norm_star / norm_one / norm_nonneg"
+    ]
+  },
+  "sections": [
+    {
+      "id": "base-identity",
+      "title": "The Base Identity det Mᴴ = star (det M)",
+      "startLine": 37,
+      "endLine": 45,
+      "mathContext": "$\\det(M^{\\mathsf H}) = \\overline{\\det M}$ over a StarRing.",
+      "summary": "det_conjTranspose re-exports Matrix.det_conjTranspose: over a commutative StarRing R, the determinant of the conjugate transpose equals the conjugate (star) of the determinant. This is the building block for the Hermitian and unitary corollaries."
+    },
+    {
+      "id": "hermitian-real-det",
+      "title": "Hermitian Matrices: the Determinant is Self-Adjoint (Real over ℂ)",
+      "startLine": 47,
+      "endLine": 74,
+      "mathContext": "$M^{\\mathsf H}=M \\Rightarrow \\overline{\\det M}=\\det M$; over $\\mathbb C$, $\\operatorname{Im}\\det M = 0$.",
+      "summary": "isSelfAdjoint_det_of_isHermitian rewrites the base identity by Mᴴ = M to conclude IsSelfAdjoint (det M) — the determinant is fixed by conjugation. Over ℂ, isHermitian_det_im_zero (via Complex.conj_eq_iff_im) gives (det M).im = 0 and isHermitian_det_isReal (via Complex.conj_eq_iff_real) gives det M = (r : ℂ) for a real r: the determinant of a Hermitian matrix is real."
+    },
+    {
+      "id": "unitary-unit-circle",
+      "title": "Unitary Matrices: the Determinant Lies on the Unit Circle",
+      "startLine": 76,
+      "endLine": 99,
+      "mathContext": "$U^{\\mathsf H}U=1 \\Rightarrow \\lVert\\det U\\rVert = 1$.",
+      "summary": "star_det_mul_det_of_unitary applies det to Uᴴ * U = 1 (det_mul, det_conjTranspose, det_one) to get star (det U) · det U = 1. unitary_det_norm_one takes norms — norm_mul, norm_star, norm_one give ‖det U‖² = 1 — and factors (‖det U‖−1)(‖det U‖+1)=0 with norm_nonneg to conclude ‖det U‖ = 1: the determinant of a unitary matrix lies on the unit circle (the det : U(n) → U(1) map)."
+    },
+    {
+      "id": "worked-instances",
+      "title": "Worked Instances",
+      "startLine": 101,
+      "endLine": 112,
+      "mathContext": "$(\\det \\mathbf 1).\\operatorname{Im} = 0$ and $\\lVert\\det \\mathbf 1\\rVert = 1$.",
+      "summary": "The identity matrix is both Hermitian (Matrix.isHermitian_one) and unitary, so the two corollaries apply to it: det 1 = 1 is real and lies on the unit circle, exhibiting both results concretely."
+    }
+  ],
+  "conclusion": "The conjugate-transpose determinant identity det Mᴴ = star (det M) and its two structural corollaries are formalised sorry-free and axiom-free. The base identity re-exports Mathlib's Matrix.det_conjTranspose; the original content is the pair of corollaries it powers: the determinant of a Hermitian matrix is self-adjoint, hence real over ℂ (the scalar form of the real-spectrum property), and the determinant of a unitary matrix lies on the unit circle (the det : U(n) → U(1) homomorphism, whose kernel is SU(n)). A natural follow-up is the special unitary group itself — characterising U with det U = 1 — or the multiplicativity ‖det (U · V)‖ = ‖det U‖ · ‖det V‖ giving det as a group homomorphism U(n) → U(1), and the analogous orthogonal statement det O = ±1 for Oᵀ O = 1 over ℝ.",
+  "crossReferences": [
+    "cramers-rule-oq-05"
+  ]
+}

--- a/src/data/proofs/matrix-posdef-sqrt-oq-01/annotations.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01/annotations.json
@@ -1,0 +1,135 @@
+[
+  {
+    "id": "ann-defining-property",
+    "proofId": "matrix-posdef-sqrt-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 66
+    },
+    "type": "theorem",
+    "title": "Defining Property (sqrt_mul_self, sq_sqrt)",
+    "content": "sqrt_mul_self re-exports CFC.sqrt_mul_sqrt_self: for a positive semidefinite matrix A (so 0 ≤ A via Matrix.PosSemidef.nonneg under the scoped MatrixOrder order), the continuous functional calculus square root satisfies √A · √A = A. sq_sqrt is the equivalent power form (√A)² = A via CFC.sq_sqrt. The matrix square root is here a special case of the C⋆-algebraic CFC.sqrt: the hypothesis 0 ≤ A in the abstract lemma is exactly A.PosSemidef on matrices.",
+    "mathContext": "$\\sqrt A\\cdot\\sqrt A = A$ and $(\\sqrt A)^2 = A$ for $A\\succeq 0$.",
+    "prerequisites": [
+      "Matrix.PosSemidef and Matrix.nonneg_iff_posSemidef / PosSemidef.nonneg (scoped MatrixOrder)",
+      "CFC.sqrt and CFC.sqrt_mul_sqrt_self, CFC.sq_sqrt"
+    ],
+    "relatedConcepts": [
+      "operator square root",
+      "continuous functional calculus",
+      "positive semidefinite matrix"
+    ],
+    "significance": "The existence/defining-property pillar: √A is genuinely a square root of A, obtained by specializing the C⋆-algebra functional calculus to matrices."
+  },
+  {
+    "id": "ann-structure",
+    "proofId": "matrix-posdef-sqrt-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 81
+    },
+    "type": "theorem",
+    "title": "Structure: √A Stays in the PSD Cone (sqrt_posSemidef, sqrt_isHermitian)",
+    "content": "sqrt_posSemidef shows √A is positive semidefinite for ANY matrix A — no hypothesis on A is needed, because CFC.sqrt is defined through the ℝ≥0 (nonnegative) continuous functional calculus, so CFC.sqrt_nonneg gives 0 ≤ √A unconditionally and LE.le.posSemidef converts it to a PosSemidef. sqrt_isHermitian then reads off that √A is Hermitian as the special case of being positive semidefinite (Matrix.PosSemidef.isHermitian). The square root never leaves the cone of PSD matrices.",
+    "mathContext": "$\\sqrt A\\succeq 0$ and $(\\sqrt A)^{\\mathsf H}=\\sqrt A$.",
+    "prerequisites": [
+      "CFC.sqrt_nonneg and LE.le.posSemidef (0 ≤ M → M.PosSemidef)",
+      "Matrix.PosSemidef.isHermitian"
+    ],
+    "relatedConcepts": [
+      "PSD cone",
+      "Hermitian matrix",
+      "nonnegative functional calculus"
+    ],
+    "significance": "The structure pillar: the square root maps matrices into the positive semidefinite (hence Hermitian) cone, so iterating or composing it stays well defined."
+  },
+  {
+    "id": "ann-uniqueness",
+    "proofId": "matrix-posdef-sqrt-oq-01",
+    "range": {
+      "startLine": 83,
+      "endLine": 91
+    },
+    "type": "theorem",
+    "title": "Uniqueness of the PSD Square Root (sqrt_unique)",
+    "content": "sqrt_unique re-exports CFC.sqrt_unique: if B is positive semidefinite (0 ≤ B) and B · B = A, then B is the square root √A. Together with sqrt_mul_self (existence) and sqrt_posSemidef (structure), this shows the positive semidefinite square root exists and is unique — there is exactly one PSD B squaring to A. This is the load-bearing content: it is what makes 'the' square root well defined and what every corollary below uses.",
+    "mathContext": "$B\\succeq 0,\\ B\\cdot B = A \\Rightarrow B = \\sqrt A$.",
+    "prerequisites": [
+      "CFC.sqrt_unique (b · b = a, 0 ≤ b ⟹ √a = b)",
+      "Matrix.PosSemidef.nonneg"
+    ],
+    "relatedConcepts": [
+      "uniqueness",
+      "positive semidefinite square root",
+      "well-definedness"
+    ],
+    "significance": "The non-trivial half of the theory: uniqueness licenses the notation √A and is the single fact every corollary specializes."
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "matrix-posdef-sqrt-oq-01",
+    "range": {
+      "startLine": 93,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "Corollaries from Uniqueness (sqrt_zero, sqrt_one, sqrt_sq)",
+    "content": "Each corollary is uniqueness applied to an obvious candidate. sqrt_zero: 0 is PSD and 0 · 0 = 0, so √0 = 0. sqrt_one: 1 is PSD and 1 · 1 = 1, so √1 = 1. sqrt_sq: for PSD A, A · A = A², so √(A²) = A — the square root inverts squaring on the PSD cone. None of these requires a fresh computation: they are sqrt_unique with B taken to be 0, 1, and A respectively.",
+    "mathContext": "$\\sqrt 0 = 0,\\quad \\sqrt 1 = 1,\\quad \\sqrt{A^2} = A\\ (A\\succeq 0).$",
+    "prerequisites": [
+      "sqrt_unique",
+      "Matrix.PosSemidef.zero, Matrix.PosSemidef.one"
+    ],
+    "relatedConcepts": [
+      "idempotence of √ on 0 and 1",
+      "square root inverts squaring",
+      "PSD cone"
+    ],
+    "significance": "Demonstrates the leverage of uniqueness: the basic identities of the square root all fall out of one lemma applied to a candidate, with no spectral computation."
+  },
+  {
+    "id": "ann-determinant-shadow",
+    "proofId": "matrix-posdef-sqrt-oq-01",
+    "range": {
+      "startLine": 109,
+      "endLine": 116
+    },
+    "type": "theorem",
+    "title": "Determinant Shadow (det_sqrt_sq)",
+    "content": "det_sqrt_sq applies the determinant to (√A)² = A: since det(Mⁿ) = (det M)ⁿ (Matrix.det_pow), det((√A)²) = (det √A)², and sq_sqrt rewrites the left side to det A, giving (det √A)² = det A. Over ℝ this exhibits det A as a perfect square (det √A)², recovering det A ≥ 0 for real positive semidefinite matrices as a one-line consequence of having a square root.",
+    "mathContext": "$\\det(\\sqrt A)^2 = \\det A$.",
+    "prerequisites": [
+      "Matrix.det_pow (det(Mⁿ) = (det M)ⁿ)",
+      "sq_sqrt"
+    ],
+    "relatedConcepts": [
+      "determinant",
+      "nonnegativity of det for PSD",
+      "multiplicativity of det"
+    ],
+    "significance": "Connects the operator square root to the scalar determinant invariant, making det A ≥ 0 (real PSD) visible as a square."
+  },
+  {
+    "id": "ann-concrete-instance",
+    "proofId": "matrix-posdef-sqrt-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 139
+    },
+    "type": "example",
+    "title": "Concrete Instance √diag(4,9) = diag(2,3) (diag_two_three_posSemidef, sqrt_diag_four_nine)",
+    "content": "diag_two_three_posSemidef establishes that diag(2,3) is positive semidefinite via Matrix.PosSemidef.diagonal, whose hypothesis 0 ≤ ![2,3] is discharged entrywise (Pi.le_def, fin_cases, norm_num). sqrt_diag_four_nine then concludes by uniqueness: diag(2,3) is PSD and squares to diag(4,9), because diagonal_mul_diagonal turns diag(2,3) · diag(2,3) into diag(![2,3] * ![2,3]) and the entrywise products are 2·2 = 4, 3·3 = 9. Since CFC.sqrt is noncomputable and defined spectrally, the diagonal square root cannot be evaluated by reduction; uniqueness is what identifies the abstract √diag(4,9) with the elementary entrywise answer diag(2,3).",
+    "mathContext": "$\\sqrt{\\operatorname{diag}(4,9)} = \\operatorname{diag}(2,3)$.",
+    "prerequisites": [
+      "Matrix.PosSemidef.diagonal and Pi.le_def",
+      "Matrix.diagonal_mul_diagonal",
+      "sqrt_unique"
+    ],
+    "relatedConcepts": [
+      "diagonal matrices",
+      "entrywise square root",
+      "worked example"
+    ],
+    "significance": "Grounds the abstract functional-calculus square root in the simplest concrete case, confirming it agrees with √4 = 2, √9 = 3 on a diagonal matrix."
+  }
+]

--- a/src/data/proofs/matrix-posdef-sqrt-oq-01/meta.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01/meta.json
@@ -1,0 +1,111 @@
+{
+  "id": "matrix-posdef-sqrt-oq-01",
+  "title": "The Positive Semidefinite Square Root of a Matrix: Existence, Structure, and Uniqueness",
+  "slug": "matrix-posdef-sqrt-oq-01",
+  "description": "Every positive semidefinite matrix A over 𝕜 = ℝ or ℂ (RCLike 𝕜) has a positive semidefinite square root, supplied by modern Mathlib through the continuous functional calculus as CFC.sqrt A (the matrix-specific Matrix.PosSemidef.sqrt was deprecated in favour of this C⋆-algebra version), with the scoped MatrixOrder instances giving 0 ≤ A ↔ A.PosSemidef. The gallery had no entry on the operator square root — a different object from the Gram/positive-definite material and the determinant identities. The packaged content is the full characterization: (1) defining property √A·√A = A and (√A)² = A; (2) structure — √A is again positive semidefinite, hence Hermitian, so the square root stays inside the cone; (3) uniqueness — √A is the only PSD matrix B with B·B = A, the non-trivial half that makes 'the' square root well defined; (4) corollaries read off from uniqueness: √0 = 0, √1 = 1, and √(A²) = A for PSD A; (5) determinant shadow det(√A)² = det A, exhibiting det A as a square; (6) a concrete instance √diag(4,9) = diag(2,3), cross-checking the abstract functional calculus against the elementary entrywise square root. The PSD square root underlies the polar decomposition A = (PSD)·(unitary), the operator absolute value |A| = √(AᴴA), and the whitening transform in statistics.",
+  "leanFile": "Proofs/MatrixPosDefSqrtOQ01.lean",
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Square_root_of_a_matrix",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MatrixPosDefSqrtOQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "matrix",
+      "positive-semidefinite",
+      "square-root",
+      "continuous-functional-calculus",
+      "c-star-algebra",
+      "loewner-order"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "relatedProblems": [
+      {
+        "id": "det-conjugate-transpose-oq-01",
+        "relationship": "Sibling complex-matrix structure: det-conjugate-transpose-oq-01 studies how the determinant transforms under the adjoint (Hermitian ⟹ real det, unitary ⟹ unit-circle det); this entry studies the positive semidefinite square root as an operator, with det(√A)² = det A as its determinant shadow."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 140,
+    "assumptions": "0 axioms, 0 sorries, no native_decide, no Lean.ofReduceBool. All theorems depend only on the foundational propext / Classical.choice / Quot.sound. The square root is Mathlib's CFC.sqrt (continuous functional calculus over a C⋆-algebra); on Matrix n n 𝕜 with RCLike 𝕜 the relevant nonnegativity is the scoped MatrixOrder order, where Matrix.nonneg_iff_posSemidef gives 0 ≤ A ↔ A.PosSemidef and Matrix.PosSemidef.nonneg is the forward direction. The defining property re-exports CFC.sqrt_mul_sqrt_self / CFC.sq_sqrt; structure uses CFC.sqrt_nonneg with LE.le.posSemidef and Matrix.PosSemidef.isHermitian; uniqueness re-exports CFC.sqrt_unique (b·b = a, 0 ≤ b ⟹ √a = b); the corollaries (√0, √1, √(A²)) and the concrete diagonal instance are uniqueness applied to explicit candidates, with Matrix.PosSemidef.diagonal for diag(2,3) ⪰ 0 and diagonal_mul_diagonal for the squaring. The determinant shadow uses Matrix.det_pow. The genuine hypotheses are the domain conditions A.PosSemidef / B.PosSemidef.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "A positive semidefinite matrix is the matrix analogue of a nonnegative real number, and just as every nonnegative real has a unique nonnegative square root, every positive semidefinite matrix has a unique positive semidefinite square root. This operator square root is one of the workhorses of applied and pure linear algebra: it gives the polar decomposition A = P·U (a PSD factor times a unitary), the operator absolute value |A| = √(AᴴA), the geometric mean of positive operators, and the whitening / Mahalanobis transform of statistics. Mathlib originally carried a bespoke Matrix.PosSemidef.sqrt built from the spectral theorem, but in 2025 it was deprecated in favour of the C⋆-algebraic CFC.sqrt from the continuous functional calculus, of which the matrix square root is now a special case via the Loewner-order instances on matrices.",
+    "problemStatement": "For a positive semidefinite matrix $A$ over $\\mathbb R$ or $\\mathbb C$, prove that its square root $\\sqrt A$ (the continuous functional calculus square root) satisfies $\\sqrt A\\cdot\\sqrt A = A$, is again positive semidefinite (hence Hermitian), and is the *unique* positive semidefinite $B$ with $B\\cdot B = A$. Derive the corollaries $\\sqrt 0 = 0$, $\\sqrt 1 = 1$, $\\sqrt{A^2} = A$, and $\\det(\\sqrt A)^2 = \\det A$, and verify the concrete instance $\\sqrt{\\operatorname{diag}(4,9)} = \\operatorname{diag}(2,3)$.",
+    "text": "Mathlib provides the C⋆-algebraic square root CFC.sqrt and its core lemmas, but the gallery had no entry on the matrix square root as an object. This entry packages the three pillars — existence/defining property, structure (staying in the PSD cone), and uniqueness — and reads off the standard corollaries from uniqueness, closing with a concrete diagonal computation that ties the abstract functional calculus to the elementary fact √4 = 2, √9 = 3. The mathematically substantive half is uniqueness: it is what licenses the notation 'the' square root and what every downstream corollary actually uses.",
+    "keyInsights": [
+      "**Existence and the defining property are a functional-calculus identity**: over a C⋆-algebra the continuous functional calculus applied to the real square root function gives an element CFC.sqrt A with CFC.sqrt A · CFC.sqrt A = A whenever 0 ≤ A. On Matrix n n 𝕜 the hypothesis 0 ≤ A is exactly A.PosSemidef (Matrix.nonneg_iff_posSemidef), so the abstract statement specializes to the matrix square root with no extra work.",
+      "**The square root stays inside the cone**: CFC.sqrt is built from the ℝ≥0 functional calculus, so its output is unconditionally nonnegative — √A is positive semidefinite (and therefore Hermitian) for any A, without assuming A itself is PSD. This is the 'structure' pillar: the square root does not leave the class of objects it acts on.",
+      "**Uniqueness is the load-bearing content**: among positive semidefinite matrices, B·B = A has at most one solution, so the PSD square root is genuinely 'the' square root. Every corollary here — √0 = 0, √1 = 1, √(A²) = A — is this single uniqueness statement applied to an obvious candidate B (namely 0, 1, A), rather than a separate computation.",
+      "**The determinant is a multiplicative shadow of the square root**: applying det to (√A)² = A and using det(Mⁿ) = (det M)ⁿ gives det(√A)² = det A. Over ℝ this exhibits det A as a perfect square, recovering det A ≥ 0 for real PSD matrices as a one-line consequence.",
+      "**The concrete diagonal instance pins the abstraction down**: CFC.sqrt is noncomputable and defined spectrally, so √diag(4,9) cannot be evaluated by reduction; instead uniqueness identifies it with diag(2,3), since diag(2,3) is PSD and squares (via diagonal_mul_diagonal) to diag(4,9). The abstract object and the entrywise square root agree."
+    ],
+    "prerequisites": [
+      "Positive semidefinite matrices Matrix.PosSemidef and the Loewner order: the scoped MatrixOrder instances with Matrix.nonneg_iff_posSemidef (0 ≤ A ↔ A.PosSemidef)",
+      "The continuous functional calculus square root CFC.sqrt and its lemmas CFC.sqrt_mul_sqrt_self, CFC.sq_sqrt, CFC.sqrt_nonneg, CFC.sqrt_unique",
+      "Matrix.PosSemidef.isHermitian, Matrix.PosSemidef.diagonal, and Matrix.diagonal_mul_diagonal",
+      "Matrix.det_pow for the determinant corollary"
+    ]
+  },
+  "sections": [
+    {
+      "id": "defining-property",
+      "title": "Defining Property: √A is a Square Root of A",
+      "startLine": 56,
+      "endLine": 66,
+      "mathContext": "$\\sqrt A\\cdot\\sqrt A = A$ and $(\\sqrt A)^2 = A$ for PSD $A$.",
+      "summary": "sqrt_mul_self and sq_sqrt re-export the functional-calculus identities CFC.sqrt_mul_sqrt_self and CFC.sq_sqrt: under the PSD hypothesis (0 ≤ A via PosSemidef.nonneg), the square root multiplied by itself returns A. This is the existence/defining-property pillar."
+    },
+    {
+      "id": "structure",
+      "title": "Structure: the Square Root Stays in the PSD Cone",
+      "startLine": 68,
+      "endLine": 81,
+      "mathContext": "$\\sqrt A \\succeq 0$ and $(\\sqrt A)^{\\mathsf H} = \\sqrt A$.",
+      "summary": "sqrt_posSemidef shows √A is positive semidefinite for ANY A (CFC.sqrt_nonneg is unconditional, since the square root is built from the ℝ≥0 functional calculus), and sqrt_isHermitian deduces √A is Hermitian as a special case. The square root never leaves the cone."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness: √A is the Unique PSD Square Root",
+      "startLine": 83,
+      "endLine": 91,
+      "mathContext": "$B\\succeq 0,\\ B\\cdot B = A \\Rightarrow B = \\sqrt A$.",
+      "summary": "sqrt_unique re-exports CFC.sqrt_unique: if B is positive semidefinite and B·B = A then B is √A. Combined with the defining property and structure, this establishes that the PSD square root exists and is unique — the load-bearing content powering every corollary."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries from Uniqueness",
+      "startLine": 93,
+      "endLine": 107,
+      "mathContext": "$\\sqrt 0 = 0$, $\\sqrt 1 = 1$, $\\sqrt{A^2} = A$.",
+      "summary": "sqrt_zero, sqrt_one, and sqrt_sq are each uniqueness applied to an obvious candidate: 0·0 = 0 with 0 PSD, 1·1 = 1 with 1 PSD, and A·A = A² with A PSD. The square root inverts squaring on the PSD cone."
+    },
+    {
+      "id": "determinant-shadow",
+      "title": "Determinant Shadow: det(√A)² = det A",
+      "startLine": 109,
+      "endLine": 116,
+      "mathContext": "$\\det(\\sqrt A)^2 = \\det A$.",
+      "summary": "det_sqrt_sq applies det to (√A)² = A and uses Matrix.det_pow (det(Mⁿ) = (det M)ⁿ) to get det(√A)² = det A. Over ℝ this exhibits det A as a square, recovering det A ≥ 0 for real PSD matrices."
+    },
+    {
+      "id": "concrete-instance",
+      "title": "Concrete Instance: √diag(4,9) = diag(2,3)",
+      "startLine": 118,
+      "endLine": 139,
+      "mathContext": "$\\sqrt{\\operatorname{diag}(4,9)} = \\operatorname{diag}(2,3)$.",
+      "summary": "diag_two_three_posSemidef establishes diag(2,3) ⪰ 0 via Matrix.PosSemidef.diagonal, and sqrt_diag_four_nine concludes from uniqueness: diag(2,3) is PSD and squares to diag(4,9) (diagonal_mul_diagonal plus the entrywise check 2·2 = 4, 3·3 = 9). The abstract CFC.sqrt agrees with the elementary entrywise square root."
+    }
+  ],
+  "conclusion": "The positive semidefinite square root is formalised sorry-free and axiom-free as the three pillars existence/defining-property, structure, and uniqueness, with the standard corollaries (√0 = 0, √1 = 1, √(A²) = A), the determinant shadow det(√A)² = det A, and a concrete diagonal computation √diag(4,9) = diag(2,3). The square root itself is Mathlib's C⋆-algebraic CFC.sqrt; the original content is the matrix-level packaging — pinning the existence/structure/uniqueness triad together and reading the corollaries off uniqueness. Natural follow-ups: the polar decomposition A = P·U with P = √(AᴴA) PSD and U unitary; the operator absolute value |A| = √(AᴴA) and the identity ‖A x‖ = ‖|A| x‖; or the Loewner-monotonicity of the square root, 0 ⪯ A ⪯ B ⟹ √A ⪯ √B, the operator-monotone half of the theory.",
+  "crossReferences": [
+    "det-conjugate-transpose-oq-01"
+  ]
+}

--- a/src/data/research/problems/det-conjugate-transpose-oq-01.json
+++ b/src/data/research/problems/det-conjugate-transpose-oq-01.json
@@ -1,0 +1,71 @@
+{
+  "slug": "det-conjugate-transpose-oq-01",
+  "title": "Determinant of the conjugate transpose: det(Mᴴ) = conj(det M)",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "A",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: over a StarRing R (canonically R = ℂ), for any square matrix M, det(Mᴴ) = star(det M) — the determinant of the conjugate transpose is the complex conjugate of the determinant.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-06-20T18:12:04.131Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: verified 0-axiom gallery entry — base identity + Hermitian/unitary corollaries",
+    "builtItems": [
+      "DetConjugateTransposeOQ01.lean: det_conjTranspose, isSelfAdjoint_det_of_isHermitian, isHermitian_det_im_zero, isHermitian_det_isReal, star_det_mul_det_of_unitary, unitary_det_norm_one (5 theorems + 2 examples, verified 0-axiom)"
+    ],
+    "insights": [
+      "det Mᴴ = star (det M) (Matrix.det_conjTranspose) is the single scalar equation behind both the Hermitian-real-det and unitary-unit-circle facts; no further matrix computation is needed.",
+      "Hermitian Mᴴ=M gives star(det M)=det M (IsSelfAdjoint), so over ℂ det M is real ((det M).im=0): the determinant share of the real-spectrum theorem, with no spectral machinery.",
+      "Unitary Uᴴ U=1 gives star(det U)·det U=1, hence ‖det U‖=1: the det:U(n)→U(1) homomorphism, kernel SU(n)."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Characterise SU(n) = {U : det U = 1} ⊂ U(n)",
+      "Real orthogonal analogue det O = ±1 for Oᵀ O = 1",
+      "det as group homomorphism: ‖det(UV)‖=‖det U‖‖det V‖"
+    ]
+  },
+  "tags": [
+    "linear-algebra",
+    "matrix",
+    "determinant",
+    "conjugate-transpose",
+    "hermitian",
+    "unitary",
+    "star-ring",
+    "seeker-selected",
+    "research"
+  ],
+  "relatedProofs": [],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-20T18:12:04.131Z",
+  "lastUpdate": "2026-06-20T18:12:04.131Z",
+  "significance": 7,
+  "tractability": 7
+}

--- a/src/data/research/problems/matrix-posdef-sqrt-oq-01.json
+++ b/src/data/research/problems/matrix-posdef-sqrt-oq-01.json
@@ -1,0 +1,75 @@
+{
+  "slug": "matrix-posdef-sqrt-oq-01",
+  "title": "Positive semidefinite square root: the unique PSD √A with √A·√A = A",
+  "phase": "COMPLETED",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: every positive semidefinite matrix A over RCLike (ℝ or ℂ) has a unique positive semidefinite square root √A satisfying √A * √A = A; √A is itself Hermitian and PSD, and the square root is unique among PSD matrices.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": "Package the PSD square root: existence/defining property, structure (PSD/Hermitian), uniqueness, corollaries, det shadow, concrete instance."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-20T18:12:04.132Z",
+    "iteration": 1,
+    "focus": "Verified 0-axiom gallery entry shipped.",
+    "blockers": [],
+    "nextAction": "Follow-ups: polar decomposition, operator absolute value |A|=√(AᴴA), Loewner monotonicity of √.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: verified 0-axiom gallery entry — PSD square root existence/structure/uniqueness + corollaries + det shadow + concrete diag instance",
+    "builtItems": [
+      "MatrixPosDefSqrtOQ01.lean: sqrt_mul_self, sq_sqrt, sqrt_posSemidef, sqrt_isHermitian, sqrt_unique, sqrt_zero, sqrt_one, sqrt_sq, det_sqrt_sq, diag_two_three_posSemidef, sqrt_diag_four_nine (9 theorems verified 0-axiom; CFC.sqrt vehicle)"
+    ],
+    "insights": [
+      "The matrix square root is now Mathlibs C-star-algebraic CFC.sqrt (Matrix.PosSemidef.sqrt was deprecated 2025-09-22); on Matrix n n 𝕜 with RCLike 𝕜 the order is the scoped MatrixOrder instances and Matrix.nonneg_iff_posSemidef gives 0 ≤ A ↔ A.PosSemidef, so the abstract 0 ≤ A hypotheses specialize to PosSemidef.",
+      "Existence/defining property (CFC.sqrt_mul_sqrt_self, CFC.sq_sqrt) and uniqueness (CFC.sqrt_unique: b·b=a, 0≤b ⟹ √a=b) are direct re-exports; the original content is packaging them as a triad and reading corollaries off uniqueness.",
+      "CFC.sqrt_nonneg is UNCONDITIONAL (square root built from ℝ≥0 functional calculus), so √A is PSD/Hermitian for ANY A, not just PSD A.",
+      "Every corollary (√0=0, √1=1, √(A²)=A) is sqrt_unique applied to an obvious PSD candidate (0,1,A); det(√A)²=det A follows from sq_sqrt + Matrix.det_pow.",
+      "CFC.sqrt is noncomputable/spectral so √diag(4,9) cannot be reduced; uniqueness identifies it with diag(2,3) via Matrix.PosSemidef.diagonal + diagonal_mul_diagonal."
+    ],
+    "mathlibGaps": [
+      "Matrix.PosSemidef.sqrt is deprecated in favour of CFC.sqrt; the matrix square root no longer has a bespoke namespace API, so all lemmas route through CFC.* plus the MatrixOrder ↔ PosSemidef bridge."
+    ],
+    "nextSteps": [
+      "Polar decomposition A = P·U with P = √(AᴴA) PSD, U unitary",
+      "Operator absolute value |A| = √(AᴴA) and ‖A x‖ = ‖|A| x‖",
+      "Loewner monotonicity of the square root: 0 ⪯ A ⪯ B ⟹ √A ⪯ √B"
+    ]
+  },
+  "tags": [
+    "linear-algebra",
+    "matrix",
+    "positive-semidefinite",
+    "square-root",
+    "hermitian",
+    "spectral-theorem",
+    "polar-decomposition",
+    "seeker-selected",
+    "research"
+  ],
+  "relatedProofs": [],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-20T18:12:04.132Z",
+  "lastUpdate": "2026-06-20T19:00:00.000Z",
+  "significance": 8,
+  "tractability": 8
+}


### PR DESCRIPTION
## Summary

New verified gallery entry: the **positive semidefinite square root** of a matrix, packaged as existence, structure, and uniqueness.

Every PSD matrix `A` over `ℝ`/`ℂ` (`RCLike 𝕜`) has a PSD square root, supplied by modern Mathlib through the continuous functional calculus as `CFC.sqrt A` — the bespoke `Matrix.PosSemidef.sqrt` was **deprecated 2025-09-22** in favour of this C⋆-algebra version, so the matrix square root is now a special case of `CFC.sqrt` under the scoped `MatrixOrder` instances (`0 ≤ A ↔ A.PosSemidef`).

`proofs/Proofs/MatrixPosDefSqrtOQ01.lean` — **9 theorems, 0 sorries, 0 axioms** (only foundational `propext`/`Classical.choice`/`Quot.sound`; no `native_decide`, no `Lean.ofReduceBool`):

- **Defining property** — `√A · √A = A` and `(√A)² = A`
- **Structure** — `√A` is PSD (unconditionally, since `CFC.sqrt` is built from the `ℝ≥0` functional calculus), hence Hermitian
- **Uniqueness** — any PSD `B` with `B·B = A` equals `√A` (the load-bearing content)
- **Corollaries from uniqueness** — `√0 = 0`, `√1 = 1`, `√(A²) = A`
- **Determinant shadow** — `det(√A)² = det A`, exhibiting `det A` as a square
- **Concrete instance** — `√diag(4,9) = diag(2,3)`, cross-checking the abstract functional calculus against `√4 = 2`, `√9 = 3`

## Verification

`./proofs/scripts/docker-build.sh Proofs.MatrixPosDefSqrtOQ01` → **Build completed successfully (3138 jobs)**, no errors, no sorry warnings.

## Notes

The square root itself is Mathlib's `CFC.sqrt`; the original content is the matrix-level packaging — pinning the existence/structure/uniqueness triad together and reading the corollaries off uniqueness. Natural follow-ups: polar decomposition `A = P·U`, operator absolute value `|A| = √(AᴴA)`, and Loewner monotonicity `0 ⪯ A ⪯ B ⟹ √A ⪯ √B`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)