### PR TITLE
research(group-order-prime-squared-abelian-oq-01-oq-01): exponent invariant sharply discriminates the order-p² dichotomy [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/GroupOrderPrimeSquaredAbelianExponentOQ01.lean
+++ b/proofs/Proofs/GroupOrderPrimeSquaredAbelianExponentOQ01.lean
@@ -1,0 +1,135 @@
+/-
+  The Exponent of a Group of Order p² — a Sharp Invariant for the Dichotomy
+
+  Follow-up open question OQ-01-OQ-01
+  (parent: group-order-prime-squared-abelian-oq-01).
+
+  The parent entry proves that a group `G` of order `p²` (`p` prime) is abelian and
+  splits into two isomorphism types via the *exponent-p predicate*: `G` is cyclic
+  (`≅ ℤ/p²`) **or** every element satisfies `gᵖ = 1` (elementary abelian, `≅ (ℤ/p)²`).
+
+  This follow-up reframes that dichotomy through the single numerical invariant
+  `Monoid.exponent G` — the least `n > 0` with `gⁿ = 1` for all `g`. The exponent is
+  the *standard* group-theoretic discriminant separating `ℤ/p²` from `(ℤ/p)²`, and we
+  show it takes exactly the two possible values and that each value pins down the type:
+
+      exponent G = p²  ⟺  G is cyclic        (≅ ℤ/p²)
+      exponent G = p   ⟺  G is NOT cyclic    (≅ (ℤ/p)², elementary abelian)
+
+  ## Contents
+
+  * `orderOf_eq_prime_of_not_isCyclic` — sharpening of the parent's `gᵖ = 1`: in the
+    non-cyclic case *every non-identity* element has order **exactly** `p`.
+  * `exponent_eq_sq_of_isCyclic` — a cyclic group of order `p²` has exponent `p²`.
+  * `exponent_eq_prime_of_not_isCyclic` — a non-cyclic group of order `p²` has
+    exponent `p`.
+  * `exponent_eq_prime_or_sq` — the exponent is `p` or `p²` and nothing else.
+  * `exponent_eq_sq_iff_isCyclic` / `exponent_eq_prime_iff_not_isCyclic` — each value
+    of the exponent characterizes the isomorphism type, so the invariant is sharp.
+
+  Everything is elementary finite group theory; no axioms, no sorries. The structural
+  dichotomy is imported from the parent file.
+-/
+import Mathlib
+import Proofs.GroupOrderPrimeSquaredAbelian
+
+namespace GroupOrderPrimeSqExponent
+
+open GroupOrderPrimeSq
+
+variable {G : Type*} [Group G]
+
+/-! ## Finiteness and nontriviality helpers -/
+
+/-- A group of cardinality `p²` (`p` prime) is finite. -/
+private theorem finite_of_card_eq_prime_sq {p : ℕ} (hp : p.Prime)
+    (hG : Nat.card G = p ^ 2) : Finite G :=
+  Nat.finite_of_card_ne_zero (hG ▸ pow_ne_zero 2 hp.pos.ne')
+
+/-- A group of cardinality `p²` (`p` prime) is nontrivial: `p² ≥ 4 > 1`. -/
+private theorem nontrivial_of_card_eq_prime_sq {p : ℕ} (hp : p.Prime)
+    (hG : Nat.card G = p ^ 2) : Nontrivial G := by
+  haveI : Finite G := finite_of_card_eq_prime_sq hp hG
+  rw [← Finite.one_lt_card_iff_nontrivial, hG]
+  nlinarith [hp.two_le]
+
+/-! ## Sharpened element orders in the non-cyclic case -/
+
+/-- **Every non-identity element has order exactly `p`.** The parent shows that a
+non-cyclic group of order `p²` has `gᵖ = 1` for all `g`; here we sharpen this to: every
+`g ≠ 1` has order *exactly* `p`. Indeed `gᵖ = 1` forces `orderOf g ∣ p`, so the order is
+`1` or `p`, and `g ≠ 1` rules out `1`. -/
+theorem orderOf_eq_prime_of_not_isCyclic {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2)
+    (hnc : ¬ IsCyclic G) {g : G} (hg : g ≠ 1) : orderOf g = p := by
+  have hdvd : orderOf g ∣ p :=
+    orderOf_dvd_iff_pow_eq_one.mpr (pow_prime_eq_one_of_not_isCyclic hp hG hnc g)
+  rcases (Nat.dvd_prime hp).mp hdvd with h1 | hp'
+  · exact absurd (orderOf_eq_one_iff.mp h1) hg
+  · exact hp'
+
+/-! ## The exponent in each case -/
+
+/-- **A cyclic group of order `p²` has exponent `p²`.** A generator `g` has order
+`Nat.card G = p²`, so `p² = orderOf g ∣ exponent G`; conversely every element's order
+divides `p²`, so `exponent G ∣ p²`. Antisymmetry of divisibility gives equality. -/
+theorem exponent_eq_sq_of_isCyclic {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2)
+    (hc : IsCyclic G) : Monoid.exponent G = p ^ 2 := by
+  haveI : Finite G := finite_of_card_eq_prime_sq hp hG
+  -- exponent divides p²: every order divides the cardinality p²
+  have hle : Monoid.exponent G ∣ p ^ 2 := by
+    refine Monoid.exponent_dvd_of_forall_pow_eq_one fun g => ?_
+    rw [← orderOf_dvd_iff_pow_eq_one]
+    exact hG ▸ orderOf_dvd_natCard g
+  -- p² divides exponent: a generator has order p²
+  obtain ⟨g, hg⟩ := isCyclic_iff_exists_orderOf_eq_natCard.mp hc
+  have hge : p ^ 2 ∣ Monoid.exponent G := by
+    rw [← hG, ← hg]; exact Monoid.order_dvd_exponent g
+  exact Nat.dvd_antisymm hle hge
+
+/-- **A non-cyclic group of order `p²` has exponent `p`.** Every element satisfies
+`gᵖ = 1`, so `exponent G ∣ p`; and the group is nontrivial, so some element has order
+`> 1`, forcing `exponent G ≠ 1`. As `p` is prime, `exponent G = p`. -/
+theorem exponent_eq_prime_of_not_isCyclic {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2)
+    (hnc : ¬ IsCyclic G) : Monoid.exponent G = p := by
+  haveI : Finite G := finite_of_card_eq_prime_sq hp hG
+  haveI : Nontrivial G := nontrivial_of_card_eq_prime_sq hp hG
+  have hle : Monoid.exponent G ∣ p :=
+    Monoid.exponent_dvd_of_forall_pow_eq_one fun g =>
+      pow_prime_eq_one_of_not_isCyclic hp hG hnc g
+  rcases (Nat.dvd_prime hp).mp hle with h1 | hp'
+  · -- exponent = 1 would make every element trivial, contradicting nontriviality
+    obtain ⟨g, hg⟩ := exists_ne (1 : G)
+    have : orderOf g ∣ 1 := h1 ▸ Monoid.order_dvd_exponent g
+    exact absurd (orderOf_eq_one_iff.mp (Nat.dvd_one.mp this)) hg
+  · exact hp'
+
+/-! ## The exponent is a sharp invariant for the dichotomy -/
+
+/-- **The exponent of a group of order `p²` is `p` or `p²`.** -/
+theorem exponent_eq_prime_or_sq {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2) :
+    Monoid.exponent G = p ∨ Monoid.exponent G = p ^ 2 := by
+  by_cases hc : IsCyclic G
+  · exact Or.inr (exponent_eq_sq_of_isCyclic hp hG hc)
+  · exact Or.inl (exponent_eq_prime_of_not_isCyclic hp hG hc)
+
+/-- **Exponent `p²` characterizes the cyclic type.** For a group of order `p²`,
+`exponent G = p²` *iff* `G` is cyclic. The reverse is `exponent_eq_sq_of_isCyclic`; the
+forward direction is the contrapositive: a non-cyclic group has exponent `p ≠ p²`. -/
+theorem exponent_eq_sq_iff_isCyclic {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2) :
+    Monoid.exponent G = p ^ 2 ↔ IsCyclic G := by
+  refine ⟨fun h => ?_, exponent_eq_sq_of_isCyclic hp hG⟩
+  by_contra hnc
+  rw [exponent_eq_prime_of_not_isCyclic hp hG hnc] at h
+  -- p = p² is impossible for p ≥ 2
+  nlinarith [hp.two_le]
+
+/-- **Exponent `p` characterizes the elementary-abelian type.** For a group of order
+`p²`, `exponent G = p` *iff* `G` is **not** cyclic (so `G ≅ (ℤ/p)²`). -/
+theorem exponent_eq_prime_iff_not_isCyclic {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2) :
+    Monoid.exponent G = p ↔ ¬ IsCyclic G := by
+  refine ⟨fun h hc => ?_, exponent_eq_prime_of_not_isCyclic hp hG⟩
+  rw [exponent_eq_sq_of_isCyclic hp hG hc] at h
+  -- p² = p is impossible for p ≥ 2
+  nlinarith [hp.two_le]
+
+end GroupOrderPrimeSqExponent

--- a/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01/meta.json
+++ b/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "group-order-prime-squared-abelian-oq-01-oq-01",
+  "title": "The Exponent of a Group of Order p² — a Sharp Invariant for the Dichotomy",
+  "slug": "group-order-prime-squared-abelian-oq-01-oq-01",
+  "description": "A follow-up to the order-p² classification that reframes the cyclic / elementary-abelian dichotomy through the single numerical invariant Monoid.exponent G. For a group G of order p² (p prime), the exponent is exactly p or p², and each value pins down the isomorphism type: exponent p² ⟺ G is cyclic (≅ ℤ/p²), exponent p ⟺ G is not cyclic (≅ (ℤ/p)², elementary abelian). A sharpening of the parent shows that in the non-cyclic case every non-identity element has order exactly p, not merely gᵖ = 1.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GroupOrderPrimeSquaredAbelianExponentOQ01.lean",
+    "tags": [
+      "group-theory",
+      "finite-groups",
+      "p-groups",
+      "cyclic-groups",
+      "exponent",
+      "elementary-abelian",
+      "algebra"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "lineCount": 135,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None beyond the stated theorem hypotheses (Nat.card G = p² with p prime). 0 axioms, 0 sorries, no native_decide. The structural dichotomy (isCyclic_or_exponent_p, pow_prime_eq_one_of_not_isCyclic) is imported from the parent file Proofs/GroupOrderPrimeSquaredAbelian.lean; the exponent computation and its sharpness are proved here from the exponent API (Monoid.order_dvd_exponent, Monoid.exponent_dvd_of_forall_pow_eq_one) and Lagrange. Two private helper lemmas (finite/nontrivial from the cardinality) are not counted among the 6 substantive theorems.",
+    "originalContributions": [
+      "orderOf_eq_prime_of_not_isCyclic: a sharpening of the parent's exponent-p statement — in a non-cyclic group of order p², every non-identity element has order EXACTLY p (not merely gᵖ = 1). From gᵖ = 1 the order divides p, so it is 1 or p; g ≠ 1 rules out 1 (orderOf_eq_one_iff).",
+      "exponent_eq_sq_of_isCyclic: a cyclic group of order p² has Monoid.exponent G = p². A generator has order Nat.card G = p², so p² ∣ exponent (Monoid.order_dvd_exponent); every order divides p², so exponent ∣ p²; antisymmetry of divisibility gives equality.",
+      "exponent_eq_prime_of_not_isCyclic: a non-cyclic group of order p² has Monoid.exponent G = p. Every gᵖ = 1 gives exponent ∣ p; nontriviality (p² ≥ 4 > 1) yields an element of order > 1, so exponent ≠ 1; primality forces exponent = p.",
+      "exponent_eq_prime_or_sq: the exponent of a group of order p² takes exactly the two values p and p² and nothing else — a clean by_cases on cyclicity over the two value lemmas.",
+      "exponent_eq_sq_iff_isCyclic: the exponent value p² characterizes the cyclic isomorphism type. Reverse is the value lemma; forward is the contrapositive (non-cyclic ⇒ exponent p ≠ p² since p < p² for p ≥ 2).",
+      "exponent_eq_prime_iff_not_isCyclic: the exponent value p characterizes the elementary-abelian type (G ≅ (ℤ/p)²) — the companion sharp characterization, dual to the previous."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Monoid.order_dvd_exponent",
+        "description": "the order of any element divides the monoid exponent — supplies p² ∣ exponent from a generator of order p² (cyclic case) and the order-> 1 witness ruling out exponent = 1 (non-cyclic case)",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "Monoid.exponent_dvd_of_forall_pow_eq_one",
+        "description": "if gⁿ = 1 for every g then the exponent divides n — gives exponent ∣ p² (every order divides the cardinality) and exponent ∣ p (the non-cyclic gᵖ = 1)",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "isCyclic_iff_exists_orderOf_eq_natCard",
+        "description": "a finite group is cyclic iff it has an element of order equal to its cardinality — produces the generator of order p² that forces exponent = p² in the cyclic case",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "Finite.one_lt_card_iff_nontrivial",
+        "description": "1 < Nat.card G iff G is nontrivial — converts p² ≥ 4 > 1 into a nontrivial element used to exclude exponent = 1",
+        "module": "Mathlib.Data.Finite.Card"
+      },
+      {
+        "theorem": "orderOf_eq_one_iff / orderOf_dvd_iff_pow_eq_one",
+        "description": "orderOf g = 1 ↔ g = 1 and gⁿ = 1 ↔ orderOf g ∣ n — the bridge between the exponent-p predicate and element orders used throughout the sharpening",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Once a group of order p² is known to be abelian and to split into the cyclic ℤ/p² and elementary-abelian (ℤ/p)² types, the natural next question is which invariant separates them. The exponent — the least n with gⁿ = 1 for all g — is the canonical answer: it is p² for ℤ/p² and p for (ℤ/p)². The parent entry phrased the split via the typeclass-free predicate '∀ g, gᵖ = 1'; this follow-up shows that predicate is exactly the statement 'exponent ≤ p', and packages the dichotomy as a computation of the exponent invariant itself.",
+    "problemStatement": "Let G be a group with Nat.card G = p² for a prime p. Compute Monoid.exponent G: show it equals p or p², that exponent G = p² iff G is cyclic, and exponent G = p iff G is not cyclic. Sharpen the parent's exponent-p statement to: in the non-cyclic case every g ≠ 1 has order exactly p.",
+    "text": "The exponent is the cleanest single invariant distinguishing the two groups of order p². Reframing the parent's dichotomy as exponent ∈ {p, p²} makes the classification a numerical computation and exposes the elementary-abelian case as 'exponent = p', the standard definition of an elementary abelian p-group. The sharpening — every non-identity element has order exactly p in the non-cyclic case — is the input to element-counting arguments (an exponent-p group of order p² has p² − 1 elements of order p).",
+    "proofStrategy": "Cyclic case: a generator g satisfies orderOf g = Nat.card G = p², so p² ∣ exponent G by Monoid.order_dvd_exponent; every element's order divides p² (Lagrange), so exponent G ∣ p² by Monoid.exponent_dvd_of_forall_pow_eq_one; Nat.dvd_antisymm closes it. Non-cyclic case: the parent's pow_prime_eq_one_of_not_isCyclic gives exponent G ∣ p; the group is nontrivial (p² ≥ 4), so some g ≠ 1 has order dividing the exponent and orderOf g ≠ 1, ruling out exponent = 1; primality leaves exponent = p. The two iff-characterizations follow by contraposition using p < p² for p ≥ 2 (nlinarith). The order-exactly-p sharpening reduces gᵖ = 1 to orderOf g ∣ p and discards orderOf g = 1 via orderOf_eq_one_iff.",
+    "keyInsights": [
+      "**Exponent is the invariant the dichotomy was really about.** The parent's split 'cyclic or ∀ g, gᵖ = 1' is literally 'exponent p² or exponent p'; computing the exponent turns the structural dichotomy into a two-valued numerical statement.",
+      "**Both bounds on the exponent come from one API.** Monoid.order_dvd_exponent gives the lower bound (a high-order element) and Monoid.exponent_dvd_of_forall_pow_eq_one gives the upper bound (a uniform relation), so each exponent value is a divisibility antisymmetry.",
+      "**Ruling out exponent = 1 is just nontriviality.** p² ≥ 4 > 1 forces a non-identity element, whose order exceeds 1 and divides the exponent — the only nontrivial step in pinning the non-cyclic exponent to p.",
+      "**The sharpening feeds element counts.** 'Every non-identity element has order exactly p' is the precise statement needed to count the p² − 1 order-p elements of an elementary-abelian group of order p², a step the bare gᵖ = 1 predicate does not give directly."
+    ],
+    "prerequisites": [
+      "The parent dichotomy: a group of order p² is cyclic or has exponent p (imported)",
+      "Monoid.exponent and its divisibility API (order divides exponent; uniform relation bounds exponent)",
+      "Lagrange's theorem orderOf g ∣ Nat.card G",
+      "The cyclic-group characterization via an element of order equal to the cardinality"
+    ]
+  },
+  "sections": [
+    {
+      "id": "helpers",
+      "title": "Finiteness and Nontriviality",
+      "startLine": 42,
+      "endLine": 55,
+      "summary": "Private helpers finite_of_card_eq_prime_sq and nontrivial_of_card_eq_prime_sq derive Finite G and Nontrivial G from Nat.card G = p² (p prime), using p² ≥ 4 > 1 for nontriviality.",
+      "mathContext": "Both the exponent computation and the exclusion of exponent = 1 need a finite, nontrivial carrier; these encapsulate that bookkeeping."
+    },
+    {
+      "id": "sharpening",
+      "title": "Order Exactly p in the Non-Cyclic Case",
+      "startLine": 56,
+      "endLine": 69,
+      "summary": "orderOf_eq_prime_of_not_isCyclic: in a non-cyclic group of order p², every g ≠ 1 has order exactly p. gᵖ = 1 forces orderOf g ∣ p, so the order is 1 or p; g ≠ 1 discards 1.",
+      "mathContext": "Sharpens the parent's gᵖ = 1 to a precise order statement, the form consumed by element-counting arguments."
+    },
+    {
+      "id": "exponent-values",
+      "title": "The Exponent in Each Case",
+      "startLine": 70,
+      "endLine": 105,
+      "summary": "exponent_eq_sq_of_isCyclic (cyclic ⇒ exponent p²) by a divisibility antisymmetry from a generator of order p²; exponent_eq_prime_of_not_isCyclic (non-cyclic ⇒ exponent p) from gᵖ = 1 plus nontriviality.",
+      "mathContext": "Computes the invariant: ℤ/p² has exponent p², (ℤ/p)² has exponent p — the two values of the exponent on groups of order p²."
+    },
+    {
+      "id": "sharp-invariant",
+      "title": "The Exponent Characterizes the Type",
+      "startLine": 106,
+      "endLine": 135,
+      "summary": "exponent_eq_prime_or_sq lists the two values; exponent_eq_sq_iff_isCyclic and exponent_eq_prime_iff_not_isCyclic make each value characterize the isomorphism type, by contraposition using p < p² for p ≥ 2.",
+      "mathContext": "Establishes the exponent as a complete invariant for the order-p² classification: knowing it is p or p² is equivalent to knowing whether G is (ℤ/p)² or ℤ/p²."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 follow-up to the order-p² classification: the exponent of a group of order p² (p prime) is exactly p or p², the value p² characterizes the cyclic type ℤ/p² and the value p the elementary-abelian type (ℤ/p)², and in the non-cyclic case every non-identity element has order exactly p. 6 substantive theorems, 135 lines, 0 axioms, 0 sorries, no native_decide; the structural dichotomy is imported from the parent.",
+    "implications": "Recasts the parent's structural dichotomy as a computation of the single invariant Monoid.exponent, exposing the elementary-abelian case as the textbook 'exponent p' definition. The order-exactly-p sharpening is the precise input needed to count the p² − 1 order-p elements of (ℤ/p)², one of the parent's stated open questions.",
+    "openQuestions": [
+      "Combine the exponent computation with element counts: an exponent-p group of order p² has exactly p² − 1 elements of order p, a cyclic one exactly p² − p; formalise Nat.card {g | orderOf g = p} in each case.",
+      "Upgrade to explicit isomorphisms G ≃* Multiplicative (ZMod (p^2)) (exponent p²) and G ≃* Multiplicative (ZMod p) × Multiplicative (ZMod p) (exponent p), turning the invariant characterization into a structure theorem.",
+      "Generalise the exponent computation to order p³, where the exponent already fails to be a complete invariant (the two non-abelian groups of order p³ for odd p are distinguished by exponent p versus p²)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "group-order-prime-squared-abelian-oq-01",
+      "relationship": "parent",
+      "description": "supplies the cyclic/exponent-p dichotomy and the order trichotomy that this entry reframes through the exponent invariant"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "John Wiley & Sons, 3rd ed.",
+      "note": "§5.2 classification of finite abelian groups; the exponent as the invariant distinguishing ℤ/p² from (ℤ/p)²"
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "Springer GTM 148, 4th ed.",
+      "note": "p-groups, exponent of a finite abelian group, and the order-p² classification"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GroupOrderPrimeSquaredAbelian"
+    ],
+    "opens": [
+      "GroupOrderPrimeSq"
+    ],
+    "namespace": "GroupOrderPrimeSqExponent",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/GroupOrderPrimeSquaredAbelianExponentOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up open question to the merged parent **group-order-prime-squared-abelian-oq-01** (#27239). The parent proves a group `G` of order `p²` (`p` prime) is abelian and splits into the cyclic (`≅ ℤ/p²`) vs. elementary-abelian (`≅ (ℤ/p)²`, "`∀ g, gᵖ = 1`") cases. This entry reframes that dichotomy through the **single numerical invariant** `Monoid.exponent G`:

| Invariant | Cyclic `ℤ/p²` | Elementary abelian `(ℤ/p)²` |
|---|---|---|
| `Monoid.exponent G` | `p²` | `p` |

and proves each exponent value characterizes the isomorphism type — so the exponent is a *complete* invariant for the order-`p²` classification.

## Results (6 substantive theorems)

- `orderOf_eq_prime_of_not_isCyclic` — **sharpening** of the parent: in the non-cyclic case every *non-identity* element has order **exactly** `p`, not merely `gᵖ = 1`.
- `exponent_eq_sq_of_isCyclic` — cyclic ⇒ `exponent G = p²` (divisibility antisymmetry from a generator of order `p²`).
- `exponent_eq_prime_of_not_isCyclic` — non-cyclic ⇒ `exponent G = p` (`gᵖ = 1` bounds it above; nontriviality excludes `1`).
- `exponent_eq_prime_or_sq` — the exponent takes exactly the two values `p`, `p²`.
- `exponent_eq_sq_iff_isCyclic` / `exponent_eq_prime_iff_not_isCyclic` — each value pins down the type.

## Verification

- **Docker build green** (`./proofs/scripts/docker-build.sh Proofs.GroupOrderPrimeSquaredAbelianExponentOQ01`, 7744 jobs).
- **0 axioms, 0 sorries, no `native_decide`** — `status: verified`, `badge: original`.
- Structural dichotomy imported from `Proofs.GroupOrderPrimeSquaredAbelian` (sibling import); exponent computation built on `Monoid.order_dvd_exponent` + `Monoid.exponent_dvd_of_forall_pow_eq_one`.

## Files

- `proofs/Proofs/GroupOrderPrimeSquaredAbelianExponentOQ01.lean` (135 lines)
- `src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)