### PR TITLE
research(erdos-ginzburg-ziv-oq-01): zero-sum theorem + sharpness of the 2n−1 threshold

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2428,6 +2428,7 @@ import Proofs.Erdos99Problem
 import Proofs.Erdos9Problem
 import Proofs.ErdosDivisibilityPigeonhole
 import Proofs.ErdosDivisibilityPigeonholeOQ01
+import Proofs.ErdosGinzburgZivOQ01
 import Proofs.ErdosKoRado
 import Proofs.ErdosMordellChordIdentity
 import Proofs.ErdosMordellChordReduction

--- a/proofs/Proofs/ErdosGinzburgZivOQ01.lean
+++ b/proofs/Proofs/ErdosGinzburgZivOQ01.lean
@@ -1,0 +1,140 @@
+import Mathlib.Combinatorics.Additive.ErdosGinzburgZiv
+import Mathlib.Tactic
+
+/-
+# The Erdős–Ginzburg–Ziv theorem and the sharpness of its threshold
+
+## What This Proves
+
+The **Erdős–Ginzburg–Ziv theorem** (1961) is a cornerstone of additive
+combinatorics: among any `2 * n - 1` integers, some `n` of them have a sum
+divisible by `n`. Equivalently, every sequence of length `2 * n - 1` in
+`ZMod n` has a zero-sum subsequence of length exactly `n`.
+
+Mathlib proves the theorem itself (`Int.erdos_ginzburg_ziv`,
+`ZMod.erdos_ginzburg_ziv`, and the multiset variants) in
+`Mathlib/Combinatorics/Additive/ErdosGinzburgZiv.lean`. This file repackages
+those statements and — the genuinely new content — proves that the threshold
+`2 * n - 1` is **best possible**.
+
+* **Main theorem** (`egz_int`, `egz_zmod`). Any sequence of at least `2 * n - 1`
+  elements of `ℤ` (resp. `ZMod n`) contains an `n`-element subsequence with sum
+  divisible by `n` (resp. equal to `0`). These are the Mathlib headlines,
+  restated as the baseline.
+
+* **Multiset forms** (`egz_int_multiset`, `egz_zmod_multiset`). The same
+  statements for multisets, which is the natural setting for "a sequence with
+  repetitions".
+
+* **Concrete instance** (`egz_three_integers`). The `n = 2` case made explicit:
+  among any three integers, two of them have an even sum. This is the historical
+  toy case (a pigeonhole on parities) read off from the general theorem.
+
+* **Sharpness / optimality** (`egz_sharp`). The threshold `2 * n - 1` cannot be
+  lowered: for every `n ≥ 2` there is a sequence of `2 * n - 2` elements of
+  `ZMod n` with **no** zero-sum subsequence of length `n`. The witness is the
+  classical extremal configuration of `n - 1` zeros and `n - 1` ones — any `n`
+  of them must include between `1` and `n - 1` ones, so their sum is a nonzero
+  residue. Mathlib has no such optimality lemma, so this is the new mathematical
+  contribution here, and together with the main theorem it pins the
+  Erdős–Ginzburg–Ziv constant of `ℤ/nℤ` at exactly `2 * n - 1`.
+
+## Context
+
+EGZ is the rank-one (`n = 2` Davenport / `s(ℤ/n) = 2n - 1`) case of the
+additive-combinatorics theory of zero-sum sequences, and is the gateway result
+of that subject (Erdős, Ginzburg, Ziv, *Bull. Research Council Israel* 1961).
+-/
+
+open Finset
+
+namespace ErdosGinzburgZivOQ01
+
+variable {ι : Type*} {n : ℕ} {s : Finset ι}
+
+/-- **Erdős–Ginzburg–Ziv theorem over `ℤ`.** Any sequence of at least `2 * n - 1`
+integers contains `n` of them whose sum is divisible by `n`. Mathlib headline,
+restated as the baseline. -/
+theorem egz_int (a : ι → ℤ) (hs : 2 * n - 1 ≤ #s) :
+    ∃ t ⊆ s, #t = n ∧ (n : ℤ) ∣ ∑ i ∈ t, a i :=
+  Int.erdos_ginzburg_ziv a hs
+
+/-- **Erdős–Ginzburg–Ziv theorem over `ZMod n`.** Any sequence of at least
+`2 * n - 1` elements of `ZMod n` contains an `n`-element subsequence summing to
+`0`. -/
+theorem egz_zmod (a : ι → ZMod n) (hs : 2 * n - 1 ≤ #s) :
+    ∃ t ⊆ s, #t = n ∧ ∑ i ∈ t, a i = 0 :=
+  ZMod.erdos_ginzburg_ziv a hs
+
+/-- **Multiset form over `ℤ`.** Any multiset of at least `2 * n - 1` integers has
+a length-`n` submultiset whose sum is divisible by `n`. -/
+theorem egz_int_multiset (m : Multiset ℤ) (hs : 2 * n - 1 ≤ Multiset.card m) :
+    ∃ t ≤ m, Multiset.card t = n ∧ (n : ℤ) ∣ t.sum :=
+  Int.erdos_ginzburg_ziv_multiset m hs
+
+/-- **Multiset form over `ZMod n`.** Any multiset of at least `2 * n - 1` elements
+of `ZMod n` has a length-`n` submultiset summing to `0`. -/
+theorem egz_zmod_multiset (m : Multiset (ZMod n)) (hs : 2 * n - 1 ≤ Multiset.card m) :
+    ∃ t ≤ m, Multiset.card t = n ∧ t.sum = 0 :=
+  ZMod.erdos_ginzburg_ziv_multiset m hs
+
+/-- **Concrete `n = 2` instance.** Among any three integers (here, a family
+indexed by any `s` with `3 ≤ #s`), some two of them have an even sum. This is
+the elementary pigeonhole-on-parity case, read off from the general theorem. -/
+theorem egz_three_integers (a : ι → ℤ) (hs : 3 ≤ #s) :
+    ∃ t ⊆ s, #t = 2 ∧ (2 : ℤ) ∣ ∑ i ∈ t, a i := by
+  have hs' : 2 * 2 - 1 ≤ #s := by simpa using hs
+  simpa using Int.erdos_ginzburg_ziv (n := 2) a hs'
+
+/-- **Sharpness of the threshold.** For every `n ≥ 2`, there is a sequence of
+exactly `2 * n - 2` elements of `ZMod n` with *no* zero-sum subsequence of length
+`n`. Hence the Erdős–Ginzburg–Ziv bound `2 * n - 1` is best possible.
+
+The witness is the extremal configuration of `n - 1` zeros and `n - 1` ones:
+`s = range (2 * n - 2)` with `a i = 1` for `i ≥ n - 1` and `a i = 0` otherwise.
+Any `n`-element subset `t` must contain at least `1` and at most `n - 1` of the
+ones (it has only `n - 1` zeros to draw on), so its sum equals the count `k` of
+chosen ones with `1 ≤ k ≤ n - 1 < n`, a nonzero residue mod `n`. -/
+theorem egz_sharp (hn : 2 ≤ n) :
+    ∃ (s : Finset ℕ) (a : ℕ → ZMod n),
+      #s = 2 * n - 2 ∧ ∀ t ⊆ s, #t = n → ∑ i ∈ t, a i ≠ 0 := by
+  classical
+  -- The "ones" live at indices `≥ n - 1`; everything below is a zero.
+  refine ⟨range (2 * n - 2), fun i => if n - 1 ≤ i then 1 else 0, ?_, ?_⟩
+  · simp
+  intro t hts htcard
+  -- The subsequence sum is the number `k` of chosen "one" indices, cast to `ZMod n`.
+  set k : ℕ := #{i ∈ t | n - 1 ≤ i} with hk
+  have hsum : ∑ i ∈ t, (if n - 1 ≤ i then (1 : ZMod n) else 0) = (k : ZMod n) := by
+    simp [hk, Finset.sum_boole]
+  rw [hsum]
+  -- Upper bound: only `n - 1` indices in `range (2 * n - 2)` satisfy `n - 1 ≤ i`.
+  have hupper : k ≤ n - 1 := by
+    have hsub : {i ∈ t | n - 1 ≤ i} ⊆ Ico (n - 1) (2 * n - 2) := by
+      intro i hi
+      simp only [mem_filter] at hi
+      have hi_range : i < 2 * n - 2 := mem_range.1 (hts hi.1)
+      exact mem_Ico.2 ⟨hi.2, hi_range⟩
+    calc k ≤ #(Ico (n - 1) (2 * n - 2)) := card_le_card hsub
+      _ = (2 * n - 2) - (n - 1) := Nat.card_Ico _ _
+      _ = n - 1 := by omega
+  -- Lower bound: at most `n - 1` indices are zeros, and `#t = n`, so `k ≥ 1`.
+  have hlower : 1 ≤ k := by
+    have hzeros : #{i ∈ t | ¬ n - 1 ≤ i} ≤ n - 1 := by
+      have hsub : {i ∈ t | ¬ n - 1 ≤ i} ⊆ range (n - 1) := by
+        intro i hi
+        simp only [mem_filter, not_le] at hi
+        exact mem_range.2 hi.2
+      calc #{i ∈ t | ¬ n - 1 ≤ i} ≤ #(range (n - 1)) := card_le_card hsub
+        _ = n - 1 := card_range _
+    have hsplit : k + #{i ∈ t | ¬ n - 1 ≤ i} = #t :=
+      filter_card_add_filter_neg_card_eq_card _
+    omega
+  -- A residue `k` with `1 ≤ k ≤ n - 1 < n` is nonzero in `ZMod n`.
+  rw [Ne, ZMod.natCast_eq_zero_iff]
+  intro hdvd
+  have hkpos : 0 < k := hlower
+  have : n ≤ k := Nat.le_of_dvd hkpos hdvd
+  omega
+
+end ErdosGinzburgZivOQ01

--- a/src/data/proofs/erdos-ginzburg-ziv-oq-01/meta.json
+++ b/src/data/proofs/erdos-ginzburg-ziv-oq-01/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "erdos-ginzburg-ziv-oq-01",
+  "title": "Erdős–Ginzburg–Ziv: the zero-sum theorem and the sharpness of its threshold",
+  "slug": "erdos-ginzburg-ziv-oq-01",
+  "description": "The Erdős–Ginzburg–Ziv theorem (1961) states that among any 2n−1 integers some n have a sum divisible by n; equivalently every length-(2n−1) sequence in ℤ/nℤ has a zero-sum subsequence of length exactly n. Mathlib proves the theorem (Int/ZMod and multiset forms) but states no optimality result. This entry repackages the theorem and proves that the threshold 2n−1 is best possible: for every n ≥ 2 the configuration of n−1 zeros and n−1 ones gives a length-(2n−2) sequence with NO zero-sum subsequence of length n — pinning the Erdős–Ginzburg–Ziv constant of ℤ/nℤ at exactly 2n−1.",
+  "meta": {
+    "author": "Paul Erdős, Abraham Ginzburg, Abraham Ziv (1961); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ErdosGinzburgZivOQ01.lean",
+    "tags": [
+      "combinatorics",
+      "additive-combinatorics",
+      "number-theory",
+      "zero-sum",
+      "erdos",
+      "ZMod",
+      "extremal",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.erdos_ginzburg_ziv",
+        "description": "The Erdős–Ginzburg–Ziv theorem over ℤ: any family with 2*n-1 ≤ #s has a subset t ⊆ s with #t = n and n ∣ ∑_{i∈t} a i",
+        "module": "Mathlib.Combinatorics.Additive.ErdosGinzburgZiv"
+      },
+      {
+        "theorem": "ZMod.erdos_ginzburg_ziv",
+        "description": "The Erdős–Ginzburg–Ziv theorem over ZMod n: any family with 2*n-1 ≤ #s has a length-n subset summing to 0",
+        "module": "Mathlib.Combinatorics.Additive.ErdosGinzburgZiv"
+      },
+      {
+        "theorem": "Int.erdos_ginzburg_ziv_multiset",
+        "description": "Multiset form over ℤ: a multiset of card ≥ 2*n-1 has a length-n submultiset whose sum is divisible by n",
+        "module": "Mathlib.Combinatorics.Additive.ErdosGinzburgZiv"
+      },
+      {
+        "theorem": "ZMod.erdos_ginzburg_ziv_multiset",
+        "description": "Multiset form over ZMod n: a multiset of card ≥ 2*n-1 has a length-n submultiset summing to 0",
+        "module": "Mathlib.Combinatorics.Additive.ErdosGinzburgZiv"
+      },
+      {
+        "theorem": "Finset.sum_boole",
+        "description": "∑_{x∈s} (if p x then 1 else 0) = #(s.filter p) cast into the ring; turns the 0/1 witness sum into the count of chosen 'one' indices",
+        "module": "Mathlib.Algebra.BigOperators.Ring.Finset"
+      },
+      {
+        "theorem": "Finset.filter_card_add_filter_neg_card_eq_card",
+        "description": "#(s.filter p) + #(s.filter (¬p ·)) = #s; the counting identity supplying the lower bound on the number of chosen ones in the sharpness proof",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(a : ZMod b) = 0 ↔ b ∣ a; used to show a count k with 1 ≤ k ≤ n-1 is a nonzero residue mod n",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "egz_int / egz_zmod: the Erdős–Ginzburg–Ziv theorem over ℤ and ZMod n restated as the baseline (Mathlib headlines)",
+      "egz_int_multiset / egz_zmod_multiset: the multiset forms of the theorem, the natural setting for sequences with repetitions",
+      "egz_three_integers: the explicit n=2 instance — among any three integers, some two have an even sum (the historical pigeonhole-on-parity case) read off from the general theorem",
+      "egz_sharp: the sharpness/optimality result — for every n ≥ 2 there is a length-(2n−2) sequence in ZMod n with NO zero-sum subsequence of length n, namely n−1 zeros and n−1 ones, proving the threshold 2n−1 is best possible. Mathlib has no such optimality lemma; this is the new content."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 140,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "In 1961 Paul Erdős, Abraham Ginzburg, and Abraham Ziv proved that any 2n−1 integers contain n whose sum is divisible by n. It is the founding theorem of the theory of zero-sum sequences in finite abelian groups: the Erdős–Ginzburg–Ziv constant s(G) is the least N such that every length-N sequence over G has a zero-sum subsequence of length exp(G), and the EGZ theorem is precisely the computation s(ℤ/nℤ) = 2n−1. The result and its many generalizations (Davenport constant, Kemnitz's conjecture for ℤ/nℤ × ℤ/nℤ) are central to additive combinatorics.",
+    "problemStatement": "Mathlib's `Combinatorics/Additive/ErdosGinzburgZiv.lean` proves the theorem itself in the ℤ and ZMod n forms (and the multiset variants), but records no statement that the bound 2n−1 is optimal. Can the optimality be formalized — exhibiting a length-(2n−2) sequence that admits no zero-sum subsequence of length n?\n\n**Answer:** Yes. The configuration of n−1 zeros and n−1 ones works: an n-element subset must use between 1 and n−1 of the ones (only n−1 zeros are available), so its sum is a nonzero residue mod n. Together with the theorem this pins the EGZ constant of ℤ/nℤ at exactly 2n−1.",
+    "text": "The Erdős–Ginzburg–Ziv theorem (any 2n−1 elements of ℤ/nℤ contain a length-n zero-sum subsequence) is restated from Mathlib in its integer, modular, and multiset forms, the n=2 toy case is read off explicitly, and — the new content — the threshold 2n−1 is shown best possible via the extremal n−1 zeros / n−1 ones configuration, verified in Lean with no axioms.",
+    "proofStrategy": "1. egz_int, egz_zmod, egz_int_multiset, egz_zmod_multiset: restate Mathlib's four headline statements as the baseline.\n2. egz_three_integers: instantiate Int.erdos_ginzburg_ziv at n=2 and simplify 2*2-1 = 3.\n3. egz_sharp: take s = range (2n−2) and a i = (if n−1 ≤ i then 1 else 0) over ZMod n. For an n-element t ⊆ s, write k = #{i ∈ t | n−1 ≤ i}. By Finset.sum_boole the subsequence sum equals (k : ZMod n). The 'ones' available in s number n−1, so k ≤ n−1 (subset of Ico (n−1) (2n−2)); the 'zeros' number n−1 and #t = n, so by filter_card_add_filter_neg_card_eq_card the count of zeros chosen is ≤ n−1 forcing k ≥ 1. A natural number k with 1 ≤ k ≤ n−1 < n is a nonzero residue mod n (ZMod.natCast_eq_zero_iff plus Nat.le_of_dvd), so the sum is nonzero.",
+    "keyInsights": [
+      "**The theorem is one lemma away, the sharpness is the work**: the four EGZ statements are direct re-exports of Mathlib, so the genuine mathematical contribution is the optimality witness, which Mathlib does not provide.",
+      "**The extremal configuration is forced by a counting balance**: with exactly n−1 zeros and n−1 ones, any n chosen elements must borrow between 1 and n−1 ones — never 0 (too few zeros) and never n (too few ones) — so the sum lands strictly between 0 and n in ℤ/nℤ.",
+      "**0/1 sums become cardinalities**: `Finset.sum_boole` converts the indicator sum into the count of chosen ones, turning the algebraic non-vanishing goal into the elementary arithmetic fact 1 ≤ k ≤ n−1 < n.",
+      "**Why n ≥ 2 is needed**: in ℤ/1ℤ every element is 0, so the optimality statement is only meaningful (and the residue k genuinely nonzero) once n ≥ 2."
+    ],
+    "prerequisites": [
+      "Finite sequences and subsequences (Finsets and their cardinality)",
+      "The ring ℤ/nℤ (ZMod n) and the divisibility criterion (k : ZMod n) = 0 ↔ n ∣ k",
+      "Zero-sum sequences and the Erdős–Ginzburg–Ziv / Davenport constants",
+      "Elementary counting identities for filtered Finsets"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Statement",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "File-level docstring framing the result: Mathlib proves the EGZ theorem but states no optimality. Lists the baseline re-exports, the n=2 instance, and the sharpness contribution. Imports the Mathlib EGZ file and Tactic.",
+      "mathContext": "The Erdős–Ginzburg–Ziv theorem and the optimality of its 2n−1 threshold."
+    },
+    {
+      "id": "main-theorem",
+      "title": "The Theorem: ℤ, ZMod n, and Multiset Forms",
+      "startLine": 55,
+      "endLine": 79,
+      "summary": "egz_int and egz_zmod restate the integer and modular Erdős–Ginzburg–Ziv theorems; egz_int_multiset and egz_zmod_multiset give the multiset forms. All are direct re-exports of the Mathlib headlines.",
+      "mathContext": "Any 2n−1 elements of ℤ (resp. ZMod n) contain n whose sum is divisible by n (resp. is 0)."
+    },
+    {
+      "id": "concrete-instance",
+      "title": "The n = 2 Instance",
+      "startLine": 81,
+      "endLine": 87,
+      "summary": "egz_three_integers specializes the integer theorem to n=2: among any three integers, some two have an even sum — the elementary pigeonhole-on-parity case.",
+      "mathContext": "EGZ at n=2 recovers the parity pigeonhole on three integers."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness of the Threshold",
+      "startLine": 89,
+      "endLine": 140,
+      "summary": "egz_sharp builds the length-(2n−2) configuration of n−1 zeros and n−1 ones and proves no n-element subset is zero-sum: the sum equals the count k of chosen ones (Finset.sum_boole), bounded 1 ≤ k ≤ n−1 < n by elementary Finset counting, hence a nonzero residue. This proves 2n−1 is best possible.",
+      "mathContext": "The extremal n−1 zeros / n−1 ones sequence shows the EGZ constant s(ℤ/nℤ) = 2n−1 is tight."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul; Ginzburg, Abraham; Ziv, Abraham",
+      "title": "Theorem in the additive number theory",
+      "year": "1961",
+      "note": "Bull. Research Council Israel 10F, 41–43 — the original theorem that any 2n−1 integers contain n with sum divisible by n"
+    },
+    {
+      "authors": "Gao, Weidong; Geroldinger, Alfred",
+      "title": "Zero-sum problems in finite abelian groups: a survey",
+      "year": "2006",
+      "note": "Expositio Mathematica 24, 337–369 — the EGZ constant s(G), Davenport constant, and the optimality of the 2n−1 bound"
+    },
+    {
+      "authors": "Nathanson, Melvyn B.",
+      "title": "Additive Number Theory: Inverse Problems and the Geometry of Sumsets",
+      "year": "1996",
+      "note": "Chapter on the Erdős–Ginzburg–Ziv theorem and the extremal configuration of n−1 zeros and n−1 ones"
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": {
+    "summary": "The Erdős–Ginzburg–Ziv theorem is restated from Mathlib in its integer, modular, and multiset forms (egz_int, egz_zmod, egz_int_multiset, egz_zmod_multiset), the n=2 case is made explicit (egz_three_integers), and the threshold 2n−1 is proved best possible (egz_sharp) via the extremal configuration of n−1 zeros and n−1 ones. All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies the optimality half of the Erdős–Ginzburg–Ziv constant computation s(ℤ/nℤ) = 2n−1 that Mathlib's theorem leaves implicit, making the sharpness of the bound a machine-checked statement.",
+    "openQuestions": [
+      "Can the EGZ constant be formalized abstractly — defining s(G) as the least N forcing a length-exp(G) zero-sum subsequence and proving s(ℤ/nℤ) = 2n−1 by combining egz_zmod with egz_sharp?",
+      "Does the Davenport constant D(ℤ/nℤ) = n admit a similar packaged formalization, and can the EGZ multiset form be used to derive it?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.Additive.ErdosGinzburgZiv",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ErdosGinzburgZivOQ01",
+    "lineCount": 140,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/ErdosGinzburgZivOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Erdős–Ginzburg–Ziv: the zero-sum theorem and the sharpness of its threshold

The **Erdős–Ginzburg–Ziv theorem** (1961) states that among any `2n−1` integers some `n` have a sum divisible by `n`; equivalently every length-`(2n−1)` sequence in `ℤ/nℤ` has a zero-sum subsequence of length exactly `n`. It is the founding theorem of zero-sum additive combinatorics — precisely the computation that the EGZ constant `s(ℤ/nℤ) = 2n−1`.

Mathlib proves the theorem (`Int.erdos_ginzburg_ziv`, `ZMod.erdos_ginzburg_ziv`, and multiset variants) but records **no optimality statement**. This entry repackages the theorem and supplies the missing half: the threshold `2n−1` is best possible.

### Contents (6 theorems, 0 axioms, 0 sorries)

- **`egz_int`, `egz_zmod`** — the theorem over `ℤ` and `ZMod n` (Mathlib headlines, restated as the baseline).
- **`egz_int_multiset`, `egz_zmod_multiset`** — the multiset forms, the natural setting for sequences with repetitions.
- **`egz_three_integers`** — the explicit `n = 2` instance: among any three integers, some two have an even sum (the historical pigeonhole-on-parity case).
- **`egz_sharp`** *(new content)* — for every `n ≥ 2` there is a length-`(2n−2)` sequence in `ZMod n` with **no** zero-sum subsequence of length `n`, namely `n−1` zeros and `n−1` ones. Any `n` chosen elements must include between `1` and `n−1` ones (only `n−1` zeros to draw on), so the sum is a nonzero residue mod `n`. This pins `s(ℤ/nℤ) = 2n−1`.

### Sharpness proof sketch

Take `s = range (2n−2)` and `a i = (if n−1 ≤ i then 1 else 0)`. For an `n`-element `t ⊆ s`, `Finset.sum_boole` turns the subsequence sum into `(k : ZMod n)` where `k` is the number of chosen ones. Counting bounds `k`:
- **upper** `k ≤ n−1` (the ones in `s` form `Ico (n−1) (2n−2)`),
- **lower** `1 ≤ k` (`filter_card_add_filter_neg_card_eq_card` with `#t = n` and at most `n−1` zeros).

A natural number `k` with `1 ≤ k ≤ n−1 < n` is nonzero in `ZMod n` (`ZMod.natCast_eq_zero_iff` + `Nat.le_of_dvd`), so the sum is nonzero. (`n ≥ 2` is essential — in `ℤ/1ℤ` everything is `0`.)

### Verification

- `./proofs/scripts/docker-build.sh Proofs.ErdosGinzburgZivOQ01` — **green**, no warnings.
- 0 `axiom` declarations, 0 `sorry`, no `native_decide`. Badge: `mathlib` (Tier B — main theorem is a Mathlib re-export; sharpness is original but elementary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)