### PR TITLE
research(lagrange-...-g2-oq-03-oq-05-oq-01): non-three-square density error is one-sided and genuinely unbounded [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2800,6 +2800,7 @@ import Proofs.LagrangeFourSquaresWaringG2OQ01ExactValue
 import Proofs.LagrangeFourSquaresWaringG2OQ01General
 import Proofs.LagrangeFourSquaresWaringG2OQ03OQ04
 import Proofs.LagrangeFourSquaresWaringG2OQ03OQ05
+import Proofs.LagrangeFourSquaresWaringG2OQ03OQ05OQ01
 import Proofs.LagrangeTheorem
 import Proofs.LagrangeTheoremOQ01
 import Proofs.LagrangeTheoremOQ01OQ01

--- a/proofs/Proofs/LagrangeFourSquaresWaringG2OQ03OQ05OQ01.lean
+++ b/proofs/Proofs/LagrangeFourSquaresWaringG2OQ03OQ05OQ01.lean
@@ -1,0 +1,172 @@
+import Mathlib
+import Proofs.LagrangeFourSquaresWaringG2OQ03OQ05
+
+/-!
+# The non-three-square density error is one-sided and genuinely unbounded
+
+**Open question (`lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01`)**, a direct sequel to
+`oq-03-oq-05` (*"the natural density of the non-three-square integers is `1/6`"*).
+
+Recall the *excluded family* `E = { 4^a (8b+7) }` of integers that are **not** sums of three
+squares (Legendre), and the counting function `excludedCount N = #{ n < N : n ∈ E }`.  The
+`oq-03-oq-05` entry proved `excludedCount N / N → 1/6` together with a two-sided logarithmic
+error bound `|6·excludedCount N − N| ≤ 6·(log₂ N + 1)`, and asked:
+
+> *Is the oscillation `6·excludedCount N − N` actually `O(1)` along subsequences, or is it
+> genuinely unbounded?  What is the true order?*
+
+This file settles the dichotomy completely.
+
+## What is new here
+
+The whole analysis collapses onto a single residue computation.  Writing
+`E(N) := 6·excludedCount N − N`, the `oq-03-oq-05` recursion
+`excludedCount N = N/8 + excludedCount ⌈N/4⌉` telescopes to
+
+  `E(N) = E(⌈N/4⌉) + δ(N)`,   where  `δ(N) = ⌊(N mod 8 + 3)/4⌋ − (N mod 8)`
+
+depends **only on `N mod 8`**, taking the eight values `0, 0, −1, −2, −3, −3, −4, −5`.  Two
+consequences follow.
+
+* **One-sided sharpness** (`six_excludedCount_le`, `excludedCount_le_div_six`):
+  because every `δ` value is `≤ 0`,
+  `6·excludedCount N ≤ N`  for **all** `N`,  i.e.  `excludedCount N ≤ ⌊N/6⌋`.
+  The density `1/6` is therefore approached **strictly from below** — never overshot.  This
+  is strictly stronger than the two-sided bound, whose upper half was `+6(log₂N+1)`.
+
+* **Genuine unboundedness** (`error_unbounded`), via an explicit extremal family.  Let
+  `a 0 = 6`, `a (k+1) = 4·a k − 2` (closed form `a k = (4^{k+2}+2)/3`).  Every `a k ≡ 6
+  (mod 8)`, the descent `⌈(a (k+1))/4⌉ = a k` stays on the family, and each step contributes
+  `δ = −4`.  Hence
+
+  `6·excludedCount (a k) = a k − (4k + 6)`   (`excludedCount_a`),
+
+  so the error `N − 6·excludedCount N` is **unbounded above**: it equals `4k+6` along the
+  family while `a k` grows like `4^k`.  Thus the oscillation is **not** `O(1)`; its true order
+  is `Θ(log N)`, matching the `oq-03-oq-05` upper bound up to a constant.
+
+Combining the two: `0 ≤ N − 6·excludedCount N` always, with the gap reaching every height.
+All proofs are axiom-free and reuse the merged `oq-03-oq-05` recursion verbatim.
+-/
+
+open LagrangeFourSquaresWaringG2OQ03OQ05
+
+namespace LagrangeFourSquaresWaringG2OQ03OQ05OQ01
+
+/-! ## One-sided sharpness: `6·excludedCount N ≤ N` for all `N` -/
+
+/-- **The density `1/6` is approached strictly from below.**  Since each descent step changes
+`6·excludedCount − id` by `δ(N) = ⌊(N mod 8 + 3)/4⌋ − (N mod 8) ≤ 0`, the running total never
+becomes positive: `6·excludedCount N ≤ N` for every `N`. -/
+theorem six_excludedCount_le (N : ℕ) : 6 * excludedCount N ≤ N := by
+  induction N using Nat.strong_induction_on with
+  | _ N ih =>
+    rcases lt_or_ge N 8 with hN | hN
+    · rw [excludedCount_zero_of_le (by omega)]; omega
+    · set M := (N + 3) / 4 with hM
+      have hMlt : M < N := by omega
+      have hrec : excludedCount N = N / 8 + excludedCount M := excludedCount_rec N
+      have ihM := ih M hMlt
+      have e8 : 8 * (N / 8) + N % 8 = N := Nat.div_add_mod N 8
+      have e8' : N % 8 < 8 := Nat.mod_lt N (by norm_num)
+      have e4 : 4 * M + (N + 3) % 4 = N + 3 := by rw [hM]; exact Nat.div_add_mod (N + 3) 4
+      have e4' : (N + 3) % 4 < 4 := Nat.mod_lt _ (by norm_num)
+      rw [hrec]
+      omega
+
+/-- Equivalent floor form: `excludedCount N ≤ ⌊N/6⌋`. -/
+theorem excludedCount_le_div_six (N : ℕ) : excludedCount N ≤ N / 6 := by
+  rw [Nat.le_div_iff_mul_le (by norm_num)]
+  have := six_excludedCount_le N
+  omega
+
+/-! ## The extremal family `a k = (4^{k+2}+2)/3` -/
+
+/-- The worst-case family for the descent: `a 0 = 6`, `a (k+1) = 4·a k − 2`.  Closed form
+`a k = (4^{k+2}+2)/3`; every member is `≡ 6 (mod 8)` and each descent step costs `δ = −4`. -/
+def a : ℕ → ℕ
+  | 0 => 6
+  | (k + 1) => 4 * a k - 2
+
+/-- Every member of the family is `≡ 6 (mod 8)` — the residue with the largest negative `δ`
+that admits an infinite descent (a residue `7` cannot chain to another `7`). -/
+theorem a_mod8 (k : ℕ) : a k % 8 = 6 := by
+  induction k with
+  | zero => rfl
+  | succ k ih =>
+    have h : a (k + 1) = 4 * a k - 2 := rfl
+    omega
+
+/-- The family is bounded below by `6` (hence the `ℕ` subtraction in the recurrence is safe). -/
+theorem a_ge (k : ℕ) : 6 ≤ a k := by have := a_mod8 k; omega
+
+/-- **The descent stays on the family:** `⌈a (k+1) / 4⌉ = a k`, i.e. `(a (k+1) + 3) / 4 = a k`.
+-/
+theorem a_step (k : ℕ) : (a (k + 1) + 3) / 4 = a k := by
+  have h : a (k + 1) = 4 * a k - 2 := rfl
+  have hge := a_ge k
+  omega
+
+/-! ## The exact error along the family -/
+
+/-- **The error is exactly `4k+6` along the extremal family:**
+`6·excludedCount (a k) = a k − (4k + 6)`.  Proved by induction using the `oq-03-oq-05`
+recursion and `a_step`; each step adds `δ = −4`. -/
+theorem excludedCount_a (k : ℕ) :
+    (6 : ℤ) * excludedCount (a k) = (a k : ℤ) - (4 * (k : ℤ) + 6) := by
+  induction k with
+  | zero =>
+    have h6 : excludedCount (a 0) = 0 := excludedCount_zero_of_le (by decide)
+    rw [h6]
+    norm_num [a]
+  | succ k ih =>
+    have hrec : excludedCount (a (k + 1))
+        = a (k + 1) / 8 + excludedCount ((a (k + 1) + 3) / 4) := excludedCount_rec (a (k + 1))
+    rw [a_step k] at hrec
+    have hmod : a k % 8 = 6 := a_mod8 k
+    have hak1 : a (k + 1) = 4 * a k - 2 := rfl
+    have hge := a_ge k
+    have hdiv : 8 * (a (k + 1) / 8) + a (k + 1) % 8 = a (k + 1) := Nat.div_add_mod _ 8
+    have hak1mod : a (k + 1) % 8 = 6 := a_mod8 (k + 1)
+    -- the per-step value of the floor `a(k+1)/8`, in `ℤ`
+    have hkeyZ : (6 : ℤ) * ((a (k + 1) / 8 : ℕ) : ℤ) = 3 * (a k : ℤ) - 6 := by omega
+    have hak1Z : (a (k + 1) : ℤ) = 4 * (a k : ℤ) - 2 := by omega
+    have hsum : (6 : ℤ) * excludedCount (a (k + 1))
+        = 6 * ((a (k + 1) / 8 : ℕ) : ℤ) + 6 * excludedCount (a k) := by
+      rw [hrec]; push_cast; ring
+    rw [hsum, ih]
+    push_cast
+    linarith [hkeyZ, hak1Z]
+
+/-- Restated: the error `N − 6·excludedCount N` equals `4k+6` at `N = a k`. -/
+theorem error_eq (k : ℕ) :
+    (a k : ℤ) - 6 * excludedCount (a k) = 4 * (k : ℤ) + 6 := by
+  have := excludedCount_a k; linarith
+
+/-! ## The dichotomy, settled -/
+
+/-- **The oscillation is genuinely unbounded.**  For every target `C` there is an `N` with
+`C ≤ N − 6·excludedCount N`.  Concretely `N = a ⌈C⌉` works, since the error there is `4·C+6`.
+Together with `six_excludedCount_le` (which gives `0 ≤ N − 6·excludedCount N` always), this
+shows the error is `≥ 0` everywhere and reaches every height — so it is **not** `O(1)`; its
+order is `Θ(log N)`. -/
+theorem error_unbounded (C : ℤ) :
+    ∃ N : ℕ, C ≤ (N : ℤ) - 6 * excludedCount N := by
+  refine ⟨a C.toNat, ?_⟩
+  rw [error_eq]
+  have h1 : C ≤ (C.toNat : ℤ) := by omega
+  have h2 : (0 : ℤ) ≤ (C.toNat : ℤ) := Int.natCast_nonneg _
+  linarith
+
+/-- **The full picture in one statement:** `0 ≤ N − 6·excludedCount N` for all `N`, and the
+quantity is unbounded above.  Hence the `oq-03-oq-05` oscillation is one-sided and `Θ(log N)`,
+never `O(1)`. -/
+theorem density_error_one_sided_and_unbounded :
+    (∀ N : ℕ, 0 ≤ (N : ℤ) - 6 * excludedCount N) ∧
+      (∀ C : ℤ, ∃ N : ℕ, C ≤ (N : ℤ) - 6 * excludedCount N) := by
+  refine ⟨fun N => ?_, error_unbounded⟩
+  have := six_excludedCount_le N
+  have : (6 : ℤ) * excludedCount N ≤ N := by exact_mod_cast this
+  linarith
+
+end LagrangeFourSquaresWaringG2OQ03OQ05OQ01

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
+  "slug": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
+  "title": "The Non-Three-Square Density Error Is One-Sided and Genuinely Unbounded",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.LagrangeFourSquaresWaringG2OQ03OQ05"
+    ],
+    "opens": [
+      "LagrangeFourSquaresWaringG2OQ03OQ05"
+    ],
+    "namespace": "LagrangeFourSquaresWaringG2OQ03OQ05OQ01",
+    "lineCount": 172,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/LagrangeFourSquaresWaringG2OQ03OQ05OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeFourSquaresWaringG2OQ03OQ05OQ01.lean",
+    "tags": [
+      "number-theory",
+      "sums-of-squares",
+      "three-square-theorem",
+      "legendre-three-square",
+      "waring-problem",
+      "natural-density",
+      "asymptotic-density",
+      "error-term",
+      "counting",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 172,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "density_error_one_sided_and_unbounded: the headline — a complete answer to the oq-03-oq-05 dichotomy. The oscillation E(N) = N − 6·excludedCount N of the non-three-square counting function satisfies BOTH (i) 0 ≤ E(N) for every N (one-sided), AND (ii) for every target C there is an N with C ≤ E(N) (unbounded above). So E(N) is NOT O(1): its true order is Θ(log N), pinned between the explicit family below and the oq-03-oq-05 upper bound |E(N)| ≤ 6(log₂N+1).",
+      "six_excludedCount_le: the ONE-SIDED SHARP bound 6·excludedCount N ≤ N for ALL N (equivalently excludedCount N ≤ ⌊N/6⌋, excludedCount_le_div_six). The density 1/6 is approached STRICTLY FROM BELOW — never overshot. This is strictly stronger than the oq-03-oq-05 two-sided bound whose upper half was +6(log₂N+1). The proof: the oq-03-oq-05 recursion telescopes E(N) = E(⌈N/4⌉) + δ(N) with a per-step increment δ(N) = ⌊(N mod 8 + 3)/4⌋ − (N mod 8) depending ONLY on N mod 8, taking the eight values 0,0,−1,−2,−3,−3,−4,−5 — all ≤ 0, so the running total never turns positive (strong induction, the residue arithmetic discharged by omega).",
+      "excludedCount_a + the extremal family a: an EXPLICIT divergent subsequence settling unboundedness. Define a 0 = 6, a (k+1) = 4·a k − 2 (closed form a k = (4^{k+2}+2)/3). Every a k ≡ 6 (mod 8) (a_mod8) — the residue with the largest negative δ = −4 that admits an infinite descent (a residue 7 cannot chain to another 7) — and the descent stays on the family: ⌈a(k+1)/4⌉ = a k (a_step). Hence by induction 6·excludedCount (a k) = a k − (4k+6), i.e. E(a k) = 4k+6 grows linearly in k = Θ(log a k) while a k ≈ 4^k.",
+      "The residue reduction δ(N) = ⌊(N mod 8 + 3)/4⌋ − (N mod 8): the conceptual core. The two-variable error analysis of oq-03-oq-05 collapses to a single mod-8 lookup, which simultaneously yields the sign (all δ ≤ 0 ⟹ one-sided) and the worst case (δ = −4 on residue 6, sustainable ⟹ unbounded). This is what turns a 'bounded or not?' question into a closed-form answer."
+    ],
+    "prerequisites": [
+      "excludedCount, excludedCount_rec (excludedCount N = N/8 + excludedCount ⌈N/4⌉), and excludedCount_zero_of_le from the merged sibling oq-03-oq-05 entry — imported and reused verbatim; this entry adds no new facts about the excluded family itself, only a finer analysis of the same recursion.",
+      "Nat.div_add_mod and Nat.strong_induction_on (Mathlib): the division/remainder identities feeding omega, and the strong-induction scheme along the 4-descent.",
+      "omega (Lean): discharges every residue-arithmetic and Nat-division goal, including the mod-8 case split for δ and the ℤ-cast error identities."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.div_add_mod",
+        "description": "8*(N/8)+N%8 = N and 4*M+(N+3)%4 = N+3; the only inputs omega needs to evaluate the per-step increment δ(N) and prove 6·excludedCount N ≤ N.",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "Nat.strong_induction_on",
+        "description": "Strong induction along the 4-descent N ↦ ⌈N/4⌉, used for the one-sided bound six_excludedCount_le.",
+        "module": "Mathlib.Init.Data.Nat.Lemmas"
+      },
+      {
+        "theorem": "Nat.le_div_iff_mul_le",
+        "description": "Converts 6·excludedCount N ≤ N into the floor form excludedCount N ≤ ⌊N/6⌋.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
+      "relationship": "extends",
+      "description": "Direct sequel answering oq-03-oq-05's own follow-up question (oq-03-oq-05-oq-01): whether the density error 6·excludedCount N − N is O(1) along subsequences or genuinely unbounded. This entry reuses the parent's 4-descent recursion verbatim and settles the dichotomy — the error is one-sided (always ≤ 0) and Θ(log N), via a residue reduction the parent did not extract."
+    },
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-04",
+      "relationship": "depends-on",
+      "description": "Transitively relies on the 2-adic normal form and computable Decidable instance for the excluded family E = {4^a(8b+7)} supplied by oq-03-oq-04, through which excludedCount is a genuine Finset.card."
+    },
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03",
+      "relationship": "related",
+      "description": "Refines the quantitative picture of the three-square exceptional set: where oq-03-oq-05 gave the leading density 1/6, this entry pins the exact one-sided sign and the Θ(log N) order of the second-order fluctuation."
+    }
+  ],
+  "references": [
+    {
+      "title": "Essai sur la théorie des nombres",
+      "author": "Adrien-Marie Legendre",
+      "year": "1798",
+      "venue": "Three-square theorem",
+      "description": "n = x²+y²+z² is solvable iff n ≠ 4^a(8b+7). This entry analyses the second-order error term in the counting function of the exceptional family 4^a(8b+7)."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "A complete answer to the oq-03-oq-05 dichotomy about the second-order behaviour of the non-three-square counting function excludedCount N = #{n < N : n ∈ E}, E = {4^a(8b+7)}. Writing E(N) = N − 6·excludedCount N, the parent's 4-descent recursion excludedCount N = N/8 + excludedCount ⌈N/4⌉ telescopes to E(N) = E(⌈N/4⌉) + δ(N), where the increment δ(N) = ⌊(N mod 8 + 3)/4⌋ − (N mod 8) depends ONLY on N mod 8, taking the eight values 0,0,−1,−2,−3,−3,−4,−5. Two consequences: (1) ONE-SIDED SHARPNESS (six_excludedCount_le) — every δ ≤ 0 forces 6·excludedCount N ≤ N for all N, i.e. excludedCount N ≤ ⌊N/6⌋, so the density 1/6 is approached strictly from below and never overshot; (2) GENUINE UNBOUNDEDNESS (error_unbounded) via the explicit extremal family a 0 = 6, a (k+1) = 4·a k − 2 (= (4^{k+2}+2)/3), every member ≡ 6 (mod 8) with descent ⌈a(k+1)/4⌉ = a k staying on the family, giving 6·excludedCount (a k) = a k − (4k+6) so E(a k) = 4k+6 → ∞. The combined statement density_error_one_sided_and_unbounded records both halves. 172 lines, 9 theorems, 1 definition, 0 axioms, 0 sorries; #print axioms = [propext, Classical.choice, Quot.sound], no native_decide.",
+    "implications": "The oscillation in the density-1/6 law is settled: not O(1) but Θ(log N), and one-sided — the counting function never exceeds N/6. The mechanism is a clean reduction of a two-variable error analysis to a single mod-8 lookup, which exposes both the sign (all increments ≤ 0) and the extremal direction (the sustainable residue 6) at once. The same residue-reduction template applies to the exceptional sets of other 2-adically self-similar ternary genera, where the analogous increment table determines whether the corresponding density error is one-sided and what its logarithmic constant is."
+  }
+}


### PR DESCRIPTION
## Summary

Settles the open dichotomy posed by **oq-03-oq-05** ("the natural density of the non-three-square integers is 1/6"): is the density error `6·excludedCount N − N` `O(1)` along subsequences, or genuinely unbounded? **Answer: one-sided (always ≤ 0) and genuinely unbounded — order Θ(log N).**

For `E = {4^a(8b+7)}` (the integers that are *not* sums of three squares) and `excludedCount N = #{n < N : n ∈ E}`, the merged oq-03-oq-05 recursion `excludedCount N = N/8 + excludedCount ⌈N/4⌉` telescopes the error `E(N) = N − 6·excludedCount N` into

> `E(N) = E(⌈N/4⌉) − δ(N)`,  where  `δ(N) = ⌊(N mod 8 + 3)/4⌋ − (N mod 8)`  depends **only on N mod 8**, taking the eight values `0, 0, −1, −2, −3, −3, −4, −5`.

## Results

- **`six_excludedCount_le`** — one-sided sharp bound: `6·excludedCount N ≤ N` for **all** N (every δ ≤ 0), equivalently `excludedCount N ≤ ⌊N/6⌋` (`excludedCount_le_div_six`). The density 1/6 is approached **strictly from below**, never overshot — strictly stronger than the parent's two-sided `+6(log₂N+1)` upper half.
- **`excludedCount_a`** — explicit extremal family `a 0 = 6`, `a (k+1) = 4·a k − 2` (closed form `(4^{k+2}+2)/3`): every member `≡ 6 (mod 8)`, descent `⌈a(k+1)/4⌉ = a k` stays on the family, giving `6·excludedCount (a k) = a k − (4k+6)`, so `E(a k) = 4k+6 → ∞` while `a k ≈ 4^k`.
- **`density_error_one_sided_and_unbounded`** — combines both: `0 ≤ E(N)` everywhere **and** unbounded above ⟹ order Θ(log N), never O(1).

## Verification

- **172 lines, 9 theorems, 1 definition, 0 axioms, 0 sorries.**
- Docker build succeeds on Lean v4.26.0 / Mathlib.
- `#print axioms density_error_one_sided_and_unbounded` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `native_decide`/`ofReduceBool`. Status `verified`, badge `original`.
- Reuses the merged oq-03-oq-05 recursion verbatim; adds no new facts about the excluded family, only a finer analysis of the same descent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)