### PR TITLE
research(taylor-theorem-oq-03-oq-01): bridge taylorWithinEval to the exp partial sum [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3343,6 +3343,7 @@ import Proofs.TaylorSinCosConvergenceOQ04
 import Proofs.TaylorTheorem
 import Proofs.TaylorTheoremOQ02
 import Proofs.TaylorTheoremOQ03
+import Proofs.TaylorTheoremOQ03OQ01
 import Proofs.TestAdmissible50
 import Proofs.TestApi1056
 import Proofs.TestApi1059

--- a/proofs/Proofs/TaylorTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/TaylorTheoremOQ03OQ01.lean
@@ -1,0 +1,160 @@
+import Mathlib
+
+/-
+# Bridging `taylorWithinEval` to the Exponential Partial Sum
+
+This file answers the open question `taylor-theorem-oq-03-oq-01`: can Mathlib's
+local Taylor polynomial `taylorWithinEval Real.exp n (Icc 0 x) 0 x` be identified,
+purely from Mathlib lemmas, with the explicit partial sum `∑_{k≤n} xᵏ/k!`?
+
+The answer is yes, and the bridge is short once the right API is located:
+
+- `taylor_within_apply` expands `taylorWithinEval` into a `Finset.sum` whose `k`-th
+  summand carries the *local* derivative `iteratedDerivWithin k Real.exp (Icc 0 x) 0`.
+- `iteratedDerivWithin_eq_iteratedDeriv` collapses each local derivative to the
+  *global* `iteratedDeriv k Real.exp 0`, using that `Real.exp` is `C^∞` and that
+  `Icc 0 x` is a `UniqueDiffOn` set containing `0`.
+- `iteratedDeriv_exp` evaluates every global derivative of `exp` back to `exp`.
+
+With the bridge in hand we promote the abstract Lagrange remainder
+(`taylor_mean_remainder_lagrange_iteratedDeriv`) to a fully explicit statement about
+the exponential partial sum: for `x > 0` there is a `ξ ∈ (0, x)` with
+
+  eˣ − ∑_{k≤n} xᵏ/k! = e^ξ · x^{n+1} / (n+1)!.
+
+This makes the Lagrange-remainder conclusion for `exp` self-contained and axiom-free.
+
+## Key Results
+
+- `iteratedDeriv_exp`        : `iteratedDeriv k Real.exp = Real.exp`
+- `iteratedDerivWithin_exp_Icc` : local derivatives of `exp` on `Icc 0 x` are `exp`
+- `taylorWithinEval_exp_eq_partialSum` : the headline bridge
+- `exp_lagrange_remainder_partialSum`  : explicit Lagrange remainder for the partial sum
+- `exp_sub_partialSum_le`              : `0 ≤ eˣ − Tₙ(x) ≤ eˣ · x^{n+1}/(n+1)!`
+
+## References
+
+- `Mathlib.Analysis.Calculus.Taylor` — `taylorWithinEval`, `taylor_within_apply`,
+  `taylor_mean_remainder_lagrange_iteratedDeriv`
+- `Mathlib.Analysis.Calculus.IteratedDeriv.Defs` — `iteratedDerivWithin_eq_iteratedDeriv`
+-/
+
+open Set Filter Topology Finset Real
+open scoped Nat
+
+set_option linter.unusedSectionVars false
+
+namespace TaylorExpBridge
+
+/-! ## Global derivatives of `exp` -/
+
+/-- The `k`-th iterated derivative of `Real.exp` on `ℝ` is again `Real.exp`. -/
+theorem iteratedDeriv_exp (k : ℕ) : iteratedDeriv k Real.exp = Real.exp := by
+  induction k with
+  | zero => simp [iteratedDeriv_zero]
+  | succ n ih =>
+    rw [iteratedDeriv_succ, ih]
+    ext x
+    exact (Real.hasDerivAt_exp x).deriv
+
+/-! ## Local derivatives of `exp` collapse to the global ones -/
+
+/-- On the unique-differentiability set `Icc 0 x` (with `0 < x`), every iterated
+derivative-within of `exp` evaluated at the basepoint `0` equals `exp 0 = 1`.
+
+This is the heart of the bridge: it converts the *local* derivatives appearing in
+`taylorWithinEval` into the *global* derivatives of the smooth function `exp`. -/
+theorem iteratedDerivWithin_exp_Icc (x : ℝ) (hx : 0 < x) (k : ℕ) :
+    iteratedDerivWithin k Real.exp (Icc 0 x) 0 = 1 := by
+  have hcda : ContDiffAt ℝ k Real.exp 0 := Real.contDiff_exp.contDiffAt.of_le le_top
+  have hmem : (0 : ℝ) ∈ Icc (0 : ℝ) x := left_mem_Icc.mpr hx.le
+  rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc hx) hcda hmem,
+    iteratedDeriv_exp, Real.exp_zero]
+
+/-! ## The bridge -/
+
+/-- **Bridge lemma.** For `x > 0`, Mathlib's local Taylor polynomial of `exp` on the
+interval `Icc 0 x`, expanded about `0` and evaluated at `x`, is exactly the standard
+exponential partial sum:
+
+  `taylorWithinEval Real.exp n (Icc 0 x) 0 x = ∑_{k≤n} xᵏ/k!`. -/
+theorem taylorWithinEval_exp_eq_partialSum (x : ℝ) (hx : 0 < x) (n : ℕ) :
+    taylorWithinEval Real.exp n (Icc 0 x) 0 x =
+      ∑ k ∈ Finset.range (n + 1), x ^ k / (k ! : ℝ) := by
+  rw [taylor_within_apply]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  rw [iteratedDerivWithin_exp_Icc x hx k]
+  simp only [sub_zero, smul_eq_mul, mul_one]
+  ring
+
+/-! ## Explicit Lagrange remainder for the partial sum -/
+
+/-- **Lagrange remainder for the exponential partial sum.**
+
+For `x > 0` and every `n`, there is a point `ξ ∈ (0, x)` such that
+
+  `eˣ − ∑_{k≤n} xᵏ/k! = e^ξ · x^{n+1} / (n+1)!`.
+
+This is the abstract Lagrange remainder, with the local Taylor polynomial replaced by
+the explicit partial sum (via `taylorWithinEval_exp_eq_partialSum`) and the local
+`(n+1)`-th derivative replaced by `e^ξ` (via `iteratedDeriv_exp`). -/
+theorem exp_lagrange_remainder_partialSum (x : ℝ) (hx : 0 < x) (n : ℕ) :
+    ∃ ξ ∈ Ioo (0 : ℝ) x,
+      Real.exp x - ∑ k ∈ Finset.range (n + 1), x ^ k / (k ! : ℝ) =
+        Real.exp ξ * x ^ (n + 1) / (n + 1)! := by
+  have hf : ContDiffOn ℝ (n + 1) Real.exp (Icc 0 x) :=
+    Real.contDiff_exp.contDiffOn.of_le le_top
+  obtain ⟨ξ, hξ, h⟩ := taylor_mean_remainder_lagrange_iteratedDeriv hx hf
+  refine ⟨ξ, hξ, ?_⟩
+  rw [taylorWithinEval_exp_eq_partialSum x hx n] at h
+  rw [h, iteratedDeriv_exp, sub_zero]
+
+/-- **Two-sided remainder bound.** The exponential partial sum underestimates `eˣ`,
+with error controlled by the next Taylor term scaled by `eˣ`:
+
+  `0 ≤ eˣ − ∑_{k≤n} xᵏ/k! ≤ eˣ · x^{n+1}/(n+1)!`.
+
+The upper bound uses `e^ξ ≤ eˣ` for `ξ < x`; the lower bound uses positivity of `e^ξ`. -/
+theorem exp_sub_partialSum_le (x : ℝ) (hx : 0 < x) (n : ℕ) :
+    0 ≤ Real.exp x - ∑ k ∈ Finset.range (n + 1), x ^ k / (k ! : ℝ) ∧
+      Real.exp x - ∑ k ∈ Finset.range (n + 1), x ^ k / (k ! : ℝ) ≤
+        Real.exp x * x ^ (n + 1) / (n + 1)! := by
+  obtain ⟨ξ, hξ, h⟩ := exp_lagrange_remainder_partialSum x hx n
+  rw [Set.mem_Ioo] at hξ
+  have hξx : Real.exp ξ ≤ Real.exp x := Real.exp_le_exp.mpr hξ.2.le
+  constructor
+  · rw [h]; positivity
+  · rw [h]; gcongr
+
+/-! ## Sanity checks against the existing partial-sum / convergence machinery -/
+
+/-- The bridge is compatible with summability: `∑ xᵏ/k!` is the convergent exponential
+series, so the bridged partial sums converge to `eˣ`. -/
+theorem taylorWithinEval_exp_tendsto (x : ℝ) (hx : 0 < x) :
+    Filter.Tendsto (fun n => taylorWithinEval Real.exp n (Icc 0 x) 0 x)
+      Filter.atTop (nhds (Real.exp x)) := by
+  have hsum : HasSum (fun k => x ^ k / (k ! : ℝ)) (Real.exp x) := by
+    have h1 : Real.exp x = ∑' k, x ^ k / (k ! : ℝ) := by
+      rw [Real.exp_eq_exp_ℝ, NormedSpace.exp_eq_tsum (𝕂 := ℝ) (𝔸 := ℝ)]
+      exact tsum_congr (fun k => by simp [smul_eq_mul, div_eq_mul_inv, mul_comm])
+    rw [h1]
+    exact (summable_pow_div_factorial x).hasSum
+  have htend := hsum.tendsto_sum_nat
+  -- partial sums of length `n+1` still converge to the same limit
+  have hshift : Filter.Tendsto
+      (fun n => ∑ k ∈ Finset.range (n + 1), x ^ k / (k ! : ℝ))
+      Filter.atTop (nhds (Real.exp x)) :=
+    htend.comp (Filter.tendsto_add_atTop_nat 1)
+  refine hshift.congr (fun n => ?_)
+  rw [taylorWithinEval_exp_eq_partialSum x hx n]
+
+/-! ## Verification -/
+
+#check @iteratedDeriv_exp
+#check @iteratedDerivWithin_exp_Icc
+#check @taylorWithinEval_exp_eq_partialSum
+#check @exp_lagrange_remainder_partialSum
+#check @exp_sub_partialSum_le
+#check @taylorWithinEval_exp_tendsto
+
+end TaylorExpBridge

--- a/src/data/proofs/taylor-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/taylor-theorem-oq-03-oq-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "taylor-theorem-oq-03-oq-01",
+  "title": "Bridging taylorWithinEval to the Exponential Partial Sum",
+  "slug": "taylor-theorem-oq-03-oq-01",
+  "description": "Identifies Mathlib's local Taylor polynomial taylorWithinEval exp n (Icc 0 x) 0 x with the explicit partial sum sum_{k<=n} x^k/k!, purely from Mathlib lemmas. The bridge collapses the local derivatives iteratedDerivWithin appearing in taylorWithinEval to the global iteratedDeriv of the smooth function exp, then promotes the abstract Lagrange remainder to a fully explicit, axiom-free statement: exp x - sum_{k<=n} x^k/k! = exp(xi) * x^(n+1)/(n+1)! for some xi in (0, x).",
+  "meta": {
+    "author": "Taylor (1715), Lagrange (1797) (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Taylor%27s_theorem",
+    "date": "1715",
+    "status": "verified",
+    "proofRepoPath": "Proofs/TaylorTheoremOQ03OQ01.lean",
+    "tags": [
+      "analysis",
+      "calculus",
+      "taylor-series",
+      "exponential-function",
+      "mathlib-api",
+      "lagrange-remainder",
+      "open-question"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "taylor_within_apply",
+        "description": "Expands taylorWithinEval into a Finset.sum whose k-th summand carries the local derivative iteratedDerivWithin k f s x0",
+        "module": "Mathlib.Analysis.Calculus.Taylor"
+      },
+      {
+        "theorem": "iteratedDerivWithin_eq_iteratedDeriv",
+        "description": "On a UniqueDiffOn set, the local iterated derivative of a ContDiffAt function equals the global iterated derivative; the heart of the bridge",
+        "module": "Mathlib.Analysis.Calculus.IteratedDeriv.Defs"
+      },
+      {
+        "theorem": "taylor_mean_remainder_lagrange_iteratedDeriv",
+        "description": "Lagrange form of the Taylor remainder using the global iteratedDeriv (n+1)",
+        "module": "Mathlib.Analysis.Calculus.Taylor"
+      },
+      {
+        "theorem": "Real.contDiff_exp",
+        "description": "The exponential function is infinitely differentiable",
+        "module": "Mathlib.Analysis.SpecialFunctions.ExpDeriv"
+      },
+      {
+        "theorem": "uniqueDiffOn_Icc",
+        "description": "A nondegenerate closed interval is a unique-differentiability set",
+        "module": "Mathlib.Analysis.Calculus.UniqueDifferentiable"
+      },
+      {
+        "theorem": "NormedSpace.exp_eq_tsum",
+        "description": "The exponential is the sum of its power series; used for the convergence sanity check",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exponential"
+      }
+    ],
+    "originalContributions": [
+      "Proved the bridge taylorWithinEval exp n (Icc 0 x) 0 x = sum_{k<=n} x^k/k! by expanding taylorWithinEval via taylor_within_apply and collapsing each local derivative to exp",
+      "Proved iteratedDerivWithin k exp (Icc 0 x) 0 = 1 for x > 0 by combining iteratedDerivWithin_eq_iteratedDeriv with the global derivative identity iteratedDeriv k exp = exp",
+      "Promoted the abstract Lagrange remainder to an explicit statement about the exp partial sum: exists xi in (0,x) with exp x - sum_{k<=n} x^k/k! = exp(xi) * x^(n+1)/(n+1)!",
+      "Derived a two-sided remainder bound 0 <= exp x - T_n(x) <= exp(x) * x^(n+1)/(n+1)! using exp(xi) <= exp(x)",
+      "Verified compatibility with convergence: the bridged partial sums tend to exp x"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 160,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext, Classical.choice, Quot.sound are used (verified via #print axioms). The Taylor-polynomial expansion (taylor_within_apply), the local-to-global derivative bridge (iteratedDerivWithin_eq_iteratedDeriv), and the abstract Lagrange remainder (taylor_mean_remainder_lagrange_iteratedDeriv) come from Mathlib; the original work is the identification of taylorWithinEval for exp with the explicit partial sum and the explicit remainder statement.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Mathlib states Taylor's theorem through taylorWithinEval, the value of the Taylor polynomial of a function restricted to a closed interval, expanded about a basepoint. This is the right level of generality for the abstract mean-value remainder theorems, but it is one step removed from the concrete partial sums sum_{k<=n} x^k/k! that one actually computes with. The gap is the difference between the local derivative iteratedDerivWithin k f (Icc 0 x) 0, which only sees f on the interval, and the global derivative iteratedDeriv k f. For a function that is smooth on all of the reals the two agree, but bridging them inside Lean requires the precise hypotheses that the underlying set is a unique-differentiability set and that the function is continuously differentiable there. This entry, the first follow-up to the exp convergence proof (taylor-theorem-oq-03), closes that gap for the exponential function and uses it to turn the abstract Lagrange remainder into the fully explicit formula that Euler and Lagrange worked with directly.",
+    "problemStatement": "**Goal**: bridge Mathlib's local Taylor polynomial to the explicit exponential partial sum and derive an explicit remainder.\n\n1. Bridge (for $x>0$): $\\operatorname{taylorWithinEval}(\\exp, n, [0,x], 0, x) = \\sum_{k=0}^{n} \\frac{x^k}{k!}$\n2. Local derivatives collapse: $\\operatorname{iteratedDerivWithin} k\\, \\exp\\, [0,x]\\, 0 = 1$\n3. Explicit Lagrange remainder: $\\exists\\, \\xi \\in (0,x),\\; e^x - \\sum_{k=0}^{n} \\frac{x^k}{k!} = \\frac{e^{\\xi}\\, x^{n+1}}{(n+1)!}$\n4. Two-sided bound: $0 \\le e^x - \\sum_{k=0}^{n} \\frac{x^k}{k!} \\le \\frac{e^{x}\\, x^{n+1}}{(n+1)!}$",
+    "text": "Identifies Mathlib's local Taylor polynomial taylorWithinEval exp n (Icc 0 x) 0 x with the explicit partial sum sum_{k<=n} x^k/k!, then promotes the abstract Lagrange remainder to a fully explicit, axiom-free statement for the exponential function.",
+    "proofStrategy": "The key Mathlib lemma taylor_within_apply expands taylorWithinEval into sum_{k<=n} (k!^{-1} * (x - x0)^k) . iteratedDerivWithin k f s x0. Specializing to f = exp, s = Icc 0 x, x0 = 0, each summand carries the local derivative iteratedDerivWithin k exp (Icc 0 x) 0. The bridge lemma iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc, ContDiffAt, mem) collapses this to iteratedDeriv k exp 0, which equals exp 0 = 1 by the induction iteratedDeriv k exp = exp. Each summand simplifies to x^k/k!, giving the bridge. For the remainder, taylor_mean_remainder_lagrange_iteratedDeriv already states the remainder using the global iteratedDeriv (n+1) exp xi, which the same derivative identity turns into exp(xi); rewriting taylorWithinEval with the bridge yields the explicit partial-sum form. The two-sided bound follows from positivity and exp(xi) <= exp(x) for xi < x (gcongr). A final sanity check confirms the bridged partial sums converge to exp x.",
+    "keyInsights": [
+      "taylorWithinEval is one bridge lemma away from the explicit partial sum: taylor_within_apply turns it into a Finset.sum of local derivatives weighted by (k!)^{-1} x^k",
+      "The only real content is local-to-global: iteratedDerivWithin k exp (Icc 0 x) 0 = iteratedDeriv k exp 0, valid because exp is C-infinity and Icc 0 x is a UniqueDiffOn set containing 0",
+      "Because every derivative of exp is exp, the global derivative in the Lagrange remainder evaluates to exp(xi), giving the closed-form remainder e^xi x^(n+1)/(n+1)! with no residual taylorWithinEval",
+      "Stating the remainder via taylor_mean_remainder_lagrange_iteratedDeriv (global iteratedDeriv) rather than taylor_mean_remainder_lagrange (local iteratedDerivWithin) avoids a second local-to-global conversion on the derivative factor",
+      "The two-sided bound 0 <= R_n <= exp(x) x^(n+1)/(n+1)! makes the convergence rate explicit and is exactly the estimate used to compute e"
+    ],
+    "prerequisites": [
+      "Calculus and real analysis",
+      "Taylor's theorem (Wiedijk #35)",
+      "Iterated derivatives and unique differentiability"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-and-docstring",
+      "title": "Imports and Module Documentation",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Imports Mathlib and opens the relevant namespaces. Module documentation explains the three-step bridge (taylor_within_apply, iteratedDerivWithin_eq_iteratedDeriv, iteratedDeriv_exp) and how it yields the explicit Lagrange remainder.",
+      "mathContext": "Setup for identifying $\\operatorname{taylorWithinEval}(\\exp, n, [0,x], 0, x)$ with $\\sum_{k\\le n} x^k/k!$ and deriving the explicit Lagrange remainder."
+    },
+    {
+      "id": "global-derivatives",
+      "title": "Section I: Global Derivatives of exp",
+      "startLine": 49,
+      "endLine": 62,
+      "summary": "Proves iteratedDeriv_exp: iteratedDeriv k exp = exp by induction (base case iteratedDeriv_zero, step uses Real.hasDerivAt_exp).",
+      "mathContext": "$\\frac{d^k}{dx^k} e^x = e^x$ for all $k \\in \\mathbb{N}$, the self-similarity that drives every later step."
+    },
+    {
+      "id": "local-derivatives",
+      "title": "Section II: Local Derivatives Collapse to Global",
+      "startLine": 64,
+      "endLine": 80,
+      "summary": "Proves iteratedDerivWithin_exp_Icc: for x > 0, iteratedDerivWithin k exp (Icc 0 x) 0 = 1, by applying iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Icc, ContDiffAt of exp, 0 in Icc 0 x), then iteratedDeriv_exp and exp_zero.",
+      "mathContext": "The heart of the bridge: on the unique-differentiability set $[0,x]$ the local derivatives of the smooth function $\\exp$ at the basepoint $0$ all equal $e^0 = 1$."
+    },
+    {
+      "id": "the-bridge",
+      "title": "Section III: The Bridge",
+      "startLine": 82,
+      "endLine": 98,
+      "summary": "Proves taylorWithinEval_exp_eq_partialSum: for x > 0, taylorWithinEval exp n (Icc 0 x) 0 x = sum_{k<=n} x^k/k!, by rewriting via taylor_within_apply and simplifying each summand using iteratedDerivWithin_exp_Icc.",
+      "mathContext": "$\\operatorname{taylorWithinEval}(\\exp, n, [0,x], 0, x) = \\sum_{k=0}^{n} \\frac{x^k}{k!}$ — the headline identification of the local Taylor polynomial with the explicit partial sum."
+    },
+    {
+      "id": "explicit-lagrange",
+      "title": "Section IV: Explicit Lagrange Remainder",
+      "startLine": 100,
+      "endLine": 138,
+      "summary": "Proves exp_lagrange_remainder_partialSum (exists xi in (0,x) with exp x - sum_{k<=n} x^k/k! = exp(xi) x^(n+1)/(n+1)!) by combining taylor_mean_remainder_lagrange_iteratedDeriv with the bridge and iteratedDeriv_exp, then exp_sub_partialSum_le (the two-sided bound 0 <= R_n <= exp(x) x^(n+1)/(n+1)!).",
+      "mathContext": "Explicit Lagrange remainder for the exp partial sum and the two-sided error bound $0 \\le e^x - T_n(x) \\le \\frac{e^x x^{n+1}}{(n+1)!}$."
+    },
+    {
+      "id": "convergence-check",
+      "title": "Section V: Convergence Sanity Check",
+      "startLine": 140,
+      "endLine": 160,
+      "summary": "Proves taylorWithinEval_exp_tendsto: the bridged Taylor polynomials taylorWithinEval exp n (Icc 0 x) 0 x converge to exp x, using NormedSpace.exp_eq_tsum, summability of the exp series, and a shift of the partial-sum index. Closes with #check verification.",
+      "mathContext": "Confirms the bridge is compatible with convergence: $\\operatorname{taylorWithinEval}(\\exp, n, [0,x], 0, x) \\to e^x$ as $n \\to \\infty$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry closes the first open question of the exp Taylor-convergence proof (taylor-theorem-oq-03): it identifies Mathlib's local Taylor polynomial taylorWithinEval exp n (Icc 0 x) 0 x with the explicit partial sum sum_{k<=n} x^k/k!, purely from Mathlib lemmas, and uses the identification to state a fully explicit, axiom-free Lagrange remainder exp x - T_n(x) = exp(xi) x^(n+1)/(n+1)! together with the two-sided bound 0 <= R_n <= exp(x) x^(n+1)/(n+1)!.",
+    "implications": "**Theoretical Significance**: The bridge makes precise the routine but technically delicate step of passing from a function's derivative-within-a-set to its global derivative. For globally smooth functions the two coincide, and the proof isolates exactly the hypotheses needed (UniqueDiffOn of the interval and ContDiffAt of the function), so the same template applies to any entire function. With the bridge in place, Mathlib's abstract Taylor remainder theorems become concrete statements about familiar partial sums, which is what is needed for verified numerical analysis.",
+    "openQuestions": [
+      "Can the bridge be extended to two-sided intervals Icc x 0 for x < 0, giving taylorWithinEval exp n (Icc x 0) 0 x = sum_{k<=n} x^k/k! for negative x?",
+      "Does the same template (taylor_within_apply + iteratedDerivWithin_eq_iteratedDeriv) yield the analogous bridge for sin and cos, whose derivatives cycle with period four?",
+      "Can the explicit two-sided bound be combined with monotone convergence to give a verified a-priori term count for approximating exp x to a prescribed tolerance?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "taylor-theorem-oq-03",
+      "relationship": "extends",
+      "description": "Direct parent: the exp Taylor-convergence proof states the Lagrange remainder via taylorWithinEval and lists this bridge as its first open question. This entry proves the bridge and the resulting explicit remainder."
+    },
+    {
+      "targetId": "taylor-theorem",
+      "relationship": "foundational",
+      "description": "The abstract Taylor's theorem (Wiedijk #35) supplies taylorWithinEval and the mean-value remainder theorems that this entry specializes to exp."
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "related",
+      "description": "The explicit remainder bound 0 <= e - S_n(1) <= e/(n+1)! quantifies the rapid convergence of sum 1/n! that underlies Hermite's transcendence proof."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Filter",
+      "Topology",
+      "Finset",
+      "Real",
+      "Nat"
+    ],
+    "namespace": "TaylorExpBridge",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/TaylorTheoremOQ03OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question **taylor-theorem-oq-03-oq-01** (the first open question listed in the `taylor-theorem-oq-03` entry): identify Mathlib's local Taylor polynomial `taylorWithinEval Real.exp n (Icc 0 x) 0 x` with the explicit exponential partial sum `∑_{k≤n} xᵏ/k!`, purely from Mathlib lemmas, and use it to make the Lagrange remainder fully explicit.

## The bridge

```lean
theorem taylorWithinEval_exp_eq_partialSum (x : ℝ) (hx : 0 < x) (n : ℕ) :
    taylorWithinEval Real.exp n (Icc 0 x) 0 x =
      ∑ k ∈ Finset.range (n + 1), x ^ k / (k ! : ℝ)
```

Three steps:
1. `taylor_within_apply` expands `taylorWithinEval` into a `Finset.sum` whose `k`-th summand carries the **local** derivative `iteratedDerivWithin k exp (Icc 0 x) 0`.
2. `iteratedDerivWithin_eq_iteratedDeriv` (using `uniqueDiffOn_Icc` + `ContDiffAt` of `exp`) collapses each local derivative to the **global** `iteratedDeriv k exp 0`.
3. `iteratedDeriv_exp` evaluates every global derivative of `exp` back to `exp`, so each summand is `xᵏ/k!`.

## Explicit Lagrange remainder

With the bridge, the abstract `taylor_mean_remainder_lagrange_iteratedDeriv` (which already uses the global `iteratedDeriv (n+1)`) becomes:

```lean
theorem exp_lagrange_remainder_partialSum (x : ℝ) (hx : 0 < x) (n : ℕ) :
    ∃ ξ ∈ Ioo (0:ℝ) x,
      Real.exp x - ∑ k ∈ Finset.range (n + 1), x ^ k / (k ! : ℝ) =
        Real.exp ξ * x ^ (n + 1) / (n + 1)!
```

plus the two-sided bound `0 ≤ Rₙ ≤ eˣ·x^{n+1}/(n+1)!` and a convergence sanity check.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.TaylorTheoremOQ03OQ01` — builds (7743 jobs).
- `#print axioms` on all 6 public theorems: only `propext`, `Classical.choice`, `Quot.sound` → **0-axiom** by project policy.
- 160 lines, 6 theorems, 0 definitions, 0 sorries.

Gallery entry added at `src/data/proofs/taylor-theorem-oq-03-oq-01/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)