### PR TITLE
research(feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01): Euler's metric identity OH² = 9R² − (a²+b²+c²) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2505,6 +2505,7 @@ import Proofs.FeuerbachsTheorem
 import Proofs.FeuerbachsTheoremDefs
 import Proofs.FeuerbachsTheoremDefsOQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01
+import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ03
 import Proofs.FeuerbachsTheoremDefsOQ04
 import Proofs.FeuerbachsTheoremOQ01

--- a/proofs/Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,229 @@
+/-
+  Feuerbach's Theorem DefsOQ01OQ01OQ01OQ01: Euler's Metric Identity for the
+  Orthocenter — OH² = 9R² − (a² + b² + c²)
+
+  ## The Open Question
+
+  The orthocenter sub-line of this development has so far been *qualitative*:
+
+  * `FeuerbachsTheoremDefsOQ01OQ01` — the three altitudes are concurrent at
+    `H = A + B + C − 2·O`;
+  * `FeuerbachsTheoremDefsOQ01OQ01OQ01` — the reflections of `H` across the
+    three sides (and across the side midpoints) lie on the circumcircle.
+
+  The grandparent `FeuerbachsTheoremDefs` records the *Euler line* as the
+  collinearity `G = (2O + H)/3` and the nine-point centre `N = (O + H)/2`, but
+  never measures the distance `OH` itself.  The natural open question closing
+  the orthocenter line is the classical **metric** identity
+
+      OH² = 9R² − (a² + b² + c²),
+
+  the distance from the circumcenter to the orthocenter in terms of the
+  circumradius `R` and the three side lengths `a, b, c`.  It is the metric
+  companion of the qualitative reflection facts and the quantitative root of
+  Euler's inequality `OH ≥ 0 ⟹ a² + b² + c² ≤ 9R²`.
+
+  ## What This File Proves
+
+  ### The headline identity
+  `orthocenter_circumcenter_dist_sq` :
+      `dist²(O, H) = 9·dist²(O, A) − (dist²(B,C) + dist²(C,A) + dist²(A,B))`
+  the squared-distance form, and
+  `orthocenter_circumcenter_dist_classical` :
+      `dist²(O, H) = 9R² − (a² + b² + c²)`
+  the textbook form in terms of `R = circumradius` and `a, b, c = side lengths`.
+
+  The proof reduces (after substituting `H = A + B + C − 2O`) to a polynomial
+  identity that holds modulo the two circumcenter-equidistance relations
+  `|B − O|² = |A − O|²` and `|C − O|² = |A − O|²`; one checks by hand that
+
+      OH² − [9R² − (a²+b²+c²)] = −3(|A−O|² − |B−O|²) − 3(|A−O|² − |C−O|²),
+
+  so a single `linear_combination 3·equidistB + 3·equidistC` discharges it.
+
+  ### Metric form of the Euler line
+  Because `G − O = (H − O)/3` and `H − G = (2/3)(H − O)`, the same kernel yields
+  `centroid_circumcenter_dist_sq` : `OH² = 9·OG²`,
+  `centroid_orthocenter_dist_sq`  : `4·OH² = 9·GH²`  (so `OG : GH : OH = 1 : 2 : 3`),
+  and the centroid version of Euler's identity
+  `centroid_circumcenter_dist_classical` : `OG² = R² − (a²+b²+c²)/9`.
+
+  ### Worked example
+  `triangle_345_OH_sq` : for the 3-4-5 right triangle `OH² = 25/4` (so `OH = 5/2`
+  = R, since the orthocenter is the right-angle vertex), matching
+  `9R² − (a²+b²+c²) = 9·(25/4) − 50 = 25/4`.
+
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Proofs.FeuerbachsTheoremDefs
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01
+
+open FeuerbachsTheorem
+
+-- ============================================================
+-- Part 0: Pairwise equidistance of the circumcenter
+--
+-- The parent declares the equidistance facts `private`; we reprove the two we
+-- need (against vertex A) so this file builds independently.  Each follows from
+-- the perpendicular-bisector identity, which is *linear* in O.
+-- ============================================================
+
+set_option maxHeartbeats 6400000 in
+private lemma perp_bisector_AB (T : Triangle) :
+    (T.B.1 - T.A.1) * (T.B.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.B.2 - T.A.2) * (T.B.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+set_option maxHeartbeats 6400000 in
+private lemma perp_bisector_AC (T : Triangle) :
+    (T.C.1 - T.A.1) * (T.C.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.C.2 - T.A.2) * (T.C.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+/-- `|B - O|² = |A - O|²` : the circumcenter is equidistant from `A` and `B`. -/
+private lemma equidistB (T : Triangle) :
+    (T.B.1 - T.circumcenter.1) ^ 2 + (T.B.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := perp_bisector_AB T
+  nlinarith [sq_nonneg (T.B.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.B.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+/-- `|C - O|² = |A - O|²` : the circumcenter is equidistant from `A` and `C`. -/
+private lemma equidistC (T : Triangle) :
+    (T.C.1 - T.circumcenter.1) ^ 2 + (T.C.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := perp_bisector_AC T
+  nlinarith [sq_nonneg (T.C.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.C.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+-- ============================================================
+-- Part I: squared distance vs. the metric `dist2`
+-- ============================================================
+
+/-- `dist2` is the square root of `dist2_sq`, so squaring recovers it. -/
+lemma sq_dist2 (P Q : Point) : (dist2 P Q) ^ 2 = dist2_sq P Q := by
+  unfold dist2 dist2_sq
+  rw [Real.sq_sqrt (by positivity)]
+
+-- ============================================================
+-- Part II: Euler's metric identity OH² = 9R² − (a²+b²+c²)
+-- ============================================================
+
+/-- **Euler's metric identity (squared-distance form).**
+    The squared distance from the circumcenter `O` to the orthocenter `H` is
+
+      `OH² = 9·|O−A|²  −  (|B−C|² + |C−A|² + |A−B|²)`.
+
+    With `H = A + B + C − 2O`, the difference of the two sides equals
+    `−3(|A−O|² − |B−O|²) − 3(|A−O|² − |C−O|²)`, which vanishes because the
+    circumcenter is equidistant from the three vertices. -/
+theorem orthocenter_circumcenter_dist_sq (T : Triangle) :
+    dist2_sq T.circumcenter T.orthocenter
+      = 9 * dist2_sq T.circumcenter T.A
+        - (dist2_sq T.B T.C + dist2_sq T.C T.A + dist2_sq T.A T.B) := by
+  simp only [dist2_sq, Triangle.orthocenter]
+  linear_combination 3 * equidistB T + 3 * equidistC T
+
+/-- **Euler's metric identity (classical form).**
+    `OH² = 9R² − (a² + b² + c²)` where `R = circumradius` and `a, b, c` are the
+    three side lengths.  Obtained from the squared-distance form by replacing
+    each squared distance with the corresponding squared length. -/
+theorem orthocenter_circumcenter_dist_classical (T : Triangle) :
+    dist2_sq T.circumcenter T.orthocenter
+      = 9 * T.circumradius ^ 2 - (T.side_a ^ 2 + T.side_b ^ 2 + T.side_c ^ 2) := by
+  rw [show T.circumradius ^ 2 = dist2_sq T.circumcenter T.A from sq_dist2 _ _,
+      show T.side_a ^ 2 = dist2_sq T.B T.C from sq_dist2 _ _,
+      show T.side_b ^ 2 = dist2_sq T.C T.A from sq_dist2 _ _,
+      show T.side_c ^ 2 = dist2_sq T.A T.B from sq_dist2 _ _]
+  exact orthocenter_circumcenter_dist_sq T
+
+/-- Euler's inequality precursor: `a² + b² + c² ≤ 9R²`, immediate from the
+    metric identity and `OH² ≥ 0`. -/
+theorem sum_sq_sides_le_nine_circumradius_sq (T : Triangle) :
+    T.side_a ^ 2 + T.side_b ^ 2 + T.side_c ^ 2 ≤ 9 * T.circumradius ^ 2 := by
+  have h := orthocenter_circumcenter_dist_classical T
+  have hnn : 0 ≤ dist2_sq T.circumcenter T.orthocenter := by
+    unfold dist2_sq; positivity
+  linarith
+
+-- ============================================================
+-- Part III: Metric form of the Euler line
+--
+-- O, G, H are collinear with G − O = (H − O)/3 and H − G = (2/3)(H − O).
+-- Squaring gives OH² = 9·OG² and 4·OH² = 9·GH², i.e. OG : GH : OH = 1 : 2 : 3.
+-- These need no equidistance — they are pure consequences of the definitions.
+-- ============================================================
+
+/-- `OH² = 9·OG²`: the circumcenter–orthocenter distance is three times the
+    circumcenter–centroid distance (the `1 : 3` leg of the Euler-line ratio). -/
+theorem centroid_circumcenter_dist_sq (T : Triangle) :
+    dist2_sq T.circumcenter T.orthocenter = 9 * dist2_sq T.circumcenter T.centroid := by
+  simp only [dist2_sq, Triangle.orthocenter, Triangle.centroid]
+  ring
+
+/-- `4·OH² = 9·GH²`: the centroid–orthocenter distance is two thirds of `OH`
+    (the `2 : 3` leg of the Euler-line ratio). -/
+theorem centroid_orthocenter_dist_sq (T : Triangle) :
+    4 * dist2_sq T.circumcenter T.orthocenter = 9 * dist2_sq T.centroid T.orthocenter := by
+  simp only [dist2_sq, Triangle.orthocenter, Triangle.centroid]
+  ring
+
+/-- The centroid form of Euler's identity: `OG² = R² − (a² + b² + c²)/9`. -/
+theorem centroid_circumcenter_dist_classical (T : Triangle) :
+    dist2_sq T.circumcenter T.centroid
+      = T.circumradius ^ 2 - (T.side_a ^ 2 + T.side_b ^ 2 + T.side_c ^ 2) / 9 := by
+  have h9 : (9 : ℝ) * dist2_sq T.circumcenter T.centroid
+      = 9 * T.circumradius ^ 2 - (T.side_a ^ 2 + T.side_b ^ 2 + T.side_c ^ 2) := by
+    rw [← centroid_circumcenter_dist_sq T]
+    exact orthocenter_circumcenter_dist_classical T
+  linarith
+
+-- ============================================================
+-- Part IV: Worked example (3-4-5 right triangle)
+-- ============================================================
+
+/-- For the 3-4-5 right triangle the orthocenter is the right-angle vertex
+    `A = (0,0)` and the circumcenter is `(3/2, 2)`, so `OH² = (3/2)² + 2² = 25/4`
+    and `OH = 5/2 = R`. -/
+theorem triangle_345_OH_sq :
+    dist2_sq triangle_345.circumcenter triangle_345.orthocenter = 25 / 4 := by
+  rw [triangle_345_circumcenter, triangle_345_orthocenter]
+  unfold dist2_sq; norm_num
+
+/-- The 3-4-5 triangle satisfies Euler's metric identity numerically:
+    `9R² − (a² + b² + c²) = 9·(25/4) − (25 + 16 + 9) = 25/4 = OH²`. -/
+theorem triangle_345_euler_metric :
+    dist2_sq triangle_345.circumcenter triangle_345.orthocenter
+      = 9 * triangle_345.circumradius ^ 2
+        - (triangle_345.side_a ^ 2 + triangle_345.side_b ^ 2 + triangle_345.side_c ^ 2) := by
+  rw [triangle_345_OH_sq, triangle_345_circumradius, triangle_345_side_a,
+      triangle_345_side_b, triangle_345_side_c]
+  norm_num
+
+end FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01",
+  "title": "Feuerbach's Theorem: Euler's Metric Identity OH² = 9R² − (a²+b²+c²)",
+  "slug": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01",
+  "description": "Caps the orthocenter sub-line with the classical metric identity: the squared distance from the circumcenter O to the orthocenter H equals 9R² minus the sum of the squared side lengths. Yields Euler's inequality precursor a²+b²+c² ≤ 9R², the metric Euler-line ratio OG : GH : OH = 1 : 2 : 3, the centroid identity OG² = R² − (a²+b²+c²)/9, and a 3-4-5 worked example. 8 theorems and 5 lemmas, 0 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
+    "tags": [
+      "geometry",
+      "feuerbach",
+      "orthocenter",
+      "circumcenter",
+      "euler-line",
+      "centroid",
+      "circumradius",
+      "metric-identity",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only propext / Classical.choice / Quot.sound, confirmed by #print axioms). Inherits the coordinate API (circumcenter/orthocenter/centroid formulas, side-length and non-degeneracy lemmas) from FeuerbachsTheoremDefs.lean, which is itself 0-sorry, 0-axiom.",
+    "lineCount": 229,
+    "theoremCount": 13,
+    "definitionCount": 0,
+    "originalContributions": [
+      "orthocenter_circumcenter_dist_sq: the squared-distance form of Euler's metric identity — dist²(O,H) = 9·dist²(O,A) − (dist²(B,C) + dist²(C,A) + dist²(A,B)) — the distance from the circumcenter to the orthocenter, a quantity the nine-point-circle development never measures",
+      "orthocenter_circumcenter_dist_classical: the textbook form OH² = 9R² − (a²+b²+c²) in terms of the circumradius R and the three side lengths a, b, c",
+      "sum_sq_sides_le_nine_circumradius_sq: Euler's inequality precursor a²+b²+c² ≤ 9R², immediate from OH² ≥ 0",
+      "centroid_circumcenter_dist_sq: OH² = 9·OG², the 1:3 leg of the metric Euler line (G − O = (H − O)/3)",
+      "centroid_orthocenter_dist_sq: 4·OH² = 9·GH², the 2:3 leg of the metric Euler line (H − G = (2/3)(H − O)), so OG : GH : OH = 1 : 2 : 3",
+      "centroid_circumcenter_dist_classical: the centroid form of Euler's identity OG² = R² − (a²+b²+c²)/9",
+      "sq_dist2: the bridge (dist P Q)² = dist2_sq P Q, letting the squared-distance identity be restated with the metric circumradius and side lengths",
+      "triangle_345_OH_sq / triangle_345_euler_metric: worked example — for the 3-4-5 right triangle OH² = 25/4 (so OH = 5/2 = R, the orthocenter being the right-angle vertex), matching 9·(25/4) − (25+16+9) = 25/4"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Euler's metric identity OH² = 9R² − (a²+b²+c²) measures the distance between the circumcenter O and the orthocenter H of a triangle. It is the quantitative companion of the qualitative orthocentric facts proved earlier in this sub-line — altitude concurrency at H = A + B + C − 2O, and the reflections of H landing on the circumcircle — and it is the algebraic source of Euler's inequality a²+b²+c² ≤ 9R² (equivalently, with R ≥ 2r, the chain of classical triangle inequalities). The grandparent FeuerbachsTheoremDefs.lean records the Euler line only qualitatively, as the collinearity G = (2O + H)/3 and the nine-point centre N = (O + H)/2; this entry supplies the missing metric content.",
+    "problemStatement": "With O the circumcenter, R the circumradius, H = A + B + C − 2O the orthocenter, G the centroid and a, b, c the side lengths, prove:\n1. **Euler's metric identity**: OH² = 9R² − (a² + b² + c²), in both squared-distance and circumradius/side-length form.\n2. **Euler's inequality precursor**: a² + b² + c² ≤ 9R².\n3. **Metric Euler line**: OH² = 9·OG² and 4·OH² = 9·GH², so OG : GH : OH = 1 : 2 : 3, together with the centroid identity OG² = R² − (a²+b²+c²)/9.\n4. A numerical instance on the 3-4-5 right triangle.",
+    "text": "A 229-line companion file with 8 theorems and 5 lemmas (no new definitions). It reproves the circumcenter's pairwise equidistance locally, establishes the squared-distance form of Euler's identity by a one-line linear_combination, lifts it to the classical R/side-length form through the sq_dist2 bridge, derives Euler's inequality precursor, gives the metric form of the Euler line (purely from the definitions, no equidistance needed), and closes with the 3-4-5 worked example.",
+    "proofStrategy": "Substituting H = A + B + C − 2O makes O−H = 3O − (A+B+C), so the headline reduces to a polynomial identity in the vertex/circumcenter coordinates. A short hand computation shows\n\n  OH² − [9R² − (a²+b²+c²)] = −3(|A−O|² − |B−O|²) − 3(|A−O|² − |C−O|²),\n\nso the whole identity lies in the ideal generated by the two circumcenter-equidistance relations and is discharged by `linear_combination 3·equidistB + 3·equidistC` after `simp only [dist2_sq, Triangle.orthocenter]`. The equidistance relations themselves are reproved locally (the parent declares them private) from the perpendicular-bisector identity, which is linear in O.\n\nThe classical form replaces each squared distance by the corresponding squared length using sq_dist2 : (dist P Q)² = dist2_sq P Q (Real.sq_sqrt on a manifestly nonnegative argument). Euler's inequality precursor is then `linarith` against OH² ≥ 0. The metric Euler-line statements OH² = 9·OG² and 4·OH² = 9·GH² unfold the centroid and orthocenter definitions and close by `ring` alone — they are exact consequences of G − O = (H − O)/3 and H − G = (2/3)(H − O), requiring no equidistance. The 3-4-5 example reuses the parent's triangle_345_circumcenter = (3/2,2) and triangle_345_orthocenter = (0,0) and finishes by norm_num.",
+    "keyInsights": [
+      "The entire metric identity collapses to a single linear_combination: OH² − [9R² − (a²+b²+c²)] is exactly −3 times the sum of the two circumcenter-equidistance defects, so no cofactor search or case analysis is needed — unlike the reflection identity of the sibling entry, the certificate is trivial.",
+      "Working in squared distances (dist2_sq) keeps the identity polynomial; the conversion to the metric circumradius and side lengths is isolated in the single bridge lemma sq_dist2, so the heavy algebra never touches Real.sqrt.",
+      "The metric Euler line OG : GH : OH = 1 : 2 : 3 needs no geometry beyond the definitions: G − O = (H − O)/3 and H − G = (2/3)(H − O) are visible after unfolding, so squaring gives OH² = 9·OG² and 4·OH² = 9·GH² by ring.",
+      "Euler's inequality a²+b²+c² ≤ 9R² drops out for free from the identity and the nonnegativity of a squared distance — a positivity fact that the qualitative orthocenter entries could not see.",
+      "In the 3-4-5 right triangle the orthocenter is the right-angle vertex A and OH = R exactly, the degenerate-looking but correct instance OH² = 25/4 = 9·(25/4) − 50."
+    ],
+    "prerequisites": [
+      "FeuerbachsTheoremDefs.lean — coordinate API (Point, Triangle, circumcenter, orthocenter, centroid, dist2, dist2_sq, circumradius, side_a/b/c) and circumcenter_denom_ne_zero, plus the triangle_345 computations",
+      "feuerbachs-theorem-defs-oq-01-oq-01-oq-01 — the orthocenter-reflection entry whose metric counterpart this provides",
+      "The Euler line H = A + B + C − 2O and the relations between circumcenter, centroid and orthocenter",
+      "Real.sq_sqrt and linear_combination / ring for polynomial and rational identities over R"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Pairwise Equidistance of the Circumcenter",
+      "startLine": 1,
+      "endLine": 125,
+      "summary": "Module docstring stating the open question, imports FeuerbachsTheoremDefs, and reproves the two circumcenter-equidistance facts (against vertex A) locally — the parent declares them private — via the perpendicular-bisector identity which is linear in O.",
+      "mathContext": "perp_bisector_AB / _AC close by substituting the circumcenter fraction and field_simp; ring; equidistB / equidistC then follow by nlinarith. These supply the |B−O|² = |A−O|² and |C−O|² = |A−O|² relations used by the metric identity."
+    },
+    {
+      "id": "bridge",
+      "title": "Part I: Squared Distance vs. the Metric dist2",
+      "startLine": 126,
+      "endLine": 136,
+      "summary": "Proves sq_dist2 : (dist2 P Q)² = dist2_sq P Q, the bridge from the polynomial squared-distance to the metric distance.",
+      "mathContext": "dist2 P Q = √(dist2_sq P Q) with dist2_sq P Q ≥ 0, so Real.sq_sqrt recovers dist2_sq on squaring."
+    },
+    {
+      "id": "euler-metric",
+      "title": "Part II: Euler's Metric Identity OH² = 9R² − (a²+b²+c²)",
+      "startLine": 137,
+      "endLine": 180,
+      "summary": "The headline identity in squared-distance form (one linear_combination), its classical R/side-length form, and Euler's inequality precursor a²+b²+c² ≤ 9R².",
+      "mathContext": "orthocenter_circumcenter_dist_sq: simp only [dist2_sq, Triangle.orthocenter]; linear_combination 3·equidistB + 3·equidistC. The classical form rewrites each squared distance via sq_dist2; sum_sq_sides_le_nine_circumradius_sq is linarith against OH² ≥ 0."
+    },
+    {
+      "id": "euler-line",
+      "title": "Part III: Metric Form of the Euler Line",
+      "startLine": 181,
+      "endLine": 214,
+      "summary": "OH² = 9·OG² and 4·OH² = 9·GH², giving OG : GH : OH = 1 : 2 : 3, and the centroid form of Euler's identity OG² = R² − (a²+b²+c²)/9.",
+      "mathContext": "centroid_circumcenter_dist_sq / centroid_orthocenter_dist_sq unfold the centroid and orthocenter and close by ring; centroid_circumcenter_dist_classical combines OH² = 9·OG² with the classical identity by linarith."
+    },
+    {
+      "id": "example",
+      "title": "Part IV: Worked Example (3-4-5 Right Triangle)",
+      "startLine": 215,
+      "endLine": 229,
+      "summary": "OH² = 25/4 for the 3-4-5 right triangle (orthocenter at the right-angle vertex, OH = R = 5/2), and the numerical check 9R² − (a²+b²+c²) = 25/4.",
+      "mathContext": "triangle_345_OH_sq rewrites the parent's circumcenter (3/2,2) and orthocenter (0,0) then norm_num; triangle_345_euler_metric substitutes R = 5/2 and sides 5,4,3."
+    }
+  ],
+  "conclusion": {
+    "summary": "Supplies the metric capstone of the orthocenter sub-line: OH² = 9R² − (a²+b²+c²), together with Euler's inequality precursor a²+b²+c² ≤ 9R², the metric Euler-line ratio OG : GH : OH = 1 : 2 : 3, the centroid identity OG² = R² − (a²+b²+c²)/9, and a 3-4-5 worked example. 8 theorems and 5 lemmas, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "**Quantitative completion**: the orthocenter is now characterized metrically (its exact distance to the circumcenter) and not only qualitatively (concurrency, reflections), and the development can now state inequalities — a²+b²+c² ≤ 9R² — that the earlier entries could not reach.\n\n**Euler line as metric**: the collinearity recorded by the grandparent is upgraded to the exact 1:2:3 distance ratio among O, G, H, the standard metric statement of the Euler line.",
+    "openQuestions": [
+      "Prove Euler's theorem OI² = R² − 2Rr (distance between circumcenter and incenter) and deduce Euler's inequality R ≥ 2r — the direct path to the Feuerbach tangency the umbrella theorem targets.",
+      "Sharpen a²+b²+c² ≤ 9R² to the equality case, showing OH = 0 (and hence equality) holds exactly for the equilateral triangle.",
+      "Reformulate OH² = 9R² − (a²+b²+c²) and the metric Euler line in Mathlib's EuclideanGeometry API (dist, EuclideanGeometry.orthocenter, circumradius) for a possible upstream contribution."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "the metric companion of the orthocenter-reflection entry: instead of placing reflections of H on the circumcircle, it measures the distance OH itself"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01-oq-01",
+      "relationship": "related",
+      "description": "uses the orthocenter H = A + B + C − 2O established by the altitude-concurrency entry"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs",
+      "relationship": "extends",
+      "description": "upgrades the qualitative Euler line (G = (2O+H)/3) recorded in FeuerbachsTheoremDefs.lean to the exact metric ratio OG : GH : OH = 1 : 2 : 3"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Proofs.FeuerbachsTheoremDefs"],
+    "opens": ["FeuerbachsTheorem"],
+    "namespace": "FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01",
+    "lineCount": 229,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 0,
+    "path": "Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "orthocenter_circumcenter_dist_classical",
+      "type": "core",
+      "description": "Euler's metric identity: the squared distance from the circumcenter to the orthocenter equals 9R² minus the sum of the squared side lengths.",
+      "leanType": "∀ T : Triangle, dist2_sq T.circumcenter T.orthocenter = 9 * T.circumradius ^ 2 - (T.side_a ^ 2 + T.side_b ^ 2 + T.side_c ^ 2)"
+    },
+    {
+      "name": "orthocenter_circumcenter_dist_sq",
+      "type": "core",
+      "description": "Squared-distance form: OH² = 9·dist²(O,A) − (dist²(B,C) + dist²(C,A) + dist²(A,B)), proved by one linear_combination over the equidistance relations.",
+      "leanType": "∀ T : Triangle, dist2_sq T.circumcenter T.orthocenter = 9 * dist2_sq T.circumcenter T.A - (dist2_sq T.B T.C + dist2_sq T.C T.A + dist2_sq T.A T.B)"
+    },
+    {
+      "name": "sum_sq_sides_le_nine_circumradius_sq",
+      "type": "core",
+      "description": "Euler's inequality precursor: a² + b² + c² ≤ 9R², immediate from OH² ≥ 0.",
+      "leanType": "∀ T : Triangle, T.side_a ^ 2 + T.side_b ^ 2 + T.side_c ^ 2 ≤ 9 * T.circumradius ^ 2"
+    },
+    {
+      "name": "centroid_circumcenter_dist_sq",
+      "type": "core",
+      "description": "Metric Euler line (1:3 leg): OH² = 9·OG², so the circumcenter–orthocenter distance is three times the circumcenter–centroid distance.",
+      "leanType": "∀ T : Triangle, dist2_sq T.circumcenter T.orthocenter = 9 * dist2_sq T.circumcenter T.centroid"
+    },
+    {
+      "name": "centroid_orthocenter_dist_sq",
+      "type": "core",
+      "description": "Metric Euler line (2:3 leg): 4·OH² = 9·GH², so OG : GH : OH = 1 : 2 : 3.",
+      "leanType": "∀ T : Triangle, 4 * dist2_sq T.circumcenter T.orthocenter = 9 * dist2_sq T.centroid T.orthocenter"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Caps the **orthocenter sub-line** of the Feuerbach development with the classical metric identity for the circumcenter–orthocenter distance:

$$OH^2 = 9R^2 - (a^2 + b^2 + c^2).$$

This is the quantitative companion of the two qualitative orthocenter entries already in the gallery — altitude concurrency (`oq-01-oq-01`) and the reflections of the orthocenter onto the circumcircle (`oq-01-oq-01-oq-01`). The grandparent `FeuerbachsTheoremDefs.lean` records the Euler line only qualitatively (collinearity `G = (2O+H)/3`); this entry measures the distance `OH` itself for the first time.

## What's proved (8 theorems + 5 lemmas, 0 defs)

- **`orthocenter_circumcenter_dist_sq`** — squared-distance form $OH^2 = 9\,|O{-}A|^2 - (|B{-}C|^2 + |C{-}A|^2 + |A{-}B|^2)$. The whole identity collapses to a *single* `linear_combination`, because
  $$OH^2 - [9R^2-(a^2{+}b^2{+}c^2)] = -3(|A{-}O|^2-|B{-}O|^2) - 3(|A{-}O|^2-|C{-}O|^2),$$
  i.e. exactly $-3$ times the sum of the two circumcenter-equidistance defects — no cofactor search (unlike the reflection identity of the sibling entry).
- **`orthocenter_circumcenter_dist_classical`** — textbook form $OH^2 = 9R^2 - (a^2+b^2+c^2)$ in terms of circumradius and side lengths, via the bridge `sq_dist2 : (dist P Q)² = dist2_sq P Q`.
- **`sum_sq_sides_le_nine_circumradius_sq`** — Euler's inequality precursor $a^2+b^2+c^2 \le 9R^2$, free from $OH^2 \ge 0$.
- **`centroid_circumcenter_dist_sq`** ($OH^2 = 9\,OG^2$) and **`centroid_orthocenter_dist_sq`** ($4\,OH^2 = 9\,GH^2$) — the **metric Euler line** $OG : GH : OH = 1 : 2 : 3$, proved by `ring` alone.
- **`centroid_circumcenter_dist_classical`** — $OG^2 = R^2 - (a^2+b^2+c^2)/9$.
- **`triangle_345_OH_sq` / `triangle_345_euler_metric`** — 3-4-5 worked example: $OH^2 = 25/4 = 9\cdot(25/4) - 50$ (here $OH = R = 5/2$, the orthocenter being the right-angle vertex).

## Verification

- Builds clean via `./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01` (first try).
- `#print axioms` on all eight theorems: only `propext` / `Classical.choice` / `Quot.sound` → **0 axioms, 0 sorries**.
- Self-contained against the grandparent `FeuerbachsTheoremDefs` (the two equidistance relations reproved locally); 229 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)