### PR TITLE
research(cauchy-schwarz-oq-02-oq-04-oq-01-oq-01): Kittaneh's numerical-radius inequality via Buzano [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -510,6 +510,7 @@ import Proofs.CauchySchwarzOQ02OQ02OQ01OQ01
 import Proofs.CauchySchwarzOQ02OQ03
 import Proofs.CauchySchwarzOQ02OQ04
 import Proofs.CauchySchwarzOQ02OQ04OQ01
+import Proofs.CauchySchwarzOQ02OQ04OQ01OQ01
 import Proofs.CauchySchwarzOQ03
 import Proofs.CauchySchwarzOQ03OQ01
 import Proofs.CauchySchwarzOQ03OQ02

--- a/proofs/Proofs/CauchySchwarzOQ02OQ04OQ01OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ02OQ04OQ01OQ01.lean
@@ -1,0 +1,152 @@
+import Mathlib.Analysis.InnerProductSpace.Adjoint
+import Mathlib.Tactic
+import Proofs.CauchySchwarzOQ02OQ04OQ01
+
+/-
+# Cauchy-Schwarz OQ-02 → OQ-04 → OQ-01 → OQ-01: Kittaneh's numerical-radius inequality
+
+## Overview
+
+The *numerical radius* of a bounded operator `T` on a Hilbert space is
+`w(T) = sup_{‖x‖=1} ‖⟪T x, x⟫‖`.  The elementary bound `w(T) ≤ ‖T‖` is immediate
+from Cauchy-Schwarz.  Kittaneh (F. Kittaneh, *Studia Math.* **158** (2003), 11-17)
+proved the genuine *strengthening*
+
+      w(T)² ≤ ½ (‖T‖² + ‖T²‖).
+
+Because `‖T²‖ ≤ ‖T‖²` always (submultiplicativity), Kittaneh's bound never exceeds
+`‖T‖²`, so it refines `w(T) ≤ ‖T‖`, and the refinement is strict whenever
+`‖T²‖ < ‖T‖²` (e.g. for a nilpotent `T`).
+
+This file derives the *pointwise* form of Kittaneh's inequality
+
+      ‖⟪T x, x⟫‖² ≤ ½ (‖T‖² + ‖T²‖)          (‖x‖ = 1),
+
+directly from **Buzano's inequality** (`CauchySchwarzOQ02OQ04OQ01`), which is the
+parent problem.  The key move is the *adjoint trick*: apply Buzano with unit vector
+`e = x` and the two vectors `T x` and `T† x`.  The two adjoint identities
+
+  * `⟪x, T† x⟫ = ⟪T x, x⟫`     (so the Buzano left side is `2 ‖⟪T x, x⟫‖²`),
+  * `⟪T x, T† x⟫ = ⟪T² x, x⟫`  (so the Buzano cross term is controlled by `‖T²‖`),
+
+turn the geometric two-vector Buzano bound into the operator inequality.  The
+remaining factor `‖T x‖ · ‖T† x‖` is bounded by `‖T‖²` using `‖T†‖ = ‖T‖`.
+
+Kittaneh's numerical-radius inequality is not in Mathlib.
+
+## Main Results (6 theorems, 0 definitions, 0 sorries)
+
+1. `opNorm_sq_le`          — ‖T²‖ ≤ ‖T‖² (submultiplicativity, used for the refinement)
+2. `kittaneh_inner_sq`     — ‖⟪T x, x⟫‖² ≤ ½(‖T‖² + ‖T²‖) for unit `x`   [HEADLINE]
+3. `kittaneh_inner_le`     — ‖⟪T x, x⟫‖ ≤ √(½(‖T‖² + ‖T²‖))             (root form)
+4. `inner_diag_le_opNorm`  — ‖⟪T x, x⟫‖ ≤ ‖T‖ (recovers `w(T) ≤ ‖T‖` from Kittaneh)
+5. `inner_diag_nilpotent`  — `T² = 0` ⟹ ‖⟪T x, x⟫‖ ≤ ‖T‖/√2 (strict refinement)
+6. `kittaneh_inner_sq_le_opNorm_sq` — ½(‖T‖² + ‖T²‖) ≤ ‖T‖² (Kittaneh ≤ trivial bound)
+-/
+
+noncomputable section
+
+open RCLike ComplexConjugate ContinuousLinearMap
+
+namespace CauchySchwarzKittaneh
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]
+
+local notation "⟪" x ", " y "⟫" => @inner 𝕜 _ _ x y
+
+omit [CompleteSpace E] in
+/-- **Submultiplicativity.**  `‖T²‖ ≤ ‖T‖²`.  This is what makes Kittaneh's bound a
+genuine refinement of `w(T) ≤ ‖T‖`: the right-hand side `½(‖T‖² + ‖T²‖)` is always
+sandwiched between `‖T²‖` and `‖T‖²`. -/
+theorem opNorm_sq_le (T : E →L[𝕜] E) : ‖T ^ 2‖ ≤ ‖T‖ ^ 2 := by
+  rw [pow_two, pow_two]
+  exact norm_mul_le T T
+
+/-- The adjoint preserves the operator norm: `‖T†‖ = ‖T‖`. -/
+private theorem norm_adjoint (T : E →L[𝕜] E) : ‖adjoint T‖ = ‖T‖ :=
+  LinearIsometryEquiv.norm_map ContinuousLinearMap.adjoint T
+
+/-- **Kittaneh's inequality (pointwise form).**  For a unit vector `x` and a bounded
+operator `T` on a Hilbert space,
+
+      ‖⟪T x, x⟫‖² ≤ ½ (‖T‖² + ‖T²‖).
+
+Taking the supremum over unit `x` gives Kittaneh's numerical-radius bound
+`w(T)² ≤ ½(‖T‖² + ‖T²‖)`.
+
+*Proof.*  Apply Buzano's inequality (`buzano_inequality`) with the unit vector `x`
+and the two vectors `T x`, `T† x`:
+
+      2 ‖⟪T x, x⟫‖ ‖⟪x, T† x⟫‖ ≤ ‖T x‖ ‖T† x‖ + ‖⟪T x, T† x⟫‖.
+
+The adjoint identity `⟪x, T† x⟫ = ⟪T x, x⟫` makes the left side `2 ‖⟪T x, x⟫‖²`.  On
+the right, `‖T x‖ ‖T† x‖ ≤ ‖T‖²` (unit `x`, `‖T†‖ = ‖T‖`), while `⟪T x, T† x⟫ = ⟪T² x, x⟫`
+gives `‖⟪T x, T† x⟫‖ ≤ ‖T²‖`.  Hence `2 ‖⟪T x, x⟫‖² ≤ ‖T‖² + ‖T²‖`. -/
+theorem kittaneh_inner_sq {x : E} (hx : ‖x‖ = 1) (T : E →L[𝕜] E) :
+    ‖⟪T x, x⟫‖ ^ 2 ≤ (‖T‖ ^ 2 + ‖T ^ 2‖) / 2 := by
+  -- Buzano with e = x, first vector `T x`, second vector `T† x`.
+  have hb := CauchySchwarzBuzano.buzano_inequality (𝕜 := 𝕜) hx (T x) (adjoint T x)
+  -- Left-side identity: ⟪x, T† x⟫ = ⟪T x, x⟫.
+  have e1 : ‖⟪x, adjoint T x⟫‖ = ‖⟪T x, x⟫‖ := by rw [adjoint_inner_right]
+  rw [e1] at hb
+  -- Norm of the adjoint.
+  have hadjnorm : ‖adjoint T‖ = ‖T‖ := norm_adjoint T
+  -- ‖T x‖ ≤ ‖T‖ and ‖T† x‖ ≤ ‖T‖ (unit x).
+  have hTx : ‖T x‖ ≤ ‖T‖ := by have := T.le_opNorm x; rwa [hx, mul_one] at this
+  have hadj : ‖adjoint T x‖ ≤ ‖T‖ := by
+    rw [← hadjnorm]; have := (adjoint T).le_opNorm x; rwa [hx, mul_one] at this
+  -- First right-hand term: ‖T x‖ ‖T† x‖ ≤ ‖T‖².
+  have e2 : ‖T x‖ * ‖adjoint T x‖ ≤ ‖T‖ ^ 2 := by
+    have h := mul_le_mul hTx hadj (norm_nonneg _) (norm_nonneg T)
+    rwa [← pow_two] at h
+  -- Cross term: ⟪T x, T† x⟫ = ⟪T² x, x⟫, controlled by ‖T²‖.
+  have e3 : ‖⟪T x, adjoint T x⟫‖ ≤ ‖T ^ 2‖ := by
+    rw [adjoint_inner_right]
+    calc ‖⟪T (T x), x⟫‖
+        ≤ ‖T (T x)‖ * ‖x‖ := norm_inner_le_norm _ _
+      _ = ‖T (T x)‖ := by rw [hx, mul_one]
+      _ = ‖(T ^ 2) x‖ := by rw [pow_two, ContinuousLinearMap.mul_apply]
+      _ ≤ ‖T ^ 2‖ := by have := (T ^ 2).le_opNorm x; rwa [hx, mul_one] at this
+  -- Combine and clear the factor of two.
+  have hcomb : 2 * ‖⟪T x, x⟫‖ * ‖⟪T x, x⟫‖ ≤ ‖T‖ ^ 2 + ‖T ^ 2‖ :=
+    le_trans hb (add_le_add e2 e3)
+  nlinarith [hcomb]
+
+/-- **Kittaneh's inequality (root form).**  `‖⟪T x, x⟫‖ ≤ √(½(‖T‖² + ‖T²‖))`. -/
+theorem kittaneh_inner_le {x : E} (hx : ‖x‖ = 1) (T : E →L[𝕜] E) :
+    ‖⟪T x, x⟫‖ ≤ Real.sqrt ((‖T‖ ^ 2 + ‖T ^ 2‖) / 2) := by
+  rw [show ‖⟪T x, x⟫‖ = Real.sqrt (‖⟪T x, x⟫‖ ^ 2) from (Real.sqrt_sq (norm_nonneg _)).symm]
+  exact Real.sqrt_le_sqrt (kittaneh_inner_sq hx T)
+
+omit [CompleteSpace E] in
+/-- The Kittaneh bound never exceeds the trivial bound: `½(‖T‖² + ‖T²‖) ≤ ‖T‖²`. -/
+theorem kittaneh_inner_sq_le_opNorm_sq (T : E →L[𝕜] E) :
+    (‖T‖ ^ 2 + ‖T ^ 2‖) / 2 ≤ ‖T‖ ^ 2 := by
+  have h := opNorm_sq_le T
+  linarith
+
+/-- **Recovery of `w(T) ≤ ‖T‖`.**  Kittaneh's inequality implies the elementary
+numerical-radius bound `‖⟪T x, x⟫‖ ≤ ‖T‖` for every unit vector `x`. -/
+theorem inner_diag_le_opNorm {x : E} (hx : ‖x‖ = 1) (T : E →L[𝕜] E) :
+    ‖⟪T x, x⟫‖ ≤ ‖T‖ := by
+  have hN : ‖⟪T x, x⟫‖ ^ 2 ≤ ‖T‖ ^ 2 :=
+    le_trans (kittaneh_inner_sq hx T) (kittaneh_inner_sq_le_opNorm_sq T)
+  calc ‖⟪T x, x⟫‖ = Real.sqrt (‖⟪T x, x⟫‖ ^ 2) := (Real.sqrt_sq (norm_nonneg _)).symm
+    _ ≤ Real.sqrt (‖T‖ ^ 2) := Real.sqrt_le_sqrt hN
+    _ = ‖T‖ := Real.sqrt_sq (norm_nonneg _)
+
+/-- **Strict refinement for nilpotent operators.**  If `T² = 0` then Kittaneh's
+inequality collapses to `‖⟪T x, x⟫‖ ≤ ‖T‖/√2`, strictly better than `‖T‖` whenever
+`T ≠ 0`.  (For the `2×2` Jordan nilpotent this gives `w(T) ≤ 1/√2`, improving the
+trivial `w(T) ≤ ‖T‖ = 1`.) -/
+theorem inner_diag_nilpotent {x : E} (hx : ‖x‖ = 1) (T : E →L[𝕜] E) (hT2 : T ^ 2 = 0) :
+    ‖⟪T x, x⟫‖ ≤ ‖T‖ / Real.sqrt 2 := by
+  have h := kittaneh_inner_sq hx T
+  rw [hT2, norm_zero, add_zero] at h
+  calc ‖⟪T x, x⟫‖ = Real.sqrt (‖⟪T x, x⟫‖ ^ 2) := (Real.sqrt_sq (norm_nonneg _)).symm
+    _ ≤ Real.sqrt (‖T‖ ^ 2 / 2) := Real.sqrt_le_sqrt h
+    _ = ‖T‖ / Real.sqrt 2 := by
+        rw [Real.sqrt_div (sq_nonneg _), Real.sqrt_sq (norm_nonneg _)]
+
+end CauchySchwarzKittaneh

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "csq02040101-ann-01",
+    "proofId": "cauchy-schwarz-oq-02-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 86,
+      "endLine": 115
+    },
+    "type": "technique",
+    "title": "The Adjoint Trick: Buzano on the Pair (T x, T†x)",
+    "content": "`kittaneh_inner_sq` is the heart of the file. It applies the parent's Buzano inequality with reference vector e = x and the two vectors a = T x, b = T†x (the adjoint applied to x). Buzano returns 2‖⟪T x, x⟫‖·‖⟪x, T†x⟫‖ ≤ ‖T x‖·‖T†x‖ + ‖⟪T x, T†x⟫‖. Two adjoint identities (`adjoint_inner_right`) then do all the work: ⟪x, T†x⟫ = ⟪T x, x⟫ folds the left side into the perfect square 2‖⟪T x, x⟫‖², and ⟪T x, T†x⟫ = ⟪T(T x), x⟫ = ⟪T²x, x⟫ rewrites the cross term so it is controlled by ‖T²‖. The choice b = T†x is exactly what conjures the square on the left and the T² on the right.",
+    "mathContext": "$2\\|\\langle Tx,x\\rangle\\|\\,\\|\\langle x,T^{\\dagger}x\\rangle\\| \\le \\|Tx\\|\\,\\|T^{\\dagger}x\\| + \\|\\langle Tx,T^{\\dagger}x\\rangle\\|,\\quad \\langle x,T^{\\dagger}x\\rangle=\\langle Tx,x\\rangle,\\ \\langle Tx,T^{\\dagger}x\\rangle=\\langle T^2x,x\\rangle.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hilbert-space adjoint",
+      "Buzano's inequality",
+      "numerical radius",
+      "adjoint_inner_right"
+    ],
+    "prerequisites": [
+      "CauchySchwarzBuzano.buzano_inequality",
+      "ContinuousLinearMap.adjoint_inner_right",
+      "(T·T) x = T (T x) via ContinuousLinearMap.mul_apply"
+    ]
+  },
+  {
+    "id": "csq02040101-ann-02",
+    "proofId": "cauchy-schwarz-oq-02-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 93,
+      "endLine": 100
+    },
+    "type": "technique",
+    "title": "Bounding the Right Side: Unit Vector and Adjoint Isometry",
+    "content": "The two right-hand pieces of the Buzano output are bounded by operator norms at the unit vector x. For the product term, `le_opNorm` gives ‖T x‖ ≤ ‖T‖ and ‖T†x‖ ≤ ‖T†‖, and the adjoint is a (semilinear) isometry so ‖T†‖ = ‖T‖ (`LinearIsometryEquiv.norm_map` applied to ContinuousLinearMap.adjoint); hence ‖T x‖·‖T†x‖ ≤ ‖T‖². For the cross term, scalar Cauchy-Schwarz `norm_inner_le_norm` plus ‖T²x‖ ≤ ‖T²‖ give ‖⟪T²x, x⟫‖ ≤ ‖T²‖. Combining, 2‖⟪T x, x⟫‖² ≤ ‖T‖² + ‖T²‖, and `nlinarith` clears the factor of two to land the headline ‖⟪T x, x⟫‖² ≤ (‖T‖² + ‖T²‖)/2.",
+    "mathContext": "$\\|Tx\\|\\,\\|T^{\\dagger}x\\| \\le \\|T\\|\\,\\|T^{\\dagger}\\| = \\|T\\|^2,\\qquad \\|\\langle T^2x,x\\rangle\\| \\le \\|T^2x\\| \\le \\|T^2\\|.$",
+    "significance": "important",
+    "relatedConcepts": [
+      "operator norm",
+      "adjoint is an isometry",
+      "scalar Cauchy-Schwarz"
+    ],
+    "prerequisites": [
+      "ContinuousLinearMap.le_opNorm",
+      "LinearIsometryEquiv.norm_map (‖T†‖ = ‖T‖)",
+      "norm_inner_le_norm"
+    ]
+  },
+  {
+    "id": "csq02040101-ann-03",
+    "proofId": "cauchy-schwarz-oq-02-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 65
+    },
+    "type": "concept",
+    "title": "Why Kittaneh Refines w(T) ≤ ‖T‖: Submultiplicativity",
+    "content": "`opNorm_sq_le` proves ‖T²‖ ≤ ‖T‖² from the submultiplicativity of the operator-norm ring (`norm_mul_le`, with T² = T·T). This single fact is what upgrades Kittaneh's bound from 'a bound' to 'a refinement': in `kittaneh_inner_sq_le_opNorm_sq` it gives (‖T‖² + ‖T²‖)/2 ≤ ‖T‖², so the Kittaneh right side is always sandwiched between ‖T²‖ and ‖T‖² and never loses to the trivial numerical-radius bound. The recovery `inner_diag_le_opNorm` (‖⟪T x, x⟫‖ ≤ ‖T‖) is then immediate by chaining through Real.sqrt.",
+    "mathContext": "$\\|T^2\\| \\le \\|T\\|^2 \\ \\Rightarrow\\ \\tfrac{1}{2}(\\|T\\|^2 + \\|T^2\\|) \\le \\|T\\|^2 \\ \\Rightarrow\\ \\|\\langle Tx,x\\rangle\\| \\le \\|T\\|.$",
+    "significance": "important",
+    "relatedConcepts": [
+      "submultiplicativity",
+      "numerical radius",
+      "refinement vs. trivial bound"
+    ],
+    "prerequisites": [
+      "norm_mul_le in the operator normed ring",
+      "Real.sqrt monotonicity and √(a²) = a"
+    ]
+  },
+  {
+    "id": "csq02040101-ann-04",
+    "proofId": "cauchy-schwarz-oq-02-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 143,
+      "endLine": 152
+    },
+    "type": "concept",
+    "title": "The Nilpotent Extreme: a Strict 1/√2 Improvement",
+    "content": "`inner_diag_nilpotent` specializes Kittaneh to T² = 0: the cross term vanishes (‖T²‖ = 0), so ‖⟪T x, x⟫‖² ≤ ‖T‖²/2, i.e. ‖⟪T x, x⟫‖ ≤ ‖T‖/√2 — strictly better than the trivial ‖T‖ whenever T ≠ 0. This is the case that exhibits Kittaneh's inequality as a genuine strengthening: for the 2×2 Jordan nilpotent [[0,1],[0,0]] with ‖T‖ = 1 it yields w(T) ≤ 1/√2, well below the trivial bound 1 (the true value is 1/2). The Lean step rewrites with hT2, then converts √(‖T‖²/2) = ‖T‖/√2 via Real.sqrt_div and Real.sqrt_sq.",
+    "mathContext": "$T^2 = 0 \\ \\Rightarrow\\ \\|\\langle Tx,x\\rangle\\|^2 \\le \\tfrac{1}{2}\\|T\\|^2 \\ \\Rightarrow\\ \\|\\langle Tx,x\\rangle\\| \\le \\dfrac{\\|T\\|}{\\sqrt 2}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "nilpotent operator",
+      "Jordan block",
+      "sharpness of the bound"
+    ],
+    "prerequisites": [
+      "kittaneh_inner_sq",
+      "Real.sqrt_div and Real.sqrt_sq"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "cauchy-schwarz-oq-02-oq-04-oq-01-oq-01",
+  "title": "Kittaneh's Numerical-Radius Inequality",
+  "slug": "cauchy-schwarz-oq-02-oq-04-oq-01-oq-01",
+  "description": "Kittaneh's inequality (F. Kittaneh, Studia Math. 158 (2003), 11-17), a genuine strengthening of the elementary numerical-radius bound w(T) ≤ ‖T‖: for a bounded operator T on a Hilbert space over an RCLike field and any unit vector x, ‖⟪T x, x⟫‖² ≤ (‖T‖² + ‖T²‖)/2. Because ‖T²‖ ≤ ‖T‖² always holds, the right side never exceeds ‖T‖², so Kittaneh's bound refines w(T) ≤ ‖T‖ and is strictly sharper whenever ‖T²‖ < ‖T‖² (e.g. for nilpotent T, where it gives ‖⟪T x, x⟫‖ ≤ ‖T‖/√2). The proof is the operator/numerical-range consequence of Buzano's inequality from the parent entry: applying Buzano with the unit vector x and the two vectors T x and T†x, the adjoint identities ⟪x, T†x⟫ = ⟪T x, x⟫ and ⟪T x, T†x⟫ = ⟪T²x, x⟫ turn the geometric two-vector bound into the operator inequality. Kittaneh's inequality is not in Mathlib. 6 theorems, 0 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ02OQ04OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "cauchy-schwarz",
+      "buzano-inequality",
+      "numerical-radius",
+      "kittaneh-inequality",
+      "operator-theory",
+      "adjoint",
+      "rclike"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified over any RCLike Hilbert space. The Mathlib inputs are Buzano's inequality from the parent entry (CauchySchwarzBuzano.buzano_inequality), the adjoint inner-product identities (ContinuousLinearMap.adjoint_inner_right), the operator-norm bound (ContinuousLinearMap.le_opNorm), the adjoint norm isometry (LinearIsometryEquiv.norm_map), and routine Real.sqrt / norm algebra. The pointwise Kittaneh inequality and all of its corollaries are original derivations with no structure-encoded assumptions.",
+    "lineCount": 152,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ContinuousLinearMap.adjoint_inner_right",
+        "description": "⟪x, T† y⟫ = ⟪T x, y⟫ for the Hilbert-space adjoint T†. Used twice: to identify ⟪x, T†x⟫ = ⟪T x, x⟫ (making the Buzano left side 2‖⟪T x, x⟫‖²) and ⟪T x, T†x⟫ = ⟪T²x, x⟫ (controlling the cross term by ‖T²‖).",
+        "module": "Mathlib.Analysis.InnerProductSpace.Adjoint"
+      },
+      {
+        "theorem": "ContinuousLinearMap.le_opNorm",
+        "description": "‖T x‖ ≤ ‖T‖·‖x‖ for a continuous linear map. Specialized at the unit vector x to bound ‖T x‖, ‖T†x‖ and ‖T²x‖ by the respective operator norms.",
+        "module": "Mathlib.Analysis.NormedSpace.OperatorNorm.Basic"
+      },
+      {
+        "theorem": "LinearIsometryEquiv.norm_map",
+        "description": "An isometry preserves norm; applied to the adjoint equivalence ContinuousLinearMap.adjoint to get ‖T†‖ = ‖T‖, which makes ‖T x‖·‖T†x‖ ≤ ‖T‖².",
+        "module": "Mathlib.Analysis.Normed.Operator.LinearIsometry"
+      },
+      {
+        "theorem": "norm_mul_le",
+        "description": "Submultiplicativity ‖a·b‖ ≤ ‖a‖·‖b‖ in the normed ring of operators, giving ‖T²‖ ≤ ‖T‖² — the fact that makes Kittaneh's bound a genuine refinement of w(T) ≤ ‖T‖.",
+        "module": "Mathlib.Analysis.Normed.Ring.Basic"
+      },
+      {
+        "theorem": "norm_inner_le_norm",
+        "description": "Scalar Cauchy-Schwarz ‖⟪u, v⟫‖ ≤ ‖u‖·‖v‖, used to bound ‖⟪T²x, x⟫‖ by ‖T²x‖·‖x‖.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "CauchySchwarzBuzano.buzano_inequality",
+        "description": "Buzano's inequality 2‖⟪a, e⟫‖·‖⟪e, b⟫‖ ≤ ‖a‖·‖b‖ + ‖⟪a, b⟫‖ from the parent entry cauchy-schwarz-oq-02-oq-04-oq-01. Instantiated with e = x (unit), a = T x, b = T†x — this is the engine of the whole file.",
+        "module": "Proofs.CauchySchwarzOQ02OQ04OQ01"
+      }
+    ],
+    "originalContributions": [
+      "kittaneh_inner_sq: the pointwise Kittaneh inequality ‖⟪T x, x⟫‖² ≤ (‖T‖² + ‖T²‖)/2 for a unit vector x, derived from Buzano via the adjoint trick (e = x, a = T x, b = T†x)",
+      "kittaneh_inner_le: the root form ‖⟪T x, x⟫‖ ≤ √((‖T‖² + ‖T²‖)/2)",
+      "opNorm_sq_le: ‖T²‖ ≤ ‖T‖² from submultiplicativity, the inequality that makes Kittaneh's bound sit below the trivial bound",
+      "kittaneh_inner_sq_le_opNorm_sq: (‖T‖² + ‖T²‖)/2 ≤ ‖T‖², so Kittaneh never loses to w(T) ≤ ‖T‖",
+      "inner_diag_le_opNorm: recovery of the elementary numerical-radius bound ‖⟪T x, x⟫‖ ≤ ‖T‖ as a corollary of Kittaneh",
+      "inner_diag_nilpotent: for T² = 0, the strict refinement ‖⟪T x, x⟫‖ ≤ ‖T‖/√2"
+    ],
+    "sourceUrl": "https://en.wikipedia.org/wiki/Numerical_range"
+  },
+  "overview": {
+    "historicalContext": "The numerical radius w(T) = sup_{‖x‖=1} |⟪T x, x⟫| of a Hilbert-space operator satisfies the two elementary bounds ½‖T‖ ≤ w(T) ≤ ‖T‖. In 2003 Fuad Kittaneh proved the sharp improvement w(T)² ≤ ½(‖T‖² + ‖T²‖), resolving a question about quantitative refinements of the upper bound and initiating an extensive line of numerical-radius inequalities (Kittaneh, Dragomir, El-Haddad, and many others). The shortest known proof — formalized here — runs through Buzano's 1974 refinement of Cauchy-Schwarz: Kittaneh's bound is precisely the operator/numerical-range shadow of Buzano applied to the pair (T x, T†x) against the reference vector x, exactly the consequence flagged as an open question in the parent Buzano entry.",
+    "problemStatement": "Prove the pointwise form of Kittaneh's numerical-radius inequality: for a bounded operator T on a Hilbert space over ℝ or ℂ and any unit vector x, ‖⟪T x, x⟫‖² ≤ (‖T‖² + ‖T²‖)/2; show it refines the trivial bound ‖⟪T x, x⟫‖ ≤ ‖T‖ and sharpens it strictly for nilpotent operators.",
+    "text": "Fix a unit vector x and apply Buzano's inequality with reference vector e = x to the two vectors a = T x and b = T†x (the adjoint applied to x): 2‖⟪T x, x⟫‖·‖⟪x, T†x⟫‖ ≤ ‖T x‖·‖T†x‖ + ‖⟪T x, T†x⟫‖. The adjoint identity ⟪x, T†x⟫ = ⟪T x, x⟫ collapses the left side to 2‖⟪T x, x⟫‖². On the right, ‖T x‖ ≤ ‖T‖ and ‖T†x‖ ≤ ‖T†‖ = ‖T‖ (the adjoint is an isometry) give ‖T x‖·‖T†x‖ ≤ ‖T‖², while ⟪T x, T†x⟫ = ⟪T(T x), x⟫ = ⟪T²x, x⟫ together with scalar Cauchy-Schwarz and ‖T²x‖ ≤ ‖T²‖ gives ‖⟪T x, T†x⟫‖ ≤ ‖T²‖. Hence 2‖⟪T x, x⟫‖² ≤ ‖T‖² + ‖T²‖, i.e. ‖⟪T x, x⟫‖² ≤ (‖T‖² + ‖T²‖)/2. Since ‖T²‖ ≤ ‖T‖² always, the right side is ≤ ‖T‖², recovering ‖⟪T x, x⟫‖ ≤ ‖T‖; when T² = 0 the bound improves to ‖⟪T x, x⟫‖ ≤ ‖T‖/√2.",
+    "proofStrategy": "The whole file is one application of the parent's buzano_inequality followed by bookkeeping. kittaneh_inner_sq sets a = T x, b = adjoint T x and rewrites the Buzano output using adjoint_inner_right (twice) — once to fold ⟪x, T†x⟫ into ⟪T x, x⟫, once to turn ⟪T x, T†x⟫ into ⟪T²x, x⟫ via (T·T) x = T (T x). The norm bounds use le_opNorm at the unit vector and LinearIsometryEquiv.norm_map for ‖T†‖ = ‖T‖; nlinarith clears the factor of two. The corollaries are pure real-analysis: opNorm_sq_le from norm_mul_le, kittaneh_inner_sq_le_opNorm_sq and inner_diag_le_opNorm by chaining inequalities through Real.sqrt, and inner_diag_nilpotent by specializing T² = 0.",
+    "keyInsights": [
+      "Kittaneh's numerical-radius inequality is Buzano's inequality evaluated on the pair (T x, T†x) with reference vector x — the operator content is entirely carried by two adjoint identities",
+      "⟪x, T†x⟫ = ⟪T x, x⟫ is what makes the Buzano left side a perfect square 2‖⟪T x, x⟫‖², so no extra Cauchy-Schwarz step is needed there",
+      "⟪T x, T†x⟫ = ⟪T²x, x⟫ is the source of the ‖T²‖ term: the cross term of Buzano sees T squared, not T",
+      "Submultiplicativity ‖T²‖ ≤ ‖T‖² guarantees Kittaneh's bound never exceeds ‖T‖², so it is a true refinement and not just a different bound",
+      "The refinement is strict exactly when ‖T²‖ < ‖T‖²; nilpotents (T² = 0) are the extreme case, giving the factor 1/√2"
+    ],
+    "prerequisites": [
+      "Hilbert spaces over RCLike fields and the Hilbert-space adjoint T† with ⟪x, T†y⟫ = ⟪T x, y⟫",
+      "The operator norm ‖T‖ with ‖T x‖ ≤ ‖T‖·‖x‖ and submultiplicativity ‖T²‖ ≤ ‖T‖²",
+      "Buzano's inequality (the parent entry) and scalar Cauchy-Schwarz",
+      "Basic properties of Real.sqrt (monotonicity, √(a²) = a for a ≥ 0)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The pointwise Kittaneh inequality ‖⟪T x, x⟫‖² ≤ (‖T‖² + ‖T²‖)/2 is verified for every bounded operator on an RCLike Hilbert space, as a direct consequence of Buzano's inequality applied to (T x, T†x) against the unit vector x. The trivial numerical-radius bound ‖⟪T x, x⟫‖ ≤ ‖T‖ is recovered, and the nilpotent case sharpens to ‖T‖/√2. 6 theorems, 152 lines, 0 axioms, 0 sorries.",
+    "implications": "This answers the parent Buzano entry's open question about the operator/numerical-range consequence of Buzano. It connects the elementary reflection-isometry proof of Buzano to a celebrated 2003 numerical-radius inequality, and supplies the pointwise core from which the supremum statement w(T)² ≤ ½(‖T‖² + ‖T²‖) follows. It also dovetails with the OQ-02 → OQ-04 operator-norm / numerical-radius lineage, strengthening the w(T) ≤ ‖T‖ bound proved there.",
+    "openQuestions": [
+      "Promote the pointwise bound to the supremum form w(T)² ≤ ½(‖T‖² + ‖T²‖) by taking the supremum over unit vectors, using the gallery's numerical-radius definition",
+      "Formalize Kittaneh's companion lower bound w(T) ≥ ½‖T + T†‖ and the two-sided refinement, or the sharper w(T) ≤ ½(‖T‖ + ‖T²‖^{1/2})",
+      "Characterize the operators attaining equality in ‖⟪T x, x⟫‖² = ½(‖T‖² + ‖T²‖) and relate them to the Buzano equality case"
+    ]
+  },
+  "leanFile": {
+    "namespace": "CauchySchwarzKittaneh",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ02OQ04OQ01OQ01.lean",
+    "sorries": 0,
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Adjoint",
+      "Mathlib.Tactic",
+      "Proofs.CauchySchwarzOQ02OQ04OQ01"
+    ],
+    "opens": [
+      "RCLike",
+      "ComplexConjugate",
+      "ContinuousLinearMap"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-02-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry proves Buzano's inequality; this entry applies it to (T x, T†x) against a unit vector x to derive Kittaneh's numerical-radius inequality, answering the parent's open question on the operator/numerical-range consequence of Buzano"
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-02-oq-04",
+      "relationship": "extends",
+      "description": "Grandparent OQ-04 develops operator-norm Cauchy-Schwarz and the numerical radius bound w(T) ≤ ‖T‖; Kittaneh's inequality proved here strictly refines that bound"
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "Scalar Cauchy-Schwarz, used to bound the cross term ⟪T²x, x⟫ and ultimately the ancestor of the whole lineage"
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-01-imports",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Imports Mathlib's adjoint theory and the parent Buzano file. Docstring states Kittaneh's inequality, the Buzano-via-adjoint proof idea, and the refinement of w(T) ≤ ‖T‖. Namespace CauchySchwarzKittaneh over an RCLike Hilbert space (CompleteSpace), with a local ⟪·,·⟫ notation and open ContinuousLinearMap."
+    },
+    {
+      "id": "sec-02-submultiplicativity",
+      "title": "Submultiplicativity and the Adjoint Norm",
+      "startLine": 61,
+      "endLine": 68,
+      "summary": "opNorm_sq_le (‖T²‖ ≤ ‖T‖² from norm_mul_le) and the private norm_adjoint (‖T†‖ = ‖T‖ from LinearIsometryEquiv.norm_map applied to ContinuousLinearMap.adjoint), the two norm facts feeding the main estimate."
+    },
+    {
+      "id": "sec-03-kittaneh",
+      "title": "Kittaneh's Inequality from Buzano",
+      "startLine": 69,
+      "endLine": 122,
+      "summary": "kittaneh_inner_sq: Buzano applied with e = x, a = T x, b = T†x; the adjoint identities ⟪x, T†x⟫ = ⟪T x, x⟫ and ⟪T x, T†x⟫ = ⟪T²x, x⟫ (via adjoint_inner_right and (T·T) x = T (T x)) plus the norm bounds give 2‖⟪T x, x⟫‖² ≤ ‖T‖² + ‖T²‖. kittaneh_inner_le restates it in root form via Real.sqrt."
+    },
+    {
+      "id": "sec-04-corollaries",
+      "title": "Refinement of the Numerical-Radius Bound",
+      "startLine": 123,
+      "endLine": 152,
+      "summary": "kittaneh_inner_sq_le_opNorm_sq ((‖T‖² + ‖T²‖)/2 ≤ ‖T‖²), inner_diag_le_opNorm (recovery of ‖⟪T x, x⟫‖ ≤ ‖T‖), and inner_diag_nilpotent (the strict refinement ‖⟪T x, x⟫‖ ≤ ‖T‖/√2 when T² = 0)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Kittaneh's Numerical-Radius Inequality

A follow-up to the just-merged **Buzano's inequality** (#27399, `cauchy-schwarz-oq-02-oq-04-oq-01`), directly answering that entry's open question on the *operator / numerical-range consequence of Buzano*.

### Result
For a bounded operator `T` on a Hilbert space over an RCLike field (ℝ or ℂ) and any unit vector `x`:

```
‖⟪T x, x⟫‖² ≤ (‖T‖² + ‖T²‖) / 2          (Kittaneh, Studia Math. 158 (2003), 11-17)
```

Taking the supremum over unit `x` gives Kittaneh's numerical-radius bound `w(T)² ≤ ½(‖T‖² + ‖T²‖)`. Since `‖T²‖ ≤ ‖T‖²` always, the right side never exceeds `‖T‖²`, so this **strictly refines** the elementary `w(T) ≤ ‖T‖` — and the refinement is strict whenever `‖T²‖ < ‖T‖²` (e.g. nilpotents, where it gives `‖⟪T x, x⟫‖ ≤ ‖T‖/√2`). Kittaneh's inequality is not in Mathlib.

### Proof: the adjoint trick
Apply the parent's `buzano_inequality` with reference vector `e = x` to the pair `a = T x`, `b = T†x`. Two adjoint identities carry all the operator content:
- `⟪x, T†x⟫ = ⟪T x, x⟫` → the Buzano left side becomes the perfect square `2‖⟪T x, x⟫‖²`;
- `⟪T x, T†x⟫ = ⟪T²x, x⟫` → the cross term is controlled by `‖T²‖`.

The factor `‖T x‖·‖T†x‖ ≤ ‖T‖²` uses `‖T†‖ = ‖T‖` (the adjoint is an isometry). Hence `2‖⟪T x, x⟫‖² ≤ ‖T‖² + ‖T²‖`.

### Contents (6 theorems, 152 lines, 0 axioms, 0 sorries)
- `kittaneh_inner_sq` — the headline `‖⟪T x, x⟫‖² ≤ ½(‖T‖² + ‖T²‖)`
- `kittaneh_inner_le` — root form via `Real.sqrt`
- `opNorm_sq_le` — `‖T²‖ ≤ ‖T‖²` (submultiplicativity)
- `kittaneh_inner_sq_le_opNorm_sq` — `½(‖T‖² + ‖T²‖) ≤ ‖T‖²`, so Kittaneh never loses to the trivial bound
- `inner_diag_le_opNorm` — recovers `‖⟪T x, x⟫‖ ≤ ‖T‖`
- `inner_diag_nilpotent` — `T² = 0 ⟹ ‖⟪T x, x⟫‖ ≤ ‖T‖/√2`

### Verification
`./proofs/scripts/docker-build.sh Proofs.CauchySchwarzOQ02OQ04OQ01OQ01` succeeds (3063 jobs, 0 warnings). No `sorry`/`axiom`/`native_decide`; status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)