### PR TITLE
audit(geometric-series-oq-08): truncation-defect entry clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17683,6 +17683,12 @@
       "lastAudited": "2026-06-21T13:11:23Z",
       "result": "clean",
       "issues": []
+    },
+    "geometric-series-oq-08": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T13:18:39Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Auditor: gallery integrity verified — clean

**Slug:** `geometric-series-oq-08` (research #27355)
**Result:** clean

### Checks
- **Counts match meta.json exactly:** 129 lines, 6 theorems, 0 defs, 0 axioms, 0 sorries
- **Namespace:** `GeometricSeriesOQ08` matches all declarations
- **No taint:** no `sorry`/`admit`/`native_decide`; `status: verified` / `badge: original` is justified (0 assumptions)
- **Build:** `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ08` → build succeeded (3061 jobs). Only an informational deprecation warning on the `Mathlib.Algebra.GeomSum` import (not an error).

### Notes
Entry quantifies the finite→infinite geometric bridge: exact truncation defect `(1−r)⁻¹ − ∑_{k<n} rᵏ = rⁿ/(1−r)`, strict/non-strict bounds below the limit, partial-sum monotonicity, and upward convergence. All six theorems are genuine assemblies over Mathlib's `geom_sum_eq` + `hasSum_geometric_of_abs_lt_one`, not single-lemma wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)