### PR TITLE
research(geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02): explicit closed form for the Eulerian numbers ⟨n,k⟩ = ∑ᵢ(−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2632,6 +2632,7 @@ import Proofs.GeometricSeriesOQ07
 import Proofs.GeometricSeriesOQ07OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ02
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ03
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ02
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ03

--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,246 @@
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01
+
+/-
+# The explicit (inclusion–exclusion) closed form for the Eulerian numbers
+
+The parent entry **geometric-series-oq-07-oq-01-oq-01-oq-01** builds the combinatorial
+Eulerian numbers `⟨n,k⟩` (`eulerian n k`) from the triangle recurrence and identifies them
+with the coefficients of the Eulerian polynomial.  Its child
+**geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01** computed the row sum `∑ⱼ ⟨n,j⟩ = n!` and
+the explicit closed forms of the *low columns* `k = 0,1,2`, and recorded the **general
+closed form** as its declared open question:
+
+  `⟨n,k⟩ = ∑_{i=0}^{k} (-1)ⁱ · C(n+1,i) · (k+1-i)ⁿ`.
+
+This entry settles it.  We define the alternating binomial sum `eulerianExplicit n k`
+(the right-hand side, as an integer) and prove it equals `⟨n,k⟩` for **all** `n,k`.
+
+## Method
+
+`eulerianExplicit` satisfies the very recurrence that *defines* `eulerian`:
+
+  `eulerianExplicit (n+1) (k+1)
+      = (k+2)·eulerianExplicit n (k+1) + (n-k)·eulerianExplicit n k`     (`eulerianExplicit_succ_succ`)
+
+The proof of this recurrence is a finite-difference computation: split `C(n+2,i)` by
+Pascal's rule, reindex, and collapse the result using the two binomial *absorption*
+identities
+
+  `C(n+1,i)·(n+1-i) = (n+1)·C(n,i)`        (`absorb_down`)
+  `C(n+1,j+1)·(j+1) = (n+1)·C(n,j)`        (`absorb_up`).
+
+The two stray sums cancel exactly.  With the recurrence and the base row `n = 0` in hand,
+a single induction on `n` matches `eulerianExplicit` to `eulerian`; the truncated natural
+subtraction `(n-k : ℕ)` is reconciled with the integer `(n-k : ℤ)` using the parent's
+diagonal vanishing `⟨n,k⟩ = 0` for `n < k`.
+-/
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ01OQ02
+
+open Finset GeometricSeriesOQ07OQ01OQ01OQ01
+
+/-- The **explicit (inclusion–exclusion) form** of the Eulerian number `⟨n,k⟩`, as an
+integer: `∑_{i=0}^{k} (-1)ⁱ · C(n+1,i) · (k+1-i)ⁿ`.  We prove below
+(`eulerian_eq_explicit`) that this equals the combinatorial `eulerian n k`. -/
+def eulerianExplicit (n k : ℕ) : ℤ :=
+  ∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ) * ((k : ℤ) + 1 - i) ^ n
+
+/-! ## Binomial absorption identities -/
+
+/-- **Upward absorption.** `C(n+1,j+1)·(j+1) = (n+1)·C(n,j)` (over `ℤ`). -/
+theorem absorb_up (n j : ℕ) :
+    ((n + 1).choose (j + 1) : ℤ) * ((j : ℤ) + 1) = ((n : ℤ) + 1) * (n.choose j : ℤ) := by
+  have h := Nat.add_one_mul_choose_eq n j
+  have h' : ((n + 1) * n.choose j : ℤ) = ((n + 1).choose (j + 1) * (j + 1) : ℤ) := by
+    exact_mod_cast h
+  push_cast at h'
+  linarith [h']
+
+/-- **Downward absorption.** `C(n+1,i)·(n+1-i) = (n+1)·C(n,i)` (over `ℤ`, valid for all `i`
+including `i > n`, where both sides vanish). -/
+theorem absorb_down (n i : ℕ) :
+    ((n + 1).choose i : ℤ) * ((n : ℤ) + 1 - i) = ((n : ℤ) + 1) * (n.choose i : ℤ) := by
+  rcases le_or_gt i n with hi | hi
+  · -- `i ≤ n`: a genuine binomial identity, obtained from `absorb_up` via symmetry.
+    have key : (n + 1).choose i * (n + 1 - i) = (n + 1) * n.choose i := by
+      have hs : (n + 1).choose i = (n + 1).choose ((n - i) + 1) := by
+        rw [show (n - i) + 1 = (n + 1) - i from by omega, Nat.choose_symm (by omega : i ≤ n + 1)]
+      calc (n + 1).choose i * (n + 1 - i)
+          = (n + 1).choose ((n - i) + 1) * ((n - i) + 1) := by
+            rw [hs, show n + 1 - i = (n - i) + 1 from by omega]
+        _ = (n + 1) * n.choose (n - i) := by rw [← Nat.add_one_mul_choose_eq n (n - i)]
+        _ = (n + 1) * n.choose i := by rw [Nat.choose_symm hi]
+    have hcast : (((n + 1).choose i * (n + 1 - i) : ℕ) : ℤ) = (((n + 1) * n.choose i : ℕ) : ℤ) := by
+      exact_mod_cast key
+    push_cast [Nat.cast_sub (show i ≤ n + 1 from by omega)] at hcast
+    linarith [hcast]
+  · -- `i > n`: the RHS vanishes (`C(n,i) = 0`); so must the LHS.
+    rw [Nat.choose_eq_zero_of_lt hi, Nat.cast_zero, mul_zero]
+    rcases eq_or_lt_of_le (show n + 1 ≤ i from hi) with he | hlt
+    · -- `i = n+1`: the factor `(n+1-i)` vanishes.
+      rw [← he]; push_cast; ring
+    · -- `i > n+1`: the binomial `C(n+1,i)` vanishes.
+      rw [Nat.choose_eq_zero_of_lt hlt, Nat.cast_zero, zero_mul]
+
+/-! ## `eulerianExplicit` satisfies the Eulerian recurrence -/
+
+/-- **Upward collapse.** The "`i·C(n+1,i)`" sum (the defect between `S1` and `(k+2)·A`)
+collapses, via `absorb_up`, to `-(n+1)` times the row-`n` alternating sum `Σ`. -/
+private theorem x_collapse (n k : ℕ) :
+    (∑ i ∈ range (k + 1 + 1),
+        (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ) * ((i : ℤ) * ((k : ℤ) + 1 + 1 - i) ^ n))
+      + ((n : ℤ) + 1) *
+        (∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * (n.choose i : ℤ) * ((k : ℤ) + 1 - i) ^ n) = 0 := by
+  rw [Finset.sum_range_succ']
+  simp only [Nat.cast_zero, mul_zero, zero_mul, add_zero]
+  rw [Finset.mul_sum, ← Finset.sum_add_distrib]
+  apply Finset.sum_eq_zero
+  intro j _
+  have hcast : ((j + 1 : ℕ) : ℤ) = (j : ℤ) + 1 := by push_cast; ring
+  rw [hcast, show ((k : ℤ) + 1 + 1 - ((j : ℤ) + 1)) = ((k : ℤ) + 1 - j) from by ring]
+  linear_combination (-(-1 : ℤ) ^ j * ((k : ℤ) + 1 - (j : ℤ)) ^ n) * absorb_up n j
+
+/-- **Downward collapse.** The "`(n+1-i)·C(n+1,i)`" sum (the defect packaging `S2` and
+`(n-k)·B`) collapses, via `absorb_down`, to `(n+1)` times the same `Σ`. -/
+private theorem y_collapse (n k : ℕ) :
+    (∑ i ∈ range (k + 1),
+        (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ) * (((n : ℤ) + 1 - i) * ((k : ℤ) + 1 - i) ^ n))
+      = ((n : ℤ) + 1) *
+        (∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * (n.choose i : ℤ) * ((k : ℤ) + 1 - i) ^ n) := by
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  linear_combination ((-1 : ℤ) ^ i * ((k : ℤ) + 1 - (i : ℤ)) ^ n) * absorb_down n i
+
+/-- **The key recurrence.**  `eulerianExplicit` obeys the same triangle recurrence as the
+combinatorial Eulerian numbers:
+`eulerianExplicit (n+1) (k+1) = (k+2)·eulerianExplicit n (k+1) + (n-k)·eulerianExplicit n k`
+(with integer subtraction `n-k`). -/
+theorem eulerianExplicit_succ_succ (n k : ℕ) :
+    eulerianExplicit (n + 1) (k + 1)
+      = ((k : ℤ) + 2) * eulerianExplicit n (k + 1)
+        + ((n : ℤ) - k) * eulerianExplicit n k := by
+  -- Normalised forms of the three `eulerianExplicit` sums (bases `↑k+1+1` and `↑k+1`).
+  have hLHSe : eulerianExplicit (n + 1) (k + 1)
+      = ∑ i ∈ range (k + 1 + 1), (-1 : ℤ) ^ i * ((n + 1 + 1).choose i : ℤ)
+          * ((k : ℤ) + 1 + 1 - i) ^ (n + 1) := by
+    simp only [eulerianExplicit]; apply Finset.sum_congr rfl; intro i _; push_cast; ring
+  have hAe : eulerianExplicit n (k + 1)
+      = ∑ i ∈ range (k + 1 + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+          * ((k : ℤ) + 1 + 1 - i) ^ n := by
+    simp only [eulerianExplicit]; apply Finset.sum_congr rfl; intro i _; push_cast; ring
+  have hBe : eulerianExplicit n k
+      = ∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+          * ((k : ℤ) + 1 - i) ^ n := rfl
+  rw [hLHSe, hAe, hBe]
+  -- Abbreviations: `S1`, `S2`, `Sig` are auxiliary sums.
+  -- `S1 = (k+2)·A + (n+1)·Σ`  via the upward collapse.
+  have hS1 : (∑ i ∈ range (k + 1 + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+          * ((k : ℤ) + 1 + 1 - i) ^ (n + 1))
+      = ((k : ℤ) + 2) * (∑ i ∈ range (k + 1 + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+            * ((k : ℤ) + 1 + 1 - i) ^ n)
+        + ((n : ℤ) + 1) * (∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * (n.choose i : ℤ)
+            * ((k : ℤ) + 1 - i) ^ n) := by
+    have e1 : (∑ i ∈ range (k + 1 + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+              * ((k : ℤ) + 1 + 1 - i) ^ (n + 1))
+        - ((k : ℤ) + 2) * (∑ i ∈ range (k + 1 + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+              * ((k : ℤ) + 1 + 1 - i) ^ n)
+        + (∑ i ∈ range (k + 1 + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+              * ((i : ℤ) * ((k : ℤ) + 1 + 1 - i) ^ n)) = 0 := by
+      rw [Finset.mul_sum, ← Finset.sum_sub_distrib, ← Finset.sum_add_distrib]
+      apply Finset.sum_eq_zero
+      intro i _
+      rw [pow_succ]; ring
+    linear_combination e1 - x_collapse n k
+  -- `S2 = (n+1)·Σ - (n-k)·B`  via the downward collapse.
+  have hS2 : (∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+          * ((k : ℤ) + 1 - i) ^ (n + 1))
+      = ((n : ℤ) + 1) * (∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * (n.choose i : ℤ)
+            * ((k : ℤ) + 1 - i) ^ n)
+        - ((n : ℤ) - k) * (∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+            * ((k : ℤ) + 1 - i) ^ n) := by
+    have e2 : ((n : ℤ) - k) * (∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+              * ((k : ℤ) + 1 - i) ^ n)
+        + (∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+              * ((k : ℤ) + 1 - i) ^ (n + 1))
+        - (∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+              * (((n : ℤ) + 1 - i) * ((k : ℤ) + 1 - i) ^ n)) = 0 := by
+      rw [Finset.mul_sum, ← Finset.sum_add_distrib, ← Finset.sum_sub_distrib]
+      apply Finset.sum_eq_zero
+      intro i _
+      rw [pow_succ]; ring
+    linear_combination e2 + y_collapse n k
+  -- Pascal step: `LHS = S1 - S2`.
+  have hLHS : (∑ i ∈ range (k + 1 + 1), (-1 : ℤ) ^ i * ((n + 1 + 1).choose i : ℤ)
+          * ((k : ℤ) + 1 + 1 - i) ^ (n + 1))
+      = (∑ i ∈ range (k + 1 + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+            * ((k : ℤ) + 1 + 1 - i) ^ (n + 1))
+        - (∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+            * ((k : ℤ) + 1 - i) ^ (n + 1)) := by
+    have e3 : (∑ i ∈ range (k + 1 + 1), (-1 : ℤ) ^ i * ((n + 1 + 1).choose i : ℤ)
+              * ((k : ℤ) + 1 + 1 - i) ^ (n + 1))
+        - (∑ i ∈ range (k + 1 + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+              * ((k : ℤ) + 1 + 1 - i) ^ (n + 1))
+        + (∑ i ∈ range (k + 1), (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ)
+              * ((k : ℤ) + 1 - i) ^ (n + 1)) = 0 := by
+      rw [← Finset.sum_sub_distrib, Finset.sum_range_succ']
+      simp only [Nat.choose_zero_right, Nat.cast_one, sub_self, add_zero]
+      rw [← Finset.sum_add_distrib]
+      apply Finset.sum_eq_zero
+      intro j _
+      have hp : ((n + 1 + 1).choose (j + 1) : ℤ)
+          = ((n + 1).choose j : ℤ) + ((n + 1).choose (j + 1) : ℤ) := by
+        have h := Nat.choose_succ_succ (n + 1) j
+        exact_mod_cast h
+      have hcast : ((j + 1 : ℕ) : ℤ) = (j : ℤ) + 1 := by push_cast; ring
+      rw [hcast, show ((k : ℤ) + 1 + 1 - ((j : ℤ) + 1)) = ((k : ℤ) + 1 - j) from by ring, hp]
+      ring
+    linear_combination e3
+  linear_combination hLHS + hS1 - hS2
+
+/-- The `n = 0` row of the explicit form: `∑_{i=0}^{k+1} (-1)ⁱ·C(1,i) = 0`
+(the alternating sum of the binomials in row `1` past the first cancels). -/
+private theorem base_row_sum (k : ℕ) :
+    ∑ i ∈ range (k + 2), (-1 : ℤ) ^ i * (Nat.choose 1 i : ℤ) = 0 := by
+  induction k with
+  | zero => norm_num [Finset.sum_range_succ, Finset.sum_range_zero]
+  | succ k ih =>
+    rw [show k + 1 + 2 = k + 2 + 1 from rfl, Finset.sum_range_succ, ih,
+      Nat.choose_eq_zero_of_lt (by omega), Nat.cast_zero, mul_zero, add_zero]
+
+/-! ## Matching to the combinatorial definition -/
+
+/-- **The explicit closed form for the Eulerian numbers.**
+`⟨n,k⟩ = ∑_{i=0}^{k} (-1)ⁱ · C(n+1,i) · (k+1-i)ⁿ`. -/
+theorem eulerian_eq_explicit (n k : ℕ) :
+    (eulerian n k : ℤ) = eulerianExplicit n k := by
+  induction n generalizing k with
+  | zero =>
+    cases k with
+    | zero => simp [eulerianExplicit, eulerian]
+    | succ k =>
+      rw [eulerian_zero_succ, Nat.cast_zero]
+      symm
+      unfold eulerianExplicit
+      simp only [pow_zero, mul_one, Nat.zero_add]
+      exact base_row_sum k
+  | succ n ih =>
+    cases k with
+    | zero =>
+      rw [eulerian_succ_zero, Nat.cast_one]
+      simp [eulerianExplicit]
+    | succ k =>
+      rw [eulerian_succ_succ]
+      push_cast
+      rw [ih (k + 1), ih k]
+      have hbridge : ((n - k : ℕ) : ℤ) * eulerianExplicit n k
+          = ((n : ℤ) - k) * eulerianExplicit n k := by
+        rcases le_or_gt k n with hkn | hkn
+        · rw [Nat.cast_sub hkn]
+        · have hz : eulerianExplicit n k = 0 := by
+            rw [← ih k, eulerian_eq_zero_of_lt hkn, Nat.cast_zero]
+          rw [hz, mul_zero, mul_zero]
+      rw [hbridge, eulerianExplicit_succ_succ]
+
+end GeometricSeriesOQ07OQ01OQ01OQ01OQ02

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "GeometricSeriesOQ07OQ01OQ01OQ01"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ01OQ02",
+    "lineCount": 246,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Explicit Formula for the Eulerian Numbers: ⟨n,k⟩ = ∑ᵢ (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "explicit-formula",
+      "inclusion-exclusion",
+      "binomial-coefficients",
+      "finite-differences",
+      "descent-statistic",
+      "induction",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 246,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "eulerian_eq_explicit: THE MAIN RESULT — the classical closed form for the combinatorial Eulerian numbers built in the parent entry, ⟨n,k⟩ = ∑_{i=0}^{k} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ (an identity of integers). This is the explicit inclusion–exclusion formula that answers the general open question recorded by the sibling oq-01, which had only computed the low columns k = 0,1,2. Mathlib has neither the Eulerian numbers nor this formula, so both the statement and the proof are built here on top of the parent's eulerian triangle.",
+      "eulerianExplicit_succ_succ: the key recurrence — the alternating binomial sum eulerianExplicit obeys the very triangle recurrence that defines the Eulerian numbers, eulerianExplicit (n+1) (k+1) = (k+2)·eulerianExplicit n (k+1) + (n−k)·eulerianExplicit n k (over ℤ, with honest integer subtraction). Its proof is a finite-difference computation: split C(n+2,i) by Pascal's rule, reindex the shifted sum via Finset.sum_range_succ', and collapse the two defect sums with the absorption identities; the residual row-n sums cancel exactly.",
+      "absorb_up / absorb_down: the two binomial absorption identities over ℤ driving the collapse, C(n+1,j+1)·(j+1) = (n+1)·C(n,j) and C(n+1,i)·(n+1−i) = (n+1)·C(n,i). The downward identity is stated for all i (both sides vanishing for i > n) and is derived from the upward one by the symmetry C(n,n−i) = C(n,i), sidestepping any direct factorial manipulation; both are transferred to ℤ so the per-term collapse is closed by linear_combination without truncated subtraction.",
+      "base_row_sum: the n = 0 base row ∑_{i<k+2} (−1)ⁱ·C(1,i) = 0, the alternating sum that makes eulerianExplicit 0 (k+1) vanish (matching ⟨0,k+1⟩ = 0), proved by a short induction peeling the vanishing tail C(1,i) = 0 for i ≥ 2.",
+      "Matching argument: with the recurrence and base row in hand, a single induction on n identifies eulerianExplicit with the parent's combinatorial eulerian; the truncated natural subtraction (n−k : ℕ) of the Eulerian recurrence is reconciled with the integer (n−k : ℤ) of eulerianExplicit_succ_succ precisely on the diagonal-vanishing locus, using the parent's ⟨n,k⟩ = 0 for n < k."
+    ],
+    "prerequisites": [
+      "Parent: geometric-series-oq-07-oq-01-oq-01-oq-01 (the combinatorial Eulerian numbers) — supplies the eulerian triangle, its recurrence eulerian_succ_succ, the base values eulerian_zero_succ / eulerian_succ_zero, and the diagonal vanishing eulerian_eq_zero_of_lt reused here",
+      "Mathlib's Nat.choose with Pascal's rule (Nat.choose_succ_succ), the binomial absorption identity (Nat.add_one_mul_choose_eq), and the symmetry Nat.choose_symm, plus Nat.choose_eq_zero_of_lt for the degenerate range",
+      "Casting ℕ identities to ℤ (Nat.cast_sub, push_cast) so the alternating-sum manipulations carry honest integer subtraction and the per-term steps close by linear_combination",
+      "Finset reindexing: Finset.sum_range_succ', Finset.sum_add_distrib, Finset.sum_sub_distrib, Finset.mul_sum, Finset.sum_eq_zero"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.add_one_mul_choose_eq",
+        "description": "The binomial absorption identity (n+1)·C(n,k) = C(n+1,k+1)·(k+1). Cast to ℤ this is absorb_up, and via the symmetry C(n,n−i)=C(n,i) it also yields absorb_down; together they collapse the two defect sums to a common row-n alternating sum that cancels in eulerianExplicit_succ_succ.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule (n+1).choose (k+1) = n.choose k + n.choose (k+1). Used (over ℤ) to split C(n+2,j+1) into C(n+1,j) + C(n+1,j+1), the Pascal step that turns the order-(n+1) Eulerian sum into S1 − S2.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "The binomial symmetry n.choose (n−k) = n.choose k (for k ≤ n). Lets absorb_down be deduced from absorb_up by reflecting the index, avoiding a separate factorial computation.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Peels the first term of a range sum with an index shift, ∑_{i<n+1} f i = ∑_{i<n} f (i+1) + f 0. Drives the reindexing that exposes the vanishing i=0 boundary term in the Pascal step and in the upward collapse.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07OQ01OQ01OQ01.eulerian",
+        "description": "The parent's from-scratch combinatorial Eulerian-number triangle ⟨n,k⟩ with its recurrence eulerian_succ_succ and diagonal vanishing eulerian_eq_zero_of_lt. Reused verbatim so this entry only adds the explicit formula, not the underlying combinatorial object.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01",
+      "question": "Use the explicit formula to prove non-negativity and the descent interpretation directly: show ∑_{i=0}^{k} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ ≥ 0 and equals the number of permutations of {1,…,n} with exactly k descents, connecting the integer inclusion–exclusion count proved here to the surjection/cell-count combinatorial model.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02",
+      "question": "Derive the palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩ from the explicit formula by the substitution i ↦ n+1−i in the alternating sum, giving an analytic proof complementary to the coefficient-extraction proof of palindromy elsewhere in the Eulerian lineage.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent (the combinatorial Eulerian numbers). The parent defines the Eulerian-number triangle ⟨n,k⟩ from the recurrence and identifies it with the coefficients of the Eulerian polynomial. This entry proves the explicit inclusion–exclusion closed form ⟨n,k⟩ = ∑ᵢ (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ for those numbers, reusing the parent's eulerian, eulerian_succ_succ and eulerian_eq_zero_of_lt."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Sibling that answered the parent's row-sum open question and computed the low columns k = 0,1,2 of the Eulerian triangle, explicitly recording the GENERAL explicit formula as its follow-up open question. This entry settles that general case: the binomial recurrence W(n+1,k+1) = (k+2)·W n (k+1) + (n−k)·W n k it flagged is exactly eulerianExplicit_succ_succ proved here."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling under the same parent. oq-03 proves Worpitzky's identity nᵐ = ∑ⱼ ⟨m,j⟩·C(n+j,m) — the change of basis from powers to shifted binomials. The explicit formula proved here is the inverse direction (recovering each ⟨n,k⟩ as an alternating binomial sum of powers); the two are finite-difference duals."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers, the explicit formula, the descent statistic)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian-number triangle recurrence and the explicit closed form ⟨n,k⟩ = ∑_{i} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ used here."
+    },
+    {
+      "title": "Mathlib4: Data.Nat.Choose.Basic",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Pascal's rule (Nat.choose_succ_succ), the binomial absorption identity (Nat.add_one_mul_choose_eq), and the symmetry (Nat.choose_symm) powering the absorption lemmas absorb_up / absorb_down."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Building on the parent entry's from-scratch combinatorial Eulerian numbers ⟨n,k⟩, this entry proves their classical explicit (inclusion–exclusion) closed form as an identity of integers: ⟨n,k⟩ = ∑_{i=0}^{k} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ. This answers the general open question flagged by the sibling oq-01, which had only computed the columns k = 0,1,2. The strategy is to define the alternating binomial sum eulerianExplicit and show it satisfies the very triangle recurrence that defines the Eulerian numbers: eulerianExplicit_succ_succ proves eulerianExplicit (n+1)(k+1) = (k+2)·eulerianExplicit n (k+1) + (n−k)·eulerianExplicit n k by splitting C(n+2,i) with Pascal's rule, reindexing via Finset.sum_range_succ', and collapsing the two defect sums with the binomial absorption identities absorb_up [C(n+1,j+1)·(j+1) = (n+1)·C(n,j)] and absorb_down [C(n+1,i)·(n+1−i) = (n+1)·C(n,i)] — the leftover row-n sums cancel exactly. With the base row ∑_{i<k+2}(−1)ⁱ·C(1,i) = 0 in hand, a single induction on n matches eulerianExplicit to the parent's eulerian, the truncated subtraction (n−k : ℕ) being reconciled with the integer (n−k : ℤ) on the diagonal-vanishing locus via ⟨n,k⟩ = 0 for n < k. 246 lines, 4 theorems, 1 definition, 0 axioms, 0 sorries; everything depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The explicit formula gives each Eulerian number as a finite alternating sum of powers — the inverse change of basis to Worpitzky's identity (the sibling oq-03), which writes powers in the shifted-binomial basis. Concretely it is the (n+1)-st finite difference of the monomial tⁿ, and it makes manifest that the ⟨n,k⟩ are integers (and, with a sign argument, non-negative) even though they are defined by a recurrence. Because the proof needs only Pascal's rule, two absorption identities, and the parent's triangle, it is a reusable, Mathlib-free addition to the Eulerian-number theory developed in this gallery, and its reusable lemma eulerianExplicit_succ_succ supplies the binomial recurrence the sibling oq-01 left open.",
+    "openQuestions": [
+      "Use the explicit formula to prove non-negativity and the descent interpretation of ⟨n,k⟩ directly via inclusion–exclusion / surjection counting.",
+      "Derive the palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩ from the explicit formula by the substitution i ↦ n+1−i, an analytic complement to the coefficient-extraction proof."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Child of **geometric-series-oq-07-oq-01-oq-01-oq-01** (the combinatorial Eulerian numbers). It settles the **general explicit (inclusion–exclusion) closed form** for the Eulerian numbers ⟨n,k⟩ — the open question explicitly recorded by sibling PR #27389 (geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01), which proved only the row sum and the low columns k = 0,1,2:

> ⟨n,k⟩ = ∑_{i=0}^{k} (−1)ⁱ · C(n+1,i) · (k+1−i)ⁿ   (an identity of integers).

| Theorem | Statement |
|---|---|
| `eulerian_eq_explicit` | **THE MAIN RESULT** — `(⟨n,k⟩ : ℤ) = ∑_{i<k+1} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ` for all `n,k` |
| `eulerianExplicit_succ_succ` | the alternating sum obeys the Eulerian recurrence `(k+2)·E(n,k+1) + (n−k)·E(n,k)` — exactly the binomial recurrence #27389 flagged as its follow-up OQ |
| `absorb_up` | `C(n+1,j+1)·(j+1) = (n+1)·C(n,j)` (over ℤ) |
| `absorb_down` | `C(n+1,i)·(n+1−i) = (n+1)·C(n,i)` (over ℤ, all `i`) |

## Method

`eulerianExplicit n k` is defined as the alternating binomial sum over ℤ. The crux `eulerianExplicit_succ_succ` is a finite-difference computation: split `C(n+2,i)` by **Pascal's rule**, reindex the shifted sum via `Finset.sum_range_succ'`, and collapse the two defect sums with the **absorption identities** `absorb_up`/`absorb_down`; the residual row-`n` alternating sums cancel exactly. With the base row `∑_{i<k+2}(−1)ⁱ·C(1,i) = 0` in hand, a single induction on `n` matches `eulerianExplicit` to the parent's `eulerian`, the **truncated** subtraction `(n−k : ℕ)` being reconciled with the **integer** `(n−k : ℤ)` precisely on the diagonal-vanishing locus via the parent's `⟨n,k⟩ = 0` for `n < k`.

This is the inverse change-of-basis to Worpitzky's identity (sibling oq-03): the explicit formula is the `(n+1)`-st finite difference of `tⁿ`.

## Verification

- Docker build green (`Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ02`).
- 246 lines, 4 theorems, 1 definition, **0 axioms, 0 sorries**.
- `#print axioms eulerian_eq_explicit` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, `ofReduceBool`, or `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)