### PR TITLE
audit(menelaus-theorem-oq-01-oq-01): persist clean mark in audit-tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17391,8 +17391,14 @@
       "issues": [],
       "lastAudited": "2026-06-21T03:54:08Z",
       "result": "clean"
+    },
+    "menelaus-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-20T00:00:00Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T03:54:08Z"
+  "lastUpdated": "2026-06-20T00:00:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: menelaus-theorem-oq-01-oq-01 (#27254, newest merge)
**Result**: clean — claims match the Lean source exactly.

### Why this PR
The entry shipped without a key in `audit-tracker.json`'s entries map, so `claim-target.sh complete` is a no-op (the perpetual "1 never-audited" loop). This commits the real clean entry so the queue drains durably.

### Verification (Proofs/MenelausTheoremOQ01.lean)
- 10 theorems, 3 definitions, 191 lines — matches meta.json exactly
- 0 sorries, 0 `axiom` declarations, **no `native_decide`** (no `Lean.ofReduceBool`)
- Proofs use `rfl`/`linarith`/`nlinarith`/`norm_num`/`simp`/`unfold` — elementary sign analysis
- Badge `original` defensible (Tier A): reuses the parent's `menelausProduct` *definition*, but the core results (sign↔external detector, signed→unsigned reconciliation, Menelaus-odd/Ceva-even parity) are proved independently — no deep Mathlib theorem does the core work
- `MenelausConfig` fields are configuration data + a non-degeneracy hypothesis (universally quantified), not assumption-axioms
- No True stubs; `example_all_external` proves a genuine existential witness

Status `verified` / `axiomCount 0` / `sorries 0` all accurate.

---
Discovered during gallery integrity audit.