### PR TITLE
research(derangements-convergence-oq-03-oq-01): floor & ceiling forms of D(n)=round(n!/e)

### DIFF
--- a/proofs/Proofs/DerangementsConvergenceOQ03OQ01.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ03OQ01.lean
@@ -1,0 +1,117 @@
+/-
+  Derangements: round, floor, and ceiling forms of the rounding formula
+  Open Question: derangements-convergence-oq-03-oq-01
+
+  The parent open question (`derangements-convergence-oq-03`) established the
+  nearest-integer identity D(n) = round(n!/e) for n ≥ 2.  This entry repackages
+  that result in the three equivalent integer-rounding forms that appear in the
+  literature, all derived from a single strict two-sided bound.
+
+  ## Main Results
+
+  `abs_derangements_sub_lt_half` : For n ≥ 2,  |D(n) - n!·e⁻¹| < 1/2.
+
+  `derangements_eq_round` : For n ≥ 2,  (numDerangements n : ℤ) = round(n!·e⁻¹).
+  `derangements_eq_floor` : For n ≥ 2,  (numDerangements n : ℤ) = ⌊n!·e⁻¹ + 1/2⌋.
+  `derangements_eq_ceil`  : For n ≥ 2,  (numDerangements n : ℤ) = ⌈n!·e⁻¹ - 1/2⌉.
+
+  ## Proof Strategy
+
+  The whole file rests on the strict bound `|D(n) - n!/e| < 1/2`, extracted from
+  `DerangementsConvergence.derangements_convergence_rate` (multiply the rate
+  `|D/n! - e⁻¹| ≤ 1/(n+1)!` by `n!`, then `1/(n+1) < 1/2` for `n ≥ 2`).
+
+  Writing x = n!/e and D = D(n), the bound `|D - x| < 1/2` gives, by elementary
+  rearrangement, the hypotheses of three Mathlib characterisations:
+
+    * `Int.floor_eq_iff`  ⟹  ⌊x + 1/2⌋ = D    (needs D ≤ x+1/2 < D+1)
+    * `Int.ceil_eq_iff`   ⟹  ⌈x - 1/2⌉ = D    (needs D-1 < x-1/2 ≤ D)
+    * `round_eq`          ⟹  round x = ⌊x+1/2⌋ = D
+
+  Because e is irrational, x = n!/e is never a half-integer, so rounding up from
+  x-1/2 and down to x+1/2 land on the same integer D.
+
+  This is a routine packaging corollary: completeness / citability, not novelty.
+  (Note: the file is intentionally self-contained — it depends only on the base
+  `DerangementsConvergence` entry, re-deriving the round form rather than
+  importing the parent `DerangementsConvergenceOQ03`.)
+-/
+
+import Mathlib
+import Proofs.DerangementsConvergence
+
+open Nat Real Filter Topology
+
+namespace DerangementsConvergenceOQ03OQ01
+
+/-- The strict two-sided bound `|D(n) - n!/e| < 1/2` for `n ≥ 2`.
+
+  This is the engine behind the round / floor / ceiling forms.  It is extracted
+  from `DerangementsConvergence.derangements_convergence_rate`. -/
+theorem abs_derangements_sub_lt_half (n : ℕ) (hn : 2 ≤ n) :
+    |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| < 1 / 2 := by
+  have hfact_pos : (0 : ℝ) < n.factorial := Nat.cast_pos.mpr n.factorial_pos
+  set x : ℝ := (n.factorial : ℝ) * rexp (-1) with hx_def
+  have hrate := derangements_convergence_rate n
+  have hmul : |(numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1)| =
+      |(numDerangements n : ℝ) - x| / (n.factorial : ℝ) := by
+    rw [show (numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1) =
+        ((numDerangements n : ℝ) - x) / (n.factorial : ℝ) from by
+      simp only [hx_def]; field_simp]
+    rw [abs_div, abs_of_pos hfact_pos]
+  rw [hmul, div_le_iff₀ hfact_pos] at hrate
+  -- hrate : |D - x| ≤ 1/(n+1)! * n!
+  have hn3 : (2 : ℝ) < n + 1 := by exact_mod_cast (show 2 < n + 1 by omega)
+  have hlt3 : 1 / (n + 1 : ℝ) < 1 / 2 := one_div_lt_one_div_of_lt (by norm_num) hn3
+  have hfe : 1 / ((n + 1).factorial : ℝ) * (n.factorial : ℝ) = 1 / (n + 1 : ℝ) := by
+    rw [Nat.factorial_succ]; push_cast; field_simp
+  calc |(numDerangements n : ℝ) - x|
+      ≤ 1 / ((n + 1).factorial : ℝ) * (n.factorial : ℝ) := hrate
+    _ = 1 / (n + 1 : ℝ) := hfe
+    _ < 1 / 2 := hlt3
+
+/-- **Floor form.** For `n ≥ 2`, the number of derangements equals `⌊n!/e + 1/2⌋`.
+
+  Directly from the strict bound via `Int.floor_eq_iff`. -/
+theorem derangements_eq_floor (n : ℕ) (hn : 2 ≤ n) :
+    (numDerangements n : ℤ) = ⌊(n.factorial : ℝ) * rexp (-1) + 1 / 2⌋ := by
+  have habs := abs_lt.mp (abs_derangements_sub_lt_half n hn)
+  -- habs.1 : -(1/2) < D - x ;  habs.2 : D - x < 1/2
+  symm
+  apply Int.floor_eq_iff.mpr
+  refine ⟨?_, ?_⟩
+  · -- (D : ℝ) ≤ x + 1/2
+    push_cast; linarith [habs.2]
+  · -- x + 1/2 < D + 1
+    push_cast; linarith [habs.1]
+
+/-- **Ceiling form.** For `n ≥ 2`, the number of derangements equals `⌈n!/e - 1/2⌉`.
+
+  Directly from the strict bound via `Int.ceil_eq_iff`. -/
+theorem derangements_eq_ceil (n : ℕ) (hn : 2 ≤ n) :
+    (numDerangements n : ℤ) = ⌈(n.factorial : ℝ) * rexp (-1) - 1 / 2⌉ := by
+  have habs := abs_lt.mp (abs_derangements_sub_lt_half n hn)
+  symm
+  apply Int.ceil_eq_iff.mpr
+  refine ⟨?_, ?_⟩
+  · -- (D : ℝ) - 1 < x - 1/2  ⟺  D - x < 1/2
+    push_cast; linarith [habs.2]
+  · -- x - 1/2 ≤ D
+    push_cast; linarith [habs.1]
+
+/-- **Round form** (parent identity, re-derived self-containedly). For `n ≥ 2`,
+    the number of derangements equals the nearest integer `round(n!/e)`.
+
+  `round x = ⌊x + 1/2⌋` by `round_eq`, then apply the floor form. -/
+theorem derangements_eq_round (n : ℕ) (hn : 2 ≤ n) :
+    (numDerangements n : ℤ) = round ((n.factorial : ℝ) * rexp (-1)) := by
+  rw [round_eq]; exact derangements_eq_floor n hn
+
+/-- The floor and ceiling forms agree (both equal `D(n)`): `n!/e` is never a
+    half-integer in the relevant range. -/
+theorem floor_eq_ceil_forms (n : ℕ) (hn : 2 ≤ n) :
+    ⌊(n.factorial : ℝ) * rexp (-1) + 1 / 2⌋
+      = ⌈(n.factorial : ℝ) * rexp (-1) - 1 / 2⌉ := by
+  rw [← derangements_eq_floor n hn, ← derangements_eq_ceil n hn]
+
+end DerangementsConvergenceOQ03OQ01

--- a/src/data/proofs/derangements-convergence-oq-03-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-01/meta.json
@@ -1,0 +1,192 @@
+{
+  "id": "derangements-convergence-oq-03-oq-01",
+  "title": "Floor and ceiling forms of D(n) = round(n!/e)",
+  "slug": "derangements-convergence-oq-03-oq-01",
+  "description": "Repackages the nearest-integer derangement identity D(n) = round(n!/e) (n ≥ 2) into its equivalent floor form D(n) = ⌊n!/e + 1/2⌋ and ceiling form D(n) = ⌈n!/e − 1/2⌉. All three forms are derived self-containedly from a single strict two-sided bound |D(n) − n!/e| < 1/2, extracted from the alternating-series rate bound of the base entry, via Int.floor_eq_iff, Int.ceil_eq_iff and round_eq.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ03OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "rounding",
+      "floor",
+      "ceiling",
+      "exponential",
+      "number-theory",
+      "analysis",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. Fully machine-checked, 0 axioms, 0 sorries. The file is intentionally self-contained: it depends only on the base entry derangements_convergence_rate (from DerangementsConvergence.lean), re-deriving the strict bound |D(n) − n!/e| < 1/2 and the round form rather than importing the parent DerangementsConvergenceOQ03. (The parent entry's source has since bit-rotted against current Mathlib — div_le_iff was renamed div_le_iff₀ and floor_eq_iff became ambiguous — which is precisely why this corollary re-derives the bound directly from the base rate lemma using current lemma names.)",
+    "dateAdded": "2026-06-20",
+    "lineCount": 117,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "abs_derangements_sub_lt_half (PROVED): For n ≥ 2, |D(n) − n!·e⁻¹| < 1/2 — the strict two-sided bound that drives all three rounding forms, re-derived from derangements_convergence_rate with current Mathlib (div_le_iff₀)",
+      "derangements_eq_floor (PROVED): For n ≥ 2, (numDerangements n : ℤ) = ⌊n!·e⁻¹ + 1/2⌋, via Int.floor_eq_iff",
+      "derangements_eq_ceil (PROVED): For n ≥ 2, (numDerangements n : ℤ) = ⌈n!·e⁻¹ − 1/2⌉, via Int.ceil_eq_iff",
+      "derangements_eq_round (PROVED): the parent round identity re-established self-containedly via round_eq and the floor form",
+      "floor_eq_ceil_forms (PROVED): ⌊n!/e + 1/2⌋ = ⌈n!/e − 1/2⌉ for n ≥ 2 — both roundings land on D(n), recording that n!/e is never a half-integer in this range"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "derangements_convergence_rate",
+        "description": "Rate bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! from alternating series estimation",
+        "module": "Proofs.DerangementsConvergence"
+      },
+      {
+        "theorem": "Int.floor_eq_iff",
+        "description": "⌊r⌋ = z ↔ ↑z ≤ r ∧ r < z + 1 — gives the floor form from the strict bound",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "Int.ceil_eq_iff",
+        "description": "⌈r⌉ = z ↔ ↑z − 1 < r ∧ r ≤ ↑z — gives the ceiling form from the strict bound",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "round_eq",
+        "description": "round x = ⌊x + 1/2⌋ — bridges the round form to the floor form",
+        "module": "Mathlib.Algebra.Order.Round"
+      },
+      {
+        "theorem": "div_le_iff₀",
+        "description": "a / b ≤ c ↔ a ≤ c * b (b > 0) — clears the n! denominator in the rate bound (current name; replaces the removed div_le_iff)",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "abs_lt",
+        "description": "|a| < c ↔ −c < a ∧ a < c — unpacks the two-sided bound into the linear inequalities linarith closes",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Montmort (1708) and Euler (1751) established the derangement formula D(n) = n!·Σ_{k=0}^n (−1)^k/k!, whose alternating tail gives D(n)/n! → e⁻¹. The strengthening D(n) = round(n!/e) (the parent open question, OQ-03) is the standard textbook statement, but the literature most often quotes one of its two equivalent integer-valued forms: the floor form D(n) = ⌊n!/e + 1/2⌋ (which is literally how nearest-integer rounding is defined) and the ceiling form D(n) = ⌈n!/e − 1/2⌉. Both are unconditionally valid because n!/e is never a half-integer — a consequence of the irrationality (indeed transcendence, Hermite 1873) of e. This entry records all three forms as machine-checked corollaries of one strict bound.",
+    "problemStatement": "**OQ-03-OQ-01 of derangements-convergence**\n\nRestate the nearest-integer identity D(n) = round(n!/e) (n ≥ 2) in its two equivalent rounding forms:\n\n  D(n) = ⌊n!/e + 1/2⌋   (floor form)\n  D(n) = ⌈n!/e − 1/2⌉   (ceiling form)\n\nand record that the two roundings coincide.",
+    "text": "For n ≥ 2: (numDerangements n : ℤ) = ⌊n!·e⁻¹ + 1/2⌋ = ⌈n!·e⁻¹ − 1/2⌉ = round(n!·e⁻¹).",
+    "proofStrategy": "**One bound, three forms:**\n1. **Strict bound** (`abs_derangements_sub_lt_half`): From `derangements_convergence_rate` (|D/n! − e⁻¹| ≤ 1/(n+1)!), multiply by n! using `div_le_iff₀` to get |D(n) − n!/e| ≤ 1/(n+1)! · n! = 1/(n+1), and 1/(n+1) < 1/2 for n ≥ 2.\n2. **Floor form**: `abs_lt` splits the bound into D(n) ≤ x + 1/2 and x + 1/2 < D(n) + 1 (x = n!/e); these are exactly `Int.floor_eq_iff`'s two hypotheses, closed by `push_cast` + `linarith`.\n3. **Ceiling form**: the same bound gives D(n) − 1 < x − 1/2 and x − 1/2 ≤ D(n), exactly `Int.ceil_eq_iff`'s hypotheses.\n4. **Round form**: `round_eq` rewrites round x = ⌊x + 1/2⌋, then the floor form applies.",
+    "keyInsights": [
+      "A single strict bound |D(n) − n!/e| < 1/2 is the common engine: floor, ceiling and round forms are three different Mathlib characterisations (Int.floor_eq_iff, Int.ceil_eq_iff, round_eq) fed by the same two inequalities.",
+      "The floor form D(n) = ⌊n!/e + 1/2⌋ is the *definitional* content of 'nearest integer' — round_eq makes this a one-line bridge — while the ceiling form D(n) = ⌈n!/e − 1/2⌉ is its mirror image, equally valid because the bound is strict on both sides.",
+      "The two forms agreeing (floor_eq_ceil_forms) is the integer-level shadow of e's irrationality: n!/e is never a half-integer, so rounding x up from x−1/2 and down from x+1/2 land on the same integer. A genuine half-integer would split the floor and ceiling forms apart.",
+      "Robustness note: the file is self-contained and re-derives the round form rather than importing the parent DerangementsConvergenceOQ03, whose source has bit-rotted against current Mathlib (div_le_iff → div_le_iff₀, ambiguous floor_eq_iff). Using current lemma names keeps this corollary buildable independent of the parent's maintenance state.",
+      "Honest scope: this is a routine packaging corollary, not new mathematics. Its value is completeness and citability — providing the floor/ceiling forms that downstream entries and the literature commonly reference, each fully machine-checked at 0 axioms."
+    ],
+    "prerequisites": [
+      "derangements_convergence_rate from DerangementsConvergence.lean",
+      "Int.floor_eq_iff, Int.ceil_eq_iff, round_eq from Mathlib",
+      "Basic real arithmetic and factorial identities"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 45,
+      "description": "Documents the round/floor/ceiling repackaging and the self-contained design (imports only the base DerangementsConvergence entry)."
+    },
+    {
+      "id": "sec-bound",
+      "title": "The strict two-sided bound",
+      "startLine": 47,
+      "endLine": 71,
+      "description": "abs_derangements_sub_lt_half: |D(n) − n!/e| < 1/2 for n ≥ 2, extracted from derangements_convergence_rate by clearing the n! denominator (div_le_iff₀) and bounding 1/(n+1) < 1/2."
+    },
+    {
+      "id": "sec-floor",
+      "title": "Floor form",
+      "startLine": 73,
+      "endLine": 86,
+      "description": "derangements_eq_floor: D(n) = ⌊n!/e + 1/2⌋ via Int.floor_eq_iff and the strict bound."
+    },
+    {
+      "id": "sec-ceil",
+      "title": "Ceiling form",
+      "startLine": 88,
+      "endLine": 100,
+      "description": "derangements_eq_ceil: D(n) = ⌈n!/e − 1/2⌉ via Int.ceil_eq_iff and the strict bound."
+    },
+    {
+      "id": "sec-round",
+      "title": "Round form and agreement",
+      "startLine": 102,
+      "endLine": 117,
+      "description": "derangements_eq_round (parent identity, re-derived via round_eq) and floor_eq_ceil_forms (the two roundings coincide)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "derangements-convergence-oq-03",
+      "relationship": "Parent open question: proves D(n) = round(n!/e). This entry repackages it as floor and ceiling forms."
+    },
+    {
+      "slug": "derangements-convergence",
+      "relationship": "Base entry: supplies the rate bound derangements_convergence_rate that this entry's strict bound is built from."
+    },
+    {
+      "slug": "derangements-convergence-oq-03-oq-02",
+      "relationship": "Sibling: one-term recurrence and modular shadow of the rounding formula."
+    }
+  ],
+  "conclusion": "For all n ≥ 2 the derangement count D(n) admits three equivalent machine-checked rounding forms — round(n!/e), ⌊n!/e + 1/2⌋ and ⌈n!/e − 1/2⌉ — all flowing from the single strict bound |D(n) − n!/e| < 1/2, with the floor and ceiling forms provably coinciding because n!/e is never a half-integer.",
+  "mainTheorems": [
+    "abs_derangements_sub_lt_half: For n ≥ 2, |D(n) − n!·e⁻¹| < 1/2",
+    "derangements_eq_floor: For n ≥ 2, (numDerangements n : ℤ) = ⌊n!·e⁻¹ + 1/2⌋",
+    "derangements_eq_ceil: For n ≥ 2, (numDerangements n : ℤ) = ⌈n!·e⁻¹ − 1/2⌉",
+    "derangements_eq_round: For n ≥ 2, (numDerangements n : ℤ) = round(n!·e⁻¹)",
+    "floor_eq_ceil_forms: For n ≥ 2, ⌊n!·e⁻¹ + 1/2⌋ = ⌈n!·e⁻¹ − 1/2⌉"
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.DerangementsConvergence"
+    ],
+    "opens": [
+      "Nat",
+      "Real",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "DerangementsConvergenceOQ03OQ01",
+    "lineCount": 117,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 5,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsConvergenceOQ03OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Pierre de Montmort",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "venue": "Paris: Jacque Quillau (2nd ed. 1713)",
+      "note": "First derivation of the derangement formula D(n) = n! Σ_{k=0}^n (−1)^k / k!."
+    },
+    {
+      "authors": "Leonhard Euler",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie de Berlin 7, pp. 255–270",
+      "note": "Independent treatment; states D(n)/n! → e⁻¹, the limit underlying the rounding formula."
+    },
+    {
+      "authors": "Charles Hermite",
+      "title": "Sur la fonction exponentielle",
+      "year": "1873",
+      "venue": "Comptes Rendus de l'Académie des Sciences 77",
+      "note": "Transcendence of e; in particular e is irrational, so n!/e is never a half-integer — why the floor and ceiling forms coincide."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Repackages the parent open question `derangements-convergence-oq-03` (which proved the nearest-integer identity **D(n) = round(n!/e)** for n ≥ 2) into the two equivalent rounding forms most often cited in the literature:

- **Floor form:** D(n) = ⌊n!/e + 1/2⌋
- **Ceiling form:** D(n) = ⌈n!/e − 1/2⌉
- **Agreement:** ⌊n!/e + 1/2⌋ = ⌈n!/e − 1/2⌉ (the two roundings coincide)
- **Round form:** D(n) = round(n!/e) (parent identity, re-derived self-containedly)

All forms flow from a single strict bound **|D(n) − n!/e| < 1/2**, extracted from the base rate lemma `derangements_convergence_rate` and fed into `Int.floor_eq_iff`, `Int.ceil_eq_iff` and `round_eq`.

## Why self-contained

The file imports **only** the base `DerangementsConvergence` entry, not the parent `DerangementsConvergenceOQ03`. The parent's *source* has bit-rotted against current Mathlib (`div_le_iff` was removed in favour of `div_le_iff₀`; `floor_eq_iff` became ambiguous between `Int`/`Nat`). Re-deriving the bound directly with current lemma names keeps this corollary buildable regardless of the parent's maintenance state. (The parent's compiled artifact is still in the gallery; only its `.lean` no longer rebuilds — a separate repair.)

## Verification

- **5 theorems, 117 lines, 0 sorries, 0 axioms** — `status: verified`, `badge: original`
- Docker build green: `Built Proofs.DerangementsConvergenceOQ03OQ01 (57s)`

## Honest scope

This is a routine packaging corollary — completeness/citability, not new mathematics — as flagged in the problem statement. Value: each rounding form downstream entries may reference is now machine-checked at 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)