### PR TITLE
audit(simson-line-theorem-oq-01-oq-01): angle-doubling entry clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17671,8 +17671,14 @@
       "lastAudited": "2026-06-21T12:53:55Z",
       "result": "clean",
       "issues": []
+    },
+    "simson-line-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T13:10:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T12:36:52Z"
+  "lastUpdated": "2026-06-21T13:10:00Z"
 }


### PR DESCRIPTION
## Audit: simson-line-theorem-oq-01-oq-01

Deep-audited the newest gallery slug (Simson lines rotate at half angular speed — angle-doubling, research PR #27352).

### Verification
Checked `meta.json` against `proofs/Proofs/SimsonLineTheoremOQ01OQ01.lean`:

| Claim | Meta | Source | ✓ |
|-------|------|--------|---|
| lineCount | 194 | 194 | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no `axiom`) | ✓ |
| sorries | 0 | 0 | ✓ |
| namespace | SimsonLineTheoremOQ01OQ01 | matches | ✓ |
| imports / opens | match | match | ✓ |

- 0 sorries, 0 axioms, 0 `native_decide`, 0 `True` stubs, no `admit`. The lone `sorry` grep hit is docstring prose ("no \`sorry\`").
- `mainTheorems` leanType signatures match the source declarations.
- `status: verified` / `badge: original` justified: 0-axiom, 0-sorry complex-coordinate geometry result.
- Reuses parent's `foot`/`foot_diff` from `SimsonLineTheorem.lean` (parent also 0-sorry, 0-axiom).

**Result: clean.** Tracker updated (auditCount 1, result clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)