### PR TITLE
research(cauchy-interlacing-theorem-oq-01): compression corollary — discharge the Rayleigh hypothesis [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingCompression.lean
+++ b/proofs/Proofs/CauchyInterlacingCompression.lean
@@ -1,0 +1,138 @@
+import Mathlib
+import Proofs.CauchyInterlacingAssembly
+
+/-
+# Cauchy interlacing — the self-contained compression corollary
+
+`CauchyInterlacingAssembly.lean` (#27236, 0-sorry/0-axiom) proves the abstract
+interlacing inequalities
+
+  `lam k.succ ≤ mu k ≤ lam k.castSucc`
+
+but it takes the *compression operator* `TH` on the codimension-one subspace
+`H`, its spectral data (`bH`, `mu`, `hTH`, `hmu`), and the Rayleigh-agreement
+hypothesis `hRayleigh` as **inputs**. That keeps the assembly purely
+order-theoretic, but it leaves a real gap: a reader still has to construct the
+compression and discharge `hRayleigh` by hand.
+
+This file closes that gap. Given only
+
+* a symmetric operator `T` on a finite-dimensional inner product space `V` of
+  dimension `n + 1`, and
+* a subspace `H ≤ V` of dimension `n`,
+
+we **build** the orthogonal compression
+
+  `compress T H := P_H ∘ T ∘ ι_H : H →ₗ[𝕜] H`,
+
+prove it is symmetric, pull its spectral data straight from Mathlib's
+`LinearMap.IsSymmetric` spectral theorem (`eigenvectorBasis` / `eigenvalues` /
+`eigenvalues_antitone`), discharge the Rayleigh-agreement hypothesis from the
+adjoint identity for the orthogonal projection, and feed everything into
+`cauchy_interlacing`.
+
+The result, `cauchy_interlacing_compression`, is the textbook statement with no
+side conditions beyond "`T` is symmetric and `H` is a hyperplane":
+
+  the descending eigenvalues `μ` of the compression of `T` to `H` interlace the
+  descending eigenvalues `λ` of `T`:  `λ_{k+1} ≤ μ_k ≤ λ_k`.
+
+## The compression's Rayleigh quotient
+
+The single fact that powers both the symmetry of `compress` and the
+Rayleigh-agreement hypothesis is the orthogonal-projection adjoint identity
+`Submodule.inner_orthogonalProjection_eq_of_mem_right`:
+
+  `⟪P_H v, u⟫ = ⟪v, u⟫`  for `u ∈ H`.
+
+With `v = T ↑y` and `u = y` this gives `⟪compress y, y⟫_H = ⟪T ↑y, ↑y⟫_V`, and
+since the subspace norm satisfies `‖y‖ = ‖↑y‖` (`Submodule.coe_norm`) the two
+Rayleigh quotients coincide exactly.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open scoped InnerProductSpace
+open CauchyInterlacing.Assembly
+
+namespace CauchyInterlacing.Compression
+
+variable {𝕜 V : Type*} [RCLike 𝕜] [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
+  [FiniteDimensional 𝕜 V]
+
+/-- The orthogonal **compression** of `T` to a subspace `H`: project `T ↑y` back
+into `H`.  For a Hermitian matrix and a coordinate hyperplane this is exactly the
+principal submatrix obtained by deleting a row and column. -/
+noncomputable def compress (T : V →ₗ[𝕜] V) (H : Submodule 𝕜 V) : H →ₗ[𝕜] H :=
+  (H.orthogonalProjection : V →L[𝕜] H).toLinearMap ∘ₗ (T ∘ₗ H.subtype)
+
+@[simp] theorem compress_apply (T : V →ₗ[𝕜] V) (H : Submodule 𝕜 V) (y : H) :
+    compress T H y = H.orthogonalProjection (T (y : V)) := rfl
+
+/-- The compression of a symmetric operator is symmetric.  Both inner products
+collapse to `⟪T ↑y, ↑z⟫_V` via the projection adjoint identity, and that is
+symmetric because `T` is. -/
+theorem isSymmetric_compress {T : V →ₗ[𝕜] V} (hT : T.IsSymmetric)
+    (H : Submodule 𝕜 V) : (compress T H).IsSymmetric := by
+  intro y z
+  -- `⟪compress y, z⟫_H = ⟪T ↑y, ↑z⟫_V` and `⟪y, compress z⟫_H = ⟪↑y, T ↑z⟫_V`.
+  have hl : @inner 𝕜 H _ (compress T H y) z = @inner 𝕜 V _ (T (y : V)) (z : V) := by
+    rw [compress_apply, Submodule.inner_orthogonalProjection_eq_of_mem_right]
+  have hr : @inner 𝕜 H _ y (compress T H z) = @inner 𝕜 V _ (y : V) (T (z : V)) := by
+    rw [compress_apply, Submodule.inner_orthogonalProjection_eq_of_mem_left]
+  show @inner 𝕜 H _ (compress T H y) z = @inner 𝕜 H _ y (compress T H z)
+  rw [hl, hr]
+  exact hT (y : V) (z : V)
+
+/-- Rayleigh-quotient agreement: on every nonzero `y ∈ H`, the compression has
+the same Rayleigh quotient as `T`.  This is the defining property of the
+orthogonal compression and is precisely the hypothesis `cauchy_interlacing`
+needs. -/
+theorem rayleigh_compress_eq (T : V →ₗ[𝕜] V) (H : Submodule 𝕜 V) (y : H) :
+    RCLike.re (@inner 𝕜 H _ (compress T H y) y) / ‖y‖ ^ 2
+      = RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2 := by
+  have hi : @inner 𝕜 H _ (compress T H y) y = @inner 𝕜 V _ (T (y : V)) (y : V) := by
+    rw [compress_apply, Submodule.inner_orthogonalProjection_eq_of_mem_right]
+  rw [hi, Submodule.coe_norm]
+
+/-- **Cauchy interlacing (compression corollary).**
+
+Let `T` be a symmetric operator on an `(n+1)`-dimensional inner product space
+`V`, with descending eigenvalues `lam := hT.eigenvalues`.  Let `H ≤ V` be a
+codimension-one subspace (`finrank H = n`), and let `mu` be the descending
+eigenvalues of the orthogonal compression `compress T H` of `T` to `H`.
+
+Then for every `k : Fin n`:
+
+  `lam k.succ ≤ mu k`  and  `mu k ≤ lam k.castSucc`,
+
+i.e. `λ_{k+1} ≤ μ_k ≤ λ_k` in descending notation (`λ_k ≤ μ_k ≤ λ_{k+1}`
+ascending).  No Rayleigh hypothesis is required: it is discharged internally
+from the orthogonal-projection adjoint identity. -/
+theorem cauchy_interlacing_compression
+    {T : V →ₗ[𝕜] V} (hT : T.IsSymmetric) {n : ℕ}
+    (hVdim : Module.finrank 𝕜 V = n + 1)
+    (H : Submodule 𝕜 V) (hHdim : Module.finrank 𝕜 H = n)
+    (k : Fin n) :
+    (hT.eigenvalues hVdim) k.succ ≤ (isSymmetric_compress hT H).eigenvalues hHdim k
+      ∧ (isSymmetric_compress hT H).eigenvalues hHdim k
+          ≤ (hT.eigenvalues hVdim) k.castSucc := by
+  -- Spectral data for `T` on `V`.
+  set b := hT.eigenvectorBasis hVdim with hb_def
+  set lam := hT.eigenvalues hVdim with hlam_def
+  have hb : ∀ i, T (b i) = (lam i : 𝕜) • b i := hT.apply_eigenvectorBasis hVdim
+  have hlam : Antitone lam := hT.eigenvalues_antitone hVdim
+  -- Spectral data for the compression `TH` on `H`.
+  set hTH := isSymmetric_compress hT H with hTH_def
+  set bH := hTH.eigenvectorBasis hHdim with hbH_def
+  set mu := hTH.eigenvalues hHdim with hmu_def
+  have hbH : ∀ i, compress T H (bH i) = (mu i : 𝕜) • bH i := hTH.apply_eigenvectorBasis hHdim
+  have hmu : Antitone mu := hTH.eigenvalues_antitone hHdim
+  -- Rayleigh agreement, in the exact shape `cauchy_interlacing` wants.
+  have hRayleigh : ∀ y : H, y ≠ 0 →
+      RCLike.re (@inner 𝕜 H _ (compress T H y) y) / ‖y‖ ^ 2
+        = RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2 :=
+    fun y _ => rayleigh_compress_eq T H y
+  exact cauchy_interlacing T b lam hb hlam H hHdim (compress T H) bH mu hbH hmu hRayleigh k
+
+end CauchyInterlacing.Compression

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-compress-def",
+    "proofId": "cauchy-interlacing-theorem-oq-01",
+    "range": { "startLine": 66, "endLine": 70 },
+    "type": "definition",
+    "title": "The Orthogonal Compression Operator",
+    "content": "`compress T H := (H.orthogonalProjection : V →L[𝕜] H).toLinearMap ∘ₗ (T ∘ₗ H.subtype)` sends `y ∈ H` to `P_H (T ↑y)`: lift `y` to the ambient space, apply `T`, project back into `H`. For a Hermitian matrix and a coordinate hyperplane `H`, this operator is exactly the principal submatrix obtained by deleting the corresponding row and column.",
+    "mathContext": "The coordinate-free avatar of 'delete a row and its matching column'. The compression is the operator-theoretic principal submatrix.",
+    "significance": "key",
+    "relatedConcepts": ["orthogonal compression", "principal submatrix", "orthogonal projection"],
+    "prerequisites": ["orthogonal projection onto a subspace", "linear map composition"]
+  },
+  {
+    "id": "ann-compress-symmetric",
+    "proofId": "cauchy-interlacing-theorem-oq-01",
+    "range": { "startLine": 72, "endLine": 85 },
+    "type": "insight",
+    "title": "The Compression Inherits Symmetry",
+    "content": "`isSymmetric_compress`: for `y, z ∈ H`, the adjoint identity `⟪P_H v, u⟫ = ⟪v, u⟫` (valid because `u ∈ H`) collapses `⟪compress y, z⟫_H` to the ambient `⟪T ↑y, ↑z⟫_V` and `⟪y, compress z⟫_H` to `⟪↑y, T ↑z⟫_V`. These agree precisely because `T` is symmetric. So projecting before pairing against a vector of `H` is invisible, and symmetry passes to the compression.",
+    "mathContext": "The orthogonal projection P_H is self-adjoint and fixes H pointwise; pairing P_H w against u ∈ H equals pairing w against u.",
+    "significance": "key",
+    "relatedConcepts": ["self-adjoint operator", "orthogonal projection adjoint", "symmetric operator"],
+    "prerequisites": ["inner product adjoint of orthogonal projection"]
+  },
+  {
+    "id": "ann-rayleigh-agreement",
+    "proofId": "cauchy-interlacing-theorem-oq-01",
+    "range": { "startLine": 87, "endLine": 96 },
+    "type": "insight",
+    "title": "Rayleigh Quotients Agree Exactly",
+    "content": "`rayleigh_compress_eq`: the same projection identity with `z = y` gives `⟪compress y, y⟫_H = ⟪T ↑y, ↑y⟫_V`, and the subspace inherits the ambient norm so `‖y‖ = ‖↑y‖` (`Submodule.coe_norm`). Hence `re⟪compress y, y⟫_H / ‖y‖² = re⟪T ↑y, ↑y⟫_V / ‖↑y‖²` exactly. This is the Rayleigh-agreement hypothesis that the abstract parent theorem takes as an input — here proved.",
+    "mathContext": "Rayleigh-quotient agreement on H is the defining property of the orthogonal compression and the engine that transports eigenvalue bounds between the two operators.",
+    "significance": "key",
+    "relatedConcepts": ["Rayleigh quotient", "orthogonal compression", "subspace norm"],
+    "prerequisites": ["Rayleigh quotient", "submodule inner product and norm"]
+  },
+  {
+    "id": "ann-corollary",
+    "proofId": "cauchy-interlacing-theorem-oq-01",
+    "range": { "startLine": 98, "endLine": 139 },
+    "type": "insight",
+    "title": "The Unconditional Compression Corollary",
+    "content": "`cauchy_interlacing_compression`: the spectral data of `T` on `V` and of `compress T H` on `H` are pulled from Mathlib's spectral theorem (`eigenvectorBasis`, `eigenvalues`, `eigenvalues_antitone`), `rayleigh_compress_eq` supplies the Rayleigh hypothesis, and the parent's `cauchy_interlacing` then yields `λ(k.succ) ≤ μ(k) ∧ μ(k) ≤ λ(k.castSucc)`. No hypothesis is needed beyond 'T symmetric, H a codimension-one subspace'.",
+    "mathContext": "The unconditional operator-level Cauchy interlacing theorem: any symmetric operator interlaces its compression to any hyperplane. Only the matrix↔operator bookkeeping separates this from the classical statement.",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy interlacing", "Courant–Fischer", "spectral theorem", "eigenvalues"],
+    "prerequisites": ["spectral theorem for symmetric operators", "abstract interlacing theorem"]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-01",
+  "title": "Cauchy Interlacing: the Self-Contained Compression Corollary",
+  "slug": "cauchy-interlacing-theorem-oq-01",
+  "description": "Discharges the Rayleigh-agreement hypothesis of the abstract Cauchy interlacing theorem by building the orthogonal compression operator explicitly. Given only a symmetric operator T on an (n+1)-dimensional inner product space and a codimension-one subspace H, the compression TH := P_H ∘ T ∘ ι_H is constructed, proved symmetric, its spectral data pulled from Mathlib's spectral theorem, and the Rayleigh hypothesis discharged from the orthogonal-projection adjoint identity — yielding interlacing λ(k+1) ≤ μ(k) ≤ λ(k) with no side conditions beyond 'T symmetric, H a hyperplane'.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyInterlacingCompression.lean",
+    "tags": [
+      "linear-algebra",
+      "spectral-theory",
+      "eigenvalues",
+      "cauchy-interlacing",
+      "orthogonal-compression",
+      "orthogonal-projection",
+      "rayleigh-quotient",
+      "inner-product-space"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "lineCount": 139,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "assumptions": "None beyond 'T is a symmetric operator and H is a codimension-one subspace'. 0 axioms, 0 sorries in this file and in its transitive imports (CauchyInterlacingAssembly.lean #27236 and CauchyInterlacingKeystone.lean #25063, both 0-sorry/0-axiom). The Rayleigh-agreement hypothesis that the abstract assembly theorem (cauchy_interlacing) takes as input is here PROVED, not assumed, from the orthogonal-projection adjoint identity. This closes the operator-level half of the parent entry's first open question. The remaining bridge is purely the matrix↔operator translation: showing that for a Hermitian matrix and a coordinate hyperplane, deleting a row/column yields exactly this orthogonal compression (a bookkeeping identification, no new spectral content).",
+    "originalContributions": [
+      "compress (definition): the orthogonal compression of a symmetric operator T to a subspace H, compress T H := (P_H : V →L[𝕜] H) ∘ₗ (T ∘ₗ H.subtype) : H →ₗ[𝕜] H. For a Hermitian matrix and a coordinate hyperplane this is exactly the principal submatrix obtained by deleting a row and its matching column.",
+      "isSymmetric_compress: the compression of a symmetric operator is symmetric. Both inner products ⟪compress y, z⟫_H and ⟪y, compress z⟫_H collapse to the ambient ⟪T ↑y, ↑z⟫_V and ⟪↑y, T ↑z⟫_V via the orthogonal-projection adjoint identity Submodule.inner_orthogonalProjection_eq_of_mem_right/left, and those agree because T is symmetric.",
+      "rayleigh_compress_eq: on every y ∈ H the compression's Rayleigh quotient re⟪compress y, y⟫_H / ‖y‖² equals re⟪T ↑y, ↑y⟫_V / ‖↑y‖² exactly — the same adjoint identity plus the subspace-norm equality ‖y‖ = ‖↑y‖ (Submodule.coe_norm). This is precisely the hypothesis the abstract theorem needs, now discharged.",
+      "cauchy_interlacing_compression: the textbook compression statement. From a symmetric T on an (n+1)-dimensional V and a codimension-one H, with μ the descending eigenvalues of compress T H pulled from Mathlib's LinearMap.IsSymmetric spectral theorem (eigenvectorBasis / eigenvalues / eigenvalues_antitone), concludes λ(k.succ) ≤ μ(k) ∧ μ(k) ≤ λ(k.castSucc) for every k — no Rayleigh hypothesis required."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Submodule.inner_orthogonalProjection_eq_of_mem_right",
+        "description": "⟪P_H v, u⟫ = ⟪v, u⟫ for u ∈ H — the orthogonal-projection adjoint identity that collapses the compression's inner product to the ambient one; the single fact powering both the symmetry of compress and the Rayleigh agreement",
+        "module": "Mathlib.Analysis.InnerProductSpace.Projection.Basic"
+      },
+      {
+        "theorem": "LinearMap.IsSymmetric.eigenvalues / eigenvectorBasis / eigenvalues_antitone",
+        "description": "the spectral theorem for a symmetric operator on a finite-dimensional inner product space: a descending (antitone) real eigenvalue tuple and a matching orthonormal eigenbasis — supplies the spectral data of the compression TH on H and of T on V",
+        "module": "Mathlib.Analysis.InnerProductSpace.Spectrum"
+      },
+      {
+        "theorem": "LinearMap.IsSymmetric.apply_eigenvectorBasis",
+        "description": "T (eigenvectorBasis i) = (eigenvalues i) • eigenvectorBasis i — the eigenvector equation feeding the abstract assembly's hypotheses hb / hbH",
+        "module": "Mathlib.Analysis.InnerProductSpace.Spectrum"
+      },
+      {
+        "theorem": "Submodule.coe_norm",
+        "description": "‖x‖ = ‖(x : E)‖ for x in a submodule — the subspace inherits the ambient norm, so the two Rayleigh denominators coincide",
+        "module": "Mathlib.Analysis.Normed.Group.Submodule"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The parent entry (cauchy-interlacing-theorem) proves Cauchy interlacing in abstract operator/compression form: it takes the smaller operator TH on a codimension-one subspace H together with a hypothesis that TH's Rayleigh quotient agrees with T's on H. That hypothesis is exactly the defining property of the orthogonal compression P_H ∘ T ∘ ι_H — the operator-theoretic avatar of deleting a row and column from a Hermitian matrix — but the abstract theorem leaves it as an input. This follow-up builds the compression and discharges the hypothesis, turning the conditional statement into an unconditional corollary about any symmetric operator and any hyperplane.",
+    "problemStatement": "Build the orthogonal compression of a symmetric operator T on a finite-dimensional inner product space V to a codimension-one subspace H, prove it symmetric, and show its descending eigenvalues μ interlace those λ of T: λ(k+1) ≤ μ(k) ≤ λ(k) for every k — with the Rayleigh-agreement hypothesis of the abstract theorem now proved rather than assumed.",
+    "text": "The compression compress T H := P_H ∘ T ∘ ι_H sends y ∈ H to the orthogonal projection back into H of T ↑y. The whole proof rests on one Mathlib identity: ⟪P_H v, u⟫ = ⟪v, u⟫ for u ∈ H. With v = T ↑y this collapses both the symmetry computation and the Rayleigh quotient of compress to the ambient operator T, after which the abstract assembly theorem applies verbatim.",
+    "proofStrategy": "Define compress T H as the composite (P_H : V →L[𝕜] H) ∘ₗ T ∘ₗ H.subtype. (1) Symmetry: ⟪compress y, z⟫_H = ⟪P_H (T ↑y), z⟫ = ⟪T ↑y, ↑z⟫ (projection adjoint, z ∈ H) and ⟪y, compress z⟫_H = ⟪↑y, T ↑z⟫, equal by symmetry of T. (2) Rayleigh agreement: the same identity with z = y gives ⟪compress y, y⟫_H = ⟪T ↑y, ↑y⟫, and ‖y‖ = ‖↑y‖ since H carries the ambient norm, so the Rayleigh quotients are literally equal. (3) Spectral data: compress is symmetric on the finite-dimensional H, so Mathlib's spectral theorem yields its antitone eigenvalues μ, an orthonormal eigenbasis, and the eigenvector equation; the same for T on V. (4) Feed everything into the parent's cauchy_interlacing — the Rayleigh hypothesis, formerly an obligation, is now the proved lemma rayleigh_compress_eq.",
+    "keyInsights": [
+      "**One projection identity does all the work.** Both the symmetry of the compression and its Rayleigh-quotient agreement reduce to ⟪P_H v, u⟫ = ⟪v, u⟫ for u ∈ H (Submodule.inner_orthogonalProjection_eq_of_mem_right). The orthogonal projection is self-adjoint and fixes H pointwise, so projecting before pairing against a vector of H changes nothing.",
+      "**The compression IS the principal submatrix.** Constructing TH as P_H ∘ T ∘ ι_H is the coordinate-free form of deleting a row and its matching column. Once H is a coordinate hyperplane and T a Hermitian matrix, this operator is exactly the (n×n) principal submatrix — so the corollary is the classical matrix Cauchy interlacing theorem modulo a bookkeeping identification.",
+      "**Spectral data is free from Mathlib.** Because compress is provably symmetric, its descending eigenvalues and orthonormal eigenbasis come straight from LinearMap.IsSymmetric.eigenvalues / eigenvectorBasis / eigenvalues_antitone — no need to supply them by hand as the abstract theorem required.",
+      "**The hypothesis becomes a lemma.** The abstract assembly carries hRayleigh as an input precisely to stay matrix-agnostic; here that same statement is the proved rayleigh_compress_eq, so the corollary has no side conditions beyond 'T symmetric, H a hyperplane'."
+    ],
+    "prerequisites": [
+      "The parent entry's abstract interlacing theorem cauchy_interlacing (compression form)",
+      "Orthogonal projection onto a subspace and its adjoint/self-adjointness identities",
+      "The spectral theorem for symmetric operators (Mathlib's LinearMap.IsSymmetric spectral API)",
+      "Submodules of inner product spaces inherit the ambient inner product and norm"
+    ]
+  },
+  "sections": [
+    {
+      "id": "compress-def",
+      "title": "The Compression Operator",
+      "startLine": 60,
+      "endLine": 70,
+      "summary": "Defines compress T H := (P_H : V →L[𝕜] H) ∘ₗ (T ∘ₗ H.subtype) and the unfolding simp lemma compress_apply: compress T H y = P_H (T ↑y). This is the orthogonal compression of T to H, the coordinate-free principal-submatrix operator.",
+      "mathContext": "Projecting T ↑y back into H is exactly what deleting the rows/columns outside H does to a matrix."
+    },
+    {
+      "id": "symmetry",
+      "title": "Symmetry of the Compression",
+      "startLine": 72,
+      "endLine": 85,
+      "summary": "isSymmetric_compress: both ⟪compress y, z⟫_H and ⟪y, compress z⟫_H collapse to ambient inner products via the projection adjoint identity, then agree because T is symmetric.",
+      "mathContext": "The orthogonal projection is self-adjoint and fixes H, so it disappears when paired against a vector of H."
+    },
+    {
+      "id": "rayleigh",
+      "title": "Rayleigh-Quotient Agreement",
+      "startLine": 87,
+      "endLine": 96,
+      "summary": "rayleigh_compress_eq: re⟪compress y, y⟫_H / ‖y‖² = re⟪T ↑y, ↑y⟫_V / ‖↑y‖² exactly — the projection identity plus the subspace-norm equality ‖y‖ = ‖↑y‖. This is the hypothesis the abstract theorem demands, now proved.",
+      "mathContext": "The compression and the ambient operator have identical Rayleigh quotients on H, which is the defining property used to transport eigenvalue bounds across the compression."
+    },
+    {
+      "id": "corollary",
+      "title": "The Compression Corollary",
+      "startLine": 98,
+      "endLine": 139,
+      "summary": "cauchy_interlacing_compression: pulls the spectral data of T (on V) and of compress T H (on H) from Mathlib's spectral theorem, packages rayleigh_compress_eq as the Rayleigh hypothesis, and applies the parent's cauchy_interlacing to conclude λ(k.succ) ≤ μ(k) ∧ μ(k) ≤ λ(k.castSucc).",
+      "mathContext": "The unconditional operator-level Cauchy interlacing theorem: any symmetric operator interlaces its compression to any hyperplane."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 corollary that removes the Rayleigh-agreement hypothesis from the abstract Cauchy interlacing theorem by constructing the orthogonal compression explicitly and discharging the hypothesis from the orthogonal-projection adjoint identity. The file is 0-axiom, 0-sorry, as are its transitive imports. The result is the unconditional operator-level statement: the descending eigenvalues of any symmetric operator interlace those of its compression to any codimension-one subspace.",
+    "implications": "Closes the operator-level half of the parent entry's first open question (build TH as the orthogonal compression and discharge Rayleigh-agreement from the spectral theorem on H). The compression construction and its symmetry/Rayleigh lemmas are reusable for any compression-to-subspace argument (e.g. Poincaré separation, the general delete-m interlacing). The only remaining step to the literal matrix theorem is the bookkeeping identification of the coordinate-hyperplane compression with the principal submatrix.",
+    "openQuestions": [
+      "Identify the orthogonal compression of a Hermitian matrix to a coordinate hyperplane with the principal submatrix obtained by deleting a row/column, completing the reduction of cauchy_interlacing_compression to the literal Matrix.IsHermitian.eigenvalues₀ statement.",
+      "Poincaré separation theorem: extend from a single hyperplane to compression onto any k-dimensional subspace, λ_i ≤ μ_i ≤ λ_{i+n-m}, by iterating compress or a direct dimension count."
+    ]
+  },
+  "crossReferences": [
+    {
+      "slug": "cauchy-interlacing-theorem",
+      "relation": "Parent entry — proves the abstract interlacing theorem cauchy_interlacing in compression form (taking the Rayleigh-agreement hypothesis as input) and the Courant–Fischer max–min keystone. This entry discharges that hypothesis."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Horn, R.A.",
+        "Johnson, C.R."
+      ],
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "Theorem 4.3.17 (Cauchy interlacing) and §4.3 on compressions / principal submatrices"
+    },
+    {
+      "authors": [
+        "Bhatia, R."
+      ],
+      "title": "Matrix Analysis",
+      "year": "1997",
+      "venue": "Springer GTM 169",
+      "note": "Compressions, Poincaré separation, and interlacing via the min-max principle"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CauchyInterlacingAssembly"
+    ],
+    "opens": [
+      "InnerProductSpace"
+    ],
+    "namespace": "CauchyInterlacing.Compression",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/CauchyInterlacingCompression.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
Follow-up to the abstract Cauchy interlacing theorem (`cauchy-interlacing-theorem`, #27236). The parent proves interlacing in **compression form**: it takes the smaller operator `TH` on a codimension-one subspace `H` plus a hypothesis that `TH`'s Rayleigh quotient agrees with `T`'s on `H`. That hypothesis is the defining property of the orthogonal compression — but the parent leaves it as an input. Its first open question asks to *"build TH as the orthogonal compression and discharge the Rayleigh-agreement hypothesis from the spectral theorem on H."*

This PR does exactly that at the operator level, turning the conditional theorem into an **unconditional corollary**.

## Progress
New file `proofs/Proofs/CauchyInterlacingCompression.lean` (4 thm + 1 def, 139 lines, **0-sorry / 0-axiom**):
- **`compress T H`** `:= (P_H : V →L[𝕜] H) ∘ₗ (T ∘ₗ H.subtype)` — the orthogonal compression, i.e. the coordinate-free principal-submatrix operator.
- **`isSymmetric_compress`** — the compression of a symmetric operator is symmetric. Both inner products collapse to the ambient `⟪T ↑y, ↑z⟫_V` via the projection adjoint identity `Submodule.inner_orthogonalProjection_eq_of_mem_right/left`.
- **`rayleigh_compress_eq`** — `re⟪compress y, y⟫_H / ‖y‖² = re⟪T ↑y, ↑y⟫_V / ‖↑y‖²` exactly (same identity + `Submodule.coe_norm`). This is the hypothesis the abstract theorem needs, now **proved**.
- **`cauchy_interlacing_compression`** — pulls spectral data from Mathlib's `LinearMap.IsSymmetric.eigenvalues / eigenvectorBasis / eigenvalues_antitone`, supplies `rayleigh_compress_eq`, and applies the parent's `cauchy_interlacing` to conclude `λ(k.succ) ≤ μ(k) ∧ μ(k) ≤ λ(k.castSucc)` — no Rayleigh hypothesis required.

Gallery entry: `src/data/proofs/cauchy-interlacing-theorem-oq-01/` (meta + annotations).

## Findings
The entire construction rests on one Mathlib fact: `⟪P_H v, u⟫ = ⟪v, u⟫` for `u ∈ H`. The orthogonal projection is self-adjoint and fixes `H`, so projecting before pairing against a vector of `H` is invisible — that single identity powers both the symmetry of `compress` and the Rayleigh agreement.

## Status
**Outcome**: completed (verified, 0-axiom). Docker build green (7745 jobs).
**Next Steps**: the only remaining step to the literal matrix theorem is the bookkeeping identification of the coordinate-hyperplane compression with the principal submatrix (`Matrix.IsHermitian.eigenvalues₀`). Also: Poincaré separation (compression onto a general k-dim subspace).

🤖 Generated by researcher-9