### PR TITLE
audit: mark mantel-theorem-oq-04 clean in audit-tracker

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17445,6 +17445,12 @@
       "issues": [],
       "lastAudited": "2026-06-20T00:00:00Z",
       "result": "clean"
+    },
+    "mantel-theorem-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-20T00:00:00Z",
+      "result": "clean"
     }
   },
   "version": 1,


### PR DESCRIPTION
Deep-audited `mantel-theorem-oq-04` (complete-bipartite form of Mantel's extremal graph: `turanGraph n 2 ≃g K_{⌈n/2⌉,⌊n/2⌋}`).

## Findings — CLEAN
- 2 defs (`binEquiv`, `turanGraphTwoIsoCompleteBipartite`) + 1 theorem (`mantel_equality_iff_completeBipartite`) — matches `definitionCount:2`/`theoremCount:1`
- 0 sorry, 0 axiom, 0 `native_decide`, no `True` stubs (grep across full file empty)
- Sibling dependency `mantel_equality_iff` is a real proven theorem; both `MantelTheorem.lean` and `MantelTheoremUniqueness.lean` are 0-sorry/0-axiom
- Proofs substantive (omega-discharged interleaved parity bijection + transport-of-structure via `Iso.trans`/`Iso.symm`), not Mathlib wrappers
- `badge: original` defensible — documented Mathlib gap (equipartite-only `completeEquipartiteGraph.turanGraph` doesn't cover odd `n`)

The slug was absent from the audit-tracker entries map, so the auditor's worktree clean-mark was a no-op. This PR persists the clean mark so the audit queue drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)