### PR TITLE
audit: mark 3 never-audited entries clean (#27261, #27263)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17409,8 +17409,26 @@
       "issues": [],
       "lastAudited": "2026-06-21T05:08:17Z",
       "result": "clean"
+    },
+    "lucas-lehmer-test-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-20T00:00:00Z",
+      "result": "clean"
+    },
+    "nakayama-lemma-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-20T00:00:00Z",
+      "result": "clean"
+    },
+    "shannon-entropy-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-20T00:00:00Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T05:08:17Z"
+  "lastUpdated": "2026-06-20T00:00:00Z"
 }


### PR DESCRIPTION
Deep-audited the 3 never-audited gallery entries returned by `find-targets --next`; all **CLEAN**:

| slug | decls | integrity |
|------|-------|-----------|
| `lucas-lehmer-test-oq-01-oq-01` | 11 thm / 5 def | 0-sorry, 0-axiom, no native_decide |
| `nakayama-lemma-oq-01-oq-01` | 5 thm / 1 def | 0-sorry, 0-axiom, no native_decide |
| `shannon-entropy-oq-03-oq-01` | 3 thm / 5 def | 0-sorry, 0-axiom, no native_decide, self-contained |

All three are `verified`/`original`, claims match Lean source. `shannon-entropy-oq-03-oq-01` uses `ShannonEntropySSAEq.lean` which is self-contained (imports only Mathlib, re-derives entropy/marginal defs) — it does **not** depend on the separate `ShannonEntropySSA.lean` file.

All three were absent from the tracker `entries` map (the new-proof never-audited loop). This PR persists their clean marks so `find-targets` drains the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)