### PR TITLE
research(feuerbachs-theorem-defs-oq-02-oq-01): Euler's circumcenter–excenter formula OIₐ² = R² + 2Rrₐ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2515,6 +2515,7 @@ import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01
 import Proofs.FeuerbachsTheoremDefsOQ02
+import Proofs.FeuerbachsTheoremDefsOQ02OQ01
 import Proofs.FeuerbachsTheoremDefsOQ03
 import Proofs.FeuerbachsTheoremDefsOQ04
 import Proofs.FeuerbachsTheoremOQ01

--- a/proofs/Proofs/FeuerbachsTheoremDefsOQ02OQ01.lean
+++ b/proofs/Proofs/FeuerbachsTheoremDefsOQ02OQ01.lean
@@ -1,0 +1,594 @@
+/-
+  Feuerbach's Theorem DefsOQ02OQ01:
+  Euler's Circumcenter–Excenter Formula   OI_a² = R² + 2·R·r_a
+
+  ## The Open Question
+
+  The sibling file `FeuerbachsTheoremDefsOQ02` proves **Euler's 1765 formula**
+  relating the circumcentre O and the *incentre* I:
+
+      OI² = R² − 2·R·r          (and hence R ≥ 2r, Euler's inequality).
+
+  Euler's *other* metric relation of the same vintage concerns the three
+  **excentres** I_a, I_b, I_c (centres of the escribed circles).  For the
+  excentre opposite A one has the sign-flipped companion
+
+      OI_a² = R² + 2·R·r_a,
+
+  where r_a is the corresponding exradius.  Unlike the incentre case the
+  right-hand side is the *sum* R² + 2Rr_a, so it never vanishes: the
+  circumcentre always lies strictly outside every excircle's centre region, in
+  fact OI_a > R for every triangle.
+
+  ## What This File Proves
+
+  For an arbitrary non-degenerate triangle T (working purely in coordinates):
+
+  ### A reusable weighted-norm identity
+  `weighted_norm_sq_gen` :  for any real weights w_a,w_b,w_c, with O the
+  circumcentre and R² = |A−O|²,
+      |w_a(A−O)+w_b(B−O)+w_c(C−O)|²
+        = R²·(w_a+w_b+w_c)² − (w_a w_b c² + w_b w_c a² + w_c w_a b²).
+  Specialising the weights to (−a,b,c), (a,−b,c), (a,b,−c) yields the three
+  excentres (and to (a,b,c) the incentre, recovering the sibling file).
+
+  ### The strict triangle inequality (the genuinely new ingredient)
+  `strict_tri_ineq_a` :  a < b + c, with the two companions for b and c.
+  These force the excentre denominators p_a = −a+b+c, p_b, p_c to be **positive**
+  — the incentre proof never needed this because its denominator is a+b+c.
+  The proof is the 2-D Lagrange/Cauchy–Schwarz identity
+      b²c² − ⟨A−C,B−A⟩² = (nondegeneracy determinant)² > 0.
+
+  ### The affine core and Euler's excentre formula
+  `OI_a_sq_eq_R2_add` :  dist²(O, I_a) = R² + abc/(−a+b+c).
+  `two_R_ra_eq`       :  2·R·r_a = abc/(−a+b+c).
+  `euler_OI_a_formula` :  dist²(O, I_a) = R² + 2·R·r_a   (and b, c versions).
+
+  ### Strict consequence
+  `circumradius_lt_OI_a` :  R < OI_a  (the circumcentre is farther from every
+  excentre than the circumradius).
+
+  ### Example
+  `triangle_345_OI_a_sq` :  for the 3-4-5 triangle, dist²(O, I_a) = 145/4
+  (and indeed R² + 2Rr_a = (5/2)² + 2·(5/2)·6 = 145/4, with I_a = (6,6),
+  r_a = 6).
+
+  The heavy law-of-sines bridge `4·R·Area = abc` is reused from the sibling
+  file `FeuerbachsTheoremDefsOQ02`; everything else is developed here.
+
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Proofs.FeuerbachsTheoremDefsOQ02
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace FeuerbachExcenterEuler
+
+open FeuerbachsTheorem
+open scoped Real
+
+-- ============================================================
+-- PART 1: Circumcentre equidistance (parent's are private)
+-- ============================================================
+
+/-- Squared distance is non-negative. -/
+private lemma dist2_sq_nonneg (P Q : Point) : 0 ≤ dist2_sq P Q := by
+  unfold dist2_sq; positivity
+
+set_option maxHeartbeats 6400000 in
+/-- Perpendicular bisector of AB passes through the circumcentre (linear in O). -/
+private lemma pb_AB (T : Triangle) :
+    (T.B.1 - T.A.1) * (T.B.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.B.2 - T.A.2) * (T.B.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+set_option maxHeartbeats 6400000 in
+/-- Perpendicular bisector of AC passes through the circumcentre. -/
+private lemma pb_AC (T : Triangle) :
+    (T.C.1 - T.A.1) * (T.C.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.C.2 - T.A.2) * (T.C.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+/-- |B − O|² = |A − O|² : circumcentre equidistant from A and B. -/
+private lemma equidist_B (T : Triangle) :
+    (T.B.1 - T.circumcenter.1) ^ 2 + (T.B.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := pb_AB T
+  nlinarith [h, sq_nonneg (T.B.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.B.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+/-- |C − O|² = |A − O|² : circumcentre equidistant from A and C. -/
+private lemma equidist_C (T : Triangle) :
+    (T.C.1 - T.circumcenter.1) ^ 2 + (T.C.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := pb_AC T
+  nlinarith [h, sq_nonneg (T.C.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.C.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+-- ============================================================
+-- PART 2: Side lengths (squared values and positivity)
+-- ============================================================
+
+private lemma side_a_sq (T : Triangle) :
+    T.side_a ^ 2 = (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by
+  unfold Triangle.side_a; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_b_sq (T : Triangle) :
+    T.side_b ^ 2 = (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by
+  unfold Triangle.side_b; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_c_sq (T : Triangle) :
+    T.side_c ^ 2 = (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by
+  unfold Triangle.side_c; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_a_nonneg (T : Triangle) : 0 ≤ T.side_a := Real.sqrt_nonneg _
+private lemma side_b_nonneg (T : Triangle) : 0 ≤ T.side_b := Real.sqrt_nonneg _
+private lemma side_c_nonneg (T : Triangle) : 0 ≤ T.side_c := Real.sqrt_nonneg _
+
+/-- The triangle area is positive (non-degeneracy). -/
+private lemma area_pos (T : Triangle) : 0 < T.area := by
+  unfold Triangle.area
+  have hne := T.nondegenerate
+  have h : 0 < |(T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2)| :=
+    abs_pos.mpr hne
+  linarith
+
+private lemma side_a_pos (T : Triangle) : 0 < T.side_a := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.C.1 - T.B.1 = 0 := by nlinarith [sq_nonneg (T.C.1 - T.B.1), sq_nonneg (T.C.2 - T.B.2)]
+    have hy : T.C.2 - T.B.2 = 0 := by nlinarith [sq_nonneg (T.C.1 - T.B.1), sq_nonneg (T.C.2 - T.B.2)]
+    apply hne; linear_combination (T.B.1 - T.A.1) * hy - (T.B.2 - T.A.2) * hx
+  unfold Triangle.side_a; exact Real.sqrt_pos.mpr h
+
+private lemma side_b_pos (T : Triangle) : 0 < T.side_b := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.A.1 - T.C.1 = 0 := by nlinarith [sq_nonneg (T.A.1 - T.C.1), sq_nonneg (T.A.2 - T.C.2)]
+    have hy : T.A.2 - T.C.2 = 0 := by nlinarith [sq_nonneg (T.A.1 - T.C.1), sq_nonneg (T.A.2 - T.C.2)]
+    apply hne; linear_combination (T.B.2 - T.A.2) * hx - (T.B.1 - T.A.1) * hy
+  unfold Triangle.side_b; exact Real.sqrt_pos.mpr h
+
+private lemma side_c_pos (T : Triangle) : 0 < T.side_c := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.B.1 - T.A.1 = 0 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+    have hy : T.B.2 - T.A.2 = 0 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+    apply hne; linear_combination (T.C.2 - T.A.2) * hx - (T.C.1 - T.A.1) * hy
+  unfold Triangle.side_c; exact Real.sqrt_pos.mpr h
+
+-- ============================================================
+-- PART 3: The strict triangle inequality  a < b + c
+-- ============================================================
+
+set_option maxHeartbeats 1600000 in
+/-- **Strict triangle inequality, side a.**  For a non-degenerate triangle the
+    Euclidean side lengths satisfy a < b + c.  This is the new ingredient that
+    the incentre proof never needed: it forces the excentre denominator
+    p_a = −a + b + c to be strictly positive.
+
+    Proof via the 2-D Lagrange identity
+        b²c² − ⟨A−C, B−A⟩² = (nondegeneracy determinant)² > 0,
+    so the dot product ⟨A−C,B−A⟩ is strictly below bc, whence a² < (b+c)². -/
+private lemma strict_tri_ineq_a (T : Triangle) :
+    T.side_a < T.side_b + T.side_c := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hapos := side_a_pos T
+  have hbpos := side_b_pos T
+  have hcpos := side_c_pos T
+  -- nondegeneracy determinant and the inner product
+  set D := (T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2) with hDdef
+  set P := (T.A.1 - T.C.1) * (T.B.1 - T.A.1) + (T.A.2 - T.C.2) * (T.B.2 - T.A.2) with hPdef
+  have hDne : D ≠ 0 := T.nondegenerate
+  have hD2 : 0 < D ^ 2 := by
+    rcases hDne.lt_or_gt with h | h
+    · nlinarith [h]
+    · nlinarith [h]
+  -- law of cosines (squared) and Lagrange identity
+  have hexp : T.side_a ^ 2 = T.side_b ^ 2 + T.side_c ^ 2 + 2 * P := by
+    rw [ha, hb, hc, hPdef]; ring
+  have hlag : T.side_b ^ 2 * T.side_c ^ 2 - P ^ 2 = D ^ 2 := by
+    rw [hb, hc, hPdef, hDdef]; ring
+  -- strict Cauchy–Schwarz: P² < (bc)²
+  have hP2 : P ^ 2 < (T.side_b * T.side_c) ^ 2 := by nlinarith [hlag, hD2]
+  -- hence P < bc
+  have hbc : 0 < T.side_b * T.side_c := mul_pos hbpos hcpos
+  have hPlt : P < T.side_b * T.side_c := by nlinarith [hP2, hbc]
+  -- a² < (b+c)²
+  have hsum_pos : 0 < T.side_b + T.side_c := by linarith
+  have hasq : T.side_a ^ 2 < (T.side_b + T.side_c) ^ 2 := by nlinarith [hexp, hPlt]
+  nlinarith [hasq, hapos, hsum_pos]
+
+set_option maxHeartbeats 1600000 in
+private lemma strict_tri_ineq_b (T : Triangle) :
+    T.side_b < T.side_a + T.side_c := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hapos := side_a_pos T
+  have hbpos := side_b_pos T
+  have hcpos := side_c_pos T
+  set D := (T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2) with hDdef
+  set P := (T.C.1 - T.B.1) * (T.B.1 - T.A.1) + (T.C.2 - T.B.2) * (T.B.2 - T.A.2) with hPdef
+  have hDne : D ≠ 0 := T.nondegenerate
+  have hD2 : 0 < D ^ 2 := by
+    rcases hDne.lt_or_gt with h | h
+    · nlinarith [h]
+    · nlinarith [h]
+  -- law of cosines at B:  b² = a² + c² + 2⟨C−B, B−A⟩
+  have hexp : T.side_b ^ 2 = T.side_a ^ 2 + T.side_c ^ 2 + 2 * P := by
+    rw [ha, hb, hc, hPdef]; ring
+  have hlag : T.side_a ^ 2 * T.side_c ^ 2 - P ^ 2 = D ^ 2 := by
+    rw [ha, hc, hPdef, hDdef]; ring
+  have hP2 : P ^ 2 < (T.side_a * T.side_c) ^ 2 := by nlinarith [hlag, hD2]
+  have hac : 0 < T.side_a * T.side_c := mul_pos hapos hcpos
+  have hPlt : P < T.side_a * T.side_c := by nlinarith [hP2, hac]
+  have hsum_pos : 0 < T.side_a + T.side_c := by linarith
+  have hbsq : T.side_b ^ 2 < (T.side_a + T.side_c) ^ 2 := by nlinarith [hexp, hPlt]
+  nlinarith [hbsq, hbpos, hsum_pos]
+
+set_option maxHeartbeats 1600000 in
+private lemma strict_tri_ineq_c (T : Triangle) :
+    T.side_c < T.side_a + T.side_b := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hapos := side_a_pos T
+  have hbpos := side_b_pos T
+  have hcpos := side_c_pos T
+  set D := (T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2) with hDdef
+  set P := (T.C.1 - T.A.1) * (T.B.1 - T.C.1) + (T.C.2 - T.A.2) * (T.B.2 - T.C.2) with hPdef
+  have hDne : D ≠ 0 := T.nondegenerate
+  have hD2 : 0 < D ^ 2 := by
+    rcases hDne.lt_or_gt with h | h
+    · nlinarith [h]
+    · nlinarith [h]
+  -- law of cosines at C:  c² = a² + b² + 2⟨C−A, B−C⟩
+  have hexp : T.side_c ^ 2 = T.side_a ^ 2 + T.side_b ^ 2 + 2 * P := by
+    rw [ha, hb, hc, hPdef]; ring
+  have hlag : T.side_a ^ 2 * T.side_b ^ 2 - P ^ 2 = D ^ 2 := by
+    rw [ha, hb, hPdef, hDdef]; ring
+  have hP2 : P ^ 2 < (T.side_a * T.side_b) ^ 2 := by nlinarith [hlag, hD2]
+  have hab : 0 < T.side_a * T.side_b := mul_pos hapos hbpos
+  have hPlt : P < T.side_a * T.side_b := by nlinarith [hP2, hab]
+  have hsum_pos : 0 < T.side_a + T.side_b := by linarith
+  have hcsq : T.side_c ^ 2 < (T.side_a + T.side_b) ^ 2 := by nlinarith [hexp, hPlt]
+  nlinarith [hcsq, hcpos, hsum_pos]
+
+/-- Excentre denominators are strictly positive. -/
+private lemma pa_pos (T : Triangle) : 0 < -T.side_a + T.side_b + T.side_c := by
+  have := strict_tri_ineq_a T; linarith
+
+private lemma pb_pos (T : Triangle) : 0 < T.side_a - T.side_b + T.side_c := by
+  have := strict_tri_ineq_b T; linarith
+
+private lemma pc_pos (T : Triangle) : 0 < T.side_a + T.side_b - T.side_c := by
+  have := strict_tri_ineq_c T; linarith
+
+-- ============================================================
+-- PART 4: The reusable weighted-norm identity
+-- ============================================================
+
+/-- Master algebraic identity.  With O the circumcentre and R² = |A − O|², the
+    weighted vector  w_a(A−O) + w_b(B−O) + w_c(C−O)  has squared length
+        R²·(w_a+w_b+w_c)² − (w_a w_b c² + w_b w_c a² + w_c w_a b²).
+    Specialising the weights selects the incentre (a,b,c) or any excentre. -/
+private lemma weighted_norm_sq_gen (T : Triangle) (wa wb wc : ℝ) :
+    (wa * (T.A.1 - T.circumcenter.1) + wb * (T.B.1 - T.circumcenter.1)
+        + wc * (T.C.1 - T.circumcenter.1)) ^ 2 +
+    (wa * (T.A.2 - T.circumcenter.2) + wb * (T.B.2 - T.circumcenter.2)
+        + wc * (T.C.2 - T.circumcenter.2)) ^ 2 =
+    ((T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2)
+        * (wa + wb + wc) ^ 2
+    - (wa * wb * T.side_c ^ 2 + wb * wc * T.side_a ^ 2 + wc * wa * T.side_b ^ 2) := by
+  set O := T.circumcenter
+  set R2 := (T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2 with hR2
+  have e1 : (T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2 = R2 := rfl
+  have e2 : (T.B.1 - O.1) ^ 2 + (T.B.2 - O.2) ^ 2 = R2 := by rw [hR2]; exact equidist_B T
+  have e3 : (T.C.1 - O.1) ^ 2 + (T.C.2 - O.2) ^ 2 = R2 := by rw [hR2]; exact equidist_C T
+  have dotAB : (T.A.1 - O.1) * (T.B.1 - O.1) + (T.A.2 - O.2) * (T.B.2 - O.2)
+      = R2 - T.side_c ^ 2 / 2 := by
+    have hc := side_c_sq T
+    linear_combination (1 / 2) * e1 + (1 / 2) * e2 + (1 / 2) * hc
+  have dotBC : (T.B.1 - O.1) * (T.C.1 - O.1) + (T.B.2 - O.2) * (T.C.2 - O.2)
+      = R2 - T.side_a ^ 2 / 2 := by
+    have ha := side_a_sq T
+    linear_combination (1 / 2) * e2 + (1 / 2) * e3 + (1 / 2) * ha
+  have dotCA : (T.C.1 - O.1) * (T.A.1 - O.1) + (T.C.2 - O.2) * (T.A.2 - O.2)
+      = R2 - T.side_b ^ 2 / 2 := by
+    have hb := side_b_sq T
+    linear_combination (1 / 2) * e3 + (1 / 2) * e1 + (1 / 2) * hb
+  linear_combination
+    wa ^ 2 * e1 + wb ^ 2 * e2 + wc ^ 2 * e3
+    + 2 * wa * wb * dotAB + 2 * wb * wc * dotBC + 2 * wc * wa * dotCA
+
+-- ============================================================
+-- PART 5: The affine core   OI_a² = R² + abc/(−a+b+c)
+-- ============================================================
+
+/-- The affine core of Euler's excentre formula:
+    dist²(O, I_a) = R² + abc/(−a+b+c), with no square roots involved. -/
+theorem OI_a_sq_eq_R2_add (T : Triangle) :
+    dist2_sq T.circumcenter T.excenter_a =
+    ((T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2)
+      + T.side_a * T.side_b * T.side_c / (-T.side_a + T.side_b + T.side_c) := by
+  set O := T.circumcenter with hO
+  set R2 := (T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2 with hR2
+  have hp : -T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (pa_pos T)
+  -- excentre coordinates over the common denominator
+  have hI : dist2_sq O T.excenter_a * (-T.side_a + T.side_b + T.side_c) ^ 2 =
+      ((-T.side_a) * (T.A.1 - O.1) + T.side_b * (T.B.1 - O.1) + T.side_c * (T.C.1 - O.1)) ^ 2 +
+      ((-T.side_a) * (T.A.2 - O.2) + T.side_b * (T.B.2 - O.2) + T.side_c * (T.C.2 - O.2)) ^ 2 := by
+    unfold dist2_sq Triangle.excenter_a
+    dsimp only
+    field_simp [hp]
+    ring
+  have hmaster := weighted_norm_sq_gen T (-T.side_a) T.side_b T.side_c
+  rw [← hO, ← hR2] at hmaster
+  -- combine: dist²·p² = R2·p² + abc·p
+  have hcombine : dist2_sq O T.excenter_a * (-T.side_a + T.side_b + T.side_c) ^ 2 =
+      R2 * (-T.side_a + T.side_b + T.side_c) ^ 2
+        + T.side_a * T.side_b * T.side_c * (-T.side_a + T.side_b + T.side_c) := by
+    rw [hI]; linear_combination hmaster
+  -- cancel one factor of p
+  have hkey : dist2_sq O T.excenter_a * (-T.side_a + T.side_b + T.side_c) =
+      R2 * (-T.side_a + T.side_b + T.side_c) + T.side_a * T.side_b * T.side_c := by
+    apply mul_right_cancel₀ hp
+    linear_combination hcombine
+  field_simp [hp]
+  linear_combination hkey
+
+-- ============================================================
+-- PART 6: Bridge   2·R·r_a = abc/(−a+b+c)   and Euler's formula
+-- ============================================================
+
+/-- R² = |A − O|² (circumradius squared, dropping the square root). -/
+private lemma circumradius_sq (T : Triangle) :
+    T.circumradius ^ 2 = (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  unfold Triangle.circumradius dist2
+  rw [Real.sq_sqrt (by positivity)]
+
+/-- Circumradius is positive (cheaply, from the reused law of sines). -/
+private lemma circumradius_pos (T : Triangle) : 0 < T.circumradius := by
+  have h := FeuerbachEulerOI.four_R_area_eq_abc T
+  have hA := area_pos T
+  have habc : 0 < T.side_a * T.side_b * T.side_c :=
+    mul_pos (mul_pos (side_a_pos T) (side_b_pos T)) (side_c_pos T)
+  by_contra hR
+  push_neg at hR
+  have hle : 4 * T.circumradius * T.area ≤ 0 := by nlinarith [hA, hR]
+  linarith [h, habc, hle]
+
+/-- The exradius opposite A is positive. -/
+private lemma exradius_a_pos (T : Triangle) : 0 < T.exradius_a := by
+  unfold Triangle.exradius_a Triangle.semiperimeter
+  apply div_pos (area_pos T)
+  have hp := pa_pos T; linarith
+
+/-- 2·R·r_a = abc/(−a+b+c). -/
+theorem two_R_ra_eq (T : Triangle) :
+    2 * T.circumradius * T.exradius_a =
+    T.side_a * T.side_b * T.side_c / (-T.side_a + T.side_b + T.side_c) := by
+  have hp : -T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (pa_pos T)
+  have hr : T.exradius_a = 2 * T.area / (-T.side_a + T.side_b + T.side_c) := by
+    unfold Triangle.exradius_a Triangle.semiperimeter
+    have hp2 : (T.side_a + T.side_b + T.side_c) / 2 - T.side_a
+        = (-T.side_a + T.side_b + T.side_c) / 2 := by ring
+    rw [hp2, div_div_eq_mul_div]
+    ring
+  rw [hr]
+  rw [show 2 * T.circumradius * (2 * T.area / (-T.side_a + T.side_b + T.side_c))
+        = (4 * T.circumradius * T.area) / (-T.side_a + T.side_b + T.side_c) from by ring]
+  rw [FeuerbachEulerOI.four_R_area_eq_abc]
+
+/-- **Euler's circumcentre–excentre formula** (opposite A):
+    the squared distance between the circumcentre and the A-excentre is
+    R² + 2·R·r_a. -/
+theorem euler_OI_a_formula (T : Triangle) :
+    dist2_sq T.circumcenter T.excenter_a =
+    T.circumradius ^ 2 + 2 * T.circumradius * T.exradius_a := by
+  rw [OI_a_sq_eq_R2_add T, two_R_ra_eq T, circumradius_sq T]
+
+-- ============================================================
+-- PART 7: The b- and c-excentre formulas (by the same machinery)
+-- ============================================================
+
+/-- Affine core for the B-excentre:  dist²(O, I_b) = R² + abc/(a−b+c). -/
+theorem OI_b_sq_eq_R2_add (T : Triangle) :
+    dist2_sq T.circumcenter T.excenter_b =
+    ((T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2)
+      + T.side_a * T.side_b * T.side_c / (T.side_a - T.side_b + T.side_c) := by
+  set O := T.circumcenter with hO
+  set R2 := (T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2 with hR2
+  have hp : T.side_a - T.side_b + T.side_c ≠ 0 := ne_of_gt (pb_pos T)
+  have hI : dist2_sq O T.excenter_b * (T.side_a - T.side_b + T.side_c) ^ 2 =
+      (T.side_a * (T.A.1 - O.1) + (-T.side_b) * (T.B.1 - O.1) + T.side_c * (T.C.1 - O.1)) ^ 2 +
+      (T.side_a * (T.A.2 - O.2) + (-T.side_b) * (T.B.2 - O.2) + T.side_c * (T.C.2 - O.2)) ^ 2 := by
+    unfold dist2_sq Triangle.excenter_b
+    dsimp only
+    field_simp [hp]
+    ring
+  have hmaster := weighted_norm_sq_gen T T.side_a (-T.side_b) T.side_c
+  rw [← hO, ← hR2] at hmaster
+  have hcombine : dist2_sq O T.excenter_b * (T.side_a - T.side_b + T.side_c) ^ 2 =
+      R2 * (T.side_a - T.side_b + T.side_c) ^ 2
+        + T.side_a * T.side_b * T.side_c * (T.side_a - T.side_b + T.side_c) := by
+    rw [hI]; linear_combination hmaster
+  have hkey : dist2_sq O T.excenter_b * (T.side_a - T.side_b + T.side_c) =
+      R2 * (T.side_a - T.side_b + T.side_c) + T.side_a * T.side_b * T.side_c := by
+    apply mul_right_cancel₀ hp
+    linear_combination hcombine
+  field_simp [hp]
+  linear_combination hkey
+
+/-- Affine core for the C-excentre:  dist²(O, I_c) = R² + abc/(a+b−c). -/
+theorem OI_c_sq_eq_R2_add (T : Triangle) :
+    dist2_sq T.circumcenter T.excenter_c =
+    ((T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2)
+      + T.side_a * T.side_b * T.side_c / (T.side_a + T.side_b - T.side_c) := by
+  set O := T.circumcenter with hO
+  set R2 := (T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2 with hR2
+  have hp : T.side_a + T.side_b - T.side_c ≠ 0 := ne_of_gt (pc_pos T)
+  have hI : dist2_sq O T.excenter_c * (T.side_a + T.side_b - T.side_c) ^ 2 =
+      (T.side_a * (T.A.1 - O.1) + T.side_b * (T.B.1 - O.1) + (-T.side_c) * (T.C.1 - O.1)) ^ 2 +
+      (T.side_a * (T.A.2 - O.2) + T.side_b * (T.B.2 - O.2) + (-T.side_c) * (T.C.2 - O.2)) ^ 2 := by
+    unfold dist2_sq Triangle.excenter_c
+    dsimp only
+    field_simp [hp]
+    ring
+  have hmaster := weighted_norm_sq_gen T T.side_a T.side_b (-T.side_c)
+  rw [← hO, ← hR2] at hmaster
+  have hcombine : dist2_sq O T.excenter_c * (T.side_a + T.side_b - T.side_c) ^ 2 =
+      R2 * (T.side_a + T.side_b - T.side_c) ^ 2
+        + T.side_a * T.side_b * T.side_c * (T.side_a + T.side_b - T.side_c) := by
+    rw [hI]; linear_combination hmaster
+  have hkey : dist2_sq O T.excenter_c * (T.side_a + T.side_b - T.side_c) =
+      R2 * (T.side_a + T.side_b - T.side_c) + T.side_a * T.side_b * T.side_c := by
+    apply mul_right_cancel₀ hp
+    linear_combination hcombine
+  field_simp [hp]
+  linear_combination hkey
+
+private lemma exradius_b_pos (T : Triangle) : 0 < T.exradius_b := by
+  unfold Triangle.exradius_b Triangle.semiperimeter
+  apply div_pos (area_pos T)
+  have hp := pb_pos T; linarith
+
+private lemma exradius_c_pos (T : Triangle) : 0 < T.exradius_c := by
+  unfold Triangle.exradius_c Triangle.semiperimeter
+  apply div_pos (area_pos T)
+  have hp := pc_pos T; linarith
+
+theorem two_R_rb_eq (T : Triangle) :
+    2 * T.circumradius * T.exradius_b =
+    T.side_a * T.side_b * T.side_c / (T.side_a - T.side_b + T.side_c) := by
+  have hp : T.side_a - T.side_b + T.side_c ≠ 0 := ne_of_gt (pb_pos T)
+  have hr : T.exradius_b = 2 * T.area / (T.side_a - T.side_b + T.side_c) := by
+    unfold Triangle.exradius_b Triangle.semiperimeter
+    have hp2 : (T.side_a + T.side_b + T.side_c) / 2 - T.side_b
+        = (T.side_a - T.side_b + T.side_c) / 2 := by ring
+    rw [hp2, div_div_eq_mul_div]
+    ring
+  rw [hr]
+  rw [show 2 * T.circumradius * (2 * T.area / (T.side_a - T.side_b + T.side_c))
+        = (4 * T.circumradius * T.area) / (T.side_a - T.side_b + T.side_c) from by ring]
+  rw [FeuerbachEulerOI.four_R_area_eq_abc]
+
+theorem two_R_rc_eq (T : Triangle) :
+    2 * T.circumradius * T.exradius_c =
+    T.side_a * T.side_b * T.side_c / (T.side_a + T.side_b - T.side_c) := by
+  have hp : T.side_a + T.side_b - T.side_c ≠ 0 := ne_of_gt (pc_pos T)
+  have hr : T.exradius_c = 2 * T.area / (T.side_a + T.side_b - T.side_c) := by
+    unfold Triangle.exradius_c Triangle.semiperimeter
+    have hp2 : (T.side_a + T.side_b + T.side_c) / 2 - T.side_c
+        = (T.side_a + T.side_b - T.side_c) / 2 := by ring
+    rw [hp2, div_div_eq_mul_div]
+    ring
+  rw [hr]
+  rw [show 2 * T.circumradius * (2 * T.area / (T.side_a + T.side_b - T.side_c))
+        = (4 * T.circumradius * T.area) / (T.side_a + T.side_b - T.side_c) from by ring]
+  rw [FeuerbachEulerOI.four_R_area_eq_abc]
+
+/-- **Euler's circumcentre–excentre formula** (opposite B):  OI_b² = R² + 2·R·r_b. -/
+theorem euler_OI_b_formula (T : Triangle) :
+    dist2_sq T.circumcenter T.excenter_b =
+    T.circumradius ^ 2 + 2 * T.circumradius * T.exradius_b := by
+  rw [OI_b_sq_eq_R2_add T, two_R_rb_eq T, circumradius_sq T]
+
+/-- **Euler's circumcentre–excentre formula** (opposite C):  OI_c² = R² + 2·R·r_c. -/
+theorem euler_OI_c_formula (T : Triangle) :
+    dist2_sq T.circumcenter T.excenter_c =
+    T.circumradius ^ 2 + 2 * T.circumradius * T.exradius_c := by
+  rw [OI_c_sq_eq_R2_add T, two_R_rc_eq T, circumradius_sq T]
+
+-- ============================================================
+-- PART 8: Strict consequence  —  R < OI_a
+-- ============================================================
+
+/-- The circumcentre is strictly farther from the A-excentre than the
+    circumradius:  R² < OI_a².  Immediate from the *plus* sign in Euler's
+    excentre formula together with R, r_a > 0. -/
+theorem circumradius_sq_lt_OI_a_sq (T : Triangle) :
+    T.circumradius ^ 2 < dist2_sq T.circumcenter T.excenter_a := by
+  rw [euler_OI_a_formula T]
+  have hR := circumradius_pos T
+  have hra := exradius_a_pos T
+  nlinarith [mul_pos hR hra]
+
+/-- True-distance form:  R < OI_a. -/
+theorem circumradius_lt_OI_a (T : Triangle) :
+    T.circumradius < dist2 T.circumcenter T.excenter_a := by
+  have h := circumradius_sq_lt_OI_a_sq T
+  have hR := le_of_lt (circumradius_pos T)
+  have hd : 0 ≤ dist2 T.circumcenter T.excenter_a := by unfold dist2; exact Real.sqrt_nonneg _
+  have hsq : (dist2 T.circumcenter T.excenter_a) ^ 2 = dist2_sq T.circumcenter T.excenter_a := by
+    unfold dist2 dist2_sq; rw [Real.sq_sqrt (by positivity)]
+  nlinarith [h, hR, hd, hsq]
+
+-- ============================================================
+-- PART 9: Worked example — the 3-4-5 right triangle
+-- ============================================================
+
+/-- The A-excentre of the 3-4-5 triangle is (6, 6). -/
+theorem triangle_345_excenter_a : triangle_345.excenter_a = (6, 6) := by
+  unfold Triangle.excenter_a
+  simp only [triangle_345_side_a, triangle_345_side_b, triangle_345_side_c]
+  unfold triangle_345; simp only
+  exact Prod.ext (by norm_num) (by norm_num)
+
+/-- The A-exradius of the 3-4-5 triangle is r_a = 6. -/
+theorem triangle_345_exradius_a : triangle_345.exradius_a = 6 := by
+  unfold Triangle.exradius_a
+  rw [triangle_345_area, triangle_345_semiperimeter, triangle_345_side_a]
+  norm_num
+
+/-- For the 3-4-5 triangle, dist²(O, I_a) = 145/4, matching
+    R² + 2Rr_a = (5/2)² + 2·(5/2)·6 = 145/4. -/
+theorem triangle_345_OI_a_sq :
+    dist2_sq triangle_345.circumcenter triangle_345.excenter_a = 145 / 4 := by
+  rw [triangle_345_circumcenter, triangle_345_excenter_a]
+  unfold dist2_sq
+  norm_num
+
+/-- The 3-4-5 triangle satisfies Euler's excentre formula concretely. -/
+theorem triangle_345_euler_a :
+    triangle_345.circumradius ^ 2
+      + 2 * triangle_345.circumradius * triangle_345.exradius_a = 145 / 4 := by
+  rw [triangle_345_circumradius, triangle_345_exradius_a]
+  norm_num
+
+end FeuerbachExcenterEuler

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01/meta.json
@@ -1,0 +1,221 @@
+{
+  "id": "feuerbachs-theorem-defs-oq-02-oq-01",
+  "title": "Euler's Circumcenter–Excenter Formula: OIₐ² = R² + 2Rrₐ",
+  "slug": "feuerbachs-theorem-defs-oq-02-oq-01",
+  "description": "Proves the excenter companion of Euler's 1765 triangle formula: for the excenter Iₐ (center of the escribed circle opposite A, radius rₐ), the squared distance to the circumcenter O is OIₐ² = R² + 2Rrₐ, the sign-flipped sibling of the incenter law OI² = R² − 2Rr. The plus sign forces OIₐ > R for every triangle. All three excenters are covered. The new ingredient absent from the incenter proof is the strict triangle inequality a < b + c, proved via the 2-D Lagrange identity. Built from the coordinate API of FeuerbachsTheoremDefs.lean and reusing the law-of-sines bridge from FeuerbachsTheoremDefsOQ02.lean. 15 theorems (+ supporting lemmas), 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ02OQ01.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefsOQ02.lean",
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
+    "tags": [
+      "geometry",
+      "feuerbach",
+      "euler",
+      "circumcenter",
+      "excenter",
+      "circumradius",
+      "exradius",
+      "triangle-inequality",
+      "cauchy-schwarz",
+      "law-of-sines",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the standard foundational axioms propext / Classical.choice / Quot.sound, which do not count as assumptions). Inherits the coordinate API (Triangle, circumcenter, excenter_a/b/c, circumradius, exradius_a/b/c, area, side lengths) and the non-degeneracy lemma circumcenter_denom_ne_zero from FeuerbachsTheoremDefs.lean, and reuses the law-of-sines identity four_R_area_eq_abc from the sibling FeuerbachsTheoremDefsOQ02.lean; both are themselves 0-sorry, 0-axiom.",
+    "lineCount": 594,
+    "theoremCount": 15,
+    "definitionCount": 0,
+    "originalContributions": [
+      "euler_OI_a_formula: Euler's circumcenter–excenter formula — dist²(O, Iₐ) = R² + 2·R·rₐ for the circumcenter O and the A-excenter Iₐ of an arbitrary non-degenerate triangle, the plus-sign sibling of the incenter law OI² = R² − 2Rr; euler_OI_b_formula and euler_OI_c_formula give the B- and C-excenter versions",
+      "OI_a_sq_eq_R2_add: the square-root-free affine core dist²(O, Iₐ) = R² + abc/(−a+b+c), obtained by collapsing the signed-weight excenter expansion with the three circumcenter equidistances (b and c cores analogous)",
+      "strict_tri_ineq_a/b/c: the strict triangle inequality a < b + c for the Euclidean side lengths — the ingredient the incenter proof never needed — proved from the 2-D Lagrange/Cauchy–Schwarz identity b²c² − ⟨A−C,B−A⟩² = (non-degeneracy determinant)² > 0, forcing each excenter denominator to be positive",
+      "weighted_norm_sq_gen: a reusable master identity |wₐ(A−O)+w_b(B−O)+w_c(C−O)|² = R²(wₐ+w_b+w_c)² − (wₐw_b·c² + w_bw_c·a² + w_cwₐ·b²) for arbitrary real weights, specializing to the incenter (a,b,c) and all three excenters (−a,b,c),(a,−b,c),(a,b,−c)",
+      "two_R_ra_eq / two_R_rb_eq / two_R_rc_eq: 2·R·rₐ = abc/(−a+b+c) (and cyclically), the bridge linking the affine core to the exradii via the reused law of sines 4·R·Area = abc",
+      "circumradius_sq_lt_OI_a_sq / circumradius_lt_OI_a: the strict consequence R < OIₐ — the circumcenter is always farther from an excenter than the circumradius, a free corollary of the plus sign",
+      "triangle_345_excenter_a / triangle_345_exradius_a / triangle_345_OI_a_sq / triangle_345_euler_a: worked example, Iₐ = (6,6), rₐ = 6, dist²(O, Iₐ) = 145/4 = (5/2)² + 2·(5/2)·6 for the 3-4-5 right triangle"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Euler's 1765 study of the triangle produced two metric relations of the same flavor. The famous one, OI² = R² − 2Rr, ties the circumcenter O to the incenter I and instantly yields Euler's inequality R ≥ 2r. The less-quoted companion concerns the three excenters — the centers Iₐ, I_b, I_c of the escribed circles, each tangent to one side and the extensions of the other two. For the excenter opposite A one has OIₐ² = R² + 2Rrₐ, identical in shape but with the sign of the 2Rr term flipped, where rₐ is the corresponding exradius. The flip matters: the right-hand side is now a sum of positive quantities, so OIₐ > R always — the circumcenter never lies as close to an excenter as the circumradius, in sharp contrast with the incenter, which sits inside the circumcircle (OI < R).\n\nThe sibling entry feuerbachs-theorem-defs-oq-02 established the incenter law. This entry supplies the excenter law, completing Euler's pair, and isolates the one genuinely new fact the excenter case requires: the strict triangle inequality, which guarantees the excenter denominators −a+b+c, a−b+c, a+b−c are positive.",
+    "problemStatement": "For a non-degenerate triangle with circumcenter O, A-excenter Iₐ, circumradius R, exradius rₐ and side lengths a, b, c, prove\n$$\\lVert OI_a\\rVert^2 = R^2 + 2Rr_a,$$\nand the analogous identities for the B- and C-excenters, and deduce R < OIₐ.",
+    "text": "A 594-line companion file. It re-establishes the circumcenter equidistances and side/area positivity, then proves the strict triangle inequality via a 2-D Lagrange identity, a reusable weighted-norm master identity, and from these the three affine cores dist²(O, I_x) = R² + abc/p_x with p_a = −a+b+c (cyclically). Reusing the law-of-sines identity 4·R·Area = abc from the incenter entry turns abc/p_x into 2Rr_x, giving Euler's excenter formula for all three excenters, the strict consequence R < OIₐ, and the 3-4-5 worked example.",
+    "proofStrategy": "Work with the vectors A−O, B−O, C−O, each of squared length R².\n- **Weighted-norm master identity** (`weighted_norm_sq_gen`): for any real weights wₐ,w_b,w_c, |wₐ(A−O)+w_b(B−O)+w_c(C−O)|² = R²(wₐ+w_b+w_c)² − (wₐw_b·c² + w_bw_c·a² + w_cwₐ·b²), closed by one linear_combination using the three equidistances and three dot products. The incenter uses weights (a,b,c); the excenters use one negated weight each.\n- **Strict triangle inequality** (`strict_tri_ineq_a`): a < b + c. Writing P = ⟨A−C, B−A⟩, the law of cosines gives a² = b² + c² + 2P, while the 2-D Lagrange identity gives b²c² − P² = D² with D the non-degeneracy determinant. Since D ≠ 0, P² < (bc)², so P < bc, hence a² < (b+c)², hence a < b + c. This forces p_a = −a+b+c > 0 (and cyclically), so the excenter denominators never vanish.\n- **Affine core** (`OI_a_sq_eq_R2_add`): the A-excenter is the signed-weight average Iₐ = (−a·A + b·B + c·C)/(−a+b+c), so p_a(Iₐ−O) = −a(A−O)+b(B−O)+c(C−O). The master identity with weights (−a,b,c) collapses |p_a(Iₐ−O)|² to R²p_a² + abc·p_a; dividing by p_a² gives R² + abc/p_a.\n- **Bridge** (`two_R_ra_eq`): rₐ = Area/(s−a) = 2·Area/p_a, so 2Rrₐ = 4·R·Area/p_a = abc/p_a using the reused law of sines 4·R·Area = abc. Substituting into the core gives R² + 2Rrₐ.\n- **Strict consequence** (`circumradius_lt_OI_a`): R² < R² + 2Rrₐ since R, rₐ > 0, so R < OIₐ.",
+    "keyInsights": [
+      "Euler's excenter formula is the incenter formula with one weight negated: replacing the incenter's barycentric weights (a,b,c) by (−a,b,c) flips abc/(a+b+c) to abc/(−a+b+c), i.e. −2Rr to +2Rrₐ. A single parametrized master identity covers both.",
+      "The plus sign is not cosmetic: OIₐ² = R² + 2Rrₐ is a sum of positive terms, so OIₐ > R unconditionally, whereas the incenter satisfies OI < R. The two Euler relations encode opposite inclusion facts.",
+      "The only obstruction the excenter case adds is that the denominator −a+b+c could in principle vanish or be negative; this is exactly the strict triangle inequality, which for genuine Euclidean side lengths is a theorem, proved here from scratch rather than assumed.",
+      "The strict triangle inequality reduces to strict Cauchy–Schwarz, and in two dimensions strict Cauchy–Schwarz is the Lagrange identity b²c² − ⟨u,v⟩² = (u×v)² together with the fact that the cross term u×v is precisely the non-degeneracy determinant — geometry and algebra meeting exactly.",
+      "Generalizing weighted_norm_sq to arbitrary weights makes the incenter and all three excenters fall out of one lemma, and re-using the already-proved law of sines avoids re-deriving the heavy 16·R²·Area² = a²b²c² identity."
+    ],
+    "prerequisites": [
+      "FeuerbachsTheoremDefs.lean — coordinate API (Point, Triangle, circumcenter, excenter_a/b/c, circumradius, exradius_a/b/c, area, side_a/b/c, dist2, dist2_sq) and circumcenter_denom_ne_zero",
+      "FeuerbachsTheoremDefsOQ02.lean — the law-of-sines identity four_R_area_eq_abc (4·R·Area = abc), reused as the bridge",
+      "The 2-D Lagrange identity and strict Cauchy–Schwarz for the strict triangle inequality",
+      "field_simp / ring / linear_combination / nlinarith for polynomial identities over ℝ, and Real.sqrt lemmas (sqrt_sq, sq_sqrt)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Namespace Setup",
+      "startLine": 1,
+      "endLine": 71,
+      "summary": "Module docstring stating Euler's excenter formula, imports FeuerbachsTheoremDefsOQ02 (transitively the parent defs), opens the FeuerbachsTheorem namespace.",
+      "mathContext": "The coordinate API, circumcenter_denom_ne_zero, and the reused law-of-sines identity four_R_area_eq_abc come from the parent and sibling files."
+    },
+    {
+      "id": "equidist",
+      "title": "Part I: Circumcenter Equidistance",
+      "startLine": 73,
+      "endLine": 130,
+      "summary": "Re-establishes the perpendicular-bisector relations and the squared equidistances |B−O|² = |A−O|² and |C−O|² = |A−O|² (the parent's are private).",
+      "mathContext": "The perpendicular-bisector condition is linear in O, proven by field_simp; ring; the equidistances follow by nlinarith."
+    },
+    {
+      "id": "sides",
+      "title": "Part II: Side Lengths and Area Positivity",
+      "startLine": 131,
+      "endLine": 192,
+      "summary": "Squared side lengths a² = |BC|² etc., non-negativity and strict positivity of each side, and positivity of the area.",
+      "mathContext": "Each side is positive because the vertices are pairwise distinct (a coincidence makes the signed area vanish, contradicting non-degeneracy)."
+    },
+    {
+      "id": "triangleineq",
+      "title": "Part III: The Strict Triangle Inequality a < b + c",
+      "startLine": 193,
+      "endLine": 301,
+      "summary": "strict_tri_ineq_a/b/c (a < b+c and cyclic) and pa_pos/pb_pos/pc_pos (positivity of the excenter denominators −a+b+c, a−b+c, a+b−c).",
+      "mathContext": "Via the law of cosines a² = b²+c²+2P and the Lagrange identity b²c² − P² = D² (D the non-degeneracy determinant), D ≠ 0 gives P < bc, hence a² < (b+c)², hence a < b+c."
+    },
+    {
+      "id": "weighted",
+      "title": "Part IV: The Reusable Weighted-Norm Identity",
+      "startLine": 303,
+      "endLine": 339,
+      "summary": "weighted_norm_sq_gen: |wₐ(A−O)+w_b(B−O)+w_c(C−O)|² = R²(wₐ+w_b+w_c)² − (wₐw_b·c²+w_bw_c·a²+w_cwₐ·b²) for arbitrary weights.",
+      "mathContext": "Substitutes the three equidistances and three dot products (A−O)·(B−O) = R² − c²/2 (cyclically) via a single linear_combination."
+    },
+    {
+      "id": "core",
+      "title": "Part V: The Affine Core OIₐ² = R² + abc/(−a+b+c)",
+      "startLine": 340,
+      "endLine": 375,
+      "summary": "OI_a_sq_eq_R2_add: dist²(O,Iₐ) = R² + abc/(−a+b+c), clearing the p_a² denominator from the signed-weight excenter expansion.",
+      "mathContext": "Specializing the master identity to weights (−a,b,c) gives |p_a(Iₐ−O)|² = R²p_a² + abc·p_a; mul_right_cancel₀ removes one factor of p_a."
+    },
+    {
+      "id": "bridge",
+      "title": "Part VI: Bridge 2Rrₐ = abc/(−a+b+c) and Euler's Formula",
+      "startLine": 376,
+      "endLine": 426,
+      "summary": "circumradius_sq, circumradius_pos (cheaply from the reused law of sines), exradius_a_pos, two_R_ra_eq, and euler_OI_a_formula (OIₐ² = R² + 2Rrₐ).",
+      "mathContext": "rₐ = 2·Area/p_a, so 2Rrₐ = 4·R·Area/p_a = abc/p_a using 4·R·Area = abc; substituting into the core yields R² + 2Rrₐ."
+    },
+    {
+      "id": "bc",
+      "title": "Part VII: The B- and C-Excenter Formulas",
+      "startLine": 427,
+      "endLine": 538,
+      "summary": "OI_b_sq_eq_R2_add, OI_c_sq_eq_R2_add, two_R_rb_eq, two_R_rc_eq, euler_OI_b_formula, euler_OI_c_formula — the same machinery with weights (a,−b,c) and (a,b,−c).",
+      "mathContext": "By the cyclic symmetry of the master identity and the strict triangle inequalities, the B- and C-excenter laws are immediate analogues."
+    },
+    {
+      "id": "consequence",
+      "title": "Part VIII: Strict Consequence R < OIₐ",
+      "startLine": 539,
+      "endLine": 562,
+      "summary": "circumradius_sq_lt_OI_a_sq (R² < OIₐ²) and circumradius_lt_OI_a (R < OIₐ), the true-distance form.",
+      "mathContext": "R² < R² + 2Rrₐ because R, rₐ > 0; the squared inequality lifts to the distance via Real.sqrt monotonicity."
+    },
+    {
+      "id": "example",
+      "title": "Part IX: Worked Example — the 3-4-5 Triangle",
+      "startLine": 563,
+      "endLine": 594,
+      "summary": "For the 3-4-5 right triangle, Iₐ = (6,6), rₐ = 6 and dist²(O, Iₐ) = 145/4 = (5/2)² + 2·(5/2)·6.",
+      "mathContext": "Uses the parent's computed circumcenter (3/2, 2), circumradius 5/2 and side lengths 5, 4, 3."
+    }
+  ],
+  "conclusion": {
+    "summary": "Establishes Euler's circumcenter–excenter formula OIₐ² = R² + 2Rrₐ for all three excenters, the sign-flipped companion of the incenter law OI² = R² − 2Rr, and derives the strict consequence R < OIₐ. Along the way it proves the strict triangle inequality for the Euclidean side lengths from the 2-D Lagrange identity. 15 theorems (plus supporting lemmas), 0 axioms, 0 sorries.",
+    "implications": "**Euler's pair completed**: the sibling entry gave OI² = R² − 2Rr; this entry gives OIₐ² = R² + 2Rrₐ, so the gallery now records both of Euler's 1765 center-distance laws.\n\n**Opposite inclusions**: the incenter law's minus sign yields OI < R (incenter inside the circumcircle); the excenter law's plus sign yields OIₐ > R (circumcenter farther from any excenter than R). One sign captures the geometric dichotomy.\n\n**Reusable triangle inequality**: strict_tri_ineq_a/b/c prove a < b+c for the coordinate side lengths via a Lagrange identity, a fact useful wherever escribed circles or barycentric coordinates with signed weights appear.",
+    "openQuestions": [
+      "Prove the excentral identity OIₐ² + OI_b² + OI_c² = 3R² + 2R(rₐ + r_b + r_c) and combine with the incenter law to obtain OI² + OIₐ² + OI_b² + OI_c² in closed form.",
+      "Establish the distance between the incenter and an excenter, IIₐ² = 4R·rₐ (so IIₐ = 2√(R rₐ)), and the excenter–excenter distances, completing the metric table of the four tritangent centers.",
+      "Show that the four points I, Iₐ, I_b, I_c form an orthocentric system whose nine-point circle is the circumcircle of ABC, linking these distances back to the Feuerbach configuration."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-02",
+      "relationship": "extends",
+      "description": "the incenter law OI² = R² − 2Rr; this entry proves the excenter companion OIₐ² = R² + 2Rrₐ and reuses its law-of-sines identity four_R_area_eq_abc"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs",
+      "relationship": "extends",
+      "description": "uses the circumcenter, excenters, circumradius and exradii defined in FeuerbachsTheoremDefs.lean and relates them by Euler's excenter formula"
+    },
+    {
+      "targetId": "feuerbachs-theorem",
+      "relationship": "related",
+      "description": "the full Feuerbach theorem, whose nine-point circle is tangent to each of the three excircles whose centers appear here"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Proofs.FeuerbachsTheoremDefsOQ02"],
+    "opens": ["FeuerbachsTheorem"],
+    "namespace": "FeuerbachExcenterEuler",
+    "lineCount": 594,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 0,
+    "path": "Proofs/FeuerbachsTheoremDefsOQ02OQ01.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefsOQ02.lean",
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "euler_OI_a_formula",
+      "type": "core",
+      "description": "Euler's circumcenter–excenter formula (opposite A): the squared distance between the circumcenter and the A-excenter equals R² + 2Rrₐ.",
+      "leanType": "∀ T : Triangle, dist2_sq T.circumcenter T.excenter_a = T.circumradius ^ 2 + 2 * T.circumradius * T.exradius_a"
+    },
+    {
+      "name": "circumradius_lt_OI_a",
+      "type": "core",
+      "description": "The circumcenter is strictly farther from the A-excenter than the circumradius: R < OIₐ.",
+      "leanType": "∀ T : Triangle, T.circumradius < dist2 T.circumcenter T.excenter_a"
+    },
+    {
+      "name": "OI_a_sq_eq_R2_add",
+      "type": "core",
+      "description": "The square-root-free affine core of Euler's excenter formula.",
+      "leanType": "∀ T : Triangle, dist2_sq T.circumcenter T.excenter_a = |A − O|² + abc/(−a+b+c)"
+    },
+    {
+      "name": "strict_tri_ineq_a",
+      "type": "lemma",
+      "description": "The strict triangle inequality a < b + c for the Euclidean side lengths, forcing the excenter denominator −a+b+c to be positive.",
+      "leanType": "∀ T : Triangle, T.side_a < T.side_b + T.side_c"
+    },
+    {
+      "name": "weighted_norm_sq_gen",
+      "type": "lemma",
+      "description": "Reusable weighted-norm master identity for arbitrary weights, specializing to the incenter and all three excenters.",
+      "leanType": "∀ (T : Triangle) (wa wb wc : ℝ), |wa(A−O)+wb(B−O)+wc(C−O)|² = |A−O|²(wa+wb+wc)² − (wa·wb·c²+wb·wc·a²+wc·wa·b²)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Euler's circumcenter–excenter formula: OIₐ² = R² + 2·R·rₐ

Follow-up open question from **feuerbachs-theorem-defs-oq-02** (Euler's incenter law OI² = R² − 2Rr). Euler's 1765 work produced *two* center-distance relations of the same shape; the sibling entry proved the incenter one, this proves the excenter one.

For the excenter Iₐ (center of the escribed circle opposite A, radius rₐ):

$$\lVert OI_a\rVert^2 = R^2 + 2\,R\,r_a,$$

the **sign-flipped companion** of the incenter law. Because the RHS is now a sum of positive terms, **OIₐ > R for every triangle** — opposite to the incenter's OI < R. All three excenters (a, b, c) are covered.

### The genuinely new ingredient
The incenter proof divided by `a+b+c` (trivially positive). The excenter proof divides by `−a+b+c`, so it needs the **strict triangle inequality** `a < b + c`, proved from scratch via the 2-D Lagrange identity

$$b^2c^2 - \langle A-C,\,B-A\rangle^2 = (\text{non-degeneracy determinant})^2 > 0$$

(strict Cauchy–Schwarz), which forces each excenter denominator positive.

### Structure
- `weighted_norm_sq_gen` — one reusable master identity for arbitrary barycentric weights, specializing to the incenter and all three excenters
- `strict_tri_ineq_a/b/c`, `pa/pb/pc_pos` — strict triangle inequality + positive denominators
- `OI_a/b/c_sq_eq_R2_add` — square-root-free affine cores R² + abc/p_x
- `two_R_ra/rb/rc_eq` — bridge 2Rr_x = abc/p_x, **reusing** `four_R_area_eq_abc` from the sibling (avoids re-deriving 16R²·Area² = a²b²c²)
- `euler_OI_a/b/c_formula`, `circumradius_lt_OI_a` (R < OIₐ)
- 3-4-5 worked example: Iₐ = (6,6), rₐ = 6, OIₐ² = 145/4 = (5/2)² + 2·(5/2)·6

### Verification
- **594 lines, 15 theorems + supporting lemmas, 0 sorries, 0 axioms**
- `#print axioms` on the main results lists only `propext / Classical.choice / Quot.sound`
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremDefsOQ02OQ01`
- All core identities cross-checked numerically before formalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)