### PR TITLE
audit(combinations-formula-oq-06): badge original → mathlib (Tier B core via Mathlib)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -385,9 +385,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-20T17:51:58Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-03": {
@@ -2893,8 +2893,8 @@
       "result": "clean"
     },
     "erdos-1006-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T04:00:46Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-20T17:37:55Z",
       "result": "clean"
     },
     "erdos-1006-oq-02": {
@@ -16110,6 +16110,300 @@
       "auditCount": 1,
       "lastAudited": "2026-06-19T19:47:13Z",
       "result": "clean",
+      "issues": []
+    },
+    "abel-ruffini-oq-07-discriminant": {
+      "auditCount": 28,
+      "lastAudited": "2026-06-20T20:01:41Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abundant-number-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T17:07:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "alternating-series-test-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T17:08:20Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T17:08:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq-05-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T17:14:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T17:14:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-07-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T17:14:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-07-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T17:16:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-07-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T17:16:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-07-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T17:16:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-minpoly-oq-02-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T17:19:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-07-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:04:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "banach-fixed-point-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:05:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-08": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:05:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-09": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:06:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arsinh-log-formula-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:08:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-10": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:11:08Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "basel-problem-oq-11": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:11:41Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-12": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:13:09Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "basel-problem-oq-13": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:13:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-14": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:14:06Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bernoulli-inequality-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:16:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "beta-integral-recurrence-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:17:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:17:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-03-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:18:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:23:53Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "birthday-problem-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:26:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "burnside-counting-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:27:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantor-diagonalization-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:32:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantor-diagonalization-oq-04-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:33:06Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantor-diagonalization-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:33:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantor-diagonalization-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:34:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantor-diagonalization-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:34:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantors-theorem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:35:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "catalan-numbers-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:35:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq-02-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:38:40Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:39:26Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-02-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:39:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:40:26Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:42:59Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:45:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-08": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:46:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-minpoly-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:46:26Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayleys-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:46:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-polynomials-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:49:18Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "chebyshev-sum-inequality-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:51:12Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "chinese-remainder-constructive-oq-04-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:53:19Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T20:54:27Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T21:00:41Z",
+      "result": "issues-fixed",
       "issues": []
     }
   },

--- a/src/data/proofs/combinations-formula-oq-06/meta.json
+++ b/src/data/proofs/combinations-formula-oq-06/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius researcher-4",
     "status": "verified",
     "proofRepoPath": "Proofs/CombinationsFormulaOQ06.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 118,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `combinations-formula-oq-06` — "The Hockey-Stick Identity and the Figurate-Number Tower"
**Issue**: Mathlib wrapper claimed as `original` (Tier B mislabeled as Tier A)
**Severity**: MEDIUM

### Evidence

The headline identity is a direct restatement of a Mathlib theorem:

```lean
theorem hockey_stick_Icc (n k : ℕ) :
    ∑ m ∈ Finset.Icc k n, Nat.choose m k = Nat.choose (n + 1) (k + 1) :=
  Nat.sum_Icc_choose n k
```

The entry's central named result (the hockey-stick identity) is obtained by calling `Nat.sum_Icc_choose` directly — this is the "0 sorries with hidden imports" failure mode. Per Tier B classification, badge must be `mathlib`, not `original`.

The remaining theorems (`hockey_stick_range`, the triangular/tetrahedral specializations, `sum_triangular_eq_tetrahedral`) are genuine short derivations layered on the Mathlib anchor, and the description/`originalContributions` already credit `Nat.sum_Icc_choose` explicitly — so only the badge overclaims.

Contrast: the sibling `combinations-formula-oq-01` proves its `hockey_stick` by hand induction and is legitimately original.

### Fix

`"badge": "original"` → `"badge": "mathlib"`. Status stays `verified` (genuinely 0 sorries, 0 axioms, kernel `decide` only — no `native_decide`/`Lean.ofReduceBool`). Matches precedent: basel oq-10/oq-12 (#27171), cauchy-schwarz-oq-06 (#27178).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)