### PR TITLE
audit: mark erdos-131-oq-01-oq-01-oq-01-oq-03 (Davenport constant) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17481,8 +17481,14 @@
       "issues": [],
       "lastAudited": "2026-06-21T08:00:00Z",
       "result": "clean"
+    },
+    "erdos-131-oq-01-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T08:30:00Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T08:00:00Z"
+  "lastUpdated": "2026-06-21T08:30:00Z"
 }


### PR DESCRIPTION
## Audit result: CLEAN

Deep-audited the newest gallery entry **The Davenport Constant of the Cyclic Group ℤ/nℤ is Exactly n** (Erdős #131, shipped in #27287).

| Check | Result |
|-------|--------|
| Sorries | 0 |
| `axiom` declarations | 0 |
| `native_decide` | none |
| Assumption-carrying structures | none (`HasZeroSumSubseq` is a genuine Prop def) |
| Status/badge | `verified` / `original` — defensible |

**Substance verified:** `davenport_constant_cyclic` proves `IsLeast {m | ∀ f : Fin m → ZMod n, HasZeroSumSubseq f} n` — i.e. D(ℤ/nℤ)=n. Upper bound via prefix-sum pigeonhole (`Fintype.exists_ne_map_eq_of_card_lt`); lower bound via the constant-1 sequence having no zero-sum subsequence for length < n. Theorem statements match the entry title; non-vacuous.

This entry was absent from `audit-tracker.json` (perpetual 'never-audited' loop). PR adds the clean mark to persist it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)