### PR TITLE
research(lagrange-four-squares-waring-g2-oq-03-oq-08): Waring g(2)=4 as a sharp least element [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2809,6 +2809,7 @@ import Proofs.LagrangeFourSquaresWaringG2OQ03OQ04
 import Proofs.LagrangeFourSquaresWaringG2OQ03OQ05
 import Proofs.LagrangeFourSquaresWaringG2OQ03OQ05OQ01
 import Proofs.LagrangeFourSquaresWaringG2OQ03OQ07
+import Proofs.LagrangeFourSquaresWaringG2OQ03OQ08
 import Proofs.LagrangeTheorem
 import Proofs.LagrangeTheoremOQ01
 import Proofs.LagrangeTheoremOQ01OQ01

--- a/proofs/Proofs/LagrangeFourSquaresWaringG2OQ03OQ08.lean
+++ b/proofs/Proofs/LagrangeFourSquaresWaringG2OQ03OQ08.lean
@@ -1,0 +1,98 @@
+/-
+Waring's number g(2) = 4 as a sharp least element (OQ-03-OQ-08)
+
+Parent umbrella: `lagrange-four-squares-waring-g2` ("Waring's Problem for Squares:
+g(2) = 4").  The umbrella file records the two halves separately — every `n` is a
+sum of 4 squares (Lagrange) and `7` is not a sum of 3 squares — but states the
+conclusion only as their conjunction, and tags the file `axiomatized` because it
+uses `native_decide` for the worked `numSquaresNeeded` examples.
+
+This file gives the **sharp, fully axiom-free** statement.  Define the Waring
+predicate `Sufficient k := every natural number is a sum of k squares`.  Then `g(2)`,
+the *least* `k` with this property, is exactly `4`:
+
+  * `g2_isLeast`   : `IsLeast {k | Sufficient k} 4`
+  * `waring_g2`    : `sInf {k | Sufficient k} = 4`
+
+The upper bound is Lagrange's four-square theorem (`Nat.sum_four_squares`).  The
+lower bound is genuinely sharp: no `k ≤ 3` can suffice, because a representation of
+`7` by `k ≤ 3` squares would, after padding with zeros, give `7 = x² + y² + z²`,
+impossible modulo `8` (squares are `0, 1, 4 (mod 8)` and no three of those sum to
+`7`).  Everything is checked with `decide`/`omega` only — no `native_decide`, so the
+result is `0`-axiom (`#print axioms` lists only `propext`/`Classical`/`Quot`).
+
+Main results:
+* `IsSumOfSquares` (def), `IsSumOfSquares.mono` — representability by `k` squares is
+  monotone in `k` (padding with zeros).
+* `four_squares_universal` — every `n` is a sum of `4` squares.
+* `seven_not_three` — `7` is not a sum of `3` squares.
+* `g2_isLeast`, `waring_g2` — the sharp value `g(2) = 4`.
+-/
+
+import Mathlib
+
+namespace WaringG2Sharp
+
+open Finset
+
+/-- `n` is a sum of `k` perfect squares. -/
+def IsSumOfSquares (k n : ℕ) : Prop := ∃ f : Fin k → ℕ, ∑ i, (f i) ^ 2 = n
+
+/-- Padding with a zero square: a sum of `k` squares is also a sum of `k + 1` squares. -/
+theorem IsSumOfSquares.succ {k n : ℕ} (h : IsSumOfSquares k n) :
+    IsSumOfSquares (k + 1) n := by
+  obtain ⟨f, hf⟩ := h
+  refine ⟨Fin.snoc f 0, ?_⟩
+  rw [Fin.sum_univ_castSucc]
+  simp [Fin.snoc_castSucc, Fin.snoc_last, hf]
+
+/-- Representability by `k` squares is monotone in `k`. -/
+theorem IsSumOfSquares.mono {k l n : ℕ} (hkl : k ≤ l) (h : IsSumOfSquares k n) :
+    IsSumOfSquares l n := by
+  obtain ⟨d, rfl⟩ := Nat.le.dest hkl
+  clear hkl
+  induction d with
+  | zero => simpa using h
+  | succ d ih => rw [Nat.add_succ]; exact ih.succ
+
+/-- **Upper bound (Lagrange 1770).** Every natural number is a sum of four squares. -/
+theorem four_squares_universal (n : ℕ) : IsSumOfSquares 4 n := by
+  obtain ⟨a, b, c, d, h⟩ := Nat.sum_four_squares n
+  exact ⟨![a, b, c, d], by rw [Fin.sum_univ_four]; simpa using h⟩
+
+/-- **Sharp lower-bound witness.** `7` is not a sum of three squares: reducing modulo
+`8`, the only squares are `0, 1, 4`, and no three of them sum to `7`. -/
+theorem seven_not_three : ¬ IsSumOfSquares 3 7 := by
+  rintro ⟨f, hf⟩
+  rw [Fin.sum_univ_three] at hf
+  have h8 := congrArg (Nat.cast : ℕ → ZMod 8) hf
+  push_cast at h8
+  have key : ∀ a b c : ZMod 8, a ^ 2 + b ^ 2 + c ^ 2 ≠ 7 := by decide
+  exact key _ _ _ h8
+
+/-- The set of "sufficient" square-counts: those `k` for which **every** natural
+number is a sum of `k` squares. -/
+def Sufficient (k : ℕ) : Prop := ∀ n, IsSumOfSquares k n
+
+/-- **Waring's theorem for squares, sharp form: `g(2) = 4`.**
+`4` is the least number of squares that suffices to represent every natural number.
+The upper bound is Lagrange's four-square theorem; the lower bound is sharp because
+no `k ≤ 3` works (else `7` would be a sum of `≤ 3` squares). -/
+theorem g2_isLeast : IsLeast {k | Sufficient k} 4 := by
+  constructor
+  · exact four_squares_universal
+  · intro k hk
+    by_contra hlt
+    push_neg at hlt
+    exact seven_not_three ((hk 7).mono (by omega))
+
+/-- The Waring number for squares as an infimum: `g(2) = 4`. -/
+theorem waring_g2 : sInf {k | Sufficient k} = 4 :=
+  g2_isLeast.csInf_eq
+
+/-- Human-readable restatement of the two halves. -/
+theorem four_squares_suffice : Sufficient 4 := four_squares_universal
+
+theorem three_squares_insufficient : ¬ Sufficient 3 := fun h => seven_not_three (h 7)
+
+end WaringG2Sharp

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-08/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-08/meta.json
@@ -1,0 +1,108 @@
+{
+  "id": "lagrange-four-squares-waring-g2-oq-03-oq-08",
+  "title": "Waring's Number g(2) = 4 as a Sharp Least Element",
+  "slug": "lagrange-four-squares-waring-g2-oq-03-oq-08",
+  "description": "Gives the sharp, fully axiom-free statement of Waring's theorem for squares. Defining the Waring predicate Sufficient(k) = 'every natural number is a sum of k squares', it proves that g(2) — the least such k — equals exactly 4, both as IsLeast {k | Sufficient k} 4 and as sInf {k | Sufficient k} = 4. The upper bound is Lagrange's four-square theorem; the lower bound is sharp because no k ≤ 3 suffices (a representation of 7 by ≤ 3 squares is impossible mod 8). Unlike the parent umbrella — which states only the conjunction 'four suffice and 7 needs four' and is tagged axiomatized due to native_decide examples — this entry uses only decide/omega and is 0-axiom.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeFourSquaresWaringG2OQ03OQ08.lean",
+    "tags": [
+      "number-theory",
+      "waring-problem",
+      "sum-of-squares",
+      "lagrange-four-squares",
+      "three-squares",
+      "least-element"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. #print axioms reports only propext, Classical.choice, Quot.sound. In particular no native_decide is used (the parent umbrella file is tagged axiomatized because it evaluates numSquaresNeeded examples by native_decide, which trusts Lean.ofReduceBool); this sharp formulation avoids it entirely.",
+    "lineCount": 98,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "originalContributions": [
+      "IsSumOfSquares (def) and IsSumOfSquares.mono: representability by k squares is monotone in k (padding with zero squares via Fin.snoc)",
+      "four_squares_universal: every n is a sum of 4 squares (Lagrange, wrapping Nat.sum_four_squares)",
+      "seven_not_three: 7 is not a sum of 3 squares, by reduction mod 8 (decide over ZMod 8)",
+      "g2_isLeast: IsLeast {k | Sufficient k} 4 — the sharp statement that 4 is the least number of squares representing every natural",
+      "waring_g2: sInf {k | Sufficient k} = 4 — the Waring number g(2) as an infimum, fully 0-axiom"
+    ]
+  },
+  "overview": {
+    "historicalContext": "In 1770 Edward Waring asserted that every natural number is a sum of at most 4 squares, 9 cubes, 19 fourth powers, and so on; the four-square case was proved by Lagrange the same year. The Waring number g(k) is the least number of k-th powers needed to represent every natural number, and g(2) = 4 is the foundational instance. The lower bound g(2) ≥ 4 is witnessed by 7 (and more generally the numbers 4^a(8b+7), which are exactly the integers not expressible as three squares — Legendre/Gauss). The parent umbrella entry assembled both halves but stated the result only as a conjunction and relied on native_decide for its tabulated examples.",
+    "problemStatement": "State and prove Waring's theorem for squares in its sharp, axiom-free form: the least number of squares that represents every natural number is exactly 4.",
+    "text": "We define IsSumOfSquares k n := ∃ f : Fin k → ℕ, ∑ i (f i)² = n and Sufficient k := ∀ n, IsSumOfSquares k n. Representability is monotone in k (pad a representation with zero squares, Fin.snoc f 0), so the set {k | Sufficient k} is upward closed. The upper bound 4 ∈ {k | Sufficient k} is Lagrange's four-square theorem (Nat.sum_four_squares). For the lower bound we show 4 is a lower bound of the set: if some k with Sufficient k had k ≤ 3, then 7 = sum of k ≤ 3 squares, which monotonicity promotes to 7 = x² + y² + z², impossible because squares are 0, 1, 4 mod 8 and no three of those sum to 7 (verified by decide over ZMod 8). Hence g(2) = 4, packaged both as IsLeast and as sInf {k | Sufficient k} = 4.",
+    "proofStrategy": "Upward-close the representability predicate by zero-padding, take the upper bound from Lagrange and the sharp lower bound from the mod-8 obstruction at 7, then read off the least element / infimum.",
+    "keyInsights": [
+      "Waring's g(2) is most faithfully captured as the least element of {k | every n is a sum of k squares}, not as a bare conjunction.",
+      "Monotonicity of IsSumOfSquares in k is exactly what turns 'no k ≤ 3 representation of 7' into the sharp lower bound 4 ≤ k.",
+      "The single witness 7 and a finite mod-8 check suffice for the lower bound, keeping the whole proof inside decide/omega — no native_decide, hence 0-axiom."
+    ],
+    "prerequisites": [
+      "Lagrange's four-square theorem (Nat.sum_four_squares)",
+      "Squares modulo 8 and finite case checking over ZMod 8",
+      "Least element / infimum in ℕ (IsLeast, sInf, IsLeast.csInf_eq)",
+      "Tuple manipulation (Fin.snoc, Fin.sum_univ_castSucc)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Waring's number for squares is pinned down sharply and axiom-free: g(2) = 4, as IsLeast {k | Sufficient k} 4 and sInf {k | Sufficient k} = 4, with the upper bound from Lagrange and a sharp mod-8 lower bound at 7. 8 theorems, 2 definitions, 98 lines, 0 axioms (no native_decide).",
+    "implications": "This upgrades the umbrella's loose conjunction to the precise least-element meaning of g(2) = 4 and removes the native_decide dependency from the headline statement, making the central claim of the family fully verified. The IsSumOfSquares scaffold (monotone, least-element) is reusable for stating g(k) for higher powers.",
+    "openQuestions": [
+      "Define g(k) uniformly and formalize the next sharp value g(3) = 9 (Wieferich/Kempner), reusing the IsSumOfSquares-style least-element scaffold.",
+      "Formalize the Hilbert–Waring theorem (finiteness of g(k) for all k) abstractly over the same predicate.",
+      "Relate Sufficient(4) to the exact-count characterization: the numbers needing all 4 squares are precisely the excluded forms 4^a(8b+7), of density 1/6 (sibling oq-03-oq-05)."
+    ]
+  },
+  "leanFile": {
+    "namespace": "WaringG2Sharp",
+    "lineCount": 98,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/LagrangeFourSquaresWaringG2OQ03OQ08.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "lagrange-four-squares-waring-g2",
+      "relationship": "extends",
+      "description": "Parent umbrella (Waring g(2) = 4). This entry sharpens the conclusion to a least-element/infimum statement and removes the native_decide dependency, giving a 0-axiom headline."
+    },
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
+      "relationship": "related",
+      "description": "Sibling: the density 1/6 of numbers requiring all four squares (the excluded forms), which are exactly the obstructions to Sufficient(3)."
+    },
+    {
+      "targetId": "lagrange-four-squares",
+      "relationship": "related",
+      "description": "Lagrange's four-square theorem, the upper bound g(2) ≤ 4 used here."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Representability and monotonicity",
+      "startLine": 42,
+      "endLine": 64,
+      "summary": "IsSumOfSquares k n and its monotonicity in k via zero-padding (Fin.snoc), making the sufficient set upward closed."
+    },
+    {
+      "title": "Upper and lower bounds",
+      "startLine": 66,
+      "endLine": 84,
+      "summary": "four_squares_universal (Lagrange upper bound) and seven_not_three (sharp lower-bound witness, mod-8 obstruction by decide over ZMod 8)."
+    },
+    {
+      "title": "g(2) = 4, sharp and axiom-free",
+      "startLine": 86,
+      "endLine": 98,
+      "summary": "Sufficient k, g2_isLeast (IsLeast {k | Sufficient k} 4), waring_g2 (sInf = 4), and the human-readable four_squares_suffice / three_squares_insufficient."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Sharpens the headline of the umbrella `lagrange-four-squares-waring-g2` ("Waring's Problem for Squares: g(2) = 4"). The umbrella states the result only as a **conjunction** ("four suffice and 7 needs four") and is tagged `axiomatized` because it evaluates `numSquaresNeeded` examples by `native_decide` (which trusts `Lean.ofReduceBool`).

This entry gives the **precise least-element statement, fully 0-axiom**:

- `Sufficient k := ∀ n, IsSumOfSquares k n`
- `g2_isLeast : IsLeast {k | Sufficient k} 4`
- `waring_g2  : sInf {k | Sufficient k} = 4`

That is the actual meaning of `g(2) = 4`: **4 is the least** number of squares representing every natural number.

## Argument

- **Monotonicity** (`IsSumOfSquares.mono`): a sum of `k` squares is also a sum of `k+1` squares (pad with `0`, via `Fin.snoc`), so `{k | Sufficient k}` is upward closed.
- **Upper bound** (`four_squares_universal`): Lagrange's four-square theorem (`Nat.sum_four_squares`).
- **Sharp lower bound**: if some `k ≤ 3` were sufficient, `7` would be a sum of `≤ 3` squares; monotonicity gives `7 = x²+y²+z²`, impossible mod 8 (`seven_not_three`, `decide` over `ZMod 8`).

No `native_decide` anywhere — only `decide`/`omega`.

## Results (`Proofs/LagrangeFourSquaresWaringG2OQ03OQ08.lean`, 8 theorems, 2 defs, 98 lines)

`IsSumOfSquares`, `IsSumOfSquares.mono`, `four_squares_universal`, `seven_not_three`, `g2_isLeast`, `waring_g2`, `four_squares_suffice`, `three_squares_insufficient`.

## Verification

```
./proofs/scripts/docker-build.sh Proofs.LagrangeFourSquaresWaringG2OQ03OQ08   # Build succeeded
#print axioms → [propext, Classical.choice, Quot.sound]                        # 0 substantive axioms
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)