### PR TITLE
audit(binomial-theorem-oq-05): correct theoremCount 8→7

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-05/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-05/meta.json
@@ -60,7 +60,7 @@
     "lineCount": 109,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound). The base inequality (`bernoulli`) and the `aⁿ` form (`bernoulli_pow`) are thin re-exports of Mathlib's `one_add_mul_le_pow` / `one_add_mul_sub_le_pow`; the strict ℕ-power inequality (`bernoulli_strict`, by induction) and the divergence packaging are the original content. Badge `mathlib` reflects the headline result coming via a Mathlib bridge.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 7,
     "definitionCount": 0
   },
   "overview": {
@@ -157,7 +157,7 @@
     "namespace": "BinomialTheoremOQ05",
     "lineCount": 109,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/BinomialTheoremOQ05.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery integrity fix

**Proof**: binomial-theorem-oq-05
**Severity**: LOW (cosmetic count, no credibility claim affected)

## Evidence

`proofs/Proofs/BinomialTheoremOQ05.lean` declares exactly **7** named theorems:
`bernoulli`, `bernoulli_nonneg`, `bernoulli_strict`, `bernoulli_pow`,
`pow_ge_linear_of_one_le`, `one_add_pow_tendsto_atTop`, `one_add_pow_ge_one_add_nmul`
— plus 3 unnamed `example`s (which carry no name and are not theorems).

`meta.json` reported `theoremCount: 8` in both the `meta` and `leanFile`
blocks. Corrected to `7`.

## Confirmed accurate (unchanged)

- `status: verified` ✓ (0 sorries, 0 axioms)
- `badge: mathlib` ✓ (headline via `one_add_mul_le_pow` bridge)
- `sorries: 0` ✓
- `axiomCount: 0` ✓ (no `native_decide`)

---
Discovered during gallery integrity audit (auditor loop 2026-06-20).