### PR TITLE
audit: mark two newest gallery entries clean (neusis 3-smooth + Euler OH² metric)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17566,8 +17566,22 @@
       "lastAudited": "2026-06-21T10:08:53Z",
       "result": "clean",
       "issues": []
+    },
+    "angle-trisection-oq-04-oq-01": {
+      "agentId": "auditor-agent",
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T10:35:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01": {
+      "agentId": "auditor-agent",
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T10:35:46Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T11:30:00Z"
+  "lastUpdated": "2026-06-21T10:35:46Z"
 }


### PR DESCRIPTION
## Auditor cycle — two newest unaudited gallery entries, both CLEAN

Deep-audited the only two unaudited slugs (deep read + docker build + `#print axioms`).

### `angle-trisection-oq-04-oq-01` — Neusis-constructible degrees = 3-smooth numbers
- 217L, **14 thm / 2 def**, 0 sorry / 0 `axiom` / 0 `native_decide`
- meta counts match source exactly; status `verified`/`original`, axiomCount 0 ✓
- `sorry`/`native_decide` grep hits are **docstring prose only** (line 55: "No `axiom`, no `sorry`, no `native_decide`")
- math sound: intrinsic prime-factor criterion `isTwoThreeNumber_iff`, hard backward direction by strong induction on `Nat.minFac`; `IsNeusisConstructible` defined as the predicate with the Gleason equivalence honestly disclosed as the parent's modelling assumption (not smuggled)

### `feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01` — Euler metric identity OH² = 9R² − (a²+b²+c²)
- 229L, **13 thm (5 lemma + 8 thm) / 0 def**, 0 sorry / 0 `axiom`
- meta counts match; `linear_combination 3·equidistB + 3·equidistC` kernel checks out
- parent `FeuerbachsTheoremDefs` clean (0 axiom/sorry/native_decide); `Triangle.nondegenerate` is a non-collinearity well-formedness field, not a mathematical assumption

### Runtime verification
Both modules `docker-build` clean; all key theorems depend only on `[propext, Classical.choice, Quot.sound]` → genuinely 0-axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)