### PR TITLE
research(geometric-series-oq-08-oq-03-oq-01-oq-01): identifying the limit — the geometric sum (1−r)⁻¹ from first principles [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2626,6 +2626,7 @@ import Proofs.GeometricSeriesOQ08
 import Proofs.GeometricSeriesOQ08OQ01OQ01
 import Proofs.GeometricSeriesOQ08OQ03
 import Proofs.GeometricSeriesOQ08OQ03OQ01
+import Proofs.GeometricSeriesOQ08OQ03OQ01OQ01
 import Proofs.GeometricSeriesOQ09
 import Proofs.GeometricSeriesOQ10
 import Proofs.GnedenkoKolmogorov

--- a/proofs/Proofs/GeometricSeriesOQ08OQ03OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ08OQ03OQ01OQ01.lean
@@ -1,0 +1,125 @@
+import Proofs.GeometricSeriesOQ08OQ03OQ01
+import Mathlib.Tactic
+
+/-
+# Identifying the Limit: the Geometric Sum from First Principles
+
+## What This Proves
+
+The sibling entry `GeometricSeriesOQ08OQ03OQ01.lean` established that the partial
+sums `S n = ∑_{k<n} rᵏ` of the geometric series form a **`CauchySeq`** and that
+the series is **`Summable`**, both derived purely from the tail-block (slice)
+bound `rᵐ/(1 − r)` — deliberately *without* quoting the evaluated closed form
+`hasSum_geometric`. At that stage we knew the series converges, but the **value**
+of the limit was still open. This entry closes the arc: it pins the limit to the
+expected `(1 − r)⁻¹` and recovers `HasSum`/`tsum` from first principles.
+
+* `geometric_truncation_defect` — the elementary identity
+  `∑_{k<n} rᵏ = (1 − r)⁻¹ − rⁿ/(1 − r)`, a pure `geom_sum_eq` rearrangement
+  (finite-sum algebra, no analysis).
+* `geometric_partialSum_tendsto` — **the partial sums converge to `(1 − r)⁻¹`**:
+  the defect `rⁿ/(1 − r) → 0`, so `S n → (1 − r)⁻¹`.
+* `geometric_limit_from_completeness` — **the abstract route, made explicit**:
+  feed the sibling's `CauchySeq` into `cauchySeq_tendsto_of_complete` to obtain
+  *some* limit `L` from completeness of `ℝ` alone (existence before value), then
+  identify `L = (1 − r)⁻¹` by `tendsto_nhds_unique` against the defect limit. This
+  is exactly the question the sibling left open.
+* `geometric_hasSum` — **`HasSum (fun n ↦ rⁿ) (1 − r)⁻¹`**, assembled from the
+  sibling's `Summable` and the partial-sum limit via
+  `Summable.hasSum_iff_tendsto_nat`, with no appeal to `hasSum_geometric`.
+* `geometric_tsum` — the unconditional sum `∑' n, rⁿ = (1 − r)⁻¹`.
+
+## Why This Matters
+
+The lineage `oq-08-oq-03 → …-oq-01 → …-oq-01-oq-01` rebuilds the geometric series'
+convergence theory from the Cauchy criterion upward: first the `ε`–`N` block
+estimate, then the abstract `CauchySeq`/`Summable` predicates, and now the limit
+*value*. The completeness of `ℝ` supplies the existence of a limit knowing only
+that the partial sums are Cauchy; the truncation defect supplies its identity.
+Together they reproduce Mathlib's `hasSum_geometric_of_lt_one` /
+`tsum_geometric_of_lt_one` along an independent path that never assumes the
+closed form it concludes — the sum `(1 − r)⁻¹` is earned, not quoted.
+
+## Mathlib Relationship
+
+`geom_sum_eq`, `tendsto_pow_atTop_nhds_zero_of_lt_one`,
+`cauchySeq_tendsto_of_complete`, `tendsto_nhds_unique`, and
+`Summable.hasSum_iff_tendsto_nat` are Mathlib lemmas; the `CauchySeq`/`Summable`
+inputs are reused verbatim from the sibling entry. The content here is the
+deliberate identification of the limit through completeness + the truncation
+defect, recovering `hasSum_geometric` without invoking it.
+-/
+
+namespace GeometricSeriesOQ08OQ03OQ01OQ01
+
+open Finset Filter
+
+variable {r : ℝ}
+
+/-- **Truncation defect (algebraic form).** For `1 − r ≠ 0`, the `n`-th partial sum
+is the full limit `(1 − r)⁻¹` minus the tail factor `rⁿ/(1 − r)`. This is a pure
+rearrangement of the finite geometric sum `geom_sum_eq`; no analysis is used. -/
+theorem geometric_truncation_defect (h1r : (1 : ℝ) - r ≠ 0) (n : ℕ) :
+    ∑ k ∈ range n, r ^ k = (1 - r)⁻¹ - r ^ n / (1 - r) := by
+  have hr1 : r ≠ 1 := fun h => h1r (by rw [h]; ring)
+  have hr1' : r - 1 ≠ 0 := sub_ne_zero.mpr hr1
+  rw [geom_sum_eq hr1]
+  field_simp
+  ring
+
+/-- **The partial sums converge to `(1 − r)⁻¹`.** Reading the truncation defect as
+`n → ∞`: the tail `rⁿ/(1 − r)` tends to `0` (since `rⁿ → 0`), so the partial sums
+tend to `(1 − r)⁻¹`. Computed directly from the defect, not from `hasSum_geometric`. -/
+theorem geometric_partialSum_tendsto (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    Tendsto (fun n => ∑ k ∈ range n, r ^ k) atTop (nhds (1 - r)⁻¹) := by
+  have h1r : (1 : ℝ) - r ≠ 0 := (by linarith : (0 : ℝ) < 1 - r).ne'
+  have hzero : Tendsto (fun n => r ^ n / (1 - r)) atTop (nhds 0) := by
+    have hp : Tendsto (fun n => r ^ n) atTop (nhds 0) :=
+      tendsto_pow_atTop_nhds_zero_of_lt_one hr0 hr1
+    simpa using hp.div_const (1 - r)
+  have heq : (fun n => ∑ k ∈ range n, r ^ k)
+      = fun n => (1 - r)⁻¹ - r ^ n / (1 - r) :=
+    funext fun n => geometric_truncation_defect h1r n
+  rw [heq]
+  have hc : Tendsto (fun _ : ℕ => (1 - r)⁻¹) atTop (nhds (1 - r)⁻¹) := tendsto_const_nhds
+  simpa using hc.sub hzero
+
+/-- **The abstract route, completed.** Completeness of `ℝ` turns the sibling's
+`CauchySeq` into the existence of *some* limit `L` (value unknown); the truncation
+defect then forces `L = (1 − r)⁻¹` by uniqueness of limits. This answers the open
+question left by `GeometricSeriesOQ08OQ03OQ01`: existence is supplied by
+completeness, identity by the defect. -/
+theorem geometric_limit_from_completeness (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    ∃ L, Tendsto (fun n => ∑ k ∈ range n, r ^ k) atTop (nhds L) ∧ L = (1 - r)⁻¹ := by
+  obtain ⟨L, hL⟩ := cauchySeq_tendsto_of_complete
+    (GeometricSeriesOQ08OQ03OQ01.geometric_partialSum_cauchySeq hr0 hr1)
+  exact ⟨L, hL, tendsto_nhds_unique hL (geometric_partialSum_tendsto hr0 hr1)⟩
+
+/-- **`HasSum` recovered from first principles.** The sibling's `Summable` gives the
+`HasSum ↔ partial-sum convergence` bridge; the partial sums converge to `(1 − r)⁻¹`;
+hence `HasSum (fun n ↦ rⁿ) (1 − r)⁻¹` — an independent derivation of
+`hasSum_geometric_of_lt_one` that never invokes it. -/
+theorem geometric_hasSum (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    HasSum (fun n => r ^ n) (1 - r)⁻¹ :=
+  (GeometricSeriesOQ08OQ03OQ01.geometric_summable hr0 hr1).hasSum_iff_tendsto_nat.mpr
+    (geometric_partialSum_tendsto hr0 hr1)
+
+/-- **The unconditional sum.** `∑' n, rⁿ = (1 − r)⁻¹`, the value of the now-identified
+limit — recovering `tsum_geometric_of_lt_one` along the Cauchy/completeness path. -/
+theorem geometric_tsum (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    ∑' n : ℕ, r ^ n = (1 - r)⁻¹ :=
+  (geometric_hasSum hr0 hr1).tsum_eq
+
+/-! ## Concrete instance
+
+For `r = 1/2` the partial sums converge to `(1 − 1/2)⁻¹ = 2`, and `∑' n, (1/2)ⁿ = 2`. -/
+
+example : Tendsto (fun n => ∑ k ∈ range n, (1 / 2 : ℝ) ^ k) atTop (nhds 2) := by
+  have := geometric_partialSum_tendsto (r := 1 / 2) (by norm_num) (by norm_num)
+  norm_num at this; exact this
+
+example : ∑' n : ℕ, (1 / 2 : ℝ) ^ n = 2 := by
+  have := geometric_tsum (r := 1 / 2) (by norm_num) (by norm_num)
+  norm_num at this; exact this
+
+end GeometricSeriesOQ08OQ03OQ01OQ01

--- a/src/data/proofs/geometric-series-oq-08-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-03-oq-01-oq-01/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "geometric-series-oq-08-oq-03-oq-01-oq-01",
+  "slug": "geometric-series-oq-08-oq-03-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Proofs.GeometricSeriesOQ08OQ03OQ01",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "Filter"
+    ],
+    "namespace": "GeometricSeriesOQ08OQ03OQ01OQ01",
+    "lineCount": 125,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ08OQ03OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Identifying the Limit: the Geometric Sum from First Principles",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ08OQ03OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "cauchy-sequence",
+      "completeness",
+      "convergence",
+      "infinite-sum",
+      "limit-identification",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 125,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "geometric_truncation_defect: the algebraic defect identity ∑_{k<n} rᵏ = (1 − r)⁻¹ − rⁿ/(1 − r) for 1 − r ≠ 0, a pure geom_sum_eq rearrangement (finite-sum algebra, no analysis) — the head-vs-limit form that drives the limit identification.",
+      "geometric_partialSum_tendsto: the partial sums converge to (1 − r)⁻¹ — reading the truncation defect as n → ∞, the tail rⁿ/(1 − r) → 0 (from tendsto_pow_atTop_nhds_zero_of_lt_one), so n ↦ ∑_{k<n} rᵏ → (1 − r)⁻¹, computed directly from the defect rather than from hasSum_geometric.",
+      "geometric_limit_from_completeness: the abstract route made explicit, answering the open question of the sibling entry — completeness of ℝ (cauchySeq_tendsto_of_complete applied to the sibling's geometric_partialSum_cauchySeq) supplies the existence of some limit L knowing only that the partial sums are Cauchy, and tendsto_nhds_unique against the defect limit pins L = (1 − r)⁻¹. Existence is supplied by completeness, identity by the defect.",
+      "geometric_hasSum: HasSum (fun n ↦ rⁿ) (1 − r)⁻¹ assembled from the sibling's geometric_summable and the partial-sum limit via Summable.hasSum_iff_tendsto_nat — an independent derivation of hasSum_geometric_of_lt_one that never invokes it.",
+      "geometric_tsum: the unconditional sum ∑' n, rⁿ = (1 − r)⁻¹, recovering tsum_geometric_of_lt_one along the Cauchy/completeness path; the value is the consequence of the identified limit, not an input."
+    ],
+    "prerequisites": [
+      "geom_sum_eq (Mathlib): the finite geometric sum ∑_{i<n} xⁱ = (xⁿ − 1)/(x − 1) for x ≠ 1, behind the truncation defect",
+      "tendsto_pow_atTop_nhds_zero_of_lt_one (Mathlib): rⁿ → 0 for 0 ≤ r < 1, giving the vanishing tail",
+      "cauchySeq_tendsto_of_complete (Mathlib): a CauchySeq in a complete space converges to some limit — the existence half",
+      "tendsto_nhds_unique (Mathlib): uniqueness of limits in a Hausdorff space — pins the abstract limit to (1 − r)⁻¹",
+      "Summable.hasSum_iff_tendsto_nat (Mathlib): for a summable f over ℕ, HasSum f m ⇔ partial sums → m",
+      "Sibling: geometric-series-oq-08-oq-03-oq-01 (the CauchySeq and Summable reused verbatim as inputs)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "geom_sum_eq",
+        "description": "∑ i ∈ range n, xⁱ = (xⁿ − 1)/(x − 1) for x ≠ 1. Rearranged into the truncation defect (1 − r)⁻¹ − rⁿ/(1 − r).",
+        "module": "Mathlib.Algebra.Field.GeomSum"
+      },
+      {
+        "theorem": "tendsto_pow_atTop_nhds_zero_of_lt_one",
+        "description": "For 0 ≤ r < 1, rⁿ → 0 as n → ∞. Makes the truncation defect's tail rⁿ/(1 − r) vanish.",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "cauchySeq_tendsto_of_complete",
+        "description": "In a complete space, every CauchySeq converges to some limit. Turns the sibling's geometric_partialSum_cauchySeq into the existence of a limit L before its value is known.",
+        "module": "Mathlib.Topology.UniformSpace.Cauchy"
+      },
+      {
+        "theorem": "tendsto_nhds_unique",
+        "description": "Limits in a Hausdorff space are unique. Identifies the completeness limit L with the defect limit (1 − r)⁻¹.",
+        "module": "Mathlib.Topology.Separation.Hausdorff"
+      },
+      {
+        "theorem": "Summable.hasSum_iff_tendsto_nat",
+        "description": "For summable f : ℕ → M in a T2 commutative monoid, HasSum f m ⇔ Tendsto (fun n ↦ ∑ i ∈ range n, f i) atTop (𝓝 m). Converts the partial-sum limit into HasSum.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-08-oq-03-oq-01-oq-01-oq-01",
+      "question": "Extend the from-first-principles identification from the nonnegative range 0 ≤ r < 1 to the full signed disc |r| < 1 (real or normed field). The Cauchy/bounded-monotone lineage relied on nonnegativity (monotone partial sums, summable_of_sum_range_le); for signed r the partial sums oscillate, so recover summability by absolute convergence (summable_geometric_of_norm_lt_one / comparison ‖rⁿ‖ = ‖r‖ⁿ) and re-identify the limit (1 − r)⁻¹ via the same truncation defect, which is already field-valid.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-08-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent and source of inputs. That entry produced geometric_partialSum_cauchySeq and geometric_summable from the slice bound without hasSum_geometric, but left the limit value open. This entry consumes both, identifies the limit as (1 − r)⁻¹ via completeness + the truncation defect, and recovers HasSum/tsum — closing the open question it posed."
+    },
+    {
+      "targetId": "geometric-series-oq-08",
+      "relationship": "depends-on",
+      "description": "Grandparent. The truncation defect (1 − r)⁻¹ − ∑_{k<n} rᵏ = rⁿ/(1 − r) is exactly the head-vs-limit statement studied there; here it is the bridge that pins the abstract completeness limit to (1 − r)⁻¹."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "depends-on",
+      "description": "Base entry recording the closed forms (1 − rⁿ)/(1 − r) and (1 − r)⁻¹. This entry rederives the infinite value (1 − r)⁻¹ along the Cauchy/completeness path, routing around hasSum_geometric."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Topology.UniformSpace.Cauchy",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Provides cauchySeq_tendsto_of_complete, the completeness step turning the geometric partial sums' CauchySeq into a convergent sequence with an a-priori-unknown limit."
+    },
+    {
+      "title": "Principles of Mathematical Analysis (completeness, convergence of series)",
+      "author": "Walter Rudin",
+      "year": "1976",
+      "venue": "McGraw-Hill",
+      "description": "Standard reference for the principle that completeness turns a Cauchy sequence into a convergent one, with the limit then identified by separate computation — the structure this entry formalizes."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For 0 ≤ r < 1 the limit of the geometric series is identified as (1 − r)⁻¹ from first principles. The truncation defect ∑_{k<n} rᵏ = (1 − r)⁻¹ − rⁿ/(1 − r) (a geom_sum_eq rearrangement) gives geometric_partialSum_tendsto: the partial sums converge to (1 − r)⁻¹ because rⁿ/(1 − r) → 0. The sibling's geometric_partialSum_cauchySeq plus completeness of ℝ (cauchySeq_tendsto_of_complete) yield a limit L abstractly, which tendsto_nhds_unique pins to (1 − r)⁻¹ (geometric_limit_from_completeness). Combined with the sibling's geometric_summable via Summable.hasSum_iff_tendsto_nat this gives HasSum (fun n ↦ rⁿ) (1 − r)⁻¹ and ∑' n, rⁿ = (1 − r)⁻¹. 125 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This closes the lineage geometric-series-oq-08-oq-03 → …-oq-01 → …-oq-01-oq-01, which rebuilds the geometric series' convergence theory from the Cauchy criterion upward: first the ε–N block estimate, then the abstract CauchySeq/Summable predicates, and now the limit value. Completeness of ℝ supplies the existence of a limit knowing only that the partial sums are Cauchy; the truncation defect supplies its identity. Together they reproduce Mathlib's hasSum_geometric_of_lt_one and tsum_geometric_of_lt_one along an independent path that never assumes the closed form it concludes — the sum (1 − r)⁻¹ is earned, not quoted.",
+    "openQuestions": [
+      "Extend the from-first-principles limit identification from 0 ≤ r < 1 to the full signed disc |r| < 1, recovering summability by absolute convergence and re-identifying (1 − r)⁻¹ through the (already field-valid) truncation defect."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

The capstone of the `oq-08-oq-03 → …-oq-01 → …-oq-01-oq-01` lineage, which rebuilds the geometric series' convergence theory from the Cauchy criterion **without ever invoking `hasSum_geometric`**. The parent (`geometric-series-oq-08-oq-03-oq-01`, merged in #27371) established that the partial sums form a `CauchySeq` and that the series is `Summable`, but left the **limit value** open. This entry closes that open question: it identifies the limit as `(1 − r)⁻¹` and recovers `HasSum`/`tsum` from first principles.

For `0 ≤ r < 1`:

- **`geometric_truncation_defect`** — `∑_{k<n} rᵏ = (1 − r)⁻¹ − rⁿ/(1 − r)`, a pure `geom_sum_eq` rearrangement (finite-sum algebra, no analysis).
- **`geometric_partialSum_tendsto`** — the partial sums converge to `(1 − r)⁻¹`, since the tail `rⁿ/(1 − r) → 0`.
- **`geometric_limit_from_completeness`** — the abstract route, made explicit (and the literal answer to the parent's open question): completeness of `ℝ` (`cauchySeq_tendsto_of_complete` on the parent's `geometric_partialSum_cauchySeq`) yields *some* limit `L` from Cauchyness alone; `tendsto_nhds_unique` against the defect limit pins `L = (1 − r)⁻¹`. **Existence by completeness, identity by the defect.**
- **`geometric_hasSum` / `geometric_tsum`** — `HasSum (fun n ↦ rⁿ) (1 − r)⁻¹` and `∑' n, rⁿ = (1 − r)⁻¹`, via the parent's `geometric_summable` and `Summable.hasSum_iff_tendsto_nat`. An independent derivation of `hasSum_geometric_of_lt_one` / `tsum_geometric_of_lt_one` that never invokes them — the sum `(1 − r)⁻¹` is *earned*, not quoted.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ08OQ03OQ01OQ01` → **Build succeeded (3060 jobs)**
- `#print axioms` on `geometric_hasSum`, `geometric_tsum`, `geometric_limit_from_completeness` → only `[propext, Classical.choice, Quot.sound]`
- 125 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries
- Imports and reuses the parent module's `geometric_partialSum_cauchySeq` and `geometric_summable` verbatim (no duplication).

🤖 Generated with [Claude Code](https://claude.com/claude-code)