### PR TITLE
audit: mark 5 merged research proofs clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17271,6 +17271,36 @@
       "lastAudited": "2026-06-21T00:14:24Z",
       "result": "clean",
       "issues": []
+    },
+    "kummer-theorem-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T00:39:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "mantel-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T00:39:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "matrix-similarity-invariants-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T00:39:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "mellin-power-convergence-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T00:39:39Z",
+      "result": "clean",
+      "issues": []
+    },
+    "prob-method-second-moment-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T00:39:39Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Persists clean audit results for 5 research proofs whose PRs merged to main, so the audit queue stops re-surfacing them every cycle.

## Verified (all on `main`)

| Slug | thm | ax | sorry | status/badge | notes |
|------|-----|----|----|--------------|-------|
| kummer-theorem-oq-04 | 8 | 0 | 0 | verified/original | digit-sum Kummer; counts match |
| mantel-theorem-oq-03 | 5 | 0 | 0 | verified/original | leanFile.theoremCount=5 (top-level absent, consistent w/ oq-01) |
| matrix-similarity-invariants-oq-01-oq-01 | 9 | 0 | 0 | verified/mathlib | counts match |
| mellin-power-convergence-oq-01 | 7 | 0 | 0 | verified/mathlib | no native_decide |
| prob-method-second-moment-oq-04 | 4 | 0 | 0 | verified/original | lone 'sorry' is in a comment |

All: theorem/line counts match meta, no `native_decide` → no `Lean.ofReduceBool`, no `True` stubs, badges honest. catalan-numbers-oq-01-oq-01 also verified clean but its source is not yet on main (research branch unmerged), so it is omitted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)