### PR TITLE
research(lebesgue-measure-oq-01-oq-01-oq-02-oq-02): Thomae and Baire category — continuity set is a dense Gδ, no function is continuous exactly on ℚ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2901,6 +2901,7 @@ import Proofs.LebesgueMeasureOQ01
 import Proofs.LebesgueMeasureOQ01OQ01
 import Proofs.LebesgueMeasureOQ01OQ01OQ01
 import Proofs.LebesgueMeasureOQ01OQ01OQ02
+import Proofs.LebesgueMeasureOQ01OQ01OQ02OQ02
 import Proofs.LebesgueMeasureOQ01OQ01OQ02Riemann
 import Proofs.LebesgueMeasureOQ01OQ03
 import Proofs.LebesgueMeasureOQ02

--- a/proofs/Proofs/LebesgueMeasureOQ01OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ01OQ01OQ02OQ02.lean
@@ -1,0 +1,216 @@
+import Mathlib
+import Proofs.LebesgueMeasureOQ01OQ01OQ01
+
+/-
+# Thomae's Function and Baire Category — the continuity set is a dense Gδ
+
+## Open Question (lebesgue-measure-oq-01-oq-01-oq-02-oq-02)
+
+Thomae's (popcorn) function is continuous exactly at the irrationals and
+discontinuous exactly at the rationals.  The green formalization
+`lebesgue-measure-oq-01-oq-01-oq-01` (module `LebesgueMeasureOQ01OQ01OQ01`)
+supplies `thomae`, `thomae_irrational`, `thomae_rat`, and the hard direction
+`thomae_continuous_at_irrational`.  Here we first recover the complementary
+direction `thomae_discontinuous_at_rat` (via an irrational sequence
+`r + √2/(n+1) → r`), assemble the sharp characterization
+`thomae_continuous_iff : ContinuousAt thomae x ↔ Irrational x`, and then turn to
+the new content.  The measure-theoretic lineage established that the
+discontinuity set ℚ is **null** (Lebesgue's criterion).  This entry records the
+**Baire-category dual**, the other half of "ℚ is small":
+
+  * the set of continuity points of Thomae equals the irrationals, a **dense Gδ**
+    set, hence **comeagre** (residual);
+  * the set of discontinuity points equals ℚ, which is **meagre** (first
+    category) — and, sharply, is **not** a Gδ set.
+
+The Gδ-ness of the irrationals is *exactly* what makes Thomae possible.  The
+general principle is that the continuity set of *any* function `f : ℝ → ℝ` is a
+Gδ (`IsGδ.setOf_continuousAt`).  Combined with the Baire-category fact that ℚ is
+not a Gδ, we obtain the classical impossibility theorem:
+
+  **No function `f : ℝ → ℝ` is continuous exactly at the rationals.**
+
+So Thomae's irrational-continuity is not a coincidence that could be mirrored:
+the rational mirror is forbidden by topology, while the irrational realisation
+is permitted — and exhibited by Thomae.
+
+## What is proved
+
+* `thomae_discontinuous_at_rat`        : `¬ ContinuousAt thomae (r : ℝ)` for `r : ℚ`
+* `thomae_continuous_iff`              : `ContinuousAt thomae x ↔ Irrational x`
+* `thomae_continuitySet_eq_irrational` : `{x | ContinuousAt thomae x} = {x | Irrational x}`
+* `thomae_continuitySet_isGδ`          : the continuity set is Gδ
+* `thomae_continuitySet_dense`         : the continuity set is dense
+* `thomae_continuitySet_residual`      : the continuity set is comeagre (residual)
+* `thomae_discontinuitySet_eq_rat`     : `{x | ¬ ContinuousAt thomae x} = range ℚ`
+* `thomae_discontinuitySet_isMeagre`   : the discontinuity set is meagre
+* `not_isGδ_range_rat`                 : ℚ is not a Gδ subset of ℝ (Baire)
+* `thomae_discontinuitySet_not_isGδ`   : the discontinuity set is not Gδ
+* `no_continuousAt_setOf_eq_rat`       : no `f : ℝ → ℝ` is continuous exactly on ℚ
+* `thomae_realizes_irrational_continuitySet` : Thomae realises the irrationals as a continuity set
+
+No sorries, no axioms.
+-/
+
+open Set Filter Topology Real
+open LebesgueMeasureOQ01OQ01OQ01
+
+namespace LebesgueMeasureOQ01OQ01OQ02OQ02
+
+/-! ## The sharp continuity characterization
+
+The green base module proves continuity at the irrationals and
+`{x | ¬ ContinuousAt thomae x} ⊆ range ℚ`.  To get the *exact* characterization
+we add the rational direction: along the irrational sequence `r + √2/(n+1) → r`
+Thomae is identically `0`, but `thomae r = 1/r.den > 0`, so it cannot be
+continuous at `r`. -/
+
+/-- **Thomae is discontinuous at every rational.** -/
+theorem thomae_discontinuous_at_rat (r : ℚ) : ¬ ContinuousAt thomae (r : ℝ) := by
+  intro h
+  -- The sequence `yₙ = r + √2/(n+1)` tends to `r` and is irrational at every `n`.
+  have h0 : Tendsto (fun n : ℕ => Real.sqrt 2 / ((n : ℝ) + 1)) atTop (𝓝 0) := by
+    have hmul := (tendsto_one_div_add_atTop_nhds_zero_nat).const_mul (Real.sqrt 2)
+    simp only [mul_one_div, mul_zero] at hmul
+    exact hmul
+  have hlim : Tendsto (fun n : ℕ => (r : ℝ) + Real.sqrt 2 / ((n : ℝ) + 1))
+      atTop (𝓝 (r : ℝ)) := by
+    have := h0.const_add (r : ℝ)
+    rwa [add_zero] at this
+  have hirr : ∀ n : ℕ, Irrational ((r : ℝ) + Real.sqrt 2 / ((n : ℝ) + 1)) := by
+    intro n
+    have hd : Irrational (Real.sqrt 2 / ((n : ℝ) + 1)) := by
+      have hcast : ((n : ℝ) + 1) = ((n + 1 : ℕ) : ℝ) := by push_cast; ring
+      rw [hcast]
+      exact irrational_sqrt_two.div_natCast (Nat.succ_ne_zero n)
+    rw [add_comm]
+    exact irrational_add_ratCast_iff.mpr hd
+  -- Compose continuity with the sequence: `thomae yₙ → thomae r`.
+  have htend : Tendsto (fun n : ℕ => thomae ((r : ℝ) + Real.sqrt 2 / ((n : ℝ) + 1)))
+      atTop (𝓝 (thomae (r : ℝ))) := h.tendsto.comp hlim
+  -- But `thomae yₙ = 0` for every `n`.
+  have hzero : (fun n : ℕ => thomae ((r : ℝ) + Real.sqrt 2 / ((n : ℝ) + 1)))
+      = fun _ => (0 : ℝ) := funext fun n => thomae_irrational (hirr n)
+  rw [hzero] at htend
+  -- Uniqueness of limits forces `thomae r = 0`, contradicting `thomae r = 1/r.den > 0`.
+  have hval : thomae (r : ℝ) = 0 := tendsto_nhds_unique htend tendsto_const_nhds
+  rw [thomae_rat] at hval
+  have hpos : (0 : ℝ) < 1 / (r.den : ℝ) := by positivity
+  linarith
+
+/-- **Thomae is continuous exactly at the irrationals.** -/
+theorem thomae_continuous_iff (x : ℝ) : ContinuousAt thomae x ↔ Irrational x := by
+  constructor
+  · intro h
+    by_contra hrat
+    simp only [Irrational, not_not] at hrat
+    obtain ⟨q, hq⟩ := hrat
+    exact thomae_discontinuous_at_rat q (hq ▸ h)
+  · exact thomae_continuous_at_irrational
+
+/-! ## Meagreness of countable sets (Baire-category infrastructure)
+
+A countable set in a perfect `T1` space is a countable union of nowhere-dense
+singletons, hence meagre.  (Same elementary argument as the companion entry
+`algebraic-numbers-countable-oq-02-oq-04`; reproduced here so this file is
+self-contained.) -/
+
+/-- A nowhere-dense set is meagre: it is covered by the one-element (hence
+countable) family `{t}` of nowhere-dense sets. -/
+theorem isMeagre_of_isNowhereDense {X : Type*} [TopologicalSpace X] {t : Set X}
+    (ht : IsNowhereDense t) : IsMeagre t := by
+  rw [isMeagre_iff_countable_union_isNowhereDense]
+  refine ⟨{t}, ?_, Set.countable_singleton t, ?_⟩
+  · intro u hu
+    rwa [Set.mem_singleton_iff.mp hu]
+  · exact (Set.sUnion_singleton t).ge
+
+/-- In a `T1` perfect space a singleton is nowhere dense: it is closed, and its
+interior is empty because the point is not isolated. -/
+theorem isNowhereDense_singleton {X : Type*} [TopologicalSpace X] [T1Space X]
+    [PerfectSpace X] (x : X) : IsNowhereDense ({x} : Set X) :=
+  (isClosed_singleton.isNowhereDense_iff).mpr (interior_singleton x)
+
+/-- **Countable sets are meagre in a perfect `T1` space** (e.g. `ℝ`). -/
+theorem countable_isMeagre {X : Type*} [TopologicalSpace X] [T1Space X] [PerfectSpace X]
+    {s : Set X} (hs : s.Countable) : IsMeagre s := by
+  rw [← Set.biUnion_of_singleton s, Set.biUnion_eq_iUnion]
+  haveI : Countable s := hs.to_subtype
+  exact isMeagre_iUnion fun i => isMeagre_of_isNowhereDense (isNowhereDense_singleton (i : X))
+
+/-! ## The continuity set of Thomae is a dense Gδ -/
+
+/-- **Thomae is continuous exactly at the irrationals**, as a set equality.
+(Repackages the parent's `thomae_continuous_iff`.) -/
+theorem thomae_continuitySet_eq_irrational :
+    {x : ℝ | ContinuousAt thomae x} = {x : ℝ | Irrational x} := by
+  ext x; exact thomae_continuous_iff x
+
+/-- The continuity set of Thomae is a Gδ: it equals the irrationals, the
+complement of the countable set `range ℚ`. -/
+theorem thomae_continuitySet_isGδ : IsGδ {x : ℝ | ContinuousAt thomae x} := by
+  rw [thomae_continuitySet_eq_irrational]
+  exact IsGδ.setOf_irrational
+
+/-- The continuity set of Thomae is dense (the irrationals are dense). -/
+theorem thomae_continuitySet_dense : Dense {x : ℝ | ContinuousAt thomae x} := by
+  rw [thomae_continuitySet_eq_irrational]
+  exact dense_irrational
+
+/-- **The continuity set of Thomae is comeagre (residual).** A dense Gδ in the
+Baire space `ℝ` is residual. -/
+theorem thomae_continuitySet_residual :
+    {x : ℝ | ContinuousAt thomae x} ∈ residual ℝ := by
+  rw [thomae_continuitySet_eq_irrational]
+  exact residual_of_dense_Gδ IsGδ.setOf_irrational dense_irrational
+
+/-! ## The discontinuity set of Thomae is exactly ℚ, and is meagre -/
+
+/-- **Thomae is discontinuous exactly at the rationals**: the discontinuity set
+equals `range ℚ`.  (`Irrational x` is definitionally `x ∉ range ℚ`, so
+`¬ Irrational x ↔ x ∈ range ℚ` by `not_not`.) -/
+theorem thomae_discontinuitySet_eq_rat :
+    {x : ℝ | ¬ ContinuousAt thomae x} = Set.range ((↑) : ℚ → ℝ) := by
+  ext x
+  rw [Set.mem_setOf_eq, thomae_continuous_iff]
+  exact not_not
+
+/-- The discontinuity set of Thomae is meagre: it is the countable set `range ℚ`. -/
+theorem thomae_discontinuitySet_isMeagre :
+    IsMeagre {x : ℝ | ¬ ContinuousAt thomae x} := by
+  rw [thomae_discontinuitySet_eq_rat]
+  exact countable_isMeagre (Set.countable_range _)
+
+/-! ## ℚ is not a Gδ, and rational continuity sets are impossible -/
+
+/-- **The rationals are not a Gδ subset of `ℝ`.** If `range ℚ` were Gδ it would
+be a dense Gδ, hence non-meagre by Baire; but it is countable, hence meagre. -/
+theorem not_isGδ_range_rat : ¬ IsGδ (Set.range ((↑) : ℚ → ℝ)) := by
+  intro h
+  exact not_isMeagre_of_isGδ_of_dense h Rat.denseRange_cast
+    (countable_isMeagre (Set.countable_range _))
+
+/-- The discontinuity set of Thomae is **not** a Gδ (it is exactly `range ℚ`).
+This is the sharp asymmetry with the continuity set, which *is* a dense Gδ. -/
+theorem thomae_discontinuitySet_not_isGδ :
+    ¬ IsGδ {x : ℝ | ¬ ContinuousAt thomae x} := by
+  rw [thomae_discontinuitySet_eq_rat]
+  exact not_isGδ_range_rat
+
+/-- **No function `f : ℝ → ℝ` is continuous exactly at the rationals.** The
+continuity set of any function is a Gδ (`IsGδ.setOf_continuousAt`), but
+`range ℚ` is not a Gδ. -/
+theorem no_continuousAt_setOf_eq_rat :
+    ¬ ∃ f : ℝ → ℝ, {x : ℝ | ContinuousAt f x} = Set.range ((↑) : ℚ → ℝ) := by
+  rintro ⟨f, hf⟩
+  exact not_isGδ_range_rat (hf ▸ IsGδ.setOf_continuousAt f)
+
+/-- **Thomae realises the irrationals as a continuity set** — possible precisely
+because the irrationals form a Gδ.  The mirror image (continuity exactly on ℚ)
+is impossible by `no_continuousAt_setOf_eq_rat`. -/
+theorem thomae_realizes_irrational_continuitySet :
+    {x : ℝ | ContinuousAt thomae x} = {x : ℝ | Irrational x} ∧
+      IsGδ {x : ℝ | ContinuousAt thomae x} :=
+  ⟨thomae_continuitySet_eq_irrational, thomae_continuitySet_isGδ⟩
+
+end LebesgueMeasureOQ01OQ01OQ02OQ02

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "lebesgue-measure-oq-01-oq-01-oq-02-oq-02",
+  "title": "Thomae's Function and Baire Category: the continuity set is a dense Gδ",
+  "slug": "lebesgue-measure-oq-01-oq-01-oq-02-oq-02",
+  "description": "The Baire-category dual of the measure-theoretic smallness of Thomae's discontinuity set. After recovering the sharp characterization that Thomae is continuous exactly at the irrationals (proving discontinuity at every rational via the irrational sequence r + √2/(n+1) → r, complementing the green base module's continuity-at-irrationals), the entry shows: the continuity set equals the irrationals — a dense Gδ, hence comeagre (residual); the discontinuity set equals ℚ — meagre, and not a Gδ. The headline is the classical impossibility theorem, obtained from Baire: since the continuity set of ANY function is a Gδ (IsGδ.setOf_continuousAt) but ℚ is not a Gδ, no function ℝ → ℝ can be continuous exactly at the rationals. Thomae realizes the irrationals (a Gδ) as a continuity set precisely because that is permitted; the rational mirror is forbidden by topology. 15 theorems, 0 axioms, 0 sorries.",
+  "leanFile": {
+    "namespace": "LebesgueMeasureOQ01OQ01OQ02OQ02",
+    "lineCount": 216,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 0,
+    "path": "Proofs/LebesgueMeasureOQ01OQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LebesgueMeasureOQ01OQ01OQ02OQ02.lean",
+    "tags": [
+      "measure-theory",
+      "baire-category",
+      "thomae-function",
+      "popcorn-function",
+      "gdelta",
+      "meagre",
+      "comeagre",
+      "residual",
+      "continuity",
+      "real-analysis",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. Fully kernel-checked (Docker build, 7744 jobs, Lean v4.26.0). Uses only the ordinary foundational axioms (propext, Classical.choice, Quot.sound) via Mathlib and the parent's classical `thomae` definition; no `axiom` declarations, no structure-encoded assumptions, no `native_decide`. Builds on the green merged module `LebesgueMeasureOQ01OQ01OQ01` (lebesgue-measure-oq-01-oq-01-oq-01), which re-derived Thomae's continuity at the irrationals self-contained — chosen over the sibling continuity module `LebesgueMeasureOQ01OQ01OQ02`, which has bit-rotted against the current Mathlib pin (deprecated `div_lt_iff`, changed `Set.Finite.ofFinset`/`Finset.induction_on` signatures). The discontinuity-at-rationals direction is re-proved here from scratch so the sharp continuity characterization is available without depending on the rotted module.",
+    "lineCount": 216,
+    "theoremCount": 15,
+    "definitionCount": 0,
+    "originalContributions": [
+      "no_continuousAt_setOf_eq_rat: no function f : ℝ → ℝ is continuous exactly at the rationals — the headline impossibility theorem, from 'continuity sets are Gδ' (IsGδ.setOf_continuousAt) plus 'ℚ is not a Gδ'",
+      "not_isGδ_range_rat: ℚ is not a Gδ subset of ℝ — a dense Gδ would be non-meagre by Baire, but range ℚ is countable hence meagre",
+      "thomae_continuitySet_residual: the set of continuity points of Thomae is comeagre (residual) — a dense Gδ in the Baire space ℝ",
+      "thomae_discontinuitySet_isMeagre: the discontinuity set of Thomae (= ℚ) is meagre, the Baire-category dual of its being Lebesgue-null",
+      "thomae_discontinuitySet_not_isGδ: the discontinuity set is not a Gδ, the sharp asymmetry with the continuity set",
+      "thomae_realizes_irrational_continuitySet: Thomae realizes the irrationals as a continuity set, possible exactly because the irrationals form a Gδ",
+      "thomae_discontinuous_at_rat: discontinuity at every rational via the irrational sequence r + √2/(n+1) → r (re-derived to complete the sharp characterization on the green base module)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Thomae's function (the 'popcorn' function) is the textbook example of a function continuous at every irrational and discontinuous at every rational. The measure-theoretic story — its discontinuity set ℚ is Lebesgue-null, hence Thomae is Riemann integrable — was treated in the parent lineage (lebesgue-measure-oq-01-oq-01-oq-01 and ...-oq-02-oq-01). 'ℚ is small' has a second, independent meaning: in the sense of Baire category, ℚ is meagre (first category) and the irrationals are comeagre. This entry records that topological side, and connects it to the classical impossibility theorem — there is no function continuous exactly on ℚ — which explains why Thomae's irrational-continuity has no rational mirror.",
+    "problemStatement": "Describe the Baire-category structure of Thomae's continuity and discontinuity sets, and determine which sets can arise as the continuity set of a function ℝ → ℝ.",
+    "text": "Thomae is continuous exactly on the irrationals, a dense Gδ set, hence its continuity set is comeagre; its discontinuity set is ℚ, which is meagre and not a Gδ. The continuity set of any function is a Gδ (a general theorem), so since ℚ is not a Gδ, no function can be continuous exactly at the rationals. The irrationals, being a Gδ, can serve as a continuity set — and Thomae exhibits this.",
+    "proofStrategy": "First the sharp characterization. The green base module supplies thomae, thomae_irrational, thomae_rat, and thomae_continuous_at_irrational (continuity at every irrational). The complementary direction, thomae_discontinuous_at_rat, is proved here: the sequence yₙ = r + √2/(n+1) consists of irrationals (irrational_sqrt_two.div_natCast then irrational_add_ratCast_iff) and tends to r; thomae yₙ = 0 for all n while thomae r = 1/r.den > 0, so by uniqueness of limits Thomae is discontinuous at r. Combining gives thomae_continuous_iff : ContinuousAt thomae x ↔ Irrational x. Then: the continuity set equals {x | Irrational x}, which is Gδ (IsGδ.setOf_irrational), dense (dense_irrational), and therefore residual (residual_of_dense_Gδ). The discontinuity set equals range ℚ (¬ Irrational x ↔ x ∈ range ℚ by not_not), which is meagre (countable_isMeagre, an elementary Baire-category lemma reproved here: countable = countable union of nowhere-dense singletons in a perfect T1 space). Finally, ℚ is not a Gδ: a dense Gδ is non-meagre (not_isMeagre_of_isGδ_of_dense) but range ℚ is meagre; and the continuity set of any f is Gδ (IsGδ.setOf_continuousAt), so no f has continuity set exactly range ℚ.",
+    "keyInsights": [
+      "Two senses of 'ℚ is small' coincide on Thomae but are logically independent. Lebesgue-null (measure) and meagre (category) are different notions; here both hold, and this entry supplies the category half complementing the measure half already in the gallery.",
+      "The continuity set of any function is a Gδ. This single general fact (IsGδ.setOf_continuousAt) is what makes the impossibility theorem possible: the question 'which sets are continuity sets?' is answered, on one side, by 'only Gδ sets'.",
+      "ℚ is not a Gδ — a Baire-category fact, not a measure fact. If range ℚ were Gδ it would be a dense Gδ, hence non-meagre; but countable sets in a perfect space are meagre. This is the crux that forbids rational continuity sets.",
+      "Thomae is not a lucky accident but a realization. The irrationals ARE a Gδ, so they can be a continuity set; Thomae demonstrates the realization. The 'mirror' function (continuous exactly on ℚ) cannot exist for purely topological reasons.",
+      "The sharp characterization needed the rational direction, re-derived to dodge bit-rot. The green base module only had continuity-at-irrationals and the inclusion disc ⊆ ℚ; the exact equality required discontinuity-at-rationals, supplied here via a concrete irrational sequence rather than by importing the bit-rotted sibling continuity module."
+    ],
+    "prerequisites": [
+      "Thomae's function and its continuity at the irrationals (LebesgueMeasureOQ01OQ01OQ01)",
+      "Gδ sets and IsGδ.setOf_continuousAt (continuity points are a Gδ) / IsGδ.setOf_irrational",
+      "Baire category: meagre sets, residual filter, not_isMeagre_of_isGδ_of_dense, residual_of_dense_Gδ",
+      "Irrationality of √2 and closure of irrationality under rational shift / nat division",
+      "Uniqueness of limits for sequences (tendsto_nhds_unique)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Thomae's continuity set is a dense Gδ (comeagre) equal to the irrationals; its discontinuity set is ℚ, meagre and not a Gδ. Because continuity sets are always Gδ and ℚ is not, no function is continuous exactly at the rationals — while Thomae realizes the irrationals (a Gδ) as a continuity set. 15 theorems, 0 axioms, 216 lines, fully kernel-checked.",
+    "implications": "Completes the 'ℚ is small' picture for Thomae by adding the Baire-category half to the measure-theoretic half already in the gallery, and frames the classical impossibility theorem (no continuity set equal to ℚ) as the structural reason Thomae's irrational-continuity cannot be mirrored. Demonstrates the idiom for transporting Gδ/dense/residual/meagre structure across a continuity characterization and reusing Mathlib's Baire machinery.",
+    "openQuestions": [
+      "Characterize precisely which subsets of ℝ arise as continuity sets of some function — the converse direction (every Gδ is the continuity set of some function), of which Thomae is the irrationals instance.",
+      "State the analogous category/measure dichotomy for the Dirichlet function 1_ℚ (nowhere continuous: continuity set empty, discontinuity set all of ℝ), contrasting with Thomae."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring-imports",
+      "title": "Docstring, Imports, and Strategy",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "States the Baire-category dual and the impossibility theorem. Imports Mathlib and the green base module LebesgueMeasureOQ01OQ01OQ01 (not the bit-rotted sibling continuity module); opens Set, Filter, Topology, Real and the base namespace."
+    },
+    {
+      "id": "sharp-characterization",
+      "title": "The Sharp Continuity Characterization",
+      "startLine": 60,
+      "endLine": 109,
+      "summary": "thomae_discontinuous_at_rat: discontinuity at every rational via yₙ = r + √2/(n+1) → r (irrationality from irrational_sqrt_two.div_natCast and irrational_add_ratCast_iff; uniqueness of limits forces thomae r = 0, contradicting 1/r.den > 0). thomae_continuous_iff assembles ContinuousAt thomae x ↔ Irrational x."
+    },
+    {
+      "id": "meagre-infra",
+      "title": "Meagreness of Countable Sets",
+      "startLine": 111,
+      "endLine": 139,
+      "summary": "Self-contained Baire-category infrastructure: isMeagre_of_isNowhereDense, isNowhereDense_singleton, and countable_isMeagre (a countable set in a perfect T1 space is a countable union of nowhere-dense singletons)."
+    },
+    {
+      "id": "continuity-set",
+      "title": "The Continuity Set is a Dense Gδ",
+      "startLine": 141,
+      "endLine": 165,
+      "summary": "thomae_continuitySet_eq_irrational (= irrationals), thomae_continuitySet_isGδ, thomae_continuitySet_dense, and thomae_continuitySet_residual (comeagre, via residual_of_dense_Gδ)."
+    },
+    {
+      "id": "discontinuity-set",
+      "title": "The Discontinuity Set is ℚ and Meagre",
+      "startLine": 167,
+      "endLine": 182,
+      "summary": "thomae_discontinuitySet_eq_rat (= range ℚ, using not_not on the definition of Irrational) and thomae_discontinuitySet_isMeagre (countable_isMeagre)."
+    },
+    {
+      "id": "impossibility",
+      "title": "ℚ is Not a Gδ; No Rational Continuity Set",
+      "startLine": 184,
+      "endLine": 216,
+      "summary": "not_isGδ_range_rat (Baire: dense Gδ is non-meagre, but ℚ is meagre), thomae_discontinuitySet_not_isGδ, the headline no_continuousAt_setOf_eq_rat (continuity sets are Gδ, ℚ is not), and thomae_realizes_irrational_continuitySet."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lebesgue-measure-oq-01-oq-01-oq-01",
+      "relationship": "depends-on",
+      "description": "Supplies thomae, thomae_irrational, thomae_rat, and thomae_continuous_at_irrational (continuity at the irrationals), the green base this entry builds on. This entry adds the complementary discontinuity-at-rationals direction."
+    },
+    {
+      "targetId": "lebesgue-measure-oq-01-oq-01-oq-02",
+      "relationship": "parent-problem",
+      "description": "The continuity/discontinuity classification of Thomae. This entry is the Baire-category companion to that classification; it re-derives the sharp characterization independently because that sibling module has bit-rotted against the current Mathlib pin."
+    },
+    {
+      "targetId": "lebesgue-measure-oq-01-oq-01-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "Riemann integrability of Thomae (integral 0) via the measure-theoretic a.e.-zero route; this entry provides the parallel Baire-category structure of the same continuity/discontinuity sets."
+    }
+  ],
+  "references": [
+    {
+      "title": "Thomae's function",
+      "url": "https://en.wikipedia.org/wiki/Thomae%27s_function",
+      "description": "The popcorn function: continuous exactly at the irrationals, discontinuous exactly at the rationals."
+    },
+    {
+      "title": "Gδ set — continuity sets",
+      "url": "https://en.wikipedia.org/wiki/G%CE%B4_set",
+      "description": "The set of continuity points of any function is a Gδ; ℚ is not a Gδ, so no function is continuous exactly at the rationals."
+    },
+    {
+      "title": "Meagre set and the Baire category theorem",
+      "url": "https://en.wikipedia.org/wiki/Meagre_set",
+      "description": "First-category (meagre) sets and the Baire category theorem, the topological notion of smallness dual to Lebesgue-null."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The **Baire-category dual** of Thomae's measure-theoretic smallness (the gallery already has its discontinuity set ℚ being Lebesgue-null). This entry shows the *other* sense in which ℚ is small — first category — and ties it to a classical impossibility theorem.

**Headline:** the continuity set of *any* function `f : ℝ → ℝ` is a Gδ, but ℚ is **not** a Gδ — so **no function is continuous exactly at the rationals**. Thomae realizes the irrationals (which *are* a Gδ) as a continuity set; the rational mirror is forbidden by topology.

## What is proved (15 theorems, 0 axioms, 0 sorries, 216 lines)

- `thomae_discontinuous_at_rat` / `thomae_continuous_iff` — the sharp characterization (continuous exactly at irrationals), re-deriving the rational direction via the irrational sequence `r + √2/(n+1) → r`.
- `thomae_continuitySet_eq_irrational`, `..._isGδ`, `..._dense`, `..._residual` — the continuity set is the irrationals: a **dense Gδ**, hence **comeagre**.
- `thomae_discontinuitySet_eq_rat`, `..._isMeagre`, `..._not_isGδ` — the discontinuity set is exactly ℚ: **meagre**, and **not a Gδ**.
- `not_isGδ_range_rat` — ℚ is not a Gδ subset of ℝ (Baire: a dense Gδ is non-meagre, but ℚ is countable hence meagre).
- `no_continuousAt_setOf_eq_rat` — **no `f : ℝ → ℝ` is continuous exactly on ℚ**.
- `thomae_realizes_irrational_continuitySet` — Thomae realizes the irrationals as a continuity set.

## Notes

- Builds on the green merged module `LebesgueMeasureOQ01OQ01OQ01` (which re-derived Thomae's continuity self-contained). The sibling continuity module `LebesgueMeasureOQ01OQ01OQ02` has **bit-rotted** against the current Mathlib pin (`div_lt_iff`, `Set.Finite.ofFinset`, `Finset.induction_on`), so the discontinuity-at-rationals direction is re-proved here from scratch rather than imported.
- Fully kernel-checked: `./proofs/scripts/docker-build.sh Proofs.LebesgueMeasureOQ01OQ01OQ02OQ02` → Build completed successfully (7744 jobs), no warnings. Only the ordinary foundational axioms; no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)