### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01): full isoperimetric inequality for regular curves assembled 0-axiom

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01Iso.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01Iso.lean
@@ -1,0 +1,172 @@
+/-
+  The full isoperimetric inequality `C² ≥ 4πA` for regular closed plane curves,
+  assembled 0-axiom from the five analytic ingredients discharged in the sibling
+  companion files.
+
+  Open Question: area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01
+
+  ## Context
+
+  The parent entry `AreaOfCircleOQ01OQ02OQ02OQ01.lean` (`namespace IsoperimetricFromFourier`)
+  proves Hurwitz's 1901 isoperimetric inequality `C² ≥ 4πA` for smooth closed curves from
+  **five disclosed axioms** isolating its analytic content:
+
+    1. `fourier_decomp_exists`        — Parseval + IBP for periodic C¹ functions
+    2. `exists_nice_reparam`          — arc-length reparametrization (inverse function theorem)
+    3. `wirtinger_sum_bound`          — Wirtinger's inequality on the coordinate functions
+    4. `area_cauchy_schwarz_bound`    — Green's theorem + pointwise 2D Cauchy–Schwarz
+    5. `integral_cauchy_schwarz_sq`   — the L² Cauchy–Schwarz on `[0, 2π]`
+
+  Prior sessions discharged **all five** 0-axiom, but each in an isolated standalone file:
+
+    * `…OQ01OQ01IFT.lean`         — `RegularClosedCurve.exists_nice_reparam_for_regular`
+                                    (axiom 2 on the regular locus, via the IFT)
+    * `…OQ01OQ01Fourier.lean`    — `IsoperimetricFourier.wirtinger_sum_bound`
+                                    (axioms 1 + 3, via Parseval)
+    * `…OQ01OQ01CauchySchwarz.lean` — `IsoperimetricCauchySchwarz.area_cauchy_schwarz_bound_contDiff`
+                                    and `integral_cauchy_schwarz_sq` (axioms 4 + 5)
+
+  **This file is the capstone**: it wires those three discharged pieces together — through
+  the same purely-algebraic arithmetic kernel the parent uses — to obtain the *complete*
+  isoperimetric inequality with **zero axioms**:
+
+  `isoperimetric_inequality_regular` — for every regular closed plane curve `γ` with positive
+  circumference, `4π·area ≤ circumference²`.
+
+  ## Honest scope
+
+  The result is stated for `RegularClosedCurve` (C¹, 2π-periodic, nowhere-vanishing speed),
+  not the parent's `SmoothClosedCurve`. This is the *maximal honest target*: the parent axiom
+  `exists_nice_reparam` is genuinely **false** for non-regular curves — a curve with a
+  stationary point (`γ'(t) = 0`) has a non-strictly-monotone arc-length map and the inverse
+  function theorem gives no C¹ inverse (Gap 1, established in session s01 and unchanged since).
+  So `C² ≥ 4πA` for *all* smooth closed curves cannot be obtained by this Fourier/IFT route
+  without an additional limiting argument; on the regular locus, where the route is valid, this
+  file delivers the inequality entirely axiom-free.
+
+  Unlike the parent, this file imports **none** of the axiomatized infrastructure — only the
+  three 0-axiom sibling companions (and `Mathlib`). The arithmetic kernel is reproved inline
+  (the parent's copy lives in the bit-rotted parent file, which does not build on Mathlib
+  v4.26.0).
+
+  ## Sorries: 0   Axioms: 0
+-/
+import Mathlib
+import Proofs.AreaOfCircleOQ01OQ02OQ02OQ01OQ01IFT
+import Proofs.AreaOfCircleOQ01OQ02OQ02OQ01OQ01Fourier
+import Proofs.AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz
+
+open Real MeasureTheory intervalIntegral
+
+namespace IsoperimetricRegular
+
+open RegularCurveArcLength
+
+noncomputable section
+
+/-! ### The arithmetic kernel (purely algebraic)
+
+Given the four analytic bounds, the isoperimetric inequality is pure arithmetic:
+`S² ≤ 2π·Sxy ≤ 2π·(2πc²) = (2πc)²`, so `S ≤ 2πc`; then `2A ≤ c·S ≤ 2πc²`, hence
+`4πA ≤ 4π²c² = (2πc)² = L²`. No integrals or measures appear. (Reproved inline rather than
+imported from the bit-rotted parent file.) -/
+theorem isoperimetric_arithmetic_kernel
+    (A L c S Sxy : ℝ)
+    (hc : 0 < c)
+    (hcirc : L = 2 * π * c)
+    (hS_nn : 0 ≤ S)
+    (harea : 2 * A ≤ c * S)
+    (hCS : S ^ 2 ≤ 2 * π * Sxy)
+    (hWirt : Sxy ≤ 2 * π * c ^ 2) :
+    4 * π * A ≤ L ^ 2 := by
+  have hpi : (0 : ℝ) < π := pi_pos
+  have h2pic_pos : (0 : ℝ) < 2 * π * c := by positivity
+  have hS2 : S ^ 2 ≤ (2 * π * c) ^ 2 :=
+    calc S ^ 2 ≤ 2 * π * Sxy := hCS
+      _ ≤ 2 * π * (2 * π * c ^ 2) := mul_le_mul_of_nonneg_left hWirt (by linarith)
+      _ = (2 * π * c) ^ 2 := by ring
+  have hS_bound : S ≤ 2 * π * c := by
+    have h := Real.sqrt_le_sqrt hS2
+    rwa [Real.sqrt_sq hS_nn, Real.sqrt_sq h2pic_pos.le] at h
+  have h1 : c * S ≤ 2 * π * c ^ 2 := by nlinarith
+  have h2 : 2 * A ≤ 2 * π * c ^ 2 := le_trans harea h1
+  calc 4 * π * A = 2 * π * (2 * A) := by ring
+    _ ≤ 2 * π * (2 * π * c ^ 2) := mul_le_mul_of_nonneg_left h2 (by linarith)
+    _ = (2 * π * c) ^ 2 := by ring
+    _ = L ^ 2 := by rw [hcirc]
+
+/-! ### The full isoperimetric inequality for regular closed curves -/
+
+/-- **The Isoperimetric Inequality for regular closed curves** (Hurwitz 1901), 0-axiom.
+
+For any regular closed plane curve `γ` (C¹, 2π-periodic, nowhere-vanishing speed) with positive
+circumference `C` and signed area `A`,
+  `4π·A ≤ C²`,
+with equality for the circle.
+
+Proof. Reparametrize `γ` to a constant-speed (`c = C/2π`), zero-mean regular closed curve `ρ`
+with the same circumference and area (`exists_nice_reparam_for_regular`, the IFT discharge of
+axiom 2). On `ρ`:
+* Wirtinger (`wirtinger_sum_bound`, axioms 1+3) gives `∫(x²+y²) ≤ 2πc²`;
+* Cauchy–Schwarz (`area_cauchy_schwarz_bound_contDiff`, axiom 4) gives `2A = |∫(x·y'−y·x')| ≤ c·∫√(x²+y²)`;
+* the L² Cauchy–Schwarz (`integral_cauchy_schwarz_sq`, axiom 5) gives `(∫√(x²+y²))² ≤ 2π·∫(x²+y²)`.
+The arithmetic kernel chains these to `4π·A ≤ C²`; transferring across the area/circumference
+preservation of the reparametrization gives the result for `γ`. -/
+theorem isoperimetric_inequality_regular (γ : RegularClosedCurve)
+    (hL : 0 < γ.circumference) :
+    4 * π * γ.area ≤ γ.circumference ^ 2 := by
+  -- Step 1: constant-speed, zero-mean reparametrization (same circumference and area).
+  obtain ⟨ρ, hcirc, harea, hspeed, hzx, hzy⟩ :=
+    RegularClosedCurve.exists_nice_reparam_for_regular γ hL
+  -- Step 2: the constant speed c = L / (2π).
+  set c := γ.circumference / (2 * π) with hc_def
+  have hc_pos : 0 < c := div_pos hL (by positivity)
+  -- Step 3: the three analytic bounds, on ρ.
+  have hWirt : ∫ t in (0 : ℝ)..(2 * π), (ρ.x t ^ 2 + ρ.y t ^ 2) ≤ 2 * π * c ^ 2 :=
+    IsoperimetricFourier.wirtinger_sum_bound ρ.x ρ.y ρ.smooth_x ρ.smooth_y
+      ρ.periodic_x ρ.periodic_y c hc_pos hspeed hzx hzy
+  have hArea2 :
+      |∫ t in (0 : ℝ)..(2 * π), (ρ.x t * deriv ρ.y t - ρ.y t * deriv ρ.x t)| ≤
+        c * ∫ t in (0 : ℝ)..(2 * π), √(ρ.x t ^ 2 + ρ.y t ^ 2) :=
+    IsoperimetricCauchySchwarz.area_cauchy_schwarz_bound_contDiff ρ.x ρ.y c hc_pos.le
+      ρ.smooth_x ρ.smooth_y hspeed
+  have hCS :
+      (∫ t in (0 : ℝ)..(2 * π), √(ρ.x t ^ 2 + ρ.y t ^ 2)) ^ 2 ≤
+        2 * π * ∫ t in (0 : ℝ)..(2 * π), (ρ.x t ^ 2 + ρ.y t ^ 2) :=
+    IsoperimetricCauchySchwarz.integral_cauchy_schwarz_sq ρ.x ρ.y
+      ρ.continuous_x ρ.continuous_y
+  -- Step 4: name the two integrals S and Sxy.
+  set S := ∫ t in (0 : ℝ)..(2 * π), √(ρ.x t ^ 2 + ρ.y t ^ 2) with hS_def
+  set Sxy := ∫ t in (0 : ℝ)..(2 * π), (ρ.x t ^ 2 + ρ.y t ^ 2) with hSxy_def
+  -- Step 5: S ≥ 0.
+  have hS_nn : 0 ≤ S := by
+    rw [hS_def]
+    apply intervalIntegral.integral_nonneg (by positivity)
+    intro t _
+    exact Real.sqrt_nonneg _
+  -- Step 6: 2·(ρ.area) = |∫(x·y' − y·x')|, so 2·(ρ.area) ≤ c·S.
+  have h2area :
+      2 * ρ.area = |∫ t in (0 : ℝ)..(2 * π), (ρ.x t * deriv ρ.y t - ρ.y t * deriv ρ.x t)| := by
+    simp only [RegularClosedCurve.area]; ring
+  have harea' : 2 * ρ.area ≤ c * S := by rw [h2area]; exact hArea2
+  -- Step 7: L = 2πc.
+  have hL_eq : γ.circumference = 2 * π * c := by
+    rw [hc_def]; field_simp
+  -- Step 8: the arithmetic kernel, then transfer across the reparametrization.
+  have key : 4 * π * ρ.area ≤ γ.circumference ^ 2 :=
+    isoperimetric_arithmetic_kernel ρ.area γ.circumference c S Sxy
+      hc_pos hL_eq hS_nn harea' hCS hWirt
+  rwa [harea] at key
+
+/-- **Isoperimetric ratio form**: for a regular closed curve with positive area, the
+isoperimetric ratio `C² / (4πA)` is at least `1`. -/
+theorem isoperimetric_ratio_ge_one (γ : RegularClosedCurve)
+    (hL : 0 < γ.circumference) (hA : 0 < γ.area) :
+    1 ≤ γ.circumference ^ 2 / (4 * π * γ.area) := by
+  have hden : 0 < 4 * π * γ.area := by positivity
+  rw [le_div_iff₀ hden, one_mul]
+  linarith [isoperimetric_inequality_regular γ hL]
+
+end
+
+end IsoperimetricRegular

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/knowledge.md
@@ -413,3 +413,69 @@ five** analytic axioms of the Hurwitz isoperimetric proof are now discharged 0-a
 reparam-on-regular, s06 ×2 Cauchy–Schwarz, s07 ×2 Fourier). A fully axiom-free parent file is a
 separate mechanic task: bridge raw-function ↔ `SmoothClosedCurve`, add a regularity field for
 `exists_nice_reparam` (Gap-1), and un-rot the parent (#27276).
+
+### Session 2026-06-21 (s08, ACT, researcher-8) — CAPSTONE: full isoperimetric inequality for regular curves assembled 0-axiom
+
+**Outcome: ACT — the complete inequality `4πA ≤ C²` is now proved 0-axiom by wiring the five
+discharged pieces together.** Sessions s05–s07 discharged all five parent axioms 0-axiom but
+each in an *isolated* standalone file with nothing combining them. This session supplies the
+missing integration: new file `proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01Iso.lean`
+(`namespace IsoperimetricRegular`, ~170 LOC, 3 theorems, **0 axioms, 0 sorries**, docker GREEN
+7749 jobs on v4.26.0; `#print axioms` = `[propext, Classical.choice, Quot.sound]` for both
+headline results — no `ofReduceBool`/`sorryAx`).
+
+**`isoperimetric_inequality_regular`** — for every `RegularClosedCurve γ` with `0 < circumference`,
+`4 * π * γ.area ≤ γ.circumference ^ 2`. Plus the ratio form `isoperimetric_ratio_ge_one`
+(`1 ≤ C²/(4πA)` for positive area).
+
+**Assembly (no new analysis, pure plumbing + the algebraic kernel):**
+1. `RegularClosedCurve.exists_nice_reparam_for_regular γ hL` (s05 IFT file) → constant-speed
+   (`c = L/2π`), zero-mean regular curve `ρ` with `ρ.circumference = γ.circumference`,
+   `ρ.area = γ.area`.
+2. `IsoperimetricFourier.wirtinger_sum_bound ρ.x ρ.y …` (s07 Fourier file) → `∫(ρ.x²+ρ.y²) ≤ 2πc²`.
+3. `IsoperimetricCauchySchwarz.area_cauchy_schwarz_bound_contDiff ρ.x ρ.y c …` (s06) →
+   `|∫(ρ.x·ρ.y'−ρ.y·ρ.x')| ≤ c·∫√(ρ.x²+ρ.y²)`; with `2·ρ.area = |∫(…)|` (def of `area`) this is
+   `2·ρ.area ≤ c·S`.
+4. `IsoperimetricCauchySchwarz.integral_cauchy_schwarz_sq ρ.x ρ.y …` (s06) → `S² ≤ 2π·Sxy`.
+5. `isoperimetric_arithmetic_kernel` (reproved inline — the parent's copy is in the bit-rotted
+   parent file): from `S² ≤ 2π·2πc² = (2πc)²` get `S ≤ 2πc`, then `2A ≤ c·S ≤ 2πc²`, hence
+   `4πA ≤ 4π²c² = (2πc)² = L²`. Transfer across `ρ.area = γ.area` / `ρ.circumference =
+   γ.circumference`.
+
+**This file imports NONE of the axiomatized infrastructure** — only `Mathlib` and the three
+0-axiom sibling companions (`…OQ01OQ01IFT`, `…OQ01OQ01Fourier`, `…OQ01OQ01CauchySchwarz`). So
+the entire chain from raw Mathlib to `4πA ≤ C²` (on the regular locus) is now machine-checked
+with zero assumptions. The bit-rotted parent `AreaOfCircleOQ01OQ02OQ02OQ01.lean` is **not**
+touched or relied upon.
+
+**Gotchas pinned (v4.26.0):**
+- `set c := γ.circumference / (2 * π)` *after* `obtain`-ing `ρ` folds the literal
+  `(γ.circumference / (2*π))^2` in the constant-speed hypothesis `hspeed` into `c^2`, matching
+  `wirtinger_sum_bound`'s `= c^2` shape exactly — no manual rewrite needed.
+- `2 * ρ.area = |∫ …|`: `simp only [RegularClosedCurve.area]; ring` (`ring` treats the `|·|` as
+  an atom; `2 * ((1/2)*|X|) = |X|`).
+- `hL_eq : γ.circumference = 2 * π * c` via `rw [hc_def]; field_simp` (no explicit `2π≠0` needed
+  — `field_simp` discharges it here).
+- The headline lemmas about `ρ` need `ρ.continuous_x`/`ρ.continuous_y` (dot notation on the
+  `RegularClosedCurve` namespace theorems) for `integral_cauchy_schwarz_sq`, and
+  `ρ.smooth_x`/`ρ.smooth_y`/`ρ.periodic_x`/`ρ.periodic_y` for `wirtinger_sum_bound`.
+
+**Honest scope (unchanged from s05).** Stated for `RegularClosedCurve`, not the parent's
+`SmoothClosedCurve`: `exists_nice_reparam` is genuinely false for non-regular curves (Gap 1), so
+`C² ≥ 4πA` for *all* smooth closed curves needs an extra limiting argument this route does not
+supply. On the regular locus — where the Fourier/IFT proof is valid — the inequality is now
+entirely axiom-free. The bit-rotted parent/sibling repair (#27276) remains a mechanic task; a
+parent edit restating its theorem for regular curves and importing this file would make the
+parent gallery entry 0-axiom, but that touches a verified entry and is left as a deliberate
+follow-up.
+
+## Next Steps (updated)
+
+1. **(mechanic, sensitive)** Repair bit-rotted `AreaOfCircleOQ01OQ02OQ02OQ01.lean` (parent) +
+   `AreaOfCircleOQ01OQ03OQ01.lean` (sibling) for v4.26.0 (renames pinned in s05). Then optionally
+   restate the parent's `isoperimetric_inequality` for `RegularClosedCurve` and discharge it via
+   `IsoperimetricRegular.isoperimetric_inequality_regular`, dropping the parent `axiomCount` 5→0
+   on the regular locus.
+2. **Equality/rigidity capstone (optional):** combine this inequality with the s-session
+   Wirtinger equality result (OQ010202010101 #27294, `C²=4πA ⟺ circle`) into a single
+   inequality-plus-rigidity statement for regular curves.

--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md
@@ -2,12 +2,24 @@
 
 ## Current State
 **Phase**: ACT
-**Status**: PROGRESS — ALL FIVE parent analytic axioms now discharged 0-axiom (reparam-on-regular, both Cauchy–Schwarz, and now both Fourier-analytic)
+**Status**: PROGRESS — CAPSTONE: full isoperimetric inequality `4πA ≤ C²` for regular curves now assembled 0-axiom from all five discharged pieces
 **Path**: full
 **Since**: 2026-06-13
-**Iteration**: 7
+**Iteration**: 8
 
 ## Current Focus
+s08 (2026-06-21, researcher-8) shipped `AreaOfCircleOQ01OQ02OQ02OQ01OQ01Iso.lean`
+(`namespace IsoperimetricRegular`, imports `Mathlib` + the three 0-axiom sibling companions
+s05/s06/s07, **0 axioms, 0 sorries**, docker-GREEN 7749 jobs, 3 thm): the **capstone** wiring
+all five discharged analytic ingredients together through the (inline-reproved) arithmetic
+kernel to obtain the complete inequality —
+**`isoperimetric_inequality_regular`**: for every `RegularClosedCurve γ` with `0 < circumference`,
+`4 * π * γ.area ≤ γ.circumference ^ 2`, plus the ratio form `isoperimetric_ratio_ge_one`.
+`#print axioms` = `[propext, Classical.choice, Quot.sound]` (no `ofReduceBool`/`sorryAx`). The
+file imports **none** of the parent's axiomatized infrastructure, so the entire chain from raw
+Mathlib to `4πA ≤ C²` (on the regular locus) is machine-checked with zero assumptions.
+
+## Prior Focus
 s07 (2026-06-21, researcher-9) shipped `AreaOfCircleOQ01OQ02OQ02OQ01OQ01Fourier.lean`
 (`namespace IsoperimetricFourier`, imports `Mathlib` + sibling `Proofs.AreaOfCircleOQ01OQ03`,
 0-axiom, docker-GREEN 7745 jobs, 3 thm/1 struct): discharges the **two remaining Fourier
@@ -26,14 +38,14 @@ axioms** —
 With s05+s06+s07, **all 5 of the parent's analytic axioms are now proved 0-axiom**: reparam
 (regular locus), integral-CS, area-CS, fourier-decomp, wirtinger-sum.
 
-## Prior Focus
+## Earlier Focus (s06)
 s06 (2026-06-21, researcher-9) shipped `AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz.lean`
 (`namespace IsoperimetricCauchySchwarz`, imports `Mathlib` only, 0-axiom, docker-GREEN, 4 thm):
 discharges **both** Cauchy–Schwarz parent axioms — `integral_cauchy_schwarz_sq`
 ((∫√(x²+y²))² ≤ 2π·∫(x²+y²), via the discriminant of `λ ↦ ∫(√(x²+y²)−λ)²`) and
 `area_cauchy_schwarz_bound` (|∫(x·dy−y·dx)| ≤ c·∫√(x²+y²) under constant speed).
 
-## Earlier Focus
+## Earlier Focus (s05)
 s05 (2026-06-21, researcher-9) shipped `AreaOfCircleOQ01OQ02OQ02OQ01OQ01IFT.lean`
 (`namespace RegularCurveArcLength`, imports Mathlib + the s04 `…Reparam` companion, 0-axiom,
 docker-GREEN, 35 thm/3 def): the **IFT-inverse + change-of-variables middle** re-derived on
@@ -47,19 +59,22 @@ Done. The arc-length map `s` is bijective (IVT + StrictMono), `σ=s⁻¹` is `C�
 Fourier axioms via the sibling's proved Parseval theorem + Wirtinger on each coordinate.
 
 ## Attempt Count
-- Total attempts: 3 (s04 ends; s05 middle+assembly; s07 Fourier — all docker-verified GREEN)
-- Approaches tried: 4 (import sibling [s05: blocked by bit-rot]; self-contained ends [s04];
+- Total attempts: 4 (s04 ends; s05 middle+assembly; s07 Fourier; s08 capstone — all docker-verified GREEN)
+- Approaches tried: 5 (import sibling [s05: blocked by bit-rot]; self-contained ends [s04];
   self-contained middle+assembly on `RegularClosedCurve` [s05]; import sibling's *proved*
-  Parseval theorem for the Fourier axioms [s07, succeeded])
+  Parseval theorem for the Fourier axioms [s07, succeeded]; wire all five discharges through the
+  arithmetic kernel into the full inequality [s08, succeeded])
 
 ## Blockers
-- None. All five parent analytic axioms are now discharged 0-axiom across s05/s06/s07. The
+- None. All five parent analytic axioms are discharged 0-axiom (s05/s06/s07) AND the full
+  isoperimetric inequality for regular curves is now assembled 0-axiom from them (s08). The
   remaining work is optional/sensitive (parent edit to drop `axiomCount` 5→0) or separate
   (mechanic repair of the two bit-rotted entries flagged in #27276).
 
 ## Next Action
-5/5 axioms now proved 0-axiom (reparam-on-regular, integral-CS, area-CS, fourier-decomp,
-wirtinger-sum). Remaining options:
+The OQ's stated target is mathematically complete: all five analytic axioms are discharged
+0-axiom and the full inequality `4πA ≤ C²` for regular curves is assembled 0-axiom (s08).
+Remaining options:
 (1) optional sensitive parent edit: replace the five `axiom` declarations in
 `AreaOfCircleOQ01OQ02OQ02OQ01.lean` with `theorem`s pointing at the standalone discharges
 (s05 IFT for regular curves, s06 CauchySchwarz, s07 Fourier), dropping the parent `axiomCount`


### PR DESCRIPTION
## Summary

Capstone for the `area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01` open question. Prior sessions
(s05–s07) discharged **all five** analytic axioms of the parent Hurwitz isoperimetric proof
(`IsoperimetricFromFourier`) 0-axiom, but each in an *isolated* standalone file with nothing
combining them. This PR supplies the missing integration: it wires the three discharged pieces
together — through the same purely-algebraic arithmetic kernel the parent uses — to obtain the
**complete inequality with zero axioms**.

```lean
theorem isoperimetric_inequality_regular (γ : RegularClosedCurve)
    (hL : 0 < γ.circumference) :
    4 * π * γ.area ≤ γ.circumference ^ 2
```

plus the ratio form `isoperimetric_ratio_ge_one` (`1 ≤ C²/(4πA)`).

## Assembly (plumbing + algebraic kernel, no new analysis)

1. `RegularClosedCurve.exists_nice_reparam_for_regular` (s05 IFT) → constant-speed (`c=L/2π`),
   zero-mean reparametrization `ρ` with the same circumference and area.
2. `IsoperimetricFourier.wirtinger_sum_bound` (s07) → `∫(ρ.x²+ρ.y²) ≤ 2πc²`.
3. `IsoperimetricCauchySchwarz.area_cauchy_schwarz_bound_contDiff` (s06) → `2·area ≤ c·∫√(ρ.x²+ρ.y²)`.
4. `IsoperimetricCauchySchwarz.integral_cauchy_schwarz_sq` (s06) → `(∫√(ρ.x²+ρ.y²))² ≤ 2π·∫(ρ.x²+ρ.y²)`.
5. `isoperimetric_arithmetic_kernel` (reproved inline) chains these to `4πA ≤ C²`; transfer
   across the reparametrization's area/circumference preservation.

## Verification

- New file `proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01Iso.lean` (`namespace IsoperimetricRegular`):
  ~170 LOC, 3 theorems, **0 axioms, 0 sorries**.
- Imports `Mathlib` + the three 0-axiom sibling companions **only** — none of the parent's
  axiomatized infrastructure, and not the bit-rotted parent file.
- `docker-build.sh` GREEN (7749 jobs, Mathlib v4.26.0).
- `#print axioms` = `[propext, Classical.choice, Quot.sound]` for both headline results — no
  `Lean.ofReduceBool`, no `sorryAx`. Genuinely 0-axiom.

## Honest scope

Stated for `RegularClosedCurve` (C¹, 2π-periodic, nowhere-vanishing speed), **not** the parent's
`SmoothClosedCurve`. This is the maximal honest target: the parent axiom `exists_nice_reparam` is
genuinely *false* for non-regular curves (a stationary point makes the arc-length map
non-strictly-monotone, so the IFT gives no C¹ inverse — Gap 1). On the regular locus, where the
Fourier/IFT proof is valid, the inequality is now entirely axiom-free.

## Status

**Outcome**: progress (capstone milestone). The OQ's stated target — discharge
`exists_nice_reparam` from the inverse function theorem and complete the inequality — is
mathematically complete 0-axiom on the regular locus.

**Next steps**: (optional, sensitive) mechanic repair + parent edit to make the parent gallery
entry itself 0-axiom on a regularity-carrying structure (#27276).

🤖 Generated by researcher-8