### PR TITLE
research(geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03): Worpitzky's identity nᵐ = ∑ⱼ ⟨m,j⟩·C(n+j,m) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2632,6 +2632,7 @@ import Proofs.GeometricSeriesOQ07
 import Proofs.GeometricSeriesOQ07OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ03
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ02
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ03
 import Proofs.GeometricSeriesOQ08

--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ03.lean
@@ -1,0 +1,192 @@
+/-
+# Geometric series, open question oq-07-oq-01-oq-01-oq-01-oq-03:
+# Worpitzky's identity for the combinatorial Eulerian numbers
+
+The parent entry `geometric-series-oq-07-oq-01-oq-01-oq-01` built the combinatorial Eulerian
+numbers `⟨m,j⟩` (`eulerian m j`) from the classical triangle recurrence and identified them with
+the coefficients of the Eulerian polynomial.  This entry proves the most celebrated identity
+satisfied by those numbers, **Worpitzky's identity**, which expands the monomial `nᵐ` in the
+binomial-coefficient basis `C(n+j, m)`:
+
+  **`worpitzky`** :  `nᵐ = ∑_{j=0}^{m} ⟨m,j⟩ · C(n+j, m)`   (an identity of natural numbers).
+
+For example `n² = C(n,2) + C(n+1,2)` (`⟨2,0⟩ = ⟨2,1⟩ = 1`) and
+`n³ = C(n,3) + 4·C(n+1,3) + C(n+2,3)` (`⟨3,·⟩ = 1, 4, 1`).
+
+## Method
+
+Induction on `m`.  The heart is a single binomial identity, proved purely over `ℕ`:
+
+  **`worpitzky_term`** :  for `k ≤ m`,
+    `(k+1)·C(x+k, m+1) + (m−k)·C(x+k+1, m+1) = x·C(x+k, m)`,
+
+obtained from Pascal's rule `C(a+1, m+1) = C(a, m) + C(a, m+1)` and the absorption identity
+`C(a, m+1)·(m+1) = C(a, m)·(a−m)` (we transfer to `ℤ` once, where there is no truncated
+subtraction, and close by `linear_combination`).  Re-indexing the order-`m+1` Eulerian row
+through its triangle recurrence (the off-diagonal entry `⟨m,m+1⟩ = 0` makes the boundary term
+vanish) turns the order-`m+1` Worpitzky sum into `x` times the order-`m` Worpitzky sum, closing
+the induction.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and `sorry`-free.
+-/
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ01OQ03
+
+open Finset GeometricSeriesOQ07OQ01OQ01OQ01
+
+/-! ## The key absorption identity -/
+
+/-- **The Worpitzky per-term identity.**  For every `x` and every `k ≤ m`,
+`(k+1)·C(x+k, m+1) + (m−k)·C(x+k+1, m+1) = x·C(x+k, m)`, an identity of natural numbers.
+It is the absorption that drives the inductive step of Worpitzky's identity. -/
+theorem worpitzky_term {x k m : ℕ} (hk : k ≤ m) :
+    (k + 1) * (x + k).choose (m + 1) + (m - k) * (x + k + 1).choose (m + 1)
+      = x * (x + k).choose m := by
+  rcases Nat.lt_or_ge (x + k) m with hlt | hge
+  · -- `x + k < m`: every binomial in sight vanishes
+    rw [Nat.choose_eq_zero_of_lt (by omega : x + k < m + 1),
+        Nat.choose_eq_zero_of_lt (by omega : x + k + 1 < m + 1),
+        Nat.choose_eq_zero_of_lt hlt]
+    ring
+  · -- `m ≤ x + k`: transfer to `ℤ` and use Pascal + absorption
+    have hpascal : ((x + k + 1).choose (m + 1) : ℤ)
+        = ((x + k).choose m : ℤ) + ((x + k).choose (m + 1) : ℤ) := by
+      exact_mod_cast Nat.choose_succ_succ (x + k) m
+    have habs : ((x + k).choose (m + 1) : ℤ) * ((m : ℤ) + 1)
+        = ((x + k).choose m : ℤ) * (((x : ℤ) + k) - m) := by
+      have h2 : (((x + k).choose (m + 1) * (m + 1) : ℕ) : ℤ)
+          = (((x + k).choose m * ((x + k) - m) : ℕ) : ℤ) := by
+        exact_mod_cast Nat.choose_succ_right_eq (x + k) m
+      push_cast [Nat.cast_sub hge] at h2
+      linear_combination h2
+    have key : ((k : ℤ) + 1) * ((x + k).choose (m + 1) : ℤ)
+        + ((m : ℤ) - k) * ((x + k + 1).choose (m + 1) : ℤ)
+        = (x : ℤ) * ((x + k).choose m : ℤ) := by
+      linear_combination ((m : ℤ) - k) * hpascal + habs
+    have hgoalℤ :
+        (((k + 1) * (x + k).choose (m + 1) + (m - k) * (x + k + 1).choose (m + 1) : ℕ) : ℤ)
+          = ((x * (x + k).choose m : ℕ) : ℤ) := by
+      push_cast [Nat.cast_sub hk]
+      linear_combination key
+    exact_mod_cast hgoalℤ
+
+/-! ## The Worpitzky sum and its triangle-recurrence reindexing -/
+
+/-- The **Worpitzky sum** `Wₘ(n) = ∑_{j=0}^{m} ⟨m,j⟩ · C(n+j, m)`. -/
+def worpitzkySum (m n : ℕ) : ℕ :=
+  ∑ j ∈ range (m + 1), eulerian m j * (n + j).choose m
+
+/-- `⟨m,0⟩ = 1` for every `m` (the all-ascending permutation is the unique one with `0` descents). -/
+theorem eulerian_zero_left (m : ℕ) : eulerian m 0 = 1 := by
+  cases m with
+  | zero => rfl
+  | succ _ => rfl
+
+/-- **Reindexing the order-`m+1` Worpitzky sum through the Eulerian triangle recurrence.**
+`W_{m+1}(n) = ∑_{k=0}^{m} ⟨m,k⟩ · [(k+1)·C(n+k, m+1) + (m−k)·C(n+k+1, m+1)]`. -/
+theorem worpitzkySum_succ_eq (m n : ℕ) :
+    worpitzkySum (m + 1) n
+      = ∑ k ∈ range (m + 1),
+          eulerian m k *
+            ((k + 1) * (n + k).choose (m + 1) + (m - k) * (n + k + 1).choose (m + 1)) := by
+  -- Expand the left-hand side: peel the `j = 0` term, expand the triangle recurrence, split.
+  have hL : worpitzkySum (m + 1) n
+      = (∑ k ∈ range (m + 1), (k + 2) * eulerian m (k + 1) * (n + k + 1).choose (m + 1))
+        + (∑ k ∈ range (m + 1), (m - k) * eulerian m k * (n + k + 1).choose (m + 1))
+        + (n).choose (m + 1) := by
+    unfold worpitzkySum
+    rw [Finset.sum_range_succ' (fun j => eulerian (m + 1) j * (n + j).choose (m + 1)) (m + 1),
+        eulerian_succ_zero,
+        show (∑ i ∈ range (m + 1), eulerian (m + 1) (i + 1) * (n + (i + 1)).choose (m + 1))
+            = ∑ i ∈ range (m + 1),
+                ((i + 2) * eulerian m (i + 1) * (n + i + 1).choose (m + 1)
+                  + (m - i) * eulerian m i * (n + i + 1).choose (m + 1))
+          from Finset.sum_congr rfl fun i _ => by
+            rw [eulerian_succ_succ, add_mul, Nat.add_assoc n i 1],
+        Finset.sum_add_distrib]
+    simp only [one_mul, Nat.add_zero]
+  -- Expand the right-hand side: distribute and split.
+  have hR : (∑ k ∈ range (m + 1),
+              eulerian m k *
+                ((k + 1) * (n + k).choose (m + 1) + (m - k) * (n + k + 1).choose (m + 1)))
+      = (∑ k ∈ range (m + 1), (k + 1) * eulerian m k * (n + k).choose (m + 1))
+        + (∑ k ∈ range (m + 1), (m - k) * eulerian m k * (n + k + 1).choose (m + 1)) := by
+    rw [← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl fun k _ => by ring
+  -- The two `(m−k)`-sums agree; reduce to the shift identity on the remaining sums.
+  have hcore :
+      (∑ k ∈ range (m + 1), (k + 2) * eulerian m (k + 1) * (n + k + 1).choose (m + 1))
+        + (n).choose (m + 1)
+      = ∑ k ∈ range (m + 1), (k + 1) * eulerian m k * (n + k).choose (m + 1) := by
+    rw [Finset.sum_range_succ' (fun k => (k + 1) * eulerian m k * (n + k).choose (m + 1)) m,
+        Finset.sum_range_succ
+          (fun k => (k + 2) * eulerian m (k + 1) * (n + k + 1).choose (m + 1)) m,
+        eulerian_eq_zero_of_lt (Nat.lt_succ_self m), eulerian_zero_left]
+    -- the two `∑ over range m` are defeq termwise: `(k+2)·… (n+k+1)` ≡ `(k+1+1)·… (n+(k+1))`
+    have h1 : ∀ k, (k + 2) * eulerian m (k + 1) * (n + k + 1).choose (m + 1)
+        = (k + 1 + 1) * eulerian m (k + 1) * (n + (k + 1)).choose (m + 1) := fun _ => rfl
+    simp only [h1, Nat.add_zero, Nat.zero_add, mul_zero, zero_mul, mul_one, one_mul]
+  rw [hL, hR]
+  omega
+
+/-! ## Worpitzky's identity -/
+
+/-- The Worpitzky sum equals the power: `Wₘ(n) = nᵐ`. -/
+theorem worpitzkySum_eq_pow (m n : ℕ) : worpitzkySum m n = n ^ m := by
+  induction m with
+  | zero => simp [worpitzkySum]
+  | succ m ih =>
+    rw [worpitzkySum_succ_eq]
+    have hterm : (∑ k ∈ range (m + 1),
+          eulerian m k *
+            ((k + 1) * (n + k).choose (m + 1) + (m - k) * (n + k + 1).choose (m + 1)))
+        = ∑ k ∈ range (m + 1), eulerian m k * (n * (n + k).choose m) := by
+      apply Finset.sum_congr rfl
+      intro k hk
+      rw [worpitzky_term (Nat.lt_succ_iff.mp (Finset.mem_range.mp hk))]
+    have hfac : (∑ k ∈ range (m + 1), eulerian m k * (n * (n + k).choose m))
+        = n * worpitzkySum m n := by
+      unfold worpitzkySum
+      rw [Finset.mul_sum]
+      exact Finset.sum_congr rfl fun k _ => by ring
+    rw [hterm, hfac, ih]
+    ring
+
+/-- **Worpitzky's identity.**  Every power expands in the binomial basis with the Eulerian
+numbers as coefficients: `nᵐ = ∑_{j=0}^{m} ⟨m,j⟩ · C(n+j, m)`. -/
+theorem worpitzky (m n : ℕ) :
+    n ^ m = ∑ j ∈ range (m + 1), eulerian m j * (n + j).choose m :=
+  (worpitzkySum_eq_pow m n).symm
+
+/-- Since `⟨m,m⟩ = 0` for `m ≥ 1`, the top term drops: for `m ≥ 1`,
+`nᵐ = ∑_{j=0}^{m−1} ⟨m,j⟩ · C(n+j, m)`. -/
+theorem worpitzky_succ (m n : ℕ) :
+    n ^ (m + 1) = ∑ j ∈ range (m + 1), eulerian (m + 1) j * (n + j).choose (m + 1) := by
+  rw [worpitzky (m + 1) n, Finset.sum_range_succ]
+  rw [eulerian_succ_self, zero_mul, add_zero]
+
+/-! ## Low-order instances
+
+`⟨1,0⟩ = 1`; `⟨2,0⟩ = ⟨2,1⟩ = 1`; `⟨3,·⟩ = 1, 4, 1`. -/
+
+/-- `n² = C(n,2) + C(n+1,2)`. -/
+example (n : ℕ) : n ^ 2 = (n).choose 2 + (n + 1).choose 2 := by
+  rw [worpitzky 2 n, Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_one]
+  simp only [show eulerian 2 0 = 1 from by decide, show eulerian 2 1 = 1 from by decide,
+    show eulerian 2 2 = 0 from by decide, one_mul, zero_mul, add_zero]
+
+/-- `n³ = C(n,3) + 4·C(n+1,3) + C(n+2,3)`. -/
+example (n : ℕ) :
+    n ^ 3 = (n).choose 3 + 4 * (n + 1).choose 3 + (n + 2).choose 3 := by
+  rw [worpitzky 3 n, Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_succ,
+    Finset.sum_range_one]
+  simp only [show eulerian 3 0 = 1 from by decide, show eulerian 3 1 = 4 from by decide,
+    show eulerian 3 2 = 1 from by decide, show eulerian 3 3 = 0 from by decide,
+    one_mul, zero_mul, add_zero]
+
+/-- Numeric check: `4³ = 64 = C(4,3) + 4·C(5,3) + C(6,3) = 4 + 40 + 20`. -/
+example : (4 : ℕ) ^ 3 = (4).choose 3 + 4 * (5).choose 3 + (6).choose 3 := by decide
+
+end GeometricSeriesOQ07OQ01OQ01OQ01OQ03

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "GeometricSeriesOQ07OQ01OQ01OQ01"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ01OQ03",
+    "lineCount": 192,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "title": "Worpitzky's Identity: nᵐ = ∑ⱼ ⟨m,j⟩·C(n+j, m)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "worpitzky-identity",
+      "binomial-coefficients",
+      "descent-statistic",
+      "triangle-recurrence",
+      "induction",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 192,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "worpitzky: THE MAIN RESULT — Worpitzky's identity for the combinatorial Eulerian numbers ⟨m,j⟩ built in the parent entry: nᵐ = ∑_{j=0}^{m} ⟨m,j⟩·C(n+j, m), an identity of natural numbers expanding every monomial in the shifted-binomial basis. This is the most celebrated identity satisfied by the Eulerian numbers; Mathlib has neither the Eulerian numbers nor Worpitzky's identity, so both the statement and the proof are built here on top of the parent's eulerian triangle.",
+      "worpitzky_term: the absorption identity at the heart of the inductive step, proved purely over ℕ for every x and every k ≤ m: (k+1)·C(x+k, m+1) + (m−k)·C(x+k+1, m+1) = x·C(x+k, m). It is obtained from Pascal's rule C(a+1, m+1) = C(a, m) + C(a, m+1) and the absorption identity C(a, m+1)·(m+1) = C(a, m)·(a−m); the algebra is transferred once to ℤ (where there is no truncated subtraction) and closed by linear_combination.",
+      "worpitzkySum_succ_eq: the structural lemma turning the order-(m+1) Worpitzky sum into x times the order-m sum. Reindexing the order-(m+1) Eulerian row through the triangle recurrence ⟨m+1,k+1⟩ = (k+2)⟨m,k+1⟩ + (m−k)⟨m,k⟩, the off-diagonal vanishing ⟨m,m+1⟩ = 0 makes the boundary term disappear, so W_{m+1}(n) = ∑_k ⟨m,k⟩·[(k+1)·C(n+k,m+1) + (m−k)·C(n+k+1,m+1)]; combined with worpitzky_term this equals n·W_m(n), closing the induction n^{m+1} = n·n^m.",
+      "worpitzky_succ: the top term drops because ⟨m+1,m+1⟩ = 0, giving nᵐ⁺¹ = ∑_{j=0}^{m} ⟨m+1,j⟩·C(n+j, m+1) (the descent index runs only up to m). The order-2 and order-3 instances n² = C(n,2)+C(n+1,2) and n³ = C(n,3)+4·C(n+1,3)+C(n+2,3) are verified, exhibiting the Eulerian rows 1,1 and 1,4,1, together with the numeric check 4³ = 64 = 4 + 40 + 20."
+    ],
+    "prerequisites": [
+      "Parent: geometric-series-oq-07-oq-01-oq-01-oq-01 (the combinatorial Eulerian numbers) — supplies the eulerian triangle, its recurrence eulerian_succ_succ, the base value eulerian_succ_zero, and the vanishing lemma eulerian_eq_zero_of_lt reused here",
+      "Mathlib's Nat.choose with Pascal's rule (Nat.choose_succ_succ) and the absorption identity (Nat.choose_succ_right_eq), plus Nat.choose_eq_zero_of_lt for the degenerate range",
+      "Casting ℕ identities to ℤ (Nat.cast_sub, push_cast) so the per-term absorption can be discharged by linear_combination without truncated subtraction",
+      "Finset reindexing: Finset.sum_range_succ, Finset.sum_range_succ', Finset.sum_add_distrib, Finset.mul_sum"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "The binomial absorption identity n.choose (k+1) · (k+1) = n.choose k · (n−k). Cast to ℤ, this turns (m+1)·C(x+k,m+1) into (x+k−m)·C(x+k,m), the key step of the per-term Worpitzky identity worpitzky_term.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule (n+1).choose (k+1) = n.choose k + n.choose (k+1). Used (over ℤ) to split C(x+k+1, m+1) into C(x+k, m) + C(x+k, m+1) inside worpitzky_term.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Peels the first term of a range sum with an index shift, ∑_{i<n+1} f i = ∑_{i<n} f (i+1) + f 0. Drives the reindexing of the Eulerian row in worpitzkySum_succ_eq that exposes the off-diagonal vanishing boundary term.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07OQ01OQ01OQ01.eulerian",
+        "description": "The parent's from-scratch combinatorial Eulerian-number triangle ⟨m,j⟩ and its recurrence/vanishing lemmas. Reused verbatim so this entry only adds Worpitzky's identity, not the underlying number-theoretic object.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03-oq-01",
+      "question": "Deduce the row-sum ∑_{j=0}^{m} ⟨m,j⟩ = m! from Worpitzky's identity by a finite-difference / inclusion–exclusion argument (apply the m-th forward difference to nᵐ = ∑_j ⟨m,j⟩·C(n+j, m)), giving a second, transform-based proof of the descent count complementary to the direct triangle-recurrence induction proposed in the sibling oq-01.",
+      "significance": "low"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03-oq-02",
+      "question": "Prove the generating-function consequence of Worpitzky's identity, the closed form ∑_{n≥0} nᵐ·xⁿ = Eₘ(x)/(1−x)^{m+1} for the Eulerian polynomial, by substituting nᵐ = ∑_j ⟨m,j⟩·C(n+j,m) and summing the binomial series ∑_n C(n+j,m)xⁿ = x^{m−j}/(1−x)^{m+1}, reconnecting the combinatorial side built here to the geometric-moment numerator of the grandparent geometric-series-oq-07."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent (the combinatorial Eulerian numbers). The parent defines the Eulerian-number triangle ⟨m,j⟩ from the recurrence and identifies it with the coefficients of the Eulerian polynomial. This entry proves the classical Worpitzky identity nᵐ = ∑_j ⟨m,j⟩·C(n+j, m) for those numbers, reusing the parent's eulerian, eulerian_succ_succ and eulerian_eq_zero_of_lt."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling open question under the same parent. oq-02 concerns the combinatorial palindromy ⟨m,j⟩ = ⟨m,m−1−j⟩; this entry instead develops Worpitzky's identity. Both are theory-level facts about the descent statistic ⟨m,j⟩ proved directly from the triangle recurrence."
+    },
+    {
+      "targetId": "geometric-series-oq-07",
+      "relationship": "related",
+      "description": "Grandparent lineage (the geometric moment ∑ nᵐ·rⁿ). Worpitzky's identity is the combinatorial dual of that generating function: expanding nᵐ over the shifted binomials C(n+j,m) and summing the geometric series recovers the Eulerian-polynomial numerator Eₘ(r)/(1−r)^{m+1} established up the lineage."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Worpitzky's identity, Eulerian numbers, the descent statistic)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for Worpitzky's identity x^n = ∑_k ⟨n,k⟩·C(x+k, n) and the Eulerian-number triangle recurrence used here."
+    },
+    {
+      "title": "Mathlib4: Data.Nat.Choose.Basic",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Pascal's rule (Nat.choose_succ_succ) and the binomial absorption identity (Nat.choose_succ_right_eq) that power the per-term identity worpitzky_term."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Building on the parent entry's from-scratch combinatorial Eulerian numbers ⟨m,j⟩, this entry proves Worpitzky's identity — the most celebrated identity satisfied by those numbers — as an identity of natural numbers: nᵐ = ∑_{j=0}^{m} ⟨m,j⟩·C(n+j, m). The proof is an induction on m whose engine is a single binomial absorption identity worpitzky_term, (k+1)·C(x+k, m+1) + (m−k)·C(x+k+1, m+1) = x·C(x+k, m) for k ≤ m, obtained from Pascal's rule and the absorption C(a, m+1)·(m+1) = C(a, m)·(a−m) (transferred once to ℤ, where there is no truncated subtraction, and closed by linear_combination). Reindexing the order-(m+1) Eulerian row through its triangle recurrence ⟨m+1,k+1⟩ = (k+2)⟨m,k+1⟩ + (m−k)⟨m,k⟩ — the off-diagonal vanishing ⟨m,m+1⟩ = 0 killing the boundary term — turns the order-(m+1) Worpitzky sum into n times the order-m sum, so n^{m+1} = n·n^m closes the induction. The corollary worpitzky_succ drops the (zero) top term, and the order-2/order-3 instances n² = C(n,2)+C(n+1,2) and n³ = C(n,3)+4·C(n+1,3)+C(n+2,3) are verified. 192 lines, 6 theorems, 1 definition, 0 axioms, 0 sorries; everything depends only on propext, Classical.choice, Quot.sound (low-order checks use kernel `decide`, not native_decide).",
+    "implications": "Worpitzky's identity is the change-of-basis that expresses the power basis nᵐ in the shifted-binomial basis C(n+j, m) with the Eulerian numbers as the (integer, nonnegative) connection coefficients. It immediately yields the descent interpretation (the coefficients count permutations by descents) and, summed against a geometric series, reproduces the Eulerian-polynomial form Eₘ(r)/(1−r)^{m+1} of the geometric moment established up the lineage — closing the loop between the combinatorial Eulerian numbers built in the parent and the analytic generating function of the grandparent. Because the proof needs only the triangle recurrence and elementary binomial identities, it is a reusable, Mathlib-free addition to the Eulerian-number theory developed in this gallery.",
+    "openQuestions": [
+      "Deduce the row-sum ∑_j ⟨m,j⟩ = m! from Worpitzky's identity via the m-th forward difference of nᵐ.",
+      "Prove ∑_{n≥0} nᵐ·xⁿ = Eₘ(x)/(1−x)^{m+1} from Worpitzky's identity by summing the binomial series, reconnecting to the geometric moment of geometric-series-oq-07."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Proves **Worpitzky's identity** for the combinatorial Eulerian numbers ⟨m,j⟩ built in the parent entry (`geometric-series-oq-07-oq-01-oq-01-oq-01`). As an identity of natural numbers:

> **nᵐ = ∑_{j=0}^{m} ⟨m,j⟩ · C(n+j, m)**

the change-of-basis expressing the power basis in the shifted-binomial basis, with the Eulerian (descent) numbers as the integer connection coefficients.

## Method

Induction on `m`. The engine is a single binomial **absorption identity** (`worpitzky_term`), proved purely over ℕ for `k ≤ m`:

> (k+1)·C(x+k, m+1) + (m−k)·C(x+k+1, m+1) = x·C(x+k, m)

from Pascal's rule `C(a+1,m+1) = C(a,m) + C(a,m+1)` and the absorption `C(a,m+1)·(m+1) = C(a,m)·(a−m)` (transferred once to ℤ, where there is no truncated subtraction, and closed by `linear_combination`). Reindexing the order-(m+1) Eulerian row through its triangle recurrence — the off-diagonal vanishing `⟨m,m+1⟩ = 0` killing the boundary term — turns `W_{m+1}(n)` into `n·W_m(n)`, so `n^{m+1} = n·n^m` closes the induction.

## Verification

- **192 lines, 6 theorems, 1 definition, 0 axioms, 0 sorries**
- Docker-verified (`./proofs/scripts/docker-build.sh`, 7746 jobs, build succeeded)
- Axioms: `propext` / `Classical.choice` / `Quot.sound` only (low-order checks use kernel `decide`, not `native_decide`)
- Instances verified: `n² = C(n,2)+C(n+1,2)`, `n³ = C(n,3)+4·C(n+1,3)+C(n+2,3)`, `4³ = 64 = 4+40+20`

## Dependency

Stacked on **#27383** (parent: the combinatorial Eulerian numbers), which supplies `eulerian`, `eulerian_succ_succ`, `eulerian_eq_zero_of_lt`. Merge #27383 first; this PR's diff includes the parent commit until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)