### PR TITLE
research(amgm-oq-02-oq-01-oq-03-oq-01): Newton–Girard k=4 reduced closed form (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -59,6 +59,7 @@ import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01OQ01
 import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01OQ03
 import Proofs.AmgmInequalityOQ02OQ01OQ03
 import Proofs.AmgmInequalityOQ02OQ01OQ03Finset
+import Proofs.AmgmInequalityOQ02OQ01OQ03OQ01
 import Proofs.AmgmInequalityOQ02OQ01OQ04
 import Proofs.AmgmInequalityOQ02OQ01OQ05
 import Proofs.AmgmInequalityOQ02OQ02

--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01.lean
@@ -1,0 +1,174 @@
+/-
+  Newton–Girard k=4 Closed Form:  p₄ = e₁⁴ − 4·e₁²·e₂ + 2·e₂² + 4·e₁·e₃ − 4·e₄
+
+  Open Question (amgm-inequality-oq-02-oq-01-oq-03-oq-01), the next rung after the
+  k=3 closed form `amgm-inequality-oq-02-oq-01-oq-03`.
+
+  Establish the fully reduced k=4 Newton–Girard identity expressing the fourth power
+  sum p₄ purely in terms of the elementary symmetric polynomials e₁, e₂, e₃, e₄:
+      p₄ = e₁⁴ − 4·e₁²·e₂ + 2·e₂² + 4·e₁·e₃ − 4·e₄.
+  For concrete values (a Finset) this is the symmetric-function form of
+      a⁴+b⁴+c⁴+d⁴
+        = (a+b+c+d)⁴ − 4(a+b+c+d)²·e₂ + 2·e₂² + 4(a+b+c+d)·e₃ − 4·e₄.
+
+  Lineage:
+  • Parent    amgm-inequality-oq-02-oq-01             : k=2 identity p₂ = e₁² − 2e₂.
+  • Recurrence amgm-inequality-oq-02-oq-01-oq-02-oq-01: p₃ = e₁p₂ − e₂p₁ + 3e₃ and the
+                                                        k=1,2 corollaries, all from
+                                                        Mathlib's `psum_eq_mul_esymm_sub_sum`.
+  • k=3 closed amgm-inequality-oq-02-oq-01-oq-03      : `psum_three_closed`
+                                                        (universal) + the concrete
+                                                        general-Finset form and the
+                                                        char-2-safe `aeval` bridge.
+
+  This file adds the next rung.  Two complementary forms, each 0-sorry / 0-axiom:
+
+  (1) UNIVERSAL (MvPolynomial).  `psum_four_recurrence` extracts the k=4 Newton
+      recurrence  p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄  directly from
+      `MvPolynomial.psum_eq_mul_esymm_sub_sum` (antidiagonal filter {(1,3),(2,2),(3,1)},
+      lead term (−1)⁵·4·e₄).  Substituting the proven closed forms for p₃, p₂, p₁ and
+      ring-normalising yields `psum_four_closed`.
+
+  (2) CONCRETE general-Finset, over an ARBITRARY CommRing (characteristic 2 included).
+      Reusing the already-built, n-general `aeval` bridge from the k=3 Finset file
+      (`aeval_psum_subtype`, `aeval_esymm_subtype`), the universal closed form transports
+      onto the subtype {x // x ∈ s} to give `newton_girard_four_finset` with the e₄/p₄
+      bridge lemmas instantiated at n=4.  No characteristic hypothesis is required — the
+      same transport that bypassed the char-2 obstruction at k=3 works verbatim here.
+
+  Every coefficient is independently checked over ℚ for n ≤ 5 variables in
+  `research/problems/.../lean/verify_newton_girard_k4.py` (residual 0 ⟹ universal).
+
+  Status: PROVED — 0 sorries, 0 axioms.  Holds over any `CommRing`.
+  Tags: algebra, symmetric-functions, newton-girard, power-sums, finset, characteristic-two
+-/
+
+import Mathlib
+import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01
+import Proofs.AmgmInequalityOQ02OQ01OQ03
+import Proofs.AmgmInequalityOQ02OQ01OQ03Finset
+
+namespace AMGMInequalityOQ02OQ01OQ03OQ01
+
+open MvPolynomial Finset BigOperators Set
+
+-- ============================================================
+-- Universal closed form (MvPolynomial setting)
+-- ============================================================
+
+section Universal
+
+variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]
+
+/-- **Newton–Girard k=4, recurrence form** (universal / MvPolynomial setting):
+      p₄ = e₁·p₃ − e₂·p₂ + e₃·p₁ − 4·e₄.
+
+    Proof: apply `psum_eq_mul_esymm_sub_sum` at n = 4.  The antidiagonal
+    {a : a.1 + a.2 = 4, 0 < a.1 < 4} = {(1,3), (2,2), (3,1)}, and the lead term is
+    (−1)⁵·4·e₄ = −4·e₄, so
+      p₄ = −4e₄ − ((−1)¹e₁p₃ + (−1)²e₂p₂ + (−1)³e₃p₁)
+         = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄. -/
+theorem psum_four_recurrence :
+    psum σ R 4 =
+      esymm σ R 1 * psum σ R 3 - esymm σ R 2 * psum σ R 2
+        + esymm σ R 3 * psum σ R 1 - 4 * esymm σ R 4 := by
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 4 (by norm_num)]
+  have hfilt : (Finset.antidiagonal 4).filter (fun a : ℕ × ℕ => a.1 ∈ Set.Ioo 0 4) =
+               {(1, 3), (2, 2), (3, 1)} := by
+    ext ⟨a, b⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo,
+               Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  simp only [hfilt,
+    Finset.sum_insert (by decide : (1, 3) ∉ ({(2, 2), (3, 1)} : Finset (ℕ × ℕ))),
+    Finset.sum_insert (by decide : (2, 2) ∉ ({(3, 1)} : Finset (ℕ × ℕ))),
+    Finset.sum_singleton]
+  ring
+
+/-- **Newton–Girard k=4, closed form** (universal / MvPolynomial setting):
+      p₄ = e₁⁴ − 4·e₁²·e₂ + 2·e₂² + 4·e₁·e₃ − 4·e₄.
+    Substitute the proven closed forms `psum_three_closed` (p₃ = e₁³ − 3e₁e₂ + 3e₃),
+    `psum_two_eq` (p₂ = e₁² − 2e₂) and `psum_one_eq_esymm_one` (p₁ = e₁) into the
+    recurrence `psum_four_recurrence`, then ring-normalise. -/
+theorem psum_four_closed :
+    psum σ R 4 =
+      esymm σ R 1 ^ 4 - 4 * (esymm σ R 1 ^ 2 * esymm σ R 2) + 2 * esymm σ R 2 ^ 2
+        + 4 * (esymm σ R 1 * esymm σ R 3) - 4 * esymm σ R 4 := by
+  have h4 := psum_four_recurrence σ R
+  have h3 := AMGMInequalityOQ02OQ01OQ03.psum_three_closed σ R
+  have h2 := AMGMInequalityOQ02OQ01OQ02OQ01.psum_two_eq σ R
+  have h1 := AMGMInequalityOQ02OQ01OQ02OQ01.psum_one_eq_esymm_one σ R
+  rw [h4, h3, h2, h1]; ring
+
+end Universal
+
+-- ============================================================
+-- Concrete general-Finset form, over ANY CommRing (char 2 included)
+-- ============================================================
+
+section Concrete
+
+open AMGMInequalityOQ02OQ01OQ03Finset
+
+variable {ι R : Type*} [CommRing R] [DecidableEq ι]
+
+/-- e₄ = Σ over 4-subsets of the product (concrete `powersetCard` form). -/
+def e4 (s : Finset ι) (f : ι → R) : R := ∑ t ∈ s.powersetCard 4, ∏ i ∈ t, f i
+/-- p₄ = Σ fᵢ⁴. -/
+def p4 (s : Finset ι) (f : ι → R) : R := ∑ i ∈ s, f i ^ 4
+
+omit [DecidableEq ι] in
+/-- Bridge at degree 4:  `aeval (esymm … 4) = e₄`  (definitional, from the n-general
+    `aeval_esymm_subtype`). -/
+theorem e4_bridge (s : Finset ι) (f : ι → R) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.esymm {x // x ∈ s} R 4) = e4 s f :=
+  aeval_esymm_subtype s f 4
+
+omit [DecidableEq ι] in
+/-- Bridge for the fourth power sum:  `aeval (psum … 4) = p₄`  (definitional, from the
+    n-general `aeval_psum_subtype`). -/
+theorem p4_bridge (s : Finset ι) (f : ι → R) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.psum {x // x ∈ s} R 4) = p4 s f :=
+  aeval_psum_subtype s f 4
+
+omit [DecidableEq ι] in
+/-- **Concrete general-Finset Newton–Girard k=4** over an arbitrary `CommRing`:
+      p₄ = e₁⁴ − 4·e₁²·e₂ + 2·e₂² + 4·e₁·e₃ − 4·e₄.
+    Transport of the universal `psum_four_closed` across the (char-2-safe) aeval bridge
+    onto the subtype {x // x ∈ s}.  No characteristic hypothesis is required. -/
+theorem newton_girard_four_finset (s : Finset ι) (f : ι → R) :
+    p4 s f =
+      e1 s f ^ 4 - 4 * (e1 s f ^ 2 * e2 s f) + 2 * e2 s f ^ 2
+        + 4 * (e1 s f * e3 s f) - 4 * e4 s f := by
+  have H := congrArg (aeval (fun i : {x // x ∈ s} => f i.1))
+    (psum_four_closed {x // x ∈ s} R)
+  simpa only [map_add, map_sub, map_mul, map_pow, map_ofNat,
+    p4_bridge, e1_bridge, e2_bridge, e3_bridge, e4_bridge] using H
+
+end Concrete
+
+-- ============================================================
+-- Concrete 4-variable instance (smallest nondegenerate case)
+-- ============================================================
+
+section Explicit
+
+variable {R : Type*} [CommRing R]
+
+/-- **Concrete 4-variable instance** — sum of fourth powers:
+      a⁴ + b⁴ + c⁴ + d⁴
+        = e₁⁴ − 4·e₁²·e₂ + 2·e₂² + 4·e₁·e₃ − 4·e₄,
+    where e₁ = a+b+c+d, e₂ = Σ pairs, e₃ = Σ triples, e₄ = abcd.
+    This is the n = 4 Finset case of `psum_four_closed`. -/
+theorem fourth_power_sum_four (a b c d : R) :
+    a ^ 4 + b ^ 4 + c ^ 4 + d ^ 4 =
+      (a + b + c + d) ^ 4
+        - 4 * ((a + b + c + d) ^ 2 * (a*b + a*c + a*d + b*c + b*d + c*d))
+        + 2 * (a*b + a*c + a*d + b*c + b*d + c*d) ^ 2
+        + 4 * ((a + b + c + d) * (a*b*c + a*b*d + a*c*d + b*c*d))
+        - 4 * (a*b*c*d) := by
+  ring
+
+end Explicit
+
+end AMGMInequalityOQ02OQ01OQ03OQ01

--- a/research/knowledge/technique-index.json
+++ b/research/knowledge/technique-index.json
@@ -29,6 +29,14 @@
       "outcome": "success",
       "date": "2026-05-07",
       "description": "legendreSym.eq_pow converts p^(q/2) = legendreSym q p in ZMod q after push_cast"
+    },
+    {
+      "name": "aeval-bridge transport (universal MvPolynomial → concrete Finset symmetric-function identity)",
+      "used_in_problems": [
+        "amgm-inequality-oq-02-oq-01-oq-03-oq-01"
+      ],
+      "outcome": "success",
+      "date": "2026-06-20"
     }
   ]
 }

--- a/research/problems/amgm-inequality-oq-02-oq-01-oq-03-oq-01/knowledge.md
+++ b/research/problems/amgm-inequality-oq-02-oq-01-oq-03-oq-01/knowledge.md
@@ -1,0 +1,69 @@
+# Knowledge Base: amgm-inequality-oq-02-oq-01-oq-03-oq-01
+
+Newton–Girard k=4 reduced closed form  p₄ = e₁⁴ − 4·e₁²·e₂ + 2·e₂² + 4·e₁·e₃ − 4·e₄.
+
+---
+
+## Problem Understanding
+
+The explicit next rung after the k=3 closed form. Express the fourth power sum purely in
+the elementary symmetric polynomials e₁..e₄, both universally (MvPolynomial) and concretely
+over a Finset of values in an arbitrary CommRing (char 2 included).
+
+---
+
+## Insights
+
+- **k=4 recurrence is mechanical.** `psum_eq_mul_esymm_sub_sum` at n=4 has antidiagonal
+  filter {(1,3),(2,2),(3,1)} and lead term (−1)⁵·4·e₄ = −4e₄, giving
+  p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄. Same recipe as k=2/k=3 (ext + omega, sum_insert/sum_singleton,
+  ring).
+- **The closed form is one `ring` step from the recurrence** once p₃, p₂, p₁ closed forms
+  are substituted. The 2·e₂² cross term is the first genuinely quartic feature (absent k≤3).
+- **The k=3 aeval bridge is degree-general.** `aeval_psum_subtype` / `aeval_esymm_subtype`
+  are stated for arbitrary n, so the concrete k=4 form needs only
+  `e4_bridge := aeval_esymm_subtype s f 4` and `p4_bridge := aeval_psum_subtype s f 4`.
+  This answers, by example, the k=3 entry's own open question about degree-generalizing the
+  bridge.
+- **No char-2 obstruction at k=4.** The closed form is read off the universal statement via
+  aeval transport (coefficient level, before evaluation), so no factor of 2 is cancelled —
+  unlike the direct k=3 ordered-triple partition (which only reached 2·p₃ = 2·closed).
+
+## Built Items
+
+- `proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01.lean` — 6 thm / 2 def / 0 sorry / 0 axiom,
+  Docker-verified GREEN (v4.26.0). #print axioms: [propext, Classical.choice, Quot.sound].
+- Registered in `proofs/Proofs.lean`.
+- Gallery entry `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01/meta.json`.
+- `lean/verify_newton_girard_k4.py` — durable cert (residual 0, n=2..6 + substitution chain
+  + explicit instance).
+
+## Mathlib Gaps
+
+- Mathlib has only the general Newton recurrence; reduced per-degree closed forms (k≥3) and
+  their concrete Finset incarnations are absent.
+- No packaged degree-uniform transport lemma; per-degree bridge wrappers are instantiated.
+
+## Next Steps
+
+1. Package a degree-uniform transport to eliminate per-degree wrappers.
+2. Continue to k=5: p₅ = e₁⁵ − 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ − 5e₂e₃ − 5e₁e₄ + 5e₅.
+3. Consider upstreaming the reduced closed forms / degree-general transport to Mathlib.
+
+---
+
+## Session 2026-06-20 (Session 1) — ACT (SOLVED)
+
+**Mode**: FRESH (follow-up after parent k=3 found already solved+merged) · **Outcome**: completed
+
+### What I Did
+- Confirmed the parent k=3 OQ (amgm-inequality-oq-02-oq-01-oq-03) is solved + merged
+  (PR #27174), then generated and proved the k=4 closed form as the natural next rung.
+- Shipped `AmgmInequalityOQ02OQ01OQ03OQ01.lean`: universal recurrence + closed form,
+  concrete general-Finset form via the reused (degree-general) aeval bridge, explicit
+  4-variable instance. 0 sorries / 0 axioms, Docker-verified GREEN.
+- Wrote durable Python cert and gallery entry; registered in Proofs.lean.
+
+### Key Findings
+- The k=3 aeval bridge is degree-general — concrete k=4 costs two one-line bridge instances.
+- No char-2 obstruction at k=4 (aeval transport bypasses any doubled factor).

--- a/research/problems/amgm-inequality-oq-02-oq-01-oq-03-oq-01/lean/verify_newton_girard_k4.py
+++ b/research/problems/amgm-inequality-oq-02-oq-01-oq-03-oq-01/lean/verify_newton_girard_k4.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Durable certificate for the Newton-Girard k=4 closed form
+    p4 = e1^4 - 4 e1^2 e2 + 2 e2^2 + 4 e1 e3 - 4 e4
+and the supporting k=4 recurrence
+    p4 = e1 p3 - e2 p2 + e3 p1 - 4 e4.
+
+Checks (symbolically, over Q):
+  1. The k=4 recurrence holds for n = 2..6 variables.
+  2. The k=4 closed form holds for n = 2..6 variables.
+  3. Substituting the proven lower closed forms (p3, p2, p1) into the recurrence
+     reproduces the closed form exactly (the `ring` step in `psum_four_closed`).
+  4. The explicit 4-variable instance matches.
+
+A residual of 0 for n >= 4 variables certifies the identity universally
+(MvPolynomial level), since the elementary symmetric polynomials e1..e4 are
+algebraically independent once there are at least 4 variables.
+
+Run:  python3 verify_newton_girard_k4.py
+"""
+import sympy as sp
+from itertools import combinations
+
+
+def psum(xs, k):
+    return sum(x ** k for x in xs)
+
+
+def esym(xs, k):
+    return sum(sp.prod(c) for c in combinations(xs, k))
+
+
+def main():
+    syms = sp.symbols('x0:6')  # up to 6 variables
+    all_ok = True
+
+    print("== (1) k=4 recurrence  p4 = e1 p3 - e2 p2 + e3 p1 - 4 e4 ==")
+    for n in range(2, 7):
+        xs = syms[:n]
+        e1, e2, e3, e4 = (esym(xs, k) for k in (1, 2, 3, 4))
+        p1, p2, p3, p4 = (psum(xs, k) for k in (1, 2, 3, 4))
+        res = sp.expand(e1 * p3 - e2 * p2 + e3 * p1 - 4 * e4 - p4)
+        print(f"  n={n}: residual = {res}")
+        all_ok &= (res == 0)
+
+    print("== (2) k=4 closed form  p4 = e1^4 - 4 e1^2 e2 + 2 e2^2 + 4 e1 e3 - 4 e4 ==")
+    for n in range(2, 7):
+        xs = syms[:n]
+        e1, e2, e3, e4 = (esym(xs, k) for k in (1, 2, 3, 4))
+        p4 = psum(xs, 4)
+        res = sp.expand(e1**4 - 4*e1**2*e2 + 2*e2**2 + 4*e1*e3 - 4*e4 - p4)
+        print(f"  n={n}: residual = {res}")
+        all_ok &= (res == 0)
+
+    print("== (3) recurrence + lower closed forms  ==>  closed form (the `ring` step) ==")
+    e1, e2, e3, e4 = sp.symbols('e1 e2 e3 e4')
+    p1 = e1
+    p2 = e1**2 - 2*e2
+    p3 = e1**3 - 3*e1*e2 + 3*e3
+    p4_from_rec = e1*p3 - e2*p2 + e3*p1 - 4*e4
+    closed = e1**4 - 4*e1**2*e2 + 2*e2**2 + 4*e1*e3 - 4*e4
+    res = sp.expand(p4_from_rec - closed)
+    print(f"  residual = {res}")
+    all_ok &= (res == 0)
+
+    print("== (4) explicit 4-variable instance ==")
+    a, b, c, d = sp.symbols('a b c d')
+    e1 = a + b + c + d
+    e2 = a*b + a*c + a*d + b*c + b*d + c*d
+    e3 = a*b*c + a*b*d + a*c*d + b*c*d
+    e4 = a*b*c*d
+    lhs = a**4 + b**4 + c**4 + d**4
+    rhs = e1**4 - 4*(e1**2*e2) + 2*e2**2 + 4*(e1*e3) - 4*e4
+    res = sp.expand(lhs - rhs)
+    print(f"  residual = {res}")
+    all_ok &= (res == 0)
+
+    print()
+    print("ALL CHECKS PASSED" if all_ok else "FAILURE: a residual was nonzero")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/problems/amgm-inequality-oq-02-oq-01-oq-03-oq-01/problem.md
+++ b/research/problems/amgm-inequality-oq-02-oq-01-oq-03-oq-01/problem.md
@@ -1,0 +1,41 @@
+# Problem: Newton–Girard $k=4$ closed form $p_4 = e_1^4 - 4 e_1^2 e_2 + 2 e_2^2 + 4 e_1 e_3 - 4 e_4$
+
+**Slug**: amgm-inequality-oq-02-oq-01-oq-03-oq-01
+**Created**: 2026-06-20
+**Status**: SOLVED
+**Source**: follow-up open question of gallery proof amgm-inequality-oq-02-oq-01-oq-03 (k=3 closed form)
+
+## Problem Statement
+
+### Formal Statement
+
+For a finite indexed family $x_1,\dots,x_m$ with power sums $p_k = \sum_i x_i^k$ and
+elementary symmetric polynomials $e_k$, prove the $k=4$ Newton–Girard closed form
+$$
+p_4 = e_1^4 - 4\,e_1^2 e_2 + 2\,e_2^2 + 4\,e_1 e_3 - 4\,e_4,
+$$
+both as the universal MvPolynomial statement and as a concrete identity over a `Finset`
+of values in an arbitrary commutative ring (characteristic 2 included).
+
+### Why This Matters
+
+This is the explicit next rung after the k=3 closed form
+`amgm-inequality-oq-02-oq-01-oq-03`. It is the first case whose reduced expression is
+genuinely quartic in the elementary symmetric polynomials (the cross term $2 e_2^2$),
+and it is a direct test of whether the k=3 `aeval` bridge is degree-general — it is,
+so the concrete form costs only two one-line bridge instantiations.
+
+## Resolution
+
+Proved 2026-06-20 in `proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01.lean`
+(Docker-verified GREEN, Lean v4.26.0; 6 theorems, 2 defs, 0 sorries, 0 axioms):
+
+1. `psum_four_recurrence` — extract $p_4 = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4 e_4$ from
+   `MvPolynomial.psum_eq_mul_esymm_sub_sum` at $n=4$.
+2. `psum_four_closed` — substitute the proven $p_3, p_2, p_1$ closed forms and `ring`.
+3. `newton_girard_four_finset` — transport `psum_four_closed` across the (degree-general)
+   k=3 `aeval` bridge at degree 4; holds over any `CommRing`.
+4. `fourth_power_sum_four` — the explicit 4-variable instance.
+
+Independently certified in `lean/verify_newton_girard_k4.py` (symbolic residual 0,
+$n=2..6$).

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "amgm-inequality-oq-02-oq-01-oq-03-oq-01",
+  "title": "Newton-Girard k=4 Closed Form over Any CommRing (incl. characteristic 2)",
+  "slug": "amgm-inequality-oq-02-oq-01-oq-03-oq-01",
+  "description": "Establishes the fully reduced fourth Newton-Girard identity p₄ = e₁⁴ − 4·e₁²·e₂ + 2·e₂² + 4·e₁·e₃ − 4·e₄ in two complementary forms: (1) the universal MvPolynomial statement, derived by extracting the k=4 Newton recurrence p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄ from Mathlib's psum_eq_mul_esymm_sub_sum and substituting the proven closed forms p₃ = e₁³ − 3e₁e₂ + 3e₃, p₂ = e₁² − 2e₂, p₁ = e₁; and (2) a concrete general-Finset form over an arbitrary CommRing obtained by reusing the n-general aeval bridge built for the k=3 entry — transporting the universal identity onto the subtype {x // x ∈ s} with the e₄/p₄ bridge lemmas instantiated at degree 4. The concrete form holds over any commutative ring including characteristic 2. Specializes to the sum-of-fourth-powers identity a⁴+b⁴+c⁴+d⁴ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ03OQ01.lean",
+    "additionalFiles": [],
+    "tags": [
+      "algebra",
+      "symmetric-functions",
+      "newton-girard",
+      "power-sums",
+      "elementary-symmetric-polynomials",
+      "finset",
+      "characteristic-two",
+      "mv-polynomial"
+    ],
+    "badge": "verified",
+    "mathlibDependencies": [
+      {
+        "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+        "description": "The general Newton-Girard recurrence pₙ = (−1)^(n+1)·n·eₙ − Σ_{0<a.1<n} (−1)^a.1 e_{a.1} p_{a.2}; instantiated at n=4 to extract p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄.",
+        "module": "Mathlib.RingTheory.MvPolynomial.NewtonIdentities"
+      },
+      {
+        "theorem": "MvPolynomial.aeval_esymm_eq_multiset_esymm",
+        "description": "aeval of the universal elementary symmetric polynomial equals the multiset elementary symmetric sum of the evaluated variables — the engine of the inherited concrete-Finset bridge (degree 4 instance).",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      },
+      {
+        "theorem": "Finset.esymm_map_val",
+        "description": "Identifies the multiset elementary symmetric sum over s.val.map f with the powersetCard sum Σ_{t ⊆ s, |t|=n} ∏_{i ∈ t} f i.",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      }
+    ],
+    "originalContributions": [
+      "psum_four_recurrence: the k=4 Newton recurrence p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄, extracted from Mathlib's psum_eq_mul_esymm_sub_sum by computing the antidiagonal filter {(1,3),(2,2),(3,1)} and the lead term (−1)⁵·4·e₄.",
+      "psum_four_closed: the universal MvPolynomial closed form p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄, obtained by substituting the proven lower closed forms into the recurrence and ring-normalising.",
+      "newton_girard_four_finset: the concrete general-Finset closed form over ANY CommRing (characteristic 2 included), obtained by transporting psum_four_closed across the aeval bridge — demonstrating that the k=3 bridge is genuinely degree-general (e4_bridge/p4_bridge are the n=4 instances of aeval_esymm_subtype/aeval_psum_subtype).",
+      "fourth_power_sum_four: the explicit 4-variable instance a⁴+b⁴+c⁴+d⁴ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ over any CommRing."
+    ],
+    "dateAdded": "2026-06-20",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 174,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms reports only [propext, Classical.choice, Quot.sound] for both psum_four_closed and newton_girard_four_finset (no sorryAx, no Lean.ofReduceBool). The universal identity is a ring-level corollary of Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum together with the sibling k=1/2/3 closed forms; the concrete-Finset form reuses the k=3 entry's aeval bridge and holds over an arbitrary CommRing including characteristic 2.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Newton's identities (Newton-Girard identities) relate the power sums pₖ = Σ xᵢᵏ to the elementary symmetric polynomials eₖ. Girard stated them around 1629 and Newton independently around 1666 (Arithmetica Universalis, 1707). The fourth identity, p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄, is the first case in which the reduced closed form acquires a quadratic e₂² term and a four-distinct elementary symmetric polynomial e₄. While Mathlib provides the general recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum, the fully reduced k=4 closed form purely in e₁, e₂, e₃, e₄ — and its concrete Finset incarnation valid in every commutative ring, characteristic 2 included — is not present in Mathlib.",
+    "problemStatement": "**Open Question (amgm-inequality-oq-02-oq-01-oq-03-oq-01)**: Establish the fully reduced k=4 Newton-Girard identity\n\np₄ = e₁⁴ − 4·e₁²·e₂ + 2·e₂² + 4·e₁·e₃ − 4·e₄\n\nexpressing the fourth power sum purely in terms of e₁, e₂, e₃, e₄, both as the universal MvPolynomial statement and as a concrete identity over a Finset of values in an arbitrary commutative ring. This is the explicit next rung after the k=3 closed form, and a direct test of whether the k=3 aeval bridge is degree-general.\n\n**Answer**: Proved in both forms. The universal form extracts the k=4 recurrence from Mathlib's general Newton identity and substitutes the lower closed forms. The concrete general-Finset form reuses the k=3 entry's aeval bridge (which is already stated for arbitrary degree n) at degree 4, and holds over any CommRing — characteristic 2 included.",
+    "text": "The file AmgmInequalityOQ02OQ01OQ03OQ01.lean resolves the question. The universal section proves psum_four_recurrence (p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄) by instantiating Mathlib's psum_eq_mul_esymm_sub_sum at n=4, computing the antidiagonal filter {(1,3),(2,2),(3,1)}, and ring-normalising; psum_four_closed then substitutes the proven closed forms for p₃, p₂, p₁ and closes with ring. The concrete section reuses the k=3 Finset definitions (e₁, e₂, e₃) and aeval bridge, adds e₄ and p₄ with their degree-4 bridge instances, and proves newton_girard_four_finset over an arbitrary CommRing by congrArg of psum_four_closed under aeval onto the subtype {x // x ∈ s}. The explicit 4-variable sum-of-fourth-powers instance is recorded as fourth_power_sum_four.",
+    "proofStrategy": "**Universal recurrence**: psum_four_recurrence rewrites with MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 4. The antidiagonal {a : a.1+a.2=4, 0<a.1<4} = {(1,3),(2,2),(3,1)} is established by ext + omega; the three-term sum is unfolded by Finset.sum_insert (mem facts by decide) and Finset.sum_singleton, and ring evaluates the (−1)^k coefficients and the lead term (−1)⁵·4·e₄.\n\n**Universal closed form**: psum_four_closed rewrites the recurrence with psum_three_closed, psum_two_eq, psum_one_eq_esymm_one and closes with ring.\n\n**Concrete Finset form (char-2 safe)**: e4_bridge and p4_bridge are the degree-4 instances of the k=3 entry's aeval_esymm_subtype / aeval_psum_subtype, so no new bridge machinery is needed — this is the concrete demonstration that the k=3 bridge is degree-general. newton_girard_four_finset is the congrArg image of psum_four_closed under aeval (fun i : {x // x ∈ s} => f i.1), simplified by map_add/map_sub/map_mul/map_pow/map_ofNat and the five bridge lemmas (e1..e4, p4). Because the transport happens at the level of polynomial coefficients, no factor of 2 is ever cancelled and the identity holds over rings with 2-torsion.",
+    "keyInsights": [
+      "The k=4 closed form is the first rung where the reduced expression is genuinely quartic in the elementary symmetric polynomials, featuring the cross term 2·e₂² absent at k≤3; it remains one recurrence step plus a ring substitution away from Mathlib's general Newton identity.",
+      "The aeval bridge built for the k=3 entry (aeval_psum_subtype / aeval_esymm_subtype) is already stated for arbitrary degree n. The k=4 concrete form therefore needs only e4_bridge := aeval_esymm_subtype s f 4 and p4_bridge := aeval_psum_subtype s f 4 — confirming the bridge is a reusable, degree-uniform transport rather than a degree-3 special case.",
+      "Transporting the universal identity (which lives at the level of polynomial coefficients, before evaluation) yields the concrete Finset identity unconditionally — there is no characteristic-2 obstruction to bypass at k=4 because the closed form is never assembled from a doubled combinatorial partition; it is read off the universal statement directly.",
+      "Extracting the k=4 recurrence from psum_eq_mul_esymm_sub_sum is purely mechanical once the antidiagonal filter {(1,3),(2,2),(3,1)} and the sign of the lead term (−1)^(n+1)·n·eₙ are pinned down, mirroring the k=2 and k=3 derivations exactly."
+    ],
+    "prerequisites": [
+      "k=3 closed form AmgmInequalityOQ02OQ01OQ03: psum_three_closed (p₃ = e₁³ − 3e₁e₂ + 3e₃).",
+      "k=3 Finset bridge AmgmInequalityOQ02OQ01OQ03Finset: the n-general aeval_psum_subtype / aeval_esymm_subtype and the e₁,e₂,e₃ definitions and bridge lemmas.",
+      "Recurrence sibling AmgmInequalityOQ02OQ01OQ02OQ01: psum_two_eq (p₂ = e₁² − 2e₂) and psum_one_eq_esymm_one (p₁ = e₁).",
+      "MvPolynomial.psum_eq_mul_esymm_sub_sum — the general Newton-Girard recurrence (Mathlib).",
+      "Finset.powersetCard — fixed-cardinality subsets, the concrete definition of eₖ (Mathlib)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Module Docstring: Newton-Girard k=4 Closed Form",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "States the target identity p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄, its lineage from the k=2/k=3 entries, the two-form strategy (universal recurrence/substitution + concrete aeval transport), and the proof status (PROVED, 0 sorries, 0 axioms).",
+      "mathContext": "$p_4 = e_1^4 - 4 e_1^2 e_2 + 2 e_2^2 + 4 e_1 e_3 - 4 e_4$."
+    },
+    {
+      "id": "universal",
+      "title": "Universal Closed Form (MvPolynomial)",
+      "startLine": 55,
+      "endLine": 103,
+      "summary": "psum_four_recurrence extracts p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄ from psum_eq_mul_esymm_sub_sum at n=4 (antidiagonal {(1,3),(2,2),(3,1)}). psum_four_closed substitutes the proven p₃, p₂, p₁ closed forms and ring-normalises.",
+      "mathContext": "In MvPolynomial σ R: $p_4 = e_1^4 - 4(e_1^2 e_2) + 2 e_2^2 + 4(e_1 e_3) - 4 e_4$."
+    },
+    {
+      "id": "concrete",
+      "title": "Concrete General-Finset Form (char-2 safe)",
+      "startLine": 105,
+      "endLine": 148,
+      "summary": "Defines e₄, p₄ over a Finset via powersetCard, adds the degree-4 bridge instances e4_bridge/p4_bridge (reusing the k=3 n-general aeval bridge), and proves newton_girard_four_finset over an arbitrary CommRing by transporting psum_four_closed across aeval onto the membership subtype.",
+      "mathContext": "Over any CommRing: $p_4 = e_1^4 - 4 e_1^2 e_2 + 2 e_2^2 + 4 e_1 e_3 - 4 e_4$, characteristic 2 included."
+    },
+    {
+      "id": "explicit",
+      "title": "Concrete 4-Variable Instance (Sum of Fourth Powers)",
+      "startLine": 150,
+      "endLine": 173,
+      "summary": "fourth_power_sum_four: a⁴+b⁴+c⁴+d⁴ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ over any CommRing, closed by ring — the smallest nondegenerate Finset instance.",
+      "mathContext": "$a^4+b^4+c^4+d^4 = e_1^4 - 4 e_1^2 e_2 + 2 e_2^2 + 4 e_1 e_3 - 4 e_4$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Resolves the open question in both the universal MvPolynomial setting and the concrete general-Finset setting. The universal identity p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ is extracted from Mathlib's general Newton recurrence plus the lower closed forms; the concrete Finset form reuses the k=3 entry's degree-general aeval bridge at degree 4 and holds over an arbitrary CommRing (characteristic 2 included). The file is machine-verified with 0 sorries and 0 axioms (only propext/Classical.choice/Quot.sound).",
+    "implications": "**For symmetric function theory**: completes the reduced k=4 Newton-Girard identity, the first with a quadratic e₂² term, extending the gallery's k=2 → k=3 → k=4 chain of explicit closed forms.\n\n**For formalization technique**: directly validates that the k=3 aeval bridge (concrete powersetCard / power-sum defs = aeval of universal MvPolynomial symmetric functions on the membership subtype) is degree-uniform: the k=4 concrete form costs only two one-line bridge instantiations. This answers, by example, the k=3 entry's own open question about generalizing the bridge to arbitrary degree.",
+    "openQuestions": [
+      "Prove the k=4 recurrence and closed form via a single degree-uniform transport lemma pₖ (powersetCard form) = aeval (psum {x // x ∈ s} R k) applied to the full Newton recurrence, eliminating per-degree wrappers (e4_bridge, p4_bridge, …) entirely.",
+      "Continue the chain to k=5: p₅ = e₁⁵ − 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ − 5e₂e₃ − 5e₁e₄ + 5e₅, the first rung involving e₅ and two distinct degree-5 monomials with coefficient 5."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-03",
+      "relationship": "parent",
+      "description": "The k=3 closed form and its n-general aeval bridge (aeval_psum_subtype / aeval_esymm_subtype), which this entry reuses verbatim at degree 4. This entry answers, by example, that parent's open question about a degree-general bridge."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Provides the closed forms p₂ = e₁² − 2e₂, p₁ = e₁ and the pattern for extracting Newton recurrences from MvPolynomial.psum_eq_mul_esymm_sub_sum; this entry repeats that pattern at n=4."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-04",
+      "relationship": "related",
+      "description": "Proves the GENERAL Finset-level Newton-Girard recurrence (pₖ in terms of lower pⱼ and eⱼ) for arbitrary k. This entry is complementary: it gives the fully REDUCED closed form for the specific case k=4, expressing p₄ purely in e₁,e₂,e₃,e₄ rather than recursively."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "The k=2 identity p₂ = e₁² − 2e₂ (concrete Finset pair partition); this entry is the k=4 rung of the same Newton-Girard closed-form chain."
+    },
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "related",
+      "description": "The e₁, e₂, e₃, e₄ appearing here are exactly Vieta's elementary symmetric polynomials in the roots; the identity expresses the fourth power sum of roots via coefficients."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Girard, Albert",
+      "title": "Invention nouvelle en l'algèbre",
+      "year": "1629",
+      "venue": "Amsterdam: Guillaume Iansson Blaeuw",
+      "note": "Earliest known statement of the identities relating power sums to elementary symmetric polynomials."
+    },
+    {
+      "authors": "Newton, Isaac",
+      "title": "Arithmetica Universalis",
+      "year": "1707",
+      "venue": "Cambridge (manuscript ~1666)",
+      "note": "Newton's independent treatment of the power-sum / elementary-symmetric identities."
+    },
+    {
+      "authors": "Macdonald, I. G.",
+      "title": "Symmetric Functions and Hall Polynomials",
+      "year": "1995",
+      "venue": "Oxford University Press, 2nd edition, Chapter I §2",
+      "note": "Canonical reference; the Newton-Girard identities appear as (2.11′)/(2.11″)."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AmgmInequalityOQ02OQ01OQ03OQ01.lean",
+    "lineCount": 174,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "axiomCount": 0,
+    "sorries": 0,
+    "additionalFiles": []
+  }
+}

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-03-oq-01.json
@@ -1,0 +1,63 @@
+{
+  "slug": "amgm-inequality-oq-02-oq-01-oq-03-oq-01",
+  "title": "Newton-Girard k=4 closed form p4 = e1^4 - 4 e1^2 e2 + 2 e2^2 + 4 e1 e3 - 4 e4",
+  "status": "active",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "significance": 5,
+  "tractability": 7,
+  "path": "full",
+  "started": "2026-06-20",
+  "problemStatement": "Establish the fully reduced k=4 Newton-Girard identity p4 = e1^4 - 4 e1^2 e2 + 2 e2^2 + 4 e1 e3 - 4 e4, expressing the fourth power sum purely in the elementary symmetric polynomials e1..e4, both as a universal MvPolynomial statement and as a concrete identity over a Finset of values in an arbitrary commutative ring (characteristic 2 included). The explicit next rung after the k=3 closed form, and a direct test of whether the k=3 aeval bridge is degree-general.",
+  "knownResults": "Mathlib provides the general recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum. The k=1/2/3 closed forms are proven in the sibling gallery entries. The general Finset-level recurrence (arbitrary k, recursive form) is proven in amgm-inequality-oq-02-oq-01-oq-04. The fully reduced k=4 closed form purely in e1..e4 was absent from both Mathlib and the gallery.",
+  "currentState": "SOLVED. proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01.lean Docker-verified GREEN (Lean v4.26.0): 6 theorems, 2 defs, 0 sorries, 0 axioms. #print axioms reports only [propext, Classical.choice, Quot.sound] for both psum_four_closed and newton_girard_four_finset. Registered in proofs/Proofs.lean; gallery entry created.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: k=4 closed form proved in universal MvPolynomial and concrete general-Finset (char-2 safe) forms, Docker-verified GREEN, 0 sorries / 0 axioms. The k=3 aeval bridge is confirmed degree-general (only e4_bridge/p4_bridge one-liners needed at degree 4).",
+    "insights": [
+      "The k=4 recurrence p4 = e1 p3 - e2 p2 + e3 p1 - 4 e4 comes from psum_eq_mul_esymm_sub_sum at n=4: antidiagonal filter {(1,3),(2,2),(3,1)}, lead term (-1)^5 * 4 * e4 = -4 e4. Mirrors the k=2/k=3 derivations exactly (ext + omega for the filter, sum_insert/sum_singleton, then ring).",
+      "Substituting p3 = e1^3 - 3 e1 e2 + 3 e3, p2 = e1^2 - 2 e2, p1 = e1 into the recurrence and ring-normalising gives p4 = e1^4 - 4 e1^2 e2 + 2 e2^2 + 4 e1 e3 - 4 e4. The 2 e2^2 cross term is the first genuinely quartic feature, absent at k<=3.",
+      "The k=3 entry's aeval bridge (aeval_psum_subtype / aeval_esymm_subtype) is already stated for arbitrary degree n, so the concrete k=4 form needs only e4_bridge := aeval_esymm_subtype s f 4 and p4_bridge := aeval_psum_subtype s f 4. This answers, by example, the k=3 entry's open question on degree-generalizing the bridge.",
+      "No characteristic-2 obstruction arises at k=4 because the closed form is read off the universal statement via aeval transport (coefficient level, before evaluation) rather than assembled from a doubled combinatorial partition — so no factor of 2 is ever cancelled."
+    ],
+    "builtItems": [
+      "proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01.lean: psum_four_recurrence, psum_four_closed (universal); e4/p4 defs + e4_bridge/p4_bridge + newton_girard_four_finset (concrete general-Finset, any CommRing); fourth_power_sum_four (explicit 4-var). 6 thm, 2 def, 0 sorry, 0 axiom. Docker-verified GREEN.",
+      "Registered import in proofs/Proofs.lean.",
+      "Gallery entry src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01/meta.json (verified/verified).",
+      "research/problems/amgm-inequality-oq-02-oq-01-oq-03-oq-01/lean/verify_newton_girard_k4.py: durable cert (recurrence + closed form residual 0 for n=2..6; substitution chain; explicit instance)."
+    ],
+    "mathlibGaps": [
+      "Mathlib has only the general Newton recurrence (MvPolynomial.psum_eq_mul_esymm_sub_sum); the fully reduced per-degree closed forms (k>=3 purely in elementary symmetric polynomials) and their concrete Finset incarnations are absent.",
+      "No single degree-uniform transport lemma pk (powersetCard form) = aeval (psum subtype k) packaged for reuse; currently per-degree bridge wrappers are instantiated."
+    ],
+    "nextSteps": [
+      "Package a degree-uniform transport lemma to eliminate per-degree bridge wrappers (e4_bridge, p4_bridge, ...).",
+      "Continue to k=5: p5 = e1^5 - 5 e1^3 e2 + 5 e1 e2^2 + 5 e1^2 e3 - 5 e2 e3 - 5 e1 e4 + 5 e5.",
+      "Consider upstreaming the reduced closed forms / the degree-general transport to Mathlib."
+    ],
+    "markdown": "# Knowledge Base: amgm-inequality-oq-02-oq-01-oq-03-oq-01\n\nNewton-Girard k=4 reduced closed form p4 = e1^4 - 4 e1^2 e2 + 2 e2^2 + 4 e1 e3 - 4 e4.\n\n---\n\n## Status\n\nSOLVED 2026-06-20. Universal (MvPolynomial) + concrete general-Finset (any CommRing, char 2 included). Docker-verified GREEN, 0 sorries / 0 axioms.\n\n## Method\n\n1. Extract the k=4 recurrence p4 = e1 p3 - e2 p2 + e3 p1 - 4 e4 from Mathlib's psum_eq_mul_esymm_sub_sum (antidiagonal {(1,3),(2,2),(3,1)}).\n2. Substitute the proven k=1/2/3 closed forms and ring-normalise -> psum_four_closed.\n3. Transport across the (degree-general) k=3 aeval bridge at degree 4 -> newton_girard_four_finset over any CommRing.\n"
+  },
+  "leanFiles": [
+    "proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01.lean"
+  ],
+  "relatedProofs": [
+    "amgm-inequality-oq-02-oq-01-oq-03",
+    "amgm-inequality-oq-02-oq-01-oq-04",
+    "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
+    "amgm-inequality-oq-02-oq-01"
+  ],
+  "references": [
+    "Macdonald, Symmetric Functions and Hall Polynomials, Ch. I §2 (Newton-Girard identities)."
+  ],
+  "tags": [
+    "algebra",
+    "symmetric-functions",
+    "newton-girard",
+    "power-sums",
+    "elementary-symmetric-polynomials",
+    "finset",
+    "characteristic-two",
+    "mv-polynomial",
+    "research"
+  ],
+  "path": "full"
+}


### PR DESCRIPTION
## Summary

Proves the **fully reduced k=4 Newton–Girard identity**
$$p_4 = e_1^4 - 4 e_1^2 e_2 + 2 e_2^2 + 4 e_1 e_3 - 4 e_4$$
the explicit next rung after the merged k=3 closed form (`amgm-inequality-oq-02-oq-01-oq-03`, PR #27174). Two complementary forms, each **0-sorry / 0-axiom**, Docker-verified GREEN (Lean v4.26.0):

- **`psum_four_recurrence` / `psum_four_closed`** — universal MvPolynomial form. Extracts the k=4 Newton recurrence `p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄` from Mathlib's `MvPolynomial.psum_eq_mul_esymm_sub_sum` (antidiagonal filter `{(1,3),(2,2),(3,1)}`, lead term `(−1)⁵·4·e₄`), then substitutes the proven k=1/2/3 closed forms and `ring`-normalises.
- **`newton_girard_four_finset`** — concrete general-Finset form over an **arbitrary CommRing (characteristic 2 included)**, by reusing the k=3 entry's *degree-general* `aeval` bridge at degree 4 (`e4_bridge`/`p4_bridge` are one-line instances of `aeval_esymm_subtype`/`aeval_psum_subtype`). This answers, by example, the k=3 entry's own open question about generalizing the bridge to arbitrary degree.
- **`fourth_power_sum_four`** — explicit 4-variable instance `a⁴+b⁴+c⁴+d⁴ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02OQ01OQ03OQ01` → **GREEN** (7746/7746).
- `#print axioms` for both `psum_four_closed` and `newton_girard_four_finset`: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.
- Durable sympy certificate `research/problems/.../lean/verify_newton_girard_k4.py`: recurrence + closed form residual 0 for n=2..6, plus the substitution chain and the explicit instance.

## Files

- `proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01.lean` (new, 6 thm / 2 def / 0 sorry / 0 axiom), registered in `proofs/Proofs.lean`.
- `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01/meta.json` (gallery entry, verified).
- `src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-03-oq-01.json` + `research/problems/.../{problem.md,knowledge.md,lean/verify_newton_girard_k4.py}`.

## Note on scope vs siblings

Complementary to `amgm-inequality-oq-02-oq-01-oq-04` (which proves the *general* Finset Newton **recurrence** for arbitrary k): this entry gives the fully **reduced closed form** for the specific case k=4, purely in e₁,e₂,e₃,e₄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)