### PR TITLE
research(geometric-series-oq-07-oq-01-oq-01-oq-03): mean and variance of the descent statistic via the Eulerian polynomial [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2630,6 +2630,7 @@ import Proofs.GeometricSeriesOQ07
 import Proofs.GeometricSeriesOQ07OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ02
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ03
 import Proofs.GeometricSeriesOQ08
 import Proofs.GeometricSeriesOQ08OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01

--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ03.lean
@@ -1,0 +1,177 @@
+/-
+# Moments of the descent statistic via the Eulerian polynomial
+
+This file is a depth follow-up of the Frobenius lineage
+(`GeometricSeriesOQ07OQ01OQ01`, which identifies the geometric-moment numerator
+as the Eulerian polynomial `Eₘ` and proves `Eₘ(1) = m!`).
+
+The Eulerian polynomial of order `m`,
+
+  Eₘ(X) = ∑_{k} ⟨m,k-1⟩ Xᵏ        (no constant term, degree `m`),
+
+is the *descent generating function* of the symmetric group `Sₘ`: the
+coefficient of `Xᵏ` is the number of permutations of `{1,…,m}` with exactly
+`k-1` descents.  Consequently `Eₘ(1) = m!` (already proved upstream) and, more
+finely, the *moments of the descent statistic* are read off from the
+derivatives of `Eₘ` evaluated at `1`:
+
+  T(m) := E'ₘ(1) = ∑_{k} k·⟨m,k-1⟩      (first factorial moment of `k = des+1`)
+  U(m) := E''ₘ(1) = ∑_{k} k(k-1)·⟨m,k-1⟩ (second factorial moment).
+
+The point of this entry is that the *analytic* definition of `Eₘ` by the
+first-order differential recurrence
+
+  E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ
+
+turns these moment computations into a **mechanical derivative-and-evaluate**:
+differentiating the recurrence once (resp. twice) and evaluating at `X = 1`
+(where the factor `X·(1-X)` vanishes) gives clean linear recurrences for `T`
+and `U`, whose closed forms are
+
+  **2·E'ₘ(1)  = (m+1)!**              (`two_mul_deriv_eulerPoly_eval_one`,  m ≥ 1)
+  **12·E''ₘ(1) = (3m-2)·(m+1)!**       (`twelve_mul_deriv2_eulerPoly_eval_one`, m ≥ 2).
+
+Dividing by `m!` recovers the two classical facts about a uniformly random
+permutation of `{1,…,m}`:
+
+  * the **mean number of descents is `(m-1)/2`**, and
+  * the **variance of the number of descents is `(m+1)/12`**.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and
+`sorry`-free.
+-/
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ03
+
+open Polynomial Nat
+open GeometricSeriesOQ07OQ01OQ01
+
+variable {R : Type*} [CommRing R]
+
+/-! ## Part 1: the one-step moment recurrences
+
+Both are pure consequences of the differential recurrence `eulerPoly_succ`,
+obtained by differentiating once / twice and evaluating at `X = 1`.  The factor
+`X·(1-X)` evaluates to `0` at `X = 1`, which is what makes the higher derivative
+terms drop out. -/
+
+/-- **First moment recurrence.**  `E'_{m+1}(1) = (m+1)·Eₘ(1) + m·E'ₘ(1)`.
+Differentiate `E_{m+1} = X(1-X)E'ₘ + (m+1)X·Eₘ` once and evaluate at `1`. -/
+theorem deriv_eulerPoly_eval_one_succ (m : ℕ) :
+    (derivative (eulerPoly (m + 1) : R[X])).eval 1
+      = ((m : R) + 1) * (eulerPoly m : R[X]).eval 1
+        + (m : R) * (derivative (eulerPoly m : R[X])).eval 1 := by
+  rw [eulerPoly_succ]
+  simp only [derivative_add, derivative_mul, derivative_sub, derivative_X, derivative_one,
+    derivative_natCast, eval_add, eval_sub, eval_mul, eval_X, eval_one,
+    eval_natCast, eval_zero, one_mul, mul_one, zero_mul, add_zero, zero_add]
+  ring
+
+/-- **Second moment recurrence.**  `E''_{m+1}(1) = 2m·E'ₘ(1) + (m-1)·E''ₘ(1)`.
+Differentiate the recurrence twice and evaluate at `1`. -/
+theorem deriv2_eulerPoly_eval_one_succ (m : ℕ) :
+    (derivative (derivative (eulerPoly (m + 1) : R[X]))).eval 1
+      = 2 * (m : R) * (derivative (eulerPoly m : R[X])).eval 1
+        + ((m : R) - 1) * (derivative (derivative (eulerPoly m : R[X]))).eval 1 := by
+  rw [eulerPoly_succ]
+  simp only [derivative_add, derivative_mul, derivative_sub, derivative_X, derivative_one,
+    derivative_natCast, derivative_zero, eval_add, eval_sub, eval_mul, eval_X, eval_one,
+    eval_natCast, eval_zero, one_mul, mul_one, mul_zero, zero_mul, add_zero, zero_add, sub_zero]
+  ring
+
+/-! ## Part 2: closed forms (integral, denominator-free) -/
+
+/-- **The first factorial moment of the descent statistic.**
+For `m ≥ 1`, `2·E'ₘ(1) = (m+1)!`.  Equivalently `∑ₖ k·⟨m,k-1⟩ = (m+1)!/2`, so the
+mean number of descents over `Sₘ` is `(m-1)/2`. -/
+theorem two_mul_deriv_eulerPoly_eval_one {m : ℕ} (hm : 1 ≤ m) :
+    2 * (derivative (eulerPoly m : R[X])).eval 1 = ((m + 1)! : R) := by
+  induction m, hm using Nat.le_induction with
+  | base =>
+    rw [eulerPoly_one, derivative_X]
+    simp [Nat.factorial]
+  | succ m hm ih =>
+    rw [deriv_eulerPoly_eval_one_succ, eval_eulerPoly_one]
+    have hf1 : ((m + 1)! : R) = ((m : R) + 1) * (m ! : R) := by
+      rw [Nat.factorial_succ]; push_cast; ring
+    have hf2 : ((m + 1 + 1)! : R) = ((m : R) + 2) * (((m : R) + 1) * (m ! : R)) := by
+      rw [Nat.factorial_succ, Nat.factorial_succ]; push_cast; ring
+    rw [hf1] at ih
+    rw [hf2]
+    linear_combination (m : R) * ih
+
+/-- **The second factorial moment of the descent statistic.**
+For `m ≥ 2`, `12·E''ₘ(1) = (3m-2)·(m+1)!`.  Combined with the first moment this
+yields variance `(m+1)/12` of the descent count over `Sₘ`. -/
+theorem twelve_mul_deriv2_eulerPoly_eval_one {m : ℕ} (hm : 2 ≤ m) :
+    12 * (derivative (derivative (eulerPoly m : R[X]))).eval 1
+      = (3 * (m : R) - 2) * ((m + 1)! : R) := by
+  induction m, hm using Nat.le_induction with
+  | base =>
+    -- E₂ = X + X², E''₂ = 2, so 12·2 = 24 = (3·2-2)·3! = 4·6.
+    rw [eulerPoly_two]
+    simp only [derivative_add, derivative_X, derivative_X_pow]
+    push_cast
+    simp [Nat.factorial]
+    ring
+  | succ m hm ih =>
+    have hm1 : 1 ≤ m := le_trans (by norm_num) hm
+    rw [deriv2_eulerPoly_eval_one_succ]
+    have hmean := two_mul_deriv_eulerPoly_eval_one (R := R) hm1
+    have hf : ((m + 1 + 1)! : R) = ((m : R) + 2) * ((m + 1)! : R) := by
+      rw [Nat.factorial_succ]; push_cast; ring
+    rw [hf]
+    push_cast
+    linear_combination (12 * (m : R)) * hmean + ((m : R) - 1) * ih
+
+/-! ## Part 3: the descent statistic over `ℚ`
+
+Specialising to `ℚ` turns the integral identities into the mean and variance of
+the number of descents of a uniformly random permutation of `{1,…,m}`. -/
+
+/-- **Mean of the `descents+1` statistic.**  Over `ℚ`,
+`E'ₘ(1) / Eₘ(1) = (m+1)/2`, i.e. the average value of `k = des+1` over `Sₘ` is
+`(m+1)/2`, so the mean number of descents is `(m-1)/2`. -/
+theorem mean_descents_succ {m : ℕ} (hm : 1 ≤ m) :
+    (derivative (eulerPoly m : ℚ[X])).eval 1 / (eulerPoly m : ℚ[X]).eval 1
+      = ((m : ℚ) + 1) / 2 := by
+  have hS : (eulerPoly m : ℚ[X]).eval 1 = (m ! : ℚ) := eval_eulerPoly_one m
+  have hT : 2 * (derivative (eulerPoly m : ℚ[X])).eval 1 = ((m + 1)! : ℚ) :=
+    two_mul_deriv_eulerPoly_eval_one hm
+  have hfac : (m ! : ℚ) ≠ 0 := by
+    exact_mod_cast (Nat.factorial_pos m).ne'
+  have hfac1 : ((m + 1)! : ℚ) = ((m : ℚ) + 1) * (m ! : ℚ) := by
+    rw [Nat.factorial_succ]; push_cast; ring
+  rw [hS, div_eq_div_iff hfac (by norm_num : (2 : ℚ) ≠ 0)]
+  linear_combination hT + hfac1
+
+/-- **Variance of the descent statistic.**  Over `ℚ`, for `m ≥ 2`,
+
+  `E''ₘ(1)/Eₘ(1) + E'ₘ(1)/Eₘ(1) - (E'ₘ(1)/Eₘ(1))² = (m+1)/12`.
+
+The left side is `E[k(k-1)] + E[k] - E[k]² = E[k²] - E[k]² = Var(k)`, the variance
+of `k = des+1` (equal to the variance of the number of descents).  So the number
+of descents of a uniformly random permutation of `{1,…,m}` has variance
+`(m+1)/12`. -/
+theorem variance_descents_succ {m : ℕ} (hm : 2 ≤ m) :
+    (derivative (derivative (eulerPoly m : ℚ[X]))).eval 1 / (eulerPoly m : ℚ[X]).eval 1
+      + (derivative (eulerPoly m : ℚ[X])).eval 1 / (eulerPoly m : ℚ[X]).eval 1
+      - ((derivative (eulerPoly m : ℚ[X])).eval 1 / (eulerPoly m : ℚ[X]).eval 1) ^ 2
+      = ((m : ℚ) + 1) / 12 := by
+  have hm1 : 1 ≤ m := le_trans (by norm_num) hm
+  have hS : (eulerPoly m : ℚ[X]).eval 1 = (m ! : ℚ) := eval_eulerPoly_one m
+  have hTval : (derivative (eulerPoly m : ℚ[X])).eval 1 = ((m + 1)! : ℚ) / 2 := by
+    linear_combination (two_mul_deriv_eulerPoly_eval_one (R := ℚ) hm1) / 2
+  have hUval : (derivative (derivative (eulerPoly m : ℚ[X]))).eval 1
+      = (3 * (m : ℚ) - 2) * ((m + 1)! : ℚ) / 12 := by
+    linear_combination (twelve_mul_deriv2_eulerPoly_eval_one (R := ℚ) hm) / 12
+  have hfac : (m ! : ℚ) ≠ 0 := by exact_mod_cast (Nat.factorial_pos m).ne'
+  have hfac1 : ((m + 1)! : ℚ) = ((m : ℚ) + 1) * (m ! : ℚ) := by
+    rw [Nat.factorial_succ]; push_cast; ring
+  rw [hS, hTval, hUval, hfac1]
+  field_simp
+  ring
+
+end GeometricSeriesOQ07OQ01OQ01OQ03

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-03",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01"
+    ],
+    "opens": [
+      "Polynomial",
+      "Nat"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ03",
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "title": "Mean and Variance of the Descent Statistic via the Eulerian Polynomial",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "eulerian-polynomial",
+      "descent-statistic",
+      "permutation-statistics",
+      "mean-and-variance",
+      "factorial-moments",
+      "formal-derivative",
+      "generating-functions",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 177,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "two_mul_deriv_eulerPoly_eval_one: the first factorial moment of the descent statistic — for m ≥ 1, 2·E'ₘ(1) = (m+1)!, over an arbitrary commutative ring. Since Eₘ(X) = ∑ₖ ⟨m,k-1⟩·Xᵏ is the descent generating function of Sₘ, the derivative E'ₘ(1) = ∑ₖ k·⟨m,k-1⟩ is the sum over Sₘ of (number of descents + 1); the identity says this sum is (m+1)!/2, i.e. the mean number of descents of a uniformly random permutation of {1,…,m} is (m-1)/2. Proved by induction directly from the differential recurrence, with no combinatorial (bijective) argument.",
+      "twelve_mul_deriv2_eulerPoly_eval_one: the second factorial moment — for m ≥ 2, 12·E''ₘ(1) = (3m-2)·(m+1)!, over an arbitrary commutative ring. Here E''ₘ(1) = ∑ₖ k(k-1)·⟨m,k-1⟩ is the second falling-factorial moment of k = des+1; combined with the first moment it pins down the variance. Proved by induction using the second-derivative recurrence and the first-moment identity.",
+      "deriv_eulerPoly_eval_one_succ: the one-step first-moment recurrence E'_{m+1}(1) = (m+1)·Eₘ(1) + m·E'ₘ(1), obtained by differentiating the differential recurrence E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ once and evaluating at X = 1. The key mechanism is that the factor X·(1-X) vanishes at X = 1, so the unwanted higher-derivative term E''ₘ drops out automatically — this is what makes the analytic definition compute moments mechanically.",
+      "deriv2_eulerPoly_eval_one_succ: the one-step second-moment recurrence E''_{m+1}(1) = 2m·E'ₘ(1) + (m-1)·E''ₘ(1), obtained by differentiating the recurrence twice and evaluating at X = 1 (the X·(1-X) factor again kills the third-derivative term).",
+      "mean_descents_succ: the mean of the (descents+1) statistic over ℚ — for m ≥ 1, E'ₘ(1)/Eₘ(1) = (m+1)/2, so the average number of descents over Sₘ is (m-1)/2 (dividing the first moment by the row sum Eₘ(1) = m!).",
+      "variance_descents_succ: the variance of the descent statistic over ℚ — for m ≥ 2, E''ₘ(1)/Eₘ(1) + E'ₘ(1)/Eₘ(1) − (E'ₘ(1)/Eₘ(1))² = (m+1)/12. The left side is E[k(k-1)] + E[k] − E[k]² = E[k²] − E[k]² = Var(k) for k = des+1 (whose variance equals that of the number of descents), recovering the classical variance (m+1)/12."
+    ],
+    "prerequisites": [
+      "Parent geometric-series-oq-07-oq-01-oq-01 (Frobenius' identity): the Eulerian polynomial eulerPoly defined by the differential recurrence E₀ = 1, E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ, together with eulerPoly_succ, the low-order values eulerPoly_one (E₁ = X) and eulerPoly_two (E₂ = X + X²), and the row sum eval_eulerPoly_one (Eₘ(1) = m!). All imported.",
+      "Mathlib's univariate polynomial derivative/evaluation API: Polynomial.derivative_mul, derivative_add, derivative_sub, derivative_X, derivative_natCast and eval_mul, eval_add, eval_sub, eval_X, eval_natCast — used to differentiate the recurrence and evaluate at X = 1.",
+      "Nat.le_induction for the m ≥ 1 and m ≥ 2 inductions, Nat.factorial_succ for the factorial algebra, and field arithmetic over ℚ (field_simp, linear_combination) for the mean and variance corollaries."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.derivative_mul",
+        "description": "derivative (p*q) = derivative p * q + p * derivative q. Applied (once or twice) to the product terms X·(1-X)·E'ₘ and (m+1)·X·Eₘ of the differential recurrence, then evaluated at X = 1 — where X·(1-X) = 0 — to obtain the one-step moment recurrences.",
+        "module": "Mathlib.Algebra.Polynomial.Derivative"
+      },
+      {
+        "theorem": "Nat.le_induction",
+        "description": "Induction starting from a base point, used to lift the one-step moment recurrences to the closed forms 2·E'ₘ(1) = (m+1)! (from m = 1) and 12·E''ₘ(1) = (3m-2)·(m+1)! (from m = 2).",
+        "module": "Mathlib.Order.Basic"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07OQ01OQ01.eulerPoly",
+        "description": "The Eulerian polynomial, its differential recurrence eulerPoly_succ, and the row sum eval_eulerPoly_one (Eₘ(1) = m!) from the parent entry. The whole development is differentiation-and-evaluation of this single recurrence.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-03-oq-01",
+      "question": "Compute the full moment generating function of the descent statistic: show that ∑ₖ ⟨m,k-1⟩·xᵏ evaluated and differentiated repeatedly at x = 1 yields all factorial moments, and identify the third central moment / skewness, confirming the descent statistic is asymptotically normal (a finite-m version of the Central Limit Theorem for descents).",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-03-oq-02",
+      "question": "Prove Worpitzky's identity xᵐ = ∑ₖ ⟨m,k-1⟩·C(x+k-1, m) (equivalently the denominator-free m!·xᵐ = ∑ₖ ⟨m,k-1⟩·(x+k-1)^{\\underline{m}}) from the same differential recurrence, using the classical triangle recurrence read off coeff_eulerPoly_succ_add_two together with the binomial absorption identity x·C(x+k,m) = (m-k)·C(x+k+1,m+1) + (k+1)·C(x+k,m+1).",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent (Frobenius' identity). It defines the Eulerian polynomial eulerPoly by its differential recurrence and proves the row sum Eₘ(1) = m! (the zeroth moment). This entry reads off the first and second moments of the descent statistic by differentiating the same recurrence and evaluating at X = 1."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "Palindromicity ⟨m,k⟩ = ⟨m,m-1-k⟩ of the Eulerian numbers, also derived from the differential recurrence by coefficient extraction. Palindromicity gives the symmetry of the descent distribution around its mean (m-1)/2, which this entry computes directly."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01",
+      "relationship": "sibling",
+      "description": "Grandparent: the all-orders analytic moment ∑ nᵐ rⁿ = ∑ₖ S(m,k)·k!·rᵏ/(1−r)^{k+1}, whose (1−r)^{m+1}-cleared numerator is the Eulerian polynomial. The descent moments here are the X = 1 derivatives of that numerator."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers; mean and variance of the descent statistic)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian numbers ⟨m,k⟩, the descent generating function, and the moments of the descent statistic (mean (m-1)/2, variance (m+1)/12)."
+    },
+    {
+      "title": "Combinatorics of Permutations (descents and Eulerian numbers)",
+      "author": "Miklós Bóna",
+      "year": "2012",
+      "venue": "CRC Press",
+      "description": "Develops the descent statistic on Sₘ, its Eulerian generating function, and the normal limit law whose first two moments are computed here."
+    },
+    {
+      "title": "Mathlib4: Algebra.Polynomial.Derivative",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of derivative_mul, derivative_X, eval_mul and the polynomial derivative/evaluation API used to differentiate the Eulerian recurrence and evaluate at X = 1."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Working only from the differential recurrence E₀ = 1, E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ that defines the Eulerian polynomial (parent entry), this file computes the first two moments of the descent statistic on the symmetric group Sₘ by differentiating the recurrence and evaluating at X = 1. Because the factor X·(1-X) vanishes at X = 1, differentiating once (resp. twice) yields clean linear recurrences for E'ₘ(1) and E''ₘ(1) (deriv_eulerPoly_eval_one_succ, deriv2_eulerPoly_eval_one_succ), whose closed forms are 2·E'ₘ(1) = (m+1)! for m ≥ 1 and 12·E''ₘ(1) = (3m-2)·(m+1)! for m ≥ 2. Dividing by the row sum Eₘ(1) = m! recovers, over ℚ, the classical facts that a uniformly random permutation of {1,…,m} has mean number of descents (m-1)/2 (mean_descents_succ) and variance (m+1)/12 (variance_descents_succ). 177 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries; every result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The mean (m-1)/2 and variance (m+1)/12 of the descent statistic are textbook facts usually obtained from the combinatorial (descent-counting) definition of the Eulerian numbers or by manipulating their generating function. Here they fall out mechanically from the analytic differential-recurrence definition: each moment is the evaluation of a formal derivative of Eₘ at X = 1, and the vanishing of X·(1-X) at 1 makes the recursion close in low order. Mathlib has neither the Eulerian numbers nor these moments. The integral identities (2·E'ₘ(1) = (m+1)!, 12·E''ₘ(1) = (3m-2)(m+1)!) hold over any commutative ring, the rational corollaries package them as the mean and variance of the permutation-descent distribution.",
+    "openQuestions": [
+      "Extend to all factorial moments and the third central moment / skewness, towards the asymptotic normality of the descent statistic.",
+      "Prove Worpitzky's identity xᵐ = ∑ₖ ⟨m,k-1⟩·C(x+k-1, m) from the same differential recurrence via the classical triangle recurrence and binomial absorption."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Depth follow-up of the Frobenius / Eulerian-polynomial lineage (`geometric-series-oq-07-oq-01-oq-01`, merged). The Eulerian polynomial

  Eₘ(X) = ∑ₖ ⟨m,k-1⟩·Xᵏ,  defined by  E₀ = 1,  E_{m+1} = X·(1-X)·E'ₘ + (m+1)·X·Eₘ

is the **descent generating function** of the symmetric group `Sₘ`. This entry computes the first two **moments of the descent statistic** by differentiating that single differential recurrence and evaluating at `X = 1` — where the factor `X·(1-X)` vanishes, so each higher-derivative term drops out and the recursion closes in low order.

### Main results (integral, any commutative ring)
- `two_mul_deriv_eulerPoly_eval_one`: **2·E'ₘ(1) = (m+1)!**  (m ≥ 1) — first factorial moment.
- `twelve_mul_deriv2_eulerPoly_eval_one`: **12·E''ₘ(1) = (3m-2)·(m+1)!**  (m ≥ 2) — second factorial moment.

### Corollaries over ℚ
- `mean_descents_succ`: **E'ₘ(1)/Eₘ(1) = (m+1)/2**, i.e. the mean number of descents is **(m-1)/2**.
- `variance_descents_succ`: **E''ₘ(1)/Eₘ(1) + E'ₘ(1)/Eₘ(1) − (E'ₘ(1)/Eₘ(1))² = (m+1)/12**, the classical descent variance **(m+1)/12**.

The point is methodological: the mean and variance — textbook facts usually proved from the combinatorial descent-counting definition — fall out **mechanically** from the analytic definition, each moment being a formal-derivative evaluation of `Eₘ` at `1`. Mathlib has neither the Eulerian numbers nor these moments.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ07OQ01OQ01OQ03` — builds clean (7745 jobs, no warnings).
- 177 lines, 6 theorems, 0 definitions, **0 axioms, 0 sorries** (propext / Classical.choice / Quot.sound only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)