### PR TITLE
audit(combinations-formula-oq-07): badge original→mathlib (Tier B)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius researcher-10",
     "status": "verified",
     "proofRepoPath": "Proofs/CombinationsFormulaOQ07.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 76,
@@ -27,6 +27,23 @@
       "add_choose_eq_sum_range: Vandermonde's convolution as a single range sum C(m+n,k) = ∑_{i≤k} C(m,i)·C(n,k-i), reindexed from Mathlib's antidiagonal form via sum_antidiagonal_eq_sum_range_succ",
       "central_binom_eq_sum_sq: the central binomial sum-of-squares identity C(2n,n) = ∑_{i≤n} C(n,i)², obtained by specializing Vandermonde at m=n, k=n and applying choose symmetry C(n,n-i)=C(n,i)",
       "Worked verification C(6,3) = ∑ C(3,i)² = 1+9+9+1 = 20"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.add_choose_eq",
+        "description": "Vandermonde's convolution in antidiagonal form: (m+n).choose k = ∑ p ∈ antidiagonal k, m.choose p.1 * n.choose p.2. Re-exported as add_choose_eq_antidiagonal and the core of add_choose_eq_sum_range.",
+        "module": "Mathlib.Combinatorics.Choose.Vandermonde"
+      },
+      {
+        "theorem": "Finset.Nat.sum_antidiagonal_eq_sum_range_succ",
+        "description": "Reindexes an antidiagonal sum over k as a range sum over i ∈ range (k+1) with j = k - i; converts the antidiagonal Vandermonde form to the single-sum range form.",
+        "module": "Mathlib.Algebra.BigOperators.NatAntidiagonal"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "Symmetry C(n, n-i) = C(n, i) for i ≤ n; collapses the m=n, k=n specialization of Vandermonde into a sum of squares.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Gallery integrity audit

**Proof**: combinations-formula-oq-07 (Vandermonde's Convolution and the Central Binomial Sum of Squares)

**Problem**: Badge was `original`, but the core result — Vandermonde's convolution — is a direct re-export of Mathlib's `Nat.add_choose_eq`. This is Tier B (core argument via Mathlib), so the badge should be `mathlib`. The structured `mathlibDependencies` field was also absent.

## Evidence

- `add_choose_eq_antidiagonal := Nat.add_choose_eq m n k` — literal re-export.
- `add_choose_eq_sum_range` reindexes it via `Finset.Nat.sum_antidiagonal_eq_sum_range_succ`.
- `central_binom_eq_sum_sq` specializes Vandermonde (m=n, k=n) and applies `Nat.choose_symm`.

The Lean docstring already transparently states "Mathlib provides this... This file reindexes that identity" — only the gallery metadata was out of step.

## Fix

- `badge`: `original` → `mathlib`
- Added `mathlibDependencies`: `Nat.add_choose_eq`, `Finset.Nat.sum_antidiagonal_eq_sum_range_succ`, `Nat.choose_symm`

No Lean source change. Counts (3 theorems, 0 axioms, 0 sorries, 76 lines) all verified accurate.

Consistent with prior audits: cauchy-schwarz-oq-06, chebyshev-polynomials-oq-01, chebyshev-sum-inequality-oq-01.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)