### PR TITLE
research(feuerbachs-theorem-defs-oq-01-oq-01-oq-01): reflections of the orthocenter lie on the circumcircle [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2504,6 +2504,7 @@ import Proofs.FermatsLastTheoremOQ03
 import Proofs.FeuerbachsTheorem
 import Proofs.FeuerbachsTheoremDefs
 import Proofs.FeuerbachsTheoremDefsOQ01
+import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ03
 import Proofs.FeuerbachsTheoremDefsOQ04
 import Proofs.FeuerbachsTheoremOQ01

--- a/proofs/Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01.lean
@@ -1,0 +1,296 @@
+/-
+  Feuerbach's Theorem DefsOQ01OQ01OQ01: Reflections of the Orthocenter Lie on
+  the Circumcircle
+
+  ## The Open Question
+
+  The sibling `FeuerbachsTheoremDefsOQ01OQ01` proved the *concurrency* of the
+  three altitudes at the orthocenter `H = A + B + C - 2·O` (O the circumcenter).
+  Its first open question asks to verify the classical companion fact that
+
+    the reflection of the orthocenter across each side of the triangle
+    lies on the circumcircle,
+
+  a hallmark of the orthocentric configuration that the nine-point-circle
+  development never establishes.
+
+  ## What This File Proves
+
+  ### Reflection over a side line
+  For a point `H` and a line through `P` with direction `Q - P`, `reflectOverLine`
+  is the mirror image of `H` across that line.  Writing `H'` for the reflection of
+  the orthocenter across a side, the headline theorems are
+
+  `reflectOrthoBC_on_circumcircle` : `dist(O, H'_BC) = R`
+  `reflectOrthoCA_on_circumcircle` : `dist(O, H'_CA) = R`
+  `reflectOrthoAB_on_circumcircle` : `dist(O, H'_AB) = R`
+
+  where `R = circumradius`.  Each reflected orthocenter is at distance `R` from the
+  circumcenter, hence on the circumcircle; `orthocenter_reflections_concyclic`
+  bundles all three.
+
+  The proof reduces, after clearing the projection denominator, to a single
+  polynomial identity in the vertex/circumcenter coordinates that holds modulo the
+  two equidistance relations `|B - O|² = |A - O|²` and `|C - O|² = |A - O|²`
+  (the `reflect_core` lemma, discharged by an explicit `linear_combination`).
+
+  ### Reflection over a side midpoint (antipode)
+  `reflectOrthoMidBC_eq_antipode` : the reflection of `H` across the midpoint of
+  `BC` is the point `2·O - A`, the antipode of `A` on the circumcircle; hence
+  `reflectOrthoMidBC_on_circumcircle` places it on the circumcircle as well.
+
+  ### Worked example
+  `triangle_345_reflectOrthoMidBC` : for the 3-4-5 right triangle the reflection of
+  the orthocenter (= `A = (0,0)`) over the midpoint of `BC` is `(3, 4)`, the
+  antipode of `A` on the circumcircle of radius `5/2` centred at `(3/2, 2)`.
+
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Proofs.FeuerbachsTheoremDefs
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace FeuerbachsTheoremDefsOQ01OQ01OQ01
+
+open FeuerbachsTheorem
+
+-- ============================================================
+-- Part 0: Pairwise equidistance of the circumcenter
+--
+-- The parent declares the equidistance facts `private`; we reprove the two we
+-- need (against vertex A) so this file builds independently.  Each follows from
+-- the perpendicular-bisector identity, which is *linear* in O.
+-- ============================================================
+
+set_option maxHeartbeats 6400000 in
+private lemma perp_bisector_AB (T : Triangle) :
+    (T.B.1 - T.A.1) * (T.B.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.B.2 - T.A.2) * (T.B.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+set_option maxHeartbeats 6400000 in
+private lemma perp_bisector_AC (T : Triangle) :
+    (T.C.1 - T.A.1) * (T.C.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.C.2 - T.A.2) * (T.C.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+/-- `|B - O|² = |A - O|²` : the circumcenter is equidistant from `A` and `B`. -/
+private lemma equidistB (T : Triangle) :
+    (T.B.1 - T.circumcenter.1) ^ 2 + (T.B.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := perp_bisector_AB T
+  nlinarith [sq_nonneg (T.B.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.B.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+/-- `|C - O|² = |A - O|²` : the circumcenter is equidistant from `A` and `C`. -/
+private lemma equidistC (T : Triangle) :
+    (T.C.1 - T.circumcenter.1) ^ 2 + (T.C.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := perp_bisector_AC T
+  nlinarith [sq_nonneg (T.C.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.C.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+-- ============================================================
+-- Part I: Reflection of a point over a line
+-- ============================================================
+
+/-- The reflection of point `H` over the line through `P` with direction `Q - P`.
+    With `t` the projection parameter of `H` onto the line, the foot is
+    `P + t·(Q - P)` and the reflection is `2·foot - H`. -/
+def reflectOverLine (H P Q : Point) : Point :=
+  let dx := Q.1 - P.1
+  let dy := Q.2 - P.2
+  let dd := dx ^ 2 + dy ^ 2
+  let t := ((H.1 - P.1) * dx + (H.2 - P.2) * dy) / dd
+  (2 * P.1 + 2 * t * dx - H.1, 2 * P.2 + 2 * t * dy - H.2)
+
+-- ============================================================
+-- Part II: The core polynomial identity
+--
+-- After clearing the projection denominator `dd = |Q - P|²`, the squared distance
+-- from O to the reflected orthocenter (numerator `N1² + N2²`) equals `|V - O|²·dd²`
+-- modulo the two equidistance relations, where V is the vertex opposite the line.
+-- The cofactors are explicit (found by ideal membership over the equidistance
+-- generators); `linear_combination` discharges the identity by `ring`.
+-- ============================================================
+
+set_option maxHeartbeats 25600000 in
+private lemma reflect_core (ox oy vx vy px py qx qy : ℝ)
+    (hP : (px - ox) ^ 2 + (py - oy) ^ 2 = (vx - ox) ^ 2 + (vy - oy) ^ 2)
+    (hQ : (qx - ox) ^ 2 + (qy - oy) ^ 2 = (vx - ox) ^ 2 + (vy - oy) ^ 2) :
+    (-3*ox*px^2 + 6*ox*px*qx + ox*py^2 - 2*ox*py*qy - 3*ox*qx^2 + ox*qy^2 - 4*oy*px*py + 4*oy*px*qy + 4*oy*py*qx - 4*oy*qx*qy + px^3 - px^2*qx + px^2*vx + px*py^2 + 2*px*py*vy - px*qx^2 - 2*px*qx*vx - px*qy^2 - 2*px*qy*vy - py^2*qx - py^2*vx - 2*py*qx*vy + 2*py*qy*vx + qx^3 + qx^2*vx + qx*qy^2 + 2*qx*qy*vy - qy^2*vx) ^ 2 + (-4*ox*px*py + 4*ox*px*qy + 4*ox*py*qx - 4*ox*qx*qy + oy*px^2 - 2*oy*px*qx - 3*oy*py^2 + 6*oy*py*qy + oy*qx^2 - 3*oy*qy^2 + px^2*py - px^2*qy - px^2*vy + 2*px*py*vx + 2*px*qx*vy - 2*px*qy*vx + py^3 - py^2*qy + py^2*vy - py*qx^2 - 2*py*qx*vx - py*qy^2 - 2*py*qy*vy + qx^2*qy - qx^2*vy + 2*qx*qy*vx + qy^3 + qy^2*vy) ^ 2
+      = ((vx - ox) ^ 2 + (vy - oy) ^ 2) * ((qx - px) ^ 2 + (qy - py) ^ 2) ^ 2 := by
+  linear_combination (-4*ox^2*px*qx + 4*ox^2*px*vx + 8*ox^2*qx^2 - 12*ox^2*qx*vx + 4*ox^2*vx^2 - 8*ox*oy^2*qx + 8*ox*oy^2*vx - 4*ox*oy*px*qy + 4*ox*oy*px*vy - 4*ox*oy*py*qx + 4*ox*oy*py*vx + 24*ox*oy*qx*qy - 4*ox*oy*qx*vy - 20*ox*oy*qy*vx - 4*ox*px^3 + 14*ox*px^2*qx - 2*ox*px^2*vx - 4*ox*px*py^2 + 8*ox*px*py*qy - 14*ox*px*qx^2 + 8*ox*px*qx*vx - 2*ox*px*qy^2 - 6*ox*px*vx^2 - 2*ox*px*vy^2 + 6*ox*py^2*qx - 2*ox*py^2*vx - 12*ox*py*qx*qy + 4*ox*py*qx*vy + 4*ox*py*qy*vx - 4*ox*py*vx*vy - 2*ox*qx^2*vx - 12*ox*qx*qy*vy + 10*ox*qx*vx^2 + 6*ox*qx*vy^2 + 2*ox*qy^2*vx + 12*ox*qy*vx*vy - 4*ox*vx^3 - 4*ox*vx*vy^2 - 8*oy^3*qy + 8*oy^3*vy - 4*oy^2*py*qy + 4*oy^2*py*vy + 4*oy^2*qx^2 + 20*oy^2*qy^2 - 12*oy^2*qy*vy - 4*oy^2*vx^2 - 8*oy^2*vy^2 - 4*oy*px^2*py + 6*oy*px^2*qy - 2*oy*px^2*vy + 8*oy*px*py*qx - 12*oy*px*qx*qy + 4*oy*px*qx*vy + 4*oy*px*qy*vx - 4*oy*px*vx*vy - 4*oy*py^3 + 14*oy*py^2*qy - 2*oy*py^2*vy - 2*oy*py*qx^2 - 14*oy*py*qy^2 + 8*oy*py*qy*vy - 2*oy*py*vx^2 - 6*oy*py*vy^2 - 4*oy*qx^2*qy - 2*oy*qx^2*vy - 4*oy*qx*qy*vx + 4*oy*qx*vx*vy - 4*oy*qy^3 - 14*oy*qy^2*vy + 10*oy*qy*vx^2 + 22*oy*qy*vy^2 + px^4 - 2*px^3*qx + 2*px^3*vx + 2*px^2*py^2 - 2*px^2*py*qy + 2*px^2*py*vy - px^2*qx^2 - 6*px^2*qx*vx - px^2*qy^2 - 2*px^2*qy*vy + px^2*vx^2 + px^2*vy^2 - 2*px*py^2*qx + 2*px*py^2*vx - 4*px*py*qx*vy - 4*px*py*qy*vx + 4*px*qx^3 + 4*px*qx^2*vx + 4*px*qx*qy^2 + 4*px*qx*qy*vy - 2*px*qx*vx^2 - 2*px*qx*vy^2 + 2*px*vx^3 + 2*px*vx*vy^2 + py^4 - 2*py^3*qy + 2*py^3*vy - py^2*qx^2 - 2*py^2*qx*vx - py^2*qy^2 - 6*py^2*qy*vy + py^2*vx^2 + py^2*vy^2 + 4*py*qx^2*qy + 4*py*qx*qy*vx + 4*py*qy^3 + 4*py*qy^2*vy - 2*py*qy*vx^2 - 2*py*qy*vy^2 + 2*py*vx^2*vy + 2*py*vy^3 - qx^4 - 2*qx^2*qy^2 + 4*qx^2*qy*vy - qx^2*vx^2 - qx^2*vy^2 - 2*qx*vx^3 - 2*qx*vx*vy^2 - qy^4 + 4*qy^3*vy - qy^2*vx^2 - qy^2*vy^2 - 6*qy*vx^2*vy - 6*qy*vy^3 + vx^4 + 2*vx^2*vy^2 + vy^4) * hP + (4*ox^2*px^2 - 8*ox^2*px*qx + 8*ox^2*qx*vx - 4*ox^2*vx^2 + 8*ox*oy^2*px - 8*ox*oy^2*vx + 8*ox*oy*px*py - 16*ox*oy*px*qy - 8*ox*oy*px*vy - 8*ox*oy*py*qx + 8*ox*oy*qx*vy + 16*ox*oy*qy*vx - 4*ox*px^2*qx - 4*ox*px^2*vx - 4*ox*px*py*qy - 4*ox*px*py*vy + 12*ox*px*qx^2 + 4*ox*px*qy^2 + 12*ox*px*qy*vy + 4*ox*px*vx^2 + 8*ox*py*qx*qy - 4*ox*py*qy*vx + 4*ox*py*vx*vy - 4*ox*qx^3 - 4*ox*qx*qy^2 - 8*ox*qx*vx^2 - 4*ox*qx*vy^2 - 12*ox*qy*vx*vy + 4*ox*vx^3 + 4*ox*vx*vy^2 + 8*oy^3*py - 8*oy^3*vy - 4*oy^2*px^2 - 16*oy^2*py*qy - 8*oy^2*py*vy + 16*oy^2*qy*vy + 4*oy^2*vx^2 + 8*oy^2*vy^2 + 4*oy*px^2*qy + 4*oy*px^2*vy - 4*oy*px*py*qx - 4*oy*px*py*vx + 8*oy*px*qx*qy - 4*oy*px*qx*vy + 4*oy*px*vx*vy + 4*oy*py*qx^2 + 4*oy*py*qx*vx + 12*oy*py*qy^2 + 8*oy*py*qy*vy + 4*oy*py*vy^2 - 4*oy*qx^2*qy - 4*oy*qx*vx*vy - 4*oy*qy^3 - 8*oy*qy*vx^2 - 20*oy*qy*vy^2 + 4*px^2*qx*vx - 4*px^2*qy*vy + 4*px*py*qx*vy + 4*px*py*qy*vx - 2*px*qx^3 - 6*px*qx^2*vx - 2*px*qx*qy^2 - 4*px*qx*qy*vy + 2*px*qx*vx^2 + 2*px*qx*vy^2 - 2*px*qy^2*vx - 2*px*vx^3 - 2*px*vx*vy^2 - 2*py*qx^2*qy - 2*py*qx^2*vy - 4*py*qx*qy*vx - 2*py*qy^3 - 6*py*qy^2*vy + 2*py*qy*vx^2 + 2*py*qy*vy^2 - 2*py*vx^2*vy - 2*py*vy^3 + qx^4 + 2*qx^3*vx + 2*qx^2*qy^2 + 2*qx^2*qy*vy + 2*qx*qy^2*vx + 2*qx*vx^3 + 2*qx*vx*vy^2 + qy^4 + 2*qy^3*vy + 6*qy*vx^2*vy + 6*qy*vy^3 - vx^4 - 2*vx^2*vy^2 - vy^4) * hQ
+
+-- ============================================================
+-- Part III: Generic distance lemma for the reflected orthocenter
+-- ============================================================
+
+set_option maxHeartbeats 25600000 in
+/-- If `H = V + P + Q - 2·O` (the orthocenter, with `V` the vertex opposite the
+    side `PQ`) and `O` is equidistant from `V, P, Q`, then the reflection of `H`
+    over line `PQ` is at distance `|V - O|` from `O`: it lies on the circumcircle. -/
+lemma reflectOverLine_orthocenter_dist_sq
+    (ox oy vx vy px py qx qy hx hy : ℝ)
+    (hHx : hx = vx + px + qx - 2 * ox) (hHy : hy = vy + py + qy - 2 * oy)
+    (hP : (px - ox) ^ 2 + (py - oy) ^ 2 = (vx - ox) ^ 2 + (vy - oy) ^ 2)
+    (hQ : (qx - ox) ^ 2 + (qy - oy) ^ 2 = (vx - ox) ^ 2 + (vy - oy) ^ 2)
+    (hdd : (qx - px) ^ 2 + (qy - py) ^ 2 ≠ 0) :
+    dist2_sq (ox, oy) (reflectOverLine (hx, hy) (px, py) (qx, qy))
+      = dist2_sq (ox, oy) (vx, vy) := by
+  subst hHx hHy
+  have hcore := reflect_core ox oy vx vy px py qx qy hP hQ
+  have hdd2 : ((qx - px) ^ 2 + (qy - py) ^ 2) ^ 2 ≠ 0 := pow_ne_zero 2 hdd
+  rw [show dist2_sq (ox, oy) (vx, vy) = (vx - ox) ^ 2 + (vy - oy) ^ 2 from rfl]
+  have expand : dist2_sq (ox, oy)
+        (reflectOverLine (vx + px + qx - 2 * ox, vy + py + qy - 2 * oy) (px, py) (qx, qy))
+      = ((-3*ox*px^2 + 6*ox*px*qx + ox*py^2 - 2*ox*py*qy - 3*ox*qx^2 + ox*qy^2 - 4*oy*px*py + 4*oy*px*qy + 4*oy*py*qx - 4*oy*qx*qy + px^3 - px^2*qx + px^2*vx + px*py^2 + 2*px*py*vy - px*qx^2 - 2*px*qx*vx - px*qy^2 - 2*px*qy*vy - py^2*qx - py^2*vx - 2*py*qx*vy + 2*py*qy*vx + qx^3 + qx^2*vx + qx*qy^2 + 2*qx*qy*vy - qy^2*vx) ^ 2 + (-4*ox*px*py + 4*ox*px*qy + 4*ox*py*qx - 4*ox*qx*qy + oy*px^2 - 2*oy*px*qx - 3*oy*py^2 + 6*oy*py*qy + oy*qx^2 - 3*oy*qy^2 + px^2*py - px^2*qy - px^2*vy + 2*px*py*vx + 2*px*qx*vy - 2*px*qy*vx + py^3 - py^2*qy + py^2*vy - py*qx^2 - 2*py*qx*vx - py*qy^2 - 2*py*qy*vy + qx^2*qy - qx^2*vy + 2*qx*qy*vx + qy^3 + qy^2*vy) ^ 2) / ((qx - px) ^ 2 + (qy - py) ^ 2) ^ 2 := by
+    unfold dist2_sq reflectOverLine
+    simp only []
+    field_simp
+    ring
+  rw [expand, div_eq_iff hdd2]
+  linear_combination hcore
+
+-- ============================================================
+-- Part IV: The three side reflections
+-- ============================================================
+
+/-- Reflection of the orthocenter across side `BC`. -/
+def reflectOrthoBC (T : Triangle) : Point := reflectOverLine T.orthocenter T.B T.C
+
+/-- Reflection of the orthocenter across side `CA`. -/
+def reflectOrthoCA (T : Triangle) : Point := reflectOverLine T.orthocenter T.C T.A
+
+/-- Reflection of the orthocenter across side `AB`. -/
+def reflectOrthoAB (T : Triangle) : Point := reflectOverLine T.orthocenter T.A T.B
+
+theorem reflectOrthoBC_dist_sq (T : Triangle) :
+    dist2_sq T.circumcenter (reflectOrthoBC T) = dist2_sq T.circumcenter T.A := by
+  unfold reflectOrthoBC
+  exact reflectOverLine_orthocenter_dist_sq T.circumcenter.1 T.circumcenter.2
+    T.A.1 T.A.2 T.B.1 T.B.2 T.C.1 T.C.2 T.orthocenter.1 T.orthocenter.2
+    (by unfold Triangle.orthocenter; ring) (by unfold Triangle.orthocenter; ring)
+    (equidistB T) (equidistC T) (bc_sq_ne_zero T)
+
+theorem reflectOrthoCA_dist_sq (T : Triangle) :
+    dist2_sq T.circumcenter (reflectOrthoCA T) = dist2_sq T.circumcenter T.B := by
+  unfold reflectOrthoCA
+  exact reflectOverLine_orthocenter_dist_sq T.circumcenter.1 T.circumcenter.2
+    T.B.1 T.B.2 T.C.1 T.C.2 T.A.1 T.A.2 T.orthocenter.1 T.orthocenter.2
+    (by unfold Triangle.orthocenter; ring) (by unfold Triangle.orthocenter; ring)
+    ((equidistC T).trans (equidistB T).symm) (equidistB T).symm (ca_sq_ne_zero T)
+
+theorem reflectOrthoAB_dist_sq (T : Triangle) :
+    dist2_sq T.circumcenter (reflectOrthoAB T) = dist2_sq T.circumcenter T.C := by
+  unfold reflectOrthoAB
+  exact reflectOverLine_orthocenter_dist_sq T.circumcenter.1 T.circumcenter.2
+    T.C.1 T.C.2 T.A.1 T.A.2 T.B.1 T.B.2 T.orthocenter.1 T.orthocenter.2
+    (by unfold Triangle.orthocenter; ring) (by unfold Triangle.orthocenter; ring)
+    ((equidistC T).symm) ((equidistB T).trans (equidistC T).symm) (ab_sq_ne_zero T)
+
+-- ============================================================
+-- Part V: On the circumcircle (distance = circumradius)
+-- ============================================================
+
+/-- The reflection of the orthocenter across `BC` lies on the circumcircle. -/
+theorem reflectOrthoBC_on_circumcircle (T : Triangle) :
+    dist2 T.circumcenter (reflectOrthoBC T) = T.circumradius := by
+  unfold Triangle.circumradius dist2
+  congr 1
+  exact reflectOrthoBC_dist_sq T
+
+/-- The reflection of the orthocenter across `CA` lies on the circumcircle. -/
+theorem reflectOrthoCA_on_circumcircle (T : Triangle) :
+    dist2 T.circumcenter (reflectOrthoCA T) = T.circumradius := by
+  unfold Triangle.circumradius dist2
+  congr 1
+  show dist2_sq T.circumcenter (reflectOrthoCA T) = dist2_sq T.circumcenter T.A
+  rw [reflectOrthoCA_dist_sq T]
+  exact equidistB T
+
+/-- The reflection of the orthocenter across `AB` lies on the circumcircle. -/
+theorem reflectOrthoAB_on_circumcircle (T : Triangle) :
+    dist2 T.circumcenter (reflectOrthoAB T) = T.circumradius := by
+  unfold Triangle.circumradius dist2
+  congr 1
+  show dist2_sq T.circumcenter (reflectOrthoAB T) = dist2_sq T.circumcenter T.A
+  rw [reflectOrthoAB_dist_sq T]
+  exact equidistC T
+
+/-- **The reflections of the orthocenter across the three sides are concyclic**,
+    all lying on the circumcircle. -/
+theorem orthocenter_reflections_concyclic (T : Triangle) :
+    dist2 T.circumcenter (reflectOrthoBC T) = T.circumradius ∧
+    dist2 T.circumcenter (reflectOrthoCA T) = T.circumradius ∧
+    dist2 T.circumcenter (reflectOrthoAB T) = T.circumradius :=
+  ⟨reflectOrthoBC_on_circumcircle T, reflectOrthoCA_on_circumcircle T,
+   reflectOrthoAB_on_circumcircle T⟩
+
+-- ============================================================
+-- Part VI: Reflection over a side midpoint is the antipode
+-- ============================================================
+
+/-- Reflection of the orthocenter across the midpoint of `BC`
+    (`= 2·midpoint(BC) - H = (B + C) - H`). -/
+def reflectOrthoMidBC (T : Triangle) : Point :=
+  (T.B.1 + T.C.1 - T.orthocenter.1, T.B.2 + T.C.2 - T.orthocenter.2)
+
+/-- The reflection of the orthocenter across the midpoint of `BC` is `2·O - A`,
+    the antipode of `A` on the circumcircle. -/
+theorem reflectOrthoMidBC_eq_antipode (T : Triangle) :
+    reflectOrthoMidBC T
+      = (2 * T.circumcenter.1 - T.A.1, 2 * T.circumcenter.2 - T.A.2) := by
+  unfold reflectOrthoMidBC Triangle.orthocenter
+  simp only [Prod.mk.injEq]
+  constructor <;> ring
+
+/-- The reflection of the orthocenter across the midpoint of `BC` lies on the
+    circumcircle (it is the antipode of `A`). -/
+theorem reflectOrthoMidBC_on_circumcircle (T : Triangle) :
+    dist2 T.circumcenter (reflectOrthoMidBC T) = T.circumradius := by
+  unfold Triangle.circumradius dist2
+  congr 1
+  unfold reflectOrthoMidBC Triangle.orthocenter
+  simp only []
+  ring
+
+-- ============================================================
+-- Part VII: Worked example (3-4-5 right triangle)
+-- ============================================================
+
+/-- For the 3-4-5 right triangle the reflection of the orthocenter (`= A = (0,0)`)
+    across the midpoint of `BC` is `(3, 4)`, the antipode of `A` on the
+    circumcircle of radius `5/2` centred at `(3/2, 2)`. -/
+theorem triangle_345_reflectOrthoMidBC :
+    reflectOrthoMidBC triangle_345 = (3, 4) := by
+  unfold reflectOrthoMidBC
+  rw [triangle_345_orthocenter]
+  unfold triangle_345
+  simp only [Prod.mk.injEq]
+  constructor <;> norm_num
+
+end FeuerbachsTheoremDefsOQ01OQ01OQ01

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,197 @@
+{
+  "id": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01",
+  "title": "Feuerbach's Theorem: Reflections of the Orthocenter Lie on the Circumcircle",
+  "slug": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01",
+  "description": "Answers the first open question of the altitude-concurrency entry: the reflection of the orthocenter across each of the three sides lies on the circumcircle (the three reflected orthocenters are concyclic with the vertices), and the reflection across each side midpoint is the antipode of the opposite vertex. 10 theorems and 6 lemmas, 5 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
+    "tags": [
+      "geometry",
+      "feuerbach",
+      "orthocenter",
+      "circumcircle",
+      "reflection",
+      "concyclic",
+      "antipode",
+      "circumcenter",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only propext / Classical.choice / Quot.sound, confirmed by #print axioms). Inherits the coordinate API (circumcenter/orthocenter formulas, non-degeneracy lemmas) from FeuerbachsTheoremDefs.lean, which is itself 0-sorry, 0-axiom.",
+    "lineCount": 296,
+    "theoremCount": 16,
+    "definitionCount": 5,
+    "originalContributions": [
+      "reflectOrthoBC_on_circumcircle / reflectOrthoCA_on_circumcircle / reflectOrthoAB_on_circumcircle: the reflection of the orthocenter across each side of the triangle lies on the circumcircle (distance from the circumcenter equals the circumradius)",
+      "orthocenter_reflections_concyclic: the three reflected orthocenters are concyclic, all lying on the circumcircle — the headline orthocentric-configuration fact the nine-point-circle development never establishes",
+      "reflect_core: the central polynomial identity — after clearing the projection denominator dd = |Q - P|^2, the squared distance numerator N1^2 + N2^2 equals |V - O|^2 * dd^2 modulo the two circumcenter-equidistance relations — discharged by an explicit linear_combination with cofactors found by ideal membership over the equidistance generators",
+      "reflectOverLine_orthocenter_dist_sq: reusable generic lemma proving that the reflection of H = V + P + Q - 2O over line PQ is at distance |V - O| from O whenever O is equidistant from V, P, Q",
+      "reflectOverLine: a reusable definition of the mirror image of a point across the line through two given points",
+      "reflectOrthoMidBC_eq_antipode: the reflection of the orthocenter across the midpoint of a side is exactly 2O - A, the antipode of the opposite vertex on the circumcircle",
+      "reflectOrthoMidBC_on_circumcircle: consequently the midpoint reflection also lies on the circumcircle",
+      "equidistB / equidistC: local reproof of the circumcenter's pairwise equidistance (the parent declares these private), via the perpendicular-bisector identity which is linear in O",
+      "triangle_345_reflectOrthoMidBC: worked example, the reflection of the orthocenter (= A = (0,0)) of the 3-4-5 right triangle over the midpoint of BC is (3,4), the antipode of A on the circumcircle of radius 5/2 centred at (3/2, 2)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "A classical hallmark of the orthocentric configuration is that reflecting the orthocenter H across any side of the triangle lands on the circumcircle; equivalently, the three such reflections are concyclic with the vertices on the circumradius-R circle about the circumcenter O. The gallery's FeuerbachsTheoremDefs.lean works with the coordinate orthocenter H = A + B + C - 2O, and the sibling concurrency entry verified that this point lies on all three altitudes. The first open question raised there asks for the reflection-onto-circumcircle property; this entry supplies it, together with the companion midpoint-reflection (antipode) fact.",
+    "problemStatement": "With O the circumcenter, R the circumradius and H = A + B + C - 2O the orthocenter, let H' be the reflection of H across a side line of the triangle. Prove:\n1. **Reflection across each side**: dist(O, H') = R, so H' lies on the circumcircle, for the reflections across BC, CA, and AB; the three reflections are concyclic.\n2. **Reflection across each side midpoint**: the reflection of H across the midpoint of BC equals 2O - A, the antipode of A on the circumcircle, and so also lies on the circumcircle.",
+    "text": "A 296-line companion file with 10 theorems and 6 lemmas (5 definitions). It defines reflection of a point across an arbitrary line, proves a reusable distance lemma for the reflected orthocenter, and instantiates it on the three sides to place each reflected orthocenter on the circumcircle, bundling them as a concyclicity capstone. It then proves the midpoint reflection is the antipode of the opposite vertex (hence also on the circumcircle) and closes with the 3-4-5 worked example.",
+    "proofStrategy": "The reflection of H across the line PQ is computed via the orthogonal-projection parameter t, giving foot = P + t(Q - P) and reflection 2*foot - H, with a single denominator dd = |Q - P|^2. Measuring the squared distance from O and clearing dd, the goal becomes the polynomial identity N1^2 + N2^2 = |V - O|^2 * dd^2 (V the vertex opposite the line), which holds modulo the two equidistance relations |P - O|^2 = |V - O|^2 and |Q - O|^2 = |V - O|^2. This identity (reflect_core) is proved by an explicit linear_combination whose cofactors were obtained by computing ideal membership over the equidistance generators (translation to the frame O = origin keeps the cofactors compact). A generic lemma reflectOverLine_orthocenter_dist_sq packages the denominator clearing (div_eq_iff after a field_simp/ring normalization) and is instantiated three times, once per side, with the appropriate equidistance facts. Reducing distances to squared distances is then a single congr 1 on Real.sqrt.\n\nThe midpoint reflection is elementary: 2*midpoint(BC) - H = (B + C) - (A + B + C - 2O) = 2O - A by ring, and dist(O, 2O - A) = |O - A| = R.",
+    "keyInsights": [
+      "Reflecting H across a side and asking it to land on the circumcircle is, after clearing the projection denominator, a single polynomial identity that lies in the ideal generated by the two circumcenter-equidistance relations — so it closes by one explicit linear_combination rather than case analysis.",
+      "Translating to the circumcenter-at-origin frame (a = A - O, etc.) collapses the cofactor search from eight variables to six and keeps the linear_combination certificate small enough to write down.",
+      "A single generic reflection-distance lemma serves all three sides: the vertex opposite the reflecting line plays the role of V, and the orthocenter's symmetric sum A + B + C makes H = V + P + Q - 2O hold in every cyclic assignment.",
+      "The midpoint reflection needs no equidistance algebra at all: (B + C) - H telescopes to 2O - A by ring, exhibiting the reflected point as the antipode of the opposite vertex, whose distance to O is the circumradius by definition.",
+      "In the 3-4-5 right triangle the orthocenter is the right-angle vertex A = (0,0), and its midpoint reflection over BC is the diametrically opposite point (3,4), a concrete instance of the antipode phenomenon."
+    ],
+    "prerequisites": [
+      "FeuerbachsTheoremDefs.lean — coordinate API (Point, Triangle, circumcenter, orthocenter, dist2, dist2_sq, circumradius) and the lemmas circumcenter_denom_ne_zero, bc/ca/ab_sq_ne_zero",
+      "feuerbachs-theorem-defs-oq-01-oq-01 — the altitude-concurrency entry whose first open question this answers",
+      "Reflection of a point across a line via orthogonal projection; the orthocentric configuration and the Euler relation H = A + B + C - 2O",
+      "field_simp / ring / linear_combination for rational and polynomial identities over R, and ideal membership for finding linear_combination cofactors"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Pairwise Equidistance of the Circumcenter",
+      "startLine": 1,
+      "endLine": 117,
+      "summary": "Module docstring stating the open question, imports FeuerbachsTheoremDefs, and reproves the two circumcenter-equidistance facts (against vertex A) locally — the parent declares them private — via the perpendicular-bisector identity which is linear in O.",
+      "mathContext": "perp_bisector_AB / _AC close by substituting the circumcenter fraction and field_simp; ring; equidistB / equidistC then follow by nlinarith. These provide the |P - O|^2 = |V - O|^2 hypotheses fed to the core lemma."
+    },
+    {
+      "id": "reflectline",
+      "title": "Part I: Reflection of a Point Over a Line",
+      "startLine": 119,
+      "endLine": 137,
+      "summary": "Defines reflectOverLine H P Q, the mirror image of H across the line through P with direction Q - P, via the orthogonal-projection parameter.",
+      "mathContext": "foot = P + t(Q - P) with t = ((H - P).(Q - P))/|Q - P|^2; the reflection is 2*foot - H, carrying a single denominator dd = |Q - P|^2."
+    },
+    {
+      "id": "core",
+      "title": "Part II: The Core Polynomial Identity",
+      "startLine": 139,
+      "endLine": 153,
+      "summary": "After clearing dd, the squared-distance numerator N1^2 + N2^2 equals |V - O|^2 * dd^2 modulo the two equidistance relations; proved by an explicit linear_combination.",
+      "mathContext": "reflect_core: the cofactors were found by ideal membership over the equidistance generators in the O-at-origin frame; ring verifies the degree-6 certificate."
+    },
+    {
+      "id": "generic",
+      "title": "Part III: Generic Distance Lemma for the Reflected Orthocenter",
+      "startLine": 154,
+      "endLine": 181,
+      "summary": "Proves dist2_sq(O, reflection of H over PQ) = dist2_sq(O, V) when H = V + P + Q - 2O and O is equidistant from V, P, Q.",
+      "mathContext": "reflectOverLine_orthocenter_dist_sq: rewrite the squared distance as (N1^2 + N2^2)/dd^2, apply div_eq_iff with dd^2 != 0, and close by linear_combination reflect_core."
+    },
+    {
+      "id": "sides",
+      "title": "Part IV: The Three Side Reflections",
+      "startLine": 182,
+      "endLine": 217,
+      "summary": "Defines the three reflected orthocenters and instantiates the generic lemma per side, giving dist2_sq(O, H'_BC) = dist2_sq(O, A) and the two cyclic analogues.",
+      "mathContext": "Each instantiation supplies the orthocenter relation by unfold; ring and the two equidistance facts (with transitivity for the CA and AB cases)."
+    },
+    {
+      "id": "circumcircle",
+      "title": "Part V: On the Circumcircle and Concyclicity",
+      "startLine": 218,
+      "endLine": 257,
+      "summary": "Converts the squared-distance equalities to dist(O, H') = R for each side and bundles them: the three reflected orthocenters are concyclic on the circumcircle.",
+      "mathContext": "reflectOrtho*_on_circumcircle: congr 1 on Real.sqrt reduces to the squared-distance lemma; orthocenter_reflections_concyclic conjoins the three."
+    },
+    {
+      "id": "antipode",
+      "title": "Part VI: Reflection Over a Side Midpoint is the Antipode",
+      "startLine": 258,
+      "endLine": 280,
+      "summary": "Shows the reflection of H over the midpoint of BC equals 2O - A, the antipode of A, and hence also lies on the circumcircle.",
+      "mathContext": "reflectOrthoMidBC_eq_antipode: (B + C) - H = 2O - A by ring; reflectOrthoMidBC_on_circumcircle: dist(O, 2O - A) = |O - A| = R."
+    },
+    {
+      "id": "example",
+      "title": "Part VII: Worked Example (3-4-5 Right Triangle)",
+      "startLine": 281,
+      "endLine": 296,
+      "summary": "The reflection of the orthocenter (= A = (0,0)) of the 3-4-5 right triangle over the midpoint of BC is (3,4), the antipode of A on the circumcircle.",
+      "mathContext": "triangle_345_reflectOrthoMidBC: rw [triangle_345_orthocenter] then norm_num, using the parent's orthocenter computation."
+    }
+  ],
+  "conclusion": {
+    "summary": "Establishes the classical orthocentric-configuration fact missing from the nine-point-circle development: reflecting the orthocenter across any side lands on the circumcircle, so the three reflections are concyclic with the vertices, and reflecting across any side midpoint gives the antipode of the opposite vertex. 10 theorems and 6 lemmas, 5 definitions, 0 axioms, 0 sorries.",
+    "implications": "**Foundational grounding**: the coordinate orthocenter is now shown to obey the reflection property that characterizes it within the circumcircle, complementing the altitude-concurrency characterization of the sibling entry.\n\n**Reusable geometry**: reflectOverLine (mirror across an arbitrary line) and reflectOverLine_orthocenter_dist_sq (a denominator-clearing distance lemma with an explicit ideal-membership certificate) are reusable tools for downstream R^2 Euclidean-geometry proofs.",
+    "openQuestions": [
+      "Show the reflections of the orthocenter across the three sides are precisely the antipodes-after-rotation of the vertices, i.e. identify each reflected orthocenter with a specific point of the circumcircle rather than only proving it lies on the circle.",
+      "Prove that the circle through the three reflected orthocenters coincides with the circumcircle as sets (not just that each reflection lies on it), and deduce the reflection of the circumcircle over a side passes through H.",
+      "Reformulate the reflection-onto-circumcircle property in Mathlib's EuclideanGeometry API (EuclideanGeometry.reflection and Sphere) to enable an upstream contribution."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "answers the first open question of the altitude-concurrency entry: the reflection of the orthocenter across each side lies on the circumcircle"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01",
+      "relationship": "related",
+      "description": "the altitude-feet characterization that, together with concurrency, underlies the orthocentric reflection configuration"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs",
+      "relationship": "extends",
+      "description": "uses the orthocenter defined by the Euler formula H = A + B + C - 2O and the circumcenter coordinate API from FeuerbachsTheoremDefs.lean"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Proofs.FeuerbachsTheoremDefs"],
+    "opens": ["FeuerbachsTheorem"],
+    "namespace": "FeuerbachsTheoremDefsOQ01OQ01OQ01",
+    "lineCount": 296,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 5,
+    "path": "Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "orthocenter_reflections_concyclic",
+      "type": "core",
+      "description": "The reflections of the orthocenter across the three sides all lie on the circumcircle (are concyclic with the vertices).",
+      "leanType": "∀ T : Triangle, dist(O, H'_BC) = R ∧ dist(O, H'_CA) = R ∧ dist(O, H'_AB) = R"
+    },
+    {
+      "name": "reflectOrthoBC_on_circumcircle",
+      "type": "core",
+      "description": "The reflection of the orthocenter across side BC is at distance R from the circumcenter, hence on the circumcircle.",
+      "leanType": "∀ T : Triangle, dist2 T.circumcenter (reflectOrthoBC T) = T.circumradius"
+    },
+    {
+      "name": "reflectOrthoMidBC_eq_antipode",
+      "type": "core",
+      "description": "The reflection of the orthocenter across the midpoint of BC is 2O - A, the antipode of A on the circumcircle.",
+      "leanType": "∀ T : Triangle, reflectOrthoMidBC T = (2*O.1 - A.1, 2*O.2 - A.2)"
+    },
+    {
+      "name": "reflectOverLine_orthocenter_dist_sq",
+      "type": "lemma",
+      "description": "Generic: the reflection of H = V + P + Q - 2O over line PQ is at distance |V - O| from O when O is equidistant from V, P, Q.",
+      "leanType": "dist2_sq (ox,oy) (reflectOverLine (hx,hy) (px,py) (qx,qy)) = dist2_sq (ox,oy) (vx,vy)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of the altitude-concurrency entry **feuerbachs-theorem-defs-oq-01-oq-01**: the reflection of the orthocenter `H = A + B + C − 2O` across each side of the triangle lies on the circumcircle. Hence the three reflected orthocenters are concyclic with the vertices on the radius-`R` circle about the circumcenter `O`. A companion result shows the reflection across each side *midpoint* is the antipode of the opposite vertex.

This is a hallmark of the orthocentric configuration that the gallery's nine-point-circle development (which only ever *names* the coordinate orthocenter) never establishes.

## What is proved

- **`reflectOverLine`** — mirror image of a point across an arbitrary line (via orthogonal projection).
- **`reflect_core`** — the central polynomial identity: after clearing the projection denominator `dd = |Q−P|²`, the squared-distance numerator `N1² + N2²` equals `|V−O|²·dd²` modulo the two circumcenter-equidistance relations. Discharged by an explicit `linear_combination` whose cofactors were obtained by ideal membership over the equidistance generators (computed in the `O`-at-origin frame to keep the certificate compact).
- **`reflectOverLine_orthocenter_dist_sq`** — reusable generic distance lemma, instantiated once per side.
- **`reflectOrthoBC/CA/AB_on_circumcircle`** + **`orthocenter_reflections_concyclic`** — distance from `O` equals the circumradius for all three reflections.
- **`reflectOrthoMidBC_eq_antipode`** (`= 2O − A`) and **`reflectOrthoMidBC_on_circumcircle`** — the elementary midpoint-reflection companion.
- **`triangle_345_reflectOrthoMidBC`** — worked example: the midpoint reflection of the 3-4-5 orthocenter is `(3,4)`, the antipode of `A`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01` — **build succeeded**.
- `#print axioms` on every theorem: only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms, 0 sorries** (no `sorryAx`, no `Lean.ofReduceBool`).
- Self-contained against the grandparent `FeuerbachsTheoremDefs` (the circumcenter equidistance facts are reproved locally, since the parent declares them `private`).

296 lines, 10 theorems + 6 lemmas, 5 definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)