### PR TITLE
research(geometric-series-oq-08-oq-04): finite second moment ∑k²·xᵏ — closed form, defect polynomial, infinite-limit bridge [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2620,6 +2620,7 @@ import Proofs.GeometricSeriesOQ03
 import Proofs.GeometricSeriesOQ06
 import Proofs.GeometricSeriesOQ07
 import Proofs.GeometricSeriesOQ08
+import Proofs.GeometricSeriesOQ08OQ04
 import Proofs.GeometricSeriesOQ09
 import Proofs.GeometricSeriesOQ10
 import Proofs.GnedenkoKolmogorov

--- a/proofs/Proofs/GeometricSeriesOQ08OQ04.lean
+++ b/proofs/Proofs/GeometricSeriesOQ08OQ04.lean
@@ -1,0 +1,171 @@
+import Mathlib.Algebra.GeomSum
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+
+/-
+# Second-Order Arithmetico-Geometric Sums: ∑ k²·xᵏ and its Infinite Limit
+
+## What This Proves
+The **finite** closed form for the *second-order* arithmetico-geometric sum
+∑_{k<n} k²·xᵏ over an arbitrary commutative ring, with an explicit truncation
+defect, the field form, and the bridge that recovers the infinite second
+moment x(1+x)/(1−x)³ as the n → ∞ limit.
+
+This fills the missing cell in the moment × truncation grid for the geometric
+series:
+- parent oq-08 (zeroth moment, finite defect): ∑_{k<n} xᵏ vs (1−x)⁻¹
+- sibling oq-08-oq-01 (first moment, finite): ∑_{k<n} k·xᵏ, closed via (1−x)²
+- sibling oq-07 (second moment, **infinite** only): ∑_{n≥0} n²·rⁿ = r(1+r)/(1−r)³
+- **this entry** (second moment, **finite**): ∑_{k<n} k²·xᵏ, closed via (1−x)³,
+  with the explicit defect polynomial — the finite/defect form that oq-07
+  (infinite tsum) does not provide.
+
+The master identity (valid in ANY `CommRing`, no division) is
+
+    (1 − x)³ · ∑_{k<n} k²·xᵏ
+        = x + x² − xⁿ·(n² + (1 + 2n − 2n²)·x + (n−1)²·x²).
+
+The polynomial tail Q(n,x) = n² + (1+2n−2n²)x + (n−1)²x² is exactly the
+truncation defect: it captures everything the finite sum is missing relative
+to the infinite series x(1+x)/(1−x)³. The induction step reduces to the
+single ring identity Q(n) − x·Q(n+1) = n²·(1−x)³.
+
+## Approach
+- **Foundation (from Mathlib):** none beyond `Finset.sum_range_succ`; the core
+  identity is a pure polynomial fact discharged by induction + `ring`.
+- **Original contribution:** the explicit finite closed form for ∑_{k<n} k²·xᵏ
+  with its `n`-dependent defect polynomial, the field form, and the bridge that
+  recovers the infinite value as the defect tail vanishes. (The infinite value
+  itself coincides with sibling oq-07's `hasSum_sq_mul_geometric`; here it is
+  re-obtained as the limit of the finite closed form rather than assumed.)
+- **Proof techniques:** induction on `n`, `ring` for the algebraic step,
+  `tendsto`/`HasSum` plumbing for the analytic corollary.
+-/
+
+namespace GeometricSeriesOQ08OQ04
+
+open Finset BigOperators Filter
+
+-- ============================================================
+-- PART 1: The finite closed form over an arbitrary CommRing
+-- ============================================================
+
+variable {R : Type*} [CommRing R]
+
+/-- The defect polynomial: the degree-2 tail multiplying `xⁿ`.
+`Q n x = n² + (1 + 2n − 2n²)·x + (n−1)²·x²`. -/
+def defectPoly (n : ℕ) (x : R) : R :=
+  (n : R) ^ 2 + (1 + 2 * n - 2 * (n : R) ^ 2) * x + ((n : R) - 1) ^ 2 * x ^ 2
+
+/-- **Master identity** (no division, any `CommRing`):
+`(1 − x)³ · ∑_{k<n} k²·xᵏ = x + x² − xⁿ · Q(n,x)`. -/
+theorem cube_one_sub_mul_sum_sq_mul_pow (x : R) (n : ℕ) :
+    (1 - x) ^ 3 * ∑ k ∈ range n, (k : R) ^ 2 * x ^ k
+      = x + x ^ 2 - x ^ n * defectPoly n x := by
+  induction n with
+  | zero => simp [defectPoly]
+  | succ n ih =>
+      rw [Finset.sum_range_succ, mul_add, ih]
+      -- Reduce to the ring identity  Q(n) − x·Q(n+1) = n²·(1−x)³,
+      -- packaged as the goal after expanding `defectPoly` and `xⁿ⁺¹`.
+      simp only [defectPoly, pow_succ, Nat.cast_succ]
+      ring
+
+-- ============================================================
+-- PART 2: Field form
+-- ============================================================
+
+variable {K : Type*} [Field K]
+
+/-- **Field closed form.** When `x ≠ 1`,
+`∑_{k<n} k²·xᵏ = (x + x² − xⁿ·Q(n,x)) / (1 − x)³`. -/
+theorem sum_sq_mul_pow_eq_div (x : K) (hx : x ≠ 1) (n : ℕ) :
+    ∑ k ∈ range n, (k : K) ^ 2 * x ^ k
+      = (x + x ^ 2 - x ^ n * defectPoly n x) / (1 - x) ^ 3 := by
+  have hne : (1 - x) ^ 3 ≠ 0 := by
+    have : (1 : K) - x ≠ 0 := sub_ne_zero.mpr (fun h => hx h.symm)
+    exact pow_ne_zero 3 this
+  rw [eq_div_iff hne, mul_comm]
+  exact cube_one_sub_mul_sum_sq_mul_pow x n
+
+-- ============================================================
+-- PART 3: A few sanity specializations
+-- ============================================================
+
+/-- `n = 1`: the sum is empty of nonzero terms (only `k = 0`), so it vanishes,
+and the master identity collapses to `0 = 0`. -/
+theorem sum_sq_one (x : R) :
+    ∑ k ∈ range 1, (k : R) ^ 2 * x ^ k = 0 := by
+  simp
+
+/-- `n = 2`: `∑_{k<2} k²·xᵏ = x`. -/
+theorem sum_sq_two (x : R) :
+    ∑ k ∈ range 2, (k : R) ^ 2 * x ^ k = x := by
+  simp [Finset.sum_range_succ]
+
+/-- `n = 3`: `∑_{k<3} k²·xᵏ = x + 4·x²`. -/
+theorem sum_sq_three (x : R) :
+    ∑ k ∈ range 3, (k : R) ^ 2 * x ^ k = x + 4 * x ^ 2 := by
+  simp [Finset.sum_range_succ]; ring
+
+-- ============================================================
+-- PART 4: Bridge to the infinite limit  ∑ k²·xᵏ = x(1+x)/(1−x)³
+-- ============================================================
+
+/-- The defect tail `xⁿ · Q(n,x)` tends to `0` as `n → ∞` when `|x| < 1`.
+This is the analytic content that turns the finite closed form into the
+classical infinite value. -/
+theorem defect_tendsto_zero {x : ℝ} (hx : |x| < 1) :
+    Tendsto (fun n => x ^ n * defectPoly n x) atTop (nhds 0) := by
+  -- `xⁿ · (a·n² + b·n + c)` → 0 since geometric decay beats polynomial growth.
+  unfold defectPoly
+  have hnx : ‖x‖ < 1 := by simpa [Real.norm_eq_abs] using hx
+  have h0 : Tendsto (fun n : ℕ => (n : ℝ) ^ 2 * x ^ n) atTop (nhds 0) :=
+    (summable_pow_mul_geometric_of_norm_lt_one 2 hnx).tendsto_atTop_zero
+  have h1 : Tendsto (fun n : ℕ => (n : ℝ) ^ 1 * x ^ n) atTop (nhds 0) :=
+    (summable_pow_mul_geometric_of_norm_lt_one 1 hnx).tendsto_atTop_zero
+  have h2 : Tendsto (fun n : ℕ => (n : ℝ) ^ 0 * x ^ n) atTop (nhds 0) :=
+    (summable_pow_mul_geometric_of_norm_lt_one 0 hnx).tendsto_atTop_zero
+  -- Expand `xⁿ · Q` into a sum of `nʲ · xⁿ` pieces, each tending to 0.
+  have : (fun n : ℕ => x ^ n *
+      ((n : ℝ) ^ 2 + (1 + 2 * n - 2 * (n : ℝ) ^ 2) * x + ((n : ℝ) - 1) ^ 2 * x ^ 2))
+      = (fun n : ℕ =>
+          (1 - 2 * x + x ^ 2) * ((n : ℝ) ^ 2 * x ^ n)
+          + (2 * x - 2 * x ^ 2) * ((n : ℝ) ^ 1 * x ^ n)
+          + (x + x ^ 2) * ((n : ℝ) ^ 0 * x ^ n)) := by
+    funext n; ring
+  rw [this]
+  have := ((h0.const_mul (1 - 2 * x + x ^ 2)).add
+            (h1.const_mul (2 * x - 2 * x ^ 2))).add
+            (h2.const_mul (x + x ^ 2))
+  simpa using this
+
+/-- **Infinite value.** For `|x| < 1`,
+`∑_{k} k²·xᵏ = x·(1 + x) / (1 − x)³`.
+The partial sums converge to the closed form with the defect tail removed. -/
+theorem hasSum_sq_mul_pow {x : ℝ} (hx : |x| < 1) :
+    HasSum (fun k : ℕ => (k : ℝ) ^ 2 * x ^ k) (x * (1 + x) / (1 - x) ^ 3) := by
+  have hx1 : x ≠ 1 := fun h => by simp [h] at hx
+  have hne : (1 - x) ^ 3 ≠ 0 := pow_ne_zero 3 (sub_ne_zero.mpr (fun h => hx1 h.symm))
+  have hnx : ‖x‖ < 1 := by simpa [Real.norm_eq_abs] using hx
+  -- absolute summability of `k² xᵏ` (pins down `f` before the rewrite)
+  have hsum : Summable (fun k : ℕ => ‖(k : ℝ) ^ 2 * x ^ k‖) :=
+    summable_norm_pow_mul_geometric_of_norm_lt_one 2 hnx
+  -- A `HasSum` over ℕ is the `atTop` limit of partial sums `∑_{k<n}`.
+  rw [hasSum_iff_tendsto_nat_of_summable_norm hsum]
+  · -- limit of the field closed form as the defect tail vanishes
+    have hform : (fun n => ∑ k ∈ range n, (k : ℝ) ^ 2 * x ^ k)
+        = (fun n => (x + x ^ 2 - x ^ n * defectPoly n x) / (1 - x) ^ 3) := by
+      funext n; exact sum_sq_mul_pow_eq_div x hx1 n
+    rw [hform]
+    have hlim : Tendsto (fun n => x + x ^ 2 - x ^ n * defectPoly n x) atTop
+        (nhds (x + x ^ 2)) := by
+      have := (tendsto_const_nhds (x := x + x ^ 2)).sub (defect_tendsto_zero hx)
+      simpa using this
+    have : Tendsto (fun n => (x + x ^ 2 - x ^ n * defectPoly n x) / (1 - x) ^ 3)
+        atTop (nhds ((x + x ^ 2) / (1 - x) ^ 3)) :=
+      hlim.div_const _
+    have heq : (x + x ^ 2) / (1 - x) ^ 3 = x * (1 + x) / (1 - x) ^ 3 := by ring
+    rwa [heq] at this
+
+end GeometricSeriesOQ08OQ04

--- a/src/data/proofs/geometric-series-oq-08-oq-04/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-04/meta.json
@@ -1,0 +1,124 @@
+{
+  "id": "geometric-series-oq-08-oq-04",
+  "slug": "geometric-series-oq-08-oq-04",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.GeomSum",
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators",
+      "Filter"
+    ],
+    "namespace": "GeometricSeriesOQ08OQ04",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ08OQ04.lean",
+    "sorries": 0
+  },
+  "title": "The Finite Second Moment: ∑_{k<n} k²·xᵏ, its Defect Polynomial, and the Infinite Limit",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ08OQ04.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "arithmetico-geometric",
+      "finite-sums",
+      "second-moment",
+      "truncation-error",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 171,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "cube_one_sub_mul_sum_sq_mul_pow: the division-free master identity (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − xⁿ·Q(n,x) over an ARBITRARY commutative ring, where Q(n,x) = n² + (1 + 2n − 2n²)·x + (n−1)²·x² is the explicit truncation defect. This is the finite second-moment analogue of the parent's zeroth-power defect (oq-08) and the first-power arithmetico-geometric form (oq-08-oq-01); it is proved by induction with the step collapsing to the single ring identity Q(n) − x·Q(n+1) = n²·(1−x)³.",
+      "defectPoly: the degree-2 tail polynomial Q(n,x) packaged as a definition, isolating exactly what ∑_{k<n} k²·xᵏ is missing relative to the infinite series x(1+x)/(1−x)³.",
+      "sum_sq_mul_pow_eq_div: the field form ∑_{k<n} k²·xᵏ = (x + x² − xⁿ·Q(n,x))/(1 − x)³ for x ≠ 1 in any field.",
+      "defect_tendsto_zero: the defect tail xⁿ·Q(n,x) → 0 for |x| < 1 (geometric decay beats the polynomial Q), the analytic content that turns the finite closed form into the infinite value.",
+      "hasSum_sq_mul_pow: recovers the infinite second moment ∑ k²·xᵏ = x(1+x)/(1−x)³ for |x| < 1 as the n → ∞ limit of the finite closed form (rather than assumed). The value coincides with sibling oq-07's hasSum_sq_mul_geometric; the novelty here is the finite/defect route."
+    ],
+    "prerequisites": [
+      "Finset.sum_range_succ (induction step on the partial sum)",
+      "ring / induction for the core polynomial identity over a CommRing",
+      "summable_pow_mul_geometric_of_norm_lt_one and Summable.tendsto_atTop_zero (nᵏ·xⁿ → 0)",
+      "summable_norm_pow_mul_geometric_of_norm_lt_one and hasSum_iff_tendsto_nat_of_summable_norm (HasSum as the limit of partial sums)",
+      "Parent: geometric-series-oq-08 (finite vs infinite, truncation defect, bounds)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑_{k<n+1} f k = (∑_{k<n} f k) + f n. Drives the induction that establishes the master identity.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "summable_pow_mul_geometric_of_norm_lt_one",
+        "description": "Summable (fun n => (n:R)^k · r^n) for ‖r‖ < 1. With Summable.tendsto_atTop_zero gives nᵏ·xⁿ → 0, used to show the defect tail vanishes.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "hasSum_iff_tendsto_nat_of_summable_norm",
+        "description": "For a norm-summable family, HasSum f a ↔ the partial sums ∑_{k<n} f k tend to a. Converts the finite closed form into the infinite HasSum statement.",
+        "module": "Mathlib.Analysis.Normed.Group.InfiniteSum"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-08-oq-04-oq-01",
+      "question": "Give the general r-th moment finite closed form: (1 − x)^{r+1}·∑_{k<n} kʳ·xᵏ = Aᵣ(x) − xⁿ·Qᵣ(n,x), where Aᵣ is the Eulerian-polynomial numerator x·Aᵣ(x)/(1−x)^{r+1} of the infinite r-th moment and Qᵣ is a degree-r defect polynomial in x with coefficients of degree r in n. The cases r = 0,1,2 are oq-08, oq-08-oq-01, and this entry.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-08-oq-04-oq-02",
+      "question": "Bound the second-moment truncation defect: for 0 ≤ x < 1 give an explicit envelope |xⁿ·Q(n,x)|/(1 − x)³ ≤ C·n²·xⁿ/(1 − x)³ and the monotone/convergence package making x(1+x)/(1−x)³ the supremum of the increasing finite sums.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-08",
+      "relationship": "extends",
+      "description": "Parent. oq-08 gives the zeroth-power truncation defect (1 − x)⁻¹ − ∑_{k<n} xᵏ = xⁿ/(1 − x). This entry is the second-moment analogue: the finite closed form for ∑_{k<n} k²·xᵏ with the explicit degree-2 defect polynomial, recovering the infinite value as n → ∞."
+    },
+    {
+      "targetId": "geometric-series-oq-07",
+      "relationship": "sibling",
+      "description": "oq-07 computes the INFINITE second moment ∑_{n≥0} n²·rⁿ = r(1+r)/(1−r)³. This entry supplies the FINITE partial sum ∑_{k<n} k²·xᵏ and its truncation defect, re-deriving oq-07's value as the limit when the defect tail vanishes."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (sums of the form ∑ k² xᵏ)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for arithmetico-geometric sums and the operator (x d/dx) raising the moment of the geometric series."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed",
+      "author": "Mathlib Community",
+      "year": "2026",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of summable_pow_mul_geometric_of_norm_lt_one and the norm-summability lemmas used to vanish the defect tail and assemble the HasSum corollary."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Over an arbitrary commutative ring, the finite second-moment sum satisfies the division-free identity (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − xⁿ·Q(n,x) with defect polynomial Q(n,x) = n² + (1 + 2n − 2n²)·x + (n−1)²·x²; the field form divides by (1 − x)³ when x ≠ 1. For |x| < 1 the defect tail xⁿ·Q(n,x) → 0, so the finite sums converge to x(1+x)/(1−x)³ — the infinite second moment, here recovered as a limit rather than assumed. 171 lines, 7 theorems, 1 definition, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This is the finite/defect cell missing from the geometric-series moment grid: the parent (oq-08) handles the zeroth moment, oq-08-oq-01 the first moment, and oq-07 the infinite second moment. The explicit degree-2 defect polynomial is exactly the error term when ∑ k² xᵏ is truncated, and the induction step's collapse to Q(n) − x·Q(n+1) = n²·(1−x)³ shows how each higher moment's defect is generated from the previous, pointing to the general Eulerian-polynomial pattern.",
+    "openQuestions": [
+      "Generalise to the r-th moment finite closed form with Eulerian-polynomial numerator and a degree-r defect polynomial.",
+      "Give the explicit truncation envelope and monotone-convergence package for the second-moment partial sums."
+    ]
+  }
+}

--- a/src/data/proofs/geometric-series-oq-08/meta.json
+++ b/src/data/proofs/geometric-series-oq-08/meta.json
@@ -80,6 +80,11 @@
       "id": "geometric-series-oq-08-oq-03",
       "question": "Extend the defect identity to the Ico-slice partial sum ∑_{k ∈ Ico m n} rᵏ and bound the slice by rᵐ/(1 − r); state the corresponding Cauchy-criterion estimate |∑_{k ∈ Ico m n} rᵏ| ≤ rᵐ/(1 − r) used in the comparison/ratio tests.",
       "significance": "low"
+    },
+    {
+      "id": "geometric-series-oq-08-oq-04",
+      "question": "Raise the index weight to k²: give the finite SECOND-moment closed form ∑_{k<n} k²·xᵏ — the division-free identity (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − xⁿ·Q(n,x) with defect polynomial Q(n,x) = n² + (1 + 2n − 2n²)·x + (n−1)²·x² over any commutative ring, the field form over (1 − x)³, and recovery of the infinite second moment x(1+x)/(1−x)³ as the n → ∞ limit.",
+      "significance": "medium"
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary

Fills the **finite/defect cell** missing from the geometric-series moment grid. The grid is moment ∈ {0,1,2} × truncation ∈ {finite-defect, infinite}:

| moment | finite (defect form) | infinite |
|--------|----------------------|----------|
| 0th | **oq-08** ∑xᵏ defect xⁿ/(1−x) | geometric-series |
| 1st | **oq-08-oq-01** ∑k·xᵏ via (1−x)² | x/(1−x)² |
| 2nd | **this entry (oq-08-oq-04)** ∑k²·xᵏ via (1−x)³ | **oq-07** x(1+x)/(1−x)³ |

### Master identity (division-free, any `CommRing`)
```
(1 − x)³ · ∑_{k<n} k²·xᵏ  =  x + x² − xⁿ·Q(n,x)
        Q(n,x) = n² + (1 + 2n − 2n²)·x + (n−1)²·x²
```
Proved by induction; the step collapses to the single ring identity
`Q(n) − x·Q(n+1) = n²·(1−x)³` (discharged by `ring`).

### Theorems (7) + 1 def
- `defectPoly` — the degree-2 tail Q(n,x)
- `cube_one_sub_mul_sum_sq_mul_pow` — the master identity over any CommRing
- `sum_sq_mul_pow_eq_div` — field form `∑ = (x+x²−xⁿQ)/(1−x)³` for x ≠ 1
- `sum_sq_one/two/three` — sanity specializations (0, x, x+4x²)
- `defect_tendsto_zero` — tail xⁿ·Q(n,x) → 0 for |x|<1
- `hasSum_sq_mul_pow` — recovers ∑ k²·xᵏ = x(1+x)/(1−x)³ as the n→∞ limit

### Honesty note
The **infinite** value coincides with sibling **oq-07**'s `hasSum_sq_mul_geometric`; the novel content here is the **finite** closed form with its explicit defect polynomial (which oq-07's `tsum`-only treatment does not provide), and the infinite value re-derived as the limit of the finite form rather than assumed.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ08OQ04` → **Build succeeded**
- 171 lines · 7 theorems · 1 def · **0 axioms** · 0 sorries · no `native_decide`
- Depends only on `propext`, `Classical.choice`, `Quot.sound`

## Files
- `proofs/Proofs/GeometricSeriesOQ08OQ04.lean` (new)
- `proofs/Proofs.lean` (register module)
- `src/data/proofs/geometric-series-oq-08-oq-04/meta.json` (new gallery entry)
- `src/data/proofs/geometric-series-oq-08/meta.json` (add matching oq-04 open question)

🤖 Generated with [Claude Code](https://claude.com/claude-code)