### PR TITLE
audit(3 new slugs): birthday-n4 metadata fix + cantor & platonic clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17626,8 +17626,29 @@
       "lastAudited": "2026-06-21T11:58:59Z",
       "result": "issues-fixed",
       "notes": "Build-verified (docker, 7743 jobs). #print axioms on jacobiSym_neg_eq_neg_one_of_three_mod_four + multiplier_route_obstructed_of_three_mod_four = [propext, Classical.choice, Quot.sound] only → 0-axiom. 0 sorries / 0 native_decide / 0 admit (grep hits on lines 53,63 are docstring PROSE). 178L, 7 theorems, 0 defs. Self-contained (import Mathlib only). Fixed meta theoremCount 8→7. status verified justified."
+    },
+    "birthday-problem-oq-03-oq-01-oq-01-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T12:27:37Z",
+      "result": "issues-fixed",
+      "notes": "Static audit: 0 sorries / 0 axiom decls / no native_decide (base cases d=0,1,2 use kernel decide → no Lean.ofReduceBool) / no structures. 0-axiom verified claim holds. Fixed stale metadata: leanFile.namespace BirthdayOptimized→BirthdayN4Closed, theoremCount 3→6, definitionCount 0→2, lineCount 60→77 (file has defs R, birthdayCount3 + theorems R_zero/R_succ/R_one/four/four_factored/four_eq_nat), plus section line ranges and summary."
+    },
+    "cantor-diagonalization-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T12:27:37Z",
+      "result": "clean",
+      "notes": "Static audit: 0 sorries / 0 axiom decls / no native_decide / no structures. 7 theorems, 1 noncomputable def (contFn), 79 lines — matches meta. 0-axiom verified claim holds (König constraint proved via Mathlib cofinality, not assumed)."
+    },
+    "platonic-solids-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-21T12:27:37Z",
+      "result": "clean",
+      "notes": "Static audit: 0 sorries / 0 axiom decls / no native_decide tactic (grep hits lines 18/29/114 are docstring prose; line 18 \"admits\" matched admit-grep) / no structures (6 plain defs/Props: angleFrac, vertexAngleSum, PositiveDefect, archimedeanTypes, family, IsUniform). 12 theorems, 6 defs, 206 lines — matches meta. 0-axiom original claim holds."
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T12:09:59Z"
+  "lastUpdated": "2026-06-21T12:27:37Z"
 }

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05/meta.json
@@ -21,9 +21,9 @@
     "dateAdded": "2026-06-21",
     "axiomCount": 0,
     "assumptions": "None. #print axioms reports only propext, Classical.choice, Quot.sound. The closed form is proved by unfolding the recurrence (no native_decide), so it carries no Lean.ofReduceBool dependency.",
-    "lineCount": 60,
-    "theoremCount": 3,
-    "definitionCount": 0,
+    "lineCount": 77,
+    "theoremCount": 6,
+    "definitionCount": 2,
     "originalContributions": [
       "birthdayCount3_four: the closed form birthdayCount3 4 d = d⁴ − 4d² + 3d over ℤ",
       "birthdayCount3_four_factored: the factored form d(d−1)(d²+d−3)",
@@ -47,7 +47,7 @@
     ]
   },
   "conclusion": {
-    "summary": "birthdayCount3 4 d = d⁴ − 4d² + 3d = d(d−1)(d²+d−3), the next closed form after the parent's n = 1, 2, 3 cases, proved 0-axiom (no native_decide). 3 theorems, 60 lines.",
+    "summary": "birthdayCount3 4 d = d⁴ − 4d² + 3d = d(d−1)(d²+d−3), the next closed form after the parent's n = 1, 2, 3 cases, proved 0-axiom (no native_decide). 6 theorems, 2 definitions, 77 lines.",
     "implications": "Continues the explicit closed-form sequence for the k=3 birthday count and demonstrates that these values are accessible by symbolic recurrence unfolding rather than the parent's native_decide evaluation, keeping the result axiom-free.",
     "openQuestions": [
       "Find the general closed form birthdayCount3 n d as a polynomial in d (a signed sum over involutions / telephone-number structure) and prove it by induction on n.",
@@ -56,11 +56,11 @@
     ]
   },
   "leanFile": {
-    "namespace": "BirthdayOptimized",
-    "lineCount": 60,
+    "namespace": "BirthdayN4Closed",
+    "lineCount": 77,
     "axiomCount": 0,
-    "theoremCount": 3,
-    "definitionCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ01OQ05.lean",
     "sorries": 0
   },
@@ -74,14 +74,14 @@
   "sections": [
     {
       "title": "The n = 4 closed form",
-      "startLine": 30,
-      "endLine": 47,
+      "startLine": 51,
+      "endLine": 62,
       "summary": "birthdayCount3_four: d⁴ − 4d² + 3d over ℤ, via small-case evaluation and symbolic unfolding of the recurrence for d = k+3."
     },
     {
       "title": "Factored and ℕ forms",
-      "startLine": 49,
-      "endLine": 60,
+      "startLine": 64,
+      "endLine": 75,
       "summary": "birthdayCount3_four_factored (d(d−1)(d²+d−3)) and birthdayCount3_four_eq_nat (a truncation-free ℕ identity for d ≥ 1)."
     }
   ],


### PR DESCRIPTION
## Auditor sweep — three never-audited slugs

Audited the three new research slugs merged into main since the last sweep, draining the queue to **2818/2818**.

| Slug | Result | Source check |
|------|--------|--------------|
| birthday-problem-oq-03-oq-01-oq-01-oq-05 | **issues-fixed** | 0 sorry / 0 axiom / no native_decide (base cases use kernel `decide`) / no structures — 0-axiom verified claim holds. Stale metadata corrected. |
| cantor-diagonalization-oq-01-oq-01-oq-03 | clean | 7 thm / 1 def / 79L match meta; König constraint proved via Mathlib cofinality, not assumed |
| platonic-solids-oq-02-oq-01 | clean | 12 thm / 6 def / 206L match meta; `native_decide`/`admit` grep hits are docstring prose only |

### Metadata fix (birthday)
The shipped meta undercounted declarations and named the wrong namespace:
- `leanFile.namespace`: `BirthdayOptimized` → `BirthdayN4Closed` (actual)
- `theoremCount`: 3 → 6 (R_zero, R_succ, R_one, birthdayCount3_four, _factored, _eq_nat)
- `definitionCount`: 0 → 2 (R, birthdayCount3)
- `lineCount`: 60 → 77
- section line ranges + conclusion summary

Substance (status `verified`, badge `verified`, axiomCount 0) was accurate and unchanged.

Tracker-only + one meta.json; no Lean source touched. All three already passed deployer build+merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)