### PR TITLE
audit(fermat-two-squares-oq-01-oq-03-oq-01): Hurwitz Euclidean discharge clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17665,6 +17665,12 @@
       "lastAudited": "2026-06-21T12:45:16Z",
       "result": "clean",
       "issues": []
+    },
+    "fermat-two-squares-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T12:53:55Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Deep audit of the newest gallery slug `fermat-two-squares-oq-01-oq-03-oq-01` (added by PR #27349 — the Hurwitz left-Euclidean covering-radius discharge).

## Verified against `Proofs/FermatTwoSquaresOQ01OQ03OQ01.lean`
- **350 lines, 6 theorems, 0 defs, 0 axioms, 0 sorries** — all match meta.json
- namespace `FermatTwoSquaresOQ01OQ03OQ01` matches actual declarations
- no `native_decide` / `Lean.ofReduceBool`; `status: verified` / `badge: verified` correct
- `hurwitz_euclidean_thm` matches the parent's `hurwitz_euclidean` axiom type **verbatim** (closing `example` confirms) — genuinely discharges the parent's sole axiom as a 0-axiom theorem
- parent un-bit-rot present: `hurwitz_normSq_mul` now uses `map_mul` (was the removed `Quaternion.normSq_mul`)

The lone `admit` grep hit (line 13) is docstring prose ("admit *left Euclidean division*"), not a tactic.

**Result: clean.** Queue drained 2822/2822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)