### PR TITLE
audit: mark borsuk-ulam-oq-02-oq-01-oq-02 clean (no exotic free representations for cyclic groups)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17580,8 +17580,14 @@
       "lastAudited": "2026-06-21T10:35:46Z",
       "result": "clean",
       "issues": []
+    },
+    "borsuk-ulam-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T10:51:50Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T10:35:46Z"
+  "lastUpdated": "2026-06-21T10:52:00Z"
 }


### PR DESCRIPTION
## Auditor: gallery integrity verified

Deep-audited the newest gallery entry **borsuk-ulam-oq-02-oq-01-oq-02** ("No Exotic Free Representations for Cyclic Groups", merged in #27323).

### Findings — CLEAN
| Claim (meta.json) | Source | Verdict |
|---|---|---|
| 144 lines | 144 | ✓ |
| 7 theorems | 7 | ✓ |
| 2 definitions | 2 | ✓ |
| 0 sorries | 0 | ✓ |
| 0 axioms | 0 `axiom` decls, no native_decide | ✓ |
| status `verified` / 0-axiom | confirmed | ✓ |

### Build + axiom verification
Built clean in Docker (`Proofs.BorsukUlamAxCheckTmp` companion). `#print axioms` on:
- `isFreeRep_iff_forall_prime` (main prime-localization theorem)
- `coprime_iff_forall_prime_dvd` (number-theoretic core)
- `not_isFreeRep_example` (the Z/6 witness)

…all report only `[propext, Classical.choice, Quot.sound]` — **no `Lean.ofReduceBool`, no `sorryAx`**. The `decide` calls are on tiny concrete Decidable facts (3∤2, 2∣2), not `native_decide`.

The parent's axiomatized `buDim` framework is **not** imported here — the model is built from rotation weights, so the 0-axiom claim is honest. Definitions `IsFreeRep`/`IsFreeAtPrime` are genuine Props, not stubs.

Persists the audit result in `audit-tracker.json` (auditCount 1, result clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)