### PR TITLE
research(halls-theorem-oq-01-oq-01): Ore deficiency form of Hall's theorem [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2665,6 +2665,7 @@ import Proofs.GreensTheoremOQ04
 import Proofs.HadamardThreeLines
 import Proofs.HallMarriageTheoremOQ01
 import Proofs.HallsTheoremOQ01
+import Proofs.HallsTheoremOQ01OQ01
 import Proofs.HallsTheoremOQ02
 import Proofs.HaltingProblem
 import Proofs.HappyNumberOQ01

--- a/proofs/Proofs/HallsTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/HallsTheoremOQ01OQ01.lean
@@ -1,0 +1,198 @@
+/-
+Hall's theorem with a defect: the deficiency (Ore) form of the marriage theorem
+
+Source: Open question from the halls-theorem gallery family (follow-up to
+`HallsTheoremOQ01`, whose `exists_violating_of_no_matching` is the qualitative
+"a deficient family must violate Hall somewhere" statement; here we quantify it).
+Status: VERIFIED (0 axioms, 0 sorries)
+
+The ordinary marriage theorem (`Finset.all_card_le_biUnion_card_iff_exists_injective`
+in Mathlib) says a finite family of finite sets `t : ι → Finset α` admits a *system
+of distinct representatives* — an injective `e : ι → α` with `e i ∈ t i` for every
+`i` — **iff** Hall's condition holds:
+
+    ∀ s : Finset ι,  #s ≤ #(s.biUnion t).
+
+The **defect** (or **deficiency**) version, due to Ore, measures *how far* a family
+is from having a full SDR. For a fixed slack `d : ℕ`:
+
+  * the *relaxed* Hall condition is  `∀ s, #s ≤ #(s.biUnion t) + d`;
+  * the matching conclusion is a *partial* SDR that leaves at most `d` indices
+    unrepresented: a set `rejected` of indices with `#rejected ≤ d`, together with
+    an assignment `e` that is injective on the remaining indices and represents
+    each of them (`e i ∈ t i` for `i ∉ rejected`).
+
+`defect_hall` proves these are equivalent. Taking `d = 0` recovers the classical
+marriage theorem (`defect_hall_zero`).
+
+Novel content (absent from Mathlib, which has only the `d = 0` case):
+
+  * `defect_hall` : the relaxed Hall condition `∀ s, #s ≤ #(s.biUnion t) + d`
+        holds **iff** there is a partial SDR missing at most `d` indices.
+  * `defect_hall_zero` : the `d = 0` specialisation, recovering the SDR theorem.
+
+Proof idea (the standard reduction). Adjoin `d` brand-new "universal" candidates by
+working over `α ⊕ Fin d`, where every set gains all `d` right-hand dummies:
+`t' i = (t i).image inl ∪ (univ.image inr)`. For a nonempty `s` the enlarged
+neighbourhood is exactly the old one plus the `d` dummies, so the relaxed condition
+for `t` becomes the *ordinary* Hall condition for `t'`. Mathlib's marriage theorem
+gives a genuine SDR `f : ι → α ⊕ Fin d`; since `f` is injective and there are only
+`d` dummies, at most `d` indices land on a dummy (these are the `rejected` ones),
+and the rest are sent injectively into `α`, giving the partial SDR. The converse is
+an elementary counting split `s = (s ∩ rejected) ∪ (s \ rejected)`.
+
+(The ground type `α` is assumed nonempty — representatives are drawn from it — which
+is the standard hypothesis; for empty `α` the family is the empty family of sets and
+the statement degenerates.)
+-/
+import Mathlib
+
+open Finset Function
+
+namespace HallsTheoremOQ01OQ01
+
+variable {ι α : Type*} [Fintype ι] [DecidableEq ι] [DecidableEq α] [Nonempty α]
+
+/-- **Hall's theorem with defect `d` (Ore's deficiency form).** A finite family of
+finite sets `t : ι → Finset α` satisfies the relaxed Hall condition
+`∀ s, #s ≤ #(s.biUnion t) + d` **iff** there is a partial system of distinct
+representatives leaving at most `d` indices unmatched: a set `rejected` with
+`#rejected ≤ d` and an assignment `e` injective off `rejected` with `e i ∈ t i`
+for every `i ∉ rejected`. -/
+theorem defect_hall (t : ι → Finset α) (d : ℕ) :
+    (∀ s : Finset ι, #s ≤ #(s.biUnion t) + d) ↔
+      ∃ (e : ι → α) (rejected : Finset ι),
+        #rejected ≤ d ∧ Set.InjOn e (↑rejectedᶜ) ∧ ∀ i ∉ rejected, e i ∈ t i := by
+  classical
+  -- the `d` universal dummies, living on the right of `α ⊕ Fin d`
+  set D : Finset (α ⊕ Fin d) := Finset.univ.image Sum.inr with hDdef
+  have hDcard : #D = d := by
+    rw [hDdef, Finset.card_image_of_injective _ Sum.inr_injective, Finset.card_univ,
+      Fintype.card_fin]
+  -- the enlarged family: each set gains all `d` dummies
+  set t' : ι → Finset (α ⊕ Fin d) := fun i => (t i).image Sum.inl ∪ D with ht'def
+  constructor
+  · -- (⟹) relaxed Hall for `t`  ⟹  ordinary Hall for `t'`  ⟹  partial SDR
+    intro h
+    -- ordinary Hall's condition holds for the enlarged family `t'`
+    have hall' : ∀ s : Finset ι, #s ≤ #(s.biUnion t') := by
+      intro s
+      rcases s.eq_empty_or_nonempty with rfl | hs
+      · simp
+      · -- for nonempty `s`, the enlarged neighbourhood is `inl`-image ⊎ all dummies
+        have hbu : s.biUnion t' = (s.biUnion t).image Sum.inl ∪ D := by
+          apply Finset.Subset.antisymm
+          · intro x hx
+            simp only [Finset.mem_biUnion, ht'def, Finset.mem_union, Finset.mem_image] at hx
+            simp only [Finset.mem_union, Finset.mem_image, Finset.mem_biUnion]
+            obtain ⟨i, hi, hcase⟩ := hx
+            rcases hcase with ⟨a, hat, rfl⟩ | hD
+            · exact Or.inl ⟨a, ⟨i, hi, hat⟩, rfl⟩
+            · exact Or.inr hD
+          · intro x hx
+            rw [Finset.mem_union] at hx
+            simp only [Finset.mem_biUnion, ht'def, Finset.mem_union, Finset.mem_image]
+            rcases hx with hI | hD
+            · rw [Finset.mem_image] at hI
+              obtain ⟨a, ha, rfl⟩ := hI
+              rw [Finset.mem_biUnion] at ha
+              obtain ⟨i, hi, hat⟩ := ha
+              exact ⟨i, hi, Or.inl ⟨a, hat, rfl⟩⟩
+            · obtain ⟨i, hi⟩ := hs
+              exact ⟨i, hi, Or.inr hD⟩
+        have hdisj : Disjoint ((s.biUnion t).image Sum.inl) D := by
+          rw [Finset.disjoint_left]
+          intro x hx hxD
+          rw [Finset.mem_image] at hx
+          obtain ⟨a, _, rfl⟩ := hx
+          rw [hDdef, Finset.mem_image] at hxD
+          obtain ⟨b, _, hb⟩ := hxD
+          exact Sum.inr_ne_inl hb
+        rw [hbu, Finset.card_union_of_disjoint hdisj,
+          Finset.card_image_of_injective _ Sum.inl_injective, hDcard]
+        exact h s
+    -- Mathlib's marriage theorem: a genuine SDR for `t'`
+    obtain ⟨f, hf_inj, hf_mem⟩ :=
+      (Finset.all_card_le_biUnion_card_iff_exists_injective t').mp hall'
+    -- indices sent to a dummy are "rejected"
+    set rejected : Finset ι := Finset.univ.filter (fun i => (f i).isRight = true) with hrejdef
+    -- the actual representative: extract the `α`-component, defaulting off the dummies
+    set e : ι → α := fun i => Sum.elim id (fun _ => Classical.arbitrary α) (f i) with hedef
+    -- off `rejected`, `f i` is genuinely `inl (e i)`
+    have key : ∀ i, i ∉ rejected → ∃ a, f i = Sum.inl a := by
+      intro i hi
+      simp only [hrejdef, Finset.mem_filter, Finset.mem_univ, true_and] at hi
+      rcases hfi : f i with a | b
+      · exact ⟨a, rfl⟩
+      · simp [hfi] at hi
+    have hfe : ∀ i, i ∉ rejected → f i = Sum.inl (e i) := by
+      intro i hi
+      obtain ⟨a, ha⟩ := key i hi
+      simp [hedef, ha]
+    refine ⟨e, rejected, ?_, ?_, ?_⟩
+    · -- at most `d` rejected indices: `f` injects them into the `d` dummies
+      rw [← hDcard]
+      apply Finset.card_le_card_of_injOn f
+      · intro i hi
+        rw [Finset.mem_coe, hrejdef, Finset.mem_filter] at hi
+        rw [Finset.mem_coe, hDdef, Finset.mem_image]
+        rcases hfi : f i with a | b
+        · simp [hfi] at hi
+        · exact ⟨b, Finset.mem_univ b, rfl⟩
+      · exact hf_inj.injOn
+    · -- injective off `rejected`
+      intro i hi j hj hij
+      rw [Finset.coe_compl, Set.mem_compl_iff, Finset.mem_coe] at hi hj
+      apply hf_inj
+      rw [hfe i hi, hfe j hj, hij]
+    · -- each non-rejected index is represented
+      intro i hi
+      have hmem := hf_mem i
+      rw [hfe i hi] at hmem
+      simp only [ht'def, Finset.mem_union, Finset.mem_image] at hmem
+      rcases hmem with ⟨a, ha, hae⟩ | hD
+      · rw [Sum.inl.injEq] at hae; rw [← hae]; exact ha
+      · rw [hDdef, Finset.mem_image] at hD
+        obtain ⟨b, _, hb⟩ := hD
+        exact absurd hb Sum.inr_ne_inl
+  · -- (⟸) a partial SDR forces the relaxed Hall condition, by a counting split
+    rintro ⟨e, rejected, hcard, hinj, hmem⟩ s
+    have hsplit : #(s ∩ rejected) + #(s \ rejected) = #s :=
+      Finset.card_inter_add_card_sdiff s rejected
+    have hA : #(s ∩ rejected) ≤ d :=
+      le_trans (Finset.card_le_card Finset.inter_subset_right) hcard
+    have hsub : (↑(s \ rejected) : Set ι) ⊆ ↑rejectedᶜ := by
+      intro x hx
+      simp only [Finset.coe_sdiff, Set.mem_diff, Finset.mem_coe] at hx
+      simp only [Finset.coe_compl, Set.mem_compl_iff, Finset.mem_coe]
+      exact hx.2
+    have hB : #(s \ rejected) ≤ #(s.biUnion t) := by
+      apply Finset.card_le_card_of_injOn e
+      · intro i hi
+        rw [Finset.mem_coe, Finset.mem_sdiff] at hi
+        rw [Finset.mem_coe, Finset.mem_biUnion]
+        exact ⟨i, hi.1, hmem i hi.2⟩
+      · exact hinj.mono hsub
+    omega
+
+/-- **Marriage theorem (no defect).** Taking `d = 0` in `defect_hall` recovers the
+classical statement: Hall's condition is equivalent to a full system of distinct
+representatives. -/
+theorem defect_hall_zero (t : ι → Finset α) :
+    (∀ s : Finset ι, #s ≤ #(s.biUnion t)) ↔
+      ∃ e : ι → α, Function.Injective e ∧ ∀ i, e i ∈ t i := by
+  have h0 : (∀ s : Finset ι, #s ≤ #(s.biUnion t)) ↔
+      (∀ s : Finset ι, #s ≤ #(s.biUnion t) + 0) := by simp
+  rw [h0, defect_hall t 0]
+  constructor
+  · rintro ⟨e, rejected, hrej, hinj, hmem⟩
+    rw [Nat.le_zero, Finset.card_eq_zero] at hrej
+    subst hrej
+    rw [Finset.compl_empty, Finset.coe_univ, Set.injOn_univ] at hinj
+    exact ⟨e, hinj, fun i => hmem i (Finset.notMem_empty i)⟩
+  · rintro ⟨e, hinj, hmem⟩
+    refine ⟨e, ∅, by simp, ?_, fun i _ => hmem i⟩
+    rw [Finset.compl_empty, Finset.coe_univ, Set.injOn_univ]
+    exact hinj
+
+end HallsTheoremOQ01OQ01

--- a/src/data/proofs/halls-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/halls-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,143 @@
+{
+  "id": "halls-theorem-oq-01-oq-01",
+  "title": "Hall's Theorem with a Defect: the Deficiency (Ore) Form",
+  "slug": "halls-theorem-oq-01-oq-01",
+  "description": "The ordinary marriage theorem (Mathlib's Finset.all_card_le_biUnion_card_iff_exists_injective) says a finite family of finite sets t : ι → Finset α admits a full system of distinct representatives iff Hall's condition ∀ s, #s ≤ #(s.biUnion t) holds. Ore's deficiency version measures how far a family is from this: for a fixed slack d, the relaxed condition ∀ s, #s ≤ #(s.biUnion t) + d is equivalent to the existence of a partial SDR that represents all but at most d of the indices — a set 'rejected' with #rejected ≤ d together with an assignment e injective off 'rejected' with e i ∈ t i for every i ∉ rejected. We prove this biconditional (defect_hall) by the classical reduction: adjoin d brand-new universal candidates over α ⊕ Fin d, turning the relaxed Hall condition for t into the ordinary Hall condition for the enlarged family, apply Mathlib's marriage theorem, and read off the partial SDR (only d indices can land on a dummy since the SDR is injective). The d = 0 case recovers the classical SDR theorem (defect_hall_zero). This answers the first open question of halls-theorem-oq-01 — the quantitative defect form of Hall's theorem — in the Finset / SDR formulation, and is absent from Mathlib, which states only the d = 0 case.",
+  "meta": {
+    "author": "Øystein Ore (1955); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hall%27s_marriage_theorem#Defect_version",
+    "date": "1955",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "matching",
+      "halls-marriage-theorem",
+      "systems-of-distinct-representatives",
+      "deficiency"
+    ],
+    "proofRepoPath": "Proofs/HallsTheoremOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 198,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.all_card_le_biUnion_card_iff_exists_injective",
+        "description": "Mathlib's marriage theorem for an indexed family of finite sets: Hall's condition ∀ s, #s ≤ #(s.biUnion t) iff there is an injective system of distinct representatives. Applied to the enlarged family t' over α ⊕ Fin d to extract the partial SDR.",
+        "module": "Mathlib.Combinatorics.Hall.Basic"
+      },
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "An injection on a finset into another bounds card. Used twice: to bound #rejected by the d dummies, and to bound #(s \\ rejected) by #(s.biUnion t) in the converse counting split.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_inter_add_card_sdiff",
+        "description": "#(s ∩ rejected) + #(s \\ rejected) = #s — the partition powering the converse direction's counting argument.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_union_of_disjoint",
+        "description": "Cardinality of a disjoint union, used to compute #(s.biUnion t') = #(s.biUnion t) + d for the enlarged neighbourhood (inl-image disjoint from the d dummies).",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "defect_hall: the deficiency biconditional — the relaxed Hall condition ∀ s, #s ≤ #(s.biUnion t) + d holds iff there is a partial system of distinct representatives missing at most d indices (a set 'rejected' with #rejected ≤ d and an assignment injective off it that represents every other index). Absent from Mathlib, which has only the d = 0 marriage theorem.",
+      "The α ⊕ Fin d reduction: each set t i is enlarged by all d right-hand dummies (t' i = (t i).image inl ∪ univ.image inr); for nonempty s the enlarged neighbourhood is exactly the old one plus the d dummies (#(s.biUnion t') = #(s.biUnion t) + d), converting relaxed Hall for t into ordinary Hall for t'.",
+      "Reading off the partial SDR: from the injective SDR f : ι → α ⊕ Fin d, the indices landing on a dummy form 'rejected'; injectivity bounds #rejected by the d dummies, and the rest map injectively into α.",
+      "defect_hall_zero: the d = 0 specialisation, recovering the classical system-of-distinct-representatives theorem from the defect form, confirming the generalisation is faithful."
+    ],
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Philip Hall's marriage theorem (1935) characterises when a finite family of finite sets admits a system of distinct representatives (SDR): exactly when every subfamily of k sets covers at least k elements (Hall's condition). Twenty years later Øystein Ore (1955) gave the defect form, which measures the failure: the largest partial SDR has size |ι| minus the maximum deficiency maxₛ(|s| − |N(s)|). Equivalently, an SDR missing at most d indices exists iff Hall's condition holds with slack d. The defect form is the quantitative refinement that turns the all-or-nothing marriage theorem into a measurement of obstruction, and underlies the deficiency version of König's theorem and the matching theory of bipartite graphs. Mathlib formalises only the exact (d = 0) marriage theorem.",
+    "problemStatement": "Let $t : \\iota \\to \\mathrm{Finset}\\,\\alpha$ be a finite family of finite sets and $d \\in \\mathbb{N}$. Show that the relaxed Hall condition\n\n$$\\forall\\, s : \\mathrm{Finset}\\,\\iota, \\quad |s| \\le \\Big| \\bigcup_{i \\in s} t\\,i \\Big| + d$$\n\nholds if and only if there is a partial system of distinct representatives leaving at most $d$ indices unrepresented: a set $R$ of indices with $|R| \\le d$ and an assignment $e$ that is injective on $\\iota \\setminus R$ with $e\\,i \\in t\\,i$ for every $i \\notin R$. Recover the classical SDR theorem as the case $d = 0$.",
+    "proofStrategy": "The forward direction is the standard 'adjoin d universal vertices' reduction. Work over α ⊕ Fin d and enlarge each set to t' i = (t i).image inl ∪ D, where D = univ.image inr is the set of all d dummies. For nonempty s the enlarged neighbourhood splits as a disjoint union of the inl-image of s.biUnion t and the d dummies, so #(s.biUnion t') = #(s.biUnion t) + d; the relaxed Hall condition for t is therefore exactly the ordinary Hall condition for t'. Mathlib's marriage theorem yields an injective SDR f : ι → α ⊕ Fin d. Define 'rejected' to be the indices i with f i a dummy (inr); injectivity of f maps 'rejected' injectively into the d dummies, so #rejected ≤ d, and off 'rejected' f i = inl (e i) with e i ∈ t i, giving the partial SDR (injective by injectivity of f and inl). The converse is an elementary counting split: for any s write #s = #(s ∩ rejected) + #(s \\ rejected); the first term is ≤ d, and e injects s \\ rejected into s.biUnion t, so the second is ≤ #(s.biUnion t).",
+    "keyInsights": [
+      "The defect d is absorbed by literally adding d new universal candidates: every set is allowed to use any of the d dummies, so a partial SDR for t becomes a full SDR for the d-enlarged family, and vice versa.",
+      "Injectivity does the bookkeeping for free: because the enlarged SDR is injective and there are only d dummies, at most d indices can be 'wasted' on a dummy — this is exactly the bound #rejected ≤ d without any separate counting.",
+      "Working in α ⊕ Fin d keeps the construction fully constructive and finite: the dummies are an honest Fin d, the neighbourhood card computation is a disjoint union, and the converse is a single inter/sdiff partition.",
+      "The d = 0 case collapses the dummy type Fin 0 to the empty type, forcing rejected = ∅ and recovering Mathlib's SDR theorem — a built-in consistency check that the defect biconditional really generalises the marriage theorem."
+    ],
+    "prerequisites": [
+      "Hall's marriage theorem and systems of distinct representatives (Finset.all_card_le_biUnion_card_iff_exists_injective)",
+      "Finset cardinality, images, bounded unions and disjoint-union counting (Finset.card, biUnion, card_union_of_disjoint)",
+      "Injections on finsets and the card_le_card_of_injOn bound",
+      "Sum types α ⊕ β and their injections inl/inr"
+    ]
+  },
+  "conclusion": {
+    "summary": "We formalised Ore's defect version of Hall's marriage theorem in the Finset / SDR setting: the relaxed Hall condition ∀ s, #s ≤ #(s.biUnion t) + d is equivalent to a partial system of distinct representatives that leaves at most d indices unrepresented. The proof reduces to Mathlib's exact marriage theorem by adjoining d universal candidates over α ⊕ Fin d, and the d = 0 case recovers the classical SDR theorem. Both results are fully machine-checked with 0 sorries and 0 axioms.",
+    "implications": "This answers the first open question of halls-theorem-oq-01 — the quantitative deficiency form of Hall's theorem — in the indexed Finset formulation. It gives Mathlib users a ready deficiency statement: a family with bounded Hall deficiency d still represents all but d of its indices, with the d 'rejected' indices a concrete certificate of the obstruction. The α ⊕ Fin d reduction is reusable for other defect-style matching results.",
+    "openQuestions": [
+      "Sharpen to Ore's exact equality: the maximum partial-SDR size equals |ι| − maxₛ(|s| − |N(s)|), extracting the optimal d rather than an a-priori bound.",
+      "Transport the defect biconditional to the bipartite SimpleGraph framework of HallsTheoremOQ01 (matchings of bounded deficiency) and connect to the deficiency form of König's theorem.",
+      "Derive the common-SDR / doubly-stochastic (Birkhoff–von Neumann) consequences from the SDR theorem now that the defect refinement is available."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Imports, an expository docstring contrasting Mathlib's exact (d = 0) marriage theorem with Ore's defect form, and the namespace/variable setup (Fintype ι, DecidableEq, Nonempty α)."
+    },
+    {
+      "id": "defect-hall",
+      "title": "The Deficiency Biconditional",
+      "startLine": 56,
+      "endLine": 177,
+      "summary": "defect_hall — the relaxed Hall condition iff a partial SDR missing at most d indices. Forward: the α ⊕ Fin d reduction, disjoint-union neighbourhood count, Mathlib's marriage theorem, and reading off rejected/e. Converse: the inter/sdiff counting split."
+    },
+    {
+      "id": "defect-hall-zero",
+      "title": "The d = 0 Specialisation",
+      "startLine": 178,
+      "endLine": 198,
+      "summary": "defect_hall_zero — recovering the classical system-of-distinct-representatives theorem from the defect form (rejected = ∅, injective on all of ι)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "halls-theorem-oq-01",
+      "relation": "Answers the first open question of this entry — the quantitative defect (deficiency) form of Hall's theorem — in the Finset / SDR formulation."
+    }
+  ],
+  "references": [
+    {
+      "text": "Ore, Ø. (1955). Graphs and matching theorems. Duke Mathematical Journal, 22(4), 625–639.",
+      "url": "https://doi.org/10.1215/S0012-7094-55-02268-7"
+    },
+    {
+      "text": "Hall, P. (1935). On Representatives of Subsets. Journal of the London Mathematical Society, 10(1), 26–30.",
+      "url": "https://doi.org/10.1112/jlms/s1-10.37.26"
+    },
+    {
+      "text": "Hall's marriage theorem — defect version.",
+      "url": "https://en.wikipedia.org/wiki/Hall%27s_marriage_theorem#Defect_version"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Function"
+    ],
+    "namespace": "HallsTheoremOQ01OQ01",
+    "lineCount": 198,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/HallsTheoremOQ01OQ01.lean",
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `halls-theorem-oq-01` — the quantitative **defect (deficiency) form** of Hall's marriage theorem — in the Finset / system-of-distinct-representatives formulation. Absent from Mathlib, which states only the exact (`d = 0`) marriage theorem.

`defect_hall` (the deficiency biconditional): for a finite family of finite sets `t : ι → Finset α` and slack `d : ℕ`,

```
(∀ s, #s ≤ #(s.biUnion t) + d)  ↔  ∃ e rejected, #rejected ≤ d ∧ Set.InjOn e ↑rejectedᶜ ∧ ∀ i ∉ rejected, e i ∈ t i
```

i.e. the relaxed Hall condition holds **iff** there is a partial SDR representing all but at most `d` of the indices.

`defect_hall_zero`: the `d = 0` case recovers the classical SDR theorem, confirming the generalisation is faithful.

## Proof

The standard "adjoin `d` universal candidates" reduction. Work over `α ⊕ Fin d` and enlarge each set to `t' i = (t i).image inl ∪ (univ.image inr)` (all `d` dummies). For nonempty `s` the enlarged neighbourhood is a disjoint union giving `#(s.biUnion t') = #(s.biUnion t) + d`, so relaxed Hall for `t` becomes **ordinary** Hall for `t'`. Mathlib's `all_card_le_biUnion_card_iff_exists_injective` yields an injective SDR `f : ι → α ⊕ Fin d`; the indices hitting a dummy are `rejected` (injectivity bounds them by `d`), and the rest map injectively into `α`. The converse is an elementary `s = (s ∩ rejected) ∪ (s \ rejected)` counting split.

## Verification

- **198 lines**, 2 theorems, 0 definitions
- `#print axioms`: only `propext`, `Classical.choice`, `Quot.sound` → **0-axiom**
- 0 sorries, no `native_decide`, no `axiom` declarations
- Builds clean under Docker (Mathlib v4.26.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)