### PR TITLE
research(cauchy-schwarz-oq-02-oq-04-oq-01): Buzano's inequality via reflection isometry [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -509,6 +509,7 @@ import Proofs.CauchySchwarzOQ02OQ02OQ01
 import Proofs.CauchySchwarzOQ02OQ02OQ01OQ01
 import Proofs.CauchySchwarzOQ02OQ03
 import Proofs.CauchySchwarzOQ02OQ04
+import Proofs.CauchySchwarzOQ02OQ04OQ01
 import Proofs.CauchySchwarzOQ03
 import Proofs.CauchySchwarzOQ03OQ01
 import Proofs.CauchySchwarzOQ03OQ02

--- a/proofs/Proofs/CauchySchwarzOQ02OQ04OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ02OQ04OQ01.lean
@@ -1,0 +1,155 @@
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Tactic
+
+/-
+# Cauchy-Schwarz OQ-02 → OQ-04 → OQ-01: Buzano's Inequality
+
+## Overview
+
+The Cauchy-Schwarz inequality `‖⟪x, y⟫‖ ≤ ‖x‖ * ‖y‖` bounds a single inner product.
+Buzano's inequality (M. L. Buzano, 1974) is a genuine *strengthening* that bounds the
+product of two inner products against a fixed unit vector `e`:
+
+      ‖⟪x, e⟫‖ * ‖⟪e, y⟫‖ ≤ (‖x‖ * ‖y‖ + ‖⟪x, y⟫‖) / 2          (‖e‖ = 1).
+
+Cauchy-Schwarz is the special case `e = x / ‖x‖` (proved here as
+`buzano_recovers_cauchy_schwarz`), so Buzano is strictly more general.
+
+This file develops Buzano's inequality on an inner product space over `𝕜 = ℝ` or `ℂ`
+(`RCLike`), as a follow-up to the operator-norm / Kadison–Schwarz material in
+`CauchySchwarzOQ02OQ04`.  The proof is elementary and self-contained, resting on a
+single geometric idea:
+
+  * **Reflection.**  For a unit vector `e`, the map `y ↦ 2⟪e, y⟫ • e - y` is the
+    reflection of `y` through the line `span e`.  It is an *isometry*
+    (`reflection_isometry`), so applying Cauchy-Schwarz to `⟪x, 2⟪e, y⟫ • e - y⟫`
+    bounds `‖2⟪x, e⟫⟪e, y⟫ - ⟪x, y⟫‖` by `‖x‖ * ‖y‖`.  The triangle inequality then
+    isolates `2‖⟪x, e⟫‖ * ‖⟪e, y⟫‖`.
+
+Buzano's inequality is not in Mathlib.
+
+## Main Results (7 theorems, 0 definitions, 0 sorries)
+
+1. `inner_reflection_eq`   — ⟪x, 2⟪e,y⟫•e - y⟫ = 2⟪x,e⟫⟪e,y⟫ - ⟪x,y⟫ (algebraic)
+2. `reflection_isometry`   — ‖2⟪e,y⟫•e - y‖ = ‖y‖ for a unit vector `e`
+3. `buzano_inner_bound`    — ‖2⟪x,e⟫⟪e,y⟫ - ⟪x,y⟫‖ ≤ ‖x‖‖y‖
+4. `buzano_inequality`     — 2‖⟪x,e⟫‖‖⟪e,y⟫‖ ≤ ‖x‖‖y‖ + ‖⟪x,y⟫‖
+5. `buzano_inequality_div` — ‖⟪x,e⟫‖‖⟪e,y⟫‖ ≤ (‖x‖‖y‖ + ‖⟪x,y⟫‖)/2
+6. `buzano_self`           — ‖⟪x,e⟫‖ ≤ ‖x‖ (Cauchy-Schwarz against a unit `e`)
+7. `buzano_recovers_cauchy_schwarz` — Buzano ⟹ ‖⟪x,y⟫‖ ≤ ‖x‖‖y‖ (general CS)
+-/
+
+noncomputable section
+
+open RCLike ComplexConjugate
+
+namespace CauchySchwarzBuzano
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+local notation "⟪" x ", " y "⟫" => @inner 𝕜 _ _ x y
+
+/-- **Reflection identity.**  Expanding the inner product against the reflected
+vector `2⟪e, y⟫ • e - y` produces the combination that drives Buzano's inequality.
+This step is purely algebraic (sesquilinearity); no unit-vector hypothesis is needed. -/
+theorem inner_reflection_eq (x e y : E) :
+    ⟪x, (2 * ⟪e, y⟫) • e - y⟫ = 2 * ⟪x, e⟫ * ⟪e, y⟫ - ⟪x, y⟫ := by
+  rw [inner_sub_right, inner_smul_right]
+  ring
+
+/-- **Reflection is an isometry.**  For a unit vector `e`, the reflection of `y`
+through the line `span e`, namely `2⟪e, y⟫ • e - y`, has the same norm as `y`.
+
+The proof computes `‖2⟪e, y⟫ • e - y‖²` via the polarization formula `norm_sub_sq`;
+the cross term `2 · re⟪2⟪e, y⟫ • e, y⟫` cancels exactly with `‖2⟪e, y⟫ • e‖²`. -/
+theorem reflection_isometry {e : E} (he : ‖e‖ = 1) (y : E) :
+    ‖(2 * ⟪e, y⟫) • e - y‖ = ‖y‖ := by
+  -- The cross term `re ⟪2⟪e,y⟫ • e, y⟫` equals `2‖⟪e,y⟫‖²`.
+  have hcross : re ⟪(2 * ⟪e, y⟫) • e, y⟫ = 2 * ‖⟪e, y⟫‖ ^ 2 := by
+    rw [inner_smul_left, map_mul (starRingEnd 𝕜), mul_assoc, RCLike.conj_mul]
+    simp only [RCLike.conj_ofNat, pow_two, RCLike.mul_re, RCLike.ofReal_re,
+      RCLike.ofReal_im, RCLike.ofNat_re, RCLike.ofNat_im, mul_zero, zero_mul, sub_zero]
+  -- Reduce the norm equality to the equality of squares.
+  rw [← Real.sqrt_sq (norm_nonneg ((2 * ⟪e, y⟫) • e - y)), ← Real.sqrt_sq (norm_nonneg y)]
+  congr 1
+  rw [norm_sub_sq (𝕜 := 𝕜), norm_smul, he, hcross, norm_mul, RCLike.norm_ofNat]
+  ring
+
+/-- **Reflected Cauchy-Schwarz bound.**  Applying Cauchy-Schwarz to `x` and the
+reflection of `y`, then using that the reflection preserves norm, bounds the
+key combination by `‖x‖ * ‖y‖`. -/
+theorem buzano_inner_bound {e : E} (he : ‖e‖ = 1) (x y : E) :
+    ‖2 * ⟪x, e⟫ * ⟪e, y⟫ - ⟪x, y⟫‖ ≤ ‖x‖ * ‖y‖ := by
+  rw [← inner_reflection_eq]
+  calc ‖⟪x, (2 * ⟪e, y⟫) • e - y⟫‖
+      ≤ ‖x‖ * ‖(2 * ⟪e, y⟫) • e - y‖ := norm_inner_le_norm _ _
+    _ = ‖x‖ * ‖y‖ := by rw [reflection_isometry he]
+
+/-- **Buzano's inequality.**  For a unit vector `e`,
+
+      2 ‖⟪x, e⟫‖ ‖⟪e, y⟫‖ ≤ ‖x‖ ‖y‖ + ‖⟪x, y⟫‖.
+
+The triangle inequality splits `2⟪x, e⟫⟪e, y⟫` off the bounded combination
+`2⟪x, e⟫⟪e, y⟫ - ⟪x, y⟫` from `buzano_inner_bound`. -/
+theorem buzano_inequality {e : E} (he : ‖e‖ = 1) (x y : E) :
+    2 * ‖⟪x, e⟫‖ * ‖⟪e, y⟫‖ ≤ ‖x‖ * ‖y‖ + ‖⟪x, y⟫‖ := by
+  have hb := buzano_inner_bound (𝕜 := 𝕜) he x y
+  have htri := norm_sub_norm_le (2 * ⟪x, e⟫ * ⟪e, y⟫) (⟪x, y⟫ : 𝕜)
+  have hnorm : ‖2 * ⟪x, e⟫ * ⟪e, y⟫‖ = 2 * ‖⟪x, e⟫‖ * ‖⟪e, y⟫‖ := by
+    rw [norm_mul, norm_mul, RCLike.norm_ofNat]
+  rw [hnorm] at htri
+  linarith
+
+/-- **Buzano's inequality, halved form.**  The product of the two inner products is
+bounded by the average of `‖x‖ ‖y‖` and `‖⟪x, y⟫‖`. -/
+theorem buzano_inequality_div {e : E} (he : ‖e‖ = 1) (x y : E) :
+    ‖⟪x, e⟫‖ * ‖⟪e, y⟫‖ ≤ (‖x‖ * ‖y‖ + ‖⟪x, y⟫‖) / 2 := by
+  have h := buzano_inequality (𝕜 := 𝕜) he x y
+  linarith
+
+/-- **Self / consistency form.**  Taking `y = x` in Buzano recovers Cauchy-Schwarz
+against the unit vector `e`: `‖⟪x, e⟫‖ ≤ ‖x‖`. -/
+theorem buzano_self {e : E} (he : ‖e‖ = 1) (x : E) :
+    ‖⟪x, e⟫‖ ≤ ‖x‖ := by
+  have h := buzano_inequality (𝕜 := 𝕜) he x x
+  have hsymm : ‖⟪e, x⟫‖ = ‖⟪x, e⟫‖ := by
+    rw [← RCLike.norm_conj, inner_conj_symm]
+  have hxx : ‖⟪x, x⟫‖ = ‖x‖ ^ 2 := by
+    rw [inner_self_eq_norm_sq_to_K, norm_pow, RCLike.norm_ofReal,
+      abs_of_nonneg (norm_nonneg x)]
+  rw [hsymm, hxx] at h
+  nlinarith [h, norm_nonneg (⟪x, e⟫ : 𝕜), norm_nonneg x]
+
+/-- **Buzano recovers Cauchy-Schwarz.**  Choosing the unit vector `e = ‖x‖⁻¹ • x`
+collapses Buzano's inequality to the classical Cauchy-Schwarz inequality
+`‖⟪x, y⟫‖ ≤ ‖x‖ ‖y‖`, witnessing that Buzano is a strict generalization. -/
+theorem buzano_recovers_cauchy_schwarz (x y : E) (hx : x ≠ 0) :
+    ‖⟪x, y⟫‖ ≤ ‖x‖ * ‖y‖ := by
+  have hxpos : (0 : ℝ) < ‖x‖ := norm_pos_iff.mpr hx
+  have hne : ‖x‖ ≠ 0 := hxpos.ne'
+  set c : 𝕜 := ((‖x‖⁻¹ : ℝ) : 𝕜) with hc
+  set e : E := c • x with he_def
+  have hcnorm : ‖c‖ = ‖x‖⁻¹ := by
+    rw [hc, RCLike.norm_ofReal, abs_of_nonneg (by positivity)]
+  have he : ‖e‖ = 1 := by
+    rw [he_def, norm_smul, hcnorm]
+    exact inv_mul_cancel₀ hne
+  -- ⟪x, e⟫ = ‖x‖ (as a real coercion)
+  have hxe : ⟪x, e⟫ = ((‖x‖ : ℝ) : 𝕜) := by
+    rw [he_def, inner_smul_right, hc, inner_self_eq_norm_sq_to_K, ← RCLike.ofReal_pow,
+      ← RCLike.ofReal_mul]
+    congr 1
+    rw [pow_two, ← mul_assoc, inv_mul_cancel₀ hne, one_mul]
+  -- ⟪e, y⟫ = c * ⟪x, y⟫
+  have hey : ⟪e, y⟫ = c * ⟪x, y⟫ := by
+    rw [he_def, inner_smul_left, hc, RCLike.conj_ofReal]
+  have h := buzano_inequality (𝕜 := 𝕜) he x y
+  rw [hxe, hey, RCLike.norm_ofReal, abs_of_nonneg hxpos.le, norm_mul, hcnorm] at h
+  have key : 2 * ‖x‖ * (‖x‖⁻¹ * ‖⟪x, y⟫‖) = 2 * ‖⟪x, y⟫‖ := by
+    rw [show 2 * ‖x‖ * (‖x‖⁻¹ * ‖⟪x, y⟫‖) = 2 * ‖⟪x, y⟫‖ * (‖x‖ * ‖x‖⁻¹) by ring,
+      mul_inv_cancel₀ hne, mul_one]
+  rw [key] at h
+  linarith
+
+end CauchySchwarzBuzano

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-01/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "csq020401-ann-01",
+    "proofId": "cauchy-schwarz-oq-02-oq-04-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 78
+    },
+    "type": "concept",
+    "title": "The Reflection Through span(e) Is an Isometry",
+    "content": "`reflection_isometry` is the geometric heart of the proof: for a unit vector e, the map R(y) = 2⟪e, y⟫·e − y reflects y through the line span(e), and reflections preserve length, so ‖R(y)‖ = ‖y‖. The Lean proof reduces the norm equality to an equality of squares (via `Real.sqrt_sq`) and expands ‖2⟪e, y⟫·e − y‖² with the polarization identity `norm_sub_sq`. The two e-dependent pieces cancel exactly: ‖2⟪e, y⟫·e‖² = 4‖⟪e, y⟫‖² and the cross term 2·re⟪2⟪e, y⟫·e, y⟫ = 4‖⟪e, y⟫‖², where the cross-term value comes from RCLike.conj_mul (conj z·z = ‖z‖²) after distributing the conjugate over the product.",
+    "mathContext": "$\\|2\\langle e,y\\rangle e - y\\|^2 = 4\\|\\langle e,y\\rangle\\|^2 - 2\\,\\mathrm{re}\\,\\overline{2\\langle e,y\\rangle}\\langle e,y\\rangle + \\|y\\|^2 = 4\\|\\langle e,y\\rangle\\|^2 - 4\\|\\langle e,y\\rangle\\|^2 + \\|y\\|^2 = \\|y\\|^2.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "reflection / Householder transformation",
+      "polarization identity",
+      "isometry",
+      "rank-one projection 2P − I"
+    ],
+    "prerequisites": [
+      "norm_sub_sq polarization identity",
+      "RCLike.conj_mul: conj z · z = ‖z‖²",
+      "sesquilinearity of the inner product"
+    ]
+  },
+  {
+    "id": "csq020401-ann-02",
+    "proofId": "cauchy-schwarz-oq-02-oq-04-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 88
+    },
+    "type": "technique",
+    "title": "Cauchy-Schwarz Against the Reflected Vector",
+    "content": "`buzano_inner_bound` pairs x against R(y) = 2⟪e, y⟫·e − y. Sesquilinearity (`inner_reflection_eq`) gives ⟪x, R(y)⟫ = 2⟪x, e⟫⟪e, y⟫ − ⟪x, y⟫, so scalar Cauchy-Schwarz ‖⟪x, R(y)⟫‖ ≤ ‖x‖·‖R(y)‖ together with the isometry ‖R(y)‖ = ‖y‖ yields the clean bound ‖2⟪x, e⟫⟪e, y⟫ − ⟪x, y⟫‖ ≤ ‖x‖·‖y‖. This is the step where the reflection earns its keep: applying Cauchy-Schwarz to a reflected (rather than the original) vector is what produces the combination 2⟪x, e⟫⟪e, y⟫.",
+    "mathContext": "$\\|2\\langle x,e\\rangle\\langle e,y\\rangle - \\langle x,y\\rangle\\| = \\|\\langle x, R(y)\\rangle\\| \\le \\|x\\|\\,\\|R(y)\\| = \\|x\\|\\,\\|y\\|.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "scalar Cauchy-Schwarz",
+      "sesquilinearity",
+      "norm_inner_le_norm"
+    ],
+    "prerequisites": [
+      "inner_reflection_eq",
+      "reflection_isometry",
+      "norm_inner_le_norm"
+    ]
+  },
+  {
+    "id": "csq020401-ann-03",
+    "proofId": "cauchy-schwarz-oq-02-oq-04-oq-01",
+    "range": {
+      "startLine": 95,
+      "endLine": 110
+    },
+    "type": "concept",
+    "title": "Buzano's Inequality via the Triangle Inequality",
+    "content": "`buzano_inequality` extracts the product term. The triangle inequality (`norm_sub_norm_le`) gives ‖2⟪x, e⟫⟪e, y⟫‖ ≤ ‖2⟪x, e⟫⟪e, y⟫ − ⟪x, y⟫‖ + ‖⟪x, y⟫‖, and the previous bound caps the first summand by ‖x‖·‖y‖. Since ‖2⟪x, e⟫⟪e, y⟫‖ = 2‖⟪x, e⟫‖·‖⟪e, y⟫‖ (multiplicativity of the norm, ‖(2 : 𝕜)‖ = 2), we obtain 2‖⟪x, e⟫‖·‖⟪e, y⟫‖ ≤ ‖x‖·‖y‖ + ‖⟪x, y⟫‖. The halved form `buzano_inequality_div` is the customary statement of Buzano's inequality.",
+    "mathContext": "$2\\|\\langle x,e\\rangle\\|\\,\\|\\langle e,y\\rangle\\| \\le \\|x\\|\\,\\|y\\| + \\|\\langle x,y\\rangle\\|, \\qquad \\|\\langle x,e\\rangle\\|\\,\\|\\langle e,y\\rangle\\| \\le \\tfrac{1}{2}\\bigl(\\|x\\|\\,\\|y\\| + \\|\\langle x,y\\rangle\\|\\bigr).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "triangle inequality",
+      "Buzano's inequality",
+      "refinements of Cauchy-Schwarz"
+    ],
+    "prerequisites": [
+      "norm_sub_norm_le",
+      "multiplicativity of the norm on 𝕜"
+    ]
+  },
+  {
+    "id": "csq020401-ann-04",
+    "proofId": "cauchy-schwarz-oq-02-oq-04-oq-01",
+    "range": {
+      "startLine": 127,
+      "endLine": 155
+    },
+    "type": "concept",
+    "title": "Buzano Strictly Generalizes Cauchy-Schwarz",
+    "content": "`buzano_recovers_cauchy_schwarz` proves Buzano is not merely implied by Cauchy-Schwarz but implies it: instantiate the unit vector as e = ‖x‖⁻¹·x (for x ≠ 0). Then ⟪x, e⟫ = ‖x‖ and ⟪e, y⟫ = ‖x‖⁻¹·⟪x, y⟫, so the left side becomes 2‖x‖·(‖x‖⁻¹·‖⟪x, y⟫‖) = 2‖⟪x, y⟫‖, and Buzano reads 2‖⟪x, y⟫‖ ≤ ‖x‖·‖y‖ + ‖⟪x, y⟫‖, i.e. ‖⟪x, y⟫‖ ≤ ‖x‖·‖y‖. The scalar bookkeeping (coercions ↑‖x‖⁻¹, conj of a real, ‖↑r‖ = |r|) is handled with RCLike.conj_ofReal, RCLike.norm_ofReal, and inner_self_eq_norm_sq_to_K.",
+    "mathContext": "With $e = x/\\|x\\|$: $\\langle x,e\\rangle = \\|x\\|$, $\\langle e,y\\rangle = \\langle x,y\\rangle/\\|x\\|$, so Buzano gives $2\\|\\langle x,y\\rangle\\| \\le \\|x\\|\\|y\\| + \\|\\langle x,y\\rangle\\|$, hence $\\|\\langle x,y\\rangle\\| \\le \\|x\\|\\|y\\|$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "strict generalization",
+      "normalized vector",
+      "classical Cauchy-Schwarz"
+    ],
+    "prerequisites": [
+      "inner_self_eq_norm_sq_to_K",
+      "RCLike.conj_ofReal and RCLike.norm_ofReal",
+      "buzano_inequality"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-01/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "cauchy-schwarz-oq-02-oq-04-oq-01",
+  "title": "Buzano's Inequality",
+  "slug": "cauchy-schwarz-oq-02-oq-04-oq-01",
+  "description": "Buzano's inequality (M. L. Buzano, 1974), a genuine strengthening of Cauchy-Schwarz: for any unit vector e on an inner product space over an RCLike field (ℝ or ℂ), ‖⟪x, e⟫‖·‖⟪e, y⟫‖ ≤ (‖x‖·‖y‖ + ‖⟪x, y⟫‖)/2. The proof rests on a single geometric fact — the reflection y ↦ 2⟪e, y⟫·e − y through the line span(e) is an isometry — after which scalar Cauchy-Schwarz and the triangle inequality finish. Classical Cauchy-Schwarz is recovered as the special case e = x/‖x‖, witnessing that Buzano is strictly more general. Buzano's inequality is not in Mathlib. 7 theorems, 0 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ02OQ04OQ01.lean",
+    "tags": [
+      "analysis",
+      "cauchy-schwarz",
+      "buzano-inequality",
+      "inner-product-space",
+      "reflection",
+      "rclike"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified. The only Mathlib inputs are scalar Cauchy-Schwarz (norm_inner_le_norm), the polarization identity norm_sub_sq, and routine RCLike/sesquilinearity lemmas; the reflection isometry, Buzano's inequality, and the recovery of Cauchy-Schwarz are original derivations with no structure-encoded assumptions.",
+    "lineCount": 155,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "norm_inner_le_norm",
+        "description": "Scalar Cauchy-Schwarz ‖⟪x, y⟫‖ ≤ ‖x‖ · ‖y‖ on an inner product space over RCLike 𝕜. Applied to x and the reflected vector to bound the key combination.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "norm_sub_sq",
+        "description": "Polarization identity ‖x − y‖² = ‖x‖² − 2·re⟪x, y⟫ + ‖y‖² over RCLike. Used to prove the reflection 2⟪e, y⟫·e − y is an isometry by an exact cancellation of cross terms.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "RCLike.conj_mul",
+        "description": "conj z · z = ‖z‖² in an RCLike field, the key scalar identity that makes the reflection cross term real and equal to 2‖⟪e, y⟫‖².",
+        "module": "Mathlib.Analysis.RCLike.Basic"
+      },
+      {
+        "theorem": "inner_self_eq_norm_sq_to_K",
+        "description": "⟪x, x⟫ = (‖x‖ : 𝕜)², used when specializing the unit vector e = ‖x‖⁻¹·x to recover classical Cauchy-Schwarz from Buzano.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      }
+    ],
+    "originalContributions": [
+      "reflection_isometry: the map y ↦ 2⟪e, y⟫·e − y (reflection through span e, e a unit vector) preserves norm, proved via norm_sub_sq with an exact cross-term cancellation",
+      "buzano_inner_bound: ‖2⟪x, e⟫⟪e, y⟫ − ⟪x, y⟫‖ ≤ ‖x‖·‖y‖, scalar Cauchy-Schwarz applied to x and the reflected y",
+      "buzano_inequality: 2‖⟪x, e⟫‖·‖⟪e, y⟫‖ ≤ ‖x‖·‖y‖ + ‖⟪x, y⟫‖ for a unit vector e, by the triangle inequality",
+      "buzano_inequality_div: the halved form ‖⟪x, e⟫‖·‖⟪e, y⟫‖ ≤ (‖x‖·‖y‖ + ‖⟪x, y⟫‖)/2",
+      "buzano_recovers_cauchy_schwarz: choosing e = ‖x‖⁻¹·x collapses Buzano to classical Cauchy-Schwarz ‖⟪x, y⟫‖ ≤ ‖x‖·‖y‖, proving Buzano is a strict generalization",
+      "buzano_self: the y = x consistency form ‖⟪x, e⟫‖ ≤ ‖x‖"
+    ],
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cauchy%E2%80%93Schwarz_inequality"
+  },
+  "overview": {
+    "historicalContext": "In 1974 Maria Luisa Buzano published a refinement of the Cauchy-Schwarz inequality that bounds, for a fixed unit vector e, the product of two pairings |⟪x, e⟫|·|⟪e, y⟫| rather than a single inner product. Buzano's inequality is one of a family of refinements of Cauchy-Schwarz (alongside those of Richard, Precupanu, and the Dunkl–Williams and Dragomir lines of work) that sharpen the classical bound by retaining information about a third reference vector. It is the operator-free shadow of the fact that the rank-one projection onto e, P = ⟪·, e⟫·e, has the reflection 2P − I as an isometry — exactly the structure exploited in the proof here.",
+    "problemStatement": "Prove Buzano's inequality: for any vectors x, y and any unit vector e on an inner product space over ℝ or ℂ, ‖⟪x, e⟫‖·‖⟪e, y⟫‖ ≤ (‖x‖·‖y‖ + ‖⟪x, y⟫‖)/2, and show that it recovers classical Cauchy-Schwarz.",
+    "text": "Fix a unit vector e. The reflection of y through the line span(e) is R(y) = 2⟪e, y⟫·e − y. A direct polarization computation shows ‖R(y)‖ = ‖y‖ (the cross term −2·re⟪2⟪e, y⟫·e, y⟫ = −4‖⟪e, y⟫‖² cancels ‖2⟪e, y⟫·e‖² = 4‖⟪e, y⟫‖² exactly). Pairing x against R(y) and using sesquilinearity gives ⟪x, R(y)⟫ = 2⟪x, e⟫⟪e, y⟫ − ⟪x, y⟫, so scalar Cauchy-Schwarz yields ‖2⟪x, e⟫⟪e, y⟫ − ⟪x, y⟫‖ ≤ ‖x‖·‖R(y)‖ = ‖x‖·‖y‖. The triangle inequality then splits off the product term: 2‖⟪x, e⟫‖·‖⟪e, y⟫‖ ≤ ‖2⟪x, e⟫⟪e, y⟫ − ⟪x, y⟫‖ + ‖⟪x, y⟫‖ ≤ ‖x‖·‖y‖ + ‖⟪x, y⟫‖, which is Buzano. Taking e = x/‖x‖ makes ‖⟪x, e⟫‖ = ‖x‖ and ‖⟪e, y⟫‖ = ‖⟪x, y⟫‖/‖x‖, collapsing the inequality to 2‖⟪x, y⟫‖ ≤ ‖x‖·‖y‖ + ‖⟪x, y⟫‖, i.e. classical Cauchy-Schwarz.",
+    "proofStrategy": "Establish the algebraic reflection identity (inner_reflection_eq) by sesquilinearity; prove the reflection is an isometry (reflection_isometry) by reducing ‖R(y)‖ = ‖y‖ to equality of squares through Real.sqrt and expanding with norm_sub_sq, where the cross term re⟪2⟪e, y⟫·e, y⟫ = 2‖⟪e, y⟫‖² is computed from RCLike.conj_mul. Combine with norm_inner_le_norm to get buzano_inner_bound, then apply norm_sub_norm_le (triangle inequality) for buzano_inequality. Recovery of Cauchy-Schwarz instantiates e = ‖x‖⁻¹·x and simplifies the scalar coefficients.",
+    "keyInsights": [
+      "Buzano's inequality is Cauchy-Schwarz applied to a *reflected* vector: the reflection 2⟪e, y⟫·e − y through span(e) is an isometry, so its pairing with x is bounded by ‖x‖·‖y‖",
+      "The single nontrivial computation is that the reflection preserves norm — an exact cancellation in the polarization formula norm_sub_sq",
+      "The triangle inequality is what converts the bound on 2⟪x, e⟫⟪e, y⟫ − ⟪x, y⟫ into a bound on the product ‖⟪x, e⟫‖·‖⟪e, y⟫‖",
+      "Cauchy-Schwarz is the special case e = x/‖x‖, so Buzano is a strict generalization rather than a mere corollary",
+      "Working over RCLike covers the real and complex cases uniformly; the conjugate-linearity of the first inner-product slot is handled by RCLike.conj_mul / conj_ofReal"
+    ],
+    "prerequisites": [
+      "Inner product spaces over RCLike fields: sesquilinearity, the induced norm, scalar Cauchy-Schwarz",
+      "The polarization identity ‖x − y‖² = ‖x‖² − 2·re⟪x, y⟫ + ‖y‖²",
+      "Basic RCLike algebra: conj z·z = ‖z‖², ‖(r : 𝕜)‖ = |r| for real r"
+    ]
+  },
+  "conclusion": {
+    "summary": "Buzano's inequality ‖⟪x, e⟫‖·‖⟪e, y⟫‖ ≤ (‖x‖·‖y‖ + ‖⟪x, y⟫‖)/2 is verified over any RCLike field, via the isometry of the reflection 2⟪e, y⟫·e − y through span(e), and is shown to recover classical Cauchy-Schwarz from the choice e = x/‖x‖. 7 theorems, 155 lines, 0 axioms, 0 sorries.",
+    "implications": "Buzano's inequality is the prototype of the reference-vector refinements of Cauchy-Schwarz; the reflection isometry it exploits is the rank-one instance of the unitary reflection 2P − I about a projection P, linking the elementary inequality to operator theory and to the OQ-02 → OQ-04 operator-norm / Kadison–Schwarz lineage.",
+    "openQuestions": [
+      "Characterize the equality case of Buzano's inequality (which triples (x, y, e) achieve it) and relate it to the equality case of Cauchy-Schwarz",
+      "Formalize the operator/numerical-range consequence: Buzano applied with e ranging over unit vectors bounds |⟪Tx, x⟫| products and feeds the numerical radius estimates of the parent OQ-04 entry",
+      "Prove the Richard / Precupanu refinements that interpolate between Buzano and Cauchy-Schwarz"
+    ]
+  },
+  "leanFile": {
+    "namespace": "CauchySchwarzBuzano",
+    "lineCount": 155,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ02OQ04OQ01.lean",
+    "sorries": 0,
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "RCLike",
+      "ComplexConjugate"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-02-oq-04",
+      "relationship": "extends",
+      "description": "Parent OQ-04 develops the operator-norm and positive-operator (Kadison–Schwarz) Cauchy-Schwarz; this entry adds Buzano's inequality, whose driving reflection 2P − I is the rank-one instance of the operator structure there"
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-02",
+      "relationship": "related",
+      "description": "Grandparent OQ-02 inner-product / Hölder family; Buzano refines the abstract Cauchy-Schwarz inequality over RCLike fields"
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "The foundational Cauchy-Schwarz inequality, recovered here as the special case e = x/‖x‖"
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-01-imports",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Mathlib imports (InnerProductSpace.Basic, Tactic). Docstring states Buzano's inequality, its proof idea (reflection isometry), and that it strengthens and recovers Cauchy-Schwarz. Namespace CauchySchwarzBuzano with RCLike-generic variables and a local ⟪·,·⟫ notation."
+    },
+    {
+      "id": "sec-02-reflection",
+      "title": "The Reflection and Its Isometry",
+      "startLine": 53,
+      "endLine": 78,
+      "summary": "inner_reflection_eq (the sesquilinear identity ⟪x, 2⟪e, y⟫·e − y⟫ = 2⟪x, e⟫⟪e, y⟫ − ⟪x, y⟫) and reflection_isometry (‖2⟪e, y⟫·e − y‖ = ‖y‖ for a unit vector e, via norm_sub_sq and the cross term re⟪2⟪e, y⟫·e, y⟫ = 2‖⟪e, y⟫‖² from RCLike.conj_mul)."
+    },
+    {
+      "id": "sec-03-buzano",
+      "title": "Buzano's Inequality",
+      "startLine": 79,
+      "endLine": 110,
+      "summary": "buzano_inner_bound (‖2⟪x, e⟫⟪e, y⟫ − ⟪x, y⟫‖ ≤ ‖x‖·‖y‖ from Cauchy-Schwarz against the reflected vector), buzano_inequality (2‖⟪x, e⟫‖·‖⟪e, y⟫‖ ≤ ‖x‖·‖y‖ + ‖⟪x, y⟫‖ via the triangle inequality), and buzano_inequality_div (the halved form)."
+    },
+    {
+      "id": "sec-04-recovery",
+      "title": "Consistency and Recovery of Cauchy-Schwarz",
+      "startLine": 111,
+      "endLine": 155,
+      "summary": "buzano_self (the y = x form ‖⟪x, e⟫‖ ≤ ‖x‖) and buzano_recovers_cauchy_schwarz (choosing e = ‖x‖⁻¹·x collapses Buzano to classical Cauchy-Schwarz ‖⟪x, y⟫‖ ≤ ‖x‖·‖y‖, proving strict generalization)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Buzano's Inequality

A genuine **strengthening** of Cauchy-Schwarz, absent from Mathlib. For any unit vector `e` on an inner product space over an `RCLike` field (ℝ or ℂ):

$$\|\langle x, e\rangle\|\cdot\|\langle e, y\rangle\| \le \tfrac{1}{2}\bigl(\|x\|\,\|y\| + \|\langle x, y\rangle\|\bigr).$$

Classical Cauchy-Schwarz is the special case `e = x/‖x‖` (proved here as `buzano_recovers_cauchy_schwarz`), so Buzano is **strictly more general**.

### Proof idea — one geometric fact
The reflection of `y` through the line `span(e)`, namely `R(y) = 2⟪e, y⟫·e − y`, is an **isometry** (`reflection_isometry`, proved via the polarization identity `norm_sub_sq` with an exact cross-term cancellation). Pairing `x` against `R(y)` and using sesquilinearity gives
`⟪x, R(y)⟫ = 2⟪x, e⟫⟪e, y⟫ − ⟪x, y⟫`, so scalar Cauchy-Schwarz bounds it by `‖x‖·‖y‖`. The triangle inequality then isolates the product `2‖⟪x, e⟫‖·‖⟪e, y⟫‖`.

### Contents (7 theorems, 0 definitions, 0 axioms, 0 sorries, 155 lines)
1. `inner_reflection_eq` — sesquilinear identity for the reflected pairing
2. `reflection_isometry` — `‖2⟪e,y⟫·e − y‖ = ‖y‖` for a unit vector `e`
3. `buzano_inner_bound` — `‖2⟪x,e⟫⟪e,y⟫ − ⟪x,y⟫‖ ≤ ‖x‖‖y‖`
4. `buzano_inequality` — `2‖⟪x,e⟫‖‖⟪e,y⟫‖ ≤ ‖x‖‖y‖ + ‖⟪x,y⟫‖`
5. `buzano_inequality_div` — the customary halved form
6. `buzano_self` — `‖⟪x,e⟫‖ ≤ ‖x‖` (the `y = x` consistency form)
7. `buzano_recovers_cauchy_schwarz` — Buzano ⟹ classical Cauchy-Schwarz

### Verification
- `./proofs/scripts/docker-build.sh Proofs.CauchySchwarzOQ02OQ04OQ01` — builds clean (3058 jobs)
- 0 `sorry`, 0 `axiom` declarations, no `native_decide`, no structure-encoded assumptions → **verified**, `badge: original`

Follow-up of the merged parent `cauchy-schwarz-oq-02-oq-04` (operator-norm / Kadison–Schwarz Cauchy-Schwarz); the driving reflection `2P − I` is the rank-one instance of the operator structure there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)