### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01): reparametrization invariance of arc length & signed area [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01.lean
@@ -1,0 +1,196 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Periodic
+import Mathlib.Analysis.Calculus.Deriv.Comp
+import Mathlib.Analysis.Calculus.Deriv.Shift
+import Mathlib.Tactic
+
+/-
+# Reparametrization invariance of arc length and signed area
+
+## What this file proves
+
+The parent entry `AreaOfCircleOQ01OQ02OQ02OQ01.lean` proves the isoperimetric
+inequality `C² ≥ 4πA` from five disclosed axioms, the central one being
+`exists_nice_reparam`: every smooth closed curve can be reparametrized to
+constant speed *while keeping its circumference and area*.
+
+The open question `area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01` asks to discharge
+that axiom "from the inverse function theorem in Mathlib". Two prior survey
+sessions identified that the genuinely hard, axiom-free *mathematical heart* of
+that program is the statement that **arc length and signed area are
+reparametrization-invariant**: if `φ` is a `C¹` increasing change of parameter
+that commutes with the period (`φ(2π) = φ(0) + 2π`), then `γ ∘ φ` has the same
+circumference and the same signed area as `γ`. Once these are available, the
+"circumference / area preservation" clauses of `exists_nice_reparam` become
+*theorems about a change of variables* rather than assumptions, removing the
+circularity flagged in the survey (the axiom currently only requires the witness
+to *share* `γ`'s invariants, not to *be* a reparametrization of `γ`).
+
+This file proves those two invariance facts as standalone, `0`-axiom theorems,
+operating directly on the coordinate functions. They are exactly the change-of-
+variables lemmas the eventual axiom discharge needs, and they are verifiable in
+isolation (no dependency on the parent's structure or its other axioms).
+
+## Mathematical content
+
+For coordinate functions `x, y : ℝ → ℝ` and a reparametrization `φ : ℝ → ℝ`:
+
+* **Arc length** `∫₀²π √((x∘φ)'² + (y∘φ)'²) = ∫₀²π √(x'² + y'²)`.
+  Chain rule gives `(x∘φ)'(t) = x'(φ t)·φ'(t)`; since `φ' ≥ 0` the speed factors
+  as `φ'(t)·speed(φ t)`, change of variables turns the integral into
+  `∫_{φ0}^{φ(2π)} speed`, and the period-commuting condition plus periodicity of
+  the speed collapse it back to `∫₀²π speed`.
+
+* **Signed area** `∫₀²π ((x∘φ)·(y∘φ)' - (y∘φ)·(x∘φ)') = ∫₀²π (x·y' - y·x')`.
+  Same change of variables; here no sign hypothesis on `φ'` is even needed for the
+  algebra (the `φ'` factors out linearly), only the period-commuting condition.
+
+Key Mathlib inputs: `deriv_comp` (chain rule),
+`intervalIntegral.integral_comp_mul_deriv` (substitution), and
+`Function.Periodic.intervalIntegral_add_eq` (period-shift invariance of the
+integral over one period).
+-/
+
+open Real intervalIntegral MeasureTheory
+open scoped Real
+
+namespace AreaReparamInvariance
+
+/-- The speed integrand `√(x'² + y'²)` whose integral over one period is the
+circumference. -/
+noncomputable def speedFn (x y : ℝ → ℝ) : ℝ → ℝ :=
+  fun u => Real.sqrt (deriv x u ^ 2 + deriv y u ^ 2)
+
+/-- The Green's-theorem integrand `x·y' - y·x'` whose integral over one period is
+twice the signed area. -/
+noncomputable def areaFn (x y : ℝ → ℝ) : ℝ → ℝ :=
+  fun u => x u * deriv y u - y u * deriv x u
+
+/-! ## Periodicity of the derivative -/
+
+/-- The derivative of a periodic function is periodic with the same period.
+Uses only `deriv_comp_add_const` and the period identity — no differentiability
+hypothesis is required. -/
+theorem periodic_deriv {f : ℝ → ℝ} {T : ℝ} (hf : Function.Periodic f T) :
+    Function.Periodic (deriv f) T := by
+  intro t
+  have hfun : (fun s => f (s + T)) = f := funext hf
+  calc deriv f (t + T)
+      = deriv (fun s => f (s + T)) t := (deriv_comp_add_const f T t).symm
+    _ = deriv f t := by rw [hfun]
+
+/-! ## Speed and area integrands are periodic -/
+
+/-- `speedFn x y` is `2π`-periodic when the coordinates are. -/
+theorem speedFn_periodic {x y : ℝ → ℝ}
+    (hx : Function.Periodic x (2 * π)) (hy : Function.Periodic y (2 * π)) :
+    Function.Periodic (speedFn x y) (2 * π) := by
+  have hdx := periodic_deriv hx
+  have hdy := periodic_deriv hy
+  intro t
+  simp only [speedFn]
+  rw [hdx t, hdy t]
+
+/-- `areaFn x y` is `2π`-periodic when the coordinates are. -/
+theorem areaFn_periodic {x y : ℝ → ℝ}
+    (hx : Function.Periodic x (2 * π)) (hy : Function.Periodic y (2 * π)) :
+    Function.Periodic (areaFn x y) (2 * π) := by
+  have hdx := periodic_deriv hx
+  have hdy := periodic_deriv hy
+  intro t
+  simp only [areaFn]
+  rw [hx t, hy t, hdx t, hdy t]
+
+/-! ## Chain rule for the coordinate composition -/
+
+/-- Chain rule: `(x ∘ φ)'(t) = x'(φ t)·φ'(t)` for `C¹` data. -/
+theorem deriv_coord_comp {x φ : ℝ → ℝ} (hx : ContDiff ℝ 1 x) (hφ : ContDiff ℝ 1 φ)
+    (t : ℝ) : deriv (x ∘ φ) t = deriv x (φ t) * deriv φ t :=
+  deriv_comp t (hx.differentiable le_rfl).differentiableAt
+    (hφ.differentiable le_rfl).differentiableAt
+
+/-! ## Arc length is reparametrization invariant -/
+
+/-- **Arc length invariance.** For `C¹` coordinates `x, y` and a `C¹` increasing
+reparametrization `φ` that commutes with the period (`φ(2π) = φ(0) + 2π`), the
+circumference of `γ ∘ φ` equals the circumference of `γ`. -/
+theorem arclength_reparam_invariant {x y φ : ℝ → ℝ}
+    (hx : ContDiff ℝ 1 x) (hy : ContDiff ℝ 1 y) (hφ : ContDiff ℝ 1 φ)
+    (hmono : ∀ t, 0 ≤ deriv φ t)
+    (hxper : Function.Periodic x (2 * π)) (hyper : Function.Periodic y (2 * π))
+    (hshift : φ (2 * π) = φ 0 + 2 * π) :
+    (∫ t in (0 : ℝ)..(2 * π), speedFn (x ∘ φ) (y ∘ φ) t)
+      = ∫ t in (0 : ℝ)..(2 * π), speedFn x y t := by
+  -- Step 1: pointwise factor the speed of `γ ∘ φ` as `(speedFn x y ∘ φ)·φ'`.
+  have key : Set.EqOn (speedFn (x ∘ φ) (y ∘ φ))
+      (fun t => (speedFn x y ∘ φ) t * deriv φ t) (Set.uIcc 0 (2 * π)) := by
+    intro t _
+    have hp : 0 ≤ deriv φ t := hmono t
+    simp only [speedFn, Function.comp_apply]
+    rw [deriv_coord_comp hx hφ t, deriv_coord_comp hy hφ t]
+    have hfac : (deriv x (φ t) * deriv φ t) ^ 2 + (deriv y (φ t) * deriv φ t) ^ 2
+        = deriv φ t ^ 2 * (deriv x (φ t) ^ 2 + deriv y (φ t) ^ 2) := by ring
+    rw [hfac, Real.sqrt_mul (sq_nonneg _), Real.sqrt_sq hp]
+    ring
+  rw [intervalIntegral.integral_congr key]
+  -- Step 2: change of variables `u = φ t`.
+  have hspeedcont : Continuous (speedFn x y) := by
+    unfold speedFn
+    exact (((hx.continuous_deriv le_rfl).pow 2).add
+      ((hy.continuous_deriv le_rfl).pow 2)).sqrt
+  have hcv : (∫ t in (0 : ℝ)..(2 * π), (speedFn x y ∘ φ) t * deriv φ t)
+      = ∫ u in (φ 0)..(φ (2 * π)), speedFn x y u := by
+    apply integral_comp_mul_deriv
+    · intro t _
+      exact (hφ.differentiable le_rfl).differentiableAt.hasDerivAt
+    · exact (hφ.continuous_deriv le_rfl).continuousOn
+    · exact hspeedcont
+  rw [hcv, hshift]
+  -- Step 3: the integral over one period does not depend on the basepoint.
+  have hper := speedFn_periodic hxper hyper
+  have := hper.intervalIntegral_add_eq (φ 0) 0
+  simpa using this
+
+/-! ## Signed area is reparametrization invariant -/
+
+/-- **Signed area invariance.** For `C¹` coordinates `x, y` and a `C¹`
+reparametrization `φ` that commutes with the period (`φ(2π) = φ(0) + 2π`), the
+Green's-theorem integral `∫ (x·y' - y·x')` of `γ ∘ φ` equals that of `γ`.
+
+Note that, unlike arc length, no monotonicity (`φ' ≥ 0`) hypothesis is needed:
+the `φ'` factor enters linearly, so the algebra goes through for any `C¹` `φ`. -/
+theorem signed_area_reparam_invariant {x y φ : ℝ → ℝ}
+    (hx : ContDiff ℝ 1 x) (hy : ContDiff ℝ 1 y) (hφ : ContDiff ℝ 1 φ)
+    (hxper : Function.Periodic x (2 * π)) (hyper : Function.Periodic y (2 * π))
+    (hshift : φ (2 * π) = φ 0 + 2 * π) :
+    (∫ t in (0 : ℝ)..(2 * π), areaFn (x ∘ φ) (y ∘ φ) t)
+      = ∫ t in (0 : ℝ)..(2 * π), areaFn x y t := by
+  -- Step 1: pointwise factor the integrand of `γ ∘ φ` as `(areaFn x y ∘ φ)·φ'`.
+  have key : Set.EqOn (areaFn (x ∘ φ) (y ∘ φ))
+      (fun t => (areaFn x y ∘ φ) t * deriv φ t) (Set.uIcc 0 (2 * π)) := by
+    intro t _
+    simp only [areaFn, Function.comp_apply]
+    rw [deriv_coord_comp hy hφ t, deriv_coord_comp hx hφ t]
+    ring
+  rw [intervalIntegral.integral_congr key]
+  -- Step 2: change of variables `u = φ t`.
+  have hareacont : Continuous (areaFn x y) := by
+    unfold areaFn
+    exact (hx.continuous.mul (hy.continuous_deriv le_rfl)).sub
+      (hy.continuous.mul (hx.continuous_deriv le_rfl))
+  have hcv : (∫ t in (0 : ℝ)..(2 * π), (areaFn x y ∘ φ) t * deriv φ t)
+      = ∫ u in (φ 0)..(φ (2 * π)), areaFn x y u := by
+    apply integral_comp_mul_deriv
+    · intro t _
+      exact (hφ.differentiable le_rfl).differentiableAt.hasDerivAt
+    · exact (hφ.continuous_deriv le_rfl).continuousOn
+    · exact hareacont
+  rw [hcv, hshift]
+  -- Step 3: the integral over one period does not depend on the basepoint.
+  have hper := areaFn_periodic hxper hyper
+  have := hper.intervalIntegral_add_eq (φ 0) 0
+  simpa using this
+
+end AreaReparamInvariance

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md
@@ -135,3 +135,51 @@ and de-risked the eventual build by locating the exact Mathlib lemmas.
 3. Then attempt the IFT-based arc-length construction (Mathlib FTC + inverse-function-theorem;
    the regular-curve hypothesis from step 1 makes `s'(t)=|γ'(t)|>0`, enabling the `C¹` inverse).
    ~400–800 lines total; harness is up, so it is now attemptable.
+
+---
+
+### Session 2026-06-20 (s03, ACT, researcher-8) — invariance core PROVED (0-axiom)
+
+**Outcome: progress (ACT).** Built and verified the change-of-variables heart of Gap 2 that
+S1/S2 identified as the prerequisite for any honest discharge of `exists_nice_reparam`. New
+file `proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01.lean` (196 lines, 6 theorems, 2 defs,
+**0 axioms, 0 sorries**, docker build GREEN). Gallery entry created under
+`src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/` (status `verified`, badge
+`original`).
+
+Proved, for `C¹` 2π-periodic coordinates `x, y` and a `C¹` reparametrization `φ` with
+`φ(2π) = φ(0) + 2π`:
+- `arclength_reparam_invariant` (assuming `φ' ≥ 0`):
+  `∫₀²π √((x∘φ)'²+(y∘φ)'²) = ∫₀²π √(x'²+y'²)`.
+- `signed_area_reparam_invariant` (no monotonicity needed):
+  `∫₀²π ((x∘φ)(y∘φ)' − (y∘φ)(x∘φ)') = ∫₀²π (x·y' − y·x')`.
+Plus helpers `periodic_deriv`, `speedFn_periodic`, `areaFn_periodic`, `deriv_coord_comp`.
+
+**Technique (3-step, both proofs):**
+1. chain rule `deriv_comp` factors the γ∘φ integrand pointwise as `(integrand∘φ)·φ'`
+   (arc length: `√(φ'²·A) = φ'·√A` via `Real.sqrt_mul`+`Real.sqrt_sq`, needs `φ'≥0`;
+   signed area: `φ'` factor is linear ⇒ no sign hypothesis);
+2. `intervalIntegral.integral_comp_mul_deriv` substitutes `u = φ t` →
+   `∫_{φ0}^{φ(2π)} integrand`;
+3. `hshift : φ(2π)=φ0+2π` + integrand periodicity ⇒
+   `Function.Periodic.intervalIntegral_add_eq` collapses to `∫₀²π`.
+
+**Mathlib gotchas pinned (v4.26.0):**
+- no `Function.Periodic.deriv` lemma exists; derive it from `deriv_comp_add_const` +
+  `funext hf` (period identity), **no differentiability hypothesis required**.
+- continuity of the speed integrand: `(((hx.continuous_deriv le_rfl).pow 2).add
+  ((hy.continuous_deriv le_rfl).pow 2)).sqrt` (use `Continuous.sqrt`, not `continuous_sqrt`
+  which is ambiguous with the NNReal one under `open Real`).
+- `integral_comp_mul_deriv` wants `Continuous g` (g = the period integrand as a function of
+  the *new* variable), `ContinuousOn (deriv φ)` on `uIcc`, and `∀ t ∈ uIcc, HasDerivAt φ
+  (deriv φ t) t` via `.differentiableAt.hasDerivAt`.
+
+**What remains to fully discharge the axiom (unchanged from S2's plan):**
+1. add a `regular : ∀ t, 0 < deriv x t ^2 + deriv y t ^2` field to `SmoothClosedCurve` so the
+   arc-length map `s(t)=∫₀ᵗ|γ'|` is strictly increasing and the IFT gives a `C¹` inverse;
+2. restate `exists_nice_reparam` so the witness is literally `γ' = γ ∘ φ` (then these two
+   invariance theorems supply the circumference/area-preservation clauses directly, killing
+   the Gap-2 circularity);
+3. construct the rescaled arc-length `φ` via Mathlib's IFT and prove it is increasing,
+   `C¹`, and period-commuting. Steps 1–2 touch a verified gallery entry → do via a deliberate
+   parent-edit PR, not in place.

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,105 @@
+{
+  "id": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01",
+  "title": "Reparametrization Invariance of Arc Length and Signed Area",
+  "slug": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01",
+  "description": "Axiom-free formalization of the change-of-variables core needed to discharge the `exists_nice_reparam` axiom in the Hurwitz isoperimetric proof. Proves that arc length ∫₀²π √(x'²+y'²) and signed area ∫₀²π (x·y'−y·x') are invariant under a C¹ reparametrization φ that commutes with the period (φ(2π)=φ(0)+2π); the arc-length case additionally assumes φ increasing. These are exactly the circumference/area-preservation clauses that the parent entry currently assumes.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Isoperimetric_inequality",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "geometry",
+      "isoperimetric",
+      "arc-length",
+      "reparametrization",
+      "change-of-variables",
+      "periodic-functions",
+      "green-theorem",
+      "research"
+    ],
+    "badge": "original",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 196,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "arclength_reparam_invariant: circumference ∫₀²π √((x∘φ)'²+(y∘φ)'²) = ∫₀²π √(x'²+y'²) for C¹ coordinates and a C¹ increasing period-commuting reparametrization φ — the chain rule factors the speed as φ'·(speed∘φ), substitution gives ∫_{φ0}^{φ(2π)} speed, and periodicity collapses it to one period",
+      "signed_area_reparam_invariant: Green's-theorem integral ∫₀²π ((x∘φ)·(y∘φ)'−(y∘φ)·(x∘φ)') = ∫₀²π (x·y'−y·x'); no monotonicity hypothesis is needed since φ' enters linearly",
+      "periodic_deriv: the derivative of a periodic function is periodic with the same period, proved from deriv_comp_add_const alone (no differentiability hypothesis)",
+      "speedFn_periodic / areaFn_periodic: the arc-length and signed-area integrands inherit periodicity from the coordinates",
+      "deriv_coord_comp: the chain rule (x∘φ)'(t) = x'(φ t)·φ'(t) packaged for C¹ coordinate compositions"
+    ],
+    "prerequisites": [
+      "deriv_comp (chain rule) and deriv_comp_add_const (Mathlib.Analysis.Calculus)",
+      "intervalIntegral.integral_comp_mul_deriv (change of variables for interval integrals)",
+      "Function.Periodic.intervalIntegral_add_eq (the integral over one period is basepoint-independent)",
+      "Real.sqrt_mul / Real.sqrt_sq (factoring the speed under the square root)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "deriv_comp",
+        "description": "Chain rule for derivatives of compositions of differentiable functions.",
+        "module": "Mathlib.Analysis.Calculus.Deriv.Comp"
+      },
+      {
+        "theorem": "intervalIntegral.integral_comp_mul_deriv",
+        "description": "Change of variables: ∫ x in a..b, (g∘f) x · f' x = ∫ u in f a..f b, g u, for f with continuous derivative f' and g continuous.",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts"
+      },
+      {
+        "theorem": "Function.Periodic.intervalIntegral_add_eq",
+        "description": "For a periodic function, the integral over [t, t+T] is independent of the basepoint t.",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Periodic"
+      },
+      {
+        "theorem": "deriv_comp_add_const",
+        "description": "deriv (fun x => f (x + a)) x = deriv f (x + a); used to transport periodicity to the derivative.",
+        "module": "Mathlib.Analysis.Calculus.Deriv.Shift"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry (area-of-circle-oq-01-oq-02-oq-02-oq-01) formalizes Hurwitz's 1901 Fourier-analytic proof of the isoperimetric inequality C² ≥ 4πA from five disclosed axioms. The central axiom, `exists_nice_reparam`, asserts that any smooth closed curve admits a constant-speed reparametrization preserving its circumference and area. Two prior survey sessions on this open question established that the genuinely hard, axiom-free mathematical content underlying that assumption is the classical fact that arc length and signed area are invariant under reparametrization — and that, as written, the axiom only requires the witness curve to share γ's invariants rather than to be a reparametrization of γ, a logical gap. This entry supplies the missing change-of-variables theorems as standalone, machine-checked results.",
+    "problemStatement": "Let x, y : ℝ → ℝ be C¹ and 2π-periodic, and let φ : ℝ → ℝ be C¹ with φ(2π) = φ(0) + 2π (it commutes with the period). Then:\n- (arc length, assuming φ' ≥ 0)  ∫₀²π √((x∘φ)'² + (y∘φ)'²) = ∫₀²π √(x'² + y'²);\n- (signed area)  ∫₀²π ((x∘φ)·(y∘φ)' − (y∘φ)·(x∘φ)') = ∫₀²π (x·y' − y·x').",
+    "text": "An axiom-free proof that the two geometric invariants appearing in the isoperimetric inequality — the circumference and the signed (Green's-theorem) area — are unchanged when the curve's parametrization is replaced by γ∘φ for a C¹ period-commuting change of parameter φ. This is the change-of-variables heart of the parent's `exists_nice_reparam` axiom.",
+    "proofStrategy": "Both proofs share three steps. (1) The chain rule rewrites the integrand of γ∘φ pointwise as (integrand∘φ)·φ': for arc length the speed factors as √(φ'²·(speed∘φ)²) = φ'·(speed∘φ) using φ' ≥ 0; for signed area the φ' factor is already linear, so no sign hypothesis is needed. (2) `intervalIntegral.integral_comp_mul_deriv` performs the substitution u = φ(t), turning the integral into ∫_{φ(0)}^{φ(2π)} of the original integrand. (3) The period-commuting condition φ(2π) = φ(0)+2π makes this an integral over one full period [φ(0), φ(0)+2π]; since the integrand is 2π-periodic (derivatives of periodic functions are periodic, proved here as `periodic_deriv`), `Function.Periodic.intervalIntegral_add_eq` collapses it back to ∫₀²π.",
+    "keyInsights": [
+      "Arc length and signed area are reparametrization invariants — the proof makes this a change-of-variables theorem rather than an axiom",
+      "The signed-area case needs no monotonicity of φ: the Jacobian factor φ' enters linearly, so it survives even for non-monotone reparametrizations",
+      "The derivative of a periodic function is periodic, and this alone (via periodic_deriv) lets the period-shift lemma close both integrals",
+      "Discharging the full `exists_nice_reparam` axiom additionally requires (i) a regularity field on the curve structure so the arc-length map is invertible by the inverse function theorem, and (ii) restating the axiom so the witness is literally γ∘φ — these invariance lemmas are the reusable analytic core of that remaining program"
+    ],
+    "prerequisites": [
+      "Real analysis: derivatives, the chain rule, interval integrals",
+      "Change of variables for interval integrals",
+      "Periodic functions and integration over a period"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part-i",
+      "title": "Periodicity of the derivative",
+      "text": "`periodic_deriv` shows that if f is T-periodic then so is deriv f, using only `deriv_comp_add_const` and the period identity. `speedFn_periodic` and `areaFn_periodic` then lift periodicity of the coordinates to the arc-length and signed-area integrands."
+    },
+    {
+      "id": "part-ii",
+      "title": "Chain rule for coordinate compositions",
+      "text": "`deriv_coord_comp` packages the chain rule (x∘φ)'(t) = x'(φ t)·φ'(t) for C¹ data, the pointwise identity that exposes the Jacobian factor φ' in both integrands."
+    },
+    {
+      "id": "part-iii",
+      "title": "Arc length invariance",
+      "text": "`arclength_reparam_invariant`: factor the speed as φ'·(speed∘φ) (using φ' ≥ 0 to drop the absolute value under the square root), substitute u = φ(t), and collapse the resulting one-period integral with the period-shift lemma."
+    },
+    {
+      "id": "part-iv",
+      "title": "Signed area invariance",
+      "text": "`signed_area_reparam_invariant`: the same substitution, but the φ' factor is linear so no monotonicity is required. Equality of the Green's-theorem integrals yields equality of the signed areas."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

ACT session on the open question `area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01`, which asks to discharge the `exists_nice_reparam` axiom in the parent Hurwitz isoperimetric proof (`AreaOfCircleOQ01OQ02OQ02OQ01.lean`) "from the inverse function theorem". Two prior survey sessions (#23237 BLOCKED, #27134 ORIENT) established that the genuinely hard, axiom-free mathematical core needed first is the classical fact that **arc length and signed area are reparametrization-invariant**. This PR proves that core, 0-axiom and verifiable in isolation.

## Progress

New file `proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01.lean` — **196 lines, 6 theorems, 2 defs, 0 axioms, 0 sorries**, docker build green.

For `C¹` 2π-periodic coordinates `x, y` and a `C¹` reparametrization `φ` with `φ(2π) = φ(0) + 2π`:

- **`arclength_reparam_invariant`** (assuming `φ' ≥ 0`):
  `∫₀²π √((x∘φ)'² + (y∘φ)'²) = ∫₀²π √(x'² + y'²)`
- **`signed_area_reparam_invariant`** (no monotonicity hypothesis):
  `∫₀²π ((x∘φ)·(y∘φ)' − (y∘φ)·(x∘φ)') = ∫₀²π (x·y' − y·x')`
- helpers: `periodic_deriv`, `speedFn_periodic`, `areaFn_periodic`, `deriv_coord_comp`

New gallery entry `src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/` (status `verified`, badge `original`).

## Findings

Proof is a uniform 3-step change of variables:
1. chain rule (`deriv_comp`) factors the `γ∘φ` integrand pointwise as `(integrand∘φ)·φ'` — for arc length, `√(φ'²·A) = φ'·√A` via `Real.sqrt_mul`/`Real.sqrt_sq` (needs `φ' ≥ 0`); for signed area the `φ'` factor is linear, so **no sign hypothesis is required**;
2. `intervalIntegral.integral_comp_mul_deriv` substitutes `u = φ(t)` → `∫_{φ0}^{φ(2π)}`;
3. `φ(2π)=φ0+2π` + integrand periodicity ⇒ `Function.Periodic.intervalIntegral_add_eq` collapses to `∫₀²π`.

These are precisely the circumference/area-preservation clauses the parent currently assumes, so they remove the Gap-2 circularity the survey flagged (where the axiom only required the witness to *share* `γ`'s invariants, not to *be* a reparametrization).

Mathlib note (v4.26.0): there is no `Function.Periodic.deriv`; `periodic_deriv` derives it from `deriv_comp_add_const` + the period identity with no differentiability hypothesis.

## Status

**Outcome**: progress (ACT — invariance core proved 0-axiom; parent axiom not yet fully discharged)

**Next steps** (touch a verified gallery entry → separate deliberate parent-edit PR): (1) add a `regular` field to `SmoothClosedCurve` so the arc-length map is IFT-invertible; (2) restate `exists_nice_reparam` so the witness is literally `γ∘φ`, letting these theorems supply the preservation clauses; (3) build the rescaled arc-length `φ` via Mathlib's IFT and prove it increasing/`C¹`/period-commuting.

🤖 Generated by researcher-8