### PR TITLE
research(feuerbachs-theorem-defs-oq-02): Euler's formula OI² = R² − 2Rr and Euler's inequality R ≥ 2r [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2510,6 +2510,7 @@ import Proofs.FeuerbachsTheoremDefsOQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01
+import Proofs.FeuerbachsTheoremDefsOQ02
 import Proofs.FeuerbachsTheoremDefsOQ03
 import Proofs.FeuerbachsTheoremDefsOQ04
 import Proofs.FeuerbachsTheoremOQ01

--- a/proofs/Proofs/FeuerbachsTheoremDefsOQ02.lean
+++ b/proofs/Proofs/FeuerbachsTheoremDefsOQ02.lean
@@ -1,0 +1,386 @@
+/-
+  Feuerbach's Theorem DefsOQ02: Euler's Triangle Formula  OI² = R² − 2Rr
+
+  ## The Open Question
+
+  The parent file `FeuerbachsTheoremDefs` defines the circumcenter O, the incenter
+  I, the circumradius R and the inradius r of a triangle, and proves the
+  nine-point circle / Feuerbach tangency results.  It never relates the two centers
+  O and I to each other metrically.
+
+  The single most famous such relation is **Euler's formula** (Leonhard Euler,
+  1765):
+
+      OI² = R² − 2Rr,
+
+  i.e. the squared distance between the circumcenter and the incenter equals
+  R(R − 2r).  Because a squared distance is non-negative this *forces*
+
+      R ≥ 2r          (Euler's inequality),
+
+  with equality iff O = I iff the triangle is equilateral.
+
+  ## What This File Proves
+
+  For an arbitrary non-degenerate triangle T (working purely in coordinates):
+
+  ### The affine core
+  `OI_sq_eq_R2_sub` :  dist²(O, I) = R² − abc/(a+b+c).
+  This is the heart of the matter.  With O placed at the origin, the incenter is
+  the side-length-weighted average I = (a·A + b·B + c·C)/(a+b+c), and the three
+  circumcentre equidistances |A−O| = |B−O| = |C−O| = R collapse the expansion of
+  |I−O|² to R² − abc/(a+b+c).  No square roots are needed for this step.
+
+  ### The law-of-sines bridge
+  `four_R_area_eq_abc` :  4·R·Area = abc      (squared form 16·R²·Area² = a²b²c²).
+  `two_R_r_eq` :  2·R·r = abc/(a+b+c).
+  Combining R = abc/(4·Area) with r = Area/s turns abc/(a+b+c) into 2Rr.
+
+  ### Euler's formula and inequality
+  `euler_OI_formula` :  dist²(O, I) = R² − 2·R·r.
+  `euler_inequality` :  2·r ≤ R.
+
+  ### Example
+  `triangle_345_OI_sq` :  for the 3-4-5 triangle, dist²(O, I) = 5/4
+  (and indeed R² − 2Rr = (5/2)² − 2·(5/2)·1 = 5/4).
+
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Proofs.FeuerbachsTheoremDefs
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace FeuerbachEulerOI
+
+open FeuerbachsTheorem
+open scoped Real
+
+-- ============================================================
+-- PART 1: Local circumcentre equidistance (the parent's are private)
+-- ============================================================
+
+/-- Squared distance is non-negative. -/
+private lemma dist2_sq_nonneg (P Q : Point) : 0 ≤ dist2_sq P Q := by
+  unfold dist2_sq; positivity
+
+set_option maxHeartbeats 6400000 in
+/-- Perpendicular bisector of AB passes through the circumcentre (linear in O). -/
+private lemma pb_AB (T : Triangle) :
+    (T.B.1 - T.A.1) * (T.B.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.B.2 - T.A.2) * (T.B.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+set_option maxHeartbeats 6400000 in
+/-- Perpendicular bisector of AC passes through the circumcentre. -/
+private lemma pb_AC (T : Triangle) :
+    (T.C.1 - T.A.1) * (T.C.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.C.2 - T.A.2) * (T.C.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+/-- |B − O|² = |A − O|² : circumcentre equidistant from A and B. -/
+private lemma equidist_B (T : Triangle) :
+    (T.B.1 - T.circumcenter.1) ^ 2 + (T.B.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := pb_AB T
+  nlinarith [h, sq_nonneg (T.B.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.B.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+/-- |C − O|² = |A − O|² : circumcentre equidistant from A and C. -/
+private lemma equidist_C (T : Triangle) :
+    (T.C.1 - T.circumcenter.1) ^ 2 + (T.C.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := pb_AC T
+  nlinarith [h, sq_nonneg (T.C.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.C.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+-- ============================================================
+-- PART 2: Side lengths are positive; squared side lengths
+-- ============================================================
+
+/-- The squared side length a² equals the squared distance |BC|². -/
+private lemma side_a_sq (T : Triangle) :
+    T.side_a ^ 2 = (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by
+  unfold Triangle.side_a; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_b_sq (T : Triangle) :
+    T.side_b ^ 2 = (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by
+  unfold Triangle.side_b; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_c_sq (T : Triangle) :
+    T.side_c ^ 2 = (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by
+  unfold Triangle.side_c; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_a_nonneg (T : Triangle) : 0 ≤ T.side_a := Real.sqrt_nonneg _
+private lemma side_b_nonneg (T : Triangle) : 0 ≤ T.side_b := Real.sqrt_nonneg _
+private lemma side_c_nonneg (T : Triangle) : 0 ≤ T.side_c := Real.sqrt_nonneg _
+
+/-- The triangle area is positive (non-degeneracy). -/
+private lemma area_pos (T : Triangle) : 0 < T.area := by
+  unfold Triangle.area
+  have hne := T.nondegenerate
+  have h : 0 < |(T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2)| :=
+    abs_pos.mpr hne
+  linarith
+
+/-- Each side length is strictly positive. -/
+private lemma side_a_pos (T : Triangle) : 0 < T.side_a := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.C.1 - T.B.1 = 0 := by nlinarith [sq_nonneg (T.C.1 - T.B.1), sq_nonneg (T.C.2 - T.B.2)]
+    have hy : T.C.2 - T.B.2 = 0 := by nlinarith [sq_nonneg (T.C.1 - T.B.1), sq_nonneg (T.C.2 - T.B.2)]
+    apply hne; linear_combination (T.B.1 - T.A.1) * hy - (T.B.2 - T.A.2) * hx
+  unfold Triangle.side_a; exact Real.sqrt_pos.mpr h
+
+private lemma side_b_pos (T : Triangle) : 0 < T.side_b := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.A.1 - T.C.1 = 0 := by nlinarith [sq_nonneg (T.A.1 - T.C.1), sq_nonneg (T.A.2 - T.C.2)]
+    have hy : T.A.2 - T.C.2 = 0 := by nlinarith [sq_nonneg (T.A.1 - T.C.1), sq_nonneg (T.A.2 - T.C.2)]
+    apply hne; linear_combination (T.B.2 - T.A.2) * hx - (T.B.1 - T.A.1) * hy
+  unfold Triangle.side_b; exact Real.sqrt_pos.mpr h
+
+private lemma side_c_pos (T : Triangle) : 0 < T.side_c := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.B.1 - T.A.1 = 0 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+    have hy : T.B.2 - T.A.2 = 0 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+    apply hne; linear_combination (T.C.2 - T.A.2) * hx - (T.C.1 - T.A.1) * hy
+  unfold Triangle.side_c; exact Real.sqrt_pos.mpr h
+
+private lemma perimeter_pos (T : Triangle) : 0 < T.side_a + T.side_b + T.side_c := by
+  have := side_a_pos T; have := side_b_pos T; have := side_c_pos T; linarith
+
+-- ============================================================
+-- PART 3: The affine core  —  OI² = R² − abc/(a+b+c)
+-- ============================================================
+
+/-- The master algebraic identity.  With a = side_a, b = side_b, c = side_c and
+    R² = |A − O|², the weighted vector  a(A−O) + b(B−O) + c(C−O)  has squared
+    length  R²(a+b+c)² − abc(a+b+c).  This is the heart of Euler's formula. -/
+private lemma weighted_norm_sq (T : Triangle) :
+    (T.side_a * (T.A.1 - T.circumcenter.1) + T.side_b * (T.B.1 - T.circumcenter.1)
+        + T.side_c * (T.C.1 - T.circumcenter.1)) ^ 2 +
+    (T.side_a * (T.A.2 - T.circumcenter.2) + T.side_b * (T.B.2 - T.circumcenter.2)
+        + T.side_c * (T.C.2 - T.circumcenter.2)) ^ 2 =
+    ((T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2)
+        * (T.side_a + T.side_b + T.side_c) ^ 2 -
+    T.side_a * T.side_b * T.side_c * (T.side_a + T.side_b + T.side_c) := by
+  set O := T.circumcenter
+  -- R² abbreviation
+  set R2 := (T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2 with hR2
+  -- equidistances as "= R2"
+  have e1 : (T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2 = R2 := rfl
+  have e2 : (T.B.1 - O.1) ^ 2 + (T.B.2 - O.2) ^ 2 = R2 := by rw [hR2]; exact equidist_B T
+  have e3 : (T.C.1 - O.1) ^ 2 + (T.C.2 - O.2) ^ 2 = R2 := by rw [hR2]; exact equidist_C T
+  -- dot products expressed via the side lengths
+  have dotAB : (T.A.1 - O.1) * (T.B.1 - O.1) + (T.A.2 - O.2) * (T.B.2 - O.2)
+      = R2 - T.side_c ^ 2 / 2 := by
+    have hc := side_c_sq T
+    linear_combination (1 / 2) * e1 + (1 / 2) * e2 + (1 / 2) * hc
+  have dotBC : (T.B.1 - O.1) * (T.C.1 - O.1) + (T.B.2 - O.2) * (T.C.2 - O.2)
+      = R2 - T.side_a ^ 2 / 2 := by
+    have ha := side_a_sq T
+    linear_combination (1 / 2) * e2 + (1 / 2) * e3 + (1 / 2) * ha
+  have dotCA : (T.C.1 - O.1) * (T.A.1 - O.1) + (T.C.2 - O.2) * (T.A.2 - O.2)
+      = R2 - T.side_b ^ 2 / 2 := by
+    have hb := side_b_sq T
+    linear_combination (1 / 2) * e3 + (1 / 2) * e1 + (1 / 2) * hb
+  linear_combination
+    T.side_a ^ 2 * e1 + T.side_b ^ 2 * e2 + T.side_c ^ 2 * e3
+    + 2 * T.side_a * T.side_b * dotAB + 2 * T.side_b * T.side_c * dotBC
+    + 2 * T.side_c * T.side_a * dotCA
+
+/-- The affine core of Euler's formula:
+    dist²(O, I) = R² − abc/(a+b+c), with no square roots involved. -/
+theorem OI_sq_eq_R2_sub (T : Triangle) :
+    dist2_sq T.circumcenter T.incenter =
+    ((T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2)
+      - T.side_a * T.side_b * T.side_c / (T.side_a + T.side_b + T.side_c) := by
+  set O := T.circumcenter with hO
+  have hp : T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (perimeter_pos T)
+  -- incenter coordinates: I − O written over the common denominator
+  have hI : dist2_sq O T.incenter * (T.side_a + T.side_b + T.side_c) ^ 2 =
+      (T.side_a * (T.A.1 - O.1) + T.side_b * (T.B.1 - O.1) + T.side_c * (T.C.1 - O.1)) ^ 2 +
+      (T.side_a * (T.A.2 - O.2) + T.side_b * (T.B.2 - O.2) + T.side_c * (T.C.2 - O.2)) ^ 2 := by
+    unfold dist2_sq Triangle.incenter
+    dsimp only
+    field_simp [hp]
+    ring
+  -- substitute the master identity
+  have hmaster := weighted_norm_sq T
+  rw [← hO] at hmaster
+  rw [hmaster] at hI
+  -- hI : dist²(O,I)·(a+b+c)² = R2·(a+b+c)² − abc·(a+b+c)
+  -- cancel one factor of (a+b+c)
+  have hkey : dist2_sq O T.incenter * (T.side_a + T.side_b + T.side_c) =
+      ((T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2) * (T.side_a + T.side_b + T.side_c)
+        - T.side_a * T.side_b * T.side_c := by
+    apply mul_right_cancel₀ hp
+    linear_combination hI
+  field_simp [hp]
+  linear_combination hkey
+
+-- ============================================================
+-- PART 4: Law-of-sines bridge  —  4·R·Area = abc
+-- ============================================================
+
+set_option maxHeartbeats 12000000 in
+/-- The squared law-of-sines/area identity:  16·R²·Area² = a²·b²·c²,
+    expressed in coordinates (R² = |A − O|²). -/
+private lemma sixteen_R2_area_sq (T : Triangle) :
+    16 * ((T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2)
+        * T.area ^ 2 =
+    ((T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2) *
+    ((T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2) *
+    ((T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2) := by
+  have harea : T.area ^ 2 =
+      ((T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2)) ^ 2 / 4 := by
+    unfold Triangle.area
+    rw [div_pow, sq_abs]
+    ring
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2)) with hd_def
+  have hd : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [harea, hox, hoy]
+  field_simp [hd]
+  ring
+
+/-- R² = |A − O|² (circumradius squared, dropping the square root). -/
+private lemma circumradius_sq (T : Triangle) :
+    T.circumradius ^ 2 = (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  unfold Triangle.circumradius dist2
+  rw [Real.sq_sqrt (by positivity)]
+
+/-- R² > 0. -/
+private lemma circumradius_sq_pos (T : Triangle) :
+    0 < (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := sixteen_R2_area_sq T
+  have hA := area_pos T
+  have hca : 0 < (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by
+    have h1 := side_a_sq T; have h2 := pow_pos (side_a_pos T) 2; linarith
+  have hab : 0 < (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by
+    have h1 := side_b_sq T; have h2 := pow_pos (side_b_pos T) 2; linarith
+  have hbc : 0 < (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by
+    have h1 := side_c_sq T; have h2 := pow_pos (side_c_pos T) 2; linarith
+  nlinarith [h, mul_pos (mul_pos hca hab) hbc, pow_pos hA 2]
+
+/-- Circumradius is positive. -/
+private lemma circumradius_pos (T : Triangle) : 0 < T.circumradius := by
+  unfold Triangle.circumradius dist2
+  exact Real.sqrt_pos.mpr (circumradius_sq_pos T)
+
+/-- Law of sines (area form):  4·R·Area = abc. -/
+theorem four_R_area_eq_abc (T : Triangle) :
+    4 * T.circumradius * T.area = T.side_a * T.side_b * T.side_c := by
+  have habc_nn : 0 ≤ T.side_a * T.side_b * T.side_c :=
+    mul_nonneg (mul_nonneg (side_a_nonneg T) (side_b_nonneg T)) (side_c_nonneg T)
+  have hA_nn : 0 ≤ T.area := le_of_lt (area_pos T)
+  -- (abc)² = 16·Area²·R²  via the coordinate identity and the squared side lengths
+  have hsq : (T.side_a * T.side_b * T.side_c) ^ 2 =
+      16 * ((T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2) * T.area ^ 2 := by
+    rw [mul_pow, mul_pow, side_a_sq, side_b_sq, side_c_sq]
+    linear_combination -(sixteen_R2_area_sq T)
+  -- take square roots
+  have key : T.side_a * T.side_b * T.side_c =
+      4 * T.area * Real.sqrt ((T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2) := by
+    have h1 : T.side_a * T.side_b * T.side_c
+        = Real.sqrt ((T.side_a * T.side_b * T.side_c) ^ 2) := (Real.sqrt_sq habc_nn).symm
+    rw [h1, hsq]
+    rw [show 16 * ((T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2) * T.area ^ 2
+          = (4 * T.area) ^ 2 * ((T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2)
+          from by ring]
+    rw [Real.sqrt_mul (by positivity), Real.sqrt_sq (by linarith [hA_nn])]
+  rw [key]
+  unfold Triangle.circumradius dist2
+  ring
+
+-- ============================================================
+-- PART 5: Euler's formula and inequality
+-- ============================================================
+
+/-- 2·R·r = abc/(a+b+c). -/
+theorem two_R_r_eq (T : Triangle) :
+    2 * T.circumradius * T.inradius =
+    T.side_a * T.side_b * T.side_c / (T.side_a + T.side_b + T.side_c) := by
+  have hp : T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (perimeter_pos T)
+  have hr : T.inradius = 2 * T.area / (T.side_a + T.side_b + T.side_c) := by
+    unfold Triangle.inradius Triangle.semiperimeter
+    rw [div_div_eq_mul_div]
+    ring
+  rw [hr]
+  rw [show 2 * T.circumradius * (2 * T.area / (T.side_a + T.side_b + T.side_c))
+        = (4 * T.circumradius * T.area) / (T.side_a + T.side_b + T.side_c) from by ring]
+  rw [four_R_area_eq_abc]
+
+/-- **Euler's triangle formula** (Euler, 1765):
+    the squared distance between the circumcentre and incentre is R² − 2Rr. -/
+theorem euler_OI_formula (T : Triangle) :
+    dist2_sq T.circumcenter T.incenter =
+    T.circumradius ^ 2 - 2 * T.circumradius * T.inradius := by
+  rw [OI_sq_eq_R2_sub T, two_R_r_eq T, circumradius_sq T]
+
+/-- **Euler's inequality**:  R ≥ 2r, with the circumradius at least twice the
+    inradius.  Immediate from `euler_OI_formula` and the non-negativity of OI². -/
+theorem euler_inequality (T : Triangle) : 2 * T.inradius ≤ T.circumradius := by
+  have hOI : 0 ≤ dist2_sq T.circumcenter T.incenter := dist2_sq_nonneg _ _
+  rw [euler_OI_formula T] at hOI
+  have hR : 0 < T.circumradius := circumradius_pos T
+  nlinarith [hOI, hR]
+
+-- ============================================================
+-- PART 6: Worked example — the 3-4-5 right triangle
+-- ============================================================
+
+/-- For the 3-4-5 triangle, dist²(O, I) = 5/4, matching
+    R² − 2Rr = (5/2)² − 2·(5/2)·1 = 5/4. -/
+theorem triangle_345_OI_sq :
+    dist2_sq triangle_345.circumcenter triangle_345.incenter = 5 / 4 := by
+  rw [triangle_345_circumcenter, triangle_345_incenter]
+  unfold dist2_sq
+  norm_num
+
+/-- The 3-4-5 triangle satisfies Euler's formula concretely. -/
+theorem triangle_345_euler :
+    triangle_345.circumradius ^ 2 - 2 * triangle_345.circumradius * triangle_345.inradius
+      = 5 / 4 := by
+  rw [triangle_345_circumradius, triangle_345_inradius]
+  norm_num
+
+end FeuerbachEulerOI

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "feuerbachs-theorem-defs-oq-02",
+  "title": "Euler's Triangle Formula: OI² = R² − 2Rr and Euler's Inequality R ≥ 2r",
+  "slug": "feuerbachs-theorem-defs-oq-02",
+  "description": "Proves Euler's 1765 formula relating the circumcenter O and incenter I of a triangle: the squared distance OI² equals R² − 2Rr, where R is the circumradius and r the inradius. Since OI² ≥ 0 this forces Euler's inequality R ≥ 2r. Built from the coordinate API of FeuerbachsTheoremDefs.lean. 7 theorems (+ supporting lemmas), 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ02.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
+    "tags": [
+      "geometry",
+      "feuerbach",
+      "euler",
+      "circumcenter",
+      "incenter",
+      "circumradius",
+      "inradius",
+      "euler-inequality",
+      "law-of-sines",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the standard foundational axioms propext / Classical.choice / Quot.sound, which do not count as assumptions). Inherits the coordinate API (Triangle, circumcenter, incenter, circumradius, inradius, area, side lengths) and the non-degeneracy lemma circumcenter_denom_ne_zero from FeuerbachsTheoremDefs.lean, which is itself 0-sorry, 0-axiom.",
+    "lineCount": 386,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "originalContributions": [
+      "euler_OI_formula: Euler's theorem (1765) — dist²(O, I) = R² − 2·R·r for the circumcenter O and incenter I of an arbitrary non-degenerate triangle, the single most famous metric relation between the two centers",
+      "euler_inequality: Euler's inequality R ≥ 2·r (the circumradius is at least twice the inradius), an immediate corollary of the non-negativity of OI²",
+      "OI_sq_eq_R2_sub: the square-root-free affine core, dist²(O, I) = R² − abc/(a+b+c), obtained by collapsing the side-length-weighted incenter expansion with the three circumcenter equidistances",
+      "four_R_area_eq_abc: the law-of-sines/area identity 4·R·Area = abc (with the underlying squared coordinate identity 16·R²·Area² = a²b²c²), the bridge that turns abc/(a+b+c) into 2Rr",
+      "two_R_r_eq: 2·R·r = abc/(a+b+c), combining R = abc/(4·Area) with r = Area/s",
+      "weighted_norm_sq: the master algebraic identity |a(A−O)+b(B−O)+c(C−O)|² = R²(a+b+c)² − abc(a+b+c) driving the affine core",
+      "triangle_345_OI_sq / triangle_345_euler: worked example, dist²(O, I) = 5/4 = (5/2)² − 2·(5/2)·1 for the 3-4-5 right triangle"
+    ]
+  },
+  "overview": {
+    "historicalContext": "In 1765 Leonhard Euler discovered a remarkably clean relation between the two most important centers of a triangle. The circumcenter O is the center of the circumscribed circle (radius R), the incenter I is the center of the inscribed circle (radius r). Euler showed that the distance between them satisfies OI² = R² − 2Rr, equivalently OI² = R(R − 2r). Because a squared distance can never be negative, this single identity instantly proves Euler's inequality R ≥ 2r — the circumradius of any triangle is at least twice its inradius, with equality precisely for the equilateral triangle (when O and I coincide).\n\nThe gallery's FeuerbachsTheoremDefs.lean already defines the circumcenter, incenter, circumradius and inradius in coordinates and proves the nine-point circle / Feuerbach tangency results, but it never relates O and I to each other. This entry supplies that classical metric law.",
+    "problemStatement": "For a non-degenerate triangle with circumcenter O, incenter I, circumradius R, inradius r and side lengths a, b, c, prove\n$$\\lVert OI\\rVert^2 = R^2 - 2Rr,$$\nand deduce Euler's inequality $R \\ge 2r$.",
+    "text": "A 386-line companion file. After re-establishing the circumcenter equidistances |A−O| = |B−O| = |C−O| = R and the positivity of the side lengths and area, the proof factors Euler's formula into three independent pieces: (1) an affine core dist²(O,I) = R² − abc/(a+b+c) needing no square roots; (2) the law-of-sines area identity 4·R·Area = abc; and (3) the substitution 2Rr = abc/(a+b+c). Combining them yields OI² = R² − 2Rr, and the non-negativity of OI² gives R ≥ 2r. Closes with the 3-4-5 worked example.",
+    "proofStrategy": "Place the circumcenter O at the origin in spirit (work with the vectors A−O, B−O, C−O, each of squared length R²).\n- **Affine core** (`OI_sq_eq_R2_sub`): the incenter is the side-length-weighted average I = (a·A + b·B + c·C)/(a+b+c), so (a+b+c)(I−O) = a(A−O)+b(B−O)+c(C−O). Expanding its squared length and substituting the dot products (A−O)·(B−O) = R² − c²/2 (and cyclically), which follow from the equidistances, collapses everything to R²(a+b+c)² − abc(a+b+c). Dividing by (a+b+c)² gives R² − abc/(a+b+c). This is the lemma `weighted_norm_sq`, closed by a single `linear_combination`.\n- **Law of sines** (`four_R_area_eq_abc`): the squared identity 16·R²·Area² = a²b²c² is a polynomial identity in the six vertex coordinates (after substituting the explicit circumcenter formula and clearing denominators with `field_simp; ring`). Taking square roots — all quantities non-negative — yields 4·R·Area = abc, i.e. R = abc/(4·Area).\n- **Assembly**: r = Area/s = 2·Area/(a+b+c), so 2Rr = 4·R·Area/(a+b+c) = abc/(a+b+c). Substituting into the affine core gives R² − 2Rr.\n- **Inequality** (`euler_inequality`): OI² ≥ 0 and R² − 2Rr = R(R − 2r) with R > 0 force R − 2r ≥ 0 via `nlinarith`.",
+    "keyInsights": [
+      "Euler's formula is fundamentally an affine fact dressed in metric clothing: OI² = R² − abc/(a+b+c) needs only the circumcenter equidistances and the weighted-average form of the incenter — no square roots, no trigonometry.",
+      "The three dot products (A−O)·(B−O) = R² − c²/2 are the workhorses; each is half of |A−B|² = |A−O|² + |B−O|² − 2(A−O)·(B−O) with the two equidistances substituted.",
+      "The irrational side lengths a, b, c never need to be simplified individually: in the expansion the cross terms combine as ab·c² + bc·a² + ca·b² = abc(a+b+c), a pure ring identity, so the whole core closes with one linear_combination.",
+      "Connecting abc/(a+b+c) to 2Rr is exactly the law of sines R = abc/(4·Area); proving it as the squared coordinate identity 16·R²·Area² = a²b²c² sidesteps every square root until a single non-negativity argument at the end.",
+      "Euler's inequality R ≥ 2r is not proved by estimation — it is a free consequence of a squared distance being non-negative, the cleanest possible derivation."
+    ],
+    "prerequisites": [
+      "FeuerbachsTheoremDefs.lean — coordinate API (Point, Triangle, circumcenter, incenter, circumradius, inradius, area, side_a/b/c, dist2_sq) and circumcenter_denom_ne_zero",
+      "Circumcenter equidistance and the perpendicular-bisector characterization",
+      "The law of sines / triangle area formula R = abc/(4·Area)",
+      "field_simp / ring / linear_combination / nlinarith for polynomial identities over ℝ, and Real.sqrt lemmas (sqrt_sq, sqrt_mul, sq_sqrt)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Namespace Setup",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Module docstring stating Euler's formula and inequality, imports FeuerbachsTheoremDefs, opens the FeuerbachsTheorem namespace.",
+      "mathContext": "The coordinate API and the non-degeneracy lemma circumcenter_denom_ne_zero come from the parent file."
+    },
+    {
+      "id": "equidist",
+      "title": "Part I: Circumcenter Equidistance",
+      "startLine": 60,
+      "endLine": 108,
+      "summary": "Re-establishes the perpendicular-bisector relations and the squared equidistances |B−O|² = |A−O|² and |C−O|² = |A−O|² (the parent's are private).",
+      "mathContext": "The perpendicular bisector condition is linear in O, proven by field_simp; ring; the equidistances follow by nlinarith."
+    },
+    {
+      "id": "sides",
+      "title": "Part II: Positivity of Side Lengths and Area",
+      "startLine": 110,
+      "endLine": 184,
+      "summary": "Squared side lengths a² = |BC|² etc., non-negativity and strict positivity of each side, positivity of the area, and positivity of the perimeter.",
+      "mathContext": "Each side is positive because the three vertices are pairwise distinct (a coincidence would make the signed area vanish, contradicting non-degeneracy); the area is |det|/2 with det ≠ 0."
+    },
+    {
+      "id": "core",
+      "title": "Part III: The Affine Core OI² = R² − abc/(a+b+c)",
+      "startLine": 186,
+      "endLine": 251,
+      "summary": "The master identity |a(A−O)+b(B−O)+c(C−O)|² = R²(a+b+c)² − abc(a+b+c) and its consequence dist²(O,I) = R² − abc/(a+b+c).",
+      "mathContext": "weighted_norm_sq substitutes the three equidistances and three dot products via linear_combination; OI_sq_eq_R2_sub clears the (a+b+c)² denominator from the incenter."
+    },
+    {
+      "id": "lawsines",
+      "title": "Part IV: Law-of-Sines Bridge 4·R·Area = abc",
+      "startLine": 253,
+      "endLine": 327,
+      "summary": "The squared coordinate identity 16·R²·Area² = a²b²c², the circumradius-squared identity R² = |A−O|², and the square-root extraction giving 4·R·Area = abc.",
+      "mathContext": "16·R²·Area² = a²b²c² is a polynomial identity proven by substituting the circumcenter formula and field_simp; ring; the square root is taken via Real.sqrt_mul / Real.sqrt_sq with all quantities non-negative."
+    },
+    {
+      "id": "euler",
+      "title": "Part V: Euler's Formula and Inequality",
+      "startLine": 329,
+      "endLine": 360,
+      "summary": "two_R_r_eq (2Rr = abc/(a+b+c)), euler_OI_formula (OI² = R² − 2Rr), and euler_inequality (R ≥ 2r).",
+      "mathContext": "Substituting the law of sines into the affine core gives Euler's formula; the non-negativity of OI² then forces R ≥ 2r by nlinarith using R > 0."
+    },
+    {
+      "id": "example",
+      "title": "Part VI: Worked Example — the 3-4-5 Triangle",
+      "startLine": 362,
+      "endLine": 386,
+      "summary": "For the 3-4-5 right triangle, dist²(O, I) = 5/4, matching R² − 2Rr = (5/2)² − 2·(5/2)·1 = 5/4.",
+      "mathContext": "Uses the parent's computed circumcenter (3/2, 2), incenter (1, 1), circumradius 5/2 and inradius 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "Establishes Euler's 1765 triangle formula OI² = R² − 2Rr relating the circumcenter and incenter, and derives Euler's inequality R ≥ 2r as an immediate corollary of the non-negativity of OI². 7 theorems (plus supporting lemmas), 0 axioms, 0 sorries.",
+    "implications": "**Two centers, one law**: the parent file defined O, I, R and r independently; this entry binds them with the classical metric identity, completing the metric picture of the triangle's two principal circles.\n\n**Euler's inequality for free**: R ≥ 2r — one of the most quoted inequalities in triangle geometry — drops out without any estimation, purely from a squared distance being non-negative.\n\n**Reusable bridge**: the law-of-sines identity 4·R·Area = abc proved here is a standard fact useful across Euclidean-geometry formalizations.",
+    "openQuestions": [
+      "Prove the equality case: OI = 0 (equivalently R = 2r) holds iff the triangle is equilateral, using the affine core and the strict positivity of abc/(a+b+c) − minimization.",
+      "Establish the Euler formulae for the excenters, OIₐ² = R² + 2Rrₐ, relating the circumcenter to each excenter and excircle radius.",
+      "Derive the consequence that the incenter lies inside the circumcircle (OI < R) and quantify the gap OI² = R² − 2Rr in terms of the triangle's angles."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-defs",
+      "relationship": "extends",
+      "description": "uses the circumcenter, incenter, circumradius and inradius defined in FeuerbachsTheoremDefs.lean and relates them by Euler's formula"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-01",
+      "relationship": "related",
+      "description": "sibling slice deriving the defining lemmas of the altitude feet from the same coordinate API"
+    },
+    {
+      "targetId": "feuerbachs-theorem",
+      "relationship": "related",
+      "description": "the full Feuerbach theorem, whose nine-point circle is tangent to the incircle whose center I appears in Euler's formula"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Proofs.FeuerbachsTheoremDefs"],
+    "opens": ["FeuerbachsTheorem"],
+    "namespace": "FeuerbachEulerOI",
+    "lineCount": 386,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/FeuerbachsTheoremDefsOQ02.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "euler_OI_formula",
+      "type": "core",
+      "description": "Euler's triangle formula (1765): the squared distance between the circumcenter and incenter equals R² − 2Rr.",
+      "leanType": "∀ T : Triangle, dist2_sq T.circumcenter T.incenter = T.circumradius ^ 2 - 2 * T.circumradius * T.inradius"
+    },
+    {
+      "name": "euler_inequality",
+      "type": "core",
+      "description": "Euler's inequality: the circumradius is at least twice the inradius.",
+      "leanType": "∀ T : Triangle, 2 * T.inradius ≤ T.circumradius"
+    },
+    {
+      "name": "OI_sq_eq_R2_sub",
+      "type": "core",
+      "description": "The square-root-free affine core of Euler's formula.",
+      "leanType": "∀ T : Triangle, dist2_sq T.circumcenter T.incenter = |A − O|² − abc/(a+b+c)"
+    },
+    {
+      "name": "four_R_area_eq_abc",
+      "type": "lemma",
+      "description": "Law-of-sines / area identity bridging abc and the circumradius.",
+      "leanType": "∀ T : Triangle, 4 * T.circumradius * T.area = T.side_a * T.side_b * T.side_c"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Euler's Triangle Formula (Euler, 1765)

Proves the most famous metric relation between a triangle's two principal centers — the **circumcenter** O and the **incenter** I:

$$\lVert OI \rVert^2 = R^2 - 2Rr$$

where R is the circumradius and r the inradius. Because a squared distance is non-negative, this instantly yields **Euler's inequality**

$$R \ge 2r,$$

with equality iff the triangle is equilateral.

The grandparent `FeuerbachsTheoremDefs.lean` defines O, I, R, r in coordinates and proves the nine-point/Feuerbach results but never relates O and I to each other. This entry supplies that classical law.

## Structure (0 axioms, 0 sorries, 386 lines, 7 theorems + lemmas)

The proof factors into three independent pieces:

1. **Affine core** `OI_sq_eq_R2_sub` — `dist²(O,I) = R² − abc/(a+b+c)`, square-root-free. The incenter is the side-weighted average `I = (a·A+b·B+c·C)/(a+b+c)`; expanding `|I−O|²` and substituting the three circumcenter equidistances and dot products `(A−O)·(B−O) = R² − c²/2` collapses to `R²(a+b+c)² − abc(a+b+c)` (one `linear_combination`).
2. **Law of sines** `four_R_area_eq_abc` — `4·R·Area = abc`, via the squared coordinate identity `16·R²·Area² = a²b²c²` (`field_simp; ring`), then a single non-negativity square-root step.
3. **Assembly** `two_R_r_eq` — `2Rr = abc/(a+b+c)`, combining `R = abc/(4·Area)` with `r = Area/s`.

`euler_OI_formula` combines them; `euler_inequality` falls out of `OI² ≥ 0`. The 3-4-5 right triangle is worked out concretely (`OI² = 5/4 = (5/2)² − 2·(5/2)·1`).

Verified 0-axiom (`#print axioms` shows only `propext` / `Classical.choice` / `Quot.sound`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)