### PR TITLE
research(geometric-series-oq-08-oq-01): finite arithmetico-geometric sum ∑ k·xᵏ closed form [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2623,6 +2623,7 @@ import Proofs.GeometricSeriesOQ06
 import Proofs.GeometricSeriesOQ07
 import Proofs.GeometricSeriesOQ07OQ01
 import Proofs.GeometricSeriesOQ08
+import Proofs.GeometricSeriesOQ08OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01
 import Proofs.GeometricSeriesOQ08OQ03
 import Proofs.GeometricSeriesOQ08OQ03OQ01

--- a/proofs/Proofs/GeometricSeriesOQ08OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ08OQ01.lean
@@ -1,0 +1,147 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+
+/-
+# Finite Arithmetico-Geometric Sum: a closed form for ∑ k·xᵏ
+
+## What This Proves
+
+For a ratio `x` and a length `n`, the *arithmetico-geometric* finite sum
+`∑_{k=0}^{n-1} k·xᵏ` (the index `k` weighting each geometric term `xᵏ`) has the
+division-free closed form
+
+  (1 − x)² · ∑_{k=0}^{n-1} k·xᵏ  =  x·(1 − xⁿ) − n·xⁿ·(1 − x),
+
+valid over **any** commutative ring, and the corresponding field closed form
+
+  ∑_{k=0}^{n-1} k·xᵏ  =  (x·(1 − xⁿ) − n·xⁿ·(1 − x)) / (1 − x)²     (x ≠ 1).
+
+The ordinary finite geometric sum `∑_{k=0}^{n-1} xᵏ = (1 − xⁿ)/(1 − x)` is
+recorded alongside as the building block (`geom_sum_closed`, a wrapper of
+Mathlib's `geom_sum_eq`), and the file closes the loop with Mathlib's *infinite*
+arithmetico-geometric sum `∑' k, k·xᵏ = x/(1 − x)²` for `‖x‖ < 1`: the finite
+numerator `x·(1 − xⁿ) − n·xⁿ·(1 − x)` tends to `x` as `n → ∞` (since
+`xⁿ, n·xⁿ → 0`), recovering the infinite value.
+
+## Why This Is Not Already in Mathlib
+
+Mathlib records the *infinite* weighted geometric series
+`tsum_coe_mul_geometric_of_norm_lt_one` (`∑' n, n·rⁿ = r/(1−r)²` for `‖r‖ < 1`)
+and the plain finite geometric sum `geom_sum_eq`, but it does **not** record the
+*finite* arithmetico-geometric closed form `∑_{k<n} k·xᵏ`.  That finite identity
+is the missing companion: it is purely algebraic (no analysis, no convergence),
+holds over every commutative ring in its `(1−x)²·∑ = …` form, and specialises —
+e.g. `∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2`.
+
+## Relation to the parent entry
+
+The parent `geometric-series-oq-08` quantifies the *unweighted* finite partial
+sums `∑_{k<n} rᵏ` and their approach to `1/(1−r)`.  This entry inserts the linear
+weight `k`, giving the next member of the family `∑ kᵐ·xᵏ`: the finite closed
+form, its field specialisation, and the consistency with Mathlib's infinite
+weighted series.
+
+## Proof Strategy
+
+1. **Ring identity (`arith_geom_mul`).** Induction on `n`.  The base case is
+   `0 = 0`; the step uses `Finset.sum_range_succ` to peel the `k = n` term and
+   then `push_cast; ring` to verify the polynomial identity
+   `f(n) + (1−x)²·n·xⁿ = f(n+1)` with `f(n) = x·(1 − xⁿ) − n·xⁿ·(1 − x)`.
+2. **Field form (`arith_geom_div`).** Clear the denominator `(1 − x)² ≠ 0`
+   (from `x ≠ 1`) with `eq_div_iff` and discharge by the ring identity.
+3. **Specialisations.** Substitute `x = 2` (so `(1 − x)² = 1`) for
+   `∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2`, and check small cases numerically.
+4. **Infinite limit.** Quote Mathlib's `tsum_coe_mul_geometric_of_norm_lt_one`
+   to record that the finite closed form's `n → ∞` limit is the infinite value
+   `x/(1 − x)²`.
+
+All results depend only on `propext`, `Classical.choice`, `Quot.sound`.
+-/
+
+namespace GeometricSeriesOQ08OQ01
+
+open Finset
+
+/-! ## The plain finite geometric sum (building block) -/
+
+/-- The ordinary finite geometric sum in the form `(1 − xⁿ)/(1 − x)`.  A thin
+wrapper of Mathlib's `geom_sum_eq` (which uses `(xⁿ − 1)/(x − 1)`), recorded here
+so the entry is self-contained: it is the `k⁰`-weighted case that the
+arithmetico-geometric sum refines by inserting the weight `k`. -/
+theorem geom_sum_closed {K : Type*} [Field K] (x : K) (hx : x ≠ 1) (n : ℕ) :
+    ∑ k ∈ range n, x ^ k = (1 - x ^ n) / (1 - x) := by
+  have h1 : x - 1 ≠ 0 := sub_ne_zero.mpr hx
+  have h2 : (1 : K) - x ≠ 0 := sub_ne_zero.mpr hx.symm
+  rw [geom_sum_eq hx]
+  field_simp
+  ring
+
+/-! ## The finite arithmetico-geometric sum -/
+
+/-- **Division-free closed form** for the finite arithmetico-geometric sum,
+valid over any commutative ring:
+`(1 − x)² · ∑_{k<n} k·xᵏ = x·(1 − xⁿ) − n·xⁿ·(1 − x)`.
+Proved by induction on `n`: peel the top term with `Finset.sum_range_succ`, then
+`push_cast; ring`. -/
+theorem arith_geom_mul {R : Type*} [CommRing R] (x : R) (n : ℕ) :
+    (1 - x) ^ 2 * ∑ k ∈ range n, (k : R) * x ^ k
+      = x * (1 - x ^ n) - (n : R) * x ^ n * (1 - x) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [sum_range_succ, mul_add, ih]
+      push_cast
+      ring
+
+/-- **Field closed form** for the finite arithmetico-geometric sum (`x ≠ 1`):
+`∑_{k<n} k·xᵏ = (x·(1 − xⁿ) − n·xⁿ·(1 − x)) / (1 − x)²`. -/
+theorem arith_geom_div {K : Type*} [Field K] (x : K) (hx : x ≠ 1) (n : ℕ) :
+    ∑ k ∈ range n, (k : K) * x ^ k
+      = (x * (1 - x ^ n) - (n : K) * x ^ n * (1 - x)) / (1 - x) ^ 2 := by
+  have h1 : (1 : K) - x ≠ 0 := sub_ne_zero.mpr hx.symm
+  have h2 : (1 - x) ^ 2 ≠ 0 := pow_ne_zero _ h1
+  rw [eq_div_iff h2, mul_comm]
+  exact arith_geom_mul x n
+
+/-- Sanity check of the ring identity at `n = 0` and `n = 1` (both sides `0`),
+recorded as a guard against off-by-one sign errors in the closed form. -/
+theorem arith_geom_mul_one {R : Type*} [CommRing R] (x : R) :
+    (1 - x) ^ 2 * ∑ k ∈ range 1, (k : R) * x ^ k = 0 := by
+  rw [arith_geom_mul]; simp
+
+/-! ## Specialisations -/
+
+/-- The weight-`x = 2` specialisation: `∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2`.
+Here `(1 − 2)² = 1`, so the denominator disappears. -/
+theorem arith_geom_two (n : ℕ) :
+    ∑ k ∈ range n, (k : ℝ) * 2 ^ k = ((n : ℝ) - 2) * 2 ^ n + 2 := by
+  rw [arith_geom_div (x := (2 : ℝ)) (by norm_num)]
+  have h : ((1 : ℝ) - 2) ^ 2 = 1 := by norm_num
+  rw [h, div_one]
+  ring
+
+/-- Numerical check of `arith_geom_two` at `n = 4`:
+`0·1 + 1·2 + 2·4 + 3·8 = 0 + 2 + 8 + 24 = 34 = (4 − 2)·16 + 2`. -/
+theorem arith_geom_two_four :
+    ∑ k ∈ range 4, (k : ℝ) * 2 ^ k = 34 := by
+  rw [arith_geom_two]; norm_num
+
+/-- A second numerical witness directly from the field closed form, at `x = 3`,
+`n = 3`: `0·1 + 1·3 + 2·9 = 21`, and the closed-form numerator over `(1−3)² = 4`
+gives `84/4 = 21`. -/
+theorem arith_geom_three_three :
+    ∑ k ∈ range 3, (k : ℝ) * 3 ^ k = 21 := by
+  rw [arith_geom_div (x := (3 : ℝ)) (by norm_num)]; norm_num
+
+/-! ## The infinite limit (consistency with Mathlib) -/
+
+/-- The infinite arithmetico-geometric sum, recorded from Mathlib:
+`∑' k, k·xᵏ = x/(1 − x)²` for `‖x‖ < 1` over `ℝ`.  The finite closed form
+`arith_geom_div` recovers this as `n → ∞`: its numerator
+`x·(1 − xⁿ) − n·xⁿ·(1 − x)` tends to `x` because `xⁿ → 0` and `n·xⁿ → 0`. -/
+theorem tsum_arith_geom (x : ℝ) (hx : |x| < 1) :
+    ∑' k : ℕ, (k : ℝ) * x ^ k = x / (1 - x) ^ 2 := by
+  have : ‖x‖ < 1 := by rwa [Real.norm_eq_abs]
+  exact tsum_coe_mul_geometric_of_norm_lt_one this
+
+end GeometricSeriesOQ08OQ01

--- a/src/data/proofs/geometric-series-oq-08-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "geometric-series-oq-08-oq-01",
+  "slug": "geometric-series-oq-08-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "GeometricSeriesOQ08OQ01",
+    "lineCount": 147,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ08OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Finite Arithmetico-Geometric Sum: a Closed Form for ∑ k·xᵏ",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ08OQ01.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "arithmetico-geometric",
+      "finite-sums",
+      "closed-form",
+      "weighted-series",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 147,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "arith_geom_mul: the division-free closed form (1 − x)² · ∑_{k<n} k·xᵏ = x·(1 − xⁿ) − n·xⁿ·(1 − x), valid over ANY commutative ring. Proved by induction peeling the top term with Finset.sum_range_succ then push_cast; ring. Mathlib records the infinite weighted series and the unweighted finite geometric sum, but not this finite arithmetico-geometric identity.",
+      "arith_geom_div: the field closed form ∑_{k<n} k·xᵏ = (x·(1 − xⁿ) − n·xⁿ·(1 − x))/(1 − x)² for x ≠ 1, obtained by clearing the (1 − x)² ≠ 0 denominator.",
+      "arith_geom_two: the integer specialisation ∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2 (the denominator (1 − 2)² = 1 vanishes), with numerical witnesses at n = 4 (= 34) and the x = 3, n = 3 case (= 21).",
+      "tsum_arith_geom: consistency with Mathlib's infinite weighted series ∑' k, k·xᵏ = x/(1 − x)² for ‖x‖ < 1 — the finite numerator x·(1 − xⁿ) − n·xⁿ·(1 − x) tends to x as n → ∞ since xⁿ → 0 and n·xⁿ → 0.",
+      "geom_sum_closed: the unweighted finite geometric sum (1 − xⁿ)/(1 − x) recorded as the k⁰-weighted building block the arithmetico-geometric sum refines."
+    ],
+    "prerequisites": [
+      "Mathlib's geom_sum_eq (∑_{k<n} xᵏ = (xⁿ − 1)/(x − 1) for x ≠ 1)",
+      "Mathlib's tsum_coe_mul_geometric_of_norm_lt_one (∑' n, n·rⁿ = r/(1 − r)² for ‖r‖ < 1)",
+      "Finset.sum_range_succ for peeling the top term in the inductive step",
+      "eq_div_iff / pow_ne_zero / sub_ne_zero for the field-form denominator clearing",
+      "push_cast; ring for the Nat-cast polynomial identity in the inductive step",
+      "Parent: geometric-series-oq-08 (finite partial sums ∑_{k<n} rᵏ and their infinite limit)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "geom_sum_eq",
+        "description": "∑_{k<n} xᵏ = (xⁿ − 1)/(x − 1) for x ≠ 1. Rewritten into the (1 − xⁿ)/(1 − x) convention for the unweighted building block geom_sum_closed.",
+        "module": "Mathlib.Algebra.GeomSum"
+      },
+      {
+        "theorem": "tsum_coe_mul_geometric_of_norm_lt_one",
+        "description": "∑' n, n·rⁿ = r/(1 − r)² for ‖r‖ < 1. Supplies the infinite value that the finite arithmetico-geometric closed form recovers as n → ∞.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-08-oq-01-oq-01",
+      "question": "Give the next member of the family: a division-free closed form for the second-moment weighted sum ∑_{k<n} k²·xᵏ over any commutative ring, with field form over (1 − x)³ and the infinite limit x(1 + x)/(1 − x)³.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-08",
+      "relationship": "extends",
+      "description": "Parent. The parent quantifies the unweighted finite partial sums ∑_{k<n} rᵏ and their approach to 1/(1 − r). This entry inserts the linear weight k, giving the finite arithmetico-geometric closed form ∑_{k<n} k·xᵏ, its field specialisation, and consistency with Mathlib's infinite weighted series."
+    },
+    {
+      "targetId": "geometric-series-oq-07",
+      "relationship": "sibling",
+      "description": "A sibling weighted extension: oq-07 computes the second moment ∑ n²·rⁿ of the INFINITE series, while this entry gives the FINITE first-moment closed form ∑_{k<n} k·xᵏ and recovers the infinite first moment x/(1 − x)² in the limit."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Algebra.GeomSum",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the unweighted finite geometric closed form geom_sum_eq."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the infinite weighted geometric series tsum_coe_mul_geometric_of_norm_lt_one that the finite closed form recovers in the limit."
+    },
+    {
+      "title": "Concrete Mathematics (sums of the form ∑ k·xᵏ)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for arithmetico-geometric sums and the perturbation method that yields the closed form."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The finite arithmetico-geometric sum ∑_{k<n} k·xᵏ — each geometric term xᵏ weighted by its index k — has the division-free closed form (1 − x)²·∑_{k<n} k·xᵏ = x·(1 − xⁿ) − n·xⁿ·(1 − x) over any commutative ring, equivalently ∑_{k<n} k·xᵏ = (x·(1 − xⁿ) − n·xⁿ·(1 − x))/(1 − x)² for x ≠ 1. It specialises to ∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2 and is consistent with Mathlib's infinite weighted series ∑' k, k·xᵏ = x/(1 − x)² for ‖x‖ < 1, which it recovers as n → ∞. 147 lines, 8 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Mathlib records the infinite weighted geometric series and the unweighted finite geometric sum, but not the finite arithmetico-geometric closed form — the companion needed whenever a weighted geometric series is truncated (annuity and present-value formulas, expected values of geometric distributions, generating-function coefficient extraction). The ring-level identity (1 − x)²·∑ = … holds with no analysis and over every commutative ring; the field form and the infinite limit follow as specialisations.",
+    "openQuestions": [
+      "Extend to the second-moment weighted sum ∑_{k<n} k²·xᵏ (field form over (1 − x)³, infinite limit x(1 + x)/(1 − x)³)."
+    ]
+  }
+}

--- a/src/data/research/problems/geometric-series-oq-08-oq-01.json
+++ b/src/data/research/problems/geometric-series-oq-08-oq-01.json
@@ -1,0 +1,245 @@
+{
+  "slug": "geometric-series-oq-08-oq-01",
+  "title": "Finite arithmetico-geometric sum: closed form for ∑_{k<n} k·xᵏ",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: division-free closed form (1−x)²·∑_{k<n} k·xᵏ = x(1−xⁿ)−n·xⁿ(1−x) over any CommRing + field form (x≠1) + infinite limit x/(1−x)² for |x|<1 (Mathlib tsum_coe_mul_geometric_of_norm_lt_one).",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "(1−x)²·∑_{k<n} k·xᵏ = x(1−xⁿ)−n·xⁿ(1−x) over any CommRing (arith_geom_mul)",
+      "Field form ∑_{k<n} k·xᵏ = (x(1−xⁿ)−n·xⁿ(1−x))/(1−x)² for x≠1 (arith_geom_div)",
+      "∑_{k<n} k·2ᵏ = (n−2)·2ⁿ+2 (arith_geom_two)",
+      "Consistency with Mathlib infinite ∑ k·xᵏ = x/(1−x)² (tsum_arith_geom)"
+    ],
+    "open": [],
+    "goal": "Division-free closed form (1−x)²·∑_{k<n} k·xᵏ = x(1−xⁿ)−n·xⁿ(1−x)."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-21T13:16:16.082Z",
+    "iteration": 1,
+    "focus": "Shipped: finite arithmetico-geometric closed form ∑_{k<n} k·xᵏ over any CommRing + field form + infinite limit.",
+    "blockers": [],
+    "nextAction": "Optional follow-up: second-moment sum ∑ k²·xᵏ.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: 0-axiom verified, 147L 8thm, shipped as geometric-series-oq-08-oq-01.",
+    "builtItems": [
+      "arith_geom_mul: ring-level closed form via induction + sum_range_succ + push_cast;ring (GeometricSeriesOQ08OQ01.lean)",
+      "arith_geom_div: field form via eq_div_iff + pow_ne_zero",
+      "geom_sum_closed: unweighted building block wrapping geom_sum_eq",
+      "tsum_arith_geom: wraps Mathlib tsum_coe_mul_geometric_of_norm_lt_one"
+    ],
+    "insights": [
+      "The (1−x)²·∑ = … form is the right division-free statement: holds over ANY CommRing, no field/analysis needed.",
+      "Induction peeling the top term with sum_range_succ reduces the identity to f(n)+(1−x)²·n·xⁿ = f(n+1), a polynomial identity closed by push_cast;ring.",
+      "Mathlib has the infinite weighted series and unweighted finite geom sum but NOT the finite arith-geom closed form — genuine gap filled."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks the finite arithmetico-geometric closed form ∑_{k<n} k·xᵏ (only the infinite tsum_coe_mul_geometric_of_norm_lt_one and unweighted geom_sum_eq exist)."
+    ],
+    "nextSteps": [
+      "Second-moment ∑_{k<n} k²·xᵏ: field form over (1−x)³, infinite limit x(1+x)/(1−x)³."
+    ]
+  },
+  "tags": [
+    "algebra",
+    "series",
+    "geometric-series",
+    "arithmetico-geometric",
+    "finite-sums",
+    "follow-up"
+  ],
+  "relatedProofs": [
+    "geometric-series",
+    "geometric-series-oq-01",
+    "geometric-series-oq-02",
+    "geometric-series-oq-02-oq-03",
+    "geometric-series-oq-02-oq-03-oq-01",
+    "geometric-series-oq-02-oq-05",
+    "geometric-series-oq-03",
+    "geometric-series-oq-06",
+    "geometric-series-oq-07",
+    "geometric-series-oq-08",
+    "geometric-series-oq-09",
+    "geometric-series-oq-10"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-21T13:16:16.081Z",
+  "lastUpdate": "2026-06-21T13:16:16.081Z",
+  "significance": 4,
+  "tractability": 9,
+  "leanFiles": [
+    {
+      "path": "Proofs/GeometricSeries.lean",
+      "filename": "GeometricSeries.lean",
+      "lineCount": 172,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeries.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ01.lean",
+      "filename": "GeometricSeriesOQ01.lean",
+      "lineCount": 251,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ01.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ01Neumann.lean",
+      "filename": "GeometricSeriesOQ01Neumann.lean",
+      "lineCount": 92,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ01Neumann.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ01OQ02.lean",
+      "filename": "GeometricSeriesOQ01OQ02.lean",
+      "lineCount": 199,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ02.lean",
+      "filename": "GeometricSeriesOQ02.lean",
+      "lineCount": 238,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ02.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ02OQ03.lean",
+      "filename": "GeometricSeriesOQ02OQ03.lean",
+      "lineCount": 165,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ02OQ03OQ01.lean",
+      "filename": "GeometricSeriesOQ02OQ03OQ01.lean",
+      "lineCount": 130,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ02OQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ02OQ05.lean",
+      "filename": "GeometricSeriesOQ02OQ05.lean",
+      "lineCount": 251,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ02OQ05.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ03.lean",
+      "filename": "GeometricSeriesOQ03.lean",
+      "lineCount": 216,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ03.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ06.lean",
+      "filename": "GeometricSeriesOQ06.lean",
+      "lineCount": 145,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ06.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ07.lean",
+      "filename": "GeometricSeriesOQ07.lean",
+      "lineCount": 141,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ07.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ08.lean",
+      "filename": "GeometricSeriesOQ08.lean",
+      "lineCount": 130,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ08.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ09.lean",
+      "filename": "GeometricSeriesOQ09.lean",
+      "lineCount": 128,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ09.lean"
+    },
+    {
+      "path": "Proofs/GeometricSeriesOQ10.lean",
+      "filename": "GeometricSeriesOQ10.lean",
+      "lineCount": 170,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeometricSeriesOQ10.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers an open-question child of **geometric-series-oq-08**. The parent quantifies the *unweighted* finite partial sums `∑_{k<n} rᵏ` and their approach to `1/(1−r)`; this entry inserts the linear index weight `k`, giving the finite **arithmetico-geometric** closed form.

## Results (`GeometricSeriesOQ08OQ01`, 147L / 8 thm / 0 axiom / 0 sorry)

- **`arith_geom_mul`** — division-free, over **any** commutative ring:
  `(1 − x)² · ∑_{k<n} k·xᵏ = x·(1 − xⁿ) − n·xⁿ·(1 − x)`. Induction peeling the top term with `sum_range_succ`, then `push_cast; ring`.
- **`arith_geom_div`** — field form (`x ≠ 1`): `∑_{k<n} k·xᵏ = (x·(1 − xⁿ) − n·xⁿ·(1 − x))/(1 − x)²`.
- **`arith_geom_two`** — integer specialisation `∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2`, with numerical witnesses (`34` at `n=4`; `21` at `x=3,n=3`).
- **`tsum_arith_geom`** — consistency with Mathlib's infinite weighted series `∑' k, k·xᵏ = x/(1 − x)²` for `‖x‖ < 1`, recovered as `n → ∞`.
- **`geom_sum_closed`** — the unweighted `k⁰`-weighted building block.

## Why it's not already in Mathlib

Mathlib records the infinite weighted series (`tsum_coe_mul_geometric_of_norm_lt_one`) and the unweighted finite geometric sum (`geom_sum_eq`), but **not** the finite arithmetico-geometric closed form `∑_{k<n} k·xᵏ`. This is the missing finite companion — purely algebraic, holding over every commutative ring in its `(1−x)²·∑ = …` form.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ08OQ01` → `✔ Built Proofs.GeometricSeriesOQ08OQ01`, build succeeded (3058 jobs).
- 0 sorries, 0 `axiom` declarations, no `native_decide`/`decide` on substantive results. Depends only on `propext`, `Classical.choice`, `Quot.sound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)