### PR TITLE
audit(compactness-finite-subcover-oq-01): record clean gallery audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17265,6 +17265,12 @@
       "lastAudited": "2026-06-20T00:00:00.000Z",
       "result": "clean",
       "issues": []
+    },
+    "compactness-finite-subcover-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T00:14:24Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — clean

**Proof**: `compactness-finite-subcover-oq-01` (merged via #27215)

Verified every meta.json claim against `proofs/Proofs/CompactnessFiniteSubcover.lean`:

| Field | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| lineCount | 123 | 123 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no `axiom`, no structure-encoded assumptions) | ✓ |
| theoremCount | 8 | 8 | ✓ |
| status / badge | verified / mathlib | core relies on Mathlib's `isCompact_iff_finite_subcover` | ✓ |

- No `True` stubs.
- `badge: mathlib` is correct (Tier B): the headline characterization re-exports `isCompact_iff_finite_subcover`, while the entry's genuine content — the by-hand re-derivation of the binary/finite union from `IsCompact.elim_finite_subcover` — is honestly scoped in `originalContributions`.

Persists the audit-tracker entry so the queue reflects this merged entry as audited.

---
Discovered during routine gallery integrity audit.