### PR TITLE
audit(eisenstein-criterion-oq-01): badge original→mathlib (Tier B)

### DIFF
--- a/src/data/proofs/eisenstein-criterion-oq-01/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01/meta.json
@@ -17,9 +17,26 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/EisensteinCriterionOQ01.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
+        "description": "Eisenstein's irreducibility criterion over an integral domain with a prime ideal P — the core irreducibility engine, re-exported as irreducible_of_eisenstein and applied to the Xⁿ − p family.",
+        "module": "Mathlib.RingTheory.Polynomial.Eisenstein.Basic"
+      },
+      {
+        "theorem": "Polynomial.monic_X_pow_sub_C / Polynomial.degree_X_pow_sub_C",
+        "description": "Monicity and degree of Xⁿ − C p, supplying the leading coefficient, degree, and primitivity inputs to the criterion.",
+        "module": "Mathlib.RingTheory.Polynomial.Basic"
+      },
+      {
+        "theorem": "Ideal.span_singleton_prime / Ideal.mem_span_singleton / Ideal.span_singleton_pow",
+        "description": "Primality of (p), membership x ∈ (p) ↔ p ∣ x, and (p)^2 = (p²); used for the coefficient bookkeeping discharging the Eisenstein hypotheses.",
+        "module": "Mathlib.RingTheory.Ideal.Operations"
+      }
+    ],
     "assumptions": "None. All 5 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide is used anywhere.",
     "originalContributions": [
       "irreducible_of_eisenstein: Eisenstein's criterion in clean form over an integral domain with a prime ideal P (leading coeff ∉ P, lower coeffs ∈ P, constant ∉ P², primitive ⇒ irreducible)",


### PR DESCRIPTION
## Gallery integrity audit

**Proof**: eisenstein-criterion-oq-01 (Eisenstein's Criterion and the Irreducibility of Xⁿ − p)

**Problem**: Badge was `original`, but the entry's core rests on Mathlib.

## Evidence
```lean
theorem irreducible_of_eisenstein ... : Irreducible f :=
  irreducible_of_eisenstein_criterion hP hlead hlow hdeg hconst hprim
```
- The general criterion is a verbatim re-export of Mathlib's `Polynomial.irreducible_of_eisenstein_criterion`. The meta's own `proofStrategy` calls it "a direct restatement of Mathlib's irreducible_of_eisenstein_criterion."
- `irreducible_X_pow_sub_C_prime` obtains its irreducibility conclusion by *applying* that criterion; the ~30 lines are hypothesis-verification bookkeeping (coefficient computation, divisibility by p / p²), not an independent irreducibility proof.

This is Tier B (core via Mathlib).

## Fix
- `badge`: `original` → `mathlib`
- Added the previously-absent `mathlibDependencies` (`irreducible_of_eisenstein_criterion`, `monic_X_pow_sub_C`/`degree_X_pow_sub_C`, the `Ideal.span_singleton_*` lemmas).

No Lean source change. The meta prose already disclosed the dependency thoroughly. `status` remains `verified` (0 axioms, 0 sorries, no native_decide). Counts (5 theorems, 102 lines) verified accurate.

Consistent with prior audits: det-conjugate-transpose-oq-01, chevalley-warning-theorem-oq-01.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)