### PR TITLE
audit(gallery): fix 4 theoremCount mismatches + 1 badge tier correction

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -16405,6 +16405,866 @@
       "lastAudited": "2026-06-20T21:00:41Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "baire-category-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "banach-steinhaus-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-group-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chevalley-warning-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-08": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-09": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "composition-card-2pow-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "composition-parts-choose-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "conjugacy-class-equation-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cramers-rule-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cube-root-2-irrational-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "denumerability-rationals-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "denumerability-rationals-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "denumerability-rationals-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "det-conjugate-transpose-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dini-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dirichlet-approximation-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dirichlet-approximation-theorem-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dirichlet-approximation-theorem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dissection-of-cubes-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-rules-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dyck-catalan-count-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "egorov-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "eisenstein-criterion-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1104-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-660-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-divisibility-pigeonhole-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-ginzburg-ziv-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-criterion-squares-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-identity-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-totient-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-totient-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-totient-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "factor-remainder-theorem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fatou-lemma-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fermat-two-squares-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "frobenius-endomorphism-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "frobenius-number-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gamma-log-convexity-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gamma-reflection-formula-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gauss-lemma-primitive-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-02-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-09": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-10": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gram-linear-independence-iff-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hall-marriage-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "halls-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "harmonic-divergence-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-10-oq-04-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-10-oq-04-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-10-oq-04-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-10-oq-04-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inclusion-exclusion-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "issues-fixed",
+      "issues": [
+        "theoremCount mismatch"
+      ]
+    },
+    "infinitude-primes-4k3-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "infinitude-primes-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "integral-root-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inverse-galois-a5-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "issues-fixed",
+      "issues": [
+        "theoremCount mismatch"
+      ]
+    },
+    "jacobi-symbol-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "knights-tour-oblique-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "issues-fixed",
+      "issues": [
+        "theoremCount mismatch"
+      ]
+    },
+    "lagrange-theorem-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-02-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-02-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "law-of-cosines-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "legendre-factorial-formula-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lifting-the-exponent-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lifting-the-exponent-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "liouville-theorem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "little-wedderburn-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lucas-lehmer-test-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "mantel-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "maschke-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "matrix-posdef-sqrt-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "matrix-similarity-invariants-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "mean-value-theorem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "menelaus-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "minkowski-theorem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "nakayama-lemma-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "nesbitt-inequality-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "newton-power-sum-identities-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "niven-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "niven-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "open-mapping-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "order-one-add-mul-prime-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "perfect-numbers-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "primitive-roots-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "primitive-roots-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ptolemys-theorem-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-08": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-09": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "quadratic-gauss-sum-square-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "rearrangement-inequality-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "repunit-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "schroder-numbers-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "schur-lemma-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "second-isomorphism-theorem-modules-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "issues-fixed",
+      "issues": [
+        "theoremCount mismatch + badge tier (verified->mathlib)"
+      ]
+    },
+    "sophie-germain-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "spectral-trace-det-eigenvalues-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "spectral-trace-det-eigenvalues-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "stirling-first-kind-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "stirling-first-kind-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "stirling-formula-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "stirling-second-kind-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sum-of-divisors-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sum-of-divisors-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sum-of-divisors-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sum-of-divisors-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sum-of-kth-powers-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "summation-by-parts-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sylvester-sequence-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "tangent-addition-formula-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "three-subgroups-lemma-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "tietze-extension-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "triangle-angle-sum-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "triangle-angle-sum-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "triangle-inequality-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "triangular-reciprocals-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "uniformbell-multinomial-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "urysohns-lemma-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "van-aubel-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "vandermonde-interpolation-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "weierstrass-approximation-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "wilsons-theorem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
+    },
+    "zsqrtd-neg-two-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-20T00:00:00.000Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/inclusion-exclusion-oq-04/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-04/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Mathlib's Finset combinatorics. The worked example uses `decide` (not `native_decide`), so the file depends only on the foundational axioms propext / Classical.choice / Quot.sound.",
     "lineCount": 187,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 0,
     "originalContributions": [
       "card_avoid_sieve: #(elements in none of the S_i) = Σ_{t⊆s} (-1)^|t| |⋂_{i∈t} S_i| — the dual/sieve form of inclusion-exclusion, the complement of the gallery's existing union form",
@@ -143,7 +143,7 @@
     "path": "Proofs/InclusionExclusionSieve.lean",
     "filename": "InclusionExclusionSieve.lean",
     "lineCount": 187,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "axiomCount": 0,
     "defCount": 0,
     "isAristotle": false,

--- a/src/data/proofs/inverse-galois-a5-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-a5-oq-03/meta.json
@@ -33,7 +33,7 @@
     ],
     "dateAdded": "2026-06-19",
     "lineCount": 205,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
   },
@@ -44,7 +44,7 @@
     "namespace": "InverseGaloisA5OQ03",
     "lineCount": 205,
     "axiomCount": 2,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 1,
     "path": "Proofs/InverseGaloisA5OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/knights-tour-oblique-oq-02/meta.json
+++ b/src/data/proofs/knights-tour-oblique-oq-02/meta.json
@@ -43,7 +43,7 @@
         "module": "Mathlib.Data.List.Basic"
       }
     ],
-    "theoremCount": 34,
+    "theoremCount": 37,
     "definitionCount": 11
   },
   "overview": {
@@ -188,7 +188,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 10,
-    "theoremCount": 34
+    "theoremCount": 37
   },
   "sorries": 0
 }

--- a/src/data/proofs/second-isomorphism-theorem-modules-oq-01/meta.json
+++ b/src/data/proofs/second-isomorphism-theorem-modules-oq-01/meta.json
@@ -16,7 +16,7 @@
       "rank-nullity",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-20",
     "mathlib_version": "4.26.0",
@@ -52,7 +52,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
     "lineCount": 131,
-    "theoremCount": 4,
+    "theoremCount": 6,
     "definitionCount": 1
   },
   "overview": {
@@ -152,7 +152,7 @@
     "namespace": "SecondIsomorphismTheoremModulesOQ01",
     "lineCount": 131,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 6,
     "definitionCount": 1,
     "path": "Proofs/SecondIsomorphismTheoremModulesOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit — 142 unaudited entries swept

Full integrity sweep of all 142 never-audited gallery entries. Checked sorry counts, axiom declarations, `native_decide` disclosure, axiomCount, and status/badge consistency (with proper multi-line block-comment stripping to avoid docstring false positives). **138 clean, 4 fixed.**

### theoremCount mismatches (meta.theoremCount + leanFile.theoremCount)
Corrected to the literal `theorem`/`lemma` declaration count (incl. `private`):

| Entry | Was | Now |
|-------|-----|-----|
| inclusion-exclusion-oq-04 | 8 | 9 |
| inverse-galois-a5-oq-03 | 8 | 9 |
| knights-tour-oblique-oq-02 | 34 | 37 |
| second-isomorphism-theorem-modules-oq-01 | 4 | 6 |

For **knights-tour-oblique-oq-02**, 37 is the main-file count (`lineCount: 695` confirms the metadata is scoped to the main file; the `KnightsTourObliqueOQ02Reverse.lean` companion's 12 are not counted). The prior value 34 matched neither the main file (37) nor the combined total (49).

### Badge tier correction (Tier B)
- **second-isomorphism-theorem-modules-oq-01**: `verified` → `mathlib`. The headline `secondIso` is a verbatim re-export of Mathlib's `LinearMap.quotientInfEquivSupQuotient`:
  ```lean
  noncomputable def secondIso (p p' : Submodule R M) : ... :=
    LinearMap.quotientInfEquivSupQuotient p p'
  ```
  `status` stays `verified` (genuinely 0 axioms / 0 sorries, no `native_decide`), but the badge must signal the Mathlib bridge per the Tier-B / "0 sorries with hidden imports" rule. The derived contributions (modular dimension law, direct-sum corollaries) remain genuine.

### No issues found
- Sorry counts: all 142 verified at 0 actual sorries (matching meta).
- Axioms: no undisclosed `axiom` decls; no undisclosed `native_decide`; `axiomatized` entries (inverse-galois-a5-oq-03 ×2 axioms, knights ofReduceBool) correctly classified.
- No `True` stubs; no status/badge contradictions among the rest.

Tracker updated for all 142 entries.

---
Discovered during gallery integrity audit.