### PR TITLE
research(feuerbachs-theorem-defs-oq-01): defining characterization of the altitude feet [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2502,6 +2502,7 @@ import Proofs.FermatsLastTheorem
 import Proofs.FermatsLastTheoremOQ03
 import Proofs.FeuerbachsTheorem
 import Proofs.FeuerbachsTheoremDefs
+import Proofs.FeuerbachsTheoremDefsOQ01
 import Proofs.FeuerbachsTheoremDefsOQ03
 import Proofs.FeuerbachsTheoremDefsOQ04
 import Proofs.FeuerbachsTheoremOQ01

--- a/proofs/Proofs/FeuerbachsTheoremDefsOQ01.lean
+++ b/proofs/Proofs/FeuerbachsTheoremDefsOQ01.lean
@@ -1,0 +1,204 @@
+/-
+  Feuerbach's Theorem DefsOQ01: The Defining Lemmas of the Altitude Feet
+
+  ## The Open Question
+
+  The parent file `FeuerbachsTheoremDefs` defines the foot of each altitude as an
+  explicit orthogonal-projection formula and proves the deep fact that all three
+  feet lie on the nine-point circle.  But it never verifies the *defining*
+  characterization of an altitude foot, namely that
+
+    1. the foot lies on the opposite side line (collinearity), and
+    2. the segment from the vertex to the foot is perpendicular to that side.
+
+  These two facts are exactly what makes the point an "altitude foot."  Without
+  them the on-circle membership theorem is a statement about an opaque formula.
+
+  ## What This File Proves
+
+  For each altitude foot Hₐ, H_b, H_c of a non-degenerate triangle:
+
+  ### Collinearity (the foot lies on the opposite side)
+  `foot_a_collinear` : Hₐ, B, C are collinear (signed-area / cross product = 0).
+  This is a pure algebraic identity: Hₐ − B is a scalar multiple of C − B, so the
+  denominator cancels and no non-degeneracy hypothesis is needed.
+
+  ### Perpendicularity (the altitude is orthogonal to the side)
+  `foot_a_perp` : (Hₐ − A) · (C − B) = 0.
+  Here the side length must be non-zero, supplied by the parent lemma.
+
+  ### Pythagoras at the foot
+  `foot_a_pythagoras` : |A Hₐ|² + |Hₐ B|² = |A B|².
+  The right angle at the foot gives an exact Pythagorean split of the side toward B.
+
+  ### Uniqueness
+  `foot_a_unique` : the foot is the *only* point on line BC whose join to A is
+  perpendicular to BC.
+
+  ### Capstone and example
+  `altitude_feet_characterization` bundles collinearity + perpendicularity for all
+  three feet; `triangle_345_foot_a` evaluates Hₐ = (48/25, 36/25) for the 3-4-5
+  right triangle.
+
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Proofs.FeuerbachsTheoremDefs
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace FeuerbachsTheoremDefsOQ01
+
+open FeuerbachsTheorem
+
+-- ============================================================
+-- Part I: Collinearity of each foot with the opposite side
+-- ============================================================
+
+/-- The foot of the altitude from A is collinear with B and C: the signed area of
+    the triangle (Hₐ, B, C) vanishes.  Purely algebraic — Hₐ − B is a scalar
+    multiple of C − B, so the projection denominator cancels. -/
+theorem foot_a_collinear (T : Triangle) :
+    (T.foot_a.1 - T.B.1) * (T.C.2 - T.B.2)
+      - (T.foot_a.2 - T.B.2) * (T.C.1 - T.B.1) = 0 := by
+  unfold Triangle.foot_a
+  simp only []
+  ring
+
+/-- The foot of the altitude from B is collinear with C and A. -/
+theorem foot_b_collinear (T : Triangle) :
+    (T.foot_b.1 - T.C.1) * (T.A.2 - T.C.2)
+      - (T.foot_b.2 - T.C.2) * (T.A.1 - T.C.1) = 0 := by
+  unfold Triangle.foot_b
+  simp only []
+  ring
+
+/-- The foot of the altitude from C is collinear with A and B. -/
+theorem foot_c_collinear (T : Triangle) :
+    (T.foot_c.1 - T.A.1) * (T.B.2 - T.A.2)
+      - (T.foot_c.2 - T.A.2) * (T.B.1 - T.A.1) = 0 := by
+  unfold Triangle.foot_c
+  simp only []
+  ring
+
+-- ============================================================
+-- Part II: Perpendicularity of each altitude to its side
+-- ============================================================
+
+/-- The altitude AHₐ is perpendicular to side BC: (Hₐ − A) · (C − B) = 0. -/
+theorem foot_a_perp (T : Triangle) :
+    (T.foot_a.1 - T.A.1) * (T.C.1 - T.B.1)
+      + (T.foot_a.2 - T.A.2) * (T.C.2 - T.B.2) = 0 := by
+  unfold Triangle.foot_a
+  simp only []
+  have hbc : (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 ≠ 0 := bc_sq_ne_zero T
+  field_simp
+  ring
+
+/-- The altitude BH_b is perpendicular to side CA: (H_b − B) · (A − C) = 0. -/
+theorem foot_b_perp (T : Triangle) :
+    (T.foot_b.1 - T.B.1) * (T.A.1 - T.C.1)
+      + (T.foot_b.2 - T.B.2) * (T.A.2 - T.C.2) = 0 := by
+  unfold Triangle.foot_b
+  simp only []
+  have hca : (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 ≠ 0 := ca_sq_ne_zero T
+  field_simp
+  ring
+
+/-- The altitude CH_c is perpendicular to side AB: (H_c − C) · (B − A) = 0. -/
+theorem foot_c_perp (T : Triangle) :
+    (T.foot_c.1 - T.C.1) * (T.B.1 - T.A.1)
+      + (T.foot_c.2 - T.C.2) * (T.B.2 - T.A.2) = 0 := by
+  unfold Triangle.foot_c
+  simp only []
+  have hab : (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 ≠ 0 := ab_sq_ne_zero T
+  field_simp
+  ring
+
+-- ============================================================
+-- Part III: Pythagoras at the foot
+-- ============================================================
+
+/-- Right angle at the foot Hₐ gives a Pythagorean split toward B:
+    |A Hₐ|² + |Hₐ B|² = |A B|² (all squared distances, no `sqrt`). -/
+theorem foot_a_pythagoras (T : Triangle) :
+    dist2_sq T.A T.foot_a + dist2_sq T.foot_a T.B = dist2_sq T.A T.B := by
+  unfold dist2_sq Triangle.foot_a
+  simp only []
+  have hbc : (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 ≠ 0 := bc_sq_ne_zero T
+  field_simp
+  ring
+
+/-- Pythagorean split at H_b toward C: |B H_b|² + |H_b C|² = |B C|². -/
+theorem foot_b_pythagoras (T : Triangle) :
+    dist2_sq T.B T.foot_b + dist2_sq T.foot_b T.C = dist2_sq T.B T.C := by
+  unfold dist2_sq Triangle.foot_b
+  simp only []
+  have hca : (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 ≠ 0 := ca_sq_ne_zero T
+  field_simp
+  ring
+
+/-- Pythagorean split at H_c toward A: |C H_c|² + |H_c A|² = |C A|². -/
+theorem foot_c_pythagoras (T : Triangle) :
+    dist2_sq T.C T.foot_c + dist2_sq T.foot_c T.A = dist2_sq T.C T.A := by
+  unfold dist2_sq Triangle.foot_c
+  simp only []
+  have hab : (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 ≠ 0 := ab_sq_ne_zero T
+  field_simp
+  ring
+
+-- ============================================================
+-- Part IV: Uniqueness of the foot on its side line
+-- ============================================================
+
+/-- The foot Hₐ is the *unique* point on line BC whose join to A is perpendicular
+    to BC.  Any point `P = B + s·(C − B)` with `(P − A) · (C − B) = 0` equals Hₐ. -/
+theorem foot_a_unique (T : Triangle) (s : ℝ)
+    (hperp : (T.B.1 + s * (T.C.1 - T.B.1) - T.A.1) * (T.C.1 - T.B.1)
+        + (T.B.2 + s * (T.C.2 - T.B.2) - T.A.2) * (T.C.2 - T.B.2) = 0) :
+    (T.B.1 + s * (T.C.1 - T.B.1), T.B.2 + s * (T.C.2 - T.B.2)) = T.foot_a := by
+  have hbc : (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 ≠ 0 := bc_sq_ne_zero T
+  -- The perpendicularity constraint pins down the parameter s.
+  have hs : s = ((T.A.1 - T.B.1) * (T.C.1 - T.B.1)
+      + (T.A.2 - T.B.2) * (T.C.2 - T.B.2))
+      / ((T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2) := by
+    field_simp
+    nlinarith [hperp]
+  unfold Triangle.foot_a
+  simp only []
+  rw [hs]
+
+-- ============================================================
+-- Part V: Capstone and worked example
+-- ============================================================
+
+/-- **The defining characterization of the three altitude feet.**
+    Each foot lies on the opposite side (collinearity) and the altitude through it
+    is perpendicular to that side. -/
+theorem altitude_feet_characterization (T : Triangle) :
+    -- foot from A
+    ((T.foot_a.1 - T.B.1) * (T.C.2 - T.B.2)
+        - (T.foot_a.2 - T.B.2) * (T.C.1 - T.B.1) = 0 ∧
+      (T.foot_a.1 - T.A.1) * (T.C.1 - T.B.1)
+        + (T.foot_a.2 - T.A.2) * (T.C.2 - T.B.2) = 0) ∧
+    -- foot from B
+    ((T.foot_b.1 - T.C.1) * (T.A.2 - T.C.2)
+        - (T.foot_b.2 - T.C.2) * (T.A.1 - T.C.1) = 0 ∧
+      (T.foot_b.1 - T.B.1) * (T.A.1 - T.C.1)
+        + (T.foot_b.2 - T.B.2) * (T.A.2 - T.C.2) = 0) ∧
+    -- foot from C
+    ((T.foot_c.1 - T.A.1) * (T.B.2 - T.A.2)
+        - (T.foot_c.2 - T.A.2) * (T.B.1 - T.A.1) = 0 ∧
+      (T.foot_c.1 - T.C.1) * (T.B.1 - T.A.1)
+        + (T.foot_c.2 - T.C.2) * (T.B.2 - T.A.2) = 0) :=
+  ⟨⟨foot_a_collinear T, foot_a_perp T⟩,
+   ⟨foot_b_collinear T, foot_b_perp T⟩,
+   ⟨foot_c_collinear T, foot_c_perp T⟩⟩
+
+/-- Worked example: for the 3-4-5 right triangle (A = (0,0), B = (3,0), C = (0,4))
+    the foot of the altitude from A onto BC is (48/25, 36/25). -/
+theorem triangle_345_foot_a : triangle_345.foot_a = (48 / 25, 36 / 25) := by
+  unfold triangle_345 Triangle.foot_a
+  norm_num

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "feuerbachs-theorem-defs-oq-01",
+  "title": "Feuerbach's Theorem: The Defining Lemmas of the Altitude Feet",
+  "slug": "feuerbachs-theorem-defs-oq-01",
+  "description": "Proves the defining geometric characterization of the three altitude feet underlying the nine-point circle: each foot lies on the opposite side (collinearity), each altitude is perpendicular to its side, a Pythagorean split holds at each foot, and the foot is the unique such point on its side line. 12 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ01.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
+    "tags": [
+      "geometry",
+      "feuerbach",
+      "nine-point-circle",
+      "altitude",
+      "orthogonal-projection",
+      "pythagoras",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Inherits the coordinate API and non-degeneracy lemmas from FeuerbachsTheoremDefs.lean, which is itself 0-sorry, 0-axiom.",
+    "lineCount": 204,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "originalContributions": [
+      "foot_a_collinear / foot_b_collinear / foot_c_collinear: each altitude foot lies on its opposite side (signed-area / cross product vanishes) — a denominator-free algebraic identity needing no non-degeneracy hypothesis",
+      "foot_a_perp / foot_b_perp / foot_c_perp: the altitude from each vertex is perpendicular to the opposite side, (foot - vertex) · (side direction) = 0",
+      "foot_a_pythagoras / foot_b_pythagoras / foot_c_pythagoras: the right angle at each foot gives an exact Pythagorean split of the adjacent side, |vertex foot|² + |foot endpoint|² = |vertex endpoint|²",
+      "foot_a_unique: the foot is the unique point on the side line whose join to the opposite vertex is perpendicular to that side",
+      "altitude_feet_characterization: bundles collinearity + perpendicularity for all three feet — the complete defining characterization of an altitude foot",
+      "triangle_345_foot_a: worked example, the foot of the altitude from A in the 3-4-5 right triangle is (48/25, 36/25)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Feuerbach's theorem (1822) concerns the nine-point circle, which passes through nine special points of a triangle: the three side midpoints, the three midpoints of the vertex-to-orthocenter segments, and the three feet of the altitudes. The gallery's FeuerbachsTheoremDefs.lean defines each altitude foot via an explicit orthogonal-projection formula and proves the deep fact that all three feet lie on the nine-point circle.\n\nHowever, the parent file never verifies what actually makes those formula-defined points the *feet of the altitudes*. This entry supplies the missing foundation: the defining geometric lemmas characterizing the altitude feet.",
+    "problemStatement": "Given the coordinate definition of the foot of the altitude from A,\n$$H_a = B + t\\,(C - B), \\qquad t = \\frac{(A - B)\\cdot(C - B)}{\\lVert C - B\\rVert^2},$$\nverify the properties that justify calling $H_a$ an altitude foot:\n1. **Collinearity**: $H_a$ lies on line $BC$.\n2. **Perpendicularity**: $(H_a - A)\\cdot(C - B) = 0$.\n3. **Pythagoras**: $\\lVert A H_a\\rVert^2 + \\lVert H_a B\\rVert^2 = \\lVert A B\\rVert^2$.\n4. **Uniqueness**: $H_a$ is the only point of line $BC$ with property 2.\nand symmetrically for the feet from $B$ and $C$.",
+    "text": "A 204-line companion file with 12 theorems and 0 definitions. For each of the three altitude feet it proves collinearity with the opposite side, perpendicularity of the altitude, and a Pythagorean split, then proves uniqueness of the foot from A and bundles the characterization for all three feet. Closes with the worked 3-4-5 example.",
+    "proofStrategy": "Each lemma reduces, after `unfold` and `simp only []`, to a polynomial identity in the six vertex coordinates.\n- **Collinearity** is denominator-free: $H_a - B = t\\,(C - B)$ is manifestly parallel to $C - B$, so the cross product is $t\\,dx\\,dy - t\\,dy\\,dx = 0$ and `ring` closes it with no hypotheses.\n- **Perpendicularity** and **Pythagoras** require clearing the side-length denominator $\\lVert C - B\\rVert^2 \\ne 0$ (the parent's `bc_sq_ne_zero`/`ca_sq_ne_zero`/`ab_sq_ne_zero` lemmas), then `field_simp; ring`.\n- **Uniqueness**: the perpendicularity constraint is linear in the parameter $s$, so `field_simp; nlinarith` pins $s$ to exactly the projection parameter $t$; substituting closes the point equality by reflexivity.",
+    "keyInsights": [
+      "Collinearity of the foot is purely formal — because the projection point is literally written as B plus a scalar times (C − B), the cross product cancels symbolically and no triangle non-degeneracy is needed.",
+      "Perpendicularity is the one place the side length must be non-zero: t·‖C−B‖² collapses to the dot product (A−B)·(C−B) only when the denominator is cleared, which is exactly where the parent's non-degeneracy lemmas enter.",
+      "The Pythagorean identity at the foot is a corollary of perpendicularity: since (A − Hₐ) ⟂ (C − B) and Hₐ − B is parallel to C − B, the cross term in expanding |A − B|² vanishes, giving an exact two-term split.",
+      "Uniqueness reflects that the orthogonal projection onto a line is the unique foot of the perpendicular: the constraint (P − A)·(C − B) = 0 is affine-linear in the line parameter, so it has exactly one solution.",
+      "Together, collinearity + perpendicularity are the complete definition of 'altitude foot' — the parent's on-circle membership theorem becomes a statement about a genuinely geometric point rather than an opaque formula."
+    ],
+    "prerequisites": [
+      "FeuerbachsTheoremDefs.lean — coordinate API (Point, Triangle, foot_a/b/c, dist2_sq) and the side-length non-degeneracy lemmas",
+      "Orthogonal projection of a point onto a line",
+      "Dot product and the cross-product test for collinearity in ℝ²",
+      "field_simp / ring / nlinarith for polynomial identities over ℝ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Namespace Setup",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Module docstring stating the open question (the parent never characterizes its formula-defined feet), imports FeuerbachsTheoremDefs, opens the FeuerbachsTheorem namespace, and marks the section noncomputable.",
+      "mathContext": "The coordinate API (Point = ℝ×ℝ, Triangle, foot_a/b/c, dist2_sq) and the non-degeneracy lemmas bc_sq_ne_zero / ca_sq_ne_zero / ab_sq_ne_zero all come from the parent file."
+    },
+    {
+      "id": "collinear",
+      "title": "Part I: Collinearity of Each Foot with the Opposite Side",
+      "startLine": 62,
+      "endLine": 88,
+      "summary": "Proves each foot lies on its opposite side line via the vanishing signed-area (cross product) test.",
+      "mathContext": "Hₐ − B = t(C − B), so the cross product (Hₐ − B) × (C − B) = 0 identically. Proof: unfold; simp only []; ring — denominator-free, no non-degeneracy needed."
+    },
+    {
+      "id": "perp",
+      "title": "Part II: Perpendicularity of Each Altitude",
+      "startLine": 90,
+      "endLine": 126,
+      "summary": "Proves the join from each vertex to its foot is orthogonal to the opposite side.",
+      "mathContext": "(Hₐ − A)·(C − B) = (A − B)·(C − B) + t‖C − B‖² = 0 once t‖C − B‖² is cleared. Proof: unfold; field_simp [bc_sq_ne_zero]; ring."
+    },
+    {
+      "id": "pythagoras",
+      "title": "Part III: Pythagoras at the Foot",
+      "startLine": 128,
+      "endLine": 154,
+      "summary": "Proves an exact Pythagorean split of the adjacent side at each foot.",
+      "mathContext": "Right angle at Hₐ gives |A Hₐ|² + |Hₐ B|² = |A B|² (squared distances, no sqrt). Proof: unfold dist2_sq; field_simp; ring."
+    },
+    {
+      "id": "unique",
+      "title": "Part IV: Uniqueness of the Foot on Its Side Line",
+      "startLine": 156,
+      "endLine": 172,
+      "summary": "Proves the foot from A is the unique point on line BC whose join to A is perpendicular to BC.",
+      "mathContext": "The perpendicularity constraint is affine-linear in the line parameter s, so field_simp; nlinarith forces s to equal the projection parameter t; substitution closes the point equality by reflexivity."
+    },
+    {
+      "id": "capstone",
+      "title": "Part V: Capstone and Worked Example",
+      "startLine": 174,
+      "endLine": 204,
+      "summary": "Bundles collinearity + perpendicularity for all three feet, and evaluates the foot from A for the 3-4-5 right triangle.",
+      "mathContext": "altitude_feet_characterization is the conjunction of the six core lemmas; triangle_345_foot_a computes Hₐ = (48/25, 36/25) for A=(0,0), B=(3,0), C=(0,4) by norm_num."
+    }
+  ],
+  "conclusion": {
+    "summary": "Supplies the defining geometric lemmas for the three altitude feet of the nine-point circle: collinearity with the opposite side, perpendicularity of each altitude, a Pythagorean split at each foot, and uniqueness of the foot as the perpendicular's base point. 12 theorems, 0 axioms, 0 sorries.",
+    "implications": "**Foundational grounding**: the parent's on-circle membership theorems now rest on a verified characterization of the feet as genuine orthogonal projections, not just on an opaque coordinate formula.\n\n**Reusable foot API**: collinearity, perpendicularity, and the Pythagorean split are the standard facts downstream Euclidean-geometry proofs need about altitude feet, available here for import.",
+    "openQuestions": [
+      "Prove the orthocenter is the common intersection of the three altitude lines (each altitude passes through its foot and is perpendicular to its side), using the perpendicularity lemmas of this file.",
+      "Show the reflection of the orthocenter across each side lies on the circumcircle, a classical consequence of the altitude-foot configuration.",
+      "Reformulate the altitude-foot characterization in Mathlib's EuclideanGeometry.orthogonalProjection API to enable an upstream contribution."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-defs",
+      "relationship": "extends",
+      "description": "characterizes the altitude feet defined in FeuerbachsTheoremDefs.lean and used in its nine-point circle membership theorems"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-04",
+      "relationship": "related",
+      "description": "sibling slice that bridges the same coordinate API to Mathlib's EuclideanSpace and Metric.sphere"
+    },
+    {
+      "targetId": "feuerbachs-theorem",
+      "relationship": "related",
+      "description": "the full Feuerbach theorem whose nine-point circle the altitude feet lie on"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Proofs.FeuerbachsTheoremDefs"],
+    "opens": ["FeuerbachsTheorem"],
+    "namespace": "FeuerbachsTheoremDefsOQ01",
+    "lineCount": 204,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/FeuerbachsTheoremDefsOQ01.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "altitude_feet_characterization",
+      "type": "core",
+      "description": "Each altitude foot is collinear with its opposite side and the altitude through it is perpendicular to that side — the complete defining characterization of the three altitude feet.",
+      "leanType": "∀ T : Triangle, (collinear ∧ perp)_a ∧ (collinear ∧ perp)_b ∧ (collinear ∧ perp)_c"
+    },
+    {
+      "name": "foot_a_unique",
+      "type": "core",
+      "description": "The foot of the altitude from A is the unique point on line BC whose join to A is perpendicular to BC.",
+      "leanType": "(P − A) · (C − B) = 0 ∧ P ∈ line BC → P = foot_a"
+    },
+    {
+      "name": "foot_a_pythagoras",
+      "type": "lemma",
+      "description": "Pythagorean split at the foot from A.",
+      "leanType": "dist2_sq A foot_a + dist2_sq foot_a B = dist2_sq A B"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **feuerbachs-theorem-defs-oq-01** — the *defining* lemmas of the altitude feet, a follow-up to `FeuerbachsTheoremDefs`.

The parent file defines each altitude foot by an explicit orthogonal-projection formula and proves the deep fact that all three feet lie on the nine-point circle — but it never verifies the two properties that actually make a point an "altitude foot." This file supplies them for all three feet Hₐ, H_b, H_c of a non-degenerate triangle.

## What it proves (12 theorems, 0 sorries, 0 axioms)

- **Collinearity** (`foot_a/b/c_collinear`): each foot lies on the opposite side line (signed area = 0). Pure algebraic identity — the projection denominator cancels, no non-degeneracy needed.
- **Perpendicularity** (`foot_a/b/c_perp`): the altitude through the foot is orthogonal to its side.
- **Pythagoras at the foot** (`foot_a/b/c_pythagoras`): exact squared-distance split of the side.
- **Uniqueness** (`foot_a_unique`): the foot is the *only* point on the side line whose join to the apex is perpendicular to the side.
- **Capstone** (`altitude_feet_characterization`) bundles collinearity + perpendicularity for all three feet; **worked example** `triangle_345_foot_a` evaluates Hₐ = (48/25, 36/25) for the 3-4-5 right triangle.

## Verification

Built clean via the Docker wrapper. `#print axioms` on the capstone, uniqueness, and example theorems reports only `[propext, Classical.choice, Quot.sound]` — **0-axiom, 0-sorry, verified**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)