### PR TITLE
research(egorov-theorem-oq-01): Egorov's theorem — a.e. convergence is almost uniform (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs/EgorovTheorem.lean
+++ b/proofs/Proofs/EgorovTheorem.lean
@@ -1,0 +1,153 @@
+import Mathlib.MeasureTheory.Function.Egorov
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Topology.Order.IntermediateValue
+import Mathlib.Tactic
+
+/-
+# Egorov's Theorem: a.e. Convergence is "Almost" Uniform Convergence
+
+## What This Proves
+
+**Egorov's theorem** (Egorov 1911, Severini 1910) is a cornerstone of real
+analysis bridging two notions of convergence. On a set `s` of *finite* measure,
+if a sequence of (strongly) measurable functions `fₙ → g` almost everywhere,
+then for every `ε > 0` there is a measurable subset `t ⊆ s` with `μ t ≤ ε` on
+which we may *throw away*, so that `fₙ → g` **uniformly** on `s \ t`. In other
+words, almost-everywhere convergence is uniform convergence off an arbitrarily
+small set.
+
+The general theorem is `MeasureTheory.tendstoUniformlyOn_of_ae_tendsto` in
+Mathlib; we restate it cleanly for the sequential (`ℕ`-indexed) case as
+`egorov_uniform_off_small_set`.
+
+The mathematical substance of this file is the **canonical worked example** that
+makes Egorov's theorem vivid, together with the matching **sharpness** result:
+
+* `pow_ae_tendsto_zero_on_Icc` — the sequence `fₙ(x) = xⁿ` on `[0,1]` converges
+  to `0` Lebesgue-almost-everywhere (the only exceptional point is `x = 1`).
+
+* `pow_egorov_on_Icc` — Egorov applied to `xⁿ` on `[0,1]`: for every `ε > 0`
+  there is a measurable `t ⊆ [0,1]` of measure `≤ ε` with `xⁿ → 0` uniformly on
+  `[0,1] \ t`.
+
+* `pow_not_tendstoUniformlyOn_Ico` — **necessity of removing a set**: `xⁿ` does
+  *not* converge uniformly to `0` on the half-open interval `[0,1)`, even though
+  it converges there *everywhere* pointwise. This is exactly the phenomenon
+  Egorov tames: the convergence is genuinely non-uniform, and no countable
+  amount of pointwise control prevents `supₓ xⁿ = 1` for every `n`.
+
+Together these show Egorov's theorem is not vacuous on this example: uniform
+convergence on the whole interval fails, but uniform convergence off a small
+set holds.
+
+## Why It Is Not in Mathlib
+
+Mathlib contains the abstract theorem but no formalized instance demonstrating
+its non-vacuity, and no statement that `xⁿ` fails to converge uniformly on
+`[0,1)`. The example, the a.e.-convergence verification, and the non-uniformity
+witness are the new content.
+
+## Axiom Status
+
+Fully verified, 0 sorries, 0 `axiom` declarations, no `native_decide`. Relies
+only on Mathlib's measure theory and the foundational axioms `propext`,
+`Classical.choice`, `Quot.sound`.
+-/
+
+open MeasureTheory Filter Set Topology
+open scoped ENNReal
+
+namespace EgorovTheorem
+
+/-! ## The general theorem (sequential form) -/
+
+/-- **Egorov's theorem**, stated for sequences (`ℕ`-indexed). If `fₙ → g`
+almost everywhere on a measurable set `s` of finite measure, then for every
+`ε > 0` there is a measurable `t ⊆ s` with `μ t ≤ ε` such that `fₙ → g`
+uniformly on `s \ t`. This is `MeasureTheory.tendstoUniformlyOn_of_ae_tendsto`
+specialized to the index type `ℕ`. -/
+theorem egorov_uniform_off_small_set
+    {α β : Type*} [MeasurableSpace α] {μ : Measure α} [PseudoEMetricSpace β]
+    {f : ℕ → α → β} {g : α → β} {s : Set α}
+    (hf : ∀ n, StronglyMeasurable (f n)) (hg : StronglyMeasurable g)
+    (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
+    (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x)))
+    {ε : ℝ} (hε : 0 < ε) :
+    ∃ t ⊆ s, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧
+      TendstoUniformlyOn f g atTop (s \ t) :=
+  tendstoUniformlyOn_of_ae_tendsto hf hg hsm hs hfg hε
+
+/-! ## The canonical example: `xⁿ` on the unit interval -/
+
+/-- The sequence `xⁿ` converges to `0` Lebesgue-almost-everywhere on `[0,1]`:
+the only point of `[0,1]` at which it fails to tend to `0` is `x = 1`, a null
+set. -/
+theorem pow_ae_tendsto_zero_on_Icc :
+    ∀ᵐ x ∂(volume : Measure ℝ), x ∈ Set.Icc (0 : ℝ) 1 →
+      Tendsto (fun n : ℕ => x ^ n) atTop (𝓝 0) := by
+  rw [ae_iff]
+  refine measure_mono_null (t := ({1} : Set ℝ)) ?_ Real.volume_singleton
+  intro x hx
+  rw [mem_setOf_eq, _root_.not_imp] at hx
+  obtain ⟨hmem, hlim⟩ := hx
+  rw [mem_Icc] at hmem
+  rw [mem_singleton_iff]
+  by_contra hne
+  exact hlim (tendsto_pow_atTop_nhds_zero_of_lt_one hmem.1 (lt_of_le_of_ne hmem.2 hne))
+
+/-- **Egorov's theorem applied to `xⁿ` on `[0,1]`.** For every `ε > 0` there is
+a measurable set `t ⊆ [0,1]` with Lebesgue measure `≤ ε` such that `xⁿ → 0`
+uniformly on `[0,1] \ t`. -/
+theorem pow_egorov_on_Icc {ε : ℝ} (hε : 0 < ε) :
+    ∃ t ⊆ Set.Icc (0 : ℝ) 1, MeasurableSet t ∧ volume t ≤ ENNReal.ofReal ε ∧
+      TendstoUniformlyOn (fun n x => x ^ n) (fun _ => 0) atTop (Set.Icc 0 1 \ t) := by
+  apply tendstoUniformlyOn_of_ae_tendsto
+  · exact fun n => (continuous_pow n).stronglyMeasurable
+  · exact stronglyMeasurable_const
+  · exact measurableSet_Icc
+  · rw [Real.volume_Icc]; exact ENNReal.ofReal_ne_top
+  · exact pow_ae_tendsto_zero_on_Icc
+  · exact hε
+
+/-! ## Sharpness: the convergence is genuinely non-uniform -/
+
+/-- For every exponent `N` there is a point `x ∈ [0,1)` with `xᴺ ≥ 1/2`. This is
+the key obstruction to uniform convergence: no matter how large `N` is, `xⁿ`
+stays bounded away from `0` somewhere in `[0,1)`. -/
+theorem exists_pow_ge_half (N : ℕ) : ∃ x ∈ Set.Ico (0 : ℝ) 1, (1 / 2 : ℝ) ≤ x ^ N := by
+  rcases Nat.eq_zero_or_pos N with hN | hN
+  · refine ⟨0, ⟨le_refl 0, by norm_num⟩, ?_⟩
+    rw [hN, pow_zero]; norm_num
+  · have hcont : ContinuousOn (fun x : ℝ => x ^ N) (Set.Icc 0 1) :=
+      (continuous_pow N).continuousOn
+    have himg := intermediate_value_Icc (by norm_num : (0 : ℝ) ≤ 1) hcont
+    have hmem : (1 / 2 : ℝ) ∈ Set.Icc ((0 : ℝ) ^ N) ((1 : ℝ) ^ N) := by
+      rw [zero_pow hN.ne', one_pow, mem_Icc]; norm_num
+    obtain ⟨x, hxmem, hxval⟩ := himg hmem
+    dsimp only at hxval
+    rw [mem_Icc] at hxmem
+    refine ⟨x, ⟨hxmem.1, ?_⟩, le_of_eq hxval.symm⟩
+    rcases hxmem.2.eq_or_lt with h | h
+    · rw [h, one_pow] at hxval; norm_num at hxval
+    · exact h
+
+/-- **Necessity of Egorov's exceptional set.** The sequence `xⁿ` does *not*
+converge uniformly to `0` on `[0,1)`, despite converging to `0` at *every* point
+of `[0,1)`. Thus the small set removed by Egorov's theorem cannot in general be
+omitted: pointwise (indeed everywhere) convergence does not upgrade to uniform
+convergence. -/
+theorem pow_not_tendstoUniformlyOn_Ico :
+    ¬ TendstoUniformlyOn (fun n x => x ^ n) (fun _ => (0 : ℝ)) atTop (Set.Ico (0 : ℝ) 1) := by
+  intro h
+  rw [Metric.tendstoUniformlyOn_iff] at h
+  have key := h (1 / 2) (by norm_num)
+  rw [eventually_atTop] at key
+  obtain ⟨N, hN⟩ := key
+  obtain ⟨x, hx, hxpow⟩ := exists_pow_ge_half N
+  have hlt := hN N (le_refl N) x hx
+  simp only at hlt
+  rw [Real.dist_eq, zero_sub, abs_neg, abs_of_nonneg (pow_nonneg hx.1 N)] at hlt
+  linarith
+
+end EgorovTheorem

--- a/src/data/proofs/egorov-theorem-oq-01/meta.json
+++ b/src/data/proofs/egorov-theorem-oq-01/meta.json
@@ -1,0 +1,127 @@
+{
+  "id": "egorov-theorem-oq-01",
+  "slug": "egorov-theorem-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.MeasureTheory.Function.Egorov",
+      "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
+      "Mathlib.Analysis.SpecificLimits.Basic",
+      "Mathlib.Topology.Order.IntermediateValue",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Filter",
+      "Set",
+      "Topology"
+    ],
+    "namespace": "EgorovTheorem",
+    "lineCount": 153,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/EgorovTheorem.lean",
+    "sorries": 0
+  },
+  "title": "Egorov's Theorem: Almost-Everywhere Convergence is Almost Uniform",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EgorovTheorem.lean",
+    "tags": [
+      "analysis",
+      "measure-theory",
+      "convergence",
+      "uniform-convergence",
+      "real-analysis",
+      "egorov",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 153,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "pow_egorov_on_Icc: the canonical worked instance of Egorov's theorem — for every ε > 0 there is a measurable t ⊆ [0,1] with Lebesgue measure ≤ ε on which xⁿ → 0 uniformly off [0,1] \\ t. Mathlib states the abstract theorem (tendstoUniformlyOn_of_ae_tendsto) but formalizes no instance demonstrating its non-vacuity; this is the assembled application (strong measurability of x ↦ xⁿ, finiteness of vol[0,1] = 1, and the a.e.-convergence hypothesis).",
+      "pow_ae_tendsto_zero_on_Icc: xⁿ → 0 Lebesgue-almost-everywhere on [0,1] — the exceptional set is exactly the single null point x = 1, proved by bounding {x | failure} ⊆ {1} and Real.volume_singleton. This is the precise a.e. hypothesis Egorov consumes.",
+      "pow_not_tendstoUniformlyOn_Ico: the matching SHARPNESS / necessity result — xⁿ does NOT converge uniformly to 0 on the half-open interval [0,1), even though it converges to 0 at every single point of [0,1). This shows Egorov's exceptional set cannot be omitted: everywhere-pointwise convergence does not upgrade to uniform convergence. Not present in Mathlib.",
+      "exists_pow_ge_half: for every exponent N there is a point x ∈ [0,1) with xᴺ ≥ 1/2 (via the intermediate value theorem), the quantitative obstruction driving the non-uniformity.",
+      "egorov_uniform_off_small_set: a clean ℕ-indexed restatement of Mathlib's tendstoUniformlyOn_of_ae_tendsto specialized to sequences, the headline Egorov statement for the gallery."
+    ],
+    "prerequisites": [
+      "MeasureTheory.tendstoUniformlyOn_of_ae_tendsto: Egorov's theorem in Mathlib (a.e. convergence on a finite-measure set ⇒ uniform convergence off an arbitrarily small measurable subset)",
+      "tendsto_pow_atTop_nhds_zero_of_lt_one: rⁿ → 0 for 0 ≤ r < 1",
+      "Metric.tendstoUniformlyOn_iff: the ε-characterization of uniform convergence on a set",
+      "intermediate_value_Icc: the intermediate value theorem on a closed interval",
+      "Real.volume_Icc and Real.volume_singleton: Lebesgue measure of an interval and of a point"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.tendstoUniformlyOn_of_ae_tendsto",
+        "description": "Egorov's theorem: if fₙ → g a.e. on a measurable set s of finite measure, then for every ε > 0 there is a measurable t ⊆ s with μ t ≤ ε and fₙ → g uniformly on s \\ t. The abstract vehicle, re-exported as egorov_uniform_off_small_set and instantiated by pow_egorov_on_Icc.",
+        "module": "Mathlib.MeasureTheory.Function.Egorov"
+      },
+      {
+        "theorem": "tendsto_pow_atTop_nhds_zero_of_lt_one",
+        "description": "For 0 ≤ r < 1, rⁿ → 0 as n → ∞. Supplies the a.e.-pointwise limit underlying pow_ae_tendsto_zero_on_Icc.",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "Metric.tendstoUniformlyOn_iff",
+        "description": "Uniform convergence on a set s is equivalent to: for every ε > 0, eventually dist (f x) (Fₙ x) < ε for all x ∈ s. Used to refute uniform convergence of xⁿ on [0,1).",
+        "module": "Mathlib.Topology.MetricSpace.Pseudo.Basic"
+      },
+      {
+        "theorem": "intermediate_value_Icc",
+        "description": "Intermediate value theorem: a continuous function on [a,b] attains every value between f a and f b. Produces, for each N, a point x ∈ [0,1) with xᴺ = 1/2.",
+        "module": "Mathlib.Topology.Order.IntermediateValue"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "egorov-theorem-oq-01-oq-01",
+      "question": "Formalize the failure of Egorov's theorem on a σ-finite-but-infinite measure space: exhibit a sequence on ℝ with Lebesgue measure (e.g. the marching indicators 1_[n,n+1]) that converges to 0 everywhere pointwise yet admits no measurable set of finite (or arbitrarily small) measure off which the convergence is uniform, proving the finiteness hypothesis μ s ≠ ∞ is essential.",
+      "significance": "high"
+    },
+    {
+      "id": "egorov-theorem-oq-01-oq-02",
+      "question": "Derive Lusin's theorem (every measurable function is continuous off a set of arbitrarily small measure) from Egorov's theorem together with the density of continuous/simple functions, giving the classical Egorov ⇒ Lusin route in formalized form.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "laws-of-large-numbers",
+      "relationship": "related",
+      "description": "The laws-of-large-numbers entry names Egorov's theorem in its related-concepts discussion of modes of convergence (a.e., in-measure, uniform). This entry supplies the formalized theorem and a concrete instance making the a.e.-versus-uniform distinction precise."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: MeasureTheory.Function.Egorov",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of MeasureTheory.tendstoUniformlyOn_of_ae_tendsto and its finite-measure-space variants."
+    },
+    {
+      "title": "Real Analysis: Modern Techniques and Their Applications",
+      "author": "Folland",
+      "year": "1999",
+      "venue": "Wiley",
+      "description": "Standard reference for Egorov's theorem (Thm 2.33), its finite-measure hypothesis, the canonical xⁿ example on [0,1], and the Egorov ⇒ Lusin implication."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Egorov's theorem states that on a finite-measure set, almost-everywhere convergence of (strongly) measurable functions upgrades to uniform convergence off a measurable subset of arbitrarily small measure. The abstract theorem is Mathlib's MeasureTheory.tendstoUniformlyOn_of_ae_tendsto, restated for sequences as egorov_uniform_off_small_set. The entry's substance is the canonical worked example xⁿ on [0,1]: pow_ae_tendsto_zero_on_Icc shows xⁿ → 0 Lebesgue-a.e. (the only exceptional point is the null point x = 1), pow_egorov_on_Icc feeds this into Egorov to extract, for every ε > 0, a measure-≤-ε exceptional set off which the convergence is uniform, and pow_not_tendstoUniformlyOn_Ico proves the matching sharpness statement: xⁿ does NOT converge uniformly on [0,1) despite converging to 0 at every point there — so Egorov's exceptional set is genuinely necessary. 153 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The abstract Egorov theorem is delegated to Mathlib (hence the mathlib badge); the new content is the formalized instance demonstrating its non-vacuity and the explicit non-uniformity witness, neither of which Mathlib records. Together they make the 'a.e. convergence is almost uniform, but not uniform' phenomenon precise and machine-checked on the textbook example.",
+    "openQuestions": [
+      "Formalize the failure of Egorov on σ-finite-but-infinite measure (marching indicators on ℝ), establishing the necessity of μ s ≠ ∞.",
+      "Derive Lusin's theorem from Egorov via density of continuous functions."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes **Egorov's theorem** (Egorov 1911 / Severini 1910) and its canonical
worked example in the gallery. On a finite-measure set, almost-everywhere
convergence of (strongly) measurable functions upgrades to **uniform**
convergence off a measurable subset of arbitrarily small measure.

The abstract theorem is Mathlib's `MeasureTheory.tendstoUniformlyOn_of_ae_tendsto`
(re-exported here as `egorov_uniform_off_small_set`). The new mathematical content
is the instance demonstrating the theorem is non-vacuous, plus the matching
sharpness result — neither of which Mathlib records.

## Theorems (`Proofs/EgorovTheorem.lean`, namespace `EgorovTheorem`)

| Theorem | Statement |
|---|---|
| `egorov_uniform_off_small_set` | Egorov for sequences (`ℕ`-indexed restatement) |
| `pow_ae_tendsto_zero_on_Icc` | `xⁿ → 0` Lebesgue-a.e. on `[0,1]` (only exceptional point `x=1` is null) |
| `pow_egorov_on_Icc` | Egorov applied to `xⁿ`: for every `ε>0`, a measure-`≤ε` set off which `xⁿ → 0` uniformly |
| `exists_pow_ge_half` | IVT obstruction: for every `N`, some `x ∈ [0,1)` has `xᴺ ≥ 1/2` |
| `pow_not_tendstoUniformlyOn_Ico` | **Necessity**: `xⁿ` does *not* converge uniformly on `[0,1)`, despite converging at every point |

Together: uniform convergence on the whole interval **fails**, but uniform
convergence off a small set **holds** — so Egorov's exceptional set is genuinely
necessary.

## Verification

- 5 theorems, **0 sorries, 0 `axiom` declarations, no `native_decide`**
- Docker build green: `./proofs/scripts/docker-build.sh Proofs.EgorovTheorem`
- Foundational axioms only (`propext`, `Classical.choice`, `Quot.sound`)
- Badge: `mathlib` (abstract theorem delegated to Mathlib; example + sharpness are new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)