### PR TITLE
research(erdos-729-oq-02): general-prime Legendre recurrences v_p((p·n+r)!) = n + v_p(n!) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2070,6 +2070,7 @@ import Proofs.Erdos728FactorialDivisibility
 import Proofs.Erdos728Problem
 import Proofs.Erdos729LegendreGeneral
 import Proofs.Erdos729LegendreRecurrence
+import Proofs.Erdos729LegendrePrimeRecurrence
 import Proofs.Erdos729Problem
 import Proofs.Erdos72Aristotle
 import Proofs.Erdos72Problem

--- a/proofs/Proofs/Erdos729LegendrePrimeRecurrence.lean
+++ b/proofs/Proofs/Erdos729LegendrePrimeRecurrence.lean
@@ -1,0 +1,135 @@
+/-
+  Erdős Problem #729 — OQ-02 follow-up: the GENERAL-prime Legendre recurrences.
+
+  Companion to `Erdos729Problem.lean`, `Erdos729LegendreGeneral.lean`, and the
+  `p = 2` companion `Erdos729LegendreRecurrence.lean` (PR #27257).
+
+  The `p = 2` companion proved the *2-adic* doubling recurrences
+  `v_2((2n)!) = n + v_2(n!)`, `v_2((2n+1)!) = n + v_2(n!)`, the digit-sum
+  invariants `s_2(2n) = s_2(n)`, `s_2(2n+1) = s_2(n)+1`, and the maximality
+  `v_2(n!) = n-1 ⟺ s_2(n) = 1`. This file lifts ALL of those to an arbitrary
+  prime `p`, unifying the even/odd split into a single statement.
+
+  ## Results (all 0 axioms / 0 sorries / 0 `native_decide`)
+
+  * `digitSum_prime_mul_add p n r (hr : r < p)` :
+        `s_p(p·n + r) = s_p(n) + r`           (base-`p` left-shift adds a digit `r`)
+  * `digitSum_prime_mul p n` :
+        `s_p(p·n) = s_p(n)`                    (the `r = 0` corollary)
+  * `padicValNat_factorial_prime_mul_add p n r (hr : r < p)` :
+        `v_p((p·n + r)!) = n + v_p(n!)`        (general doubling recurrence — the
+        value is INDEPENDENT of the residue `r`, so the whole block
+        `pn, pn+1, …, pn+(p-1)` shares one valuation increment `n`)
+  * `padicValNat_factorial_prime_mul p n` :
+        `v_p((p·n)!) = n + v_p(n!)`            (the `r = 0` corollary)
+  * `sub_one_mul_padicValNat_factorial_eq_pred_iff p n (hn : 1 ≤ n)` :
+        `(p-1)·v_p(n!) = n - 1 ⟺ s_p(n) = 1`  (maximality; `s_p(n) = 1` means `n`
+        is a power of `p`, the equivalence with `n = p^k` delegated as in the
+        `p = 2` companion)
+
+  ## The bridge
+
+  Everything rests on Mathlib's multiplied Legendre theorem
+  `sub_one_mul_padicValNat_factorial [Fact p.Prime] (n) :`
+  `(p - 1) * padicValNat p (n!) = n - (p.digits n).sum`
+  (`Mathlib/NumberTheory/Padics/PadicVal/Basic.lean:587`) together with the
+  base-`p` digit recursion `Nat.digits_def'` (`Data/Nat/Digits/Defs.lean:115`).
+  The doubling recurrence is then a one-line cancellation of `p - 1 > 0` after
+  observing `s_p(p·n + r) = s_p(n) + r` and `(p-1)·n + n = p·n`.
+
+  None of the five named results are Mathlib lemmas.
+
+  Bearer lemmas verified against the Mathlib pin `v4.26.0`:
+  `sub_one_mul_padicValNat_factorial`,
+  `sub_one_mul_padicValNat_factorial_lt_of_ne_zero`,
+  `Nat.digits_def'`, `Nat.digit_sum_le`, `Nat.add_mul_mod_self_left`,
+  `Nat.mul_add_div`, `Nat.sub_one_mul`, `Nat.le_mul_of_pos_left`, `List.sum_cons`.
+-/
+
+import Mathlib
+
+namespace Erdos729LegendrePrime
+
+open Nat
+
+/-- Base-`p` digit-sum left-shift law: appending the residue `r < p` as a new
+    least-significant digit adds exactly `r` to the digit sum.
+    `s_p(p·n + r) = s_p(n) + r`. -/
+theorem digitSum_prime_mul_add (p n r : ℕ) (hp : 1 < p) (hr : r < p) :
+    (Nat.digits p (p * n + r)).sum = (Nat.digits p n).sum + r := by
+  rcases Nat.eq_zero_or_pos (p * n + r) with h0 | hpos
+  · -- `p·n + r = 0` forces `n = 0` and then `r = 0`
+    have hn0 : n = 0 := by
+      rcases Nat.eq_zero_or_pos n with h | h
+      · exact h
+      · have : 0 < p * n := Nat.mul_pos (by omega) h
+        omega
+    subst hn0
+    simp only [Nat.mul_zero, Nat.zero_add] at h0
+    subst h0
+    simp
+  · rw [Nat.digits_def' hp hpos]
+    have hmod : (p * n + r) % p = r := by
+      rw [Nat.add_comm (p * n) r, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hr]
+    have hdiv : (p * n + r) / p = n := by
+      rw [Nat.mul_add_div (by omega : 0 < p), Nat.div_eq_of_lt hr, Nat.add_zero]
+    rw [hmod, hdiv, List.sum_cons]
+    omega
+
+/-- Special case `r = 0`: multiplying by `p` is a pure left-shift, so the base-`p`
+    digit sum is invariant. `s_p(p·n) = s_p(n)`. -/
+theorem digitSum_prime_mul (p n : ℕ) (hp : 1 < p) :
+    (Nat.digits p (p * n)).sum = (Nat.digits p n).sum := by
+  simpa using digitSum_prime_mul_add p n 0 hp (by omega)
+
+/-- **General-prime doubling recurrence.** For every prime `p`, residue `r < p`,
+    and `n`, the `p`-adic valuation of `(p·n + r)!` exceeds that of `n!` by
+    exactly `n` — *independent of the residue* `r`:
+        `v_p((p·n + r)!) = n + v_p(n!)`.
+    Specializing `p = 2` recovers both `v_2((2n)!) = n + v_2(n!)` (`r = 0`) and
+    `v_2((2n+1)!) = n + v_2(n!)` (`r = 1`). -/
+theorem padicValNat_factorial_prime_mul_add
+    (p n r : ℕ) [hp : Fact p.Prime] (hr : r < p) :
+    padicValNat p (p * n + r).factorial = n + padicValNat p n.factorial := by
+  have hp1 : 1 < p := hp.out.one_lt
+  have hSle : (Nat.digits p n).sum ≤ n := Nat.digit_sum_le p n
+  have hnle : n ≤ p * n := Nat.le_mul_of_pos_left n (by omega)
+  have hpm : (p - 1) * n + n = p * n := by
+    rw [Nat.sub_one_mul]; exact Nat.sub_add_cancel hnle
+  -- multiply both sides by `p - 1` and cancel the positive factor
+  have key : (p - 1) * padicValNat p (p * n + r).factorial
+      = (p - 1) * (n + padicValNat p n.factorial) := by
+    rw [sub_one_mul_padicValNat_factorial (p * n + r), Nat.mul_add,
+      sub_one_mul_padicValNat_factorial n, digitSum_prime_mul_add p n r hp1 hr]
+    omega
+  exact Nat.eq_of_mul_eq_mul_left (by omega) key
+
+/-- Special case `r = 0`: `v_p((p·n)!) = n + v_p(n!)`. -/
+theorem padicValNat_factorial_prime_mul
+    (p n : ℕ) [hp : Fact p.Prime] :
+    padicValNat p (p * n).factorial = n + padicValNat p n.factorial := by
+  simpa using padicValNat_factorial_prime_mul_add p n 0 hp.out.pos
+
+/-- **Maximality characterization.** For `n ≥ 1`, the `p`-adic valuation of `n!`
+    attains the ceiling allowed by Legendre's bound `(p-1)·v_p(n!) < n` — namely
+    `(p-1)·v_p(n!) = n - 1` — exactly when the base-`p` digit sum is `1`, i.e.
+    `n` is a power of `p`. (The equivalence `s_p(n) = 1 ⟺ n = p^k` is delegated,
+    as in the `p = 2` Kummer companion.) -/
+theorem sub_one_mul_padicValNat_factorial_eq_pred_iff
+    (p n : ℕ) [hp : Fact p.Prime] (hn : 1 ≤ n) :
+    (p - 1) * padicValNat p n.factorial = n - 1 ↔ (Nat.digits p n).sum = 1 := by
+  have hSle : (Nat.digits p n).sum ≤ n := Nat.digit_sum_le p n
+  have hSpos : 1 ≤ (Nat.digits p n).sum := by
+    have hlt := sub_one_mul_padicValNat_factorial_lt_of_ne_zero p (n := n) (by omega)
+    rw [sub_one_mul_padicValNat_factorial n] at hlt
+    omega
+  rw [sub_one_mul_padicValNat_factorial n]
+  omega
+
+/-- Sanity instance: `p = 2` doubling recurrence falls out of the general one. -/
+example (n : ℕ) :
+    padicValNat 2 (2 * n).factorial = n + padicValNat 2 n.factorial := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  exact padicValNat_factorial_prime_mul 2 n
+
+end Erdos729LegendrePrime

--- a/src/data/research/problems/erdos-729-oq-02.json
+++ b/src/data/research/problems/erdos-729-oq-02.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-05T23:54:18-07:00",
-    "iteration": 1,
-    "focus": "2-adic recurrences + maximality characterization companion shipped (verified, 0-axiom).",
+    "iteration": 2,
+    "focus": "General-prime Legendre recurrences companion shipped (verified, 0-axiom): the p=2 doubling/digit-sum/maximality results lifted to every prime p.",
     "blockers": [],
-    "nextAction": "Optional: prove s_2(n)=1 <-> n=2^k here too (currently delegated to Kummer companion), or extend doubling recurrence to general prime p (v_p((p*n)!) = ? ).",
+    "nextAction": "Optional: prove s_p(n)=1 <-> n=p^k for general p (digit-sum-one characterization), or the dual Kummer-style carry count for v_p(C(m+n, n)) at general p.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,8 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT (researcher-9, 2026-06-20): added third self-contained companion Erdos729LegendreRecurrence.lean — the DOWNSTREAM consequences of Legendre's identity for p=2 that are absent from Mathlib and the two prior companions. Proves the 2-adic doubling recurrences v_2((2n)!)=n+v_2(n!) and v_2((2n+1)!)=n+v_2(n!) (the factorial of 2n collects exactly n extra factors of 2), the digit-sum invariants s_2(2n)=s_2(n) / s_2(2n+1)=s_2(n)+1, and the maximality characterization v_2(n!)=n-1 <-> s_2(n)=1 (n a power of two) — n-1 being the ceiling since v_2(n!)<n for n>=1. 5 theorems, 0 axioms, 0 sorries, 0 native_decide; #print axioms = {propext, Classical.choice, Quot.sound} only. Registered Proofs.lean. Built GREEN (docker, 7743 jobs). The equivalence s_2(n)=1 <-> n=2^k is left to the Kummer companion KummerTheoremOQ04OQ01.lean (not reproved here).\n\nPRIOR: ACT (researcher-2, 2026-06-15, build-pending, dual blackout): added self-contained companion Erdos729LegendreGeneral.lean proving the general textbook Legendre identity v_p(n!)=(n-s_p(n))/(p-1) axiom-free for EVERY prime p (sibling PR #24474 discharges only the p=2 case before deleting the general axiom). Division form bridges Mathlib sub_one_mul_padicValNat_factorial by cancelling p-1; states both Mathlib (p.digits n).sum form and recursive digitSum form. 0 axioms/0 sorries; math certified over 7500 (p,n) pairs. UNREGISTERED (blackout); does not touch the contested registered file (#24474/#24481). The 3 remaining axioms (erdos_1968_classical, barreto_leeham_theorem/bound) are deep published research, out of scope.",
+    "progressSummary": "ACT (researcher-9, 2026-06-20): added fourth self-contained companion Erdos729LegendrePrimeRecurrence.lean lifting the p=2 recurrence companion to ARBITRARY prime p. Proves the general doubling recurrence v_p((p*n + r)!) = n + v_p(n!) for every residue 0<=r<p (the valuation increment n is INDEPENDENT of r, unifying the even/odd p=2 split into one statement), the base-p digit-shift law s_p(p*n + r) = s_p(n) + r (and its r=0 invariant s_p(p*n)=s_p(n)), and the general maximality characterization (p-1)*v_p(n!) = n-1 <-> s_p(n)=1 (n a power of p; the equivalence s_p(n)=1 <-> n=p^k delegated as in the p=2 Kummer companion). 5 theorems, 0 axioms, 0 sorries, 0 native_decide; #print axioms = {propext, Classical.choice, Quot.sound} only. Built GREEN (docker). Registered in Proofs.lean. Engine: Mathlib sub_one_mul_padicValNat_factorial ((p-1)*v_p(n!)=n-s_p(n)) + base-p digit recursion Nat.digits_def', cancelling the positive factor p-1 after s_p(p*n+r)=s_p(n)+r and (p-1)*n+n=p*n. None of the five results are named Mathlib lemmas.\n\nACT (researcher-9, 2026-06-20): added third self-contained companion Erdos729LegendreRecurrence.lean — the DOWNSTREAM consequences of Legendre's identity for p=2 that are absent from Mathlib and the two prior companions. Proves the 2-adic doubling recurrences v_2((2n)!)=n+v_2(n!) and v_2((2n+1)!)=n+v_2(n!) (the factorial of 2n collects exactly n extra factors of 2), the digit-sum invariants s_2(2n)=s_2(n) / s_2(2n+1)=s_2(n)+1, and the maximality characterization v_2(n!)=n-1 <-> s_2(n)=1 (n a power of two) — n-1 being the ceiling since v_2(n!)<n for n>=1. 5 theorems, 0 axioms, 0 sorries, 0 native_decide; #print axioms = {propext, Classical.choice, Quot.sound} only. Registered Proofs.lean. Built GREEN (docker, 7743 jobs). The equivalence s_2(n)=1 <-> n=2^k is left to the Kummer companion KummerTheoremOQ04OQ01.lean (not reproved here).\n\nPRIOR: ACT (researcher-2, 2026-06-15, build-pending, dual blackout): added self-contained companion Erdos729LegendreGeneral.lean proving the general textbook Legendre identity v_p(n!)=(n-s_p(n))/(p-1) axiom-free for EVERY prime p (sibling PR #24474 discharges only the p=2 case before deleting the general axiom). Division form bridges Mathlib sub_one_mul_padicValNat_factorial by cancelling p-1; states both Mathlib (p.digits n).sum form and recursive digitSum form. 0 axioms/0 sorries; math certified over 7500 (p,n) pairs. UNREGISTERED (blackout); does not touch the contested registered file (#24474/#24481). The 3 remaining axioms (erdos_1968_classical, barreto_leeham_theorem/bound) are deep published research, out of scope.",
     "builtItems": [
+      "digitSum_prime_mul_add (p n r)(hp:1<p)(hr:r<p): (Nat.digits p (p*n+r)).sum = (Nat.digits p n).sum + r -- general base-p digit left-shift, Erdos729LegendrePrimeRecurrence.lean",
+      "digitSum_prime_mul (p n)(hp:1<p): s_p(p*n)=s_p(n) -- r=0 invariant",
+      "padicValNat_factorial_prime_mul_add (p n r)[Fact p.Prime](hr:r<p): padicValNat p (p*n+r)! = n + padicValNat p n! -- GENERAL doubling recurrence, value independent of residue r",
+      "padicValNat_factorial_prime_mul (p n)[Fact p.Prime]: padicValNat p (p*n)! = n + padicValNat p n! -- r=0 corollary",
+      "sub_one_mul_padicValNat_factorial_eq_pred_iff (p n)[Fact p.Prime](hn:1<=n): (p-1)*padicValNat p n! = n-1 <-> s_p(n)=1 -- general maximality (n a power of p)",
       "padicValNat_factorial_eq_div (p n)(hp:p.Prime): padicValNat p n.factorial = (n-(p.digits n).sum)/(p-1) -- Erdos729LegendreGeneral.lean",
       "legendre_digit_sum_identity (p n)(hp:p.Prime): same in recursive digitSum form (exact deleted-axiom statement, all primes)",
       "verify_legendre_general.py: 7500 (p,n) pairs (p<50,n<500) certify the identity + (p-1)|(n-s_p(n)) divisibility, 0 mismatches",
@@ -40,6 +45,7 @@
       "v2_factorial_eq_pred_iff (n)(hn:1<=n): padicValNat 2 n.factorial = n-1 <-> (Nat.digits 2 n).sum = 1 -- maximality (n a power of two)"
     ],
     "insights": [
+      "The 2-adic doubling recurrence v_2((2n)!)=n+v_2(n!) is the p=2 shadow of a general-prime law: for EVERY prime p and residue 0<=r<p, v_p((p*n+r)!) = n + v_p(n!), the increment n being INDEPENDENT of r. So all p consecutive arguments pn, pn+1, ..., pn+(p-1) share one valuation step. Proof: (p-1)*v_p(m!)=m-s_p(m) (Mathlib) plus s_p(p*n+r)=s_p(n)+r and (p-1)*n+n=p*n, then cancel p-1>0. Not a named Mathlib lemma.",
       "General textbook Legendre identity v_p(n!)=(n-s_p(n))/(p-1) proved axiom-free for ALL primes p in new companion Erdos729LegendreGeneral.lean (sibling PR #24474 covers only p=2). Division form derived from Mathlib sub_one_mul_padicValNat_factorial via Nat.mul_div_cancel_left; not a named Mathlib lemma.",
       "v_2((2n)!) = n + v_2(n!): the 2-adic valuation of the factorial doubles-with-offset because multiplying by 2 left-shifts the binary expansion (s_2 invariant) — i.e. 2n! gains exactly n factors of two over n!. Equivalent to Legendre + s_2(2n)=s_2(n). v_2(n!) hits its ceiling n-1 exactly when s_2(n)=1 (n a power of two). None of these are named Mathlib lemmas."
     ],
@@ -90,6 +96,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos729LegendreRecurrence.lean"
+    },
+    {
+      "path": "Proofs/Erdos729LegendrePrimeRecurrence.lean",
+      "filename": "Erdos729LegendrePrimeRecurrence.lean",
+      "lineCount": 135,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos729LegendrePrimeRecurrence.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fourth self-contained companion to **Erdős #729 / OQ-02** (Legendre's formula for the $p$-adic valuation of factorials). The existing companion `Erdos729LegendreRecurrence.lean` (#27257) proved the *2-adic* doubling recurrences, digit-sum invariants, and maximality. This PR **lifts all of them to an arbitrary prime $p$**, and unifies the even/odd $p=2$ split into a single residue-independent statement.

New file `proofs/Proofs/Erdos729LegendrePrimeRecurrence.lean` (5 theorems, 0 axioms, 0 sorries, 0 `native_decide`):

| Theorem | Statement |
|---|---|
| `digitSum_prime_mul_add` | $s_p(p\cdot n + r) = s_p(n) + r$ for $r < p$ (base-$p$ left-shift) |
| `digitSum_prime_mul` | $s_p(p\cdot n) = s_p(n)$ (the $r=0$ invariant) |
| `padicValNat_factorial_prime_mul_add` | $v_p((p\cdot n + r)!) = n + v_p(n!)$ for all $0 \le r < p$ |
| `padicValNat_factorial_prime_mul` | $v_p((p\cdot n)!) = n + v_p(n!)$ (the $r=0$ corollary) |
| `sub_one_mul_padicValNat_factorial_eq_pred_iff` | $(p-1)\,v_p(n!) = n-1 \iff s_p(n) = 1$ (maximality; $n$ a power of $p$) |

The valuation increment $n$ in the doubling recurrence is **independent of the residue $r$**, so the whole block $pn, pn+1, \dots, pn+(p-1)$ shares one valuation step. Specializing $p=2$ recovers both $v_2((2n)!)=n+v_2(n!)$ ($r=0$) and $v_2((2n+1)!)=n+v_2(n!)$ ($r=1$) from the prior companion (checked by an `example`).

## Engine

All results rest on Mathlib's multiplied Legendre theorem `sub_one_mul_padicValNat_factorial` ($(p-1)\,v_p(n!) = n - s_p(n)$) together with the base-$p$ digit recursion `Nat.digits_def'`. The doubling recurrence is a one-line cancellation of $p-1>0$ after observing $s_p(p\cdot n + r) = s_p(n) + r$ and $(p-1)\cdot n + n = p\cdot n$. None of the five results are named Mathlib lemmas.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos729LegendrePrimeRecurrence` — **GREEN** (7743 jobs).
- `#print axioms` reduces to `{propext, Classical.choice, Quot.sound}` only.
- Identities cross-checked numerically for $p \in \{2,3,5,7,11,13\}$ over $n < 200$.

🤖 Generated with [Claude Code](https://claude.com/claude-code)