### PR TITLE
research(geometric-series-oq-07-oq-01-oq-01-oq-02): the Eulerian polynomial is palindromic — ⟨m,k⟩ = ⟨m,m−1−k⟩ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2628,6 +2628,7 @@ import Proofs.GeometricSeriesOQ06
 import Proofs.GeometricSeriesOQ07
 import Proofs.GeometricSeriesOQ07OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ02
 import Proofs.GeometricSeriesOQ08
 import Proofs.GeometricSeriesOQ08OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01

--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ02.lean
@@ -1,0 +1,228 @@
+/-
+# Geometric series, open question oq-07-oq-01-oq-01-oq-02:
+# The Eulerian polynomial is palindromic — the Eulerian numbers are symmetric
+
+The parent entry `geometric-series-oq-07-oq-01-oq-01` builds the **Eulerian
+polynomial** `eulerPoly m` by its classical first-order differential recurrence
+
+  E₀ = 1,   E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ,
+
+and identifies it (Frobenius' identity) with the Stirling closed form.  Its
+integer coefficients are the Eulerian numbers: in this "geometric" normalisation
+`E_m(X) = ∑_{k=1}^{m} ⟨m,k-1⟩·Xᵏ` for `m ≥ 1`, with
+
+  E₁ = X,   E₂ = X + X²,   E₃ = X + 4X² + X³.
+
+This entry answers the parent's recorded open question
+`geometric-series-oq-07-oq-01-oq-01-oq-02`: prove the **palindromic symmetry**
+`⟨m,k⟩ = ⟨m,m-1-k⟩` of the Eulerian numbers, equivalently
+`Eₘ(X) = X^{m+1}·Eₘ(1/X)` for `m ≥ 1`.
+
+We work entirely at the level of coefficients over an arbitrary commutative ring.
+The engine is a **coefficient recurrence** extracted from the differential
+recurrence by coefficient extraction:
+
+  coeff(E_{m+1}, j+2) = (j+2)·coeff(Eₘ, j+2) − (j+1)·coeff(Eₘ, j+1)
+                          + (m+1)·coeff(Eₘ, j+1),
+
+together with the boundary values `coeff(E_{m+1}, 0) = 0` and
+`coeff(E_{m+1}, 1) = coeff(Eₘ, 1) + (m+1)·coeff(Eₘ, 0)`.  From these we prove, by
+induction on `m`, the symmetric statement
+
+  `eulerPoly_palindrome` :  a + b = m + 1  →  coeff(Eₘ, a) = coeff(Eₘ, b)   (m ≥ 1),
+
+which is exactly palindromicity (`eulerPoly_coeff_symm`:
+`coeff(Eₘ, a) = coeff(Eₘ, m+1-a)`).  As corollaries we read off the extreme
+Eulerian numbers `⟨m,0⟩ = ⟨m,m-1⟩ = 1` (`eulerPoly_coeff_one`,
+`eulerPoly_coeff_self`), the degree `deg Eₘ = m` and monicity
+(`eulerPoly_natDegree`, `eulerPoly_monic`), all for `m ≥ 1`.
+
+Mathlib has no Eulerian numbers or polynomials, so the symmetry — a textbook
+structural fact (Concrete Mathematics) — is new here.  Everything is `0`-axiom
+(`propext` / `Classical.choice` / `Quot.sound` only) and `sorry`-free.
+-/
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ02
+
+open Polynomial Finset
+
+open GeometricSeriesOQ07OQ01OQ01 (eulerPoly eulerPoly_zero eulerPoly_succ eulerPoly_one)
+
+variable {R : Type*} [CommRing R]
+
+/-! ## Part 1: the coefficient recurrence for `eulerPoly`
+
+Coefficient extraction turns the differential recurrence
+`E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ` into a recurrence on coefficients.  Because
+`X` and `X²` shift indices, the three index regions `j = 0`, `j = 1`,
+`j ≥ 2` are handled separately. -/
+
+/-- Rewriting `(↑m + 1 : R[X])` as the constant polynomial `C (↑m + 1)`. -/
+private theorem natCast_add_one_eq_C (m : ℕ) : ((m : R[X]) + 1) = C ((m : R) + 1) := by
+  rw [map_add, map_natCast, map_one]
+
+/-- Boundary value: the constant coefficient of `E_{m+1}` vanishes (every term of
+the recurrence carries a factor `X`). -/
+theorem coeff_eulerPoly_succ_zero (m : ℕ) :
+    (eulerPoly (m + 1) : R[X]).coeff 0 = 0 := by
+  rw [coeff_zero_eq_eval_zero, eulerPoly_succ]
+  simp
+
+/-- The constant coefficient of `Eₘ` vanishes for `m ≥ 1`. -/
+theorem coeff_eulerPoly_zero_eq_zero {m : ℕ} (hm : 1 ≤ m) :
+    (eulerPoly m : R[X]).coeff 0 = 0 := by
+  obtain ⟨n, rfl⟩ : ∃ n, m = n + 1 := ⟨m - 1, by omega⟩
+  exact coeff_eulerPoly_succ_zero n
+
+/-- Boundary value at index `1`. -/
+theorem coeff_eulerPoly_succ_one (m : ℕ) :
+    (eulerPoly (m + 1) : R[X]).coeff 1
+      = (eulerPoly m).coeff 1 + ((m : R) + 1) * (eulerPoly m).coeff 0 := by
+  have hcomm : ((m : R[X]) + 1) * X * eulerPoly m
+      = X * (((m : R[X]) + 1) * eulerPoly m) := by ring
+  have hassoc : (X * (1 - X) * derivative (eulerPoly m) : R[X])
+      = X * ((1 - X) * derivative (eulerPoly m)) := by ring
+  rw [eulerPoly_succ, hassoc, hcomm, coeff_add]
+  rw [show (1 : ℕ) = 0 + 1 from rfl, coeff_X_mul, coeff_X_mul]
+  rw [mul_coeff_zero, natCast_add_one_eq_C, coeff_C_mul, coeff_derivative]
+  simp [coeff_one, coeff_X]
+
+/-- The core coefficient recurrence at index `j + 2`. -/
+theorem coeff_eulerPoly_succ_add_two (m j : ℕ) :
+    (eulerPoly (m + 1) : R[X]).coeff (j + 2)
+      = (eulerPoly m).coeff (j + 2) * ((j : R) + 2)
+        - (eulerPoly m).coeff (j + 1) * ((j : R) + 1)
+        + ((m : R) + 1) * (eulerPoly m).coeff (j + 1) := by
+  have hsplit : (X * (1 - X) * derivative (eulerPoly m) : R[X])
+      = X * derivative (eulerPoly m) - X ^ 2 * derivative (eulerPoly m) := by ring
+  have hcomm : ((m : R[X]) + 1) * X * eulerPoly m
+      = X * (((m : R[X]) + 1) * eulerPoly m) := by ring
+  have e1 : (X * derivative (eulerPoly m) : R[X]).coeff (j + 2)
+      = (eulerPoly m).coeff (j + 2) * ((j : R) + 2) := by
+    rw [show j + 2 = (j + 1) + 1 from rfl, coeff_X_mul, coeff_derivative]
+    push_cast; ring
+  have e2 : (X ^ 2 * derivative (eulerPoly m) : R[X]).coeff (j + 2)
+      = (eulerPoly m).coeff (j + 1) * ((j : R) + 1) := by
+    rw [coeff_X_pow_mul, coeff_derivative]
+  have e3 : (X * (((m : R[X]) + 1) * eulerPoly m) : R[X]).coeff (j + 2)
+      = ((m : R) + 1) * (eulerPoly m).coeff (j + 1) := by
+    rw [show j + 2 = (j + 1) + 1 from rfl, coeff_X_mul, natCast_add_one_eq_C, coeff_C_mul]
+  rw [eulerPoly_succ, hsplit, hcomm, coeff_add, coeff_sub, e1, e2, e3]
+
+/-! ## Part 2: degree bound -/
+
+/-- The Eulerian polynomial `Eₘ` has degree at most `m`: its coefficients vanish
+above index `m`. -/
+theorem coeff_eulerPoly_eq_zero {m j : ℕ} (h : m < j) :
+    (eulerPoly m : R[X]).coeff j = 0 := by
+  induction m generalizing j with
+  | zero =>
+    rw [eulerPoly_zero, coeff_one, if_neg (by omega)]
+  | succ n ih =>
+    obtain ⟨j', rfl⟩ : ∃ k, j = k + 2 := ⟨j - 2, by omega⟩
+    rw [coeff_eulerPoly_succ_add_two]
+    rw [ih (by omega), ih (by omega)]
+    ring
+
+/-! ## Part 3: palindromicity -/
+
+/-- **Palindromicity of the Eulerian polynomial** (symmetric form).  For `m ≥ 1`,
+the coefficients of `eulerPoly m` are symmetric about `(m+1)/2`:
+`a + b = m + 1` implies `coeff(Eₘ, a) = coeff(Eₘ, b)`.  Equivalently the Eulerian
+numbers satisfy `⟨m,k⟩ = ⟨m,m-1-k⟩`. -/
+theorem eulerPoly_palindrome {m : ℕ} (hm : 1 ≤ m) :
+    ∀ a b : ℕ, a + b = m + 1 → (eulerPoly m : R[X]).coeff a = (eulerPoly m).coeff b := by
+  induction m, hm using Nat.le_induction with
+  | base =>
+    intro a b hab
+    rw [eulerPoly_one, coeff_X, coeff_X]
+    split_ifs <;> first | rfl | (exfalso; omega)
+  | succ n hn ih =>
+    -- ordered helper: prove the statement assuming `a ≤ b`, then close by symmetry.
+    have key : ∀ a b : ℕ, a + b = n + 2 → a ≤ b →
+        (eulerPoly (n + 1) : R[X]).coeff a = (eulerPoly (n + 1)).coeff b := by
+      intro a b hab hle
+      match a, b with
+      | 0, b =>
+        -- b = n + 2 : both sides vanish (constant term, and above the degree)
+        rw [coeff_eulerPoly_succ_zero, coeff_eulerPoly_eq_zero (by omega)]
+      | 1, b =>
+        -- b = n + 1 : the two boundary values, equated through the IH `coeff 1 = coeff n`
+        obtain rfl : b = n + 1 := by omega
+        obtain ⟨n', rfl⟩ : ∃ k, n = k + 1 := ⟨n - 1, by omega⟩
+        rw [coeff_eulerPoly_succ_one, coeff_eulerPoly_zero_eq_zero (by omega : 1 ≤ n' + 1),
+          mul_zero, add_zero]
+        -- normalise the index `n'+1+1` to the `_ + 2` form expected by the recurrence
+        show (eulerPoly (n' + 1) : R[X]).coeff 1
+          = (eulerPoly (n' + 1 + 1)).coeff (n' + 2)
+        rw [coeff_eulerPoly_succ_add_two,
+          coeff_eulerPoly_eq_zero (show n' + 1 < n' + 2 by omega)]
+        -- now relate coeff(Eₙ, 1) and coeff(Eₙ, n) by the inner palindrome
+        rw [ih 1 (n' + 1) (by omega)]
+        push_cast; ring
+      | (a + 2), (b + 2) =>
+        -- interior: both via the core recurrence, then the IH pairs the coefficients
+        rw [coeff_eulerPoly_succ_add_two, coeff_eulerPoly_succ_add_two]
+        have hrel : a + b + 2 = n := by omega
+        rw [ih (a + 2) (b + 1) (by omega), ih (a + 1) (b + 2) (by omega)]
+        have hc : ((a : R) + (b : R) + 2) = (n : R) := by exact_mod_cast congrArg (Nat.cast) hrel
+        linear_combination
+          ((eulerPoly n : R[X]).coeff (b + 1) - (eulerPoly n).coeff (b + 2)) * hc
+    intro a b hab
+    rcases le_total a b with h | h
+    · exact key a b hab h
+    · exact (key b a (by omega) h).symm
+
+/-- **Palindromicity** (reflection form).  For `m ≥ 1`,
+`coeff(Eₘ, a) = coeff(Eₘ, m + 1 - a)` for every `a`. -/
+theorem eulerPoly_coeff_symm {m : ℕ} (hm : 1 ≤ m) (a : ℕ) :
+    (eulerPoly m : R[X]).coeff a = (eulerPoly m).coeff (m + 1 - a) := by
+  rcases le_or_gt a (m + 1) with h | h
+  · exact eulerPoly_palindrome hm a (m + 1 - a) (by omega)
+  · -- a > m + 1 : LHS = 0 (above degree), RHS = coeff 0 = 0 (m ≥ 1)
+    obtain ⟨n, rfl⟩ : ∃ n, m = n + 1 := ⟨m - 1, by omega⟩
+    rw [coeff_eulerPoly_eq_zero (by omega), show n + 1 + 1 - a = 0 from by omega,
+      coeff_eulerPoly_succ_zero]
+
+/-! ## Part 4: structural corollaries (`m ≥ 1`) -/
+
+/-- The first Eulerian number is `⟨m,0⟩ = 1`: `coeff(Eₘ, 1) = 1`. -/
+theorem eulerPoly_coeff_one {m : ℕ} (hm : 1 ≤ m) :
+    (eulerPoly m : R[X]).coeff 1 = 1 := by
+  induction m, hm using Nat.le_induction with
+  | base => rw [eulerPoly_one, coeff_X]; simp
+  | succ n hn ih =>
+    rw [coeff_eulerPoly_succ_one, coeff_eulerPoly_zero_eq_zero hn, mul_zero, add_zero, ih]
+
+/-- The leading Eulerian number is `⟨m,m-1⟩ = 1`: `coeff(Eₘ, m) = 1`.  Read off
+from palindromicity and `coeff(Eₘ, 1) = 1`. -/
+theorem eulerPoly_coeff_self {m : ℕ} (hm : 1 ≤ m) :
+    (eulerPoly m : R[X]).coeff m = 1 := by
+  rw [eulerPoly_coeff_symm hm m, show m + 1 - m = 1 from by omega, eulerPoly_coeff_one hm]
+
+/-- For `m ≥ 1` over a nontrivial ring, `eulerPoly m` has degree exactly `m`. -/
+theorem eulerPoly_natDegree [Nontrivial R] {m : ℕ} (hm : 1 ≤ m) :
+    (eulerPoly m : R[X]).natDegree = m := by
+  refine le_antisymm (natDegree_le_iff_coeff_eq_zero.mpr ?_)
+    (le_natDegree_of_ne_zero ?_)
+  · intro j hj
+    exact coeff_eulerPoly_eq_zero hj
+  · rw [eulerPoly_coeff_self hm]
+    exact one_ne_zero
+
+/-- For `m ≥ 1` over a nontrivial ring, `eulerPoly m` is monic. -/
+theorem eulerPoly_monic [Nontrivial R] {m : ℕ} (hm : 1 ≤ m) :
+    (eulerPoly m : R[X]).Monic := by
+  rw [Monic, leadingCoeff, eulerPoly_natDegree hm, eulerPoly_coeff_self hm]
+
+/-! ## Part 5: low-order sanity checks (the symmetric rows `1`, `1 4 1`) -/
+
+example : (eulerPoly 2 : ℤ[X]).coeff 1 = (eulerPoly 2 : ℤ[X]).coeff 2 :=
+  eulerPoly_palindrome (by norm_num) 1 2 rfl
+
+example : (eulerPoly 3 : ℤ[X]).coeff 1 = (eulerPoly 3 : ℤ[X]).coeff 3 :=
+  eulerPoly_palindrome (by norm_num) 1 3 rfl
+
+end GeometricSeriesOQ07OQ01OQ01OQ02

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-02",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01"
+    ],
+    "opens": [
+      "Polynomial",
+      "Finset"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ02",
+    "lineCount": 228,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "Palindromicity of the Eulerian Polynomial: the Eulerian Numbers are Symmetric",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "eulerian-polynomial",
+      "palindromic-polynomial",
+      "symmetry",
+      "polynomial",
+      "formal-derivative",
+      "coefficient-extraction",
+      "generating-functions",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 228,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "eulerPoly_palindrome (symmetric form): for m ≥ 1, the coefficients of the Eulerian polynomial Eₘ are symmetric — a + b = m + 1 implies coeff(Eₘ, a) = coeff(Eₘ, b). This is exactly the palindromicity ⟨m,k⟩ = ⟨m,m-1-k⟩ of the Eulerian numbers, the open question geometric-series-oq-07-oq-01-oq-01-oq-02 recorded on the parent entry. Proved by induction on m directly from the differential recurrence, over an arbitrary commutative ring, with no appeal to a combinatorial (descent-statistic) definition. Mathlib has no Eulerian numbers, polynomials, or this symmetry.",
+      "coeff_eulerPoly_succ_add_two: the core coefficient recurrence obtained by extracting the coefficient at index j+2 from the differential recurrence E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ — coeff(E_{m+1}, j+2) = (j+2)·coeff(Eₘ, j+2) − (j+1)·coeff(Eₘ, j+1) + (m+1)·coeff(Eₘ, j+1). Together with the boundary values coeff(E_{m+1}, 0) = 0 (coeff_eulerPoly_succ_zero) and coeff(E_{m+1}, 1) = coeff(Eₘ, 1) + (m+1)·coeff(Eₘ, 0) (coeff_eulerPoly_succ_one), this is the engine of the induction: the coefficient at j+2 of E_{m+1} pairs the coefficients at j+1 and j+2 of Eₘ with weights whose sum is m+2, which is exactly what propagates the symmetry through the recurrence.",
+      "eulerPoly_coeff_symm (reflection form): for m ≥ 1, coeff(Eₘ, a) = coeff(Eₘ, m+1-a) for every a — the X^{m+1}·Eₘ(1/X) = Eₘ(X) restatement of palindromicity, including the off-support indices where both coefficients vanish.",
+      "coeff_eulerPoly_eq_zero: the degree bound deg Eₘ ≤ m (coefficients vanish above index m), proved by induction from the same coefficient recurrence; the boundary input that lets the symmetric induction close at the top of each row.",
+      "eulerPoly_coeff_one and eulerPoly_coeff_self: the extreme Eulerian numbers ⟨m,0⟩ = ⟨m,m-1⟩ = 1, i.e. coeff(Eₘ, 1) = coeff(Eₘ, m) = 1 for m ≥ 1. The first is an independent induction; the second is read off from it by palindromicity, exhibiting the symmetry concretely on the corners.",
+      "eulerPoly_natDegree and eulerPoly_monic: over a nontrivial ring, Eₘ has degree exactly m and is monic for m ≥ 1 — the leading coefficient is the top Eulerian number ⟨m,m-1⟩ = 1, combining the degree bound with the non-vanishing leading coefficient from palindromicity."
+    ],
+    "prerequisites": [
+      "Parent geometric-series-oq-07-oq-01-oq-01: the Eulerian polynomial eulerPoly defined by the differential recurrence E₀ = 1, E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ, together with eulerPoly_succ, eulerPoly_zero and the low-order value eulerPoly_one (E₁ = X). These are imported; this entry adds only structural facts about the coefficients.",
+      "Mathlib's univariate polynomial coefficient API: Polynomial.coeff_derivative ((derivative p).coeff n = p.coeff (n+1)·(n+1)), coeff_X_mul, coeff_X_pow_mul, mul_coeff_zero, coeff_C_mul, coeff_zero_eq_eval_zero and coeff_X — used to turn the differential recurrence into a coefficient recurrence.",
+      "Polynomial.natDegree_le_iff_coeff_eq_zero, le_natDegree_of_ne_zero and Monic/leadingCoeff for the degree and monicity corollaries (over a Nontrivial ring)",
+      "Nat.le_induction for the m ≥ 1 induction underlying the symmetric statement"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.coeff_derivative",
+        "description": "(derivative p).coeff n = p.coeff (n + 1) * (n + 1). The bridge from the formal derivative in the Eulerian recurrence to a recurrence on coefficients; combined with coeff_X_mul and coeff_X_pow_mul (which implement the index shifts of the X and X² factors) it yields the core recurrence coeff_eulerPoly_succ_add_two.",
+        "module": "Mathlib.Algebra.Polynomial.Derivative"
+      },
+      {
+        "theorem": "Polynomial.natDegree_le_iff_coeff_eq_zero",
+        "description": "natDegree p ≤ n ↔ ∀ m > n, p.coeff m = 0, with le_natDegree_of_ne_zero for the reverse bound. Used with the degree bound coeff_eulerPoly_eq_zero and the leading coefficient ⟨m,m-1⟩ = 1 to compute natDegree Eₘ = m and Monic Eₘ over a nontrivial ring.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Definitions"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07OQ01OQ01.eulerPoly",
+        "description": "The Eulerian polynomial and its differential recurrence eulerPoly_succ from the parent entry. The entire development here is coefficient extraction from this single recurrence.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-02-oq-01",
+      "question": "Strengthen the corner values to the full combinatorial triangle: prove coeff(Eₘ, k) = ⟨m,k-1⟩ where ⟨m,k⟩ is the Eulerian number defined by the triangle recurrence ⟨m,k⟩ = (k+1)·⟨m-1,k⟩ + (m-k)·⟨m-1,k-1⟩, by reading the same coefficient recurrence coeff_eulerPoly_succ_add_two as that triangle recurrence after the index shift. The coefficient recurrence proved here is already in the right form; what remains is to define the Eulerian triangle and match indices.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-02-oq-02",
+      "question": "Use palindromicity plus the row sum Eₘ(1) = m! (parent's eval_eulerPoly_one) to derive the central/extreme value bounds and the unimodality statement ⟨m,0⟩ ≤ ⟨m,1⟩ ≤ … ≤ ⟨m,⌊(m-1)/2⌋⌋ of the Eulerian numbers, or at least the weaker monotone-to-the-centre claim for small fixed rows.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent (Frobenius' identity). It defines the Eulerian polynomial eulerPoly by its differential recurrence and records this palindromicity as its open question oq-02. This entry answers it: working purely with coefficients, it proves the symmetry coeff(Eₘ, a) = coeff(Eₘ, m+1-a) and reads off the extreme Eulerian numbers, the degree and monicity."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01",
+      "relationship": "sibling",
+      "description": "Grandparent. The all-orders analytic moment ∑ nᵐ rⁿ = ∑ₖ S(m,k)·k!·rᵏ/(1−r)^{k+1}, whose (1-r)^{m+1}-cleared numerator is the Eulerian polynomial. Palindromicity is the symmetry of that numerator's coefficients."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers, the symmetry identity ⟨n,k⟩ = ⟨n,n-1-k⟩)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian numbers ⟨m,k⟩, their row sum m!, and the reflection symmetry ⟨m,k⟩ = ⟨m,m-1-k⟩ proved here from the differential recurrence."
+    },
+    {
+      "title": "Mathlib4: Algebra.Polynomial.Derivative",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of coeff_derivative, coeff_X_mul, coeff_X_pow_mul and the coefficient API used to convert the differential recurrence into the coefficient recurrence."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Over any commutative ring, the Eulerian polynomial Eₘ (defined by the differential recurrence E₀ = 1, E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ in the parent entry) is palindromic for m ≥ 1: coeff(Eₘ, a) = coeff(Eₘ, m+1-a), i.e. the Eulerian numbers satisfy ⟨m,k⟩ = ⟨m,m-1-k⟩ (eulerPoly_palindrome, eulerPoly_coeff_symm). The proof extracts a coefficient recurrence coeff(E_{m+1}, j+2) = (j+2)·coeff(Eₘ, j+2) − (j+1)·coeff(Eₘ, j+1) + (m+1)·coeff(Eₘ, j+1) from the differential recurrence (coeff_eulerPoly_succ_add_two), and an induction on m shows the weights pair the j+1 and j+2 coefficients symmetrically. Corollaries: the extreme Eulerian numbers ⟨m,0⟩ = ⟨m,m-1⟩ = 1, the degree deg Eₘ = m and monicity (over a nontrivial ring). 228 lines, 11 theorems, 0 definitions, 0 axioms, 0 sorries; every result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Palindromicity is the most basic structural symmetry of the Eulerian numbers, and Mathlib has neither the numbers nor the symmetry. The contribution here is methodological as well as factual: the symmetry is derived purely from the analytic (differential-recurrence) definition by coefficient extraction, without passing through the combinatorial descent-statistic definition or any bijection. The same coefficient recurrence is exactly the Eulerian triangle recurrence after an index shift, so this entry also sets up the textbook combinatorial identification (the parent's other open question) and the unimodality of the Eulerian rows.",
+    "openQuestions": [
+      "Identify the coefficients with the Eulerian triangle ⟨m,k⟩ = (k+1)·⟨m-1,k⟩ + (m-k)·⟨m-1,k-1⟩ explicitly, reading coeff_eulerPoly_succ_add_two as that recurrence.",
+      "Derive unimodality of the Eulerian rows from palindromicity together with the row sum Eₘ(1) = m!."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question **geometric-series-oq-07-oq-01-oq-01-oq-02** recorded on the Frobenius parent (#27375, just merged): prove the **palindromic symmetry of the Eulerian polynomial**, `⟨m,k⟩ = ⟨m,m−1−k⟩`, equivalently `Eₘ(X) = X^{m+1}·Eₘ(1/X)` for `m ≥ 1`.

Mathlib has no Eulerian numbers, polynomials, or this symmetry. The proof works **entirely at the coefficient level over an arbitrary commutative ring**, deriving everything from the parent's differential recurrence `E₀ = 1, E_{m+1} = X·(1−X)·E'ₘ + (m+1)·X·Eₘ` — no combinatorial (descent-statistic) definition is used.

## Method

1. **Coefficient recurrence** (`coeff_eulerPoly_succ_add_two`), by coefficient extraction from the differential recurrence:

   `coeff(E_{m+1}, j+2) = (j+2)·coeff(Eₘ, j+2) − (j+1)·coeff(Eₘ, j+1) + (m+1)·coeff(Eₘ, j+1)`

   plus the boundary values `coeff(E_{m+1}, 0) = 0` and `coeff(E_{m+1}, 1) = coeff(Eₘ, 1) + (m+1)·coeff(Eₘ, 0)`. The three index regions (X and X² shifts) are handled separately.
2. **Degree bound** `deg Eₘ ≤ m` (`coeff_eulerPoly_eq_zero`) from the same recurrence.
3. **Palindromicity** (`eulerPoly_palindrome`): induction on `m`; `a+b = m+1 → coeff(Eₘ, a) = coeff(Eₘ, b)`. The recurrence's weights pair the `j+1` and `j+2` coefficients with weights summing to `m+2`, which is exactly what propagates the symmetry. The step uses `le_total` + symmetry to cut to three cases (boundary 0, boundary 1, interior).
4. **Corollaries**: reflection form `coeff(Eₘ, a) = coeff(Eₘ, m+1−a)`; the extreme Eulerian numbers `⟨m,0⟩ = ⟨m,m−1⟩ = 1`; `deg Eₘ = m` and `Monic Eₘ` (over a nontrivial ring).

## Verification

- 228 lines, 11 theorems, 0 definitions, **0 axioms**, 0 sorries.
- `#print axioms eulerPoly_palindrome` / `eulerPoly_monic` → `[propext, Classical.choice, Quot.sound]` only.
- Builds via `docker-build.sh Proofs.GeometricSeriesOQ07OQ01OQ01OQ02` (7745 jobs, clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)