### PR TITLE
research(spectral-trace-det-eigenvalues-oq-01): trace=Σλ, det=Πλ + eigenvalue Vieta & singularity criterion (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3143,6 +3143,7 @@ import Proofs.SophieGermain
 import Proofs.SophieGermainOQ01
 import Proofs.SophieGermainOQ02
 import Proofs.SophieGermainOQ04
+import Proofs.SpectralTraceDetEigenvaluesOQ01
 import Proofs.SpernerFreudenthal
 import Proofs.SpernerFreudenthalAristotle
 import Proofs.SpernerFreudenthalSimplex

--- a/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01.lean
+++ b/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01.lean
@@ -1,0 +1,132 @@
+import Mathlib
+
+/-!
+# Trace and determinant from the eigenvalues (spectral symmetric functions)
+
+For a square matrix `A : Matrix n n K` over a field `K`, the roots of the characteristic
+polynomial `A.charpoly` are the **eigenvalues** of `A`, counted with algebraic
+multiplicity. Mathlib proves the two headline spectral identities (hence the `mathlib`
+badge on them):
+
+* `Matrix.trace_eq_sum_roots_charpoly` — over an algebraically closed field, the trace is
+  the **sum** of the eigenvalues;
+* `Matrix.det_eq_prod_roots_charpoly` — and the determinant is their **product**.
+
+We re-export those two under eigenvalue-flavoured names and then derive the genuine
+content absent from Mathlib for the characteristic polynomial:
+
+* `card_eigenvalues_eq_dim` — over an algebraically closed field there are exactly
+  `Fintype.card n` eigenvalues counted with multiplicity (the multiset of roots has the
+  same cardinality as the dimension of the space);
+* `charpoly_coeff_eq_esymm_eigenvalues` — **Vieta for eigenvalues**: every coefficient of
+  the characteristic polynomial is, up to sign, an elementary symmetric function of the
+  eigenvalues. Trace (`k = n - 1`) and determinant (`k = 0`) are the two extreme cases of
+  this single statement;
+* `det_eq_zero_iff_zero_mem_spectrum` — over **any** field, a matrix is singular iff `0`
+  is an eigenvalue (`0 ∈ spectrum K A`); equivalently
+  `isUnit_det_iff_zero_not_mem_spectrum`, a matrix is invertible iff `0` is not an
+  eigenvalue.
+
+The closing examples illustrate the headline identities on the concrete `2 × 2` complex
+matrix `!![1, 2; 3, 4]`: its eigenvalues are the irrational numbers `(5 ± √33)/2`, yet
+their sum is `5` and their product is `-2` — read off the trace and determinant without
+ever computing the eigenvalues themselves.
+
+All results are fully machine-checked with no `sorry` and no extra axioms.
+-/
+
+namespace SpectralTraceDetEigenvaluesOQ01
+
+open Matrix Polynomial
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {K : Type*} [Field K]
+
+/-- The eigenvalues of `A`, counted with algebraic multiplicity: the multiset of roots of
+the characteristic polynomial.  (A reducible alias for `A.charpoly.roots`.) -/
+noncomputable abbrev eigenvalues (A : Matrix n n K) : Multiset K := A.charpoly.roots
+
+/-! ### The headline identities (re-exported from Mathlib) -/
+
+/-- Over an algebraically closed field, the **trace is the sum of the eigenvalues**
+(counted with multiplicity).  This is `Matrix.trace_eq_sum_roots_charpoly`. -/
+theorem trace_eq_sum_eigenvalues [IsAlgClosed K] (A : Matrix n n K) :
+    A.trace = (eigenvalues A).sum :=
+  A.trace_eq_sum_roots_charpoly
+
+/-- Over an algebraically closed field, the **determinant is the product of the
+eigenvalues** (counted with multiplicity).  This is `Matrix.det_eq_prod_roots_charpoly`. -/
+theorem det_eq_prod_eigenvalues [IsAlgClosed K] (A : Matrix n n K) :
+    A.det = (eigenvalues A).prod :=
+  A.det_eq_prod_roots_charpoly
+
+/-! ### Genuine content beyond Mathlib -/
+
+/-- Over an algebraically closed field, a matrix has exactly `Fintype.card n` eigenvalues
+counted with algebraic multiplicity: the eigenvalue multiset has cardinality equal to the
+dimension of the space. -/
+theorem card_eigenvalues_eq_dim [IsAlgClosed K] (A : Matrix n n K) :
+    Multiset.card (eigenvalues A) = Fintype.card n := by
+  rw [eigenvalues, (splits_iff_card_roots).1 (IsAlgClosed.splits A.charpoly),
+    charpoly_natDegree_eq_dim]
+
+/-- **Vieta's formulas for the eigenvalues.**  Over an algebraically closed field, the
+`k`-th coefficient of the characteristic polynomial is, up to the sign `(-1) ^ (n - k)`,
+the `(n - k)`-th elementary symmetric polynomial of the eigenvalues, where `n` is the
+dimension.  The two extreme cases are the headline identities above: `k = n - 1` recovers
+the trace (sum, `esymm 1`) and `k = 0` recovers the determinant (product, `esymm n`). -/
+theorem charpoly_coeff_eq_esymm_eigenvalues [IsAlgClosed K] (A : Matrix n n K)
+    {k : ℕ} (hk : k ≤ Fintype.card n) :
+    A.charpoly.coeff k =
+      (-1) ^ (Fintype.card n - k) * (eigenvalues A).esymm (Fintype.card n - k) := by
+  have hdeg : A.charpoly.natDegree = Fintype.card n := charpoly_natDegree_eq_dim A
+  have hk' : k ≤ A.charpoly.natDegree := hdeg ▸ hk
+  rw [Polynomial.coeff_eq_esymm_roots_of_splits (IsAlgClosed.splits A.charpoly) hk',
+    A.charpoly_monic.leadingCoeff, one_mul, hdeg]
+
+/-- **Singular ⟺ zero is an eigenvalue**, over an arbitrary field.  A matrix has vanishing
+determinant exactly when `0` lies in its spectrum (equivalently, `0` is a root of the
+characteristic polynomial). -/
+theorem det_eq_zero_iff_zero_mem_spectrum (A : Matrix n n K) :
+    A.det = 0 ↔ (0 : K) ∈ spectrum K A := by
+  rw [det_eq_sign_charpoly_coeff, mul_eq_zero, mem_spectrum_iff_isRoot_charpoly,
+    Polynomial.IsRoot.def, ← coeff_zero_eq_eval_zero]
+  have hne : ((-1 : K)) ^ Fintype.card n ≠ 0 := pow_ne_zero _ (neg_ne_zero.2 one_ne_zero)
+  simp [hne]
+
+/-- **Invertible ⟺ zero is not an eigenvalue**, over an arbitrary field. -/
+theorem isUnit_det_iff_zero_not_mem_spectrum (A : Matrix n n K) :
+    IsUnit A.det ↔ (0 : K) ∉ spectrum K A := by
+  rw [isUnit_iff_ne_zero, ne_eq, det_eq_zero_iff_zero_mem_spectrum]
+
+/-! ### A concrete `2 × 2` illustration over `ℂ`
+
+The matrix `!![1, 2; 3, 4]` has characteristic polynomial `X² - 5X - 2`, whose roots are
+`(5 ± √33)/2` — irrational.  Nevertheless the spectral identities give their sum and
+product immediately from the (rational) trace and determinant. -/
+
+/-- The sum of the two (irrational) eigenvalues of `!![1, 2; 3, 4]` is `5`. -/
+theorem sum_eigenvalues_example :
+    (eigenvalues (!![(1 : ℂ), 2; 3, 4])).sum = 5 := by
+  rw [← trace_eq_sum_eigenvalues, Matrix.trace_fin_two]
+  norm_num
+
+/-- The product of the two (irrational) eigenvalues of `!![1, 2; 3, 4]` is `-2`. -/
+theorem prod_eigenvalues_example :
+    (eigenvalues (!![(1 : ℂ), 2; 3, 4])).prod = -2 := by
+  rw [← det_eq_prod_eigenvalues, Matrix.det_fin_two]
+  norm_num
+
+/-- There are exactly two eigenvalues (counted with multiplicity) of `!![1, 2; 3, 4]`. -/
+theorem card_eigenvalues_example :
+    Multiset.card (eigenvalues (!![(1 : ℂ), 2; 3, 4])) = 2 := by
+  rw [card_eigenvalues_eq_dim]
+  simp
+
+end SpectralTraceDetEigenvaluesOQ01
+
+#print axioms SpectralTraceDetEigenvaluesOQ01.charpoly_coeff_eq_esymm_eigenvalues
+#print axioms SpectralTraceDetEigenvaluesOQ01.det_eq_zero_iff_zero_mem_spectrum
+#print axioms SpectralTraceDetEigenvaluesOQ01.card_eigenvalues_eq_dim
+#print axioms SpectralTraceDetEigenvaluesOQ01.sum_eigenvalues_example
+#print axioms SpectralTraceDetEigenvaluesOQ01.prod_eigenvalues_example

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "spectral-trace-det-eigenvalues-oq-01",
+  "title": "Trace and Determinant Are the Sum and Product of the Eigenvalues",
+  "slug": "spectral-trace-det-eigenvalues-oq-01",
+  "description": "For a square matrix over a field, the eigenvalues (with algebraic multiplicity) are the roots of the characteristic polynomial. Mathlib (LinearAlgebra/Matrix/Charpoly/Eigs.lean) proves the two headline spectral identities over an algebraically closed field: the trace is the sum of the eigenvalues (Matrix.trace_eq_sum_roots_charpoly) and the determinant is their product (Matrix.det_eq_prod_roots_charpoly). This entry re-exports those and then derives the content Mathlib does not state for the characteristic polynomial: that there are exactly dim-many eigenvalues counted with multiplicity (card_eigenvalues_eq_dim), the full Vieta theorem that EVERY charpoly coefficient is, up to sign, an elementary symmetric function of the eigenvalues (charpoly_coeff_eq_esymm_eigenvalues — the single statement of which trace and determinant are the two extreme cases), and the singularity criterion det = 0 iff 0 is an eigenvalue, valid over any field (det_eq_zero_iff_zero_mem_spectrum, isUnit_det_iff_zero_not_mem_spectrum). A concrete 2x2 complex example reads off the sum (5) and product (-2) of the irrational eigenvalues (5 ± √33)/2 without ever computing them. Fully verified, 0 axioms, 0 sorries, no decide/native_decide.",
+  "meta": {
+    "author": "Classical (Vieta; Cauchy, characteristic polynomial); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Characteristic_polynomial",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "linear-algebra",
+      "eigenvalues",
+      "characteristic-polynomial",
+      "trace",
+      "determinant",
+      "spectrum",
+      "vietas-formulas",
+      "symmetric-functions",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SpectralTraceDetEigenvaluesOQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.trace_eq_sum_roots_charpoly",
+        "description": "Over an algebraically closed field, A.trace = (A.charpoly).roots.sum: the trace is the sum of the eigenvalues counted with multiplicity. Re-exported here as trace_eq_sum_eigenvalues and reused to evaluate the example.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs"
+      },
+      {
+        "theorem": "Matrix.det_eq_prod_roots_charpoly",
+        "description": "Over an algebraically closed field, A.det = (A.charpoly).roots.prod: the determinant is the product of the eigenvalues counted with multiplicity. Re-exported as det_eq_prod_eigenvalues.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs"
+      },
+      {
+        "theorem": "Matrix.mem_spectrum_iff_isRoot_charpoly",
+        "description": "Over a field, r ∈ spectrum K A iff A.charpoly.IsRoot r — the spectrum is exactly the root set of the characteristic polynomial. Drives the singularity criterion det = 0 ↔ 0 ∈ spectrum.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs"
+      },
+      {
+        "theorem": "Polynomial.coeff_eq_esymm_roots_of_splits",
+        "description": "Vieta for a split polynomial over a field: coeff k = leadingCoeff · (-1)^(natDegree-k) · roots.esymm (natDegree-k). Specialised to the monic characteristic polynomial to obtain the eigenvalue Vieta formula.",
+        "module": "Mathlib.RingTheory.Polynomial.Vieta"
+      },
+      {
+        "theorem": "Polynomial.splits_iff_card_roots",
+        "description": "A polynomial splits iff its root multiset has cardinality equal to its degree. With IsAlgClosed.splits this gives the eigenvalue count = dimension.",
+        "module": "Mathlib.Algebra.Polynomial.Factors"
+      },
+      {
+        "theorem": "Matrix.charpoly_natDegree_eq_dim",
+        "description": "The characteristic polynomial of an n×n matrix has degree Fintype.card n. Converts the degree-indexed Vieta/root-count statements into dimension-indexed ones.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff"
+      },
+      {
+        "theorem": "Matrix.det_eq_sign_charpoly_coeff",
+        "description": "A.det = (-1)^(Fintype.card n) · A.charpoly.coeff 0. Combined with coeff 0 = eval 0 it identifies the determinant's vanishing with 0 being a root of the characteristic polynomial.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff"
+      }
+    ],
+    "originalContributions": [
+      "card_eigenvalues_eq_dim: over an algebraically closed field a matrix has exactly Fintype.card n eigenvalues counted with algebraic multiplicity (the root multiset has cardinality equal to the dimension) — not stated in Mathlib for the characteristic polynomial",
+      "charpoly_coeff_eq_esymm_eigenvalues: the full Vieta theorem for eigenvalues — every coefficient of the characteristic polynomial is, up to the sign (-1)^(n-k), the (n-k)-th elementary symmetric function of the eigenvalues; trace (k = n-1) and determinant (k = 0) are exactly its two extreme cases, unifying both headline identities in one statement",
+      "det_eq_zero_iff_zero_mem_spectrum: the singularity criterion det A = 0 ⟺ 0 ∈ spectrum K A, valid over an arbitrary field (a matrix is singular exactly when 0 is an eigenvalue)",
+      "isUnit_det_iff_zero_not_mem_spectrum: the invertibility dual — A is invertible iff 0 is not an eigenvalue, over an arbitrary field",
+      "sum_eigenvalues_example / prod_eigenvalues_example: the sum (5) and product (-2) of the irrational eigenvalues (5 ± √33)/2 of !![1,2;3,4] read off the rational trace and determinant without computing the eigenvalues themselves"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 126,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used. The headline identities require an algebraically closed field; the singularity criteria hold over an arbitrary field.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "That the sum of the roots of a polynomial is minus the next-to-leading coefficient, and the product is the constant term up to sign, is Vieta's sixteenth-century observation. Applied to the characteristic polynomial det(X·I − A) — whose roots are by definition the eigenvalues with algebraic multiplicity — it yields the two most quoted spectral invariants of a matrix: trace = Σλ and determinant = Πλ. The intermediate coefficients are the remaining elementary symmetric functions of the eigenvalues, so the entire characteristic polynomial is a generating function for the symmetric functions of the spectrum.",
+    "problemStatement": "**Open Question (spectral-trace-det-eigenvalues-oq-01)**: Establish in Lean that the trace and determinant of a matrix are the sum and product of its eigenvalues (roots of the characteristic polynomial), and derive the surrounding spectral facts: the eigenvalue count equals the dimension, the general Vieta correspondence between charpoly coefficients and elementary symmetric functions of the eigenvalues, and the criterion that a matrix is singular exactly when 0 is an eigenvalue.\n\n**Result**: trace_eq_sum_eigenvalues and det_eq_prod_eigenvalues (from Mathlib), plus card_eigenvalues_eq_dim, charpoly_coeff_eq_esymm_eigenvalues, and det_eq_zero_iff_zero_mem_spectrum — all fully verified with 0 axioms.",
+    "text": "Let A be an n×n matrix over a field K and let its eigenvalues, counted with algebraic multiplicity, be the roots of the characteristic polynomial. Over an algebraically closed K the trace is the sum of the eigenvalues, the determinant is their product, and there are exactly n of them. More generally the k-th coefficient of the characteristic polynomial equals (-1)^(n-k) times the (n-k)-th elementary symmetric polynomial of the eigenvalues. Over any field, A is singular iff 0 is an eigenvalue.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Define eigenvalues A := A.charpoly.roots and re-export Mathlib's trace_eq_sum_roots_charpoly and det_eq_prod_roots_charpoly as the headline sum/product identities.\n\n2. Eigenvalue count: IsAlgClosed.splits makes the characteristic polynomial split; splits_iff_card_roots then equates the root-multiset cardinality with the degree, and charpoly_natDegree_eq_dim rewrites the degree as Fintype.card n.\n\n3. General Vieta: apply Polynomial.coeff_eq_esymm_roots_of_splits to the (monic) characteristic polynomial; charpoly_monic kills the leadingCoeff factor and charpoly_natDegree_eq_dim converts every degree to the dimension, yielding coeff k = (-1)^(n-k)·esymm(n-k).\n\n4. Singularity: det_eq_sign_charpoly_coeff writes det as (-1)^n·coeff 0; coeff_zero_eq_eval_zero identifies coeff 0 with eval 0, and mem_spectrum_iff_isRoot_charpoly identifies 0 ∈ spectrum with charpoly having 0 as a root. Since (-1)^n ≠ 0, det vanishes iff coeff 0 does. The invertibility dual follows from isUnit_iff_ne_zero in a field.\n\n5. Example: instantiate at !![1,2;3,4] over ℂ; trace_fin_two and det_fin_two compute the trace (5) and determinant (-2), which the headline identities equate with the sum and product of the eigenvalues.",
+    "keyInsights": [
+      "**Multiplicity matters: eigenvalues are charpoly roots, not minpoly roots.** Mathlib's defined eigenvalues (roots of the minimal polynomial) lose algebraic multiplicity, so the sum/product identities are stated for the characteristic-polynomial root multiset. This entry stays in that multiset throughout, which is exactly what makes the count card = dim and the Vieta sums correct.",
+      "**Trace and determinant are one theorem, not two.** charpoly_coeff_eq_esymm_eigenvalues shows both are instances of a single Vieta correspondence: k = n-1 gives e_1 = Σλ = trace, k = 0 gives e_n = Πλ = det. The intermediate coefficients are the other elementary symmetric functions of the spectrum.",
+      "**Singularity is a spectral statement over any field.** det A = 0 ⟺ 0 ∈ spectrum K A needs no algebraic closure: it is just the observation that the constant term of the characteristic polynomial (which is ± det) vanishes exactly when 0 is a root.",
+      "**The identities compute the unknowable.** The eigenvalues of !![1,2;3,4] are the irrational (5 ± √33)/2, but their sum and product are forced to be the rational trace 5 and determinant -2 — a clean demonstration that the symmetric functions of a spectrum are accessible even when the spectrum is not."
+    ],
+    "prerequisites": [
+      "The characteristic polynomial of a matrix and its roots as eigenvalues with algebraic multiplicity",
+      "Vieta's formulas and elementary symmetric polynomials of a multiset (Multiset.esymm)",
+      "Splitting of polynomials over algebraically closed fields; the spectrum of a matrix"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and the Eigenvalue Multiset",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring stating the headline identities, the value added over Mathlib (eigenvalue count, general Vieta, singularity criterion), and the worked example; import of Mathlib, open of Matrix/Polynomial, and the reducible abbreviation eigenvalues A := A.charpoly.roots.",
+      "mathContext": "Eigenvalues with multiplicity $= \\operatorname{roots}(\\det(X I - A))$."
+    },
+    {
+      "id": "headline",
+      "title": "Trace = Sum, Determinant = Product",
+      "startLine": 49,
+      "endLine": 62,
+      "summary": "trace_eq_sum_eigenvalues and det_eq_prod_eigenvalues: the two headline spectral identities over an algebraically closed field, re-exported from Mathlib's trace_eq_sum_roots_charpoly and det_eq_prod_roots_charpoly.",
+      "mathContext": "$\\operatorname{tr} A = \\sum_i \\lambda_i,\\quad \\det A = \\prod_i \\lambda_i$."
+    },
+    {
+      "id": "count-and-vieta",
+      "title": "Eigenvalue Count and the General Vieta Formula",
+      "startLine": 63,
+      "endLine": 88,
+      "summary": "card_eigenvalues_eq_dim (there are exactly Fintype.card n eigenvalues with multiplicity) and charpoly_coeff_eq_esymm_eigenvalues (every charpoly coefficient is a signed elementary symmetric function of the eigenvalues), unifying trace and determinant as the two extreme cases.",
+      "mathContext": "$\\operatorname{coeff}_k = (-1)^{n-k} e_{n-k}(\\lambda),\\ \\#\\{\\lambda_i\\} = n$."
+    },
+    {
+      "id": "singularity",
+      "title": "Singular ⟺ Zero Is an Eigenvalue",
+      "startLine": 89,
+      "endLine": 101,
+      "summary": "det_eq_zero_iff_zero_mem_spectrum and isUnit_det_iff_zero_not_mem_spectrum: over an arbitrary field, a matrix is singular exactly when 0 lies in its spectrum, and invertible exactly when it does not.",
+      "mathContext": "$\\det A = 0 \\iff 0 \\in \\sigma(A)$."
+    },
+    {
+      "id": "example",
+      "title": "A Concrete 2×2 Complex Illustration",
+      "startLine": 102,
+      "endLine": 126,
+      "summary": "sum_eigenvalues_example, prod_eigenvalues_example, and card_eigenvalues_example: for !![1,2;3,4] over ℂ the two eigenvalues sum to 5 and multiply to -2 (read off the trace and determinant) and number exactly 2, even though the eigenvalues themselves are the irrational (5 ± √33)/2.",
+      "mathContext": "$\\lambda_{1,2} = \\tfrac{5 \\pm \\sqrt{33}}{2},\\ \\lambda_1+\\lambda_2=5,\\ \\lambda_1\\lambda_2=-2$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "minpoly-charpoly",
+      "relationship": "Companion matrix-polynomial entry on the relationship between the minimal and characteristic polynomials; this entry instead reads spectral invariants (trace, determinant, symmetric functions) off the characteristic polynomial's roots."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization that the trace and determinant of a matrix are the sum and product of its eigenvalues, packaged with the eigenvalue count (= dimension), the full Vieta correspondence expressing every characteristic-polynomial coefficient as an elementary symmetric function of the eigenvalues, and the field-general singularity criterion det = 0 ⟺ 0 is an eigenvalue.",
+    "implications": "Bridges Mathlib's characteristic-polynomial root theorems to the symmetric-function viewpoint of the spectrum, supplying an eigenvalue-count lemma and a unified Vieta statement the library lacks for the characteristic polynomial, plus a reusable singularity criterion phrased through the spectrum.",
+    "openQuestions": [
+      "Prove that the sum of the k-th powers of the eigenvalues equals trace(A^k) (Newton's identities relating power sums to the elementary symmetric functions established here).",
+      "Formalize that over an arbitrary field a matrix is invertible iff its determinant is a unit, recovering det_eq_zero_iff via the more general spectral mapping for the inverse."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial"
+    ],
+    "namespace": "SpectralTraceDetEigenvaluesOQ01",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/SpectralTraceDetEigenvaluesOQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Roger A. Horn and Charles R. Johnson",
+      "title": "Matrix Analysis",
+      "year": "2012",
+      "venue": "Cambridge University Press",
+      "note": "Standard reference for the characteristic polynomial, the trace/determinant as symmetric functions of the eigenvalues, and Vieta-type coefficient relations."
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs and Mathlib.RingTheory.Polynomial.Vieta",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Source of the trace/determinant-as-roots theorems, the spectrum/charpoly-root correspondence, and the Vieta coefficient/esymm formula specialised here to the characteristic polynomial."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes that the **trace and determinant of a matrix are the sum and product of its eigenvalues** (roots of the characteristic polynomial, with algebraic multiplicity), then derives the surrounding spectral facts Mathlib does not state for the characteristic polynomial.

Mathlib already proves the two headline identities over an algebraically closed field (`Matrix.trace_eq_sum_roots_charpoly`, `Matrix.det_eq_prod_roots_charpoly`); these are re-exported under eigenvalue-flavoured names and the entry adds the genuine content:

- **`card_eigenvalues_eq_dim`** — over an algebraically closed field there are exactly `Fintype.card n` eigenvalues counted with multiplicity.
- **`charpoly_coeff_eq_esymm_eigenvalues`** — the full **Vieta theorem**: every coefficient of the characteristic polynomial is, up to sign `(-1)^(n-k)`, the `(n-k)`-th elementary symmetric function of the eigenvalues. Trace (`k=n-1`) and determinant (`k=0`) are its two extreme cases, unifying both headline identities in one statement.
- **`det_eq_zero_iff_zero_mem_spectrum` / `isUnit_det_iff_zero_not_mem_spectrum`** — the singularity criterion `det A = 0 ⟺ 0 ∈ spectrum K A`, valid over an **arbitrary** field.
- **Concrete 2×2 example over ℂ**: `!![1,2;3,4]` has irrational eigenvalues `(5±√33)/2`, yet their sum (5), product (-2), and count (2) are read off the rational trace and determinant without ever computing them.

## Verification

- **9 theorems, 1 definition, 0 sorries, 0 axioms** (only foundational `propext`/`Classical.choice`/`Quot.sound`).
- No `decide`/`native_decide`.
- Docker build green (7743 jobs, 391s): `./proofs/scripts/docker-build.sh Proofs.SpectralTraceDetEigenvaluesOQ01`.
- Status `verified`, badge `mathlib` (headline identities are Mathlib wrappers; original content is the count, the unified Vieta, and the field-general singularity criterion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)