### PR TITLE
research(erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03): general direct-sum Davenport lower bound D(G₁⊕G₂)≥D(G₁)+D(G₂)−1 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos131DavenportDirectSum.lean
+++ b/proofs/Proofs/Erdos131DavenportDirectSum.lean
@@ -1,0 +1,196 @@
+/-
+  Erdős Problem #131 — Non-Dividing Sets
+  Follow-up (oq-01-oq-01-oq-01-oq-04-oq-01): the GENERAL direct-sum Davenport
+  lower bound
+
+      D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1            for additive groups G₁, G₂.
+
+  Source: https://erdosproblems.com/131
+  Companion to:
+    * `Proofs.Erdos131DavenportRank2`     — the rank-2 CYCLIC lower bound
+      `D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1`, proved with an explicit extremal sequence;
+    * `Proofs.Erdos131DavenportConstant`  — the EXACT cyclic value `D(ℤ/nℤ) = n`.
+
+  NOTE.  This file is deliberately SELF-CONTAINED (only `import Mathlib`); it does
+  not import the companions, which keeps it independently verifiable and
+  axiom-free.
+
+  ## What this file adds
+
+  The rank-2 companion proves `D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1` by exhibiting *one*
+  concrete extremal sequence in `ℤ/aℤ ⊕ ℤ/bℤ`.  Here we prove the underlying
+  STRUCTURAL principle in full generality, for ARBITRARY additive groups:
+
+      D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1.
+
+  The engine is the **concatenation principle** for zero-sum-free sequences: if
+  `f₁` is a zero-sum-free sequence over `G₁` and `f₂` is one over `G₂`, then the
+  sequence `(f₁ i, 0)` followed by `(0, f₂ j)` is zero-sum-free over `G₁ ⊕ G₂`.
+  The proof reindexes a candidate zero-sum subset along `Fin m₁ ⊕ Fin m₂ ≃ Fin
+  (m₁ + m₂)`, splits it into its `G₁`- and `G₂`-blocks (`Finset.toLeft` /
+  `Finset.toRight`), reads off the two coordinates, and uses zero-sum-freeness of
+  each factor to force both blocks empty.
+
+  Specialising `G₁ = ℤ/aℤ`, `G₂ = ℤ/bℤ` with the cyclic value `D(ℤ/nℤ) = n`
+  recovers the rank-2 bound `a + b − 1`; the upper bound `D(ℤ/aℤ ⊕ ℤ/bℤ) = a+b−1`
+  for `a ∣ b` is Olson's theorem, a substantial result not in Mathlib and not
+  formalized here.
+
+  All results are unconditional and axiom-free.
+-/
+
+import Mathlib
+
+namespace Erdos131DavenportDirectSum
+
+open Finset
+
+/-- A sequence `f : Fin m → G` *has a nonempty zero-sum subsequence* if some
+nonempty index set `s` has `∑ i ∈ s, f i = 0`. -/
+def HasZeroSumSubseq {G : Type*} [AddCommMonoid G] {m : ℕ} (f : Fin m → G) : Prop :=
+  ∃ s : Finset (Fin m), s.Nonempty ∧ ∑ i ∈ s, f i = 0
+
+/-- The **Davenport set** of `G`: the lengths `m` such that *every* length-`m`
+sequence over `G` has a nonempty zero-sum subsequence.  The Davenport constant
+`D(G)` is the least element of this set. -/
+def DavenportSet (G : Type*) [AddCommMonoid G] : Set ℕ :=
+  {m | ∀ f : Fin m → G, HasZeroSumSubseq f}
+
+/-- **The Davenport set is upward closed.**  If every length-`m` sequence has a
+nonempty zero-sum subsequence, then so does every length-`m'` sequence for
+`m ≤ m'`.
+
+Restrict `f : Fin m' → G` to its first `m` entries via `Fin.castLE`, obtain a
+zero-sum subset `s : Finset (Fin m)`, and re-embed it into `Fin m'` with the
+order embedding `Fin.castLEEmb`; `Finset.sum_map` keeps the sum unchanged. -/
+theorem davenport_set_mono {G : Type*} [AddCommMonoid G] {m m' : ℕ} (h : m ≤ m')
+    (hm : m ∈ DavenportSet G) : m' ∈ DavenportSet G := by
+  intro f
+  obtain ⟨s, hne, hsum⟩ := hm (fun i => f (Fin.castLE h i))
+  refine ⟨s.map (Fin.castLEEmb h), Finset.map_nonempty.mpr hne, ?_⟩
+  rw [Finset.sum_map]
+  simpa [Fin.coe_castLEEmb] using hsum
+
+/-- **Length `0` is never a Davenport length.**  The empty sequence has no
+nonempty index subset at all, so `HasZeroSumSubseq` fails vacuously. -/
+theorem zero_not_mem_davenportSet (G : Type*) [AddCommMonoid G] :
+    0 ∉ DavenportSet G := by
+  intro h
+  obtain ⟨s, hne, _⟩ := h (fun _ => 0)
+  obtain ⟨i, _⟩ := hne
+  exact absurd i.2 (by omega)
+
+/-- **The least Davenport length is positive.**  Since `0 ∉ DavenportSet G`, the
+least element of a nonempty Davenport set is at least `1`. -/
+theorem one_le_of_isLeast_davenport {G : Type*} [AddCommMonoid G] {d : ℕ}
+    (hd : IsLeast (DavenportSet G) d) : 1 ≤ d := by
+  rcases Nat.eq_zero_or_pos d with h0 | hpos
+  · exact absurd (h0 ▸ hd.1) (zero_not_mem_davenportSet G)
+  · exact hpos
+
+/-- **The concatenated sequence.**  Place `f₁` in the first coordinate over the
+first block, and `f₂` in the second coordinate over the second block:
+`concatSeq f₁ f₂` sends the `i`-th index (`i < m₁`) to `(f₁ i, 0)` and the
+`(m₁ + j)`-th index to `(0, f₂ j)`. -/
+def concatSeq {G₁ G₂ : Type*} [Zero G₁] [Zero G₂] {m₁ m₂ : ℕ}
+    (f₁ : Fin m₁ → G₁) (f₂ : Fin m₂ → G₂) : Fin (m₁ + m₂) → G₁ × G₂ :=
+  Fin.addCases (fun i => (f₁ i, 0)) (fun j => (0, f₂ j))
+
+/-- **Concatenation preserves zero-sum-freeness.**  If `f₁` over `G₁` and `f₂`
+over `G₂` each have no nonempty zero-sum subsequence, then neither does their
+concatenation over `G₁ ⊕ G₂`.
+
+A candidate zero-sum subset `s ⊆ Fin (m₁ + m₂)` is reindexed along
+`finSumFinEquiv : Fin m₁ ⊕ Fin m₂ ≃ Fin (m₁ + m₂)` to `t ⊆ Fin m₁ ⊕ Fin m₂`,
+split into `t.toLeft` and `t.toRight`.  The first coordinate of the total sum is
+`∑_{j ∈ t.toLeft} f₁ j`, the second is `∑_{k ∈ t.toRight} f₂ k`; both vanish, so
+zero-sum-freeness of `f₁`, `f₂` forces both blocks empty, hence `t = ∅` and
+`s = ∅`. -/
+theorem concat_not_hasZeroSum {G₁ G₂ : Type*} [AddCommGroup G₁] [AddCommGroup G₂]
+    {m₁ m₂ : ℕ} {f₁ : Fin m₁ → G₁} {f₂ : Fin m₂ → G₂}
+    (h₁ : ¬ HasZeroSumSubseq f₁) (h₂ : ¬ HasZeroSumSubseq f₂) :
+    ¬ HasZeroSumSubseq (concatSeq f₁ f₂) := by
+  rintro ⟨s, hne, hsum⟩
+  -- Reindex `s` along `Fin m₁ ⊕ Fin m₂ ≃ Fin (m₁ + m₂)`.
+  set t : Finset (Fin m₁ ⊕ Fin m₂) := s.map finSumFinEquiv.symm.toEmbedding with ht
+  have hmap : t.map finSumFinEquiv.toEmbedding = s := by
+    rw [ht, Finset.map_map]; ext x; simp
+  rw [← hmap, Finset.sum_map, ← Finset.toLeft_disjSum_toRight (u := t),
+      Finset.sum_disjSum] at hsum
+  simp only [Equiv.coe_toEmbedding, finSumFinEquiv_apply_left,
+    finSumFinEquiv_apply_right, concatSeq, Fin.addCases_left, Fin.addCases_right]
+    at hsum
+  -- Read off the two coordinates of the (vanishing) total.
+  have hL : ∑ j ∈ t.toLeft, f₁ j = 0 := by
+    have h := congrArg Prod.fst hsum
+    simpa [Prod.fst_sum] using h
+  have hR : ∑ k ∈ t.toRight, f₂ k = 0 := by
+    have h := congrArg Prod.snd hsum
+    simpa [Prod.snd_sum] using h
+  -- Zero-sum-freeness forces each block empty.
+  have hLempty : t.toLeft = ∅ := by
+    by_contra h0
+    exact h₁ ⟨t.toLeft, Finset.nonempty_of_ne_empty h0, hL⟩
+  have hRempty : t.toRight = ∅ := by
+    by_contra h0
+    exact h₂ ⟨t.toRight, Finset.nonempty_of_ne_empty h0, hR⟩
+  -- Hence `t = ∅`, so `s = ∅`, contradicting nonemptiness.
+  have htempty : t = ∅ := by
+    rw [← Finset.toLeft_disjSum_toRight (u := t), Finset.disjSum_eq_empty]
+    exact ⟨hLempty, hRempty⟩
+  have hsempty : s = ∅ := by rw [← hmap, htempty, Finset.map_empty]
+  exact absurd hne (hsempty ▸ Finset.not_nonempty_empty)
+
+/-- **General direct-sum Davenport lower bound: `D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1`.**
+
+Let `d₁ = D(G₁)`, `d₂ = D(G₂)`, `d = D(G₁ ⊕ G₂)` be the least Davenport lengths.
+Since `d₁` is least, length `d₁ − 1` admits a zero-sum-free sequence `f₁`;
+likewise `f₂` of length `d₂ − 1`.  Their concatenation is a zero-sum-free
+sequence over `G₁ ⊕ G₂` of length `(d₁ − 1) + (d₂ − 1) = d₁ + d₂ − 2`, so that
+length is NOT a Davenport length.  Were `d ≤ d₁ + d₂ − 2`, upward closure would
+make `d₁ + d₂ − 2` a Davenport length — contradiction.  Hence `d ≥ d₁+d₂−1`. -/
+theorem davenport_directSum_lower {G₁ G₂ : Type*} [AddCommGroup G₁]
+    [AddCommGroup G₂] {d₁ d₂ d : ℕ}
+    (h₁ : IsLeast (DavenportSet G₁) d₁) (h₂ : IsLeast (DavenportSet G₂) d₂)
+    (hd : IsLeast (DavenportSet (G₁ × G₂)) d) :
+    d₁ + d₂ - 1 ≤ d := by
+  have hd₁ : 1 ≤ d₁ := one_le_of_isLeast_davenport h₁
+  have hd₂ : 1 ≤ d₂ := one_le_of_isLeast_davenport h₂
+  -- `d₁ − 1` is below the least Davenport length, so it is not in the set:
+  -- there is a zero-sum-free sequence `f₁` of length `d₁ − 1`.
+  have hns₁ : (d₁ - 1) ∉ DavenportSet G₁ := fun hmem =>
+    absurd (h₁.2 hmem) (by omega)
+  have hns₂ : (d₂ - 1) ∉ DavenportSet G₂ := fun hmem =>
+    absurd (h₂.2 hmem) (by omega)
+  rw [DavenportSet, Set.mem_setOf_eq, not_forall] at hns₁ hns₂
+  obtain ⟨f₁, hf₁⟩ := hns₁
+  obtain ⟨f₂, hf₂⟩ := hns₂
+  -- The concatenation is zero-sum-free, so its length is not a Davenport length.
+  have hfree : ¬ HasZeroSumSubseq (concatSeq f₁ f₂) := concat_not_hasZeroSum hf₁ hf₂
+  by_contra hlt
+  push_neg at hlt
+  -- `d ≤ (d₁ − 1) + (d₂ − 1)`, so upward closure makes that a Davenport length.
+  have hdle : d ≤ (d₁ - 1) + (d₂ - 1) := by omega
+  have hmem : ((d₁ - 1) + (d₂ - 1)) ∈ DavenportSet (G₁ × G₂) :=
+    davenport_set_mono hdle hd.1
+  exact hfree (hmem (concatSeq f₁ f₂))
+
+/-- **Recovering the rank-2 cyclic bound.**  Given the cyclic Davenport values
+`D(ℤ/aℤ) = a` and `D(ℤ/bℤ) = b` (companion `Erdos131DavenportConstant`), the
+general bound specialises to `D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1`. -/
+theorem davenport_rank2_lower_of_cyclic {a b d : ℕ}
+    (ha : IsLeast (DavenportSet (ZMod a)) a) (hb : IsLeast (DavenportSet (ZMod b)) b)
+    (hd : IsLeast (DavenportSet (ZMod a × ZMod b)) d) :
+    a + b - 1 ≤ d :=
+  davenport_directSum_lower ha hb hd
+
+/-- **Diagonal special case: `D(G ⊕ G) ≥ 2·D(G) − 1`.**  For `G = ℤ/nℤ` this is
+the sharp bound `D(ℤ/nℤ ⊕ ℤ/nℤ) ≥ 2n − 1` (Olson's theorem gives equality; the
+matching upper bound is not formalized here). -/
+theorem davenport_directSum_diag_lower {G : Type*} [AddCommGroup G] {c d : ℕ}
+    (hc : IsLeast (DavenportSet G) c) (hd : IsLeast (DavenportSet (G × G)) d) :
+    2 * c - 1 ≤ d := by
+  have := davenport_directSum_lower hc hc hd
+  omega
+
+end Erdos131DavenportDirectSum

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03/knowledge.md
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03/knowledge.md
@@ -1,0 +1,94 @@
+# Erdős #131 — General Direct-Sum Davenport Lower Bound `D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1`
+
+**Slug:** `erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03`
+**Lean file:** `proofs/Proofs/Erdos131DavenportDirectSum.lean` (namespace `Erdos131DavenportDirectSum`)
+**Status:** verified · 0 axioms · 0 sorries · 7 theorems · 3 definitions · 196 lines
+
+## Summary
+
+The **Davenport constant** `D(G)` of an additive group `G` is the least `d` such that
+every length-`d` sequence over `G` has a nonempty zero-sum subsequence. The cyclic value
+`D(ℤ/nℤ) = n` is elementary (companion `erdos-131-oq-01-oq-01-oq-01-oq-03`); the rank-2
+**cyclic** lower bound `D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1` (companion
+`erdos-131-oq-01-oq-01-oq-01-oq-04`) is proved there by exhibiting one explicit extremal
+sequence `(1,0)^{a−1}(0,1)^{b−1}`.
+
+This entry proves the **structural principle** behind that witness, for **arbitrary**
+additive groups:
+
+> `davenport_directSum_lower : IsLeast (DavenportSet G₁) d₁ → IsLeast (DavenportSet G₂) d₂ → IsLeast (DavenportSet (G₁ × G₂)) d → d₁ + d₂ − 1 ≤ d`.
+
+Iterating it over an invariant-factor decomposition (each factor cyclic) recovers the
+Olson–Davenport lower bound `D(G) ≥ 1 + Σ(nᵢ − 1)`. The matching **upper** bound — Olson's
+theorem, sharp only for rank ≤ 2 and `p`-groups — is the deep open piece and is *not*
+formalized (Mathlib lacks it).
+
+## The engine: concatenation principle
+
+`concat_not_hasZeroSum`: if `f₁ : Fin m₁ → G₁` and `f₂ : Fin m₂ → G₂` are each
+zero-sum-free, then `concatSeq f₁ f₂ : Fin (m₁ + m₂) → G₁ × G₂` is too, where
+`concatSeq f₁ f₂ = Fin.addCases (fun i => (f₁ i, 0)) (fun j => (0, f₂ j))` places `f₁` in
+the first coordinate over the first block and `f₂` in the second over the second.
+
+Proof sketch:
+1. A candidate zero-sum index set `s ⊆ Fin (m₁ + m₂)` is reindexed along
+   `finSumFinEquiv : Fin m₁ ⊕ Fin m₂ ≃ Fin (m₁ + m₂)` to `t ⊆ Fin m₁ ⊕ Fin m₂`.
+2. `Finset.toLeft_disjSum_toRight` + `Finset.sum_disjSum` split the total sum over `t`
+   into a `t.toLeft` block and a `t.toRight` block; `finSumFinEquiv_apply_left/right` and
+   `Fin.addCases_left/right` evaluate `concatSeq` on each block to `(f₁ j, 0)` resp.
+   `(0, f₂ k)`.
+3. `Prod.fst_sum` / `Prod.snd_sum` read the two coordinates: the first is
+   `∑_{j ∈ t.toLeft} f₁ j`, the second `∑_{k ∈ t.toRight} f₂ k`. The pair being `0` forces
+   both block sums to `0`.
+4. Zero-sum-freeness of `f₁`, `f₂` makes each block empty; `Finset.disjSum_eq_empty` gives
+   `t = ∅`, hence `s = ∅`, contradicting nonemptiness.
+
+## Supporting infrastructure
+
+- `DavenportSet G := {m | ∀ f : Fin m → G, HasZeroSumSubseq f}`, with `HasZeroSumSubseq`
+  the nonempty-zero-sum-subsequence predicate (same as the companions, now over a generic
+  additive group).
+- `davenport_set_mono`: the Davenport set is upward closed (restrict via `Fin.castLE`,
+  re-embed via `Fin.castLEEmb`).
+- `zero_not_mem_davenportSet` / `one_le_of_isLeast_davenport`: length `0` is never a
+  Davenport length, so the least Davenport length is positive — needed so that
+  `D(Gᵢ) − 1` is a genuine zero-sum-free length.
+
+## Main proof
+
+`davenport_directSum_lower`: from `IsLeast` minimality, `D(G₁) − 1` and `D(G₂) − 1` are
+below the least Davenport lengths, so each admits a zero-sum-free sequence `f₁`, `f₂`.
+Their concatenation is zero-sum-free of length `(d₁ − 1) + (d₂ − 1) = d₁ + d₂ − 2`, so that
+length is not a Davenport length. Were `d ≤ d₁ + d₂ − 2`, upward closure would make
+`d₁ + d₂ − 2` a Davenport length — contradiction. Hence `d ≥ d₁ + d₂ − 1`.
+
+Specializations: `davenport_rank2_lower_of_cyclic` (feed `D(ℤ/aℤ)=a`, `D(ℤ/bℤ)=b` → `a+b−1`)
+and `davenport_directSum_diag_lower` (`D(G ⊕ G) ≥ 2·D(G) − 1`).
+
+## Mathlib gaps filled
+
+Mathlib has the Erdős–Ginzburg–Ziv constant `s(ℤ/nℤ) = 2n − 1` but **not** the Davenport
+constant, zero-sum-free sequences, or the direct-sum concatenation principle. This entry
+supplies the general-group concatenation infrastructure (`concatSeq`,
+`concat_not_hasZeroSum`) axiom-free.
+
+## Lean gotchas (v4.26.0)
+
+- `finSumFinEquiv_apply_left/right` are simp lemmas; do **not** `set e := finSumFinEquiv`
+  (the simp lemmas are stated for `finSumFinEquiv`, and `set` hides it). Write
+  `finSumFinEquiv` literally.
+- Reindex via `t := s.map finSumFinEquiv.symm.toEmbedding`, then prove
+  `t.map finSumFinEquiv.toEmbedding = s` by `rw [Finset.map_map]; ext x; simp`
+  (`Equiv.symm` then `Equiv` collapses to the identity embedding under `simp`).
+- One `simp only [Equiv.coe_toEmbedding, finSumFinEquiv_apply_left,
+  finSumFinEquiv_apply_right, concatSeq, Fin.addCases_left, Fin.addCases_right]` reduces both
+  block summands to the `(f₁ j, 0)` / `(0, f₂ k)` form in one shot.
+- Extract coordinates with `congrArg Prod.fst hsum` then `simpa [Prod.fst_sum]`.
+
+## Next steps
+
+- `oq-04-oq-03-oq-01`: lift the binary principle to an arbitrary indexed direct sum
+  `⨁_{i : Fin k} Gᵢ` (Σ-type block bookkeeping).
+- `oq-04-oq-03-oq-02`: characterize / exhibit groups where the bound is strict
+  (rank ≥ 4 examples beyond Olson's equality range).
+- The matching upper bound (Olson, `oq-04-oq-01`) remains the deep open piece.

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03/meta.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03",
+  "slug": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos131DavenportDirectSum",
+    "lineCount": 196,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos131DavenportDirectSum.lean",
+    "sorries": 0
+  },
+  "title": "The General Direct-Sum Davenport Lower Bound D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1 (Erdős #131)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos131DavenportDirectSum.lean",
+    "tags": [
+      "number-theory",
+      "additive-combinatorics",
+      "erdos-problems",
+      "erdos-131",
+      "davenport-constant",
+      "zero-sum-free",
+      "zero-sum-subsequence",
+      "direct-sum",
+      "concatenation-principle",
+      "finite-abelian-group",
+      "isleast",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 196,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "badge": "original",
+    "originalContributions": [
+      "davenport_directSum_lower: the headline result — for ARBITRARY additive groups G₁, G₂ the Davenport constant of the direct sum satisfies D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1, formalized via IsLeast of the Davenport-length sets. This is the structural backbone of the Olson–Davenport lower bound: the rank-2 cyclic companion (erdos-131-oq-01-oq-01-oq-01-oq-04) exhibits only ONE explicit extremal sequence in ℤ/aℤ ⊕ ℤ/bℤ, whereas this entry proves the underlying principle for any group summands, axiom-free. Iterating it across an invariant-factor decomposition recovers D(G) ≥ 1 + Σ(nᵢ − 1).",
+      "concat_not_hasZeroSum: the engine — the CONCATENATION PRINCIPLE for zero-sum-free sequences. If f₁ : Fin m₁ → G₁ and f₂ : Fin m₂ → G₂ each have no nonempty zero-sum subsequence, then concatSeq f₁ f₂ : Fin (m₁ + m₂) → G₁ × G₂ (which places f₁ in the first coordinate over the first block and f₂ in the second over the second) also has none. Proof: a candidate zero-sum index set s ⊆ Fin (m₁ + m₂) is reindexed along finSumFinEquiv : Fin m₁ ⊕ Fin m₂ ≃ Fin (m₁ + m₂) to t ⊆ Fin m₁ ⊕ Fin m₂, split into its blocks via Finset.toLeft / Finset.toRight; the first coordinate of the total is ∑_{j ∈ t.toLeft} f₁ j and the second is ∑_{k ∈ t.toRight} f₂ k (Finset.sum_disjSum + Prod.fst_sum/snd_sum + Fin.addCases_left/right), both vanish, and zero-sum-freeness of each factor forces both blocks empty, hence t = ∅ (Finset.disjSum_eq_empty) and s = ∅.",
+      "concatSeq: the abstract block-concatenation of two sequences into a sequence over the product group, encoded with Fin.addCases on Fin (m₁ + m₂) — the general-group replacement for the explicit (1,0)/(0,1) witness of the rank-2 entry.",
+      "davenport_set_mono: the Davenport set {m | ∀ f : Fin m → G, HasZeroSumSubseq f} is upward closed — restrict a length-m' sequence to its first m entries via Fin.castLE and re-embed the zero-sum witness through Fin.castLEEmb (Finset.sum_map keeps the sum). Stated for an arbitrary additive group, not a fixed cyclic factor.",
+      "zero_not_mem_davenportSet and one_le_of_isLeast_davenport: length 0 is never a Davenport length (the empty sequence has no nonempty index subset), so the least Davenport length is positive — the small but essential fact that lets D(Gᵢ) − 1 be a genuine zero-sum-free length.",
+      "davenport_rank2_lower_of_cyclic and davenport_directSum_diag_lower: specializations — feeding the cyclic values D(ℤ/aℤ) = a, D(ℤ/bℤ) = b recovers the rank-2 bound a + b − 1, and the diagonal case gives D(G ⊕ G) ≥ 2·D(G) − 1 (sharp for ℤ/nℤ by Olson)."
+    ],
+    "prerequisites": [
+      "finSumFinEquiv (Mathlib): the equivalence Fin m₁ ⊕ Fin m₂ ≃ Fin (m₁ + m₂), with finSumFinEquiv_apply_left/right sending Sum.inl/Sum.inr to Fin.castAdd / Fin.natAdd; the reindexing that turns a subset of the concatenation index into a disjoint pair of blocks.",
+      "Finset.toLeft / Finset.toRight, Finset.sum_disjSum, Finset.toLeft_disjSum_toRight, Finset.disjSum_eq_empty: the sum-type Finset calculus that splits a reindexed index set into its two group blocks and recombines them.",
+      "Fin.addCases and Fin.addCases_left / Fin.addCases_right: case analysis on Fin (m₁ + m₂) by the castAdd / natAdd halves, used to define concatSeq and to evaluate it on each block.",
+      "Prod.fst_sum / Prod.snd_sum: a sum of pairs splits coordinatewise, reading the two group-component conditions off the single vanishing pair.",
+      "IsLeast (Mathlib): the order-theoretic packaging of the Davenport constant as the least Davenport length, common to the cyclic and rank-2 companions."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "finSumFinEquiv",
+        "description": "Equivalence Fin m ⊕ Fin n ≃ Fin (m + n). The reindexing along which a candidate zero-sum subset of the concatenation is split into its two blocks; finSumFinEquiv_apply_left/right are simp lemmas evaluating it.",
+        "module": "Mathlib.Logic.Equiv.Fin.Basic"
+      },
+      {
+        "theorem": "Finset.sum_disjSum",
+        "description": "∑ over s.disjSum t splits as ∑ over s of f∘inl plus ∑ over t of f∘inr. Combined with Finset.toLeft_disjSum_toRight it expresses the total sum over the reindexed set as the two block sums.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.disjSum_eq_empty",
+        "description": "s.disjSum t = ∅ ↔ s = ∅ ∧ t = ∅. Turns the two empty blocks (forced by zero-sum-freeness) back into emptiness of the whole reindexed set.",
+        "module": "Mathlib.Data.Finset.Sum"
+      },
+      {
+        "theorem": "Fin.addCases_left",
+        "description": "Fin.addCases evaluated on Fin.castAdd reduces to the left branch (dually addCases_right on Fin.natAdd). Used both to define concatSeq and to reduce concatSeq on each block to (f₁ j, 0) resp. (0, f₂ k).",
+        "module": "Init.Data.Fin.Basic"
+      },
+      {
+        "theorem": "Prod.fst_sum",
+        "description": "(∑ x ∈ s, f x).1 = ∑ x ∈ s, (f x).1 (and the .2 analogue). Reads the two coordinatewise zero-sum conditions off the single vanishing total in G₁ × G₂.",
+        "module": "Mathlib.Algebra.BigOperators.Pi"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01",
+      "question": "The concatenation principle here is binary (G₁ ⊕ G₂). Iterating it gives D(⨁ᵢ Gᵢ) ≥ 1 + Σ(D(Gᵢ) − 1) for a finite indexed family, but formalizing the k-fold version directly over ⨁_{i : Fin k} Gᵢ requires a Σ-type / nested-block index rather than the single product split used here. Is there a clean inductive lift of concat_not_hasZeroSum to an arbitrary indexed direct sum that keeps the toLeft/toRight block argument, or does the indexed encoding force a genuinely different bookkeeping?",
+      "significance": "medium"
+    },
+    {
+      "id": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-02",
+      "question": "The lower bound D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1 is sharp for rank ≤ 2 cyclic groups and for p-groups (Olson) but STRICT in general (e.g. some rank-≥4 groups have D(G) > 1 + Σ(nᵢ − 1)). Can the gap D(G) − (1 + Σ(nᵢ − 1)) be characterized, or at least a verified family of groups exhibited where the concatenation bound is provably NOT tight?",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-131-oq-01-oq-01-oq-01-oq-04",
+      "relationship": "generalizes",
+      "description": "Lifts the rank-2 CYCLIC lower bound D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1 — which the parent proves by displaying one explicit extremal sequence (1,0)^{a−1}(0,1)^{b−1} — to the structural principle D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1 for ARBITRARY additive groups, isolating the concatenation argument behind the witness. davenport_rank2_lower_of_cyclic recovers the parent's bound from the cyclic Davenport values."
+    },
+    {
+      "targetId": "erdos-131-oq-01-oq-01-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "Uses the exact cyclic Davenport constant D(ℤ/nℤ) = n from that entry as the input D(Gᵢ) for the cyclic specialization, and advances its open question oq-03-oq-01 (lifting the cyclic bound to direct sums) by supplying the general direct-sum lower half."
+    },
+    {
+      "targetId": "erdos-131",
+      "relationship": "extends",
+      "description": "Provides the group-theoretic backbone of the Olson–Davenport lower bound for the additive-combinatorial constant governing non-dividing sets in the parent Erdős #131 study, as reusable axiom-free infrastructure Mathlib lacks."
+    }
+  ],
+  "references": [
+    {
+      "title": "A combinatorial problem on finite Abelian groups, I",
+      "author": "John E. Olson",
+      "year": "1969",
+      "venue": "J. Number Theory",
+      "description": "Foundational results on the Davenport constant, including D(G) for p-groups and the lower bound D(G) ≥ 1 + Σ(nᵢ − 1); the binary direct-sum lower bound formalized here is the structural step behind that inequality."
+    },
+    {
+      "title": "On Davenport's constant",
+      "author": "various (survey)",
+      "year": "2006",
+      "venue": "Expo. Math. / survey",
+      "description": "The Davenport constant D(G) is the least d such that every length-d sequence over G has a nonempty zero-sum subsequence; the concatenation of zero-sum-free sequences across a direct sum gives the standard lower bound, with equality known only for rank ≤ 2 and p-groups."
+    },
+    {
+      "title": "On some problems in combinatorial number theory",
+      "author": "Paul Erdős",
+      "year": "1975",
+      "venue": "Er75b",
+      "description": "Erdős's problem #131 on non-dividing sets; the Davenport constant is the invariant behind the per-element size bounds, and its direct-sum lower bound is the higher-rank generalization of the cyclic case used there."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For arbitrary additive groups G₁, G₂, the Davenport constant of the direct sum satisfies D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1 (davenport_directSum_lower, with D stated as the least Davenport length via IsLeast). The proof rests on the concatenation principle concat_not_hasZeroSum: given zero-sum-free sequences f₁ over G₁ (length D(G₁) − 1) and f₂ over G₂ (length D(G₂) − 1), the block-concatenation concatSeq f₁ f₂ over G₁ ⊕ G₂ is zero-sum-free — a candidate zero-sum index set is reindexed along finSumFinEquiv into Fin m₁ ⊕ Fin m₂, split by Finset.toLeft / Finset.toRight, and its two coordinates are exactly the f₁- and f₂-block sums (Finset.sum_disjSum, Fin.addCases_left/right, Prod.fst_sum/snd_sum), both forced to vanish and hence both blocks empty. Upward closure of the Davenport set (davenport_set_mono) then pushes the length D(G₁)+D(G₂)−2 out of the Davenport set, giving the bound. Specializations recover the rank-2 cyclic value a + b − 1 and the diagonal D(G ⊕ G) ≥ 2·D(G) − 1. 196 lines, 7 theorems, 3 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The entry isolates and verifies, for arbitrary group summands, the structural mechanism that the rank-2 cyclic companion only instantiated with one explicit witness. The concatenation principle is the reusable core of the Olson–Davenport lower bound D(G) ≥ 1 + Σ(nᵢ − 1): iterating davenport_directSum_lower over an invariant-factor decomposition (each factor cyclic with D(ℤ/nᵢℤ) = nᵢ) yields the full lower bound, while the matching upper bound — Olson's theorem, sharp only for rank ≤ 2 and p-groups — remains the deep open piece (oq-04-oq-01). The clean Fin.addCases / finSumFinEquiv / toLeft-toRight encoding supplies the general-group zero-sum-free infrastructure Mathlib lacks."
+  }
+}


### PR DESCRIPTION
## Summary

Generalizes the rank-2 **cyclic** Davenport lower bound `D(ℤ/aℤ⊕ℤ/bℤ) ≥ a+b−1` (companion `erdos-131-oq-01-oq-01-oq-01-oq-04`, which exhibits one explicit extremal sequence) to the **structural principle** for arbitrary additive groups:

> `davenport_directSum_lower : D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1`

(with `D` the least Davenport length, stated via `IsLeast`).

## Engine: the concatenation principle

`concat_not_hasZeroSum` — if `f₁` over `G₁` and `f₂` over `G₂` are each zero-sum-free, so is the block-concatenation `concatSeq f₁ f₂` over `G₁ ⊕ G₂` (`(f₁ i, 0)` over the first block, `(0, f₂ j)` over the second). A candidate zero-sum index set is reindexed along `finSumFinEquiv : Fin m₁ ⊕ Fin m₂ ≃ Fin (m₁+m₂)`, split via `Finset.toLeft`/`Finset.toRight`, and its two coordinates are exactly the `f₁`- and `f₂`-block sums (`Finset.sum_disjSum`, `Fin.addCases_left/right`, `Prod.fst_sum/snd_sum`); both vanish, forcing both blocks — and hence the whole set — empty.

Iterating over an invariant-factor decomposition recovers the Olson lower bound `D(G) ≥ 1 + Σ(nᵢ − 1)`. Specializations `davenport_rank2_lower_of_cyclic` (→ `a+b−1`) and `davenport_directSum_diag_lower` (→ `2·D(G)−1`) are included.

The matching **upper** bound (Olson's theorem, sharp only for rank ≤ 2 and p-groups) remains the deep open piece — Mathlib lacks the Davenport constant entirely.

## Verification

- **7 theorems, 3 definitions, 196 lines, 0 axioms, 0 sorries.**
- `#print axioms` on `davenport_directSum_lower` and `concat_not_hasZeroSum`: `[propext, Classical.choice, Quot.sound]` only.
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.Erdos131DavenportDirectSum`.

Gallery entry: `src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)