### PR TITLE
fix(herald): significance (not the cap) as the real gate; stop ~40s busy-loop

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -140,6 +140,12 @@ MAX_RETRIES="${MAX_RETRIES:-5}"
 INITIAL_BACKOFF=60       # 1 minute
 MAX_BACKOFF=300          # 5 minutes
 CLAUDE_TIMEOUT="${CLAUDE_TIMEOUT:-3600}"  # 1 hour default; configurable per agent
+# Minimum wall-clock seconds per daemon cycle. After a successful (or timed-out)
+# cycle that finished faster than this, sleep the remainder before the next cycle.
+# Prevents busy-looping when an agent stands down in seconds (e.g. the herald with
+# nothing noteworthy to post). Default 0 = no floor, so continuously-working agents
+# (researchers, etc.) are unaffected.
+CYCLE_MIN_SECONDS="${CYCLE_MIN_SECONDS:-0}"
 REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 LOG_FILE=""
@@ -644,6 +650,30 @@ run_with_retry() {
     return 1
 }
 
+# Sleep the remainder of CYCLE_MIN_SECONDS after a cycle that finished early.
+# No-op when CYCLE_MIN_SECONDS is 0 (the default for continuously-working agents)
+# or when the cycle already ran at least that long. A stop signal during the sleep
+# breaks out promptly so shutdown stays responsive.
+enforce_cycle_floor() {
+    local cycle_start="$1"
+    [[ "${CYCLE_MIN_SECONDS:-0}" -le 0 ]] && return 0
+    local elapsed=$(( $(date +%s) - cycle_start ))
+    local remaining=$(( CYCLE_MIN_SECONDS - elapsed ))
+    [[ "$remaining" -le 0 ]] && return 0
+    log_info "Cycle floor: sleeping ${remaining}s (interval ${CYCLE_MIN_SECONDS}s, cycle took ${elapsed}s)"
+    # Sleep in short slices so a stop signal is honored within ~30s.
+    local slept=0
+    while [[ "$slept" -lt "$remaining" ]]; do
+        if check_stop_signal; then
+            log_info "Cycle floor interrupted by stop signal"
+            return 0
+        fi
+        sleep 30
+        slept=$((slept + 30))
+    done
+    return 0
+}
+
 # Daemon mode: infinite retry loop
 run_daemon() {
     local cycle=1
@@ -684,6 +714,8 @@ run_daemon() {
         write_cycle_separator "$cycle"
 
         # Run Claude
+        local cycle_start
+        cycle_start=$(date +%s)
         run_claude_once
         local exit_code=$?
 
@@ -698,6 +730,7 @@ run_daemon() {
                 consecutive_failures=0
                 # Reset pin-exhaust counter on success
                 rm -f "${REPO_ROOT:-.}/.loom/tokens/.pin-exhaust-count" 2>/dev/null
+                enforce_cycle_floor "$cycle_start"
                 cycle=$((cycle + 1))
                 continue
                 ;;
@@ -705,6 +738,7 @@ run_daemon() {
                 log_info "Daemon cycle $cycle: completed (hit ${CLAUDE_TIMEOUT}s timeout)"
                 backoff=$INITIAL_BACKOFF
                 consecutive_failures=0
+                enforce_cycle_floor "$cycle_start"
                 cycle=$((cycle + 1))
                 continue
                 ;;

--- a/scripts/herald/launch-agent.sh
+++ b/scripts/herald/launch-agent.sh
@@ -109,7 +109,7 @@ You are the **herald** agent for Lean Genius. Your mission is to post noteworthy
 All posting goes through `post-mathstodon.sh`. The script handles:
 - Posting to the Mastodon API
 - Updating state file (post history + daily counts) automatically
-- Rate limit enforcement (max 4 posts/day)
+- Rate limit enforcement (max 2 posts/day — a backstop, not a target; significance is the real gate)
 - Dedup checking (blocks posts with previously-used subject keys)
 - Appending `[automated post]` tag when `--automated` is set
 
@@ -191,12 +191,21 @@ find ${REPO_ROOT}/src/data/proofs -name "meta.json" -mmin -420 -type f 2>/dev/nu
 
 ### 6. Assess significance
 
-Apply the criteria from your role definition (herald.md):
-- **Tier 1 (always post)**: Full proof completion (0 axioms, 0 sorries), Freek 100 entry, soundness catch
-- **Tier 2 (if notable)**: Major axiom elimination (N→0), named theorem formalization
-- **Tier 3 (weekly max)**: Cumulative stats roundup
+**Default disposition: stand down.** On a typical cycle the correct action is to post NOTHING. The fleet completes many fully-verified proofs every day; "0 axioms, 0 sorries, fully verified" is the BASELINE of every gallery entry, not news. A result is NOT post-worthy just because it is verified, and NOT post-worthy just because it has a textbook name.
 
-Skip if nothing meets the threshold.
+Apply the full significance criteria from your role definition (herald.md) — that file is the source of truth and overrides any shorthand here. The bar for a **standalone post** is high; post only if a result CLEARLY clears one of:
+
+- **Infrastructure milestone** — a whole reusable library/suite reaches 0 sorries (not one theorem).
+- **Flagship pipeline progression** — the next stage of the Probabilistic Method → Regularity → Counting → Removal → Roth arc completes.
+- **Freek 100 entry** — a theorem from the Freek 100 list.
+- **Genuinely famous result** — a household-name theorem a working mathematician would recognize instantly AND be pleased to see formalized. A merely textbook-named result (a routine named lemma, a numbered Erdős-problem OQ extension) does NOT qualify on its name alone.
+- **Genuinely novel finding** — a soundness catch / counterexample that overturns a stated claim, a surprising cross-area connection, or a real proof-engineering lesson.
+
+If a result does not CLEARLY clear one of these, it is **roundup material, not a standalone post** — do not post it, and do not "queue" it to spend tomorrow's quota on. When in doubt, stand down: a cycle that posts nothing because nothing cleared the bar is a SUCCESSFUL cycle, not a failed one.
+
+Standing down because the daily cap is reached is a red flag — it means routine results were posted that should have gone to the weekly roundup. Aim to stand down for *lack of noteworthy results* far more often than for *hitting the cap*.
+
+**Weekly roundup (at most 1 per week):** routine-but-real named formalizations that did not clear the standalone bar are not lost — consolidate the best of them into a single themed roundup post (lead with pipeline progress, never raw counts). Before posting a roundup, check recent post history (`post-mathstodon.sh --status` and `${STATE_FILE}`) and only post one if a week has elapsed since the last roundup.
 
 ### 7. Verify the proof page is deployed (MANDATORY)
 
@@ -290,7 +299,7 @@ sleep ${INTERVAL}m
 
 ## Important Rules
 
-- **Max 1 post per cycle, max 4 posts per day**
+- **Max 1 post per cycle, max 2 posts per day (hard backstop)** — but prefer 0; post only when a result clearly clears the high bar in step 6. Hitting the cap should be rare.
 - **Max 3 replies per engagement scan** (replies also count toward daily post limit)
 - **Never post about**: build fixes, data syncs, enrichment batches, axiom decomposition
 - **Always use --subject** for every post (enables dedup)
@@ -351,8 +360,14 @@ launch_agent() {
     # (e.g. claude-fable-5) without affecting the rest of the pool.
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
     local herald_model="${HERALD_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
+    # Enforce the scan interval as a floor between cycles. The herald often stands
+    # down in seconds (nothing noteworthy, or daily cap reached); without a floor the
+    # wrapper would busy-loop and re-invoke Claude every ~40s, burning quota on no-ops.
+    # CYCLE_MIN_SECONDS makes the wrapper sleep the remainder of the interval after a
+    # successful cycle (default 0 elsewhere, so other agents are unaffected).
+    local cycle_min_seconds=$((INTERVAL * 60))
     tmux new-session -d -s "$SESSION_NAME" -c "$REPO_ROOT" \
-        "ENHANCER_ID=herald REPO_ROOT=$REPO_ROOT CLAUDE_MODEL=$herald_model $wrapper_script --daemon --prompt 'You are the herald agent. Read $prompt_file for your instructions, then start the scan loop.' --log '$LOG_FILE'"
+        "ENHANCER_ID=herald REPO_ROOT=$REPO_ROOT CLAUDE_MODEL=$herald_model CYCLE_MIN_SECONDS=$cycle_min_seconds $wrapper_script --daemon --prompt 'You are the herald agent. Read $prompt_file for your instructions, then start the scan loop.' --log '$LOG_FILE'"
 
     print_success "Launched herald agent"
     echo ""


### PR DESCRIPTION
Follow-up to #27147.

## What we observed after #27147
The herald dropped from 8 → **2 posts/day**, but it was **still gated by the cap, not significance** — exactly what we wanted to avoid. On 2026-06-21 it posted its 2 at the UTC reset (00:00, 00:02) on routine "0-axiom named theorem" results (Hall's marriage theorem, Davenport, n-ball volume), kept a **queue** of more "Tier-2" candidates, and stood down the rest of the day citing *"2/2 reached."* It also re-ran no-op cycles every **~40s**, burning quota.

## Root cause
The herald's *live* prompt is the heredoc in `scripts/herald/launch-agent.sh`, which still carried the **old criteria that contradicted the merged `herald.md`**:
- *"Tier 1 (always post): full proof completion (0 axioms, 0 sorries)"* — the loophole #27147 removed from herald.md was still here.
- *"Tier 2: named theorem formalization"* → drove the Hall/Davenport posts.
- stale *"max 4 posts/day"*.

The prompt undercut the role file, so the herald never adopted the high bar.

## Changes
**1. `launch-agent.sh` — bar + roundup**
Rewrote the in-prompt significance section to match `herald.md`: default to **stand down**; "0 axioms, 0 sorries, verified" is the **baseline of every entry, not news**; a textbook name doesn't qualify on its own. Standalone posts now require a clear hook (whole-library milestone, flagship pipeline step, Freek 100, a genuinely *famous* theorem, or a novel finding / soundness catch). Everything else → **weekly roundup**, not a queued post that spends tomorrow's quota. Fixed stale "4/day" → "2/day (backstop, not target)".

**2. Cadence fix — `claude-wrapper.sh` + `launch-agent.sh`**
`run_daemon` had **no inter-cycle sleep on success** — it relied on the agent's turn to consume the scan interval, but a herald stand-down returns in ~40s, so the wrapper busy-looped. Added a `CYCLE_MIN_SECONDS` floor (`enforce_cycle_floor`): after a successful/timed-out cycle that finished early, sleep the remainder in 30s slices (stop-signal responsive). **Default 0 → no change for continuously-working agents** (researchers). `launch-agent.sh` passes `CYCLE_MIN_SECONDS = INTERVAL*60` (6h) so the herald honors its scan interval.

## Net effect
The herald should now **stand down most cycles for lack of noteworthy results** (the stated goal), reserve standalone posts for genuinely famous/infrastructural/novel results, fold routine named work into a weekly roundup, and stop spinning no-op cycles.

## Testing
- `bash -n` passes on both scripts.
- `CYCLE_MIN_SECONDS` defaults to 0, so non-herald agents are provably unaffected.
- Requires a herald respawn to take effect (new prompt + new env); will restart after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)