### PR TITLE
audit: mark 2 never-audited entries clean (antitone-integral-sum, group-p²-exponent)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17397,8 +17397,20 @@
       "issues": [],
       "lastAudited": "2026-06-20T00:00:00Z",
       "result": "clean"
+    },
+    "antitone-integral-sum-comparison-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T05:08:17Z",
+      "result": "clean"
+    },
+    "group-order-prime-squared-abelian-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T05:08:17Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-20T00:00:00Z"
+  "lastUpdated": "2026-06-21T05:08:17Z"
 }


### PR DESCRIPTION
## Auditor: persist clean marks for 2 never-audited entries

Both newest gallery entries were absent from the audit-tracker `entries` map (shipped without a tracker key), producing the perpetual *never-audited* loop. Deep-audited both; both are **CLEAN**.

### antitone-integral-sum-comparison-oq-01 (#27259)
- `Proofs/AntitoneIntegralSumComparison.lean` — 7 theorems, 141 lines
- 0 sorries, 0 axioms, **no** native_decide
- Integral-test sandwich `∑f(x₀+i+1) ≤ ∫ ≤ ∑f(x₀+i)` packaged from `AntitoneOn.sum_le_integral`/`integral_le_sum`, then genuine log bounds on harmonic numbers (`log(n+1) ≤ Hₙ`, `H_{n+1} ≤ 1+log(n+1)`) and Euler–Mascheroni boundedness in [0,1]. badge `original` defensible (synthesis + derivation beyond the two wrapped lemmas).

### group-order-prime-squared-abelian-oq-01-oq-01 (#27255)
- `Proofs/GroupOrderPrimeSquaredAbelianExponentOQ01.lean` — 8 theorems (6 substantive + 2 private helpers), 135 lines
- 0 sorries, 0 axioms, **no** native_decide
- Exponent of a group of order p² as a sharp invariant: `exponent G = p² ⟺ cyclic`, `exponent G = p ⟺ non-cyclic`. Structural dichotomy imported from the parent file; exponent computation/sharpness proved here from `Monoid.order_dvd_exponent` / `exponent_dvd_of_forall_pow_eq_one` + Lagrange. badge `original` defensible.

Adds real clean entries (`auditCount:1, result:clean`) + bumps `lastUpdated`. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)