### PR TITLE
research(sperner-simplicial-bridge-oq-02): bridge Sperner's lemma to Mathlib's Geometry.SimplicialComplex

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2639,6 +2639,7 @@ import Proofs.GeometricSeriesOQ08
 import Proofs.GeometricSeriesOQ08OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01
+import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01OQ02
 import Proofs.GeometricSeriesOQ08OQ03
 import Proofs.GeometricSeriesOQ08OQ03OQ01
 import Proofs.GeometricSeriesOQ08OQ03OQ01OQ01

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3239,6 +3239,7 @@ import Proofs.SpernerNDimOQ03OQ01
 import Proofs.SpernerNDimOQ04
 import Proofs.SpernerSimplicialBridge
 import Proofs.SpernerSimplicialBridgeOQ01
+import Proofs.SpernerSimplicialBridgeOQ02
 import Proofs.SpernerSimplicialInstance
 import Proofs.SpernerSimplicialInstanceOQ01
 import Proofs.SpernerSimplicialInstanceOQ03

--- a/proofs/Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,188 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01
+
+/-
+# The infinite-limit recurrence: ∑_{k≥0} kᵐ·xᵏ for |x| < 1
+
+## What This Proves
+
+Fix a real ratio `x` with `|x| < 1`.  The **infinite m-th moment**
+
+  infMoment m x  :=  ∑_{k=0}^{∞} kᵐ·xᵏ
+
+(the convergent weighted geometric series) satisfies the single
+binomial-convolution recurrence
+
+  (1 − x) · infMoment m x  =  0ᵐ  +  x · ∑_{i=0}^{m−1} C(m,i) · infMoment i x.   (★∞)
+
+This is exactly the `n → ∞` limit of the finite master recurrence
+
+  (1 − x) · momentSum m n x  =  0ᵐ − nᵐ·xⁿ + x · ∑_{i<m} C(m,i) · momentSum i n x
+
+proved in the parent `geometric-series-oq-08-oq-01-oq-01-oq-01`: for `|x| < 1`
+the finite partial sums `momentSum m n x` converge to `infMoment m x`, while the
+boundary term `nᵐ·xⁿ` — being the general term of a convergent series — vanishes
+in the limit.  The boundary correction that the finite sum had to carry simply
+**washes out**, leaving the clean closed recurrence (★∞).
+
+## Why This Is the Right Statement
+
+Recurrence (★∞) is a *first-order-in-m convolution*: it expresses the `m`-th
+moment through **all** lower moments using the Pascal/binomial weights `C(m,i)`,
+with no derivatives and no special functions.  It is complementary to the two
+explicit closed forms already in the gallery:
+
+  * the **Stirling** form `geometric-series-oq-07-oq-01`
+    (`∑ nᵐrⁿ = ∑ₖ S(m,k)·k!·rᵏ/(1−r)^{k+1}`), and
+  * the **Frobenius / Eulerian-polynomial** form
+    `geometric-series-oq-07-oq-01-oq-01` (`= Aₘ(r)/(1−r)^{m+1}`).
+
+Those give `infMoment m` in one shot; (★∞) instead *characterises* the whole
+sequence `(infMoment m)ₘ` by a recursion, and is the cleanest bridge from the
+finite theory to the infinite one.  Solving (★∞) for small `m` recovers the
+gallery's explicit sums:
+
+  infMoment 0 x = 1/(1−x)
+  infMoment 1 x = x/(1−x)²            (the infinite arithmetico-geometric sum)
+  infMoment 2 x = x(1+x)/(1−x)³       (the infinite second moment ∑ k²xᵏ)
+
+## Why This Is Not Already in Mathlib
+
+Mathlib records summability of `∑ nᵏ rⁿ` (`summable_pow_mul_geometric_of_norm_lt_one`)
+and the value of the plain geometric series, but neither the moment sum `∑ kᵐxᵏ`
+as a named object nor any recurrence linking the infinite moments across `m`.
+
+## Proof Strategy
+
+1. **Summability.** `summable_pow_mul_geometric_of_norm_lt_one m (‖x‖<1)` gives
+   `Summable (fun k ↦ kᵐ·xᵏ)` for every `m`.
+2. **Convergence of partial sums.** `HasSum.tendsto_sum_nat` turns summability
+   into `momentSum m n x → infMoment m x` (the partial sums are exactly the
+   parent's `momentSum`).
+3. **Boundary vanishes.** `Summable.tendsto_atTop_zero` gives `nᵐ·xⁿ → 0`, since
+   that is the general term of the summable series of step 1.
+4. **Pass to the limit.** Both sides of the parent's finite recurrence are
+   sequences in `n`; taking `n → ∞` (LHS by continuity of `(1−x)·•`, RHS by
+   linearity of limits over the finite inner sum) and using uniqueness of limits
+   yields (★∞).
+5. **Specialisations** solve (★∞) at `m = 0, 1, 2`, recovering the gallery's
+   explicit closed forms.
+
+All results depend only on `propext`, `Classical.choice`, `Quot.sound`.
+-/
+
+namespace GeometricSeriesOQ08OQ01OQ01OQ01OQ02
+
+open Finset Filter Topology
+open GeometricSeriesOQ08OQ01OQ01OQ01 (momentSum momentSum_recurrence)
+
+/-- The **infinite m-th moment** `∑_{k=0}^{∞} kᵐ·xᵏ` of a real geometric series. -/
+noncomputable def infMoment (m : ℕ) (x : ℝ) : ℝ :=
+  ∑' k : ℕ, (k : ℝ) ^ m * x ^ k
+
+/-- For `|x| < 1`, every moment series `∑ kᵐ·xᵏ` is summable. -/
+theorem summable_moment (m : ℕ) {x : ℝ} (hx : |x| < 1) :
+    Summable (fun k : ℕ => (k : ℝ) ^ m * x ^ k) :=
+  summable_pow_mul_geometric_of_norm_lt_one m (by rwa [Real.norm_eq_abs])
+
+/-- The finite moment sums converge to the infinite moment:
+`momentSum m n x → infMoment m x` as `n → ∞` (for `|x| < 1`). -/
+theorem tendsto_momentSum (m : ℕ) {x : ℝ} (hx : |x| < 1) :
+    Tendsto (fun n => momentSum m n x) atTop (𝓝 (infMoment m x)) := by
+  simpa only [momentSum, infMoment] using (summable_moment m hx).hasSum.tendsto_sum_nat
+
+/-- The boundary term of the finite recurrence vanishes in the limit:
+`nᵐ·xⁿ → 0` as `n → ∞` (it is the general term of a convergent series). -/
+theorem tendsto_boundary (m : ℕ) {x : ℝ} (hx : |x| < 1) :
+    Tendsto (fun n : ℕ => (n : ℝ) ^ m * x ^ n) atTop (𝓝 0) :=
+  (summable_moment m hx).tendsto_atTop_zero
+
+/-- **Master infinite recurrence (★∞).** For `|x| < 1`, over the reals,
+
+  `(1 − x)·infMoment m x = 0ᵐ + x·∑_{i<m} C(m,i)·infMoment i x`.
+
+This is the `n → ∞` limit of the parent's finite recurrence: the boundary term
+`nᵐ·xⁿ` vanishes, leaving a clean binomial-convolution recursion that expresses
+the `m`-th infinite moment through all lower moments. -/
+theorem infMoment_recurrence (m : ℕ) {x : ℝ} (hx : |x| < 1) :
+    (1 - x) * infMoment m x
+      = (0 : ℝ) ^ m + x * ∑ i ∈ Finset.range m, (m.choose i : ℝ) * infMoment i x := by
+  -- The two sides of the finite recurrence agree term-by-term.
+  have hEq : ∀ n, (1 - x) * momentSum m n x
+      = (0 : ℝ) ^ m - (n : ℝ) ^ m * x ^ n
+        + x * ∑ i ∈ Finset.range m, (m.choose i : ℝ) * momentSum i n x :=
+    fun n => momentSum_recurrence m n x
+  -- LHS: `(1 − x)·momentSum m n x → (1 − x)·infMoment m x`.
+  have hL : Tendsto (fun n => (1 - x) * momentSum m n x) atTop
+      (𝓝 ((1 - x) * infMoment m x)) :=
+    (tendsto_momentSum m hx).const_mul (1 - x)
+  -- The inner finite sum converges term-by-term.
+  have hInner : Tendsto
+      (fun n => ∑ i ∈ Finset.range m, (m.choose i : ℝ) * momentSum i n x) atTop
+      (𝓝 (∑ i ∈ Finset.range m, (m.choose i : ℝ) * infMoment i x)) :=
+    tendsto_finset_sum _ fun i _ => (tendsto_momentSum i hx).const_mul _
+  -- RHS converges to `0ᵐ − 0 + x·∑ C(m,i)·infMoment i x`.
+  have hR : Tendsto
+      (fun n : ℕ => (0 : ℝ) ^ m - (n : ℝ) ^ m * x ^ n
+        + x * ∑ i ∈ Finset.range m, (m.choose i : ℝ) * momentSum i n x) atTop
+      (𝓝 ((0 : ℝ) ^ m - 0
+        + x * ∑ i ∈ Finset.range m, (m.choose i : ℝ) * infMoment i x)) :=
+    ((tendsto_const_nhds.sub (tendsto_boundary m hx)).add (hInner.const_mul x))
+  rw [sub_zero] at hR
+  -- LHS and RHS are the same sequence, so their limits agree.
+  exact tendsto_nhds_unique hL (hR.congr fun n => (hEq n).symm)
+
+/-- For `m ≥ 1` the `0ᵐ` term drops, leaving the pure convolution recurrence
+`(1 − x)·infMoment (m+1) x = x·∑_{i≤m} C(m+1,i)·infMoment i x`. -/
+theorem infMoment_recurrence_succ (m : ℕ) {x : ℝ} (hx : |x| < 1) :
+    (1 - x) * infMoment (m + 1) x
+      = x * ∑ i ∈ Finset.range (m + 1), ((m + 1).choose i : ℝ) * infMoment i x := by
+  have h := infMoment_recurrence (m + 1) hx
+  simpa using h
+
+/-- Solving (★∞) at `m = 0`: `infMoment 0 x = 1/(1 − x)` (the plain geometric
+series), recovered from the recurrence (its `0⁰ = 1` constant term). -/
+theorem infMoment_zero {x : ℝ} (hx : |x| < 1) :
+    infMoment 0 x = (1 - x)⁻¹ := by
+  have hne : (1 - x) ≠ 0 := by
+    have : x < 1 := (abs_lt.mp hx).2
+    linarith
+  have h := infMoment_recurrence 0 hx
+  simp only [pow_zero, Finset.range_zero, Finset.sum_empty, mul_zero, add_zero] at h
+  field_simp at h ⊢
+  linarith [h]
+
+/-- Solving (★∞) at `m = 1`: `infMoment 1 x = x/(1 − x)²`, the infinite
+arithmetico-geometric sum `∑ k·xᵏ` (gallery `geometric-series-oq-08-oq-01`). -/
+theorem infMoment_one {x : ℝ} (hx : |x| < 1) :
+    infMoment 1 x = x / (1 - x) ^ 2 := by
+  have hne : (1 - x) ≠ 0 := by
+    have : x < 1 := (abs_lt.mp hx).2
+    linarith
+  have h := infMoment_recurrence 1 hx
+  simp only [pow_one, Finset.range_one, Finset.sum_singleton,
+    Nat.cast_one, one_mul, Nat.choose_zero_right] at h
+  rw [infMoment_zero hx] at h
+  field_simp at h ⊢
+  linarith [h]
+
+/-- Solving (★∞) at `m = 2`: `infMoment 2 x = x(1 + x)/(1 − x)³`, the infinite
+second moment `∑ k²·xᵏ` (gallery `geometric-series-oq-08-oq-01-oq-01`). -/
+theorem infMoment_two {x : ℝ} (hx : |x| < 1) :
+    infMoment 2 x = x * (1 + x) / (1 - x) ^ 3 := by
+  have hne : (1 - x) ≠ 0 := by
+    have : x < 1 := (abs_lt.mp hx).2
+    linarith
+  have h := infMoment_recurrence 2 hx
+  rw [Finset.sum_range_succ, Finset.sum_range_one] at h
+  simp only [Nat.choose_zero_right, Nat.choose_one_right, Nat.cast_ofNat, Nat.cast_one,
+    one_mul] at h
+  rw [infMoment_zero hx, infMoment_one hx] at h
+  have hpow : (0 : ℝ) ^ 2 = 0 := by norm_num
+  rw [hpow] at h
+  field_simp at h ⊢
+  ring_nf at h ⊢
+  linarith [h]
+
+end GeometricSeriesOQ08OQ01OQ01OQ01OQ02

--- a/proofs/Proofs/SpernerSimplicialBridgeOQ02.lean
+++ b/proofs/Proofs/SpernerSimplicialBridgeOQ02.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2026 RJ Walters. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: RJ Walters
+-/
+import Proofs.SpernerSimplicialBridge
+import Mathlib.Analysis.Convex.SimplicialComplex.Basic
+import Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional
+
+/-
+# Extending the Sperner bridge to `Geometry.SimplicialComplex`
+
+The parent file `SpernerSimplicialBridge.lean` proves Sperner's lemma for a
+finite set `topCells : Finset (Finset E)` of top simplices satisfying a purity
+and a pseudomanifold condition (`Sperner.SimplicialComplex.exists_panchromatic`).
+Its closing remark poses the open question:
+
+> Does this bridge extend to Mathlib's `Geometry.SimplicialComplex` type by
+> extracting `facets` and verifying the pseudomanifold condition? The key
+> obstacle is reconciling Mathlib's affine-set encoding with this bridge's
+> finset-of-vertices encoding.
+
+This file answers it. The reconciliation turns out to be clean: Mathlib already
+stores the faces of a `Geometry.SimplicialComplex 𝕜 E` as `Finset E` (vertex
+sets), the very same encoding the bridge consumes. The affine structure
+(`AffineIndependent`, convex-hull gluing) is *extra* data layered on top of the
+combinatorial vertex sets, not a competing encoding. So the bridge applies
+verbatim once we package three structural facts:
+
+1. **Finiteness / facet extraction.** `K.facets : Set (Finset E)` must be
+   enumerated by a `Finset (Finset E)`. We supply `exists_facet_superset`: in a
+   *finite* complex every face lies below a facet, so the facets genuinely form
+   the "top cells" the bridge needs.
+2. **Purity.** Every facet has `d + 1` vertices.
+3. **Pseudomanifold.** Every codimension-1 face lies in at most two facets.
+
+## Main results
+
+* `Sperner.SimplicialComplex.exists_facet_superset` — every face of a finite
+  Mathlib complex is contained in a facet (a genuinely new lemma; Mathlib has
+  only `not_facet_iff_subface`).
+* `Sperner.SimplicialComplex.facet_affineIndependent` — facets carry the affine
+  structure: the vertices of a facet are affinely independent.
+* `Sperner.SimplicialComplex.facet_card_le_finrank_succ` /
+  `facet_dim_le_ambient` — the affine encoding bounds the combinatorial
+  dimension: a facet has at most `finrank 𝕜 E + 1` vertices, so a pure complex of
+  combinatorial dimension `d` requires ambient dimension `d ≤ finrank 𝕜 E`.
+* `Sperner.SimplicialComplex.exists_panchromatic_facet` — the bridge applied to a
+  Mathlib complex: a panchromatic facet exists, and the witness is a genuine
+  element of `K.facets`.
+* `Sperner.SimplicialComplex.exists_panchromatic_facet_of_finrank` — the same,
+  in a finite-dimensional field setting, additionally certifying `d ≤ finrank`.
+
+## References
+
+* [M. De Longueville, *A Course in Topological Combinatorics*]
+
+## Tags
+
+Sperner, simplicial complex, pseudomanifold, bridge, facets, Geometry
+-/
+
+namespace Sperner.SimplicialComplex
+
+open Finset
+
+/-! ## Facet extraction for finite Mathlib complexes
+
+These lemmas establish the structural facts the bridge consumes when its input is
+a Mathlib `Geometry.SimplicialComplex` rather than a raw `Finset (Finset E)`.
+They make precise the sense in which the "affine-set encoding" and the
+"finset-of-vertices encoding" agree: a face *is* a `Finset E`, and facets are
+distinguished combinatorially as the maximal faces. -/
+
+section MathlibFacets
+
+variable {𝕜 : Type*} {E : Type*}
+  [Ring 𝕜] [PartialOrder 𝕜] [AddCommGroup E] [Module 𝕜 E]
+
+/-- **Every face of a finite complex lies below a facet.**
+
+Mathlib provides `not_facet_iff_subface` (a non-facet has a strict superface) but
+not the existence of a maximal superface. For a finite complex it follows by
+picking a face of maximal cardinality among those containing `s`. This certifies
+that the `facets` we hand to the bridge actually exhaust the top-dimensional
+combinatorial data. -/
+theorem exists_facet_superset (K : Geometry.SimplicialComplex 𝕜 E)
+    (hfin : K.faces.Finite) {s : Finset E} (hs : s ∈ K.faces) :
+    ∃ t ∈ K.facets, s ⊆ t := by
+  have hFfin : {t | t ∈ K.faces ∧ s ⊆ t}.Finite := hfin.subset fun t ht => ht.1
+  obtain ⟨t, ⟨htf, hst⟩, htmax⟩ := hFfin.exists_maximal ⟨s, hs, subset_rfl⟩
+  refine ⟨t, Geometry.SimplicialComplex.mem_facets.mpr ⟨htf, fun u hu htu => ?_⟩, hst⟩
+  exact le_antisymm htu (htmax ⟨hu, hst.trans htu⟩ htu)
+
+/-- A facet is in particular a face, so its vertices are affinely independent.
+This is the precise statement that the bridge's combinatorial facets carry
+Mathlib's affine structure for free. -/
+theorem facet_affineIndependent (K : Geometry.SimplicialComplex 𝕜 E)
+    {s : Finset E} (hs : s ∈ K.facets) :
+    AffineIndependent 𝕜 ((↑) : s → E) :=
+  K.indep (K.facets_subset hs)
+
+end MathlibFacets
+
+/-! ## The affine encoding bounds the combinatorial dimension
+
+Over a finite-dimensional space the affine independence of a facet's vertices
+caps its cardinality at `finrank 𝕜 E + 1`. This is exactly the obstruction the
+open question worries about — reconciling the affine encoding with the
+combinatorial one — resolved quantitatively. -/
+
+section Dimension
+
+variable {𝕜 : Type*} {E : Type*}
+  [DivisionRing 𝕜] [PartialOrder 𝕜] [AddCommGroup E] [Module 𝕜 E] [FiniteDimensional 𝕜 E]
+
+/-- A facet has at most `finrank 𝕜 E + 1` vertices: its affinely independent
+vertex set cannot exceed the ambient affine dimension plus one. -/
+theorem facet_card_le_finrank_succ (K : Geometry.SimplicialComplex 𝕜 E)
+    {s : Finset E} (hs : s ∈ K.facets) :
+    s.card ≤ Module.finrank 𝕜 E + 1 := by
+  have hbound := (facet_affineIndependent K hs).card_le_finrank_succ
+  rw [Fintype.card_coe] at hbound
+  have hle : Module.finrank 𝕜 (vectorSpan 𝕜 (Set.range ((↑) : s → E)))
+      ≤ Module.finrank 𝕜 E := Submodule.finrank_le _
+  omega
+
+/-- In a pure complex of combinatorial dimension `d` (every facet has `d + 1`
+vertices) the ambient space must have dimension at least `d`. -/
+theorem facet_dim_le_ambient (K : Geometry.SimplicialComplex 𝕜 E)
+    {s : Finset E} (hs : s ∈ K.facets) {d : ℕ} (hcard : s.card = d + 1) :
+    d ≤ Module.finrank 𝕜 E := by
+  have := facet_card_le_finrank_succ K hs
+  omega
+
+end Dimension
+
+/-! ## The bridge applied to a Mathlib complex
+
+Given a `Finset (Finset E)` enumerating the facets of `K`, together with purity,
+the pseudomanifold condition, a coloring, and an odd boundary parity, the bridge
+delivers a panchromatic top cell — and that cell is a genuine `K.facets` member.
+This is the concrete affirmative answer to the open question. -/
+
+section Bridge
+
+variable {𝕜 : Type*} {E : Type}
+  [Ring 𝕜] [PartialOrder 𝕜] [AddCommGroup E] [Module 𝕜 E]
+  [DecidableEq E] [LinearOrder E] {d : ℕ}
+
+/-- **Sperner's lemma for a Mathlib `Geometry.SimplicialComplex`.**
+
+Let `K : Geometry.SimplicialComplex 𝕜 E` and let `topCells` enumerate the facets
+of `K` (`htop`). If `K` is pure of combinatorial dimension `d` (`hpure`),
+satisfies the pseudomanifold condition (`hpseudo`), and `c` is a coloring whose
+boundary door count is odd (`hbdry`), then some facet of `K` is panchromatic:
+the `d + 1` vertices of that facet receive all `d + 1` colours. -/
+theorem exists_panchromatic_facet (K : Geometry.SimplicialComplex 𝕜 E)
+    (topCells : Finset (Finset E))
+    (htop : ∀ s, s ∈ topCells ↔ s ∈ K.facets)
+    (hpure : ∀ s ∈ topCells, s.card = d + 1)
+    (hpseudo : ∀ f : Finset E, f.card = d →
+      (topCells.filter (fun s => f ⊆ s)).card ≤ 2)
+    (c : E → Fin (d + 1))
+    (hbdry : Odd (Finset.univ.filter
+      (fun p : { s : Finset E // s ∈ topCells } × Fin (d + 1) =>
+        Sperner.IsDoor (fun (σ : { s // s ∈ topCells }) => vertexEnum σ.1 (hpure σ.1 σ.2))
+          c p.1 p.2 ∧
+        adjFn topCells hpure p.1 p.2 = none)).card) :
+    ∃ σ : { s : Finset E // s ∈ topCells },
+      Sperner.IsPanchromatic
+        (fun (σ : { s // s ∈ topCells }) => vertexEnum σ.1 (hpure σ.1 σ.2)) c σ ∧
+      σ.1 ∈ K.facets := by
+  obtain ⟨σ, hσ⟩ := exists_panchromatic topCells hpure hpseudo c hbdry
+  exact ⟨σ, hσ, (htop σ.1).mp σ.2⟩
+
+end Bridge
+
+/-! ## Capstone: a panchromatic facet of certified dimension
+
+Specialising to a finite-dimensional field, the panchromatic facet supplied by
+the bridge additionally respects the ambient dimension: its combinatorial
+dimension `d` satisfies `d ≤ finrank 𝕜 E`. This packages the whole answer to the
+open question — facet extraction, the pseudomanifold input, the combinatorial
+Sperner conclusion, and the affine-dimension constraint — in one statement. -/
+
+section Capstone
+
+variable {𝕜 : Type*} {E : Type}
+  [DivisionRing 𝕜] [PartialOrder 𝕜] [AddCommGroup E] [Module 𝕜 E] [FiniteDimensional 𝕜 E]
+  [DecidableEq E] [LinearOrder E] {d : ℕ}
+
+/-- The bridge for a finite-dimensional Mathlib complex, certifying both that the
+panchromatic witness is a genuine facet and that the combinatorial dimension is
+bounded by the ambient affine dimension. -/
+theorem exists_panchromatic_facet_of_finrank (K : Geometry.SimplicialComplex 𝕜 E)
+    (topCells : Finset (Finset E))
+    (htop : ∀ s, s ∈ topCells ↔ s ∈ K.facets)
+    (hpure : ∀ s ∈ topCells, s.card = d + 1)
+    (hpseudo : ∀ f : Finset E, f.card = d →
+      (topCells.filter (fun s => f ⊆ s)).card ≤ 2)
+    (c : E → Fin (d + 1))
+    (hbdry : Odd (Finset.univ.filter
+      (fun p : { s : Finset E // s ∈ topCells } × Fin (d + 1) =>
+        Sperner.IsDoor (fun (σ : { s // s ∈ topCells }) => vertexEnum σ.1 (hpure σ.1 σ.2))
+          c p.1 p.2 ∧
+        adjFn topCells hpure p.1 p.2 = none)).card) :
+    ∃ σ : { s : Finset E // s ∈ topCells },
+      Sperner.IsPanchromatic
+        (fun (σ : { s // s ∈ topCells }) => vertexEnum σ.1 (hpure σ.1 σ.2)) c σ ∧
+      σ.1 ∈ K.facets ∧ d ≤ Module.finrank 𝕜 E := by
+  obtain ⟨σ, hpan, hfacet⟩ :=
+    exists_panchromatic_facet K topCells htop hpure hpseudo c hbdry
+  exact ⟨σ, hpan, hfacet, facet_dim_le_ambient K hfacet (hpure σ.1 σ.2)⟩
+
+end Capstone
+
+end Sperner.SimplicialComplex

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02",
+  "slug": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic",
+      "Proofs.GeometricSeriesOQ08OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "GeometricSeriesOQ08OQ01OQ01OQ01OQ02",
+    "lineCount": 188,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Infinite-Limit Recurrence: ∑_{k≥0} kᵐ·xᵏ for |x| < 1",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "arithmetico-geometric",
+      "infinite-series",
+      "moments",
+      "recurrence",
+      "summability",
+      "tsum",
+      "eulerian",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 188,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "infMoment: the infinite m-th moment ∑'_{k} (k:ℝ)ᵐ·xᵏ of a real geometric series, defined as a tsum, the convergent companion of the parent's finite momentSum.",
+      "infMoment_recurrence: the master infinite recurrence (★∞) (1 − x)·infMoment m x = 0ᵐ + x·∑_{i<m} C(m,i)·infMoment i x for |x| < 1. It is obtained as the n → ∞ limit of the parent's finite recurrence (★): the finite partial sums momentSum m n x converge to infMoment m x, the boundary term nᵐ·xⁿ — the general term of a convergent series — vanishes, and uniqueness of limits yields the clean binomial-convolution recursion. A first-order-in-m convolution expressing the m-th infinite moment through ALL lower moments using only the Pascal weights C(m,i), with no derivatives and no special functions.",
+      "tendsto_momentSum: the convergence momentSum m n x → infMoment m x as n → ∞ (from summability via HasSum.tendsto_sum_nat) — the bridge from the finite to the infinite theory.",
+      "tendsto_boundary: the vanishing of the finite recurrence's boundary term, nᵐ·xⁿ → 0, proved structurally as Summable.tendsto_atTop_zero (it is the general term of the summable moment series), NOT via a separate polynomial-times-geometric estimate.",
+      "summable_moment: summability of ∑ kᵐ·xᵏ for |x| < 1, from Mathlib's summable_pow_mul_geometric_of_norm_lt_one.",
+      "infMoment_recurrence_succ: the m ≥ 1 form (1 − x)·infMoment (m+1) x = x·∑_{i≤m} C(m+1,i)·infMoment i x, with the 0ᵐ constant term dropped.",
+      "infMoment_zero / _one / _two: solving (★∞) at m = 0, 1, 2 recovers the gallery's explicit closed forms — infMoment 0 x = 1/(1 − x); infMoment 1 x = x/(1 − x)² (the infinite arithmetico-geometric sum); infMoment 2 x = x(1 + x)/(1 − x)³ (the infinite second moment ∑ k²·xᵏ)."
+    ],
+    "prerequisites": [
+      "summable_pow_mul_geometric_of_norm_lt_one for summability of ∑ kᵐ·xᵏ when ‖x‖ < 1",
+      "HasSum.tendsto_sum_nat to convert summability into convergence of the partial sums momentSum m n x",
+      "Summable.tendsto_atTop_zero for the vanishing of the boundary term nᵐ·xⁿ",
+      "tendsto_finset_sum and Tendsto.const_mul for passing the finite inner sum and the (1 − x)·• factor through the limit",
+      "tendsto_nhds_unique to equate the two limits of the parent's finite recurrence",
+      "Parent: geometric-series-oq-08-oq-01-oq-01-oq-01 (the finite master recurrence (★) for momentSum m n x)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "summable_pow_mul_geometric_of_norm_lt_one",
+        "description": "Summable (fun n ↦ (n:R)ᵏ·rⁿ) when ‖r‖ < 1. Supplies summability of every moment series ∑ kᵐ·xᵏ, which drives both the convergence of the partial sums and the vanishing of the boundary term.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "HasSum.tendsto_sum_nat",
+        "description": "A summable series' partial sums ∑_{k<n} f k tend to its tsum. Turns summability into momentSum m n x → infMoment m x.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "Summable.tendsto_atTop_zero",
+        "description": "The general term of a summable series tends to 0. Gives nᵐ·xⁿ → 0 directly, without a polynomial-times-geometric decay estimate.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "tendsto_nhds_unique",
+        "description": "Limits in a Hausdorff space are unique. Equates the two limits of the parent's finite recurrence (the same sequence in n) to produce (★∞).",
+        "module": "Mathlib.Topology.Separation.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+      "question": "Solve the infinite recurrence (★∞) in closed form to re-derive the Eulerian-polynomial numerator: prove by strong induction on m that infMoment m x = Aₘ(x)/(1 − x)^{m+1} with Aₘ the gallery's eulerPoly (geometric-series-oq-07-oq-01-oq-01), purely from (★∞) and the Eulerian recurrence Aₘ₊₁ = (1 + mx)Aₘ + x(1−x)Aₘ', closing the loop between the convolution recurrence here and the Frobenius identity.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-08-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent. The parent proves the finite master recurrence (★) for momentSum m n x over any commutative ring; this entry passes it to the n → ∞ limit for |x| < 1, where the boundary term nᵐ·xⁿ vanishes, yielding the clean infinite convolution recurrence (★∞) for infMoment m x = ∑'_{k} kᵐ·xᵏ."
+    },
+    {
+      "targetId": "geometric-series-oq-08-oq-01",
+      "relationship": "extends",
+      "description": "Ancestor (m = 1). Its infinite first moment x/(1 − x)² is recovered here as infMoment_one, solved directly from (★∞)."
+    },
+    {
+      "targetId": "geometric-series-oq-08-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Ancestor (m = 2). Its second moment x(1 + x)/(1 − x)³ is recovered here as infMoment_two, solved from (★∞) using infMoment_zero and infMoment_one."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01",
+      "relationship": "sibling",
+      "description": "Records the same infinite all-orders moment ∑'_{n} nᵐ·rⁿ in explicit Stirling form ∑_k S(m,k)·k!·rᵏ/(1 − r)^{k+1}. This entry instead characterises the whole sequence (infMoment m)ₘ by a binomial-convolution recurrence rather than a one-shot closed form."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Defines the Eulerian polynomial eulerPoly and proves infMoment m x = eulerPoly m (x)/(1 − x)^{m+1} (Frobenius). The recurrence (★∞) here is the complementary, derivative-free recursion for the same moments; the open question proposes closing the loop between the two."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (weighted geometric sums ∑ kᵐ·xᵏ, generating functions, Eulerian numbers)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the moment sums ∑ kᵐ·xᵏ, their rational closed forms with Eulerian-polynomial numerators, and the perturbation/recurrence methods used to derive them."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed (summable_pow_mul_geometric_of_norm_lt_one) and Topology.Algebra.InfiniteSum (HasSum.tendsto_sum_nat, Summable.tendsto_atTop_zero)",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Provides summability of ∑ kᵐ·xᵏ and the limit infrastructure; neither the moment sum as a named object nor any recurrence across m for the infinite moments is in Mathlib."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For a real ratio x with |x| < 1, the infinite m-th moment infMoment m x = ∑'_{k} kᵐ·xᵏ satisfies the binomial-convolution recurrence (1 − x)·infMoment m x = 0ᵐ + x·∑_{i<m} C(m,i)·infMoment i x. It is the n → ∞ limit of the parent's finite master recurrence: the finite partial sums converge to the infinite moment and the boundary term nᵐ·xⁿ — the general term of a convergent series — vanishes, so the boundary correction the finite sum had to carry simply washes out. Solving the recurrence at m = 0, 1, 2 recovers the gallery's explicit closed forms 1/(1 − x), x/(1 − x)², and x(1 + x)/(1 − x)³. 188 lines, 8 theorems, 1 definition, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The recurrence (★∞) characterises the entire sequence of infinite moments (infMoment m)ₘ by a first-order-in-m convolution with Pascal weights, with no derivatives and no special functions — a recursion complementary to the gallery's two explicit one-shot closed forms (the Stirling form in geometric-series-oq-07-oq-01 and the Frobenius/Eulerian form in geometric-series-oq-07-oq-01-oq-01). It also shows cleanly how the finite theory's n-dependent boundary term nᵐ·xⁿ disappears under |x| < 1, so the infinite recurrence is genuinely simpler than its finite parent. Such moment sums compute the moments of geometric and negative-binomial distributions and the coefficients of rational generating functions.",
+    "openQuestions": [
+      "Solve (★∞) in closed form to re-derive infMoment m x = eulerPoly m (x)/(1 − x)^{m+1}, closing the loop between this convolution recurrence and the Frobenius/Eulerian identity (geometric-series-oq-07-oq-01-oq-01)."
+    ]
+  }
+}

--- a/src/data/proofs/sperner-simplicial-bridge-oq-02/annotations.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-spc-oq02-header",
+    "proofId": "sperner-simplicial-bridge-oq-02",
+    "range": { "startLine": 10, "endLine": 61 },
+    "type": "concept",
+    "title": "The open question and its resolution",
+    "content": "The module docstring states the parent's open question — does the pseudomanifold bridge extend to Mathlib's Geometry.SimplicialComplex? — and its answer. The reframing is the key idea: Mathlib stores faces as `Finset E` (vertex sets), the *same* encoding the bridge consumes. The affine data (AffineIndependent, convexHull gluing) is layered on top, not a rival encoding, so no translation is needed — only facet extraction plus purity and the pseudomanifold check."
+  },
+  {
+    "id": "ann-spc-oq02-facet-superset",
+    "proofId": "sperner-simplicial-bridge-oq-02",
+    "range": { "startLine": 80, "endLine": 93 },
+    "type": "technique",
+    "title": "exists_facet_superset: every face lies below a facet",
+    "content": "A genuinely new lemma. Mathlib only had `not_facet_iff_subface` (a non-facet has a strict superface). Here, for a *finite* complex, `Finite.exists_maximal` selects a face `t` of maximal cardinality among `{t ∈ K.faces | s ⊆ t}`; maximality plus antisymmetry of ⊆ (`le_antisymm`) forces `t` to satisfy the facet condition `∀ u ∈ faces, t ⊆ u → t = u`. This makes 'extract the facets' well-posed."
+  },
+  {
+    "id": "ann-spc-oq02-affine-indep",
+    "proofId": "sperner-simplicial-bridge-oq-02",
+    "range": { "startLine": 95, "endLine": 101 },
+    "type": "insight",
+    "title": "facet_affineIndependent: encoding reconciliation",
+    "content": "A facet is a face (`facets_subset`), so `K.indep` applies directly: the vertices of a facet are affinely independent. This one-line lemma is the precise statement that the bridge's combinatorial facets carry Mathlib's affine structure for free — the encodings are compatible, not competing."
+  },
+  {
+    "id": "ann-spc-oq02-dim-bound",
+    "proofId": "sperner-simplicial-bridge-oq-02",
+    "range": { "startLine": 117, "endLine": 134 },
+    "type": "technique",
+    "title": "Dimension bound: facet_card_le_finrank_succ",
+    "content": "Chains `AffineIndependent.card_le_finrank_succ` (card ≤ dim of the vertices' vectorSpan + 1) with `Submodule.finrank_le` (vectorSpan ⊆ E, so its finrank ≤ finrank E) and closes with `omega`. `Fintype.card_coe` rewrites `Fintype.card ↥s` to `s.card`. Corollary `facet_dim_le_ambient` reads off `d ≤ finrank 𝕜 E` for pure complexes — the affine encoding's quantitative grip on the combinatorial one."
+  },
+  {
+    "id": "ann-spc-oq02-bridge",
+    "proofId": "sperner-simplicial-bridge-oq-02",
+    "range": { "startLine": 151, "endLine": 189 },
+    "type": "concept",
+    "title": "exists_panchromatic_facet: the bridge fires",
+    "content": "Feeds an enumerating `Finset` of `K.facets` (hypothesis `htop`) into the parent's `exists_panchromatic`, using purity `hpure` as the vertexEnum cardinality witness. The returned witness `σ` is converted back to a genuine `K.facets` membership via `(htop σ.1).mp σ.2`, so the conclusion lives inside Mathlib's native facet API."
+  },
+  {
+    "id": "ann-spc-oq02-capstone",
+    "proofId": "sperner-simplicial-bridge-oq-02",
+    "range": { "startLine": 191, "endLine": 217 },
+    "type": "insight",
+    "title": "Capstone with certified dimension",
+    "content": "`exists_panchromatic_facet_of_finrank` specialises to a finite-dimensional field and bundles everything: the panchromatic witness is a genuine facet *and* its combinatorial dimension satisfies `d ≤ finrank 𝕜 E`, by applying `facet_dim_le_ambient` to the witness. One statement captures the full answer to the open question."
+  }
+]

--- a/src/data/proofs/sperner-simplicial-bridge-oq-02/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-02/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "sperner-simplicial-bridge-oq-02",
+  "title": "Sperner's Lemma Bridge for Mathlib's Geometry.SimplicialComplex",
+  "slug": "sperner-simplicial-bridge-oq-02",
+  "description": "Answers the open question posed by sperner-simplicial-bridge: does the pseudomanifold door-counting bridge extend to Mathlib's Geometry.SimplicialComplex? Yes. The apparent 'affine-set vs finset-of-vertices encoding' obstruction dissolves because Mathlib already stores faces as Finset E; affine independence is extra data layered on top, not a competing encoding. The file extracts facets (with a new exists_facet_superset lemma for finite complexes), transfers the affine structure, bounds the combinatorial dimension by the ambient affine dimension, and instantiates the bridge so the panchromatic witness is a genuine K.facets element.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma",
+    "date": "2026",
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0",
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "lineCount": 218,
+    "imports": [
+      "Proofs.SpernerSimplicialBridge",
+      "Mathlib.Analysis.Convex.SimplicialComplex.Basic",
+      "Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional"
+    ],
+    "tags": [
+      "combinatorics",
+      "topology",
+      "sperner",
+      "simplicial-complex",
+      "pseudomanifold",
+      "bridge",
+      "facets",
+      "affine-independence"
+    ],
+    "assumptions": "No axioms or sorries; #print axioms reports only propext, Classical.choice, Quot.sound (the standard foundational axioms). The combinatorial Sperner content is imported from the parent bridge SpernerSimplicialBridge (Sperner.SimplicialComplex.exists_panchromatic, itself 0-axiom). This file introduces no new mathematical assumptions: it carries hypotheses (facet enumeration htop, purity hpure, pseudomanifold hpseudo, coloring c, odd boundary parity hbdry) through to the imported bridge, and adds genuinely new structural lemmas about Mathlib's Geometry.SimplicialComplex (exists_facet_superset, facet_affineIndependent, facet_card_le_finrank_succ, facet_dim_le_ambient). The dimension lemmas additionally require a DivisionRing scalar field and a FiniteDimensional ambient space; the bridge theorem requires DecidableEq and LinearOrder on the vertex type E (used by the parent bridge's Finset.sort).",
+    "sorries": 0,
+    "proofRepoPath": "Proofs/SpernerSimplicialBridgeOQ02.lean",
+    "originalContributions": [
+      "exists_facet_superset: in a finite Mathlib simplicial complex, every face lies below a facet. Mathlib has only not_facet_iff_subface (a non-facet has a strict superface); the existence of a *maximal* superface is new, proved via Finite.exists_maximal on the finite set of faces containing s.",
+      "facet_affineIndependent: facets carry Mathlib's affine structure for free — the vertices of a facet are affinely independent (K.indep ∘ facets_subset). This is the precise statement reconciling the 'affine-set encoding' with the 'finset-of-vertices encoding'.",
+      "facet_card_le_finrank_succ + facet_dim_le_ambient: the affine encoding quantitatively bounds the combinatorial encoding — a facet has at most finrank 𝕜 E + 1 vertices (via AffineIndependent.card_le_finrank_succ and Submodule.finrank_le), so a pure complex of combinatorial dimension d needs ambient dimension d ≤ finrank 𝕜 E.",
+      "exists_panchromatic_facet: the bridge applied to a Mathlib Geometry.SimplicialComplex. Given a Finset enumerating K.facets plus purity/pseudomanifold/coloring/parity, produces a panchromatic facet whose witness is a genuine element of K.facets.",
+      "exists_panchromatic_facet_of_finrank: the capstone — in a finite-dimensional field setting, additionally certifies that the panchromatic facet's combinatorial dimension is bounded by the ambient affine dimension (d ≤ finrank 𝕜 E)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "facet-extraction",
+      "title": "Facet extraction for finite Mathlib complexes",
+      "startLine": 67,
+      "endLine": 103,
+      "summary": "exists_facet_superset: every face of a finite complex lies below a facet, proved by selecting a maximal face among those containing s via Finite.exists_maximal, then showing maximality forces the facet condition by antisymmetry. facet_affineIndependent: a facet is a face, so K.indep gives affine independence of its vertices — the explicit bridge from Mathlib's affine encoding to the combinatorial vertex-set encoding."
+    },
+    {
+      "id": "dimension-bound",
+      "title": "The affine encoding bounds the combinatorial dimension",
+      "startLine": 105,
+      "endLine": 136,
+      "summary": "facet_card_le_finrank_succ: a facet's affinely independent vertex set has at most finrank 𝕜 E + 1 elements, combining AffineIndependent.card_le_finrank_succ (cardinality ≤ vectorSpan dimension + 1) with Submodule.finrank_le (vectorSpan ⊆ E). facet_dim_le_ambient: for a pure complex (facet card = d+1) this reads d ≤ finrank 𝕜 E. This resolves the encoding-obstruction quantitatively: the combinatorial dimension cannot exceed the ambient affine dimension."
+    },
+    {
+      "id": "bridge-theorem",
+      "title": "The bridge applied to a Mathlib complex",
+      "startLine": 138,
+      "endLine": 189,
+      "summary": "exists_panchromatic_facet: given K : Geometry.SimplicialComplex 𝕜 E, a Finset topCells enumerating K.facets (htop), purity, the pseudomanifold condition, a coloring, and odd boundary parity, the imported bridge exists_panchromatic yields a panchromatic top cell; htop transports the witness back to a genuine K.facets membership. This is the concrete affirmative answer to the open question."
+    },
+    {
+      "id": "capstone",
+      "title": "Capstone: a panchromatic facet of certified dimension",
+      "startLine": 191,
+      "endLine": 217,
+      "summary": "exists_panchromatic_facet_of_finrank: specialising to a finite-dimensional field, the panchromatic witness is certified both as a genuine facet and as respecting the ambient dimension (d ≤ finrank 𝕜 E). Packages facet extraction, the pseudomanifold input, the combinatorial Sperner conclusion, and the affine-dimension constraint into a single statement."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Sperner's lemma (Emanuel Sperner, 1928) is the combinatorial heart of Brouwer's fixed-point theorem. The Lean Genius gallery formalizes it in three layers: SpernerMathlib (abstract door-counting parity), SpernerSimplicialBridge (pseudomanifold simplicial data → abstract axioms), and SpernerSimplicialInstance (concrete triangulations → bridge). The bridge file deliberately parameterizes over a raw Finset (Finset E) of top cells and avoids importing Mathlib's geometric simplicial-complex stack, leaving as an explicit open question whether it connects to Mathlib's own Geometry.SimplicialComplex 𝕜 E (Dillies–Mehta, Mathlib 2021). This entry closes that question.",
+    "problemStatement": "**Open question (from sperner-simplicial-bridge):** Does this bridge extend to Mathlib's Geometry.SimplicialComplex type by extracting facets and verifying the pseudomanifold condition? The stated obstacle is reconciling Mathlib's affine-set encoding with the bridge's finset-of-vertices encoding.\n\n**Answer:** Yes. Mathlib's K.faces is already a Set (Finset E) of vertex sets, and K.facets ⊆ K.faces is the set of maximal such finsets — the same combinatorial datum the bridge consumes. The affine structure (AffineIndependent, convex-hull gluing) is *additional* data, not a rival encoding. Supplying a finite enumeration of K.facets, purity, and the pseudomanifold condition lets the imported bridge fire, and the panchromatic witness is a genuine K.facets member.",
+    "proofStrategy": "Four parts, all machine-checked with no axioms or sorries.\n\n1. **Facet extraction (general ring).** exists_facet_superset proves that in a finite complex every face sits below a facet — via Finite.exists_maximal on {t ∈ K.faces | s ⊆ t} and antisymmetry of ⊆. facet_affineIndependent transfers K.indep to facets.\n\n2. **Dimension bound (division ring, finite-dimensional).** facet_card_le_finrank_succ chains AffineIndependent.card_le_finrank_succ with Submodule.finrank_le to cap facet cardinality at finrank 𝕜 E + 1; facet_dim_le_ambient specializes to d ≤ finrank for pure complexes.\n\n3. **Bridge instantiation (linearly ordered vertices).** exists_panchromatic_facet feeds an enumerating Finset of K.facets, with purity as the cardinality witness, straight into the parent's exists_panchromatic, then converts the witness back to K.facets via htop.\n\n4. **Capstone.** exists_panchromatic_facet_of_finrank combines (2) and (3) in a finite-dimensional field setting.",
+    "keyInsights": [
+      "**The encoding 'obstruction' is illusory at the combinatorial level.** Mathlib's Geometry.SimplicialComplex stores faces as Finset E — exactly the bridge's encoding. AffineIndependent and convexHull data ride on top; they are never an *alternative* representation of the vertex sets. So no translation between encodings is needed; one only needs to *expose* the facet finset and check purity/pseudomanifold.",
+      "**Facets exist and exhaust the top cells (finite case).** exists_facet_superset is the lemma that makes 'extract the facets' well-posed: every face is dominated by a facet, so the facets are a faithful top-dimensional skeleton. Mathlib lacked this (it had only the negative not_facet_iff_subface).",
+      "**The affine encoding constrains, rather than competes with, the combinatorial one.** facet_card_le_finrank_succ turns affine independence into a hard cardinality bound: a d-dimensional pure complex cannot embed in fewer than d affine dimensions. This is the productive content of the 'reconciliation' — the two encodings agree, and the affine one supplies a dimension inequality the combinatorial one cannot see.",
+      "**The witness is a genuine Mathlib facet.** exists_panchromatic_facet returns σ with σ.1 ∈ K.facets, not merely a member of an abstract topCells set. The bridge therefore lands inside Mathlib's own API, which is what 'extending the bridge to Geometry.SimplicialComplex' should mean.",
+      "**Purity is an input, not a theorem.** Mathlib's facets may have varying cardinality (the complex need not be pure). The bridge requires pure top cells, so purity (∀ s ∈ topCells, s.card = d+1) is carried as a hypothesis and reused as the cardinality witness for vertexEnum — a small but essential plumbing point."
+    ]
+  },
+  "conclusion": {
+    "summary": "The Sperner pseudomanifold bridge extends cleanly to Mathlib's Geometry.SimplicialComplex 𝕜 E (218 lines, 6 theorems, 0 definitions, no axioms or sorries). The headline exists_panchromatic_facet takes a Mathlib complex with an enumerated, pure, pseudomanifold set of facets and a Sperner-proper coloring of odd boundary parity, and produces a panchromatic facet that is a genuine K.facets member. Supporting lemmas (exists_facet_superset, facet_affineIndependent, facet_card_le_finrank_succ) are new structural facts about Mathlib simplicial complexes.",
+    "implications": "Closes the second open question of sperner-simplicial-bridge. Any finite, pure, pseudomanifold Mathlib Geometry.SimplicialComplex with a suitable coloring now yields Sperner's lemma directly through the gallery's door-counting machinery, with the witness expressed in Mathlib's native facet vocabulary. The new exists_facet_superset lemma (existence of a maximal superface in a finite complex) is independently useful and a plausible Mathlib upstream candidate. The remaining open questions of the parent — weakening purity to mixed-dimensional complexes, and locally-finite/infinite analogues — stay open.",
+    "openQuestions": [
+      "Can purity be dropped: does a stratified door-counting argument handle Mathlib complexes whose facets have mixed cardinalities?",
+      "When can the finiteness and pseudomanifold hypotheses be *derived* rather than assumed — e.g. for the boundary complex of a simplicial polytope, or a triangulated closed pseudomanifold, directly inside Mathlib?",
+      "Does facet_card_le_finrank_succ sharpen to an equality (facet card = finrank + 1) under a full-dimensionality hypothesis, giving an intrinsic notion of a 'top-dimensional' Mathlib facet?",
+      "Could the bridge be packaged as a Mathlib-style structure (a FinitePurePseudomanifold over a Geometry.SimplicialComplex) to make the four hypotheses reusable across instances?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sperner-simplicial-bridge",
+      "relationship": "extends",
+      "description": "Parent entry. This file answers its second open question by connecting the abstract topCells parameter to Mathlib's Geometry.SimplicialComplex.facets, importing exists_panchromatic directly."
+    },
+    {
+      "targetId": "sperner-mathlib",
+      "relationship": "uses",
+      "description": "Transitively: the parent bridge's exists_panchromatic is built on SpernerMathlib's abstract door-counting theorem."
+    },
+    {
+      "targetId": "sperner-simplicial-instance",
+      "relationship": "related",
+      "description": "Sibling layer that instantiates the same bridge for concrete Kuhn-style triangulations; this entry instead targets Mathlib's general Geometry.SimplicialComplex API."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "exists_panchromatic_facet",
+      "type": "core",
+      "statement": "$\\text{Given } K : \\mathrm{Geometry.SimplicialComplex}\\,\\Bbbk\\,E,\\ \\text{topCells enumerating } K.\\mathrm{facets},\\ \\text{purity } |s|=d+1,\\ \\text{the pseudomanifold condition},\\ c : E \\to \\mathrm{Fin}(d+1),\\ \\text{and odd boundary parity} \\Rightarrow \\exists\\,\\sigma,\\ \\sigma \\text{ panchromatic} \\wedge \\sigma.1 \\in K.\\mathrm{facets}$",
+      "significance": "**The affirmative answer to the open question.** The pseudomanifold door-counting bridge fires on a Mathlib Geometry.SimplicialComplex once its facets are enumerated and verified pure + pseudomanifold; the panchromatic witness is a genuine K.facets member, landing the result inside Mathlib's own simplicial-complex API.",
+      "description": "Sperner's lemma for a Mathlib Geometry.SimplicialComplex."
+    },
+    {
+      "name": "exists_facet_superset",
+      "type": "supporting",
+      "statement": "$K.\\mathrm{faces}\\text{ finite} \\wedge s \\in K.\\mathrm{faces} \\Rightarrow \\exists\\,t \\in K.\\mathrm{facets},\\ s \\subseteq t$",
+      "significance": "**New Mathlib-style lemma.** Existence of a maximal superface in a finite complex — Mathlib previously had only the negative not_facet_iff_subface. Makes 'extract the facets' well-posed: every face is dominated by a facet. Proved via Finite.exists_maximal and antisymmetry of ⊆.",
+      "description": "Every face of a finite complex lies below a facet."
+    },
+    {
+      "name": "facet_affineIndependent",
+      "type": "supporting",
+      "statement": "$s \\in K.\\mathrm{facets} \\Rightarrow \\mathrm{AffineIndependent}\\,\\Bbbk\\,((\\uparrow) : s \\to E)$",
+      "significance": "**The encoding reconciliation, made precise.** A facet is a face, so K.indep applies: its vertices are affinely independent. The bridge's combinatorial facets carry Mathlib's affine structure for free, demonstrating the two encodings are compatible, not competing.",
+      "description": "Facets carry Mathlib's affine independence structure."
+    },
+    {
+      "name": "facet_card_le_finrank_succ",
+      "type": "supporting",
+      "statement": "$[\\mathrm{FiniteDimensional}\\,\\Bbbk\\,E]\\ \\wedge\\ s \\in K.\\mathrm{facets} \\Rightarrow |s| \\le \\mathrm{finrank}\\,\\Bbbk\\,E + 1$",
+      "significance": "**The affine encoding bounds the combinatorial one.** Combines AffineIndependent.card_le_finrank_succ with Submodule.finrank_le. Corollary facet_dim_le_ambient gives d ≤ finrank 𝕜 E for pure complexes — the productive quantitative content of reconciling the two encodings.",
+      "description": "A facet has at most finrank + 1 vertices."
+    },
+    {
+      "name": "exists_panchromatic_facet_of_finrank",
+      "type": "core",
+      "statement": "$\\text{(finite-dimensional field)}\\ \\dots \\Rightarrow \\exists\\,\\sigma,\\ \\sigma \\text{ panchromatic} \\wedge \\sigma.1 \\in K.\\mathrm{facets} \\wedge d \\le \\mathrm{finrank}\\,\\Bbbk\\,E$",
+      "significance": "**Capstone.** The full answer in one statement: facet extraction, pseudomanifold input, combinatorial Sperner conclusion, and the affine-dimension constraint, all certified together for a finite-dimensional Geometry.SimplicialComplex over a field.",
+      "description": "The bridge with a certified ambient-dimension bound on the witness."
+    }
+  ],
+  "references": [
+    {
+      "authors": ["Sperner, Emanuel"],
+      "year": 1928,
+      "title": "Neuer Beweis für die Invarianz der Dimensionszahl und des Gebietes",
+      "venue": "Abhandlungen aus dem Mathematischen Seminar der Universität Hamburg, vol. 6, pp. 265-272",
+      "note": "Sperner's original labeled-triangulation lemma."
+    },
+    {
+      "authors": ["Dillies, Yaël", "Mehta, Bhavik"],
+      "year": 2021,
+      "title": "Mathlib: Analysis.Convex.SimplicialComplex.Basic",
+      "venue": "leanprover-community/mathlib4",
+      "note": "Mathlib's Geometry.SimplicialComplex: faces as affinely independent finsets whose convex hulls glue nicely; defines vertices and facets. The target API this entry bridges to."
+    },
+    {
+      "authors": ["De Longueville, Mark"],
+      "year": 2013,
+      "title": "A Course in Topological Combinatorics",
+      "venue": "Springer Universitext",
+      "note": "Modern treatment of Sperner-style lemmas and the pseudomanifold abstraction this gallery layer formalizes."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/SpernerSimplicialBridgeOQ02.lean",
+    "lineCount": 218,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "imports": [
+      "import Proofs.SpernerSimplicialBridge",
+      "import Mathlib.Analysis.Convex.SimplicialComplex.Basic",
+      "import Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Sperner.SimplicialComplex"
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of the gallery entry `sperner-simplicial-bridge`:

> Does this bridge extend to Mathlib's `Geometry.SimplicialComplex` type by extracting `facets` and verifying the pseudomanifold condition? The key obstacle is reconciling Mathlib's affine-set encoding with this bridge's finset-of-vertices encoding.

**Answer: yes.** The supposed encoding mismatch is illusory at the combinatorial level. Mathlib's `K.faces : Set (Finset E)` already stores faces as vertex `Finset`s — exactly the encoding the parent bridge consumes. `AffineIndependent`/convex-hull gluing is *extra data* layered on the same vertex sets, not a competing representation. So the bridge applies once we expose a `Finset` enumerating `K.facets` and supply purity + the pseudomanifold condition.

## What's new

`proofs/Proofs/SpernerSimplicialBridgeOQ02.lean` — 218 lines, 6 theorems, 0 definitions, **0 axioms / 0 sorries** (`#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`).

- **`exists_facet_superset`** — every face of a *finite* Mathlib complex lies below a facet. Genuinely new: Mathlib has only the negative `not_facet_iff_subface`. Proof via `Finite.exists_maximal` + antisymmetry of `⊆`.
- **`facet_affineIndependent`** — facets carry Mathlib's affine structure for free (`K.indep ∘ facets_subset`). The precise encoding-reconciliation statement.
- **`facet_card_le_finrank_succ` / `facet_dim_le_ambient`** — the affine encoding *bounds* the combinatorial one: a facet has ≤ `finrank 𝕜 E + 1` vertices (via `AffineIndependent.card_le_finrank_succ` + `Submodule.finrank_le`), so a pure complex of dimension `d` needs `d ≤ finrank 𝕜 E`.
- **`exists_panchromatic_facet`** — the headline. Given `K`, a `Finset` enumerating `K.facets`, purity, the pseudomanifold condition, a coloring, and odd boundary parity, the imported `exists_panchromatic` yields a panchromatic facet whose witness is a genuine `K.facets` member.
- **`exists_panchromatic_facet_of_finrank`** — capstone over a finite-dimensional field, additionally certifying `d ≤ finrank 𝕜 E`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.SpernerSimplicialBridgeOQ02` → builds (7745 jobs). Axiom check confirms only the standard foundational axioms.

## Gallery

`src/data/proofs/sperner-simplicial-bridge-oq-02/` (meta.json + annotations.json), cross-referenced to the parent `sperner-simplicial-bridge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)