### PR TITLE
research(geometric-series-oq-08): align parent openQuestions with shipped oq-01 (arith-geo)

### DIFF
--- a/src/data/proofs/geometric-series-oq-08/meta.json
+++ b/src/data/proofs/geometric-series-oq-08/meta.json
@@ -68,12 +68,17 @@
   "openQuestions": [
     {
       "id": "geometric-series-oq-08-oq-01",
-      "question": "Extend the defect identity to the Ico-slice partial sum ∑_{k ∈ Ico m n} rᵏ and bound the slice by rᵐ/(1 − r); state the corresponding Cauchy-criterion estimate |∑_{k ∈ Ico m n} rᵏ| ≤ rᵐ/(1 − r) used in the comparison/ratio tests.",
+      "question": "Insert the index weight k: give the finite arithmetico-geometric closed form ∑_{k<n} k·xᵏ — the division-free identity (1 − x)²·∑_{k<n} k·xᵏ = x·(1 − xⁿ) − n·xⁿ·(1 − x) over any commutative ring and the field form over (1 − x)² — and reconcile it with Mathlib's infinite value x/(1 − x)².",
       "significance": "low"
     },
     {
       "id": "geometric-series-oq-08-oq-02",
       "question": "Give the two-sided form for negative ratios: for −1 < r < 0 the partial sums oscillate around (1 − r)⁻¹, with the same |rⁿ|/(1 − r) error envelope; formalise the alternating bracketing.",
+      "significance": "low"
+    },
+    {
+      "id": "geometric-series-oq-08-oq-03",
+      "question": "Extend the defect identity to the Ico-slice partial sum ∑_{k ∈ Ico m n} rᵏ and bound the slice by rᵐ/(1 − r); state the corresponding Cauchy-criterion estimate |∑_{k ∈ Ico m n} rᵏ| ≤ rᵐ/(1 − r) used in the comparison/ratio tests.",
       "significance": "low"
     }
   ],
@@ -117,8 +122,8 @@
     "summary": "For a real ratio r the finite geometric partial sum S n = ∑_{k<n} rᵏ has closed form (1 − rⁿ)/(1 − r) when r ≠ 1. This entry quantifies the relationship between these finite sums and the infinite value (1 − r)⁻¹ for 0 ≤ r < 1: the exact truncation defect (1 − r)⁻¹ − S n = rⁿ/(1 − r); the bounds S n < (1 − r)⁻¹ (strict, 0 < r < 1) and S n ≤ (1 − r)⁻¹; monotonicity of n ↦ S n; and upward convergence S n → (1 − r)⁻¹. Together they exhibit the infinite geometric value as the supremum of an increasing, bounded sequence with explicit error rⁿ/(1 − r). 128 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
     "implications": "Mathlib provides the finite closed form and the infinite value as separate facts; the difference between them — the truncation error rⁿ/(1 − r) — is exactly what is needed to estimate a truncated geometric series, and it is the engine behind the comparison test, the ratio-test remainder, and numerical error bounds. Packaging it as a typed identity, together with the monotonicity and bound that make 1/(1 − r) the least upper bound of the partial sums, makes the finite/infinite relationship reusable rather than re-derived inline.",
     "openQuestions": [
-      "Extend the defect and error envelope to Ico-slice partial sums (the Cauchy-criterion form).",
-      "State the alternating-bracketing version for −1 < r < 0."
+      "State the alternating-bracketing version for −1 < r < 0.",
+      "Extend the defect and error envelope to Ico-slice partial sums (the Cauchy-criterion form)."
     ]
   }
 }


### PR DESCRIPTION
## Summary

PR #27360 ships `geometric-series-oq-08-oq-01` as the **finite arithmetico-geometric closed form** $\sum_{k<n} k\cdot x^k$. The parent `geometric-series-oq-08` entry, however, still described its `oq-01` open question as the **Ico-slice partial sum** $\sum_{k\in \mathrm{Ico}\,m\,n} r^k$ — a different question. Once #27360 merges the parent and child disagree on what `oq-01` is.

This metadata-only PR reconciles them:

- **`oq-01`** question text → the arithmetico-geometric sum (matches the shipped child).
- **`oq-03`** (new) → preserves the original Ico-slice / Cauchy-criterion question so no open question is lost.
- **`oq-02`** (alternating-ratio) → unchanged.
- `conclusion.openQuestions` summary → refreshed to the two genuinely-open items (alternating-ratio, Ico-slice).

No Lean changes; the proof content lives in #27360.

## Verification
- `jq empty` validates the JSON.
- openQuestions ids are now oq-01/oq-02/oq-03 (no duplicates, none orphaned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)