### PR TITLE
audit(erdos-744): fix stale metadata after #27334 un-bit-rot

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9354,10 +9354,10 @@
       "result": "clean"
     },
     "erdos-744": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-24T21:48:08Z",
-      "result": "clean"
+      "agentId": "auditor-agent-20260621",
+      "auditCount": 5,
+      "lastAudited": "2026-06-21T12:09:59Z",
+      "result": "issues-fixed"
     },
     "erdos-745": {
       "agentId": "auditor-cycle-20-batch",
@@ -17629,5 +17629,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21"
+  "lastUpdated": "2026-06-21T12:09:59Z"
 }

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -17,7 +17,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 744,
     "erdosUrl": "https://erdosproblems.com/744",
     "erdosProblemStatus": "disproved",
@@ -58,10 +58,10 @@
       "erdos_744_statement theorem: combined main result"
     ],
     "axiomCount": 2,
-    "lineCount": 344,
-    "assumptions": "2 axioms: chromaticNumber, rodl_tuza_theorem. 1 sorries.",
-    "theoremCount": 8,
-    "definitionCount": 10
+    "lineCount": 388,
+    "assumptions": "2 axioms: chromaticNumber, rodl_tuza_theorem. 0 sorries.",
+    "theoremCount": 10,
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "Erdős Problem #744 originates from a question posed by Erdős, Hajnal, and Szemerédi in the early 1980s (references [Er81] and [EHS82]). The problem concerns a fundamental question about the structure of k-chromatic critical graphs: how many edges must be removed to make such a graph bipartite? The function f_k(n) measures the minimum number of edge deletions needed across all k-critical graphs on n vertices.\n\nThe case k = 3 is trivial: the only 3-critical graphs are odd cycles, and removing any single edge yields a path (which is bipartite), so f_3(n) = 1. For k ≥ 4, early results were encouraging for the conjecture. Gallai (1968) established that f_4(n) ≤ O(√n), and Lovász extended this to f_k(n) ≤ O(n^{1-1/(k-2)}) for general k. Erdős and collaborators conjectured that f_k(n) → ∞ as n → ∞, and specifically asked whether f_4(n) grows at least as fast as log(n).\n\nIn a surprising turn, Rödl and Tuza disproved the conjecture entirely in 1985. They showed that for every fixed k ≥ 3, the function f_k(n) is eventually constant: f_k(n) = C(k-1, 2) = (k-1)(k-2)/2 for all sufficiently large n. This means the non-bipartiteness of large k-critical graphs is concentrated in a bounded substructure, regardless of the total graph size.",
@@ -208,5 +208,5 @@
       "description": "Related Erdős problem sharing themes: chromatic-number, disproved, graph-theory"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Audit: erdos-744 (Critical Graphs and Bipartition)

Erdős #744 was un-bit-rotted in #27334 (`bipartitionNumber` definition completed → **0 sorries, 2 axioms**). The nested `meta` block was stale, while the `leanFile` block already reflected the new source. Reconciled `meta` to the actual source:

| field | was | now (source) |
|---|---|---|
| `meta.sorries` / top-level `sorries` | 1 | **0** |
| `meta.lineCount` | 344 | **388** |
| `meta.theoremCount` | 8 | **10** |
| `meta.definitionCount` | 10 | **11** |
| `assumptions` text | '1 sorries' | '0 sorries' |

### Verification (`proofs/Proofs/Erdos744Problem.lean`)
- 0 real sorries (the lone `sorry` grep hit is docstring prose at L110)
- 2 `axiom` declarations at col 0: `chromaticNumber` (L42), `rodl_tuza_theorem` (L239) — matches `axiomCount: 2`
- 10 `theorem`/`lemma`, 11 `def`, 388 lines
- 0 `native_decide`, no `True` stubs, no structure-encoded assumptions
- `status: axiomatized` / `badge: axiom` correct (open problem, disproved, axiomatized)

Metadata-only change; no Lean source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)