### PR TITLE
research(compactness-finite-subcover-oq-01): finite-subcover characterization + by-hand structural consequences (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -646,6 +646,7 @@ import Proofs.CombinationsFormulaOQ06
 import Proofs.CombinationsFormulaOQ07
 import Proofs.CombinationsFormulaOQ08
 import Proofs.CombinationsFormulaOQ09
+import Proofs.CompactnessFiniteSubcover
 import Proofs.ComplexityCore
 import Proofs.CompositionCard2PowOQ01
 import Proofs.CompositionPartsChooseOQ01

--- a/proofs/Proofs/CompactnessFiniteSubcover.lean
+++ b/proofs/Proofs/CompactnessFiniteSubcover.lean
@@ -1,0 +1,123 @@
+import Mathlib
+
+/-
+# Compactness via Finite Subcovers
+
+## What This Proves
+
+The **finite subcover characterization of compactness**: a set `s` in a
+topological space is compact **iff** every open cover of `s` admits a finite
+subcover.  This is the Heine–Borel definition of compactness, and it is the
+form that powers the extreme value theorem, the tube lemma, and the proof that
+continuous images of compact sets are compact.
+
+`Mathlib` packages the equivalence as `isCompact_iff_finite_subcover` (with the
+forward direction `IsCompact.elim_finite_subcover`).  We re-export that
+characterization as the headline, and then use it **directly** — not via the
+ready-made `IsCompact.union` — to build the structural consequences:
+
+* `isCompact_union_of_finite_subcover` — a binary union of compact sets is
+  compact, **re-derived from the subcover characterization itself**: given a
+  cover of `s ∪ t`, extract a finite subcover of `s` and a finite subcover of
+  `t`, then union the two finite index sets.  This is the genuine content of the
+  file — we never invoke `IsCompact.union`.
+* `isCompact_finset_biUnion` — a finite (indexed) union of compact sets is
+  compact, by induction on the `Finset` using only the binary case above.
+* `isCompact_finset_coe` — every finite set is compact, as a corollary
+  (`↑s = ⋃ x ∈ s, {x}` and singletons are compact).
+* `isCompact_image_of_continuous` / `isCompact_image_union_of_continuous` —
+  the continuous-image cross-check: continuous images preserve compactness, and
+  in particular the continuous image of a union of compacts is compact.
+* `isCompact_two_intervals` — a concrete instance over `ℝ`: `[0,1] ∪ [2,3]` is
+  compact, obtained from the re-derived union theorem and `isCompact_Icc`.
+
+## Why This Is a Non-Wrapper
+
+The headline `compact_iff_finite_subcover` is a `Mathlib` restatement, but the
+finite-union results are produced by *running the subcover characterization by
+hand* — extracting subcovers and combining index `Finset`s — rather than citing
+`IsCompact.union`.  That re-derivation, the finite-family induction, the
+finite-set corollary, and the concrete `ℝ` instance are the mathematical
+substance.
+-/
+
+open Set
+
+universe u
+
+variable {X : Type u} {Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {s t : Set X}
+
+/-- **Finite subcover characterization of compactness.**  A set `s` is compact
+iff every open cover of `s` admits a finite subcover.  (Re-export of
+`isCompact_iff_finite_subcover`, the Heine–Borel definition.) -/
+theorem compact_iff_finite_subcover :
+    IsCompact s ↔ ∀ {ι : Type u} (U : ι → Set X),
+      (∀ i, IsOpen (U i)) → (s ⊆ ⋃ i, U i) → ∃ r : Finset ι, s ⊆ ⋃ i ∈ r, U i :=
+  isCompact_iff_finite_subcover
+
+/-- **Forward direction.**  From a compact set and an open cover we may extract a
+finite subcover. -/
+theorem finite_subcover_of_isCompact (hs : IsCompact s) {ι : Type*} (U : ι → Set X)
+    (hUo : ∀ i, IsOpen (U i)) (hsU : s ⊆ ⋃ i, U i) :
+    ∃ r : Finset ι, s ⊆ ⋃ i ∈ r, U i :=
+  hs.elim_finite_subcover U hUo hsU
+
+/-- **A binary union of compact sets is compact**, re-derived directly from the
+finite subcover characterization.  Given an open cover of `s ∪ t`, it covers `s`
+and `t` separately; extract a finite subcover of each and union the two finite
+index sets.  We deliberately do *not* invoke `IsCompact.union`. -/
+theorem isCompact_union_of_finite_subcover (hs : IsCompact s) (ht : IsCompact t) :
+    IsCompact (s ∪ t) := by
+  classical
+  refine isCompact_of_finite_subcover fun {ι} U hUo hsU => ?_
+  -- the cover of `s ∪ t` covers `s` and `t` individually
+  obtain ⟨a, ha⟩ := hs.elim_finite_subcover U hUo (Set.subset_union_left.trans hsU)
+  obtain ⟨b, hb⟩ := ht.elim_finite_subcover U hUo (Set.subset_union_right.trans hsU)
+  -- the union of the two finite index sets is a finite subcover of `s ∪ t`
+  refine ⟨a ∪ b, Set.union_subset ?_ ?_⟩
+  · refine ha.trans fun x hx => ?_
+    obtain ⟨i, hi, hxi⟩ := Set.mem_iUnion₂.1 hx
+    exact Set.mem_iUnion₂.2 ⟨i, Finset.mem_union_left _ hi, hxi⟩
+  · refine hb.trans fun x hx => ?_
+    obtain ⟨i, hi, hxi⟩ := Set.mem_iUnion₂.1 hx
+    exact Set.mem_iUnion₂.2 ⟨i, Finset.mem_union_right _ hi, hxi⟩
+
+/-- **A finite indexed union of compact sets is compact**, by induction on the
+`Finset` using only the binary union above. -/
+theorem isCompact_finset_biUnion {ι : Type*} {f : ι → Set X} (a : Finset ι)
+    (hf : ∀ i ∈ a, IsCompact (f i)) : IsCompact (⋃ i ∈ a, f i) := by
+  classical
+  induction a using Finset.induction_on with
+  | empty => simp
+  | @insert j a' hj ih =>
+      rw [Finset.set_biUnion_insert]
+      exact isCompact_union_of_finite_subcover
+        (hf j (Finset.mem_insert_self j a'))
+        (ih fun i hi => hf i (Finset.mem_insert_of_mem hi))
+
+/-- **Every finite set is compact** (in any topological space), as a corollary:
+`↑s = ⋃ x ∈ s, {x}` and singletons are compact. -/
+theorem isCompact_finset_coe (s : Finset X) : IsCompact (↑s : Set X) := by
+  have h : (↑s : Set X) = ⋃ x ∈ s, ({x} : Set X) := by
+    ext y; simp
+  rw [h]
+  exact isCompact_finset_biUnion s fun x _ => isCompact_singleton
+
+/-- **Continuous-image cross-check.**  A continuous image of a compact set is
+compact. -/
+theorem isCompact_image_of_continuous {f : X → Y} (hs : IsCompact s)
+    (hf : Continuous f) : IsCompact (f '' s) :=
+  hs.image hf
+
+/-- The continuous image of a union of two compact sets is compact — combining
+the re-derived union theorem with the continuous-image preservation. -/
+theorem isCompact_image_union_of_continuous {f : X → Y} (hs : IsCompact s)
+    (ht : IsCompact t) (hf : Continuous f) : IsCompact (f '' (s ∪ t)) :=
+  (isCompact_union_of_finite_subcover hs ht).image hf
+
+/-- **Concrete instance over `ℝ`.**  The union of the two disjoint closed
+intervals `[0,1]` and `[2,3]` is compact, via the re-derived union theorem and
+`isCompact_Icc`. -/
+theorem isCompact_two_intervals :
+    IsCompact (Set.Icc (0 : ℝ) 1 ∪ Set.Icc (2 : ℝ) 3) :=
+  isCompact_union_of_finite_subcover isCompact_Icc isCompact_Icc

--- a/src/data/proofs/compactness-finite-subcover-oq-01/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "compactness-finite-subcover-oq-01",
+  "slug": "compactness-finite-subcover-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set"
+    ],
+    "namespace": "",
+    "lineCount": 123,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/CompactnessFiniteSubcover.lean",
+    "sorries": 0
+  },
+  "title": "Compactness via Finite Subcovers: the Heine–Borel Characterization",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CompactnessFiniteSubcover.lean",
+    "tags": [
+      "topology",
+      "compactness",
+      "heine-borel",
+      "finite-subcover",
+      "open-cover",
+      "general-topology",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 123,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "isCompact_union_of_finite_subcover: a binary union of compact sets is compact, RE-DERIVED directly from the finite-subcover characterization rather than citing Mathlib's IsCompact.union. Given an open cover of s ∪ t, the proof extracts a finite subcover of s and a finite subcover of t (via IsCompact.elim_finite_subcover) and returns the union of the two finite index Finsets — the genuine content of the entry, running the Heine–Borel definition by hand.",
+      "isCompact_finset_biUnion: a finite indexed union ⋃ i ∈ a, f i of compact sets is compact, by induction on the Finset a using ONLY the re-derived binary union above (Finset.set_biUnion_insert + the empty case), so the whole finite-union result is bootstrapped from the subcover characterization.",
+      "isCompact_finset_coe: every finite set ↑s (s : Finset X) is compact in an arbitrary topological space, as a corollary — ↑s = ⋃ x ∈ s, {x} and singletons are compact, fed through isCompact_finset_biUnion.",
+      "isCompact_image_union_of_continuous: the continuous image f '' (s ∪ t) of a union of two compact sets is compact, combining the re-derived union theorem with continuous-image preservation (IsCompact.image).",
+      "isCompact_two_intervals: a concrete instance over ℝ — the union [0,1] ∪ [2,3] of two disjoint closed intervals is compact, obtained from isCompact_union_of_finite_subcover and isCompact_Icc, a worked cross-check of the abstract machinery.",
+      "compact_iff_finite_subcover / finite_subcover_of_isCompact: the headline Heine–Borel characterization (re-export of isCompact_iff_finite_subcover) and its forward elimination form, packaged as the gallery statement."
+    ],
+    "prerequisites": [
+      "isCompact_iff_finite_subcover: Mathlib's equivalence between compactness and the finite-subcover property",
+      "IsCompact.elim_finite_subcover: extraction of a finite subcover from a compact set and an open cover",
+      "isCompact_of_finite_subcover: the converse — finite-subcover property implies compactness",
+      "Finset.set_biUnion_insert: ⋃ x ∈ insert a s, f x = f a ∪ ⋃ x ∈ s, f x, the inductive step for the finite union",
+      "isCompact_singleton and isCompact_Icc: singletons are compact, and closed real intervals are compact"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "isCompact_iff_finite_subcover",
+        "description": "A set s is compact iff every open cover of s admits a finite subcover. The Heine–Borel characterization, re-exported as compact_iff_finite_subcover.",
+        "module": "Mathlib.Topology.Compactness.Compact"
+      },
+      {
+        "theorem": "IsCompact.elim_finite_subcover",
+        "description": "From a compact set and an open cover, extract a finite index Finset whose corresponding subfamily still covers. The workhorse driving the re-derived binary union.",
+        "module": "Mathlib.Topology.Compactness.Compact"
+      },
+      {
+        "theorem": "isCompact_of_finite_subcover",
+        "description": "If every open cover of s has a finite subcover then s is compact. Used to conclude isCompact_union_of_finite_subcover from the constructed subcover.",
+        "module": "Mathlib.Topology.Compactness.Compact"
+      },
+      {
+        "theorem": "IsCompact.image",
+        "description": "The continuous image of a compact set is compact. Supplies the continuous-image cross-check isCompact_image_union_of_continuous.",
+        "module": "Mathlib.Topology.Compactness.Compact"
+      },
+      {
+        "theorem": "Finset.set_biUnion_insert",
+        "description": "⋃ x ∈ insert a s, f x = f a ∪ ⋃ x ∈ s, f x. The inductive step turning the binary union into the finite-family union.",
+        "module": "Mathlib.Order.CompleteLattice.Finset"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "compactness-finite-subcover-oq-01-oq-01",
+      "question": "Re-derive the tube lemma (if K is compact and N is open with K × {y} ⊆ N, then some open tube K × V ⊆ N) directly from the finite-subcover characterization, by covering K × {y} with basic open boxes and extracting a finite subcover, mirroring the by-hand subcover style used here for the union.",
+      "significance": "high"
+    },
+    {
+      "id": "compactness-finite-subcover-oq-01-oq-02",
+      "question": "Prove the finite-intersection-property dual (a space is compact iff every family of closed sets with the FIP has nonempty intersection) and connect it to isCompact_iff_finite_subfamily_closed, then derive that a nested sequence of nonempty compact sets has nonempty intersection (Cantor's intersection theorem).",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "egorov-theorem-oq-01",
+      "relationship": "related",
+      "description": "Egorov's theorem uses finite-measure compactness-style covering arguments; this entry isolates the open-cover characterization of compactness that underlies such finite-extraction proofs."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Topology.Compactness.Compact",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of isCompact_iff_finite_subcover, IsCompact.elim_finite_subcover, isCompact_of_finite_subcover, and IsCompact.image."
+    },
+    {
+      "title": "Topology",
+      "author": "Munkres",
+      "year": "2000",
+      "venue": "Prentice Hall",
+      "description": "Standard reference for the open-cover definition of compactness, the finite-union and continuous-image preservation theorems, and the tube lemma."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "A set s in a topological space is compact iff every open cover of s admits a finite subcover (the Heine–Borel characterization, Mathlib's isCompact_iff_finite_subcover, re-exported as compact_iff_finite_subcover). The entry's substance is using that characterization BY HAND rather than citing the ready-made lemmas: isCompact_union_of_finite_subcover proves a binary union of compacts is compact by extracting finite subcovers of each piece and unioning the two index Finsets (never invoking IsCompact.union); isCompact_finset_biUnion lifts this to finite indexed unions by induction; isCompact_finset_coe deduces that every finite set is compact; isCompact_image_union_of_continuous adds the continuous-image cross-check; and isCompact_two_intervals gives the concrete ℝ instance [0,1] ∪ [2,3]. 123 lines, 8 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The iff-characterization itself is delegated to Mathlib (hence the mathlib badge), but the finite-union results are produced by running the subcover definition directly — the from-scratch binary union, its finite-family induction, the finite-set corollary, and the concrete instance are the formalized content, demonstrating the standard ways compactness propagates (finite unions, continuous images) from first principles.",
+    "openQuestions": [
+      "Re-derive the tube lemma directly from the finite-subcover characterization.",
+      "Prove the finite-intersection-property dual and Cantor's intersection theorem for nested compacts."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Gallery entry **Compactness via Finite Subcovers: the Heine–Borel Characterization**.

Re-exports Mathlib's `isCompact_iff_finite_subcover` as the headline `compact_iff_finite_subcover`, then exercises the finite-subcover definition **by hand** to rebuild the standard structural consequences — rather than citing Mathlib's ready-made lemmas (`IsCompact.union`, `isCompact_biUnion`, etc.).

## Theorems (8 total, 0 sorries, 0 axioms)

- `compact_iff_finite_subcover` / `finite_subcover_of_isCompact` — the Heine–Borel iff and its forward elimination form (Mathlib re-export → `mathlib` badge).
- `isCompact_union_of_finite_subcover` — **the genuine content**: a binary union of compacts is compact, re-derived by extracting a finite subcover of `s` and of `t` and unioning the two index `Finset`s. Never invokes `IsCompact.union`.
- `isCompact_finset_biUnion` — finite indexed union, by `Finset` induction on the binary case above.
- `isCompact_finset_coe` — every finite set is compact (corollary via singletons).
- `isCompact_image_of_continuous` / `isCompact_image_union_of_continuous` — continuous-image cross-check.
- `isCompact_two_intervals` — concrete `ℝ` instance: `[0,1] ∪ [2,3]` is compact.

## Verification

`./proofs/scripts/docker-build.sh Proofs.CompactnessFiniteSubcover` → `✔ Built Proofs.CompactnessFiniteSubcover`, `Build succeeded`. 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. Status `verified`, badge `mathlib`.

Note: `ι` in the iff must share the ambient universe `u` with `X` (matches Mathlib's signature), hence `variable {X : Type u}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)