### PR TITLE
research(lagrange-four-squares-waring-g2-oq-03-oq-02): two triangular numbers ⟺ 4n+1 sum of two squares [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3399,6 +3399,7 @@ import Proofs.TriangularReciprocalsOQ04
 import Proofs.TuranEdgeBound
 import Proofs.TwinPrimes
 import Proofs.TwinPrimesSpecialOQ01
+import Proofs.TwoTrianglesTwoSquares
 import Proofs.UnitDistanceHN7
 import Proofs.UnitDistanceHN7Aristotle
 import Proofs.UnitDistanceIndependence

--- a/proofs/Proofs/TwoTrianglesTwoSquares.lean
+++ b/proofs/Proofs/TwoTrianglesTwoSquares.lean
@@ -1,0 +1,178 @@
+/-
+  Sums of two triangular numbers and the `4n+1` two-square slice.
+
+  CONTEXT.  This is the *two*-summand analogue of `Proofs.ThreeSquaresGaussEureka`
+  (Gauss's Eureka theorem: every natural is a sum of three triangular numbers,
+  the `8n+3` slice of Legendre's three-square sufficiency).  Whereas Eureka is
+  conditional on the still-open three-square *sufficiency* axiom, the *two*-square
+  theorem is fully available in Mathlib, so the result here is **unconditional and
+  axiom-free**.
+
+  MAIN RESULT (`isSumTwoTriangular_iff`):
+
+      For every natural number `n`,
+          `n` is a sum of two triangular numbers `T(k) = k(k+1)/2`
+      **iff**
+          `4n + 1` is a sum of two integer squares.
+
+  The bridge is the classical change of variables
+      `4·(T(a) + T(b)) + 1 = (a+b+1)² + (a−b)²`,
+  a *rotation* of the lattice `(a,b) ↦ (a+b+1, a−b)`.  The forward direction
+  reads it left-to-right.  The backward direction observes that `4n+1 ≡ 1 (mod 4)`
+  forces one of the two squares even and the other odd, say `X = 2t`, `Y = 2s+1`;
+  then the *inverse* rotation `p = s+t`, `q = s−t` (no division needed) gives
+  `2n = p(p+1) + q(q+1)`, and each integer triangular value `k(k+1)/2` coincides
+  with a natural triangular number (since `T(k) = T(−1−k)`).
+
+  Composing with Mathlib's sum-of-two-squares characterization
+  (`Nat.eq_sq_add_sq_iff`) turns this into a complete arithmetic test
+  (`isSumTwoTriangular_iff_factorization`): `n` is a sum of two triangular numbers
+  iff every prime `≡ 3 (mod 4)` divides `4n+1` to an even power.  (Note the naive
+  "no prime factor `≡ 3 (mod 4)`" form is *false*: `n = 2 = T₁+T₁` while
+  `4·2+1 = 9 = 3²`.)
+
+  No `sorry`, no `axiom`, no `native_decide`.
+-/
+
+import Mathlib
+
+namespace TwoTrianglesTwoSquares
+
+/-- The `k`-th triangular number `T(k) = k(k+1)/2`. -/
+def tri (k : ℕ) : ℕ := k * (k + 1) / 2
+
+/-- `n` is a sum of two triangular numbers. -/
+def IsSumTwoTriangular (n : ℕ) : Prop := ∃ a b : ℕ, tri a + tri b = n
+
+@[simp] lemma tri_zero : tri 0 = 0 := rfl
+@[simp] lemma tri_one : tri 1 = 1 := rfl
+@[simp] lemma tri_two : tri 2 = 3 := rfl
+
+/-- Twice a triangular number is `k(k+1)` — the division is exact. -/
+lemma two_mul_tri (k : ℕ) : 2 * tri k = k * (k + 1) := by
+  unfold tri
+  exact Nat.mul_div_cancel' (Nat.even_mul_succ_self k).two_dvd
+
+/-- Integer form of `two_mul_tri`. -/
+lemma two_mul_tri_int (k : ℕ) : 2 * (tri k : ℤ) = (k : ℤ) * ((k : ℤ) + 1) := by
+  exact_mod_cast two_mul_tri k
+
+/-- For any integer index `k`, the integer `k(k+1)` equals `j(j+1)` for some
+*natural* `j` — because `T(k) = T(−1−k)`, so negative indices give nothing new. -/
+lemma exists_nat_tri_index (k : ℤ) : ∃ j : ℕ, (j : ℤ) * ((j : ℤ) + 1) = k * (k + 1) := by
+  rcases le_or_gt 0 k with hk | hk
+  · exact ⟨k.toNat, by rw [Int.toNat_of_nonneg hk]⟩
+  · refine ⟨(-1 - k).toNat, ?_⟩
+    have h : (0 : ℤ) ≤ -1 - k := by omega
+    rw [Int.toNat_of_nonneg h]; ring
+
+/-- For any integer `p`, `p(p+1)` is twice a natural triangular number. -/
+lemma exists_nat_two_mul_tri (p : ℤ) : ∃ j : ℕ, 2 * (tri j : ℤ) = p * (p + 1) := by
+  obtain ⟨j, hj⟩ := exists_nat_tri_index p
+  exact ⟨j, by rw [two_mul_tri_int]; exact hj⟩
+
+/-- The defining rotation identity:
+`4·(T(a) + T(b)) + 1 = (a+b+1)² + (a−b)²`. -/
+lemma sum_tri_identity (a b : ℕ) :
+    4 * ((tri a : ℤ) + (tri b : ℤ)) + 1 = ((a : ℤ) + b + 1) ^ 2 + ((a : ℤ) - b) ^ 2 := by
+  have hA := two_mul_tri_int a
+  have hB := two_mul_tri_int b
+  linear_combination 2 * hA + 2 * hB
+
+/-- **Forward direction.** A sum of two triangular numbers makes `4n+1` a sum of
+two integer squares. -/
+theorem isSumTwoTriangular_to_sq (n : ℕ) (h : IsSumTwoTriangular n) :
+    ∃ X Y : ℤ, X ^ 2 + Y ^ 2 = 4 * (n : ℤ) + 1 := by
+  obtain ⟨a, b, hab⟩ := h
+  refine ⟨(a : ℤ) + b + 1, (a : ℤ) - b, ?_⟩
+  have hn : (tri a : ℤ) + (tri b : ℤ) = (n : ℤ) := by exact_mod_cast hab
+  have hid := sum_tri_identity a b
+  linarith [hid, hn]
+
+/-- The arithmetic core of the backward direction: from
+`(2s+1)² + (2t)² = 4n+1` produce `p, q` with `2n = p(p+1) + q(q+1)`. -/
+lemma core_pq (n : ℕ) (s t : ℤ) (h : (2 * s + 1) ^ 2 + (2 * t) ^ 2 = 4 * (n : ℤ) + 1) :
+    ∃ p q : ℤ, 2 * (n : ℤ) = p * (p + 1) + q * (q + 1) := by
+  refine ⟨s + t, s - t, ?_⟩
+  have hexp : (s + t) * ((s + t) + 1) + (s - t) * ((s - t) + 1)
+      = 2 * s ^ 2 + 2 * t ^ 2 + 2 * s := by ring
+  have h' : 4 * s ^ 2 + 4 * s + 1 + 4 * t ^ 2 = 4 * (n : ℤ) + 1 := by linear_combination h
+  rw [hexp]; linarith [h']
+
+/-- **Backward direction.** If `4n+1` is a sum of two integer squares then `n` is
+a sum of two triangular numbers. -/
+theorem sq_to_isSumTwoTriangular (n : ℕ)
+    (h : ∃ X Y : ℤ, X ^ 2 + Y ^ 2 = 4 * (n : ℤ) + 1) : IsSumTwoTriangular n := by
+  obtain ⟨X, Y, hXY⟩ := h
+  -- Parity analysis: `4n+1 ≡ 1 (mod 4)` ⟹ exactly one of `X, Y` is odd.
+  obtain ⟨p, q, hpq⟩ : ∃ p q : ℤ, 2 * (n : ℤ) = p * (p + 1) + q * (q + 1) := by
+    rcases Int.even_or_odd X with hX | hX <;> rcases Int.even_or_odd Y with hY | hY
+    · -- both even: contradiction (sum ≡ 0, not 1, mod 4)
+      exfalso
+      obtain ⟨a, ha⟩ := hX; obtain ⟨b, hb⟩ := hY
+      have hcon : (4 : ℤ) * (a ^ 2 + b ^ 2) = 4 * (n : ℤ) + 1 := by
+        rw [ha, hb] at hXY; linear_combination hXY
+      have hdvd : (4 : ℤ) ∣ 1 := ⟨a ^ 2 + b ^ 2 - (n : ℤ), by linear_combination -hcon⟩
+      exact absurd hdvd (by norm_num)
+    · -- X even, Y odd
+      obtain ⟨t, ht⟩ := hX; obtain ⟨s, hs⟩ := hY
+      apply core_pq n s t
+      rw [hs, ht] at hXY; linear_combination hXY
+    · -- X odd, Y even
+      obtain ⟨s, hs⟩ := hX; obtain ⟨t, ht⟩ := hY
+      apply core_pq n s t
+      rw [hs, ht] at hXY; linear_combination hXY
+    · -- both odd: contradiction (sum ≡ 2, not 1, mod 4)
+      exfalso
+      obtain ⟨a, ha⟩ := hX; obtain ⟨b, hb⟩ := hY
+      have hcon : (4 : ℤ) * (a ^ 2 + a + b ^ 2 + b) + 2 = 4 * (n : ℤ) + 1 := by
+        rw [ha, hb] at hXY; linear_combination hXY
+      have hdvd : (4 : ℤ) ∣ 1 := ⟨(n : ℤ) - (a ^ 2 + a + b ^ 2 + b), by linear_combination hcon⟩
+      exact absurd hdvd (by norm_num)
+  -- Convert the integer indices `p, q` to natural triangular numbers.
+  obtain ⟨jp, hjp⟩ := exists_nat_two_mul_tri p
+  obtain ⟨jq, hjq⟩ := exists_nat_two_mul_tri q
+  refine ⟨jp, jq, ?_⟩
+  have hsum : 2 * ((tri jp : ℤ) + (tri jq : ℤ)) = 2 * (n : ℤ) := by
+    rw [hpq]; linear_combination hjp + hjq
+  have : (tri jp : ℤ) + (tri jq : ℤ) = (n : ℤ) := by linarith [hsum]
+  exact_mod_cast this
+
+/-- **Main equivalence.** `n` is a sum of two triangular numbers **iff** `4n+1`
+is a sum of two integer squares. -/
+theorem isSumTwoTriangular_iff (n : ℕ) :
+    IsSumTwoTriangular n ↔ ∃ X Y : ℤ, X ^ 2 + Y ^ 2 = 4 * (n : ℤ) + 1 :=
+  ⟨isSumTwoTriangular_to_sq n, sq_to_isSumTwoTriangular n⟩
+
+/-- Sum of two integer squares ↔ sum of two natural squares (the squared
+quantities only depend on absolute values). -/
+lemma int_sq_iff_nat_sq (m : ℕ) :
+    (∃ X Y : ℤ, X ^ 2 + Y ^ 2 = (m : ℤ)) ↔ ∃ x y : ℕ, x ^ 2 + y ^ 2 = m := by
+  constructor
+  · rintro ⟨X, Y, h⟩
+    refine ⟨X.natAbs, Y.natAbs, ?_⟩
+    have hx : ((X.natAbs : ℤ)) ^ 2 = X ^ 2 := by rw [← Int.abs_eq_natAbs, sq_abs]
+    have hy : ((Y.natAbs : ℤ)) ^ 2 = Y ^ 2 := by rw [← Int.abs_eq_natAbs, sq_abs]
+    have : ((X.natAbs : ℤ)) ^ 2 + ((Y.natAbs : ℤ)) ^ 2 = (m : ℤ) := by rw [hx, hy]; exact h
+    exact_mod_cast this
+  · rintro ⟨x, y, h⟩; exact ⟨x, y, by exact_mod_cast h⟩
+
+/-- Natural-number restatement of the main equivalence. -/
+theorem isSumTwoTriangular_iff_nat (n : ℕ) :
+    IsSumTwoTriangular n ↔ ∃ x y : ℕ, x ^ 2 + y ^ 2 = 4 * n + 1 := by
+  rw [isSumTwoTriangular_iff]
+  have hcast : (4 * (n : ℤ) + 1) = ((4 * n + 1 : ℕ) : ℤ) := by push_cast; ring
+  rw [hcast, int_sq_iff_nat_sq]
+
+/-- **Complete arithmetic characterization** via Mathlib's two-square theorem.
+`n` is a sum of two triangular numbers iff every prime `≡ 3 (mod 4)` divides
+`4n+1` to an even power (`padicValNat q (4n+1)`, equivalently `(4n+1).factorization q`). -/
+theorem isSumTwoTriangular_iff_factorization (n : ℕ) :
+    IsSumTwoTriangular n ↔
+      ∀ q ∈ (4 * n + 1).primeFactors, q % 4 = 3 → Even (padicValNat q (4 * n + 1)) := by
+  rw [isSumTwoTriangular_iff_nat]
+  have hflip : (∃ x y : ℕ, x ^ 2 + y ^ 2 = 4 * n + 1) ↔ (∃ a b : ℕ, 4 * n + 1 = a ^ 2 + b ^ 2) := by
+    constructor <;> rintro ⟨a, b, h⟩ <;> exact ⟨a, b, h.symm⟩
+  rw [hflip, Nat.eq_sq_add_sq_iff]
+
+end TwoTrianglesTwoSquares

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
@@ -4,6 +4,47 @@ Insights accumulated during research on this problem.
 
 ---
 
+## Session 2026-06-20 (researcher-11) — S8 SHIPPED oq-02: two-triangular ⟺ 4n+1 two-squares [verified, 0-axiom]
+
+**Mode**: FRESH (follow-up). **Outcome**: completed, new gallery entry
+`lagrange-four-squares-waring-g2-oq-03-oq-02`, file
+`proofs/Proofs/TwoTrianglesTwoSquares.lean` (178 L, 12 thm, 2 def, 0 axiom,
+0 sorry, no native_decide). Docker build green (7743 jobs). Registered in
+Proofs.lean. PR pending.
+
+**What.** The *two*-summand analogue of my just-merged Gauss Eureka companion
+(oq-01: three triangular ⟺ 8n+3 three squares, #27268). Headline
+`isSumTwoTriangular_iff`: for every n, `n = T(a)+T(b)` ⟺ `4n+1` is a sum of two
+integer squares. Bridge = rotation identity `4·(T a+T b)+1=(a+b+1)²+(a−b)²`.
+
+**Why it matters / how it differs from oq-01.** This one is **UNCONDITIONAL and
+fully axiom-free** — the two-square theorem is in Mathlib (`Nat.eq_sq_add_sq_iff`),
+whereas Eureka still rests on the open three-square sufficiency axiom. So I also
+ship the *complete arithmetic test* `isSumTwoTriangular_iff_factorization`:
+`n=T(a)+T(b)` ⟺ every prime `q≡3 (mod 4)` divides `4n+1` to an even power.
+
+**Gotchas captured:**
+- Backward direction is **division-free**: `4n+1≡1 (mod 4)` ⟹ one square even
+  `=2t`, one odd `=2s+1`; set `p=s+t, q=s−t` (integers) ⟹ `2n=p(p+1)+q(q+1)`.
+  The two non-mixed parity cases die as `(4:ℤ) ∣ 1` (anon ctor + `linear_combination`).
+- Integer→nat triangular bridge: `exists_nat_tri_index` uses `T(k)=T(−1−k)`
+  (`k(k+1)=(−1−k)(−k)`), `Int.toNat_of_nonneg` on the nonneg of `{k, −1−k}`.
+- **`Nat.eq_sq_add_sq_iff` RHS uses `padicValNat q m`, NOT `m.factorization q`** —
+  state the corollary with `padicValNat` so `rw [..., Nat.eq_sq_add_sq_iff]` closes
+  by `Iff.rfl`. Its LHS is `∃ a b, m = a²+b²` (number on LEFT) → add a flip lemma.
+- **TRAP:** the naive "no prime factor ≡3 mod4" form is FALSE: `n=2=T₁+T₁` but
+  `4·2+1=9=3²`. Must use even-power. Certified in
+  `verify_two_triangular_two_squares.py` ([A] 0 mismatches n<20000, [B] identity,
+  [C] naive-fail at n=2 + even-power PASS).
+- `le_or_lt` deprecated → `le_or_gt`.
+
+**Parent status unchanged:** the hard direction `not_excluded_form_is_sum_three_sq`
+(ThreeSquares.lean:1838, lone axiom) still needs the 2D-slice Minkowski /
+Davenport–Cassels build (>500 L, not in Mathlib; active across
+ThreeSquaresDavenportCassels/RationalBridge/SquarefreeReduction). Not touched here.
+
+---
+
 ## Problem Understanding
 
 Goal: the **"if" direction** of Legendre's three-square theorem,

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_two_triangular_two_squares.py
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_two_triangular_two_squares.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Independent build-free certificate for the two-triangular / 4n+1 two-square slice.
+
+Checks, by brute force:
+  [A] n is a sum of two triangular numbers  <=>  4n+1 is a sum of two squares.
+  [B] the rotation identity 4*(T a + T b)+1 = (a+b+1)^2 + (a-b)^2  over a Z^2 box.
+  [C] the naive 'no prime factor == 3 mod 4' form is FALSE (n=2: 9=3^2),
+      while the even-power form holds.
+Companion to proofs/Proofs/TwoTrianglesTwoSquares.lean.
+"""
+import math
+
+def is_tri(m):
+    if m < 0: return False
+    k = (math.isqrt(8*m+1)-1)//2
+    return any(kk>=0 and kk*(kk+1)//2==m for kk in (k-1,k,k+1))
+
+def sum_two_tri(n):
+    a=0
+    while a*(a+1)//2 <= n:
+        if is_tri(n - a*(a+1)//2): return True
+        a+=1
+    return False
+
+def sum_two_sq(m):
+    x=0
+    while x*x<=m:
+        r=m-x*x
+        s=math.isqrt(r)
+        if s*s==r: return True
+        x+=1
+    return False
+
+# [A]
+bad=0; N=20000
+for n in range(N):
+    if sum_two_tri(n) != sum_two_sq(4*n+1): bad+=1
+print(f"[A] checked n in [0,{N}): mismatches = {bad}")
+
+# [B]
+ok=True
+T=lambda k:k*(k+1)//2
+for a in range(-50,50):
+    for b in range(-50,50):
+        if 4*(T(a)+T(b))+1 != (a+b+1)**2+(a-b)**2: ok=False
+print(f"[B] rotation identity over [-50,50]^2: {'PASS' if ok else 'FAIL'}")
+
+# [C]
+def factor(m):
+    f={}; d=2
+    while d*d<=m:
+        while m%d==0: f[d]=f.get(d,0)+1; m//=d
+        d+=1
+    if m>1: f[m]=f.get(m,0)+1
+    return f
+naive_fail=False; evenpow_ok=True
+for n in range(N):
+    m=4*n+1; f=factor(m)
+    no3 = all(not(p%4==3) for p in f)
+    evenpow = all((e%2==0) for p,e in f.items() if p%4==3)
+    if sum_two_tri(n) != no3 and not naive_fail:
+        naive_fail=True
+        print(f"[C] naive 'no prime==3mod4' FALSE first at n={n}: 4n+1={m}={f}, two-tri={sum_two_tri(n)}")
+    if sum_two_tri(n) != evenpow: evenpow_ok=False
+print(f"[C] even-power characterization over [0,{N}): {'PASS' if evenpow_ok else 'FAIL'}")

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-02/meta.json
@@ -1,0 +1,121 @@
+{
+  "id": "lagrange-four-squares-waring-g2-oq-03-oq-02",
+  "slug": "lagrange-four-squares-waring-g2-oq-03-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "TwoTrianglesTwoSquares",
+    "lineCount": 178,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/TwoTrianglesTwoSquares.lean",
+    "sorries": 0
+  },
+  "title": "Sums of Two Triangular Numbers and the 4n+1 Two-Square Slice",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/TwoTrianglesTwoSquares.lean",
+    "tags": [
+      "number-theory",
+      "sums-of-squares",
+      "two-square-theorem",
+      "triangular-numbers",
+      "two-triangular-numbers",
+      "additive-number-theory",
+      "geometry-of-numbers",
+      "reduction",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 178,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "badge": "original",
+    "originalContributions": [
+      "isSumTwoTriangular_iff: the headline equivalence — for every natural number n, n is a sum of two triangular numbers T(k)=k(k+1)/2 IF AND ONLY IF 4n+1 is a sum of two integer squares. This is the two-summand analogue of the gallery's Gauss Eureka entry (three triangular ⟺ 8n+3 three squares), proved unconditionally and axiom-free.",
+      "isSumTwoTriangular_iff_nat: the natural-number restatement, n is a sum of two triangular numbers iff 4n+1 = x²+y² for naturals x,y; obtained by composing the integer equivalence with the int/nat absolute-value bridge.",
+      "isSumTwoTriangular_iff_factorization: the COMPLETE arithmetic characterization via Mathlib's two-square theorem (Nat.eq_sq_add_sq_iff) — n is a sum of two triangular numbers iff every prime q ≡ 3 (mod 4) divides 4n+1 to an even power. Because the two-square theorem (unlike three-square sufficiency) is fully in Mathlib, this gives a decidable test, making the result strictly stronger than the conditional Gauss Eureka companion. The docstring records the trap that the naive 'no prime factor ≡ 3 mod 4' form is FALSE (n=2=T₁+T₁ while 4·2+1=9=3²).",
+      "sum_tri_identity: the rotation identity 4·(T(a)+T(b))+1 = (a+b+1)² + (a−b)², the linear change of variables (a,b) ↦ (a+b+1, a−b) that bridges triangular sums and two-square representations of 4n+1.",
+      "sq_to_isSumTwoTriangular: the backward direction handled DIVISION-FREE — 4n+1 ≡ 1 (mod 4) forces one square even (=2t) and one odd (=2s+1), and the inverse rotation p=s+t, q=s−t (integers, no halving) yields 2n = p(p+1)+q(q+1); the two non-mixed parity cases are dispatched as 4 ∣ 1 contradictions.",
+      "exists_nat_tri_index: every integer index k gives k(k+1) = j(j+1) for a natural j, formalizing T(k)=T(−1−k) so that negative integer triangular indices contribute nothing new — the lemma that lets the integer construction land back in natural triangular numbers.",
+      "int_sq_iff_nat_sq: a sum of two integer squares equals a sum of two natural squares (the squared quantities depend only on |·|), the bridge from the integer equivalence to Mathlib's natural-number two-square characterization."
+    ],
+    "prerequisites": [
+      "Nat.eq_sq_add_sq_iff (Mathlib): a natural number is a sum of two squares iff every prime ≡ 3 (mod 4) in its factorization occurs to an even power — the two-square theorem that makes the characterization unconditional.",
+      "Nat.mul_div_cancel' and Nat.even_mul_succ_self: exactness of the triangular-number division 2·T(k)=k(k+1).",
+      "Int.even_or_odd, Int.toNat_of_nonneg, Int.abs_eq_natAbs, sq_abs: the parity split of 4n+1 and the integer↔natural square/triangular bridges."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.eq_sq_add_sq_iff",
+        "description": "A natural n is a sum of two squares iff every prime q ≡ 3 (mod 4) has Even (padicValNat q n); supplies the complete arithmetic characterization, replacing the open three-square sufficiency axiom that the Gauss Eureka companion still needs.",
+        "module": "Mathlib.NumberTheory.SumTwoSquares"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel'",
+        "description": "Exact division a ∣ b → a · (b / a) = b; gives 2 · (k(k+1)/2) = k(k+1) so triangular numbers behave as exact halves.",
+        "module": "Mathlib.Algebra.Order.Group.Nat"
+      },
+      {
+        "theorem": "Int.even_or_odd",
+        "description": "Every integer is even or odd; drives the parity case split that forces, from 4n+1 ≡ 1 (mod 4), exactly one of the two squares to be odd.",
+        "module": "Mathlib.Algebra.Parity"
+      },
+      {
+        "theorem": "Int.toNat_of_nonneg",
+        "description": "For 0 ≤ a, ↑a.toNat = a; converts the integer triangular indices p, q (one possibly negative) into the natural indices the predicate IsSumTwoTriangular requires, using k(k+1)=(−1−k)(−k).",
+        "module": "Mathlib.Data.Int.Order"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "lagrange-four-squares-waring-g2-oq-03-oq-02-oq-01",
+      "question": "Quantitative two-triangular count: the number of ordered representations of n as T(a)+T(b) equals the number of representations of 4n+1 as an ordered sum of two squares (the rotation (a,b)↦(a+b+1,a−b) is a bijection ℤ²→{(X,Y): X+Y odd}). Formalize the counting identity r_{2△}(n) = r₂(4n+1) and connect it to the sum-of-two-squares function.",
+      "significance": "medium"
+    },
+    {
+      "id": "lagrange-four-squares-waring-g2-oq-03-oq-02-oq-02",
+      "question": "Unify the two-, three-, and four-triangular slices: two triangular ⟺ 4n+1 two squares (this entry), three triangular ⟺ 8n+3 three squares (Gauss Eureka companion). Is there a single 'd·n + c(d) ⟺ d squares' meta-statement, and does the four-triangular case correspond cleanly to Lagrange's four-square theorem on an arithmetic progression?",
+      "significance": "high"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "The two-summand analogue of the Gauss Eureka companion. Where that entry needs the still-open three-square sufficiency axiom to conclude unconditionally, this entry is fully unconditional and axiom-free because Mathlib supplies the two-square theorem, and it adds the complete arithmetic characterization via prime factorization of 4n+1."
+    },
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03",
+      "relationship": "depends-on",
+      "description": "Companion to the parent three-square sufficiency study: it records the elementary 4n+1 ⟷ two-triangular bijection in the same sums-of-squares ↔ triangular-numbers circle of ideas, using the (a,b)↦(a+b+1,a−b) rotation."
+    }
+  ],
+  "references": [
+    {
+      "title": "Disquisitiones Arithmeticae",
+      "author": "Carl Friedrich Gauss",
+      "year": "1801",
+      "venue": "Articles 291–293",
+      "description": "Gauss's theory of representations by binary quadratic forms and triangular/polygonal numbers; the two-triangular ⟷ 4n+1 sum-of-two-squares correspondence sits in this circle of ideas."
+    },
+    {
+      "title": "Sur la théorie des nombres",
+      "author": "Pierre de Fermat / Leonhard Euler",
+      "year": "1640/1749",
+      "venue": "Fermat's Christmas theorem; Euler's proof",
+      "description": "The two-square theorem characterizing which integers are sums of two squares (every prime ≡ 3 mod 4 to an even power), used here via Mathlib's Nat.eq_sq_add_sq_iff to make the triangular characterization unconditional."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For every natural number n, n is a sum of two triangular numbers T(k)=k(k+1)/2 if and only if 4n+1 is a sum of two integer squares (isSumTwoTriangular_iff). The bridge is the rotation identity 4·(T(a)+T(b))+1 = (a+b+1)²+(a−b)²: the forward direction reads it left-to-right; the backward direction uses that 4n+1 ≡ 1 (mod 4) forces one square even (2t) and one odd (2s+1), so the inverse rotation p=s+t, q=s−t gives 2n = p(p+1)+q(q+1) with no division, and each integer triangular value equals a natural one since T(k)=T(−1−k). Composing with Mathlib's two-square theorem (Nat.eq_sq_add_sq_iff) yields the complete arithmetic test isSumTwoTriangular_iff_factorization: n is a sum of two triangular numbers iff every prime ≡ 3 (mod 4) divides 4n+1 to an even power. 178 lines, 12 theorems/lemmas, 2 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This is the unconditional two-summand analogue of the gallery's Gauss Eureka entry (three triangular ⟺ 8n+3 three squares). Because the two-square theorem is available in Mathlib while three-square sufficiency is not, the two-triangular result is fully machine-checked end to end and even delivers a decidable factorization test, whereas Eureka still rests on an axiom. The pair sharpens the general picture that 'sums of d triangular numbers' is exactly a fixed arithmetic-progression slice of 'sums of d squares', and points toward a unified d=2,3,4 statement (the open question) bridging to Lagrange's four-square theorem."
+  }
+}


### PR DESCRIPTION
## Summary

The **two-summand analogue** of the just-merged Gauss Eureka companion (oq-01, #27268: *three* triangular ⟺ `8n+3` three squares). Adds `proofs/Proofs/TwoTrianglesTwoSquares.lean` + gallery entry `lagrange-four-squares-waring-g2-oq-03-oq-02`.

**Headline (`isSumTwoTriangular_iff`).** For every natural `n`:
> `n` is a sum of two triangular numbers `T(k)=k(k+1)/2`  ⟺  `4n+1` is a sum of two integer squares.

The bridge is the rotation identity `4·(T a + T b) + 1 = (a+b+1)² + (a−b)²` — the linear change of variables `(a,b) ↦ (a+b+1, a−b)`.

**Unconditional & axiom-free.** Unlike Eureka (which rests on the still-open three-square *sufficiency* axiom), the two-square theorem is in Mathlib (`Nat.eq_sq_add_sq_iff`), so this result is fully machine-checked end to end. It therefore also delivers the **complete arithmetic test** `isSumTwoTriangular_iff_factorization`: `n` is a sum of two triangular numbers iff every prime `q ≡ 3 (mod 4)` divides `4n+1` to an even power.

> Trap recorded in the file: the naive *"no prime factor ≡ 3 (mod 4)"* form is **false** — `n=2=T₁+T₁` while `4·2+1 = 9 = 3²`.

## Proof notes
- **Backward direction is division-free**: `4n+1 ≡ 1 (mod 4)` forces one square even (`2t`) and one odd (`2s+1`); the inverse rotation `p=s+t, q=s−t` (integers) gives `2n = p(p+1)+q(q+1)`. The two non-mixed parity cases collapse to `(4:ℤ) ∣ 1` contradictions.
- Integer→natural triangular bridge uses `T(k)=T(−1−k)` so negative indices contribute nothing new.

## Verification
- Docker build green: **7743 jobs**, 0 sorries, 0 axioms, no `native_decide`. Registered in `Proofs.lean`.
- Named theorems depend only on `propext`, `Classical.choice`, `Quot.sound`.
- Independent stdlib certificate `verify_two_triangular_two_squares.py`: [A] 0 mismatches for `n < 20000`, [B] rotation identity over `[-50,50]²`, [C] naive form fails at `n=2`, even-power form PASS.

178 lines, 12 theorems/lemmas, 2 defs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)