### PR TITLE
research(fermat-two-squares-oq-01-oq-03-oq-01): discharge the Hurwitz Euclidean axiom — ℍ_ℤ is left-Euclidean [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2503,6 +2503,7 @@ import Proofs.FermatDefectOneOQ04
 import Proofs.FermatTwoSquares
 import Proofs.FermatTwoSquaresOQ01
 import Proofs.FermatTwoSquaresOQ01OQ03
+import Proofs.FermatTwoSquaresOQ01OQ03OQ01
 import Proofs.FermatTwoSquaresOQ05
 import Proofs.FermatsLastTheorem
 import Proofs.FermatsLastTheoremOQ03

--- a/proofs/Proofs/FermatTwoSquaresOQ01OQ03.lean
+++ b/proofs/Proofs/FermatTwoSquaresOQ01OQ03.lean
@@ -173,7 +173,7 @@ lemma hurwitz_normSq4_toQuat (q : HurwitzQuat) :
 theorem hurwitz_normSq_mul (q r : HurwitzQuat) :
     Quaternion.normSq (q.toQuat * r.toQuat) =
     Quaternion.normSq q.toQuat * Quaternion.normSq r.toQuat :=
-  Quaternion.normSq_mul q.toQuat r.toQuat
+  map_mul Quaternion.normSq q.toQuat r.toQuat
 
 /-- The scaled norm identity: normSq4(q) · normSq4(r) = 16 · normSq(q.toQuat · r.toQuat). -/
 theorem hurwitz_normSq4_mul_identity (q r : HurwitzQuat) :

--- a/proofs/Proofs/FermatTwoSquaresOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/FermatTwoSquaresOQ01OQ03OQ01.lean
@@ -1,0 +1,350 @@
+/-
+  Discharging the Hurwitz Euclidean Axiom
+  Open Question: fermat-two-squares-oq-01-oq-03-oq-01
+
+  The parent file `FermatTwoSquaresOQ01OQ03.lean` proves Lagrange's four-square
+  theorem via the Hurwitz quaternions, but assumes ONE axiom:
+
+      axiom hurwitz_euclidean :
+        ∀ (a b : HurwitzQuat), b.normSq > 0 →
+          ∃ (q r : HurwitzQuat),
+            a.toQuat = b.toQuat * q.toQuat + r.toQuat ∧ r.normSq < b.normSq
+
+  i.e. the Hurwitz integers admit *left Euclidean division* with strictly
+  decreasing norm.  The open question asks: can this be formalized in Lean 4
+  without new heavy machinery, just the elementary half-integer rounding
+  argument?  **Answer: YES.**  This file proves `hurwitz_euclidean` as a
+  THEOREM, with zero axioms (only propext / Classical.choice / Quot.sound).
+
+  ## The mathematical content
+
+  The crux is a *covering-radius* bound for the Hurwitz lattice:
+
+      For every rational quaternion x there is a Hurwitz integer q with
+          N(x - q) ≤ 1/2.
+
+  This is the single property the Lipschitz integers ℤ⟨1,i,j,k⟩ lack
+  (their covering radius² is 1, only ≤, giving N(r) ≤ N(b) — not strict).
+  Adjoining ω = ½(1+i+j+k) lets us round each coordinate either to the
+  nearest *integer* (giving an all-even Hurwitz point) or to the nearest
+  *half-integer* (giving an all-odd Hurwitz point), and one of the two
+  always has squared error ≤ 1/2.  Per coordinate,
+
+      (x - ⌊x⌉)² + (x - ½ - ⌊x - ½⌉)² ≤ 1/4,
+
+  so summing the four coordinates, the two squared errors total ≤ 1; hence
+  the smaller is ≤ 1/2 < 1.  Then for the left quotient x = b⁻¹·a we get a
+  Hurwitz q with N(a - b·q) = N(b)·N(x - q) ≤ N(b)/2 < N(b).
+
+  Beyond rounding we need the Hurwitz integers to be closed under
+  multiplication and subtraction (so that r = a - b·q is again Hurwitz);
+  these are proved here directly from the equal-parity coordinate condition.
+
+  References:
+  - Hurwitz (1896): Über die Zahlentheorie der Quaternionen
+  - Conway & Smith (2003): On Quaternions and Octonions, Ch. 5 (covering radius)
+-/
+
+import Mathlib.Algebra.Quaternion
+import Mathlib.Algebra.Order.Round
+import Mathlib.Tactic
+import Proofs.FermatTwoSquaresOQ01OQ03
+
+namespace FermatTwoSquaresOQ01OQ03OQ01
+
+open FermatTwoSquaresOQ01OQ03 Quaternion
+
+-- ============================================================================
+-- Part I: Norm bridge  ℤ ↔ ℚ
+-- ============================================================================
+
+/-- The integer Hurwitz norm equals the rational quaternion norm of the image:
+    `(N(q) : ℚ) = N(q.toQuat)`. -/
+theorem normSq_cast (q : HurwitzQuat) :
+    (q.normSq : ℚ) = Quaternion.normSq q.toQuat := by
+  have h4 : (q.normSq4 : ℚ) = 4 * Quaternion.normSq q.toQuat :=
+    hurwitz_normSq4_toQuat q
+  have hspec : (q.normSq : ℚ) * 4 = (q.normSq4 : ℚ) := by
+    exact_mod_cast (HurwitzQuat.normSq_spec q)
+  have : (q.normSq : ℚ) * 4 = 4 * Quaternion.normSq q.toQuat := by rw [hspec, h4]
+  linarith
+
+-- ============================================================================
+-- Part II: Closure of the Hurwitz integers under subtraction and multiplication
+-- ============================================================================
+
+/-- The Hurwitz integers are closed under subtraction:
+    there is a Hurwitz quaternion whose image is `a.toQuat - b.toQuat`. -/
+theorem hurwitz_sub_closed (a b : HurwitzQuat) :
+    ∃ c : HurwitzQuat, c.toQuat = a.toQuat - b.toQuat := by
+  refine ⟨⟨a.n₀ - b.n₀, a.n₁ - b.n₁, a.n₂ - b.n₂, a.n₃ - b.n₃, ?_⟩, ?_⟩
+  · obtain ⟨ha01, ha12, ha23⟩ := a.parity
+    obtain ⟨hb01, hb12, hb23⟩ := b.parity
+    refine ⟨?_, ?_, ?_⟩ <;> omega
+  · apply Quaternion.ext <;>
+      simp only [HurwitzQuat.toQuat, Quaternion.re_sub, Quaternion.imI_sub,
+        Quaternion.imJ_sub, Quaternion.imK_sub] <;>
+      push_cast <;> ring
+
+/-- The Hurwitz integers are closed under multiplication:
+    there is a Hurwitz quaternion whose image is `a.toQuat * b.toQuat`.
+
+    Proof: split on the parity of `a` and of `b` (each is all-even or
+    all-odd).  In each of the four cases substitute the explicit integer
+    halves and exhibit the product coordinates as integers; the parity
+    condition closes by `omega`, the coordinate identities by `ring`. -/
+theorem hurwitz_mul_closed (a b : HurwitzQuat) :
+    ∃ c : HurwitzQuat, c.toQuat = a.toQuat * b.toQuat := by
+  obtain ⟨ha01, ha12, ha23⟩ := a.parity
+  obtain ⟨hb01, hb12, hb23⟩ := b.parity
+  -- name the eight coordinates
+  rcases Int.emod_two_eq_zero_or_one a.n₀ with hA | hA <;>
+  rcases Int.emod_two_eq_zero_or_one b.n₀ with hB | hB
+  -- Case 1: a all even, b all even
+  · have ha1 : a.n₁ % 2 = 0 := ha01 ▸ hA
+    have ha2 : a.n₂ % 2 = 0 := ha12 ▸ ha1
+    have ha3 : a.n₃ % 2 = 0 := ha23 ▸ ha2
+    have hb1 : b.n₁ % 2 = 0 := hb01 ▸ hB
+    have hb2 : b.n₂ % 2 = 0 := hb12 ▸ hb1
+    have hb3 : b.n₃ % 2 = 0 := hb23 ▸ hb2
+    obtain ⟨a0, ha0⟩ := Int.dvd_of_emod_eq_zero hA
+    obtain ⟨a1, ha1'⟩ := Int.dvd_of_emod_eq_zero ha1
+    obtain ⟨a2, ha2'⟩ := Int.dvd_of_emod_eq_zero ha2
+    obtain ⟨a3, ha3'⟩ := Int.dvd_of_emod_eq_zero ha3
+    obtain ⟨c0, hc0⟩ := Int.dvd_of_emod_eq_zero hB
+    obtain ⟨c1, hc1⟩ := Int.dvd_of_emod_eq_zero hb1
+    obtain ⟨c2, hc2⟩ := Int.dvd_of_emod_eq_zero hb2
+    obtain ⟨c3, hc3⟩ := Int.dvd_of_emod_eq_zero hb3
+    refine ⟨⟨ 2*(a0*c0 - a1*c1 - a2*c2 - a3*c3),
+              2*(a0*c1 + a1*c0 + a2*c3 - a3*c2),
+              2*(a0*c2 - a1*c3 + a2*c0 + a3*c1),
+              2*(a0*c3 + a1*c2 - a2*c1 + a3*c0), ?_⟩, ?_⟩
+    · refine ⟨?_, ?_, ?_⟩ <;> omega
+    · apply Quaternion.ext <;>
+        simp only [HurwitzQuat.toQuat, Quaternion.re_mul, Quaternion.imI_mul,
+          Quaternion.imJ_mul, Quaternion.imK_mul] <;>
+        rw [ha0, ha1', ha2', ha3', hc0, hc1, hc2, hc3] <;>
+        push_cast <;> ring
+  -- Case 2: a all even, b all odd
+  · have ha1 : a.n₁ % 2 = 0 := ha01 ▸ hA
+    have ha2 : a.n₂ % 2 = 0 := ha12 ▸ ha1
+    have ha3 : a.n₃ % 2 = 0 := ha23 ▸ ha2
+    have hb1 : b.n₁ % 2 = 1 := hb01 ▸ hB
+    have hb2 : b.n₂ % 2 = 1 := hb12 ▸ hb1
+    have hb3 : b.n₃ % 2 = 1 := hb23 ▸ hb2
+    obtain ⟨a0, ha0⟩ := Int.dvd_of_emod_eq_zero hA
+    obtain ⟨a1, ha1'⟩ := Int.dvd_of_emod_eq_zero ha1
+    obtain ⟨a2, ha2'⟩ := Int.dvd_of_emod_eq_zero ha2
+    obtain ⟨a3, ha3'⟩ := Int.dvd_of_emod_eq_zero ha3
+    obtain ⟨c0, hc0⟩ : ∃ k : ℤ, b.n₀ = 2 * k + 1 := ⟨b.n₀ / 2, by omega⟩
+    obtain ⟨c1, hc1⟩ : ∃ k : ℤ, b.n₁ = 2 * k + 1 := ⟨b.n₁ / 2, by omega⟩
+    obtain ⟨c2, hc2⟩ : ∃ k : ℤ, b.n₂ = 2 * k + 1 := ⟨b.n₂ / 2, by omega⟩
+    obtain ⟨c3, hc3⟩ : ∃ k : ℤ, b.n₃ = 2 * k + 1 := ⟨b.n₃ / 2, by omega⟩
+    refine ⟨⟨ 2*(a0*c0 - a1*c1 - a2*c2 - a3*c3) + (a0 - a1 - a2 - a3),
+              2*(a0*c1 + a1*c0 + a2*c3 - a3*c2) + (a0 + a1 + a2 - a3),
+              2*(a0*c2 - a1*c3 + a2*c0 + a3*c1) + (a0 - a1 + a2 + a3),
+              2*(a0*c3 + a1*c2 - a2*c1 + a3*c0) + (a0 + a1 - a2 + a3), ?_⟩, ?_⟩
+    · refine ⟨?_, ?_, ?_⟩ <;> omega
+    · apply Quaternion.ext <;>
+        simp only [HurwitzQuat.toQuat, Quaternion.re_mul, Quaternion.imI_mul,
+          Quaternion.imJ_mul, Quaternion.imK_mul] <;>
+        rw [ha0, ha1', ha2', ha3', hc0, hc1, hc2, hc3] <;>
+        push_cast <;> ring
+  -- Case 3: a all odd, b all even
+  · have ha1 : a.n₁ % 2 = 1 := ha01 ▸ hA
+    have ha2 : a.n₂ % 2 = 1 := ha12 ▸ ha1
+    have ha3 : a.n₃ % 2 = 1 := ha23 ▸ ha2
+    have hb1 : b.n₁ % 2 = 0 := hb01 ▸ hB
+    have hb2 : b.n₂ % 2 = 0 := hb12 ▸ hb1
+    have hb3 : b.n₃ % 2 = 0 := hb23 ▸ hb2
+    obtain ⟨a0, ha0⟩ : ∃ k : ℤ, a.n₀ = 2 * k + 1 := ⟨a.n₀ / 2, by omega⟩
+    obtain ⟨a1, ha1'⟩ : ∃ k : ℤ, a.n₁ = 2 * k + 1 := ⟨a.n₁ / 2, by omega⟩
+    obtain ⟨a2, ha2'⟩ : ∃ k : ℤ, a.n₂ = 2 * k + 1 := ⟨a.n₂ / 2, by omega⟩
+    obtain ⟨a3, ha3'⟩ : ∃ k : ℤ, a.n₃ = 2 * k + 1 := ⟨a.n₃ / 2, by omega⟩
+    obtain ⟨c0, hc0⟩ := Int.dvd_of_emod_eq_zero hB
+    obtain ⟨c1, hc1⟩ := Int.dvd_of_emod_eq_zero hb1
+    obtain ⟨c2, hc2⟩ := Int.dvd_of_emod_eq_zero hb2
+    obtain ⟨c3, hc3⟩ := Int.dvd_of_emod_eq_zero hb3
+    refine ⟨⟨ 2*(a0*c0 - a1*c1 - a2*c2 - a3*c3) + (c0 - c1 - c2 - c3),
+              2*(a0*c1 + a1*c0 + a2*c3 - a3*c2) + (c1 + c0 + c3 - c2),
+              2*(a0*c2 - a1*c3 + a2*c0 + a3*c1) + (c2 - c3 + c0 + c1),
+              2*(a0*c3 + a1*c2 - a2*c1 + a3*c0) + (c3 + c2 - c1 + c0), ?_⟩, ?_⟩
+    · refine ⟨?_, ?_, ?_⟩ <;> omega
+    · apply Quaternion.ext <;>
+        simp only [HurwitzQuat.toQuat, Quaternion.re_mul, Quaternion.imI_mul,
+          Quaternion.imJ_mul, Quaternion.imK_mul] <;>
+        rw [ha0, ha1', ha2', ha3', hc0, hc1, hc2, hc3] <;>
+        push_cast <;> ring
+  -- Case 4: a all odd, b all odd
+  · have ha1 : a.n₁ % 2 = 1 := ha01 ▸ hA
+    have ha2 : a.n₂ % 2 = 1 := ha12 ▸ ha1
+    have ha3 : a.n₃ % 2 = 1 := ha23 ▸ ha2
+    have hb1 : b.n₁ % 2 = 1 := hb01 ▸ hB
+    have hb2 : b.n₂ % 2 = 1 := hb12 ▸ hb1
+    have hb3 : b.n₃ % 2 = 1 := hb23 ▸ hb2
+    obtain ⟨a0, ha0⟩ : ∃ k : ℤ, a.n₀ = 2 * k + 1 := ⟨a.n₀ / 2, by omega⟩
+    obtain ⟨a1, ha1'⟩ : ∃ k : ℤ, a.n₁ = 2 * k + 1 := ⟨a.n₁ / 2, by omega⟩
+    obtain ⟨a2, ha2'⟩ : ∃ k : ℤ, a.n₂ = 2 * k + 1 := ⟨a.n₂ / 2, by omega⟩
+    obtain ⟨a3, ha3'⟩ : ∃ k : ℤ, a.n₃ = 2 * k + 1 := ⟨a.n₃ / 2, by omega⟩
+    obtain ⟨c0, hc0⟩ : ∃ k : ℤ, b.n₀ = 2 * k + 1 := ⟨b.n₀ / 2, by omega⟩
+    obtain ⟨c1, hc1⟩ : ∃ k : ℤ, b.n₁ = 2 * k + 1 := ⟨b.n₁ / 2, by omega⟩
+    obtain ⟨c2, hc2⟩ : ∃ k : ℤ, b.n₂ = 2 * k + 1 := ⟨b.n₂ / 2, by omega⟩
+    obtain ⟨c3, hc3⟩ : ∃ k : ℤ, b.n₃ = 2 * k + 1 := ⟨b.n₃ / 2, by omega⟩
+    -- Each product coordinate cᵢ is even; we record half of it.
+    -- c₀ = (2a₀+1)(2c₀+1) - Σ ... ; here we give cᵢ/2 directly.
+    refine ⟨⟨ 2*(a0*c0 - a1*c1 - a2*c2 - a3*c3) + (a0 - a1 - a2 - a3)
+                + (c0 - c1 - c2 - c3) - 1,
+              2*(a0*c1 + a1*c0 + a2*c3 - a3*c2) + (a0 + a1 + a2 - a3)
+                + (c1 + c0 + c3 - c2) + 1,
+              2*(a0*c2 - a1*c3 + a2*c0 + a3*c1) + (a0 - a1 + a2 + a3)
+                + (c2 - c3 + c0 + c1) + 1,
+              2*(a0*c3 + a1*c2 - a2*c1 + a3*c0) + (a0 + a1 - a2 + a3)
+                + (c3 + c2 - c1 + c0) + 1, ?_⟩, ?_⟩
+    · refine ⟨?_, ?_, ?_⟩ <;> omega
+    · apply Quaternion.ext <;>
+        simp only [HurwitzQuat.toQuat, Quaternion.re_mul, Quaternion.imI_mul,
+          Quaternion.imJ_mul, Quaternion.imK_mul] <;>
+        rw [ha0, ha1', ha2', ha3', hc0, hc1, hc2, hc3] <;>
+        push_cast <;> ring
+
+-- ============================================================================
+-- Part III: The covering-radius rounding lemma
+-- ============================================================================
+
+/-- Per-coordinate covering bound: for any rational `x`, the squared distance
+    to the nearest integer plus the squared distance to the nearest
+    half-integer is at most `1/4`. -/
+theorem per_coord_bound (x : ℚ) :
+    (x - (round x : ℚ))^2 + ((x - 1/2) - (round (x - 1/2) : ℚ))^2 ≤ 1/4 := by
+  set δ : ℚ := x - (round x : ℚ) with hδdef
+  set ε : ℚ := (x - 1/2) - (round (x - 1/2) : ℚ) with hεdef
+  have hδ : |δ| ≤ 1/2 := abs_sub_round x
+  have hε : |ε| ≤ 1/2 := abs_sub_round (x - 1/2)
+  obtain ⟨hδl, hδr⟩ := abs_le.mp hδ
+  obtain ⟨hεl, hεr⟩ := abs_le.mp hε
+  set k : ℤ := round (x - 1/2) - round x with hkdef
+  have hrel : δ - ε = 1/2 + (k : ℚ) := by
+    rw [hδdef, hεdef, hkdef]; push_cast; ring
+  -- k ∈ {-1, 0}
+  have hk_lt1 : k < 1 := by
+    have : (k : ℚ) < 1 := by linarith
+    exact_mod_cast this
+  have hk_gtm2 : -2 < k := by
+    have : (-2 : ℚ) < (k : ℚ) := by linarith
+    exact_mod_cast this
+  have hk_le' : k ≤ 0 := by omega
+  have hk_ge' : -1 ≤ k := by omega
+  interval_cases k
+  · -- k = -1 : ε = δ + 1/2
+    have heq : ε = δ + 1/2 := by push_cast at hrel; linarith
+    have hδ0 : δ ≤ 0 := by linarith [hεr, heq]
+    rw [heq]
+    nlinarith [hδl, hδ0, mul_nonneg (by linarith : (0:ℚ) ≤ -δ) (by linarith : (0:ℚ) ≤ 2*δ+1)]
+  · -- k = 0 : ε = δ - 1/2
+    have heq : ε = δ - 1/2 := by push_cast at hrel; linarith
+    have hδ0 : 0 ≤ δ := by linarith [hεl, heq]
+    rw [heq]
+    nlinarith [hδr, hδ0, mul_nonneg (by linarith : (0:ℚ) ≤ δ) (by linarith : (0:ℚ) ≤ 1-2*δ)]
+
+/-- **Covering radius bound for the Hurwitz lattice.**  For every rational
+    quaternion `x` there is a Hurwitz integer `q` with `N(x - q.toQuat) ≤ 1/2`.
+
+    Round each coordinate either all to the nearest integer (an all-even, i.e.
+    Lipschitz, Hurwitz point) or all to the nearest half-integer (an all-odd
+    Hurwitz point); the smaller of the two total squared errors is ≤ 1/2. -/
+theorem exists_hurwitz_close (x : Quaternion ℚ) :
+    ∃ q : HurwitzQuat, Quaternion.normSq (x - q.toQuat) ≤ 1/2 := by
+  -- the integer-rounded Hurwitz point (all coordinates even)
+  set qI : HurwitzQuat :=
+    ⟨2 * round x.re, 2 * round x.imI, 2 * round x.imJ, 2 * round x.imK,
+      by refine ⟨?_, ?_, ?_⟩ <;> omega⟩ with hqI
+  -- the half-integer-rounded Hurwitz point (all coordinates odd)
+  set qH : HurwitzQuat :=
+    ⟨2 * round (x.re - 1/2) + 1, 2 * round (x.imI - 1/2) + 1,
+      2 * round (x.imJ - 1/2) + 1, 2 * round (x.imK - 1/2) + 1,
+      by refine ⟨?_, ?_, ?_⟩ <;> omega⟩ with hqH
+  -- squared errors, computed coordinate-wise
+  have eI : Quaternion.normSq (x - qI.toQuat) =
+      (x.re - round x.re)^2 + (x.imI - round x.imI)^2
+        + (x.imJ - round x.imJ)^2 + (x.imK - round x.imK)^2 := by
+    rw [hqI, Quaternion.normSq_def']
+    simp only [HurwitzQuat.toQuat, Quaternion.re_sub, Quaternion.imI_sub,
+      Quaternion.imJ_sub, Quaternion.imK_sub]
+    push_cast; ring
+  have eH : Quaternion.normSq (x - qH.toQuat) =
+      ((x.re - 1/2) - round (x.re - 1/2))^2 + ((x.imI - 1/2) - round (x.imI - 1/2))^2
+        + ((x.imJ - 1/2) - round (x.imJ - 1/2))^2 + ((x.imK - 1/2) - round (x.imK - 1/2))^2 := by
+    rw [hqH, Quaternion.normSq_def']
+    simp only [HurwitzQuat.toQuat, Quaternion.re_sub, Quaternion.imI_sub,
+      Quaternion.imJ_sub, Quaternion.imK_sub]
+    push_cast; ring
+  -- the two squared errors sum to ≤ 1
+  have hsum : Quaternion.normSq (x - qI.toQuat) + Quaternion.normSq (x - qH.toQuat) ≤ 1 := by
+    rw [eI, eH]
+    have b0 := per_coord_bound x.re
+    have b1 := per_coord_bound x.imI
+    have b2 := per_coord_bound x.imJ
+    have b3 := per_coord_bound x.imK
+    linarith
+  -- pick the smaller
+  by_cases hcase : Quaternion.normSq (x - qI.toQuat) ≤ 1/2
+  · exact ⟨qI, hcase⟩
+  · exact ⟨qH, by linarith⟩
+
+-- ============================================================================
+-- Part IV: Discharging the Euclidean axiom
+-- ============================================================================
+
+/-- **The Hurwitz integers form a (left) Euclidean ring** — this is the
+    statement declared as `axiom hurwitz_euclidean` in the parent file, now
+    proved as a theorem.
+
+    Given `a, b` with `N(b) > 0`, set `x = b⁻¹·a` in `ℍ(ℚ)`, round it to a
+    Hurwitz integer `q` with `N(x - q) ≤ 1/2`, and let `r = a - b·q` (Hurwitz
+    by closure).  Then
+        `N(r) = N(b·(x - q)) = N(b)·N(x - q) ≤ N(b)/2 < N(b).` -/
+theorem hurwitz_euclidean_thm :
+    ∀ (a b : HurwitzQuat), b.normSq > 0 →
+      ∃ (q r : HurwitzQuat),
+        a.toQuat = b.toQuat * q.toQuat + r.toQuat ∧ r.normSq < b.normSq := by
+  intro a b hb
+  -- b.toQuat ≠ 0
+  have hbQ : Quaternion.normSq b.toQuat > 0 := by
+    rw [← normSq_cast b]; exact_mod_cast hb
+  have hbne : b.toQuat ≠ 0 := by
+    intro h; rw [h] at hbQ; simp at hbQ
+  -- round the left quotient x = b⁻¹ * a
+  set x : Quaternion ℚ := b.toQuat⁻¹ * a.toQuat with hxdef
+  obtain ⟨q, hq⟩ := exists_hurwitz_close x
+  -- r = a - b*q  is Hurwitz
+  obtain ⟨bq, hbq⟩ := hurwitz_mul_closed b q
+  obtain ⟨r, hr⟩ := hurwitz_sub_closed a bq
+  have hr' : r.toQuat = a.toQuat - b.toQuat * q.toQuat := by rw [hr, hbq]
+  refine ⟨q, r, ?_, ?_⟩
+  · -- a = b*q + r  (additive identity in the noncommutative ring)
+    rw [hr']; abel
+  · -- N(r) < N(b)
+    -- r.toQuat = b.toQuat * (x - q.toQuat)
+    have hfactor : r.toQuat = b.toQuat * (x - q.toQuat) := by
+      rw [hr', hxdef, mul_sub, mul_inv_cancel_left₀ hbne]
+    have hnorm : Quaternion.normSq r.toQuat
+        = Quaternion.normSq b.toQuat * Quaternion.normSq (x - q.toQuat) := by
+      rw [hfactor, map_mul]
+    have hbound : Quaternion.normSq r.toQuat ≤ Quaternion.normSq b.toQuat * (1/2) := by
+      rw [hnorm]
+      exact mul_le_mul_of_nonneg_left hq (le_of_lt hbQ)
+    -- transfer to ℤ
+    have hrlt : (r.normSq : ℚ) < (b.normSq : ℚ) := by
+      rw [normSq_cast r, normSq_cast b]
+      have : Quaternion.normSq b.toQuat * (1/2) < Quaternion.normSq b.toQuat := by
+        nlinarith [hbQ]
+      linarith [hbound]
+    exact_mod_cast hrlt
+
+-- A sanity check that the discharged statement matches the parent axiom's type.
+example : ∀ (a b : HurwitzQuat), b.normSq > 0 →
+    ∃ (q r : HurwitzQuat),
+      a.toQuat = b.toQuat * q.toQuat + r.toQuat ∧ r.normSq < b.normSq :=
+  hurwitz_euclidean_thm
+
+end FermatTwoSquaresOQ01OQ03OQ01

--- a/src/data/proofs/fermat-two-squares-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/fermat-two-squares-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-norm-bridge",
+    "proofId": "fermat-two-squares-oq-01-oq-03-oq-01",
+    "range": { "startLine": 63, "endLine": 70 },
+    "type": "concept",
+    "title": "Bridging the Integer and Rational Norms",
+    "content": "`normSq_cast` proves (N(q) : ℚ) = Quaternion.normSq q.toQuat, identifying the integer Hurwitz norm with the rational quaternion norm of the embedded point. It follows from the parent's `hurwitz_normSq4_toQuat` (normSq4 cast = 4·N(toQuat)) and `normSq_spec` (normSq·4 = normSq4). This bridge is what lets the final norm inequality, naturally living in ℚ, be transferred back to the integer statement N(r) < N(b)."
+  },
+  {
+    "id": "ann-mul-closure",
+    "proofId": "fermat-two-squares-oq-01-oq-03-oq-01",
+    "range": { "startLine": 96, "endLine": 208 },
+    "type": "technique",
+    "title": "Closure under Multiplication via a Four-Way Parity Split",
+    "content": "The remainder r = a − b·q must itself be a Hurwitz integer, so the Hurwitz integers must be closed under multiplication. `hurwitz_mul_closed` proves this directly: split each of a and b into all-even (Lipschitz) or all-odd (half-integer) parity, giving four cases. In each, the product's doubled coordinates are written explicitly in the form 2·W + (linear), where W collects the nonlinear cross terms. Writing them this way is essential: it lets `omega` verify the equal-parity condition (the 2·W part is even, so parity is decided by the linear part), while `ring` verifies the coordinate identities against Mathlib's quaternion multiplication formulas (`re_mul`, `imI_mul`, …)."
+  },
+  {
+    "id": "ann-per-coord",
+    "proofId": "fermat-two-squares-oq-01-oq-03-oq-01",
+    "range": { "startLine": 217, "endLine": 247 },
+    "type": "key-step",
+    "title": "The Complementary-Rounding Inequality",
+    "content": "`per_coord_bound` shows that for any rational x, the squared distance to the nearest integer plus the squared distance to the nearest half-integer is at most ¼: (x − ⌊x⌉)² + ((x − ½) − ⌊x − ½⌉)² ≤ ¼. The proof writes both offsets δ and ε via `round`, notes |δ|, |ε| ≤ ½ (`abs_sub_round`), and shows their integer difference k = round(x − ½) − round(x) lies in {−1, 0} from δ − ε = ½ + k. In each case ε = δ ± ½, and a one-line `nlinarith` with the product (∓δ)(2δ ± 1) ≥ 0 closes the bound. Summed over four coordinates, the integer- and half-integer-roundings have squared errors totalling ≤ 1."
+  },
+  {
+    "id": "ann-covering-radius",
+    "proofId": "fermat-two-squares-oq-01-oq-03-oq-01",
+    "range": { "startLine": 255, "endLine": 293 },
+    "type": "concept",
+    "title": "Covering Radius² ≤ ½: Why ℍ_ℤ Is Euclidean",
+    "content": "`exists_hurwitz_close` builds two candidate Hurwitz integers for a rational quaternion x: qI rounds every coordinate to the nearest integer (an all-even, i.e. Lipschitz, point) and qH rounds every coordinate to the nearest half-integer (an all-odd point). By `per_coord_bound`, N(x − qI) + N(x − qH) ≤ 1, so whichever is smaller is ≤ ½. This is exactly the covering-radius² ≤ ½ statement for the Hurwitz (D₄*) lattice. The Lipschitz lattice alone has covering radius² = 1 (the deep hole ½(1+i+j+k) sits at squared-distance 1), which is why adjoining ω is what makes Euclidean division strict."
+  },
+  {
+    "id": "ann-discharge",
+    "proofId": "fermat-two-squares-oq-01-oq-03-oq-01",
+    "range": { "startLine": 306, "endLine": 343 },
+    "type": "key-step",
+    "title": "Assembling the Euclidean Division",
+    "content": "`hurwitz_euclidean_thm` proves the parent's axiom verbatim. With N(b) > 0, b.toQuat is a unit in the division ring ℍ(ℚ); set x = b⁻¹·a and round it to a Hurwitz q with N(x − q) ≤ ½. Closure gives a Hurwitz r with r.toQuat = a.toQuat − b.toQuat·q.toQuat, and the key factorization r.toQuat = b.toQuat·(x − q.toQuat) yields N(r) = N(b)·N(x − q) ≤ N(b)/2 < N(b) by norm multiplicativity (`map_mul`). The strict inequality is immediate from ½ < 1 — no boundary 'equality impossible' argument is needed. A closing `example` checks the statement matches the axiom's type exactly."
+  }
+]

--- a/src/data/proofs/fermat-two-squares-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "fermat-two-squares-oq-01-oq-03-oq-01",
+  "slug": "fermat-two-squares-oq-01-oq-03-oq-01",
+  "parent": "fermat-two-squares-oq-01-oq-03",
+  "title": "Discharging the Hurwitz Euclidean Axiom: ℍ_ℤ Is Left-Euclidean (Covering Radius² ≤ ½)",
+  "description": "The parent's Hurwitz-quaternion proof of Lagrange's four-square theorem assumed one axiom — that the Hurwitz integers admit left Euclidean division with strictly decreasing norm. This entry discharges that axiom as a 0-axiom theorem using only the elementary covering-radius rounding argument: every rational quaternion is within squared-distance ½ of a Hurwitz integer, because rounding each coordinate either all-to-the-nearest-integer or all-to-the-nearest-half-integer yields two squared errors summing to ≤ 1, so the smaller is ≤ ½ < 1.",
+  "overview": {
+    "problemStatement": "Open question fermat-two-squares-oq-01-oq-03-oq-01 asks: can the `hurwitz_euclidean` axiom of the parent entry — for all Hurwitz quaternions a and b with N(b) > 0, there exist Hurwitz q, r with a = b·q + r and N(r) < N(b) — be fully formalized in Lean 4 without new heavy machinery, just the half-integer rounding argument? The answer is YES: this file proves it as a theorem depending only on propext, Classical.choice, Quot.sound.",
+    "historicalContext": "Hurwitz (1896) observed that adjoining ω = ½(1+i+j+k) to the Lipschitz integers ℤ⟨1,i,j,k⟩ turns the non-Euclidean Lipschitz order into a left-Euclidean ring. Geometrically, the Lipschitz lattice (the D₄ lattice) has covering radius² = 1, so a deep hole such as ½(1+i+j+k) is at squared-distance exactly 1 from its nearest lattice points — division gives only N(r) ≤ N(b), not strict. The Hurwitz lattice D₄* has covering radius² = ½ < 1, restoring strict Euclidean division. Conway & Smith (2003, Ch. 5) give the modern lattice account.",
+    "keyInsights": [
+      "The single property the Lipschitz integers lack is a covering radius² < 1; Hurwitz integers achieve ≤ ½.",
+      "Per coordinate, (x − ⌊x⌉)² + (x − ½ − ⌊x − ½⌉)² ≤ ¼: the squared distances to the nearest integer and to the nearest half-integer are complementary.",
+      "Summing the four coordinates, the all-integer and all-half-integer roundings have squared errors totalling ≤ 1, so one of them is ≤ ½.",
+      "For the left quotient x = b⁻¹·a, the rounded q gives N(a − b·q) = N(b)·N(x − q) ≤ N(b)/2 < N(b).",
+      "The remainder r = a − b·q is again a Hurwitz integer because the Hurwitz integers are closed under multiplication and subtraction — proved here directly from the equal-parity coordinate condition by a four-way parity split."
+    ],
+    "prerequisites": [
+      "Quaternion arithmetic over ℚ (Mathlib's `Quaternion ℚ`), its norm `Quaternion.normSq` as a `MonoidWithZeroHom`, and its division-ring structure",
+      "The integer `round : ℚ → ℤ` and `abs_sub_round : |x − round x| ≤ 1/2`",
+      "The parent's `HurwitzQuat` structure (equal-parity integer coordinates), `toQuat`, `normSq`, and the bridge `hurwitz_normSq4_toQuat`"
+    ],
+    "proofStrategy": "Build three pieces and assemble. (1) A norm bridge `normSq_cast`: the integer Hurwitz norm equals the rational quaternion norm of the image. (2) Closure: the Hurwitz integers are closed under subtraction (parity is preserved coordinatewise) and under multiplication (split a and b each into all-even / all-odd parity; in each of the four cases give the product's doubled coordinates explicitly in 2·W + linear form so that parity closes by `omega` and the coordinate identities by `ring`). (3) The covering bound `exists_hurwitz_close`: round all-to-integer or all-to-half-integer and pick the smaller squared error, ≤ ½ by the per-coordinate bound. Finally `hurwitz_euclidean_thm` sets x = b⁻¹·a, rounds to q, takes r = a − b·q (Hurwitz by closure), and bounds N(r) = N(b)·N(x − q) ≤ N(b)/2 < N(b).",
+    "text": "This entry converts the parent's `axiomatized` Hurwitz proof of Lagrange's four-square theorem into a verified one on the Euclidean-division front: the lone axiom is now a theorem. It also un-bit-rots the parent (whose `hurwitz_normSq_mul` referenced the removed `Quaternion.normSq_mul`; it now uses `map_mul`)."
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "File header explaining the open question and the covering-radius argument. Imports Mathlib.Algebra.Quaternion, Mathlib.Algebra.Order.Round, Mathlib.Tactic, and the parent FermatTwoSquaresOQ01OQ03 (reusing its HurwitzQuat structure, toQuat, normSq, normSq4, and norm bridge). Opens the parent namespace and Quaternion.",
+      "mathContext": "The Hurwitz integers ℍ_ℤ are the half-integer quaternions with all four coordinates of equal parity; toQuat embeds them into ℍ(ℚ), where Mathlib supplies a multiplicative norm and a division ring."
+    },
+    {
+      "id": "norm-bridge",
+      "title": "Part I — Norm Bridge ℤ ↔ ℚ",
+      "startLine": 57,
+      "endLine": 71,
+      "summary": "normSq_cast: the integer Hurwitz norm cast to ℚ equals Quaternion.normSq of the image, (N(q) : ℚ) = N(q.toQuat). Derived from the parent's hurwitz_normSq4_toQuat and normSq_spec.",
+      "mathContext": "N(q) = normSq4(q)/4 with normSq4 = n₀²+n₁²+n₂²+n₃², and (normSq4 : ℚ) = 4·N(q.toQuat); dividing gives the bridge."
+    },
+    {
+      "id": "closure",
+      "title": "Part II — Closure under Subtraction and Multiplication",
+      "startLine": 72,
+      "endLine": 209,
+      "summary": "hurwitz_sub_closed: the image of a Hurwitz integer minus another is a Hurwitz integer (parity preserved by omega). hurwitz_mul_closed: the product of two Hurwitz images is a Hurwitz image, by splitting each factor into all-even / all-odd parity and exhibiting the product's doubled coordinates in 2·W + linear form (parity by omega, coordinate identities by ring after the quaternion multiplication formulas).",
+      "mathContext": "The Hurwitz integers form a maximal order (a ring); the four-case parity computation is exactly the statement that the equal-parity condition is preserved by Hamilton multiplication."
+    },
+    {
+      "id": "covering-radius",
+      "title": "Part III — The Covering-Radius Rounding Lemma",
+      "startLine": 210,
+      "endLine": 293,
+      "summary": "per_coord_bound: for any rational x, (x − round x)² + ((x − ½) − round(x − ½))² ≤ ¼, proved by bounding the integer offset between the two roundings to {−1, 0} and a short nlinarith. exists_hurwitz_close: for any rational quaternion x there is a Hurwitz q with N(x − q.toQuat) ≤ ½, by comparing the all-integer and all-half-integer roundings whose squared errors sum to ≤ 1.",
+      "mathContext": "This is the covering-radius² ≤ ½ statement for the Hurwitz (D₄*) lattice — the geometric heart of why ℍ_ℤ, unlike the Lipschitz integers, is Euclidean."
+    },
+    {
+      "id": "discharge",
+      "title": "Part IV — Discharging the Euclidean Axiom",
+      "startLine": 294,
+      "endLine": 350,
+      "summary": "hurwitz_euclidean_thm: the exact statement of the parent's axiom, now a theorem. Sets x = b⁻¹·a, rounds it to a Hurwitz q with N(x − q) ≤ ½, takes r = a − b·q (Hurwitz by closure), and shows N(r) = N(b)·N(x − q) ≤ N(b)/2 < N(b). A closing `example` confirms the discharged statement matches the axiom's type verbatim.",
+      "mathContext": "Left Euclidean division: a = b·q + r with N(r) < N(b). Strictness comes for free from ½ < 1, so no boundary 'equality impossible' argument is needed."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent's `hurwitz_euclidean` axiom is proved as a 0-axiom theorem (only propext, Classical.choice, Quot.sound), using the elementary covering-radius rounding argument and a direct proof that the Hurwitz integers are closed under multiplication and subtraction. The answer to the open question is YES — no algebraic-topology / EuclideanLattice machinery is required, only coordinate rounding and a parity case split.",
+    "implications": [
+      "The Hurwitz route to Lagrange's four-square theorem can be made fully verified: combined with the parent's remaining (already 0-sorry) infrastructure, the only assumption blocking a from-scratch algebraic proof is removed on the Euclidean-division front.",
+      "The covering-radius² ≤ ½ bound is exhibited concretely as a finite per-coordinate inequality, isolating precisely the geometric fact that distinguishes the Hurwitz lattice from the Lipschitz lattice.",
+      "Confirms that the standard textbook half-integer rounding proof formalizes directly, without invoking Mathlib's lattice covering-radius API."
+    ],
+    "openQuestions": [
+      "Can the closure-under-multiplication proof be replaced by equipping HurwitzQuat with a full `CommRing`-compatible (noncommutative) ring instance, so that subtraction and multiplication closure become instance lemmas rather than a four-case parity split?",
+      "Does the same coordinate-rounding template discharge the analogous Euclidean property for the Hurwitz–Coxeter octonion integers (the E₈ lattice, covering radius² = 1), and if so does the boundary case (radius exactly 1) require the 'equality impossible for prime norm' refinement that the quaternion case avoids?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fermat-two-squares-oq-01-oq-03",
+      "relationship": "discharges-axiom",
+      "description": "Proves the parent's sole axiom `hurwitz_euclidean` (left Euclidean division in ℍ_ℤ) as a 0-axiom theorem, and un-bit-rots the parent's `hurwitz_normSq_mul` (replacing the removed `Quaternion.normSq_mul` with `map_mul`)."
+    },
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "extends",
+      "description": "The dimension-4 analogue of the Gaussian-integer Euclidean argument behind Fermat's two-square theorem: the same covering-radius technique, with the Hurwitz lattice D₄* playing the role of ℤ[i]."
+    },
+    {
+      "targetId": "lagrange-four-squares",
+      "relationship": "supports",
+      "description": "Removes the single assumption in the Hurwitz-quaternion route to Lagrange's four-square theorem, complementing the descent-based proof in lagrange-four-squares."
+    }
+  ],
+  "references": [
+    {
+      "title": "Über die Zahlentheorie der Quaternionen",
+      "author": "A. Hurwitz",
+      "year": "1896"
+    },
+    {
+      "title": "On Quaternions and Octonions, Chapter 5 (covering radii of quaternionic lattices)",
+      "author": "J. H. Conway and D. A. Smith",
+      "year": "2003"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.Quaternion",
+      "Mathlib.Algebra.Order.Round",
+      "Mathlib.Tactic",
+      "Proofs.FermatTwoSquaresOQ01OQ03"
+    ],
+    "opens": [
+      "FermatTwoSquaresOQ01OQ03",
+      "Quaternion"
+    ],
+    "namespace": "FermatTwoSquaresOQ01OQ03OQ01",
+    "lineCount": 350,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/FermatTwoSquaresOQ01OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hurwitz_quaternion",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "quaternions",
+      "four-squares",
+      "euclidean-domain",
+      "hurwitz",
+      "covering-radius",
+      "axiom-discharge",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FermatTwoSquaresOQ01OQ03OQ01.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "abs_sub_round",
+        "description": "|x − round x| ≤ 1/2 for the integer-rounding function on ℚ",
+        "module": "Mathlib.Algebra.Order.Round"
+      },
+      {
+        "theorem": "Quaternion.normSq",
+        "description": "The quaternion norm as a MonoidWithZeroHom, giving map_mul (norm multiplicativity)",
+        "module": "Mathlib.Algebra.Quaternion"
+      },
+      {
+        "theorem": "mul_inv_cancel_left₀",
+        "description": "a ≠ 0 → a * (a⁻¹ * b) = b in a group with zero (used for b·(b⁻¹·a) = a)",
+        "module": "Mathlib.Algebra.GroupWithZero.Defs"
+      }
+    ],
+    "originalContributions": [
+      "hurwitz_euclidean_thm: a 0-axiom proof of the parent's left-Euclidean-division axiom for the Hurwitz integers",
+      "exists_hurwitz_close: the covering-radius² ≤ ½ bound for the Hurwitz lattice via all-integer vs all-half-integer coordinate rounding",
+      "per_coord_bound: the per-coordinate complementary-rounding inequality (x − ⌊x⌉)² + (x − ½ − ⌊x − ½⌉)² ≤ ¼",
+      "hurwitz_mul_closed and hurwitz_sub_closed: direct proofs that the Hurwitz integers are closed under multiplication and subtraction, from the equal-parity condition",
+      "normSq_cast: the bridge identifying the integer Hurwitz norm with the rational quaternion norm",
+      "Drive-by fix un-bit-rotting the parent: hurwitz_normSq_mul now uses map_mul instead of the removed Quaternion.normSq_mul"
+    ],
+    "dateAdded": "2026-06-21",
+    "lineCount": 350,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext, Classical.choice, Quot.sound are used (verified via #print axioms hurwitz_euclidean_thm). No native_decide / Lean.ofReduceBool and no sorryAx. The HurwitzQuat structure, toQuat, normSq and the normSq4 bridge are reused from the parent entry (also 0-axiom).",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers open question **fermat-two-squares-oq-01-oq-03-oq-01**: *"Can the `hurwitz_euclidean` axiom be fully formalized in Lean 4 using the half-integer rounding argument, or does it need new machinery?"* — **YES, with only elementary coordinate rounding.**

The parent entry (`fermat-two-squares-oq-01-oq-03`) proves Lagrange's four-square theorem via the Hurwitz quaternions but assumes one axiom: ℍ_ℤ admits **left Euclidean division** with strictly decreasing norm. This PR proves that axiom as a **theorem**, `hurwitz_euclidean_thm`, depending only on `propext / Classical.choice / Quot.sound` (verified via `#print axioms` — no `sorryAx`, no `Lean.ofReduceBool`).

## Mathematical content — covering radius² ≤ ½

- **`per_coord_bound`**: `(x − ⌊x⌉)² + (x − ½ − ⌊x − ½⌉)² ≤ ¼` — the squared distances from a rational to the nearest integer and to the nearest half-integer are complementary (the integer offset between the two roundings is `−1` or `0`).
- **`exists_hurwitz_close`**: every rational quaternion is within squared-distance ½ of a Hurwitz integer, by rounding all coordinates to the nearest integer (an all-even / Lipschitz point) **or** all to the nearest half-integer (an all-odd point); the two squared errors total ≤ 1, so the smaller is ≤ ½ < 1. This is exactly the property the Lipschitz integers lack (their covering radius² = 1, the deep hole ½(1+i+j+k)).
- **`hurwitz_euclidean_thm`**: for the left quotient `x = b⁻¹·a`, the rounded `q` gives `N(a − b·q) = N(b)·N(x − q) ≤ N(b)/2 < N(b)`. Strictness is free from ½ < 1 — no boundary "equality impossible" argument needed.

## Supporting infrastructure

- **`hurwitz_mul_closed` / `hurwitz_sub_closed`**: the Hurwitz integers are closed under multiplication and subtraction (so `r = a − b·q` is again Hurwitz), proved directly from the equal-parity coordinate condition by a four-way parity split, with product coordinates written in `2·W + linear` form (parity by `omega`, identities by `ring` against Mathlib's quaternion multiplication formulas).
- **`normSq_cast`**: bridges the integer Hurwitz norm and the rational quaternion norm so the ℚ-valued inequality transfers to `N(r) < N(b)` over ℤ.

## Stats

- 6 theorems, 0 defs, **350 lines, 0 sorries, 0 axioms** (`verified`).
- `#print axioms hurwitz_euclidean_thm` → `[propext, Classical.choice, Quot.sound]`.

## Drive-by parent fix

The parent file was **bit-rotted** on the current toolchain (Lean v4.26.0 / current Mathlib): its `hurwitz_normSq_mul` referenced the removed `Quaternion.normSq_mul`. Replaced with `map_mul Quaternion.normSq` (one line). The parent retains its `hurwitz_euclidean` axiom (its `axiomCount` stays 1); this entry supplies the independent 0-axiom discharge.

## Verification

`./proofs/scripts/docker-build.sh Proofs.FermatTwoSquaresOQ01OQ03OQ01` → `Build succeeded` (3066/3066 jobs). Axiom check captured before removing the temporary `#print axioms` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)