### PR TITLE
research(second-isomorphism-theorem-modules-oq-01): modular dimension law as a corollary of the diamond isomorphism (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3078,6 +3078,7 @@ import Proofs.SchroederBernsteinOQ03StatementOnly
 import Proofs.SchroederBernsteinOQ04
 import Proofs.SchursTheorem
 import Proofs.SearchMathlib
+import Proofs.SecondIsomorphismTheoremModulesOQ01
 import Proofs.ShannonChannelCoding
 import Proofs.ShannonChannelCodingAWGN
 import Proofs.ShannonChannelCodingBEC

--- a/proofs/Proofs/SecondIsomorphismTheoremModulesOQ01.lean
+++ b/proofs/Proofs/SecondIsomorphismTheoremModulesOQ01.lean
@@ -1,0 +1,131 @@
+import Mathlib.Tactic
+import Mathlib.LinearAlgebra.Isomorphisms
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+
+/-
+# Second (Diamond) Isomorphism Theorem for modules — OQ01
+
+## Question
+
+The three classical isomorphism theorems are foundational structure theorems for modules.
+Mathlib packages the **second (diamond) isomorphism theorem** as the linear equivalence
+`Submodule.quotientInfEquivSupQuotient`: for submodules `p p'` of an `R`-module `M`,
+
+  `p ⧸ (p ⊓ p')  ≃ₗ[R]  (p ⊔ p') ⧸ p'`
+
+(read inside the relevant ambient submodules, so the literal types are
+`↥p ⧸ comap p.subtype (p ⊓ p')` and `↥(p ⊔ p') ⧸ comap (p ⊔ p').subtype p'`).
+
+This entry is **not** a re-export of that equivalence. The question is whether the equivalence
+has genuine *computational* force: does it, on its own, recover the **modular dimension law**
+
+  `finrank (p ⊔ p') + finrank (p ⊓ p') = finrank p + finrank p'`
+
+for finite-dimensional vector spaces — without appealing to Mathlib's independent proof
+`Submodule.finrank_sup_add_finrank_inf_eq`?
+
+## Answer
+
+**Yes.** We derive the modular dimension law *purely from the second isomorphism theorem*
+(`secondIso`), the rank–nullity identity for quotients
+(`Submodule.finrank_quotient_add_finrank`), and the fact that the comap of a submodule
+under an inclusion has the same dimension as that submodule
+(`Submodule.comap_subtype_equiv_of_le`). The equivalence forces the two quotients to share a
+dimension; rank–nullity turns each quotient dimension into a difference of finranks; the two
+differences being equal *is* the modular law. We then read off the direct-sum corollary
+(`p ⊓ p' = ⊥ ⟹ finrank (p ⊔ p') = finrank p + finrank p'`).
+
+## What this establishes
+
+* `secondIso` — the second isomorphism theorem as a named `LinearEquiv` (any ring/module).
+* `secondIso_bijective` — its underlying map is a genuine bijection (the equivalence is
+  *constructed*, via `LinearEquiv.ofBijective` upstream, not postulated).
+* `finrank_modular_law` — the modular dimension law, derived from `secondIso`.
+* `finrank_sup_of_inf_bot` — the direct-sum dimension corollary.
+* `finrank_inf_of_sup_top` — the dual co-dimension corollary.
+
+Mathlib's `Submodule.finrank_sup_add_finrank_inf_eq` is an *independent* proof of the same
+law; the value here is exhibiting it as a corollary of the isomorphism theorem.
+-/
+
+open Submodule FiniteDimensional Module
+
+namespace SecondIsomorphismTheoremModulesOQ01
+
+section AnyRing
+
+variable {R : Type*} [Ring R] {M : Type*} [AddCommGroup M] [Module R M]
+
+/-- **Second (diamond) isomorphism theorem** as a named linear equivalence:
+`p ⧸ (p ⊓ p') ≃ₗ (p ⊔ p') ⧸ p'`, read inside the appropriate ambient submodules. -/
+noncomputable def secondIso (p p' : Submodule R M) :
+    (↥p ⧸ Submodule.comap p.subtype (p ⊓ p')) ≃ₗ[R]
+      (↥(p ⊔ p') ⧸ Submodule.comap (p ⊔ p').subtype p') :=
+  LinearMap.quotientInfEquivSupQuotient p p'
+
+/-- The underlying linear map of the second isomorphism is a genuine bijection. -/
+theorem secondIso_bijective (p p' : Submodule R M) :
+    Function.Bijective (secondIso p p') :=
+  (secondIso p p').bijective
+
+end AnyRing
+
+section FiniteDimensional
+
+variable {K : Type*} [Field K] {V : Type*} [AddCommGroup V] [Module K V]
+variable [FiniteDimensional K V] (p p' : Submodule K V)
+
+omit [FiniteDimensional K V] in
+/-- The comap of `p ⊓ p'` into `p` has the same dimension as `p ⊓ p'`. -/
+private theorem finrank_comap_inf :
+    Module.finrank K (Submodule.comap p.subtype (p ⊓ p')) = Module.finrank K ↥(p ⊓ p') :=
+  (Submodule.comapSubtypeEquivOfLe (inf_le_left)).finrank_eq
+
+omit [FiniteDimensional K V] in
+/-- The comap of `p'` into `p ⊔ p'` has the same dimension as `p'`. -/
+private theorem finrank_comap_sup :
+    Module.finrank K (Submodule.comap (p ⊔ p').subtype p') = Module.finrank K ↥p' :=
+  (Submodule.comapSubtypeEquivOfLe (le_sup_right)).finrank_eq
+
+/-- **Modular dimension law**, derived *from the second isomorphism theorem*:
+`finrank (p ⊔ p') + finrank (p ⊓ p') = finrank p + finrank p'`. -/
+theorem finrank_modular_law :
+    Module.finrank K ↥(p ⊔ p') + Module.finrank K ↥(p ⊓ p')
+      = Module.finrank K ↥p + Module.finrank K ↥p' := by
+  -- The two quotients have equal dimension because `secondIso` is an equivalence.
+  have hiso :
+      Module.finrank K (↥p ⧸ Submodule.comap p.subtype (p ⊓ p'))
+        = Module.finrank K (↥(p ⊔ p') ⧸ Submodule.comap (p ⊔ p').subtype p') :=
+    (secondIso p p').finrank_eq
+  -- Rank–nullity on the left quotient (ambient `↥p`).
+  have hL :
+      Module.finrank K (↥p ⧸ Submodule.comap p.subtype (p ⊓ p'))
+        + Module.finrank K ↥(p ⊓ p') = Module.finrank K ↥p := by
+    have := Submodule.finrank_quotient_add_finrank (Submodule.comap p.subtype (p ⊓ p'))
+    rwa [finrank_comap_inf] at this
+  -- Rank–nullity on the right quotient (ambient `↥(p ⊔ p')`).
+  have hR :
+      Module.finrank K (↥(p ⊔ p') ⧸ Submodule.comap (p ⊔ p').subtype p')
+        + Module.finrank K ↥p' = Module.finrank K ↥(p ⊔ p') := by
+    have := Submodule.finrank_quotient_add_finrank (Submodule.comap (p ⊔ p').subtype p')
+    rwa [finrank_comap_sup] at this
+  omega
+
+/-- **Direct-sum dimension corollary**: independent submodules add dimensions. -/
+theorem finrank_sup_of_inf_bot (h : p ⊓ p' = ⊥) :
+    Module.finrank K ↥(p ⊔ p') = Module.finrank K ↥p + Module.finrank K ↥p' := by
+  have hmod := finrank_modular_law p p'
+  rw [h, finrank_bot] at hmod
+  omega
+
+/-- **Co-dimension corollary**: spanning submodules' intersection carries the excess dimension. -/
+theorem finrank_inf_of_sup_top (h : p ⊔ p' = ⊤) :
+    Module.finrank K ↥(p ⊓ p') + Module.finrank K V
+      = Module.finrank K ↥p + Module.finrank K ↥p' := by
+  have hmod := finrank_modular_law p p'
+  rw [h, finrank_top] at hmod
+  omega
+
+end FiniteDimensional
+
+end SecondIsomorphismTheoremModulesOQ01

--- a/src/data/proofs/second-isomorphism-theorem-modules-oq-01/annotations.json
+++ b/src/data/proofs/second-isomorphism-theorem-modules-oq-01/annotations.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "ann-imports-docstring",
+    "proofId": "second-isomorphism-theorem-modules-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 49
+    },
+    "type": "concept",
+    "title": "The Diamond Isomorphism and the Modular Law",
+    "content": "The second (diamond) isomorphism theorem says p/(p∩p') ≃ (p+p')/p' for submodules p, p' of a module M. Mathlib provides this as LinearMap.quotientInfEquivSupQuotient, with the literal types read inside the ambient submodules: ↥p ⧸ comap p.subtype (p ⊓ p') and ↥(p ⊔ p') ⧸ comap (p ⊔ p').subtype p'. The entry asks whether this equivalence, on its own, recovers the modular dimension law finrank(p+p') + finrank(p∩p') = finrank p + finrank p' for finite-dimensional spaces — without invoking Mathlib's independent proof Submodule.finrank_sup_add_finrank_inf_eq. The answer is yes.",
+    "mathContext": "$p \\,/\\, (p \\cap p') \\;\\cong\\; (p + p') \\,/\\, p'$; taking dimensions gives $\\dim(p+p') + \\dim(p \\cap p') = \\dim p + \\dim p'$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "isomorphism theorems",
+      "modular dimension law",
+      "quotient modules",
+      "submodule lattice"
+    ],
+    "prerequisites": [
+      "modules and quotient modules",
+      "linear equivalences"
+    ]
+  },
+  {
+    "id": "ann-second-iso",
+    "proofId": "second-isomorphism-theorem-modules-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 71
+    },
+    "type": "definition",
+    "title": "The Second Isomorphism as a Named Equivalence",
+    "content": "secondIso packages Mathlib's LinearMap.quotientInfEquivSupQuotient as a LinearEquiv over an arbitrary ring R and module M, writing the ambient comaps explicitly in the type so the statement is self-describing. secondIso_bijective records that the underlying linear map is a genuine bijection — this is inherited from the equivalence, which Mathlib constructs via LinearEquiv.ofBijective from an explicit injectivity and surjectivity proof, not by fiat. Keeping this section over a general ring makes clear that the isomorphism itself needs no finiteness or field hypothesis.",
+    "mathContext": "$\\uparrow\\!p \\,\\big/\\, \\mathrm{comap}\\,p.\\mathrm{subtype}\\,(p \\sqcap p') \\;\\simeq_{\\ell}[R]\\; \\uparrow\\!(p \\sqcup p') \\,\\big/\\, \\mathrm{comap}\\,(p \\sqcup p').\\mathrm{subtype}\\,p'$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "LinearEquiv",
+      "bijection",
+      "LinearMap.quotientInfEquivSupQuotient"
+    ],
+    "prerequisites": [
+      "linear equivalences",
+      "comap of a submodule under an inclusion"
+    ]
+  },
+  {
+    "id": "ann-comap-dimensions",
+    "proofId": "second-isomorphism-theorem-modules-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 88
+    },
+    "type": "key-step",
+    "title": "Re-reading the Quotient Denominators as Honest Submodules",
+    "content": "The equivalence's quotient denominators are comaps into the ambient submodules — comap p.subtype (p ⊓ p') sits inside ↥p, not in M. finrank_comap_inf and finrank_comap_sup use Submodule.comapSubtypeEquivOfLe (which, for p ≤ q, gives comap q.subtype p ≃ₗ p) to certify these comaps have the same finrank as p ⊓ p' and p' respectively. Without this bridge, rank–nullity would speak about the comaps rather than the dimensions finrank(p ⊓ p') and finrank p' that appear in the modular law. The omit clause drops the unused [FiniteDimensional K V] instance from these two lemmas, since each follows from a plain linear equivalence.",
+    "mathContext": "For $p \\le q$, $\\mathrm{comap}\\,q.\\mathrm{subtype}\\,p \\simeq_\\ell p$, so $\\operatorname{finrank}$ is preserved; applied with $p \\sqcap p' \\le p$ and $p' \\le p \\sqcup p'$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Submodule.comapSubtypeEquivOfLe",
+      "LinearEquiv.finrank_eq",
+      "comap"
+    ],
+    "prerequisites": [
+      "comap under an inclusion map",
+      "dimension invariance under equivalence"
+    ]
+  },
+  {
+    "id": "ann-modular-law",
+    "proofId": "second-isomorphism-theorem-modules-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 112
+    },
+    "type": "key-step",
+    "title": "From Equal Quotient Dimensions to the Modular Law",
+    "content": "finrank_modular_law is the heart of the entry. The single quantitative fact taken from the diamond equivalence is that its two sides have equal finrank ((secondIso p p').finrank_eq). Rank–nullity in quotient form (Submodule.finrank_quotient_add_finrank) gives two additive identities: finrank(↥p ⧸ ...) + finrank(p ⊓ p') = finrank p and finrank(↥(p ⊔ p') ⧸ ...) + finrank p' = finrank(p ⊔ p'), each after rewriting the denominator dimension via the comap lemmas. omega then combines the isomorphism equality with these two identities — never forming a difference explicitly, so the proof stays in ℕ — to conclude finrank(p ⊔ p') + finrank(p ⊓ p') = finrank p + finrank p'.",
+    "mathContext": "$\\dim Q_L = \\dim Q_R$, $\\dim Q_L = \\dim p - \\dim(p\\cap p')$, $\\dim Q_R = \\dim(p+p') - \\dim p'$ $\\Rightarrow$ $\\dim(p+p') + \\dim(p\\cap p') = \\dim p + \\dim p'$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "rank-nullity theorem",
+      "Submodule.finrank_quotient_add_finrank",
+      "modular law",
+      "omega"
+    ],
+    "prerequisites": [
+      "rank-nullity for quotients",
+      "natural-number linear arithmetic"
+    ]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "second-isomorphism-theorem-modules-oq-01",
+    "range": {
+      "startLine": 114,
+      "endLine": 127
+    },
+    "type": "key-step",
+    "title": "Direct-Sum and Co-Dimension Corollaries",
+    "content": "Two boundary cases of the modular law. finrank_sup_of_inf_bot: when p ⊓ p' = ⊥, finrank_bot rewrites finrank(p ⊓ p') to 0 and the law becomes finrank(p ⊔ p') = finrank p + finrank p' — dimensions add for independent submodules, the dimension count behind internal direct sums. finrank_inf_of_sup_top: when p ⊔ p' = ⊤, finrank_top rewrites finrank(p ⊔ p') to finrank V, giving finrank(p ⊓ p') + finrank V = finrank p + finrank p' — for two spanning submodules, the intersection carries exactly the excess of their dimensions over the whole space.",
+    "mathContext": "$p \\cap p' = 0 \\Rightarrow \\dim(p+p') = \\dim p + \\dim p'$; $\\ p + p' = V \\Rightarrow \\dim(p \\cap p') + \\dim V = \\dim p + \\dim p'$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "internal direct sum",
+      "codimension",
+      "finrank_bot",
+      "finrank_top"
+    ],
+    "prerequisites": [
+      "the modular dimension law",
+      "the lattice bounds ⊥ and ⊤"
+    ]
+  }
+]

--- a/src/data/proofs/second-isomorphism-theorem-modules-oq-01/meta.json
+++ b/src/data/proofs/second-isomorphism-theorem-modules-oq-01/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "second-isomorphism-theorem-modules-oq-01",
+  "title": "Second (Diamond) Isomorphism Theorem for Modules: the modular dimension law as a corollary",
+  "slug": "second-isomorphism-theorem-modules-oq-01",
+  "description": "Mathlib packages the second (diamond) isomorphism theorem as the linear equivalence p/(p∩p') ≃ (p+p')/p'. This entry asks whether that equivalence carries genuine computational force: does it, on its own, recover the modular dimension law finrank(p+p') + finrank(p∩p') = finrank p + finrank p' for finite-dimensional vector spaces — without appealing to Mathlib's independent proof? The answer is yes: combining the isomorphism with rank–nullity and the dimension-invariance of comaps under inclusion derives the modular law and its direct-sum and co-dimension corollaries.",
+  "meta": {
+    "author": "Emmy Noether (1927); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SecondIsomorphismTheoremModulesOQ01.lean",
+    "tags": [
+      "algebra",
+      "module-theory",
+      "linear-algebra",
+      "isomorphism-theorems",
+      "dimension",
+      "rank-nullity",
+      "classic"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "LinearMap.quotientInfEquivSupQuotient",
+        "description": "The second (diamond) isomorphism theorem for modules: the linear equivalence p ⧸ (p ⊓ p') ≃ₗ (p ⊔ p') ⧸ p', read inside the appropriate ambient submodules",
+        "module": "Mathlib.LinearAlgebra.Isomorphisms"
+      },
+      {
+        "theorem": "Submodule.finrank_quotient_add_finrank",
+        "description": "Rank–nullity for quotients: finrank (M ⧸ N) + finrank N = finrank M for a submodule N of a finite-dimensional space",
+        "module": "Mathlib.LinearAlgebra.FiniteDimensional.Lemmas"
+      },
+      {
+        "theorem": "Submodule.comapSubtypeEquivOfLe",
+        "description": "For submodules p ≤ q, the comap of p under q's inclusion is linearly equivalent to p; hence they share a finrank",
+        "module": "Mathlib.Algebra.Module.Submodule.Map"
+      },
+      {
+        "theorem": "LinearEquiv.finrank_eq",
+        "description": "A linear equivalence preserves finrank; applied to the second-isomorphism equivalence to equate the two quotient dimensions",
+        "module": "Mathlib.LinearAlgebra.FiniteDimensional.Basic"
+      }
+    ],
+    "originalContributions": [
+      "secondIso: the second (diamond) isomorphism theorem packaged as a named LinearEquiv over an arbitrary ring and module, with the ambient comaps made explicit in the type",
+      "secondIso_bijective: confirmation that the underlying linear map is a genuine bijection (the equivalence is constructed via LinearEquiv.ofBijective upstream, not postulated)",
+      "finrank_modular_law: the modular dimension law finrank(p ⊔ p') + finrank(p ⊓ p') = finrank p + finrank p', derived purely from the second isomorphism theorem plus rank–nullity, independently of Mathlib's Submodule.finrank_sup_add_finrank_inf_eq",
+      "finrank_sup_of_inf_bot: the direct-sum corollary — independent submodules (p ⊓ p' = ⊥) add their dimensions",
+      "finrank_inf_of_sup_top: the dual co-dimension corollary — for spanning submodules (p ⊔ p' = ⊤), the intersection carries the excess dimension"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 131,
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The three isomorphism theorems are the foundational structure theorems of abstract algebra, formulated in full generality by Emmy Noether in the 1920s. The second — the diamond or parallelogram theorem — states that for submodules p, p' of a module M, the quotient p/(p∩p') is isomorphic to (p+p')/p'. Its name comes from the Hasse diagram: p∩p', p, p', and p+p' form a diamond, and the theorem says the two 'slanted' edges (the quotients along opposite sides) are isomorphic. Over a field, taking dimensions of both sides of this isomorphism yields the modular law dim(p+p') + dim(p∩p') = dim p + dim p', the linear-algebraic analogue of inclusion–exclusion.",
+    "problemStatement": "Mathlib records the second isomorphism theorem as the equivalence `LinearMap.quotientInfEquivSupQuotient` and, separately and independently, the dimension identity `Submodule.finrank_sup_add_finrank_inf_eq`. Does the isomorphism *alone* — together with rank–nullity — force the dimension identity, or is the latter genuinely independent content?\n\n**Answer:** The isomorphism alone suffices. The modular dimension law is a corollary of the second isomorphism theorem.",
+    "text": "The second (diamond) isomorphism theorem p/(p∩p') ≃ (p+p')/p' is shown to imply the modular dimension law finrank(p+p') + finrank(p∩p') = finrank p + finrank p', verified in Lean with no axioms, and the direct-sum and co-dimension corollaries are read off from it.",
+    "proofStrategy": "1. secondIso: name the Mathlib equivalence as a LinearEquiv with the ambient comaps spelled out — domain ↥p ⧸ comap p.subtype (p ⊓ p'), codomain ↥(p ⊔ p') ⧸ comap (p ⊔ p').subtype p'.\n2. finrank_comap_inf / finrank_comap_sup: via Submodule.comapSubtypeEquivOfLe, the comap of p ⊓ p' into p has finrank equal to finrank ↥(p ⊓ p'), and likewise the comap of p' into p ⊔ p' equals finrank ↥p'. These translate the quotient denominators back to honest submodule dimensions.\n3. finrank_modular_law: a linear equivalence preserves finrank, so the two quotients (left over ↥p, right over ↥(p ⊔ p')) have equal dimension. Rank–nullity (Submodule.finrank_quotient_add_finrank) turns each quotient dimension into a difference: finrank(↥p ⧸ ...) = finrank p − finrank(p ⊓ p') and finrank(↥(p ⊔ p') ⧸ ...) = finrank(p ⊔ p') − finrank p'. Equating the two and clearing the subtractions with omega yields the modular law.\n4. finrank_sup_of_inf_bot: substitute p ⊓ p' = ⊥ (finrank_bot rewrites its dimension to 0) into the modular law.\n5. finrank_inf_of_sup_top: substitute p ⊔ p' = ⊤ (finrank_top rewrites its dimension to finrank V).",
+    "keyInsights": [
+      "**Isomorphism ⟹ equal dimension**: the only quantitative fact extracted from the diamond equivalence is that its two sides have equal finrank (LinearEquiv.finrank_eq). Everything quantitative then comes from rank–nullity applied to each side.",
+      "**The denominators must be re-read as honest submodules**: Mathlib states the equivalence with quotient denominators that are comaps into the ambient submodules (comap p.subtype (p ⊓ p'), not p ⊓ p' itself). Submodule.comapSubtypeEquivOfLe certifies these comaps have the expected dimensions, which is what lets rank–nullity speak about finrank p, finrank p', finrank(p ⊓ p'), finrank(p ⊔ p').",
+      "**Natural-subtraction discipline**: rank–nullity is stated additively (quotient + sub = whole), so the proof never forms a difference explicitly; omega combines the two additive identities and the isomorphism equality into the modular law without leaving ℕ.",
+      "**An independent route to a known lemma**: Mathlib already proves the modular law as Submodule.finrank_sup_add_finrank_inf_eq by a direct argument. The value here is exhibiting it as a *consequence* of the structural isomorphism theorem — making explicit the conceptual dependency the two Mathlib results leave implicit."
+    ],
+    "prerequisites": [
+      "Modules and submodules over a ring; quotient modules",
+      "Linear equivalences and that they preserve dimension",
+      "The rank–nullity theorem in its quotient form",
+      "The lattice of submodules: ⊓ (intersection), ⊔ (sum), ⊥, ⊤"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Statement",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "File-level docstring framing the question: does the second isomorphism theorem carry computational force enough to recover the modular dimension law without Mathlib's independent proof? Records the equivalence, the ambient-comap subtlety, and the derivation plan. Imports Mathlib's Isomorphisms and FiniteDimensional.Lemmas.",
+      "mathContext": "Second isomorphism theorem: p ⧸ (p ⊓ p') ≃ₗ (p ⊔ p') ⧸ p', stated inside ambient submodules."
+    },
+    {
+      "id": "second-iso",
+      "title": "The Second Isomorphism Theorem as a Named Equivalence",
+      "startLine": 55,
+      "endLine": 71,
+      "summary": "secondIso names LinearMap.quotientInfEquivSupQuotient as a LinearEquiv over an arbitrary ring R and module M, with the ambient comaps written explicitly in the type. secondIso_bijective records that the underlying map is a genuine bijection, inherited from the equivalence (constructed upstream via LinearEquiv.ofBijective, not postulated).",
+      "mathContext": "For submodules p, p' of an R-module M: ↥p ⧸ comap p.subtype (p ⊓ p') ≃ₗ[R] ↥(p ⊔ p') ⧸ comap (p ⊔ p').subtype p'."
+    },
+    {
+      "id": "comap-dimensions",
+      "title": "Dimension Invariance of the Comap Denominators",
+      "startLine": 73,
+      "endLine": 88,
+      "summary": "finrank_comap_inf and finrank_comap_sup use Submodule.comapSubtypeEquivOfLe to show the two quotient denominators — comaps of p ⊓ p' into p and of p' into p ⊔ p' — have the same finrank as p ⊓ p' and p' respectively. These are the bridge lemmas that let rank–nullity speak about honest submodule dimensions.",
+      "mathContext": "comap q.subtype p ≃ₗ p when p ≤ q, hence finrank-equal; applied with inf_le_left and le_sup_right."
+    },
+    {
+      "id": "modular-law",
+      "title": "Deriving the Modular Dimension Law",
+      "startLine": 90,
+      "endLine": 112,
+      "summary": "finrank_modular_law: the equivalence gives equal finrank of the two quotients (LinearEquiv.finrank_eq); rank–nullity (Submodule.finrank_quotient_add_finrank) on each side, rewritten by the comap-dimension lemmas, gives two additive identities; omega combines them with the isomorphism equality to produce finrank(p ⊔ p') + finrank(p ⊓ p') = finrank p + finrank p'.",
+      "mathContext": "dim(p+p') + dim(p∩p') = dim p + dim p' — the linear-algebraic inclusion–exclusion, here a corollary of the diamond isomorphism."
+    },
+    {
+      "id": "corollaries",
+      "title": "Direct-Sum and Co-Dimension Corollaries",
+      "startLine": 114,
+      "endLine": 127,
+      "summary": "finrank_sup_of_inf_bot: when p ⊓ p' = ⊥, the modular law collapses to finrank(p ⊔ p') = finrank p + finrank p' (dimensions add for independent submodules). finrank_inf_of_sup_top: when p ⊔ p' = ⊤, it becomes finrank(p ⊓ p') + finrank V = finrank p + finrank p' (the intersection carries the excess of two spanning submodules).",
+      "mathContext": "Special cases p∩p'=0 (direct sum) and p+p'=V (spanning) of the modular law."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Noether, Emmy",
+      "title": "Abstrakter Aufbau der Idealtheorie in algebraischen Zahl- und Funktionenkörpern",
+      "year": "1927",
+      "note": "General formulation of the isomorphism theorems for modules and rings"
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "note": "Section 10.2 (the isomorphism theorems for modules) and the modular/dimension law for vector spaces"
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": {
+    "summary": "The modular dimension law finrank(p ⊔ p') + finrank(p ⊓ p') = finrank p + finrank p' is derived purely from the second (diamond) isomorphism theorem (secondIso) and the quotient form of rank–nullity, with the comap denominators identified via comapSubtypeEquivOfLe. The direct-sum (finrank_sup_of_inf_bot) and co-dimension (finrank_inf_of_sup_top) corollaries follow by substituting the boundary cases ⊥ and ⊤. All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Makes explicit the conceptual dependency between two facts Mathlib proves independently — the diamond isomorphism and the modular dimension law — by exhibiting the latter as a corollary of the former, the standard textbook route.",
+    "openQuestions": [
+      "Can the analogous count for three submodules be derived structurally, given that the naive 'inclusion–exclusion' finrank(p ⊔ q ⊔ r) formula fails for the lattice of subspaces (it is non-distributive)?",
+      "Does the same isomorphism-to-invariant strategy recover the additivity of length (composition-series length) for modules over a ring, in place of finrank over a field?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.LinearAlgebra.Isomorphisms",
+      "Mathlib.LinearAlgebra.FiniteDimensional.Lemmas"
+    ],
+    "opens": [
+      "Submodule",
+      "FiniteDimensional",
+      "Module"
+    ],
+    "namespace": "SecondIsomorphismTheoremModulesOQ01",
+    "lineCount": 131,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/SecondIsomorphismTheoremModulesOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Packages Mathlib's **second (diamond) isomorphism theorem** `LinearMap.quotientInfEquivSupQuotient`

  `p ⧸ (p ⊓ p')  ≃ₗ[R]  (p ⊔ p') ⧸ p'`

as a named `LinearEquiv` (`secondIso`, over any ring/module) and shows it carries genuine **computational** force: the equivalence *alone* — plus rank–nullity for quotients and the dimension-invariance of comaps under inclusion — recovers the **modular dimension law**

  `finrank(p ⊔ p') + finrank(p ⊓ p') = finrank p + finrank p'`

for finite-dimensional vector spaces, **independently** of Mathlib's own `Submodule.finrank_sup_add_finrank_inf_eq`.

## What's established

- `secondIso` — the diamond isomorphism as a named `LinearEquiv` (any ring/module), ambient comaps explicit in the type.
- `secondIso_bijective` — the underlying map is a genuine bijection (constructed via `LinearEquiv.ofBijective` upstream, not postulated).
- `finrank_modular_law` — the modular dimension law, derived from `secondIso` + `Submodule.finrank_quotient_add_finrank` + `Submodule.comapSubtypeEquivOfLe`.
- `finrank_sup_of_inf_bot` — direct-sum corollary: `p ⊓ p' = ⊥ ⟹ finrank(p ⊔ p') = finrank p + finrank p'`.
- `finrank_inf_of_sup_top` — dual co-dimension corollary: `p ⊔ p' = ⊤ ⟹ finrank(p ⊓ p') + finrank V = finrank p + finrank p'`.

The value is exhibiting the dimension law as a *corollary* of the structural isomorphism theorem — the standard textbook route — making explicit a dependency Mathlib's two independent results leave implicit.

## Verification

- 6 theorems + 1 definition, **0 sorry / 0 axiom / 0 `native_decide`**.
- Builds green via Docker wrapper (`3058 jobs`), no warnings.
- Depends only on foundational axioms (`propext`, `Classical.choice`, `Quot.sound`) through standard Mathlib lemmas.
- `status: verified`, `badge: verified`, `axiomCount: 0`.

Gallery entry added: `src/data/proofs/second-isomorphism-theorem-modules-oq-01/` (meta.json + annotations.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)