### PR TITLE
audit(cauchy-schwarz-oq-06): badge original → mathlib (Tier B core via Mathlib)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-06/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-06/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/CauchySchwarzOQ06.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [


### PR DESCRIPTION
## Gallery integrity fix

**Proof**: `cauchy-schwarz-oq-06` — *Cauchy-Schwarz Equality: The Linear-Dependence Characterization*
**Severity**: MEDIUM (Mathlib wrapper badged `original`)

## Problem

The headline equality theorem `norm_inner_eq_norm_mul_iff_not_linearIndependent` obtains its **analytic core** by a direct call to Mathlib's `norm_inner_eq_norm_tfae`:

```lean
have key : ‖⟪x, y⟫_𝕜‖ = ‖x‖ * ‖y‖ ↔ x = 0 ∨ ∃ r : 𝕜, y = r • x :=
  (norm_inner_eq_norm_tfae 𝕜 x y).out 0 2   -- CauchySchwarzOQ06.lean:83
```

The file's own contribution is the **linear-algebra reformulation** of Mathlib's proportionality statement into the unconditional, symmetric `¬ LinearIndependent 𝕜 ![x,y]` form (plus the strict-inequality dual and real specializations). That is genuinely useful but it is **Tier B** — the core argument relies on a Mathlib theorem — so the badge should be `mathlib`, not `original`.

## Evidence

- `mathlibDependencies` already lists `norm_inner_eq_norm_tfae` (the wrapper-detection criterion).
- The description and `originalContributions` already credit Mathlib's `norm_inner_eq_norm_iff`/`norm_inner_eq_norm_tfae`, so there is **no delegation opacity** — only the `badge` field overclaimed.
- Sibling cauchy-schwarz entries whose core results are direct Mathlib calls (oq-02-*, oq-03, oq-07, oq-08) are correctly badged `mathlib`.

## Fix

`badge`: `original` → `mathlib`. `status` remains `verified` (0 sorries, 0 axioms confirmed). No Lean source change.

---
Discovered during gallery integrity audit. The Lean proof is correct and complete; this only aligns the public badge with the Tier B classification.