### PR TITLE
research(derangements-convergence-oq-03-oq-02): one-term recurrence convention + modular shadow D(m) ≡ (-1)^m (mod m)

### DIFF
--- a/proofs/Proofs/DerangementsConvergenceOQ03OQ02.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ03OQ02.lean
@@ -1,0 +1,82 @@
+/-
+  Derangements: the alternating one-term recurrence
+  Open Question: derangements-convergence-oq-03-oq-02
+
+  ## Main result (requested form)
+
+  `numDerangements_succ_alt` :
+    (numDerangements (n + 1) : ℤ) = (n + 1) * numDerangements n + (-1) ^ (n + 1)
+
+  This is the `+(-1)^(n+1)` sign-convention form of Mathlib's
+  `numDerangements_succ`, which states the same recurrence as
+  `(n + 1) * numDerangements n - (-1) ^ n`.  The two are equivalent because
+  `(-1)^(n+1) = -(-1)^n`, so the recurrence itself is a one-line restatement of
+  the Mathlib lemma in the convention used by the open-question statement.
+
+  ## What is genuinely new here
+
+  Beyond presenting the recurrence in the requested convention, we record two
+  consequences that Mathlib does not carry and that follow immediately from the
+  one-term form:
+
+  * `numDerangements_sub_eq` :
+      (numDerangements (n + 1) : ℤ) - (n + 1) * numDerangements n = (-1) ^ (n + 1)
+    The exact one-term "error" between D(n+1) and (n+1)·D(n) is always ±1; in
+    particular |D(n+1) - (n+1)·D(n)| = 1.
+
+  * `numDerangements_modEq` :
+      (numDerangements (n + 1) : ℤ) ≡ (-1) ^ (n + 1) [ZMOD (n + 1)]
+    Reducing the recurrence modulo (n+1) kills the (n+1)·D(n) term, so the
+    derangement count is congruent to ±1 modulo its order: D(m) ≡ (-1)^m (mod m)
+    for every m ≥ 1.
+
+  All results are fully machine-checked with no `sorry` and no extra axioms
+  (only Lean/Mathlib's foundational `propext`/`Classical.choice`/`Quot.sound`).
+-/
+
+import Mathlib
+
+namespace DerangementsConvergenceOQ03OQ02
+
+/-- **Alternating one-term derangement recurrence** in the `+(-1)^(n+1)`
+convention requested by the open question:
+`D(n+1) = (n+1)·D(n) + (-1)^(n+1)`.
+
+Equivalent to Mathlib's `numDerangements_succ` (which uses `-(-1)^n`). -/
+theorem numDerangements_succ_alt (n : ℕ) :
+    (numDerangements (n + 1) : ℤ)
+      = (n + 1) * (numDerangements n : ℤ) + (-1) ^ (n + 1) := by
+  rw [numDerangements_succ, pow_succ]
+  ring
+
+/-- The exact one-term error: `D(n+1) - (n+1)·D(n) = (-1)^(n+1)`.
+In particular `|D(n+1) - (n+1)·D(n)| = 1`. -/
+theorem numDerangements_sub_eq (n : ℕ) :
+    (numDerangements (n + 1) : ℤ) - (n + 1) * (numDerangements n : ℤ)
+      = (-1) ^ (n + 1) := by
+  rw [numDerangements_succ_alt]; ring
+
+/-- `|D(n+1) - (n+1)·D(n)| = 1`: the one-term remainder always has size one. -/
+theorem numDerangements_abs_sub (n : ℕ) :
+    |(numDerangements (n + 1) : ℤ) - (n + 1) * (numDerangements n : ℤ)| = 1 := by
+  rw [numDerangements_sub_eq, abs_pow, abs_neg, abs_one, one_pow]
+
+/-- **Modular consequence.** Reducing the recurrence modulo `n+1` annihilates the
+`(n+1)·D(n)` term, leaving `D(n+1) ≡ (-1)^(n+1) (mod n+1)`.
+
+Equivalently, for every `m ≥ 1`, `D(m) ≡ (-1)^m (mod m)`: the number of
+derangements is congruent to `±1` modulo its order. -/
+theorem numDerangements_modEq (n : ℕ) :
+    (numDerangements (n + 1) : ℤ) ≡ (-1) ^ (n + 1) [ZMOD ((n : ℤ) + 1)] := by
+  rw [numDerangements_succ_alt]
+  have hdvd : ((n : ℤ) + 1) ∣ ((n : ℤ) + 1) * (numDerangements n : ℤ) :=
+    Dvd.intro _ rfl
+  have h := Int.ModEq.add_right ((-1 : ℤ) ^ (n + 1))
+    ((Int.modEq_zero_iff_dvd).mpr hdvd)
+  rwa [zero_add] at h
+
+/-- Sanity check on the small values: `D(4) = 9`, consistent with
+`9 = 4·2 + (-1)^4 = 8 + 1`. -/
+example : numDerangements 4 = 9 := by decide
+
+end DerangementsConvergenceOQ03OQ02

--- a/src/data/proofs/derangements-convergence-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-02/annotations.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "ann-dcoq0302-header",
+    "proofId": "derangements-convergence-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "Module Overview: One-Term Recurrence and Its Modular Shadow",
+    "content": "This module restates the one-term derangement recurrence in the convention D(n+1) = (n+1)·D(n) + (-1)^(n+1) requested by the open question, and then records two consequences that Mathlib does not carry: the exact one-term remainder |D(n+1) - (n+1)·D(n)| = 1, and the congruence D(m) ≡ (-1)^m (mod m). The core recurrence is a one-line restatement of Mathlib's numDerangements_succ; the value added here is the modular consequence. The file imports all of Mathlib and works entirely over ℤ, where the alternating ±1 corrections are visible.",
+    "mathContext": "Mathlib states the recurrence as $D(n+1) = (n+1)D(n) - (-1)^n$. Since $(-1)^{n+1} = -(-1)^n$, the requested $+(-1)^{n+1}$ form is the same identity. Reducing it modulo $n+1$ annihilates the $(n+1)D(n)$ term and leaves $D(n+1) \\equiv (-1)^{n+1} \\pmod{n+1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "numDerangements",
+      "numDerangements_succ",
+      "Int.ModEq",
+      "alternating recurrence"
+    ],
+    "prerequisites": [
+      "Mathlib's numDerangements_succ (one-term derangement recurrence)",
+      "Int.ModEq congruence API",
+      "Parity of (-1)^k"
+    ]
+  },
+  {
+    "id": "ann-dcoq0302-recurrence",
+    "proofId": "derangements-convergence-oq-03-oq-02",
+    "range": { "startLine": 41, "endLine": 50 },
+    "type": "theorem",
+    "title": "numDerangements_succ_alt: the requested sign convention",
+    "content": "Proves D(n+1) = (n+1)·D(n) + (-1)^(n+1). The proof rewrites Mathlib's numDerangements_succ (which gives -(-1)^n) and pow_succ (which expands (-1)^(n+1) = (-1)^n·(-1)), then ring reconciles the two. Mathematically this is a pure restatement — its purpose is to match the open question's stated convention.",
+    "mathContext": "$(-1)^{n+1} = (-1)^n \\cdot (-1) = -(-1)^n$, so $+(-1)^{n+1}$ and $-(-1)^n$ are interchangeable. The recurrence itself carries no new content beyond numDerangements_succ.",
+    "significance": "standard",
+    "relatedConcepts": ["numDerangements_succ", "pow_succ", "ring"],
+    "prerequisites": ["Mathlib numDerangements_succ"]
+  },
+  {
+    "id": "ann-dcoq0302-error",
+    "proofId": "derangements-convergence-oq-03-oq-02",
+    "range": { "startLine": 52, "endLine": 62 },
+    "type": "theorem",
+    "title": "Exact one-term remainder is ±1",
+    "content": "numDerangements_sub_eq rearranges the recurrence to D(n+1) - (n+1)·D(n) = (-1)^(n+1), and numDerangements_abs_sub takes absolute values to conclude |D(n+1) - (n+1)·D(n)| = 1. This says the 'multiply by n+1' approximation to D has a remainder that is always exactly one in magnitude — the discrete analogue of the |D(n) - n!/e| < 1/2 rounding bound from the parent entry.",
+    "mathContext": "$|(-1)^{n+1}| = 1$ via abs_pow / abs_neg / abs_one / one_pow. The remainder is exact, not asymptotic.",
+    "significance": "supporting",
+    "relatedConcepts": ["abs_pow", "abs_neg", "one_pow"],
+    "prerequisites": ["numDerangements_succ_alt"]
+  },
+  {
+    "id": "ann-dcoq0302-modular",
+    "proofId": "derangements-convergence-oq-03-oq-02",
+    "range": { "startLine": 64, "endLine": 82 },
+    "type": "theorem",
+    "title": "Modular consequence: D(m) ≡ (-1)^m (mod m)",
+    "content": "numDerangements_modEq proves D(n+1) ≡ (-1)^(n+1) [ZMOD (n+1)]. The proof rewrites with the recurrence, observes that (n+1)·D(n) is divisible by n+1 (Dvd.intro), turns that into the congruence (n+1)·D(n) ≡ 0 [ZMOD (n+1)] (Int.modEq_zero_iff_dvd), adds (-1)^(n+1) to both sides (Int.ModEq.add_right), and simplifies 0 + (-1)^(n+1). Equivalently, for every m ≥ 1, D(m) ≡ (-1)^m (mod m): the derangement count is congruent to ±1 modulo its order. A sanity check D(4) = 9 (= 4·2 + 1) closes the file. This congruence is the genuinely new content of the entry — it is not in Mathlib.",
+    "mathContext": "Modulo $n+1$, the multiple $(n+1)D(n) \\equiv 0$, so the recurrence collapses to $D(n+1) \\equiv (-1)^{n+1} \\pmod{n+1}$. For even $m$, $D(m) \\equiv 1$; for odd $m$, $D(m) \\equiv -1 \\equiv m-1 \\pmod m$.",
+    "significance": "key",
+    "relatedConcepts": ["Int.ModEq", "Int.modEq_zero_iff_dvd", "Int.ModEq.add_right", "Dvd.intro"],
+    "prerequisites": ["numDerangements_succ_alt", "Int.ModEq API"]
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-03-oq-02/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-02/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "derangements-convergence-oq-03-oq-02",
+  "title": "Alternating one-term derangement recurrence and its modular shadow",
+  "slug": "derangements-convergence-oq-03-oq-02",
+  "description": "States the derangement recurrence in the sign convention D(n+1) = (n+1)·D(n) + (-1)^(n+1) (a one-line restatement of Mathlib's numDerangements_succ), and records two consequences Mathlib does not carry: the exact one-term error |D(n+1) - (n+1)·D(n)| = 1, and the congruence D(m) ≡ (-1)^m (mod m) obtained by reducing the recurrence modulo its order.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ03OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "recurrence",
+      "modular-arithmetic",
+      "integer-arithmetic",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. Fully machine-checked with only Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). The core recurrence is derived from Mathlib's numDerangements_succ; the modular and error-bound consequences follow by elementary integer arithmetic.",
+    "dateAdded": "2026-06-20",
+    "lineCount": 82,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "numDerangements_succ_alt (PROVED): D(n+1) = (n+1)·D(n) + (-1)^(n+1) — the requested +(-1)^(n+1) sign convention, equivalent to Mathlib's numDerangements_succ via (-1)^(n+1) = -(-1)^n",
+      "numDerangements_sub_eq + numDerangements_abs_sub (PROVED): the exact one-term remainder D(n+1) - (n+1)·D(n) = (-1)^(n+1), hence |D(n+1) - (n+1)·D(n)| = 1 always",
+      "numDerangements_modEq (PROVED): D(n+1) ≡ (-1)^(n+1) (mod n+1) — reducing the recurrence modulo n+1 kills the (n+1)·D(n) term, giving D(m) ≡ (-1)^m (mod m) for every m ≥ 1"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "numDerangements_succ",
+        "description": "D(n+1) = (n+1)·D(n) - (-1)^n, the one-term derangement recurrence in Mathlib's sign convention",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "Int.ModEq.add_right",
+        "description": "Adding a fixed integer to both sides preserves a congruence — used to add (-1)^(n+1) after reducing the multiple of (n+1) to zero",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Int.modEq_zero_iff_dvd",
+        "description": "a ≡ 0 [ZMOD n] ↔ n ∣ a — turns divisibility of the (n+1)·D(n) term into a congruence",
+        "module": "Mathlib.Data.Int.GCD"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The derangement numbers D(n) (permutations with no fixed point) satisfy two classical recurrences: the two-term D(n) = (n-1)(D(n-1) + D(n-2)) and the one-term D(n) = n·D(n-1) + (-1)^n. The one-term form, due to Euler, is the more arithmetically transparent of the two: it says that each derangement count is n times the previous one, corrected by a single alternating ±1. Mathlib formalizes this one-term recurrence as numDerangements_succ in the convention D(n+1) = (n+1)·D(n) - (-1)^n. This entry presents the equivalent +(-1)^(n+1) convention requested by the open question and then reads off two elementary but unrecorded consequences: the remainder is always exactly ±1, and modulo n+1 the count collapses to D(m) ≡ (-1)^m (mod m).",
+    "problemStatement": "**OQ-03-02 of derangements-convergence**\n\nState the one-term derangement recurrence in the form\n\n  D(n+1) = (n+1)·D(n) + (-1)^(n+1)\n\nand record the consequences that follow immediately from it.",
+    "text": "(numDerangements (n+1) : ℤ) = (n+1)·numDerangements n + (-1)^(n+1), together with the exact ±1 remainder and the congruence D(m) ≡ (-1)^m (mod m).",
+    "proofStrategy": "**Core recurrence**: rewrite Mathlib's `numDerangements_succ` and use `pow_succ` to convert `-(-1)^n` into `+(-1)^(n+1)`; `ring` closes it.\n\n**Error bound**: subtract `(n+1)·D(n)` from both sides (`ring`), then take absolute values; `abs_pow`/`abs_neg`/`abs_one`/`one_pow` give `|(-1)^(n+1)| = 1`.\n\n**Modular consequence**: rewrite with the recurrence; the term `(n+1)·D(n)` is divisible by `n+1`, so it is `≡ 0 [ZMOD (n+1)]` by `Int.modEq_zero_iff_dvd`; adding `(-1)^(n+1)` to both sides via `Int.ModEq.add_right` and simplifying `0 + (-1)^(n+1)` yields the claim.",
+    "keyInsights": [
+      "The two sign conventions are the *same* recurrence: (-1)^(n+1) = -(-1)^n, so D(n+1) = (n+1)·D(n) + (-1)^(n+1) is `pow_succ` + `ring` away from Mathlib's numDerangements_succ. The mathematical content of the restatement is zero; its value is matching the open question's stated form.",
+      "The genuinely new content is the modular congruence D(m) ≡ (-1)^m (mod m). Because the one-term recurrence has a single correction term of size 1, reducing mod (n+1) annihilates the (n+1)·D(n) term and leaves only the ±1. This is a clean arithmetic fact about derangement numbers that does not appear in Mathlib.",
+      "The error bound |D(n+1) - (n+1)·D(n)| = 1 is exact, not asymptotic: the one-term recurrence is the tightest possible 'multiply by n+1' approximation, with a remainder that never exceeds 1 in absolute value. This is the discrete analogue of the |D(n) - n!/e| < 1/2 rounding bound proved in the sibling entry derangements-convergence-oq-03.",
+      "Working over ℤ (rather than ℕ) is essential: the corrections (-1)^(n+1) are signed, and subtraction D(n+1) - (n+1)·D(n) underflows in ℕ. The cast to ℤ is what makes the alternating structure visible."
+    ],
+    "prerequisites": [
+      "numDerangements_succ from Mathlib (the one-term derangement recurrence)",
+      "Int.ModEq API: Int.ModEq.add_right and Int.modEq_zero_iff_dvd",
+      "Basic integer arithmetic and the parity of (-1)^k"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring explaining the +(-1)^(n+1) convention and the two recorded consequences (exact ±1 remainder, congruence mod n+1). Imports Mathlib. Namespace DerangementsConvergenceOQ03OQ02.",
+      "mathContext": "The one-term derangement recurrence $D(n+1) = (n+1)D(n) + (-1)^{n+1}$ is the sign-flipped form of Mathlib's $D(n+1) = (n+1)D(n) - (-1)^n$, since $(-1)^{n+1} = -(-1)^n$."
+    },
+    {
+      "id": "sec-recurrence",
+      "title": "Core Recurrence in the Requested Convention",
+      "startLine": 41,
+      "endLine": 50,
+      "summary": "numDerangements_succ_alt: D(n+1) = (n+1)·D(n) + (-1)^(n+1). Proof rewrites numDerangements_succ and pow_succ, then closes with ring.",
+      "mathContext": "$(-1)^{n+1} = (-1)^n \\cdot (-1) = -(-1)^n$, so adding $(-1)^{n+1}$ equals subtracting $(-1)^n$; the two conventions coincide."
+    },
+    {
+      "id": "sec-error",
+      "title": "Exact One-Term Remainder",
+      "startLine": 52,
+      "endLine": 62,
+      "summary": "numDerangements_sub_eq: D(n+1) - (n+1)·D(n) = (-1)^(n+1), and numDerangements_abs_sub: |D(n+1) - (n+1)·D(n)| = 1. Proved by ring and the abs lemmas for ±1 powers.",
+      "mathContext": "The remainder of the 'multiply by $n+1$' approximation to $D$ is always exactly $\\pm 1$: $|(-1)^{n+1}| = 1$."
+    },
+    {
+      "id": "sec-modular",
+      "title": "Modular Consequence: D(m) ≡ (-1)^m (mod m)",
+      "startLine": 64,
+      "endLine": 82,
+      "summary": "numDerangements_modEq: D(n+1) ≡ (-1)^(n+1) [ZMOD (n+1)]. Reduces the recurrence mod (n+1): the term (n+1)·D(n) is divisible by n+1 hence ≡ 0, and adding (-1)^(n+1) via Int.ModEq.add_right gives the result. Closes with a sanity check D(4) = 9 = 4·2 + 1.",
+      "mathContext": "Modulo $n+1$, the multiple $(n+1)D(n)$ vanishes, leaving $D(n+1) \\equiv (-1)^{n+1} \\pmod{n+1}$; equivalently $D(m) \\equiv (-1)^m \\pmod m$ for every $m \\geq 1$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence-oq-03",
+      "relationship": "sibling",
+      "description": "Parent entry: proves the rounding characterization D(n) = round(n!/e) via the |D(n) - n!/e| < 1/2 bound. This entry gives the discrete analogue — the exact one-term remainder ±1 — and the modular shadow of the same recurrence."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "foundational",
+      "description": "Root entry: basic derangement definitions and the one-term recurrence numDerangements_succ that this file restates and exploits."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "related",
+      "description": "Establishes the convergence rate |D(n)/n! - e⁻¹| ≤ 1/(n+1)!; this entry works with the integer recurrence directly rather than the analytic limit."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified: the one-term derangement recurrence in the +(-1)^(n+1) convention, with two consequences absent from Mathlib — the exact ±1 remainder |D(n+1) - (n+1)·D(n)| = 1 and the congruence D(m) ≡ (-1)^m (mod m). Zero sorries, zero axioms beyond the foundational ones.",
+    "implications": "The modular congruence D(m) ≡ (-1)^m (mod m) gives a one-line divisibility test and a parity-of-residue fact for derangement numbers: D(m) ≡ +1 (mod m) for even m, ≡ -1 (mod m) for odd m. The ±1 remainder bound is the integer counterpart of the analytic 1/(n+1) rate bound from the parent entry.",
+    "openQuestions": [
+      "Iterate the recurrence to express D(n) ≡ Σ (-1)^k · (falling factorials) and extract congruences of D(n) modulo composite moduli, e.g. D(p) ≡ -1 (mod p) for prime p — a Wilson-flavored statement.",
+      "Combine with the two-term recurrence D(n) = (n-1)(D(n-1)+D(n-2)) to characterise the 2-adic valuation of D(n)."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "numDerangements_succ_alt",
+      "type": "core",
+      "description": "D(n+1) = (n+1)·D(n) + (-1)^(n+1), the one-term recurrence in the requested sign convention",
+      "leanType": "(n : ℕ) → (numDerangements (n + 1) : ℤ) = (n + 1) * (numDerangements n : ℤ) + (-1) ^ (n + 1)"
+    },
+    {
+      "name": "numDerangements_modEq",
+      "type": "core",
+      "description": "D(n+1) ≡ (-1)^(n+1) (mod n+1); equivalently D(m) ≡ (-1)^m (mod m) for m ≥ 1",
+      "leanType": "(n : ℕ) → (numDerangements (n + 1) : ℤ) ≡ (-1) ^ (n + 1) [ZMOD ((n : ℤ) + 1)]"
+    },
+    {
+      "name": "numDerangements_abs_sub",
+      "type": "supporting",
+      "description": "|D(n+1) - (n+1)·D(n)| = 1, the exact one-term remainder",
+      "leanType": "(n : ℕ) → |(numDerangements (n + 1) : ℤ) - (n + 1) * (numDerangements n : ℤ)| = 1"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "DerangementsConvergenceOQ03OQ02",
+    "lineCount": 82,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "substantiveTheoremCount": 3,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsConvergenceOQ03OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Leonhard Euler",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie de Berlin 7, pp. 255–270",
+      "note": "Source of the one-term derangement recurrence D(n) = n·D(n-1) + (-1)^n, the recurrence restated and exploited in this entry."
+    },
+    {
+      "authors": "Riordan, John",
+      "title": "An Introduction to Combinatorial Analysis",
+      "year": "1958",
+      "venue": "Wiley, Chapter 3 §3",
+      "note": "Classic treatment of derangements including both the one-term and two-term recurrences and the rounding identity D(n) = round(n!/e)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the gallery gap **derangements-convergence-oq-03-oq-02** (Tier B, seeker-selected).

States the one-term derangement recurrence in the requested sign convention
```
D(n+1) = (n+1)·D(n) + (-1)^(n+1)
```
a one-line restatement of Mathlib's `numDerangements_succ` (which uses `-(-1)^n`), and records **two consequences Mathlib does not carry**:

- **Exact one-term remainder:** `|D(n+1) - (n+1)·D(n)| = 1` — the discrete analogue of the parent entry's `|D(n) - n!/e| < 1/2` rounding bound.
- **Modular shadow:** `D(m) ≡ (-1)^m (mod m)` for every `m ≥ 1`, obtained by reducing the recurrence modulo its order (the `(n+1)·D(n)` term vanishes). This is the genuinely new content — a clean arithmetic fact about derangement numbers not in Mathlib.

## Honesty note

The core recurrence `numDerangements_succ_alt` is a pure restatement (mathematical content = the Mathlib lemma). The value of this entry is the modular congruence and the exact ±1 remainder bound.

## Verification

- **Build:** `./proofs/scripts/docker-build.sh Proofs.DerangementsConvergenceOQ03OQ02` — ✅ green (7743 jobs)
- **Theorems:** 4 (+1 `decide` sanity check D(4)=9), **0 sorries, 0 `axiom` declarations**
- Foundational axioms only (`propext`/`Classical.choice`/`Quot.sound`); no `native_decide`/`ofReduceBool`
- Gallery: `meta.json` + `annotations.json` added; `annotations:validate` clean for this entry; entry registers as `status=verified` in generated listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)