### PR TITLE
audit(divisibility-rules-oq-04): correct theoremCount 5→4

### DIFF
--- a/src/data/proofs/divisibility-rules-oq-04/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-04/meta.json
@@ -13,7 +13,7 @@
     "namespace": "DivisibilityRulesOQ04",
     "lineCount": 68,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 4,
     "definitionCount": 0,
     "path": "Proofs/DivisibilityRulesOQ04.lean",
     "sorries": 0
@@ -33,7 +33,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 68,
-    "theoremCount": 5,
+    "theoremCount": 4,
     "definitionCount": 0,
     "badge": "mathlib",
     "originalContributions": [


### PR DESCRIPTION
## Gallery integrity audit

**Proof**: divisibility-rules-oq-04 (Three Divisibility Rules for 11)

**Problem**: `theoremCount` read 5 (in both `leanFile` and `meta`), but the file has only 4 theorems.

## Evidence
```
eleven_dvd_iff_block_sum, eleven_dvd_iff_alternating,
eleven_dvd_iff_block_alternating, eleven_modEq_alternating
```
No def, no `@[simp]` lemma, no private helper accounts for a 5th.

## Fix
- `leanFile.theoremCount`: 5 → 4
- `meta.theoremCount`: 5 → 4

No Lean source change. Badge `mathlib` (specializations of Mathlib's digit machinery) is correct; 0 axioms, 0 sorries verified accurate.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)