### PR TITLE
research(geometric-series-oq-08-oq-03-oq-01): the geometric series as an abstract Cauchy sequence [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2623,6 +2623,7 @@ import Proofs.GeometricSeriesOQ07
 import Proofs.GeometricSeriesOQ08
 import Proofs.GeometricSeriesOQ08OQ01OQ01
 import Proofs.GeometricSeriesOQ08OQ03
+import Proofs.GeometricSeriesOQ08OQ03OQ01
 import Proofs.GeometricSeriesOQ09
 import Proofs.GeometricSeriesOQ10
 import Proofs.GnedenkoKolmogorov

--- a/proofs/Proofs/GeometricSeriesOQ08OQ03OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ08OQ03OQ01.lean
@@ -1,0 +1,152 @@
+import Mathlib.Algebra.Field.GeomSum
+import Mathlib.Algebra.Order.Field.GeomSum
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Topology.Algebra.InfiniteSum.Real
+import Mathlib.Tactic
+
+/-
+# The Geometric Series as an Abstract Cauchy Sequence
+
+## What This Proves
+
+The sibling entry `GeometricSeriesOQ08OQ03.lean` produced the elementary `ε`–`N`
+estimate `geometric_slice_cauchy`: for `0 ≤ r < 1` and every `ε > 0` there is a
+threshold `N` past which *every* middle block `∑_{k ∈ Ico m n} rᵏ` is at most `ε`.
+That statement is the raw analytic content of "the geometric series is Cauchy",
+but phrased as a bespoke inequality. This follow-up **promotes it to Mathlib's
+abstract predicates**, so the result can be plugged directly into the library's
+convergence machinery:
+
+* `geometric_partialSum_dist` — the metric reading of the slice: for `m ≤ n` the
+  distance between the partial sums `∑_{k<m} rᵏ` and `∑_{k<n} rᵏ` is exactly the
+  block `∑_{k ∈ Ico m n} rᵏ`, hence `≤ rᵐ/(1 − r)`.
+* `geometric_partialSum_dist_le` — the symmetric distance bound
+  `dist (Sₘ) (Sₙ) ≤ r^{min m n}/(1 − r)`, the form `Metric.cauchySeq_iff` wants.
+* `geometric_partialSum_cauchySeq` — **the headline**: the partial sums
+  `n ↦ ∑_{k<n} rᵏ` form a `CauchySeq`, proved straight from the slice bound via
+  `Metric.cauchySeq_iff`, *without* invoking `hasSum_geometric`.
+* `geometric_partialSum_le` — the partial sums are bounded by `(1 − r)⁻¹`
+  (the `m = 0` slice bound), the hypothesis needed for the comparison test.
+* `geometric_summable` — **summability recovered elementarily**: from the bounded
+  monotone partial sums via `summable_of_sum_range_le`, again with no appeal to
+  the closed-form `hasSum_geometric`.
+* `geometric_cauchySeq_finset` — the unordered/Mathlib-native face: the net of
+  finite partial sums `s ↦ ∑_{k ∈ s} rᵏ` over the directed set of finsets is a
+  `CauchySeq` (`summable_iff_cauchySeq_finset`), the predicate that *defines*
+  summability in a complete group.
+
+## Why This Matters
+
+`geometric_slice_cauchy` answers "is the tail block small?" with a hand-rolled
+inequality. Convergence theorems in Mathlib speak a different language —
+`CauchySeq`, `Summable`, `cauchySeq_finset` — and this file is the translation
+layer. The payoff is conceptual honesty: the geometric series is shown to
+**converge as a Cauchy sequence**, and to be **summable**, from first principles
+(bounded blocks / bounded monotone partial sums) rather than by quoting the
+already-evaluated infinite sum. The closed form `(1 − r)⁻¹` is the *consequence*
+of convergence here, not its premise.
+
+## Mathlib Relationship
+
+The block bound (`geom_sum_Ico_le_of_lt_one`), the metric Cauchy criterion
+(`Metric.cauchySeq_iff`), the bounded-partial-sums summability test
+(`summable_of_sum_range_le`), and the `Summable ↔ CauchySeq`-over-finsets bridge
+(`summable_iff_cauchySeq_finset`) are Mathlib lemmas. The assembled content is the
+metric repackaging of the slice estimate and the deliberate derivation of
+`CauchySeq`/`Summable` that routes around `hasSum_geometric`.
+-/
+
+namespace GeometricSeriesOQ08OQ03OQ01
+
+open Finset
+
+variable {r : ℝ}
+
+/-- The `n`-th partial sum `∑_{k<n} rᵏ`. -/
+local notation3 "S" => fun (n : ℕ) => ∑ k ∈ range n, r ^ k
+
+/-- **Slice bound (self-contained).** For `0 ≤ r < 1`,
+`|∑_{k ∈ Ico m n} rᵏ| ≤ rᵐ/(1 − r)`, independently of the right endpoint `n`.
+The slice is a sum of nonnegative terms, so the absolute value is harmless. -/
+theorem geometric_slice_abs_le (hr0 : 0 ≤ r) (hr1 : r < 1) (m n : ℕ) :
+    |∑ k ∈ Ico m n, r ^ k| ≤ r ^ m / (1 - r) := by
+  rw [abs_of_nonneg (Finset.sum_nonneg fun i _ => pow_nonneg hr0 i)]
+  exact geom_sum_Ico_le_of_lt_one hr0 hr1
+
+/-- **Metric reading of the slice.** For `m ≤ n` the distance between the two
+partial sums is the middle block, hence bounded by `rᵐ/(1 − r)`. -/
+theorem geometric_partialSum_dist (hr0 : 0 ≤ r) (hr1 : r < 1) {m n : ℕ}
+    (hmn : m ≤ n) :
+    dist (∑ k ∈ range m, r ^ k) (∑ k ∈ range n, r ^ k) ≤ r ^ m / (1 - r) := by
+  have hslice : ∑ k ∈ Ico m n, r ^ k =
+      (∑ k ∈ range n, r ^ k) - ∑ k ∈ range m, r ^ k :=
+    Finset.sum_Ico_eq_sub _ hmn
+  rw [Real.dist_eq, abs_sub_comm, ← hslice]
+  exact geometric_slice_abs_le hr0 hr1 m n
+
+/-- **Symmetric distance bound.** `dist (Sₘ) (Sₙ) ≤ r^{min m n}/(1 − r)` for all
+`m, n`: the exact shape consumed by `Metric.cauchySeq_iff`. -/
+theorem geometric_partialSum_dist_le (hr0 : 0 ≤ r) (hr1 : r < 1) (m n : ℕ) :
+    dist (∑ k ∈ range m, r ^ k) (∑ k ∈ range n, r ^ k)
+      ≤ r ^ min m n / (1 - r) := by
+  rcases le_total m n with h | h
+  · rw [min_eq_left h]; exact geometric_partialSum_dist hr0 hr1 h
+  · rw [min_eq_right h, dist_comm]; exact geometric_partialSum_dist hr0 hr1 h
+
+/-- **The geometric partial sums are a Cauchy sequence.** Proved directly from the
+slice bound via `Metric.cauchySeq_iff`, with no appeal to `hasSum_geometric`. -/
+theorem geometric_partialSum_cauchySeq (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    CauchySeq (fun n => ∑ k ∈ range n, r ^ k) := by
+  rw [Metric.cauchySeq_iff]
+  intro ε hε
+  have h1r : (0 : ℝ) < 1 - r := by linarith
+  obtain ⟨N, hN⟩ := exists_pow_lt_of_lt_one (mul_pos hε h1r) hr1
+  refine ⟨N, fun m hm n hn => ?_⟩
+  have hbound : dist (∑ k ∈ range m, r ^ k) (∑ k ∈ range n, r ^ k)
+      ≤ r ^ min m n / (1 - r) := geometric_partialSum_dist_le hr0 hr1 m n
+  have hmono : r ^ min m n ≤ r ^ N :=
+    pow_le_pow_of_le_one hr0 hr1.le (le_min hm hn)
+  have hlt : r ^ min m n / (1 - r) < ε := by
+    rw [div_lt_iff₀ h1r]
+    calc r ^ min m n ≤ r ^ N := hmono
+      _ < ε * (1 - r) := hN
+  linarith
+
+/-- **Bounded partial sums.** Every partial sum `∑_{k<n} rᵏ` is at most
+`(1 − r)⁻¹` — the `m = 0` instance of the slice bound. -/
+theorem geometric_partialSum_le (hr0 : 0 ≤ r) (hr1 : r < 1) (n : ℕ) :
+    ∑ k ∈ range n, r ^ k ≤ (1 - r)⁻¹ := by
+  rw [Finset.range_eq_Ico]
+  simpa [one_div] using geom_sum_Ico_le_of_lt_one (x := r) (m := 0) (n := n) hr0 hr1
+
+/-- **Summability, recovered elementarily.** The geometric series is summable
+because its terms are nonnegative and its partial sums are bounded
+(`summable_of_sum_range_le`) — no use of the closed-form `hasSum_geometric`. -/
+theorem geometric_summable (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    Summable (fun k => r ^ k) :=
+  summable_of_sum_range_le (fun n => pow_nonneg hr0 n)
+    (fun n => geometric_partialSum_le hr0 hr1 n)
+
+/-- **Cauchy over finsets.** The Mathlib-native predicate: the net of finite
+partial sums `s ↦ ∑_{k ∈ s} rᵏ` over the directed set of finsets is a
+`CauchySeq` — equivalent to summability via `summable_iff_cauchySeq_finset`. -/
+theorem geometric_cauchySeq_finset (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    CauchySeq (fun s : Finset ℕ => ∑ k ∈ s, r ^ k) :=
+  summable_iff_cauchySeq_finset.mp (geometric_summable hr0 hr1)
+
+/-! ## Concrete instance
+
+For `r = 1/2` the partial sums are Cauchy and bounded by `(1 − 1/2)⁻¹ = 2`, and
+the series is summable. -/
+
+example : CauchySeq (fun n => ∑ k ∈ range n, (1 / 2 : ℝ) ^ k) :=
+  geometric_partialSum_cauchySeq (by norm_num) (by norm_num)
+
+example : Summable (fun k => (1 / 2 : ℝ) ^ k) :=
+  geometric_summable (by norm_num) (by norm_num)
+
+example (n : ℕ) : ∑ k ∈ range n, (1 / 2 : ℝ) ^ k ≤ 2 := by
+  have := geometric_partialSum_le (r := 1 / 2) (by norm_num) (by norm_num) n
+  norm_num at this ⊢; linarith
+
+end GeometricSeriesOQ08OQ03OQ01

--- a/src/data/proofs/geometric-series-oq-08-oq-03-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-03-oq-01/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "geometric-series-oq-08-oq-03-oq-01",
+  "slug": "geometric-series-oq-08-oq-03-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.Field.GeomSum",
+      "Mathlib.Algebra.Order.Field.GeomSum",
+      "Mathlib.Analysis.SpecificLimits.Basic",
+      "Mathlib.Topology.Algebra.InfiniteSum.Real",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "GeometricSeriesOQ08OQ03OQ01",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ08OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Geometric Series as an Abstract Cauchy Sequence",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ08OQ03OQ01.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "cauchy-sequence",
+      "summable",
+      "partial-sums",
+      "convergence",
+      "metric-space",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 152,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "geometric_partialSum_dist: the metric reading of the Ico-slice — for 0 ≤ r < 1 and m ≤ n, dist (∑_{k<m} rᵏ) (∑_{k<n} rᵏ) ≤ rᵐ/(1 − r). The distance between two partial sums is exactly the middle block ∑_{k ∈ Ico m n} rᵏ (via Finset.sum_Ico_eq_sub and abs_sub_comm), hence bounded by the endpoint-free slice envelope.",
+      "geometric_partialSum_dist_le: the symmetric distance bound dist (Sₘ) (Sₙ) ≤ r^{min m n}/(1 − r) for all m, n, obtained from the m ≤ n case by le_total and dist_comm — the exact shape consumed by Metric.cauchySeq_iff.",
+      "geometric_partialSum_cauchySeq: the headline — the finite partial sums n ↦ ∑_{k<n} rᵏ form a CauchySeq, proved directly from the slice/distance bound via Metric.cauchySeq_iff with the threshold from exists_pow_lt_of_lt_one and monotonicity pow_le_pow_of_le_one, without invoking hasSum_geometric.",
+      "geometric_partialSum_le: every partial sum ∑_{k<n} rᵏ is bounded by (1 − r)⁻¹ — the m = 0 instance of geom_sum_Ico_le_of_lt_one after range_eq_Ico — the hypothesis the comparison test needs.",
+      "geometric_summable: summability recovered elementarily from nonnegativity and bounded partial sums (summable_of_sum_range_le), with no appeal to the closed-form hasSum_geometric; the value (1 − r)⁻¹ is the consequence of convergence here, not its premise.",
+      "geometric_cauchySeq_finset: the Mathlib-native face — the net of finite partial sums s ↦ ∑_{k ∈ s} rᵏ over the directed set of finsets is a CauchySeq, via summable_iff_cauchySeq_finset applied to geometric_summable; this is the predicate that defines summability in a complete group."
+    ],
+    "prerequisites": [
+      "geom_sum_Ico_le_of_lt_one (Mathlib): the slice bound rᵐ/(1 − r), valid for all m, n",
+      "Finset.sum_Ico_eq_sub (Mathlib): ∑_{k ∈ Ico m n} f = ∑_{k<n} f − ∑_{k<m} f, the bridge from a slice to a distance of partial sums",
+      "Metric.cauchySeq_iff (Mathlib): the ε–N characterisation of CauchySeq in a metric space",
+      "summable_of_sum_range_le (Mathlib): bounded nonnegative partial sums ⇒ Summable",
+      "summable_iff_cauchySeq_finset (Mathlib): Summable ⇔ the finset net is Cauchy",
+      "exists_pow_lt_of_lt_one and pow_le_pow_of_le_one for the ε–N threshold",
+      "Sibling: geometric-series-oq-08-oq-03 (the ε–N slice Cauchy criterion this entry abstracts)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "geom_sum_Ico_le_of_lt_one",
+        "description": "∑ i ∈ Ico m n, xⁱ ≤ xᵐ/(1 − x) for 0 ≤ x < 1, valid for all m, n. The raw block bound behind the distance estimate and (at m = 0) the partial-sum bound.",
+        "module": "Mathlib.Algebra.Order.Field.GeomSum"
+      },
+      {
+        "theorem": "Finset.sum_Ico_eq_sub",
+        "description": "∑ k ∈ Ico m n, f k = ∑ k ∈ range n, f k − ∑ k ∈ range m, f k for m ≤ n. Turns a slice into the difference of two partial sums, i.e. their metric distance.",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Metric.cauchySeq_iff",
+        "description": "CauchySeq u ⇔ ∀ ε > 0, ∃ N, ∀ m ≥ N, ∀ n ≥ N, dist (u m) (u n) < ε. The abstract predicate the slice bound is promoted into.",
+        "module": "Mathlib.Topology.MetricSpace.Cauchy"
+      },
+      {
+        "theorem": "summable_of_sum_range_le",
+        "description": "For f : ℕ → ℝ nonnegative with ∑_{k<n} f k ≤ c for all n, Summable f. Recovers summability from the bounded partial sums without the closed-form value.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Real"
+      },
+      {
+        "theorem": "summable_iff_cauchySeq_finset",
+        "description": "Summable f ⇔ CauchySeq (fun s : Finset ι => ∑ i ∈ s, f i). Used to turn geometric_summable into the finset-net Cauchy statement.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "exists_pow_lt_of_lt_one",
+        "description": "For 0 < ε and r < 1 there is N with rᴺ < ε. Supplies the Cauchy threshold (applied to ε·(1 − r)).",
+        "module": "Mathlib.Algebra.Order.Archimedean.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-08-oq-03-oq-01-oq-01",
+      "question": "Identify the limit of the now-established Cauchy sequence with the closed form: from geometric_partialSum_cauchySeq and completeness of ℝ obtain a limit L via cauchySeq_tendsto_of_complete, then prove L = (1 − r)⁻¹ using only the truncation defect (1 − r)⁻¹ − ∑_{k<n} rᵏ = rⁿ/(1 − r) → 0, giving an independent derivation of hasSum_geometric from first principles.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-08-oq-03",
+      "relationship": "extends",
+      "description": "Sibling and direct source. That entry proved the hand-rolled ε–N criterion geometric_slice_cauchy (|∑_{k ∈ Ico m n} rᵏ| ≤ ε past a threshold). This entry promotes the same estimate to Mathlib's abstract predicates: CauchySeq for the partial sums, Summable for the series, and the finset-net CauchySeq."
+    },
+    {
+      "targetId": "geometric-series-oq-08",
+      "relationship": "depends-on",
+      "description": "Grandparent. The one-sided truncation defect (1 − r)⁻¹ − ∑_{k<n} rᵏ = rⁿ/(1 − r) is the head-vs-limit statement; the bounded partial sums used in geometric_summable are the m = 0 face of its slice bound."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "depends-on",
+      "description": "Base entry recording the finite closed form (1 − rⁿ)/(1 − r) and the infinite value (1 − r)⁻¹, which appears here only as the partial-sum bound, not as an input to the convergence proof."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Topology.Algebra.InfiniteSum.Real",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Provides summable_of_sum_range_le, the bounded-partial-sums summability test used to recover summability without hasSum_geometric."
+    },
+    {
+      "title": "Principles of Mathematical Analysis (Cauchy criterion for series, completeness)",
+      "author": "Walter Rudin",
+      "year": "1976",
+      "venue": "McGraw-Hill",
+      "description": "Standard reference for the Cauchy criterion characterisation of convergent series and the role of completeness in turning a Cauchy series into a convergent one."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For 0 ≤ r < 1 the geometric series is shown to converge as a Cauchy sequence and to be summable, from first principles. The Ico-slice bound rᵐ/(1 − r) is read metrically — dist (∑_{k<m} rᵏ) (∑_{k<n} rᵏ) ≤ r^{min m n}/(1 − r) — and fed to Metric.cauchySeq_iff to give geometric_partialSum_cauchySeq; the m = 0 bound ∑_{k<n} rᵏ ≤ (1 − r)⁻¹ feeds summable_of_sum_range_le to give geometric_summable; and summable_iff_cauchySeq_finset yields the finset-net CauchySeq. 152 lines, 7 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The sibling geometric-series-oq-08-oq-03 stated the Cauchy property as a bespoke inequality; this entry is the translation into Mathlib's convergence vocabulary (CauchySeq, Summable, cauchySeq over finsets), so the geometric series can be dropped into the library's general theorems. Conceptually it closes a loop: the series is exhibited as convergent/summable using only bounded blocks and bounded monotone partial sums, with the closed form (1 − r)⁻¹ appearing as a consequence of convergence rather than as the premise — a derivation that deliberately routes around hasSum_geometric.",
+    "openQuestions": [
+      "Combine geometric_partialSum_cauchySeq with completeness (cauchySeq_tendsto_of_complete) and the truncation defect rⁿ/(1 − r) → 0 to identify the limit as (1 − r)⁻¹, recovering hasSum_geometric independently."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the follow-up open question of `geometric-series-oq-08-oq-03`: **promote the elementary ε–N slice criterion to Mathlib's abstract convergence predicates**, recovering summability *without* invoking `hasSum_geometric`.

For `0 ≤ r < 1`:

- `geometric_partialSum_dist` / `geometric_partialSum_dist_le` — the metric reading of the Ico-slice: `dist (∑_{k<m} rᵏ) (∑_{k<n} rᵏ) ≤ r^{min m n}/(1 − r)` (the distance between partial sums *is* the middle block, via `Finset.sum_Ico_eq_sub`).
- `geometric_partialSum_cauchySeq` — **headline**: `n ↦ ∑_{k<n} rᵏ` is a `CauchySeq`, proved straight from the slice bound through `Metric.cauchySeq_iff`.
- `geometric_partialSum_le` — partial sums bounded by `(1 − r)⁻¹` (the `m = 0` slice bound).
- `geometric_summable` — **summability recovered elementarily** from bounded nonnegative partial sums (`summable_of_sum_range_le`), with no appeal to the closed-form value.
- `geometric_cauchySeq_finset` — the Mathlib-native face: the finset net `s ↦ ∑_{k ∈ s} rᵏ` is `CauchySeq` (`summable_iff_cauchySeq_finset`).

The point is conceptual honesty: the series is exhibited as **convergent/summable from first principles** (bounded blocks, bounded monotone heads); the closed form `(1 − r)⁻¹` is the *consequence*, not the premise.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ08OQ03OQ01` — succeeds (3059 jobs).
- 152 lines, 7 theorems, 0 definitions, **0 axioms**, 0 sorries. No `native_decide`; only `propext` / `Classical.choice` / `Quot.sound`.
- Self-contained off `origin/main` (does not stack on the still-open sibling PR #27368); the slice bound is re-derived inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)