### PR TITLE
audit: mark 5 newest gallery entries clean in tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17361,8 +17361,38 @@
       "lastAudited": "2026-06-21T03:01:30Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-interlacing-theorem-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T03:54:08Z",
+      "result": "clean"
+    },
+    "cauchy-interlacing-theorem-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T03:54:08Z",
+      "result": "clean"
+    },
+    "derangements-convergence-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T03:54:08Z",
+      "result": "clean"
+    },
+    "dilworth-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T03:54:08Z",
+      "result": "clean"
+    },
+    "maschke-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T03:54:08Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T03:01:30Z"
+  "lastUpdated": "2026-06-21T03:54:08Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Five newly-merged gallery proofs shipped without `audit-tracker.json` keys. Because `claim-target.sh complete` only updates **existing** tracker entries, marking them clean was a no-op and `find-targets` reported them perpetually "never audited". This commits real `clean` entries to break that loop.

### Audited substantively — all CLEAN (0 axioms, 0 sorries, 0 True stubs)

| slug | status/badge | notes |
|------|--------------|-------|
| cauchy-interlacing-theorem-oq-01 | verified/original | Rayleigh hyp proved (not assumed) via projection adjoint identity |
| cauchy-interlacing-theorem-oq-02 | verified/original | Poincaré separation; abstract form, hyp disclosed as input |
| derangements-convergence-oq-03-oq-01 | verified/original | self-contained re-derivation of round form |
| dilworth-theorem-oq-01-oq-01 | verified/verified | hard direction, 0-axiom from scratch |
| maschke-theorem-oq-01-oq-01 | verified/mathlib | badge correctly credits Mathlib `IsSemisimpleRing→IsReduced` |

Each file: 0 real code sorries (the lone grep hit in each Cauchy file is the docstring text `0-sorry/0-axiom`), 0 `axiom` declarations, 0 `native_decide`, 0 True stubs. Badges defensible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)