### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01): both Fourier parent axioms discharged — all 5 now 0-axiom

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01Fourier.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01Fourier.lean
@@ -1,0 +1,173 @@
+/-
+  The two Fourier-analytic axioms of the Hurwitz isoperimetric proof,
+  discharged 0-axiom: `fourier_decomp_exists` and `wirtinger_sum_bound`.
+
+  Open Question: area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01
+
+  ## Context
+
+  The parent entry `AreaOfCircleOQ01OQ02OQ02OQ01.lean`
+  (`namespace IsoperimetricFromFourier`) proves the isoperimetric inequality
+  `C² ≥ 4πA` from five disclosed axioms.  Prior sessions discharged
+
+  * `exists_nice_reparam`      — inverse function theorem (`…OQ01OQ01IFT.lean`);
+  * `area_cauchy_schwarz_bound`— Green's theorem + 2D Cauchy–Schwarz (`…CauchySchwarz.lean`);
+  * `integral_cauchy_schwarz_sq`— L² Cauchy–Schwarz (`…CauchySchwarz.lean`).
+
+  The two *remaining* parent axioms are the genuinely Fourier-analytic ones:
+
+  * `fourier_decomp_exists` — every `2π`-periodic `C¹` function admits a real
+        Fourier decomposition satisfying Parseval for `f` and `f'`;
+  * `wirtinger_sum_bound`   — for a zero-mean constant-speed curve,
+        `∫₀²π (x²+y²) ≤ 2π c²`.
+
+  **This file discharges both, 0-axiom.**  The heavy analytic content (Parseval
+  via `tsum_sq_fourierCoeff` on `AddCircle (2π)`, integration by parts for the
+  derivative coefficients) is already a fully proved, axiom-free theorem,
+  `IsoperimetricOQ.fourier_decomposition`, in the sibling file
+  `AreaOfCircleOQ01OQ03.lean`.  We import it and:
+
+  1. package its existential output into the parent's `FourierDecomp` structure
+     (→ `fourier_decomp_exists`);
+  2. reprove Wirtinger's inequality for a single coordinate from that
+     decomposition (`c₀ = 0` from zero mean, `n² ≥ 1` for `n ≠ 0`);
+  3. apply Wirtinger to the two coordinates and integrate the constant-speed
+     identity `x'² + y'² = c²` to obtain `wirtinger_sum_bound`.
+
+  With this file the five analytic axioms of the parent isoperimetric proof are
+  now *all* discharged as standalone 0-axiom theorems.
+
+  ## Why this does not by itself remove the parent axioms
+
+  As with the Cauchy–Schwarz discharge, `wirtinger_sum_bound` here is stated for
+  raw `C¹` periodic coordinate functions rather than the parent's
+  `SmoothClosedCurve` structure, so wiring it into the parent (to drop its
+  `axiomCount`) is a separate, sensitive parent edit.  Mathematically both
+  Fourier axioms are now fully proved.
+
+  ## Sorries: 0   Axioms: 0
+-/
+import Mathlib
+import Proofs.AreaOfCircleOQ01OQ03
+
+open Real MeasureTheory intervalIntegral
+
+namespace IsoperimetricFourier
+
+/-- A Fourier decomposition of a `2π`-periodic `C¹` function `f` into real
+    coefficients `cₙ` satisfying Parseval's identity for both `f` and `f'`.
+    (Identical to the parent's `IsoperimetricFromFourier.FourierDecomp`.) -/
+structure FourierDecomp (f : ℝ → ℝ) where
+  /-- Real Fourier coefficients -/
+  c : ℤ → ℝ
+  /-- The coefficients are square-summable -/
+  summable_sq : Summable (fun n : ℤ => c n ^ 2)
+  /-- The weighted coefficients `n²cₙ²` are summable -/
+  summable_n2_sq : Summable (fun n : ℤ => (↑n : ℝ) ^ 2 * c n ^ 2)
+  /-- Parseval for `f`: `∫f² = Σcₙ²` -/
+  parseval_f : ∫ t in (0 : ℝ)..(2 * π), f t ^ 2 = ∑' n : ℤ, c n ^ 2
+  /-- Parseval for `f'` (via IBP): `∫(f')² = Σn²cₙ²` -/
+  parseval_df : ∫ t in (0 : ℝ)..(2 * π), deriv f t ^ 2 = ∑' n : ℤ, (↑n : ℝ) ^ 2 * c n ^ 2
+  /-- The zeroth coefficient captures the mean -/
+  c_zero : c 0 = (1 / Real.sqrt (2 * π)) * ∫ t in (0 : ℝ)..(2 * π), f t
+
+/-- **Discharges the parent axiom `fourier_decomp_exists`.**
+    Every `2π`-periodic `C¹` function admits a Fourier decomposition.  The data
+    is provided verbatim by `IsoperimetricOQ.fourier_decomposition`; we only
+    repackage the existential into the structure. -/
+theorem fourier_decomp_exists (f : ℝ → ℝ) (hf : ContDiff ℝ 1 f)
+    (hperiod : ∀ t, f (t + 2 * π) = f t) :
+    Nonempty (FourierDecomp f) := by
+  obtain ⟨c, hsum, hsum', hf_sq, hdf_sq, hc0⟩ :=
+    IsoperimetricOQ.fourier_decomposition f hf hperiod
+  exact ⟨{ c := c
+           summable_sq := hsum
+           summable_n2_sq := hsum'
+           parseval_f := hf_sq
+           parseval_df := hdf_sq
+           c_zero := hc0 }⟩
+
+/-- **Wirtinger's inequality**: for a mean-zero `2π`-periodic `C¹` function,
+    `∫₀²π f² ≤ ∫₀²π (f')²`.
+
+    Proof: from the Fourier decomposition, `c₀ = 0` (mean zero), and for `n ≠ 0`,
+    `n² ≥ 1` gives `n²cₙ² ≥ cₙ²`; summing via Parseval yields the claim. -/
+theorem wirtinger_inequality (f : ℝ → ℝ) (hf : ContDiff ℝ 1 f)
+    (hperiod : ∀ t, f (t + 2 * π) = f t)
+    (hmean : ∫ t in (0 : ℝ)..(2 * π), f t = 0) :
+    ∫ t in (0 : ℝ)..(2 * π), f t ^ 2 ≤
+    ∫ t in (0 : ℝ)..(2 * π), deriv f t ^ 2 := by
+  obtain ⟨c, hsum, hsum', hf_sq, hdf_sq, hc0⟩ :=
+    IsoperimetricOQ.fourier_decomposition f hf hperiod
+  -- c₀ = 0 from zero mean
+  have hc0' : c 0 = 0 := by rw [hc0, hmean, mul_zero]
+  -- Pointwise bound n²cₙ² ≥ cₙ² for all n
+  have h_pw : ∀ n : ℤ, c n ^ 2 ≤ (↑n : ℝ) ^ 2 * c n ^ 2 := by
+    intro n
+    by_cases hn : n = 0
+    · subst hn; rw [hc0']; simp
+    · have habs : (1 : ℝ) ≤ |(↑n : ℝ)| := by exact_mod_cast Int.one_le_abs hn
+      have h1 : (1 : ℝ) ≤ (↑n : ℝ) ^ 2 := by nlinarith [sq_abs (↑n : ℝ)]
+      calc c n ^ 2 = 1 * c n ^ 2 := (one_mul _).symm
+        _ ≤ (↑n : ℝ) ^ 2 * c n ^ 2 :=
+          mul_le_mul_of_nonneg_right h1 (sq_nonneg _)
+  -- Sum the pointwise bounds via Parseval
+  rw [hf_sq, hdf_sq]
+  exact hasSum_le h_pw hsum.hasSum hsum'.hasSum
+
+/-- **Discharges the parent axiom `wirtinger_sum_bound`.**
+    For a zero-mean constant-speed `C¹` closed curve `(x, y)` with speed `c`,
+    `∫₀²π (x² + y²) ≤ 2π c²`.
+
+    Proof: apply Wirtinger to `x` and `y` separately, then integrate the
+    constant-speed identity `x'² + y'² = c²` over `[0, 2π]`. -/
+theorem wirtinger_sum_bound (x y : ℝ → ℝ)
+    (hx : ContDiff ℝ 1 x) (hy : ContDiff ℝ 1 y)
+    (hpx : ∀ t, x (t + 2 * π) = x t) (hpy : ∀ t, y (t + 2 * π) = y t)
+    (c : ℝ) (hc : 0 < c)
+    (hspeed : ∀ t, deriv x t ^ 2 + deriv y t ^ 2 = c ^ 2)
+    (hzx : ∫ t in (0 : ℝ)..(2 * π), x t = 0)
+    (hzy : ∫ t in (0 : ℝ)..(2 * π), y t = 0) :
+    ∫ t in (0 : ℝ)..(2 * π), (x t ^ 2 + y t ^ 2) ≤ 2 * π * c ^ 2 := by
+  -- Wirtinger on each coordinate
+  have hWx := wirtinger_inequality x hx hpx hzx
+  have hWy := wirtinger_inequality y hy hpy hzy
+  -- Continuity of coordinates and their derivatives
+  have hcx : Continuous x := hx.continuous
+  have hcy : Continuous y := hy.continuous
+  have hcdx : Continuous (deriv x) := hx.continuous_deriv le_rfl
+  have hcdy : Continuous (deriv y) := hy.continuous_deriv le_rfl
+  -- Interval integrability of the four squares
+  have ix2 : IntervalIntegrable (fun t => x t ^ 2) volume 0 (2 * π) :=
+    (hcx.pow 2).intervalIntegrable _ _
+  have iy2 : IntervalIntegrable (fun t => y t ^ 2) volume 0 (2 * π) :=
+    (hcy.pow 2).intervalIntegrable _ _
+  have idx2 : IntervalIntegrable (fun t => deriv x t ^ 2) volume 0 (2 * π) :=
+    (hcdx.pow 2).intervalIntegrable _ _
+  have idy2 : IntervalIntegrable (fun t => deriv y t ^ 2) volume 0 (2 * π) :=
+    (hcdy.pow 2).intervalIntegrable _ _
+  -- Split the left-hand integral
+  have hsplitL : (∫ t in (0 : ℝ)..(2 * π), (x t ^ 2 + y t ^ 2))
+      = (∫ t in (0 : ℝ)..(2 * π), x t ^ 2) + ∫ t in (0 : ℝ)..(2 * π), y t ^ 2 :=
+    intervalIntegral.integral_add ix2 iy2
+  -- Combine the derivative integrals
+  have hcombine : (∫ t in (0 : ℝ)..(2 * π), deriv x t ^ 2)
+        + (∫ t in (0 : ℝ)..(2 * π), deriv y t ^ 2)
+      = ∫ t in (0 : ℝ)..(2 * π), (deriv x t ^ 2 + deriv y t ^ 2) :=
+    (intervalIntegral.integral_add idx2 idy2).symm
+  -- Integrate the constant-speed identity: ∫ (x'² + y'²) = ∫ c² = 2π c²
+  have heqon : Set.EqOn (fun t => deriv x t ^ 2 + deriv y t ^ 2)
+      (fun _ => c ^ 2) (Set.uIcc 0 (2 * π)) := fun t _ => hspeed t
+  have hspeed_int : (∫ t in (0 : ℝ)..(2 * π), (deriv x t ^ 2 + deriv y t ^ 2))
+      = 2 * π * c ^ 2 := by
+    rw [intervalIntegral.integral_congr heqon, intervalIntegral.integral_const]
+    simp only [sub_zero, smul_eq_mul]
+  -- Chain the bounds
+  rw [hsplitL]
+  calc (∫ t in (0 : ℝ)..(2 * π), x t ^ 2) + ∫ t in (0 : ℝ)..(2 * π), y t ^ 2
+      ≤ (∫ t in (0 : ℝ)..(2 * π), deriv x t ^ 2)
+          + ∫ t in (0 : ℝ)..(2 * π), deriv y t ^ 2 := add_le_add hWx hWy
+    _ = ∫ t in (0 : ℝ)..(2 * π), (deriv x t ^ 2 + deriv y t ^ 2) := hcombine
+    _ = 2 * π * c ^ 2 := hspeed_int
+
+end IsoperimetricFourier

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md
@@ -349,3 +349,67 @@ Cauchy–Schwarz axioms of the parent `IsoperimetricFromFourier` proof:
 sensitive parent edit that would drop `axiomCount` 5→4→…→2). Mathematically the two
 Cauchy–Schwarz axioms are now fully discharged 0-axiom; only the two genuinely Fourier-analytic
 axioms (`fourier_decomp_exists`, `wirtinger_sum_bound`) remain.
+
+### Session 2026-06-21 (s07, ACT, researcher-9) — both Fourier-analytic parent axioms discharged 0-axiom; ALL FIVE now proved
+
+**Outcome: ACT — the two remaining analytic parent axioms are now proved, completing the set.**
+New file `proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01Fourier.lean`
+(`namespace IsoperimetricFourier`, imports `Mathlib` + sibling `Proofs.AreaOfCircleOQ01OQ03`;
+**0 axioms, 0 sorries, 3 theorems + 1 structure, docker GREEN 7745 jobs on v4.26.0**). This
+discharges the parent `IsoperimetricFromFourier` axioms `fourier_decomp_exists` and
+`wirtinger_sum_bound`.
+
+**Key realization the prior (s06) next-action analysis missed.** s06 declared
+`fourier_decomp_exists` "the real analytic core (Parseval + IBP) … the hard remaining target"
+and concluded `wirtinger_sum_bound` was "genuinely downstream of the Fourier axiom." But the
+hard analytic content was **already a fully proved, 0-axiom theorem** sitting in the sibling
+gallery file `AreaOfCircleOQ01OQ03.lean`:
+
+```
+theorem IsoperimetricOQ.fourier_decomposition (f : ℝ → ℝ) (hf : ContDiff ℝ 1 f)
+    (hperiod : ∀ t, f (t + 2*π) = f t) :
+    ∃ c : ℤ → ℝ, Summable (c ·^2) ∧ Summable (fun n => (n:ℝ)^2 * c n^2) ∧
+      (∫ t in 0..2π, f t^2 = ∑' n, c n^2) ∧
+      (∫ t in 0..2π, deriv f t^2 = ∑' n, (n:ℝ)^2 * c n^2) ∧
+      (c 0 = (1/√(2π)) * ∫ t in 0..2π, f t)
+```
+
+proved there via `tsum_sq_fourierCoeff` (Parseval on `AddCircle (2π)`, lifting `f` through
+`AddCircle.liftIoc`) and `fourierCoeffOn_deriv_periodic` (IBP: `ĉₙ(f') = i·n·ĉₙ(f)`). That file
+**builds clean on v4.26.0** (verified this session: `docker-build.sh Proofs.AreaOfCircleOQ01OQ03`
+→ 7744 jobs, 0 errors; it imports only the grandparent `OQ01OQ02OQ02`, *not* the bit-rotted
+parent `OQ01OQ02OQ02OQ01` from #27276). So the discharge needed **no Parseval reproof** — only:
+
+* **`fourier_decomp_exists`** — define a local `FourierDecomp` structure (copy of the parent's),
+  `obtain` the existential from `IsoperimetricOQ.fourier_decomposition`, and repackage the six
+  components as the structure fields → `Nonempty (FourierDecomp f)`. ~6 lines.
+
+* **`wirtinger_inequality`** (single coordinate, reproved standalone) — from the decomposition,
+  `c₀ = 0` (zero mean ⇒ `c_zero` term vanishes), pointwise `cₙ² ≤ n²cₙ²` (`n²≥1` for `n≠0`,
+  trivial at `n=0` via `c₀=0`), then `rw [parseval_f, parseval_df]` and close with
+  `hasSum_le h_pw hsum.hasSum hsum'.hasSum`.
+
+* **`wirtinger_sum_bound`** (parent axiom shape, raw `C¹` periodic `x,y`) —
+  `∫₀²π (x²+y²) ≤ 2π c²` for zero-mean constant-speed `x'²+y'²=c²`. Apply `wirtinger_inequality`
+  to `x` and `y`; split `∫(x²+y²)=∫x²+∫y²` and recombine `∫(x'²+y'²)=∫x'²+∫y'²` via
+  `intervalIntegral.integral_add` on the four `Continuous.pow … |>.intervalIntegrable` squares;
+  then `∫(x'²+y'²) = ∫c² = 2π·c²` by `intervalIntegral.integral_congr` (the `EqOn` from
+  `hspeed`) + `intervalIntegral.integral_const` (`(2π−0)•c² = 2π·c²`, `simp [sub_zero, smul_eq_mul]`).
+  `add_le_add` chains the three steps.
+
+**Mathlib v4.26.0 notes / gotchas:**
+- `IsoperimetricOQ.fourier_decomposition` lives inside `namespace IsoperimetricOQ` (the inner
+  `AristotleLemmas` sub-namespace ends before it) — reference it fully qualified.
+- `Continuous.pow hf 2` then `.intervalIntegrable _ _` gives the interval-integrability of a
+  squared continuous function on `[0,2π]`; do *not* hand-roll `MeasureTheory` integrability.
+- `intervalIntegral.integral_const` returns `(b−a) • c`, an `smul`; close with
+  `simp only [sub_zero, smul_eq_mul]`, not `ring` (which won't touch `•`).
+- The `(hc : 0 < c)` hypothesis is unused in `wirtinger_sum_bound` (kept verbatim to match the
+  parent axiom signature) → one harmless `unusedVariables` linter warning.
+
+**Honest scope.** As with s06, these are stated for raw `C¹` periodic functions, not the
+parent's `SmoothClosedCurve`, so they are not yet *wired into* the parent. Mathematically **all
+five** analytic axioms of the Hurwitz isoperimetric proof are now discharged 0-axiom (s05
+reparam-on-regular, s06 ×2 Cauchy–Schwarz, s07 ×2 Fourier). A fully axiom-free parent file is a
+separate mechanic task: bridge raw-function ↔ `SmoothClosedCurve`, add a regularity field for
+`exists_nice_reparam` (Gap-1), and un-rot the parent (#27276).

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md
@@ -2,55 +2,71 @@
 
 ## Current State
 **Phase**: ACT
-**Status**: PROGRESS — reparam axiom (regular locus) + BOTH Cauchy–Schwarz axioms now discharged 0-axiom; only the two Fourier-analytic axioms remain
+**Status**: PROGRESS — ALL FIVE parent analytic axioms now discharged 0-axiom (reparam-on-regular, both Cauchy–Schwarz, and now both Fourier-analytic)
 **Path**: full
 **Since**: 2026-06-13
-**Iteration**: 6
+**Iteration**: 7
 
 ## Current Focus
-s06 (2026-06-21, researcher-9) shipped `AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz.lean`
-(`namespace IsoperimetricCauchySchwarz`, imports `Mathlib` only, 0-axiom, docker-GREEN, 4 thm,
-`#print axioms` = propext/Classical.choice/Quot.sound): discharges **both** Cauchy–Schwarz
-parent axioms — `integral_cauchy_schwarz_sq` ((∫√(x²+y²))² ≤ 2π·∫(x²+y²), via the discriminant
-of the nonnegative quadratic `λ ↦ ∫(√(x²+y²)−λ)²`) and `area_cauchy_schwarz_bound`
-(|∫(x·dy−y·dx)| ≤ c·∫√(x²+y²) under constant speed, plus a `…_contDiff` corollary matching the
-axiom signature). After s05+s06, 3 of the parent's 5 axioms (reparam-on-regular, integral-CS,
-area-CS) are proved 0-axiom; only `fourier_decomp_exists` and `wirtinger_sum_bound` remain.
-See knowledge.md s06 for the proof and v4.26.0 gotchas.
+s07 (2026-06-21, researcher-9) shipped `AreaOfCircleOQ01OQ02OQ02OQ01OQ01Fourier.lean`
+(`namespace IsoperimetricFourier`, imports `Mathlib` + sibling `Proofs.AreaOfCircleOQ01OQ03`,
+0-axiom, docker-GREEN 7745 jobs, 3 thm/1 struct): discharges the **two remaining Fourier
+axioms** —
+- `fourier_decomp_exists`: every `2π`-periodic `C¹` `f` admits a real Fourier decomposition
+  with Parseval for `f` and `f'`.  **Key realization the prior session missed**: the entire
+  analytic core is *already* a proved, 0-axiom theorem `IsoperimetricOQ.fourier_decomposition`
+  in the sibling `AreaOfCircleOQ01OQ03.lean` (Parseval via `tsum_sq_fourierCoeff` on
+  `AddCircle (2π)` + IBP `fourierCoeffOn_deriv_periodic`).  We import it and repackage its
+  existential into the parent's `FourierDecomp` structure — no Parseval reproof needed.
+- `wirtinger_sum_bound`: `∫₀²π (x²+y²) ≤ 2π c²` for a zero-mean constant-speed curve.  Reprove
+  `wirtinger_inequality` for one coordinate from the decomposition (`c₀=0` from zero mean,
+  `n²≥1` for `n≠0`, `hasSum_le`), apply to `x` and `y`, then split/recombine the integrals and
+  integrate the constant-speed identity `x'²+y'²=c²` (`integral_congr` + `integral_const`).
+
+With s05+s06+s07, **all 5 of the parent's analytic axioms are now proved 0-axiom**: reparam
+(regular locus), integral-CS, area-CS, fourier-decomp, wirtinger-sum.
 
 ## Prior Focus
+s06 (2026-06-21, researcher-9) shipped `AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz.lean`
+(`namespace IsoperimetricCauchySchwarz`, imports `Mathlib` only, 0-axiom, docker-GREEN, 4 thm):
+discharges **both** Cauchy–Schwarz parent axioms — `integral_cauchy_schwarz_sq`
+((∫√(x²+y²))² ≤ 2π·∫(x²+y²), via the discriminant of `λ ↦ ∫(√(x²+y²)−λ)²`) and
+`area_cauchy_schwarz_bound` (|∫(x·dy−y·dx)| ≤ c·∫√(x²+y²) under constant speed).
+
+## Earlier Focus
 s05 (2026-06-21, researcher-9) shipped `AreaOfCircleOQ01OQ02OQ02OQ01OQ01IFT.lean`
 (`namespace RegularCurveArcLength`, imports Mathlib + the s04 `…Reparam` companion, 0-axiom,
-docker-GREEN, 35 thm/3 def, `#print axioms`=propext/Classical.choice/Quot.sound only): the
-**IFT-inverse + change-of-variables middle** re-derived on Mathlib v4.26.0, composed with the
-s04 ends (`centered`) to give **`exists_nice_reparam_for_regular`** — the parent axiom's exact
-conclusion (same circumference & area, constant speed `(L/2π)²`, zero mean) discharged on the
-Gap-1 regular locus. This closes the mathematical core of the open question on the locus where
-the IFT route is valid. See knowledge.md s05 for the construction and pinned v4.26.0 gotchas.
+docker-GREEN, 35 thm/3 def): the **IFT-inverse + change-of-variables middle** re-derived on
+Mathlib v4.26.0, composed with the s04 ends (`centered`) to give
+**`exists_nice_reparam_for_regular`** — the parent axiom's exact conclusion (same circumference
+& area, constant speed `(L/2π)²`, zero mean) discharged on the Gap-1 regular locus.
 
 ## Active Approach
-Done for the regular-curve target. The arc-length map `s` is bijective (IVT surjectivity +
-StrictMono injectivity), `σ=s⁻¹` is `C¹` by the IFT, `τ=σ(c·)` gives a constant-speed reparam
-built directly as a `RegularClosedCurve`, circumference preserved trivially, area preserved by
-`integral_comp_mul_deriv'` + periodic shift, then `centered` adds zero mean.
+Done. The arc-length map `s` is bijective (IVT + StrictMono), `σ=s⁻¹` is `C¹` by the IFT,
+`τ=σ(c·)` gives constant-speed reparam; Cauchy–Schwarz axioms via discriminant/pointwise 2D CS;
+Fourier axioms via the sibling's proved Parseval theorem + Wirtinger on each coordinate.
 
 ## Attempt Count
-- Total attempts: 2 (s04 ends; s05 middle+assembly — both docker-verified GREEN)
-- Approaches tried: 3 (import sibling [blocked by bit-rot]; self-contained ends [s04]; self-
-  contained middle+assembly on `RegularClosedCurve` [s05, succeeded])
+- Total attempts: 3 (s04 ends; s05 middle+assembly; s07 Fourier — all docker-verified GREEN)
+- Approaches tried: 4 (import sibling [s05: blocked by bit-rot]; self-contained ends [s04];
+  self-contained middle+assembly on `RegularClosedCurve` [s05]; import sibling's *proved*
+  Parseval theorem for the Fourier axioms [s07, succeeded])
 
 ## Blockers
-- None for the regular-curve target. The remaining work is optional/sensitive (parent edit to
-  drop `axiomCount` 5→4) or separate (four other parent axioms; mechanic repair of the two
-  bit-rotted entries).
+- None. All five parent analytic axioms are now discharged 0-axiom across s05/s06/s07. The
+  remaining work is optional/sensitive (parent edit to drop `axiomCount` 5→0) or separate
+  (mechanic repair of the two bit-rotted entries flagged in #27276).
 
 ## Next Action
-3/5 axioms now proved 0-axiom (reparam-on-regular, integral-CS, area-CS). Next:
-(1) **`wirtinger_sum_bound`** — apply the already-PROVED `wirtinger_inequality` (parent thm) to
-each coordinate and add: `∫(x²+y²) = ∫x²+∫y² ≤ ∫x'²+∫y'² = ∫(speed²) = 2π·c²`. The only gap is
-the `FourierDecomp` existence the parent `wirtinger_inequality` requires — i.e. it still leans
-on `fourier_decomp_exists`. So Wirtinger is genuinely downstream of the Fourier axiom.
-(2) **`fourier_decomp_exists`** — the real analytic core (Parseval + IBP for periodic C¹
-functions); the hard remaining target.
-(3) optional sensitive parent edit wiring s05/s06 theorems into the parent to drop `axiomCount`.
-(4) mechanic: repair bit-rotted sibling/parent (renames pinned in knowledge.md s05).
+5/5 axioms now proved 0-axiom (reparam-on-regular, integral-CS, area-CS, fourier-decomp,
+wirtinger-sum). Remaining options:
+(1) optional sensitive parent edit: replace the five `axiom` declarations in
+`AreaOfCircleOQ01OQ02OQ02OQ01.lean` with `theorem`s pointing at the standalone discharges
+(s05 IFT for regular curves, s06 CauchySchwarz, s07 Fourier), dropping the parent `axiomCount`
+to 0. This requires bridging the raw-function discharges to the `SmoothClosedCurve` structure
+and re-verifying the parent builds (currently bit-rotted on v4.26.0, #27276) — a mechanic task.
+Note `exists_nice_reparam` only holds on the **regular** locus, so a fully axiom-free parent
+needs the structure to carry a regularity field (Gap-1).
+(2) mechanic: repair the bit-rotted sibling/parent (renames pinned in knowledge.md s05).
+(3) the open question's stated target (`exists_nice_reparam` from the IFT) is mathematically
+complete on the regular locus; consider closing/graduating.


### PR DESCRIPTION
## Summary

Discharges the **two remaining analytic axioms** of the parent Hurwitz isoperimetric proof (`AreaOfCircleOQ01OQ02OQ02OQ01.lean`, `namespace IsoperimetricFromFourier`), completing the set: **all five of the parent's analytic axioms are now proved 0-axiom** as standalone theorems (s05 IFT reparam on the regular locus, s06 ×2 Cauchy–Schwarz, s07 ×2 Fourier here).

New file `proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01Fourier.lean` (`namespace IsoperimetricFourier`, imports `Mathlib` + sibling `Proofs.AreaOfCircleOQ01OQ03`): **0 axioms, 0 sorries, 3 theorems + 1 structure, docker GREEN (7745 jobs) on Mathlib v4.26.0**.

### Results

- **`fourier_decomp_exists`** — every `2π`-periodic `C¹` `f` admits a real Fourier decomposition with Parseval for `f` and `f'`. The heavy analytic content (Parseval via `tsum_sq_fourierCoeff` on `AddCircle (2π)`, IBP for the derivative coefficients) is *already* a proved 0-axiom theorem `IsoperimetricOQ.fourier_decomposition` in the sibling `AreaOfCircleOQ01OQ03.lean` (which builds clean on v4.26.0 — verified this session). We import it and repackage its existential into the `FourierDecomp` structure; **no Parseval reproof needed**.
- **`wirtinger_sum_bound`** — `∫₀²π (x²+y²) ≤ 2π c²` for a zero-mean constant-speed curve. Reprove Wirtinger's inequality for one coordinate from the decomposition (`c₀=0` from zero mean, `n²≥1` for `n≠0`, `hasSum_le`), apply to `x` and `y`, then integrate the constant-speed identity `x'²+y'²=c²`.

### Key insight

The prior session (s06) flagged `fourier_decomp_exists` as "the hard remaining target (Parseval + IBP)" and `wirtinger_sum_bound` as downstream of it. The realization here: the Parseval/IBP core was already proved 0-axiom in the sibling gallery file — the discharge is an import + repackage, not a reproof.

### Scope / honesty

As with the s06 Cauchy–Schwarz discharge, these theorems are stated for raw `C¹` periodic coordinate functions, not the parent's `SmoothClosedCurve` structure, so they are **not yet wired into the parent** (that is a separate, sensitive parent edit that would drop the parent `axiomCount` 5→0, and also needs a regularity field for `exists_nice_reparam` + un-rotting the parent per #27276). Mathematically all five analytic axioms are now fully discharged 0-axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)