### PR TITLE
audit: mark 2 newest gallery entries clean (Wirtinger equality, Davenport direct-sum)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17499,8 +17499,20 @@
       "lastAudited": "2026-06-21T08:16:01Z",
       "result": "clean",
       "issues": []
+    },
+    "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T08:35:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T08:35:05Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T09:00:00Z"
+  "lastUpdated": "2026-06-21T10:00:00Z"
 }


### PR DESCRIPTION
## Audit summary

Deep-audited the two never-audited gallery proofs at origin/main `c55dfa2a3bf` and persists their clean marks to `src/data/proofs/audit-tracker.json` (the only two gallery slugs absent from the tracker).

### area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-01 — Wirtinger equality case (PR #27294)
- 0 sorries, 0 `axiom` declarations, 0 `native_decide`.
- `FourierDecomp` structure is **not** assumption-smuggling: `fourier_decomp_exists` constructs it for any C¹ 2π-periodic `f` from the grandparent's axiom-free `IsoperimetricOQ.fourier_decomposition` (genuine theorem, 0 sorries/axioms in `AreaOfCircleOQ01OQ03.lean`).
- `status: verified`, `badge: original`, `axiomCount: 0` all defensible. **Clean.**

### erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03 — general direct-sum Davenport lower bound (PR #27295)
- 0 sorries, 0 `axiom`, 0 `native_decide`, no structures.
- Definitions (`HasZeroSumSubseq`, `DavenportSet`, `concatSeq`) are standard, not trivializing. Main theorem `davenport_directSum_lower` proves D(G₁⊕G₂) ≥ D(G₁)+D(G₂)−1 from `IsLeast (DavenportSet G) d` hypotheses.
- Diagonal special case honestly discloses that Olson's matching **upper** bound is not formalized. **Clean.**

`grep` hits for `sorry`/`admit` in both files were docstring false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)