### PR TITLE
research(geometric-series-oq-01-oq-03): Abel summability at the |r|=1 boundary [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2619,6 +2619,7 @@ import Proofs.GeometricSeries
 import Proofs.GeometricSeriesOQ01
 import Proofs.GeometricSeriesOQ01Neumann
 import Proofs.GeometricSeriesOQ01OQ02
+import Proofs.GeometricSeriesOQ01OQ03
 import Proofs.GeometricSeriesOQ02
 import Proofs.GeometricSeriesOQ02OQ03
 import Proofs.GeometricSeriesOQ02OQ03OQ01

--- a/proofs/Proofs/GeometricSeriesOQ01OQ03.lean
+++ b/proofs/Proofs/GeometricSeriesOQ01OQ03.lean
@@ -1,0 +1,205 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Topology.Algebra.InfiniteSum.Basic
+import Mathlib.Tactic
+
+/-
+# Geometric Series at the Boundary: Abel Summability
+
+## What This Proves
+The parent entry (`geometric-series-oq-01`) studies the geometric series ∑ rⁿ at
+the critical boundary |r| = 1. There, ordinary convergence fails, but the
+**Cesàro mean** of Grandi's series 1 − 1 + 1 − 1 + ⋯ still converges to 1/2.
+
+This entry develops the **third regularization lens** at the boundary:
+**Abel summability**. A sequence (aₙ) is Abel summable to L when the power
+series A(x) = ∑ₙ aₙ xⁿ converges for x ∈ [0,1) and A(x) → L as x → 1⁻.
+
+We prove:
+
+1. **Grandi is Abel summable to 1/2.** The Abel function of (−1)ⁿ is
+   ∑ₙ (−1)ⁿ xⁿ = 1/(1+x), whose left-limit at 1 is 1/2 — recovering Euler's
+   value and agreeing with the Cesàro sum from the parent.
+
+2. **r = 1 is NOT Abel summable.** The Abel function of the constant 1 is
+   ∑ₙ xⁿ = 1/(1−x), which diverges to +∞ as x → 1⁻. So Abel summability still
+   separates r = 1 (genuinely divergent) from r = −1 (summable to 1/2),
+   refining the parent's blanket "|r| ≥ 1 ⇒ not summable".
+
+3. **Abel summability is regular.** For |r| < 1 the Abel function
+   ∑ₙ rⁿ xⁿ = 1/(1−rx) tends to 1/(1−r) as x → 1⁻ — exactly the ordinary sum.
+   So Abel summation never contradicts ordinary convergence; it only extends it.
+
+## Historical Context
+Niels Henrik Abel proved (1826) that if ∑ aₙ converges to L then the power
+series ∑ aₙ xⁿ tends to L as x → 1⁻ (Abel's theorem); the converse defines Abel
+summation. Like Cesàro's method, Abel's is *regular* (consistent with ordinary
+sums) and assigns 1/2 to Grandi's series. The two methods agree here, but Abel's
+is strictly stronger in general (Abel summable ⊋ Cesàro summable, by Frobenius).
+
+## Approach
+- **Foundation (from Mathlib):** `hasSum_geometric_of_abs_lt_one` gives the
+  closed form of each Abel function for |x| < 1.
+- **Original Contributions:** the Abel-summability predicate at the boundary, the
+  three boundary outcomes (Grandi → 1/2, r = 1 → divergent, |r| < 1 regular),
+  with the left-limits computed by continuity / `tendsto_inv_nhdsGT_zero`.
+-/
+
+namespace GeometricSeriesOQ01OQ03
+
+open Filter Topology
+
+/-- Near `1` from below, points have absolute value `< 1`. -/
+private theorem abs_lt_one_eventually : ∀ᶠ x in 𝓝[<] (1 : ℝ), |x| < 1 := by
+  have h1 : ∀ᶠ x in 𝓝[<] (1 : ℝ), x < 1 := by
+    filter_upwards [self_mem_nhdsWithin] with x hx; exact hx
+  have hopen : IsOpen {x : ℝ | (-1 : ℝ) < x} := isOpen_lt continuous_const continuous_id
+  have h2 : ∀ᶠ x in 𝓝[<] (1 : ℝ), (-1 : ℝ) < x :=
+    (hopen.eventually_mem (by norm_num : (-1 : ℝ) < 1)).filter_mono nhdsWithin_le_nhds
+  filter_upwards [h1, h2] with x hx1 hx2
+  exact abs_lt.mpr ⟨hx2, hx1⟩
+
+-- ============================================================
+-- PART 0: The Abel-summability predicate
+-- ============================================================
+
+/-- A real sequence `a` is **Abel summable** to `L` when its power series
+`A(x) = ∑ₙ aₙ xⁿ` converges for every `x ∈ [0,1)` and its value tends to `L`
+as `x → 1⁻`. This is the boundary regularization studied here. -/
+def AbelSummableTo (a : ℕ → ℝ) (L : ℝ) : Prop :=
+  (∀ x : ℝ, 0 ≤ x → x < 1 → Summable (fun n => a n * x ^ n)) ∧
+    Tendsto (fun x => ∑' n, a n * x ^ n) (𝓝[<] (1 : ℝ)) (𝓝 L)
+
+/-- The Abel sum is unique: a sequence cannot be Abel summable to two distinct
+values (the left-neighborhood filter at `1` is nontrivial). -/
+theorem abelSummableTo_unique {a : ℕ → ℝ} {L₁ L₂ : ℝ}
+    (h₁ : AbelSummableTo a L₁) (h₂ : AbelSummableTo a L₂) : L₁ = L₂ :=
+  tendsto_nhds_unique h₁.2 h₂.2
+
+-- ============================================================
+-- PART 1: Grandi's series 1 − 1 + 1 − 1 + ⋯ is Abel summable to 1/2
+-- ============================================================
+
+/-- For `|x| < 1`, the Abel function of Grandi's series sums in closed form:
+`∑ₙ (−1)ⁿ xⁿ = 1/(1+x)`. -/
+theorem grandi_abel_hasSum {x : ℝ} (hx : |x| < 1) :
+    HasSum (fun n => (-1 : ℝ) ^ n * x ^ n) (1 + x)⁻¹ := by
+  have key : HasSum (fun n => (-x) ^ n) (1 - (-x))⁻¹ :=
+    hasSum_geometric_of_abs_lt_one (by rwa [abs_neg])
+  rw [sub_neg_eq_add] at key
+  have e : (fun n => (-1 : ℝ) ^ n * x ^ n) = fun n => (-x) ^ n := by
+    funext n; rw [← mul_pow, neg_one_mul]
+  rw [e]; exact key
+
+/-- The Abel function of Grandi's series tends to `1/2` as `x → 1⁻`:
+the Abel sum of `1 − 1 + 1 − ⋯` is `1/2`, matching Euler and the Cesàro mean. -/
+theorem grandi_abel_tendsto :
+    Tendsto (fun x => ∑' n, (-1 : ℝ) ^ n * x ^ n) (𝓝[<] (1 : ℝ)) (𝓝 (1 / 2)) := by
+  have hcont : Tendsto (fun x : ℝ => (1 + x)⁻¹) (𝓝[<] (1 : ℝ)) (𝓝 (1 / 2)) := by
+    have htend : Tendsto (fun x : ℝ => (1 + x)⁻¹) (𝓝 (1 : ℝ)) (𝓝 (1 / 2)) := by
+      have h2 : ((1 : ℝ) + 1)⁻¹ = 1 / 2 := by norm_num
+      rw [← h2]
+      exact ((continuous_const.add continuous_id).tendsto 1).inv₀ (by norm_num)
+    exact htend.mono_left nhdsWithin_le_nhds
+  refine hcont.congr' ?_
+  filter_upwards [abs_lt_one_eventually] with x hx
+  exact ((grandi_abel_hasSum hx).tsum_eq).symm
+
+/-- Grandi's series `1 − 1 + 1 − 1 + ⋯` is Abel summable to `1/2`. -/
+theorem grandi_abelSummableTo_half :
+    AbelSummableTo (fun n => (-1 : ℝ) ^ n) (1 / 2) := by
+  refine ⟨fun x hx0 hx1 => ?_, grandi_abel_tendsto⟩
+  have hx : |x| < 1 := by rw [abs_of_nonneg hx0]; exact hx1
+  exact (grandi_abel_hasSum hx).summable
+
+-- ============================================================
+-- PART 2: r = 1 is NOT Abel summable (the Abel function diverges)
+-- ============================================================
+
+/-- The Abel function of the constant sequence `1` diverges to `+∞` as `x → 1⁻`:
+`∑ₙ xⁿ = 1/(1−x) → +∞`. -/
+theorem one_abel_tendsto_atTop :
+    Tendsto (fun x => ∑' n, (1 : ℝ) ^ n * x ^ n) (𝓝[<] (1 : ℝ)) atTop := by
+  have hbase : Tendsto (fun x : ℝ => (1 - x)⁻¹) (𝓝[<] (1 : ℝ)) atTop := by
+    have h0 : Tendsto (fun x : ℝ => 1 - x) (𝓝[<] (1 : ℝ)) (𝓝[>] (0 : ℝ)) := by
+      rw [tendsto_nhdsWithin_iff]
+      refine ⟨?_, ?_⟩
+      · have hc : Tendsto (fun x : ℝ => (1 : ℝ) - x) (𝓝 (1 : ℝ)) (𝓝 ((1 : ℝ) - 1)) :=
+          (continuous_const.sub continuous_id).tendsto 1
+        rw [sub_self] at hc
+        exact hc.mono_left nhdsWithin_le_nhds
+      · filter_upwards [self_mem_nhdsWithin] with x hx
+        simp only [Set.mem_Iio] at hx
+        simp only [Set.mem_Ioi]; linarith
+    exact h0.inv_tendsto_nhdsGT_zero
+  refine hbase.congr' ?_
+  filter_upwards [abs_lt_one_eventually] with x hx
+  have hs : HasSum (fun n => (1 : ℝ) ^ n * x ^ n) (1 - x)⁻¹ := by
+    have key : HasSum (fun n => x ^ n) (1 - x)⁻¹ := hasSum_geometric_of_abs_lt_one hx
+    simpa using key
+  exact hs.tsum_eq.symm
+
+/-- The constant sequence `1` (i.e. `r = 1`) is not Abel summable to any value:
+its Abel function diverges, so no finite limit exists. -/
+theorem one_not_abelSummable : ¬ ∃ L, AbelSummableTo (fun _ => (1 : ℝ)) L := by
+  rintro ⟨L, _, hL⟩
+  have hAt : Tendsto (fun x => ∑' n, (1 : ℝ) * x ^ n) (𝓝[<] (1 : ℝ)) atTop := by
+    refine one_abel_tendsto_atTop.congr ?_
+    intro x; simp
+  have : (𝓝[<] (1 : ℝ)).NeBot := inferInstance
+  exact not_tendsto_nhds_of_tendsto_atTop hAt L hL
+
+-- ============================================================
+-- PART 3: Abel summability is regular (|r| < 1 ⇒ Abel sum = ordinary sum)
+-- ============================================================
+
+/-- For `|r·x| < 1`, the Abel function of the geometric sequence `rⁿ` sums to
+`1/(1−r·x)`. -/
+theorem geom_abel_hasSum {r x : ℝ} (h : |r * x| < 1) :
+    HasSum (fun n => r ^ n * x ^ n) (1 - r * x)⁻¹ := by
+  have key : HasSum (fun n => (r * x) ^ n) (1 - r * x)⁻¹ :=
+    hasSum_geometric_of_abs_lt_one h
+  have e : (fun n => r ^ n * x ^ n) = fun n => (r * x) ^ n := by
+    funext n; rw [mul_pow]
+  rw [e]; exact key
+
+/-- For `|r| < 1`, the Abel function of `rⁿ` tends to `1/(1−r)` as `x → 1⁻`. -/
+theorem geom_abel_tendsto {r : ℝ} (hr : |r| < 1) :
+    Tendsto (fun x => ∑' n, r ^ n * x ^ n) (𝓝[<] (1 : ℝ)) (𝓝 (1 - r)⁻¹) := by
+  have hr1 : r < 1 := (abs_lt.mp hr).2
+  have hcont : Tendsto (fun x : ℝ => (1 - r * x)⁻¹) (𝓝[<] (1 : ℝ)) (𝓝 (1 - r)⁻¹) := by
+    have hpos : (0 : ℝ) < 1 - r * 1 := by rw [mul_one]; linarith
+    have htend : Tendsto (fun x : ℝ => (1 - r * x)⁻¹) (𝓝 (1 : ℝ))
+        (𝓝 (1 - r * 1)⁻¹) :=
+      ((continuous_const.sub (continuous_const.mul continuous_id)).tendsto 1).inv₀ hpos.ne'
+    rw [mul_one] at htend
+    exact htend.mono_left nhdsWithin_le_nhds
+  refine hcont.congr' ?_
+  filter_upwards [abs_lt_one_eventually] with x hx
+  have hrx : |r * x| < 1 := by
+    rw [abs_mul]
+    calc |r| * |x| ≤ |r| * 1 := mul_le_mul_of_nonneg_left (le_of_lt hx) (abs_nonneg r)
+      _ = |r| := mul_one _
+      _ < 1 := hr
+  exact ((geom_abel_hasSum hrx).tsum_eq).symm
+
+/-- For `|r| < 1`, the geometric sequence `rⁿ` is Abel summable to `1/(1−r)`. -/
+theorem geom_abelSummableTo {r : ℝ} (hr : |r| < 1) :
+    AbelSummableTo (fun n => r ^ n) (1 - r)⁻¹ := by
+  refine ⟨fun x hx0 hx1 => ?_, geom_abel_tendsto hr⟩
+  have hrx : |r * x| < 1 := by
+    rw [abs_mul]
+    have hx : |x| ≤ 1 := by rw [abs_of_nonneg hx0]; exact le_of_lt hx1
+    calc |r| * |x| ≤ |r| * 1 := mul_le_mul_of_nonneg_left hx (abs_nonneg r)
+      _ = |r| := mul_one _
+      _ < 1 := hr
+  exact (geom_abel_hasSum hrx).summable
+
+/-- **Regularity of Abel summation.** For `|r| < 1` the Abel sum of `rⁿ` equals
+its *ordinary* sum `∑ₙ rⁿ`. Abel summation extends ordinary convergence without
+ever contradicting it. -/
+theorem geom_abel_regular {r : ℝ} (hr : |r| < 1) :
+    AbelSummableTo (fun n => r ^ n) (∑' n, r ^ n) := by
+  have h : (∑' n, r ^ n) = (1 - r)⁻¹ := (hasSum_geometric_of_abs_lt_one hr).tsum_eq
+  rw [h]; exact geom_abelSummableTo hr
+
+end GeometricSeriesOQ01OQ03

--- a/src/data/proofs/geometric-series-oq-01-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-03/meta.json
@@ -1,0 +1,145 @@
+{
+  "id": "geometric-series-oq-01-oq-03",
+  "slug": "geometric-series-oq-01-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Topology.Algebra.InfiniteSum.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "GeometricSeriesOQ01OQ03",
+    "lineCount": 205,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "title": "Geometric Series at the Boundary: Abel Summability",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ01OQ03.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "abel-summability",
+      "summability-theory",
+      "grandi-series",
+      "regularization",
+      "divergent-series",
+      "power-series",
+      "boundary",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 205,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "AbelSummableTo: the Abel-summability predicate at the boundary — a sequence a is Abel summable to L when its power series ∑ₙ aₙ xⁿ converges for every x ∈ [0,1) and its value tends to L as x → 1⁻. The boundary regularization that complements the parent's Cesàro mean.",
+      "abelSummableTo_unique: the Abel sum is unique, since the left-neighborhood filter 𝓝[<] 1 is nontrivial (NeBot) — Abel summation assigns at most one value.",
+      "grandi_abel_hasSum / grandi_abel_tendsto: the Abel function of Grandi's series 1 − 1 + 1 − ⋯ is ∑ₙ (−1)ⁿ xⁿ = 1/(1+x), whose left-limit at 1 is 1/2 — recovering Euler's value along Abel's path, in agreement with the parent's Cesàro mean.",
+      "grandi_abelSummableTo_half: Grandi's series is Abel summable to 1/2 — the headline regularization result at the boundary.",
+      "one_abel_tendsto_atTop / one_not_abelSummable: at r = 1 the Abel function ∑ₙ xⁿ = 1/(1−x) diverges to +∞ as x → 1⁻ (via tendsto_inv_nhdsGT_zero), so r = 1 is Abel summable to no value. Abel summability still separates the genuinely divergent r = 1 from the regularizable r = −1, refining the parent's blanket '|r| ≥ 1 ⇒ not summable'.",
+      "geom_abel_hasSum / geom_abel_tendsto: for |r| < 1 the Abel function ∑ₙ rⁿ xⁿ = 1/(1−rx) tends to 1/(1−r) as x → 1⁻.",
+      "geom_abelSummableTo / geom_abel_regular: regularity of Abel summation — for |r| < 1 the Abel sum of rⁿ equals its ordinary sum ∑ₙ rⁿ. Abel summation extends ordinary convergence without ever contradicting it."
+    ],
+    "prerequisites": [
+      "hasSum_geometric_of_abs_lt_one (Mathlib): for |r| < 1, HasSum (fun n ↦ rⁿ) (1 − r)⁻¹ — the closed form of each Abel function on the open disc",
+      "tendsto_inv_nhdsGT_zero (Mathlib): x⁻¹ → +∞ as x → 0⁺ — drives the r = 1 divergence",
+      "Tendsto.inv₀ (Mathlib): continuity of inversion away from 0 — supplies the left-limits 1/2 and 1/(1−r)",
+      "tendsto_nhds_unique (Mathlib): uniqueness of limits in a Hausdorff space — behind the uniqueness of the Abel sum",
+      "not_tendsto_nhds_of_tendsto_atTop (Mathlib): along a nontrivial filter a function cannot tend both to +∞ and to a finite limit — behind one_not_abelSummable",
+      "Parent: geometric-series-oq-01 (boundary |r| = 1: divergence at r = 1, Grandi oscillation at r = −1, Cesàro mean → 1/2)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_geometric_of_abs_lt_one",
+        "description": "For |r| < 1, HasSum (fun n ↦ rⁿ) (1 − r)⁻¹. Specialized at r ↦ −x, x, and r·x to give the closed forms 1/(1+x), 1/(1−x), 1/(1−rx) of the three Abel functions on [0,1).",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "tendsto_inv_nhdsGT_zero",
+        "description": "Tendsto (fun x ↦ x⁻¹) (𝓝[>] 0) atTop. Composed with x ↦ 1 − x (which sends 𝓝[<] 1 to 𝓝[>] 0) to show the r = 1 Abel function 1/(1−x) diverges to +∞.",
+        "module": "Mathlib.Topology.Algebra.Order.Field"
+      },
+      {
+        "theorem": "Tendsto.inv₀",
+        "description": "If f → a ≠ 0 then f⁻¹ → a⁻¹. Gives the left-limits (1+x)⁻¹ → 1/2 and (1−rx)⁻¹ → (1−r)⁻¹ by continuity at x = 1.",
+        "module": "Mathlib.Topology.Algebra.GroupWithZero"
+      },
+      {
+        "theorem": "not_tendsto_nhds_of_tendsto_atTop",
+        "description": "Along a NeBot filter, a function tending to atTop cannot also tend to any 𝓝 L. Turns the divergence of 1/(1−x) into the non-Abel-summability of r = 1.",
+        "module": "Mathlib.Order.Filter.AtTopBot.Basic"
+      },
+      {
+        "theorem": "tendsto_nhds_unique",
+        "description": "Limits in a Hausdorff space are unique. Gives abelSummableTo_unique: at most one Abel sum.",
+        "module": "Mathlib.Topology.Separation.Hausdorff"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-01-oq-03-oq-01",
+      "question": "Prove Abel's theorem in the regular direction at full strength: if ∑ₙ aₙ converges to L (not only for geometric aₙ = rⁿ), then the power series ∑ₙ aₙ xⁿ tends to L as x → 1⁻. The geometric case here is the consistency check; the general theorem (summation by parts plus a uniform tail estimate) would give regularity for every convergent series.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-01-oq-03-oq-02",
+      "question": "Establish the Abel ⊋ Cesàro hierarchy at the boundary by exhibiting a sequence Abel summable but not Cesàro summable (e.g. aₙ = (−1)ⁿ (n+1), whose Abel function is 1/(1+x)² → 1/4 while its Cesàro means diverge), formalizing Frobenius's theorem that Abel summation dominates Cesàro.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-01-oq-03-oq-03",
+      "question": "Extend Abel summability of the geometric series to complex ratios r = e^{iθ} on the unit circle (θ ≠ 0), where the Abel function ∑ₙ rⁿ xⁿ = 1/(1−rx) tends to 1/(1−r) — assigning Euler's regularized value 1/(1−e^{iθ}) to every boundary point except r = 1.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: the boundary |r| = 1, where it analyzed divergence at r = 1, Grandi oscillation at r = −1, and the Cesàro mean → 1/2. This entry adds the third regularization lens, Abel summability, recovering the same 1/2 for Grandi along a different route, keeping r = 1 divergent, and proving the method regular for |r| < 1."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "depends-on",
+      "description": "Base entry recording the closed form ∑ₙ rⁿ = 1/(1−r) for |r| < 1. The Abel functions here are exactly these geometric sums in the auxiliary variable x, and regularity says the Abel limit reproduces this value."
+    }
+  ],
+  "references": [
+    {
+      "title": "Untersuchungen über die Reihe 1 + (m/1)x + …",
+      "author": "Niels Henrik Abel",
+      "year": "1826",
+      "venue": "Journal für die reine und angewandte Mathematik",
+      "description": "Abel's continuity theorem: if ∑ aₙ converges to L then ∑ aₙ xⁿ → L as x → 1⁻. The regular direction whose geometric instance this entry formalizes, and whose converse defines Abel summation."
+    },
+    {
+      "title": "Divergent Series",
+      "author": "G. H. Hardy",
+      "year": "1949",
+      "venue": "Oxford University Press",
+      "description": "Standard reference for summability methods, their regularity, and the inclusions Cesàro ⊊ Abel among the classical regular methods that all assign 1/2 to Grandi's series."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "At the boundary |r| = 1 the geometric series is studied through Abel summation: a sequence a is Abel summable to L when ∑ₙ aₙ xⁿ converges on [0,1) and tends to L as x → 1⁻ (AbelSummableTo), a value that is unique because 𝓝[<] 1 is NeBot (abelSummableTo_unique). Three boundary outcomes follow. Grandi's series 1 − 1 + 1 − ⋯ has Abel function ∑ₙ (−1)ⁿ xⁿ = 1/(1+x) → 1/2, so it is Abel summable to 1/2 (grandi_abelSummableTo_half), matching the parent's Cesàro mean and Euler's value. The constant 1 (r = 1) has Abel function ∑ₙ xⁿ = 1/(1−x) → +∞, so it is Abel summable to no value (one_not_abelSummable). For |r| < 1 the Abel function ∑ₙ rⁿ xⁿ = 1/(1−rx) → 1/(1−r), which equals the ordinary sum ∑ₙ rⁿ — Abel summation is regular (geom_abel_regular). 205 lines, 10 theorems, 1 definition, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Abel summation is the third regularization lens on the |r| = 1 boundary, after the parent's divergence analysis and Cesàro mean. It agrees with Cesàro on Grandi (both give 1/2) yet is built from a genuinely different object — the radial limit of a power series rather than the average of partial sums — and its regularity (Abel sum = ordinary sum for |r| < 1) shows it never contradicts convergence; it only extends it. Crucially, Abel summation still refuses r = 1: the boundary point where the series truly diverges stays divergent under regularization, so the method discriminates between the two boundary ratios r = ±1 exactly as one would want. This sets up the open questions: full Abel's theorem for arbitrary convergent series, the Abel ⊋ Cesàro hierarchy, and the complex unit circle.",
+    "openQuestions": [
+      "Prove Abel's theorem in full: ∑ aₙ → L ⇒ ∑ aₙ xⁿ → L as x → 1⁻ for arbitrary (not only geometric) convergent series.",
+      "Exhibit a sequence Abel summable but not Cesàro summable (e.g. (−1)ⁿ(n+1) → 1/4), formalizing the Frobenius hierarchy Cesàro ⊊ Abel.",
+      "Extend Abel summability of the geometric series to complex boundary ratios r = e^{iθ}, θ ≠ 0, regularizing to 1/(1−e^{iθ})."
+    ]
+  }
+}

--- a/src/data/proofs/geometric-series-oq-01-oq-03/proof.md
+++ b/src/data/proofs/geometric-series-oq-01-oq-03/proof.md
@@ -1,0 +1,77 @@
+# Geometric Series at the Boundary: Abel Summability
+
+## The Question
+
+The parent entry studied the geometric series $\sum_{n=0}^{\infty} r^n$ at the
+critical boundary $|r| = 1$. There ordinary convergence fails, but the **Cesàro
+mean** of Grandi's series $1 - 1 + 1 - 1 + \cdots$ still converges to $\tfrac12$.
+
+Cesàro is one way to extract a value from a divergent series. Is it the only one,
+and does a *different* method give the same answer? This entry develops the third
+regularization lens at the boundary: **Abel summability**.
+
+## Abel Summability
+
+A real sequence $(a_n)$ is **Abel summable to $L$** when the power series
+$$A(x) = \sum_{n=0}^{\infty} a_n x^n$$
+converges for every $x \in [0,1)$ and its value tends to $L$ as $x \to 1^-$:
+$$\lim_{x \to 1^-} A(x) = L.$$
+The Abel sum is unique, because the left-neighborhood filter $\mathcal{N}^{<}(1)$
+is nontrivial — a function cannot tend to two different limits along it.
+
+## Three Outcomes at the Boundary
+
+### 1. Grandi's series is Abel summable to $\tfrac12$
+
+For $|x| < 1$ the Abel function of $a_n = (-1)^n$ is a geometric series with
+ratio $-x$:
+$$\sum_{n=0}^{\infty} (-1)^n x^n = \sum_{n=0}^{\infty} (-x)^n = \frac{1}{1+x}.$$
+As $x \to 1^-$ this tends to $\tfrac{1}{1+1} = \tfrac12$. So
+$$1 - 1 + 1 - 1 + \cdots \ \xrightarrow{\text{Abel}}\ \tfrac12,$$
+**recovering Euler's value and agreeing with the parent's Cesàro mean** — two
+genuinely different methods, the same answer.
+
+### 2. $r = 1$ is *not* Abel summable
+
+For $a_n = 1$ the Abel function is the ordinary geometric series
+$$\sum_{n=0}^{\infty} x^n = \frac{1}{1-x},$$
+which **diverges to $+\infty$** as $x \to 1^-$ (here $1 - x \to 0^+$, so its
+reciprocal blows up). Hence $r = 1$ has no Abel sum. Abel summability still
+**separates** the genuinely divergent $r = 1$ from the regularizable $r = -1$,
+sharpening the parent's blanket statement "$|r| \ge 1 \Rightarrow$ not summable."
+
+### 3. Abel summability is regular
+
+For $|r| < 1$ the Abel function of $a_n = r^n$ is
+$$\sum_{n=0}^{\infty} r^n x^n = \sum_{n=0}^{\infty} (rx)^n = \frac{1}{1-rx}
+\ \xrightarrow[x \to 1^-]{}\ \frac{1}{1-r},$$
+which is exactly the **ordinary** sum $\sum_n r^n$. So whenever a series already
+converges, its Abel sum equals its true sum: Abel summation *extends* ordinary
+convergence and never contradicts it. This property is called **regularity**.
+
+## Key Proof Techniques
+
+- **Closed form on the disc**: each Abel function is a geometric series in an
+  auxiliary variable, evaluated by Mathlib's `hasSum_geometric_of_abs_lt_one`
+  after rewriting $(-1)^n x^n = (-x)^n$ and $r^n x^n = (rx)^n$.
+- **Radial limits by continuity**: the limits $\tfrac{1}{1+x} \to \tfrac12$ and
+  $\tfrac{1}{1-rx} \to \tfrac{1}{1-r}$ come from `Tendsto.inv₀` (inversion is
+  continuous away from $0$) restricted to $\mathcal{N}^{<}(1)$ via
+  `mono_left nhdsWithin_le_nhds`.
+- **Divergence at $r = 1$**: the map $x \mapsto 1 - x$ sends
+  $\mathcal{N}^{<}(1)$ to $\mathcal{N}^{>}(0)$, and `tendsto_inv_nhdsGT_zero`
+  sends that to $+\infty$; `not_tendsto_nhds_of_tendsto_atTop` over the NeBot
+  filter rules out any finite Abel sum.
+- **Eventual closed form**: each Abel function equals its closed form only on
+  $|x| < 1$, so the limit is transported by `Tendsto.congr'` along the
+  eventual equality near $1^-$.
+
+## Historical Significance
+
+Niels Henrik Abel proved in 1826 that a convergent series $\sum a_n = L$ always
+satisfies $\sum a_n x^n \to L$ as $x \to 1^-$ — *Abel's continuity theorem*. The
+converse is taken as a *definition* of summability for divergent series. Abel's
+method, like Cesàro's, is **regular** and assigns $\tfrac12$ to Grandi's series;
+Frobenius later showed Abel summation strictly dominates Cesàro. These regular
+methods are the rigorous core behind Euler's bold $1 - 1 + 1 - \cdots = \tfrac12$,
+and the same machinery underlies modern regularization in analysis and physics.


### PR DESCRIPTION
## Summary

Opens the **`geometric-series-oq-01` lineage** (the |r|=1 boundary), adding the **third regularization lens** after the parent's divergence analysis and **Cesàro mean**: **Abel summability**.

A sequence `aₙ` is Abel summable to `L` when its power series `A(x) = ∑ₙ aₙ xⁿ` converges on `[0,1)` and `A(x) → L` as `x → 1⁻`. The file defines `AbelSummableTo` and proves three boundary outcomes:

1. **Grandi → 1/2.** `∑ₙ (−1)ⁿ xⁿ = 1/(1+x) → 1/2`, so `1 − 1 + 1 − ⋯` is Abel summable to `1/2` — recovering Euler's value and **agreeing with the parent's Cesàro mean** along a genuinely different route.
2. **r = 1 stays divergent.** `∑ₙ xⁿ = 1/(1−x) → +∞`, so `r = 1` is Abel summable to *no* value. Abel summation still separates the genuinely divergent `r = 1` from the regularizable `r = −1`, refining the parent's blanket "|r| ≥ 1 ⇒ not summable".
3. **Regularity.** For `|r| < 1`, `∑ₙ rⁿ xⁿ = 1/(1−rx) → 1/(1−r) = ∑ₙ rⁿ` — the Abel sum equals the ordinary sum, so Abel summation extends ordinary convergence without ever contradicting it.

Plus `abelSummableTo_unique` (the Abel sum is unique, since `𝓝[<] 1` is NeBot).

## Verification

- **205 lines, 10 theorems, 1 definition, 0 axioms, 0 sorries**
- Docker build succeeds, no warnings
- `#print axioms` on the three headline results: `[propext, Classical.choice, Quot.sound]` only — genuinely 0-axiom

## Key Mathlib ingredients
`hasSum_geometric_of_abs_lt_one` (closed forms), `Tendsto.inv₀` (radial limits 1/2 and 1/(1−r)), `tendsto_inv_nhdsGT_zero` (the r=1 blow-up), `not_tendsto_nhds_of_tendsto_atTop` (non-summability), `tendsto_nhds_unique` (uniqueness).

## Open questions recorded
- Full Abel's theorem: `∑ aₙ → L ⇒ ∑ aₙ xⁿ → L` for arbitrary convergent series.
- Abel ⊋ Cesàro hierarchy (e.g. `(−1)ⁿ(n+1) → 1/4` Abel but not Cesàro).
- Complex boundary ratios `r = e^{iθ}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)