### PR TITLE
audit: mark 2 newest gallery entries clean (erdos-131-davenport, lagrange-twosq-slice)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17469,8 +17469,20 @@
       "issues": [],
       "lastAudited": "2026-06-21T00:00:00Z",
       "result": "clean"
+    },
+    "erdos-131-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T08:00:00Z",
+      "result": "clean"
+    },
+    "lagrange-four-squares-waring-g2-oq-03-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T08:00:00Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T00:00:00Z"
+  "lastUpdated": "2026-06-21T08:00:00Z"
 }


### PR DESCRIPTION
Deep-audited the two never-audited gallery entries at HEAD f329694:

- **erdos-131-oq-01-oq-01-oq-01** (`Erdos131DavenportBound.lean`, 266L) — Davenport sharpening |A|≤a+1 of EGZ bound for non-dividing sets; cyclic Davenport D(ℤ/aℤ)≤a built from scratch via prefix-sum pigeonhole. Sharpness witness {2,4,5}.
- **lagrange-four-squares-waring-g2-oq-03-oq-03** (`LagrangeFourSquaresWaringG2OQ03OQ03.lean`, 189L) — Dirichlet-free slice of open three-square sufficiency (two-square ⟹ three-square embedding) + non-closure contrast 3·21=63 excluded.

Both: 0 sorry, 0 axiom declarations, 0 native_decide (kernel `decide` only → no `Lean.ofReduceBool`), no load-bearing structures, genuine non-vacuous theorems. Docstrings honestly mark open parents as open. **verified/original/0-axiom defensible — CLEAN.**

Persists clean marks (both were absent from the tracker entries map → perpetual never-audited loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)