### PR TITLE
research(erdos-131-oq-01-oq-01-oq-01): sharpen EGZ bound |A|≤2a−1 to Davenport bound |A|≤a+1

### DIFF
--- a/proofs/Proofs/Erdos131DavenportBound.lean
+++ b/proofs/Proofs/Erdos131DavenportBound.lean
@@ -1,0 +1,266 @@
+/-
+  Erdős Problem #131 — Non-Dividing Sets
+  Follow-up (oq-01-oq-01-oq-01): sharpening the EGZ bound `|A| ≤ 2a − 1` to the
+  Davenport bound `|A| ≤ a + 1`.
+
+  Source: https://erdosproblems.com/131
+  Companion to: `Proofs.Erdos131Problem` (def `Erdos131.IsNonDividing`) and the
+  EGZ follow-up `Proofs.Erdos131EGZBound` (`egz_nondividing_card_bound`).
+
+  NOTE.  This file is deliberately SELF-CONTAINED: it re-states `IsNonDividing`
+  (verbatim from the parent) rather than importing the companions, because the
+  parent file does not currently compile against the pinned Mathlib (v4.26.0).
+  Decoupling keeps this contribution axiom-free and independently verifiable.
+
+  ## What this file adds
+
+  The EGZ follow-up proves, via `Int.erdos_ginzburg_ziv`, that
+
+      `egz_nondividing_card_bound` :  a ∈ A → 2 ≤ a → IsNonDividing A → A.card ≤ 2a − 1.
+
+  That argument only uses the *size-exactly-`a`* zero-sum subset produced by EGZ
+  (the Erdős–Ginzburg–Ziv constant `s(ℤ/aℤ) = 2a − 1`).  But the non-dividing
+  property forbids a zero-sum subset of *every* size `≥ 2`, so the governing
+  invariant is really the **Davenport constant** `D(ℤ/aℤ) = a`, which forbids a
+  zero-sum subset of *any* size.  Exploiting this sharpens the bound to
+
+      **If `a ∈ A`, `2 ≤ a`, and `A` is non-dividing, then `A.card ≤ a + 1`.**
+
+  This nearly halves the EGZ bound: `a + 1 ≤ 2a − 1` for all `a ≥ 2`, with strict
+  inequality for `a ≥ 3` (`davenport_le_egz`, `davenport_strictly_sharper`).
+
+  Mechanism.  Work inside `A \ {a}`.
+  * At most one element of `A \ {a}` is divisible by `a`: two such would form a
+    size-`2` subset whose sum is `≡ 0 (mod a)`, violating non-dividing.
+  * The remaining `≥ a` elements all have *nonzero* residue mod `a`.  By the
+    Davenport bound (`exists_nonempty_subset_sum_dvd`: any `a` integers contain a
+    nonempty subset with sum divisible by `a`, proved here by a prefix-sum
+    pigeonhole) one of their nonempty subsets has sum `≡ 0`.  As every element is
+    nonzero mod `a`, that subset has size `≥ 2` — again a violation.
+
+  Hence `|A \ {a}| ≤ a`, i.e. `|A| ≤ a + 1`.
+
+  Mathlib has EGZ but *not* the cyclic Davenport constant / zero-sum-free
+  sequences, so `exists_nonempty_subset_sum_dvd` is built from scratch.
+
+  All results are unconditional and axiom-free.  The bound is sharp at `a = 2`
+  (`{2,4,5}`, `davenport_bound_sharp_at_two`), where `a + 1 = 3 = 2a − 1`.
+-/
+
+import Mathlib
+
+namespace Erdos131Davenport
+
+open Finset
+
+/-- A set `A` is *non-dividing* if no `a ∈ A` divides the sum of any subset of
+`A \ {a}` of size `≥ 2`.  (Verbatim copy of `Erdos131.IsNonDividing` from the
+parent file `Proofs.Erdos131Problem`.) -/
+def IsNonDividing (A : Finset ℕ) : Prop :=
+  ∀ a ∈ A, ∀ S : Finset ℕ, S ⊆ A.erase a → S.card ≥ 2 →
+    ¬(a ∣ S.sum id)
+
+/-- **Davenport bound for the cyclic group `ℤ/aℤ`.**  Any `a` natural numbers
+contain a *nonempty* subset whose sum is divisible by `a`.
+
+Proof: order `s` as a list `L` and consider the `a + 1` prefix sums of `L`
+reduced mod `a`.  These land in `ZMod a` (which has `a` elements), so by
+pigeonhole two prefix sums coincide; the block of `L` strictly between the two
+indices is a nonempty sublist whose sum is `≡ 0 (mod a)`.  Its `toFinset` is the
+desired subset.  (This is `D(ℤ/aℤ) ≤ a`; Mathlib lacks the Davenport constant.) -/
+theorem exists_nonempty_subset_sum_dvd (a : ℕ) (ha : 1 ≤ a) (s : Finset ℕ)
+    (hs : a ≤ s.card) :
+    ∃ t ⊆ s, t.Nonempty ∧ a ∣ t.sum id := by
+  haveI : NeZero a := ⟨by omega⟩
+  classical
+  -- Order `s` as a sorted (hence nodup) list.
+  set L : List ℕ := s.sort (· ≤ ·) with hLdef
+  have hnod : L.Nodup := by rw [hLdef]; exact s.sort_nodup _
+  have hlen : L.length = s.card := by rw [hLdef]; exact s.length_sort _
+  have hmem : ∀ x ∈ L, x ∈ s := by
+    intro x hx; rw [hLdef] at hx; exact (Finset.mem_sort _).1 hx
+  -- A prefix-sum splitting identity (no group/cast needed yet).
+  have key_eq : ∀ (m n : ℕ), m ≤ n →
+      (L.take n).sum = (L.take m).sum + ((L.take n).drop m).sum := by
+    intro m n hmn
+    have e1 : (L.take n).take m = L.take m := by
+      rw [List.take_take, Nat.min_eq_left hmn]
+    calc (L.take n).sum
+        = ((L.take n).take m ++ (L.take n).drop m).sum := by rw [List.take_append_drop]
+      _ = ((L.take n).take m).sum + ((L.take n).drop m).sum := by rw [List.sum_append]
+      _ = (L.take m).sum + ((L.take n).drop m).sum := by rw [e1]
+  -- The core: given two prefix indices with equal prefix-sum mod `a`, the block
+  -- between them is a nonempty subset of `s` with sum divisible by `a`.
+  have key : ∀ p q : Fin (L.length + 1), (p : ℕ) < (q : ℕ) →
+      ((L.take (p : ℕ)).sum : ZMod a) = ((L.take (q : ℕ)).sum : ZMod a) →
+      ∃ t ⊆ s, t.Nonempty ∧ a ∣ t.sum id := by
+    intro p q hpq hfpq
+    -- The block sum is `0` in `ZMod a`.
+    have hcast : (((L.take (q : ℕ)).drop (p : ℕ)).sum : ZMod a) = 0 := by
+      have hk := key_eq (p : ℕ) (q : ℕ) hpq.le
+      have h2 : ((L.take (q : ℕ)).sum : ZMod a) =
+          ((L.take (p : ℕ)).sum : ZMod a) + (((L.take (q : ℕ)).drop (p : ℕ)).sum : ZMod a) := by
+        rw [hk]; push_cast; ring
+      rw [← hfpq] at h2
+      linear_combination -h2
+    have hdvdblock : a ∣ ((L.take (q : ℕ)).drop (p : ℕ)).sum :=
+      (ZMod.natCast_eq_zero_iff _ _).mp hcast
+    -- The block is a nodup sublist of `L`.
+    have hsub_block : List.Sublist ((L.take (q : ℕ)).drop (p : ℕ)) L :=
+      (List.drop_sublist _ _).trans (List.take_sublist _ _)
+    have hnod_block : ((L.take (q : ℕ)).drop (p : ℕ)).Nodup := hnod.sublist hsub_block
+    -- ... and it is nonempty (its length is `q - p ≥ 1`).
+    have hjle : (q : ℕ) ≤ L.length := by have := q.isLt; omega
+    have hblen : ((L.take (q : ℕ)).drop (p : ℕ)).length = (q : ℕ) - (p : ℕ) := by
+      rw [List.length_drop, List.length_take, Nat.min_eq_left hjle]
+    have hblenpos : 0 < ((L.take (q : ℕ)).drop (p : ℕ)).length := by rw [hblen]; omega
+    refine ⟨((L.take (q : ℕ)).drop (p : ℕ)).toFinset, ?_, ?_, ?_⟩
+    · intro x hx
+      rw [List.mem_toFinset] at hx
+      exact hmem x (hsub_block.subset hx)
+    · obtain ⟨z, hz⟩ :=
+        List.exists_mem_of_ne_nil _ (List.ne_nil_of_length_pos hblenpos)
+      exact ⟨z, List.mem_toFinset.2 hz⟩
+    · have hsumeq : ((L.take (q : ℕ)).drop (p : ℕ)).toFinset.sum id
+          = ((L.take (q : ℕ)).drop (p : ℕ)).sum := by
+        rw [List.sum_toFinset id hnod_block, List.map_id]
+      rw [hsumeq]; exact hdvdblock
+  -- Pigeonhole on the `L.length + 1` prefix sums mod `a`.
+  have hcardlt : Fintype.card (ZMod a) < Fintype.card (Fin (L.length + 1)) := by
+    rw [ZMod.card, Fintype.card_fin]; omega
+  obtain ⟨i, j, hne, hfeq⟩ :=
+    Fintype.exists_ne_map_eq_of_card_lt
+      (fun i : Fin (L.length + 1) => ((L.take (i : ℕ)).sum : ZMod a)) hcardlt
+  have hvalne : (i : ℕ) ≠ (j : ℕ) := Fin.val_injective.ne hne
+  rcases lt_or_gt_of_ne hvalne with h | h
+  · exact key i j h hfeq
+  · exact key j i h hfeq.symm
+
+/-- **Davenport structural bound for non-dividing sets.**
+
+If `a ∈ A` with `a ≥ 2` and `A` is non-dividing, then `A.card ≤ a + 1`.
+
+This sharpens `egz_nondividing_card_bound` (`A.card ≤ 2a − 1`): the EGZ argument
+uses only a size-`a` zero-sum subset, whereas non-dividing forbids zero-sum
+subsets of *every* size `≥ 2`, so the Davenport constant `D(ℤ/aℤ) = a` governs. -/
+theorem davenport_nondividing_card_bound (A : Finset ℕ) (a : ℕ)
+    (ha : a ∈ A) (ha2 : 2 ≤ a) (hND : IsNonDividing A) :
+    A.card ≤ a + 1 := by
+  by_contra hcon
+  push_neg at hcon
+  set B := A.erase a with hB
+  have hBcard : a + 1 ≤ B.card := by
+    rw [hB, Finset.card_erase_of_mem ha]; omega
+  -- At most one element of `B` is divisible by `a` (two would pair to a size-2
+  -- zero-sum subset).
+  have hZle : (B.filter (fun x => a ∣ x)).card ≤ 1 := by
+    by_contra hc
+    push_neg at hc
+    obtain ⟨x, hx, y, hy, hxy⟩ := Finset.one_lt_card.1 hc
+    rw [Finset.mem_filter] at hx hy
+    have hsub : ({x, y} : Finset ℕ) ⊆ B := by
+      intro z hz
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hz
+      rcases hz with rfl | rfl
+      · exact hx.1
+      · exact hy.1
+    have hcard2 : ({x, y} : Finset ℕ).card = 2 := Finset.card_pair hxy
+    have hdvd : a ∣ ({x, y} : Finset ℕ).sum id := by
+      apply Finset.dvd_sum
+      intro z hz
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hz
+      rcases hz with rfl | rfl
+      · exact hx.2
+      · exact hy.2
+    exact hND a ha {x, y} hsub hcard2.ge hdvd
+  -- The remaining (nonzero-residue) part has `≥ a` elements.
+  have hNZcard : a ≤ (B.filter (fun x => ¬ a ∣ x)).card := by
+    have hsplit :=
+      Finset.filter_card_add_filter_neg_card_eq_card (s := B) (p := fun x => a ∣ x)
+    omega
+  -- Davenport applied to the nonzero part yields a nonempty zero-sum subset...
+  obtain ⟨t, htsub, htne, htdvd⟩ :=
+    exists_nonempty_subset_sum_dvd a (by omega) (B.filter (fun x => ¬ a ∣ x)) hNZcard
+  -- ... of size `≥ 2`, since each element is nonzero mod `a`.
+  have ht2 : 2 ≤ t.card := by
+    rcases Nat.lt_or_ge t.card 2 with h | h
+    · exfalso
+      have h1 : t.card = 1 := by have := Finset.card_pos.2 htne; omega
+      obtain ⟨x, hxsing⟩ := Finset.card_eq_one.1 h1
+      have hxmem : x ∈ B.filter (fun x => ¬ a ∣ x) :=
+        htsub (by rw [hxsing]; exact Finset.mem_singleton_self x)
+      rw [Finset.mem_filter] at hxmem
+      have hax : a ∣ x := by
+        have hsx : t.sum id = x := by simp [hxsing]
+        rwa [hsx] at htdvd
+      exact hxmem.2 hax
+    · exact h
+  have htB : t ⊆ B := htsub.trans (Finset.filter_subset _ _)
+  exact hND a ha t htB ht2 htdvd
+
+/-- **Smallest-element bound.** A non-dividing set all of whose elements are `≥ 2`
+has at most `min + 1` elements, where `min` is its least element. -/
+theorem davenport_card_le_min_succ (A : Finset ℕ) (hA : A.Nonempty)
+    (hmin : ∀ x ∈ A, 2 ≤ x) (hND : IsNonDividing A) :
+    A.card ≤ A.min' hA + 1 := by
+  have hmem := A.min'_mem hA
+  exact davenport_nondividing_card_bound A (A.min' hA) hmem (hmin _ hmem) hND
+
+/-- The Davenport bound is **at least as strong** as the EGZ bound: for `a ≥ 2`,
+`a + 1 ≤ 2a − 1`. -/
+theorem davenport_le_egz (a : ℕ) (ha : 2 ≤ a) : a + 1 ≤ 2 * a - 1 := by omega
+
+/-- ... and **strictly stronger** for `a ≥ 3`: `a + 1 < 2a − 1`. -/
+theorem davenport_strictly_sharper (a : ℕ) (ha : 3 ≤ a) : a + 1 < 2 * a - 1 := by omega
+
+/-- **Recovers the parent parity bound** `two_in_nondividing_bound` as the
+`a = 2` special case: `2 ∈ A` forces `A.card ≤ 3 = 2 + 1`.  (Here the Davenport
+bound `a + 1` and the EGZ bound `2a − 1` coincide.) -/
+theorem two_in_card_le_three (A : Finset ℕ) (h2 : 2 ∈ A) (hND : IsNonDividing A) :
+    A.card ≤ 3 := by
+  have h := davenport_nondividing_card_bound A 2 h2 (le_refl 2) hND
+  omega
+
+/-- **Contrapositive / certification form.** If a candidate set has more than
+`a + 1` elements for some `a ∈ A` with `a ≥ 2`, it cannot be non-dividing. -/
+theorem not_nondividing_of_card_gt (A : Finset ℕ) (a : ℕ)
+    (ha : a ∈ A) (ha2 : 2 ≤ a) (hcard : a + 1 < A.card) :
+    ¬ IsNonDividing A := by
+  intro hND
+  exact absurd (davenport_nondividing_card_bound A a ha ha2 hND) (by omega)
+
+/- ## Sharpness at `a = 2` -/
+
+/-- Helper: a subset of size `≥ 2` inside a set of size `≤ 2` equals it. -/
+private lemma finset_eq_of_subset_of_card_two {S T : Finset ℕ}
+    (hsub : S ⊆ T) (hS : S.card ≥ 2) (hT : T.card ≤ 2) : S = T :=
+  Finset.eq_of_subset_of_card_le hsub (by omega)
+
+/-- `{2, 4, 5}` is non-dividing (`2 ∤ 9`, `4 ∤ 7`, `5 ∤ 6`). -/
+theorem two_four_five_nondividing : IsNonDividing ({2, 4, 5} : Finset ℕ) := by
+  intro a ha S hS hCard hdvd
+  simp only [Finset.mem_insert, Finset.mem_singleton] at ha
+  rcases ha with rfl | rfl | rfl
+  · have hle : (({2, 4, 5} : Finset ℕ).erase 2).card ≤ 2 := by decide
+    have hseq : S = ({2, 4, 5} : Finset ℕ).erase 2 :=
+      finset_eq_of_subset_of_card_two hS hCard hle
+    subst hseq; exact absurd hdvd (by decide)
+  · have hle : (({2, 4, 5} : Finset ℕ).erase 4).card ≤ 2 := by decide
+    have hseq : S = ({2, 4, 5} : Finset ℕ).erase 4 :=
+      finset_eq_of_subset_of_card_two hS hCard hle
+    subst hseq; exact absurd hdvd (by decide)
+  · have hle : (({2, 4, 5} : Finset ℕ).erase 5).card ≤ 2 := by decide
+    have hseq : S = ({2, 4, 5} : Finset ℕ).erase 5 :=
+      finset_eq_of_subset_of_card_two hS hCard hle
+    subst hseq; exact absurd hdvd (by decide)
+
+/-- The Davenport bound is **sharp at `a = 2`**: `{2,4,5}` is non-dividing,
+contains `2`, and has `card = 3 = 2 + 1`, meeting `two_in_card_le_three` (and
+`davenport_nondividing_card_bound` at `a = 2`) with equality. -/
+theorem davenport_bound_sharp_at_two :
+    (2 : ℕ) ∈ ({2, 4, 5} : Finset ℕ) ∧
+    IsNonDividing ({2, 4, 5} : Finset ℕ) ∧
+    ({2, 4, 5} : Finset ℕ).card = 2 + 1 :=
+  ⟨by decide, two_four_five_nondividing, by decide⟩
+
+end Erdos131Davenport

--- a/research/problems/erdos-131-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/erdos-131-oq-01-oq-01-oq-01/knowledge.md
@@ -1,0 +1,80 @@
+# Erdős #131 — Davenport sharpening of the non-dividing size bound
+
+**Slug:** `erdos-131-oq-01-oq-01-oq-01`
+**Lean file:** `proofs/Proofs/Erdos131DavenportBound.lean`
+**Status:** verified, 0-axiom (propext / Classical.choice / Quot.sound only)
+
+## Summary
+
+For a non-dividing set `A ⊆ ℕ` (no `a ∈ A` divides the sum of any `≥2`-element
+subset of `A \ {a}`) and any `a ∈ A` with `a ≥ 2`:
+
+    |A| ≤ a + 1            (davenport_nondividing_card_bound)
+
+This **sharpens** the EGZ follow-up (`erdos-131-oq-01-oq-01`) bound `|A| ≤ 2a − 1`.
+
+**Why the improvement is possible.** The EGZ argument applies
+`Int.erdos_ginzburg_ziv` and only consumes the *size-exactly-`a`* zero-sum
+subset (the EGZ constant `s(ℤ/aℤ) = 2a − 1`). But non-dividing forbids a zero-sum
+subset of **every** size `≥ 2`. The right invariant is therefore the **Davenport
+constant** `D(ℤ/aℤ) = a` (max zero-sum-free length is `a − 1`), which is smaller.
+
+## Mechanism
+
+Inside `B := A \ {a}` (|B| = |A| − 1):
+1. At most one element of `B` is `≡ 0 (mod a)` — two would be a size-2 zero-sum.
+2. The remaining `≥ a` elements have nonzero residue mod `a`.
+3. Davenport (`exists_nonempty_subset_sum_dvd`) gives a nonempty zero-sum subset;
+   since every element is nonzero mod `a`, it has size `≥ 2` → contradiction.
+
+So `|B| ≤ a`, i.e. `|A| ≤ a + 1`.
+
+## Built infrastructure
+
+- `exists_nonempty_subset_sum_dvd (a) (1 ≤ a) (s) (a ≤ |s|) : ∃ t ⊆ s, t.Nonempty ∧ a ∣ t.sum id`
+  — the cyclic Davenport bound `D(ℤ/aℤ) ≤ a`, **built from scratch** (Mathlib has
+  no Davenport constant / zero-sum-free sequences). Proof = prefix-sum pigeonhole:
+  sort `s` to a nodup list `L`; the `|L|+1` prefix sums reduced mod `a` collide in
+  `ZMod a` (`Fintype.exists_ne_map_eq_of_card_lt`); the block between the colliding
+  indices is a nonempty nodup sublist whose `toFinset` sum is `≡ 0`.
+- Corollaries: `davenport_card_le_min_succ` (|A| ≤ min(A)+1), `davenport_le_egz`
+  (a+1 ≤ 2a−1), `davenport_strictly_sharper` (a+1 < 2a−1 for a ≥ 3),
+  `two_in_card_le_three` (a=2 recovery), `not_nondividing_of_card_gt`,
+  `davenport_bound_sharp_at_two` ({2,4,5}).
+
+## Mathlib gaps found
+
+- No cyclic **Davenport constant** / zero-sum-free sequence bound. EGZ is present
+  (`Int.erdos_ginzburg_ziv`) but it is the *stronger-hypothesis / weaker-conclusion*
+  constant (`2n−1`, fixed subset size `n`), not the Davenport `n`. This file's
+  `exists_nonempty_subset_sum_dvd` fills the gap for the cyclic case and is reusable.
+
+## Lean gotchas (v4.26.0)
+
+- `<+` (List.Sublist) notation is NOT in scope under `open Finset`; write
+  `List.Sublist a b` explicitly.
+- `Finset.sum_pair` not found — use `Finset.dvd_sum` for `a ∣ {x,y}.sum`.
+- `self_eq_add_right.mp` failed to resolve; `linear_combination -h2` is robust in
+  `ZMod a` (CommRing) to get `b = 0` from `c = c + b`.
+- `({x}).sum id = x` is NOT closed by `Finset.sum_singleton` alone (leaves
+  `id x = x`); use `simp`.
+- A multi-line `have h : T :=` with a leading `+` on a continuation line fails to
+  parse; put the binary op's LHS and the `=`/operator on the same line.
+- `ZMod.natCast_zmod_eq_zero_iff_dvd` is **deprecated** → `ZMod.natCast_eq_zero_iff`.
+
+## Next steps / open questions
+
+- (`-oq-01`) Is `|A| ≤ a + 1` sharp for `a ≥ 3`? Needs a non-dividing set with
+  one `≡0` element + `a−1` equal-nonzero-residue elements, all distinct AND
+  non-dividing at every element (cross-element constraint may force smaller).
+- (`-oq-02`) Aggregate `|A| ≤ min(A)+1` over residue classes / truncations to get
+  an elementary global `F(N)` bound toward Pham–Zakharov `N^{1/4+o(1)}`.
+
+## Session log
+
+### 2026-06-21 (Session 1) — FRESH follow-up, COMPLETED
+- **Mode:** REVISIT (pool empty) → built a strong follow-up to my own merged
+  EGZ entry (`erdos-131-oq-01-oq-01`, PR #27277).
+- Identified the EGZ→Davenport gap, confirmed Mathlib lacks Davenport, built the
+  prefix-sum pigeonhole Davenport bound, proved `|A| ≤ a+1`, 0-axiom verified.
+- Docker build `Proofs.Erdos131DavenportBound` GREEN (7743/7743).

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "erdos-131-oq-01-oq-01-oq-01",
+  "slug": "erdos-131-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos131Davenport",
+    "lineCount": 266,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos131DavenportBound.lean",
+    "sorries": 0
+  },
+  "title": "Sharpening the EGZ Bound for Non-Dividing Sets to |A| ≤ a + 1 (Erdős #131)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos131DavenportBound.lean",
+    "tags": [
+      "number-theory",
+      "additive-combinatorics",
+      "erdos-problems",
+      "erdos-131",
+      "non-dividing-sets",
+      "davenport-constant",
+      "zero-sum-free",
+      "pigeonhole",
+      "extremal-set-theory",
+      "structural-bound",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 266,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "davenport_nondividing_card_bound: the headline theorem — if a ∈ A with a ≥ 2 and A is non-dividing (no element divides the sum of any ≥2-element subset of the others), then |A| ≤ a + 1. This SHARPENS the EGZ follow-up's bound |A| ≤ 2a − 1: the EGZ argument only consumes the size-exactly-a zero-sum subset (the EGZ constant s(ℤ/aℤ) = 2a − 1), but the non-dividing property forbids zero-sum subsets of EVERY size ≥ 2, so the governing invariant is the Davenport constant D(ℤ/aℤ) = a. Proved unconditionally and axiom-free.",
+      "exists_nonempty_subset_sum_dvd: the Davenport bound D(ℤ/aℤ) ≤ a, built from scratch because Mathlib lacks the Davenport constant / zero-sum-free sequences. Any a natural numbers contain a NONEMPTY subset whose sum is divisible by a. Proof: order s as a sorted (nodup) list L; the a+1 prefix sums of L reduced mod a land in ZMod a (an a-element type), so by pigeonhole (Fintype.exists_ne_map_eq_of_card_lt) two prefix sums coincide and the list block strictly between those indices is a nonempty sublist with sum ≡ 0 (mod a); its toFinset is the desired subset.",
+      "Mechanism for the sharpening (inside A \\ {a}): (1) at most ONE element of A\\{a} is divisible by a — two such would form a size-2 subset with sum ≡ 0, violating non-dividing; (2) the remaining ≥ a elements all have NONZERO residue mod a, so the Davenport bound hands back a nonempty zero-sum subset which, since singletons are nonzero, must have size ≥ 2 — again a violation. Hence |A\\{a}| ≤ a, i.e. |A| ≤ a + 1.",
+      "davenport_le_egz and davenport_strictly_sharper: the new bound is at least as strong as EGZ (a + 1 ≤ 2a − 1 for a ≥ 2) and STRICTLY stronger for a ≥ 3 (a + 1 < 2a − 1). In particular the EGZ bound 2a − 1 is NOT sharp for any a ≥ 3 — a negative answer to the parent follow-up's open question on the sharpness of 2a − 1.",
+      "davenport_card_le_min_succ: the smallest-element form — a non-dividing set whose every element is ≥ 2 has |A| ≤ min(A) + 1, applying the main bound at the least element.",
+      "two_in_card_le_three: recovers the original parity bound 2 ∈ A ⟹ |A| ≤ 3 as the a = 2 case, where the Davenport bound a + 1 = 3 and the EGZ bound 2a − 1 = 3 coincide.",
+      "davenport_bound_sharp_at_two: the Davenport bound is sharp at a = 2, witnessed by {2,4,5} (non-dividing, contains 2, card 3 = 2 + 1)."
+    ],
+    "prerequisites": [
+      "Fintype.exists_ne_map_eq_of_card_lt (Mathlib): the pigeonhole principle — a map from a finite type into a smaller finite type identifies two points; applied to the a+1 prefix-sum function into ZMod a.",
+      "ZMod.card and ZMod.natCast_eq_zero_iff: |ZMod a| = a and (n : ZMod a) = 0 ↔ a ∣ n, the bridge between the mod-a prefix-sum collision and integer divisibility.",
+      "List.take_append_drop / List.take_take / List.sum_toFinset: the list-surgery lemmas turning a prefix-sum collision into a genuine Finset block with the right sum (via the sorted nodup list of s).",
+      "Finset.filter_card_add_filter_neg_card_eq_card: splits A\\{a} into its a-divisible and non-a-divisible parts to isolate the ≥ a nonzero-residue elements."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.exists_ne_map_eq_of_card_lt",
+        "description": "Pigeonhole: if |β| < |α| then any f : α → β collides. Instantiated with α = Fin (|s|+1) (the prefix indices) and β = ZMod a; this is the engine of the home-grown Davenport bound exists_nonempty_subset_sum_dvd.",
+        "module": "Mathlib.Data.Fintype.Pigeonhole"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(n : ZMod a) = 0 ↔ a ∣ n. Transports the mod-a collision of two prefix sums into the integer divisibility a ∣ (block sum) needed to violate the non-dividing property.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.filter_card_add_filter_neg_card_eq_card",
+        "description": "|filter p| + |filter ¬p| = |s|. Splits A\\{a} by divisibility-by-a so that, with at most one a-divisible element, at least a elements of nonzero residue remain for the Davenport bound.",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "erdos-131-oq-01-oq-01-oq-01-oq-01",
+      "question": "Is the Davenport bound |A| ≤ a + 1 itself sharp for a ≥ 3? It is tight at a = 2 ({2,4,5}). Achieving |A| = a + 1 would require a\\{a} to consist of one element ≡ 0 (mod a) together with a − 1 elements of equal nonzero residue (a maximal zero-sum-free configuration over ℤ/aℤ), all DISTINCT naturals AND simultaneously non-dividing at every element of A — not just at a. Does such a set exist, or does the cross-element non-dividing constraint force a strictly smaller maximum?",
+      "significance": "medium"
+    },
+    {
+      "id": "erdos-131-oq-01-oq-01-oq-01-oq-02",
+      "question": "The bound |A| ≤ min(A) + 1 says a non-dividing set is barely larger than its smallest element. Can this be combined with the spread of A (e.g. running the Davenport bound on residue-class restrictions, or on A ∩ [1, t] for varying t) to extract a nontrivial GLOBAL bound on F(N) = max non-dividing subset of {1,…,N}, ideally approaching the Pham–Zakharov F(N) ≤ N^{1/4+o(1)} ceiling by elementary means?",
+      "significance": "high"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-131-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Directly sharpens the EGZ follow-up. That entry proves |A| ≤ 2a − 1 from Erdős–Ginzburg–Ziv (which only uses a size-a zero-sum subset); this entry replaces EGZ by the Davenport constant D(ℤ/aℤ) = a — which forbids zero-sum subsets of every size — to get |A| ≤ a + 1, strictly better for a ≥ 3, and in doing so shows the EGZ bound 2a − 1 is not sharp for a ≥ 3."
+    },
+    {
+      "targetId": "erdos-131",
+      "relationship": "extends",
+      "description": "Contributes a tighter per-element structural upper bound on non-dividing sets for the parent Erdős #131 growth-rate study: |A| ≤ min(A) + 1, making precise (and nearly optimal at the level of a single element) the mechanism by which small elements force small non-dividing sets."
+    }
+  ],
+  "references": [
+    {
+      "title": "On some problems in combinatorial number theory",
+      "author": "Paul Erdős",
+      "year": "1975",
+      "venue": "Er75b",
+      "description": "Erdős's problem #131 on non-dividing sets and the function F(N), the maximal size of a subset of {1,…,N} no element of which divides the sum of any distinct others."
+    },
+    {
+      "title": "On Davenport's constant",
+      "author": "various (survey)",
+      "year": "2006",
+      "venue": "Expo. Math. / survey",
+      "description": "The Davenport constant D(G) is the least d such that every length-d sequence over G has a nonempty zero-sum subsequence; for cyclic groups D(ℤ/nℤ) = n. The n-bound proved here from scratch by prefix-sum pigeonhole is the special case powering the sharpened set bound."
+    },
+    {
+      "title": "Theorem in the additive number theory",
+      "author": "Paul Erdős, Abraham Ginzburg, Abraham Ziv",
+      "year": "1961",
+      "venue": "Bull. Res. Council Israel",
+      "description": "The Erdős–Ginzburg–Ziv theorem (any 2n − 1 integers contain n with sum divisible by n) underlies the weaker 2a − 1 bound that this entry sharpens; the EGZ constant 2n − 1 versus the Davenport constant n is exactly the gap exploited here."
+    },
+    {
+      "title": "On the number of monochromatic solutions to additive equations / non-averaging sets",
+      "author": "Huy Tuan Pham, Dmitrii Zakharov",
+      "year": "2024",
+      "venue": "arXiv",
+      "description": "Proves F(N) ≤ N^{1/4+o(1)} via the non-dividing ⟹ non-averaging connection; context for the open question of recovering global F(N) bounds elementarily from per-element constraints."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For a non-dividing set A ⊆ ℕ and any a ∈ A with a ≥ 2, the size bound |A| ≤ 2a − 1 coming from Erdős–Ginzburg–Ziv can be sharpened to |A| ≤ a + 1 (davenport_nondividing_card_bound). The point is that non-dividing forbids a zero-sum subset of EVERY size ≥ 2, not just of size a, so the relevant invariant is the Davenport constant D(ℤ/aℤ) = a rather than the EGZ constant 2a − 1. The Davenport bound itself (exists_nonempty_subset_sum_dvd: any a integers have a nonempty subset with sum divisible by a) is proved from scratch by a prefix-sum pigeonhole, since Mathlib lacks it. Working inside A\\{a}: at most one element is ≡ 0 (mod a) (else a size-2 zero-sum pair), and the remaining ≥ a nonzero-residue elements yield, via Davenport, a zero-sum subset of size ≥ 2 — a contradiction; hence |A\\{a}| ≤ a. The new bound is ≤ the EGZ bound for all a ≥ 2 and strictly smaller for a ≥ 3 (davenport_strictly_sharper), so 2a − 1 is not sharp beyond a = 2; it recovers |A| ≤ 3 at a = 2 (two_in_card_le_three) and is sharp there via {2,4,5} (davenport_bound_sharp_at_two). 266 lines, 9 theorems + 1 private lemma, 1 definition, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The entry pinpoints the correct additive-combinatorial invariant behind the non-dividing size bound — the cyclic Davenport constant, not the EGZ constant — and in doing so nearly halves the previously published bound and shows the EGZ bound is non-sharp for every a ≥ 3. It also supplies a reusable, axiom-free formalization of D(ℤ/nℤ) ≤ n (a nonempty zero-sum subsequence in any length-n sequence over ℤ/nℤ), which Mathlib currently lacks. The smallest-element corollary |A| ≤ min(A) + 1 is essentially the tightest single-element constraint available and sets up the open problem of aggregating per-element Davenport bounds into a global, elementary upper bound on F(N)."
+  }
+}


### PR DESCRIPTION
## Summary

Sharpens the EGZ follow-up (`erdos-131-oq-01-oq-01`, PR #27277) bound `|A| ≤ 2a − 1` for **non-dividing sets** to

```
|A| ≤ a + 1        (davenport_nondividing_card_bound, for a ∈ A, a ≥ 2)
```

**Why the improvement exists.** The EGZ argument applies `Int.erdos_ginzburg_ziv` and only consumes the *size-exactly-`a`* zero-sum subset (the EGZ constant `s(ℤ/aℤ) = 2a − 1`). But the non-dividing property forbids a zero-sum subset of **every** size `≥ 2`, so the governing invariant is the **Davenport constant** `D(ℤ/aℤ) = a`, which is smaller. The new bound is `≤` the EGZ bound for all `a ≥ 2` and **strictly smaller for `a ≥ 3`** (`davenport_strictly_sharper`) — so the EGZ bound `2a − 1` is **not sharp** for any `a ≥ 3`.

## Mechanism (inside `B := A \ {a}`)

1. At most **one** element of `B` is `≡ 0 (mod a)` — two would form a size-2 zero-sum subset, violating non-dividing.
2. The remaining `≥ a` elements all have **nonzero** residue mod `a`.
3. The Davenport bound hands back a nonempty zero-sum subset; since singletons are nonzero, it has size `≥ 2` — again a violation.

Hence `|B| ≤ a`, i.e. `|A| ≤ a + 1`.

## Built infrastructure (Mathlib gap)

`exists_nonempty_subset_sum_dvd` — the cyclic Davenport bound `D(ℤ/aℤ) ≤ a` (any `a` naturals contain a nonempty subset with sum divisible by `a`), **built from scratch** because Mathlib has EGZ but **not** the Davenport constant / zero-sum-free sequences. Proof = prefix-sum pigeonhole: sort `s` to a nodup list, the `|s|+1` prefix sums collide in `ZMod a` (`Fintype.exists_ne_map_eq_of_card_lt`), the list block between the colliding indices is a nonempty zero-sum sublist whose `toFinset` is the desired subset. Reusable for the cyclic case.

## Corollaries

- `davenport_card_le_min_succ`: `|A| ≤ min(A) + 1`.
- `two_in_card_le_three`: recovers the original parity bound `2 ∈ A ⟹ |A| ≤ 3` (a=2, where `a+1 = 2a−1 = 3`).
- `davenport_bound_sharp_at_two`: sharp at `a = 2` via `{2,4,5}`.
- `not_nondividing_of_card_gt`: contrapositive certification filter.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos131DavenportBound` — **GREEN** (7743/7743).
- `#print axioms` on the three headline results: only `propext, Classical.choice, Quot.sound` → **0-axiom verified**.
- 266 lines, 9 theorems + 1 private lemma, 1 definition, 0 sorries.
- Self-contained (re-states `IsNonDividing`); the parent `Erdos131Problem.lean` remains bit-rotted on Mathlib v4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)