### PR TITLE
audit: mark feuerbachs-theorem-defs-oq-01-oq-01-oq-01 clean (orthocenter reflections)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17559,8 +17559,15 @@
       "lastAudited": "2026-06-21T11:00:00Z",
       "result": "clean",
       "issues": []
+    },
+    "feuerbachs-theorem-defs-oq-01-oq-01-oq-01": {
+      "agentId": "auditor-agent",
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T10:08:53Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T11:00:00Z"
+  "lastUpdated": "2026-06-21T11:30:00Z"
 }


### PR DESCRIPTION
## Audit: `feuerbachs-theorem-defs-oq-01-oq-01-oq-01` — CLEAN

Deep audit of the orthocenter-reflection entry (research PR #27315: reflections of the orthocenter lie on the circumcircle).

### Verification
| Claim | meta.json | Source | ✓ |
|---|---|---|---|
| definitions | 5 | 5 | ✓ |
| theorems+lemmas | 16 | 16 (10 thm + 6 lemma) | ✓ |
| lineCount | 296 | 296 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no `axiom` decls) | ✓ |

- No `native_decide`, no `admit`/`sorryAx`, no `True` stubs.
- `status: verified` / `badge: original` defensible — `#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound`.
- Dependency `FeuerbachsTheoremDefs.lean`: its single structure (`Triangle`) carries only a non-collinearity well-formedness precondition (`nondegenerate`), not a smuggled mathematical result. Parent already audited 0-axiom clean (#27304, #27307).

Tracker: adds `feuerbachs-theorem-defs-oq-01-oq-01-oq-01` with `result: clean`, `auditCount: 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)