### PR TITLE
research: the incenter is the orthocenter of the excentral triangle (orthocentric system) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2525,6 +2525,7 @@ import Proofs.FeuerbachsTheoremDefsOQ02OQ01
 import Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01
+import Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ03
 import Proofs.FeuerbachsTheoremDefsOQ04
 import Proofs.FeuerbachsTheoremOQ01

--- a/proofs/Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,408 @@
+/-
+  Feuerbach's Theorem DefsOQ02OQ01OQ01OQ01OQ01OQ01:
+  The incentre is the orthocentre of the excentral triangle
+  (the four tritangent centres form an orthocentric system).
+
+  ## The Open Question
+
+  The sibling file `FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01` proves that the
+  reflection O' = 2·O − I of the incentre in the circumcentre is the circumcentre
+  of the excentral triangle I_a I_b I_c, at distance 2R from each excentre, and
+  that O is the midpoint of I and O'.  That last fact *only makes sense* — it is
+  the nine-point relation — once one knows the missing ingredient that file's
+  narrative repeatedly *asserts but never proves*: that **the incentre I is the
+  orthocentre of the excentral triangle**.  This file supplies that proof.
+
+  ## What This File Proves
+
+  For an arbitrary non-degenerate triangle T with incentre I and excentres
+  I_a, I_b, I_c, the three internal angle bisectors of ABC — the lines I I_a,
+  I I_b, I I_c — are the three **altitudes** of the excentral triangle:
+
+  `incenter_altitude_perp_a` :  ⟨I_a − I, I_c − I_b⟩ = 0
+  `incenter_altitude_perp_b` :  ⟨I_b − I, I_c − I_a⟩ = 0
+  `incenter_altitude_perp_c` :  ⟨I_c − I, I_b − I_a⟩ = 0
+
+  Each says the line through the incentre I and one excentre is perpendicular to
+  the opposite side of the excentral triangle.  Since all three altitudes pass
+  through the single point I, they concur there:
+
+  `incenter_is_excentral_orthocenter` bundles the three — exactly the statement
+  that **I is the orthocentre of I_a I_b I_c**.
+
+  Equivalently the four points {I, I_a, I_b, I_c} form an **orthocentric system**:
+  the three pairs of opposite connectors
+      {I, I_a} ⟂ {I_b, I_c},   {I, I_b} ⟂ {I_a, I_c},   {I, I_c} ⟂ {I_a, I_b}
+  are mutually perpendicular, so each of the four points is the orthocentre of the
+  triangle formed by the other three.  Combined with the sibling's results — O' =
+  2O − I is the excentral circumcentre (circumradius 2R) and O = ½(I + O') is the
+  excentral nine-point centre — this completes the orthocentric-system picture:
+  the nine-point circle of the excentral triangle is the circumcircle of ABC.
+
+  ### Worked example
+  `triangle_345_orthocentric_system` :  for the 3-4-5 triangle, I = (1,1),
+  I_a = (6,6), I_b = (−3,3), I_c = (2,−2); and indeed
+      ⟨I_a−I, I_c−I_b⟩ = ⟨5,5⟩·⟨5,−5⟩ = 0,
+      ⟨I_b−I, I_c−I_a⟩ = ⟨−4,2⟩·⟨−4,−8⟩ = 0,
+      ⟨I_c−I, I_b−I_a⟩ = ⟨1,−3⟩·⟨−9,−3⟩ = 0.
+
+  ## Method
+
+  The heart is a one-line vector identity.  Writing the excentre-minus-incentre
+  difference over its common denominator,
+      I_a − I  =  2a·[ b·(B−A) + c·(C−A) ] / ((−a+b+c)(a+b+c)),
+  while the opposite excentral side, over its common denominator, is
+      I_c − I_b  =  2a·[ b·(B−A) − c·(C−A) ] / ((a+b−c)(a−b+c)).
+  With u := b·(B−A) and v := c·(C−A) these are proportional to u+v and u−v, so
+      ⟨I_a − I, I_c − I_b⟩  ∝  ⟨u+v, u−v⟩  =  |u|² − |v|²
+        =  b²·|B−A|²  −  c²·|C−A|²  =  b²c² − c²b²  =  0,
+  using only the *definitions* |B−A|² = c² and |C−A|² = b².  No deeper triangle
+  geometry is needed: perpendicularity of an internal bisector to the opposite
+  external-bisector chord is forced by the side-length weights alone.  The b- and
+  c-altitudes are the cyclic images.
+
+  Concretely each statement is proved by clearing the four tritangent-centre
+  denominators (`field_simp; ring`, a pure rational identity) to land on
+      4a²·( b²·|B−A|² − c²·|C−A|² ),
+  then substituting the squared-side definitions (`linear_combination`) to get 0,
+  and finally cancelling the nonzero denominator product.
+
+  The squared-side, positivity and strict-triangle-inequality lemmas (needed to
+  keep the excentre denominators nonzero) are reproved locally, as the parent
+  files declare them `private`.
+
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Proofs.FeuerbachsTheoremDefs
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace FeuerbachExcentralOrthocenter
+
+open FeuerbachsTheorem
+open scoped Real
+
+-- ============================================================
+-- PART 1: Squared side lengths and positivity (parent's are private)
+-- ============================================================
+
+private lemma side_a_sq (T : Triangle) :
+    T.side_a ^ 2 = (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by
+  unfold Triangle.side_a; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_b_sq (T : Triangle) :
+    T.side_b ^ 2 = (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by
+  unfold Triangle.side_b; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_c_sq (T : Triangle) :
+    T.side_c ^ 2 = (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by
+  unfold Triangle.side_c; rw [Real.sq_sqrt (by positivity)]
+
+private lemma side_a_pos (T : Triangle) : 0 < T.side_a := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.C.1 - T.B.1 = 0 := by nlinarith [sq_nonneg (T.C.1 - T.B.1), sq_nonneg (T.C.2 - T.B.2)]
+    have hy : T.C.2 - T.B.2 = 0 := by nlinarith [sq_nonneg (T.C.1 - T.B.1), sq_nonneg (T.C.2 - T.B.2)]
+    apply hne; linear_combination (T.B.1 - T.A.1) * hy - (T.B.2 - T.A.2) * hx
+  unfold Triangle.side_a; exact Real.sqrt_pos.mpr h
+
+private lemma side_b_pos (T : Triangle) : 0 < T.side_b := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.A.1 - T.C.1 = 0 := by nlinarith [sq_nonneg (T.A.1 - T.C.1), sq_nonneg (T.A.2 - T.C.2)]
+    have hy : T.A.2 - T.C.2 = 0 := by nlinarith [sq_nonneg (T.A.1 - T.C.1), sq_nonneg (T.A.2 - T.C.2)]
+    apply hne; linear_combination (T.B.2 - T.A.2) * hx - (T.B.1 - T.A.1) * hy
+  unfold Triangle.side_b; exact Real.sqrt_pos.mpr h
+
+private lemma side_c_pos (T : Triangle) : 0 < T.side_c := by
+  have hne := T.nondegenerate
+  have h : 0 < (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by
+    by_contra h
+    push_neg at h
+    have h0 : (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 = 0 := le_antisymm h (by positivity)
+    have hx : T.B.1 - T.A.1 = 0 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+    have hy : T.B.2 - T.A.2 = 0 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+    apply hne; linear_combination (T.C.2 - T.A.2) * hx - (T.C.1 - T.A.1) * hy
+  unfold Triangle.side_c; exact Real.sqrt_pos.mpr h
+
+private lemma perimeter_pos (T : Triangle) : 0 < T.side_a + T.side_b + T.side_c := by
+  have := side_a_pos T; have := side_b_pos T; have := side_c_pos T; linarith
+
+-- ============================================================
+-- PART 2: The strict triangle inequality  a < b + c
+-- ============================================================
+
+set_option maxHeartbeats 1600000 in
+private lemma strict_tri_ineq_a (T : Triangle) :
+    T.side_a < T.side_b + T.side_c := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hapos := side_a_pos T
+  have hbpos := side_b_pos T
+  have hcpos := side_c_pos T
+  set D := (T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2) with hDdef
+  set P := (T.A.1 - T.C.1) * (T.B.1 - T.A.1) + (T.A.2 - T.C.2) * (T.B.2 - T.A.2) with hPdef
+  have hDne : D ≠ 0 := T.nondegenerate
+  have hD2 : 0 < D ^ 2 := by
+    rcases hDne.lt_or_gt with h | h
+    · nlinarith [h]
+    · nlinarith [h]
+  have hexp : T.side_a ^ 2 = T.side_b ^ 2 + T.side_c ^ 2 + 2 * P := by
+    rw [ha, hb, hc, hPdef]; ring
+  have hlag : T.side_b ^ 2 * T.side_c ^ 2 - P ^ 2 = D ^ 2 := by
+    rw [hb, hc, hPdef, hDdef]; ring
+  have hP2 : P ^ 2 < (T.side_b * T.side_c) ^ 2 := by nlinarith [hlag, hD2]
+  have hbc : 0 < T.side_b * T.side_c := mul_pos hbpos hcpos
+  have hPlt : P < T.side_b * T.side_c := by nlinarith [hP2, hbc]
+  have hsum_pos : 0 < T.side_b + T.side_c := by linarith
+  have hasq : T.side_a ^ 2 < (T.side_b + T.side_c) ^ 2 := by nlinarith [hexp, hPlt]
+  nlinarith [hasq, hapos, hsum_pos]
+
+set_option maxHeartbeats 1600000 in
+private lemma strict_tri_ineq_b (T : Triangle) :
+    T.side_b < T.side_a + T.side_c := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hapos := side_a_pos T
+  have hbpos := side_b_pos T
+  have hcpos := side_c_pos T
+  set D := (T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2) with hDdef
+  set P := (T.C.1 - T.B.1) * (T.B.1 - T.A.1) + (T.C.2 - T.B.2) * (T.B.2 - T.A.2) with hPdef
+  have hDne : D ≠ 0 := T.nondegenerate
+  have hD2 : 0 < D ^ 2 := by
+    rcases hDne.lt_or_gt with h | h
+    · nlinarith [h]
+    · nlinarith [h]
+  have hexp : T.side_b ^ 2 = T.side_a ^ 2 + T.side_c ^ 2 + 2 * P := by
+    rw [ha, hb, hc, hPdef]; ring
+  have hlag : T.side_a ^ 2 * T.side_c ^ 2 - P ^ 2 = D ^ 2 := by
+    rw [ha, hc, hPdef, hDdef]; ring
+  have hP2 : P ^ 2 < (T.side_a * T.side_c) ^ 2 := by nlinarith [hlag, hD2]
+  have hac : 0 < T.side_a * T.side_c := mul_pos hapos hcpos
+  have hPlt : P < T.side_a * T.side_c := by nlinarith [hP2, hac]
+  have hsum_pos : 0 < T.side_a + T.side_c := by linarith
+  have hbsq : T.side_b ^ 2 < (T.side_a + T.side_c) ^ 2 := by nlinarith [hexp, hPlt]
+  nlinarith [hbsq, hbpos, hsum_pos]
+
+set_option maxHeartbeats 1600000 in
+private lemma strict_tri_ineq_c (T : Triangle) :
+    T.side_c < T.side_a + T.side_b := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hapos := side_a_pos T
+  have hbpos := side_b_pos T
+  have hcpos := side_c_pos T
+  set D := (T.B.1 - T.A.1) * (T.C.2 - T.A.2) - (T.C.1 - T.A.1) * (T.B.2 - T.A.2) with hDdef
+  set P := (T.C.1 - T.A.1) * (T.B.1 - T.C.1) + (T.C.2 - T.A.2) * (T.B.2 - T.C.2) with hPdef
+  have hDne : D ≠ 0 := T.nondegenerate
+  have hD2 : 0 < D ^ 2 := by
+    rcases hDne.lt_or_gt with h | h
+    · nlinarith [h]
+    · nlinarith [h]
+  have hexp : T.side_c ^ 2 = T.side_a ^ 2 + T.side_b ^ 2 + 2 * P := by
+    rw [ha, hb, hc, hPdef]; ring
+  have hlag : T.side_a ^ 2 * T.side_b ^ 2 - P ^ 2 = D ^ 2 := by
+    rw [ha, hb, hPdef, hDdef]; ring
+  have hP2 : P ^ 2 < (T.side_a * T.side_b) ^ 2 := by nlinarith [hlag, hD2]
+  have hab : 0 < T.side_a * T.side_b := mul_pos hapos hbpos
+  have hPlt : P < T.side_a * T.side_b := by nlinarith [hP2, hab]
+  have hsum_pos : 0 < T.side_a + T.side_b := by linarith
+  have hcsq : T.side_c ^ 2 < (T.side_a + T.side_b) ^ 2 := by nlinarith [hexp, hPlt]
+  nlinarith [hcsq, hcpos, hsum_pos]
+
+/-- Excentre denominators are strictly positive. -/
+private lemma pa_pos (T : Triangle) : 0 < -T.side_a + T.side_b + T.side_c := by
+  have := strict_tri_ineq_a T; linarith
+
+private lemma pb_pos (T : Triangle) : 0 < T.side_a - T.side_b + T.side_c := by
+  have := strict_tri_ineq_b T; linarith
+
+private lemma pc_pos (T : Triangle) : 0 < T.side_a + T.side_b - T.side_c := by
+  have := strict_tri_ineq_c T; linarith
+
+-- ============================================================
+-- PART 3: The three altitudes of the excentral triangle pass through I
+-- ============================================================
+
+set_option maxHeartbeats 4000000 in
+/-- **The A-altitude of the excentral triangle passes through I.**  The line
+    I I_a (the internal bisector from A) is perpendicular to the opposite side
+    I_b I_c of the excentral triangle:  ⟨I_a − I, I_c − I_b⟩ = 0. -/
+theorem incenter_altitude_perp_a (T : Triangle) :
+    (T.excenter_a.1 - T.incenter.1) * (T.excenter_c.1 - T.excenter_b.1)
+      + (T.excenter_a.2 - T.incenter.2) * (T.excenter_c.2 - T.excenter_b.2) = 0 := by
+  have hb := side_b_sq T
+  have hc := side_c_sq T
+  have hpa : -T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (pa_pos T)
+  have hP : T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (perimeter_pos T)
+  have hpb : T.side_a - T.side_b + T.side_c ≠ 0 := ne_of_gt (pb_pos T)
+  have hpc : T.side_a + T.side_b - T.side_c ≠ 0 := ne_of_gt (pc_pos T)
+  have hD : ((-T.side_a + T.side_b + T.side_c) * (T.side_a + T.side_b + T.side_c))
+            * ((T.side_a + T.side_b - T.side_c) * (T.side_a - T.side_b + T.side_c)) ≠ 0 :=
+    mul_ne_zero (mul_ne_zero hpa hP) (mul_ne_zero hpc hpb)
+  have hclear :
+      ((T.excenter_a.1 - T.incenter.1) * (T.excenter_c.1 - T.excenter_b.1)
+        + (T.excenter_a.2 - T.incenter.2) * (T.excenter_c.2 - T.excenter_b.2))
+        * (((-T.side_a + T.side_b + T.side_c) * (T.side_a + T.side_b + T.side_c))
+            * ((T.side_a + T.side_b - T.side_c) * (T.side_a - T.side_b + T.side_c)))
+      = 4 * T.side_a ^ 2 *
+          (T.side_b ^ 2 * ((T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2)
+            - T.side_c ^ 2 * ((T.C.1 - T.A.1) ^ 2 + (T.C.2 - T.A.2) ^ 2)) := by
+    unfold Triangle.incenter Triangle.excenter_a Triangle.excenter_b Triangle.excenter_c
+    dsimp only
+    field_simp
+    ring
+  have hzero : 4 * T.side_a ^ 2 *
+      (T.side_b ^ 2 * ((T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2)
+        - T.side_c ^ 2 * ((T.C.1 - T.A.1) ^ 2 + (T.C.2 - T.A.2) ^ 2)) = 0 := by
+    linear_combination (-4 * T.side_a ^ 2 * T.side_b ^ 2) * hc
+      + (4 * T.side_a ^ 2 * T.side_c ^ 2) * hb
+  have hprod := hclear.trans hzero
+  exact (mul_eq_zero.mp hprod).resolve_right hD
+
+set_option maxHeartbeats 4000000 in
+/-- **The B-altitude of the excentral triangle passes through I.**  The line
+    I I_b is perpendicular to the opposite side I_a I_c:  ⟨I_b − I, I_c − I_a⟩ = 0. -/
+theorem incenter_altitude_perp_b (T : Triangle) :
+    (T.excenter_b.1 - T.incenter.1) * (T.excenter_c.1 - T.excenter_a.1)
+      + (T.excenter_b.2 - T.incenter.2) * (T.excenter_c.2 - T.excenter_a.2) = 0 := by
+  have ha := side_a_sq T
+  have hc := side_c_sq T
+  have hpa : -T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (pa_pos T)
+  have hP : T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (perimeter_pos T)
+  have hpb : T.side_a - T.side_b + T.side_c ≠ 0 := ne_of_gt (pb_pos T)
+  have hpc : T.side_a + T.side_b - T.side_c ≠ 0 := ne_of_gt (pc_pos T)
+  have hD : ((T.side_a - T.side_b + T.side_c) * (T.side_a + T.side_b + T.side_c))
+            * ((T.side_a + T.side_b - T.side_c) * (-T.side_a + T.side_b + T.side_c)) ≠ 0 :=
+    mul_ne_zero (mul_ne_zero hpb hP) (mul_ne_zero hpc hpa)
+  have hclear :
+      ((T.excenter_b.1 - T.incenter.1) * (T.excenter_c.1 - T.excenter_a.1)
+        + (T.excenter_b.2 - T.incenter.2) * (T.excenter_c.2 - T.excenter_a.2))
+        * (((T.side_a - T.side_b + T.side_c) * (T.side_a + T.side_b + T.side_c))
+            * ((T.side_a + T.side_b - T.side_c) * (-T.side_a + T.side_b + T.side_c)))
+      = 4 * T.side_b ^ 2 *
+          (T.side_a ^ 2 * ((T.A.1 - T.B.1) ^ 2 + (T.A.2 - T.B.2) ^ 2)
+            - T.side_c ^ 2 * ((T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2)) := by
+    unfold Triangle.incenter Triangle.excenter_a Triangle.excenter_b Triangle.excenter_c
+    dsimp only
+    field_simp
+    ring
+  have hzero : 4 * T.side_b ^ 2 *
+      (T.side_a ^ 2 * ((T.A.1 - T.B.1) ^ 2 + (T.A.2 - T.B.2) ^ 2)
+        - T.side_c ^ 2 * ((T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2)) = 0 := by
+    linear_combination (-4 * T.side_a ^ 2 * T.side_b ^ 2) * hc
+      + (4 * T.side_b ^ 2 * T.side_c ^ 2) * ha
+  have hprod := hclear.trans hzero
+  exact (mul_eq_zero.mp hprod).resolve_right hD
+
+set_option maxHeartbeats 4000000 in
+/-- **The C-altitude of the excentral triangle passes through I.**  The line
+    I I_c is perpendicular to the opposite side I_a I_b:  ⟨I_c − I, I_b − I_a⟩ = 0. -/
+theorem incenter_altitude_perp_c (T : Triangle) :
+    (T.excenter_c.1 - T.incenter.1) * (T.excenter_b.1 - T.excenter_a.1)
+      + (T.excenter_c.2 - T.incenter.2) * (T.excenter_b.2 - T.excenter_a.2) = 0 := by
+  have ha := side_a_sq T
+  have hb := side_b_sq T
+  have hpa : -T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (pa_pos T)
+  have hP : T.side_a + T.side_b + T.side_c ≠ 0 := ne_of_gt (perimeter_pos T)
+  have hpb : T.side_a - T.side_b + T.side_c ≠ 0 := ne_of_gt (pb_pos T)
+  have hpc : T.side_a + T.side_b - T.side_c ≠ 0 := ne_of_gt (pc_pos T)
+  have hD : ((T.side_a + T.side_b - T.side_c) * (T.side_a + T.side_b + T.side_c))
+            * ((T.side_a - T.side_b + T.side_c) * (-T.side_a + T.side_b + T.side_c)) ≠ 0 :=
+    mul_ne_zero (mul_ne_zero hpc hP) (mul_ne_zero hpb hpa)
+  have hclear :
+      ((T.excenter_c.1 - T.incenter.1) * (T.excenter_b.1 - T.excenter_a.1)
+        + (T.excenter_c.2 - T.incenter.2) * (T.excenter_b.2 - T.excenter_a.2))
+        * (((T.side_a + T.side_b - T.side_c) * (T.side_a + T.side_b + T.side_c))
+            * ((T.side_a - T.side_b + T.side_c) * (-T.side_a + T.side_b + T.side_c)))
+      = 4 * T.side_c ^ 2 *
+          (T.side_a ^ 2 * ((T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2)
+            - T.side_b ^ 2 * ((T.B.1 - T.C.1) ^ 2 + (T.B.2 - T.C.2) ^ 2)) := by
+    unfold Triangle.incenter Triangle.excenter_a Triangle.excenter_b Triangle.excenter_c
+    dsimp only
+    field_simp
+    ring
+  have hzero : 4 * T.side_c ^ 2 *
+      (T.side_a ^ 2 * ((T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2)
+        - T.side_b ^ 2 * ((T.B.1 - T.C.1) ^ 2 + (T.B.2 - T.C.2) ^ 2)) = 0 := by
+    linear_combination (-4 * T.side_a ^ 2 * T.side_c ^ 2) * hb
+      + (4 * T.side_b ^ 2 * T.side_c ^ 2) * ha
+  have hprod := hclear.trans hzero
+  exact (mul_eq_zero.mp hprod).resolve_right hD
+
+-- ============================================================
+-- PART 4: I is the orthocentre of the excentral triangle
+-- ============================================================
+
+/-- **The incentre is the orthocentre of the excentral triangle.**  All three
+    altitudes of I_a I_b I_c — each the perpendicular from a vertex to the
+    opposite side — pass through the single point I, so they concur there.  This
+    is exactly the statement that I is the orthocentre of the excentral triangle,
+    and that {I, I_a, I_b, I_c} is an orthocentric system. -/
+theorem incenter_is_excentral_orthocenter (T : Triangle) :
+    (T.excenter_a.1 - T.incenter.1) * (T.excenter_c.1 - T.excenter_b.1)
+      + (T.excenter_a.2 - T.incenter.2) * (T.excenter_c.2 - T.excenter_b.2) = 0 ∧
+    (T.excenter_b.1 - T.incenter.1) * (T.excenter_c.1 - T.excenter_a.1)
+      + (T.excenter_b.2 - T.incenter.2) * (T.excenter_c.2 - T.excenter_a.2) = 0 ∧
+    (T.excenter_c.1 - T.incenter.1) * (T.excenter_b.1 - T.excenter_a.1)
+      + (T.excenter_c.2 - T.incenter.2) * (T.excenter_b.2 - T.excenter_a.2) = 0 :=
+  ⟨incenter_altitude_perp_a T, incenter_altitude_perp_b T, incenter_altitude_perp_c T⟩
+
+-- ============================================================
+-- PART 5: Worked example — the 3-4-5 right triangle
+-- ============================================================
+
+/-- A-excentre of the 3-4-5 triangle is (6, 6). -/
+theorem triangle_345_excenter_a : triangle_345.excenter_a = (6, 6) := by
+  unfold Triangle.excenter_a
+  simp only [triangle_345_side_a, triangle_345_side_b, triangle_345_side_c]
+  unfold triangle_345; simp only
+  exact Prod.ext (by norm_num) (by norm_num)
+
+/-- B-excentre of the 3-4-5 triangle is (−3, 3). -/
+theorem triangle_345_excenter_b : triangle_345.excenter_b = (-3, 3) := by
+  unfold Triangle.excenter_b
+  simp only [triangle_345_side_a, triangle_345_side_b, triangle_345_side_c]
+  unfold triangle_345; simp only
+  exact Prod.ext (by norm_num) (by norm_num)
+
+/-- C-excentre of the 3-4-5 triangle is (2, −2). -/
+theorem triangle_345_excenter_c : triangle_345.excenter_c = (2, -2) := by
+  unfold Triangle.excenter_c
+  simp only [triangle_345_side_a, triangle_345_side_b, triangle_345_side_c]
+  unfold triangle_345; simp only
+  exact Prod.ext (by norm_num) (by norm_num)
+
+/-- **Orthocentric system verified for the 3-4-5 triangle.**  With I = (1,1),
+    I_a = (6,6), I_b = (−3,3), I_c = (2,−2), the three pairs of opposite
+    connectors are mutually perpendicular, so I is the orthocentre of I_a I_b I_c. -/
+theorem triangle_345_orthocentric_system :
+    (triangle_345.excenter_a.1 - triangle_345.incenter.1)
+        * (triangle_345.excenter_c.1 - triangle_345.excenter_b.1)
+      + (triangle_345.excenter_a.2 - triangle_345.incenter.2)
+        * (triangle_345.excenter_c.2 - triangle_345.excenter_b.2) = 0 ∧
+    (triangle_345.excenter_b.1 - triangle_345.incenter.1)
+        * (triangle_345.excenter_c.1 - triangle_345.excenter_a.1)
+      + (triangle_345.excenter_b.2 - triangle_345.incenter.2)
+        * (triangle_345.excenter_c.2 - triangle_345.excenter_a.2) = 0 ∧
+    (triangle_345.excenter_c.1 - triangle_345.incenter.1)
+        * (triangle_345.excenter_b.1 - triangle_345.excenter_a.1)
+      + (triangle_345.excenter_c.2 - triangle_345.incenter.2)
+        * (triangle_345.excenter_b.2 - triangle_345.excenter_a.2) = 0 := by
+  rw [triangle_345_incenter, triangle_345_excenter_a, triangle_345_excenter_b,
+      triangle_345_excenter_c]
+  refine ⟨by norm_num, by norm_num, by norm_num⟩
+
+end FeuerbachExcentralOrthocenter

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,205 @@
+{
+  "id": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "title": "The Incenter Is the Orthocenter of the Excentral Triangle",
+  "slug": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "description": "Direct proof of the dot-product fact cited but never proved by the circumradius-2R entry: the incenter I is the orthocenter of the excentral triangle IₐI_bI_c, so the four tritangent centers {I, Iₐ, I_b, I_c} form an orthocentric system. The three internal angle bisectors of ABC — the lines I Iₐ, I I_b, I I_c — are the three altitudes of the excentral triangle, i.e. each is perpendicular to the opposite excentral side: ⟨Iₐ−I, I_c−I_b⟩ = ⟨I_b−I, I_c−Iₐ⟩ = ⟨I_c−I, I_b−Iₐ⟩ = 0. Since all three altitudes pass through I, they concur there, which is exactly the orthocenter statement. The proof rests on a one-line vector identity: written over its common denominator, Iₐ−I = 2a·[b(B−A)+c(C−A)]/((−a+b+c)(a+b+c)) while the opposite side I_c−I_b = 2a·[b(B−A)−c(C−A)]/((a+b−c)(a−b+c)), so with u = b(B−A), v = c(C−A) the inner product is proportional to ⟨u+v, u−v⟩ = |u|² − |v|² = b²·|B−A|² − c²·|C−A|² = b²c² − c²b² = 0, using only the definitions |B−A|² = c² and |C−A|² = b². Answers the first open question of the circumradius-2R entry. 8 theorems (+ 13 supporting lemmas), 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01OQ01.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
+    "tags": [
+      "geometry",
+      "feuerbach",
+      "incenter",
+      "excenter",
+      "excentral-triangle",
+      "orthocenter",
+      "orthocentric-system",
+      "angle-bisector",
+      "perpendicularity",
+      "nine-point-circle",
+      "barycentric",
+      "triangle-inequality",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the standard foundational axioms propext / Classical.choice / Quot.sound, which do not count as assumptions). Uses only the coordinate API (Point, Triangle, incenter, excenter_a/b/c, side_a/b/c, area, triangle_345 with its side/incenter lemmas) from FeuerbachsTheoremDefs.lean, which is itself 0-sorry, 0-axiom. The squared side lengths, side/area positivity and the strict triangle inequalities (declared private in the parent files) are reproved locally; everything else is closed by field_simp / ring / linear_combination / nlinarith and the real square-root lemma Real.sq_sqrt.",
+    "lineCount": 408,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "originalContributions": [
+      "incenter_altitude_perp_a / _b / _c: the three perpendicularity identities ⟨Iₐ−I, I_c−I_b⟩ = ⟨I_b−I, I_c−Iₐ⟩ = ⟨I_c−I, I_b−Iₐ⟩ = 0 — each says the line from the incenter through one excenter is perpendicular to the opposite side of the excentral triangle, i.e. the internal angle bisectors of ABC are the altitudes of IₐI_bI_c",
+      "incenter_is_excentral_orthocenter: bundles the three perpendicularities — all three altitudes of the excentral triangle pass through I, so they concur there and I is the orthocenter of IₐI_bI_c; equivalently {I, Iₐ, I_b, I_c} is an orthocentric system",
+      "The clearing mechanism: ⟨Iₐ−I, I_c−I_b⟩ cleared over the four tritangent denominators collapses to 4a²(b²·|B−A|² − c²·|C−A|²), a pure rational identity, which then vanishes by the squared-side definitions |B−A|²=c², |C−A|²=b² — no deeper triangle geometry needed, the perpendicularity is forced by the side-length weights alone",
+      "triangle_345_excenter_a / _b / _c: the explicit excenter coordinates (6,6), (−3,3), (2,−2) of the 3-4-5 right triangle",
+      "triangle_345_orthocentric_system: worked example — with I=(1,1), Iₐ=(6,6), I_b=(−3,3), I_c=(2,−2), the three pairs of opposite connectors are mutually perpendicular, so I is the orthocenter of the excentral triangle"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The three excenters of a triangle — the centers of the circles tangent to one side and the extensions of the other two — are the vertices of the excentral triangle, and one of the most elegant classical facts about this configuration is that the original triangle's incenter I is its orthocenter. The reason is purely about angle bisectors: at each vertex the internal and external bisectors are perpendicular, and the line joining I to an excenter is an internal bisector while the opposite side of the excentral triangle lies along external bisectors. Hence the three lines I Iₐ, I I_b, I I_c are the altitudes of the excentral triangle, concurring at I. This makes {I, Iₐ, I_b, I_c} an orthocentric system: each of the four tritangent centers is the orthocenter of the triangle formed by the other three, and the four points share a single nine-point circle. The sibling circumradius-2R entry repeatedly asserts 'I is the orthocenter of the excentral triangle' to justify its nine-point-center identification but never proves it; this entry supplies the missing proof, directly answering that entry's first open question.",
+    "problemStatement": "For a non-degenerate triangle ABC with incenter I and excenters Iₐ, I_b, I_c, prove that the three lines joining I to the excenters are the altitudes of the excentral triangle IₐI_bI_c, i.e.\n$$\\langle I_a - I,\\ I_c - I_b\\rangle = \\langle I_b - I,\\ I_c - I_a\\rangle = \\langle I_c - I,\\ I_b - I_a\\rangle = 0,$$\nso all three altitudes concur at I and I is the orthocenter of the excentral triangle (and {I, Iₐ, I_b, I_c} is an orthocentric system).",
+    "text": "A 408-line companion file. It reproves the squared side lengths, the side/area positivity and the strict triangle inequalities (keeping the excenter denominators −a+b+c, a−b+c, a+b−c nonzero), then proves the three perpendicularity identities, bundles them into the orthocenter statement, and verifies the 3-4-5 worked example with explicit excenter coordinates.",
+    "proofStrategy": "Each perpendicularity is proved by clearing denominators to a clean weighted form and then collapsing it with the squared-side definitions.\n- **Clear the four tritangent denominators** (`hclear`): unfolding the incenter and excenter coordinate definitions and clearing the four denominators (−a+b+c)(a+b+c)(a+b−c)(a−b+c) turns the inner product ⟨Iₐ−I, I_c−I_b⟩·(denominator product) into 4a²(b²·|B−A|² − c²·|C−A|²). This is a pure rational identity (field_simp; ring) — no side-length facts are used yet.\n- **The one-line vector reason**: over its common denominator Iₐ−I is proportional to u+v and the opposite side I_c−I_b to u−v, with u = b(B−A), v = c(C−A); so the inner product is proportional to ⟨u+v, u−v⟩ = |u|² − |v|², which is the 4a²(b²|B−A|² − c²|C−A|²) above.\n- **Collapse with the squared sides** (`hzero`, `linear_combination`): substituting |B−A|² = c² and |C−A|² = b² (the definitions of the side lengths) makes b²|B−A|² − c²|C−A|² = b²c² − c²b² = 0.\n- **Cancel the nonzero denominator** (`mul_eq_zero` / `resolve_right`): the denominator product is nonzero by the strict triangle inequalities and positive perimeter, so the inner product itself is 0. The b- and c-altitudes are the cyclic images, using the side pairs (|A−B|²=c², |C−B|²=a²) and (|A−C|²=b², |B−C|²=a²).",
+    "keyInsights": [
+      "Perpendicularity is forced by the side-length weights alone: ⟨Iₐ−I, I_c−I_b⟩ collapses to 4a²(b²|B−A|² − c²|C−A|²), which is zero purely because the two cross terms are b²c² and c²b² — no angle-chasing, no circumcenter, just the definitions of the side lengths.",
+      "The internal/external-bisector picture made algebraic: Iₐ−I = 2a(u+v)/D₁ and I_c−I_b = 2a(u−v)/D₂ with u = b(B−A), v = c(C−A); the inner product ⟨u+v, u−v⟩ = |u|² − |v|² is the analytic shadow of the internal bisector being perpendicular to the opposite external-bisector chord.",
+      "Three perpendicularities, one orthocentric system: ⟨I−Iₐ, I_b−I_c⟩, ⟨I−I_b, Iₐ−I_c⟩, ⟨I−I_c, Iₐ−I_b⟩ are the three pairs of opposite connectors of the complete quadrangle {I, Iₐ, I_b, I_c}; their mutual perpendicularity is exactly the orthocentric-system condition, so every one of the four points is the orthocenter of the other three.",
+      "This is the dot-product fact underlying both halves of the tritangent picture — the affine centroid law I+Iₐ+I_b+I_c = 4O and the metric circumradius-2R law — and it is precisely the open question the circumradius-2R entry left unproved while relying on it to call O the excentral nine-point center.",
+      "The proof is self-contained on the bare coordinate definitions: no circumcenter, no master norm identity, no nine-point machinery — only the incenter/excenter weighted averages and |B−A|² = c²."
+    ],
+    "prerequisites": [
+      "FeuerbachsTheoremDefs.lean — the coordinate API (Point, Triangle, incenter, excenter_a/b/c, side_a/b/c, area) and the worked triangle_345 with its side and incenter lemmas",
+      "The squared side lengths a² = |BC|² etc. and the strict triangle inequalities a < b+c (keeping the excenter denominators nonzero), reproved here from the non-degeneracy determinant via a Lagrange identity",
+      "field_simp, ring, linear_combination, nlinarith and the real square-root lemma Real.sq_sqrt over ℝ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Namespace",
+      "startLine": 1,
+      "endLine": 113,
+      "summary": "Module docstring stating that the incenter is the orthocenter of the excentral triangle (the tritangent centers form an orthocentric system), with the one-line vector reason; imports only FeuerbachsTheoremDefs and opens FeuerbachsTheorem.",
+      "mathContext": "Self-contained on the base coordinate definitions: every analytic input is reproved locally, so the file depends only on FeuerbachsTheoremDefs."
+    },
+    {
+      "id": "positivity",
+      "title": "Part I: Squared Side Lengths and Positivity",
+      "startLine": 114,
+      "endLine": 178,
+      "summary": "Squared side lengths a² = |BC|² etc. (side_a_sq/b/c), positivity of each side, and positivity of the perimeter — the facts needed to use the side definitions and to keep the excenter denominators nonzero.",
+      "mathContext": "Each side is positive because the vertices are pairwise distinct (non-degeneracy); the squared-side identities drop the Real.sqrt via Real.sq_sqrt."
+    },
+    {
+      "id": "triangleineq",
+      "title": "Part II: The Strict Triangle Inequalities",
+      "startLine": 179,
+      "endLine": 268,
+      "summary": "strict_tri_ineq_a/b/c (a < b+c and cyclic) and pa_pos/pb_pos/pc_pos (positivity of the excenter denominators −a+b+c, a−b+c, a+b−c).",
+      "mathContext": "Via the law of cosines a² = b²+c²+2P and the Lagrange identity b²c² − P² = D² with D the non-degeneracy determinant; D ≠ 0 gives P < bc, hence a < b+c, so the excenter denominators are strictly positive."
+    },
+    {
+      "id": "altitudes",
+      "title": "Part III: The Three Altitudes Pass Through I",
+      "startLine": 269,
+      "endLine": 384,
+      "summary": "incenter_altitude_perp_a/b/c: ⟨Iₐ−I, I_c−I_b⟩ = ⟨I_b−I, I_c−Iₐ⟩ = ⟨I_c−I, I_b−Iₐ⟩ = 0. Each clears the four tritangent denominators into 4a²(b²|B−A|² − c²|C−A|²) (cyclically), then collapses it with the squared-side definitions and cancels the nonzero denominator product.",
+      "mathContext": "The line from the incenter through one excenter is an internal angle bisector; the opposite side of the excentral triangle lies along external bisectors; internal and external bisectors at a vertex are perpendicular, which the side-length weights enforce algebraically."
+    },
+    {
+      "id": "orthocenter",
+      "title": "Part IV: I Is the Orthocenter of the Excentral Triangle",
+      "startLine": 385,
+      "endLine": 399,
+      "summary": "incenter_is_excentral_orthocenter bundles the three perpendicularities: all three altitudes of the excentral triangle pass through the single point I, so they concur there and I is its orthocenter; equivalently {I, Iₐ, I_b, I_c} is an orthocentric system.",
+      "mathContext": "Concurrence of the three altitudes at one point is the definition of the orthocenter; that the common point is the incenter is exactly the orthocentric-system property of the four tritangent centers."
+    },
+    {
+      "id": "example",
+      "title": "Part V: Worked Example — the 3-4-5 Right Triangle",
+      "startLine": 400,
+      "endLine": 408,
+      "summary": "triangle_345_excenter_a/b/c give the excenter coordinates (6,6), (−3,3), (2,−2); triangle_345_orthocentric_system verifies the three perpendicularities for I=(1,1), confirming I is the orthocenter of the excentral triangle.",
+      "mathContext": "Instantiates the general perpendicularity at the integer-sided 3-4-5 triangle, where all side lengths and centers are rational so the dot products evaluate by norm_num."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves directly that the incenter I is the orthocenter of the excentral triangle IₐI_bI_c: the three lines joining I to the excenters are the altitudes of the excentral triangle, perpendicular to the opposite sides (⟨Iₐ−I, I_c−I_b⟩ = ⟨I_b−I, I_c−Iₐ⟩ = ⟨I_c−I, I_b−Iₐ⟩ = 0), so they concur at I and {I, Iₐ, I_b, I_c} is an orthocentric system. Answers the first open question of the circumradius-2R entry. 8 theorems (plus 13 supporting lemmas), 0 axioms, 0 sorries.",
+    "implications": "**The dot-product foundation of the tritangent picture**: this perpendicularity fact is the geometric reason behind both the affine centroid law I+Iₐ+I_b+I_c = 4O and the metric circumradius-2R law O' = 2O−I; the sibling entries cite 'I is the excentral orthocenter' to call O the nine-point center, and this entry finally proves it.\n\n**Orthocentric system as gallery infrastructure**: the three perpendicularity identities (and their bundle) are reusable across the triangle-geometry strand wherever the orthocentric structure of the tritangent centers is needed — for instance to identify the excentral nine-point circle with the circumcircle of ABC.\n\n**A bisector-only proof technique**: the clearing-to-|u|²−|v|² mechanism shows that internal/external-bisector perpendicularity is forced by the side-length weights alone, a method that transfers to other angle-bisector configurations in the same coordinate framework.",
+    "openQuestions": [
+      "Show that each excenter is the orthocenter of the triangle formed by the incenter and the other two excenters (e.g. ⟨I−Iₐ, I_b−I_c⟩ = 0 read from Iₐ's vertex), making the full orthocentric-system symmetry of {I, Iₐ, I_b, I_c} explicit rather than implicit in the three shared perpendicularities.",
+      "Combine this orthocenter fact with the circumradius-2R entry to prove the excentral nine-point circle is the circumcircle of ABC as a circle-tangency statement, closing the loop toward the Feuerbach tangency of the nine-point circle to the incircle and excircles."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "the metric law that O' = 2O − I is the excentral circumcenter (circumradius 2R) and O = ½(I + O') the excentral nine-point center; this entry proves the dot-product fact 'I is the excentral orthocenter' that that entry asserts but leaves as its first open question"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01",
+      "relationship": "related",
+      "description": "the affine centroid law I + Iₐ + I_b + I_c = 4O; together with the orthocentric-system perpendicularities proved here, the four tritangent centers share a common nine-point circle centered at O"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-02-oq-01",
+      "relationship": "related",
+      "description": "the excenter Euler law OIₐ² = R² + 2Rrₐ; the same excenters whose mutual perpendicular structure this entry establishes"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs",
+      "relationship": "extends",
+      "description": "uses the incenter, excenters, side lengths and area defined in FeuerbachsTheoremDefs.lean and the worked triangle_345 with its side and incenter lemmas"
+    },
+    {
+      "targetId": "feuerbachs-theorem",
+      "relationship": "related",
+      "description": "the full Feuerbach theorem, whose nine-point circle is tangent to the incircle and all three excircles whose centers form the excentral triangle studied here"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.FeuerbachsTheoremDefs"
+    ],
+    "opens": [
+      "FeuerbachsTheorem"
+    ],
+    "namespace": "FeuerbachExcentralOrthocenter",
+    "lineCount": 408,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "incenter_is_excentral_orthocenter",
+      "type": "core",
+      "description": "The incenter is the orthocenter of the excentral triangle: all three altitudes of IₐI_bI_c — each perpendicular from a vertex to the opposite side — pass through I, so they concur there and {I, Iₐ, I_b, I_c} is an orthocentric system.",
+      "leanType": "∀ T : Triangle, (T.excenter_a.1 - T.incenter.1) * (T.excenter_c.1 - T.excenter_b.1) + (T.excenter_a.2 - T.incenter.2) * (T.excenter_c.2 - T.excenter_b.2) = 0 ∧ (T.excenter_b.1 - T.incenter.1) * (T.excenter_c.1 - T.excenter_a.1) + (T.excenter_b.2 - T.incenter.2) * (T.excenter_c.2 - T.excenter_a.2) = 0 ∧ (T.excenter_c.1 - T.incenter.1) * (T.excenter_b.1 - T.excenter_a.1) + (T.excenter_c.2 - T.incenter.2) * (T.excenter_b.2 - T.excenter_a.2) = 0"
+    },
+    {
+      "name": "incenter_altitude_perp_a",
+      "type": "core",
+      "description": "The A-altitude of the excentral triangle passes through I: the line I Iₐ (internal bisector from A) is perpendicular to the opposite side I_b I_c, i.e. ⟨Iₐ − I, I_c − I_b⟩ = 0.",
+      "leanType": "∀ T : Triangle, (T.excenter_a.1 - T.incenter.1) * (T.excenter_c.1 - T.excenter_b.1) + (T.excenter_a.2 - T.incenter.2) * (T.excenter_c.2 - T.excenter_b.2) = 0"
+    },
+    {
+      "name": "incenter_altitude_perp_b",
+      "type": "core",
+      "description": "The B-altitude of the excentral triangle passes through I: the line I I_b is perpendicular to the opposite side Iₐ I_c, i.e. ⟨I_b − I, I_c − Iₐ⟩ = 0.",
+      "leanType": "∀ T : Triangle, (T.excenter_b.1 - T.incenter.1) * (T.excenter_c.1 - T.excenter_a.1) + (T.excenter_b.2 - T.incenter.2) * (T.excenter_c.2 - T.excenter_a.2) = 0"
+    },
+    {
+      "name": "incenter_altitude_perp_c",
+      "type": "core",
+      "description": "The C-altitude of the excentral triangle passes through I: the line I I_c is perpendicular to the opposite side Iₐ I_b, i.e. ⟨I_c − I, I_b − Iₐ⟩ = 0.",
+      "leanType": "∀ T : Triangle, (T.excenter_c.1 - T.incenter.1) * (T.excenter_b.1 - T.excenter_a.1) + (T.excenter_c.2 - T.incenter.2) * (T.excenter_b.2 - T.excenter_a.2) = 0"
+    },
+    {
+      "name": "triangle_345_orthocentric_system",
+      "type": "example",
+      "description": "Worked example: for the 3-4-5 right triangle with I=(1,1), Iₐ=(6,6), I_b=(−3,3), I_c=(2,−2), the three pairs of opposite connectors are mutually perpendicular, so I is the orthocenter of the excentral triangle.",
+      "leanType": "(triangle_345.excenter_a.1 - triangle_345.incenter.1) * (triangle_345.excenter_c.1 - triangle_345.excenter_b.1) + (triangle_345.excenter_a.2 - triangle_345.incenter.2) * (triangle_345.excenter_c.2 - triangle_345.excenter_b.2) = 0 ∧ … ∧ …"
+    },
+    {
+      "name": "triangle_345_excenter_a",
+      "type": "example",
+      "description": "The A-excenter of the 3-4-5 right triangle is (6, 6).",
+      "leanType": "triangle_345.excenter_a = (6, 6)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves directly that **the incenter I is the orthocenter of the excentral triangle IₐI_bI_c**, so the four tritangent centers {I, Iₐ, I_b, I_c} form an **orthocentric system**. This answers the **first open question** of the circumradius-2R entry (`feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01`), which repeatedly asserts "I is the excentral orthocenter" to justify calling O the nine-point center but never proves it.

The three internal angle bisectors of ABC — the lines I Iₐ, I I_b, I I_c — are the three **altitudes** of the excentral triangle:

```
⟨Iₐ − I, I_c − I_b⟩ = ⟨I_b − I, I_c − Iₐ⟩ = ⟨I_c − I, I_b − Iₐ⟩ = 0
```

Since all three altitudes pass through I, they concur there — exactly the orthocenter statement.

## Method

A one-line vector identity. Over its common denominator, `Iₐ − I = 2a·[b(B−A)+c(C−A)]/((−a+b+c)(a+b+c))` while the opposite side `I_c − I_b = 2a·[b(B−A)−c(C−A)]/((a+b−c)(a−b+c))`. With `u = b(B−A)`, `v = c(C−A)`, the inner product is proportional to `⟨u+v, u−v⟩ = |u|² − |v|² = b²|B−A|² − c²|C−A|² = b²c² − c²b² = 0`, using only the side-length definitions `|B−A|² = c²`, `|C−A|² = b²`. No circumcenter, no master norm identity, no nine-point machinery.

Concretely each statement clears the four tritangent denominators (`field_simp; ring`, a pure rational identity) to land on `4a²(b²|B−A|² − c²|C−A|²)`, substitutes the squared sides (`linear_combination`), and cancels the nonzero denominator product.

## Verification

- **8 theorems** + 13 supporting private lemmas, 408 lines
- **0 sorries, 0 axioms** — `#print axioms` shows only `propext / Classical.choice / Quot.sound`
- Builds cleanly (`Built Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01OQ01`, 3093 jobs)
- Worked example: 3-4-5 triangle, I=(1,1), Iₐ=(6,6), I_b=(−3,3), I_c=(2,−2), all three dot products = 0

## Files

- `proofs/Proofs/FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01OQ01.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)