### PR TITLE
research(chevalley-warning-theorem-oq-01): Chevalley–Warning divisibility + nontrivial-zero corollary

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -605,6 +605,7 @@ import Proofs.ChebyshevPNTBridgeOQ01OQ02
 import Proofs.ChebyshevPNTBridgeOQ02
 import Proofs.ChebyshevPolynomialsOQ01
 import Proofs.ChebyshevSumMonotoneOQ01
+import Proofs.ChevalleyWarningTheoremOQ01
 import Proofs.ChineseRemainderConstructive
 import Proofs.ChineseRemainderConstructiveOQ03
 import Proofs.ChineseRemainderConstructiveOQ03OQ03

--- a/proofs/Proofs/ChevalleyWarningTheoremOQ01.lean
+++ b/proofs/Proofs/ChevalleyWarningTheoremOQ01.lean
@@ -1,0 +1,172 @@
+import Mathlib.FieldTheory.ChevalleyWarning
+import Mathlib.Tactic
+
+/-
+# The Chevalley–Warning theorem and the nontrivial-solution corollary
+
+## What This Proves
+
+The **Chevalley–Warning theorem** (Chevalley 1935, Warning 1935) is a foundational
+fact of finite-field arithmetic: if a finite system of polynomial equations over a
+finite field `K` of characteristic `p` is *low degree* — the sum of the total
+degrees of the polynomials is strictly smaller than the number of variables — then
+the number of common zeros is divisible by `p`.
+
+Mathlib proves the divisibility statements
+(`char_dvd_card_solutions_of_sum_lt`, `char_dvd_card_solutions`,
+`char_dvd_card_solutions_of_add_lt`, `char_dvd_card_solutions_of_fintype_sum_lt`)
+in `Mathlib/FieldTheory/ChevalleyWarning.lean`, where the sole downstream consumer
+is the Erdős–Ginzburg–Ziv theorem. It does **not** record the classical
+existence corollary that Chevalley himself drew, and which is the genuinely new
+content of this file.
+
+* **Divisibility re-exports** (`chevalley_warning_dvd`,
+  `chevalley_warning_dvd_univ`, `chevalley_warning_dvd_single`,
+  `chevalley_warning_dvd_pair`). The Mathlib headlines restated as the baseline:
+  the count of common zeros of a low-degree system is divisible by the
+  characteristic `p`, in the `Finset`-indexed, full-`Fintype`-indexed, single-
+  polynomial, and two-polynomial forms.
+
+* **Chevalley's nontrivial-solution corollary** (`chevalley_warning_nontrivial`,
+  `chevalley_warning_nontrivial_single`) — the new content. If, in addition to the
+  degree condition, every polynomial vanishes at the origin (zero constant term, so
+  `x = 0` is already a common zero), then there exists a **nonzero** common zero.
+  Reason: the origin gives at least one solution, and `p ∣ #solutions` with `p`
+  prime forces `#solutions ≥ p ≥ 2`, so a second, necessarily nonzero, solution
+  must exist. Mathlib provides the divisibility but not this existence statement.
+
+* **Concrete instances** (`chevalley_linear_F2`, `chevalley_quadratic_F2`). Two
+  explicit nontrivial zeros over `𝔽₂`, computed: the linear form `X₀ + X₁` in two
+  variables vanishes at `(1, 1)`, and the quadratic form `X₀·X₁ + X₂²` in three
+  variables vanishes at `(1, 0, 0)` — small witnesses confirming the corollary
+  numerically.
+
+## Context
+
+Chevalley–Warning underlies the Erdős–Ginzburg–Ziv theorem (its standard proof
+applies the corollary to a pair of degree-`(n−1)` power-sum forms over `𝔽_p`),
+Warning's second theorem on the number of solutions, the Ax–Katz refinement, and
+the combinatorial-nullstellensatz circle of ideas. The nontrivial-solution form
+proved here is the version actually used in those applications: a low-degree system
+through the origin always has a solution away from the origin.
+-/
+
+namespace ChevalleyWarningTheoremOQ01
+
+open MvPolynomial
+
+/-! ## Divisibility: the Mathlib headlines restated -/
+
+/-- **Chevalley–Warning (Finset form).** For a finite family `f : ι → MvPolynomial σ K`
+indexed by a `Finset s`, if the total degrees sum to less than the number of
+variables then the characteristic `p` divides the number of common zeros. Direct
+re-export of `char_dvd_card_solutions_of_sum_lt`. -/
+theorem chevalley_warning_dvd
+    {K σ ι : Type*} [Field K] [Fintype K] [DecidableEq K] [Fintype σ] [DecidableEq σ]
+    (p : ℕ) [CharP K p] {s : Finset ι} {f : ι → MvPolynomial σ K}
+    (h : (∑ i ∈ s, (f i).totalDegree) < Fintype.card σ) :
+    p ∣ Fintype.card {x : σ → K // ∀ i ∈ s, eval x (f i) = 0} :=
+  char_dvd_card_solutions_of_sum_lt p h
+
+/-- **Chevalley–Warning (full Fintype form).** The same divisibility when the system
+is indexed by the whole of a finite type `ι`. Re-export of
+`char_dvd_card_solutions_of_fintype_sum_lt`. -/
+theorem chevalley_warning_dvd_univ
+    {K σ ι : Type*} [Field K] [Fintype K] [DecidableEq K] [Fintype σ] [DecidableEq σ]
+    [Fintype ι] (p : ℕ) [CharP K p] {f : ι → MvPolynomial σ K}
+    (h : (∑ i, (f i).totalDegree) < Fintype.card σ) :
+    p ∣ Fintype.card {x : σ → K // ∀ i, eval x (f i) = 0} :=
+  char_dvd_card_solutions_of_fintype_sum_lt p h
+
+/-- **Chevalley–Warning (single polynomial).** One polynomial of total degree less
+than the number of variables has a number of zeros divisible by `p`. Re-export of
+`char_dvd_card_solutions`. -/
+theorem chevalley_warning_dvd_single
+    {K σ : Type*} [Field K] [Fintype K] [DecidableEq K] [Fintype σ] [DecidableEq σ]
+    (p : ℕ) [CharP K p] {f : MvPolynomial σ K} (h : f.totalDegree < Fintype.card σ) :
+    p ∣ Fintype.card {x : σ → K // eval x f = 0} :=
+  char_dvd_card_solutions p h
+
+/-- **Chevalley–Warning (two polynomials).** For two polynomials whose total degrees
+sum to less than the number of variables, `p` divides the number of common zeros.
+Re-export of `char_dvd_card_solutions_of_add_lt`. -/
+theorem chevalley_warning_dvd_pair
+    {K σ : Type*} [Field K] [Fintype K] [DecidableEq K] [Fintype σ] [DecidableEq σ]
+    (p : ℕ) [CharP K p] {f₁ f₂ : MvPolynomial σ K}
+    (h : f₁.totalDegree + f₂.totalDegree < Fintype.card σ) :
+    p ∣ Fintype.card {x : σ → K // eval x f₁ = 0 ∧ eval x f₂ = 0} :=
+  char_dvd_card_solutions_of_add_lt p h
+
+/-! ## Chevalley's nontrivial-solution corollary (the new content) -/
+
+/-- **Chevalley's corollary (Finset form).** Suppose the total degrees of the system
+`f : ι → MvPolynomial σ K` (indexed over `s`) sum to less than the number of
+variables, and every `f i` vanishes at the origin (zero constant term), so the
+origin `x = 0` is a common zero. Then there is a **nonzero** common zero.
+
+The origin gives at least one solution; the Chevalley–Warning divisibility together
+with `p` prime forces the number of solutions to be at least `p ≥ 2`, so a solution
+distinct from the origin — necessarily nonzero — exists. Mathlib supplies the
+divisibility but not this existence statement. -/
+theorem chevalley_warning_nontrivial
+    {K σ ι : Type*} [Field K] [Fintype K] [DecidableEq K] [Fintype σ] [DecidableEq σ]
+    (p : ℕ) [CharP K p] [Fact p.Prime] {s : Finset ι} {f : ι → MvPolynomial σ K}
+    (hdeg : (∑ i ∈ s, (f i).totalDegree) < Fintype.card σ)
+    (h0 : ∀ i ∈ s, eval (0 : σ → K) (f i) = 0) :
+    ∃ x : σ → K, x ≠ 0 ∧ ∀ i ∈ s, eval x (f i) = 0 := by
+  -- `p` divides the number of common zeros.
+  have hdvd : p ∣ Fintype.card {x : σ → K // ∀ i ∈ s, eval x (f i) = 0} :=
+    char_dvd_card_solutions_of_sum_lt p hdeg
+  -- The origin is a common zero, so there is at least one solution.
+  have hpos : 0 < Fintype.card {x : σ → K // ∀ i ∈ s, eval x (f i) = 0} :=
+    Fintype.card_pos_iff.mpr ⟨⟨0, h0⟩⟩
+  -- `p` is prime, so `p ≥ 2`, and `p ∣ #solutions` with `#solutions ≥ 1` gives `#solutions ≥ 2`.
+  have hp : p.Prime := Fact.out
+  have h1lt : 1 < Fintype.card {x : σ → K // ∀ i ∈ s, eval x (f i) = 0} :=
+    lt_of_lt_of_le hp.one_lt (Nat.le_of_dvd hpos hdvd)
+  -- A second solution, distinct from the origin, hence nonzero.
+  obtain ⟨y, hy⟩ := Fintype.exists_ne_of_one_lt_card h1lt ⟨0, h0⟩
+  exact ⟨y.val, fun hc => hy (Subtype.ext hc), y.property⟩
+
+/-- **Chevalley's corollary (single polynomial).** A single polynomial of total
+degree less than the number of variables that vanishes at the origin has a nonzero
+zero. The classical statement: a form of degree `d < n` in `n` variables with no
+constant term has a nontrivial zero over a finite field. -/
+theorem chevalley_warning_nontrivial_single
+    {K σ : Type*} [Field K] [Fintype K] [DecidableEq K] [Fintype σ] [DecidableEq σ]
+    (p : ℕ) [CharP K p] [Fact p.Prime] {f : MvPolynomial σ K}
+    (hdeg : f.totalDegree < Fintype.card σ) (h0 : eval (0 : σ → K) f = 0) :
+    ∃ x : σ → K, x ≠ 0 ∧ eval x f = 0 := by
+  have hdvd : p ∣ Fintype.card {x : σ → K // eval x f = 0} :=
+    char_dvd_card_solutions p hdeg
+  have hpos : 0 < Fintype.card {x : σ → K // eval x f = 0} :=
+    Fintype.card_pos_iff.mpr ⟨⟨0, h0⟩⟩
+  have hp : p.Prime := Fact.out
+  have h1lt : 1 < Fintype.card {x : σ → K // eval x f = 0} :=
+    lt_of_lt_of_le hp.one_lt (Nat.le_of_dvd hpos hdvd)
+  obtain ⟨y, hy⟩ := Fintype.exists_ne_of_one_lt_card h1lt ⟨0, h0⟩
+  exact ⟨y.val, fun hc => hy (Subtype.ext hc), y.property⟩
+
+/-! ## Concrete instances over `𝔽₂` -/
+
+/-- The linear form `X₀ + X₁` over `𝔽₂` (degree `1 < 2` variables) has the nonzero
+common zero `(1, 1)`: `1 + 1 = 0` in `ZMod 2`. -/
+theorem chevalley_linear_F2 :
+    (fun _ => (1 : ZMod 2)) ≠ (0 : Fin 2 → ZMod 2) ∧
+      eval (fun _ => (1 : ZMod 2)) (X 0 + X 1 : MvPolynomial (Fin 2) (ZMod 2)) = 0 := by
+  refine ⟨?_, ?_⟩
+  · intro h; have := congrFun h 0; simp at this
+  · simp only [eval_add, eval_X]; decide
+
+/-- The quadratic form `X₀·X₁ + X₂²` over `𝔽₂` (total degree `2 < 3` variables) has
+the nonzero common zero `(1, 0, 0)`: `1·0 + 0² = 0`. A genuine degree-2 witness,
+the typical shape in which Chevalley–Warning is applied. -/
+theorem chevalley_quadratic_F2 :
+    (![1, 0, 0] : Fin 3 → ZMod 2) ≠ 0 ∧
+      eval (![1, 0, 0] : Fin 3 → ZMod 2)
+        (X 0 * X 1 + X 2 ^ 2 : MvPolynomial (Fin 3) (ZMod 2)) = 0 := by
+  refine ⟨?_, ?_⟩
+  · intro h; have := congrFun h 0; simp at this
+  · simp only [eval_add, eval_mul, eval_pow, eval_X]; decide
+
+end ChevalleyWarningTheoremOQ01

--- a/src/data/proofs/chevalley-warning-theorem-oq-01/meta.json
+++ b/src/data/proofs/chevalley-warning-theorem-oq-01/meta.json
@@ -1,0 +1,174 @@
+{
+  "id": "chevalley-warning-theorem-oq-01",
+  "title": "Chevalley–Warning: divisibility of the solution count and the nontrivial-zero corollary",
+  "slug": "chevalley-warning-theorem-oq-01",
+  "description": "The Chevalley–Warning theorem (1935): over a finite field K of characteristic p, a system of polynomials whose total degrees sum to less than the number of variables has a number of common zeros divisible by p. Mathlib proves the divisibility statements (the only downstream consumer being Erdős–Ginzburg–Ziv) but records no existence corollary. This entry restates the four divisibility forms and proves the classical nontrivial-solution corollary Mathlib omits: if every polynomial also vanishes at the origin then there is a NONZERO common zero — because the origin gives one solution and p ∣ #solutions with p prime forces at least p ≥ 2 of them. Two explicit witnesses over 𝔽₂ confirm the corollary numerically.",
+  "meta": {
+    "author": "Claude Chevalley, Ewald Warning (1935); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChevalleyWarningTheoremOQ01.lean",
+    "tags": [
+      "number-theory",
+      "finite-fields",
+      "chevalley-warning",
+      "polynomials",
+      "combinatorial-nullstellensatz",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "char_dvd_card_solutions_of_sum_lt",
+        "description": "Chevalley–Warning (Finset form): if Σ_{i∈s} (f i).totalDegree < Fintype.card σ then p ∣ #{x // ∀ i∈s, eval x (f i) = 0}",
+        "module": "Mathlib.FieldTheory.ChevalleyWarning"
+      },
+      {
+        "theorem": "char_dvd_card_solutions_of_fintype_sum_lt",
+        "description": "Chevalley–Warning (full Fintype form): the divisibility when the system is indexed by the whole of a finite type ι",
+        "module": "Mathlib.FieldTheory.ChevalleyWarning"
+      },
+      {
+        "theorem": "char_dvd_card_solutions",
+        "description": "Chevalley–Warning (single polynomial): if f.totalDegree < Fintype.card σ then p ∣ #{x // eval x f = 0}",
+        "module": "Mathlib.FieldTheory.ChevalleyWarning"
+      },
+      {
+        "theorem": "char_dvd_card_solutions_of_add_lt",
+        "description": "Chevalley–Warning (two polynomials): if f₁.totalDegree + f₂.totalDegree < Fintype.card σ then p ∣ #{x // eval x f₁ = 0 ∧ eval x f₂ = 0}",
+        "module": "Mathlib.FieldTheory.ChevalleyWarning"
+      },
+      {
+        "theorem": "Fintype.exists_ne_of_one_lt_card",
+        "description": "If 1 < Fintype.card α then for every a there is b ≠ a; used to extract a second solution distinct from the origin",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Fintype.card_pos_iff",
+        "description": "0 < Fintype.card α ↔ Nonempty α; the origin solution witnesses #solutions ≥ 1",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Nat.le_of_dvd",
+        "description": "0 < n → m ∣ n → m ≤ n; with p ∣ #solutions and #solutions ≥ 1 gives p ≤ #solutions",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "chevalley_warning_dvd / chevalley_warning_dvd_univ / chevalley_warning_dvd_single / chevalley_warning_dvd_pair: the four Chevalley–Warning divisibility statements (Finset, full-Fintype, single-polynomial, two-polynomial) restated as the baseline (Mathlib headlines)",
+      "chevalley_warning_nontrivial: Chevalley's nontrivial-solution corollary (Finset form) — if the degree condition holds and every f i vanishes at the origin, there is a NONZERO common zero. The origin gives ≥1 solution, and p ∣ #solutions with p prime forces #solutions ≥ p ≥ 2, so a second (nonzero) solution exists. Mathlib has only the divisibility, not this existence statement; this is the new content.",
+      "chevalley_warning_nontrivial_single: the single-polynomial form of the corollary — a form of degree d < n in n variables with zero constant term has a nontrivial zero over a finite field (the classical statement Chevalley proved)",
+      "chevalley_linear_F2 / chevalley_quadratic_F2: two explicit nonzero common zeros over 𝔽₂ verified by kernel computation — the linear form X₀+X₁ vanishes at (1,1), and the quadratic form X₀·X₁+X₂² vanishes at (1,0,0)"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Uses only kernel `decide` (no native_decide, so no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 172,
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "In 1935 Claude Chevalley proved (settling a conjecture of Emil Artin) that a homogeneous polynomial of degree less than its number of variables over a finite field always has a nontrivial zero; Ewald Warning simultaneously strengthened this to the divisibility statement that the number of common zeros of any such low-degree system is divisible by the characteristic. Chevalley–Warning is a cornerstone of finite-field arithmetic and the combinatorial nullstellensatz, and underlies the Erdős–Ginzburg–Ziv theorem, Warning's second theorem on the number of solutions, and the Ax–Katz refinement.",
+    "problemStatement": "Mathlib's `FieldTheory/ChevalleyWarning.lean` proves the divisibility forms — the number of common zeros of a low-degree polynomial system over a finite field is divisible by the characteristic — and uses them only to prove Erdős–Ginzburg–Ziv. It does not record the existence corollary that motivated Chevalley's original work. Can that corollary be formalized: a low-degree system passing through the origin has a zero away from the origin?\n\n**Answer:** Yes. The origin contributes one solution, so the solution count is ≥ 1; Chevalley–Warning divisibility plus primality of p forces the count to be at least p ≥ 2, hence a second, necessarily nonzero, solution exists.",
+    "text": "The four Chevalley–Warning divisibility statements are restated from Mathlib (Finset, full-Fintype, single-polynomial, and two-polynomial forms), and — the new content — Chevalley's nontrivial-solution corollary is proved in both the family and single-polynomial forms: a low-degree system vanishing at the origin has a nonzero common zero. Two explicit 𝔽₂ witnesses confirm the corollary, all verified with no axioms.",
+    "proofStrategy": "1. chevalley_warning_dvd, _univ, _single, _pair: direct re-exports of char_dvd_card_solutions_of_sum_lt, char_dvd_card_solutions_of_fintype_sum_lt, char_dvd_card_solutions, char_dvd_card_solutions_of_add_lt.\n2. chevalley_warning_nontrivial: let S = {x // ∀ i∈s, eval x (f i) = 0}. Chevalley–Warning gives p ∣ #S. The origin ⟨0, h0⟩ ∈ S so #S ≥ 1 (Fintype.card_pos_iff). With p prime, p.one_lt and Nat.le_of_dvd give 1 < #S. Fintype.exists_ne_of_one_lt_card yields y ∈ S with y ≠ origin; y.val ≠ 0 (Subtype.ext) is the nontrivial zero.\n3. chevalley_warning_nontrivial_single: identical argument with the single-polynomial divisibility char_dvd_card_solutions.\n4. chevalley_linear_F2, chevalley_quadratic_F2: exhibit explicit nonzero witnesses and evaluate by simp + kernel decide over ZMod 2.",
+    "keyInsights": [
+      "**Divisibility is one re-export, the existence corollary is the work**: Mathlib supplies only the count-mod-p statements and uses them solely for Erdős–Ginzburg–Ziv; the nontrivial-zero existence — the form actually used in applications — is the genuine contribution here.",
+      "**Counting forces a second solution**: 'the origin is a solution' gives #solutions ≥ 1, and 'p divides #solutions' with p ≥ 2 prime upgrades this to #solutions ≥ p ≥ 2, so a solution distinct from the origin must exist — a pure cardinality argument, no algebraic geometry.",
+      "**Why primality of p is essential**: the jump from ≥ 1 to ≥ 2 needs p ≥ 2; over a finite field the characteristic is automatically prime, recorded here as the hypothesis Fact p.Prime.",
+      "**Vanishing at the origin = zero constant term**: the hypothesis eval 0 (f i) = 0 says exactly that the origin is a common zero (each f i has no constant term), the standard setup of the Chevalley corollary."
+    ],
+    "prerequisites": [
+      "Finite fields and their characteristic (CharP, the characteristic of a finite field is prime)",
+      "Multivariate polynomials and evaluation (MvPolynomial, eval, totalDegree)",
+      "Finite types and cardinality of subtypes (Fintype.card, Fintype.card_pos_iff)",
+      "Elementary divisibility (Nat.le_of_dvd) and the Chevalley–Warning theorem"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Statement",
+      "startLine": 1,
+      "endLine": 57,
+      "summary": "File-level docstring framing the result: Mathlib proves the Chevalley–Warning divisibility forms but records no existence corollary. Lists the divisibility re-exports, the nontrivial-solution corollary, and the two concrete 𝔽₂ witnesses. Imports the Mathlib ChevalleyWarning file and Tactic.",
+      "mathContext": "The Chevalley–Warning theorem and the nontrivial-zero corollary over a finite field."
+    },
+    {
+      "id": "divisibility",
+      "title": "Divisibility: the Mathlib Headlines Restated",
+      "startLine": 58,
+      "endLine": 99,
+      "summary": "chevalley_warning_dvd, _univ, _single, _pair restate the four Chevalley–Warning divisibility statements (Finset-indexed, full-Fintype-indexed, single-polynomial, two-polynomial). All are direct re-exports of the Mathlib lemmas.",
+      "mathContext": "The number of common zeros of a low-degree polynomial system over a finite field is divisible by the characteristic p."
+    },
+    {
+      "id": "nontrivial-corollary",
+      "title": "Chevalley's Nontrivial-Solution Corollary",
+      "startLine": 100,
+      "endLine": 149,
+      "summary": "chevalley_warning_nontrivial and chevalley_warning_nontrivial_single prove that a low-degree system (resp. single polynomial) vanishing at the origin has a NONZERO common zero: the origin gives ≥1 solution, p ∣ #solutions with p prime forces ≥2, so a second nonzero solution exists. This existence statement is absent from Mathlib.",
+      "mathContext": "A low-degree polynomial system through the origin over a finite field has a solution away from the origin."
+    },
+    {
+      "id": "concrete",
+      "title": "Concrete Instances over 𝔽₂",
+      "startLine": 150,
+      "endLine": 172,
+      "summary": "chevalley_linear_F2 and chevalley_quadratic_F2 exhibit explicit nonzero common zeros over ZMod 2 — (1,1) for the linear form X₀+X₁, and (1,0,0) for the quadratic form X₀·X₁+X₂² — verified by simp plus kernel decide.",
+      "mathContext": "Explicit small witnesses confirming the nontrivial-zero corollary numerically over 𝔽₂."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Chevalley, Claude",
+      "title": "Démonstration d'une hypothèse de M. Artin",
+      "year": "1935",
+      "note": "Abh. Math. Sem. Univ. Hamburg 11, 73–75 — a form of degree < number of variables over a finite field has a nontrivial zero"
+    },
+    {
+      "authors": "Warning, Ewald",
+      "title": "Bemerkung zur vorstehenden Arbeit von Herrn Chevalley",
+      "year": "1935",
+      "note": "Abh. Math. Sem. Univ. Hamburg 11, 76–83 — the divisibility strengthening: the number of common zeros is divisible by the characteristic"
+    },
+    {
+      "authors": "Serre, Jean-Pierre",
+      "title": "A Course in Arithmetic",
+      "year": "1973",
+      "note": "Chapter I §2 — the Chevalley–Warning theorem and its nontrivial-solution corollary over finite fields"
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "erdos-ginzburg-ziv-oq-01",
+      "reason": "Erdős–Ginzburg–Ziv is the sole downstream consumer of Mathlib's Chevalley–Warning lemmas; its standard proof applies the nontrivial-solution corollary to a pair of power-sum forms over 𝔽_p"
+    }
+  ],
+  "conclusion": {
+    "summary": "The four Chevalley–Warning divisibility statements are restated from Mathlib (chevalley_warning_dvd, _univ, _single, _pair), Chevalley's nontrivial-solution corollary is proved in the family and single-polynomial forms (chevalley_warning_nontrivial, _single), and two explicit nonzero witnesses over 𝔽₂ are verified (chevalley_linear_F2, chevalley_quadratic_F2). All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies the existence corollary that motivated Chevalley's original theorem and that Mathlib leaves implicit — a low-degree system through the origin over a finite field always has a nonzero solution — making the form actually used in applications (Erdős–Ginzburg–Ziv, Warning's second theorem) a machine-checked statement.",
+    "openQuestions": [
+      "Can Warning's second theorem — that the number of common zeros is either 0 or at least q^(n−d) where q = |K| — be formalized to refine the count-mod-p divisibility?",
+      "Can the EGZ proof be re-derived inside the gallery by applying chevalley_warning_nontrivial to the two power-sum forms ∑ xᵢ^(n−1) and ∑ aᵢ xᵢ^(n−1) over 𝔽_p, exhibiting Chevalley–Warning as its engine?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.FieldTheory.ChevalleyWarning",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MvPolynomial"
+    ],
+    "namespace": "ChevalleyWarningTheoremOQ01",
+    "lineCount": 172,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/ChevalleyWarningTheoremOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **Chevalley–Warning theorem** (1935) and the classical **nontrivial-solution corollary** that Mathlib omits.

Mathlib (`FieldTheory/ChevalleyWarning.lean`) proves the divisibility statements — the number of common zeros of a low-degree polynomial system over a finite field is divisible by the characteristic `p` — and uses them *only* to prove Erdős–Ginzburg–Ziv. It records no existence corollary. This entry supplies it.

### Baseline (re-exports of Mathlib headlines)
- `chevalley_warning_dvd` / `_univ` / `_single` / `_pair`: the four divisibility forms (Finset-indexed, full-Fintype-indexed, single-polynomial, two-polynomial).

### New content
- `chevalley_warning_nontrivial` (and `_single`): if the degree condition holds **and** every polynomial vanishes at the origin (zero constant term), there is a **nonzero** common zero. The origin gives ≥ 1 solution, and `p ∣ #solutions` with `p` prime forces `#solutions ≥ p ≥ 2`, so a second, necessarily nonzero, solution exists. This is the form actually used in applications (it is the engine of the EGZ proof); Mathlib has only the divisibility.
- `chevalley_linear_F2`, `chevalley_quadratic_F2`: two explicit nonzero witnesses over 𝔽₂ — `X₀+X₁` vanishes at `(1,1)`, `X₀·X₁+X₂²` vanishes at `(1,0,0)` — verified by kernel computation.

## Verification
- **8 theorems, 0 defs, 0 axioms, 0 sorries, no `native_decide`** (kernel `decide` only → no `Lean.ofReduceBool`).
- Docker-verified: `Built Proofs.ChevalleyWarningTheoremOQ01`.
- badge `mathlib` (the divisibility headlines are Mathlib restatements; the nontrivial corollary is the original contribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)