### PR TITLE
research(weierstrass-approximation-theorem-oq-01): uniform approximation by polynomials — epsilon/sequence/density/Bernstein + |x| witness [verified]

### DIFF
--- a/proofs/Proofs/WeierstrassApproximationTheoremOQ01.lean
+++ b/proofs/Proofs/WeierstrassApproximationTheoremOQ01.lean
@@ -1,0 +1,141 @@
+import Mathlib.Topology.ContinuousMap.Weierstrass
+import Mathlib.Analysis.SpecialFunctions.Bernstein
+import Mathlib.Tactic
+
+/-
+# The Weierstrass Approximation Theorem
+
+## What This Proves
+
+Karl Weierstrass's 1885 approximation theorem is a cornerstone of analysis:
+
+> Every real-valued function that is continuous on a closed bounded interval
+> `[a, b]` is a uniform limit of polynomials.
+
+This file assembles the theorem in four complementary forms — the
+"epsilon" form, the genuine *sequence* form (a single sequence of polynomials
+converging uniformly), the abstract *density* form, and an explicit
+*constructive* sequence (Bernstein polynomials) — and finishes with
+Weierstrass's own celebrated witness, the non-differentiable function `|x|`.
+
+* **Epsilon form** (`weierstrass_epsilon`). For every `ε > 0` there is a
+  polynomial `p` with `|p(x) - f(x)| < ε` for all `x ∈ [a, b]`.
+
+* **Sequence form** (`exists_polynomial_seq_tendstoUniformlyOn`). There is a
+  single sequence of polynomials `pₙ` converging *uniformly* to `f` on
+  `[a, b]`. This is the literal "uniform limit of polynomials" statement and
+  is the mathematical heart of the file: it is built from the epsilon form by
+  choosing `pₙ` within `1/(n+1)` of `f` and proving the resulting sequence
+  satisfies the `TendstoUniformlyOn` predicate.
+
+* **Density form** (`weierstrass_density`). The subalgebra of polynomial
+  functions is topologically dense in `C([a, b], ℝ)`: its closure is the whole
+  space.
+
+* **Constructive form** (`bernstein_tendstoUniformly`). On `[0, 1]` the
+  explicit Bernstein polynomials `∑ₖ f(k/n)·C(n,k)·xᵏ·(1-x)^(n-k)` converge
+  uniformly to `f` — an effective approximating sequence, not a mere existence
+  statement.
+
+* **Concrete instance** (`exists_polynomial_near_abs`,
+  `exists_polynomial_seq_abs`). The absolute-value function `|x|`, Weierstrass's
+  own example of a continuous but non-smooth function, is uniformly
+  approximable by polynomials on `[-1, 1]`.
+
+## Relation to Mathlib
+
+Mathlib proves the theorem behind the bundled/unbundled epsilon forms
+(`exists_polynomial_near_of_continuousOn`) and the density form
+(`polynomialFunctions_closure_eq_top`), and the constructive Bernstein
+convergence (`bernsteinApproximation_uniform`). What is **not** in Mathlib —
+and what this file contributes — is the packaging of these into the single
+*uniformly convergent sequence of polynomials* (`TendstoUniformlyOn`) that is
+the textbook statement of the theorem, together with the worked `|x|`
+instance. A `grep` of `proofs/Proofs` for `exists_polynomial_near`,
+`polynomialFunctions`, or `bernsteinApproximation` returns no prior
+formalization; the gallery had only incidental prose mentions.
+
+This file is `0`-axiom (only `propext` / `Classical.choice` / `Quot.sound`;
+no `native_decide`).
+-/
+
+namespace WeierstrassApproximation
+
+open Filter Topology unitInterval
+open scoped Polynomial
+
+/-- **Weierstrass approximation, epsilon form.** Every function continuous on
+`[a, b]` is within any `ε > 0` of some polynomial, uniformly on `[a, b]`. This
+is `exists_polynomial_near_of_continuousOn`, restated as the headline. -/
+theorem weierstrass_epsilon (a b : ℝ) (f : ℝ → ℝ)
+    (hf : ContinuousOn f (Set.Icc a b)) {ε : ℝ} (hε : 0 < ε) :
+    ∃ p : ℝ[X], ∀ x ∈ Set.Icc a b, |p.eval x - f x| < ε :=
+  exists_polynomial_near_of_continuousOn a b f hf ε hε
+
+/-- **Weierstrass approximation, density form.** The polynomial functions are
+topologically dense in `C([a, b], ℝ)`: the closure of the subalgebra they
+generate is the whole space. This is `polynomialFunctions_closure_eq_top`. -/
+theorem weierstrass_density (a b : ℝ) :
+    (polynomialFunctions (Set.Icc a b)).topologicalClosure = ⊤ :=
+  polynomialFunctions_closure_eq_top a b
+
+/-- **Weierstrass approximation, sequence form** (the textbook statement).
+Every function continuous on `[a, b]` is the *uniform* limit of a single
+sequence of polynomials.
+
+Construction: choose, for each `n`, a polynomial `pₙ` within `1/(n+1)` of `f`
+on `[a, b]` (epsilon form); since `1/(n+1) → 0`, the sequence `pₙ` converges to
+`f` uniformly on `[a, b]`. -/
+theorem exists_polynomial_seq_tendstoUniformlyOn (a b : ℝ) (f : ℝ → ℝ)
+    (hf : ContinuousOn f (Set.Icc a b)) :
+    ∃ p : ℕ → ℝ[X],
+      TendstoUniformlyOn (fun n x => (p n).eval x) f atTop (Set.Icc a b) := by
+  -- For each `n`, pick a polynomial within `1/(n+1)` of `f` on `[a, b]`.
+  choose p hp using fun n : ℕ =>
+    exists_polynomial_near_of_continuousOn a b f hf (1 / ((n : ℝ) + 1)) (by positivity)
+  refine ⟨p, ?_⟩
+  rw [Metric.tendstoUniformlyOn_iff]
+  intro ε hε
+  -- Beyond some index `N > 1/ε`, the gap `1/(n+1)` drops below `ε`.
+  obtain ⟨N, hN⟩ := exists_nat_gt (1 / ε)
+  filter_upwards [eventually_ge_atTop N] with n hn x hx
+  have hnpos : (0 : ℝ) < (n : ℝ) + 1 := by positivity
+  -- `1/(n+1) ≤ ε` for `n ≥ N`.
+  have hbound : 1 / ((n : ℝ) + 1) ≤ ε := by
+    rw [div_le_iff₀ hnpos]
+    have h1 : (1 : ℝ) / ε < (n : ℝ) + 1 :=
+      calc (1 : ℝ) / ε < N := hN
+        _ ≤ (n : ℝ) := by exact_mod_cast hn
+        _ ≤ (n : ℝ) + 1 := by linarith
+    rw [div_lt_iff₀ hε] at h1
+    nlinarith [h1]
+  rw [Real.dist_eq, abs_sub_comm]
+  exact lt_of_lt_of_le (hp n x hx) hbound
+
+/-- **Weierstrass approximation, constructive form (Bernstein).** For a
+continuous `f` on `[0, 1]`, the explicit Bernstein approximants
+`bernsteinApproximation n f = ∑ₖ bernstein n k · f(k/n)` converge uniformly to
+`f` as `n → ∞`. This is `bernsteinApproximation_uniform`, an *effective*
+approximating sequence — no choice or existential is needed to write it down. -/
+theorem bernstein_tendstoUniformly (f : C(I, ℝ)) :
+    Tendsto (fun n : ℕ => bernsteinApproximation n f) atTop (𝓝 f) :=
+  bernsteinApproximation_uniform f
+
+/-- **The absolute-value function is uniformly approximable.** Weierstrass's own
+example: `|x|` is continuous but not differentiable at `0`, yet for every
+`ε > 0` there is a polynomial `p` with `|p(x) - |x|| < ε` for all
+`x ∈ [-1, 1]`. -/
+theorem exists_polynomial_near_abs {ε : ℝ} (hε : 0 < ε) :
+    ∃ p : ℝ[X], ∀ x ∈ Set.Icc (-1 : ℝ) 1, |p.eval x - abs x| < ε :=
+  weierstrass_epsilon (-1) 1 (fun x => |x|) (_root_.continuous_abs.continuousOn) hε
+
+/-- **A polynomial sequence converging uniformly to `|x|` on `[-1, 1]`.** The
+sequence form specialized to Weierstrass's non-smooth witness. -/
+theorem exists_polynomial_seq_abs :
+    ∃ p : ℕ → ℝ[X],
+      TendstoUniformlyOn (fun n x => (p n).eval x) (fun x => |x|) atTop
+        (Set.Icc (-1 : ℝ) 1) :=
+  exists_polynomial_seq_tendstoUniformlyOn (-1) 1 (fun x => |x|)
+    (_root_.continuous_abs.continuousOn)
+
+end WeierstrassApproximation

--- a/src/data/proofs/weierstrass-approximation-theorem-oq-01/annotations.json
+++ b/src/data/proofs/weierstrass-approximation-theorem-oq-01/annotations.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": "ann-epsilon-and-density",
+    "proofId": "weierstrass-approximation-theorem-oq-01",
+    "range": { "startLine": 67, "endLine": 79 },
+    "type": "theorem",
+    "title": "Epsilon and Density Forms (weierstrass_epsilon, weierstrass_density)",
+    "content": "weierstrass_epsilon restates Mathlib's exists_polynomial_near_of_continuousOn: for f continuous on [a,b] and every ε>0 there is a polynomial p with |p(x)−f(x)| < ε for all x ∈ [a,b] — uniform approximation to any accuracy. weierstrass_density restates polynomialFunctions_closure_eq_top: the subalgebra of polynomial functions has topological closure ⊤ in C([a,b],ℝ), i.e. it is dense in the sup norm. The two are logically equivalent statements of Weierstrass's theorem; the density form is the one that generalizes to the Stone–Weierstrass theorem.",
+    "mathContext": "$\\forall \\varepsilon>0,\\ \\exists p,\\ \\sup_{x\\in[a,b]}|p(x)-f(x)|<\\varepsilon$; equivalently $\\overline{\\mathrm{poly}([a,b])}=\\top$.",
+    "prerequisites": [
+      "exists_polynomial_near_of_continuousOn (Mathlib's unbundled ε-form)",
+      "polynomialFunctions_closure_eq_top (Mathlib's density form)",
+      "The sup norm on C([a,b],ℝ) and topological closure of a subalgebra"
+    ],
+    "relatedConcepts": ["uniform approximation", "density", "subalgebra closure", "Stone–Weierstrass"],
+    "significance": "The two equivalent faces of the theorem: the analyst's ε-form one actually applies, and the algebraist's density form that generalizes to Stone–Weierstrass."
+  },
+  {
+    "id": "ann-sequence-form",
+    "proofId": "weierstrass-approximation-theorem-oq-01",
+    "range": { "startLine": 82, "endLine": 113 },
+    "type": "theorem",
+    "title": "The Uniformly Convergent Polynomial Sequence (exists_polynomial_seq_tendstoUniformlyOn) — centerpiece",
+    "content": "This is the genuine contribution beyond Mathlib: the literal textbook statement that f is the uniform limit of a single sequence of polynomials. Construction: the `choose` tactic extracts, for each n, a polynomial pₙ within 1/(n+1) of f on [a,b] (applying weierstrass_epsilon at ε = 1/(n+1)). To prove TendstoUniformlyOn (fun n x => (pₙ).eval x) f atTop [a,b], rewrite with Metric.tendstoUniformlyOn_iff and fix ε>0; exists_nat_gt (1/ε) yields an index N, and for n ≥ N one has 1/(n+1) ≤ ε (proved with div_le_iff₀, div_lt_iff₀, and nlinarith from the chain 1/ε < N ≤ n ≤ n+1). Then abs_sub_comm reconciles dist(f x, pₙ x) with the chosen bound |pₙ(x)−f(x)| < 1/(n+1) ≤ ε. Mathlib has the ε-form and the density form but not this sequence form.",
+    "mathContext": "$\\exists (p_n)\\subset\\mathbb{R}[X],\\ p_n \\to f \\text{ uniformly on } [a,b]$.",
+    "prerequisites": [
+      "weierstrass_epsilon (this file) and the `choose` tactic",
+      "Metric.tendstoUniformlyOn_iff (uniform convergence via dist)",
+      "exists_nat_gt (Archimedean property) and div_le_iff₀ / div_lt_iff₀",
+      "abs_sub_comm, nlinarith"
+    ],
+    "relatedConcepts": ["uniform convergence", "TendstoUniformlyOn", "Archimedean estimate", "axiom of choice (choose)"],
+    "significance": "The centerpiece: it turns Mathlib's per-ε existence into the single uniformly convergent sequence of polynomials that is the standard statement of Weierstrass's theorem."
+  },
+  {
+    "id": "ann-bernstein",
+    "proofId": "weierstrass-approximation-theorem-oq-01",
+    "range": { "startLine": 115, "endLine": 122 },
+    "type": "theorem",
+    "title": "The Constructive Bernstein Form (bernstein_tendstoUniformly)",
+    "content": "bernstein_tendstoUniformly restates bernsteinApproximation_uniform: for a continuous f on the unit interval I = [0,1], the explicit Bernstein approximants bernsteinApproximation n f = ∑ₖ bernstein n k · f(k/n) = ∑ₖ f(k/n)·C(n,k)·xᵏ·(1−x)^(n−k) converge uniformly to f as n → ∞. Unlike the ε- and sequence-forms, which only assert existence, this gives an effective approximating sequence computed directly from the sampled values f(k/n) — no choice or existential is invoked. Bernstein's 1912 proof connects the theorem to the law of large numbers via the binomial distribution.",
+    "mathContext": "$\\sum_{k=0}^{n} f\\!\\left(\\tfrac{k}{n}\\right)\\binom{n}{k}x^k(1-x)^{n-k} \\to f$ uniformly on $[0,1]$.",
+    "prerequisites": [
+      "bernsteinApproximation and bernsteinApproximation_uniform (Mathlib)",
+      "The unit interval I = unitInterval and C(I,ℝ) with its sup norm",
+      "Convergence in 𝓝 f within the space of continuous maps"
+    ],
+    "relatedConcepts": ["Bernstein polynomials", "constructive approximation", "law of large numbers", "binomial distribution"],
+    "significance": "The effective form: an explicit, computable sequence of approximating polynomials, in contrast to the existence-only ε- and sequence-forms."
+  },
+  {
+    "id": "ann-abs-witness",
+    "proofId": "weierstrass-approximation-theorem-oq-01",
+    "range": { "startLine": 124, "endLine": 140 },
+    "type": "theorem",
+    "title": "Weierstrass's Witness |x| (exists_polynomial_near_abs, exists_polynomial_seq_abs)",
+    "content": "The two corollaries specialize the ε-form and the sequence form to f = |·| on [−1,1], using _root_.continuous_abs.continuousOn to supply continuity. exists_polynomial_near_abs gives, for every ε>0, a polynomial within ε of |x| on [−1,1]; exists_polynomial_seq_abs gives a single sequence of polynomials converging uniformly to |x| there. The absolute value is Weierstrass's own touchstone — continuous everywhere but non-differentiable at 0 — so that an infinitely smooth polynomial can nonetheless hug a function with a corner to within any ε makes the surprise of the theorem concrete.",
+    "mathContext": "$\\forall \\varepsilon>0,\\ \\exists p,\\ \\sup_{x\\in[-1,1]}|p(x)-|x||<\\varepsilon$, and $\\exists (p_n),\\ p_n\\to |\\cdot|$ uniformly on $[-1,1]$.",
+    "prerequisites": [
+      "weierstrass_epsilon and exists_polynomial_seq_tendstoUniformlyOn (this file)",
+      "_root_.continuous_abs and ContinuousOn from a global Continuous",
+      "Set.Icc (-1) 1"
+    ],
+    "relatedConcepts": ["absolute value", "non-differentiable function", "concrete instance", "uniform approximation"],
+    "significance": "The concrete payoff: Weierstrass's own non-smooth example, shown uniformly approximable by polynomials in both the ε-form and as a convergent sequence."
+  }
+]

--- a/src/data/proofs/weierstrass-approximation-theorem-oq-01/meta.json
+++ b/src/data/proofs/weierstrass-approximation-theorem-oq-01/meta.json
@@ -1,0 +1,90 @@
+{
+  "id": "weierstrass-approximation-theorem-oq-01",
+  "title": "The Weierstrass Approximation Theorem",
+  "slug": "weierstrass-approximation-theorem-oq-01",
+  "description": "Karl Weierstrass's 1885 approximation theorem: every real-valued function continuous on a closed bounded interval [a,b] is a uniform limit of polynomials. This entry assembles the theorem in four complementary forms and finishes with Weierstrass's own non-smooth witness |x|. (1) EPSILON FORM weierstrass_epsilon: for every ε>0 there is a polynomial p with |p(x)−f(x)| < ε for all x ∈ [a,b]. (2) SEQUENCE FORM exists_polynomial_seq_tendstoUniformlyOn — the textbook statement and the mathematical heart of the file: a SINGLE sequence of polynomials pₙ converging UNIFORMLY to f on [a,b] (TendstoUniformlyOn), built from the epsilon form by choosing pₙ within 1/(n+1) of f and proving the resulting sequence meets the uniform-convergence predicate. (3) DENSITY FORM weierstrass_density: the subalgebra of polynomial functions is topologically dense in C([a,b],ℝ), i.e. its closure is ⊤. (4) CONSTRUCTIVE FORM bernstein_tendstoUniformly: on [0,1] the explicit Bernstein polynomials ∑ₖ f(k/n)·C(n,k)·xᵏ·(1−x)^(n−k) converge uniformly to f — an effective approximating sequence, not a mere existence statement. (5) CONCRETE INSTANCE exists_polynomial_near_abs / exists_polynomial_seq_abs: the absolute-value function |x|, Weierstrass's own example of a continuous but non-differentiable function, is uniformly approximable by polynomials on [−1,1] — both the ε-form and a uniformly convergent sequence. Mathlib proves the theorem behind the epsilon and density forms (exists_polynomial_near_of_continuousOn, polynomialFunctions_closure_eq_top) and the Bernstein convergence (bernsteinApproximation_uniform); what is NOT in Mathlib and is the genuine contribution here is the packaging into the single uniformly-convergent sequence of polynomials (TendstoUniformlyOn) that IS the textbook statement, plus the worked |x| instance. A grep of proofs/Proofs for exists_polynomial_near / polynomialFunctions / bernsteinApproximation returned zero prior formalization; the gallery had only incidental prose mentions. Foundational: underlies approximation theory, numerical analysis, Fourier/orthogonal-polynomial theory, and the Stone–Weierstrass generalization.",
+  "leanFile": "Proofs/WeierstrassApproximationTheoremOQ01.lean",
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Stone%E2%80%93Weierstrass_theorem#Weierstrass_approximation_theorem",
+    "date": "1885",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WeierstrassApproximationTheoremOQ01.lean",
+    "tags": [
+      "analysis",
+      "approximation-theory",
+      "weierstrass",
+      "polynomials",
+      "uniform-convergence",
+      "bernstein-polynomials",
+      "continuous-functions",
+      "density"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "relatedProblems": [],
+    "axiomCount": 0,
+    "lineCount": 141,
+    "assumptions": "0 axioms, 0 sorries, no native_decide, no Lean.ofReduceBool. All six theorems depend only on the foundational propext / Classical.choice / Quot.sound (verified via #print axioms). weierstrass_epsilon is exists_polynomial_near_of_continuousOn restated as the headline; weierstrass_density is polynomialFunctions_closure_eq_top; bernstein_tendstoUniformly is bernsteinApproximation_uniform. The genuinely new content, exists_polynomial_seq_tendstoUniformlyOn, uses choose to pick pₙ within 1/(n+1) of f from the epsilon form, then proves TendstoUniformlyOn via Metric.tendstoUniformlyOn_iff: given ε>0, exists_nat_gt (1/ε) supplies an index N beyond which 1/(n+1) ≤ ε (div_le_iff₀ / div_lt_iff₀ + nlinarith), and abs_sub_comm matches the chosen bound. exists_polynomial_near_abs and exists_polynomial_seq_abs specialize the epsilon and sequence forms to f = |·| via _root_.continuous_abs.continuousOn. The only mathematical hypothesis anywhere is continuity of f on the interval.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "In 1885 Karl Weierstrass proved that every continuous function on a closed bounded interval can be approximated uniformly, to any desired accuracy, by polynomials. The result was striking precisely because continuous functions can be extremely wild — nowhere differentiable, for instance — yet are nonetheless limits of the smoothest functions imaginable. It launched modern approximation theory and was later subsumed by the Stone–Weierstrass theorem (1937–48), which characterizes which subalgebras of C(X) are dense. Several constructive proofs followed; Sergei Bernstein's 1912 proof, using the probabilistic Bernstein polynomials ∑ₖ f(k/n)·C(n,k)·xᵏ·(1−x)^(n−k), gives an explicit approximating sequence and connects the theorem to the law of large numbers. Weierstrass's own touchstone example was |x|, continuous everywhere but differentiable nowhere at the origin, yet still a uniform limit of polynomials.",
+    "problemStatement": "Prove the Weierstrass approximation theorem and package its standard forms: (i) the epsilon form — for continuous f on [a,b] and every ε>0 there is a polynomial within ε of f uniformly on [a,b]; (ii) the sequence form — there is a single sequence of polynomials converging uniformly to f on [a,b]; (iii) the density form — the polynomial functions are topologically dense in C([a,b],ℝ); (iv) the constructive Bernstein form — the explicit Bernstein approximants of a continuous f on [0,1] converge uniformly; and (v) the concrete witness — the non-differentiable function |x| is uniformly approximable by polynomials on [−1,1].",
+    "text": "Mathlib carries the analytic core of Weierstrass approximation (exists_polynomial_near_of_continuousOn, polynomialFunctions_closure_eq_top) and Bernstein's constructive convergence (bernsteinApproximation_uniform), but it does not state the theorem in the form most textbooks give it: a single sequence of polynomials converging uniformly to f. This entry supplies exactly that bridge. From the epsilon form it chooses, for each n, a polynomial pₙ within 1/(n+1) of f, and proves the sequence (pₙ) converges uniformly via the metric characterization of TendstoUniformlyOn — the new mathematical content. It then restates the density and Bernstein forms cleanly and specializes both the ε-form and the sequence form to Weierstrass's own example |x| on [−1,1], anchoring the abstract theorem to a concrete non-smooth function.",
+    "keyInsights": [
+      "**The textbook statement is a sequence, and that sequence has to be built.** Mathlib gives the ε-form (an existential for each ε) and the abstract density form, but not the literal 'uniform limit of polynomials'. exists_polynomial_seq_tendstoUniformlyOn closes the gap: choose pₙ within 1/(n+1) of f for every n (the `choose` tactic over the ε-form), then verify the single sequence converges uniformly. This packaging is the genuine contribution.",
+      "**Uniform convergence reduces to one Archimedean estimate.** Via Metric.tendstoUniformlyOn_iff, uniform convergence of (pₙ) means: for every ε>0, eventually sup over x of dist(f x, pₙ x) < ε. Since pₙ is within 1/(n+1) of f, it suffices that 1/(n+1) ≤ ε beyond some index — and exists_nat_gt (1/ε) furnishes that index. The whole proof of the headline is this estimate plus abs_sub_comm.",
+      "**Density is the algebraic face of the same theorem.** polynomialFunctions_closure_eq_top says the subalgebra of polynomial functions has topological closure ⊤ in C([a,b],ℝ): every continuous function is a limit of polynomials in the sup norm. This is logically equivalent to the ε-form but phrased in the language of subalgebras, the form that generalizes to Stone–Weierstrass.",
+      "**Bernstein makes the approximation effective.** Where the ε- and sequence-forms only assert existence, bernsteinApproximation_uniform exhibits an explicit sequence ∑ₖ f(k/n)·C(n,k)·xᵏ·(1−x)^(n−k) that converges uniformly on [0,1]. No choice or existential is needed to write a Bernstein approximant down — it is computed directly from the values of f at the dyadic-like points k/n.",
+      "**|x| is the canonical witness.** Weierstrass's own example, continuous but non-differentiable at 0, is uniformly approximable: exists_polynomial_near_abs and exists_polynomial_seq_abs specialize the ε- and sequence-forms to f = |·| on [−1,1]. That a polynomial — infinitely smooth — can hug a function with a corner to within any ε is the surprise the theorem makes precise."
+    ],
+    "prerequisites": [
+      "Continuous functions on a closed interval and the sup norm on C([a,b],ℝ)",
+      "Mathlib's exists_polynomial_near_of_continuousOn and polynomialFunctions_closure_eq_top (the analytic core of the theorem)",
+      "The uniform-convergence predicate TendstoUniformlyOn and its metric characterization Metric.tendstoUniformlyOn_iff",
+      "Bernstein polynomials and bernsteinApproximation_uniform for the constructive form",
+      "The Archimedean property (exists_nat_gt) for the index estimate, and continuity of |·| (continuous_abs) for the worked instance"
+    ]
+  },
+  "sections": [
+    {
+      "id": "epsilon-and-density",
+      "title": "Epsilon and Density Forms",
+      "startLine": 67,
+      "endLine": 79,
+      "mathContext": "$\\forall \\varepsilon>0,\\ \\exists p,\\ \\sup_{x\\in[a,b]}|p(x)-f(x)|<\\varepsilon$; equivalently $\\overline{\\mathrm{poly}([a,b])}=\\top$ in $C([a,b],\\mathbb{R})$.",
+      "summary": "weierstrass_epsilon restates exists_polynomial_near_of_continuousOn: every f continuous on [a,b] is within any ε>0 of a polynomial, uniformly on [a,b]. weierstrass_density restates polynomialFunctions_closure_eq_top: the polynomial functions are topologically dense in C([a,b],ℝ), the form that generalizes to Stone–Weierstrass."
+    },
+    {
+      "id": "sequence-form",
+      "title": "The Uniformly Convergent Polynomial Sequence (centerpiece)",
+      "startLine": 82,
+      "endLine": 113,
+      "mathContext": "$\\exists (p_n),\\ p_n \\to f$ uniformly on $[a,b]$ — the textbook 'uniform limit of polynomials'.",
+      "summary": "exists_polynomial_seq_tendstoUniformlyOn is the new content: choose pₙ within 1/(n+1) of f for each n (the choose tactic over weierstrass_epsilon), then prove the single sequence converges uniformly via Metric.tendstoUniformlyOn_iff. The proof reduces to one Archimedean estimate — exists_nat_gt (1/ε) gives an index beyond which 1/(n+1) ≤ ε (div_le_iff₀/div_lt_iff₀ + nlinarith) — with abs_sub_comm matching the chosen bound."
+    },
+    {
+      "id": "bernstein",
+      "title": "The Constructive Bernstein Form",
+      "startLine": 115,
+      "endLine": 122,
+      "mathContext": "$\\sum_{k=0}^{n} f\\!\\left(\\tfrac{k}{n}\\right)\\binom{n}{k}x^k(1-x)^{n-k} \\to f$ uniformly on $[0,1]$.",
+      "summary": "bernstein_tendstoUniformly restates bernsteinApproximation_uniform: for continuous f on [0,1], the explicit Bernstein approximants converge uniformly. Unlike the ε- and sequence-forms, this is an effective sequence — computed directly from the values f(k/n), no choice required."
+    },
+    {
+      "id": "abs-witness",
+      "title": "Weierstrass's Witness: the Function |x|",
+      "startLine": 124,
+      "endLine": 140,
+      "mathContext": "$\\forall \\varepsilon>0,\\ \\exists p,\\ \\sup_{x\\in[-1,1]}|p(x)-|x||<\\varepsilon$, and a sequence $p_n\\to |\\cdot|$ uniformly on $[-1,1]$.",
+      "summary": "exists_polynomial_near_abs and exists_polynomial_seq_abs specialize the ε-form and the sequence form to f = |·| on [−1,1] via _root_.continuous_abs.continuousOn. Weierstrass's own example — continuous but non-differentiable at 0 — is uniformly approximable by polynomials, the concrete payoff of the abstract theorem."
+    }
+  ],
+  "conclusion": "The Weierstrass approximation theorem is assembled in its four standard forms — epsilon, sequence, density, and constructive Bernstein — with the sequence form (a single sequence of polynomials converging uniformly on [a,b], TendstoUniformlyOn) the genuine contribution beyond Mathlib's analytic core, built from the ε-form by choosing approximants within 1/(n+1) and verifying uniform convergence through one Archimedean estimate. The development is sorry-free and axiom-free (only propext / Classical.choice / Quot.sound, no native_decide), and is anchored by Weierstrass's own witness |x|, shown uniformly approximable by polynomials on [−1,1] in both the ε-form and as a convergent sequence.",
+  "crossReferences": []
+}


### PR DESCRIPTION
## Weierstrass Approximation Theorem

Karl Weierstrass's 1885 theorem — **every real-valued function continuous on a closed bounded interval `[a,b]` is a uniform limit of polynomials** — assembled in four complementary forms, with his own non-differentiable witness `|x|`.

### Theorems (6 total, 0 def, 0 sorry, 0 axioms)

1. **`weierstrass_epsilon`** — ε-form: for every `ε>0` a polynomial within `ε` of `f` uniformly on `[a,b]` (restates `exists_polynomial_near_of_continuousOn`).
2. **`exists_polynomial_seq_tendstoUniformlyOn`** — **the genuine new content**: a *single* sequence of polynomials converging **uniformly** to `f` on `[a,b]` (`TendstoUniformlyOn`). This is the textbook statement and is **not in Mathlib**. Built from the ε-form by `choose`-ing `pₙ` within `1/(n+1)` of `f`, then verifying uniform convergence via `Metric.tendstoUniformlyOn_iff` and one Archimedean estimate (`exists_nat_gt (1/ε)`).
3. **`weierstrass_density`** — density form: polynomial functions are topologically dense in `C([a,b],ℝ)`, closure `= ⊤` (restates `polynomialFunctions_closure_eq_top`); the Stone–Weierstrass face.
4. **`bernstein_tendstoUniformly`** — constructive form: the explicit Bernstein approximants converge uniformly on `[0,1]` (restates `bernsteinApproximation_uniform`) — an *effective* sequence.
5. **`exists_polynomial_near_abs`** / **`exists_polynomial_seq_abs`** — Weierstrass's own witness `|x|` on `[-1,1]`: uniformly approximable in both the ε-form and as a convergent sequence.

### Relation to Mathlib

Mathlib proves the analytic core (`exists_polynomial_near_of_continuousOn`, `polynomialFunctions_closure_eq_top`, `bernsteinApproximation_uniform`) but **does not** state the theorem as the single uniformly-convergent polynomial *sequence* that textbooks give — this PR supplies that bridge plus the worked `|x|` instance. `grep proofs/Proofs` for `exists_polynomial_near` / `polynomialFunctions` / `bernsteinApproximation` → 0 prior formalization.

### Verification

- Docker build green (`Proofs.WeierstrassApproximationTheoremOQ01`).
- `#print axioms` on all 6 theorems: only `propext`, `Classical.choice`, `Quot.sound`. **0 axioms, no `native_decide`, no `Lean.ofReduceBool`.**
- Gallery annotations validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)