### PR TITLE
research(erdos-1006-oq-01-oq-01): de-axiomatize Pretzel-Brightwell cover-graph characterization (verified, 0 extra axioms)

### DIFF
--- a/proofs/Proofs/Erdos1006OQ01.lean
+++ b/proofs/Proofs/Erdos1006OQ01.lean
@@ -275,11 +275,161 @@ theorem bipartite_admits_robust (hbip : isBipartite' G) :
 def isCoverGraph (G : SimpleGraph V) : Prop :=
   ∃ (_ : PartialOrder V), isCoverGraphOf G
 
-/-- Pretzel-Brightwell Characterization (1985):
+/-
+## Pretzel-Brightwell Characterization (de-axiomatized)
+
+We now prove `cover_graph_characterization` directly. The key construction is the
+**reachability order** `reachOrder`: the reflexive-transitive closure of the arc
+relation of a robustly acyclic orientation `O`. Acyclicity makes this a partial
+order, and the "no dependent arc" condition makes `G` exactly the cover graph
+(Hasse diagram) of that order. The reverse implication (cover graph → robust) is
+`cover_graph_admits_robust`.
+-/
+
+/-- Along a directed path (`ReflTransGen` of the arcs), the acyclic rank is weakly
+    monotone. -/
+private theorem rank_le_of_rtg {O : GraphOrientation G} {rank : V → ℕ}
+    (hrank : ∀ a b, O.arc a b → rank a < rank b) {a b : V}
+    (h : Relation.ReflTransGen O.arc a b) : rank a ≤ rank b := by
+  induction h with
+  | refl => exact le_rfl
+  | tail _ hs ih => exact le_trans ih (le_of_lt (hrank _ _ hs))
+
+/-- Along a nonempty directed path (`TransGen` of the arcs), the acyclic rank is
+    strictly monotone. In particular such a path cannot be a cycle. -/
+private theorem rank_lt_of_tg {O : GraphOrientation G} {rank : V → ℕ}
+    (hrank : ∀ a b, O.arc a b → rank a < rank b) {a b : V}
+    (h : Relation.TransGen O.arc a b) : rank a < rank b := by
+  induction h with
+  | single hs => exact hrank _ _ hs
+  | tail _ hs ih => exact lt_trans ih (hrank _ _ hs)
+
+/-- A directed path whose endpoint has rank below `rank v` never uses the arc
+    `(u, v)`, so it lifts to a path in the relation with `(u, v)` excluded. -/
+private theorem lift_below {O : GraphOrientation G} {rank : V → ℕ}
+    (hrank : ∀ a b, O.arc a b → rank a < rank b) (u v : V) {a b : V}
+    (h : Relation.TransGen O.arc a b) :
+    rank b < rank v →
+      Relation.TransGen (fun x y => O.arc x y ∧ (x, y) ≠ (u, v)) a b := by
+  induction h with
+  | single hab =>
+      intro hb
+      refine Relation.TransGen.single ⟨hab, fun hc => ?_⟩
+      rw [Prod.mk.injEq] at hc
+      exact absurd (hc.2 ▸ hb) (lt_irrefl _)
+  | @tail c d hp hs ih =>
+      intro hb
+      have hcd : rank c < rank d := hrank _ _ hs
+      refine Relation.TransGen.tail (ih (lt_trans hcd hb)) ⟨hs, fun hc => ?_⟩
+      rw [Prod.mk.injEq] at hc
+      exact absurd (hc.2 ▸ hb) (lt_irrefl _)
+
+/-- A directed path whose start has rank above `rank u` never uses the arc
+    `(u, v)`, so it lifts to a path in the relation with `(u, v)` excluded. -/
+private theorem lift_above {O : GraphOrientation G} {rank : V → ℕ}
+    (hrank : ∀ a b, O.arc a b → rank a < rank b) (u v : V) {a b : V}
+    (h : Relation.TransGen O.arc a b) :
+    rank u < rank a →
+      Relation.TransGen (fun x y => O.arc x y ∧ (x, y) ≠ (u, v)) a b := by
+  induction h with
+  | single hab =>
+      intro ha
+      refine Relation.TransGen.single ⟨hab, fun hc => ?_⟩
+      rw [Prod.mk.injEq] at hc
+      exact absurd (hc.1 ▸ ha) (lt_irrefl _)
+  | @tail c d hp hs ih =>
+      intro ha
+      have hac : rank a < rank c := rank_lt_of_tg hrank hp
+      refine Relation.TransGen.tail (ih ha) ⟨hs, fun hc => ?_⟩
+      rw [Prod.mk.injEq] at hc
+      exact absurd (hc.1 ▸ (lt_trans ha hac)) (lt_irrefl _)
+
+/-- The **reachability order** of an acyclic orientation: `a ≤ b` iff there is a
+    directed path from `a` to `b`. Acyclicity gives antisymmetry. -/
+def reachOrder (O : GraphOrientation G) (hO : O.isAcyclic) : PartialOrder V where
+  le := Relation.ReflTransGen O.arc
+  le_refl _ := Relation.ReflTransGen.refl
+  le_trans _ _ _ hab hbc := Relation.ReflTransGen.trans hab hbc
+  le_antisymm a b hab hba := by
+    obtain ⟨rank, hrank⟩ := hO
+    by_contra hne
+    rcases Relation.reflTransGen_iff_eq_or_transGen.mp hab with h | h
+    · exact hne h.symm
+    · rcases Relation.reflTransGen_iff_eq_or_transGen.mp hba with h2 | h2
+      · exact hne h2
+      · exact absurd (lt_trans (rank_lt_of_tg hrank h) (rank_lt_of_tg hrank h2))
+          (lt_irrefl _)
+
+/-- **Pretzel-Brightwell Characterization (1985)**, now proved (no axiom):
     A finite graph admits a robustly acyclic orientation if and only if
-    it is a cover graph of some poset. -/
-axiom cover_graph_characterization [Fintype V] :
-  admitsRobustAcyclicOrientation G ↔ isCoverGraph G
+    it is a cover graph of some poset.
+
+    Forward: the reachability order `reachOrder` of a robust orientation makes `G`
+    its cover graph — each arc is a covering pair precisely because there is no
+    alternate directed path (no dependent arc).
+    Reverse: `cover_graph_admits_robust`. -/
+theorem cover_graph_characterization [Fintype V] :
+    admitsRobustAcyclicOrientation G ↔ isCoverGraph G := by
+  constructor
+  · -- Robust orientation ⟹ cover graph.
+    rintro ⟨O, hAcyc, hNoDep⟩
+    obtain ⟨rank, hrank⟩ := hAcyc
+    letI P : PartialOrder V := reachOrder O ⟨rank, hrank⟩
+    refine ⟨P, ?_⟩
+    have le_iff : ∀ a b : V, (a ≤ b) ↔ Relation.ReflTransGen O.arc a b :=
+      fun _ _ => Iff.rfl
+    have lt_iff : ∀ a b : V, (a < b) ↔ Relation.TransGen O.arc a b := by
+      intro a b
+      constructor
+      · intro hab
+        rcases Relation.reflTransGen_iff_eq_or_transGen.mp ((le_iff a b).mp hab.le)
+          with h | h
+        · exact absurd h.symm hab.ne
+        · exact h
+      · intro hab
+        refine lt_of_le_not_ge ((le_iff a b).mpr hab.to_reflTransGen) ?_
+        intro hba
+        exact absurd (lt_of_lt_of_le (rank_lt_of_tg hrank hab)
+          (rank_le_of_rtg hrank ((le_iff b a).mp hba))) (lt_irrefl _)
+    intro u v
+    constructor
+    · -- Edge ⟹ covering pair (in one direction or the other).
+      intro hadj
+      rcases O.covers u v hadj with harc | harc
+      · refine Or.inl ⟨(lt_iff u v).mpr (Relation.TransGen.single harc), ?_⟩
+        intro c hc hcv
+        have tuc : Relation.TransGen O.arc u c := (lt_iff u c).mp hc
+        have tcv : Relation.TransGen O.arc c v := (lt_iff c v).mp hcv
+        have p1 := lift_below hrank u v tuc (rank_lt_of_tg hrank tcv)
+        have p2 := lift_above hrank u v tcv (rank_lt_of_tg hrank tuc)
+        exact hNoDep ⟨u, v, harc, Relation.TransGen.trans p1 p2⟩
+      · refine Or.inr ⟨(lt_iff v u).mpr (Relation.TransGen.single harc), ?_⟩
+        intro c hc hcu
+        have tvc : Relation.TransGen O.arc v c := (lt_iff v c).mp hc
+        have tcu : Relation.TransGen O.arc c u := (lt_iff c u).mp hcu
+        have p1 := lift_below hrank v u tvc (rank_lt_of_tg hrank tcu)
+        have p2 := lift_above hrank v u tcu (rank_lt_of_tg hrank tvc)
+        exact hNoDep ⟨v, u, harc, Relation.TransGen.trans p1 p2⟩
+    · -- Covering pair ⟹ edge.
+      rintro (hcov | hcov)
+      · cases (lt_iff u v).mp hcov.1 with
+        | single h => exact O.respects u v h
+        | tail h hs =>
+            rename_i c
+            exact absurd ((lt_iff c v).mpr (Relation.TransGen.single hs))
+              (hcov.2 ((lt_iff u c).mpr h))
+      · cases (lt_iff v u).mp hcov.1 with
+        | single h => exact (O.respects v u h).symm
+        | tail h hs =>
+            rename_i c
+            exact absurd ((lt_iff c u).mpr (Relation.TransGen.single hs))
+              (hcov.2 ((lt_iff v c).mpr h))
+  · -- Cover graph ⟹ robust orientation.
+    rintro ⟨P, hP⟩
+    letI := P
+    letI : DecidableEq V := Classical.decEq V
+    letI : DecidableLT V := fun a b => Classical.propDecidable _
+    exact cover_graph_admits_robust hP
 
 /-- Fisher-Fraughnaugh-Langley-West (1997): If the chromatic number of G
     is less than its girth, then G admits a robustly acyclic orientation. -/
@@ -307,9 +457,11 @@ axiom nesetril_rodl_counterexample (g : ℕ) (hg : g ≥ 3) :
 4. `bipartite_admits_robust` - Bipartite graphs admit robust orientations
 5. `posetRank_strictMono` - Rank function is strictly monotone on partial orders
 6. `cover_graph_admits_robust` - Cover graphs admit robust orientations
+7. `cover_graph_characterization` - Robust orientation ↔ cover graph
+   (de-axiomatized: forward via the reachability order `reachOrder`,
+    reverse via `cover_graph_admits_robust`)
 
 ### Axiomatized (deep results):
-7. `cover_graph_characterization` - Robust orientation ↔ cover graph
 8. `chromatic_lt_girth_implies_robust` - χ(G) < girth(G) suffices
 9. `nesetril_rodl_counterexample` - Counterexamples for all girths ≥ 3
 -/

--- a/src/data/proofs/erdos-1006-oq-01/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1006-oq-01",
   "title": "Robustly Acyclic Orientations and Cover Graphs",
   "slug": "erdos-1006-oq-01",
-  "description": "Formalizes Erdős Problem #1006 (OQ-01): characterize which graphs admit robustly acyclic orientations. Axiomatizes the Pretzel-Brightwell characterization (1985): a graph admits a robustly acyclic orientation iff it is a cover graph of some poset. Also axiomatizes: Nešetřil-Rödl counterexamples (1978) for all girths, Fisher-Fraughnaugh-Langley-West criterion (χ < girth implies robust). Proves empty and bipartite graphs have robust orientations. 6 theorems, 3 axioms.",
+  "description": "Formalizes Erdős Problem #1006 (OQ-01): characterize which graphs admit robustly acyclic orientations. Proves the Pretzel-Brightwell characterization (1985) — a graph admits a robustly acyclic orientation iff it is a cover graph of some poset — with no axiom: the forward direction uses the reachability order (transitive closure of the orientation), the reverse is cover_graph_admits_robust. Still axiomatizes two deeper results: Nešetřil-Rödl counterexamples (1978) for all girths, and the Fisher-Fraughnaugh-Langley-West criterion (χ < girth implies robust). Also proves empty and bipartite graphs have robust orientations. 11 theorems, 2 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
@@ -19,18 +19,19 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 3,
-    "assumptions": "3 axioms: cover_graph_characterization (Pretzel-Brightwell 1985: G admits robustly acyclic orientation ↔ G is a cover graph of some poset), chromatic_lt_girth_implies_robust (Fisher-Fraughnaugh-Langley-West 1997: χ(G) < girth(G) → G has robust orientation), nesetril_rodl_counterexample (Nešetřil-Rödl 1978: for every girth g≥3, there exists a graph with girth g that does NOT have a robust orientation).",
-    "lineCount": 315,
-    "theoremCount": 6,
+    "axiomCount": 2,
+    "assumptions": "2 axioms: chromatic_lt_girth_implies_robust (Fisher-Fraughnaugh-Langley-West 1997: χ(G) < girth(G) → G has robust orientation), nesetril_rodl_counterexample (Nešetřil-Rödl 1978: for every girth g≥3, there exists a graph with girth g that does NOT have a robust orientation). The Pretzel-Brightwell characterization (cover_graph_characterization) is now a proved theorem, not an axiom.",
+    "lineCount": 467,
+    "theoremCount": 11,
     "definitionCount": 13,
     "originalContributions": [
       "admitsRobustAcyclicOrientation: predicate — G has an orientation that stays acyclic under any single edge reversal",
       "isCoverGraph / isCoverGraphOf: G is a cover graph of a poset P if G = Hasse diagram of P",
       "empty_graph_robust: empty graphs (no edges) trivially admit robust orientations",
       "bipartiteOrientation_acyclic: the natural 2-coloring orientation of a bipartite graph is acyclic",
-      "cover_graph_iff_robust: the complete characterization (axiomatized)",
-      "dependent_vs_independent_edges: edges in an orientation are dependent if reversing creates a cycle, independent otherwise"
+      "cover_graph_characterization: the complete Pretzel-Brightwell characterization (robust orientation ↔ cover graph), proved without axioms via the reachability order",
+      "dependent_vs_independent_edges: edges in an orientation are dependent if reversing creates a cycle, independent otherwise",
+      "reachOrder: the reachability partial order (reflexive-transitive closure of an acyclic orientation's arcs), whose Hasse diagram recovers G"
     ]
   },
   "overview": {
@@ -96,26 +97,26 @@
     },
     {
       "id": "sec-axioms",
-      "title": "Axiomatized Deep Results",
-      "startLine": 232,
-      "endLine": 261,
-      "summary": "Defines isCoverGraph (existence of a PartialOrder making G a cover graph). Axiomatizes: cover_graph_characterization (Pretzel-Brightwell 1985: robust ↔ cover graph), chromatic_lt_girth_implies_robust (Fisher et al. 1997), nesetril_rodl_counterexample (1978: non-cover graphs of every girth ≥ 3 exist)."
+      "title": "Cover-Graph Characterization (proved) and Remaining Deep Axioms",
+      "startLine": 270,
+      "endLine": 456,
+      "summary": "Defines isCoverGraph (existence of a PartialOrder making G a cover graph) and reachOrder (transitive-closure order of an acyclic orientation). Proves cover_graph_characterization (Pretzel-Brightwell 1985: robust ↔ cover graph) with no axiom — the forward direction shows each arc is a covering pair of reachOrder exactly because no dependent arc exists. Still axiomatizes chromatic_lt_girth_implies_robust (Fisher et al. 1997) and nesetril_rodl_counterexample (1978)."
     }
   ],
   "conclusion": {
-    "summary": "Formalizes Erdős #1006 OQ-01: characterizes robustly acyclic orientations as cover graphs of posets. Proves the easy direction constructively (cover graphs and bipartite graphs admit robust orientations) with machine-verified proofs. Axiomatizes the full equivalence (Pretzel-Brightwell 1985) and the counterexample existence (Nešetřil-Rödl 1978). 6 theorems, 277 lines, 3 axioms.",
+    "summary": "Formalizes Erdős #1006 OQ-01: characterizes robustly acyclic orientations as cover graphs of posets. Proves the full Pretzel-Brightwell equivalence (1985) with no axiom — the forward direction via the reachability order, the reverse via cover_graph_admits_robust — along with the empty and bipartite special cases. Still axiomatizes the counterexample existence (Nešetřil-Rödl 1978) and the χ < girth criterion (FFLW 1997). 11 theorems, 467 lines, 2 axioms.",
     "implications": "The Pretzel-Brightwell characterization is a striking bridge between orientation theory and order theory — it says that 'robustness under perturbation' in orientations is exactly captured by the poset structure of cover graphs. This has applications in scheduling (finding a robust ordering for job dependencies), lattice theory (identifying which graphs are Hasse diagrams), and database theory (stable acyclic transactions). The Nešetřil-Rödl result implies that the property is not monotone in girth alone — high-girth graphs can still fail to be cover graphs.",
     "openQuestions": [
-      "Prove cover_graph_characterization without axioms: formalize Pretzel's original proof that robustly acyclic orientations must be Hasse diagrams by showing that dependent arcs produce 'incomparable' elements in any linearization, forcing a poset structure.",
+      "Sharpen the characterization to a decidable recognizer: with [Fintype V] and DecidableEq, is admitsRobustAcyclicOrientation a DecidablePred? The reachOrder construction is computable, so the obstruction is quantifying over all orientations.",
       "Formalize the algorithmic recognition: cover graph recognition is in polynomial time (it reduces to testing whether a graph is the comparability graph of a partial order). Can this be encoded in Lean using Fintype computability?",
       "Generalize to robustness under $k$ edge reversals: which graphs admit orientations that remain acyclic after any $k$ simultaneous edge reversals? This extends the Pretzel-Brightwell theory to $k$-robust orientations."
     ]
   },
   "leanFile": {
     "namespace": "Erdos1006OQ01",
-    "lineCount": 315,
-    "axiomCount": 3,
-    "theoremCount": 6,
+    "lineCount": 467,
+    "axiomCount": 2,
+    "theoremCount": 11,
     "definitionCount": 13,
     "path": "Proofs/Erdos1006OQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-1006-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1006-oq-01-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1006-oq-01-oq-01",
   "title": "Formalize cover graph characterization (Pretzel) without axioms",
-  "phase": "OBSERVE",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "C",
   "path": "full",
@@ -24,12 +24,12 @@
     "goal": "Replace the characterization axiom with a direct Lean proof."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-04-05T20:06:18-07:00",
     "iteration": 1,
     "focus": "Metadata refreshed against the current seven-file Erdos1006 proof family; the target remains the axiom-removal version of the cover-graph characterization.",
     "blockers": [],
-    "nextAction": "Audit the Pretzel/Brightwell reverse direction and identify a small formal sublemma that can replace part of `cover_graph_characterization`.",
+    "nextAction": "Remaining axioms (nesetril_rodl, chromatic_lt_girth) are deep; OQ-01-OQ-01 target (cover_graph_characterization) is DONE.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -37,21 +37,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S3 2026-06-20): restored soundness/faithfulness of the robust-orientation model by redefining hasDependentArc via reachability; cover_graph_characterization and nesetril_rodl_counterexample axioms are now TRUE statements. axiomCount unchanged at 3. Deep characterization remains the open goal.",
+    "progressSummary": "COMPLETE (S4 2026-06-20): de-axiomatized cover_graph_characterization (Pretzel-Brightwell). Proved in Lean with 0 extra axioms (depends only on propext/Classical.choice/Quot.sound). File axiomCount 3→2; remaining axioms are nesetril_rodl_counterexample and chromatic_lt_girth_implies_robust.",
     "builtItems": [
       "Broad Erdos1006 leanFiles metadata refreshed to seven current proof files.",
-      "Re-proved empty_graph_robust, cover_graph_admits_robust, bipartiteOrientation_robust against the reachability definition in Proofs/Erdos1006OQ01.lean (no rank-based dependent-arc reasoning)."
+      "Re-proved empty_graph_robust, cover_graph_admits_robust, bipartiteOrientation_robust against the reachability definition in Proofs/Erdos1006OQ01.lean (no rank-based dependent-arc reasoning).",
+      "reachOrder (Proofs/Erdos1006OQ01.lean): reflexive-transitive closure of an acyclic orientation's arcs as a PartialOrder; antisymmetry from rank-strict-monotonicity.",
+      "rank_lt_of_tg / rank_le_of_rtg: rank is strictly/weakly monotone along TransGen/ReflTransGen paths.",
+      "lift_below / lift_above: a directed path whose endpoint is rank-below v (resp. start rank-above u) never uses the arc (u,v), so it lifts to the (u,v)-excluded relation — the technical core of 'each arc is a covering pair'.",
+      "cover_graph_characterization is now a theorem (Proofs/Erdos1006OQ01.lean:371): admits robust orientation ↔ isCoverGraph, verified 0 extra axioms."
     ],
     "insights": [
       "The slug broad-matches the whole Erdos1006* proof family because the stripped base prefix is Erdos1006.",
       "The main characterization is still represented by an explicit axiom in Erdos1006OQ01.lean.",
       "S1/S2 found a soundness bug: hasDependentArc had its rank inequality backwards (rank v ≤ rank u), making it vacuously false for every acyclic orientation. This collapsed isRobustlyAcyclic to isAcyclic and rendered the cover_graph_characterization and nesetril_rodl_counterexample axioms UNSOUND (false statements).",
-      "S3 fix: redefine hasDependentArc via reachability — an arc (u,v) is dependent iff Relation.TransGen of the arc relation (with (u,v) excluded) connects u to v. Reversing the arc then closes a directed cycle v→u⇝v. This is faithful to the textbook meaning and makes all three robustness obligations elementary TransGen inductions (no Szpilrajn/linear-extension machinery)."
+      "S3 fix: redefine hasDependentArc via reachability — an arc (u,v) is dependent iff Relation.TransGen of the arc relation (with (u,v) excluded) connects u to v. Reversing the arc then closes a directed cycle v→u⇝v. This is faithful to the textbook meaning and makes all three robustness obligations elementary TransGen inductions (no Szpilrajn/linear-extension machinery).",
+      "With the reachability definition of hasDependentArc, BOTH directions of Pretzel-Brightwell are elementary: forward = take transitive-closure poset, 'no dependent arc' ⇔ 'every arc is a covering pair'; reverse = cover_graph_admits_robust. The literature's 'depth' is in the definition/recognition, not the equivalence under this model."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Survey dependent-arc and cover-graph lemmas needed for the Pretzel/Brightwell reverse implication.",
-      "De-axiomatize cover_graph_characterization (Pretzel-Brightwell) — still the OQ-01-OQ-01 goal; the soundness fix is a prerequisite, not the theorem itself."
+      "Tackle the remaining axioms: nesetril_rodl_counterexample (needs explicit high-girth non-cover-graph constructions) and chromatic_lt_girth_implies_robust (FFLW). Both are genuinely deep.",
+      "Consider decidability of admitsRobustAcyclicOrientation for Fintype V (reachOrder is computable)."
     ],
     "markdown": "# Knowledge Base: erdos-1006-oq-01-oq-01\n\nMetadata refreshed on 2026-05-18. The target is the axiom-removal version of the Pretzel/Brightwell cover-graph characterization: prove directly that robustly acyclic orientations correspond to cover graphs.\n"
   },


### PR DESCRIPTION
## Summary

De-axiomatizes the **Pretzel-Brightwell cover-graph characterization** (1985) in `Proofs/Erdos1006OQ01.lean`, the explicit goal of research problem `erdos-1006-oq-01-oq-01`. The `cover_graph_characterization` axiom becomes a proved theorem.

> A finite graph admits a robustly acyclic orientation ⟺ it is a cover graph (Hasse diagram) of some poset.

## How

- **Reverse** (cover graph ⟹ robust): already available as `cover_graph_admits_robust`.
- **Forward** (robust orientation ⟹ cover graph): construct the **reachability order** `reachOrder` — the reflexive-transitive closure of the orientation's arc relation. Acyclicity (via the rank witness) gives antisymmetry, so it is a `PartialOrder`. The "no dependent arc" condition means each arc is a *covering pair* of `reachOrder`, hence `G` is exactly its Hasse diagram.
  - Technical core: `lift_below` / `lift_above` — a directed path whose endpoint sits rank-below `v` (resp. whose start sits rank-above `u`) never traverses the arc `(u,v)`, so any alternate `u ⇝ v` path lifts to the `(u,v)`-excluded relation and produces a genuine dependent-arc witness.

## Verification

```
#print axioms cover_graph_characterization
  ⟹ [propext, Classical.choice, Quot.sound]
```

Only the foundational axioms — **no `sorryAx`, no `Lean.ofReduceBool`**, and crucially **not** the file's other two axioms. Builds cleanly via `docker-build.sh Proofs.Erdos1006OQ01` (7743 jobs).

File `axiomCount` 3 → 2. The remaining axioms (`nesetril_rodl_counterexample`, `chromatic_lt_girth_implies_robust`) are genuinely deep and untouched, so the entry stays `axiomatized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)