### PR TITLE
audit: mark 2 newest gallery proofs clean (erdos-131-oq-01-oq-01, area-of-circle-oq-02-oq-02)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17457,8 +17457,20 @@
       "issues": [],
       "lastAudited": "2026-06-20T00:00:00Z",
       "result": "clean"
+    },
+    "erdos-131-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T00:00:00Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T00:00:00Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-20T00:00:00Z"
+  "lastUpdated": "2026-06-21T00:00:00Z"
 }


### PR DESCRIPTION
## Auditor: persist clean marks for 2 never-audited gallery proofs

Two gallery proofs merged recently (#27277, #27279) but were absent from `audit-tracker.json` entries map — the perpetual "never-audited" loop. Both deep-audited **clean** at HEAD 8a5210942e9.

### erdos-131-oq-01-oq-01 — `Erdos131EGZBound.lean` (153 L)
- verified / original / 0-axiom; 6 theorems + 1 def
- 0 sorry, 0 native_decide, 0 structures, 0 True stubs
- EGZ structural bound `|A| ≤ 2a−1` for non-dividing sets via Mathlib `Int.erdos_ginzburg_ziv`; finite checks use kernel `decide` (no `Lean.ofReduceBool`); sharpness witness `{2,4,5}`

### area-of-circle-oq-02-oq-02 — `AreaOfCircleOQ02OQ02.lean` (229 L)
- verified / original / 0-axiom; 12 theorems + 1 def
- 0 sorry (only docstring mention), 0 native_decide, 0 structures
- n-ball volume `Vₙ = π^(n/2)/Γ(n/2+1) → 0`; closed-form def tied to real Lebesgue `volume (ball …)` via `volume_unitBall_eq`; assumptions field honestly discloses foundational-only axioms

Full-gallery cheap-check sweep at this HEAD: 2791 metas, 0 missing files, 0 verified-with-sorry, 52 native_decide all example-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)