### PR TITLE
research(geometric-series-oq-07-oq-01-oq-01-oq-01): the combinatorial Eulerian numbers — coefficients of the Eulerian polynomial are ⟨m,j⟩ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2631,6 +2631,7 @@ import Proofs.GeometricSeriesOQ06
 import Proofs.GeometricSeriesOQ07
 import Proofs.GeometricSeriesOQ07OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ02
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ03
 import Proofs.GeometricSeriesOQ08

--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01.lean
@@ -1,0 +1,192 @@
+/-
+# Geometric series, open question oq-07-oq-01-oq-01-oq-01:
+# The combinatorial Eulerian numbers and the coefficients of the Eulerian polynomial
+
+The parent entry `geometric-series-oq-07-oq-01-oq-01` (Frobenius' identity) proves that the
+geometric-moment numerator `Nₘ(X) = ∑_{k} S(m,k)·k!·Xᵏ·(1−X)^{m−k}` equals the **Eulerian
+polynomial** `Eₘ`, where `Eₘ` is *defined by its first-order differential recurrence*
+`E₀ = 1`, `E_{m+1} = X·(1−X)·E′ₘ + (m+1)·X·Eₘ`.  That entry left open (`oq-01`) the textbook
+identification of the *coefficients* of `Eₘ` with the **combinatorial Eulerian numbers** `⟨m,k⟩`,
+the descent statistic on permutations, defined by the classical triangle recurrence
+
+  ⟨m,k⟩ = (k+1)·⟨m−1,k⟩ + (m−k)·⟨m−1,k−1⟩,    ⟨m,0⟩ = 1.
+
+This entry settles it.  We build `⟨m,k⟩` from scratch (Mathlib has only Eulerian *graphs*, no
+Eulerian *numbers*) and prove that the Eulerian polynomial `Eₘ` of the parent is exactly the
+generating polynomial of its row:
+
+  **`eulerPoly_eq_eulerianNumbers`** :  `E_{m+1}(X) = ∑_{j=0}^{m} ⟨m+1,j⟩ · X^{j+1}`.
+
+Composing with the parent's Frobenius identity gives the same expansion for the Stirling form
+(**`stirlingForm_eq_eulerianNumbers`**):
+
+  `∑_{k=0}^{m+1} S(m+1,k)·k!·Xᵏ·(1−X)^{m+1−k} = ∑_{j=0}^{m} ⟨m+1,j⟩·X^{j+1}`,
+
+so the geometric moment numerator's coefficients are, on the nose, the Eulerian numbers.
+
+## Method
+
+We import the parent's `eulerPoly` and its defining recurrence `eulerPoly_succ`.  The
+identification is an induction on `m`: substituting the inductive monomial description of `Eₘ`
+into the differential recurrence reproduces, coefficient by coefficient, the Eulerian triangle
+recurrence (here packaged as `eulerian_succ_succ`).  The base case `E₁ = X` is the parent's
+`eulerPoly_one`.  The Eulerian rows of order `1,2,3` are `1`; `1,1`; `1,4,1`, matching the
+parent's `E₁ = X`, `E₂ = X+X²`, `E₃ = X+4X²+X³`.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and `sorry`-free.
+-/
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ01
+
+open Finset Nat Polynomial GeometricSeriesOQ07OQ01OQ01
+
+variable {R : Type*} [CommRing R]
+
+/-! ## The combinatorial Eulerian numbers -/
+
+/-- The **Eulerian numbers** `⟨m,j⟩`, the number of permutations of `{1,…,m}` with `j`
+descents, defined by the classical triangle recurrence
+`⟨n+1,k+1⟩ = (k+2)·⟨n,k+1⟩ + (n−k)·⟨n,k⟩`, `⟨m,0⟩ = 1` (equivalently
+`⟨m,k⟩ = (k+1)·⟨m−1,k⟩ + (m−k)·⟨m−1,k−1⟩`). -/
+def eulerian : ℕ → ℕ → ℕ
+  | 0, 0 => 1
+  | 0, _ + 1 => 0
+  | _ + 1, 0 => 1
+  | n + 1, k + 1 => (k + 2) * eulerian n (k + 1) + (n - k) * eulerian n k
+
+@[simp] theorem eulerian_zero_zero : eulerian 0 0 = 1 := rfl
+@[simp] theorem eulerian_zero_succ (k : ℕ) : eulerian 0 (k + 1) = 0 := rfl
+@[simp] theorem eulerian_succ_zero (n : ℕ) : eulerian (n + 1) 0 = 1 := rfl
+
+theorem eulerian_succ_succ (n k : ℕ) :
+    eulerian (n + 1) (k + 1) = (k + 2) * eulerian n (k + 1) + (n - k) * eulerian n k := rfl
+
+/-- The Eulerian numbers vanish above the diagonal: `⟨n,j⟩ = 0` for `n < j`. -/
+theorem eulerian_eq_zero_of_lt {n j : ℕ} (h : n < j) : eulerian n j = 0 := by
+  induction n generalizing j with
+  | zero => obtain ⟨j, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : j ≠ 0); rfl
+  | succ n ih =>
+    obtain ⟨j, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : j ≠ 0)
+    rw [eulerian_succ_succ, show n - j = 0 from by omega, zero_mul, add_zero,
+      ih (by omega : n < j + 1), mul_zero]
+
+/-- The Eulerian numbers vanish on the diagonal: `⟨n+1,n+1⟩ = 0` (max descents is `n`). -/
+theorem eulerian_succ_self (n : ℕ) : eulerian (n + 1) (n + 1) = 0 := by
+  rw [eulerian_succ_succ, Nat.sub_self, zero_mul, add_zero,
+    eulerian_eq_zero_of_lt (Nat.lt_succ_self n), mul_zero]
+
+/-- Cast helper: a product of two `C`-coerced naturals is the `C`-coercion of their product. -/
+private theorem C_natCast_mul (a b : ℕ) :
+    (C (a : R)) * (C (b : R)) = C ((a * b : ℕ) : R) := by
+  rw [← map_mul]; push_cast; ring
+
+/-! ## The coefficients of the Eulerian polynomial are the Eulerian numbers -/
+
+/-- **The Eulerian polynomial is the generating polynomial of its Eulerian-number row.**
+For every `m ≥ 1` (written `m+1`), `E_{m+1}(X) = ∑_{j=0}^{m} ⟨m+1,j⟩ · X^{j+1}`, where `Eₘ` is
+the parent's `eulerPoly` (defined by its differential recurrence) and `⟨m,j⟩` are the
+combinatorial Eulerian numbers defined above. -/
+theorem eulerPoly_eq_eulerianNumbers (m : ℕ) :
+    (eulerPoly (m + 1) : R[X])
+      = ∑ j ∈ range (m + 1), C ((eulerian (m + 1) j : ℕ) : R) * X ^ (j + 1) := by
+  induction m with
+  | zero =>
+    rw [eulerPoly_one, Finset.sum_range_one]
+    simp [show eulerian 1 0 = 1 from rfl]
+  | succ m ih =>
+    rw [eulerPoly_succ, ih,
+      show (((m + 1 : ℕ) : R[X]) + 1) = C (((m + 1 : ℕ) : R) + 1) from by
+        rw [map_add, map_natCast, map_one]]
+    -- derivative of the Eulerian polynomial (a sum of monomials)
+    have hD : derivative (∑ j ∈ range (m + 1), C ((eulerian (m + 1) j : ℕ) : R) * X ^ (j + 1))
+        = ∑ j ∈ range (m + 1),
+            C ((eulerian (m + 1) j : ℕ) : R) * (C ((j + 1 : ℕ) : R) * X ^ j) := by
+      rw [derivative_sum]
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [derivative_C_mul, derivative_X_pow, Nat.add_sub_cancel]
+    -- assemble the left-hand side into `S₁ + S₂`
+    have hLHS :
+        X * (1 - X) *
+              derivative (∑ j ∈ range (m + 1), C ((eulerian (m + 1) j : ℕ) : R) * X ^ (j + 1))
+            + C (((m + 1 : ℕ) : R) + 1) * X *
+                ∑ j ∈ range (m + 1), C ((eulerian (m + 1) j : ℕ) : R) * X ^ (j + 1)
+          = (∑ j ∈ range (m + 1), C (((j + 1) * eulerian (m + 1) j : ℕ) : R) * X ^ (j + 1))
+            + (∑ j ∈ range (m + 1), C (((m + 1 - j) * eulerian (m + 1) j : ℕ) : R) * X ^ (j + 2)) := by
+      rw [hD, Finset.mul_sum, Finset.mul_sum, ← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
+      apply Finset.sum_congr rfl
+      intro j hj
+      rw [Finset.mem_range, Nat.lt_succ_iff] at hj
+      have hcast : C (((m + 1 : ℕ) : R) + 1) = C ((j + 1 : ℕ) : R) + C ((m + 1 - j : ℕ) : R) := by
+        rw [← map_add]; congr 1; push_cast [Nat.cast_sub (by omega : j ≤ m + 1)]; ring
+      have hc1 : C (((j + 1) * eulerian (m + 1) j : ℕ) : R)
+          = C ((eulerian (m + 1) j : ℕ) : R) * C ((j + 1 : ℕ) : R) := by
+        rw [C_natCast_mul]; congr 1; push_cast; ring
+      have hc2 : C (((m + 1 - j) * eulerian (m + 1) j : ℕ) : R)
+          = C ((eulerian (m + 1) j : ℕ) : R) * C ((m + 1 - j : ℕ) : R) := by
+        rw [C_natCast_mul]; congr 1; push_cast; ring
+      rw [hc1, hc2, hcast]
+      ring
+    rw [hLHS]
+    -- expand the target Eulerian polynomial for `m+2` and peel the `i = 0` term
+    rw [Finset.sum_range_succ' (fun i => C ((eulerian (m + 2) i : ℕ) : R) * X ^ (i + 1)) (m + 1)]
+    have hg0 : C ((eulerian (m + 2) 0 : ℕ) : R) * X ^ (0 + 1) = X := by
+      simp [eulerian_succ_zero]
+    rw [hg0]
+    -- split each `i = k+1` summand by the Eulerian triangle recurrence
+    have hsplit : (∑ k ∈ range (m + 1), C ((eulerian (m + 2) (k + 1) : ℕ) : R) * X ^ (k + 1 + 1))
+        = (∑ k ∈ range (m + 1), C (((k + 2) * eulerian (m + 1) (k + 1) : ℕ) : R) * X ^ (k + 2))
+          + (∑ k ∈ range (m + 1), C (((m + 1 - k) * eulerian (m + 1) k : ℕ) : R) * X ^ (k + 2)) := by
+      rw [← Finset.sum_add_distrib]
+      apply Finset.sum_congr rfl
+      intro k _
+      have hrec : eulerian (m + 2) (k + 1)
+          = (k + 2) * eulerian (m + 1) (k + 1) + (m + 1 - k) * eulerian (m + 1) k := by
+        rw [eulerian_succ_succ]
+      rw [hrec, Nat.cast_add, map_add, show k + 1 + 1 = k + 2 from rfl]
+      ring
+    rw [hsplit]
+    -- reconcile the `S₁` part: re-index the `(k+2)·⟨m+1,k+1⟩` sum
+    have hS1 : (∑ j ∈ range (m + 1), C (((j + 1) * eulerian (m + 1) j : ℕ) : R) * X ^ (j + 1))
+        = (∑ k ∈ range (m + 1), C (((k + 2) * eulerian (m + 1) (k + 1) : ℕ) : R) * X ^ (k + 2))
+          + X := by
+      rw [Finset.sum_range_succ' (fun j =>
+            C (((j + 1) * eulerian (m + 1) j : ℕ) : R) * X ^ (j + 1)) m,
+          Finset.sum_range_succ (fun k =>
+            C (((k + 2) * eulerian (m + 1) (k + 1) : ℕ) : R) * X ^ (k + 2)) m]
+      have hz : C (((m + 2) * eulerian (m + 1) (m + 1) : ℕ) : R) * X ^ (m + 2) = 0 := by
+        rw [eulerian_succ_self]; simp
+      rw [hz, add_zero]
+      have hx0 : C (((0 + 1) * eulerian (m + 1) 0 : ℕ) : R) * X ^ (0 + 1) = X := by
+        simp [eulerian_succ_zero]
+      rw [hx0]
+    rw [hS1]
+    ring
+
+/-- **The Stirling moment numerator expanded over the Eulerian numbers.**  Composing the parent's
+Frobenius identity `stirlingForm = eulerPoly` with `eulerPoly_eq_eulerianNumbers`:
+`∑_{k=0}^{m+1} S(m+1,k)·k!·Xᵏ·(1−X)^{m+1−k} = ∑_{j=0}^{m} ⟨m+1,j⟩·X^{j+1}`. -/
+theorem stirlingForm_eq_eulerianNumbers (m : ℕ) :
+    (stirlingForm (m + 1) : R[X])
+      = ∑ j ∈ range (m + 1), C ((eulerian (m + 1) j : ℕ) : R) * X ^ (j + 1) := by
+  rw [← eulerPoly_eq_stirlingForm, eulerPoly_eq_eulerianNumbers]
+
+/-! ## The low-order Eulerian rows
+
+`⟨1,0⟩ = 1`; `⟨2,0⟩ = ⟨2,1⟩ = 1`; `⟨3,0⟩ = ⟨3,2⟩ = 1`, `⟨3,1⟩ = 4`, reproducing the
+parent's `E₁ = X`, `E₂ = X + X²`, `E₃ = X + 4X² + X³`. -/
+
+example : eulerian 1 0 = 1 ∧ eulerian 2 0 = 1 ∧ eulerian 2 1 = 1 ∧
+    eulerian 3 0 = 1 ∧ eulerian 3 1 = 4 ∧ eulerian 3 2 = 1 := by decide
+
+/-- Order 3: `E₃(X) = ⟨3,0⟩X + ⟨3,1⟩X² + ⟨3,2⟩X³ = X + 4X² + X³`. -/
+example : (eulerPoly 3 : ℚ[X]) = X + 4 * X ^ 2 + X ^ 3 := by
+  rw [eulerPoly_eq_eulerianNumbers 2, Finset.sum_range_succ, Finset.sum_range_succ,
+    Finset.sum_range_one]
+  simp only [show eulerian 3 0 = 1 from by decide, show eulerian 3 1 = 4 from by decide,
+    show eulerian 3 2 = 1 from by decide, Nat.cast_one, Nat.cast_ofNat, map_one, map_ofNat]
+  ring
+
+end GeometricSeriesOQ07OQ01OQ01OQ01

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,124 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "Nat",
+      "Polynomial",
+      "GeometricSeriesOQ07OQ01OQ01"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ01",
+    "lineCount": 192,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Combinatorial Eulerian Numbers: the Coefficients of the Eulerian Polynomial are ⟨m,j⟩",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "eulerian-polynomial",
+      "stirling-numbers",
+      "descent-statistic",
+      "triangle-recurrence",
+      "polynomial",
+      "coefficient-extraction",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 192,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "eulerian: a from-scratch definition of the combinatorial Eulerian numbers ⟨m,j⟩ (the number of permutations of {1,…,m} with j descents) via the classical triangle recurrence ⟨n+1,k+1⟩ = (k+2)·⟨n,k+1⟩ + (n−k)·⟨n,k⟩ with ⟨m,0⟩ = 1 (equivalently ⟨m,k⟩ = (k+1)·⟨m−1,k⟩ + (m−k)·⟨m−1,k−1⟩). Mathlib has Eulerian GRAPHS/circuits but NO Eulerian numbers or polynomials, so the triangle is built here, with the diagonal/above-diagonal vanishing lemmas eulerian_eq_zero_of_lt (⟨n,j⟩=0 for n<j) and eulerian_succ_self (⟨n+1,n+1⟩=0).",
+      "eulerPoly_eq_eulerianNumbers: THE MAIN RESULT — the parent's Eulerian polynomial Eₘ (defined by its differential recurrence E₀=1, E_{m+1}=X(1−X)E′ₘ+(m+1)X·Eₘ) is exactly the generating polynomial of its Eulerian-number row: for m ≥ 1, E_{m+1}(X) = ∑_{j=0}^{m} ⟨m+1,j⟩·X^{j+1}. This answers the open question geometric-series-oq-07-oq-01-oq-01-oq-01 (identify the coefficients of eulerPoly with the combinatorial Eulerian numbers). Proved by induction: substituting the inductive monomial description of Eₘ into the differential recurrence reproduces, coefficient by coefficient, the Eulerian triangle recurrence.",
+      "stirlingForm_eq_eulerianNumbers: composing the main result with the parent's Frobenius identity (eulerPoly = stirlingForm) gives the Stirling moment numerator expanded directly over the Eulerian numbers: ∑_{k=0}^{m+1} S(m+1,k)·k!·Xᵏ·(1−X)^{m+1−k} = ∑_{j=0}^{m} ⟨m+1,j⟩·X^{j+1}. So the coefficients of the geometric-moment numerator are, on the nose, the descent numbers ⟨m,j⟩.",
+      "The order-1,2,3 instances verify the Eulerian rows ⟨1,0⟩=1; ⟨2,0⟩=⟨2,1⟩=1; ⟨3,0⟩=1,⟨3,1⟩=4,⟨3,2⟩=1, exhibiting E₃ = ⟨3,0⟩X + ⟨3,1⟩X² + ⟨3,2⟩X³ = X + 4X² + X³ and matching the parent's E₁,E₂,E₃ and the numerators of geometric-series-oq-07 / oq-10."
+    ],
+    "prerequisites": [
+      "Parent: geometric-series-oq-07-oq-01-oq-01 (Frobenius' identity) — supplies eulerPoly, its defining recurrence eulerPoly_succ, the low-order values eulerPoly_one/two/three, and the identity eulerPoly_eq_stirlingForm reused here",
+      "Mathlib's univariate polynomial formal derivative Polynomial.derivative (derivative_sum, derivative_C_mul, derivative_X_pow) for differentiating the monomial form of the Eulerian polynomial",
+      "Polynomial.C as a ring homomorphism (map_mul, map_add, map_natCast, map_one) for transporting the Eulerian/Nat coefficients into R[X]",
+      "Finset reindexing: Finset.sum_range_succ, Finset.sum_range_succ', Finset.sum_add_distrib, Finset.mul_sum"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.derivative",
+        "description": "The univariate formal derivative as an R-linear map. derivative_sum, derivative_C_mul and derivative_X_pow compute the derivative of the monomial form ∑ⱼ ⟨m,j⟩·X^{j+1} during the induction matching the differential recurrence to the Eulerian triangle.",
+        "module": "Mathlib.Algebra.Polynomial.Derivative"
+      },
+      {
+        "theorem": "Polynomial.C",
+        "description": "The constant-polynomial ring homomorphism. map_add / map_natCast / map_one and the cast helper C_natCast_mul move the Eulerian numbers ⟨m,j⟩ and the recurrence coefficients under C so the combinatorial triangle recurrence becomes a coefficient identity in R[X].",
+        "module": "Mathlib.Algebra.Polynomial.Basic"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07OQ01OQ01.eulerPoly_eq_stirlingForm",
+        "description": "The parent's Frobenius identity eulerPoly = stirlingForm. Reused (with the parent's eulerPoly and its recurrence eulerPoly_succ) so this entry only has to add the combinatorial coefficient identification, not re-derive the differential recurrence.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01",
+      "question": "Prove Worpitzky's row identity ∑_{j} ⟨m,j⟩ = m! for the combinatorial Eulerian numbers defined here (the parent proves Eₘ(1) = m! analytically via the Stirling form; deduce it instead by induction on the triangle recurrence, summing the coefficient (j+1) + (m−j) = m+1 over each row), confirming ⟨m,j⟩ is the descent statistic.",
+      "significance": "low"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+      "question": "Prove the combinatorial form of Eulerian palindromy ⟨m,j⟩ = ⟨m,m−1−j⟩ directly from the triangle recurrence (the sibling oq-02 proves the polynomial symmetry Eₘ(X) = X^{m+1}Eₘ(1/X) by coefficient extraction; connect it to the descent-reversal bijection on permutations via the combinatorial ⟨m,j⟩ built here)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent (Frobenius' identity). The parent identifies the geometric-moment numerator with the Eulerian polynomial Eₘ defined by its differential recurrence, but leaves open (as oq-01) the textbook identification of Eₘ's coefficients with the combinatorial Eulerian numbers ⟨m,j⟩. This entry answers it: builds the ⟨m,j⟩ triangle from scratch and proves Eₘ₊₁(X) = ∑ⱼ ⟨m+1,j⟩ X^{j+1} (hence the Stirling numerator equals ∑ⱼ ⟨m+1,j⟩ X^{j+1}), reusing the parent's eulerPoly, eulerPoly_succ and eulerPoly_eq_stirlingForm."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling. oq-02 proves the palindromicity of the Eulerian polynomial Eₘ(X) = X^{m+1}Eₘ(1/X) by coefficient extraction (without a combinatorial definition). This entry supplies the missing combinatorial Eulerian-number triangle ⟨m,j⟩, the descent-statistic object whose palindromy ⟨m,j⟩ = ⟨m,m−1−j⟩ is the combinatorial content of that symmetry."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers, the triangle recurrence, descents)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian numbers ⟨n,k⟩, the descent statistic, and the triangle recurrence ⟨n,k⟩ = (k+1)⟨n-1,k⟩ + (n-k)⟨n-1,k-1⟩ implemented here."
+    },
+    {
+      "title": "Mathlib4: Algebra.Polynomial.Derivative",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the formal polynomial derivative used to match the Eulerian polynomial's differential recurrence against the combinatorial triangle recurrence on its coefficients."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The parent entry (Frobenius' identity) proves the geometric-moment numerator equals the Eulerian polynomial Eₘ defined by its first-order differential recurrence, but identifies Eₘ only as a recurrence-defined polynomial. This entry supplies the textbook combinatorial object: it defines the Eulerian numbers ⟨m,j⟩ (descents of permutations) from scratch via the triangle recurrence ⟨n+1,k+1⟩ = (k+2)⟨n,k+1⟩ + (n−k)⟨n,k⟩, ⟨m,0⟩ = 1 (Mathlib has only Eulerian graphs), and proves that the coefficients of Eₘ are exactly these integers: for m ≥ 1, E_{m+1}(X) = ∑_{j=0}^{m} ⟨m+1,j⟩·X^{j+1}. The proof is an induction on m in which substituting the inductive monomial description of Eₘ into the differential recurrence reproduces, coefficient by coefficient, the Eulerian triangle recurrence; the parent's eulerPoly, eulerPoly_succ and Frobenius identity eulerPoly_eq_stirlingForm are imported and reused, so no recurrence is re-derived. Composing with Frobenius gives the same Eulerian expansion for the Stirling form: ∑_k S(m+1,k)·k!·Xᵏ·(1−X)^{m+1−k} = ∑_j ⟨m+1,j⟩·X^{j+1}. The Eulerian rows of order 1,2,3 (1; 1,1; 1,4,1) are verified, recovering the parent's E₁,E₂,E₃. 192 lines, 8 theorems, 1 definition, 0 axioms, 0 sorries; everything depends only on propext, Classical.choice, Quot.sound (low-order checks use kernel `decide`, not native_decide).",
+    "implications": "This completes the identification of the geometric-moment numerator with the Eulerian polynomial down to the combinatorial level: the numerator's coefficients are the descent numbers ⟨m,j⟩, the Stirling form S(m,k)·k! (a surjection count) and the Eulerian form ⟨m,j⟩ (a descent count) being two faces of one polynomial. Because the coefficient identity is proved over an arbitrary commutative ring, the resulting Eulerian-number triangle and its basic theory (vanishing lemmas, generating polynomial) are a reusable, Mathlib-free foundation for further Eulerian-number work, e.g. Worpitzky's row identity and the descent-reversal palindromy.",
+    "openQuestions": [
+      "Prove Worpitzky's row identity ∑_j ⟨m,j⟩ = m! from the triangle recurrence.",
+      "Prove the combinatorial palindromy ⟨m,j⟩ = ⟨m,m−1−j⟩ and link it to the sibling's polynomial symmetry Eₘ(X) = X^{m+1}Eₘ(1/X)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **medium-significance** open question `geometric-series-oq-07-oq-01-oq-01-oq-01`, posed by the merged parent **#27375** (Frobenius' identity): *build the Eulerian numbers `⟨m,k⟩` explicitly via the combinatorial triangle recurrence and prove the coefficients of `eulerPoly` are exactly these integers.*

This PR **builds on** #27375 — importing and reusing its `eulerPoly`, `eulerPoly_succ` and `eulerPoly_eq_stirlingForm` (supersedes the now-closed #27379, which collided with #27375's parent slug).

## What is added (over #27375)

#27375 defines the Eulerian polynomial `Eₘ` *by its differential recurrence* and never builds the combinatorial Eulerian-number triangle. This PR supplies exactly that:

- **`eulerian`** — the combinatorial Eulerian numbers `⟨m,j⟩` (descents of permutations), **from scratch** (Mathlib has only Eulerian *graphs*), via the triangle recurrence `⟨n+1,k+1⟩ = (k+2)⟨n,k+1⟩ + (n−k)⟨n,k⟩`, `⟨m,0⟩ = 1`, with vanishing lemmas `eulerian_eq_zero_of_lt`, `eulerian_succ_self`.
- **`eulerPoly_eq_eulerianNumbers`** — the main result: for `m ≥ 1`, `E_{m+1}(X) = ∑ⱼ ⟨m+1,j⟩·X^{j+1}`. Proved by induction: substituting the inductive monomial description of `Eₘ` into the parent's differential recurrence (`eulerPoly_succ`) reproduces, coefficient by coefficient, the Eulerian triangle recurrence.
- **`stirlingForm_eq_eulerianNumbers`** — composing with the parent's Frobenius identity: `∑ₖ S(m+1,k)·k!·Xᵏ(1−X)^{m+1−k} = ∑ⱼ ⟨m+1,j⟩·X^{j+1}`. The geometric-moment numerator's coefficients are, on the nose, the descent numbers.
- Order-1,2,3 instances verifying the Eulerian rows `1`; `1,1`; `1,4,1`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ07OQ01OQ01OQ01` — **builds, 7745 jobs**.
- `#print axioms` on both main theorems: `[propext, Classical.choice, Quot.sound]` — **0-axiom** (low-order checks use kernel `decide`, not `native_decide`).
- 192 lines, 8 theorems, 1 definition, 0 sorries. Reuses the merged parent `Proofs.GeometricSeriesOQ07OQ01OQ01`; the parent file is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)