### PR TITLE
research(erdos-131-oq-01-oq-01-oq-01-oq-03): exact cyclic Davenport constant D(ℤ/nℤ)=n [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos131DavenportConstant.lean
+++ b/proofs/Proofs/Erdos131DavenportConstant.lean
@@ -1,0 +1,170 @@
+/-
+  Erdős Problem #131 — Non-Dividing Sets
+  Follow-up (oq-01-oq-01-oq-01-oq-03): the EXACT Davenport constant of the cyclic
+  group `ℤ/nℤ`.
+
+  Source: https://erdosproblems.com/131
+  Companion to: `Proofs.Erdos131DavenportBound` (`exists_nonempty_subset_sum_dvd`,
+  the upper bound `D(ℤ/aℤ) ≤ a` in the integer-divisibility / `Finset ℕ` form used
+  to sharpen the EGZ set bound).
+
+  NOTE.  This file is deliberately SELF-CONTAINED (only `import Mathlib`); it does
+  not import the companions, which keeps it independently verifiable and axiom-free.
+
+  ## What this file adds
+
+  The **Davenport constant** `D(G)` of a finite abelian group `G` is the least `d`
+  such that every length-`d` sequence over `G` has a nonempty zero-sum subsequence.
+  Mathlib has the Erdős–Ginzburg–Ziv theorem (the EGZ constant `s(ℤ/nℤ) = 2n − 1`)
+  but NOT the Davenport constant.  The companion `Erdos131DavenportBound` proved
+  only the upper bound `D(ℤ/aℤ) ≤ a`, and only in the special integer-divisibility
+  form (a nonempty subset of any `a` *distinct naturals* has sum divisible by `a`).
+
+  Here we prove the constant EXACTLY, in the genuine sequence setting over
+  `ZMod n`, as an `IsLeast` statement:
+
+      **`D(ℤ/nℤ) = n`**  (`davenport_constant_cyclic`).
+
+  Concretely:
+  * **Upper bound** (`davenport_upper`): every sequence `f : Fin m → ZMod n` with
+    `n ≤ m` has a nonempty `s : Finset (Fin m)` with `∑ i ∈ s, f i = 0`.  Proof:
+    the `m + 1` prefix sums land in `ZMod n` (an `n`-element type), so by
+    pigeonhole two coincide and the index interval between them is a nonempty
+    zero-sum subsequence.  (This generalises the companion's `Finset ℕ` version to
+    arbitrary `ZMod n` sequences — the actual Davenport setting.)
+  * **Lower bound** (`davenport_no_zerosum_const_one`): the constant sequence `1`
+    of any length `m < n` has NO nonempty zero-sum subsequence — a nonempty subset
+    of size `k` sums to `(k : ZMod n)` with `1 ≤ k ≤ m < n`, hence `≠ 0`.  So no
+    `m < n` is a Davenport length: the bound `n` is sharp.
+
+  Both directions are unconditional and axiom-free.
+-/
+
+import Mathlib
+
+namespace Erdos131DavenportConstant
+
+open Finset
+
+/-- A sequence `f : Fin m → ZMod n` *has a nonempty zero-sum subsequence* if some
+nonempty index set `s` has `∑ i ∈ s, f i = 0`.  The Davenport constant `D(ℤ/nℤ)`
+is the least `m` for which EVERY such sequence has this property. -/
+def HasZeroSumSubseq {n m : ℕ} (f : Fin m → ZMod n) : Prop :=
+  ∃ s : Finset (Fin m), s.Nonempty ∧ ∑ i ∈ s, f i = 0
+
+/-- **Davenport upper bound `D(ℤ/nℤ) ≤ n`.**  Every sequence of length `≥ n` over
+`ℤ/nℤ` has a nonempty zero-sum subsequence.
+
+Proof: consider the `m + 1` prefix sums `P k = ∑_{i.val < k} f i` for `k = 0,…,m`.
+They take values in `ZMod n`, which has `n < m + 1` elements, so by pigeonhole
+(`Fintype.exists_ne_map_eq_of_card_lt`) two indices `p < q` give `P p = P q`.  The
+index interval `[p, q)` then sums to `0` and is nonempty (it contains `p`). -/
+theorem davenport_upper {n m : ℕ} (hn : 1 ≤ n) (f : Fin m → ZMod n) (hm : n ≤ m) :
+    HasZeroSumSubseq f := by
+  haveI : NeZero n := ⟨by omega⟩
+  classical
+  -- From a collision of two prefix sums we extract the zero-sum interval.
+  have core : ∀ p q : ℕ, p < q → q ≤ m →
+      (∑ i ∈ univ.filter (fun i : Fin m => i.val < p), f i)
+        = (∑ i ∈ univ.filter (fun i : Fin m => i.val < q), f i) →
+      HasZeroSumSubseq f := by
+    intro p q hpq hqm heq
+    refine ⟨univ.filter (fun i : Fin m => p ≤ i.val ∧ i.val < q), ⟨⟨p, by omega⟩, ?_⟩, ?_⟩
+    · simp only [Finset.mem_filter, Finset.mem_univ, true_and]; omega
+    · -- The interval `[p, q)` splits the prefix `[0, q)` off the prefix `[0, p)`.
+      have hUnion : univ.filter (fun i : Fin m => i.val < q)
+          = univ.filter (fun i : Fin m => i.val < p)
+            ∪ univ.filter (fun i : Fin m => p ≤ i.val ∧ i.val < q) := by
+        ext i
+        simp only [Finset.mem_union, Finset.mem_filter, Finset.mem_univ, true_and]
+        omega
+      have hDisj : Disjoint (univ.filter (fun i : Fin m => i.val < p))
+          (univ.filter (fun i : Fin m => p ≤ i.val ∧ i.val < q)) := by
+        rw [Finset.disjoint_left]
+        intro i hi1 hi2
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hi1 hi2
+        omega
+      have hsplit : (∑ i ∈ univ.filter (fun i : Fin m => i.val < q), f i)
+          = (∑ i ∈ univ.filter (fun i : Fin m => i.val < p), f i)
+            + ∑ i ∈ univ.filter (fun i : Fin m => p ≤ i.val ∧ i.val < q), f i := by
+        rw [hUnion, Finset.sum_union hDisj]
+      rw [← heq] at hsplit
+      -- `hsplit : prefix = prefix + block`, hence `block = 0`.
+      linear_combination -hsplit
+  -- Pigeonhole on the `m + 1` prefix sums.
+  have hcard : Fintype.card (ZMod n) < Fintype.card (Fin (m + 1)) := by
+    rw [ZMod.card, Fintype.card_fin]; omega
+  obtain ⟨a, b, hne, hPeq⟩ :=
+    Fintype.exists_ne_map_eq_of_card_lt
+      (fun k : Fin (m + 1) =>
+        ∑ i ∈ univ.filter (fun i : Fin m => i.val < k.val), f i) hcard
+  have hvne : a.val ≠ b.val := Fin.val_injective.ne hne
+  have ha := a.isLt
+  have hb := b.isLt
+  rcases lt_or_gt_of_ne hvne with h | h
+  · exact core a.val b.val h (by omega) hPeq
+  · exact core b.val a.val h (by omega) hPeq.symm
+
+/-- **Davenport lower bound (sharpness): `D(ℤ/nℤ) ≥ n`.**  For any `m < n` the
+constant sequence `1` of length `m` over `ℤ/nℤ` has NO nonempty zero-sum
+subsequence: a nonempty `s` of size `k` sums to `(k : ZMod n)` with `1 ≤ k ≤ m < n`,
+so the sum is nonzero. -/
+theorem davenport_no_zerosum_const_one {n m : ℕ} (hmn : m < n) :
+    ¬ HasZeroSumSubseq (fun _ : Fin m => (1 : ZMod n)) := by
+  haveI : NeZero n := ⟨by omega⟩
+  rintro ⟨s, hne, hsum⟩
+  -- The subsequence sum is just the cardinality of `s`, cast into `ZMod n`.
+  simp only [Finset.sum_const, nsmul_eq_mul, mul_one] at hsum
+  have hdvd : (n : ℕ) ∣ s.card := (ZMod.natCast_eq_zero_iff _ _).mp hsum
+  have hpos : 0 < s.card := Finset.card_pos.mpr hne
+  have hle : s.card ≤ m := by
+    have h := Finset.card_le_univ s
+    rwa [Fintype.card_fin] at h
+  exact absurd hdvd (Nat.not_dvd_of_pos_of_lt hpos (by omega))
+
+/-- **The Davenport constant of the cyclic group `ℤ/nℤ` is exactly `n`.**
+
+`D(ℤ/nℤ) = n`, stated as: `n` is the LEAST length such that every sequence over
+`ℤ/nℤ` of that length has a nonempty zero-sum subsequence.  The two halves are
+`davenport_upper` (`n` works) and `davenport_no_zerosum_const_one` (no `m < n`
+works, witnessed by the constant-`1` sequence). -/
+theorem davenport_constant_cyclic {n : ℕ} (hn : 1 ≤ n) :
+    IsLeast {m : ℕ | ∀ f : Fin m → ZMod n, HasZeroSumSubseq f} n := by
+  constructor
+  · -- `n` is in the set: every length-`n` sequence has a zero-sum subsequence.
+    intro f
+    exact davenport_upper hn f (le_refl n)
+  · -- `n` is a lower bound: any length in the set is `≥ n`.
+    intro m hm
+    by_contra hlt
+    push_neg at hlt
+    exact davenport_no_zerosum_const_one hlt (hm (fun _ => 1))
+
+/-- **Membership form of the upper bound.**  Restates `davenport_upper` as
+membership in the Davenport set: every length `≥ n` is a Davenport length. -/
+theorem mem_davenport_set_of_ge {n m : ℕ} (hn : 1 ≤ n) (hm : n ≤ m) :
+    m ∈ {m : ℕ | ∀ f : Fin m → ZMod n, HasZeroSumSubseq f} :=
+  fun f => davenport_upper hn f hm
+
+/-- **Exact-value extraction.**  The least Davenport length is computably `n`. -/
+theorem davenport_isLeast_eq {n : ℕ} (hn : 1 ≤ n)
+    {d : ℕ} (hd : IsLeast {m : ℕ | ∀ f : Fin m → ZMod n, HasZeroSumSubseq f} d) :
+    d = n :=
+  IsLeast.unique hd (davenport_constant_cyclic hn)
+
+/-- **The general-sequence upper bound strengthens the companion's `Finset ℕ` bound.**
+
+Specialising `davenport_upper` to the sequence `i ↦ (g i : ZMod n)` recovers, for any
+function `g : Fin m → ℕ` with `n ≤ m`, a nonempty index set whose `g`-sum is divisible
+by `n` — the Davenport bound `D(ℤ/nℤ) ≤ n` in integer-divisibility form, now without
+the distinctness/`Finset` restriction of the companion file. -/
+theorem exists_index_subset_sum_dvd {n m : ℕ} (hn : 1 ≤ n) (g : Fin m → ℕ)
+    (hm : n ≤ m) :
+    ∃ s : Finset (Fin m), s.Nonempty ∧ (n : ℕ) ∣ ∑ i ∈ s, g i := by
+  haveI : NeZero n := ⟨by omega⟩
+  obtain ⟨s, hne, hsum⟩ := davenport_upper hn (fun i => (g i : ZMod n)) hm
+  refine ⟨s, hne, ?_⟩
+  have : ((∑ i ∈ s, g i : ℕ) : ZMod n) = 0 := by push_cast; simpa using hsum
+  exact (ZMod.natCast_eq_zero_iff _ _).mp this
+
+end Erdos131DavenportConstant

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-03/knowledge.md
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-03/knowledge.md
@@ -1,0 +1,72 @@
+# Erdős #131 — Exact Cyclic Davenport Constant `D(ℤ/nℤ) = n`
+
+**Slug:** `erdos-131-oq-01-oq-01-oq-01-oq-03`
+**File:** `proofs/Proofs/Erdos131DavenportConstant.lean`
+**Status:** verified · 0 axioms · 0 sorries · 6 theorems · 1 definition · 170 lines
+
+## Summary
+
+The **Davenport constant** `D(G)` of a finite abelian group `G` is the least `d`
+such that every length-`d` sequence over `G` has a nonempty zero-sum subsequence.
+This entry proves the classical cyclic value **`D(ℤ/nℤ) = n`** exactly and
+axiom-free, packaged as
+
+```
+davenport_constant_cyclic : IsLeast {m | ∀ f : Fin m → ZMod n, HasZeroSumSubseq f} n
+```
+
+Mathlib has the Erdős–Ginzburg–Ziv constant `s(ℤ/nℤ) = 2n − 1` but **not** the
+Davenport constant, so this is built from scratch.
+
+## Relation to the companion (`erdos-131-oq-01-oq-01-oq-01`)
+
+The companion EGZ-sharpening entry proved only the **upper bound** `D ≤ a`, and
+only in the **integer-divisibility form for distinct naturals**
+(`exists_nonempty_subset_sum_dvd` over `Finset ℕ`), using it to sharpen the
+non-dividing set bound to `|A| ≤ a + 1`. This entry:
+
+1. Proves the upper bound for **arbitrary `ZMod n` sequences** (with repeats) —
+   the genuine Davenport setting (`davenport_upper`).
+2. Adds the **matching lower bound** (`davenport_no_zerosum_const_one`): the
+   constant-`1` sequence of length `< n` is zero-sum-free, so `n` is sharp.
+3. Packages the exact value as `IsLeast` and extracts uniqueness.
+
+## Proof sketch
+
+- **Upper (`davenport_upper`).** For `f : Fin m → ZMod n` with `n ≤ m`, the `m+1`
+  prefix sums `P k = ∑_{i.val < k} f i` lie in the `n`-element type `ZMod n`. Since
+  `n < m+1`, `Fintype.exists_ne_map_eq_of_card_lt` collides two indices `p < q`.
+  The index interval `[p,q)` then has sum `0` — obtained by splitting the prefix
+  filter `[0,q) = [0,p) ⊔ [p,q)` (disjoint, `Finset.sum_union`) and cancelling —
+  and is nonempty (contains `p`, since `p < q ≤ m`).
+- **Lower (`davenport_no_zerosum_const_one`).** A nonempty `s ⊆ Fin m` for the
+  constant-`1` sequence sums to `(s.card : ZMod n)`. With `1 ≤ s.card ≤ m < n`,
+  `ZMod.natCast_eq_zero_iff` (n ∤ k for `0 < k < n`) gives sum `≠ 0`.
+
+## Key Lean gotchas (Mathlib v4.26.0)
+
+- `self_eq_add_right` is **not** a usable identifier here — to get `block = 0`
+  from `prefix = prefix + block`, use `linear_combination -hsplit` (ZMod n is a
+  CommRing).
+- Deriving `NeZero n` from `hmn : m < n` via `⟨by omega⟩` makes a separate
+  `hn : 1 ≤ n` hypothesis **unused** (linter error in verified entries) — drop it.
+- The prefix split is cleanest via an explicit `ext i; … ; omega` Finset equality
+  plus `Finset.disjoint_left` + `omega`, then `Finset.sum_union`.
+- `ZMod.natCast_eq_zero_iff _ _ : (k : ZMod n) = 0 ↔ n ∣ k` (not `…_zmod_…`).
+
+## Open questions generated
+
+1. **(high)** Lift the prefix-sum pigeonhole to the rank-2 group
+   `D(ℤ/n₁ ⊕ ℤ/n₂) = n₁ + n₂ − 1` by an elementary axiom-free argument.
+2. **(medium)** Does the *set* (distinct-element) zero-sum threshold differ from
+   the *sequence* Davenport constant `n`?
+
+## Session log
+
+### 2026-06-21 (FRESH follow-up, REVISIT-mode session) — completed
+- Pool had 0 available; chose to ship a strong self-contained follow-up to the
+  just-merged Davenport sharpening (PR #27284).
+- Wrote, built (docker, warm cache, clean), and packaged the exact cyclic
+  Davenport constant. 0-axiom verified.
+- Files: `proofs/Proofs/Erdos131DavenportConstant.lean`,
+  `src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-03/{meta.json,knowledge.md}`.

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "erdos-131-oq-01-oq-01-oq-01-oq-03",
+  "slug": "erdos-131-oq-01-oq-01-oq-01-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos131DavenportConstant",
+    "lineCount": 170,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos131DavenportConstant.lean",
+    "sorries": 0
+  },
+  "title": "The Davenport Constant of the Cyclic Group ℤ/nℤ is Exactly n (Erdős #131)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos131DavenportConstant.lean",
+    "tags": [
+      "number-theory",
+      "additive-combinatorics",
+      "erdos-problems",
+      "erdos-131",
+      "davenport-constant",
+      "zero-sum-free",
+      "zero-sum-subsequence",
+      "cyclic-group",
+      "pigeonhole",
+      "isleast",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 170,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "davenport_constant_cyclic: the headline result — the Davenport constant of the cyclic group ℤ/nℤ is EXACTLY n, formalized as IsLeast {m | ∀ f : Fin m → ZMod n, HasZeroSumSubseq f} n. The Davenport constant D(G) is the least length d such that every length-d sequence over G has a nonempty zero-sum subsequence; this establishes D(ℤ/nℤ) = n in full (both the upper bound and its sharpness), axiom-free. Mathlib has the Erdős–Ginzburg–Ziv constant s(ℤ/nℤ) = 2n − 1 but NOT the Davenport constant, so this is built from scratch.",
+      "davenport_upper: the upper bound D(ℤ/nℤ) ≤ n in the GENUINE sequence setting — every sequence f : Fin m → ZMod n with n ≤ m has a nonempty index set s with ∑_{i ∈ s} f i = 0. Proof: the m + 1 prefix sums P k = ∑_{i.val < k} f i live in ZMod n (an n-element type), so for m ≥ n pigeonhole (Fintype.exists_ne_map_eq_of_card_lt) collides two, P p = P q with p < q; the index interval [p, q) then has sum 0 (prefix split via Finset.sum_union of the disjoint [0,p) and [p,q) blocks) and is nonempty (it contains p). This STRENGTHENS the companion Erdos131DavenportBound's exists_nonempty_subset_sum_dvd, which proved the bound only for Finsets of DISTINCT naturals via integer divisibility; here it holds for arbitrary ZMod n sequences (with repeats), the actual Davenport setting.",
+      "davenport_no_zerosum_const_one: the matching lower bound / sharpness D(ℤ/nℤ) ≥ n — for every m < n the constant sequence 1 of length m over ℤ/nℤ has NO nonempty zero-sum subsequence. A nonempty index set s sums to (s.card : ZMod n) with 1 ≤ s.card ≤ m < n, hence nonzero by ZMod.natCast_eq_zero_iff (n ∤ k for 0 < k < n). This shows no length below n suffices, so the constant n is sharp — the extremal zero-sum-free sequence is the n − 1 repeated 1's.",
+      "exists_index_subset_sum_dvd: a corollary that the general-sequence upper bound recovers and strengthens the companion's divisibility statement — any g : Fin m → ℕ with n ≤ m has a nonempty index set whose g-sum is divisible by n, now WITHOUT the distinctness restriction of the Finset ℕ version (the indices may carry equal values).",
+      "davenport_isLeast_eq: uniqueness extraction — any d realising the IsLeast Davenport characterisation equals n, via IsLeast.unique.",
+      "HasZeroSumSubseq and mem_davenport_set_of_ge: the clean predicate ‘sequence has a nonempty zero-sum subsequence’ and the membership form of the upper bound, packaging the Davenport-length set {m | ∀ f, HasZeroSumSubseq f} whose least element is computed."
+    ],
+    "prerequisites": [
+      "Fintype.exists_ne_map_eq_of_card_lt (Mathlib): the pigeonhole principle — a map from a finite type into a strictly smaller finite type identifies two points; applied to the m + 1 prefix-sum function Fin (m+1) → ZMod n.",
+      "ZMod.card and ZMod.natCast_eq_zero_iff: |ZMod n| = n (the source of the pigeonhole inequality n < m + 1) and (k : ZMod n) = 0 ↔ n ∣ k (bridging both the prefix-sum collision to the zero interval sum and the constant-1 cardinality to nonzero).",
+      "Finset.sum_union together with the disjoint decomposition of the prefix filter [0, q) into [0, p) and [p, q): turns equal prefix sums into a zero block sum.",
+      "IsLeast / IsLeast.unique (Mathlib): the order-theoretic packaging ‘least element of a set of naturals’, used to state D(ℤ/nℤ) = n as a least Davenport length and to extract its uniqueness."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.exists_ne_map_eq_of_card_lt",
+        "description": "Pigeonhole: if |β| < |α| then any f : α → β collides. Instantiated with α = Fin (m+1) (prefix indices) and β = ZMod n; the engine of davenport_upper.",
+        "module": "Mathlib.Data.Fintype.Pigeonhole"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(k : ZMod n) = 0 ↔ n ∣ k. Used both to read off the zero interval sum and, contrapositively, to show the constant-1 sequence of length < n is zero-sum-free.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.sum_union",
+        "description": "Sum over a disjoint union splits additively. Applied to the prefix filter [0, q) = [0, p) ⊔ [p, q) to express the interval block sum as P q − P p.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "IsLeast.unique",
+        "description": "A set has at most one least element. Yields davenport_isLeast_eq: any Davenport length characterisation equals n.",
+        "module": "Mathlib.Order.Bounds.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "erdos-131-oq-01-oq-01-oq-01-oq-03-oq-01",
+      "question": "The general-group Davenport constant D(G) for a finite abelian group G = ℤ/n₁ ⊕ ⋯ ⊕ ℤ/n_k (n₁ | ⋯ | n_k) satisfies D(G) ≥ 1 + Σ(nᵢ − 1), with equality for k ≤ 2 and for p-groups (Olson) but NOT in general. Can the prefix-sum pigeonhole upper bound here be lifted to give D(ℤ/n₁ ⊕ ℤ/n₂) = n₁ + n₂ − 1 (rank-2 case) by an elementary, axiom-free argument?",
+      "significance": "high"
+    },
+    {
+      "id": "erdos-131-oq-01-oq-01-oq-01-oq-03-oq-02",
+      "question": "The exact constant D(ℤ/nℤ) = n drives the set bound |A| ≤ a + 1 for non-dividing sets, but the SET version (distinct elements) may have a strictly smaller threshold than the sequence version. What is the least m such that every m-element SUBSET of ℕ (distinct residues mod n permitted to repeat across the set only via value, not residue) contains a nonempty zero-sum subset mod n, and does it differ from the Davenport constant n?",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-131-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Completes the underlying invariant of the EGZ-sharpening entry. That entry proved only the upper bound D(ℤ/aℤ) ≤ a, and only in the integer-divisibility form for Finsets of distinct naturals (exists_nonempty_subset_sum_dvd), using it to sharpen the non-dividing set bound to |A| ≤ a + 1. This entry proves the constant EXACTLY — D(ℤ/nℤ) = n — in the proper sequence setting over ZMod n, adding the matching lower bound (the constant-1 sequence of length n − 1 is zero-sum-free) and packaging the result as IsLeast, and strengthens the upper bound to arbitrary (non-distinct) sequences."
+    },
+    {
+      "targetId": "erdos-131",
+      "relationship": "extends",
+      "description": "Supplies the exact additive-combinatorial constant — the cyclic Davenport constant — that governs the structural size bounds on non-dividing sets in the parent Erdős #131 study, as a reusable axiom-free formalization Mathlib currently lacks."
+    }
+  ],
+  "references": [
+    {
+      "title": "On some problems in combinatorial number theory",
+      "author": "Paul Erdős",
+      "year": "1975",
+      "venue": "Er75b",
+      "description": "Erdős's problem #131 on non-dividing sets and the function F(N); the cyclic Davenport constant is the invariant behind the per-element size bounds on such sets."
+    },
+    {
+      "title": "On Davenport's constant",
+      "author": "various (survey)",
+      "year": "2006",
+      "venue": "Expo. Math. / survey",
+      "description": "The Davenport constant D(G) is the least d such that every length-d sequence over G has a nonempty zero-sum subsequence; the classical value for cyclic groups is D(ℤ/nℤ) = n, proved here from scratch (both bounds) by prefix-sum pigeonhole and an extremal constant-1 sequence."
+    },
+    {
+      "title": "A combinatorial problem on finite Abelian groups, I",
+      "author": "John E. Olson",
+      "year": "1969",
+      "venue": "J. Number Theory",
+      "description": "Foundational results on the Davenport constant, including D(G) for p-groups; context for the rank-2 generalisation posed in the open questions."
+    },
+    {
+      "title": "Theorem in the additive number theory",
+      "author": "Paul Erdős, Abraham Ginzburg, Abraham Ziv",
+      "year": "1961",
+      "venue": "Bull. Res. Council Israel",
+      "description": "The Erdős–Ginzburg–Ziv theorem and its constant s(ℤ/nℤ) = 2n − 1; the Davenport constant n is strictly smaller (it forbids zero-sum subsequences of every length, not just length n), the distinction exploited by the parent EGZ-sharpening entry."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The Davenport constant of the cyclic group ℤ/nℤ — the least length d such that every length-d sequence over ℤ/nℤ has a nonempty zero-sum subsequence — is exactly n (davenport_constant_cyclic, stated as IsLeast). The upper bound D(ℤ/nℤ) ≤ n (davenport_upper) holds for arbitrary sequences f : Fin m → ZMod n with n ≤ m: the m + 1 prefix sums collide in the n-element type ZMod n by pigeonhole, and the index interval between a collision sums to zero (prefix split via Finset.sum_union) and is nonempty. The matching lower bound (davenport_no_zerosum_const_one) shows sharpness: for every m < n the constant sequence 1 of length m is zero-sum-free, since any nonempty subsequence of size k sums to (k : ZMod n) with 1 ≤ k ≤ m < n. A corollary (exists_index_subset_sum_dvd) recovers and strengthens the companion entry's integer-divisibility bound to arbitrary (non-distinct) index sequences, and davenport_isLeast_eq extracts uniqueness. 170 lines, 6 theorems, 1 definition, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The entry provides a complete, exact, axiom-free formalization of the cyclic Davenport constant D(ℤ/nℤ) = n — a named additive-combinatorial invariant Mathlib lacks (it has only the larger EGZ constant 2n − 1). Where the companion EGZ-sharpening entry needed only the upper bound (and only for distinct naturals) to bound non-dividing sets, this entry pins the invariant exactly and in its proper sequence generality, supplying the prefix-sum pigeonhole upper bound and the extremal zero-sum-free witness (n − 1 repeated ones) as reusable infrastructure. It sets up the natural generalisations to rank-2 and p-group Davenport constants posed in the open questions."
+  }
+}


### PR DESCRIPTION
## Summary

The **Davenport constant** `D(G)` of a finite abelian group is the least length `d` such that every length-`d` sequence over `G` has a nonempty zero-sum subsequence. This entry proves the classical cyclic value **`D(ℤ/nℤ) = n`** exactly and axiom-free, packaged as `IsLeast`. Mathlib has the Erdős–Ginzburg–Ziv constant `s(ℤ/nℤ) = 2n − 1` but **not** the Davenport constant.

Follow-up (oq-01-oq-01-oq-01-oq-03) to the just-merged EGZ-sharpening entry (#27284), which proved only the **upper bound** `D ≤ a` and only in integer-divisibility form for **distinct naturals**. This entry pins the constant **exactly**, in the **genuine sequence setting** over `ZMod n`.

## Results (`Proofs/Erdos131DavenportConstant.lean`)

- `davenport_upper` — every `f : Fin m → ZMod n` with `n ≤ m` has a nonempty zero-sum subsequence. Proof: the `m+1` prefix sums collide in the `n`-element type `ZMod n` by pigeonhole; the index interval between a collision sums to `0` (disjoint prefix split via `Finset.sum_union`) and is nonempty. Strengthens the companion to arbitrary (non-distinct) sequences.
- `davenport_no_zerosum_const_one` — the constant-`1` sequence of length `m < n` is zero-sum-free (any nonempty subseq sums to `(k : ZMod n)`, `1 ≤ k < n`). Hence `n` is **sharp**.
- `davenport_constant_cyclic` — `IsLeast {m | ∀ f : Fin m → ZMod n, HasZeroSumSubseq f} n`, i.e. `D(ℤ/nℤ) = n`.
- `exists_index_subset_sum_dvd`, `davenport_isLeast_eq`, `mem_davenport_set_of_ge` — corollaries (divisibility form without distinctness; uniqueness; membership form).

## Verification

- **170 lines · 6 theorems · 1 definition · 0 axioms · 0 sorries · 0 native_decide**
- Docker-built clean on Mathlib v4.26.0 (`./proofs/scripts/docker-build.sh Proofs.Erdos131DavenportConstant`).
- Axioms: `propext`, `Classical.choice`, `Quot.sound` only → `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)