### PR TITLE
audit(chebyshev-sum-inequality-oq-01): badge original→mathlib (Tier B bridge)

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01/meta.json
@@ -17,7 +17,7 @@
       "analysis"
     ],
     "proofRepoPath": "Proofs/ChebyshevSumMonotoneOQ01.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 100,


### PR DESCRIPTION
## Gallery Integrity Issue

**Proof**: chebyshev-sum-inequality-oq-01
**Problem**: Badge `original` overstates a Tier-B repackaging of Mathlib lemmas via Mathlib order-bridges.

## Evidence

Every theorem in `Proofs/ChebyshevSumMonotoneOQ01.lean` is a one-line application of a Mathlib lemma composed with Mathlib's `Monotone ⇒ Monovary` / `Antitone ⇒ Antivary` bridge:

- `chebyshev_monotone`: `simpa using ((hf.monovary hg).monovaryOn _).sum_mul_sum_le_card_mul_sum`
- `chebyshev_antitone`: via `AntivaryOn.card_mul_sum_le_sum_mul_sum`
- `sq_sum_le`: `simpa using sq_sum_le_card_mul_sum_sq`
- `chebyshev_monotoneOn` / `chebyshev_antitoneOn`: direct `(hf.monovaryOn hg).sum_mul_sum_le_card_mul_sum`
- `chebyshev_mean`: arithmetic rescaling of `chebyshev_monotone`

The core inequality is entirely Mathlib's `MonovaryOn.sum_mul_sum_le_card_mul_sum`. The docstring states the file works "by feeding the Monotone/Antitone ⇒ Monovary/Antivary bridges into the Mathlib lemmas" — i.e. a bridge/repackaging, which is **Tier B**.

**meta.json claimed**: `badge: "original"` → should be `mathlib`.

## Fix Applied

`badge: "original"` → `badge: "mathlib"`. Status `verified` retained (0 sorries / 0 axioms). Description and `originalContributions` already credit Mathlib honestly (they note Mathlib "never states" this *form*) and were left unchanged — the new content is genuinely a new *statement form*, but it is not an independent proof of the core inequality.

Consistent with chebyshev-polynomials-oq-01 (#27179), basel-oq-10/12 (#27171), cauchy-schwarz-oq-06 (#27178).

---
Discovered during gallery integrity audit.