### PR TITLE
research(newton-power-sum-identities-oq-01-oq-01): Newton identities degrees 4 & 5 closed forms [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -60,6 +60,7 @@ import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01OQ03
 import Proofs.AmgmInequalityOQ02OQ01OQ03
 import Proofs.AmgmInequalityOQ02OQ01OQ03Finset
 import Proofs.AmgmInequalityOQ02OQ01OQ03OQ01
+import Proofs.AmgmInequalityOQ02OQ01OQ03OQ01OQ01
 import Proofs.AmgmInequalityOQ02OQ01OQ04
 import Proofs.AmgmInequalityOQ02OQ01OQ05
 import Proofs.AmgmInequalityOQ02OQ02

--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01OQ01.lean
@@ -1,0 +1,189 @@
+/-
+  Newton–Girard k=5 Closed Form:
+      p₅ = e₁⁵ − 5·e₁³·e₂ + 5·e₁·e₂² + 5·e₁²·e₃ − 5·e₂·e₃ − 5·e₁·e₄ + 5·e₅.
+
+  Open Question (amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01), the next rung after the
+  k=4 closed form `amgm-inequality-oq-02-oq-01-oq-03-oq-01`.
+
+  Establish the fully reduced k=5 Newton–Girard identity expressing the fifth power sum
+  p₅ purely in terms of the elementary symmetric polynomials e₁, e₂, e₃, e₄, e₅:
+      p₅ = e₁⁵ − 5·e₁³·e₂ + 5·e₁·e₂² + 5·e₁²·e₃ − 5·e₂·e₃ − 5·e₁·e₄ + 5·e₅.
+  For concrete values (a Finset) this is the symmetric-function form of
+      a⁵+b⁵+c⁵+d⁵+e⁵
+        = e₁⁵ − 5·e₁³·e₂ + 5·e₁·e₂² + 5·e₁²·e₃ − 5·e₂·e₃ − 5·e₁·e₄ + 5·e₅.
+
+  Lineage:
+  • Parent     amgm-inequality-oq-02-oq-01             : k=2 identity p₂ = e₁² − 2e₂.
+  • Recurrence amgm-inequality-oq-02-oq-01-oq-02-oq-01 : p₃ = e₁p₂ − e₂p₁ + 3e₃ and the
+                                                         k=1,2 corollaries.
+  • k=3 closed amgm-inequality-oq-02-oq-01-oq-03       : `psum_three_closed`.
+  • k=4 closed amgm-inequality-oq-02-oq-01-oq-03-oq-01 : `psum_four_closed` + the concrete
+                                                         general-Finset form `newton_girard_four_finset`
+                                                         and the e₄/p₄ aeval bridges.
+
+  This file adds the next rung.  Two complementary forms, each 0-sorry / 0-axiom:
+
+  (1) UNIVERSAL (MvPolynomial).  `psum_five_recurrence` extracts the k=5 Newton
+      recurrence  p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅  directly from
+      `MvPolynomial.psum_eq_mul_esymm_sub_sum` (antidiagonal filter {(1,4),(2,3),(3,2),(4,1)},
+      lead term (−1)⁶·5·e₅ = +5·e₅).  Substituting the proven closed forms for p₄, p₃, p₂, p₁
+      and ring-normalising yields `psum_five_closed`.
+
+  (2) CONCRETE general-Finset, over an ARBITRARY CommRing (characteristic 2 and 5 included).
+      Reusing the already-built, n-general `aeval` bridge from the k=3 Finset file
+      (`aeval_psum_subtype`, `aeval_esymm_subtype`) and the e₁..e₄ bridges from the
+      parent files, the universal closed form transports onto the subtype {x // x ∈ s} to
+      give `newton_girard_five_finset` with the e₅/p₅ bridge lemmas instantiated at n=5.
+      No characteristic hypothesis is required — the same transport that bypassed the
+      char-2 obstruction at k=3 works verbatim here.
+
+  Every coefficient is independently checked over ℚ for n ≤ 6 variables (residual 0 ⟹
+  universal).
+
+  Status: PROVED — 0 sorries, 0 axioms.  Holds over any `CommRing`.
+  Tags: algebra, symmetric-functions, newton-girard, power-sums, finset, characteristic-two
+-/
+
+import Mathlib
+import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01
+import Proofs.AmgmInequalityOQ02OQ01OQ03
+import Proofs.AmgmInequalityOQ02OQ01OQ03Finset
+import Proofs.AmgmInequalityOQ02OQ01OQ03OQ01
+
+namespace AMGMInequalityOQ02OQ01OQ03OQ01OQ01
+
+open MvPolynomial Finset BigOperators Set
+
+-- ============================================================
+-- Universal closed form (MvPolynomial setting)
+-- ============================================================
+
+section Universal
+
+variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]
+
+/-- **Newton–Girard k=5, recurrence form** (universal / MvPolynomial setting):
+      p₅ = e₁·p₄ − e₂·p₃ + e₃·p₂ − e₄·p₁ + 5·e₅.
+
+    Proof: apply `psum_eq_mul_esymm_sub_sum` at n = 5.  The antidiagonal
+    {a : a.1 + a.2 = 5, 0 < a.1 < 5} = {(1,4), (2,3), (3,2), (4,1)}, and the lead term is
+    (−1)⁶·5·e₅ = 5·e₅, so
+      p₅ = 5e₅ − ((−1)¹e₁p₄ + (−1)²e₂p₃ + (−1)³e₃p₂ + (−1)⁴e₄p₁)
+         = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅. -/
+theorem psum_five_recurrence :
+    psum σ R 5 =
+      esymm σ R 1 * psum σ R 4 - esymm σ R 2 * psum σ R 3
+        + esymm σ R 3 * psum σ R 2 - esymm σ R 4 * psum σ R 1 + 5 * esymm σ R 5 := by
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 5 (by norm_num)]
+  have hfilt : (Finset.antidiagonal 5).filter (fun a : ℕ × ℕ => a.1 ∈ Set.Ioo 0 5) =
+               {(1, 4), (2, 3), (3, 2), (4, 1)} := by
+    ext ⟨a, b⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo,
+               Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  simp only [hfilt,
+    Finset.sum_insert (by decide : (1, 4) ∉ ({(2, 3), (3, 2), (4, 1)} : Finset (ℕ × ℕ))),
+    Finset.sum_insert (by decide : (2, 3) ∉ ({(3, 2), (4, 1)} : Finset (ℕ × ℕ))),
+    Finset.sum_insert (by decide : (3, 2) ∉ ({(4, 1)} : Finset (ℕ × ℕ))),
+    Finset.sum_singleton]
+  ring
+
+/-- **Newton–Girard k=5, closed form** (universal / MvPolynomial setting):
+      p₅ = e₁⁵ − 5·e₁³·e₂ + 5·e₁·e₂² + 5·e₁²·e₃ − 5·e₂·e₃ − 5·e₁·e₄ + 5·e₅.
+    Substitute the proven closed forms `psum_four_closed` (p₄), `psum_three_closed` (p₃),
+    `psum_two_eq` (p₂ = e₁² − 2e₂) and `psum_one_eq_esymm_one` (p₁ = e₁) into the
+    recurrence `psum_five_recurrence`, then ring-normalise. -/
+theorem psum_five_closed :
+    psum σ R 5 =
+      esymm σ R 1 ^ 5 - 5 * (esymm σ R 1 ^ 3 * esymm σ R 2)
+        + 5 * (esymm σ R 1 * esymm σ R 2 ^ 2) + 5 * (esymm σ R 1 ^ 2 * esymm σ R 3)
+        - 5 * (esymm σ R 2 * esymm σ R 3) - 5 * (esymm σ R 1 * esymm σ R 4)
+        + 5 * esymm σ R 5 := by
+  have h5 := psum_five_recurrence σ R
+  have h4 := AMGMInequalityOQ02OQ01OQ03OQ01.psum_four_closed σ R
+  have h3 := AMGMInequalityOQ02OQ01OQ03.psum_three_closed σ R
+  have h2 := AMGMInequalityOQ02OQ01OQ02OQ01.psum_two_eq σ R
+  have h1 := AMGMInequalityOQ02OQ01OQ02OQ01.psum_one_eq_esymm_one σ R
+  rw [h5, h4, h3, h2, h1]; ring
+
+end Universal
+
+-- ============================================================
+-- Concrete general-Finset form, over ANY CommRing (char 2, 5 included)
+-- ============================================================
+
+section Concrete
+
+open AMGMInequalityOQ02OQ01OQ03Finset
+open AMGMInequalityOQ02OQ01OQ03OQ01
+
+variable {ι R : Type*} [CommRing R] [DecidableEq ι]
+
+/-- e₅ = Σ over 5-subsets of the product (concrete `powersetCard` form). -/
+def e5 (s : Finset ι) (f : ι → R) : R := ∑ t ∈ s.powersetCard 5, ∏ i ∈ t, f i
+/-- p₅ = Σ fᵢ⁵. -/
+def p5 (s : Finset ι) (f : ι → R) : R := ∑ i ∈ s, f i ^ 5
+
+omit [DecidableEq ι] in
+/-- Bridge at degree 5:  `aeval (esymm … 5) = e₅`  (definitional, from the n-general
+    `aeval_esymm_subtype`). -/
+theorem e5_bridge (s : Finset ι) (f : ι → R) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.esymm {x // x ∈ s} R 5) = e5 s f :=
+  aeval_esymm_subtype s f 5
+
+omit [DecidableEq ι] in
+/-- Bridge for the fifth power sum:  `aeval (psum … 5) = p₅`  (definitional, from the
+    n-general `aeval_psum_subtype`). -/
+theorem p5_bridge (s : Finset ι) (f : ι → R) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.psum {x // x ∈ s} R 5) = p5 s f :=
+  aeval_psum_subtype s f 5
+
+omit [DecidableEq ι] in
+/-- **Concrete general-Finset Newton–Girard k=5** over an arbitrary `CommRing`:
+      p₅ = e₁⁵ − 5·e₁³·e₂ + 5·e₁·e₂² + 5·e₁²·e₃ − 5·e₂·e₃ − 5·e₁·e₄ + 5·e₅.
+    Transport of the universal `psum_five_closed` across the (char-2/5-safe) aeval bridge
+    onto the subtype {x // x ∈ s}.  No characteristic hypothesis is required. -/
+theorem newton_girard_five_finset (s : Finset ι) (f : ι → R) :
+    p5 s f =
+      e1 s f ^ 5 - 5 * (e1 s f ^ 3 * e2 s f) + 5 * (e1 s f * e2 s f ^ 2)
+        + 5 * (e1 s f ^ 2 * e3 s f) - 5 * (e2 s f * e3 s f) - 5 * (e1 s f * e4 s f)
+        + 5 * e5 s f := by
+  have H := congrArg (aeval (fun i : {x // x ∈ s} => f i.1))
+    (psum_five_closed {x // x ∈ s} R)
+  simpa only [map_add, map_sub, map_mul, map_pow, map_ofNat,
+    p5_bridge, e1_bridge, e2_bridge, e3_bridge, e4_bridge, e5_bridge] using H
+
+end Concrete
+
+-- ============================================================
+-- Concrete 5-variable instance (smallest nondegenerate case)
+-- ============================================================
+
+section Explicit
+
+variable {R : Type*} [CommRing R]
+
+/-- **Concrete 5-variable instance** — sum of fifth powers:
+      a⁵ + b⁵ + c⁵ + d⁵ + e⁵
+        = e₁⁵ − 5·e₁³·e₂ + 5·e₁·e₂² + 5·e₁²·e₃ − 5·e₂·e₃ − 5·e₁·e₄ + 5·e₅,
+    where e₁ = a+b+c+d+e, e₂ = Σ pairs, e₃ = Σ triples, e₄ = Σ quadruples, e₅ = abcde.
+    This is the n = 5 Finset case of `psum_five_closed`. -/
+theorem fifth_power_sum_five (a b c d e : R) :
+    a ^ 5 + b ^ 5 + c ^ 5 + d ^ 5 + e ^ 5 =
+      (a + b + c + d + e) ^ 5
+        - 5 * ((a + b + c + d + e) ^ 3 *
+            (a*b + a*c + a*d + a*e + b*c + b*d + b*e + c*d + c*e + d*e))
+        + 5 * ((a + b + c + d + e) *
+            (a*b + a*c + a*d + a*e + b*c + b*d + b*e + c*d + c*e + d*e) ^ 2)
+        + 5 * ((a + b + c + d + e) ^ 2 *
+            (a*b*c + a*b*d + a*b*e + a*c*d + a*c*e + a*d*e + b*c*d + b*c*e + b*d*e + c*d*e))
+        - 5 * ((a*b + a*c + a*d + a*e + b*c + b*d + b*e + c*d + c*e + d*e) *
+            (a*b*c + a*b*d + a*b*e + a*c*d + a*c*e + a*d*e + b*c*d + b*c*e + b*d*e + c*d*e))
+        - 5 * ((a + b + c + d + e) *
+            (a*b*c*d + a*b*c*e + a*b*d*e + a*c*d*e + b*c*d*e))
+        + 5 * (a*b*c*d*e) := by
+  ring
+
+end Explicit
+
+end AMGMInequalityOQ02OQ01OQ03OQ01OQ01

--- a/proofs/Proofs/NewtonPowerSumIdentitiesOQ01OQ01.lean
+++ b/proofs/Proofs/NewtonPowerSumIdentitiesOQ01OQ01.lean
@@ -1,0 +1,124 @@
+import Mathlib
+
+/-
+# Newton's identities in degrees 4 and 5: explicit power-sum closed forms
+
+For the elementary symmetric polynomials `eₖ = esymm σ R k` and the power sums
+`pₖ = psum σ R k = ∑ᵢ Xᵢᵏ` in finitely many variables over a commutative ring,
+*Newton's identities* express each power sum as a polynomial in the elementary
+symmetric polynomials.  Mathlib proves the general recurrence
+
+  `pₖ = (-1)^{k+1}·k·eₖ - ∑_{0 < i < k} (-1)^i·eᵢ·p_{k-i}`
+
+(`MvPolynomial.psum_eq_mul_esymm_sub_sum`), but does **not** record the explicit
+closed forms in low degree.  The parent entry unrolled the recurrence for
+`k = 1, 2, 3`:
+
+* `p₁ = e₁`
+* `p₂ = e₁² - 2 e₂`
+* `p₃ = e₁³ - 3 e₁ e₂ + 3 e₃`
+
+This child continues the *identical* documented method two more rungs, recording
+the two next classical identities
+
+* `p₄ = e₁⁴ - 4 e₁² e₂ + 2 e₂² + 4 e₁ e₃ - 4 e₄`
+* `p₅ = e₁⁵ - 5 e₁³ e₂ + 5 e₁ e₂² + 5 e₁² e₃ - 5 e₂ e₃ - 5 e₁ e₄ + 5 e₅`
+
+These hold as identities in `MvPolynomial σ R` for *any* finite index type `σ`
+and any commutative ring `R`; when `card σ < k` the higher `eₖ` simply vanish,
+so the formulas remain valid (e.g. with a single variable all of `e₂,…,e₅ = 0`,
+giving `p₄ = e₁⁴` and `p₅ = e₁⁵`).
+
+For each degree we feed the Newton recurrence the explicit (finite) index set of
+its inner sum — computed once and for all by `omega` — expand the sum over that
+literal `Finset`, substitute the previously established lower identities, and
+close with `push_cast; ring`.  The entry is self-contained: the degree-1,2,3
+identities are restated and reproved here so the file stands alone.
+-/
+
+open Finset
+
+namespace NewtonPowerSumOQ01
+
+variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]
+
+/-- **Newton's identity, degree 1:** `p₁ = e₁`. -/
+theorem psum_one_eq : MvPolynomial.psum σ R 1 = MvPolynomial.esymm σ R 1 := by
+  rw [MvPolynomial.psum_one, MvPolynomial.esymm_one]
+
+/-- **Newton's identity, degree 2:** `p₂ = e₁² - 2 e₂`. -/
+theorem psum_two_eq :
+    MvPolynomial.psum σ R 2 = MvPolynomial.esymm σ R 1 ^ 2 - 2 * MvPolynomial.esymm σ R 2 := by
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 2 (by norm_num)]
+  -- inner sum ranges over `{a ∈ antidiagonal 2 | 0 < a.1 < 2}`, i.e. just `(1, 1)`.
+  have hset : {a ∈ Finset.antidiagonal 2 | a.1 ∈ Set.Ioo 0 2} = {(1, 1)} := by
+    ext ⟨i, j⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo, Finset.mem_singleton,
+      Prod.mk.injEq]
+    omega
+  rw [hset, Finset.sum_singleton, psum_one_eq]
+  push_cast
+  ring
+
+/-- **Newton's identity, degree 3:** `p₃ = e₁³ - 3 e₁ e₂ + 3 e₃`. -/
+theorem psum_three_eq :
+    MvPolynomial.psum σ R 3 =
+      MvPolynomial.esymm σ R 1 ^ 3 - 3 * MvPolynomial.esymm σ R 1 * MvPolynomial.esymm σ R 2
+        + 3 * MvPolynomial.esymm σ R 3 := by
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 3 (by norm_num)]
+  -- inner sum ranges over `{(1, 2), (2, 1)}`.
+  have hset : {a ∈ Finset.antidiagonal 3 | a.1 ∈ Set.Ioo 0 3} = {(1, 2), (2, 1)} := by
+    ext ⟨i, j⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo, Finset.mem_insert,
+      Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  rw [hset, Finset.sum_pair (by decide), psum_two_eq, psum_one_eq]
+  push_cast
+  ring
+
+/-- **Newton's identity, degree 4:** `p₄ = e₁⁴ - 4 e₁² e₂ + 2 e₂² + 4 e₁ e₃ - 4 e₄`. -/
+theorem psum_four_eq :
+    MvPolynomial.psum σ R 4 =
+      MvPolynomial.esymm σ R 1 ^ 4
+        - 4 * MvPolynomial.esymm σ R 1 ^ 2 * MvPolynomial.esymm σ R 2
+        + 2 * MvPolynomial.esymm σ R 2 ^ 2
+        + 4 * MvPolynomial.esymm σ R 1 * MvPolynomial.esymm σ R 3
+        - 4 * MvPolynomial.esymm σ R 4 := by
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 4 (by norm_num)]
+  -- inner sum ranges over `{(1, 3), (2, 2), (3, 1)}`.
+  have hset : {a ∈ Finset.antidiagonal 4 | a.1 ∈ Set.Ioo 0 4} = {(1, 3), (2, 2), (3, 1)} := by
+    ext ⟨i, j⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo, Finset.mem_insert,
+      Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  rw [hset, Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_singleton,
+    psum_three_eq, psum_two_eq, psum_one_eq]
+  push_cast
+  ring
+
+/-- **Newton's identity, degree 5:**
+`p₅ = e₁⁵ - 5 e₁³ e₂ + 5 e₁ e₂² + 5 e₁² e₃ - 5 e₂ e₃ - 5 e₁ e₄ + 5 e₅`. -/
+theorem psum_five_eq :
+    MvPolynomial.psum σ R 5 =
+      MvPolynomial.esymm σ R 1 ^ 5
+        - 5 * MvPolynomial.esymm σ R 1 ^ 3 * MvPolynomial.esymm σ R 2
+        + 5 * MvPolynomial.esymm σ R 1 * MvPolynomial.esymm σ R 2 ^ 2
+        + 5 * MvPolynomial.esymm σ R 1 ^ 2 * MvPolynomial.esymm σ R 3
+        - 5 * MvPolynomial.esymm σ R 2 * MvPolynomial.esymm σ R 3
+        - 5 * MvPolynomial.esymm σ R 1 * MvPolynomial.esymm σ R 4
+        + 5 * MvPolynomial.esymm σ R 5 := by
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 5 (by norm_num)]
+  -- inner sum ranges over `{(1, 4), (2, 3), (3, 2), (4, 1)}`.
+  have hset :
+      {a ∈ Finset.antidiagonal 5 | a.1 ∈ Set.Ioo 0 5} = {(1, 4), (2, 3), (3, 2), (4, 1)} := by
+    ext ⟨i, j⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo, Finset.mem_insert,
+      Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  rw [hset, Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+    Finset.sum_insert (by decide), Finset.sum_singleton,
+    psum_four_eq, psum_three_eq, psum_two_eq, psum_one_eq]
+  push_cast
+  ring
+
+end NewtonPowerSumOQ01

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01",
+  "title": "Newton-Girard k=5 Closed Form over Any CommRing (incl. characteristic 5)",
+  "slug": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01",
+  "description": "Establishes the fully reduced fifth Newton-Girard identity p₅ = e₁⁵ − 5·e₁³·e₂ + 5·e₁·e₂² + 5·e₁²·e₃ − 5·e₂·e₃ − 5·e₁·e₄ + 5·e₅ in two complementary forms: (1) the universal MvPolynomial statement, derived by extracting the k=5 Newton recurrence p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅ from Mathlib's psum_eq_mul_esymm_sub_sum and substituting the proven closed forms p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄, p₃ = e₁³ − 3e₁e₂ + 3e₃, p₂ = e₁² − 2e₂, p₁ = e₁; and (2) a concrete general-Finset form over an arbitrary CommRing obtained by reusing the n-general aeval bridge built for the k=3 entry — transporting the universal identity onto the subtype {x // x ∈ s} with the e₅/p₅ bridge lemmas instantiated at degree 5. The concrete form holds over any commutative ring including characteristic 5, where the leading +5·e₅ term vanishes. Specializes to the sum-of-fifth-powers identity a⁵+b⁵+c⁵+d⁵+e⁵ = e₁⁵ − 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ − 5e₂e₃ − 5e₁e₄ + 5e₅.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ03OQ01OQ01.lean",
+    "additionalFiles": [],
+    "tags": [
+      "algebra",
+      "symmetric-functions",
+      "newton-girard",
+      "power-sums",
+      "elementary-symmetric-polynomials",
+      "finset",
+      "characteristic-two",
+      "mv-polynomial"
+    ],
+    "badge": "verified",
+    "mathlibDependencies": [
+      {
+        "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+        "description": "The general Newton-Girard recurrence pₙ = (−1)^(n+1)·n·eₙ − Σ_{0<a.1<n} (−1)^a.1 e_{a.1} p_{a.2}; instantiated at n=5 to extract p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅.",
+        "module": "Mathlib.RingTheory.MvPolynomial.NewtonIdentities"
+      },
+      {
+        "theorem": "MvPolynomial.aeval_esymm_eq_multiset_esymm",
+        "description": "aeval of the universal elementary symmetric polynomial equals the multiset elementary symmetric sum of the evaluated variables — the engine of the inherited concrete-Finset bridge (degree 5 instance).",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      },
+      {
+        "theorem": "Finset.esymm_map_val",
+        "description": "Identifies the multiset elementary symmetric sum over s.val.map f with the powersetCard sum Σ_{t ⊆ s, |t|=n} ∏_{i ∈ t} f i.",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      }
+    ],
+    "originalContributions": [
+      "psum_five_recurrence: the k=5 Newton recurrence p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅, extracted from Mathlib's psum_eq_mul_esymm_sub_sum by computing the antidiagonal filter {(1,4),(2,3),(3,2),(4,1)} and the lead term (−1)⁶·5·e₅ = +5·e₅.",
+      "psum_five_closed: the universal MvPolynomial closed form p₅ = e₁⁵ − 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ − 5e₂e₃ − 5e₁e₄ + 5e₅, obtained by substituting the proven lower closed forms (p₄, p₃, p₂, p₁) into the recurrence and ring-normalising.",
+      "newton_girard_five_finset: the concrete general-Finset closed form over ANY CommRing (characteristic 5 included), obtained by transporting psum_five_closed across the aeval bridge — confirming again that the k=3 bridge is genuinely degree-general (e5_bridge/p5_bridge are the n=5 instances of aeval_esymm_subtype/aeval_psum_subtype).",
+      "fifth_power_sum_five: the explicit 5-variable instance a⁵+b⁵+c⁵+d⁵+e⁵ = e₁⁵ − 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ − 5e₂e₃ − 5e₁e₄ + 5e₅ over any CommRing."
+    ],
+    "dateAdded": "2026-06-20",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 189,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms reports only [propext, Classical.choice, Quot.sound] for both psum_five_closed and newton_girard_five_finset (no sorryAx, no Lean.ofReduceBool). The universal identity is a ring-level corollary of Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum together with the sibling k=1/2/3/4 closed forms; the concrete-Finset form reuses the k=3 entry's aeval bridge and holds over an arbitrary CommRing including characteristic 5.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Newton's identities (Newton-Girard identities) relate the power sums pₖ = Σ xᵢᵏ to the elementary symmetric polynomials eₖ. Girard stated them around 1629 and Newton independently around 1666 (Arithmetica Universalis, 1707). The fifth identity, p₅ = e₁⁵ − 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ − 5e₂e₃ − 5e₁e₄ + 5e₅, is the first rung involving the fifth elementary symmetric polynomial e₅ and two distinct degree-(1,1) cross terms (5e₁e₂² and 5e₂e₃) with coefficient 5. While Mathlib provides the general recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum, the fully reduced k=5 closed form purely in e₁,…,e₅ — and its concrete Finset incarnation valid in every commutative ring, characteristic 5 included — is not present in Mathlib.",
+    "problemStatement": "**Open Question (amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01)**: Establish the fully reduced k=5 Newton-Girard identity\n\np₅ = e₁⁵ − 5·e₁³·e₂ + 5·e₁·e₂² + 5·e₁²·e₃ − 5·e₂·e₃ − 5·e₁·e₄ + 5·e₅\n\nexpressing the fifth power sum purely in terms of e₁, e₂, e₃, e₄, e₅, both as the universal MvPolynomial statement and as a concrete identity over a Finset of values in an arbitrary commutative ring. This is the explicit next rung after the k=4 closed form, and a further test of whether the k=3 aeval bridge is degree-general.\n\n**Answer**: Proved in both forms. The universal form extracts the k=5 recurrence from Mathlib's general Newton identity and substitutes the lower closed forms. The concrete general-Finset form reuses the k=3 entry's aeval bridge (already stated for arbitrary degree n) at degree 5, and holds over any CommRing — characteristic 5 included.",
+    "text": "The file AmgmInequalityOQ02OQ01OQ03OQ01OQ01.lean resolves the question. The universal section proves psum_five_recurrence (p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅) by instantiating Mathlib's psum_eq_mul_esymm_sub_sum at n=5, computing the antidiagonal filter {(1,4),(2,3),(3,2),(4,1)}, and ring-normalising; psum_five_closed then substitutes the proven closed forms for p₄, p₃, p₂, p₁ and closes with ring. The concrete section reuses the k=3 Finset definitions (e₁, e₂, e₃) and aeval bridge plus the k=4 e₄ definition and bridge, adds e₅ and p₅ with their degree-5 bridge instances, and proves newton_girard_five_finset over an arbitrary CommRing by congrArg of psum_five_closed under aeval onto the subtype {x // x ∈ s}. The explicit 5-variable sum-of-fifth-powers instance is recorded as fifth_power_sum_five.",
+    "proofStrategy": "**Universal recurrence**: psum_five_recurrence rewrites with MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 5. The antidiagonal {a : a.1+a.2=5, 0<a.1<5} = {(1,4),(2,3),(3,2),(4,1)} is established by ext + omega; the four-term sum is unfolded by Finset.sum_insert (mem facts by decide) and Finset.sum_singleton, and ring evaluates the (−1)^k coefficients and the lead term (−1)⁶·5·e₅ = +5·e₅.\n\n**Universal closed form**: psum_five_closed rewrites the recurrence with psum_four_closed, psum_three_closed, psum_two_eq, psum_one_eq_esymm_one and closes with ring.\n\n**Concrete Finset form (char-5 safe)**: e5_bridge and p5_bridge are the degree-5 instances of the k=3 entry's aeval_esymm_subtype / aeval_psum_subtype, so no new bridge machinery is needed — this is once more the concrete demonstration that the k=3 bridge is degree-general. newton_girard_five_finset is the congrArg image of psum_five_closed under aeval (fun i : {x // x ∈ s} => f i.1), simplified by map_add/map_sub/map_mul/map_pow/map_ofNat and the six bridge lemmas (e1..e5, p5). Because the transport happens at the level of polynomial coefficients, the identity holds over rings of arbitrary characteristic, including characteristic 5 where the +5·e₅ term collapses.",
+    "keyInsights": [
+      "The k=5 closed form is the first rung where the fifth elementary symmetric polynomial e₅ appears, and where the reduced expression carries two genuinely distinct mixed monomials of coefficient 5 (5·e₁·e₂² and 5·e₂·e₃); it remains one recurrence step plus a ring substitution away from Mathlib's general Newton identity.",
+      "The aeval bridge built for the k=3 entry (aeval_psum_subtype / aeval_esymm_subtype) is already stated for arbitrary degree n. The k=5 concrete form therefore needs only e5_bridge := aeval_esymm_subtype s f 5 and p5_bridge := aeval_psum_subtype s f 5 — a second confirmation (after k=4) that the bridge is a reusable, degree-uniform transport.",
+      "Transporting the universal identity (which lives at the level of polynomial coefficients, before evaluation) yields the concrete Finset identity unconditionally — there is no characteristic obstruction at k=5; over a ring of characteristic 5 the identity reads p₅ = e₁⁵ + 0 + 0 + 0 − 0 − 0 + 0 in the relevant coefficients, with the +5·e₅ lead term simply vanishing, and the proof never relied on dividing by 5.",
+      "Extracting the k=5 recurrence from psum_eq_mul_esymm_sub_sum is purely mechanical once the antidiagonal filter {(1,4),(2,3),(3,2),(4,1)} and the sign of the lead term (−1)^(n+1)·n·eₙ = (−1)⁶·5·e₅ are pinned down, mirroring the k=2, k=3, k=4 derivations exactly."
+    ],
+    "prerequisites": [
+      "k=4 closed form AmgmInequalityOQ02OQ01OQ03OQ01: psum_four_closed (p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄) and the e₄ definition / e4_bridge.",
+      "k=3 closed form AmgmInequalityOQ02OQ01OQ03: psum_three_closed (p₃ = e₁³ − 3e₁e₂ + 3e₃).",
+      "k=3 Finset bridge AmgmInequalityOQ02OQ01OQ03Finset: the n-general aeval_psum_subtype / aeval_esymm_subtype and the e₁,e₂,e₃ definitions and bridge lemmas.",
+      "Recurrence sibling AmgmInequalityOQ02OQ01OQ02OQ01: psum_two_eq (p₂ = e₁² − 2e₂) and psum_one_eq_esymm_one (p₁ = e₁).",
+      "MvPolynomial.psum_eq_mul_esymm_sub_sum — the general Newton-Girard recurrence (Mathlib).",
+      "Finset.powersetCard — fixed-cardinality subsets, the concrete definition of eₖ (Mathlib)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Module Docstring: Newton-Girard k=5 Closed Form",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "States the target identity p₅ = e₁⁵ − 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ − 5e₂e₃ − 5e₁e₄ + 5e₅, its lineage from the k=2/k=3/k=4 entries, the two-form strategy (universal recurrence/substitution + concrete aeval transport), and the proof status (PROVED, 0 sorries, 0 axioms).",
+      "mathContext": "$p_5 = e_1^5 - 5 e_1^3 e_2 + 5 e_1 e_2^2 + 5 e_1^2 e_3 - 5 e_2 e_3 - 5 e_1 e_4 + 5 e_5$."
+    },
+    {
+      "id": "universal",
+      "title": "Universal Closed Form (MvPolynomial)",
+      "startLine": 57,
+      "endLine": 109,
+      "summary": "psum_five_recurrence extracts p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅ from psum_eq_mul_esymm_sub_sum at n=5 (antidiagonal {(1,4),(2,3),(3,2),(4,1)}). psum_five_closed substitutes the proven p₄, p₃, p₂, p₁ closed forms and ring-normalises.",
+      "mathContext": "In MvPolynomial σ R: $p_5 = e_1^5 - 5 e_1^3 e_2 + 5 e_1 e_2^2 + 5 e_1^2 e_3 - 5 e_2 e_3 - 5 e_1 e_4 + 5 e_5$."
+    },
+    {
+      "id": "concrete",
+      "title": "Concrete General-Finset Form (char-5 safe)",
+      "startLine": 111,
+      "endLine": 156,
+      "summary": "Defines e₅, p₅ over a Finset via powersetCard, adds the degree-5 bridge instances e5_bridge/p5_bridge (reusing the k=3 n-general aeval bridge), and proves newton_girard_five_finset over an arbitrary CommRing by transporting psum_five_closed across aeval onto the membership subtype.",
+      "mathContext": "Over any CommRing: $p_5 = e_1^5 - 5 e_1^3 e_2 + 5 e_1 e_2^2 + 5 e_1^2 e_3 - 5 e_2 e_3 - 5 e_1 e_4 + 5 e_5$, characteristic 5 included."
+    },
+    {
+      "id": "explicit",
+      "title": "Concrete 5-Variable Instance (Sum of Fifth Powers)",
+      "startLine": 158,
+      "endLine": 187,
+      "summary": "fifth_power_sum_five: a⁵+b⁵+c⁵+d⁵+e⁵ = e₁⁵ − 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ − 5e₂e₃ − 5e₁e₄ + 5e₅ over any CommRing, closed by ring — the smallest nondegenerate Finset instance.",
+      "mathContext": "$a^5+b^5+c^5+d^5+e^5 = e_1^5 - 5 e_1^3 e_2 + 5 e_1 e_2^2 + 5 e_1^2 e_3 - 5 e_2 e_3 - 5 e_1 e_4 + 5 e_5$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Resolves the open question in both the universal MvPolynomial setting and the concrete general-Finset setting. The universal identity p₅ = e₁⁵ − 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ − 5e₂e₃ − 5e₁e₄ + 5e₅ is extracted from Mathlib's general Newton recurrence plus the lower closed forms; the concrete Finset form reuses the k=3 entry's degree-general aeval bridge at degree 5 and holds over an arbitrary CommRing (characteristic 5 included). The file is machine-verified with 0 sorries and 0 axioms (only propext/Classical.choice/Quot.sound).",
+    "implications": "**For symmetric function theory**: completes the reduced k=5 Newton-Girard identity, the first involving e₅, extending the gallery's k=2 → k=3 → k=4 → k=5 chain of explicit closed forms.\n\n**For formalization technique**: gives a second confirmation, after k=4, that the k=3 aeval bridge (concrete powersetCard / power-sum defs = aeval of universal MvPolynomial symmetric functions on the membership subtype) is degree-uniform: the k=5 concrete form again costs only two one-line bridge instantiations.",
+    "openQuestions": [
+      "Prove the k=5 recurrence and closed form via a single degree-uniform transport lemma pₖ (powersetCard form) = aeval (psum {x // x ∈ s} R k) applied to the full Newton recurrence, eliminating per-degree wrappers (e5_bridge, p5_bridge, …) entirely.",
+      "Continue the chain to k=6: p₆ = e₁⁶ − 6e₁⁴e₂ + 9e₁²e₂² − 2e₂³ + 6e₁³e₃ − 12e₁e₂e₃ + 3e₃² − 6e₁²e₄ + 6e₂e₄ + 6e₁e₅ − 6e₆, the first rung with the cubic e₂³ term and the e₃² square."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01",
+      "relationship": "parent",
+      "description": "The k=4 closed form psum_four_closed and its e₄ definition / e4_bridge, which this entry substitutes into the k=5 recurrence and reuses at degree 5. This entry is the direct next rung in the Newton-Girard closed-form chain."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "The k=3 closed form and its n-general aeval bridge (aeval_psum_subtype / aeval_esymm_subtype), which this entry reuses verbatim at degree 5 — a second confirmation that the bridge is degree-general."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Provides the closed forms p₂ = e₁² − 2e₂, p₁ = e₁ and the pattern for extracting Newton recurrences from MvPolynomial.psum_eq_mul_esymm_sub_sum; this entry repeats that pattern at n=5."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-04",
+      "relationship": "related",
+      "description": "Proves the GENERAL Finset-level Newton-Girard recurrence (pₖ in terms of lower pⱼ and eⱼ) for arbitrary k. This entry is complementary: it gives the fully REDUCED closed form for the specific case k=5, expressing p₅ purely in e₁,…,e₅ rather than recursively."
+    },
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "related",
+      "description": "The e₁,…,e₅ appearing here are exactly Vieta's elementary symmetric polynomials in the roots; the identity expresses the fifth power sum of roots via coefficients."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Girard, Albert",
+      "title": "Invention nouvelle en l'algèbre",
+      "year": "1629",
+      "venue": "Amsterdam: Guillaume Iansson Blaeuw",
+      "note": "Earliest known statement of the identities relating power sums to elementary symmetric polynomials."
+    },
+    {
+      "authors": "Newton, Isaac",
+      "title": "Arithmetica Universalis",
+      "year": "1707",
+      "venue": "Cambridge (manuscript ~1666)",
+      "note": "Newton's independent treatment of the power-sum / elementary-symmetric identities."
+    },
+    {
+      "authors": "Macdonald, I. G.",
+      "title": "Symmetric Functions and Hall Polynomials",
+      "year": "1995",
+      "venue": "Oxford University Press, 2nd edition, Chapter I §2",
+      "note": "Canonical reference; the Newton-Girard identities appear as (2.11′)/(2.11″)."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AmgmInequalityOQ02OQ01OQ03OQ01OQ01.lean",
+    "lineCount": 189,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "axiomCount": 0,
+    "sorries": 0,
+    "additionalFiles": []
+  }
+}

--- a/src/data/proofs/newton-power-sum-identities-oq-01-oq-01/meta.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01-oq-01/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "newton-power-sum-identities-oq-01-oq-01",
+  "title": "Newton's Identities in Degrees 4 and 5: Explicit Power-Sum Closed Forms",
+  "slug": "newton-power-sum-identities-oq-01-oq-01",
+  "description": "Newton's identities express the power sums pₖ = ∑ᵢ Xᵢᵏ of finitely many variables in terms of the elementary symmetric polynomials eⱼ. Mathlib proves the general recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum, namely pₖ = (-1)^{k+1}·k·eₖ - ∑_{0<i<k} (-1)^i·eᵢ·p_{k-i}, but does not record the explicit closed forms in low degree. The parent entry (newton-power-sum-identities-oq-01) unrolled the recurrence for k = 1, 2, 3; this child continues the identical method two further rungs to obtain p₄ = e₁⁴ - 4e₁²e₂ + 2e₂² + 4e₁e₃ - 4e₄ and p₅ = e₁⁵ - 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ - 5e₂e₃ - 5e₁e₄ + 5e₅, valid as identities in MvPolynomial σ R for any finite index type σ and any commutative ring R. The finite inner index sets of the recurrence ({(1,3),(2,2),(3,1)} at k=4 and {(1,4),(2,3),(3,2),(4,1)} at k=5) are computed by omega and the results closed by ring after substituting the lower identities. The entry is self-contained: degrees 1, 2, 3 are restated and reproved.",
+  "meta": {
+    "author": "Isaac Newton (Arithmetica Universalis, 1707) / classical theory of symmetric functions; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Newton%27s_identities",
+    "date": "1707",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "symmetric-functions",
+      "newton-identities",
+      "power-sums",
+      "elementary-symmetric-polynomials",
+      "mvpolynomial",
+      "commutative-ring",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/NewtonPowerSumIdentitiesOQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+        "description": "The Newton recurrence pₖ = (-1)^{k+1}·k·eₖ - ∑_{0<i<k}(-1)^i·eᵢ·p_{k-i} (for 0 < k); the engine that is unrolled at k = 4 and k = 5",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.NewtonIdentities"
+      },
+      {
+        "theorem": "MvPolynomial.psum_one",
+        "description": "psum σ R 1 = ∑ᵢ Xᵢ — used together with esymm_one to give the base identity p₁ = e₁",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      },
+      {
+        "theorem": "MvPolynomial.esymm_one",
+        "description": "esymm σ R 1 = ∑ᵢ Xᵢ — matches psum_one to establish p₁ = e₁",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      },
+      {
+        "theorem": "Finset.sum_insert / Finset.sum_pair / Finset.sum_singleton",
+        "description": "Evaluate the recurrence's finite inner sums over the explicit three- and four-element index sets by peeling elements off the literal Finset",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.mem_antidiagonal",
+        "description": "Membership in the ℕ-antidiagonal, reducing the inner index set {a ∈ antidiagonal k | 0 < a.1 < k} to a linear-arithmetic condition discharged by omega",
+        "module": "Mathlib.Algebra.Order.Antidiag.Nat"
+      }
+    ],
+    "originalContributions": [
+      "psum_four_eq: p₄ = e₁⁴ - 4e₁²e₂ + 2e₂² + 4e₁e₃ - 4e₄ — the degree-4 Newton identity, unrolled from the Mathlib recurrence over the inner index set {(1,3),(2,2),(3,1)}",
+      "psum_five_eq: p₅ = e₁⁵ - 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ - 5e₂e₃ - 5e₁e₄ + 5e₅ — the degree-5 Newton identity, unrolled over {(1,4),(2,3),(3,2),(4,1)}; these explicit closed forms are not stated in Mathlib, which carries only the general recurrence",
+      "Self-contained restatement and reproof of the degree-1,2,3 identities (psum_one_eq, psum_two_eq, psum_three_eq) so the file stands alone"
+    ],
+    "dateAdded": "2026-06-20",
+    "lineCount": 124,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). The uses of decide prove pair-inequality side conditions ((1,3) ∉ {…} etc.) by kernel reduction, not native_decide, so no Lean.ofReduceBool is introduced.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Newton's identities (also called the Newton–Girard formulae) relate the two most fundamental bases of the ring of symmetric functions: the power sums pₖ = ∑ xᵢᵏ and the elementary symmetric polynomials eⱼ = ∑_{i₁<···<iⱼ} xᵢ₁···xᵢⱼ. They were stated by Newton in his Arithmetica Universalis (1707) and earlier by Girard (1629), and are the computational backbone of Galois theory, the theory of resultants, and the conversion between the characteristic polynomial of a matrix and its traces of powers. While the degree 1–3 identities appear most often, the degree-4 and degree-5 formulas are exactly what is needed for sums of fourth and fifth powers of the roots of a quartic or quintic in terms of its coefficients, and for the trace-power-to-coefficient conversion of 4×4 and 5×5 matrices.",
+    "problemStatement": "**Open Question (newton-power-sum-identities-oq-01-oq-01)**: Extend the explicit low-degree Newton identities (parent: k = 1, 2, 3) two further rungs, deriving the degree-4 and degree-5 closed forms for the power sums pₖ = ∑ᵢ Xᵢᵏ in terms of the elementary symmetric polynomials eⱼ over a commutative ring.\n\n**Result**: psum_four_eq (p₄ = e₁⁴ - 4e₁²e₂ + 2e₂² + 4e₁e₃ - 4e₄) and psum_five_eq (p₅ = e₁⁵ - 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ - 5e₂e₃ - 5e₁e₄ + 5e₅), obtained by unrolling Mathlib's general Newton recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum, which does not itself record these closed forms.",
+    "text": "Let σ be a finite index type and R a commutative ring. For the elementary symmetric polynomials eⱼ = MvPolynomial.esymm σ R j and power sums pₖ = MvPolynomial.psum σ R k = ∑ᵢ Xᵢᵏ in MvPolynomial σ R, one has p₄ = e₁⁴ - 4e₁²e₂ + 2e₂² + 4e₁e₃ - 4e₄ and p₅ = e₁⁵ - 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ - 5e₂e₃ - 5e₁e₄ + 5e₅. These hold for every finite σ; when card σ < k the higher eⱼ vanish, so e.g. with a single variable p₄ = e₁⁴ and p₅ = e₁⁵.",
+    "proofStrategy": "**Proof Strategy.**\n\nThe file first restates and reproves the degree-1,2,3 identities (psum_one_eq, psum_two_eq, psum_three_eq) exactly as in the parent, then advances two rungs.\n\n4. p₄ = e₁⁴ - 4e₁²e₂ + 2e₂² + 4e₁e₃ - 4e₄ (psum_four_eq): apply the Newton recurrence at k = 4. Its inner sum ranges over {a ∈ antidiagonal 4 | 0 < a.1 < 4}; an omega-discharged set equality shows this is {(1,3),(2,2),(3,1)}. Peel the three terms with two Finset.sum_insert (the disjointness side goals (1,3) ∉ {(2,2),(3,1)} and (2,2) ∉ {(3,1)} closed by decide) and Finset.sum_singleton, substitute the degree-3, 2, 1 identities, and close with push_cast; ring (which evaluates the (-1)^i signs and integer casts).\n\n5. p₅ = e₁⁵ - 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ - 5e₂e₃ - 5e₁e₄ + 5e₅ (psum_five_eq): apply the recurrence at k = 5. The inner index set {a ∈ antidiagonal 5 | 0 < a.1 < 5} is {(1,4),(2,3),(3,2),(4,1)} (again by omega), peeled by three Finset.sum_insert and a Finset.sum_singleton into the four terms (-1)^i·eᵢ·p_{5-i}. Substitute the degree-4,3,2,1 identities and finish with push_cast; ring.",
+    "keyInsights": [
+      "**The recurrence keeps specializing cleanly.** Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum gives Newton's law for all k; each explicit low-degree formula comes from evaluating its finite inner sum over a tiny, omega-computable index set and substituting the already-established lower identities — a uniform descent that does not get harder as the degree grows.",
+      "**The index sets remain pure linear arithmetic.** {a ∈ antidiagonal k | 0 < a.1 < k} reduces, via mem_antidiagonal and mem_Ioo, to {(i,j) | i+j=k, 0<i<k}, which omega resolves to {(1,3),(2,2),(3,1)} for k=4 and {(1,4),(2,3),(3,2),(4,1)} for k=5 — no Finset computation or decide on the polynomial ring is needed; decide is used only for the trivial pair-disjointness side goals of sum_insert.",
+      "**Identities, not equalities of numbers.** The results live in MvPolynomial σ R, so they are universal symmetric-function identities; specializing the variables recovers the relations for ∑xᵢ⁴ and ∑xᵢ⁵ in terms of the coefficients of any quartic or quintic.",
+      "**New beyond Mathlib.** Mathlib records the recurrence but not the explicit closed forms p₄ and p₅; this entry supplies them as reusable lemmas, extending the parent's degree-1,2,3 coverage."
+    ],
+    "prerequisites": [
+      "The parent entry newton-power-sum-identities-oq-01 (degrees 1, 2, 3)",
+      "The definitions MvPolynomial.psum and MvPolynomial.esymm (Symmetric/Defs.lean)",
+      "The Newton recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum (Symmetric/NewtonIdentities.lean)",
+      "Finset.antidiagonal over ℕ and the big-operator lemmas Finset.sum_singleton, Finset.sum_pair, Finset.sum_insert"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring stating Newton's recurrence, the parent's degree-1,2,3 forms, and the two new closed forms p₄ and p₅ to be derived, with the validity for any finite σ (higher eⱼ vanishing when card σ < k). The Mathlib import, the open Finset, the namespace, and the variables (σ finite, R a commutative ring).",
+      "mathContext": "$p_k = (-1)^{k+1} k\\,e_k - \\sum_{0<i<k} (-1)^i e_i\\, p_{k-i}$."
+    },
+    {
+      "id": "degrees-one-two-three",
+      "title": "Degrees 1–3 (restated): p₁, p₂, p₃",
+      "startLine": 45,
+      "endLine": 77,
+      "summary": "psum_one_eq, psum_two_eq, psum_three_eq: the parent's three identities reproved verbatim so the file is self-contained — base case from psum_one/esymm_one, then the recurrence at k = 2, 3 with omega-computed inner sets {(1,1)} and {(1,2),(2,1)}.",
+      "mathContext": "$p_1 = e_1,\\quad p_2 = e_1^2 - 2e_2,\\quad p_3 = e_1^3 - 3e_1 e_2 + 3e_3$."
+    },
+    {
+      "id": "degree-four",
+      "title": "Degree 4: p₄ = e₁⁴ - 4e₁²e₂ + 2e₂² + 4e₁e₃ - 4e₄",
+      "startLine": 79,
+      "endLine": 97,
+      "summary": "psum_four_eq: apply the recurrence at k = 4, reduce its inner index set to {(1,3),(2,2),(3,1)} via an omega-proved set equality, evaluate by two Finset.sum_insert plus Finset.sum_singleton, substitute the degree-3, 2, 1 identities, and close with push_cast; ring.",
+      "mathContext": "$p_4 = e_1^4 - 4e_1^2 e_2 + 2e_2^2 + 4e_1 e_3 - 4e_4$."
+    },
+    {
+      "id": "degree-five",
+      "title": "Degree 5: p₅ = e₁⁵ - 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ - 5e₂e₃ - 5e₁e₄ + 5e₅",
+      "startLine": 99,
+      "endLine": 124,
+      "summary": "psum_five_eq: apply the recurrence at k = 5, reduce its inner index set to {(1,4),(2,3),(3,2),(4,1)} via omega, evaluate by three Finset.sum_insert plus Finset.sum_singleton, substitute the degree-4,3,2,1 identities, and finish with push_cast; ring.",
+      "mathContext": "$p_5 = e_1^5 - 5e_1^3 e_2 + 5e_1 e_2^2 + 5e_1^2 e_3 - 5e_2 e_3 - 5e_1 e_4 + 5e_5$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "newton-power-sum-identities-oq-01",
+      "relation": "parent",
+      "description": "Parent entry deriving the degree-1,2,3 Newton identities by the same unrolling of MvPolynomial.psum_eq_mul_esymm_sub_sum; this entry continues to degrees 4 and 5."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) derivation of the degree-4 and degree-5 Newton identities p₄ = e₁⁴ - 4e₁²e₂ + 2e₂² + 4e₁e₃ - 4e₄ and p₅ = e₁⁵ - 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ - 5e₂e₃ - 5e₁e₄ + 5e₅ as universal identities in MvPolynomial σ R, obtained by unrolling Mathlib's general Newton recurrence and substituting the lower identities (also reproved here for self-containment).",
+    "implications": "Extends the parent's degree-1,2,3 closed forms to degrees 4 and 5, supplying reusable lemmas for converting between power sums and elementary symmetric polynomials (equivalently between traces of powers and coefficients of a characteristic polynomial) at the degrees relevant to quartic and quintic root-power sums.",
+    "openQuestions": [
+      "Derive the degree-6 identity p₆ = e₁⁶ - 6e₁⁴e₂ + 9e₁²e₂² - 2e₂³ + 6e₁³e₃ - 12e₁e₂e₃ + 3e₃² - 6e₁²e₄ + 6e₂e₄ + 6e₁e₅ - 6e₆ by the same unrolling (inner index set {(1,5),(2,4),(3,3),(4,2),(5,1)}).",
+      "Prove the dual (reverse) Newton identities expressing each eₖ as a polynomial in the power sums (k! eₖ = det of a Toeplitz matrix in the pᵢ), valid over a ℚ-algebra."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "NewtonPowerSumOQ01",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/NewtonPowerSumIdentitiesOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Newton, Isaac",
+      "title": "Arithmetica Universalis",
+      "year": "1707",
+      "venue": "",
+      "note": "Classical source of the identities relating power sums and elementary symmetric polynomials"
+    },
+    {
+      "authors": "Mead, D. G.",
+      "title": "Newton's Identities",
+      "year": "1992",
+      "venue": "The American Mathematical Monthly 99(8), 749–751",
+      "note": "Modern exposition and proofs of the Newton–Girard formulae"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Extends the merged parent entry **newton-power-sum-identities-oq-01** (degrees 1, 2, 3) two further rungs, deriving the explicit **degree-4 and degree-5** Newton power-sum closed forms as identities in `MvPolynomial σ R` for any finite index type `σ` and any commutative ring `R`:

```
p₄ = e₁⁴ - 4 e₁² e₂ + 2 e₂² + 4 e₁ e₃ - 4 e₄
p₅ = e₁⁵ - 5 e₁³ e₂ + 5 e₁ e₂² + 5 e₁² e₃ - 5 e₂ e₃ - 5 e₁ e₄ + 5 e₅
```

Mathlib proves the general Newton recurrence `MvPolynomial.psum_eq_mul_esymm_sub_sum` but does **not** record these low-degree closed forms.

## Method (identical to parent)

`rw` the recurrence; resolve the inner antidiagonal index set by `omega` (`{(1,3),(2,2),(3,1)}` for k=4; `{(1,4),(2,3),(3,2),(4,1)}` for k=5); peel the sum with `Finset.sum_insert`/`sum_singleton`; substitute the lower `psum` identities; close with `push_cast; ring`.

## Verification

- **Builds green** via `./proofs/scripts/docker-build.sh Proofs.NewtonPowerSumIdentitiesOQ01OQ01` (7743 jobs).
- 5 theorems, 124 lines, **0 sorries, 0 axiom declarations**.
- No `native_decide`; `decide` is used only for kernel-checked pair-disjointness side goals → no `Lean.ofReduceBool`. Genuinely **verified, 0-axiom**.
- Self-contained: degrees 1, 2, 3 restated and reproved so the file stands alone.

## Files
- `proofs/Proofs/NewtonPowerSumIdentitiesOQ01OQ01.lean` (new)
- `src/data/proofs/newton-power-sum-identities-oq-01-oq-01/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)