### PR TITLE
research(geometric-series-oq-08-oq-01-oq-01): finite second-order arithmetico-geometric sum ∑ k²·xᵏ over (1−x)³ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2618,6 +2618,7 @@ import Proofs.GeometricSeriesOQ03
 import Proofs.GeometricSeriesOQ06
 import Proofs.GeometricSeriesOQ07
 import Proofs.GeometricSeriesOQ08
+import Proofs.GeometricSeriesOQ08OQ01OQ01
 import Proofs.GeometricSeriesOQ09
 import Proofs.GeometricSeriesOQ10
 import Proofs.GnedenkoKolmogorov

--- a/proofs/Proofs/GeometricSeriesOQ08OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ08OQ01OQ01.lean
@@ -1,0 +1,137 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+
+/-
+# Second-order Arithmetico-Geometric Sum: a closed form for ∑ k²·xᵏ
+
+## What This Proves
+
+For a ratio `x` and a length `n`, the *second-order* arithmetico-geometric
+finite sum `∑_{k=0}^{n-1} k²·xᵏ` (each geometric term `xᵏ` weighted by the
+square `k²`) has the division-free closed form
+
+  (1 − x)³ · ∑_{k=0}^{n-1} k²·xᵏ
+      =  x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2},
+
+valid over **any** commutative ring, and the corresponding field closed form
+
+  ∑_{k=0}^{n-1} k²·xᵏ
+      =  (x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2}) / (1 − x)³
+                                                                   (x ≠ 1).
+
+This is the next member of the weight family `∑ kᵐ·xᵏ` after the unweighted
+geometric sum (`m = 0`, ancestor `geometric-series-oq-08`) and the linear
+arithmetico-geometric sum (`m = 1`, parent `geometric-series-oq-08-oq-01`,
+`(1 − x)²·∑ k·xᵏ = x(1 − xⁿ) − n·xⁿ(1 − x)`).
+
+The **infinite** second-order series `∑' k, k²·xᵏ = x(1+x)/(1−x)³` (`‖x‖ < 1`)
+is the `n → ∞` limit of this finite closed form (the tail terms `n²·xⁿ`,
+`n²·x^{n+1}`, `n²·x^{n+2}` all vanish), leaving `(x + x²)/(1 − x)³`.  That
+infinite value is *already* in the gallery as `geometric-series-oq-07`
+(`tsum_sq_mul_geometric`), so it is **not** reproved here; this entry supplies
+the missing *finite* companion and cross-references oq-07 for the limit.
+
+## Why This Is Not Already in Mathlib
+
+Mathlib records the infinite linear weighted series
+`tsum_coe_mul_geometric_of_norm_lt_one` (`∑' n, n·rⁿ = r/(1−r)²`) and the
+`choose`-weighted family `tsum_choose_mul_geometric_of_norm_lt_one`
+(`∑' n, C(n+k,k)·rⁿ = 1/(1−r)^{k+1}`), plus the plain finite geometric sum
+`geom_sum_eq`.  It does **not** record the *finite* second-order
+arithmetico-geometric closed form `∑_{k<n} k²·xᵏ`, which is supplied here.
+
+## Proof Strategy
+
+1. **Ring identity (`sq_arith_geom_mul`).** Induction on `n`.  The base case is
+   `0 = 0`; the step uses `Finset.sum_range_succ` to peel the `k = n` term and
+   then `push_cast; ring`.  Coefficients are written with ring casts
+   (`(n : R)`, `(n : R) − 1`) so the `n = 0` instance is well-defined (no ℕ
+   truncated subtraction).
+2. **Field form (`sq_arith_geom_div`).** Clear `(1 − x)³ ≠ 0` (from `x ≠ 1`)
+   with `eq_div_iff` and discharge by the ring identity.
+3. **Specialisations / numeric witnesses.** `x = 2` and direct numeric checks
+   at `n = 4` (`0 + 1·2 + 4·4 + 9·8 = 90`) and `x = 3, n = 3` (`= 39`).
+
+All results depend only on `propext`, `Classical.choice`, `Quot.sound`.
+-/
+
+namespace GeometricSeriesOQ08OQ01OQ01
+
+open Finset
+
+/-! ## The finite second-order arithmetico-geometric sum -/
+
+/-- **Division-free closed form** for the finite second-order
+arithmetico-geometric sum, valid over any commutative ring:
+`(1 − x)³ · ∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2}`.
+Proved by induction on `n`: peel the top term with `Finset.sum_range_succ`, then
+`push_cast; ring`. -/
+theorem sq_arith_geom_mul {R : Type*} [CommRing R] (x : R) (n : ℕ) :
+    (1 - x) ^ 3 * ∑ k ∈ range n, (k : R) ^ 2 * x ^ k
+      = x + x ^ 2 - (n : R) ^ 2 * x ^ n
+        + (2 * (n : R) ^ 2 - 2 * (n : R) - 1) * x ^ (n + 1)
+        - ((n : R) - 1) ^ 2 * x ^ (n + 2) := by
+  induction n with
+  | zero => simp only [range_zero, sum_empty, mul_zero, Nat.cast_zero]; ring
+  | succ n ih =>
+      rw [sum_range_succ, mul_add, ih]
+      push_cast
+      ring
+
+/-- **Field closed form** for the finite second-order arithmetico-geometric sum
+(`x ≠ 1`):
+`∑_{k<n} k²·xᵏ = (x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2}) / (1 − x)³`. -/
+theorem sq_arith_geom_div {K : Type*} [Field K] (x : K) (hx : x ≠ 1) (n : ℕ) :
+    ∑ k ∈ range n, (k : K) ^ 2 * x ^ k
+      = (x + x ^ 2 - (n : K) ^ 2 * x ^ n
+          + (2 * (n : K) ^ 2 - 2 * (n : K) - 1) * x ^ (n + 1)
+          - ((n : K) - 1) ^ 2 * x ^ (n + 2)) / (1 - x) ^ 3 := by
+  have h1 : (1 : K) - x ≠ 0 := sub_ne_zero.mpr hx.symm
+  have h2 : (1 - x) ^ 3 ≠ 0 := pow_ne_zero _ h1
+  rw [eq_div_iff h2, mul_comm]
+  exact sq_arith_geom_mul x n
+
+/-- Sanity check of the ring identity at `n = 1` (both sides `0`): the only term
+is `0²·x⁰ = 0`.  Recorded as a guard against off-by-one sign errors. -/
+theorem sq_arith_geom_mul_one {R : Type*} [CommRing R] (x : R) :
+    (1 - x) ^ 3 * ∑ k ∈ range 1, (k : R) ^ 2 * x ^ k = 0 := by
+  rw [sq_arith_geom_mul]; ring
+
+/-! ## Specialisations and numeric witnesses -/
+
+/-- The weight-`x = 2` specialisation, from the field closed form.  Here
+`(1 − 2)³ = −1`, so `∑_{k<n} k²·2ᵏ = −(2 + 4 − n²·2ⁿ + (2n² − 2n − 1)·2^{n+1}
+− (n − 1)²·2^{n+2})`. -/
+theorem sq_arith_geom_two (n : ℕ) :
+    ∑ k ∈ range n, (k : ℝ) ^ 2 * 2 ^ k
+      = (n : ℝ) ^ 2 * 2 ^ n
+        - (2 * (n : ℝ) ^ 2 - 2 * (n : ℝ) - 1) * 2 ^ (n + 1)
+        + ((n : ℝ) - 1) ^ 2 * 2 ^ (n + 2) - 6 := by
+  rw [sq_arith_geom_div (x := (2 : ℝ)) (by norm_num)]
+  have h : ((1 : ℝ) - 2) ^ 3 = -1 := by norm_num
+  rw [h]
+  field_simp
+  ring
+
+/-- Numerical check at `n = 4`:
+`0²·1 + 1²·2 + 2²·4 + 3²·8 = 0 + 2 + 16 + 72 = 90`. -/
+theorem sq_arith_geom_two_four :
+    ∑ k ∈ range 4, (k : ℝ) ^ 2 * 2 ^ k = 90 := by
+  rw [sq_arith_geom_two]; norm_num
+
+/-- A second numerical witness directly from the field closed form, at `x = 3`,
+`n = 3`: `0²·1 + 1²·3 + 2²·9 = 0 + 3 + 36 = 39`. -/
+theorem sq_arith_geom_three_three :
+    ∑ k ∈ range 3, (k : ℝ) ^ 2 * 3 ^ k = 39 := by
+  rw [sq_arith_geom_div (x := (3 : ℝ)) (by norm_num)]; norm_num
+
+/-! ## The infinite limit (recorded elsewhere)
+
+The `n → ∞` limit of the finite closed form is the infinite second-order
+weighted series `∑' k, k²·xᵏ = x(1+x)/(1−x)³` for `‖x‖ < 1`: the tail terms
+`n²·xⁿ`, `(2n²−2n−1)·x^{n+1}`, `(n−1)²·x^{n+2}` all tend to `0`, leaving the
+numerator `x + x²`.  That infinite value is already in the gallery as
+`geometric-series-oq-07` (`GeometricSeriesOQ07.tsum_sq_mul_geometric`) and is
+**not** reproved here. -/
+
+end GeometricSeriesOQ08OQ01OQ01

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/meta.json
@@ -1,0 +1,115 @@
+{
+  "id": "geometric-series-oq-08-oq-01-oq-01",
+  "slug": "geometric-series-oq-08-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "GeometricSeriesOQ08OQ01OQ01",
+    "lineCount": 137,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ08OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Second-order Arithmetico-Geometric Sum: a Closed Form for ∑ k²·xᵏ",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ08OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "arithmetico-geometric",
+      "finite-sums",
+      "closed-form",
+      "weighted-series",
+      "second-moment",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 137,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "sq_arith_geom_mul: the division-free closed form (1 − x)³ · ∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2}, valid over ANY commutative ring. Proved by induction peeling the top term with Finset.sum_range_succ then push_cast; ring. Coefficients use ring casts ((n:R), (n:R)−1) so the n = 0 instance is well-defined (no ℕ truncated subtraction). This finite second-order identity is not in Mathlib.",
+      "sq_arith_geom_div: the field closed form ∑_{k<n} k²·xᵏ = (x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2})/(1 − x)³ for x ≠ 1, obtained by clearing the (1 − x)³ ≠ 0 denominator.",
+      "sq_arith_geom_two: the weight-x = 2 specialisation ∑_{k<n} k²·2ᵏ = n²·2ⁿ − (2n² − 2n − 1)·2^{n+1} + (n−1)²·2^{n+2} − 6 (the denominator (1 − 2)³ = −1), with numerical witnesses at n = 4 (= 90) and the x = 3, n = 3 case (= 39).",
+      "sq_arith_geom_mul_one: a base-case sanity guard that the n = 1 instance reduces to 0 (the only term 0²·x⁰ = 0), checking the sign pattern of the closed form."
+    ],
+    "prerequisites": [
+      "Finset.sum_range_succ for peeling the top term in the inductive step",
+      "eq_div_iff / pow_ne_zero / sub_ne_zero for the field-form denominator clearing",
+      "push_cast; ring for the Nat-cast polynomial identity in the inductive step",
+      "Parent: geometric-series-oq-08-oq-01 (the first-moment finite sum ∑_{k<n} k·xᵏ over (1 − x)²)",
+      "Ancestor: geometric-series-oq-08 (finite partial sums ∑_{k<n} rᵏ and their infinite limit)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑_{k<n+1} f k = ∑_{k<n} f k + f n. Peels the k = n term in the inductive step of the ring identity.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "eq_div_iff",
+        "description": "a = b / c ↔ a * c = b for c ≠ 0. Clears the (1 − x)³ denominator to reduce the field form to the ring identity.",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-08-oq-01-oq-01-oq-01",
+      "question": "Unify the family: give a single division-free closed form for the m-th moment finite sum ∑_{k<n} kᵐ·xᵏ over any commutative ring, with denominator (1 − x)^{m+1} and Eulerian-polynomial numerator, specialising to the m = 0, 1, 2 cases recorded here.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-08-oq-01",
+      "relationship": "extends",
+      "description": "Parent. The parent gives the first-moment finite arithmetico-geometric sum (1 − x)²·∑_{k<n} k·xᵏ = x(1 − xⁿ) − n·xⁿ(1 − x). This entry raises the weight to k², giving the second-moment finite closed form over (1 − x)³."
+    },
+    {
+      "targetId": "geometric-series-oq-08",
+      "relationship": "extends",
+      "description": "Ancestor. The unweighted (m = 0) finite geometric partial sums ∑_{k<n} rᵏ; this entry is the m = 2 member of the weight family ∑ kᵐ·xᵏ."
+    },
+    {
+      "targetId": "geometric-series-oq-07",
+      "relationship": "sibling",
+      "description": "Records the INFINITE second moment ∑' k, k²·xᵏ = x(1 + x)/(1 − x)³ for ‖x‖ < 1. That value is precisely the n → ∞ limit of this entry's FINITE closed form (the tail terms n²·xⁿ, (2n²−2n−1)·x^{n+1}, (n−1)²·x^{n+2} vanish, leaving x + x² over (1 − x)³). The infinite result is not reproved here; this entry supplies the finite companion."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Provides the finite/infinite geometric-series infrastructure; the finite second-order closed form here is the missing companion to its infinite weighted series."
+    },
+    {
+      "title": "Concrete Mathematics (sums of the form ∑ kᵐ·xᵏ and Eulerian numbers)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for weighted geometric (arithmetico-geometric) sums and the perturbation method yielding their closed forms."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The finite second-order arithmetico-geometric sum ∑_{k<n} k²·xᵏ — each geometric term xᵏ weighted by the square k² — has the division-free closed form (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2} over any commutative ring, equivalently ∑_{k<n} k²·xᵏ = (…)/(1 − x)³ for x ≠ 1. It specialises to ∑_{k<n} k²·2ᵏ (numerically 90 at n = 4) and, as n → ∞ with ‖x‖ < 1, recovers the gallery's infinite second moment x(1 + x)/(1 − x)³ (geometric-series-oq-07). 137 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This completes the m = 0, 1, 2 row of the weighted-geometric family ∑_{k<n} kᵐ·xᵏ in finite form: m = 0 is geometric-series-oq-08 (denominator 1 − x), m = 1 is the parent geometric-series-oq-08-oq-01 (denominator (1 − x)²), and m = 2 is supplied here (denominator (1 − x)³). The ring-level identity holds with no analysis and over every commutative ring; the field form and the infinite-limit connection follow as specialisations. Such finite second-moment sums arise in computing variances of geometric/negative-binomial distributions and in coefficient extraction for rational generating functions.",
+    "openQuestions": [
+      "Unify into a single closed form for ∑_{k<n} kᵐ·xᵏ over (1 − x)^{m+1} with an Eulerian-polynomial numerator, specialising to m = 0, 1, 2."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question of parent **geometric-series-oq-08-oq-01**: the next member of the weighted-geometric family `∑ kᵐ·xᵏ` after `m=0` (`geometric-series-oq-08`, denominator `1−x`) and `m=1` (parent, `(1−x)²`).

**Division-free closed form, valid over ANY commutative ring:**

```
(1 − x)³ · ∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2}
```

Coefficients use ring casts (`(n:R)`, `(n:R)−1`) so the `n=0` instance is well-defined (no ℕ truncated subtraction). Proved by induction: peel the top term with `Finset.sum_range_succ`, then `push_cast; ring`.

## Contents (137 lines, 6 theorems, 0 defs, 0 axioms, 0 sorries)

- `sq_arith_geom_mul` — the ring closed form above.
- `sq_arith_geom_div` — field form `∑ = (…)/(1−x)³` for `x ≠ 1`.
- `sq_arith_geom_mul_one` — `n=1` base-case sign guard.
- `sq_arith_geom_two` — `x=2` specialisation (`(1−2)³ = −1`).
- `sq_arith_geom_two_four` / `sq_arith_geom_three_three` — numeric witnesses (`n=4 → 90`; `x=3,n=3 → 39`).

## Novelty / honesty

- The **finite** second-order closed form is **not** in Mathlib (which has only the infinite weighted/choose families and the plain finite geometric sum).
- The **infinite** limit `∑' k, k²·xᵏ = x(1+x)/(1−x)³` is the `n→∞` limit of this finite form, but it is **already** in the gallery as `geometric-series-oq-07` — so it is **cross-referenced, not reproved**, to avoid duplication.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ08OQ01OQ01` → builds clean.
- `#print axioms` on `sq_arith_geom_mul`, `sq_arith_geom_div` → `[propext, Classical.choice, Quot.sound]` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)