### PR TITLE
research(cauchy-interlacing): assemble interlacing from the Courant–Fischer keystone [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingAssembly.lean
+++ b/proofs/Proofs/CauchyInterlacingAssembly.lean
@@ -1,0 +1,139 @@
+import Mathlib
+import Proofs.CauchyInterlacingKeystone
+
+/-
+# Cauchy interlacing — assembly from the Courant–Fischer keystone
+
+`CauchyInterlacingKeystone.lean` (#25063, 0-sorry/0-axiom) proves the genuine
+Mathlib gap: the bound-form Courant–Fischer max–min characterisation of the
+descending k-th eigenvalue of a symmetric operator,
+
+* `eigenvalue_maxmin_lower` — an optimal `(k+1)`-dim subspace on which every
+  Rayleigh quotient is `≥ μ k` exists, and
+* `eigenvalue_maxmin_upper` — on *every* `(k+1)`-dim subspace some nonzero
+  vector has Rayleigh quotient `≤ μ k`,
+
+plus the index-set-parametrised `exists_rayleigh_le_in_subspace`.
+
+This file closes the **assembly**: from those two halves we derive the actual
+interlacing inequalities
+
+  `lam (k.succ) ≤ mu k ≤ lam (k.castSucc)`
+
+relating the descending eigenvalues `lam : Fin (n+1) → ℝ` of a symmetric
+operator `T` on a space `V` of dimension `n+1` to the descending eigenvalues
+`mu : Fin n → ℝ` of a symmetric operator `TH` on a codimension-one subspace
+`H ≤ V` (`finrank H = n`).
+
+## The compression interface
+
+The only thing connecting `TH` to `T` is the **Rayleigh-agreement** hypothesis
+
+  `hRayleigh : ∀ y : H, y ≠ 0 → R_{TH}(y) = R_T(↑y)`,
+
+which is exactly the property satisfied by the orthogonal *compression*
+`TH = P_H ∘ T ∘ ι` of `T` to `H` (the principal-submatrix operator):
+for `y ∈ H`, `⟪TH y, y⟫_H = ⟪P_H (T ↑y), ↑y⟫ = ⟪T ↑y, ↑y⟫` because `↑y ∈ H`,
+and `‖y‖_H = ‖↑y‖_V`. Stating it as a hypothesis keeps this file purely
+order-theoretic / dimension-counting and reusable: the spectral theorem on `H`
+supplies `bH, mu, hTH`, and the compression supplies `hRayleigh`.
+
+## Proof
+
+* **Upper** `mu k ≤ lam k.castSucc`: take the optimal `(k+1)`-dim subspace
+  `SH ⊆ H` for `TH` (lower half, `TH`); push it into `V`; the upper half for `T`
+  finds a vector in it with `R_T ≤ lam k.castSucc`; Rayleigh-agreement turns the
+  `≥ mu k` lower bound on `SH` into the same bound for that vector.
+* **Lower** `lam k.succ ≤ mu k`: take the optimal `(k+2)`-dim subspace `S` for
+  `T` (lower half, `T`); `S ⊓ H` has dimension `≥ k+1` (codimension-one count);
+  pull it back into `H` and apply `exists_rayleigh_le_in_subspace` for `TH` to
+  find a vector with `R_{TH} ≤ mu k`; that vector lies in `S`, so
+  `lam k.succ ≤ R_T = R_{TH} ≤ mu k`.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open scoped InnerProductSpace
+open CauchyInterlacing.Keystone
+
+namespace CauchyInterlacing.Assembly
+
+/-- **Cauchy interlacing (abstract / compression form).**
+
+Let `T` be a symmetric operator on a `(n+1)`-dimensional inner product space `V`
+with orthonormal eigenbasis `b` and antitone (descending) eigenvalues `lam`.
+Let `H ≤ V` have dimension `n`, and let `TH` be a symmetric operator on `H` with
+orthonormal eigenbasis `bH` and antitone eigenvalues `mu`, whose Rayleigh
+quotient agrees with that of `T` on every nonzero `y ∈ H` (the defining property
+of the orthogonal compression of `T` to `H`).
+
+Then the eigenvalues interlace: for every `k : Fin n`,
+
+  `lam (k.succ) ≤ mu k`  and  `mu k ≤ lam (k.castSucc)`.
+
+In ascending textbook notation this is `λ_k ≤ μ_k ≤ λ_{k+1}`. -/
+theorem cauchy_interlacing
+    {𝕜 V : Type*} [RCLike 𝕜] [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
+    [FiniteDimensional 𝕜 V] {n : ℕ}
+    (T : V →ₗ[𝕜] V) (b : OrthonormalBasis (Fin (n + 1)) 𝕜 V) (lam : Fin (n + 1) → ℝ)
+    (hT : ∀ i, T (b i) = (lam i : 𝕜) • b i) (hlam : Antitone lam)
+    (H : Submodule 𝕜 V) (hHdim : Module.finrank 𝕜 H = n)
+    (TH : H →ₗ[𝕜] H) (bH : OrthonormalBasis (Fin n) 𝕜 H) (mu : Fin n → ℝ)
+    (hTH : ∀ i, TH (bH i) = (mu i : 𝕜) • bH i) (hmu : Antitone mu)
+    (hRayleigh : ∀ y : H, y ≠ 0 →
+      RCLike.re (@inner 𝕜 H _ (TH y) y) / ‖y‖ ^ 2
+        = RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2)
+    (k : Fin n) :
+    lam k.succ ≤ mu k ∧ mu k ≤ lam k.castSucc := by
+  have hVdim : Module.finrank 𝕜 V = n + 1 := by
+    rw [Module.finrank_eq_card_basis b.toBasis, Fintype.card_fin]
+  refine ⟨?_, ?_⟩
+  · -- LOWER bound: lam k.succ ≤ mu k
+    obtain ⟨S, hSdim, hSlb⟩ := eigenvalue_maxmin_lower T b lam hT hlam k.succ
+    -- the compression-side subspace: pull `S ⊓ H` back into `H`
+    set SH : Submodule 𝕜 H := (S ⊓ H).comap H.subtype with hSHdef
+    have hmap : SH.map H.subtype = S ⊓ H := by
+      rw [hSHdef, Submodule.map_comap_subtype, inf_of_le_right inf_le_right]
+    have hSHfr : Module.finrank 𝕜 SH = Module.finrank 𝕜 (S ⊓ H : Submodule 𝕜 V) := by
+      rw [← hmap, Submodule.finrank_map_subtype_eq]
+    -- dimension count: finrank (S ⊓ H) ≥ k + 1
+    have hks : (k.succ : ℕ) = (k : ℕ) + 1 := Fin.val_succ k
+    have hsum := Submodule.finrank_sup_add_finrank_inf_eq S H
+    have hsuple : Module.finrank 𝕜 (S ⊔ H : Submodule 𝕜 V) ≤ n + 1 := by
+      rw [← hVdim]; exact Submodule.finrank_le _
+    have hk : (k : ℕ) < n := k.isLt
+    have hge : (k : ℕ) + 1 ≤ Module.finrank 𝕜 (S ⊓ H : Submodule 𝕜 V) := by
+      rw [hHdim] at hsum; omega
+    have hSHge : (k : ℕ) + 1 ≤ Module.finrank 𝕜 SH := by rw [hSHfr]; exact hge
+    have hdim : Module.finrank 𝕜 H < Module.finrank 𝕜 SH + (Finset.Ici k).card := by
+      rw [hHdim, Fin.card_Ici]; omega
+    have hc : ∀ i ∈ Finset.Ici k, mu i ≤ mu k := fun i hi => hmu (Finset.mem_Ici.1 hi)
+    obtain ⟨y, hySH, hy0, hyle⟩ :=
+      exists_rayleigh_le_in_subspace TH bH mu hTH (Finset.Ici k) (mu k) hc SH hdim
+    -- the witness, pushed to `V`, lies in `S`
+    have hyHS : (y : V) ∈ S ⊓ H := by
+      have h := Submodule.mem_comap.1 (hSHdef ▸ hySH)
+      simpa using h
+    have hyS : (y : V) ∈ S := (Submodule.mem_inf.1 hyHS).1
+    have hyv0 : (y : V) ≠ 0 := fun h => hy0 (Submodule.coe_eq_zero.1 h)
+    calc lam k.succ
+        ≤ RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2 := hSlb (y : V) hyS hyv0
+      _ = RCLike.re (@inner 𝕜 H _ (TH y) y) / ‖y‖ ^ 2 := (hRayleigh y hy0).symm
+      _ ≤ mu k := hyle
+  · -- UPPER bound: mu k ≤ lam k.castSucc
+    obtain ⟨SH, hSHdim, hSHlb⟩ := eigenvalue_maxmin_lower TH bH mu hTH hmu k
+    set S : Submodule 𝕜 V := SH.map H.subtype with hSdef
+    have hSdim : Module.finrank 𝕜 S = (k.castSucc : ℕ) + 1 := by
+      rw [hSdef, Submodule.finrank_map_subtype_eq, hSHdim, Fin.coe_castSucc]
+    obtain ⟨x, hxS, hx0, hxle⟩ := eigenvalue_maxmin_upper T b lam hT hlam k.castSucc S hSdim
+    rw [hSdef, Submodule.mem_map] at hxS
+    obtain ⟨y, hySH, hyx⟩ := hxS
+    have hy0 : y ≠ 0 := fun h => hx0 (by rw [← hyx, h, map_zero])
+    have hxv : x = (y : V) := by rw [← hyx]; rfl
+    calc mu k
+        ≤ RCLike.re (@inner 𝕜 H _ (TH y) y) / ‖y‖ ^ 2 := hSHlb y hySH hy0
+      _ = RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2 := hRayleigh y hy0
+      _ = RCLike.re (@inner 𝕜 V _ (T x) x) / ‖x‖ ^ 2 := by rw [hxv]
+      _ ≤ lam k.castSucc := hxle
+
+end CauchyInterlacing.Assembly

--- a/src/data/proofs/cauchy-interlacing-theorem/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "ann-cauchy-interlacing-statement",
+    "proofId": "cauchy-interlacing-theorem",
+    "range": {
+      "startLine": 79,
+      "endLine": 96
+    },
+    "type": "insight",
+    "title": "Cauchy Interlacing in Compression Form",
+    "content": "`cauchy_interlacing` concludes `lam k.succ ≤ mu k ∧ mu k ≤ lam k.castSucc` — the interlacing inequalities in descending convention (ascending textbook form λ_k ≤ μ_k ≤ λ_{k+1}). The only hypothesis linking the big operator T (on V, dim n+1) to the small operator TH (on the codimension-one subspace H, dim n) is `hRayleigh`: their Rayleigh quotients agree on every nonzero y ∈ H. This is exactly the property of the orthogonal compression of T to H — the principal-submatrix operator — so the result specialises to the classical matrix theorem.",
+    "mathContext": "The compression form keeps the proof purely order-theoretic and dimension-counting; the spectral theorem on H and the compression construction supply b, mu, hRayleigh when reducing to matrices.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy interlacing",
+      "orthogonal compression",
+      "principal submatrix",
+      "Rayleigh quotient"
+    ],
+    "prerequisites": [
+      "symmetric operator spectral decomposition",
+      "Rayleigh quotient"
+    ]
+  },
+  {
+    "id": "ann-cauchy-interlacing-lower",
+    "proofId": "cauchy-interlacing-theorem",
+    "range": {
+      "startLine": 98,
+      "endLine": 122
+    },
+    "type": "insight",
+    "title": "Lower Bound: the Codimension-One Dimension Drop",
+    "content": "For `lam k.succ ≤ mu k`, take the optimal (k+2)-dimensional eigenspan S for T from the keystone lower half `eigenvalue_maxmin_lower` at `k.succ`. The intersection S ⊓ H has dimension ≥ k+1: from `Submodule.finrank_sup_add_finrank_inf_eq` and finrank(S⊔H) ≤ n+1 with finrank H = n, omega gives the count. Pulling S ⊓ H back into H and applying `exists_rayleigh_le_in_subspace` for TH yields a vector y with R_TH(y) ≤ mu k; since y also sits in S, the lower bound gives lam k.succ ≤ R_T(y), and Rayleigh-agreement equates R_T(y) = R_TH(y).",
+    "mathContext": "Intersecting a (k+2)-dimensional subspace with a hyperplane loses at most one dimension, leaving room (≥ k+1) to meet the high eigenspan of TH — the engine of the lower interlacing inequality.",
+    "significance": "key",
+    "relatedConcepts": [
+      "dimension counting",
+      "subspace intersection",
+      "Courant–Fischer max–min"
+    ],
+    "prerequisites": [
+      "finrank_sup_add_finrank_inf_eq",
+      "Submodule.finrank_map_subtype_eq"
+    ]
+  },
+  {
+    "id": "ann-cauchy-interlacing-upper",
+    "proofId": "cauchy-interlacing-theorem",
+    "range": {
+      "startLine": 123,
+      "endLine": 139
+    },
+    "type": "insight",
+    "title": "Upper Bound: Transport Through Rayleigh-Agreement",
+    "content": "For `mu k ≤ lam k.castSucc`, take the optimal (k+1)-dimensional eigenspan SH for TH (keystone lower half on H), push it into V via `H.subtype` (dimension preserved by `Submodule.finrank_map_subtype_eq`), and apply the keystone upper half `eigenvalue_maxmin_upper` for T: every (k+1)-dim subspace contains a nonzero vector with R_T ≤ lam k.castSucc. That vector is the image of some y ∈ SH, where SH's lower bound gives mu k ≤ R_TH(y); Rayleigh-agreement turns this into mu k ≤ R_T = R_T(x) ≤ lam k.castSucc.",
+    "mathContext": "Here the optimal subspace already lives inside H, so no dimension drop is needed — the bound transports directly across the compression.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Courant–Fischer max–min",
+      "subspace pushforward",
+      "Rayleigh quotient agreement"
+    ],
+    "prerequisites": [
+      "eigenvalue_maxmin_upper",
+      "eigenvalue_maxmin_lower"
+    ]
+  },
+  {
+    "id": "ann-cauchy-interlacing-keystone",
+    "proofId": "cauchy-interlacing-theorem",
+    "range": {
+      "startLine": 1,
+      "endLine": 30
+    },
+    "type": "insight",
+    "title": "The Keystone: k-th Courant–Fischer Max–Min (the Mathlib Gap)",
+    "content": "The assembly imports `Proofs.CauchyInterlacingKeystone` (#25063, 0-sorry/0-axiom), which proves the genuine Mathlib gap: the bound-form Courant–Fischer max–min characterisation of the descending k-th eigenvalue. `eigenvalue_maxmin_lower` exhibits an optimal (k+1)-dim eigenspan with all Rayleigh quotients ≥ μ_k; `eigenvalue_maxmin_upper` shows every (k+1)-dim subspace contains a nonzero vector with Rayleigh quotient ≤ μ_k. Both reduce to `rayleigh_bounds_on_eigenspan`: on the eigenspan over an index set I, the Rayleigh quotient is a convex combination Σ w_i μ_i of the eigenvalues there, hence in [inf' I μ, sup' I μ]. Before this, Mathlib had only the extreme (largest/smallest) Rayleigh cases.",
+    "mathContext": "The bound form avoids the conditionally-complete-lattice junk values of an iSup/iInf statement while carrying the same content max_{dim S=k+1} min_{0≠x∈S} R(x) = μ_k.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Courant–Fischer theorem",
+      "min-max principle",
+      "Rayleigh quotient",
+      "convex combination of eigenvalues"
+    ],
+    "prerequisites": [
+      "orthonormal eigenbasis",
+      "finrank_span_eq_card"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "cauchy-interlacing-theorem",
+  "title": "Cauchy Interlacing via the Courant–Fischer Max–Min Keystone",
+  "slug": "cauchy-interlacing-theorem",
+  "description": "Cauchy eigenvalue interlacing for a symmetric operator and its orthogonal compression to a codimension-one subspace, λ(k+1) ≤ μ(k) ≤ λ(k) (descending convention). The proof is assembled from a fully machine-checked, bound-form Courant–Fischer max–min characterisation of the descending k-th eigenvalue — the single Mathlib gap blocking interlacing, proved from scratch over an orthonormal eigenbasis. Compression form: the only link between the two operators is a Rayleigh-quotient agreement hypothesis, exactly the property of the principal-submatrix (orthogonal compression) operator.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyInterlacingAssembly.lean",
+    "tags": [
+      "linear-algebra",
+      "spectral-theory",
+      "eigenvalues",
+      "cauchy-interlacing",
+      "courant-fischer",
+      "min-max",
+      "rayleigh-quotient",
+      "inner-product-space"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "lineCount": 139,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "assumptions": "None beyond the stated theorem hypotheses. 0 axioms, 0 sorries in both the assembly file and the imported keystone (CauchyInterlacingKeystone.lean, #25063, 0-sorry/0-axiom). The interlacing theorem is proved in compression form: it takes as a hypothesis that the smaller operator TH on the codimension-one subspace H has the same Rayleigh quotient as T on every nonzero vector of H. This is precisely the defining property of the orthogonal compression of T to H (the principal-submatrix operator), so the result specialises to the matrix Cauchy interlacing theorem; the matrix-to-compression instantiation (spectral theorem on H + compression construction) is the remaining bridge and is documented, not assumed away.",
+    "originalContributions": [
+      "cauchy_interlacing (assembly): from the two Courant–Fischer halves, derives both interlacing inequalities λ(k.succ) ≤ μ(k) and μ(k) ≤ λ(k.castSucc) for a symmetric operator T on an (n+1)-dimensional space and a symmetric operator TH on a codimension-one subspace H whose Rayleigh quotient agrees with T's. Pure order-theoretic / dimension-counting argument once the keystone is in hand.",
+      "eigenvalue_maxmin_lower / eigenvalue_maxmin_upper (keystone, #25063): the bound-form Courant–Fischer max–min characterisation of the descending k-th eigenvalue — an optimal (k+1)-dimensional eigenspan with all Rayleigh quotients ≥ μ(k) exists (lower), and every (k+1)-dimensional subspace contains a nonzero vector with Rayleigh quotient ≤ μ(k) (upper). This is the documented Mathlib gap; only extreme top/bottom Rayleigh cases existed before.",
+      "exists_rayleigh_le_in_subspace (keystone): index-set-parametrised upper half — any subspace S with finrank E < finrank S + J.card meets the eigenspan over J nontrivially (dimension count), and there the Rayleigh quotient is ≤ max over J; the reusable engine behind both the keystone upper half and the assembly lower bound.",
+      "rayleigh_bounds_on_eigenspan (keystone): the Rayleigh quotient of any nonzero vector in the eigenspan over an index set I is a convex combination of {μ i : i ∈ I}, hence lies in [inf' I μ, sup' I μ] — proved via the orthonormal repr expansion, ⟪Tx,x⟫ = Σ |⟨b_i,x⟩|² μ_i and ‖x‖² = Σ |⟨b_i,x⟩|².",
+      "finrank_span_image_eq_card (keystone): the eigenspan over a finite index set I has dimension exactly I.card (orthonormal ⇒ linearly independent ⇒ finrank_span_eq_card), supplying the dimension bookkeeping for the codimension-one intersection count."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Submodule.finrank_sup_add_finrank_inf_eq",
+        "description": "finrank(V ⊔ W) + finrank(V ⊓ W) = finrank V + finrank W — the dimension identity giving the nontrivial intersection of a (k+1)-dim subspace with a codimension-one eigenspan",
+        "module": "Mathlib.LinearAlgebra.FiniteDimensional"
+      },
+      {
+        "theorem": "finrank_span_eq_card",
+        "description": "the span of a linearly independent family has dimension equal to the cardinality of its index type — converts orthonormality of an eigen-subfamily into the eigenspan dimension I.card",
+        "module": "Mathlib.LinearAlgebra.Finrank"
+      },
+      {
+        "theorem": "OrthonormalBasis.repr / orthonormal_iff_ite",
+        "description": "the orthonormal coordinate expansion x = Σ ⟨b_i,x⟩ b_i with ⟨b_i,b_j⟩ = δ_ij — used to write the Rayleigh quotient as a convex combination of eigenvalues",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Submodule.finrank_map_subtype_eq",
+        "description": "finrank of a submodule of H pushed into the ambient space via H.subtype is unchanged — used to transport the optimal subspace between H and V in both interlacing directions",
+        "module": "Mathlib.LinearAlgebra.FiniteDimensional"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Cauchy's interlacing theorem (1829) states that deleting a row and its matching column from a Hermitian matrix produces a principal submatrix whose eigenvalues interlace those of the original: λ_k ≤ μ_k ≤ λ_{k+1} in ascending order. It is a cornerstone of spectral graph theory (vertex-deleted eigenvalue bounds), numerical linear algebra (divide-and-conquer eigensolvers), and the theory of orthogonal polynomials, and underlies the Marcus–Spielman–Srivastava resolution of Kadison–Singer. The textbook proof runs through the Courant–Fischer max–min characterisation of eigenvalues — which Mathlib did not provide beyond the two extreme (largest/smallest) Rayleigh cases. This entry builds the missing k-th max–min keystone and assembles interlacing from it.",
+    "problemStatement": "For a symmetric operator T on a finite-dimensional inner product space V of dimension n+1 with descending eigenvalues λ, and a symmetric operator TH on a codimension-one subspace H (dim n) whose Rayleigh quotient agrees with T's on H, show the eigenvalues μ of TH interlace those of T: λ(k+1) ≤ μ(k) ≤ λ(k) for every k (descending convention).",
+    "text": "The result is the operator/compression form of Cauchy interlacing. The Rayleigh-agreement hypothesis is exactly what the orthogonal compression of T to H (i.e. the principal-submatrix operator) satisfies, so the theorem specialises to the classical matrix statement once H is taken to be a coordinate hyperplane.",
+    "proofStrategy": "Prove the bound-form Courant–Fischer max–min characterisation of the descending k-th eigenvalue (the keystone), then assemble interlacing by dimension counting. Keystone lower half: the eigenspan span{b_0,…,b_k} is (k+1)-dimensional and every nonzero Rayleigh quotient on it is ≥ μ_k (the Rayleigh quotient is a convex combination of the eigenvalues indexed by the span). Keystone upper half: any (k+1)-dimensional subspace meets span{b_k,…,b_{n-1}} (dimensions sum to n+1 > n), where the Rayleigh quotient is ≤ μ_k. Assembly upper bound μ_k ≤ λ_{k.castSucc}: push the optimal (k+1)-dim eigenspan for TH into V and apply the keystone upper half for T. Assembly lower bound λ_{k.succ} ≤ μ_k: take the optimal (k+2)-dim eigenspan for T; its intersection with H has dimension ≥ k+1 (codimension-one count), pull it back to H and apply the index-set upper half for TH. Rayleigh-agreement transports the bounds across the compression.",
+    "keyInsights": [
+      "**The k-th max–min is the whole content.** Cauchy interlacing reduces entirely to the Courant–Fischer characterisation of the descending k-th eigenvalue. Mathlib had only the extreme Rayleigh cases (largest/smallest eigenvalue); the k-th case is built here from scratch over an orthonormal eigenbasis.",
+      "**Bound form dodges lattice junk.** Rather than an iSup/iInf identity (which carries conditionally-complete-lattice junk values needing explicit BddAbove/BddBelow discharge), the keystone is phrased as an existence/universal bound pair carrying the same information — `max_{dim S=k+1} min_{0≠x∈S} R(x) = μ_k` — but staying junk-free.",
+      "**Rayleigh quotient = convex combination of eigenvalues.** On the eigenspan over an index set I, ⟪Tx,x⟫/‖x‖² = Σ_{i∈I} w_i μ_i with weights w_i = |⟨b_i,x⟩|²/‖x‖² summing to 1, so the quotient lies between the smallest and largest eigenvalue in I. This single lemma drives both keystone halves.",
+      "**Interlacing is then pure dimension counting.** With the keystone in hand the two inequalities follow by intersecting optimal subspaces with the codimension-one H: a (k+1)-dim space inside H meets the high eigenspan, and a (k+2)-dim space in V drops to ≥(k+1) dimensions inside H. No further spectral input.",
+      "**Compression form isolates the matrix bridge.** Stating the link between T and TH as a Rayleigh-agreement hypothesis keeps the assembly purely order-theoretic and reusable; the matrix Cauchy interlacing theorem is the instantiation H = coordinate hyperplane, TH = orthogonal compression."
+    ],
+    "prerequisites": [
+      "The spectral theorem for symmetric operators: orthonormal eigenbasis b with T(b_i) = μ_i • b_i (Mathlib's InnerProductSpace spectral API)",
+      "Rayleigh quotient ⟪Tx,x⟫/‖x‖² and its convex-combination expansion in an orthonormal eigenbasis",
+      "Dimension counting: finrank(V⊔W) + finrank(V⊓W) = finrank V + finrank W, and finrank of a span of an orthonormal subfamily",
+      "The Courant–Fischer max–min principle for eigenvalues (built here for the k-th eigenvalue)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Compression Interface and Statement",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "File header: the interlacing inequalities to be proved, the compression interface (Rayleigh-agreement hypothesis as the only link between T and TH, satisfied by the orthogonal compression / principal submatrix), and the two-direction proof outline.",
+      "mathContext": "Frames interlacing in the abstract operator/compression form so the assembly is purely order-theoretic; the spectral theorem on H and the compression construction supply the hypotheses when specialising to matrices."
+    },
+    {
+      "id": "statement",
+      "title": "cauchy_interlacing: the theorem",
+      "startLine": 63,
+      "endLine": 96,
+      "summary": "Statement of cauchy_interlacing: symmetric T on (n+1)-dim V with antitone eigenvalues λ and eigenbasis b; symmetric TH on codim-one H with antitone eigenvalues μ and eigenbasis bH; Rayleigh-agreement on H; conclusion λ(k.succ) ≤ μ(k) ∧ μ(k) ≤ λ(k.castSucc).",
+      "mathContext": "In ascending textbook notation this reads λ_k ≤ μ_k ≤ λ_{k+1}; the descending convention used here matches Mathlib's sorted eigenvalues."
+    },
+    {
+      "id": "lower-bound",
+      "title": "Lower Bound λ(k.succ) ≤ μ(k)",
+      "startLine": 97,
+      "endLine": 122,
+      "summary": "Take the optimal (k+2)-dim eigenspan S for T (keystone lower half at k.succ); S ⊓ H has dimension ≥ k+1 by the codimension-one count; pull it back into H and apply the index-set upper half exists_rayleigh_le_in_subspace for TH to find a vector with Rayleigh ≤ μ(k); that vector lies in S, so λ(k.succ) ≤ R_T = R_TH ≤ μ(k).",
+      "mathContext": "The dimension drop from k+2 to k+1 under intersection with a hyperplane is the heart of the lower interlacing inequality."
+    },
+    {
+      "id": "upper-bound",
+      "title": "Upper Bound μ(k) ≤ λ(k.castSucc)",
+      "startLine": 123,
+      "endLine": 139,
+      "summary": "Take the optimal (k+1)-dim eigenspan SH for TH (keystone lower half on H); push it into V; the keystone upper half for T finds a nonzero vector in it with Rayleigh ≤ λ(k.castSucc); Rayleigh-agreement turns the ≥ μ(k) lower bound on SH into the same bound for that vector, giving μ(k) ≤ λ(k.castSucc).",
+      "mathContext": "Here the optimal subspace already lives inside H, so no dimension drop is needed — the bound transports directly through Rayleigh-agreement."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 proof of Cauchy eigenvalue interlacing in operator/compression form, assembled from a from-scratch bound-form Courant–Fischer max–min characterisation of the descending k-th eigenvalue (the keystone, #25063, the one documented Mathlib gap). Both files are 0-axiom, 0-sorry. The assembly is a pure dimension-counting argument; all spectral content lives in the keystone's convex-combination Rayleigh bound.",
+    "implications": "Supplies the reusable k-th Courant–Fischer max–min keystone absent from Mathlib (independently useful for Weyl's inequality, Lidskii's theorem, and spectral graph eigenvalue bounds), and the interlacing inequality for compressions. Specialising H to a coordinate hyperplane and TH to the orthogonal compression yields the classical matrix Cauchy interlacing theorem.",
+    "openQuestions": [
+      "Instantiate the compression form to the literal matrix statement: build TH as the orthogonal compression of a Hermitian matrix to a coordinate hyperplane and discharge the Rayleigh-agreement hypothesis from the spectral theorem on H.",
+      "The general 'delete m rows/columns' interlacing λ_k ≤ μ_k ≤ λ_{k+m}, by iterating the codimension-one case or a direct (k+...)-dimensional count.",
+      "Package the keystone's bound form as an iSup/iInf equality with the BddAbove/BddBelow obligations discharged, for downstream Weyl/Lidskii applications."
+    ]
+  },
+  "crossReferences": [],
+  "references": [
+    {
+      "authors": [
+        "Cauchy, A.-L."
+      ],
+      "title": "Sur l'équation à l'aide de laquelle on détermine les inégalités séculaires des mouvements des planètes",
+      "year": "1829",
+      "venue": "Exercices de mathématiques 4",
+      "note": "Original interlacing / secular-equation theorem for symmetric matrices"
+    },
+    {
+      "authors": [
+        "Courant, R.",
+        "Hilbert, D."
+      ],
+      "title": "Methods of Mathematical Physics, Vol. I",
+      "year": "1953",
+      "venue": "Interscience Publishers",
+      "note": "Min-max (Courant–Fischer) variational characterisation of eigenvalues, the route used here"
+    },
+    {
+      "authors": [
+        "Horn, R.A.",
+        "Johnson, C.R."
+      ],
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "Theorem 4.3.17 (Cauchy interlacing) and the Courant–Fischer theorem (4.2.6)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CauchyInterlacingKeystone"
+    ],
+    "opens": [
+      "InnerProductSpace"
+    ],
+    "namespace": "CauchyInterlacing.Assembly",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyInterlacingAssembly.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Productionizes the **Cauchy eigenvalue interlacing** assembly (compression form) on top of the merged Courant–Fischer max–min keystone (#25063). An orphan `CauchyInterlacingAssembly.lean` left by a prior crashed session did not compile; this PR fixes it, verifies it under Docker, and registers the first gallery entry for `cauchy-interlacing-theorem`.

## What's proved

`cauchy_interlacing` — for a symmetric operator `T` on `V` (dim `n+1`) with antitone eigenvalues `λ` and a symmetric operator `TH` on a codimension-one subspace `H` (dim `n`) whose Rayleigh quotient agrees with `T`'s on every nonzero `y ∈ H`:

```
λ(k.succ) ≤ μ(k)  ∧  μ(k) ≤ λ(k.castSucc)     (descending convention)
```

i.e. the textbook interlacing `λ_k ≤ μ_k ≤ λ_{k+1}`.

The Rayleigh-agreement hypothesis is exactly the defining property of the **orthogonal compression** of `T` to `H` (the principal-submatrix operator), so the result specialises to the classical matrix Cauchy interlacing theorem.

## The bug that was fixed

The orphan failed to build with `failed to synthesize Min/Max (Type)` — `Module.finrank 𝕜 (S ⊓ H)` elaborated `⊓`/`⊔` at the `Type` level. Fixed with `: Submodule 𝕜 V` ascriptions (the pattern the keystone already uses), preserving the `omega` atom matching against `Submodule.finrank_sup_add_finrank_inf_eq`.

## Proof shape

Pure dimension counting once the keystone is available:
- **Upper** `μ_k ≤ λ_{k.castSucc}`: push the optimal `(k+1)`-dim eigenspan for `TH` into `V`, apply the keystone upper half for `T`, transport via Rayleigh-agreement.
- **Lower** `λ_{k.succ} ≤ μ_k`: take the optimal `(k+2)`-dim eigenspan for `T`; the codimension-one count gives `finrank(S ⊓ H) ≥ k+1`, pull back into `H` and apply the index-set upper half for `TH`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CauchyInterlacingAssembly` → **GREEN**, 7744 jobs (imports + checks the keystone too).
- **0 sorries, 0 axiom declarations, no `native_decide`.**

## Honesty note

This is the **operator/compression form**. The matrix-to-compression instantiation (build `TH` as the orthogonal compression of a Hermitian matrix to a coordinate hyperplane and discharge Rayleigh-agreement from the spectral theorem on `H`) is the remaining bridge — documented in the entry's open questions, **not** assumed away. The `hRayleigh` link is a theorem hypothesis, not a structure-encoded global assumption, so the result is genuinely 0-axiom.

## Files

- `proofs/Proofs/CauchyInterlacingAssembly.lean` (139 lines, 1 theorem) — the interlacing assembly
- `src/data/proofs/cauchy-interlacing-theorem/{meta.json,annotations.json}` — gallery entry (meta + 4 annotations), badge `original`, status `verified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)