### PR TITLE
research(tangent-addition-formula-oq-01): triangle tangent & cotangent identities [verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3243,6 +3243,7 @@ import Proofs.SzemerediRegularity
 import Proofs.SzemerediRegularityOQ02
 import Proofs.SzemerediTheorem
 import Proofs.SzemerediTheoremOQ01
+import Proofs.TangentAdditionFormula
 import Proofs.TaxicabNumberOQ01
 import Proofs.TaylorSinCosConvergence
 import Proofs.TaylorSinCosConvergenceOQ01

--- a/proofs/Proofs/TangentAdditionFormula.lean
+++ b/proofs/Proofs/TangentAdditionFormula.lean
@@ -1,0 +1,130 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan
+import Mathlib.Analysis.Complex.Trigonometric
+import Mathlib.Tactic
+
+/-
+# The Tangent Addition Law and the Triangle Tangent Identities
+
+## What This Proves
+
+Starting from the tangent addition law, this file builds up to two classical
+*triangle* identities that are **not** in Mathlib:
+
+* **Triple tangent identity.** If `A + B + C = π` (the angles of a triangle)
+  and none of the angles is a right angle, then
+  `tan A + tan B + tan C = tan A · tan B · tan C`.
+  The sum of the tangents equals their product — a striking fact with no
+  analogue for sine or cosine.
+
+* **Triple cotangent identity.** Under the same angle-sum constraint (with no
+  angle equal to `0` or `π`),
+  `cot A · cot B + cot B · cot C + cot C · cot A = 1`.
+
+Both reduce to a single symmetric polynomial identity in the sines and cosines
+of the three angles, `sin_cos_triangle_identity`, which is the mathematical
+heart of the file.
+
+## Relation to Mathlib
+
+Mathlib already provides the *two-argument* tangent laws
+(`Real.tan_add`, `Real.tan_add'`, `Real.tan_sub`, `Real.tan_two_mul`) and the
+arctangent addition law (`Real.arctan_add`), but it states them with the
+hypothesis `∀ k : ℤ, x ≠ (2 k + 1) * π / 2`. We first repackage addition and
+subtraction with the more usable hypothesis `cos x ≠ 0` (equivalent via
+`Real.cos_eq_zero_iff`), then prove the genuinely new three-angle identities.
+
+As a concrete application on rational tangents we derive
+`arctan (1/2) + arctan (1/3) = π/4`, connecting to the gallery's
+`MachinFromAddition` entry from the tangent side.
+-/
+
+namespace TangentAdditionFormula
+
+open Real
+
+variable {x y A B C : ℝ}
+
+/-- **Tangent addition law, `cos ≠ 0` form.** This is `Real.tan_add'` restated
+with the directly checkable hypotheses `cos x ≠ 0`, `cos y ≠ 0`
+(equivalent to "`x`, `y` are not odd multiples of `π/2`" by
+`Real.cos_eq_zero_iff`). -/
+theorem tan_add_of_cos_ne_zero (hx : cos x ≠ 0) (hy : cos y ≠ 0) :
+    tan (x + y) = (tan x + tan y) / (1 - tan x * tan y) := by
+  refine Real.tan_add' ⟨fun k => ?_, fun l => ?_⟩
+  · intro hk; exact hx (cos_eq_zero_iff.mpr ⟨k, hk⟩)
+  · intro hl; exact hy (cos_eq_zero_iff.mpr ⟨l, hl⟩)
+
+/-- **Tangent subtraction law, `cos ≠ 0` form.** The companion of
+`tan_add_of_cos_ne_zero`, with the characteristic `1 + tan x · tan y`
+denominator. -/
+theorem tan_sub_of_cos_ne_zero (hx : cos x ≠ 0) (hy : cos y ≠ 0) :
+    tan (x - y) = (tan x - tan y) / (1 + tan x * tan y) := by
+  refine Real.tan_sub' ⟨fun k => ?_, fun l => ?_⟩
+  · intro hk; exact hx (cos_eq_zero_iff.mpr ⟨k, hk⟩)
+  · intro hl; exact hy (cos_eq_zero_iff.mpr ⟨l, hl⟩)
+
+/-- **The symmetric trigonometric heart.** For three angles summing to `π`,
+`sin A cos B cos C + sin B cos A cos C + sin C cos A cos B = sin A sin B sin C`.
+
+Both triple identities below are this polynomial identity divided by an
+appropriate product of sines or cosines. It is proved by eliminating `C` via
+`C = π - (A + B)` and expanding with the two-argument addition laws. -/
+theorem sin_cos_triangle_identity (h : A + B + C = π) :
+    sin A * cos B * cos C + sin B * cos A * cos C + sin C * cos A * cos B
+      = sin A * sin B * sin C := by
+  have hC : C = π - (A + B) := by linarith
+  rw [hC, sin_pi_sub, cos_pi_sub, sin_add, cos_add]
+  ring
+
+/-- **Triple tangent identity.** For the angles of a (possibly degenerate)
+triangle, `A + B + C = π`, with no angle a right angle (`cos · ≠ 0`),
+the sum of the tangents equals their product:
+`tan A + tan B + tan C = tan A · tan B · tan C`. Not in Mathlib. -/
+theorem tan_sum_eq_tan_prod (h : A + B + C = π)
+    (hA : cos A ≠ 0) (hB : cos B ≠ 0) (hC : cos C ≠ 0) :
+    tan A + tan B + tan C = tan A * tan B * tan C := by
+  have e1 : tan A + tan B + tan C
+      = (sin A * cos B * cos C + sin B * cos A * cos C + sin C * cos A * cos B)
+          / (cos A * cos B * cos C) := by
+    rw [tan_eq_sin_div_cos, tan_eq_sin_div_cos, tan_eq_sin_div_cos]
+    field_simp
+  have e2 : tan A * tan B * tan C
+      = sin A * sin B * sin C / (cos A * cos B * cos C) := by
+    rw [tan_eq_sin_div_cos, tan_eq_sin_div_cos, tan_eq_sin_div_cos]
+    field_simp
+  rw [e1, e2, sin_cos_triangle_identity h]
+
+/-- **Triple cotangent identity.** For `A + B + C = π` with no angle a multiple
+of `π` (`sin · ≠ 0`), the pairwise products of cotangents sum to `1`:
+`cot A · cot B + cot B · cot C + cot C · cot A = 1`. Not in Mathlib. -/
+theorem cot_sum_eq_one (h : A + B + C = π)
+    (hA : sin A ≠ 0) (hB : sin B ≠ 0) (hC : sin C ≠ 0) :
+    cot A * cot B + cot B * cot C + cot C * cot A = 1 := by
+  have e : cot A * cot B + cot B * cot C + cot C * cot A
+      = (cos A * cos B * sin C + cos B * cos C * sin A + cos C * cos A * sin B)
+          / (sin A * sin B * sin C) := by
+    rw [cot_eq_cos_div_sin, cot_eq_cos_div_sin, cot_eq_cos_div_sin]
+    field_simp
+  rw [e, div_eq_one_iff_eq (mul_ne_zero (mul_ne_zero hA hB) hC)]
+  linear_combination sin_cos_triangle_identity h
+
+/-- **Concrete application on rational tangents.**
+`arctan (1/2) + arctan (1/3) = π/4`. The two right-triangle angles with leg
+ratios `1:2` and `1:3` add to half a right angle — the tangent addition law
+applied to `tan = 1/2, 1/3` lands exactly on `tan = 1`. -/
+theorem arctan_half_add_arctan_third :
+    arctan (1 / 2) + arctan (1 / 3) = π / 4 := by
+  have harg : ((1 : ℝ) / 2 + 1 / 3) / (1 - 1 / 2 * (1 / 3)) = 1 := by norm_num
+  rw [arctan_add (by norm_num), harg, arctan_one]
+
+/-- The equilateral instance of the triple tangent identity: with all three
+angles equal to `π/3`, both sides equal `3√3`. A concrete check that the
+centerpiece theorem applies. -/
+example :
+    tan (π / 3) + tan (π / 3) + tan (π / 3)
+      = tan (π / 3) * tan (π / 3) * tan (π / 3) := by
+  have h : π / 3 + π / 3 + π / 3 = π := by ring
+  have hcos : cos (π / 3) ≠ 0 := by rw [cos_pi_div_three]; norm_num
+  exact tan_sum_eq_tan_prod h hcos hcos hcos
+
+end TangentAdditionFormula

--- a/src/data/proofs/tangent-addition-formula-oq-01/annotations.json
+++ b/src/data/proofs/tangent-addition-formula-oq-01/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-addition-subtraction",
+    "proofId": "tangent-addition-formula-oq-01",
+    "range": { "startLine": 47, "endLine": 64 },
+    "type": "theorem",
+    "title": "Addition & Subtraction in cos≠0 Form (tan_add_of_cos_ne_zero, tan_sub_of_cos_ne_zero)",
+    "content": "These two lemmas restate Mathlib's Real.tan_add' and Real.tan_sub' with the directly checkable hypotheses cos x ≠ 0 and cos y ≠ 0. Mathlib phrases the precondition as '∀ k : ℤ, x ≠ (2k+1)·π/2' (x is not an odd multiple of π/2); Real.cos_eq_zero_iff says exactly cos x = 0 ↔ ∃ k, x = (2k+1)π/2, so cos x ≠ 0 supplies the universal statement by contraposition. The proofs are a one-line refine that discharges each conjunct with cos_eq_zero_iff.mpr. The output is the familiar tan(x+y) = (tan x + tan y)/(1 − tan x tan y) and tan(x−y) = (tan x − tan y)/(1 + tan x tan y).",
+    "mathContext": "$\\tan(x\\pm y) = \\dfrac{\\tan x \\pm \\tan y}{1 \\mp \\tan x\\,\\tan y}$ when $\\cos x,\\cos y\\neq 0$.",
+    "prerequisites": [
+      "Real.tan_add' and Real.tan_sub' (the ∀k≠(2k+1)π/2 forms)",
+      "Real.cos_eq_zero_iff (cos θ = 0 ↔ ∃ k, θ = (2k+1)π/2)"
+    ],
+    "relatedConcepts": ["angle addition formula", "tangent", "right angle / odd multiple of π/2"],
+    "significance": "Usability building blocks: they expose the addition and subtraction laws under the single hypothesis one actually verifies for a concrete angle, namely cos ≠ 0."
+  },
+  {
+    "id": "ann-trig-heart",
+    "proofId": "tangent-addition-formula-oq-01",
+    "range": { "startLine": 66, "endLine": 77 },
+    "type": "theorem",
+    "title": "The Symmetric Trigonometric Heart (sin_cos_triangle_identity)",
+    "content": "For A+B+C = π this proves sin A cos B cos C + sin B cos A cos C + sin C cos A cos B = sin A sin B sin C. The proof eliminates one angle: C = π − (A+B) (linarith), then Real.sin_pi_sub turns sin C into sin(A+B) and Real.cos_pi_sub turns cos C into −cos(A+B); expanding with Real.sin_add and Real.cos_add reduces the whole goal to a polynomial in sin A, cos A, sin B, cos B, which ring closes. The (A+B) angle cancels exactly. This single identity is the trigonometric content shared by both triangle identities below.",
+    "mathContext": "$A+B+C=\\pi \\Rightarrow \\sin A\\cos B\\cos C + \\sin B\\cos A\\cos C + \\sin C\\cos A\\cos B = \\sin A\\sin B\\sin C$.",
+    "prerequisites": [
+      "Real.sin_pi_sub (sin(π−x) = sin x), Real.cos_pi_sub (cos(π−x) = −cos x)",
+      "Real.sin_add, Real.cos_add",
+      "linarith, ring"
+    ],
+    "relatedConcepts": ["symmetric polynomial identity", "angle-sum constraint", "supplementary angle"],
+    "significance": "The load-bearing lemma: both the triple tangent and triple cotangent identities are this single fact divided by a product of cosines or of sines."
+  },
+  {
+    "id": "ann-triple-tangent",
+    "proofId": "tangent-addition-formula-oq-01",
+    "range": { "startLine": 79, "endLine": 95 },
+    "type": "theorem",
+    "title": "The Triple Tangent Identity (tan_sum_eq_tan_prod) — centerpiece",
+    "content": "For a triangle A+B+C = π with no right angle (cos A, cos B, cos C ≠ 0), tan A + tan B + tan C = tan A · tan B · tan C. After rewriting each tangent as sin/cos, both sides are expressed over the common denominator cos A cos B cos C: the sum becomes the heart numerator sin A cos B cos C + sin B cos A cos C + sin C cos A cos B (established by field_simp), and the product becomes sin A sin B sin C, both over cos A cos B cos C. Applying sin_cos_triangle_identity equates the two numerators, closing the goal. The striking phenomenon — a sum equal to a product — has no sine or cosine analogue. This identity is NOT in Mathlib.",
+    "mathContext": "$A+B+C=\\pi,\\ \\cos A,\\cos B,\\cos C\\neq 0 \\Rightarrow \\tan A + \\tan B + \\tan C = \\tan A\\,\\tan B\\,\\tan C$.",
+    "prerequisites": [
+      "Real.tan_eq_sin_div_cos",
+      "field_simp under cos A, cos B, cos C ≠ 0",
+      "sin_cos_triangle_identity (this file)"
+    ],
+    "relatedConcepts": ["triangle identity", "sum equals product", "tangent"],
+    "significance": "The centerpiece: a memorable triangle identity, absent from Mathlib, obtained by dividing the symmetric heart identity by the product of cosines."
+  },
+  {
+    "id": "ann-triple-cotangent",
+    "proofId": "tangent-addition-formula-oq-01",
+    "range": { "startLine": 97, "endLine": 110 },
+    "type": "theorem",
+    "title": "The Triple Cotangent Identity (cot_sum_eq_one)",
+    "content": "For A+B+C = π with no angle a multiple of π (sin A, sin B, sin C ≠ 0), cot A cot B + cot B cot C + cot C cot A = 1. Writing each cotangent as cos/sin and clearing denominators over sin A sin B sin C (field_simp) turns the left side into (cos A cos B sin C + cos B cos C sin A + cos C cos A sin B)/(sin A sin B sin C); div_eq_one_iff_eq reduces '= 1' to equating the numerator with sin A sin B sin C, which linear_combination matches against sin_cos_triangle_identity (the same monomials up to commutativity). The cotangent companion of the tangent identity — also NOT in Mathlib.",
+    "mathContext": "$A+B+C=\\pi,\\ \\sin A,\\sin B,\\sin C\\neq 0 \\Rightarrow \\cot A\\cot B + \\cot B\\cot C + \\cot C\\cot A = 1$.",
+    "prerequisites": [
+      "Real.cot_eq_cos_div_sin",
+      "div_eq_one_iff_eq, field_simp under sin A, sin B, sin C ≠ 0",
+      "linear_combination with sin_cos_triangle_identity (this file)"
+    ],
+    "relatedConcepts": ["triangle identity", "cotangent", "symmetric function"],
+    "significance": "Shows the heart identity is genuinely two-sided: the same polynomial, divided by the product of sines instead of cosines, gives the cotangent identity."
+  },
+  {
+    "id": "ann-arctan-application",
+    "proofId": "tangent-addition-formula-oq-01",
+    "range": { "startLine": 111, "endLine": 118 },
+    "type": "theorem",
+    "title": "Concrete Application: arctan(1/2) + arctan(1/3) = π/4 (arctan_half_add_arctan_third)",
+    "content": "A rational-tangent witness for the addition law. Since (1/2)·(1/3) = 1/6 < 1, Real.arctan_add gives arctan(1/2) + arctan(1/3) = arctan((1/2 + 1/3)/(1 − 1/6)). The argument simplifies (norm_num) to (5/6)/(5/6) = 1, and Real.arctan_one finishes with arctan 1 = π/4. This is the two-term analogue of Machin's formula and links the entry to MachinFromAddition from the tangent side.",
+    "mathContext": "$\\arctan\\tfrac12 + \\arctan\\tfrac13 = \\tfrac{\\pi}{4}$.",
+    "prerequisites": [
+      "Real.arctan_add (hypothesis x·y < 1)",
+      "Real.arctan_one (arctan 1 = π/4)",
+      "norm_num"
+    ],
+    "relatedConcepts": ["arctangent addition", "Machin-like formula", "π identities"],
+    "significance": "Anchors the abstract addition law to concrete rational tangents and to the gallery's Machin material."
+  },
+  {
+    "id": "ann-equilateral-check",
+    "proofId": "tangent-addition-formula-oq-01",
+    "range": { "startLine": 120, "endLine": 128 },
+    "type": "example",
+    "title": "Equilateral Check of the Triple Tangent Identity",
+    "content": "A worked instance of the centerpiece on the equilateral triangle: with A = B = C = π/3 (so A+B+C = π and cos(π/3) = 1/2 ≠ 0), tan_sum_eq_tan_prod yields tan(π/3) + tan(π/3) + tan(π/3) = tan(π/3)³, i.e. 3√3 = (√3)³ = 3√3. Demonstrates the main theorem reused on concrete data.",
+    "mathContext": "$A=B=C=\\tfrac{\\pi}{3}$: both sides equal $3\\sqrt3$.",
+    "prerequisites": [
+      "tan_sum_eq_tan_prod (this file)",
+      "Real.cos_pi_div_three (cos(π/3) = 1/2)"
+    ],
+    "relatedConcepts": ["equilateral triangle", "concrete instance", "sanity check"],
+    "significance": "Confirms the triple tangent identity is not vacuous and applies on a familiar triangle."
+  }
+]

--- a/src/data/proofs/tangent-addition-formula-oq-01/meta.json
+++ b/src/data/proofs/tangent-addition-formula-oq-01/meta.json
@@ -1,0 +1,110 @@
+{
+  "id": "tangent-addition-formula-oq-01",
+  "title": "The Tangent Addition Law and the Triangle Tangent Identities",
+  "slug": "tangent-addition-formula-oq-01",
+  "description": "Starting from the tangent addition law tan(x+y) = (tan x + tan y)/(1 − tan x · tan y), this entry builds up to two classical triangle identities that are NOT in Mathlib. Mathlib already ships the two-argument laws Real.tan_add / tan_add' / tan_sub / tan_two_mul and the arctangent law Real.arctan_add, but it states them with the hypothesis ∀ k : ℤ, x ≠ (2k+1)·π/2; we first repackage addition and subtraction with the directly usable hypothesis cos x ≠ 0 (equivalent via Real.cos_eq_zero_iff). The genuinely new content is the three-angle theory: (1) a single symmetric trigonometric identity sin A cos B cos C + sin B cos A cos C + sin C cos A cos B = sin A sin B sin C whenever A+B+C = π, proved by eliminating C = π−(A+B) and expanding with sin_add/cos_add — this is the mathematical heart; (2) the TRIPLE TANGENT IDENTITY tan A + tan B + tan C = tan A · tan B · tan C for a triangle (A+B+C = π, no right angle), the striking fact that the sum of the tangents equals their product, with no analogue for sine or cosine; (3) the TRIPLE COTANGENT IDENTITY cot A · cot B + cot B · cot C + cot C · cot A = 1, the same polynomial heart divided by the product of sines; (4) a concrete rational-tangent application arctan(1/2) + arctan(1/3) = π/4, connecting to the gallery's MachinFromAddition entry from the tangent side; (5) the equilateral check that the triple identity holds at A=B=C=π/3 (both sides 3√3). The tangent addition law underpins arctangent addition, Machin's formula for π, the Cayley transform, the slope-of-rotated-line formula, and the Weierstrass t = tan(θ/2) substitution.",
+  "leanFile": "Proofs/TangentAdditionFormula.lean",
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/List_of_trigonometric_identities#Angle_sum_and_difference_identities",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/TangentAdditionFormula.lean",
+    "tags": [
+      "trigonometry",
+      "tangent",
+      "cotangent",
+      "addition-formula",
+      "triangle",
+      "geometry",
+      "machin",
+      "arctangent"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "relatedProblems": [
+      {
+        "id": "triangle-angle-sum-oq-06",
+        "relationship": "The triangle-angle-sum family covers the sine/cosine addition and sum-to-product (prosthaphaeresis) identities for angles summing to π; this entry contributes the tangent and cotangent triangle identities, which have no sine/cosine analogue and rest on the same A+B+C=π constraint."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 130,
+    "assumptions": "0 axioms, 0 sorries, no native_decide, no Lean.ofReduceBool. All six theorems and the example depend only on the foundational propext / Classical.choice / Quot.sound. tan_add_of_cos_ne_zero and tan_sub_of_cos_ne_zero apply Real.tan_add' / Real.tan_sub' after converting cos x ≠ 0 to ¬∃k, x = (2k+1)π/2 via Real.cos_eq_zero_iff. sin_cos_triangle_identity eliminates C via C = π−(A+B) (linarith) and expands with Real.sin_pi_sub, Real.cos_pi_sub, Real.sin_add, Real.cos_add, closed by ring. tan_sum_eq_tan_prod and cot_sum_eq_one reduce to that single identity after rewriting tan = sin/cos (Real.tan_eq_sin_div_cos) / cot = cos/sin (Real.cot_eq_cos_div_sin), clearing denominators with field_simp under the cos≠0 / sin≠0 hypotheses, and applying it via rw / linear_combination. arctan_half_add_arctan_third uses Real.arctan_add (xy<1) and Real.arctan_one with a norm_num computation. The genuine hypotheses are the geometric side-conditions: A+B+C = π and the non-degeneracy cos·≠0 (no right angle) or sin·≠0 (no straight/zero angle).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The angle-sum formula for the tangent, tan(x+y) = (tan x + tan y)/(1 − tan x tan y), is the multiplicative counterpart of the sine and cosine addition laws and the algebraic engine behind much of classical π-computation: John Machin's 1706 formula and the whole family of arctangent identities are repeated applications of it. Restricted to the angles of a triangle, where A+B+C = π, it collapses into two of the most memorable identities in elementary trigonometry — the tangent identity tan A + tan B + tan C = tan A tan B tan C, in which a sum equals a product, and the cotangent identity cot A cot B + cot B cot C + cot C cot A = 1. Mathlib carries the two-argument tangent and arctangent laws but not these triangle specializations.",
+    "problemStatement": "Prove the tangent addition law in the directly usable form (with hypotheses cos x ≠ 0, cos y ≠ 0), and from it derive, for three real angles A, B, C with A + B + C = π: (i) the triple tangent identity tan A + tan B + tan C = tan A · tan B · tan C, valid when no angle is a right angle; (ii) the triple cotangent identity cot A cot B + cot B cot C + cot C cot A = 1, valid when no angle is a multiple of π; and as a concrete instance on rational tangents, arctan(1/2) + arctan(1/3) = π/4.",
+    "text": "Mathlib provides the bare two-argument tangent and arctangent laws, but states them with the integer-multiple-of-π/2 hypothesis and offers no three-angle specialization. This entry first repackages addition and subtraction with the checkable cos≠0 hypotheses, then isolates the symmetric polynomial identity that both triangle identities share — sin A cos B cos C + sin B cos A cos C + sin C cos A cos B = sin A sin B sin C under A+B+C = π — and divides it by the appropriate product of cosines or sines to obtain the tangent and cotangent identities. The new mathematical content is precisely the three-angle theory (the heart identity and the two triple identities); the addition/subtraction restatements are genuine usability lemmas, and the arctangent corollary plus the equilateral check anchor the abstract identities to concrete numbers.",
+    "keyInsights": [
+      "**The cos≠0 hypothesis is the usable face of the addition law.** Mathlib's Real.tan_add' requires '∀ k : ℤ, x ≠ (2k+1)·π/2', which is exactly cos x ≠ 0 by Real.cos_eq_zero_iff. Converting once gives tan_add_of_cos_ne_zero / tan_sub_of_cos_ne_zero, which take the single hypothesis cos x ≠ 0 — the form one actually checks for a concrete angle.",
+      "**Both triangle identities are one symmetric polynomial identity in disguise.** Under A+B+C = π one has sin A cos B cos C + sin B cos A cos C + sin C cos A cos B = sin A sin B sin C. Dividing by cos A cos B cos C yields the tangent identity; dividing by sin A sin B sin C yields the cotangent identity. The single lemma sin_cos_triangle_identity does all the trigonometric work.",
+      "**The heart identity is proved by eliminating one angle.** Writing C = π − (A+B) turns sin C into sin(A+B) and cos C into −cos(A+B) (Real.sin_pi_sub, Real.cos_pi_sub); expanding with the sine/cosine addition laws reduces everything to a polynomial in sin A, cos A, sin B, cos B that ring verifies — the (A+B) angle cancels exactly.",
+      "**Sum equals product is special to the tangent.** tan A + tan B + tan C = tan A tan B tan C has no counterpart for sine or cosine: it is forced by the angle constraint, and the side-condition 'no right angle' (cos · ≠ 0) is exactly what keeps every tangent finite so the identity is meaningful.",
+      "**The arctangent corollary lands the law on rational tangents.** With tangents 1/2 and 1/3 the addition formula gives (1/2 + 1/3)/(1 − 1/6) = 1, so arctan(1/2) + arctan(1/3) = arctan 1 = π/4 — a clean numeric witness connecting the tangent law to Machin-style π identities."
+    ],
+    "prerequisites": [
+      "Real.tan, Real.cot and Real.tan_eq_sin_div_cos / Real.cot_eq_cos_div_sin",
+      "Mathlib's two-argument laws Real.tan_add', Real.tan_sub' and the right-angle characterization Real.cos_eq_zero_iff",
+      "The sine/cosine addition and supplementary-angle laws Real.sin_add, Real.cos_add, Real.sin_pi_sub, Real.cos_pi_sub",
+      "Real.arctan_add (for x·y < 1) and Real.arctan_one for the rational-tangent application"
+    ]
+  },
+  "sections": [
+    {
+      "id": "addition-subtraction",
+      "title": "Addition and Subtraction in cos≠0 Form",
+      "startLine": 47,
+      "endLine": 64,
+      "mathContext": "$\\tan(x\\pm y) = \\dfrac{\\tan x \\pm \\tan y}{1 \\mp \\tan x\\,\\tan y}$ for $\\cos x,\\cos y\\neq 0$.",
+      "summary": "tan_add_of_cos_ne_zero and tan_sub_of_cos_ne_zero restate Mathlib's Real.tan_add' / Real.tan_sub' with the directly checkable hypotheses cos x ≠ 0, cos y ≠ 0, converting them to '∀ k, x ≠ (2k+1)π/2' through Real.cos_eq_zero_iff. These are the usability building blocks for the three-angle identities."
+    },
+    {
+      "id": "trig-heart",
+      "title": "The Symmetric Trigonometric Heart",
+      "startLine": 66,
+      "endLine": 77,
+      "mathContext": "$A+B+C=\\pi \\Rightarrow \\sin A\\cos B\\cos C + \\sin B\\cos A\\cos C + \\sin C\\cos A\\cos B = \\sin A\\sin B\\sin C$.",
+      "summary": "sin_cos_triangle_identity is the polynomial identity shared by both triangle identities. Eliminating C = π−(A+B) with sin_pi_sub / cos_pi_sub and expanding via sin_add / cos_add reduces the goal to a polynomial in sin/cos of A and B that ring closes; the (A+B) terms cancel exactly."
+    },
+    {
+      "id": "triple-tangent",
+      "title": "The Triple Tangent Identity (centerpiece)",
+      "startLine": 79,
+      "endLine": 95,
+      "mathContext": "$A+B+C=\\pi,\\ \\cos A,\\cos B,\\cos C\\neq 0 \\Rightarrow \\tan A + \\tan B + \\tan C = \\tan A\\,\\tan B\\,\\tan C$.",
+      "summary": "tan_sum_eq_tan_prod rewrites each tangent as sin/cos, expresses both sides as the heart numerator over cos A cos B cos C (cleared by field_simp under the cos≠0 hypotheses), and applies sin_cos_triangle_identity. The result: in any triangle without a right angle, the sum of the tangents equals their product — not in Mathlib."
+    },
+    {
+      "id": "triple-cotangent",
+      "title": "The Triple Cotangent Identity",
+      "startLine": 97,
+      "endLine": 110,
+      "mathContext": "$A+B+C=\\pi,\\ \\sin A,\\sin B,\\sin C\\neq 0 \\Rightarrow \\cot A\\cot B + \\cot B\\cot C + \\cot C\\cot A = 1$.",
+      "summary": "cot_sum_eq_one writes each cotangent as cos/sin, clears denominators over sin A sin B sin C, and reduces via div_eq_one_iff_eq to the same symmetric numerator, which linear_combination matches against sin_cos_triangle_identity. The cotangent companion of the tangent identity — also not in Mathlib."
+    },
+    {
+      "id": "arctan-application",
+      "title": "Concrete Application: arctan(1/2) + arctan(1/3) = π/4",
+      "startLine": 111,
+      "endLine": 118,
+      "mathContext": "$\\arctan\\tfrac12 + \\arctan\\tfrac13 = \\tfrac{\\pi}{4}$.",
+      "summary": "arctan_half_add_arctan_third applies Real.arctan_add (1/2 · 1/3 = 1/6 < 1): the combined argument (1/2 + 1/3)/(1 − 1/6) = 1, so the sum is arctan 1 = π/4. A rational-tangent witness for the addition law that links to the MachinFromAddition entry."
+    },
+    {
+      "id": "equilateral-check",
+      "title": "Equilateral Check",
+      "startLine": 120,
+      "endLine": 128,
+      "mathContext": "$A=B=C=\\tfrac{\\pi}{3}$: both sides equal $3\\sqrt3$.",
+      "summary": "A worked instance of the centerpiece: with all three angles π/3 (cos π/3 = 1/2 ≠ 0), tan_sum_eq_tan_prod gives tan(π/3)·3 = tan(π/3)³, i.e. 3√3 = (√3)³. Confirms the triple identity on a concrete triangle."
+    }
+  ],
+  "conclusion": "The tangent addition law is repackaged in the directly usable cos≠0 form and pushed to its two classical triangle specializations — tan A + tan B + tan C = tan A tan B tan C and cot A cot B + cot B cot C + cot C cot A = 1 for A+B+C = π — neither of which is in Mathlib. Both rest on a single symmetric polynomial identity in the sines and cosines of the three angles, proved by eliminating one angle and expanding the two-argument laws. The development is sorry-free and axiom-free (only propext / Classical.choice / Quot.sound), with the rational-tangent corollary arctan(1/2)+arctan(1/3) = π/4 and an equilateral check anchoring the abstract identities to concrete numbers.",
+  "crossReferences": ["triangle-angle-sum-oq-06"]
+}


### PR DESCRIPTION
## Tangent Addition Law → Triangle Tangent & Cotangent Identities

Builds the tangent addition law into two classical **triangle identities that are not in Mathlib**.

### What's new (not in Mathlib)
Mathlib ships the two-argument laws (`Real.tan_add`, `tan_add'`, `tan_sub`, `tan_two_mul`) and `Real.arctan_add`, but no three-angle specialization. This entry adds:

- **Symmetric heart identity** — `A+B+C=π ⟹ sin A cos B cos C + sin B cos A cos C + sin C cos A cos B = sin A sin B sin C` (proved by eliminating `C = π−(A+B)` and expanding via `sin_add`/`cos_add`).
- **Triple tangent identity** (centerpiece) — `A+B+C=π`, no right angle ⟹ `tan A + tan B + tan C = tan A · tan B · tan C`. The sum equals the product — no analogue for sine/cosine.
- **Triple cotangent identity** — `A+B+C=π`, no straight/zero angle ⟹ `cot A cot B + cot B cot C + cot C cot A = 1` (same heart identity, divided by the product of sines).

### Supporting / concrete
- `tan_add_of_cos_ne_zero`, `tan_sub_of_cos_ne_zero` — addition/subtraction restated with the directly checkable `cos ≠ 0` hypotheses (via `Real.cos_eq_zero_iff`).
- `arctan_half_add_arctan_third` — `arctan(1/2) + arctan(1/3) = π/4`, a rational-tangent witness linking to the gallery's Machin material.
- Equilateral check: the triple identity at `A=B=C=π/3` (both sides `3√3`).

### Verification
- **6 theorems, 0 sorries, 0 `axiom` declarations, no `native_decide`** — depends only on `propext` / `Classical.choice` / `Quot.sound`.
- `status: verified`, `badge: original`, `axiomCount: 0`.
- Docker build green (`Proofs.TangentAdditionFormula`, 3060 jobs).
- Gallery data added under `src/data/proofs/tangent-addition-formula-oq-01/` (meta + annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)