### PR TITLE
research(shannon-entropy-oq-03-oq-01): SSA equality condition — Markov-chain characterization [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3132,6 +3132,7 @@ import Proofs.ShannonEntropyOQ01OQ01
 import Proofs.ShannonEntropyOQ02
 import Proofs.ShannonEntropySSA
 import Proofs.ShannonEntropySSAAristotle
+import Proofs.ShannonEntropySSAEq
 import Proofs.ShannonSourceCoding
 import Proofs.ShannonSourceCodingOQ01
 import Proofs.ShannonSourceCodingOQ02

--- a/proofs/Proofs/ShannonEntropySSAEq.lean
+++ b/proofs/Proofs/ShannonEntropySSAEq.lean
@@ -1,0 +1,448 @@
+import Mathlib
+
+/-
+# Equality Condition for Strong Subadditivity of Shannon Entropy
+
+## What This Proves
+
+Strong subadditivity (SSA) of Shannon entropy states
+
+  H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z).
+
+This file pins down exactly *when equality holds*. The SSA deficit equals the
+conditional mutual information
+
+  I(X;Z|Y) = H(X,Y) + H(Y,Z) − H(X,Y,Z) − H(Y) ≥ 0,
+
+and `I(X;Z|Y) = 0` precisely when `X` and `Z` are conditionally independent
+given `Y` — i.e. `X – Y – Z` is a Markov chain:
+
+  p(x,y,z) · p_Y(y) = p_{XY}(x,y) · p_{YZ}(y,z)   for all x, y, z.
+
+This is the sharp boundary of SSA: the inequality is an equality iff the joint
+distribution factors through `Y`.
+
+## Proof Strategy
+
+1. `ssa_deficit_eq_cmi`: an entropy-algebra identity rewriting the SSA deficit
+   as the relative-entropy sum
+     cmiSum = Σ_{x,y,z} p(x,y,z) · log( p(x,y,z) · p_Y(y)
+                                        / (p_{XY}(x,y) · p_{YZ}(y,z)) ).
+2. `ssa_cmi_eq_zero_iff`: `cmiSum = 0 ↔ factorization`. With
+   q(x,y,z) = p_{XY}(x,y)·p_{YZ}(y,z)/p_Y(y) the summand is `p·log(p/q)`, a
+   relative entropy whose nonnegativity is strict unless `p = q` (the strict KL
+   bound). Equality forces `p = q` everywhere — the Markov factorization.
+3. `strong_subadditivity_eq_iff`: combine the two.
+
+## Mathlib Dependencies
+
+Self-contained: imports only Mathlib. The Shannon entropy, three-variable
+marginals, marginal telescoping helper, and the strict/non-strict pointwise KL
+bounds are all reproduced here.
+-/
+
+namespace InformationTheory
+
+open Finset
+
+-- ═══════════════════════════════════════════════════════════════
+-- Shannon entropy and three-variable marginals (self-contained)
+-- ═══════════════════════════════════════════════════════════════
+
+/-- Shannon entropy `H(p) = -∑ p(x) log p(x)`, with `0 log 0 = 0`. -/
+noncomputable def shannonEntropy' {α : Type*} [Fintype α] [DecidableEq α]
+    (p : α → ℝ) : ℝ :=
+  -∑ x : α, if p x = 0 then 0 else p x * Real.log (p x)
+
+/-- Marginal on `(X,Y)`: `p_{XY}(x,y) = ∑_z p(x,y,z)`. -/
+noncomputable def marginalXY {α β γ : Type*} [Fintype γ]
+    (pXYZ : α × β × γ → ℝ) : α × β → ℝ :=
+  fun ⟨x, y⟩ => ∑ z : γ, pXYZ (x, y, z)
+
+/-- Marginal on `(Y,Z)`: `p_{YZ}(y,z) = ∑_x p(x,y,z)`. -/
+noncomputable def marginalYZ {α β γ : Type*} [Fintype α]
+    (pXYZ : α × β × γ → ℝ) : β × γ → ℝ :=
+  fun ⟨y, z⟩ => ∑ x : α, pXYZ (x, y, z)
+
+/-- Marginal on `Y`: `p_Y(y) = ∑_x ∑_z p(x,y,z)`. -/
+noncomputable def marginalY_3 {α β γ : Type*} [Fintype α] [Fintype γ]
+    (pXYZ : α × β × γ → ℝ) : β → ℝ :=
+  fun y => ∑ x : α, ∑ z : γ, pXYZ (x, y, z)
+
+-- ═══════════════════════════════════════════════════════════════
+-- Marginal telescoping and pointwise KL bounds (helpers)
+-- ═══════════════════════════════════════════════════════════════
+
+/-- `S log S = Σ_i a_i · log S` over the support, where `S = ∑ a_i`. -/
+private lemma marginal_telescope {ι : Type*} [Fintype ι] (a : ι → ℝ)
+    (ha : ∀ i, 0 ≤ a i) :
+    (if (∑ i, a i) = 0 then (0 : ℝ) else (∑ i, a i) * Real.log (∑ i, a i)) =
+    ∑ i, (if a i = 0 then 0 else a i * Real.log (∑ j, a j)) := by
+  by_cases hs : (∑ i, a i) = 0
+  · have h0 : ∀ i, a i = 0 := fun i =>
+      le_antisymm (by linarith [Finset.single_le_sum (fun j _ => ha j) (Finset.mem_univ i)]) (ha i)
+    simp [h0]
+  · simp only [hs, ↓reduceIte]; symm
+    rw [show ∑ i, (if a i = 0 then (0 : ℝ) else a i * Real.log (∑ j, a j)) =
+        ∑ i, a i * Real.log (∑ j, a j) from
+      Finset.sum_congr rfl fun i _ => by by_cases h : a i = 0 <;> simp [h]]
+    rw [← Finset.sum_mul]
+
+private lemma rlog_lt_sub_one {y : ℝ} (hy : 0 < y) (hne : y ≠ 1) :
+    Real.log y < y - 1 := by
+  have hlog_ne : Real.log y ≠ 0 := by
+    intro h; apply hne; rw [← Real.exp_log hy, h, Real.exp_zero]
+  have hexp := Real.add_one_lt_exp hlog_ne
+  rw [Real.exp_log hy] at hexp
+  linarith
+
+private lemma kl_lb {p q : ℝ} (hp : 0 < p) (hq : 0 < q) :
+    p - q ≤ p * Real.log (p / q) := by
+  have h1 : Real.log (q / p) ≤ q / p - 1 := Real.log_le_sub_one_of_pos (div_pos hq hp)
+  have hlog : Real.log (p / q) = -Real.log (q / p) := by
+    rw [Real.log_div (ne_of_gt hp) (ne_of_gt hq), Real.log_div (ne_of_gt hq) (ne_of_gt hp)]; ring
+  have hmul : p * Real.log (q / p) ≤ p * (q / p - 1) :=
+    mul_le_mul_of_nonneg_left h1 (le_of_lt hp)
+  have heq : p * (q / p - 1) = q - p := by field_simp
+  rw [hlog, mul_neg]; linarith [hmul, heq]
+
+private lemma kl_lb_strict {p q : ℝ} (hp : 0 < p) (hq : 0 < q) (hne : p ≠ q) :
+    p - q < p * Real.log (p / q) := by
+  have hqp_ne_one : q / p ≠ 1 := by
+    intro h; field_simp at h; exact hne h.symm
+  have h1 : Real.log (q / p) < q / p - 1 := rlog_lt_sub_one (div_pos hq hp) hqp_ne_one
+  have hlog : Real.log (p / q) = -Real.log (q / p) := by
+    rw [Real.log_div (ne_of_gt hp) (ne_of_gt hq), Real.log_div (ne_of_gt hq) (ne_of_gt hp)]; ring
+  have hmul : p * Real.log (q / p) < p * (q / p - 1) := mul_lt_mul_of_pos_left h1 hp
+  have heq : p * (q / p - 1) = q - p := by field_simp
+  rw [hlog, mul_neg]; linarith [hmul, heq]
+
+-- ═══════════════════════════════════════════════════════════════
+-- The conditional mutual information sum
+-- ═══════════════════════════════════════════════════════════════
+
+/-- The conditional mutual information `I(X;Z|Y)` written as a relative-entropy
+    sum, with the convention that a zero-probability term contributes `0`. -/
+noncomputable def cmiSum {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    (pXYZ : α × β × γ → ℝ) : ℝ :=
+  ∑ x : α, ∑ y : β, ∑ z : γ,
+    (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+     else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) *
+       (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) /
+       ((∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z)))))
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART I: The SSA deficit equals the conditional mutual information
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **Deficit = conditional mutual information.** -/
+theorem ssa_deficit_eq_cmi {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
+    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz) :
+    shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ)
+      - shannonEntropy' pXYZ - shannonEntropy' (marginalY_3 pXYZ)
+    = cmiSum pXYZ := by
+  have hXY : ∀ x y, (if (∑ z : γ, pXYZ (x, y, z)) = 0 then (0 : ℝ)
+      else (∑ z, pXYZ (x, y, z)) * Real.log (∑ z, pXYZ (x, y, z))) =
+      ∑ z : γ, (if pXYZ (x, y, z) = 0 then 0
+        else pXYZ (x, y, z) * Real.log (∑ z' : γ, pXYZ (x, y, z'))) := by
+    intro x y; exact marginal_telescope (fun z => pXYZ (x, y, z)) (fun z => hp (x, y, z))
+  have hYZ : ∀ y z, (if (∑ x : α, pXYZ (x, y, z)) = 0 then (0 : ℝ)
+      else (∑ x, pXYZ (x, y, z)) * Real.log (∑ x, pXYZ (x, y, z))) =
+      ∑ x : α, (if pXYZ (x, y, z) = 0 then 0
+        else pXYZ (x, y, z) * Real.log (∑ x' : α, pXYZ (x', y, z))) := by
+    intro y z; exact marginal_telescope (fun x => pXYZ (x, y, z)) (fun x => hp (x, y, z))
+  have hY : ∀ y, (if (∑ x : α, ∑ z : γ, pXYZ (x, y, z)) = 0 then (0 : ℝ)
+      else (∑ x, ∑ z, pXYZ (x, y, z)) * Real.log (∑ x, ∑ z, pXYZ (x, y, z))) =
+      ∑ x : α, ∑ z : γ, (if pXYZ (x, y, z) = 0 then 0
+        else pXYZ (x, y, z) * Real.log (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z'))) := by
+    intro y
+    have h := marginal_telescope (fun (xz : α × γ) => pXYZ (xz.1, y, xz.2))
+      (fun (xz : α × γ) => hp (xz.1, y, xz.2))
+    simp_rw [Fintype.sum_prod_type] at h; exact h
+  have hterm : ∀ x y z,
+      (if pXYZ (x, y, z) = 0 then (0 : ℝ) else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z))) =
+      (if pXYZ (x, y, z) = 0 then 0
+       else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) *
+         (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) /
+         ((∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z))))) +
+      (if pXYZ (x, y, z) = 0 then 0
+       else pXYZ (x, y, z) * Real.log (∑ z' : γ, pXYZ (x, y, z'))) +
+      (if pXYZ (x, y, z) = 0 then 0
+       else pXYZ (x, y, z) * Real.log (∑ x' : α, pXYZ (x', y, z))) -
+      (if pXYZ (x, y, z) = 0 then 0
+       else pXYZ (x, y, z) * Real.log (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z'))) := by
+    intro x y z
+    by_cases hpxyz : pXYZ (x, y, z) = 0
+    · simp [hpxyz]
+    · simp only [hpxyz, ↓reduceIte]
+      have hpos : 0 < pXYZ (x, y, z) := lt_of_le_of_ne (hp _) (Ne.symm hpxyz)
+      have hpXY : 0 < ∑ z', pXYZ (x, y, z') :=
+        lt_of_lt_of_le hpos (Finset.single_le_sum (fun z' _ => hp (x, y, z')) (Finset.mem_univ z))
+      have hpYZ : 0 < ∑ x', pXYZ (x', y, z) :=
+        lt_of_lt_of_le hpos (Finset.single_le_sum (fun x' _ => hp (x', y, z)) (Finset.mem_univ x))
+      have hpY : 0 < ∑ x' : α, ∑ z' : γ, pXYZ (x', y, z') :=
+        lt_of_lt_of_le hpXY (Finset.single_le_sum
+          (fun x' _ => Finset.sum_nonneg fun z' _ => hp (x', y, z')) (Finset.mem_univ x))
+      have hlog : Real.log (pXYZ (x, y, z)) =
+          Real.log (pXYZ (x, y, z) * (∑ x', ∑ z', pXYZ (x', y, z')) /
+            ((∑ z', pXYZ (x, y, z')) * (∑ x', pXYZ (x', y, z)))) +
+          Real.log (∑ z', pXYZ (x, y, z')) +
+          Real.log (∑ x', pXYZ (x', y, z)) -
+          Real.log (∑ x', ∑ z', pXYZ (x', y, z')) := by
+        rw [Real.log_div (ne_of_gt (mul_pos hpos hpY)) (ne_of_gt (mul_pos hpXY hpYZ)),
+            Real.log_mul (ne_of_gt hpos) (ne_of_gt hpY),
+            Real.log_mul (ne_of_gt hpXY) (ne_of_gt hpYZ)]
+        ring
+      rw [hlog]; ring
+  have hHXY : shannonEntropy' (marginalXY pXYZ) =
+      -∑ x : α, ∑ y : β, ∑ z : γ, (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+        else pXYZ (x, y, z) * Real.log (∑ z' : γ, pXYZ (x, y, z'))) := by
+    unfold shannonEntropy' marginalXY
+    congr 1
+    rw [Fintype.sum_prod_type]
+    exact Finset.sum_congr rfl (fun x _ => Finset.sum_congr rfl (fun y _ => hXY x y))
+  have hHYZ : shannonEntropy' (marginalYZ pXYZ) =
+      -∑ x : α, ∑ y : β, ∑ z : γ, (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+        else pXYZ (x, y, z) * Real.log (∑ x' : α, pXYZ (x', y, z))) := by
+    unfold shannonEntropy' marginalYZ
+    congr 1
+    rw [Fintype.sum_prod_type]
+    rw [show (∑ y : β, ∑ z : γ, (if (∑ x : α, pXYZ (x, y, z)) = 0 then (0 : ℝ)
+          else (∑ x, pXYZ (x, y, z)) * Real.log (∑ x, pXYZ (x, y, z))))
+        = ∑ y : β, ∑ z : γ, ∑ x : α, (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+          else pXYZ (x, y, z) * Real.log (∑ x' : α, pXYZ (x', y, z))) from
+      Finset.sum_congr rfl (fun y _ => Finset.sum_congr rfl (fun z _ => hYZ y z))]
+    rw [show (∑ y : β, ∑ z : γ, ∑ x : α, (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+          else pXYZ (x, y, z) * Real.log (∑ x' : α, pXYZ (x', y, z))))
+        = ∑ y : β, ∑ x : α, ∑ z : γ, (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+          else pXYZ (x, y, z) * Real.log (∑ x' : α, pXYZ (x', y, z))) from
+      Finset.sum_congr rfl (fun y _ => Finset.sum_comm)]
+    rw [Finset.sum_comm]
+  have hHXYZ : shannonEntropy' pXYZ =
+      -∑ x : α, ∑ y : β, ∑ z : γ, (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+        else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z))) := by
+    unfold shannonEntropy'
+    congr 1
+    rw [Fintype.sum_prod_type]
+    simp_rw [Fintype.sum_prod_type]
+  have hHY : shannonEntropy' (marginalY_3 pXYZ) =
+      -∑ x : α, ∑ y : β, ∑ z : γ, (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+        else pXYZ (x, y, z) * Real.log (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z'))) := by
+    unfold shannonEntropy' marginalY_3
+    congr 1
+    rw [show (∑ y : β, (if (∑ x : α, ∑ z : γ, pXYZ (x, y, z)) = 0 then (0 : ℝ)
+          else (∑ x, ∑ z, pXYZ (x, y, z)) * Real.log (∑ x, ∑ z, pXYZ (x, y, z))))
+        = ∑ y : β, ∑ x : α, ∑ z : γ, (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+          else pXYZ (x, y, z) * Real.log (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z'))) from
+      Finset.sum_congr rfl (fun y _ => hY y)]
+    rw [Finset.sum_comm]
+  rw [hHXY, hHYZ, hHXYZ, hHY]
+  unfold cmiSum
+  simp_rw [hterm]
+  simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib]
+  ring
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART II: CMI vanishes iff the Markov factorization holds
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **Vanishing of conditional mutual information.**
+    `I(X;Z|Y) = 0` iff `X – Y – Z` is a Markov chain, in division-free form. -/
+theorem ssa_cmi_eq_zero_iff {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
+    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz)
+    (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
+    cmiSum pXYZ = 0 ↔
+    ∀ x y z, pXYZ (x, y, z) * marginalY_3 pXYZ y
+      = marginalXY pXYZ (x, y) * marginalYZ pXYZ (y, z) := by
+  have hsum_n : ∑ x : α, ∑ y : β, ∑ z : γ, pXYZ (x, y, z) = 1 := by
+    have h := hsum; rw [Fintype.sum_prod_type] at h; simp_rw [Fintype.sum_prod_type] at h; exact h
+  set q := fun x y z => (∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z)) /
+    (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) with hq_def
+  have hq_nn : ∀ x y z, 0 ≤ q x y z := fun x y z => by
+    simp only [hq_def]
+    exact div_nonneg
+      (mul_nonneg (Finset.sum_nonneg fun z' _ => hp _) (Finset.sum_nonneg fun x' _ => hp _))
+      (Finset.sum_nonneg fun x' _ => Finset.sum_nonneg fun z' _ => hp _)
+  -- positivity of marginals at a support point
+  have hmarg_pos : ∀ x y z, pXYZ (x, y, z) ≠ 0 →
+      0 < (∑ z' : γ, pXYZ (x, y, z')) ∧ 0 < (∑ x' : α, pXYZ (x', y, z)) ∧
+      0 < (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) := by
+    intro x y z hne
+    have hpos : 0 < pXYZ (x, y, z) := lt_of_le_of_ne (hp _) (Ne.symm hne)
+    have hpXY : 0 < ∑ z', pXYZ (x, y, z') :=
+      lt_of_lt_of_le hpos (Finset.single_le_sum (fun z' _ => hp (x, y, z')) (Finset.mem_univ z))
+    have hpYZ : 0 < ∑ x', pXYZ (x', y, z) :=
+      lt_of_lt_of_le hpos (Finset.single_le_sum (fun x' _ => hp (x', y, z)) (Finset.mem_univ x))
+    have hpY : 0 < ∑ x' : α, ∑ z' : γ, pXYZ (x', y, z') :=
+      lt_of_lt_of_le hpXY (Finset.single_le_sum
+        (fun x' _ => Finset.sum_nonneg fun z' _ => hp (x', y, z')) (Finset.mem_univ x))
+    exact ⟨hpXY, hpYZ, hpY⟩
+  have hq_pos_of : ∀ x y z, pXYZ (x, y, z) ≠ 0 → 0 < q x y z := by
+    intro x y z hne
+    obtain ⟨hpXY, hpYZ, hpY⟩ := hmarg_pos x y z hne
+    simp only [hq_def]; exact div_pos (mul_pos hpXY hpYZ) hpY
+  have hq_sum_y : ∀ y, ∑ x : α, ∑ z : γ, q x y z = ∑ x, ∑ z, pXYZ (x, y, z) := by
+    intro y
+    simp only [hq_def]
+    by_cases hpy : (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) = 0
+    · have hall : ∀ x z, pXYZ (x, y, z) = 0 := by
+        have h2 := (Finset.sum_eq_zero_iff_of_nonneg
+          (fun x _ => Finset.sum_nonneg fun z _ => hp (x, y, z))).mp hpy
+        intro x z
+        exact (Finset.sum_eq_zero_iff_of_nonneg
+          (fun z _ => hp (x, y, z))).mp (h2 x (Finset.mem_univ x)) z (Finset.mem_univ z)
+      simp [hall]
+    · have hD : (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) ≠ 0 := hpy
+      have step1 : ∀ x : α, (∑ z : γ,
+            (∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z))
+              / (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')))
+          = (∑ z' : γ, pXYZ (x, y, z')) * (∑ z : γ, ∑ x' : α, pXYZ (x', y, z))
+              / (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) := by
+        intro x
+        rw [← Finset.sum_div, ← Finset.mul_sum]
+      simp_rw [step1]
+      rw [← Finset.sum_div, ← Finset.sum_mul]
+      rw [show (∑ z : γ, ∑ x' : α, pXYZ (x', y, z)) = ∑ x' : α, ∑ z : γ, pXYZ (x', y, z) from
+        Finset.sum_comm]
+      rw [mul_div_assoc, div_self hD, mul_one]
+  have hq_sum : ∑ x : α, ∑ y : β, ∑ z : γ, q x y z = 1 := by
+    conv_lhs => rw [Finset.sum_comm]
+    simp_rw [hq_sum_y]
+    rw [Finset.sum_comm]; exact hsum_n
+  -- Rewrite cmiSum's summand into relative-entropy `p · log(p / q)` form.
+  have hcmi_q : cmiSum pXYZ = ∑ x : α, ∑ y : β, ∑ z : γ,
+      (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+       else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) / q x y z)) := by
+    unfold cmiSum
+    refine Finset.sum_congr rfl (fun x _ => Finset.sum_congr rfl
+      (fun y _ => Finset.sum_congr rfl (fun z _ => ?_)))
+    by_cases hpxyz : pXYZ (x, y, z) = 0
+    · simp [hpxyz]
+    · rw [if_neg hpxyz, if_neg hpxyz]
+      obtain ⟨hpXY, hpYZ, hpY⟩ := hmarg_pos x y z hpxyz
+      have hlog_eq : pXYZ (x, y, z) * (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) /
+          ((∑ z' : γ, pXYZ (x, y, z')) * (∑ x' : α, pXYZ (x', y, z))) =
+          pXYZ (x, y, z) / q x y z := by
+        simp only [hq_def]
+        field_simp
+      rw [hlog_eq]
+  rw [hcmi_q]
+  constructor
+  · -- Forward: cmiSum = 0 → factorization.
+    intro hS
+    have hbound : ∀ x y z, pXYZ (x, y, z) - q x y z ≤
+        (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+         else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) / q x y z)) := by
+      intro x y z
+      by_cases hpxyz : pXYZ (x, y, z) = 0
+      · rw [if_pos hpxyz]; have := hq_nn x y z; linarith
+      · rw [if_neg hpxyz]
+        have hpos : 0 < pXYZ (x, y, z) := lt_of_le_of_ne (hp _) (Ne.symm hpxyz)
+        exact kl_lb hpos (hq_pos_of x y z hpxyz)
+    have hFge : ∀ x y z, 0 ≤
+        (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+         else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) / q x y z))
+        - (pXYZ (x, y, z) - q x y z) := fun x y z => by linarith [hbound x y z]
+    have hsumFge : ∑ x : α, ∑ y : β, ∑ z : γ,
+        ((if pXYZ (x, y, z) = 0 then (0 : ℝ)
+          else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) / q x y z))
+         - (pXYZ (x, y, z) - q x y z)) = 0 := by
+      simp only [Finset.sum_sub_distrib]
+      rw [hS, hsum_n, hq_sum]; ring
+    have h1 := (Finset.sum_eq_zero_iff_of_nonneg
+      (fun x _ => Finset.sum_nonneg fun y _ => Finset.sum_nonneg fun z _ =>
+        hFge x y z)).mp hsumFge
+    have hFeq : ∀ x y z,
+        (if pXYZ (x, y, z) = 0 then (0 : ℝ)
+         else pXYZ (x, y, z) * Real.log (pXYZ (x, y, z) / q x y z))
+        - (pXYZ (x, y, z) - q x y z) = 0 := by
+      intro x y z
+      have hx := h1 x (Finset.mem_univ x)
+      have h2 := (Finset.sum_eq_zero_iff_of_nonneg
+        (fun y _ => Finset.sum_nonneg fun z _ => hFge x y z)).mp hx
+      have hy := h2 y (Finset.mem_univ y)
+      have h3 := (Finset.sum_eq_zero_iff_of_nonneg
+        (fun z _ => hFge x y z)).mp hy
+      exact h3 z (Finset.mem_univ z)
+    have hpeqq : ∀ x y z, pXYZ (x, y, z) = q x y z := by
+      intro x y z
+      have hf := hFeq x y z
+      by_cases hpxyz : pXYZ (x, y, z) = 0
+      · rw [if_pos hpxyz] at hf; linarith
+      · rw [if_neg hpxyz] at hf
+        have hpos : 0 < pXYZ (x, y, z) := lt_of_le_of_ne (hp _) (Ne.symm hpxyz)
+        have hqpos := hq_pos_of x y z hpxyz
+        by_contra hne
+        have := kl_lb_strict hpos hqpos hne
+        linarith
+    intro x y z
+    simp only [marginalY_3, marginalXY, marginalYZ]
+    by_cases hpy : (∑ x' : α, ∑ z' : γ, pXYZ (x', y, z')) = 0
+    · have hp0 : pXYZ (x, y, z) = 0 := by
+        have hle : pXYZ (x, y, z) ≤ ∑ x', ∑ z', pXYZ (x', y, z') :=
+          le_trans (Finset.single_le_sum (fun z' _ => hp (x, y, z')) (Finset.mem_univ z))
+            (Finset.single_le_sum (fun x' _ => Finset.sum_nonneg fun z' _ => hp (x', y, z'))
+              (Finset.mem_univ x))
+        linarith [hp (x, y, z)]
+      have hpXY0 : (∑ z' : γ, pXYZ (x, y, z')) = 0 := by
+        apply Finset.sum_eq_zero; intro z' _
+        have hle : pXYZ (x, y, z') ≤ ∑ x', ∑ z', pXYZ (x', y, z') :=
+          le_trans (Finset.single_le_sum (fun z'' _ => hp (x, y, z'')) (Finset.mem_univ z'))
+            (Finset.single_le_sum (fun x' _ => Finset.sum_nonneg fun z'' _ => hp (x', y, z''))
+              (Finset.mem_univ x))
+        linarith [hp (x, y, z')]
+      rw [hpy, hp0, hpXY0]; ring
+    · have hpY_pos : 0 < ∑ x' : α, ∑ z' : γ, pXYZ (x', y, z') :=
+        lt_of_le_of_ne
+          (Finset.sum_nonneg fun x' _ => Finset.sum_nonneg fun z' _ => hp (x', y, z'))
+          (Ne.symm hpy)
+      rw [hpeqq x y z]
+      simp only [hq_def]
+      field_simp
+  · -- Backward: factorization → cmiSum = 0.
+    intro hfac
+    apply Finset.sum_eq_zero; intro x _
+    apply Finset.sum_eq_zero; intro y _
+    apply Finset.sum_eq_zero; intro z _
+    by_cases hpxyz : pXYZ (x, y, z) = 0
+    · rw [if_pos hpxyz]
+    · rw [if_neg hpxyz]
+      have hqpos := hq_pos_of x y z hpxyz
+      obtain ⟨_, _, hpY_pos⟩ := hmarg_pos x y z hpxyz
+      have hpq : pXYZ (x, y, z) = q x y z := by
+        have hf := hfac x y z
+        simp only [marginalY_3, marginalXY, marginalYZ] at hf
+        simp only [hq_def]
+        rw [eq_div_iff hpY_pos.ne']
+        linarith [hf]
+      rw [hpq, div_self hqpos.ne', Real.log_one, mul_zero]
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART III: Equality condition for strong subadditivity
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **Equality condition for strong subadditivity.**
+    `H(X,Y,Z) + H(Y) = H(X,Y) + H(Y,Z)` holds iff `X – Y – Z` is a Markov chain
+    (conditional independence of `X` and `Z` given `Y`):
+      p(x,y,z) · p_Y(y) = p_{XY}(x,y) · p_{YZ}(y,z)   for all x, y, z. -/
+theorem strong_subadditivity_eq_iff {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
+    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz)
+    (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
+    (shannonEntropy' pXYZ + shannonEntropy' (marginalY_3 pXYZ)
+      = shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ))
+    ↔ (∀ x y z, pXYZ (x, y, z) * marginalY_3 pXYZ y
+        = marginalXY pXYZ (x, y) * marginalYZ pXYZ (y, z)) := by
+  rw [← ssa_cmi_eq_zero_iff hp hsum]
+  have hdef := ssa_deficit_eq_cmi (pXYZ := pXYZ) hp
+  constructor
+  · intro heq; linear_combination -hdef - heq
+  · intro hcmi; linear_combination -hdef - hcmi
+
+end InformationTheory

--- a/src/data/proofs/shannon-entropy-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/shannon-entropy-oq-03-oq-01/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-cmisum-def",
+    "proofId": "shannon-entropy-oq-03-oq-01",
+    "range": { "startLine": 126, "endLine": 137 },
+    "type": "definition",
+    "title": "cmiSum: conditional mutual information as a relative entropy",
+    "content": "cmiSum encodes I(X;Z|Y) = Σ_{x,y,z} p(x,y,z)·log( p(x,y,z)·p_Y(y) / (p_{XY}(x,y)·p_{YZ}(y,z)) ), with the convention that zero-probability terms contribute 0. This is exactly the relative entropy D(p ‖ q) against the conditional-independence distribution q(x,y,z) = p_{XY}(x,y)·p_{YZ}(y,z)/p_Y(y), written in a division-free numerator so the summand is well-defined even when a slice has probability zero."
+  },
+  {
+    "id": "ann-kl-strict",
+    "proofId": "shannon-entropy-oq-03-oq-01",
+    "range": { "startLine": 109, "endLine": 122 },
+    "type": "lemma",
+    "title": "kl_lb_strict: the strict pointwise KL bound",
+    "content": "For p, q > 0 with p ≠ q, the relative-entropy term is strictly bounded: p·log(p/q) > p − q. This strictness is the engine of the equality characterization — it is what forces p = q at every support point once the total deficit is known to vanish. It refines the non-strict bound kl_lb (p·log(p/q) ≥ p − q) used to prove SSA itself."
+  },
+  {
+    "id": "ann-deficit-eq-cmi",
+    "proofId": "shannon-entropy-oq-03-oq-01",
+    "range": { "startLine": 140, "endLine": 251 },
+    "type": "theorem",
+    "title": "ssa_deficit_eq_cmi: the SSA deficit IS the conditional mutual information",
+    "content": "The slack H(X,Y)+H(Y,Z)−H(X,Y,Z)−H(Y) equals cmiSum exactly. The proof expands each entropy as a nested sum over (x,y,z), applies the marginal-telescoping identity to rewrite the marginal entropies, and splits log p(x,y,z) into the conditional-MI term plus the three marginal log terms; the marginal pieces cancel and the deficit collapses to the single relative-entropy sum. This is the precise (equality) form of the algebra that underlies the SSA inequality."
+  },
+  {
+    "id": "ann-cmi-zero-iff",
+    "proofId": "shannon-entropy-oq-03-oq-01",
+    "range": { "startLine": 254, "endLine": 431 },
+    "type": "theorem",
+    "title": "ssa_cmi_eq_zero_iff: vanishing CMI ⟺ Markov factorization",
+    "content": "cmiSum = 0 iff p(x,y,z)·p_Y(y) = p_{XY}(x,y)·p_{YZ}(y,z) for all x,y,z. Forward: each summand p·log(p/q) dominates p − q, and Σ(p − q) = 0, so the deficit vanishes only if every summand equals p − q; the strict KL bound then forces p = q everywhere, i.e. the factorization (handled uniformly across zero-probability slices). Backward: substituting the factorization makes every log(p/q) = log 1 = 0."
+  },
+  {
+    "id": "ann-ssa-eq-iff",
+    "proofId": "shannon-entropy-oq-03-oq-01",
+    "range": { "startLine": 433, "endLine": 446 },
+    "type": "theorem",
+    "title": "strong_subadditivity_eq_iff: SSA equality ⟺ Markov chain X–Y–Z",
+    "content": "Combining the two reductions: H(X,Y,Z)+H(Y) = H(X,Y)+H(Y,Z) holds if and only if X and Z are conditionally independent given Y, i.e. X–Y–Z is a Markov chain. This is the sharp boundary of the deepest classical entropy inequality — the classical special case of the quantum SSA equality theorem of Hayden–Jozsa–Petz–Winter."
+  }
+]

--- a/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "shannon-entropy-oq-03-oq-01",
+  "title": "Equality Condition for Strong Subadditivity (Markov Chain Characterization)",
+  "slug": "shannon-entropy-oq-03-oq-01",
+  "description": "Characterizes exactly when strong subadditivity of Shannon entropy holds with equality. The SSA deficit H(X,Y)+H(Y,Z)-H(X,Y,Z)-H(Y) equals the conditional mutual information I(X;Z|Y), and this vanishes iff X-Y-Z is a Markov chain, i.e. p(x,y,z)·p_Y(y) = p_{XY}(x,y)·p_{YZ}(y,z) for all x,y,z. The sharp boundary of the deepest classical entropy inequality.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShannonEntropySSAEq.lean",
+    "tags": [
+      "information-theory",
+      "entropy",
+      "strong-subadditivity",
+      "conditional-independence",
+      "markov-chain",
+      "kl-divergence",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "lineCount": 443,
+    "theoremCount": 7,
+    "definitionCount": 5,
+    "assumptions": "None mathematically (0 axioms, 0 sorries). Machine-verified via Docker (lean4 v4.26.0). Self-contained: imports only Mathlib and reproduces the Shannon entropy / three-variable marginal definitions (matching the SSA proof) plus the private pointwise KL bounds, so it does not depend on any other Proofs file.",
+    "originalContributions": [
+      "cmiSum: the conditional mutual information I(X;Z|Y) as a relative-entropy sum Σ p·log(p·p_Y/(p_XY·p_YZ))",
+      "ssa_deficit_eq_cmi: the SSA deficit equals cmiSum (entropy chain-rule telescoping isolated as an exact identity)",
+      "ssa_cmi_eq_zero_iff: I(X;Z|Y)=0 iff the Markov factorization p·p_Y = p_XY·p_YZ holds everywhere (forward via strict KL bound, backward by direct substitution)",
+      "strong_subadditivity_eq_iff: SSA holds with equality iff X-Y-Z is a Markov chain"
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Strong subadditivity (SSA) of entropy — H(X,Y,Z)+H(Y) ≤ H(X,Y)+H(Y,Z) — is the deepest inequality of classical information theory and, in its von Neumann form, was proved by Lieb and Ruskai (1973). A standard companion question is the equality case: when is the inequality tight? Classically the SSA deficit equals the conditional mutual information I(X;Z|Y), a weighted sum of per-slice KL divergences, each strictly positive unless the conditional distribution factors. Equality therefore characterizes conditional independence of X and Z given Y — the statement that X–Y–Z forms a Markov chain. This equality condition is the classical shadow of the quantum equality case (Hayden–Jozsa–Petz–Winter 2004), where SSA is saturated exactly by quantum Markov states / states with a Petz recovery map; the classical characterization formalized here is the elementary special case.",
+    "problemStatement": "When does strong subadditivity hold with equality? Prove that for a joint distribution p(x,y,z),\n\n$$H(X,Y,Z) + H(Y) = H(X,Y) + H(Y,Z)$$\n\nholds if and only if X and Z are conditionally independent given Y, i.e. p(x,y,z)·p_Y(y) = p_{XY}(x,y)·p_{YZ}(y,z) for all x,y,z (the Markov chain X–Y–Z).",
+    "text": "A self-contained formalization (7 theorems, 5 definitions, 0 axioms, 0 sorries) of the equality condition for strong subadditivity of Shannon entropy. The SSA deficit is rewritten as the conditional mutual information I(X;Z|Y) = Σ_{x,y,z} p(x,y,z)·log( p(x,y,z)·p_Y(y) / (p_{XY}(x,y)·p_{YZ}(y,z)) ) via the entropy chain-rule telescoping (ssa_deficit_eq_cmi). This sum is a relative entropy D(p ‖ q) with q(x,y,z) = p_{XY}(x,y)·p_{YZ}(y,z)/p_Y(y); the strict pointwise KL bound forces each summand to exceed p−q unless p=q, so the sum vanishes iff p=q everywhere, which is precisely the Markov factorization (ssa_cmi_eq_zero_iff). Combining gives strong_subadditivity_eq_iff.",
+    "proofStrategy": "**Two-step reduction:**\n\n1. *Deficit = CMI* (`ssa_deficit_eq_cmi`): expand each of the four entropies as a nested sum over (x,y,z), use the marginal-telescoping identity to align the marginal-log terms, and split log p(x,y,z) into the conditional-MI term plus the three marginal logs. The deficit collapses algebraically to the single relative-entropy sum cmiSum.\n\n2. *CMI = 0 iff Markov* (`ssa_cmi_eq_zero_iff`): with q = p_XY·p_YZ/p_Y (a sub-probability that sums to 1), each summand equals p·log(p/q) ≥ p − q (KL bound). Since Σ(p − q) = 1 − 1 = 0 and every summand dominates p − q, the total being zero forces each summand to equal p − q, and the *strict* KL bound (p·log(p/q) > p − q whenever p ≠ q) then forces p = q at every support point. p = q is exactly p·p_Y = p_XY·p_YZ. The converse substitutes the factorization back to make each log(p/q) = log 1 = 0.",
+    "keyInsights": [
+      "The SSA deficit is not merely nonnegative — it is *exactly* the conditional mutual information I(X;Z|Y), so SSA equality is the vanishing of conditional MI.",
+      "Conditional MI is a relative entropy D(p ‖ q) against the conditional-independence distribution q(x,y,z) = p_{XY}(x,y)·p_{YZ}(y,z)/p_Y(y); KL divergence vanishes iff its two arguments coincide.",
+      "The *strict* pointwise KL bound p·log(p/q) > p − q (for p ≠ q) is what upgrades 'deficit ≥ 0' to a sharp characterization: equality cannot hold unless the distribution factors at every support point.",
+      "p = q everywhere is the division-free Markov factorization p(x,y,z)·p_Y(y) = p_{XY}(x,y)·p_{YZ}(y,z); the formalization avoids conditional probabilities entirely, handling zero-probability slices uniformly.",
+      "This is the classical special case of the quantum SSA equality theorem (Hayden–Jozsa–Petz–Winter), where saturation corresponds to states recoverable by a Petz map — the structural reason SSA underlies quantum error correction."
+    ],
+    "prerequisites": [
+      "Shannon entropy and the entropy chain rule",
+      "KL divergence non-negativity and its strict (equality) refinement",
+      "Conditional mutual information and conditional independence"
+    ]
+  },
+  "conclusion": {
+    "summary": "Strong subadditivity of Shannon entropy holds with equality exactly when X–Y–Z is a Markov chain. The proof rewrites the SSA deficit as the conditional mutual information I(X;Z|Y) and characterizes its vanishing via the strict KL divergence bound, yielding the Markov factorization p·p_Y = p_XY·p_YZ.",
+    "implications": "Equality conditions sharpen inequalities into structural dichotomies: SSA is tight precisely on Markov chains. This classical characterization is the elementary template for the quantum saturation theory (approximate Markov states, Petz recovery) that governs quantum error correction and the holographic entropy program.",
+    "openQuestions": [
+      "Can an approximate/stability version be formalized: if the SSA deficit is at most ε, is the distribution O(√ε)-close to a Markov chain?",
+      "Can the quantum (von Neumann) equality case be formalized, characterizing saturation by short quantum Markov chains?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-entropy-oq-03",
+      "relationship": "extends",
+      "description": "Parent formalization of strong subadditivity (the inequality). This entry adds the sharp equality condition: SSA is tight iff X–Y–Z is a Markov chain."
+    },
+    {
+      "targetId": "shannon-entropy",
+      "relationship": "extends",
+      "description": "Builds on the Shannon entropy / KL divergence framework; the strict KL bound used here is the equality refinement of KL non-negativity proved in the parent."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Cover, Thomas M. and Thomas, Joy A.",
+      "title": "Elements of Information Theory",
+      "year": "2006",
+      "venue": "Wiley, 2nd edition",
+      "note": "Theorem 2.8.1 and the equality conditions for the data-processing / conditional mutual information inequalities"
+    },
+    {
+      "authors": "Hayden, Patrick; Jozsa, Richard; Petz, Dénes; Winter, Andreas",
+      "title": "Structure of states which satisfy strong subadditivity of quantum entropy with equality",
+      "year": "2004",
+      "venue": "Communications in Mathematical Physics 246(2):359-374",
+      "note": "Quantum equality case; the classical Markov-chain characterization formalized here is its elementary special case"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "InformationTheory",
+    "lineCount": 443,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 5,
+    "path": "Proofs/ShannonEntropySSAEq.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "ssa_deficit_eq_cmi",
+      "type": "core",
+      "description": "The SSA deficit equals the conditional mutual information I(X;Z|Y)",
+      "leanType": "shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ) - shannonEntropy' pXYZ - shannonEntropy' (marginalY_3 pXYZ) = cmiSum pXYZ"
+    },
+    {
+      "name": "ssa_cmi_eq_zero_iff",
+      "type": "core",
+      "description": "Conditional mutual information vanishes iff the Markov factorization holds",
+      "leanType": "cmiSum pXYZ = 0 ↔ ∀ x y z, pXYZ (x,y,z) * marginalY_3 pXYZ y = marginalXY pXYZ (x,y) * marginalYZ pXYZ (y,z)"
+    },
+    {
+      "name": "strong_subadditivity_eq_iff",
+      "type": "core",
+      "description": "SSA holds with equality iff X–Y–Z is a Markov chain",
+      "leanType": "(shannonEntropy' pXYZ + shannonEntropy' (marginalY_3 pXYZ) = shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ)) ↔ (∀ x y z, pXYZ (x,y,z) * marginalY_3 pXYZ y = marginalXY pXYZ (x,y) * marginalYZ pXYZ (y,z))"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/shannon-entropy-oq-03-incomplete-01.json
+++ b/src/data/research/problems/shannon-entropy-oq-03-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "shannon-entropy-oq-03-incomplete-01",
   "title": "Strong Subadditivity of Shannon Entropy",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -22,7 +22,7 @@
     "goal": "Express the deficit as I(X;Z|Y) = sum_y p(y) D(p(x,z|y) || p(x|y) * p(z|y)) and prove it nonnegative using KL divergence non-negativity."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-04-03T02:25:34-07:00",
     "iteration": 1,
     "focus": "Inspect the remaining strong-subadditivity sorry and the available entropy/KL-divergence lemmas.",
@@ -35,15 +35,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Initial observe phase. The local notes identify this as the remaining strong-subadditivity theorem for Shannon entropy, with one known sorry in the parent gallery proof.",
-    "builtItems": [],
-    "insights": [
-      "Suggested proof route: rewrite the entropy deficit as conditional mutual information and discharge nonnegativity via KL divergence."
+    "progressSummary": "COMPLETE (reframed): the premise (a remaining SSA sorry) is FALSE — SSA is fully proven (ShannonEntropy.lean:875; the cited ShannonEntropySSA.lean is BROKEN on main via dup-decl conflict). Pivoted to a genuine follow-up: the SSA EQUALITY CONDITION (Markov-chain characterization), shipped as self-contained ShannonEntropySSAEq.lean → gallery shannon-entropy-oq-03-oq-01.",
+    "builtItems": [
+      "cmiSum def + ssa_deficit_eq_cmi + ssa_cmi_eq_zero_iff + strong_subadditivity_eq_iff in Proofs/ShannonEntropySSAEq.lean (self-contained, 0 sorry/0 axiom)"
     ],
-    "mathlibGaps": [],
+    "insights": [
+      "Suggested proof route: rewrite the entropy deficit as conditional mutual information and discharge nonnegativity via KL divergence.",
+      "ShannonEntropySSA.lean does not compile on main: it imports ShannonEntropy.lean which now also declares marginalXY/marginalYZ/strong_subadditivity/entropy_chain_rule/subadditivity (same namespace) → already-declared errors. SSA is genuinely proven in ShannonEntropy.lean.",
+      "SSA deficit = conditional mutual information I(X;Z|Y) exactly (ssa_deficit_eq_cmi).",
+      "I(X;Z|Y)=0 iff the division-free Markov factorization p·p_Y = p_XY·p_YZ holds everywhere; forward via the STRICT KL bound, backward by substitution.",
+      "v4.26.0: `hp _` underscore fails to infer in single_le_sum hint lists (need explicit triples); local universe-poly `have` leaks a 4th universe param (extract top-level); conv `ext y` fails on Finset.sum."
+    ],
+    "mathlibGaps": [
+      "No SSA equality-case lemma in Mathlib; KL equality (klDivergence_eq_zero_iff) exists in ShannonEntropy.lean but is private and the file conflicts."
+    ],
     "nextSteps": [
-      "Read the parent Lean proof shannon-entropy-oq-03 and inspect the remaining sorry location.",
-      "Move from OBSERVE to ORIENT by checking the available entropy and KL-divergence lemmas."
+      "Mechanic: fix/delete broken ShannonEntropySSA.lean and repoint gallery shannon-entropy-oq-03 to ShannonEntropy.lean.",
+      "Optional: approximate/stability version of the equality condition."
     ],
     "markdown": "# Knowledge Base: shannon-entropy-oq-03-incomplete-01\n\n## Problem Understanding\n\nThe target is strong subadditivity of Shannon entropy:\n\n$$\nH(X,Y,Z) + H(Y) \\leq H(X,Y) + H(Y,Z)\n$$\n\nThe local problem note says the supporting infrastructure is already in `ShannonEntropySSA.lean`; the remaining work is the main theorem left as a `sorry`.\n\n## Known Direction\n\nUse the parent proof `shannon-entropy-oq-03` as the foundation. The stated goal is to express the deficit as conditional mutual information, `I(X;Z|Y) = sum_y p(y) D(p(x,z|y) || p(x|y) * p(z|y))`, then use KL divergence non-negativity.\n\n## Current State\n\nNo attempts have been recorded yet. The next action in `state.md` is to read the problem thoroughly and then move to ORIENT by exploring literature and related proofs.\n"
   },


### PR DESCRIPTION
## Summary

Follow-up to **shannon-entropy-oq-03** (strong subadditivity). Pins down exactly **when SSA is an equality**:

> `H(X,Y,Z) + H(Y) = H(X,Y) + H(Y,Z)` **iff** `X – Y – Z` is a Markov chain (X ⊥ Z | Y), i.e. `p(x,y,z)·p_Y(y) = p_XY(x,y)·p_YZ(y,z)` for all x,y,z.

This is the sharp boundary of the deepest classical entropy inequality — the elementary (classical) special case of the quantum SSA equality theorem (Hayden–Jozsa–Petz–Winter 2004).

## What's proved (`Proofs/ShannonEntropySSAEq.lean`, self-contained, 0 sorries / 0 axioms)

- `cmiSum` — the conditional mutual information `I(X;Z|Y)` as a relative-entropy sum.
- `ssa_deficit_eq_cmi` — the SSA deficit `H(X,Y)+H(Y,Z)−H(X,Y,Z)−H(Y)` **equals** `I(X;Z|Y)` (entropy chain-rule telescoping isolated as an exact identity).
- `ssa_cmi_eq_zero_iff` — `I(X;Z|Y)=0` ⟺ the Markov factorization. Forward via the **strict** pointwise KL bound (`p·log(p/q) > p−q` unless `p=q`); backward by substitution.
- `strong_subadditivity_eq_iff` — the headline equality characterization.

Verified via Docker (`lean4 v4.26.0`, 7743 jobs, green). 7 theorems / 5 defs / 443 lines.

## ⚠️ Integrity finding (for mechanic/auditor)

While orienting I found that **`Proofs/ShannonEntropySSA.lean` does not compile on `main`** — the file that gallery entry `shannon-entropy-oq-03` cites (`proofRepoPath`). It does `import Proofs.ShannonEntropy`, which now **also** declares `marginalXY`, `marginalYZ`, `strong_subadditivity`, `entropy_chain_rule`, `subadditivity` in the same `InformationTheory` namespace → `"has already been declared"` + a cascade parse error. A consolidation likely folded the SSA content into `ShannonEntropy.lean` without removing the standalone file. Auditors miss this because they do cheap grep checks, not a full `lake build`.

SSA itself **is** genuinely proven (in `ShannonEntropy.lean:875`). Suggested fix (separate PR): delete/repair `ShannonEntropySSA.lean` and repoint `shannon-entropy-oq-03` to `ShannonEntropy.lean`. **This PR is self-contained** (imports only Mathlib, re-defines the marginals) precisely to avoid the broken dependency.

## Files
- `proofs/Proofs/ShannonEntropySSAEq.lean` (new)
- `proofs/Proofs.lean` (register module)
- `src/data/proofs/shannon-entropy-oq-03-oq-01/{meta,annotations}.json` (new gallery entry)
- `src/data/research/problems/shannon-entropy-oq-03-incomplete-01.json` (knowledge update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)