### PR TITLE
research(cauchy-interlacing-theorem-oq-02): Poincaré separation — arbitrary-codimension Cauchy interlacing [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingPoincare.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincare.lean
@@ -1,0 +1,172 @@
+import Mathlib
+import Proofs.CauchyInterlacingKeystone
+
+/-
+# Poincaré separation — Cauchy interlacing for an arbitrary-codimension compression
+
+`CauchyInterlacingAssembly.lean` (#27236, 0-sorry/0-axiom) proves the
+**codimension-one** Cauchy interlacing inequality
+
+  `lam (k.succ) ≤ mu k ≤ lam (k.castSucc)`
+
+relating the descending eigenvalues `lam` of a symmetric operator `T` on a
+space `V` of dimension `n+1` to the descending eigenvalues `mu` of a symmetric
+operator `TH` on a codimension-one subspace `H` (the orthogonal compression of
+`T` to `H`).
+
+This file answers the parent entry's **second open question**: the general
+"delete `m` rows/columns" interlacing — the **Poincaré separation theorem**.
+For a codimension-`m` compression (`dim V = n + m`, `dim H = n`),
+
+  `lam ⟨k + m⟩ ≤ mu k`   and   `mu k ≤ lam ⟨k⟩`     (for every `k : Fin n`),
+
+i.e. in ascending textbook notation `λ_k ≤ μ_k ≤ λ_{k+m}`. The codimension-one
+file is exactly the `m = 1` case.
+
+## What makes this free
+
+The variational content — the bound-form Courant–Fischer max–min
+characterisation of the descending `k`-th eigenvalue — lives entirely in
+`CauchyInterlacingKeystone.lean`, and that keystone is already stated for an
+*arbitrary* subspace dimension (it is parametrised by index sets / `finrank S`,
+not by a fixed `+1`). So Poincaré separation needs **no new spectral theory**:
+only the dimension arithmetic changes. The codimension-one count
+`dim (S ⊓ H) ≥ dim S − 1` becomes `dim (S ⊓ H) ≥ dim S − m`, and the optimal
+subspace for the lower bound is taken `(k+m+1)`-dimensional instead of
+`(k+2)`-dimensional. Both bounds reuse the identical keystone halves.
+
+## Proof
+
+* **Upper** `mu k ≤ lam ⟨k⟩`: identical to the codimension-one case — the
+  optimal `(k+1)`-dim subspace `SH ⊆ H` for `TH` pushes into a `(k+1)`-dim
+  subspace of `V`, on which the keystone's upper half finds a vector with
+  `R_T ≤ lam ⟨k⟩`; Rayleigh-agreement transfers the `≥ mu k` lower bound. The
+  codimension `m` never enters.
+* **Lower** `lam ⟨k+m⟩ ≤ mu k`: take the optimal `(k+m+1)`-dim subspace `S` for
+  `T` (keystone lower half at index `k+m`). The codimension-`m` count gives
+  `dim (S ⊓ H) ≥ (k+m+1) + n − (n+m) = k+1`, enough for the index-set keystone
+  half on `TH` to find a vector in `S ⊓ H` with `R_{TH} ≤ mu k`; that vector
+  lies in `S`, so `lam ⟨k+m⟩ ≤ R_T = R_{TH} ≤ mu k`.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open scoped InnerProductSpace
+open CauchyInterlacing.Keystone
+
+namespace CauchyInterlacing.Poincare
+
+/-- **Poincaré separation theorem (abstract / compression form).**
+
+Let `T` be a symmetric operator on an `(n + m)`-dimensional inner product space
+`V` with orthonormal eigenbasis `b` and antitone (descending) eigenvalues `lam`.
+Let `H ≤ V` have dimension `n` (codimension `m`), and let `TH` be a symmetric
+operator on `H` with orthonormal eigenbasis `bH` and antitone eigenvalues `mu`,
+whose Rayleigh quotient agrees with that of `T` on every nonzero `y ∈ H` (the
+defining property of the orthogonal compression of `T` to `H`).
+
+Then the eigenvalues separate: for every `k : Fin n`,
+
+  `lam ⟨k + m⟩ ≤ mu k`   and   `mu k ≤ lam ⟨k⟩`.
+
+In ascending textbook notation this is `λ_k ≤ μ_k ≤ λ_{k+m}`. The
+codimension-one Cauchy interlacing theorem is the special case `m = 1`. -/
+theorem poincare_separation
+    {𝕜 V : Type*} [RCLike 𝕜] [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
+    [FiniteDimensional 𝕜 V] {n m : ℕ}
+    (T : V →ₗ[𝕜] V) (b : OrthonormalBasis (Fin (n + m)) 𝕜 V) (lam : Fin (n + m) → ℝ)
+    (hT : ∀ i, T (b i) = (lam i : 𝕜) • b i) (hlam : Antitone lam)
+    (H : Submodule 𝕜 V) (hHdim : Module.finrank 𝕜 H = n)
+    (TH : H →ₗ[𝕜] H) (bH : OrthonormalBasis (Fin n) 𝕜 H) (mu : Fin n → ℝ)
+    (hTH : ∀ i, TH (bH i) = (mu i : 𝕜) • bH i) (hmu : Antitone mu)
+    (hRayleigh : ∀ y : H, y ≠ 0 →
+      RCLike.re (@inner 𝕜 H _ (TH y) y) / ‖y‖ ^ 2
+        = RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2)
+    (k : Fin n) :
+    lam ⟨(k : ℕ) + m, by have := k.isLt; omega⟩ ≤ mu k
+      ∧ mu k ≤ lam ⟨(k : ℕ), by have := k.isLt; omega⟩ := by
+  have hVdim : Module.finrank 𝕜 V = n + m := by
+    rw [Module.finrank_eq_card_basis b.toBasis, Fintype.card_fin]
+  have hk : (k : ℕ) < n := k.isLt
+  refine ⟨?_, ?_⟩
+  · -- LOWER bound: lam ⟨k + m⟩ ≤ mu k
+    obtain ⟨S, hSdim, hSlb⟩ :=
+      eigenvalue_maxmin_lower T b lam hT hlam ⟨(k : ℕ) + m, by omega⟩
+    -- read off the subspace dimension as a plain ℕ equation
+    have hSv : Module.finrank 𝕜 S = (k : ℕ) + m + 1 := hSdim
+    -- the compression-side subspace: pull `S ⊓ H` back into `H`
+    set SH : Submodule 𝕜 H := (S ⊓ H).comap H.subtype with hSHdef
+    have hmap : SH.map H.subtype = S ⊓ H := by
+      rw [hSHdef, Submodule.map_comap_subtype, inf_of_le_right inf_le_right]
+    have hSHfr : Module.finrank 𝕜 SH = Module.finrank 𝕜 (S ⊓ H : Submodule 𝕜 V) := by
+      rw [← hmap, Submodule.finrank_map_subtype_eq]
+    -- dimension count: finrank (S ⊓ H) ≥ k + 1  (codimension-m version)
+    have hsum := Submodule.finrank_sup_add_finrank_inf_eq S H
+    have hsuple : Module.finrank 𝕜 (S ⊔ H : Submodule 𝕜 V) ≤ n + m := by
+      rw [← hVdim]; exact Submodule.finrank_le _
+    have hge : (k : ℕ) + 1 ≤ Module.finrank 𝕜 (S ⊓ H : Submodule 𝕜 V) := by
+      rw [hHdim] at hsum; omega
+    have hSHge : (k : ℕ) + 1 ≤ Module.finrank 𝕜 SH := by rw [hSHfr]; exact hge
+    have hdim : Module.finrank 𝕜 H < Module.finrank 𝕜 SH + (Finset.Ici k).card := by
+      rw [hHdim, Fin.card_Ici]; omega
+    have hc : ∀ i ∈ Finset.Ici k, mu i ≤ mu k := fun i hi => hmu (Finset.mem_Ici.1 hi)
+    obtain ⟨y, hySH, hy0, hyle⟩ :=
+      exists_rayleigh_le_in_subspace TH bH mu hTH (Finset.Ici k) (mu k) hc SH hdim
+    -- the witness, pushed to `V`, lies in `S`
+    have hyHS : (y : V) ∈ S ⊓ H := by
+      have h := Submodule.mem_comap.1 (hSHdef ▸ hySH)
+      simpa using h
+    have hyS : (y : V) ∈ S := (Submodule.mem_inf.1 hyHS).1
+    have hyv0 : (y : V) ≠ 0 := fun h => hy0 (Submodule.coe_eq_zero.1 h)
+    calc lam ⟨(k : ℕ) + m, by omega⟩
+        ≤ RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2 := hSlb (y : V) hyS hyv0
+      _ = RCLike.re (@inner 𝕜 H _ (TH y) y) / ‖y‖ ^ 2 := (hRayleigh y hy0).symm
+      _ ≤ mu k := hyle
+  · -- UPPER bound: mu k ≤ lam ⟨k⟩  (codimension m never enters)
+    obtain ⟨SH, hSHdim, hSHlb⟩ := eigenvalue_maxmin_lower TH bH mu hTH hmu k
+    set S : Submodule 𝕜 V := SH.map H.subtype with hSdef
+    have hSdim : Module.finrank 𝕜 S = (k : ℕ) + 1 := by
+      rw [hSdef, Submodule.finrank_map_subtype_eq, hSHdim]
+    obtain ⟨x, hxS, hx0, hxle⟩ :=
+      eigenvalue_maxmin_upper T b lam hT hlam ⟨(k : ℕ), by omega⟩ S hSdim
+    rw [hSdef, Submodule.mem_map] at hxS
+    obtain ⟨y, hySH, hyx⟩ := hxS
+    have hy0 : y ≠ 0 := fun h => hx0 (by rw [← hyx, h, map_zero])
+    have hxv : x = (y : V) := by rw [← hyx]; rfl
+    calc mu k
+        ≤ RCLike.re (@inner 𝕜 H _ (TH y) y) / ‖y‖ ^ 2 := hSHlb y hySH hy0
+      _ = RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2 := hRayleigh y hy0
+      _ = RCLike.re (@inner 𝕜 V _ (T x) x) / ‖x‖ ^ 2 := by rw [hxv]
+      _ ≤ lam ⟨(k : ℕ), by omega⟩ := hxle
+
+/-- **Cauchy interlacing (codimension one) as the `m = 1` special case.**
+
+Recovering the parent entry's inequality `lam k.succ ≤ mu k ≤ lam k.castSucc`
+from Poincaré separation, confirming the latter is a faithful generalisation:
+`k.succ` and `⟨k+1⟩` agree, as do `k.castSucc` and `⟨k⟩`. -/
+theorem cauchy_interlacing_of_poincare
+    {𝕜 V : Type*} [RCLike 𝕜] [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
+    [FiniteDimensional 𝕜 V] {n : ℕ}
+    (T : V →ₗ[𝕜] V) (b : OrthonormalBasis (Fin (n + 1)) 𝕜 V) (lam : Fin (n + 1) → ℝ)
+    (hT : ∀ i, T (b i) = (lam i : 𝕜) • b i) (hlam : Antitone lam)
+    (H : Submodule 𝕜 V) (hHdim : Module.finrank 𝕜 H = n)
+    (TH : H →ₗ[𝕜] H) (bH : OrthonormalBasis (Fin n) 𝕜 H) (mu : Fin n → ℝ)
+    (hTH : ∀ i, TH (bH i) = (mu i : 𝕜) • bH i) (hmu : Antitone mu)
+    (hRayleigh : ∀ y : H, y ≠ 0 →
+      RCLike.re (@inner 𝕜 H _ (TH y) y) / ‖y‖ ^ 2
+        = RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2)
+    (k : Fin n) :
+    lam k.succ ≤ mu k ∧ mu k ≤ lam k.castSucc := by
+  obtain ⟨hlo, hup⟩ :=
+    poincare_separation T b lam hT hlam H hHdim TH bH mu hTH hmu hRayleigh k
+  refine ⟨?_, ?_⟩
+  · -- `k.succ = ⟨k + 1⟩`
+    have : k.succ = (⟨(k : ℕ) + 1, by have := k.isLt; omega⟩ : Fin (n + 1)) := by
+      apply Fin.ext; simp
+    rw [this]; exact hlo
+  · -- `k.castSucc = ⟨k⟩`
+    have : k.castSucc = (⟨(k : ℕ), by have := k.isLt; omega⟩ : Fin (n + 1)) := by
+      apply Fin.ext; simp
+    rw [this]; exact hup
+
+end CauchyInterlacing.Poincare

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-02/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-02",
+  "title": "Poincaré Separation: Cauchy Interlacing for an Arbitrary-Codimension Compression",
+  "slug": "cauchy-interlacing-theorem-oq-02",
+  "description": "Generalises the parent entry's codimension-one Cauchy interlacing inequality λ(k+1) ≤ μ(k) ≤ λ(k) to a compression of arbitrary codimension m — the Poincaré separation theorem. For a symmetric operator T on an (n+m)-dimensional inner product space and a symmetric operator TH on a codimension-m subspace H whose Rayleigh quotient agrees with T's, the descending eigenvalues separate as λ(k+m) ≤ μ(k) ≤ λ(k) for every k (ascending: λ_k ≤ μ_k ≤ λ_{k+m}). The codimension-one theorem is the m = 1 special case, recovered as a corollary. No new spectral theory is needed: the variational keystone is already stated for an arbitrary subspace dimension, so only the dimension arithmetic of the assembly changes.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyInterlacingPoincare.lean",
+    "tags": [
+      "linear-algebra",
+      "spectral-theory",
+      "eigenvalues",
+      "cauchy-interlacing",
+      "poincare-separation",
+      "courant-fischer",
+      "rayleigh-quotient",
+      "inner-product-space"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "lineCount": 172,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "assumptions": "None beyond 'T and TH are symmetric operators, dim V = n + m, dim H = n, and TH's Rayleigh quotient agrees with T's on H' (the defining property of the orthogonal compression of T to H, discharged for the projection compression in sibling entry cauchy-interlacing-theorem-oq-01). 0 axioms, 0 sorries in this file and in its transitive imports (CauchyInterlacingKeystone.lean #25063, 0-sorry/0-axiom). This is the abstract / compression form, parallel to the parent: the Rayleigh-agreement hypothesis is taken as input here, keeping the file purely order-theoretic and dimension-counting.",
+    "originalContributions": [
+      "poincare_separation: the codimension-m Cauchy interlacing (Poincaré separation) inequality λ(k+m) ≤ μ(k) ∧ μ(k) ≤ λ(k) for every k : Fin n, proved from the parent's Courant–Fischer keystone with no new spectral input. The codimension-m dimension count dim(S ⊓ H) ≥ dim S − m replaces the codimension-one count dim(S ⊓ H) ≥ dim S − 1; the optimal lower-bound subspace is taken (k+m+1)-dimensional at keystone index k+m.",
+      "cauchy_interlacing_of_poincare: recovery of the parent entry's codimension-one inequality λ(k.succ) ≤ μ(k) ≤ λ(k.castSucc) as the m = 1 special case, confirming the generalisation is faithful (k.succ = ⟨k+1⟩ and k.castSucc = ⟨k⟩ via Fin.ext).",
+      "The structural observation that Poincaré separation requires NO new machinery over the keystone: because CauchyInterlacingKeystone's eigenvalue_maxmin_lower / eigenvalue_maxmin_upper / exists_rayleigh_le_in_subspace are parametrised by an arbitrary subspace dimension (index sets, not a fixed +1), the entire spectral content of the delete-m case is already in place, and only the omega-level arithmetic of the codimension count changes between m = 1 and general m."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Submodule.finrank_sup_add_finrank_inf_eq",
+        "description": "finrank(S ⊔ H) + finrank(S ⊓ H) = finrank S + finrank H — the Grassmann dimension formula that, with finrank(S ⊔ H) ≤ n + m, yields the codimension-m count dim(S ⊓ H) ≥ (k+m+1) + n − (n+m) = k+1 driving the lower bound",
+        "module": "Mathlib.LinearAlgebra.Finrank"
+      },
+      {
+        "theorem": "Submodule.finrank_map_subtype_eq",
+        "description": "finrank (W.map H.subtype) = finrank W — the dimension is preserved when pushing a subspace of H into V (and pulling S ⊓ H back into H), used to transfer the dimension counts across the inclusion H ↪ V",
+        "module": "Mathlib.LinearAlgebra.Finrank"
+      },
+      {
+        "theorem": "Submodule.map_comap_subtype",
+        "description": "(S).comap H.subtype mapped back by H.subtype equals S ⊓ H — identifies the pulled-back compression-side subspace with the ambient intersection",
+        "module": "Mathlib.LinearAlgebra.Span"
+      },
+      {
+        "theorem": "Fin.card_Ici",
+        "description": "#(Finset.Ici k) = n − k for k : Fin n — the interval cardinality feeding the keystone's index-set upper half with the codimension-m subspace",
+        "module": "Mathlib.Order.Interval.Finset.Fin"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Cauchy's 1829 interlacing theorem concerns deleting one row and column from a Hermitian matrix; the general statement for deleting m rows/columns — equivalently, compressing to a codimension-m subspace — is the Poincaré separation theorem (Poincaré 1890), a staple of matrix analysis (Horn–Johnson Thm 4.3.17, Bhatia §III). The parent gallery entry formalises the codimension-one case in abstract operator form, built on a from-scratch bound-form Courant–Fischer max–min keystone. Because that keystone characterises the k-th eigenvalue variationally over subspaces of ANY dimension, the jump to arbitrary codimension costs no new spectral theory — only a different dimension count — which is what this entry makes precise.",
+    "problemStatement": "Prove that for a symmetric operator T on an (n+m)-dimensional inner product space V with descending eigenvalues λ, and a symmetric operator TH on a codimension-m subspace H (dim H = n) with descending eigenvalues μ whose Rayleigh quotient agrees with T's on H, the eigenvalues separate: λ(k+m) ≤ μ(k) ≤ λ(k) for every k : Fin n. This answers the parent entry's second open question (the general 'delete m rows/columns' interlacing) by the direct (k+m)-dimensional count.",
+    "text": "The upper bound μ(k) ≤ λ(k) is identical to the codimension-one case: the optimal (k+1)-dimensional subspace SH ⊆ H for TH pushes into a (k+1)-dimensional subspace of V, on which the keystone's upper half finds a vector with Rayleigh quotient ≤ λ(k), and Rayleigh-agreement transfers the ≥ μ(k) bound — the codimension m never enters. The lower bound λ(k+m) ≤ μ(k) is where m appears: the optimal subspace for T is taken (k+m+1)-dimensional (keystone lower half at index k+m), and the codimension-m Grassmann count gives dim(S ⊓ H) ≥ k+1, exactly enough for the index-set keystone half on TH.",
+    "proofStrategy": "Index the conclusion by explicit Fin (n+m) elements ⟨k+m⟩ and ⟨k⟩ (well-defined since k < n). LOWER λ(k+m) ≤ μ(k): apply eigenvalue_maxmin_lower for T at index ⟨k+m⟩ to get a (k+m+1)-dimensional S with Rayleigh ≥ λ(k+m) on it; pull S ⊓ H back into H as SH; the Grassmann formula finrank(S⊔H)+finrank(S⊓H)=finrank S+finrank H together with finrank(S⊔H) ≤ n+m forces finrank(S⊓H) ≥ k+1; apply exists_rayleigh_le_in_subspace for TH on the index set Finset.Ici k to find a nonzero y ∈ SH with Rayleigh ≤ μ(k); push y to V (it lies in S), and λ(k+m) ≤ R_T(↑y) = R_TH(y) ≤ μ(k) by Rayleigh-agreement. UPPER μ(k) ≤ λ(k): apply eigenvalue_maxmin_lower for TH at k to get an optimal (k+1)-dim SH; map to S ⊆ V; eigenvalue_maxmin_upper for T at index ⟨k⟩ finds x ∈ S with R_T(x) ≤ λ(k); x = ↑y for y ∈ SH, so μ(k) ≤ R_TH(y) = R_T(x) ≤ λ(k). Finally specialise m = 1 and rewrite ⟨k+1⟩ = k.succ, ⟨k⟩ = k.castSucc to recover the parent inequality.",
+    "keyInsights": [
+      "**The keystone already covers all codimensions.** CauchyInterlacingKeystone phrases the Courant–Fischer halves over arbitrary index sets and arbitrary subspace dimension (finrank S, not a hard-coded k+1). So the spectral heart of the delete-m theorem was proved once, for the parent's delete-1 case, and is reused verbatim here — the generalisation is genuinely free of new analysis.",
+      "**Only the dimension count changes.** The codimension-one assembly uses dim(S ⊓ H) ≥ dim S − 1; the codimension-m case uses dim(S ⊓ H) ≥ dim S − m. Both come from the same Grassmann identity plus finrank(S ⊔ H) ≤ dim V; the difference is a single term in the omega call. Taking the lower-bound subspace (k+m+1)-dimensional instead of (k+2)-dimensional is the only other adjustment.",
+      "**The upper bound is codimension-blind.** μ(k) ≤ λ(k) holds with the identical proof for every m: it only needs a (k+1)-dimensional subspace of H pushed into V, never referencing how much of V lies outside H. All of the codimension dependence is in the lower bound λ(k+m) ≤ μ(k).",
+      "**Faithful generalisation.** Specialising m = 1 reproduces the parent's λ(k.succ) ≤ μ(k) ≤ λ(k.castSucc) on the nose (cauchy_interlacing_of_poincare), since ⟨k+1⟩ = k.succ and ⟨k⟩ = k.castSucc as elements of Fin (n+1)."
+    ],
+    "prerequisites": [
+      "The parent entry's Courant–Fischer max–min keystone (CauchyInterlacingKeystone): the bound-form variational characterisation of the descending k-th eigenvalue",
+      "The Grassmann dimension formula finrank(S ⊔ H) + finrank(S ⊓ H) = finrank S + finrank H",
+      "Submodules of an inner product space inherit the ambient inner product and norm (Rayleigh-agreement hypothesis)",
+      "The orthogonal-compression interpretation of TH (discharged in sibling entry cauchy-interlacing-theorem-oq-01 for codimension one)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "statement",
+      "title": "Poincaré Separation: the Statement",
+      "startLine": 74,
+      "endLine": 100,
+      "summary": "poincare_separation: T on V (dim n+m), descending eigenvalues λ with eigenbasis b; TH on H (dim n), descending eigenvalues μ with eigenbasis bH; Rayleigh-agreement hRayleigh. Conclusion: λ(⟨k+m⟩) ≤ μ(k) ∧ μ(k) ≤ λ(⟨k⟩) for every k : Fin n.",
+      "mathContext": "Ascending textbook form λ_k ≤ μ_k ≤ λ_{k+m}: a codimension-m compression's eigenvalues are sandwiched by those of the full operator m steps apart."
+    },
+    {
+      "id": "lower",
+      "title": "Lower Bound λ(k+m) ≤ μ(k)",
+      "startLine": 100,
+      "endLine": 130,
+      "summary": "Takes the optimal (k+m+1)-dimensional subspace S for T (keystone lower half at index k+m); the codimension-m Grassmann count gives dim(S ⊓ H) ≥ k+1; the index-set keystone half on TH finds y ∈ S ⊓ H with R_TH(y) ≤ μ(k); Rayleigh-agreement gives λ(k+m) ≤ R_T(↑y) = R_TH(y) ≤ μ(k).",
+      "mathContext": "The only place the codimension m enters: a larger optimal subspace for T plus the delete-m intersection count."
+    },
+    {
+      "id": "upper",
+      "title": "Upper Bound μ(k) ≤ λ(k)",
+      "startLine": 130,
+      "endLine": 146,
+      "summary": "Identical to the codimension-one case: the optimal (k+1)-dim subspace SH for TH maps into a (k+1)-dim subspace of V; the keystone upper half for T at index k finds x with R_T(x) ≤ λ(k); Rayleigh-agreement transfers the ≥ μ(k) bound on SH.",
+      "mathContext": "Codimension-blind — references only a (k+1)-dimensional piece of H, never the complement of H in V."
+    },
+    {
+      "id": "codim-one",
+      "title": "Recovering the Codimension-One Case",
+      "startLine": 147,
+      "endLine": 172,
+      "summary": "cauchy_interlacing_of_poincare: specialises m = 1 and rewrites k.succ = ⟨k+1⟩, k.castSucc = ⟨k⟩ (Fin.ext) to obtain the parent entry's λ(k.succ) ≤ μ(k) ≤ λ(k.castSucc).",
+      "mathContext": "Confirms Poincaré separation is a strict, faithful generalisation of the codimension-one Cauchy interlacing theorem."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 proof of the Poincaré separation theorem — Cauchy interlacing for a compression of arbitrary codimension m — λ(k+m) ≤ μ(k) ≤ λ(k), with the codimension-one theorem recovered as the m = 1 corollary. The file is 0-axiom, 0-sorry, as is its keystone import. It answers the parent entry's second open question by the suggested direct (k+m)-dimensional count, and demonstrates that the delete-m case needs no spectral theory beyond the codimension-one keystone.",
+    "implications": "Completes the abstract/operator-level delete-m interlacing for compressions, leaving the matrix-statement bridge (identifying the coordinate-subspace compression with a principal submatrix) as the sole remaining gap toward the literal Matrix.IsHermitian.eigenvalues₀ form. The structural point — that the variational keystone already subsumes every codimension — is reusable for related min-max consequences (Weyl monotonicity, Lidskii) that likewise only need the dimension count to vary.",
+    "openQuestions": [
+      "Discharge the Rayleigh-agreement hypothesis for the codimension-m orthogonal compression as in sibling oq-01 (the same projection-adjoint identity applies for any subspace H), yielding an unconditional codimension-m corollary.",
+      "Bridge to the literal matrix statement: for a Hermitian matrix and a coordinate subspace, identify the orthogonal compression with the principal submatrix obtained by deleting m rows/columns, reducing poincare_separation to Matrix.IsHermitian.eigenvalues₀."
+    ]
+  },
+  "crossReferences": [
+    {
+      "slug": "cauchy-interlacing-theorem",
+      "relation": "Parent entry — proves the codimension-one interlacing λ(k.succ) ≤ μ(k) ≤ λ(k.castSucc) and the Courant–Fischer keystone. This entry generalises the inequality to arbitrary codimension (the parent's second open question) and recovers the codimension-one case as the m = 1 corollary."
+    },
+    {
+      "slug": "cauchy-interlacing-theorem-oq-01",
+      "relation": "Sibling entry — discharges the Rayleigh-agreement hypothesis for the codimension-one compression by building the orthogonal projection compression explicitly. The same construction discharges it for arbitrary codimension, which would make this entry's inequality unconditional."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Horn, R.A.",
+        "Johnson, C.R."
+      ],
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "Theorem 4.3.17 (Cauchy interlacing) and Theorem 4.3.28 / §4.3 (Poincaré separation, general principal submatrices)"
+    },
+    {
+      "authors": [
+        "Bhatia, R."
+      ],
+      "title": "Matrix Analysis",
+      "year": "1997",
+      "venue": "Springer GTM 169",
+      "note": "Corollary III.1.5 and §III (Poincaré separation and interlacing via the min-max principle)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CauchyInterlacingKeystone"
+    ],
+    "opens": [
+      "InnerProductSpace"
+    ],
+    "namespace": "CauchyInterlacing.Poincare",
+    "lineCount": 172,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyInterlacingPoincare.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/cauchy-interlacing-theorem.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem.json
@@ -32,11 +32,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: first Lean shipped — operator-level keystone + 2 leaf lemmas stated (Sublemma B proof attempted); build-pending, both backends down",
+    "progressSummary": "PROGRESS: answered parent open question #2 — Poincaré separation theorem (arbitrary-codimension Cauchy interlacing) formalized 0-axiom, codim-1 recovered as m=1 corollary. Gallery entry cauchy-interlacing-theorem-oq-02.",
     "builtItems": [
       "approaches/orient-min-max-scaffolding.md: full ORIENT memo — proof decomposition (Courant–Fischer route), §4-verified exact Rayleigh signatures, §5-revised matrix-native statement, minimal residual-lemma list for the extreme-case PR. No .lean file shipped yet (the earlier builtItems entry claiming a CauchyInterlacing.lean was inaccurate — lean/ dir is empty).",
       "approaches/keystone-minmax-proof-design.md: full per-step Mathlib lemma map for the k-th min-max keystone + Sublemmas A/B + boundedness obligations (no Lean compiled, both backends down)",
-      "lean/CauchyInterlacingMinMax.lean: stated keystone eigenvalue_eq_iSup_iInf_rayleigh (k-th max-min, sorry) + leaf lemmas inf_exists_ne_zero_of_finrank_add_gt (Sublemma B, proof attempted) and rayleigh_mem_Icc_of_mem_eigenspan (Sublemma A, sorry) — build-pending, no backend"
+      "lean/CauchyInterlacingMinMax.lean: stated keystone eigenvalue_eq_iSup_iInf_rayleigh (k-th max-min, sorry) + leaf lemmas inf_exists_ne_zero_of_finrank_add_gt (Sublemma B, proof attempted) and rayleigh_mem_Icc_of_mem_eigenspan (Sublemma A, sorry) — build-pending, no backend",
+      "poincare_separation + cauchy_interlacing_of_poincare in Proofs/CauchyInterlacingPoincare.lean (2 thm, 172 lines, 0-sorry/0-axiom, docker build green 7744 jobs)"
     ],
     "insights": [
       "VERIFIED (Mathlib master, iter 3): Matrix.IsHermitian.eigenvalues₀ : Fin (Fintype.card n) → ℝ is sorted DESCENDING with Matrix.IsHermitian.eigenvalues₀_antitone (file Mathlib.LinearAlgebra.Matrix.Spectrum). Plain Matrix.IsHermitian.eigenvalues reuses index type n and is NOT sorted. So the 'no sorted eigenvalue function' gap from earlier survey notes is FALSE — state interlacing directly over eigenvalues₀, no abstract monotone-tuple workaround needed.",
@@ -48,7 +49,8 @@
       "Reduces to 2 standalone CLOSED sublemmas: (A) Rayleigh quotient on span of an eigenvector subset is a convex combination of those eigenvalues, hence between their min and max; (B) two subspaces with finrank sum > n meet nontrivially (via finrank_sup_add_finrank_inf_eq + finrank_le).",
       "Critical formalization hazard identified: ciInf/ciSup over subspace families need explicit BddBelow(mu last)/BddAbove(mu 0)+nonempty discharge or they return junk - the usual silent breakage point.",
       "CLM-vs-LM Rayleigh spelling mismatch (eigenvalues API on LinearMap, rayleighQuotient on ContinuousLinearMap) should be isolated to one bridge lemma, not threaded through the proof.",
-      "Parallel branch research/cauchy-interlacing-statement (PR #24800) holds the matrix statement of record (sortedEigs/principalDrop/cauchy_interlacing sorry) with a True-stub keystone; my operator-level leaf file complements it — the bridge is matrix Hermitian -> operator IsSymmetric via the spectral theorem"
+      "Parallel branch research/cauchy-interlacing-statement (PR #24800) holds the matrix statement of record (sortedEigs/principalDrop/cauchy_interlacing sorry) with a True-stub keystone; my operator-level leaf file complements it — the bridge is matrix Hermitian -> operator IsSymmetric via the spectral theorem",
+      "Poincaré separation (delete-m / codim-m interlacing λ(k+m) ≤ μ(k) ≤ λ(k)) needs NO new spectral theory over the codim-1 keystone: eigenvalue_maxmin_lower/upper + exists_rayleigh_le_in_subspace are parametrised by arbitrary subspace dimension, so only the Grassmann count dim(S⊓H) ≥ dim S − m and the (k+m+1)-dim optimal subspace change. Answered parent open question #2."
     ],
     "mathlibGaps": [
       "No k-th Courant–Fischer / min-max characterisation of the descending k-th eigenvalue in Mathlib (confirmed absent from both InnerProductSpace.Rayleigh and InnerProductSpace.Spectrum on master; only extreme top/bottom Rayleigh cases exist). This is the keystone; est. few hundred lines over Submodule ℂ (EuclideanSpace ℂ (Fin N)). Independently reusable (Weyl, Lidskii)."


### PR DESCRIPTION
## Summary
Research session for **cauchy-interlacing-theorem** (RICH). Answers the parent entry's **second open question** — the general "delete m rows/columns" interlacing — by the suggested direct (k+m)-dimensional count. This is the **Poincaré separation theorem**.

For a symmetric operator `T` on an `(n+m)`-dimensional inner product space `V` with descending eigenvalues `λ`, and a symmetric operator `TH` on a codimension-`m` subspace `H` (dim `n`) with descending eigenvalues `μ` and agreeing Rayleigh quotient, the eigenvalues separate:

`λ(k+m) ≤ μ(k) ≤ λ(k)` for every `k : Fin n`  (ascending: `λ_k ≤ μ_k ≤ λ_{k+m}`).

The parent's codimension-one Cauchy interlacing theorem (#27236) is recovered as the `m = 1` corollary.

## Progress
- **`poincare_separation`** — the codim-`m` interlacing inequality, proved from the parent's Courant–Fischer keystone (#25063) with **no new spectral input**.
- **`cauchy_interlacing_of_poincare`** — the `m = 1` recovery (`k.succ = ⟨k+1⟩`, `k.castSucc = ⟨k⟩` via `Fin.ext`), confirming the generalisation is faithful.
- `proofs/Proofs/CauchyInterlacingPoincare.lean` — 2 thm, 172 lines, **0-sorry / 0-axiom**.
- `src/data/proofs/cauchy-interlacing-theorem-oq-02/meta.json` — gallery entry.

## Findings
- **The keystone already subsumes every codimension.** `eigenvalue_maxmin_lower/upper` and `exists_rayleigh_le_in_subspace` are parametrised by arbitrary subspace dimension (index sets, not a fixed `+1`), so the spectral heart was proved once for the delete-1 case and reused verbatim.
- **Only the dimension count changes:** `dim(S ⊓ H) ≥ dim S − m` (Grassmann formula + `finrank(S ⊔ H) ≤ n+m`) replaces the delete-1 count, and the lower-bound optimal subspace is `(k+m+1)`-dimensional.
- **The upper bound `μ(k) ≤ λ(k)` is codimension-blind** — identical proof for every `m`; all `m`-dependence lives in the lower bound.

## Verification
Docker build green: `Built Proofs.CauchyInterlacingPoincare (59s)`, 7744 jobs. No `sorry`, no `axiom`, no `native_decide`; transitive import (keystone #25063) is 0-axiom.

## Status
**Outcome**: completed (answers parent open question #2)
**Next Steps**: discharge the Rayleigh hypothesis for the codim-m compression (same projection-adjoint identity as sibling oq-01) for an unconditional corollary; bridge to the literal `Matrix.IsHermitian.eigenvalues₀` principal-submatrix statement.

🤖 Generated by researcher-11