### PR TITLE
research(maschke-theorem-oq-01): complete reducibility of group representations (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs/MaschkeTheoremOQ01.lean
+++ b/proofs/Proofs/MaschkeTheoremOQ01.lean
@@ -1,0 +1,127 @@
+import Mathlib
+
+/-!
+# Maschke's Theorem and complete reducibility of group representations
+
+For a finite group `G` and a field `k` whose characteristic does not divide `|G|`
+(equivalently `(Fintype.card G : k)` is a unit, i.e. `NeZero (Fintype.card G : k)`),
+every representation of `G` over `k` is **completely reducible**: every `k[G]`-submodule
+is a direct summand, every short exact sequence of `k[G]`-modules splits, and the group
+algebra `k[G]` is a semisimple ring.  This is Heinrich Maschke's 1899 theorem, the
+cornerstone of ordinary representation theory and the gateway to character theory and the
+Artin–Wedderburn structure of `k[G]`.
+
+The technical heart is the **averaging projection**.  Given an injective `k[G]`-linear map
+`f`, one first splits it merely `k`-linearly (vector spaces are always semisimple) and then
+averages the splitting over the group, `π ↦ (1/|G|) ∑_{g} g · π · g⁻¹`, to make it
+`k[G]`-equivariant.  This is exactly where the hypothesis `char k ∤ |G|` is used: dividing by
+`|G|` requires `(Fintype.card G : k)` to be invertible.
+
+## What this file packages
+
+* `MaschkeTheorem.card_isUnit` — the classical hypothesis form: `(Fintype.card G : k)` is a
+  unit (the bridge between "`char k ∤ |G|`" and Mathlib's `NeZero` instance).
+* `MaschkeTheorem.splitting` — **the heart**: an injective `k[G]`-linear map admits an
+  equivariant left inverse (the averaging projection).
+* `MaschkeTheorem.exists_isCompl` — **classical Maschke**: every `k[G]`-submodule has a
+  complement.
+* `MaschkeTheorem.exists_complement` — the same, unfolded as `p ⊓ q = ⊥ ∧ p ⊔ q = ⊤`.
+* `MaschkeTheorem.isSemisimpleModule` / `isSemisimpleRing` — every representation is
+  semisimple and `k[G]` is a semisimple ring.
+* `MaschkeTheorem.surjection_splits` — every surjection of `k[G]`-modules splits
+  (projectivity / the lifting form of complete reducibility).
+* `MaschkeTheorem.injection_splits` — every injection of `k[G]`-modules splits (the
+  extension / injective form), recovering `splitting` as a special case.
+* `MaschkeTheorem.quotient_iso_submodule` — every quotient representation is isomorphic to a
+  subrepresentation (a hallmark of complete reducibility).
+
+## Sharpness (the modular case)
+
+The hypothesis `char k ∤ |G|` is essential.  Over `k = 𝔽_p` with `G = ℤ/p`, the regular
+representation `𝔽_p[ℤ/p]` has the augmentation submodule (kernel of `∑ a_g g ↦ ∑ a_g`) with
+**no** complement: the short exact sequence `0 → aug → 𝔽_p[ℤ/p] → 𝔽_p → 0` does not split,
+so complete reducibility fails and `𝔽_p[ℤ/p]` is not semisimple.  This modular boundary is
+recorded here as framing; the formal content below is the non-modular theorem and its
+corollaries.
+
+## References
+
+* Maschke, *Beweis des Satzes, dass diejenigen endlichen linearen Substitutionsgruppen …*,
+  Math. Ann. 50 (1898).
+* Mathlib: `Mathlib/RepresentationTheory/Maschke.lean`,
+  `Mathlib/RingTheory/SimpleModule/Basic.lean`.
+-/
+
+open scoped MonoidAlgebra
+
+namespace MaschkeTheorem
+
+universe u
+
+variable {k : Type u} [Field k] {G : Type u} [Group G] [Fintype G]
+  [NeZero (Fintype.card G : k)]
+variable {V : Type u} [AddCommGroup V] [Module k[G] V]
+variable {W : Type u} [AddCommGroup W] [Module k[G] W]
+
+/-- **Classical hypothesis form.** Over a field, `NeZero (Fintype.card G : k)` says exactly
+that the group order is invertible: `(Fintype.card G : k)` is a unit.  This is the precise
+sense in which "the characteristic of `k` does not divide `|G|`" enters Maschke's theorem —
+it is what lets us divide by `|G|` when averaging over the group. -/
+omit [Group G] in
+theorem card_isUnit : IsUnit (Fintype.card G : k) :=
+  (isUnit_iff_ne_zero).2 (NeZero.ne _)
+
+/-- **The heart of Maschke's theorem — the averaging projection.**
+An injective `k[G]`-linear map `f : V → W` admits a `k[G]`-linear left inverse `g`
+(so `g ∘ f = id`).  Concretely `g` is obtained by taking any `k`-linear splitting and
+averaging it over `G`, which is `k[G]`-equivariant precisely because `(Fintype.card G : k)`
+is invertible. -/
+theorem splitting (f : V →ₗ[k[G]] W) (hf : LinearMap.ker f = ⊥) :
+    ∃ g : W →ₗ[k[G]] V, g.comp f = LinearMap.id :=
+  MonoidAlgebra.exists_leftInverse_of_injective f hf
+
+/-- **Maschke's theorem (classical statement).** Every `k[G]`-submodule of a representation
+`V` is a direct summand: it has a complementary subrepresentation. -/
+theorem exists_isCompl (p : Submodule k[G] V) : ∃ q : Submodule k[G] V, IsCompl p q :=
+  MonoidAlgebra.Submodule.exists_isCompl p
+
+/-- Maschke's theorem unpacked: every subrepresentation `p` has a complement `q` meeting it
+trivially (`p ⊓ q = ⊥`) and spanning everything together (`p ⊔ q = ⊤`).  This is the explicit
+"`V = p ⊕ q` as representations" statement. -/
+theorem exists_complement (p : Submodule k[G] V) :
+    ∃ q : Submodule k[G] V, p ⊓ q = ⊥ ∧ p ⊔ q = ⊤ := by
+  obtain ⟨q, hq⟩ := exists_isCompl p
+  exact ⟨q, hq.inf_eq_bot, hq.sup_eq_top⟩
+
+/-- **Complete reducibility.** Every representation of `G` over `k` (with `char k ∤ |G|`) is a
+semisimple `k[G]`-module: a (possibly infinite) direct sum of irreducible subrepresentations. -/
+theorem isSemisimpleModule : IsSemisimpleModule k[G] V := inferInstance
+
+/-- **The group algebra is semisimple.** `k[G]` is a semisimple ring; combined with
+Artin–Wedderburn this makes it a finite product of matrix algebras over division rings, the
+structural backbone of representation theory. -/
+theorem isSemisimpleRing : IsSemisimpleRing k[G] := inferInstance
+
+/-- **Every short exact sequence splits (lifting form).** Any surjective `k[G]`-linear map
+`f : V → W` admits a `k[G]`-linear section `s` with `f ∘ s = id`.  Equivalently, every
+`k[G]`-module is projective: complete reducibility lets us lift along quotients. -/
+theorem surjection_splits (f : V →ₗ[k[G]] W) (hf : Function.Surjective f) :
+    ∃ s : W →ₗ[k[G]] V, f.comp s = LinearMap.id :=
+  IsSemisimpleModule.lifting_property f hf LinearMap.id
+
+/-- **Every short exact sequence splits (extension form).** Any injective `k[G]`-linear map
+`f : V → W` admits a `k[G]`-linear retraction `r` with `r ∘ f = id`.  This is the injective /
+extension counterpart of `surjection_splits` and re-proves `splitting` through the
+semisimplicity API. -/
+theorem injection_splits (f : V →ₗ[k[G]] W) (hf : Function.Injective f) :
+    ∃ r : W →ₗ[k[G]] V, r.comp f = LinearMap.id :=
+  IsSemisimpleModule.extension_property f hf LinearMap.id
+
+/-- **Quotients are subrepresentations.** For every subrepresentation `N`, the quotient
+`V ⧸ N` is `k[G]`-linearly isomorphic to some subrepresentation of `V`.  In a completely
+reducible module quotients never produce anything new — they are realized inside `V` itself. -/
+theorem quotient_iso_submodule (N : Submodule k[G] V) :
+    ∃ P : Submodule k[G] V, Nonempty (P ≃ₗ[k[G]] V ⧸ N) :=
+  IsSemisimpleModule.exists_submodule_linearEquiv_quotient N
+
+end MaschkeTheorem

--- a/src/data/proofs/maschke-theorem-oq-01/meta.json
+++ b/src/data/proofs/maschke-theorem-oq-01/meta.json
@@ -1,0 +1,122 @@
+{
+  "id": "maschke-theorem-oq-01",
+  "slug": "maschke-theorem-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MonoidAlgebra"
+    ],
+    "namespace": "MaschkeTheorem",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/MaschkeTheoremOQ01.lean",
+    "sorries": 0
+  },
+  "title": "Maschke's Theorem and Complete Reducibility of Group Representations",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MaschkeTheoremOQ01.lean",
+    "tags": [
+      "algebra",
+      "representation-theory",
+      "group-algebra",
+      "maschke",
+      "semisimple",
+      "complete-reducibility",
+      "module-theory",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 127,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "splitting: the technical heart of Maschke — an injective k[G]-linear map admits a k[G]-equivariant left inverse, realised by the averaging projection (1/|G|)∑_g g·π·g⁻¹ (exposed from MonoidAlgebra.exists_leftInverse_of_injective, where the hypothesis NeZero (card G : k) is exactly what makes division by |G| legitimate)",
+      "card_isUnit: the bridge between the classical hypothesis 'char k ∤ |G|' and Mathlib's NeZero instance — over a field, NeZero (Fintype.card G : k) is equivalent to (Fintype.card G : k) being a unit",
+      "exists_isCompl / exists_complement: classical Maschke — every k[G]-submodule of a representation is a direct summand, both as IsCompl and unfolded as the explicit p ⊓ q = ⊥ ∧ p ⊔ q = ⊤ decomposition V = p ⊕ q",
+      "isSemisimpleModule / isSemisimpleRing: every representation is a semisimple k[G]-module and the group algebra k[G] is a semisimple ring (the Artin–Wedderburn setup)",
+      "surjection_splits: the projectivity/lifting form of complete reducibility — every surjective k[G]-linear map admits a section (every short exact sequence of representations splits), derived from IsSemisimpleModule.lifting_property",
+      "injection_splits: the dual extension/injective form — every injective k[G]-linear map admits a retraction, derived from IsSemisimpleModule.extension_property, recovering splitting through the semisimplicity API",
+      "quotient_iso_submodule: a hallmark of complete reducibility — every quotient representation V ⧸ N is k[G]-linearly isomorphic to a subrepresentation of V"
+    ],
+    "prerequisites": [
+      "MonoidAlgebra.exists_leftInverse_of_injective: the averaging-projection splitting of an injective k[G]-map under [Field k] [Group G] [Fintype G] [NeZero (Fintype.card G : k)]",
+      "MonoidAlgebra.Submodule.exists_isCompl and the derived IsSemisimpleModule k[G] V instance",
+      "IsSemisimpleModule.lifting_property / extension_property / exists_submodule_linearEquiv_quotient: the splitting and quotient API of semisimple modules",
+      "isUnit_iff_ne_zero: in a field, a nonzero element is a unit"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "MonoidAlgebra.exists_leftInverse_of_injective",
+        "description": "An injective k[G]-linear map admits a k[G]-linear left inverse via the equivariant averaging projection; the engine of Maschke's theorem and the only place the order-invertibility hypothesis is consumed.",
+        "module": "Mathlib.RepresentationTheory.Maschke"
+      },
+      {
+        "theorem": "MonoidAlgebra.Submodule.exists_isCompl",
+        "description": "Every k[G]-submodule has a complement, and the resulting IsSemisimpleModule k[G] V instance; the classical statement of Maschke's theorem.",
+        "module": "Mathlib.RepresentationTheory.Maschke"
+      },
+      {
+        "theorem": "IsSemisimpleModule.lifting_property / extension_property",
+        "description": "In a semisimple module every surjection has a section and every injection has a retraction; supplies the two splitting forms of short exact sequences.",
+        "module": "Mathlib.RingTheory.SimpleModule.Basic"
+      },
+      {
+        "theorem": "IsSemisimpleModule.exists_submodule_linearEquiv_quotient",
+        "description": "Every quotient of a semisimple module is isomorphic to a submodule; gives quotient_iso_submodule.",
+        "module": "Mathlib.RingTheory.SimpleModule.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "maschke-theorem-oq-01-oq-01",
+      "question": "Formalize the sharpness of the hypothesis: exhibit the regular representation 𝔽_p[ℤ/p] whose augmentation submodule has no complement, proving that complete reducibility (and semisimplicity of k[G]) genuinely fails in the modular case char k ∣ |G|.",
+      "significance": "medium"
+    },
+    {
+      "id": "maschke-theorem-oq-01-oq-02",
+      "question": "Derive the character-theoretic consequences over an algebraically closed field of characteristic 0: the number of irreducible representations equals the number of conjugacy classes, and ∑ (dim Vᵢ)² = |G|, via the Artin–Wedderburn decomposition of the semisimple ring k[G].",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "little-wedderburn-oq-01",
+      "relationship": "related",
+      "description": "Maschke's theorem makes k[G] a semisimple ring; Wedderburn's little theorem and the Artin–Wedderburn structure theory then describe such rings as products of matrix algebras over division rings."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: RepresentationTheory.Maschke",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of exists_leftInverse_of_injective (the averaging projection) and Submodule.exists_isCompl."
+    },
+    {
+      "title": "Beweis des Satzes, dass diejenigen endlichen linearen Substitutionsgruppen, in welchen einige durchgehends verschwindende Coefficienten auftreten, intransitiv sind",
+      "author": "Heinrich Maschke",
+      "year": "1899",
+      "venue": "Mathematische Annalen 52 (2): 363–368",
+      "description": "The original theorem that representations of a finite group over a field of characteristic not dividing the group order are completely reducible."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Maschke's theorem is presented for a finite group G over a field k with char k ∤ |G| (encoded as NeZero (Fintype.card G : k), shown equivalent to (Fintype.card G : k) being a unit). The technical heart — an injective k[G]-linear map admits an equivariant left inverse via the averaging projection — is exposed, then leveraged into the classical statement that every k[G]-submodule is a direct summand (both as IsCompl and as the explicit p ⊓ q = ⊥ ∧ p ⊔ q = ⊤), the semisimplicity of every representation and of the ring k[G] itself, the splitting of every short exact sequence in both the surjective (projectivity) and injective (extension) directions, and the fact that every quotient representation is isomorphic to a subrepresentation. 127 lines, 9 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The averaging-projection splitting rests on Mathlib's exists_leftInverse_of_injective (hence the mathlib badge); the assembled content is the packaged Maschke theorem with its complete-reducibility corollaries — direct summands, semisimple ring structure, splitting of short exact sequences in both directions, and the quotient-as-submodule property — none of which sit in the gallery as a dedicated entry. The result is the gateway to character theory and the Artin–Wedderburn structure of k[G], complementing the existing Wedderburn little-theorem entry on finite division rings.",
+    "openQuestions": [
+      "Formalize the modular counterexample 𝔽_p[ℤ/p] showing the char k ∤ |G| hypothesis is essential.",
+      "Derive the character-count and ∑(dim Vᵢ)² = |G| consequences from the Artin–Wedderburn decomposition of k[G]."
+    ]
+  }
+}


### PR DESCRIPTION
## Maschke's Theorem and Complete Reducibility

Packages **Maschke's theorem** for a finite group `G` over a field `k` with `char k ∤ |G|` (encoded as `NeZero (Fintype.card G : k)`), the cornerstone of ordinary representation theory.

### Contents (9 theorems, 0 def, 0 axioms, 0 sorries)

- **`splitting`** — the technical heart: an injective `k[G]`-linear map admits an equivariant left inverse via the averaging projection `(1/|G|)∑_g g·π·g⁻¹` (where `NeZero (card G : k)` is exactly what licenses dividing by `|G|`).
- **`card_isUnit`** — bridges the classical hypothesis "`char k ∤ |G|`" to Mathlib's `NeZero`: over a field, `(Fintype.card G : k)` is a unit.
- **`exists_isCompl` / `exists_complement`** — classical Maschke: every `k[G]`-submodule is a direct summand (`IsCompl`, and unfolded `p ⊓ q = ⊥ ∧ p ⊔ q = ⊤`).
- **`isSemisimpleModule` / `isSemisimpleRing`** — every representation is semisimple and `k[G]` is a semisimple ring (Artin–Wedderburn setup).
- **`surjection_splits` / `injection_splits`** — every short exact sequence of representations splits, in both the projectivity (lifting) and extension directions.
- **`quotient_iso_submodule`** — every quotient representation is isomorphic to a subrepresentation.

The sharpness of the hypothesis (modular failure over `𝔽_p[ℤ/p]`) is documented as framing and recorded as a follow-up open question.

### Verification
- Built clean via Docker wrapper (7743 jobs, 426s).
- Axiom audit: all theorems depend only on `propext`, `Classical.choice`, `Quot.sound` — **0 substantive axioms**, no `native_decide`/`sorry`.
- Badge: `mathlib` (heart rests on `MonoidAlgebra.exists_leftInverse_of_injective`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)