### PR TITLE
research(gram-linear-independence-iff-oq-01): Gramian determinant criterion for linear independence (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2598,6 +2598,7 @@ import Proofs.GodelSecondIncompletenessOQ02GLSyntax
 import Proofs.GodelSecondIncompletenessOQ02Soundness
 import Proofs.GodelSecondIncompletenessOQ02Translate
 import Proofs.GoemansWilliamsonMaxCut
+import Proofs.GramLinearIndependenceOQ01
 import Proofs.GraphCore
 import Proofs.GreensTheorem
 import Proofs.GreensTheoremOQ01

--- a/proofs/Proofs/GramLinearIndependenceOQ01.lean
+++ b/proofs/Proofs/GramLinearIndependenceOQ01.lean
@@ -1,0 +1,116 @@
+import Mathlib
+
+/-!
+# The Gram matrix, positive definiteness, and the Gramian determinant criterion
+
+For a finite family of vectors `v : n → E` in an inner product space over `𝕜` (`ℝ` or
+`ℂ`), the **Gram matrix** `gram 𝕜 v` has entries `⟪v i, v j⟫`. Mathlib proves the
+headline characterisation
+
+* `Matrix.posDef_gram_iff_linearIndependent` : `gram 𝕜 v` is positive definite **iff**
+  the family `v` is linearly independent,
+
+together with the structural facts that a Gram matrix is always Hermitian
+(`isHermitian_gram`) and positive semidefinite (`posSemidef_gram`). This file re-exports
+those (hence the `mathlib` badge on the headline) and then derives the genuine content
+absent from Mathlib: the classical **Gramian determinant test**.
+
+The Gram determinant `det (gram 𝕜 v)` (the *Gramian*) is the standard numerical witness
+for linear independence. We prove:
+
+* `gram_det_nonneg` — the Gramian is always `≥ 0` (it is the determinant of a positive
+  semidefinite matrix);
+* `gram_mulVec_eq_zero_of_dependent` — a linear dependence `∑ gⱼ • vⱼ = 0` is exactly a
+  null vector of the Gram matrix (`gram 𝕜 v *ᵥ g = 0`), the elementary kernel identity
+  `(gram 𝕜 v *ᵥ g) i = ⟪v i, ∑ gⱼ • vⱼ⟫`;
+* `gram_det_eq_zero_of_not_linearIndependent` — a dependent family has a **singular** Gram
+  matrix (Gramian `= 0`), obtained from the kernel identity via
+  `Matrix.exists_mulVec_eq_zero_iff`;
+* `linearIndependent_iff_gram_det_pos` — `v` is linearly independent **iff** its Gramian
+  is strictly positive;
+* the corollaries `gram_det_eq_zero_iff_not_linearIndependent` (Gramian vanishes iff
+  dependent) and `linearIndependent_iff_gram_det_ne_zero`.
+
+Everything is stated over an arbitrary `RCLike` field `𝕜`, so it applies uniformly to real
+and complex inner product spaces. All results are fully machine-checked with no `sorry`
+and no extra axioms.
+-/
+
+namespace GramLinearIndependenceOQ01
+
+open Matrix RCLike
+open scoped ComplexOrder InnerProductSpace
+
+variable {𝕜 E n : Type*} [RCLike 𝕜]
+variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [Fintype n] [DecidableEq n]
+
+/-! ## Re-exported Mathlib facts -/
+
+/-- **Gram positive-definiteness criterion** (Mathlib `posDef_gram_iff_linearIndependent`):
+the Gram matrix of `v` is positive definite iff `v` is linearly independent. -/
+theorem posDef_gram_iff_linearIndependent (v : n → E) :
+    (gram 𝕜 v).PosDef ↔ LinearIndependent 𝕜 v :=
+  Matrix.posDef_gram_iff_linearIndependent
+
+/-- A Gram matrix is always Hermitian. -/
+theorem gram_isHermitian (v : n → E) : (gram 𝕜 v).IsHermitian :=
+  Matrix.isHermitian_gram 𝕜 v
+
+/-- A Gram matrix is always positive semidefinite. -/
+theorem gram_posSemidef (v : n → E) : (gram 𝕜 v).PosSemidef :=
+  Matrix.posSemidef_gram 𝕜 v
+
+/-! ## The Gramian determinant test (new content) -/
+
+/-- The **Gramian** (Gram determinant) is always nonnegative: it is the determinant of a
+positive semidefinite matrix. -/
+theorem gram_det_nonneg (v : n → E) : 0 ≤ (gram 𝕜 v).det :=
+  (Matrix.posSemidef_gram 𝕜 v).det_nonneg
+
+/-- **Kernel identity.** A linear dependence `∑ j, g j • v j = 0` is precisely a null
+vector of the Gram matrix. The proof is the one-line computation
+`(gram 𝕜 v *ᵥ g) i = ⟪v i, ∑ j, g j • v j⟫`, using that the inner product is linear in
+its second argument. -/
+theorem gram_mulVec_eq_zero_of_dependent {v : n → E} {g : n → 𝕜}
+    (hg : ∑ i, g i • v i = 0) : gram 𝕜 v *ᵥ g = 0 := by
+  funext i
+  have key : (gram 𝕜 v *ᵥ g) i = ⟪v i, ∑ j, g j • v j⟫_𝕜 := by
+    simp only [mulVec, dotProduct, Matrix.gram_apply, inner_sum, inner_smul_right]
+    exact Finset.sum_congr rfl fun j _ => mul_comm _ _
+  rw [Pi.zero_apply, key, hg, inner_zero_right]
+
+/-- A linearly **dependent** family has a singular Gram matrix: its Gramian vanishes. -/
+theorem gram_det_eq_zero_of_not_linearIndependent {v : n → E}
+    (h : ¬ LinearIndependent 𝕜 v) : (gram 𝕜 v).det = 0 := by
+  obtain ⟨g, hg, i, hi⟩ := Fintype.not_linearIndependent_iff.mp h
+  rw [← Matrix.exists_mulVec_eq_zero_iff]
+  exact ⟨g, fun hgz => hi (by rw [hgz]; rfl), gram_mulVec_eq_zero_of_dependent hg⟩
+
+/-- **Gramian determinant criterion.** A finite family of vectors is linearly independent
+iff its Gram determinant is strictly positive. -/
+theorem linearIndependent_iff_gram_det_pos (v : n → E) :
+    LinearIndependent 𝕜 v ↔ 0 < (gram 𝕜 v).det := by
+  constructor
+  · intro h
+    exact ((posDef_gram_iff_linearIndependent v).mpr h).det_pos
+  · intro h
+    by_contra hni
+    rw [gram_det_eq_zero_of_not_linearIndependent hni] at h
+    exact lt_irrefl 0 h
+
+/-- The Gramian vanishes **iff** the family is linearly dependent. -/
+theorem gram_det_eq_zero_iff_not_linearIndependent (v : n → E) :
+    (gram 𝕜 v).det = 0 ↔ ¬ LinearIndependent 𝕜 v := by
+  constructor
+  · intro h hli
+    have hpos := (linearIndependent_iff_gram_det_pos v).mp hli
+    rw [h] at hpos
+    exact lt_irrefl 0 hpos
+  · exact gram_det_eq_zero_of_not_linearIndependent
+
+/-- Linear independence is equivalent to a nonzero Gramian. -/
+theorem linearIndependent_iff_gram_det_ne_zero (v : n → E) :
+    LinearIndependent 𝕜 v ↔ (gram 𝕜 v).det ≠ 0 := by
+  rw [Ne, gram_det_eq_zero_iff_not_linearIndependent, not_not]
+
+end GramLinearIndependenceOQ01

--- a/src/data/proofs/gram-linear-independence-iff-oq-01/meta.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01/meta.json
@@ -1,0 +1,124 @@
+{
+  "id": "gram-linear-independence-iff-oq-01",
+  "slug": "gram-linear-independence-iff-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Matrix",
+      "RCLike",
+      "ComplexOrder",
+      "InnerProductSpace"
+    ],
+    "namespace": "GramLinearIndependenceOQ01",
+    "lineCount": 116,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/GramLinearIndependenceOQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Gram Matrix and the Gramian Determinant Criterion for Linear Independence",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GramLinearIndependenceOQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "inner-product-space",
+      "gram-matrix",
+      "positive-definite",
+      "determinant",
+      "linear-independence",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 116,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "posDef_gram_iff_linearIndependent: stable re-export of Mathlib's headline characterisation — the Gram matrix gram 𝕜 v is positive definite iff the family v is linearly independent (Matrix.posDef_gram_iff_linearIndependent), with the structural facts gram_isHermitian and gram_posSemidef",
+      "gram_det_nonneg: the Gramian (Gram determinant) is always ≥ 0, being the determinant of a positive semidefinite matrix",
+      "gram_mulVec_eq_zero_of_dependent: kernel identity — a linear dependence ∑ j, g j • v j = 0 is exactly a null vector of the Gram matrix (gram 𝕜 v *ᵥ g = 0), via the one-line computation (gram 𝕜 v *ᵥ g) i = ⟪v i, ∑ j, g j • v j⟫ using linearity of the inner product in its second argument",
+      "gram_det_eq_zero_of_not_linearIndependent: a linearly dependent family has a singular Gram matrix (Gramian = 0), obtained from the kernel identity via Matrix.exists_mulVec_eq_zero_iff",
+      "linearIndependent_iff_gram_det_pos: the Gramian determinant criterion — v is linearly independent iff its Gram determinant is strictly positive",
+      "gram_det_eq_zero_iff_not_linearIndependent: the Gramian vanishes iff the family is linearly dependent",
+      "linearIndependent_iff_gram_det_ne_zero: linear independence is equivalent to a nonzero Gramian"
+    ],
+    "prerequisites": [
+      "Gram matrix Matrix.gram 𝕜 v with entries ⟪v i, v j⟫ over an RCLike field 𝕜",
+      "Mathlib's Matrix.posDef_gram_iff_linearIndependent, isHermitian_gram, posSemidef_gram",
+      "Determinant sign for (semi)definite matrices: Matrix.PosDef.det_pos and Matrix.PosSemidef.det_nonneg",
+      "Matrix.exists_mulVec_eq_zero_iff: a square matrix over a domain maps some nonzero vector to 0 iff its determinant vanishes",
+      "Fintype.not_linearIndependent_iff: a finite family is dependent iff some nontrivial combination vanishes"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.posDef_gram_iff_linearIndependent",
+        "description": "The Gram matrix gram 𝕜 v is positive definite iff v is linearly independent — the headline characterisation re-exported here.",
+        "module": "Mathlib.Analysis.InnerProductSpace.GramMatrix"
+      },
+      {
+        "theorem": "Matrix.posSemidef_gram / Matrix.isHermitian_gram",
+        "description": "A Gram matrix is always Hermitian and positive semidefinite; supplies gram_det_nonneg and the always-true side of the criterion.",
+        "module": "Mathlib.Analysis.InnerProductSpace.GramMatrix"
+      },
+      {
+        "theorem": "Matrix.PosDef.det_pos / Matrix.PosSemidef.det_nonneg",
+        "description": "The determinant of a positive definite matrix is strictly positive, and of a positive semidefinite matrix is nonnegative (over an RCLike field with the ComplexOrder).",
+        "module": "Mathlib.Analysis.Matrix.PosDef"
+      },
+      {
+        "theorem": "Matrix.exists_mulVec_eq_zero_iff",
+        "description": "Over an integral domain, a square matrix sends some nonzero vector to 0 iff its determinant is 0 — converts the Gram kernel vector into the vanishing of the Gramian.",
+        "module": "Mathlib.LinearAlgebra.Matrix.ToLinearEquiv"
+      },
+      {
+        "theorem": "Fintype.not_linearIndependent_iff",
+        "description": "A finite family is linearly dependent iff there is a nontrivial vanishing linear combination — the source of the dependence coefficients used in the kernel argument.",
+        "module": "Mathlib.LinearAlgebra.LinearIndependent.Defs"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "gram-linear-independence-iff-oq-01-oq-01",
+      "question": "Quantify the Gramian beyond positivity: prove Hadamard's inequality det(gram 𝕜 v) ≤ ∏ i, ‖v i‖² with equality iff the vectors are pairwise orthogonal, exhibiting the Gram determinant as a squared volume.",
+      "significance": "medium"
+    },
+    {
+      "id": "gram-linear-independence-iff-oq-01-oq-02",
+      "question": "Identify √(det gram) with the volume of the parallelepiped spanned by v (the k-dimensional content), connecting the Gramian criterion to the Cauchy–Binet / exterior-power picture of independence.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.InnerProductSpace.GramMatrix",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Matrix.gram, posDef_gram_iff_linearIndependent, isHermitian_gram and posSemidef_gram, the Gram matrix API underlying this entry."
+    },
+    {
+      "title": "Jørgen Pedersen Gram, Über die Entwickelung reeller Functionen in Reihen",
+      "author": "J. P. Gram",
+      "year": "1883",
+      "venue": "Journal für die reine und angewandte Mathematik",
+      "description": "Origin of the Gram matrix and the Gram determinant as a test for linear independence of a system of functions/vectors."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For a finite family of vectors v : n → E in an inner product space over an RCLike field 𝕜, Mathlib's Matrix.posDef_gram_iff_linearIndependent characterises linear independence by positive definiteness of the Gram matrix gram 𝕜 v (entries ⟪v i, v j⟫), which is always Hermitian and positive semidefinite. This entry re-exports that headline (mathlib badge) and derives the classical Gramian determinant test absent from Mathlib: the Gram determinant is always ≥ 0 (gram_det_nonneg); a dependence ∑ g j • v j = 0 is exactly a null vector of the Gram matrix via the kernel identity (gram 𝕜 v *ᵥ g) i = ⟪v i, ∑ g j • v j⟫ (gram_mulVec_eq_zero_of_dependent); hence a dependent family has a singular Gram matrix (gram_det_eq_zero_of_not_linearIndependent); and the family is independent iff its Gramian is strictly positive (linearIndependent_iff_gram_det_pos), equivalently nonzero (linearIndependent_iff_gram_det_ne_zero), while the Gramian vanishes iff the family is dependent (gram_det_eq_zero_iff_not_linearIndependent). 116 lines, 9 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The positive-definiteness criterion is delegated to Mathlib; the genuine new content is the determinant formulation — the Gramian determinant criterion together with the elementary kernel identity that realises a linear dependence as a null vector of the Gram matrix. This packages the textbook 'Gram determinant test' in machine-checked form, uniformly over real and complex inner product spaces, and sets up the volumetric refinements (Hadamard's inequality, parallelepiped volume) recorded as open questions.",
+    "openQuestions": [
+      "Prove Hadamard's inequality det(gram) ≤ ∏ ‖v i‖² with equality iff pairwise orthogonal.",
+      "Identify √(det gram) with the volume of the parallelepiped spanned by v."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes the **Gramian determinant criterion** for linear independence of a finite family of vectors `v : n → E` in an inner product space over an `RCLike` field `𝕜` (covers `ℝ` and `ℂ` uniformly).

Mathlib already proves the headline characterisation `Matrix.posDef_gram_iff_linearIndependent` (Gram matrix positive definite ⟺ family linearly independent), together with `isHermitian_gram` / `posSemidef_gram`. This entry re-exports those (hence the `mathlib` badge on the headline) and derives the classical **determinant** formulation, which is absent from Mathlib:

- `gram_det_nonneg` — the Gramian `det (gram 𝕜 v)` is always `≥ 0` (determinant of a PSD matrix)
- `gram_mulVec_eq_zero_of_dependent` — **kernel identity**: a dependence `∑ gⱼ • vⱼ = 0` is exactly a null vector of the Gram matrix, via the one-line `(gram 𝕜 v *ᵥ g) i = ⟪v i, ∑ gⱼ • vⱼ⟫`
- `gram_det_eq_zero_of_not_linearIndependent` — a dependent family has a **singular** Gram matrix (via `Matrix.exists_mulVec_eq_zero_iff`)
- `linearIndependent_iff_gram_det_pos` — independent ⟺ Gramian strictly positive
- `gram_det_eq_zero_iff_not_linearIndependent` and `linearIndependent_iff_gram_det_ne_zero` — the dual/nonzero forms

## Verification

- **9 theorems, 0 definitions, 0 sorries, 0 axioms** (standard `propext`/`Classical.choice`/`Quot.sound` only; no `native_decide`)
- Docker build green: `./proofs/scripts/docker-build.sh Proofs.GramLinearIndependenceOQ01` → 7743 jobs, success
- Status `verified`, badge `mathlib`

## Open questions (recorded in meta)

- Hadamard's inequality `det(gram) ≤ ∏ ‖vᵢ‖²` with equality iff pairwise orthogonal
- Identify `√(det gram)` with the parallelepiped volume (Cauchy–Binet / exterior-power picture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)