### PR TITLE
research(baire-category-theorem-oq-01): Baire category theorem + uncountability of ℝ (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs/BaireCategoryTheoremOQ01.lean
+++ b/proofs/Proofs/BaireCategoryTheoremOQ01.lean
@@ -1,0 +1,119 @@
+import Mathlib
+
+/-!
+# The Baire category theorem and its consequences
+
+**Baire's category theorem** (Baire 1899) is the backbone of functional analysis and
+descriptive set theory: a complete (pseudo)metric space — or more generally any
+`BaireSpace` — cannot be "small" in a topological sense. Mathlib packages the abstract
+theorem through several named lemmas, which this file re-exports (hence the `mathlib`
+badge):
+
+* `dense_iInter_of_isOpen` — the **dense-Gδ form**: a countable intersection of dense
+  open sets is dense;
+* `nonempty_interior_of_iUnion_of_closed` — the **category form**: if countably many
+  closed sets cover a nonempty space, one of them has nonempty interior;
+* `not_isMeagre_of_isOpen` — every nonempty open set is non-meagre;
+* `BaireSpace.of_completelyPseudoMetrizable` — the **instance**: every complete
+  metrizable space (in particular `ℝ`) is a `BaireSpace`.
+
+On top of these we record the genuine content absent from the gallery: the
+**contrapositive category form** (a nonempty Baire space is *not* a countable union of
+closed sets all with empty interior, `baire_not_iUnion_empty_interior`), the fact that
+the whole space is non-meagre (`baire_univ_not_meagre`), and — as the concrete witness —
+the classical **uncountability of `ℝ`** derived from Baire:
+
+* every singleton in `ℝ` is meagre (`isMeagre_singleton_real`), hence every countable
+  subset is meagre (`isMeagre_of_countable_real`);
+* since the whole space is non-meagre, `ℝ` is uncountable (`real_uncountable`); concretely
+  `ℝ` is never the union of countably many singletons (`real_not_iUnion_singletons`).
+
+All results are fully machine-checked with no `sorry` and no extra axioms (no
+`native_decide`).
+-/
+
+namespace BaireCategoryTheoremOQ01
+
+open Set Topology
+
+/-! ## Part (a): the abstract Baire category theorem -/
+
+/-- **Baire category theorem, dense-Gδ form.** In any `BaireSpace`, a countable
+intersection of dense open sets is dense. (Re-export of `dense_iInter_of_isOpen`.) -/
+theorem baire_dense_iInter {X : Type*} [TopologicalSpace X] [BaireSpace X]
+    {ι : Type*} [Countable ι] {f : ι → Set X}
+    (ho : ∀ i, IsOpen (f i)) (hd : ∀ i, Dense (f i)) : Dense (⋂ i, f i) :=
+  dense_iInter_of_isOpen ho hd
+
+/-- **Baire category theorem, category form.** If a countable family of closed sets covers
+a nonempty Baire space, then at least one of them has nonempty interior. (Re-export of
+`nonempty_interior_of_iUnion_of_closed`.) -/
+theorem baire_nonempty_interior {X : Type*} [TopologicalSpace X] [BaireSpace X] [Nonempty X]
+    {ι : Type*} [Countable ι] {f : ι → Set X}
+    (hc : ∀ i, IsClosed (f i)) (hU : ⋃ i, f i = univ) : ∃ i, (interior (f i)).Nonempty :=
+  nonempty_interior_of_iUnion_of_closed hc hU
+
+/-- **Contrapositive category form.** A nonempty Baire space is *not* the union of a
+countable family of closed sets all having empty interior. This is the precise sense in
+which a complete metric space "is not meagre in itself": it cannot be exhausted by
+countably many nowhere-dense closed pieces. -/
+theorem baire_not_iUnion_empty_interior {X : Type*} [TopologicalSpace X] [BaireSpace X]
+    [Nonempty X] {ι : Type*} [Countable ι] {f : ι → Set X}
+    (hc : ∀ i, IsClosed (f i)) (he : ∀ i, interior (f i) = ∅) : ⋃ i, f i ≠ univ := by
+  intro hU
+  obtain ⟨i, hi⟩ := nonempty_interior_of_iUnion_of_closed hc hU
+  rw [he i] at hi
+  exact not_nonempty_empty hi
+
+/-- **Meagre form.** In a nonempty Baire space the whole space is non-meagre: it is not a
+countable union of nowhere-dense sets. -/
+theorem baire_univ_not_meagre {X : Type*} [TopologicalSpace X] [BaireSpace X] [Nonempty X] :
+    ¬ IsMeagre (univ : Set X) :=
+  not_isMeagre_of_isOpen isOpen_univ univ_nonempty
+
+/-! ## Part (b): the Baire space instance -/
+
+/-- Every complete metrizable space is a Baire space; in particular `ℝ` is a `BaireSpace`,
+resolved automatically from `BaireSpace.of_completelyPseudoMetrizable`. -/
+theorem baireSpace_real : BaireSpace ℝ := inferInstance
+
+/-! ## Part (c): concrete consequence — `ℝ` is uncountable
+
+The classical application of Baire's theorem: a nonempty complete metric space with no
+isolated points is uncountable. We carry this out for `ℝ`, whose points are non-isolated
+(`interior {x} = ∅`), so every countable subset is meagre while the whole line is not. -/
+
+/-- A singleton in `ℝ` is meagre: it is closed with empty interior, hence nowhere dense. -/
+theorem isMeagre_singleton_real (x : ℝ) : IsMeagre ({x} : Set ℝ) := by
+  rw [isMeagre_iff_countable_union_isNowhereDense]
+  refine ⟨{({x} : Set ℝ)}, ?_, countable_singleton _, ?_⟩
+  · intro t ht
+    rw [mem_singleton_iff] at ht; subst ht
+    rw [(isClosed_singleton).isNowhereDense_iff]
+    exact interior_singleton x
+  · simp
+
+/-- Every countable subset of `ℝ` is meagre: write it as a countable union of singletons,
+each nowhere dense. -/
+theorem isMeagre_of_countable_real {s : Set ℝ} (hs : s.Countable) : IsMeagre s := by
+  rw [isMeagre_iff_countable_union_isNowhereDense]
+  refine ⟨(fun x => ({x} : Set ℝ)) '' s, ?_, hs.image _, ?_⟩
+  · rintro t ⟨x, _, rfl⟩
+    rw [(isClosed_singleton).isNowhereDense_iff]
+    exact interior_singleton x
+  · intro x hx
+    exact mem_sUnion.2 ⟨{x}, ⟨x, hx, rfl⟩, rfl⟩
+
+/-- **Uncountability of `ℝ` via Baire.** If `ℝ` were countable it would be meagre in
+itself, contradicting that a nonempty Baire space is non-meagre. -/
+theorem real_uncountable : ¬ (univ : Set ℝ).Countable := by
+  intro h
+  exact baire_univ_not_meagre (isMeagre_of_countable_real h)
+
+/-- A concrete restatement of uncountability through the category form: `ℝ` is never the
+union of countably many singletons. (Each `{g n}` is closed with empty interior.) -/
+theorem real_not_iUnion_singletons (g : ℕ → ℝ) : ⋃ n, ({g n} : Set ℝ) ≠ univ :=
+  baire_not_iUnion_empty_interior (fun _ => isClosed_singleton)
+    (fun n => interior_singleton (g n))
+
+end BaireCategoryTheoremOQ01

--- a/src/data/proofs/baire-category-theorem-oq-01/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "baire-category-theorem-oq-01",
+  "slug": "baire-category-theorem-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Topology"
+    ],
+    "namespace": "BaireCategoryTheoremOQ01",
+    "lineCount": 119,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/BaireCategoryTheoremOQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Baire Category Theorem and the Uncountability of ℝ",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaireCategoryTheoremOQ01.lean",
+    "tags": [
+      "topology",
+      "baire-category",
+      "complete-metric-space",
+      "meagre-set",
+      "functional-analysis",
+      "uncountability",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 119,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "baire_dense_iInter: dense-Gδ form of Baire's theorem — in any BaireSpace a countable intersection of dense open sets is dense (re-export of dense_iInter_of_isOpen)",
+      "baire_nonempty_interior: category form — if countably many closed sets cover a nonempty Baire space, one of them has nonempty interior (re-export of nonempty_interior_of_iUnion_of_closed)",
+      "baire_not_iUnion_empty_interior: contrapositive category form absent from Mathlib — a nonempty Baire space is NOT a countable union of closed sets all with empty interior, the precise 'not meagre in itself' statement",
+      "baire_univ_not_meagre: the whole nonempty Baire space is non-meagre (it is not a countable union of nowhere-dense sets), via not_isMeagre_of_isOpen on the universal set",
+      "baireSpace_real: ℝ is a BaireSpace, resolved automatically from BaireSpace.of_completelyPseudoMetrizable (every complete metrizable space is Baire)",
+      "isMeagre_singleton_real: every singleton in ℝ is meagre — it is closed with empty interior (interior_singleton, ℝ has no isolated points), hence nowhere dense",
+      "isMeagre_of_countable_real: every countable subset of ℝ is meagre, written as a countable union of nowhere-dense singletons",
+      "real_uncountable: the classical uncountability of ℝ derived from Baire — a countable ℝ would be meagre in itself, contradicting baire_univ_not_meagre",
+      "real_not_iUnion_singletons: concrete restatement through the category form — ℝ is never the union of countably many singletons ⋃ n, {g n}"
+    ],
+    "prerequisites": [
+      "BaireSpace typeclass and the abstract Baire lemmas in Mathlib.Topology.Baire (dense_iInter_of_isOpen, nonempty_interior_of_iUnion_of_closed, not_isMeagre_of_isOpen)",
+      "BaireSpace.of_completelyPseudoMetrizable: every complete (pseudo)metrizable space, in particular ℝ, is a Baire space",
+      "IsMeagre and IsNowhereDense (Mathlib.Topology.GDelta.Basic), with isMeagre_iff_countable_union_isNowhereDense and IsClosed.isNowhereDense_iff",
+      "interior_singleton: in a space with no isolated points (NeBot (𝓝[≠] x), true for ℝ) a singleton has empty interior"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "dense_iInter_of_isOpen",
+        "description": "Baire's theorem in dense-open form: a countable intersection of dense open sets is dense in any BaireSpace. Re-exported as baire_dense_iInter.",
+        "module": "Mathlib.Topology.Baire.Lemmas"
+      },
+      {
+        "theorem": "nonempty_interior_of_iUnion_of_closed",
+        "description": "Category form: a countable closed cover of a nonempty Baire space has a member with nonempty interior. Re-exported as baire_nonempty_interior and used for baire_not_iUnion_empty_interior.",
+        "module": "Mathlib.Topology.Baire.Lemmas"
+      },
+      {
+        "theorem": "not_isMeagre_of_isOpen",
+        "description": "Every nonempty open set in a Baire space is non-meagre; specialised to the universal set in baire_univ_not_meagre.",
+        "module": "Mathlib.Topology.Baire.Lemmas"
+      },
+      {
+        "theorem": "BaireSpace.of_completelyPseudoMetrizable",
+        "description": "Every complete metrizable space is a Baire space — the instance that makes ℝ a BaireSpace (baireSpace_real).",
+        "module": "Mathlib.Topology.Baire.CompleteMetrizable"
+      },
+      {
+        "theorem": "isMeagre_iff_countable_union_isNowhereDense / IsClosed.isNowhereDense_iff",
+        "description": "Characterise meagre sets as countable unions of nowhere-dense sets, and closed nowhere-dense sets by empty interior — used to show singletons and countable sets in ℝ are meagre.",
+        "module": "Mathlib.Topology.GDelta.Basic"
+      },
+      {
+        "theorem": "interior_singleton",
+        "description": "A singleton has empty interior in a space with no isolated points (NeBot (𝓝[≠] x)); supplies the nowhere-density of points in ℝ.",
+        "module": "Mathlib.Topology.ClusterPt"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "baire-category-theorem-oq-01-oq-01",
+      "question": "Derive the Banach–Steinhaus (uniform boundedness) principle from the category form of Baire's theorem: a pointwise-bounded family of continuous linear maps between Banach spaces is uniformly bounded.",
+      "significance": "high"
+    },
+    {
+      "id": "baire-category-theorem-oq-01-oq-02",
+      "question": "Show that a complete metric space with no isolated points has cardinality at least that of the continuum, sharpening the uncountability of ℝ obtained here.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [],
+  "references": [
+    {
+      "title": "René-Louis Baire, Sur les fonctions de variables réelles",
+      "author": "R. Baire",
+      "year": "1899",
+      "venue": "Annali di Matematica Pura ed Applicata",
+      "description": "Origin of the category theorem, the foundational 'large set' principle for complete metric spaces."
+    },
+    {
+      "title": "Mathlib4: Topology.Baire",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of dense_iInter_of_isOpen, nonempty_interior_of_iUnion_of_closed, not_isMeagre_of_isOpen and the BaireSpace.of_completelyPseudoMetrizable instance re-exported in this entry."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The Baire category theorem states that a complete (pseudo)metric space — more generally any BaireSpace — is 'large': a countable intersection of dense open sets is dense (baire_dense_iInter), and dually a countable closed cover of a nonempty space has a member with nonempty interior (baire_nonempty_interior). This entry re-exports those abstract forms from Mathlib and adds the content the gallery lacked: the contrapositive 'not meagre in itself' statement that a nonempty Baire space is never a countable union of closed sets with empty interior (baire_not_iUnion_empty_interior), the non-meagreness of the whole space (baire_univ_not_meagre), the BaireSpace instance for ℝ (baireSpace_real), and a concrete application chain — singletons in ℝ are meagre (isMeagre_singleton_real), hence every countable subset is meagre (isMeagre_of_countable_real), so ℝ is uncountable (real_uncountable) and is never a countable union of singletons (real_not_iUnion_singletons). 119 lines, 9 theorems, 0 axioms, 0 sorries.",
+    "implications": "The abstract theorem is delegated to Mathlib; the new content is the packaging of its dual forms together with a self-contained Baire proof of the uncountability of ℝ — the textbook 'a perfect complete metric space is uncountable' argument made fully explicit through the meagre/nowhere-dense API. Baire is the engine behind the Banach–Steinhaus, open mapping and closed graph theorems, recorded as the lead open question.",
+    "openQuestions": [
+      "Derive Banach–Steinhaus (uniform boundedness) from the category form.",
+      "Sharpen uncountability to a continuum-cardinality lower bound for perfect complete metric spaces."
+    ]
+  }
+}


### PR DESCRIPTION
## The Baire Category Theorem and the Uncountability of ℝ

Re-exports Mathlib's abstract Baire forms and adds the content the gallery lacked, culminating in a self-contained Baire proof that ℝ is uncountable.

### Abstract theorem (re-exported from Mathlib)
- `baire_dense_iInter` — dense-Gδ form (`dense_iInter_of_isOpen`)
- `baire_nonempty_interior` — category form (`nonempty_interior_of_iUnion_of_closed`)

### New content
- **`baire_not_iUnion_empty_interior`** — contrapositive category form (absent from Mathlib): a nonempty Baire space is *never* a countable union of closed sets all with empty interior — the precise "not meagre in itself" statement.
- **`baire_univ_not_meagre`** — the whole nonempty Baire space is non-meagre.
- **`baireSpace_real`** — ℝ is a `BaireSpace` (via `BaireSpace.of_completelyPseudoMetrizable`).
- **`isMeagre_singleton_real` / `isMeagre_of_countable_real`** — singletons and countable subsets of ℝ are meagre.
- **`real_uncountable` / `real_not_iUnion_singletons`** — the classical Baire proof of the uncountability of ℝ, made fully explicit through the meagre / nowhere-dense API.

### Verification
- 9 theorems, 0 definitions, 119 lines
- **0 axioms, 0 sorries, no `native_decide`**
- Badge: `mathlib` · Status: `verified`
- Docker build green (7743 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)