### PR TITLE
audit(fermat-two-squares-oq-04): Jacobi divisor-character sum entry clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17677,6 +17677,12 @@
       "lastAudited": "2026-06-21T13:10:00Z",
       "result": "clean",
       "issues": []
+    },
+    "fermat-two-squares-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T13:11:23Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Auditor Report

Verified gallery integrity for **fermat-two-squares-oq-04** (Jacobi's two-square theorem, divisor-character-sum side — shipped in #27353).

### Result: CLEAN ✅

| Check | meta.json | source | match |
|-------|-----------|--------|-------|
| lineCount | 225 | 225 | ✅ |
| theoremCount | 10 | 10 | ✅ |
| definitionCount | 1 | 1 | ✅ |
| axiomCount | 0 | 0 | ✅ |
| sorries | 0 | 0 | ✅ |
| namespace | FermatTwoSquaresOQ04 | FermatTwoSquaresOQ04 | ✅ |

### Verification
- All 11 declarations present and named as claimed (`jacobiSum` def + 10 theorems incl. headline `jacobiSum_pos_iff_sq_add_sq`, `jacobiSum_eq_zero_iff`, `isMultiplicative_jacobiSum`).
- No `sorry`/`admit`/`native_decide`/`True` stubs.
- **Docker build succeeds**: `✔ Built Proofs.FermatTwoSquaresOQ04`.
- **`#print axioms`** on headline theorems lists only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. The `verified` status / 0-axiom claim is accurate.
- Honest scope: meta correctly states the full geometric identity r₂(n) = 4δ(n) is NOT formalized (needs ℤ[i] counting); only the divisor-sum side + qualitative representability bridge is claimed.

Updates `audit-tracker.json` to mark this slug audited (result: clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)