### PR TITLE
research(group-order-prime-squared-abelian-oq-01): order-p² abelian + cyclic/elementary-abelian dichotomy [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/GroupOrderPrimeSquaredAbelian.lean
+++ b/proofs/Proofs/GroupOrderPrimeSquaredAbelian.lean
@@ -1,0 +1,104 @@
+/-
+  Groups of Order p² are Abelian — with the Cyclic / Elementary-Abelian Dichotomy
+
+  Open question OQ-01 (parent: group-order-prime-squared-abelian).
+
+  The first nontrivial step in the classification of finite p-groups: every group
+  `G` of order `p²` (`p` prime) is abelian. Mathlib proves the bare commutativity
+  via `IsPGroup.commutative_of_card_eq_prime_sq` (the center is nontrivial, so the
+  central quotient `G/Z(G)` has order `1` or `p`, hence is cyclic, hence `G` is
+  abelian). This entry packages that result from the *order hypothesis* alone and
+  then goes further, supplying the **structural classification** that Mathlib does
+  not state:
+
+      |G| = p²  ⟹  G is cyclic (≅ ℤ/p²)   XOR   every element satisfies gᵖ = 1
+                                                  (elementary abelian, ≅ (ℤ/p)²).
+
+  ## Contents
+
+  * `mul_comm_of_card_eq_prime_sq` — the abelian theorem, stated from `Nat.card G = p²`.
+  * `orderOf_eq_of_card_eq_prime_sq` — every element has order `1`, `p`, or `p²`
+    (Lagrange + the divisors of a prime square).
+  * `isCyclic_or_exponent_p` — the structural dichotomy: `G` is cyclic, or `G` has
+    exponent `p` (i.e. `∀ g, gᵖ = 1`).
+  * `pow_prime_eq_one_of_not_isCyclic` — the non-cyclic case is elementary abelian.
+  * `isCyclic_iff_not_forall_pow_prime` — the two cases are mutually exclusive, so the
+    dichotomy is sharp: `G` is cyclic *iff* it does not have exponent `p`.
+
+  Everything is elementary group theory over a finite group; no axioms, no sorries.
+-/
+import Mathlib
+
+namespace GroupOrderPrimeSq
+
+variable {G : Type*} [Group G]
+
+/-! ## The abelian theorem -/
+
+/-- **A group of order `p²` is abelian.** Stated from the order hypothesis
+`Nat.card G = p²` with `p` prime. This repackages
+`IsPGroup.commutative_of_card_eq_prime_sq` (whose proof routes through the
+nontrivial center and the cyclic central quotient) so that the only hypotheses are
+the cardinality and primality. -/
+theorem mul_comm_of_card_eq_prime_sq {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2) :
+    ∀ a b : G, a * b = b * a := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  exact IsPGroup.commutative_of_card_eq_prime_sq hG
+
+/-! ## Element orders -/
+
+/-- **Trichotomy of element orders.** In a group of order `p²` (`p` prime) every
+element has order `1`, `p`, or `p²`: its order divides `p²` (Lagrange), and the only
+divisors of a prime square are `1`, `p`, `p²`. -/
+theorem orderOf_eq_of_card_eq_prime_sq {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2)
+    (g : G) : orderOf g = 1 ∨ orderOf g = p ∨ orderOf g = p ^ 2 := by
+  have hdvd : orderOf g ∣ p ^ 2 := hG ▸ orderOf_dvd_natCard g
+  obtain ⟨k, hk, hke⟩ := (Nat.dvd_prime_pow hp).mp hdvd
+  interval_cases k
+  · exact Or.inl (by simpa using hke)
+  · exact Or.inr (Or.inl (by simpa using hke))
+  · exact Or.inr (Or.inr hke)
+
+/-! ## The structural dichotomy -/
+
+/-- **Cyclic or elementary abelian.** A group of order `p²` (`p` prime) is either
+cyclic — there is an element of order `p²` generating it — or it has exponent `p`,
+meaning `gᵖ = 1` for every `g` (so it is elementary abelian, `≅ (ℤ/p)²`). The split
+is on whether an element of order `p²` exists; if not, the trichotomy forces every
+order to divide `p`. -/
+theorem isCyclic_or_exponent_p {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2) :
+    IsCyclic G ∨ ∀ g : G, g ^ p = 1 := by
+  by_cases h : ∃ g : G, orderOf g = p ^ 2
+  · obtain ⟨g, hg⟩ := h
+    haveI : Finite G := Nat.finite_of_card_ne_zero (hG ▸ pow_ne_zero 2 hp.pos.ne')
+    exact Or.inl (isCyclic_of_orderOf_eq_card g (by rw [hg, hG]))
+  · push_neg at h
+    refine Or.inr (fun g => ?_)
+    rcases orderOf_eq_of_card_eq_prime_sq hp hG g with h1 | hp' | hsq
+    · rw [← orderOf_dvd_iff_pow_eq_one, h1]; exact one_dvd p
+    · rw [← orderOf_dvd_iff_pow_eq_one, hp']
+    · exact absurd hsq (h g)
+
+/-- **The non-cyclic case is elementary abelian.** If a group of order `p²` is not
+cyclic, then every element satisfies `gᵖ = 1` (exponent `p`). -/
+theorem pow_prime_eq_one_of_not_isCyclic {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2)
+    (hnc : ¬ IsCyclic G) (g : G) : g ^ p = 1 :=
+  (isCyclic_or_exponent_p hp hG).resolve_left hnc g
+
+/-- **The dichotomy is sharp (mutually exclusive cases).** A group of order `p²`
+(`p` prime) is cyclic *iff* it does not have exponent `p`. The forward direction uses
+that a cyclic group of order `p²` has a generator of order `p²`, which cannot satisfy
+`gᵖ = 1` since `p² ∤ p`; the reverse is the dichotomy. -/
+theorem isCyclic_iff_not_forall_pow_prime {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2) :
+    IsCyclic G ↔ ¬ ∀ g : G, g ^ p = 1 := by
+  haveI : Finite G := Nat.finite_of_card_ne_zero (hG ▸ pow_ne_zero 2 hp.pos.ne')
+  constructor
+  · intro hc hall
+    obtain ⟨g, hg⟩ := isCyclic_iff_exists_orderOf_eq_natCard.mp hc
+    have hdvd : orderOf g ∣ p := orderOf_dvd_iff_pow_eq_one.mpr (hall g)
+    have hle : p ^ 2 ≤ p := Nat.le_of_dvd hp.pos (by rwa [hg, hG] at hdvd)
+    nlinarith [hp.two_le]
+  · intro h
+    exact (isCyclic_or_exponent_p hp hG).resolve_right h
+
+end GroupOrderPrimeSq

--- a/src/data/proofs/group-order-prime-squared-abelian-oq-01/meta.json
+++ b/src/data/proofs/group-order-prime-squared-abelian-oq-01/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "group-order-prime-squared-abelian-oq-01",
+  "title": "Groups of Order p² Are Abelian — with the Cyclic / Elementary-Abelian Dichotomy",
+  "slug": "group-order-prime-squared-abelian-oq-01",
+  "description": "Every group G of order p² (p prime) is abelian, and beyond the bare commutativity this entry supplies the structural classification Mathlib does not state: such a G is either cyclic (≅ ℤ/p²) or has exponent p (every element satisfies gᵖ = 1, the elementary-abelian (ℤ/p)² case). The split is sharp — G is cyclic iff it does not have exponent p — and rests on the order trichotomy that every element has order 1, p, or p² by Lagrange.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GroupOrderPrimeSquaredAbelian.lean",
+    "tags": [
+      "group-theory",
+      "finite-groups",
+      "p-groups",
+      "abelian-groups",
+      "cyclic-groups",
+      "lagrange-theorem",
+      "algebra"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "lineCount": 104,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "None beyond the stated theorem hypotheses (Nat.card G = p² with p prime). 0 axioms, 0 sorries, no native_decide. The abelian theorem repackages Mathlib's IsPGroup.commutative_of_card_eq_prime_sq from the order hypothesis alone; the order trichotomy, the cyclic/exponent-p dichotomy, and its sharpness are proved here from Lagrange (orderOf_dvd_natCard) and the divisor structure of a prime square — content Mathlib does not provide.",
+    "originalContributions": [
+      "mul_comm_of_card_eq_prime_sq: a group of order p² is abelian, stated from the cardinality hypothesis Nat.card G = p² (p prime) rather than from a packaged IsPGroup instance. Repackages IsPGroup.commutative_of_card_eq_prime_sq (whose proof routes through the nontrivial center and the cyclic central quotient G/Z(G)) so the only hypotheses are cardinality and primality.",
+      "orderOf_eq_of_card_eq_prime_sq: the order trichotomy — in a group of order p² every element has order 1, p, or p². Lagrange gives orderOf g ∣ p²; the only divisors of a prime square are 1, p, p² (Nat.dvd_prime_pow + interval_cases on the exponent).",
+      "isCyclic_or_exponent_p: the structural dichotomy — G is cyclic (an element of order p² generates it, isCyclic_of_orderOf_eq_card) or G has exponent p (∀ g, gᵖ = 1). Case split on whether an element of order p² exists; if not, the trichotomy forces every order to divide p.",
+      "pow_prime_eq_one_of_not_isCyclic: the non-cyclic case is elementary abelian — if G of order p² is not cyclic then gᵖ = 1 for every g. Direct corollary of the dichotomy.",
+      "isCyclic_iff_not_forall_pow_prime: the dichotomy is sharp / the two cases are mutually exclusive — G is cyclic iff it does NOT have exponent p. Forward direction: a generator has order p² = card G, which cannot divide p, so it fails gᵖ = 1; reverse is the dichotomy."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "IsPGroup.commutative_of_card_eq_prime_sq",
+        "description": "a group whose cardinality is the square of a prime is commutative — proved in Mathlib via the nontrivial center and the cyclic central quotient G/Z(G); the abelian half of this entry packages it from the order hypothesis",
+        "module": "Mathlib.GroupTheory.PGroup"
+      },
+      {
+        "theorem": "orderOf_dvd_natCard",
+        "description": "Lagrange: the order of any element divides the cardinality of the group — gives orderOf g ∣ p² and seeds the order trichotomy",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "Nat.dvd_prime_pow",
+        "description": "the divisors of pⁿ are exactly the pᵏ for k ≤ n — with interval_cases yields the three possible element orders 1, p, p²",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "isCyclic_of_orderOf_eq_card",
+        "description": "an element whose order equals the cardinality of a finite group generates it, making the group cyclic — the cyclic branch of the dichotomy",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "isCyclic_iff_exists_orderOf_eq_natCard / orderOf_dvd_iff_pow_eq_one",
+        "description": "a finite group is cyclic iff it has an element of order equal to its cardinality, and gⁿ = 1 iff orderOf g ∣ n — together they make the sharpness (mutual exclusivity) of the dichotomy a clean divisibility contradiction p² ∤ p",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Classifying the groups of small order is the first chapter of finite group theory, and the order-p² case is its first genuinely structural step beyond Lagrange and Cauchy. The result splits into two classical facts: every group of order p² is abelian (a consequence of the nontrivial center of a p-group, since the central quotient cannot be a nontrivial cyclic group without forcing commutativity), and every abelian group of order p² is either cyclic ℤ/p² or the elementary abelian (ℤ/p)² — exactly the two abelian groups of that order. Together they give the complete classification: up to isomorphism there are precisely two groups of order p², both abelian. Mathlib proves the commutativity (IsPGroup.commutative_of_card_eq_prime_sq) but stops short of the cyclic/elementary-abelian dichotomy; this entry adds it.",
+    "problemStatement": "Let G be a group with Nat.card G = p² for a prime p. Show (1) G is abelian; (2) every element of G has order 1, p, or p²; (3) G is either cyclic or has exponent p (∀ g, gᵖ = 1); and (4) these two cases are mutually exclusive — G is cyclic iff it does not have exponent p.",
+    "text": "The dichotomy isolates the structural content the bare commutativity theorem omits. Combined with the classification of finite abelian groups it pins down G up to isomorphism: cyclic ⇒ ℤ/p², exponent p ⇒ (ℤ/p)². The exponent-p formulation (∀ g, gᵖ = 1) is the typeclass-free shadow of elementary-abelianness and is what downstream arguments (e.g. counting elements of each order, building the Frattini quotient) actually consume.",
+    "proofStrategy": "Abelian: apply IsPGroup.commutative_of_card_eq_prime_sq after supplying the Fact p.Prime instance. Order trichotomy: orderOf g ∣ p² by Lagrange, and Nat.dvd_prime_pow lists the divisors as pᵏ for k ≤ 2, so interval_cases on k gives orders 1, p, p². Dichotomy: case-split on ∃ g, orderOf g = p². If such g exists, isCyclic_of_orderOf_eq_card makes G cyclic. Otherwise the trichotomy collapses every order to 1 or p, so orderOf g ∣ p and gᵖ = 1 for all g. Sharpness: a cyclic G of order p² has a generator of order p² = card G; if it also had exponent p then orderOf(generator) ∣ p, i.e. p² ∣ p, impossible for p ≥ 2 (nlinarith).",
+    "keyInsights": [
+      "**Commutativity is only half the story.** The named Mathlib result stops at 'G is abelian'; the mathematically informative statement is the cyclic vs. elementary-abelian dichotomy, which determines G up to isomorphism. This entry supplies that second half.",
+      "**The whole dichotomy rides on one trichotomy.** Once Lagrange + the divisor structure of p² pin every element order to {1, p, p²}, the structure theorem is immediate: existence of a p²-order element ⇔ cyclic, its absence ⇔ exponent p.",
+      "**Exponent p is the usable form of elementary-abelian.** Phrasing the non-cyclic case as ∀ g, gᵖ = 1 keeps it typeclass-free and order-theoretic, avoiding any commitment to a (ℤ/p)² isomorphism while carrying the same information for downstream use.",
+      "**Sharpness is a one-line divisibility contradiction.** Mutual exclusivity reduces to p² ∤ p: a generator's order p² cannot divide p, so a cyclic group of order p² can never have exponent p."
+    ],
+    "prerequisites": [
+      "Lagrange's theorem in the form orderOf g ∣ Nat.card G",
+      "The divisor structure of a prime power (Nat.dvd_prime_pow)",
+      "The characterisation of finite cyclic groups via an element of order equal to the cardinality",
+      "p-group facts behind IsPGroup.commutative_of_card_eq_prime_sq: nontrivial center and cyclic central quotient"
+    ]
+  },
+  "sections": [
+    {
+      "id": "abelian",
+      "title": "The Abelian Theorem",
+      "startLine": 36,
+      "endLine": 46,
+      "summary": "mul_comm_of_card_eq_prime_sq: from Nat.card G = p² (p prime) conclude ∀ a b, a*b = b*a, by supplying the Fact p.Prime instance and invoking IsPGroup.commutative_of_card_eq_prime_sq.",
+      "mathContext": "The commutativity comes from the nontrivial center of a p-group: G/Z(G) has order 1 or p, hence is cyclic, which forces G abelian. This entry restates it from the order hypothesis alone."
+    },
+    {
+      "id": "trichotomy",
+      "title": "Order Trichotomy",
+      "startLine": 48,
+      "endLine": 60,
+      "summary": "orderOf_eq_of_card_eq_prime_sq: every element has order 1, p, or p². orderOf g ∣ p² by Lagrange; Nat.dvd_prime_pow + interval_cases enumerate the prime-power divisors.",
+      "mathContext": "The divisor lattice of p² is the chain 1 | p | p²; element orders are confined to it. This is the combinatorial engine for the dichotomy."
+    },
+    {
+      "id": "dichotomy",
+      "title": "Cyclic or Exponent p",
+      "startLine": 62,
+      "endLine": 86,
+      "summary": "isCyclic_or_exponent_p: case-split on the existence of an element of order p². If present, isCyclic_of_orderOf_eq_card gives cyclicity; otherwise the trichotomy forces orderOf g ∣ p, so gᵖ = 1 for all g. pow_prime_eq_one_of_not_isCyclic packages the non-cyclic branch.",
+      "mathContext": "This is the structural classification: ℤ/p² (cyclic) versus (ℤ/p)² (exponent p / elementary abelian), the only two groups of order p²."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness of the Dichotomy",
+      "startLine": 88,
+      "endLine": 104,
+      "summary": "isCyclic_iff_not_forall_pow_prime: G is cyclic iff it does NOT have exponent p. Forward direction derives p² ∣ p from a generator of order p² satisfying gᵖ = 1 and refutes it with nlinarith; reverse direction is the dichotomy.",
+      "mathContext": "Establishes the two cases are mutually exclusive, so the dichotomy is a genuine classification rather than an inclusive 'or'."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 proof that every group of order p² (p prime) is abelian, extended with the structural classification Mathlib omits: such a group is either cyclic (ℤ/p²) or has exponent p (elementary abelian (ℤ/p)²), and the two cases are mutually exclusive. 5 theorems, 104 lines, 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Completes the order-p² classification to the level a structural argument needs: combined with the classification of finite abelian groups it identifies G up to isomorphism. The exponent-p / order-trichotomy lemmas are reusable for element-counting and Frattini-quotient arguments in larger p-group classifications.",
+    "openQuestions": [
+      "Upgrade the dichotomy to an explicit isomorphism: G ≃* Multiplicative (ZMod (p^2)) in the cyclic case and G ≃* (Multiplicative (ZMod p) × Multiplicative (ZMod p)) in the exponent-p case, via the classification of finite abelian groups.",
+      "The next classification rung: groups of order p³, where non-abelian examples first appear (the Heisenberg group mod p and the modular group of order p³).",
+      "Count elements of each order from the trichotomy: an exponent-p group of order p² has exactly p² − 1 elements of order p, a cyclic one has p² − p; formalise these counts."
+    ]
+  },
+  "crossReferences": [],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "John Wiley & Sons, 3rd ed.",
+      "note": "Corollary to the class equation: groups of order p² are abelian; §5.2 classification of finite abelian groups giving the ℤ/p² vs (ℤ/p)² dichotomy"
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "Springer GTM 148, 4th ed.",
+      "note": "Theorem 4.4 and surrounding material on p-groups, the nontrivial center, and order-p² groups"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "GroupOrderPrimeSq",
+    "lineCount": 104,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/GroupOrderPrimeSquaredAbelian.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **group-order-prime-squared-abelian-oq-01**: every group `G` of order `p²` (`p` prime) is abelian, extended with the structural classification Mathlib does **not** state.

The bare commutativity is Mathlib's `IsPGroup.commutative_of_card_eq_prime_sq`. This entry repackages it from the order hypothesis alone and goes further:

> `|G| = p²` ⟹ `G` cyclic (`≅ ℤ/p²`) **XOR** `G` has exponent `p` (`∀ g, gᵖ = 1`, the elementary-abelian `(ℤ/p)²` case)

and proves the two cases are **mutually exclusive** (`G` cyclic ⇔ not exponent `p`), so it is a genuine classification — up to isomorphism the only two groups of order `p²`.

## Theorems (5, all 0-axiom / 0-sorry)

| Theorem | Content |
|---|---|
| `mul_comm_of_card_eq_prime_sq` | `G` of order `p²` is abelian, from `Nat.card G = p²` |
| `orderOf_eq_of_card_eq_prime_sq` | order trichotomy: every element has order `1`, `p`, or `p²` (Lagrange + divisors of `p²`) |
| `isCyclic_or_exponent_p` | the dichotomy: cyclic, or `∀ g, gᵖ = 1` |
| `pow_prime_eq_one_of_not_isCyclic` | non-cyclic ⇒ elementary abelian |
| `isCyclic_iff_not_forall_pow_prime` | sharpness: cyclic ⇔ ¬ exponent `p` (the `p² ∤ p` contradiction) |

## Method

Order trichotomy from `orderOf_dvd_natCard` + `Nat.dvd_prime_pow` + `interval_cases`; the dichotomy case-splits on existence of a `p²`-order element (`isCyclic_of_orderOf_eq_card` for the cyclic branch). Pure elementary finite group theory.

## Verification

- **Build GREEN** via Docker wrapper (`Proofs.GroupOrderPrimeSquaredAbelian`, 7743 jobs)
- 104 lines, 0 sorries, 0 `axiom` declarations, no `native_decide`
- Status `verified`, badge `original`

Picked up and productionized from a complete WIP file left by a crashed prior session (dead PID lock reclaimed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)