### PR TITLE
research(area-of-circle-…-oq-01-oq-01-oq-02): axiom-free isoperimetric inequality 4πA≤L² for regular closed curves (Hurwitz capstone)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -131,6 +131,7 @@ import Proofs.AreaOfCircleOQ01OQ02OQ01OQ03
 import Proofs.AreaOfCircleOQ01OQ02OQ02
 import Proofs.AreaOfCircleOQ01OQ02OQ02OQ01
 import Proofs.AreaOfCircleOQ01OQ02OQ02OQ01OQ01OQ01
+import Proofs.AreaOfCircleOQ01OQ02OQ02OQ01OQ01OQ02
 import Proofs.AreaOfCircleOQ01OQ02OQ03
 import Proofs.AreaOfCircleOQ01OQ02OQ03OQ03
 import Proofs.AreaOfCircleOQ01OQ03

--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01OQ02.lean
@@ -1,0 +1,166 @@
+/-
+  The isoperimetric inequality `4πA ≤ L²`, fully axiom-free, for regular closed curves.
+
+  Open Question: area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01
+  (child slug: area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02)
+
+  ## Context — the capstone of the Hurwitz isoperimetric program
+
+  The gallery parent `AreaOfCircleOQ01OQ02OQ02OQ01.lean` (`namespace IsoperimetricFromFourier`)
+  proves the isoperimetric inequality `C² ≥ 4πA` for `SmoothClosedCurve`s from **five disclosed
+  axioms**:
+
+  1. `fourier_decomp_exists`      — Parseval/IBP Fourier decomposition,
+  2. `exists_nice_reparam`        — constant-speed, zero-mean reparametrization (the IFT step),
+  3. `wirtinger_sum_bound`        — Wirtinger applied to the coordinate functions,
+  4. `area_cauchy_schwarz_bound`  — Green's-formula area ≤ `c·∫√(x²+y²)` (pointwise 2-D CS),
+  5. `integral_cauchy_schwarz_sq` — the L² Cauchy–Schwarz `S² ≤ 2π·∫(x²+y²)`,
+
+  together with the *fully proved* `isoperimetric_arithmetic_kernel` (the purely algebraic
+  deduction `4πA ≤ L²` from the analytic bounds).
+
+  Across the OQ research lineage each of these five analytic axioms was **individually
+  discharged, 0-axiom**, in self-contained companions:
+
+  * `AreaOfCircleOQ01OQ02OQ02OQ01OQ01Fourier.lean` (`namespace IsoperimetricFourier`):
+    `fourier_decomp_exists`, `wirtinger_inequality`, and `wirtinger_sum_bound` (#3).
+  * `AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz.lean` (`namespace IsoperimetricCauchySchwarz`):
+    `integral_cauchy_schwarz_sq` (#5) and `area_cauchy_schwarz_bound_contDiff` (#4).
+  * `AreaOfCircleOQ01OQ02OQ02OQ01OQ01IFT.lean` (`namespace RegularCurveArcLength`):
+    `exists_nice_reparam_for_regular` (#2) — the inverse-function-theorem arc-length
+    reparametrization, proved for the `RegularClosedCurve` structure (the regularity field is
+    genuinely needed: the axiom is *false* for curves with stationary points, see that file's
+    header, "Gap 1").
+
+  Each companion stood alone. **This file performs the final assembly**: it feeds the four
+  discharged analytic bounds (on the constant-speed, zero-mean reparametrization produced by the
+  IFT) into the algebraic kernel and obtains the isoperimetric inequality
+
+      `isoperimetric_inequality_regular : 4 * π * γ.area ≤ γ.circumference ^ 2`
+
+  for every `RegularClosedCurve γ` with positive circumference — with **0 axioms and 0 sorries**.
+
+  This is the maximal honest endpoint of the program: the parent's statement quantifies over all
+  `SmoothClosedCurve`, where the reparametrization axiom is genuinely false (stationary points),
+  so a literal 0-axiom replacement of the parent theorem is impossible. On the regular locus —
+  exactly where the inverse-function-theorem route can succeed — the entire chain
+  Fourier ⇒ Wirtinger ⇒ Cauchy–Schwarz ⇒ IFT reparametrization ⇒ arithmetic kernel is now
+  machine-checked end to end with no remaining assumptions.
+
+  ## Proof
+
+  Mirrors the parent's `isoperimetric_inequality` proof verbatim, but every axiom invocation is
+  replaced by the corresponding 0-axiom companion theorem, and the curve structure is
+  `RegularClosedCurve` (so the reparametrization actually exists). Given `γ`:
+
+  * `exists_nice_reparam_for_regular` yields a regular curve `ρ` with the same circumference and
+    area, constant speed `c = L/(2π)`, and zero mean.
+  * `wirtinger_sum_bound` on `(ρ.x, ρ.y)` gives `∫(ρ.x²+ρ.y²) ≤ 2πc²`.
+  * `integral_cauchy_schwarz_sq` on `(ρ.x, ρ.y)` gives `S² ≤ 2π·∫(ρ.x²+ρ.y²)`.
+  * `area_cauchy_schwarz_bound_contDiff` gives `|∫(ρ.x·ρ.y' − ρ.y·ρ.x')| ≤ c·S`, and since
+    `2·ρ.area = |∫(…)|` this is `2·ρ.area ≤ c·S`.
+  * `isoperimetric_arithmetic_kernel` assembles these into `4π·ρ.area ≤ ρ.circumference²`, which
+    transports back to `γ` by the circumference/area preservation of `ρ`.
+
+  ## Sorries: 0   Axioms: 0
+-/
+import Mathlib
+import Proofs.AreaOfCircleOQ01OQ02OQ02OQ01OQ01Fourier
+import Proofs.AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz
+import Proofs.AreaOfCircleOQ01OQ02OQ02OQ01OQ01IFT
+
+open Real MeasureTheory intervalIntegral Topology Filter
+
+namespace IsoperimetricCapstone
+
+open RegularCurveArcLength
+
+/-! ### The algebraic kernel
+
+The parent entry's purely-algebraic `isoperimetric_arithmetic_kernel` — re-proved here verbatim
+so this capstone is self-contained and does not depend on the (currently Mathlib-v4.26.0
+bit-rotted) parent file `AreaOfCircleOQ01OQ02OQ02OQ01.lean`.  No integrals or measures appear;
+it is the final algebraic step of Hurwitz's 1901 proof once the analytic bounds are assembled. -/
+
+/-- **Arithmetic kernel**: from the assembled analytic bounds (`2A ≤ cS`, `S² ≤ 2π·Sxy`,
+`Sxy ≤ 2πc²`) and `L = 2πc`, deduce `4πA ≤ L²`. Purely algebraic. -/
+theorem isoperimetric_arithmetic_kernel
+    (A L c S Sxy : ℝ)
+    (hc : 0 < c)
+    (hcirc : L = 2 * π * c)
+    (hS_nn : 0 ≤ S)
+    (harea : 2 * A ≤ c * S)
+    (hCS : S ^ 2 ≤ 2 * π * Sxy)
+    (hWirt : Sxy ≤ 2 * π * c ^ 2) :
+    4 * π * A ≤ L ^ 2 := by
+  have hpi : (0 : ℝ) < π := pi_pos
+  have h2pic_pos : (0 : ℝ) < 2 * π * c := by positivity
+  have hS2 : S ^ 2 ≤ (2 * π * c) ^ 2 :=
+    calc S ^ 2 ≤ 2 * π * Sxy := hCS
+      _ ≤ 2 * π * (2 * π * c ^ 2) := mul_le_mul_of_nonneg_left hWirt (by linarith)
+      _ = (2 * π * c) ^ 2 := by ring
+  have hS_bound : S ≤ 2 * π * c := by
+    have h := Real.sqrt_le_sqrt hS2
+    rwa [Real.sqrt_sq hS_nn, Real.sqrt_sq h2pic_pos.le] at h
+  have h1 : c * S ≤ 2 * π * c ^ 2 := by nlinarith
+  have h2 : 2 * A ≤ 2 * π * c ^ 2 := le_trans harea h1
+  calc 4 * π * A = 2 * π * (2 * A) := by ring
+    _ ≤ 2 * π * (2 * π * c ^ 2) := mul_le_mul_of_nonneg_left h2 (by linarith)
+    _ = (2 * π * c) ^ 2 := by ring
+    _ = L ^ 2 := by rw [hcirc]
+
+/-- **The isoperimetric inequality `4πA ≤ L²` for regular closed curves — 0 axioms.**
+
+For every regular `C¹` closed plane curve `γ` (`2π`-periodic, nowhere-vanishing speed) with
+positive circumference `L = γ.circumference` and enclosed signed area `A = γ.area`,
+
+  `4 * π * A ≤ L²`.
+
+This is Hurwitz's 1901 isoperimetric inequality, assembled entirely from machine-checked,
+axiom-free pieces: the Fourier/Wirtinger bound, the two Cauchy–Schwarz bounds, the
+inverse-function-theorem constant-speed reparametrization, and the algebraic kernel. Every one of
+the parent entry's five analytic axioms has been discharged; this theorem invokes none of them. -/
+theorem isoperimetric_inequality_regular (γ : RegularClosedCurve)
+    (hL : 0 < γ.circumference) :
+    4 * π * γ.area ≤ γ.circumference ^ 2 := by
+  -- Step 1: constant-speed, zero-mean reparametrization (inverse function theorem, 0-axiom).
+  obtain ⟨ρ, hρcirc, hρarea, hρspeed, hρzx, hρzy⟩ :=
+    RegularClosedCurve.exists_nice_reparam_for_regular γ hL
+  -- Step 2: the constant speed `c = L/(2π)`.
+  set c := γ.circumference / (2 * π) with hc_def
+  have hc_pos : 0 < c := div_pos hL (by positivity)
+  -- `set` has folded the speed hypothesis to `… = c²`.
+  -- Step 3: name the two integral aggregates `S = ∫√(x²+y²)` and `Sxy = ∫(x²+y²)`.
+  set S := ∫ t in (0 : ℝ)..(2 * π), Real.sqrt (ρ.x t ^ 2 + ρ.y t ^ 2) with hS_def
+  set Sxy := ∫ t in (0 : ℝ)..(2 * π), (ρ.x t ^ 2 + ρ.y t ^ 2) with hSxy_def
+  -- Step 4: `S ≥ 0`.
+  have hS_nn : 0 ≤ S := by
+    rw [hS_def]
+    apply intervalIntegral.integral_nonneg (by positivity)
+    intro t _
+    exact Real.sqrt_nonneg _
+  -- Step 5: the three analytic bounds, each from a 0-axiom companion.
+  -- Wirtinger sum bound:  `Sxy ≤ 2πc²`.
+  have hWirt : Sxy ≤ 2 * π * c ^ 2 :=
+    IsoperimetricFourier.wirtinger_sum_bound ρ.x ρ.y ρ.smooth_x ρ.smooth_y
+      ρ.periodic_x ρ.periodic_y c hc_pos hρspeed hρzx hρzy
+  -- L² Cauchy–Schwarz:  `S² ≤ 2π·Sxy`.
+  have hCS : S ^ 2 ≤ 2 * π * Sxy :=
+    IsoperimetricCauchySchwarz.integral_cauchy_schwarz_sq ρ.x ρ.y
+      ρ.smooth_x.continuous ρ.smooth_y.continuous
+  -- Area Cauchy–Schwarz:  `|∫(x·y' − y·x')| ≤ c·S`, i.e. `2·area ≤ c·S`.
+  have hAbs : |∫ t in (0 : ℝ)..(2 * π), (ρ.x t * deriv ρ.y t - ρ.y t * deriv ρ.x t)| ≤ c * S :=
+    IsoperimetricCauchySchwarz.area_cauchy_schwarz_bound_contDiff ρ.x ρ.y c hc_pos.le
+      ρ.smooth_x ρ.smooth_y hρspeed
+  have h2area : 2 * ρ.area =
+      |∫ t in (0 : ℝ)..(2 * π), (ρ.x t * deriv ρ.y t - ρ.y t * deriv ρ.x t)| := by
+    unfold RegularCurveArcLength.RegularClosedCurve.area
+    ring
+  have hArea : 2 * ρ.area ≤ c * S := by rw [h2area]; exact hAbs
+  -- Step 6: transport the goal to `ρ` and apply the algebraic kernel.
+  rw [← hρarea, ← hρcirc]
+  exact isoperimetric_arithmetic_kernel
+    ρ.area ρ.circumference c S Sxy hc_pos
+    (by rw [hρcirc, hc_def]; field_simp) hS_nn hArea hCS hWirt
+
+end IsoperimetricCapstone

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,91 @@
+{
+  "id": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02",
+  "title": "Axiom-Free Isoperimetric Inequality for Regular Closed Curves (Hurwitz Capstone)",
+  "slug": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02",
+  "description": "The capstone of the Hurwitz 1901 isoperimetric program: 4πA ≤ L² proved with ZERO axioms for every regular C¹ closed plane curve. The gallery parent proved the inequality for smooth closed curves from five disclosed analytic axioms (Fourier decomposition, constant-speed reparametrization, the Wirtinger sum bound, and two Cauchy–Schwarz bounds). Across the research lineage each axiom was individually discharged 0-axiom in a self-contained companion. This entry performs the final assembly — feeding the inverse-function-theorem reparametrization, the Wirtinger/Fourier bound, and the two Cauchy–Schwarz bounds into the purely-algebraic kernel — to obtain the isoperimetric inequality on the regular locus with no remaining assumptions. The regularity hypothesis is genuinely necessary: the reparametrization axiom is false for curves with stationary points, so this is the maximal honest 0-axiom endpoint of the program.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Isoperimetric_inequality",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "geometry",
+      "isoperimetric",
+      "hurwitz",
+      "wirtinger",
+      "cauchy-schwarz",
+      "inverse-function-theorem",
+      "reparametrization",
+      "wiedijk-100",
+      "axiom-free",
+      "research"
+    ],
+    "badge": "original",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 166,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "isoperimetric_inequality_regular: the isoperimetric inequality 4πA ≤ L² for every RegularClosedCurve with positive circumference, proved with 0 axioms and 0 sorries — the end-to-end assembly of the entire Hurwitz Fourier proof on the regular locus. #print axioms reports only propext / Classical.choice / Quot.sound (no sorryAx, no custom axioms, no Lean.ofReduceBool).",
+      "Final assembly of the five-axiom chain: the parent's exists_nice_reparam, wirtinger_sum_bound, area_cauchy_schwarz_bound, and integral_cauchy_schwarz_sq are each replaced by their 0-axiom companion (the IFT arc-length reparametrization for regular curves, the Wirtinger/Fourier bound, and the two Cauchy–Schwarz bounds), and fed into the algebraic kernel. Every analytic axiom of the parent isoperimetric entry is thereby eliminated simultaneously.",
+      "isoperimetric_arithmetic_kernel: the purely-algebraic deduction 4πA ≤ L² from the assembled bounds (2A ≤ cS, S² ≤ 2π·Sxy, Sxy ≤ 2πc², L = 2πc), re-proved here so the capstone is self-contained and does not depend on the (currently Mathlib-v4.26.0 bit-rotted) parent file.",
+      "The bridge 2·area = |∫(x·y' − y·x')| connecting the Green's-theorem signed-area definition of RegularClosedCurve to the integral the area Cauchy–Schwarz bound controls, letting the constant-speed zero-mean reparametrization's analytic bounds drive the kernel."
+    ],
+    "prerequisites": [
+      "RegularCurveArcLength.RegularClosedCurve.exists_nice_reparam_for_regular (constant-speed, zero-mean reparametrization via the inverse function theorem) from AreaOfCircleOQ01OQ02OQ02OQ01OQ01IFT.lean",
+      "IsoperimetricFourier.wirtinger_sum_bound (∫(x²+y²) ≤ 2πc² via Wirtinger on each coordinate) from AreaOfCircleOQ01OQ02OQ02OQ01OQ01Fourier.lean",
+      "IsoperimetricCauchySchwarz.integral_cauchy_schwarz_sq and area_cauchy_schwarz_bound_contDiff from AreaOfCircleOQ01OQ02OQ02OQ01OQ01CauchySchwarz.lean",
+      "Real.sqrt_sq / Real.sqrt_le_sqrt and basic ordered-field arithmetic (nlinarith) for the algebraic kernel"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "intervalIntegral.integral_nonneg",
+        "description": "Nonnegativity of an interval integral of a pointwise-nonnegative function, used to show S = ∫√(x²+y²) ≥ 0.",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "Real.sqrt_sq",
+        "description": "√(a²) = a for a ≥ 0; turns S² ≤ (2πc)² into S ≤ 2πc inside the algebraic kernel.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "mul_le_mul_of_nonneg_left",
+        "description": "Monotonicity of multiplication by a nonnegative constant, chaining the Wirtinger and Cauchy–Schwarz bounds.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Hurwitz's 1901 proof of the isoperimetric inequality C² ≥ 4πA expresses arc length and enclosed area as Fourier integrals and reduces the inequality, coordinate by coordinate, to Wirtinger's inequality plus a Cauchy–Schwarz estimate. The gallery parent (area-of-circle-oq-01-oq-02-oq-02-oq-01) formalized this for smooth closed curves but isolated five analytic facts as axioms: the existence of a Fourier decomposition, a constant-speed zero-mean reparametrization (the inverse-function-theorem step), the Wirtinger sum bound, and two Cauchy–Schwarz bounds. A sequence of research companions discharged each of these 0-axiom. This entry is the capstone: it assembles those companions into a single, fully machine-checked, axiom-free proof of the inequality on the locus where the reparametrization step is even true — the regular curves.",
+    "problemStatement": "Let γ be a regular C¹ closed plane curve: γ.x, γ.y : ℝ → ℝ are C¹ and 2π-periodic with nowhere-vanishing speed (deriv γ.x t² + deriv γ.y t² > 0 for all t). Let L = γ.circumference = ∫₀²π √(x'²+y'²) and A = γ.area = ½|∫₀²π (x·y' − y·x')|. If L > 0 then 4πA ≤ L². The proof uses no axioms beyond Lean's foundational propext / Classical.choice / Quot.sound.",
+    "text": "An end-to-end, axiom-free formalization of Hurwitz's isoperimetric inequality for regular closed curves. Every analytic ingredient that the parent entry assumed is now a proven theorem, and this file simply wires them together: reparametrize γ to constant speed c = L/(2π) with zero mean (inverse function theorem), bound ∫(x²+y²) ≤ 2πc² (Wirtinger), bound the squared arc-length integral S² ≤ 2π·∫(x²+y²) and the area 2A ≤ cS (Cauchy–Schwarz), and finish with the algebraic kernel 4πA ≤ L².",
+    "proofStrategy": "(1) Apply exists_nice_reparam_for_regular to obtain a regular curve ρ with the same circumference and area as γ, constant speed c = L/(2π), and zero mean — discharged 0-axiom via the Mathlib inverse function theorem on the strictly monotone arc-length map, composed with mean subtraction. (2) Set S = ∫₀²π √(ρ.x²+ρ.y²) and Sxy = ∫₀²π (ρ.x²+ρ.y²). (3) wirtinger_sum_bound on (ρ.x, ρ.y) gives Sxy ≤ 2πc². (4) integral_cauchy_schwarz_sq gives S² ≤ 2π·Sxy. (5) area_cauchy_schwarz_bound_contDiff gives |∫(ρ.x·ρ.y' − ρ.y·ρ.x')| ≤ c·S, and since 2·ρ.area equals that absolute value, 2·ρ.area ≤ c·S. (6) The algebraic kernel chains these: S² ≤ (2πc)² so S ≤ 2πc, hence 2A ≤ cS ≤ 2πc², giving 4πA ≤ 4π²c² = L². (7) ρ shares γ's circumference and area, so the bound transports back to γ.",
+    "keyInsights": [
+      "The isoperimetric inequality on the regular locus is now provable with no assumptions: every one of the parent's five analytic axioms has been independently discharged, and this capstone shows the chain composes cleanly into a single 0-axiom theorem",
+      "Regularity is not a technical convenience but a genuine necessity — the reparametrization step is false for curves with stationary points (the arc-length map is not strictly monotone, so the inverse function theorem yields no C¹ inverse), which is exactly why the parent's all-curves statement cannot be made literally axiom-free",
+      "The proof is purely a composition: reparametrization (analysis) → Wirtinger and Cauchy–Schwarz (Fourier/inequalities) → an algebraic kernel with no integrals, mirroring Hurwitz's three-layer Analytical → Algebraic → Geometric structure",
+      "Self-containment matters: re-proving the ~25-line algebraic kernel locally lets the capstone build even though the original parent file has bit-rotted on the current Mathlib pin, isolating the verified result from upstream breakage"
+    ],
+    "prerequisites": [
+      "Fourier series, Parseval's identity, and Wirtinger's inequality",
+      "The inverse function theorem and change of variables for interval integrals",
+      "Cauchy–Schwarz (pointwise 2-D and L²) and basic ordered-field inequality reasoning"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part-i",
+      "title": "The algebraic kernel",
+      "text": "`isoperimetric_arithmetic_kernel` reproves the parent's purely-algebraic step: from 2A ≤ cS, S² ≤ 2π·Sxy, Sxy ≤ 2πc², and L = 2πc it deduces 4πA ≤ L². No integrals or measures appear. It is re-proved here so the capstone is self-contained and independent of the bit-rotted parent file."
+    },
+    {
+      "id": "part-ii",
+      "title": "Assembling the axiom-free isoperimetric inequality",
+      "text": "`isoperimetric_inequality_regular` is the capstone. It applies exists_nice_reparam_for_regular (IFT, 0-axiom) to get a constant-speed zero-mean reparametrization ρ of γ, then invokes the Wirtinger sum bound and both Cauchy–Schwarz bounds (each 0-axiom) on ρ, bridges 2·ρ.area = |∫(ρ.x·ρ.y' − ρ.y·ρ.x')|, and feeds everything to the kernel. The circumference/area preservation of ρ transports the bound back to γ, giving 4πA ≤ L² with #print axioms reporting only the foundational propext / Classical.choice / Quot.sound."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The **capstone** of the Hurwitz 1901 isoperimetric research lineage: the isoperimetric inequality **`4πA ≤ L²` proved with ZERO axioms** for every regular C¹ closed plane curve.

The gallery parent (`area-of-circle-oq-01-oq-02-oq-02-oq-01`) proved `C² ≥ 4πA` for `SmoothClosedCurve`s from **five disclosed analytic axioms**:
1. `fourier_decomp_exists`
2. `exists_nice_reparam` (constant-speed, zero-mean reparametrization — the IFT step)
3. `wirtinger_sum_bound`
4. `area_cauchy_schwarz_bound`
5. `integral_cauchy_schwarz_sq`

Across the OQ lineage each axiom was **individually discharged 0-axiom** in a self-contained companion (Fourier, CauchySchwarz, IFT). This PR performs the **final assembly**: it feeds the inverse-function-theorem constant-speed reparametrization, the Wirtinger/Fourier bound, and the two Cauchy–Schwarz bounds into the purely-algebraic kernel, eliminating **all five axioms simultaneously** on the regular locus.

```lean
theorem isoperimetric_inequality_regular (γ : RegularClosedCurve)
    (hL : 0 < γ.circumference) :
    4 * π * γ.area ≤ γ.circumference ^ 2
```

`#print axioms isoperimetric_inequality_regular` reports only `propext / Classical.choice / Quot.sound` — no `sorryAx`, no custom axioms, no `Lean.ofReduceBool`.

## Why the regular locus

The regularity hypothesis is **genuinely necessary**, not a convenience: the reparametrization step is false for curves with stationary points (the arc-length map is not strictly monotone, so the inverse function theorem yields no C¹ inverse). The parent's all-`SmoothClosedCurve` statement therefore cannot be made literally axiom-free; this is the maximal honest 0-axiom endpoint of the program.

## Proof

Mirrors the parent's `isoperimetric_inequality` verbatim, but every axiom invocation is replaced by the corresponding 0-axiom companion theorem, on `RegularClosedCurve`:
- `exists_nice_reparam_for_regular` → constant-speed zero-mean `ρ` with `ρ.circumference = γ.circumference`, `ρ.area = γ.area`
- `wirtinger_sum_bound` → `∫(ρ.x²+ρ.y²) ≤ 2πc²`
- `integral_cauchy_schwarz_sq` → `S² ≤ 2π·∫(ρ.x²+ρ.y²)`
- `area_cauchy_schwarz_bound_contDiff` → `2·ρ.area ≤ c·S`
- `isoperimetric_arithmetic_kernel` → `4π·ρ.area ≤ ρ.circumference²`, transported back to γ

## Self-containment / parent bit-rot

The capstone re-proves the ~25-line purely-algebraic `isoperimetric_arithmetic_kernel` locally rather than importing the parent. This is required: the parent file `Proofs/AreaOfCircleOQ01OQ02OQ02OQ01.lean` **no longer builds on Mathlib v4.26.0** (the `set c` tactic now folds `(L/2π)²` into `c²` inside the axiom hypotheses, breaking `rwa [hcirc]` at lines 378/392). Filing a follow-up note for the mechanic to repair the parent gallery entry.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AreaOfCircleOQ01OQ02OQ02OQ01OQ01OQ02` ✔ (7749 jobs)
- `#print axioms` → only foundational axioms
- 166 lines, 2 theorems, 0 defs, **0 axioms, 0 sorries**

🤖 Generated with [Claude Code](https://claude.com/claude-code)