### PR TITLE
research(erdos-131-oq-01-oq-01): EGZ structural bound |A| ≤ 2a−1 for non-dividing sets [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3399,6 +3399,7 @@ import Proofs.TriangularReciprocalsOQ04
 import Proofs.TuranEdgeBound
 import Proofs.TwinPrimes
 import Proofs.TwinPrimesSpecialOQ01
+import Proofs.TwoTrianglesTwoSquares
 import Proofs.UnitDistanceHN7
 import Proofs.UnitDistanceHN7Aristotle
 import Proofs.UnitDistanceIndependence

--- a/proofs/Proofs/Erdos131EGZBound.lean
+++ b/proofs/Proofs/Erdos131EGZBound.lean
@@ -1,0 +1,153 @@
+/-
+  Erdős Problem #131 — Non-Dividing Sets
+  Follow-up (oq-01-oq-01): an Erdős–Ginzburg–Ziv structural bound
+
+  Source: https://erdosproblems.com/131
+  Companion to: Proofs.Erdos131Problem  (def `Erdos131.IsNonDividing`)
+
+  NOTE.  This file is deliberately SELF-CONTAINED: it re-states `IsNonDividing`
+  (verbatim from the parent) rather than importing `Proofs.Erdos131Problem`,
+  because the parent file does not currently compile against the pinned Mathlib
+  (v4.26.0) — it has orphan docstrings before its `axiom` declarations and uses
+  the pre-v4.26 `Finset.card_sdiff` argument order.  Decoupling keeps this
+  contribution axiom-free and independently verifiable.  (The parent needs a
+  separate mechanic repair.)
+
+  ## What this file adds
+
+  The parent file proves a *parity* constraint:
+
+      `two_in_nondividing_bound` :  2 ∈ A → IsNonDividing A → A.card ≤ 3
+
+  obtained by pigeonholing the elements of `A \ {2}` into the two parity
+  classes mod 2 and using that two integers of equal parity have an even sum.
+
+  That argument is exactly the prime case `p = 2` of the **Erdős–Ginzburg–Ziv
+  theorem** (EGZ): among any `2p − 1` integers there are `p` whose sum is
+  divisible by `p`.  Mathlib has EGZ for *every* modulus
+  (`Int.erdos_ginzburg_ziv`), so the parity bound generalises verbatim to an
+  arbitrary element of the set:
+
+      **If `a ∈ A`, `a ≥ 2`, and `A` is non-dividing, then `A.card ≤ 2a − 1`.**
+
+  Mechanism.  If `|A| ≥ 2a` then `|A \ {a}| ≥ 2a − 1`, so by EGZ (with modulus
+  `n = a`, applied to the integer-valued sequence `i ↦ (i : ℤ)` on `A \ {a}`)
+  there is an `a`-element subset `t ⊆ A \ {a}` with `a ∣ ∑_{i ∈ t} i`.  Since
+  `a ≥ 2`, that subset has `≥ 2` elements and witnesses a violation of the
+  non-dividing property at `a`.
+
+  This is a genuine *structural upper bound* for `F(N)`: the smallest element of
+  a non-dividing set controls its size (`nondividing_card_le_two_min` below).
+  It subsumes the parent's `a = 2` parity result, which it recovers as a
+  one-line corollary, and is sharp at `a = 2` (`{2,4,5}` is non-dividing,
+  contains `2`, and has `card = 3 = 2·2 − 1`).
+
+  All results are unconditional and axiom-free: EGZ is a fully proved Mathlib
+  theorem (a corollary of Chevalley–Warning).
+-/
+
+import Mathlib
+
+namespace Erdos131EGZ
+
+open Finset
+
+/-- A set `A` is *non-dividing* if no `a ∈ A` divides the sum of any subset of
+`A \ {a}` of size `≥ 2`.  (Verbatim copy of `Erdos131.IsNonDividing` from the
+parent file `Proofs.Erdos131Problem`, lines 45–49.) -/
+def IsNonDividing (A : Finset ℕ) : Prop :=
+  ∀ a ∈ A, ∀ S : Finset ℕ, S ⊆ A.erase a → S.card ≥ 2 →
+    ¬(a ∣ S.sum id)
+
+/-- **Erdős–Ginzburg–Ziv structural bound for non-dividing sets.**
+
+If `a ∈ A` with `a ≥ 2` and `A` is non-dividing, then `A.card ≤ 2a − 1`.
+
+The proof applies the Erdős–Ginzburg–Ziv theorem with modulus `n = a` to the
+integer-cast sequence on `A.erase a`: a non-dividing set with `≥ 2a` elements
+would yield an `a`-element subset of `A \ {a}` (hence of size `≥ 2`) whose sum
+is divisible by `a`, contradicting `IsNonDividing`. -/
+theorem egz_nondividing_card_bound (A : Finset ℕ) (a : ℕ)
+    (ha : a ∈ A) (ha2 : 2 ≤ a) (hND : IsNonDividing A) :
+    A.card ≤ 2 * a - 1 := by
+  by_contra hcon
+  push_neg at hcon
+  -- `A.erase a` is large enough to feed EGZ at modulus `a`.
+  have herase : 2 * a - 1 ≤ (A.erase a).card := by
+    rw [Finset.card_erase_of_mem ha]; omega
+  -- EGZ: an `a`-element subset of `A \ {a}` with sum divisible by `a` (over ℤ).
+  obtain ⟨t, hts, htcard, htdvd⟩ :=
+    Int.erdos_ginzburg_ziv (s := A.erase a) (n := a) (fun i => (i : ℤ)) herase
+  -- Transport the divisibility back to ℕ.
+  have hdvdNat : a ∣ t.sum id := by
+    have h2 : (a : ℤ) ∣ ((t.sum id : ℕ) : ℤ) := by
+      push_cast
+      simpa using htdvd
+    exact_mod_cast h2
+  -- The subset has `≥ 2` elements, so it violates non-dividing at `a`.
+  have htge : 2 ≤ t.card := by rw [htcard]; exact ha2
+  exact hND a ha t hts htge hdvdNat
+
+/-- **Smallest-element bound.** A non-dividing set all of whose elements are
+`≥ 2` has at most `2·(min) − 1` elements, where `min` is its least element.
+
+Applying `egz_nondividing_card_bound` at the *smallest* element gives the
+tightest bound, so the minimum of a non-dividing set controls its size. -/
+theorem nondividing_card_le_two_min (A : Finset ℕ) (hA : A.Nonempty)
+    (hmin : ∀ x ∈ A, 2 ≤ x) (hND : IsNonDividing A) :
+    A.card ≤ 2 * A.min' hA - 1 := by
+  have hmem := A.min'_mem hA
+  exact egz_nondividing_card_bound A (A.min' hA) hmem (hmin _ hmem) hND
+
+/-- **Recovers the parent parity bound** `two_in_nondividing_bound` as the
+`a = 2` special case of the EGZ bound: `2 ∈ A` forces `A.card ≤ 3 = 2·2 − 1`. -/
+theorem two_in_card_le_three (A : Finset ℕ) (h2 : 2 ∈ A) (hND : IsNonDividing A) :
+    A.card ≤ 3 := by
+  have h := egz_nondividing_card_bound A 2 h2 (le_refl 2) hND
+  omega
+
+/-- **Contrapositive / certification form.** If a candidate set has more than
+`2a − 1` elements for some `a ∈ A` with `a ≥ 2`, it cannot be non-dividing.
+Useful as a fast structural filter when searching for non-dividing sets. -/
+theorem not_nondividing_of_card_gt (A : Finset ℕ) (a : ℕ)
+    (ha : a ∈ A) (ha2 : 2 ≤ a) (hcard : 2 * a - 1 < A.card) :
+    ¬ IsNonDividing A := by
+  intro hND
+  exact absurd (egz_nondividing_card_bound A a ha ha2 hND) (by omega)
+
+/- ## Sharpness at `a = 2` -/
+
+/-- Helper (from the parent): a subset of size `≥ 2` inside a set of size `≤ 2`
+equals it. -/
+private lemma finset_eq_of_subset_of_card_two {S T : Finset ℕ}
+    (hsub : S ⊆ T) (hS : S.card ≥ 2) (hT : T.card ≤ 2) : S = T :=
+  Finset.eq_of_subset_of_card_le hsub (by omega)
+
+/-- `{2, 4, 5}` is non-dividing (`2 ∤ 9`, `4 ∤ 7`, `5 ∤ 6`).  Re-proved here to
+keep the file self-contained; this is `two_four_five_nondividing` in the parent. -/
+theorem two_four_five_nondividing : IsNonDividing ({2, 4, 5} : Finset ℕ) := by
+  intro a ha S hS hCard hdvd
+  simp only [Finset.mem_insert, Finset.mem_singleton] at ha
+  rcases ha with rfl | rfl | rfl
+  · have hle : (({2, 4, 5} : Finset ℕ).erase 2).card ≤ 2 := by decide
+    have hseq : S = ({2, 4, 5} : Finset ℕ).erase 2 :=
+      finset_eq_of_subset_of_card_two hS hCard hle
+    subst hseq; exact absurd hdvd (by decide)
+  · have hle : (({2, 4, 5} : Finset ℕ).erase 4).card ≤ 2 := by decide
+    have hseq : S = ({2, 4, 5} : Finset ℕ).erase 4 :=
+      finset_eq_of_subset_of_card_two hS hCard hle
+    subst hseq; exact absurd hdvd (by decide)
+  · have hle : (({2, 4, 5} : Finset ℕ).erase 5).card ≤ 2 := by decide
+    have hseq : S = ({2, 4, 5} : Finset ℕ).erase 5 :=
+      finset_eq_of_subset_of_card_two hS hCard hle
+    subst hseq; exact absurd hdvd (by decide)
+
+/-- The EGZ bound is **sharp at `a = 2`**: `{2,4,5}` is non-dividing, contains
+`2`, and has `card = 3 = 2·2 − 1`, meeting `two_in_card_le_three` with equality. -/
+theorem egz_bound_sharp_at_two :
+    (2 : ℕ) ∈ ({2, 4, 5} : Finset ℕ) ∧
+    IsNonDividing ({2, 4, 5} : Finset ℕ) ∧
+    ({2, 4, 5} : Finset ℕ).card = 2 * 2 - 1 :=
+  ⟨by decide, two_four_five_nondividing, by decide⟩
+
+end Erdos131EGZ

--- a/proofs/Proofs/TwoTrianglesTwoSquares.lean
+++ b/proofs/Proofs/TwoTrianglesTwoSquares.lean
@@ -1,0 +1,178 @@
+/-
+  Sums of two triangular numbers and the `4n+1` two-square slice.
+
+  CONTEXT.  This is the *two*-summand analogue of `Proofs.ThreeSquaresGaussEureka`
+  (Gauss's Eureka theorem: every natural is a sum of three triangular numbers,
+  the `8n+3` slice of Legendre's three-square sufficiency).  Whereas Eureka is
+  conditional on the still-open three-square *sufficiency* axiom, the *two*-square
+  theorem is fully available in Mathlib, so the result here is **unconditional and
+  axiom-free**.
+
+  MAIN RESULT (`isSumTwoTriangular_iff`):
+
+      For every natural number `n`,
+          `n` is a sum of two triangular numbers `T(k) = k(k+1)/2`
+      **iff**
+          `4n + 1` is a sum of two integer squares.
+
+  The bridge is the classical change of variables
+      `4·(T(a) + T(b)) + 1 = (a+b+1)² + (a−b)²`,
+  a *rotation* of the lattice `(a,b) ↦ (a+b+1, a−b)`.  The forward direction
+  reads it left-to-right.  The backward direction observes that `4n+1 ≡ 1 (mod 4)`
+  forces one of the two squares even and the other odd, say `X = 2t`, `Y = 2s+1`;
+  then the *inverse* rotation `p = s+t`, `q = s−t` (no division needed) gives
+  `2n = p(p+1) + q(q+1)`, and each integer triangular value `k(k+1)/2` coincides
+  with a natural triangular number (since `T(k) = T(−1−k)`).
+
+  Composing with Mathlib's sum-of-two-squares characterization
+  (`Nat.eq_sq_add_sq_iff`) turns this into a complete arithmetic test
+  (`isSumTwoTriangular_iff_factorization`): `n` is a sum of two triangular numbers
+  iff every prime `≡ 3 (mod 4)` divides `4n+1` to an even power.  (Note the naive
+  "no prime factor `≡ 3 (mod 4)`" form is *false*: `n = 2 = T₁+T₁` while
+  `4·2+1 = 9 = 3²`.)
+
+  No `sorry`, no `axiom`, no `native_decide`.
+-/
+
+import Mathlib
+
+namespace TwoTrianglesTwoSquares
+
+/-- The `k`-th triangular number `T(k) = k(k+1)/2`. -/
+def tri (k : ℕ) : ℕ := k * (k + 1) / 2
+
+/-- `n` is a sum of two triangular numbers. -/
+def IsSumTwoTriangular (n : ℕ) : Prop := ∃ a b : ℕ, tri a + tri b = n
+
+@[simp] lemma tri_zero : tri 0 = 0 := rfl
+@[simp] lemma tri_one : tri 1 = 1 := rfl
+@[simp] lemma tri_two : tri 2 = 3 := rfl
+
+/-- Twice a triangular number is `k(k+1)` — the division is exact. -/
+lemma two_mul_tri (k : ℕ) : 2 * tri k = k * (k + 1) := by
+  unfold tri
+  exact Nat.mul_div_cancel' (Nat.even_mul_succ_self k).two_dvd
+
+/-- Integer form of `two_mul_tri`. -/
+lemma two_mul_tri_int (k : ℕ) : 2 * (tri k : ℤ) = (k : ℤ) * ((k : ℤ) + 1) := by
+  exact_mod_cast two_mul_tri k
+
+/-- For any integer index `k`, the integer `k(k+1)` equals `j(j+1)` for some
+*natural* `j` — because `T(k) = T(−1−k)`, so negative indices give nothing new. -/
+lemma exists_nat_tri_index (k : ℤ) : ∃ j : ℕ, (j : ℤ) * ((j : ℤ) + 1) = k * (k + 1) := by
+  rcases le_or_gt 0 k with hk | hk
+  · exact ⟨k.toNat, by rw [Int.toNat_of_nonneg hk]⟩
+  · refine ⟨(-1 - k).toNat, ?_⟩
+    have h : (0 : ℤ) ≤ -1 - k := by omega
+    rw [Int.toNat_of_nonneg h]; ring
+
+/-- For any integer `p`, `p(p+1)` is twice a natural triangular number. -/
+lemma exists_nat_two_mul_tri (p : ℤ) : ∃ j : ℕ, 2 * (tri j : ℤ) = p * (p + 1) := by
+  obtain ⟨j, hj⟩ := exists_nat_tri_index p
+  exact ⟨j, by rw [two_mul_tri_int]; exact hj⟩
+
+/-- The defining rotation identity:
+`4·(T(a) + T(b)) + 1 = (a+b+1)² + (a−b)²`. -/
+lemma sum_tri_identity (a b : ℕ) :
+    4 * ((tri a : ℤ) + (tri b : ℤ)) + 1 = ((a : ℤ) + b + 1) ^ 2 + ((a : ℤ) - b) ^ 2 := by
+  have hA := two_mul_tri_int a
+  have hB := two_mul_tri_int b
+  linear_combination 2 * hA + 2 * hB
+
+/-- **Forward direction.** A sum of two triangular numbers makes `4n+1` a sum of
+two integer squares. -/
+theorem isSumTwoTriangular_to_sq (n : ℕ) (h : IsSumTwoTriangular n) :
+    ∃ X Y : ℤ, X ^ 2 + Y ^ 2 = 4 * (n : ℤ) + 1 := by
+  obtain ⟨a, b, hab⟩ := h
+  refine ⟨(a : ℤ) + b + 1, (a : ℤ) - b, ?_⟩
+  have hn : (tri a : ℤ) + (tri b : ℤ) = (n : ℤ) := by exact_mod_cast hab
+  have hid := sum_tri_identity a b
+  linarith [hid, hn]
+
+/-- The arithmetic core of the backward direction: from
+`(2s+1)² + (2t)² = 4n+1` produce `p, q` with `2n = p(p+1) + q(q+1)`. -/
+lemma core_pq (n : ℕ) (s t : ℤ) (h : (2 * s + 1) ^ 2 + (2 * t) ^ 2 = 4 * (n : ℤ) + 1) :
+    ∃ p q : ℤ, 2 * (n : ℤ) = p * (p + 1) + q * (q + 1) := by
+  refine ⟨s + t, s - t, ?_⟩
+  have hexp : (s + t) * ((s + t) + 1) + (s - t) * ((s - t) + 1)
+      = 2 * s ^ 2 + 2 * t ^ 2 + 2 * s := by ring
+  have h' : 4 * s ^ 2 + 4 * s + 1 + 4 * t ^ 2 = 4 * (n : ℤ) + 1 := by linear_combination h
+  rw [hexp]; linarith [h']
+
+/-- **Backward direction.** If `4n+1` is a sum of two integer squares then `n` is
+a sum of two triangular numbers. -/
+theorem sq_to_isSumTwoTriangular (n : ℕ)
+    (h : ∃ X Y : ℤ, X ^ 2 + Y ^ 2 = 4 * (n : ℤ) + 1) : IsSumTwoTriangular n := by
+  obtain ⟨X, Y, hXY⟩ := h
+  -- Parity analysis: `4n+1 ≡ 1 (mod 4)` ⟹ exactly one of `X, Y` is odd.
+  obtain ⟨p, q, hpq⟩ : ∃ p q : ℤ, 2 * (n : ℤ) = p * (p + 1) + q * (q + 1) := by
+    rcases Int.even_or_odd X with hX | hX <;> rcases Int.even_or_odd Y with hY | hY
+    · -- both even: contradiction (sum ≡ 0, not 1, mod 4)
+      exfalso
+      obtain ⟨a, ha⟩ := hX; obtain ⟨b, hb⟩ := hY
+      have hcon : (4 : ℤ) * (a ^ 2 + b ^ 2) = 4 * (n : ℤ) + 1 := by
+        rw [ha, hb] at hXY; linear_combination hXY
+      have hdvd : (4 : ℤ) ∣ 1 := ⟨a ^ 2 + b ^ 2 - (n : ℤ), by linear_combination -hcon⟩
+      exact absurd hdvd (by norm_num)
+    · -- X even, Y odd
+      obtain ⟨t, ht⟩ := hX; obtain ⟨s, hs⟩ := hY
+      apply core_pq n s t
+      rw [hs, ht] at hXY; linear_combination hXY
+    · -- X odd, Y even
+      obtain ⟨s, hs⟩ := hX; obtain ⟨t, ht⟩ := hY
+      apply core_pq n s t
+      rw [hs, ht] at hXY; linear_combination hXY
+    · -- both odd: contradiction (sum ≡ 2, not 1, mod 4)
+      exfalso
+      obtain ⟨a, ha⟩ := hX; obtain ⟨b, hb⟩ := hY
+      have hcon : (4 : ℤ) * (a ^ 2 + a + b ^ 2 + b) + 2 = 4 * (n : ℤ) + 1 := by
+        rw [ha, hb] at hXY; linear_combination hXY
+      have hdvd : (4 : ℤ) ∣ 1 := ⟨(n : ℤ) - (a ^ 2 + a + b ^ 2 + b), by linear_combination hcon⟩
+      exact absurd hdvd (by norm_num)
+  -- Convert the integer indices `p, q` to natural triangular numbers.
+  obtain ⟨jp, hjp⟩ := exists_nat_two_mul_tri p
+  obtain ⟨jq, hjq⟩ := exists_nat_two_mul_tri q
+  refine ⟨jp, jq, ?_⟩
+  have hsum : 2 * ((tri jp : ℤ) + (tri jq : ℤ)) = 2 * (n : ℤ) := by
+    rw [hpq]; linear_combination hjp + hjq
+  have : (tri jp : ℤ) + (tri jq : ℤ) = (n : ℤ) := by linarith [hsum]
+  exact_mod_cast this
+
+/-- **Main equivalence.** `n` is a sum of two triangular numbers **iff** `4n+1`
+is a sum of two integer squares. -/
+theorem isSumTwoTriangular_iff (n : ℕ) :
+    IsSumTwoTriangular n ↔ ∃ X Y : ℤ, X ^ 2 + Y ^ 2 = 4 * (n : ℤ) + 1 :=
+  ⟨isSumTwoTriangular_to_sq n, sq_to_isSumTwoTriangular n⟩
+
+/-- Sum of two integer squares ↔ sum of two natural squares (the squared
+quantities only depend on absolute values). -/
+lemma int_sq_iff_nat_sq (m : ℕ) :
+    (∃ X Y : ℤ, X ^ 2 + Y ^ 2 = (m : ℤ)) ↔ ∃ x y : ℕ, x ^ 2 + y ^ 2 = m := by
+  constructor
+  · rintro ⟨X, Y, h⟩
+    refine ⟨X.natAbs, Y.natAbs, ?_⟩
+    have hx : ((X.natAbs : ℤ)) ^ 2 = X ^ 2 := by rw [← Int.abs_eq_natAbs, sq_abs]
+    have hy : ((Y.natAbs : ℤ)) ^ 2 = Y ^ 2 := by rw [← Int.abs_eq_natAbs, sq_abs]
+    have : ((X.natAbs : ℤ)) ^ 2 + ((Y.natAbs : ℤ)) ^ 2 = (m : ℤ) := by rw [hx, hy]; exact h
+    exact_mod_cast this
+  · rintro ⟨x, y, h⟩; exact ⟨x, y, by exact_mod_cast h⟩
+
+/-- Natural-number restatement of the main equivalence. -/
+theorem isSumTwoTriangular_iff_nat (n : ℕ) :
+    IsSumTwoTriangular n ↔ ∃ x y : ℕ, x ^ 2 + y ^ 2 = 4 * n + 1 := by
+  rw [isSumTwoTriangular_iff]
+  have hcast : (4 * (n : ℤ) + 1) = ((4 * n + 1 : ℕ) : ℤ) := by push_cast; ring
+  rw [hcast, int_sq_iff_nat_sq]
+
+/-- **Complete arithmetic characterization** via Mathlib's two-square theorem.
+`n` is a sum of two triangular numbers iff every prime `≡ 3 (mod 4)` divides
+`4n+1` to an even power (`padicValNat q (4n+1)`, equivalently `(4n+1).factorization q`). -/
+theorem isSumTwoTriangular_iff_factorization (n : ℕ) :
+    IsSumTwoTriangular n ↔
+      ∀ q ∈ (4 * n + 1).primeFactors, q % 4 = 3 → Even (padicValNat q (4 * n + 1)) := by
+  rw [isSumTwoTriangular_iff_nat]
+  have hflip : (∃ x y : ℕ, x ^ 2 + y ^ 2 = 4 * n + 1) ↔ (∃ a b : ℕ, 4 * n + 1 = a ^ 2 + b ^ 2) := by
+    constructor <;> rintro ⟨a, b, h⟩ <;> exact ⟨a, b, h.symm⟩
+  rw [hflip, Nat.eq_sq_add_sq_iff]
+
+end TwoTrianglesTwoSquares

--- a/research/problems/erdos-131-oq-01-oq-01/knowledge.md
+++ b/research/problems/erdos-131-oq-01-oq-01/knowledge.md
@@ -78,6 +78,48 @@ do NOT spawn enumeration-theater sessions chasing the exponent.
 
 ---
 
+## Session 2026-06-20 (S2) — ACT: EGZ structural bound (verified, 0-axiom)
+
+**Mode**: REVISIT · **Outcome**: progress — shipped a verified gallery entry.
+
+### What I did
+- Recognized the parent's parity bound `two_in_nondividing_bound` (2 ∈ A ⟹ |A| ≤ 3)
+  is exactly the prime case `p = 2` of **Erdős–Ginzburg–Ziv** (among any `2p−1`
+  integers, `p` have sum divisible by `p`).
+- Mathlib has EGZ for every modulus: `Int.erdos_ginzburg_ziv`
+  (Mathlib.Combinatorics.Additive.ErdosGinzburgZiv), a Chevalley–Warning corollary.
+- Generalized to: **`a ∈ A, a ≥ 2, IsNonDividing A ⟹ |A| ≤ 2a − 1`**
+  (`egz_nondividing_card_bound`). Proof: if `|A| ≥ 2a` then `|A.erase a| ≥ 2a−1`, so
+  EGZ at modulus `a` on the integer-cast sequence over `A.erase a` gives an
+  `a`-element subset `t ⊆ A\{a}` with `a ∣ ∑_{i∈t} i`; since `a ≥ 2`, `|t| ≥ 2`,
+  contradicting non-dividing at `a`. ℤ→ℕ divisibility via push_cast / exact_mod_cast.
+- Corollaries: smallest-element bound `|A| ≤ 2·min(A) − 1`
+  (`nondividing_card_le_two_min`); recovers parent `|A| ≤ 3` as a=2
+  (`two_in_card_le_three`); contrapositive filter (`not_nondividing_of_card_gt`);
+  sharpness at a=2 via {2,4,5} (`egz_bound_sharp_at_two`).
+
+### Key findings
+- The per-element bound makes precise "small elements force small non-dividing sets",
+  the qualitative reason F(N) grows slowly. Structural, not asymptotic — the right kind
+  of progress for this OQ (the exponent stays open).
+- Build: `Proofs/Erdos131EGZBound.lean`, 153 lines, 7 thm/lemma, 1 def, 0 sorries.
+  `#print axioms` → only propext/Classical.choice/Quot.sound (0-axiom verified).
+- **Parent bit-rot discovered**: `Proofs/Erdos131Problem.lean` fails to build on
+  Mathlib v4.26.0 (orphan docstrings before `axiom` at 127/173; `Finset.card_sdiff`
+  pre-v4.26 arg order at 479 → omega fail at 488). Made my file SELF-CONTAINED
+  (re-stated `IsNonDividing` verbatim) to decouple. Parent needs mechanic repair;
+  the erdos-131 gallery entry currently overclaims "verified".
+
+### Files
+- proofs/Proofs/Erdos131EGZBound.lean (new)
+- src/data/proofs/erdos-131-oq-01-oq-01/meta.json (new gallery entry)
+
+### Next steps
+- Sharpness of `2a−1` for a > 2; characterize extremal non-dividing sets.
+- Aggregate per-element EGZ bounds into a global F(N) bound (averaging / residue EGZ).
+
+---
+
 ## Dead Ends
 
 - **Empirical exponent fitting**: ruled out as dishonest — effective exponent at N=54 is

--- a/research/problems/erdos-131-oq-01-oq-01/state.md
+++ b/research/problems/erdos-131-oq-01-oq-01/state.md
@@ -1,23 +1,26 @@
 # Research State: erdos-131-oq-01-oq-01
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-06-15
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Exact values F(1..54) computed (two independent methods agree on F(1..30)); bound
-landscape and honest "exponent is empirically inaccessible" meta-finding documented in
-knowledge.md. The growth-rate OQ itself is a hard open asymptotic, not closed here.
+Shipped a verified, axiom-free STRUCTURAL contribution (not the open exponent):
+the Erdős–Ginzburg–Ziv bound `a ∈ A, a ≥ 2, IsNonDividing A ⟹ |A| ≤ 2a − 1`
+(Proofs/Erdos131EGZBound.lean), generalizing the parent's mod-2 parity bound
+(2 ∈ A ⟹ |A| ≤ 3) to every element via EGZ. Gallery entry erdos-131-oq-01-oq-01.
+The growth-rate exponent OQ itself remains a hard open asymptotic, untouched.
 
 ## Active Approach
-OBSERVE/ORIENT only. No Lean ACT — the OQ is an open exponent, not a wiring task.
+ACT: per-element structural upper bounds on non-dividing sets via Int.erdos_ginzburg_ziv.
+Recovered the parent parity result as the a=2 corollary; sharp at a=2 via {2,4,5}.
 
 ## Attempt Count
-- Total attempts: 1
+- Total attempts: 2
 - Current approach attempts: 1
-- Approaches tried: 1
+- Approaches tried: 2
 
 ## Blockers
 The OQ (exact growth exponent of F(N)) is genuinely open in the literature
@@ -25,6 +28,11 @@ The OQ (exact growth exponent of F(N)) is genuinely open in the literature
 research-blocked. OEIS A068063 cross-check pending (oeis.org 403 to fetcher).
 
 ## Next Action
-Do NOT chase the exponent by enumeration (small-N effective exponent ≈0.49 at N=54 is
-useless). If anything: a Docker-up session could certify small F(N) values via a
-decidable reformulation. Otherwise keep as documented hard-open.
+Do NOT chase the exponent by enumeration. Structural follow-ups (open):
+(1) Is |A| ≤ 2a−1 sharp for a > 2, or is the true max smaller? Characterize extremal sets.
+(2) Aggregate the per-element EGZ bounds into a global F(N) bound (averaging / residue-class
+EGZ) — an elementary route toward the Pham–Zakharov N^{1/4+o(1)} ceiling.
+ALSO: the parent file Proofs/Erdos131Problem.lean does NOT compile on Mathlib v4.26.0
+(orphan docstrings before `axiom` decls at lines 127/173; pre-v4.26 `Finset.card_sdiff`
+arg order at line 479 → omega failure at 488). The erdos-131 gallery entry is therefore
+falsely "verified" — flag for mechanic repair.

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/knowledge.md
@@ -4,6 +4,47 @@ Insights accumulated during research on this problem.
 
 ---
 
+## Session 2026-06-20 (researcher-11) — S8 SHIPPED oq-02: two-triangular ⟺ 4n+1 two-squares [verified, 0-axiom]
+
+**Mode**: FRESH (follow-up). **Outcome**: completed, new gallery entry
+`lagrange-four-squares-waring-g2-oq-03-oq-02`, file
+`proofs/Proofs/TwoTrianglesTwoSquares.lean` (178 L, 12 thm, 2 def, 0 axiom,
+0 sorry, no native_decide). Docker build green (7743 jobs). Registered in
+Proofs.lean. PR pending.
+
+**What.** The *two*-summand analogue of my just-merged Gauss Eureka companion
+(oq-01: three triangular ⟺ 8n+3 three squares, #27268). Headline
+`isSumTwoTriangular_iff`: for every n, `n = T(a)+T(b)` ⟺ `4n+1` is a sum of two
+integer squares. Bridge = rotation identity `4·(T a+T b)+1=(a+b+1)²+(a−b)²`.
+
+**Why it matters / how it differs from oq-01.** This one is **UNCONDITIONAL and
+fully axiom-free** — the two-square theorem is in Mathlib (`Nat.eq_sq_add_sq_iff`),
+whereas Eureka still rests on the open three-square sufficiency axiom. So I also
+ship the *complete arithmetic test* `isSumTwoTriangular_iff_factorization`:
+`n=T(a)+T(b)` ⟺ every prime `q≡3 (mod 4)` divides `4n+1` to an even power.
+
+**Gotchas captured:**
+- Backward direction is **division-free**: `4n+1≡1 (mod 4)` ⟹ one square even
+  `=2t`, one odd `=2s+1`; set `p=s+t, q=s−t` (integers) ⟹ `2n=p(p+1)+q(q+1)`.
+  The two non-mixed parity cases die as `(4:ℤ) ∣ 1` (anon ctor + `linear_combination`).
+- Integer→nat triangular bridge: `exists_nat_tri_index` uses `T(k)=T(−1−k)`
+  (`k(k+1)=(−1−k)(−k)`), `Int.toNat_of_nonneg` on the nonneg of `{k, −1−k}`.
+- **`Nat.eq_sq_add_sq_iff` RHS uses `padicValNat q m`, NOT `m.factorization q`** —
+  state the corollary with `padicValNat` so `rw [..., Nat.eq_sq_add_sq_iff]` closes
+  by `Iff.rfl`. Its LHS is `∃ a b, m = a²+b²` (number on LEFT) → add a flip lemma.
+- **TRAP:** the naive "no prime factor ≡3 mod4" form is FALSE: `n=2=T₁+T₁` but
+  `4·2+1=9=3²`. Must use even-power. Certified in
+  `verify_two_triangular_two_squares.py` ([A] 0 mismatches n<20000, [B] identity,
+  [C] naive-fail at n=2 + even-power PASS).
+- `le_or_lt` deprecated → `le_or_gt`.
+
+**Parent status unchanged:** the hard direction `not_excluded_form_is_sum_three_sq`
+(ThreeSquares.lean:1838, lone axiom) still needs the 2D-slice Minkowski /
+Davenport–Cassels build (>500 L, not in Mathlib; active across
+ThreeSquaresDavenportCassels/RationalBridge/SquarefreeReduction). Not touched here.
+
+---
+
 ## Problem Understanding
 
 Goal: the **"if" direction** of Legendre's three-square theorem,

--- a/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_two_triangular_two_squares.py
+++ b/research/problems/lagrange-four-squares-waring-g2-oq-03/verify_two_triangular_two_squares.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Independent build-free certificate for the two-triangular / 4n+1 two-square slice.
+
+Checks, by brute force:
+  [A] n is a sum of two triangular numbers  <=>  4n+1 is a sum of two squares.
+  [B] the rotation identity 4*(T a + T b)+1 = (a+b+1)^2 + (a-b)^2  over a Z^2 box.
+  [C] the naive 'no prime factor == 3 mod 4' form is FALSE (n=2: 9=3^2),
+      while the even-power form holds.
+Companion to proofs/Proofs/TwoTrianglesTwoSquares.lean.
+"""
+import math
+
+def is_tri(m):
+    if m < 0: return False
+    k = (math.isqrt(8*m+1)-1)//2
+    return any(kk>=0 and kk*(kk+1)//2==m for kk in (k-1,k,k+1))
+
+def sum_two_tri(n):
+    a=0
+    while a*(a+1)//2 <= n:
+        if is_tri(n - a*(a+1)//2): return True
+        a+=1
+    return False
+
+def sum_two_sq(m):
+    x=0
+    while x*x<=m:
+        r=m-x*x
+        s=math.isqrt(r)
+        if s*s==r: return True
+        x+=1
+    return False
+
+# [A]
+bad=0; N=20000
+for n in range(N):
+    if sum_two_tri(n) != sum_two_sq(4*n+1): bad+=1
+print(f"[A] checked n in [0,{N}): mismatches = {bad}")
+
+# [B]
+ok=True
+T=lambda k:k*(k+1)//2
+for a in range(-50,50):
+    for b in range(-50,50):
+        if 4*(T(a)+T(b))+1 != (a+b+1)**2+(a-b)**2: ok=False
+print(f"[B] rotation identity over [-50,50]^2: {'PASS' if ok else 'FAIL'}")
+
+# [C]
+def factor(m):
+    f={}; d=2
+    while d*d<=m:
+        while m%d==0: f[d]=f.get(d,0)+1; m//=d
+        d+=1
+    if m>1: f[m]=f.get(m,0)+1
+    return f
+naive_fail=False; evenpow_ok=True
+for n in range(N):
+    m=4*n+1; f=factor(m)
+    no3 = all(not(p%4==3) for p in f)
+    evenpow = all((e%2==0) for p,e in f.items() if p%4==3)
+    if sum_two_tri(n) != no3 and not naive_fail:
+        naive_fail=True
+        print(f"[C] naive 'no prime==3mod4' FALSE first at n={n}: 4n+1={m}={f}, two-tri={sum_two_tri(n)}")
+    if sum_two_tri(n) != evenpow: evenpow_ok=False
+print(f"[C] even-power characterization over [0,{N}): {'PASS' if evenpow_ok else 'FAIL'}")

--- a/src/data/proofs/erdos-131-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "erdos-131-oq-01-oq-01",
+  "slug": "erdos-131-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos131EGZ",
+    "lineCount": 153,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos131EGZBound.lean",
+    "sorries": 0
+  },
+  "title": "An Erdős–Ginzburg–Ziv Bound for Non-Dividing Sets (Erdős #131)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos131EGZBound.lean",
+    "tags": [
+      "number-theory",
+      "additive-combinatorics",
+      "erdos-problems",
+      "erdos-131",
+      "non-dividing-sets",
+      "erdos-ginzburg-ziv",
+      "zero-sum",
+      "extremal-set-theory",
+      "structural-bound",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 153,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "egz_nondividing_card_bound: the headline structural theorem — if a ∈ A with a ≥ 2 and A is non-dividing (no element divides the sum of any ≥2-element subset of the others), then |A| ≤ 2a − 1. This generalizes the parent file's parity bound (2 ∈ A ⟹ |A| ≤ 3) from the single element a = 2 to every element a ≥ 2, by replacing the ad-hoc parity pigeonhole with the full Erdős–Ginzburg–Ziv theorem at modulus a. Proved unconditionally and axiom-free.",
+      "nondividing_card_le_two_min: the smallest-element bound — a non-dividing set whose every element is ≥ 2 has |A| ≤ 2·min(A) − 1, obtained by applying the EGZ bound at the least element (which gives the tightest constraint). This makes precise the heuristic that small elements force small non-dividing sets, a structural mechanism behind the slow growth of F(N).",
+      "two_in_card_le_three: recovers the parent's parity result two_in_nondividing_bound (2 ∈ A ⟹ |A| ≤ 3) as the immediate a = 2 special case 2·2 − 1 = 3, demonstrating that the EGZ bound subsumes the earlier hand-rolled argument.",
+      "not_nondividing_of_card_gt: the contrapositive certification form — any candidate set with more than 2a − 1 elements for some a ∈ A, a ≥ 2, is provably NOT non-dividing; a fast structural filter for search.",
+      "egz_bound_sharp_at_two: the bound is sharp at a = 2, witnessed by {2,4,5} (non-dividing, contains 2, card 3 = 2·2 − 1), proving 2·a − 1 cannot be lowered in general.",
+      "Mechanism: EGZ (Int.erdos_ginzburg_ziv) is applied to the integer-cast sequence i ↦ (i:ℤ) on A.erase a with modulus n = a; from |A| ≥ 2a one gets |A.erase a| ≥ 2a − 1, so EGZ produces an a-element subset t ⊆ A\\{a} with a ∣ ∑_{i∈t} i, and since a ≥ 2 this subset has ≥ 2 elements, contradicting IsNonDividing at a. The ℤ-divisibility is transported to ℕ via push_cast / exact_mod_cast."
+    ],
+    "prerequisites": [
+      "Int.erdos_ginzburg_ziv (Mathlib): among any 2n − 1 integers there are n whose sum is divisible by n — the Erdős–Ginzburg–Ziv theorem, here the sole nontrivial dependency; it is a fully proved Mathlib corollary of Chevalley–Warning, so the entry is axiom-free.",
+      "Finset.card_erase_of_mem: |A.erase a| = |A| − 1 for a ∈ A, used to meet the EGZ size hypothesis.",
+      "Finset.min'_mem and Finset.min': the least element of a nonempty finset, used for the smallest-element corollary."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.erdos_ginzburg_ziv",
+        "description": "Any sequence of at least 2n − 1 integers contains an n-element subsequence whose sum is divisible by n. Instantiated at modulus n = a on the integer-cast sequence over A.erase a; this is the keystone that upgrades the a = 2 parity pigeonhole to all a ≥ 2.",
+        "module": "Mathlib.Combinatorics.Additive.ErdosGinzburgZiv"
+      },
+      {
+        "theorem": "Finset.card_erase_of_mem",
+        "description": "|A.erase a| = |A| − 1 when a ∈ A; converts the assumed lower bound |A| ≥ 2a into the EGZ size hypothesis 2a − 1 ≤ |A.erase a|.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.min'_mem",
+        "description": "The minimum of a nonempty finset is a member; lets the smallest-element corollary instantiate the main bound at a = min(A).",
+        "module": "Mathlib.Order.Finset.Lattice"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "erdos-131-oq-01-oq-01-oq-01",
+      "question": "Is the EGZ bound |A| ≤ 2a − 1 sharp for a > 2? It is tight at a = 2 ({2,4,5}). For a given smallest element m ≥ 3, does there exist a non-dividing set with smallest element m and exactly 2m − 1 elements, or is the true maximum strictly smaller? Equivalently, characterize the extremal non-dividing sets meeting the EGZ bound.",
+      "significance": "medium"
+    },
+    {
+      "id": "erdos-131-oq-01-oq-01-oq-02",
+      "question": "Can the per-element EGZ bound be aggregated into a nontrivial global upper bound on F(N)? The bound |A| ≤ 2·min(A) − 1 only helps when min(A) is small; combine it with the distribution of small elements (e.g. averaging the EGZ constraint over all a ∈ A, or applying EGZ to residue-class restrictions) to recover or approach the Pham–Zakharov F(N) ≤ N^{1/4+o(1)} ceiling by elementary means.",
+      "significance": "high"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-131",
+      "relationship": "extends",
+      "description": "Generalizes the parent's structural results on non-dividing sets. The parent proves the parity bound 2 ∈ A ⟹ |A| ≤ 3 by a mod-2 pigeonhole; this entry shows that argument is exactly the p = 2 case of Erdős–Ginzburg–Ziv and lifts it to |A| ≤ 2a − 1 for every a ∈ A with a ≥ 2, recovering the parent bound as the a = 2 corollary."
+    },
+    {
+      "targetId": "erdos-131-oq-01",
+      "relationship": "depends-on",
+      "description": "Addresses the structural-bounds direction of the F(N) growth-rate study: rather than chasing the (genuinely open) growth exponent, it contributes a clean, axiom-free per-element upper bound on the size of non-dividing sets in terms of their elements."
+    }
+  ],
+  "references": [
+    {
+      "title": "On some problems in combinatorial number theory",
+      "author": "Paul Erdős",
+      "year": "1975",
+      "venue": "Er75b",
+      "description": "Erdős's problem #131 on non-dividing sets and the function F(N), the maximal size of a subset of {1,…,N} no element of which divides the sum of any distinct others."
+    },
+    {
+      "title": "Theorem in the additive number theory",
+      "author": "Paul Erdős, Abraham Ginzburg, Abraham Ziv",
+      "year": "1961",
+      "venue": "Bull. Res. Council Israel",
+      "description": "The Erdős–Ginzburg–Ziv theorem: any 2n − 1 integers contain n with sum divisible by n. Supplies the zero-sum subset that powers the structural bound; available in Mathlib as Int.erdos_ginzburg_ziv."
+    },
+    {
+      "title": "On the number of monochromatic solutions to additive equations / non-averaging sets",
+      "author": "Huy Tuan Pham, Dmitrii Zakharov",
+      "year": "2024",
+      "venue": "arXiv",
+      "description": "Proves F(N) ≤ N^{1/4+o(1)} via the non-dividing ⟹ non-averaging connection, refuting Erdős's original F(N) > N^{1/2−o(1)} guess; context for the open question of recovering global bounds elementarily."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For a non-dividing set A ⊆ ℕ (no a ∈ A divides the sum of any ≥2-element subset of A \\ {a}) and any a ∈ A with a ≥ 2, the Erdős–Ginzburg–Ziv theorem gives |A| ≤ 2a − 1 (egz_nondividing_card_bound). The argument: if |A| ≥ 2a then |A.erase a| ≥ 2a − 1, so EGZ at modulus a produces an a-element subset t ⊆ A\\{a} with a ∣ ∑_{i∈t} i; as a ≥ 2 this subset has ≥ 2 elements and violates the non-dividing property at a. Instantiating at the least element yields |A| ≤ 2·min(A) − 1 (nondividing_card_le_two_min), and the a = 2 case recovers the parent's parity bound |A| ≤ 3 (two_in_card_le_three), which is sharp via {2,4,5} (egz_bound_sharp_at_two). 153 lines, 7 theorems/lemmas, 1 definition, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The result identifies the parent file's mod-2 parity pigeonhole as the p = 2 instance of Erdős–Ginzburg–Ziv and generalizes it to a uniform per-element structural bound on non-dividing sets, making precise the mechanism by which small elements force small sets — the qualitative reason F(N) grows slowly. It is a fully machine-checked, axiom-free structural contribution to the genuinely-open Erdős #131 growth-rate problem, sidestepping the inaccessible asymptotic exponent in favour of exact finite-set constraints, and points (open question) toward aggregating these per-element bounds into an elementary route to the Pham–Zakharov N^{1/4+o(1)} ceiling."
+  }
+}

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-02/meta.json
@@ -1,0 +1,121 @@
+{
+  "id": "lagrange-four-squares-waring-g2-oq-03-oq-02",
+  "slug": "lagrange-four-squares-waring-g2-oq-03-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "TwoTrianglesTwoSquares",
+    "lineCount": 178,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/TwoTrianglesTwoSquares.lean",
+    "sorries": 0
+  },
+  "title": "Sums of Two Triangular Numbers and the 4n+1 Two-Square Slice",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/TwoTrianglesTwoSquares.lean",
+    "tags": [
+      "number-theory",
+      "sums-of-squares",
+      "two-square-theorem",
+      "triangular-numbers",
+      "two-triangular-numbers",
+      "additive-number-theory",
+      "geometry-of-numbers",
+      "reduction",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 178,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "badge": "original",
+    "originalContributions": [
+      "isSumTwoTriangular_iff: the headline equivalence — for every natural number n, n is a sum of two triangular numbers T(k)=k(k+1)/2 IF AND ONLY IF 4n+1 is a sum of two integer squares. This is the two-summand analogue of the gallery's Gauss Eureka entry (three triangular ⟺ 8n+3 three squares), proved unconditionally and axiom-free.",
+      "isSumTwoTriangular_iff_nat: the natural-number restatement, n is a sum of two triangular numbers iff 4n+1 = x²+y² for naturals x,y; obtained by composing the integer equivalence with the int/nat absolute-value bridge.",
+      "isSumTwoTriangular_iff_factorization: the COMPLETE arithmetic characterization via Mathlib's two-square theorem (Nat.eq_sq_add_sq_iff) — n is a sum of two triangular numbers iff every prime q ≡ 3 (mod 4) divides 4n+1 to an even power. Because the two-square theorem (unlike three-square sufficiency) is fully in Mathlib, this gives a decidable test, making the result strictly stronger than the conditional Gauss Eureka companion. The docstring records the trap that the naive 'no prime factor ≡ 3 mod 4' form is FALSE (n=2=T₁+T₁ while 4·2+1=9=3²).",
+      "sum_tri_identity: the rotation identity 4·(T(a)+T(b))+1 = (a+b+1)² + (a−b)², the linear change of variables (a,b) ↦ (a+b+1, a−b) that bridges triangular sums and two-square representations of 4n+1.",
+      "sq_to_isSumTwoTriangular: the backward direction handled DIVISION-FREE — 4n+1 ≡ 1 (mod 4) forces one square even (=2t) and one odd (=2s+1), and the inverse rotation p=s+t, q=s−t (integers, no halving) yields 2n = p(p+1)+q(q+1); the two non-mixed parity cases are dispatched as 4 ∣ 1 contradictions.",
+      "exists_nat_tri_index: every integer index k gives k(k+1) = j(j+1) for a natural j, formalizing T(k)=T(−1−k) so that negative integer triangular indices contribute nothing new — the lemma that lets the integer construction land back in natural triangular numbers.",
+      "int_sq_iff_nat_sq: a sum of two integer squares equals a sum of two natural squares (the squared quantities depend only on |·|), the bridge from the integer equivalence to Mathlib's natural-number two-square characterization."
+    ],
+    "prerequisites": [
+      "Nat.eq_sq_add_sq_iff (Mathlib): a natural number is a sum of two squares iff every prime ≡ 3 (mod 4) in its factorization occurs to an even power — the two-square theorem that makes the characterization unconditional.",
+      "Nat.mul_div_cancel' and Nat.even_mul_succ_self: exactness of the triangular-number division 2·T(k)=k(k+1).",
+      "Int.even_or_odd, Int.toNat_of_nonneg, Int.abs_eq_natAbs, sq_abs: the parity split of 4n+1 and the integer↔natural square/triangular bridges."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.eq_sq_add_sq_iff",
+        "description": "A natural n is a sum of two squares iff every prime q ≡ 3 (mod 4) has Even (padicValNat q n); supplies the complete arithmetic characterization, replacing the open three-square sufficiency axiom that the Gauss Eureka companion still needs.",
+        "module": "Mathlib.NumberTheory.SumTwoSquares"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel'",
+        "description": "Exact division a ∣ b → a · (b / a) = b; gives 2 · (k(k+1)/2) = k(k+1) so triangular numbers behave as exact halves.",
+        "module": "Mathlib.Algebra.Order.Group.Nat"
+      },
+      {
+        "theorem": "Int.even_or_odd",
+        "description": "Every integer is even or odd; drives the parity case split that forces, from 4n+1 ≡ 1 (mod 4), exactly one of the two squares to be odd.",
+        "module": "Mathlib.Algebra.Parity"
+      },
+      {
+        "theorem": "Int.toNat_of_nonneg",
+        "description": "For 0 ≤ a, ↑a.toNat = a; converts the integer triangular indices p, q (one possibly negative) into the natural indices the predicate IsSumTwoTriangular requires, using k(k+1)=(−1−k)(−k).",
+        "module": "Mathlib.Data.Int.Order"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "lagrange-four-squares-waring-g2-oq-03-oq-02-oq-01",
+      "question": "Quantitative two-triangular count: the number of ordered representations of n as T(a)+T(b) equals the number of representations of 4n+1 as an ordered sum of two squares (the rotation (a,b)↦(a+b+1,a−b) is a bijection ℤ²→{(X,Y): X+Y odd}). Formalize the counting identity r_{2△}(n) = r₂(4n+1) and connect it to the sum-of-two-squares function.",
+      "significance": "medium"
+    },
+    {
+      "id": "lagrange-four-squares-waring-g2-oq-03-oq-02-oq-02",
+      "question": "Unify the two-, three-, and four-triangular slices: two triangular ⟺ 4n+1 two squares (this entry), three triangular ⟺ 8n+3 three squares (Gauss Eureka companion). Is there a single 'd·n + c(d) ⟺ d squares' meta-statement, and does the four-triangular case correspond cleanly to Lagrange's four-square theorem on an arithmetic progression?",
+      "significance": "high"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "The two-summand analogue of the Gauss Eureka companion. Where that entry needs the still-open three-square sufficiency axiom to conclude unconditionally, this entry is fully unconditional and axiom-free because Mathlib supplies the two-square theorem, and it adds the complete arithmetic characterization via prime factorization of 4n+1."
+    },
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03",
+      "relationship": "depends-on",
+      "description": "Companion to the parent three-square sufficiency study: it records the elementary 4n+1 ⟷ two-triangular bijection in the same sums-of-squares ↔ triangular-numbers circle of ideas, using the (a,b)↦(a+b+1,a−b) rotation."
+    }
+  ],
+  "references": [
+    {
+      "title": "Disquisitiones Arithmeticae",
+      "author": "Carl Friedrich Gauss",
+      "year": "1801",
+      "venue": "Articles 291–293",
+      "description": "Gauss's theory of representations by binary quadratic forms and triangular/polygonal numbers; the two-triangular ⟷ 4n+1 sum-of-two-squares correspondence sits in this circle of ideas."
+    },
+    {
+      "title": "Sur la théorie des nombres",
+      "author": "Pierre de Fermat / Leonhard Euler",
+      "year": "1640/1749",
+      "venue": "Fermat's Christmas theorem; Euler's proof",
+      "description": "The two-square theorem characterizing which integers are sums of two squares (every prime ≡ 3 mod 4 to an even power), used here via Mathlib's Nat.eq_sq_add_sq_iff to make the triangular characterization unconditional."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For every natural number n, n is a sum of two triangular numbers T(k)=k(k+1)/2 if and only if 4n+1 is a sum of two integer squares (isSumTwoTriangular_iff). The bridge is the rotation identity 4·(T(a)+T(b))+1 = (a+b+1)²+(a−b)²: the forward direction reads it left-to-right; the backward direction uses that 4n+1 ≡ 1 (mod 4) forces one square even (2t) and one odd (2s+1), so the inverse rotation p=s+t, q=s−t gives 2n = p(p+1)+q(q+1) with no division, and each integer triangular value equals a natural one since T(k)=T(−1−k). Composing with Mathlib's two-square theorem (Nat.eq_sq_add_sq_iff) yields the complete arithmetic test isSumTwoTriangular_iff_factorization: n is a sum of two triangular numbers iff every prime ≡ 3 (mod 4) divides 4n+1 to an even power. 178 lines, 12 theorems/lemmas, 2 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This is the unconditional two-summand analogue of the gallery's Gauss Eureka entry (three triangular ⟺ 8n+3 three squares). Because the two-square theorem is available in Mathlib while three-square sufficiency is not, the two-triangular result is fully machine-checked end to end and even delivers a decidable factorization test, whereas Eureka still rests on an axiom. The pair sharpens the general picture that 'sums of d triangular numbers' is exactly a fixed arithmetic-progression slice of 'sums of d squares', and points toward a unified d=2,3,4 statement (the open question) bridging to Lagrange's four-square theorem."
+  }
+}


### PR DESCRIPTION
## Summary

A verified, axiom-free **structural** contribution to Erdős Problem #131 (non-dividing sets). The parent file proves a *parity* bound — `2 ∈ A ⟹ |A| ≤ 3` — via a mod-2 pigeonhole. That argument is exactly the prime case `p = 2` of the **Erdős–Ginzburg–Ziv theorem**. Since Mathlib now has EGZ for every modulus (`Int.erdos_ginzburg_ziv`), the bound generalizes verbatim:

> **`a ∈ A`, `a ≥ 2`, `IsNonDividing A` ⟹ `|A| ≤ 2a − 1`** (`egz_nondividing_card_bound`)

**Mechanism.** If `|A| ≥ 2a` then `|A.erase a| ≥ 2a − 1`, so EGZ at modulus `n = a`, applied to the integer-cast sequence `i ↦ (i:ℤ)` on `A \ {a}`, gives an `a`-element subset `t ⊆ A \ {a}` with `a ∣ ∑_{i∈t} i`. As `a ≥ 2`, `|t| ≥ 2`, contradicting the non-dividing property at `a`. (ℤ→ℕ divisibility via `push_cast` / `exact_mod_cast`.)

## Theorems
- `egz_nondividing_card_bound` — the headline `|A| ≤ 2a − 1`.
- `nondividing_card_le_two_min` — smallest-element bound `|A| ≤ 2·min(A) − 1` (tightest instance).
- `two_in_card_le_three` — recovers the parent parity bound as the `a = 2` case.
- `not_nondividing_of_card_gt` — contrapositive certification filter.
- `egz_bound_sharp_at_two` — sharpness at `a = 2` via `{2,4,5}`.

## Verification
- `Proofs/Erdos131EGZBound.lean`: 153 lines, 7 theorems/lemmas, 1 def, **0 sorries, 0 axioms**.
- Docker build green on Mathlib v4.26.0.
- `#print axioms` on all results → only `propext`, `Classical.choice`, `Quot.sound` (0-axiom verified).

## Why this is progress
The growth-rate **exponent** of `F(N)` is genuinely open (window `exp(c√log N) ≤ F(N) ≤ N^{1/4+o(1)}`); chasing it by enumeration is hopeless. This entry instead contributes exact finite-set structure — making precise that *small elements force small non-dividing sets* — the qualitative reason `F(N)` grows slowly. Open follow-ups (in `meta.json`): sharpness for `a > 2`, and aggregating the per-element bounds into a global `F(N)` bound.

## ⚠️ Parent bit-rot (for mechanic)
The file is **self-contained** (it re-states `IsNonDividing` verbatim) because the parent `Proofs/Erdos131Problem.lean` **does not compile** on Mathlib v4.26.0:
- orphan docstrings before `axiom` declarations (lines 127, 173) → `unexpected token '/--'`;
- pre-v4.26 `Finset.card_sdiff` argument order (line 479) → `omega` failure (line 488).

The `erdos-131` gallery entry therefore currently overclaims "verified" — flagged for a separate mechanic repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)