### PR TITLE
research(erdos-729-oq-02): 2-adic factorial recurrences + maximality characterization [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2069,6 +2069,7 @@ import Proofs.Erdos727Problem
 import Proofs.Erdos728FactorialDivisibility
 import Proofs.Erdos728Problem
 import Proofs.Erdos729LegendreGeneral
+import Proofs.Erdos729LegendreRecurrence
 import Proofs.Erdos729Problem
 import Proofs.Erdos72Aristotle
 import Proofs.Erdos72Problem

--- a/proofs/Proofs/Erdos729LegendreRecurrence.lean
+++ b/proofs/Proofs/Erdos729LegendreRecurrence.lean
@@ -1,0 +1,132 @@
+/-
+  Erdős Problem #729 — OQ-02 follow-up: 2-adic recurrences and the maximality
+  characterization of `v₂(n!)`.
+
+  Companion to `Erdos729Problem.lean` (the `p = 2` case `legendre_for_two`) and
+  `Erdos729LegendreGeneral.lean` (the general identity for all primes). Those
+  files establish Legendre's identity itself:
+
+        v₂(n!) = n − s₂(n)            (s₂ = binary digit sum, number of 1-bits)
+
+  This file develops the *consequences* of that identity that are NOT in Mathlib
+  and not in the companion files: the **doubling recurrences** for the 2-adic
+  valuation of factorials, and the **maximality characterization** describing
+  exactly when `v₂(n!)` attains its largest possible value `n − 1`.
+
+  ## Results
+
+  * `binary_digit_sum_two_mul`     : `s₂(2n) = s₂(n)` — appending a `0` bit.
+  * `binary_digit_sum_two_mul_add_one` : `s₂(2n+1) = s₂(n) + 1` — appending a `1` bit.
+  * `legendre_two`                 : `v₂(n!) = n − s₂(n)` (re-derived locally, self-contained).
+  * `v2_factorial_two_mul`         : `v₂((2n)!) = n + v₂(n!)`.
+  * `v2_factorial_two_mul_add_one` : `v₂((2n+1)!) = n + v₂(n!)`.
+  * `v2_factorial_eq_pred_iff`     : for `n ≥ 1`, `v₂(n!) = n − 1 ↔ s₂(n) = 1`.
+
+  The doubling recurrence `v₂((2n)!) = n + v₂(n!)` is the clean arithmetic shadow
+  of the fact that multiplying by `2` shifts the binary expansion left by one bit
+  without changing its digit sum: the factorial of `2n` collects exactly `n`
+  extra factors of `2` (one per even number `2, 4, …, 2n`) on top of the
+  `v₂(n!)` it inherits.
+
+  The maximality characterization records that `s₂(n) = 1`, i.e. `n` is a power
+  of two, is *exactly* the condition for `v₂(n!)` to hit its ceiling `n − 1`
+  (it is always `< n` for `n ≥ 1` by `padicValNat_factorial_lt_of_ne_zero`).
+  We state the threshold in digit-sum form, which is self-contained; the
+  equivalence `s₂(n) = 1 ↔ n is a power of two` is proved separately in the
+  Kummer companion (`KummerTheoremOQ04OQ01.lean`) and is not reproved here.
+
+  Bearer lemmas verified against the Mathlib pin `v4.26.0`:
+  `sub_one_mul_padicValNat_factorial` (PadicVal/Basic.lean:587),
+  `Nat.digits_def'` (Data/Nat/Digits/Defs.lean:115),
+  `Nat.digit_sum_le` (Data/Nat/Digits/Defs.lean:432),
+  `List.sum_cons`, `Nat.mul_mod_right`, `Nat.mul_div_cancel_left`.
+-/
+
+import Mathlib
+
+namespace Erdos729Recurrence
+
+open Nat
+
+/-- The binary digit sum `s₂(n) = (Nat.digits 2 n).sum` (number of 1-bits). -/
+noncomputable abbrev s₂ (n : ℕ) : ℕ := (Nat.digits 2 n).sum
+
+/-- **Doubling a number appends a `0` bit**, so the binary digit sum is
+unchanged: `s₂(2n) = s₂(n)`. -/
+theorem binary_digit_sum_two_mul (n : ℕ) : s₂ (2 * n) = s₂ n := by
+  rcases Nat.eq_zero_or_pos n with rfl | hpos
+  · simp [s₂]
+  · have h2n : 0 < 2 * n := by positivity
+    have hmod : 2 * n % 2 = 0 := by simp [Nat.mul_mod_right]
+    have hdiv : 2 * n / 2 = n := by
+      rw [Nat.mul_div_cancel_left n (by norm_num)]
+    simp only [s₂]
+    rw [Nat.digits_def' (b := 2) (by norm_num) h2n, hmod, hdiv, List.sum_cons,
+      Nat.zero_add]
+
+/-- **`2n+1` appends a `1` bit**, so the binary digit sum gains one:
+`s₂(2n+1) = s₂(n) + 1`. -/
+theorem binary_digit_sum_two_mul_add_one (n : ℕ) : s₂ (2 * n + 1) = s₂ n + 1 := by
+  have h2n : 0 < 2 * n + 1 := by positivity
+  have hmod : (2 * n + 1) % 2 = 1 := by omega
+  have hdiv : (2 * n + 1) / 2 = n := by omega
+  simp only [s₂]
+  rw [Nat.digits_def' (b := 2) (by norm_num) h2n, hmod, hdiv, List.sum_cons]
+  omega
+
+/-- **Legendre's identity for `p = 2`** (re-derived here so this file is
+self-contained): `v₂(n!) = n − s₂(n)`. Obtained from Mathlib's multiplied form
+`(2−1)·v₂(n!) = n − s₂(n)` by `one_mul`. -/
+theorem legendre_two (n : ℕ) : padicValNat 2 n.factorial = n - s₂ n := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have h := sub_one_mul_padicValNat_factorial (p := 2) n
+  rw [show (2 - 1 : ℕ) = 1 from rfl, one_mul] at h
+  simpa [s₂] using h
+
+/-- **Doubling recurrence.** `v₂((2n)!) = n + v₂(n!)`.
+
+The factorial of `2n` carries exactly `n` more factors of two than `n!`: one
+from each of the `n` even numbers `2, 4, …, 2n`. Arithmetically this is the
+Legendre identity together with `s₂(2n) = s₂(n)`. -/
+theorem v2_factorial_two_mul (n : ℕ) :
+    padicValNat 2 (2 * n).factorial = n + padicValNat 2 n.factorial := by
+  have h2n := legendre_two (2 * n)
+  have hn := legendre_two n
+  have hdouble := binary_digit_sum_two_mul n
+  have hle : s₂ n ≤ n := Nat.digit_sum_le 2 n
+  rw [h2n, hdouble, hn]
+  omega
+
+/-- **Odd-step recurrence.** `v₂((2n+1)!) = n + v₂(n!)`.
+
+Since `2n+1` is odd it contributes no new factor of two, so `(2n+1)!` has the
+same 2-adic valuation as `(2n)!`. -/
+theorem v2_factorial_two_mul_add_one (n : ℕ) :
+    padicValNat 2 (2 * n + 1).factorial = n + padicValNat 2 n.factorial := by
+  have h2n := legendre_two (2 * n + 1)
+  have hn := legendre_two n
+  have hodd := binary_digit_sum_two_mul_add_one n
+  have hle : s₂ n ≤ n := Nat.digit_sum_le 2 n
+  rw [h2n, hodd, hn]
+  omega
+
+/-- **Maximality characterization.** For `n ≥ 1`, the 2-adic valuation of `n!`
+attains its maximum possible value `n − 1` exactly when the binary digit sum is
+`1`, i.e. exactly when `n` is a power of two:
+
+        v₂(n!) = n − 1   ↔   s₂(n) = 1.
+
+(The valuation is always `< n` for `n ≥ 1`, so `n − 1` is the ceiling.) The
+equivalence `s₂(n) = 1 ↔ ∃ k, n = 2^k` is proved in the Kummer companion. -/
+theorem v2_factorial_eq_pred_iff (n : ℕ) (hn : 1 ≤ n) :
+    padicValNat 2 n.factorial = n - 1 ↔ s₂ n = 1 := by
+  have hL := legendre_two n
+  have hle : s₂ n ≤ n := Nat.digit_sum_le 2 n
+  rw [hL]
+  omega
+
+#check @v2_factorial_two_mul
+#check @v2_factorial_two_mul_add_one
+#check @v2_factorial_eq_pred_iff
+
+end Erdos729Recurrence

--- a/src/data/research/problems/erdos-729-oq-02.json
+++ b/src/data/research/problems/erdos-729-oq-02.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-04-05T23:54:18-07:00",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "2-adic recurrences + maximality characterization companion shipped (verified, 0-axiom).",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Optional: prove s_2(n)=1 <-> n=2^k here too (currently delegated to Kummer companion), or extend doubling recurrence to general prime p (v_p((p*n)!) = ? ).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,14 +29,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT (researcher-2, 2026-06-15, build-pending, dual blackout): added self-contained companion Erdos729LegendreGeneral.lean proving the general textbook Legendre identity v_p(n!)=(n-s_p(n))/(p-1) axiom-free for EVERY prime p (sibling PR #24474 discharges only the p=2 case before deleting the general axiom). Division form bridges Mathlib sub_one_mul_padicValNat_factorial by cancelling p-1; states both Mathlib (p.digits n).sum form and recursive digitSum form. 0 axioms/0 sorries; math certified over 7500 (p,n) pairs. UNREGISTERED (blackout); does not touch the contested registered file (#24474/#24481). The 3 remaining axioms (erdos_1968_classical, barreto_leeham_theorem/bound) are deep published research, out of scope.",
+    "progressSummary": "ACT (researcher-9, 2026-06-20): added third self-contained companion Erdos729LegendreRecurrence.lean — the DOWNSTREAM consequences of Legendre's identity for p=2 that are absent from Mathlib and the two prior companions. Proves the 2-adic doubling recurrences v_2((2n)!)=n+v_2(n!) and v_2((2n+1)!)=n+v_2(n!) (the factorial of 2n collects exactly n extra factors of 2), the digit-sum invariants s_2(2n)=s_2(n) / s_2(2n+1)=s_2(n)+1, and the maximality characterization v_2(n!)=n-1 <-> s_2(n)=1 (n a power of two) — n-1 being the ceiling since v_2(n!)<n for n>=1. 5 theorems, 0 axioms, 0 sorries, 0 native_decide; #print axioms = {propext, Classical.choice, Quot.sound} only. Registered Proofs.lean. Built GREEN (docker, 7743 jobs). The equivalence s_2(n)=1 <-> n=2^k is left to the Kummer companion KummerTheoremOQ04OQ01.lean (not reproved here).\n\nPRIOR: ACT (researcher-2, 2026-06-15, build-pending, dual blackout): added self-contained companion Erdos729LegendreGeneral.lean proving the general textbook Legendre identity v_p(n!)=(n-s_p(n))/(p-1) axiom-free for EVERY prime p (sibling PR #24474 discharges only the p=2 case before deleting the general axiom). Division form bridges Mathlib sub_one_mul_padicValNat_factorial by cancelling p-1; states both Mathlib (p.digits n).sum form and recursive digitSum form. 0 axioms/0 sorries; math certified over 7500 (p,n) pairs. UNREGISTERED (blackout); does not touch the contested registered file (#24474/#24481). The 3 remaining axioms (erdos_1968_classical, barreto_leeham_theorem/bound) are deep published research, out of scope.",
     "builtItems": [
       "padicValNat_factorial_eq_div (p n)(hp:p.Prime): padicValNat p n.factorial = (n-(p.digits n).sum)/(p-1) -- Erdos729LegendreGeneral.lean",
       "legendre_digit_sum_identity (p n)(hp:p.Prime): same in recursive digitSum form (exact deleted-axiom statement, all primes)",
-      "verify_legendre_general.py: 7500 (p,n) pairs (p<50,n<500) certify the identity + (p-1)|(n-s_p(n)) divisibility, 0 mismatches"
+      "verify_legendre_general.py: 7500 (p,n) pairs (p<50,n<500) certify the identity + (p-1)|(n-s_p(n)) divisibility, 0 mismatches",
+      "v2_factorial_two_mul (n): padicValNat 2 (2*n).factorial = n + padicValNat 2 n.factorial -- 2-adic doubling recurrence, Erdos729LegendreRecurrence.lean",
+      "v2_factorial_two_mul_add_one (n): padicValNat 2 (2*n+1).factorial = n + padicValNat 2 n.factorial -- odd-step recurrence (2n+1 odd contributes no factor of 2)",
+      "binary_digit_sum_two_mul (n): s_2(2n)=s_2(n); binary_digit_sum_two_mul_add_one (n): s_2(2n+1)=s_2(n)+1 -- digit-sum bit-shift invariants",
+      "v2_factorial_eq_pred_iff (n)(hn:1<=n): padicValNat 2 n.factorial = n-1 <-> (Nat.digits 2 n).sum = 1 -- maximality (n a power of two)"
     ],
     "insights": [
-      "General textbook Legendre identity v_p(n!)=(n-s_p(n))/(p-1) proved axiom-free for ALL primes p in new companion Erdos729LegendreGeneral.lean (sibling PR #24474 covers only p=2). Division form derived from Mathlib sub_one_mul_padicValNat_factorial via Nat.mul_div_cancel_left; not a named Mathlib lemma."
+      "General textbook Legendre identity v_p(n!)=(n-s_p(n))/(p-1) proved axiom-free for ALL primes p in new companion Erdos729LegendreGeneral.lean (sibling PR #24474 covers only p=2). Division form derived from Mathlib sub_one_mul_padicValNat_factorial via Nat.mul_div_cancel_left; not a named Mathlib lemma.",
+      "v_2((2n)!) = n + v_2(n!): the 2-adic valuation of the factorial doubles-with-offset because multiplying by 2 left-shifts the binary expansion (s_2 invariant) — i.e. 2n! gains exactly n factors of two over n!. Equivalent to Legendre + s_2(2n)=s_2(n). v_2(n!) hits its ceiling n-1 exactly when s_2(n)=1 (n a power of two). None of these are named Mathlib lemmas."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -60,7 +65,7 @@
     "mathlib": []
   },
   "started": "2026-04-13T00:54:20.846Z",
-  "lastUpdate": "2026-06-15",
+  "lastUpdate": "2026-06-20",
   "significance": 7,
   "tractability": 8,
   "leanFiles": [
@@ -74,6 +79,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos729Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos729LegendreRecurrence.lean",
+      "filename": "Erdos729LegendreRecurrence.lean",
+      "lineCount": 132,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos729LegendreRecurrence.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

A third self-contained companion to Erdős #729 OQ-02 (`v₂(n!) = n − s₂(n)`), developing the **downstream consequences** of Legendre's identity for `p = 2` that are *not* in Mathlib and *not* in the two prior companions (`Erdos729Problem.lean`, `Erdos729LegendreGeneral.lean`).

New file `proofs/Proofs/Erdos729LegendreRecurrence.lean` (132 lines, 6 theorems):

| theorem | statement |
|---|---|
| `binary_digit_sum_two_mul` | `s₂(2n) = s₂(n)` — doubling appends a `0` bit |
| `binary_digit_sum_two_mul_add_one` | `s₂(2n+1) = s₂(n) + 1` — appends a `1` bit |
| `legendre_two` | `v₂(n!) = n − s₂(n)` (re-derived locally, self-contained) |
| `v2_factorial_two_mul` | **`v₂((2n)!) = n + v₂(n!)`** — 2-adic doubling recurrence |
| `v2_factorial_two_mul_add_one` | **`v₂((2n+1)!) = n + v₂(n!)`** — odd step |
| `v2_factorial_eq_pred_iff` | **`v₂(n!) = n − 1  ↔  s₂(n) = 1`** — maximality (n a power of two) |

## Why it's interesting

`v₂((2n)!) = n + v₂(n!)` is the clean arithmetic shadow of "multiplying by 2 left-shifts the binary expansion without changing its digit sum": `(2n)!` collects exactly `n` extra factors of two (one per even number `2, 4, …, 2n`) on top of `v₂(n!)`. The maximality theorem records that `v₂(n!)` hits its ceiling `n − 1` (it is always `< n` for `n ≥ 1`) exactly when `s₂(n) = 1`, i.e. when `n` is a power of two.

## Verification

- Built green via `docker-build.sh Proofs.Erdos729LegendreRecurrence` — `Build completed successfully (7743 jobs)`, EXIT 0, no errors/linter warnings.
- `#print axioms` for all five results reports only `[propext, Classical.choice, Quot.sound]` — **0 stated axioms, 0 sorries, 0 `native_decide`** (no `sorryAx`, no `ofReduceBool`). Status: verified.
- Builds only on Mathlib (`sub_one_mul_padicValNat_factorial`, `Nat.digits_def'`, `Nat.digit_sum_le`).

Registered in `proofs/Proofs.lean`; research knowledge base updated in `src/data/research/problems/erdos-729-oq-02.json`. The equivalence `s₂(n) = 1 ↔ n = 2^k` is delegated to the Kummer companion and not reproved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)