### PR TITLE
research(dissection-of-cubes-oq-01-oq-01-oq-01): genuine minimal-collision dissection needs ≥3 cubes [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/DissectionOfCubesOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ01OQ01OQ01.lean
@@ -202,4 +202,83 @@ file genuinely `axiom`-free. The transport is a one-liner
 (`at_least_two_colliding_cubes g.toCubeDissection h`) for any consumer who wants it.
 -/
 
+-- ============================================================
+-- SECTION 5: The colliding pair alone cannot fill — a genuine
+--            minimal-collision dissection needs ≥ 3 cubes
+-- ============================================================
+
+/-!
+The previous sections show the *specific* combinatorial witness is not geometric. Here we
+extract the first genuine **lower bound on the cardinality** of any volume-filling
+minimal-collision dissection, using only the volumetric coverage field and the geometry of
+interior-disjoint cubes in `[0,1]³`. It rules out the smallest conceivable case — the colliding
+pair on its own — so a genuine `HasMinimalCollision` dissection, if one exists at all, must
+carry at least one further (distinct-sized) cube.
+
+The engine is a clean elementary fact: two interior-disjoint cubes inside the unit cube have
+total side length `≤ 1` along the separating axis, hence combined volume `< 1` (strictly, since
+the cross term `3ab(a+b) > 0`). No measure theory and no geometric axiom is used.
+-/
+
+/-- **Separation bound.** Two interior-disjoint cubes both contained in `[0,1]³` have total side
+    length at most `1`: whichever axis separates them, the far cube's containment leaves room
+    only for the sum of the two sides. -/
+theorem side_sum_le_one (c₁ c₂ : Cube)
+    (h₁ : c₁.inUnitCube) (h₂ : c₂.inUnitCube) (hd : c₁.interiorDisjoint c₂) :
+    c₁.side + c₂.side ≤ 1 := by
+  unfold Cube.inUnitCube at h₁ h₂
+  unfold Cube.interiorDisjoint at hd
+  obtain ⟨h1x0, h1x1, h1y0, h1y1, h1z0, h1z1⟩ := h₁
+  obtain ⟨h2x0, h2x1, h2y0, h2y1, h2z0, h2z1⟩ := h₂
+  rcases hd with h | h | h | h | h | h <;> linarith
+
+/-- **Volume bound.** Two interior-disjoint cubes inside the unit cube have combined volume
+    strictly below `1`. With `a + b ≤ 1` and `a, b > 0`,
+    `a³ + b³ = (a+b)³ − 3ab(a+b) ≤ 1 − 3ab(a+b) < 1`. -/
+theorem two_disjoint_volume_lt_one (c₁ c₂ : Cube)
+    (h₁ : c₁.inUnitCube) (h₂ : c₂.inUnitCube) (hd : c₁.interiorDisjoint c₂) :
+    c₁.size ^ 3 + c₂.size ^ 3 < 1 := by
+  have hsum := side_sum_le_one c₁ c₂ h₁ h₂ hd
+  have hp1 := c₁.side_pos
+  have hp2 := c₂.side_pos
+  have hle : (c₁.side + c₂.side) ^ 3 ≤ 1 := pow_le_one₀ (by linarith) hsum
+  have hpos : 0 < 3 * c₁.side * c₂.side * (c₁.side + c₂.side) := by positivity
+  have key : c₁.side ^ 3 + c₂.side ^ 3
+      = (c₁.side + c₂.side) ^ 3 - 3 * c₁.side * c₂.side * (c₁.side + c₂.side) := by ring
+  show c₁.side ^ 3 + c₂.side ^ 3 < 1
+  rw [key]; linarith
+
+/-- **No two-cube genuine dissection.** Volumetric coverage `∑ side³ = 1` is incompatible with
+    having exactly two cubes: any two interior-disjoint cubes in `[0,1]³` fill strictly less than
+    the whole volume. -/
+theorem geo_card_ne_two (g : GeoCubeDissection) : g.cubes.card ≠ 2 := by
+  intro hcard
+  obtain ⟨c₁, c₂, hne, hpair⟩ := Finset.card_eq_two.mp hcard
+  have hc1 : c₁ ∈ g.cubes := by rw [hpair]; simp
+  have hc2 : c₂ ∈ g.cubes := by rw [hpair]; simp
+  have hcontain1 := g.all_contained c₁ hc1
+  have hcontain2 := g.all_contained c₂ hc2
+  have hdisj := g.pairwise_disjoint c₁ hc1 c₂ hc2 hne
+  have hvol := g.volume_fills
+  rw [hpair, Finset.sum_pair hne] at hvol
+  have hlt := two_disjoint_volume_lt_one c₁ c₂ hcontain1 hcontain2 hdisj
+  linarith
+
+/-- **Headline.** A *genuine* (volume-filling) minimal-collision dissection — if one exists —
+    must contain **at least three cubes**. The two colliding cubes cannot constitute the whole
+    dissection, because two interior-disjoint cubes never fill the unit cube. This rules out the
+    smallest case of the open question and sharpens the target: any genuine `HasMinimalCollision`
+    tiling needs a third, distinct-sized cube beyond the colliding pair. -/
+theorem minimal_collision_needs_three (g : GeoCubeDissection)
+    (h : HasMinimalCollision g.toCubeDissection) : 3 ≤ g.cubes.card := by
+  unfold HasMinimalCollision at h
+  have hsub : collidingCubes g.toCubeDissection ⊆ g.toCubeDissection.cubes :=
+    Finset.filter_subset _ _
+  have h2 : 2 ≤ g.cubes.card := by
+    have hcard := Finset.card_le_card hsub
+    rw [h] at hcard
+    simpa using hcard
+  have hne2 := geo_card_ne_two g
+  omega
+
 end DissectionOfCubesOQ01OQ01OQ01

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "dissection-of-cubes-oq-01-oq-01-oq-01",
   "title": "Genuine Coverage Kills the Minimal-Collision Witness",
   "slug": "dissection-of-cubes-oq-01-oq-01-oq-01",
-  "description": "The gallery result `minimal_collision_achievable` (OQ-01-01) builds a CubeDissection with exactly 2 colliding cubes, but that structure carries `covers_unit_cube : True` as a placeholder — the cubes do not actually fill the unit cube. This entry replaces the placeholder with a genuine volumetric coverage predicate `∑ c.side³ = 1` (the necessary, and with disjointness measure-sufficient, tiling condition) in a new `GeoCubeDissection` structure. Two results: (1) the predicate is satisfiable — the single unit cube is a genuine dissection with 0 colliding cubes; (2) the published minimal-collision example {A,B,C} (sizes 1/4,1/4,1/3) has total volume 59/864 ≈ 0.068 ≠ 1, so NO GeoCubeDissection can have that cube set. The combinatorial 2-collision witness is therefore not geometric; whether any genuine tiling achieves exactly 2 collisions remains open.",
+  "description": "The gallery result `minimal_collision_achievable` (OQ-01-01) builds a CubeDissection with exactly 2 colliding cubes, but that structure carries `covers_unit_cube : True` as a placeholder — the cubes do not actually fill the unit cube. This entry replaces the placeholder with a genuine volumetric coverage predicate `∑ c.side³ = 1` (the necessary, and with disjointness measure-sufficient, tiling condition) in a new `GeoCubeDissection` structure. Two results: (1) the predicate is satisfiable — the single unit cube is a genuine dissection with 0 colliding cubes; (2) the published minimal-collision example {A,B,C} (sizes 1/4,1/4,1/3) has total volume 59/864 ≈ 0.068 ≠ 1, so NO GeoCubeDissection can have that cube set. The combinatorial 2-collision witness is therefore not geometric; whether any genuine tiling achieves exactly 2 collisions remains open. A new cardinality bound sharpens the target: two interior-disjoint cubes in [0,1]³ have side sum ≤ 1 and combined volume < 1, so no GeoCubeDissection can have exactly 2 cubes — hence any genuine minimal-collision dissection (if one exists) must contain at least 3 cubes, ruling out the colliding pair on its own.",
   "meta": {
     "author": "Lean Genius Researcher",
     "sourceUrl": "https://en.wikipedia.org/wiki/Squaring_the_square",
@@ -35,6 +35,31 @@
         "theorem": "Finset.mem_filter",
         "description": "Membership in a filtered Finset",
         "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.card_eq_two",
+        "description": "A Finset has card 2 iff it is an unordered pair of distinct elements",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.sum_pair",
+        "description": "Sum over a two-element Finset {a,b} with a ≠ b",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.filter_subset",
+        "description": "A filtered Finset is a subset of the original",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.card_le_card",
+        "description": "Cardinality is monotone under subset",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "pow_le_one₀",
+        "description": "0 ≤ a ≤ 1 implies aⁿ ≤ 1 (used for (a+b)³ ≤ 1)",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
       }
     ],
     "originalContributions": [
@@ -43,25 +68,30 @@
       "unitGeoDissection: the single unit cube as a genuine volume-filling dissection (predicate is satisfiable)",
       "unitGeo_no_collision: the unit-cube dissection has 0 colliding cubes",
       "exampleCubes_volume_ne_one: the OQ-01-01 minimal-collision cube set has total volume 59/864 ≠ 1",
-      "no_geo_with_exampleCubes: no GeoCubeDissection can be built from the minimal-collision cube set"
+      "no_geo_with_exampleCubes: no GeoCubeDissection can be built from the minimal-collision cube set",
+      "side_sum_le_one: two interior-disjoint cubes contained in [0,1]³ have total side length ≤ 1 (case analysis over the 6-way separating-axis disjunction)",
+      "two_disjoint_volume_lt_one: two interior-disjoint cubes in [0,1]³ have combined volume a³+b³ = (a+b)³−3ab(a+b) < 1, strictly, since the cross term is positive",
+      "geo_card_ne_two: no GeoCubeDissection has exactly 2 cubes — volumetric coverage ∑side³=1 is incompatible with two disjoint cubes filling under the whole volume",
+      "minimal_collision_needs_three: headline cardinality bound — any genuine (volume-filling) minimal-collision dissection must contain ≥ 3 cubes, so the colliding pair alone cannot tile"
     ],
     "dateAdded": "2026-06-20",
     "assumptions": "The coverage predicate `volume_fills` is the volumetric (measure) coverage condition ∑ c.side³ = 1, not pointwise coverage of every boundary point. For axis-aligned, pairwise interior-disjoint cubes contained in [0,1]³ it is exactly the necessary condition for filling the unit cube and is measure-sufficient. Every result in this file is 0-axiom and 0-sorry. The ≥2 lower bound (DissectionOfCubesOQ01.at_least_two_colliding_cubes, which depends on the two geometric axioms in DissectionOfCubes.lean) is referenced only in prose, deliberately not re-exported as a theorem here, so this file imports no axioms.",
     "axiomCount": 0,
-    "lineCount": 205,
-    "theoremCount": 7,
+    "lineCount": 284,
+    "theoremCount": 11,
     "definitionCount": 4
   },
   "overview": {
     "historicalContext": "DissectionOfCubesOQ01 proved every nonempty cube dissection has ≥ 2 colliding cubes; DissectionOfCubesOQ01OQ01 then proved the bound 2 is tight — but only within a formalization whose covering constraint is the placeholder `covers_unit_cube : True`. The achievability witness places three tiny cubes inside [0,1]³ that occupy under 7% of the volume. This sub-question asks the natural follow-up: does the witness survive once coverage is real?",
     "problemStatement": "Replace `covers_unit_cube : True` with a genuine geometric coverage predicate using explicit tile coordinates, and determine whether the minimal-collision result (HasMinimalCollision) still holds.",
     "text": "Introduces GeoCubeDissection with volumetric coverage ∑ c.side³ = 1. Shows the predicate is satisfiable (unit cube, 0 collisions) and that the published 2-collision witness fails it (volume 59/864), so the witness is not geometric. The deep question — whether any genuine tiling achieves exactly 2 collisions — stays open.",
-    "proofStrategy": "1. Define GeoCubeDissection: same containment + pairwise-disjointness as CubeDissection, with `volume_fills : ∑ c.side³ = 1` in place of the True placeholder. 2. A forgetful map toCubeDissection reuses collidingCubes/HasMinimalCollision. 3. unitGeoDissection witnesses satisfiability (sum over a singleton = 1³ = 1) and has empty collidingCubes (no second cube). 4. For the OQ-01-01 example, peel the 3-term Finset sum via Finset.sum_insert (using the existing distinctness lemmas) and norm_num to 2·(1/4)³+(1/3)³ = 59/864 ≠ 1; hence no GeoCubeDissection has that cube set.",
+    "proofStrategy": "1. Define GeoCubeDissection: same containment + pairwise-disjointness as CubeDissection, with `volume_fills : ∑ c.side³ = 1` in place of the True placeholder. 2. A forgetful map toCubeDissection reuses collidingCubes/HasMinimalCollision. 3. unitGeoDissection witnesses satisfiability (sum over a singleton = 1³ = 1) and has empty collidingCubes (no second cube). 4. For the OQ-01-01 example, peel the 3-term Finset sum via Finset.sum_insert (using the existing distinctness lemmas) and norm_num to 2·(1/4)³+(1/3)³ = 59/864 ≠ 1; hence no GeoCubeDissection has that cube set. 5. (SECTION 5) For two interior-disjoint cubes in [0,1]³, rcases the 6-way separating-axis disjunction and linarith yields side sum ≤ 1; then a³+b³ = (a+b)³ − 3ab(a+b) with pow_le_one₀ and positivity gives combined volume < 1. So geo_card_ne_two (no 2-cube GeoCubeDissection via Finset.card_eq_two + Finset.sum_pair), and minimal_collision_needs_three (collidingCubes ⊆ cubes gives card ≥ 2, geo_card_ne_two rules out =2, omega gives ≥ 3).",
     "keyInsights": [
       "The `True` placeholder was masking a genuine obstruction: the minimal-collision witness covers under 7% of the unit cube",
       "Volumetric coverage ∑ side³ = 1 is the right machine-checkable surrogate: necessary for any tiling and, with interior-disjointness, sufficient for full-measure coverage",
       "Satisfiability matters: the single unit cube shows the predicate is not vacuous (and has 0 collisions, so it is not itself a minimal-collision example)",
-      "The combinatorial achievability and the geometric achievability are genuinely different problems — the former is proved, the latter remains open"
+      "The combinatorial achievability and the geometric achievability are genuinely different problems — the former is proved, the latter remains open",
+      "A cardinality lower bound follows cheaply from coverage alone: two interior-disjoint cubes have side sum ≤ 1, so combined volume a³+b³ = (a+b)³−3ab(a+b) < 1; the colliding pair can never fill the unit cube, forcing any genuine minimal-collision dissection to use ≥ 3 cubes"
     ],
     "prerequisites": [
       "Finset big operators (sum over insert / singleton)",
@@ -103,15 +133,23 @@
       "id": "open-question",
       "title": "The Open Question, Restated",
       "startLine": 181,
-      "endLine": 206,
+      "endLine": 203,
       "summary": "Restates the open geometric question and transports the ≥2 lower bound to GeoCubeDissection."
+    },
+    {
+      "id": "cardinality-bound",
+      "title": "SECTION 5 — The Colliding Pair Alone Cannot Fill (≥ 3 cubes)",
+      "startLine": 205,
+      "endLine": 284,
+      "summary": "side_sum_le_one (two disjoint cubes in [0,1]³ have side sum ≤ 1), two_disjoint_volume_lt_one (combined volume < 1 via a³+b³=(a+b)³−3ab(a+b)), geo_card_ne_two (no 2-cube GeoCubeDissection), and the headline minimal_collision_needs_three (any genuine minimal-collision dissection needs ≥ 3 cubes)."
     }
   ],
   "conclusion": {
     "summary": "Replacing the `covers_unit_cube : True` placeholder with the genuine volumetric coverage predicate ∑ c.side³ = 1 destroys the published minimal-collision witness: the three-cube example occupies volume 59/864 ≈ 0.068, so no GeoCubeDissection can use it. The predicate is satisfiable (the unit cube fills it with 0 collisions), confirming it is a real, non-vacuous constraint.",
-    "implications": "This isolates exactly where the open problem lives. The combinatorial constraints (containment + disjointness) do not obstruct 2 colliding cubes — but the volume/coverage constraint does obstruct the specific known witness. Whether some other genuine tiling achieves exactly 2 collisions is the remaining open geometric question; Littlewood's cascade heuristic suggests the answer is no, but it is unproved.",
+    "implications": "This isolates exactly where the open problem lives. The combinatorial constraints (containment + disjointness) do not obstruct 2 colliding cubes — but the volume/coverage constraint does obstruct the specific known witness, and now also any 2-cube configuration. The new cardinality bound (minimal_collision_needs_three) takes the first step beyond 'the known witness fails': it rules out the smallest case unconditionally, showing a genuine minimal-collision dissection must spend at least three cubes — the colliding pair plus a third, distinct-sized cube. Whether some genuine tiling achieves exactly 2 collisions remains the open geometric question; Littlewood's cascade heuristic suggests the answer is no, but it is unproved.",
     "openQuestions": [
-      "Does there exist a GeoCubeDissection (∑ side³ = 1) with exactly 2 colliding cubes?",
+      "Does there exist a GeoCubeDissection (∑ side³ = 1) with exactly 2 colliding cubes? (Now known: it would need ≥ 3 cubes total.)",
+      "Can the cardinality bound be pushed beyond 3 — i.e. is there an explicit n with every genuine minimal-collision dissection having > n cubes, or a proof that none exists?",
       "Does the volume constraint combined with disjointness force strictly more than 2 colliding cubes?",
       "Can Littlewood's cascade be formalized into a quantitative lower bound on colliding cubes?"
     ]
@@ -129,9 +167,9 @@
       "DissectionOfCubesOQ01OQ01"
     ],
     "namespace": "DissectionOfCubesOQ01OQ01OQ01",
-    "lineCount": 205,
+    "lineCount": 284,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 11,
     "definitionCount": 4,
     "path": "Proofs/DissectionOfCubesOQ01OQ01OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the gallery entry `dissection-of-cubes-oq-01-oq-01-oq-01` with **SECTION 5**: the first genuine *cardinality* lower bound on any volume-filling minimal-collision cube dissection.

Prior state of this entry: `GeoCubeDissection` replaces the `covers_unit_cube : True` placeholder with the volumetric coverage identity `∑ side³ = 1`; it was shown satisfiable (unit cube, 0 collisions) and that the published 2-collision witness is **not** geometric (volume 59/864 ≠ 1). The deep open question — does *any* genuine tiling achieve exactly 2 collisions? — remained wide open.

This PR takes the first unconditional step beyond "the known witness fails", ruling out the smallest conceivable case:

| Theorem | Statement |
|---------|-----------|
| `side_sum_le_one` | Two interior-disjoint cubes in [0,1]³ have total side length ≤ 1 (case split on the 6-way separating-axis disjunction). |
| `two_disjoint_volume_lt_one` | Their combined volume is strictly < 1: `a³+b³ = (a+b)³ − 3ab(a+b)`, and the cross term is positive. |
| `geo_card_ne_two` | No `GeoCubeDissection` has exactly 2 cubes — coverage `∑ side³ = 1` is incompatible with two disjoint cubes. |
| **`minimal_collision_needs_three`** | **Any genuine (volume-filling) minimal-collision dissection must contain ≥ 3 cubes** — the colliding pair alone can never tile the unit cube. |

No measure theory and **no geometric axiom** is used (the two axioms in `DissectionOfCubes.lean` are not invoked). Every result is `sorry`-free and `axiom`-free.

## Verification
`./proofs/scripts/docker-build.sh Proofs.DissectionOfCubesOQ01OQ01OQ01` → `Completed successfully!`

File now: 284 lines, 11 theorems/lemmas, 4 defs, 0 sorries, 0 axioms. `meta.json` updated (theoremCount 7→11, lineCount, contributions, mathlib deps, sections, open questions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)