### PR TITLE
research(mantel-theorem-oq-04): extremal graph is K_{⌈n/2⌉,⌊n/2⌋} — complete-bipartite form [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2881,6 +2881,7 @@ import Proofs.MachinFromAddition
 import Proofs.MantelStabilityOQ01
 import Proofs.MantelTheorem
 import Proofs.MantelTheoremUniqueness
+import Proofs.MantelTheoremOQ04
 import Proofs.MathematicalInduction
 import Proofs.MathematicalInductionOQ01
 import Proofs.MathematicalInductionOQ03

--- a/proofs/Proofs/MantelTheoremOQ04.lean
+++ b/proofs/Proofs/MantelTheoremOQ04.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2024-2026 lean-genius contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+import Proofs.MantelTheorem
+import Proofs.MantelTheoremUniqueness
+
+/-!
+# Mantel's Theorem — Complete-Bipartite Form of the Extremal Graph
+
+`Proofs/MantelTheoremUniqueness.lean` proves the Mantel equality characterization
+(`mantel_equality_iff`): a triangle-free graph on `n` vertices attains the maximum
+`⌊n²/4⌋` edges **iff** it is isomorphic to Mathlib's canonical Turán graph
+`turanGraph n 2` (adjacency `v % 2 ≠ w % 2` on `Fin n`).
+
+That phrasing names the extremal graph abstractly. The *classical* statement of
+Mantel's theorem identifies it concretely as the **balanced complete bipartite graph**
+`K_{⌈n/2⌉,⌊n/2⌋}`. This file supplies that identification and re-states the equality
+characterization in complete-bipartite form.
+
+## Main results
+
+* `turanGraphTwoIsoCompleteBipartite` : `completeBipartiteGraph (Fin ⌈n/2⌉) (Fin ⌊n/2⌋) ≃g
+  turanGraph n 2`. The two parts are the even-index and odd-index vertices of `Fin n`.
+* `mantel_equality_iff_completeBipartite` : a triangle-free `G` has exactly `⌊n²/4⌋` edges
+  **iff** `G ≃g K_{⌈n/2⌉,⌊n/2⌋}` — the full extremal form of Mantel's theorem with the
+  unique extremal graph named explicitly.
+
+## Why this is not already in Mathlib
+
+Mathlib's `completeEquipartiteGraph.turanGraph` gives `completeEquipartiteGraph r t ≃g
+turanGraph (r * t) r`, i.e. the *equipartite* case with all parts equal — it requires
+`n = r * t`. For general `n` (odd `n` in particular) the two parts of `turanGraph n 2`
+have **unequal** sizes `⌈n/2⌉ = ⌊n/2⌋ + 1`, which the equipartite isomorphism does not
+cover. The interleaved parity bijection below handles arbitrary `n`.
+
+## Proof of the isomorphism
+
+The vertices of `turanGraph n 2` are `Fin n` with two adjacency classes by parity:
+even indices (there are `⌈n/2⌉ = (n+1)/2` of them) and odd indices (`⌊n/2⌋ = n/2`).
+Two vertices are adjacent iff their parities differ. The map
+
+* `inl k ↦ 2 * k`  (the `k`-th even index),
+* `inr k ↦ 2 * k + 1`  (the `k`-th odd index)
+
+is a bijection `Fin ⌈n/2⌉ ⊕ Fin ⌊n/2⌋ ≃ Fin n` carrying "different side of the bipartition"
+to "different parity", i.e. carrying complete-bipartite adjacency to `turanGraph n 2`
+adjacency. All `Fin`/divmod side conditions are discharged by `omega`.
+-/
+
+open Finset Fintype SimpleGraph
+
+namespace Mantel
+
+/-- The interleaved parity bijection `Fin ⌈n/2⌉ ⊕ Fin ⌊n/2⌋ ≃ Fin n`: the left part enumerates
+the even indices `2*k`, the right part the odd indices `2*k + 1`. -/
+def binEquiv (n : ℕ) : Fin ((n + 1) / 2) ⊕ Fin (n / 2) ≃ Fin n where
+  toFun := Sum.elim (fun k => ⟨2 * k, by have := k.2; omega⟩)
+                    (fun k => ⟨2 * k + 1, by have := k.2; omega⟩)
+  invFun := fun v =>
+    if h : (v : ℕ) % 2 = 0 then Sum.inl ⟨v / 2, by have := v.2; omega⟩
+    else Sum.inr ⟨v / 2, by have := v.2; omega⟩
+  left_inv := by
+    rintro (⟨k, hk⟩ | ⟨k, hk⟩)
+    · simp only [Sum.elim_inl]
+      rw [dif_pos (by simp)]
+      simp only [Sum.inl.injEq, Fin.mk.injEq]
+      omega
+    · simp only [Sum.elim_inr]
+      rw [dif_neg (by simp)]
+      simp only [Sum.inr.injEq, Fin.mk.injEq]
+      omega
+  right_inv := by
+    rintro ⟨v, hv⟩
+    dsimp only
+    by_cases h : v % 2 = 0
+    · rw [dif_pos h]
+      simp only [Sum.elim_inl, Fin.mk.injEq]
+      omega
+    · rw [dif_neg h]
+      simp only [Sum.elim_inr, Fin.mk.injEq]
+      omega
+
+/-- **The balanced complete bipartite graph is the Mantel/Turán extremal graph.**
+`turanGraph n 2` is isomorphic to `K_{⌈n/2⌉,⌊n/2⌋}`, the complete bipartite graph whose parts
+are the even-index and odd-index vertices. Generalizes Mathlib's equipartite
+`completeEquipartiteGraph.turanGraph` to arbitrary (possibly odd) `n`. -/
+def turanGraphTwoIsoCompleteBipartite (n : ℕ) :
+    completeBipartiteGraph (Fin ((n + 1) / 2)) (Fin (n / 2)) ≃g turanGraph n 2 where
+  toEquiv := binEquiv n
+  map_rel_iff' := by
+    rintro (a | a) (b | b) <;>
+      simp [binEquiv, turanGraph_adj, completeBipartiteGraph_adj, Nat.mul_add_mod] <;>
+      omega
+
+/-- **Mantel's theorem, complete-bipartite equality characterization.** A triangle-free graph
+`G` on `n` vertices has exactly `⌊n²/4⌋` edges **iff** it is isomorphic to the balanced complete
+bipartite graph `K_{⌈n/2⌉,⌊n/2⌋}`. This is the classical extremal form of Mantel's theorem with
+the unique extremal graph named explicitly, sharpening `mantel_equality_iff` (which names it as
+the abstract `turanGraph n 2`). -/
+theorem mantel_equality_iff_completeBipartite {V : Type*} [Fintype V] (G : SimpleGraph V)
+    [DecidableRel G.Adj] (h : G.CliqueFree 3) :
+    G.edgeFinset.card = (Fintype.card V) ^ 2 / 4 ↔
+      Nonempty (G ≃g completeBipartiteGraph
+        (Fin ((Fintype.card V + 1) / 2)) (Fin (Fintype.card V / 2))) := by
+  rw [mantel_equality_iff G h]
+  exact ⟨fun ⟨f⟩ => ⟨f.trans (turanGraphTwoIsoCompleteBipartite _).symm⟩,
+         fun ⟨f⟩ => ⟨f.trans (turanGraphTwoIsoCompleteBipartite _)⟩⟩
+
+end Mantel

--- a/src/data/proofs/mantel-theorem-oq-04/annotations.json
+++ b/src/data/proofs/mantel-theorem-oq-04/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "mantel-oq04-ann-import",
+    "proofId": "mantel-theorem-oq-04",
+    "range": { "startLine": 1, "endLine": 7 },
+    "type": "concept",
+    "title": "Imports: Turán Graphs, Complete Bipartite Graphs, and the Sibling Mantel Files",
+    "content": "Besides import Mathlib (for turanGraph, completeBipartiteGraph, SimpleGraph.Iso, and the Equiv API), the file imports the sibling entries Proofs.MantelTheorem and Proofs.MantelTheoremUniqueness. From them it reuses the abstract equality characterization mantel_equality_iff (triangle-free attains ⌊n²/4⌋ iff isomorphic to turanGraph n 2) and the Turán-graph edge count, so this entry adds only the concrete complete-bipartite identification.",
+    "mathContext": "Builds on Mathlib's $\\mathrm{turanGraph}\\,n\\,2$, $\\mathrm{completeBipartiteGraph}$, and $\\mathrm{SimpleGraph.Iso}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["turanGraph", "completeBipartiteGraph", "SimpleGraph.Iso", "mantel_equality_iff"],
+    "prerequisites": ["simple graphs", "Turán's theorem", "graph isomorphism"]
+  },
+  {
+    "id": "mantel-oq04-ann-docstring",
+    "proofId": "mantel-theorem-oq-04",
+    "range": { "startLine": 9, "endLine": 53 },
+    "type": "concept",
+    "title": "Statement: The Concrete Complete-Bipartite Form of the Extremal Graph",
+    "content": "Mathlib names the Mantel/Turán extremal graph abstractly as turanGraph n 2 (adjacency v % 2 ≠ w % 2 on Fin n). The classical statement names it concretely as the balanced complete bipartite graph K_{⌈n/2⌉,⌊n/2⌋}. This file proves they are isomorphic for every n and re-states the equality characterization with the extremal graph named explicitly. Mathlib already has the equipartite identification completeEquipartiteGraph r t ≃g turanGraph (r·t) r, but it forces n = r·t with equal parts; for odd n the two parts differ in size by one, so a fresh construction is needed.",
+    "mathContext": "$\\mathrm{turanGraph}\\,n\\,2 \\cong K_{\\lceil n/2\\rceil,\\lfloor n/2\\rfloor}$ for all $n$.",
+    "significance": "central",
+    "relatedConcepts": ["Mantel's theorem", "Turán graph", "complete bipartite graph", "extremal graph theory"],
+    "prerequisites": ["Mantel's theorem", "graph isomorphism"]
+  },
+  {
+    "id": "mantel-oq04-ann-parity-bijection",
+    "proofId": "mantel-theorem-oq-04",
+    "range": { "startLine": 56, "endLine": 83 },
+    "type": "technique",
+    "title": "The Interleaved Parity Bijection `binEquiv`",
+    "content": "binEquiv : Fin ⌈n/2⌉ ⊕ Fin ⌊n/2⌋ ≃ Fin n sends inl k ↦ 2k (the k-th even index) and inr k ↦ 2k+1 (the k-th odd index); its inverse splits a vertex v by parity, sending it to v/2 on the matching side. The choice of the interleaved map (rather than the block bijection finSumFinEquiv) is essential: only interleaving by parity matches turanGraph's mod-2 adjacency. The forward Fin bounds (2k < n, 2k+1 < n) and both round-trip identities reduce, once simp normalizes the Fin coercions and the parity dite, to linear divmod goals that omega closes.",
+    "mathContext": "$k \\mapsto 2k$ (left, evens), $k \\mapsto 2k+1$ (right, odds); inverse by parity.",
+    "significance": "central",
+    "relatedConcepts": ["Equiv", "parity", "Fin", "omega", "Sum.elim"],
+    "prerequisites": ["bijections", "Euclidean division", "Fin arithmetic"]
+  },
+  {
+    "id": "mantel-oq04-ann-graph-iso",
+    "proofId": "mantel-theorem-oq-04",
+    "range": { "startLine": 85, "endLine": 95 },
+    "type": "key-step",
+    "title": "The Graph Isomorphism `turanGraphTwoIsoCompleteBipartite`",
+    "content": "Using binEquiv as the underlying equivalence, this builds the graph isomorphism completeBipartiteGraph (Fin ⌈n/2⌉) (Fin ⌊n/2⌋) ≃g turanGraph n 2. The only real obligation is map_rel_iff', that the bijection preserves adjacency. Case-splitting both endpoints on inl/inr: same-side pairs map to indices of equal parity (2k, 2k or 2k+1, 2k+1) — non-adjacent on both sides; opposite-side pairs map to indices of different parity — adjacent on both sides. After simp on completeBipartiteGraph_adj and turanGraph_adj, omega settles the residues mod 2 in all four cases.",
+    "mathContext": "'opposite side of the bipartition' $\\iff$ 'different residue mod 2'.",
+    "significance": "central",
+    "relatedConcepts": ["SimpleGraph.Iso", "RelIso", "map_rel_iff'", "completeBipartiteGraph_adj", "turanGraph_adj"],
+    "prerequisites": ["graph isomorphism", "case analysis", "modular arithmetic"]
+  },
+  {
+    "id": "mantel-oq04-ann-complete-bipartite-form",
+    "proofId": "mantel-theorem-oq-04",
+    "range": { "startLine": 97, "endLine": 109 },
+    "type": "key-step",
+    "title": "The Complete-Bipartite Equality Characterization",
+    "content": "mantel_equality_iff_completeBipartite: a triangle-free graph G on n vertices has exactly ⌊n²/4⌋ edges iff G ≃g K_{⌈n/2⌉,⌊n/2⌋}. The proof rewrites with the abstract mantel_equality_iff (extremal iff G ≃g turanGraph n 2) and then transports the isomorphism with Iso.trans and Iso.symm — no combinatorics is re-proved, the new content is exactly the graph isomorphism. This is the textbook extremal form of Mantel's theorem with the unique extremal graph named explicitly.",
+    "mathContext": "$\\#E(G) = \\lfloor n^2/4\\rfloor \\iff G \\cong K_{\\lceil n/2\\rceil,\\lfloor n/2\\rfloor}$.",
+    "significance": "central",
+    "relatedConcepts": ["mantel_equality_iff", "Iso.trans", "Iso.symm", "transport of structure"],
+    "prerequisites": ["Mantel's theorem", "graph isomorphism"]
+  }
+]

--- a/src/data/proofs/mantel-theorem-oq-04/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-04/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "mantel-theorem-oq-04",
+  "title": "Mantel's Theorem, Complete-Bipartite Form: The Unique Extremal Graph Is K_{⌈n/2⌉,⌊n/2⌋}",
+  "slug": "mantel-theorem-oq-04",
+  "description": "A fully verified, axiom-free identification of the extremal graph in Mantel's theorem with the balanced complete bipartite graph. The companion entry mantel-theorem-oq-02 (equality characterization) shows that a triangle-free graph on n vertices attains the maximum ⌊n²/4⌋ edges iff it is isomorphic to Mathlib's abstract Turán graph turanGraph n 2 (adjacency v % 2 ≠ w % 2 on Fin n). This entry supplies the classical concrete form: turanGraph n 2 ≃g completeBipartiteGraph (Fin ⌈n/2⌉) (Fin ⌊n/2⌋), and re-states the equality characterization with the unique extremal graph named explicitly as K_{⌈n/2⌉,⌊n/2⌋}. The graph isomorphism is the interleaved parity bijection (even index 2k ↦ left k, odd index 2k+1 ↦ right k), which carries 'different side of the bipartition' to 'different parity'. Generalizes Mathlib's equipartite completeEquipartiteGraph.turanGraph (which requires n = r·t) to arbitrary, possibly odd, n where the two parts have unequal sizes ⌈n/2⌉ = ⌊n/2⌋ + 1.",
+  "meta": {
+    "author": "lean-genius researcher agents, formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Mantel%27s_theorem",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "graph-theory",
+      "combinatorics",
+      "extremal-graph-theory",
+      "triangle-free",
+      "mantel-theorem",
+      "turan-graph",
+      "complete-bipartite",
+      "graph-isomorphism"
+    ],
+    "proofRepoPath": "Proofs/MantelTheoremOQ04.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.turanGraph",
+        "description": "The canonical (r+1)-clique-free Turán graph on Fin n with adjacency v % r ≠ w % r; specialized to r = 2 it is the abstract Mantel extremal graph",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Extremal.Turan"
+      },
+      {
+        "theorem": "SimpleGraph.completeBipartiteGraph",
+        "description": "The complete bipartite graph on V ⊕ W (adjacency exactly between the two sides); its @[simps]-generated completeBipartiteGraph_adj drives the adjacency check",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+      },
+      {
+        "theorem": "SimpleGraph.Iso",
+        "description": "Graph isomorphism as a RelIso of adjacency relations, built here from an explicit Equiv plus a map_rel_iff' adjacency-preservation proof; Iso.trans and Iso.symm transport the characterization",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Maps"
+      },
+      {
+        "theorem": "Equiv",
+        "description": "The interleaved parity bijection Fin ⌈n/2⌉ ⊕ Fin ⌊n/2⌋ ≃ Fin n is constructed by hand (Sum.elim forward, parity dite inverse) with all Fin/divmod side conditions discharged by omega",
+        "module": "Mathlib.Logic.Equiv.Defs"
+      }
+    ],
+    "originalContributions": [
+      "binEquiv: the interleaved parity bijection Fin ⌈n/2⌉ ⊕ Fin ⌊n/2⌋ ≃ Fin n sending inl k ↦ 2k (the k-th even index) and inr k ↦ 2k+1 (the k-th odd index), with inverse v ↦ inl (v/2) or inr (v/2) by parity; round-trip and Fin-bound side conditions all closed by omega",
+      "turanGraphTwoIsoCompleteBipartite: the graph isomorphism completeBipartiteGraph (Fin ⌈n/2⌉) (Fin ⌊n/2⌋) ≃g turanGraph n 2, proving that 'opposite sides of the bipartition' coincides with 'different parity'; valid for all n (including odd n with unequal parts), generalizing Mathlib's equipartite-only completeEquipartiteGraph.turanGraph",
+      "mantel_equality_iff_completeBipartite: the classical extremal form of Mantel's theorem — a triangle-free graph has exactly ⌊n²/4⌋ edges iff it is isomorphic to the balanced complete bipartite graph K_{⌈n/2⌉,⌊n/2⌋} — obtained by transporting mantel_equality_iff along the isomorphism, naming the unique extremal graph explicitly"
+    ],
+    "dateAdded": "2026-06-20",
+    "axiomCountNote": "0 axiom declarations, 0 sorries, 0 structure-encoded assumptions, no native_decide. The isomorphism is constructed and verified entirely from Mathlib's SimpleGraph and Equiv APIs; the only foundational dependencies are propext/Classical.choice/Quot.sound, which the project does not count."
+  },
+  "overview": {
+    "historicalContext": "Mantel's 1907 theorem states that a triangle-free graph on n vertices has at most ⌊n²/4⌋ edges. The classical statement adds that the bound is attained uniquely by the balanced complete bipartite graph K_{⌈n/2⌉,⌊n/2⌋} — split the vertices into two parts as equal as possible and join every cross pair. Mathlib's formalization of Turán's theorem instead names the extremal graph abstractly as turanGraph n 2, whose vertices are Fin n with two vertices adjacent iff their indices have different parity. These are the same graph, but the equivalence — and in particular the identification of the parts as the ⌈n/2⌉ even indices and the ⌊n/2⌋ odd indices — is the content that turns the abstract Turán phrasing into the textbook complete-bipartite statement.",
+    "problemStatement": "Identify the extremal graph of Mantel's theorem concretely: prove that turanGraph n 2 is isomorphic to the balanced complete bipartite graph K_{⌈n/2⌉,⌊n/2⌋} for every n, and re-state the Mantel equality characterization (gallery entry mantel-theorem-oq-02) so that the unique extremal graph is named as the complete bipartite graph rather than as an abstract Turán graph.",
+    "proofStrategy": "The vertices of turanGraph n 2 form two adjacency classes by parity: the ⌈n/2⌉ = (n+1)/2 even indices and the ⌊n/2⌋ = n/2 odd indices, with two vertices adjacent iff their parities differ. The interleaved bijection binEquiv : Fin ⌈n/2⌉ ⊕ Fin ⌊n/2⌋ ≃ Fin n sends inl k ↦ 2k and inr k ↦ 2k+1; its inverse splits a vertex by parity, sending it to v/2 on the appropriate side. All four round-trip and Fin-bound obligations reduce to linear divmod facts closed by omega. The isomorphism turanGraphTwoIsoCompleteBipartite uses binEquiv as its underlying equivalence; the adjacency-preservation obligation map_rel_iff' is discharged by case-splitting both endpoints on inl/inr and observing that 'same side' ⟺ '2k, 2k' or '2k+1, 2k+1' both have the same parity (non-adjacent), while 'opposite sides' have different parity (adjacent) — simp plus omega on the residues mod 2. Finally mantel_equality_iff_completeBipartite rewrites by the abstract equality characterization and transports the isomorphism with Iso.trans / Iso.symm.",
+    "keyInsights": [
+      "The Turán graph turanGraph n 2 and the balanced complete bipartite graph K_{⌈n/2⌉,⌊n/2⌋} are literally the same object viewed two ways: 'different residue mod 2' is exactly 'opposite side of the bipartition'.",
+      "The right bijection is the interleaved one (evens ↔ left, odds ↔ right), not the block bijection finSumFinEquiv: only interleaving by parity matches turanGraph's mod-2 adjacency, so the standard Fin ⊕ Fin ≃ Fin (m+n) does not transport the graph structure.",
+      "Mathlib already has the equipartite identification completeEquipartiteGraph r t ≃g turanGraph (r·t) r, but it requires n = r·t with all parts equal; for odd n the two parts differ in size by one, so the general complete-bipartite form genuinely needed a fresh construction.",
+      "Once the isomorphism exists, the whole extremal characterization is purely transport-of-structure: edge counts and the iff are preserved by Iso.card_edgeFinset_eq and Iso.trans, so no combinatorics is re-proved — the new content is exactly the graph isomorphism.",
+      "Every arithmetic obligation in the bijection (2k < n, v/2 bounds, round trips, parity of 2k and 2k+1) is linear in n, k, v once the parities are exposed, so omega discharges all of them after simp normalizes the Fin coercions."
+    ]
+  },
+  "conclusion": {
+    "summary": "A complete, axiom-free and sorry-free identification of Mantel's extremal graph with the balanced complete bipartite graph: turanGraph n 2 ≃g K_{⌈n/2⌉,⌊n/2⌋} for all n, together with the resulting complete-bipartite form of the Mantel equality characterization. This upgrades the abstract Turán-graph statement of mantel-theorem-oq-02 to the classical textbook phrasing with the unique extremal graph named explicitly.",
+    "implications": "Supplies a reusable bridge between Mathlib's residue-based turanGraph (at r = 2) and the complete bipartite graph, valid for arbitrary, possibly odd, n with unequal parts — a strict generalization of the equipartite-only completeEquipartiteGraph.turanGraph. The interleaved parity bijection and the transport pattern are directly reusable for analogous identifications of turanGraph n r with complete r-partite graphs.",
+    "openQuestions": [
+      "Compute the edge count of the balanced complete bipartite graph directly as ⌈n/2⌉·⌊n/2⌋ and verify ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋, giving a self-contained complete-bipartite proof of the Mantel tightness bound independent of card_edgeFinset_turanGraph_two.",
+      "Generalize turanGraphTwoIsoCompleteBipartite to turanGraph n r ≃g the complete r-partite graph on the r residue classes mod r, the general (non-equipartite) bridge of which the r = 2 case is proved here.",
+      "Derive structural corollaries of the extremal graph from the complete-bipartite form: it is bipartite, 2-chromatic, connected for n ≥ 2, and has diameter ≤ 2 — properties immediate for completeBipartiteGraph but obscured in the turanGraph residue presentation."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "License and Imports",
+      "startLine": 1,
+      "endLine": 7,
+      "summary": "Apache-2.0 header and imports: Mathlib for the SimpleGraph/Equiv API, plus the sibling Mantel files MantelTheorem and MantelTheoremUniqueness supplying the edge bound, the Turán-graph edge count, and the abstract equality characterization mantel_equality_iff.",
+      "mathContext": "Builds on Mathlib's turanGraph, completeBipartiteGraph, and SimpleGraph.Iso."
+    },
+    {
+      "id": "docstring",
+      "title": "Statement and Approach",
+      "startLine": 9,
+      "endLine": 53,
+      "summary": "Module docstring locating the result as the concrete complete-bipartite form of the Mantel extremal graph, explaining why Mathlib's equipartite identification does not cover general (odd) n, and outlining the interleaved parity bijection that powers the isomorphism.",
+      "mathContext": "turanGraph n 2 ≃g K_{⌈n/2⌉,⌊n/2⌋} for all n."
+    },
+    {
+      "id": "parity-bijection",
+      "title": "The Interleaved Parity Bijection",
+      "startLine": 56,
+      "endLine": 83,
+      "summary": "binEquiv: the equivalence Fin ⌈n/2⌉ ⊕ Fin ⌊n/2⌋ ≃ Fin n sending inl k ↦ 2k and inr k ↦ 2k+1, with inverse splitting a vertex by parity to v/2 on the matching side. The forward Fin bounds and both round-trip identities (left_inv, right_inv) reduce, after simp normalizes the Fin coercions and the parity dite, to linear divmod goals closed by omega.",
+      "mathContext": "$\\mathrm{Fin}\\,\\lceil n/2\\rceil \\oplus \\mathrm{Fin}\\,\\lfloor n/2\\rfloor \\simeq \\mathrm{Fin}\\,n$, $k \\mapsto 2k,\\ k \\mapsto 2k+1$."
+    },
+    {
+      "id": "graph-isomorphism",
+      "title": "The Graph Isomorphism",
+      "startLine": 85,
+      "endLine": 95,
+      "summary": "turanGraphTwoIsoCompleteBipartite: the graph isomorphism completeBipartiteGraph (Fin ⌈n/2⌉) (Fin ⌊n/2⌋) ≃g turanGraph n 2, with binEquiv as its underlying equivalence. The adjacency-preservation obligation map_rel_iff' is proved by case-splitting both endpoints on inl/inr: same-side pairs map to indices of equal parity (non-adjacent), opposite-side pairs to indices of different parity (adjacent); simp on completeBipartiteGraph_adj/turanGraph_adj and omega on the mod-2 residues close all four cases.",
+      "mathContext": "$K_{\\lceil n/2\\rceil,\\lfloor n/2\\rfloor} \\cong \\mathrm{turanGraph}\\,n\\,2$."
+    },
+    {
+      "id": "complete-bipartite-form",
+      "title": "Complete-Bipartite Equality Characterization",
+      "startLine": 97,
+      "endLine": 109,
+      "summary": "mantel_equality_iff_completeBipartite: a triangle-free graph G on n vertices has exactly ⌊n²/4⌋ edges iff G ≃g K_{⌈n/2⌉,⌊n/2⌋}. Proved by rewriting with the abstract characterization mantel_equality_iff and transporting the isomorphism along Iso.trans and Iso.symm — naming the unique extremal graph explicitly as the balanced complete bipartite graph.",
+      "mathContext": "$\\#E(G) = \\lfloor n^2/4\\rfloor \\iff G \\cong K_{\\lceil n/2\\rceil,\\lfloor n/2\\rfloor}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "mantel-theorem-oq-02",
+      "relationship": "extends",
+      "description": "mantel-theorem-oq-02 proves the equality characterization with the extremal graph named abstractly as turanGraph n 2; this entry identifies that graph concretely as the balanced complete bipartite graph K_{⌈n/2⌉,⌊n/2⌋} and re-states the characterization in that classical form."
+    },
+    {
+      "targetId": "mantel-theorem",
+      "relationship": "related",
+      "description": "mantel-theorem proves the global edge bound ⌊n²/4⌋ and its tightness via turanGraph n 2; this entry supplies the textbook description of the tight example as a balanced complete bipartite graph."
+    },
+    {
+      "targetId": "mantel-theorem-oq-03",
+      "relationship": "related",
+      "description": "Both refine the extremal picture of triangle-free graphs: oq-03 proves the local minimum-degree bound ⌊n/2⌋, while this entry pins down the global extremal graph as K_{⌈n/2⌉,⌊n/2⌋}, whose minimum degree is exactly ⌊n/2⌋ (the sharpness witness for oq-03)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.MantelTheorem",
+      "Proofs.MantelTheoremUniqueness"
+    ],
+    "opens": [
+      "Finset",
+      "Fintype",
+      "SimpleGraph"
+    ],
+    "namespace": "Mantel",
+    "lineCount": 111,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 2,
+    "path": "Proofs/MantelTheoremOQ04.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    "binEquiv",
+    "turanGraphTwoIsoCompleteBipartite",
+    "mantel_equality_iff_completeBipartite"
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/mantel-theorem-oq-04.json
+++ b/src/data/research/problems/mantel-theorem-oq-04.json
@@ -1,0 +1,28 @@
+{
+  "id": "mantel-theorem-oq-04",
+  "statement": "A triangle-free graph on n vertices with exactly ⌊n²/4⌋ edges is isomorphic to the balanced complete bipartite graph K_{⌈n/2⌉,⌊n/2⌋}.",
+  "question": "Identify the Mantel/Turán extremal graph concretely as the balanced complete bipartite graph, and re-state the equality characterization in that classical form.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: proved turanGraph n 2 ≃g completeBipartiteGraph (Fin ⌈n/2⌉) (Fin ⌊n/2⌋) for all n, and the complete-bipartite equality characterization mantel_equality_iff_completeBipartite. Verified, 0-axiom, 0-sorry (PR for gallery entry mantel-theorem-oq-04).",
+    "builtItems": [
+      "binEquiv (Proofs/MantelTheoremOQ04.lean): interleaved parity bijection Fin ⌈n/2⌉ ⊕ Fin ⌊n/2⌋ ≃ Fin n, inl k ↦ 2k, inr k ↦ 2k+1, inverse by parity v ↦ v/2; all Fin bounds and round-trips by omega",
+      "turanGraphTwoIsoCompleteBipartite (Proofs/MantelTheoremOQ04.lean): graph isomorphism completeBipartiteGraph (Fin ⌈n/2⌉) (Fin ⌊n/2⌋) ≃g turanGraph n 2, general n",
+      "mantel_equality_iff_completeBipartite (Proofs/MantelTheoremOQ04.lean): triangle-free G has ⌊n²/4⌋ edges ↔ G ≃g K_{⌈n/2⌉,⌊n/2⌋}"
+    ],
+    "insights": [
+      "turanGraph n 2 adjacency 'v % 2 ≠ w % 2' is exactly 'opposite side' of the parity bipartition; the right bijection is interleaved (evens↔left, odds↔right), NOT the block finSumFinEquiv which does not preserve mod-2 adjacency",
+      "Mathlib's completeEquipartiteGraph.turanGraph only covers the equipartite case n = r·t (equal parts); for odd n the parts differ in size by one, so the general complete-bipartite identification needed a fresh construction",
+      "Once the iso exists, the equality characterization is pure transport of structure (Iso.trans / Iso.symm) on top of the abstract mantel_equality_iff — no combinatorics is re-proved",
+      "map_rel_iff' adjacency proof: full `simp [completeBipartiteGraph_adj, turanGraph_adj, Nat.mul_add_mod]` reduces .val(mk) and mod-2 residues; `simp only` with Fin.val_mk did NOT fire (left ↑(2*↑a) unreduced and blocked omega)"
+    ],
+    "mathlibGaps": [
+      "No general (non-equipartite) bridge turanGraph n r ≃g complete r-partite graph for n not a multiple of r; only completeEquipartiteGraph.turanGraph (n = r·t) exists",
+      "No lemma computing #edgeFinset of completeBipartiteGraph (Fin a) (Fin b) = a*b in the form needed; would let the tightness bound be re-derived directly in complete-bipartite form"
+    ],
+    "nextSteps": [
+      "Generalize turanGraphTwoIsoCompleteBipartite to turanGraph n r ≃g complete r-partite graph on the r residue classes mod r (this is the r=2 case)",
+      "Prove #E(K_{⌈n/2⌉,⌊n/2⌋}) = ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋ for a self-contained complete-bipartite tightness proof",
+      "Derive structural corollaries from the complete-bipartite form: extremal graph is bipartite, 2-chromatic, diameter ≤ 2"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Identifies the **Mantel/Turán extremal graph** concretely. The sibling entry `mantel-theorem-oq-02` (`mantel_equality_iff`) characterizes the equality case but names the extremal graph abstractly as Mathlib's `turanGraph n 2` (adjacency `v % 2 ≠ w % 2` on `Fin n`). This entry supplies the **classical** form: the unique extremal graph is the **balanced complete bipartite graph** `K_{⌈n/2⌉,⌊n/2⌋}`.

## What's proved (`Proofs/MantelTheoremOQ04.lean`)

- **`binEquiv`** — the interleaved parity bijection `Fin ⌈n/2⌉ ⊕ Fin ⌊n/2⌋ ≃ Fin n` (`inl k ↦ 2k`, the *k*-th even index; `inr k ↦ 2k+1`, the *k*-th odd index). All `Fin` bounds and round-trips discharged by `omega`.
- **`turanGraphTwoIsoCompleteBipartite`** — the graph isomorphism `completeBipartiteGraph (Fin ⌈n/2⌉) (Fin ⌊n/2⌋) ≃g turanGraph n 2`, proving "opposite side of the bipartition" ⟺ "different parity".
- **`mantel_equality_iff_completeBipartite`** — the textbook extremal form: a triangle-free `G` has exactly `⌊n²/4⌋` edges **iff** `G ≃g K_{⌈n/2⌉,⌊n/2⌋}`. Obtained by transporting `mantel_equality_iff` along the isomorphism (`Iso.trans` / `Iso.symm`).

## Why this isn't already in Mathlib

Mathlib's `completeEquipartiteGraph.turanGraph` gives `completeEquipartiteGraph r t ≃g turanGraph (r·t) r` — the **equipartite** case with all parts equal, requiring `n = r·t`. For general (odd) `n` the two parts have **unequal** sizes `⌈n/2⌉ = ⌊n/2⌋ + 1`, so the interleaved parity bijection here is a genuine generalization.

## Verification

- 2 definitions + 1 theorem; **0 sorries, 0 axioms, no `native_decide`**.
- Builds green via `docker-build.sh Proofs.MantelTheoremOQ04` (7745 jobs, exit 0), Lean v4.26.0.
- Foundational deps limited to `propext`/`Classical.choice`/`Quot.sound`.

Gallery entry: `src/data/proofs/mantel-theorem-oq-04/` (meta + annotations). Registered in `Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)