### PR TITLE
research(geometric-series-oq-08-oq-03): the Ico-slice and the Cauchy criterion [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2621,6 +2621,7 @@ import Proofs.GeometricSeriesOQ06
 import Proofs.GeometricSeriesOQ07
 import Proofs.GeometricSeriesOQ08
 import Proofs.GeometricSeriesOQ08OQ01OQ01
+import Proofs.GeometricSeriesOQ08OQ03
 import Proofs.GeometricSeriesOQ09
 import Proofs.GeometricSeriesOQ10
 import Proofs.GnedenkoKolmogorov

--- a/proofs/Proofs/GeometricSeriesOQ08OQ03.lean
+++ b/proofs/Proofs/GeometricSeriesOQ08OQ03.lean
@@ -1,0 +1,141 @@
+import Mathlib.Algebra.Field.GeomSum
+import Mathlib.Algebra.Order.Field.GeomSum
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Tactic
+
+/-
+# The Ico-slice of a Geometric Series and the Cauchy Criterion
+
+## What This Proves
+
+The parent entry `GeometricSeriesOQ08.lean` quantifies how the finite
+geometric partial sums `∑_{k<n} rᵏ` approach the infinite value `(1 − r)⁻¹`,
+with the exact truncation defect `rⁿ / (1 − r)`. This follow-up turns that
+one-sided "head vs. limit" statement into the **two-sided slice** estimate that
+the comparison and ratio tests actually invoke: a bound on an arbitrary middle
+block `∑_{k ∈ Ico m n} rᵏ`.
+
+* `geometric_slice_closed` — the closed form `(rᵐ − rⁿ)/(1 − r)` for the slice
+  (a thin wrapper over Mathlib's `geom_sum_Ico'`).
+* `geometric_slice_eq_tail_sub` — the **difference-of-tails identity**
+  `∑_{k ∈ Ico m n} rᵏ = rᵐ/(1 − r) − rⁿ/(1 − r)`: the slice is exactly the
+  parent's `m`-tail minus its `n`-tail. This is the bridge that ties the slice
+  back to `GeometricSeriesOQ08.geometric_sum_tail`.
+* `geometric_slice_factor` — the **self-similarity** `∑_{k ∈ Ico m n} rᵏ =
+  rᵐ · ∑_{k < n − m} rᵏ`: a slice starting at `m` is `rᵐ` times a fresh
+  partial sum.
+* `geometric_slice_le` / `geometric_slice_abs_le` — the slice bound
+  `∑_{k ∈ Ico m n} rᵏ ≤ rᵐ/(1 − r)` and its absolute-value form, valid for
+  *all* `m, n` (the slice is empty, hence `0`, when `n ≤ m`).
+* `geometric_slice_bound_tendsto` — the envelope `rᵐ/(1 − r) → 0`.
+* `geometric_slice_cauchy` — the **Cauchy criterion**: for every `ε > 0` there
+  is an `N` past which *every* block has `|∑_{k ∈ Ico m n} rᵏ| ≤ ε`,
+  uniformly in the right endpoint `n`. This is the exact estimate that proves a
+  geometric series Cauchy, and the template the comparison/ratio tests follow.
+
+## Why This Matters
+
+The truncation defect `rⁿ/(1 − r)` answers "how far is the `n`-term sum from the
+limit?". The slice bound `rᵐ/(1 − r)` answers the question convergence proofs
+really ask: "how large can the discarded *tail block* between steps `m` and `n`
+be?" — and the answer does not depend on `n`. Packaging this as a typed Cauchy
+statement (`geometric_slice_cauchy`) gives the reusable engine behind the
+comparison test, the ratio-test remainder, and dominated convergence of
+geometric majorants.
+
+## Mathlib Relationship
+
+The slice closed form (`geom_sum_Ico'`) and the raw slice bound
+(`geom_sum_Ico_le_of_lt_one`) are Mathlib lemmas; they are wrapped here for the
+gallery's self-containedness and clearly attributed. The genuinely assembled
+content is the difference-of-tails identity, the self-similar factorisation, the
+absolute-value/Cauchy packaging, and the explicit `ε`–`N` Cauchy criterion —
+none of which is a single Mathlib lemma for this series.
+-/
+
+namespace GeometricSeriesOQ08OQ03
+
+open Finset
+
+variable {r : ℝ}
+
+/-- **Slice closed form.** For `r ≠ 1` and `m ≤ n`, the middle block has the
+closed form `(rᵐ − rⁿ)/(1 − r)`. Wraps Mathlib's `geom_sum_Ico'`. -/
+theorem geometric_slice_closed (hr : r ≠ 1) {m n : ℕ} (hmn : m ≤ n) :
+    ∑ k ∈ Ico m n, r ^ k = (r ^ m - r ^ n) / (1 - r) :=
+  geom_sum_Ico' hr hmn
+
+/-- **Difference of tails.** For `r < 1` and `m ≤ n`, the slice equals the
+parent's `m`-tail minus its `n`-tail:
+`∑_{k ∈ Ico m n} rᵏ = rᵐ/(1 − r) − rⁿ/(1 − r)`. This is the bridge from the
+two-sided slice back to `GeometricSeriesOQ08.geometric_sum_tail`. -/
+theorem geometric_slice_eq_tail_sub (hr : r < 1) {m n : ℕ} (hmn : m ≤ n) :
+    ∑ k ∈ Ico m n, r ^ k = r ^ m / (1 - r) - r ^ n / (1 - r) := by
+  rw [geometric_slice_closed (ne_of_lt hr) hmn, sub_div]
+
+/-- **Self-similarity.** A slice starting at `m` is `rᵐ` times a fresh partial
+sum: `∑_{k ∈ Ico m n} rᵏ = rᵐ · ∑_{k < n − m} rᵏ`. Holds for all `m, n`. -/
+theorem geometric_slice_factor (m n : ℕ) :
+    ∑ k ∈ Ico m n, r ^ k = r ^ m * ∑ k ∈ range (n - m), r ^ k := by
+  rw [Finset.sum_Ico_eq_sum_range, Finset.mul_sum]
+  exact Finset.sum_congr rfl fun i _ => by rw [pow_add]
+
+/-- **Slice bound.** For `0 ≤ r < 1` the middle block is at most `rᵐ/(1 − r)`,
+*independently of the right endpoint* `n` (and of whether `m ≤ n`). Wraps
+Mathlib's `geom_sum_Ico_le_of_lt_one`. -/
+theorem geometric_slice_le (hr0 : 0 ≤ r) (hr1 : r < 1) (m n : ℕ) :
+    ∑ k ∈ Ico m n, r ^ k ≤ r ^ m / (1 - r) :=
+  geom_sum_Ico_le_of_lt_one hr0 hr1
+
+/-- **Absolute slice bound (Cauchy estimate).** For `0 ≤ r < 1`,
+`|∑_{k ∈ Ico m n} rᵏ| ≤ rᵐ/(1 − r)`. The slice is nonnegative, so the absolute
+value is harmless; this is the form used in the comparison/ratio tests. -/
+theorem geometric_slice_abs_le (hr0 : 0 ≤ r) (hr1 : r < 1) (m n : ℕ) :
+    |∑ k ∈ Ico m n, r ^ k| ≤ r ^ m / (1 - r) := by
+  rw [abs_of_nonneg (Finset.sum_nonneg fun i _ => pow_nonneg hr0 i)]
+  exact geometric_slice_le hr0 hr1 m n
+
+/-- **Envelope vanishes.** The slice bound `rᵐ/(1 − r)` tends to `0` as the left
+endpoint `m → ∞`. -/
+theorem geometric_slice_bound_tendsto (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    Filter.Tendsto (fun m => r ^ m / (1 - r)) Filter.atTop (nhds 0) := by
+  have h0 : Filter.Tendsto (fun m => r ^ m) Filter.atTop (nhds 0) :=
+    tendsto_pow_atTop_nhds_zero_of_lt_one hr0 hr1
+  simpa using h0.div_const (1 - r)
+
+/-- **Cauchy criterion.** For `0 ≤ r < 1` and any `ε > 0` there is a threshold
+`N` such that *every* slice with left endpoint `m ≥ N` satisfies
+`|∑_{k ∈ Ico m n} rᵏ| ≤ ε`, uniformly in the right endpoint `n`. This is the
+estimate that exhibits the geometric series as Cauchy and underlies the
+comparison and ratio tests. -/
+theorem geometric_slice_cauchy (hr0 : 0 ≤ r) (hr1 : r < 1) {ε : ℝ} (hε : 0 < ε) :
+    ∃ N : ℕ, ∀ m, N ≤ m → ∀ n, |∑ k ∈ Ico m n, r ^ k| ≤ ε := by
+  have h1r : (0 : ℝ) < 1 - r := by linarith
+  obtain ⟨N, hN⟩ := exists_pow_lt_of_lt_one (mul_pos hε h1r) hr1
+  refine ⟨N, fun m hm n => ?_⟩
+  have hbound : |∑ k ∈ Ico m n, r ^ k| ≤ r ^ m / (1 - r) :=
+    geometric_slice_abs_le hr0 hr1 m n
+  have hmono : r ^ m ≤ r ^ N := pow_le_pow_of_le_one hr0 hr1.le hm
+  have hle : r ^ m / (1 - r) ≤ ε := by
+    rw [div_le_iff₀ h1r]
+    calc r ^ m ≤ r ^ N := hmono
+      _ ≤ ε * (1 - r) := le_of_lt hN
+  linarith
+
+/-! ## Concrete instance
+
+`r = 1/2`, slice `Ico 2 5`: the block `(1/2)² + (1/2)³ + (1/2)⁴ = 7/16`,
+equal to the tail difference `(1/2)²/(1−1/2) − (1/2)⁵/(1−1/2) = 1/2 − 1/16`,
+and bounded by the endpoint-free envelope `(1/2)²/(1−1/2) = 1/2`. -/
+
+example : ∑ k ∈ Ico 2 5, (1 / 2 : ℝ) ^ k = 7 / 16 := by
+  norm_num [Finset.sum_Ico_eq_sum_range, Finset.sum_range_succ]
+
+example : ∑ k ∈ Ico 2 5, (1 / 2 : ℝ) ^ k =
+    (1 / 2 : ℝ) ^ 2 / (1 - 1 / 2) - (1 / 2 : ℝ) ^ 5 / (1 - 1 / 2) :=
+  geometric_slice_eq_tail_sub (by norm_num) (by norm_num)
+
+example : ∑ k ∈ Ico 2 5, (1 / 2 : ℝ) ^ k ≤ (1 / 2 : ℝ) ^ 2 / (1 - 1 / 2) :=
+  geometric_slice_le (by norm_num) (by norm_num) 2 5
+
+end GeometricSeriesOQ08OQ03

--- a/src/data/proofs/geometric-series-oq-08-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-03/meta.json
@@ -1,0 +1,124 @@
+{
+  "id": "geometric-series-oq-08-oq-03",
+  "slug": "geometric-series-oq-08-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.Field.GeomSum",
+      "Mathlib.Algebra.Order.Field.GeomSum",
+      "Mathlib.Analysis.SpecificLimits.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "GeometricSeriesOQ08OQ03",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ08OQ03.lean",
+    "sorries": 0
+  },
+  "title": "The Ico-slice of a Geometric Series and the Cauchy Criterion",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ08OQ03.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "cauchy-criterion",
+      "partial-sums",
+      "comparison-test",
+      "ratio-test",
+      "convergence",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 141,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "geometric_slice_eq_tail_sub: the difference-of-tails identity ∑_{k ∈ Ico m n} rᵏ = rᵐ/(1 − r) − rⁿ/(1 − r) for r < 1 and m ≤ n. It exhibits a middle block as exactly the parent's m-tail minus its n-tail, the bridge from the two-sided slice back to GeometricSeriesOQ08.geometric_sum_tail. Proved from geom_sum_Ico' by sub_div.",
+      "geometric_slice_factor: the self-similarity ∑_{k ∈ Ico m n} rᵏ = rᵐ · ∑_{k < n − m} rᵏ for all m, n — a slice starting at m is rᵐ times a fresh partial sum. Proved via Finset.sum_Ico_eq_sum_range and pow_add, with no order hypothesis.",
+      "geometric_slice_abs_le: the absolute-value Cauchy estimate |∑_{k ∈ Ico m n} rᵏ| ≤ rᵐ/(1 − r) for 0 ≤ r < 1, the form invoked by the comparison and ratio tests (the bound is independent of the right endpoint n).",
+      "geometric_slice_bound_tendsto: the envelope rᵐ/(1 − r) → 0 as m → ∞, obtained from tendsto_pow_atTop_nhds_zero_of_lt_one by dividing by the constant 1 − r.",
+      "geometric_slice_cauchy: the explicit ε–N Cauchy criterion — for 0 ≤ r < 1 and every ε > 0 there is an N past which every slice with left endpoint m ≥ N has |∑_{k ∈ Ico m n} rᵏ| ≤ ε, uniformly in the right endpoint n. The threshold is extracted with exists_pow_lt_of_lt_one and the monotonicity pow_le_pow_of_le_one. This is the estimate that exhibits the geometric series as Cauchy and the template the comparison/ratio tests follow."
+    ],
+    "prerequisites": [
+      "geom_sum_Ico' (Mathlib): the slice closed form (rᵐ − rⁿ)/(1 − r)",
+      "geom_sum_Ico_le_of_lt_one (Mathlib): the raw slice bound rᵐ/(1 − r), valid for all m, n",
+      "Finset.sum_Ico_eq_sum_range and pow_add for the self-similar factorisation",
+      "exists_pow_lt_of_lt_one and pow_le_pow_of_le_one for the ε–N Cauchy threshold",
+      "tendsto_pow_atTop_nhds_zero_of_lt_one for the vanishing envelope",
+      "Parent: geometric-series-oq-08 (the one-sided truncation defect rⁿ/(1 − r) and monotone upward convergence)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "geom_sum_Ico'",
+        "description": "∑ i ∈ Ico m n, xⁱ = (xᵐ − xⁿ)/(1 − x) for x ≠ 1 and m ≤ n. Wrapped as geometric_slice_closed and used to derive the difference-of-tails identity.",
+        "module": "Mathlib.Algebra.Field.GeomSum"
+      },
+      {
+        "theorem": "geom_sum_Ico_le_of_lt_one",
+        "description": "∑ i ∈ Ico m n, xⁱ ≤ xᵐ/(1 − x) for 0 ≤ x < 1, valid for all m, n (empty slice when n ≤ m). The raw slice bound behind the absolute estimate and the Cauchy criterion.",
+        "module": "Mathlib.Algebra.Order.Field.GeomSum"
+      },
+      {
+        "theorem": "exists_pow_lt_of_lt_one",
+        "description": "For 0 < ε and r < 1 there is N with rᴺ < ε. Supplies the Cauchy threshold (applied to ε·(1 − r)).",
+        "module": "Mathlib.Algebra.Order.Archimedean.Basic"
+      },
+      {
+        "theorem": "tendsto_pow_atTop_nhds_zero_of_lt_one",
+        "description": "rⁿ → 0 for 0 ≤ r < 1. Divided by 1 − r to show the slice-bound envelope vanishes.",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-08-oq-03-oq-01",
+      "question": "Promote the elementary ε–N criterion to the abstract metric Cauchy predicate: show the finite partial sums n ↦ ∑_{k<n} rᵏ form a CauchySeq (or that the series satisfies Mathlib's cauchySeq_finset_iff) directly from geometric_slice_cauchy, recovering summability without invoking hasSum_geometric.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-08",
+      "relationship": "extends",
+      "description": "Parent. The parent gives the one-sided truncation defect (1 − r)⁻¹ − ∑_{k<n} rᵏ = rⁿ/(1 − r) and the monotone upward convergence of the heads. This entry turns that into the two-sided slice estimate: geometric_slice_eq_tail_sub writes a middle block Ico m n as the m-tail minus the n-tail, and geometric_slice_cauchy packages the resulting bound as the ε–N Cauchy criterion."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "depends-on",
+      "description": "Base entry recording the finite closed form (1 − rⁿ)/(1 − r) and the infinite value (1 − r)⁻¹. The slice closed form (rᵐ − rⁿ)/(1 − r) used here is the difference of two such heads."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Algebra.Order.Field.GeomSum",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Provides geom_sum_Ico' and geom_sum_Ico_le_of_lt_one, the slice closed form and raw slice bound wrapped and assembled here into the Cauchy criterion."
+    },
+    {
+      "title": "Principles of Mathematical Analysis (Cauchy criterion, comparison and ratio tests)",
+      "author": "Walter Rudin",
+      "year": "1976",
+      "venue": "McGraw-Hill",
+      "description": "Standard reference for the Cauchy criterion for series and its use through the geometric majorant in the comparison and ratio tests."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For 0 ≤ r < 1 an arbitrary middle block of a geometric series is controlled by an endpoint-free envelope: ∑_{k ∈ Ico m n} rᵏ = rᵐ/(1 − r) − rⁿ/(1 − r) ≤ rᵐ/(1 − r), and |∑_{k ∈ Ico m n} rᵏ| ≤ rᵐ/(1 − r) with rᵐ/(1 − r) → 0. Packaged as the ε–N Cauchy criterion: for every ε > 0 there is an N past which every slice with left endpoint m ≥ N satisfies |∑_{k ∈ Ico m n} rᵏ| ≤ ε, uniformly in n. 141 lines, 7 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Where the parent geometric-series-oq-08 measures how far a head ∑_{k<n} rᵏ sits below the limit, this entry measures how large a discarded tail block between steps m and n can be — and the bound rᵐ/(1 − r) does not depend on n. That endpoint-free control is exactly the Cauchy criterion, the reusable engine behind the comparison test, the ratio-test remainder, and dominated convergence by a geometric majorant. The closed form (geom_sum_Ico') and the raw slice bound (geom_sum_Ico_le_of_lt_one) are Mathlib; the difference-of-tails identity, the self-similar factorisation, the absolute-value packaging, and the explicit ε–N criterion are assembled here.",
+    "openQuestions": [
+      "Derive Mathlib's abstract CauchySeq / cauchySeq_finset predicate for the geometric partial sums directly from the ε–N criterion, recovering summability without hasSum_geometric."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers open question **oq-03** of `geometric-series-oq-08`: extend the truncation-defect analysis from one-sided heads to an arbitrary two-sided **Ico-slice** `∑_{k ∈ Ico m n} rᵏ`, and package the resulting bound as the **Cauchy criterion** the comparison/ratio tests invoke.

The parent measures how far a head `∑_{k<n} rᵏ` sits below the limit (defect `rⁿ/(1−r)`). This entry measures how large a discarded *tail block* between steps `m` and `n` can be — and the bound `rᵐ/(1−r)` does **not** depend on the right endpoint `n`. That endpoint-free control is exactly the Cauchy criterion.

## What's new vs. Mathlib

Mathlib already has the slice closed form (`geom_sum_Ico'`) and the raw slice bound (`geom_sum_Ico_le_of_lt_one`); both are wrapped here and **explicitly attributed**. The genuinely assembled content:

- `geometric_slice_eq_tail_sub` — difference-of-tails identity `∑_{Ico m n} rᵏ = rᵐ/(1−r) − rⁿ/(1−r)`, the bridge back to the parent's `geometric_sum_tail`.
- `geometric_slice_factor` — self-similarity `∑_{Ico m n} rᵏ = rᵐ · ∑_{k<n−m} rᵏ`.
- `geometric_slice_abs_le` — the absolute Cauchy estimate `|∑_{Ico m n} rᵏ| ≤ rᵐ/(1−r)`.
- `geometric_slice_bound_tendsto` — the envelope `rᵐ/(1−r) → 0`.
- `geometric_slice_cauchy` — the explicit **ε–N Cauchy criterion**: for every `ε > 0` there is an `N` past which every slice with left endpoint `m ≥ N` has `|∑_{Ico m n} rᵏ| ≤ ε`, uniformly in `n`.

## Verification

- **141 lines, 7 theorems, 0 definitions, 0 axioms, 0 sorries.**
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ08OQ03` (3059 jobs, no warnings).
- 0-axiom: only `propext` / `Classical.choice` / `Quot.sound`.

## Files

- `proofs/Proofs/GeometricSeriesOQ08OQ03.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/geometric-series-oq-08-oq-03/meta.json` (gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)