### PR TITLE
audit: mark halls-theorem-oq-02 clean (balanced bipartite Hall)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17547,8 +17547,14 @@
       "lastAudited": "2026-06-21T09:27:27Z",
       "result": "clean",
       "issues": []
+    },
+    "halls-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T09:38:07Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T10:15:00Z"
+  "lastUpdated": "2026-06-21T10:30:00Z"
 }


### PR DESCRIPTION
## Audit: halls-theorem-oq-02 — CLEAN

Deep-audited the newest unaudited gallery entry, **halls-theorem-oq-02** ("Hall's Theorem for Balanced Bipartite Graphs: the One-Sided Condition Suffices", merged in #27309).

### Verification (`Proofs/HallsTheoremOQ02.lean`)
| Claim (meta.json) | Source | ✓ |
|---|---|---|
| lineCount 110 | 110 | ✓ |
| theoremCount 2 | `isMatching_saturating_both_of_balanced`, `exists_isPerfectMatching_of_balanced` | ✓ |
| definitionCount 0 | only an in-proof `let φ` | ✓ |
| axiomCount 0 | no `axiom` decls | ✓ |
| sorries 0 | none | ✓ |
| status verified / badge original | no `native_decide`, no assumption-carrying structures | ✓ |

### Substance
- Both theorems build on the parent `HallsTheoremOQ01.hall_marriage` (verified, 0-sorry / 0-axiom) via an elementary `ncard` counting argument (matched-partner map `φ` injects `p₁` into `p₂`; balance + finiteness upgrade injection to bijection).
- Genuine strengthening (one-sided Hall ⟹ both-sides saturation in the balanced case), not a trivial Mathlib wrapper.
- 0-axiom claim is consistent with reliance only on standard foundational axioms (propext / Classical.choice / Quot.sound).

Queue: 2804 → 2805 audited (drained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)