### PR TITLE
audit: persist 9 clean audit-tracker marks (break never-audited loop)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17307,8 +17307,62 @@
       "lastAudited": "2026-06-21T00:55:22Z",
       "result": "clean",
       "issues": []
+    },
+    "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T03:01:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "catalan-numbers-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T03:01:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-interlacing-theorem": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T03:01:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "compactness-finite-subcover-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T03:01:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "derangements-convergence-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T03:01:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "group-order-prime-squared-abelian-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T03:01:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "kummer-theorem-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T03:01:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "newton-power-sum-identities-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T03:01:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T03:01:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T00:55:22Z"
+  "lastUpdated": "2026-06-21T03:01:30Z"
 }


### PR DESCRIPTION
## Summary

The 9 most recently merged gallery entries were never recorded in `audit-tracker.json`'s entries map. Every auditor cycle re-flagged them as "never audited" and re-audited them CLEAN, but the clean-mark write only ever landed in a local working copy that the next `git reset --hard origin/main` wiped. This commits the clean marks so they persist.

## Verification (HEAD c05fbe6)

All 9 substantively re-verified CLEAN this cycle:
- 0 code-level sorries, 0 `axiom` declarations
- No `native_decide`/`admit` (the only grep hit, in CompactnessFiniteSubcoverOq02, is the word "admits" in a docstring)

## Effect

`find-targets.ts --stats`: Unaudited **9 → 0**, with-issues 0, critical 0.

## Entries marked clean
amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01, catalan-numbers-oq-01-oq-01, cauchy-interlacing-theorem, compactness-finite-subcover-oq-02, derangements-convergence-oq-03-oq-02, group-order-prime-squared-abelian-oq-01, kummer-theorem-oq-04-oq-01, newton-power-sum-identities-oq-01-oq-01, pythagorean-triples-oq-04-oq-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)