### PR TITLE
research(amgm-oq-02-oq-01-oq-03): de-sorry concrete-Finset Newton–Girard k=3 via aeval bridge (char-2 safe)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean
@@ -54,10 +54,10 @@ theorem psum_two_eq :
     psum σ R 2 = esymm σ R 1 ^ 2 - 2 * esymm σ R 2 := by
   have h1 : psum σ R 1 = esymm σ R 1 := psum_one_eq_esymm_one σ R
   rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 2 two_pos]
-  have hfilt : (Finset.antidiagonal 2).filter (fun a : ℕ × ℕ => a.1 ∈ Ioo 0 2) =
+  have hfilt : (Finset.antidiagonal 2).filter (fun a : ℕ × ℕ => a.1 ∈ Set.Ioo 0 2) =
                {(1, 1)} := by
     ext ⟨a, b⟩
-    simp only [Finset.mem_filter, Finset.Nat.mem_antidiagonal, mem_Ioo,
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo,
                Finset.mem_singleton, Prod.mk.injEq]
     omega
   simp only [hfilt, Finset.sum_singleton, h1]
@@ -78,10 +78,10 @@ theorem psum_three_eq :
     psum σ R 3 =
       esymm σ R 1 * psum σ R 2 - esymm σ R 2 * psum σ R 1 + 3 * esymm σ R 3 := by
   rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 3 (by norm_num)]
-  have hfilt : (Finset.antidiagonal 3).filter (fun a : ℕ × ℕ => a.1 ∈ Ioo 0 3) =
+  have hfilt : (Finset.antidiagonal 3).filter (fun a : ℕ × ℕ => a.1 ∈ Set.Ioo 0 3) =
                {(1, 2), (2, 1)} := by
     ext ⟨a, b⟩
-    simp only [Finset.mem_filter, Finset.Nat.mem_antidiagonal, mem_Ioo,
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo,
                Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
     omega
   simp only [hfilt, Finset.sum_insert (by decide : (1, 2) ∉ ({(2, 1)} : Finset (ℕ × ℕ))),

--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ03Finset.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ03Finset.lean
@@ -8,56 +8,50 @@
 
   Lineage:
   • Parent   amgm-inequality-oq-02-oq-01             : k=2 split (∑f)² = ∑f² + Σ_{i≠j} fᵢfⱼ.
-  • Sibling  amgm-inequality-oq-02-oq-01-oq-02-oq-01 : the recurrence p₃ = e₁p₂ − e₂p₁ + 3e₃.
+  • Sibling  amgm-inequality-oq-02-oq-01-oq-02-oq-01 : the recurrence p₃ = e₁p₂ − e₂p₁ + 3e₃,
+                                                       and `psum_two_eq` (p₂ = e₁² − 2e₂).
   • Universal amgm-inequality-oq-02-oq-01-oq-03       : `psum_three_closed` over MvPolynomial,
                                                        valid for every CommRing.
 
   ───────────────────────────────────────────────────────────────────────────
-  KEY FINDING OF THIS FILE — the char-2 obstruction.
+  RESOLUTION — Route B (aeval bridge), fully general over any CommRing.
 
-  The "direct ordered-triple partition" route (Approach 1 / Route A in the OQ) assembles
-  the closed form from three concrete-Finset facts:
+  A previous iteration assembled the closed form from three concrete-Finset facts
       (L2) cube_partition :  e₁³ = p₃ + 3·Doff + 6·e₃
       (L3) D_collapse     :  Doff = e₁·p₂ − p₃
       (L4)+(k=2)          :  p₂ = e₁² − 2·e₂
-  Combining them (see `two_mul_p3_closed`) yields exactly
+  and found that combining them yields only `2·p₃ = 2·(e₁³ − 3e₁e₂ + 3e₃)` (the **char-2
+  obstruction**: over a ring with 2-torsion the factor 2 is a zero-divisor, so Route A
+  closes only when 2 is cancellable).
 
-      2 · p₃ = 2 · (e₁³ − 3·e₁·e₂ + 3·e₃).
+  This file removes that restriction.  The key lemmas `e2_bridge`/`e3_bridge`/`p3_bridge`
+  identify the concrete `powersetCard`/power-sum definitions over a `Finset s` with the
+  evaluation (`MvPolynomial.aeval`) of `MvPolynomial.esymm`/`MvPolynomial.psum` on the
+  subtype `{x // x ∈ s}`.  Transporting the proven universal identities `psum_two_eq` and
+  `psum_three_closed` across that bridge gives `p2_closed` and `p3_closed` over **any**
+  CommRing.  The combinatorial facts L2 (`cube_partition`) and L4 (`two_e2_eq_offPairs`)
+  then follow as algebraic corollaries — char 2 included.
 
-  Over ℤ, ℚ, ℝ this gives p₃ = e₁³ − 3e₁e₂ + 3e₃ after cancelling the 2.  But over a
-  ring with 2-torsion (e.g. 𝔽₂) the factor 2 is a zero-divisor and the identity 2·p₃ =
-  2·(…) collapses to 0 = 0, carrying NO information.  The closed form is still *true* over
-  𝔽₂ (the universal `psum_three_closed` proves it for every CommRing), but it is NOT
-  derivable from L2/L3/L4 alone there.  So Route A's "everything is `ring`" only closes
-  over rings where 2 is cancellable; full generality requires Route B (evaluate the proven
-  universal `psum_three_closed` through `MvPolynomial.aeval`).
-
-  This corrects the earlier ACT skeleton, which asserted the final assembly was "all `ring`
-  once the sums are reconciled" — that is false over char 2.
+  Bridge ingredients (Mathlib):
+    • `MvPolynomial.aeval_esymm_eq_multiset_esymm`, `Finset.esymm_map_val`
+    • `Finset.univ_eq_attach` (rfl), `Finset.attach_val`, `Multiset.attach_map_val'`
+    • `MvPolynomial.aeval_X`, `Finset.sum_coe_sort`, `Finset.powersetCard_one`.
 
   ───────────────────────────────────────────────────────────────────────────
-  STATUS (build-pending; Docker + Aristotle both down this session):
-    • PROVEN over any CommRing:  sq_split (k=2), D_collapse (L3), p2_closed,
-      two_mul_p3_closed (the corrected Route-A reduction).
-    • PROVEN over a CommRing with no zero-divisors and 2 ≠ 0:
-      newton_girard_three_finset (cancel the 2).
-    • Two isolated combinatorial `sorry`s remain — the genuine OQ content:
-        cube_partition       (L2: ordered-triple coincidence partition, multiplicities 1/3/6)
-        two_e2_eq_offPairs   (L4: powersetCard-2 ↔ ordered distinct pairs)
-      Both are HARD-but-known Finset-bookkeeping lemmas — ideal Aristotle targets once the
-      backend is back, or Route B (aeval) supersedes them with one reindexing lemma.
-
+  STATUS: 0 sorries, 0 axioms.  Everything holds over an arbitrary `CommRing`.
   Every numeric fact (multiplicities 1/3/6, D = e₁p₂ − p₃, 2e₂ = off-diag pairs, and the
-  char-2 collapse) is checked exactly in `verify_newton_girard_k3.py`.
+  char-2 collapse) is also checked exactly in `verify_newton_girard_k3.py`.
 
   Tags: algebra, symmetric-functions, newton-girard, power-sums, finset, characteristic-two
 -/
 
 import Mathlib
+import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01
+import Proofs.AmgmInequalityOQ02OQ01OQ03
 
 namespace AMGMInequalityOQ02OQ01OQ03Finset
 
-open Finset BigOperators
+open Finset BigOperators MvPolynomial
 
 variable {ι R : Type*} [CommRing R] [DecidableEq ι]
 
@@ -110,59 +104,120 @@ theorem D_collapse (s : Finset ι) (f : ι → R) :
         rw [← Finset.sum_mul]; ring
 
 -- ============================================================
--- L2 / L4: the two genuine combinatorial bridges (OQ content) — sorry
+-- The aeval bridge:  concrete Finset defs  =  aeval of MvPolynomial symmetric functions
+-- evaluated on the subtype `{x // x ∈ s}`.  This is what carries the universal Newton
+-- identities (char-2 safe) down to the concrete `powersetCard`/power-sum statements.
+-- ============================================================
+
+/-- `aeval` of the universal `psum` on the subtype `{x // x ∈ s}` is the concrete
+    power sum `Σ_{i ∈ s} fᵢⁿ`. -/
+theorem aeval_psum_subtype (s : Finset ι) (f : ι → R) (n : ℕ) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.psum {x // x ∈ s} R n)
+      = ∑ i ∈ s, f i ^ n := by
+  rw [MvPolynomial.psum, map_sum]
+  simp only [map_pow, aeval_X]
+  exact Finset.sum_coe_sort s (fun i => f i ^ n)
+
+/-- `aeval` of the universal `esymm` on the subtype `{x // x ∈ s}` is the concrete
+    `powersetCard`-`n` symmetric sum `Σ_{t ⊆ s, |t| = n} ∏_{i ∈ t} fᵢ`. -/
+theorem aeval_esymm_subtype (s : Finset ι) (f : ι → R) (n : ℕ) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.esymm {x // x ∈ s} R n)
+      = ∑ t ∈ s.powersetCard n, ∏ i ∈ t, f i := by
+  rw [MvPolynomial.aeval_esymm_eq_multiset_esymm, ← Finset.esymm_map_val f s n]
+  congr 1
+  -- `univ.val.map (fun i => f i.1) = s.val.map f`; the `univ`→`attach` steps are `rfl`,
+  -- so `Multiset.attach_map_val'` (which strips the subtype projection) closes it up to defeq.
+  exact Multiset.attach_map_val' s.val f
+
+/-- The `powersetCard`-1 symmetric sum is just `e₁`. -/
+theorem esymm_one_eq_e1 (s : Finset ι) (f : ι → R) :
+    (∑ t ∈ s.powersetCard 1, ∏ i ∈ t, f i) = e1 s f := by
+  rw [Finset.powersetCard_one]
+  simp [e1, Finset.sum_map, Finset.prod_singleton]
+
+/-- Bridge at degree 1:  `aeval (esymm … 1) = e₁`. -/
+theorem e1_bridge (s : Finset ι) (f : ι → R) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.esymm {x // x ∈ s} R 1) = e1 s f :=
+  (aeval_esymm_subtype s f 1).trans (esymm_one_eq_e1 s f)
+
+/-- Bridge at degree 2:  `aeval (esymm … 2) = e₂`  (definitional). -/
+theorem e2_bridge (s : Finset ι) (f : ι → R) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.esymm {x // x ∈ s} R 2) = e2 s f :=
+  aeval_esymm_subtype s f 2
+
+/-- Bridge at degree 3:  `aeval (esymm … 3) = e₃`  (definitional). -/
+theorem e3_bridge (s : Finset ι) (f : ι → R) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.esymm {x // x ∈ s} R 3) = e3 s f :=
+  aeval_esymm_subtype s f 3
+
+/-- Bridge for the second power sum:  `aeval (psum … 2) = p₂`  (definitional). -/
+theorem p2_bridge (s : Finset ι) (f : ι → R) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.psum {x // x ∈ s} R 2) = p2 s f :=
+  aeval_psum_subtype s f 2
+
+/-- Bridge for the third power sum:  `aeval (psum … 3) = p₃`  (definitional). -/
+theorem p3_bridge (s : Finset ι) (f : ι → R) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.psum {x // x ∈ s} R 3) = p3 s f :=
+  aeval_psum_subtype s f 3
+
+-- ============================================================
+-- Closed forms over ANY CommRing, via the bridge (no char-2 restriction)
+-- ============================================================
+
+/-- **p₂ closed form** over any CommRing:  p₂ = e₁² − 2·e₂.
+    Transport of the universal `psum_two_eq` across the aeval bridge. -/
+theorem p2_closed (s : Finset ι) (f : ι → R) :
+    p2 s f = e1 s f ^ 2 - 2 * e2 s f := by
+  have H := congrArg (aeval (fun i : {x // x ∈ s} => f i.1))
+    (AMGMInequalityOQ02OQ01OQ02OQ01.psum_two_eq {x // x ∈ s} R)
+  simpa only [map_sub, map_mul, map_pow, map_ofNat,
+    p2_bridge, e1_bridge, e2_bridge] using H
+
+/-- **p₃ closed form** over any CommRing:  p₃ = e₁³ − 3·e₁·e₂ + 3·e₃.
+    Transport of the universal `psum_three_closed` across the aeval bridge.
+    This is the genuinely general concrete-Finset Newton–Girard k=3 identity. -/
+theorem p3_closed (s : Finset ι) (f : ι → R) :
+    p3 s f = e1 s f ^ 3 - 3 * (e1 s f * e2 s f) + 3 * e3 s f := by
+  have H := congrArg (aeval (fun i : {x // x ∈ s} => f i.1))
+    (AMGMInequalityOQ02OQ01OQ03.psum_three_closed {x // x ∈ s} R)
+  simpa only [map_add, map_sub, map_mul, map_pow, map_ofNat,
+    p3_bridge, e1_bridge, e2_bridge, e3_bridge] using H
+
+-- ============================================================
+-- The two combinatorial bridges (former `sorry`s), now algebraic corollaries
 -- ============================================================
 
 /-- **L4 (powersetCard-2 ↔ ordered pairs).**  2·e₂ = Σᵢ Σ_{j≠i} fᵢfⱼ.
-    Each unordered 2-subset `{i,j}` corresponds to exactly the two ordered pairs `(i,j)`,
-    `(j,i)`, each contributing `fᵢfⱼ`; hence the ordered sum is `2·e₂`.  Verified exactly
-    in `verify_newton_girard_k3.py`.  Lean route: bridge `s.powersetCard 2` to `s.offDiag`
-    via `Sym2`/`Finset.sum_sym2` (no single-lemma shortcut in Mathlib). HARD/known —
-    Aristotle target, or supplant by Route B (aeval). -/
+    Now an algebraic corollary of the k=2 split and the (char-2 safe) `p2_closed`. -/
 theorem two_e2_eq_offPairs (s : Finset ι) (f : ι → R) :
     2 * e2 s f = OffPairs s f := by
-  sorry
+  linear_combination sq_split s f + p2_closed s f
 
 /-- **L2 (cube partition — the crux).**  e₁³ = p₃ + 3·Doff + 6·e₃.
-    Expand `(∑fᵢ)³ = Σᵢ Σⱼ Σₖ fᵢfⱼfₖ` (two `sum_mul_sum`) and partition the index cube
-    `s×s×s` by coincidence pattern:
-        all-equal  (1 ordering)        → p₃,
-        exactly-two-equal (3 orderings) → 3·Doff,
-        all-distinct (6 orderings)      → 6·e₃.
-    Multiplicities 1/3/6 verified exactly in `verify_newton_girard_k3.py`.  This is the
-    reusable combinatorial artifact the OQ is meant to produce. HARD/known — Aristotle
-    target, or supplant by Route B (aeval). -/
+    The reusable ordered-triple coincidence partition (multiplicities 1/3/6), obtained
+    as an algebraic corollary of `p3_closed`, `D_collapse` and `p2_closed`.  Holds over
+    any CommRing (char 2 included) because no factor of 2 is cancelled. -/
 theorem cube_partition (s : Finset ι) (f : ι → R) :
     e1 s f ^ 3 = p3 s f + 3 * Doff s f + 6 * e3 s f := by
-  sorry
+  linear_combination 2 * p3_closed s f - 3 * D_collapse s f - 3 * e1 s f * p2_closed s f
 
 -- ============================================================
--- Corrected Route-A assembly (proven from L2,L3,L4 over any CommRing)
+-- Route-A reduction (still valid; now with everything proven)
 -- ============================================================
 
-/-- p₂ = e₁² − 2·e₂, from the k=2 split and L4. -/
-theorem p2_closed (s : Finset ι) (f : ι → R) :
-    p2 s f = e1 s f ^ 2 - 2 * e2 s f := by
-  have h2 := sq_split s f
-  have h4 := two_e2_eq_offPairs s f
-  linear_combination h4 - h2
-
-/-- **The honest Route-A output:** `2·p₃ = 2·(e₁³ − 3e₁e₂ + 3e₃)`.
-    Valid over ANY CommRing — but note the factor 2 does NOT cancel in char 2.
-    Coefficients (derived, sympy-checked):  `cube_partition + 3·D_collapse + 3·e₁·p2_closed`. -/
+/-- The Route-A reduction `2·p₃ = 2·(e₁³ − 3e₁e₂ + 3e₃)`, valid over any CommRing.
+    (Historically this was as far as the direct ordered-triple partition could go without
+    a cancellable 2; it is now subsumed by the general `p3_closed`.) -/
 theorem two_mul_p3_closed (s : Finset ι) (f : ι → R) :
     2 * p3 s f = 2 * (e1 s f ^ 3 - 3 * (e1 s f * e2 s f) + 3 * e3 s f) := by
-  have hc := cube_partition s f
-  have hd := D_collapse s f
-  have hp := p2_closed s f
-  linear_combination hc + 3 * hd + 3 * e1 s f * hp
+  linear_combination cube_partition s f + 3 * D_collapse s f + 3 * e1 s f * p2_closed s f
 
-/-- **Concrete general-Finset Newton–Girard k=3** over a CommRing where 2 is cancellable
-    (no zero-divisors and `2 ≠ 0`):  p₃ = e₁³ − 3·e₁·e₂ + 3·e₃.
-    The char-2 hypothesis is essential — see the file header. -/
-theorem newton_girard_three_finset [NoZeroDivisors R] (h2 : (2 : R) ≠ 0)
-    (s : Finset ι) (f : ι → R) :
+/-- **Concrete general-Finset Newton–Girard k=3** over an arbitrary `CommRing`:
+      p₃ = e₁³ − 3·e₁·e₂ + 3·e₃.
+    No characteristic hypothesis is needed — the char-2 obstruction of the direct
+    Route-A assembly is bypassed by the `aeval` transport (`p3_closed`). -/
+theorem newton_girard_three_finset (s : Finset ι) (f : ι → R) :
     p3 s f = e1 s f ^ 3 - 3 * (e1 s f * e2 s f) + 3 * e3 s f :=
-  mul_left_cancel₀ h2 (two_mul_p3_closed s f)
+  p3_closed s f
 
 end AMGMInequalityOQ02OQ01OQ03Finset

--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ03Finset.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ03Finset.lean
@@ -109,6 +109,7 @@ theorem D_collapse (s : Finset ι) (f : ι → R) :
 -- identities (char-2 safe) down to the concrete `powersetCard`/power-sum statements.
 -- ============================================================
 
+omit [DecidableEq ι] in
 /-- `aeval` of the universal `psum` on the subtype `{x // x ∈ s}` is the concrete
     power sum `Σ_{i ∈ s} fᵢⁿ`. -/
 theorem aeval_psum_subtype (s : Finset ι) (f : ι → R) (n : ℕ) :
@@ -118,6 +119,7 @@ theorem aeval_psum_subtype (s : Finset ι) (f : ι → R) (n : ℕ) :
   simp only [map_pow, aeval_X]
   exact Finset.sum_coe_sort s (fun i => f i ^ n)
 
+omit [DecidableEq ι] in
 /-- `aeval` of the universal `esymm` on the subtype `{x // x ∈ s}` is the concrete
     `powersetCard`-`n` symmetric sum `Σ_{t ⊆ s, |t| = n} ∏_{i ∈ t} fᵢ`. -/
 theorem aeval_esymm_subtype (s : Finset ι) (f : ι → R) (n : ℕ) :
@@ -129,32 +131,38 @@ theorem aeval_esymm_subtype (s : Finset ι) (f : ι → R) (n : ℕ) :
   -- so `Multiset.attach_map_val'` (which strips the subtype projection) closes it up to defeq.
   exact Multiset.attach_map_val' s.val f
 
+omit [DecidableEq ι] in
 /-- The `powersetCard`-1 symmetric sum is just `e₁`. -/
 theorem esymm_one_eq_e1 (s : Finset ι) (f : ι → R) :
     (∑ t ∈ s.powersetCard 1, ∏ i ∈ t, f i) = e1 s f := by
   rw [Finset.powersetCard_one]
   simp [e1, Finset.sum_map, Finset.prod_singleton]
 
+omit [DecidableEq ι] in
 /-- Bridge at degree 1:  `aeval (esymm … 1) = e₁`. -/
 theorem e1_bridge (s : Finset ι) (f : ι → R) :
     aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.esymm {x // x ∈ s} R 1) = e1 s f :=
   (aeval_esymm_subtype s f 1).trans (esymm_one_eq_e1 s f)
 
+omit [DecidableEq ι] in
 /-- Bridge at degree 2:  `aeval (esymm … 2) = e₂`  (definitional). -/
 theorem e2_bridge (s : Finset ι) (f : ι → R) :
     aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.esymm {x // x ∈ s} R 2) = e2 s f :=
   aeval_esymm_subtype s f 2
 
+omit [DecidableEq ι] in
 /-- Bridge at degree 3:  `aeval (esymm … 3) = e₃`  (definitional). -/
 theorem e3_bridge (s : Finset ι) (f : ι → R) :
     aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.esymm {x // x ∈ s} R 3) = e3 s f :=
   aeval_esymm_subtype s f 3
 
+omit [DecidableEq ι] in
 /-- Bridge for the second power sum:  `aeval (psum … 2) = p₂`  (definitional). -/
 theorem p2_bridge (s : Finset ι) (f : ι → R) :
     aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.psum {x // x ∈ s} R 2) = p2 s f :=
   aeval_psum_subtype s f 2
 
+omit [DecidableEq ι] in
 /-- Bridge for the third power sum:  `aeval (psum … 3) = p₃`  (definitional). -/
 theorem p3_bridge (s : Finset ι) (f : ι → R) :
     aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.psum {x // x ∈ s} R 3) = p3 s f :=
@@ -164,6 +172,7 @@ theorem p3_bridge (s : Finset ι) (f : ι → R) :
 -- Closed forms over ANY CommRing, via the bridge (no char-2 restriction)
 -- ============================================================
 
+omit [DecidableEq ι] in
 /-- **p₂ closed form** over any CommRing:  p₂ = e₁² − 2·e₂.
     Transport of the universal `psum_two_eq` across the aeval bridge. -/
 theorem p2_closed (s : Finset ι) (f : ι → R) :
@@ -173,6 +182,7 @@ theorem p2_closed (s : Finset ι) (f : ι → R) :
   simpa only [map_sub, map_mul, map_pow, map_ofNat,
     p2_bridge, e1_bridge, e2_bridge] using H
 
+omit [DecidableEq ι] in
 /-- **p₃ closed form** over any CommRing:  p₃ = e₁³ − 3·e₁·e₂ + 3·e₃.
     Transport of the universal `psum_three_closed` across the aeval bridge.
     This is the genuinely general concrete-Finset Newton–Girard k=3 identity. -/
@@ -212,6 +222,7 @@ theorem two_mul_p3_closed (s : Finset ι) (f : ι → R) :
     2 * p3 s f = 2 * (e1 s f ^ 3 - 3 * (e1 s f * e2 s f) + 3 * e3 s f) := by
   linear_combination cube_partition s f + 3 * D_collapse s f + 3 * e1 s f * p2_closed s f
 
+omit [DecidableEq ι] in
 /-- **Concrete general-Finset Newton–Girard k=3** over an arbitrary `CommRing`:
       p₃ = e₁³ − 3·e₁·e₂ + 3·e₃.
     No characteristic hypothesis is needed — the char-2 obstruction of the direct

--- a/research/problems/amgm-inequality-oq-02-oq-01-oq-03/state.md
+++ b/research/problems/amgm-inequality-oq-02-oq-01-oq-03/state.md
@@ -4,27 +4,32 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-06-15T00:34:09-07:00
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-Concrete general-Finset Route A shipped build-pending (`AmgmInequalityOQ02OQ01OQ03Finset.lean`).
-S2 found the **char-2 obstruction**: L2+L3+L4 only give `2·p₃ = 2·closed`, so Route A needs a
-cancellable 2; Route B (aeval) is required for full general-CommRing generality.
+**Route B implemented — both sorries discharged, char-2 restriction removed.**
+The aeval bridge identifies the concrete `powersetCard`/power-sum definitions over a
+`Finset s` with the evaluation of `MvPolynomial.esymm`/`psum` on the subtype `{x // x ∈ s}`,
+transporting the proven universal `psum_two_eq` and `psum_three_closed` down to concrete
+`p2_closed`/`p3_closed` over ANY CommRing. L2 (`cube_partition`) and L4 (`two_e2_eq_offPairs`)
+are now algebraic corollaries (`linear_combination`).
 
 ## Active Approach
-Route A: `sq_split`/`D_collapse`/`p2_closed`/`two_mul_p3_closed` proven (any CommRing);
-`newton_girard_three_finset` proven over `[NoZeroDivisors]`+`2≠0`. Two combinatorial sorries
-remain (`cube_partition` L2, `two_e2_eq_offPairs` L4). Route B now recommended for generality.
+Route B (aeval transport). Bridge lemmas: `aeval_psum_subtype`, `aeval_esymm_subtype`
+(via `aeval_esymm_eq_multiset_esymm` + `Finset.esymm_map_val` + `Multiset.attach_map_val'`),
+`esymm_one_eq_e1`, and per-degree wrappers `e1_bridge`/`e2_bridge`/`e3_bridge`/`p2_bridge`/
+`p3_bridge`. Downstream: `p2_closed`, `p3_closed` (general), then `two_e2_eq_offPairs`,
+`cube_partition`, `two_mul_p3_closed`, and an unconditional `newton_girard_three_finset`.
 
 ## Attempt Count
-- Total attempts: 2
-- Current approach attempts: 2
-- Approaches tried: 2 (Route A char≠2; Route B pending)
+- Total attempts: 3
+- Current approach attempts: 1 (Route B)
+- Approaches tried: 2 (Route A char≠2; Route B general)
 
 ## Blockers
-Docker build offline + Aristotle 404 (dual blackout, 2026-06-15) — file build-pending,
-unregistered (has 2 sorries). L2/L4 are Aristotle targets when backend returns.
+None at the math level. Build verification via Docker in progress this session
+(Aristotle backend still returns 404). Gallery status held until green build confirms.
 
 ## Next Action
-Build-verify the proven parts; pursue Route B aeval reindexing (supersedes L2+L4, char-2 safe);
-submit L2/L4 to Aristotle when up.
+Confirm green Docker build of `Proofs.AmgmInequalityOQ02OQ01OQ03Finset`; create the gallery
+entry (`src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03/`) as verified; mark completed.

--- a/research/problems/amgm-inequality-oq-02-oq-01-oq-03/state.md
+++ b/research/problems/amgm-inequality-oq-02-oq-01-oq-03/state.md
@@ -1,10 +1,11 @@
 # Research State: amgm-inequality-oq-02-oq-01-oq-03
 
 ## Current State
-**Phase**: ACT
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-06-15T00:34:09-07:00
+**Since**: 2026-06-20
 **Iteration**: 3
+**PR**: #27174 (build green, 7745 jobs, 0 warnings/sorries/axioms)
 
 ## Current Focus
 **Route B implemented — both sorries discharged, char-2 restriction removed.**

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-ng3-header",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 26
+    },
+    "type": "concept",
+    "title": "Newton-Girard k=3: From the Recurrence to the Reduced Closed Form",
+    "content": "The third Newton-Girard identity is the symmetric-function form of the classical sum-of-cubes factorization. The sibling AmgmInequalityOQ02OQ01OQ02OQ01 derives the recurrence form p₃ = e₁p₂ − e₂p₁ + 3e₃ from Mathlib's general MvPolynomial.psum_eq_mul_esymm_sub_sum. This file closes the loop: substituting the proven closed forms p₂ = e₁² − 2e₂ and p₁ = e₁ into that recurrence and ring-normalising yields the fully reduced identity p₃ = e₁³ − 3e₁e₂ + 3e₃, expressed purely in the elementary symmetric polynomials. The companion file then carries this universal statement down to concrete Finsets over any CommRing.",
+    "mathContext": "$p_3 = e_1 p_2 - e_2 p_1 + 3 e_3$ together with $p_2 = e_1^2 - 2e_2$ and $p_1 = e_1$ gives $p_3 = e_1^3 - 3 e_1 e_2 + 3 e_3$. Concretely $a^3+b^3+c^3 = (a+b+c)^3 - 3(a+b+c)(ab+ac+bc) + 3abc$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "elementary symmetric polynomials",
+      "power sums",
+      "Newton-Girard identities",
+      "sum of cubes"
+    ],
+    "prerequisites": [
+      "multivariate polynomials",
+      "symmetric polynomials",
+      "ring theory"
+    ]
+  },
+  {
+    "id": "ann-ng3-universal",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03",
+    "range": {
+      "startLine": 43,
+      "endLine": 59
+    },
+    "type": "proof-technique",
+    "title": "psum_three_closed: Substitute-and-Ring over Any CommRing",
+    "content": "The universal identity is proved in four lines: pull in the recurrence (psum_three_eq) and the two closed forms (psum_two_eq, psum_one_eq_esymm_one) as hypotheses, rewrite the recurrence with them, and close with ring. Because the statement lives in MvPolynomial σ R for an arbitrary [CommRing R] [Fintype σ], the resulting identity is a polynomial identity with integer coefficients and specializes to every concrete finite family of values in any commutative ring by evaluation.",
+    "mathContext": "In $\\text{MvPolynomial}(\\sigma, R)$: rewriting $p_3 = e_1 p_2 - e_2 p_1 + 3 e_3$ via $p_2 = e_1^2 - 2e_2$, $p_1 = e_1$ gives $p_3 = e_1(e_1^2 - 2e_2) - e_2 e_1 + 3 e_3 = e_1^3 - 3 e_1 e_2 + 3 e_3$, closed by `ring`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MvPolynomial",
+      "ring tactic",
+      "base change"
+    ],
+    "prerequisites": [
+      "polynomial identities",
+      "CommRing"
+    ]
+  },
+  {
+    "id": "ann-ng3-cube",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03",
+    "range": {
+      "startLine": 65,
+      "endLine": 78
+    },
+    "type": "concept",
+    "title": "Concrete 3-Variable Instance: The Sum-of-Cubes Factorization",
+    "content": "cube_sum_three records the smallest concrete Finset instance: a³ + b³ + c³ = (a+b+c)³ − 3(a+b+c)(ab+ac+bc) + 3abc over any CommRing, closed by ring. Here e₁ = a+b+c, e₂ = ab+ac+bc, e₃ = abc, p₃ = a³+b³+c³. This is the everyday face of the abstract identity and is exactly the n=3 specialization of psum_three_closed.",
+    "mathContext": "$a^3+b^3+c^3 = (a+b+c)^3 - 3(a+b+c)(ab+ac+bc) + 3abc$; equivalently $a^3+b^3+c^3 - 3abc = (a+b+c)(a^2+b^2+c^2-ab-bc-ca)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sum of cubes",
+      "factorization"
+    ],
+    "prerequisites": [
+      "CommRing"
+    ]
+  },
+  {
+    "id": "ann-ng3-bridge",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 26
+    },
+    "type": "proof-technique",
+    "title": "The aeval Bridge and the Characteristic-2 Obstruction (companion file)",
+    "content": "The companion AmgmInequalityOQ02OQ01OQ03Finset.lean defines e₁, e₂, e₃, p₂, p₃ directly over a Finset via powersetCard, and proves the same closed form over an arbitrary CommRing. The crux is an aeval transport: aeval_esymm_subtype and aeval_psum_subtype identify the concrete powersetCard / power-sum definitions over s with the aeval of MvPolynomial.esymm / MvPolynomial.psum on the membership subtype {x // x ∈ s} (using aeval_esymm_eq_multiset_esymm, Finset.esymm_map_val, and Multiset.attach_map_val'). Transporting the universal psum_three_closed across this bridge gives the concrete closed form WITHOUT any characteristic hypothesis. This matters: the direct ordered-triple coincidence partition only proves 2·p₃ = 2·(e₁³ − 3e₁e₂ + 3e₃), which fails to determine p₃ when 2 is a zero-divisor. The aeval route — operating at the level of polynomial coefficients, before evaluation — avoids the doubled factor, so cube_partition and two_e2_eq_offPairs become algebraic corollaries valid even in characteristic 2.",
+    "mathContext": "Bridge: $\\text{aeval}(f|_s)\\,(\\text{esymm}\\,\\{x \\in s\\}\\,R\\,n) = \\sum_{t \\subseteq s,\\,|t|=n} \\prod_{i \\in t} f_i$ and likewise for psum. Char-2 obstruction: the direct partition gives $e_1^3 = p_3 + 3 D_{\\text{off}} + 6 e_3$ and $D_{\\text{off}} = e_1 p_2 - p_3$, combining to $2 p_3 = 2(e_1^3 - 3 e_1 e_2 + 3 e_3)$; cancelling 2 needs 2 to be a non-zero-divisor.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MvPolynomial.aeval",
+      "powersetCard",
+      "subtype evaluation",
+      "characteristic two",
+      "symmetric function transport"
+    ],
+    "prerequisites": [
+      "MvPolynomial evaluation",
+      "Finset.powersetCard",
+      "multiset symmetric functions"
+    ]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "amgm-inequality-oq-02-oq-01-oq-03",
+  "title": "Newton-Girard k=3 Closed Form over Any CommRing (incl. characteristic 2)",
+  "slug": "amgm-inequality-oq-02-oq-01-oq-03",
+  "description": "Establishes the fully reduced third Newton-Girard identity p₃ = e₁³ − 3·e₁·e₂ + 3·e₃ in two complementary forms: (1) the universal MvPolynomial statement, derived from the recurrence p₃ = e₁p₂ − e₂p₁ + 3e₃ by substituting p₂ = e₁² − 2e₂ and p₁ = e₁; and (2) a concrete general-Finset form over an arbitrary CommRing using the powersetCard / power-sum definitions directly. The concrete form holds even in characteristic 2 — the obstruction of the direct ordered-triple partition (which yields only 2·p₃ = 2·(…)) is bypassed via an aeval transport that pushes the universal identities down onto the subtype {x // x ∈ s}. Specializes to the classical sum-of-cubes factorization a³ + b³ + c³ = (a+b+c)³ − 3(a+b+c)(ab+ac+bc) + 3abc.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ03.lean",
+    "additionalFiles": [
+      "Proofs/AmgmInequalityOQ02OQ01OQ03Finset.lean"
+    ],
+    "tags": [
+      "algebra",
+      "symmetric-functions",
+      "newton-girard",
+      "power-sums",
+      "elementary-symmetric-polynomials",
+      "finset",
+      "characteristic-two",
+      "mv-polynomial"
+    ],
+    "badge": "verified",
+    "mathlibDependencies": [
+      {
+        "theorem": "MvPolynomial.aeval_esymm_eq_multiset_esymm",
+        "description": "aeval of the universal elementary symmetric polynomial equals the multiset elementary symmetric sum of the evaluated variables — the engine of the concrete-Finset bridge.",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      },
+      {
+        "theorem": "Finset.esymm_map_val",
+        "description": "Identifies the multiset elementary symmetric sum over s.val.map f with the powersetCard sum Σ_{t ⊆ s, |t|=n} ∏_{i ∈ t} f i.",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      },
+      {
+        "theorem": "Multiset.attach_map_val'",
+        "description": "Strips the subtype projection: (s.val.attach).map (fun i => f i.1) = s.val.map f, closing the univ→attach steps up to defeq.",
+        "module": "Mathlib.Data.Multiset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "psum_three_closed: universal MvPolynomial identity p₃ = e₁³ − 3·e₁·e₂ + 3·e₃, derived by substituting the closed forms p₂ = e₁² − 2e₂ and p₁ = e₁ into the sibling's recurrence and ring-normalising.",
+      "aeval_psum_subtype / aeval_esymm_subtype: the central bridge lemmas identifying the concrete powersetCard / power-sum definitions over a Finset s with the aeval of MvPolynomial.esymm / MvPolynomial.psum on the subtype {x // x ∈ s}.",
+      "p2_closed / p3_closed: concrete-Finset closed forms over ANY CommRing, obtained by transporting the universal identities across the aeval bridge — no characteristic hypothesis.",
+      "cube_partition (L2) and two_e2_eq_offPairs (L4): the ordered-triple multiplicity partition e₁³ = p₃ + 3·Doff + 6·e₃ and the pair identity 2·e₂ = Σ_{i≠j} fᵢfⱼ, recovered as algebraic corollaries (linear_combination) valid in characteristic 2.",
+      "Diagnosis and resolution of the char-2 obstruction: the direct ordered-triple assembly closes only when 2 is cancellable; the aeval transport removes that restriction."
+    ],
+    "dateAdded": "2026-06-20",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 80,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. The universal identity is a ring-level corollary of the sibling Newton-Girard recurrence (itself backed by Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum). The concrete-Finset companion (AmgmInequalityOQ02OQ01OQ03Finset.lean) adds the aeval bridge and holds over an arbitrary CommRing including characteristic 2.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Newton's identities (Newton-Girard identities) relate the power sums pₖ = Σ xᵢᵏ to the elementary symmetric polynomials eₖ. Girard stated them around 1629 and Newton independently around 1666 (Arithmetica Universalis, 1707). The third identity, p₃ = e₁³ − 3e₁e₂ + 3e₃, is the symmetric-function form of the classical sum-of-cubes factorization a³ + b³ + c³ = (a+b+c)³ − 3(a+b+c)(ab+ac+bc) + 3abc. While the recurrence form p₃ = e₁p₂ − e₂p₁ + 3e₃ follows directly from Mathlib's general Newton-Girard theorem, the fully reduced closed form purely in e₁, e₂, e₃ — and its concrete Finset incarnation valid in every commutative ring, characteristic 2 included — is not present in Mathlib.",
+    "problemStatement": "**Open Question (amgm-inequality-oq-02-oq-01-oq-03)**: Establish the fully reduced k=3 Newton-Girard identity\n\np₃ = e₁³ − 3·e₁·e₂ + 3·e₃\n\nexpressing the third power sum purely in terms of e₁, e₂, e₃, both as the universal MvPolynomial statement and as a concrete identity over a Finset of values in an arbitrary commutative ring.\n\n**Answer**: Proved in both forms. The universal form is a ring-level corollary of the sibling recurrence. The concrete general-Finset form is obtained by an aeval transport that carries the universal identity onto the subtype {x // x ∈ s}, and holds over any CommRing — the characteristic-2 obstruction of the direct combinatorial assembly is bypassed.",
+    "text": "Two files resolve the question. AmgmInequalityOQ02OQ01OQ03.lean proves the universal identity psum_three_closed by substituting the proven closed forms p₂ = e₁² − 2e₂ and p₁ = e₁ into the recurrence p₃ = e₁p₂ − e₂p₁ + 3e₃ and ring-normalising; it also records the explicit 3-variable instance (sum of cubes). AmgmInequalityOQ02OQ01OQ03Finset.lean defines e₁, e₂, e₃, p₂, p₃ directly over a Finset via powersetCard, and proves the same closed form over an arbitrary CommRing by transporting the universal statement across an aeval bridge onto the subtype {x // x ∈ s}.",
+    "proofStrategy": "**Universal form**: psum_three_closed rewrites the recurrence psum_three_eq (p₃ = e₁p₂ − e₂p₁ + 3e₃) using psum_two_eq (p₂ = e₁² − 2e₂) and psum_one_eq_esymm_one (p₁ = e₁), then closes with ring.\n\n**Concrete Finset form (char-2 safe)**: The bridge lemmas aeval_psum_subtype and aeval_esymm_subtype identify the concrete powersetCard / power-sum definitions over a Finset s with aeval of MvPolynomial.psum / MvPolynomial.esymm on the subtype {x // x ∈ s}. aeval_esymm_subtype uses MvPolynomial.aeval_esymm_eq_multiset_esymm, Finset.esymm_map_val, and Multiset.attach_map_val' (the univ→attach steps are rfl). Per-degree wrappers (e1_bridge, e2_bridge, e3_bridge, p2_bridge, p3_bridge) then let p2_closed and p3_closed be obtained as congrArg images of the universal psum_two_eq / psum_three_closed under aeval. Finally cube_partition and two_e2_eq_offPairs follow as linear_combination corollaries.\n\n**Why characteristic 2 matters**: The direct ordered-triple coincidence partition combined with the off-diagonal collapse yields only 2·p₃ = 2·(e₁³ − 3e₁e₂ + 3e₃). When 2 is a zero-divisor this does not determine p₃. The aeval transport sidesteps the doubled factor entirely, so the closed form holds even when 2 = 0.",
+    "keyInsights": [
+      "The fully reduced closed form p₃ = e₁³ − 3e₁e₂ + 3e₃ is one ring step away from Mathlib's recurrence once the k=1 and k=2 closed forms are substituted.",
+      "Concrete powersetCard / power-sum definitions over a Finset s are the aeval images of the universal MvPolynomial.esymm / MvPolynomial.psum evaluated on the subtype {x // x ∈ s}; this aeval bridge is the clean way to specialize universal symmetric-function identities to concrete finite families.",
+      "The char-2 obstruction is real: the direct ordered-triple partition only proves 2·p₃ = 2·(closed form). Cancelling the 2 requires 2 to be a non-zero-divisor, so the direct route fails over rings with 2-torsion.",
+      "Transporting the universal identity (which lives at the level of polynomial coefficients, before any evaluation) avoids the doubled factor and yields the identity unconditionally — the combinatorial facts cube_partition and two_e2_eq_offPairs then drop out as algebraic corollaries even in characteristic 2.",
+      "Multiset.attach_map_val' is the lemma that strips the subtype projection so that univ.val.map (fun i => f i.1) reduces to s.val.map f, making the bridge a defeq-level identification."
+    ],
+    "prerequisites": [
+      "Sibling AmgmInequalityOQ02OQ01OQ02OQ01: the recurrence p₃ = e₁p₂ − e₂p₁ + 3e₃ and the closed forms p₂ = e₁² − 2e₂, p₁ = e₁.",
+      "MvPolynomial.aeval_esymm_eq_multiset_esymm and Finset.esymm_map_val — elementary symmetric polynomial evaluation (Mathlib).",
+      "MvPolynomial.psum and MvPolynomial.esymm — universal power sums and elementary symmetric polynomials (Mathlib).",
+      "Finset.powersetCard — fixed-cardinality subsets, the concrete definition of eₖ (Mathlib)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Module Docstring: Newton-Girard k=3 Closed Form",
+      "startLine": 1,
+      "endLine": 26,
+      "summary": "States the target identity p₃ = e₁³ − 3e₁e₂ + 3e₃, its lineage from the k=2 identity and the recurrence sibling, and the proof status (PROVED, 0 sorries, 0 axioms).",
+      "mathContext": "$p_3 = e_1^3 - 3 e_1 e_2 + 3 e_3$; concretely $a^3+b^3+c^3 = (a+b+c)^3 - 3(a+b+c)(ab+ac+bc) + 3abc$."
+    },
+    {
+      "id": "universal",
+      "title": "Universal Closed Form (MvPolynomial)",
+      "startLine": 39,
+      "endLine": 59,
+      "summary": "psum_three_closed: substitutes p₂ = e₁² − 2e₂ and p₁ = e₁ into the recurrence p₃ = e₁p₂ − e₂p₁ + 3e₃, then closes with ring. Holds over any CommRing with a Fintype index.",
+      "mathContext": "In MvPolynomial σ R: $p_3 = e_1^3 - 3(e_1 e_2) + 3 e_3$."
+    },
+    {
+      "id": "concrete",
+      "title": "Concrete 3-Variable Instance (Sum of Cubes)",
+      "startLine": 65,
+      "endLine": 78,
+      "summary": "cube_sum_three: the classical factorization a³+b³+c³ = (a+b+c)³ − 3(a+b+c)(ab+ac+bc) + 3abc over any CommRing, closed by ring — the smallest concrete Finset instance.",
+      "mathContext": "$a^3+b^3+c^3 = (a+b+c)^3 - 3(a+b+c)(ab+ac+bc) + 3abc$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Resolves the open question in both the universal MvPolynomial setting and the concrete general-Finset setting. The universal identity p₃ = e₁³ − 3e₁e₂ + 3e₃ is a ring corollary of the sibling recurrence; the concrete Finset companion proves the same identity over an arbitrary CommRing (characteristic 2 included) via an aeval transport onto the subtype {x // x ∈ s}. Both files are machine-verified with 0 sorries and 0 axioms.",
+    "implications": "**For symmetric function theory**: completes the reduced k=3 Newton-Girard identity to a form purely in e₁, e₂, e₃, the building block for expressing higher power sums.\n\n**For formalization technique**: the aeval bridge (concrete powersetCard / power-sum defs = aeval of universal MvPolynomial symmetric functions on the membership subtype) is a reusable pattern for transporting any universal symmetric-function identity to concrete finite families without re-deriving the combinatorics, and it is robust to characteristic 2.",
+    "openQuestions": [
+      "Generalize the aeval bridge to arbitrary degree k: prove pₖ (powersetCard form) = aeval (psum {x // x ∈ s} R k) and use it to transport the full Newton-Girard recurrence to concrete Finsets uniformly, eliminating per-degree wrappers.",
+      "Formalize the dual statement for complete homogeneous symmetric polynomials hₖ over a Finset via the same transport, using the positive-sign recurrence k·hₖ = Σ_{j=1}^k hₖ₋ⱼ·pⱼ."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "Provides the recurrence p₃ = e₁p₂ − e₂p₁ + 3e₃ and the closed forms p₂ = e₁² − 2e₂, p₁ = e₁ that this entry substitutes to reach the fully reduced k=3 identity."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "The k=2 identity p₂ = e₁² − 2e₂ (concrete Finset pair partition); this entry is its k=3 analogue, and the concrete companion reuses the same diagonal/off-diagonal split (sq_split)."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "extends",
+      "description": "Root AM-GM formalization; the Newton-Girard closed forms are part of the symmetric-function framework underlying AM-GM."
+    },
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "related",
+      "description": "The e₁, e₂, e₃ appearing here are exactly Vieta's elementary symmetric polynomials in the roots; the identity expresses the third power sum of roots via coefficients."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Girard, Albert",
+      "title": "Invention nouvelle en l'algèbre",
+      "year": "1629",
+      "venue": "Amsterdam: Guillaume Iansson Blaeuw",
+      "note": "Earliest known statement of the identities relating power sums to elementary symmetric polynomials."
+    },
+    {
+      "authors": "Newton, Isaac",
+      "title": "Arithmetica Universalis",
+      "year": "1707",
+      "venue": "Cambridge (manuscript ~1666)",
+      "note": "Newton's independent treatment of the power-sum / elementary-symmetric identities."
+    },
+    {
+      "authors": "Macdonald, I. G.",
+      "title": "Symmetric Functions and Hall Polynomials",
+      "year": "1995",
+      "venue": "Oxford University Press, 2nd edition, Chapter I §2",
+      "note": "Canonical reference; the Newton-Girard identities appear as (2.11′)/(2.11″)."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AmgmInequalityOQ02OQ01OQ03.lean",
+    "lineCount": 80,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "axiomCount": 0,
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/AmgmInequalityOQ02OQ01OQ03Finset.lean"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

De-sorries the **concrete general-Finset Newton–Girard k=3 identity** over an arbitrary `CommRing` (characteristic 2 included):

$$p_3 = e_1^3 - 3\,e_1 e_2 + 3\,e_3$$

where `e₁,e₂,e₃` are the concrete `powersetCard` elementary-symmetric sums and `p₂,p₃` the power sums over a `Finset`.

### The technique: an `aeval` bridge

The direct ordered-triple partition (`cube_partition`: `e₁³ = p₃ + 3·Doff + 6·e₃`) can only reach `2·p₃ = …` without a cancellable factor of 2, so it stalls in characteristic 2. This PR bypasses that obstruction by **transporting the universal MvPolynomial Newton identity** down to the concrete statement via `aeval` on the subtype `{x // x ∈ s}`:

- `aeval_psum_subtype` / `aeval_esymm_subtype`: `aeval` of `MvPolynomial.psum`/`esymm` on the subtype equals the concrete `Finset` power-sum / `powersetCard` symmetric sum.
- `e1_bridge … p3_bridge`: degree-by-degree bridges to the concrete `eₖ`/`pₖ`.
- `p2_closed` / `p3_closed`: transport of the sibling universal identities (`psum_two_eq`, `psum_three_closed`) across the bridge — char-2 safe because no factor of 2 is cancelled.

The former two `sorry`s (`two_e2_eq_offPairs`, `cube_partition`) are now algebraic corollaries via `linear_combination`.

### Files

- `proofs/Proofs/AmgmInequalityOQ02OQ01OQ03Finset.lean` — the aeval bridge + de-sorried theorems (16 theorems, 0 sorries, 0 axioms).
- `proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean` — fixes Mathlib API bit-rot in the imported parent (`Set.Ioo`/`Set.mem_Ioo` disambiguation under `open Set Finset`; `Finset.Nat.mem_antidiagonal` → `Finset.mem_antidiagonal`).
- Gallery integration: `meta.json`, `annotations.json`, `state.md`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02OQ01OQ03Finset` → **Build completed successfully (7745 jobs)**, 0 warnings.
- Parent file builds green independently (7743 jobs).
- **0 sorries, 0 axiom declarations, 0 structure-encoded assumptions.** Only the standard foundational axioms (`propext`/`Classical.choice`/`Quot.sound`). `status: verified`, `badge: verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)