### PR TITLE
research(area-of-circle-oq-02-oq-02): n-ball volume vanishes Vₙ → 0 in high dimensions [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ02OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ02OQ02.lean
@@ -1,0 +1,229 @@
+/-
+  N-Ball Volume Vanishes in High Dimensions:  V_n → 0  as  n → ∞
+
+  Open Question: area-of-circle-oq-02-oq-02
+  Parent:        area-of-circle-oq-02  (N-Dimensional Ball Volume Formula)
+
+  The volume of the unit n-ball is
+
+      V_n = π^(n/2) / Γ(n/2 + 1).
+
+  Although V_n first GROWS with n (it peaks near n = 5, where V_5 ≈ 5.26),
+  it ultimately DECAYS to 0: in high dimensions the unit ball occupies a
+  vanishing fraction of its bounding cube.  This file proves the limit.
+
+  Main results:
+  * `unitBallVolume_two_mul`            : V_{2m} = π^m / m!     (exact even closed form)
+  * `unitBallVolume_two_mul_add_one_le` : V_{2m+1} ≤ 2·π^m / m! (odd uniform bound)
+  * `unitBallVolume_tendsto_zero`       : Tendsto unitBallVolume atTop (𝓝 0)   ★ MAIN
+  * `volume_unitBall_toReal_tendsto_zero`
+        : the actual Lebesgue measure of the unit ball in
+          EuclideanSpace ℝ (Fin n) tends to 0.
+
+  Strategy (elementary; the limit step is Gamma-free):
+  * The even subsequence has the exact closed form V_{2m} = π^m / m!, which
+    tends to 0 by Mathlib's `tendsto_pow_div_factorial_atTop`
+    (an exponential is eventually beaten by a factorial).
+  * The odd subsequence is bounded by 2·π^m / m!, proved by induction from
+    the recurrence V_n = V_{n-2}·2π/n, since each step's factor satisfies
+    2π/(2m+3) ≤ π/(m+1).  A squeeze then sends it to 0.
+  * The two subsequences cover ℕ, so an ε–N parity argument combines them.
+
+  This file is deliberately self-contained (it imports only Mathlib and
+  re-derives the unit ball volume, its recurrence, and the Euclidean
+  scaling law from `EuclideanSpace.volume_ball`).  It carries no axioms
+  and no `sorry`s.
+-/
+
+import Mathlib
+
+open MeasureTheory Metric Real Filter Topology
+open scoped Nat
+
+namespace AreaOfCircleOQ02OQ02
+
+/-
+## Part I: The unit n-ball volume and its basic structure
+-/
+
+/-- The volume of the unit `n`-ball: `V_n = π^(n/2) / Γ(n/2 + 1)`. -/
+noncomputable def unitBallVolume (n : ℕ) : ℝ :=
+  π ^ ((n : ℝ) / 2) / Gamma ((n : ℝ) / 2 + 1)
+
+/-- The unit ball volume is non-negative. -/
+theorem unitBallVolume_nonneg (n : ℕ) : 0 ≤ unitBallVolume n := by
+  unfold unitBallVolume
+  apply div_nonneg
+  · exact rpow_nonneg (le_of_lt pi_pos) _
+  · exact le_of_lt (Gamma_pos_of_pos (by positivity))
+
+/-- Helper: `Γ(3/2) = √π / 2`, from `Γ(1/2 + 1) = (1/2)·Γ(1/2)` and `Γ(1/2) = √π`. -/
+private lemma gamma_three_div_two : Gamma (3 / 2 : ℝ) = √π / 2 := by
+  have h := Real.Gamma_add_one (show (1 / 2 : ℝ) ≠ 0 from by norm_num)
+  rw [show (1 : ℝ) / 2 + 1 = 3 / 2 from by ring] at h
+  rw [h, Gamma_one_half_eq]
+  ring
+
+/-- For `n = 1`, the unit ball is the interval `[-1,1]`, of length 2. -/
+theorem unitBallVolume_one : unitBallVolume 1 = 2 := by
+  unfold unitBallVolume
+  simp only [Nat.cast_one]
+  rw [show (1 : ℝ) / 2 + 1 = 3 / 2 from by ring, gamma_three_div_two]
+  rw [← Real.sqrt_eq_rpow]
+  have h : (0 : ℝ) < √π := Real.sqrt_pos.mpr Real.pi_pos
+  field_simp [h.ne']
+
+/-- For `n = 2`, the unit ball is the unit disk, of area π (the area-of-circle case). -/
+theorem unitBallVolume_two : unitBallVolume 2 = π := by
+  unfold unitBallVolume
+  simp only [Nat.cast_ofNat]
+  rw [show (2 : ℝ) / 2 + 1 = 2 from by ring, show (2 : ℝ) / 2 = 1 from by ring]
+  rw [rpow_one, Gamma_two]
+  simp
+
+/-- **Dimension recurrence.**  `V_n = V_{n-2} · 2π / n` for `n ≥ 2`, from the
+    Gamma functional equation `Γ(x+1) = x·Γ(x)`. -/
+theorem unitBallVolume_recurrence (n : ℕ) (hn : 2 ≤ n) :
+    unitBallVolume n = unitBallVolume (n - 2) * (2 * π) / n := by
+  unfold unitBallVolume
+  have hnn : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  have hn2 : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have hcast : ((n - 2 : ℕ) : ℝ) = (n : ℝ) - 2 := by
+    rw [Nat.cast_sub hn]; norm_num
+  rw [hcast, show (n : ℝ) / 2 = ((n : ℝ) - 2) / 2 + 1 from by ring,
+      Real.rpow_add pi_pos, Real.rpow_one]
+  have hpos : (0 : ℝ) < ((n : ℝ) - 2) / 2 + 1 := by linarith
+  rw [Real.Gamma_add_one (ne_of_gt hpos)]
+  have hG : Gamma (((n : ℝ) - 2) / 2 + 1) ≠ 0 := ne_of_gt (Gamma_pos_of_pos hpos)
+  have ha1 : ((n : ℝ) - 2) / 2 + 1 ≠ 0 := ne_of_gt hpos
+  rw [div_mul_eq_mul_div, div_div,
+      div_eq_div_iff (mul_ne_zero ha1 hG) (mul_ne_zero hG hnn)]
+  ring
+
+/-
+## Part II: Closed form / bound for the even / odd subsequences
+-/
+
+/-- **Even closed form.**  `V_{2m} = π^m / m!`, since `Γ(m+1) = m!`. -/
+theorem unitBallVolume_two_mul (m : ℕ) :
+    unitBallVolume (2 * m) = π ^ m / (m ! : ℝ) := by
+  unfold unitBallVolume
+  rw [show ((2 * m : ℕ) : ℝ) / 2 = (m : ℝ) by push_cast; ring,
+      Real.rpow_natCast, Real.Gamma_nat_eq_factorial]
+
+/-- **Odd uniform bound.**  `V_{2m+1} ≤ 2·π^m / m!`, by induction from the
+    recurrence: each step multiplies by `2π/(2m+3) ≤ π/(m+1)`. -/
+theorem unitBallVolume_two_mul_add_one_le (m : ℕ) :
+    unitBallVolume (2 * m + 1) ≤ 2 * π ^ m / (m ! : ℝ) := by
+  induction m with
+  | zero =>
+    rw [show (2 * 0 + 1) = 1 from rfl, unitBallVolume_one]
+    norm_num
+  | succ k ih =>
+    have hrec := unitBallVolume_recurrence (2 * (k + 1) + 1) (by omega)
+    have hidx : 2 * (k + 1) + 1 - 2 = 2 * k + 1 := by omega
+    rw [hidx] at hrec
+    rw [hrec]
+    have hfac : (0 : ℝ) < (k ! : ℝ) := by exact_mod_cast Nat.factorial_pos k
+    have hAk : unitBallVolume (2 * k + 1) * (k ! : ℝ) ≤ 2 * π ^ k :=
+      (le_div_iff₀ hfac).mp ih
+    have ha : 0 ≤ unitBallVolume (2 * k + 1) := unitBallVolume_nonneg _
+    have hpi : 0 < π := pi_pos
+    have hc : (0 : ℝ) < ((2 * (k + 1) + 1 : ℕ) : ℝ) := by positivity
+    have hd : (0 : ℝ) < (((k + 1)! : ℕ) : ℝ) := by exact_mod_cast Nat.factorial_pos (k + 1)
+    rw [div_le_div_iff₀ hc hd]
+    have hcast1 : ((2 * (k + 1) + 1 : ℕ) : ℝ) = 2 * (k : ℝ) + 3 := by push_cast; ring
+    have hcast2 : (((k + 1)! : ℕ) : ℝ) = ((k : ℝ) + 1) * (k ! : ℝ) := by
+      rw [Nat.factorial_succ]; push_cast; ring
+    rw [hcast1, hcast2, pow_succ]
+    nlinarith [mul_le_mul_of_nonneg_left hAk (by positivity : (0 : ℝ) ≤ 2 * π * ((k : ℝ) + 1)),
+               pow_pos hpi k, hpi, mul_pos (pow_pos hpi k) hpi, ha]
+
+/-
+## Part III: Each subsequence tends to 0
+-/
+
+/-- The even subsequence tends to 0: `V_{2m} = π^m / m! → 0`. -/
+theorem tendsto_even :
+    Tendsto (fun m => unitBallVolume (2 * m)) atTop (𝓝 0) :=
+  Filter.Tendsto.congr (fun m => (unitBallVolume_two_mul m).symm)
+    (FloorSemiring.tendsto_pow_div_factorial_atTop (π : ℝ))
+
+/-- The odd subsequence tends to 0, squeezed by `2·π^m / m! → 0`. -/
+theorem tendsto_odd :
+    Tendsto (fun m => unitBallVolume (2 * m + 1)) atTop (𝓝 0) := by
+  have hg : Tendsto (fun m => 2 * π ^ m / (m ! : ℝ)) atTop (𝓝 0) := by
+    have h := (FloorSemiring.tendsto_pow_div_factorial_atTop (π : ℝ)).const_mul (2 : ℝ)
+    simp only [mul_zero] at h
+    exact Filter.Tendsto.congr (fun m => (mul_div_assoc 2 (π ^ m) ((m ! : ℝ))).symm) h
+  exact squeeze_zero (fun m => unitBallVolume_nonneg _) unitBallVolume_two_mul_add_one_le hg
+
+/-
+## Part IV: The main limit  V_n → 0
+-/
+
+/-- **Main result.**  The unit `n`-ball volume vanishes as `n → ∞`:
+
+      `V_n = π^(n/2) / Γ(n/2 + 1) ⟶ 0`.
+
+    The even and odd subsequences each tend to 0 and together exhaust ℕ, so an
+    ε–N argument over the parity of `n` delivers the full limit. -/
+theorem unitBallVolume_tendsto_zero :
+    Tendsto unitBallVolume atTop (𝓝 0) := by
+  rw [Metric.tendsto_atTop]
+  intro ε hε
+  obtain ⟨Me, hMe⟩ := (Metric.tendsto_atTop.mp tendsto_even) ε hε
+  obtain ⟨Mo, hMo⟩ := (Metric.tendsto_atTop.mp tendsto_odd) ε hε
+  refine ⟨2 * Me + 2 * Mo + 1, fun n hn => ?_⟩
+  obtain ⟨k, hk | hk⟩ := Nat.even_or_odd' n
+  · subst hk
+    have hk' : Me ≤ k := by omega
+    simpa using hMe k hk'
+  · subst hk
+    have hk' : Mo ≤ k := by omega
+    simpa using hMo k hk'
+
+/-- Restatement: for every `ε > 0` the unit ball volume is eventually `< ε`. -/
+theorem unitBallVolume_eventually_lt (ε : ℝ) (hε : 0 < ε) :
+    ∃ N, ∀ n ≥ N, unitBallVolume n < ε := by
+  obtain ⟨N, hN⟩ := (Metric.tendsto_atTop.mp unitBallVolume_tendsto_zero) ε hε
+  refine ⟨N, fun n hn => ?_⟩
+  have h := hN n hn
+  rw [Real.dist_eq, sub_zero, abs_of_nonneg (unitBallVolume_nonneg n)] at h
+  exact h
+
+/-
+## Part V: Measure-theoretic headline
+
+The actual Lebesgue measure of the unit ball in Euclidean space tends to 0.
+We derive the Euclidean scaling law directly from `EuclideanSpace.volume_ball`,
+keeping the whole development assumption-free.
+-/
+
+/-- Bridge identity `(√π)^n = π^(n/2)` between Mathlib's and the gallery's forms. -/
+private lemma sqrt_pi_pow_eq (n : ℕ) : (Real.sqrt π) ^ n = π ^ ((n : ℝ) / 2) := by
+  rw [Real.sqrt_eq_rpow, ← Real.rpow_natCast (π ^ ((1 : ℝ) / 2)) n,
+      ← Real.rpow_mul Real.pi_pos.le]
+  congr 1
+  ring
+
+/-- The Lebesgue measure of the unit ball equals `V_n` for `n ≥ 1`, from
+    `EuclideanSpace.volume_ball`. -/
+theorem volume_unitBall_eq (n : ℕ) (hn : 0 < n) :
+    volume (ball (0 : EuclideanSpace ℝ (Fin n)) 1) = ENNReal.ofReal (unitBallVolume n) := by
+  haveI : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
+  rw [EuclideanSpace.volume_ball, Fintype.card_fin]
+  simp only [ENNReal.ofReal_one, one_pow, one_mul]
+  unfold unitBallVolume
+  rw [sqrt_pi_pow_eq]
+
+/-- **Geometric headline.**  The Lebesgue measure of the unit ball in
+    `EuclideanSpace ℝ (Fin n)` tends to 0 as the dimension `n → ∞`. -/
+theorem volume_unitBall_toReal_tendsto_zero :
+    Tendsto (fun n => (volume (ball (0 : EuclideanSpace ℝ (Fin n)) 1)).toReal)
+      atTop (𝓝 0) := by
+  refine Filter.Tendsto.congr' ?_ unitBallVolume_tendsto_zero
+  filter_upwards [eventually_gt_atTop 0] with n hn
+  rw [volume_unitBall_eq n hn, ENNReal.toReal_ofReal (unitBallVolume_nonneg n)]
+
+end AreaOfCircleOQ02OQ02

--- a/research/problems/area-of-circle-oq-02-oq-02/knowledge.md
+++ b/research/problems/area-of-circle-oq-02-oq-02/knowledge.md
@@ -1,0 +1,64 @@
+# Knowledge Base: area-of-circle-oq-02-oq-02
+
+**Problem**: Prove Vₙ → 0 as n → ∞ — the unit n-ball volume vanishes in high dimensions
+**Status**: COMPLETED (0 sorries, 0 axioms)
+**Lean file**: `proofs/Proofs/AreaOfCircleOQ02OQ02.lean`
+
+---
+
+## Session 2026-06-20 (Session 1) — Proof Complete
+
+**Mode**: FRESH (self-contained)
+**Outcome**: completed
+
+### What I Did
+
+Proved `unitBallVolume_tendsto_zero : Tendsto unitBallVolume atTop (𝓝 0)` where
+`unitBallVolume n = π^(n/2)/Γ(n/2+1)`, plus the measure-theoretic corollary
+`volume_unitBall_toReal_tendsto_zero`. Created the gallery entry (meta.json).
+
+### Proof Architecture (Gamma-free at the limit step)
+
+1. **Even closed form**: `V₂ₘ = πᵐ/m!` exactly, because `Γ(m+1) = m!`
+   (`Real.Gamma_nat_eq_factorial`) and `π^((2m)/2) = πᵐ` (`Real.rpow_natCast`).
+   Tends to 0 by `FloorSemiring.tendsto_pow_div_factorial_atTop` (cⁿ/n! → 0).
+
+2. **Odd bound**: `V₂ₘ₊₁ ≤ 2·πᵐ/m!`, by induction on m from the recurrence
+   `Vₙ = Vₙ₋₂·2π/n`. Step factor `2π/(2m+3) ≤ π/(m+1)`. The succ step clears
+   denominators with `div_le_div_iff₀` then closes with `nlinarith` fed
+   `mul_le_mul_of_nonneg_left ih (0 ≤ 2π(k+1))` and `π^k·π > 0`. Squeeze to 0.
+
+3. **Combine**: even and odd subsequences exhaust ℕ, so `Metric.tendsto_atTop` +
+   `Nat.even_or_odd'` + an ε–N argument (`N = 2·Mₑ + 2·Mₒ + 1`, `omega` for the
+   index bounds) gives the full limit. No dedicated even/odd combinator lemma needed.
+
+4. **Measure headline**: `EuclideanSpace.volume_ball` + bridge `(√π)ⁿ = π^(n/2)`
+   gives `volume(ball 0 1) = ofReal(Vₙ)` for n ≥ 1; `Tendsto.congr'` over
+   `eventually_gt_atTop 0` transports the limit to `.toReal`.
+
+### Gotchas (Mathlib v4.26.0)
+
+- **Parent file `AreaOfCircleOQ02.lean` is BIT-ROTTED on main** — `unitBallVolume_recurrence`
+  (line ~120) and `area_scaling_2d` (lines ~163/167, `hr.le` invalid since `hr : 0 ≤ r`)
+  do not compile. This is why this file is fully self-contained instead of importing the
+  parent. Flag for a mechanic. (Auditors miss it: cheap-check, not lake build.)
+- `field_simp` output on the recurrence is **non-deterministic** (left `n·n⁻¹` one run,
+  a different fraction the next). Replaced with deterministic
+  `div_mul_eq_mul_div, div_div, div_eq_div_iff (mul_ne_zero ..) (mul_ne_zero ..); ring`.
+- Recurrence: rewrite Nat `↑(n-2)` to `↑n - 2` (`Nat.cast_sub hn; norm_num`) BEFORE the
+  exponent/Gamma rewrites so `ring` can verify `n = 2·((n-2)/2+1)`.
+- `pi_nonneg.le` does NOT typecheck (`pi_nonneg : 0 ≤ π` already) — use `Real.pi_pos.le`.
+- `le_div_iff₀` / `div_le_div_iff₀` are the current (non-deprecated) names.
+
+### Files Added
+- `proofs/Proofs/AreaOfCircleOQ02OQ02.lean` (229 lines, 12 thm / 2 lemma / 1 def)
+- `src/data/proofs/area-of-circle-oq-02-oq-02/meta.json`
+
+### Verification
+`#print axioms unitBallVolume_tendsto_zero` → `[propext, Classical.choice, Quot.sound]`
+(no `Lean.ofReduceBool`, no `sorryAx`). Docker build green (7743 jobs).
+
+### Open Follow-ups
+- Quantitative decay rate (Stirling): `Vₙ ~ (2πe/n)^(n/2)/√(nπ)`.
+- One-statement non-monotonicity: increasing for n ≤ 5, decreasing for n ≥ 5.
+- Ratio `Vₙ/2ⁿ` (ball vs bounding cube) → 0 super-exponentially.

--- a/src/data/proofs/area-of-circle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-02/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "area-of-circle-oq-02-oq-02",
+  "title": "N-Ball Volume Vanishes in High Dimensions: Vₙ → 0",
+  "slug": "area-of-circle-oq-02-oq-02",
+  "description": "Proves that the unit n-ball volume Vₙ = π^(n/2)/Γ(n/2+1) tends to 0 as n → ∞. Although Vₙ first grows (peaking near n = 5), it ultimately decays to zero — in high dimensions the unit ball occupies a vanishing fraction of its bounding cube. The proof splits into even and odd subsequences: V₂ₘ = πᵐ/m! has an exact closed form that vanishes by the factorial-beats-exponential limit, and V₂ₘ₊₁ ≤ 2·πᵐ/m! is bounded by induction from the dimension recurrence, then squeezed. A measure-theoretic corollary shows the actual Lebesgue volume of the Euclidean unit ball tends to 0.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-20",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "measure-theory",
+      "geometry",
+      "n-ball-volume",
+      "gamma-function",
+      "asymptotics",
+      "limits"
+    ],
+    "proofRepoPath": "Proofs/AreaOfCircleOQ02OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 229,
+    "originalContributions": [
+      "unitBallVolume_tendsto_zero: the unit n-ball volume Vₙ = π^(n/2)/Γ(n/2+1) tends to 0 as n → ∞ (main result)",
+      "unitBallVolume_two_mul: exact even closed form V₂ₘ = πᵐ/m! (since Γ(m+1) = m!)",
+      "unitBallVolume_two_mul_add_one_le: uniform odd bound V₂ₘ₊₁ ≤ 2·πᵐ/m!, proved by induction from the recurrence with step factor 2π/(2m+3) ≤ π/(m+1)",
+      "unitBallVolume_recurrence: the dimension recurrence Vₙ = Vₙ₋₂·2π/n (re-derived self-contained from the Gamma functional equation)",
+      "volume_unitBall_toReal_tendsto_zero: the Lebesgue measure of the unit ball in EuclideanSpace ℝ (Fin n) tends to 0, via EuclideanSpace.volume_ball",
+      "unitBallVolume_eventually_lt: for every ε > 0 the volume is eventually below ε"
+    ],
+    "assumptions": "0 axioms and 0 sorries. Fully machine-verified. The main limit and all supporting lemmas depend only on the foundational axioms propext, Classical.choice, Quot.sound (no native_decide / Lean.ofReduceBool).",
+    "mathlibDependencies": [
+      {
+        "theorem": "FloorSemiring.tendsto_pow_div_factorial_atTop",
+        "description": "cⁿ/n! → 0: an exponential is eventually beaten by a factorial. Drives both subsequence limits.",
+        "module": "Mathlib.Topology.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "Real.Gamma_nat_eq_factorial",
+        "description": "Γ(n+1) = n!, giving the exact even closed form V₂ₘ = πᵐ/m!.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Real.Gamma_add_one",
+        "description": "Γ(x+1) = x·Γ(x), the functional equation behind the dimension recurrence.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "EuclideanSpace.volume_ball",
+        "description": "Volume of the n-ball in Euclidean space; bridges the formula to the actual Lebesgue measure.",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls"
+      }
+    ],
+    "theoremCount": 12,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The volume of the unit ball in n-dimensional Euclidean space, Vₙ = π^(n/2)/Γ(n/2+1), was computed in closed form in the 19th century. One of its most counterintuitive features is its asymptotic behaviour: the sequence V₀ = 1, V₁ = 2, V₂ = π ≈ 3.14, V₃ ≈ 4.19, V₄ ≈ 4.93, V₅ ≈ 5.26 increases up to dimension five, then turns around and decreases to 0. The maximum sits at n = 5 because the ratio Vₙ/Vₙ₋₂ = 2π/n crosses 1 near n = 2π ≈ 6.28. As n grows the Gamma function in the denominator (super-exponential) overwhelms the π^(n/2) in the numerator (exponential), so Vₙ → 0. Geometrically this is the 'concentration of measure' phenomenon: in high dimensions almost all of the volume of the bounding cube [-1,1]ⁿ lies near its corners, and the inscribed ball becomes negligible.",
+    "problemStatement": "Prove that the unit n-ball volume Vₙ = π^(n/2)/Γ(n/2+1) converges to 0 as n → ∞, and that the actual Lebesgue measure of the unit ball in EuclideanSpace ℝ (Fin n) does likewise.",
+    "proofStrategy": "Split ℕ into even and odd subsequences. For even dimensions the formula collapses to the exact closed form V₂ₘ = πᵐ/m! (because Γ(m+1) = m!), which tends to 0 by Mathlib's FloorSemiring.tendsto_pow_div_factorial_atTop. For odd dimensions, the recurrence Vₙ = Vₙ₋₂·2π/n gives, by a short induction, the uniform bound V₂ₘ₊₁ ≤ 2·πᵐ/m! (each step's factor satisfies 2π/(2m+3) ≤ π/(m+1)); a squeeze sends it to 0 as well. Finally, since the two subsequences exhaust ℕ, an ε–N argument over the parity of n combines them into the full limit. The file is self-contained: it re-derives the volume formula, its recurrence, and the Euclidean scaling law from EuclideanSpace.volume_ball, and carries no axioms.",
+    "text": "The unit n-ball volume Vₙ is famous for its non-monotone, ultimately vanishing behaviour. This entry gives a fully verified, elementary proof that Vₙ → 0 in which the limit step itself is Gamma-free: the even subsequence is exactly πᵐ/m!, the odd subsequence is sandwiched by 2·πᵐ/m!, and both vanish because a factorial eventually beats an exponential. A measure-theoretic corollary lifts the statement to the genuine Lebesgue measure of the Euclidean unit ball.",
+    "keyInsights": [
+      "Even dimensions have the exact closed form V₂ₘ = πᵐ/m!, reducing the limit to the classic fact that xⁿ/n! → 0.",
+      "Odd dimensions need no closed form: the recurrence Vₙ = Vₙ₋₂·2π/n yields V₂ₘ₊₁ ≤ 2·πᵐ/m! because 2π/(2m+3) ≤ π/(m+1) at every step.",
+      "The two subsequences cover ℕ, so the full limit follows from an ε–N parity argument — no separate even/odd combinator lemma is required.",
+      "The non-monotonicity (Vₙ grows until n = 5) is invisible to the proof: only the eventual factorial dominance matters.",
+      "The bound V₂ₘ₊₁ ≤ 2·πᵐ/m! is uniform in m and reuses the same factorial limit as the even case, so a single Mathlib lemma drives both halves."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-setup",
+      "title": "Header, Imports, and the Volume Definition",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Documentation header on the concentration-of-measure phenomenon and the proof strategy. Imports Mathlib; defines unitBallVolume n = π^(n/2)/Γ(n/2+1) and proves its non-negativity.",
+      "mathContext": "$V_n = \\pi^{n/2}/\\Gamma(n/2+1) \\ge 0$."
+    },
+    {
+      "id": "basic-values",
+      "title": "Basic Values and the Dimension Recurrence",
+      "startLine": 60,
+      "endLine": 99,
+      "summary": "Helper Γ(3/2) = √π/2; the special values V₁ = 2 and V₂ = π; and the recurrence Vₙ = Vₙ₋₂·2π/n for n ≥ 2, derived from Γ(x+1) = x·Γ(x) via a deterministic div_eq_div_iff + ring closing.",
+      "mathContext": "$V_n = V_{n-2}\\cdot 2\\pi/n$, from $\\Gamma(n/2+1) = (n/2)\\,\\Gamma(n/2)$."
+    },
+    {
+      "id": "subsequence-bounds",
+      "title": "Even Closed Form and Odd Bound",
+      "startLine": 101,
+      "endLine": 138,
+      "summary": "V₂ₘ = πᵐ/m! exactly (via Γ(m+1) = m!); and V₂ₘ₊₁ ≤ 2·πᵐ/m! by induction from the recurrence, using 2π/(2m+3) ≤ π/(m+1) and an nlinarith step.",
+      "mathContext": "$V_{2m} = \\pi^m/m!$ and $V_{2m+1} \\le 2\\,\\pi^m/m!$."
+    },
+    {
+      "id": "subsequence-limits",
+      "title": "Each Subsequence Tends to 0",
+      "startLine": 140,
+      "endLine": 157,
+      "summary": "Both V₂ₘ and V₂ₘ₊₁ tend to 0: the even case directly from tendsto_pow_div_factorial_atTop, the odd case by squeeze_zero against 2·πᵐ/m!.",
+      "mathContext": "$V_{2m} \\to 0$ and $V_{2m+1} \\to 0$ as $m \\to \\infty$."
+    },
+    {
+      "id": "main-limit",
+      "title": "The Main Limit Vₙ → 0",
+      "startLine": 159,
+      "endLine": 199,
+      "summary": "unitBallVolume_tendsto_zero: an ε–N parity argument combining the two subsequence limits. Plus unitBallVolume_eventually_lt restating it as 'eventually below ε'.",
+      "mathContext": "$\\lim_{n\\to\\infty} V_n = 0$."
+    },
+    {
+      "id": "measure-headline",
+      "title": "Measure-Theoretic Headline",
+      "startLine": 201,
+      "endLine": 229,
+      "summary": "Bridge lemma (√π)ⁿ = π^(n/2); the identity volume(ball) = ofReal(Vₙ) for n ≥ 1 from EuclideanSpace.volume_ball; and volume_unitBall_toReal_tendsto_zero, the actual Lebesgue measure of the unit ball tending to 0.",
+      "mathContext": "$\\mathrm{vol}(B^n(1)) \\to 0$ in $\\mathbb{R}$ as $n \\to \\infty$."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) proof that the unit n-ball volume Vₙ = π^(n/2)/Γ(n/2+1) vanishes as n → ∞, together with the corresponding statement for the genuine Lebesgue measure of the Euclidean unit ball. The argument is elementary: an exact even closed form πᵐ/m!, a uniform odd bound 2·πᵐ/m!, and an ε–N parity combination.",
+    "implications": "Formalizes the 'concentration of measure' fact that high-dimensional balls are negligible relative to their bounding cubes. The self-contained recurrence and scaling derivations make the entry independent of the parent file's axiom.",
+    "openQuestions": [
+      "Quantify the decay rate: prove Vₙ ~ (2πe/n)^(n/2)/√(nπ) (Stirling) and a clean exponential upper bound.",
+      "Locate the maximum rigorously: prove Vₙ is increasing for n ≤ 5 and decreasing for n ≥ 5 in one statement.",
+      "Extend to the ratio Vₙ/2ⁿ (ball vs. bounding cube), showing it tends to 0 super-exponentially."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-02",
+      "relationship": "extends",
+      "description": "Adds the asymptotic n → ∞ behaviour to the parent's n-ball volume formula Vₙ = π^(n/2)/Γ(n/2+1)."
+    },
+    {
+      "targetId": "area-of-circle-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Both derive the Euclidean scaling law from EuclideanSpace.volume_ball; this entry uses the n = 1 unit-ball case for its measure-theoretic corollary."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "AreaOfCircleOQ02OQ02",
+    "lineCount": 229,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "path": "Proofs/AreaOfCircleOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves that the unit **n-ball volume vanishes in high dimensions**:

> `unitBallVolume_tendsto_zero : Tendsto unitBallVolume atTop (𝓝 0)`

where `unitBallVolume n = π^(n/2) / Γ(n/2 + 1)`. Although Vₙ first *grows* (peaking near n = 5, where V₅ ≈ 5.26), it ultimately decays to 0 — the concentration-of-measure fact that a high-dimensional ball is negligible relative to its bounding cube. A measure-theoretic corollary lifts this to the genuine Lebesgue measure of the Euclidean unit ball.

## Proof architecture (the limit step is Gamma-free)

- **Even subsequence** — exact closed form `V₂ₘ = πᵐ/m!` (since `Γ(m+1) = m!`), which tends to 0 by Mathlib's `FloorSemiring.tendsto_pow_div_factorial_atTop` (a factorial eventually beats an exponential).
- **Odd subsequence** — uniform bound `V₂ₘ₊₁ ≤ 2·πᵐ/m!`, proved by induction from the dimension recurrence `Vₙ = Vₙ₋₂·2π/n` (each step's factor satisfies `2π/(2m+3) ≤ π/(m+1)`); a squeeze sends it to 0.
- **Combine** — the two subsequences exhaust ℕ, so an ε–N argument over the parity of n (`Nat.even_or_odd'`) yields the full limit; no dedicated combinator lemma is needed.
- **Measure headline** — `EuclideanSpace.volume_ball` + the bridge `(√π)ⁿ = π^(n/2)` give `volume(ball 0 1) = ofReal(Vₙ)` for n ≥ 1, transported to `.toReal` via `Tendsto.congr'`.

## Verification

- Docker build green (7743 jobs, Mathlib v4.26.0).
- `#print axioms unitBallVolume_tendsto_zero` → `[propext, Classical.choice, Quot.sound]` only (no `Lean.ofReduceBool`, no `sorryAx`).
- **0 sorries, 0 axioms.** 12 theorems / 2 lemmas / 1 def, 229 lines.

## Notes

- The file is **self-contained** (imports only `Mathlib`): it re-derives the volume definition, the recurrence, and the Euclidean scaling law. This was necessary because the parent `Proofs/AreaOfCircleOQ02.lean` is currently **bit-rotted on `main`** (its `unitBallVolume_recurrence` and `area_scaling_2d` no longer compile under Mathlib v4.26.0) — flagged separately for a mechanic.
- Adds gallery entry `src/data/proofs/area-of-circle-oq-02-oq-02/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)