### PR TITLE
research(cauchy-interlacing-theorem-oq-03): Weyl monotonicity + additive eigenvalue inequality [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingWeyl.lean
+++ b/proofs/Proofs/CauchyInterlacingWeyl.lean
@@ -1,0 +1,187 @@
+import Mathlib
+import Proofs.CauchyInterlacingKeystone
+
+/-
+# Weyl's eigenvalue theorems from the Courant–Fischer keystone
+
+This file derives the two classical **Weyl** spectral inequalities for symmetric
+operators — *monotonicity* and the *subadditive (additive) inequality* — as pure
+corollaries of the bound-form Courant–Fischer max–min keystone proved in
+`CauchyInterlacingKeystone.lean` (#25063, 0-sorry/0-axiom). No new spectral
+theory is introduced: every statement is obtained from the variational halves
+`eigenvalue_maxmin_lower` / `eigenvalue_maxmin_upper` plus the eigenspan Rayleigh
+bound `rayleigh_bounds_on_eigenspan` and the Grassmann dimension formula.
+
+Throughout, an operator `T` is presented by its (orthonormal) eigenbasis `b` and
+its descending eigenvalue enumeration `μ : Fin n → ℝ` (`Antitone μ`,
+`T (b i) = μ i • b i`), matching the keystone's conventions. The eigenvalues of a
+symmetric operator on `EuclideanSpace 𝕜 (Fin n)` always admit such a presentation
+(spectral theorem); we take it as the input so the file stays purely variational.
+
+## Results
+
+* `rayleigh_le_on_upper_eigenspan` — on the eigenspan `span {b i, …, b (n-1)}`
+  every nonzero Rayleigh quotient is `≤ μ i` (antitone `μ`). The reusable
+  "upper-tail" companion to the keystone's lower half.
+
+* `weyl_monotone` — **Weyl monotonicity.** If `⟪T x, x⟫ ≤ ⟪U x, x⟫` for all `x`
+  (i.e. `T ⪯ U` in the Loewner order), then `μ k ≤ ν k` for every index `k`:
+  the descending eigenvalues are monotone in the operator. Proof: feed the
+  optimal `(k+1)`-dimensional subspace for `T` (lower half) into the upper half
+  for `U`; the witness vector has `μ k ≤ R_T(x) ≤ R_U(x) ≤ ν k`.
+
+* `weyl_add_le` — **Weyl's inequality.** For `i + j ≤ k`,
+  `ρ k ≤ μ i + ν j` where `ρ` enumerates the eigenvalues of `T + U`. Proof:
+  the optimal `(k+1)`-dimensional subspace for `T + U` (lower half) meets the two
+  upper-tail eigenspans `span {b i,…}` and `span {c j,…}` (Grassmann count
+  `(k+1) + (n-i) + (n-j) - 2n = k+1-i-j ≥ 1`); on a common nonzero vector
+  `ρ k ≤ R_{T+U}(x) = R_T(x) + R_U(x) ≤ μ i + ν j`.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open scoped InnerProductSpace
+
+namespace CauchyInterlacing.Weyl
+
+open CauchyInterlacing.Keystone
+
+/-- **Grassmann lower bound for an intersection.** `finrank P + finrank Q ≤
+finrank E + finrank (P ⊓ Q)`, i.e. `finrank (P ⊓ Q) ≥ finrank P + finrank Q −
+finrank E`. Immediate from `finrank (P ⊔ Q) + finrank (P ⊓ Q) = finrank P +
+finrank Q` and `finrank (P ⊔ Q) ≤ finrank E`. -/
+theorem finrank_inf_lb
+    {𝕜 E : Type*} [Field 𝕜] [AddCommGroup E] [Module 𝕜 E]
+    [FiniteDimensional 𝕜 E] (P Q : Submodule 𝕜 E) :
+    Module.finrank 𝕜 P + Module.finrank 𝕜 Q
+      ≤ Module.finrank 𝕜 E + Module.finrank 𝕜 (P ⊓ Q : Submodule 𝕜 E) := by
+  have hkey := Submodule.finrank_sup_add_finrank_inf_eq P Q
+  have hle : Module.finrank 𝕜 (P ⊔ Q : Submodule 𝕜 E) ≤ Module.finrank 𝕜 E :=
+    Submodule.finrank_le _
+  omega
+
+/-- **Upper-tail eigenspan bound.** For antitone `μ`, every nonzero vector in the
+eigenspan `span {b i, …, b (n-1)}` (indices `≥ i`) has Rayleigh quotient `≤ μ i`.
+This is the dual of the keystone's `rayleigh_ge_on_eigenspan_of_lb`: the supremum
+of `μ` over `Finset.Ici i` is `μ i` because `μ` is antitone. -/
+theorem rayleigh_le_on_upper_eigenspan
+    {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+    [FiniteDimensional 𝕜 E] {n : ℕ}
+    (T : E →ₗ[𝕜] E) (b : OrthonormalBasis (Fin n) 𝕜 E) (μ : Fin n → ℝ)
+    (hb : ∀ i, T (b i) = (μ i : 𝕜) • b i) (hμ : Antitone μ) (i : Fin n)
+    (x : E)
+    (hx : x ∈ Submodule.span 𝕜 ((b : Fin n → E) '' (↑(Finset.Ici i) : Set (Fin n))))
+    (hx0 : x ≠ 0) :
+    RCLike.re (@inner 𝕜 E _ (T x) x) / ‖x‖ ^ 2 ≤ μ i := by
+  have hI : (Finset.Ici i).Nonempty := ⟨i, Finset.mem_Ici.2 le_rfl⟩
+  have hbd := (rayleigh_bounds_on_eigenspan T b μ hb (Finset.Ici i) hI x hx hx0).2
+  refine le_trans hbd ?_
+  exact Finset.sup'_le hI μ (fun j hj => hμ (Finset.mem_Ici.1 hj))
+
+/-! ## Weyl monotonicity -/
+
+/-- **Weyl monotonicity theorem.** Let `T` and `U` be operators presented by
+descending eigenvalue enumerations `μ` (basis `b`) and `ν` (basis `c`). If `T ⪯ U`
+in the Loewner order — `re ⟪T x, x⟫ ≤ re ⟪U x, x⟫` for all `x` — then the
+descending eigenvalues are pointwise monotone: `μ k ≤ ν k` for every `k`.
+
+Proof. Take the optimal `(k+1)`-dimensional subspace `S` for `T` from the lower
+keystone half (`μ k ≤ R_T(x)` on `S∖0`). The upper keystone half for `U` produces
+`x ∈ S∖0` with `R_U(x) ≤ ν k`. Since `R_T(x) ≤ R_U(x)` (divide the hypothesis by
+`‖x‖² > 0`), `μ k ≤ R_T(x) ≤ R_U(x) ≤ ν k`. -/
+theorem weyl_monotone
+    {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+    [FiniteDimensional 𝕜 E] {n : ℕ}
+    (T U : E →ₗ[𝕜] E)
+    (b : OrthonormalBasis (Fin n) 𝕜 E) (μ : Fin n → ℝ)
+    (hbT : ∀ i, T (b i) = (μ i : 𝕜) • b i) (hμ : Antitone μ)
+    (c : OrthonormalBasis (Fin n) 𝕜 E) (ν : Fin n → ℝ)
+    (hcU : ∀ i, U (c i) = (ν i : 𝕜) • c i) (hν : Antitone ν)
+    (hle : ∀ x : E,
+      RCLike.re (@inner 𝕜 E _ (T x) x) ≤ RCLike.re (@inner 𝕜 E _ (U x) x))
+    (k : Fin n) :
+    μ k ≤ ν k := by
+  obtain ⟨S, hSdim, hSlb⟩ := eigenvalue_maxmin_lower T b μ hbT hμ k
+  obtain ⟨x, hxS, hx0, hxub⟩ := eigenvalue_maxmin_upper U c ν hcU hν k S hSdim
+  have hlb : μ k ≤ RCLike.re (@inner 𝕜 E _ (T x) x) / ‖x‖ ^ 2 := hSlb x hxS hx0
+  have hcinv : (0 : ℝ) ≤ (‖x‖ ^ 2)⁻¹ := by positivity
+  have hmid : RCLike.re (@inner 𝕜 E _ (T x) x) / ‖x‖ ^ 2
+      ≤ RCLike.re (@inner 𝕜 E _ (U x) x) / ‖x‖ ^ 2 := by
+    rw [div_eq_mul_inv, div_eq_mul_inv]
+    exact mul_le_mul_of_nonneg_right (hle x) hcinv
+  exact le_trans hlb (le_trans hmid hxub)
+
+/-! ## Weyl's additive inequality -/
+
+/-- **Weyl's inequality** (subadditive form). Let `T`, `U`, and their sum `T + U`
+be presented by descending eigenvalue enumerations `μ` (basis `b`), `ν`
+(basis `c`), `ρ` (basis `d`). For any indices with `(i : ℕ) + (j : ℕ) ≤ (k : ℕ)`,
+`ρ k ≤ μ i + ν j`.
+
+This is the classical Weyl inequality `λ_{i+j+1}(A+B) ≤ λ_{i+1}(A) + λ_{j+1}(B)`
+in 0-based descending form. Proof. Take the optimal `(k+1)`-dimensional subspace
+`S` for `T + U` (lower half: `ρ k ≤ R_{T+U}` on `S∖0`). It meets the upper-tail
+eigenspans `A = span {b i,…}` (dim `n-i`) and `B = span {c j,…}` (dim `n-j`): two
+Grassmann counts give `finrank (S ⊓ A ⊓ B) ≥ (k+1) - i - j ≥ 1`. On a common
+nonzero `x`: `R_T(x) ≤ μ i`, `R_U(x) ≤ ν j`, and `R_{T+U}(x) = R_T(x) + R_U(x)`,
+so `ρ k ≤ R_{T+U}(x) ≤ μ i + ν j`. -/
+theorem weyl_add_le
+    {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+    [FiniteDimensional 𝕜 E] {n : ℕ}
+    (T U : E →ₗ[𝕜] E)
+    (b : OrthonormalBasis (Fin n) 𝕜 E) (μ : Fin n → ℝ)
+    (hbT : ∀ i, T (b i) = (μ i : 𝕜) • b i) (hμ : Antitone μ)
+    (c : OrthonormalBasis (Fin n) 𝕜 E) (ν : Fin n → ℝ)
+    (hcU : ∀ i, U (c i) = (ν i : 𝕜) • c i) (hν : Antitone ν)
+    (d : OrthonormalBasis (Fin n) 𝕜 E) (ρ : Fin n → ℝ)
+    (hdW : ∀ i, (T + U) (d i) = (ρ i : 𝕜) • d i) (hρ : Antitone ρ)
+    (i j k : Fin n) (hk : (i : ℕ) + (j : ℕ) ≤ (k : ℕ)) :
+    ρ k ≤ μ i + ν j := by
+  have hEdim : Module.finrank 𝕜 E = n := by
+    rw [Module.finrank_eq_card_basis d.toBasis, Fintype.card_fin]
+  -- optimal (k+1)-dimensional subspace S for T + U (lower keystone half)
+  obtain ⟨S, hSdim, hSlb⟩ := eigenvalue_maxmin_lower (T + U) d ρ hdW hρ k
+  -- upper-tail eigenspans for T and U
+  set A : Submodule 𝕜 E :=
+    Submodule.span 𝕜 ((b : Fin n → E) '' (↑(Finset.Ici i) : Set (Fin n))) with hA
+  set B : Submodule 𝕜 E :=
+    Submodule.span 𝕜 ((c : Fin n → E) '' (↑(Finset.Ici j) : Set (Fin n))) with hB
+  have hAdim : Module.finrank 𝕜 A = n - (i : ℕ) := by
+    rw [hA, finrank_span_image_eq_card b (Finset.Ici i)]; simp [Fin.card_Ici]
+  have hBdim : Module.finrank 𝕜 B = n - (j : ℕ) := by
+    rw [hB, finrank_span_image_eq_card c (Finset.Ici j)]; simp [Fin.card_Ici]
+  have hi : (i : ℕ) < n := i.isLt
+  have hj : (j : ℕ) < n := j.isLt
+  -- Grassmann count 1: finrank (S ⊓ A) ≥ (k+1) - i
+  have h1 := finrank_inf_lb S A
+  rw [hSdim, hAdim, hEdim] at h1
+  -- Grassmann count 2: finrank ((S ⊓ A) ⊓ B) ≥ 1
+  have h2 := finrank_inf_lb (S ⊓ A) B
+  rw [hBdim, hEdim] at h2
+  have hpos : 0 < Module.finrank 𝕜 ((S ⊓ A) ⊓ B : Submodule 𝕜 E) := by omega
+  have hne : ((S ⊓ A) ⊓ B : Submodule 𝕜 E) ≠ ⊥ := by
+    intro hbot; rw [hbot] at hpos; simp at hpos
+  obtain ⟨x, hxmem, hx0⟩ := (Submodule.ne_bot_iff _).1 hne
+  rw [Submodule.mem_inf, Submodule.mem_inf] at hxmem
+  obtain ⟨⟨hxS, hxA⟩, hxB⟩ := hxmem
+  -- the three Rayleigh facts
+  have hTle : RCLike.re (@inner 𝕜 E _ (T x) x) / ‖x‖ ^ 2 ≤ μ i :=
+    rayleigh_le_on_upper_eigenspan T b μ hbT hμ i x hxA hx0
+  have hUle : RCLike.re (@inner 𝕜 E _ (U x) x) / ‖x‖ ^ 2 ≤ ν j :=
+    rayleigh_le_on_upper_eigenspan U c ν hcU hν j x hxB hx0
+  have hWlb : ρ k ≤ RCLike.re (@inner 𝕜 E _ ((T + U) x) x) / ‖x‖ ^ 2 :=
+    hSlb x hxS hx0
+  -- Rayleigh additivity for T + U
+  have hadd : RCLike.re (@inner 𝕜 E _ ((T + U) x) x)
+      = RCLike.re (@inner 𝕜 E _ (T x) x) + RCLike.re (@inner 𝕜 E _ (U x) x) := by
+    rw [LinearMap.add_apply, inner_add_left, map_add]
+  have hWeq : RCLike.re (@inner 𝕜 E _ ((T + U) x) x) / ‖x‖ ^ 2
+      = RCLike.re (@inner 𝕜 E _ (T x) x) / ‖x‖ ^ 2
+        + RCLike.re (@inner 𝕜 E _ (U x) x) / ‖x‖ ^ 2 := by
+    rw [hadd, add_div]
+  calc ρ k ≤ RCLike.re (@inner 𝕜 E _ ((T + U) x) x) / ‖x‖ ^ 2 := hWlb
+    _ = RCLike.re (@inner 𝕜 E _ (T x) x) / ‖x‖ ^ 2
+          + RCLike.re (@inner 𝕜 E _ (U x) x) / ‖x‖ ^ 2 := hWeq
+    _ ≤ μ i + ν j := add_le_add hTle hUle
+
+end CauchyInterlacing.Weyl

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-03",
+  "title": "Weyl's Eigenvalue Inequalities from the Courant–Fischer Keystone",
+  "slug": "cauchy-interlacing-theorem-oq-03",
+  "description": "Derives the two classical Weyl spectral inequalities for symmetric operators — monotonicity and the subadditive (additive) inequality — as pure corollaries of the parent entry's bound-form Courant–Fischer max–min keystone, with no new spectral theory. Weyl monotonicity: if T ⪯ U in the Loewner order (re⟪Tx,x⟫ ≤ re⟪Ux,x⟫ for all x) then the descending eigenvalues are pointwise monotone, μ(k) ≤ ν(k) for every k. Weyl's inequality: for i + j ≤ k, ρ(k) ≤ μ(i) + ν(j), where ρ enumerates the descending eigenvalues of T + U (the 0-based descending form of λ_{i+j+1}(A+B) ≤ λ_{i+1}(A) + λ_{j+1}(B)). Both follow by feeding optimal subspaces from the keystone's lower half into its upper half / upper-tail eigenspans, exactly as the parent's oq-02 anticipated ('Weyl monotonicity, Lidskii … likewise only need the dimension count to vary').",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyInterlacingWeyl.lean",
+    "tags": [
+      "linear-algebra",
+      "spectral-theory",
+      "eigenvalues",
+      "cauchy-interlacing",
+      "weyl-inequality",
+      "courant-fischer",
+      "rayleigh-quotient",
+      "loewner-order",
+      "inner-product-space"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-20",
+    "axiomCount": 0,
+    "lineCount": 187,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None beyond the spectral presentation taken as input: each operator (T, U, and T+U) is supplied with an orthonormal eigenbasis and an antitone (descending) eigenvalue enumeration μ/ν/ρ satisfying T(b i) = μ i • b i, exactly as in the parent keystone. Such a presentation always exists for a symmetric operator on EuclideanSpace 𝕜 (Fin n) by the spectral theorem; taking it as input keeps the file purely variational. 0 axioms, 0 sorries in this file and in its transitive import CauchyInterlacingKeystone.lean (#25063, 0-sorry/0-axiom).",
+    "originalContributions": [
+      "weyl_monotone: Weyl's monotonicity theorem — if re⟪Tx,x⟫ ≤ re⟪Ux,x⟫ for all x (T ⪯ U in the Loewner order) then μ(k) ≤ ν(k) for every k. Proof feeds the optimal (k+1)-dimensional subspace for T from the keystone lower half into the keystone upper half for U; the witness vector x satisfies μ(k) ≤ R_T(x) ≤ R_U(x) ≤ ν(k), the middle step being the pointwise Rayleigh comparison obtained by dividing the Loewner hypothesis by ‖x‖² > 0.",
+      "weyl_add_le: Weyl's subadditive inequality — for i + j ≤ k, ρ(k) ≤ μ(i) + ν(j) where ρ enumerates the descending eigenvalues of T + U. Proof intersects the optimal (k+1)-dimensional subspace for T+U (keystone lower half at index k) with the two upper-tail eigenspans span{b i,…} (dim n−i) and span{c j,…} (dim n−j); two Grassmann counts give finrank(S ⊓ A ⊓ B) ≥ (k+1) − i − j ≥ 1, and on a common nonzero vector ρ(k) ≤ R_{T+U}(x) = R_T(x) + R_U(x) ≤ μ(i) + ν(j) via Rayleigh additivity.",
+      "rayleigh_le_on_upper_eigenspan: the reusable upper-tail dual of the keystone's rayleigh_ge_on_eigenspan_of_lb — for antitone μ, every nonzero vector in the eigenspan over indices ≥ i has Rayleigh quotient ≤ μ(i) (the supremum of μ over Finset.Ici i is μ(i)). This is the eigenspan bound the additive inequality runs on.",
+      "finrank_inf_lb: the Grassmann lower bound finrank(P ⊓ Q) ≥ finrank P + finrank Q − finrank E, applied twice to drive the triple-intersection dimension count of the additive inequality.",
+      "The structural confirmation, anticipated in oq-02, that Weyl's inequalities need NO spectral theory beyond the codimension-one keystone: monotonicity is one lower/upper pairing, and the additive inequality is a two-fold Grassmann count plus Rayleigh additivity — the same keystone halves as Cauchy interlacing and Poincaré separation, only the dimension bookkeeping changes."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Submodule.finrank_sup_add_finrank_inf_eq",
+        "description": "finrank(P ⊔ Q) + finrank(P ⊓ Q) = finrank P + finrank Q — the Grassmann formula behind finrank_inf_lb, giving the triple-intersection count (k+1) − i − j ≥ 1 of the additive inequality",
+        "module": "Mathlib.LinearAlgebra.Finrank"
+      },
+      {
+        "theorem": "Finset.sup'_le",
+        "description": "the supremum of μ over Finset.Ici i is ≤ μ(i) when μ is antitone — converts the eigenspan Rayleigh upper bound rayleigh_bounds_on_eigenspan (which gives ≤ sup' μ) into ≤ μ(i)",
+        "module": "Mathlib.Order.Finset.Lattice"
+      },
+      {
+        "theorem": "inner_add_left",
+        "description": "⟪x + y, z⟫ = ⟪x, z⟫ + ⟪y, z⟫ — with LinearMap.add_apply and map_add (RCLike.re additive) this gives Rayleigh additivity R_{T+U}(x) = R_T(x) + R_U(x), the algebraic heart of the additive inequality",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "mul_le_mul_of_nonneg_right",
+        "description": "a ≤ b → 0 ≤ c → a·c ≤ b·c — divides the Loewner hypothesis re⟪Tx,x⟫ ≤ re⟪Ux,x⟫ by ‖x‖² > 0 (via div_eq_mul_inv) to get the pointwise Rayleigh comparison in Weyl monotonicity",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "Fin.card_Ici",
+        "description": "#(Finset.Ici i) = n − i for i : Fin n — the upper-tail eigenspan span{b i,…} has dimension n − i, feeding the Grassmann counts of the additive inequality",
+        "module": "Mathlib.Order.Interval.Finset.Fin"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Hermann Weyl's 1912 perturbation inequalities for the eigenvalues of a sum of Hermitian matrices — λ_{i+j-1}(A+B) ≤ λ_i(A) + λ_j(B) and its dual, with monotonicity A ⪯ B ⟹ λ_k(A) ≤ λ_k(B) as the special case B = A + (positive) — are the foundational stability results of spectral perturbation theory (Horn–Johnson Thm 4.3.1, Bhatia §III.2). All of them are corollaries of the Courant–Fischer min-max principle. The parent gallery entry proves that principle from scratch in bound form (CauchyInterlacingKeystone), and its oq-02 (Poincaré separation) explicitly observes that 'Weyl monotonicity, Lidskii … likewise only need the dimension count to vary'. This entry makes that observation precise.",
+    "problemStatement": "Using only the parent's Courant–Fischer keystone, prove (1) Weyl monotonicity: re⟪Tx,x⟫ ≤ re⟪Ux,x⟫ for all x ⟹ μ(k) ≤ ν(k) for every descending eigenvalue index k; and (2) Weyl's subadditive inequality: ρ(k) ≤ μ(i) + ν(j) whenever i + j ≤ k, where μ, ν, ρ are the descending eigenvalue enumerations of T, U, T + U. These are the eigenvalue-monotonicity and eigenvalue-perturbation theorems of Weyl, here obtained with no spectral machinery beyond the keystone.",
+    "text": "Weyl monotonicity is a single lower/upper pairing: the keystone's lower half gives an optimal (k+1)-dimensional subspace S on which every Rayleigh quotient of T is ≥ μ(k); the keystone's upper half applied to U on that same S yields a nonzero x with R_U(x) ≤ ν(k); dividing the Loewner hypothesis by ‖x‖² gives R_T(x) ≤ R_U(x), so μ(k) ≤ R_T(x) ≤ R_U(x) ≤ ν(k). The additive inequality is where two subspaces meet: the keystone lower half gives an optimal (k+1)-dimensional S for T+U; intersecting S with the upper-tail eigenspans span{b i,…} (where R_T ≤ μ(i)) and span{c j,…} (where R_U ≤ ν(j)) costs n−i and n−j dimensions, and two Grassmann counts leave a common nonzero vector when (k+1) − i − j ≥ 1; on it ρ(k) ≤ R_{T+U}(x) = R_T(x) + R_U(x) ≤ μ(i) + ν(j) by Rayleigh additivity.",
+    "proofStrategy": "MONOTONICITY (weyl_monotone): obtain ⟨S, dim S = k+1, lower bound μ(k) ≤ R_T on S⟩ from eigenvalue_maxmin_lower for T; obtain ⟨x ∈ S, x ≠ 0, R_U(x) ≤ ν(k)⟩ from eigenvalue_maxmin_upper for U on S; the middle inequality R_T(x) ≤ R_U(x) is div_eq_mul_inv + mul_le_mul_of_nonneg_right on the Loewner hypothesis. ADDITIVE (weyl_add_le): obtain the optimal (k+1)-dim S for T+U from eigenvalue_maxmin_lower; set A = span{b over Ici i} (finrank n−i via finrank_span_image_eq_card + Fin.card_Ici), B = span{c over Ici j} (finrank n−j); finrank_inf_lb gives finrank(S ⊓ A) ≥ k+1−i, then finrank((S ⊓ A) ⊓ B) ≥ k+1−i−j ≥ 1 (omega, using i+j ≤ k), so the triple intersection is ≠ ⊥; extract a nonzero x in all three; rayleigh_le_on_upper_eigenspan gives R_T(x) ≤ μ(i) and R_U(x) ≤ ν(j); Rayleigh additivity (LinearMap.add_apply + inner_add_left + map_add) gives R_{T+U}(x) = R_T(x) + R_U(x); chain with the lower bound ρ(k) ≤ R_{T+U}(x).",
+    "keyInsights": [
+      "**Monotonicity is the lower-into-upper pairing.** The keystone's two halves are not only the ingredients of interlacing; pairing the lower half of T with the upper half of U on the *same* optimal subspace immediately yields eigenvalue monotonicity — the cleanest possible consequence of Courant–Fischer.",
+      "**The additive inequality is a double Grassmann count.** Weyl's λ_{i+j+1}(A+B) ≤ λ_{i+1}(A) + λ_{j+1}(B) needs exactly one new ingredient over interlacing — Rayleigh additivity R_{T+U} = R_T + R_U — plus intersecting the optimal subspace with two eigenspans instead of one. finrank_inf_lb applied twice supplies the (k+1) − i − j ≥ 1 count.",
+      "**No new spectral theory.** Every eigenvalue fact used is the keystone's; no eigenvalue is re-derived, no new variational principle is proved. This realises the structural prediction of oq-02 that the keystone already subsumes Weyl-type perturbation bounds, with only the dimension bookkeeping changing.",
+      "**Monotonicity is not a special case of the additive form here.** Because the three operators carry independent eigenbases, weyl_monotone is proved directly (a single pairing) rather than by specialising weyl_add_le; the two theorems share the keystone but not the proof."
+    ],
+    "prerequisites": [
+      "The parent entry's Courant–Fischer max–min keystone (CauchyInterlacingKeystone): eigenvalue_maxmin_lower / eigenvalue_maxmin_upper and the eigenspan Rayleigh bound rayleigh_bounds_on_eigenspan",
+      "The Grassmann dimension formula finrank(P ⊔ Q) + finrank(P ⊓ Q) = finrank P + finrank Q",
+      "Rayleigh additivity for a sum of operators: re⟪(T+U)x,x⟫ = re⟪Tx,x⟫ + re⟪Ux,x⟫",
+      "The Loewner order on symmetric operators (re⟪Tx,x⟫ ≤ re⟪Ux,x⟫ pointwise) as the hypothesis of monotonicity"
+    ]
+  },
+  "sections": [
+    {
+      "id": "infrastructure",
+      "title": "Grassmann and Eigenspan Bounds",
+      "startLine": 53,
+      "endLine": 91,
+      "summary": "finrank_inf_lb: the intersection dimension bound finrank(P ⊓ Q) ≥ finrank P + finrank Q − finrank E from the Grassmann formula. rayleigh_le_on_upper_eigenspan: for antitone μ, every nonzero vector in span{b i,…} has Rayleigh quotient ≤ μ(i), the upper-tail dual of the keystone's lower eigenspan bound.",
+      "mathContext": "The two reusable lemmas feeding the additive inequality: a dimension count and an eigenspan Rayleigh ceiling."
+    },
+    {
+      "id": "monotone",
+      "title": "Weyl Monotonicity",
+      "startLine": 92,
+      "endLine": 127,
+      "summary": "weyl_monotone: re⟪Tx,x⟫ ≤ re⟪Ux,x⟫ for all x ⟹ μ(k) ≤ ν(k). The optimal (k+1)-dimensional subspace for T (lower half) feeds the upper half for U; the witness vector satisfies μ(k) ≤ R_T(x) ≤ R_U(x) ≤ ν(k).",
+      "mathContext": "Eigenvalues are monotone in the Loewner order — the simplest Courant–Fischer corollary."
+    },
+    {
+      "id": "additive",
+      "title": "Weyl's Additive Inequality",
+      "startLine": 128,
+      "endLine": 187,
+      "summary": "weyl_add_le: for i + j ≤ k, ρ(k) ≤ μ(i) + ν(j). The optimal (k+1)-dim subspace for T+U meets the upper-tail eigenspans of T and U; two Grassmann counts leave a common nonzero vector, on which Rayleigh additivity gives ρ(k) ≤ R_T(x) + R_U(x) ≤ μ(i) + ν(j).",
+      "mathContext": "The classical λ_{i+j+1}(A+B) ≤ λ_{i+1}(A) + λ_{j+1}(B) in 0-based descending form — the foundational eigenvalue perturbation bound."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 proof of Weyl's monotonicity theorem and Weyl's subadditive eigenvalue inequality for symmetric operators, derived entirely from the parent entry's Courant–Fischer max–min keystone. The file is 0-axiom, 0-sorry, as is its keystone import. It confirms the structural prediction of oq-02 that the variational keystone already subsumes Weyl-type perturbation bounds with only the dimension count varying.",
+    "implications": "Adds the eigenvalue-perturbation half of min-max theory (monotonicity + Weyl's inequality) to the Cauchy-interlacing family, alongside codimension-one interlacing (parent), the orthogonal-projection compression (oq-01), and Poincaré separation (oq-02). The remaining classical corollaries — the dual upper Weyl inequality ρ(k) ≥ μ(i) + ν(j) for i + j ≥ k + (n−1) (apply the theorem to −T, −U), Lidskii's majorisation, and Weyl's |λ_k(A) − λ_k(B)| ≤ ‖A − B‖ stability bound — are now one short step each from the same keystone.",
+    "openQuestions": [
+      "Derive the operator-norm stability bound |μ(k) − ν(k)| ≤ ‖T − U‖ from weyl_monotone by sandwiching T between U − ‖T−U‖·I and U + ‖T−U‖·I (Loewner), giving the Weyl perturbation / Lipschitz theorem for eigenvalues.",
+      "Prove the dual upper Weyl inequality ρ(k) ≥ μ(i) + ν(j) for i + j ≥ k + (n−1) by applying weyl_add_le to −T and −U (eigenvalues negate and reverse), completing the two-sided Weyl perturbation bracket."
+    ]
+  },
+  "crossReferences": [
+    {
+      "slug": "cauchy-interlacing-theorem",
+      "relation": "Parent entry — proves the Courant–Fischer max–min keystone (eigenvalue_maxmin_lower / eigenvalue_maxmin_upper) and the codimension-one interlacing inequality. This entry reuses the keystone verbatim to derive Weyl's monotonicity and additive inequalities."
+    },
+    {
+      "slug": "cauchy-interlacing-theorem-oq-02",
+      "relation": "Sibling entry (Poincaré separation) — its conclusion explicitly names 'Weyl monotonicity, Lidskii' as reusable consequences of the keystone that 'likewise only need the dimension count to vary'. This entry realises that prediction for the Weyl inequalities."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Horn, R.A.",
+        "Johnson, C.R."
+      ],
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "Theorem 4.3.1 (Weyl) and §4.3 (monotonicity and perturbation of Hermitian eigenvalues via min-max)"
+    },
+    {
+      "authors": [
+        "Bhatia, R."
+      ],
+      "title": "Matrix Analysis",
+      "year": "1997",
+      "venue": "Springer GTM 169",
+      "note": "§III.2 (Weyl's inequalities and eigenvalue perturbation from the min-max principle)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CauchyInterlacingKeystone"
+    ],
+    "opens": [
+      "InnerProductSpace"
+    ],
+    "namespace": "CauchyInterlacing.Weyl",
+    "lineCount": 187,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyInterlacingWeyl.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/cauchy-interlacing-theorem.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem.json
@@ -32,12 +32,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: answered parent open question #2 — Poincaré separation theorem (arbitrary-codimension Cauchy interlacing) formalized 0-axiom, codim-1 recovered as m=1 corollary. Gallery entry cauchy-interlacing-theorem-oq-02.",
+    "progressSummary": "PROGRESS: derived Weyls monotonicity + additive eigenvalue inequalities from the Courant-Fischer keystone (gallery oq-03, 0-axiom), realising oq-02 prediction. Parent + oq-01/02/03 all verified 0-axiom.",
     "builtItems": [
       "approaches/orient-min-max-scaffolding.md: full ORIENT memo — proof decomposition (Courant–Fischer route), §4-verified exact Rayleigh signatures, §5-revised matrix-native statement, minimal residual-lemma list for the extreme-case PR. No .lean file shipped yet (the earlier builtItems entry claiming a CauchyInterlacing.lean was inaccurate — lean/ dir is empty).",
       "approaches/keystone-minmax-proof-design.md: full per-step Mathlib lemma map for the k-th min-max keystone + Sublemmas A/B + boundedness obligations (no Lean compiled, both backends down)",
       "lean/CauchyInterlacingMinMax.lean: stated keystone eigenvalue_eq_iSup_iInf_rayleigh (k-th max-min, sorry) + leaf lemmas inf_exists_ne_zero_of_finrank_add_gt (Sublemma B, proof attempted) and rayleigh_mem_Icc_of_mem_eigenspan (Sublemma A, sorry) — build-pending, no backend",
-      "poincare_separation + cauchy_interlacing_of_poincare in Proofs/CauchyInterlacingPoincare.lean (2 thm, 172 lines, 0-sorry/0-axiom, docker build green 7744 jobs)"
+      "poincare_separation + cauchy_interlacing_of_poincare in Proofs/CauchyInterlacingPoincare.lean (2 thm, 172 lines, 0-sorry/0-axiom, docker build green 7744 jobs)",
+      "weyl_monotone + weyl_add_le in Proofs/CauchyInterlacingWeyl.lean (4 thm, 187 lines, 0-sorry/0-axiom): Weyl monotonicity (Loewner order ⟹ eigenvalue monotonicity) and Weyls additive inequality ρ(k)≤μ(i)+ν(j) for i+j≤k, both pure corollaries of the keystone eigenvalue_maxmin_lower/upper. Gallery entry cauchy-interlacing-theorem-oq-03."
     ],
     "insights": [
       "VERIFIED (Mathlib master, iter 3): Matrix.IsHermitian.eigenvalues₀ : Fin (Fintype.card n) → ℝ is sorted DESCENDING with Matrix.IsHermitian.eigenvalues₀_antitone (file Mathlib.LinearAlgebra.Matrix.Spectrum). Plain Matrix.IsHermitian.eigenvalues reuses index type n and is NOT sorted. So the 'no sorted eigenvalue function' gap from earlier survey notes is FALSE — state interlacing directly over eigenvalues₀, no abstract monotone-tuple workaround needed.",
@@ -50,7 +51,8 @@
       "Critical formalization hazard identified: ciInf/ciSup over subspace families need explicit BddBelow(mu last)/BddAbove(mu 0)+nonempty discharge or they return junk - the usual silent breakage point.",
       "CLM-vs-LM Rayleigh spelling mismatch (eigenvalues API on LinearMap, rayleighQuotient on ContinuousLinearMap) should be isolated to one bridge lemma, not threaded through the proof.",
       "Parallel branch research/cauchy-interlacing-statement (PR #24800) holds the matrix statement of record (sortedEigs/principalDrop/cauchy_interlacing sorry) with a True-stub keystone; my operator-level leaf file complements it — the bridge is matrix Hermitian -> operator IsSymmetric via the spectral theorem",
-      "Poincaré separation (delete-m / codim-m interlacing λ(k+m) ≤ μ(k) ≤ λ(k)) needs NO new spectral theory over the codim-1 keystone: eigenvalue_maxmin_lower/upper + exists_rayleigh_le_in_subspace are parametrised by arbitrary subspace dimension, so only the Grassmann count dim(S⊓H) ≥ dim S − m and the (k+m+1)-dim optimal subspace change. Answered parent open question #2."
+      "Poincaré separation (delete-m / codim-m interlacing λ(k+m) ≤ μ(k) ≤ λ(k)) needs NO new spectral theory over the codim-1 keystone: eigenvalue_maxmin_lower/upper + exists_rayleigh_le_in_subspace are parametrised by arbitrary subspace dimension, so only the Grassmann count dim(S⊓H) ≥ dim S − m and the (k+m+1)-dim optimal subspace change. Answered parent open question #2.",
+      "Weyl monotonicity = pairing the keystone LOWER half of T with the UPPER half of U on the SAME optimal (k+1)-dim subspace; the additive Weyl inequality = the keystone lower half for T+U intersected with TWO upper-tail eigenspans (double Grassmann count (k+1)-i-j≥1) plus Rayleigh additivity R_{T+U}=R_T+R_U. Confirms oq-02 prediction that Weyl needs no new spectral theory over the keystone — only the dimension count varies."
     ],
     "mathlibGaps": [
       "No k-th Courant–Fischer / min-max characterisation of the descending k-th eigenvalue in Mathlib (confirmed absent from both InnerProductSpace.Rayleigh and InnerProductSpace.Spectrum on master; only extreme top/bottom Rayleigh cases exist). This is the keystone; est. few hundred lines over Submodule ℂ (EuclideanSpace ℂ (Fin N)). Independently reusable (Weyl, Lidskii)."
@@ -63,7 +65,9 @@
       "When a backend returns: submit Sublemma A (Rayleigh=convex combo of eigenvalues) and Sublemma B (nontrivial intersection by finrank count) to Aristotle FIRST - they are leaf deps, closed/HARD-not-OPEN, unblock everything above.",
       "Then build boundedness haves (mu 0 / mu last), then the max-min identity, then dual via -T, then interlacing assembly.",
       "Re-confirm eigenvalues_antitone + apply_eigenvectorBasis + finrank_sup_add_finrank_inf_eq exist in pin v4.26.0 (checked vs master only).",
-      "Submit lean/CauchyInterlacingMinMax.lean to Aristotle prove_file (Sublemma A+B are closed leaf targets) or docker-build when <=2 containers; reconfirm finrank_bot/eigenvalues/eigenvectorBasis names vs v4.26.0 pin"
+      "Submit lean/CauchyInterlacingMinMax.lean to Aristotle prove_file (Sublemma A+B are closed leaf targets) or docker-build when <=2 containers; reconfirm finrank_bot/eigenvalues/eigenvectorBasis names vs v4.26.0 pin",
+      "Weyl stability |μ(k)-ν(k)| ≤ ‖T-U‖ by sandwiching T between U±‖T-U‖·I (Loewner) + weyl_monotone.",
+      "Dual upper Weyl ρ(k)≥μ(i)+ν(j) for i+j≥k+(n-1) by applying weyl_add_le to -T,-U (eigenvalues negate+reverse)."
     ],
     "markdown": "# Knowledge Base: cauchy-interlacing-theorem\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Derives the two classical **Weyl** spectral inequalities for symmetric operators — *monotonicity* and the *subadditive (additive) inequality* — as pure corollaries of the parent entry's bound-form Courant–Fischer max–min keystone (`CauchyInterlacingKeystone.lean`, #25063, 0-sorry/0-axiom). No new spectral theory.

This is the natural third follow-up to `cauchy-interlacing-theorem`: the parent proves codim-1 interlacing + the keystone, oq-01 the orthogonal-projection compression, oq-02 Poincaré separation. oq-02's own conclusion names "Weyl monotonicity, Lidskii" as the reusable consequences that "likewise only need the dimension count to vary" — this entry realises that prediction.

## Results (`Proofs/CauchyInterlacingWeyl.lean`, 4 thm, 187 lines, 0-sorry/0-axiom)

- **`weyl_monotone`** — Weyl monotonicity. If `re⟪Tx,x⟫ ≤ re⟪Ux,x⟫` for all `x` (T ⪯ U in the Loewner order) then the descending eigenvalues are pointwise monotone, `μ(k) ≤ ν(k)`. Proof: feed the optimal (k+1)-dim subspace for T (keystone lower half) into the keystone upper half for U; the witness vector satisfies `μ(k) ≤ R_T(x) ≤ R_U(x) ≤ ν(k)`.
- **`weyl_add_le`** — Weyl's inequality. For `i + j ≤ k`, `ρ(k) ≤ μ(i) + ν(j)` where ρ enumerates the descending eigenvalues of T+U (0-based form of λ_{i+j+1}(A+B) ≤ λ_{i+1}(A) + λ_{j+1}(B)). Proof: the optimal (k+1)-dim subspace for T+U meets the two upper-tail eigenspans span{b i,…} and span{c j,…}; two Grassmann counts give finrank(S ⊓ A ⊓ B) ≥ (k+1) − i − j ≥ 1, and Rayleigh additivity `R_{T+U} = R_T + R_U` closes it.
- **`rayleigh_le_on_upper_eigenspan`**, **`finrank_inf_lb`** — reusable supporting lemmas (upper-tail eigenspan Rayleigh ceiling; Grassmann intersection bound).

## Verification

`./proofs/scripts/docker-build.sh Proofs.CauchyInterlacingWeyl` → `✔ [7744/7744] Built Proofs.CauchyInterlacingWeyl`, 0 errors, 0 sorries, 0 axioms. New gallery entry `cauchy-interlacing-theorem-oq-03` (status verified, badge original).

🤖 Generated with [Claude Code](https://claude.com/claude-code)