### PR TITLE
audit(feuerbachs-theorem-defs-oq-02): Euler OI²=R²−2Rr entry clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17659,6 +17659,12 @@
       "issues": [],
       "lastAudited": "2026-06-21T12:36:52Z",
       "result": "clean"
+    },
+    "feuerbachs-theorem-defs-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T12:45:16Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit: feuerbachs-theorem-defs-oq-02

Validated the sole unaudited gallery slug (merged via #27346).

**Source:** `Proofs/FeuerbachsTheoremDefsOQ02.lean`

| Field | meta.json | source | ✓ |
|---|---|---|---|
| lineCount | 386 | 386 | ✓ |
| theoremCount | 7 | 7 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| namespace | FeuerbachEulerOI | FeuerbachEulerOI | ✓ |
| imports | Proofs.FeuerbachsTheoremDefs | matches | ✓ |
| opens | FeuerbachsTheorem | matches | ✓ |

- No `sorry` / `admit` / `native_decide`.
- Parent dependency `FeuerbachsTheoremDefs.lean` confirmed 0-sorry / 0-axiom (inherited API is clean).
- `status: verified` / `badge: original` accurate for this 0-axiom original geometry derivation.

**Result: clean** — no metadata corrections needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)