### PR TITLE
audit(compactness-finite-subcover-oq-01): mark clean in tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17265,6 +17265,12 @@
       "lastAudited": "2026-06-20T00:00:00.000Z",
       "result": "clean",
       "issues": []
+    },
+    "compactness-finite-subcover-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T00:16:52Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — CLEAN

**Proof**: compactness-finite-subcover-oq-01 (merged #27215)

Drains the audit queue (2758/2758 audited, 0 unaudited).

### Verified against `proofs/Proofs/CompactnessFiniteSubcover.lean`
| Field | meta.json | Lean source |
|-------|-----------|-------------|
| theoremCount | 8 | 8 ✓ |
| axiomCount | 0 | 0 (no `axiom`, no structures, no `native_decide`) ✓ |
| definitionCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |
| lineCount | 123 | 123 ✓ |

### Narrative integrity
- **Tier B** (Mathlib-backed): headline `compact_iff_finite_subcover` is a re-export of Mathlib's `isCompact_iff_finite_subcover`. Badge is `mathlib` — correctly disclosed, no delegation opacity.
- `originalContributions` scope claims to the by-hand re-derivations (binary union via `elim_finite_subcover`, finite-family induction, finite-set corollary, ℝ instance) — does **not** claim independent proof of the characterization.
- No True stubs, no axiom masking, no inequality-as-theorem inflation.

Only changes `audit-tracker.json` (single clean entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)