### PR TITLE
research(geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04): explicit closed form for the Eulerian numbers ⟨m,k⟩ = ∑ⱼ (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3508,3 +3508,4 @@ import Proofs.ZsqrtdNegTwoOQ03OQ01
 import Proofs.eTranscendental
 import Proofs.MellinPowerConvergenceOQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ04

--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ04.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ04.lean
@@ -1,0 +1,265 @@
+/-
+# Geometric series, open question oq-07-oq-01-oq-01-oq-01-oq-04:
+# The explicit closed form for the Eulerian numbers
+
+The parent entry `geometric-series-oq-07-oq-01-oq-01-oq-01` built the combinatorial Eulerian
+numbers `⟨m,k⟩` (`eulerian m k`) from the classical triangle recurrence
+`⟨n+1,k+1⟩ = (k+2)·⟨n,k+1⟩ + (n−k)·⟨n,k⟩`, `⟨m,0⟩ = 1`, and identified them with the coefficients
+of the Eulerian polynomial.  Worpitzky's identity (`...-oq-03`) expands `nᵐ` in the binomial
+basis.  This entry proves the celebrated **explicit closed form** that solves the triangle
+recurrence outright — a single alternating binomial sum, with no recursion:
+
+  **`eulerian_explicit`** :  `⟨m,k⟩ = ∑_{j=0}^{k} (−1)ʲ · C(m+1, j) · (k+1−j)ᵐ`   (over `ℤ`).
+
+For example `⟨2,1⟩ = C(3,0)·2² − C(3,1)·1² = 4 − 3 = 1` and
+`⟨3,1⟩ = C(4,0)·2³ − C(4,1)·1³ = 8 − 4 = 4`, matching the rows `1,1` and `1,4,1`.
+
+## Method
+
+Write `A(m,k) := ∑_{j=0}^{k} (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ` (`eulExpl`).  We prove `⟨m,k⟩ = A(m,k)` by
+induction on `m`, by showing `A` satisfies the *same* defining recurrence and boundary values as
+`eulerian`.  The boundary cases `A(m,0) = 1` and `A(0,k) = [k=0]` are direct.  The heart is the
+recurrence (`eulExpl_recurrence`)
+
+  `A(m+1,k+1) = (k+2)·A(m,k+1) + (m−k)·A(m,k)`,
+
+proved purely over `ℤ`.  Splitting `C(m+2,j)` by Pascal's rule and `(k+2−j)^{m+1}` as
+`(k+2−j)·(k+2−j)ᵐ`, then applying the absorption identity `j·C(m+1,j) = (m+1)·C(m,j−1)` and a
+single index shift `j ↦ j+1`, collapses the order-`m+1` sum into the order-`m` sums.  The residual
+combinatorial fact is the clean Pascal identity (`eulExpl_pascal_step`)
+
+  `∑_{i=0}^{k}(−1)ⁱC(m,i)(k+1−i)ᵐ − ∑_{i=0}^{k−1}(−1)ⁱC(m,i)(k−i)ᵐ = A(m,k)`,
+
+itself just `C(m+1,j) = C(m,j) + C(m,j−1)` re-summed.  Because the integer coefficient `(m−k)`
+agrees with the natural-number `(m−k)` exactly when `eulerian m k ≠ 0`, the integer recurrence
+transfers to `eulerian`'s `ℕ`-truncated one.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and `sorry`-free.
+-/
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ01OQ04
+
+open Finset GeometricSeriesOQ07OQ01OQ01OQ01
+
+/-- The explicit alternating-binomial sum for the Eulerian numbers, as an integer:
+`A(m,k) = ∑_{j=0}^{k} (−1)ʲ · C(m+1,j) · (k+1−j)ᵐ`. -/
+def eulExpl (m k : ℕ) : ℤ :=
+  ∑ j ∈ range (k + 1), (-1) ^ j * ((m + 1).choose j : ℤ) * ((k + 1 - j : ℕ) : ℤ) ^ m
+
+/-! ## Boundary values -/
+
+theorem eulExpl_zero_right (m : ℕ) : eulExpl m 0 = 1 := by
+  simp [eulExpl]
+
+theorem eulExpl_zero_left (k : ℕ) : eulExpl 0 k = if k = 0 then 1 else 0 := by
+  rcases Nat.eq_zero_or_pos k with rfl | hk
+  · simp [eulExpl]
+  · rw [if_neg (by omega)]
+    -- every factor `(k+1-j)^0 = 1`, and `C(1,j) = 0` for `j ≥ 2`
+    have hsub : range 2 ⊆ range (k + 1) := by
+      intro x hx; simp only [Finset.mem_range] at *; omega
+    have hkey : eulExpl 0 k
+        = ∑ j ∈ range 2, (-1) ^ j * ((0 + 1).choose j : ℤ) * ((k + 1 - j : ℕ) : ℤ) ^ 0 := by
+      rw [eulExpl]
+      refine (Finset.sum_subset hsub ?_).symm
+      intro x _ hx
+      have hx2 : 2 ≤ x := by rwa [Finset.mem_range, not_lt] at hx
+      rw [Nat.choose_eq_zero_of_lt (show (0 : ℕ) + 1 < x by omega)]
+      simp
+    rw [hkey]
+    simp [Finset.sum_range_succ]
+
+/-! ## A Pascal re-summation identity
+
+`∑_{i=0}^{k}(−1)ⁱC(m,i)(k+1−i)ᵐ − ∑_{i=0}^{k−1}(−1)ⁱC(m,i)(k−i)ᵐ = A(m,k)`, obtained from
+`C(m+1,i+1) = C(m,i) + C(m,i+1)` after peeling the leading term of each sum. -/
+theorem eulExpl_pascal_step (m k : ℕ) :
+    (∑ i ∈ range (k + 1), (-1) ^ i * (m.choose i : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ m)
+      - (∑ i ∈ range k, (-1) ^ i * (m.choose i : ℤ) * ((k - i : ℕ) : ℤ) ^ m)
+      = eulExpl m k := by
+  -- Peel the leading term off `A` (the order-`m` sum over `range (k+1)`).
+  have hA : (∑ i ∈ range (k + 1), (-1) ^ i * (m.choose i : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ m)
+      = (∑ i ∈ range k, -((-1) ^ i * (m.choose (i + 1) : ℤ) * ((k - i : ℕ) : ℤ) ^ m))
+          + ((k + 1 : ℕ) : ℤ) ^ m := by
+    rw [Finset.sum_range_succ']
+    congr 1
+    · refine Finset.sum_congr rfl (fun i _ => ?_)
+      rw [Nat.succ_sub_succ]; ring
+    · simp
+  -- Peel the leading term off `S = eulExpl m k`.
+  have hS : eulExpl m k
+      = (∑ i ∈ range k, -((-1) ^ i * ((m + 1).choose (i + 1) : ℤ) * ((k - i : ℕ) : ℤ) ^ m))
+          + ((k + 1 : ℕ) : ℤ) ^ m := by
+    rw [eulExpl, Finset.sum_range_succ']
+    congr 1
+    · refine Finset.sum_congr rfl (fun i _ => ?_)
+      rw [Nat.succ_sub_succ]; ring
+    · simp
+  rw [hA, hS]
+  -- the two leading `(k+1)ᵐ` cancel; the order-`k` sums match termwise by Pascal
+  have hcomb :
+      (∑ i ∈ range k, -((-1) ^ i * (m.choose (i + 1) : ℤ) * ((k - i : ℕ) : ℤ) ^ m))
+        - (∑ i ∈ range k, (-1) ^ i * (m.choose i : ℤ) * ((k - i : ℕ) : ℤ) ^ m)
+        = ∑ i ∈ range k, -((-1) ^ i * ((m + 1).choose (i + 1) : ℤ) * ((k - i : ℕ) : ℤ) ^ m) := by
+    rw [← Finset.sum_sub_distrib]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [Nat.choose_succ_succ m i]
+    push_cast
+    ring
+  linarith [hcomb]
+
+/-! ## Absorption and the absorbed alternating sum -/
+
+/-- Absorption identity `(i+1)·C(m+1,i+1) = (m+1)·C(m,i)` over `ℤ`. -/
+private theorem habsorb (m i : ℕ) :
+    ((i : ℤ) + 1) * ((m + 1).choose (i + 1) : ℤ) = ((m : ℤ) + 1) * (m.choose i : ℤ) := by
+  have h := Nat.add_one_mul_choose_eq m i
+  have h2 : (((m + 1) * m.choose i : ℕ) : ℤ) = (((m + 1).choose (i + 1) * (i + 1) : ℕ) : ℤ) := by
+    exact_mod_cast h
+  push_cast at h2
+  linear_combination h2.symm
+
+/-- The alternating sum weighted by `j` collapses, via absorption and an index shift, to
+`−(m+1)` times an order-`m` alternating sum. -/
+private theorem absorbed_sum (m N : ℕ) :
+    (∑ j ∈ range (N + 1), (j : ℤ) * ((-1) ^ j * ((m + 1).choose j : ℤ) * ((N + 1 - j : ℕ) : ℤ) ^ m))
+      = -((m : ℤ) + 1) * (∑ i ∈ range N, (-1) ^ i * (m.choose i : ℤ) * ((N - i : ℕ) : ℤ) ^ m) := by
+  rw [Finset.sum_range_succ', Finset.mul_sum]
+  simp only [Nat.cast_zero, zero_mul, add_zero]
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  rw [Nat.succ_sub_succ]
+  push_cast
+  linear_combination (-(-1 : ℤ) ^ i * ((N - i : ℕ) : ℤ) ^ m) * habsorb m i
+
+/-! ## The core recurrence -/
+
+theorem eulExpl_recurrence (m k : ℕ) :
+    eulExpl (m + 1) (k + 1)
+      = (k + 2) * eulExpl m (k + 1) + ((m : ℤ) - k) * eulExpl m k := by
+  -- Split `(k+2−j)^{m+1}` and re-sum the order-`m+1` numerator over `range (k+2)`.
+  have hstep1 :
+      (∑ j ∈ range (k + 1 + 1),
+          (-1) ^ j * ((m + 1).choose j : ℤ) * ((k + 1 + 1 - j : ℕ) : ℤ) ^ (m + 1))
+        = (k + 2) * eulExpl m (k + 1)
+          - (∑ j ∈ range (k + 1 + 1),
+              (j : ℤ) * ((-1) ^ j * ((m + 1).choose j : ℤ) * ((k + 1 + 1 - j : ℕ) : ℤ) ^ m)) := by
+    rw [eulExpl, Finset.mul_sum, ← Finset.sum_sub_distrib]
+    refine Finset.sum_congr rfl (fun j hj => ?_)
+    have hjk : j < k + 1 + 1 := Finset.mem_range.mp hj
+    have hb : ((k + 1 + 1 - j : ℕ) : ℤ) = (k : ℤ) + 2 - (j : ℤ) := by
+      rw [Nat.cast_sub (by omega)]; push_cast; ring
+    rw [pow_succ]
+    linear_combination
+      ((-1) ^ j * ((m + 1).choose j : ℤ) * ((k + 1 + 1 - j : ℕ) : ℤ) ^ m) * hb
+  -- Same split for the order-`m+1` sum over `range (k+1)`.
+  have hstep2 :
+      (∑ i ∈ range (k + 1),
+          (-1) ^ i * ((m + 1).choose i : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ (m + 1))
+        = (k + 1) * eulExpl m k
+          - (∑ i ∈ range (k + 1),
+              (i : ℤ) * ((-1) ^ i * ((m + 1).choose i : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ m)) := by
+    rw [eulExpl, Finset.mul_sum, ← Finset.sum_sub_distrib]
+    refine Finset.sum_congr rfl (fun i hi => ?_)
+    have hik : i < k + 1 := Finset.mem_range.mp hi
+    have hb : ((k + 1 - i : ℕ) : ℤ) = (k : ℤ) + 1 - (i : ℤ) := by
+      rw [Nat.cast_sub (by omega)]; push_cast; ring
+    rw [pow_succ]
+    linear_combination
+      ((-1) ^ i * ((m + 1).choose i : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ m) * hb
+  -- Now collapse the weighted sums via `absorbed_sum`.
+  have hS1 :
+      (∑ j ∈ range (k + 1 + 1),
+          (-1) ^ j * ((m + 1).choose j : ℤ) * ((k + 1 + 1 - j : ℕ) : ℤ) ^ (m + 1))
+        = (k + 2) * eulExpl m (k + 1)
+          + ((m : ℤ) + 1)
+            * (∑ i ∈ range (k + 1), (-1) ^ i * (m.choose i : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ m) := by
+    rw [hstep1, absorbed_sum m (k + 1)]; ring
+  have hS2 :
+      (∑ i ∈ range (k + 1),
+          (-1) ^ i * ((m + 1).choose i : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ (m + 1))
+        = (k + 1) * eulExpl m k
+          + ((m : ℤ) + 1)
+            * (∑ i ∈ range k, (-1) ^ i * (m.choose i : ℤ) * ((k - i : ℕ) : ℤ) ^ m) := by
+    rw [hstep2, absorbed_sum m k]; ring
+  -- Pascal on `C(m+2,j)` writes the numerator as `S1 − S2`.
+  have hP :
+      eulExpl (m + 1) (k + 1)
+        = (∑ j ∈ range (k + 1 + 1),
+            (-1) ^ j * ((m + 1).choose j : ℤ) * ((k + 1 + 1 - j : ℕ) : ℤ) ^ (m + 1))
+          - (∑ i ∈ range (k + 1),
+              (-1) ^ i * ((m + 1).choose i : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ (m + 1)) := by
+    have e1 :
+        eulExpl (m + 1) (k + 1)
+          = (∑ i ∈ range (k + 1),
+              (-1) ^ (i + 1) * ((m + 1 + 1).choose (i + 1) : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ (m + 1))
+            + ((k + 1 + 1 : ℕ) : ℤ) ^ (m + 1) := by
+      rw [eulExpl, Finset.sum_range_succ']
+      congr 1
+      · refine Finset.sum_congr rfl (fun i _ => ?_); rw [Nat.succ_sub_succ]
+      · simp
+    have e2 :
+        (∑ j ∈ range (k + 1 + 1),
+            (-1) ^ j * ((m + 1).choose j : ℤ) * ((k + 1 + 1 - j : ℕ) : ℤ) ^ (m + 1))
+          = (∑ i ∈ range (k + 1),
+              (-1) ^ (i + 1) * ((m + 1).choose (i + 1) : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ (m + 1))
+            + ((k + 1 + 1 : ℕ) : ℤ) ^ (m + 1) := by
+      rw [Finset.sum_range_succ']
+      congr 1
+      · refine Finset.sum_congr rfl (fun i _ => ?_); rw [Nat.succ_sub_succ]
+      · simp
+    rw [e1, e2]
+    have hterm :
+        (∑ i ∈ range (k + 1),
+            (-1) ^ (i + 1) * ((m + 1 + 1).choose (i + 1) : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ (m + 1))
+          = (∑ i ∈ range (k + 1),
+              (-1) ^ (i + 1) * ((m + 1).choose (i + 1) : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ (m + 1))
+            - (∑ i ∈ range (k + 1),
+                (-1) ^ i * ((m + 1).choose i : ℤ) * ((k + 1 - i : ℕ) : ℤ) ^ (m + 1)) := by
+      rw [← Finset.sum_sub_distrib]
+      refine Finset.sum_congr rfl (fun i _ => ?_)
+      rw [Nat.choose_succ_succ (m + 1) i]
+      push_cast
+      ring
+    linarith [hterm]
+  linear_combination hP + hS1 - hS2 + ((m : ℤ) + 1) * eulExpl_pascal_step m k
+
+/-! ## The explicit formula -/
+
+theorem eulerian_explicit (m k : ℕ) : (eulerian m k : ℤ) = eulExpl m k := by
+  induction m generalizing k with
+  | zero =>
+    rw [eulExpl_zero_left]
+    rcases Nat.eq_zero_or_pos k with rfl | hk
+    · simp
+    · obtain ⟨k, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : k ≠ 0)
+      simp [eulerian_zero_succ]
+  | succ m ih =>
+    rcases Nat.eq_zero_or_pos k with rfl | hk
+    · rw [eulExpl_zero_right]; simp
+    · obtain ⟨k, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : k ≠ 0)
+      -- reconcile the `ℕ`-truncated `(m - k)` with the integer `(m : ℤ) - k`
+      have hcast : ((m - k : ℕ) : ℤ) * (eulerian m k : ℤ) = ((m : ℤ) - k) * (eulerian m k : ℤ) := by
+        rcases le_or_gt k m with h | h
+        · rw [Nat.cast_sub h]
+        · rw [eulerian_eq_zero_of_lt h]; simp
+      rw [eulExpl_recurrence, ← ih (k + 1), ← ih k, eulerian_succ_succ]
+      push_cast
+      rw [hcast]
+
+/-! ## Worked examples
+
+The closed form reproduces the Eulerian rows `1, 1` (order 2), `1, 4, 1` (order 3) and
+`1, 11, 11, 1` (order 4). -/
+
+/-- `⟨2,1⟩ = C(3,0)·2² − C(3,1)·1² = 4 − 3 = 1`. -/
+example : (eulerian 2 1 : ℤ) = 1 := by rw [eulerian_explicit]; decide
+
+/-- `⟨3,1⟩ = C(4,0)·2³ − C(4,1)·1³ = 8 − 4 = 4`. -/
+example : (eulerian 3 1 : ℤ) = 4 := by rw [eulerian_explicit]; decide
+
+/-- `⟨4,2⟩ = C(5,0)·3⁴ − C(5,1)·2⁴ + C(5,2)·1⁴ = 81 − 80 + 10 = 11`. -/
+example : (eulerian 4 2 : ℤ) = 11 := by rw [eulerian_explicit]; decide
+
+end GeometricSeriesOQ07OQ01OQ01OQ01OQ04

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "GeometricSeriesOQ07OQ01OQ01OQ01"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ01OQ04",
+    "lineCount": 265,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ04.lean",
+    "sorries": 0
+  },
+  "title": "The Explicit Closed Form for the Eulerian Numbers: ⟨m,k⟩ = ∑ⱼ (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ04.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "closed-form",
+      "binomial-coefficients",
+      "inclusion-exclusion",
+      "descent-statistic",
+      "triangle-recurrence",
+      "induction",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 265,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "eulerian_explicit: THE MAIN RESULT — the celebrated explicit closed form for the combinatorial Eulerian numbers ⟨m,k⟩ built in the parent entry, as an identity of integers: ⟨m,k⟩ = ∑_{j=0}^{k} (−1)ʲ·C(m+1, j)·(k+1−j)ᵐ. Unlike the triangle recurrence (which defines ⟨m,k⟩ implicitly) and Worpitzky's identity (which expands nᵐ in the binomial basis), this is a single non-recursive alternating binomial sum that *solves* the triangle recurrence outright — the standard textbook formula for the Eulerian numbers. Mathlib has neither the Eulerian numbers nor this formula; both statement and proof are built here.",
+      "eulExpl: the explicit alternating-binomial sum A(m,k) = ∑_{j∈range(k+1)} (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ, defined over ℤ (the alternating signs force ℤ), with the natural-number base (k+1−j) cast in. The proof shows ⟨m,k⟩ = A(m,k) by induction on m, verifying A satisfies the same defining recurrence and boundary values as eulerian: A(m,0) = 1 (eulExpl_zero_right) and A(0,k) = [k=0] (eulExpl_zero_left, the latter using that C(1,j) = 0 for j ≥ 2 so the alternating row sum 1 − 1 telescopes to 0).",
+      "eulExpl_recurrence: the heart of the proof — A satisfies the Eulerian triangle recurrence A(m+1,k+1) = (k+2)·A(m,k+1) + (m−k)·A(m,k), proved purely over ℤ. Splitting C(m+2,j) by Pascal's rule and (k+2−j)^{m+1} = (k+2−j)·(k+2−j)ᵐ, then applying the absorption identity j·C(m+1,j) = (m+1)·C(m,j−1) with a single index shift j ↦ j+1, collapses the order-(m+1) sums into order-m sums; the whole assembly closes by a single linear_combination over the four structural sub-lemmas.",
+      "absorbed_sum: a reusable lemma packaging the absorption-plus-shift step once for both numerator sums — the j-weighted alternating sum ∑_{j∈range(N+1)} j·(−1)ʲ·C(m+1,j)·(N+1−j)ᵐ collapses to −(m+1)·∑_{i∈range N} (−1)ⁱ·C(m,i)·(N−i)ᵐ, via Nat.add_one_mul_choose_eq (cast to ℤ in habsorb) and Finset.sum_range_succ'.",
+      "eulExpl_pascal_step: the residual combinatorial identity ∑_{i=0}^{k}(−1)ⁱC(m,i)(k+1−i)ᵐ − ∑_{i=0}^{k−1}(−1)ⁱC(m,i)(k−i)ᵐ = A(m,k), which is just Pascal's rule C(m+1,i+1) = C(m,i) + C(m,i+1) re-summed termwise after peeling the leading term of each sum. The transfer of the integer recurrence to eulerian's ℕ-truncated one uses that the integer coefficient (m−k) and the truncated (m−k) agree exactly when eulerian m k ≠ 0 (it vanishes for k > m). The Eulerian rows 1,1 (order 2), 1,4,1 (order 3) and 1,11,11,1 (order 4) are verified from the formula by kernel decide."
+    ],
+    "prerequisites": [
+      "Parent: geometric-series-oq-07-oq-01-oq-01-oq-01 (the combinatorial Eulerian numbers) — supplies the eulerian triangle, its recurrence eulerian_succ_succ, the base eulerian_succ_zero, and the vanishing lemma eulerian_eq_zero_of_lt reused to transfer the ℤ recurrence to ℕ",
+      "Mathlib's Nat.choose with Pascal's rule (Nat.choose_succ_succ), binomial absorption (Nat.add_one_mul_choose_eq), and Nat.choose_eq_zero_of_lt for the degenerate row",
+      "Casting ℕ identities to ℤ (Nat.cast_sub, push_cast) so the alternating signs and per-term absorptions can be discharged by linear_combination without truncated subtraction",
+      "Finset reindexing: Finset.sum_range_succ', Finset.sum_sub_distrib, Finset.mul_sum, Finset.sum_subset"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.add_one_mul_choose_eq",
+        "description": "The binomial absorption identity (n+1)·n.choose k = (n+1).choose (k+1)·(k+1). Cast to ℤ in habsorb, it turns j·C(m+1,j) into (m+1)·C(m,j−1), the step that lowers the order-(m+1) weighted sum to order m.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule (n+1).choose (k+1) = n.choose k + n.choose (k+1). Used (over ℤ) both to split C(m+2,j) in the core recurrence and to close the termwise Pascal re-summation eulExpl_pascal_step.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Peels the first term of a range sum with an index shift, ∑_{i<n+1} f i = ∑_{i<n} f (i+1) + f 0. Drives the j ↦ j+1 reindexing in absorbed_sum and the leading-term peels in eulExpl_pascal_step.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07OQ01OQ01OQ01.eulerian",
+        "description": "The parent's from-scratch combinatorial Eulerian-number triangle ⟨m,j⟩ with eulerian_succ_succ and eulerian_eq_zero_of_lt. Reused verbatim so this entry only adds the explicit closed form, not the underlying object.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04-oq-01",
+      "question": "Specialize the explicit formula at the row ends to recover the corner values ⟨m,0⟩ = 1 and ⟨m,m−1⟩ = 1 directly (the j=0 term gives (k+1)ᵐ and the alternating tail telescopes), and prove the maximal entry ⟨m,⌊m/2⌋⌋ dominates, giving an elementary route to unimodality of each Eulerian row.",
+      "significance": "low"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04-oq-02",
+      "question": "Derive the explicit formula a second way, by inverting Worpitzky's identity nᵐ = ∑_j ⟨m,j⟩·C(n+j,m) (proved in the sibling oq-03): apply the alternating binomial transform to the binomial basis and show ∑_i (−1)ⁱ·C(m+1,i)·C(k+1−i+j, m) = [i = k], yielding the closed form as a finite-difference inversion complementary to the recurrence-matching proof given here."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent (the combinatorial Eulerian numbers). The parent defines the triangle ⟨m,j⟩ and identifies it with the Eulerian-polynomial coefficients. This entry proves the explicit closed form ⟨m,k⟩ = ∑_j (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ that solves the recurrence, reusing the parent's eulerian, eulerian_succ_succ and eulerian_eq_zero_of_lt."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling under the same parent. oq-03 proves Worpitzky's identity nᵐ = ∑_j ⟨m,j⟩·C(n+j,m); this entry proves the complementary explicit closed form for ⟨m,k⟩ itself. Together they are the two classical 'change of basis' facts of Eulerian theory: Worpitzky expands the power basis in shifted binomials, the explicit formula inverts the relation to isolate a single Eulerian number."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling under the same parent. oq-02 (polynomial palindromy E_m(X) = X^{m+1}E_m(1/X)) reflects the symmetry ⟨m,k⟩ = ⟨m,m−1−k⟩; the explicit closed form proved here makes that symmetry an explicit equality of two alternating binomial sums."
+    },
+    {
+      "targetId": "geometric-series-oq-07",
+      "relationship": "related",
+      "description": "Grandparent lineage (the geometric moment ∑ nᵐ·rⁿ = E_m(r)/(1−r)^{m+1}). The explicit formula is exactly the coefficient extraction of the Eulerian polynomial from that generating function: convolving (1−x)^{m+1} = ∑_j (−1)ʲC(m+1,j)xʲ with ∑_i (i+1)ᵐxⁱ produces the alternating binomial sum proved here."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers, the explicit formula, the descent statistic)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian-number triangle and the closed form ⟨n,k⟩ = ∑_j (−1)ʲ·C(n+1,j)·(k+1−j)ⁿ."
+    },
+    {
+      "title": "Mathlib4: Data.Nat.Choose.Basic",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Pascal's rule (Nat.choose_succ_succ) and the binomial absorption identity (Nat.add_one_mul_choose_eq) powering the core recurrence."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Building on the parent entry's from-scratch combinatorial Eulerian numbers ⟨m,k⟩, this entry proves their celebrated explicit closed form as an identity of integers: ⟨m,k⟩ = ∑_{j=0}^{k} (−1)ʲ·C(m+1, j)·(k+1−j)ᵐ. Where the triangle recurrence defines the numbers implicitly and Worpitzky's identity expands nᵐ over shifted binomials, this single non-recursive alternating binomial sum solves the recurrence outright. The proof shows the formula A(m,k) := ∑_j (−1)ʲC(m+1,j)(k+1−j)ᵐ (eulExpl) agrees with eulerian by induction on m: A satisfies the same boundary values A(m,0)=1, A(0,k)=[k=0] and the same triangle recurrence A(m+1,k+1) = (k+2)A(m,k+1) + (m−k)A(m,k) (eulExpl_recurrence). That recurrence is proved purely over ℤ — Pascal's rule splits C(m+2,j), the power (k+2−j)^{m+1} is split off one factor, and the binomial absorption j·C(m+1,j) = (m+1)·C(m,j−1) (packaged once as absorbed_sum, via Nat.add_one_mul_choose_eq) with an index shift collapses the order-(m+1) sums to order m; a residual Pascal re-summation eulExpl_pascal_step and a single linear_combination finish it. The integer recurrence transfers to eulerian's ℕ-truncated (m−k) because the two coefficients agree exactly when eulerian m k ≠ 0. The Eulerian rows 1,1; 1,4,1; 1,11,11,1 are verified from the formula by kernel decide. 265 lines, 5 public theorems (+2 private helpers), 1 definition, 0 axioms, 0 sorries; everything depends only on propext, Classical.choice, Quot.sound (the numeric checks use kernel decide, not native_decide, so no Lean.ofReduceBool).",
+    "implications": "The explicit closed form is the canonical non-recursive description of the Eulerian numbers and the basis for most of their analytic theory (unimodality, log-concavity, asymptotic normality of the descent statistic). It is the alternating-binomial inverse of Worpitzky's identity and the literal coefficient extraction of the Eulerian polynomial from the geometric-moment generating function ∑ nᵐxⁿ = E_m(x)/(1−x)^{m+1} established up the lineage: convolving (1−x)^{m+1} with ∑(i+1)ᵐxⁱ produces exactly this sum. Because the proof rests only on the triangle recurrence and elementary binomial identities, it is a self-contained, Mathlib-free addition completing the core identities (recurrence, Worpitzky, palindromy, closed form) of the Eulerian-number theory developed in this gallery.",
+    "openQuestions": [
+      "Read the row-end values ⟨m,0⟩ = ⟨m,m−1⟩ = 1 and unimodality off the explicit formula.",
+      "Re-derive the closed form by inverting Worpitzky's identity (alternating binomial transform / finite-difference inversion)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Proves the **celebrated explicit closed form** for the combinatorial Eulerian numbers `⟨m,k⟩` built in the parent entry (`geometric-series-oq-07-oq-01-oq-01-oq-01`), as an identity of integers:

```
⟨m,k⟩ = ∑_{j=0}^{k} (−1)ʲ·C(m+1, j)·(k+1−j)ᵐ
```

This is the textbook non-recursive formula that **solves** the Eulerian triangle recurrence. It complements the lineage's other core identities: the triangle recurrence (parent), Worpitzky's identity (sibling `oq-03`), and palindromy (sibling `oq-02`). Mathlib has neither the Eulerian numbers nor this formula.

## Method

Set `A(m,k) := ∑_j (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ` (`eulExpl`, over ℤ — the alternating signs force ℤ). Prove `⟨m,k⟩ = A(m,k)` by induction on `m`, showing `A` satisfies the **same boundary values and triangle recurrence** as `eulerian`:

- `eulExpl_recurrence`: `A(m+1,k+1) = (k+2)·A(m,k+1) + (m−k)·A(m,k)`, proved purely over ℤ. Pascal splits `C(m+2,j)`; the power `(k+2−j)^{m+1}` splits off one factor; the binomial absorption `j·C(m+1,j) = (m+1)·C(m,j−1)` plus a single index shift (packaged once as the reusable `absorbed_sum`) collapses the order-(m+1) sums to order m; a residual Pascal re-summation (`eulExpl_pascal_step`) and one `linear_combination` finish.
- The ℤ recurrence transfers to `eulerian`'s ℕ-truncated `(m−k)` because the two coefficients agree exactly when `eulerian m k ≠ 0`.

The Eulerian rows `1,1` / `1,4,1` / `1,11,11,1` are verified from the formula by **kernel `decide`** (no `native_decide`).

## Verification

- Builds via `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ04` (7746 jobs, success).
- 265 lines, 5 public theorems + 2 private helpers, 1 definition, **0 axioms, 0 sorries** (`propext`/`Classical.choice`/`Quot.sound` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)