### PR TITLE
research(uniformbell-multinomial-oq-01): uniform Bell numbers and the multinomial structure of equal-block partitions (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3381,6 +3381,7 @@ import Proofs.TwinPrimesSpecialOQ01
 import Proofs.UnitDistanceHN7
 import Proofs.UnitDistanceHN7Aristotle
 import Proofs.UnitDistanceIndependence
+import Proofs.UniformBellMultinomialOQ01
 import Proofs.UrysohnsLemmaOQ01
 import Proofs.VanAubelTheoremOQ01
 import Proofs.VandermondeInterpolationOQ01

--- a/proofs/Proofs/UniformBellMultinomialOQ01.lean
+++ b/proofs/Proofs/UniformBellMultinomialOQ01.lean
@@ -1,0 +1,119 @@
+/-
+# Uniform Bell numbers and the multinomial structure of equal-block partitions
+
+`Nat.uniformBell m n` counts the partitions of an `m·n`-element set into `m`
+*unordered* blocks, each of size `n`.  Pinned Mathlib defines it as
+`Multiset.bell (Multiset.replicate m n)` and records the cornerstone structural
+identity
+
+    uniformBell m n · (n!)^m · m! = (m·n)!            (`Nat.uniformBell_mul_eq`)
+
+together with its division form
+`uniformBell m n = (m·n)! / ((n!)^m · m!)` (`Nat.uniformBell_eq_div`).  This file
+re-exports those two cornerstones and then adds the material the gallery — and
+Mathlib — lack:
+
+* **Ordered vs. unordered blocks.**  The number of ways to split `m·n` labelled
+  items into `m` *ordered* blocks of size `n` is the multinomial coefficient
+  `multinomial (range m) (fun _ => n)`.  We prove the ordered count
+      (n!)^m · multinomial (range m) (const n) = (m·n)!
+  (`multinomial_range_const`) and the bridge
+      uniformBell m n · m! = multinomial (range m) (const n)
+  (`uniformBell_mul_factorial`), making precise that "forgetting the order of the
+  `m` equal blocks" divides the ordered count by exactly `m!`.
+* **Positivity** `0 < uniformBell m n` — an equal-block partition always exists.
+* **A factorial divisibility corollary** `(n!)^m · m! ∣ (m·n)!`, the integrality
+  statement underlying the closed form.
+* **Concrete instances** `uniformBell 2 2 = 3`, `uniformBell 2 3 = 10`,
+  `uniformBell 3 2 = 15`, checked against the closed product form.
+
+## Main results (0 sorry, 0 axiom, no `native_decide`)
+* `uniformBell_mul_eq'`        — `uniformBell m n · (n!)^m · m! = (m·n)!` (re-export)
+* `uniformBell_eq_div'`        — division form (re-export)
+* `multinomial_range_const`    — `(n!)^m · multinomial (range m) (const n) = (m·n)!`
+* `uniformBell_mul_factorial`  — `uniformBell m n · m! = multinomial (range m) (const n)`
+* `uniformBell_pos`            — `0 < uniformBell m n`
+* `factorial_pow_mul_factorial_dvd` — `(n!)^m · m! ∣ (m·n)!`
+* `uniformBell_two_two`, `uniformBell_two_three`, `uniformBell_three_two`
+
+Fully machine-checked, no extra axioms, no `native_decide`.
+-/
+
+import Mathlib.Combinatorics.Enumerative.Bell
+import Mathlib.Data.Nat.Choose.Multinomial
+import Mathlib.Tactic
+
+namespace UniformBellMultinomialOQ01
+
+open Nat Finset
+
+/-- **Re-export of the cornerstone uniform-Bell identity.**  Splitting an
+`m·n`-element set into `m` unordered blocks of size `n` satisfies
+`uniformBell m n · (n!)^m · m! = (m·n)!`. -/
+theorem uniformBell_mul_eq' (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
+    uniformBell m n * n ! ^ m * m ! = (m * n)! :=
+  Nat.uniformBell_mul_eq m hn
+
+/-- **Re-export of the division form** `uniformBell m n = (m·n)! / ((n!)^m · m!)`. -/
+theorem uniformBell_eq_div' (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
+    uniformBell m n = (m * n)! / (n ! ^ m * m !) :=
+  Nat.uniformBell_eq_div m hn
+
+/-- **Ordered equal-block count.**  The number of ways to split `m·n` labelled
+items into a sequence of `m` *ordered* blocks of size `n` is the multinomial
+coefficient `multinomial (range m) (const n)`, and it satisfies
+`(n!)^m · multinomial (range m) (const n) = (m·n)!`.  This is the "ordered"
+analogue of `uniformBell_mul_eq`. -/
+theorem multinomial_range_const (m n : ℕ) :
+    n ! ^ m * Nat.multinomial (Finset.range m) (fun _ => n) = (m * n)! := by
+  have h := Nat.multinomial_spec (Finset.range m) (fun _ => n)
+  simpa [Finset.prod_const, Finset.sum_const, Finset.card_range, smul_eq_mul] using h
+
+/-- **The unordered/ordered bridge.**  Forgetting the order of the `m` equal-size
+blocks divides the ordered count by exactly `m!`:
+`uniformBell m n · m! = multinomial (range m) (const n)`. -/
+theorem uniformBell_mul_factorial (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
+    uniformBell m n * m ! = Nat.multinomial (Finset.range m) (fun _ => n) := by
+  have hpos : 0 < n ! ^ m := pow_pos (Nat.factorial_pos n) m
+  apply Nat.eq_of_mul_eq_mul_left hpos
+  calc n ! ^ m * (uniformBell m n * m !)
+      = uniformBell m n * n ! ^ m * m ! := by ring
+    _ = (m * n)! := Nat.uniformBell_mul_eq m hn
+    _ = n ! ^ m * Nat.multinomial (Finset.range m) (fun _ => n) :=
+        (multinomial_range_const m n).symm
+
+/-- **Positivity.**  An equal-block partition always exists, so `0 < uniformBell m n`. -/
+theorem uniformBell_pos (m n : ℕ) : 0 < uniformBell m n := by
+  rcases Nat.eq_zero_or_pos (uniformBell m n) with h0 | h0
+  · exfalso
+    rcases Nat.eq_zero_or_pos n with hn | hn
+    · rw [hn, Nat.uniformBell_zero_right] at h0
+      exact one_ne_zero h0
+    · have h := Nat.uniformBell_mul_eq m hn.ne'
+      rw [h0, zero_mul, zero_mul] at h
+      exact Nat.factorial_ne_zero _ h.symm
+  · exact h0
+
+/-- **Factorial divisibility corollary.**  The denominator of the closed form
+divides the factorial: `(n!)^m · m! ∣ (m·n)!`.  This is the integrality statement
+that makes `uniformBell_eq_div` an honest natural number. -/
+theorem factorial_pow_mul_factorial_dvd (m : ℕ) {n : ℕ} (hn : n ≠ 0) :
+    n ! ^ m * m ! ∣ (m * n)! :=
+  ⟨uniformBell m n, by rw [← Nat.uniformBell_mul_eq m hn]; ring⟩
+
+/-- `uniformBell 2 2 = 3`: the three pairings of a 4-element set into two pairs. -/
+theorem uniformBell_two_two : uniformBell 2 2 = 3 := by
+  simp only [Nat.uniformBell_eq, Finset.prod_range_succ, Finset.prod_range_zero]
+  decide
+
+/-- `uniformBell 2 3 = 10`: splits of a 6-element set into two triples. -/
+theorem uniformBell_two_three : uniformBell 2 3 = 10 := by
+  simp only [Nat.uniformBell_eq, Finset.prod_range_succ, Finset.prod_range_zero]
+  decide
+
+/-- `uniformBell 3 2 = 15`: splits of a 6-element set into three pairs. -/
+theorem uniformBell_three_two : uniformBell 3 2 = 15 := by
+  simp only [Nat.uniformBell_eq, Finset.prod_range_succ, Finset.prod_range_zero]
+  decide
+
+end UniformBellMultinomialOQ01

--- a/src/data/proofs/uniformbell-multinomial-oq-01/annotations.json
+++ b/src/data/proofs/uniformbell-multinomial-oq-01/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-imports-docstring",
+    "proofId": "uniformbell-multinomial-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
+    "type": "concept",
+    "title": "Uniform Bell Numbers",
+    "content": "Nat.uniformBell m n counts the partitions of an m·n-element set into m unordered blocks, each of size exactly n. Mathlib defines it as Multiset.bell (replicate m n) and proves the cornerstone identity uniformBell m n · (n!)^m · m! = (m·n)! together with the division form uniformBell m n = (m·n)! / ((n!)^m · m!). The surrounding theory — how it relates to the multinomial coefficient, that it is positive, and that the denominator divides the factorial — is absent from Mathlib and is what this file supplies.",
+    "mathContext": "$\\operatorname{uniformBell}(m,n)$ = number of partitions of an $mn$-set into $m$ unordered $n$-blocks; $\\operatorname{uniformBell}(m,n)\\,(n!)^m\\,m! = (mn)!$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bell numbers",
+      "set partitions",
+      "equal-block partitions",
+      "Nat.uniformBell"
+    ],
+    "prerequisites": [
+      "finite set partitions",
+      "factorials"
+    ]
+  },
+  {
+    "id": "ann-ordered-count",
+    "proofId": "uniformbell-multinomial-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 74
+    },
+    "type": "key-step",
+    "title": "The Ordered Equal-Block Count",
+    "content": "multinomial_range_const specialises Mathlib's multinomial_spec — (∏ i ∈ s, (f i)!) · multinomial s f = (∑ i ∈ s, f i)! — to the constant function fun _ => n over Finset.range m. The product of factorials simplifies via prod_const and card_range to (n!)^m, and the sum simplifies via sum_const, card_range, and smul_eq_mul to m·n, giving (n!)^m · multinomial (range m) (const n) = (m·n)!. This is the ordered analogue of uniformBell_mul_eq: it counts splits of the m·n items into a SEQUENCE of m blocks of size n.",
+    "mathContext": "The number of ordered $m$-tuples of size-$n$ blocks is the multinomial coefficient $\\binom{mn}{n,\\dots,n} = (mn)!/(n!)^m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "multinomial coefficient",
+      "Nat.multinomial_spec",
+      "Finset.prod_const",
+      "ordered partitions"
+    ],
+    "prerequisites": [
+      "multinomial coefficients",
+      "Finset sums and products over range"
+    ]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "uniformbell-multinomial-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 84
+    },
+    "type": "key-step",
+    "title": "The Unordered/Ordered Bridge",
+    "content": "uniformBell_mul_factorial proves uniformBell m n · m! = multinomial (range m) (const n) for n ≠ 0. Both uniformBell_mul_eq and multinomial_range_const express (m·n)! as (n!)^m times a cofactor; equating them and cancelling the positive factor (n!)^m with Nat.eq_of_mul_eq_mul_left isolates the bridge. Combinatorially it says the m equal-size blocks can be permuted in m! ways without changing the underlying partition, so the ordered count is exactly m! times the unordered count — all carried out over ℕ with no division.",
+    "mathContext": "$\\operatorname{uniformBell}(m,n)\\cdot m! = \\binom{mn}{n,\\dots,n}$: forgetting the order of the $m$ equal blocks divides by $m!$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "multinomial coefficient",
+      "Nat.eq_of_mul_eq_mul_left",
+      "ordered vs unordered partitions"
+    ],
+    "prerequisites": [
+      "left cancellation in ℕ",
+      "the ordered equal-block count"
+    ]
+  },
+  {
+    "id": "ann-positivity-divisibility",
+    "proofId": "uniformbell-multinomial-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 103
+    },
+    "type": "key-step",
+    "title": "Positivity and Divisibility",
+    "content": "uniformBell_pos shows 0 < uniformBell m n: were the count zero, uniformBell_mul_eq would force (m·n)! = 0, contradicting factorial_ne_zero (the n = 0 case is uniformBell m 0 = 1). factorial_pow_mul_factorial_dvd then records (n!)^m · m! ∣ (m·n)!, witnessed directly by uniformBell m n through the structural identity — this is precisely the integrality statement that makes the division form an honest natural number.",
+    "mathContext": "$0 < \\operatorname{uniformBell}(m,n)$ and $(n!)^m\\,m! \\mid (mn)!$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.factorial_ne_zero",
+      "divisibility in ℕ",
+      "Dvd.intro"
+    ],
+    "prerequisites": [
+      "factorials are nonzero",
+      "divisibility as existence of a cofactor"
+    ]
+  },
+  {
+    "id": "ann-instances",
+    "proofId": "uniformbell-multinomial-oq-01",
+    "range": {
+      "startLine": 104,
+      "endLine": 119
+    },
+    "type": "example",
+    "title": "Concrete Instances",
+    "content": "uniformBell 2 2 = 3, uniformBell 2 3 = 10, and uniformBell 3 2 = 15 are verified by rewriting with the closed product form uniformBell_eq, expanding the range product with prod_range_succ down to prod_range_zero, and closing the resulting numeric goal with kernel `decide` (not native_decide, so no Lean.ofReduceBool is introduced). These read off as: 3 ways to split a 4-set into two pairs, 10 ways to split a 6-set into two triples, and 15 ways into three pairs.",
+    "mathContext": "$\\operatorname{uniformBell}(2,2)=3,\\ \\operatorname{uniformBell}(2,3)=10,\\ \\operatorname{uniformBell}(3,2)=15$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.uniformBell_eq",
+      "Finset.prod_range_succ",
+      "kernel decide"
+    ],
+    "prerequisites": [
+      "evaluating finite products",
+      "binomial coefficients"
+    ]
+  }
+]

--- a/src/data/proofs/uniformbell-multinomial-oq-01/meta.json
+++ b/src/data/proofs/uniformbell-multinomial-oq-01/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "uniformbell-multinomial-oq-01",
+  "title": "Uniform Bell numbers: the multinomial structure of equal-block partitions",
+  "slug": "uniformbell-multinomial-oq-01",
+  "description": "The uniform Bell number uniformBell m n counts the partitions of an m·n-element set into m unordered blocks of size n. Mathlib records the cornerstone identity uniformBell m n · (n!)^m · m! = (m·n)! and its division form, but stops there. This entry re-exports those cornerstones and adds the missing surrounding theory: the ordered-block multinomial count, the bridge that forgetting block order divides by m!, positivity, the factorial divisibility corollary, and concrete instances.",
+  "meta": {
+    "author": "E. T. Bell / classical combinatorics",
+    "status": "verified",
+    "proofRepoPath": "Proofs/UniformBellMultinomialOQ01.lean",
+    "tags": [
+      "combinatorics",
+      "bell-numbers",
+      "multinomial",
+      "set-partitions",
+      "enumerative",
+      "factorial",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.uniformBell_mul_eq",
+        "description": "The cornerstone identity uniformBell m n · (n!)^m · m! = (m·n)! for n ≠ 0",
+        "module": "Mathlib.Combinatorics.Enumerative.Bell"
+      },
+      {
+        "theorem": "Nat.uniformBell_eq_div",
+        "description": "Division form uniformBell m n = (m·n)! / ((n!)^m · m!)",
+        "module": "Mathlib.Combinatorics.Enumerative.Bell"
+      },
+      {
+        "theorem": "Nat.uniformBell_eq",
+        "description": "Closed product form uniformBell m n = ∏_{p<m} C(p·n + n − 1, n − 1), used to evaluate concrete instances",
+        "module": "Mathlib.Combinatorics.Enumerative.Bell"
+      },
+      {
+        "theorem": "Nat.multinomial_spec",
+        "description": "(∏ i ∈ s, (f i)!) · multinomial s f = (∑ i ∈ s, f i)!, specialised to the constant function to count ordered blocks",
+        "module": "Mathlib.Data.Nat.Choose.Multinomial"
+      }
+    ],
+    "originalContributions": [
+      "multinomial_range_const: the ordered equal-block count (n!)^m · multinomial (range m) (fun _ => n) = (m·n)!, the ordered analogue of uniformBell_mul_eq, absent from Mathlib",
+      "uniformBell_mul_factorial: the bridge uniformBell m n · m! = multinomial (range m) (fun _ => n), making precise that forgetting the order of the m equal blocks divides the ordered count by exactly m!",
+      "uniformBell_pos: 0 < uniformBell m n for all m, n (an equal-block partition always exists), not recorded in Mathlib",
+      "factorial_pow_mul_factorial_dvd: the divisibility (n!)^m · m! ∣ (m·n)!, the integrality statement underlying the division form",
+      "uniformBell_two_two, uniformBell_two_three, uniformBell_three_two: concrete values 3, 10, 15 verified against the closed product form"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound. Concrete instances use kernel `decide` (no `native_decide`, so no `Lean.ofReduceBool`).",
+    "lineCount": 119,
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Bell numbers and their refinements count set partitions, a central object of enumerative combinatorics going back to E. T. Bell. The uniform (or equal-block) Bell number uniformBell m n is the number of ways to partition an m·n-element set into m unordered blocks, each of size exactly n. It is the m·n / (n,…,n) case of the partition-into-blocks-of-prescribed-sizes count and is intimately tied to the multinomial coefficient: the number of ways to split the same set into m ORDERED blocks of size n is the multinomial (m·n)! / (n!)^m, and dividing by m! to forget the order of the equal-size blocks recovers uniformBell m n.",
+    "problemStatement": "Determine the multinomial structure of equal-block set partitions: relate uniformBell m n (unordered blocks) to the multinomial coefficient (ordered blocks), establish positivity and divisibility, and verify concrete values.",
+    "text": "uniformBell m n counts partitions of an m·n-set into m unordered blocks of size n. It satisfies uniformBell m n · (n!)^m · m! = (m·n)! and equals the multinomial ordered-block count divided by m!.",
+    "proofStrategy": "1. Re-export the Mathlib cornerstones uniformBell_mul_eq and uniformBell_eq_div. 2. multinomial_range_const: specialise Nat.multinomial_spec to the constant function fun _ => n over Finset.range m; the product of factorials becomes (n!)^m (prod_const + card_range) and the sum becomes m·n (sum_const + card_range + smul_eq_mul), giving (n!)^m · multinomial = (m·n)!. 3. uniformBell_mul_factorial: both uniformBell_mul_eq and multinomial_range_const express (m·n)! as (n!)^m times something; cancel the positive factor (n!)^m via Nat.eq_of_mul_eq_mul_left to read off uniformBell m n · m! = multinomial. 4. uniformBell_pos: if uniformBell m n were 0 then uniformBell_mul_eq forces (m·n)! = 0, contradicting factorial_ne_zero (the n = 0 case is uniformBell m 0 = 1). 5. factorial_pow_mul_factorial_dvd: exhibit uniformBell m n as the cofactor in uniformBell_mul_eq. 6. Concrete instances: rewrite with uniformBell_eq, expand the range product with prod_range_succ, and close the numeric goal with kernel decide.",
+    "keyInsights": [
+      "**Ordered vs. unordered blocks.** The multinomial (m·n)! / (n!)^m counts ordered tuples of m blocks of size n; the m equal-size blocks can be permuted in m! ways without changing the underlying partition, so uniformBell m n · m! = multinomial — the single clean identity organising the whole picture.",
+      "**Cancellation over ℕ.** Both the ordered and unordered identities pin (m·n)! as (n!)^m times a cofactor; since (n!)^m > 0, left-cancellation in ℕ gives the bridge directly, with no division.",
+      "**Filling a Mathlib gap.** Mathlib proves uniformBell_mul_eq and its division form but neither the multinomial bridge, positivity, nor the denominator-divides-factorial corollary; this entry supplies all three.",
+      "**Integrality is a corollary, not an assumption.** That (m·n)! / ((n!)^m · m!) is an honest natural number is exactly the divisibility (n!)^m · m! ∣ (m·n)!, which falls straight out of the structural identity."
+    ],
+    "prerequisites": [
+      "Set partitions and the (uniform) Bell numbers",
+      "Multinomial coefficients",
+      "Factorials and natural-number divisibility"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "File-level docstring describing uniformBell m n, the cornerstone identity, and the additions. Imports Mathlib's Bell and Multinomial files and opens Nat and Finset.",
+      "mathContext": "uniformBell m n = Multiset.bell (replicate m n) counts equal-block partitions; Mathlib supplies the structural identity and division form."
+    },
+    {
+      "id": "reexports",
+      "title": "Re-exported Cornerstones",
+      "startLine": 52,
+      "endLine": 65,
+      "summary": "uniformBell_mul_eq' and uniformBell_eq_div' restate the two Mathlib cornerstones with the gallery's naming.",
+      "mathContext": "uniformBell m n · (n!)^m · m! = (m·n)! and its division form."
+    },
+    {
+      "id": "ordered-count",
+      "title": "The Ordered Equal-Block Count",
+      "startLine": 66,
+      "endLine": 74,
+      "summary": "multinomial_range_const: specialise multinomial_spec to the constant function over range m, simplifying the product to (n!)^m and the sum to m·n.",
+      "mathContext": "The number of ordered m-tuples of size-n blocks is the multinomial (m·n)! / (n!)^m."
+    },
+    {
+      "id": "bridge",
+      "title": "The Unordered/Ordered Bridge",
+      "startLine": 75,
+      "endLine": 84,
+      "summary": "uniformBell_mul_factorial: cancel the positive factor (n!)^m from the two equal-block identities to obtain uniformBell m n · m! = multinomial (range m) (const n).",
+      "mathContext": "Forgetting the order of the m equal blocks divides the ordered count by exactly m!."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity",
+      "startLine": 85,
+      "endLine": 98,
+      "summary": "uniformBell_pos: 0 < uniformBell m n. If it were 0, uniformBell_mul_eq forces (m·n)! = 0, impossible; the n = 0 case uses uniformBell m 0 = 1.",
+      "mathContext": "An equal-block partition always exists, so the count is strictly positive."
+    },
+    {
+      "id": "divisibility",
+      "title": "Factorial Divisibility",
+      "startLine": 99,
+      "endLine": 103,
+      "summary": "factorial_pow_mul_factorial_dvd: (n!)^m · m! ∣ (m·n)!, witnessed by uniformBell m n via the structural identity.",
+      "mathContext": "The denominator of the closed form divides the factorial — the integrality statement."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances",
+      "startLine": 104,
+      "endLine": 119,
+      "summary": "uniformBell 2 2 = 3, uniformBell 2 3 = 10, uniformBell 3 2 = 15: rewrite with the closed product form, expand with prod_range_succ, close with kernel decide.",
+      "mathContext": "3 ways to pair a 4-set, 10 ways to split a 6-set into two triples, 15 ways into three pairs."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Bell, E. T.",
+      "title": "Exponential numbers",
+      "year": "1934",
+      "note": "Origin of the Bell numbers counting set partitions"
+    },
+    {
+      "authors": "Graham, Knuth, Patashnik",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "note": "Chapter 6 develops set partitions, multinomial coefficients, and equal-block counts"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "bell-numbers-oq-01",
+      "relationship": "related",
+      "description": "Bell-numbers-oq-01 connects the standard Bell number to the Stirling row sum; this entry treats the distinct uniform (equal-block) Bell number and its multinomial structure"
+    },
+    {
+      "targetId": "stirling-second-kind-oq-01",
+      "relationship": "related",
+      "description": "Both count set partitions; Stirling S(n,k) fixes the number of blocks, uniformBell fixes the common block size"
+    }
+  ],
+  "conclusion": {
+    "summary": "uniformBell m n counts equal-block set partitions and satisfies uniformBell m n · (n!)^m · m! = (m·n)!. Beyond re-exporting this cornerstone and its division form, the entry proves the ordered-block multinomial count (multinomial_range_const), the bridge uniformBell m n · m! = multinomial (range m) (const n) that converts ordered to unordered by dividing out m! (uniformBell_mul_factorial), positivity (uniformBell_pos), the divisibility (n!)^m · m! ∣ (m·n)! (factorial_pow_mul_factorial_dvd), and three concrete values. All are verified with 0 axioms and 0 sorries.",
+    "implications": "Provides the multinomial scaffolding around Mathlib's uniform Bell identity — the ordered/unordered bridge, positivity, and integrality — as directly citable lemmas.",
+    "openQuestions": [
+      "Does the bridge generalise to blocks of prescribed (non-uniform) sizes, i.e. Multiset.bell m · ∏ (multiplicities)! = multinomial of the size profile?",
+      "Can uniformBell m n be characterised as the cardinality of an explicit Finset of partitions, connecting the arithmetic identity to a bijective count?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.Enumerative.Bell",
+      "Mathlib.Data.Nat.Choose.Multinomial",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "UniformBellMultinomialOQ01",
+    "lineCount": 119,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/UniformBellMultinomialOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

`Nat.uniformBell m n` counts the partitions of an `m·n`-element set into `m` **unordered** blocks, each of size `n`. Pinned Mathlib records the cornerstone identity `uniformBell m n · (n!)^m · m! = (m·n)!` and its division form, but stops there. This entry re-exports those cornerstones and supplies the missing surrounding theory.

## Results (9 theorems, 0 defs, 119 lines, 0 sorry, 0 axiom)

**Re-exports (Mathlib cornerstones):**
- `uniformBell_mul_eq'` — `uniformBell m n · (n!)^m · m! = (m·n)!`
- `uniformBell_eq_div'` — `uniformBell m n = (m·n)! / ((n!)^m · m!)`

**Original contributions (absent from Mathlib):**
- `multinomial_range_const` — the **ordered** equal-block count `(n!)^m · multinomial (range m) (fun _ => n) = (m·n)!`
- `uniformBell_mul_factorial` — the **bridge** `uniformBell m n · m! = multinomial (range m) (fun _ => n)`: forgetting the order of the `m` equal blocks divides the ordered count by exactly `m!`
- `uniformBell_pos` — `0 < uniformBell m n` (an equal-block partition always exists)
- `factorial_pow_mul_factorial_dvd` — `(n!)^m · m! ∣ (m·n)!` (the integrality statement behind the closed form)
- `uniformBell_two_two = 3`, `uniformBell_two_three = 10`, `uniformBell_three_two = 15`

## Verification

- Docker build: `✔ Built Proofs.UniformBellMultinomialOQ01`
- 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions
- Concrete instances use **kernel `decide`** (no `native_decide`, so no `Lean.ofReduceBool`)
- Badge **mathlib**: the two cornerstones are re-exports; the bridge, ordered count, positivity, and divisibility are original. Status **verified**, axiomCount 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)