### PR TITLE
research(fermat-two-squares-oq-04): Jacobi divisor-character sum δ(n)=∑χ₄(d) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2505,6 +2505,7 @@ import Proofs.FermatTwoSquares
 import Proofs.FermatTwoSquaresOQ01
 import Proofs.FermatTwoSquaresOQ01OQ03
 import Proofs.FermatTwoSquaresOQ01OQ03OQ01
+import Proofs.FermatTwoSquaresOQ04
 import Proofs.FermatTwoSquaresOQ05
 import Proofs.FermatsLastTheorem
 import Proofs.FermatsLastTheoremOQ03

--- a/proofs/Proofs/FermatTwoSquaresOQ04.lean
+++ b/proofs/Proofs/FermatTwoSquaresOQ04.lean
@@ -1,0 +1,225 @@
+/-
+  Jacobi's Two-Square Theorem — the divisor-character sum side
+  Open Question: fermat-two-squares-oq-04
+
+  Fermat's two-squares theorem characterizes *which* primes are sums of two
+  squares.  Jacobi's refinement is quantitative: the number of representations
+  of `n` as an ordered sum of two (signed) squares is
+
+        r₂(n) = 4 · ∑_{d ∣ n} χ₄(d),
+
+  where `χ₄` is the non-principal Dirichlet character mod 4 (the character of
+  ℚ(√-1)/ℚ).  The full counting theorem requires the arithmetic of the
+  Gaussian integers ℤ[i] and is not available in Mathlib.  This file formalizes
+  the **arithmetic engine** of the formula: the divisor-character sum
+
+        δ(n) := ∑_{d ∣ n} χ₄(d)    (`jacobiSum n`),
+
+  realized as the Dirichlet convolution `ζ * χ₄`, and proves its structural
+  properties:
+
+  * `jacobiSum` is **multiplicative** (Dirichlet product of two multiplicative
+    arithmetic functions);
+  * its value on prime powers is the geometric sum `∑_{i≤k} χ₄(p)^i`, hence
+      δ(2^k) = 1,  δ(p^k) = k+1  (p ≡ 1 mod 4),  δ(p^k) ∈ {0,1}  (p ≡ 3 mod 4);
+  * δ(n) ≥ 0 for all n;
+  * **bridge to representability** (the qualitative shadow of Jacobi's theorem):
+      δ(n) > 0  ⇔  n is a sum of two squares,
+      δ(n) = 0  ⇔  n is NOT a sum of two squares.
+    This recovers the prime-factor criterion of Fermat/Gauss from the
+    *character sum* without any Gaussian-integer counting machinery.
+  * For a prime p, δ(p) = 1 + χ₄(p), so δ(p) = 2 when p ≡ 1 (mod 4) — matching
+    r₂(p) = 8 — and δ(p) = 0 when p ≡ 3 (mod 4).
+
+  The construction mirrors Mathlib's `DirichletCharacter.zetaMul` (defined there
+  only for ℂ-valued quadratic characters, used in Dirichlet-`L` non-vanishing),
+  ported to the integer-valued `χ₄` so that it can be connected to the
+  ℕ-valued representability criterion `Nat.eq_sq_add_sq_iff`.
+
+  References:
+  - Jacobi (1834): two-square theorem, r₂(n) = 4 ∑_{d∣n} χ₄(d)
+  - Zagier (1990): one-sentence existence proof (parent file)
+  - FermatTwoSquares.lean: parent two-squares characterization
+  - FermatTwoSquaresOQ05.lean: the n ≡ 3 (mod 4) obstruction
+  - Mathlib `DirichletCharacter.zetaMul` (NumberTheory/LSeries/Nonvanishing)
+-/
+
+import Mathlib.NumberTheory.LSeries.Dirichlet
+import Mathlib.NumberTheory.ArithmeticFunction.Zeta
+import Mathlib.NumberTheory.LegendreSymbol.ZModChar
+import Mathlib.NumberTheory.SumTwoSquares
+import Mathlib.Tactic
+
+open ArithmeticFunction ArithmeticFunction.zeta DirichletCharacter ZMod Finset
+
+namespace FermatTwoSquaresOQ04
+
+-- ============================================================================
+-- Part I: The Jacobi divisor-character sum  δ(n) = ∑_{d ∣ n} χ₄(d)
+-- ============================================================================
+
+/-- **The Jacobi divisor-character sum** `δ(n) = ∑_{d ∣ n} χ₄(d)`, realized as
+the Dirichlet convolution of the constant function `1` (= `ζ`) with the
+non-principal character `χ₄` mod 4.  This is the right-hand side of Jacobi's
+two-square theorem `r₂(n) = 4 δ(n)`. -/
+noncomputable def jacobiSum : ArithmeticFunction ℤ :=
+  (ζ : ArithmeticFunction ℤ) * toArithmeticFunction (χ₄ ·)
+
+/-- `δ` is multiplicative: it is the Dirichlet product of the multiplicative
+function `ζ` and the (completely) multiplicative character `χ₄`. -/
+theorem isMultiplicative_jacobiSum : jacobiSum.IsMultiplicative :=
+  isMultiplicative_zeta.natCast.mul (isMultiplicative_toArithmeticFunction χ₄)
+
+/-- Unfolding `δ(n) = ∑_{d ∣ n} χ₄(d)` for `n ≠ 0`. -/
+theorem jacobiSum_apply {n : ℕ} (_hn : n ≠ 0) :
+    jacobiSum n = ∑ d ∈ n.divisors, χ₄ (d : ZMod 4) := by
+  unfold jacobiSum
+  rw [coe_zeta_mul_apply]
+  refine sum_congr rfl fun d hd => ?_
+  have hd0 : d ≠ 0 := (Nat.pos_of_mem_divisors hd).ne'
+  simp [toArithmeticFunction, hd0]
+
+-- ============================================================================
+-- Part II: Value on prime powers — the geometric sum  ∑_{i≤k} χ₄(p)^i
+-- ============================================================================
+
+/-- On a prime power, `δ` is the geometric sum `∑_{i=0}^{k} χ₄(p)^i`. -/
+theorem jacobiSum_prime_pow {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    jacobiSum (p ^ k) = ∑ i ∈ range (k + 1), (χ₄ (p : ZMod 4)) ^ i := by
+  rw [jacobiSum_apply (pow_ne_zero k hp.ne_zero), Nat.sum_divisors_prime_pow hp]
+  refine sum_congr rfl fun i _ => ?_
+  rw [Nat.cast_pow, map_pow]
+
+/-- `δ(p^k) ≥ 0` for every prime `p` — the geometric sum of a `{0,1,-1}`-valued
+quadratic character is nonnegative.  (Ports `zetaMul_prime_pow_nonneg`.) -/
+theorem jacobiSum_prime_pow_nonneg {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    0 ≤ jacobiSum (p ^ k) := by
+  rw [jacobiSum_prime_pow hp]
+  rcases isQuadratic_χ₄ (p : ZMod 4) with h | h | h
+  · refine sum_nonneg fun i _ => ?_; simp only [h, le_refl, pow_nonneg]
+  · refine sum_nonneg fun i _ => ?_; simp only [h, one_pow, zero_le_one]
+  · simp only [h, neg_one_geom_sum]; split_ifs; exacts [le_rfl, zero_le_one]
+
+/-- **The key prime-power dichotomy.**  `δ(p^k) > 0` exactly when the obstruction
+to representability is absent: either `p ≢ 3 (mod 4)`, or the exponent `k` is
+even.  Concretely δ(2^k)=1, δ(p^k)=k+1 for p≡1, and δ(p^k)=[k even] for p≡3. -/
+theorem jacobiSum_prime_pow_pos_iff {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    0 < jacobiSum (p ^ k) ↔ (p % 4 = 3 → Even k) := by
+  rw [jacobiSum_prime_pow hp]
+  have hval := χ₄_nat_eq_if_mod_four p
+  by_cases hpar : p % 2 = 0
+  · -- p = 2: χ₄(p) = 0, the sum collapses to the single term χ₄(1) = 1
+    rw [if_pos hpar] at hval
+    rw [hval]
+    have hsum : ∑ i ∈ range (k + 1), (0 : ℤ) ^ i = 1 := by
+      rw [sum_range_succ']
+      simp only [pow_succ, mul_zero, sum_const_zero, pow_zero, zero_add]
+    have h43 : p % 4 ≠ 3 := by omega
+    rw [hsum]
+    exact iff_of_true one_pos (fun h => absurd h h43)
+  · rw [if_neg hpar] at hval
+    by_cases hmod1 : p % 4 = 1
+    · -- p ≡ 1 (mod 4): χ₄(p) = 1, the sum equals k + 1 > 0
+      rw [if_pos hmod1] at hval
+      rw [hval]
+      have hpos : 0 < ∑ i ∈ range (k + 1), (1 : ℤ) ^ i := by
+        apply sum_pos
+        · intro i _; rw [one_pow]; exact one_pos
+        · exact ⟨0, mem_range.mpr (Nat.succ_pos k)⟩
+      have h43 : p % 4 ≠ 3 := by omega
+      exact iff_of_true hpos (fun h => absurd h h43)
+    · -- p ≡ 3 (mod 4): χ₄(p) = -1, the sum is the alternating geometric series
+      rw [if_neg hmod1] at hval
+      rw [hval]
+      have h43 : p % 4 = 3 := by omega
+      rw [neg_one_geom_sum]
+      by_cases hk : Even k
+      · rw [if_neg (by rw [Nat.even_add_one]; simpa using hk)]
+        exact iff_of_true one_pos (fun _ => hk)
+      · rw [if_pos (by rw [Nat.even_add_one]; simpa using hk)]
+        exact iff_of_false (lt_irrefl 0) (fun h => hk (h h43))
+
+-- ============================================================================
+-- Part III: Bridge to representability — the qualitative Jacobi theorem
+-- ============================================================================
+
+/-- `δ(n) ≥ 0` for all `n`.  (Ports `zetaMul_nonneg`.) -/
+theorem jacobiSum_nonneg (n : ℕ) : 0 ≤ jacobiSum n := by
+  rcases eq_or_ne n 0 with rfl | hn
+  · simp
+  · simpa only [isMultiplicative_jacobiSum.multiplicative_factorization _ hn] using
+      Finset.prod_nonneg fun p hp =>
+        jacobiSum_prime_pow_nonneg (Nat.prime_of_mem_primeFactors hp) _
+
+/-- **Qualitative Jacobi two-square theorem.**  The divisor-character sum is
+*strictly positive* exactly on the sums of two squares:
+
+      0 < δ(n)  ⇔  ∃ x y, n = x² + y².
+
+This recovers Fermat/Gauss's prime-factorization criterion (every prime
+`q ≡ 3 (mod 4)` occurs to an even power) directly from the character sum,
+with no Gaussian-integer counting. -/
+theorem jacobiSum_pos_iff_sq_add_sq {n : ℕ} (hn : n ≠ 0) :
+    0 < jacobiSum n ↔ ∃ x y : ℕ, n = x ^ 2 + y ^ 2 := by
+  have hprod : jacobiSum n
+      = ∏ p ∈ n.primeFactors, jacobiSum (p ^ n.factorization p) := by
+    rw [isMultiplicative_jacobiSum.multiplicative_factorization _ hn,
+      ← Nat.support_factorization]
+    rfl
+  rw [hprod, Nat.eq_sq_add_sq_iff]
+  constructor
+  · -- positivity of the product forces every prime-power factor positive
+    intro hpos q hq h4
+    have hqp : q.Prime := Nat.prime_of_mem_primeFactors hq
+    have hge : 0 ≤ jacobiSum (q ^ n.factorization q) :=
+      jacobiSum_prime_pow_nonneg hqp _
+    have hfac_pos : 0 < jacobiSum (q ^ n.factorization q) := by
+      rcases hge.eq_or_lt with h | h
+      · exact absurd hpos (by rw [Finset.prod_eq_zero hq h.symm]; exact lt_irrefl 0)
+      · exact h
+    have hEven := (jacobiSum_prime_pow_pos_iff hqp (n.factorization q)).mp hfac_pos h4
+    rwa [Nat.factorization_def n hqp] at hEven
+  · -- each factor is positive, so the product is
+    intro h
+    apply Finset.prod_pos
+    intro p hp
+    have hpp : p.Prime := Nat.prime_of_mem_primeFactors hp
+    rw [jacobiSum_prime_pow_pos_iff hpp]
+    intro h4
+    rw [Nat.factorization_def n hpp]
+    exact h p hp h4
+
+/-- The complementary form: `δ(n) = 0` exactly on the non-representable `n`. -/
+theorem jacobiSum_eq_zero_iff {n : ℕ} (hn : n ≠ 0) :
+    jacobiSum n = 0 ↔ ¬ ∃ x y : ℕ, n = x ^ 2 + y ^ 2 := by
+  rw [← jacobiSum_pos_iff_sq_add_sq hn]
+  constructor
+  · intro h; rw [h]; exact lt_irrefl 0
+  · intro h
+    rcases (jacobiSum_nonneg n).eq_or_lt with h' | h'
+    · exact h'.symm
+    · exact absurd h' h
+
+-- ============================================================================
+-- Part IV: Headline prime values (Jacobi's count for primes)
+-- ============================================================================
+
+/-- For a prime `p ≡ 1 (mod 4)`, `δ(p) = 2`, i.e. `r₂(p) = 4·2 = 8`: the eight
+representations `(±a, ±b), (±b, ±a)` of the unique unordered pair. -/
+theorem jacobiSum_prime_one_mod_four {p : ℕ} (hp : p.Prime) (hmod : p % 4 = 1) :
+    jacobiSum p = 2 := by
+  have hk := jacobiSum_prime_pow hp 1
+  rw [pow_one] at hk
+  rw [hk, χ₄_nat_one_mod_four hmod]
+  norm_num [Finset.sum_range_succ]
+
+/-- For a prime `p ≡ 3 (mod 4)`, `δ(p) = 0`, i.e. `r₂(p) = 0`: no representation
+as a sum of two squares. -/
+theorem jacobiSum_prime_three_mod_four {p : ℕ} (hp : p.Prime) (hmod : p % 4 = 3) :
+    jacobiSum p = 0 := by
+  have hk := jacobiSum_prime_pow hp 1
+  rw [pow_one] at hk
+  rw [hk, χ₄_nat_three_mod_four hmod]
+  norm_num [Finset.sum_range_succ]
+
+end FermatTwoSquaresOQ04

--- a/src/data/proofs/fermat-two-squares-oq-04/annotations.json
+++ b/src/data/proofs/fermat-two-squares-oq-04/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-definition",
+    "proofId": "fermat-two-squares-oq-04",
+    "range": {
+      "startLine": 61,
+      "endLine": 71
+    },
+    "type": "concept",
+    "title": "δ as a Dirichlet Convolution ζ * χ₄",
+    "content": "The divisor-character sum δ(n) = ∑_{d∣n} χ₄(d) is defined as the Dirichlet convolution of ζ (the constant function 1) with the character χ₄ mod 4, taken over ℤ. This mirrors Mathlib's `DirichletCharacter.zetaMul`, which is defined only for ℂ-valued quadratic characters (for Dirichlet-L non-vanishing); porting it to the integer-valued χ₄ is what lets it connect to the ℕ-valued representability criterion. Multiplicativity is then immediate: δ is the Dirichlet product of the multiplicative ζ and the completely multiplicative χ₄, so `isMultiplicative_zeta.natCast.mul (isMultiplicative_toArithmeticFunction χ₄)` finishes it."
+  },
+  {
+    "id": "ann-apply",
+    "proofId": "fermat-two-squares-oq-04",
+    "range": {
+      "startLine": 73,
+      "endLine": 80
+    },
+    "type": "technique",
+    "title": "Unfolding the Convolution to a Divisor Sum",
+    "content": "`coe_zeta_mul_apply` is the key identity (ζ * f) n = ∑_{d∣n} f d: convolution with ζ is precisely the divisor sum. The auxiliary `toArithmeticFunction` wrapper sends 0 ↦ 0 and otherwise applies χ₄; on the nonzero divisors d of n it equals χ₄(d), so `simp` with the divisor positivity `Nat.pos_of_mem_divisors` collapses it to δ(n) = ∑_{d∣n} χ₄(d)."
+  },
+  {
+    "id": "ann-prime-pow",
+    "proofId": "fermat-two-squares-oq-04",
+    "range": {
+      "startLine": 86,
+      "endLine": 91
+    },
+    "type": "key-step",
+    "title": "Prime Powers Give a Geometric Series",
+    "content": "On a prime power the divisors are 1, p, p², …, pᵏ, so `Nat.sum_divisors_prime_pow` rewrites the divisor sum as ∑_{i=0}^{k} χ₄(pⁱ). Because χ₄ is multiplicative, χ₄(pⁱ) = χ₄(p)ⁱ (via `Nat.cast_pow` and `map_pow`), exposing the geometric series ∑_{i≤k} χ₄(p)ⁱ. The entire prime-power behaviour of δ is now governed by the single value χ₄(p) ∈ {0, 1, -1}."
+  },
+  {
+    "id": "ann-dichotomy",
+    "proofId": "fermat-two-squares-oq-04",
+    "range": {
+      "startLine": 103,
+      "endLine": 140
+    },
+    "type": "key-step",
+    "title": "The Prime-Power Positivity Dichotomy",
+    "content": "Splitting on χ₄(p) via `χ₄_nat_eq_if_mod_four` gives three regimes: for p = 2 the series collapses to the single term 1 (δ(2ᵏ) = 1); for p ≡ 1 (mod 4) every term is 1, so δ(pᵏ) = k+1; for p ≡ 3 (mod 4) the series alternates, and `neg_one_geom_sum` evaluates ∑_{i≤k} (-1)ⁱ = [k even]. Combining, 0 < δ(pᵏ) ⇔ (p ≡ 3 mod 4 → k even). This single inequality is the atom from which the global representability criterion is reassembled. The `omega` calls discharge the residue bookkeeping (e.g. p % 2 = 0 forces p % 4 ≠ 3)."
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "fermat-two-squares-oq-04",
+    "range": {
+      "startLine": 154,
+      "endLine": 191
+    },
+    "type": "concept",
+    "title": "From Character Sum to Representability",
+    "content": "`multiplicative_factorization` writes δ(n) as the product ∏_{p∣n} δ(p^{vₚ(n)}). Every factor is nonnegative (the geometric-sum lemma), so the product is strictly positive iff every factor is — proved by `Finset.prod_pos` one way and `Finset.prod_eq_zero` the other. By the prime-power dichotomy this is exactly the condition that every prime q ≡ 3 (mod 4) appears to an even power, which `Nat.eq_sq_add_sq_iff` identifies with n being a sum of two squares. The result, δ(n) > 0 ⇔ ∃ x y, n = x² + y², is the qualitative shadow of Jacobi's theorem: the SIGN of the character sum is a complete detector of representability, with no Gaussian-integer counting."
+  },
+  {
+    "id": "ann-prime-values",
+    "proofId": "fermat-two-squares-oq-04",
+    "range": {
+      "startLine": 207,
+      "endLine": 224
+    },
+    "type": "concept",
+    "title": "Jacobi's Count for Primes",
+    "content": "For a prime, the divisors are just 1 and p, so δ(p) = χ₄(1) + χ₄(p) = 1 + χ₄(p). Hence δ(p) = 2 when p ≡ 1 (mod 4), matching r₂(p) = 4·2 = 8 — the eight representations (±a, ±b), (±b, ±a) of the unique unordered pair {a, b}. And δ(p) = 0 when p ≡ 3 (mod 4), matching r₂(p) = 0. These are the smallest nontrivial instances of the full Jacobi identity r₂(n) = 4 δ(n)."
+  }
+]

--- a/src/data/proofs/fermat-two-squares-oq-04/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-04/meta.json
@@ -1,0 +1,199 @@
+{
+  "id": "fermat-two-squares-oq-04",
+  "title": "Jacobi's Two-Square Theorem: the Divisor-Character Sum Side",
+  "slug": "fermat-two-squares-oq-04",
+  "description": "Jacobi's theorem counts representations as r₂(n) = 4 ∑_{d∣n} χ₄(d). This entry formalizes the arithmetic engine of that formula — the divisor-character sum δ(n) = ∑_{d∣n} χ₄(d), built as the Dirichlet convolution ζ * χ₄ — proves it multiplicative and nonnegative, evaluates it on prime powers, and bridges it to representability: δ(n) > 0 ⇔ n is a sum of two squares. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Jacobi (1834) (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sum_of_two_squares_theorem",
+    "date": "1834",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "sum-of-two-squares",
+      "dirichlet-character",
+      "arithmetic-function",
+      "dirichlet-convolution",
+      "jacobi",
+      "multiplicative-function",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FermatTwoSquaresOQ04.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.χ₄",
+        "description": "The non-principal quadratic Dirichlet character mod 4, the character of ℚ(√-1)/ℚ",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.ZModChar"
+      },
+      {
+        "theorem": "DirichletCharacter.isMultiplicative_toArithmeticFunction",
+        "description": "A Dirichlet character, viewed as an arithmetic function, is multiplicative",
+        "module": "Mathlib.NumberTheory.LSeries.Dirichlet"
+      },
+      {
+        "theorem": "ArithmeticFunction.coe_zeta_mul_apply",
+        "description": "(ζ * f) n = ∑_{d∣n} f d — Dirichlet convolution with ζ is the divisor sum",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Zeta"
+      },
+      {
+        "theorem": "ArithmeticFunction.IsMultiplicative.multiplicative_factorization",
+        "description": "A multiplicative arithmetic function factors as a product over the prime-power decomposition",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction"
+      },
+      {
+        "theorem": "Nat.eq_sq_add_sq_iff",
+        "description": "n is a sum of two squares iff every prime q ≡ 3 (mod 4) divides n to an even power",
+        "module": "Mathlib.NumberTheory.SumTwoSquares"
+      },
+      {
+        "theorem": "neg_one_geom_sum",
+        "description": "∑_{i<n} (-1)^i = if Even n then 0 else 1, the alternating geometric series",
+        "module": "Mathlib.Algebra.Ring.GeomSum"
+      }
+    ],
+    "originalContributions": [
+      "jacobiSum: the divisor-character sum δ(n) = ∑_{d∣n} χ₄(d) realized as the Dirichlet convolution ζ * χ₄ over ℤ (an integer-valued port of Mathlib's ℂ-only DirichletCharacter.zetaMul)",
+      "isMultiplicative_jacobiSum: δ is multiplicative, as the Dirichlet product of two multiplicative functions",
+      "jacobiSum_prime_pow: on a prime power δ(p^k) = ∑_{i≤k} χ₄(p)^i, the geometric sum",
+      "jacobiSum_prime_pow_nonneg / jacobiSum_nonneg: δ(n) ≥ 0 for all n",
+      "jacobiSum_prime_pow_pos_iff: the key dichotomy 0 < δ(p^k) ⇔ (p ≡ 3 mod 4 → k even), encoding δ(2^k)=1, δ(p^k)=k+1 for p≡1, δ(p^k)=[k even] for p≡3",
+      "jacobiSum_pos_iff_sq_add_sq: the qualitative Jacobi theorem — δ(n) > 0 ⇔ n is a sum of two squares — recovering the Fermat/Gauss prime-factor criterion from the character sum",
+      "jacobiSum_eq_zero_iff: the complement — δ(n) = 0 ⇔ n is NOT a sum of two squares",
+      "jacobiSum_prime_one_mod_four: δ(p) = 2 for p ≡ 1 (mod 4), matching r₂(p) = 4·2 = 8",
+      "jacobiSum_prime_three_mod_four: δ(p) = 0 for p ≡ 3 (mod 4), matching r₂(p) = 0"
+    ],
+    "dateAdded": "2026-06-21",
+    "lineCount": 225,
+    "assumptions": "0 axioms, 0 sorries. The headline theorems (jacobiSum_pos_iff_sq_add_sq, jacobiSum_eq_zero_iff, isMultiplicative_jacobiSum, jacobiSum_prime_one_mod_four) depend only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms). The full Jacobi counting identity r₂(n) = 4 δ(n) — connecting δ to the actual representation count — requires the arithmetic of the Gaussian integers ℤ[i] and is NOT formalized here; this entry formalizes the divisor-sum (right-hand) side and its qualitative bridge to representability.",
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Fermat's two-squares theorem (1640) decides WHETHER a prime is a sum of two squares. Jacobi's two-square theorem (1834) is the quantitative refinement: it counts HOW MANY ways, with the strikingly clean formula r₂(n) = 4 ∑_{d∣n} χ₄(d), where r₂(n) is the number of ordered pairs (x, y) ∈ ℤ² with x² + y² = n and χ₄ is the non-principal Dirichlet character mod 4 (χ₄(d) = +1, -1, 0 according as d ≡ 1, 3, 0,2 mod 4). The factor of 4 reflects the four units ±1, ±i of the Gaussian integers ℤ[i]; the divisor sum ∑_{d∣n} χ₄(d) is the number of ideals of given norm, equivalently the difference between the number of divisors ≡ 1 and ≡ 3 mod 4.\n\nThe deep half of Jacobi's theorem — that the geometric count r₂(n) equals 4 times the arithmetic sum — is a statement about unique factorization in ℤ[i] and is not available in Mathlib. The divisor sum δ(n) = ∑_{d∣n} χ₄(d) on its own, however, is a purely elementary arithmetic object, and its structure (multiplicativity, prime-power values, positivity, and its sign as a representability detector) is exactly the content that makes Jacobi's formula tick. This entry isolates and verifies that arithmetic engine.",
+    "problemStatement": "**Open question (fermat-two-squares-oq-04)**: The Jacobi two-square theorem counts representations: r₂(n) = 4 ∑_{d∣n} χ(d) where χ is the non-principal character mod 4. Can this quantitative refinement be formalized, connecting to L-functions and Dirichlet series?\n\n**Result of this entry**: The divisor-character sum δ(n) = ∑_{d∣n} χ₄(d) — the right-hand side of Jacobi's identity — is formalized as the Dirichlet convolution ζ * χ₄ and verified (0 sorries, 0 axioms) to be multiplicative and nonnegative, with explicit prime-power values. Its sign is shown to be a complete detector of representability:\n\n  0 < δ(n)  ⇔  ∃ x y, n = x² + y²,    δ(n) = 0  ⇔  n is not a sum of two squares.\n\nFor primes this yields δ(p) = 2 (p ≡ 1 mod 4, r₂ = 8) and δ(p) = 0 (p ≡ 3 mod 4). The full geometric identity r₂(n) = 4 δ(n) is left open, as it requires the Gaussian-integer counting machinery absent from Mathlib.",
+    "text": "Jacobi's two-square theorem counts representations via r₂(n) = 4 ∑_{d∣n} χ₄(d). This entry formalizes the divisor-character sum δ(n) = ∑_{d∣n} χ₄(d) as the convolution ζ * χ₄, proves it multiplicative and nonnegative, evaluates it on prime powers, and shows δ(n) > 0 iff n is a sum of two squares.",
+    "proofStrategy": "**Proof Strategy:**\n\n1. **Definition as a convolution**: δ = ζ * χ₄ as arithmetic functions over ℤ, mirroring Mathlib's ℂ-valued `DirichletCharacter.zetaMul`. The evaluation `coe_zeta_mul_apply` gives δ(n) = ∑_{d∣n} χ₄(d).\n\n2. **Multiplicativity**: δ is the Dirichlet product of the multiplicative ζ and the completely multiplicative χ₄, so `IsMultiplicative.mul` applies directly.\n\n3. **Prime powers**: `Nat.sum_divisors_prime_pow` collapses the divisor sum to the geometric series ∑_{i≤k} χ₄(p)^i. Splitting on the value of χ₄(p) ∈ {0, 1, -1} (via `χ₄_nat_eq_if_mod_four`) gives δ(2^k)=1, δ(p^k)=k+1 (p≡1), and the alternating sum `neg_one_geom_sum` = [k even] (p≡3). This yields the dichotomy 0 < δ(p^k) ⇔ (p ≡ 3 mod 4 → k even).\n\n4. **Bridge to representability**: `multiplicative_factorization` writes δ(n) = ∏_{p∣n} δ(p^{v_p(n)}). Since each factor is ≥ 0, the product is positive iff every factor is positive (using `Finset.prod_pos` and `Finset.prod_eq_zero`). By the prime-power dichotomy this is exactly the condition 'every prime q ≡ 3 (mod 4) has even exponent', which `Nat.eq_sq_add_sq_iff` identifies with being a sum of two squares.\n\n5. **Prime values and complement**: δ(p) = 1 + χ₄(p) gives the headline counts; `jacobiSum_eq_zero_iff` is the contrapositive of the bridge via nonnegativity.",
+    "keyInsights": [
+      "**The arithmetic side of Jacobi's formula is elementary and self-contained**: The right-hand side 4 ∑_{d∣n} χ₄(d) needs no Gaussian integers — it is a Dirichlet convolution of standard multiplicative functions. Isolating it from the geometric count r₂(n) makes the bulk of Jacobi's theorem formalizable today, with the genuinely hard ℤ[i]-counting deferred.",
+      "**Multiplicativity is the whole game**: Because δ = ζ * χ₄ is a product of multiplicative functions, it is determined by its values on prime powers, and every global statement (positivity, the representability bridge) reduces to a per-prime-power check. The prime-power dichotomy 0 < δ(p^k) ⇔ (p ≡ 3 → k even) is the atom from which the Fermat/Gauss criterion is reassembled.",
+      "**The SIGN of a divisor sum detects representability**: δ(n) > 0 ⇔ n = x² + y² is a clean qualitative shadow of Jacobi's quantitative theorem. It says the character sum is positive exactly when there is at least one representation — recovering Fermat's prime-factor condition purely from ∑_{d∣n} χ₄(d), with no counting argument.",
+      "**Mathlib's ℂ-only machinery ports cleanly to ℤ**: Mathlib defines `DirichletCharacter.zetaMul` and proves its nonnegativity only for ℂ-valued quadratic characters (for Dirichlet L non-vanishing). Re-running the same construction over ℤ for χ₄ is what makes the result connectable to the ℕ-valued representability criterion `Nat.eq_sq_add_sq_iff`.",
+      "**The alternating geometric series is the p ≡ 3 obstruction**: For p ≡ 3 (mod 4), χ₄(p) = -1 and δ(p^k) = ∑ (-1)^i = [k even]. A single odd-exponent prime ≡ 3 (mod 4) makes its factor vanish, killing the whole product — precisely the obstruction that prevents n from being a sum of two squares."
+    ],
+    "prerequisites": [
+      "Dirichlet characters (the character χ₄ mod 4) and multiplicative arithmetic functions",
+      "Dirichlet convolution and the function ζ (the constant 1)",
+      "Unique factorization and multiplicative functions over prime-power decompositions",
+      "Fermat's two-squares theorem and the prime-factor representability criterion"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Imports and the Divisor-Character Sum",
+      "startLine": 1,
+      "endLine": 80,
+      "summary": "Header motivating δ as the arithmetic side of Jacobi's r₂(n) = 4 ∑ χ₄(d). Defines jacobiSum = ζ * χ₄ as a ℤ-valued arithmetic function, proves it multiplicative, and unfolds δ(n) = ∑_{d∣n} χ₄(d).",
+      "mathContext": "δ is the Dirichlet convolution of ζ (constant 1) with the character χ₄ mod 4. As a product of multiplicative functions it is multiplicative, and coe_zeta_mul_apply identifies it with the divisor-character sum."
+    },
+    {
+      "id": "prime-powers",
+      "title": "Value on Prime Powers",
+      "startLine": 82,
+      "endLine": 140,
+      "summary": "On p^k, δ collapses to the geometric sum ∑_{i≤k} χ₄(p)^i. Proves nonnegativity and the central dichotomy 0 < δ(p^k) ⇔ (p ≡ 3 mod 4 → k even) by splitting on χ₄(p) ∈ {0, 1, -1}.",
+      "mathContext": "Nat.sum_divisors_prime_pow reduces the divisor sum to a geometric series. δ(2^k)=1, δ(p^k)=k+1 (p≡1), and δ(p^k) = [k even] (p≡3) via neg_one_geom_sum."
+    },
+    {
+      "id": "bridge",
+      "title": "Bridge to Representability",
+      "startLine": 142,
+      "endLine": 205,
+      "summary": "Globalizes via multiplicative_factorization: δ(n) = ∏ δ(p^{v_p}). Since factors are nonnegative, positivity of the product is equivalent to positivity of each factor, which by the prime-power dichotomy matches Nat.eq_sq_add_sq_iff. Yields δ(n) > 0 ⇔ n is a sum of two squares, and the complement δ(n) = 0 ⇔ not.",
+      "mathContext": "The qualitative Jacobi theorem: the character sum is positive exactly on representable n, recovering the Fermat/Gauss prime-factor criterion from ∑_{d∣n} χ₄(d)."
+    },
+    {
+      "id": "prime-values",
+      "title": "Headline Prime Values",
+      "startLine": 207,
+      "endLine": 225,
+      "summary": "δ(p) = 1 + χ₄(p): equals 2 for p ≡ 1 (mod 4) (so r₂(p) = 8) and 0 for p ≡ 3 (mod 4) (so r₂(p) = 0).",
+      "mathContext": "Jacobi's count for primes: the eight representations (±a, ±b), (±b, ±a) of the unique unordered pair when p ≡ 1 (mod 4), and none when p ≡ 3 (mod 4)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "extends",
+      "description": "Refines the parent's WHICH-primes characterization toward the HOW-MANY count of Jacobi: formalizes the divisor-character sum that is the right-hand side of r₂(n) = 4 ∑_{d∣n} χ₄(d)."
+    },
+    {
+      "targetId": "fermat-two-squares-oq-05",
+      "relationship": "related",
+      "description": "OQ-05 supplies the n ≡ 3 (mod 4) obstruction directly; here the same obstruction reappears as the vanishing of δ(p^k) for p ≡ 3 (mod 4) and odd k, recovered from the character sum."
+    },
+    {
+      "targetId": "fermat-two-squares-oq-01",
+      "relationship": "related",
+      "description": "The Lagrange four-squares extension removes all congruence obstructions; this entry shows how the mod-4 obstruction is encoded in the sign of the character sum δ."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) formalization of the divisor-character sum δ(n) = ∑_{d∣n} χ₄(d) — the arithmetic side of Jacobi's two-square theorem r₂(n) = 4 δ(n). Realized as the Dirichlet convolution ζ * χ₄, δ is proved multiplicative and nonnegative, evaluated on prime powers as a geometric series, and its sign is shown to detect representability exactly: δ(n) > 0 ⇔ n is a sum of two squares, with δ(p) = 2 for primes p ≡ 1 (mod 4) (r₂ = 8) and δ(p) = 0 for p ≡ 3 (mod 4).",
+    "implications": "**Theoretical Significance**: This isolates the elementary, fully formalizable core of Jacobi's theorem from the Gaussian-integer counting that Mathlib lacks. The divisor sum ∑_{d∣n} χ₄(d) is exactly the local factor at the heart of the Dirichlet L-function L(s, χ₄) = ∑ χ₄(n) n^{-s} = β(s) (the Dirichlet beta function), whose value β(1) = π/4 underlies the analytic class-number / Leibniz formula. Proving δ multiplicative with the stated prime-power values is the arithmetic input to the Euler product for L(s, χ₄); the representability bridge is its qualitative shadow. Completing the geometric identity r₂(n) = 4 δ(n) is the natural next target once Mathlib's Gaussian-integer norm-counting matures.",
+    "openQuestions": [
+      "Can the full geometric identity r₂(n) = 4 ∑_{d∣n} χ₄(d) be formalized by counting Gaussian integers of norm n, using unique factorization in ℤ[i] and the splitting behaviour of primes?",
+      "Can δ be connected to the Dirichlet L-function L(s, χ₄) (the Dirichlet beta function) via its Euler product, formalizing ∑ r₂(n) n^{-s} = 4 ζ(s) L(s, χ₄) on the half-plane of convergence?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.LSeries.Dirichlet",
+      "Mathlib.NumberTheory.ArithmeticFunction.Zeta",
+      "Mathlib.NumberTheory.LegendreSymbol.ZModChar",
+      "Mathlib.NumberTheory.SumTwoSquares",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "ArithmeticFunction",
+      "ArithmeticFunction.zeta",
+      "DirichletCharacter",
+      "ZMod",
+      "Finset"
+    ],
+    "namespace": "FermatTwoSquaresOQ04",
+    "lineCount": 225,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/FermatTwoSquaresOQ04.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "C. G. J. Jacobi",
+      "title": "Fundamenta Nova Theoriae Functionum Ellipticarum",
+      "year": "1829",
+      "venue": "Königsberg",
+      "note": "Source of the two-square counting theorem r₂(n) = 4 ∑_{d∣n} χ₄(d) via theta-function identities"
+    },
+    {
+      "authors": "G. H. Hardy, E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition",
+      "note": "Chapter 16 (arithmetic functions) and Chapter 20 (sums of squares), including the divisor-character sum and r₂(n)"
+    },
+    {
+      "authors": "D. Zagier",
+      "title": "A One-Sentence Proof That Every Prime p ≡ 1 (mod 4) Is a Sum of Two Squares",
+      "year": "1990",
+      "venue": "The American Mathematical Monthly, 97(2), p. 144",
+      "note": "The parent entry's existence proof; this entry refines from existence toward Jacobi's count"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ#4** of Fermat's two-squares theorem — Jacobi's quantitative refinement
`r₂(n) = 4 ∑_{d∣n} χ₄(d)` (number of representations as an ordered sum of two signed squares).

The **full geometric identity** `r₂(n) = 4 δ(n)` requires Gaussian-integer (ℤ[i]) norm-counting that Mathlib lacks (truly blocked, >1000 lines). This PR formalizes the **arithmetic side** — the divisor-character sum `δ(n) = ∑_{d∣n} χ₄(d)`, realized as the Dirichlet convolution `ζ * χ₄` — together with its qualitative bridge to representability.

The construction ports Mathlib's `DirichletCharacter.zetaMul` (defined there only for ℂ-valued quadratic characters, for Dirichlet-L non-vanishing) to the **integer-valued** `χ₄`, so it can be connected to the ℕ-valued criterion `Nat.eq_sq_add_sq_iff`.

## Results (`Proofs/FermatTwoSquaresOQ04.lean`, 225 lines, 10 thm + 1 def)

- `isMultiplicative_jacobiSum` — δ is multiplicative (Dirichlet product of multiplicative functions)
- `jacobiSum_prime_pow` — `δ(p^k) = ∑_{i≤k} χ₄(p)^i` (geometric series)
- `jacobiSum_prime_pow_pos_iff` — the dichotomy `0 < δ(p^k) ⇔ (p ≡ 3 mod 4 → k even)`; encodes δ(2^k)=1, δ(p^k)=k+1 (p≡1), δ(p^k)=[k even] (p≡3)
- `jacobiSum_nonneg` — `δ(n) ≥ 0`
- **`jacobiSum_pos_iff_sq_add_sq`** — `δ(n) > 0 ⇔ ∃ x y, n = x²+y²`: the *qualitative Jacobi theorem*. The **sign** of the character sum is a complete detector of representability, recovering the Fermat/Gauss prime-factor criterion with **no** Gaussian-integer counting.
- `jacobiSum_eq_zero_iff` — `δ(n) = 0 ⇔ n is NOT a sum of two squares`
- `jacobiSum_prime_one_mod_four` / `..._three_mod_four` — `δ(p)=2` (so r₂(p)=8) / `δ(p)=0`

## Verification

- **0 sorries, 0 axioms.** `#print axioms` on the headline theorems lists only `propext`, `Classical.choice`, `Quot.sound`.
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.FermatTwoSquaresOQ04` (Lean v4.26.0 / Mathlib).
- Gallery `meta.json` + `annotations.json` added; `Proofs.lean` import registered.

## Honest scope

This is the **divisor-sum (right-hand) side** of Jacobi's formula plus its qualitative shadow — not the geometric count `r₂` itself, which remains open pending Mathlib ℤ[i] norm-counting infrastructure (documented in the entry's open questions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)