### PR TITLE
research(feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01): a vertex–orthocenter segment is twice the circumcenter–opposite-midpoint segment AH = 2·OM_a [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2507,6 +2507,7 @@ import Proofs.FeuerbachsTheoremDefs
 import Proofs.FeuerbachsTheoremDefsOQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01
+import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01
 import Proofs.FeuerbachsTheoremDefsOQ03
 import Proofs.FeuerbachsTheoremDefsOQ04
 import Proofs.FeuerbachsTheoremOQ01

--- a/proofs/Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,347 @@
+/-
+  Feuerbach's Theorem DefsOQ01OQ01OQ01OQ02OQ01: A Vertex–Orthocenter segment is
+  twice the Circumcenter–Opposite-Midpoint segment — AH = 2·OM_a
+
+  ## The Open Question
+
+  The parent file `FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02` proved the metric
+  identity for the distance from a vertex to the orthocenter,
+
+      AH² = 4R² − a²,   BH² = 4R² − b²,   CH² = 4R² − c².
+
+  A classical companion expresses the *same* quantity geometrically: the distance
+  from a vertex to the orthocenter equals **twice** the distance from the
+  circumcenter `O` to the midpoint `M_a` of the opposite side `BC`:
+
+      AH = 2·OM_a,   BH = 2·OM_b,   CH = 2·OM_c.
+
+  Indeed `OM_a = R·cos A` (`O` projects orthogonally onto `BC` at `M_a`, and the
+  right triangle `O M_a B` gives `OM_a² = R² − (a/2)²`), so `2·OM_a = 2R·cos A = AH`.
+
+  ## What This File Proves
+
+  ### The exact vector identity (no circle hypothesis needed)
+  `vertexA_orthocenter_vec` :  `A − H = 2·(O − M_a)`  (componentwise).
+
+  Substituting `H = A + B + C − 2O` and `M_a = (B + C)/2` makes both sides equal
+  to `2O − B − C` — a *purely affine* identity, independent of the circumcenter's
+  equidistance property.  In particular the segment `HA` is parallel to `OM_a`.
+
+  ### Squared-length consequence (still no circle hypothesis)
+  `orthocenter_vertexA_eq_four_OMa_sq` :  `AH² = 4·OM_a²`,
+  immediate by squaring the vector identity.
+
+  ### The circumcenter–midpoint distance (uses equidistance)
+  `circumcenter_midpoint_a_sq` :  `4·OM_a² = 4R² − a²`,  i.e. `OM_a² = R² − (a/2)²`.
+  Here `M_a` lies on the perpendicular bisector of `BC`, so the two equidistance
+  relations `|B−O|² = |A−O|²`, `|C−O|² = |A−O|²` collapse `4·OM_a²` to `4R² − a²`.
+
+  ### Putting them together
+  `orthocenter_vertexA_eq_four_OMa_classical` re-derives `AH² = 4R² − a²` from the
+  two pieces above (a cross-check of the parent, proved here independently), and
+  `orthocenter_vertexA_dist_eq_two_OMa` gives the textbook **`AH = 2·OM_a`** as an
+  identity of actual (square-root) distances.
+
+  ### Perpendicularity of the altitude
+  `altitude_A_perp_BC` :  `(A − H) · (C − B) = 0`.  Because `A − H ∥ O − M_a` and
+  `O` is equidistant from `B`, `C`, the line `HA` is perpendicular to `BC`; this
+  recovers the defining property of the altitude through `A`.
+
+  ### The sum identity
+  `circumcenter_midpoint_sum_sq` :
+      `4·(OM_a² + OM_b² + OM_c²) = 12R² − (a² + b² + c²)`,
+  so `OM_a² + OM_b² + OM_c² = ¼(AH² + BH² + CH²)`.
+
+  ### Worked example (3-4-5 right triangle)
+  `O = (3/2, 2)`, `M_a = (3/2, 2)` so `OM_a = 0 = AH/2` (the orthocenter is the
+  right-angle vertex `A`), while `OM_b² = 9/4` (`BH = 3 = 2·OM_b`) and
+  `OM_c² = 4` (`CH = 4 = 2·OM_c`).
+
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Proofs.FeuerbachsTheoremDefs
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01
+
+open FeuerbachsTheorem
+
+-- ============================================================
+-- Part 0: Pairwise equidistance of the circumcenter
+--
+-- The parent declares the equidistance facts `private`; we reprove the three we
+-- need (A–B, A–C, and the derived B–C) so this file builds independently.  Each
+-- follows from the perpendicular-bisector identity, which is *linear* in O.
+-- ============================================================
+
+set_option maxHeartbeats 6400000 in
+private lemma perp_bisector_AB (T : Triangle) :
+    (T.B.1 - T.A.1) * (T.B.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.B.2 - T.A.2) * (T.B.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+set_option maxHeartbeats 6400000 in
+private lemma perp_bisector_AC (T : Triangle) :
+    (T.C.1 - T.A.1) * (T.C.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.C.2 - T.A.2) * (T.C.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+/-- `|B - O|² = |A - O|²` : the circumcenter is equidistant from `A` and `B`. -/
+private lemma equidistB (T : Triangle) :
+    (T.B.1 - T.circumcenter.1) ^ 2 + (T.B.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := perp_bisector_AB T
+  nlinarith [sq_nonneg (T.B.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.B.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+/-- `|C - O|² = |A - O|²` : the circumcenter is equidistant from `A` and `C`. -/
+private lemma equidistC (T : Triangle) :
+    (T.C.1 - T.circumcenter.1) ^ 2 + (T.C.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := perp_bisector_AC T
+  nlinarith [sq_nonneg (T.C.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.C.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+-- ============================================================
+-- Part I: squared distance vs. the metric `dist2`
+-- ============================================================
+
+/-- `dist2` is the square root of `dist2_sq`, so squaring recovers it. -/
+lemma sq_dist2 (P Q : Point) : (dist2 P Q) ^ 2 = dist2_sq P Q := by
+  unfold dist2 dist2_sq
+  rw [Real.sq_sqrt (by positivity)]
+
+-- ============================================================
+-- Part II: The exact vector identity  A − H = 2·(O − M_a)
+--
+-- With H = A + B + C − 2O and M_a = (B + C)/2 both sides equal 2O − B − C.
+-- This is purely affine — it needs no equidistance / circle hypothesis.
+-- ============================================================
+
+/-- **`A − H = 2·(O − M_a)`** (componentwise).  The directed segment from the
+    orthocenter to vertex `A` is exactly twice the directed segment from the
+    midpoint `M_a` of `BC` to the circumcenter `O`; in particular `HA ∥ OM_a`. -/
+theorem vertexA_orthocenter_vec (T : Triangle) :
+    (T.A.1 - T.orthocenter.1, T.A.2 - T.orthocenter.2)
+      = (2 * (T.circumcenter.1 - T.midpoint_a.1),
+         2 * (T.circumcenter.2 - T.midpoint_a.2)) := by
+  unfold Triangle.orthocenter Triangle.midpoint_a pointMidpoint
+  exact Prod.ext (by dsimp; ring) (by dsimp; ring)
+
+/-- **`B − H = 2·(O − M_b)`** (componentwise). -/
+theorem vertexB_orthocenter_vec (T : Triangle) :
+    (T.B.1 - T.orthocenter.1, T.B.2 - T.orthocenter.2)
+      = (2 * (T.circumcenter.1 - T.midpoint_b.1),
+         2 * (T.circumcenter.2 - T.midpoint_b.2)) := by
+  unfold Triangle.orthocenter Triangle.midpoint_b pointMidpoint
+  exact Prod.ext (by dsimp; ring) (by dsimp; ring)
+
+/-- **`C − H = 2·(O − M_c)`** (componentwise). -/
+theorem vertexC_orthocenter_vec (T : Triangle) :
+    (T.C.1 - T.orthocenter.1, T.C.2 - T.orthocenter.2)
+      = (2 * (T.circumcenter.1 - T.midpoint_c.1),
+         2 * (T.circumcenter.2 - T.midpoint_c.2)) := by
+  unfold Triangle.orthocenter Triangle.midpoint_c pointMidpoint
+  exact Prod.ext (by dsimp; ring) (by dsimp; ring)
+
+-- ============================================================
+-- Part III: Squared lengths  AH² = 4·OM_a²  (still circle-free)
+--
+-- Squaring the vector identity; a pure `ring` identity in the coordinates.
+-- ============================================================
+
+/-- **`AH² = 4·OM_a²`**: the squared vertex–orthocenter distance is four times the
+    squared circumcenter–midpoint distance.  Immediate from the vector identity. -/
+theorem orthocenter_vertexA_eq_four_OMa_sq (T : Triangle) :
+    dist2_sq T.A T.orthocenter = 4 * dist2_sq T.circumcenter T.midpoint_a := by
+  simp only [dist2_sq, Triangle.orthocenter, Triangle.midpoint_a, pointMidpoint]
+  ring
+
+/-- **`BH² = 4·OM_b²`**. -/
+theorem orthocenter_vertexB_eq_four_OMb_sq (T : Triangle) :
+    dist2_sq T.B T.orthocenter = 4 * dist2_sq T.circumcenter T.midpoint_b := by
+  simp only [dist2_sq, Triangle.orthocenter, Triangle.midpoint_b, pointMidpoint]
+  ring
+
+/-- **`CH² = 4·OM_c²`**. -/
+theorem orthocenter_vertexC_eq_four_OMc_sq (T : Triangle) :
+    dist2_sq T.C T.orthocenter = 4 * dist2_sq T.circumcenter T.midpoint_c := by
+  simp only [dist2_sq, Triangle.orthocenter, Triangle.midpoint_c, pointMidpoint]
+  ring
+
+-- ============================================================
+-- Part IV: The circumcenter–midpoint distance  4·OM_a² = 4R² − a²
+--
+-- M_a is on the perpendicular bisector of BC, so the two equidistance relations
+-- |b|² = |a|² = |c|² (O-centered) collapse 4·OM_a² = |b + c|² to 4R² − a².
+-- ============================================================
+
+/-- **`4·OM_a² = 4R² − a²`**, i.e. `OM_a² = R² − (a/2)²` (squared-distance form).
+    The squared circumcenter–to–`BC`-midpoint distance is `R² − (a/2)²`. -/
+theorem circumcenter_midpoint_a_sq (T : Triangle) :
+    4 * dist2_sq T.circumcenter T.midpoint_a
+      = 4 * dist2_sq T.circumcenter T.A - dist2_sq T.B T.C := by
+  simp only [dist2_sq, Triangle.midpoint_a, pointMidpoint]
+  linear_combination 2 * equidistB T + 2 * equidistC T
+
+/-- **`4·OM_b² = 4R² − b²`**. -/
+theorem circumcenter_midpoint_b_sq (T : Triangle) :
+    4 * dist2_sq T.circumcenter T.midpoint_b
+      = 4 * dist2_sq T.circumcenter T.A - dist2_sq T.C T.A := by
+  simp only [dist2_sq, Triangle.midpoint_b, pointMidpoint]
+  linear_combination 2 * equidistC T
+
+/-- **`4·OM_c² = 4R² − c²`**. -/
+theorem circumcenter_midpoint_c_sq (T : Triangle) :
+    4 * dist2_sq T.circumcenter T.midpoint_c
+      = 4 * dist2_sq T.circumcenter T.A - dist2_sq T.A T.B := by
+  simp only [dist2_sq, Triangle.midpoint_c, pointMidpoint]
+  linear_combination 2 * equidistB T
+
+/-- **`OM_a² = R² − (a/2)²`** in textbook form (`R = circumradius`, `a = side_a`). -/
+theorem circumcenter_midpoint_a_classical (T : Triangle) :
+    dist2_sq T.circumcenter T.midpoint_a
+      = T.circumradius ^ 2 - (T.side_a / 2) ^ 2 := by
+  have h := circumcenter_midpoint_a_sq T
+  have hR : T.circumradius ^ 2 = dist2_sq T.circumcenter T.A := sq_dist2 _ _
+  have ha : T.side_a ^ 2 = dist2_sq T.B T.C := sq_dist2 _ _
+  have hhalf : (T.side_a / 2) ^ 2 = dist2_sq T.B T.C / 4 := by rw [div_pow, ha]; norm_num
+  rw [hR, hhalf]
+  linarith [h]
+
+-- ============================================================
+-- Part V: Putting them together — AH² = 4R² − a² and AH = 2·OM_a
+-- ============================================================
+
+/-- **`AH² = 4R² − a²`** (squared-distance form), re-derived here from the vector
+    identity (`AH² = 4·OM_a²`) and the circumcenter–midpoint distance
+    (`4·OM_a² = 4R² − a²`).  An independent cross-check of the parent result. -/
+theorem orthocenter_vertexA_eq_four_OMa_classical (T : Triangle) :
+    dist2_sq T.A T.orthocenter
+      = 4 * dist2_sq T.circumcenter T.A - dist2_sq T.B T.C := by
+  rw [orthocenter_vertexA_eq_four_OMa_sq T, circumcenter_midpoint_a_sq T]
+
+/-- **`AH = 2·OM_a`** (true distances): the vertex–orthocenter distance equals
+    twice the circumcenter–opposite-midpoint distance.  From `AH² = 4·OM_a²` with
+    both distances non-negative. -/
+theorem orthocenter_vertexA_dist_eq_two_OMa (T : Triangle) :
+    dist2 T.A T.orthocenter = 2 * dist2 T.circumcenter T.midpoint_a := by
+  apply eq_of_sq_eq_of_nonneg (dist2_nonneg _ _)
+    (mul_nonneg (by norm_num) (dist2_nonneg _ _))
+  rw [mul_pow, sq_dist2, sq_dist2]
+  have h := orthocenter_vertexA_eq_four_OMa_sq T
+  linarith [h]
+
+/-- **`BH = 2·OM_b`** (true distances). -/
+theorem orthocenter_vertexB_dist_eq_two_OMb (T : Triangle) :
+    dist2 T.B T.orthocenter = 2 * dist2 T.circumcenter T.midpoint_b := by
+  apply eq_of_sq_eq_of_nonneg (dist2_nonneg _ _)
+    (mul_nonneg (by norm_num) (dist2_nonneg _ _))
+  rw [mul_pow, sq_dist2, sq_dist2]
+  have h := orthocenter_vertexB_eq_four_OMb_sq T
+  linarith [h]
+
+/-- **`CH = 2·OM_c`** (true distances). -/
+theorem orthocenter_vertexC_dist_eq_two_OMc (T : Triangle) :
+    dist2 T.C T.orthocenter = 2 * dist2 T.circumcenter T.midpoint_c := by
+  apply eq_of_sq_eq_of_nonneg (dist2_nonneg _ _)
+    (mul_nonneg (by norm_num) (dist2_nonneg _ _))
+  rw [mul_pow, sq_dist2, sq_dist2]
+  have h := orthocenter_vertexC_eq_four_OMc_sq T
+  linarith [h]
+
+-- ============================================================
+-- Part VI: Perpendicularity of the altitude
+--
+-- A − H ∥ O − M_a, and O − M_a ⊥ BC (perp bisector), so HA ⊥ BC.  The dot
+-- product (A − H)·(C − B) collapses to |B − O|² − |C − O|² = equidistB − equidistC.
+-- ============================================================
+
+/-- **`(A − H) · (C − B) = 0`**: the segment `HA` is perpendicular to `BC`.
+    Recovers the defining property of the altitude through `A` from the parallel
+    segment `OM_a` (which bisects `BC` perpendicularly). -/
+theorem altitude_A_perp_BC (T : Triangle) :
+    (T.A.1 - T.orthocenter.1) * (T.C.1 - T.B.1)
+      + (T.A.2 - T.orthocenter.2) * (T.C.2 - T.B.2) = 0 := by
+  simp only [Triangle.orthocenter]
+  linear_combination equidistB T - equidistC T
+
+-- ============================================================
+-- Part VII: The sum identity
+-- ============================================================
+
+/-- **`4·(OM_a² + OM_b² + OM_c²) = 12R² − (a² + b² + c²)`**, hence
+    `OM_a² + OM_b² + OM_c² = ¼(AH² + BH² + CH²)`.  Summing the three
+    circumcenter–midpoint identities. -/
+theorem circumcenter_midpoint_sum_sq (T : Triangle) :
+    4 * (dist2_sq T.circumcenter T.midpoint_a
+          + dist2_sq T.circumcenter T.midpoint_b
+          + dist2_sq T.circumcenter T.midpoint_c)
+      = 12 * dist2_sq T.circumcenter T.A
+        - (dist2_sq T.B T.C + dist2_sq T.C T.A + dist2_sq T.A T.B) := by
+  have ha := circumcenter_midpoint_a_sq T
+  have hb := circumcenter_midpoint_b_sq T
+  have hc := circumcenter_midpoint_c_sq T
+  linarith [ha, hb, hc]
+
+-- ============================================================
+-- Part VIII: Worked example (3-4-5 right triangle)
+--
+-- O = (3/2, 2), M_a = midpoint(B,C) = (3/2, 2) = O so OM_a = 0 = AH/2;
+-- M_b = (0, 2) gives OM_b² = 9/4 (BH = 3 = 2·OM_b),
+-- M_c = (3/2, 0) gives OM_c² = 4   (CH = 4 = 2·OM_c).
+-- ============================================================
+
+/-- For the 3-4-5 triangle, `OM_a² = 0` (the circumcenter is the hypotenuse
+    midpoint `M_a`), matching `AH² = 0 = 4·OM_a²`. -/
+theorem triangle_345_OMa_sq :
+    dist2_sq triangle_345.circumcenter triangle_345.midpoint_a = 0 := by
+  rw [triangle_345_circumcenter]
+  simp only [dist2_sq, Triangle.midpoint_a, pointMidpoint, triangle_345]
+  norm_num
+
+/-- For the 3-4-5 triangle, `OM_b² = 9/4`, so `2·OM_b = 3 = BH`. -/
+theorem triangle_345_OMb_sq :
+    dist2_sq triangle_345.circumcenter triangle_345.midpoint_b = 9 / 4 := by
+  rw [triangle_345_circumcenter]
+  simp only [dist2_sq, Triangle.midpoint_b, pointMidpoint, triangle_345]
+  norm_num
+
+/-- For the 3-4-5 triangle, `OM_c² = 4`, so `2·OM_c = 4 = CH`. -/
+theorem triangle_345_OMc_sq :
+    dist2_sq triangle_345.circumcenter triangle_345.midpoint_c = 4 := by
+  rw [triangle_345_circumcenter]
+  simp only [dist2_sq, Triangle.midpoint_c, pointMidpoint, triangle_345]
+  norm_num
+
+/-- The 3-4-5 triangle satisfies `BH² = 4·OM_b²` numerically (`9 = 4·(9/4)`). -/
+theorem triangle_345_vertexB_eq_four_OMb :
+    dist2_sq triangle_345.B triangle_345.orthocenter
+      = 4 * dist2_sq triangle_345.circumcenter triangle_345.midpoint_b := by
+  rw [orthocenter_vertexB_eq_four_OMb_sq, triangle_345_OMb_sq]
+
+end FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,206 @@
+{
+  "id": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+  "title": "Feuerbach's Theorem: A Vertex–Orthocenter Segment is Twice the Circumcenter–Opposite-Midpoint Segment (AH = 2·OM_a)",
+  "slug": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+  "description": "Proves the classical companion of AH² = 4R² − a²: the distance from a vertex to the orthocenter is exactly twice the distance from the circumcenter O to the midpoint of the opposite side, AH = 2·OM_a (and B, C). The engine is the exact affine vector identity A − H = 2(O − M_a) — purely from H = A + B + C − 2O and M_a = (B+C)/2, with no circle hypothesis — which gives AH² = 4·OM_a² by squaring; the circle then enters only to evaluate 4·OM_a² = 4R² − a² (OM_a² = R² − (a/2)²) via the perpendicular-bisector equidistance. Re-derives AH² = 4R² − a² independently, lifts to the true-distance AH = 2·OM_a, recovers the altitude's perpendicularity (A−H)·(C−B) = 0 from the parallel segment OM_a, sums to 4(OM_a²+OM_b²+OM_c²) = 12R² − (a²+b²+c²), and verifies the 3-4-5 right triangle. 20 theorems and 5 lemmas, 0 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
+    "tags": [
+      "geometry",
+      "feuerbach",
+      "orthocenter",
+      "circumcenter",
+      "circumradius",
+      "midpoint",
+      "vector-identity",
+      "vertex-distance",
+      "metric-identity",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only propext / Classical.choice / Quot.sound, confirmed by #print axioms on every theorem). Inherits the coordinate API (circumcenter/orthocenter/midpoint formulas, side-length lemmas, dist2/dist2_sq, eq_of_sq_eq_of_nonneg, dist2_nonneg, circumcenter_denom_ne_zero, and the triangle_345 computations) from FeuerbachsTheoremDefs.lean, which is itself 0-sorry, 0-axiom.",
+    "lineCount": 347,
+    "theoremCount": 20,
+    "definitionCount": 0,
+    "originalContributions": [
+      "vertexA_orthocenter_vec (and B, C): the exact componentwise vector identity A − H = 2·(O − M_a), proved purely affinely (both sides equal 2O − B − C) with NO circle / equidistance hypothesis — the structural core showing the segment HA is parallel to OM_a and twice its length",
+      "orthocenter_vertexA_eq_four_OMa_sq (and B, C): AH² = 4·OM_a², the squared-length consequence of the vector identity, a pure ring identity in the coordinates (still circle-free)",
+      "circumcenter_midpoint_a_sq (and b, c): 4·OM_a² = 4R² − a², i.e. OM_a² = R² − (a/2)² — the squared circumcenter-to-opposite-midpoint distance, where the circle finally enters through the perpendicular-bisector equidistance (one linear_combination over the equidistance defects)",
+      "circumcenter_midpoint_a_classical: OM_a² = R² − (a/2)² in textbook R/side-length form (M_a lies on the perpendicular bisector of BC, so OM_a is the apothem-like leg of the right triangle O M_a B)",
+      "orthocenter_vertexA_eq_four_OMa_classical: AH² = 4R² − a² re-derived here independently (AH² = 4·OM_a² = 4R² − a²), a cross-check of the parent entry obtained through the OM_a route rather than directly",
+      "orthocenter_vertexA_dist_eq_two_OMa (and B, C): the textbook AH = 2·OM_a as an identity of actual square-root distances (from AH² = 4·OM_a² and non-negativity)",
+      "altitude_A_perp_BC: (A − H)·(C − B) = 0 — the altitude through A is perpendicular to BC, recovered from the parallel segment OM_a (which bisects BC perpendicularly); collapses to equidistB − equidistC",
+      "circumcenter_midpoint_sum_sq: 4·(OM_a² + OM_b² + OM_c²) = 12R² − (a²+b²+c²), so OM_a² + OM_b² + OM_c² = ¼(AH² + BH² + CH²)",
+      "triangle_345_OMa_sq / OMb_sq / OMc_sq / vertexB_eq_four_OMb: worked example — for the 3-4-5 right triangle the circumcenter is the hypotenuse midpoint M_a so OM_a = 0 = AH/2, while OM_b² = 9/4 (BH = 3 = 2·OM_b) and OM_c² = 4 (CH = 4 = 2·OM_c)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "AH = 2·OM_a — the distance from a vertex to the orthocenter equals twice the distance from the circumcenter to the midpoint of the opposite side — is one of the oldest relations in the geometry of the Euler line. It is the lever behind the standard synthetic construction of the orthocenter (translate the circumcenter's medial picture by the homothety of ratio −2 about the centroid) and the cleanest route to AH = 2R·cos A, since OM_a = R·cos A is the apothem of the side BC. The parent entry FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02 measured AH² = 4R² − a² directly; this entry recovers the same number through OM_a, exposing the underlying parallel segments O→M_a and H→A and the exact factor of 2 between them.",
+    "problemStatement": "With O the circumcenter, R the circumradius, H = A + B + C − 2O the orthocenter, M_a = (B+C)/2 the midpoint of BC (and M_b, M_c the other side midpoints), and a, b, c the side lengths, prove:\n1. **Vector identity**: A − H = 2·(O − M_a) (componentwise), hence HA ∥ OM_a; likewise for B, C.\n2. **Squared lengths**: AH² = 4·OM_a² (circle-free), and 4·OM_a² = 4R² − a², i.e. OM_a² = R² − (a/2)².\n3. **True distance**: AH = 2·OM_a, BH = 2·OM_b, CH = 2·OM_c.\n4. **Altitude**: (A − H)·(C − B) = 0 (HA ⊥ BC).\n5. **Sum**: 4·(OM_a² + OM_b² + OM_c²) = 12R² − (a² + b² + c²).\n6. A numerical instance on the 3-4-5 right triangle.",
+    "text": "A 347-line companion file with 20 theorems and 5 lemmas (no new definitions). It reproves the circumcenter's pairwise equidistance against vertex A locally (the parent declares it private), establishes the exact affine vector identity A − H = 2(O − M_a) by Prod.ext + ring, squares it to AH² = 4·OM_a² by a single ring step, evaluates 4·OM_a² = 4R² − a² by one linear_combination over the equidistance relations, lifts to the metric R/side-length forms and to the true distance AH = 2·OM_a via the sq_dist2 bridge and eq_of_sq_eq_of_nonneg, recovers the altitude perpendicularity, sums the three midpoint identities, and closes with the 3-4-5 worked example.",
+    "proofStrategy": "Work in O-centered coordinates a = A − O, b = B − O, c = C − O. From H = A + B + C − 2O one has A − H = −(b + c) = −2·M_a (with O the origin, M_a = (b+c)/2), i.e. A − H = 2(O − M_a) — an identity of polynomials in the coordinates that needs NO equidistance, dispatched by unfolding orthocenter/midpoint_a/pointMidpoint and `Prod.ext (by dsimp; ring) (by dsimp; ring)`. Squaring is again pure `ring`: AH² = |b + c|² = 4·|M_a|² = 4·OM_a². The circle enters only in 4·OM_a² = 4R² − a²: expand 4·OM_a² = |b + c|² = |b|² + |c|² + 2b·c and 4R² − a² = 4|a|² − |b − c|² = 4|a|² − (|b|² + |c|² − 2b·c); their difference is 2(|b|²−|a|²) + 2(|c|²−|a|²), so `linear_combination 2·equidistB + 2·equidistC` closes it (the b- and c-midpoints need one equidistance each). The equidistance relations are reproved locally from the perpendicular-bisector identity, which is linear in O (field_simp; ring after substituting the circumcenter fraction; nlinarith to clear squares). The true-distance form uses eq_of_sq_eq_of_nonneg with sq_dist2 : (dist2 P Q)² = dist2_sq P Q and the non-negativity of dist2 (so `mul_nonneg` covers 0 ≤ 2·OM_a). The altitude perpendicularity (A − H)·(C − B) = 0 substitutes A − H = 2O − B − C and collapses to |B − O|² − |C − O|² = equidistB − equidistC.",
+    "keyInsights": [
+      "The whole result factors into a circle-free part and a circle part. A − H = 2(O − M_a) and AH² = 4·OM_a² are PURE coordinate identities (affine, then ring) — true for the orthocenter of ANY triangle regardless of the circumscribed circle. Only the evaluation 4·OM_a² = 4R² − a² uses the circumcenter's defining equidistance.",
+      "The factor of 2 is not metric but structural: it is the literal coefficient in the vector identity A − H = 2(O − M_a), so AH ∥ OM_a with ratio exactly 2 — the same homothety (centroid, ratio −2) that carries the medial triangle to the original.",
+      "OM_a² = R² − (a/2)² is the Pythagorean apothem identity in disguise: M_a is the foot of the perpendicular from O to BC, and the right triangle O M_a B has hypotenuse R and one leg a/2. The linear_combination over the equidistance defects is exactly this Pythagoras.",
+      "Because HA ∥ OM_a and OM_a ⊥ BC (O is equidistant from B and C), the altitude perpendicularity (A − H)·(C − B) = 0 falls out of the SAME equidistance facts — a free re-derivation of the defining property of the altitude through A, this time from the circumcenter side.",
+      "The 3-4-5 instance is the clean degenerate case: O is the hypotenuse midpoint M_a, so OM_a = 0 forces AH = 0 (the orthocenter is the right-angle vertex), while OM_b, OM_c give the other two non-trivial 2·OM = vertex-distance checks."
+    ],
+    "prerequisites": [
+      "FeuerbachsTheoremDefs.lean — coordinate API (Point, Triangle, circumcenter, orthocenter, midpoint_a/b/c, pointMidpoint, dist2, dist2_sq, circumradius, side_a/b/c), eq_of_sq_eq_of_nonneg, dist2_nonneg, circumcenter_denom_ne_zero, and the triangle_345 computations",
+      "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02 — the parent metric identity AH² = 4R² − a², which this entry recovers through OM_a",
+      "feuerbachs-theorem-defs-oq-01-oq-01 — the altitude-concurrency entry establishing H = A + B + C − 2O",
+      "Real.sq_sqrt and linear_combination / ring for the polynomial and rational identities over R"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Pairwise Equidistance of the Circumcenter",
+      "startLine": 1,
+      "endLine": 127,
+      "summary": "Module docstring stating the open question, imports FeuerbachsTheoremDefs, and reproves the two circumcenter-equidistance facts (against vertex A) locally — the parent declares them private — via the perpendicular-bisector identity, which is linear in O.",
+      "mathContext": "perp_bisector_AB / _AC close by substituting the circumcenter fraction and field_simp; ring; equidistB / equidistC then follow by nlinarith. These supply |B−O|² = |A−O|² and |C−O|² = |A−O|², the only place the circumscribed circle is used."
+    },
+    {
+      "id": "bridge",
+      "title": "Part I: Squared Distance vs. the Metric dist2",
+      "startLine": 128,
+      "endLine": 137,
+      "summary": "Proves sq_dist2 : (dist2 P Q)² = dist2_sq P Q, the bridge from the polynomial squared-distance to the metric (square-root) distance.",
+      "mathContext": "dist2 P Q = √(dist2_sq P Q) with dist2_sq P Q ≥ 0, so Real.sq_sqrt recovers dist2_sq on squaring; used by the true-distance AH = 2·OM_a form and the classical R/side-length forms."
+    },
+    {
+      "id": "vector-identity",
+      "title": "Part II: The Exact Vector Identity A − H = 2·(O − M_a)",
+      "startLine": 138,
+      "endLine": 172,
+      "summary": "The three componentwise vector identities A − H = 2(O − M_a), B − H = 2(O − M_b), C − H = 2(O − M_c), proved purely affinely.",
+      "mathContext": "Unfold orthocenter / midpoint_x / pointMidpoint; both sides equal 2O − (vertex sum minus the vertex); Prod.ext (by dsimp; ring) (by dsimp; ring). No circle hypothesis is used."
+    },
+    {
+      "id": "squared-lengths",
+      "title": "Part III: Squared Lengths AH² = 4·OM_a² (circle-free)",
+      "startLine": 173,
+      "endLine": 200,
+      "summary": "AH² = 4·OM_a², BH² = 4·OM_b², CH² = 4·OM_c², each a pure ring identity obtained by squaring the vector identity.",
+      "mathContext": "simp only [dist2_sq, Triangle.orthocenter, Triangle.midpoint_x, pointMidpoint]; ring. Still independent of the circumscribed circle."
+    },
+    {
+      "id": "circumcenter-midpoint",
+      "title": "Part IV: The Circumcenter–Midpoint Distance 4·OM_a² = 4R² − a²",
+      "startLine": 201,
+      "endLine": 240,
+      "summary": "4·OM_a² = 4R² − a² (and b, c), i.e. OM_a² = R² − (a/2)², plus the textbook R/side-length form circumcenter_midpoint_a_classical.",
+      "mathContext": "simp only [dist2_sq, Triangle.midpoint_a, pointMidpoint]; linear_combination 2·equidistB + 2·equidistC (the b/c versions use one equidistance each). The classical form rewrites R² and a² via sq_dist2 and div_pow."
+    },
+    {
+      "id": "together",
+      "title": "Part V: Putting Them Together — AH² = 4R² − a² and AH = 2·OM_a",
+      "startLine": 241,
+      "endLine": 277,
+      "summary": "Re-derives AH² = 4R² − a² (AH² = 4·OM_a² = 4R² − a²) and gives the true-distance AH = 2·OM_a, BH = 2·OM_b, CH = 2·OM_c.",
+      "mathContext": "orthocenter_vertexA_eq_four_OMa_classical chains the two earlier rewrites; the true-distance forms use eq_of_sq_eq_of_nonneg with sq_dist2 and mul_nonneg for 0 ≤ 2·OM_a."
+    },
+    {
+      "id": "altitude-sum-example",
+      "title": "Part VI–VIII: Altitude Perpendicularity, Sum Identity, 3-4-5 Example",
+      "startLine": 278,
+      "endLine": 347,
+      "summary": "altitude_A_perp_BC : (A − H)·(C − B) = 0; the sum 4·(OM_a²+OM_b²+OM_c²) = 12R² − (a²+b²+c²); and the 3-4-5 instance OM_a = 0, OM_b² = 9/4, OM_c² = 4.",
+      "mathContext": "altitude_A_perp_BC collapses to equidistB − equidistC; circumcenter_midpoint_sum_sq is linarith over the three midpoint identities; the 3-4-5 theorems rewrite triangle_345_circumcenter then norm_num."
+    }
+  ],
+  "conclusion": {
+    "summary": "Supplies the segment relation AH = 2·OM_a of the orthocenter sub-line: the exact affine vector identity A − H = 2(O − M_a) (circle-free), the squared form AH² = 4·OM_a², the circumcenter–midpoint distance 4·OM_a² = 4R² − a² (OM_a² = R² − (a/2)²), an independent re-derivation of AH² = 4R² − a², the true-distance AH = 2·OM_a, the altitude perpendicularity (A−H)·(C−B) = 0, the sum 4(OM_a²+OM_b²+OM_c²) = 12R² − (a²+b²+c²), and a 3-4-5 worked example. 20 theorems and 5 lemmas, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "**Structural source of AH² = 4R² − a²**: the parent measured AH directly; here the factor of 2 is exhibited as the literal coefficient of an affine identity A − H = 2(O − M_a), separating the part true for any triangle (the parallel segments) from the part that uses the circumscribed circle (OM_a² = R² − (a/2)²).\n\n**Toward the angle form and the medial homothety**: OM_a = R·cos A makes AH = 2·OM_a the same statement as AH = 2R·cos A; and the vector identity is exactly the homothety (centroid, ratio −2) sending the medial triangle's circumcenter picture to the orthocenter, the standard bridge to the Euler line and the nine-point circle of the Feuerbach umbrella.",
+    "openQuestions": [
+      "Promote the affine identity A − H = 2(O − M_a) to a clean statement of the homothety h(G, −2) carrying each side midpoint M_a to the opposite vertex A and the circumcenter O to the orthocenter H, deriving the Euler-line collinearity O, G, H with HG = 2·GO as a corollary.",
+      "Combine OM_a = R·cos A with the obtuse/acute dichotomy to determine the sign of cos A geometrically and hence whether the foot of the perpendicular from O lands inside segment BC, locating the orthocenter inside or outside the triangle."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "the parent metric identity AH² = 4R² − a²; this entry recovers the same quantity geometrically as AH = 2·OM_a via the vector identity A − H = 2(O − M_a), and re-derives AH² = 4R² − a² independently through OM_a"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "the sibling metric measurement OH² = 9R² − (a²+b²+c²); both quantify the orthocenter's position relative to the circumcenter, and the midpoint-sum 4(OM_a²+OM_b²+OM_c²) = 12R² − (a²+b²+c²) equals AH²+BH²+CH²"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01-oq-01",
+      "relationship": "related",
+      "description": "uses the orthocenter H = A + B + C − 2O established by the altitude-concurrency entry; here the altitude's perpendicularity is re-derived from the parallel segment OM_a"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs",
+      "relationship": "extends",
+      "description": "adds the vertex–orthocenter / circumcenter–midpoint segment relation AH = 2·OM_a, a quantity the nine-point-circle and Euler-line development in FeuerbachsTheoremDefs.lean never measures"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Proofs.FeuerbachsTheoremDefs"],
+    "opens": ["FeuerbachsTheorem"],
+    "namespace": "FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01",
+    "lineCount": 347,
+    "axiomCount": 0,
+    "theoremCount": 20,
+    "definitionCount": 0,
+    "path": "Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "vertexA_orthocenter_vec",
+      "type": "core",
+      "description": "The exact componentwise vector identity A − H = 2·(O − M_a): the directed segment from the orthocenter to vertex A is twice the directed segment from the midpoint of BC to the circumcenter. Purely affine — no circle hypothesis.",
+      "leanType": "∀ T : Triangle, (T.A.1 - T.orthocenter.1, T.A.2 - T.orthocenter.2) = (2 * (T.circumcenter.1 - T.midpoint_a.1), 2 * (T.circumcenter.2 - T.midpoint_a.2))"
+    },
+    {
+      "name": "orthocenter_vertexA_eq_four_OMa_sq",
+      "type": "core",
+      "description": "AH² = 4·OM_a²: the squared vertex–orthocenter distance is four times the squared circumcenter–opposite-midpoint distance, by squaring the vector identity (a pure ring identity, still circle-free).",
+      "leanType": "∀ T : Triangle, dist2_sq T.A T.orthocenter = 4 * dist2_sq T.circumcenter T.midpoint_a"
+    },
+    {
+      "name": "circumcenter_midpoint_a_classical",
+      "type": "core",
+      "description": "OM_a² = R² − (a/2)²: the squared circumcenter-to-opposite-midpoint distance equals R² minus the square of half the opposite side (the apothem Pythagoras for the perpendicular bisector of BC).",
+      "leanType": "∀ T : Triangle, dist2_sq T.circumcenter T.midpoint_a = T.circumradius ^ 2 - (T.side_a / 2) ^ 2"
+    },
+    {
+      "name": "orthocenter_vertexA_dist_eq_two_OMa",
+      "type": "core",
+      "description": "AH = 2·OM_a as an identity of actual (square-root) distances: the vertex–orthocenter distance is twice the circumcenter–opposite-midpoint distance.",
+      "leanType": "∀ T : Triangle, dist2 T.A T.orthocenter = 2 * dist2 T.circumcenter T.midpoint_a"
+    },
+    {
+      "name": "altitude_A_perp_BC",
+      "type": "core",
+      "description": "(A − H)·(C − B) = 0: the segment HA is perpendicular to BC, recovering the defining property of the altitude through A from the parallel segment OM_a (which bisects BC perpendicularly).",
+      "leanType": "∀ T : Triangle, (T.A.1 - T.orthocenter.1) * (T.C.1 - T.B.1) + (T.A.2 - T.orthocenter.2) * (T.C.2 - T.B.2) = 0"
+    },
+    {
+      "name": "circumcenter_midpoint_sum_sq",
+      "type": "core",
+      "description": "4·(OM_a² + OM_b² + OM_c²) = 12R² − (a² + b² + c²), hence OM_a² + OM_b² + OM_c² = ¼(AH² + BH² + CH²).",
+      "leanType": "∀ T : Triangle, 4 * (dist2_sq T.circumcenter T.midpoint_a + dist2_sq T.circumcenter T.midpoint_b + dist2_sq T.circumcenter T.midpoint_c) = 12 * dist2_sq T.circumcenter T.A - (dist2_sq T.B T.C + dist2_sq T.C T.A + dist2_sq T.A T.B)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Classical companion of the parent's **AH² = 4R² − a²**: the distance from a vertex to the orthocenter is exactly **twice** the distance from the circumcenter `O` to the midpoint of the opposite side,

> **AH = 2·OM_a**,  BH = 2·OM_b,  CH = 2·OM_c.

The proof factors cleanly into a **circle-free** part and a **circle** part:

- **Affine core (no circle):** the exact componentwise vector identity `A − H = 2·(O − M_a)` — both sides equal `2O − B − C` from `H = A + B + C − 2O` and `M_a = (B+C)/2`. Hence `HA ∥ OM_a` with ratio exactly 2, and `AH² = 4·OM_a²` by a single `ring`.
- **Circle part:** `4·OM_a² = 4R² − a²`, i.e. `OM_a² = R² − (a/2)²` (the apothem Pythagoras for the perpendicular bisector of `BC`), discharged by one `linear_combination` over the circumcenter-equidistance relations.

## Contents (347 lines, 20 theorems + 5 lemmas, 0 def, **0 axioms, 0 sorries**)

- `vertexA_orthocenter_vec` (+B, +C): the exact vector identity `A − H = 2(O − M_a)`, purely affine.
- `orthocenter_vertexA_eq_four_OMa_sq` (+B, +C): `AH² = 4·OM_a²` (circle-free).
- `circumcenter_midpoint_a_sq` (+b, +c) / `_classical`: `4·OM_a² = 4R² − a²`, `OM_a² = R² − (a/2)²`.
- `orthocenter_vertexA_eq_four_OMa_classical`: re-derives `AH² = 4R² − a²` independently through `OM_a`.
- `orthocenter_vertexA_dist_eq_two_OMa` (+B, +C): the textbook `AH = 2·OM_a` as true (square-root) distances.
- `altitude_A_perp_BC`: `(A − H)·(C − B) = 0` — the altitude is perpendicular to `BC`, recovered from the parallel segment `OM_a`.
- `circumcenter_midpoint_sum_sq`: `4·(OM_a²+OM_b²+OM_c²) = 12R² − (a²+b²+c²)`.
- 3-4-5 worked example: `OM_a = 0 = AH/2`, `OM_b² = 9/4` (`BH = 3`), `OM_c² = 4` (`CH = 4`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01` ✔ (builds clean).
- `#print axioms` on every theorem lists only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms**.
- Self-contained: imports the grandparent `FeuerbachsTheoremDefs` only (parent oq-02 not required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)