### PR TITLE
research(lagrange-four-squares-waring-g2-oq-03-oq-01): Gauss's Eureka theorem as the 8n+3 slice of three-square sufficiency [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/ThreeSquaresGaussEureka.lean
+++ b/proofs/Proofs/ThreeSquaresGaussEureka.lean
@@ -1,0 +1,168 @@
+/-
+  Gauss's Eureka theorem from the three-square sufficiency axiom.
+
+  CONTEXT.  `Proofs.ThreeSquares` formalizes Legendre's three-square theorem,
+  proving the **necessity** direction axiom-free
+  (`excluded_form_not_sum_three_sq`: a number of the form `4^a(8b+7)` is never a
+  sum of three integer squares) and isolating the **sufficiency** direction as a
+  single axiom
+      not_excluded_form_is_sum_three_sq {n : ℕ} (h : ¬IsExcludedForm n) :
+          ∃ a b c : ℤ, a^2 + b^2 + c^2 = n          (ThreeSquares.lean:1838)
+
+  THIS FILE supplies a famous classical *consequence* of that sufficiency:
+
+      **Gauss's Eureka theorem (1796):** every natural number is a sum of three
+      triangular numbers `T(k) = k(k+1)/2`.  ("ΕΥΡΗΚΑ! num = Δ + Δ + Δ".)
+
+  The reduction is entirely elementary and is proved here **axiom-free**.  Its
+  two unconditional ingredients are:
+
+    1. `eight_mul_add_three_iff` — for every `n`, the integer `8n+3` is a sum of
+       three squares *iff* `n` is a sum of three triangular numbers.  The forward
+       direction uses that `8n+3 ≡ 3 (mod 4)` forces all three squares odd, and
+       an odd square is exactly `8·T(k)+1`; the backward direction is the same
+       identity run in reverse.
+
+    2. `not_excluded_eight_mul_add_three` — `8n+3` is never of the excluded form
+       `4^a(8b+7)` (it is odd and `≡ 3 (mod 8) ≠ 7`).
+
+  Combining (1) and (2): the three-square sufficiency, *applied only at the
+  arithmetic progression `8n+3`*, yields Eureka.  We package this as the
+  hypothesis-parametrised theorem `gauss_eureka_of_sufficiency`, which is
+  therefore axiom-free; discharging its hypothesis with
+  `ThreeSquares.not_excluded_form_is_sum_three_sq` (or the proved
+  `ThreeSquares.legendre_three_squares`) gives the unconditional statement.
+
+  In fact `eight_mul_add_three_iff` shows the two are *logically equivalent*:
+  Eureka for `n` ⇔ three-square representability of `8n+3`.  Gauss's theorem is
+  thus exactly the `8n+3`-slice of Legendre's sufficiency, no more and no less.
+
+  No `sorry`, no `axiom`, no `native_decide`.
+-/
+
+import Mathlib
+import Proofs.ThreeSquares
+
+namespace ThreeSquaresGaussEureka
+
+open ThreeSquares
+
+/-- The `k`-th triangular number `T(k) = k(k+1)/2`. -/
+def tri (k : ℕ) : ℕ := k * (k + 1) / 2
+
+/-- `n` is a sum of three triangular numbers (the content of Gauss's Eureka
+theorem: this predicate holds for every `n`). -/
+def IsSumThreeTriangular (n : ℕ) : Prop :=
+  ∃ a b c : ℕ, tri a + tri b + tri c = n
+
+@[simp] lemma tri_zero : tri 0 = 0 := rfl
+@[simp] lemma tri_one : tri 1 = 1 := rfl
+@[simp] lemma tri_two : tri 2 = 3 := rfl
+
+/-- Twice a triangular number is `k(k+1)` — the division is exact. -/
+lemma two_mul_tri (k : ℕ) : 2 * tri k = k * (k + 1) := by
+  unfold tri
+  exact Nat.mul_div_cancel' (Nat.even_mul_succ_self k).two_dvd
+
+/-- The defining identity: an odd square `(2a+1)²` equals `8·T(a) + 1`. -/
+lemma sq_two_mul_add_one (a : ℕ) : (2 * a + 1) ^ 2 = 8 * tri a + 1 := by
+  have h2 : 2 * tri a = a * (a + 1) := two_mul_tri a
+  have hexp : (2 * a + 1) ^ 2 = 4 * (a * (a + 1)) + 1 := by ring
+  rw [hexp, show (8 : ℕ) * tri a = 4 * (2 * tri a) by ring, h2]
+
+/-- Every odd integer's square has the shape `8·T(j) + 1` for some natural `j`. -/
+lemma odd_sq_eq_eight_tri_add_one {x : ℤ} (hx : Odd x) :
+    ∃ j : ℕ, x ^ 2 = 8 * (tri j : ℤ) + 1 := by
+  -- Reduce to the natural-number identity on `|x| = 2j+1`.
+  obtain ⟨j, hj⟩ := Int.natAbs_odd.mpr hx
+  refine ⟨j, ?_⟩
+  have hnat : x.natAbs ^ 2 = 8 * tri j + 1 := by
+    rw [hj]; exact sq_two_mul_add_one j
+  have hcast : (x.natAbs : ℤ) ^ 2 = x ^ 2 := by
+    rw [← Int.abs_eq_natAbs, sq_abs]
+  calc x ^ 2 = (x.natAbs : ℤ) ^ 2 := hcast.symm
+    _ = ((x.natAbs ^ 2 : ℕ) : ℤ) := by push_cast; ring
+    _ = ((8 * tri j + 1 : ℕ) : ℤ) := by rw [hnat]
+    _ = 8 * (tri j : ℤ) + 1 := by push_cast; ring
+
+/-- An integer whose square is `≡ 1 (mod 4)` is odd. -/
+lemma odd_of_sq_mod_four_one {x : ℤ} (h : x ^ 2 % 4 = 1) : Odd x := by
+  rcases Int.even_or_odd x with he | ho
+  · exfalso
+    obtain ⟨m, hm⟩ := he
+    have hx2 : x ^ 2 = 4 * m ^ 2 := by rw [hm]; ring
+    omega
+  · exact ho
+
+/-- **Key equivalence.** `8n+3` is a sum of three integer squares **iff** `n` is
+a sum of three triangular numbers. -/
+theorem eight_mul_add_three_iff (n : ℕ) :
+    (∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = 8 * (n : ℤ) + 3) ↔
+      IsSumThreeTriangular n := by
+  constructor
+  · -- Forward: a representation of `8n+3` is built from three odd squares.
+    rintro ⟨x, y, z, h⟩
+    -- Each square is `≡ 1 (mod 4)`, hence each of `x, y, z` is odd.
+    have hx4 := int_sq_mod_four x
+    have hy4 := int_sq_mod_four y
+    have hz4 := int_sq_mod_four z
+    have hsum : (x ^ 2 + y ^ 2 + z ^ 2) % 4 = 3 := by rw [h]; omega
+    have hall : x ^ 2 % 4 = 1 ∧ y ^ 2 % 4 = 1 ∧ z ^ 2 % 4 = 1 := by omega
+    have hxo : Odd x := odd_of_sq_mod_four_one hall.1
+    have hyo : Odd y := odd_of_sq_mod_four_one hall.2.1
+    have hzo : Odd z := odd_of_sq_mod_four_one hall.2.2
+    obtain ⟨jx, hjx⟩ := odd_sq_eq_eight_tri_add_one hxo
+    obtain ⟨jy, hjy⟩ := odd_sq_eq_eight_tri_add_one hyo
+    obtain ⟨jz, hjz⟩ := odd_sq_eq_eight_tri_add_one hzo
+    refine ⟨jx, jy, jz, ?_⟩
+    have hZ : ((tri jx + tri jy + tri jz : ℕ) : ℤ) = (n : ℤ) := by
+      push_cast
+      rw [hjx, hjy, hjz] at h
+      linarith
+    exact_mod_cast hZ
+  · -- Backward: `(2a+1)² + (2b+1)² + (2c+1)² = 8(T a + T b + T c) + 3`.
+    rintro ⟨a, b, c, habc⟩
+    refine ⟨2 * (a : ℤ) + 1, 2 * (b : ℤ) + 1, 2 * (c : ℤ) + 1, ?_⟩
+    have keya : (2 * (a : ℤ) + 1) ^ 2 = 8 * (tri a : ℤ) + 1 := by
+      exact_mod_cast sq_two_mul_add_one a
+    have keyb : (2 * (b : ℤ) + 1) ^ 2 = 8 * (tri b : ℤ) + 1 := by
+      exact_mod_cast sq_two_mul_add_one b
+    have keyc : (2 * (c : ℤ) + 1) ^ 2 = 8 * (tri c : ℤ) + 1 := by
+      exact_mod_cast sq_two_mul_add_one c
+    have hsum : (tri a : ℤ) + (tri b : ℤ) + (tri c : ℤ) = (n : ℤ) := by
+      exact_mod_cast habc
+    rw [keya, keyb, keyc]; linarith
+
+/-- `8n+3` is never of the excluded form `4^a(8b+7)`: it is odd and `≡ 3 (mod 8)`. -/
+theorem not_excluded_eight_mul_add_three (n : ℕ) :
+    ¬ ThreeSquares.IsExcludedForm (8 * n + 3) := by
+  have hodd : Odd (8 * n + 3) := ⟨4 * n + 1, by ring⟩
+  rw [ThreeSquares.odd_excluded_iff hodd]
+  omega
+
+/-- **Gauss's Eureka theorem, reduced to three-square sufficiency.**
+
+Given the sufficiency direction of Legendre's three-square theorem (as a
+hypothesis `suff`), every natural number is a sum of three triangular numbers.
+This theorem is *axiom-free*; instantiating `suff` with
+`ThreeSquares.not_excluded_form_is_sum_three_sq` (or the proved
+`ThreeSquares.legendre_three_squares`) yields the unconditional Eureka theorem.
+
+The reduction invokes sufficiency only at the arithmetic progression `8n+3`. -/
+theorem gauss_eureka_of_sufficiency
+    (suff : ∀ m : ℕ, ¬ ThreeSquares.IsExcludedForm m →
+      ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = m)
+    (n : ℕ) : IsSumThreeTriangular n := by
+  obtain ⟨x, y, z, hxyz⟩ := suff (8 * n + 3) (not_excluded_eight_mul_add_three n)
+  apply (eight_mul_add_three_iff n).mp
+  exact ⟨x, y, z, by push_cast at hxyz ⊢; linarith⟩
+
+/-- The logical equivalence made explicit: Eureka for `n` holds **iff** `8n+3`
+is a sum of three squares.  Gauss's theorem is precisely the `8n+3`-slice of
+Legendre's sufficiency. -/
+theorem eureka_iff_three_square_repr (n : ℕ) :
+    IsSumThreeTriangular n ↔
+      ∃ x y z : ℤ, x ^ 2 + y ^ 2 + z ^ 2 = 8 * (n : ℤ) + 3 :=
+  (eight_mul_add_three_iff n).symm
+
+end ThreeSquaresGaussEureka

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "lagrange-four-squares-waring-g2-oq-03-oq-01",
+  "slug": "lagrange-four-squares-waring-g2-oq-03-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ThreeSquares"
+    ],
+    "opens": [
+      "ThreeSquares"
+    ],
+    "namespace": "ThreeSquaresGaussEureka",
+    "lineCount": 168,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/ThreeSquaresGaussEureka.lean",
+    "sorries": 0
+  },
+  "title": "Gauss's Eureka Theorem as the 8n+3 Slice of Three-Square Sufficiency",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ThreeSquaresGaussEureka.lean",
+    "tags": [
+      "number-theory",
+      "sums-of-squares",
+      "legendre-three-square",
+      "gauss-eureka",
+      "triangular-numbers",
+      "three-triangular-numbers",
+      "additive-number-theory",
+      "reduction",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 168,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "badge": "original",
+    "originalContributions": [
+      "eight_mul_add_three_iff: the headline equivalence — for every n, the integer 8n+3 is a sum of three integer squares IF AND ONLY IF n is a sum of three triangular numbers T(k)=k(k+1)/2. This is the exact bridge between Legendre's three-square theorem and Gauss's Eureka theorem, and it is proved unconditionally and axiom-free.",
+      "gauss_eureka_of_sufficiency: Gauss's Eureka theorem (1796, 'ΕΥΡΗΚΑ! num = Δ+Δ+Δ') — every natural number is a sum of three triangular numbers — derived axiom-free from the sufficiency direction of Legendre's three-square theorem supplied as an explicit hypothesis. The reduction invokes sufficiency only on the single arithmetic progression 8n+3.",
+      "not_excluded_eight_mul_add_three: 8n+3 is never of the excluded form 4^a(8b+7) — it is odd with 8n+3 ≡ 3 (mod 8) ≠ 7 — so the sufficiency hypothesis always applies to it (the half that makes the reduction unconditional on the progression).",
+      "odd_sq_eq_eight_tri_add_one: every odd integer's square has the exact shape 8·T(j)+1 for a natural index j (obtained from |x| = 2j+1), the identity that powers the forward direction of the equivalence.",
+      "sq_two_mul_add_one: the defining natural-number identity (2a+1)² = 8·T(a)+1, the backward direction's engine.",
+      "odd_of_sq_mod_four_one: an integer whose square is ≡ 1 (mod 4) is odd — used with 8n+3 ≡ 3 (mod 4) to force all three squares odd, the key observation that a three-square representation of 8n+3 is automatically a representation by three ODD squares.",
+      "eureka_iff_three_square_repr: the equivalence stated in the Eureka-first direction, making explicit that Gauss's theorem for n is logically equivalent to the three-square representability of 8n+3 — no more and no less than the 8n+3 slice of Legendre's sufficiency."
+    ],
+    "prerequisites": [
+      "ThreeSquares.IsExcludedForm, ThreeSquares.odd_excluded_iff (an odd number is excluded iff it is ≡ 7 mod 8) and ThreeSquares.int_sq_mod_four (integer squares are 0 or 1 mod 4) — the axiom-free building blocks reused from the parent three-square formalization.",
+      "Nat.even_mul_succ_self and Nat.mul_div_cancel': exactness of the triangular-number division 2·T(k) = k(k+1).",
+      "Int.natAbs_odd, Int.abs_eq_natAbs, sq_abs: reducing an odd integer's square to the natural-number identity via |x| = 2j+1."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.mul_div_cancel'",
+        "description": "Exact division a ∣ b → a · (b / a) = b; gives 2 · (k(k+1)/2) = k(k+1) so the triangular numbers behave as exact halves.",
+        "module": "Mathlib.Algebra.Order.Group.Nat"
+      },
+      {
+        "theorem": "Int.natAbs_odd",
+        "description": "Odd x.natAbs ↔ Odd x; lets an odd integer's square be computed from the natural-number identity (2j+1)² = 8·T(j)+1.",
+        "module": "Mathlib.Algebra.Order.Group.Int"
+      },
+      {
+        "theorem": "ThreeSquares.odd_excluded_iff",
+        "description": "For odd n, IsExcludedForm n ↔ n % 8 = 7; used to certify 8n+3 (which is ≡ 3 mod 8) is never of the excluded form 4^a(8b+7).",
+        "module": "Proofs.ThreeSquares"
+      },
+      {
+        "theorem": "ThreeSquares.int_sq_mod_four",
+        "description": "Integer squares are ≡ 0 or 1 (mod 4); combined with 8n+3 ≡ 3 (mod 4) it forces each of the three squares to be odd.",
+        "module": "Proofs.ThreeSquares"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "lagrange-four-squares-waring-g2-oq-03-oq-01-oq-01",
+      "question": "Quantitative Eureka: the number of representations of n as an ordered sum of three triangular numbers equals r₃(8n+3)/(something) via the same 8n+3 bijection. Formalize the counting identity connecting the triangular representation count to ThreeSquares.r3_count (8n+3).",
+      "significance": "medium"
+    },
+    {
+      "id": "lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02",
+      "question": "Cauchy's polygonal number theorem for k=3 and the general k-gonal case: every n is a sum of (at most) k+2 k-gonal numbers. The triangular (k=3) case is exactly Eureka; can the 8n+3 reduction be generalized to the (8n+...)-shaped slices for pentagonal/hexagonal numbers?",
+      "significance": "high"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03",
+      "relationship": "depends-on",
+      "description": "This entry derives Gauss's Eureka theorem from the sufficiency direction of Legendre's three-square theorem (the 'if' direction studied in the parent problem), reducing it to the single arithmetic progression 8n+3 and proving the connecting equivalence axiom-free."
+    },
+    {
+      "targetId": "lagrange-four-squares-waring-g2",
+      "relationship": "extends",
+      "description": "Companion in the sums-of-squares / Waring family: where the parent establishes g(2) = 4 (four squares always suffice), this entry records a famous three-square consequence — every number is a sum of three triangular numbers."
+    }
+  ],
+  "references": [
+    {
+      "title": "Disquisitiones Arithmeticae",
+      "author": "Carl Friedrich Gauss",
+      "year": "1801",
+      "venue": "Article 293",
+      "description": "Gauss's three-triangular-number theorem; his diary entry of 10 July 1796 records the discovery as 'ΕΥΡΗΚΑ! num = Δ + Δ + Δ'."
+    },
+    {
+      "title": "Essai sur la théorie des nombres",
+      "author": "Adrien-Marie Legendre",
+      "year": "1798",
+      "venue": "Paris",
+      "description": "Legendre's three-square theorem: n is a sum of three squares iff n is not of the form 4^a(8b+7). Its sufficiency direction is the input to this reduction."
+    },
+    {
+      "title": "Démonstration du théorème général de Fermat sur les nombres polygones",
+      "author": "Augustin-Louis Cauchy",
+      "year": "1813",
+      "venue": "Mém. Sci. Math. Phys. Inst. France",
+      "description": "Cauchy's polygonal number theorem; the triangular case k=3 is Gauss's Eureka theorem formalized here."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Gauss's Eureka theorem — every natural number is a sum of three triangular numbers T(k)=k(k+1)/2 — is shown to be exactly the 8n+3 slice of Legendre's three-square theorem. The verified, axiom-free core is the equivalence eight_mul_add_three_iff: 8n+3 is a sum of three integer squares iff n is a sum of three triangular numbers. The forward direction observes that 8n+3 ≡ 3 (mod 4) forces a three-square representation to use three ODD squares, each of which is exactly 8·T(j)+1 (via |x|=2j+1); the backward direction runs the identity (2a+1)²=8·T(a)+1 in reverse. Since 8n+3 is odd and ≡ 3 (mod 8) ≠ 7 it is never of the excluded form 4^a(8b+7), so the sufficiency direction of Legendre's theorem always applies: gauss_eureka_of_sufficiency derives Eureka axiom-free from sufficiency supplied as a hypothesis (dischargeable by ThreeSquares.legendre_three_squares). 168 lines, 8 theorems/lemmas, 2 definitions, 0 axioms, 0 sorries; the named theorems depend only on propext, Classical.choice, Quot.sound.",
+    "implications": "The reduction pins down the precise logical relationship between two classical theorems: Gauss's Eureka theorem for n is logically equivalent to the three-square representability of 8n+3, so it is neither stronger nor weaker than the 8n+3 instance of Legendre's sufficiency. This isolates the genuinely hard content (the three-square sufficiency, still an axiom in the parent formalization) from the elementary triangular-number bookkeeping, which is now fully machine-checked. It also frames the natural next target — Cauchy's polygonal number theorem — as the analogous slice for higher k-gonal numbers."
+  }
+}


### PR DESCRIPTION
## Summary

Adds `Proofs/ThreeSquaresGaussEureka.lean` and the gallery entry `lagrange-four-squares-waring-g2-oq-03-oq-01`, a companion to the **Legendre three-square "if" direction** problem (`lagrange-four-squares-waring-g2-oq-03`).

It pins down the exact logical relationship between two classical theorems:

> **Gauss's Eureka theorem (1796, "ΕΥΡΗΚΑ! num = Δ + Δ + Δ")** — every natural number is a sum of three triangular numbers — is precisely the **8n+3 slice** of Legendre's three-square sufficiency.

## What is proved (axiom-free)

- **`eight_mul_add_three_iff`** (headline, unconditional): for every `n`, the integer `8n+3` is a sum of three integer squares **iff** `n` is a sum of three triangular numbers `T(k)=k(k+1)/2`.
  - *Forward*: `8n+3 ≡ 3 (mod 4)` forces a three-square representation to use three **odd** squares, and an odd square is exactly `8·T(j)+1` (via `|x| = 2j+1`).
  - *Backward*: run the identity `(2a+1)² = 8·T(a)+1` in reverse.
- **`not_excluded_eight_mul_add_three`**: `8n+3` is never of the excluded form `4^a(8b+7)` (odd, and `≡ 3 (mod 8) ≠ 7`).
- **`gauss_eureka_of_sufficiency`**: Gauss's Eureka theorem, derived **axiom-free** from the three-square sufficiency direction supplied as a hypothesis (dischargeable by the parent's `ThreeSquares.legendre_three_squares`). The reduction invokes sufficiency only on the single arithmetic progression `8n+3`.
- **`eureka_iff_three_square_repr`**: the equivalence stated Eureka-first.

## Why it matters

The reduction isolates the genuinely hard content (the three-square sufficiency, still an axiom in the parent formalization) from the elementary triangular-number bookkeeping, which is now fully machine-checked. Eureka for `n` is shown to be neither stronger nor weaker than the `8n+3` instance of Legendre's sufficiency. Mathlib has no three-triangular-number theorem.

## Verification

- Docker build green: `✔ [7746/7746] Built Proofs.ThreeSquaresGaussEureka`.
- `#print axioms` on `eight_mul_add_three_iff`, `gauss_eureka_of_sufficiency`, `not_excluded_eight_mul_add_three` → `[propext, Classical.choice, Quot.sound]` only (no `ofReduceBool`, no `sorryAx`, no `native_decide`).
- 168 lines, 8 theorems/lemmas, 2 definitions, **0 sorries, 0 axioms** → `status: verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)