### PR TITLE
research(geometric-series-oq-08): finite geometric sums vs the infinite limit — truncation defect, bounds, monotonicity [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2617,6 +2617,7 @@ import Proofs.GeometricSeriesOQ02OQ05
 import Proofs.GeometricSeriesOQ03
 import Proofs.GeometricSeriesOQ06
 import Proofs.GeometricSeriesOQ07
+import Proofs.GeometricSeriesOQ08
 import Proofs.GeometricSeriesOQ09
 import Proofs.GeometricSeriesOQ10
 import Proofs.GnedenkoKolmogorov

--- a/proofs/Proofs/GeometricSeriesOQ08.lean
+++ b/proofs/Proofs/GeometricSeriesOQ08.lean
@@ -1,0 +1,129 @@
+import Mathlib.Algebra.GeomSum
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Tactic
+
+/-
+# Finite Geometric Sums and the Infinite Limit: Bounds and Monotonicity
+
+## What This Proves
+
+For a real ratio `r` the finite geometric partial sum
+
+  `S n = ∑_{k=0}^{n-1} r^k`
+
+has the textbook closed form `(1 - r^n)/(1 - r)` when `r ≠ 1`
+(`geometric_sum_closed`). The base gallery entry `GeometricSeries.lean`
+already records that closed form and, separately, the infinite value
+`∑' k, r^k = (1 - r)⁻¹` for `|r| < 1`. What it does **not** make explicit is
+the quantitative bridge between the two: *how the finite sums approach the
+infinite limit*.
+
+This entry fills that gap for `0 ≤ r < 1`:
+
+* `geometric_sum_tail` — the exact defect `(1 - r)⁻¹ - S n = r^n / (1 - r)`,
+  i.e. the infinite tail is itself a scaled geometric power.
+* `geometric_sum_lt_inv` — every finite sum is **strictly** below the limit,
+  `S n < (1 - r)⁻¹` (for `0 < r < 1`).
+* `geometric_sum_le_inv` — the non-strict bound `S n ≤ (1 - r)⁻¹`, valid for
+  all `n` including `n = 0`, and for `r = 0`.
+* `geometric_sum_monotone` — the partial sums increase in `n`.
+* `geometric_sum_tendsto_inv` — they converge upward to `(1 - r)⁻¹`.
+
+Together these say the finite geometric sums form a bounded increasing sequence
+converging to the infinite value, with an explicit error term `r^n/(1-r)`.
+
+## Why This Matters
+
+The error term `r^n/(1-r)` is exactly the estimate used whenever a geometric
+series is truncated (numerical analysis, generating functions, the comparison
+test, the ratio-test remainder). Stating it as a typed identity — rather than
+re-deriving it inline each time — makes the finite/infinite relationship
+reusable.
+
+## Mathlib Relationship
+
+The closed form `geom_sum_eq` and the infinite value
+`tsum_geometric_of_lt_one` are Mathlib. The defect identity, the strict and
+non-strict bounds, the monotonicity statement, and the explicit upward
+convergence are assembled here; they are not single Mathlib lemmas.
+-/
+
+namespace GeometricSeriesOQ08
+
+open Finset
+
+variable {r : ℝ}
+
+/-- **Closed form** in the `(1 - rⁿ)/(1 - r)` convention.
+Wraps Mathlib's `geom_sum_eq` (which uses `(rⁿ - 1)/(r - 1)`). -/
+theorem geometric_sum_closed (hr : r ≠ 1) (n : ℕ) :
+    ∑ k ∈ range n, r ^ k = (1 - r ^ n) / (1 - r) := by
+  rw [geom_sum_eq hr]
+  rw [div_eq_div_iff (sub_ne_zero.mpr hr) (sub_ne_zero.mpr (fun h => hr h.symm))]
+  ring
+
+/-- **Exact truncation defect.** For `r < 1` the gap between the infinite value
+`(1 - r)⁻¹` and the `n`-term partial sum is the scaled power `rⁿ / (1 - r)`. -/
+theorem geometric_sum_tail (hr : r < 1) (n : ℕ) :
+    (1 - r)⁻¹ - ∑ k ∈ range n, r ^ k = r ^ n / (1 - r) := by
+  have h1r : (1 : ℝ) - r ≠ 0 := sub_ne_zero.mpr (ne_of_gt hr)
+  rw [geometric_sum_closed (ne_of_lt hr) n]
+  field_simp
+  ring
+
+/-- **Non-strict bound.** For `0 ≤ r < 1`, every finite geometric sum is at most
+the infinite value `(1 - r)⁻¹`. Holds for all `n` (including `n = 0`). -/
+theorem geometric_sum_le_inv (hr0 : 0 ≤ r) (hr1 : r < 1) (n : ℕ) :
+    ∑ k ∈ range n, r ^ k ≤ (1 - r)⁻¹ := by
+  have h1r : (0 : ℝ) < 1 - r := by linarith
+  have htail : (1 - r)⁻¹ - ∑ k ∈ range n, r ^ k = r ^ n / (1 - r) :=
+    geometric_sum_tail hr1 n
+  have hnonneg : 0 ≤ r ^ n / (1 - r) :=
+    div_nonneg (pow_nonneg hr0 n) (le_of_lt h1r)
+  linarith [htail ▸ hnonneg]
+
+/-- **Strict bound.** For `0 < r < 1`, every finite geometric sum is *strictly*
+below the infinite value `(1 - r)⁻¹` (the missing tail is positive). -/
+theorem geometric_sum_lt_inv (hr0 : 0 < r) (hr1 : r < 1) (n : ℕ) :
+    ∑ k ∈ range n, r ^ k < (1 - r)⁻¹ := by
+  have h1r : (0 : ℝ) < 1 - r := by linarith
+  have htail : (1 - r)⁻¹ - ∑ k ∈ range n, r ^ k = r ^ n / (1 - r) :=
+    geometric_sum_tail hr1 n
+  have hpos : 0 < r ^ n / (1 - r) := div_pos (pow_pos hr0 n) h1r
+  linarith [htail ▸ hpos]
+
+/-- **Monotonicity.** For `0 ≤ r` the partial sums increase in `n`
+(each new term `rⁿ` is nonnegative). -/
+theorem geometric_sum_monotone (hr0 : 0 ≤ r) :
+    Monotone (fun n => ∑ k ∈ range n, r ^ k) := by
+  apply monotone_nat_of_le_succ
+  intro n
+  rw [Finset.sum_range_succ]
+  have : 0 ≤ r ^ n := pow_nonneg hr0 n
+  linarith
+
+/-- **Upward convergence.** For `0 ≤ r < 1` the finite geometric sums converge to
+the infinite value `(1 - r)⁻¹`. Combined with `geometric_sum_monotone` and
+`geometric_sum_le_inv`, this exhibits `(1 - r)⁻¹` as the supremum of an
+increasing, bounded sequence. -/
+theorem geometric_sum_tendsto_inv (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    Filter.Tendsto (fun n => ∑ k ∈ range n, r ^ k) Filter.atTop
+      (nhds (1 - r)⁻¹) := by
+  have habs : |r| < 1 := by rw [abs_of_nonneg hr0]; exact hr1
+  have hsum := hasSum_geometric_of_abs_lt_one habs
+  simpa using hsum.tendsto_sum_nat
+
+/-! ## Concrete instance
+
+`r = 1/2`: the four-term sum is `15/8`, strictly below the limit `2`,
+with truncation defect `(1/2)^4 / (1 - 1/2) = 1/8`. -/
+
+example : ∑ k ∈ range 4, (1 / 2 : ℝ) ^ k = 15 / 8 := by norm_num [Finset.sum_range_succ]
+
+example : (1 - (1 / 2 : ℝ))⁻¹ - ∑ k ∈ range 4, (1 / 2 : ℝ) ^ k = 1 / 8 := by
+  rw [geometric_sum_tail (by norm_num) 4]; norm_num
+
+example : ∑ k ∈ range 4, (1 / 2 : ℝ) ^ k < (1 - (1 / 2 : ℝ))⁻¹ :=
+  geometric_sum_lt_inv (by norm_num) (by norm_num) 4
+
+end GeometricSeriesOQ08

--- a/src/data/proofs/geometric-series-oq-08/meta.json
+++ b/src/data/proofs/geometric-series-oq-08/meta.json
@@ -1,0 +1,124 @@
+{
+  "id": "geometric-series-oq-08",
+  "slug": "geometric-series-oq-08",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.GeomSum",
+      "Mathlib.Analysis.SpecificLimits.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "GeometricSeriesOQ08",
+    "lineCount": 129,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ08.lean",
+    "sorries": 0
+  },
+  "title": "Finite Geometric Sums and the Infinite Limit: Defect, Bounds, and Monotonicity",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ08.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "finite-sums",
+      "partial-sums",
+      "truncation-error",
+      "monotonicity",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 129,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "geometric_sum_tail: the exact truncation defect (1 - r)⁻¹ − ∑_{k<n} rᵏ = rⁿ/(1 − r) for real r < 1 — the infinite tail of the geometric series is itself a scaled power. This explicit error term is the estimate used whenever a geometric series is truncated; Mathlib states the closed form and the infinite value separately but not this difference.",
+      "geometric_sum_lt_inv / geometric_sum_le_inv: the strict bound ∑_{k<n} rᵏ < (1 − r)⁻¹ (for 0 < r < 1) and the non-strict bound ≤ (for 0 ≤ r < 1, all n), exhibiting every finite geometric sum as lying strictly below its infinite limit.",
+      "geometric_sum_monotone: the partial sums n ↦ ∑_{k<n} rᵏ are Monotone for 0 ≤ r (each new term rⁿ ≥ 0).",
+      "geometric_sum_tendsto_inv: the finite sums converge to (1 − r)⁻¹; combined with monotonicity and the upper bound this realises the infinite value as the supremum of an increasing, bounded sequence.",
+      "geometric_sum_closed: the closed form in the (1 − rⁿ)/(1 − r) convention, the anchor from which the defect and bounds are derived."
+    ],
+    "prerequisites": [
+      "Mathlib's geom_sum_eq (∑_{k<n} xᵏ = (xⁿ − 1)/(x − 1) for x ≠ 1)",
+      "Mathlib's hasSum_geometric_of_abs_lt_one (∑ rⁿ = (1 − r)⁻¹ for |r| < 1)",
+      "HasSum.tendsto_sum_nat (partial sums of a HasSum tend to its value)",
+      "monotone_nat_of_le_succ; pow_nonneg / pow_pos; div_pos / div_nonneg",
+      "Parent: geometric-series (∑ rⁿ = 1/(1−r)) and base finite forms in GeometricSeries.lean"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "geom_sum_eq",
+        "description": "∑_{k<n} xᵏ = (xⁿ − 1)/(x − 1) for x ≠ 1. Rewritten into the (1 − xⁿ)/(1 − x) convention to anchor the defect and bound theorems.",
+        "module": "Mathlib.Algebra.GeomSum"
+      },
+      {
+        "theorem": "hasSum_geometric_of_abs_lt_one",
+        "description": "HasSum (fun n => rⁿ) (1 − r)⁻¹ for |r| < 1. Supplies the infinite value and, via HasSum.tendsto_sum_nat, the upward convergence of the partial sums.",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-08-oq-01",
+      "question": "Extend the defect identity to the Ico-slice partial sum ∑_{k ∈ Ico m n} rᵏ and bound the slice by rᵐ/(1 − r); state the corresponding Cauchy-criterion estimate |∑_{k ∈ Ico m n} rᵏ| ≤ rᵐ/(1 − r) used in the comparison/ratio tests.",
+      "significance": "low"
+    },
+    {
+      "id": "geometric-series-oq-08-oq-02",
+      "question": "Give the two-sided form for negative ratios: for −1 < r < 0 the partial sums oscillate around (1 − r)⁻¹, with the same |rⁿ|/(1 − r) error envelope; formalise the alternating bracketing.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series",
+      "relationship": "extends",
+      "description": "Parent. The base entry records the finite closed form (1 − rⁿ)/(1 − r) and, separately, the infinite value 1/(1 − r). This entry supplies the quantitative bridge between them: the exact truncation defect rⁿ/(1 − r), the strict/non-strict bounds, monotonicity, and upward convergence."
+    },
+    {
+      "targetId": "geometric-series-oq-07",
+      "relationship": "sibling",
+      "description": "A sibling extension of the geometric series: oq-07 computes the second moment ∑ n² rⁿ of the infinite series, while this entry quantifies how the bare finite partial sums ∑_{k<n} rᵏ approach the infinite value 1/(1 − r)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Algebra.GeomSum",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the finite geometric closed form geom_sum_eq used as the anchor."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Basic",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the infinite geometric value hasSum_geometric_of_abs_lt_one and the partial-sum convergence HasSum.tendsto_sum_nat."
+    },
+    {
+      "title": "Concrete Mathematics (geometric series)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the finite geometric sum, its closed form, and the truncation error term."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For a real ratio r the finite geometric partial sum S n = ∑_{k<n} rᵏ has closed form (1 − rⁿ)/(1 − r) when r ≠ 1. This entry quantifies the relationship between these finite sums and the infinite value (1 − r)⁻¹ for 0 ≤ r < 1: the exact truncation defect (1 − r)⁻¹ − S n = rⁿ/(1 − r); the bounds S n < (1 − r)⁻¹ (strict, 0 < r < 1) and S n ≤ (1 − r)⁻¹; monotonicity of n ↦ S n; and upward convergence S n → (1 − r)⁻¹. Together they exhibit the infinite geometric value as the supremum of an increasing, bounded sequence with explicit error rⁿ/(1 − r). 128 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Mathlib provides the finite closed form and the infinite value as separate facts; the difference between them — the truncation error rⁿ/(1 − r) — is exactly what is needed to estimate a truncated geometric series, and it is the engine behind the comparison test, the ratio-test remainder, and numerical error bounds. Packaging it as a typed identity, together with the monotonicity and bound that make 1/(1 − r) the least upper bound of the partial sums, makes the finite/infinite relationship reusable rather than re-derived inline.",
+    "openQuestions": [
+      "Extend the defect and error envelope to Ico-slice partial sums (the Cauchy-criterion form).",
+      "State the alternating-bracketing version for −1 < r < 0."
+    ]
+  }
+}

--- a/src/data/research/problems/geometric-series-oq-08.json
+++ b/src/data/research/problems/geometric-series-oq-08.json
@@ -1,0 +1,70 @@
+{
+  "slug": "geometric-series-oq-08",
+  "title": "Finite Geometric Sums and the Infinite Limit: Defect, Bounds, and Monotonicity",
+  "phase": "COMPLETE",
+  "status": "active",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\forall (r : \\mathbb{R}),\\ 0 \\le r < 1 \\Rightarrow (1-r)^{-1} - \\sum_{k<n} r^k = \\frac{r^n}{1-r} \\ \\wedge\\ \\sum_{k<n} r^k \\le (1-r)^{-1}",
+    "plain": "For a real ratio r with 0 ≤ r < 1, the finite geometric partial sum ∑_{k<n} r^k approaches its infinite value (1−r)⁻¹ from below: the truncation defect is exactly r^n/(1−r), the partial sums are bounded above by (1−r)⁻¹ (strictly for 0 < r < 1), increase in n, and converge upward to the limit.",
+    "whyMatters": [
+      "The truncation error r^n/(1−r) is the estimate behind the comparison test, the ratio-test remainder, and numerical geometric-sum approximations.",
+      "Exhibits the infinite geometric value 1/(1−r) as the supremum of an increasing, bounded sequence of finite partial sums — the quantitative bridge between the gallery's finite closed form and its infinite value.",
+      "Provides a typed, reusable defect/bound package rather than re-deriving the error inline each time a geometric series is truncated."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Mathlib geom_sum_eq: ∑_{k<n} x^k = (x^n − 1)/(x − 1) for x ≠ 1 (finite closed form).",
+      "Mathlib hasSum_geometric_of_abs_lt_one: ∑ r^n = (1 − r)⁻¹ for |r| < 1 (infinite value).",
+      "Gallery GeometricSeries.lean: finite_geom_sum_div records the closed form (1 − r^n)/(1 − r); the infinite value is infinite_geom_sum."
+    ],
+    "open": [
+      "Ico-slice defect and Cauchy-criterion envelope (oq-01); alternating bracketing for −1 < r < 0 (oq-02)."
+    ],
+    "goal": "Ship a verified (0 sorries, 0 axioms) gallery entry with the truncation defect, strict/non-strict bounds, monotonicity, and upward convergence of finite geometric sums."
+  },
+  "currentState": {
+    "phase": "COMPLETE",
+    "since": "2026-06-20T00:00:00Z",
+    "iteration": 1,
+    "focus": "Shipped GeometricSeriesOQ08.lean + gallery entry; Docker build green (Lean v4.26.0), axiom-clean.",
+    "blockers": [],
+    "nextAction": "Done. Optional: Ico-slice envelope and negative-ratio bracketing (see openQuestions).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Shipped proofs/Proofs/GeometricSeriesOQ08.lean (128 lines, 6 theorems, 0 sorries/axioms) plus gallery meta.json. Theorems: geometric_sum_closed (closed form in the (1−r^n)/(1−r) convention), geometric_sum_tail (exact defect (1−r)⁻¹ − S n = r^n/(1−r)), geometric_sum_le_inv / geometric_sum_lt_inv (non-strict / strict upper bound by the infinite value), geometric_sum_monotone (partial sums increase), geometric_sum_tendsto_inv (upward convergence). Docker build verified green on Lean v4.26.0; import registered in Proofs.lean.",
+    "builtItems": [
+      "proofs/Proofs/GeometricSeriesOQ08.lean (verified, Docker-built); src/data/proofs/geometric-series-oq-08/meta.json; import in Proofs.lean."
+    ],
+    "mathlibGaps": [
+      "Mathlib states the finite closed form and the infinite value separately but not their difference (the truncation defect) nor the monotone-bounded-convergence package."
+    ],
+    "nextSteps": [
+      "Ico-slice defect + Cauchy envelope; alternating bracketing for negative ratios."
+    ]
+  },
+  "tags": [
+    "analysis",
+    "geometric-series",
+    "finite-sums",
+    "partial-sums",
+    "truncation-error",
+    "monotonicity",
+    "research"
+  ],
+  "relatedProofs": [
+    "geometric-series",
+    "geometric-series-oq-07"
+  ],
+  "started": "2026-06-20T00:00:00.000Z",
+  "lastUpdate": "2026-06-20T00:00:00.000Z",
+  "significance": 4,
+  "tractability": 8
+}


### PR DESCRIPTION
## Summary

New gallery entry **geometric-series-oq-08** — the quantitative bridge between the finite geometric partial sums and their infinite limit, for `0 ≤ r < 1`.

The base entry `GeometricSeries.lean` records the closed form `∑_{k<n} rᵏ = (1−rⁿ)/(1−r)` and, separately, the infinite value `∑' rᵏ = (1−r)⁻¹`. It does **not** make explicit *how* the finite sums approach the limit. This entry fills that gap.

## Results (6 theorems, 0 axioms, 0 sorries)

- `geometric_sum_closed` — closed form in the `(1−rⁿ)/(1−r)` convention (anchor; wraps `geom_sum_eq`).
- `geometric_sum_tail` — **exact truncation defect** `(1−r)⁻¹ − ∑_{k<n} rᵏ = rⁿ/(1−r)`: the infinite tail is itself a scaled geometric power.
- `geometric_sum_lt_inv` / `geometric_sum_le_inv` — strict bound `< (1−r)⁻¹` (for `0<r<1`) and non-strict `≤` (for `0≤r<1`, all `n`).
- `geometric_sum_monotone` — partial sums increase in `n` (each new term `rⁿ ≥ 0`).
- `geometric_sum_tendsto_inv` — upward convergence to `(1−r)⁻¹`, realising it as the supremum of an increasing bounded sequence.

The error term `rⁿ/(1−r)` is exactly the estimate used whenever a geometric series is truncated (numerical analysis, generating functions, comparison/ratio-test remainder). Mathlib has the closed form (`geom_sum_eq`) and the infinite value (`hasSum_geometric_of_abs_lt_one`) but not this defect/bound bundle.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ08` — **builds successfully** (3061 jobs, 0 errors).
- 0 `axiom` declarations, 0 `sorry`, no `native_decide` — status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)