### PR TITLE
research(erdos-131…oq-04-oq-03-oq-01): homogeneous-power Davenport lower bound D(Gⁿ)≥n·(D(G)−1)+1 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1218,6 +1218,7 @@ import Proofs.Erdos12ProblemAPNPartI
 import Proofs.Erdos12ProblemAPNPartII
 import Proofs.Erdos130Problem
 import Proofs.Erdos130WIP01
+import Proofs.Erdos131DavenportPower
 import Proofs.Erdos131Problem
 import Proofs.Erdos132Problem
 import Proofs.Erdos133Problem

--- a/proofs/Proofs/Erdos131DavenportPower.lean
+++ b/proofs/Proofs/Erdos131DavenportPower.lean
@@ -1,0 +1,210 @@
+/-
+  Erdős Problem #131 — Non-Dividing Sets
+  Follow-up (oq-01-oq-01-oq-01-oq-04-oq-03-oq-01): the homogeneous-power
+  Davenport lower bound
+
+      D(Gⁿ) ≥ n·(D(G) − 1) + 1            for an additive group G,
+
+  where `Gⁿ = Fin n → G` is the `n`-fold direct power.
+
+  Source: https://erdosproblems.com/131
+  Companion to:
+    * `Proofs.Erdos131DavenportDirectSum` — the BINARY direct-sum lower bound
+      `D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1`;
+    * `Proofs.Erdos131DavenportRank2`     — the rank-2 cyclic instance;
+    * `Proofs.Erdos131DavenportConstant`  — the exact cyclic value `D(ℤ/nℤ) = n`.
+
+  NOTE.  This file is deliberately SELF-CONTAINED (only `import Mathlib`); it does
+  not import the companions, which keeps it independently verifiable and
+  axiom-free.  The three small helper lemmas about `DavenportSet` are reproduced
+  here verbatim from the direct-sum companion.
+
+  ## What this file adds
+
+  Iterating the binary bound `D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1` over `n` copies of
+  `G` gives `D(Gⁿ) ≥ n·(D(G) − 1) + 1`.  Such an induction would, however, need
+  the Davenport constant of every intermediate power `Gᵏ` to exist (i.e.
+  `IsLeast` hypotheses at each stage), which forces a separate finiteness
+  argument.  Here we instead prove the bound in **one shot** with an explicit
+  extremal construction, the **power sequence** `powerSeq n f`.
+
+  Given a zero-sum-free sequence `f : Fin ℓ → G`, the power sequence is indexed by
+  `Fin n × Fin ℓ ≃ Fin (n·ℓ)` and sends `(i, k) ↦ Pi.single i (f k)` — i.e. it
+  places `f k` in coordinate `i` of `Gⁿ` and `0` elsewhere.  Evaluating any
+  candidate zero-sum subset coordinatewise turns the `j`-th coordinate of the
+  total into the sum of `f` over the slice `{k : (j, k) ∈ s}`; zero-sum-freeness
+  of `f` forces every slice empty, hence the subset empty.  So `powerSeq n f` is
+  a zero-sum-free sequence over `Gⁿ` of length `n·ℓ`; taking `ℓ = D(G) − 1`
+  yields the bound.
+
+  Specialising `G = ℤ/pℤ` with `D(ℤ/pℤ) = p` gives
+
+      D((ℤ/pℤ)ⁿ) ≥ n·(p − 1) + 1,
+
+  the lower-bound half of Olson's theorem for elementary abelian `p`-groups
+  (where equality in fact holds — the matching upper bound is a substantial
+  result not in Mathlib and not formalized here).
+
+  All results are unconditional and axiom-free.
+-/
+
+import Mathlib
+
+namespace Erdos131DavenportPower
+
+open Finset
+
+/-- A sequence `f : Fin m → G` *has a nonempty zero-sum subsequence* if some
+nonempty index set `s` has `∑ i ∈ s, f i = 0`. -/
+def HasZeroSumSubseq {G : Type*} [AddCommMonoid G] {m : ℕ} (f : Fin m → G) : Prop :=
+  ∃ s : Finset (Fin m), s.Nonempty ∧ ∑ i ∈ s, f i = 0
+
+/-- The **Davenport set** of `G`: the lengths `m` such that *every* length-`m`
+sequence over `G` has a nonempty zero-sum subsequence.  The Davenport constant
+`D(G)` is the least element of this set. -/
+def DavenportSet (G : Type*) [AddCommMonoid G] : Set ℕ :=
+  {m | ∀ f : Fin m → G, HasZeroSumSubseq f}
+
+/-- **The Davenport set is upward closed.** -/
+theorem davenport_set_mono {G : Type*} [AddCommMonoid G] {m m' : ℕ} (h : m ≤ m')
+    (hm : m ∈ DavenportSet G) : m' ∈ DavenportSet G := by
+  intro f
+  obtain ⟨s, hne, hsum⟩ := hm (fun i => f (Fin.castLE h i))
+  refine ⟨s.map (Fin.castLEEmb h), Finset.map_nonempty.mpr hne, ?_⟩
+  rw [Finset.sum_map]
+  simpa [Fin.coe_castLEEmb] using hsum
+
+/-- **Length `0` is never a Davenport length.** -/
+theorem zero_not_mem_davenportSet (G : Type*) [AddCommMonoid G] :
+    0 ∉ DavenportSet G := by
+  intro h
+  obtain ⟨s, hne, _⟩ := h (fun _ => 0)
+  obtain ⟨i, _⟩ := hne
+  exact absurd i.2 (by omega)
+
+/-- **The least Davenport length is positive.** -/
+theorem one_le_of_isLeast_davenport {G : Type*} [AddCommMonoid G] {d : ℕ}
+    (hd : IsLeast (DavenportSet G) d) : 1 ≤ d := by
+  rcases Nat.eq_zero_or_pos d with h0 | hpos
+  · exact absurd (h0 ▸ hd.1) (zero_not_mem_davenportSet G)
+  · exact hpos
+
+/-- **The power sequence.**  Given `f : Fin ℓ → G`, the sequence
+`powerSeq n f : Fin (n·ℓ) → (Fin n → G)` sends the index `x`, decoded as
+`(i, k) : Fin n × Fin ℓ` via `finProdFinEquiv`, to the vector `Pi.single i (f k)`
+— i.e. `f k` in coordinate `i` and `0` in all other coordinates. -/
+def powerSeq {G : Type*} [Zero G] {ℓ : ℕ} (n : ℕ) (f : Fin ℓ → G) :
+    Fin (n * ℓ) → (Fin n → G) :=
+  fun x => Pi.single (finProdFinEquiv.symm x : Fin n × Fin ℓ).1
+                     (f (finProdFinEquiv.symm x : Fin n × Fin ℓ).2)
+
+/-- **The power sequence is zero-sum-free.**  If `f` over `G` has no nonempty
+zero-sum subsequence, then neither does `powerSeq n f` over `Gⁿ`.
+
+A candidate zero-sum subset `s ⊆ Fin (n·ℓ)` is reindexed along
+`finProdFinEquiv : Fin n × Fin ℓ ≃ Fin (n·ℓ)` to `t ⊆ Fin n × Fin ℓ`.  The total
+sum is then `∑_{(i,k) ∈ t} Pi.single i (f k)`; reading off its `j`-th coordinate
+keeps only the terms with `i = j`, giving `∑_{k : (j,k) ∈ t} f k = 0` for every
+`j`.  Zero-sum-freeness of `f` forces each such slice empty, hence `t = ∅` and
+`s = ∅`, contradicting nonemptiness. -/
+theorem powerseq_not_hasZeroSum {G : Type*} [AddCommGroup G] {ℓ n : ℕ}
+    {f : Fin ℓ → G} (hf : ¬ HasZeroSumSubseq f) :
+    ¬ HasZeroSumSubseq (powerSeq n f) := by
+  rintro ⟨s, hne, hsum⟩
+  -- Reindex `s` along `Fin n × Fin ℓ ≃ Fin (n·ℓ)`.
+  set t : Finset (Fin n × Fin ℓ) := s.map finProdFinEquiv.symm.toEmbedding with ht
+  have hmap : t.map finProdFinEquiv.toEmbedding = s := by
+    rw [ht, Finset.map_map]; ext x; simp
+  rw [← hmap, Finset.sum_map] at hsum
+  simp only [Equiv.coe_toEmbedding, powerSeq, Equiv.symm_apply_apply] at hsum
+  -- `hsum : ∑ x ∈ t, Pi.single x.1 (f x.2) = 0`
+  -- For each coordinate `j`, the slice over `j` has vanishing sum.
+  have hcoord : ∀ j : Fin n,
+      ∑ x ∈ t, (Pi.single x.1 (f x.2) : Fin n → G) j = 0 := by
+    intro j
+    have h := congrFun hsum j
+    rwa [Finset.sum_apply, Pi.zero_apply] at h
+  have hslice : ∀ j : Fin n, ∑ x ∈ t.filter (fun x => j = x.1), f x.2 = 0 := by
+    intro j
+    have h := hcoord j
+    simp only [Pi.single_apply] at h
+    rwa [← Finset.sum_filter] at h
+  -- Zero-sum-freeness forces every slice (filter) empty.
+  have hfemp : ∀ j : Fin n, t.filter (fun x => j = x.1) = ∅ := by
+    intro j
+    by_contra hnz
+    obtain ⟨x0, hx0⟩ := Finset.nonempty_of_ne_empty hnz
+    -- The image of the slice under `Prod.snd` is a zero-sum subset of `f`.
+    have hinj : ∀ a ∈ t.filter (fun x => j = x.1),
+        ∀ b ∈ t.filter (fun x => j = x.1), a.2 = b.2 → a = b := by
+      intro a ha b hb hab
+      rw [Finset.mem_filter] at ha hb
+      have hfst : a.1 = b.1 := by rw [← ha.2, ← hb.2]
+      exact Prod.ext_iff.mpr ⟨hfst, hab⟩
+    set K := (t.filter (fun x => j = x.1)).image Prod.snd with hK
+    have hKsum : ∑ k ∈ K, f k = 0 := by
+      rw [hK, Finset.sum_image hinj]; exact hslice j
+    have hKne : K.Nonempty := ⟨x0.2, by rw [hK]; exact Finset.mem_image_of_mem _ hx0⟩
+    exact hf ⟨K, hKne, hKsum⟩
+  -- Hence `t = ∅`, so `s = ∅`, contradicting nonemptiness.
+  have htempty : t = ∅ := by
+    rw [Finset.eq_empty_iff_forall_notMem]
+    intro x hx
+    have hxmem : x ∈ t.filter (fun y => x.1 = y.1) :=
+      Finset.mem_filter.mpr ⟨hx, rfl⟩
+    rw [hfemp x.1] at hxmem
+    exact absurd hxmem (Finset.notMem_empty _)
+  have hsempty : s = ∅ := by rw [← hmap, htempty, Finset.map_empty]
+  exact absurd hne (hsempty ▸ Finset.not_nonempty_empty)
+
+/-- **Homogeneous-power Davenport lower bound: `D(Gⁿ) ≥ n·(D(G) − 1) + 1`.**
+
+Let `d = D(G)` and `dₙ = D(Gⁿ)` be the least Davenport lengths.  Since `d` is
+least, length `d − 1` admits a zero-sum-free sequence `f`.  Its power sequence
+`powerSeq n f` is a zero-sum-free sequence over `Gⁿ` of length `n·(d − 1)`, so
+that length is NOT a Davenport length.  Were `dₙ ≤ n·(d − 1)`, upward closure
+would make `n·(d − 1)` a Davenport length — contradiction.  Hence
+`dₙ ≥ n·(d − 1) + 1`. -/
+theorem davenport_pow_lower {G : Type*} [AddCommGroup G] {d dₙ n : ℕ}
+    (hG : IsLeast (DavenportSet G) d)
+    (hpow : IsLeast (DavenportSet (Fin n → G)) dₙ) :
+    n * (d - 1) + 1 ≤ dₙ := by
+  have hd1 : 1 ≤ d := one_le_of_isLeast_davenport hG
+  -- `d − 1` is below the least Davenport length, so a zero-sum-free `f` exists.
+  have hns : (d - 1) ∉ DavenportSet G := fun hmem => absurd (hG.2 hmem) (by omega)
+  rw [DavenportSet, Set.mem_setOf_eq, not_forall] at hns
+  obtain ⟨f, hf⟩ := hns
+  have hfree : ¬ HasZeroSumSubseq (powerSeq n f) := powerseq_not_hasZeroSum hf
+  by_contra hlt
+  push_neg at hlt
+  -- `dₙ ≤ n·(d − 1)`, so upward closure makes that length a Davenport length.
+  have hdle : dₙ ≤ n * (d - 1) := by omega
+  have hmem : (n * (d - 1)) ∈ DavenportSet (Fin n → G) :=
+    davenport_set_mono hdle hpow.1
+  exact hfree (hmem (powerSeq n f))
+
+/-- **Lower-bound half of Olson's theorem for elementary abelian `p`-groups.**
+Given the cyclic Davenport value `D(ℤ/pℤ) = p` (companion
+`Erdos131DavenportConstant`), the power bound specialises to
+
+    D((ℤ/pℤ)ⁿ) ≥ n·(p − 1) + 1.
+
+Equality in fact holds (Olson); the matching upper bound is not formalized. -/
+theorem davenport_elementary_abelian_lower {p n dₙ : ℕ}
+    (hp : IsLeast (DavenportSet (ZMod p)) p)
+    (hpow : IsLeast (DavenportSet (Fin n → ZMod p)) dₙ) :
+    n * (p - 1) + 1 ≤ dₙ :=
+  davenport_pow_lower hp hpow
+
+/-- **Recovering the binary diagonal bound.**  Taking `n = 2` gives
+`D(G²) ≥ 2·(D(G) − 1) + 1 = 2·D(G) − 1`, matching the diagonal special case of
+the binary direct-sum companion. -/
+theorem davenport_pow_two_lower {G : Type*} [AddCommGroup G] {d d₂ : ℕ}
+    (hG : IsLeast (DavenportSet G) d)
+    (hpow : IsLeast (DavenportSet (Fin 2 → G)) d₂) :
+    2 * d - 1 ≤ d₂ := by
+  have h := davenport_pow_lower (n := 2) hG hpow
+  have hd1 : 1 ≤ d := one_le_of_isLeast_davenport hG
+  omega
+
+end Erdos131DavenportPower

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01/knowledge.md
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01/knowledge.md
@@ -1,0 +1,94 @@
+# Erdős #131 — Homogeneous-Power Davenport Lower Bound `D(Gⁿ) ≥ n·(D(G) − 1) + 1`
+
+**Slug:** `erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01`
+**Lean file:** `proofs/Proofs/Erdos131DavenportPower.lean` (namespace `Erdos131DavenportPower`)
+**Status:** verified · 0 axioms · 0 sorries · 7 theorems · 3 definitions · 210 lines
+
+## Summary
+
+The **Davenport constant** `D(G)` of an additive group `G` is the least `d` such that
+every length-`d` sequence over `G` has a nonempty zero-sum subsequence. The cyclic value
+`D(ℤ/nℤ) = n` is elementary (companion `erdos-131-oq-01-oq-01-oq-01-oq-03`); the binary
+direct-sum lower bound `D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1` (companion
+`erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03`) proves the structural concatenation principle
+behind it.
+
+This entry proves the **homogeneous-power** lower bound for the `n`-fold direct power
+`Gⁿ = (Fin n → G)`:
+
+> `davenport_pow_lower : IsLeast (DavenportSet G) d → IsLeast (DavenportSet (Fin n → G)) dₙ → n·(d − 1) + 1 ≤ dₙ`.
+
+It is the homogeneous case of the iterated Olson–Davenport lower bound, and it directly
+advances the open question `oq-04-oq-03-oq-01` of the binary companion (lifting the binary
+concatenation to a k-fold direct sum). The key design choice: it is proved in **one shot**
+with a single explicit extremal construction, so it needs only `IsLeast` for `G` and for
+`Gⁿ` — **not** the per-stage `IsLeast` for every intermediate power `Gᵏ` that an induction
+on the binary bound would require (which in turn would need a separate finiteness argument).
+
+Specializing `D(ℤ/pℤ) = p` gives `D((ℤ/pℤ)ⁿ) ≥ n·(p − 1) + 1`, the **lower-bound half of
+Olson's theorem** for elementary abelian `p`-groups (equality holds; the matching upper
+bound — Olson's Chevalley–Warning argument — is not formalized).
+
+## The engine: power-concatenation principle
+
+`powerseq_not_hasZeroSum`: if `f : Fin ℓ → G` is zero-sum-free, then so is
+`powerSeq n f : Fin (n·ℓ) → (Fin n → G)`, where
+
+    powerSeq n f x = Pi.single (finProdFinEquiv.symm x).1 (f (finProdFinEquiv.symm x).2)
+
+i.e. the index `x` is decoded as `(i, k) : Fin n × Fin ℓ` and mapped to the vector with
+`f k` in coordinate `i` and `0` elsewhere.
+
+Proof outline:
+1. Reindex a candidate zero-sum set `s ⊆ Fin (n·ℓ)` along `finProdFinEquiv` to
+   `t ⊆ Fin n × Fin ℓ`; the total becomes `∑_{(i,k) ∈ t} Pi.single i (f k) = 0`.
+2. Read off coordinate `j` (`congrFun` + `Finset.sum_apply` + `Pi.single_apply`): the
+   `j`-th coordinate keeps only terms with `i = j`, giving (after `Finset.sum_filter`)
+   `∑_{x ∈ t.filter (j = ·.1)} f x.2 = 0` for every `j`.
+3. The slice maps injectively under `Prod.snd` (first coordinate fixed `= j`), so
+   `Finset.sum_image` turns the slice sum into `∑_{k ∈ K} f k = 0` over a genuine
+   `K : Finset (Fin ℓ)`; zero-sum-freeness of `f` forces `K = ∅`, hence the slice empty.
+4. Every slice empty ⟹ `t = ∅` ⟹ `s = ∅`, contradicting nonemptiness.
+
+`davenport_pow_lower` then takes `f` of length `D(G) − 1` (exists since `D(G)` is least),
+notes `powerSeq n f` is a zero-sum-free sequence of length `n·(D(G) − 1)` over `Gⁿ`, so
+that length is not a Davenport length; upward closure (`davenport_set_mono`) forces
+`dₙ ≥ n·(D(G) − 1) + 1`.
+
+## Corollaries
+
+- `davenport_elementary_abelian_lower`: `D((ℤ/pℤ)ⁿ) ≥ n·(p − 1) + 1` (sharp; Olson).
+- `davenport_pow_two_lower`: `D(G²) ≥ 2·D(G) − 1` (matches the binary diagonal case).
+
+## Session log
+
+### Session 2026-06-21 (s01) — FRESH-style follow-up (pool empty → REVISIT)
+
+**Mode:** REVISIT (candidate pool has no `available` status). Chosen as a depth follow-up
+to my merged binary direct-sum entry (`oq-04-oq-03`, PR #27295), answering its open
+question `oq-04-oq-03-oq-01` for the homogeneous case.
+
+**What I did**
+- Wrote `Erdos131DavenportPower.lean` from scratch (self-contained, `import Mathlib`),
+  reproducing the three small `DavenportSet` helpers from the binary companion.
+- New construction `powerSeq` + new engine lemma `powerseq_not_hasZeroSum` using a
+  product reindexing (`finProdFinEquiv`) and coordinatewise slice analysis
+  (`Pi.single_apply`, `Finset.sum_apply`, `Finset.sum_filter`, `Finset.sum_image`).
+- Built clean via docker wrapper; verified `#print axioms` shows only
+  `propext, Classical.choice, Quot.sound` for both headline theorems (0-axiom).
+
+**Key findings / gotchas**
+- `simp only [Equiv.coe_toEmbedding, powerSeq, Equiv.symm_apply_apply]` cleanly unfolds the
+  reindexed summand to `Pi.single x.1 (f x.2)` (def `powerSeq` unfolds under `simp only`).
+- `Finset.sum_image` wants the `∀ a ∈ s, ∀ b ∈ s, g a = g b → a = b` membership form (not
+  `Set.InjOn`); injectivity of `Prod.snd` on the slice comes from the fixed first coord.
+- v4.26.0 deprecations: use `Finset.eq_empty_iff_forall_notMem` and `Finset.notMem_empty`.
+
+**Outcome:** completed — shipped verified 0-axiom entry.
+
+**Next steps**
+- The fully general indexed direct sum `⨁_{i:Fin k} Gᵢ` (distinct factors) via a Σ-type
+  index `Σ i, Fin (ℓ i)` and dependent `Pi.single` over `finSigmaFinEquiv` — does the
+  one-shot argument lift? (open question `…-oq-01-oq-01`).
+- Upper half for elementary abelian groups via Mathlib's Chevalley–Warning
+  (open question `…-oq-01-oq-02`).

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01",
+  "slug": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos131DavenportPower",
+    "lineCount": 210,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos131DavenportPower.lean",
+    "sorries": 0
+  },
+  "title": "The Homogeneous-Power Davenport Lower Bound D(Gⁿ) ≥ n·(D(G) − 1) + 1 (Erdős #131)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos131DavenportPower.lean",
+    "tags": [
+      "number-theory",
+      "additive-combinatorics",
+      "erdos-problems",
+      "erdos-131",
+      "davenport-constant",
+      "zero-sum-free",
+      "zero-sum-subsequence",
+      "direct-power",
+      "elementary-abelian",
+      "olson-theorem",
+      "isleast",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 210,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "badge": "original",
+    "originalContributions": [
+      "davenport_pow_lower: the headline result — for an arbitrary additive group G the Davenport constant of the n-fold direct power Gⁿ = (Fin n → G) satisfies D(Gⁿ) ≥ n·(D(G) − 1) + 1, formalized via IsLeast of the Davenport-length sets. This is the homogeneous case of the iterated Olson–Davenport lower bound; it advances the open question oq-04-oq-03-oq-01 of the binary direct-sum companion (lifting the binary concatenation to a k-fold direct sum) for the homogeneous family. Crucially it is proved in ONE shot, needing only IsLeast (DavenportSet G) and IsLeast (DavenportSet Gⁿ) as hypotheses — no per-stage finiteness/IsLeast for the intermediate powers Gᵏ that an induction on the binary bound would require.",
+      "powerseq_not_hasZeroSum: the engine — the POWER-CONCATENATION principle for zero-sum-free sequences. If f : Fin ℓ → G has no nonempty zero-sum subsequence, then powerSeq n f : Fin (n·ℓ) → (Fin n → G) has none either. Proof: a candidate zero-sum index set s ⊆ Fin (n·ℓ) is reindexed along finProdFinEquiv : Fin n × Fin ℓ ≃ Fin (n·ℓ) to t ⊆ Fin n × Fin ℓ; the total is ∑_{(i,k) ∈ t} Pi.single i (f k), whose j-th coordinate (Finset.sum_apply, Pi.single_apply) keeps only the terms with i = j and equals ∑ over the slice {(j,k) ∈ t} of f k. Each slice sum vanishes; reindexing the slice by Prod.snd (injective there, Finset.sum_image) makes it a zero-sum subset of f, forced empty by zero-sum-freeness. Every slice empty ⟹ t = ∅ ⟹ s = ∅, contradicting nonemptiness.",
+      "powerSeq: the abstract n-fold power construction — powerSeq n f sends the index x, decoded as (i, k) : Fin n × Fin ℓ via finProdFinEquiv, to the vector Pi.single i (f k) (place f k in coordinate i of Gⁿ, 0 elsewhere). The single explicit extremal sequence whose length n·(D(G)−1) certifies the bound, generalizing the binary concatSeq of the parent.",
+      "davenport_elementary_abelian_lower: feeding the cyclic value D(ℤ/pℤ) = p gives D((ℤ/pℤ)ⁿ) ≥ n·(p − 1) + 1 — the lower-bound half of Olson's theorem for elementary abelian p-groups, where equality in fact holds (the matching upper bound is not formalized).",
+      "davenport_pow_two_lower: the n = 2 specialization D(G²) ≥ 2·D(G) − 1, matching the diagonal special case of the binary direct-sum companion (davenport_directSum_diag_lower) but obtained directly from the power construction.",
+      "davenport_set_mono, zero_not_mem_davenportSet, one_le_of_isLeast_davenport: the upward-closure of the Davenport set and positivity of the least Davenport length (reproduced verbatim from the binary companion to keep the file self-contained), the small facts that let D(G) − 1 be a genuine zero-sum-free length."
+    ],
+    "prerequisites": [
+      "finProdFinEquiv (Mathlib): the equivalence Fin m × Fin n ≃ Fin (m·n); the product reindexing that turns a subset of the power index Fin (n·ℓ) into a subset of Fin n × Fin ℓ, splitting each candidate zero-sum set into per-coordinate slices.",
+      "Pi.single and Pi.single_apply (Mathlib): the standard-basis vector Pi.single i v with (Pi.single i v) j = if j = i then v else 0; the building block placing f k in a single coordinate of Gⁿ and the evaluation that isolates the i = j slice.",
+      "Finset.sum_apply: (∑ x ∈ s, g x) j = ∑ x ∈ s, g x j for a Finset sum of functions, used to read off coordinate j of the vanishing total.",
+      "Finset.sum_filter and Finset.sum_image: rewrite ∑ (if p x then …) as a sum over a filter, and a sum over an image as a sum over the source under an injection — together turning the j-th coordinate condition into a genuine zero-sum subset of f.",
+      "IsLeast (Mathlib): the order-theoretic packaging of the Davenport constant as the least Davenport length, shared with the cyclic, rank-2 and binary direct-sum companions."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "finProdFinEquiv",
+        "description": "Equivalence Fin m × Fin n ≃ Fin (m·n). The reindexing along which a candidate zero-sum subset of the power index is split into per-coordinate slices; powerSeq is defined through its inverse.",
+        "module": "Mathlib.Logic.Equiv.Fin.Basic"
+      },
+      {
+        "theorem": "Pi.single_apply",
+        "description": "(Pi.single i v) j = if j = i then v else 0. Evaluating the power sequence's vector at coordinate j keeps the term only when the block index equals j, isolating the slice over j.",
+        "module": "Mathlib.Data.Pi.Algebra"
+      },
+      {
+        "theorem": "Finset.sum_apply",
+        "description": "(∑ x ∈ s, g x) j = ∑ x ∈ s, g x j for a sum of functions into a Pi type. Reads coordinate j of the vanishing total ∑ Pi.single x.1 (f x.2) = 0.",
+        "module": "Mathlib.Algebra.BigOperators.Pi"
+      },
+      {
+        "theorem": "Finset.sum_filter",
+        "description": "∑ x ∈ s.filter p, g x = ∑ x ∈ s, if p x then g x else 0. Converts the coordinate-j sum (with its if-then-else from Pi.single_apply) into a sum over the slice filter {x : j = x.1}.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_image",
+        "description": "∑ b ∈ s.image g, h b = ∑ a ∈ s, h (g a) when g is injective on s. With g = Prod.snd (injective on a slice where the first coordinate is fixed) it identifies the slice sum with a sum over a genuine Finset of indices of f, exhibiting a zero-sum subset.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01-oq-01",
+      "question": "This entry handles the HOMOGENEOUS power Gⁿ = (Fin n → G) with a single product-index reindexing finProdFinEquiv. The fully general indexed direct sum ⨁_{i : Fin k} Gᵢ with distinct factors needs a Σ-type index Σ i, Fin (ℓ i) and dependent Pi.single. Does the one-shot powerSeq argument lift verbatim to a sigmaSeq over finSigmaFinEquiv : (Σ i, Fin (ℓ i)) ≃ Fin (Σ ℓ i) — giving D(⨁ᵢ Gᵢ) ≥ 1 + Σ(D(Gᵢ) − 1) without per-stage IsLeast — or does the dependent encoding force genuinely different bookkeeping?",
+      "significance": "medium"
+    },
+    {
+      "id": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01-oq-02",
+      "question": "For elementary abelian p-groups the bound D((ℤ/pℤ)ⁿ) ≥ n·(p − 1) + 1 is SHARP (Olson). The matching upper bound D((ℤ/pℤ)ⁿ) ≤ n·(p − 1) + 1 — i.e. every length n(p−1)+1 sequence over (ℤ/pℤ)ⁿ has a nonempty zero-sum subsequence — has an elementary proof for n = 1 (already formalized: D(ℤ/pℤ) = p) but the general p-group case uses the group-algebra / Chevalley–Warning argument. Is the n-variable Chevalley–Warning vanishing-of-power-sums step formalizable in Mathlib (which has Chevalley–Warning) to close the upper half for elementary abelian groups?",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03",
+      "relationship": "extends",
+      "description": "Advances that entry's open question oq-04-oq-03-oq-01 (lifting the binary concatenation to a k-fold direct sum) for the homogeneous family Gⁿ. Where the binary bound D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1 would need per-stage IsLeast hypotheses for every intermediate power to iterate, the powerSeq construction here gives D(Gⁿ) ≥ n·(D(G) − 1) + 1 in one step using a single product reindexing finProdFinEquiv in place of the binary finSumFinEquiv split."
+    },
+    {
+      "targetId": "erdos-131-oq-01-oq-01-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "Uses the exact cyclic Davenport constant D(ℤ/nℤ) = n from that entry as the input D(G) for the elementary-abelian specialization D((ℤ/pℤ)ⁿ) ≥ n·(p − 1) + 1."
+    },
+    {
+      "targetId": "erdos-131",
+      "relationship": "extends",
+      "description": "Supplies the homogeneous-power case of the Olson–Davenport lower bound for the additive-combinatorial constant governing non-dividing sets in the parent Erdős #131 study, as reusable axiom-free infrastructure Mathlib lacks."
+    }
+  ],
+  "references": [
+    {
+      "title": "A combinatorial problem on finite Abelian groups, I",
+      "author": "John E. Olson",
+      "year": "1969",
+      "venue": "J. Number Theory",
+      "description": "Proves D((ℤ/pℤ)ⁿ) = n·(p − 1) + 1 for elementary abelian p-groups; the lower-bound half formalized here is exactly the zero-sum-free power-sequence construction, and the matching upper bound is Olson's Chevalley–Warning argument."
+    },
+    {
+      "title": "On Davenport's constant",
+      "author": "various (survey)",
+      "year": "2006",
+      "venue": "Expo. Math. / survey",
+      "description": "The Davenport constant D(G) is the least d such that every length-d sequence over G has a nonempty zero-sum subsequence; iterating the concatenation of zero-sum-free sequences across a direct power gives the standard lower bound, sharp for p-groups."
+    },
+    {
+      "title": "On some problems in combinatorial number theory",
+      "author": "Paul Erdős",
+      "year": "1975",
+      "venue": "Er75b",
+      "description": "Erdős's problem #131 on non-dividing sets; the Davenport constant is the invariant behind the per-element size bounds, and its direct-power lower bound is the higher-rank generalization of the cyclic case."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For an arbitrary additive group G, the Davenport constant of the n-fold direct power Gⁿ = (Fin n → G) satisfies D(Gⁿ) ≥ n·(D(G) − 1) + 1 (davenport_pow_lower, with D stated as the least Davenport length via IsLeast). The proof rests on the power-concatenation principle powerseq_not_hasZeroSum: given a zero-sum-free sequence f over G of length D(G) − 1, the power sequence powerSeq n f over Gⁿ (which places f k in coordinate i for the index decoded as (i,k) via finProdFinEquiv) is zero-sum-free — a candidate zero-sum index set is reindexed into Fin n × Fin ℓ, and reading off coordinate j (Finset.sum_apply, Pi.single_apply, Finset.sum_filter) turns the vanishing total into the slice sum ∑ over {(j,k) ∈ t} of f k, which Finset.sum_image identifies with a zero-sum subset of f, forced empty; all slices empty ⟹ the set is empty. Upward closure of the Davenport set (davenport_set_mono) then pushes the length n·(D(G)−1) out of the Davenport set, giving the bound. Specializations recover the elementary abelian value D((ℤ/pℤ)ⁿ) ≥ n·(p − 1) + 1 and the n = 2 diagonal D(G²) ≥ 2·D(G) − 1. 210 lines, 7 theorems, 3 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The entry isolates the homogeneous case of the iterated Olson–Davenport lower bound and proves it with a single explicit construction rather than an induction on the binary bound, so it needs no finiteness argument for the intermediate powers. The elementary abelian specialization D((ℤ/pℤ)ⁿ) ≥ n·(p − 1) + 1 is the sharp lower half of Olson's classical p-group theorem; the matching upper bound (Olson's Chevalley–Warning argument) remains the deep open piece. The product-index Pi.single / finProdFinEquiv encoding supplies reusable direct-power zero-sum-free infrastructure complementing the binary toLeft/toRight machinery of the parent entry."
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to the merged binary direct-sum entry (`erdos-131-…-oq-04-oq-03`, PR #27295), answering its open question **oq-04-oq-03-oq-01** for the homogeneous case.

For an arbitrary additive group `G`, the Davenport constant of the `n`-fold direct power `Gⁿ = (Fin n → G)` satisfies

> **D(Gⁿ) ≥ n·(D(G) − 1) + 1**  (`davenport_pow_lower`, D = least Davenport length via `IsLeast`).

Specializing `D(ℤ/pℤ) = p` gives **D((ℤ/pℤ)ⁿ) ≥ n·(p − 1) + 1** — the sharp lower-bound half of **Olson's theorem** for elementary abelian `p`-groups (`davenport_elementary_abelian_lower`).

## What's new vs. the binary companion

- New construction **`powerSeq n f`**: decode the index via `finProdFinEquiv : Fin n × Fin ℓ ≃ Fin (n·ℓ)` as `(i,k)` and emit `Pi.single i (f k)` (place `f k` in coordinate `i` of `Gⁿ`, `0` elsewhere).
- New engine **`powerseq_not_hasZeroSum`**: the power-concatenation principle — coordinatewise slice analysis (`Finset.sum_apply`, `Pi.single_apply`, `Finset.sum_filter`, `Finset.sum_image`) forces each per-coordinate slice empty.
- Proved in **one shot**: needs only `IsLeast` for `G` and `Gⁿ`, **not** the per-stage `IsLeast`/finiteness an induction on the binary bound would require.

## Verification

- Builds clean via the docker wrapper (`Proofs.Erdos131DavenportPower`).
- `#print axioms` for both headline theorems → only `propext, Classical.choice, Quot.sound`.
- **210 lines · 7 theorems · 3 definitions · 0 axioms · 0 sorries.**

## Files
- `proofs/Proofs/Erdos131DavenportPower.lean` (new, self-contained)
- `proofs/Proofs.lean` (import added)
- `src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01/{meta.json,knowledge.md}` (gallery entry, verified/original badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)