### PR TITLE
research(beta-integral-recurrence-oq-01): symmetric integer closed form B(m+1,n+1)=m!·n!/(m+n+1)! (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs/BetaIntegralRecurrence.lean
+++ b/proofs/Proofs/BetaIntegralRecurrence.lean
@@ -1,0 +1,105 @@
+import Mathlib.Analysis.SpecialFunctions.Gamma.Beta
+import Mathlib.Tactic
+
+/-
+# The Beta Integral: Recurrence and the Integer Closed Form
+
+## What This Proves
+
+The Euler Beta integral `B(u, v) = ∫₀¹ t^(u-1) (1-t)^(v-1) dt` satisfies the
+parameter recurrence
+
+  u · B(u, v+1) = v · B(u+1, v)          (`betaIntegral_recurrence`, Mathlib)
+
+which, together with the Beta–Gamma relation `B(u,v) = Γu·Γv / Γ(u+v)`, pins
+down the value of the Beta function on the integer lattice. The centerpiece of
+this file is that closed form:
+
+  **`betaIntegral_nat_nat`**:  `B(m+1, n+1) = m! · n! / (m+n+1)!`   for `m, n : ℕ`.
+
+From it we read off concrete values such as `B(1,1) = 1`, `B(2,3) = 1/12`, and
+the symmetry `B(m+1,n+1) = B(n+1,m+1)` becomes the manifest symmetry of the
+right-hand side under `m ↔ n`.
+
+## Relation to Mathlib
+
+Mathlib (`Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean`) provides the
+recurrence `Complex.betaIntegral_recurrence`, the Beta–Gamma division formula
+`Complex.betaIntegral_eq_Gamma_mul_div`, and the *one-sided* evaluation
+`Complex.betaIntegral_eval_nat_add_one_right`, which gives
+`B(u, n+1) = n! / ∏_{j≤n} (u+j)` for a single integer argument. It does **not**
+state the fully symmetric integer closed form `B(m+1,n+1) = m!·n!/(m+n+1)!`,
+which is the classical "Beta function of two integers" value. We derive it here
+by feeding the two integer arguments through the Beta–Gamma relation and
+`Complex.Gamma_nat_eq_factorial`, then specialize to numeric instances.
+
+## Approach
+
+`betaIntegral_nat_nat`: rewrite `B(m+1,n+1)` with `betaIntegral_eq_Gamma_mul_div`
+(both real parts are positive), collapse the three Gamma values to factorials
+via `Gamma_nat_eq_factorial`, after rewriting the denominator argument
+`(m+1)+(n+1)` as `(m+n+1)+1`. The numeric corollaries follow by `push_cast`
+and `norm_num`.
+-/
+
+namespace BetaIntegralRecurrence
+
+open Complex
+
+/-- **Beta recurrence (the stated identity).** For `Re u > 0`, `Re v > 0`,
+
+  `u · B(u, v+1) = v · B(u+1, v)`.
+
+This is `Complex.betaIntegral_recurrence`; we restate it under our namespace as
+the entry's headline identity. -/
+theorem beta_recurrence {u v : ℂ} (hu : 0 < u.re) (hv : 0 < v.re) :
+    u * betaIntegral u (v + 1) = v * betaIntegral (u + 1) v :=
+  betaIntegral_recurrence hu hv
+
+/-- **Integer closed form (new).** For natural numbers `m, n`,
+
+  `B(m+1, n+1) = m! · n! / (m+n+1)!`.
+
+This symmetric two-integer evaluation is not in Mathlib; it is obtained from the
+Beta–Gamma relation by collapsing each Gamma value to a factorial. -/
+theorem betaIntegral_nat_nat (m n : ℕ) :
+    betaIntegral ((m : ℂ) + 1) ((n : ℂ) + 1)
+      = (Nat.factorial m : ℂ) * (Nat.factorial n : ℂ)
+          / (Nat.factorial (m + n + 1) : ℂ) := by
+  have hm : 0 < ((m : ℂ) + 1).re := by
+    simp only [add_re, one_re, natCast_re]; positivity
+  have hn : 0 < ((n : ℂ) + 1).re := by
+    simp only [add_re, one_re, natCast_re]; positivity
+  have hsum : ((m : ℂ) + 1) + ((n : ℂ) + 1) = ((m + n + 1 : ℕ) : ℂ) + 1 := by
+    push_cast; ring
+  rw [betaIntegral_eq_Gamma_mul_div _ _ hm hn, hsum,
+      Gamma_nat_eq_factorial m, Gamma_nat_eq_factorial n,
+      Gamma_nat_eq_factorial (m + n + 1)]
+
+/-- **Symmetry on the integer lattice.** `B(m+1,n+1) = B(n+1,m+1)`, visibly the
+`m ↔ n` symmetry of the closed form. -/
+theorem betaIntegral_nat_nat_symm (m n : ℕ) :
+    betaIntegral ((m : ℂ) + 1) ((n : ℂ) + 1)
+      = betaIntegral ((n : ℂ) + 1) ((m : ℂ) + 1) := by
+  rw [betaIntegral_nat_nat, betaIntegral_nat_nat, Nat.add_comm n m]
+  ring
+
+/-- `B(1,1) = 1` (the integral of the constant `1` over `[0,1]`). -/
+theorem betaIntegral_one_one : betaIntegral 1 1 = 1 := by
+  have h := betaIntegral_nat_nat 0 0
+  norm_num [Nat.factorial] at h
+  linear_combination h
+
+/-- `B(2,3) = 1/12`. -/
+theorem betaIntegral_two_three : betaIntegral 2 3 = 1 / 12 := by
+  have h := betaIntegral_nat_nat 1 2
+  norm_num [Nat.factorial] at h
+  linear_combination h
+
+/-- `B(3,3) = 1/30`. -/
+theorem betaIntegral_three_three : betaIntegral 3 3 = 1 / 30 := by
+  have h := betaIntegral_nat_nat 2 2
+  norm_num [Nat.factorial] at h
+  linear_combination h
+
+end BetaIntegralRecurrence

--- a/src/data/proofs/beta-integral-recurrence-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01/meta.json
@@ -1,0 +1,112 @@
+{
+  "id": "beta-integral-recurrence-oq-01",
+  "slug": "beta-integral-recurrence-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Complex"
+    ],
+    "namespace": "BetaIntegralRecurrence",
+    "lineCount": 105,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BetaIntegralRecurrence.lean",
+    "sorries": 0
+  },
+  "title": "The Beta Integral: Recurrence and the Integer Closed Form",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BetaIntegralRecurrence.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "beta-function",
+      "gamma-function",
+      "factorial",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 105,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "betaIntegral_nat_nat: the symmetric two-integer closed form B(m+1, n+1) = m!·n!/(m+n+1)! for all m, n : ℕ — NOT in Mathlib, which only records the one-sided evaluation betaIntegral_eval_nat_add_one_right (B(u, n+1) = n!/∏_{j≤n}(u+j) for a single integer argument). Derived by feeding both integer arguments through the Beta–Gamma relation betaIntegral_eq_Gamma_mul_div and collapsing each of the three Gamma values to a factorial via Complex.Gamma_nat_eq_factorial.",
+      "betaIntegral_nat_nat_symm: the integer-lattice symmetry B(m+1, n+1) = B(n+1, m+1) read off as the visible m ↔ n symmetry of the factorial closed form.",
+      "betaIntegral_one_one / betaIntegral_two_three / betaIntegral_three_three: concrete machine-checked evaluations B(1,1) = 1, B(2,3) = 1/12, B(3,3) = 1/30, instantiating the closed form at small integer arguments.",
+      "beta_recurrence: namespaced re-export of Mathlib's parameter recurrence u·B(u, v+1) = v·B(u+1, v), the entry's headline identity."
+    ],
+    "prerequisites": [
+      "Euler Beta integral Complex.betaIntegral u v = ∫₀¹ tᵘ⁻¹ (1−t)ᵛ⁻¹ dt",
+      "Beta–Gamma relation Complex.betaIntegral_eq_Gamma_mul_div: B(u,v) = Γu·Γv/Γ(u+v) for Re u, Re v > 0",
+      "Complex.Gamma_nat_eq_factorial: Γ(n+1) = n! for n : ℕ",
+      "Complex.betaIntegral_recurrence: the parameter recurrence u·B(u,v+1) = v·B(u+1,v)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.betaIntegral_recurrence",
+        "description": "Recurrence for the Beta integral: u·B(u, v+1) = v·B(u+1, v) for Re u > 0, Re v > 0. The headline identity re-exported as beta_recurrence.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Complex.betaIntegral_eq_Gamma_mul_div",
+        "description": "Beta–Gamma division formula B(u,v) = Γu·Γv/Γ(u+v) for Re u, Re v > 0, the bridge used to turn the integer Beta values into factorial quotients.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Complex.Gamma_nat_eq_factorial",
+        "description": "Γ(n+1) = n! for n : ℕ, used to collapse each of the three Gamma values in the Beta–Gamma relation to a factorial.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "beta-integral-recurrence-oq-01-oq-01",
+      "question": "Derive the central-binomial / Wallis-type identity B(n+1, n+1) = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n)) as a function of n, and connect it to the normalization of the symmetric Beta(n+1,n+1) density on [0,1].",
+      "significance": "medium"
+    },
+    {
+      "id": "beta-integral-recurrence-oq-01-oq-02",
+      "question": "Prove the half-integer evaluation B(1/2, 1/2) = π from Γ(1/2)² = π via the same Beta–Gamma relation, exhibiting the total mass of the arcsine density and linking to the gamma-reflection entry.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gamma-reflection-formula-oq-01",
+      "relationship": "related",
+      "description": "Both entries exploit Mathlib's Gamma/Beta theory in Analysis.SpecialFunctions.Gamma.Beta. There the reflection formula evaluates Gamma products at rational arguments; here the Beta–Gamma relation evaluates the Beta integral at integer arguments as factorial quotients."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gamma.Beta",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Complex.betaIntegral_recurrence, Complex.betaIntegral_eq_Gamma_mul_div, and the one-sided integer evaluation betaIntegral_eval_nat_add_one_right."
+    },
+    {
+      "title": "Special Functions (Beta and Gamma functions)",
+      "author": "Andrews, Askey, Roy",
+      "year": "1999",
+      "venue": "Cambridge University Press",
+      "description": "Standard reference for the Beta integral, its parameter recurrence, the Beta–Gamma relation, and the integer evaluation B(m+1,n+1) = m!·n!/(m+n+1)!."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The Euler Beta integral B(u,v) satisfies the parameter recurrence u·B(u,v+1) = v·B(u+1,v) (Mathlib's Complex.betaIntegral_recurrence, re-exported as beta_recurrence). Combined with the Beta–Gamma relation B(u,v) = Γu·Γv/Γ(u+v), this pins the Beta function on the integer lattice: the centerpiece betaIntegral_nat_nat proves B(m+1,n+1) = m!·n!/(m+n+1)! for all m, n : ℕ — the classical symmetric two-integer value, which Mathlib does not state (it has only the one-sided evaluation B(u, n+1) = n!/∏(u+j)). The closed form yields the manifest symmetry B(m+1,n+1) = B(n+1,m+1) and the concrete values B(1,1) = 1, B(2,3) = 1/12, B(3,3) = 1/30. 105 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The recurrence and Beta–Gamma relation are delegated to Mathlib (hence the mathlib badge); the genuine new content is the symmetric integer closed form B(m+1,n+1) = m!·n!/(m+n+1)! and its numeric instances, which Mathlib records only in the asymmetric one-argument form. The entry packages the textbook 'Beta function of two integers' value in machine-checked form via the Gamma-to-factorial bridge.",
+    "openQuestions": [
+      "Derive B(n+1,n+1) = (n!)²/(2n+1)! and connect to the central binomial coefficient.",
+      "Prove B(1/2,1/2) = π from Γ(1/2)² = π via the Beta–Gamma relation."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes the **Euler Beta integral** identities for the gallery candidate `beta-integral-recurrence-oq-01`. The genuine new content is the **symmetric two-integer closed form**

  `B(m+1, n+1) = m!·n!/(m+n+1)!`   for all `m, n : ℕ`

which Mathlib does **not** state — it records only the *one-sided* evaluation `Complex.betaIntegral_eval_nat_add_one_right` (`B(u, n+1) = n!/∏_{j≤n}(u+j)` for a single integer argument). We derive the symmetric form by feeding both integer arguments through the Beta–Gamma relation `betaIntegral_eq_Gamma_mul_div` and collapsing each Gamma value to a factorial via `Complex.Gamma_nat_eq_factorial`.

## Theorems (6 total, 0 defs)

- `beta_recurrence` — namespaced re-export of Mathlib's parameter recurrence `u·B(u,v+1) = v·B(u+1,v)` (the candidate's headline identity)
- `betaIntegral_nat_nat` **(new)** — `B(m+1,n+1) = m!·n!/(m+n+1)!`
- `betaIntegral_nat_nat_symm` — integer-lattice symmetry `B(m+1,n+1) = B(n+1,m+1)`
- `betaIntegral_one_one`, `betaIntegral_two_three`, `betaIntegral_three_three` — concrete values `B(1,1)=1`, `B(2,3)=1/12`, `B(3,3)=1/30`

## Verification

- **Docker build green** (`./proofs/scripts/docker-build.sh Proofs.BetaIntegralRecurrence`, 3131 jobs)
- 0 sorries, 0 `axiom` declarations, 0 `native_decide`
- `status: verified`, `badge: mathlib` (recurrence + Beta–Gamma relation delegated to Mathlib; the symmetric closed form and numeric instances are the new content)
- 105 lines

## Why not a wrapper

Mathlib's Beta API stops at the asymmetric one-argument evaluation. The classical "Beta function of two integers" value `m!·n!/(m+n+1)!` — the form that actually appears in textbooks and that makes the `m ↔ n` symmetry manifest — is assembled here from the Gamma-to-factorial bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)