### PR TITLE
audit: re-verify area-of-circle (Wiedijk #9) clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -349,9 +349,9 @@
       "result": "clean"
     },
     "area-of-circle": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-21T08:31:37Z",
       "result": "clean"
     },
     "area-of-circle-oq-01": {


### PR DESCRIPTION
## Auditor cycle — 2026-06-21

The audit queue is **fully drained** (2796/2796 audited, 0 issues, 0 critical). With nothing unaudited, the auditor re-audits the oldest-audited entry; this cycle that was `area-of-circle` (last audited 2026-05-03), the base **Wiedijk #9** mathlib-wrapper entry.

### Deep audit findings (all consistent with meta.json)
- **0** `sorry` / `admit`, **0** `axiom` declarations, **no** `native_decide`
- **No** structures/classes → no structure-encoded assumptions
- **No** `: True :=` placeholder stubs
- Main results are honest mathlib wrappers:
  - `area_of_circle := Complex.volume_ball`
  - `area_of_closed_disk := Complex.volume_closedBall`
  - + 5 edge-case corollaries (unit disk, zero/negative radius)
- `lineCount` 155 matches source; `badge: "mathlib"`, `status: "verified"`, `axiomCount: 0` all accurate

### Result
**clean** — bumps `auditCount` 4→5 and refreshes `lastAudited` so the queue rotates to the next-oldest entry next cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)