### PR TITLE
research: excentral triangle has circumradius 2R, circumcenter 2O − I [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2520,6 +2520,7 @@ import Proofs.FeuerbachsTheoremDefsOQ02
 import Proofs.FeuerbachsTheoremDefsOQ02OQ01
 import Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01
+import Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ03
 import Proofs.FeuerbachsTheoremDefsOQ04
 import Proofs.FeuerbachsTheoremOQ01

--- a/proofs/Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,553 @@
+/-
+  Feuerbach's Theorem DefsOQ02OQ01OQ01OQ01OQ01:
+  The excentral triangle has circumradius 2R and circumcenter 2O − I.
+
+  ## The Open Question
+
+  The sibling file `FeuerbachsTheoremDefsOQ02OQ01OQ01` proves the *affine*
+  relation among the four classical tritangent centres — the incentre I and the
+  three excentres I_a, I_b, I_c — namely that the circumcentre O is their
+  centroid,
+
+      I + I_a + I_b + I_c = 4·O.
+
+  That entry's first open question asks to prove *directly* the classical fact it
+  only cites: that **the excentral triangle I_a I_b I_c has circumradius 2R**,
+  twice the circumradius of the original triangle ABC, completing the
+  orthocentric-system picture whose nine-point centre the centroid identity
+  locates at O.  This file answers it.
+
+  ## What This File Proves
+
+  For an arbitrary non-degenerate triangle T, write O for the circumcentre, I for
+  the incentre, and define the **excentral circumcentre**
+
+      O' := 2·O − I        (`Triangle.excentralCircumcenter`).
+
+  ### The circumradius of the excentral triangle is 2R
+  `excentral_dist_a_sq`, `excentral_dist_b_sq`, `excentral_dist_c_sq` :
+      dist²(O', I_a) = dist²(O', I_b) = dist²(O', I_c) = 4·R².
+  Since one single point O' is equidistant (distance² = 4R²) from all three
+  excentres, O' is the circumcentre of the excentral triangle and its
+  circumradius is 2R.
+
+  `excentral_circumradius_a/b/c` and `excentral_circumradius_eq_two_R` :
+      dist(O', I_a) = dist(O', I_b) = dist(O', I_c) = 2·R   (the square-root form).
+
+  ### The nine-point relation
+  `circumcenter_is_excentral_ninePointCenter` :  O is the midpoint of I and O',
+      O = ½(I + O').
+  Together with `O' = 2O − I` being the excentral circumcentre and I the
+  orthocentre of the excentral triangle, this is exactly the statement that O is
+  the nine-point centre of the excentral triangle (whose nine-point circle is
+  therefore the circumcircle of ABC, of radius R = ½·2R).
+
+  ### Worked example
+  `triangle_345_excentral_circumradius` :  for the 3-4-5 triangle, O = (3/2,2),
+  I = (1,1), so O' = (2,3); and indeed dist²(O', I_a) = dist²(O', I_b) =
+  dist²(O', I_c) = 25 = 4·(5/2)² = 4R², with I_a=(6,6), I_b=(−3,3), I_c=(2,−2).
+
+  ## Method
+
+  The clean algebraic heart is that  I_a + I − 2O,  cleared over the common
+  denominator p_a·p_s = (−a+b+c)(a+b+c), is the O-shifted weighted vector
+      2·[ −a²·(A−O) + b(b+c)·(B−O) + c(b+c)·(C−O) ].
+  These weights w = (−a², b(b+c), c(b+c)) have the two miraculous properties
+      w_a + w_b + w_c = p_a·p_s        and        w_a w_b c² + w_b w_c a² + w_c w_a b² = 0,
+  both pure `ring` identities in the free side lengths.  Feeding them into the
+  reusable master identity
+      |w_a(A−O)+w_b(B−O)+w_c(C−O)|² = R²(w_a+w_b+w_c)² − (w_a w_b c²+w_b w_c a²+w_c w_a b²)
+  collapses the right-hand side to exactly R²·(p_a p_s)², so
+      dist²(O', I_a)·(p_a p_s)² = 4·R²·(p_a p_s)²,
+  and cancelling the (nonzero) factor gives dist²(O', I_a) = 4R².  The b- and
+  c-excentres are identical after the cyclic weight change
+  (a(a+c), −b², c(a+c)) and (a(a+b), b(a+b), −c²).
+
+  The squared-side, area- and side-positivity, strict-triangle-inequality
+  (needed to keep p_a, p_b, p_c nonzero) and circumcentre-equidistance lemmas,
+  and the master weighted-norm identity, are reproved locally, as the parent
+  declares them `private`.
+
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Proofs.FeuerbachsTheoremDefs
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace FeuerbachExcentralCircumradius
+
+open FeuerbachsTheorem
+open scoped Real
+
+/-- The **excentral circumcentre** O' = 2·O − I, the reflection of the incentre
+    in the circumcentre.  We prove it is the circumcentre of the excentral
+    triangle I_a I_b I_c, at distance 2R from each excentre. -/
+def _root_.FeuerbachsTheorem.Triangle.excentralCircumcenter (T : Triangle) : Point :=
+  (2 * T.circumcenter.1 - T.incenter.1, 2 * T.circumcenter.2 - T.incenter.2)
+
+-- ============================================================
+-- PART 1: Circumcentre equidistance (parent's are private)
+-- ============================================================
+
+/-- Squared distance is non-negative. -/
+private lemma dist2_sq_nonneg (P Q : Point) : 0 ≤ dist2_sq P Q := by
+  unfold dist2_sq; positivity
+
+set_option maxHeartbeats 6400000 in
+/-- Perpendicular bisector of AB passes through the circumcentre (linear in O). -/
+private lemma pb_AB (T : Triangle) :
+    (T.B.1 - T.A.1) * (T.B.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.B.2 - T.A.2) * (T.B.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+set_option maxHeartbeats 6400000 in
+/-- Perpendicular bisector of AC passes through the circumcentre. -/
+private lemma pb_AC (T : Triangle) :
+    (T.C.1 - T.A.1) * (T.C.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.C.2 - T.A.2) * (T.C.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := circumcenter_denom_ne_zero T
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]
+  field_simp [hd_ne]
+  ring
+
+/-- |B − O|² = |A − O|² : circumcentre equidistant from A and B. -/
+private lemma equidist_B (T : Triangle) :
+    (T.B.1 - T.circumcenter.1) ^ 2 + (T.B.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := pb_AB T
+  nlinarith [h, sq_nonneg (T.B.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.B.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+/-- |C − O|² = |A − O|² : circumcentre equidistant from A and C. -/
+private lemma equidist_C (T : Triangle) :
+    (T.C.1 - T.circumcenter.1) ^ 2 + (T.C.2 - T.circumcenter.2) ^ 2 =
+    (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  have h := pb_AC T
+  nlinarith [h, sq_nonneg (T.C.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.C.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
+
+-- ============================================================
+-- PART 2: Side lengths (squared values and positivity)
+-- ============================================================
+
+private lemma side_a_sq (T : Triangle) :
+    T.side_a ^ 2 = (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by
+  unfold Triangle.side_a; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_b_sq (T : Triangle) :
+    T.side_b ^ 2 = (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by
+  unfold Triangle.side_b; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_c_sq (T : Triangle) :
+    T.side_c ^ 2 = (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by
+  unfold Triangle.side_c; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_a_nonneg (T : Triangle) : 0 ≤ T.side_a := Real.sqrt_nonneg _
+private lemma side_b_nonneg (T : Triangle) : 0 ≤ T.side_b := Real.sqrt_nonneg _
+private lemma side_c_nonneg (T : Triangle) : 0 ≤ T.side_c := Real.sqrt_nonneg _
+
+/-- The triangle area is positive (non-degeneracy). -/
+private lemma area_pos (T : Triangle) : 0 < T.area := by
+  unfold Triangle.area
+  have hne := T.nondegenerate
+  have h : 0 < |(T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2)| :=
+    abs_pos.mpr hne
+  linarith
+
+private lemma side_a_pos (T : Triangle) : 0 < T.side_a := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.C.1 - T.B.1 = 0 := by nlinarith [sq_nonneg (T.C.1 - T.B.1), sq_nonneg (T.C.2 - T.B.2)]
+    have hy : T.C.2 - T.B.2 = 0 := by nlinarith [sq_nonneg (T.C.1 - T.B.1), sq_nonneg (T.C.2 - T.B.2)]
+    apply hne; linear_combination (T.B.1 - T.A.1) * hy - (T.B.2 - T.A.2) * hx
+  unfold Triangle.side_a; exact Real.sqrt_pos.mpr h
+
+private lemma side_b_pos (T : Triangle) : 0 < T.side_b := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.A.1 - T.C.1 = 0 := by nlinarith [sq_nonneg (T.A.1 - T.C.1), sq_nonneg (T.A.2 - T.C.2)]
+    have hy : T.A.2 - T.C.2 = 0 := by nlinarith [sq_nonneg (T.A.1 - T.C.1), sq_nonneg (T.A.2 - T.C.2)]
+    apply hne; linear_combination (T.B.2 - T.A.2) * hx - (T.B.1 - T.A.1) * hy
+  unfold Triangle.side_b; exact Real.sqrt_pos.mpr h
+
+private lemma side_c_pos (T : Triangle) : 0 < T.side_c := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.B.1 - T.A.1 = 0 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+    have hy : T.B.2 - T.A.2 = 0 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+    apply hne; linear_combination (T.C.2 - T.A.2) * hx - (T.C.1 - T.A.1) * hy
+  unfold Triangle.side_c; exact Real.sqrt_pos.mpr h
+
+private lemma perimeter_pos (T : Triangle) : 0 < T.side_a + T.side_b + T.side_c := by
+  have := side_a_pos T; have := side_b_pos T; have := side_c_pos T; linarith
+
+-- ============================================================
+-- PART 3: The strict triangle inequality  a < b + c
+-- ============================================================
+
+set_option maxHeartbeats 1600000 in
+private lemma strict_tri_ineq_a (T : Triangle) :
+    T.side_a < T.side_b + T.side_c := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hapos := side_a_pos T
+  have hbpos := side_b_pos T
+  have hcpos := side_c_pos T
+  set D := (T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2) with hDdef
+  set P := (T.A.1 - T.C.1) * (T.B.1 - T.A.1) + (T.A.2 - T.C.2) * (T.B.2 - T.A.2) with hPdef
+  have hDne : D ≠ 0 := T.nondegenerate
+  have hD2 : 0 < D ^ 2 := by
+    rcases hDne.lt_or_gt with h | h
+    · nlinarith [h]
+    · nlinarith [h]
+  have hexp : T.side_a ^ 2 = T.side_b ^ 2 + T.side_c ^ 2 + 2 * P := by
+    rw [ha, hb, hc, hPdef]; ring
+  have hlag : T.side_b ^ 2 * T.side_c ^ 2 - P ^ 2 = D ^ 2 := by
+    rw [hb, hc, hPdef, hDdef]; ring
+  have hP2 : P ^ 2 < (T.side_b * T.side_c) ^ 2 := by nlinarith [hlag, hD2]
+  have hbc : 0 < T.side_b * T.side_c := mul_pos hbpos hcpos
+  have hPlt : P < T.side_b * T.side_c := by nlinarith [hP2, hbc]
+  have hsum_pos : 0 < T.side_b + T.side_c := by linarith
+  have hasq : T.side_a ^ 2 < (T.side_b + T.side_c) ^ 2 := by nlinarith [hexp, hPlt]
+  nlinarith [hasq, hapos, hsum_pos]
+
+set_option maxHeartbeats 1600000 in
+private lemma strict_tri_ineq_b (T : Triangle) :
+    T.side_b < T.side_a + T.side_c := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hapos := side_a_pos T
+  have hbpos := side_b_pos T
+  have hcpos := side_c_pos T
+  set D := (T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2) with hDdef
+  set P := (T.C.1 - T.B.1) * (T.B.1 - T.A.1) + (T.C.2 - T.B.2) * (T.B.2 - T.A.2) with hPdef
+  have hDne : D ≠ 0 := T.nondegenerate
+  have hD2 : 0 < D ^ 2 := by
+    rcases hDne.lt_or_gt with h | h
+    · nlinarith [h]
+    · nlinarith [h]
+  have hexp : T.side_b ^ 2 = T.side_a ^ 2 + T.side_c ^ 2 + 2 * P := by
+    rw [ha, hb, hc, hPdef]; ring
+  have hlag : T.side_a ^ 2 * T.side_c ^ 2 - P ^ 2 = D ^ 2 := by
+    rw [ha, hc, hPdef, hDdef]; ring
+  have hP2 : P ^ 2 < (T.side_a * T.side_c) ^ 2 := by nlinarith [hlag, hD2]
+  have hac : 0 < T.side_a * T.side_c := mul_pos hapos hcpos
+  have hPlt : P < T.side_a * T.side_c := by nlinarith [hP2, hac]
+  have hsum_pos : 0 < T.side_a + T.side_c := by linarith
+  have hbsq : T.side_b ^ 2 < (T.side_a + T.side_c) ^ 2 := by nlinarith [hexp, hPlt]
+  nlinarith [hbsq, hbpos, hsum_pos]
+
+set_option maxHeartbeats 1600000 in
+private lemma strict_tri_ineq_c (T : Triangle) :
+    T.side_c < T.side_a + T.side_b := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hapos := side_a_pos T
+  have hbpos := side_b_pos T
+  have hcpos := side_c_pos T
+  set D := (T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2) with hDdef
+  set P := (T.C.1 - T.A.1) * (T.B.1 - T.C.1) + (T.C.2 - T.A.2) * (T.B.2 - T.C.2) with hPdef
+  have hDne : D ≠ 0 := T.nondegenerate
+  have hD2 : 0 < D ^ 2 := by
+    rcases hDne.lt_or_gt with h | h
+    · nlinarith [h]
+    · nlinarith [h]
+  have hexp : T.side_c ^ 2 = T.side_a ^ 2 + T.side_b ^ 2 + 2 * P := by
+    rw [ha, hb, hc, hPdef]; ring
+  have hlag : T.side_a ^ 2 * T.side_b ^ 2 - P ^ 2 = D ^ 2 := by
+    rw [ha, hb, hPdef, hDdef]; ring
+  have hP2 : P ^ 2 < (T.side_a * T.side_b) ^ 2 := by nlinarith [hlag, hD2]
+  have hab : 0 < T.side_a * T.side_b := mul_pos hapos hbpos
+  have hPlt : P < T.side_a * T.side_b := by nlinarith [hP2, hab]
+  have hsum_pos : 0 < T.side_a + T.side_b := by linarith
+  have hcsq : T.side_c ^ 2 < (T.side_a + T.side_b) ^ 2 := by nlinarith [hexp, hPlt]
+  nlinarith [hcsq, hcpos, hsum_pos]
+
+/-- Excentre denominators are strictly positive. -/
+private lemma pa_pos (T : Triangle) : 0 < -T.side_a + T.side_b + T.side_c := by
+  have := strict_tri_ineq_a T; linarith
+
+private lemma pb_pos (T : Triangle) : 0 < T.side_a - T.side_b + T.side_c := by
+  have := strict_tri_ineq_b T; linarith
+
+private lemma pc_pos (T : Triangle) : 0 < T.side_a + T.side_b - T.side_c := by
+  have := strict_tri_ineq_c T; linarith
+
+-- ============================================================
+-- PART 4: The reusable weighted-norm identity
+-- ============================================================
+
+/-- Master algebraic identity.  With O the circumcentre and R² = |A − O|², the
+    weighted vector  w_a(A−O) + w_b(B−O) + w_c(C−O)  has squared length
+        R²·(w_a+w_b+w_c)² − (w_a w_b c² + w_b w_c a² + w_c w_a b²). -/
+private lemma weighted_norm_sq_gen (T : Triangle) (wa wb wc : ℝ) :
+    (wa * (T.A.1 - T.circumcenter.1) + wb * (T.B.1 - T.circumcenter.1)
+        + wc * (T.C.1 - T.circumcenter.1)) ^ 2 +
+    (wa * (T.A.2 - T.circumcenter.2) + wb * (T.B.2 - T.circumcenter.2)
+        + wc * (T.C.2 - T.circumcenter.2)) ^ 2 =
+    ((T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2)
+        * (wa + wb + wc) ^ 2
+    - (wa * wb * T.side_c ^ 2 + wb * wc * T.side_a ^ 2 + wc * wa * T.side_b ^ 2) := by
+  set O := T.circumcenter
+  set R2 := (T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2 with hR2
+  have e1 : (T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2 = R2 := rfl
+  have e2 : (T.B.1 - O.1) ^ 2 + (T.B.2 - O.2) ^ 2 = R2 := by rw [hR2]; exact equidist_B T
+  have e3 : (T.C.1 - O.1) ^ 2 + (T.C.2 - O.2) ^ 2 = R2 := by rw [hR2]; exact equidist_C T
+  have dotAB : (T.A.1 - O.1) * (T.B.1 - O.1) + (T.A.2 - O.2) * (T.B.2 - O.2)
+      = R2 - T.side_c ^ 2 / 2 := by
+    have hc := side_c_sq T
+    linear_combination (1 / 2) * e1 + (1 / 2) * e2 + (1 / 2) * hc
+  have dotBC : (T.B.1 - O.1) * (T.C.1 - O.1) + (T.B.2 - O.2) * (T.C.2 - O.2)
+      = R2 - T.side_a ^ 2 / 2 := by
+    have ha := side_a_sq T
+    linear_combination (1 / 2) * e2 + (1 / 2) * e3 + (1 / 2) * ha
+  have dotCA : (T.C.1 - O.1) * (T.A.1 - O.1) + (T.C.2 - O.2) * (T.A.2 - O.2)
+      = R2 - T.side_b ^ 2 / 2 := by
+    have hb := side_b_sq T
+    linear_combination (1 / 2) * e3 + (1 / 2) * e1 + (1 / 2) * hb
+  linear_combination
+    wa ^ 2 * e1 + wb ^ 2 * e2 + wc ^ 2 * e3
+    + 2 * wa * wb * dotAB + 2 * wb * wc * dotBC + 2 * wc * wa * dotCA
+
+/-- R² = |A − O|² (circumradius squared, dropping the square root). -/
+private lemma circumradius_sq (T : Triangle) :
+    T.circumradius ^ 2 = (T.A.1 - T.circumcenter.1) ^ 2 + (T.A.2 - T.circumcenter.2) ^ 2 := by
+  unfold Triangle.circumradius dist2
+  rw [Real.sq_sqrt (by positivity)]
+
+private lemma circumradius_nonneg (T : Triangle) : 0 ≤ T.circumradius := by
+  unfold Triangle.circumradius dist2; exact Real.sqrt_nonneg _
+
+-- ============================================================
+-- PART 5: The excentral circumradius  dist²(O', I_x) = 4R²
+-- ============================================================
+
+/-- **The excentral circumradius, excentre a.**  The reflection O' = 2O − I of
+    the incentre in the circumcentre is at squared distance 4R² from the
+    A-excentre. -/
+theorem excentral_dist_a_sq (T : Triangle) :
+    dist2_sq T.excentralCircumcenter T.excenter_a = 4 * T.circumradius ^ 2 := by
+  rw [circumradius_sq]
+  unfold Triangle.excentralCircumcenter
+  set O := T.circumcenter with hO
+  set R2 := (T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2 with hR2
+  have hpa : -T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (pa_pos T)
+  have hP : T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (perimeter_pos T)
+  have hk : ((-T.side_a + T.side_b + T.side_c) * (T.side_a + T.side_b + T.side_c)) ^ 2 ≠ 0 :=
+    pow_ne_zero 2 (mul_ne_zero hpa hP)
+  -- clear denominators:  dist²·(p_a·p_s)² = 4·|weighted vector|²
+  have hI : dist2_sq (2 * O.1 - T.incenter.1, 2 * O.2 - T.incenter.2) T.excenter_a
+        * ((-T.side_a + T.side_b + T.side_c) * (T.side_a + T.side_b + T.side_c)) ^ 2
+      = 4 * (((-T.side_a ^ 2) * (T.A.1 - O.1)
+                + (T.side_b * (T.side_b + T.side_c)) * (T.B.1 - O.1)
+                + (T.side_c * (T.side_b + T.side_c)) * (T.C.1 - O.1)) ^ 2
+            + ((-T.side_a ^ 2) * (T.A.2 - O.2)
+                + (T.side_b * (T.side_b + T.side_c)) * (T.B.2 - O.2)
+                + (T.side_c * (T.side_b + T.side_c)) * (T.C.2 - O.2)) ^ 2) := by
+    unfold dist2_sq Triangle.excenter_a Triangle.incenter
+    dsimp only
+    field_simp
+    ring
+  have hmaster := weighted_norm_sq_gen T (-T.side_a ^ 2)
+    (T.side_b * (T.side_b + T.side_c)) (T.side_c * (T.side_b + T.side_c))
+  rw [← hO, ← hR2] at hmaster
+  have hcombine :
+      ((-T.side_a ^ 2) * (T.A.1 - O.1)
+            + (T.side_b * (T.side_b + T.side_c)) * (T.B.1 - O.1)
+            + (T.side_c * (T.side_b + T.side_c)) * (T.C.1 - O.1)) ^ 2
+        + ((-T.side_a ^ 2) * (T.A.2 - O.2)
+            + (T.side_b * (T.side_b + T.side_c)) * (T.B.2 - O.2)
+            + (T.side_c * (T.side_b + T.side_c)) * (T.C.2 - O.2)) ^ 2
+      = R2 * ((-T.side_a + T.side_b + T.side_c) * (T.side_a + T.side_b + T.side_c)) ^ 2 := by
+    rw [hmaster]; ring
+  apply mul_right_cancel₀ hk
+  rw [hI, hcombine]; ring
+
+/-- **The excentral circumradius, excentre b.** -/
+theorem excentral_dist_b_sq (T : Triangle) :
+    dist2_sq T.excentralCircumcenter T.excenter_b = 4 * T.circumradius ^ 2 := by
+  rw [circumradius_sq]
+  unfold Triangle.excentralCircumcenter
+  set O := T.circumcenter with hO
+  set R2 := (T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2 with hR2
+  have hpb : T.side_a - T.side_b + T.side_c ≠ 0 := ne_of_gt (pb_pos T)
+  have hP : T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (perimeter_pos T)
+  have hk : ((T.side_a - T.side_b + T.side_c) * (T.side_a + T.side_b + T.side_c)) ^ 2 ≠ 0 :=
+    pow_ne_zero 2 (mul_ne_zero hpb hP)
+  have hI : dist2_sq (2 * O.1 - T.incenter.1, 2 * O.2 - T.incenter.2) T.excenter_b
+        * ((T.side_a - T.side_b + T.side_c) * (T.side_a + T.side_b + T.side_c)) ^ 2
+      = 4 * (((T.side_a * (T.side_a + T.side_c)) * (T.A.1 - O.1)
+                + (-T.side_b ^ 2) * (T.B.1 - O.1)
+                + (T.side_c * (T.side_a + T.side_c)) * (T.C.1 - O.1)) ^ 2
+            + ((T.side_a * (T.side_a + T.side_c)) * (T.A.2 - O.2)
+                + (-T.side_b ^ 2) * (T.B.2 - O.2)
+                + (T.side_c * (T.side_a + T.side_c)) * (T.C.2 - O.2)) ^ 2) := by
+    unfold dist2_sq Triangle.excenter_b Triangle.incenter
+    dsimp only
+    field_simp
+    ring
+  have hmaster := weighted_norm_sq_gen T (T.side_a * (T.side_a + T.side_c))
+    (-T.side_b ^ 2) (T.side_c * (T.side_a + T.side_c))
+  rw [← hO, ← hR2] at hmaster
+  have hcombine :
+      ((T.side_a * (T.side_a + T.side_c)) * (T.A.1 - O.1)
+            + (-T.side_b ^ 2) * (T.B.1 - O.1)
+            + (T.side_c * (T.side_a + T.side_c)) * (T.C.1 - O.1)) ^ 2
+        + ((T.side_a * (T.side_a + T.side_c)) * (T.A.2 - O.2)
+            + (-T.side_b ^ 2) * (T.B.2 - O.2)
+            + (T.side_c * (T.side_a + T.side_c)) * (T.C.2 - O.2)) ^ 2
+      = R2 * ((T.side_a - T.side_b + T.side_c) * (T.side_a + T.side_b + T.side_c)) ^ 2 := by
+    rw [hmaster]; ring
+  apply mul_right_cancel₀ hk
+  rw [hI, hcombine]; ring
+
+/-- **The excentral circumradius, excentre c.** -/
+theorem excentral_dist_c_sq (T : Triangle) :
+    dist2_sq T.excentralCircumcenter T.excenter_c = 4 * T.circumradius ^ 2 := by
+  rw [circumradius_sq]
+  unfold Triangle.excentralCircumcenter
+  set O := T.circumcenter with hO
+  set R2 := (T.A.1 - O.1) ^ 2 + (T.A.2 - O.2) ^ 2 with hR2
+  have hpc : T.side_a + T.side_b - T.side_c ≠ 0 := ne_of_gt (pc_pos T)
+  have hP : T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (perimeter_pos T)
+  have hk : ((T.side_a + T.side_b - T.side_c) * (T.side_a + T.side_b + T.side_c)) ^ 2 ≠ 0 :=
+    pow_ne_zero 2 (mul_ne_zero hpc hP)
+  have hI : dist2_sq (2 * O.1 - T.incenter.1, 2 * O.2 - T.incenter.2) T.excenter_c
+        * ((T.side_a + T.side_b - T.side_c) * (T.side_a + T.side_b + T.side_c)) ^ 2
+      = 4 * (((T.side_a * (T.side_a + T.side_b)) * (T.A.1 - O.1)
+                + (T.side_b * (T.side_a + T.side_b)) * (T.B.1 - O.1)
+                + (-T.side_c ^ 2) * (T.C.1 - O.1)) ^ 2
+            + ((T.side_a * (T.side_a + T.side_b)) * (T.A.2 - O.2)
+                + (T.side_b * (T.side_a + T.side_b)) * (T.B.2 - O.2)
+                + (-T.side_c ^ 2) * (T.C.2 - O.2)) ^ 2) := by
+    unfold dist2_sq Triangle.excenter_c Triangle.incenter
+    dsimp only
+    field_simp
+    ring
+  have hmaster := weighted_norm_sq_gen T (T.side_a * (T.side_a + T.side_b))
+    (T.side_b * (T.side_a + T.side_b)) (-T.side_c ^ 2)
+  rw [← hO, ← hR2] at hmaster
+  have hcombine :
+      ((T.side_a * (T.side_a + T.side_b)) * (T.A.1 - O.1)
+            + (T.side_b * (T.side_a + T.side_b)) * (T.B.1 - O.1)
+            + (-T.side_c ^ 2) * (T.C.1 - O.1)) ^ 2
+        + ((T.side_a * (T.side_a + T.side_b)) * (T.A.2 - O.2)
+            + (T.side_b * (T.side_a + T.side_b)) * (T.B.2 - O.2)
+            + (-T.side_c ^ 2) * (T.C.2 - O.2)) ^ 2
+      = R2 * ((T.side_a + T.side_b - T.side_c) * (T.side_a + T.side_b + T.side_c)) ^ 2 := by
+    rw [hmaster]; ring
+  apply mul_right_cancel₀ hk
+  rw [hI, hcombine]; ring
+
+-- ============================================================
+-- PART 6: The square-root form  dist(O', I_x) = 2R
+-- ============================================================
+
+/-- **Excentral circumradius (distance form), excentre a:** dist(O', I_a) = 2R. -/
+theorem excentral_circumradius_a (T : Triangle) :
+    dist2 T.excentralCircumcenter T.excenter_a = 2 * T.circumradius := by
+  have h := excentral_dist_a_sq T
+  have hR := circumradius_nonneg T
+  rw [show dist2 T.excentralCircumcenter T.excenter_a
+        = Real.sqrt (dist2_sq T.excentralCircumcenter T.excenter_a) from rfl,
+      h, show (4 : ℝ) * T.circumradius ^ 2 = (2 * T.circumradius) ^ 2 by ring,
+      Real.sqrt_sq (by linarith)]
+
+/-- **Excentral circumradius (distance form), excentre b:** dist(O', I_b) = 2R. -/
+theorem excentral_circumradius_b (T : Triangle) :
+    dist2 T.excentralCircumcenter T.excenter_b = 2 * T.circumradius := by
+  have h := excentral_dist_b_sq T
+  have hR := circumradius_nonneg T
+  rw [show dist2 T.excentralCircumcenter T.excenter_b
+        = Real.sqrt (dist2_sq T.excentralCircumcenter T.excenter_b) from rfl,
+      h, show (4 : ℝ) * T.circumradius ^ 2 = (2 * T.circumradius) ^ 2 by ring,
+      Real.sqrt_sq (by linarith)]
+
+/-- **Excentral circumradius (distance form), excentre c:** dist(O', I_c) = 2R. -/
+theorem excentral_circumradius_c (T : Triangle) :
+    dist2 T.excentralCircumcenter T.excenter_c = 2 * T.circumradius := by
+  have h := excentral_dist_c_sq T
+  have hR := circumradius_nonneg T
+  rw [show dist2 T.excentralCircumcenter T.excenter_c
+        = Real.sqrt (dist2_sq T.excentralCircumcenter T.excenter_c) from rfl,
+      h, show (4 : ℝ) * T.circumradius ^ 2 = (2 * T.circumradius) ^ 2 by ring,
+      Real.sqrt_sq (by linarith)]
+
+/-- **The excentral triangle has circumradius 2R.**  The point O' = 2O − I is
+    equidistant — at distance exactly 2R — from all three excentres, hence is the
+    circumcentre of the excentral triangle I_a I_b I_c, whose circumradius is
+    therefore twice that of ABC. -/
+theorem excentral_circumradius_eq_two_R (T : Triangle) :
+    dist2 T.excentralCircumcenter T.excenter_a = 2 * T.circumradius ∧
+    dist2 T.excentralCircumcenter T.excenter_b = 2 * T.circumradius ∧
+    dist2 T.excentralCircumcenter T.excenter_c = 2 * T.circumradius :=
+  ⟨excentral_circumradius_a T, excentral_circumradius_b T, excentral_circumradius_c T⟩
+
+-- ============================================================
+-- PART 7: The nine-point relation  O = ½(I + O')
+-- ============================================================
+
+/-- **O is the nine-point centre of the excentral triangle.**  The circumcentre
+    is the midpoint of the incentre I (the orthocentre of the excentral triangle)
+    and the excentral circumcentre O' — the defining relation of the nine-point
+    centre.  Hence the nine-point circle of I_a I_b I_c is the circumcircle of
+    ABC (its radius R is half the excentral circumradius 2R). -/
+theorem circumcenter_is_excentral_ninePointCenter (T : Triangle) :
+    T.circumcenter.1 = (T.incenter.1 + T.excentralCircumcenter.1) / 2 ∧
+    T.circumcenter.2 = (T.incenter.2 + T.excentralCircumcenter.2) / 2 := by
+  unfold Triangle.excentralCircumcenter
+  refine ⟨?_, ?_⟩ <;> · dsimp only; ring
+
+-- ============================================================
+-- PART 8: Worked example — the 3-4-5 right triangle
+-- ============================================================
+
+/-- **Excentral circumradius for the 3-4-5 triangle.**  With O = (3/2,2),
+    I = (1,1), the excentral circumcentre is O' = (2,3), and its squared
+    distance to each excentre is 25 = 4·(5/2)² = 4R². -/
+theorem triangle_345_excentral_circumradius :
+    dist2_sq triangle_345.excentralCircumcenter triangle_345.excenter_a = 25 ∧
+    dist2_sq triangle_345.excentralCircumcenter triangle_345.excenter_b = 25 ∧
+    dist2_sq triangle_345.excentralCircumcenter triangle_345.excenter_c = 25 := by
+  have ha := excentral_dist_a_sq triangle_345
+  have hb := excentral_dist_b_sq triangle_345
+  have hc := excentral_dist_c_sq triangle_345
+  rw [triangle_345_circumradius] at ha hb hc
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ha]; norm_num
+  · rw [hb]; norm_num
+  · rw [hc]; norm_num
+
+end FeuerbachExcentralCircumradius

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,215 @@
+{
+  "id": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01",
+  "title": "The Excentral Triangle Has Circumradius 2R and Circumcenter 2O − I",
+  "slug": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01",
+  "description": "Direct proof of the classical fact cited by the centroid entry: the excentral triangle IₐI_bI_c — formed by the three excenters of a triangle ABC — has circumradius exactly 2R (twice that of ABC), and its circumcenter is the reflection O' = 2O − I of the incenter in the circumcenter. The single point O' = 2O − I is shown to be equidistant from all three excenters at squared distance 4R² (distance 2R), so it is the excentral circumcenter and 2R is the excentral circumradius. Combined with O being the midpoint of I and O', this places O as the nine-point center of the excentral triangle, completing the orthocentric-system picture whose centroid the sibling entry located at O (I + Iₐ + I_b + I_c = 4O). Answers the first open question posed by that entry. The proof reduces, for each excenter, to the reusable weighted-norm master identity with weights whose sum equals the product of denominators (−a+b+c)(a+b+c) and whose mixed cross-term vanishes identically — both pure ring facts — collapsing dist²(O',Iₐ)·(pₐp_s)² = 4R²·(pₐp_s)². 9 theorems (+ 25 supporting lemmas, 1 definition), 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
+    "tags": [
+      "geometry",
+      "feuerbach",
+      "euler",
+      "circumcenter",
+      "incenter",
+      "excenter",
+      "excentral-triangle",
+      "circumradius",
+      "orthocentric-system",
+      "nine-point-circle",
+      "barycentric",
+      "triangle-inequality",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the standard foundational axioms propext / Classical.choice / Quot.sound, which do not count as assumptions). Uses only the coordinate API (Point, Triangle, circumcenter, incenter, excenter_a/b/c, circumradius, area, side_a/b/c, dist2, dist2_sq, circumcenter_denom_ne_zero, triangle_345 with its side/incenter/circumcenter/circumradius lemmas) from FeuerbachsTheoremDefs.lean, which is itself 0-sorry, 0-axiom. The squared side lengths, side/area positivity, the strict triangle inequalities (declared private in the parent), the circumcenter equidistance lemmas, and the weighted-norm master identity are reproved locally; everything after the coordinate definitions is closed by ring / field_simp / linear_combination / nlinarith and the real square-root lemmas Real.sq_sqrt / Real.sqrt_sq.",
+    "lineCount": 553,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "originalContributions": [
+      "excentral_dist_a_sq / _b_sq / _c_sq: the squared excentral circumradius — dist²(O', Iₐ) = dist²(O', I_b) = dist²(O', I_c) = 4R² for the single point O' = 2O − I, so O' is equidistant from all three excenters and is therefore the circumcenter of the excentral triangle",
+      "excentral_circumradius_a / _b / _c and excentral_circumradius_eq_two_R: the square-root form dist(O', Iₐ) = dist(O', I_b) = dist(O', I_c) = 2R — the excentral triangle has circumradius exactly twice that of ABC",
+      "Triangle.excentralCircumcenter: the named center O' = 2O − I (the reflection of the incenter in the circumcenter), reusable triangle-center infrastructure",
+      "circumcenter_is_excentral_ninePointCenter: O = ½(I + O') — the circumcenter is the midpoint of the incenter and the excentral circumcenter, i.e. O is the nine-point center of the excentral triangle (whose nine-point circle is the circumcircle of ABC, radius R = ½·2R)",
+      "The weighted-collapse mechanism: Iₐ + I − 2O cleared over (−a+b+c)(a+b+c) is the O-shifted weighted vector 2[−a²(A−O)+b(b+c)(B−O)+c(b+c)(C−O)], whose weights satisfy wₐ+w_b+w_c = (−a+b+c)(a+b+c) and wₐw_b c²+w_b w_c a²+w_c wₐ b² = 0 (pure ring), collapsing the master identity to R²(pₐp_s)²",
+      "triangle_345_excentral_circumradius: worked example — for the 3-4-5 right triangle O'=(2,3) and dist²(O', Iₐ)=dist²(O', I_b)=dist²(O', I_c)=25=4·(5/2)²=4R²"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The three excenters of a triangle — the centers of the circles tangent to one side and the extensions of the other two — are the vertices of the excentral triangle, and the original triangle's incenter I is its orthocenter. Among the most elegant classical facts about this configuration is that the excentral triangle's circumcircle has radius exactly 2R, twice the circumradius of the base triangle, and its center is the reflection of the incenter in the circumcenter, O' = 2O − I. This is the metric counterpart of the affine fact proved by the sibling entry (I + Iₐ + I_b + I_c = 4O, the circumcenter is the centroid of the four tritangent centers): the four tritangent centers form an orthocentric system whose common nine-point circle is the circumcircle of ABC, so the nine-point center is O and the excentral circumradius is 2R. The present entry proves the 2R fact directly and analytically, by exhibiting a single point (O' = 2O − I) equidistant at distance 2R from all three excenters.",
+    "problemStatement": "For a non-degenerate triangle with circumcenter O, circumradius R, incenter I and excenters Iₐ, I_b, I_c, prove that the point O' = 2O − I satisfies\n$$\\mathrm{dist}(O', I_a) = \\mathrm{dist}(O', I_b) = \\mathrm{dist}(O', I_c) = 2R,$$\nso O' is the circumcenter of the excentral triangle IₐI_bI_c and its circumradius is 2R, and that O is the midpoint of I and O' (the nine-point center of the excentral triangle).",
+    "text": "A 553-line companion file. It reproves the side/area positivity, the strict triangle inequalities (keeping the excenter denominators −a+b+c, a−b+c, a+b−c nonzero), the circumcenter equidistance lemmas and the reusable weighted-norm master identity, then proves the three squared-distance identities dist²(O', I_x) = 4R², their square-root forms 2R, the nine-point midpoint relation, and the 3-4-5 worked example.",
+    "proofStrategy": "Work one excenter at a time and clear the two denominators (the excenter's and the incenter's perimeter denominator) against the master weighted-norm identity.\n- **Express the displacement as a weighted vector** (`hI`): in O-shifted coordinates, Iₐ + I − 2O cleared over the common denominator pₐ·p_s = (−a+b+c)(a+b+c) equals 2[−a²(A−O) + b(b+c)(B−O) + c(b+c)(C−O)]. This is a pure field_simp/ring identity once the incenter and excenter definitions are unfolded, because the O-terms cancel exactly when the weight sum equals the denominator product.\n- **The two weight miracles** (inside `hcombine`): the weights w = (−a², b(b+c), c(b+c)) satisfy wₐ+w_b+w_c = (−a+b+c)(a+b+c) = pₐ·p_s and the master identity's mixed term wₐw_b c² + w_b w_c a² + w_c wₐ b² = 0, both identities in the free side lengths closed by ring. Feeding them into the master identity |wₐ(A−O)+w_b(B−O)+w_c(C−O)|² = R²(wₐ+w_b+w_c)² − (wₐw_b c²+w_b w_c a²+w_c wₐ b²) collapses the right-hand side to exactly R²·(pₐp_s)².\n- **Cancel the common factor** (`mul_right_cancel₀`): combining the two gives dist²(O', Iₐ)·(pₐp_s)² = 4·R²·(pₐp_s)²; since (pₐp_s)² ≠ 0 (strict triangle inequality and positive perimeter), dist²(O', Iₐ) = 4R². The b- and c-excenters are identical after the cyclic weight change (a(a+c), −b², c(a+c)) and (a(a+b), b(a+b), −c²).\n- **Square roots and structure**: dist(O', I_x) = √(4R²) = 2R since R ≥ 0 (Real.sqrt_sq); and O = ½(I + O') is immediate from O' = 2O − I.",
+    "keyInsights": [
+      "One point does all the work: rather than computing the excentral circumcenter from scratch, the reflection O' = 2O − I is shown equidistant from all three excenters, which both identifies it as the circumcenter and gives the radius 2R in a single mechanism.",
+      "The displacement Iₐ + I − 2O is a weighted barycentric vector with weights (−a², b(b+c), c(b+c)); the cancellation of the circumcenter term O is exactly the statement that these weights sum to the denominator product (−a+b+c)(a+b+c), a free ring identity.",
+      "The mixed cross-term of the master identity vanishes identically for these weights — wₐw_b c²+w_b w_c a²+w_c wₐ b² = a²bc(b+c)·0 = 0 — so the squared length is purely R²(wₐ+w_b+w_c)², with no leftover side-length defect; this is why the radius comes out as a clean multiple of R.",
+      "This metric law (circumradius 2R) and the sibling's affine law (4O centroid) are the two halves of the orthocentric-system / nine-point picture: the four tritangent centers share a nine-point circle equal to the circumcircle of ABC, centered at O with radius R, half the excentral circumradius 2R.",
+      "The reflection O' = 2O − I sits on the line OI (the Euler-like line of the tritangent system) at twice the O-distance of I on the opposite side, the analytic shadow of O being the nine-point center (midpoint of orthocenter I and circumcenter O') of the excentral triangle."
+    ],
+    "prerequisites": [
+      "FeuerbachsTheoremDefs.lean — the coordinate API (Point, Triangle, circumcenter, incenter, excenter_a/b/c, circumradius, area, side_a/b/c, dist2, dist2_sq), the lemma circumcenter_denom_ne_zero, and the worked triangle_345 with its side/incenter/circumcenter/circumradius lemmas",
+      "The weighted-norm master identity |wₐ(A−O)+w_b(B−O)+w_c(C−O)|² = R²(Σw)² − (wₐw_b c²+⋯), reproved here from the circumcenter equidistance lemmas",
+      "ring, field_simp, linear_combination, nlinarith and the real square-root lemmas Real.sq_sqrt / Real.sqrt_sq over ℝ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports, Namespace, and the Excentral Circumcenter",
+      "startLine": 1,
+      "endLine": 91,
+      "summary": "Module docstring stating the excentral circumradius is 2R with circumcenter O' = 2O − I, imports only FeuerbachsTheoremDefs, opens FeuerbachsTheorem, and defines Triangle.excentralCircumcenter = (2O − I).",
+      "mathContext": "Self-contained on the base coordinate definitions: every analytic input is reproved locally, so the file depends only on FeuerbachsTheoremDefs."
+    },
+    {
+      "id": "equidistance",
+      "title": "Part I: Circumcenter Equidistance",
+      "startLine": 92,
+      "endLine": 149,
+      "summary": "dist2_sq_nonneg, the perpendicular-bisector identities pb_AB / pb_AC, and equidist_B / equidist_C (|B − O|² = |C − O|² = |A − O|²), reproved since the parent declares them private.",
+      "mathContext": "The circumcenter lies on the perpendicular bisectors of the sides, so it is equidistant from the three vertices; these supply the R² = |X − O|² facts the master identity needs."
+    },
+    {
+      "id": "positivity",
+      "title": "Part II: Squared Side Lengths and Positivity",
+      "startLine": 150,
+      "endLine": 213,
+      "summary": "Squared side lengths a² = |BC|² etc., positivity of each side and of the area, and positivity of the perimeter.",
+      "mathContext": "Each side is positive because the vertices are pairwise distinct; the area is positive by non-degeneracy."
+    },
+    {
+      "id": "triangleineq",
+      "title": "Part III: The Strict Triangle Inequalities",
+      "startLine": 214,
+      "endLine": 308,
+      "summary": "strict_tri_ineq_a/b/c (a < b+c and cyclic) and pa_pos/pb_pos/pc_pos (positivity of the excenter denominators −a+b+c, a−b+c, a+b−c).",
+      "mathContext": "Via the law of cosines a² = b²+c²+2P and the Lagrange identity b²c² − P² = D² with D the non-degeneracy determinant; D ≠ 0 gives P < bc, hence a < b+c. These keep the excenter denominators nonzero so the common factor (pₐp_s)² can be cancelled."
+    },
+    {
+      "id": "master",
+      "title": "Part IV: The Weighted-Norm Master Identity",
+      "startLine": 309,
+      "endLine": 353,
+      "summary": "weighted_norm_sq_gen: |wₐ(A−O)+w_b(B−O)+w_c(C−O)|² = R²(wₐ+w_b+w_c)² − (wₐw_b c²+w_b w_c a²+w_c wₐ b²); plus circumradius_sq (R² = |A−O|²) and circumradius_nonneg (R ≥ 0).",
+      "mathContext": "Expanding the squared weighted sum and substituting the three pairwise dot products ⟨X−O, Y−O⟩ = R² − (opposite side)²/2 (from equidistance and the squared sides) yields the closed form; specializing the weights selects each excenter."
+    },
+    {
+      "id": "squared",
+      "title": "Part V: The Excentral Circumradius dist²(O', I_x) = 4R²",
+      "startLine": 354,
+      "endLine": 474,
+      "summary": "excentral_dist_a_sq / _b_sq / _c_sq: for O' = 2O − I, the squared distance to each excenter is 4R². Each clears the displacement Iₐ + I − 2O over (pₐp_s)² into a weighted vector, applies the master identity, and cancels via the weight-sum and zero-cross-term ring identities.",
+      "mathContext": "The weights (−a², b(b+c), c(b+c)) (cyclically (a(a+c), −b², c(a+c)) and (a(a+b), b(a+b), −c²)) have sum pₓ·p_s and vanishing master cross-term, so |displacement|²·(pₓp_s)² = 4R²(pₓp_s)²."
+    },
+    {
+      "id": "distance",
+      "title": "Part VI: The Square-Root Form dist(O', I_x) = 2R",
+      "startLine": 475,
+      "endLine": 553,
+      "summary": "excentral_circumradius_a/b/c and the combined excentral_circumradius_eq_two_R: dist(O', I_x) = 2R; circumcenter_is_excentral_ninePointCenter: O = ½(I + O'); and triangle_345_excentral_circumradius: the 3-4-5 example with all three squared distances 25 = 4R².",
+      "mathContext": "dist = √(dist²) = √(4R²) = 2R since R ≥ 0 (Real.sqrt_sq); the midpoint relation is immediate from O' = 2O − I, and the example instantiates at triangle_345 via the general theorem and triangle_345_circumradius."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves directly that the excentral triangle IₐI_bI_c has circumradius 2R and circumcenter O' = 2O − I, by showing the single point O' = 2O − I is equidistant (distance 2R, squared distance 4R²) from all three excenters, for an arbitrary non-degenerate triangle. Establishes also that O is the midpoint of I and O' — the nine-point center of the excentral triangle — completing the orthocentric-system picture whose centroid the sibling entry placed at O. Answers the first open question of the centroid (4O) entry. 9 theorems (plus 25 supporting lemmas and 1 definition), 0 axioms, 0 sorries.",
+    "implications": "**The metric half of the tritangent picture**: together with the sibling's affine law I+Iₐ+I_b+I_c = 4O and the square-distance law OI²+OIₐ²+OI_b²+OI_c² = 12R², this completes the analytic description of the orthocentric system {I, Iₐ, I_b, I_c} — its common nine-point circle is the circumcircle of ABC (center O, radius R), and the excentral circumcircle (center O' = 2O − I, radius 2R) is its double.\n\n**A named triangle-center as gallery infrastructure**: Triangle.excentralCircumcenter = 2O − I is supplied as a 0-axiom coordinate definition together with its defining property (equidistant 2R from the excenters), reusable across the triangle-geometry strand.\n\n**The reflection mechanism**: the proof technique — reflecting a known center and verifying equidistance via the weighted-norm identity — generalizes to other circumcircle/incircle reflection problems in the same coordinate framework.",
+    "openQuestions": [
+      "Prove the incenter I is the orthocenter of the excentral triangle IₐI_bI_c directly (each tritangent center is the orthocenter of the other three): show ⟨Iₐ − I, I_b − I_c⟩ = 0 and cyclically, the dot-product fact underlying the orthocentric system and hence both the 4O centroid and the 2R circumradius laws.",
+      "Establish the excentral nine-point radius is R and identify the excentral nine-point center with O as a circle-tangency statement, closing the loop with the Feuerbach tangency of the nine-point circle to the incircle and excircles.",
+      "Compute the side lengths of the excentral triangle (IₐI_b, etc.) in terms of R and the angles, and verify the law of sines IₐI_b = 2·(2R)·sin(∠) consistent with the excentral circumradius 2R proved here."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "the affine law I + Iₐ + I_b + I_c = 4O (the circumcenter is the centroid of the four tritangent centers); this entry proves the metric companion it cites — the excentral circumradius is 2R with circumcenter 2O − I — directly answering that entry's first open question"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01",
+      "relationship": "related",
+      "description": "the square-distance law OI² + OIₐ² + OI_b² + OI_c² = 12R²; the three excenters whose common circumcircle (radius 2R) this entry locates are the same ones measured there"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-02-oq-01",
+      "relationship": "related",
+      "description": "the excenter Euler law OIₐ² = R² + 2Rrₐ; this entry reuses the same weighted-norm master identity to instead measure distances from the reflected center O' = 2O − I"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs",
+      "relationship": "extends",
+      "description": "uses the circumcenter, incenter, excenters, circumradius, area and side lengths defined in FeuerbachsTheoremDefs.lean, the lemma circumcenter_denom_ne_zero, and the worked triangle_345"
+    },
+    {
+      "targetId": "feuerbachs-theorem",
+      "relationship": "related",
+      "description": "the full Feuerbach theorem, whose nine-point circle is tangent to the incircle and all three excircles whose centers form the excentral triangle studied here"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
+    "namespace": "FeuerbachExcentralCircumradius",
+    "lineCount": 553,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "excentral_circumradius_eq_two_R",
+      "type": "core",
+      "description": "The excentral triangle has circumradius 2R: the point O' = 2O − I is at distance exactly 2R from all three excenters, so it is the circumcenter of the excentral triangle whose circumradius is twice that of ABC.",
+      "leanType": "∀ T : Triangle, dist2 T.excentralCircumcenter T.excenter_a = 2 * T.circumradius ∧ dist2 T.excentralCircumcenter T.excenter_b = 2 * T.circumradius ∧ dist2 T.excentralCircumcenter T.excenter_c = 2 * T.circumradius"
+    },
+    {
+      "name": "excentral_dist_a_sq",
+      "type": "core",
+      "description": "The squared excentral circumradius at excenter a: dist²(O', Iₐ) = 4R² for O' = 2O − I.",
+      "leanType": "∀ T : Triangle, dist2_sq T.excentralCircumcenter T.excenter_a = 4 * T.circumradius ^ 2"
+    },
+    {
+      "name": "excentral_dist_b_sq",
+      "type": "core",
+      "description": "The squared excentral circumradius at excenter b: dist²(O', I_b) = 4R².",
+      "leanType": "∀ T : Triangle, dist2_sq T.excentralCircumcenter T.excenter_b = 4 * T.circumradius ^ 2"
+    },
+    {
+      "name": "excentral_dist_c_sq",
+      "type": "core",
+      "description": "The squared excentral circumradius at excenter c: dist²(O', I_c) = 4R².",
+      "leanType": "∀ T : Triangle, dist2_sq T.excentralCircumcenter T.excenter_c = 4 * T.circumradius ^ 2"
+    },
+    {
+      "name": "circumcenter_is_excentral_ninePointCenter",
+      "type": "core",
+      "description": "O is the nine-point center of the excentral triangle: the circumcenter is the midpoint of the incenter I (the excentral orthocenter) and the excentral circumcenter O' = 2O − I.",
+      "leanType": "∀ T : Triangle, T.circumcenter.1 = (T.incenter.1 + T.excentralCircumcenter.1) / 2 ∧ T.circumcenter.2 = (T.incenter.2 + T.excentralCircumcenter.2) / 2"
+    },
+    {
+      "name": "triangle_345_excentral_circumradius",
+      "type": "example",
+      "description": "Worked example: for the 3-4-5 right triangle, O' = 2O − I = (2,3) and the squared distance to each excenter is 25 = 4·(5/2)² = 4R².",
+      "leanType": "dist2_sq triangle_345.excentralCircumcenter triangle_345.excenter_a = 25 ∧ dist2_sq triangle_345.excentralCircumcenter triangle_345.excenter_b = 25 ∧ dist2_sq triangle_345.excentralCircumcenter triangle_345.excenter_c = 25"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves directly that the **excentral triangle IₐI_bI_c has circumradius exactly 2R** (twice that of ABC), with circumcenter **O' = 2O − I** (the reflection of the incenter in the circumcenter). This answers the **first open question** posed by the centroid entry (#27372, `I + Iₐ + I_b + I_c = 4O`), which only cited this classical fact.

The single point O' = 2O − I is shown equidistant from all three excenters at squared distance **4R²** (distance 2R), so it is the excentral circumcenter and 2R the excentral circumradius. Combined with `O = ½(I + O')`, this places O as the **nine-point center of the excentral triangle** — completing the orthocentric-system picture whose centroid the sibling located at O.

## Method

For each excenter, `Iₐ + I − 2O` cleared over the common denominator `(−a+b+c)(a+b+c)` is the O-shifted weighted vector `2[−a²(A−O) + b(b+c)(B−O) + c(b+c)(C−O)]`. These weights have two miraculous (pure `ring`) properties:
- `wₐ + w_b + w_c = (−a+b+c)(a+b+c) = pₐ·p_s`
- mixed cross-term `wₐw_b c² + w_b w_c a² + w_c wₐ b² = 0`

Feeding them into the reusable weighted-norm master identity collapses its right side to exactly `R²·(pₐp_s)²`, so `dist²(O',Iₐ)·(pₐp_s)² = 4R²·(pₐp_s)²`; cancel the nonzero factor. The b/c excenters follow by the cyclic weight change `(a(a+c),−b²,c(a+c))` and `(a(a+b),b(a+b),−c²)`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01` → **Build succeeded (3093 jobs)**
- `#print axioms` on the main theorems → `[propext, Classical.choice, Quot.sound]` only (genuinely **0-axiom**, no `ofReduceBool`/`sorryAx`)
- 553 lines, **9 theorems** (+25 supporting lemmas, 1 definition), **0 sorries, 0 axioms**
- Worked example: 3-4-5 triangle, O'=(2,3), all three squared distances = 25 = 4·(5/2)² = 4R²

## Files

- `proofs/Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01.lean` (new, 553L, self-contained on `FeuerbachsTheoremDefs`)
- `proofs/Proofs.lean` (+1 import)
- `src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)