### PR TITLE
research(antitone-integral-sum-comparison-oq-01): the integral test — sum/integral sandwich + logarithmic bounds on harmonic numbers [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/AntitoneIntegralSumComparison.lean
+++ b/proofs/Proofs/AntitoneIntegralSumComparison.lean
@@ -1,0 +1,141 @@
+import Mathlib
+
+/-
+# The Integral Test: Sum–Integral Comparison for Antitone Functions
+
+For an antitone (non-increasing) function `f` on an interval, the definite
+integral is sandwiched between the right-endpoint (lower) Riemann sum and the
+left-endpoint (upper) Riemann sum:
+
+  ∑_{i<a} f(x₀ + i + 1)  ≤  ∫_{x₀}^{x₀+a} f  ≤  ∑_{i<a} f(x₀ + i).
+
+This is the engine behind the **integral test** for series convergence.  We
+package the two one-sided Mathlib bounds (`AntitoneOn.sum_le_integral` and
+`AntitoneOn.integral_le_sum`) into the single two-sided comparison, and then
+apply it to `f(x) = 1/x` on `[1, n+1]` to obtain the classical logarithmic
+bounds on the harmonic numbers:
+
+  log(n + 1)  ≤  Hₙ        and        H_{n+1}  ≤  1 + log(n + 1),
+
+so that `Hₙ - log(n+1)` stays in `[0, 1]` — the boundedness that defines the
+Euler–Mascheroni constant and proves the harmonic series diverges only
+logarithmically.
+
+All results are fully machine-verified: 0 sorries, 0 axioms.
+-/
+
+namespace AntitoneIntegralSumComparison
+
+open scoped BigOperators
+open Finset intervalIntegral
+
+/-! ## Part I — The general integral-test sandwich -/
+
+/-- **Integral test sandwich.** For `f` antitone on `[x₀, x₀ + a]`, the integral
+lies between the right Riemann sum (lower bound) and the left Riemann sum (upper
+bound).  This is the two-sided comparison underlying the integral test. -/
+theorem integral_sandwich {f : ℝ → ℝ} {x₀ : ℝ} {a : ℕ}
+    (hf : AntitoneOn f (Set.Icc x₀ (x₀ + a))) :
+    (∑ i ∈ Finset.range a, f (x₀ + (i + 1 : ℕ))) ≤ (∫ x in x₀..x₀ + a, f x) ∧
+      (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ Finset.range a, f (x₀ + i) :=
+  ⟨hf.sum_le_integral, hf.integral_le_sum⟩
+
+/-! ## Part II — The harmonic numbers -/
+
+/-- The `n`-th harmonic number `Hₙ = 1 + 1/2 + ⋯ + 1/n = ∑_{i<n} 1/(i+1)`. -/
+noncomputable def harmonic (n : ℕ) : ℝ := ∑ i ∈ Finset.range n, 1 / (i + 1 : ℝ)
+
+@[simp] theorem harmonic_zero : harmonic 0 = 0 := by simp [harmonic]
+
+/-- `x ↦ 1/x` is antitone on `[1, 1+n]` (it lives on the positive reals). -/
+private theorem oneDiv_antitone (n : ℕ) :
+    AntitoneOn (fun x : ℝ => 1 / x) (Set.Icc (1 : ℝ) (1 + n)) := by
+  intro x hx y _ hxy
+  have hx0 : (0 : ℝ) < x := lt_of_lt_of_le one_pos hx.1
+  exact one_div_le_one_div_of_le hx0 hxy
+
+/-- `∫₁^{1+n} 1/x dx = log(n + 1)`. -/
+private theorem log_integral (n : ℕ) :
+    (∫ x in (1 : ℝ)..(1 + (n : ℝ)), 1 / x) = Real.log ((n : ℝ) + 1) := by
+  have h0 : (0 : ℝ) ∉ Set.uIcc (1 : ℝ) (1 + (n : ℝ)) :=
+    Set.notMem_uIcc_of_lt one_pos (by positivity)
+  rw [integral_one_div h0, div_one]
+  congr 1
+  ring
+
+/-! ## Part III — Logarithmic bounds on the harmonic numbers -/
+
+/-- **Lower bound.** `log(n + 1) ≤ Hₙ`.  Applying `integral_le_sum` to `1/x`:
+the integral `log(n+1)` is at most the left Riemann sum `∑_{i<n} 1/(i+1) = Hₙ`. -/
+theorem log_le_harmonic (n : ℕ) : Real.log ((n : ℝ) + 1) ≤ harmonic n := by
+  have key := (oneDiv_antitone n).integral_le_sum
+  rw [log_integral n] at key
+  refine key.trans_eq ?_
+  unfold harmonic
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [add_comm (1 : ℝ) (i : ℝ)]
+
+/-- **Upper bound.** `H_{n+1} ≤ 1 + log(n + 1)`.  Applying `sum_le_integral` to
+`1/x`: the right Riemann sum `∑_{i<n} 1/(i+2) = H_{n+1} - 1` is at most the
+integral `log(n+1)`. -/
+theorem harmonic_succ_le (n : ℕ) : harmonic (n + 1) ≤ 1 + Real.log ((n : ℝ) + 1) := by
+  have key := (oneDiv_antitone n).sum_le_integral
+  rw [log_integral n] at key
+  push_cast at key
+  -- rewrite the right Riemann sum into `∑_{i<n} 1/(i+2)`
+  have hsum : (∑ i ∈ Finset.range n, 1 / (1 + ((i : ℝ) + 1)))
+      = ∑ i ∈ Finset.range n, 1 / ((i : ℝ) + 2) := by
+    apply Finset.sum_congr rfl
+    intro i _
+    congr 1
+    ring
+  rw [hsum] at key
+  -- and `H_{n+1} = (∑_{i<n} 1/(i+2)) + 1`
+  have hH : harmonic (n + 1) = (∑ i ∈ Finset.range n, 1 / ((i : ℝ) + 2)) + 1 := by
+    unfold harmonic
+    rw [Finset.sum_range_succ']
+    congr 1
+    · apply Finset.sum_congr rfl
+      intro i _
+      congr 1
+      push_cast
+      ring
+    · norm_num
+  rw [hH]
+  linarith [key]
+
+/-! ## Part IV — Boundedness of `Hₙ - log(n+1)` (Euler–Mascheroni) -/
+
+/-- `Hₙ - log(n + 1) ≥ 0` for every `n`. -/
+theorem harmonic_sub_log_nonneg (n : ℕ) : 0 ≤ harmonic n - Real.log ((n : ℝ) + 1) := by
+  linarith [log_le_harmonic n]
+
+/-- `H_{n+1} - log(n + 1) ≤ 1` for every `n`.  Together with the previous bound,
+`Hₙ - log(n+1)` is trapped in `[0, 1]`, the boundedness behind the
+Euler–Mascheroni constant `γ = lim (Hₙ - log n) ∈ (0, 1)`. -/
+theorem harmonic_succ_sub_log_le_one (n : ℕ) :
+    harmonic (n + 1) - Real.log ((n : ℝ) + 1) ≤ 1 := by
+  linarith [harmonic_succ_le n]
+
+/-! ## Part V — Worked witnesses -/
+
+/-- `H₃ = 1 + 1/2 + 1/3 = 11/6`. -/
+example : harmonic 3 = 11 / 6 := by
+  unfold harmonic
+  rw [Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_succ,
+    Finset.sum_range_zero]
+  norm_num
+
+/-- The lower bound instantiated at `n = 3`: `log 4 ≤ H₃`. -/
+example : Real.log ((3 : ℝ) + 1) ≤ harmonic 3 := log_le_harmonic 3
+
+/-- The sandwich specialised to `1/x` on `[1, 1+n]`: the harmonic Riemann sums
+trap the logarithmic integral. -/
+example (n : ℕ) :
+    (∑ i ∈ Finset.range n, 1 / ((1 : ℝ) + (i + 1 : ℕ))) ≤
+      (∫ x in (1 : ℝ)..(1 + n), 1 / x) ∧
+    (∫ x in (1 : ℝ)..(1 + n), 1 / x) ≤ ∑ i ∈ Finset.range n, 1 / ((1 : ℝ) + i) :=
+  integral_sandwich (oneDiv_antitone n)
+
+end AntitoneIntegralSumComparison

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-antitone-isc-sandwich",
+    "proofId": "antitone-integral-sum-comparison-oq-01",
+    "range": { "startLine": 37, "endLine": 43 },
+    "type": "theorem",
+    "title": "The Integral-Test Sandwich",
+    "content": "integral_sandwich packages both one-sided comparisons into a single statement: for f antitone on [x₀, x₀+a], the right Riemann sum ∑ f(x₀+i+1) underestimates the integral and the left Riemann sum ∑ f(x₀+i) overestimates it. The proof is the pair ⟨AntitoneOn.sum_le_integral, AntitoneOn.integral_le_sum⟩ — antitonicity orders each unit subinterval so the integrand sits between its right and left endpoint values.",
+    "mathContext": "\\sum_{i<a} f(x_0+i+1) \\;\\le\\; \\int_{x_0}^{x_0+a} f \\;\\le\\; \\sum_{i<a} f(x_0+i)",
+    "significance": "key",
+    "relatedConcepts": ["integral test", "Riemann sums", "antitone functions", "convergence tests"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-antitone-isc-harmonic-def",
+    "proofId": "antitone-integral-sum-comparison-oq-01",
+    "range": { "startLine": 46, "endLine": 48 },
+    "type": "definition",
+    "title": "Harmonic Numbers",
+    "content": "harmonic n = ∑_{i<n} 1/(i+1) is the n-th harmonic number Hₙ = 1 + 1/2 + ⋯ + 1/n as a real number. This is the left Riemann sum of 1/x on [1, 1+n], which is exactly why the integral test pins it against log(n+1).",
+    "mathContext": "H_n = \\sum_{i=0}^{n-1} \\frac{1}{i+1} = 1 + \\tfrac12 + \\cdots + \\tfrac1n",
+    "significance": "standard",
+    "relatedConcepts": ["harmonic series", "partial sums"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-antitone-isc-log-integral",
+    "proofId": "antitone-integral-sum-comparison-oq-01",
+    "range": { "startLine": 58, "endLine": 68 },
+    "type": "theorem",
+    "title": "The Logarithmic Integral ∫₁^{1+n} 1/x = log(n+1)",
+    "content": "The exact integral feeding both harmonic bounds. integral_one_div evaluates ∫ₐᵇ 1/x = log(b/a) provided 0 ∉ uIcc a b; here 0 < 1 ≤ 1+n discharges that side condition, and div_one simplifies log((1+n)/1) to log(n+1).",
+    "mathContext": "\\int_1^{1+n} \\frac{1}{x}\\,dx = \\log\\frac{1+n}{1} = \\log(n+1)",
+    "significance": "key",
+    "relatedConcepts": ["natural logarithm", "interval integral", "integral_one_div"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-antitone-isc-lower",
+    "proofId": "antitone-integral-sum-comparison-oq-01",
+    "range": { "startLine": 70, "endLine": 81 },
+    "type": "theorem",
+    "title": "Lower Bound: log(n+1) ≤ Hₙ",
+    "content": "Applying integral_le_sum to 1/x: the integral log(n+1) is at most the left Riemann sum ∑_{i<n} 1/(1+i), which equals Hₙ verbatim after add_comm. No slack to manage — the harmonic number is exactly the upper staircase sum of 1/x.",
+    "mathContext": "\\log(n+1) = \\int_1^{1+n}\\tfrac1x \\le \\sum_{i<n}\\tfrac1{1+i} = H_n",
+    "significance": "key",
+    "relatedConcepts": ["integral test", "harmonic series", "logarithmic divergence"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-antitone-isc-upper",
+    "proofId": "antitone-integral-sum-comparison-oq-01",
+    "range": { "startLine": 83, "endLine": 110 },
+    "type": "theorem",
+    "title": "Upper Bound: H_{n+1} ≤ 1 + log(n+1)",
+    "content": "Applying sum_le_integral to 1/x: the right Riemann sum ∑_{i<n} 1/(i+2) is at most log(n+1). Reindexing with Finset.sum_range_succ' peels the leading term 1 off H_{n+1}, identifying that sum with H_{n+1} − 1, so H_{n+1} − 1 ≤ log(n+1).",
+    "mathContext": "H_{n+1} - 1 = \\sum_{i<n}\\tfrac1{i+2} \\le \\int_1^{1+n}\\tfrac1x = \\log(n+1)",
+    "significance": "key",
+    "relatedConcepts": ["integral test", "Finset.sum_range_succ'", "reindexing"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-antitone-isc-euler-mascheroni",
+    "proofId": "antitone-integral-sum-comparison-oq-01",
+    "range": { "startLine": 112, "endLine": 123 },
+    "type": "theorem",
+    "title": "Hₙ − log(n+1) ∈ [0, 1]: Euler–Mascheroni Boundedness",
+    "content": "Combining the two bounds traps the gap Hₙ − log(n+1) in the unit interval: the lower bound gives nonnegativity, the upper bound (at index n+1) gives ≤ 1. This boundedness is precisely what makes the Euler–Mascheroni limit γ = lim (Hₙ − log n) exist and shows the harmonic series diverges only logarithmically.",
+    "mathContext": "0 \\le H_n - \\log(n+1), \\qquad H_{n+1} - \\log(n+1) \\le 1 \\;\\Rightarrow\\; \\gamma = \\lim_{n\\to\\infty}(H_n - \\log n) \\in (0,1)",
+    "significance": "key",
+    "relatedConcepts": ["Euler–Mascheroni constant", "bounded sequence", "harmonic series divergence"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01/meta.json
@@ -1,0 +1,76 @@
+{
+  "id": "antitone-integral-sum-comparison-oq-01",
+  "title": "The Integral Test: Sum–Integral Comparison for Antitone Functions",
+  "slug": "antitone-integral-sum-comparison-oq-01",
+  "description": "Packages the two one-sided Mathlib bounds for antitone functions into the single two-sided integral-test sandwich ∑_{i<a} f(x₀+i+1) ≤ ∫_{x₀}^{x₀+a} f ≤ ∑_{i<a} f(x₀+i), then applies it to f(x)=1/x on [1,1+n] to derive the classical logarithmic bounds on the harmonic numbers: log(n+1) ≤ Hₙ and H_{n+1} ≤ 1 + log(n+1). Together these trap Hₙ − log(n+1) in [0,1], the boundedness behind the Euler–Mascheroni constant and the logarithmic divergence of the harmonic series. 5 theorems, 1 definition, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Integral_test_for_convergence",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AntitoneIntegralSumComparison.lean",
+    "tags": [
+      "analysis",
+      "integral-test",
+      "harmonic-series",
+      "riemann-sums",
+      "antitone",
+      "euler-mascheroni",
+      "convergence"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified.",
+    "lineCount": 141,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "originalContributions": [
+      "integral_sandwich: the two-sided integral-test comparison for an antitone f on [x₀, x₀+a], bundling AntitoneOn.sum_le_integral and AntitoneOn.integral_le_sum into one statement",
+      "harmonic: the n-th harmonic number Hₙ = ∑_{i<n} 1/(i+1) as a real number",
+      "oneDiv_antitone: x ↦ 1/x is antitone on [1, 1+n] (the convergence-test vehicle)",
+      "log_integral: ∫₁^{1+n} 1/x dx = log(n+1), the exact integral feeding both bounds",
+      "log_le_harmonic: the lower bound log(n+1) ≤ Hₙ via integral_le_sum",
+      "harmonic_succ_le: the upper bound H_{n+1} ≤ 1 + log(n+1) via sum_le_integral",
+      "harmonic_sub_log_nonneg / harmonic_succ_sub_log_le_one: Hₙ − log(n+1) ∈ [0,1] — the Euler–Mascheroni boundedness"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The integral test compares a series ∑ f(n) with the integral ∫ f, exploiting monotonicity so that the function's graph dominates (or is dominated by) the staircase of rectangles forming the Riemann sums. Cauchy formalized the test in the early 19th century, and its archetypal application is the harmonic series 1 + 1/2 + 1/3 + ⋯: comparing with ∫ 1/x = log shows the partial sums Hₙ grow like log n, diverging but only logarithmically. The gap Hₙ − log n converges to the Euler–Mascheroni constant γ ≈ 0.5772, one of the most mysterious constants in mathematics (its irrationality is still open).",
+    "problemStatement": "State and prove the two-sided integral-test comparison for an antitone function, and apply it to 1/x to obtain sharp logarithmic bounds on the harmonic numbers Hₙ, exhibiting the boundedness of Hₙ − log(n+1) that underlies the Euler–Mascheroni constant.",
+    "text": "For an antitone f on [x₀, x₀+a] each subinterval [x₀+i, x₀+i+1] has the function bounded below by its right value f(x₀+i+1) and above by its left value f(x₀+i); integrating and summing over i gives ∑ f(x₀+i+1) ≤ ∫ f ≤ ∑ f(x₀+i). Mathlib supplies both halves (AntitoneOn.sum_le_integral and AntitoneOn.integral_le_sum); integral_sandwich bundles them. For f(x)=1/x on [1,1+n] the integral evaluates to log(n+1) (integral_one_div), the left sum is exactly Hₙ, and the right sum is H_{n+1} − 1. Reading off the two inequalities yields log(n+1) ≤ Hₙ and H_{n+1} − 1 ≤ log(n+1).",
+    "proofStrategy": "Part I states integral_sandwich as the conjunction of the two Mathlib one-sided bounds. Part II defines the harmonic numbers and proves the two ingredients for the 1/x specialization: oneDiv_antitone (antitonicity from one_div_le_one_div_of_le on the positive reals) and log_integral (∫₁^{1+n} 1/x = log(n+1) via integral_one_div with 0 ∉ uIcc 1 (1+n)). Part III reads off the bounds: log_le_harmonic applies integral_le_sum and identifies the left Riemann sum with Hₙ by add_comm; harmonic_succ_le applies sum_le_integral, reindexes the right sum to ∑ 1/(i+2) and uses Finset.sum_range_succ' to peel the leading 1 from H_{n+1}. Part IV records the resulting boundedness Hₙ − log(n+1) ∈ [0,1] by linarith. Part V gives worked witnesses (H₃ = 11/6, log 4 ≤ H₃, and the general sandwich for 1/x).",
+    "keyInsights": [
+      "Antitonicity is exactly what orders the staircase: right value ≤ integrand ≤ left value on each unit subinterval",
+      "The integral test sandwich is symmetric — one inequality bounds the lower (right) sum, the other the upper (left) sum — so both convergence and divergence follow from one comparison",
+      "For 1/x the integral is log(n+1) and the left Riemann sum is the harmonic number verbatim, giving log(n+1) ≤ Hₙ with no slack to manage",
+      "Reindexing via Finset.sum_range_succ' turns the right Riemann sum into H_{n+1} − 1, producing the matching upper bound H_{n+1} ≤ 1 + log(n+1)",
+      "The two bounds trap Hₙ − log(n+1) in the unit interval [0,1] — the boundedness that makes the Euler–Mascheroni limit exist and shows the harmonic series diverges only logarithmically"
+    ],
+    "prerequisites": [
+      "Antitone / AntitoneOn functions and monotone comparison of 1/x",
+      "Interval integrals and the evaluation ∫ 1/x = log",
+      "Finset.range sums, reindexing with Finset.sum_range_succ'",
+      "Real logarithm basics"
+    ]
+  },
+  "conclusion": {
+    "summary": "The two-sided integral-test comparison for antitone functions is formalized and applied to 1/x, yielding the sharp logarithmic bounds log(n+1) ≤ Hₙ and H_{n+1} ≤ 1 + log(n+1). These trap Hₙ − log(n+1) in [0,1], the boundedness underlying the Euler–Mascheroni constant. 8 theorems, 1 definition, 141 lines, 0 sorries, 0 axioms.",
+    "implications": "Adds the foundational integral-test convergence infrastructure (absent from the gallery) in reusable form: integral_sandwich applies to any antitone summand, and the 1/x specialization is the template for p-series and other comparison-test results. The harmonic bounds are the quantitative heart of the harmonic series' logarithmic divergence.",
+    "openQuestions": [
+      "Derive the analogous monotone sandwich and a p-series corollary (∑ 1/i^p convergent iff p > 1) from MonotoneOn.sum_le_integral / integral_le_sum",
+      "Promote the boundedness Hₙ − log(n+1) ∈ [0,1] to convergence: show Hₙ − log n tends to a limit γ (monotone-bounded sequence)",
+      "Sharpen to the two-term asymptotic Hₙ = log n + γ + 1/(2n) + O(1/n²) via the Euler–Maclaurin correction"
+    ]
+  },
+  "leanFile": {
+    "namespace": "AntitoneIntegralSumComparison",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/AntitoneIntegralSumComparison.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry **antitone-integral-sum-comparison-oq-01** — the **integral test** for series, packaged from Mathlib's one-sided bounds and applied to the harmonic series.

- `integral_sandwich`: the two-sided comparison for an antitone `f` on `[x₀, x₀+a]`,
  `∑_{i<a} f(x₀+i+1) ≤ ∫_{x₀}^{x₀+a} f ≤ ∑_{i<a} f(x₀+i)` — bundling `AntitoneOn.sum_le_integral` and `AntitoneOn.integral_le_sum`.
- Specialized to `f(x)=1/x` on `[1,1+n]` (integral `= log(n+1)` via `integral_one_div`):
  - `log_le_harmonic`: `log(n+1) ≤ Hₙ`
  - `harmonic_succ_le`: `H_{n+1} ≤ 1 + log(n+1)`
  - `harmonic_sub_log_nonneg` / `harmonic_succ_sub_log_le_one`: `Hₙ − log(n+1) ∈ [0,1]` — the boundedness behind the **Euler–Mascheroni constant** and the harmonic series' logarithmic divergence.
- Worked witnesses: `H₃ = 11/6`, `log 4 ≤ H₃`, and the general `1/x` sandwich.

Foundational convergence-test infrastructure that was absent from the gallery.

## Verification

- Docker build green (`Proofs.AntitoneIntegralSumComparison`, Lean v4.26.0 / Mathlib).
- **8 theorems, 1 definition, 0 sorries, 0 axioms** — no `decide`/`native_decide`; only standard tactics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)