### PR TITLE
research(lagrange-four-squares-waring-g2-oq-03-oq-07): multiplier–QR reduction collapses legendreSym p (−d) onto legendreSym p (−n) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2804,6 +2804,7 @@ import Proofs.LagrangeFourSquaresWaringG2OQ01General
 import Proofs.LagrangeFourSquaresWaringG2OQ03OQ04
 import Proofs.LagrangeFourSquaresWaringG2OQ03OQ05
 import Proofs.LagrangeFourSquaresWaringG2OQ03OQ05OQ01
+import Proofs.LagrangeFourSquaresWaringG2OQ03OQ07
 import Proofs.LagrangeTheorem
 import Proofs.LagrangeTheoremOQ01
 import Proofs.LagrangeTheoremOQ01OQ01

--- a/proofs/Proofs/LagrangeFourSquaresWaringG2OQ03OQ07.lean
+++ b/proofs/Proofs/LagrangeFourSquaresWaringG2OQ03OQ07.lean
@@ -1,0 +1,171 @@
+import Mathlib
+
+/-!
+# The multiplier–quadratic-residue reduction for three-square sufficiency
+
+**Open question (`lagrange-four-squares-waring-g2-oq-03-oq-07`)**, a slice of the
+"if" direction of Legendre's three-square theorem
+(`lagrange-four-squares-waring-g2-oq-03`).
+
+## Background: the multiplier mechanism
+
+The classical Dirichlet/Minkowski route to *sufficiency*
+(`n ≠ 4^a(8b+7) ⟹ n = x²+y²+z²`) hinges on a geometry-of-numbers step
+(`Proofs.ThreeSquares.dirichlet_key_lemma`) whose hypotheses are:
+
+* a **multiplier** `d ≥ 1` and a **prime** `p = d·n − 1`, and
+* a **quadratic-residue condition** `legendreSym p (−d) = 1`.
+
+From such data the sublattice `L = {(x,y,z) : p ∣ x − r·y, p ∣ z}` carries a
+short vector that descends to a representation of `n`.  Dirichlet's theorem on
+primes in arithmetic progressions (now in Mathlib as
+`Nat.forall_exists_prime_gt_and_modEq`) is what supplies the prime `p` once the
+right congruence class is identified.
+
+The friction in the existing development is that the QR condition is phrased in
+terms of the **multiplier** `d`, which — for the residue classes
+`n mod 8 ∈ {1,2,5,6}` — must be allowed to grow unboundedly (no small `d` works).
+That makes the Dirichlet selection look like it must control a moving target.
+
+## What this file proves
+
+The QR condition on the multiplier collapses to a QR condition on `n` **alone**.
+
+Because `p = d·n − 1`, we have `d·n ≡ 1 (mod p)`, hence
+`(−d)·(−n) = d·n ≡ 1 (mod p)`, so `−d` and `−n` are inverse modulo `p`.  Two
+numbers that are inverse mod `p` are simultaneously squares or simultaneously
+non-squares, therefore
+
+  `legendreSym p (−d) = legendreSym p (−n)`     (`legendreSym_neg_multiplier_eq`).
+
+In particular the geometry's hypothesis `legendreSym p (−d) = 1` is **equivalent**
+to `legendreSym p (−n) = 1` — a condition that depends only on `p` (through
+`p mod 4n`, by quadratic reciprocity), with the awkward multiplier `d` entirely
+eliminated.  This is exactly the simplification that makes the Dirichlet
+selection a fixed-target problem.
+
+We also record the Dirichlet **supply** of multiplier primes
+(`exists_multiplier_prime`): for every `n ≥ 2` and every bound `N` there is a
+prime `p > N` of the form `p = d·n − 1`.  Combining the two
+(`exists_multiplier_prime_qr_reduces`) yields, for every bound, a multiplier
+prime for which the geometry's QR hypothesis is governed solely by
+`legendreSym p (−n)`.
+
+## Honest scope
+
+This is the **selection / number-theoretic** layer.  It is `0`-axiom and
+self-contained.  It does **not** by itself discharge the sufficiency axiom
+`Proofs.ThreeSquares.not_excluded_form_is_sum_three_sq`: the companion geometry
+lemma `dirichlet_key_lemma` is currently established only for `d ∈ {1,2}` (its
+final descent `x² + d·y² = d·n − 1 ⟹ three squares` is special to those
+multipliers), whereas the classes needing unbounded `d` would require a
+`d`-uniform geometric construction.  What this file removes is the *apparent*
+need to track `d` inside the residue/QR bookkeeping.
+
+No `axiom`, no `sorry`, no `native_decide`.
+-/
+
+namespace ThreeSquaresMultiplierQR
+
+/-- **Key residue identity.**  If `p = d·n − 1` (encoded as `d·n = p + 1`), then
+`d·n ≡ 1 (mod p)`, i.e. `(d : ZMod p) · (n : ZMod p) = 1`. -/
+lemma natCast_mul_eq_one {n d p : ℕ} [Fact p.Prime] (hdn : d * n = p + 1) :
+    (d : ZMod p) * (n : ZMod p) = 1 := by
+  have h : (d : ZMod p) * (n : ZMod p) = ((d * n : ℕ) : ZMod p) := by push_cast; ring
+  rw [h, hdn]
+  push_cast
+  rw [ZMod.natCast_self]
+  ring
+
+/-- **Multiplier–QR reduction (Legendre-symbol form).**
+For a prime `p = d·n − 1`, the Legendre symbol of the *multiplier* `−d` equals
+that of `−n`:
+
+  `legendreSym p (−d) = legendreSym p (−n)`.
+
+The point is that `(−d)·(−n) = d·n ≡ 1 (mod p)`, so `−d` and `−n` are inverse
+modulo `p`; a unit and its inverse are simultaneously squares mod `p`. -/
+theorem legendreSym_neg_multiplier_eq {n d p : ℕ} [Fact p.Prime]
+    (hdn : d * n = p + 1) :
+    legendreSym p (-(d : ℤ)) = legendreSym p (-(n : ℤ)) := by
+  have hpc : (d : ZMod p) * (n : ZMod p) = 1 := natCast_mul_eq_one hdn
+  -- `d` and `n` are units mod `p`, hence nonzero, hence so are their negations.
+  have hdne : (d : ZMod p) ≠ 0 := by
+    intro h; rw [h, zero_mul] at hpc; exact zero_ne_one hpc
+  have hnne : (n : ZMod p) ≠ 0 := by
+    intro h; rw [h, mul_zero] at hpc; exact zero_ne_one hpc
+  -- `(−d)·(−n) ≡ 1 (mod p)`, so its Legendre symbol is `1` (it is a square).
+  have hz : (((-(d : ℤ)) * (-(n : ℤ)) : ℤ) : ZMod p) = 1 := by
+    push_cast; linear_combination hpc
+  have hprod : legendreSym p (-(d : ℤ)) * legendreSym p (-(n : ℤ)) = 1 := by
+    rw [← legendreSym.mul p]
+    rw [legendreSym.eq_one_iff p (by rw [hz]; exact one_ne_zero)]
+    rw [hz]; exact IsSquare.one
+  -- Both symbols are `±1`; a product of `1` forces them equal.  (The nonzero
+  -- hypotheses are elaborated directly against the expected `↑(-↑·) ≠ 0` form.)
+  rcases legendreSym.eq_one_or_neg_one (p := p) (a := -(d : ℤ))
+      (by push_cast; simpa using hdne) with hd | hd <;>
+    rcases legendreSym.eq_one_or_neg_one (p := p) (a := -(n : ℤ))
+      (by push_cast; simpa using hnne) with hn | hn <;>
+    rw [hd, hn] at hprod ⊢ <;> simp_all
+
+/-- **Selection criterion.**  The geometry's QR hypothesis on the multiplier is
+equivalent to the QR condition on `n` itself. -/
+theorem legendreSym_neg_d_eq_one_iff {n d p : ℕ} [Fact p.Prime]
+    (hdn : d * n = p + 1) :
+    legendreSym p (-(d : ℤ)) = 1 ↔ legendreSym p (-(n : ℤ)) = 1 := by
+  rw [legendreSym_neg_multiplier_eq hdn]
+
+/-- The QR condition on `n` *suffices* for the geometry's QR hypothesis on the
+multiplier — the direction actually consumed by `dirichlet_key_lemma`. -/
+theorem legendreSym_neg_n_one_imp_neg_d_one {n d p : ℕ} [Fact p.Prime]
+    (hdn : d * n = p + 1) (h : legendreSym p (-(n : ℤ)) = 1) :
+    legendreSym p (-(d : ℤ)) = 1 :=
+  (legendreSym_neg_d_eq_one_iff hdn).2 h
+
+/-- `n - 1` is coprime to `n` for `n ≥ 1` (consecutive integers). -/
+lemma coprime_pred_self {n : ℕ} (hn : 1 ≤ n) : Nat.Coprime (n - 1) n := by
+  rw [Nat.coprime_self_sub_left hn]
+  exact Nat.coprime_one_left n
+
+/-- **Dirichlet supply of multiplier primes.**  For every `n ≥ 2` and every
+bound `N` there is a prime `p > N` of the multiplier shape `p = d·n − 1` with
+`d ≥ 1`.  Here `p` is produced by Dirichlet's theorem in the residue class
+`p ≡ n − 1 (mod n)`, i.e. `p ≡ −1`. -/
+theorem exists_multiplier_prime {n : ℕ} (hn : 2 ≤ n) (N : ℕ) :
+    ∃ p d : ℕ, N < p ∧ p.Prime ∧ 1 ≤ d ∧ d * n = p + 1 := by
+  have hq : n ≠ 0 := by omega
+  have hcop : Nat.Coprime (n - 1) n := coprime_pred_self (by omega)
+  obtain ⟨p, hpgt, hpp, hpmod⟩ :=
+    Nat.forall_exists_prime_gt_and_modEq (max N n) hq hcop
+  have hpN : N < p := lt_of_le_of_lt (le_max_left _ _) hpgt
+  have hpn : n < p := lt_of_le_of_lt (le_max_right _ _) hpgt
+  -- `p ≡ n − 1 (mod n)` pins down `p % n = n − 1`.
+  have hpmod' : p % n = n - 1 := by
+    have h1 : p % n = (n - 1) % n := hpmod
+    rw [Nat.mod_eq_of_lt (show n - 1 < n by omega)] at h1
+    exact h1
+  -- Repackage the quotient as a fresh variable `q` (avoiding `p / n`, which
+  -- `omega` cannot reason about for a variable divisor `n`).
+  obtain ⟨q, hq⟩ : ∃ q, n * q + (n - 1) = p :=
+    ⟨p / n, by rw [← hpmod']; exact Nat.div_add_mod p n⟩
+  -- The multiplier is `d := q + 1`.
+  refine ⟨p, q + 1, hpN, hpp, by omega, ?_⟩
+  have hexp : (q + 1) * n = n * q + n := by ring
+  rw [hexp]
+  omega
+
+/-- **Selection assembled.**  For every `n ≥ 2` and every bound `N` there is a
+prime `p > N` of multiplier shape `p = d·n − 1` for which the geometry's QR
+hypothesis `legendreSym p (−d) = 1` is governed *solely* by `legendreSym p (−n)`:
+the latter being `1` already forces the former.  (The supplied `Fact p.Prime`
+instance is the standard hook for `legendreSym`.) -/
+theorem exists_multiplier_prime_qr_reduces {n : ℕ} (hn : 2 ≤ n) (N : ℕ) :
+    ∃ p d : ℕ, N < p ∧ p.Prime ∧ 1 ≤ d ∧ d * n = p + 1 ∧
+      ∀ _ : Fact p.Prime,
+        legendreSym p (-(n : ℤ)) = 1 → legendreSym p (-(d : ℤ)) = 1 := by
+  obtain ⟨p, d, hpN, hpp, hd1, hdn⟩ := exists_multiplier_prime hn N
+  exact ⟨p, d, hpN, hpp, hd1, hdn, fun _ h =>
+    legendreSym_neg_n_one_imp_neg_d_one hdn h⟩
+
+end ThreeSquaresMultiplierQR

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07/meta.json
@@ -1,0 +1,120 @@
+{
+  "id": "lagrange-four-squares-waring-g2-oq-03-oq-07",
+  "slug": "lagrange-four-squares-waring-g2-oq-03-oq-07",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "ThreeSquaresMultiplierQR",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/LagrangeFourSquaresWaringG2OQ03OQ07.lean",
+    "sorries": 0
+  },
+  "title": "The Multiplier–Quadratic-Residue Reduction for Three-Square Sufficiency",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeFourSquaresWaringG2OQ03OQ07.lean",
+    "tags": [
+      "number-theory",
+      "sums-of-squares",
+      "three-square-theorem",
+      "legendre-three-square",
+      "quadratic-residues",
+      "legendre-symbol",
+      "dirichlet-primes-in-ap",
+      "geometry-of-numbers",
+      "additive-number-theory",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 171,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "legendreSym_neg_multiplier_eq: the central identity. For a prime p of the multiplier shape p = d·n − 1, the Legendre symbol of the multiplier −d equals that of −n: legendreSym p (−d) = legendreSym p (−n). The proof is reciprocity-free: p = d·n − 1 gives d·n ≡ 1 (mod p), so (−d)·(−n) = d·n ≡ 1, making −d and −n inverse mod p; a product of two Legendre symbols equal to 1 (since the product argument is a square) forces the two symbols to coincide. This collapses the geometry-of-numbers QR hypothesis, phrased in terms of the awkward unbounded multiplier d, onto a condition on n alone.",
+      "legendreSym_neg_d_eq_one_iff / legendreSym_neg_n_one_imp_neg_d_one: the selection criterion. The hypothesis legendreSym p (−d) = 1 consumed by the gallery's geometry lemma ThreeSquares.dirichlet_key_lemma is equivalent to (and in particular implied by) legendreSym p (−n) = 1 — a condition depending only on p mod 4n, with the multiplier d entirely eliminated from the residue bookkeeping.",
+      "exists_multiplier_prime: the Dirichlet supply. For every n ≥ 2 and every bound N there is a prime p > N of multiplier shape p = d·n − 1 with d ≥ 1, produced by Mathlib's Dirichlet theorem on primes in arithmetic progressions (Nat.forall_exists_prime_gt_and_modEq) in the residue class p ≡ n − 1 ≡ −1 (mod n). The quotient is repackaged as a fresh variable to keep the divisibility bookkeeping inside omega's linear fragment.",
+      "exists_multiplier_prime_qr_reduces: the assembled selection layer. For every n ≥ 2 and bound N there is a multiplier prime p > N for which the geometry's QR hypothesis legendreSym p (−d) = 1 is governed solely by legendreSym p (−n): the latter being 1 already forces the former. This is exactly the number-theoretic input the unbounded-multiplier classes (n mod 8 ∈ {1,2,5,6}) need, now that Dirichlet-in-AP is available in Mathlib, with the dependence on d removed."
+    ],
+    "prerequisites": [
+      "Nat.forall_exists_prime_gt_and_modEq (Mathlib, NumberTheory/LSeries/PrimesInAP): Dirichlet's theorem on primes in arithmetic progressions — for coprime a, q there are infinitely many primes p ≡ a (mod q). The recently-added input that supplies the multiplier prime p ≡ −1 (mod n).",
+      "legendreSym.mul, legendreSym.eq_one_iff, legendreSym.eq_one_or_neg_one (Mathlib, NumberTheory/LegendreSymbol/Basic): multiplicativity, the square characterisation, and the ±1 dichotomy of the Legendre symbol — the algebra behind the multiplier reduction.",
+      "Nat.div_add_mod, Nat.mod_eq_of_lt, Nat.coprime_self_sub_left (Mathlib): the elementary ℕ arithmetic pinning p % n = n − 1 and the coprimality (n−1, n) feeding Dirichlet.",
+      "ThreeSquares.dirichlet_key_lemma (gallery, 0-axiom, d ∈ {1,2}): the geometry-of-numbers consumer whose QR hypothesis this entry reduces; the reduction is what makes its selection step a fixed-target (n-only) problem."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.forall_exists_prime_gt_and_modEq",
+        "description": "Dirichlet's theorem on primes in arithmetic progressions: for a coprime to q there are arbitrarily large primes p ≡ a (mod q). Supplies the multiplier prime p ≡ −1 (mod n).",
+        "module": "Mathlib.NumberTheory.LSeries.PrimesInAP"
+      },
+      {
+        "theorem": "legendreSym.eq_one_or_neg_one",
+        "description": "For p ∤ a, legendreSym p a = 1 or −1. With multiplicativity (legendreSym.mul) this is what turns a Legendre-symbol product of 1 into an equality of the two symbols.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
+      "question": "Force the QR condition legendreSym p (−n) = 1 by congruence selection: identify the residue class of p mod 4n (equivalently mod 8 and mod the odd part of n, via quadratic reciprocity for the Jacobi symbol) on which −n is a quadratic residue, show that class is coprime to 4n and compatible with p ≡ −1 (mod n), and conclude via Dirichlet that infinitely many multiplier primes p satisfy BOTH p = d·n − 1 and legendreSym p (−n) = 1. This upgrades exists_multiplier_prime_qr_reduces from a conditional reduction to an unconditional existence of a fully-qualified multiplier prime.",
+      "significance": "high"
+    },
+    {
+      "id": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-02",
+      "question": "Generalise the d ∈ {1,2} geometry of ThreeSquares.dirichlet_key_lemma to a d-uniform sublattice construction, so that the multiplier prime supplied here (with d = (p+1)/n unbounded) actually discharges n = x²+y²+z² for the classes n mod 8 ∈ {1,2,5,6}. The selection layer is now complete and d-free; the residual gap is purely geometric (a ternary-form descent valid for all d, e.g. via Gauss reduction of the form x² + d·y² + d·z²).",
+      "significance": "high"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03",
+      "relationship": "depends-on",
+      "description": "The parent three-square sufficiency study isolates sufficiency as the single axiom not_excluded_form_is_sum_three_sq, whose classical proof selects a multiplier prime p = d·n − 1 with legendreSym p (−d) = 1 and runs a geometry-of-numbers descent. This entry simplifies that selection step: legendreSym p (−d) reduces to legendreSym p (−n), eliminating the unbounded multiplier d from the residue/QR bookkeeping, and supplies the multiplier primes via Mathlib's Dirichlet theorem."
+    },
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-01",
+      "relationship": "related",
+      "description": "The Gauss-Eureka 8n+3 slice (oq-03-oq-01) handles one residue class of sufficiency via a bounded auxiliary prime; this entry treats the multiplier-selection mechanism uniformly in n and shows the QR condition is intrinsically a condition on −n, the form needed for the harder classes n mod 8 ∈ {1,2,5,6} that require unbounded multipliers."
+    },
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-06",
+      "relationship": "related",
+      "description": "The rational-half entry (oq-03-oq-06) reduces the remaining open sufficiency to a single Hasse-Minkowski statement (squarefree non-excluded n is a sum of three rational squares), explicitly noting it requires a Dirichlet-prime-in-AP input. This entry provides exactly that input in the multiplier formulation and shows the Legendre-symbol side condition depends only on n."
+    },
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-04",
+      "relationship": "related",
+      "description": "The 2-adic normal form (oq-03-oq-04) characterises the excluded family E = {4^a(8b+7)} via residues mod 8; the multiplier reduction here is the complementary selection tool for the NON-excluded classes, reducing their QR side condition to legendreSym p (−n), the quantity controlled by p mod 4n."
+    }
+  ],
+  "references": [
+    {
+      "title": "Sur la possibilité de décomposer un nombre en trois carrés",
+      "author": "P. G. L. Dirichlet",
+      "year": "1850",
+      "venue": "Three-square theorem via primes in arithmetic progressions",
+      "description": "Dirichlet's proof of Legendre's three-square theorem selects an auxiliary prime in an arithmetic progression and applies a quadratic-form argument. This entry formalises the multiplier-selection core of that route and shows the quadratic-residue side condition depends only on −n."
+    },
+    {
+      "title": "Essai sur la théorie des nombres",
+      "author": "Adrien-Marie Legendre",
+      "year": "1798",
+      "venue": "Three-square theorem",
+      "description": "n = x²+y²+z² is solvable over ℤ iff n ≠ 4^a(8b+7). The sufficiency direction is the target this selection layer advances."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The number-theoretic selection layer of the Dirichlet/Minkowski route to three-square sufficiency, made d-free and supplied by Mathlib's Dirichlet theorem. The headline legendreSym_neg_multiplier_eq proves that for a prime p = d·n − 1 the Legendre symbol of the multiplier, legendreSym p (−d), equals legendreSym p (−n): a reciprocity-free consequence of (−d)·(−n) = d·n ≡ 1 (mod p), so −d and −n are mutually inverse mod p and hence simultaneously (non)squares. The selection corollaries legendreSym_neg_d_eq_one_iff / legendreSym_neg_n_one_imp_neg_d_one turn the geometry's QR hypothesis into a condition on n alone, and exists_multiplier_prime / exists_multiplier_prime_qr_reduces use Dirichlet on primes in the class p ≡ −1 (mod n) to supply arbitrarily large multiplier primes for which legendreSym p (−n) = 1 already forces legendreSym p (−d) = 1. 171 lines, 7 theorems, 0 definitions, 0 axioms, 0 sorries; verified to depend only on propext / Classical.choice / Quot.sound.",
+    "implications": "This removes the apparent obstruction that the multiplier d must be tracked through the residue/QR bookkeeping in the unbounded-multiplier classes n mod 8 ∈ {1,2,5,6}: the quadratic-residue side condition is intrinsically a condition on −n (governed by p mod 4n), independent of d. Combined with Mathlib's now-available Dirichlet theorem, the selection of a multiplier prime is a fixed-target problem. The residual gap toward the parent's sufficiency axiom is therefore isolated to two clean follow-ups: (oq-07-oq-01) forcing legendreSym p (−n) = 1 by reciprocity-driven congruence selection, and (oq-07-oq-02) extending the d ∈ {1,2} sublattice geometry to a d-uniform construction that consumes the unbounded multiplier."
+  }
+}


### PR DESCRIPTION
## Summary

The number-theoretic **selection layer** of the Dirichlet/Minkowski route to three-square sufficiency (`n ≠ 4^a(8b+7) ⟹ n = x²+y²+z²`), made **multiplier-free** and supplied by Mathlib's Dirichlet theorem on primes in arithmetic progressions.

The classical route selects a multiplier `d ≥ 1` and a prime `p = d·n − 1` subject to the quadratic-residue side condition `legendreSym p (−d) = 1`, then runs a geometry-of-numbers descent (`ThreeSquares.dirichlet_key_lemma`). The friction: for `n mod 8 ∈ {1,2,5,6}` the multiplier `d` must grow unboundedly, so the QR condition looks like a moving target.

**Headline — `legendreSym_neg_multiplier_eq`:** for a prime `p = d·n − 1`,
> `legendreSym p (−d) = legendreSym p (−n)`.

Reciprocity-free: `p = d·n − 1` gives `d·n ≡ 1 (mod p)`, so `(−d)·(−n) = d·n ≡ 1` makes `−d` and `−n` mutually inverse mod `p`, hence simultaneously (non)squares. The awkward multiplier `d` drops out of the QR bookkeeping entirely — the condition is intrinsically about `−n` (governed by `p mod 4n`).

## Contents (171 lines, 7 theorems, 0 definitions)

- `legendreSym_neg_multiplier_eq` — the central identity.
- `legendreSym_neg_d_eq_one_iff` / `legendreSym_neg_n_one_imp_neg_d_one` — the selection criterion: `dirichlet_key_lemma`'s hypothesis `legendreSym p (−d) = 1` ⟺ (and ⟸) `legendreSym p (−n) = 1`.
- `exists_multiplier_prime` — Dirichlet supply: for `n ≥ 2` and any bound `N`, a prime `p > N` of shape `p = d·n − 1`, via `Nat.forall_exists_prime_gt_and_modEq` in the class `p ≡ −1 (mod n)`.
- `exists_multiplier_prime_qr_reduces` — assembled: arbitrarily large multiplier primes for which `legendreSym p (−n) = 1` already forces `legendreSym p (−d) = 1`.

## Verification

- **0-axiom, verified.** `#print axioms` on all headline theorems → `[propext, Classical.choice, Quot.sound]` only.
- No `axiom`, no `sorry`, no `native_decide`.
- Builds clean against Mathlib v4.26.0 (`./proofs/scripts/docker-build.sh Proofs.LagrangeFourSquaresWaringG2OQ03OQ07`).

## Honest scope

This is the **selection / number-theoretic** layer; it does not by itself discharge the parent's sufficiency axiom. The two residual gaps are recorded as follow-ups:
- **oq-07-oq-01:** force `legendreSym p (−n) = 1` by reciprocity-driven congruence selection (upgrade the conditional reduction to unconditional existence).
- **oq-07-oq-02:** extend the `d ∈ {1,2}` sublattice geometry to a `d`-uniform construction consuming the unbounded multiplier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)