### PR TITLE
research(urysohns-lemma-oq-01): explicit metric Urysohn function (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3379,6 +3379,7 @@ import Proofs.TwinPrimesSpecialOQ01
 import Proofs.UnitDistanceHN7
 import Proofs.UnitDistanceHN7Aristotle
 import Proofs.UnitDistanceIndependence
+import Proofs.UrysohnsLemmaOQ01
 import Proofs.VanAubelTheoremOQ01
 import Proofs.VandermondeInterpolationOQ01
 import Proofs.VarignonTheorem

--- a/proofs/Proofs/UrysohnsLemmaOQ01.lean
+++ b/proofs/Proofs/UrysohnsLemmaOQ01.lean
@@ -1,0 +1,170 @@
+import Mathlib
+
+/-!
+# Urysohn's lemma and the explicit metric Urysohn function
+
+**Urysohn's lemma** (Urysohn 1925) is the cornerstone separation theorem of point-set
+topology: in a normal space any two disjoint closed sets are *functionally separated* by a
+continuous real-valued function. Mathlib proves the abstract statement
+
+* `exists_continuous_zero_one_of_isClosed` — in a `NormalSpace`, disjoint closed sets `s`,
+  `t` admit a continuous `f : C(X, ℝ)` with `f = 0` on `s`, `f = 1` on `t`, `0 ≤ f ≤ 1`,
+
+and the locally-compact-Hausdorff variant `exists_continuous_zero_one_of_isCompact`. This
+file re-exports those headline results (hence the `mathlib` badge) and then supplies the
+genuine content absent from Mathlib: the **explicit Urysohn function on a metric space**.
+
+For disjoint nonempty closed sets `s`, `t` in a metric space the textbook witness is
+$$ f(x) \;=\; \frac{d(x,s)}{d(x,s) + d(x,t)}, $$
+built from the distance-to-a-set function `Metric.infDist`. We construct it as
+`urysohnFn s t` and prove, with no appeal to the abstract Urysohn machinery, that it is
+
+* continuous (`continuous_urysohnFn`), the denominator never vanishing
+  (`infDist_add_pos`);
+* identically `0` on `s` (`urysohnFn_eq_zero`) and `1` on `t` (`urysohnFn_eq_one`);
+* valued in `[0, 1]` (`urysohnFn_mem_Icc`),
+
+then package it as the bundled separator `urysohn_metric`. We also record that the abstract
+lemma applies verbatim in a metric space (every metric space is normal,
+`urysohn_metric_of_normalSpace`), the consequence that a point can be separated from a
+disjoint closed set in a normal `T1` space (`urysohn_point_isClosed`), and a concrete
+evaluation of the explicit function (`urysohnFn_half_at_midpoint`).
+
+All results are fully machine-checked with no `sorry` and no extra axioms.
+-/
+
+namespace UrysohnsLemmaOQ01
+
+open Set Metric
+
+/-! ## Part (a): the abstract lemma in a normal space
+
+These are direct re-exports of Mathlib's Urysohn lemma; they carry the `mathlib` badge.
+-/
+
+section Abstract
+
+variable {X : Type*} [TopologicalSpace X]
+
+/-- **Urysohn's lemma.** In a normal space, two disjoint closed sets `s`, `t` are separated
+by a continuous function `f : X → ℝ` with `f = 0` on `s`, `f = 1` on `t`, and `0 ≤ f ≤ 1`. -/
+theorem urysohn_normal [NormalSpace X] {s t : Set X}
+    (hs : IsClosed s) (ht : IsClosed t) (hd : Disjoint s t) :
+    ∃ f : C(X, ℝ), EqOn f 0 s ∧ EqOn f 1 t ∧ ∀ x, f x ∈ Icc (0 : ℝ) 1 :=
+  exists_continuous_zero_one_of_isClosed hs ht hd
+
+/-- **Urysohn's lemma, locally compact Hausdorff form.** In a regular locally compact space,
+a compact set `s` and a disjoint closed set `t` are separated by a continuous `f : X → ℝ`
+with `f = 0` on `s`, `f = 1` on `t`, `0 ≤ f ≤ 1`. This is the version behind the Riesz
+representation theorem and partitions of unity. -/
+theorem urysohn_locallyCompact [RegularSpace X] [LocallyCompactSpace X] {s t : Set X}
+    (hs : IsCompact s) (ht : IsClosed t) (hd : Disjoint s t) :
+    ∃ f : C(X, ℝ), EqOn f 0 s ∧ EqOn f 1 t ∧ ∀ x, f x ∈ Icc (0 : ℝ) 1 :=
+  exists_continuous_zero_one_of_isCompact hs ht hd
+
+/-- **Functional separation of a point from a closed set.** In a normal `T1` space a point
+`x₀` outside a closed set `t` is separated from it by a continuous `f` with `f x₀ = 0`,
+`f = 1` on `t`, `0 ≤ f ≤ 1`. This is the gateway to complete regularity. -/
+theorem urysohn_point_isClosed [T1Space X] [NormalSpace X] {t : Set X} {x₀ : X}
+    (ht : IsClosed t) (hx₀ : x₀ ∉ t) :
+    ∃ f : C(X, ℝ), f x₀ = 0 ∧ EqOn f 1 t ∧ ∀ x, f x ∈ Icc (0 : ℝ) 1 := by
+  obtain ⟨f, hfs, hft, hficc⟩ :=
+    urysohn_normal (isClosed_singleton (x := x₀)) ht (disjoint_singleton_left.mpr hx₀)
+  exact ⟨f, by simpa using hfs (show x₀ ∈ ({x₀} : Set X) from rfl), hft, hficc⟩
+
+end Abstract
+
+/-! ## Part (b): the explicit Urysohn function on a metric space
+
+The construction `f(x) = d(x,s) / (d(x,s) + d(x,t))` separates disjoint nonempty closed
+sets, built entirely from the `Metric.infDist` API and independent of the abstract Urysohn
+machinery. This explicit function is not a named result in Mathlib.
+-/
+
+section Metric
+
+variable {X : Type*} [MetricSpace X]
+
+/-- The explicit Urysohn function separating two sets in a metric space:
+`x ↦ d(x, s) / (d(x, s) + d(x, t))`. -/
+noncomputable def urysohnFn (s t : Set X) (x : X) : ℝ :=
+  infDist x s / (infDist x s + infDist x t)
+
+/-- For disjoint nonempty closed sets, the denominator `d(x,s) + d(x,t)` is strictly
+positive everywhere: a point with both distances zero would lie in `s ∩ t`. -/
+theorem infDist_add_pos {s t : Set X} (hs : IsClosed s) (ht : IsClosed t)
+    (hsne : s.Nonempty) (htne : t.Nonempty) (hd : Disjoint s t) (x : X) :
+    0 < infDist x s + infDist x t := by
+  rcases (infDist_nonneg : (0 : ℝ) ≤ infDist x s).eq_or_lt with hxs | hpos
+  · -- `infDist x s = 0`, so `x ∈ s`, hence `x ∉ t`, hence `infDist x t > 0`.
+    have hmem : x ∈ s := (hs.mem_iff_infDist_zero hsne).2 hxs.symm
+    have hnt : x ∉ t := Set.disjoint_left.1 hd hmem
+    have htpos : 0 < infDist x t := (ht.notMem_iff_infDist_pos htne).1 hnt
+    rw [← hxs, zero_add]; exact htpos
+  · exact add_pos_of_pos_of_nonneg hpos infDist_nonneg
+
+/-- The explicit Urysohn function is continuous: a quotient of the continuous
+distance-to-a-set functions with a nowhere-vanishing denominator. -/
+theorem continuous_urysohnFn {s t : Set X} (hs : IsClosed s) (ht : IsClosed t)
+    (hsne : s.Nonempty) (htne : t.Nonempty) (hd : Disjoint s t) :
+    Continuous (urysohnFn s t) := by
+  unfold urysohnFn
+  exact (continuous_infDist_pt s).div
+    ((continuous_infDist_pt s).add (continuous_infDist_pt t))
+    (fun x => (infDist_add_pos hs ht hsne htne hd x).ne')
+
+/-- The explicit Urysohn function vanishes on `s` (its distance to `s` is zero there). -/
+theorem urysohnFn_eq_zero {s t : Set X} {x : X} (hx : x ∈ s) : urysohnFn s t x = 0 := by
+  unfold urysohnFn
+  rw [infDist_zero_of_mem hx, zero_div]
+
+/-- The explicit Urysohn function equals `1` on `t`: its distance to `t` is zero there, and
+(by disjointness with the closed nonempty `s`) its distance to `s` is positive. -/
+theorem urysohnFn_eq_one {s t : Set X} (hs : IsClosed s) (hsne : s.Nonempty)
+    (hd : Disjoint s t) {x : X} (hx : x ∈ t) : urysohnFn s t x = 1 := by
+  have hxs : x ∉ s := Set.disjoint_right.1 hd hx
+  have hpos : 0 < infDist x s := (hs.notMem_iff_infDist_pos hsne).1 hxs
+  unfold urysohnFn
+  rw [infDist_zero_of_mem hx, add_zero, div_self hpos.ne']
+
+/-- The explicit Urysohn function is valued in `[0, 1]`. -/
+theorem urysohnFn_mem_Icc {s t : Set X} (hs : IsClosed s) (ht : IsClosed t)
+    (hsne : s.Nonempty) (htne : t.Nonempty) (hd : Disjoint s t) (x : X) :
+    urysohnFn s t x ∈ Icc (0 : ℝ) 1 := by
+  have hpos := infDist_add_pos hs ht hsne htne hd x
+  unfold urysohnFn
+  refine ⟨div_nonneg infDist_nonneg hpos.le, ?_⟩
+  rw [div_le_one hpos]
+  exact le_add_of_nonneg_right infDist_nonneg
+
+/-- **Metric Urysohn lemma (explicit witness).** Disjoint nonempty closed sets in a metric
+space are separated by the explicit function `urysohnFn s t`, packaged as a bundled
+continuous map. -/
+theorem urysohn_metric {s t : Set X} (hs : IsClosed s) (ht : IsClosed t)
+    (hsne : s.Nonempty) (htne : t.Nonempty) (hd : Disjoint s t) :
+    ∃ f : C(X, ℝ), EqOn f 0 s ∧ EqOn f 1 t ∧ ∀ x, f x ∈ Icc (0 : ℝ) 1 := by
+  refine ⟨⟨urysohnFn s t, continuous_urysohnFn hs ht hsne htne hd⟩, ?_, ?_, ?_⟩
+  · intro x hx; simpa using urysohnFn_eq_zero (t := t) hx
+  · intro x hx; simpa using urysohnFn_eq_one hs hsne hd hx
+  · intro x; simpa using urysohnFn_mem_Icc hs ht hsne htne hd x
+
+/-- Every metric space is normal, so the abstract Urysohn lemma applies to it verbatim
+(no nonemptiness hypotheses needed). -/
+theorem urysohn_metric_of_normalSpace {s t : Set X} (hs : IsClosed s) (ht : IsClosed t)
+    (hd : Disjoint s t) :
+    ∃ f : C(X, ℝ), EqOn f 0 s ∧ EqOn f 1 t ∧ ∀ x, f x ∈ Icc (0 : ℝ) 1 :=
+  exists_continuous_zero_one_of_isClosed hs ht hd
+
+end Metric
+
+/-! ## Part (c): a concrete evaluation -/
+
+/-- On `ℝ`, the explicit Urysohn function separating `{0}` and `{1}` takes the value `1/2`
+at the midpoint `1/2`, as it must by symmetry. -/
+theorem urysohnFn_half_at_midpoint :
+    urysohnFn ({0} : Set ℝ) {1} (1 / 2) = 1 / 2 := by
+  unfold urysohnFn
+  rw [infDist_singleton, infDist_singleton, Real.dist_eq, Real.dist_eq]
+  norm_num
+
+end UrysohnsLemmaOQ01

--- a/src/data/proofs/urysohns-lemma-oq-01/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "urysohns-lemma-oq-01",
+  "slug": "urysohns-lemma-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Metric"
+    ],
+    "namespace": "UrysohnsLemmaOQ01",
+    "lineCount": 170,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "path": "Proofs/UrysohnsLemmaOQ01.lean",
+    "sorries": 0
+  },
+  "title": "Urysohn's Lemma and the Explicit Metric Urysohn Function",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/UrysohnsLemmaOQ01.lean",
+    "tags": [
+      "topology",
+      "separation-axioms",
+      "normal-space",
+      "urysohns-lemma",
+      "metric-space",
+      "continuous-function",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 170,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "badge": "mathlib",
+    "originalContributions": [
+      "urysohn_normal: stable re-export of Mathlib's Urysohn lemma — in a NormalSpace, disjoint closed sets s, t admit a continuous f : C(X, ℝ) with f = 0 on s, f = 1 on t and 0 ≤ f ≤ 1 (exists_continuous_zero_one_of_isClosed)",
+      "urysohn_locallyCompact: the locally-compact-Hausdorff variant separating a compact set from a disjoint closed set (exists_continuous_zero_one_of_isCompact), the form behind the Riesz representation theorem and partitions of unity",
+      "urysohn_point_isClosed: functional separation of a point from a disjoint closed set in a normal T1 space (apply Urysohn to the closed singleton {x₀}), the gateway to complete regularity",
+      "urysohnFn: the explicit metric Urysohn function urysohnFn s t x = infDist x s / (infDist x s + infDist x t) — the classical closed-form witness, not a named result in Mathlib",
+      "infDist_add_pos: the denominator infDist x s + infDist x t is strictly positive everywhere for disjoint nonempty closed s, t (a point with both distances zero would lie in s ∩ t)",
+      "continuous_urysohnFn: continuity of urysohnFn as a quotient of the continuous distance-to-a-set maps with a nowhere-vanishing denominator (continuous_infDist_pt + Continuous.div)",
+      "urysohnFn_eq_zero / urysohnFn_eq_one: the explicit function is identically 0 on s and 1 on t (via infDist_zero_of_mem and the closed-set positivity IsClosed.notMem_iff_infDist_pos)",
+      "urysohnFn_mem_Icc: the explicit function is valued in [0,1] (numerator nonnegative, bounded by the positive denominator)",
+      "urysohn_metric: the explicit witness packaged as a bundled separator ∃ f : C(X, ℝ), independent of the abstract Urysohn machinery",
+      "urysohn_metric_of_normalSpace: the abstract lemma applies verbatim in any metric space, since every metric space is normal",
+      "urysohnFn_half_at_midpoint: concrete evaluation — on ℝ the explicit function separating {0} and {1} takes the value 1/2 at the midpoint"
+    ],
+    "prerequisites": [
+      "Normal topological spaces and the bundled continuous-map type C(X, ℝ)",
+      "Mathlib's exists_continuous_zero_one_of_isClosed (Urysohn's lemma) and exists_continuous_zero_one_of_isCompact (LCH variant)",
+      "Metric.infDist (distance from a point to a set) and its API: continuous_infDist_pt, infDist_zero_of_mem, infDist_nonneg",
+      "IsClosed.mem_iff_infDist_zero and IsClosed.notMem_iff_infDist_pos: the closed-set characterisation of vanishing / positive distance",
+      "Continuous.div: a quotient of continuous functions with nowhere-vanishing denominator is continuous"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "exists_continuous_zero_one_of_isClosed",
+        "description": "Urysohn's lemma: in a normal space, disjoint closed sets are separated by a continuous [0,1]-valued function. Re-exported as the headline urysohn_normal.",
+        "module": "Mathlib.Topology.UrysohnsLemma"
+      },
+      {
+        "theorem": "exists_continuous_zero_one_of_isCompact",
+        "description": "The locally compact Hausdorff form of Urysohn's lemma, separating a compact set from a disjoint closed set.",
+        "module": "Mathlib.Topology.UrysohnsLemma"
+      },
+      {
+        "theorem": "Metric.continuous_infDist_pt / Metric.infDist_zero_of_mem / Metric.infDist_nonneg",
+        "description": "Continuity, vanishing-on-membership, and nonnegativity of the distance-to-a-set function, the engine behind the explicit metric Urysohn function.",
+        "module": "Mathlib.Topology.MetricSpace.HausdorffDistance"
+      },
+      {
+        "theorem": "IsClosed.mem_iff_infDist_zero / IsClosed.notMem_iff_infDist_pos",
+        "description": "For a closed nonempty set, infDist vanishes iff the point lies in the set, equivalently is positive off the set — supplies denominator positivity and the value-1-on-t computation.",
+        "module": "Mathlib.Topology.MetricSpace.HausdorffDistance"
+      },
+      {
+        "theorem": "Continuous.div",
+        "description": "A pointwise quotient of continuous functions with a nowhere-vanishing denominator is continuous — gives continuity of urysohnFn.",
+        "module": "Mathlib.Topology.Algebra.GroupWithZero"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "urysohns-lemma-oq-01-oq-01",
+      "question": "Prove the Tietze extension theorem from Urysohn's lemma: a continuous real-valued function on a closed subset of a normal space extends continuously to the whole space (Mathlib: ContinuousMap.exists_extension / exists_restrict_eq).",
+      "significance": "high"
+    },
+    {
+      "id": "urysohns-lemma-oq-01-oq-02",
+      "question": "Establish that the explicit metric Urysohn function is Lipschitz when the two sets are a fixed positive distance apart, quantifying the modulus of separation in terms of that gap.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [],
+  "references": [
+    {
+      "title": "Mathlib4: Topology.UrysohnsLemma",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of exists_continuous_zero_one_of_isClosed and exists_continuous_zero_one_of_isCompact, the abstract Urysohn lemma re-exported in this entry."
+    },
+    {
+      "title": "Paul Urysohn, Über die Mächtigkeit der zusammenhängenden Mengen",
+      "author": "P. Urysohn",
+      "year": "1925",
+      "venue": "Mathematische Annalen",
+      "description": "Origin of Urysohn's lemma, the foundational functional-separation result for normal spaces."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Urysohn's lemma states that in a normal topological space any two disjoint closed sets are separated by a continuous [0,1]-valued function vanishing on one and equal to 1 on the other. This entry re-exports Mathlib's abstract statement (urysohn_normal from exists_continuous_zero_one_of_isClosed) together with the locally compact Hausdorff variant (urysohn_locallyCompact) and the point-from-closed-set consequence in a normal T1 space (urysohn_point_isClosed). It then supplies the content absent from Mathlib: the explicit metric Urysohn function urysohnFn s t x = infDist x s / (infDist x s + infDist x t) for disjoint nonempty closed sets, proved continuous (continuous_urysohnFn, via nowhere-vanishing denominator infDist_add_pos), identically 0 on s (urysohnFn_eq_zero), identically 1 on t (urysohnFn_eq_one), and [0,1]-valued (urysohnFn_mem_Icc), packaged as a bundled separator (urysohn_metric). The abstract lemma is shown to apply to any metric space (urysohn_metric_of_normalSpace), and a concrete evaluation on ℝ is recorded (urysohnFn_half_at_midpoint). 170 lines, 11 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "The abstract separation theorem is delegated to Mathlib; the genuine new content is the closed-form metric witness — the standard infDist construction realising Urysohn separation explicitly and constructively, with full continuity, boundary-value, and range proofs that bypass the abstract Urysohn machinery entirely. This packages the textbook 'distance Urysohn function' in machine-checked form and sets up the Tietze extension theorem and a Lipschitz refinement recorded as open questions.",
+    "openQuestions": [
+      "Derive the Tietze extension theorem from Urysohn's lemma.",
+      "Show the explicit metric Urysohn function is Lipschitz when the sets are a positive distance apart."
+    ]
+  }
+}


### PR DESCRIPTION
## Urysohn's Lemma and the Explicit Metric Urysohn Function

**Urysohn's lemma** is the cornerstone separation theorem of point-set topology: in a normal space any two disjoint closed sets are functionally separated by a continuous real-valued function.

This entry re-exports Mathlib's abstract statement and then supplies the genuine content **absent from Mathlib**: the explicit closed-form Urysohn function on a metric space.

### Part (a) — abstract lemma (re-exports, `mathlib` badge)
- `urysohn_normal` — `exists_continuous_zero_one_of_isClosed` for a `NormalSpace`
- `urysohn_locallyCompact` — the locally-compact-Hausdorff variant (Riesz/partitions of unity)
- `urysohn_point_isClosed` — separating a point from a disjoint closed set in a normal `T1` space

### Part (b) — explicit metric witness (new content)
For disjoint nonempty closed sets `s`, `t` in a metric space:
$$ f(x) = \frac{d(x,s)}{d(x,s) + d(x,t)} $$
built from `Metric.infDist`. Proved:
- `infDist_add_pos` — denominator strictly positive everywhere
- `continuous_urysohnFn` — continuity (quotient with nowhere-vanishing denominator)
- `urysohnFn_eq_zero` / `urysohnFn_eq_one` — boundary values `0` on `s`, `1` on `t`
- `urysohnFn_mem_Icc` — valued in `[0,1]`
- `urysohn_metric` — packaged as a bundled `C(X, ℝ)` separator
- `urysohn_metric_of_normalSpace` — abstract lemma applies to any metric space

### Part (c) — concrete evaluation
- `urysohnFn_half_at_midpoint` — on ℝ, separating `{0}` and `{1}` gives `1/2` at the midpoint

### Verification
- 11 theorems, 1 definition, **0 axioms, 0 sorries**
- Docker build green (`Proofs.UrysohnsLemmaOQ01`, 7743 jobs)
- Badge: `mathlib`; status: `verified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)