### PR TITLE
research(platonic-solids-oq-02-oq-01): angle defect is necessary but not sufficient for Archimedean solids [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3014,6 +3014,7 @@ import Proofs.PicksTheoremOQ03Product
 import Proofs.PlatonicSolids
 import Proofs.PlatonicSolidsOQ01
 import Proofs.PlatonicSolidsOQ02
+import Proofs.PlatonicSolidsOQ02OQ01
 import Proofs.PoincareConjecture
 import Proofs.PompeiuTheorem
 import Proofs.PowerMeanCrossZeroOQ

--- a/proofs/Proofs/PlatonicSolidsOQ02OQ01.lean
+++ b/proofs/Proofs/PlatonicSolidsOQ02OQ01.lean
@@ -1,0 +1,206 @@
+/-
+# The Angle-Defect Condition Is Necessary but Not Sufficient for Archimedean Solids
+
+The parent classification (`PlatonicSolidsOQ02.lean`) verifies that all 13
+Archimedean vertex types have *positive angle defect* — the regular polygons
+meeting at a vertex leave an angular gap (their interior angles sum to strictly
+less than `2π`). It leaves open:
+
+> **Open question.** Can the angle constraint alone (without geometric analysis)
+> determine the 13 Archimedean types?
+
+This file answers that question: **No.** The positive-defect condition is a
+genuine *necessary* condition with real combinatorial force — it caps the number
+of faces meeting at a vertex at five (`degree_le_five`) — but it is far from
+*sufficient*. We exhibit an infinite family of vertex types `[3, 3, n]` that
+each satisfy positive defect yet are non-uniform and absent from the 13. Hence:
+
+* The defect condition admits **infinitely many** vertex types
+  (`infinitely_many_positiveDefect`).
+* Even after excluding the Platonic (uniform) types and the 13 Archimedean
+  types, infinitely many positive-defect configurations remain
+  (`infinitely_many_nonArchimedean_positiveDefect`).
+
+So no purely angular/combinatorial criterion at the level of a single vertex can
+single out the 13: the missing ingredient is exactly the *global geometric
+realizability* (convex closure) that the angle condition cannot see.
+
+Everything here is over `ℚ` and proved with `norm_num` / `nlinarith` /
+`induction` — no `native_decide`, hence genuinely axiom-free (only the standard
+`propext` / `Classical.choice` / `Quot.sound`).
+-/
+import Mathlib.Tactic
+
+namespace ArchimedeanAngleDefect
+
+-- ============================================================
+-- Section 1: The Angle Model (over ℚ)
+-- ============================================================
+
+/-- Interior angle of a regular `n`-gon, measured in units of `π`:
+    `(n - 2)/n = 1 - 2/n`. (A triangle: `1/3`; a square: `1/2`; → `1` as
+    `n → ∞`.) -/
+def angleFrac (n : ℕ) : ℚ := 1 - 2 / (n : ℚ)
+
+/-- Total angle (in units of `π`) of the regular polygons meeting at a vertex
+    whose face sizes are `faces`. -/
+def vertexAngleSum (faces : List ℕ) : ℚ := (faces.map angleFrac).sum
+
+/-- A vertex has **positive angle defect** when its faces leave a gap, i.e. the
+    interior angles sum to strictly less than `2π` (`< 2` in units of `π`). -/
+def PositiveDefect (faces : List ℕ) : Prop := vertexAngleSum faces < 2
+
+/-- The interior angle of any regular polygon (`n ≥ 3`) is at least that of an
+    equilateral triangle, `1/3` of `π`. This is the key monotonicity fact. -/
+theorem angleFrac_ge_third {n : ℕ} (hn : 3 ≤ n) : (1 : ℚ) / 3 ≤ angleFrac n := by
+  have hn' : (3 : ℚ) ≤ (n : ℚ) := by exact_mod_cast hn
+  have hnpos : (0 : ℚ) < (n : ℚ) := by linarith
+  set t : ℚ := 2 / (n : ℚ) with ht
+  have htn : t * (n : ℚ) = 2 := by rw [ht]; field_simp
+  have ht0 : 0 ≤ t := by rw [ht]; positivity
+  have hle : t ≤ 2 / 3 := by
+    nlinarith [mul_nonneg ht0 (by linarith : (0 : ℚ) ≤ (n : ℚ) - 3)]
+  unfold angleFrac
+  rw [← ht]
+  linarith
+
+-- ============================================================
+-- Section 2: The Necessary Direction — Degree Is at Most Five
+-- ============================================================
+
+/-- Generic list bound: if `f n ≥ c` for every entry, then `Σ f ≥ (length)·c`. -/
+theorem list_sum_lb (f : ℕ → ℚ) (c : ℚ) :
+    ∀ (l : List ℕ), (∀ n ∈ l, c ≤ f n) → (l.length : ℚ) * c ≤ (l.map f).sum := by
+  intro l
+  induction l with
+  | nil => intro _; simp
+  | cons a t ih =>
+    intro h
+    simp only [List.map_cons, List.sum_cons, List.length_cons]
+    have ha := h a (by simp)
+    have ht := ih (fun n hn => h n (by simp [hn]))
+    push_cast
+    nlinarith [ha, ht]
+
+/-- If every face has at least three sides, the angle sum is bounded below by
+    `(degree) · (1/3)`: each face contributes at least a triangle's angle. -/
+theorem vertexAngleSum_ge (faces : List ℕ) (hreg : ∀ n ∈ faces, 3 ≤ n) :
+    (faces.length : ℚ) * (1 / 3) ≤ vertexAngleSum faces :=
+  list_sum_lb angleFrac (1 / 3) faces (fun n hn => angleFrac_ge_third (hreg n hn))
+
+/-- **Degree bound (necessary condition).** At most five regular polygons can
+    meet at a vertex with positive angle defect. (Six equilateral triangles
+    already tile flatly: angle sum exactly `2`.) -/
+theorem degree_le_five (faces : List ℕ) (hreg : ∀ n ∈ faces, 3 ≤ n)
+    (hdef : PositiveDefect faces) : faces.length ≤ 5 := by
+  have hlb := vertexAngleSum_ge faces hreg
+  unfold PositiveDefect at hdef
+  have hlt : (faces.length : ℚ) * (1 / 3) < 2 := lt_of_le_of_lt hlb hdef
+  have h6 : (faces.length : ℚ) < 6 := by linarith
+  have : faces.length < 6 := by exact_mod_cast h6
+  omega
+
+-- ============================================================
+-- Section 3: The 13 Archimedean Types All Satisfy It (axiom-free)
+-- ============================================================
+
+/-- The 13 Archimedean vertex types (same data as the parent file). -/
+def archimedeanTypes : List (List ℕ) :=
+  [[3, 6, 6], [3, 4, 3, 4], [3, 8, 8], [4, 6, 6], [3, 4, 4, 4], [4, 6, 8],
+   [3, 3, 3, 3, 4], [3, 5, 3, 5], [3, 10, 10], [5, 6, 6], [3, 4, 5, 4],
+   [4, 6, 10], [3, 3, 3, 3, 5]]
+
+/-- All 13 Archimedean vertex types have positive angle defect — re-proved here
+    with `norm_num` over `ℚ`, replacing the parent's `native_decide`
+    (which depends on `Lean.ofReduceBool`). -/
+theorem all_archimedean_positiveDefect :
+    ∀ v ∈ archimedeanTypes, PositiveDefect v := by
+  intro v hv
+  simp only [archimedeanTypes, List.mem_cons, List.not_mem_nil, or_false] at hv
+  rcases hv with h | h | h | h | h | h | h | h | h | h | h | h | h <;>
+    (subst h
+     unfold PositiveDefect vertexAngleSum angleFrac
+     simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil]
+     norm_num)
+
+-- ============================================================
+-- Section 4: Insufficiency — An Infinite Family Passes the Test
+-- ============================================================
+
+/-- The witness family: two triangles and one `n`-gon meet at a vertex. -/
+def family (k : ℕ) : List ℕ := [3, 3, k + 4]
+
+/-- Every member of the family has positive angle defect: its angle sum is
+    `5/3 - 2/n`, which is `< 2` for all `n ≥ 3` (indeed it is `< 5/3`). -/
+theorem family_positiveDefect {n : ℕ} (hn : 3 ≤ n) : PositiveDefect [3, 3, n] := by
+  unfold PositiveDefect vertexAngleSum angleFrac
+  simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil]
+  have hnpos : (0 : ℚ) < (n : ℚ) := by exact_mod_cast (by omega : 0 < n)
+  have hge : (0 : ℚ) ≤ 2 / (n : ℚ) := by positivity
+  nlinarith [hge]
+
+/-- The family is injective in `k`, so it has infinitely many distinct members. -/
+theorem family_injective : Function.Injective family := by
+  intro a b hab
+  simp only [family, List.cons.injEq, and_true, true_and] at hab
+  omega
+
+/-- No member of the family is one of the 13 Archimedean types: every length-3
+    Archimedean type has a face of size `≥ 6` in its second slot, whereas the
+    family's second face is a triangle. -/
+theorem family_not_archimedean (k : ℕ) : family k ∉ archimedeanTypes := by
+  simp [family, archimedeanTypes]
+
+/-- A vertex type is **uniform** (Platonic) when all its faces are congruent. -/
+def IsUniform (faces : List ℕ) : Prop := ∀ a ∈ faces, ∀ b ∈ faces, a = b
+
+/-- No member of the family is uniform: it pairs a triangle with an `(k+4)`-gon,
+    and `k + 4 ≠ 3`. -/
+theorem family_not_uniform (k : ℕ) : ¬ IsUniform (family k) := by
+  intro h
+  have : (3 : ℕ) = k + 4 :=
+    h 3 (by simp [family]) (k + 4) (by simp [family])
+  omega
+
+-- ============================================================
+-- Section 5: The Answer — Infinitely Many Non-Archimedean Witnesses
+-- ============================================================
+
+/-- **Insufficiency, basic form.** Infinitely many vertex types satisfy the
+    positive-defect condition. A finite list (the 13) can never be carved out by
+    this condition alone. -/
+theorem infinitely_many_positiveDefect :
+    {v : List ℕ | PositiveDefect v}.Infinite :=
+  Set.infinite_of_injective_forall_mem family_injective
+    (fun k => by
+      show PositiveDefect [3, 3, k + 4]
+      exact family_positiveDefect (by omega))
+
+/-- **Insufficiency, sharp form — the answer to the open question.** Even after
+    excluding the Platonic (uniform) types *and* the 13 Archimedean types,
+    infinitely many vertex types still satisfy positive angle defect. Therefore
+    the angle constraint alone — at the level of a single vertex — cannot
+    determine the 13 Archimedean solids; the decisive missing ingredient is the
+    global geometric realizability that the angle sum cannot detect. -/
+theorem infinitely_many_nonArchimedean_positiveDefect :
+    {v : List ℕ |
+        PositiveDefect v ∧ ¬ IsUniform v ∧ v ∉ archimedeanTypes}.Infinite := by
+  apply Set.infinite_of_injective_forall_mem (f := family) family_injective
+  intro k
+  refine ⟨?_, family_not_uniform k, family_not_archimedean k⟩
+  show PositiveDefect [3, 3, k + 4]
+  exact family_positiveDefect (by omega)
+
+/-- Two concrete smallest witnesses, `[3,3,4]` and `[3,3,5]`: both have positive
+    defect, neither is among the 13 Archimedean types nor uniform. -/
+theorem concrete_witnesses :
+    (PositiveDefect [3, 3, 4] ∧ [3, 3, 4] ∉ archimedeanTypes ∧ ¬ IsUniform [3, 3, 4]) ∧
+    (PositiveDefect [3, 3, 5] ∧ [3, 3, 5] ∉ archimedeanTypes ∧ ¬ IsUniform [3, 3, 5]) := by
+  refine ⟨⟨family_positiveDefect (by norm_num), ?_, ?_⟩,
+          ⟨family_positiveDefect (by norm_num), ?_, ?_⟩⟩
+  · have := family_not_archimedean 0; simpa [family] using this
+  · have := family_not_uniform 0; simpa [family] using this
+  · have := family_not_archimedean 1; simpa [family] using this
+  · have := family_not_uniform 1; simpa [family] using this
+
+end ArchimedeanAngleDefect

--- a/src/data/proofs/platonic-solids-oq-02-oq-01/meta.json
+++ b/src/data/proofs/platonic-solids-oq-02-oq-01/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "platonic-solids-oq-02-oq-01",
+  "slug": "platonic-solids-oq-02-oq-01",
+  "title": "The Angle-Defect Condition Is Necessary but Not Sufficient for Archimedean Solids",
+  "description": "A rigorous answer to the open question raised by the Archimedean classification (platonic-solids-oq-02): can the angle constraint alone determine the 13 Archimedean types? The answer is no. Positive angle defect is a genuine necessary condition with real force - it caps vertex degree at five - but infinitely many vertex types (the family [3,3,n]) satisfy it while being neither Platonic nor among the 13 Archimedean solids. The missing ingredient is global geometric realizability, which a single-vertex angle sum cannot detect. Everything is proved over the rationals with norm_num / nlinarith / induction, with no native_decide, so it is genuinely axiom-free.",
+  "overview": "The parent proof verifies that all 13 Archimedean vertex types have positive angle defect (the interior angles of the regular polygons meeting at a vertex sum to less than 2*pi), but does so with native_decide and leaves the classification statement as a True-stub. It asks whether the angle constraint by itself could pin down the 13 types. This file settles that question. On the necessary side, we prove degree_le_five: since every regular polygon has interior angle at least pi/3 (a triangle's), at most five faces can meet at a vertex with positive defect - six equilateral triangles already tile flatly. On the sufficiency side, we exhibit the infinite family family k = [3,3,k+4]: each has angle sum 5/3 - 2/n < 2, none is uniform (Platonic), and none is among the 13. Hence the positive-defect set is infinite (infinitely_many_positiveDefect) and remains infinite even after excluding the Platonic and the 13 Archimedean types (infinitely_many_nonArchimedean_positiveDefect). No purely angular, single-vertex criterion can therefore characterize the 13 Archimedean solids.",
+  "conclusion": "Positive angle defect is necessary (it bounds vertex degree by 5 and every Archimedean type satisfies it) but decisively not sufficient: infinitely many non-Platonic, non-Archimedean vertex types pass the test. The angle constraint alone cannot determine the 13 Archimedean solids - global geometric realizability is essential. The supporting computations are re-proved over the rationals without native_decide, upgrading the parent's angle-defect checks to genuinely axiom-free (only propext / Classical.choice / Quot.sound).",
+  "meta": {
+    "author": "formalized here",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Archimedean_solid",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PlatonicSolidsOQ02OQ01.lean",
+    "tags": [
+      "geometry",
+      "polyhedra",
+      "combinatorics",
+      "classification",
+      "angle-defect",
+      "research",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "defCount": 6,
+    "definitionCount": 6,
+    "lineCount": 206,
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.infinite_of_injective_forall_mem",
+        "description": "An injection from an infinite type whose image lies in a set proves the set is infinite",
+        "module": "Mathlib.Data.Set.Finite"
+      },
+      {
+        "theorem": "Function.Injective",
+        "description": "Injectivity of the witness family in its index",
+        "module": "Mathlib.Logic.Function.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Rational (norm_num-based) re-proof that all 13 Archimedean vertex types have positive angle defect, removing the parent's native_decide / Lean.ofReduceBool dependence",
+      "degree_le_five: at most five regular polygons meet at a vertex with positive angle defect (necessary direction with real combinatorial force)",
+      "angleFrac_ge_third: the interior angle of any regular n-gon (n>=3) is at least 1/3 of pi, the key monotonicity fact",
+      "family_positiveDefect: the infinite family [3,3,n] all have positive angle defect (angle sum 5/3 - 2/n)",
+      "infinitely_many_positiveDefect: the positive-defect condition admits infinitely many vertex types",
+      "infinitely_many_nonArchimedean_positiveDefect: infinitely many positive-defect types remain even after excluding Platonic and the 13 Archimedean types - the sharp answer to the open question (NO)",
+      "concrete_witnesses: the two smallest explicit counterexamples [3,3,4] and [3,3,5]"
+    ],
+    "assumptions": "0 axioms, 0 sorries. Every theorem depends only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms); in particular there is no Lean.ofReduceBool (no native_decide) and no sorryAx. The angle model is the standard one: a regular n-gon has interior angle (n-2)/n in units of pi; positive defect means the angles at a vertex sum to strictly less than 2.",
+    "prerequisites": [
+      "Interior angles of regular polygons",
+      "Archimedean solids classification (parent proof platonic-solids-oq-02)",
+      "Basic theory of List.sum over the rationals"
+    ],
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-21"
+  },
+  "leanFile": {
+    "imports": ["Mathlib.Tactic"],
+    "opens": [],
+    "namespace": "ArchimedeanAngleDefect",
+    "lineCount": 206,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 6,
+    "path": "Proofs/PlatonicSolidsOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": [],
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Module Overview and the Angle Model",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Docstring stating the open question and the answer, then the rational angle model: angleFrac (interior angle in units of pi), vertexAngleSum, and PositiveDefect.",
+      "mathContext": "A regular n-gon has interior angle (n-2)/n = 1 - 2/n in units of pi. A vertex has positive angle defect when the faces meeting there leave an angular gap, i.e. the angle sum is < 2."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Triangle Is the Sharpest: angleFrac >= 1/3",
+      "startLine": 51,
+      "endLine": 65,
+      "summary": "angleFrac_ge_third: the interior angle of any regular polygon with at least three sides is at least 1/3 of pi (attained by the equilateral triangle).",
+      "mathContext": "Since 1 - 2/n is increasing in n, its minimum over n >= 3 is 1 - 2/3 = 1/3. This is the key bound driving the degree cap."
+    },
+    {
+      "id": "degree-bound",
+      "title": "Necessary Direction: At Most Five Faces per Vertex",
+      "startLine": 81,
+      "endLine": 113,
+      "summary": "A generic list lower bound (list_sum_lb), the angle-sum bound vertexAngleSum_ge (>= degree * 1/3), and degree_le_five: positive defect forces at most five faces at a vertex.",
+      "mathContext": "If each of d faces contributes at least 1/3 and the total is < 2, then d/3 < 2, so d <= 5. Six equilateral triangles give angle sum exactly 2 (a flat tiling), the boundary case."
+    },
+    {
+      "id": "thirteen-valid",
+      "title": "All 13 Archimedean Types Pass (axiom-free)",
+      "startLine": 116,
+      "endLine": 138,
+      "summary": "archimedeanTypes lists the 13 vertex types; all_archimedean_positiveDefect re-proves each has positive defect via norm_num over the rationals, replacing the parent's native_decide.",
+      "mathContext": "This confirms positive defect is genuinely necessary for the 13, while removing the Lean.ofReduceBool dependence of the parent's computational checks."
+    },
+    {
+      "id": "family",
+      "title": "Insufficiency: An Infinite Family Passes",
+      "startLine": 140,
+      "endLine": 188,
+      "summary": "The witness family [3,3,n], its positive defect (family_positiveDefect), injectivity, absence from the 13 (family_not_archimedean), and non-uniformity (family_not_uniform).",
+      "mathContext": "[3,3,n] has angle sum 1/3 + 1/3 + (1 - 2/n) = 5/3 - 2/n < 2 for every n >= 3. For n >= 4 it is non-uniform and not one of the 13, since no length-3 Archimedean type has the shape [3,3,*]."
+    },
+    {
+      "id": "answer",
+      "title": "The Answer: Infinitely Many Non-Archimedean Witnesses",
+      "startLine": 190,
+      "endLine": 206,
+      "summary": "infinitely_many_positiveDefect and infinitely_many_nonArchimedean_positiveDefect establish that the angle condition admits infinitely many vertex types even after excluding Platonic and Archimedean ones; concrete_witnesses gives [3,3,4] and [3,3,5].",
+      "mathContext": "Since a finite list can never equal an infinite set, no single-vertex angle/combinatorial criterion can determine the 13 Archimedean solids; global geometric realizability is the decisive missing ingredient."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "platonic-solids-oq-02",
+      "relationship": "answers",
+      "description": "Answers the parent's open question 'Can the angle constraint alone (without geometric analysis) determine the 13 types?' in the negative, and re-proves its angle-defect checks without native_decide."
+    },
+    {
+      "targetId": "platonic-solids",
+      "relationship": "extends",
+      "description": "Builds on the Platonic solids classification; here the uniform (Platonic) types are one of the families explicitly excluded from the witness set."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Kepler, Johannes",
+      "title": "Harmonices Mundi",
+      "year": "1619",
+      "venue": "Linz",
+      "note": "First systematic enumeration of the 13 Archimedean solids"
+    },
+    {
+      "authors": "Grünbaum, Branko",
+      "title": "Convex Polytopes",
+      "year": "1967",
+      "venue": "John Wiley & Sons",
+      "note": "Rigorous modern treatment of the Archimedean classification, including the role of global realizability"
+    },
+    {
+      "authors": "Cromwell, Peter R.",
+      "title": "Polyhedra",
+      "year": "1997",
+      "venue": "Cambridge University Press",
+      "note": "Accessible treatment of Archimedean solids; discusses vertex configurations that satisfy local angle conditions but fail to close globally"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question raised by **platonic-solids-oq-02** (Archimedean classification):

> *Can the angle constraint alone (without geometric analysis) determine the 13 Archimedean types?*

**No.** Positive angle defect is a genuine *necessary* condition with real combinatorial force, but it is decisively *not sufficient* — infinitely many vertex types pass it.

## What's proved (`Proofs/PlatonicSolidsOQ02OQ01.lean`, 206L, 12 thm / 6 def, 0 sorries)

**Necessary direction**
- `angleFrac_ge_third` — every regular `n`-gon (`n ≥ 3`) has interior angle `≥ 1/3` of `π` (the equilateral triangle is sharpest).
- `degree_le_five` — at most **five** regular polygons meet at a vertex with positive defect (six triangles already tile flatly: angle sum exactly `2`).
- `all_archimedean_positiveDefect` — all 13 Archimedean vertex types re-verified to have positive defect, over `ℚ` with `norm_num`, **removing the parent's `native_decide` / `Lean.ofReduceBool` dependence**.

**Insufficiency (the answer)**
- `family_positiveDefect` — the family `[3, 3, n]` all have positive defect (angle sum `5/3 − 2/n < 2`).
- `infinitely_many_positiveDefect` — the positive-defect set is infinite.
- `infinitely_many_nonArchimedean_positiveDefect` — it *stays* infinite after excluding the Platonic (uniform) types **and** the 13 Archimedean types. Hence no single-vertex angle/combinatorial criterion can carve out the 13; global geometric realizability is the missing ingredient.
- `concrete_witnesses` — the two smallest explicit counterexamples `[3,3,4]`, `[3,3,5]`.

## Verification

- Builds clean via `./proofs/scripts/docker-build.sh Proofs.PlatonicSolidsOQ02OQ01`.
- `#print axioms` on every headline theorem: only `propext`, `Classical.choice`, `Quot.sound` — **no `Lean.ofReduceBool`, no `sorryAx`**. Genuinely axiom-free (`status: verified`, `badge: original`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)