### PR TITLE
research(maschke-theorem-oq-01-oq-01): the modular counterexample — 𝔽_p[ℤ/p] is not semisimple (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs/MaschkeModularCounterexampleOQ01.lean
+++ b/proofs/Proofs/MaschkeModularCounterexampleOQ01.lean
@@ -1,0 +1,139 @@
+import Mathlib
+
+/-!
+# The modular counterexample to Maschke's theorem: `𝔽_p[ℤ/p]` is not semisimple
+
+Maschke's theorem (the parent entry `maschke-theorem-oq-01`) asserts that for a finite group
+`G` and a field `k` with `char k ∤ |G|`, every representation is completely reducible and the
+group algebra `k[G]` is a semisimple ring.  The hypothesis `char k ∤ |G|` is **essential**:
+this file records the cleanest witness to its sharpness.
+
+Take `k = 𝔽_p` and `G = ℤ/p` (so `char k = p` divides `|G| = p`).  Then the group algebra
+
+```
+A = 𝔽_p[ℤ/p]
+```
+
+is **not** semisimple.  The obstruction is a single nonzero nilpotent element.  Writing
+`g` for the basis generator indexed by `1 ∈ ℤ/p`, the *freshman's dream* in characteristic
+`p` gives
+
+```
+(g - 1) ^ p = g ^ p - 1 ^ p = 1 - 1 = 0,
+```
+
+since `g ^ p = 1` (the group element has order `p`), while `g - 1 ≠ 0`.  Thus `A` contains a
+nonzero nilpotent, so it is **not reduced**.  A commutative semisimple ring is reduced
+(`Mathlib`'s low-priority instance `IsSemisimpleRing → IsReduced` for commutative rings, a
+consequence of `Ring.jacobson A = ⊥`), so `A` cannot be semisimple.  Equivalently, complete
+reducibility fails: some submodule (the augmentation ideal, generated here by `g - 1`) has no
+complement.
+
+The element `g - 1` is precisely a generator of the **augmentation ideal**
+`I = ker(ε)` where `ε : 𝔽_p[ℤ/p] → 𝔽_p`, `∑ a_g g ↦ ∑ a_g`; the short exact sequence
+`0 → I → 𝔽_p[ℤ/p] → 𝔽_p → 0` does not split.  Unlike a `p = 2` `decide` check, the argument
+below is uniform in the prime `p`.
+
+## What this file packages
+
+* `MaschkeModularCounterexample.g_pow_card` — the generator has order `p`: `g ^ p = 1`.
+* `MaschkeModularCounterexample.g_sub_one_pow_card` — freshman's dream: `(g - 1) ^ p = 0`.
+* `MaschkeModularCounterexample.g_sub_one_ne_zero` — `g - 1 ≠ 0`.
+* `MaschkeModularCounterexample.isNilpotent_g_sub_one` — `g - 1` is a nonzero nilpotent.
+* `MaschkeModularCounterexample.not_isReduced` — `𝔽_p[ℤ/p]` is not reduced.
+* `MaschkeModularCounterexample.not_isSemisimpleRing` — **the counterexample**: `𝔽_p[ℤ/p]`
+  is not a semisimple ring.
+* `MaschkeModularCounterexample.not_isSemisimpleModule` — equivalently, not semisimple as a
+  module over itself.
+* `MaschkeModularCounterexample.exists_submodule_no_complement` — complete reducibility fails:
+  some subrepresentation has no complement.
+
+## References
+
+* H. Maschke, *Beweis des Satzes …*, Math. Ann. 52 (1899) 363-368.
+* R. Brauer, *Über die Darstellung von Gruppen in Galoisschen Feldern*, 1935.
+* Mathlib: `Mathlib/RingTheory/Jacobson/Semiprimary.lean` (semisimple commutative rings are
+  reduced), `Mathlib/Algebra/CharP/Lemmas.lean` (`sub_pow_char`).
+-/
+
+open scoped MonoidAlgebra
+
+namespace MaschkeModularCounterexample
+
+variable (p : ℕ) [hp : Fact p.Prime]
+
+/-- The cyclic group `ℤ/p`, written multiplicatively so that its group algebra is a
+`MonoidAlgebra`. -/
+abbrev G : Type := Multiplicative (ZMod p)
+
+/-- The modular group algebra `A = 𝔽_p[ℤ/p]`, i.e. the regular representation of the cyclic
+group of order `p` over the field with `p` elements. -/
+abbrev A : Type := MonoidAlgebra (ZMod p) (G p)
+
+/-- `A = 𝔽_p[ℤ/p]` has characteristic `p`, inherited from its scalar field `𝔽_p`. -/
+instance : CharP (A p) p := charP_of_injective_algebraMap' (ZMod p) (A := A p) p
+
+/-- The standard generator `g = [1]` of the group algebra: the basis element indexed by the
+additive generator `1 ∈ ℤ/p`. -/
+noncomputable def g : A p :=
+  MonoidAlgebra.single (Multiplicative.ofAdd (1 : ZMod p)) (1 : ZMod p)
+
+/-- **The generator has order `p`.** `g ^ p = 1`, because the underlying group element
+`1 ∈ ℤ/p` satisfies `p • 1 = 0`. -/
+theorem g_pow_card : (g p) ^ p = 1 := by
+  have hp1 : (p • (1 : ZMod p)) = 0 := by
+    rw [nsmul_eq_mul, mul_one]; exact ZMod.natCast_self p
+  show (MonoidAlgebra.single (Multiplicative.ofAdd (1 : ZMod p)) (1 : ZMod p)) ^ p = 1
+  rw [MonoidAlgebra.single_pow, one_pow, ← ofAdd_nsmul, hp1, ofAdd_zero, MonoidAlgebra.one_def]
+
+/-- **Freshman's dream.** In characteristic `p`, `(g - 1) ^ p = g ^ p - 1 ^ p = 1 - 1 = 0`,
+so `g - 1` is nilpotent. -/
+theorem g_sub_one_pow_card : (g p - 1) ^ p = 0 := by
+  rw [sub_pow_char, g_pow_card, one_pow, sub_self]
+
+/-- The generator differs from the identity: `g ≠ 1`, since `1 ≠ 0` in `𝔽_p`. -/
+theorem g_ne_one : g p ≠ 1 := by
+  intro hg
+  rw [show g p = MonoidAlgebra.single (Multiplicative.ofAdd (1 : ZMod p)) (1 : ZMod p) from rfl,
+    MonoidAlgebra.one_def, Finsupp.single_eq_single_iff] at hg
+  rcases hg with ⟨ha, -⟩ | ⟨hb, -⟩
+  · exact one_ne_zero (ofAdd_eq_one.mp ha)
+  · exact one_ne_zero hb
+
+/-- `g - 1 ≠ 0`: the nilpotent witness is genuinely nonzero. -/
+theorem g_sub_one_ne_zero : (g p - 1 : A p) ≠ 0 :=
+  sub_ne_zero.mpr (g_ne_one p)
+
+/-- **The augmentation generator `g - 1` is a nonzero nilpotent.** This single element is the
+entire obstruction to semisimplicity. -/
+theorem isNilpotent_g_sub_one : IsNilpotent (g p - 1 : A p) :=
+  ⟨p, g_sub_one_pow_card p⟩
+
+/-- **`𝔽_p[ℤ/p]` is not reduced.** It contains the nonzero nilpotent `g - 1`. -/
+theorem not_isReduced : ¬ IsReduced (A p) := fun h => by
+  haveI := h
+  exact g_sub_one_ne_zero p (isNilpotent_iff_eq_zero.mp (isNilpotent_g_sub_one p))
+
+/-- **The modular counterexample to Maschke's theorem.** Over the field `𝔽_p`, the group
+algebra `𝔽_p[ℤ/p]` is *not* a semisimple ring.  This shows the hypothesis `char k ∤ |G|` of
+Maschke's theorem cannot be dropped: a commutative semisimple ring is reduced, but
+`𝔽_p[ℤ/p]` has the nonzero nilpotent `g - 1`. -/
+theorem not_isSemisimpleRing : ¬ IsSemisimpleRing (A p) := fun h => by
+  haveI := h
+  exact not_isReduced p inferInstance
+
+/-- Equivalently, `𝔽_p[ℤ/p]` is not semisimple as a module over itself: the regular
+representation of `ℤ/p` over `𝔽_p` is not completely reducible. -/
+theorem not_isSemisimpleModule : ¬ IsSemisimpleModule (A p) (A p) :=
+  not_isSemisimpleRing p
+
+/-- **Complete reducibility fails.** Some subrepresentation of `𝔽_p[ℤ/p]` (the augmentation
+ideal) has *no* complement: there is no internal direct-sum decomposition splitting it off. -/
+theorem exists_submodule_no_complement :
+    ∃ I : Submodule (A p) (A p), ¬ ∃ J : Submodule (A p) (A p), IsCompl I J := by
+  by_contra hcon
+  push_neg at hcon
+  haveI : ComplementedLattice (Submodule (A p) (A p)) := ⟨hcon⟩
+  exact not_isSemisimpleModule p ⟨⟩
+
+end MaschkeModularCounterexample

--- a/src/data/proofs/maschke-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/maschke-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "maschke-theorem-oq-01-oq-01",
+  "slug": "maschke-theorem-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MonoidAlgebra"
+    ],
+    "namespace": "MaschkeModularCounterexample",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/MaschkeModularCounterexampleOQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Modular Counterexample to Maschke's Theorem: 𝔽ₚ[ℤ/p] Is Not Semisimple",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MaschkeModularCounterexampleOQ01.lean",
+    "tags": [
+      "algebra",
+      "representation-theory",
+      "group-algebra",
+      "maschke",
+      "semisimple",
+      "modular-representation-theory",
+      "counterexample",
+      "nilpotent",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 139,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "badge": "mathlib",
+    "originalContributions": [
+      "not_isSemisimpleRing: the headline result — over the field 𝔽_p the group algebra 𝔽_p[ℤ/p] is NOT a semisimple ring, proving the hypothesis char k ∤ |G| of Maschke's theorem (the parent entry) is essential and cannot be dropped; uniform in the prime p rather than a single decidable instance",
+      "g_pow_card: the basis generator g = [1] indexed by 1 ∈ ℤ/p has order p (g ^ p = 1), reduced to p • (1 : ZMod p) = 0 via MonoidAlgebra.single_pow and ofAdd_nsmul",
+      "g_sub_one_pow_card: the freshman's-dream computation (g - 1) ^ p = g ^ p - 1 ^ p = 1 - 1 = 0 over 𝔽_p[ℤ/p] (characteristic p established by charP_of_injective_algebraMap'), exhibiting an explicit nilpotent",
+      "g_sub_one_ne_zero / g_ne_one: the witness g - 1 is genuinely nonzero, since 1 ≠ 0 in 𝔽_p (Finsupp.single_eq_single_iff)",
+      "isNilpotent_g_sub_one: g - 1 is a nonzero nilpotent — the single element that is the entire obstruction to semisimplicity (a generator of the augmentation ideal ker ε)",
+      "not_isReduced: 𝔽_p[ℤ/p] is not a reduced ring, the bridge between the nilpotent witness and the failure of semisimplicity (a commutative semisimple ring is reduced)",
+      "not_isSemisimpleModule: equivalently, 𝔽_p[ℤ/p] is not semisimple as a module over itself — the regular representation of ℤ/p over 𝔽_p is not completely reducible",
+      "exists_submodule_no_complement: complete reducibility fails concretely — some subrepresentation (the augmentation ideal) has no complement, with no internal direct-sum splitting"
+    ],
+    "prerequisites": [
+      "CommRing R, IsSemisimpleRing R ⟹ IsReduced R: the low-priority Mathlib instance (Mathlib.RingTheory.Jacobson.Semiprimary) for commutative rings, a consequence of Ring.jacobson R = ⊥ for semisimple rings",
+      "sub_pow_char: the freshman's dream (x - y) ^ p = x ^ p - y ^ p in a commutative ring of prime characteristic p",
+      "charP_of_injective_algebraMap': a commutative-algebra A over 𝔽_p with faithful scalar action inherits characteristic p",
+      "MonoidAlgebra.single_pow, ofAdd_nsmul, ofAdd_eq_one: the group-algebra basis arithmetic identifying g ^ p with the basis element of p • 1 = 0",
+      "isNilpotent_iff_eq_zero: in a reduced ring, the only nilpotent is 0"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "IsSemisimpleRing → IsReduced (commutative case)",
+        "description": "For a commutative ring, being semisimple forces the Jacobson radical to vanish, hence no nonzero nilpotents; this is the decisive step turning the explicit nilpotent g - 1 into a proof that 𝔽_p[ℤ/p] is not semisimple.",
+        "module": "Mathlib.RingTheory.Jacobson.Semiprimary"
+      },
+      {
+        "theorem": "sub_pow_char",
+        "description": "The freshman's dream (x - y) ^ p = x ^ p - y ^ p in prime characteristic; supplies (g - 1) ^ p = 0 from g ^ p = 1.",
+        "module": "Mathlib.Algebra.CharP.Lemmas"
+      },
+      {
+        "theorem": "MonoidAlgebra.single_pow",
+        "description": "Powers of a single-supported group-algebra element: (single m r) ^ n = single (m ^ n) (r ^ n); used to show the generator has order p.",
+        "module": "Mathlib.Algebra.MonoidAlgebra.Defs"
+      },
+      {
+        "theorem": "charP_of_injective_algebraMap'",
+        "description": "Transfer of characteristic from a base ring to a faithful algebra over it; gives CharP (𝔽_p[ℤ/p]) p.",
+        "module": "Mathlib.Algebra.CharP.Algebra"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "maschke-theorem-oq-01-oq-01-oq-01",
+      "question": "Identify the nilpotent g - 1 explicitly with a generator of the augmentation ideal ker ε (ε : 𝔽_p[ℤ/p] → 𝔽_p, ∑ a_g g ↦ ∑ a_g) and show the short exact sequence 0 → ker ε → 𝔽_p[ℤ/p] → 𝔽_p → 0 does not split, recovering exists_submodule_no_complement with a named witness.",
+      "significance": "medium"
+    },
+    {
+      "id": "maschke-theorem-oq-01-oq-01-oq-02",
+      "question": "Generalize to char k = p ∣ |G| for an arbitrary finite group G with p ∣ |G|: the group algebra k[G] is non-semisimple because its Jacobson radical (the augmentation-ideal contribution from a Sylow p-subgroup) is nonzero.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "maschke-theorem-oq-01",
+      "relationship": "sharpens",
+      "description": "This entry is the sharpness companion to Maschke's theorem: it proves the parent's hypothesis char k ∤ |G| cannot be dropped by exhibiting the non-semisimple modular group algebra 𝔽_p[ℤ/p]."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: RingTheory.Jacobson.Semiprimary",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the commutative IsSemisimpleRing → IsReduced instance used to derive non-semisimplicity from the nilpotent witness."
+    },
+    {
+      "title": "Beweis des Satzes, dass diejenigen endlichen linearen Substitutionsgruppen, in welchen einige durchgehends verschwindende Coefficienten auftreten, intransitiv sind",
+      "author": "Heinrich Maschke",
+      "year": "1899",
+      "venue": "Mathematische Annalen 52 (2): 363–368",
+      "description": "The original theorem; this entry records the sharpness of its characteristic hypothesis."
+    },
+    {
+      "title": "Über die Darstellung von Gruppen in Galoisschen Feldern",
+      "author": "Richard Brauer",
+      "year": "1935",
+      "venue": "Actualités Sci. Ind.",
+      "description": "Foundational modular representation theory, where the failure of Maschke's theorem in characteristic p ∣ |G| is the starting point."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Over the field 𝔽_p, the group algebra 𝔽_p[ℤ/p] (the regular representation of the cyclic group of order p) is proved NOT semisimple, uniformly in the prime p. The obstruction is a single explicit nilpotent: the basis generator g = [1] satisfies g ^ p = 1 (because p • 1 = 0 in ℤ/p), so the freshman's dream in characteristic p gives (g - 1) ^ p = g ^ p - 1 = 0 while g - 1 ≠ 0. Thus 𝔽_p[ℤ/p] contains a nonzero nilpotent and is not reduced; since a commutative semisimple ring is reduced, it cannot be semisimple, and consequently the regular representation is not completely reducible — some subrepresentation (the augmentation ideal generated by g - 1) has no complement. 139 lines, 9 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "This is the sharpness companion to the parent Maschke entry: it shows the hypothesis char k ∤ |G| is genuinely necessary. The decisive non-triviality — that a commutative semisimple ring is reduced — is a Mathlib instance (hence the mathlib badge); the contribution is the assembly of the explicit counterexample 𝔽_p[ℤ/p], the order-p generator computation, the nilpotent witness g - 1, and the bridge from non-reducedness to the failure of complete reducibility, none of which sit in the gallery. Unlike a p = 2 decidability check, the argument is uniform in p.",
+    "openQuestions": [
+      "Identify g - 1 with a generator of the augmentation ideal and show the augmentation short exact sequence does not split.",
+      "Generalize to arbitrary finite G with p ∣ |G| via the nonzero Jacobson radical of k[G]."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question **maschke-theorem-oq-01-oq-01** (the sharpness companion to the merged Maschke entry #27182): the hypothesis `char k ∤ |G|` of Maschke's theorem is **essential**.

Over the field `𝔽_p`, the group algebra `A = 𝔽_p[ℤ/p]` (the regular representation of the cyclic group of order `p`) is **not semisimple** — proved uniformly in the prime `p`, not just a single `p = 2` decidability check.

## The argument

The obstruction is a single explicit nonzero nilpotent. Writing `g` for the basis generator indexed by `1 ∈ ℤ/p`:

- `g ^ p = 1` (the group element has order `p`, since `p • 1 = 0` in `ℤ/p`),
- freshman's dream in characteristic `p`: `(g - 1) ^ p = g ^ p - 1 ^ p = 1 - 1 = 0`,
- yet `g - 1 ≠ 0` (because `1 ≠ 0` in `𝔽_p`).

So `A` contains a nonzero nilpotent and is **not reduced**. A commutative semisimple ring is reduced (Mathlib's `IsSemisimpleRing → IsReduced` instance, via `Ring.jacobson A = ⊥`), hence `A` is not semisimple, and complete reducibility fails: some subrepresentation (the augmentation ideal, generated by `g - 1`) has no complement.

## Contents (`Proofs/MaschkeModularCounterexampleOQ01.lean`)

- `g_pow_card` — `g ^ p = 1`
- `g_sub_one_pow_card` — `(g - 1) ^ p = 0`
- `g_ne_one` / `g_sub_one_ne_zero` — the witness is nonzero
- `isNilpotent_g_sub_one` — `g - 1` is a nonzero nilpotent
- `not_isReduced` — `𝔽_p[ℤ/p]` is not reduced
- `not_isSemisimpleRing` — **the counterexample**
- `not_isSemisimpleModule` — equivalently, not semisimple over itself
- `exists_submodule_no_complement` — complete reducibility fails

## Verification

9 theorems, 1 definition, **0 sorries, 0 axioms**. Docker build green (7743 jobs). Badge `mathlib` (the decisive step, commutative-semisimple ⟹ reduced, is a Mathlib instance; the contribution is the explicit counterexample assembly and the order-`p` generator computation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)