### PR TITLE
research(nakayama-lemma-oq-01-oq-01): minimal generators = dim of residue space M/𝔪M [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2920,6 +2920,7 @@ import Proofs.MotivicFlagMapsOQ03
 import Proofs.MotivicFlagMapsPartialFlags
 import Proofs.MotivicFlagMapsProvable
 import Proofs.NakayamaLemmaOQ01
+import Proofs.NakayamaLemmaOQ01OQ01
 import Proofs.NapoleonsTheorem
 import Proofs.NapoleonsTheoremOQ02
 import Proofs.NapoleonsTheoremOQ03

--- a/proofs/Proofs/NakayamaLemmaOQ01OQ01.lean
+++ b/proofs/Proofs/NakayamaLemmaOQ01OQ01.lean
@@ -1,0 +1,185 @@
+import Mathlib.RingTheory.Nakayama
+import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
+import Mathlib.RingTheory.Ideal.Cotangent
+import Mathlib.Algebra.Module.Torsion.Basic
+import Mathlib.LinearAlgebra.Dimension.Constructions
+import Mathlib.LinearAlgebra.Dimension.Free
+import Mathlib.Tactic
+import Proofs.NakayamaLemmaOQ01
+
+/-
+# Minimal number of generators equals `dim` of the residue space `M / 𝔪M`
+
+## What This Proves
+
+Over a local ring `(R, 𝔪)` with residue field `k = R / 𝔪`, a finitely generated
+module `M` has a *minimal* number of generators, and that number is computed by a
+single linear-algebra invariant: the `k`-dimension of the residue vector space
+`M / 𝔪M`.
+
+* **Residue space as a `k`-vector space.** `ResidueModule R M := M ⧸ 𝔪 • ⊤` is an
+  `R`-module annihilated by `𝔪`, hence a module over `k = R / 𝔪 = ResidueField R`.
+  Mathlib already supplies the `Module (R ⧸ I) (M ⧸ I • ⊤)` instance
+  (`Module.instModuleQuotientIdealSMulTop`) and `M / 𝔪M` is a finite-dimensional
+  `k`-vector space when `M` is `R`-finite.
+
+* **The bridge lemma** (`span_residueModule_eq_top_iff`). A set `t ⊆ M` has its
+  image spanning `M / 𝔪M` over `k` iff `span R t ⊔ 𝔪 • ⊤ = ⊤`, i.e. iff `t`
+  generates `M` *modulo* `𝔪M`. This is the precise translation between the
+  `k`-vector-space picture and the `R`-module picture, proved by combining
+  `Submodule.map_mkQ_eq_top` (surjective quotient maps) with
+  `Submodule.restrictScalars_span` (spans over `R` and over the residue field `k`
+  coincide, since `R → k` is surjective).
+
+* **Lower bound** (`finrank_le_card_of_span_eq_top`). *Every* generating set of `M`
+  has at least `dim_k (M/𝔪M)` elements. Its image spans the residue space, and a
+  spanning set of a finite-dimensional vector space has at least `dim`-many
+  elements (`finrank_le_of_span_eq_top`).
+
+* **Existence / upper bound** (`exists_spanning_finset_card_eq_finrank`). There is a
+  generating set of `M` of size *exactly* `dim_k (M/𝔪M)`: lift a `k`-basis of
+  `M/𝔪M` to `M`, and the parent file's `nakayama_span_of_span_quotient` promotes
+  "spans mod `𝔪M`" to "spans `M`". The lift has at most `dim`-many elements, and
+  the lower bound forces equality.
+
+* **The headline** (`numGenerators_eq_finrank`). Packaging the minimal generator
+  count as `numGenerators R M := sInf { n | ∃ s : Finset M, s.card = n ∧ span R s = ⊤ }`,
+  the two bounds give
+  `numGenerators R M = finrank (ResidueField R) (M ⧸ 𝔪M)`.
+
+## Relation to Mathlib and the parent
+
+Mathlib has Nakayama, the residue field, the `k`-vector-space structure on
+`M / 𝔪M`, and the cotangent-space specialisation `𝔪/𝔪²` (`Ideal.Cotangent`), but
+states the minimal-generator-count equation `μ(M) = dim_k M/𝔪M` for *no* module —
+only the principal-ideal corollary `finrank … ≤ 1 ↔ IsPrincipal` for the cotangent
+space. The parent file `NakayamaLemmaOQ01` contributes
+`nakayama_span_of_span_quotient` (lifting a residue-space spanning set to a
+generating set); this file builds the two-sided count on top of it.
+
+This file is `0`-axiom (only `propext` / `Classical.choice` / `Quot.sound`; no
+`native_decide`, no `axiom`, no `sorry`).
+-/
+
+namespace NakayamaGenerators
+
+open Submodule IsLocalRing Module
+
+variable {R : Type*} [CommRing R] [IsLocalRing R]
+variable {M : Type*} [AddCommGroup M] [Module R M]
+
+/-- The residue vector space `M / 𝔪M`. As `M / 𝔪M` is annihilated by `𝔪`, it is a
+module over the residue field `k = R / 𝔪`. -/
+abbrev ResidueModule (R M : Type*) [CommRing R] [IsLocalRing R] [AddCommGroup M]
+    [Module R M] : Type _ :=
+  M ⧸ (maximalIdeal R • (⊤ : Submodule R M))
+
+/-- The residue space `M / 𝔪M` is a vector space over the residue field. -/
+instance : Module (ResidueField R) (ResidueModule R M) :=
+  inferInstanceAs <| Module (R ⧸ maximalIdeal R) _
+
+instance : IsScalarTower R (ResidueField R) (ResidueModule R M) :=
+  inferInstanceAs <| IsScalarTower R (R ⧸ maximalIdeal R) _
+
+instance [Module.Finite R M] : FiniteDimensional (ResidueField R) (ResidueModule R M) :=
+  Module.Finite.of_restrictScalars_finite R _ _
+
+/-- The quotient map `M → M / 𝔪M`. -/
+abbrev residueMap (R M : Type*) [CommRing R] [IsLocalRing R] [AddCommGroup M]
+    [Module R M] : M →ₗ[R] ResidueModule R M :=
+  (maximalIdeal R • (⊤ : Submodule R M)).mkQ
+
+/-- **Bridge lemma.** A family `t ⊆ M` has its image spanning the residue space
+`M / 𝔪M` over the residue field iff `t` generates `M` modulo `𝔪M`, i.e.
+`span R t ⊔ 𝔪 • ⊤ = ⊤`. Spans over `R` and over `k = R/𝔪` coincide because
+`R → k` is surjective. -/
+theorem span_residueModule_eq_top_iff {t : Set M} :
+    Submodule.span (ResidueField R) (residueMap R M '' t) = ⊤ ↔
+      Submodule.span R t ⊔ maximalIdeal R • (⊤ : Submodule R M) = ⊤ := by
+  rw [← (Submodule.restrictScalars_injective R ..).eq_iff,
+    Submodule.restrictScalars_span, Submodule.restrictScalars_top,
+    ← Submodule.map_span, Submodule.map_mkQ_eq_top, sup_comm]
+  exact Ideal.Quotient.mk_surjective
+
+/-- **Lower bound, family form.** Any finite spanning family of `M` has at least
+`dim_k (M / 𝔪M)` elements. -/
+theorem finrank_le_of_span_eq_top' {ι : Type*} [Fintype ι] {g : ι → M}
+    (hg : Submodule.span R (Set.range g) = ⊤) :
+    finrank (ResidueField R) (ResidueModule R M) ≤ Fintype.card ι := by
+  refine _root_.finrank_le_of_span_eq_top (v := fun i => residueMap R M (g i)) ?_
+  have hcomp : (fun i => residueMap R M (g i)) = residueMap R M ∘ g := rfl
+  rw [hcomp, Set.range_comp, span_residueModule_eq_top_iff, hg, top_sup_eq]
+
+/-- **Lower bound.** Every generating finset of `M` has at least `dim_k (M / 𝔪M)`
+elements. -/
+theorem finrank_le_card_of_span_eq_top {s : Finset M}
+    (hs : Submodule.span R (s : Set M) = ⊤) :
+    finrank (ResidueField R) (ResidueModule R M) ≤ s.card := by
+  have hrange : Set.range (Subtype.val : ↥s → M) = (s : Set M) := by
+    ext x; simp
+  have hspan : Submodule.span R (Set.range (Subtype.val : ↥s → M)) = ⊤ := by
+    rw [hrange]; exact hs
+  have h := finrank_le_of_span_eq_top' hspan
+  simpa [Fintype.card_coe] using h
+
+/-- **Existence / upper bound.** There is a generating set of `M` of size exactly
+`dim_k (M / 𝔪M)`: lift a `k`-basis of `M / 𝔪M` and apply Nakayama. -/
+theorem exists_spanning_finset_card_eq_finrank [Module.Finite R M] :
+    ∃ t : Finset M, Submodule.span R (t : Set M) = ⊤ ∧
+      t.card = finrank (ResidueField R) (ResidueModule R M) := by
+  classical
+  set d := finrank (ResidueField R) (ResidueModule R M) with hd
+  -- a `k`-basis of the residue space, indexed by `Fin d`
+  let b := Module.finBasis (ResidueField R) (ResidueModule R M)
+  -- lift each basis vector to `M`
+  choose g hg using fun i =>
+    (Submodule.mkQ_surjective (maximalIdeal R • (⊤ : Submodule R M))) (b i)
+  -- the lifts span the residue space over `k` (they map onto the basis)
+  have hkspan : Submodule.span (ResidueField R) (residueMap R M '' Set.range g) = ⊤ := by
+    have hb : residueMap R M '' Set.range g = Set.range ⇑b := by
+      rw [← Set.range_comp]
+      exact congrArg Set.range (funext hg)
+    rw [hb]; exact b.span_eq
+  -- hence they span `M` modulo `𝔪M`, and Nakayama lifts this to spanning `M`
+  have hsup : Submodule.span R (Set.range g) ⊔ maximalIdeal R • (⊤ : Submodule R M) = ⊤ :=
+    span_residueModule_eq_top_iff.mp hkspan
+  have hrange : Submodule.span R (Set.range g) = ⊤ :=
+    NakayamaLemma.nakayama_span_of_span_quotient hsup.ge
+  -- package the lifts as a finset
+  refine ⟨Finset.image g Finset.univ, ?_, ?_⟩
+  · rwa [Finset.coe_image, Finset.coe_univ, Set.image_univ]
+  · have hts : ((Finset.image g Finset.univ : Finset M) : Set M) = Set.range g := by
+      rw [Finset.coe_image, Finset.coe_univ, Set.image_univ]
+    have hle : (Finset.image g Finset.univ).card ≤ d := by
+      calc (Finset.image g Finset.univ).card
+          ≤ (Finset.univ : Finset (Fin d)).card := Finset.card_image_le
+        _ = d := by simp
+    have hge : d ≤ (Finset.image g Finset.univ).card :=
+      finrank_le_card_of_span_eq_top (s := Finset.image g Finset.univ) (by rw [hts]; exact hrange)
+    omega
+
+/-- The minimal number of generators of an `R`-module `M`: the least size of a
+finite generating set. -/
+noncomputable def numGenerators (R M : Type*) [CommRing R] [AddCommGroup M]
+    [Module R M] : ℕ :=
+  sInf { n | ∃ s : Finset M, s.card = n ∧ Submodule.span R (s : Set M) = ⊤ }
+
+/-- **Minimal number of generators = `dim` of the residue space.** Over a local
+ring `(R, 𝔪)` with residue field `k`, a finitely generated module `M` satisfies
+`μ(M) = dim_k (M / 𝔪M)`. -/
+theorem numGenerators_eq_finrank [Module.Finite R M] :
+    numGenerators R M = finrank (ResidueField R) (ResidueModule R M) := by
+  obtain ⟨t, htspan, htcard⟩ := exists_spanning_finset_card_eq_finrank (R := R) (M := M)
+  have hne : { n | ∃ s : Finset M, s.card = n ∧ Submodule.span R (s : Set M) = ⊤ }.Nonempty :=
+    ⟨t.card, t, rfl, htspan⟩
+  refine le_antisymm ?_ ?_
+  · -- `d` is attained, so `μ ≤ d`
+    rw [← htcard]
+    exact Nat.sInf_le ⟨t, rfl, htspan⟩
+  · -- the minimiser is a generating set, so it has `≥ d` elements
+    obtain ⟨s, hscard, hsspan⟩ := Nat.sInf_mem hne
+    have := finrank_le_card_of_span_eq_top hsspan
+    rw [numGenerators, ← hscard]
+    exact this
+
+end NakayamaGenerators

--- a/src/data/proofs/nakayama-lemma-oq-01-oq-01/meta.json
+++ b/src/data/proofs/nakayama-lemma-oq-01-oq-01/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "nakayama-lemma-oq-01-oq-01",
+  "title": "Minimal number of generators equals dim of the residue space M/𝔪M",
+  "slug": "nakayama-lemma-oq-01-oq-01",
+  "description": "Over a local ring (R, 𝔪) with residue field k = R/𝔪, a finitely generated module M has a minimal generating set whose size equals dim_k(M/𝔪M). This entry proves the two-sided count: every generating set has at least dim_k(M/𝔪M) elements (a spanning set of the residue vector space), and a basis of M/𝔪M lifts (via the parent's nakayama_span_of_span_quotient) to a generating set of exactly that size. Packaged as numGenerators R M = finrank (ResidueField R) (M/𝔪M), where numGenerators is the infimum of finite-generating-set cardinalities. Answers the parent entry's first open question. Mathlib supplies Nakayama, the residue field, and the k-vector-space structure on M/𝔪M, but states this minimal-generator-count equation for no module.",
+  "meta": {
+    "author": "Krull / Azumaya / Nakayama (c. 1950); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NakayamaLemmaOQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "commutative-algebra",
+      "module-theory",
+      "local-ring",
+      "nakayama",
+      "minimal-generators",
+      "residue-field",
+      "dimension",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "finrank_le_of_span_eq_top",
+        "description": "In a finite-dimensional vector space, any spanning family has at least dim-many elements; the engine of the lower bound after passing to the residue space",
+        "module": "Mathlib.LinearAlgebra.Dimension.Constructions"
+      },
+      {
+        "theorem": "Submodule.restrictScalars_span",
+        "description": "Spans over R and over an algebra A coincide when the structure map R → A is surjective; used to identify k-spans (k = R/𝔪) with R-spans of the same set",
+        "module": "Mathlib.Algebra.Algebra.Tower"
+      },
+      {
+        "theorem": "Submodule.map_mkQ_eq_top",
+        "description": "For a quotient map, map mkQ p' = ⊤ ↔ p ⊔ p' = ⊤; translates 'image spans the quotient' into 'spans modulo the submodule'",
+        "module": "Mathlib.LinearAlgebra.Quotient.Basic"
+      },
+      {
+        "theorem": "Module.instModuleQuotientIdealSMulTop",
+        "description": "M ⧸ I•⊤ is a module over R ⧸ I (for a two-sided ideal I); specialized to I = 𝔪 it gives the residue-field vector-space structure on M/𝔪M",
+        "module": "Mathlib.Algebra.Module.Torsion.Basic"
+      },
+      {
+        "theorem": "Module.finBasis",
+        "description": "A finite free module over a division ring has a basis indexed by Fin (finrank); supplies the k-basis of M/𝔪M that is lifted to a generating set",
+        "module": "Mathlib.LinearAlgebra.Dimension.Free"
+      },
+      {
+        "theorem": "Module.Finite.of_restrictScalars_finite",
+        "description": "R-finiteness descends to A-finiteness along a scalar tower; gives FiniteDimensional k (M/𝔪M) from Module.Finite R M",
+        "module": "Mathlib.RingTheory.Finiteness.Basic"
+      },
+      {
+        "theorem": "NakayamaLemma.nakayama_span_of_span_quotient",
+        "description": "Parent result: for finite M, a set spanning M modulo 𝔪M spans M; promotes the lifted basis from 'spans M/𝔪M' to 'generates M'",
+        "module": "Proofs.NakayamaLemmaOQ01"
+      }
+    ],
+    "originalContributions": [
+      "span_residueModule_eq_top_iff: the bridge lemma — a set t ⊆ M has image spanning M/𝔪M over the residue field iff span R t ⊔ 𝔪•⊤ = ⊤, i.e. iff t generates M modulo 𝔪M; combines Submodule.map_mkQ_eq_top with restrictScalars_span (R → R/𝔪 surjective)",
+      "finrank_le_of_span_eq_top': lower bound, family form — any finite spanning family of M has at least dim_k(M/𝔪M) elements",
+      "finrank_le_card_of_span_eq_top: lower bound — every generating finset of M has at least dim_k(M/𝔪M) elements",
+      "exists_spanning_finset_card_eq_finrank: existence/upper bound — there is a generating set of M of size exactly dim_k(M/𝔪M), obtained by lifting a k-basis of M/𝔪M and applying the parent's Nakayama lifting lemma; the lower bound forces the lift's cardinality down to the dimension",
+      "numGenerators: definition of the minimal number of generators as sInf of finite-generating-set cardinalities",
+      "numGenerators_eq_finrank: the headline — μ(M) = dim_{R/𝔪}(M/𝔪M) for a finitely generated module over a local ring"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. #print axioms reports only propext, Classical.choice, Quot.sound for all headline results (numGenerators_eq_finrank, finrank_le_card_of_span_eq_top, exists_spanning_finset_card_eq_finrank).",
+    "lineCount": 185,
+    "theoremCount": 5,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "That the minimal number of generators of a finitely generated module M over a local ring (R, 𝔪) equals dim_{R/𝔪}(M/𝔪M) is the quantitative heart of Nakayama's lemma — it is what makes the residue vector space M/𝔪M the right linearization of M near the closed point, and it underlies the theory of minimal free resolutions, the fibre dimension of coherent sheaves, and Nakayama-style descent. The statement appears as Corollary 2.7 ff. in Atiyah–Macdonald and Theorem 2.3 in Matsumura.",
+    "problemStatement": "The parent entry's nakayama_span_of_span_quotient shows a set spanning M/𝔪M lifts to a generating set of M, but stops short of the count. Can the minimal-generator number itself be formalized — the least cardinality of a finite generating set of M equals dim_{R/𝔪}(M/𝔪M)?\n\n**Answer:** Yes. The image of any generating set spans M/𝔪M, so it has at least dim_k(M/𝔪M) elements (lower bound); lifting a k-basis of M/𝔪M gives a generating set of M of at most dim_k(M/𝔪M) elements, which the lower bound pins to exactly the dimension (upper bound). Together: μ(M) = dim_k(M/𝔪M).",
+    "text": "Over a local ring (R, 𝔪) with residue field k, the minimal number of generators of a finitely generated module M equals dim_k(M/𝔪M). The lower bound passes any generating set to a spanning set of the residue vector space; the upper bound lifts a k-basis of M/𝔪M to a generating set of M via Nakayama. Verified in Lean with 0 axioms.",
+    "proofStrategy": "1. span_residueModule_eq_top_iff: identify 'image of t spans M/𝔪M over k' with 'span R t ⊔ 𝔪•⊤ = ⊤' using Submodule.map_mkQ_eq_top (surjective quotient) and Submodule.restrictScalars_span (R → R/𝔪 surjective, so k-spans = R-spans).\n2. finrank_le_of_span_eq_top' / finrank_le_card_of_span_eq_top: the image of a spanning family of M spans the residue space, so by finrank_le_of_span_eq_top the family has ≥ dim_k(M/𝔪M) elements.\n3. exists_spanning_finset_card_eq_finrank: take a k-basis of M/𝔪M (Module.finBasis), lift each vector along the surjective quotient map, apply nakayama_span_of_span_quotient to get a generating set of M of card ≤ dim; the lower bound forces card = dim.\n4. numGenerators_eq_finrank: with numGenerators M := sInf{ card s : s generates M }, the upper bound gives dim ∈ the cardinality set (so sInf ≤ dim) and the lower bound bounds every element below (so dim ≤ sInf), hence equality.",
+    "keyInsights": [
+      "**The bridge lemma is the whole translation**: span_residueModule_eq_top_iff turns the residue-space (k-vector-space) statement into the M-level statement span R t ⊔ 𝔪•⊤ = ⊤ in one step, by composing the surjective-quotient lemma map_mkQ_eq_top with the surjective-scalar lemma restrictScalars_span. Everything else is bookkeeping on each side of it.",
+      "**Lower and upper bounds reuse the same bridge in opposite directions**: the lower bound reads the bridge left-to-right (spanning M ⟹ spanning M/𝔪M ⟹ card ≥ dim), the upper bound reads it right-to-left (a lifted basis spans M/𝔪M ⟹ spans M modulo 𝔪M ⟹, by the parent's Nakayama, generates M).",
+      "**The lift is automatically minimal**: lifting a dim-element basis can only collide, giving a generating set of ≤ dim elements; but the lower bound says any generating set has ≥ dim elements, so the lift has exactly dim — no separate injectivity argument is needed.",
+      "**Residue-space structure is off-the-shelf**: M/𝔪M is a k = R/𝔪 vector space via Mathlib's Module (R⧸I) (M⧸I•⊤) instance, and finite-dimensional via Module.Finite.of_restrictScalars_finite — the same machinery Mathlib uses for the cotangent space 𝔪/𝔪²."
+    ],
+    "prerequisites": [
+      "Commutative rings, ideals, modules; finitely generated and finite modules",
+      "Local rings, the maximal ideal 𝔪, and the residue field k = R/𝔪",
+      "Finite-dimensional vector spaces: bases, dimension (finrank), spanning sets",
+      "Quotient modules, scalar restriction/extension, and Nakayama's lemma (parent entry)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Residue Space as a k-Vector Space",
+      "startLine": 71,
+      "endLine": 90,
+      "summary": "ResidueModule R M := M ⧸ 𝔪•⊤ with its Module (ResidueField R) and IsScalarTower instances (from Mathlib's quotient-by-ideal-smul-top module), finite-dimensional when M is R-finite. residueMap is the quotient map M → M/𝔪M.",
+      "mathContext": "M/𝔪M as the residue vector space over k = R/𝔪."
+    },
+    {
+      "id": "bridge",
+      "title": "The Bridge Lemma",
+      "startLine": 92,
+      "endLine": 102,
+      "summary": "span_residueModule_eq_top_iff: span_k (residueMap '' t) = ⊤ ↔ span R t ⊔ 𝔪•⊤ = ⊤, via restrictScalars_span (surjective R → k) and map_mkQ_eq_top (surjective quotient).",
+      "mathContext": "Translating residue-space spanning into M-level spanning modulo 𝔪M."
+    },
+    {
+      "id": "lower",
+      "title": "Lower Bound",
+      "startLine": 104,
+      "endLine": 123,
+      "summary": "finrank_le_of_span_eq_top' (family form) and finrank_le_card_of_span_eq_top (finset form): a spanning set of M maps to a spanning set of M/𝔪M, so it has at least dim_k(M/𝔪M) elements.",
+      "mathContext": "Every generating set has ≥ dim_k(M/𝔪M) elements."
+    },
+    {
+      "id": "upper",
+      "title": "Existence and Upper Bound",
+      "startLine": 125,
+      "endLine": 157,
+      "summary": "exists_spanning_finset_card_eq_finrank: lift a k-basis of M/𝔪M to M, use nakayama_span_of_span_quotient to get a generating set, and combine card ≤ dim with the lower bound to force card = dim.",
+      "mathContext": "A k-basis of M/𝔪M lifts to a minimal generating set of M."
+    },
+    {
+      "id": "headline",
+      "title": "Minimal Generators = Dimension",
+      "startLine": 159,
+      "endLine": 183,
+      "summary": "numGenerators R M := sInf of finite-generating-set cardinalities; numGenerators_eq_finrank proves it equals finrank (ResidueField R) (M/𝔪M) by antisymmetry from the two bounds.",
+      "mathContext": "μ(M) = dim_{R/𝔪}(M/𝔪M)."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Atiyah, Michael F.; Macdonald, Ian G.",
+      "title": "Introduction to Commutative Algebra",
+      "year": "1969",
+      "note": "Proposition 2.8 and Corollary 2.7: minimal generators and the role of M/𝔪M over a local ring"
+    },
+    {
+      "authors": "Matsumura, Hideyuki",
+      "title": "Commutative Ring Theory",
+      "year": "1986",
+      "note": "Theorem 2.3: a minimal basis of M corresponds to a k-basis of M/𝔪M"
+    },
+    {
+      "authors": "The Stacks Project Authors",
+      "title": "Stacks Project, Tag 00DV / 07RC",
+      "year": "2024",
+      "note": "Nakayama's lemma and minimal generators of finite modules over local rings"
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "nakayama-lemma-oq-01",
+      "note": "Parent entry: the local-ring forms of Nakayama and nakayama_span_of_span_quotient, on which this count is built; this entry answers its first open question."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a finitely generated module M over a local ring (R, 𝔪), the minimal number of generators equals dim_{R/𝔪}(M/𝔪M). The lower bound (every generating set maps onto a spanning set of the residue vector space) and the upper bound (a lifted k-basis of M/𝔪M generates M, via the parent's Nakayama lifting lemma) are joined through one bridge lemma identifying residue-space spanning with spanning modulo 𝔪M. All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Completes the quantitative side of the parent Nakayama entry: M/𝔪M does not merely detect nonvanishing of M, it counts its minimal generators. This is the statement behind minimal free resolutions and fibre-dimension arguments for coherent sheaves.",
+    "openQuestions": [
+      "Does the minimal-generator count behave as expected under the structure theorems — e.g. is numGenerators additive on direct sums of finite modules over a local ring, numGenerators (M ⊕ N) = numGenerators M + numGenerators N, via finrank_add of the residue spaces?",
+      "Over a Noetherian local ring, does the same residue-space count give the lower bound dim R ≤ numGenerators 𝔪 (the embedding-dimension inequality) by specializing M = 𝔪?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Nakayama",
+      "Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic",
+      "Mathlib.RingTheory.Ideal.Cotangent",
+      "Mathlib.Algebra.Module.Torsion.Basic",
+      "Mathlib.LinearAlgebra.Dimension.Constructions",
+      "Mathlib.LinearAlgebra.Dimension.Free",
+      "Mathlib.Tactic",
+      "Proofs.NakayamaLemmaOQ01"
+    ],
+    "opens": [
+      "Submodule",
+      "IsLocalRing",
+      "Module"
+    ],
+    "namespace": "NakayamaGenerators",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 3,
+    "path": "Proofs/NakayamaLemmaOQ01OQ01.lean"
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Minimal number of generators = dim_{R/𝔪}(M/𝔪M)

Over a local ring $(R, \mathfrak{m})$ with residue field $k = R/\mathfrak{m}$, a finitely generated module $M$ has a **minimal generating set whose size equals $\dim_k(M/\mathfrak{m}M)$**. This answers the **first open question** of the parent entry `nakayama-lemma-oq-01` (#27181).

### Results (`Proofs/NakayamaLemmaOQ01OQ01.lean`)

- **`span_residueModule_eq_top_iff`** — the bridge lemma: the image of $t \subseteq M$ spans $M/\mathfrak{m}M$ over $k$ iff $\operatorname{span}_R t \sqcup \mathfrak{m}\cdot\top = \top$ (i.e. $t$ generates $M$ modulo $\mathfrak{m}M$). Combines `Submodule.map_mkQ_eq_top` (surjective quotient) with `Submodule.restrictScalars_span` ($R \to k$ surjective, so $k$-spans $= R$-spans).
- **`finrank_le_card_of_span_eq_top`** — lower bound: every generating set of $M$ has at least $\dim_k(M/\mathfrak{m}M)$ elements.
- **`exists_spanning_finset_card_eq_finrank`** — upper bound: lifting a $k$-basis of $M/\mathfrak{m}M$ and applying the parent's `nakayama_span_of_span_quotient` yields a generating set of size $\le \dim$; the lower bound forces equality.
- **`numGenerators_eq_finrank`** — the headline: $\mu(M) = \dim_{R/\mathfrak{m}}(M/\mathfrak{m}M)$, where `numGenerators` is the infimum of finite-generating-set cardinalities.

### Verification

5 theorems, 3 definitions, 185 lines. Docker build green on Mathlib 4.26.0. `#print axioms` reports only `propext, Classical.choice, Quot.sound` for all headline results — **0 axioms, 0 sorries, no `native_decide`**.

### Mathlib gap

Mathlib has Nakayama, the residue field, and the $k$-vector-space structure on $M/\mathfrak{m}M$, but states this minimal-generator-count equation for *no* module — only `finrank … ≤ 1 ↔ IsPrincipal` for the cotangent space $\mathfrak{m}/\mathfrak{m}^2$.

🤖 Generated with [Claude Code](https://claude.com/claude-code)