### PR TITLE
research(feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02): orthocenter–vertex distances AH² = 4R² − a² [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2515,6 +2515,7 @@ import Proofs.FeuerbachsTheoremDefs
 import Proofs.FeuerbachsTheoremDefsOQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01
+import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01
 import Proofs.FeuerbachsTheoremDefsOQ02
 import Proofs.FeuerbachsTheoremDefsOQ02OQ01

--- a/proofs/Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,272 @@
+/-
+  Feuerbach's Theorem DefsOQ01OQ01OQ01OQ02: Distances from the Orthocenter to the
+  Vertices — AH² = 4R² − a²
+
+  ## The Open Question
+
+  The metric strand of the orthocenter sub-line has so far measured the distance
+  from the circumcenter to the orthocenter:
+
+  * `FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01` proved Euler's metric identity
+    `OH² = 9R² − (a² + b² + c²)`.
+
+  The remaining classical metric facts about `H` are the **distances from the
+  orthocenter to the three vertices**.  These are the squared form of the
+  textbook relation `AH = 2R·cos A`:
+
+      AH² = 4R² − a²,   BH² = 4R² − b²,   CH² = 4R² − c²,
+
+  the distance from a vertex to the orthocenter in terms of the circumradius `R`
+  and the *opposite* side length.  (Indeed `a = 2R sin A`, so
+  `4R² − a² = 4R²cos²A = (2R cos A)²`.)
+
+  ## What This File Proves
+
+  ### The headline identities (one per vertex)
+  `orthocenter_vertex_A_dist_sq` : `AH² = 4·|O−A|² − |B−C|²`  (squared-distance form)
+  `orthocenter_vertex_A_dist_classical` : `AH² = 4R² − a²`     (textbook form),
+  and the `B`, `C` analogues.
+
+  Each reduces, after substituting `H = A + B + C − 2O`, to a polynomial identity
+  modulo the two circumcenter-equidistance relations
+  `|B − O|² = |A − O|²` and `|C − O|² = |A − O|²`.  For the `A` version one checks
+
+      AH² − [4R² − a²] = 2(|B−O|² − |A−O|²) + 2(|C−O|² − |A−O|²),
+
+  so a single `linear_combination` over the two equidistance facts discharges it.
+
+  ### The sum and its link to Euler's identity
+  `orthocenter_vertex_sum_sq` :
+      `AH² + BH² + CH² = 12R² − (a² + b² + c²)`,
+  and the clean relation to the circumcenter–orthocenter distance
+  `orthocenter_vertex_sum_eq_OH` :
+      `AH² + BH² + CH² = OH² + 3R²`
+  (consistent with `OH² = 9R² − (a²+b²+c²)`: the two differ by exactly `3R²`).
+
+  ### Consequence
+  `orthocenter_vertex_le_diameter_sq` : `AH² ≤ 4R²` — a vertex never lies farther
+  from the orthocenter than the diameter of the circumcircle.
+
+  ### Worked example
+  For the 3-4-5 right triangle the orthocenter coincides with the right-angle
+  vertex `A`, so `AH² = 0 = 4R² − a² = 25 − 25`, while `BH² = 9`, `CH² = 16`,
+  summing to `25 = 12R² − (a²+b²+c²)`.
+
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Proofs.FeuerbachsTheoremDefs
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02
+
+open FeuerbachsTheorem
+
+-- ============================================================
+-- Part 0: Pairwise equidistance of the circumcenter
+--
+-- The parent declares the equidistance facts `private`; we reprove the two we
+-- need (against vertex A) so this file builds independently.  Each follows from
+-- the perpendicular-bisector identity, which is *linear* in O.
+-- ============================================================
+
+set_option maxHeartbeats 6400000 in
+private lemma perp_bisector_AB (T : Triangle) :
+    (T.B.1 - T.A.1) * (T.B.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.B.2 - T.A.2) * (T.B.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+set_option maxHeartbeats 6400000 in
+private lemma perp_bisector_AC (T : Triangle) :
+    (T.C.1 - T.A.1) * (T.C.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.C.2 - T.A.2) * (T.C.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+/-- `|B - O|² = |A - O|²` : the circumcenter is equidistant from `A` and `B`. -/
+private lemma equidistB (T : Triangle) :
+    (T.B.1 - T.circumcenter.1) ^ 2 + (T.B.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := perp_bisector_AB T
+  nlinarith [sq_nonneg (T.B.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.B.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+/-- `|C - O|² = |A - O|²` : the circumcenter is equidistant from `A` and `C`. -/
+private lemma equidistC (T : Triangle) :
+    (T.C.1 - T.circumcenter.1) ^ 2 + (T.C.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := perp_bisector_AC T
+  nlinarith [sq_nonneg (T.C.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.C.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+-- ============================================================
+-- Part I: squared distance vs. the metric `dist2`
+-- ============================================================
+
+/-- `dist2` is the square root of `dist2_sq`, so squaring recovers it. -/
+lemma sq_dist2 (P Q : Point) : (dist2 P Q) ^ 2 = dist2_sq P Q := by
+  unfold dist2 dist2_sq
+  rw [Real.sq_sqrt (by positivity)]
+
+-- ============================================================
+-- Part II: Distances from the orthocenter to each vertex
+--
+-- With H = A + B + C − 2O one has, in O-centered coordinates a = A − O etc.,
+--   AH² = |b + c|² = |b|² + |c|² + 2 b·c,
+--   a²  = |c − b|² = |b|² + |c|² − 2 b·c,
+-- hence AH² + a² = 2(|b|² + |c|²), and the two equidistance relations
+-- |b|² = |a|² = |c|² collapse this to AH² + a² = 4|a|² = 4R².
+-- ============================================================
+
+/-- **AH² = 4R² − a²** (squared-distance form).
+    The squared distance from vertex `A` to the orthocenter `H` equals four times
+    the squared circumradius minus the squared length of the *opposite* side `BC`. -/
+theorem orthocenter_vertex_A_dist_sq (T : Triangle) :
+    dist2_sq T.A T.orthocenter
+      = 4 * dist2_sq T.circumcenter T.A - dist2_sq T.B T.C := by
+  simp only [dist2_sq, Triangle.orthocenter]
+  linear_combination 2 * equidistB T + 2 * equidistC T
+
+/-- **BH² = 4R² − b²** (squared-distance form). -/
+theorem orthocenter_vertex_B_dist_sq (T : Triangle) :
+    dist2_sq T.B T.orthocenter
+      = 4 * dist2_sq T.circumcenter T.A - dist2_sq T.C T.A := by
+  simp only [dist2_sq, Triangle.orthocenter]
+  linear_combination 2 * equidistC T
+
+/-- **CH² = 4R² − c²** (squared-distance form). -/
+theorem orthocenter_vertex_C_dist_sq (T : Triangle) :
+    dist2_sq T.C T.orthocenter
+      = 4 * dist2_sq T.circumcenter T.A - dist2_sq T.A T.B := by
+  simp only [dist2_sq, Triangle.orthocenter]
+  linear_combination 2 * equidistB T
+
+-- ============================================================
+-- Part III: Classical (textbook) forms in terms of R and a, b, c
+-- ============================================================
+
+/-- **AH² = 4R² − a²** in textbook form (`R = circumradius`, `a = side_a`). -/
+theorem orthocenter_vertex_A_dist_classical (T : Triangle) :
+    dist2_sq T.A T.orthocenter = 4 * T.circumradius ^ 2 - T.side_a ^ 2 := by
+  rw [show T.circumradius ^ 2 = dist2_sq T.circumcenter T.A from sq_dist2 _ _,
+      show T.side_a ^ 2 = dist2_sq T.B T.C from sq_dist2 _ _]
+  exact orthocenter_vertex_A_dist_sq T
+
+/-- **BH² = 4R² − b²** in textbook form. -/
+theorem orthocenter_vertex_B_dist_classical (T : Triangle) :
+    dist2_sq T.B T.orthocenter = 4 * T.circumradius ^ 2 - T.side_b ^ 2 := by
+  rw [show T.circumradius ^ 2 = dist2_sq T.circumcenter T.A from sq_dist2 _ _,
+      show T.side_b ^ 2 = dist2_sq T.C T.A from sq_dist2 _ _]
+  exact orthocenter_vertex_B_dist_sq T
+
+/-- **CH² = 4R² − c²** in textbook form. -/
+theorem orthocenter_vertex_C_dist_classical (T : Triangle) :
+    dist2_sq T.C T.orthocenter = 4 * T.circumradius ^ 2 - T.side_c ^ 2 := by
+  rw [show T.circumradius ^ 2 = dist2_sq T.circumcenter T.A from sq_dist2 _ _,
+      show T.side_c ^ 2 = dist2_sq T.A T.B from sq_dist2 _ _]
+  exact orthocenter_vertex_C_dist_sq T
+
+-- ============================================================
+-- Part IV: The sum and its link to Euler's metric identity
+-- ============================================================
+
+/-- **AH² + BH² + CH² = 12R² − (a² + b² + c²)** (squared-distance form).
+    Summing the three vertex identities; the three `4R²` terms combine to `12R²`
+    after the equidistance relations identify `|O−A|² = |O−B|² = |O−C|²`. -/
+theorem orthocenter_vertex_sum_sq (T : Triangle) :
+    dist2_sq T.A T.orthocenter + dist2_sq T.B T.orthocenter + dist2_sq T.C T.orthocenter
+      = 12 * dist2_sq T.circumcenter T.A
+        - (dist2_sq T.B T.C + dist2_sq T.C T.A + dist2_sq T.A T.B) := by
+  simp only [dist2_sq, Triangle.orthocenter]
+  linear_combination 4 * equidistB T + 4 * equidistC T
+
+/-- **AH² + BH² + CH² = 12R² − (a² + b² + c²)** in textbook form. -/
+theorem orthocenter_vertex_sum_classical (T : Triangle) :
+    dist2_sq T.A T.orthocenter + dist2_sq T.B T.orthocenter + dist2_sq T.C T.orthocenter
+      = 12 * T.circumradius ^ 2 - (T.side_a ^ 2 + T.side_b ^ 2 + T.side_c ^ 2) := by
+  rw [show T.circumradius ^ 2 = dist2_sq T.circumcenter T.A from sq_dist2 _ _,
+      show T.side_a ^ 2 = dist2_sq T.B T.C from sq_dist2 _ _,
+      show T.side_b ^ 2 = dist2_sq T.C T.A from sq_dist2 _ _,
+      show T.side_c ^ 2 = dist2_sq T.A T.B from sq_dist2 _ _]
+  exact orthocenter_vertex_sum_sq T
+
+/-- **AH² + BH² + CH² = OH² + 3R².**
+    The sum of the squared vertex–orthocenter distances exceeds the squared
+    circumcenter–orthocenter distance by exactly `3R²`.  Combined with Euler's
+    identity `OH² = 9R² − (a²+b²+c²)` this reproves the sum identity above
+    (`12R² − (a²+b²+c²) = (9R² − (a²+b²+c²)) + 3R²`). -/
+theorem orthocenter_vertex_sum_eq_OH (T : Triangle) :
+    dist2_sq T.A T.orthocenter + dist2_sq T.B T.orthocenter + dist2_sq T.C T.orthocenter
+      = dist2_sq T.circumcenter T.orthocenter + 3 * dist2_sq T.circumcenter T.A := by
+  simp only [dist2_sq, Triangle.orthocenter]
+  linear_combination equidistB T + equidistC T
+
+-- ============================================================
+-- Part V: Consequence — a vertex is within the diameter of the orthocenter
+-- ============================================================
+
+/-- `AH² ≤ 4R²`: the distance from a vertex to the orthocenter never exceeds the
+    diameter of the circumcircle (immediate from `AH² = 4R² − a²` and `a² ≥ 0`). -/
+theorem orthocenter_vertex_le_diameter_sq (T : Triangle) :
+    dist2_sq T.A T.orthocenter ≤ 4 * T.circumradius ^ 2 := by
+  have h := orthocenter_vertex_A_dist_classical T
+  have hnn : 0 ≤ T.side_a ^ 2 := sq_nonneg _
+  linarith
+
+-- ============================================================
+-- Part VI: Worked example (3-4-5 right triangle)
+--
+-- A = (0,0) is the right-angle vertex and the orthocenter, so AH² = 0; the other
+-- two vertices sit at the legs' ends.
+-- ============================================================
+
+/-- For the 3-4-5 right triangle, `AH² = 0` (the orthocenter is the right-angle
+    vertex `A`), matching `4R² − a² = 4·(25/4) − 25 = 0`. -/
+theorem triangle_345_AH_sq :
+    dist2_sq triangle_345.A triangle_345.orthocenter = 0 := by
+  rw [triangle_345_orthocenter]
+  simp only [dist2_sq, triangle_345]
+  norm_num
+
+/-- The 3-4-5 triangle satisfies `AH² = 4R² − a²` numerically (`0 = 25 − 25`). -/
+theorem triangle_345_vertex_A_metric :
+    dist2_sq triangle_345.A triangle_345.orthocenter
+      = 4 * triangle_345.circumradius ^ 2 - triangle_345.side_a ^ 2 := by
+  rw [triangle_345_AH_sq, triangle_345_circumradius, triangle_345_side_a]
+  norm_num
+
+/-- The 3-4-5 vertex–orthocenter sum: `0 + 9 + 16 = 25 = 12R² − (a²+b²+c²)`. -/
+theorem triangle_345_vertex_sum :
+    dist2_sq triangle_345.A triangle_345.orthocenter
+        + dist2_sq triangle_345.B triangle_345.orthocenter
+        + dist2_sq triangle_345.C triangle_345.orthocenter
+      = 12 * triangle_345.circumradius ^ 2
+        - (triangle_345.side_a ^ 2 + triangle_345.side_b ^ 2 + triangle_345.side_c ^ 2) := by
+  rw [triangle_345_circumradius, triangle_345_side_a, triangle_345_side_b, triangle_345_side_c,
+      triangle_345_orthocenter]
+  simp only [dist2_sq, triangle_345]
+  norm_num
+
+end FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
+  "title": "Feuerbach's Theorem: Orthocenter–Vertex Distances AH² = 4R² − a²",
+  "slug": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
+  "description": "Measures the distances from the orthocenter H to the three vertices: AH² = 4R² − a², BH² = 4R² − b², CH² = 4R² − c² (the squared form of the textbook AH = 2R·cos A). Sums them to AH² + BH² + CH² = 12R² − (a²+b²+c²), links this to Euler's metric identity via AH² + BH² + CH² = OH² + 3R², bounds AH² ≤ 4R², and verifies all of it on the 3-4-5 right triangle. 13 theorems and 5 lemmas, 0 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
+    "tags": [
+      "geometry",
+      "feuerbach",
+      "orthocenter",
+      "circumcenter",
+      "circumradius",
+      "vertex-distance",
+      "metric-identity",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only propext / Classical.choice / Quot.sound, confirmed by #print axioms). Inherits the coordinate API (circumcenter/orthocenter formulas, side-length lemmas, circumcenter_denom_ne_zero, and the triangle_345 computations) from FeuerbachsTheoremDefs.lean, which is itself 0-sorry, 0-axiom.",
+    "lineCount": 272,
+    "theoremCount": 13,
+    "definitionCount": 0,
+    "originalContributions": [
+      "orthocenter_vertex_A_dist_sq (and B, C): the squared-distance form AH² = 4·dist²(O,A) − dist²(B,C), the distance from a vertex to the orthocenter in terms of the circumcenter and the opposite side — a quantity the nine-point-circle and Euler-line development never measures",
+      "orthocenter_vertex_A_dist_classical (and B, C): the textbook form AH² = 4R² − a² in terms of the circumradius R and the opposite side length a (the squared form of AH = 2R·cos A)",
+      "orthocenter_vertex_sum_sq / orthocenter_vertex_sum_classical: AH² + BH² + CH² = 12R² − (a²+b²+c²), the sum of the three vertex distances",
+      "orthocenter_vertex_sum_eq_OH: AH² + BH² + CH² = OH² + 3R², the clean link to Euler's metric identity OH² = 9R² − (a²+b²+c²) (the two differ by exactly 3R²)",
+      "orthocenter_vertex_le_diameter_sq: AH² ≤ 4R² — a vertex is never farther from the orthocenter than the diameter of the circumcircle",
+      "sq_dist2: the bridge (dist2 P Q)² = dist2_sq P Q, letting the squared-distance identities be restated with the metric circumradius and side lengths",
+      "triangle_345_AH_sq / triangle_345_vertex_A_metric / triangle_345_vertex_sum: worked example — for the 3-4-5 right triangle the orthocenter is the right-angle vertex A, so AH² = 0 = 4R² − a² = 25 − 25, BH² = 9, CH² = 16, summing to 25 = 12R² − (a²+b²+c²)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The squared distances from the orthocenter H to the three vertices, AH² = 4R² − a², are the metric companions of the qualitative orthocentric facts proved earlier in this sub-line — altitude concurrency at H = A + B + C − 2O, and the reflections of H landing on the circumcircle. They are the squared form of the classical relation AH = 2R·cos A (since a = 2R·sin A gives 4R² − a² = 4R²cos²A), and together with the circumcenter–orthocenter distance OH² = 9R² − (a²+b²+c²) measured in the sibling entry they complete the elementary metric picture of the orthocenter. The grandparent FeuerbachsTheoremDefs.lean records the orthocenter only through the nine-point circle and Euler line; this entry supplies its distances to the vertices.",
+    "problemStatement": "With O the circumcenter, R the circumradius, H = A + B + C − 2O the orthocenter and a, b, c the side lengths (a = BC opposite A, etc.), prove:\n1. **Vertex distances**: AH² = 4R² − a², BH² = 4R² − b², CH² = 4R² − c², in both squared-distance and circumradius/side-length form.\n2. **Sum**: AH² + BH² + CH² = 12R² − (a² + b² + c²).\n3. **Link to Euler's identity**: AH² + BH² + CH² = OH² + 3R².\n4. **Bound**: AH² ≤ 4R².\n5. A numerical instance on the 3-4-5 right triangle.",
+    "text": "A 272-line companion file with 13 theorems and 5 lemmas (no new definitions). It reproves the circumcenter's pairwise equidistance against vertex A locally, establishes each vertex-distance identity in squared-distance form by a one-line linear_combination, lifts them to the classical R/side-length form through the sq_dist2 bridge, sums them, ties the sum to the circumcenter–orthocenter distance, derives the diameter bound, and closes with the 3-4-5 worked example.",
+    "proofStrategy": "Work in O-centered coordinates, writing a = A − O, b = B − O, c = C − O. Since H = A + B + C − 2O, one has A − H = −(b + c), so AH² = |b + c|² = |b|² + |c|² + 2b·c, while the opposite side a² = |c − b|² = |b|² + |c|² − 2b·c. Hence AH² + a² = 2(|b|² + |c|²), and the two circumcenter-equidistance relations |b|² = |a|² = |c|² collapse this to AH² + a² = 4|a|² = 4R². Concretely, after `simp only [dist2_sq, Triangle.orthocenter]`, the A-identity is discharged by `linear_combination 2·equidistB + 2·equidistC` (the B- and C-identities need only one equidistance each). The equidistance relations are reproved locally (the parent declares them private) from the perpendicular-bisector identity, which is linear in O. The classical forms replace each squared distance by the corresponding squared length using sq_dist2 : (dist2 P Q)² = dist2_sq P Q (Real.sq_sqrt on a manifestly nonnegative argument). The sum is a single linear_combination; the link to OH² is `linear_combination equidistB + equidistC`; the diameter bound is linarith against a² ≥ 0. The 3-4-5 example reuses the parent's triangle_345_orthocenter = (0,0) and finishes by norm_num.",
+    "keyInsights": [
+      "Each vertex-distance identity collapses to a one-line linear_combination over the circumcenter-equidistance defects: AH² − (4R² − a²) = 2(|b|²−|a|²) + 2(|c|²−|a|²), with no cofactor search — the B- and C-versions need only a single equidistance relation each.",
+      "Working in squared distances (dist2_sq) keeps every identity polynomial; the conversion to the metric circumradius and side lengths is isolated in the single bridge lemma sq_dist2, so the heavy algebra never touches Real.sqrt.",
+      "The sum AH² + BH² + CH² = OH² + 3R² exposes the exact 3R² gap between the vertex-distance sum (12R² − Σa²) and Euler's circumcenter–orthocenter distance (9R² − Σa²), a relation provable directly from the same two equidistance facts.",
+      "The diameter bound AH² ≤ 4R² is immediate once the identity AH² = 4R² − a² is in hand and a² ≥ 0 — a positivity fact invisible to the purely qualitative orthocenter entries.",
+      "In the 3-4-5 right triangle the orthocenter coincides with the right-angle vertex A, the degenerate-looking but correct instance AH² = 0 = 4R² − a² = 25 − 25."
+    ],
+    "prerequisites": [
+      "FeuerbachsTheoremDefs.lean — coordinate API (Point, Triangle, circumcenter, orthocenter, dist2, dist2_sq, circumradius, side_a/b/c) and circumcenter_denom_ne_zero, plus the triangle_345 computations",
+      "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01 — Euler's metric identity OH² = 9R² − (a²+b²+c²), to which the vertex-distance sum is linked",
+      "feuerbachs-theorem-defs-oq-01-oq-01 — the altitude-concurrency entry establishing H = A + B + C − 2O",
+      "Real.sq_sqrt and linear_combination / ring for polynomial and rational identities over R"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Pairwise Equidistance of the Circumcenter",
+      "startLine": 1,
+      "endLine": 123,
+      "summary": "Module docstring stating the open question, imports FeuerbachsTheoremDefs, and reproves the two circumcenter-equidistance facts (against vertex A) locally — the parent declares them private — via the perpendicular-bisector identity which is linear in O.",
+      "mathContext": "perp_bisector_AB / _AC close by substituting the circumcenter fraction and field_simp; ring; equidistB / equidistC then follow by nlinarith. These supply the |B−O|² = |A−O|² and |C−O|² = |A−O|² relations used by the vertex-distance identities."
+    },
+    {
+      "id": "bridge",
+      "title": "Part I: Squared Distance vs. the Metric dist2",
+      "startLine": 124,
+      "endLine": 131,
+      "summary": "Proves sq_dist2 : (dist2 P Q)² = dist2_sq P Q, the bridge from the polynomial squared-distance to the metric distance.",
+      "mathContext": "dist2 P Q = √(dist2_sq P Q) with dist2_sq P Q ≥ 0, so Real.sq_sqrt recovers dist2_sq on squaring."
+    },
+    {
+      "id": "vertex-distances",
+      "title": "Part II–III: Vertex Distances AH² = 4R² − a²",
+      "startLine": 132,
+      "endLine": 189,
+      "summary": "The three squared-distance identities (one linear_combination each over the equidistance relations) and their classical R/side-length forms.",
+      "mathContext": "orthocenter_vertex_A_dist_sq: simp only [dist2_sq, Triangle.orthocenter]; linear_combination 2·equidistB + 2·equidistC; the B/C versions use one equidistance each. The classical forms rewrite each squared distance via sq_dist2."
+    },
+    {
+      "id": "sum",
+      "title": "Part IV: The Sum and its Link to Euler's Identity",
+      "startLine": 190,
+      "endLine": 225,
+      "summary": "AH² + BH² + CH² = 12R² − (a²+b²+c²) in squared-distance and classical form, and the relation AH² + BH² + CH² = OH² + 3R² to the circumcenter–orthocenter distance.",
+      "mathContext": "orthocenter_vertex_sum_sq: linear_combination 4·equidistB + 4·equidistC; orthocenter_vertex_sum_eq_OH: linear_combination equidistB + equidistC, the 3R² gap to Euler's identity."
+    },
+    {
+      "id": "bound-example",
+      "title": "Part V–VI: Diameter Bound and the 3-4-5 Example",
+      "startLine": 226,
+      "endLine": 272,
+      "summary": "AH² ≤ 4R² (linarith against a² ≥ 0) and the numerical 3-4-5 instance: AH² = 0, the vertex sum 0 + 9 + 16 = 25 = 12R² − (a²+b²+c²).",
+      "mathContext": "orthocenter_vertex_le_diameter_sq uses the classical identity and sq_nonneg; triangle_345_AH_sq / triangle_345_vertex_A_metric / triangle_345_vertex_sum rewrite the parent's orthocenter (0,0) and side/circumradius values then norm_num."
+    }
+  ],
+  "conclusion": {
+    "summary": "Supplies the orthocenter–vertex distances of the orthocenter sub-line: AH² = 4R² − a², BH² = 4R² − b², CH² = 4R² − c², their sum AH² + BH² + CH² = 12R² − (a²+b²+c²), the link AH² + BH² + CH² = OH² + 3R² to Euler's metric identity, the diameter bound AH² ≤ 4R², and a 3-4-5 worked example. 13 theorems and 5 lemmas, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "**Metric completion**: together with the sibling entry's OH² = 9R² − (a²+b²+c²), the orthocenter is now fully characterized metrically — its distance to the circumcenter and to each vertex — and not only qualitatively (concurrency, reflections).\n\n**Bridge to angle form**: AH² = 4R² − a² is the squared, coordinate-free statement of AH = 2R·cos A, the natural entry point to a trigonometric treatment of the orthocenter and the pedal triangle.",
+    "openQuestions": [
+      "Prove the angle form AH = 2R·cos A directly, recovering the sign of cos A (and hence whether H lies inside or outside the triangle) from the obtuse/acute dichotomy.",
+      "Use AH² = 4R² − a² together with the reflection entry to compute the side lengths of the orthic (pedal) triangle, a²·(…)-type identities feeding the nine-point circle's tangency in the Feuerbach umbrella.",
+      "Reformulate AH² = 4R² − a² and the vertex-distance sum in Mathlib's EuclideanGeometry API (dist, EuclideanGeometry.orthocenter, circumradius) for a possible upstream contribution."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "the companion metric measurement: where the sibling measures OH (circumcenter to orthocenter), this measures AH, BH, CH (vertices to orthocenter); the two are tied by AH² + BH² + CH² = OH² + 3R²"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "the metric companion of the orthocenter-reflection entry: instead of placing reflections of H on the circumcircle, it measures the distances from H to the vertices"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01-oq-01",
+      "relationship": "related",
+      "description": "uses the orthocenter H = A + B + C − 2O established by the altitude-concurrency entry"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs",
+      "relationship": "extends",
+      "description": "adds the vertex distances of the orthocenter, a metric quantity the nine-point-circle development in FeuerbachsTheoremDefs.lean never measures"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Proofs.FeuerbachsTheoremDefs"],
+    "opens": ["FeuerbachsTheorem"],
+    "namespace": "FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02",
+    "lineCount": 272,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 0,
+    "path": "Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "orthocenter_vertex_A_dist_classical",
+      "type": "core",
+      "description": "AH² = 4R² − a² in textbook form: the squared distance from vertex A to the orthocenter equals four times the squared circumradius minus the squared opposite side a (the squared form of AH = 2R·cos A).",
+      "leanType": "∀ T : Triangle, dist2_sq T.A T.orthocenter = 4 * T.circumradius ^ 2 - T.side_a ^ 2"
+    },
+    {
+      "name": "orthocenter_vertex_A_dist_sq",
+      "type": "core",
+      "description": "Squared-distance form: AH² = 4·dist²(O,A) − dist²(B,C), proved by one linear_combination over the circumcenter-equidistance relations.",
+      "leanType": "∀ T : Triangle, dist2_sq T.A T.orthocenter = 4 * dist2_sq T.circumcenter T.A - dist2_sq T.B T.C"
+    },
+    {
+      "name": "orthocenter_vertex_sum_classical",
+      "type": "core",
+      "description": "The sum of the three vertex–orthocenter distances: AH² + BH² + CH² = 12R² − (a² + b² + c²).",
+      "leanType": "∀ T : Triangle, dist2_sq T.A T.orthocenter + dist2_sq T.B T.orthocenter + dist2_sq T.C T.orthocenter = 12 * T.circumradius ^ 2 - (T.side_a ^ 2 + T.side_b ^ 2 + T.side_c ^ 2)"
+    },
+    {
+      "name": "orthocenter_vertex_sum_eq_OH",
+      "type": "core",
+      "description": "Link to Euler's metric identity: AH² + BH² + CH² = OH² + 3R², so the vertex-distance sum exceeds the squared circumcenter–orthocenter distance by exactly 3R².",
+      "leanType": "∀ T : Triangle, dist2_sq T.A T.orthocenter + dist2_sq T.B T.orthocenter + dist2_sq T.C T.orthocenter = dist2_sq T.circumcenter T.orthocenter + 3 * dist2_sq T.circumcenter T.A"
+    },
+    {
+      "name": "orthocenter_vertex_le_diameter_sq",
+      "type": "core",
+      "description": "Diameter bound: AH² ≤ 4R², a vertex is never farther from the orthocenter than the diameter of the circumcircle (immediate from AH² = 4R² − a² and a² ≥ 0).",
+      "leanType": "∀ T : Triangle, dist2_sq T.A T.orthocenter ≤ 4 * T.circumradius ^ 2"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Extends the metric strand of the Feuerbach orthocenter sub-line. The sibling entry (`-oq-01-oq-01-oq-01-oq-01`) measured the circumcenter–orthocenter distance `OH² = 9R² − (a²+b²+c²)`; this entry measures the **distances from the orthocenter `H` to the three vertices**:

- `AH² = 4R² − a²`, `BH² = 4R² − b²`, `CH² = 4R² − c²` — the squared, coordinate-free form of the textbook `AH = 2R·cos A`, in both squared-distance and circumradius/side-length form.
- `AH² + BH² + CH² = 12R² − (a²+b²+c²)` — the sum of the three vertex distances.
- `AH² + BH² + CH² = OH² + 3R²` — the clean link to Euler's metric identity (the two differ by exactly `3R²`).
- `AH² ≤ 4R²` — a vertex is never farther from `H` than the circumcircle's diameter.
- A fully numerical 3-4-5 worked example (`H` is the right-angle vertex `A`, so `AH² = 0 = 25 − 25`, `BH² = 9`, `CH² = 16`, summing to `25`).

## Proof note

In O-centered coordinates `b = B−O`, `c = C−O`, the Euler line `H = A+B+C−2O` gives `A−H = −(b+c)`, so `AH² = |b+c|²` and `a² = |c−b|²`; hence `AH² + a² = 2(|b|²+|c|²)`, which the two circumcenter-equidistance relations `|b|²=|a|²=|c|²` collapse to `4R²`. Each identity is therefore a **one-line `linear_combination`** over the equidistance defects (no cofactor search). The classical R/side forms go through the single bridge lemma `sq_dist2 : (dist2 P Q)² = dist2_sq P Q`, keeping all heavy algebra polynomial.

## Verification

- **13 theorems + 5 lemmas, 0 definitions, 272 lines, 0 axioms, 0 sorries.**
- Built clean via the Docker wrapper (`3093 jobs`).
- `#print axioms` confirms only `propext` / `Classical.choice` / `Quot.sound`.
- Self-contained: imports only the grandparent `FeuerbachsTheoremDefs` (already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)