### PR TITLE
research(lucas-lehmer-test-oq-01): Lucas–Lehmer primality test biconditional + worked witnesses

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2864,6 +2864,7 @@ import Proofs.LittleWedderburnOQ01
 import Proofs.LovaszLocalLemma
 import Proofs.LovaszLocalLemmaOQ02
 import Proofs.LovaszLocalLemmaOQ02Aristotle
+import Proofs.LucasLehmerTestOQ01
 import Proofs.MachinFromAddition
 import Proofs.MantelStabilityOQ01
 import Proofs.MantelTheorem

--- a/proofs/Proofs/LucasLehmerTestOQ01.lean
+++ b/proofs/Proofs/LucasLehmerTestOQ01.lean
@@ -1,0 +1,110 @@
+import Mathlib
+
+/-
+# The Lucas–Lehmer primality test for Mersenne numbers
+
+For an odd prime `p`, the Mersenne number `M_p = 2^p - 1` is prime **iff** the
+Lucas–Lehmer residue vanishes:
+
+    s₀ = 4,   s_{i+1} = s_i² − 2,   M_p prime ⟺ s_{p-2} ≡ 0  (mod M_p).
+
+Mathlib supplies the two directions *separately*
+(`lucas_lehmer_sufficiency` : `LucasLehmerTest p → (mersenne p).Prime`, for `1 < p`,
+and `lucas_lehmer_necessity` : `(mersenne p).Prime → LucasLehmerTest p`, for `3 ≤ p`)
+together with a `norm_num` extension that evaluates `LucasLehmerTest p` by kernel
+reduction.  It does **not** package the full biconditional, nor does it record
+worked instances of the test deciding concrete Mersenne numbers.
+
+This file assembles the genuine content the gallery was missing:
+
+* the recurrence `s` spelled out (`s_zero`, `s_succ`) with its first values;
+* the **iff** characterization `mersenne_prime_iff_lucasLehmerTest` (`3 ≤ p`),
+  combining the sufficiency and necessity halves;
+* four prime witnesses decided *through the test* — `M₅ = 31`, `M₇ = 127`,
+  `M₁₃ = 8191`, `M₁₇ = 131071`;
+* a composite witness — the test *fails* for `p = 11`, so `M₁₁ = 2047 = 23·89`
+  is not prime, demonstrating both directions of the criterion.
+
+Everything is decided by kernel reduction (`norm_num`'s `evalLucasLehmerTest`
+uses `rfl` on the tail-recursive residue), so the file is axiom-free in the
+foundational sense — no `native_decide`, hence no `Lean.ofReduceBool`.
+-/
+
+namespace LucasLehmerTestOQ01
+
+open LucasLehmer
+
+/-! ## The Lucas–Lehmer recurrence `sᵢ` -/
+
+/-- The recurrence starts at `s₀ = 4`. -/
+theorem s_zero : LucasLehmer.s 0 = 4 := rfl
+
+/-- The defining recurrence `s_{i+1} = s_i² − 2` (over `ℤ`). -/
+theorem s_succ (i : ℕ) : LucasLehmer.s (i + 1) = LucasLehmer.s i ^ 2 - 2 := rfl
+
+/-- `s₁ = 4² − 2 = 14`. -/
+theorem s_one : LucasLehmer.s 1 = 14 := by norm_num [LucasLehmer.s]
+
+/-- `s₂ = 14² − 2 = 194`. -/
+theorem s_two : LucasLehmer.s 2 = 194 := by norm_num [LucasLehmer.s]
+
+/-- `s₃ = 194² − 2 = 37634`. -/
+theorem s_three : LucasLehmer.s 3 = 37634 := by norm_num [LucasLehmer.s]
+
+/-- By definition the test is the vanishing of the Lucas–Lehmer residue
+`s_{p-2}` taken in `ZMod (2^p − 1)`. -/
+theorem lucasLehmerTest_iff_residue (p : ℕ) :
+    LucasLehmerTest p ↔ lucasLehmerResidue p = 0 := Iff.rfl
+
+/-! ## The biconditional criterion
+
+Mathlib proves the two implications under slightly different hypotheses
+(`1 < p` for sufficiency, `3 ≤ p` for necessity). Bundling them under the
+single hypothesis `3 ≤ p` gives the textbook statement. -/
+
+/-- **Lucas–Lehmer test.** For `3 ≤ p`, the Mersenne number `2^p − 1` is prime
+**iff** the Lucas–Lehmer test passes. -/
+theorem mersenne_prime_iff_lucasLehmerTest (p : ℕ) (hp : 3 ≤ p) :
+    (mersenne p).Prime ↔ LucasLehmerTest p :=
+  ⟨lucas_lehmer_necessity p hp, lucas_lehmer_sufficiency p (by omega)⟩
+
+/-! ## Prime witnesses, decided through the test -/
+
+/-- `M₅ = 2⁵ − 1 = 31` is prime. -/
+theorem mersenne_five_prime : (mersenne 5).Prime := by
+  rw [mersenne_prime_iff_lucasLehmerTest 5 (by norm_num)]
+  norm_num
+
+/-- `M₇ = 2⁷ − 1 = 127` is prime. -/
+theorem mersenne_seven_prime : (mersenne 7).Prime := by
+  rw [mersenne_prime_iff_lucasLehmerTest 7 (by norm_num)]
+  norm_num
+
+/-- `M₁₃ = 2¹³ − 1 = 8191` is prime. -/
+theorem mersenne_thirteen_prime : (mersenne 13).Prime := by
+  rw [mersenne_prime_iff_lucasLehmerTest 13 (by norm_num)]
+  norm_num
+
+/-- `M₁₇ = 2¹⁷ − 1 = 131071` is prime. -/
+theorem mersenne_seventeen_prime : (mersenne 17).Prime := by
+  rw [mersenne_prime_iff_lucasLehmerTest 17 (by norm_num)]
+  norm_num
+
+/-! ## A composite witness: `p = 11`
+
+`p = 11` is prime but `M₁₁ = 2047 = 23 · 89` is not — the Lucas–Lehmer test
+correctly fails, exercising the necessity direction. -/
+
+/-- The test fails at `p = 11`. -/
+theorem lucasLehmerTest_eleven_false : ¬ LucasLehmerTest 11 := by norm_num
+
+/-- Hence `M₁₁ = 2¹¹ − 1` is **not** prime (contrapositive of necessity). -/
+theorem mersenne_eleven_not_prime : ¬ (mersenne 11).Prime := by
+  rw [mersenne_prime_iff_lucasLehmerTest 11 (by norm_num)]
+  exact lucasLehmerTest_eleven_false
+
+/-- The explicit factorization confirming compositeness: `M₁₁ = 2047 = 23 · 89`. -/
+theorem mersenne_eleven_factorization : mersenne 11 = 23 * 89 := by
+  norm_num [mersenne]
+
+end LucasLehmerTestOQ01

--- a/research/problems/lucas-lehmer-test-oq-01/knowledge.md
+++ b/research/problems/lucas-lehmer-test-oq-01/knowledge.md
@@ -1,0 +1,102 @@
+# Knowledge Base: lucas-lehmer-test-oq-01
+
+The Lucas–Lehmer primality test for Mersenne numbers, packaged as a biconditional
+with worked prime and composite witnesses.
+
+---
+
+## Problem Understanding
+
+For `3 ≤ p`, the Mersenne number `M_p = 2^p − 1` is prime **iff** the
+Lucas–Lehmer test passes:
+
+    s₀ = 4,   s_{i+1} = s_i² − 2,   M_p prime ⟺ s_{p-2} ≡ 0 (mod M_p).
+
+Mathlib supplies the two implications separately (`lucas_lehmer_sufficiency`,
+`1 < p`; `lucas_lehmer_necessity`, `3 ≤ p`) plus a `norm_num` extension
+`evalLucasLehmerTest` that decides `LucasLehmerTest p`. It does NOT bundle the
+biconditional nor record worked instances.
+
+---
+
+## Insights
+
+- The deciding `norm_num` extension `evalLucasLehmerTest` works by **kernel
+  reduction** of the tail-recursive residue `sModNatTR` and closes via `rfl`
+  (`testTrueHelper`/`testFalseHelper`). This means it is foundational-axiom-only:
+  NO `native_decide`, hence NO `Lean.ofReduceBool`. The entry is genuinely
+  0-axiom (`propext`/`Classical.choice`/`Quot.sound` only).
+- The Mathlib docstring states the extension proves up to `2^4423 − 1`
+  "nearly instantly", so `M₅, M₇, M₁₃, M₁₇` are trivial for the kernel.
+- The biconditional is assembled under the stronger hypothesis `3 ≤ p`:
+  necessity gives `→` directly, sufficiency gives `←` after `omega` weakens
+  `3 ≤ p` to `1 < p`.
+- A failing test (`p = 11`) certifies compositeness via the SAME biconditional
+  rewritten in the `¬` direction; confirmed by the explicit `M₁₁ = 2047 = 23·89`.
+
+---
+
+## Mathlib Gaps
+
+- Mathlib has both directions and the decision procedure but NOT the packaged
+  biconditional `(mersenne p).Prime ↔ LucasLehmerTest p` and NOT any worked
+  prime/composite witnesses. These are the original content here.
+
+---
+
+## Outcome
+
+COMPLETED — `proofs/Proofs/LucasLehmerTestOQ01.lean`, 11 theorems, 0
+definitions, 0 sorries, 0 axioms (foundational only; no `native_decide`,
+no `Lean.ofReduceBool`). Status verified / badge mathlib (the two implications
+and the decision procedure are Mathlib's; the biconditional packaging + worked
+witnesses are new). Registered in `Proofs.lean`.
+
+Content: recurrence `s_zero`/`s_succ`/`s_one`/`s_two`/`s_three`,
+`lucasLehmerTest_iff_residue`, the keystone
+`mersenne_prime_iff_lucasLehmerTest`, prime witnesses `M₅/M₇/M₁₃/M₁₇`, and the
+composite witness `p = 11` (`lucasLehmerTest_eleven_false`,
+`mersenne_eleven_not_prime`, `mersenne_eleven_factorization`).
+
+---
+
+## Follow-Ups
+
+- Seed-independence: same verdict from `s₀ = 10`; characterize admissible seeds.
+- Connect to the gallery's Euclid–Euler perfect-number characterization (every
+  even perfect number arises from a Mersenne prime certified by this test).
+
+---
+
+## Dead Ends
+
+None — the biconditional assembly and the norm_num witnesses went through
+cleanly on the first structured attempt.
+
+---
+
+## Session 2026-06-20 (Session 1) — FRESH, claim & ship
+
+**Mode**: FRESH
+**Outcome**: completed (pending Docker build confirmation at write time)
+
+### What I Did
+- Claimed `lucas-lehmer-test-oq-01` (atomic lock), branched
+  `research/lucas-lehmer-test-oq-01` off `origin/main`.
+- Inspected `Mathlib/NumberTheory/LucasLehmer.lean`: confirmed
+  `lucas_lehmer_sufficiency`/`necessity` spellings, the `s` recurrence, and that
+  `evalLucasLehmerTest` uses kernel reduction (0-axiom).
+- Wrote `LucasLehmerTestOQ01.lean` (11 theorems), registered in `Proofs.lean`,
+  authored `meta.json` + `annotations.json`.
+
+### Key Findings
+- `evalLucasLehmerTest` is `rfl`-backed kernel reduction → axiom-free; use
+  `norm_num` (NOT `native_decide`).
+- Biconditional needs `3 ≤ p` + `omega` to feed sufficiency's `1 < p`.
+
+### Files Modified
+- `proofs/Proofs/LucasLehmerTestOQ01.lean`, `proofs/Proofs.lean`
+- `src/data/proofs/lucas-lehmer-test-oq-01/{meta,annotations}.json`
+
+### Next Steps
+- On green build: commit, open PR to `main` (no `loom:review-requested`).

--- a/src/data/proofs/lucas-lehmer-test-oq-01/annotations.json
+++ b/src/data/proofs/lucas-lehmer-test-oq-01/annotations.json
@@ -1,0 +1,69 @@
+[
+  {
+    "id": "ann-recurrence",
+    "proofId": "lucas-lehmer-test-oq-01",
+    "range": {
+      "startLine": 40,
+      "endLine": 57
+    },
+    "type": "definition",
+    "title": "The Lucas–Lehmer recurrence sᵢ (s_zero, s_succ, s_one/s_two/s_three, lucasLehmerTest_iff_residue)",
+    "content": "The test inspects the integer sequence s₀ = 4, s_{i+1} = s_i² − 2. s_zero and s_succ expose the two defining clauses (both definitional, closed by rfl), and s_one/s_two/s_three compute the first iterates 14, 194, 37634 by unfolding the recurrence with norm_num. lucasLehmerTest_iff_residue records the definition of the test itself: LucasLehmerTest p holds iff the Lucas–Lehmer residue lucasLehmerResidue p — the iterate s_{p-2} taken in ZMod (2^p − 1) — equals 0. This is the object whose vanishing the whole criterion turns on.",
+    "mathContext": "$s_0 = 4,\\quad s_{i+1} = s_i^2 - 2;\\qquad \\mathrm{LucasLehmerTest}(p) \\iff s_{p-2} \\equiv 0 \\pmod{2^p - 1}.$",
+    "prerequisites": [
+      "The Mathlib definitions LucasLehmer.s, LucasLehmer.lucasLehmerResidue",
+      "Definitional unfolding (rfl) and norm_num for the integer recurrence values"
+    ],
+    "relatedConcepts": [
+      "Lucas sequences",
+      "quadratic recurrence",
+      "residue mod a Mersenne number"
+    ],
+    "significance": "Fixes the concrete arithmetic engine of the test — a single quadratic recurrence whose (p−2)-nd term modulo 2^p − 1 certifies primality of the Mersenne number."
+  },
+  {
+    "id": "ann-biconditional",
+    "proofId": "lucas-lehmer-test-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 69
+    },
+    "type": "theorem",
+    "title": "The Lucas–Lehmer criterion as a biconditional (mersenne_prime_iff_lucasLehmerTest)",
+    "content": "Mathlib proves the two halves of the criterion under different hypotheses: lucas_lehmer_sufficiency (LucasLehmerTest p → (mersenne p).Prime) needs only 1 < p, while lucas_lehmer_necessity ((mersenne p).Prime → LucasLehmerTest p) needs 3 ≤ p. Packaging them under the single hypothesis 3 ≤ p gives the textbook statement (mersenne p).Prime ↔ LucasLehmerTest p: necessity supplies the forward map directly, and sufficiency the backward map after weakening 3 ≤ p to 1 < p by omega. This bundled biconditional is the form actually used to certify the concrete witnesses below and is not stated as such in Mathlib.",
+    "mathContext": "For $3 \\le p$: $\\;(2^p - 1)\\text{ is prime} \\iff \\mathrm{LucasLehmerTest}(p).$",
+    "prerequisites": [
+      "lucas_lehmer_sufficiency (1 < p) and lucas_lehmer_necessity (3 ≤ p)",
+      "omega to weaken 3 ≤ p to 1 < p for the sufficiency direction"
+    ],
+    "relatedConcepts": [
+      "Mersenne primes",
+      "primality criteria",
+      "if-and-only-if packaging"
+    ],
+    "significance": "The keystone of the entry: the deterministic primality criterion for Mersenne numbers in its standard biconditional form, assembled from Mathlib's two one-directional theorems."
+  },
+  {
+    "id": "ann-witnesses",
+    "proofId": "lucas-lehmer-test-oq-01",
+    "range": {
+      "startLine": 71,
+      "endLine": 109
+    },
+    "type": "theorem",
+    "title": "Prime and composite witnesses decided through the test (mersenne_*_prime, lucasLehmerTest_eleven_false, mersenne_eleven_*)",
+    "content": "Each Mersenne prime is certified by rewriting the goal (mersenne p).Prime along mersenne_prime_iff_lucasLehmerTest and then discharging LucasLehmerTest p with norm_num, which fires the evalLucasLehmerTest extension: it computes the residue by kernel reduction of the tail-recursive sModNatTR and closes the goal by rfl (no native_decide, so no Lean.ofReduceBool). This certifies M₅ = 31, M₇ = 127, M₁₃ = 8191, and M₁₇ = 131071. The composite direction is exercised at p = 11: lucasLehmerTest_eleven_false shows the test fails (norm_num), mersenne_eleven_not_prime rewrites along the biconditional to conclude M₁₁ is not prime, and mersenne_eleven_factorization confirms it explicitly with M₁₁ = 2047 = 23·89. The same biconditional thus reads in both directions — passing test ⇒ prime, failing test ⇒ composite.",
+    "mathContext": "$M_5=31,\\;M_7=127,\\;M_{13}=8191,\\;M_{17}=131071$ are prime; $M_{11}=2047=23\\cdot 89$ is not, and the test fails there.",
+    "prerequisites": [
+      "mersenne_prime_iff_lucasLehmerTest for the rewrite in both directions",
+      "The norm_num extension evalLucasLehmerTest deciding LucasLehmerTest p by kernel reduction",
+      "norm_num [mersenne] for the explicit factorization 2¹¹ − 1 = 23·89"
+    ],
+    "relatedConcepts": [
+      "Mersenne primes",
+      "compositeness certificate",
+      "kernel-reduction decision procedure"
+    ],
+    "significance": "Demonstrates the criterion as an effective algorithm: concrete Mersenne numbers are settled — prime and composite alike — purely through the Lucas–Lehmer residue, with verification by kernel reduction keeping the whole development axiom-free."
+  }
+]

--- a/src/data/proofs/lucas-lehmer-test-oq-01/meta.json
+++ b/src/data/proofs/lucas-lehmer-test-oq-01/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "lucas-lehmer-test-oq-01",
+  "slug": "lucas-lehmer-test-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "LucasLehmer"
+    ],
+    "namespace": "LucasLehmerTestOQ01",
+    "lineCount": 110,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/LucasLehmerTestOQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Lucas–Lehmer Primality Test for Mersenne Numbers",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LucasLehmerTestOQ01.lean",
+    "tags": [
+      "number-theory",
+      "primality",
+      "mersenne-primes",
+      "lucas-lehmer",
+      "recurrence",
+      "norm_num",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 110,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "mersenne_prime_iff_lucasLehmerTest: the full biconditional (mersenne p).Prime ↔ LucasLehmerTest p for 3 ≤ p — Mathlib carries the two implications only as separate theorems (lucas_lehmer_sufficiency under 1 < p, lucas_lehmer_necessity under 3 ≤ p); this packages them under one hypothesis as the textbook criterion",
+      "mersenne_five_prime / mersenne_seven_prime / mersenne_thirteen_prime / mersenne_seventeen_prime: four Mersenne primes (M₅ = 31, M₇ = 127, M₁₃ = 8191, M₁₇ = 131071) decided through the Lucas–Lehmer test by rewriting along the biconditional and discharging LucasLehmerTest p with the kernel-reducing norm_num extension",
+      "lucasLehmerTest_eleven_false + mersenne_eleven_not_prime + mersenne_eleven_factorization: a composite witness — the test fails at p = 11, so M₁₁ = 2047 = 23·89 is not prime, exercising the necessity (contrapositive) direction and confirmed by the explicit factorization",
+      "s_zero / s_succ / s_one / s_two / s_three: the Lucas–Lehmer recurrence s₀ = 4, s_{i+1} = s_i² − 2 spelled out with its first computed values, the iterate whose residue mod 2^p − 1 the test inspects",
+      "lucasLehmerTest_iff_residue: the definitional identification of the test with the vanishing of the Lucas–Lehmer residue s_{p-2} in ZMod (2^p − 1)"
+    ],
+    "prerequisites": [
+      "Mathlib's lucas_lehmer_sufficiency: LucasLehmerTest p → (mersenne p).Prime for 1 < p",
+      "Mathlib's lucas_lehmer_necessity: (mersenne p).Prime → LucasLehmerTest p for 3 ≤ p",
+      "The norm_num extension evalLucasLehmerTest, which decides LucasLehmerTest p by kernel reduction of the tail-recursive residue sModNatTR (no native_decide)",
+      "The recurrence LucasLehmer.s and the residue LucasLehmer.lucasLehmerResidue"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "lucas_lehmer_sufficiency",
+        "description": "If the Lucas–Lehmer test passes (and 1 < p) then the Mersenne number 2^p − 1 is prime; the harder, group-order direction of the criterion.",
+        "module": "Mathlib.NumberTheory.LucasLehmer"
+      },
+      {
+        "theorem": "lucas_lehmer_necessity",
+        "description": "If the Mersenne number 2^p − 1 is prime (and 3 ≤ p) then the Lucas–Lehmer test passes; the converse direction.",
+        "module": "Mathlib.NumberTheory.LucasLehmer"
+      },
+      {
+        "theorem": "evalLucasLehmerTest (norm_num extension)",
+        "description": "A norm_num extension that decides LucasLehmerTest p for 1 < p by kernel reduction of the tail-recursive residue function sModNatTR; used to discharge each concrete prime/composite witness while remaining axiom-free.",
+        "module": "Mathlib.NumberTheory.LucasLehmer"
+      },
+      {
+        "theorem": "LucasLehmer.s / LucasLehmer.lucasLehmerResidue",
+        "description": "The integer recurrence s₀ = 4, s_{i+1} = s_i² − 2 and the residue s_{p-2} reduced mod 2^p − 1 that defines the test.",
+        "module": "Mathlib.NumberTheory.LucasLehmer"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "lucas-lehmer-test-oq-01-oq-01",
+      "question": "Formalize the equivalent seed-independence: the Lucas–Lehmer test gives the same verdict using the alternative starting value s₀ = 10 (or any seed of the form ω + ω⁻¹ with ω a unit of norm 1 and trace not ±2 in the relevant ring), and characterize which seeds are admissible.",
+      "significance": "medium"
+    },
+    {
+      "id": "lucas-lehmer-test-oq-01-oq-02",
+      "question": "Establish the density/distribution framing: state and connect the Lenstra–Pomerance–Wagstaff heuristic for the count of Mersenne primes below x to the test, or prove that every even perfect number arises from a Mersenne prime certified by this test (linking to the Euclid–Euler characterization already in the gallery).",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "perfect-numbers",
+      "relationship": "related",
+      "description": "The gallery's perfect-number work formalizes the mersenne definition and the Euclid–Euler characterization of even perfect numbers; this entry is the distinct primality *test* that certifies which Mersenne numbers (and hence which even perfect numbers) actually occur."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: NumberTheory.LucasLehmer",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of lucas_lehmer_sufficiency, lucas_lehmer_necessity, the recurrence s, and the norm_num extension deciding the test."
+    },
+    {
+      "title": "Théorie des nombres (the Lucas sequences and primality of 2^n − 1)",
+      "author": "Édouard Lucas",
+      "year": "1878",
+      "venue": "American Journal of Mathematics 1",
+      "description": "Lucas's original primality criteria for Mersenne numbers via the recurrence, later made rigorous and simplified by Lehmer."
+    },
+    {
+      "title": "An extended theory of Lucas' functions",
+      "author": "Derrick H. Lehmer",
+      "year": "1930",
+      "venue": "Annals of Mathematics 31 (3): 419–448",
+      "description": "Lehmer's rigorous treatment establishing the modern Lucas–Lehmer test in its final form."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The Lucas–Lehmer test is assembled as the full biconditional (mersenne p).Prime ↔ LucasLehmerTest p for 3 ≤ p, combining Mathlib's separately-stated sufficiency and necessity halves under one hypothesis. The recurrence s₀ = 4, s_{i+1} = s_i² − 2 is spelled out with its first values and identified with the vanishing of the residue s_{p-2} mod 2^p − 1. Four Mersenne primes (M₅ = 31, M₇ = 127, M₁₃ = 8191, M₁₇ = 131071) are decided *through the test*, and a composite witness (p = 11, where the test fails so M₁₁ = 2047 = 23·89 is not prime) exercises the converse direction. 110 lines, 11 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The two implications and the deciding norm_num extension are Mathlib's (hence the mathlib badge); the genuine new content is the packaged biconditional criterion plus the worked prime and composite instances, which Mathlib does not record. All witnesses are discharged by the norm_num extension's kernel reduction of the tail-recursive residue, so the entry is axiom-free in the foundational sense — no native_decide and hence no Lean.ofReduceBool. The entry brings the Lucas–Lehmer primality test, distinct from the gallery's perfect-number / Euclid–Euler work, to the collection.",
+    "openQuestions": [
+      "Formalize seed-independence and characterize admissible Lucas–Lehmer starting values.",
+      "Connect the test to the Lenstra–Pomerance–Wagstaff heuristic or to the Euclid–Euler perfect-number characterization."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes the **Lucas–Lehmer primality test** for Mersenne numbers as the textbook biconditional, with worked prime and composite witnesses that Mathlib does not record.

For `3 ≤ p`, the Mersenne number `M_p = 2^p − 1` is prime **iff** the Lucas–Lehmer test passes:

    s₀ = 4,   s_{i+1} = s_i² − 2,   M_p prime ⟺ s_{p−2} ≡ 0 (mod M_p).

Mathlib supplies the two implications *separately* (`lucas_lehmer_sufficiency` under `1 < p`, `lucas_lehmer_necessity` under `3 ≤ p`) plus a `norm_num` extension that decides `LucasLehmerTest p` by kernel reduction. It does **not** bundle the biconditional nor record worked instances.

## Original content

- `mersenne_prime_iff_lucasLehmerTest` — the full iff `(mersenne p).Prime ↔ LucasLehmerTest p` for `3 ≤ p`, combining both halves under one hypothesis
- `s_zero / s_succ / s_one / s_two / s_three` — the recurrence spelled out with first values
- `lucasLehmerTest_iff_residue` — test ⟺ vanishing of the residue `s_{p−2}` in `ZMod (2^p − 1)`
- prime witnesses decided *through the test*: `M₅ = 31`, `M₇ = 127`, `M₁₃ = 8191`, `M₁₇ = 131071`
- composite witness: the test fails at `p = 11`, so `M₁₁ = 2047 = 23·89` is not prime (necessity direction), confirmed by the explicit factorization

## Verification

- **11 theorems, 0 definitions, 0 sorries, 0 axioms**
- All witnesses discharged by the `norm_num` extension's **kernel reduction** of the tail-recursive residue — **no `native_decide`**, hence **no `Lean.ofReduceBool`**. Axiom-free in the foundational sense.
- Status `verified`, badge `mathlib` (the two implications and the decision procedure are Mathlib's; the biconditional packaging and worked witnesses are new).
- Docker build: `✔ [7743/7743] Built Proofs.LucasLehmerTestOQ01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)