### PR TITLE
audit(binomial-theorem-oq-05): badge verified→mathlib (Mathlib-wrapped headline)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-05/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-05/meta.json
@@ -18,7 +18,7 @@
       "geometric-growth",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -58,7 +58,7 @@
     "axioms": 0,
     "axiomCount": 0,
     "lineCount": 109,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound).",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound). The base inequality (`bernoulli`) and the `aⁿ` form (`bernoulli_pow`) are thin re-exports of Mathlib's `one_add_mul_le_pow` / `one_add_mul_sub_le_pow`; the strict ℕ-power inequality (`bernoulli_strict`, by induction) and the divergence packaging are the original content. Badge `mathlib` reflects the headline result coming via a Mathlib bridge.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
     "definitionCount": 0


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `binomial-theorem-oq-05` (Bernoulli's Inequality)
**Severity**: MEDIUM — Mathlib wrapper presented with `verified` badge
**Finding**: failure-mode-5 ("0 sorries with hidden imports") / Tier B

## Evidence

The titular theorem is a direct one-line re-export of a Mathlib theorem:

```lean
theorem bernoulli {a : ℝ} (ha : -2 ≤ a) (n : ℕ) : 1 + n * a ≤ (1 + a) ^ n :=
  one_add_mul_le_pow ha n            -- BinomialTheoremOQ05.lean:39-40
```

`bernoulli_pow` likewise re-exports `one_add_mul_sub_le_pow`, and
`one_add_pow_tendsto_atTop` wraps `tendsto_pow_atTop_atTop_of_one_lt`.

**meta.json claimed**: `badge: "verified"`
**Reality**: the headline result comes via a Mathlib bridge → Tier B → `badge: "mathlib"`

This was the **only** entry in the `binomial-theorem-oq-*` family with
`badge: verified` despite a Mathlib-wrapped headline; every wrapper sibling
(oq-01, oq-02-oq-01, oq-03, oq-04, …) correctly uses `badge: mathlib`. Same
pattern previously fixed for the Basel ζ-value entries (#27171).

## Fix

- `badge`: `verified` → `mathlib`
- `assumptions`: disclose the Mathlib bridge and note the original content
- `status` unchanged (`verified` — fully machine-checked, 0 assumptions)

Genuine original content is preserved: `bernoulli_strict` (the ℕ-power strict
inequality proved by induction, which Mathlib lacks) remains in
`originalContributions`.

Static checks pass: 0 sorries, 0 axioms, 0 native_decide, 0 True stubs.

---
Discovered during gallery integrity audit.