### PR TITLE
research(sqrt2-irrational-oq-02): transcendental numbers exist (Liouville's constant) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3221,6 +3221,7 @@ import Proofs.SphericalLawOfSinesOQ03
 import Proofs.Sqrt2
 import Proofs.Sqrt2FromAxiomsOQ01
 import Proofs.Sqrt2Irrational
+import Proofs.Sqrt2IrrationalOQ02
 import Proofs.Sqrt2IrrationalFromAxioms
 import Proofs.Sqrt2Minpoly
 import Proofs.Sqrt2MinpolyOQ01

--- a/proofs/Proofs/Sqrt2IrrationalOQ02.lean
+++ b/proofs/Proofs/Sqrt2IrrationalOQ02.lean
@@ -1,0 +1,61 @@
+/-
+Beyond irrationality: transcendental numbers exist (OQ-02)
+
+Parent entry `sqrt2-irrational` proves `√n` irrational for non-square `n` — every such
+number is irrational but *algebraic* (a root of `x² − n`).  Its second open question asks:
+
+  *Are there irrational numbers that aren't roots of any polynomial?  Yes — transcendental
+  numbers.*
+
+This file answers it concretely and axiom-free, using Mathlib's Liouville theory.
+Liouville's constant `∑_k m^{-k!}` (for `m = 2`) is **transcendental**: it is not a root
+of any nonzero polynomial with integer coefficients, and in particular it is irrational —
+an irrational number lying strictly beyond the algebraic numbers `√n` of the parent.
+
+Main results:
+* `liouvilleConst_liouville`        — Liouville's constant is a Liouville number.
+* `liouvilleConst_irrational`       — it is irrational.
+* `liouvilleConst_transcendental`   — it is transcendental over `ℤ` (no integer polynomial
+  has it as a root).
+* `exists_irrational_transcendental`— there exists an irrational, transcendental real.
+* `not_forall_irrational_isAlgebraic` — not every irrational real is algebraic (so the
+  parent's `√n` family does not exhaust the irrationals).
+-/
+
+import Mathlib
+
+open LiouvilleNumber
+
+namespace Sqrt2IrrationalOQ02
+
+/-- **Liouville's constant** `L = ∑_{k} 2^{-k!}`, the canonical concrete transcendental. -/
+noncomputable def liouvilleConst : ℝ := liouvilleNumber (2 : ℕ)
+
+/-- Liouville's constant is a Liouville number. -/
+theorem liouvilleConst_liouville : Liouville liouvilleConst :=
+  liouville_liouvilleNumber (by norm_num)
+
+/-- Liouville's constant is irrational. -/
+theorem liouvilleConst_irrational : Irrational liouvilleConst :=
+  liouvilleConst_liouville.irrational
+
+/-- **Liouville's constant is transcendental** over `ℤ`: it is not a root of any nonzero
+polynomial with integer coefficients. -/
+theorem liouvilleConst_transcendental : Transcendental ℤ liouvilleConst :=
+  transcendental_liouvilleNumber (by norm_num)
+
+/-- **Answer to OQ-02.** There is an irrational real number that is not a root of any
+nonzero integer polynomial — a transcendental number, lying beyond the algebraic
+irrationals `√n` of the parent entry. -/
+theorem exists_irrational_transcendental :
+    ∃ x : ℝ, Irrational x ∧ Transcendental ℤ x :=
+  ⟨liouvilleConst, liouvilleConst_irrational, liouvilleConst_transcendental⟩
+
+/-- Transcendence is genuinely stronger than irrationality: there is an irrational real
+that is **not algebraic** over `ℤ`.  Hence the algebraic irrationals (such as the parent's
+`√n`) do not exhaust the irrational numbers. -/
+theorem not_forall_irrational_isAlgebraic :
+    ∃ x : ℝ, Irrational x ∧ ¬ IsAlgebraic ℤ x :=
+  ⟨liouvilleConst, liouvilleConst_irrational, liouvilleConst_transcendental⟩
+
+end Sqrt2IrrationalOQ02

--- a/src/data/proofs/sqrt2-irrational-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-irrational-oq-02/meta.json
@@ -1,0 +1,89 @@
+{
+  "id": "sqrt2-irrational-oq-02",
+  "title": "Beyond Irrationality: Transcendental Numbers Exist",
+  "slug": "sqrt2-irrational-oq-02",
+  "description": "Answers the parent's question of whether there are irrational numbers that are not roots of any polynomial: yes, transcendental numbers. Exhibits Liouville's constant ∑ 2^{-k!} as a concrete irrational real that is transcendental over ℤ — not a root of any nonzero integer polynomial — and concludes that the algebraic irrationals √n of the parent do not exhaust the irrationals. Built axiom-free on Mathlib's Liouville theory.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Sqrt2IrrationalOQ02.lean",
+    "tags": [
+      "number-theory",
+      "irrationality",
+      "transcendental",
+      "liouville-numbers",
+      "algebraic-numbers"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. #print axioms reports only propext, Classical.choice, Quot.sound. The transcendence and irrationality come from Mathlib's verified Liouville theory.",
+    "lineCount": 61,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "originalContributions": [
+      "liouvilleConst: Liouville's constant ∑_k 2^{-k!} as the canonical concrete transcendental",
+      "liouvilleConst_irrational: it is irrational (via Liouville.irrational)",
+      "liouvilleConst_transcendental: it is transcendental over ℤ (no integer polynomial has it as a root)",
+      "exists_irrational_transcendental: there exists an irrational, transcendental real",
+      "not_forall_irrational_isAlgebraic: not every irrational real is algebraic — the parent's √n family does not exhaust the irrationals"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry establishes that √n is irrational for non-square n — but each such number is algebraic, a root of x² − n. Liouville (1844) gave the first explicit transcendental numbers, constants like ∑_k 10^{-k!} that are approximable by rationals far better than any algebraic number can be, and hence are roots of no integer polynomial. Cantor (1874) later showed transcendentals are in fact the overwhelming majority (the algebraic numbers are countable). Lindemann (1882) proved π transcendental, settling the impossibility of squaring the circle.",
+    "problemStatement": "Are there irrational numbers that are not roots of any polynomial — i.e. do transcendental numbers exist?",
+    "text": "Yes, concretely. Mathlib's Liouville theory gives that Liouville's constant liouvilleNumber 2 = ∑_k 2^{-k!} is a Liouville number (liouville_liouvilleNumber), hence irrational (Liouville.irrational) and transcendental over ℤ (transcendental_liouvilleNumber) — meaning it is a root of no nonzero polynomial with integer coefficients. We package this as exists_irrational_transcendental, and conclude not_forall_irrational_isAlgebraic: there is an irrational real that is not algebraic, so the algebraic irrationals √n of the parent do not exhaust the irrational numbers.",
+    "proofStrategy": "Instantiate Mathlib's Liouville number at base 2 and read off the Liouville property, irrationality, and transcendence; assemble the existence and non-exhaustion statements.",
+    "keyInsights": [
+      "Transcendence is strictly stronger than irrationality: √2 is irrational but algebraic, whereas Liouville's constant is irrational and transcendental.",
+      "A single explicit construction (Liouville's constant) answers the existence question constructively, without invoking Cantor's counting argument.",
+      "'Not a root of any polynomial' is exactly Transcendental ℤ x = ¬ IsAlgebraic ℤ x, which Mathlib's Liouville theory provides directly."
+    ],
+    "prerequisites": [
+      "Irrationality (Irrational) and algebraic/transcendental numbers (IsAlgebraic, Transcendental)",
+      "Mathlib's Liouville number theory (liouvilleNumber, Liouville.irrational, transcendental_liouvilleNumber)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Transcendental numbers exist concretely: Liouville's constant is irrational and transcendental over ℤ, an irrational lying beyond all algebraic numbers. 5 theorems, 1 definition, 61 lines, 0 axioms.",
+    "implications": "Completes the arc of the sqrt2-irrational family by exhibiting irrationals that are not algebraic, showing the parent's √n examples are only the algebraic tip of the irrationals. Supplies a reusable concrete transcendental for downstream work.",
+    "openQuestions": [
+      "Prove the transcendence of e (Mathlib has irrationality; Lindemann–Weierstrass would give transcendence).",
+      "Formalize Cantor's argument that the algebraic numbers are countable, so 'almost every' real is transcendental.",
+      "Upgrade Transcendental ℤ to Transcendental ℚ (equivalent for reals) and connect to the rational root theorem from the parent's first open question."
+    ]
+  },
+  "leanFile": {
+    "namespace": "Sqrt2IrrationalOQ02",
+    "lineCount": 61,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/Sqrt2IrrationalOQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "extends",
+      "description": "Parent: irrationality of √n (algebraic irrationals). This entry answers its open question by exhibiting irrational numbers that are not algebraic at all (transcendentals)."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Liouville's constant: irrational and transcendental",
+      "startLine": 31,
+      "endLine": 50,
+      "summary": "liouvilleConst = liouvilleNumber 2, with its Liouville property, irrationality, and transcendence over ℤ from Mathlib."
+    },
+    {
+      "title": "Existence and non-exhaustion",
+      "startLine": 52,
+      "endLine": 61,
+      "summary": "exists_irrational_transcendental and not_forall_irrational_isAlgebraic: irrational transcendentals exist, so algebraic irrationals do not exhaust the irrationals."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers the second open question of the parent entry `sqrt2-irrational`:

> *Are there irrational numbers that aren't roots of any polynomial? Yes — transcendental numbers.*

The parent shows `√n` is irrational for non-square `n`, but each such number is **algebraic** (a root of `x² − n`). This entry exhibits a concrete irrational that is **transcendental** — beyond all algebraic numbers — axiom-free via Mathlib's Liouville theory.

## Results (`Proofs/Sqrt2IrrationalOQ02.lean`, 5 theorems, 1 def, 61 lines)

Taking `liouvilleConst = ∑_k 2^{-k!}` (`liouvilleNumber 2`):
- `liouvilleConst_liouville` — it is a Liouville number.
- `liouvilleConst_irrational` — it is irrational (`Liouville.irrational`).
- `liouvilleConst_transcendental` — it is transcendental over `ℤ`: a root of no nonzero integer polynomial (`transcendental_liouvilleNumber`).
- `exists_irrational_transcendental` — there exists an irrational, transcendental real.
- `not_forall_irrational_isAlgebraic` — not every irrational is algebraic, so the parent's `√n` family does not exhaust the irrationals.

## Verification

```
./proofs/scripts/docker-build.sh Proofs.Sqrt2IrrationalOQ02   # Build succeeded
```
No `axiom`, `sorry`, or `native_decide`; axioms reduce to `propext / Classical.choice / Quot.sound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)