### PR TITLE
audit(dirichlet-approximation-theorem-oq-04): badge original→mathlib (Tier B)

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem-oq-04/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-04/meta.json
@@ -20,9 +20,30 @@
       "circle-rotation",
       "topological-dynamics"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-20",
+    "originalContributions": [
+      "denseRange_iff_irrational: Kronecker's density theorem on the unit circle — multiples {n•a} are dense in AddCircle 1 iff a is irrational — the period-1 specialisation of Mathlib's AddCircle.denseRange_zsmul_coe_iff (a/1 = a)",
+      "exists_pos_nat_mul_sub_round_lt: the homogeneous Dirichlet/Kronecker corollary (genuine derived content absent from Mathlib) — for irrational a and every ε > 0 there is a positive integer n with |n·a − round(n·a)| < ε, via a punctured-ball density extraction, a small nonzero circle point construction, and a sign normalisation reading the circle norm back as distance to the nearest integer"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "AddCircle.denseRange_zsmul_coe_iff",
+        "description": "Multiples of a are dense on the circle of length p iff a/p is irrational. Specialised at p = 1 (a/1 = a) to give denseRange_iff_irrational — the entry's named headline.",
+        "module": "Mathlib.Dynamics.Circle.RotationNumber.TranslationNumber"
+      },
+      {
+        "theorem": "AddCircle.norm_eq / AddCircle.norm_coe_eq_abs_iff / AddCircle.coe_neg",
+        "description": "The AddCircle normed-group API: ‖(x : AddCircle 1)‖ = |x − round x|, the norm-of-coe characterisation, and coe-negation; used to build a small nonzero circle point and read the norm back as distance to the nearest integer.",
+        "module": "Mathlib.Topology.Instances.AddCircle"
+      },
+      {
+        "theorem": "DenseRange.exists_mem_open",
+        "description": "A dense range meets every nonempty open set; applied to the punctured ball B(0,ε) ∖ {0} to extract the approximating multiple.",
+        "module": "Mathlib.Topology.DenseEmbedding"
+      }
+    ],
     "relatedProblems": [
       {
         "id": "dirichlet-approximation-theorem",


### PR DESCRIPTION
## Gallery integrity audit

**Proof**: dirichlet-approximation-theorem-oq-04 (Kronecker's Density Theorem)

**Problem**: Badge was `original`, but the entry's named headline — Kronecker's density theorem — is a near-direct specialization of a Mathlib theorem.

## Evidence

```lean
theorem denseRange_iff_irrational (a : ℝ) :
    DenseRange (fun n : ℤ => (↑(n • a) : AddCircle (1:ℝ))) ↔ Irrational a := by
  have h := AddCircle.denseRange_zsmul_coe_iff (a := a) (p := (1:ℝ))
  rwa [div_one] at h
```
The docstring states: "everything reduces to Mathlib's `AddCircle` API" and "denseRange_iff_irrational is `AddCircle.denseRange_zsmul_coe_iff` at p = 1." This is Tier B (core via Mathlib).

The second theorem (`exists_pos_nat_mul_sub_round_lt`, the homogeneous Dirichlet corollary) is genuine substantial derived content (~45 lines) and is recorded in `originalContributions`.

## Fix

- `badge`: `original` → `mathlib`
- Added the previously-absent structured `originalContributions` and `mathlibDependencies` (the meta prose already disclosed the dependency thoroughly).

No Lean source change. `status` remains `verified` (0 axioms, 0 sorries, no native_decide). Counts (2 theorems, 0 defs, 107 lines) verified accurate.

Consistent with prior audits: combinations-formula-oq-07/08, de-moivre-oq-05.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)