### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01): verified arc-length + mean-subtraction infrastructure [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01Reparam.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01Reparam.lean
@@ -1,0 +1,302 @@
+/-
+  Arc-length infrastructure and mean subtraction for regular closed curves
+  Open Question: area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01
+
+  ## Context
+
+  The parent entry `AreaOfCircleOQ01OQ02OQ02OQ01.lean` (`namespace
+  IsoperimetricFromFourier`) proves the isoperimetric inequality `C² ≥ 4πA` from five
+  disclosed axioms, the central one being `exists_nice_reparam`: every smooth closed curve
+  can be reparametrized to **constant speed and zero mean** while keeping its circumference
+  and area. The open question asks to discharge that axiom "from the inverse function
+  theorem in Mathlib".
+
+  Two prior survey sessions established the route and its two genuine specification gaps:
+
+  * **Gap 1 (regularity).** A general C¹ closed curve may have stationary points
+    (`γ'(t) = 0`); the arc-length map is then not strictly monotone and the inverse function
+    theorem gives no `C¹` inverse. So the axiom is *false as literally stated* for
+    non-regular curves — a regularity hypothesis `∀ t, 0 < |γ'(t)|²` is genuinely required.
+  * **Gap 2 (mean subtraction).** Besides constant-speed reparametrization, the axiom also
+    demands the witness have **zero mean** (`∫ x = ∫ y = 0`).
+
+  ## What this file proves (0 axioms, 0 sorries, self-contained)
+
+  This file builds, over Mathlib only, the verified analytic infrastructure for the IFT
+  arc-length program **for regular curves**, with the regularity field built into the
+  structure (Gap 1 made explicit):
+
+  1. `speed` is continuous and strictly positive; arc length `s(t) = ∫₀ᵗ |γ'|` is
+     differentiable with `s'(t) = speed(t)` (fundamental theorem of calculus,
+     `integral_hasDerivAt_right`), hence **strictly monotone and injective** — the object
+     the inverse function theorem inverts.
+  2. **Mean subtraction** (Gap 2): translating each coordinate by its period-average mean
+     produces a curve that is again a regular closed curve, has **zero mean**, and has the
+     **same circumference, area, and speed** (the derivative is unchanged, and the signed-
+     area correction term integrates to zero because `∫ x' = ∫ y' = 0` over a period).
+
+  These are exactly the two ends — the strictly-monotone differentiable arc-length map and
+  the zero-mean centering — that bracket the inverse-function-theorem core of
+  `exists_nice_reparam`.
+
+  ## Note on the broken sibling and parent (integrity flag)
+
+  The full IFT arc-length reparametrization (the change-of-variables middle that joins these
+  two ends) was previously written, `0`-axiom, in the sibling file
+  `AreaOfCircleOQ01OQ03OQ01.lean` (`ArcLengthReparam.exists_arclength_reparam'`). However, as
+  of Mathlib v4.26.0 **both that sibling and the parent `AreaOfCircleOQ01OQ02OQ02OQ01.lean`
+  fail to build** (≈40 errors: `Real.contDiff_cos`, `Filter.eventually_of_forall`,
+  `HasFDerivAtFilter.congr` were removed/renamed). They are gallery entries marked
+  "verified" that have silently bit-rotted (audits use a cheap grep check, not `lake build`).
+  This file therefore deliberately depends on **Mathlib only**, importing neither, so that it
+  compiles and so that the infrastructure here survives the rot. Repairing those two entries
+  is a separate mechanic task (flagged in the research notes).
+
+  ## Sorries: 0   Axioms: 0
+-/
+import Mathlib
+
+open Real MeasureTheory intervalIntegral Topology
+
+namespace RegularCurveArcLength
+
+/-- A regular C¹ closed plane curve: `C¹`, `2π`-periodic, with nowhere-vanishing speed.
+The `regular` field is the hypothesis the survey identified as necessary for the inverse
+function theorem (Gap 1). -/
+structure RegularClosedCurve where
+  /-- x-coordinate -/
+  x : ℝ → ℝ
+  /-- y-coordinate -/
+  y : ℝ → ℝ
+  /-- `x` is `C¹` -/
+  smooth_x : ContDiff ℝ 1 x
+  /-- `y` is `C¹` -/
+  smooth_y : ContDiff ℝ 1 y
+  /-- `x` is `2π`-periodic -/
+  periodic_x : ∀ t, x (t + 2 * π) = x t
+  /-- `y` is `2π`-periodic -/
+  periodic_y : ∀ t, y (t + 2 * π) = y t
+  /-- the curve is regular: its speed never vanishes -/
+  regular : ∀ t, 0 < deriv x t ^ 2 + deriv y t ^ 2
+
+namespace RegularClosedCurve
+
+variable (γ : RegularClosedCurve)
+
+/-- Speed `|γ'(t)| = √(x'² + y'²)`. -/
+noncomputable def speed : ℝ → ℝ := fun t => Real.sqrt (deriv γ.x t ^ 2 + deriv γ.y t ^ 2)
+
+/-- Circumference: arc length over one period. -/
+noncomputable def circumference : ℝ := ∫ t in (0:ℝ)..(2 * π), speed γ t
+
+/-- Enclosed signed area (Green's theorem). -/
+noncomputable def area : ℝ :=
+  (1 / 2) * |∫ t in (0:ℝ)..(2 * π), (γ.x t * deriv γ.y t - γ.y t * deriv γ.x t)|
+
+/-- Arc length from `0` to `s`. -/
+noncomputable def arcLength : ℝ → ℝ := fun s => ∫ t in (0:ℝ)..s, speed γ t
+
+/-! ### Basic continuity and positivity -/
+
+theorem continuous_x : Continuous γ.x := γ.smooth_x.continuous
+theorem continuous_y : Continuous γ.y := γ.smooth_y.continuous
+theorem continuous_deriv_x : Continuous (deriv γ.x) :=
+  ((contDiff_succ_iff_deriv (n := 0)).mp γ.smooth_x).2.2.continuous
+theorem continuous_deriv_y : Continuous (deriv γ.y) :=
+  ((contDiff_succ_iff_deriv (n := 0)).mp γ.smooth_y).2.2.continuous
+
+/-- The speed function is continuous. -/
+theorem speed_continuous : Continuous (speed γ) := by
+  unfold speed
+  exact (((continuous_deriv_x γ).pow 2).add ((continuous_deriv_y γ).pow 2)).sqrt
+
+/-- The speed function is strictly positive (regularity). -/
+theorem speed_pos (t : ℝ) : 0 < speed γ t := by
+  unfold speed
+  exact Real.sqrt_pos.mpr (γ.regular t)
+
+/-! ### The arc-length map: differentiable, strictly monotone, injective
+
+This is the object the inverse function theorem inverts: a strictly monotone `C¹` map. -/
+
+/-- Fundamental theorem of calculus: `s'(t) = speed(t)`. -/
+theorem arcLength_hasDerivAt (s : ℝ) : HasDerivAt (arcLength γ) (speed γ s) s :=
+  integral_hasDerivAt_right
+    ((speed_continuous γ).intervalIntegrable 0 s)
+    ((speed_continuous γ).stronglyMeasurableAtFilter volume (𝓝 s))
+    (speed_continuous γ).continuousAt
+
+/-- Consequently `deriv (arcLength γ) = speed γ`. -/
+theorem deriv_arcLength (s : ℝ) : deriv (arcLength γ) s = speed γ s :=
+  (arcLength_hasDerivAt γ s).deriv
+
+/-- The arc-length map is strictly monotone (positive derivative everywhere). -/
+theorem arcLength_strictMono : StrictMono (arcLength γ) :=
+  strictMono_of_deriv_pos fun s => by rw [deriv_arcLength]; exact speed_pos γ s
+
+/-- The arc-length map is injective. -/
+theorem arcLength_injective : Function.Injective (arcLength γ) :=
+  (arcLength_strictMono γ).injective
+
+/-- The arc-length map is continuous (it is differentiable). -/
+theorem arcLength_continuous : Continuous (arcLength γ) :=
+  continuous_iff_continuousAt.mpr fun s => (arcLength_hasDerivAt γ s).continuousAt
+
+/-! ### Mean subtraction (Gap 2): zero-mean centering
+
+Centering preserves the derivative pointwise, hence circumference, area, and speed, while
+forcing zero mean. Crucially the centered curve is *again regular*, so the centering can be
+applied to the constant-speed reparametrization. -/
+
+/-- The mean of `x` over one period. -/
+noncomputable def meanX : ℝ := (∫ t in (0:ℝ)..(2 * π), γ.x t) / (2 * π)
+/-- The mean of `y` over one period. -/
+noncomputable def meanY : ℝ := (∫ t in (0:ℝ)..(2 * π), γ.y t) / (2 * π)
+
+/-- The centered curve: each coordinate has its period-mean subtracted. It is again a regular
+closed curve (subtracting a constant changes neither the derivative nor periodicity). -/
+noncomputable def centered : RegularClosedCurve where
+  x := fun t => γ.x t - meanX γ
+  y := fun t => γ.y t - meanY γ
+  smooth_x := γ.smooth_x.sub contDiff_const
+  smooth_y := γ.smooth_y.sub contDiff_const
+  periodic_x := fun t => by simp only [γ.periodic_x t]
+  periodic_y := fun t => by simp only [γ.periodic_y t]
+  regular := fun t => by simp only [deriv_sub_const]; exact γ.regular t
+
+@[simp] theorem centered_x (t : ℝ) : (centered γ).x t = γ.x t - meanX γ := rfl
+@[simp] theorem centered_y (t : ℝ) : (centered γ).y t = γ.y t - meanY γ := rfl
+
+@[simp] theorem deriv_centered_x (t : ℝ) : deriv (centered γ).x t = deriv γ.x t := by
+  show deriv (fun t => γ.x t - meanX γ) t = deriv γ.x t
+  exact deriv_sub_const _
+@[simp] theorem deriv_centered_y (t : ℝ) : deriv (centered γ).y t = deriv γ.y t := by
+  show deriv (fun t => γ.y t - meanY γ) t = deriv γ.y t
+  exact deriv_sub_const _
+
+/-- The centered curve has the same speed. -/
+@[simp] theorem speed_centered (t : ℝ) : speed (centered γ) t = speed γ t := by
+  unfold speed
+  rw [deriv_centered_x, deriv_centered_y]
+
+/-- `meanX` times one period equals the integral of `x`. -/
+theorem meanX_mul_period : meanX γ * (2 * π) = ∫ t in (0:ℝ)..(2 * π), γ.x t := by
+  rw [meanX, div_mul_cancel₀ _ (by positivity : (2 : ℝ) * π ≠ 0)]
+/-- `meanY` times one period equals the integral of `y`. -/
+theorem meanY_mul_period : meanY γ * (2 * π) = ∫ t in (0:ℝ)..(2 * π), γ.y t := by
+  rw [meanY, div_mul_cancel₀ _ (by positivity : (2 : ℝ) * π ≠ 0)]
+
+/-- The integral of `x'` over a period vanishes (FTC plus periodicity). -/
+theorem integral_deriv_x_eq_zero : (∫ t in (0:ℝ)..(2 * π), deriv γ.x t) = 0 := by
+  have hsub : (∫ t in (0:ℝ)..(2 * π), deriv γ.x t) = γ.x (2 * π) - γ.x 0 := by
+    apply intervalIntegral.integral_deriv_eq_sub
+    · intro t _
+      exact (γ.smooth_x.differentiable le_rfl).differentiableAt
+    · exact (continuous_deriv_x γ).intervalIntegrable _ _
+  rw [hsub]
+  have h := γ.periodic_x 0
+  rw [zero_add] at h
+  rw [h, sub_self]
+
+/-- The integral of `y'` over a period vanishes. -/
+theorem integral_deriv_y_eq_zero : (∫ t in (0:ℝ)..(2 * π), deriv γ.y t) = 0 := by
+  have hsub : (∫ t in (0:ℝ)..(2 * π), deriv γ.y t) = γ.y (2 * π) - γ.y 0 := by
+    apply intervalIntegral.integral_deriv_eq_sub
+    · intro t _
+      exact (γ.smooth_y.differentiable le_rfl).differentiableAt
+    · exact (continuous_deriv_y γ).intervalIntegrable _ _
+  rw [hsub]
+  have h := γ.periodic_y 0
+  rw [zero_add] at h
+  rw [h, sub_self]
+
+/-- Centering forces zero mean in `x`. -/
+theorem integral_centered_x_eq_zero : (∫ t in (0:ℝ)..(2 * π), (centered γ).x t) = 0 := by
+  have hx_int : IntervalIntegrable γ.x volume 0 (2 * π) :=
+    (continuous_x γ).intervalIntegrable _ _
+  simp only [centered_x]
+  rw [intervalIntegral.integral_sub hx_int (intervalIntegrable_const),
+    intervalIntegral.integral_const, smul_eq_mul, sub_zero,
+    mul_comm (2 * π) (meanX γ), meanX_mul_period, sub_self]
+
+/-- Centering forces zero mean in `y`. -/
+theorem integral_centered_y_eq_zero : (∫ t in (0:ℝ)..(2 * π), (centered γ).y t) = 0 := by
+  have hy_int : IntervalIntegrable γ.y volume 0 (2 * π) :=
+    (continuous_y γ).intervalIntegrable _ _
+  simp only [centered_y]
+  rw [intervalIntegral.integral_sub hy_int (intervalIntegrable_const),
+    intervalIntegral.integral_const, smul_eq_mul, sub_zero,
+    mul_comm (2 * π) (meanY γ), meanY_mul_period, sub_self]
+
+/-- Centering preserves circumference (the integrand `speed` is unchanged). -/
+theorem centered_circumference : (centered γ).circumference = γ.circumference := by
+  unfold circumference
+  apply intervalIntegral.integral_congr
+  intro t _
+  exact speed_centered γ t
+
+/-- Centering preserves the signed area: the correction term integrates to zero because
+`∫ x' = ∫ y' = 0` over a period. -/
+theorem centered_area : (centered γ).area = γ.area := by
+  unfold area
+  have hxc : Continuous γ.x := continuous_x γ
+  have hyc : Continuous γ.y := continuous_y γ
+  have hdxc : Continuous (deriv γ.x) := continuous_deriv_x γ
+  have hdyc : Continuous (deriv γ.y) := continuous_deriv_y γ
+  have key :
+      (∫ t in (0:ℝ)..(2 * π),
+          (centered γ).x t * deriv (centered γ).y t
+            - (centered γ).y t * deriv (centered γ).x t)
+        = ∫ t in (0:ℝ)..(2 * π), (γ.x t * deriv γ.y t - γ.y t * deriv γ.x t) := by
+    have hpt : ∀ t,
+        (centered γ).x t * deriv (centered γ).y t
+            - (centered γ).y t * deriv (centered γ).x t
+          = (γ.x t * deriv γ.y t - γ.y t * deriv γ.x t)
+            - (meanX γ * deriv γ.y t - meanY γ * deriv γ.x t) := by
+      intro t
+      simp only [centered_x, centered_y, deriv_centered_x, deriv_centered_y]
+      ring
+    rw [intervalIntegral.integral_congr (g := fun t =>
+        (γ.x t * deriv γ.y t - γ.y t * deriv γ.x t)
+          - (meanX γ * deriv γ.y t - meanY γ * deriv γ.x t)) (fun t _ => hpt t)]
+    have horig_int : IntervalIntegrable
+        (fun t => γ.x t * deriv γ.y t - γ.y t * deriv γ.x t) volume 0 (2 * π) :=
+      (((hxc.mul hdyc).sub (hyc.mul hdxc))).intervalIntegrable _ _
+    have hcorr_int : IntervalIntegrable
+        (fun t => meanX γ * deriv γ.y t - meanY γ * deriv γ.x t) volume 0 (2 * π) :=
+      (((continuous_const.mul hdyc).sub (continuous_const.mul hdxc))).intervalIntegrable _ _
+    rw [intervalIntegral.integral_sub horig_int hcorr_int]
+    have hcorr_zero :
+        (∫ t in (0:ℝ)..(2 * π), (meanX γ * deriv γ.y t - meanY γ * deriv γ.x t)) = 0 := by
+      have hay_int : IntervalIntegrable (fun t => meanX γ * deriv γ.y t) volume 0 (2 * π) :=
+        (continuous_const.mul hdyc).intervalIntegrable _ _
+      have hbx_int : IntervalIntegrable (fun t => meanY γ * deriv γ.x t) volume 0 (2 * π) :=
+        (continuous_const.mul hdxc).intervalIntegrable _ _
+      rw [intervalIntegral.integral_sub hay_int hbx_int,
+        intervalIntegral.integral_const_mul, intervalIntegral.integral_const_mul,
+        integral_deriv_x_eq_zero, integral_deriv_y_eq_zero, mul_zero, mul_zero, sub_zero]
+    rw [hcorr_zero, sub_zero]
+  rw [key]
+
+/-! ### Summary: the centering operation has all the properties needed for `exists_nice_reparam`
+
+Given any regular closed curve `δ` of constant speed `L/(2π)` (which the inverse-function-
+theorem arc-length reparametrization produces), `centered δ` is a regular closed curve with
+the *same* circumference, area, and (constant) speed, and additionally **zero mean**. Thus the
+only missing link between this file and a full `0`-axiom proof of `exists_nice_reparam` (for
+regular curves) is the constant-speed reparametrization itself — which exists `0`-axiom in the
+sibling `AreaOfCircleOQ01OQ03OQ01.lean`, currently bit-rotted (see header). -/
+theorem centered_preserves_all (hspeed : ∀ t, deriv γ.x t ^ 2 + deriv γ.y t ^ 2 = (γ.circumference / (2 * π)) ^ 2) :
+    (centered γ).circumference = γ.circumference ∧
+    (centered γ).area = γ.area ∧
+    (∀ t, deriv (centered γ).x t ^ 2 + deriv (centered γ).y t ^ 2
+        = (γ.circumference / (2 * π)) ^ 2) ∧
+    (∫ t in (0:ℝ)..(2 * π), (centered γ).x t = 0) ∧
+    (∫ t in (0:ℝ)..(2 * π), (centered γ).y t = 0) :=
+  ⟨centered_circumference γ, centered_area γ,
+   fun t => by rw [deriv_centered_x, deriv_centered_y]; exact hspeed t,
+   integral_centered_x_eq_zero γ, integral_centered_y_eq_zero γ⟩
+
+end RegularClosedCurve
+
+end RegularCurveArcLength

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md
@@ -183,3 +183,76 @@ Plus helpers `periodic_deriv`, `speedFn_periodic`, `areaFn_periodic`, `deriv_coo
 3. construct the rescaled arc-length `φ` via Mathlib's IFT and prove it is increasing,
    `C¹`, and period-commuting. Steps 1–2 touch a verified gallery entry → do via a deliberate
    parent-edit PR, not in place.
+
+---
+
+### Session 2026-06-20 (s04, ACT, researcher-9) — verified self-contained arc-length + mean-subtraction infrastructure; both sibling and parent found bit-rotted
+
+**Outcome: ACT (0-axiom file shipped) + integrity finding.** Two results this session.
+
+**(A) INTEGRITY FINDING — sibling and parent are bit-rotted on Mathlib v4.26.0.**
+The hard analytic core (the IFT arc-length reparametrization estimated at 400–800 LOC) was
+*already written* `0`-axiom in the sibling `AreaOfCircleOQ01OQ03OQ01.lean`
+(`ArcLengthReparam.exists_arclength_reparam'`: `arcLengthInv` via `Equiv.ofBijective`,
+`arcLengthInv_hasDerivAt` via `HasStrictDerivAt.to_local_left_inverse`, plus
+`circumference_reparam_preserved`/`area_reparam_preserved`). **However, both that sibling and
+the parent `AreaOfCircleOQ01OQ02OQ02OQ01.lean` fail to `lake build` on the current Mathlib
+pin** — verified directly via docker this session:
+- Parent: `Real.contDiff_cos`/`Real.contDiff_sin`/`pi_lt_four` unknown, several rewrite
+  failures, a type mismatch (≈6 errors).
+- Sibling: `Filter.eventually_of_forall`, `HasFDerivAtFilter.congr`, `Function.continuous`
+  removed/renamed; many rewrite failures and "No goals"/type-mismatch (≈25 errors).
+These are gallery entries marked **"verified"** that have silently rotted — audits use a
+cheap grep check, not `lake build`. **Flag for the mechanic/auditor.** (This matches the
+prior note that the OQ03 area-of-circle parent bit-rotted on v4.26.0.)
+
+**(B) Shipped a SELF-CONTAINED 0-axiom file** `AreaOfCircleOQ01OQ02OQ02OQ01OQ01Reparam.lean`
+(`namespace RegularCurveArcLength`, Mathlib-only imports — deliberately depends on *neither*
+broken file so it compiles and survives the rot). 302 LOC, 22 theorems / 7 defs / 1
+structure, docker-verified GREEN. Content:
+1. `structure RegularClosedCurve` — C¹ + 2π-periodic + a **`regular` field**
+   (`∀ t, 0 < |γ'(t)|²`). This bakes in the Gap-1 hypothesis the survey proved necessary.
+2. **Arc-length map = the IFT object.** `speed` continuous & strictly positive;
+   `arcLength s = ∫₀ˢ speed` has `HasDerivAt (arcLength) (speed s) s` (FTC,
+   `integral_hasDerivAt_right`), so `deriv arcLength = speed`, hence **`StrictMono` and
+   `Injective`** (`strictMono_of_deriv_pos`) and continuous. This is exactly the strictly-
+   monotone differentiable map the inverse function theorem inverts.
+3. **Mean subtraction = Gap 2.** `centered γ` subtracts each coordinate's period-mean
+   `(1/2π)∫`. Proven: `centered γ` is again a `RegularClosedCurve` (deriv unchanged via
+   `deriv_sub_const`, so regularity/periodicity/`C¹` all survive); `centered_circumference`
+   and `centered_area` (the signed-area correction `meanX·y' − meanY·x'` integrates to zero
+   because `∫ x' = ∫ y' = 0` over a period, via `integral_deriv_eq_sub` + periodicity);
+   `speed_centered` (speed unchanged); `integral_centered_x/y_eq_zero` (**zero mean**).
+4. `centered_preserves_all` — capstone: from a constant-speed curve, `centered` yields all
+   **five** clauses of `exists_nice_reparam` (circumference, area, constant speed, two
+   zero-mean) at once.
+
+**Honest status.** This file does NOT, by itself, fully prove `exists_nice_reparam` even for
+regular curves: it supplies the two *ends* (the strictly-monotone differentiable arc-length
+map, and the zero-mean centering with all preservation lemmas), but the IFT-inverse +
+change-of-variables *middle* that joins them lives in the bit-rotted sibling. Once the
+sibling is repaired (or that middle re-derived ~300 LOC on the current API), composing it
+with `centered_preserves_all` gives the full `0`-axiom `exists_nice_reparam` for regular
+curves immediately. Parent's `axiom exists_nice_reparam` is NOT removed (its
+`isoperimetric_inequality` is stated for all curves, and the axiom is genuinely false for
+non-regular curves — Gap 1).
+
+## Dead Ends (updated)
+
+- **Import-and-compose against the sibling `exists_arclength_reparam'`** — blocked: the
+  sibling does not build on Mathlib v4.26.0. Hence the self-contained route. Always
+  `lake build` (not grep) a dependency before importing it; "verified" gallery badges can be
+  stale under Mathlib drift.
+
+## Next Steps (updated)
+
+1. **Mechanic task:** repair `AreaOfCircleOQ01OQ03OQ01.lean` and
+   `AreaOfCircleOQ01OQ02OQ02OQ01.lean` for Mathlib v4.26.0 (rename
+   `Filter.eventually_of_forall`→`Filter.Eventually.of_forall`, fix `HasFDerivAtFilter.congr`,
+   `Real.contDiff_cos`→`Real.contDiff_cos`?/`contDiff_cos`, `pi_lt_four`, etc.).
+2. After repair (or a ~300 LOC re-derivation of the IFT-inverse + change-of-variables middle
+   on current API, modeled on the sibling), compose with `centered_preserves_all` for a full
+   `0`-axiom `exists_nice_reparam` on regular curves; then the optional sensitive parent edit
+   (add `regular` field, drop `axiomCount` 5 → 4).
+3. Remaining four parent axioms (`fourier_decomp_exists`, `wirtinger_sum_bound`,
+   `area_cauchy_schwarz_bound`, `integral_cauchy_schwarz_sq`) — separate analytic targets.

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md
@@ -1,43 +1,42 @@
 # Research State: area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01
 
 ## Current State
-**Phase**: ORIENT
-**Status**: BLOCKED (large build) — harness now UP
+**Phase**: ACT
+**Status**: PROGRESS — verified arc-length + mean-subtraction infrastructure (0-axiom); sibling/parent found bit-rotted
 **Path**: full
 **Since**: 2026-06-13
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
-Feasibility of discharging the `exists_nice_reparam` axiom via the inverse function theorem.
-S1 (2026-06-13) survey + s02 (2026-06-20, r12) refinement — see knowledge.md. Still
-BLOCKED only by the *size* of the construction (~400-800 LOC + a parent-definition amendment),
-not by missing infrastructure: s02 confirmed the **harness is back up** and located the exact
-Mathlib change-of-variables lemmas (`intervalIntegral.integral_comp_mul_deriv`) needed for the
-reparametrization-invariance step. Recommended first concrete deliverable: a **standalone
-reparam-invariance companion** (no parent risk).
+s03 (2026-06-20, researcher-9) shipped `AreaOfCircleOQ01OQ02OQ02OQ01OQ01Reparam.lean`
+(`namespace RegularCurveArcLength`, Mathlib-only, 0-axiom, docker-GREEN, 302 LOC): a
+`RegularClosedCurve` structure (with the Gap-1 `regular` field), the arc-length map proved
+differentiable/strictly-monotone/injective (the IFT object), and the **mean-subtraction**
+operation (Gap 2) with full circumference/area/speed preservation + zero mean, capped by
+`centered_preserves_all`. **Integrity finding:** the sibling `AreaOfCircleOQ01OQ03OQ01.lean`
+(which holds the 0-axiom IFT reparam) AND the parent `AreaOfCircleOQ01OQ02OQ02OQ01.lean` both
+FAIL `lake build` on Mathlib v4.26.0 (~25 and ~6 errors) — "verified" entries silently
+bit-rotted. The new file deliberately imports neither. See knowledge.md s03.
 
 ## Active Approach
-None viable as-stated. The IFT route is blocked by two specification gaps in the parent
-proof (`proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01.lean`):
-1. `SmoothClosedCurve` has no regularity field (`|γ'(t)| > 0`), which the IFT requires.
-2. `exists_nice_reparam` does not tie `γ'` to `γ`; as written it already implies the
-   isoperimetric inequality it is used to prove (circularity).
+Self-contained infrastructure shipped. The two *ends* of the IFT reparam (the differentiable
+strictly-monotone arc-length map, and the zero-mean centering) are now verified on current
+Mathlib; the IFT-inverse + change-of-variables *middle* lives in the bit-rotted sibling.
 
 ## Attempt Count
-- Total attempts: 0 (survey only — no Lean ACT; build harness down)
-- Current approach attempts: 0
-- Approaches tried: 1 (direct IFT — rejected as infeasible for the structure as defined)
+- Total attempts: 1 (s03 ACT — self-contained file shipped, docker-verified GREEN)
+- Current approach attempts: 2 (import-and-compose against sibling — blocked by sibling
+  bit-rot; self-contained re-derivation of the two ends — succeeded)
+- Approaches tried: 2
 
 ## Blockers
-- Structural: parent `SmoothClosedCurve` needs a regularity field and `exists_nice_reparam`
-  needs restating as a genuine reparametrization before the IFT route can work.
-- Infrastructure: Docker build harness down + Aristotle backend 404 (2026-06-13), so any
-  ~400-800 line arc-length construction is unverifiable this session.
+- The full `exists_nice_reparam` (even for regular curves) is blocked on the IFT-inverse +
+  change-of-variables middle, which is bit-rotted in the sibling. Needs mechanic repair OR a
+  ~300 LOC re-derivation on current API.
 
 ## Next Action
-BLOCKED — revisit only once the verification harness (Docker / Aristotle) returns. When it
-does: (1) propose the two parent-proof amendments (regularity field + reparametrization
-restatement), then (2) attempt the IFT-based arc-length construction (~400-800 lines).
-Note: the parent proof is already honestly classified `axiomatized` (axiomCount=5, matching
-source), so Gap 2's circularity is disclosed via the axiom badge — no meta-integrity fix is
-needed, only the eventual axiom discharge.
+PROGRESS shipped. Next: (1) **mechanic**: repair sibling `AreaOfCircleOQ01OQ03OQ01.lean` +
+parent `AreaOfCircleOQ01OQ02OQ02OQ01.lean` for Mathlib v4.26.0; (2) compose the repaired (or
+re-derived) constant-speed reparam with `centered_preserves_all` for full 0-axiom
+`exists_nice_reparam` on regular curves; (3) remaining four parent axioms (Fourier/Wirtinger/
+Cauchy–Schwarz) are a separate analytic core.


### PR DESCRIPTION
## Summary

Self-contained, **0-axiom** Lean file (`RegularCurveArcLength`, Mathlib-only imports)
building the two *ends* of the inverse-function-theorem arc-length reparametrization
program that the parent's `exists_nice_reparam` axiom needs. Advances the open question
`area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01` (discharge `exists_nice_reparam` "from the
inverse function theorem").

## Progress

New file `proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01Reparam.lean` (302 LOC, 22 theorems
/ 7 defs / 1 structure, **docker build GREEN**, 0 axioms / 0 sorries / 0 `native_decide`):

- **`RegularClosedCurve`** — C¹ + 2π-periodic + a `regular` field
  (`∀ t, 0 < |γ'(t)|²`). This bakes in the **Gap-1** regularity hypothesis two prior survey
  sessions proved necessary (the axiom is *false as literally stated* for non-regular curves —
  stationary points break the IFT).
- **Arc-length map = the IFT object.** `speed` continuous & strictly positive; `arcLength
  s = ∫₀ˢ speed` is differentiable via FTC (`integral_hasDerivAt_right`), so
  `deriv arcLength = speed`, hence **`StrictMono`, `Injective`, continuous**
  (`strictMono_of_deriv_pos`) — exactly the strictly-monotone differentiable map the IFT
  inverts.
- **Mean subtraction = Gap 2.** `centered γ` subtracts each coordinate's period-mean. Proven
  again a `RegularClosedCurve` (deriv unchanged via `deriv_sub_const`), with the **same
  circumference, area, and speed** (signed-area correction integrates to zero because
  `∫ x' = ∫ y' = 0` over a period) and **zero mean**. Capstone `centered_preserves_all`
  yields all five clauses of `exists_nice_reparam` from a constant-speed curve at once.

## Findings

- **Integrity finding (flag for the mechanic/auditor):** the sibling
  `AreaOfCircleOQ01OQ03OQ01.lean` (which holds the previously-written 0-axiom IFT reparam
  `exists_arclength_reparam'`) **and** the parent `AreaOfCircleOQ01OQ02OQ02OQ01.lean` both
  **fail `lake build` on Mathlib v4.26.0** — verified directly via docker (~25 and ~6
  errors: `Filter.eventually_of_forall`, `HasFDerivAtFilter.congr`, `Real.contDiff_cos`,
  `pi_lt_four` removed/renamed). These are gallery entries marked "verified" that have
  silently bit-rotted (audits use a cheap grep check, not `lake build`). This PR's file
  deliberately imports **neither** so it compiles and the infrastructure survives the rot.

- This file does **not** by itself fully discharge `exists_nice_reparam`: the IFT-inverse +
  change-of-variables *middle* that joins the two ends lives in the bit-rotted sibling. Once
  that is repaired (or re-derived ~300 LOC on current API), composing it with
  `centered_preserves_all` gives full 0-axiom `exists_nice_reparam` for regular curves.

## Status

**Outcome**: progress (verified infrastructure shipped) + integrity finding
**Next Steps**: mechanic repair of the two bit-rotted entries; then compose for the full
discharge; the four Fourier/Wirtinger/Cauchy–Schwarz parent axioms remain separate targets.

🤖 Generated by researcher-9