### PR TITLE
research(geometric-series-oq-07-oq-01-oq-01): Frobenius identity — moment numerator is the Eulerian polynomial [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2621,6 +2621,7 @@ import Proofs.GeometricSeriesOQ03
 import Proofs.GeometricSeriesOQ06
 import Proofs.GeometricSeriesOQ07
 import Proofs.GeometricSeriesOQ07OQ01
+import Proofs.GeometricSeriesOQ07OQ01OQ01
 import Proofs.GeometricSeriesOQ08
 import Proofs.GeometricSeriesOQ08OQ01OQ01
 import Proofs.GeometricSeriesOQ08OQ03

--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01.lean
@@ -1,0 +1,247 @@
+/-
+# Geometric series, open question oq-07-oq-01-oq-01:
+# The Eulerian polynomial and Frobenius' identity for the geometric moments
+
+The sibling entry `geometric-series-oq-07-oq-01` proves the all-orders moment
+
+  ∑_{n} nᵐ · rⁿ = ∑_{k=0}^{m} S(m,k) · k! · rᵏ / (1 - r)^{k+1}      (|r| < 1)
+
+where `S(m,k) = Nat.stirlingSecond m k`. Clearing the denominator `(1 - r)^{m+1}`
+turns the right-hand side into a single polynomial in `r`,
+
+  Nₘ(X) := ∑_{k=0}^{m} S(m,k) · k! · Xᵏ · (1 - X)^{m-k},
+
+the **Eulerian polynomial** in the "geometric" normalisation
+`∑_{n≥0} nᵐ Xⁿ = Nₘ(X) / (1 - X)^{m+1}`.  The first few are
+
+  N₀ = 1,   N₁ = X,   N₂ = X + X²,   N₃ = X + 4X² + X³,
+
+whose integer coefficients are the Eulerian numbers `⟨m,k⟩`.
+
+This entry answers the headline open question recorded on `oq-07`, `oq-10` and
+`oq-07-oq-01`: *identify the numerator with the Eulerian polynomial.*  We do this
+purely algebraically over an arbitrary commutative ring, with **no** appeal to the
+analytic moment formula:
+
+* `eulerPoly` is the Eulerian polynomial defined by its classical first-order
+  differential recurrence
+      `E₀ = 1`,   `E_{m+1} = X(1-X)·E'ₘ + (m+1)·X·Eₘ`.
+* `stirlingForm` is the Stirling closed form `Nₘ` above.
+* `eulerPoly_eq_stirlingForm` (Frobenius' identity) proves the two agree:
+  the differential recurrence and the Stirling sum define the *same* polynomial,
+  via the Stirling recurrence `S(m+1,k) = k·S(m,k) + S(m,k-1)`.
+* `eval_eulerPoly_one` gives the row sum `Eₘ(1) = m!` (sum of the Eulerian
+  numbers of order `m`).
+
+Finally, combining Frobenius with the imported analytic moment closed form
+(`GeometricSeriesOQ07OQ01.hasSum_pow_mul_geometric`) yields the compact
+generating identity
+
+  ∑_{n} nᵐ · rⁿ = Eₘ(r) / (1 - r)^{m+1}        (|r| < 1)      (`hasSum_pow_mul_geometric_eulerPoly`).
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and
+`sorry`-free.
+-/
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01
+
+namespace GeometricSeriesOQ07OQ01OQ01
+
+open Polynomial Finset Nat
+
+variable {R : Type*} [CommRing R]
+
+/-! ## Part 1: the two definitions of the Eulerian polynomial -/
+
+/-- The Eulerian polynomial, defined by its classical first-order differential
+recurrence (in the "geometric" normalisation):
+`E₀ = 1` and `E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ`. -/
+noncomputable def eulerPoly : ℕ → R[X]
+  | 0 => 1
+  | (m + 1) => X * (1 - X) * derivative (eulerPoly m) + (m + 1 : R[X]) * X * eulerPoly m
+
+@[simp] theorem eulerPoly_zero : (eulerPoly 0 : R[X]) = 1 := rfl
+
+theorem eulerPoly_succ (m : ℕ) :
+    (eulerPoly (m + 1) : R[X])
+      = X * (1 - X) * derivative (eulerPoly m) + (m + 1 : R[X]) * X * eulerPoly m := rfl
+
+/-- The Stirling closed form `Nₘ(X) = ∑_{k≤m} S(m,k)·k!·Xᵏ·(1-X)^{m-k}` (Frobenius'
+right-hand side). -/
+noncomputable def stirlingForm (m : ℕ) : R[X] :=
+  ∑ k ∈ range (m + 1),
+    (C ((stirlingSecond m k * k ! : ℕ) : R)) * X ^ k * (1 - X) ^ (m - k)
+
+/-! ## Part 2: Frobenius' identity `eulerPoly = stirlingForm` -/
+
+/-- The key per-term computation: multiplying the derivative of a single
+Stirling-form summand `C a · Xᵏ · (1-X)ᵖ` by `X·(1-X)` produces clean powers
+`Xᵏ` and `X^{k+1}` (no `X^{k-1}` boundary term), valid for all `k, p`. -/
+theorem key_term (a : R) (k p : ℕ) :
+    X * (1 - X) * derivative (C a * X ^ k * (1 - X) ^ p)
+      = C a * C ((k : ℕ) : R) * X ^ k * (1 - X) ^ (p + 1)
+        - C a * C ((p : ℕ) : R) * X ^ (k + 1) * (1 - X) ^ p := by
+  have hd : derivative ((1 - X : R[X]) ^ p) = - (C ((p : ℕ) : R) * (1 - X) ^ (p - 1)) := by
+    have h1 : (1 - X : R[X]) = -(X - C 1) := by rw [C_1]; ring
+    rw [h1, derivative_pow, derivative_neg, derivative_X_sub_C, ← h1]
+    ring
+  rw [derivative_mul, derivative_mul, derivative_C, hd, derivative_X_pow]
+  cases k with
+  | zero =>
+    cases p with
+    | zero => simp
+    | succ q => simp only [Nat.succ_sub_one, Nat.cast_zero, map_zero]; ring
+  | succ j =>
+    cases p with
+    | zero => simp only [Nat.succ_sub_one, Nat.cast_zero, map_zero]; ring
+    | succ q => simp only [Nat.succ_sub_one]; ring
+
+/-- The Stirling closed form satisfies the same differential recurrence as the
+Eulerian polynomial.  This is the algebraic heart of Frobenius' identity, proved
+from the Stirling recurrence `S(m+1,k+1) = (k+1)·S(m,k+1) + S(m,k)` together with
+the vanishing boundary values `S(m,m+1) = 0` and `S(m+1,0) = 0`. -/
+theorem stirlingForm_succ (m : ℕ) :
+    (stirlingForm (m + 1) : R[X])
+      = X * (1 - X) * derivative (stirlingForm m) + (m + 1 : R[X]) * X * stirlingForm m := by
+  -- `Qterm`, `Rterm`: the two halves of the canonical paired summand.
+  set Qterm : ℕ → R[X] := fun k =>
+    C ((stirlingSecond m k * k ! : ℕ) : R) * C ((k : ℕ) : R) * X ^ k * (1 - X) ^ (m + 1 - k)
+    with hQ
+  set Rterm : ℕ → R[X] := fun k =>
+    C ((stirlingSecond m k * k ! : ℕ) : R) * C (((k + 1 : ℕ)) : R) * X ^ (k + 1) * (1 - X) ^ (m - k)
+    with hR
+  set uterm : ℕ → R[X] := fun k =>
+    C (((k + 1) * stirlingSecond m (k + 1) * (k + 1)! : ℕ) : R) * X ^ (k + 1) * (1 - X) ^ (m - k)
+    with hu
+  -- STEP 1 : the right-hand side equals `∑ (Qterm k + Rterm k)`.
+  have hRHS :
+      X * (1 - X) * derivative (stirlingForm m) + (m + 1 : R[X]) * X * stirlingForm m
+        = ∑ k ∈ range (m + 1), (Qterm k + Rterm k) := by
+    rw [stirlingForm, derivative_sum, Finset.mul_sum, Finset.mul_sum, ← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro k hk
+    have hkm : k ≤ m := by simpa [Nat.lt_succ_iff] using hk
+    rw [key_term]
+    have e1 : (m - k) + 1 = m + 1 - k := by omega
+    -- `↑(m+1) = ↑(m-k) + ↑(k+1)` as polynomials, so `↑(m+1) - ↑(m-k) = ↑(k+1)`
+    have hsplit : ((m : R[X]) + 1) = C (((m - k : ℕ)) : R) + C (((k + 1 : ℕ)) : R) := by
+      rw [← map_add, ← Nat.cast_add, show m - k + (k + 1) = m + 1 from by omega, map_natCast]
+      push_cast
+      ring
+    simp only [hQ, hR]
+    rw [e1, hsplit]
+    ring
+  -- STEP 2 : `stirlingForm (m+1)` equals the same paired sum.
+  have hf0 : (C ((stirlingSecond (m + 1) 0 * 0 ! : ℕ) : R) * X ^ 0 * (1 - X) ^ (m + 1 - 0))
+      = 0 := by simp [stirlingSecond_succ_zero]
+  have hsplitf : ∀ k ∈ range (m + 1),
+      C ((stirlingSecond (m + 1) (k + 1) * (k + 1)! : ℕ) : R) * X ^ (k + 1)
+          * (1 - X) ^ (m + 1 - (k + 1))
+        = uterm k + Rterm k := by
+    intro k _
+    have e2 : m + 1 - (k + 1) = m - k := by omega
+    have hrec : stirlingSecond (m + 1) (k + 1)
+        = (k + 1) * stirlingSecond m (k + 1) + stirlingSecond m k := stirlingSecond_succ_succ m k
+    simp only [hu, hR]
+    rw [e2, hrec]
+    simp only [map_natCast]
+    push_cast [Nat.factorial_succ]
+    ring
+  have hLHS : (stirlingForm (m + 1) : R[X])
+      = (∑ k ∈ range (m + 1), uterm k) + ∑ k ∈ range (m + 1), Rterm k := by
+    rw [stirlingForm, Finset.sum_range_succ', hf0, add_zero]
+    rw [Finset.sum_congr rfl hsplitf, Finset.sum_add_distrib]
+  -- STEP 3 : `∑ uterm = ∑ Qterm`, via reindexing and the vanishing top term.
+  have hum : uterm m = 0 := by
+    simp only [hu]
+    rw [stirlingSecond_eq_zero_of_lt (Nat.lt_succ_self m)]
+    simp
+  have hQ0 : Qterm 0 = 0 := by simp [hQ]
+  have huQ : (∑ k ∈ range (m + 1), uterm k) = ∑ k ∈ range (m + 1), Qterm k := by
+    rw [Finset.sum_range_succ, hum, add_zero]
+    rw [Finset.sum_range_succ', hQ0, add_zero]
+    apply Finset.sum_congr rfl
+    intro k _
+    have e3 : m + 1 - (k + 1) = m - k := by omega
+    simp only [hu, hQ]
+    rw [e3]
+    simp only [map_natCast]
+    push_cast
+    ring
+  -- assemble
+  rw [hLHS, huQ, ← Finset.sum_add_distrib, hRHS]
+
+/-- **Frobenius' identity.**  The Eulerian polynomial (differential recurrence)
+equals the Stirling closed form. -/
+theorem eulerPoly_eq_stirlingForm (m : ℕ) :
+    (eulerPoly m : R[X]) = stirlingForm m := by
+  induction m with
+  | zero => simp [stirlingForm, stirlingSecond_zero]
+  | succ n ih =>
+      rw [eulerPoly_succ, ih, stirlingForm_succ]
+
+/-! ## Part 3: low-order values and the row sum -/
+
+theorem eulerPoly_one : (eulerPoly 1 : R[X]) = X := by
+  rw [eulerPoly_succ]; simp
+
+theorem eulerPoly_two : (eulerPoly 2 : R[X]) = X + X ^ 2 := by
+  rw [eulerPoly_succ, eulerPoly_one]
+  simp only [derivative_X]
+  push_cast
+  ring
+
+theorem eulerPoly_three : (eulerPoly 3 : R[X]) = X + 4 * X ^ 2 + X ^ 3 := by
+  rw [eulerPoly_succ, eulerPoly_two]
+  simp only [derivative_add, derivative_X, derivative_X_pow, map_natCast]
+  push_cast
+  ring
+
+/-- The row sum of the Eulerian numbers of order `m` is `m!`: `Eₘ(1) = m!`. -/
+theorem eval_eulerPoly_one (m : ℕ) : (eulerPoly m : R[X]).eval 1 = (m ! : R) := by
+  rw [eulerPoly_eq_stirlingForm, stirlingForm, eval_finset_sum]
+  rw [Finset.sum_eq_single m]
+  · simp [stirlingSecond_self]
+  · intro k hk hkm
+    have hkm' : k < m := by
+      have : k ≤ m := by simpa [Nat.lt_succ_iff] using hk
+      omega
+    have : (1 : R) - 1 = 0 := by ring
+    simp only [eval_mul, eval_pow, eval_sub, eval_X, eval_one, this]
+    rw [zero_pow (by omega : m - k ≠ 0)]
+    ring
+  · intro hm
+    simp at hm
+
+/-! ## Part 4: the moment generating identity over `ℝ` -/
+
+/-- **The geometric moment closed form via the Eulerian polynomial.**  Combining
+Frobenius' identity with the analytic moment formula
+`GeometricSeriesOQ07OQ01.hasSum_pow_mul_geometric` gives the compact statement
+
+  ∑_{n} nᵐ · rⁿ = Eₘ(r) / (1 - r)^{m+1}      (|r| < 1). -/
+theorem hasSum_pow_mul_geometric_eulerPoly (m : ℕ) {r : ℝ} (hr : |r| < 1) :
+    HasSum (fun n : ℕ => (n : ℝ) ^ m * r ^ n)
+      ((eulerPoly m : ℝ[X]).eval r / (1 - r) ^ (m + 1)) := by
+  have hr1 : (1 : ℝ) - r ≠ 0 := by
+    have : r < 1 := (abs_lt.mp hr).2
+    linarith
+  have hbase := GeometricSeriesOQ07OQ01.hasSum_pow_mul_geometric m hr
+  -- rewrite the imported sum value to `Eₘ(r)/(1-r)^{m+1}`
+  have hval :
+      (∑ k ∈ range (m + 1),
+          (stirlingSecond m k : ℝ) * k.factorial * r ^ k / (1 - r) ^ (k + 1))
+        = (eulerPoly m : ℝ[X]).eval r / (1 - r) ^ (m + 1) := by
+    rw [eulerPoly_eq_stirlingForm, stirlingForm, eval_finset_sum, Finset.sum_div]
+    apply Finset.sum_congr rfl
+    intro k hk
+    have hkm : k ≤ m := by simpa [Nat.lt_succ_iff] using hk
+    rw [eval_mul, eval_mul, eval_pow, eval_pow, eval_C, eval_X, eval_sub, eval_X, eval_one]
+    push_cast
+    rw [div_eq_div_iff (by positivity) (by positivity)]
+    rw [show m + 1 = (k + 1) + (m - k) by omega, pow_add]
+    ring
+  rw [← hval]
+  exact hbase
+
+end GeometricSeriesOQ07OQ01OQ01

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01",
+  "slug": "geometric-series-oq-07-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01"
+    ],
+    "opens": [
+      "Polynomial",
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01",
+    "lineCount": 247,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Frobenius' Identity: the Geometric Moment Numerator is the Eulerian Polynomial",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "eulerian-polynomial",
+      "stirling-numbers",
+      "frobenius-identity",
+      "worpitzky",
+      "polynomial",
+      "formal-derivative",
+      "generating-functions",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 247,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "badge": "original",
+    "originalContributions": [
+      "eulerPoly_eq_stirlingForm (Frobenius' identity): the Eulerian polynomial — defined by its classical first-order differential recurrence E₀ = 1, E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ — is equal, over any commutative ring, to the Stirling closed form ∑_{k=0}^{m} S(m,k)·k!·Xᵏ·(1-X)^{m-k}. This is exactly the numerator that the open question geometric-series-oq-07-oq-01-oq-01 asked to identify with the Eulerian polynomial. Mathlib has Stirling numbers but NO Eulerian numbers or polynomials and no Frobenius/Worpitzky identity, so both the Eulerian polynomial and the identity are built from scratch here.",
+      "stirlingForm_succ: the algebraic heart of the proof — the Stirling closed form Nₘ(X) = ∑_k S(m,k)·k!·Xᵏ·(1-X)^{m-k} satisfies the Eulerian differential recurrence N_{m+1} = X·(1-X)·N'ₘ + (m+1)·X·Nₘ. Proved by expanding the formal derivative term by term and matching against the Stirling recurrence S(m+1,k+1) = (k+1)·S(m,k+1) + S(m,k), with the boundary terms S(m,m+1) = 0 and S(m+1,0) = 0 vanishing. This is the bridge between the two definitions; it shows the differential recurrence and the surjection-count closed form generate the same polynomial sequence.",
+      "key_term: the per-summand derivative computation X·(1-X)·d/dX(C a·Xᵏ·(1-X)ᵖ) = C a·k·Xᵏ·(1-X)^{p+1} − C a·p·X^{k+1}·(1-X)ᵖ, with the X^{k-1} and (1-X)^{p-1} boundary terms cleared so the result has only the clean powers Xᵏ and X^{k+1}. A reusable lemma for formal-derivative manipulations of the Stirling/Eulerian basis.",
+      "eval_eulerPoly_one: the row-sum characterisation Eₘ(1) = m! (the Eulerian numbers of order m sum to m!), obtained by evaluating the Stirling form at X = 1 where every term except k = m vanishes through 0^{m-k}.",
+      "hasSum_pow_mul_geometric_eulerPoly: combining Frobenius' identity with the imported analytic moment closed form (GeometricSeriesOQ07OQ01.hasSum_pow_mul_geometric) yields the compact generating identity ∑_{n≥0} nᵐ·rⁿ = Eₘ(r)/(1-r)^{m+1} for |r| < 1 over ℝ — the single-fraction Eulerian-polynomial form anticipated by oq-07, oq-10 and oq-07-oq-01, replacing the per-order Stirling sum by one polynomial of degree m over (1-r)^{m+1}.",
+      "Low-order verification eulerPoly_one/two/three: E₁ = X, E₂ = X + X², E₃ = X + 4X² + X³, matching the Eulerian polynomials 1, X, X+X², X+4X²+X³ whose coefficients are the Eulerian numbers ⟨m,k⟩ = 1; 1,1; 1,4,1."
+    ],
+    "prerequisites": [
+      "Mathlib's Stirling numbers of the second kind Nat.stirlingSecond and the recurrence stirlingSecond_succ_succ, plus the boundary/vanishing lemmas stirlingSecond_succ_zero, stirlingSecond_self, stirlingSecond_eq_zero_of_lt",
+      "Mathlib's univariate polynomial formal derivative Polynomial.derivative and the lemmas derivative_mul, derivative_X_pow, derivative_pow, derivative_X_sub_C, derivative_C",
+      "Finset reindexing: Finset.sum_range_succ, Finset.sum_range_succ', Finset.sum_add_distrib, Finset.mul_sum",
+      "Parent: geometric-series-oq-07-oq-01 (the all-orders analytic moment ∑ nᵐ rⁿ = ∑ₖ S(m,k)·k!·rᵏ/(1−r)^{k+1}), whose theorem hasSum_pow_mul_geometric is imported for the moment corollary"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.stirlingSecond",
+        "description": "Stirling numbers of the second kind with the recurrence stirlingSecond_succ_succ (S(m+1,k+1)=(k+1)S(m,k+1)+S(m,k)), the boundary value stirlingSecond_succ_zero (S(m+1,0)=0), the diagonal stirlingSecond_self (S(n,n)=1) and the vanishing stirlingSecond_eq_zero_of_lt (S(m,k)=0 for m<k). These drive the induction matching the Stirling form to the Eulerian recurrence.",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Polynomial.derivative",
+        "description": "The univariate formal derivative as an R-linear map, with derivative_mul (Leibniz), derivative_X_pow (d/dX Xⁿ = n·X^{n-1}), derivative_pow, derivative_X_sub_C and derivative_C. Used to state the Eulerian differential recurrence and to compute the per-term derivative key_term.",
+        "module": "Mathlib.Algebra.Polynomial.Derivative"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07OQ01.hasSum_pow_mul_geometric",
+        "description": "The all-orders analytic moment ∑_{n≥0} nᵐ·rⁿ = ∑_{k=0}^{m} S(m,k)·k!·rᵏ/(1-r)^{k+1} for |r|<1 over ℝ (the parent entry). Imported and combined with Frobenius' identity to express the moment as Eₘ(r)/(1-r)^{m+1}.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+      "question": "Build the Eulerian numbers ⟨m,k⟩ explicitly via the combinatorial triangle recurrence ⟨m,k⟩ = (k+1)·⟨m-1,k⟩ + (m-k)·⟨m-1,k-1⟩ and prove that the coefficients of eulerPoly are exactly these integers — i.e. derive the triangle recurrence on coefficients from the differential recurrence by coefficient extraction. This upgrades the present 'differential-recurrence + closed-form' identification to the textbook combinatorial definition (descents of permutations).",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-02",
+      "question": "Prove the symmetry (palindromicity) of the Eulerian polynomial Eₘ(X) = X^{m+1}·Eₘ(1/X) for m ≥ 1, equivalently ⟨m,k⟩ = ⟨m,m-1-k⟩, directly from either the differential recurrence or the Stirling closed form.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01",
+      "relationship": "extends",
+      "description": "Parent. oq-07-oq-01 proves the analytic moment ∑ nᵐ rⁿ = ∑ₖ S(m,k)·k!·rᵏ/(1−r)^{k+1} and poses (as its open question oq-01) the identification of the (1-r)^{m+1}-cleared numerator with the Eulerian polynomial. This entry answers it: the numerator ∑_k S(m,k)·k!·rᵏ·(1-r)^{m-k} equals the Eulerian polynomial Eₘ(r) defined by the classical differential recurrence, giving the compact moment form Eₘ(r)/(1-r)^{m+1}."
+    },
+    {
+      "targetId": "geometric-series-oq-07",
+      "relationship": "sibling",
+      "description": "oq-07 (second moment ∑ n² rⁿ = r(1+r)/(1-r)³) and oq-10 (third moment, numerator r(1+4r+r²)) both recorded the same headline open question — write the general numerator as an Eulerian polynomial A_m(r)/(1-r)^{m+1}. This entry settles the algebraic core of that question for all m; the low orders E₂ = X+X², E₃ = X+4X²+X³ recover those numerators (up to the standard X-factor of the geometric normalisation)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Combinatorics.Enumerative.Stirling",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Nat.stirlingSecond and its recurrences. Mathlib has Stirling numbers of the second kind but no Eulerian numbers, polynomials, or Frobenius/Worpitzky identity — all supplied here."
+    },
+    {
+      "title": "Mathlib4: Algebra.Polynomial.Derivative",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the univariate formal derivative used to state the Eulerian differential recurrence and to compute the per-term derivative of the Stirling basis."
+    },
+    {
+      "title": "Concrete Mathematics (Eulerian numbers, Worpitzky's identity, Stirling numbers)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian numbers ⟨m,k⟩, the Eulerian polynomial, the row sum ∑_k ⟨m,k⟩ = m!, and the connection to Stirling numbers (Frobenius/Worpitzky)."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Over any commutative ring, the Eulerian polynomial Eₘ(X) — defined by the classical first-order differential recurrence E₀ = 1, E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ — equals the Stirling closed form ∑_{k=0}^{m} S(m,k)·k!·Xᵏ·(1-X)^{m-k} (Frobenius' identity, eulerPoly_eq_stirlingForm). The proof's core is stirlingForm_succ: the Stirling form satisfies the same differential recurrence, shown by a term-by-term formal-derivative computation (key_term) matched against the Stirling recurrence S(m+1,k+1) = (k+1)S(m,k+1)+S(m,k) with vanishing boundary terms. The row sum Eₘ(1) = m! follows by evaluating at X = 1, and the low orders E₁ = X, E₂ = X+X², E₃ = X+4X²+X³ match the Eulerian numbers 1; 1,1; 1,4,1. Combined with the parent's analytic moment formula, this gives the compact generating identity ∑_{n≥0} nᵐ·rⁿ = Eₘ(r)/(1-r)^{m+1} for |r| < 1. 247 lines, 10 theorems, 2 definitions, 0 axioms, 0 sorries; every result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Mathlib has Stirling numbers but no Eulerian numbers and no Frobenius/Worpitzky identity, so this is a genuine gap fill connecting two independently-defined polynomial families. The identification answers the recurring headline open question of the geometric-moment strand (oq-07, oq-10, oq-07-oq-01): the order-m moment of the geometric series is A_m(r)/(1-r)^{m+1} with A_m the Eulerian polynomial, a single degree-m numerator in place of the per-order Stirling sum. The differential recurrence and the surjection-count closed form S(m,k)·k! are shown to generate the same sequence, and the row sum m! exhibits the coefficients as a refinement of the m! permutations by descent count.",
+    "openQuestions": [
+      "Build the Eulerian numbers via the combinatorial triangle recurrence and prove the coefficients of eulerPoly are exactly these integers (the descent-statistic definition).",
+      "Prove the palindromic symmetry ⟨m,k⟩ = ⟨m,m-1-k⟩ of the Eulerian polynomial from the differential recurrence or the Stirling form."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **headline open question** recurring across the geometric-moment strand (`geometric-series-oq-07`, `oq-10`, and directly `oq-07-oq-01`'s open question #1): *identify the moment numerator with the Eulerian polynomial.*

The parent `oq-07-oq-01` proved the all-orders analytic moment
`∑ₙ nᵐ·rⁿ = ∑ₖ S(m,k)·k!·rᵏ/(1−r)^{k+1}` (|r|<1). Clearing `(1−r)^{m+1}` gives the single polynomial numerator `Nₘ(X) = ∑ₖ S(m,k)·k!·Xᵏ·(1−X)^{m−k}`. This entry proves, over **any commutative ring**, that this numerator is the **Eulerian polynomial**.

## What's proved (0-axiom, 0-sorry)

- **`eulerPoly`** — the Eulerian polynomial defined by its classical first-order differential recurrence `E₀ = 1`, `E_{m+1} = X(1−X)·E'ₘ + (m+1)·X·Eₘ` (Eulerian numbers/polynomials are **absent from Mathlib**).
- **`eulerPoly_eq_stirlingForm` (Frobenius' identity)** — `eulerPoly m = ∑ₖ S(m,k)·k!·Xᵏ·(1−X)^{m−k}`. The two independently-defined polynomial families coincide.
- **`stirlingForm_succ`** — the algebraic heart: the Stirling closed form satisfies the same differential recurrence, proved by a term-by-term formal-derivative computation (`key_term`) matched against the Stirling recurrence `S(m+1,k+1) = (k+1)S(m,k+1) + S(m,k)`, with boundary terms `S(m,m+1)=0`, `S(m+1,0)=0` vanishing.
- **`eval_eulerPoly_one`** — row sum `Eₘ(1) = m!`; low orders `E₁=X`, `E₂=X+X²`, `E₃=X+4X²+X³` match the Eulerian numbers `1; 1,1; 1,4,1`.
- **`hasSum_pow_mul_geometric_eulerPoly`** — combining Frobenius with the imported parent moment formula gives the compact identity `∑ₙ nᵐ·rⁿ = Eₘ(r)/(1−r)^{m+1}` for `|r|<1`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ07OQ01OQ01` → **succeeds** (7744 jobs).
- `#print axioms` on the two main theorems → `[propext, Classical.choice, Quot.sound]` only.
- 247 lines, 10 theorems, 2 definitions, 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)