### PR TITLE
audit(cantor-diagonalization-oq-02-oq-03-oq-02-oq-01): register missing module in Proofs.lean

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -444,6 +444,7 @@ import Proofs.CantorDiagonalizationOQ02OQ01
 import Proofs.CantorDiagonalizationOQ02OQ03
 import Proofs.CantorDiagonalizationOQ02OQ03OQ02
 import Proofs.CantorDiagonalizationOQ02OQ03OQ02Aristotle
+import Proofs.CantorDiagonalizationOQ02OQ03OQ02OQ01
 import Proofs.CantorDiagonalizationOQ03
 import Proofs.CantorDiagonalizationOQ03OQ01
 import Proofs.CantorDiagonalizationOQ03OQ01Incomplete01

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17689,6 +17689,12 @@
       "lastAudited": "2026-06-21T13:18:39Z",
       "result": "clean",
       "issues": []
+    },
+    "cantor-diagonalization-oq-02-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-21T13:31:04Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit: cantor-diagonalization-oq-02-oq-03-oq-02-oq-01 (The Club Filter and the Nonstationary Ideal)

### Finding (fixed)
The entry merged in #27358 added `proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02OQ01.lean` but **did not register it** in the aggregate `proofs/Proofs.lean` import list. As a result the new module was silently excluded from the project build. Added the missing import line (alphabetically positioned after the parent's `...OQ02Aristotle` companion).

### Verification (otherwise clean)
- **meta.json ↔ source match**: 247 lines, 10 theorems, 1 def, 0 axioms, 0 sorries, namespace `FodorLemma`, mainTheorem `inter_isClub` — all exact.
- **No `sorry`/`admit`/`native_decide`** in source.
- **Docker build succeeds** (`Proofs.CantorDiagonalizationOQ02OQ03OQ02OQ01`, 7744 jobs).
- **0-axiom confirmed**: `#print axioms` on `inter_isClub`, `isStationary_iff_not_isNonStationary`, `isNonStationary_union` reports only `propext, Classical.choice, Quot.sound`.

Status `verified` / badge `original` are accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)