### PR TITLE
research(feuerbachs-theorem-defs-oq-01-oq-01-oq-02): the orthocentric system — each of A,B,C,H is the orthocenter of the other three [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2516,6 +2516,7 @@ import Proofs.FeuerbachsTheoremDefsOQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01
+import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ02
 import Proofs.FeuerbachsTheoremDefsOQ02
 import Proofs.FeuerbachsTheoremDefsOQ02OQ01
 import Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01

--- a/proofs/Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ02.lean
@@ -1,0 +1,344 @@
+/-
+  Feuerbach's Theorem DefsOQ01OQ01OQ02: The Orthocentric System
+  — each of A, B, C, H is the orthocenter of the triangle on the other three.
+
+  ## The Open Question
+
+  The orthocenter sub-line established the *existence* of the orthocenter
+  `H = A + B + C − 2O` (concurrency of the three altitudes) and then measured it
+  metrically (`OH²`, `AH²`, `AH = 2·OM_a`).  All of this treats `H` as a derived
+  point attached to a *fixed* base triangle `ABC`.
+
+  The reflections file `FeuerbachsTheoremDefsOQ01OQ01OQ01` noted in passing that
+  putting `H` on the circumcircle is "a hallmark of the **orthocentric
+  configuration** that the nine-point-circle development never establishes."
+  This file establishes that configuration.
+
+  **Open question.** Is the four-point set `{A, B, C, H}` *symmetric* — does each
+  of the four points play the role of the orthocenter of the triangle formed by
+  the other three?  Equivalently: is `A` the orthocenter of `BCH`, `B` the
+  orthocenter of `CAH`, and `C` the orthocenter of `ABH`?
+
+  ## What This File Proves
+
+  We characterize "`P` is an orthocenter of triangle `XYZ`" by the three
+  altitude-perpendicularity conditions (`IsOrthocenterOf`) and show:
+
+  ### The three perpendicularities of the configuration
+  `orthocentric_perp_a` : `(A − H) ⊥ (B − C)`
+  `orthocentric_perp_b` : `(B − H) ⊥ (C − A)`
+  `orthocentric_perp_c` : `(C − H) ⊥ (A − B)`
+  Each is a *linear* fact in the circumcenter `O`: after substituting
+  `H = A + B + C − 2O` it is exactly one perpendicular-bisector relation.  These
+  three "opposite connectors are perpendicular" statements ARE the orthocentric
+  system.
+
+  ### The four orthocenter memberships
+  `orthocenter_of_ABC` : `H` is the orthocenter of `ABC` (consistency with the
+      parent's `Triangle.orthocenter`),
+  `orthocenter_of_BCH` : `A` is the orthocenter of `BCH`,
+  `orthocenter_of_CAH` : `B` is the orthocenter of `CAH`,
+  `orthocenter_of_ABH` : `C` is the orthocenter of `ABH`.
+  Capstone `orthocentric_system` bundles all four.
+
+  ### Uniqueness — "THE" orthocenter
+  `isOrthocenterOf_unique` : for a non-degenerate triangle the perpendicularity
+  characterization pins the orthocenter down uniquely (a `2×2` Cramer argument
+  whose determinant is exactly the triangle's non-degeneracy determinant).  Hence
+  on a non-degenerate sub-triangle the membership facts above identify *the*
+  orthocenter (`orthocenter_of_BCH_unique`).
+
+  ### Structural consequence: one shared nine-point circle
+  `orthocentric_six_midpoints_concyclic` : the midpoints of all six connectors of
+  `{A, B, C, H}` — the three sides `BC, CA, AB` and the three cevian segments
+  `AH, BH, CH` — lie on a single circle (the common nine-point circle, centre
+  `N`, radius `R/2`).  This repackages the parent's six nine-point theorems as a
+  statement about the orthocentric system.
+
+  ### Worked example
+  For `A = (0,0)`, `B = (4,0)`, `C = (1,2)` the circumcenter is `(2, 1/4)` and the
+  orthocenter is `H = (1, 3/2)`; the four points are genuinely distinct (an
+  *acute* configuration, unlike the degenerate 3-4-5 right triangle where `H`
+  collapses onto the right-angle vertex), and `A` is verified to be the
+  orthocenter of `BCH`.
+
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Proofs.FeuerbachsTheoremDefs
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace FeuerbachsTheoremDefsOQ01OQ01OQ02
+
+open FeuerbachsTheorem
+
+-- ============================================================
+-- Part 0: Perpendicular-bisector relations for the circumcenter
+--
+-- The parent declares these `private`; we reprove the two against vertex A
+-- (linear in O via `field_simp; ring`) and derive the BC relation as their
+-- difference, so this file builds independently.
+-- ============================================================
+
+set_option maxHeartbeats 6400000 in
+private lemma perp_bisector_AB (T : Triangle) :
+    (T.B.1 - T.A.1) * (T.B.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.B.2 - T.A.2) * (T.B.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+set_option maxHeartbeats 6400000 in
+private lemma perp_bisector_AC (T : Triangle) :
+    (T.C.1 - T.A.1) * (T.C.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.C.2 - T.A.2) * (T.C.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+/-- The perpendicular bisector of `BC`: `(C − B) ⊥ (C + B − 2O)`.  Obtained as the
+    difference of the `AC` and `AB` relations (equidistance is transitive). -/
+private lemma perp_bisector_BC (T : Triangle) :
+    (T.C.1 - T.B.1) * (T.C.1 + T.B.1 - 2 * T.circumcenter.1) +
+    (T.C.2 - T.B.2) * (T.C.2 + T.B.2 - 2 * T.circumcenter.2) = 0 := by
+  linear_combination perp_bisector_AC T - perp_bisector_AB T
+
+-- ============================================================
+-- Part 1: The orthocenter in coordinates
+-- ============================================================
+
+/-- The first coordinate of the orthocenter: `H₁ = A₁ + B₁ + C₁ − 2O₁`. -/
+private lemma orthocenter_fst (T : Triangle) :
+    T.orthocenter.1 = T.A.1 + T.B.1 + T.C.1 - 2 * T.circumcenter.1 := rfl
+
+/-- The second coordinate of the orthocenter: `H₂ = A₂ + B₂ + C₂ − 2O₂`. -/
+private lemma orthocenter_snd (T : Triangle) :
+    T.orthocenter.2 = T.A.2 + T.B.2 + T.C.2 - 2 * T.circumcenter.2 := rfl
+
+-- ============================================================
+-- Part 2: The three perpendicularities of the orthocentric system
+--
+-- In an orthocentric system the three pairs of OPPOSITE connectors are
+-- perpendicular:  AH ⊥ BC,  BH ⊥ CA,  CH ⊥ AB.  Each, after substituting
+-- H = A + B + C − 2O, is exactly one perpendicular-bisector relation.
+-- ============================================================
+
+/-- `(A − H) ⊥ (B − C)`: the connector `AH` is perpendicular to side `BC`. -/
+theorem orthocentric_perp_a (T : Triangle) :
+    (T.A.1 - T.orthocenter.1) * (T.B.1 - T.C.1) +
+    (T.A.2 - T.orthocenter.2) * (T.B.2 - T.C.2) = 0 := by
+  rw [orthocenter_fst, orthocenter_snd]
+  linear_combination perp_bisector_BC T
+
+/-- `(B − H) ⊥ (C − A)`: the connector `BH` is perpendicular to side `CA`. -/
+theorem orthocentric_perp_b (T : Triangle) :
+    (T.B.1 - T.orthocenter.1) * (T.C.1 - T.A.1) +
+    (T.B.2 - T.orthocenter.2) * (T.C.2 - T.A.2) = 0 := by
+  rw [orthocenter_fst, orthocenter_snd]
+  linear_combination -(perp_bisector_AC T)
+
+/-- `(C − H) ⊥ (A − B)`: the connector `CH` is perpendicular to side `AB`. -/
+theorem orthocentric_perp_c (T : Triangle) :
+    (T.C.1 - T.orthocenter.1) * (T.A.1 - T.B.1) +
+    (T.C.2 - T.orthocenter.2) * (T.A.2 - T.B.2) = 0 := by
+  rw [orthocenter_fst, orthocenter_snd]
+  linear_combination perp_bisector_AB T
+
+/-- The three perpendicularities bundled: opposite connectors of `{A,B,C,H}` are
+    perpendicular. -/
+theorem orthocentric_perpendicularities (T : Triangle) :
+    ((T.A.1 - T.orthocenter.1) * (T.B.1 - T.C.1) +
+       (T.A.2 - T.orthocenter.2) * (T.B.2 - T.C.2) = 0) ∧
+    ((T.B.1 - T.orthocenter.1) * (T.C.1 - T.A.1) +
+       (T.B.2 - T.orthocenter.2) * (T.C.2 - T.A.2) = 0) ∧
+    ((T.C.1 - T.orthocenter.1) * (T.A.1 - T.B.1) +
+       (T.C.2 - T.orthocenter.2) * (T.A.2 - T.B.2) = 0) :=
+  ⟨orthocentric_perp_a T, orthocentric_perp_b T, orthocentric_perp_c T⟩
+
+-- ============================================================
+-- Part 3: The orthocenter predicate and the four memberships
+-- ============================================================
+
+/-- `P` is *an* orthocenter of triangle `XYZ`: each connector from a vertex to `P`
+    is perpendicular to the opposite side.  Stated coordinatewise; for a
+    non-degenerate triangle `isOrthocenterOf_unique` shows `P` is unique. -/
+def IsOrthocenterOf (P X Y Z : Point) : Prop :=
+    ((P.1 - X.1) * (Y.1 - Z.1) + (P.2 - X.2) * (Y.2 - Z.2) = 0) ∧
+    ((P.1 - Y.1) * (Z.1 - X.1) + (P.2 - Y.2) * (Z.2 - X.2) = 0) ∧
+    ((P.1 - Z.1) * (X.1 - Y.1) + (P.2 - Z.2) * (X.2 - Y.2) = 0)
+
+/-- Consistency: the parent's `Triangle.orthocenter` is an orthocenter of `ABC`
+    in the perpendicularity sense — `H` lies on all three altitudes. -/
+theorem orthocenter_of_ABC (T : Triangle) :
+    IsOrthocenterOf T.orthocenter T.A T.B T.C := by
+  refine ⟨?_, ?_, ?_⟩
+  · linear_combination -(orthocentric_perp_a T)
+  · linear_combination -(orthocentric_perp_b T)
+  · linear_combination -(orthocentric_perp_c T)
+
+/-- `A` is the orthocenter of triangle `BCH`. -/
+theorem orthocenter_of_BCH (T : Triangle) :
+    IsOrthocenterOf T.A T.B T.C T.orthocenter := by
+  refine ⟨?_, ?_, ?_⟩
+  · linear_combination orthocentric_perp_c T
+  · linear_combination orthocentric_perp_b T
+  · linear_combination orthocentric_perp_a T
+
+/-- `B` is the orthocenter of triangle `CAH`. -/
+theorem orthocenter_of_CAH (T : Triangle) :
+    IsOrthocenterOf T.B T.C T.A T.orthocenter := by
+  refine ⟨?_, ?_, ?_⟩
+  · linear_combination orthocentric_perp_a T
+  · linear_combination orthocentric_perp_c T
+  · linear_combination orthocentric_perp_b T
+
+/-- `C` is the orthocenter of triangle `ABH`. -/
+theorem orthocenter_of_ABH (T : Triangle) :
+    IsOrthocenterOf T.C T.A T.B T.orthocenter := by
+  refine ⟨?_, ?_, ?_⟩
+  · linear_combination orthocentric_perp_b T
+  · linear_combination orthocentric_perp_a T
+  · linear_combination orthocentric_perp_c T
+
+/-- **The orthocentric system.**  Each of the four points `A, B, C, H` is the
+    orthocenter of the triangle formed by the other three. -/
+theorem orthocentric_system (T : Triangle) :
+    IsOrthocenterOf T.orthocenter T.A T.B T.C ∧
+    IsOrthocenterOf T.A T.B T.C T.orthocenter ∧
+    IsOrthocenterOf T.B T.C T.A T.orthocenter ∧
+    IsOrthocenterOf T.C T.A T.B T.orthocenter :=
+  ⟨orthocenter_of_ABC T, orthocenter_of_BCH T, orthocenter_of_CAH T,
+   orthocenter_of_ABH T⟩
+
+-- ============================================================
+-- Part 4: Uniqueness — pinning down "THE" orthocenter
+-- ============================================================
+
+/-- For a non-degenerate triangle `XYZ` the perpendicularity characterization
+    determines the orthocenter uniquely.  The two altitude conditions form a
+    `2×2` linear system in `P − P'` whose determinant is precisely the triangle's
+    non-degeneracy determinant, so `P = P'`. -/
+theorem isOrthocenterOf_unique (X Y Z P P' : Point)
+    (hdet : (Y.1 - X.1) * (Z.2 - X.2) - (Z.1 - X.1) * (Y.2 - X.2) ≠ 0)
+    (hP : IsOrthocenterOf P X Y Z) (hP' : IsOrthocenterOf P' X Y Z) :
+    P = P' := by
+  obtain ⟨hP1, hP2, _⟩ := hP
+  obtain ⟨hP1', hP2', _⟩ := hP'
+  -- Differences of the two altitude conditions: two linear equations in P − P'.
+  have e1 : (P.1 - P'.1) * (Y.1 - Z.1) + (P.2 - P'.2) * (Y.2 - Z.2) = 0 := by
+    linear_combination hP1 - hP1'
+  have e2 : (P.1 - P'.1) * (Z.1 - X.1) + (P.2 - P'.2) * (Z.2 - X.2) = 0 := by
+    linear_combination hP2 - hP2'
+  -- Cramer: (P.1 − P'.1)·det = 0 and (P.2 − P'.2)·det = 0.
+  have hx : (P.1 - P'.1) *
+      ((Y.1 - X.1) * (Z.2 - X.2) - (Z.1 - X.1) * (Y.2 - X.2)) = 0 := by
+    linear_combination (Z.2 - X.2) * e1 - (Y.2 - Z.2) * e2
+  have hy : (P.2 - P'.2) *
+      ((Y.1 - X.1) * (Z.2 - X.2) - (Z.1 - X.1) * (Y.2 - X.2)) = 0 := by
+    linear_combination (Y.1 - Z.1) * e2 - (Z.1 - X.1) * e1
+  have hx0 : P.1 - P'.1 = 0 := by
+    rcases mul_eq_zero.mp hx with h | h
+    · exact h
+    · exact absurd h hdet
+  have hy0 : P.2 - P'.2 = 0 := by
+    rcases mul_eq_zero.mp hy with h | h
+    · exact h
+    · exact absurd h hdet
+  have h1 : P.1 = P'.1 := by linarith
+  have h2 : P.2 = P'.2 := by linarith
+  calc P = (P.1, P.2) := rfl
+    _ = (P'.1, P'.2) := by rw [h1, h2]
+    _ = P' := rfl
+
+/-- On a non-degenerate sub-triangle `BCH`, `A` is *the* orthocenter: any point
+    satisfying the perpendicularity characterization coincides with `A`. -/
+theorem orthocenter_of_BCH_unique (T : Triangle) (P : Point)
+    (hdet : (T.C.1 - T.B.1) * (T.orthocenter.2 - T.B.2) -
+            (T.orthocenter.1 - T.B.1) * (T.C.2 - T.B.2) ≠ 0)
+    (hP : IsOrthocenterOf P T.B T.C T.orthocenter) :
+    P = T.A :=
+  isOrthocenterOf_unique T.B T.C T.orthocenter P T.A hdet hP (orthocenter_of_BCH T)
+
+-- ============================================================
+-- Part 5: Structural consequence — one shared nine-point circle
+-- ============================================================
+
+/-- **One shared nine-point circle.**  The midpoints of all six connectors of the
+    orthocentric system `{A, B, C, H}` — the three sides `BC, CA, AB` and the
+    three cevian segments `AH, BH, CH` — lie on a single circle, the common
+    nine-point circle (centre `N`, radius `R/2`).  Repackages the parent's six
+    nine-point membership theorems. -/
+theorem orthocentric_six_midpoints_concyclic (T : Triangle) :
+    dist2 T.ninePointCenter T.midpoint_a = T.ninePointRadius ∧
+    dist2 T.ninePointCenter T.midpoint_b = T.ninePointRadius ∧
+    dist2 T.ninePointCenter T.midpoint_c = T.ninePointRadius ∧
+    dist2 T.ninePointCenter T.midpoint_AH = T.ninePointRadius ∧
+    dist2 T.ninePointCenter T.midpoint_BH = T.ninePointRadius ∧
+    dist2 T.ninePointCenter T.midpoint_CH = T.ninePointRadius :=
+  ⟨midpoint_a_on_ninePointCircle T, midpoint_b_on_ninePointCircle T,
+   midpoint_c_on_ninePointCircle T, midpoint_AH_on_ninePointCircle T,
+   midpoint_BH_on_ninePointCircle T, midpoint_CH_on_ninePointCircle T⟩
+
+-- ============================================================
+-- Part 6: Worked example — a genuine (acute) orthocentric system
+-- ============================================================
+
+/-- An acute triangle `A=(0,0)`, `B=(4,0)`, `C=(1,2)` with four distinct points
+    `A, B, C, H` (the 3-4-5 right triangle is degenerate as `H` collapses onto
+    the right-angle vertex). -/
+def exampleTriangle : Triangle where
+  A := (0, 0)
+  B := (4, 0)
+  C := (1, 2)
+  nondegenerate := by norm_num
+
+theorem exampleTriangle_circumcenter :
+    exampleTriangle.circumcenter = (2, 1/4) := by
+  unfold Triangle.circumcenter exampleTriangle
+  norm_num
+
+theorem exampleTriangle_orthocenter :
+    exampleTriangle.orthocenter = (1, 3/2) := by
+  unfold Triangle.orthocenter
+  rw [exampleTriangle_circumcenter]
+  norm_num [exampleTriangle]
+
+/-- The four points of the example are pairwise distinct: a genuine, non-collapsed
+    orthocentric system. -/
+theorem exampleTriangle_four_distinct :
+    exampleTriangle.A ≠ exampleTriangle.B ∧
+    exampleTriangle.A ≠ exampleTriangle.C ∧
+    exampleTriangle.B ≠ exampleTriangle.C ∧
+    exampleTriangle.orthocenter ≠ exampleTriangle.A ∧
+    exampleTriangle.orthocenter ≠ exampleTriangle.B ∧
+    exampleTriangle.orthocenter ≠ exampleTriangle.C := by
+  rw [exampleTriangle_orthocenter]
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    simp only [exampleTriangle, ne_eq, Prod.mk.injEq, not_and] <;> norm_num
+
+/-- In the example, `A = (0,0)` is the orthocenter of triangle `B C H`. -/
+theorem exampleTriangle_A_orthocenter_of_BCH :
+    IsOrthocenterOf exampleTriangle.A exampleTriangle.B exampleTriangle.C
+      exampleTriangle.orthocenter :=
+  orthocenter_of_BCH exampleTriangle
+
+end FeuerbachsTheoremDefsOQ01OQ01OQ02

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "feuerbachs-theorem-defs-oq-01-oq-01-oq-02",
+  "title": "Feuerbach's Theorem: The Orthocentric System",
+  "slug": "feuerbachs-theorem-defs-oq-01-oq-01-oq-02",
+  "description": "Answers the symmetry open question of the altitude-concurrency entry: the four-point set {A, B, C, H} is an orthocentric system — each of the four points is the orthocenter of the triangle formed by the other three. Establishes the three opposite-connector perpendicularities, the four orthocenter memberships, a Cramer uniqueness theorem identifying THE orthocenter on a non-degenerate sub-triangle, and the structural consequence that all six connector midpoints share one nine-point circle. 16 theorems, 2 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ02.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
+    "tags": [
+      "geometry",
+      "feuerbach",
+      "orthocenter",
+      "orthocentric-system",
+      "circumcenter",
+      "perpendicularity",
+      "nine-point-circle",
+      "cramer",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only propext / Classical.choice / Quot.sound, confirmed by #print axioms). Inherits the coordinate API (circumcenter/orthocenter formulas, non-degeneracy lemmas, nine-point circle theorems) from FeuerbachsTheoremDefs.lean, which is itself 0-sorry, 0-axiom.",
+    "lineCount": 344,
+    "theoremCount": 16,
+    "definitionCount": 2,
+    "originalContributions": [
+      "orthocentric_system: the headline result — each of the four points A, B, C, H is the orthocenter of the triangle formed by the other three, bundling the four memberships into the symmetry statement that the concurrency/metric strand never established",
+      "orthocentric_perp_a / orthocentric_perp_b / orthocentric_perp_c: the three perpendicularities of the configuration (AH ⊥ BC, BH ⊥ CA, CH ⊥ AB) — each is a single perpendicular-bisector relation after substituting H = A + B + C − 2O, so each closes by one linear_combination",
+      "orthocenter_of_BCH / orthocenter_of_CAH / orthocenter_of_ABH: A is the orthocenter of BCH, B of CAH, C of ABH — the three non-trivial memberships, each three perpendicularity conjuncts reusing the three core lemmas with reordering",
+      "orthocenter_of_ABC: consistency check that the parent's coordinate Triangle.orthocenter is an orthocenter of ABC in the perpendicularity sense (H lies on all three altitudes)",
+      "IsOrthocenterOf: a coordinate-level predicate characterizing an orthocenter of a triangle by its three altitude-perpendicularity conditions, independent of the circumcenter formula",
+      "isOrthocenterOf_unique: a 2×2 Cramer uniqueness theorem — the perpendicularity characterization pins the orthocenter down uniquely on a non-degenerate triangle, the determinant of the altitude system being exactly the triangle's non-degeneracy determinant",
+      "orthocenter_of_BCH_unique: combining membership and uniqueness, A is THE orthocenter of BCH whenever the sub-triangle is non-degenerate",
+      "orthocentric_six_midpoints_concyclic: the structural consequence — the midpoints of all six connectors of {A, B, C, H} (the three sides BC, CA, AB and the three cevian segments AH, BH, CH) lie on one circle, the common nine-point circle of centre N and radius R/2, repackaging the parent's six nine-point theorems",
+      "perp_bisector_BC: the BC perpendicular-bisector relation obtained as the difference of the AB and AC relations (equidistance is transitive), avoiding a third field_simp computation",
+      "exampleTriangle (A=(0,0), B=(4,0), C=(1,2)): an acute worked example with circumcenter (2, 1/4) and orthocenter (1, 3/2) where the four points are genuinely distinct, unlike the degenerate 3-4-5 right triangle in which H collapses onto the right-angle vertex"
+    ]
+  },
+  "overview": {
+    "historicalContext": "If H is the orthocenter of triangle ABC, then {A, B, C, H} forms an orthocentric system: each of the four points is the orthocenter of the triangle formed by the other three, and the configuration is completely symmetric in its four points. The four triangles share one nine-point circle and one common nine-point centre. The gallery's FeuerbachsTheoremDefs.lean works with the coordinate orthocenter H = A + B + C − 2O, the sibling concurrency entry verified that this point lies on all three altitudes, and the reflections entry noted that putting H on the circumcircle is a hallmark of the orthocentric configuration the nine-point-circle development never establishes. This entry establishes that configuration outright.",
+    "problemStatement": "With O the circumcenter and H = A + B + C − 2O the orthocenter of a non-degenerate triangle ABC, prove that {A, B, C, H} is an orthocentric system:\n1. **Perpendicularities**: the three pairs of opposite connectors are perpendicular — AH ⊥ BC, BH ⊥ CA, CH ⊥ AB.\n2. **Symmetry**: A is the orthocenter of triangle BCH, B of CAH, C of ABH, and (for consistency) H of ABC, under the altitude-perpendicularity characterization of the orthocenter.\n3. **Uniqueness**: on a non-degenerate triangle the perpendicularity characterization determines the orthocenter uniquely, so the memberships identify THE orthocenter.\n4. **Shared circle**: the midpoints of all six connectors of the system lie on a single nine-point circle.",
+    "text": "A 344-line companion file with 16 theorems and 2 definitions (5 private supporting lemmas). It reproves the two vertex-A perpendicular-bisector relations and derives the BC relation as their difference, extracts the three opposite-connector perpendicularities of the configuration, defines the coordinate predicate IsOrthocenterOf, proves the four orthocenter memberships and bundles them into the orthocentric_system capstone, supplies a Cramer uniqueness theorem (and its application to BCH), repackages the parent's six nine-point membership facts as one shared circle for the system, and closes with an acute worked example whose four points are genuinely distinct.",
+    "proofStrategy": "Everything reduces to the three perpendicular-bisector relations, which are LINEAR in the circumcenter O. The opposite-connector perpendicularity AH ⊥ BC, written (A − H) · (B − C) = 0, becomes — after substituting H = A + B + C − 2O — exactly the perpendicular bisector of BC, so it is one linear_combination; the BH and CH cases use the CA and AB bisectors. These three facts (orthocentric_perp_a/b/c) are the whole geometric content: each of the four orthocenter memberships is just the same three perpendicularities reorganized for a different base triangle, so each membership conjunct is discharged by a single linear_combination over a core lemma (sign and ordering only, since the dot product is symmetric).\n\nUniqueness is a 2×2 Cramer argument. From two altitude conditions for P and the same two for P', subtracting gives two linear equations in the displacement P − P'; eliminating each coordinate yields (P.i − P'.i) · det = 0 where det is exactly the triangle's non-degeneracy determinant (verified to equal the altitude-system determinant by ring), so det ≠ 0 forces P = P'.\n\nThe shared-circle corollary is pure assembly: the six connectors of {A, B, C, H} are the three sides (midpoints M_a, M_b, M_c) and the three cevian segments AH, BH, CH (midpoints already named in the parent), and the parent already proved all six lie on the nine-point circle.\n\nThe worked example computes the circumcenter (2, 1/4) and orthocenter (1, 3/2) by norm_num, checks the four points are pairwise distinct, and instantiates orthocenter_of_BCH to exhibit A as the orthocenter of the concrete triangle on B, C, H.",
+    "keyInsights": [
+      "The orthocentric system is, at bottom, just the three perpendicular-bisector relations seen from four viewpoints: AH ⊥ BC after H = A + B + C − 2O IS the perpendicular bisector of BC, so the deep-looking symmetry collapses to one linear_combination per perpendicularity.",
+      "Because the dot product is symmetric and the four base triangles reuse the same three opposite-connector perpendicularities, all twelve altitude conditions across the four memberships are discharged by the same three core lemmas with only sign and argument-order changes.",
+      "The determinant of the 2×2 altitude system that locates the orthocenter is, after ring normalization, identical to the triangle's non-degeneracy determinant — so uniqueness needs no separate non-degeneracy hypothesis beyond the one already carried by the Triangle structure.",
+      "The orthocentric system makes the six nine-point points fall into two symmetric triples: side midpoints and cevian-segment midpoints are interchangeable roles, and all six are the connector midpoints of the four-point system, sharing one circle.",
+      "The 3-4-5 right triangle is a poor witness for the orthocentric system because its orthocenter collapses onto the right-angle vertex; the acute triangle (0,0),(4,0),(1,2) keeps all four points distinct and exhibits a genuine, non-degenerate configuration."
+    ],
+    "prerequisites": [
+      "FeuerbachsTheoremDefs.lean — coordinate API (Point, Triangle, circumcenter, orthocenter, dist2, ninePointCenter, ninePointRadius, the side- and cevian-midpoints) plus circumcenter_denom_ne_zero and the six nine-point membership theorems",
+      "feuerbachs-theorem-defs-oq-01-oq-01 — the altitude-concurrency entry establishing H = A + B + C − 2O as the orthocenter, whose symmetry open question this answers",
+      "feuerbachs-theorem-defs-oq-01-oq-01-oq-01 — the reflections entry that first named the orthocentric configuration as the missing hallmark",
+      "The altitude-perpendicularity characterization of the orthocenter; Cramer's rule for a 2×2 linear system; the Euler relation H = A + B + C − 2O"
+    ]
+  },
+  "sections": [
+    {
+      "id": "perp-bisectors",
+      "title": "Perpendicular-bisector relations",
+      "startLine": 76,
+      "endLine": 122,
+      "summary": "Reproves the AB and AC perpendicular-bisector relations of the circumcenter (linear in O via field_simp; ring) and derives the BC relation as their difference, so the file builds from the grandparent alone.",
+      "mathContext": "The circumcenter O satisfies (B − A) · (B + A − 2O) = 0 and (C − A) · (C + A − 2O) = 0; the BC relation is their difference since equidistance is transitive."
+    },
+    {
+      "id": "orthocenter-coords",
+      "title": "Orthocenter in coordinates",
+      "startLine": 124,
+      "endLine": 136,
+      "summary": "Records H₁ = A₁ + B₁ + C₁ − 2O₁ and H₂ = A₂ + B₂ + C₂ − 2O₂ by rfl, the coordinate form of the parent's Triangle.orthocenter.",
+      "mathContext": "The Euler relation H = A + B + C − 2O written componentwise, ready for substitution into the perpendicularity goals."
+    },
+    {
+      "id": "perpendicularities",
+      "title": "The three perpendicularities",
+      "startLine": 138,
+      "endLine": 181,
+      "summary": "Proves AH ⊥ BC, BH ⊥ CA, CH ⊥ AB — each one linear_combination over a perpendicular-bisector relation after substituting the orthocenter — and bundles them.",
+      "mathContext": "In an orthocentric system the three pairs of opposite connectors are perpendicular; these three facts carry all the geometric content of the configuration."
+    },
+    {
+      "id": "memberships",
+      "title": "The orthocenter predicate and four memberships",
+      "startLine": 182,
+      "endLine": 231,
+      "summary": "Defines IsOrthocenterOf by the three altitude-perpendicularity conditions and proves H is the orthocenter of ABC, A of BCH, B of CAH, C of ABH, with the orthocentric_system capstone.",
+      "mathContext": "Each membership is the same three perpendicularities reorganized for a different base triangle, so each conjunct reduces to a core lemma by sign/order."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Cramer uniqueness",
+      "startLine": 232,
+      "endLine": 286,
+      "summary": "Shows the perpendicularity characterization determines the orthocenter uniquely on a non-degenerate triangle (2×2 Cramer; the altitude-system determinant equals the non-degeneracy determinant), and applies it to identify A as THE orthocenter of BCH.",
+      "mathContext": "Two altitude conditions form a linear system in the displacement P − P' whose determinant is the triangle's non-degeneracy determinant, forcing P = P'."
+    },
+    {
+      "id": "shared-circle",
+      "title": "One shared nine-point circle",
+      "startLine": 287,
+      "endLine": 305,
+      "summary": "Repackages the parent's six nine-point membership theorems: the midpoints of all six connectors of {A, B, C, H} lie on a single circle of centre N and radius R/2.",
+      "mathContext": "The six connectors are the three sides and the three cevian segments; their midpoints are the nine-point points the parent already placed on the circle."
+    },
+    {
+      "id": "example",
+      "title": "Worked example (acute triangle)",
+      "startLine": 306,
+      "endLine": 344,
+      "summary": "Computes circumcenter (2, 1/4) and orthocenter (1, 3/2) for A=(0,0), B=(4,0), C=(1,2), verifies the four points are pairwise distinct, and exhibits A as the orthocenter of triangle BCH.",
+      "mathContext": "An acute configuration keeps all four points distinct, unlike the degenerate 3-4-5 right triangle where H coincides with the right-angle vertex."
+    }
+  ],
+  "conclusion": {
+    "summary": "Establishes the orthocentric system that the concurrency, metric, and reflection strands of the orthocenter sub-line left implicit: the four-point set {A, B, C, H} is symmetric, each point being the orthocenter of the triangle on the other three. The deep-looking symmetry reduces entirely to the three perpendicular-bisector relations of the circumcenter — one linear_combination per perpendicularity — and a 2×2 Cramer argument upgrades the memberships to a uniqueness statement identifying THE orthocenter. As a structural consequence the six connector midpoints of the system share one nine-point circle, and an acute worked example exhibits a genuine, non-collapsed configuration.",
+    "significance": "Completes the conceptual picture of the orthocenter begun by the concurrency entry: beyond existing and being measured, the orthocenter is the fourth point of a symmetric four-point system, which is the natural home of the nine-point circle and the reflection facts proved earlier in the strand.",
+    "futureDirections": [
+      "Identify the common nine-point centre N as the circumcenter of the medial-type configuration shared by all four triangles of the system, and prove the four circumcircles are congruent (all radius R).",
+      "Show the de Longchamps point (reflection of H over O) is the orthocenter of the anticomplementary triangle, extending the system outward.",
+      "Formalize that the four triangles of an orthocentric system have a common nine-point circle as an equality of circles, not just a shared six-point incidence."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "answers the symmetry open question of the altitude-concurrency entry: each of A, B, C, H is the orthocenter of the triangle on the other three"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "the reflections entry that first named the orthocentric configuration as the hallmark missing from the nine-point-circle development"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs",
+      "relationship": "extends",
+      "description": "uses the grandparent's coordinate orthocenter, circumcenter and nine-point circle theorems to state and prove the orthocentric system"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Proofs.FeuerbachsTheoremDefs"],
+    "opens": ["FeuerbachsTheorem"],
+    "namespace": "FeuerbachsTheoremDefsOQ01OQ01OQ02",
+    "lineCount": 344,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 2,
+    "path": "Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ02.lean",
+    "sorries": 0,
+    "additionalFiles": ["Proofs/FeuerbachsTheoremDefs.lean"]
+  },
+  "mainTheorems": [
+    {
+      "name": "orthocentric_system",
+      "type": "core",
+      "description": "The four-point set {A, B, C, H} is an orthocentric system: each of the four points is the orthocenter of the triangle formed by the other three.",
+      "leanType": "∀ T : Triangle, IsOrthocenterOf H A B C ∧ IsOrthocenterOf A B C H ∧ IsOrthocenterOf B C A H ∧ IsOrthocenterOf C A B H"
+    },
+    {
+      "name": "orthocentric_perpendicularities",
+      "type": "core",
+      "description": "The three opposite-connector perpendicularities of the configuration: AH ⊥ BC, BH ⊥ CA, CH ⊥ AB.",
+      "leanType": "∀ T : Triangle, ((A − H) · (B − C) = 0) ∧ ((B − H) · (C − A) = 0) ∧ ((C − H) · (A − B) = 0)"
+    },
+    {
+      "name": "isOrthocenterOf_unique",
+      "type": "core",
+      "description": "On a non-degenerate triangle the altitude-perpendicularity characterization determines the orthocenter uniquely (2×2 Cramer; the system determinant is the non-degeneracy determinant).",
+      "leanType": "∀ (X Y Z P P' : Point), det(XYZ) ≠ 0 → IsOrthocenterOf P X Y Z → IsOrthocenterOf P' X Y Z → P = P'"
+    },
+    {
+      "name": "orthocentric_six_midpoints_concyclic",
+      "type": "corollary",
+      "description": "The midpoints of all six connectors of {A, B, C, H} — three sides and three cevian segments — lie on one nine-point circle of centre N and radius R/2.",
+      "leanType": "∀ T : Triangle, dist(N, M_a) = R/2 ∧ … ∧ dist(N, M_CH) = R/2"
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers the **symmetry open question** of the altitude-concurrency strand of Feuerbach's theorem: the four-point set `{A, B, C, H}` is an **orthocentric system** — each of the four points is the orthocenter of the triangle formed by the other three. This is the structural fact the concurrency, metric (`OH²`, `AH²`, `AH = 2·OM_a`), and reflection entries all left implicit.

**Key realization:** the deep-looking four-fold symmetry collapses to the three perpendicular-bisector relations of the circumcenter. After substituting `H = A + B + C − 2O`, each opposite-connector perpendicularity (`AH ⊥ BC`, `BH ⊥ CA`, `CH ⊥ AB`) is *exactly one* perpendicular-bisector relation, so it closes by a single `linear_combination`. Each of the four orthocenter memberships is then the same three perpendicularities reorganized for a different base triangle.

## What it proves (16 theorems, 2 definitions)

- `orthocentric_perp_a/b/c` — the three opposite-connector perpendicularities
- `IsOrthocenterOf` — a circumcenter-free altitude-perpendicularity predicate
- `orthocenter_of_ABC / BCH / CAH / ABH` — the four memberships, bundled as `orthocentric_system`
- `isOrthocenterOf_unique` — a 2×2 **Cramer uniqueness** theorem whose system determinant equals the triangle's non-degeneracy determinant, upgrading membership to "**THE** orthocenter" (`orthocenter_of_BCH_unique`)
- `orthocentric_six_midpoints_concyclic` — all six connector midpoints of the system share one **nine-point circle** (centre `N`, radius `R/2`)
- worked example `A=(0,0), B=(4,0), C=(1,2)` — an *acute* configuration with four genuinely distinct points (the 3-4-5 right triangle is degenerate: `H` collapses onto the right-angle vertex)

## Verification

- Builds clean via `./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ02` (3093 jobs).
- **0 sorries, 0 axioms** — `#print axioms` on the headline results lists only `propext / Classical.choice / Quot.sound`.
- Self-contained: imports the grandparent `FeuerbachsTheoremDefs` only; reproves the two vertex-A perpendicular-bisector lemmas locally (the parent declares them `private`) and derives the BC relation as their difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)