### PR TITLE
audit(de-moivre-oq-05): badge verified→mathlib (Tier B)

### DIFF
--- a/src/data/proofs/de-moivre-oq-05/meta.json
+++ b/src/data/proofs/de-moivre-oq-05/meta.json
@@ -16,7 +16,7 @@
       "discrete-fourier",
       "de-moivre"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Gallery integrity audit

**Proof**: de-moivre-oq-05 (The n-th Roots of Unity Sum to Zero)

**Problem**: Badge was `verified`, implying fully independent work, but the headline result reduces directly to Mathlib's `IsPrimitiveRoot.geom_sum_eq_zero`. This is Tier B (core argument via Mathlib), so the badge should be `mathlib`.

## Evidence

- `sum_nthRootsFinset_eq_zero` finishes with `exact hζ.geom_sum_eq_zero hn` — the vanishing is Mathlib's.
- `sum_exp_eq_zero` likewise reduces to `geom_sum_eq_zero`.
- The docstring states: "Mathlib records exactly this single-primitive-root geometric-series statement, `IsPrimitiveRoot.geom_sum_eq_zero`."

The genuine in-file contribution is the structural bridge `nthRootsFinset_eq_image` (a real cardinality-argument lemma absent from Mathlib) and the set-form / DFT repackagings — but the core sum-is-zero engine is Mathlib's.

The sibling **de-moivre-oq-04** (which proves `ωⁿ=1` directly via De Moivre, leaning on Mathlib *less*) is badged `mathlib`; consistency requires the same here.

## Fix

- `badge`: `verified` → `mathlib`

No Lean source change. `mathlibDependencies` already lists `geom_sum_eq_zero`; the docstring is fully transparent. Counts (4 theorems, 0 axioms, 0 sorries, 108 lines) verified accurate. `status` remains `verified` (machine-checked, 0 assumptions) — only the public badge is adjusted to reflect the Mathlib-core tier.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)