### PR TITLE
research: tritangent-center centroid is the circumcenter — I + Iₐ + I_b + I_c = 4O [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2519,6 +2519,7 @@ import Proofs.FeuerbachsTheoremDefsOQ01OQ01OQ01OQ02OQ01
 import Proofs.FeuerbachsTheoremDefsOQ02
 import Proofs.FeuerbachsTheoremDefsOQ02OQ01
 import Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01
+import Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ03
 import Proofs.FeuerbachsTheoremDefsOQ04
 import Proofs.FeuerbachsTheoremOQ01

--- a/proofs/Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01.lean
@@ -1,0 +1,447 @@
+/-
+  Feuerbach's Theorem DefsOQ02OQ01OQ01OQ01:
+  The tritangent-centre centroid is the circumcentre   I + I_a + I_b + I_c = 4·O
+
+  ## The Open Question
+
+  The sibling file `FeuerbachsTheoremDefsOQ02OQ01OQ01` proves the *metric*
+  relation among the four classical tritangent centres — the incentre I and the
+  three excentres I_a, I_b, I_c — measured from the circumcentre O:
+
+      OI² + OI_a² + OI_b² + OI_c² = 12·R²              (square-distance sum).
+
+  That identity is about *distances*.  A natural structural companion asks for
+  the *affine* relation: where does the centroid of the four tritangent centres
+  sit?  The answer is the cleanest possible —
+
+      I + I_a + I_b + I_c = 4·O,
+
+  i.e. the circumcentre O is the centroid (arithmetic mean) of the four
+  tritangent centres, **for every triangle**.
+
+  ## Why this is the affine companion of the 12R² law
+
+  The two facts are two halves of one picture.  Write G for the centroid of the
+  four centres.  Leibniz's identity gives, for any point P,
+
+      Σ PX² = 4·PG² + Σ GX²        (X ranging over I, I_a, I_b, I_c).
+
+  Taking P = O, the present theorem says G = O, so the first term vanishes and
+  the 12R² law is exactly Σ OX² = Σ GX² = 12R².  The square-distance sum is the
+  moment of inertia of the four centres about their own centroid — and that
+  centroid is O.
+
+  Equivalently: {I, I_a, I_b, I_c} is an orthocentric system (I is the
+  orthocentre of the excentral triangle I_a I_b I_c), whose common nine-point
+  centre is the centroid of the four points.  The statement I+I_a+I_b+I_c = 4O
+  is precisely the classical fact that **the circumcircle of ABC is the
+  nine-point circle of the excentral triangle** (so the nine-point centre of
+  I_a I_b I_c is O and the excentral circumradius is 2R).
+
+  ## What This File Proves
+
+  For an arbitrary non-degenerate triangle T:
+
+  ### The main identity (both coordinates)
+  `tritangent_centroid_x`,  `tritangent_centroid_y` :
+      I.x + I_a.x + I_b.x + I_c.x = 4·O.x   and the y-analogue.
+
+  ### Point form
+  `circumcenter_eq_tritangent_centroid` :  O = ((Σx)/4, (Σy)/4).
+
+  ### Worked example
+  `triangle_345_tritangent_centroid` :  for the 3-4-5 triangle the four centres
+  are I=(1,1), I_a=(6,6), I_b=(−3,3), I_c=(2,−2), summing to (6,8) = 4·(3/2,2)
+  = 4·O.
+
+  ## Method
+
+  Both centres and the circumcentre are written in coordinates.  The proof rests
+  on three algebraic identities:
+
+  * `tritangent_mul_heron_x/y` :  the tritangent coordinate sum, multiplied by
+    the Heron product p_s·p_a·p_b·p_c, equals 4·N, where N is the standard
+    *circumcentre barycentric numerator*
+        N_x = a²(b²+c²−a²)·A.x + b²(c²+a²−b²)·B.x + c²(a²+b²−c²)·C.x.
+    This is an identity in the *free* side lengths a,b,c (the reciprocal
+    denominators telescope), so it is pure `ring`.
+  * `circ_bary_x/y` :  N = (circumcentre numerator)·d, a pure coordinate `ring`
+    identity expressing that O has barycentric coordinates (a²(b²+c²−a²) : … : …).
+  * `sixteen_area_sq` :  16·Area² = d², where d is the circumcentre determinant.
+    Combined with Heron (16·Area² = p_s·p_a·p_b·p_c) this gives
+    p_s·p_a·p_b·p_c = d², the bridge between the two numerators.
+
+  The squared-side and strict-triangle-inequality lemmas (needed to know the
+  excentre denominators p_a,p_b,p_c are nonzero) are reproved locally, as the
+  sibling declares them `private`.
+
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Proofs.FeuerbachsTheoremDefs
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace FeuerbachTritangentCentroid
+
+open FeuerbachsTheorem
+
+-- ============================================================
+-- PART 1: Squared side lengths and positivity (parent's are private)
+-- ============================================================
+
+private lemma side_a_sq (T : Triangle) :
+    T.side_a ^ 2 = (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by
+  unfold Triangle.side_a; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_b_sq (T : Triangle) :
+    T.side_b ^ 2 = (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by
+  unfold Triangle.side_b; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_c_sq (T : Triangle) :
+    T.side_c ^ 2 = (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by
+  unfold Triangle.side_c; rw [Real.sq_sqrt (by positivity)]
+
+private lemma area_pos (T : Triangle) : 0 < T.area := by
+  unfold Triangle.area
+  have hne := T.nondegenerate
+  have h : 0 < |(T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2)| :=
+    abs_pos.mpr hne
+  linarith
+
+private lemma side_a_pos (T : Triangle) : 0 < T.side_a := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.C.1 - T.B.1 = 0 := by nlinarith [sq_nonneg (T.C.1 - T.B.1), sq_nonneg (T.C.2 - T.B.2)]
+    have hy : T.C.2 - T.B.2 = 0 := by nlinarith [sq_nonneg (T.C.1 - T.B.1), sq_nonneg (T.C.2 - T.B.2)]
+    apply hne; linear_combination (T.B.1 - T.A.1) * hy - (T.B.2 - T.A.2) * hx
+  unfold Triangle.side_a; exact Real.sqrt_pos.mpr h
+
+private lemma side_b_pos (T : Triangle) : 0 < T.side_b := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.A.1 - T.C.1 = 0 := by nlinarith [sq_nonneg (T.A.1 - T.C.1), sq_nonneg (T.A.2 - T.C.2)]
+    have hy : T.A.2 - T.C.2 = 0 := by nlinarith [sq_nonneg (T.A.1 - T.C.1), sq_nonneg (T.A.2 - T.C.2)]
+    apply hne; linear_combination (T.B.2 - T.A.2) * hx - (T.B.1 - T.A.1) * hy
+  unfold Triangle.side_b; exact Real.sqrt_pos.mpr h
+
+private lemma side_c_pos (T : Triangle) : 0 < T.side_c := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.B.1 - T.A.1 = 0 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+    have hy : T.B.2 - T.A.2 = 0 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+    apply hne; linear_combination (T.C.2 - T.A.2) * hx - (T.C.1 - T.A.1) * hy
+  unfold Triangle.side_c; exact Real.sqrt_pos.mpr h
+
+private lemma perimeter_pos (T : Triangle) : 0 < T.side_a + T.side_b + T.side_c := by
+  have := side_a_pos T; have := side_b_pos T; have := side_c_pos T; linarith
+
+-- ============================================================
+-- PART 2: Strict triangle inequalities (force the excentre denominators > 0)
+-- ============================================================
+
+set_option maxHeartbeats 1600000 in
+private lemma strict_tri_ineq_a (T : Triangle) :
+    T.side_a < T.side_b + T.side_c := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hapos := side_a_pos T
+  have hbpos := side_b_pos T
+  have hcpos := side_c_pos T
+  set D := (T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2) with hDdef
+  set P := (T.A.1 - T.C.1) * (T.B.1 - T.A.1) + (T.A.2 - T.C.2) * (T.B.2 - T.A.2) with hPdef
+  have hDne : D ≠ 0 := T.nondegenerate
+  have hD2 : 0 < D ^ 2 := by
+    rcases hDne.lt_or_gt with h | h
+    · nlinarith [h]
+    · nlinarith [h]
+  have hexp : T.side_a ^ 2 = T.side_b ^ 2 + T.side_c ^ 2 + 2 * P := by
+    rw [ha, hb, hc, hPdef]; ring
+  have hlag : T.side_b ^ 2 * T.side_c ^ 2 - P ^ 2 = D ^ 2 := by
+    rw [hb, hc, hPdef, hDdef]; ring
+  have hP2 : P ^ 2 < (T.side_b * T.side_c) ^ 2 := by nlinarith [hlag, hD2]
+  have hbc : 0 < T.side_b * T.side_c := mul_pos hbpos hcpos
+  have hPlt : P < T.side_b * T.side_c := by nlinarith [hP2, hbc]
+  have hsum_pos : 0 < T.side_b + T.side_c := by linarith
+  have hasq : T.side_a ^ 2 < (T.side_b + T.side_c) ^ 2 := by nlinarith [hexp, hPlt]
+  nlinarith [hasq, hapos, hsum_pos]
+
+set_option maxHeartbeats 1600000 in
+private lemma strict_tri_ineq_b (T : Triangle) :
+    T.side_b < T.side_a + T.side_c := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hapos := side_a_pos T
+  have hbpos := side_b_pos T
+  have hcpos := side_c_pos T
+  set D := (T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2) with hDdef
+  set P := (T.C.1 - T.B.1) * (T.B.1 - T.A.1) + (T.C.2 - T.B.2) * (T.B.2 - T.A.2) with hPdef
+  have hDne : D ≠ 0 := T.nondegenerate
+  have hD2 : 0 < D ^ 2 := by
+    rcases hDne.lt_or_gt with h | h
+    · nlinarith [h]
+    · nlinarith [h]
+  have hexp : T.side_b ^ 2 = T.side_a ^ 2 + T.side_c ^ 2 + 2 * P := by
+    rw [ha, hb, hc, hPdef]; ring
+  have hlag : T.side_a ^ 2 * T.side_c ^ 2 - P ^ 2 = D ^ 2 := by
+    rw [ha, hc, hPdef, hDdef]; ring
+  have hP2 : P ^ 2 < (T.side_a * T.side_c) ^ 2 := by nlinarith [hlag, hD2]
+  have hac : 0 < T.side_a * T.side_c := mul_pos hapos hcpos
+  have hPlt : P < T.side_a * T.side_c := by nlinarith [hP2, hac]
+  have hsum_pos : 0 < T.side_a + T.side_c := by linarith
+  have hbsq : T.side_b ^ 2 < (T.side_a + T.side_c) ^ 2 := by nlinarith [hexp, hPlt]
+  nlinarith [hbsq, hbpos, hsum_pos]
+
+set_option maxHeartbeats 1600000 in
+private lemma strict_tri_ineq_c (T : Triangle) :
+    T.side_c < T.side_a + T.side_b := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hapos := side_a_pos T
+  have hbpos := side_b_pos T
+  have hcpos := side_c_pos T
+  set D := (T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2) with hDdef
+  set P := (T.C.1 - T.A.1) * (T.B.1 - T.C.1) + (T.C.2 - T.A.2) * (T.B.2 - T.C.2) with hPdef
+  have hDne : D ≠ 0 := T.nondegenerate
+  have hD2 : 0 < D ^ 2 := by
+    rcases hDne.lt_or_gt with h | h
+    · nlinarith [h]
+    · nlinarith [h]
+  have hexp : T.side_c ^ 2 = T.side_a ^ 2 + T.side_b ^ 2 + 2 * P := by
+    rw [ha, hb, hc, hPdef]; ring
+  have hlag : T.side_a ^ 2 * T.side_b ^ 2 - P ^ 2 = D ^ 2 := by
+    rw [ha, hb, hPdef, hDdef]; ring
+  have hP2 : P ^ 2 < (T.side_a * T.side_b) ^ 2 := by nlinarith [hlag, hD2]
+  have hab : 0 < T.side_a * T.side_b := mul_pos hapos hbpos
+  have hPlt : P < T.side_a * T.side_b := by nlinarith [hP2, hab]
+  have hsum_pos : 0 < T.side_a + T.side_b := by linarith
+  have hcsq : T.side_c ^ 2 < (T.side_a + T.side_b) ^ 2 := by nlinarith [hexp, hPlt]
+  nlinarith [hcsq, hcpos, hsum_pos]
+
+private lemma pa_pos (T : Triangle) : 0 < -T.side_a + T.side_b + T.side_c := by
+  have := strict_tri_ineq_a T; linarith
+
+private lemma pb_pos (T : Triangle) : 0 < T.side_a - T.side_b + T.side_c := by
+  have := strict_tri_ineq_b T; linarith
+
+private lemma pc_pos (T : Triangle) : 0 < T.side_a + T.side_b - T.side_c := by
+  have := strict_tri_ineq_c T; linarith
+
+-- ============================================================
+-- PART 3: The circumcentre barycentric numerator N and the Heron product
+-- ============================================================
+
+/-- The Heron product `p_s · p_a · p_b · p_c`. -/
+private def prodP (T : Triangle) : ℝ :=
+  (T.side_a + T.side_b + T.side_c) * (-T.side_a + T.side_b + T.side_c)
+    * (T.side_a - T.side_b + T.side_c) * (T.side_a + T.side_b - T.side_c)
+
+private lemma prodP_pos (T : Triangle) : 0 < prodP T := by
+  unfold prodP
+  exact mul_pos (mul_pos (mul_pos (perimeter_pos T) (pa_pos T)) (pb_pos T)) (pc_pos T)
+
+/-- The x-component of the circumcentre barycentric numerator:
+    `N_x = a²(b²+c²−a²)·A.x + b²(c²+a²−b²)·B.x + c²(a²+b²−c²)·C.x`. -/
+private def num_x (T : Triangle) : ℝ :=
+  T.side_a ^ 2 * (T.side_b ^ 2 + T.side_c ^ 2 - T.side_a ^ 2) * T.A.1
+    + T.side_b ^ 2 * (T.side_c ^ 2 + T.side_a ^ 2 - T.side_b ^ 2) * T.B.1
+    + T.side_c ^ 2 * (T.side_a ^ 2 + T.side_b ^ 2 - T.side_c ^ 2) * T.C.1
+
+private def num_y (T : Triangle) : ℝ :=
+  T.side_a ^ 2 * (T.side_b ^ 2 + T.side_c ^ 2 - T.side_a ^ 2) * T.A.2
+    + T.side_b ^ 2 * (T.side_c ^ 2 + T.side_a ^ 2 - T.side_b ^ 2) * T.B.2
+    + T.side_c ^ 2 * (T.side_a ^ 2 + T.side_b ^ 2 - T.side_c ^ 2) * T.C.2
+
+/-- **Heron in determinant form.**  `16·Area² = d²`, where
+    `d = 2·((A.x−C.x)(B.y−C.y) − (B.x−C.x)(A.y−C.y))` is the circumcentre
+    determinant.  Both sides equal four times the squared signed area. -/
+private lemma sixteen_area_sq (T : Triangle) :
+    16 * T.area ^ 2 =
+      (2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))) ^ 2 := by
+  unfold Triangle.area
+  rw [div_pow, sq_abs]
+  ring
+
+/-- Heron's identity `16·Area² = p_s·p_a·p_b·p_c` (proved from the shoelace area
+    and the coordinate squared side lengths). -/
+private lemma heron (T : Triangle) : 16 * T.area ^ 2 = prodP T := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hsq :
+      prodP T
+      = 2 * (T.side_a ^ 2) * (T.side_b ^ 2) + 2 * (T.side_b ^ 2) * (T.side_c ^ 2)
+        + 2 * (T.side_c ^ 2) * (T.side_a ^ 2)
+        - (T.side_a ^ 2) ^ 2 - (T.side_b ^ 2) ^ 2 - (T.side_c ^ 2) ^ 2 := by
+    unfold prodP; ring
+  rw [hsq, ha, hb, hc]
+  unfold Triangle.area
+  have habs := sq_abs ((T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2))
+  rw [div_pow, habs]
+  ring
+
+/-- The Heron product equals the squared circumcentre determinant. -/
+private lemma prodP_eq_d_sq (T : Triangle) :
+    prodP T =
+      (2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))) ^ 2 := by
+  have h1 := heron T
+  have h2 := sixteen_area_sq T
+  linarith
+
+/-- **The circumcentre is barycentric** in the x-coordinate:
+    `(circumcentre x-numerator)·d = N_x`.  A pure coordinate identity. -/
+private lemma circ_bary_x (T : Triangle) :
+    ((T.A.1 ^ 2 + T.A.2 ^ 2 - T.C.1 ^ 2 - T.C.2 ^ 2) * (T.B.2 - T.C.2) -
+        (T.B.1 ^ 2 + T.B.2 ^ 2 - T.C.1 ^ 2 - T.C.2 ^ 2) * (T.A.2 - T.C.2))
+      * (2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2)))
+    = num_x T := by
+  unfold num_x
+  rw [side_a_sq, side_b_sq, side_c_sq]
+  ring
+
+/-- **The circumcentre is barycentric** in the y-coordinate. -/
+private lemma circ_bary_y (T : Triangle) :
+    ((T.B.1 ^ 2 + T.B.2 ^ 2 - T.C.1 ^ 2 - T.C.2 ^ 2) * (T.A.1 - T.C.1) -
+        (T.A.1 ^ 2 + T.A.2 ^ 2 - T.C.1 ^ 2 - T.C.2 ^ 2) * (T.B.1 - T.C.1))
+      * (2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2)))
+    = num_y T := by
+  unfold num_y
+  rw [side_a_sq, side_b_sq, side_c_sq]
+  ring
+
+-- ============================================================
+-- PART 4: The tritangent telescoping identity
+-- ============================================================
+
+set_option maxHeartbeats 1600000 in
+/-- **The tritangent telescoping identity** (x-coordinate).  The sum of the four
+    tritangent x-coordinates, cleared by the Heron product, equals `4·N_x`.  The
+    reciprocal denominators telescope, so this is an identity in the *free* side
+    lengths a, b, c — pure `ring` after clearing the four fractions. -/
+private lemma tritangent_mul_heron_x (T : Triangle) :
+    (T.incenter.1 + T.excenter_a.1 + T.excenter_b.1 + T.excenter_c.1) * prodP T
+      = 4 * num_x T := by
+  have hps := (perimeter_pos T).ne'
+  have hpa := (pa_pos T).ne'
+  have hpb := (pb_pos T).ne'
+  have hpc := (pc_pos T).ne'
+  unfold Triangle.incenter Triangle.excenter_a Triangle.excenter_b Triangle.excenter_c prodP num_x
+  dsimp only
+  field_simp
+  ring
+
+set_option maxHeartbeats 1600000 in
+/-- **The tritangent telescoping identity** (y-coordinate). -/
+private lemma tritangent_mul_heron_y (T : Triangle) :
+    (T.incenter.2 + T.excenter_a.2 + T.excenter_b.2 + T.excenter_c.2) * prodP T
+      = 4 * num_y T := by
+  have hps := (perimeter_pos T).ne'
+  have hpa := (pa_pos T).ne'
+  have hpb := (pb_pos T).ne'
+  have hpc := (pc_pos T).ne'
+  unfold Triangle.incenter Triangle.excenter_a Triangle.excenter_b Triangle.excenter_c prodP num_y
+  dsimp only
+  field_simp
+  ring
+
+-- ============================================================
+-- PART 5: The main identity   I + I_a + I_b + I_c = 4·O
+-- ============================================================
+
+/-- **The tritangent-centroid identity (x-coordinate).**  The sum of the
+    x-coordinates of the incentre and the three excentres equals four times the
+    circumcentre's x-coordinate. -/
+theorem tritangent_centroid_x (T : Triangle) :
+    T.incenter.1 + T.excenter_a.1 + T.excenter_b.1 + T.excenter_c.1
+      = 4 * T.circumcenter.1 := by
+  have hd_ne := circumcenter_denom_ne_zero T
+  have hO1 : T.circumcenter.1 =
+      ((T.A.1 ^ 2 + T.A.2 ^ 2 - T.C.1 ^ 2 - T.C.2 ^ 2) * (T.B.2 - T.C.2) -
+          (T.B.1 ^ 2 + T.B.2 ^ 2 - T.C.1 ^ 2 - T.C.2 ^ 2) * (T.A.2 - T.C.2)) /
+        (2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))) := by
+    unfold Triangle.circumcenter; dsimp
+  have e1 : (T.incenter.1 + T.excenter_a.1 + T.excenter_b.1 + T.excenter_c.1) * prodP T
+      = 4 * num_x T := tritangent_mul_heron_x T
+  have e2 : (4 * T.circumcenter.1) * prodP T = 4 * num_x T := by
+    rw [prodP_eq_d_sq T, hO1, ← circ_bary_x T]
+    field_simp
+  exact mul_right_cancel₀ (prodP_pos T).ne' (e1.trans e2.symm)
+
+/-- **The tritangent-centroid identity (y-coordinate).** -/
+theorem tritangent_centroid_y (T : Triangle) :
+    T.incenter.2 + T.excenter_a.2 + T.excenter_b.2 + T.excenter_c.2
+      = 4 * T.circumcenter.2 := by
+  have hd_ne := circumcenter_denom_ne_zero T
+  have hO2 : T.circumcenter.2 =
+      ((T.B.1 ^ 2 + T.B.2 ^ 2 - T.C.1 ^ 2 - T.C.2 ^ 2) * (T.A.1 - T.C.1) -
+          (T.A.1 ^ 2 + T.A.2 ^ 2 - T.C.1 ^ 2 - T.C.2 ^ 2) * (T.B.1 - T.C.1)) /
+        (2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))) := by
+    unfold Triangle.circumcenter; dsimp
+  have e1 : (T.incenter.2 + T.excenter_a.2 + T.excenter_b.2 + T.excenter_c.2) * prodP T
+      = 4 * num_y T := tritangent_mul_heron_y T
+  have e2 : (4 * T.circumcenter.2) * prodP T = 4 * num_y T := by
+    rw [prodP_eq_d_sq T, hO2, ← circ_bary_y T]
+    field_simp
+  exact mul_right_cancel₀ (prodP_pos T).ne' (e1.trans e2.symm)
+
+/-- **The circumcentre is the centroid of the four tritangent centres.**
+    `O = ((I.x+I_a.x+I_b.x+I_c.x)/4, (I.y+I_a.y+I_b.y+I_c.y)/4)`.  Equivalently the
+    circumcircle of ABC is the nine-point circle of the excentral triangle. -/
+theorem circumcenter_eq_tritangent_centroid (T : Triangle) :
+    T.circumcenter =
+      ((T.incenter.1 + T.excenter_a.1 + T.excenter_b.1 + T.excenter_c.1) / 4,
+       (T.incenter.2 + T.excenter_a.2 + T.excenter_b.2 + T.excenter_c.2) / 4) := by
+  apply Prod.ext
+  · rw [tritangent_centroid_x T]; ring
+  · rw [tritangent_centroid_y T]; ring
+
+-- ============================================================
+-- PART 6: Worked example — the 3-4-5 right triangle
+-- ============================================================
+
+private lemma t345_excenter_a : triangle_345.excenter_a = (6, 6) := by
+  unfold Triangle.excenter_a
+  simp only [triangle_345_side_a, triangle_345_side_b, triangle_345_side_c]
+  unfold triangle_345; dsimp
+  exact Prod.ext (by norm_num) (by norm_num)
+
+private lemma t345_excenter_b : triangle_345.excenter_b = (-3, 3) := by
+  unfold Triangle.excenter_b
+  simp only [triangle_345_side_a, triangle_345_side_b, triangle_345_side_c]
+  unfold triangle_345; dsimp
+  exact Prod.ext (by norm_num) (by norm_num)
+
+private lemma t345_excenter_c : triangle_345.excenter_c = (2, -2) := by
+  unfold Triangle.excenter_c
+  simp only [triangle_345_side_a, triangle_345_side_b, triangle_345_side_c]
+  unfold triangle_345; dsimp
+  exact Prod.ext (by norm_num) (by norm_num)
+
+/-- **Tritangent centroid for the 3-4-5 triangle.**  The incentre (1,1) and the
+    three excentres (6,6), (−3,3), (2,−2) sum to (6,8) = 4·(3/2,2) = 4·O. -/
+theorem triangle_345_tritangent_centroid :
+    (triangle_345.incenter.1 + triangle_345.excenter_a.1
+        + triangle_345.excenter_b.1 + triangle_345.excenter_c.1
+      = 4 * triangle_345.circumcenter.1)
+    ∧ (triangle_345.incenter.2 + triangle_345.excenter_a.2
+        + triangle_345.excenter_b.2 + triangle_345.excenter_c.2
+      = 4 * triangle_345.circumcenter.2) := by
+  rw [triangle_345_incenter, t345_excenter_a, t345_excenter_b, t345_excenter_c,
+      triangle_345_circumcenter]
+  constructor <;> norm_num
+
+end FeuerbachTritangentCentroid

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,206 @@
+{
+  "id": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01",
+  "title": "The Tritangent-Center Centroid is the Circumcenter: I + Iₐ + I_b + I_c = 4O",
+  "slug": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01",
+  "description": "The affine companion of the 12R² square-distance law. Where the sibling entry sums the squared distances from the circumcenter O to the four classical tritangent centers (the incenter I and the three excenters Iₐ, I_b, I_c) and finds the shape-independent constant 12R², this entry locates their centroid: I + Iₐ + I_b + I_c = 4O, i.e. the circumcenter is exactly the arithmetic mean of the four tritangent centers, for every triangle. Equivalently, the circumcircle of ABC is the nine-point circle of the excentral triangle IₐI_bI_c (whose orthocenter is I), so the nine-point center of the excentral triangle is O and its circumradius is 2R. By Leibniz's identity Σ OX² = 4·OG² + Σ GX² with G the centroid of the four centers, this identity (G = O) is precisely what makes the 12R² sum equal to the moment of inertia of the four centers about their own centroid. Answers the second open question of the 12R² entry. 4 theorems (+ 21 supporting lemmas), 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
+    "tags": [
+      "geometry",
+      "feuerbach",
+      "euler",
+      "circumcenter",
+      "incenter",
+      "excenter",
+      "excentral-triangle",
+      "orthocentric-system",
+      "nine-point-circle",
+      "barycentric",
+      "heron",
+      "triangle-inequality",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the standard foundational axioms propext / Classical.choice / Quot.sound, which do not count as assumptions). Uses only the coordinate API (Point, Triangle, circumcenter, incenter, excenter_a/b/c, area, side_a/b/c, circumcenter_denom_ne_zero, triangle_345 and its side/incenter/circumcenter lemmas) from FeuerbachsTheoremDefs.lean, which is itself 0-sorry, 0-axiom. The squared side lengths, side/area positivity, the strict triangle inequalities (declared private in the parent), and Heron's identity are reproved locally; everything else after the coordinate definitions is a polynomial identity over ℝ closed by ring / field_simp / linear_combination / nlinarith.",
+    "lineCount": 447,
+    "theoremCount": 4,
+    "definitionCount": 3,
+    "originalContributions": [
+      "tritangent_centroid_x and tritangent_centroid_y: the affine identity I.x+Iₐ.x+I_b.x+I_c.x = 4·O.x (and the y-analogue) for an arbitrary non-degenerate triangle — the circumcenter is four times nothing but the average of the four tritangent centers",
+      "circumcenter_eq_tritangent_centroid: the point form O = ((I+Iₐ+I_b+I_c).x / 4, (I+Iₐ+I_b+I_c).y / 4), i.e. the circumcenter is the centroid of the four tritangent centers — equivalently the circumcircle of ABC is the nine-point circle of the excentral triangle",
+      "tritangent_mul_heron_x/y: the telescoping identity — the tritangent coordinate sum cleared by the Heron product p_s·pₐ·p_b·p_c equals 4·N, where N is the standard circumcenter barycentric numerator a²(b²+c²−a²)·A + b²(c²+a²−b²)·B + c²(a²+b²−c²)·C; an identity in the free side lengths since the four reciprocal denominators telescope",
+      "circ_bary_x/y: the circumcenter is barycentric — the coordinate identity (circumcenter determinant numerator)·d = N expressing that O has barycentric coordinates a²(b²+c²−a²) : b²(c²+a²−b²) : c²(a²+b²−c²)",
+      "sixteen_area_sq and prodP_eq_d_sq: 16·Area² = d² (Heron in determinant form, d the circumcenter denominator) and hence p_s·pₐ·p_b·p_c = d², the bridge identifying the two numerators' denominators",
+      "triangle_345_tritangent_centroid: worked example — for the 3-4-5 right triangle the incenter (1,1) and excenters (6,6), (−3,3), (2,−2) sum to (6,8) = 4·(3/2,2) = 4·O"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The four classical tritangent centers — the incenter and the three excenters, the centers of the four circles tangent to all three sidelines of a triangle — sit in a beautifully rigid configuration. They form an orthocentric system: the incenter I is the orthocenter of the excentral triangle IₐI_bI_c, and each of the four is the orthocenter of the other three. A defining feature of any orthocentric system is that all four points share a single nine-point circle, and that circle's center is the centroid of the four points. For the tritangent system this common nine-point circle is the circumcircle of the original triangle ABC (the excentral triangle has ABC as its medial-like configuration, with circumradius 2R), so its center is the circumcenter O. The arithmetic translation of this classical fact is the strikingly clean vector identity I + Iₐ + I_b + I_c = 4O: the circumcenter is the average of the four tritangent centers. The sibling entry proved the metric law OI² + OIₐ² + OI_b² + OI_c² = 12R²; the present identity is its affine shadow, and the two together are simply Leibniz's parallel-axis decomposition of the same four points.",
+    "problemStatement": "For a non-degenerate triangle with circumcenter O, incenter I and excenters Iₐ, I_b, I_c, prove the vector identity\n$$I + I_a + I_b + I_c = 4\\,O,$$\nequivalently that O is the centroid (arithmetic mean) of the four tritangent centers.",
+    "text": "A 447-line companion file. It reproves the side/area positivity and the strict triangle inequalities (which keep the excenter denominators −a+b+c, a−b+c, a+b−c positive), proves Heron's identity in two forms (16·Area² = p_s·pₐ·p_b·p_c and 16·Area² = d²), establishes that the circumcenter has the standard barycentric coordinates a²(b²+c²−a²) : ⋯, and combines these to show the tritangent coordinate sum equals 4O in each coordinate, with the 3-4-5 worked example.",
+    "proofStrategy": "Clear all denominators against a single common factor (the Heron product, which also equals the squared circumcenter determinant) and reduce to two polynomial identities.\n- **Telescope the tritangent sum** (`tritangent_mul_heron_x/y`): writing the incenter as (a·A+b·B+c·C)/p_s and the excenters with denominators pₐ = −a+b+c (cyclically), the coordinate of A in the sum is a·(1/p_s − 1/pₐ + 1/p_b + 1/p_c). Multiplying through by the common denominator p_s·pₐ·p_b·p_c and simplifying, the A-coefficient telescopes to 4a²(b²+c²−a²) — an identity in the *free* side lengths, since the cross terms cancel without using any relation between a,b,c and the coordinates. So the sum cleared by the Heron product equals 4·N where N = a²(b²+c²−a²)·A + ⋯ is the circumcenter barycentric numerator. Pure ring after field_simp.\n- **The circumcenter is barycentric** (`circ_bary_x/y`): the coordinate circumcenter formula O = (ux/d, uy/d) satisfies ux·d = N_x and uy·d = N_y, a pure coordinate ring identity (after substituting a² = |BC|² etc.) — the classical statement that O has barycentric coordinates a²(b²+c²−a²) : b²(c²+a²−b²) : c²(a²+b²−c²).\n- **Bridge the denominators** (`sixteen_area_sq`, `prodP_eq_d_sq`): both Heron forms 16·Area² = p_s·pₐ·p_b·p_c (from the shoelace area and squared sides) and 16·Area² = d² (the circumcenter determinant is twice the signed area) give p_s·pₐ·p_b·p_c = d².\n- **Assemble** (`tritangent_centroid_x/y`): multiplying the target by the Heron product, the left side is 4·N by the telescoping identity, and the right side 4·O·(Heron product) = 4·O·d² = 4·(ux/d)·d² = 4·ux·d = 4·N by the barycentric identity; cancelling the positive Heron product (mul_right_cancel₀) gives the result. The point form and the 3-4-5 example follow.",
+    "keyInsights": [
+      "The metric law (12R²) and this affine law (4O) are two halves of Leibniz's parallel-axis identity Σ_X OX² = 4·OG² + Σ_X GX² for the four tritangent centers X and their centroid G: this entry proves G = O, so OG = 0 and the square-distance sum is exactly the moment of inertia of the four centers about their own centroid.",
+      "The tritangent coordinate sum telescopes in the *free* side lengths: a·(1/p_s − 1/pₐ + 1/p_b + 1/p_c) collapses to 4a²(b²+c²−a²)/(p_s pₐ p_b p_c) by elementary fraction algebra, with no appeal to the coordinates — so that step is a single ring call after clearing fractions.",
+      "Only even powers of the side lengths survive: the half-telescoped coefficient 2a²(p_s pₐ − p_b p_c) equals 4a²(b²+c²−a²), so the whole identity lives in a², b², c² and never touches the square roots, keeping every step polynomial.",
+      "The numerator N is exactly the circumcenter's barycentric numerator: the same coefficients a²(b²+c²−a²) that telescope out of the tritangent sum are the unnormalized barycentric coordinates of O, which is why the two cleared expressions coincide and the centroid lands precisely on the circumcenter.",
+      "The Heron product p_s·pₐ·p_b·p_c equals the squared circumcenter determinant d²; this single identification lets one common factor clear the tritangent denominators (p's) and the circumcenter denominator (d) simultaneously, turning the whole problem into two ring identities."
+    ],
+    "prerequisites": [
+      "FeuerbachsTheoremDefs.lean — the coordinate API (Point, Triangle, circumcenter, incenter, excenter_a/b/c, area, side_a/b/c), the lemma circumcenter_denom_ne_zero, and the worked triangle_345 with its side/incenter/circumcenter evaluation lemmas",
+      "Heron's identity / the shoelace area, the standard barycentric coordinates of the circumcenter, and the orthocentric-system / excentral-triangle picture for the geometric interpretation",
+      "ring, field_simp, linear_combination and nlinarith for polynomial identities and the strict triangle inequalities over ℝ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Namespace Setup",
+      "startLine": 1,
+      "endLine": 89,
+      "summary": "Module docstring stating I+Iₐ+I_b+I_c = 4O and its reading as the affine companion of the 12R² law, imports only FeuerbachsTheoremDefs (the coordinate API), opens the FeuerbachsTheorem namespace.",
+      "mathContext": "Self-contained on the base coordinate definitions: every analytic input (Heron, positivity, triangle inequalities) is reproved locally, so the file depends only on FeuerbachsTheoremDefs."
+    },
+    {
+      "id": "positivity",
+      "title": "Part I: Squared Side Lengths and Positivity",
+      "startLine": 91,
+      "endLine": 148,
+      "summary": "Squared side lengths a² = |BC|² etc., positivity of each side and of the area, and positivity of the perimeter (the parent's are private).",
+      "mathContext": "Each side is positive because the vertices are pairwise distinct; the area is positive because the signed shoelace determinant is nonzero (non-degeneracy)."
+    },
+    {
+      "id": "triangleineq",
+      "title": "Part II: The Strict Triangle Inequalities",
+      "startLine": 150,
+      "endLine": 242,
+      "summary": "strict_tri_ineq_a/b/c (a < b+c and cyclic) and pa_pos/pb_pos/pc_pos (positivity of the excenter denominators −a+b+c, a−b+c, a+b−c), reproved locally since the parent declares them private.",
+      "mathContext": "Via the law of cosines a² = b²+c²+2P and the Lagrange identity b²c² − P² = D² with D the non-degeneracy determinant; D ≠ 0 gives P < bc, hence a² < (b+c)², hence a < b+c. These keep the tritangent denominators nonzero so the Heron product is positive."
+    },
+    {
+      "id": "barycentric",
+      "title": "Part III: The Circumcenter Barycentric Numerator and Heron",
+      "startLine": 244,
+      "endLine": 324,
+      "summary": "The Heron product prodP = p_s·pₐ·p_b·p_c (with prodP_pos) and the barycentric numerators num_x, num_y; the two Heron forms sixteen_area_sq (16·Area² = d²) and heron (16·Area² = prodP), their consequence prodP_eq_d_sq (prodP = d²), and circ_bary_x/y showing the circumcenter determinant numerator times d equals N.",
+      "mathContext": "d = 2·det is twice the signed area, so 16·Area² = d²; combined with the coordinate Heron 16·Area² = prodP this identifies prodP with d². circ_bary_x/y are the classical barycentric coordinates of O, proved as pure coordinate ring identities."
+    },
+    {
+      "id": "telescope",
+      "title": "Part IV: The Tritangent Telescoping Identity",
+      "startLine": 326,
+      "endLine": 360,
+      "summary": "tritangent_mul_heron_x/y: the tritangent coordinate sum cleared by the Heron product equals 4·N. After clearing the four reciprocal denominators the A-coefficient telescopes to 4a²(b²+c²−a²), an identity in the free side lengths closed by ring.",
+      "mathContext": "The coefficient of A in the sum is a·(1/p_s − 1/pₐ + 1/p_b + 1/p_c); multiplying by p_s·pₐ·p_b·p_c and simplifying gives 2a²(p_s pₐ − p_b p_c) = 4a²(b²+c²−a²), with no use of the coordinates."
+    },
+    {
+      "id": "main",
+      "title": "Part V: The Main Identity I + Iₐ + I_b + I_c = 4O",
+      "startLine": 361,
+      "endLine": 410,
+      "summary": "tritangent_centroid_x/y: multiplying the target by the Heron product, the left side is 4·N (telescoping) and the right side 4·O·d² = 4·ux·d = 4·N (barycentric), cancelling the positive Heron product. circumcenter_eq_tritangent_centroid: the point form O = (Σx/4, Σy/4).",
+      "mathContext": "mul_right_cancel₀ on the positive Heron product turns the two cleared identities into I+Iₐ+I_b+I_c = 4O coordinatewise; Prod.ext assembles the point form."
+    },
+    {
+      "id": "example",
+      "title": "Part VI: Worked Example — the 3-4-5 Triangle",
+      "startLine": 412,
+      "endLine": 447,
+      "summary": "t345_excenter_a/b/c evaluate the three excenters to (6,6), (−3,3), (2,−2); triangle_345_tritangent_centroid sums them with the incenter (1,1) to (6,8) = 4·(3/2,2) = 4·O.",
+      "mathContext": "Instantiates the identity at the parent's triangle_345 (A=(0,0), B=(3,0), C=(0,4)); norm_num evaluates the weighted barycentric coordinates with the known side lengths a=5, b=4, c=3."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves the affine identity I + Iₐ + I_b + I_c = 4O — the circumcenter is the centroid of the four classical tritangent centers — for an arbitrary non-degenerate triangle, the affine companion of the sibling's metric law OI² + OIₐ² + OI_b² + OI_c² = 12R² and the second open question that entry posed. The proof clears all denominators against the Heron product (shown equal to the squared circumcenter determinant), telescopes the tritangent sum into the circumcenter's barycentric numerator, and cancels. 4 theorems (plus 21 supporting lemmas), 0 axioms, 0 sorries.",
+    "implications": "**The affine half of the tritangent conservation law**: together with the 12R² square-distance sum, this completes Leibniz's parallel-axis decomposition Σ OX² = 4·OG² + Σ GX² for the four tritangent centers — the centroid G is the circumcenter O, so the 12R² constant is exactly the moment of inertia of the four centers about O.\n\n**The excentral triangle's nine-point circle is the circumcircle of ABC**: the identity I+Iₐ+I_b+I_c = 4O is the arithmetic form of the classical fact that the four tritangent centers form an orthocentric system whose common nine-point center is O (and whose excentral circumradius is 2R).\n\n**The circumcenter's barycentric coordinates as gallery infrastructure**: circ_bary_x/y supply the standard unnormalized barycentrics a²(b²+c²−a²) : b²(c²+a²−b²) : c²(a²+b²−c²) of O as 0-axiom coordinate identities, reusable across the triangle-geometry strand.",
+    "openQuestions": [
+      "Prove the excentral circumradius is 2R directly: show the circumradius of the excentral triangle IₐI_bI_c equals twice that of ABC, completing the orthocentric-system picture whose nine-point center this entry locates at O.",
+      "Establish that the incenter I is the orthocenter of the excentral triangle IₐI_bI_c (each tritangent center is the orthocenter of the other three), the structural fact underlying the orthocentric system and hence the 4O centroid identity.",
+      "Generalize the barycentric telescoping: for which vertex-weight schemes does a signed combination of weighted barycentric centers (incenter, excenters, and beyond) again land on a named triangle center, and which centers arise as such averages?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "the metric law OI² + OIₐ² + OI_b² + OI_c² = 12R²; this entry proves its affine companion I+Iₐ+I_b+I_c = 4O (the centroid of the four tritangent centers is O), directly answering that entry's second open question and supplying the G = O half of Leibniz's parallel-axis identity"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-02-oq-01",
+      "relationship": "related",
+      "description": "the excenter Euler law OIₐ² = R² + 2Rrₐ; the three excenters whose centroid (with the incenter) lands on O are the same ones measured there"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs",
+      "relationship": "extends",
+      "description": "uses the circumcenter, incenter, excenters, area and side lengths defined in FeuerbachsTheoremDefs.lean, the lemma circumcenter_denom_ne_zero, and the worked triangle_345"
+    },
+    {
+      "targetId": "feuerbachs-theorem",
+      "relationship": "related",
+      "description": "the full Feuerbach theorem, whose nine-point circle is tangent to the incircle and all three excircles whose centers form the orthocentric system studied here"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Proofs.FeuerbachsTheoremDefs"],
+    "opens": ["FeuerbachsTheorem"],
+    "namespace": "FeuerbachTritangentCentroid",
+    "lineCount": 447,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 3,
+    "path": "Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "circumcenter_eq_tritangent_centroid",
+      "type": "core",
+      "description": "The circumcenter is the centroid of the four tritangent centers: O equals the coordinatewise average of the incenter and the three excenters.",
+      "leanType": "∀ T : Triangle, T.circumcenter = ((T.incenter.1 + T.excenter_a.1 + T.excenter_b.1 + T.excenter_c.1) / 4, (T.incenter.2 + T.excenter_a.2 + T.excenter_b.2 + T.excenter_c.2) / 4)"
+    },
+    {
+      "name": "tritangent_centroid_x",
+      "type": "core",
+      "description": "The x-coordinate of the affine identity: the sum of the incenter and three excenter x-coordinates equals four times the circumcenter's x-coordinate.",
+      "leanType": "∀ T : Triangle, T.incenter.1 + T.excenter_a.1 + T.excenter_b.1 + T.excenter_c.1 = 4 * T.circumcenter.1"
+    },
+    {
+      "name": "tritangent_centroid_y",
+      "type": "core",
+      "description": "The y-coordinate of the affine identity.",
+      "leanType": "∀ T : Triangle, T.incenter.2 + T.excenter_a.2 + T.excenter_b.2 + T.excenter_c.2 = 4 * T.circumcenter.2"
+    },
+    {
+      "name": "tritangent_mul_heron_x",
+      "type": "lemma",
+      "description": "The telescoping identity: the tritangent x-coordinate sum cleared by the Heron product equals four times the circumcenter barycentric numerator N_x.",
+      "leanType": "∀ T : Triangle, (T.incenter.1 + T.excenter_a.1 + T.excenter_b.1 + T.excenter_c.1) * prodP T = 4 * num_x T"
+    },
+    {
+      "name": "circ_bary_x",
+      "type": "lemma",
+      "description": "The circumcenter is barycentric: its determinant numerator times the determinant d equals N_x, expressing O's barycentric coordinates a²(b²+c²−a²) : ⋯.",
+      "leanType": "∀ T : Triangle, ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) - (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) * (2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))) = num_x T"
+    },
+    {
+      "name": "triangle_345_tritangent_centroid",
+      "type": "example",
+      "description": "Worked example: for the 3-4-5 right triangle the incenter (1,1) and excenters (6,6), (−3,3), (2,−2) sum to (6,8) = 4·(3/2,2) = 4·O.",
+      "leanType": "(triangle_345.incenter.1 + triangle_345.excenter_a.1 + triangle_345.excenter_b.1 + triangle_345.excenter_c.1 = 4 * triangle_345.circumcenter.1) ∧ (triangle_345.incenter.2 + triangle_345.excenter_a.2 + triangle_345.excenter_b.2 + triangle_345.excenter_c.2 = 4 * triangle_345.circumcenter.2)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The **affine companion** of the metric 12R² square-distance law (#27367). Where the sibling entry sums the squared distances from the circumcenter O to the four classical tritangent centers (incenter I, excenters Iₐ, I_b, I_c) and gets the shape-independent constant **12R²**, this entry locates their **centroid**:

$$I + I_a + I_b + I_c = 4\,O,$$

i.e. the circumcenter is exactly the arithmetic mean of the four tritangent centers, for every non-degenerate triangle. Equivalently, the **circumcircle of ABC is the nine-point circle of the excentral triangle** IₐI_bI_c (whose orthocenter is I), so its nine-point center is O and its circumradius is 2R.

This directly answers the **second open question** posed by the 12R² entry. Together the two laws are Leibniz's parallel-axis decomposition Σ OX² = 4·OG² + Σ GX² of the same four points: this entry proves **G = O**, so the 12R² sum is the moment of inertia of the four centers about their own centroid.

## Method

- **Telescope** (`tritangent_mul_heron_x/y`): the tritangent coordinate sum cleared by the Heron product p_s·pₐ·p_b·p_c telescopes — in the *free* side lengths — into `4·N`, where N = a²(b²+c²−a²)·A + ⋯ is the circumcenter barycentric numerator. Pure `ring` after `field_simp`.
- **Barycentric** (`circ_bary_x/y`): the coordinate circumcenter `ux/d` satisfies `ux·d = N` — O has barycentric coords a²(b²+c²−a²) : b²(c²+a²−b²) : c²(a²+b²−c²).
- **Bridge** (`sixteen_area_sq`, `prodP_eq_d_sq`): 16·Area² = d² and 16·Area² = p_s·pₐ·p_b·p_c, hence p_s·pₐ·p_b·p_c = d² — one common factor clears both the tritangent denominators and the circumcenter denominator.
- **Assemble + cancel** the positive Heron product.

## Verification

- **447 lines**, **4 theorems** (+ 21 supporting lemmas, 3 defs)
- **0 axioms, 0 sorries** — no `native_decide`, no `decide`, no `axiom`
- Builds clean: `./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01` (3093 jobs)
- Self-contained: imports only `Proofs.FeuerbachsTheoremDefs`
- Worked example: 3-4-5 triangle, I=(1,1), Iₐ=(6,6), I_b=(−3,3), I_c=(2,−2) → (6,8) = 4·(3/2,2) = 4·O

🤖 Generated with [Claude Code](https://claude.com/claude-code)