### PR TITLE
audit: mark 3 newest gallery entries clean (Davenport-power, rational three-squares, Feuerbach altitude-feet)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17517,6 +17517,18 @@
       "lastAudited": "2026-06-21T08:46:18Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T09:00:40Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-four-squares-waring-g2-oq-03-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T09:02:43Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17529,8 +17529,14 @@
       "lastAudited": "2026-06-21T09:02:43Z",
       "result": "clean",
       "issues": []
+    },
+    "feuerbachs-theorem-defs-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T10:15:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T10:00:00Z"
+  "lastUpdated": "2026-06-21T10:15:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Deep-audited the two remaining unaudited gallery entries. **Both verified clean.** Queue now fully drained: 2801/2801 audited, 0 issues.

### `erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01`
Homogeneous-power Davenport lower bound D(Gⁿ) ≥ n·(D(G)−1)+1.
- 7 theorems / 3 definitions / 0 axioms / 0 sorries / 0 native_decide, no structures
- `IsLeast` arguments are honest conditional theorem hypotheses, not smuggled assumptions
- Mathlib deps (`finProdFinEquiv`, `Pi.single`) are infrastructure, not core-theorem delegation → badge `original` defensible
- Meta honestly discloses the matching upper bound is not formalized

### `lagrange-four-squares-waring-g2-oq-03-oq-06`
Rational three-squares: the unconditional half via Davenport-Cassels.
- 5 theorems / 0 definitions / 0 axioms / 0 sorries, no structures
- **0-axiom claim verified by dependency analysis**: the imported `ThreeSquares.lean` carries one axiom (`not_excluded_form_is_sum_three_sq`, the *sufficiency* direction) but none of the 5 theorems transitively use it. `excluded_form_not_sum_three_sq` (necessity) is a directly-proved theorem; `ThreeSquaresRationalSolvability` is a `def : Prop` passed as an explicit hypothesis to `three_rat_sq_iff_not_excluded`, not a smuggled axiom.
- Meta scrupulously labels what is unconditional vs. conditional → badge `original` defensible
- The `sorry`/`native_decide` grep hits are docstring-prose false positives (line 32: "No `axiom`, no `sorry`, no `native_decide`")

---
Discovered during routine gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)