### PR TITLE
research(geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06): combinatorial Eulerian → Stirling identity i!·S(n,i) = ∑ⱼ C(j,n−i)·⟨n,j⟩ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3509,3 +3509,4 @@ import Proofs.eTranscendental
 import Proofs.MellinPowerConvergenceOQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ04
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06

--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ06.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ06.lean
@@ -1,0 +1,217 @@
+/-
+# Geometric series, open question oq-07-oq-01-oq-01-oq-01-oq-06:
+# The combinatorial Eulerian → Stirling identity
+
+The parent entry `geometric-series-oq-07-oq-01-oq-01-oq-01` builds the combinatorial
+**Eulerian numbers** `⟨n,k⟩` (`eulerian n k`) from the triangle recurrence
+`⟨n+1,k+1⟩ = (k+2)·⟨n,k+1⟩ + (n−k)·⟨n,k⟩`, and identifies them with the coefficients of the
+Eulerian polynomial.  At the *polynomial* level it also records `stirlingForm_eq_eulerianNumbers`,
+linking the Stirling numbers `S(n,k) = stirlingSecond n k` to the Eulerian row.  Siblings settled
+Worpitzky's identity (`oq-03`), the explicit closed form (`oq-04`), and the combinatorial
+palindromy (`oq-05`).
+
+This entry settles `oq-06`: the **combinatorial Eulerian → Stirling identity**, the per-coefficient
+companion of Worpitzky's identity,
+
+  **`eulerian_stirling`** :  `i!·S(n,i) = ∑_{j<n} C(j, n−i)·⟨n,j⟩`   (for `1 ≤ n`, `i ≤ n`).
+
+Worpitzky (`oq-03`) expands a power `xⁿ` over the Eulerian row using the *ascending* binomial
+weights `C(x+j, n)`; this identity is its dual, expanding `i!·S(n,i)` — the number of surjections
+from an `n`-set onto an `i`-set — over the same Eulerian row using the *plain* binomial weights
+`C(j, n−i)`.  Equivalently, applying Vandermonde's convolution to Worpitzky and matching the
+binomial basis `C(x,i)` of `xⁿ = ∑ᵢ i!·S(n,i)·C(x,i)` gives exactly this pairing.
+
+The proof is self-contained and elementary: induction on the row `n`, reducing the inductive step —
+via the Stirling recurrence `S(n+1,i) = i·S(n,i) + S(n,i−1)` and the Eulerian triangle recurrence —
+to a single **per-term binomial identity** (`term_binom`) that follows from Pascal's rule together
+with the absorption identity `C(j,d)·d = C(j,d−1)·(j−d+1)`.  The top corner uses the Worpitzky row
+sum `∑_{j<n} ⟨n,j⟩ = n!` (`oq-01`).
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and `sorry`-free.
+-/
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ01OQ06
+
+open Finset Nat GeometricSeriesOQ07OQ01OQ01OQ01
+
+/-! ## The per-term binomial identity -/
+
+/-- The per-term binomial identity driving the inductive step.  For `i' ≤ n` and `j ≤ n`,
+writing `d = n+1−i'` (so `d−1 = n−i'`):
+`(j+1)·C(j,d) + (n+1−j)·C(j+1,d) = (i'+1)·C(j,d−1) + (i'+1)·C(j,d)`.
+It follows from Pascal's rule `C(j+1,d) = C(j,d−1) + C(j,d)` and the absorption identity
+`C(j,d)·d = C(j,d−1)·(j−(d−1))`. -/
+private theorem term_binom (n i' j : ℕ) (hi' : i' ≤ n) (hj : j ≤ n) :
+    (j + 1) * j.choose (n + 1 - i') + (n + 1 - j) * (j + 1).choose (n + 1 - i')
+      = (i' + 1) * j.choose (n - i') + (i' + 1) * j.choose (n + 1 - i') := by
+  -- write the upper index as `(n - i') + 1` and apply Pascal
+  have hd : n + 1 - i' = (n - i') + 1 := by omega
+  rw [hd, Nat.choose_succ_succ j (n - i')]
+  rcases Nat.lt_or_ge j (n - i') with hlt | hge
+  · -- both binomials vanish (the lower index exceeds `j`)
+    rw [Nat.choose_eq_zero_of_lt hlt, Nat.choose_eq_zero_of_lt (by omega : j < n - i' + 1)]
+    ring
+  · -- genuine subtraction; transfer the absorption identity to ℤ
+    have habs : j.choose ((n - i') + 1) * ((n - i') + 1) = j.choose (n - i') * (j - (n - i')) :=
+      Nat.choose_succ_right_eq j (n - i')
+    zify [hge, hi'] at habs
+    zify [show j ≤ n + 1 from by omega]
+    linear_combination habs
+
+/-! ## The Eulerian → Stirling identity -/
+
+/-- Regrouping the Eulerian recurrence inside a binomial-weighted row sum.  For every `m` and
+every fixed lower index `d ≥ 1`,
+`∑_{j<m+1} C(j,d)·⟨m+1,j⟩ = ∑_{j<m} ⟨m,j⟩·((j+1)·C(j,d) + (m−j)·C(j+1,d))`.
+The corner terms `C(0,d) = 0` (as `d ≥ 1`) and `⟨m,m⟩ = 0` make the index shift exact. -/
+private theorem row_regroup (m d : ℕ) (hd : 1 ≤ d) :
+    ∑ j ∈ range (m + 1), j.choose d * eulerian (m + 1) j
+      = ∑ j ∈ range m, eulerian m j * ((j + 1) * j.choose d + (m - j) * (j + 1).choose d) := by
+  -- peel the `j = 0` term (which vanishes since `C(0,d) = 0`) and expand the recurrence
+  rw [Finset.sum_range_succ']
+  have hzero : (0 : ℕ).choose d = 0 := Nat.choose_eq_zero_of_lt hd
+  simp only [hzero, Nat.zero_mul, add_zero]
+  -- substitute the Eulerian triangle recurrence in each remaining term
+  have hstep : ∀ k ∈ range m,
+      (k + 1).choose d * eulerian (m + 1) (k + 1)
+        = (k + 1).choose d * (k + 2) * eulerian m (k + 1)
+          + (k + 1).choose d * (m - k) * eulerian m k := by
+    intro k _
+    rw [eulerian_succ_succ]; ring
+  rw [Finset.sum_congr rfl hstep, Finset.sum_add_distrib]
+  -- the second sum is already in the desired `B` shape
+  -- the first sum `A'` reindexes `k ↦ k+1`
+  have hA : ∑ k ∈ range m, (k + 1).choose d * (k + 2) * eulerian m (k + 1)
+      = ∑ j ∈ range m, (j + 1) * j.choose d * eulerian m j := by
+    -- define h j = (j+1)·C(j,d)·⟨m,j⟩; then the LHS is ∑_{k<m} h (k+1)
+    have key : ∀ k ∈ range m,
+        (k + 1).choose d * (k + 2) * eulerian m (k + 1)
+          = ((k + 1) + 1) * (k + 1).choose d * eulerian m (k + 1) := by
+      intro k _; ring
+    rw [Finset.sum_congr rfl key]
+    -- ∑_{k<m} h (k+1) = ∑_{j<m+1} h j (since h 0 = 0) ... = ∑_{j<m} h j (since h m = 0)
+    have hshift : ∑ k ∈ range m, ((k + 1) + 1) * (k + 1).choose d * eulerian m (k + 1)
+        = ∑ j ∈ range (m + 1), (j + 1) * j.choose d * eulerian m j - 0 := by
+      rw [Finset.sum_range_succ']
+      have h0 : (0 : ℕ).choose d = 0 := Nat.choose_eq_zero_of_lt hd
+      simp [h0]
+    rw [hshift, Nat.sub_zero, Finset.sum_range_succ]
+    -- the top term `h m = (m+1)·C(m,d)·⟨m,m⟩` vanishes: ⟨m,m⟩ = 0 (m ≥ 1) or C(0,d)=0 (m=0)
+    have htop : (m + 1) * m.choose d * eulerian m m = 0 := by
+      cases m with
+      | zero => simp [Nat.choose_eq_zero_of_lt hd]
+      | succ p => rw [eulerian_succ_self]; ring
+    rw [htop, add_zero]
+  rw [hA]
+  -- combine A' and B termwise
+  rw [← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intro j _
+  ring
+
+/-- **The combinatorial Eulerian → Stirling identity** (row-`n+1` form, by induction on the row).
+For `i ≤ n+1`:  `i!·S(n+1,i) = ∑_{j<n+1} C(j, n+1−i)·⟨n+1,j⟩`. -/
+private theorem eulerian_stirling_succ :
+    ∀ (n i : ℕ), i ≤ n + 1 →
+      i ! * stirlingSecond (n + 1) i
+        = ∑ j ∈ range (n + 1), j.choose (n + 1 - i) * eulerian (n + 1) j := by
+  intro n
+  induction n with
+  | zero =>
+    intro i hi
+    interval_cases i
+    · decide
+    · decide
+  | succ n ih =>
+    intro i hi
+    rcases i with _ | i'
+    · -- i = 0:  both sides vanish
+      rw [Nat.factorial_zero, one_mul, stirlingSecond_succ_zero]
+      symm
+      apply Finset.sum_eq_zero
+      intro j hj
+      rw [mem_range] at hj
+      rw [Nat.choose_eq_zero_of_lt (by omega), Nat.zero_mul]
+    · rcases Nat.lt_or_ge (i' + 1) (n + 2) with hlt | hge
+      · -- main case: 1 ≤ i = i'+1 ≤ n+1
+        have hi'n : i' ≤ n := by omega
+        -- Stirling recurrence: S(n+2, i'+1) = (i'+1)·S(n+1,i'+1) + S(n+1,i')
+        rw [stirlingSecond_succ_succ (n + 1) i']
+        -- expand the factorial-weighted Stirling combination using the IH on row n+1
+        have hG1 : (i' + 1) ! * stirlingSecond (n + 1) (i' + 1)
+            = ∑ j ∈ range (n + 1), j.choose (n - i') * eulerian (n + 1) j := by
+          have := ih (i' + 1) (by omega)
+          have he : n + 1 - (i' + 1) = n - i' := by omega
+          rwa [he] at this
+        have hG0 : i' ! * stirlingSecond (n + 1) i'
+            = ∑ j ∈ range (n + 1), j.choose (n + 1 - i') * eulerian (n + 1) j := ih i' (by omega)
+        -- LHS = (i'+1)·G(n+1,i'+1) + (i'+1)·G(n+1,i')
+        have hLHS : (i' + 1) ! * ((i' + 1) * stirlingSecond (n + 1) (i' + 1)
+              + stirlingSecond (n + 1) i')
+            = (i' + 1) * (∑ j ∈ range (n + 1), j.choose (n - i') * eulerian (n + 1) j)
+              + (i' + 1) * (∑ j ∈ range (n + 1), j.choose (n + 1 - i') * eulerian (n + 1) j) := by
+          have hfac : (i' + 1) ! = (i' + 1) * i' ! := Nat.factorial_succ i'
+          rw [mul_add]
+          congr 1
+          · rw [← hG1]; rw [hfac]; ring
+          · rw [← hG0]; rw [hfac]; ring
+        rw [hLHS]
+        -- RHS: regroup row n+2 via `row_regroup` with d = n+1-i'
+        have hidx : n + 2 - (i' + 1) = n + 1 - i' := by omega
+        rw [hidx]
+        rw [row_regroup (n + 1) (n + 1 - i') (by omega)]
+        -- now match termwise
+        rw [Finset.mul_sum, Finset.mul_sum, ← Finset.sum_add_distrib]
+        apply Finset.sum_congr rfl
+        intro j hj
+        rw [mem_range] at hj
+        have htb := term_binom n i' j hi'n (by omega)
+        -- htb : (j+1)·C(j,n+1-i') + (n+1-j)·C(j+1,n+1-i')
+        --        = (i'+1)·C(j,n-i') + (i'+1)·C(j,n+1-i')
+        -- goal: ⟨n+1,j⟩·((j+1)·C(j,d) + (n+1-j)·C(j+1,d))
+        --        = (i'+1)·(C(j,n-i')·⟨n+1,j⟩) + (i'+1)·(C(j,n+1-i')·⟨n+1,j⟩)
+        rw [htb]; ring
+      · -- top corner: i = n+2
+        have hi2 : i' = n + 1 := by omega
+        subst hi2
+        rw [Nat.sub_self, stirlingSecond_self]
+        -- LHS = (n+2)!
+        rw [mul_one]
+        -- RHS = ∑_{j<n+2} C(j,0)·⟨n+2,j⟩ = ∑_{j<n+2} ⟨n+2,j⟩ = (n+2)!
+        have hchoose : ∀ j ∈ range (n + 2), j.choose 0 * eulerian (n + 2) j = eulerian (n + 2) j := by
+          intro j _; rw [Nat.choose_zero_right, Nat.one_mul]
+        rw [Finset.sum_congr rfl hchoose]
+        -- relate to the Worpitzky row sum on row n+2
+        have hrow := GeometricSeriesOQ07OQ01OQ01OQ01OQ01.eulerian_row_sum (n + 2)
+        rw [Finset.sum_range_succ] at hrow
+        rw [eulerian_succ_self] at hrow
+        rw [add_zero] at hrow
+        exact hrow.symm
+
+/-- **The combinatorial Eulerian → Stirling identity.**  For `1 ≤ n` and `i ≤ n`,
+`i!·S(n,i) = ∑_{j<n} C(j, n−i)·⟨n,j⟩`, where `S(n,i) = stirlingSecond n i` is the Stirling number
+of the second kind (the number of partitions of an `n`-set into `i` blocks) and `⟨n,j⟩` is the
+combinatorial Eulerian number.  This is the per-coefficient dual of Worpitzky's identity. -/
+theorem eulerian_stirling (n i : ℕ) (hn : 1 ≤ n) (hin : i ≤ n) :
+    i ! * stirlingSecond n i = ∑ j ∈ range n, j.choose (n - i) * eulerian n j := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  exact eulerian_stirling_succ m i hin
+
+/-! ## Corroboration on concrete rows -/
+
+-- `2!·S(3,2) = 2·3 = 6 = ∑_{j<3} C(j,1)·⟨3,j⟩ = C(0,1)·1 + C(1,1)·4 + C(2,1)·1 = 0+4+2`.
+example : 2 ! * stirlingSecond 3 2 = ∑ j ∈ range 3, j.choose (3 - 2) * eulerian 3 j := by decide
+
+-- `1!·S(3,1) = 1 = ∑_{j<3} C(j,2)·⟨3,j⟩ = C(2,2)·⟨3,2⟩ = 1`.
+example : 1 ! * stirlingSecond 3 1 = ∑ j ∈ range 3, j.choose (3 - 1) * eulerian 3 j := by decide
+
+-- `3!·S(3,3) = 6 = ∑_{j<3} C(j,0)·⟨3,j⟩ = 1+4+1` (the row sum).
+example : 3 ! * stirlingSecond 3 3 = ∑ j ∈ range 3, j.choose (3 - 3) * eulerian 3 j := by decide
+
+-- Row 4:  `2!·S(4,2) = 2·7 = 14 = ∑_{j<4} C(j,2)·⟨4,j⟩ = C(2,2)·11 + C(3,2)·1 = 11+3`.
+example : 2 ! * stirlingSecond 4 2 = ∑ j ∈ range 4, j.choose (4 - 2) * eulerian 4 j := by decide
+
+end GeometricSeriesOQ07OQ01OQ01OQ01OQ06

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "Nat",
+      "GeometricSeriesOQ07OQ01OQ01OQ01"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ01OQ06",
+    "lineCount": 217,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ06.lean",
+    "sorries": 0
+  },
+  "title": "The Combinatorial Eulerian → Stirling Identity: i!·S(n,i) = ∑ⱼ C(j, n−i)·⟨n,j⟩",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ06.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "stirling-numbers",
+      "worpitzky",
+      "binomial-coefficients",
+      "descent-statistic",
+      "triangle-recurrence",
+      "induction",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 217,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "eulerian_stirling: THE MAIN RESULT — the combinatorial Eulerian → Stirling identity, i!·S(n,i) = ∑_{j<n} C(j, n−i)·⟨n,j⟩ (for 1 ≤ n, i ≤ n), where S(n,i) = Nat.stirlingSecond n i is the Stirling number of the second kind and ⟨n,j⟩ = eulerian n j is the parent's combinatorial Eulerian number. This is the per-coefficient dual of Worpitzky's identity (sibling oq-03 expands a power nᵐ over the Eulerian row using the ascending binomial weights C(n+j,m); this identity expands i!·S(n,i) — the number of surjections from an n-set onto an i-set — over the same Eulerian row using the plain weights C(j,n−i)). The parent only records the polynomial-level Stirling↔Eulerian link (stirlingForm_eq_eulerianNumbers); this is the genuinely combinatorial, per-entry statement, and Mathlib has neither the Eulerian numbers nor this pairing.",
+      "term_binom: the per-term binomial identity that the whole induction collapses onto — (j+1)·C(j,d) + (n+1−j)·C(j+1,d) = (i'+1)·C(j,d−1) + (i'+1)·C(j,d) with d = n+1−i'. After Pascal's rule C(j+1,d) = C(j,d−1)+C(j,d) it reduces to the absorption identity C(j,d)·d = C(j,d−1)·(j−(d−1)) (Nat.choose_succ_right_eq), discharged over ℤ by a single linear_combination once the case d−1 > j (where both binomials vanish) is split off to keep the truncated subtraction honest.",
+      "row_regroup: the structural lemma turning a binomial-weighted row sum of ⟨n+1,·⟩ into one of ⟨n,·⟩, ∑_{j<m+1} C(j,d)·⟨m+1,j⟩ = ∑_{j<m} ⟨m,j⟩·((j+1)·C(j,d) + (m−j)·C(j+1,d)), by substituting the Eulerian triangle recurrence and shifting indices. The two corner terms C(0,d)=0 (since d ≥ 1) and ⟨m,m⟩=0 make the index shift exact, handled uniformly for m=0 and m≥1.",
+      "eulerian_stirling_succ: the inductive engine (row-(n+1) form, induction on the row). The step uses the Stirling recurrence S(n+2,i) = i·S(n+1,i) + S(n+1,i−1) to write i!·S(n+2,i) as i·G(n+1,i) + i·G(n+1,i−1) with G the binomial-weighted Eulerian row sums supplied by the induction hypothesis, then matches it against row_regroup of row n+2 via term_binom under Finset.sum_congr. Three boundary cases — i=0 (both sides vanish), the interior 1 ≤ i ≤ n+1, and the top corner i=n+2 (which is the Worpitzky row sum ∑_{j<n+2} ⟨n+2,j⟩ = (n+2)! from oq-01) — are dispatched separately. The concrete rows S(3,1), S(3,2), S(3,3), S(4,2) are checked against the formula by kernel decide."
+    ],
+    "prerequisites": [
+      "Parent: geometric-series-oq-07-oq-01-oq-01-oq-01 (the combinatorial Eulerian numbers) — supplies the eulerian triangle, its recurrence eulerian_succ_succ, and the diagonal-vanishing eulerian_succ_self used to kill the top corner term in row_regroup and in the top-corner case",
+      "Sibling oq-01: geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01 — supplies the Worpitzky row sum eulerian_row_sum n : ∑_{j<n+1} ⟨n,j⟩ = n!, used to evaluate the top corner i=n of the identity",
+      "Mathlib's Nat.stirlingSecond with the Stirling recurrence (Nat.stirlingSecond_succ_succ), boundary (Nat.stirlingSecond_succ_zero) and diagonal (Nat.stirlingSecond_self)",
+      "Mathlib's Nat.choose with Pascal's rule (Nat.choose_succ_succ), absorption (Nat.choose_succ_right_eq), and Nat.choose_eq_zero_of_lt; Finset reindexing (Finset.sum_range_succ', Finset.sum_range_succ, Finset.sum_add_distrib, Finset.mul_sum, Finset.sum_congr); ℤ transfer (zify, linear_combination) to keep truncated subtraction honest"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.stirlingSecond_succ_succ",
+        "description": "The Stirling recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k). Drives the inductive step: it expresses i!·S(n+2,i) as a combination of the row-(n+1) binomial sums furnished by the induction hypothesis.",
+        "module": "Mathlib.Combinatorics.Stirling"
+      },
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "The binomial absorption identity j.choose (k+1) · (k+1) = j.choose k · (j − k). Cast to ℤ, it is the entire content of the per-term identity term_binom after Pascal's rule.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule (n+1).choose (k+1) = n.choose k + n.choose (k+1). Splits C(j+1,d) into C(j,d−1)+C(j,d) inside term_binom.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Peels the first term of a range sum with an index shift, ∑_{i<n+1} f i = ∑_{i<n} f (i+1) + f 0. Powers the j ↦ j+1 reindexing of the Eulerian recurrence in row_regroup.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07OQ01OQ01OQ01.eulerian",
+        "description": "The parent's from-scratch combinatorial Eulerian-number triangle ⟨n,j⟩, with eulerian_succ_succ and eulerian_succ_self. Reused verbatim so this entry only adds the Stirling pairing, not the underlying object.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07OQ01OQ01OQ01OQ01.eulerian_row_sum",
+        "description": "The Worpitzky row sum ∑_{j<n+1} ⟨n,j⟩ = n!, proved in sibling oq-01. Evaluates the top corner i=n of the Eulerian → Stirling identity (where C(j,0)=1 and S(n,n)=1).",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01",
+      "question": "Prove the inverse pairing, the Eulerian numbers expanded over the Stirling row with signs: ⟨n,k⟩ = ∑_j (−1)^{k−j}·C(n−j, k−j)·j!·S(n,j), the alternating companion obtained by binomial-inverting this identity. Together the two would exhibit the Eulerian and (factorial-weighted) Stirling rows as mutually inverse under the binomial-coefficient triangle.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-02",
+      "question": "Use the identity to read off the row sum ∑_i i!·S(n,i)·xⁱ-type specializations: at the binomial-basis evaluation it recovers nᵐ = ∑_i i!·S(n,i)·C(x,i), tying this entry's pairing back to Worpitzky via Vandermonde's convolution C(x+j,n) = ∑_i C(x,i)·C(j,n−i). Formalize that Vandermonde route as an independent second proof.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent (the combinatorial Eulerian numbers). The parent defines the triangle ⟨n,j⟩, identifies it with the Eulerian-polynomial coefficients, and records the polynomial-level Stirling form stirlingForm_eq_eulerianNumbers. This entry proves the genuinely combinatorial, per-entry Stirling pairing i!·S(n,i) = ∑_j C(j,n−i)·⟨n,j⟩, reusing the parent's eulerian, eulerian_succ_succ and eulerian_succ_self."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling under the same parent. oq-03 proves Worpitzky's identity nᵐ = ∑_j ⟨m,j⟩·C(n+j,m), expanding a power over the Eulerian row in ascending binomial weights. This entry is its dual: it expands i!·S(n,i) over the same Eulerian row in the plain weights C(j,n−i). Applying Vandermonde's convolution to Worpitzky and matching the binomial basis C(x,i) yields exactly this pairing."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "uses",
+      "description": "Sibling oq-01 supplies the Worpitzky row sum ∑_{j<n+1} ⟨n,j⟩ = n! (eulerian_row_sum), which evaluates the top corner i=n of the Eulerian → Stirling identity, where the binomial weight C(j,0)=1 and S(n,n)=1."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04",
+      "relationship": "sibling",
+      "description": "Sibling under the same parent. oq-04 proves the explicit closed form ⟨m,k⟩ = ∑_j (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ. Both express Eulerian numbers through binomial sums; oq-04 solves the triangle recurrence in the power basis, this entry pairs the Eulerian row with the Stirling (surjection-count) numbers."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers, Stirling numbers, Worpitzky's identity)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian and Stirling triangles and the identities relating them, including the surjection interpretation i!·S(n,i) and Worpitzky's identity."
+    },
+    {
+      "title": "Mathlib4: Combinatorics.Stirling and Data.Nat.Choose.Basic",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Nat.stirlingSecond and its recurrence, plus Pascal's rule and the binomial absorption identity powering the per-term reduction."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Building on the parent entry's from-scratch combinatorial Eulerian numbers ⟨n,j⟩, this entry proves the combinatorial Eulerian → Stirling identity i!·S(n,i) = ∑_{j<n} C(j, n−i)·⟨n,j⟩ (for 1 ≤ n, i ≤ n), where S(n,i) = Nat.stirlingSecond n i counts surjections from an n-set onto an i-set (up to the i! relabelling) and ⟨n,j⟩ is the combinatorial Eulerian number. Where the parent only links Stirling and Eulerian numbers at the level of polynomials (stirlingForm_eq_eulerianNumbers), this is the per-coefficient combinatorial statement — the dual of Worpitzky's identity (sibling oq-03), pairing the same Eulerian row with the Stirling numbers via plain binomial weights. The proof is self-contained: induction on the row n (eulerian_stirling_succ). The inductive step rewrites i!·S(n+2,i), via the Stirling recurrence, as i·G(n+1,i) + i·G(n+1,i−1) — combinations of the binomial-weighted Eulerian row sums G furnished by the induction hypothesis — and matches it, under Finset.sum_congr, against the same row sum of ⟨n+2,·⟩ regrouped through the Eulerian triangle recurrence (row_regroup). The entire match collapses to a single per-term binomial identity (term_binom) that is Pascal's rule plus the absorption C(j,d)·d = C(j,d−1)·(j−d+1), discharged over ℤ. The boundary cases are i=0 (both sides vanish), the interior, and the top corner i=n (the Worpitzky row sum from oq-01). The rows S(3,1), S(3,2), S(3,3), S(4,2) are verified against the formula by kernel decide. 217 lines, 1 public theorem plus 3 private supporting lemmas, 0 definitions, 0 axioms, 0 sorries; everything depends only on propext, Classical.choice, Quot.sound (the numeric checks use kernel decide, not native_decide, so no Lean.ofReduceBool).",
+    "implications": "The identity completes the classical 'change of basis' picture of Eulerian theory in this gallery: Worpitzky (oq-03) expands powers over the Eulerian row in ascending binomials, the explicit formula (oq-04) inverts the recurrence in the power basis, and this entry pairs the Eulerian row with the factorial-weighted Stirling numbers in the plain binomial basis. Equivalently, it is the coefficient form of the two-way relation xⁿ = ∑_i i!·S(n,i)·C(x,i) = ∑_j ⟨n,j⟩·C(x+j,n) under Vandermonde's convolution. Because the proof rests only on the Eulerian triangle recurrence, the Stirling recurrence, and elementary binomial identities, it is a near-Mathlib-free addition that strengthens the combinatorial half of the Stirling–Eulerian link already present at the polynomial level in the parent.",
+    "openQuestions": [
+      "Prove the inverse pairing ⟨n,k⟩ = ∑_j (−1)^{k−j}·C(n−j,k−j)·j!·S(n,j), exhibiting the Eulerian and factorial-Stirling rows as binomial-inverse.",
+      "Formalize the Vandermonde route (C(x+j,n) = ∑_i C(x,i)·C(j,n−i) applied to Worpitzky) as an independent second proof of this identity."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Settles open question `oq-06` of the combinatorial Eulerian-number lineage: the **combinatorial Eulerian → Stirling identity**

```
eulerian_stirling :  i! · S(n,i) = ∑_{j<n} C(j, n−i) · ⟨n,j⟩      (for 1 ≤ n, i ≤ n)
```

where `S(n,i) = Nat.stirlingSecond n i` (partitions of an `n`-set into `i` blocks; `i!·S(n,i)` = surjections `n ↠ i`) and `⟨n,j⟩ = eulerian n j` is the parent's combinatorial Eulerian number.

This is the **per-coefficient dual of Worpitzky's identity** (sibling `oq-03`): Worpitzky expands a power `nᵐ` over the Eulerian row using *ascending* binomial weights `C(n+j,m)`; this identity expands `i!·S(n,i)` over the *same* Eulerian row using the *plain* weights `C(j,n−i)`. The parent only records the **polynomial**-level Stirling↔Eulerian link (`stirlingForm_eq_eulerianNumbers`); this is the genuinely combinatorial, per-entry statement. Mathlib has neither the Eulerian numbers nor this pairing.

## Proof

Self-contained induction on the row `n` (`eulerian_stirling_succ`):
- the step rewrites `i!·S(n+2,i)`, via the Stirling recurrence `S(n+1,i) = i·S(n,i) + S(n,i−1)`, as `i·G(n+1,i) + i·G(n+1,i−1)` with `G` the binomial-weighted Eulerian row sums from the IH;
- it matches that, under `Finset.sum_congr`, against the same row sum of `⟨n+2,·⟩` regrouped through the Eulerian triangle recurrence (`row_regroup`);
- the whole match collapses to a single **per-term binomial identity** (`term_binom`) = Pascal's rule + the absorption `C(j,d)·d = C(j,d−1)·(j−d+1)`, discharged over ℤ.
- Boundary cases: `i=0` (both sides vanish), the interior, and the top corner `i=n` (the Worpitzky row sum `∑_{j<n} ⟨n,j⟩ = n!` from `oq-01`).

Concrete rows `S(3,1), S(3,2), S(3,3), S(4,2)` are checked against the formula by **kernel `decide`** (not `native_decide`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06` — builds clean.
- `#print axioms eulerian_stirling` → `[propext, Classical.choice, Quot.sound]` only — **0-axiom** (no `Lean.ofReduceBool`, no `sorryAx`).
- 217 lines, 1 public theorem + 3 private supporting lemmas, 0 definitions, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)