### PR TITLE
audit(chebyshev-polynomials-oq-01): badge original→mathlib (Tier B wrapper)

### DIFF
--- a/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
@@ -16,7 +16,7 @@
       "trigonometry",
       "classic"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "mathlib_version": "4.26.0",


### PR DESCRIPTION
## Gallery Integrity Issue

**Proof**: chebyshev-polynomials-oq-01 — "Chebyshev polynomials compose: T_{mn} = T_m ∘ T_n…"
**Problem**: Badge `original` overstates a Tier-B result whose core is a direct Mathlib wrapper.

## Evidence

**Lean source** (`Proofs/ChebyshevPolynomialsOQ01.lean`):
- The headline composition law is `theorem T_comp (m n) : T R (m*n) = (T R m).comp (T R n) := T_mul R m n` — a **one-line re-export** of Mathlib's `Polynomial.Chebyshev.T_mul`.
- Every other theorem is a one-line corollary of `T_comp`:
  - `T_comp_comm` (the advertised "headline fact"): `rw [← T_comp, ← T_comp, mul_comm]`
  - identity lemmas: `rw [T_one, comp_X]` etc.
  - `T_comp_assoc'`: `comp_assoc _ _ _`
  - trig forms: `rw [T_real_cos, …]`

The mathematically substantive content (Chebyshev multiplicativity) is **entirely Mathlib's `T_mul`**. The file contributes new *statements* not present in Mathlib (commutativity, the compositional-monoid picture), but no independent proof of the core law.

**meta.json claimed**: `badge: "original"`
**Tier**: B (core argument relies on a Mathlib theorem; file provides bridge/corollaries) → badge should be `mathlib`.

## Fix Applied

`badge: "original"` → `badge: "mathlib"`. Status `verified` retained (0 sorries / 0 axioms, consistent with the Tier-B `verified`+`mathlib` pattern used by sibling inner-product entries). Description and `originalContributions` already credit `T_mul` honestly and were left unchanged.

Consistent with prior badge fixes basel-oq-10/12 (#27171) and cauchy-schwarz-oq-06 (#27178).

---
Discovered during gallery integrity audit.