### PR TITLE
audit(euler-criterion-squares-oq-01): correct theoremCount 10→11

### DIFF
--- a/src/data/proofs/euler-criterion-squares-oq-01/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01/meta.json
@@ -30,7 +30,7 @@
     ],
     "dateAdded": "2026-06-20",
     "lineCount": 105,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
   },
@@ -68,7 +68,7 @@
     "namespace": "EulerCriterionSquaresOQ01",
     "lineCount": 105,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 0,
     "path": "Proofs/EulerCriterionSquaresOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Integrity Issue

**Proof**: euler-criterion-squares-oq-01
**Problem**: `theoremCount` understated by 1.

## Evidence

**meta.json claims**: `theoremCount: 10` (both `meta.theoremCount` and `leanFile.theoremCount`)
**Lean file shows**: 11 theorem declarations in `Proofs/EulerCriterionSquaresOQ01.lean`:
`half_eq`, `isSquare_iff_pow`, `pow_half_eq_one_or_neg_one`, `one_ne_neg_one`, `not_isSquare_iff_pow`, `legendreSym_eq_pow`, `legendreSym_mul`, `isSquare_two_mod_seven`, `not_isSquare_three_mod_seven`, `two_pow_three_mod_seven`, `three_pow_three_mod_seven`.

0 defs, 0 axioms, 0 sorries — those fields are accurate.

## Fix

Updated both `theoremCount` fields 10 → 11. No claim/status/badge change.

---
Discovered during gallery integrity audit. LOW severity (count nit).