### PR TITLE
research(geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02): the infinite-limit recurrence ∑ kᵐ·xᵏ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2639,6 +2639,7 @@ import Proofs.GeometricSeriesOQ08
 import Proofs.GeometricSeriesOQ08OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01
+import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01OQ02
 import Proofs.GeometricSeriesOQ08OQ03
 import Proofs.GeometricSeriesOQ08OQ03OQ01
 import Proofs.GeometricSeriesOQ08OQ03OQ01OQ01

--- a/proofs/Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,188 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01
+
+/-
+# The infinite-limit recurrence: ∑_{k≥0} kᵐ·xᵏ for |x| < 1
+
+## What This Proves
+
+Fix a real ratio `x` with `|x| < 1`.  The **infinite m-th moment**
+
+  infMoment m x  :=  ∑_{k=0}^{∞} kᵐ·xᵏ
+
+(the convergent weighted geometric series) satisfies the single
+binomial-convolution recurrence
+
+  (1 − x) · infMoment m x  =  0ᵐ  +  x · ∑_{i=0}^{m−1} C(m,i) · infMoment i x.   (★∞)
+
+This is exactly the `n → ∞` limit of the finite master recurrence
+
+  (1 − x) · momentSum m n x  =  0ᵐ − nᵐ·xⁿ + x · ∑_{i<m} C(m,i) · momentSum i n x
+
+proved in the parent `geometric-series-oq-08-oq-01-oq-01-oq-01`: for `|x| < 1`
+the finite partial sums `momentSum m n x` converge to `infMoment m x`, while the
+boundary term `nᵐ·xⁿ` — being the general term of a convergent series — vanishes
+in the limit.  The boundary correction that the finite sum had to carry simply
+**washes out**, leaving the clean closed recurrence (★∞).
+
+## Why This Is the Right Statement
+
+Recurrence (★∞) is a *first-order-in-m convolution*: it expresses the `m`-th
+moment through **all** lower moments using the Pascal/binomial weights `C(m,i)`,
+with no derivatives and no special functions.  It is complementary to the two
+explicit closed forms already in the gallery:
+
+  * the **Stirling** form `geometric-series-oq-07-oq-01`
+    (`∑ nᵐrⁿ = ∑ₖ S(m,k)·k!·rᵏ/(1−r)^{k+1}`), and
+  * the **Frobenius / Eulerian-polynomial** form
+    `geometric-series-oq-07-oq-01-oq-01` (`= Aₘ(r)/(1−r)^{m+1}`).
+
+Those give `infMoment m` in one shot; (★∞) instead *characterises* the whole
+sequence `(infMoment m)ₘ` by a recursion, and is the cleanest bridge from the
+finite theory to the infinite one.  Solving (★∞) for small `m` recovers the
+gallery's explicit sums:
+
+  infMoment 0 x = 1/(1−x)
+  infMoment 1 x = x/(1−x)²            (the infinite arithmetico-geometric sum)
+  infMoment 2 x = x(1+x)/(1−x)³       (the infinite second moment ∑ k²xᵏ)
+
+## Why This Is Not Already in Mathlib
+
+Mathlib records summability of `∑ nᵏ rⁿ` (`summable_pow_mul_geometric_of_norm_lt_one`)
+and the value of the plain geometric series, but neither the moment sum `∑ kᵐxᵏ`
+as a named object nor any recurrence linking the infinite moments across `m`.
+
+## Proof Strategy
+
+1. **Summability.** `summable_pow_mul_geometric_of_norm_lt_one m (‖x‖<1)` gives
+   `Summable (fun k ↦ kᵐ·xᵏ)` for every `m`.
+2. **Convergence of partial sums.** `HasSum.tendsto_sum_nat` turns summability
+   into `momentSum m n x → infMoment m x` (the partial sums are exactly the
+   parent's `momentSum`).
+3. **Boundary vanishes.** `Summable.tendsto_atTop_zero` gives `nᵐ·xⁿ → 0`, since
+   that is the general term of the summable series of step 1.
+4. **Pass to the limit.** Both sides of the parent's finite recurrence are
+   sequences in `n`; taking `n → ∞` (LHS by continuity of `(1−x)·•`, RHS by
+   linearity of limits over the finite inner sum) and using uniqueness of limits
+   yields (★∞).
+5. **Specialisations** solve (★∞) at `m = 0, 1, 2`, recovering the gallery's
+   explicit closed forms.
+
+All results depend only on `propext`, `Classical.choice`, `Quot.sound`.
+-/
+
+namespace GeometricSeriesOQ08OQ01OQ01OQ01OQ02
+
+open Finset Filter Topology
+open GeometricSeriesOQ08OQ01OQ01OQ01 (momentSum momentSum_recurrence)
+
+/-- The **infinite m-th moment** `∑_{k=0}^{∞} kᵐ·xᵏ` of a real geometric series. -/
+noncomputable def infMoment (m : ℕ) (x : ℝ) : ℝ :=
+  ∑' k : ℕ, (k : ℝ) ^ m * x ^ k
+
+/-- For `|x| < 1`, every moment series `∑ kᵐ·xᵏ` is summable. -/
+theorem summable_moment (m : ℕ) {x : ℝ} (hx : |x| < 1) :
+    Summable (fun k : ℕ => (k : ℝ) ^ m * x ^ k) :=
+  summable_pow_mul_geometric_of_norm_lt_one m (by rwa [Real.norm_eq_abs])
+
+/-- The finite moment sums converge to the infinite moment:
+`momentSum m n x → infMoment m x` as `n → ∞` (for `|x| < 1`). -/
+theorem tendsto_momentSum (m : ℕ) {x : ℝ} (hx : |x| < 1) :
+    Tendsto (fun n => momentSum m n x) atTop (𝓝 (infMoment m x)) := by
+  simpa only [momentSum, infMoment] using (summable_moment m hx).hasSum.tendsto_sum_nat
+
+/-- The boundary term of the finite recurrence vanishes in the limit:
+`nᵐ·xⁿ → 0` as `n → ∞` (it is the general term of a convergent series). -/
+theorem tendsto_boundary (m : ℕ) {x : ℝ} (hx : |x| < 1) :
+    Tendsto (fun n : ℕ => (n : ℝ) ^ m * x ^ n) atTop (𝓝 0) :=
+  (summable_moment m hx).tendsto_atTop_zero
+
+/-- **Master infinite recurrence (★∞).** For `|x| < 1`, over the reals,
+
+  `(1 − x)·infMoment m x = 0ᵐ + x·∑_{i<m} C(m,i)·infMoment i x`.
+
+This is the `n → ∞` limit of the parent's finite recurrence: the boundary term
+`nᵐ·xⁿ` vanishes, leaving a clean binomial-convolution recursion that expresses
+the `m`-th infinite moment through all lower moments. -/
+theorem infMoment_recurrence (m : ℕ) {x : ℝ} (hx : |x| < 1) :
+    (1 - x) * infMoment m x
+      = (0 : ℝ) ^ m + x * ∑ i ∈ Finset.range m, (m.choose i : ℝ) * infMoment i x := by
+  -- The two sides of the finite recurrence agree term-by-term.
+  have hEq : ∀ n, (1 - x) * momentSum m n x
+      = (0 : ℝ) ^ m - (n : ℝ) ^ m * x ^ n
+        + x * ∑ i ∈ Finset.range m, (m.choose i : ℝ) * momentSum i n x :=
+    fun n => momentSum_recurrence m n x
+  -- LHS: `(1 − x)·momentSum m n x → (1 − x)·infMoment m x`.
+  have hL : Tendsto (fun n => (1 - x) * momentSum m n x) atTop
+      (𝓝 ((1 - x) * infMoment m x)) :=
+    (tendsto_momentSum m hx).const_mul (1 - x)
+  -- The inner finite sum converges term-by-term.
+  have hInner : Tendsto
+      (fun n => ∑ i ∈ Finset.range m, (m.choose i : ℝ) * momentSum i n x) atTop
+      (𝓝 (∑ i ∈ Finset.range m, (m.choose i : ℝ) * infMoment i x)) :=
+    tendsto_finset_sum _ fun i _ => (tendsto_momentSum i hx).const_mul _
+  -- RHS converges to `0ᵐ − 0 + x·∑ C(m,i)·infMoment i x`.
+  have hR : Tendsto
+      (fun n : ℕ => (0 : ℝ) ^ m - (n : ℝ) ^ m * x ^ n
+        + x * ∑ i ∈ Finset.range m, (m.choose i : ℝ) * momentSum i n x) atTop
+      (𝓝 ((0 : ℝ) ^ m - 0
+        + x * ∑ i ∈ Finset.range m, (m.choose i : ℝ) * infMoment i x)) :=
+    ((tendsto_const_nhds.sub (tendsto_boundary m hx)).add (hInner.const_mul x))
+  rw [sub_zero] at hR
+  -- LHS and RHS are the same sequence, so their limits agree.
+  exact tendsto_nhds_unique hL (hR.congr fun n => (hEq n).symm)
+
+/-- For `m ≥ 1` the `0ᵐ` term drops, leaving the pure convolution recurrence
+`(1 − x)·infMoment (m+1) x = x·∑_{i≤m} C(m+1,i)·infMoment i x`. -/
+theorem infMoment_recurrence_succ (m : ℕ) {x : ℝ} (hx : |x| < 1) :
+    (1 - x) * infMoment (m + 1) x
+      = x * ∑ i ∈ Finset.range (m + 1), ((m + 1).choose i : ℝ) * infMoment i x := by
+  have h := infMoment_recurrence (m + 1) hx
+  simpa using h
+
+/-- Solving (★∞) at `m = 0`: `infMoment 0 x = 1/(1 − x)` (the plain geometric
+series), recovered from the recurrence (its `0⁰ = 1` constant term). -/
+theorem infMoment_zero {x : ℝ} (hx : |x| < 1) :
+    infMoment 0 x = (1 - x)⁻¹ := by
+  have hne : (1 - x) ≠ 0 := by
+    have : x < 1 := (abs_lt.mp hx).2
+    linarith
+  have h := infMoment_recurrence 0 hx
+  simp only [pow_zero, Finset.range_zero, Finset.sum_empty, mul_zero, add_zero] at h
+  field_simp at h ⊢
+  linarith [h]
+
+/-- Solving (★∞) at `m = 1`: `infMoment 1 x = x/(1 − x)²`, the infinite
+arithmetico-geometric sum `∑ k·xᵏ` (gallery `geometric-series-oq-08-oq-01`). -/
+theorem infMoment_one {x : ℝ} (hx : |x| < 1) :
+    infMoment 1 x = x / (1 - x) ^ 2 := by
+  have hne : (1 - x) ≠ 0 := by
+    have : x < 1 := (abs_lt.mp hx).2
+    linarith
+  have h := infMoment_recurrence 1 hx
+  simp only [pow_one, Finset.range_one, Finset.sum_singleton,
+    Nat.cast_one, one_mul, Nat.choose_zero_right] at h
+  rw [infMoment_zero hx] at h
+  field_simp at h ⊢
+  linarith [h]
+
+/-- Solving (★∞) at `m = 2`: `infMoment 2 x = x(1 + x)/(1 − x)³`, the infinite
+second moment `∑ k²·xᵏ` (gallery `geometric-series-oq-08-oq-01-oq-01`). -/
+theorem infMoment_two {x : ℝ} (hx : |x| < 1) :
+    infMoment 2 x = x * (1 + x) / (1 - x) ^ 3 := by
+  have hne : (1 - x) ≠ 0 := by
+    have : x < 1 := (abs_lt.mp hx).2
+    linarith
+  have h := infMoment_recurrence 2 hx
+  rw [Finset.sum_range_succ, Finset.sum_range_one] at h
+  simp only [Nat.choose_zero_right, Nat.choose_one_right, Nat.cast_ofNat, Nat.cast_one,
+    one_mul] at h
+  rw [infMoment_zero hx, infMoment_one hx] at h
+  have hpow : (0 : ℝ) ^ 2 = 0 := by norm_num
+  rw [hpow] at h
+  field_simp at h ⊢
+  ring_nf at h ⊢
+  linarith [h]
+
+end GeometricSeriesOQ08OQ01OQ01OQ01OQ02

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02",
+  "slug": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic",
+      "Proofs.GeometricSeriesOQ08OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "GeometricSeriesOQ08OQ01OQ01OQ01OQ02",
+    "lineCount": 188,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Infinite-Limit Recurrence: ∑_{k≥0} kᵐ·xᵏ for |x| < 1",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "arithmetico-geometric",
+      "infinite-series",
+      "moments",
+      "recurrence",
+      "summability",
+      "tsum",
+      "eulerian",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 188,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "infMoment: the infinite m-th moment ∑'_{k} (k:ℝ)ᵐ·xᵏ of a real geometric series, defined as a tsum, the convergent companion of the parent's finite momentSum.",
+      "infMoment_recurrence: the master infinite recurrence (★∞) (1 − x)·infMoment m x = 0ᵐ + x·∑_{i<m} C(m,i)·infMoment i x for |x| < 1. It is obtained as the n → ∞ limit of the parent's finite recurrence (★): the finite partial sums momentSum m n x converge to infMoment m x, the boundary term nᵐ·xⁿ — the general term of a convergent series — vanishes, and uniqueness of limits yields the clean binomial-convolution recursion. A first-order-in-m convolution expressing the m-th infinite moment through ALL lower moments using only the Pascal weights C(m,i), with no derivatives and no special functions.",
+      "tendsto_momentSum: the convergence momentSum m n x → infMoment m x as n → ∞ (from summability via HasSum.tendsto_sum_nat) — the bridge from the finite to the infinite theory.",
+      "tendsto_boundary: the vanishing of the finite recurrence's boundary term, nᵐ·xⁿ → 0, proved structurally as Summable.tendsto_atTop_zero (it is the general term of the summable moment series), NOT via a separate polynomial-times-geometric estimate.",
+      "summable_moment: summability of ∑ kᵐ·xᵏ for |x| < 1, from Mathlib's summable_pow_mul_geometric_of_norm_lt_one.",
+      "infMoment_recurrence_succ: the m ≥ 1 form (1 − x)·infMoment (m+1) x = x·∑_{i≤m} C(m+1,i)·infMoment i x, with the 0ᵐ constant term dropped.",
+      "infMoment_zero / _one / _two: solving (★∞) at m = 0, 1, 2 recovers the gallery's explicit closed forms — infMoment 0 x = 1/(1 − x); infMoment 1 x = x/(1 − x)² (the infinite arithmetico-geometric sum); infMoment 2 x = x(1 + x)/(1 − x)³ (the infinite second moment ∑ k²·xᵏ)."
+    ],
+    "prerequisites": [
+      "summable_pow_mul_geometric_of_norm_lt_one for summability of ∑ kᵐ·xᵏ when ‖x‖ < 1",
+      "HasSum.tendsto_sum_nat to convert summability into convergence of the partial sums momentSum m n x",
+      "Summable.tendsto_atTop_zero for the vanishing of the boundary term nᵐ·xⁿ",
+      "tendsto_finset_sum and Tendsto.const_mul for passing the finite inner sum and the (1 − x)·• factor through the limit",
+      "tendsto_nhds_unique to equate the two limits of the parent's finite recurrence",
+      "Parent: geometric-series-oq-08-oq-01-oq-01-oq-01 (the finite master recurrence (★) for momentSum m n x)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "summable_pow_mul_geometric_of_norm_lt_one",
+        "description": "Summable (fun n ↦ (n:R)ᵏ·rⁿ) when ‖r‖ < 1. Supplies summability of every moment series ∑ kᵐ·xᵏ, which drives both the convergence of the partial sums and the vanishing of the boundary term.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "HasSum.tendsto_sum_nat",
+        "description": "A summable series' partial sums ∑_{k<n} f k tend to its tsum. Turns summability into momentSum m n x → infMoment m x.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "Summable.tendsto_atTop_zero",
+        "description": "The general term of a summable series tends to 0. Gives nᵐ·xⁿ → 0 directly, without a polynomial-times-geometric decay estimate.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "tendsto_nhds_unique",
+        "description": "Limits in a Hausdorff space are unique. Equates the two limits of the parent's finite recurrence (the same sequence in n) to produce (★∞).",
+        "module": "Mathlib.Topology.Separation.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+      "question": "Solve the infinite recurrence (★∞) in closed form to re-derive the Eulerian-polynomial numerator: prove by strong induction on m that infMoment m x = Aₘ(x)/(1 − x)^{m+1} with Aₘ the gallery's eulerPoly (geometric-series-oq-07-oq-01-oq-01), purely from (★∞) and the Eulerian recurrence Aₘ₊₁ = (1 + mx)Aₘ + x(1−x)Aₘ', closing the loop between the convolution recurrence here and the Frobenius identity.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-08-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent. The parent proves the finite master recurrence (★) for momentSum m n x over any commutative ring; this entry passes it to the n → ∞ limit for |x| < 1, where the boundary term nᵐ·xⁿ vanishes, yielding the clean infinite convolution recurrence (★∞) for infMoment m x = ∑'_{k} kᵐ·xᵏ."
+    },
+    {
+      "targetId": "geometric-series-oq-08-oq-01",
+      "relationship": "extends",
+      "description": "Ancestor (m = 1). Its infinite first moment x/(1 − x)² is recovered here as infMoment_one, solved directly from (★∞)."
+    },
+    {
+      "targetId": "geometric-series-oq-08-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Ancestor (m = 2). Its second moment x(1 + x)/(1 − x)³ is recovered here as infMoment_two, solved from (★∞) using infMoment_zero and infMoment_one."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01",
+      "relationship": "sibling",
+      "description": "Records the same infinite all-orders moment ∑'_{n} nᵐ·rⁿ in explicit Stirling form ∑_k S(m,k)·k!·rᵏ/(1 − r)^{k+1}. This entry instead characterises the whole sequence (infMoment m)ₘ by a binomial-convolution recurrence rather than a one-shot closed form."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Defines the Eulerian polynomial eulerPoly and proves infMoment m x = eulerPoly m (x)/(1 − x)^{m+1} (Frobenius). The recurrence (★∞) here is the complementary, derivative-free recursion for the same moments; the open question proposes closing the loop between the two."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (weighted geometric sums ∑ kᵐ·xᵏ, generating functions, Eulerian numbers)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the moment sums ∑ kᵐ·xᵏ, their rational closed forms with Eulerian-polynomial numerators, and the perturbation/recurrence methods used to derive them."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed (summable_pow_mul_geometric_of_norm_lt_one) and Topology.Algebra.InfiniteSum (HasSum.tendsto_sum_nat, Summable.tendsto_atTop_zero)",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Provides summability of ∑ kᵐ·xᵏ and the limit infrastructure; neither the moment sum as a named object nor any recurrence across m for the infinite moments is in Mathlib."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For a real ratio x with |x| < 1, the infinite m-th moment infMoment m x = ∑'_{k} kᵐ·xᵏ satisfies the binomial-convolution recurrence (1 − x)·infMoment m x = 0ᵐ + x·∑_{i<m} C(m,i)·infMoment i x. It is the n → ∞ limit of the parent's finite master recurrence: the finite partial sums converge to the infinite moment and the boundary term nᵐ·xⁿ — the general term of a convergent series — vanishes, so the boundary correction the finite sum had to carry simply washes out. Solving the recurrence at m = 0, 1, 2 recovers the gallery's explicit closed forms 1/(1 − x), x/(1 − x)², and x(1 + x)/(1 − x)³. 188 lines, 8 theorems, 1 definition, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The recurrence (★∞) characterises the entire sequence of infinite moments (infMoment m)ₘ by a first-order-in-m convolution with Pascal weights, with no derivatives and no special functions — a recursion complementary to the gallery's two explicit one-shot closed forms (the Stirling form in geometric-series-oq-07-oq-01 and the Frobenius/Eulerian form in geometric-series-oq-07-oq-01-oq-01). It also shows cleanly how the finite theory's n-dependent boundary term nᵐ·xⁿ disappears under |x| < 1, so the infinite recurrence is genuinely simpler than its finite parent. Such moment sums compute the moments of geometric and negative-binomial distributions and the coefficients of rational generating functions.",
+    "openQuestions": [
+      "Solve (★∞) in closed form to re-derive infMoment m x = eulerPoly m (x)/(1 − x)^{m+1}, closing the loop between this convolution recurrence and the Frobenius/Eulerian identity (geometric-series-oq-07-oq-01-oq-01)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up (depth) to the merged parent **geometric-series-oq-08-oq-01-oq-01-oq-01** (PR #27386), which proved the *finite* m-th moment master recurrence (★) over any commutative ring. This entry passes (★) to the **n → ∞ limit** for `|x| < 1`.

For a real ratio `x` with `|x| < 1`, define the infinite m-th moment `infMoment m x := ∑'_k (k:ℝ)ᵐ·xᵏ`. Then:

```
(1 − x)·infMoment m x = 0ᵐ + x·∑_{i<m} C(m,i)·infMoment i x.   (★∞)
```

The finite partial sums `momentSum m n x` converge to `infMoment m x`, and the boundary term `nᵐ·xⁿ` — being the **general term of a convergent series** — vanishes (`Summable.tendsto_atTop_zero`). The boundary correction the finite sum had to carry simply washes out, leaving a clean binomial-convolution recursion: it expresses the m-th infinite moment through **all** lower moments using only the Pascal weights `C(m,i)`, with no derivatives and no special functions.

Solving (★∞) recovers the gallery's explicit closed forms:
- `infMoment 0 x = 1/(1 − x)`
- `infMoment 1 x = x/(1 − x)²`   (infinite arithmetico-geometric sum)
- `infMoment 2 x = x(1 + x)/(1 − x)³`   (infinite second moment ∑ k²xᵏ)

It is complementary to the gallery's two one-shot closed forms: the Stirling form (oq-07-oq-01) and the Frobenius/Eulerian-polynomial form (oq-07-oq-01-oq-01).

## Verification
- `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ08OQ01OQ01OQ01OQ02` → builds, 3059 jobs, **0 errors, 0 warnings**.
- 188 lines, 8 theorems, 1 definition, **0 axioms, 0 sorries**. Each result depends only on `propext`, `Classical.choice`, `Quot.sound`.

## Note on slug
The parent reserved its `oq-01` child for a *different* question (the finite closed form Aₘ(x)−xⁿBₘ(n,x)), still open. This infinite-limit result is a distinct follow-up, shipped under a fresh sibling slug `oq-02` to keep the gallery graph honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)