### PR TITLE
audit: badge original→mathlib for two Mathlib-specialization ζ-value entries (basel-oq-10, basel-oq-12)

### DIFF
--- a/src/data/proofs/basel-problem-oq-10/meta.json
+++ b/src/data/proofs/basel-problem-oq-10/meta.json
@@ -41,7 +41,7 @@
     "lineCount": 93,
     "theoremCount": 4,
     "definitionCount": 0,
-    "badge": "original",
+    "badge": "mathlib",
     "originalContributions": [
       "not_summable_leibniz: the Leibniz family (-1)^k/(2k+1) is NOT Summable — its absolute values 1/(2k+1) dominate the divergent half-harmonic series, so convergence is only conditional. This is the substantive new lemma.",
       "tsum_leibniz_eq_zero: as a consequence, the unconditional tsum ∑' k, (-1)^k/(2k+1) equals the junk value 0, not π/4",

--- a/src/data/proofs/basel-problem-oq-12/meta.json
+++ b/src/data/proofs/basel-problem-oq-12/meta.json
@@ -17,7 +17,7 @@
       "infinite-series",
       "euler"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Gallery integrity: badge corrections (Mathlib Wrapper Detection)

Two Basel-family entries carry badge `original`, but each obtains the theorem named in its title by directly calling a Mathlib theorem. Per the gallery **Mathlib Wrapper Detection** rule, a headline result obtained via a Mathlib theorem is Tier B and should carry badge `mathlib`. Both entries' `originalContributions` already honestly disclose the dependency — this only corrects the top-level badge to match.

### 1. `basel-problem-oq-10` — "Leibniz's Series for π — and Why It Is Only Conditional"
The titled theorem `leibniz_tendsto_pi_div_four` is a verbatim re-export:
```lean
theorem leibniz_tendsto_pi_div_four : ... := tendsto_sum_pi_div_four
```
The genuinely original lemma is `not_summable_leibniz` (conditional convergence). The file's docstring already states "the convergence itself is Mathlib's."

### 2. `basel-problem-oq-12` — "The Sixth-Power Zeta Value ζ(6) = π⁶/945"
The titled theorem `hasSum_zeta_six` is `convert hasSum_zeta_nat (k:=3)` (Euler's general even-zeta formula). The file's docstring: "everything else is bookkeeping on top of `hasSum_zeta_nat`." The genuinely new lemma is `bernoulli'_six` (B₆=1/42, which Mathlib lacks). This also restores consistency with the sibling entry `basel-problem-oq-11`, which already uses badge `mathlib` for an analogous ζ-value derivation.

## Fix
`meta.meta.badge`: `original` → `mathlib` in both entries. No status change (both remain `verified` — 0 sorries, 0 axioms, no structure-encoded assumptions). The original lemmas (`not_summable_leibniz`, `bernoulli'_six`) remain accurately credited in `originalContributions`.

---
Discovered during gallery integrity audit. Severity: MEDIUM (each).