### PR TITLE
research(lebesgue-measure-oq-01-oq-01-oq-01-oq-02): the oscillation of Thomae's function is exactly 1/q [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2904,6 +2904,7 @@ import Proofs.LebesgueMeasure
 import Proofs.LebesgueMeasureOQ01
 import Proofs.LebesgueMeasureOQ01OQ01
 import Proofs.LebesgueMeasureOQ01OQ01OQ01
+import Proofs.LebesgueMeasureOQ01OQ01OQ01OQ02
 import Proofs.LebesgueMeasureOQ01OQ01OQ02
 import Proofs.LebesgueMeasureOQ01OQ01OQ02OQ02
 import Proofs.LebesgueMeasureOQ01OQ01OQ02Riemann

--- a/proofs/Proofs/LebesgueMeasureOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,316 @@
+import Mathlib
+
+/-
+# The Oscillation of Thomae's Function
+
+## Open Question (lebesgue-measure-oq-01-oq-01-oq-01-oq-02)
+Quantify the discontinuity of Thomae's function via the **oscillation function**.
+Prove that the oscillation of Thomae's function at a rational `p/q` (in lowest
+terms) is exactly `1/q`, that it vanishes at every irrational, and that the level
+set `{x | oscillation thomae x ≥ ε}` is finite in every bounded interval — the
+finer, oscillation-theoretic form of Lebesgue's criterion.
+
+## Answer: YES — `oscillation thomae (p/q) = 1/q`
+Working with Mathlib's `oscillation f x = ⨅ S ∈ (𝓝 x).map f, EMetric.diam S`
+(`Mathlib.Analysis.Oscillation`), we prove, for `r : ℚ` with reduced denominator
+`d = r.den`:
+
+  `oscillation thomae r = ENNReal.ofReal (1 / d)`.
+
+The two inequalities use complementary facts about Thomae's function:
+
+* **Upper bound** `≤ 1/d`.  A single key lemma (`exists_nbhd_thomae_le`) shows
+  that for any threshold `v > 0` with `thomae a ≤ v`, some ball around `a`
+  keeps `thomae ≤ v`: the points where `thomae > v` are rationals of denominator
+  `< 1/v`, finitely many near `a`, and none equal to `a`. Taking `v = 1/d`
+  bounds the image of a small ball inside `[0, 1/d]`, so its diameter — hence the
+  oscillation — is `≤ 1/d`.
+* **Lower bound** `≥ 1/d`.  Every neighborhood of `a = r` contains `a` itself
+  (where `thomae = 1/d`) and, since the irrationals are dense
+  (`dense_irrational`), an irrational point (where `thomae = 0`). So every set in
+  the mapped neighborhood filter has diameter `≥ 1/d`.
+
+At an irrational `x` the same key lemma gives `thomae ≤ ε` on a small ball for
+*every* `ε > 0`, so the oscillation is `0` — recovering continuity at the
+irrationals (`Oscillation.eq_zero_iff_continuousAt`).
+
+Finally `{x ∈ [a,b] | ofReal ε ≤ oscillation thomae x}` is finite: every such `x`
+is rational with `1/x.den ≥ ε`, i.e. `x.den ≤ 1/ε`, and rationals of bounded
+denominator in a bounded interval form a finite set. This is the oscillation form
+of Lebesgue's criterion: the discontinuity set is a countable union of finite
+level sets, hence null.
+
+## Self-containment
+The Thomae infrastructure (definition, value at rationals/irrationals, finiteness
+of bounded-denominator rationals) is reproved here so the file builds against the
+current Mathlib independently of the sibling entries.
+-/
+
+namespace LebesgueMeasureOQ01OQ01OQ01OQ02
+
+open MeasureTheory Topology
+
+open Classical in
+/-- Thomae's function (popcorn function): `1/q.den` if `x` is rational, `0` if
+irrational. -/
+noncomputable def thomae : ℝ → ℝ := fun x =>
+  if h : ∃ q : ℚ, (q : ℝ) = x then 1 / (h.choose.den : ℝ) else 0
+
+/-- `thomae = 0` at irrationals. -/
+theorem thomae_irrational {x : ℝ} (hx : Irrational x) : thomae x = 0 := by
+  have hne : ¬ ∃ q : ℚ, (q : ℝ) = x := by
+    rintro ⟨q, rfl⟩; exact hx ⟨q, rfl⟩
+  simp only [thomae, dif_neg hne]
+
+/-- `thomae` at a rational `q` equals `1/q.den`. -/
+theorem thomae_rat (q : ℚ) : thomae (q : ℝ) = 1 / (q.den : ℝ) := by
+  have hq : ∃ r : ℚ, (r : ℝ) = (q : ℝ) := ⟨q, rfl⟩
+  have heq : hq.choose = q := Rat.cast_inj.mp hq.choose_spec
+  simp only [thomae, dif_pos hq, heq]
+
+/-- Thomae's function is non-negative. -/
+theorem thomae_nonneg (x : ℝ) : 0 ≤ thomae x := by
+  simp only [thomae]
+  split <;> positivity
+
+-- ============================================================
+-- PART 0: Finiteness of bounded-denominator rationals
+-- ============================================================
+
+/-- `q.num = q * q.den` over `ℝ`. -/
+private lemma rat_num_eq_mul_den (q : ℚ) : (q.num : ℝ) = (q : ℝ) * q.den := by
+  have hd : (q.den : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr q.pos.ne'
+  have hq_eq : (q.num : ℚ) = q * q.den := (div_eq_iff hd).mp (Rat.num_div_den q)
+  exact_mod_cast hq_eq
+
+/-- Rationals with bounded denominator in `[x-1, x+1]` form a finite set. -/
+private lemma finite_rat_bounded (x : ℝ) (N : ℕ) :
+    Set.Finite {q : ℚ | |(q : ℝ) - x| ≤ 1 ∧ q.den ≤ N} := by
+  apply Set.Finite.subset (Finset.finite_toSet
+    ((Finset.range (N + 1)).biUnion fun d =>
+      (Finset.Icc ⌊(x - 1) * (d : ℝ)⌋ ⌈(x + 1) * (d : ℝ)⌉).image
+        fun n : ℤ => (n : ℚ) / (d : ℚ)))
+  intro q hq
+  obtain ⟨habs, hden⟩ := hq
+  rw [Finset.mem_coe]
+  simp only [Finset.mem_biUnion, Finset.mem_range, Finset.mem_image, Finset.mem_Icc]
+  have habs' := abs_le.mp habs
+  have hq_lower : x - 1 ≤ (q : ℝ) := by linarith [habs'.1]
+  have hq_upper : (q : ℝ) ≤ x + 1 := by linarith [habs'.2]
+  have hden_pos : (0 : ℝ) < (q.den : ℝ) := Nat.cast_pos.mpr q.pos
+  have hq_num := rat_num_eq_mul_den q
+  refine ⟨q.den, Nat.lt_succ_of_le hden, q.num, ⟨?_, ?_⟩, ?_⟩
+  · have hle : (x - 1) * (q.den : ℝ) ≤ (q.num : ℝ) := by
+      rw [hq_num]; nlinarith [hq_lower, hden_pos]
+    have := (Int.floor_le ((x - 1) * (q.den : ℝ))).trans hle
+    exact_mod_cast this
+  · have hge : (q.num : ℝ) ≤ (x + 1) * (q.den : ℝ) := by
+      rw [hq_num]; nlinarith [hq_upper, hden_pos]
+    have := hge.trans (Int.le_ceil ((x + 1) * (q.den : ℝ)))
+    exact_mod_cast this
+  · exact Rat.num_div_den q
+
+/-- From a point `x` and a finite set `S` of rationals none of which casts to `x`,
+there is a positive minimum distance from `x` to the set. -/
+private lemma pos_min_dist {x : ℝ} (S : Finset ℚ) (hS : ∀ q ∈ S, (q : ℝ) ≠ x) :
+    ∃ δ > 0, ∀ q ∈ S, δ ≤ |x - (q : ℝ)| := by
+  induction S using Finset.induction_on with
+  | empty => exact ⟨1, one_pos, by simp⟩
+  | @insert a s _ ih =>
+    have hS' : ∀ q ∈ s, (q : ℝ) ≠ x := fun q hq => hS q (Finset.mem_insert_of_mem hq)
+    obtain ⟨δ₀, hδ₀, hq₀⟩ := ih hS'
+    have ha : (a : ℝ) ≠ x := hS a (Finset.mem_insert_self a s)
+    refine ⟨min δ₀ |x - (a : ℝ)|, lt_min hδ₀ ?_, fun q hq' => ?_⟩
+    · rw [abs_pos, sub_ne_zero]; exact fun h => ha h.symm
+    · rcases Finset.mem_insert.mp hq' with rfl | hq''
+      · exact min_le_right _ _
+      · exact (min_le_left _ _).trans (hq₀ q hq'')
+
+-- ============================================================
+-- PART 1: A uniform local bound for Thomae's function
+-- ============================================================
+
+/-- **Key lemma.** If `thomae a ≤ v` with `v > 0`, then `thomae ≤ v` on a whole
+ball around `a`. The exceptional points (where `thomae > v`) are rationals of
+denominator `< 1/v` — finitely many near `a`, and none equal to `a`. -/
+theorem exists_nbhd_thomae_le (a : ℝ) (v : ℝ) (hv : 0 < v) (hav : thomae a ≤ v) :
+    ∃ δ > 0, ∀ y ∈ Metric.ball a δ, thomae y ≤ v := by
+  -- Choose `N` with `1/v ≤ N`, so `thomae q > v → q.den ≤ N`.
+  obtain ⟨N, hN⟩ : ∃ N : ℕ, (1 : ℝ) / v ≤ N := ⟨⌈(1 : ℝ) / v⌉₊, Nat.le_ceil _⟩
+  -- The exceptional rationals near `a`.
+  set T : Set ℚ := {q : ℚ | |(q : ℝ) - a| ≤ 1 ∧ v < 1 / (q.den : ℝ)} with hTdef
+  have hTfin : T.Finite := by
+    apply Set.Finite.subset (finite_rat_bounded a N)
+    intro q hq
+    obtain ⟨habs, hvq⟩ := hq
+    refine ⟨habs, ?_⟩
+    -- `v < 1/q.den → q.den < 1/v ≤ N`
+    have hden_pos : (0 : ℝ) < (q.den : ℝ) := Nat.cast_pos.mpr q.pos
+    have hlt : (q.den : ℝ) < 1 / v := by
+      rw [lt_div_iff₀ hv]
+      have h1 : v * (q.den : ℝ) < 1 := (lt_div_iff₀ hden_pos).mp hvq
+      linarith [h1, mul_comm v (q.den : ℝ)]
+    have : (q.den : ℝ) < (N : ℝ) := lt_of_lt_of_le hlt hN
+    exact_mod_cast this.le
+  -- None of the exceptional rationals casts to `a`.
+  have hne : ∀ q ∈ hTfin.toFinset, (q : ℝ) ≠ a := by
+    intro q hq hcast
+    rw [Set.Finite.mem_toFinset] at hq
+    have hvq : v < 1 / (q.den : ℝ) := hq.2
+    rw [← thomae_rat q, hcast] at hvq
+    exact absurd (hav.trans_lt hvq) (lt_irrefl _)
+  obtain ⟨δ, hδ, hdist⟩ := pos_min_dist hTfin.toFinset hne
+  refine ⟨min δ 1, lt_min hδ one_pos, fun y hy => ?_⟩
+  rw [Metric.mem_ball, Real.dist_eq] at hy
+  have hy1 : |y - a| < 1 := lt_of_lt_of_le hy (min_le_right _ _)
+  have hyδ : |y - a| < δ := lt_of_lt_of_le hy (min_le_left _ _)
+  by_cases hirr : Irrational y
+  · rw [thomae_irrational hirr]; exact hv.le
+  · simp only [Irrational, not_not] at hirr
+    obtain ⟨q, hq⟩ := hirr
+    rw [← hq, thomae_rat]
+    by_contra hcon
+    push_neg at hcon
+    -- `v < 1/q.den` so `q ∈ T`, contradicting the minimum distance.
+    have hmem : q ∈ hTfin.toFinset := by
+      rw [Set.Finite.mem_toFinset]
+      refine ⟨?_, hcon⟩
+      rw [hq]; exact hy1.le
+    have := hdist q hmem
+    rw [← hq] at hyδ
+    rw [abs_sub_comm] at this
+    linarith
+
+-- ============================================================
+-- PART 2: The oscillation of Thomae's function
+-- ============================================================
+
+/-- The image of a `thomae`-ball of bounded values has small diameter:
+if `thomae ≤ v` on `Metric.ball a δ` then the EMetric diameter of the image is
+`≤ ofReal v`. -/
+private lemma diam_image_le {a v δ : ℝ} (_hv : 0 ≤ v)
+    (hδ : ∀ y ∈ Metric.ball a δ, thomae y ≤ v) :
+    EMetric.diam (thomae '' Metric.ball a δ) ≤ ENNReal.ofReal v := by
+  apply EMetric.diam_le
+  rintro u ⟨x, hx, rfl⟩ w ⟨y, hy, rfl⟩
+  rw [edist_dist, Real.dist_eq]
+  apply ENNReal.ofReal_le_ofReal
+  rw [abs_le]
+  constructor
+  · linarith [thomae_nonneg x, hδ y hy]
+  · linarith [hδ x hx, thomae_nonneg y]
+
+/-- **The oscillation of Thomae's function at a rational `r` is exactly `1/r.den`.**
+This is the sharp, quantitative form of the discontinuity of Thomae's function. -/
+theorem oscillation_thomae_rat (r : ℚ) :
+    oscillation thomae (r : ℝ) = ENNReal.ofReal (1 / (r.den : ℝ)) := by
+  have hdpos : (0 : ℝ) < (r.den : ℝ) := Nat.cast_pos.mpr r.pos
+  have hvpos : (0 : ℝ) < 1 / (r.den : ℝ) := by positivity
+  refine le_antisymm ?_ ?_
+  · -- Upper bound: a small ball keeps `thomae ≤ 1/r.den`.
+    obtain ⟨δ, hδ, hball⟩ :=
+      exists_nbhd_thomae_le (r : ℝ) (1 / (r.den : ℝ)) hvpos (le_of_eq (thomae_rat r))
+    have hmem : thomae '' Metric.ball (r : ℝ) δ ∈ (𝓝 (r : ℝ)).map thomae :=
+      Filter.image_mem_map (Metric.ball_mem_nhds _ hδ)
+    calc oscillation thomae (r : ℝ)
+        ≤ EMetric.diam (thomae '' Metric.ball (r : ℝ) δ) := biInf_le _ hmem
+      _ ≤ ENNReal.ofReal (1 / (r.den : ℝ)) := diam_image_le hvpos.le hball
+  · -- Lower bound: every neighborhood meets `r` (value `1/r.den`) and an
+    -- irrational (value `0`), so every set in the mapped filter has diameter
+    -- `≥ 1/r.den`.
+    rw [oscillation]
+    refine le_iInf₂ fun S hS => ?_
+    rw [Filter.mem_map, mem_nhds_iff] at hS
+    obtain ⟨U, hUsub, hUopen, haU⟩ := hS
+    obtain ⟨y, hyirr, hyU⟩ := dense_irrational.exists_mem_open hUopen ⟨(r : ℝ), haU⟩
+    have haS : thomae (r : ℝ) ∈ S := hUsub haU
+    have hyS : thomae y ∈ S := hUsub hyU
+    calc ENNReal.ofReal (1 / (r.den : ℝ))
+        = edist (thomae (r : ℝ)) (thomae y) := by
+          rw [thomae_rat r, thomae_irrational hyirr, edist_dist, Real.dist_eq,
+            sub_zero, abs_of_nonneg hvpos.le]
+      _ ≤ EMetric.diam S := EMetric.edist_le_diam_of_mem haS hyS
+
+/-- **The oscillation of Thomae's function vanishes at every irrational.**
+Equivalently, Thomae's function is continuous at the irrationals. -/
+theorem oscillation_thomae_irrational {x : ℝ} (hx : Irrational x) :
+    oscillation thomae x = 0 := by
+  refine le_antisymm ?_ (zero_le _)
+  refine ENNReal.le_of_forall_pos_le_add fun ε hε _ => ?_
+  rw [zero_add]
+  obtain ⟨δ, hδ, hball⟩ :=
+    exists_nbhd_thomae_le x (ε : ℝ) (by exact_mod_cast hε) (by rw [thomae_irrational hx]; positivity)
+  have hmem : thomae '' Metric.ball x δ ∈ (𝓝 x).map thomae :=
+    Filter.image_mem_map (Metric.ball_mem_nhds _ hδ)
+  calc oscillation thomae x
+      ≤ EMetric.diam (thomae '' Metric.ball x δ) := biInf_le _ hmem
+    _ ≤ ENNReal.ofReal (ε : ℝ) := diam_image_le (by positivity) hball
+    _ = (ε : ENNReal) := ENNReal.ofReal_coe_nnreal
+
+/-- Thomae's function is continuous at every irrational (oscillation form). -/
+theorem thomae_continuousAt_irrational {x : ℝ} (hx : Irrational x) :
+    ContinuousAt thomae x :=
+  (Oscillation.eq_zero_iff_continuousAt thomae x).mp (oscillation_thomae_irrational hx)
+
+-- ============================================================
+-- PART 3: Finiteness of the oscillation level sets
+-- ============================================================
+
+/-- Rationals of bounded denominator in a bounded interval form a finite set. -/
+private lemma finite_rat_Icc (a b : ℝ) (N : ℕ) :
+    Set.Finite {q : ℚ | a ≤ (q : ℝ) ∧ (q : ℝ) ≤ b ∧ q.den ≤ N} := by
+  apply Set.Finite.subset (Finset.finite_toSet
+    ((Finset.range (N + 1)).biUnion fun d =>
+      (Finset.Icc ⌊a * (d : ℝ)⌋ ⌈b * (d : ℝ)⌉).image
+        fun n : ℤ => (n : ℚ) / (d : ℚ)))
+  intro q hq
+  obtain ⟨hqa, hqb, hden⟩ := hq
+  rw [Finset.mem_coe]
+  simp only [Finset.mem_biUnion, Finset.mem_range, Finset.mem_image, Finset.mem_Icc]
+  have hden_pos : (0 : ℝ) < (q.den : ℝ) := Nat.cast_pos.mpr q.pos
+  have hq_num := rat_num_eq_mul_den q
+  refine ⟨q.den, Nat.lt_succ_of_le hden, q.num, ⟨?_, ?_⟩, ?_⟩
+  · have hle : a * (q.den : ℝ) ≤ (q.num : ℝ) := by
+      rw [hq_num]; nlinarith [hqa, hden_pos]
+    have := (Int.floor_le (a * (q.den : ℝ))).trans hle
+    exact_mod_cast this
+  · have hge : (q.num : ℝ) ≤ b * (q.den : ℝ) := by
+      rw [hq_num]; nlinarith [hqb, hden_pos]
+    have := hge.trans (Int.le_ceil (b * (q.den : ℝ)))
+    exact_mod_cast this
+  · exact Rat.num_div_den q
+
+/-- **The oscillation level sets are finite (oscillation form of Lebesgue's
+criterion).** For `ε > 0`, only finitely many points of any bounded interval
+`[a,b]` have oscillation `≥ ε`. Hence the discontinuity set is a countable union
+of finite sets, so null. -/
+theorem oscillation_levelSet_finite (ε : ℝ) (hε : 0 < ε) (a b : ℝ) :
+    Set.Finite {x : ℝ | a ≤ x ∧ x ≤ b ∧ ENNReal.ofReal ε ≤ oscillation thomae x} := by
+  obtain ⟨N, hN⟩ : ∃ N : ℕ, (1 : ℝ) / ε ≤ N := ⟨⌈(1 : ℝ) / ε⌉₊, Nat.le_ceil _⟩
+  -- Every such `x` is a rational with denominator `≤ N`.
+  apply Set.Finite.subset
+    ((finite_rat_Icc a b N).image ((↑) : ℚ → ℝ))
+  intro x hx
+  obtain ⟨hxa, hxb, hosc⟩ := hx
+  -- `x` cannot be irrational: there the oscillation is `0 < ε`.
+  by_cases hirr : Irrational x
+  · rw [oscillation_thomae_irrational hirr] at hosc
+    exact absurd (lt_of_lt_of_le (by positivity) hosc) (lt_irrefl _)
+  · simp only [Irrational, not_not] at hirr
+    obtain ⟨q, hq⟩ := hirr
+    refine ⟨q, ⟨?_, ?_, ?_⟩, hq⟩
+    · rw [hq]; exact hxa
+    · rw [hq]; exact hxb
+    · -- `ofReal ε ≤ oscillation = ofReal (1/q.den)` forces `q.den ≤ N`.
+      rw [← hq, oscillation_thomae_rat q] at hosc
+      have hdpos : (0 : ℝ) < (q.den : ℝ) := Nat.cast_pos.mpr q.pos
+      have hle : ε ≤ 1 / (q.den : ℝ) :=
+        (ENNReal.ofReal_le_ofReal_iff (by positivity)).mp hosc
+      have hlt : (q.den : ℝ) ≤ 1 / ε := by
+        rw [le_div_iff₀ hε]
+        have h1 : ε * (q.den : ℝ) ≤ 1 := (le_div_iff₀ hdpos).mp hle
+        linarith [h1, mul_comm ε (q.den : ℝ)]
+      have : (q.den : ℝ) ≤ (N : ℝ) := hlt.trans hN
+      exact_mod_cast this
+
+end LebesgueMeasureOQ01OQ01OQ01OQ02

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "lebesgue-measure-oq-01-oq-01-oq-01-oq-02",
+  "slug": "lebesgue-measure-oq-01-oq-01-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Topology"
+    ],
+    "namespace": "LebesgueMeasureOQ01OQ01OQ01OQ02",
+    "lineCount": 316,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "path": "Proofs/LebesgueMeasureOQ01OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Oscillation of Thomae's Function is Exactly 1/q",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LebesgueMeasureOQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "measure-theory",
+      "lebesgue-measure",
+      "thomae-function",
+      "popcorn-function",
+      "oscillation",
+      "lebesgue-criterion",
+      "riemann-integrability",
+      "real-analysis",
+      "diophantine-approximation",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 316,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "oscillation_thomae_rat: **the sharp value** — the oscillation of Thomae's function (Mathlib's `oscillation f x = ⨅ S ∈ (𝓝 x).map f, EMetric.diam S`) at a rational `r` is exactly `ENNReal.ofReal (1/r.den)`. The upper bound comes from a single key lemma keeping `thomae ≤ 1/r.den` on a small ball; the lower bound from the fact that every neighborhood meets both `r` (value `1/r.den`) and a dense irrational (value `0`), so every set in the mapped neighborhood filter has EMetric diameter `≥ 1/r.den`.",
+      "exists_nbhd_thomae_le: the reusable key lemma — if `thomae a ≤ v` for some `v > 0`, then `thomae ≤ v` on a whole ball around `a`. The points where `thomae > v` are rationals of denominator `< 1/v`, of which only finitely many lie near `a` (none equal to `a`), so they sit a positive distance away. This single lemma drives BOTH the rational upper bound (v = 1/r.den) and continuity at the irrationals (v = ε for every ε > 0).",
+      "oscillation_thomae_irrational: the oscillation vanishes at every irrational, obtained from the key lemma with `v = ε` for all `ε > 0` and `ENNReal.le_of_forall_pos_le_add` — recovering continuity at the irrationals without an ad-hoc ε–δ argument.",
+      "thomae_continuousAt_irrational: continuity at the irrationals as a corollary, via Mathlib's `Oscillation.eq_zero_iff_continuousAt` — the oscillation characterization of continuity.",
+      "oscillation_levelSet_finite: **the oscillation form of Lebesgue's criterion** — for every ε > 0, only finitely many points of any bounded interval [a,b] have oscillation ≥ ε. Each such point is rational with 1/den ≥ ε, i.e. denominator ≤ 1/ε, and rationals of bounded denominator in a bounded interval form a finite set (finite_rat_Icc). Hence the discontinuity set is a countable union of finite level sets, so null.",
+      "diam_image_le: the EMetric diameter of a `thomae`-image is small when the values are bounded — packaging `edist (thomae x) (thomae y) ≤ ofReal v` from `0 ≤ thomae ≤ v`, used for both oscillation upper bounds.",
+      "finite_rat_bounded / finite_rat_Icc: only finitely many rationals of bounded denominator lie in a bounded real interval (in [x−1,x+1] and in [a,b] respectively), via integer bracketing of the numerator (Int.floor_le, Int.le_ceil)."
+    ],
+    "prerequisites": [
+      "oscillation (Mathlib, Mathlib.Analysis.Oscillation): oscillation f x = ⨅ S ∈ (𝓝 x).map f, EMetric.diam S — the definition whose value is computed here",
+      "Oscillation.eq_zero_iff_continuousAt (Mathlib): oscillation f x = 0 ↔ ContinuousAt f x — turns the vanishing oscillation at irrationals into continuity",
+      "dense_irrational (Mathlib, Mathlib.Topology.Instances.Irrational): the irrationals are dense in ℝ — supplies the value-0 point in every neighborhood for the lower bound",
+      "EMetric.diam_le, EMetric.edist_le_diam_of_mem (Mathlib): EMetric diameter bounds in both directions",
+      "ENNReal.le_of_forall_pos_le_add (Mathlib): a ≤ b from a ≤ b + ε for all ε > 0 — the ε → 0 step for the irrational case",
+      "Int.floor_le, Int.le_ceil (Mathlib): integer bracketing of the numerator, behind the finiteness of bounded-denominator rationals",
+      "Parent: lebesgue-measure-oq-01-oq-01-oq-01 (Thomae via Lebesgue's criterion, the measure side), whose second open question this answers"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "oscillation",
+        "description": "oscillation f x = ⨅ S ∈ (𝓝 x).map f, EMetric.diam S. The infimum, over sets in the image of the neighborhood filter, of the EMetric diameter. Its exact value 1/r.den at rationals and 0 at irrationals is the headline result.",
+        "module": "Mathlib.Analysis.Oscillation"
+      },
+      {
+        "theorem": "Oscillation.eq_zero_iff_continuousAt",
+        "description": "oscillation f x = 0 ↔ ContinuousAt f x. Converts the computed vanishing oscillation at irrationals into continuity there.",
+        "module": "Mathlib.Analysis.Oscillation"
+      },
+      {
+        "theorem": "dense_irrational",
+        "description": "Dense {x : ℝ | Irrational x}. Every neighborhood of a rational contains an irrational (value 0 of Thomae), giving the lower bound on the diameter.",
+        "module": "Mathlib.Topology.Instances.Irrational"
+      },
+      {
+        "theorem": "EMetric.edist_le_diam_of_mem",
+        "description": "x ∈ s → y ∈ s → edist x y ≤ diam s. With x = thomae r (= 1/r.den) and y = thomae(irrational) (= 0) gives ofReal(1/r.den) ≤ diam S for every set S in the mapped filter.",
+        "module": "Mathlib.Topology.EMetricSpace.Diam"
+      },
+      {
+        "theorem": "ENNReal.le_of_forall_pos_le_add",
+        "description": "(∀ ε > 0, a ≤ b + ε) → a ≤ b. With b = 0 this is the ε → 0 limit forcing the oscillation at an irrational to be 0 from the family of bounds oscillation ≤ ofReal ε.",
+        "module": "Mathlib.Data.ENNReal.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "lebesgue-measure-oq-01-oq-01-oq-01-oq-02-oq-01",
+      "question": "Prove the uniform-oscillation consequence: for Thomae's function on [0,1] and any ε > 0, the finitely many points of oscillation ≥ ε admit a single δ > 0 with diam(thomae '' ball x δ) ≤ ε off them — assembling, via Mathlib's IsCompact.uniform_oscillation, the Riemann-sum / Darboux upper-lower gap bound that is the analytic heart of Lebesgue's criterion (the step a Lean Riemann integral would consume).",
+      "significance": "medium"
+    },
+    {
+      "id": "lebesgue-measure-oq-01-oq-01-oq-01-oq-02-oq-02",
+      "question": "Establish the Diophantine sharpening behind the upper bound: the separation |p/q − p'/q'| ≥ 1/(q·q') for distinct fractions, and deduce that the radius δ keeping thomae ≤ 1/q near p/q can be taken explicitly as ≍ 1/q² — turning the existence proof of exists_nbhd_thomae_le into a quantitative modulus tied to continued-fraction approximation.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lebesgue-measure-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent: Thomae's function via Lebesgue's criterion (the measure side — the discontinuity set is null). Its second open question asked for the oscillation-theoretic refinement: oscillation = 1/q at p/q and finite level sets. This entry answers it."
+    },
+    {
+      "targetId": "lebesgue-measure-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling that classified the continuity of Thomae's function (continuous at irrationals, discontinuous at rationals). This entry strengthens the discontinuity to a sharp quantitative measure — the oscillation 1/q — and rederives continuity at the irrationals via the oscillation characterization."
+    }
+  ],
+  "references": [
+    {
+      "title": "Sur une généralisation de l'intégrale définie (Lebesgue's criterion)",
+      "author": "Henri Lebesgue",
+      "year": "1902",
+      "venue": "Comptes Rendus / Annali di Matematica",
+      "description": "Lebesgue's theorem: a bounded function on [a,b] is Riemann integrable iff its set of discontinuities has measure zero. The oscillation function and its level sets are the technical device in the proof, formalized here for Thomae's function."
+    },
+    {
+      "title": "Principles of Mathematical Analysis",
+      "author": "Walter Rudin",
+      "year": "1976",
+      "venue": "McGraw-Hill",
+      "description": "Standard reference for the oscillation function and for Thomae's (popcorn) function as the canonical Riemann-integrable function with a dense discontinuity set; the oscillation at p/q is the textbook 1/q computed here."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Working with Mathlib's oscillation function (oscillation f x = ⨅ S ∈ (𝓝 x).map f, EMetric.diam S), the oscillation of Thomae's function is computed exactly: at a rational r it equals ENNReal.ofReal (1/r.den) (oscillation_thomae_rat), and at every irrational it is 0 (oscillation_thomae_irrational). A single key lemma (exists_nbhd_thomae_le: thomae ≤ v on a ball whenever thomae a ≤ v, v > 0, because the points of value > v are finitely many bounded-denominator rationals at positive distance) drives both the rational upper bound (v = 1/r.den) and continuity at the irrationals (v = ε for all ε > 0); the lower bound uses density of the irrationals to place a value-0 point in every neighborhood. As a corollary continuity at the irrationals follows from Oscillation.eq_zero_iff_continuousAt. Finally the level sets {x ∈ [a,b] | oscillation ≥ ε} are finite (oscillation_levelSet_finite): every such point is rational with denominator ≤ 1/ε, and bounded-denominator rationals in a bounded interval are finite. 316 lines, 13 theorems/lemmas, 1 definition, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This is the sharp, quantitative form of the discontinuity of Thomae's function and the oscillation-theoretic version of Lebesgue's criterion the parent's measure-side proof pointed at: the discontinuity set is exactly ⋃ₙ {x | oscillation ≥ 1/n}, a countable union of finite (hence null) level sets, which is why Thomae's function is Riemann integrable. The exact value 1/q ties the analytic oscillation to the arithmetic of the rational's reduced denominator, the point where Diophantine separation of fractions enters. Mathlib still has no Riemann/Darboux integral, so the genuinely general criterion stays open; here its finite-level-set mechanism is realized concretely for the popcorn function.",
+    "openQuestions": [
+      "Assemble the uniform-oscillation / Darboux-gap bound on [0,1] from the finite level sets via IsCompact.uniform_oscillation — the analytic core a Lean Riemann integral would consume.",
+      "Sharpen exists_nbhd_thomae_le to a quantitative modulus δ ≍ 1/q² using the Diophantine separation |p/q − p'/q'| ≥ 1/(q·q')."
+    ]
+  }
+}

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-01-oq-02/proof.md
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-01-oq-02/proof.md
@@ -1,0 +1,89 @@
+# The Oscillation of Thomae's Function is Exactly 1/q
+
+## The Question
+
+Thomae's function (the "popcorn function")
+$$
+T(x) = \begin{cases} 1/q & x = p/q \text{ in lowest terms},\\ 0 & x \text{ irrational},\end{cases}
+$$
+is continuous at the irrationals and discontinuous at every rational. *How big*
+is each discontinuity? The right gauge is the **oscillation**
+$$
+\omega_T(x) \;=\; \inf_{N \ni x \text{ nbhd}} \operatorname{diam} T(N),
+$$
+the eventual spread of values near $x$. The parent entry showed the discontinuity
+set of $T$ is null (the measure side of **Lebesgue's criterion**); this entry
+computes the oscillation *exactly* and shows its level sets are finite — the
+finer, oscillation-theoretic form of the criterion.
+
+We work with Mathlib's `oscillation f x = ⨅ S ∈ (𝓝 x).map f, EMetric.diam S`
+(`Mathlib.Analysis.Oscillation`), valued in $[0,\infty]$.
+
+## The Result
+
+$$
+\boxed{\;\omega_T(p/q) = \tfrac{1}{q} \quad\text{(}q\text{ the reduced denominator)},\qquad \omega_T(x) = 0 \text{ for } x \text{ irrational}.\;}
+$$
+
+## The Argument
+
+### A key local bound (`exists_nbhd_thomae_le`)
+
+Everything rests on one lemma: **if $T(a) \le v$ with $v > 0$, then $T \le v$ on a
+whole ball around $a$.** The points where $T > v$ are exactly the rationals with
+$1/\text{den} > v$, i.e. denominator $< 1/v$. For each denominator $d$ there are
+finitely many such fractions near $a$ (`finite_rat_bounded`: the numerator is
+pinned between $\lfloor(a-1)d\rfloor$ and $\lceil(a+1)d\rceil$), and **none of them
+equals $a$** (they have value $> v \ge T(a)$). A finite set of points, all
+distinct from $a$, lies a positive distance $\delta$ away (`pos_min_dist`); on
+$\operatorname{ball}(a,\delta)$ the function stays $\le v$.
+
+### Oscillation at a rational $r = p/q$ (`oscillation_thomae_rat`)
+
+- **Upper bound $\le 1/q$.** Take $v = 1/q = T(r)$ in the key lemma: on a small
+  ball $T \in [0, 1/q]$, so the image has diameter $\le 1/q$, and the oscillation
+  — an infimum over neighborhoods — is $\le 1/q$ (`biInf_le` against the image of
+  the ball, which lies in the mapped neighborhood filter via
+  `Filter.image_mem_map`).
+- **Lower bound $\ge 1/q$.** Any set $S$ in $(\mathcal N_r)_* T$ has $T^{-1}S$ a
+  neighborhood of $r$, hence contains an open $U \ni r$. It holds $T(r) = 1/q \in S$,
+  and — since the **irrationals are dense** (`dense_irrational`) — some irrational
+  $y \in U$ gives $T(y) = 0 \in S$. So $\operatorname{diam} S \ge \operatorname{edist}(1/q, 0) = 1/q$
+  (`EMetric.edist_le_diam_of_mem`). The infimum is therefore $\ge 1/q$.
+
+### Oscillation at an irrational (`oscillation_thomae_irrational`)
+
+The same key lemma with $v = \varepsilon$ (any $\varepsilon > 0$, legitimate since
+$T(x) = 0 \le \varepsilon$) bounds the oscillation by $\operatorname{ofReal}\varepsilon$.
+Letting $\varepsilon \to 0$ (`ENNReal.le_of_forall_pos_le_add`) gives
+$\omega_T(x) = 0$, and `Oscillation.eq_zero_iff_continuousAt` returns continuity at
+$x$ — the parent's continuity-at-irrationals, now read off the oscillation.
+
+### Finite level sets (`oscillation_levelSet_finite`)
+
+For $\varepsilon > 0$, a point of $[a,b]$ with $\omega_T \ge \varepsilon$ cannot be
+irrational (oscillation $0$ there), so it is a rational $p/q$ with
+$1/q = \omega_T(p/q) \ge \varepsilon$, i.e. $q \le 1/\varepsilon$. Bounded-denominator
+rationals in a bounded interval are finite (`finite_rat_Icc`), so the level set is
+finite. Consequently the discontinuity set is
+$\bigcup_n \{x : \omega_T(x) \ge 1/n\}$, a **countable union of finite sets** — null,
+which is precisely why $T$ is Riemann integrable.
+
+## Why It Matters
+
+The value $1/q$ ties the analytic oscillation to the **arithmetic of the reduced
+denominator**: the discontinuity at $p/q$ is large exactly when $q$ is small, and
+the finite level sets are the mechanism inside Lebesgue's criterion. Mathlib has no
+Riemann/Darboux integral, so the fully general criterion remains open; here its
+oscillation engine is realized concretely for the canonical example.
+
+## Formalization Notes
+
+- 316 lines, 13 theorems/lemmas, 1 definition, **0 axioms, 0 sorries** (only
+  `propext`, `Classical.choice`, `Quot.sound`).
+- The Thomae infrastructure (definition, value at rationals/irrationals,
+  finiteness of bounded-denominator rationals) is reproved in-file so the entry
+  builds independently of its siblings.
+- One lemma, `exists_nbhd_thomae_le`, serves three masters: the rational upper
+  bound, the irrational vanishing, and (through the latter) continuity at the
+  irrationals.


### PR DESCRIPTION
## Summary

Computes the **oscillation** of Thomae's function exactly, answering the second open question (oq-02) of the parent *Thomae via Lebesgue's criterion* entry.

Using Mathlib's `oscillation f x = ⨅ S ∈ (𝓝 x).map f, EMetric.diam S`:

- **`oscillation_thomae_rat`** — at a rational `r`, the oscillation is exactly `ENNReal.ofReal (1/r.den)`. Upper bound from a small ball keeping `thomae ≤ 1/r.den`; lower bound because every neighborhood meets both `r` (value `1/r.den`) and a dense irrational (value `0`).
- **`oscillation_thomae_irrational`** — the oscillation vanishes at every irrational; **`thomae_continuousAt_irrational`** then recovers continuity there via `Oscillation.eq_zero_iff_continuousAt`.
- **`oscillation_levelSet_finite`** — for every ε > 0 only finitely many points of any `[a,b]` have oscillation ≥ ε (denominator ≤ 1/ε). This is the **oscillation form of Lebesgue's criterion**: the discontinuity set is a countable union of finite level sets, hence null.

A single key lemma **`exists_nbhd_thomae_le`** (if `thomae a ≤ v`, `v > 0`, then `thomae ≤ v` on a ball) drives the rational upper bound *and* continuity at the irrationals.

## Verification

- Builds against Lean v4.26.0 / current Mathlib (`docker-build.sh Proofs.LebesgueMeasureOQ01OQ01OQ01OQ02`).
- **0 axioms, 0 sorries** — `#print axioms` lists only `propext, Classical.choice, Quot.sound`.
- 316 lines, 13 theorems/lemmas, 1 definition.
- Self-contained: the Thomae infrastructure is reproved in-file, so the entry does not depend on the (still-open) parent PR.

## Open follow-ups
- Assemble the uniform-oscillation / Darboux-gap bound on [0,1] via `IsCompact.uniform_oscillation`.
- Sharpen `exists_nbhd_thomae_le` to an explicit modulus δ ≍ 1/q² via Diophantine separation of fractions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)