### PR TITLE
research(banach-steinhaus-theorem-oq-01): uniform boundedness principle, resonance, and pointwise limits (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs/BanachSteinhausTheoremOQ01.lean
+++ b/proofs/Proofs/BanachSteinhausTheoremOQ01.lean
@@ -1,0 +1,94 @@
+/-
+# The Banach–Steinhaus Theorem (Uniform Boundedness Principle)
+
+Mathlib proves the Banach–Steinhaus theorem (`banach_steinhaus`) and its
+supremum-of-norms reformulation (`banach_steinhaus_iSup_nnnorm`), and constructs the
+pointwise limit of a convergent family of continuous linear maps
+(`continuousLinearMapOfTendsto`). The proof gallery, however, has no dedicated entry
+for the uniform boundedness principle — one of the three pillars of linear functional
+analysis (alongside the open mapping and Hahn–Banach theorems), all flowing from the
+Baire category theorem.
+
+This entry packages the theorem with its two characteristic consequences, which
+Mathlib does not state in this form:
+
+* `uniform_boundedness` — the main theorem: a pointwise-bounded family of continuous
+  linear maps out of a complete (Banach) space is uniformly bounded in operator norm;
+* `uniform_boundedness_iSup` — the supremum-of-norms form;
+* `resonance` — the **condensation of singularities** consequence (the contrapositive):
+  if the operator norms are unbounded, then there is a *single* point `x` at which the
+  values `‖g i x‖` are unbounded — one resonance point witnesses the failure;
+* `pointwise_limit_isClm` — the **closure-under-pointwise-limits** corollary: a
+  pointwise limit of continuous linear maps is itself a continuous linear map;
+* `pointwise_limit_map_add` — a concrete consequence of the previous: the limit map
+  is additive.
+
+All results are verified with no axioms and no `sorry`.
+-/
+import Mathlib.Analysis.Normed.Operator.BanachSteinhaus
+import Mathlib.Tactic
+
+open Filter Topology
+open scoped ENNReal NNReal
+
+namespace BanachSteinhausTheorem
+
+variable {𝕜 𝕜₂ : Type*} [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂]
+  {σ₁₂ : 𝕜 →+* 𝕜₂} [RingHomIsometric σ₁₂]
+  {E : Type*} [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {F : Type*} [SeminormedAddCommGroup F] [NormedSpace 𝕜₂ F]
+  {ι : Type*}
+
+/-- **Banach–Steinhaus theorem (Uniform Boundedness Principle).**
+A family `g : ι → E →SL[σ₁₂] F` of continuous linear maps out of a complete (Banach)
+space `E` that is *pointwise bounded* (for every `x` the norms `‖g i x‖` are bounded by
+some constant depending only on `x`) is *uniformly bounded*: a single constant bounds
+all of the operator norms `‖g i‖`. -/
+theorem uniform_boundedness [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ x, ∃ C, ∀ i, ‖g i x‖ ≤ C) : ∃ C', ∀ i, ‖g i‖ ≤ C' :=
+  banach_steinhaus h
+
+/-- The supremum form of the uniform boundedness principle, phrased with `ℝ≥0∞`:
+if the pointwise suprema `⨆ i, ‖g i x‖₊` are all finite, then so is the supremum of the
+operator norms `⨆ i, ‖g i‖₊`. -/
+theorem uniform_boundedness_iSup [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ x, (⨆ i, (‖g i x‖₊ : ENNReal)) < ∞) : (⨆ i, (‖g i‖₊ : ENNReal)) < ∞ :=
+  banach_steinhaus_iSup_nnnorm h
+
+/-- **Condensation of singularities / resonance.**
+The contrapositive of the uniform boundedness principle: if the operator norms of a
+family of continuous linear maps out of a Banach space are *unbounded* (for every `C`
+some `g i` has norm exceeding `C`), then there is a *single* point `x` — a resonance
+point — at which the values `‖g i x‖` are unbounded. Failure of uniform boundedness is
+always witnessed at one point. -/
+theorem resonance [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ C : ℝ, ∃ i, C < ‖g i‖) : ∃ x : E, ∀ C : ℝ, ∃ i, C < ‖g i x‖ := by
+  by_contra hcon
+  push_neg at hcon
+  obtain ⟨C', hC'⟩ := uniform_boundedness hcon
+  obtain ⟨i, hi⟩ := h C'
+  exact absurd (hC' i) (not_le.mpr hi)
+
+/-- **Pointwise limits of continuous linear maps are continuous linear maps.**
+If a family `g : α → E →SL[σ₁₂] F` (indexed by any countably generated, nontrivial
+filter `l` — in particular a sequence with `l = atTop`) out of a Banach space `E`
+converges *pointwise* to a function `f`, then `f` is itself (the coercion of) a
+continuous linear map. This is the standard corollary of Banach–Steinhaus: pointwise
+boundedness of the convergent family gives equicontinuity, which makes the limit
+continuous. -/
+theorem pointwise_limit_isClm [CompleteSpace E] [T2Space F] {α : Type*} {l : Filter α}
+    [l.IsCountablyGenerated] [l.NeBot] (g : α → E →SL[σ₁₂] F) {f : E → F}
+    (h : Tendsto (fun n x ↦ g n x) l (𝓝 f)) :
+    ∃ F' : E →SL[σ₁₂] F, ∀ x, F' x = f x :=
+  ⟨continuousLinearMapOfTendsto g h, fun _ ↦ rfl⟩
+
+/-- A concrete consequence of `pointwise_limit_isClm`: the pointwise limit of a
+convergent family of continuous linear maps is additive. -/
+theorem pointwise_limit_map_add [CompleteSpace E] [T2Space F] {α : Type*} {l : Filter α}
+    [l.IsCountablyGenerated] [l.NeBot] (g : α → E →SL[σ₁₂] F) {f : E → F}
+    (h : Tendsto (fun n x ↦ g n x) l (𝓝 f)) (x y : E) :
+    f (x + y) = f x + f y := by
+  obtain ⟨F', hF'⟩ := pointwise_limit_isClm g h
+  rw [← hF', ← hF', ← hF', map_add]
+
+end BanachSteinhausTheorem

--- a/src/data/proofs/banach-steinhaus-theorem-oq-01/meta.json
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01/meta.json
@@ -1,0 +1,154 @@
+{
+  "id": "banach-steinhaus-theorem-oq-01",
+  "title": "The Banach–Steinhaus Theorem: uniform boundedness, resonance, and pointwise limits",
+  "slug": "banach-steinhaus-theorem-oq-01",
+  "description": "Mathlib proves the Banach–Steinhaus theorem (`banach_steinhaus`) and its supremum form, and constructs the pointwise limit of a convergent family of continuous linear maps, but the gallery has no dedicated entry for the uniform boundedness principle — one of the three pillars of linear functional analysis. This entry packages the main theorem with its two characteristic consequences in usable form: the condensation-of-singularities contrapositive (unbounded operator norms force a single resonance point where the values blow up) and the closure-under-pointwise-limits corollary (a pointwise limit of continuous linear maps is again continuous linear, hence additive).",
+  "meta": {
+    "author": "Stefan Banach / Hugo Steinhaus (1927); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BanachSteinhausTheoremOQ01.lean",
+    "tags": [
+      "analysis",
+      "functional-analysis",
+      "banach-space",
+      "operator-theory",
+      "uniform-boundedness",
+      "baire-category",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "banach_steinhaus",
+        "description": "The Banach–Steinhaus theorem: a pointwise-bounded family of continuous linear maps out of a complete space is uniformly bounded in operator norm",
+        "module": "Mathlib.Analysis.Normed.Operator.BanachSteinhaus"
+      },
+      {
+        "theorem": "banach_steinhaus_iSup_nnnorm",
+        "description": "The supremum form, phrased in ℝ≥0∞: pointwise-finite suprema of values imply a finite supremum of operator norms",
+        "module": "Mathlib.Analysis.Normed.Operator.BanachSteinhaus"
+      },
+      {
+        "theorem": "continuousLinearMapOfTendsto",
+        "description": "Given a pointwise-convergent family of continuous linear maps out of a complete space, packages the limit as a bundled continuous linear map (uses Banach–Steinhaus to get equicontinuity, hence continuity of the limit)",
+        "module": "Mathlib.Analysis.Normed.Operator.BanachSteinhaus"
+      }
+    ],
+    "originalContributions": [
+      "uniform_boundedness: the main theorem restated as the gallery headline — a pointwise-bounded family of continuous linear maps out of a Banach space is uniformly bounded in operator norm",
+      "uniform_boundedness_iSup: the supremum-of-norms reformulation in ℝ≥0∞",
+      "resonance: the condensation-of-singularities consequence (contrapositive of the theorem) — if the operator norms are unbounded then there is a single point x at which the values ‖g i x‖ are unbounded; failure of uniform boundedness is always witnessed at one resonance point. Not stated in Mathlib",
+      "pointwise_limit_isClm: the closure-under-pointwise-limits corollary — a pointwise limit (over any countably generated nontrivial filter, e.g. a sequence) of continuous linear maps is itself the coercion of a continuous linear map, packaged as an existence statement Mathlib leaves implicit in `continuousLinearMapOfTendsto`",
+      "pointwise_limit_map_add: a concrete applied consequence — the pointwise limit map is additive, f(x+y) = f x + f y"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 94,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The uniform boundedness principle, proved by Stefan Banach and Hugo Steinhaus in 1927 (with an essential contribution from the Baire category theorem), is one of the three cornerstones of linear functional analysis, alongside the open mapping/closed graph theorems and the Hahn–Banach theorem. Its striking content is that a purely *pointwise* hypothesis — boundedness of ‖g i x‖ for each fixed x — upgrades automatically to a *uniform* conclusion about the operator norms. The contrapositive, the principle of condensation of singularities, produces a single point at which a divergent family of operators resonates; it is the standard route to existence results such as continuous functions whose Fourier series diverge.",
+    "problemStatement": "Mathlib records the theorem (`banach_steinhaus`), its supremum form (`banach_steinhaus_iSup_nnnorm`), and the bundled pointwise-limit map (`continuousLinearMapOfTendsto`), but the gallery has no entry naming the uniform boundedness principle, and neither the resonance contrapositive nor the 'pointwise limit of operators is an operator' corollary is stated in a directly usable form. Can these be assembled cleanly and verified with no axioms?\n\n**Answer:** Yes. The main theorem and supremum form are restated directly; the resonance statement is the contrapositive obtained by `push_neg` over the theorem; and the limit corollary reads the existence of the bundled continuous linear map off `continuousLinearMapOfTendsto`, with additivity as an immediate concrete consequence.",
+    "text": "The Banach–Steinhaus theorem (pointwise-bounded ⟹ uniformly-bounded family of continuous linear maps out of a Banach space), its ℝ≥0∞ supremum form, the condensation-of-singularities resonance contrapositive, and the closure of continuous linear maps under pointwise limits — all verified in Lean with no axioms.",
+    "proofStrategy": "1. uniform_boundedness: apply Mathlib's `banach_steinhaus` to the pointwise-bound hypothesis.\n2. uniform_boundedness_iSup: apply `banach_steinhaus_iSup_nnnorm`.\n3. resonance: by contradiction; `push_neg` turns the negated '∃ resonance point' into exactly the pointwise-bounded hypothesis of the theorem, whose uniform bound C' contradicts the assumption that some operator norm exceeds C'.\n4. pointwise_limit_isClm: take the witness `continuousLinearMapOfTendsto g h`; its coercion is the limit function f by construction (the underlying linear map is `linearMapOfTendsto`, whose coercion is f), so each F' x = f x holds by reflexivity.\n5. pointwise_limit_map_add: rewrite f through the continuous linear map of (4) and apply `map_add`.",
+    "keyInsights": [
+      "**Pointwise ⟹ uniform is the whole miracle**: the hypothesis only constrains each `x` separately, yet the conclusion is a single constant bounding *all* operator norms. The mechanism is Baire category — completeness of the domain forces one of the sublevel sets to have nonempty interior.",
+      "**Resonance is the contrapositive, and `push_neg` makes it mechanical**: negating 'there is a point where the values blow up' yields precisely 'the family is pointwise bounded', so the contrapositive of Banach–Steinhaus is a one-step transformation. The mathematical payload — a *single* universal resonance point — is what makes condensation of singularities useful.",
+      "**Pointwise limits of operators are operators**: this closure property is the reason the space of continuous linear maps behaves well under limiting arguments; it is the engine behind defining operators as limits of approximations. Here the limit's continuity is itself a Banach–Steinhaus consequence (the convergent family is pointwise bounded, hence equicontinuous).",
+      "**One filter, many index sets**: the limit corollary is stated for an arbitrary countably generated nontrivial filter, so it covers sequential limits (`atTop` on ℕ) and any net reducible to a sequence, without separate proofs."
+    ],
+    "prerequisites": [
+      "Normed and Banach spaces; continuous linear maps and the operator norm",
+      "Completeness and the Baire category theorem",
+      "Pointwise vs. uniform boundedness; equicontinuity",
+      "Filters and pointwise convergence in Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Statement",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "File-level docstring framing the gap: Mathlib proves Banach–Steinhaus and builds the pointwise-limit map but the gallery has no uniform-boundedness entry and no usable resonance/limit corollaries. Imports `Analysis.Normed.Operator.BanachSteinhaus` and sets up the Banach-space variable context.",
+      "mathContext": "The uniform boundedness principle for continuous linear maps between normed spaces."
+    },
+    {
+      "id": "main-theorem",
+      "title": "The Theorem and its Supremum Form",
+      "startLine": 41,
+      "endLine": 55,
+      "summary": "uniform_boundedness restates `banach_steinhaus` (pointwise-bounded ⟹ uniformly-bounded operator norms) as the headline; uniform_boundedness_iSup restates the ℝ≥0∞ supremum form `banach_steinhaus_iSup_nnnorm`.",
+      "mathContext": "Banach–Steinhaus: pointwise boundedness implies uniform boundedness in operator norm."
+    },
+    {
+      "id": "resonance",
+      "title": "Condensation of Singularities",
+      "startLine": 57,
+      "endLine": 69,
+      "summary": "resonance is the contrapositive: unbounded operator norms force a single point x where ‖g i x‖ is unbounded. Proof negates the goal, `push_neg` recovers the pointwise-bound hypothesis, and the resulting uniform bound contradicts the unboundedness assumption.",
+      "mathContext": "The principle of condensation of singularities — a universal resonance point witnesses non-uniform-boundedness."
+    },
+    {
+      "id": "pointwise-limits",
+      "title": "Pointwise Limits of Operators",
+      "startLine": 71,
+      "endLine": 93,
+      "summary": "pointwise_limit_isClm: a pointwise limit of continuous linear maps (over any countably generated nontrivial filter) is the coercion of a continuous linear map, via `continuousLinearMapOfTendsto`. pointwise_limit_map_add: a concrete consequence — the limit map is additive.",
+      "mathContext": "Closure of continuous linear maps under pointwise limits, a Banach–Steinhaus corollary."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Banach, Stefan; Steinhaus, Hugo",
+      "title": "Sur le principe de la condensation de singularités",
+      "year": "1927",
+      "note": "Fundamenta Mathematicae 9, 50–61 — the original uniform boundedness principle and condensation of singularities"
+    },
+    {
+      "authors": "Rudin, Walter",
+      "title": "Functional Analysis",
+      "year": "1991",
+      "note": "Theorem 2.5 (Banach–Steinhaus) and Theorem 2.7 (condensation of singularities)"
+    },
+    {
+      "authors": "Brezis, Haïm",
+      "title": "Functional Analysis, Sobolev Spaces and Partial Differential Equations",
+      "year": "2011",
+      "note": "Theorem 2.2 (uniform boundedness) and Corollary 2.3 (pointwise limits of operators)"
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": {
+    "summary": "The Banach–Steinhaus theorem (uniform_boundedness), its supremum form (uniform_boundedness_iSup), the condensation-of-singularities contrapositive (resonance), and the closure of continuous linear maps under pointwise limits (pointwise_limit_isClm, with additivity pointwise_limit_map_add) are packaged from Mathlib's `banach_steinhaus` and `continuousLinearMapOfTendsto`. All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies a dedicated gallery statement of one of the three pillars of functional analysis, together with the two consequences practitioners actually invoke: a single resonance point for divergent operator families, and the fact that pointwise limits of operators remain operators.",
+    "openQuestions": [
+      "Can the standard application be formalized — that there exists a continuous 2π-periodic function whose Fourier series diverges at a point — via the resonance statement applied to the partial-sum operators?",
+      "Does the quantitative refinement hold, that the resonance set (points where the values are unbounded) is comeagre, not merely nonempty, packaging the Baire-category strengthening of the contrapositive?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Normed.Operator.BanachSteinhaus",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Topology",
+      "scoped ENNReal",
+      "scoped NNReal"
+    ],
+    "namespace": "BanachSteinhausTheorem",
+    "lineCount": 94,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/BanachSteinhausTheoremOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds a dedicated gallery entry for the **Banach–Steinhaus theorem (uniform boundedness principle)** — one of the three pillars of linear functional analysis, alongside the open mapping/closed graph and Hahn–Banach theorems. Mathlib proves the core theorem (`banach_steinhaus`) and builds the pointwise-limit map (`continuousLinearMapOfTendsto`), but the gallery had no entry naming the principle, and neither the resonance contrapositive nor the closure-under-pointwise-limits corollary is stated in a directly usable form.

## Results (5 theorems, 0 definitions, 94 lines)

- **`uniform_boundedness`** — the headline: a pointwise-bounded family of continuous linear maps out of a Banach space is uniformly bounded in operator norm.
- **`uniform_boundedness_iSup`** — the `ℝ≥0∞` supremum-of-norms reformulation.
- **`resonance`** — **condensation of singularities** (contrapositive): if the operator norms are unbounded, there is a *single* point `x` at which `‖g i x‖` is unbounded. Obtained mechanically via `push_neg` over the theorem. Not stated in Mathlib.
- **`pointwise_limit_isClm`** — **closure under pointwise limits**: a pointwise limit (over any countably generated nontrivial filter, e.g. a sequence) of continuous linear maps is itself a continuous linear map, packaged as an existence statement Mathlib leaves implicit.
- **`pointwise_limit_map_add`** — a concrete consequence: the limit map is additive.

## Verification

- Docker build succeeds (`./proofs/scripts/docker-build.sh Proofs.BanachSteinhausTheoremOQ01`).
- `#print axioms` on all 5 theorems: only `propext`, `Classical.choice`, `Quot.sound`.
- **0 axioms, 0 sorries, no `native_decide`.** Status `verified`, badge `mathlib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)