### PR TITLE
research(erdos-816-oq-01): why K_{n,n+1} is the extremal counterexample + degree pigeonhole [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2193,6 +2193,7 @@ import Proofs.Erdos813Problem
 import Proofs.Erdos814Problem
 import Proofs.Erdos815Problem
 import Proofs.Erdos816Problem
+import Proofs.Erdos816OQ01
 import Proofs.Erdos817Aristotle
 import Proofs.Erdos817Problem
 import Proofs.Erdos818Aristotle

--- a/proofs/Proofs/Erdos816OQ01.lean
+++ b/proofs/Proofs/Erdos816OQ01.lean
@@ -1,0 +1,161 @@
+/-
+Erdős Problem #816 — structural facts the parent left unproven (OQ-01)
+
+Parent entry `erdos-816` ("Equal-Degree Vertices and Paths of Length 3") states the
+Chen–Ma theorem as an axiom and leaves two supporting structural facts as prose:
+
+* **Part V** — *why* the complete bipartite graph `K_{n,n+1}` is the extremal
+  counterexample at the `n² + n` edge threshold (it has no equal-degree pair joined
+  by a path of length 3), and
+* **Part VII** — the degree *pigeonhole* guaranteeing equal-degree pairs exist at all.
+
+This file proves both, axiom-free, on top of the parent's own definitions.
+
+The counterexample mechanism is a clean parity argument: in a bipartite graph a path
+of length 3 (an odd path) joins vertices in *opposite* parts, so if the two parts have
+distinct degrees, an equal-degree pair must lie in the same part and therefore cannot
+be joined by such a path.  This is exactly why `K_{n,n+1}` — bipartite with part
+degrees `n+1` and `n` — escapes the property, pinning the threshold.
+
+Main results:
+* `hasPath3_opposite_color` — a length-3 path in a bipartite graph joins opposite parts.
+* `no_equalDegreePath3_of_bipartition` / `_of_distinctDegrees` — bipartite graphs whose
+  parts have distinct degrees have **no** equal-degree path-3 pair (the counterexample).
+* `exists_sameDegree_pair` — the degree pigeonhole: any graph on `≥ 2` vertices has two
+  distinct vertices of equal degree (so equal-degree pairs always exist).
+-/
+
+import Mathlib
+
+namespace Erdos816OQ01
+
+open SimpleGraph
+
+variable {V : Type*}
+
+/-!
+## Parent definitions (inlined)
+
+The parent file `Erdos816Problem.lean` does not compile under Lean/Mathlib v4.26.0
+(orphan docstrings and a `satisfiesEH816` instance mismatch), so we reproduce the
+handful of definitions we need here, keeping this file self-contained and axiom-free.
+-/
+
+/-- A path of length 3: four distinct vertices `u - a - b - v` with consecutive
+adjacencies. -/
+def hasPath3 (G : SimpleGraph V) (u v : V) : Prop :=
+  ∃ a b : V, u ≠ a ∧ a ≠ b ∧ b ≠ v ∧
+    u ≠ b ∧ a ≠ v ∧ u ≠ v ∧
+    G.Adj u a ∧ G.Adj a b ∧ G.Adj b v
+
+/-- Two vertices have the same degree. -/
+def sameDegree (G : SimpleGraph V) [Fintype V] [DecidableRel G.Adj] (u v : V) : Prop :=
+  G.degree u = G.degree v
+
+/-- `G` has an equal-degree pair joined by a path of length 3. -/
+def hasEqualDegreePath3Pair (G : SimpleGraph V) [Fintype V] [DecidableRel G.Adj] : Prop :=
+  ∃ u v : V, u ≠ v ∧ sameDegree G u v ∧ hasPath3 G u v
+
+/-- A proper 2-coloring (bipartition) of `G`: adjacent vertices receive opposite colors. -/
+def IsBipartition (G : SimpleGraph V) (c : V → Bool) : Prop :=
+  ∀ ⦃x y⦄, G.Adj x y → c x ≠ c y
+
+/-- **Parity of length-3 paths.** In a bipartite graph, a path of length 3 joins two
+vertices of *opposite* colour: the three edges flip the Boolean colour three times. -/
+theorem hasPath3_opposite_color {G : SimpleGraph V} {c : V → Bool}
+    (hc : IsBipartition G c) {u v : V} (h : hasPath3 G u v) : c u ≠ c v := by
+  obtain ⟨a, b, _, _, _, _, _, _, hua, hab, hbv⟩ := h
+  have h1 := hc hua
+  have h2 := hc hab
+  have h3 := hc hbv
+  revert h1 h2 h3
+  cases c u <;> cases c a <;> cases c b <;> cases c v <;> simp
+
+/-- **The counterexample mechanism (general form).** If `G` is bipartite via `c` and
+every equal-degree pair shares a colour, then `G` has no equal-degree pair joined by a
+path of length 3. -/
+theorem no_equalDegreePath3_of_bipartition {G : SimpleGraph V} [Fintype V]
+    [DecidableRel G.Adj] {c : V → Bool}
+    (hc : IsBipartition G c) (hdeg : ∀ u v, sameDegree G u v → c u = c v) :
+    ¬ hasEqualDegreePath3Pair G := by
+  rintro ⟨u, v, _, hsame, hpath⟩
+  exact hasPath3_opposite_color hc hpath (hdeg u v hsame)
+
+/-- **The counterexample mechanism (vertices of different colour have unequal degree).**
+If `G` is bipartite via `c` and any two vertices of opposite colour have different
+degrees, then `G` has no equal-degree pair joined by a path of length 3. -/
+theorem no_equalDegreePath3_of_distinctDegrees {G : SimpleGraph V} [Fintype V]
+    [DecidableRel G.Adj] {c : V → Bool} (hc : IsBipartition G c)
+    (hdist : ∀ u v, c u ≠ c v → G.degree u ≠ G.degree v) :
+    ¬ hasEqualDegreePath3Pair G := by
+  refine no_equalDegreePath3_of_bipartition hc (fun u v hsame => ?_)
+  unfold sameDegree at hsame
+  exact not_not.mp (fun h => hdist u v h hsame)
+
+/-- **The counterexample mechanism (distinct part degrees).** If `G` is bipartite via
+`c`, every colour-`false` vertex has degree `d₀`, every colour-`true` vertex has degree
+`d₁`, and `d₀ ≠ d₁`, then `G` has no equal-degree pair joined by a path of length 3.
+This is precisely the situation of `K_{n,n+1}` (part degrees `n+1 ≠ n`). -/
+theorem no_equalDegreePath3_of_partDegrees {G : SimpleGraph V} [Fintype V]
+    [DecidableRel G.Adj] {c : V → Bool}
+    (hc : IsBipartition G c) {d₀ d₁ : ℕ} (hne : d₀ ≠ d₁)
+    (h0 : ∀ v, c v = false → G.degree v = d₀)
+    (h1 : ∀ v, c v = true → G.degree v = d₁) :
+    ¬ hasEqualDegreePath3Pair G := by
+  refine no_equalDegreePath3_of_distinctDegrees hc (fun u v hcuv => ?_)
+  rcases Bool.dichotomy (c u) with hu | hu <;> rcases Bool.dichotomy (c v) with hv | hv
+  · exact absurd (hu.trans hv.symm) hcuv
+  · rw [h0 u hu, h1 v hv]; exact hne
+  · rw [h1 u hu, h0 v hv]; exact fun h => hne h.symm
+  · exact absurd (hu.trans hv.symm) hcuv
+
+/-- **Degree pigeonhole (Part VII).** Any finite simple graph on at least two vertices
+has two distinct vertices of equal degree.  (If all degrees were distinct they would
+realize every value `0, …, card-1`, forcing a vertex adjacent to all others to coexist
+with an isolated vertex — a contradiction.) -/
+theorem exists_sameDegree_pair (G : SimpleGraph V) [Fintype V] [DecidableEq V]
+    [DecidableRel G.Adj] (hcard : 2 ≤ Fintype.card V) :
+    ∃ u v : V, u ≠ v ∧ G.degree u = G.degree v := by
+  by_contra hcon
+  push_neg at hcon
+  -- `hcon : ∀ u v, u ≠ v → degree G u ≠ degree G v`, i.e. the degree map is injective.
+  have hinj : Function.Injective (fun v => G.degree v) := by
+    intro x y hxy
+    by_contra hne
+    exact hcon x y hne hxy
+  -- Package degrees into `Fin (card V)`; injective + equal cardinality ⇒ surjective.
+  let f : V → Fin (Fintype.card V) := fun v => ⟨G.degree v, G.degree_lt_card_verts v⟩
+  have hfinj : Function.Injective f := by
+    intro x y hxy
+    exact hinj (by simpa [f, Fin.ext_iff] using hxy)
+  have hsurj : Function.Surjective f :=
+    (Fintype.bijective_iff_injective_and_card f).mpr ⟨hfinj, by simp⟩ |>.2
+  -- A vertex of full degree `card-1` and an isolated vertex of degree `0` must coexist.
+  obtain ⟨w, hw⟩ := hsurj ⟨Fintype.card V - 1, by omega⟩
+  obtain ⟨u, hu⟩ := hsurj ⟨0, by omega⟩
+  have hdw : G.degree w = Fintype.card V - 1 := by simpa [f] using congrArg Fin.val hw
+  have hdu : G.degree u = 0 := by simpa [f] using congrArg Fin.val hu
+  have huw : u ≠ w := by
+    intro h; rw [h, hdw] at hdu; omega
+  -- `w` is adjacent to every other vertex, so to `u`.
+  have hsub : G.neighborFinset w ⊆ Finset.univ.erase w := by
+    intro x hx
+    rw [Finset.mem_erase]
+    refine ⟨fun hxw => ?_, Finset.mem_univ x⟩
+    rw [hxw] at hx
+    exact (G.notMem_neighborFinset_self w) hx
+  have hcardw : (G.neighborFinset w).card = (Finset.univ.erase w).card := by
+    rw [Finset.card_erase_of_mem (Finset.mem_univ w), Finset.card_univ]
+    exact hdw
+  have heq : G.neighborFinset w = Finset.univ.erase w :=
+    Finset.eq_of_subset_of_card_le hsub (le_of_eq hcardw.symm)
+  have hadj : G.Adj w u := by
+    rw [← SimpleGraph.mem_neighborFinset, heq, Finset.mem_erase]
+    exact ⟨huw, Finset.mem_univ u⟩
+  -- But `u` is isolated: its neighbour finset is empty.
+  have hempty : G.neighborFinset u = ∅ := Finset.card_eq_zero.mp hdu
+  have hwmem : w ∈ G.neighborFinset u := (G.mem_neighborFinset u w).mpr hadj.symm
+  rw [hempty] at hwmem
+  exact (Finset.notMem_empty w) hwmem
+
+end Erdos816OQ01

--- a/src/data/proofs/erdos-816-oq-01/meta.json
+++ b/src/data/proofs/erdos-816-oq-01/meta.json
@@ -1,0 +1,98 @@
+{
+  "id": "erdos-816-oq-01",
+  "title": "Erdős #816: Why K_{n,n+1} is the Extremal Counterexample (and Equal-Degree Pairs Always Exist)",
+  "slug": "erdos-816-oq-01",
+  "description": "Proves, axiom-free, the two structural facts the parent entry on Erdős Problem #816 left as prose. (1) The counterexample mechanism: in a bipartite graph a path of length 3 joins vertices of opposite parts, so a graph whose two parts have distinct degrees — exactly the complete bipartite graph K_{n,n+1} at the n²+n threshold — has no equal-degree pair joined by a path of length 3. (2) The degree pigeonhole: any graph on at least two vertices has two distinct vertices of equal degree, so equal-degree pairs always exist. Together these explain why the threshold is sharp and why the problem is non-trivial. The parent file axiomatizes the Chen–Ma theorem and does not compile on Lean v4.26.0; this entry is self-contained and 0-axiom.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos816OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "erdos-problems",
+      "bipartite",
+      "degree-sequence",
+      "pigeonhole",
+      "extremal-graph-theory"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. #print axioms reports only propext, Classical.choice, Quot.sound. The parent file Erdos816Problem.lean (which axiomatizes Chen–Ma and does not compile on v4.26.0) is NOT imported; the few definitions used are inlined here.",
+    "lineCount": 161,
+    "theoremCount": 5,
+    "definitionCount": 4,
+    "originalContributions": [
+      "hasPath3_opposite_color: in a bipartite graph, a path of length 3 (odd) joins vertices of opposite parts — a clean Boolean parity argument",
+      "no_equalDegreePath3_of_bipartition / _of_distinctDegrees: bipartite graphs whose colour classes carry distinct degrees have no equal-degree pair joined by a path of length 3",
+      "no_equalDegreePath3_of_partDegrees: the K_{n,n+1} situation (part degrees n+1 ≠ n) made explicit — the extremal counterexample at the n²+n edge threshold",
+      "exists_sameDegree_pair: the degree pigeonhole — any graph on ≥ 2 vertices has two distinct vertices of equal degree (so equal-degree pairs always exist)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #816 asks whether every graph with 2n+1 vertices and n²+n+1 edges contains two vertices of equal degree joined by a path of length 3; the answer is YES (Chen–Ma 2025, arXiv:2503.19569), who further show n²+n edges suffice for n ≥ 600 with the unique exception K_{n,n+1}. The complete bipartite graph K_{n,n+1} has exactly 2n+1 vertices and n²+n edges and is the extremal example: removing one edge below the threshold lets it escape the property. The parent gallery entry recorded the Chen–Ma theorem as an axiom and described — but did not prove — both why K_{n,n+1} works and the degree pigeonhole that makes equal-degree pairs available in the first place.",
+    "problemStatement": "Formalize, axiom-free, the structural facts underlying Erdős #816: why the complete bipartite graph K_{n,n+1} contains no equal-degree pair joined by a path of length 3, and why equal-degree pairs always exist.",
+    "text": "We model a bipartition as a proper Boolean 2-colouring c (adjacent vertices get opposite colours). A path of length 3 is an odd path, so it flips the colour three times and joins vertices of opposite colour (hasPath3_opposite_color). Consequently, if the two colour classes carry distinct degrees — as in K_{n,n+1}, whose parts have degrees n+1 and n — then any equal-degree pair lies in a single class (same colour) and therefore cannot be joined by a path of length 3 (no_equalDegreePath3_of_partDegrees). This is exactly the obstruction making K_{n,n+1} the extremal counterexample at n²+n edges. Separately, the degree pigeonhole (exists_sameDegree_pair) shows equal-degree pairs always exist on ≥2 vertices: if all degrees were distinct they would realise every value 0,…,card−1, forcing a vertex adjacent to all others to coexist with an isolated vertex — impossible.",
+    "proofStrategy": "Encode bipartiteness as a proper Boolean colouring; prove the odd-path parity fact by a 16-case Boolean check; deduce the counterexample obstruction; prove the pigeonhole by packaging degrees into Fin (card V), using injectivity + equal cardinality to force surjectivity and hence a degree-0 / degree-(card−1) clash.",
+    "keyInsights": [
+      "A path of length 3 has odd length, so in a bipartite graph its endpoints lie in opposite parts — the single fact behind the counterexample.",
+      "Distinct part degrees turn 'equal degree' into 'same part', which an odd path can never connect; this is precisely the K_{n,n+1} obstruction.",
+      "The degree pigeonhole is not immediate (n vertices, n possible degrees) but follows because degrees 0 and card−1 cannot both occur."
+    ],
+    "prerequisites": [
+      "Bipartite graphs as proper 2-colourings",
+      "Paths and their parity in bipartite graphs",
+      "SimpleGraph.degree and degree_lt_card_verts",
+      "Pigeonhole via injective-equals-surjective on finite types"
+    ]
+  },
+  "conclusion": {
+    "summary": "The two structural pillars of Erdős #816 are now formalized axiom-free: the bipartite parity obstruction explaining why K_{n,n+1} is the extremal counterexample (no_equalDegreePath3_of_partDegrees), and the degree pigeonhole guaranteeing equal-degree pairs exist (exists_sameDegree_pair). 5 theorems, 4 definitions, 161 lines, 0 axioms.",
+    "implications": "This separates the genuinely hard part of #816 (the Chen–Ma extremal theorem, still axiomatized in the parent) from its elementary scaffolding, both of which are now machine-checked. The parity obstruction pinpoints exactly which graphs escape the property, clarifying the sharpness of the n²+n threshold; the pigeonhole shows the problem is about *connecting* equal-degree pairs, not their existence.",
+    "openQuestions": [
+      "Construct K_{n,n+1} concretely (e.g. via Mathlib's completeBipartiteGraph) and discharge the partDegrees hypotheses by computing the part degrees n+1 and n.",
+      "Formalize the edges count of K_{n,n+1} as exactly n²+n, completing the threshold-sharpness statement.",
+      "Repair the parent Erdos816Problem.lean for v4.26.0 (orphan docstrings, satisfiesEH816 instance mismatch) so the axiomatized Chen–Ma statement can be linked to these structural lemmas."
+    ]
+  },
+  "leanFile": {
+    "namespace": "Erdos816OQ01",
+    "lineCount": 161,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 4,
+    "path": "Proofs/Erdos816OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-816",
+      "relationship": "extends",
+      "description": "Parent: Erdős Problem #816 (Chen–Ma theorem, axiomatized). This entry proves the supporting structural facts (Part V counterexample mechanism, Part VII pigeonhole) the parent left as prose, axiom-free and self-contained."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Inlined definitions",
+      "startLine": 36,
+      "endLine": 62,
+      "summary": "Self-contained copies of hasPath3, sameDegree, hasEqualDegreePath3Pair (the parent file does not compile on v4.26.0) and the Boolean bipartition predicate IsBipartition."
+    },
+    {
+      "title": "Parity of length-3 paths and the counterexample",
+      "startLine": 64,
+      "endLine": 114,
+      "summary": "hasPath3_opposite_color (odd path joins opposite parts) and the obstruction theorems no_equalDegreePath3_of_bipartition / _distinctDegrees / _partDegrees — the K_{n,n+1} mechanism."
+    },
+    {
+      "title": "Degree pigeonhole",
+      "startLine": 116,
+      "endLine": 161,
+      "summary": "exists_sameDegree_pair: any graph on ≥ 2 vertices has two vertices of equal degree, via injective-implies-surjective degree packaging and the degree-0 / degree-(card−1) clash."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Proves the two structural facts the parent entry on **Erdős Problem #816** ("Equal-Degree Vertices and Paths of Length 3") states only as prose. The parent axiomatizes the Chen–Ma theorem; this entry supplies the elementary scaffolding, axiom-free.

### 1. Why `K_{n,n+1}` is the extremal counterexample (Part V)

- `hasPath3_opposite_color` — in a bipartite graph, a path of length 3 (odd) joins vertices of **opposite** parts (Boolean parity: three colour flips).
- `no_equalDegreePath3_of_partDegrees` — if the two parts carry distinct degrees (`d₀ ≠ d₁`), there is **no** equal-degree pair joined by a path of length 3. This is exactly `K_{n,n+1}` (part degrees `n+1 ≠ n`), the extremal example at the `n²+n` edge threshold: equal-degree pairs lie in one part, which an odd path can never connect.

### 2. Equal-degree pairs always exist (Part VII)

- `exists_sameDegree_pair` — any graph on `≥ 2` vertices has two distinct vertices of equal degree. (If all degrees were distinct they would realise every value `0,…,card−1`, forcing a vertex adjacent to all others to coexist with an isolated vertex.)

## Self-contained

The parent file `Erdos816Problem.lean` does **not compile on Lean v4.26.0** (orphan docstrings + a `satisfiesEH816` instance mismatch), so the few definitions used (`hasPath3`, `sameDegree`, `hasEqualDegreePath3Pair`) are inlined. Repairing the parent is noted as an open follow-up.

## Results (`Proofs/Erdos816OQ01.lean`, 5 theorems, 4 defs, 161 lines)

`hasPath3_opposite_color`, `no_equalDegreePath3_of_bipartition`, `no_equalDegreePath3_of_distinctDegrees`, `no_equalDegreePath3_of_partDegrees`, `exists_sameDegree_pair`.

## Verification

```
./proofs/scripts/docker-build.sh Proofs.Erdos816OQ01   # Build succeeded
#print axioms → [propext, Classical.choice, Quot.sound] # 0 substantive axioms
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)