### PR TITLE
audit: correct theoremCount for 8 gallery entries

### DIFF
--- a/src/data/proofs/frobenius-endomorphism-oq-01/meta.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01/meta.json
@@ -63,7 +63,7 @@
     ],
     "dateAdded": "2026-06-20",
     "lineCount": 101,
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
   },
@@ -101,7 +101,7 @@
     "namespace": "FrobeniusEndomorphismOQ01",
     "lineCount": 101,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/FrobeniusEndomorphismOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/gamma-log-convexity-oq-01/meta.json
+++ b/src/data/proofs/gamma-log-convexity-oq-01/meta.json
@@ -56,7 +56,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully verified, 0 axioms, 0 sorries. All theorems depend only on propext, Classical.choice, Quot.sound (Lean's foundational axioms). No native_decide, so no Lean.ofReduceBool.",
     "lineCount": 149,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0
   },
   "overview": {
@@ -165,7 +165,7 @@
     "namespace": "GammaLogConvexityOQ01",
     "lineCount": 149,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/GammaLogConvexityOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/inclusion-exclusion-oq-04/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-04/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Mathlib's Finset combinatorics. The worked example uses `decide` (not `native_decide`), so the file depends only on the foundational axioms propext / Classical.choice / Quot.sound.",
     "lineCount": 187,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 0,
     "originalContributions": [
       "card_avoid_sieve: #(elements in none of the S_i) = Σ_{t⊆s} (-1)^|t| |⋂_{i∈t} S_i| — the dual/sieve form of inclusion-exclusion, the complement of the gallery's existing union form",
@@ -143,7 +143,7 @@
     "path": "Proofs/InclusionExclusionSieve.lean",
     "filename": "InclusionExclusionSieve.lean",
     "lineCount": 187,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "axiomCount": 0,
     "defCount": 0,
     "isAristotle": false,

--- a/src/data/proofs/inverse-galois-a5-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-a5-oq-03/meta.json
@@ -33,7 +33,7 @@
     ],
     "dateAdded": "2026-06-19",
     "lineCount": 205,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
   },
@@ -44,7 +44,7 @@
     "namespace": "InverseGaloisA5OQ03",
     "lineCount": 205,
     "axiomCount": 2,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/InverseGaloisA5OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/knights-tour-oblique-oq-02/meta.json
+++ b/src/data/proofs/knights-tour-oblique-oq-02/meta.json
@@ -43,7 +43,7 @@
         "module": "Mathlib.Data.List.Basic"
       }
     ],
-    "theoremCount": 49,
+    "theoremCount": 34,
     "definitionCount": 11
   },
   "overview": {
@@ -188,7 +188,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 10,
-    "theoremCount": 37
+    "theoremCount": 34
   },
   "sorries": 0
 }

--- a/src/data/proofs/lucas-lehmer-test-oq-01/meta.json
+++ b/src/data/proofs/lucas-lehmer-test-oq-01/meta.json
@@ -11,7 +11,7 @@
     "namespace": "LucasLehmerTestOQ01",
     "lineCount": 110,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 14,
     "definitionCount": 0,
     "path": "Proofs/LucasLehmerTestOQ01.lean",
     "sorries": 0
@@ -33,7 +33,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 110,
-    "theoremCount": 11,
+    "theoremCount": 14,
     "definitionCount": 0,
     "badge": "mathlib",
     "originalContributions": [

--- a/src/data/proofs/matrix-posdef-sqrt-oq-01/meta.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01/meta.json
@@ -18,7 +18,7 @@
     "namespace": "MatrixPosDefSqrtOQ01",
     "lineCount": 140,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 0,
     "path": "Proofs/MatrixPosDefSqrtOQ01.lean",
     "sorries": 0
@@ -52,7 +52,7 @@
     "lineCount": 140,
     "assumptions": "0 axioms, 0 sorries, no native_decide, no Lean.ofReduceBool. All theorems depend only on the foundational propext / Classical.choice / Quot.sound. The square root is Mathlib's CFC.sqrt (continuous functional calculus over a C⋆-algebra); on Matrix n n 𝕜 with RCLike 𝕜 the relevant nonnegativity is the scoped MatrixOrder order, where Matrix.nonneg_iff_posSemidef gives 0 ≤ A ↔ A.PosSemidef and Matrix.PosSemidef.nonneg is the forward direction. The defining property re-exports CFC.sqrt_mul_sqrt_self / CFC.sq_sqrt; structure uses CFC.sqrt_nonneg with LE.le.posSemidef and Matrix.PosSemidef.isHermitian; uniqueness re-exports CFC.sqrt_unique (b·b = a, 0 ≤ b ⟹ √a = b); the corollaries (√0, √1, √(A²)) and the concrete diagonal instance are uniqueness applied to explicit candidates, with Matrix.PosSemidef.diagonal for diag(2,3) ⪰ 0 and diagonal_mul_diagonal for the squaring. The determinant shadow uses Matrix.det_pow. The genuine hypotheses are the domain conditions A.PosSemidef / B.PosSemidef.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 0
   },
   "overview": {

--- a/src/data/proofs/second-isomorphism-theorem-modules-oq-01/meta.json
+++ b/src/data/proofs/second-isomorphism-theorem-modules-oq-01/meta.json
@@ -52,7 +52,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
     "lineCount": 131,
-    "theoremCount": 6,
+    "theoremCount": 4,
     "definitionCount": 1
   },
   "overview": {
@@ -152,7 +152,7 @@
     "namespace": "SecondIsomorphismTheoremModulesOQ01",
     "lineCount": 131,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 4,
     "definitionCount": 1,
     "path": "Proofs/SecondIsomorphismTheoremModulesOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit

During the periodic gallery integrity audit, `theoremCount` (both `meta.theoremCount` and `leanFile.theoremCount`) was found out of sync with the actual `theorem`/`lemma` declarations in the Lean source for 8 entries.

Counts were verified by enumerating top-level `theorem`/`lemma` declarations and excluding declaration-like lines appearing inside doc comments (e.g. `inverse-galois-a5-oq-03` line 66 is comment prose, not a theorem).

| slug | stored | corrected |
|---|---|---|
| frobenius-endomorphism-oq-01 | 7 | 9 |
| gamma-log-convexity-oq-01 | 5 | 6 |
| inclusion-exclusion-oq-04 | 9 | 8 |
| inverse-galois-a5-oq-03 | 9 | 8 |
| lucas-lehmer-test-oq-01 | 11 | 14 |
| matrix-posdef-sqrt-oq-01 | 9 | 11 |
| second-isomorphism-theorem-modules-oq-01 | 6 | 4 |
| knights-tour-oblique-oq-02 | lf 37 / meta 49 | 34 |

## Not affected

No `status`, `badge`, `sorries`, or `axiomCount` claims changed. All 8 entries remain accurately classified — `knights-tour-oblique-oq-02` stays `axiomatized`/`axiom` with its documented `Lean.ofReduceBool` (native_decide) assumption.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)