### PR TITLE
audit: 3 never-audited entries clean (area-of-circle reparam, cauchy-interlacing-oq-03, three-squares-eureka)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17427,6 +17427,24 @@
       "issues": [],
       "lastAudited": "2026-06-20T00:00:00Z",
       "result": "clean"
+    },
+    "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-20T00:00:00Z",
+      "result": "clean"
+    },
+    "cauchy-interlacing-theorem-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-20T00:00:00Z",
+      "result": "clean"
+    },
+    "lagrange-four-squares-waring-g2-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-20T00:00:00Z",
+      "result": "clean"
     }
   },
   "version": 1,


### PR DESCRIPTION
## Auditor: persist clean marks for 3 never-audited gallery entries

Deep-audited the 3 unaudited entries at HEAD 437410e8a13; all CLEAN.

| Slug | Lean file | thm | axiom | sorry | native_decide |
|------|-----------|-----|-------|-------|---------------|
| area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01 | AreaOfCircleOQ01OQ02OQ02OQ01OQ01.lean | 6 | 0 | 0 | none |
| cauchy-interlacing-theorem-oq-03 | CauchyInterlacingWeyl.lean | 4 | 0 | 0 | none |
| lagrange-four-squares-waring-g2-oq-03-oq-01 | ThreeSquaresGaussEureka.lean | 9 | 0 | 0 | none |

- status `verified` / badge `original`, axiomCount 0 — all consistent.
- No `axiom` declarations, no assumption-carrying structures/classes.
- grep `sorry`/`native_decide` hits are docstring text only.
- gauss_eureka_of_sufficiency is an honest conditional theorem (sufficiency as hypothesis), correctly framed axiom-free.

All three slugs were absent from the audit-tracker entries map (the perpetual never-audited loop). This PR adds clean entries to persist the marks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)