### PR TITLE
research(lebesgue-measure-oq-01-oq-01-oq-01): Thomae's function via Lebesgue's criterion — the discontinuity set is null [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2893,6 +2893,7 @@ import Proofs.LawsOfLargeNumbersOQ04OQ03QuantileBracketing
 import Proofs.LebesgueMeasure
 import Proofs.LebesgueMeasureOQ01
 import Proofs.LebesgueMeasureOQ01OQ01
+import Proofs.LebesgueMeasureOQ01OQ01OQ01
 import Proofs.LebesgueMeasureOQ01OQ01OQ02
 import Proofs.LebesgueMeasureOQ01OQ01OQ02Riemann
 import Proofs.LebesgueMeasureOQ01OQ03

--- a/proofs/Proofs/LebesgueMeasureOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ01OQ01OQ01.lean
@@ -1,0 +1,229 @@
+import Mathlib
+
+/-
+# Thomae's Function and Lebesgue's Criterion for Riemann Integrability
+
+## Open Question (lebesgue-measure-oq-01-oq-01-oq-01)
+Can we formalize the Riemann integrability of Thomae's function via **Lebesgue's
+criterion** — the principle that a bounded function on `[a,b]` is Riemann
+integrable iff its set of discontinuities has Lebesgue measure zero?
+
+## Answer: YES — the discontinuity set is null
+This entry supplies the **measure-theoretic content of Lebesgue's criterion**,
+the part the prior Riemann entry (`…-oq-01-oq-01-oq-02-oq-01`) deliberately
+sidestepped (it went through `thomae =ᵐ 0` instead, noting Mathlib exposes no
+first-class Lebesgue-criterion lemma). Concretely:
+
+1. Thomae's function is **continuous at every irrational** (rebuilt here in a
+   self-contained way: only finitely many rationals of bounded denominator lie
+   near an irrational, and they sit a positive distance away).
+2. Hence the discontinuity set `{x | ¬ ContinuousAt thomae x}` is contained in
+   the rationals `range ((↑) : ℚ → ℝ)`.
+3. The rationals are countable, hence **Lebesgue-null** for the atomless measure
+   `volume` (`Set.Countable.measure_zero`).
+4. Therefore the discontinuity set is null, so Thomae's function is **continuous
+   almost everywhere** — exactly the hypothesis of Lebesgue's criterion.
+
+By Lebesgue's theorem this is what makes Thomae's function Riemann integrable; we
+package the criterion (null discontinuity set + a.e.-continuity) with the value:
+the function is integrable with `∫ = 0`, on the line and on `[0,1]`.
+
+## Note on "Riemann integrable"
+Mathlib's `intervalIntegral` is the Bochner/Lebesgue integral and carries no
+separate `RiemannIntegrable` predicate. The classical assertion "Thomae's
+function is Riemann integrable on `[0,1]`" is the consequence of Lebesgue's
+criterion *because* its discontinuity set is null — the content of
+`thomae_discontinuitySet_null` and `thomae_ae_continuousAt`. The value `0`
+agrees with the Lebesgue integral.
+
+## Self-containment
+The continuity-at-irrationals argument is reproved here rather than imported: the
+existing gallery file carrying it has bit-rotted against the current Mathlib
+(`div_lt_iff`, `Set.Finite.ofFinset` signature, induction-pattern drift). The
+proof below uses the current API (`div_lt_iff₀`, `Set.Finite.subset`,
+`one_div_le_one_div_of_le`).
+-/
+
+namespace LebesgueMeasureOQ01OQ01OQ01
+
+open MeasureTheory
+
+open Classical in
+/-- Thomae's function (popcorn function): `1/q.den` if `x` is rational, `0` if
+irrational. -/
+noncomputable def thomae : ℝ → ℝ := fun x =>
+  if h : ∃ q : ℚ, (q : ℝ) = x then 1 / (h.choose.den : ℝ) else 0
+
+/-- `thomae = 0` at irrationals. -/
+theorem thomae_irrational {x : ℝ} (hx : Irrational x) : thomae x = 0 := by
+  have hne : ¬ ∃ q : ℚ, (q : ℝ) = x := by
+    rintro ⟨q, rfl⟩; exact hx ⟨q, rfl⟩
+  simp only [thomae, dif_neg hne]
+
+/-- `thomae` at a rational `q` equals `1/q.den`. -/
+theorem thomae_rat (q : ℚ) : thomae (q : ℝ) = 1 / (q.den : ℝ) := by
+  have hq : ∃ r : ℚ, (r : ℝ) = (q : ℝ) := ⟨q, rfl⟩
+  have heq : hq.choose = q := Rat.cast_inj.mp hq.choose_spec
+  simp only [thomae, dif_pos hq, heq]
+
+-- ============================================================
+-- PART 1: Continuity at the irrationals (self-contained)
+-- ============================================================
+
+/-- `q.num = q * q.den` over `ℝ`. -/
+private lemma rat_num_eq_mul_den (q : ℚ) : (q.num : ℝ) = (q : ℝ) * q.den := by
+  have hd : (q.den : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr q.pos.ne'
+  have hq_eq : (q.num : ℚ) = q * q.den := (div_eq_iff hd).mp (Rat.num_div_den q)
+  exact_mod_cast hq_eq
+
+/-- Rationals with bounded denominator in `[x-1, x+1]` form a finite set. -/
+private lemma finite_rat_bounded (x : ℝ) (N : ℕ) :
+    Set.Finite {q : ℚ | |(q : ℝ) - x| ≤ 1 ∧ q.den ≤ N} := by
+  apply Set.Finite.subset (Finset.finite_toSet
+    ((Finset.range (N + 1)).biUnion fun d =>
+      (Finset.Icc ⌊(x - 1) * (d : ℝ)⌋ ⌈(x + 1) * (d : ℝ)⌉).image
+        fun n : ℤ => (n : ℚ) / (d : ℚ)))
+  intro q hq
+  obtain ⟨habs, hden⟩ := hq
+  rw [Finset.mem_coe]
+  simp only [Finset.mem_biUnion, Finset.mem_range, Finset.mem_image, Finset.mem_Icc]
+  have habs' := abs_le.mp habs
+  have hq_lower : x - 1 ≤ (q : ℝ) := by linarith [habs'.1]
+  have hq_upper : (q : ℝ) ≤ x + 1 := by linarith [habs'.2]
+  have hden_pos : (0 : ℝ) < (q.den : ℝ) := Nat.cast_pos.mpr q.pos
+  have hq_num := rat_num_eq_mul_den q
+  refine ⟨q.den, Nat.lt_succ_of_le hden, q.num, ⟨?_, ?_⟩, ?_⟩
+  · have hle : (x - 1) * (q.den : ℝ) ≤ (q.num : ℝ) := by
+      rw [hq_num]; nlinarith [hq_lower, hden_pos]
+    have := (Int.floor_le ((x - 1) * (q.den : ℝ))).trans hle
+    exact_mod_cast this
+  · have hge : (q.num : ℝ) ≤ (x + 1) * (q.den : ℝ) := by
+      rw [hq_num]; nlinarith [hq_upper, hden_pos]
+    have := hge.trans (Int.le_ceil ((x + 1) * (q.den : ℝ)))
+    exact_mod_cast this
+  · exact Rat.num_div_den q
+
+/-- From an irrational `x` and a finite set of rationals, there is a positive
+minimum distance from `x` to the set. -/
+private lemma pos_min_dist {x : ℝ} (hx : Irrational x) (S : Finset ℚ) :
+    ∃ δ > 0, ∀ q ∈ S, δ ≤ |x - (q : ℝ)| := by
+  induction S using Finset.induction_on with
+  | empty => exact ⟨1, one_pos, by simp⟩
+  | @insert a s _ ih =>
+    obtain ⟨δ₀, hδ₀, hq₀⟩ := ih
+    refine ⟨min δ₀ |x - (a : ℝ)|, lt_min hδ₀ ?_, fun q hq' => ?_⟩
+    · rw [abs_pos, sub_ne_zero]
+      exact fun h => hx ⟨a, h.symm⟩
+    · rcases Finset.mem_insert.mp hq' with rfl | hq''
+      · exact min_le_right _ _
+      · exact (min_le_left _ _).trans (hq₀ q hq'')
+
+/-- **Thomae's function is continuous at every irrational.** -/
+theorem thomae_continuous_at_irrational {x : ℝ} (hx : Irrational x) :
+    ContinuousAt thomae x := by
+  rw [Metric.continuousAt_iff]
+  simp only [thomae_irrational hx, Real.dist_eq, sub_zero]
+  intro ε hε
+  obtain ⟨N, hN_raw⟩ : ∃ N : ℕ, (1 : ℝ) / ε < N := exists_nat_gt (1 / ε)
+  have hNpos : (0 : ℝ) < N := by linarith [div_pos one_pos hε]
+  have hN : (1 : ℝ) / (↑N + 1) < ε := by
+    rw [div_lt_iff₀ (by linarith : (0 : ℝ) < ↑N + 1)]
+    have h1 : (1 : ℝ) < N * ε := (div_lt_iff₀ hε).mp hN_raw
+    nlinarith [h1, hε]
+  have hS := finite_rat_bounded x N
+  obtain ⟨δ, hδ, hbnd⟩ := pos_min_dist hx hS.toFinset
+  refine ⟨min δ 1, lt_min hδ one_pos, fun y hy => ?_⟩
+  have hy1 : |y - x| ≤ 1 := le_of_lt (hy.trans_le (min_le_right _ _))
+  by_cases hirr : Irrational y
+  · rw [thomae_irrational hirr, abs_zero]; exact hε
+  · simp only [Irrational, not_not] at hirr
+    obtain ⟨q, hq⟩ := hirr
+    rw [← hq, thomae_rat, abs_of_nonneg (by positivity)]
+    rcases le_or_gt q.den N with hle | hlt
+    · have hmem : q ∈ hS.toFinset := by
+        rw [Set.Finite.mem_toFinset]
+        refine ⟨?_, hle⟩
+        rw [hq]; exact hy1
+      have hdist : δ ≤ |x - (q : ℝ)| := hbnd q hmem
+      have hclose : |y - x| < δ := hy.trans_le (min_le_left _ _)
+      rw [← hq] at hclose
+      linarith [abs_sub_comm (q : ℝ) x]
+    · calc (1 : ℝ) / (q.den : ℝ)
+          ≤ 1 / (↑N + 1) :=
+            one_div_le_one_div_of_le (by linarith)
+              (by exact_mod_cast Nat.succ_le_of_lt hlt)
+        _ < ε := hN
+
+-- ============================================================
+-- PART 2: Lebesgue's criterion — the discontinuity set is null
+-- ============================================================
+
+/-- Every discontinuity point of Thomae's function is rational. -/
+theorem thomae_discontinuitySet_subset :
+    {x : ℝ | ¬ ContinuousAt thomae x} ⊆ Set.range ((↑) : ℚ → ℝ) := by
+  intro x hx
+  by_contra hxr
+  -- `hxr : x ∉ Set.range ((↑) : ℚ → ℝ)` is definitionally `Irrational x`
+  exact hx (thomae_continuous_at_irrational hxr)
+
+/-- The image of `ℚ` in `ℝ` has Lebesgue measure zero (countable, atomless `volume`). -/
+theorem rat_range_null : volume (Set.range ((↑) : ℚ → ℝ)) = 0 :=
+  (Set.countable_range _).measure_zero volume
+
+/-- **Lebesgue's criterion (measure side).** The discontinuity set of Thomae's
+function has Lebesgue measure zero. -/
+theorem thomae_discontinuitySet_null :
+    volume {x : ℝ | ¬ ContinuousAt thomae x} = 0 :=
+  measure_mono_null thomae_discontinuitySet_subset rat_range_null
+
+/-- Thomae's function is **continuous almost everywhere** — the hypothesis of
+Lebesgue's criterion, from which classical Riemann integrability follows. -/
+theorem thomae_ae_continuousAt : ∀ᵐ x ∂volume, ContinuousAt thomae x := by
+  rw [ae_iff]
+  exact thomae_discontinuitySet_null
+
+-- ============================================================
+-- PART 3: Integrability and the value
+-- ============================================================
+
+/-- Thomae's function vanishes almost everywhere. -/
+theorem thomae_ae_zero : ∀ᵐ x ∂volume, thomae x = 0 := by
+  have hsub : {x : ℝ | thomae x ≠ 0} ⊆ Set.range ((↑) : ℚ → ℝ) := by
+    intro x hx
+    by_contra hxr
+    exact hx (thomae_irrational hxr)
+  rw [ae_iff]
+  exact measure_mono_null hsub rat_range_null
+
+/-- Thomae's function is Lebesgue integrable (a.e. equal to `0`). -/
+theorem thomae_integrable : Integrable thomae volume := by
+  refine (integrable_zero ℝ ℝ volume).congr ?_
+  filter_upwards [thomae_ae_zero] with x hx
+  exact hx.symm
+
+/-- The integral of Thomae's function over the line is `0`. -/
+theorem thomae_integral_zero : ∫ x, thomae x ∂volume = 0 :=
+  integral_eq_zero_of_ae thomae_ae_zero
+
+/-- Thomae's function is integrable on `[0,1]`. -/
+theorem thomae_integrableOn_Icc : IntegrableOn thomae (Set.Icc 0 1) volume :=
+  thomae_integrable.integrableOn
+
+/-- The interval integral of Thomae's function over `[0,1]` is `0`. -/
+theorem thomae_intervalIntegral_zero : ∫ x in (0 : ℝ)..1, thomae x = 0 := by
+  have h0 : ∫ x in (0 : ℝ)..1, thomae x = ∫ _ in (0 : ℝ)..1, (0 : ℝ) :=
+    intervalIntegral.integral_congr_ae
+      (by filter_upwards [thomae_ae_zero] with x hx _; exact hx)
+  rw [h0, intervalIntegral.integral_zero]
+
+/-- **Lebesgue's criterion for Thomae's function.** Its discontinuity set is
+Lebesgue-null (so it is continuous a.e.), and it is integrable with interval
+integral `0` over `[0,1]`. Classically this is exactly the statement that
+Thomae's function is Riemann integrable on `[0,1]` with value `0`, now obtained
+through the criterion rather than around it. -/
+theorem thomae_riemann_via_lebesgue_criterion :
+    volume {x : ℝ | ¬ ContinuousAt thomae x} = 0 ∧
+      Integrable thomae volume ∧ ∫ x in (0 : ℝ)..1, thomae x = 0 :=
+  ⟨thomae_discontinuitySet_null, thomae_integrable, thomae_intervalIntegral_zero⟩
+
+end LebesgueMeasureOQ01OQ01OQ01

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "lebesgue-measure-oq-01-oq-01-oq-01",
+  "slug": "lebesgue-measure-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MeasureTheory"
+    ],
+    "namespace": "LebesgueMeasureOQ01OQ01OQ01",
+    "lineCount": 229,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "path": "Proofs/LebesgueMeasureOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Thomae's Function and Lebesgue's Criterion for Riemann Integrability",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LebesgueMeasureOQ01OQ01OQ01.lean",
+    "tags": [
+      "measure-theory",
+      "lebesgue-measure",
+      "thomae-function",
+      "popcorn-function",
+      "riemann-integrability",
+      "lebesgue-criterion",
+      "almost-everywhere-continuity",
+      "null-set",
+      "real-analysis",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 229,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "thomae_continuous_at_irrational: a self-contained proof that Thomae's function is continuous at every irrational, rebuilt against the current Mathlib API (the gallery file previously carrying this had bit-rotted: `div_lt_iff` → `div_lt_iff₀`, `Set.Finite.ofFinset` now needs an iff so `Set.Finite.subset` is used, `one_div_le_one_div_of_le` for the denominator bound, `@insert` induction pattern). The ε–δ argument: pick N with 1/(N+1) < ε; only finitely many rationals of denominator ≤ N lie in [x−1,x+1] (finite_rat_bounded), so they keep a positive distance δ from the irrational x (pos_min_dist); within min(δ,1), a rational point has denominator > N hence value < ε.",
+      "thomae_discontinuitySet_subset: the discontinuity set {x | ¬ContinuousAt thomae x} is contained in the rationals range((↑):ℚ→ℝ) — the contrapositive of continuity at the irrationals.",
+      "rat_range_null: the image of ℚ in ℝ is Lebesgue-null (countable set in the atomless measure volume, via Set.Countable.measure_zero).",
+      "thomae_discontinuitySet_null: **the measure side of Lebesgue's criterion** — the discontinuity set of Thomae's function has Lebesgue measure zero.",
+      "thomae_ae_continuousAt: Thomae's function is continuous almost everywhere — the exact hypothesis of Lebesgue's criterion for Riemann integrability, the part the prior Riemann entry deliberately routed around.",
+      "thomae_integrable / thomae_integral_zero / thomae_integrableOn_Icc / thomae_intervalIntegral_zero: integrability and the integral value 0 (over the line and over [0,1]), recovered self-containedly from a.e.-vanishing.",
+      "thomae_riemann_via_lebesgue_criterion: the criterion packaged — null discontinuity set ∧ integrable ∧ ∫₀¹ = 0; classically, 'Riemann integrable on [0,1] with value 0' obtained through the criterion rather than around it."
+    ],
+    "prerequisites": [
+      "Set.Countable.measure_zero (Mathlib): a countable set is null for any atomless (NoAtoms) measure — turns the rationals into a null set",
+      "MeasureTheory.ae_iff (Mathlib): (∀ᵐ x, p x) ↔ μ {x | ¬ p x} = 0 — converts the null discontinuity set into a.e.-continuity",
+      "measure_mono_null (Mathlib): a subset of a null set is null — the discontinuity set ⊆ rationals",
+      "div_lt_iff₀, one_div_le_one_div_of_le (Mathlib): ordered-field reciprocal manipulations behind the ε–δ continuity bound",
+      "Int.floor_le, Int.le_ceil (Mathlib): integer bracketing of the numerator, behind finite_rat_bounded",
+      "Sibling: lebesgue-measure-oq-01-oq-01-oq-02 (the continuity classification; reproved here because that file has bit-rotted), and …-oq-02-oq-01 (the prior Riemann-integrability entry that sidestepped the criterion)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.Countable.measure_zero",
+        "description": "A countable set has measure zero for any NoAtoms measure. Applied to range((↑):ℚ→ℝ) with volume to make the rationals (hence the discontinuity set) null.",
+        "module": "Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms"
+      },
+      {
+        "theorem": "MeasureTheory.ae_iff",
+        "description": "(∀ᵐ x ∂μ, p x) ↔ μ {x | ¬ p x} = 0. Converts the null discontinuity set into the a.e.-continuity statement (Lebesgue's criterion) and the null nonzero-set into a.e.-vanishing.",
+        "module": "Mathlib.MeasureTheory.Measure.AEDisjoint"
+      },
+      {
+        "theorem": "measure_mono_null",
+        "description": "s ⊆ t → μ t = 0 → μ s = 0. The discontinuity set, contained in the null rationals, is itself null.",
+        "module": "Mathlib.MeasureTheory.Measure.MeasureSpaceDef"
+      },
+      {
+        "theorem": "div_lt_iff₀",
+        "description": "0 < c → (b / c < a ↔ b < a * c). The current-API replacement for the bit-rotted `div_lt_iff`, used to turn 1/(N+1) < ε into a polynomial inequality.",
+        "module": "Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic"
+      },
+      {
+        "theorem": "intervalIntegral.integral_congr_ae",
+        "description": "Equal a.e. on the interval ⇒ equal interval integrals. Reduces ∫₀¹ thomae to ∫₀¹ 0 = 0 from a.e.-vanishing.",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "lebesgue-measure-oq-01-oq-01-oq-01-oq-01",
+      "question": "State and prove the *general* Lebesgue criterion in Lean — for an arbitrary bounded f on [a,b], Riemann integrability ⇔ the discontinuity set is null — rather than instantiating it for Thomae's function. This needs a Lean development of the Riemann/Darboux integral (Mathlib currently has only the Bochner/Lebesgue integral and the box-integral), against which Thomae would become a corollary.",
+      "significance": "high"
+    },
+    {
+      "id": "lebesgue-measure-oq-01-oq-01-oq-01-oq-02",
+      "question": "Quantify the discontinuity: prove that the oscillation of Thomae's function at a rational p/q (in lowest terms) is exactly 1/q, and that the set where oscillation ≥ ε is finite in every bounded interval — the finer form of Lebesgue's criterion via the oscillation function.",
+      "significance": "medium"
+    },
+    {
+      "id": "lebesgue-measure-oq-01-oq-01-oq-01-oq-03",
+      "question": "Construct the 2D popcorn function and show it is Lebesgue integrable but not Riemann integrable on the unit square (its discontinuity set has positive planar measure on a line of rationals), giving an explicit Lebesgue-but-not-Riemann example — the parent's third open question.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lebesgue-measure-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent: Thomae's (modified Dirichlet) function and its Lebesgue integral 0 via a.e.-zero. Its first open question asks to formalize Riemann integrability via Lebesgue's criterion (measure-zero discontinuities) — answered here on the measure side."
+    },
+    {
+      "targetId": "lebesgue-measure-oq-01-oq-01-oq-02",
+      "relationship": "depends-on",
+      "description": "Sibling that classified the continuity of Thomae's function (continuous at irrationals, discontinuous at rationals). The continuity-at-irrationals result is reproved here self-containedly because that file has bit-rotted against the current Mathlib."
+    },
+    {
+      "targetId": "lebesgue-measure-oq-01-oq-01-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Prior Riemann-integrability entry which proved integrability and ∫₀¹ = 0 through `thomae =ᵐ 0`, explicitly stating it sidestepped the Lebesgue criterion. This entry supplies precisely the criterion it routed around: the null discontinuity set and a.e.-continuity."
+    }
+  ],
+  "references": [
+    {
+      "title": "Sur une généralisation de l'intégrale définie (Lebesgue's criterion)",
+      "author": "Henri Lebesgue",
+      "year": "1902",
+      "venue": "Comptes Rendus / Annali di Matematica",
+      "description": "Lebesgue's theorem: a bounded function on [a,b] is Riemann integrable iff its set of discontinuities has measure zero. The criterion whose measure-theoretic content is formalized here for Thomae's function."
+    },
+    {
+      "title": "Principles of Mathematical Analysis",
+      "author": "Walter Rudin",
+      "year": "1976",
+      "venue": "McGraw-Hill",
+      "description": "Standard reference for Lebesgue's criterion, the oscillation function, and Thomae's (popcorn) function as the canonical Riemann-integrable function with a dense set of discontinuities."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Thomae's function is treated through Lebesgue's criterion for Riemann integrability. Continuity at every irrational is reproved self-containedly (only finitely many rationals of bounded denominator lie near an irrational, at a positive distance), so the discontinuity set {x | ¬ContinuousAt thomae x} is contained in the rationals (thomae_discontinuitySet_subset). The rationals are countable hence Lebesgue-null (rat_range_null), so the discontinuity set is null (thomae_discontinuitySet_null) — the measure side of Lebesgue's criterion — and Thomae's function is continuous almost everywhere (thomae_ae_continuousAt). It is integrable with integral 0 over the line and over [0,1] (thomae_integrable, thomae_integral_zero, thomae_intervalIntegral_zero), packaged as thomae_riemann_via_lebesgue_criterion. 229 lines, 13 theorems, 1 definition, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This answers the first open question of the Thomae grandparent — formalizing the Riemann integrability of Thomae's function via Lebesgue's criterion — by supplying exactly the criterion's measure-theoretic content (the null discontinuity set and a.e.-continuity) that the prior Riemann entry explicitly sidestepped in favor of the cheaper `thomae =ᵐ 0` route. Because Mathlib has no first-class Riemann/Darboux integral or general Lebesgue-criterion lemma, the genuinely general statement remains open; here the criterion is realized concretely for the popcorn function, the textbook example where it bites. A side effect is a self-contained, current-API proof of continuity-at-irrationals that repairs the bit-rotted continuity file.",
+    "openQuestions": [
+      "Formalize the general Lebesgue criterion (bounded f on [a,b] Riemann integrable ⇔ discontinuities null), which requires a Lean Riemann/Darboux integral.",
+      "Prove the oscillation of Thomae at p/q is exactly 1/q and that {oscillation ≥ ε} is finite per bounded interval.",
+      "Build the 2D popcorn function as an explicit Lebesgue-but-not-Riemann integrable example on the unit square."
+    ]
+  }
+}

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-01/proof.md
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-01/proof.md
@@ -1,0 +1,90 @@
+# Thomae's Function and Lebesgue's Criterion for Riemann Integrability
+
+## The Question
+
+Thomae's function (the "popcorn function")
+$$
+T(x) = \begin{cases} 1/q & x = p/q \text{ in lowest terms},\\ 0 & x \text{ irrational},\end{cases}
+$$
+is the textbook example of a function that is **Riemann integrable despite being
+discontinuous on a dense set** (every rational). *Why* is it Riemann integrable?
+**Lebesgue's criterion**: a bounded function on $[a,b]$ is Riemann integrable if
+and only if its set of discontinuities has Lebesgue measure zero.
+
+The grandparent entry computed the Lebesgue integral of $T$ via $T =_{\text{a.e.}} 0$;
+a later entry proved Riemann integrability but **deliberately routed around the
+criterion** (Mathlib has no first-class `RiemannIntegrable` predicate). This entry
+supplies the part that was skipped: the **measure-theoretic heart of Lebesgue's
+criterion** — that the discontinuity set of $T$ is null.
+
+## The Argument
+
+### 1. $T$ is continuous at every irrational
+
+Fix an irrational $x$ and $\varepsilon > 0$. Choose $N$ with $1/(N+1) < \varepsilon$.
+
+- **Finitely many "bad" rationals nearby.** Only finitely many rationals with
+  denominator $\le N$ lie in $[x-1, x+1]$ (`finite_rat_bounded`): for each
+  denominator $d \le N$ the numerator is pinned between $\lfloor (x-1)d\rfloor$
+  and $\lceil (x+1)d\rceil$.
+- **They stay away from $x$.** Since $x$ is irrational, its distance to this
+  finite set is some $\delta > 0$ (`pos_min_dist`).
+- **Conclusion.** For $|y - x| < \min(\delta, 1)$: if $y$ is irrational then
+  $T(y) = 0 < \varepsilon$; if $y = p/q$ then $q > N$ (else $y$ would be one of
+  the bad rationals within $\delta$), so $T(y) = 1/q < 1/(N+1) < \varepsilon$.
+
+Hence $|T(y) - T(x)| = |T(y)| < \varepsilon$, i.e. $T$ is continuous at $x$.
+
+### 2. The discontinuity set is contained in the rationals
+
+By the contrapositive: if $T$ is discontinuous at $x$, then $x$ is not irrational,
+so $x \in \operatorname{range}(\mathbb{Q} \hookrightarrow \mathbb{R})$
+(`thomae_discontinuitySet_subset`).
+
+### 3. The rationals are Lebesgue-null
+
+$\operatorname{range}(\mathbb{Q} \hookrightarrow \mathbb{R})$ is **countable**, and
+Lebesgue measure has no atoms, so it is null (`rat_range_null`,
+`Set.Countable.measure_zero`).
+
+### 4. Lebesgue's criterion
+
+Therefore the discontinuity set is null (`thomae_discontinuitySet_null`), which is
+**exactly the hypothesis of Lebesgue's criterion**. Equivalently, $T$ is
+**continuous almost everywhere** (`thomae_ae_continuousAt`). By Lebesgue's theorem
+this is what makes $T$ Riemann integrable.
+
+### 5. The value
+
+$T$ vanishes a.e. (its nonzero set $\subseteq$ the null rationals), so it is
+integrable with
+$$\int_{\mathbb{R}} T = 0, \qquad \int_0^1 T = 0,$$
+packaged with the criterion in `thomae_riemann_via_lebesgue_criterion`.
+
+## A Note on "Riemann Integrable"
+
+Mathlib's `intervalIntegral` *is* the Bochner/Lebesgue integral; there is no
+separate `RiemannIntegrable` predicate, and no general Lebesgue-criterion lemma.
+So "Riemann integrable" is not a Lean statement we can name directly. What we
+*can* — and do — formalize is the criterion's content for $T$: the discontinuity
+set is null and $T$ is continuous a.e. Classically these *are* the reason $T$ is
+Riemann integrable, and the Lebesgue value $0$ matches the Riemann value.
+
+## Self-Containment
+
+The continuity-at-irrationals argument is reproved here rather than imported,
+because the gallery file that carried it has **bit-rotted** against the current
+Mathlib: `div_lt_iff` became `div_lt_iff₀`, `Set.Finite.ofFinset` now demands an
+`iff` (so we use `Set.Finite.subset`), the denominator bound uses
+`one_div_le_one_div_of_le`, and the `Finset.induction_on` `insert` case takes the
+`@insert` binder form. The proof here compiles 0-sorry, 0-axiom against the
+pinned toolchain.
+
+## Historical Significance
+
+Henri Lebesgue's 1902 criterion explained, once and for all, *which* bounded
+functions are Riemann integrable — the discontinuities must be negligible in
+measure. Thomae's function (1875) is the sharp example: discontinuous on a dense
+set yet Riemann integrable, because that dense set (the rationals) has measure
+zero. It marks the boundary where the Riemann integral runs out and the Lebesgue
+integral takes over.


### PR DESCRIPTION
## Summary

Answers the **first open question** of the Thomae grandparent (`lebesgue-measure-oq-01-oq-01`): *formalize the Riemann integrability of Thomae's function via Lebesgue's criterion (measure-zero discontinuities).*

A later entry (`…-oq-02-oq-01`) proved integrability and `∫₀¹ = 0` but **explicitly sidestepped** the criterion, going through `thomae =ᵐ 0`. This PR supplies precisely the criterion's measure-theoretic content it routed around:

1. **Discontinuities ⊆ rationals** — `{x | ¬ContinuousAt thomae x} ⊆ range((↑):ℚ→ℝ)`, the contrapositive of continuity at the irrationals.
2. **Rationals are null** — countable + atomless `volume` (`Set.Countable.measure_zero`).
3. **Lebesgue's criterion (measure side)** — the discontinuity set is null (`thomae_discontinuitySet_null`).
4. **a.e.-continuity** — `thomae_ae_continuousAt`, the exact hypothesis of Lebesgue's theorem.
5. **Value** — integrable with `∫ = 0` on the line and on `[0,1]`, packaged in `thomae_riemann_via_lebesgue_criterion`.

## Self-contained (repairs bit-rot)

The continuity-at-irrationals result lives in a sibling file that has **bit-rotted** against the current pinned Mathlib (`div_lt_iff` removed, `Set.Finite.ofFinset` now needs an `iff`, induction-pattern drift), so it cannot be imported. I reprove it here with the current API: `div_lt_iff₀`, `Set.Finite.subset`, `one_div_le_one_div_of_le`, `@insert` induction. The ε–δ argument: only finitely many bounded-denominator rationals lie near an irrational, at a positive distance δ; within `min(δ,1)` a rational point has denominator > N hence value < ε.

## Verification

- **229 lines, 13 theorems, 1 definition, 0 axioms, 0 sorries**
- Docker build succeeds
- `#print axioms` on `thomae_riemann_via_lebesgue_criterion` and `thomae_ae_continuousAt`: `[propext, Classical.choice, Quot.sound]` only — genuinely 0-axiom

## Note

Mathlib's `intervalIntegral` is the Bochner/Lebesgue integral with no separate `RiemannIntegrable` predicate; "Riemann integrable" is therefore not a nameable Lean statement. What is formalized is the criterion's content for Thomae's function (null discontinuity set + a.e.-continuity), which is *why* it is classically Riemann integrable, with the value `0` matching.

## Heads-up for Mechanic/Auditor

`Proofs/LebesgueMeasureOQ01OQ01OQ02.lean` (and the `…OQ02Riemann` file importing it) currently **fail to build** against the pinned Mathlib (`Function.tendsto`, `div_lt_iff`, `Set.Finite.ofFinset` signature, `rcases`/`introN` drift). Worth a repair pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)