### PR TITLE
audit(amgm-k4): mark Newton-Girard k=4 closed form clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17301,8 +17301,14 @@
       "lastAudited": "2026-06-21T00:39:39Z",
       "result": "clean",
       "issues": []
+    },
+    "amgm-inequality-oq-02-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T00:55:22Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-19T12:15:00Z"
+  "lastUpdated": "2026-06-21T00:55:22Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: amgm-inequality-oq-02-oq-01-oq-03-oq-01 (Newton-Girard k=4 closed form, merged via #27227)

Verified meta.json claims against `proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01.lean`:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 174 | 174 | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 2 | 2 | ✓ |
| sorries | 0 | 0 (lone `sorry` token is in docstring line 24) | ✓ |
| axiomCount | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| native_decide | — | 0 | ✓ |

- **Badge `verified`** is consistent with the direct parent k=3 entry (`amgm-inequality-oq-02-oq-01-oq-03`, also `verified`). The reduced closed form p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ is genuine work, not a direct Mathlib call.
- **Mathlib dependency** (`psum_eq_mul_esymm_sub_sum`) honestly disclosed in `assumptions` and `mathlibDependencies`.
- `#print axioms` claim (only propext/Classical.choice/Quot.sound) is credible — no `native_decide`, no axiom declarations.

Persists the clean mark to main's audit-tracker.json (the audit ran in a worktree whose tracker write does not reach main).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)