### PR TITLE
research(intermediate-value-theorem-oq-02-oq-01): bisection converges to an exact zero — recovering classical IVT [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2733,6 +2733,7 @@ import Proofs.IntegralRootTheoremOQ01
 import Proofs.IntermediateValueTheorem
 import Proofs.IntermediateValueTheoremOQ01
 import Proofs.IntermediateValueTheoremOQ02
+import Proofs.IntermediateValueTheoremOQ02OQ01
 import Proofs.IntermediateValueTheoremOQ02OQ03
 import Proofs.IntermediateValueTheoremOQ03
 import Proofs.InverseGalois

--- a/proofs/Proofs/IntermediateValueTheoremOQ02OQ01.lean
+++ b/proofs/Proofs/IntermediateValueTheoremOQ02OQ01.lean
@@ -1,0 +1,137 @@
+/-
+Intermediate Value Theorem — convergence of bisection to an exact zero (OQ-02-OQ-01)
+
+Open Question (parent `intermediate-value-theorem-oq-02`):
+  *Formalize convergence of the bisection midpoints to an exact zero via completeness
+  of ℝ (Cauchy sequences), recovering the full classical IVT from the approximate
+  version.*
+
+The parent entry `intermediate-value-theorem-oq-02` built the bisection algorithm and
+proved its *approximate* content: for every ε > 0 it produces a point with |f(x)| < ε.
+Here we close the loop and recover the **exact** classical IVT from that same algorithm.
+
+The bisection endpoint sequences `Lₙ = (bisect f n (a,b)).1` and `Rₙ = (bisect f n (a,b)).2`
+are monotone (one up, one down), order-bounded, and satisfy `Rₙ − Lₙ = (b−a)/2ⁿ → 0`.
+By completeness of ℝ (here: monotone bounded convergence, `tendsto_atTop_ciSup`) both
+converge to a common limit `c ∈ [a,b]`, which is also the limit of the midpoints.
+Continuity carries the sign invariant `f(Lₙ) ≤ 0 ≤ f(Rₙ)` to the limit, forcing
+`f(c) ≤ 0 ≤ f(c)`, i.e. `f(c) = 0`.
+
+Main results:
+* `bisect_tendsto_root` — the bisection midpoints converge to a point `c ∈ [a,b]` with
+  `f c = 0` (the exact IVT, obtained constructively from the algorithm).
+* `exact_ivt_zero` — the existence statement `∃ c ∈ [a,b], f c = 0`.
+* `exact_ivt` — the **full classical IVT** for an arbitrary intermediate value `y`
+  between `f a` and `f b`, recovered from the bisection construction.
+
+This file imports and builds directly on the parent's verified bisection lemmas; it
+adds the completeness/limit layer that the parent deliberately left open.
+-/
+
+import Mathlib
+import Proofs.IntermediateValueTheoremOQ02
+
+open Set Filter Topology
+
+namespace ConstructiveIVT
+
+/-- The left bisection endpoints form a monotone (non-decreasing) sequence. -/
+theorem bisect_left_seq_mono {a b : ℝ} (hab : a ≤ b) (f : ℝ → ℝ) :
+    Monotone (fun n => (bisect f n (a, b)).1) := by
+  apply monotone_nat_of_le_succ
+  intro n
+  have ho := bisect_ordered f n (a, b) hab
+  show (bisect f n (a, b)).1 ≤ (bisectStep f (bisect f n (a, b))).1
+  unfold bisectStep; split_ifs <;> dsimp only <;> linarith
+
+/-- The right bisection endpoints form an antitone (non-increasing) sequence. -/
+theorem bisect_right_seq_anti {a b : ℝ} (hab : a ≤ b) (f : ℝ → ℝ) :
+    Antitone (fun n => (bisect f n (a, b)).2) := by
+  apply antitone_nat_of_succ_le
+  intro n
+  have ho := bisect_ordered f n (a, b) hab
+  show (bisectStep f (bisect f n (a, b))).2 ≤ (bisect f n (a, b)).2
+  unfold bisectStep; split_ifs <;> dsimp only <;> linarith
+
+/-- **Bisection converges to an exact zero.**
+For continuous `f` on `[a,b]` with `f a ≤ 0 ≤ f b`, the bisection midpoints converge to
+a point `c ∈ [a,b]` with `f c = 0`.  This recovers the exact IVT from the parent's
+approximate (ε-) version using completeness of ℝ. -/
+theorem bisect_tendsto_root {a b : ℝ} (hab : a < b) {f : ℝ → ℝ}
+    (hf : ContinuousOn f (Icc a b)) (hfa : f a ≤ 0) (hfb : 0 ≤ f b) :
+    ∃ c ∈ Icc a b,
+      Tendsto (fun n => bisectMid f n (a, b)) atTop (𝓝 c) ∧ f c = 0 := by
+  -- Endpoints lie in `[a,b]`.
+  have hmemL : ∀ n, (bisect f n (a, b)).1 ∈ Icc a b := fun n => by
+    have hc := bisect_contained f n a b hab.le
+    have ho := bisect_ordered f n (a, b) hab.le
+    exact ⟨hc.1, le_trans ho hc.2⟩
+  have hmemR : ∀ n, (bisect f n (a, b)).2 ∈ Icc a b := fun n => by
+    have hc := bisect_contained f n a b hab.le
+    have ho := bisect_ordered f n (a, b) hab.le
+    exact ⟨le_trans hc.1 ho, hc.2⟩
+  -- Monotone bounded ⇒ the left sequence converges to its supremum `c`.
+  have hLmono := bisect_left_seq_mono hab.le f
+  have hbdd : BddAbove (Set.range (fun n => (bisect f n (a, b)).1)) :=
+    ⟨b, by rintro x ⟨n, rfl⟩; exact (hmemL n).2⟩
+  obtain ⟨c, hLc⟩ : ∃ c, Tendsto (fun n => (bisect f n (a, b)).1) atTop (𝓝 c) :=
+    ⟨_, tendsto_atTop_ciSup hLmono hbdd⟩
+  -- The interval width tends to `0`.
+  have hpow : Tendsto (fun n : ℕ => (b - a) / 2 ^ n) atTop (𝓝 0) := by
+    have h2 : Tendsto (fun n : ℕ => ((1 : ℝ) / 2) ^ n) atTop (𝓝 0) :=
+      tendsto_pow_atTop_nhds_zero_of_lt_one (by norm_num) (by norm_num)
+    have h3 := h2.const_mul (b - a)
+    rw [mul_zero] at h3
+    exact h3.congr (fun n => by rw [div_pow, one_pow]; ring)
+  have hwidth : Tendsto (fun n => (bisect f n (a, b)).2 - (bisect f n (a, b)).1)
+      atTop (𝓝 0) :=
+    hpow.congr (fun n => (bisect_width f n (a, b)).symm)
+  -- Hence the right sequence converges to the same limit `c`.
+  have hRc : Tendsto (fun n => (bisect f n (a, b)).2) atTop (𝓝 c) := by
+    have h := hLc.add hwidth
+    rw [add_zero] at h
+    exact h.congr (fun n => by ring)
+  -- The common limit lies in `[a,b]`.
+  have hc_mem : c ∈ Icc a b :=
+    ⟨ge_of_tendsto hLc (Eventually.of_forall fun n => (hmemL n).1),
+     le_of_tendsto hLc (Eventually.of_forall fun n => (hmemL n).2)⟩
+  -- The midpoints converge to `c` as well.
+  have hMid : Tendsto (fun n => bisectMid f n (a, b)) atTop (𝓝 c) := by
+    have h := (hLc.add hRc).div_const 2
+    rw [show (c + c) / 2 = c by ring] at h
+    exact h.congr (fun n => by simp only [bisectMid])
+  refine ⟨c, hc_mem, hMid, ?_⟩
+  -- Continuity transports the sign invariant to the limit.
+  have hcontL : Tendsto (fun n => f ((bisect f n (a, b)).1)) atTop (𝓝 (f c)) :=
+    (hf c hc_mem).tendsto.comp
+      (tendsto_nhdsWithin_iff.mpr ⟨hLc, Eventually.of_forall hmemL⟩)
+  have hcontR : Tendsto (fun n => f ((bisect f n (a, b)).2)) atTop (𝓝 (f c)) :=
+    (hf c hc_mem).tendsto.comp
+      (tendsto_nhdsWithin_iff.mpr ⟨hRc, Eventually.of_forall hmemR⟩)
+  have hle : f c ≤ 0 :=
+    le_of_tendsto hcontL
+      (Eventually.of_forall fun n => (bisect_sign f n (a, b) hfa hfb).1)
+  have hge : 0 ≤ f c :=
+    ge_of_tendsto hcontR
+      (Eventually.of_forall fun n => (bisect_sign f n (a, b) hfa hfb).2)
+  exact le_antisymm hle hge
+
+/-- **Exact IVT (zero version).** A continuous `f` on `[a,b]` with `f a ≤ 0 ≤ f b` has an
+exact zero in `[a,b]` — recovered from the bisection algorithm. -/
+theorem exact_ivt_zero {a b : ℝ} (hab : a < b) {f : ℝ → ℝ}
+    (hf : ContinuousOn f (Icc a b)) (hfa : f a ≤ 0) (hfb : 0 ≤ f b) :
+    ∃ c ∈ Icc a b, f c = 0 := by
+  obtain ⟨c, hc, _, hfc⟩ := bisect_tendsto_root hab hf hfa hfb
+  exact ⟨c, hc, hfc⟩
+
+/-- **Full classical Intermediate Value Theorem.** For continuous `f` on `[a,b]` and any
+value `y` between `f a` and `f b`, there is `c ∈ [a,b]` with `f c = y`.  This is recovered
+from the bisection construction by applying the zero version to `g = f − y`. -/
+theorem exact_ivt {a b : ℝ} (hab : a < b) {f : ℝ → ℝ}
+    (hf : ContinuousOn f (Icc a b)) {y : ℝ} (hfa : f a ≤ y) (hfb : y ≤ f b) :
+    ∃ c ∈ Icc a b, f c = y := by
+  have hg : ContinuousOn (fun x => f x - y) (Icc a b) := hf.sub continuousOn_const
+  obtain ⟨c, hc, hgc⟩ := exact_ivt_zero hab hg (by simpa using hfa) (by simpa using hfb)
+  exact ⟨c, hc, by linarith [hgc]⟩
+
+end ConstructiveIVT

--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-01/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "intermediate-value-theorem-oq-02-oq-01",
+  "title": "Bisection Converges to an Exact Zero: Recovering the Classical IVT",
+  "slug": "intermediate-value-theorem-oq-02-oq-01",
+  "description": "Closes the loop on the constructive bisection IVT of the parent entry by recovering the exact classical Intermediate Value Theorem from the algorithm. The bisection endpoint sequences are monotone, order-bounded, and have width (b-a)/2^n → 0; by completeness of ℝ (monotone bounded convergence) both endpoints and the midpoints converge to a common limit c ∈ [a,b], and continuity carries the sign invariant f(left) ≤ 0 ≤ f(right) to the limit, forcing f(c) = 0. Builds directly on the parent's verified bisection lemmas and proves the full classical IVT for an arbitrary intermediate value. Fully machine-checked, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/IntermediateValueTheoremOQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "intermediate-value-theorem",
+      "bisection",
+      "completeness-of-reals",
+      "constructive",
+      "continuity",
+      "convergence"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. #print axioms reports only propext, Classical.choice, Quot.sound. The result uses completeness of ℝ via Mathlib's monotone bounded convergence (tendsto_atTop_ciSup), not any added axiom.",
+    "lineCount": 137,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "bisect_left_seq_mono / bisect_right_seq_anti: the bisection endpoint sequences are monotone (one non-decreasing, one non-increasing)",
+      "bisect_tendsto_root: the bisection midpoints converge to a point c ∈ [a,b] with f c = 0 — the exact zero promised by the parent's approximate version",
+      "exact_ivt_zero: existence of an exact zero for f a ≤ 0 ≤ f b, recovered from the algorithm",
+      "exact_ivt: the full classical IVT for an arbitrary intermediate value y between f a and f b (via g = f − y)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Bolzano (1817) first proved the Intermediate Value Theorem rigorously, isolating completeness of the reals as the essential ingredient; Cauchy popularized the bisection argument. The parent gallery entry (intermediate-value-theorem-oq-02) formalized the constructive, algorithmic content of bisection — width halving, the sign invariant, and the approximate conclusion |f(x)| < ε — but deliberately stopped short of the exact zero, leaving 'recover the classical IVT via completeness' as an explicit open question. This entry supplies precisely that completeness layer.",
+    "problemStatement": "Formalize the convergence of the bisection midpoints to an exact zero via completeness of ℝ, recovering the full classical IVT from the approximate version proved in the parent entry.",
+    "text": "Working from the parent's bisection operator, the left endpoints Lₙ = (bisect f n (a,b)).1 form a monotone non-decreasing sequence and the right endpoints Rₙ a monotone non-increasing one, both confined to [a,b]; their gap Rₙ − Lₙ = (b−a)/2ⁿ tends to 0. Monotone bounded convergence (tendsto_atTop_ciSup) gives Lₙ → c for some c, and since the width vanishes Rₙ → c and the midpoints → c as well, with c ∈ [a,b]. The parent's sign invariant f(Lₙ) ≤ 0 ≤ f(Rₙ) passes to the limit under continuity (f(Lₙ) → f(c) and f(Rₙ) → f(c) via convergence within [a,b]), yielding f(c) ≤ 0 and 0 ≤ f(c), hence f(c) = 0. Applying this to g = f − y recovers the classical IVT for any intermediate value y.",
+    "proofStrategy": "Promote the parent's per-step bisection lemmas to statements about the endpoint sequences (monotone/antitone, bounded, width → 0), invoke monotone bounded convergence for the limit, and transport the sign invariant across the limit using continuity within the interval; finally shift by a constant to obtain the general intermediate-value form.",
+    "keyInsights": [
+      "The exact zero is the shared limit of the two monotone endpoint sequences; completeness enters only through monotone bounded convergence.",
+      "The vanishing width (b−a)/2ⁿ forces the left limit, right limit, and midpoint limit to coincide, so the algorithm pins down a single point.",
+      "Continuity is used exactly once, to move the sign invariant f(left) ≤ 0 ≤ f(right) to the limit; the strict approximate bound of the parent is not needed for the exact statement."
+    ],
+    "prerequisites": [
+      "The parent bisection algorithm and its width/sign/containment lemmas",
+      "Monotone bounded convergence in ℝ (tendsto_atTop_ciSup)",
+      "Limits of sequences and order-limit lemmas (le_of_tendsto, ge_of_tendsto)",
+      "Continuity within a set (ContinuousOn / ContinuousWithinAt)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The open question is resolved: the bisection midpoints converge to an exact zero c ∈ [a,b] with f c = 0 (bisect_tendsto_root), recovering the classical IVT (exact_ivt) for any intermediate value, all 0-axiom and built on the parent's verified lemmas. 5 theorems, 137 lines.",
+    "implications": "This completes the constructive-to-classical bridge for the IVT: the parent supplied the algorithm and its approximate guarantee, and this entry supplies the completeness argument turning the approximation into an exact root. It is a clean template for extracting classical existence theorems from convergent algorithms.",
+    "openQuestions": [
+      "Quantify the convergence rate explicitly (one bit per step) and compare against Newton's quadratic convergence, as raised in the parent's second open question.",
+      "Carry out the same recovery in a constructive type theory without classical logic, identifying the extra hypotheses on f (locatedness of the zero).",
+      "Establish uniqueness of the recovered zero under strict monotonicity by linking to the parent's monotone_ivt_unique."
+    ]
+  },
+  "leanFile": {
+    "namespace": "ConstructiveIVT",
+    "lineCount": 137,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/IntermediateValueTheoremOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "intermediate-value-theorem-oq-02",
+      "relationship": "extends",
+      "description": "Parent: the constructive bisection IVT (width halving, sign invariant, approximate |f(x)| < ε). This entry adds the completeness/limit layer recovering the exact zero, reusing the parent's verified lemmas directly."
+    },
+    {
+      "targetId": "intermediate-value-theorem",
+      "relationship": "related",
+      "description": "The classical Intermediate Value Theorem, here recovered constructively from the bisection algorithm."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Endpoint sequences are monotone",
+      "startLine": 44,
+      "endLine": 64,
+      "summary": "bisect_left_seq_mono and bisect_right_seq_anti promote the parent's per-step monotonicity to the full sequences of left/right endpoints."
+    },
+    {
+      "title": "Convergence to an exact zero",
+      "startLine": 66,
+      "endLine": 128,
+      "summary": "bisect_tendsto_root: monotone bounded convergence gives the left limit c; the width (b−a)/2ⁿ → 0 forces the right endpoints and midpoints to c ∈ [a,b]; continuity transports the sign invariant to give f c = 0."
+    },
+    {
+      "title": "Recovering the classical IVT",
+      "startLine": 130,
+      "endLine": 137,
+      "summary": "exact_ivt_zero (existence of a zero) and exact_ivt (the full IVT for an arbitrary intermediate value y, via g = f − y)."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Resolves the first open question of the parent entry `intermediate-value-theorem-oq-02`:

> *Formalize convergence of the bisection midpoints to an exact zero via completeness of ℝ, recovering the full classical IVT from the approximate version.*

The parent built the bisection algorithm and proved its **approximate** conclusion (`|f(x)| < ε`). This entry adds the completeness layer that turns the approximation into an **exact** root, recovering the classical IVT.

## Argument

The endpoint sequences `Lₙ = (bisect f n (a,b)).1` and `Rₙ = (bisect f n (a,b)).2`:
- are monotone (`bisect_left_seq_mono`) and antitone (`bisect_right_seq_anti`), confined to `[a,b]`;
- have vanishing width `Rₙ − Lₙ = (b−a)/2ⁿ → 0`.

Monotone bounded convergence (`tendsto_atTop_ciSup`) gives `Lₙ → c`; the vanishing width forces `Rₙ → c` and the midpoints `→ c`, with `c ∈ [a,b]`. Continuity transports the parent's sign invariant `f(Lₙ) ≤ 0 ≤ f(Rₙ)` to the limit, so `f c ≤ 0` and `0 ≤ f c`, hence **`f c = 0`**.

## Results (`Proofs/IntermediateValueTheoremOQ02OQ01.lean`, 5 theorems, 137 lines)

- `bisect_tendsto_root` — midpoints converge to `c ∈ [a,b]` with `f c = 0`.
- `exact_ivt_zero` — `∃ c ∈ [a,b], f c = 0` for `f a ≤ 0 ≤ f b`.
- `exact_ivt` — the **full classical IVT** for any intermediate value `y` between `f a` and `f b` (via `g = f − y`).

Built directly on the parent's verified bisection lemmas (`bisect_ordered`, `bisect_width`, `bisect_sign`, `bisect_contained`).

## Verification

```
./proofs/scripts/docker-build.sh Proofs.IntermediateValueTheoremOQ02OQ01   # Build succeeded
#print axioms → [propext, Classical.choice, Quot.sound]                    # 0 substantive axioms
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)