### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01): both Cauchy–Schwarz parent axioms discharged [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz.lean
@@ -1,0 +1,189 @@
+/-
+  The two Cauchy–Schwarz analytic axioms of the Hurwitz isoperimetric proof,
+  discharged 0-axiom: `integral_cauchy_schwarz_sq` and `area_cauchy_schwarz_bound`.
+
+  Open Question: area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01
+
+  ## Context
+
+  The parent entry `AreaOfCircleOQ01OQ02OQ02OQ01.lean`
+  (`namespace IsoperimetricFromFourier`) proves the isoperimetric inequality
+  `C² ≥ 4πA` from five disclosed axioms.  Prior sessions discharged the central
+  reparametrization axiom (`exists_nice_reparam`) for regular curves via the
+  inverse function theorem (`…OQ01OQ01IFT.lean` / `…OQ01OQ01Reparam.lean`).  The
+  four *remaining* parent axioms are the analytic bounds
+
+  * `fourier_decomp_exists`     — Parseval + integration by parts;
+  * `wirtinger_sum_bound`       — Wirtinger applied to the coordinates;
+  * `area_cauchy_schwarz_bound` — Green's theorem + pointwise 2D Cauchy–Schwarz;
+  * `integral_cauchy_schwarz_sq`— L² Cauchy–Schwarz of `1` against `√(x²+y²)`.
+
+  **This file discharges the two Cauchy–Schwarz axioms 0-axiom**, leaving only the
+  two genuinely Fourier-analytic axioms.  Both are pure integral inequalities that
+  need no Fourier machinery — only continuity of the coordinate functions, which a
+  `SmoothClosedCurve` supplies.
+
+  ## Results (namespace `IsoperimetricCauchySchwarz`)
+
+  * `integral_cauchy_schwarz_sq` — for continuous `x, y`,
+        `(∫₀²π √(x²+y²))² ≤ 2π · ∫₀²π (x²+y²)`.
+    This is the parent axiom verbatim (the axiom imposes no extra hypotheses
+    because `SmoothClosedCurve` is `C¹`, hence continuous).  Proved by the
+    discriminant of the nonnegative quadratic `λ ↦ ∫₀²π (√(x²+y²) − λ)²`.
+
+  * `area_cauchy_schwarz_bound` — for continuous coordinates `x, y` and continuous
+    velocity field `dx, dy` with constant speed `dx² + dy² = c²` (`0 ≤ c`),
+        `|∫₀²π (x·dy − y·dx)| ≤ c · ∫₀²π √(x²+y²)`.
+    Since the signed area is `A = ½|∫₀²π (x·dy − y·dx)|`, the left side is exactly
+    `2A`, so this is the parent axiom `2A ≤ c·∫√(x²+y²)`.  Proved from the
+    pointwise 2D Cauchy–Schwarz `|x·dy − y·dx| ≤ √(x²+y²)·√(dx²+dy²)` and
+    `√(dx²+dy²) = √(c²) = c`.
+
+  * `area_cauchy_schwarz_bound_contDiff` — the same with `dx, dy` instantiated at
+    the actual derivatives `deriv x, deriv y` of `C¹` coordinates: literally the
+    shape of the parent axiom `area_cauchy_schwarz_bound`.
+
+  ## Why this does not by itself remove the parent axioms
+
+  These theorems are stated for raw continuous functions, not the parent's
+  `SmoothClosedCurve` structure, so wiring them into the parent (to drop its
+  `axiomCount`) is a separate, sensitive parent edit.  Mathematically the two
+  Cauchy–Schwarz axioms are now fully proved.
+
+  ## Sorries: 0   Axioms: 0
+-/
+import Mathlib
+
+open Real MeasureTheory intervalIntegral
+
+namespace IsoperimetricCauchySchwarz
+
+/-- **L² Cauchy–Schwarz on `[0, 2π]`** — the parent axiom `integral_cauchy_schwarz_sq`.
+
+For continuous coordinate functions `x, y`,
+`(∫₀²π √(x²+y²))² ≤ 2π · ∫₀²π (x²+y²)`.
+
+This is Cauchy–Schwarz of the constant `1` against `g = √(x²+y²)`:
+`(∫ 1·g)² ≤ (∫ 1²)(∫ g²) = 2π · ∫ g²`.  We prove it from the discriminant of the
+nonnegative quadratic `λ ↦ ∫₀²π (g − λ)² = ∫g² − 2λ∫g + 2π·λ²`, evaluated at
+`λ = (∫g)/(2π)`. -/
+theorem integral_cauchy_schwarz_sq (x y : ℝ → ℝ)
+    (hx : Continuous x) (hy : Continuous y) :
+    (∫ t in (0 : ℝ)..(2 * π), √(x t ^ 2 + y t ^ 2)) ^ 2 ≤
+      2 * π * ∫ t in (0 : ℝ)..(2 * π), (x t ^ 2 + y t ^ 2) := by
+  set g : ℝ → ℝ := fun t => √(x t ^ 2 + y t ^ 2) with hg
+  -- continuity / integrability of `g` and `g²`
+  have hgc : Continuous g := ((hx.pow 2).add (hy.pow 2)).sqrt
+  have hgI : IntervalIntegrable g volume 0 (2 * π) := hgc.intervalIntegrable 0 (2 * π)
+  have hg2I : IntervalIntegrable (fun t => g t ^ 2) volume 0 (2 * π) :=
+    (hgc.pow 2).intervalIntegrable 0 (2 * π)
+  have hconstI : ∀ lam : ℝ, IntervalIntegrable (fun _ : ℝ => lam) volume 0 (2 * π) :=
+    fun lam => (continuous_const).intervalIntegrable 0 (2 * π)
+  -- `g t ² = x t ² + y t ²`
+  have hg2eq : ∀ t, g t ^ 2 = x t ^ 2 + y t ^ 2 := by
+    intro t
+    have ht : g t = √(x t ^ 2 + y t ^ 2) := by rw [hg]
+    rw [ht]; exact Real.sq_sqrt (by positivity)
+  -- rewrite the right-hand integrand `x²+y²` as `g²`
+  have hRHS : (∫ t in (0 : ℝ)..(2 * π), (x t ^ 2 + y t ^ 2)) =
+      ∫ t in (0 : ℝ)..(2 * π), g t ^ 2 := by
+    apply integral_congr; intro t _; exact (hg2eq t).symm
+  rw [hRHS]
+  -- the quadratic in `λ`
+  have hpiPos : (0 : ℝ) < 2 * π := by positivity
+  have key : ∀ lam : ℝ, (0 : ℝ) ≤ ∫ t in (0 : ℝ)..(2 * π), (g t - lam) ^ 2 := by
+    intro lam
+    apply intervalIntegral.integral_nonneg (le_of_lt hpiPos)
+    intro t _; positivity
+  have expand : ∀ lam : ℝ,
+      (∫ t in (0 : ℝ)..(2 * π), (g t - lam) ^ 2) =
+        (∫ t in (0 : ℝ)..(2 * π), g t ^ 2) - 2 * lam * (∫ t in (0 : ℝ)..(2 * π), g t) +
+          lam ^ 2 * (2 * π) := by
+    intro lam
+    have hcongr : (∫ t in (0 : ℝ)..(2 * π), (g t - lam) ^ 2) =
+        ∫ t in (0 : ℝ)..(2 * π), ((g t ^ 2 - (2 * lam) * g t) + lam ^ 2) := by
+      apply integral_congr; intro t _; ring
+    rw [hcongr,
+        integral_add (hg2I.sub (hgI.const_mul (2 * lam))) (hconstI (lam ^ 2)),
+        integral_sub hg2I (hgI.const_mul (2 * lam)),
+        intervalIntegral.integral_const_mul, intervalIntegral.integral_const]
+    simp only [smul_eq_mul, sub_zero]
+    ring
+  -- discriminant: evaluate at `λ = (∫g)/(2π)`
+  have hquad : ∀ lam : ℝ,
+      (0 : ℝ) ≤ (∫ t in (0 : ℝ)..(2 * π), g t ^ 2) - 2 * lam * (∫ t in (0 : ℝ)..(2 * π), g t) +
+        lam ^ 2 * (2 * π) := by
+    intro lam; rw [← expand lam]; exact key lam
+  set A := ∫ t in (0 : ℝ)..(2 * π), g t ^ 2 with hA
+  set B := ∫ t in (0 : ℝ)..(2 * π), g t with hB
+  -- goal is now `B^2 ≤ 2π * A`
+  have hpiNe : π ≠ 0 := ne_of_gt pi_pos
+  have h := hquad (B / (2 * π))
+  have hsub : A - 2 * (B / (2 * π)) * B + (B / (2 * π)) ^ 2 * (2 * π) = A - B ^ 2 / (2 * π) := by
+    field_simp; ring
+  rw [hsub] at h
+  have hle : B ^ 2 / (2 * π) ≤ A := by linarith
+  calc B ^ 2 = B ^ 2 / (2 * π) * (2 * π) := by field_simp
+    _ ≤ A * (2 * π) := by exact mul_le_mul_of_nonneg_right hle (le_of_lt hpiPos)
+    _ = 2 * π * A := by ring
+
+/-- **Pointwise 2D Cauchy–Schwarz**: `(a·v − b·u)² ≤ (a²+b²)(u²+v²)`. -/
+theorem cross_product_sq_le (a b u v : ℝ) :
+    (a * v - b * u) ^ 2 ≤ (a ^ 2 + b ^ 2) * (u ^ 2 + v ^ 2) := by
+  nlinarith [sq_nonneg (a * u + b * v)]
+
+/-- **Area bound from Cauchy–Schwarz** — the parent axiom `area_cauchy_schwarz_bound`.
+
+For continuous coordinates `x, y` and a continuous velocity field `dx, dy` of
+constant speed `dx² + dy² = c²` with `0 ≤ c`,
+`|∫₀²π (x·dy − y·dx)| ≤ c · ∫₀²π √(x²+y²)`.
+
+Since the Green's-theorem signed area is `A = ½|∫₀²π (x·dy − y·dx)|`, the left side
+is `2A`, so this is exactly `2A ≤ c · ∫√(x²+y²)`.  Proof: pointwise
+`|x·dy − y·dx| ≤ √(x²+y²)·√(dx²+dy²) = c·√(x²+y²)`, then integrate. -/
+theorem area_cauchy_schwarz_bound (x y dx dy : ℝ → ℝ) (c : ℝ) (hc : 0 ≤ c)
+    (hx : Continuous x) (hy : Continuous y) (hdx : Continuous dx) (hdy : Continuous dy)
+    (hspeed : ∀ t, dx t ^ 2 + dy t ^ 2 = c ^ 2) :
+    |∫ t in (0 : ℝ)..(2 * π), (x t * dy t - y t * dx t)| ≤
+      c * ∫ t in (0 : ℝ)..(2 * π), √(x t ^ 2 + y t ^ 2) := by
+  have hpi : (0 : ℝ) ≤ 2 * π := by positivity
+  -- pointwise bound on `[0, 2π]`
+  have hpw : ∀ t ∈ Set.Icc (0 : ℝ) (2 * π),
+      |x t * dy t - y t * dx t| ≤ c * √(x t ^ 2 + y t ^ 2) := by
+    intro t _
+    have hcs : (x t * dy t - y t * dx t) ^ 2 ≤
+        (x t ^ 2 + y t ^ 2) * (dx t ^ 2 + dy t ^ 2) := cross_product_sq_le _ _ _ _
+    have h1 : |x t * dy t - y t * dx t| ≤ √((x t ^ 2 + y t ^ 2) * (dx t ^ 2 + dy t ^ 2)) := by
+      rw [← Real.sqrt_sq_eq_abs]
+      exact Real.sqrt_le_sqrt hcs
+    rw [Real.sqrt_mul (by positivity), hspeed t, Real.sqrt_sq hc] at h1
+    rw [mul_comm (√(x t ^ 2 + y t ^ 2)) c] at h1
+    exact h1
+  -- integrability of the two integrands
+  have hI_abs : IntervalIntegrable (fun t => |x t * dy t - y t * dx t|) volume 0 (2 * π) :=
+    (((hx.mul hdy).sub (hy.mul hdx)).abs).intervalIntegrable 0 (2 * π)
+  have hI_rhs : IntervalIntegrable (fun t => c * √(x t ^ 2 + y t ^ 2)) volume 0 (2 * π) :=
+    (continuous_const.mul (((hx.pow 2).add (hy.pow 2)).sqrt)).intervalIntegrable 0 (2 * π)
+  -- |∫| ≤ ∫|·| ≤ ∫ c√(x²+y²) = c·∫√(x²+y²)
+  have step1 : |∫ t in (0 : ℝ)..(2 * π), (x t * dy t - y t * dx t)| ≤
+      ∫ t in (0 : ℝ)..(2 * π), |x t * dy t - y t * dx t| :=
+    abs_integral_le_integral_abs hpi
+  have step2 : (∫ t in (0 : ℝ)..(2 * π), |x t * dy t - y t * dx t|) ≤
+      ∫ t in (0 : ℝ)..(2 * π), c * √(x t ^ 2 + y t ^ 2) :=
+    integral_mono_on hpi hI_abs hI_rhs hpw
+  have step3 : (∫ t in (0 : ℝ)..(2 * π), c * √(x t ^ 2 + y t ^ 2)) =
+      c * ∫ t in (0 : ℝ)..(2 * π), √(x t ^ 2 + y t ^ 2) :=
+    intervalIntegral.integral_const_mul c _
+  linarith [step1, step2, step3]
+
+/-- The area bound with the velocity field instantiated at the genuine derivatives
+of `C¹` coordinates — literally the shape of the parent axiom. -/
+theorem area_cauchy_schwarz_bound_contDiff (x y : ℝ → ℝ) (c : ℝ) (hc : 0 ≤ c)
+    (hx : ContDiff ℝ 1 x) (hy : ContDiff ℝ 1 y)
+    (hspeed : ∀ t, deriv x t ^ 2 + deriv y t ^ 2 = c ^ 2) :
+    |∫ t in (0 : ℝ)..(2 * π), (x t * deriv y t - y t * deriv x t)| ≤
+      c * ∫ t in (0 : ℝ)..(2 * π), √(x t ^ 2 + y t ^ 2) :=
+  area_cauchy_schwarz_bound x y (deriv x) (deriv y) c hc
+    hx.continuous hy.continuous hx.continuous_deriv_one hy.continuous_deriv_one hspeed
+
+end IsoperimetricCauchySchwarz

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md
@@ -303,3 +303,49 @@ would drop `axiomCount` 5→4, but touches a verified gallery entry (sensitive).
    above. These are "verified" gallery entries that fail `lake build`.
 3. Remaining four parent axioms (`fourier_decomp_exists`, `wirtinger_sum_bound`,
    `area_cauchy_schwarz_bound`, `integral_cauchy_schwarz_sq`) — separate analytic targets.
+
+### Session 2026-06-21 (s06, ACT, researcher-9) — both Cauchy–Schwarz parent axioms discharged 0-axiom
+
+**Outcome: ACT — two of the four remaining analytic parent axioms are now proved.** New
+self-contained file `proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz.lean`
+(`namespace IsoperimetricCauchySchwarz`, imports `Mathlib` only; **0 axioms, 0 sorries, 4
+theorems, docker GREEN on v4.26.0**, `#print axioms` = `[propext, Classical.choice, Quot.sound]`
+for all three headline results — no `ofReduceBool`/`sorryAx`). This discharges the two
+Cauchy–Schwarz axioms of the parent `IsoperimetricFromFourier` proof:
+
+* **`integral_cauchy_schwarz_sq`** (parent axiom verbatim) — for continuous `x, y`,
+  `(∫₀²π √(x²+y²))² ≤ 2π · ∫₀²π (x²+y²)`. Proof = discriminant of the nonnegative quadratic
+  `λ ↦ ∫₀²π (√(x²+y²) − λ)² = ∫g² − 2λ∫g + 2π·λ²`, evaluated at `λ = (∫g)/(2π)`. The parent
+  axiom carries *no* hypotheses because `SmoothClosedCurve` is `C¹` hence continuous; my
+  statement makes that continuity explicit (strictly more general — no periodicity/`C¹` needed).
+
+* **`area_cauchy_schwarz_bound`** + **`…_contDiff`** corollary (parent axiom shape) — for
+  continuous coords `x,y` and continuous velocity `dx,dy` with constant speed `dx²+dy²=c²`
+  (`0≤c`), `|∫₀²π (x·dy − y·dx)| ≤ c·∫₀²π √(x²+y²)`. Since signed area `A = ½|∫(x·dy−y·dx)|`,
+  the LHS is exactly `2A`, so this is the parent's `2A ≤ c·∫√(x²+y²)`. The `…_contDiff` version
+  instantiates `dx,dy := deriv x, deriv y` for `C¹` coords (literally the axiom signature).
+  Proof = pointwise 2D CS `|x·dy − y·dx| ≤ √(x²+y²)·√(dx²+dy²) = c·√(x²+y²)`, then
+  `|∫| ≤ ∫|·| ≤ ∫ c√(x²+y²) = c·∫√(x²+y²)`.
+
+**Mathlib v4.26.0 pin notes / gotchas:**
+- `integral_const_mul` and `integral_const` are **ambiguous** (`intervalIntegral.*` vs
+  `MeasureTheory.*`) — must fully qualify as `intervalIntegral.integral_const_mul` /
+  `intervalIntegral.integral_const` inside an `open MeasureTheory intervalIntegral` file.
+- Bare `rw [mul_comm]` rewrites the *first* product it finds (here the `|x·dy − y·dx|` inside
+  the abs) — give explicit args `rw [mul_comm (√(x t^2+y t^2)) c]` to flip the intended factor.
+- Discriminant assembly: avoid `set S`/`Sxy` before the `integral_add/sub` rewrites — those
+  rewrites *produce* fresh `∫ g` terms that won't fold to the `set` name, so `ring` then sees
+  two distinct atoms. Prove the `expand` equation purely between integral expressions first,
+  derive `hquad`, and only then `set A := ∫g²`, `set B := ∫g` (no further rewriting after).
+- Finish the discriminant division-safely: `B² = B²/(2π)·(2π) ≤ A·(2π) = 2π·A`
+  (`field_simp` for the first `=`, `mul_le_mul_of_nonneg_right` for the `≤`) — feeding the
+  raw `B/(2π)` substitution to `nlinarith` fails on the divisions.
+- Key lemmas: `intervalIntegral.integral_nonneg`, `IntervalIntegrable.const_mul`/`.sub`/`.add`,
+  `abs_integral_le_integral_abs`, `integral_mono_on hab hf hg h`, `Real.sqrt_sq_eq_abs`,
+  `Real.sqrt_mul (0≤·)`, `Real.sqrt_sq (0≤·)`, `Real.sq_sqrt (0≤·)`, `ContDiff.continuous_deriv_one`.
+
+**Honest scope.** These theorems are stated for raw continuous functions, not the parent's
+`SmoothClosedCurve` structure, so they are not yet *wired into* the parent (that is a separate,
+sensitive parent edit that would drop `axiomCount` 5→4→…→2). Mathematically the two
+Cauchy–Schwarz axioms are now fully discharged 0-axiom; only the two genuinely Fourier-analytic
+axioms (`fourier_decomp_exists`, `wirtinger_sum_bound`) remain.

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md
@@ -2,12 +2,23 @@
 
 ## Current State
 **Phase**: ACT
-**Status**: PROGRESS — full `exists_nice_reparam` for REGULAR curves PROVED (0-axiom); IFT middle re-derived on current Mathlib
+**Status**: PROGRESS — reparam axiom (regular locus) + BOTH Cauchy–Schwarz axioms now discharged 0-axiom; only the two Fourier-analytic axioms remain
 **Path**: full
 **Since**: 2026-06-13
-**Iteration**: 5
+**Iteration**: 6
 
 ## Current Focus
+s06 (2026-06-21, researcher-9) shipped `AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz.lean`
+(`namespace IsoperimetricCauchySchwarz`, imports `Mathlib` only, 0-axiom, docker-GREEN, 4 thm,
+`#print axioms` = propext/Classical.choice/Quot.sound): discharges **both** Cauchy–Schwarz
+parent axioms — `integral_cauchy_schwarz_sq` ((∫√(x²+y²))² ≤ 2π·∫(x²+y²), via the discriminant
+of the nonnegative quadratic `λ ↦ ∫(√(x²+y²)−λ)²`) and `area_cauchy_schwarz_bound`
+(|∫(x·dy−y·dx)| ≤ c·∫√(x²+y²) under constant speed, plus a `…_contDiff` corollary matching the
+axiom signature). After s05+s06, 3 of the parent's 5 axioms (reparam-on-regular, integral-CS,
+area-CS) are proved 0-axiom; only `fourier_decomp_exists` and `wirtinger_sum_bound` remain.
+See knowledge.md s06 for the proof and v4.26.0 gotchas.
+
+## Prior Focus
 s05 (2026-06-21, researcher-9) shipped `AreaOfCircleOQ01OQ02OQ02OQ01OQ01IFT.lean`
 (`namespace RegularCurveArcLength`, imports Mathlib + the s04 `…Reparam` companion, 0-axiom,
 docker-GREEN, 35 thm/3 def, `#print axioms`=propext/Classical.choice/Quot.sound only): the
@@ -34,8 +45,12 @@ built directly as a `RegularClosedCurve`, circumference preserved trivially, are
   bit-rotted entries).
 
 ## Next Action
-CORE PROVED. Next: (1) optional sensitive parent edit — restate parent `exists_nice_reparam`
-with a `regular` field and discharge via `exists_nice_reparam_for_regular` (needs a
-SmoothClosedCurve↔RegularClosedCurve bridge), dropping parent `axiomCount` 5→4; (2) mechanic:
-repair bit-rotted sibling/parent (renames now pinned in knowledge.md s05); (3) remaining four
-parent axioms (Fourier/Wirtinger/Cauchy–Schwarz) — separate analytic core.
+3/5 axioms now proved 0-axiom (reparam-on-regular, integral-CS, area-CS). Next:
+(1) **`wirtinger_sum_bound`** — apply the already-PROVED `wirtinger_inequality` (parent thm) to
+each coordinate and add: `∫(x²+y²) = ∫x²+∫y² ≤ ∫x'²+∫y'² = ∫(speed²) = 2π·c²`. The only gap is
+the `FourierDecomp` existence the parent `wirtinger_inequality` requires — i.e. it still leans
+on `fourier_decomp_exists`. So Wirtinger is genuinely downstream of the Fourier axiom.
+(2) **`fourier_decomp_exists`** — the real analytic core (Parseval + IBP for periodic C¹
+functions); the hard remaining target.
+(3) optional sensitive parent edit wiring s05/s06 theorems into the parent to drop `axiomCount`.
+(4) mechanic: repair bit-rotted sibling/parent (renames pinned in knowledge.md s05).


### PR DESCRIPTION
## Summary

Discharges **two of the five axioms** of the parent Hurwitz isoperimetric proof
(`AreaOfCircleOQ01OQ02OQ02OQ01.lean`, `namespace IsoperimetricFromFourier`) — the two
Cauchy–Schwarz analytic bounds — **0-axiom**, in a new self-contained companion
`proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz.lean`
(`namespace IsoperimetricCauchySchwarz`, imports `Mathlib` only).

Combined with the prior IFT session (#27281, reparametrization axiom on the regular locus),
**3 of the parent's 5 axioms are now proved 0-axiom**; only the two genuinely Fourier-analytic
axioms remain (`fourier_decomp_exists`, `wirtinger_sum_bound`).

## Results (4 theorems, all `#print axioms` = `[propext, Classical.choice, Quot.sound]`)

- **`integral_cauchy_schwarz_sq`** — the parent axiom verbatim. For continuous `x, y`,
  `(∫₀²π √(x²+y²))² ≤ 2π · ∫₀²π (x²+y²)`. This is L² Cauchy–Schwarz of `1` against `√(x²+y²)`;
  proved from the discriminant of the nonnegative quadratic
  `λ ↦ ∫₀²π (√(x²+y²) − λ)² = ∫g² − 2λ∫g + 2π·λ²`, evaluated at `λ = (∫g)/(2π)`. (The parent
  axiom carries no hypotheses because `SmoothClosedCurve` is `C¹` hence continuous — made
  explicit here, strictly more general.)

- **`area_cauchy_schwarz_bound`** (+ **`area_cauchy_schwarz_bound_contDiff`**) — the parent
  axiom shape. For continuous coordinates and a constant-speed velocity field
  (`dx²+dy²=c²`, `0≤c`), `|∫₀²π (x·dy − y·dx)| ≤ c · ∫₀²π √(x²+y²)`. Since the Green's-theorem
  signed area is `A = ½|∫₀²π (x·dy − y·dx)|`, the LHS is exactly `2A`, so this is the parent's
  `2A ≤ c·∫√(x²+y²)`. Proved from pointwise 2D Cauchy–Schwarz
  `|x·dy − y·dx| ≤ √(x²+y²)·√(dx²+dy²) = c·√(x²+y²)`, then
  `|∫| ≤ ∫|·| ≤ ∫ c√(x²+y²) = c·∫√(x²+y²)`. The `_contDiff` corollary instantiates
  `dx,dy := deriv x, deriv y` for `C¹` coordinates — literally the axiom signature.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz` — GREEN (Lean v4.26.0 / Mathlib v4.26.0)
- `#print axioms` on all three headline theorems = `[propext, Classical.choice, Quot.sound]` (no `ofReduceBool`, no `sorryAx`)
- 0 sorries, 0 `axiom` declarations, 0 assumption-carrying structures

## Scope

The theorems are stated for raw continuous functions rather than the parent's
`SmoothClosedCurve` structure, so wiring them into the parent (to lower its `axiomCount`) is a
separate, sensitive parent edit. Mathematically the two Cauchy–Schwarz axioms are now fully
discharged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)