### PR TITLE
research(geometric-series-oq-08-oq-01-oq-01-oq-01): unifying recurrence for the finite m-th moment ∑ kᵐ·xᵏ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2637,6 +2637,7 @@ import Proofs.GeometricSeriesOQ07OQ01OQ01OQ03
 import Proofs.GeometricSeriesOQ08
 import Proofs.GeometricSeriesOQ08OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01
+import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01
 import Proofs.GeometricSeriesOQ08OQ03
 import Proofs.GeometricSeriesOQ08OQ03OQ01
 import Proofs.GeometricSeriesOQ08OQ03OQ01OQ01

--- a/proofs/Proofs/GeometricSeriesOQ08OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ08OQ01OQ01OQ01.lean
@@ -1,0 +1,162 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+
+/-
+# Unifying the weight family: a recurrence for the finite m-th moment ∑ kᵐ·xᵏ
+
+## What This Proves
+
+For a ratio `x`, a length `n`, and an exponent `m`, the *m-th moment*
+finite weighted geometric sum
+
+  momentSum m n x  :=  ∑_{k=0}^{n-1} kᵐ·xᵏ
+
+(each geometric term `xᵏ` weighted by the `m`-th power of its index) satisfies,
+over **any** commutative ring, the single division-free recurrence
+
+  (1 − x) · momentSum m n x
+      =  0ᵐ  −  nᵐ·xⁿ  +  x · ∑_{i=0}^{m−1} C(m,i) · momentSum i n x.       (★)
+
+This is the unified statement behind the whole `∑ kᵐ·xᵏ` family.  Reading it as
+`momentSum m n x = (…)/(1 − x)` and iterating, the denominator after fully
+unwinding the `m` nested moments is exactly `(1 − x)^{m+1}`, and the numerator
+is the finite analogue of the Eulerian polynomial Aₘ(x) (the *interior* part,
+`0ᵐ + x·∑ C(m,i)·(numerator of moment i)`) corrected by the boundary term
+`nᵐ·xⁿ`.  Specialising `m = 0, 1, 2` recovers the closed forms already in the
+gallery:
+
+  m = 0 : (1 − x)·∑_{k<n} xᵏ        = 1 − xⁿ
+  m = 1 : (1 − x)·∑_{k<n} k·xᵏ      = −n·xⁿ + x·∑_{k<n} xᵏ
+  m = 2 : (1 − x)·∑_{k<n} k²·xᵏ     = −n²·xⁿ + x·(∑_{k<n} xᵏ + 2·∑_{k<n} k·xᵏ)
+
+Multiplying the `m = 1` line by `(1 − x)` and the `m = 2` line by `(1 − x)²`
+reproduces the `(1 − x)²` and `(1 − x)³` closed forms of the parents
+`geometric-series-oq-08-oq-01` and `geometric-series-oq-08-oq-01-oq-01`.
+
+## Why a Recurrence (and not one explicit Eulerian formula)
+
+The infinite series `∑_{k≥0} kᵐ·rᵏ = Aₘ(r)/(1 − r)^{m+1}` has a clean explicit
+Eulerian-polynomial numerator, recorded in the gallery via the all-orders
+moment `geometric-series-oq-07-oq-01` (Stirling form) and the Frobenius identity
+`geometric-series-oq-07-oq-01-oq-01` (`eulerPoly`).  The **finite** sum carries,
+in addition, an `n`-dependent *boundary* contribution `nᵐ·xⁿ` whose expansion in
+powers of `n` has no single closed form independent of `m`.  Recurrence (★) is
+therefore the sharpest fully general, fully explicit, division-free statement:
+it is uniform in `m`, valid over any commutative ring, and reduces moment `m`
+to *all* lower moments in one step.  The interior part of (★) is precisely the
+Eulerian recurrence in the `n → ∞` limit (each `momentSum i n x → Aᵢ(x)/(1−x)^{i+1}`).
+
+## Why This Is Not Already in Mathlib
+
+Mathlib records the infinite linear and `choose`-weighted geometric series and
+the plain finite geometric sum `geom_sum_eq`, but no finite m-th moment sum and
+no recurrence linking the finite moments across `m`.
+
+## Proof Strategy
+
+1. **`sum_choose_mul_pow`.** `∑_{i<m} C(m,i)·aⁱ = (a+1)ᵐ − aᵐ`, from the binomial
+   theorem `add_pow` with the top term `C(m,m)·aᵐ = aᵐ` peeled off.
+2. **`momentSum_succ`.** Peel the top term with `Finset.sum_range_succ`.
+3. **`momentSum_recurrence` (★).** Induction on `n`.  The base case is `0 = 0`;
+   the step rewrites every `momentSum · (n+1)` with `momentSum_succ`, collapses
+   the resulting `∑_{i<m} C(m,i)·nⁱ` via step 1 into `(n+1)ᵐ − nᵐ`, and closes
+   with `linear_combination` against the induction hypothesis.  All index bases
+   are kept as ring casts so the `n = 0` instance is well-defined (no ℕ
+   truncated subtraction).
+4. **Specialisations** `momentSum_recurrence_{zero,one,two}` instantiate `m`.
+
+All results depend only on `propext`, `Classical.choice`, `Quot.sound`.
+-/
+
+namespace GeometricSeriesOQ08OQ01OQ01OQ01
+
+open Finset
+
+variable {R : Type*} [CommRing R]
+
+/-- The finite **m-th moment weighted geometric sum** `∑_{k=0}^{n-1} kᵐ·xᵏ`. -/
+def momentSum (m n : ℕ) (x : R) : R :=
+  ∑ k ∈ Finset.range n, (k : R) ^ m * x ^ k
+
+/-- Binomial helper: `∑_{i<m} C(m,i)·aⁱ = (a+1)ᵐ − aᵐ` over any commutative ring.
+The full binomial sum is `(a+1)ᵐ`; peeling off its top term `C(m,m)·aᵐ = aᵐ`
+leaves the partial sum over `i < m`. -/
+theorem sum_choose_mul_pow (m : ℕ) (a : R) :
+    ∑ i ∈ Finset.range m, (m.choose i : R) * a ^ i = (a + 1) ^ m - a ^ m := by
+  have h := add_pow a 1 m
+  simp only [one_pow, mul_one] at h
+  rw [Finset.sum_range_succ, Nat.choose_self, Nat.cast_one, mul_one] at h
+  rw [h, add_sub_cancel_right]
+  exact Finset.sum_congr rfl fun i _ => by ring
+
+/-- Peeling the top term of a moment sum: `momentSum m (n+1) x = momentSum m n x + nᵐ·xⁿ`. -/
+theorem momentSum_succ (m n : ℕ) (x : R) :
+    momentSum m (n + 1) x = momentSum m n x + (n : R) ^ m * x ^ n := by
+  simp only [momentSum, Finset.sum_range_succ]
+
+/-- **Master recurrence (★).** Over any commutative ring,
+
+  `(1 − x)·momentSum m n x = 0ᵐ − nᵐ·xⁿ + x·∑_{i<m} C(m,i)·momentSum i n x`.
+
+Uniform in the exponent `m`, this reduces the `m`-th finite moment to all lower
+moments in a single division-free step.  Iterating it clears the denominator
+`(1 − x)^{m+1}`; its interior part is the Eulerian-polynomial recurrence in the
+`n → ∞` limit. -/
+theorem momentSum_recurrence (m n : ℕ) (x : R) :
+    (1 - x) * momentSum m n x
+      = (0 : R) ^ m - (n : R) ^ m * x ^ n
+        + x * ∑ i ∈ Finset.range m, (m.choose i : R) * momentSum i n x := by
+  induction n with
+  | zero =>
+    simp only [momentSum, Finset.sum_range_zero, mul_zero, pow_zero, mul_one,
+      Finset.sum_const_zero, Nat.cast_zero, sub_self, add_zero]
+  | succ n ih =>
+    -- Expand the interior sum at `n+1` using `momentSum_succ` and collapse
+    -- `∑_{i<m} C(m,i)·nⁱ` to `(n+1)ᵐ − nᵐ` via the binomial helper.
+    have hsig : (∑ i ∈ Finset.range m, (m.choose i : R) * momentSum i (n + 1) x)
+        = (∑ i ∈ Finset.range m, (m.choose i : R) * momentSum i n x)
+          + x ^ n * (((n : R) + 1) ^ m - (n : R) ^ m) := by
+      have hterm : ∀ i, (m.choose i : R) * momentSum i (n + 1) x
+          = (m.choose i : R) * momentSum i n x
+            + (m.choose i : R) * (n : R) ^ i * x ^ n := by
+        intro i; rw [momentSum_succ]; ring
+      rw [Finset.sum_congr rfl (fun i _ => hterm i), Finset.sum_add_distrib]
+      congr 1
+      rw [← Finset.sum_mul, sum_choose_mul_pow]
+      ring
+    rw [momentSum_succ, hsig, pow_succ]
+    push_cast
+    linear_combination ih
+
+/-- `m = 0`: the plain finite geometric sum identity `(1 − x)·∑_{k<n} xᵏ = 1 − xⁿ`. -/
+theorem momentSum_recurrence_zero (n : ℕ) (x : R) :
+    (1 - x) * momentSum 0 n x = 1 - x ^ n := by
+  have h := momentSum_recurrence 0 n x
+  simpa using h
+
+/-- `m = 1`: the linear arithmetico-geometric step
+`(1 − x)·∑_{k<n} k·xᵏ = −n·xⁿ + x·∑_{k<n} xᵏ`. -/
+theorem momentSum_recurrence_one (n : ℕ) (x : R) :
+    (1 - x) * momentSum 1 n x = -(n : R) * x ^ n + x * momentSum 0 n x := by
+  rw [momentSum_recurrence 1 n x, Finset.sum_range_one]
+  simp only [pow_one, Nat.choose_zero_right, Nat.cast_one, one_mul]
+  ring
+
+/-- `m = 2`: the second-moment step
+`(1 − x)·∑_{k<n} k²·xᵏ = −n²·xⁿ + x·(∑_{k<n} xᵏ + 2·∑_{k<n} k·xᵏ)`. -/
+theorem momentSum_recurrence_two (n : ℕ) (x : R) :
+    (1 - x) * momentSum 2 n x
+      = -(n : R) ^ 2 * x ^ n + x * (momentSum 0 n x + 2 * momentSum 1 n x) := by
+  have e2 : ∑ i ∈ Finset.range 2, (Nat.choose 2 i : R) * momentSum i n x
+      = momentSum 0 n x + 2 * momentSum 1 n x := by
+    simp [Finset.sum_range_succ]
+  rw [momentSum_recurrence 2 n x, e2]
+  have h0 : (0 : R) ^ 2 = 0 := by ring
+  rw [h0]; ring
+
+/-- Numerical sanity check over `ℤ`: `∑_{k<3} k·2ᵏ = 0 + 1·2 + 2·4 = 10`,
+and the `m = 1` recurrence gives `(1 − 2)·10 = 0 − 3·8 + 2·(1 + 2 + 4) = −10`. -/
+example : momentSum 1 3 (2 : ℤ) = 10 := by
+  norm_num [momentSum, Finset.sum_range_succ]
+
+end GeometricSeriesOQ08OQ01OQ01OQ01

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "geometric-series-oq-08-oq-01-oq-01-oq-01",
+  "slug": "geometric-series-oq-08-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "GeometricSeriesOQ08OQ01OQ01OQ01",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ08OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Unifying the Weight Family: a Recurrence for the Finite m-th Moment ∑ kᵐ·xᵏ",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ08OQ01OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "arithmetico-geometric",
+      "finite-sums",
+      "moments",
+      "recurrence",
+      "eulerian",
+      "weighted-series",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 162,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "momentSum: a single definition ∑_{k<n} (k:R)ᵐ·xᵏ for the finite m-th moment weighted geometric sum over any commutative ring, uniform in the exponent m.",
+      "momentSum_recurrence: the master recurrence (★) (1 − x)·momentSum m n x = 0ᵐ − nᵐ·xⁿ + x·∑_{i<m} C(m,i)·momentSum i n x, valid over ANY commutative ring and uniform in m. It reduces the m-th finite moment to ALL lower moments in a single division-free step; iterating clears the denominator (1 − x)^{m+1}, and its interior part is the Eulerian-polynomial recurrence in the n → ∞ limit. Proved by induction on n: the inductive step rewrites every momentSum·(n+1) with momentSum_succ, collapses ∑_{i<m} C(m,i)·nⁱ to (n+1)ᵐ − nᵐ via the binomial helper, and closes with linear_combination against the hypothesis. Index bases are kept as ring casts so the n = 0 instance is well-defined (no ℕ truncated subtraction).",
+      "sum_choose_mul_pow: the binomial helper ∑_{i<m} C(m,i)·aⁱ = (a+1)ᵐ − aᵐ over any commutative ring, from add_pow with the top term C(m,m)·aᵐ peeled off. This is the algebraic engine of the recurrence.",
+      "momentSum_recurrence_zero / _one / _two: the m = 0, 1, 2 specialisations of (★) — (1 − x)·∑_{k<n} xᵏ = 1 − xⁿ; (1 − x)·∑_{k<n} k·xᵏ = −n·xⁿ + x·∑_{k<n} xᵏ; (1 − x)·∑_{k<n} k²·xᵏ = −n²·xⁿ + x·(∑_{k<n} xᵏ + 2·∑_{k<n} k·xᵏ) — recovering the (1 − x), (1 − x)², (1 − x)³ closed forms of the ancestors after iteration.",
+      "momentSum_succ: the top-term peel momentSum m (n+1) x = momentSum m n x + nᵐ·xⁿ via Finset.sum_range_succ, the inductive workhorse."
+    ],
+    "prerequisites": [
+      "add_pow (binomial theorem) for the helper ∑_{i<m} C(m,i)·aⁱ = (a+1)ᵐ − aᵐ",
+      "Finset.sum_range_succ for peeling the top term (momentSum_succ)",
+      "Finset.sum_add_distrib / Finset.sum_mul / Finset.sum_congr for the interior-sum manipulation in the inductive step",
+      "linear_combination to close the inductive step against the hypothesis",
+      "Parent: geometric-series-oq-08-oq-01-oq-01 (the m = 2 finite second moment over (1 − x)³)",
+      "Ancestors: geometric-series-oq-08-oq-01 (m = 1) and geometric-series-oq-08 (m = 0)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "add_pow",
+        "description": "(x + y)ⁿ = ∑_{k<n+1} xᵏ·y^{n−k}·C(n,k). Specialised at y = 1 to prove the binomial helper sum_choose_mul_pow.",
+        "module": "Mathlib.Algebra.BigOperators.Ring"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑_{k<n+1} f k = ∑_{k<n} f k + f n. Peels the k = n term (momentSum_succ) and the top binomial term in the helper.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-01",
+      "question": "Solve the recurrence (★) in closed form: prove (1 − x)^{m+1}·∑_{k<n} kᵐ·xᵏ = Aₘ(x) − xⁿ·Bₘ(n,x) with Aₘ the finite Eulerian numerator and Bₘ an explicit boundary polynomial, by strong induction on m, and verify Aₘ matches the gallery's eulerPoly (geometric-series-oq-07-oq-01-oq-01).",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-08-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent. The parent gives the m = 2 finite second moment (1 − x)³·∑_{k<n} k²·xᵏ as an explicit polynomial; this entry generalises to all m via the uniform recurrence (★) and recovers the parent's m = 2 case as momentSum_recurrence_two."
+    },
+    {
+      "targetId": "geometric-series-oq-08-oq-01",
+      "relationship": "extends",
+      "description": "Ancestor (m = 1). Its first-moment finite closed form (1 − x)²·∑_{k<n} k·xᵏ is recovered by multiplying momentSum_recurrence_one by (1 − x)."
+    },
+    {
+      "targetId": "geometric-series-oq-08",
+      "relationship": "extends",
+      "description": "Ancestor (m = 0). The unweighted finite geometric sum (1 − x)·∑_{k<n} xᵏ = 1 − xⁿ is exactly momentSum_recurrence_zero."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01",
+      "relationship": "sibling",
+      "description": "Records the INFINITE all-orders moment ∑' n, nᵐ·rⁿ = ∑_k S(m,k)·k!·rᵏ/(1 − r)^{k+1} (Stirling form). The recurrence (★) here is the finite companion; in the n → ∞ limit its boundary term nᵐ·xⁿ vanishes and the interior part becomes the Eulerian recurrence for that infinite moment."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Defines the Eulerian polynomial eulerPoly via its differential recurrence (Frobenius identity). The numerator of the n → ∞ limit of (★) is precisely eulerPoly; this entry supplies the finite, division-free moment recurrence over any commutative ring."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (sums ∑ kᵐ·xᵏ, the perturbation method, and Eulerian numbers)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for weighted geometric (arithmetico-geometric) sums, their closed forms, and the role of Eulerian numbers in the moment generating function."
+    },
+    {
+      "title": "Mathlib4: Algebra.BigOperators.Ring (add_pow) and Algebra.BigOperators.Basic (Finset.sum_range_succ)",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Provides the binomial theorem and finite-sum peeling lemmas that drive the recurrence; the finite m-th moment recurrence itself is not in Mathlib."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The finite m-th moment weighted geometric sum momentSum m n x = ∑_{k<n} kᵐ·xᵏ satisfies, over any commutative ring and uniformly in the exponent m, the single division-free master recurrence (1 − x)·momentSum m n x = 0ᵐ − nᵐ·xⁿ + x·∑_{i<m} C(m,i)·momentSum i n x. It reduces the m-th finite moment to all lower moments in one step; iterating it clears the denominator (1 − x)^{m+1}, and its interior part is the Eulerian-polynomial recurrence in the n → ∞ limit. The m = 0, 1, 2 specialisations recover the gallery's (1 − x), (1 − x)², (1 − x)³ closed forms. 162 lines, 6 theorems, 1 definition, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This unifies the whole ∑_{k<n} kᵐ·xᵏ family (m = 0 in geometric-series-oq-08, m = 1 in geometric-series-oq-08-oq-01, m = 2 in geometric-series-oq-08-oq-01-oq-01) into one recurrence valid for every m over every commutative ring, with no analysis. The honest scope of a single uniform statement is a recurrence rather than one explicit Eulerian formula: the finite sum carries an n-dependent boundary contribution nᵐ·xⁿ whose expansion in n has no m-independent closed form, so (★) is the sharpest fully general division-free identity. Such moment sums compute variances of geometric/negative-binomial distributions and coefficients of rational generating functions.",
+    "openQuestions": [
+      "Solve (★) in closed form: (1 − x)^{m+1}·∑_{k<n} kᵐ·xᵏ = Aₘ(x) − xⁿ·Bₘ(n,x) with Aₘ the finite Eulerian numerator (matching the gallery's eulerPoly) and Bₘ an explicit boundary polynomial, by strong induction on m."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Closes the open question of `geometric-series-oq-08-oq-01-oq-01`: a single, uniform, division-free statement for the **finite m-th moment** weighted geometric sum `momentSum m n x = ∑_{k<n} kᵐ·xᵏ` over **any commutative ring**.

**Master recurrence (★)**, uniform in the exponent `m`:

```
(1 − x)·momentSum m n x = 0ᵐ − nᵐ·xⁿ + x·∑_{i<m} C(m,i)·momentSum i n x
```

It reduces the `m`-th finite moment to **all** lower moments in one division-free step. Iterating it clears the denominator `(1 − x)^{m+1}`; its *interior* part is precisely the Eulerian-polynomial recurrence in the `n → ∞` limit (each `momentSum i n x → Aᵢ(x)/(1−x)^{i+1}`).

**Specialisations** recover the gallery's existing closed forms:
- `m = 0`: `(1 − x)·∑_{k<n} xᵏ = 1 − xⁿ`  (geometric-series-oq-08)
- `m = 1`: `(1 − x)·∑_{k<n} k·xᵏ = −n·xⁿ + x·∑_{k<n} xᵏ`  (geometric-series-oq-08-oq-01)
- `m = 2`: `(1 − x)·∑_{k<n} k²·xᵏ = −n²·xⁿ + x·(∑_{k<n} xᵏ + 2·∑_{k<n} k·xᵏ)`  (parent oq-08-oq-01-oq-01)

## Why a recurrence (honest scope)

The **infinite** series `∑_{k≥0} kᵐ·rᵏ = Aₘ(r)/(1 − r)^{m+1}` has a clean explicit Eulerian numerator (already in the gallery: oq-07-oq-01 Stirling form, oq-07-oq-01-oq-01 `eulerPoly`). The **finite** sum carries an additional `n`-dependent boundary term `nᵐ·xⁿ` whose expansion in `n` has no `m`-independent closed form. So the sharpest *single uniform* statement is the recurrence (★), not one explicit formula — the residual closed-form question is left as a child OQ.

## Proof

- `sum_choose_mul_pow`: `∑_{i<m} C(m,i)·aⁱ = (a+1)ᵐ − aᵐ` from `add_pow` (top term peeled).
- `momentSum_succ`: top-term peel via `Finset.sum_range_succ`.
- `momentSum_recurrence`: induction on `n`, interior sum collapsed via the binomial helper, closed by `linear_combination`. Index bases kept as ring casts so the `n = 0` instance is well-defined (no ℕ truncated subtraction).

## Verification

- Docker build: `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ08OQ01OQ01OQ01` ✅ (3058 jobs)
- 162 lines, 6 theorems, 1 definition, **0 axioms, 0 sorries**
- Depends only on `propext`, `Classical.choice`, `Quot.sound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)