### PR TITLE
research(geometric-series-oq-07-oq-01): general-order moment ∑ nᵐ·rⁿ closed form via Stirling numbers [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2619,6 +2619,7 @@ import Proofs.GeometricSeriesOQ02OQ05
 import Proofs.GeometricSeriesOQ03
 import Proofs.GeometricSeriesOQ06
 import Proofs.GeometricSeriesOQ07
+import Proofs.GeometricSeriesOQ07OQ01
 import Proofs.GeometricSeriesOQ08
 import Proofs.GeometricSeriesOQ08OQ01OQ01
 import Proofs.GeometricSeriesOQ09

--- a/proofs/Proofs/GeometricSeriesOQ07OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01.lean
@@ -1,0 +1,244 @@
+/-
+# The General Moment of the Geometric Series
+
+For `|r| < 1` and any order `m`, the `m`-th moment of the geometric weights `rⁿ` has the
+closed form
+
+  ∑_{n≥0} nᵐ · rⁿ  =  ∑_{k=0}^{m}  S(m,k) · k! · rᵏ / (1 - r)^{k+1},
+
+where `S(m,k)` is the Stirling number of the second kind (`Nat.stirlingSecond`).
+
+This answers the first open question of the gallery entry
+`geometric-series-oq-07` ("The Second Moment of the Geometric Series"), which asked to
+generalise the moment computation to arbitrary order with a polynomial-in-`r` numerator and
+a `(1-r)^{m+1}` denominator. The Stirling-number formulation makes the change-of-basis
+coefficients explicit and uniform in `m`: it recovers the gallery's order-0, order-1,
+order-2 and order-3 formulas (`oq-07`, `oq-10`) as the special cases `m = 0,1,2,3`.
+
+## Method
+
+The proof rests on two ingredients.
+
+* **The falling-factorial change of basis.** Every monomial expands over the falling
+  factorials `n^{\underline k} = n.descFactorial k` with Stirling coefficients:
+      nᵐ = ∑_{k=0}^{m} S(m,k) · n^{\underline k}.
+  We prove this purely combinatorial `ℕ`-identity by induction on `m`, using the Stirling
+  recurrence `S(m+1,k+1) = (k+1)·S(m,k+1) + S(m,k)` and the falling-factorial recurrence
+  `n · n^{\underline k} = n^{\underline{k+1}} + k · n^{\underline k}`.
+
+* **The falling-factorial geometric sum.** Mathlib already evaluates the *ascending*
+  factorial generating function (`hasSum_choose_mul_geometric_of_norm_lt_one`). Shifting the
+  index by `k` turns it into the falling-factorial sum
+      ∑_{n≥0} n^{\underline k} · rⁿ = k! · rᵏ / (1 - r)^{k+1}.
+
+Summing the (finite) Stirling expansion against `rⁿ` and using linearity of `HasSum` over the
+finite range `0 ≤ k ≤ m` assembles the closed form.
+
+All results are over `ℝ`; everything is `0`-axiom (`propext`/`Classical.choice`/`Quot.sound`
+only) and `sorry`-free.
+-/
+import Mathlib
+
+namespace GeometricSeriesOQ07OQ01
+
+open Finset Nat
+
+/-! ## Part 1: the falling-factorial change of basis (a combinatorial `ℕ`-identity) -/
+
+/-- The falling-factorial recurrence in additive form, valid for all `n k : ℕ`
+(no side condition `k ≤ n`):
+`n · n^{\underline k} = n^{\underline{k+1}} + k · n^{\underline k}`. -/
+theorem mul_descFactorial (n k : ℕ) :
+    n * n.descFactorial k = n.descFactorial (k + 1) + k * n.descFactorial k := by
+  rw [Nat.descFactorial_succ, ← add_mul]
+  rcases le_or_gt k n with h | h
+  · rw [Nat.sub_add_cancel h]
+  · rw [Nat.descFactorial_eq_zero_iff_lt.mpr h]; simp
+
+/-- **Stirling's monomial expansion.** Every power expands over the falling factorials with
+Stirling-number-of-the-second-kind coefficients:
+`n ^ m = ∑_{k=0}^{m} S(m,k) · n^{\underline k}`. -/
+theorem pow_eq_sum_stirlingSecond_descFactorial (n m : ℕ) :
+    n ^ m = ∑ k ∈ range (m + 1), stirlingSecond m k * n.descFactorial k := by
+  induction m with
+  | zero => simp [stirlingSecond_zero]
+  | succ m ih =>
+    rw [pow_succ', ih, Finset.mul_sum]
+    -- Rewrite each LHS summand `n · (S(m,k) · descFac n k)` using the falling-factorial
+    -- recurrence, giving `S(m,k)·descFac n (k+1) + k·S(m,k)·descFac n k`.
+    have hL : ∀ k ∈ range (m + 1),
+        n * (stirlingSecond m k * n.descFactorial k)
+          = stirlingSecond m k * n.descFactorial (k + 1)
+            + k * stirlingSecond m k * n.descFactorial k := by
+      intro k _
+      rw [show n * (stirlingSecond m k * n.descFactorial k)
+            = stirlingSecond m k * (n * n.descFactorial k) by ring, mul_descFactorial]
+      ring
+    rw [Finset.sum_congr rfl hL, Finset.sum_add_distrib]
+    -- LHS = S1 + S2, with
+    --   S1 = ∑_{k<m+1} S(m,k) · descFac n (k+1)
+    --   S2 = ∑_{k<m+1} k · S(m,k) · descFac n k
+    -- Expand the RHS sum: peel the `k = 0` term (which vanishes) and apply the Stirling
+    -- recurrence to the shifted summands.
+    rw [Finset.sum_range_succ' (fun k => stirlingSecond (m + 1) k * n.descFactorial k) (m + 1)]
+    have h0 : stirlingSecond (m + 1) 0 = 0 := stirlingSecond_succ_zero m
+    rw [h0, zero_mul, add_zero]
+    have hR : ∀ k ∈ range (m + 1),
+        stirlingSecond (m + 1) (k + 1) * n.descFactorial (k + 1)
+          = (k + 1) * stirlingSecond m (k + 1) * n.descFactorial (k + 1)
+            + stirlingSecond m k * n.descFactorial (k + 1) := by
+      intro k _
+      rw [stirlingSecond_succ_succ]; ring
+    rw [Finset.sum_congr rfl hR, Finset.sum_add_distrib]
+    -- RHS = T1 + S1, with T1 = ∑_{k<m+1} (k+1)·S(m,k+1)·descFac n (k+1).
+    -- Goal is now `S1 + S2 = T1 + S1`; it suffices to prove `S2 = T1`.
+    have hS2T1 : (∑ k ∈ range (m + 1), k * stirlingSecond m k * n.descFactorial k)
+        = ∑ k ∈ range (m + 1),
+            (k + 1) * stirlingSecond m (k + 1) * n.descFactorial (k + 1) := by
+      rw [Finset.sum_range_succ' (fun k => k * stirlingSecond m k * n.descFactorial k) m,
+          Finset.sum_range_succ
+            (fun k => (k + 1) * stirlingSecond m (k + 1) * n.descFactorial (k + 1)) m]
+      have hT : stirlingSecond m (m + 1) = 0 := stirlingSecond_eq_zero_of_lt (Nat.lt_succ_self m)
+      rw [hT]
+      simp
+    omega
+
+/-! ## Part 2: the falling-factorial geometric sum -/
+
+/-- **Ascending-factorial geometric sum** (a thin wrapper over Mathlib's
+`hasSum_choose_mul_geometric_of_norm_lt_one`, rephrased via
+`descFactorial_eq_factorial_mul_choose`):
+`∑_{n≥0} (n+k)^{\underline k} · rⁿ = k! / (1 - r)^{k+1}`. -/
+theorem hasSum_ascFactorial_geometric (k : ℕ) {r : ℝ} (hr : |r| < 1) :
+    HasSum (fun n => ((n + k).descFactorial k : ℝ) * r ^ n)
+      ((k.factorial : ℝ) / (1 - r) ^ (k + 1)) := by
+  have hnorm : ‖r‖ < 1 := by rwa [Real.norm_eq_abs]
+  have h := (hasSum_choose_mul_geometric_of_norm_lt_one k hnorm).mul_left (k.factorial : ℝ)
+  have hval : (k.factorial : ℝ) * (1 / (1 - r) ^ (k + 1)) = (k.factorial : ℝ) / (1 - r) ^ (k + 1) := by
+    ring
+  rw [hval] at h
+  have hfun : (fun n => ((n + k).descFactorial k : ℝ) * r ^ n)
+            = (fun n => (k.factorial : ℝ) * (((n + k).choose k : ℝ) * r ^ n)) := by
+    funext n
+    rw [Nat.descFactorial_eq_factorial_mul_choose]
+    push_cast
+    ring
+  rw [hfun]
+  exact h
+
+/-- **Falling-factorial geometric sum.** Shifting the ascending-factorial sum down by `k`
+positions (the first `k` terms vanish since `n^{\underline k} = 0` for `n < k`):
+`∑_{n≥0} n^{\underline k} · rⁿ = k! · rᵏ / (1 - r)^{k+1}`. -/
+theorem hasSum_descFactorial_geometric (k : ℕ) {r : ℝ} (hr : |r| < 1) :
+    HasSum (fun n => (n.descFactorial k : ℝ) * r ^ n)
+      ((k.factorial : ℝ) * r ^ k / (1 - r) ^ (k + 1)) := by
+  have h := (hasSum_ascFactorial_geometric k hr).mul_left (r ^ k)
+  have hval : r ^ k * ((k.factorial : ℝ) / (1 - r) ^ (k + 1))
+            = (k.factorial : ℝ) * r ^ k / (1 - r) ^ (k + 1) := by ring
+  rw [hval] at h
+  -- Recognise `h` as the shifted version of the target sum.
+  have hshift : HasSum (fun n => ((n + k).descFactorial k : ℝ) * r ^ (n + k))
+      ((k.factorial : ℝ) * r ^ k / (1 - r) ^ (k + 1)) := by
+    have hfun : (fun n => ((n + k).descFactorial k : ℝ) * r ^ (n + k))
+              = (fun n => r ^ k * (((n + k).descFactorial k : ℝ) * r ^ n)) := by
+      funext n; rw [pow_add]; ring
+    rw [hfun]; exact h
+  -- The first `k` terms of the un-shifted sum vanish.
+  have hsum0 : ∑ i ∈ range k, ((i.descFactorial k : ℝ) * r ^ i) = 0 := by
+    apply Finset.sum_eq_zero
+    intro i hi
+    rw [Finset.mem_range] at hi
+    rw [Nat.descFactorial_eq_zero_iff_lt.mpr hi]
+    simp
+  have key := (hasSum_nat_add_iff (f := fun n => (n.descFactorial k : ℝ) * r ^ n) k).mp hshift
+  simp only [hsum0, add_zero] at key
+  exact key
+
+/-! ## Part 3: the general moment closed form -/
+
+/-- **The general moment of the geometric series.** For `|r| < 1` and any order `m`,
+`∑_{n≥0} nᵐ · rⁿ = ∑_{k=0}^{m} S(m,k) · k! · rᵏ / (1 - r)^{k+1}`. -/
+theorem hasSum_pow_mul_geometric (m : ℕ) {r : ℝ} (hr : |r| < 1) :
+    HasSum (fun n : ℕ => (n : ℝ) ^ m * r ^ n)
+      (∑ k ∈ range (m + 1),
+        (stirlingSecond m k : ℝ) * k.factorial * r ^ k / (1 - r) ^ (k + 1)) := by
+  -- Cast the combinatorial Stirling expansion to `ℝ`.
+  have hcast : ∀ n : ℕ, (n : ℝ) ^ m
+      = ∑ k ∈ range (m + 1), (stirlingSecond m k : ℝ) * (n.descFactorial k : ℝ) := by
+    intro n
+    exact_mod_cast pow_eq_sum_stirlingSecond_descFactorial n m
+  -- Each `k`-summand is a `HasSum` via the falling-factorial geometric sum.
+  have hterm : ∀ k ∈ range (m + 1),
+      HasSum (fun n => (stirlingSecond m k : ℝ) * ((n.descFactorial k : ℝ) * r ^ n))
+        ((stirlingSecond m k : ℝ) * k.factorial * r ^ k / (1 - r) ^ (k + 1)) := by
+    intro k _
+    have h := (hasSum_descFactorial_geometric k hr).mul_left (stirlingSecond m k : ℝ)
+    have hval : (stirlingSecond m k : ℝ) * ((k.factorial : ℝ) * r ^ k / (1 - r) ^ (k + 1))
+              = (stirlingSecond m k : ℝ) * k.factorial * r ^ k / (1 - r) ^ (k + 1) := by ring
+    rwa [hval] at h
+  have hbig := hasSum_sum hterm
+  -- Collapse the inner finite sum back to `nᵐ · rⁿ`.
+  have hfun : (fun n : ℕ => ∑ k ∈ range (m + 1),
+        (stirlingSecond m k : ℝ) * ((n.descFactorial k : ℝ) * r ^ n))
+      = fun n : ℕ => (n : ℝ) ^ m * r ^ n := by
+    funext n
+    rw [hcast n, Finset.sum_mul]
+    apply Finset.sum_congr rfl
+    intro k _; ring
+  rw [hfun] at hbig
+  exact hbig
+
+/-- `tsum` form of the general moment closed form. -/
+theorem tsum_pow_mul_geometric (m : ℕ) {r : ℝ} (hr : |r| < 1) :
+    ∑' n : ℕ, (n : ℝ) ^ m * r ^ n
+      = ∑ k ∈ range (m + 1),
+          (stirlingSecond m k : ℝ) * k.factorial * r ^ k / (1 - r) ^ (k + 1) :=
+  (hasSum_pow_mul_geometric m hr).tsum_eq
+
+/-! ## Part 4: recovering the gallery's low-order moments
+
+The general formula specialises to the moments already in the gallery.  The Stirling
+coefficients are evaluated by `decide`; the resulting `r`-rational identities by `ring`
+(after clearing the nonzero denominator `(1 - r) ≠ 0`). -/
+
+/-- Order 0 (the geometric series itself): `∑ rⁿ = 1/(1-r)`. -/
+example {r : ℝ} (hr : |r| < 1) : ∑' n : ℕ, (n : ℝ) ^ 0 * r ^ n = 1 / (1 - r) := by
+  rw [tsum_pow_mul_geometric 0 hr]
+  simp [stirlingSecond_zero]
+
+/-- Order 1: `∑ n·rⁿ = r/(1-r)²`. -/
+example {r : ℝ} (hr : |r| < 1) :
+    ∑' n : ℕ, (n : ℝ) ^ 1 * r ^ n = r / (1 - r) ^ 2 := by
+  have hne : (1 - r) ≠ 0 := by
+    intro h; rw [sub_eq_zero] at h; rw [← h] at hr; simp at hr
+  rw [tsum_pow_mul_geometric 1 hr]
+  rw [Finset.sum_range_succ, Finset.sum_range_one]
+  rw [show stirlingSecond 1 0 = 0 from by decide, show stirlingSecond 1 1 = 1 from by decide]
+  field_simp
+  ring
+
+/-- Order 2 (the gallery's `oq-07`): `∑ n²·rⁿ = r(1+r)/(1-r)³`. -/
+example {r : ℝ} (hr : |r| < 1) :
+    ∑' n : ℕ, (n : ℝ) ^ 2 * r ^ n = r * (1 + r) / (1 - r) ^ 3 := by
+  have hne : (1 - r) ≠ 0 := by
+    intro h; rw [sub_eq_zero] at h; rw [← h] at hr; simp at hr
+  rw [tsum_pow_mul_geometric 2 hr]
+  rw [Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_one]
+  rw [show stirlingSecond 2 0 = 0 from by decide, show stirlingSecond 2 1 = 1 from by decide,
+      show stirlingSecond 2 2 = 1 from by decide]
+  field_simp
+  ring
+
+/-- Order 3 (the gallery's `oq-10`): `∑ n³·rⁿ = r(1+4r+r²)/(1-r)⁴`. -/
+example {r : ℝ} (hr : |r| < 1) :
+    ∑' n : ℕ, (n : ℝ) ^ 3 * r ^ n = r * (1 + 4 * r + r ^ 2) / (1 - r) ^ 4 := by
+  have hne : (1 - r) ≠ 0 := by
+    intro h; rw [sub_eq_zero] at h; rw [← h] at hr; simp at hr
+  rw [tsum_pow_mul_geometric 3 hr]
+  rw [Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_one]
+  rw [show stirlingSecond 3 0 = 0 from by decide, show stirlingSecond 3 1 = 1 from by decide,
+      show stirlingSecond 3 2 = 3 from by decide, show stirlingSecond 3 3 = 1 from by decide]
+  field_simp
+  ring
+
+end GeometricSeriesOQ07OQ01

--- a/src/data/proofs/geometric-series-oq-07-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "geometric-series-oq-07-oq-01",
+  "slug": "geometric-series-oq-07-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01",
+    "lineCount": 244,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ07OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The General Moment of the Geometric Series: ∑ nᵐ rⁿ = ∑ₖ S(m,k)·k!·rᵏ/(1−r)^{k+1}",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01.lean",
+    "tags": [
+      "analysis",
+      "combinatorics",
+      "geometric-series",
+      "infinite-series",
+      "power-series",
+      "moments",
+      "stirling-numbers",
+      "falling-factorial",
+      "summability",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 244,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "hasSum_pow_mul_geometric / tsum_pow_mul_geometric: the closed form for the m-th moment of the geometric series to ALL orders, ∑_{n≥0} nᵐ · rⁿ = ∑_{k=0}^{m} S(m,k) · k! · rᵏ / (1-r)^{k+1} for |r| < 1 over ℝ, where S(m,k) is the Stirling number of the second kind. This directly answers the open question geometric-series-oq-07-oq-01 (generalise the moment to arbitrary order with a polynomial numerator over (1-r)^{m+1}). Mathlib proves only summability of nᵐ rⁿ (summable_pow_mul_geometric_of_norm_lt_one) and the m=0,1 closed forms; it has no general-order value.",
+      "pow_eq_sum_stirlingSecond_descFactorial: the combinatorial ℕ-identity nᵐ = ∑_{k=0}^{m} S(m,k) · n^{underline k} (the falling-factorial change of basis for a monomial). Mathlib defines Nat.stirlingSecond with its recurrences but provides NO link between Stirling numbers and powers; this lemma supplies that bridge. Proved by induction on m, combining the Stirling recurrence S(m+1,k+1)=(k+1)S(m,k+1)+S(m,k) with a telescoping reindex of the falling-factorial sums.",
+      "hasSum_descFactorial_geometric: the falling-factorial generating function ∑_{n≥0} n^{underline k} · rⁿ = k! · rᵏ / (1-r)^{k+1}, obtained by shifting Mathlib's ascending-factorial sum down by k positions (the first k terms vanish because n^{underline k} = 0 for n < k). The companion mul_descFactorial gives the side-condition-free recurrence n · n^{underline k} = n^{underline{k+1}} + k · n^{underline k}.",
+      "A Stirling-number formulation that is cleaner than the Eulerian-number numerator the open question proposed: since Mathlib has Nat.stirlingSecond but no Eulerian numbers, the coefficient S(m,k)·k! (the number of surjections from an m-set onto a k-set) is the directly available form. The general theorem recovers the gallery's order-0/1/2/3 moments (geometric-series, oq-07, oq-10) as the special cases m = 0,1,2,3, with the small Stirling values discharged by kernel `decide`."
+    ],
+    "prerequisites": [
+      "Mathlib's ascending-factorial geometric sum hasSum_choose_mul_geometric_of_norm_lt_one (∑ (n+k choose k) rⁿ = 1/(1-r)^{k+1})",
+      "Mathlib's Stirling numbers of the second kind Nat.stirlingSecond and the recurrence stirlingSecond_succ_succ",
+      "Nat.descFactorial (the falling factorial) and Nat.descFactorial_eq_factorial_mul_choose, descFactorial_succ, descFactorial_eq_zero_iff_lt",
+      "hasSum_nat_add_iff: index-shift identity HasSum (fun n => f(n+k)) a ↔ HasSum f (a + ∑_{i<k} f i)",
+      "HasSum arithmetic (HasSum.mul_left, hasSum_sum, HasSum.tsum_eq)",
+      "Parent: geometric-series-oq-07 (∑ n² rⁿ = r(1+r)/(1-r)³)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_choose_mul_geometric_of_norm_lt_one",
+        "description": "∑_n (n+k choose k) · rⁿ = 1/(1-r)^{k+1} for ‖r‖ < 1. After multiplying by k! and applying descFactorial_eq_factorial_mul_choose this becomes the ascending-factorial sum; an index shift by k then yields the falling-factorial sum used per order.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Nat.stirlingSecond",
+        "description": "Stirling numbers of the second kind with the recurrence stirlingSecond_succ_succ (S(m+1,k+1)=(k+1)S(m,k+1)+S(m,k)), the boundary values stirlingSecond_succ_zero / stirlingSecond_zero, and the vanishing stirlingSecond_eq_zero_of_lt. These drive the induction for the monomial expansion.",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.descFactorial_eq_factorial_mul_choose",
+        "description": "n^{underline k} = k! · (n choose k). Converts Mathlib's binomial geometric sum into the falling-factorial form and supplies the k! that appears in the moment numerator.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "hasSum_nat_add_iff",
+        "description": "HasSum (fun n => f(n+k)) a ↔ HasSum f (a + ∑_{i<k} f i). Used to recover ∑_n n^{underline k} rⁿ from the shifted sum, the first k terms vanishing since n^{underline k}=0 for n<k.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "summable_pow_mul_geometric_of_norm_lt_one",
+        "description": "Mathlib's summability of nᵏ rⁿ for ‖r‖ < 1. It establishes convergence but no closed value — the gap this entry fills for the value at arbitrary order.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01",
+      "question": "Identify the numerator with the Eulerian polynomial: prove ∑_{k=0}^{m} S(m,k)·k!·rᵏ·(1-r)^{m-k} = A_m(r), the m-th Eulerian polynomial ∑_j ⟨m,j⟩ rʲ, exhibiting the moment closed form as A_m(r)/(1-r)^{m+1} with nonnegative integer coefficients summing to m!. This requires building Eulerian numbers (absent from Mathlib) and proving Worpitzky's identity.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-02",
+      "question": "Derive the factorial moments of the geometric distribution as a corollary: for X with P(X=n) = (1-r)rⁿ, show E[X^{underline k}] = k!·(r/(1-r))ᵏ directly from hasSum_descFactorial_geometric, and recover E[X], E[X²], Var(X) by re-expanding the falling factorials.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07",
+      "relationship": "extends",
+      "description": "Parent. oq-07 proves the second moment ∑ n² rⁿ = r(1+r)/(1-r)³ and poses (as its open question oq-01) the generalisation to arbitrary order. This entry answers it with the all-orders closed form ∑ nᵐ rⁿ = ∑ₖ S(m,k)·k!·rᵏ/(1-r)^{k+1}, recovering oq-07 as the case m=2."
+    },
+    {
+      "targetId": "geometric-series-oq-10",
+      "relationship": "sibling",
+      "description": "oq-10 proves the third moment ∑ n³ rⁿ = r(1+4r+r²)/(1-r)⁴ by the rising-binomial method for the single order m=3. This entry subsumes it as the case m=3 of the general formula (verified as an explicit example)."
+    },
+    {
+      "targetId": "geometric-series-oq-08-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "A parallel moment-family strand on the FINITE side: oq-08-oq-01-oq-01 gives the finite second-order arithmetico-geometric sum ∑_{k<n} k²·xᵏ as a rational function over (1-x)³. This entry is the infinite-limit, all-orders counterpart, with the Stirling/falling-factorial basis replacing the explicit polynomial assembly."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the ascending-factorial geometric sums (hasSum_choose_mul_geometric_of_norm_lt_one) and the summability of nᵏ rⁿ that this entry upgrades to a closed value."
+    },
+    {
+      "title": "Mathlib4: Combinatorics.Enumerative.Stirling",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Nat.stirlingSecond and its recurrences. Mathlib has the Stirling numbers but not their connection to powers; the monomial expansion proved here supplies that bridge."
+    },
+    {
+      "title": "Concrete Mathematics (Stirling numbers, falling factorials, generating functions)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the monomial expansion nᵐ = ∑ S(m,k) n^{underline k} and the falling-factorial generating function used to evaluate ∑ nᵐ rⁿ."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For |r| < 1 over ℝ and every order m, the m-th moment of the geometric series has the closed form ∑_{n≥0} nᵐ · rⁿ = ∑_{k=0}^{m} S(m,k) · k! · rᵏ / (1-r)^{k+1}, where S(m,k) = Nat.stirlingSecond m k. The proof has two pillars: (1) the combinatorial identity nᵐ = ∑_k S(m,k) · n^{underline k} expanding a monomial over falling factorials (proved by induction with a telescoping reindex of the Stirling recurrence), and (2) the falling-factorial generating function ∑_n n^{underline k} rⁿ = k! rᵏ/(1-r)^{k+1} (an index shift of Mathlib's ascending-factorial sum). Summing the finite expansion against rⁿ by linearity of HasSum assembles the result. The file provides HasSum and tsum forms and verifies the orders m=0,1,2,3 — the gallery's geometric-series, oq-07 and oq-10 — as explicit specialisations. 244 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound (the low-order checks use kernel `decide`, not native_decide).",
+    "implications": "Mathlib proves nᵐ rⁿ is summable but gives no value beyond the first moment, so the all-orders closed form is a genuine gap fill. The conceptual content is the change of basis: every monomial lies in the span of the falling factorials, and each falling factorial has an elementary geometric generating function, so a single finite linear combination evaluates the moment at any order — no per-order convergence argument and no separate algebraic identity (as oq-07 and oq-10 each needed). The Stirling-number coefficient S(m,k)·k! (the surjection count) is the directly Mathlib-supported form of the Eulerian numerator the parent open question anticipated; making that identification explicit (Worpitzky's identity) is the first follow-up.",
+    "openQuestions": [
+      "Identify the numerator ∑_k S(m,k) k! rᵏ (1-r)^{m-k} with the Eulerian polynomial A_m(r) (requires building Eulerian numbers and Worpitzky's identity).",
+      "Derive the geometric-distribution factorial moments E[X^{underline k}] = k!(r/(1-r))ᵏ as a probabilistic corollary."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the first open question of **geometric-series-oq-07** ("generalise the moment computation to arbitrary order"). Proves the **all-orders closed form** for the moment of the geometric series, for every `m` and `|r| < 1` over ℝ:

```
∑_{n≥0} nᵐ · rⁿ  =  ∑_{k=0}^{m}  S(m,k) · k! · rᵏ / (1 - r)^{k+1}
```

where `S(m,k) = Nat.stirlingSecond m k`. Mathlib proves only *summability* of `nᵐrⁿ` (`summable_pow_mul_geometric_of_norm_lt_one`) and the `m=0,1` closed forms — there is no general-order value. This fills that gap.

## Method

Two ingredients:

1. **Falling-factorial change of basis** (`pow_eq_sum_stirlingSecond_descFactorial`): the combinatorial ℕ-identity `nᵐ = ∑ₖ S(m,k)·n^{underline k}`. Mathlib has `Nat.stirlingSecond` with its recurrences but *no link to powers*; this lemma supplies the bridge, proved by induction with a telescoping reindex of the Stirling recurrence.
2. **Falling-factorial generating function** (`hasSum_descFactorial_geometric`): `∑ₙ n^{underline k}·rⁿ = k!·rᵏ/(1-r)^{k+1}`, an index shift of Mathlib's ascending-factorial sum.

Summing the finite expansion against `rⁿ` by linearity of `HasSum` assembles the closed form. The orders `m = 0,1,2,3` (the gallery's `geometric-series`, `oq-07`, `oq-10`) are recovered as explicit examples, with the small Stirling values discharged by kernel `decide`.

## Why Stirling rather than Eulerian

The parent open question anticipated an *Eulerian-number* numerator. Since Mathlib has `Nat.stirlingSecond` but no Eulerian numbers, the surjection count `S(m,k)·k!` is the directly available equivalent form. Identifying it with the Eulerian polynomial (Worpitzky's identity) is filed as the lead follow-up open question.

## Verification

- **244 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries**
- Builds clean: `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ07OQ01` (7743 jobs, success)
- 0-axiom: `propext` / `Classical.choice` / `Quot.sound` only (low-order checks use kernel `decide`, **not** `native_decide`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)