### PR TITLE
research(minkowski-theorem-oq-05): build verified — promote power-sum convexity bound to verified/original

### DIFF
--- a/research/problems/minkowski-theorem-oq-05/knowledge.md
+++ b/research/problems/minkowski-theorem-oq-05/knowledge.md
@@ -22,9 +22,38 @@ both absent.
 - `proofs/Proofs/MinkowskiTheoremOQ05.lean` — 4 theorems, 0 def, 0 sorry, 0 axiom
   (by construction). Registered in `proofs/Proofs.lean`.
 - `src/data/proofs/minkowski-theorem-oq-05/{meta.json,annotations.json}` — gallery
-  entry, held at `formalized`/`wip` pending a green build.
+  entry, **verified/original** (build confirmed 2026-06-20).
 
 ---
+
+## Session 2026-06-20 (Session 2) — Build verified, promoted to verified/original
+
+**Mode**: REVISIT
+**Outcome**: completed (proof machine-verified)
+
+### What I Did
+- Docker harness had recovered. Ran `./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ05`
+  → **green**, `✔ [7743/7743] Built Proofs.MinkowskiTheoremOQ05 (469s)`.
+- Ran a temporary `#print axioms` companion on all four theorems: each depends only on
+  `[propext, Classical.choice, Quot.sound]` — no `Lean.ofReduceBool`, no `sorryAx`.
+  Genuine 0-axiom verified result. Removed the companion afterward.
+- Promoted gallery `meta.json`: `status formalized → verified`, `badge wip → original`,
+  rewrote `assumptions` to record the green build + clean axiom profile.
+- Updated `src/data/research/problems/minkowski-theorem-oq-05.json` knowledge.
+
+### Key Findings
+- The Session-1 self-review held up exactly: no elaboration surprises — the
+  `exact_mod_cast` transport, the rpow `rw`-chain, and the `IsLeast` packaging all
+  kernel-check as written.
+
+### Files Modified
+- `src/data/proofs/minkowski-theorem-oq-05/meta.json` (formalized/wip → verified/original)
+- `src/data/research/problems/minkowski-theorem-oq-05.json` (knowledge)
+- `research/problems/minkowski-theorem-oq-05/knowledge.md` (this entry)
+
+### Next Steps
+- Follow-up veins (unchanged): reverse bound for `0 < p ≤ 1` (constant 1); n-term
+  form `(Σ aᵢ)^p ≤ n^(p−1) Σ aᵢ^p` with `n^(p−1)` optimal.
 
 ## Session 2026-06-20 (Session 1) — Full proof written, build blocked by harness blackout
 

--- a/src/data/proofs/minkowski-theorem-oq-05/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-05/meta.json
@@ -5,7 +5,7 @@
   "description": "For a real exponent p ≥ 1 and nonnegative reals a, b, the power-sum convexity bound (a+b)^p ≤ 2^(p−1)(a^p+b^p), together with the sharpness statement that 2^(p−1) is the best possible constant: equality holds on the diagonal a = b, and any constant C valid for all nonnegative a, b satisfies C ≥ 2^(p−1). Mathlib proves the inequality only for ℝ≥0 (NNReal.rpow_add_le_mul_rpow_add_rpow) and ℝ≥0∞; the real-valued nonnegative formulation and the optimality of the constant are both absent. The headline result is the characterization 2^(p−1) = IsLeast of the admissible-constant set.",
   "meta": {
     "author": "Classical (power-mean / Jensen convexity)",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/MinkowskiTheoremOQ05.lean",
     "tags": [
       "analysis",
@@ -16,7 +16,7 @@
       "minkowski",
       "optimal-constant"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "mathlib_version": "4.26.0",
@@ -54,7 +54,7 @@
       "isLeast_two_rpow_sub_one: the headline characterization — 2^(p−1) is the least element of { C | ∀ a b ≥ 0, (a+b)^p ≤ C(a^p+b^p) }, packaging admissibility and the lower bound into a single optimal-constant statement"
     ],
     "axiomCount": 0,
-    "assumptions": "Proof is complete by construction — 0 sorries, 0 `axiom` declarations, no native_decide (so no Lean.ofReduceBool), no structure-encoded assumptions. BUILD VERIFICATION PENDING: the local Docker build (`./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ05`) was NOT run this session due to a Docker-daemon harness blackout on 2026-06-20. Status is held at `formalized`/`wip` rather than `verified`/`original` until a green Docker/CI build confirms machine-checking; promote to verified + badge original once the build passes (expected to depend only on propext, Classical.choice, Quot.sound).",
+    "assumptions": "None. Fully machine-checked — 0 sorries, 0 `axiom` declarations, no native_decide (so no Lean.ofReduceBool), no structure-encoded assumptions. The Docker build (`./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ05`) succeeded on 2026-06-20 (7743/7743 jobs), and `#print axioms` confirms all four theorems depend only on the foundational [propext, Classical.choice, Quot.sound].",
     "lineCount": 121,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/research/problems/minkowski-theorem-oq-05.json
+++ b/src/data/research/problems/minkowski-theorem-oq-05.json
@@ -26,12 +26,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROOF COMPLETE, BUILD PENDING. MinkowskiTheoremOQ05.lean (4 theorems, 0 def, 0 sorry, 0 axiom by construction) written and registered in Proofs.lean; gallery meta.json + annotations.json drafted at formalized/wip. Headline: 2^(p−1) = IsLeast { C | ∀ a b ≥ 0, (a+b)^p ≤ C(a^p+b^p) } — i.e. the optimal constant in the two-term power-sum convexity bound. Build verification blocked by the 2026-06-20 Docker harness blackout.",
+    "progressSummary": "VERIFIED. MinkowskiTheoremOQ05.lean (4 theorems, 0 def, 0 sorry, 0 axiom) builds green via Docker (7743/7743, 2026-06-20) and #print axioms confirms all four theorems depend only on [propext, Classical.choice, Quot.sound]. Gallery promoted to verified/original. Headline: 2^(p−1) = IsLeast { C | ∀ a b ≥ 0, (a+b)^p ≤ C(a^p+b^p) } — the optimal constant in the two-term power-sum convexity bound, real-valued nonnegative form + optimality both absent from Mathlib (which has only the ℝ≥0/ℝ≥0∞ inequality).",
     "builtItems": [
       "MinkowskiTheoremOQ05.rpow_add_le_two_rpow_sub_one_mul — real-valued bound (a+b)^p ≤ 2^(p−1)(a^p+b^p) for a,b ≥ 0, p ≥ 1, via ℝ≥0 transport (MinkowskiTheoremOQ05.lean:62)",
       "MinkowskiTheoremOQ05.rpow_add_self_eq — diagonal equality (a+a)^p = 2^(p−1)(a^p+a^p), all real p (MinkowskiTheoremOQ05.lean:76)",
       "MinkowskiTheoremOQ05.two_rpow_sub_one_le_of_forall — optimality lower bound C ≥ 2^(p−1) from test point a=b=1 (MinkowskiTheoremOQ05.lean:91)",
-      "MinkowskiTheoremOQ05.isLeast_two_rpow_sub_one — 2^(p−1) is the least admissible constant (MinkowskiTheoremOQ05.lean:112)"
+      "MinkowskiTheoremOQ05.isLeast_two_rpow_sub_one — 2^(p−1) is the least admissible constant (MinkowskiTheoremOQ05.lean:112)",
+      "BUILD VERIFIED 2026-06-20: docker-build.sh Proofs.MinkowskiTheoremOQ05 succeeded (7743/7743); #print axioms = [propext, Classical.choice, Quot.sound] for all 4 theorems — genuine 0-axiom verified, no Lean.ofReduceBool/sorryAx."
     ],
     "insights": [
       "The ℝ≥0 inequality itself is verbatim in Mathlib (NNReal.rpow_add_le_mul_rpow_add_rpow, MeanInequalitiesPow.lean:117); the genuine content is the real-valued nonnegative form (absent) plus the optimality of the constant 2^(p−1) (absent).",


### PR DESCRIPTION
## Summary

The Lean proof `Proofs/MinkowskiTheoremOQ05.lean` (merged in #27143) was fully written in a prior session but **never kernel-checked** — a Docker harness blackout on 2026-06-20 prevented the build, so the gallery entry was conservatively held at `formalized`/`wip`.

The Docker harness has recovered. This PR records the verification and promotes the entry.

## What changed

- **Build confirmed green**: `✔ [7743/7743] Built Proofs.MinkowskiTheoremOQ05 (469s)`
- **Axiom profile clean**: `#print axioms` on all four theorems reports only `[propext, Classical.choice, Quot.sound]` — no `Lean.ofReduceBool`, no `sorryAx`. Genuine 0-axiom verified.
- `meta.json`: `status formalized → verified`, `badge wip → original`, `assumptions` rewritten to record the green build.
- Research knowledge (`*.json` + `knowledge.md`) updated.

No Lean source changes — only gallery metadata + research knowledge.

## The result

For `p ≥ 1` and nonnegative reals `a, b`: `(a + b)^p ≤ 2^(p−1)(a^p + b^p)`, with `2^(p−1)` shown to be the **optimal** constant:
```
2^(p−1) = IsLeast { C | ∀ a b ≥ 0, (a+b)^p ≤ C·(a^p + b^p) }
```
Mathlib has the inequality only for `ℝ≥0`/`ℝ≥0∞`; the real-valued nonnegative form and the optimality of the constant are both absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)