### PR TITLE
research(dyck-catalan-count-oq-01): Dyck words are counted by the Catalan numbers — verified, 0-axiom

### DIFF
--- a/proofs/Proofs/DyckCatalanCountOQ01.lean
+++ b/proofs/Proofs/DyckCatalanCountOQ01.lean
@@ -1,0 +1,126 @@
+import Mathlib
+
+/-!
+# Dyck words are counted by the Catalan numbers
+
+A **Dyck word** of semilength `n` is a sequence of `n` up-steps `U` and `n`
+down-steps `D` such that every prefix has at least as many `U`s as `D`s — the
+balanced-bracket / lattice-path objects at the heart of enumerative
+combinatorics.  Mathlib (`Mathlib/Combinatorics/Enumerative/DyckWord.lean`)
+defines `DyckWord`, its `semilength`, and proves the headline counting theorem
+
+  `DyckWord.card_dyckWord_semilength_eq_catalan :`
+  `  Fintype.card { p : DyckWord // p.semilength = n } = catalan n`
+
+via a bijection with rooted binary trees on `n` internal nodes.  This is the
+*canonical combinatorial meaning* of the Catalan numbers, and it is genuinely
+distinct from the sibling gallery entry `catalan-numbers-oq-01`, which is purely
+about the arithmetic linear recurrence of `catalan` and never mentions Dyck
+words.
+
+What this file adds on top of the bare Mathlib statement:
+
+* **Closed forms.** Combining the count with `catalan_eq_centralBinom_div`
+  gives the explicit `C(2n, n) / (n+1)` count, together with its clean
+  *division-free* integer form `(n + 1) · (#Dyck words) = centralBinom n`.
+* **A length reformulation.** Phrasing the count by total length `2 * n`
+  rather than semilength `n`, via the equivalence of the two predicates
+  (`2 · semilength = length`).
+* **Positivity from an explicit witness.** Mathlib has *no* `catalan_pos`
+  lemma.  We supply one combinatorially: the fully nested word `Uⁿ Dⁿ`
+  (`nest^[n] 0`) has semilength `n`, so the counted set is nonempty, hence
+  `0 < catalan n`.
+* **The Segner convolution recurrence, read on the counts themselves.**
+
+Everything is over `ℕ`, fully machine-checked, 0 axioms, 0 sorries, no
+`decide` / `native_decide`.
+-/
+
+open DyckWord
+
+namespace DyckCatalanCount
+
+/-- **Headline.** The number of Dyck words of semilength `n` is the `n`-th
+Catalan number.  This is the combinatorial definition of `catalan`, exposed as
+the entry point for this gallery item. -/
+theorem card_semilength_eq_catalan (n : ℕ) :
+    Fintype.card { p : DyckWord // p.semilength = n } = catalan n :=
+  DyckWord.card_dyckWord_semilength_eq_catalan n
+
+/-- **Closed form (with division).** The Dyck-word count equals the central
+binomial coefficient divided by `n + 1`, i.e. `C(2n, n) / (n + 1)`. -/
+theorem card_semilength_eq_centralBinom_div (n : ℕ) :
+    Fintype.card { p : DyckWord // p.semilength = n } = n.centralBinom / (n + 1) := by
+  rw [card_semilength_eq_catalan, catalan_eq_centralBinom_div]
+
+/-- **Closed form (division-free).** The cleanest exact identity: `n + 1` times
+the number of Dyck words of semilength `n` is exactly the central binomial
+coefficient `C(2n, n)`.  This avoids the `ℕ`-division of the previous corollary
+(the division there is exact precisely because of this identity). -/
+theorem succ_mul_card_eq_centralBinom (n : ℕ) :
+    (n + 1) * Fintype.card { p : DyckWord // p.semilength = n } = n.centralBinom := by
+  rw [card_semilength_eq_catalan]
+  exact succ_mul_catalan_eq_centralBinom n
+
+/-- **Length reformulation.** Counting Dyck words by their *total length* `2 * n`
+gives the same answer as counting by semilength `n`, namely `catalan n`.  The two
+defining predicates agree because a Dyck word has length exactly twice its
+semilength (`two_mul_semilength_eq_length`).  Stated with `Nat.card` so no
+auxiliary `Fintype` instance on the length-indexed set is needed. -/
+theorem card_length_eq_catalan (n : ℕ) :
+    Nat.card { p : DyckWord // p.toList.length = 2 * n } = catalan n := by
+  have e : { p : DyckWord // p.toList.length = 2 * n } ≃
+      { p : DyckWord // p.semilength = n } :=
+    Equiv.subtypeEquivRight fun p => by
+      rw [← DyckWord.two_mul_semilength_eq_length]; omega
+  rw [Nat.card_congr e, Nat.card_eq_fintype_card, card_semilength_eq_catalan]
+
+/-- The fully nested Dyck word `Uⁿ Dⁿ` — obtained by nesting the empty word `n`
+times — has semilength `n`.  This is the explicit witness powering positivity. -/
+theorem semilength_nest_iterate (n : ℕ) : (DyckWord.nest^[n] 0).semilength = n := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    rw [Function.iterate_succ_apply', DyckWord.semilength_nest, ih]
+
+/-- **Positivity of the count.** There is always at least one Dyck word of any
+given semilength (the fully nested `Uⁿ Dⁿ`), so the counted set is nonempty. -/
+theorem card_semilength_pos (n : ℕ) :
+    0 < Fintype.card { p : DyckWord // p.semilength = n } := by
+  rw [Fintype.card_pos_iff]
+  exact ⟨⟨DyckWord.nest^[n] 0, semilength_nest_iterate n⟩⟩
+
+/-- **`catalan n > 0`, proved combinatorially.** Mathlib does not provide a
+positivity lemma for `catalan`; here it falls out of the existence of the nested
+Dyck word of each semilength. -/
+theorem catalan_pos (n : ℕ) : 0 < catalan n := by
+  rw [← card_semilength_eq_catalan]
+  exact card_semilength_pos n
+
+/-- **Segner convolution recurrence, read on the counts.** Splitting a nonempty
+Dyck word at its first return to the axis decomposes it into an inside part of
+semilength `i` and an outside part of semilength `n - i`; counting both pieces
+gives the Catalan recurrence directly in terms of Dyck-word counts. -/
+theorem card_semilength_succ (n : ℕ) :
+    Fintype.card { p : DyckWord // p.semilength = n + 1 }
+      = ∑ i : Fin (n + 1),
+          Fintype.card { p : DyckWord // p.semilength = (i : ℕ) }
+            * Fintype.card { p : DyckWord // p.semilength = n - (i : ℕ) } := by
+  simp_rw [card_semilength_eq_catalan]
+  exact catalan_succ n
+
+/-! ### Small-case sanity ladder: `1, 1, 2, 5`. -/
+
+example : Fintype.card { p : DyckWord // p.semilength = 0 } = 1 := by
+  rw [card_semilength_eq_catalan, catalan_zero]
+
+example : Fintype.card { p : DyckWord // p.semilength = 1 } = 1 := by
+  rw [card_semilength_eq_catalan, catalan_one]
+
+example : Fintype.card { p : DyckWord // p.semilength = 2 } = 2 := by
+  rw [card_semilength_eq_catalan, catalan_two]
+
+example : Fintype.card { p : DyckWord // p.semilength = 3 } = 5 := by
+  rw [card_semilength_eq_catalan, catalan_three]
+
+end DyckCatalanCount

--- a/src/data/proofs/dyck-catalan-count-oq-01/meta.json
+++ b/src/data/proofs/dyck-catalan-count-oq-01/meta.json
@@ -1,0 +1,180 @@
+{
+  "id": "dyck-catalan-count-oq-01",
+  "title": "Dyck Words Are Counted by the Catalan Numbers",
+  "slug": "dyck-catalan-count-oq-01",
+  "description": "The canonical combinatorial meaning of the Catalan numbers: the number of Dyck words of semilength n — sequences of n up-steps and n down-steps in which every prefix has at least as many ups as downs — is exactly catalan n. Mathlib (Combinatorics/Enumerative/DyckWord.lean) proves the headline DyckWord.card_dyckWord_semilength_eq_catalan via a bijection with rooted binary trees on n internal nodes. This entry packages that count into the consequences a combinatorialist actually wants: the explicit closed forms C(2n,n)/(n+1) (with the cleaner division-free identity (n+1)·#{Dyck words} = centralBinom n), a reformulation counting by total length 2n rather than semilength n, the Segner convolution recurrence read directly on the Dyck-word counts, and — filling a real Mathlib gap — a combinatorial proof that catalan n > 0 from the existence of the fully nested word Uⁿ Dⁿ (Mathlib has no catalan_pos). Distinct from catalan-numbers-oq-01, which is purely the arithmetic linear recurrence and never mentions Dyck words. Fully verified, 0 axioms, 0 sorries, no decide/native_decide.",
+  "meta": {
+    "author": "Classical (Euler / Catalan; Dyck 1882); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "dyck-words",
+      "enumerative-combinatorics",
+      "lattice-paths",
+      "central-binomial",
+      "bijective-combinatorics",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DyckCatalanCountOQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "DyckWord.card_dyckWord_semilength_eq_catalan",
+        "description": "The headline counting theorem: Fintype.card { p : DyckWord // p.semilength = n } = catalan n, proved in Mathlib via the bijection between Dyck words of semilength n and rooted binary trees with n internal nodes. Every result in this file is built on it.",
+        "module": "Mathlib.Combinatorics.Enumerative.DyckWord"
+      },
+      {
+        "theorem": "catalan_eq_centralBinom_div",
+        "description": "The closed form catalan n = centralBinom n / (n + 1). Composed with the count to express the number of Dyck words as C(2n,n)/(n+1).",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "succ_mul_catalan_eq_centralBinom",
+        "description": "(n + 1) * catalan n = centralBinom n. Gives the division-free closed form for the Dyck-word count.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "catalan_succ",
+        "description": "The Segner convolution recurrence catalan (n+1) = Σ_{i:Fin (n+1)} catalan i · catalan (n-i), transported to a recurrence on the Dyck-word counts.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "DyckWord.two_mul_semilength_eq_length",
+        "description": "2 * p.semilength = p.toList.length. Establishes that the predicates 'semilength = n' and 'length = 2n' agree, powering the length reformulation of the count.",
+        "module": "Mathlib.Combinatorics.Enumerative.DyckWord"
+      },
+      {
+        "theorem": "DyckWord.semilength_nest",
+        "description": "p.nest.semilength = p.semilength + 1. Iterated from the empty word, it builds the fully nested word Uⁿ Dⁿ of semilength n used to prove positivity of the count.",
+        "module": "Mathlib.Combinatorics.Enumerative.DyckWord"
+      },
+      {
+        "theorem": "Equiv.subtypeEquivRight",
+        "description": "Turns a pointwise iff of predicates into an equivalence of subtypes; used to identify Dyck words of length 2n with those of semilength n.",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      }
+    ],
+    "originalContributions": [
+      "card_semilength_eq_centralBinom_div and succ_mul_card_eq_centralBinom: the explicit closed forms for the number of Dyck words of semilength n — C(2n,n)/(n+1) and its division-free integer form (n+1)·#{Dyck words} = centralBinom n — neither stated in Mathlib for Dyck words",
+      "card_length_eq_catalan: the count reformulated by total length 2n instead of semilength n, via the subtype equivalence from 2·semilength = length, phrased with Nat.card",
+      "catalan_pos: 0 < catalan n proved combinatorially from the explicit nested witness Uⁿ Dⁿ — Mathlib provides no positivity lemma for catalan; supported by semilength_nest_iterate (the nested word has semilength n) and card_semilength_pos (the counted set is nonempty)",
+      "card_semilength_succ: the Segner convolution recurrence stated directly on the Dyck-word counts rather than on the abstract Catalan numbers"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 126,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used; the small-case ladder (counts 1,1,2,5) is derived through the counting theorem and Mathlib's catalan_zero/one/two/three, not by kernel computation.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Dyck words — coined for Walther von Dyck — are the balanced-bracket sequences, equivalently lattice paths from (0,0) to (2n,0) with ±1 steps that never dip below the axis. They are the prototypical Catalan object: their count, catalan n, is shared with binary trees, polygon triangulations, noncrossing partitions, and hundreds of other families catalogued by Stanley. The bijection Mathlib uses — Dyck words of semilength n ↔ rooted binary trees with n internal nodes — is the classical recursive 'first return' decomposition that also explains why the counts satisfy the Segner convolution recurrence.",
+    "problemStatement": "**Open Question (dyck-catalan-count-oq-01)**: Establish in Lean the combinatorial identity that the number of Dyck words of semilength n equals the n-th Catalan number, and derive the closed-form count, a length-based reformulation, the convolution recurrence on the counts, and positivity of catalan n from an explicit Dyck-word witness.\n\n**Result**: card_semilength_eq_catalan plus the closed forms, length reformulation, recurrence, and a combinatorial catalan_pos — all fully verified with 0 axioms.",
+    "text": "For every natural number n, the number of Dyck words of semilength n is catalan n = C(2n,n)/(n+1). Equivalently (n+1) times this count is the central binomial coefficient C(2n,n); the same count results from fixing the total length to 2n; the counts obey the Segner convolution recurrence; and the count is always positive because the fully nested word Uⁿ Dⁿ is a Dyck word of semilength n.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. The headline is Mathlib's DyckWord.card_dyckWord_semilength_eq_catalan, exposed as card_semilength_eq_catalan — the entry point.\n\n2. Closed forms: rewrite the count to catalan n and apply catalan_eq_centralBinom_div for C(2n,n)/(n+1); for the division-free form apply succ_mul_catalan_eq_centralBinom to get (n+1)·count = centralBinom n.\n\n3. Length reformulation: the predicates 'semilength = n' and 'toList.length = 2n' are pointwise equivalent because 2·semilength = length (two_mul_semilength_eq_length); Equiv.subtypeEquivRight turns this into an equivalence of subtypes, and Nat.card_congr transfers the count.\n\n4. Positivity: nest^[n] 0 is the fully nested word Uⁿ Dⁿ; semilength_nest_iterate (an induction using semilength_nest) shows it has semilength n, so the counted set is nonempty (card_semilength_pos via Fintype.card_pos_iff), hence catalan n > 0.\n\n5. Recurrence: simp_rw the count to catalan everywhere and close with catalan_succ.",
+    "keyInsights": [
+      "**This is the combinatorial definition of catalan, not the arithmetic one.** The sibling entry catalan-numbers-oq-01 proves the first-order recurrence of the abstract sequence; this entry is about what the sequence *counts*. The two share the word 'Catalan' and nothing else.",
+      "**Mathlib has no catalan_pos.** Positivity is obtained here the combinatorial way: exhibit one object of each size. The fully nested word Uⁿ Dⁿ = nest^[n] 0 is the canonical witness, and semilength_nest makes the semilength bookkeeping a one-line induction.",
+      "**The division-free closed form is the honest one over ℕ.** (n+1)·#{Dyck words} = C(2n,n) holds exactly; the popular C(2n,n)/(n+1) is correct only because n+1 divides C(2n,n), which is exactly this identity. Both are recorded.",
+      "**Counting by length or by semilength is the same count.** Because every Dyck word has length exactly twice its semilength, fixing either parameter selects the same finite set; Equiv.subtypeEquivRight makes this a clean transport rather than a re-derivation."
+    ],
+    "prerequisites": [
+      "Dyck words / balanced-bracket sequences and the notion of semilength",
+      "The Catalan numbers, their Segner convolution recurrence, and the central-binomial closed form in Mathlib",
+      "Counting via Fintype.card and Nat.card, and transporting counts along subtype equivalences"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Module docstring defining Dyck words and semilength, stating the headline count, and listing the value added over Mathlib (closed forms, length reformulation, combinatorial positivity, recurrence on counts); import of Mathlib and open of the DyckWord namespace.",
+      "mathContext": "$\\#\\{p : \\mathrm{DyckWord} \\mid \\mathrm{semilength}\\,p = n\\} = C_n$."
+    },
+    {
+      "id": "count-and-closed-forms",
+      "title": "The Count and Its Closed Forms",
+      "startLine": 51,
+      "endLine": 76,
+      "summary": "card_semilength_eq_catalan (headline, from Mathlib); card_semilength_eq_centralBinom_div giving C(2n,n)/(n+1); and succ_mul_card_eq_centralBinom giving the division-free identity (n+1)·count = centralBinom n.",
+      "mathContext": "$C_n = \\binom{2n}{n}/(n+1)$, equivalently $(n+1)C_n = \\binom{2n}{n}$."
+    },
+    {
+      "id": "length-reformulation",
+      "title": "Counting by Total Length",
+      "startLine": 77,
+      "endLine": 90,
+      "summary": "card_length_eq_catalan: the number of Dyck words of total length 2n is catalan n, transported from the semilength count along Equiv.subtypeEquivRight using 2·semilength = length, stated with Nat.card.",
+      "mathContext": "$\\#\\{p \\mid |p| = 2n\\} = C_n$."
+    },
+    {
+      "id": "positivity",
+      "title": "Combinatorial Positivity of catalan",
+      "startLine": 91,
+      "endLine": 116,
+      "summary": "semilength_nest_iterate: the nested word nest^[n] 0 has semilength n; card_semilength_pos: the counted set is nonempty; catalan_pos: 0 < catalan n — a positivity lemma absent from Mathlib, proved from the explicit witness.",
+      "mathContext": "The fully nested word $U^n D^n$ witnesses $C_n \\ge 1$."
+    },
+    {
+      "id": "recurrence-and-ladder",
+      "title": "Convolution Recurrence and Small Cases",
+      "startLine": 117,
+      "endLine": 126,
+      "summary": "card_semilength_succ: the Segner convolution recurrence read on the Dyck-word counts; followed by the small-case sanity ladder verifying the counts 1, 1, 2, 5 for semilengths 0, 1, 2, 3.",
+      "mathContext": "$C_{n+1} = \\sum_{i=0}^{n} C_i\\,C_{n-i}$; $C_0,\\dots,C_3 = 1,1,2,5$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "catalan-numbers-oq-01",
+      "relationship": "Companion Catalan entry covering the arithmetic side — the first-order (holonomic) linear recurrence of the abstract sequence — disjoint from this entry's combinatorial enumeration."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization that the number of Dyck words of semilength n is the n-th Catalan number, packaged with the closed forms C(2n,n)/(n+1) and (n+1)·count = C(2n,n), a length-based reformulation, the Segner convolution recurrence on the counts, and a combinatorial proof that catalan n > 0.",
+    "implications": "Connects Mathlib's Dyck-word bijection to the explicit Catalan closed forms and supplies a catalan positivity lemma the library lacks. The nested-word witness and the count recurrence give reusable building blocks for further Catalan-object enumeration in Lean.",
+    "openQuestions": [
+      "Prove the corresponding enumeration for another Catalan family not yet counted in Mathlib (e.g. noncrossing partitions or triangulations of a convex polygon) and exhibit an explicit bijection to Dyck words.",
+      "Formalize the cycle-lemma / reflection proof of the count to obtain C(2n,n)/(n+1) directly, independently of the binary-tree bijection."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "DyckWord"
+    ],
+    "namespace": "DyckCatalanCount",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/DyckCatalanCountOQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Richard P. Stanley",
+      "title": "Catalan Numbers",
+      "year": "2015",
+      "venue": "Cambridge University Press",
+      "note": "Definitive catalogue of Catalan objects; Dyck paths and the closed form C(n) = binom(2n,n)/(n+1) appear as foundational examples."
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.Combinatorics.Enumerative.DyckWord and Mathlib.Combinatorics.Enumerative.Catalan",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Source of the Dyck-word/binary-tree bijection, the count theorem, and the Catalan closed-form and recurrence lemmas built on here."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Dyck Words Are Counted by the Catalan Numbers

The canonical *combinatorial* meaning of the Catalan numbers: the number of Dyck words of semilength `n` is exactly `catalan n`. Built on Mathlib's `DyckWord.card_dyckWord_semilength_eq_catalan` (the bijection with rooted binary trees), this entry packages the consequences a combinatorialist actually wants.

### What this adds on top of the bare Mathlib statement
- **Closed forms.** `card_semilength_eq_centralBinom_div` gives `C(2n,n)/(n+1)`; `succ_mul_card_eq_centralBinom` gives the cleaner **division-free** integer identity `(n+1)·#{Dyck words} = centralBinom n`.
- **Length reformulation.** `card_length_eq_catalan` counts by total length `2n` instead of semilength `n`, transported along `Equiv.subtypeEquivRight` from `2·semilength = length` (`Nat.card`).
- **Combinatorial positivity.** Mathlib has **no** `catalan_pos`. We supply one: the fully nested word `Uⁿ Dⁿ = nest^[n] 0` has semilength `n` (`semilength_nest_iterate`), so the counted set is nonempty (`card_semilength_pos`), hence `0 < catalan n`.
- **Segner convolution recurrence** read directly on the Dyck-word counts (`card_semilength_succ`).
- Small-case sanity ladder `1, 1, 2, 5` derived through the count, not by `decide`.

### Verification
- **8 theorems, 0 definitions, 0 sorries, 0 axiom declarations**
- No `decide` / `native_decide` — only foundational `propext`/`Classical.choice`/`Quot.sound` (which do not count)
- Docker build green (7743 jobs)
- `status: verified`, `badge: mathlib`

Distinct from `catalan-numbers-oq-01`, which is purely the arithmetic linear recurrence and never mentions Dyck words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)