### PR TITLE
research(kummer-theorem-oq-04-oq-01): C(2n,n) divisible by 2 exactly once ⟺ n a power of two [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/KummerTheoremOQ04OQ01.lean
+++ b/proofs/Proofs/KummerTheoremOQ04OQ01.lean
@@ -1,0 +1,190 @@
+import Mathlib
+
+/-
+# When is the Central Binomial Coefficient `C(2n, n)` Divisible by 2 Exactly Once?
+
+## The Open Question
+
+The parent result (`KummerTheoremOQ04`) computes the 2-adic valuation of the central
+binomial coefficient as the binary digit sum:
+
+$$\nu_2\binom{2n}{n} \;=\; s_2(n),$$
+
+where `s₂(n) = (Nat.digits 2 n).sum` is the number of `1`-bits of `n` (its popcount).
+
+A natural sharp follow-up asks for the *characterisation of the extreme case*: for
+which `n` is `C(2n, n)` divisible by `2` **exactly once**, i.e. `v₂(C(2n,n)) = 1`?
+
+## Answer: exactly when `n` is a power of two
+
+$$\nu_2\binom{2n}{n} = 1 \iff \exists k,\; n = 2^k.$$
+
+### Why this is true
+
+By the parent valuation formula this is equivalent to `s₂(n) = 1`, and the binary
+digit sum of a natural number equals `1` exactly when its binary expansion is a single
+`1` followed by zeros — that is, exactly when `n` is a power of `2`.
+
+The substantive new content here is the number-theoretic lemma
+
+* `sum_digits_two_eq_one_iff` : `s₂(n) = 1 ↔ ∃ k, n = 2^k`,
+
+which **Mathlib does not provide** (there is no `popcount = 1 ↔ power of two`
+characterisation in `Mathlib.Data.Nat.Digits`). The forward direction is a strong
+induction peeling the lowest bit; the converse reuses the digit sum of a pure power.
+
+## What Mathlib / the parent already have (reused here, kept self-contained)
+
+* `Nat.sub_one_mul_padicValNat_choose_eq_sub_sum_digits` — Kummer in digit-sum form;
+* `Nat.digits_base_mul`, `Nat.digits_def'`, `Nat.digits_base_pow_mul` — digit recursion;
+* the headline `v₂(C(2n,n)) = s₂(n)` is re-derived locally (≈10 lines) so this file
+  stands alone.
+
+## Results in this file (original content, 0 axioms / 0 sorries)
+
+* `sum_digits_two_eq_one_iff`           : `s₂(n) = 1 ↔ ∃ k, n = 2^k`  ← the new lemma
+* `padicValNat_two_centralBinom_eq_one_iff`
+                                        : `v₂(C(2n,n)) = 1 ↔ ∃ k, n = 2^k`  ← headline
+* `two_exactDvd_centralBinom_of_pow_two`: `n = 2^k ⟹ 2 ∣ C(2n,n) ∧ ¬ 4 ∣ C(2n,n)`
+* worked numeric witnesses (`C(2,1)=2`, `C(8,4)=70`, `n=6` is not a power of two …).
+-/
+
+namespace KummerCentralBinomPowerTwo
+
+open Nat
+
+/-- **Doubling-invariance of the binary digit sum.** Multiplying by the base `2`
+prepends a `0` digit, leaving the digit sum unchanged: `s₂(2n) = s₂(n)`. -/
+theorem sum_digits_two_mul (n : ℕ) :
+    (Nat.digits 2 (2 * n)).sum = (Nat.digits 2 n).sum := by
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · subst hn; simp
+  · rw [Nat.digits_base_mul one_lt_two hn]; simp
+
+/-- For `n > 0` the binary digit sum is positive (the leading digit is nonzero). -/
+theorem sum_digits_two_pos {n : ℕ} (hn : 0 < n) : 0 < (Nat.digits 2 n).sum := by
+  have hnil : Nat.digits 2 n ≠ [] := Nat.digits_ne_nil_iff_ne_zero.mpr hn.ne'
+  exact Nat.sum_pos_iff_exists_pos.mpr
+    ⟨_, List.getLast_mem hnil, Nat.pos_of_ne_zero (Nat.getLast_digit_ne_zero 2 hn.ne')⟩
+
+/-- **The 2-adic valuation of the central binomial coefficient is the binary digit
+sum** (parent headline, re-derived to keep this file self-contained):
+`v₂(C(2n, n)) = s₂(n)`. -/
+theorem padicValNat_two_centralBinom (n : ℕ) :
+    padicValNat 2 (Nat.centralBinom n) = (Nat.digits 2 n).sum := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have h : n ≤ 2 * n := by omega
+  have key := sub_one_mul_padicValNat_choose_eq_sub_sum_digits (p := 2) (k := n) (n := 2 * n) h
+  have e1 : (2 : ℕ) * n - n = n := by omega
+  rw [e1, sum_digits_two_mul] at key
+  rw [Nat.centralBinom_eq_two_mul_choose]
+  omega
+
+/-- **Digit sum of a pure power of two is one.** `s₂(2^k) = 1`: the binary expansion
+of `2^k` is `1` preceded by `k` zeros. -/
+theorem sum_digits_two_pow (k : ℕ) :
+    (Nat.digits 2 (2 ^ k)).sum = 1 := by
+  rw [show (2 : ℕ) ^ k = 2 ^ k * 1 by ring, Nat.digits_base_pow_mul one_lt_two one_pos]
+  simp
+
+/-- **Forward direction of the characterisation.** If the binary digit sum of `n` is
+`1`, then `n` is a power of two. Strong induction, peeling the lowest bit:
+`s₂(n) = (n % 2) + s₂(n / 2)`. -/
+theorem sum_digits_two_eq_one_imp (n : ℕ) :
+    (Nat.digits 2 n).sum = 1 → ∃ k, n = 2 ^ k := by
+  induction n using Nat.strongRecOn with
+  | ind n ih =>
+    intro h
+    have hn : 0 < n := by
+      rcases Nat.eq_zero_or_pos n with rfl | hp
+      · simp at h
+      · exact hp
+    rw [Nat.digits_def' one_lt_two hn, List.sum_cons] at h
+    -- h : n % 2 + (Nat.digits 2 (n / 2)).sum = 1
+    have hhalf : n / 2 < n := Nat.div_lt_self hn one_lt_two
+    rcases Nat.even_or_odd n with he | ho
+    · -- n even: lowest bit is 0, so s₂(n/2) = 1
+      have h0 : n % 2 = 0 := Nat.even_iff.mp he
+      rw [h0, Nat.zero_add] at h
+      obtain ⟨j, hj⟩ := ih (n / 2) hhalf h
+      refine ⟨j + 1, ?_⟩
+      have he2 : n = 2 * (n / 2) := by omega
+      rw [he2, hj]; ring
+    · -- n odd: lowest bit is 1, so s₂(n/2) = 0, forcing n/2 = 0 and n = 1 = 2^0
+      have h1 : n % 2 = 1 := Nat.odd_iff.mp ho
+      rw [h1] at h
+      have hz : (Nat.digits 2 (n / 2)).sum = 0 := by omega
+      have hz2 : n / 2 = 0 := by
+        by_contra hne
+        have := sum_digits_two_pos (Nat.pos_of_ne_zero hne)
+        omega
+      exact ⟨0, by rw [pow_zero]; omega⟩
+
+/-- **The binary digit sum equals one exactly for powers of two.**
+`s₂(n) = 1 ↔ ∃ k, n = 2^k`. (Not available in Mathlib.) -/
+theorem sum_digits_two_eq_one_iff (n : ℕ) :
+    (Nat.digits 2 n).sum = 1 ↔ ∃ k, n = 2 ^ k := by
+  constructor
+  · exact sum_digits_two_eq_one_imp n
+  · rintro ⟨k, rfl⟩
+    exact sum_digits_two_pow k
+
+/-- **Headline characterisation.** The central binomial coefficient `C(2n, n)` is
+divisible by `2` exactly once iff `n` is a power of two:
+`v₂(C(2n, n)) = 1 ↔ ∃ k, n = 2^k`. -/
+theorem padicValNat_two_centralBinom_eq_one_iff (n : ℕ) :
+    padicValNat 2 (Nat.centralBinom n) = 1 ↔ ∃ k, n = 2 ^ k := by
+  rw [padicValNat_two_centralBinom]
+  exact sum_digits_two_eq_one_iff n
+
+/-- **Sharp divisibility at a power of two.** When `n = 2^k`, the central binomial
+coefficient is divisible by `2` but not by `4`: `2 ∣ C(2n,n)` and `¬ 4 ∣ C(2n,n)`. -/
+theorem two_exactDvd_centralBinom_of_pow_two (k : ℕ) :
+    2 ∣ Nat.centralBinom (2 ^ k) ∧ ¬ (4 ∣ Nat.centralBinom (2 ^ k)) := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have hv : padicValNat 2 (Nat.centralBinom (2 ^ k)) = 1 := by
+    rw [padicValNat_two_centralBinom, sum_digits_two_pow]
+  refine ⟨?_, ?_⟩
+  · have hd : (2 : ℕ) ^ padicValNat 2 (Nat.centralBinom (2 ^ k)) ∣
+        Nat.centralBinom (2 ^ k) := pow_padicValNat_dvd
+    rwa [hv, pow_one] at hd
+  · intro h4
+    have h4' : (2 : ℕ) ^ 2 ∣ Nat.centralBinom (2 ^ k) := by
+      rwa [show (4 : ℕ) = 2 ^ 2 by norm_num] at h4
+    have hle := (padicValNat_dvd_iff_le (Nat.centralBinom_ne_zero _)).mp h4'
+    rw [hv] at hle; omega
+
+/-! ### Worked numeric witnesses (0-axiom)
+
+Concrete `centralBinom` values are evaluated by kernel `decide`; valuations are read
+off from the characterisation above. -/
+
+/-- `n = 1 = 2^0`: `C(2,1) = 2`, divisible by `2` exactly once. -/
+example : Nat.centralBinom 1 = 2 := by decide
+example : padicValNat 2 (Nat.centralBinom 1) = 1 :=
+  (padicValNat_two_centralBinom_eq_one_iff 1).mpr ⟨0, rfl⟩
+
+/-- `n = 4 = 2^2`: `C(8,4) = 70 = 2 · 35`, so `v₂ = 1`. -/
+example : Nat.centralBinom 4 = 70 := by decide
+example : padicValNat 2 (Nat.centralBinom 4) = 1 :=
+  (padicValNat_two_centralBinom_eq_one_iff 4).mpr ⟨2, rfl⟩
+
+/-- `n = 8 = 2^3`: a power of two, so `v₂(C(16,8)) = 1`. -/
+example : padicValNat 2 (Nat.centralBinom 8) = 1 :=
+  (padicValNat_two_centralBinom_eq_one_iff 8).mpr ⟨3, rfl⟩
+
+/-- `n = 6 = 110₂` is **not** a power of two (`s₂(6) = 2`), so `v₂(C(12,6)) ≠ 1`
+(indeed `C(12,6) = 924 = 2² · 231`). -/
+example : Nat.centralBinom 6 = 924 := by decide
+example : padicValNat 2 (Nat.centralBinom 6) ≠ 1 := by
+  rw [ne_eq, padicValNat_two_centralBinom_eq_one_iff]
+  rintro ⟨k, hk⟩
+  have hk6 : (2 : ℕ) ^ k = 6 := hk.symm
+  have hk3 : k < 3 := by
+    by_contra hcon
+    push_neg at hcon
+    have : (2 : ℕ) ^ 3 ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) hcon
+    omega
+  interval_cases k <;> norm_num at hk6
+
+end KummerCentralBinomPowerTwo

--- a/src/data/proofs/kummer-theorem-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-04-oq-01/annotations.json
@@ -1,0 +1,120 @@
+[
+  {
+    "id": "ann-kummer-oq0401-headline",
+    "proofId": "kummer-theorem-oq-04-oq-01",
+    "range": {
+      "startLine": 135,
+      "endLine": 139
+    },
+    "type": "insight",
+    "title": "Headline: v₂(C(2n,n)) = 1 ⟺ n is a Power of Two",
+    "content": "`padicValNat_two_centralBinom_eq_one_iff` is the main result: the central binomial coefficient is divisible by 2 exactly once iff n is a power of two. The proof is a single `rw [padicValNat_two_centralBinom]` rewriting the valuation as the binary digit sum s₂(n), followed by `exact sum_digits_two_eq_one_iff n`. All the real work is in the popcount lemma; the binomial coefficient contributes only through the parent valuation formula.",
+    "mathContext": "Since $v_2(\\binom{2n}{n}) = s_2(n)$, the minimal nonzero valuation $1$ occurs exactly when the binary expansion of $n$ has a single $1$-bit — i.e. $n = 2^k$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "2-adic valuation",
+      "popcount",
+      "powers of two"
+    ],
+    "prerequisites": [
+      "Nat.centralBinom",
+      "padicValNat",
+      "binary digit sum"
+    ]
+  },
+  {
+    "id": "ann-kummer-oq0401-popcount-iff",
+    "proofId": "kummer-theorem-oq-04-oq-01",
+    "range": {
+      "startLine": 125,
+      "endLine": 133
+    },
+    "type": "insight",
+    "title": "The New Lemma: s₂(n) = 1 ⟺ ∃k, n = 2^k",
+    "content": "`sum_digits_two_eq_one_iff` characterises when the binary digit sum (popcount) equals 1: exactly for the powers of two. Mathlib's `Mathlib.Data.Nat.Digits` has no such statement, so this is genuinely new infrastructure. The forward direction is `sum_digits_two_eq_one_imp` (strong induction); the converse `rintro ⟨k, rfl⟩; exact sum_digits_two_pow k` uses that 2^k has digit sum 1.",
+    "mathContext": "A natural number has Hamming weight (popcount) $1$ precisely when it is a power of two — the binary string is a single $1$ followed by zeros.",
+    "significance": "key",
+    "relatedConcepts": [
+      "popcount",
+      "Hamming weight",
+      "binary representation",
+      "powers of two"
+    ],
+    "prerequisites": [
+      "Nat.digits",
+      "List.sum",
+      "strong induction"
+    ]
+  },
+  {
+    "id": "ann-kummer-oq0401-forward-induction",
+    "proofId": "kummer-theorem-oq-04-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 123
+    },
+    "type": "technique",
+    "title": "Forward Direction by Lowest-Bit Peeling",
+    "content": "`sum_digits_two_eq_one_imp` uses `Nat.strongRecOn` and `Nat.digits_def'` to rewrite s₂(n) = (n%2) + s₂(n/2). On even n the low bit is 0, so s₂(n/2) = 1 and the induction hypothesis (applicable since n/2 < n) gives n/2 = 2^j, hence n = 2·2^j = 2^{j+1}. On odd n the low bit is 1, so s₂(n/2) = 0; since a positive number has positive digit sum (`sum_digits_two_pos`), n/2 = 0, forcing n = 1 = 2^0. `omega` discharges the arithmetic in each branch.",
+    "mathContext": "The recursion $s_2(n) = (n \\bmod 2) + s_2(\\lfloor n/2 \\rfloor)$ is the binary analogue of digit extraction; descending on $\\lfloor n/2 \\rfloor$ tracks the bits one at a time.",
+    "significance": "important",
+    "relatedConcepts": [
+      "strong induction",
+      "Nat.digits_def'",
+      "parity case split",
+      "binary digit recursion"
+    ],
+    "prerequisites": [
+      "Nat.strongRecOn",
+      "Nat.digits_def'",
+      "Nat.even_or_odd",
+      "omega"
+    ]
+  },
+  {
+    "id": "ann-kummer-oq0401-power-two-digitsum",
+    "proofId": "kummer-theorem-oq-04-oq-01",
+    "range": {
+      "startLine": 84,
+      "endLine": 91
+    },
+    "type": "insight",
+    "title": "Digit Sum of a Pure Power of Two is One",
+    "content": "`sum_digits_two_pow` proves s₂(2^k) = 1 with no case analysis: rewriting 2^k = 2^k · 1 and applying `Nat.digits_base_pow_mul one_lt_two one_pos` expresses the binary expansion as `replicate k 0 ++ digits 2 1`, whose sum `simp` collapses to 1. This is the converse half of the popcount characterisation.",
+    "mathContext": "$2^k$ in binary is $1\\underbrace{0\\cdots0}_{k}$, a single nonzero digit.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Nat.digits_base_pow_mul",
+      "powers of two",
+      "binary representation"
+    ],
+    "prerequisites": [
+      "Nat.digits",
+      "List.replicate",
+      "List.sum"
+    ]
+  },
+  {
+    "id": "ann-kummer-oq0401-sharp-divisibility",
+    "proofId": "kummer-theorem-oq-04-oq-01",
+    "range": {
+      "startLine": 141,
+      "endLine": 159
+    },
+    "type": "insight",
+    "title": "Sharp 2-Exact Divisibility: 2 ∥ C(2^{k+1}, 2^k)",
+    "content": "`two_exactDvd_centralBinom_of_pow_two` records the sharp form at a power of two: 2 ∣ C(2n,n) but 4 ∤ C(2n,n). From v₂ = 1, `pow_padicValNat_dvd` gives 2^1 ∣ C(2n,n); for non-divisibility by 4 = 2², `padicValNat_dvd_iff_le` would force 2 ≤ v₂ = 1, a contradiction closed by `omega`.",
+    "mathContext": "At the powers of two the 2-adic valuation attains its minimal nonzero value, so $2$ divides the central coefficient exactly once.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "exact divisibility",
+      "pow_padicValNat_dvd",
+      "padicValNat_dvd_iff_le"
+    ],
+    "prerequisites": [
+      "padicValNat",
+      "divisibility"
+    ]
+  }
+]

--- a/src/data/proofs/kummer-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-04-oq-01/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "kummer-theorem-oq-04-oq-01",
+  "title": "Kummer OQ-04-OQ-01: C(2n,n) Divisible by 2 Exactly Once ⟺ n a Power of Two",
+  "slug": "kummer-theorem-oq-04-oq-01",
+  "description": "Sharp characterisation of the minimal-valuation case of the central binomial coefficient: v₂(C(2n,n)) = 1 if and only if n is a power of two. Reduces, via the parent closed form v₂(C(2n,n)) = s₂(n), to the binary-digit-sum lemma s₂(n) = 1 ⟺ ∃k, n = 2^k — a popcount characterisation Mathlib does not provide. Includes the sharp 2-exact-divisibility 2 ∥ C(2^{k+1}, 2^k).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KummerTheoremOQ04OQ01.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "kummer-theorem",
+      "p-adic",
+      "binomial-coefficient",
+      "central-binomial-coefficient",
+      "popcount",
+      "powers-of-two"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "lineCount": 190,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "assumptions": "None. 0 axioms, 0 sorries. The headline v₂(C(2n,n)) = s₂(n) is re-derived locally from Mathlib's digit-sum Kummer theorem (sub_one_mul_padicValNat_choose_eq_sub_sum_digits); the new content is the popcount = 1 ⟺ power-of-two characterisation proved by strong induction. Numeric witnesses use kernel `decide` (not native_decide), so no Lean.ofReduceBool dependency.",
+    "originalContributions": [
+      "sum_digits_two_eq_one_iff: the binary digit sum equals 1 exactly for powers of two, s₂(n) = 1 ⟺ ∃k, n = 2^k — the core new lemma, absent from Mathlib (no popcount/digit-sum power-of-two characterisation in Mathlib.Data.Nat.Digits)",
+      "sum_digits_two_eq_one_imp: forward direction by strong induction, peeling the lowest bit s₂(n) = (n%2) + s₂(n/2): even n recurses on n/2, odd n>1 forces a second 1-bit (contradiction), only n=1 survives among odds",
+      "padicValNat_two_centralBinom_eq_one_iff: the headline characterisation v₂(C(2n,n)) = 1 ⟺ ∃k, n = 2^k, packaging the parent valuation formula with the new popcount lemma",
+      "sum_digits_two_pow: digit sum of a pure power of two is 1 (the binary expansion 1 followed by k zeros), via Nat.digits_base_pow_mul",
+      "two_exactDvd_centralBinom_of_pow_two: sharp divisibility at the extreme — for n = 2^k, 2 ∣ C(2n,n) but 4 ∤ C(2n,n), i.e. 2 ∥ C(2^{k+1}, 2^k)",
+      "worked numeric witnesses: C(2,1)=2 (n=1=2^0), C(8,4)=70=2·35 (n=4=2^2), n=8=2^3, and the non-example n=6=110₂ with C(12,6)=924=2²·231 showing v₂≠1 for non-powers"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sub_one_mul_padicValNat_choose_eq_sub_sum_digits",
+        "description": "Legendre/Kummer digit-sum identity: (p-1)·v_p(C(n,k)) = s_p(k) + s_p(n-k) - s_p(n), specialised here to p=2 on the diagonal",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal"
+      },
+      {
+        "theorem": "Nat.digits_def'",
+        "description": "digits b n = n % b :: digits b (n / b) for 1 < b, 0 < n — the lowest-bit peel driving the strong induction",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "Nat.digits_base_pow_mul",
+        "description": "digits b (b^k * m) = replicate k 0 ++ digits b m — gives s₂(2^k) = 1 directly",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "pow_padicValNat_dvd / padicValNat_dvd_iff_le",
+        "description": "p^{v_p(m)} ∣ m and p^n ∣ m ↔ n ≤ v_p(m) — used for the sharp 2 ∥ C(2n,n) corollary",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Kummer's theorem (1852) computes the $p$-adic valuation $v_p(\\binom{n}{k})$ as the number of carries when adding $k$ and $n-k$ in base $p$; equivalently $(p-1)v_p(\\binom{n}{k}) = s_p(k)+s_p(n-k)-s_p(n)$ for the base-$p$ digit sum $s_p$. The parent entry specialises this to the central binomial coefficient $\\binom{2n}{n}$, giving the closed form $v_2(\\binom{2n}{n}) = s_2(n)$, the binary popcount of $n$. This follow-up isolates the extreme of that formula: the central coefficient is divisible by exactly one factor of $2$ precisely when $n$ has a single $1$-bit, i.e. $n$ is a power of two. The underlying arithmetic fact — popcount equals $1$ iff a power of two — is elementary but, perhaps surprisingly, has no direct statement in Mathlib's digit library.",
+    "problemStatement": "Characterise the natural numbers $n$ for which the central binomial coefficient $\\binom{2n}{n}$ is divisible by $2$ exactly once, $v_2(\\binom{2n}{n}) = 1$.",
+    "text": "Via the parent closed form $v_2(\\binom{2n}{n}) = s_2(n)$, the answer is exactly the powers of two: $v_2(\\binom{2n}{n}) = 1 \\iff \\exists k,\\, n = 2^k$.",
+    "proofStrategy": "Reduce $v_2(\\binom{2n}{n}) = 1$ to $s_2(n) = 1$ using the parent valuation formula (re-derived locally to stay self-contained). Then prove $s_2(n) = 1 \\iff \\exists k, n = 2^k$. Forward: strong induction on $n$, using $s_2(n) = (n \\bmod 2) + s_2(n/2)$ from `Nat.digits_def'`. If $n$ is even the low bit is $0$ so $s_2(n/2)=1$ and the induction hypothesis gives $n/2 = 2^j$, hence $n = 2^{j+1}$; if $n$ is odd the low bit is $1$ so $s_2(n/2)=0$, forcing $n/2 = 0$ (a positive number has positive digit sum) and thus $n = 1 = 2^0$. Converse: $s_2(2^k) = 1$ from `Nat.digits_base_pow_mul`. The sharp divisibility corollary reads $2 \\parallel \\binom{2^{k+1}}{2^k}$ off the valuation via the `padicValNat` API.",
+    "keyInsights": [
+      "**Popcount = 1 is the whole content.** Stripping away the binomial coefficient, the theorem is the clean bit-counting fact that a natural number has exactly one $1$-bit iff it is a power of two. The central binomial coefficient enters only through the parent identity $v_2 = s_2$.",
+      "**Strong induction peels the lowest bit.** The recursion $s_2(n) = (n \\bmod 2) + s_2(n/2)$ splits on parity: an even $n$ inherits its single bit from $n/2$, while an odd $n>1$ would need a second bit and is impossible — only $n=1$ remains.",
+      "**Positivity of the digit sum closes the odd case.** The step $s_2(n/2) = 0 \\Rightarrow n/2 = 0$ uses that any positive number has a nonzero leading binary digit, so its digit sum is strictly positive.",
+      "**The converse is immediate.** $2^k$ in binary is a single $1$ preceded by $k$ zeros, so its digit sum is $1$ with no case analysis — `Nat.digits_base_pow_mul` delivers this.",
+      "**Sharpness, not just divisibility.** At a power of two the valuation is exactly $1$: $2 \\mid \\binom{2n}{n}$ but $4 \\nmid \\binom{2n}{n}$, the minimal nonzero $2$-adic valuation among all $n \\geq 1$."
+    ],
+    "prerequisites": [
+      "The parent closed form v₂(C(2n,n)) = s₂(n) (Kummer specialised to p=2 on the diagonal)",
+      "Base-2 digit representations and the recursion digits 2 n = n%2 :: digits 2 (n/2)",
+      "Strong induction on ℕ (Nat.strongRecOn)",
+      "The padicValNat divisibility API: pow_padicValNat_dvd, padicValNat_dvd_iff_le"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Research Question and Answer",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "File header: the open question (when is C(2n,n) divisible by 2 exactly once), the answer (exactly the powers of two), the reduction to s₂(n)=1, and a note that the popcount characterisation is the new content absent from Mathlib."
+    },
+    {
+      "id": "reused-headline",
+      "title": "Reused Building Blocks: Doubling-Invariance and v₂ = s₂",
+      "startLine": 53,
+      "endLine": 83,
+      "summary": "sum_digits_two_mul (s₂(2n)=s₂(n)), sum_digits_two_pos (s₂(n)>0 for n>0), and padicValNat_two_centralBinom (the parent headline v₂(C(2n,n))=s₂(n), re-derived locally so the file is self-contained).",
+      "mathContext": "These three lemmas reproduce just enough of the parent entry to translate the valuation question into a pure digit-sum question."
+    },
+    {
+      "id": "digit-sum-power-two",
+      "title": "Digit Sum of a Power of Two is One",
+      "startLine": 84,
+      "endLine": 91,
+      "summary": "sum_digits_two_pow: s₂(2^k)=1, since 2^k = 2^k·1 has binary expansion replicate k 0 ++ [1] via Nat.digits_base_pow_mul.",
+      "mathContext": "$2^k$ has a single 1-bit; this is the converse half of the characterisation."
+    },
+    {
+      "id": "forward-induction",
+      "title": "Forward Direction: s₂(n)=1 ⟹ n is a Power of Two",
+      "startLine": 92,
+      "endLine": 123,
+      "summary": "sum_digits_two_eq_one_imp: strong induction peeling the lowest bit. Even n: low bit 0, recurse on n/2 to get n=2^{j+1}. Odd n: low bit 1 forces s₂(n/2)=0, so n/2=0 and n=1=2^0.",
+      "mathContext": "The only way to spend a digit-sum budget of 1 is a single 1-bit, which by parity descent lands exactly on the powers of two."
+    },
+    {
+      "id": "characterisation",
+      "title": "The Characterisations: Digit Sum and Valuation",
+      "startLine": 124,
+      "endLine": 140,
+      "summary": "sum_digits_two_eq_one_iff (s₂(n)=1 ⟺ ∃k, n=2^k) combining the two directions, and padicValNat_two_centralBinom_eq_one_iff (v₂(C(2n,n))=1 ⟺ ∃k, n=2^k), the headline result.",
+      "mathContext": "Rewriting the valuation by the parent formula turns the binomial statement into the popcount statement."
+    },
+    {
+      "id": "sharp-divisibility",
+      "title": "Sharp 2-Exact Divisibility at Powers of Two",
+      "startLine": 141,
+      "endLine": 159,
+      "summary": "two_exactDvd_centralBinom_of_pow_two: for n=2^k, 2 ∣ C(2n,n) and ¬ 4 ∣ C(2n,n), i.e. 2 ∥ C(2^{k+1},2^k), derived from v₂=1 via pow_padicValNat_dvd and padicValNat_dvd_iff_le.",
+      "mathContext": "At the powers of two the 2-adic valuation attains its minimal nonzero value 1."
+    },
+    {
+      "id": "numeric-witnesses",
+      "title": "Worked Numeric Witnesses",
+      "startLine": 160,
+      "endLine": 190,
+      "summary": "Kernel-decidable evaluations: C(2,1)=2 (n=1=2^0), C(8,4)=70 (n=4=2^2), n=8=2^3, and the non-example n=6 with C(12,6)=924 showing v₂≠1 for the non-power 6=110₂. Ends namespace KummerCentralBinomPowerTwo.",
+      "mathContext": "Sanity checks confirm both the positive characterisation and its failure on a number with two 1-bits."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, self-contained Lean 4 formalization characterising the minimal-valuation case of the central binomial coefficient: v₂(C(2n,n)) = 1 ⟺ n is a power of two. The crux is a new popcount lemma s₂(n)=1 ⟺ ∃k, n=2^k (strong induction on the binary expansion), which Mathlib does not provide. 8 theorems, 0 axioms, 0 sorries.",
+    "implications": "Pins down exactly which central binomial coefficients are divisible by 2 only once, the extreme opposite of the all-ones case (parent's padicValNat_two_centralBinom_pred_pow_two) where the valuation is maximal. The standalone popcount characterisation s₂(n)=1 ⟺ power-of-two is reusable for any digit-sum/popcount argument over ℕ.",
+    "openQuestions": [
+      "Characterise the n with v₂(C(2n,n)) = 2 (exactly two 1-bits): is there a clean closed description of the level sets of popcount?",
+      "For an odd prime p, when is v_p(C(2n,n)) minimal, and does a base-p single-digit characterisation hold?",
+      "Transfer the v₂=1 characterisation to the Catalan number C_n = C(2n,n)/(n+1): for which n is C_n odd or 2-exactly-divisible?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "kummer-theorem-oq-04",
+      "relationship": "extends",
+      "description": "Parent entry proving v₂(C(2n,n)) = s₂(n); this follow-up characterises the minimal case v₂ = 1 as exactly the powers of two."
+    },
+    {
+      "targetId": "kummer-theorem",
+      "relationship": "extends",
+      "description": "Root Kummer's theorem on p-adic valuations of binomial coefficients via carry counts."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Kummer, E.E."
+      ],
+      "title": "Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen",
+      "year": "1852",
+      "venue": "Journal für die reine und angewandte Mathematik 44, pp. 93-146",
+      "note": "Original carry-count theorem for v_p(C(n,k)); the digit-sum form specialised here"
+    },
+    {
+      "authors": [
+        "Legendre, A.-M."
+      ],
+      "title": "Théorie des nombres",
+      "year": "1830",
+      "venue": "3rd edition, Firmin Didot Frères, Paris",
+      "note": "Legendre's formula v_p(n!) = (n - s_p(n))/(p-1), source of the digit-sum identity"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "KummerCentralBinomPowerTwo",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/KummerTheoremOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Sharp follow-up to **kummer-theorem-oq-04** (which gives $v_2\binom{2n}{n} = s_2(n)$). Characterises the extreme case:

$$v_2\binom{2n}{n} = 1 \iff \exists k,\; n = 2^k.$$

## Substantive new content

The core lemma **`sum_digits_two_eq_one_iff`** : `(Nat.digits 2 n).sum = 1 ↔ ∃ k, n = 2^k` is **absent from Mathlib** (no popcount/digit-sum "= 1 ⟺ power of two" characterisation in `Mathlib.Data.Nat.Digits`). Forward direction is a strong induction peeling the lowest bit $s_2(n) = (n\bmod 2) + s_2(n/2)$: even $n$ recurses on $n/2$; odd $n>1$ forces a second 1-bit (contradiction); only $n=1$ survives among odds.

## Results (8 theorems, 0 sorries, 0 axioms)

- `sum_digits_two_eq_one_iff` — the new lemma
- `padicValNat_two_centralBinom_eq_one_iff` — headline $v_2(C(2n,n))=1 \iff n=2^k$
- `two_exactDvd_centralBinom_of_pow_two` — sharp $2 \parallel C(2^{k+1}, 2^k)$ ($2\mid$ but $4\nmid$)
- worked witnesses: $C(2,1)=2$, $C(8,4)=70$, $n=8$, non-example $n=6$ with $C(12,6)=924=2^2\cdot231$

The valuation formula $v_2(C(2n,n)) = s_2(n)$ is re-derived locally from Mathlib's `sub_one_mul_padicValNat_choose_eq_sub_sum_digits` so the file is self-contained.

## Verification

Built green via `./proofs/scripts/docker-build.sh Proofs.KummerTheoremOQ04OQ01` (7743 jobs). 0 axioms, 0 sorries; numeric witnesses use **kernel `decide`** (no `native_decide`, so no `Lean.ofReduceBool`). Badge `original` — the popcount lemma is new; Mathlib re-derivation disclosed in `assumptions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)