### PR TITLE
audit: mark lagrange-four-squares-waring-g2-oq-03-oq-02 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17451,6 +17451,12 @@
       "issues": [],
       "lastAudited": "2026-06-20T00:00:00Z",
       "result": "clean"
+    },
+    "lagrange-four-squares-waring-g2-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-20T00:00:00Z",
+      "result": "clean"
     }
   },
   "version": 1,


### PR DESCRIPTION
Persists the clean audit mark for the newly merged gallery entry `lagrange-four-squares-waring-g2-oq-03-oq-02` (#27272).

## Audit result: CLEAN

Deep-audited `proofs/Proofs/TwoTrianglesTwoSquares.lean`:
- **12 theorems, 2 defs** — matches meta.json exactly
- **0 sorry, 0 axiom, 0 native_decide** (verified after stripping comments)
- **No structures/classes** → no structure-encoded assumptions
- **No True stubs**, no trivial Mathlib re-export
- Genuine result: sum of two triangular numbers ⟺ 4n+1 is a sum of two squares, composing Mathlib's `Nat.eq_sq_add_sq_iff` via an explicit lattice rotation

`status: verified` / `badge: original` / `axiomCount: 0` are all defensible.

The slug was absent from the audit-tracker entries map (new gallery proofs ship without a tracker key → perpetual "never audited"). This adds the clean entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)