### PR TITLE
research(hall-marriage-theorem-oq-01): Hall SDR/transversal form + deficiency obstruction + witnesses (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2629,6 +2629,7 @@ import Proofs.GreensTheoremOQ03
 import Proofs.GreensTheoremOQ03OQ04
 import Proofs.GreensTheoremOQ04
 import Proofs.HadamardThreeLines
+import Proofs.HallMarriageTheoremOQ01
 import Proofs.HallsTheoremOQ01
 import Proofs.HaltingProblem
 import Proofs.HappyNumberOQ01

--- a/proofs/Proofs/HallMarriageTheoremOQ01.lean
+++ b/proofs/Proofs/HallMarriageTheoremOQ01.lean
@@ -1,0 +1,135 @@
+import Mathlib
+
+/-!
+# Hall's marriage theorem: SDR existence, the deficiency obstruction, and witnesses
+
+Let `ι` be an index set and `t : ι → Finset α` a family of finite "preference" sets.  A
+**system of distinct representatives** (SDR), or *transversal*, is an injective map
+`f : ι → α` with `f i ∈ t i` for every `i` — a way to choose a distinct representative from
+each set.  **Hall's marriage theorem** characterizes exactly when one exists: an SDR exists
+iff **Hall's condition** holds, namely that every sub-family covers at least as many elements
+as it has members,
+
+`∀ s : Finset ι, #s ≤ #(s.biUnion t)`.
+
+Mathlib proves the biconditional in `Finset.all_card_le_biUnion_card_iff_exists_injective`
+(`Mathlib/Combinatorics/Hall/Basic.lean`), via Rado's compactness argument over the finite
+case.  What Mathlib does **not** package — and what this file adds — are the two practical
+faces of the theorem used in applications:
+
+## New content
+
+* **Necessity, standalone** (`hall_condition_of_sdr`, `hall_condition_of_exists_sdr`).  The
+  easy direction proved directly, *not* extracted from the biconditional: if an SDR exists
+  then Hall's condition holds.  The proof is one counting step — `s.image f ⊆ s.biUnion t` and
+  `f` injective forces `#s = #(s.image f) ≤ #(s.biUnion t)`.  This direction needs **no**
+  finiteness of `ι` and no compactness, so isolating it is genuinely cheaper than invoking the
+  full theorem.
+
+* **The deficiency / failure obstruction** (`no_sdr_of_deficiency`).  The contrapositive form
+  actually used to *certify non-existence*: if some sub-family is "deficient"
+  (`#(s.biUnion t) < #s`, more members than available representatives) then **no** SDR exists.
+  This is the workhorse for proving a matching impossible.
+
+* **Concrete `0`-axiom witnesses** (`hall_satisfiable_example`, `hall_violating_example`).  A
+  satisfying `Fin 3` family with an exhibited transversal, and a violating family
+  (`t₀ = t₁ = t₂ = {0,1}`) where three indices compete for two values, certified impossible
+  through the deficiency theorem.  Both are checked by **kernel `decide`** (not
+  `native_decide`), so they carry no `Lean.ofReduceBool` and remain axiom-free.
+
+## What this file packages
+
+* `HallMarriage.hall_marriage_iff` — re-export of Mathlib's biconditional (badge: mathlib).
+* `HallMarriage.exists_sdr_of_hall` — sufficiency direction as a standalone corollary.
+* `HallMarriage.hall_condition_of_sdr` / `hall_condition_of_exists_sdr` — necessity, proved
+  directly by a counting argument.
+* `HallMarriage.no_sdr_of_deficiency` — the deficiency obstruction (new).
+* `HallMarriage.hall_violating_deficiency` — a concrete deficient sub-family.
+* `HallMarriage.hall_satisfiable_example` / `hall_violating_example` — concrete witnesses.
+
+All results are `0`-axiom (no `sorry`, no `axiom`, no `native_decide`).
+-/
+
+namespace HallMarriage
+
+variable {ι α : Type*} [DecidableEq α]
+
+/-- **Hall's marriage theorem** (re-export).  For a family `t : ι → Finset α`, a system of
+distinct representatives — an injective `f` with `f i ∈ t i` for all `i` — exists iff every
+sub-family `s` satisfies Hall's condition `#s ≤ #(s.biUnion t)`.  This is Mathlib's
+`Finset.all_card_le_biUnion_card_iff_exists_injective`, the foundation the corollaries below
+refine. -/
+theorem hall_marriage_iff (t : ι → Finset α) :
+    (∀ s : Finset ι, s.card ≤ (s.biUnion t).card) ↔
+      ∃ f : ι → α, Function.Injective f ∧ ∀ x, f x ∈ t x :=
+  Finset.all_card_le_biUnion_card_iff_exists_injective t
+
+/-- **Sufficiency direction.**  If Hall's condition holds for every sub-family, then a system
+of distinct representatives exists.  (The substantive half of the theorem; relies on Mathlib's
+compactness argument.) -/
+theorem exists_sdr_of_hall {t : ι → Finset α}
+    (h : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card) :
+    ∃ f : ι → α, Function.Injective f ∧ ∀ x, f x ∈ t x :=
+  (hall_marriage_iff t).mp h
+
+/-- **Necessity, direct proof.**  If `f` is an injective transversal of `t` then Hall's
+condition holds: every sub-family covers at least as many elements as it has members.  Proved
+by the counting inequality `#s = #(s.image f) ≤ #(s.biUnion t)`, using only that `f` is
+injective and lands in the sets — no finiteness of `ι`, no compactness. -/
+theorem hall_condition_of_sdr {t : ι → Finset α} {f : ι → α}
+    (hinj : Function.Injective f) (hf : ∀ x, f x ∈ t x) (s : Finset ι) :
+    s.card ≤ (s.biUnion t).card := by
+  calc s.card = (s.image f).card := (Finset.card_image_of_injective s hinj).symm
+    _ ≤ (s.biUnion t).card :=
+        Finset.card_le_card (by
+          intro a ha
+          obtain ⟨x, hx, rfl⟩ := Finset.mem_image.mp ha
+          exact Finset.mem_biUnion.mpr ⟨x, hx, hf x⟩)
+
+/-- **Necessity, existential form.**  If *some* system of distinct representatives exists, then
+Hall's condition holds.  This is the clean standalone converse of `exists_sdr_of_hall`, proved
+without re-deriving the biconditional. -/
+theorem hall_condition_of_exists_sdr {t : ι → Finset α}
+    (h : ∃ f : ι → α, Function.Injective f ∧ ∀ x, f x ∈ t x) (s : Finset ι) :
+    s.card ≤ (s.biUnion t).card := by
+  obtain ⟨f, hinj, hf⟩ := h
+  exact hall_condition_of_sdr hinj hf s
+
+/-- **The deficiency obstruction.**  If a sub-family `s` is *deficient* — it has strictly more
+members than the number of elements its sets jointly cover, `#(s.biUnion t) < #s` — then **no**
+system of distinct representatives exists.  This is the contrapositive of necessity and the
+form used in practice to certify that a matching is impossible. -/
+theorem no_sdr_of_deficiency {t : ι → Finset α} {s : Finset ι}
+    (hs : (s.biUnion t).card < s.card) :
+    ¬ ∃ f : ι → α, Function.Injective f ∧ ∀ x, f x ∈ t x := fun h =>
+  absurd (hall_condition_of_exists_sdr h s) (not_le.mpr hs)
+
+/-! ### Concrete witnesses over `Fin 3` (kernel `decide`, axiom-free) -/
+
+/-- **A satisfiable instance.**  The family `t₀ = {0,1}`, `t₁ = {1,2}`, `t₂ = {0,2}` over
+`Fin 3` admits the identity transversal `f = ![0,1,2]`: it is injective and `f i ∈ t i` for
+each `i`.  (Verified by kernel `decide` searching the `3³` candidate maps.) -/
+theorem hall_satisfiable_example :
+    ∃ f : Fin 3 → Fin 3, Function.Injective f ∧
+      ∀ x, f x ∈ (![({0, 1} : Finset (Fin 3)), {1, 2}, {0, 2}]) x := by
+  decide
+
+/-- **A deficient sub-family.**  For the family `t₀ = t₁ = t₂ = {0,1}` over `Fin 3`, the whole
+index set `univ` covers only `{0,1}` — two elements for three indices — so
+`#(univ.biUnion t) = 2 < 3 = #univ`. -/
+theorem hall_violating_deficiency :
+    ((Finset.univ : Finset (Fin 3)).biUnion
+        (![({0, 1} : Finset (Fin 3)), {0, 1}, {0, 1}])).card
+      < (Finset.univ : Finset (Fin 3)).card := by
+  decide
+
+/-- **A violating instance.**  Because three indices compete for the two values `{0,1}`, the
+family `t₀ = t₁ = t₂ = {0,1}` has **no** system of distinct representatives.  Established not by
+brute force over the maps but by applying the deficiency obstruction to the deficient sub-family
+`univ` — exactly how Hall's theorem is used to rule out a matching. -/
+theorem hall_violating_example :
+    ¬ ∃ f : Fin 3 → Fin 3, Function.Injective f ∧
+      ∀ x, f x ∈ (![({0, 1} : Finset (Fin 3)), {0, 1}, {0, 1}]) x :=
+  no_sdr_of_deficiency hall_violating_deficiency
+
+end HallMarriage

--- a/src/data/proofs/hall-marriage-theorem-oq-01/meta.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01/meta.json
@@ -1,0 +1,124 @@
+{
+  "id": "hall-marriage-theorem-oq-01",
+  "title": "Hall's marriage theorem: systems of distinct representatives, the deficiency obstruction, and concrete witnesses",
+  "slug": "hall-marriage-theorem-oq-01",
+  "description": "Hall's marriage theorem in its set-system (transversal) formulation: for a family t : ι → Finset α, an injective system of distinct representatives — an injective f with f i ∈ t i for all i — exists iff Hall's condition #s ≤ #(s.biUnion t) holds for every finite sub-family s. Mathlib proves only the biconditional (Finset.all_card_le_biUnion_card_iff_exists_injective, via Rado's compactness argument). This entry restates that headline and adds the two faces used in practice: the necessity direction proved directly by a one-line counting argument (no finiteness of ι, no compactness), and the deficiency / failure obstruction — a deficient sub-family (#(s.biUnion t) < #s) certifies that NO transversal exists. Two explicit Fin 3 witnesses (a satisfying family with an exhibited transversal, and a violating family where three indices compete for two values) confirm both directions by kernel decide. Distinct from the gallery's bipartite-graph matching formulation (halls-theorem-oq-01): this is the original set-system 'marriage' statement over a Finset family, built on a different Mathlib backbone.",
+  "meta": {
+    "author": "Philip Hall (1935); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HallMarriageTheoremOQ01.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "hall-marriage",
+      "transversal",
+      "matching",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.all_card_le_biUnion_card_iff_exists_injective",
+        "description": "Hall's marriage theorem (set-system form): (∀ s : Finset ι, #s ≤ #(s.biUnion t)) ↔ ∃ f, Function.Injective f ∧ ∀ x, f x ∈ t x. Proved in Mathlib via Rado's compactness argument over the finite case.",
+        "module": "Mathlib.Combinatorics.Hall.Basic"
+      },
+      {
+        "theorem": "Finset.card_image_of_injective",
+        "description": "If f is injective then #(s.image f) = #s; the equality driving the necessity counting step.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_le_card",
+        "description": "s ⊆ t → #s ≤ #t; applied to s.image f ⊆ s.biUnion t.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.mem_biUnion",
+        "description": "a ∈ s.biUnion t ↔ ∃ i ∈ s, a ∈ t i; witnesses the inclusion s.image f ⊆ s.biUnion t.",
+        "module": "Mathlib.Data.Finset.Lattice"
+      }
+    ],
+    "originalContributions": [
+      "hall_marriage_iff: the Hall biconditional in set-system form restated as the headline (Mathlib re-export).",
+      "exists_sdr_of_hall: the sufficiency direction (Hall's condition ⟹ a transversal exists) extracted as a standalone corollary.",
+      "hall_condition_of_sdr / hall_condition_of_exists_sdr: the necessity direction proved DIRECTLY by the counting inequality #s = #(s.image f) ≤ #(s.biUnion t), using only injectivity of f — no finiteness of ι and no compactness, so it is strictly cheaper than invoking the full biconditional. Mathlib does not isolate this direction.",
+      "no_sdr_of_deficiency: the deficiency / failure obstruction — a deficient sub-family (#(s.biUnion t) < #s) certifies that NO system of distinct representatives exists. The contrapositive of necessity and the form actually used to prove a matching impossible. New content.",
+      "hall_violating_deficiency: a concrete deficient sub-family — for t₀=t₁=t₂={0,1} over Fin 3, univ.biUnion t = {0,1} so #(univ.biUnion t) = 2 < 3 = #univ.",
+      "hall_satisfiable_example / hall_violating_example: explicit Fin 3 witnesses verified by kernel decide — the family {0,1},{1,2},{0,2} admits the transversal ![0,1,2], and the family {0,1},{0,1},{0,1} has no transversal (derived through the deficiency theorem, not brute force over the maps)."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Uses only kernel `decide` for the concrete witnesses (no native_decide, so no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 135,
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Philip Hall proved his marriage theorem in 1935: a family of finite sets has a system of distinct representatives (a transversal) iff every k of the sets jointly contain at least k elements. It is one of the central theorems of combinatorics — equivalent to König's theorem, Dilworth's theorem, the max-flow min-cut theorem for bipartite graphs, and Menger's theorem — and underlies transversal theory, Latin squares, doubly stochastic matrices (Birkhoff–von Neumann), and the theory of matchings.",
+    "problemStatement": "Mathlib's `Combinatorics/Hall/Basic.lean` proves the biconditional `Finset.all_card_le_biUnion_card_iff_exists_injective` via Rado's compactness argument, but packages neither the cheap necessity direction on its own nor the deficiency obstruction used to certify non-existence. Can the necessity direction be proved directly (without finiteness of the index type or compactness), and can the failure form — a deficient sub-family rules out any transversal — be isolated and exercised on concrete instances?\n\n**Answer:** Yes. Necessity is a one-step counting argument valid for an arbitrary index type, and its contrapositive is exactly the deficiency obstruction; both are confirmed on explicit Fin 3 families.",
+    "text": "The set-system formulation of Hall's theorem is restated from Mathlib, the sufficiency and necessity directions are split out (necessity proved directly), the deficiency obstruction is derived, and two explicit Fin 3 families — one satisfiable, one violating — are checked with no axioms.",
+    "proofStrategy": "1. hall_marriage_iff / exists_sdr_of_hall: re-export of Finset.all_card_le_biUnion_card_iff_exists_injective and its forward direction.\n2. hall_condition_of_sdr: for a transversal f and a sub-family s, s.image f ⊆ s.biUnion t (each f x ∈ t x) and f injective gives #s = #(s.image f) ≤ #(s.biUnion t) via card_image_of_injective and card_le_card.\n3. hall_condition_of_exists_sdr: destructure the existential and apply (2).\n4. no_sdr_of_deficiency: contrapositive — a transversal would force #s ≤ #(s.biUnion t), contradicting #(s.biUnion t) < #s.\n5. hall_satisfiable_example: kernel decide finds the transversal ![0,1,2] for {0,1},{1,2},{0,2}.\n6. hall_violating_deficiency + hall_violating_example: decide checks #(univ.biUnion t) = 2 < 3 for {0,1},{0,1},{0,1}, and no_sdr_of_deficiency converts the deficiency into impossibility of any transversal.",
+    "keyInsights": [
+      "**The biconditional is one re-export; the work is the two practical faces.** Mathlib supplies only the iff. The necessity direction proved directly and the deficiency obstruction — the form used to rule out matchings — are the genuine content here.",
+      "**Necessity is free of compactness.** The easy direction needs only that f is injective and lands in the sets: #s = #(s.image f) ≤ #(s.biUnion t). It holds for an arbitrary (possibly infinite) index type ι, unlike the sufficiency direction which relies on Rado's compactness argument over the finite case.",
+      "**Deficiency certifies impossibility.** In applications one rarely produces a transversal directly; one exhibits a deficient sub-family. no_sdr_of_deficiency packages exactly this contrapositive: more members than available representatives ⟹ no transversal.",
+      "**Two values, three suitors.** The violating witness t₀=t₁=t₂={0,1} is the smallest pigeonhole obstruction: three indices, two possible representatives, so univ is deficient and no injective choice exists — certified through the deficiency theorem rather than by brute-force enumeration."
+    ],
+    "exampleSections": [
+      {
+        "title": "Concrete Fin 3 witnesses",
+        "mathContext": "A satisfiable family with an exhibited transversal and a pigeonhole-violating family, both checked by kernel decide, confirming the iff and the deficiency obstruction numerically."
+      }
+    ]
+  },
+  "references": [
+    {
+      "authors": "Hall, Philip",
+      "title": "On Representatives of Subsets",
+      "year": "1935",
+      "note": "J. London Math. Soc. 10, 26–30 — the original marriage theorem: a family of finite sets has a system of distinct representatives iff every k of them cover ≥ k elements."
+    },
+    {
+      "authors": "Rado, Richard",
+      "title": "A theorem on independence relations",
+      "year": "1942",
+      "note": "Quart. J. Math. 13, 83–89 — the compactness argument extending Hall's theorem to infinite index sets, the route Mathlib formalizes."
+    },
+    {
+      "authors": "van Lint, J. H.; Wilson, R. M.",
+      "title": "A Course in Combinatorics",
+      "year": "2001",
+      "note": "Chapter 5 — Hall's marriage theorem, systems of distinct representatives, the deficiency version, and equivalences with König's and Dilworth's theorems."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "halls-theorem-oq-01",
+      "reason": "The bipartite-graph matching formulation of Hall's theorem (SimpleGraph.IsBipartiteWith / IsMatching). This entry gives the dual set-system / transversal (SDR) formulation over a Finset family — the original 'marriage' statement — on a different Mathlib backbone."
+    }
+  ],
+  "conclusion": {
+    "summary": "The set-system formulation of Hall's marriage theorem is restated from Mathlib (hall_marriage_iff, exists_sdr_of_hall), the necessity direction is proved directly by a counting argument (hall_condition_of_sdr, hall_condition_of_exists_sdr), the deficiency obstruction is derived (no_sdr_of_deficiency), and two explicit Fin 3 families are verified (hall_satisfiable_example, hall_violating_deficiency, hall_violating_example). All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Provides the transversal-theory face of Hall's theorem alongside the gallery's bipartite-graph version, and isolates the deficiency obstruction — the certificate of impossibility — as a reusable standalone lemma valid for an arbitrary index type.",
+    "openQuestions": [
+      "Can the defect (deficiency) version of Hall's theorem be formalized quantitatively — that the maximum size of a partial transversal equals #ι − max_s (#s − #(s.biUnion t)) — refining the all-or-nothing obstruction to an exact count?",
+      "Can König's theorem (max matching = min vertex cover in bipartite graphs) be derived in the gallery from this set-system Hall theorem, exhibiting the standard equivalence?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "HallMarriage",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/HallMarriageTheoremOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Hall's marriage theorem — set-system (transversal) formulation

Adds the **set-system / system-of-distinct-representatives (SDR)** form of Hall's marriage theorem: for a family `t : ι → Finset α`, an injective transversal (`f` injective with `f i ∈ t i`) exists iff Hall's condition `#s ≤ #(s.biUnion t)` holds for every finite sub-family `s`.

This is **distinct** from the gallery's existing `halls-theorem-oq-01`, which is the **bipartite-graph matching** formulation (`SimpleGraph.IsBipartiteWith` / `IsMatching` / `neighborSet`). This entry is the original "marriage" statement over a `Finset` family, built on a different Mathlib backbone (`Mathlib.Combinatorics.Hall.Basic`). Cross-referenced in the meta.

### Content
- `hall_marriage_iff` — re-export of `Finset.all_card_le_biUnion_card_iff_exists_injective` (badge: **mathlib**).
- `exists_sdr_of_hall` — sufficiency direction as a standalone corollary.
- `hall_condition_of_sdr` / `hall_condition_of_exists_sdr` — **necessity proved directly** by the counting inequality `#s = #(s.image f) ≤ #(s.biUnion t)`, using only injectivity of `f`. No finiteness of `ι`, no compactness — strictly cheaper than invoking the full biconditional, and Mathlib does not isolate it.
- `no_sdr_of_deficiency` — **the deficiency / failure obstruction**: a deficient sub-family (`#(s.biUnion t) < #s`) certifies that no transversal exists. The contrapositive of necessity, and the form actually used to rule out matchings. New content.
- `hall_satisfiable_example` / `hall_violating_deficiency` / `hall_violating_example` — concrete `Fin 3` witnesses: the family `{0,1},{1,2},{0,2}` admits transversal `![0,1,2]`; the family `{0,1},{0,1},{0,1}` (three indices, two values) has no transversal, certified via the deficiency theorem rather than brute force.

### Verification
- Builds via `./proofs/scripts/docker-build.sh Proofs.HallMarriageTheoremOQ01` ✓ (`Build completed successfully`).
- **0 axioms, 0 sorries.** Concrete witnesses use **kernel `decide`** (not `native_decide`), so no `Lean.ofReduceBool`.
- 8 theorems, 0 definitions, 135 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)