### PR TITLE
research(menelaus-theorem-oq-01-oq-01): signed/unsigned reconciliation + external-segment parity [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2893,6 +2893,7 @@ import Proofs.MeanValueTheoremOQ03
 import Proofs.MeanValueTheoremOQ04
 import Proofs.MeanValueTheoremOQ05
 import Proofs.MenelausTheorem
+import Proofs.MenelausTheoremOQ01
 import Proofs.MidyTheorem
 import Proofs.MinkowskiFundamentalTheorem
 import Proofs.MinkowskiFundamentalTheoremOQ02

--- a/proofs/Proofs/MenelausTheoremOQ01.lean
+++ b/proofs/Proofs/MenelausTheoremOQ01.lean
@@ -1,0 +1,191 @@
+import Proofs.MenelausTheorem
+import Mathlib.Tactic
+
+/-
+# Menelaus follow-up: signed/unsigned reconciliation and external-segment parity
+
+Open question: `menelaus-theorem-oq-01-oq-01`
+Parent: `Proofs/MenelausTheorem.lean` (`menelaus-theorem-oq-01`).
+
+## What this adds
+
+The parent proves the *signed* Menelaus criterion: for a non-degenerate triangle
+`A B C` with transversal division parameters `t, u, v`, the three division points
+`X, Y, Z` are collinear iff the product of signed side ratios
+
+  `menelausProduct cfg = (t/(1-t)) · (u/(1-u)) · (v/(1-v)) = -1`.
+
+Two natural questions are *not* answered by the signed criterion alone:
+
+1. **Reconciliation with the unsigned form.** Many textbooks state Menelaus with an
+   *unsigned* product equal to `1`. We show the signed criterion forces the unsigned
+   product `|BX/XC| · |CY/YA| · |AZ/ZB|` to equal exactly `1` — the sign `-1` is the
+   only extra information the signed statement carries.
+
+2. **External-segment parity.** The signed ratio `s/(1-s)` of a division point is
+   *negative* exactly when the point lies **outside** its segment (external division),
+   and *positive* when it lies strictly between the endpoints (internal division).
+   Since the signed product is `-1 < 0`, an **odd** number (one or all three) of the
+   division points must be external. Conversely the Ceva-type value `+1 > 0` forces an
+   **even** number (zero or two). This is the classical parity dichotomy
+   `Menelaus = odd # external`, `Ceva = even # external`.
+
+## Status
+- [x] Sign of a division ratio characterises external vs internal division
+- [x] Signed product `-1` ⟹ unsigned product `1` (reconciliation)
+- [x] Signed product `-1` ⟹ odd number of external points
+- [x] Signed product `+1` ⟹ even number of external points
+- [x] Concrete witness: the parent's collinear instance has all three external
+- [x] 0 sorries, 0 axioms
+-/
+
+namespace MenelausTheoremOQ01
+
+open MenelausTheorem
+
+set_option linter.unusedVariables false
+
+/-- The signed side ratio `BX/XC = t/(1-t)` of the point `X` on line `BC`. -/
+noncomputable def rX (cfg : MenelausConfig) : ℝ := cfg.t / (1 - cfg.t)
+
+/-- The signed side ratio `CY/YA = u/(1-u)` of the point `Y` on line `CA`. -/
+noncomputable def rY (cfg : MenelausConfig) : ℝ := cfg.u / (1 - cfg.u)
+
+/-- The signed side ratio `AZ/ZB = v/(1-v)` of the point `Z` on line `AB`. -/
+noncomputable def rZ (cfg : MenelausConfig) : ℝ := cfg.v / (1 - cfg.v)
+
+/-- The three signed ratios multiply to the Menelaus product. Definitional. -/
+theorem product_eq (cfg : MenelausConfig) :
+    rX cfg * rY cfg * rZ cfg = menelausProduct cfg := rfl
+
+/-! ### Sign of a division ratio ↔ external vs internal division -/
+
+/-- A division point with parameter `s` (point `= (1-s)·P + s·Q`) lies **outside** the
+    segment `PQ` exactly when `s < 0` or `1 < s`; in that case the signed ratio
+    `s/(1-s)` is negative. -/
+theorem ratio_neg_iff {s : ℝ} (hs : s ≠ 1) :
+    s / (1 - s) < 0 ↔ s < 0 ∨ 1 < s := by
+  have h1 : (1 : ℝ) - s ≠ 0 := sub_ne_zero.mpr (Ne.symm hs)
+  rw [div_neg_iff]
+  constructor
+  · rintro (⟨ha, hb⟩ | ⟨ha, hb⟩)
+    · exact Or.inr (by linarith)
+    · exact Or.inl ha
+  · rintro (h | h)
+    · exact Or.inr ⟨h, by linarith⟩
+    · exact Or.inl ⟨by linarith, by linarith⟩
+
+/-- A division point lies strictly **between** the endpoints (internal division) exactly
+    when `0 < s < 1`; in that case the signed ratio `s/(1-s)` is positive. -/
+theorem ratio_pos_iff {s : ℝ} (hs : s ≠ 1) :
+    0 < s / (1 - s) ↔ 0 < s ∧ s < 1 := by
+  have h1 : (1 : ℝ) - s ≠ 0 := sub_ne_zero.mpr (Ne.symm hs)
+  rw [div_pos_iff]
+  constructor
+  · rintro (⟨ha, hb⟩ | ⟨ha, hb⟩)
+    · exact ⟨ha, by linarith⟩
+    · exact absurd hb (by linarith)
+  · rintro ⟨ha, hb⟩
+    exact Or.inl ⟨ha, by linarith⟩
+
+/-- `X` is an external division point of `BC` iff its signed ratio is negative. -/
+theorem external_X_iff (cfg : MenelausConfig) :
+    rX cfg < 0 ↔ cfg.t < 0 ∨ 1 < cfg.t := ratio_neg_iff cfg.t_ne_1
+
+/-- `Y` is an external division point of `CA` iff its signed ratio is negative. -/
+theorem external_Y_iff (cfg : MenelausConfig) :
+    rY cfg < 0 ↔ cfg.u < 0 ∨ 1 < cfg.u := ratio_neg_iff cfg.u_ne_1
+
+/-- `Z` is an external division point of `AB` iff its signed ratio is negative. -/
+theorem external_Z_iff (cfg : MenelausConfig) :
+    rZ cfg < 0 ↔ cfg.v < 0 ∨ 1 < cfg.v := ratio_neg_iff cfg.v_ne_1
+
+/-! ### Reconciliation: signed `-1` ⟹ unsigned `1` -/
+
+/-- **Signed/unsigned reconciliation.** When the signed Menelaus product is `-1`
+    (collinear transversal), the *unsigned* product of side ratios equals `1`. The sign
+    is the only extra information carried by the signed statement. -/
+theorem unsigned_product_eq_one (cfg : MenelausConfig)
+    (h : menelausProduct cfg = -1) :
+    |rX cfg| * |rY cfg| * |rZ cfg| = 1 := by
+  calc |rX cfg| * |rY cfg| * |rZ cfg|
+      = |rX cfg * rY cfg * rZ cfg| := by rw [← abs_mul, ← abs_mul]
+    _ = |menelausProduct cfg| := by rw [product_eq]
+    _ = |(-1 : ℝ)| := by rw [h]
+    _ = 1 := by norm_num
+
+/-! ### External-segment parity -/
+
+/-- **External parity (Menelaus).** A collinear transversal (`menelausProduct = -1`)
+    crosses an **odd** number of the triangle's sides externally: either all three
+    division points are external, or exactly one is (the other two internal). The four
+    disjuncts list, in order, "all three external" and the three "exactly one external"
+    configurations. -/
+theorem external_parity_odd (cfg : MenelausConfig)
+    (h : menelausProduct cfg = -1) :
+    (rX cfg < 0 ∧ rY cfg < 0 ∧ rZ cfg < 0)
+    ∨ (rX cfg < 0 ∧ 0 < rY cfg ∧ 0 < rZ cfg)
+    ∨ (0 < rX cfg ∧ rY cfg < 0 ∧ 0 < rZ cfg)
+    ∨ (0 < rX cfg ∧ 0 < rY cfg ∧ rZ cfg < 0) := by
+  have key : rX cfg * rY cfg * rZ cfg = -1 := by rw [product_eq]; exact h
+  have hX0 : rX cfg ≠ 0 := by rintro h0; rw [h0] at key; simp at key
+  have hY0 : rY cfg ≠ 0 := by rintro h0; rw [h0] at key; simp at key
+  have hZ0 : rZ cfg ≠ 0 := by rintro h0; rw [h0] at key; simp at key
+  rcases lt_or_gt_of_ne hX0 with hX | hX <;>
+    rcases lt_or_gt_of_ne hY0 with hY | hY <;>
+      rcases lt_or_gt_of_ne hZ0 with hZ | hZ
+  · exact Or.inl ⟨hX, hY, hZ⟩
+  · nlinarith [mul_pos (mul_pos_of_neg_of_neg hX hY) hZ]
+  · nlinarith [mul_pos_of_neg_of_neg (mul_neg_of_neg_of_pos hX hY) hZ]
+  · exact Or.inr (Or.inl ⟨hX, hY, hZ⟩)
+  · nlinarith [mul_pos_of_neg_of_neg (mul_neg_of_pos_of_neg hX hY) hZ]
+  · exact Or.inr (Or.inr (Or.inl ⟨hX, hY, hZ⟩))
+  · exact Or.inr (Or.inr (Or.inr ⟨hX, hY, hZ⟩))
+  · nlinarith [mul_pos (mul_pos hX hY) hZ]
+
+/-- **External parity (Ceva companion).** When the product is `+1` — the Ceva value of
+    concurrency — an **even** number of division points are external: either none (all
+    three internal), or exactly two. The four disjuncts list "none external" and the
+    three "exactly two external" configurations. -/
+theorem external_parity_even (cfg : MenelausConfig)
+    (h : menelausProduct cfg = 1) :
+    (0 < rX cfg ∧ 0 < rY cfg ∧ 0 < rZ cfg)
+    ∨ (0 < rX cfg ∧ rY cfg < 0 ∧ rZ cfg < 0)
+    ∨ (rX cfg < 0 ∧ 0 < rY cfg ∧ rZ cfg < 0)
+    ∨ (rX cfg < 0 ∧ rY cfg < 0 ∧ 0 < rZ cfg) := by
+  have key : rX cfg * rY cfg * rZ cfg = 1 := by rw [product_eq]; exact h
+  have hX0 : rX cfg ≠ 0 := by rintro h0; rw [h0] at key; simp at key
+  have hY0 : rY cfg ≠ 0 := by rintro h0; rw [h0] at key; simp at key
+  have hZ0 : rZ cfg ≠ 0 := by rintro h0; rw [h0] at key; simp at key
+  rcases lt_or_gt_of_ne hX0 with hX | hX <;>
+    rcases lt_or_gt_of_ne hY0 with hY | hY <;>
+      rcases lt_or_gt_of_ne hZ0 with hZ | hZ
+  · nlinarith [mul_neg_of_pos_of_neg (mul_pos_of_neg_of_neg hX hY) hZ]
+  · exact Or.inr (Or.inr (Or.inr ⟨hX, hY, hZ⟩))
+  · exact Or.inr (Or.inr (Or.inl ⟨hX, hY, hZ⟩))
+  · nlinarith [mul_neg_of_neg_of_pos (mul_neg_of_neg_of_pos hX hY) hZ]
+  · exact Or.inr (Or.inl ⟨hX, hY, hZ⟩)
+  · nlinarith [mul_neg_of_neg_of_pos (mul_neg_of_pos_of_neg hX hY) hZ]
+  · nlinarith [mul_neg_of_pos_of_neg (mul_pos hX hY) hZ]
+  · exact Or.inl ⟨hX, hY, hZ⟩
+
+/-! ### Concrete witness -/
+
+/-- The parent's worked collinear instance — triangle `(0,0),(1,0),(0,1)` with
+    `t = u = 2`, `v = -1/3` — realises the **all-three-external** case: each division
+    point lies outside its segment, and the unsigned product is `1`. -/
+theorem example_all_external :
+    ∃ cfg : MenelausConfig,
+      menelausProduct cfg = -1 ∧
+      (rX cfg < 0 ∧ rY cfg < 0 ∧ rZ cfg < 0) ∧
+      |rX cfg| * |rY cfg| * |rZ cfg| = 1 := by
+  refine ⟨{ A := (0, 0), B := (1, 0), C := (0, 1), t := 2, u := 2, v := -1/3,
+            t_ne_1 := by norm_num, u_ne_1 := by norm_num, v_ne_1 := by norm_num,
+            nondegen := by norm_num [collinearDet] }, ?_, ⟨?_, ?_, ?_⟩, ?_⟩
+  · unfold menelausProduct; norm_num
+  · unfold rX; norm_num
+  · unfold rY; norm_num
+  · unfold rZ; norm_num
+  · unfold rX rY rZ; norm_num
+
+end MenelausTheoremOQ01

--- a/src/data/proofs/menelaus-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/menelaus-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "menelaus-theorem-oq-01-oq-01",
+  "title": "Menelaus: Signed/Unsigned Reconciliation and External-Segment Parity",
+  "slug": "menelaus-theorem-oq-01-oq-01",
+  "description": "Answers the parent's open question by reconciling the signed Menelaus criterion (product of signed side ratios = -1) with the classical unsigned form (|product| = 1) and proving the external-segment parity dichotomy. The signed ratio s/(1-s) of a division point is negative exactly when the point lies outside its segment; since the Menelaus product is -1 < 0, an ODD number (one or all three) of the division points are external, while the Ceva value +1 > 0 forces an EVEN number (zero or two). 10 theorems, 0 sorries, 0 axioms. Builds directly on Proofs/MenelausTheorem.lean.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Menelaus%27s_theorem",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MenelausTheoremOQ01.lean",
+    "tags": [
+      "geometry",
+      "menelaus",
+      "ceva",
+      "signed-ratios",
+      "parity",
+      "collinearity",
+      "triangles"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified.",
+    "lineCount": 191,
+    "theoremCount": 10,
+    "definitionCount": 3,
+    "originalContributions": [
+      "rX, rY, rZ: the three signed side ratios t/(1-t), u/(1-u), v/(1-v) isolated as named quantities, with product_eq tying their product to the parent's menelausProduct",
+      "ratio_neg_iff: s/(1-s) < 0 ↔ s < 0 ∨ 1 < s — the sign of a division ratio detects external division (point outside its segment)",
+      "ratio_pos_iff: 0 < s/(1-s) ↔ 0 < s ∧ s < 1 — positive ratio detects internal division (point strictly between endpoints)",
+      "external_X_iff / external_Y_iff / external_Z_iff: per-point translations grounding the sign criterion in the parameter ranges of the parent's MenelausConfig",
+      "unsigned_product_eq_one: signed product -1 ⟹ unsigned product |rX|·|rY|·|rZ| = 1, reconciling the signed criterion with the textbook unsigned form",
+      "external_parity_odd: a collinear transversal (product = -1) crosses an ODD number of sides externally (all three, or exactly one) — full sign-case enumeration",
+      "external_parity_even: the Ceva concurrency value (product = +1) forces an EVEN number of external points (none, or exactly two)",
+      "example_all_external: the parent's collinear witness (t=u=2, v=-1/3) realises the all-three-external case with unsigned product 1"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Menelaus's theorem is classically stated in two superficially different forms: a signed version (product of signed side ratios = -1) and an unsigned version (product of unsigned ratios = 1, with a side condition fixing the parity of external divisions). The relationship between them — and the geometric meaning of the sign -1 versus Ceva's +1 — is the parity phenomenon noted already by 19th-century projective geometers: a straight transversal must cut an odd number of a triangle's three sides externally, whereas three concurrent cevians cut an even number. This entry makes that folklore precise on top of the parent's affine formalization.",
+    "problemStatement": "The parent proves the signed Menelaus criterion menelausProduct cfg = -1 for collinear transversal points. (1) Reconcile this with the unsigned form: show the signed product -1 forces |rX|·|rY|·|rZ| = 1. (2) Make the external-segment parity precise: characterise when each division point is external (signed ratio negative), and prove the product's sign fixes the parity of the number of external points — odd for Menelaus (-1), even for the Ceva value (+1).",
+    "text": "Each signed ratio rX = t/(1-t) is negative exactly when t < 0 or t > 1, i.e. when the point X = (1-t)B + tC falls outside segment BC (external division); it is positive exactly when 0 < t < 1 (internal division). The unsigned reconciliation is immediate from multiplicativity of absolute value: |rX·rY·rZ| = |menelausProduct| = |-1| = 1. The parity statements follow from the sign rule for products of nonzero reals: rX·rY·rZ = -1 < 0 forces an odd number of negative factors, and = +1 > 0 forces an even number. Both are proved by a complete enumeration of the eight sign patterns, picking the matching disjunct in the consistent cases and deriving a contradiction (via nlinarith on the appropriate signed product) in the inconsistent ones.",
+    "proofStrategy": "Define the three signed ratios rX, rY, rZ and prove product_eq : rX·rY·rZ = menelausProduct (definitional). Establish ratio_neg_iff and ratio_pos_iff as general one-variable sign lemmas via div_neg_iff / div_pos_iff, then specialise to the three configuration parameters. For unsigned_product_eq_one, push absolute value through the product with abs_mul and evaluate |-1| = 1. For external_parity_odd and external_parity_even, observe each ratio is nonzero (the product is ±1 ≠ 0), split each into < 0 or > 0 via lt_or_gt_of_ne, and across the eight branches either select the correct parity disjunct or refute via nlinarith with an explicit signed-product witness.",
+    "keyInsights": [
+      "The sign of the signed ratio s/(1-s) is a faithful external/internal-division detector: negative ⟺ outside the segment, positive ⟺ strictly inside",
+      "The unsigned Menelaus form is just |signed product| = 1; the signed statement carries strictly more information (the sign)",
+      "The product's sign is exactly the parity of the number of external divisions: -1 ⟺ odd, +1 ⟺ even",
+      "This recovers the classical Menelaus/Ceva contrast geometrically: a transversal crosses an odd number of sides externally, concurrent cevians an even number",
+      "All parity content is elementary real sign analysis once the determinant geometry of the parent is in place"
+    ],
+    "prerequisites": [
+      "Parent formalization: MenelausConfig, menelausProduct, the signed Menelaus biconditional (Proofs/MenelausTheorem.lean)",
+      "Sign rules for division and products of reals: div_neg_iff, div_pos_iff, mul_pos, mul_neg_of_*",
+      "Absolute value multiplicativity (abs_mul) and basic case analysis (lt_or_gt_of_ne, nlinarith)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The parent's open question is fully answered. The signed Menelaus product -1 is reconciled with the classical unsigned form |rX|·|rY|·|rZ| = 1, and the external-segment parity is made precise: a collinear transversal crosses an odd number of the triangle's sides externally (external_parity_odd), while the Ceva concurrency value +1 forces an even number (external_parity_even). The sign of each ratio is shown to detect external versus internal division. 10 theorems, 3 definitions, 191 lines, 0 sorries, 0 axioms.",
+    "implications": "Completes the signed/unsigned and parity story for the gallery's Menelaus formalization and sharpens the Menelaus/Ceva duality into a quantitative parity dichotomy. The general sign lemmas ratio_neg_iff / ratio_pos_iff are reusable for any affine division-ratio analysis (Ceva, Routh, Desargues configurations).",
+    "openQuestions": [
+      "Strengthen the parity statements to biconditionals: characterise exactly which sign patterns are realisable by some genuine non-degenerate configuration with the given product",
+      "Phrase the parity count via a Finset cardinality (number of external points) and prove Odd/Even of that cardinality directly, not just the disjunctive enumeration"
+    ]
+  },
+  "leanFile": {
+    "namespace": "MenelausTheoremOQ01",
+    "lineCount": 191,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 3,
+    "path": "Proofs/MenelausTheoremOQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "menelaus-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the signed Menelaus criterion (product = -1). This entry answers its open question on signed/unsigned reconciliation and external-segment parity."
+    },
+    {
+      "targetId": "cevas-theorem-oq-01",
+      "relationship": "related",
+      "description": "Ceva concurrency (product = +1). external_parity_even is the Ceva companion of the Menelaus odd-parity statement."
+    }
+  ],
+  "references": [
+    {
+      "text": "Menelaus of Alexandria, Sphaerica (c. 100 CE). Planar transversal form.",
+      "url": "https://en.wikipedia.org/wiki/Menelaus%27s_theorem"
+    },
+    {
+      "text": "Coxeter, H. S. M. & Greitzer, S. L. (1967). Geometry Revisited. MAA. §3.4 on Menelaus's theorem and signed ratios.",
+      "url": "https://en.wikipedia.org/wiki/Geometry_Revisited"
+    }
+  ],
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview and Imports",
+      "startLine": 1,
+      "endLine": 52,
+      "description": "Module docstring framing the two follow-up questions: reconcile the signed product -1 with the unsigned form |product| = 1, and make the external-segment parity dichotomy (Menelaus odd / Ceva even) precise. Imports the parent Proofs.MenelausTheorem.",
+      "mathContext": "Signed criterion $\\frac{t}{1-t}\\frac{u}{1-u}\\frac{v}{1-v}=-1$; unsigned form $\\left|\\frac{t}{1-t}\\right|\\left|\\frac{u}{1-u}\\right|\\left|\\frac{v}{1-v}\\right|=1$."
+    },
+    {
+      "id": "signed-ratios",
+      "title": "Signed Ratios and Product",
+      "startLine": 53,
+      "endLine": 71,
+      "description": "Defines the three signed side ratios rX = t/(1-t), rY = u/(1-u), rZ = v/(1-v) and proves product_eq : rX·rY·rZ = menelausProduct (definitional).",
+      "mathContext": "$r_X r_Y r_Z = \\text{menelausProduct}$."
+    },
+    {
+      "id": "external-internal",
+      "title": "Sign Detects External vs Internal Division",
+      "startLine": 72,
+      "endLine": 113,
+      "description": "ratio_neg_iff (s/(1-s) < 0 ↔ s < 0 ∨ 1 < s) and ratio_pos_iff (0 < s/(1-s) ↔ 0 < s ∧ s < 1), with per-point specialisations external_X_iff, external_Y_iff, external_Z_iff. A negative ratio means the division point lies outside its segment.",
+      "mathContext": "$\\frac{s}{1-s}<0 \\iff s<0 \\lor s>1$ (external); $0<\\frac{s}{1-s} \\iff 0<s<1$ (internal)."
+    },
+    {
+      "id": "unsigned-reconciliation",
+      "title": "Signed −1 ⟹ Unsigned 1",
+      "startLine": 114,
+      "endLine": 130,
+      "description": "unsigned_product_eq_one: when menelausProduct = -1, the unsigned product |rX|·|rY|·|rZ| equals 1, via abs_mul and |-1| = 1. Reconciles the signed criterion with the classical unsigned statement.",
+      "mathContext": "$|r_X|\\,|r_Y|\\,|r_Z| = |r_X r_Y r_Z| = |-1| = 1$."
+    },
+    {
+      "id": "parity",
+      "title": "External-Segment Parity Dichotomy",
+      "startLine": 131,
+      "endLine": 179,
+      "description": "external_parity_odd: product = -1 forces an odd number of external points (all three, or exactly one). external_parity_even: the Ceva value +1 forces an even number (none, or exactly two). Both by complete enumeration of the eight sign patterns, refuting the inconsistent ones with nlinarith on an explicit signed product.",
+      "mathContext": "$\\operatorname{sign}(r_X r_Y r_Z) = (-1)^{\\#\\{\\text{external points}\\}}$: $-1$ ⟺ odd, $+1$ ⟺ even."
+    },
+    {
+      "id": "example",
+      "title": "Concrete All-External Witness",
+      "startLine": 180,
+      "endLine": 191,
+      "description": "example_all_external: the parent's collinear instance (triangle (0,0),(1,0),(0,1), t=u=2, v=-1/3) realises the all-three-external case, with all three signed ratios negative and unsigned product 1.",
+      "mathContext": "$r_X=r_Y=-2,\\ r_Z=-\\tfrac14$: all negative, $(-2)(-2)(-\\tfrac14)=-1$, $|{-2}||{-2}||{-\\tfrac14}|=1$."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question recorded on the parent **menelaus-theorem-oq-01**:
*"Signed/unsigned reconciliation: derive the unsigned |product| = 1 form and the precise external-segment parity statement."*

Builds directly on `Proofs/MenelausTheorem.lean` (imports the parent module and reuses `MenelausConfig`, `menelausProduct`).

## Results (10 theorems, 3 defs, 191 lines, 0 sorries, 0 axioms)

- **Sign detects external/internal division** — `ratio_neg_iff`: `s/(1-s) < 0 ↔ s < 0 ∨ 1 < s` (point outside its segment); `ratio_pos_iff`: `0 < s/(1-s) ↔ 0 < s ∧ s < 1` (point strictly inside). Specialised per point as `external_X_iff/Y/Z`.
- **Unsigned reconciliation** — `unsigned_product_eq_one`: the signed product `-1` forces `|rX|·|rY|·|rZ| = 1`, the classical textbook form. The sign is the only extra information the signed statement carries.
- **External-segment parity dichotomy** — `external_parity_odd`: a collinear transversal (`menelausProduct = -1`) crosses an **odd** number of the triangle's sides externally (all three, or exactly one). `external_parity_even`: the Ceva concurrency value (`+1`) forces an **even** number (none, or exactly two). This makes the classical Menelaus(`-1`)/Ceva(`+1`) sign contrast a quantitative parity statement.
- **Concrete witness** — `example_all_external`: the parent's collinear instance (`t=u=2, v=-1/3`) realises the all-three-external case with unsigned product `1`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.MenelausTheoremOQ01` → `Build completed successfully (3059 jobs)`. No `sorry`, no `axiom`, no `native_decide`; only kernel-checked tactics (`rfl`, `rcases`, `nlinarith`, `linarith`, `norm_num`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)