### PR TITLE
research(simson-line-theorem-oq-01-oq-01): Simson-line angle-doubling — lines rotate at half angular speed [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3169,6 +3169,7 @@ import Proofs.ShapleyFolkmanAristotle
 import Proofs.ShapleyFolkmanOQ01
 import Proofs.ShapleyFolkmanOQ03
 import Proofs.SimsonLineTheorem
+import Proofs.SimsonLineTheoremOQ01OQ01
 import Proofs.SkolemNoetherCSA
 import Proofs.SkolemNoetherMatrixAut
 import Proofs.SkolemNoetherMatrixAutAristotle

--- a/proofs/Proofs/SimsonLineTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/SimsonLineTheoremOQ01OQ01.lean
@@ -1,0 +1,194 @@
+import Mathlib.Tactic
+import Proofs.SimsonLineTheorem
+
+/-!
+# Simson lines rotate at half angular speed — the angle-doubling theorem
+  (simson-line-theorem-oq-01-oq-01)
+
+The parent entry `simson-line-theorem-oq-01` proves Simson's theorem (the feet of the
+perpendiculars from a circumcircle point `P` onto the side-lines of `△ABC` are collinear),
+together with several classical strengthenings. One of them is the special fact that the Simson
+lines of **antipodal** points `P` and `-P` are **perpendicular** (`antipodal_simson_perp`).
+
+This entry settles the **sharp generalisation** that the antipodal fact is a single instance of:
+as `P` traverses the circumcircle, its Simson line rotates at **half** `P`'s angular speed — the
+angle between the Simson lines of `P` and `Q` is exactly half the central angle of the arc `PQ`.
+Antipodal points (`Q = -P`) subtend a half-arc of `90°`, recovering perpendicularity.
+
+## The coordinate model and the direction vector
+
+Reusing the parent's model (circumcircle = unit circle, `Complex.normSq · = 1`), the Simson line of
+`p` is spanned by `D p := foot b c p - foot a b p`, which `foot_diff` puts in closed form
+`(c - a) * (1 - b * conj p) / 2`. On the unit circle (`conj p = p⁻¹`) this simplifies to
+
+    D p = (c - a) * (p - b) / (2 p).                                   (`simson_direction`)
+
+## Why squaring is the right invariant
+
+A line's direction is only defined up to a real scalar, so its angle lives in `ℝ / πℤ`. The naive
+Hermitian product `D p * conj (D q)` still depends on the triangle (through `b`). **Squaring**
+removes that ambiguity: working with `D p ^ 2` lifts the angle to `ℝ / 2πℤ`, and the triangle
+dependence cancels. Concretely, the master identity is the *exact* closed form
+
+    (D p)² · p · conj((D q)² · q) = |c - a|⁴ · |p - b|² · |q - b|² / 16,   (`simson_angle_doubling`)
+
+a manifestly **nonnegative real**. A positive-real value has argument `0 (mod 2π)`, which says
+
+    2·arg(D p / D q) - arg(q / p) ≡ 0 (mod 2π),   i.e.   arg(D p / D q) ≡ ½·arg(q / p) (mod π):
+
+the angle between the two Simson lines is half the arc `PQ`. Realness alone would only pin this down
+mod `π/2`; the nonnegativity (not merely realness) of the right-hand side is what makes the encoding
+*faithful*. Two corollaries read this off: the product is real (`simson_hermitian_real`) and
+nonnegative (`simson_hermitian_nonneg`).
+
+Specialising to `q = -p` recovers the parent's perpendicularity result
+(`antipodal_perp_recovered`): the squared form forces `(D p · conj (D (-p)))²` to be a nonpositive
+real, hence `D p · conj (D (-p))` is purely imaginary — exactly perpendicularity of the two lines.
+
+The proof is fully machine-checked: no axioms, no `sorry`. The engine is the parent's
+`foot_diff` plus `conj z = z⁻¹` on the unit circle, after which every identity is a rational-function
+fact closed by `field_simp; ring`.
+-/
+
+namespace SimsonLineTheoremOQ01OQ01
+
+open Complex ComplexConjugate
+open SimsonLineTheorem (foot foot_diff)
+
+/-- A point on the unit circle is nonzero. -/
+private lemma ne_zero_of_normSq_one {z : ℂ} (h : Complex.normSq z = 1) : z ≠ 0 := by
+  rintro rfl; simp at h
+
+/-- On the unit circle, `conj z = z⁻¹`. -/
+private lemma conj_eq_inv {z : ℂ} (h : Complex.normSq z = 1) : conj z = z⁻¹ := by
+  have h0 : z ≠ 0 := ne_zero_of_normSq_one h
+  have hzz : z * conj z = 1 := by rw [Complex.mul_conj, h]; norm_num
+  rw [inv_eq_one_div, eq_div_iff h0]
+  linear_combination hzz
+
+/-- If `conj z = z` then `z` is real, so `z.im = 0`. -/
+private lemma im_eq_zero_of_conj_eq {z : ℂ} (h : conj z = z) : z.im = 0 := by
+  have h1 : (conj z).im = z.im := by rw [h]
+  rw [Complex.conj_im] at h1
+  linarith
+
+/-- If `conj z = -z` then `z` is purely imaginary, so `z.re = 0`. -/
+private lemma re_eq_zero_of_conj_eq_neg {z : ℂ} (h : conj z = -z) : z.re = 0 := by
+  have h1 : (conj z).re = (-z).re := by rw [h]
+  rw [Complex.conj_re, Complex.neg_re] at h1
+  linarith
+
+/-- **Closed form of the Simson direction.** For `p` on the unit circle, the direction vector
+`D p = foot b c p - foot a b p` of the Simson line of `p` equals `(c - a)(p - b)/(2p)`. This is the
+parent's `foot_diff` with the conjugate eliminated via `conj p = p⁻¹`; it exposes how the direction
+depends on `p` (through the single linear factor `p - b`, divided by `p`). -/
+theorem simson_direction {a b c p : ℂ} (hp : Complex.normSq p = 1) :
+    foot b c p - foot a b p = (c - a) * (p - b) / (2 * p) := by
+  have hp0 := ne_zero_of_normSq_one hp
+  rw [foot_diff, conj_eq_inv hp]
+  field_simp
+
+/-- **Angle-doubling master identity.** For `A, B, C, P, Q` on the unit circle, the squared Simson
+directions satisfy the *exact* closed form
+
+    (D P)² · P · conj((D Q)² · Q) = |C - A|⁴ · |P - B|² · |Q - B|² / 16,
+
+where `D X = foot b c X - foot a b X`. The right-hand side is a manifestly **nonnegative real**, so
+the left-hand side has argument `0 (mod 2π)`; equivalently the Simson line of `P` makes with that of
+`Q` an angle equal to half the central angle of the arc `PQ`. (Squaring the directions is what lifts
+the line-angle to `mod 2π` and cancels the triangle's dependence on `B`.) -/
+theorem simson_angle_doubling {a b c p q : ℂ}
+    (ha : Complex.normSq a = 1) (hb : Complex.normSq b = 1)
+    (hc : Complex.normSq c = 1) (hp : Complex.normSq p = 1) (hq : Complex.normSq q = 1) :
+    (foot b c p - foot a b p) ^ 2 * p * conj ((foot b c q - foot a b q) ^ 2 * q)
+      = ((Complex.normSq (c - a) ^ 2 * Complex.normSq (p - b) * Complex.normSq (q - b) / 16 : ℝ) :
+          ℂ) := by
+  have ha0 := ne_zero_of_normSq_one ha
+  have hb0 := ne_zero_of_normSq_one hb
+  have hc0 := ne_zero_of_normSq_one hc
+  have hp0 := ne_zero_of_normSq_one hp
+  have hq0 := ne_zero_of_normSq_one hq
+  have hca : ((Complex.normSq (c - a) : ℝ) : ℂ) = (c - a) * conj (c - a) :=
+    (Complex.mul_conj _).symm
+  have hpb : ((Complex.normSq (p - b) : ℝ) : ℂ) = (p - b) * conj (p - b) :=
+    (Complex.mul_conj _).symm
+  have hqb : ((Complex.normSq (q - b) : ℝ) : ℂ) = (q - b) * conj (q - b) :=
+    (Complex.mul_conj _).symm
+  rw [foot_diff, foot_diff]
+  push_cast
+  rw [hca, hpb, hqb]
+  simp only [map_mul, map_sub, map_pow, map_div₀, map_one, map_ofNat, Complex.conj_conj]
+  rw [conj_eq_inv ha, conj_eq_inv hb, conj_eq_inv hc, conj_eq_inv hp, conj_eq_inv hq]
+  field_simp
+  ring
+
+/-- **The angle-doubling Hermitian product is real.** Immediate from `simson_angle_doubling`: the
+right-hand side is a real number, so the squared-direction Hermitian product has vanishing imaginary
+part. -/
+theorem simson_hermitian_real {a b c p q : ℂ}
+    (ha : Complex.normSq a = 1) (hb : Complex.normSq b = 1)
+    (hc : Complex.normSq c = 1) (hp : Complex.normSq p = 1) (hq : Complex.normSq q = 1) :
+    ((foot b c p - foot a b p) ^ 2 * p * conj ((foot b c q - foot a b q) ^ 2 * q)).im = 0 := by
+  rw [simson_angle_doubling ha hb hc hp hq, Complex.ofReal_im]
+
+/-- **The angle-doubling Hermitian product is nonnegative.** The real part of the squared-direction
+Hermitian product equals `|c - a|⁴ |p - b|² |q - b|² / 16 ≥ 0`. Together with `simson_hermitian_real`
+this pins the product to the nonnegative real axis — the faithful (mod `2π`) form of angle-doubling
+that mere realness could not provide. -/
+theorem simson_hermitian_nonneg {a b c p q : ℂ}
+    (ha : Complex.normSq a = 1) (hb : Complex.normSq b = 1)
+    (hc : Complex.normSq c = 1) (hp : Complex.normSq p = 1) (hq : Complex.normSq q = 1) :
+    0 ≤ ((foot b c p - foot a b p) ^ 2 * p * conj ((foot b c q - foot a b q) ^ 2 * q)).re := by
+  rw [simson_angle_doubling ha hb hc hp hq, Complex.ofReal_re]
+  apply div_nonneg _ (by norm_num : (0 : ℝ) ≤ 16)
+  exact mul_nonneg (mul_nonneg (sq_nonneg _) (Complex.normSq_nonneg _)) (Complex.normSq_nonneg _)
+
+/-- **The antipodal-perpendicularity theorem is the `Q = -P` instance.** Specialising the master
+identity to `Q = -P` forces `(D P · conj (D (-P)))²` to be a nonpositive real, so `D P · conj (D (-P))`
+is purely imaginary: the Simson lines of `P` and its antipode `-P` are perpendicular. This recovers
+the parent's `antipodal_simson_perp` as a corollary of angle-doubling (half-arc `= 90°`). -/
+theorem antipodal_perp_recovered {a b c p : ℂ}
+    (ha : Complex.normSq a = 1) (hb : Complex.normSq b = 1)
+    (hc : Complex.normSq c = 1) (hp : Complex.normSq p = 1) :
+    ((foot b c p - foot a b p) * conj (foot b c (-p) - foot a b (-p))).re = 0 := by
+  have hp0 := ne_zero_of_normSq_one hp
+  have hq : Complex.normSq (-p) = 1 := by rwa [Complex.normSq_neg]
+  -- abbreviations for the two direction vectors
+  set Dp := foot b c p - foot a b p with hDp
+  set Dm := foot b c (-p) - foot a b (-p) with hDm
+  -- master identity at `q = -p`
+  have H := simson_angle_doubling (a := a) (b := b) (c := c) (p := p) (q := -p) ha hb hc hp hq
+  rw [← hDp, ← hDm] at H
+  -- rewrite the master LHS as `-(Dp * conj Dm)² * (p * conj p)`
+  have hpp : p * conj p = 1 := by rw [Complex.mul_conj, hp]; norm_num
+  have e : Dp ^ 2 * p * conj (Dm ^ 2 * -p) = -(Dp * conj Dm) ^ 2 * (p * conj p) := by
+    rw [map_mul, map_pow, map_neg]; ring
+  rw [e, hpp, mul_one] at H
+  -- so `(Dp * conj Dm)² = ↑(-R)`, a nonpositive real
+  set Y := Dp * conj Dm with hY
+  set R : ℝ := Complex.normSq (c - a) ^ 2 * Complex.normSq (p - b) * Complex.normSq (-p - b) / 16
+    with hR
+  have hYsq : Y ^ 2 = ((-R : ℝ) : ℂ) := by push_cast; linear_combination -H
+  -- `Y² = conj (Y²)`, hence `(conj Y)² = Y²`
+  have hreal : conj (Y ^ 2) = Y ^ 2 := by rw [hYsq, Complex.conj_ofReal]
+  have hsq : (conj Y) ^ 2 = Y ^ 2 := by rw [← map_pow]; exact hreal
+  -- factor the difference of squares
+  have hfac : (conj Y - Y) * (conj Y + Y) = 0 := by linear_combination hsq
+  rcases mul_eq_zero.mp hfac with h1 | h2
+  · -- `conj Y = Y`: `Y` is real with `Y² = -R ≤ 0`, forcing `Y = 0`
+    have hYeq : conj Y = Y := sub_eq_zero.mp h1
+    have hRnn : 0 ≤ R := by
+      rw [hR]
+      apply div_nonneg _ (by norm_num : (0 : ℝ) ≤ 16)
+      exact mul_nonneg (mul_nonneg (sq_nonneg _) (Complex.normSq_nonneg _))
+        (Complex.normSq_nonneg _)
+    have him : Y.im = 0 := im_eq_zero_of_conj_eq hYeq
+    -- take real parts of `Y² = ↑(-R)`
+    have hre : Y.re ^ 2 - Y.im ^ 2 = -R := by
+      have := congrArg Complex.re hYsq
+      simpa [pow_two, Complex.mul_re, Complex.ofReal_re] using this
+    nlinarith [sq_nonneg Y.re, hRnn, him, hre]
+  · -- `conj Y = -Y`: `Y` is purely imaginary, i.e. perpendicularity
+    exact re_eq_zero_of_conj_eq_neg (eq_neg_of_add_eq_zero_left h2)
+
+end SimsonLineTheoremOQ01OQ01

--- a/src/data/proofs/simson-line-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/simson-line-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "simson-line-theorem-oq-01-oq-01",
+  "title": "Simson Lines Rotate at Half Angular Speed (Angle-Doubling)",
+  "slug": "simson-line-theorem-oq-01-oq-01",
+  "description": "The sharp generalisation of the parent's antipodal-perpendicularity result: as a point P traverses the circumcircle of a triangle, its Simson line rotates at exactly half P's angular speed, so the angle between the Simson lines of P and Q equals half the central angle of arc PQ. Captured as an exact, manifestly nonnegative-real closed form for the squared-direction Hermitian product. Antipodal points (Q = -P) subtend a 90° half-arc, recovering perpendicularity.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SimsonLineTheoremOQ01OQ01.lean",
+    "additionalFiles": [
+      "Proofs/SimsonLineTheorem.lean"
+    ],
+    "tags": [
+      "geometry",
+      "triangle",
+      "simson-line",
+      "circumcircle",
+      "angle-doubling",
+      "perpendicularity",
+      "complex-coordinates",
+      "classic",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the standard foundational axioms propext / Classical.choice / Quot.sound, which do not count as assumptions). Reuses the closed-form perpendicular foot `foot` and its difference identity `foot_diff` from the parent SimsonLineTheorem.lean (itself 0-sorry, 0-axiom); the unit-circle helper lemmas (conj z = z⁻¹, the real/imaginary bridges) are re-derived locally. Circumcircle normalised to the unit circle (Complex.normSq = 1) without loss of generality.",
+    "lineCount": 194,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "simson_angle_doubling: the master angle-doubling identity (D P)²·P·conj((D Q)²·Q) = |C−A|⁴·|P−B|²·|Q−B|²/16, where D X = foot bc X − foot ab X is the Simson direction. The right-hand side is a manifestly nonnegative real, so the left-hand side has argument 0 (mod 2π), i.e. 2·arg(D P / D Q) ≡ arg(Q/P): the Simson line of P makes with that of Q an angle equal to half the central angle of arc PQ",
+      "Squaring the direction is the key device: a line's direction is defined only up to a real scalar (angle in ℝ/πℤ), but squaring lifts it to ℝ/2πℤ and cancels the triangle's dependence on the auxiliary vertex B — this is why the squared Hermitian product, not the raw one, is triangle-independent",
+      "Faithfulness via nonnegativity, not mere realness: realness of the product alone would pin the angle only mod π/2; it is the nonnegativity of |C−A|⁴|P−B|²|Q−B|²/16 that pins it mod π, faithfully encoding angle-doubling",
+      "simson_direction: closed form D P = (C−A)(P−B)/(2P) on the unit circle, obtained from the parent's foot_diff by eliminating the conjugate via conj P = P⁻¹; exposes that the direction depends on P through the single linear factor P−B divided by P",
+      "simson_hermitian_real and simson_hermitian_nonneg: the squared-direction Hermitian product is real (imaginary part 0) and nonnegative (real part = |C−A|⁴|P−B|²|Q−B|²/16 ≥ 0), the two halves that pin it to the nonnegative real axis",
+      "antipodal_perp_recovered: specialising the master identity to Q = −P forces (D P · conj (D (−P)))² to be a nonpositive real, hence D P · conj (D (−P)) is purely imaginary — the parent's antipodal_simson_perp recovered as the half-arc = 90° instance of angle-doubling, proved by a difference-of-squares case split (conj Y = ±Y)"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "simson_angle_doubling",
+      "type": "core",
+      "description": "Angle-doubling master identity: the squared-direction Hermitian product of the Simson lines of P and Q is the nonnegative real |C−A|⁴·|P−B|²·|Q−B|²/16, so the angle between the two Simson lines is half the central angle of arc PQ.",
+      "leanType": "(foot b c p - foot a b p)^2 * p * conj ((foot b c q - foot a b q)^2 * q) = ↑(normSq (c-a)^2 * normSq (p-b) * normSq (q-b) / 16)"
+    },
+    {
+      "name": "simson_direction",
+      "type": "lemma",
+      "description": "Closed form of the Simson direction vector on the unit circumcircle.",
+      "leanType": "∀ {a b c p : ℂ}, normSq p = 1 → foot b c p - foot a b p = (c - a) * (p - b) / (2 * p)"
+    },
+    {
+      "name": "simson_hermitian_nonneg",
+      "type": "corollary",
+      "description": "The squared-direction Hermitian product is a nonnegative real — the faithful (mod 2π) form of angle-doubling.",
+      "leanType": "0 ≤ ((foot b c p - foot a b p)^2 * p * conj ((foot b c q - foot a b q)^2 * q)).re"
+    },
+    {
+      "name": "antipodal_perp_recovered",
+      "type": "corollary",
+      "description": "The parent's antipodal-perpendicularity theorem recovered as the Q = -P (half-arc = 90°) instance of angle-doubling.",
+      "leanType": "((foot b c p - foot a b p) * conj (foot b c (-p) - foot a b (-p))).re = 0"
+    }
+  ],
+  "sections": [
+    {
+      "title": "Unit-Circle Algebra",
+      "startLine": 59,
+      "endLine": 83,
+      "description": "Re-derived helper lemmas: a unit-circle point is nonzero, conj z = z⁻¹ on the unit circle, and the real/imaginary bridges (conj z = z ⟹ im = 0, conj z = −z ⟹ re = 0).",
+      "summary": "Unit-Circle Algebra",
+      "id": "unit-circle-algebra"
+    },
+    {
+      "title": "Closed Form of the Simson Direction",
+      "startLine": 85,
+      "endLine": 98,
+      "description": "simson_direction: D P = foot bc P − foot ab P = (C−A)(P−B)/(2P) on the unit circle, from the parent's foot_diff with the conjugate eliminated.",
+      "summary": "Closed Form of the Simson Direction",
+      "id": "simson-direction"
+    },
+    {
+      "title": "Angle-Doubling Master Identity",
+      "startLine": 100,
+      "endLine": 148,
+      "description": "simson_angle_doubling: the exact closed form (D P)²·P·conj((D Q)²·Q) = |C−A|⁴|P−B|²|Q−B|²/16, a nonnegative real, encoding that the Simson line rotates at half P's angular speed. Corollaries simson_hermitian_real (im = 0) and simson_hermitian_nonneg (re ≥ 0) pin it to the nonnegative real axis.",
+      "summary": "Angle-Doubling Master Identity",
+      "id": "angle-doubling"
+    },
+    {
+      "title": "Recovering Antipodal Perpendicularity",
+      "startLine": 150,
+      "endLine": 193,
+      "description": "antipodal_perp_recovered: specialising to Q = −P makes (D P · conj (D (−P)))² a nonpositive real, so D P · conj (D (−P)) is purely imaginary — perpendicularity, the half-arc = 90° case, proved by a difference-of-squares case split.",
+      "summary": "Recovering Antipodal Perpendicularity",
+      "id": "antipodal-recovery"
+    }
+  ],
+  "overview": {
+    "historicalContext": "As a point P traverses the circumcircle of a triangle, its Simson line is not static: it sweeps out a one-parameter family whose envelope is the Steiner deltoid. A classical and striking feature of this motion is that the Simson line turns at exactly HALF the angular rate of P. Equivalently, the angle between the Simson lines of two points P and Q equals half the central angle of the arc PQ. The most famous instance — that the Simson lines of two diametrically opposite (antipodal) points are perpendicular — is the half-arc of a 180° diameter, giving 90°. The parent entry formalized that special antipodal case; this entry settles the full angle-doubling law of which it is a single instance.",
+    "problemStatement": "**Simson-line angle-doubling**: Let A, B, C, P, Q lie on a common circle. As P moves on the circle, the direction of its Simson line with respect to △ABC rotates at half the angular speed of P. Equivalently, the angle between the Simson line of P and the Simson line of Q equals one half of the central angle subtended by the arc PQ. The antipodal-perpendicularity theorem (Simson lines of P and -P are perpendicular) is the case Q = -P.",
+    "text": "The Simson line of a point on the circumcircle rotates at half the angular speed of the point; the angle between the Simson lines of two points is half the arc between them.",
+    "proofStrategy": "Working in the parent's model (circumcircle = unit circle, encoded by Complex.normSq · = 1), the Simson line of p is spanned by the direction vector D p = foot b c p − foot a b p, which the parent's foot_diff puts in closed form (c−a)(1 − b·conj p)/2; on the unit circle this is (c−a)(p−b)/(2p) (simson_direction).\n\nA line's direction is only defined up to a real scalar, so its angle lives in ℝ/πℤ; the naive Hermitian product D p · conj (D q) still depends on the triangle through the vertex b. **Squaring** the directions removes both problems at once: it lifts the angle to ℝ/2πℤ and cancels the b-dependence. The exact computation gives the master identity\n\n  (D p)² · p · conj((D q)² · q) = |c−a|⁴ · |p−b|² · |q−b|² / 16   (simson_angle_doubling),\n\nproved by substituting conj z = z⁻¹ on the unit circle and clearing denominators (field_simp; ring), with the squared moduli on the right re-expressed through Complex.mul_conj. Because the right-hand side is a manifestly nonnegative real (simson_hermitian_nonneg), the left-hand side has argument 0 mod 2π, i.e. 2·arg(D p / D q) ≡ arg(q/p): angle-doubling. (Realness alone, simson_hermitian_real, would only give the result mod π/2; nonnegativity is what makes it faithful.)\n\nSpecialising to q = −p, the identity forces (D p · conj (D (−p)))² to equal a nonpositive real; a difference-of-squares case split on conj Y = ±Y (Y = D p · conj (D (−p))) then shows Y is purely imaginary, recovering the parent's antipodal_simson_perp (antipodal_perp_recovered).",
+    "keyInsights": [
+      "**Square the direction**: a line's direction is defined only up to a real scalar (angle in ℝ/πℤ); squaring lifts the angle to ℝ/2πℤ and simultaneously cancels the triangle's dependence on the auxiliary vertex b, making the squared Hermitian product triangle-independent",
+      "**Exact nonnegative-real closed form**: (D p)²·p·conj((D q)²·q) = |c−a|⁴|p−b|²|q−b|²/16 — the geometric angle-doubling is encoded as a single algebraic identity whose right-hand side is patently ≥ 0",
+      "**Nonnegativity, not realness, is the faithful encoding**: a real value would pin the angle only mod π/2; the nonnegativity of the closed form pins it mod π, which is exactly half-arc angle-doubling for lines",
+      "**Antipodal perpendicularity is one instance**: at q = -p the half-arc is 90°; the master identity collapses to (D p · conj (D (-p)))² being a nonpositive real, hence the product is purely imaginary — perpendicularity",
+      "**Reuse the parent engine**: the whole result rides on the parent's foot_diff plus conj z = z⁻¹, with no new geometric machinery — only the algebraic insight that squaring is the right invariant"
+    ],
+    "prerequisites": [
+      "Complex numbers and arithmetic in ℂ",
+      "Complex conjugation and modulus (normSq), with the unit-circle identity conj z = z⁻¹",
+      "Simson's theorem and the closed-form perpendicular foot (parent entry simson-line-theorem-oq-01)",
+      "The interpretation of arg of a Hermitian product as the angle between two directed lines"
+    ],
+    "openQuestions": [
+      "Can the angle-doubling law be packaged as an honest statement about Complex.arg (the directed angle between the two Simson lines equals half the directed arc), rather than the algebraic nonnegative-real surrogate used here? This needs careful handling of arg's branch cut and the degenerate cases p = b, q = b.",
+      "Angle-doubling is the infinitesimal mechanism behind the Steiner deltoid (the envelope of all Simson lines): can the half-speed rotation be integrated into a formalization of the deltoid envelope?"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Simson-line angle-doubling law is formalized as an exact algebraic identity in complex coordinates: with the circumcircle normalised to the unit circle, the squared-direction Hermitian product (D p)²·p·conj((D q)²·q) of the Simson lines of P and Q equals the nonnegative real |c−a|⁴|p−b|²|q−b|²/16. Nonnegativity (not mere realness) pins the relative angle to half the central angle of arc PQ — the statement that the Simson line rotates at half P's angular speed. Squaring the direction is the decisive device: it lifts the line-angle to mod 2π and cancels the dependence on the auxiliary vertex. The parent's antipodal-perpendicularity theorem is recovered as the Q = -P instance. All steps reuse the parent's foot_diff with the conj z = z⁻¹ substitution; no axioms, no sorries.",
+    "implications": "**Theoretical Significance**: The result shows the leverage of the unit-circle complex model extends from static incidence facts (collinearity, the converse) to a kinematic statement about how the Simson line MOVES, and it unifies the previously isolated antipodal-perpendicularity result as a single case of a continuous angle-doubling law. The squaring trick — promoting a direction defined mod π to a vector defined mod 2π so that a triangle-dependent quantity becomes invariant — is a reusable pattern for encoding line angles algebraically without invoking Complex.arg.",
+    "openQuestions": [
+      "Can the law be restated directly in terms of Complex.arg (directed angle = half directed arc), handling arg's branch cut and the degenerate cases?",
+      "Can the half-speed rotation be integrated into a formalization of the Steiner deltoid, the envelope of all Simson lines?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "simson-line-theorem-oq-01",
+      "relationship": "parent",
+      "description": "Generalises the parent's antipodal_simson_perp (Simson lines of P and -P are perpendicular) to the full angle-doubling law; reuses the parent's foot and foot_diff"
+    },
+    {
+      "targetId": "napoleons-theorem",
+      "relationship": "related",
+      "description": "Both reduce a classical triangle theorem to a complex-coordinate identity using rotations/conjugation on the circle"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.SimsonLineTheorem"
+    ],
+    "opens": [
+      "Complex",
+      "ComplexConjugate"
+    ],
+    "namespace": "SimsonLineTheoremOQ01OQ01",
+    "lineCount": 194,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/SimsonLineTheoremOQ01OQ01.lean",
+    "additionalFiles": [
+      "Proofs/SimsonLineTheorem.lean"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Sharp **generalisation** of the parent entry's antipodal-perpendicularity result (`antipodal_simson_perp`): as a point `P` traverses the circumcircle of `△ABC`, its **Simson line rotates at exactly half `P`'s angular speed**. Equivalently, the angle between the Simson lines of `P` and `Q` is half the central angle of arc `PQ`. The diametrically-opposite case `Q = -P` (half-arc `= 90°`) recovers perpendicularity as a single instance of this continuous law.

New child of [`simson-line-theorem-oq-01`](../tree/main/src/data/proofs/simson-line-theorem-oq-01), reusing that entry's unit-circle complex model and its `foot` / `foot_diff`.

## Mathematical content

The Simson direction is `D p = foot b c p − foot a b p`; on the unit circle `simson_direction` gives `D p = (c−a)(p−b)/(2p)`.

A line's direction is defined only up to a real scalar (angle mod π), and the raw Hermitian product `D p · conj (D q)` still depends on the triangle through vertex `b`. **Squaring** the direction lifts the angle to mod 2π and cancels the `b`-dependence, yielding the exact master identity (`simson_angle_doubling`):

```
(D p)² · p · conj((D q)² · q) = |c−a|⁴ · |p−b|² · |q−b|² / 16
```

— a manifestly **nonnegative real**. Nonnegativity (not mere realness, which would only pin the angle mod π/2) is what faithfully encodes angle-doubling. The argument-0-mod-2π of the LHS says `2·arg(D p / D q) ≡ arg(q/p)`.

## Theorems (5, all 0-axiom / 0-sorry)

| Theorem | Statement |
|---|---|
| `simson_direction` | `D p = (c−a)(p−b)/(2p)` on the unit circle |
| `simson_angle_doubling` | the master identity above |
| `simson_hermitian_real` | the squared-direction Hermitian product has `im = 0` |
| `simson_hermitian_nonneg` | its `re ≥ 0` (pins it to the nonnegative real axis) |
| `antipodal_perp_recovered` | the parent's `antipodal_simson_perp` recovered as the `q = -p` case |

## Verification

- `./proofs/scripts/docker-build.sh Proofs.SimsonLineTheoremOQ01OQ01` — builds clean.
- `#print axioms` on all five theorems: only `propext / Classical.choice / Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). **0 axioms, 0 sorries.**
- 194 lines, 5 theorems, 0 definitions. Every identity discharged by `conj z = z⁻¹` + `field_simp` + `ring`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)