### PR TITLE
research(erdos-131-oq-01-oq-01-oq-01-oq-04): rank-2 Davenport lower bound D(ℤ/aℤ⊕ℤ/bℤ)≥a+b−1 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos131DavenportRank2.lean
+++ b/proofs/Proofs/Erdos131DavenportRank2.lean
@@ -1,0 +1,180 @@
+/-
+  Erdős Problem #131 — Non-Dividing Sets
+  Follow-up (oq-01-oq-01-oq-01-oq-04): the rank-2 Davenport LOWER bound
+
+      D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1.
+
+  Source: https://erdosproblems.com/131
+  Companion to: `Proofs.Erdos131DavenportConstant` (the EXACT cyclic Davenport
+  constant `D(ℤ/nℤ) = n`, proved as an `IsLeast` statement in the genuine
+  sequence setting over `ZMod n`).
+
+  NOTE.  This file is deliberately SELF-CONTAINED (only `import Mathlib`); it does
+  not import the companions, which keeps it independently verifiable and axiom-free.
+
+  ## Why this is the interesting regime
+
+  For CYCLIC groups the Davenport constant is elementary: `D(ℤ/nℤ) = n` (companion
+  file).  The non-trivial theory of the Davenport constant lives in higher RANK.
+  The famous result of Olson is
+
+      D(ℤ/aℤ ⊕ ℤ/bℤ) = a + b − 1            (for a ∣ b),
+
+  whose *upper* bound is a substantial combinatorial theorem (NOT in Mathlib).  The
+  matching **lower** bound, however, is completely elementary and unconditional, and
+  is what we formalize here.
+
+  ## What this file adds
+
+  * `HasZeroSumSubseq` / `DavenportSet` — the same sequence-level definitions as the
+    cyclic companion, but for an arbitrary additive group `G`.
+  * `davenport_set_mono` — the Davenport set is upward closed: if every length-`m`
+    sequence has a nonempty zero-sum subsequence, so does every longer one
+    (restrict to a prefix via `Fin.castLE`, then re-embed the witness subset).
+  * `witness` — the standard extremal sequence: `e₁ = (1,0)` repeated `a−1` times
+    followed by `e₂ = (0,1)` repeated `b−1` times, of length `(a−1)+(b−1) = a+b−2`.
+  * `davenport_rank2_witness` — that sequence has NO nonempty zero-sum subsequence.
+    Reason: a nonempty subset `s` sums to `(k₁, k₂)` with `k₁ = |s ∩ block₁|` (mod a)
+    and `k₂ = |s ∩ block₂|` (mod b); zero forces `a ∣ k₁` with `0 ≤ k₁ ≤ a−1` and
+    `b ∣ k₂` with `0 ≤ k₂ ≤ b−1`, hence `k₁ = k₂ = 0`, i.e. `s` is empty.
+  * `davenport_rank2_lower` — therefore `a + b − 2 ∉ DavenportSet`, and by upward
+    closure the least Davenport length `d` satisfies `a + b − 1 ≤ d`.
+  * `davenport_rank2_diag_lower` — the diagonal special case
+    `D(ℤ/nℤ ⊕ ℤ/nℤ) ≥ 2n − 1` (sharp, by Olson; the upper half is not formalized).
+
+  All results are unconditional and axiom-free.
+-/
+
+import Mathlib
+
+namespace Erdos131DavenportRank2
+
+open Finset
+
+/-- A sequence `f : Fin m → G` *has a nonempty zero-sum subsequence* if some nonempty
+index set `s` has `∑ i ∈ s, f i = 0`. -/
+def HasZeroSumSubseq {G : Type*} [AddCommMonoid G] {m : ℕ} (f : Fin m → G) : Prop :=
+  ∃ s : Finset (Fin m), s.Nonempty ∧ ∑ i ∈ s, f i = 0
+
+/-- The **Davenport set** of `G`: the set of lengths `m` such that *every* length-`m`
+sequence over `G` has a nonempty zero-sum subsequence.  The Davenport constant `D(G)`
+is the least element of this set. -/
+def DavenportSet (G : Type*) [AddCommMonoid G] : Set ℕ :=
+  {m | ∀ f : Fin m → G, HasZeroSumSubseq f}
+
+/-- **The Davenport set is upward closed.**  If every length-`m` sequence has a nonempty
+zero-sum subsequence, then so does every length-`m'` sequence for `m ≤ m'`.
+
+Proof: restrict `f : Fin m' → G` to its first `m` entries via `Fin.castLE`, obtain a
+zero-sum subset `s : Finset (Fin m)`, and re-embed it into `Fin m'` with the order
+embedding `Fin.castLEEmb`; `Finset.sum_map` keeps the sum unchanged. -/
+theorem davenport_set_mono {G : Type*} [AddCommMonoid G] {m m' : ℕ} (h : m ≤ m')
+    (hm : m ∈ DavenportSet G) : m' ∈ DavenportSet G := by
+  intro f
+  obtain ⟨s, hne, hsum⟩ := hm (fun i => f (Fin.castLE h i))
+  refine ⟨s.map (Fin.castLEEmb h), Finset.map_nonempty.mpr hne, ?_⟩
+  rw [Finset.sum_map]
+  simpa [Fin.coe_castLEEmb] using hsum
+
+/-- The **rank-2 extremal sequence**: `e₁ = (1,0)` repeated `a−1` times, then
+`e₂ = (0,1)` repeated `b−1` times.  Length `(a−1)+(b−1) = a+b−2`. -/
+def witness (a b : ℕ) : Fin (a - 1 + (b - 1)) → ZMod a × ZMod b :=
+  fun i => if (i : ℕ) < a - 1 then (1, 0) else (0, 1)
+
+/-- **No nonempty zero-sum subsequence of the rank-2 witness.**
+
+For `a, b ≥ 1`, the sequence `witness a b` over `ℤ/aℤ ⊕ ℤ/bℤ` has no nonempty
+zero-sum subsequence.  A nonempty `s` splits as `s₁ = s ∩ block₁`, `s₂ = s ∩ block₂`;
+the two coordinates of `∑_{i∈s} witness a b i` are `(|s₁| : ZMod a)` and
+`(|s₂| : ZMod b)`.  Vanishing forces `a ∣ |s₁|` with `|s₁| ≤ a−1` and `b ∣ |s₂|` with
+`|s₂| ≤ b−1`, so `|s₁| = |s₂| = 0` and `s = ∅`. -/
+theorem davenport_rank2_witness {a b : ℕ} (ha : 1 ≤ a) (hb : 1 ≤ b) :
+    ¬ HasZeroSumSubseq (witness a b) := by
+  rintro ⟨s, hne, hsum⟩
+  -- Coordinatewise description of each term.
+  have hfst : ∀ i, (witness a b i).1 = if (i : ℕ) < a - 1 then (1 : ZMod a) else 0 := by
+    intro i; unfold witness; by_cases h : (i : ℕ) < a - 1 <;> simp [h]
+  have hsnd : ∀ i, (witness a b i).2 = if ¬ ((i : ℕ) < a - 1) then (1 : ZMod b) else 0 := by
+    intro i; unfold witness; by_cases h : (i : ℕ) < a - 1 <;> simp [h]
+  -- The two coordinates of the (zero) total are the two block-cardinalities, mod a / mod b.
+  have hz1 : (∑ i ∈ s, witness a b i).1 = 0 := by rw [hsum]; rfl
+  have hz2 : (∑ i ∈ s, witness a b i).2 = 0 := by rw [hsum]; rfl
+  have h1 : ((s.filter (fun i : Fin (a - 1 + (b - 1)) => (i : ℕ) < a - 1)).card : ZMod a) = 0 := by
+    rw [Prod.fst_sum] at hz1
+    simp only [hfst] at hz1
+    rwa [Finset.sum_boole] at hz1
+  have h2 : ((s.filter (fun i : Fin (a - 1 + (b - 1)) => ¬ ((i : ℕ) < a - 1))).card : ZMod b) = 0 := by
+    rw [Prod.snd_sum] at hz2
+    simp only [hsnd] at hz2
+    rwa [Finset.sum_boole] at hz2
+  -- Each block-cardinality is bounded by the block size, so divisibility forces it to 0.
+  have hb1 : (s.filter (fun i : Fin (a - 1 + (b - 1)) => (i : ℕ) < a - 1)).card ≤ a - 1 := by
+    have key : (s.filter (fun i : Fin (a - 1 + (b - 1)) => (i : ℕ) < a - 1)).card
+        ≤ (Finset.range (a - 1)).card := by
+      apply Finset.card_le_card_of_injOn (fun i : Fin (a - 1 + (b - 1)) => (i : ℕ))
+      · intro i hi
+        simp only [Finset.coe_filter, Set.mem_setOf_eq] at hi
+        simp only [Finset.coe_range, Set.mem_Iio]
+        exact hi.2
+      · intro x _ y _ hxy; exact Fin.val_injective hxy
+    simpa using key
+  have hb2 : (s.filter (fun i : Fin (a - 1 + (b - 1)) => ¬ ((i : ℕ) < a - 1))).card ≤ b - 1 := by
+    have key : (s.filter (fun i : Fin (a - 1 + (b - 1)) => ¬ ((i : ℕ) < a - 1))).card
+        ≤ (Finset.range (b - 1)).card := by
+      apply Finset.card_le_card_of_injOn (fun i : Fin (a - 1 + (b - 1)) => (i : ℕ) - (a - 1))
+      · intro i hi
+        simp only [Finset.coe_filter, Set.mem_setOf_eq, not_lt] at hi
+        simp only [Finset.coe_range, Set.mem_Iio]
+        have := i.isLt
+        omega
+      · intro x hx y hy hxy
+        simp only [Finset.coe_filter, Set.mem_setOf_eq, not_lt] at hx hy
+        replace hxy : (↑x : ℕ) - (a - 1) = (↑y : ℕ) - (a - 1) := hxy
+        apply Fin.val_injective
+        omega
+    simpa using key
+  have hc1 : (s.filter (fun i : Fin (a - 1 + (b - 1)) => (i : ℕ) < a - 1)).card = 0 := by
+    rcases Nat.eq_zero_or_pos
+        (s.filter (fun i : Fin (a - 1 + (b - 1)) => (i : ℕ) < a - 1)).card with h0 | hpos
+    · exact h0
+    · exact absurd ((ZMod.natCast_eq_zero_iff _ _).mp h1)
+        (Nat.not_dvd_of_pos_of_lt hpos (by omega))
+  have hc2 : (s.filter (fun i : Fin (a - 1 + (b - 1)) => ¬ ((i : ℕ) < a - 1))).card = 0 := by
+    rcases Nat.eq_zero_or_pos
+        (s.filter (fun i : Fin (a - 1 + (b - 1)) => ¬ ((i : ℕ) < a - 1))).card with h0 | hpos
+    · exact h0
+    · exact absurd ((ZMod.natCast_eq_zero_iff _ _).mp h2)
+        (Nat.not_dvd_of_pos_of_lt hpos (by omega))
+  -- The two blocks partition `s`, so `s` is empty — contradicting nonemptiness.
+  have hsplit : (s.filter (fun i : Fin (a - 1 + (b - 1)) => (i : ℕ) < a - 1)).card
+      + (s.filter (fun i : Fin (a - 1 + (b - 1)) => ¬ ((i : ℕ) < a - 1))).card = s.card :=
+    Finset.filter_card_add_filter_neg_card_eq_card _
+  have hcard0 : s.card = 0 := by omega
+  exact absurd (Finset.card_pos.mpr hne) (by omega)
+
+/-- **Rank-2 Davenport lower bound: `D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1`.**
+
+If `d` is the least Davenport length for `ℤ/aℤ ⊕ ℤ/bℤ`, then `a + b − 1 ≤ d`.  Were
+`d ≤ a + b − 2`, upward closure (`davenport_set_mono`) would put `a + b − 2` in the
+Davenport set, contradicting `davenport_rank2_witness`. -/
+theorem davenport_rank2_lower {a b : ℕ} (ha : 1 ≤ a) (hb : 1 ≤ b)
+    {d : ℕ} (hd : IsLeast (DavenportSet (ZMod a × ZMod b)) d) :
+    a + b - 1 ≤ d := by
+  by_contra hlt
+  push_neg at hlt
+  have hdle : d ≤ a - 1 + (b - 1) := by omega
+  have hmem : (a - 1 + (b - 1)) ∈ DavenportSet (ZMod a × ZMod b) :=
+    davenport_set_mono hdle hd.1
+  exact davenport_rank2_witness ha hb (hmem (witness a b))
+
+/-- **Diagonal special case: `D(ℤ/nℤ ⊕ ℤ/nℤ) ≥ 2n − 1`.**
+
+This bound is sharp — Olson's theorem gives `D(ℤ/nℤ ⊕ ℤ/nℤ) = 2n − 1` — but the
+matching upper bound is a substantial result not formalized here (and not in Mathlib). -/
+theorem davenport_rank2_diag_lower {n : ℕ} (hn : 1 ≤ n)
+    {d : ℕ} (hd : IsLeast (DavenportSet (ZMod n × ZMod n)) d) :
+    2 * n - 1 ≤ d := by
+  have := davenport_rank2_lower hn hn hd
+  omega
+
+end Erdos131DavenportRank2

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04/knowledge.md
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04/knowledge.md
@@ -1,0 +1,79 @@
+# Erdős #131 — Rank-2 Davenport Lower Bound `D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1`
+
+**Slug:** `erdos-131-oq-01-oq-01-oq-01-oq-04`
+**Lean file:** `proofs/Proofs/Erdos131DavenportRank2.lean` (namespace `Erdos131DavenportRank2`)
+**Status:** verified · 0 axioms · 0 sorries · 4 theorems · 3 definitions · 180 lines
+
+## Summary
+
+The **Davenport constant** `D(G)` of a finite abelian group `G` is the least `d` such
+that every length-`d` sequence over `G` has a nonempty zero-sum subsequence. For
+**cyclic** groups it is elementary — `D(ℤ/nℤ) = n` (companion entry
+`erdos-131-oq-01-oq-01-oq-01-oq-03`). The non-trivial theory lives in higher **rank**:
+Olson's theorem states
+
+> `D(ℤ/aℤ ⊕ ℤ/bℤ) = a + b − 1`   (for `a ∣ b`),
+
+whose *upper* bound is a substantial combinatorial theorem (not in Mathlib). This entry
+formalizes the matching **lower** bound — completely elementary and unconditional:
+
+> `davenport_rank2_lower : IsLeast (DavenportSet (ZMod a × ZMod b)) d → a + b − 1 ≤ d`.
+
+## Proof architecture
+
+Two reusable pieces, both stated for the group-agnostic predicate
+`HasZeroSumSubseq f := ∃ s, s.Nonempty ∧ ∑ i ∈ s, f i = 0` and the set
+`DavenportSet G := {m | ∀ f : Fin m → G, HasZeroSumSubseq f}`:
+
+1. **`witness` + `davenport_rank2_witness` (the extremal sequence).**
+   `witness a b : Fin (a−1+(b−1)) → ZMod a × ZMod b` is `e₁ = (1,0)` repeated `a−1`
+   times then `e₂ = (0,1)` repeated `b−1` times (length `a+b−2`). It has no nonempty
+   zero-sum subsequence: for a nonempty index set `s`, the two coordinates of
+   `∑_{i∈s} witness a b i` are `(|s₁| : ZMod a)` and `(|s₂| : ZMod b)` where
+   `s₁ = s ∩ block₁`, `s₂ = s ∩ block₂` (via `Prod.fst_sum`/`Prod.snd_sum` then
+   `Finset.sum_boole`). Vanishing forces `a ∣ |s₁|`, `b ∣ |s₂|`; with `|s₁| ≤ a−1`
+   and `|s₂| ≤ b−1` (each block injects into `Finset.range` by `Fin.val` resp.
+   `Fin.val − (a−1)`), both cardinalities are `0`, so `s = ∅` — contradiction.
+
+2. **`davenport_set_mono` (upward closure).** `m ≤ m'` and `m ∈ DavenportSet G ⟹
+   m' ∈ DavenportSet G`: restrict a length-`m'` sequence to its first `m` entries
+   via `Fin.castLE`, get a zero-sum subset in `Fin m`, re-embed into `Fin m'` along
+   `Fin.castLEEmb` with `Finset.sum_map` preserving the sum.
+
+Combining: if the least Davenport length `d ≤ a+b−2`, monotonicity puts `a+b−2` in the
+Davenport set, contradicting the witness. Hence `a+b−1 ≤ d`.
+
+`davenport_rank2_diag_lower` specializes to `D(ℤ/nℤ ⊕ ℤ/nℤ) ≥ 2n − 1`.
+
+## Lean gotchas encountered (Mathlib v4.26.0)
+
+- **Binder-type ambiguity.** Writing the filter predicate as `fun i => (i : ℕ) < a − 1`
+  lets Lean infer `i : ℕ` (taking `↑i = i`), making `s.filter` expect `Finset ℕ` and
+  producing "Application type mismatch ... expected Finset ℕ". Fix: annotate every
+  filter binder explicitly, `fun i : Fin (a − 1 + (b − 1)) => …`.
+- **`set L := a−1+(b−1)` backfires.** Folding the length into an abbreviation broke
+  `rw [hsum]` (syntactic pattern no longer found) and made `omega` lose the
+  `i.isLt : ↑i < a−1+(b−1)` bound. Keep the literal expression instead.
+- **`card_le_card_of_injOn` is `Set`-valued.** Its `MapsTo`/`InjOn` hypotheses range
+  over `↑s` (the coe to `Set`), so `Finset.mem_filter` makes no progress on the intro'd
+  membership; use `simp only [Finset.coe_filter, Set.mem_setOf_eq, not_lt]` and
+  `simp only [Finset.coe_range, Set.mem_Iio]` on the goal.
+- **`omega` needs a beta-reduced hypothesis.** In the `InjOn` goal the equality
+  `hxy : (fun i => ↑i − (a−1)) x = (fun i => ↑i − (a−1)) y` stays as an opaque lambda
+  application, invisible to `omega`. `replace hxy : (↑x:ℕ) − (a−1) = (↑y:ℕ) − (a−1) := hxy`
+  (defeq beta) exposes it; nat-subtraction injectivity then needs the `a−1 ≤ ↑x`,
+  `a−1 ≤ ↑y` bounds from the filter membership.
+
+## Open questions (see meta.json)
+
+1. **(high)** The matching Olson upper bound `D(ℤ/aℤ ⊕ ℤ/bℤ) ≤ a + b − 1` — is there an
+   elementary axiom-free Lean proof, or does it require the group-algebra polynomial method?
+2. **(medium)** General-rank lower bound `D(⨁ᵢ ℤ/nᵢ) ≥ 1 + Σ(nᵢ − 1)` by concatenating
+   `k` coordinate blocks — cleanest Lean encoding of the indexed direct sum?
+
+## Relationship to other entries
+
+- **Extends** `erdos-131-oq-01-oq-01-oq-01-oq-03` (exact cyclic constant `D(ℤ/nℤ) = n`):
+  answers its open question `…-oq-03-oq-01` for the rank-2 lower bound.
+- Self-contained (`import Mathlib` only); does not import the cyclic companion, so it is
+  independently verifiable and axiom-free.

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04/meta.json
@@ -1,0 +1,145 @@
+{
+  "id": "erdos-131-oq-01-oq-01-oq-01-oq-04",
+  "slug": "erdos-131-oq-01-oq-01-oq-01-oq-04",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos131DavenportRank2",
+    "lineCount": 180,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos131DavenportRank2.lean",
+    "sorries": 0
+  },
+  "title": "The Rank-2 Davenport Lower Bound D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1 (Erdős #131)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos131DavenportRank2.lean",
+    "tags": [
+      "number-theory",
+      "additive-combinatorics",
+      "erdos-problems",
+      "erdos-131",
+      "davenport-constant",
+      "zero-sum-free",
+      "zero-sum-subsequence",
+      "non-cyclic-group",
+      "rank-two",
+      "olson-theorem",
+      "isleast",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 180,
+    "theoremCount": 4,
+    "definitionCount": 3,
+    "badge": "original",
+    "originalContributions": [
+      "davenport_rank2_lower: the headline result — the Davenport constant of the rank-2 group ℤ/aℤ ⊕ ℤ/bℤ is at least a + b − 1. Formalized as: if d is the least length such that every length-d sequence over ℤ/aℤ ⊕ ℤ/bℤ has a nonempty zero-sum subsequence (IsLeast (DavenportSet (ZMod a × ZMod b)) d), then a + b − 1 ≤ d. This is the elementary, unconditional HALF of Olson's theorem D(ℤ/aℤ ⊕ ℤ/bℤ) = a + b − 1 (for a ∣ b); the matching upper bound is a substantial combinatorial theorem that is NOT in Mathlib. The cyclic case D(ℤ/nℤ) = n is elementary (companion entry); rank ≥ 2 is where the Davenport constant becomes non-trivial, and this entry breaks into that regime axiom-free. It answers the rank-2 lower-bound part of the open question posed by the cyclic-constant entry (erdos-131-oq-01-oq-01-oq-01-oq-03-oq-01).",
+      "davenport_rank2_witness: the extremal construction and its key property — the standard sequence consisting of e₁ = (1,0) repeated a − 1 times followed by e₂ = (0,1) repeated b − 1 times (length (a−1)+(b−1) = a+b−2) has NO nonempty zero-sum subsequence. Proof: a nonempty index set s splits as s₁ (the e₁-block) and s₂ (the e₂-block); the two coordinates of ∑_{i∈s} witness a b i are (|s₁| : ZMod a) and (|s₂| : ZMod b) (computed via Prod.fst_sum / Prod.snd_sum and Finset.sum_boole). Vanishing forces a ∣ |s₁| with 0 ≤ |s₁| ≤ a−1 and b ∣ |s₂| with 0 ≤ |s₂| ≤ b−1, hence |s₁| = |s₂| = 0 and s = ∅. The block-size bounds use an injection of each block into Finset.range via Fin.val (resp. Fin.val − (a−1)).",
+      "davenport_set_mono: the Davenport set {m | every length-m sequence has a nonempty zero-sum subsequence} is upward closed — m ≤ m' and m ∈ DavenportSet G ⟹ m' ∈ DavenportSet G. Proof: restrict a length-m' sequence to its first m entries via Fin.castLE, obtain a zero-sum subset in Fin m, and re-embed it into Fin m' along the order embedding Fin.castLEEmb, with Finset.sum_map preserving the sum. This monotonicity is exactly what converts the single extremal witness of length a+b−2 into the lower bound a+b−1 on the LEAST Davenport length.",
+      "davenport_rank2_diag_lower: the diagonal special case D(ℤ/nℤ ⊕ ℤ/nℤ) ≥ 2n − 1, an immediate corollary. This bound is sharp — Olson's theorem gives D(ℤ/nℤ ⊕ ℤ/nℤ) = 2n − 1 — and exhibits the gap with the cyclic constant: the rank-2 diagonal group has Davenport constant 2n − 1, nearly double the cyclic n.",
+      "HasZeroSumSubseq and DavenportSet: the group-agnostic predicate ‘a sequence has a nonempty zero-sum subsequence’ and the Davenport-length set, both stated for an arbitrary AddCommMonoid, generalizing the ZMod-n-only definitions of the cyclic companion to the multi-rank setting needed here."
+    ],
+    "prerequisites": [
+      "Prod.fst_sum / Prod.snd_sum (Mathlib): the coordinate projections commute with finite sums, (∑ i ∈ s, f i).1 = ∑ i ∈ s, (f i).1 and likewise for .2; this is what decomposes a zero-sum over ℤ/aℤ ⊕ ℤ/bℤ into two coordinatewise cardinality conditions.",
+      "Finset.sum_boole (Mathlib): ∑ x ∈ s, (if p x then 1 else 0) = (s.filter p).card; identifies each coordinate sum of the witness with the size of the corresponding block restricted to s.",
+      "ZMod.natCast_eq_zero_iff (Mathlib): (k : ZMod n) = 0 ↔ n ∣ k; turns the vanishing of each coordinate (a block cardinality mod a or mod b) into a divisibility, which with the block-size bound forces the cardinality to 0.",
+      "Fin.castLEEmb / Finset.sum_map (Mathlib): the order embedding Fin m ↪ Fin m' and sum-preservation under Finset.map; the mechanism of the upward-closure lemma davenport_set_mono.",
+      "Finset.card_le_card_of_injOn and Finset.filter_card_add_filter_neg_card_eq_card (Mathlib): bound each block cardinality by injecting into Finset.range, and recombine the two complementary blocks back into s.card."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Prod.fst_sum",
+        "description": "(∑ i ∈ s, f i).1 = ∑ i ∈ s, (f i).1 (and Prod.snd_sum for .2). Decomposes a zero-sum over the product group ℤ/aℤ ⊕ ℤ/bℤ into two independent coordinate conditions, the heart of davenport_rank2_witness.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_boole",
+        "description": "∑ x ∈ s, (if p x then 1 else 0) = ↑(s.filter p).card. Evaluates each coordinate of the witness sum as the size of the e₁- or e₂-block of s.",
+        "module": "Mathlib.Algebra.BigOperators.Ring.Finset"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(k : ZMod n) = 0 ↔ n ∣ k. With 0 ≤ |block| ≤ n − 1 this forces each block cardinality to 0, hence s empty.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.sum_map",
+        "description": "Sum over a mapped Finset equals the sum of the precomposition. Used with the embedding Fin.castLEEmb to re-embed a zero-sum subset of a prefix into the full index set, proving davenport_set_mono.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.filter_card_add_filter_neg_card_eq_card",
+        "description": "(s.filter p).card + (s.filter (¬ p ·)).card = s.card. Recombines the e₁- and e₂-blocks (which partition s) so that both being empty forces s.card = 0.",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-01",
+      "question": "The matching upper bound D(ℤ/aℤ ⊕ ℤ/bℤ) ≤ a + b − 1 (for a ∣ b) — Olson's theorem — would complete the rank-2 Davenport constant. Mathlib lacks it. Is there an elementary, axiom-free Lean proof of the rank-2 upper bound (e.g. via the Davenport-constant induction on |G|, or via the group-ring / Olson polynomial-method argument), or does it genuinely require infrastructure beyond the prefix-sum pigeonhole that settles the cyclic case?",
+      "significance": "high"
+    },
+    {
+      "id": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-02",
+      "question": "The construction here generalizes verbatim to give the Olson–Davenport lower bound D(ℤ/n₁ ⊕ ⋯ ⊕ ℤ/n_k) ≥ 1 + Σ(nᵢ − 1) for arbitrary rank k, by concatenating the k coordinate blocks. Formalizing this for a general indexed direct sum ⨁ᵢ ℤ/nᵢ requires summing over Σ-types / Fin k indexed coordinates rather than a fixed product — what is the cleanest Lean encoding (DirectSum, Π-types, or Fin k → ℤ/nᵢ) that keeps the block-cardinality argument as elementary as the rank-2 case?",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-131-oq-01-oq-01-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "Answers the rank-2 lower-bound part of that entry's open question erdos-131-oq-01-oq-01-oq-01-oq-03-oq-01. The cyclic-constant entry proved D(ℤ/nℤ) = n exactly (the elementary case) and asked whether the prefix-sum pigeonhole could be lifted to the rank-2 constant a + b − 1. Here we settle the LOWER bound D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1 unconditionally via the explicit e₁/e₂ extremal sequence plus upward closure of the Davenport set, reusing the same sequence-level HasZeroSumSubseq / IsLeast packaging now generalized to an arbitrary additive group."
+    },
+    {
+      "targetId": "erdos-131",
+      "relationship": "extends",
+      "description": "Extends the additive-combinatorial machinery of the parent Erdős #131 study into the non-cyclic regime: the rank-2 Davenport constant a + b − 1 (lower half, axiom-free) is the next invariant beyond the cyclic D(ℤ/nℤ) = n that governs structural size bounds, and is supplied as reusable Lean infrastructure Mathlib lacks."
+    }
+  ],
+  "references": [
+    {
+      "title": "On some problems in combinatorial number theory",
+      "author": "Paul Erdős",
+      "year": "1975",
+      "venue": "Er75b",
+      "description": "Erdős's problem #131 on non-dividing sets; the Davenport constant is the additive-combinatorial invariant behind the per-element size bounds, here studied in rank 2."
+    },
+    {
+      "title": "A combinatorial problem on finite Abelian groups, I",
+      "author": "John E. Olson",
+      "year": "1969",
+      "venue": "J. Number Theory 1, 8–10",
+      "description": "Olson's theorem: for a ∣ b, D(ℤ/aℤ ⊕ ℤ/bℤ) = a + b − 1, and D(G) for p-groups. This entry formalizes the elementary lower bound a + b − 1; Olson supplies the deep matching upper bound."
+    },
+    {
+      "title": "A combinatorial problem on finite Abelian groups, II",
+      "author": "John E. Olson",
+      "year": "1969",
+      "venue": "J. Number Theory 1, 195–199",
+      "description": "Continuation establishing the Davenport constant of p-groups via the group-algebra / polynomial method; context for the higher-rank upper bounds posed in the open questions."
+    },
+    {
+      "title": "Zero-sum problems in finite abelian groups: a survey",
+      "author": "Weidong Gao, Alfred Geroldinger",
+      "year": "2006",
+      "venue": "Expo. Math. 24, 337–369",
+      "description": "Comprehensive survey of the Davenport constant D(G), the EGZ constant, and the standard extremal constructions; the rank-2 lower-bound sequence e₁^{a−1} e₂^{b−1} formalized here is the textbook witness."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The Davenport constant of the rank-2 group ℤ/aℤ ⊕ ℤ/bℤ is at least a + b − 1 (davenport_rank2_lower): if d is the least length such that every length-d sequence over the group has a nonempty zero-sum subsequence, then a + b − 1 ≤ d. The proof combines two pieces. (1) davenport_rank2_witness: the extremal sequence e₁=(1,0) repeated a−1 times then e₂=(0,1) repeated b−1 times (length a+b−2) has no nonempty zero-sum subsequence — its two coordinate sums over any nonempty index set s are the block cardinalities |s₁| (mod a) and |s₂| (mod b), each bounded by a−1, b−1 and hence forced to 0 by ZMod.natCast_eq_zero_iff, so s is empty. (2) davenport_set_mono: the Davenport-length set is upward closed (restrict a longer sequence to a prefix via Fin.castLE, re-embed the zero-sum subset via Fin.castLEEmb), so the single witness of length a+b−2 rules out every length ≤ a+b−2. The diagonal corollary davenport_rank2_diag_lower gives D(ℤ/nℤ ⊕ ℤ/nℤ) ≥ 2n − 1. 180 lines, 4 theorems, 3 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This breaks the Erdős #131 Davenport line out of the elementary cyclic regime into rank 2, where the constant is genuinely non-trivial. The bound a + b − 1 is sharp by Olson's theorem (the upper half, a substantial result absent from Mathlib), so the entry formalizes exactly the elementary, unconditional half and isolates the deep half as an open question. The reusable infrastructure — a group-agnostic HasZeroSumSubseq / DavenportSet, the upward-closure lemma, and the coordinatewise block-cardinality technique — generalizes verbatim to the Olson–Davenport lower bound 1 + Σ(nᵢ − 1) for arbitrary rank, the next target posed in the open questions."
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes the **rank-2 Davenport lower bound**

```
D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1
```

the elementary, unconditional **half** of Olson's theorem `D(ℤ/aℤ ⊕ ℤ/bℤ) = a + b − 1` (for `a ∣ b`). The cyclic Davenport constant `D(ℤ/nℤ) = n` is elementary (companion #27287); **rank ≥ 2 is where the constant becomes non-trivial**, and this entry breaks into that regime axiom-free. It answers the rank-2 lower-bound part of the open question `erdos-131-oq-01-oq-01-oq-01-oq-03-oq-01` raised by the cyclic-constant entry.

## Result (`Proofs/Erdos131DavenportRank2.lean`, namespace `Erdos131DavenportRank2`)

- **`davenport_rank2_lower`** — if `d` is the least length such that every length-`d` sequence over `ℤ/aℤ ⊕ ℤ/bℤ` has a nonempty zero-sum subsequence (`IsLeast (DavenportSet (ZMod a × ZMod b)) d`), then `a + b − 1 ≤ d`.
- **`davenport_rank2_witness`** — the extremal sequence `e₁=(1,0)` repeated `a−1` times then `e₂=(0,1)` repeated `b−1` times (length `a+b−2`) has **no** nonempty zero-sum subsequence. Its two coordinate sums over any nonempty `s` are the block cardinalities `|s₁|` (mod a) and `|s₂|` (mod b), each bounded by `a−1`,`b−1` and hence forced to `0` by `ZMod.natCast_eq_zero_iff`.
- **`davenport_set_mono`** — the Davenport-length set is upward closed (restrict to a prefix via `Fin.castLE`, re-embed via `Fin.castLEEmb`, `Finset.sum_map`); this turns the single length-`a+b−2` witness into the lower bound on the least length.
- **`davenport_rank2_diag_lower`** — corollary `D(ℤ/nℤ ⊕ ℤ/nℤ) ≥ 2n − 1` (sharp by Olson).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos131DavenportRank2` ✓ (Build completed successfully, 7743 jobs)
- **0 axioms, 0 sorries, 0 native_decide** — depends only on `propext`, `Classical.choice`, `Quot.sound`
- 180 lines · 4 theorems · 3 definitions · self-contained (`import Mathlib` only)

## Open questions (in meta.json)

1. *(high)* The matching Olson **upper** bound `D(ℤ/aℤ ⊕ ℤ/bℤ) ≤ a + b − 1` — elementary axiom-free Lean proof, or does it need the group-algebra polynomial method? (Not in Mathlib.)
2. *(medium)* General-rank lower bound `D(⨁ᵢ ℤ/nᵢ) ≥ 1 + Σ(nᵢ − 1)` — cleanest indexed-direct-sum encoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)