### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01): prove multinomial PMF support (4→3 sorries)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean
@@ -161,7 +161,23 @@ theorem multinomialPMF_support {α : Type*} [DecidableEq α]
     (k : Composition α s n) :
     (multinomialPMF s p n hp) k ≠ 0 ↔
     ∀ i ∈ s, k.counts i ≠ 0 → p i ≠ 0 := by
-  sorry -- Follows from the product being nonzero iff each factor is nonzero
+  -- The PMF value is `multinomial · ∏ p i ^ counts i`. The multinomial coefficient
+  -- is a positive natural, hence a nonzero ENNReal, so the value is nonzero iff the
+  -- product is. In ℝ≥0∞ (no zero divisors) a product is nonzero iff every factor is,
+  -- and `p i ^ counts i ≠ 0` iff `counts i = 0` (giving `1`) or `p i ≠ 0`.
+  rw [multinomialPMF_apply]
+  unfold multinomialPMFVal
+  rw [mul_ne_zero_iff, Finset.prod_ne_zero_iff]
+  have hmul : (Nat.multinomial s k.counts : ℝ≥0∞) ≠ 0 := by
+    rw [Nat.cast_ne_zero]; exact (Nat.multinomial_pos s k.counts).ne'
+  constructor
+  · rintro ⟨_, hprod⟩ i hi hcount
+    exact (pow_ne_zero_iff hcount).mp (hprod i hi)
+  · intro h
+    refine ⟨hmul, fun i hi => ?_⟩
+    rcases eq_or_ne (k.counts i) 0 with hc | hc
+    · rw [hc, pow_zero]; exact one_ne_zero
+    · rw [pow_ne_zero_iff hc]; exact h i hi hc
 
 -- ============================================================
 -- PART 6: Marginal Distribution (Binomial)

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -16,10 +16,10 @@
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 3,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 292,
+    "lineCount": 308,
     "assumptions": "No axioms. 5 sorries (aggregate): 4 in main file (support characterization at line 164, marginal distribution at line 185, mean at line 200, covariance at line 213) + 1 in BinomialTheoremOQ02OQ01OQ01Aristotle.lean. ENNReal normalization (multinomialPMF_sum_eq_one), the Fintype instance, the PMF construction, and the concrete dice example are fully proved.",
     "originalContributions": [
       "Composition type as support of multinomial distribution",
@@ -188,14 +188,14 @@
       "MeasureTheory"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01",
-    "lineCount": 292,
+    "lineCount": 308,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
     "definitionCount": 4,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
-    "sorries": 4,
+    "sorries": 3,
     "additionalFiles": [
       "Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean"
     ]


### PR DESCRIPTION
## Summary

Incremental progress on the **Multinomial PMF Integration with Mathlib** entry (`binomial-theorem-oq-02-oq-01-oq-01`). Proves the `multinomialPMF_support` lemma, reducing the file's sorries from **4 → 3**.

## The lemma

For the Mathlib `PMF` built from the multinomial distribution, the value at a composition `k` is nonzero exactly when every counted outcome has positive probability:

```
(multinomialPMF s p n hp) k ≠ 0  ↔  ∀ i ∈ s, k.counts i ≠ 0 → p i ≠ 0
```

**Proof.** The value is `Nat.multinomial s k.counts · ∏ i ∈ s, p i ^ k.counts i` in `ℝ≥0∞`. The multinomial coefficient is a positive natural (`Nat.multinomial_pos`), hence a nonzero `ENNReal`, so the value is nonzero iff the product is. `ℝ≥0∞` has no zero divisors, so `Finset.prod_ne_zero_iff` reduces to each factor, and `pow_ne_zero_iff` gives `p i ^ k.counts i ≠ 0 ↔ (k.counts i = 0 ∨ p i ≠ 0)`.

## Scope / honesty

The three remaining sorries are genuine combinatorial-probability identities (summation over `piAntidiag`) deliberately **not** bluffed here:
- `multinomial_marginal_binomial` — the marginal of `Xᵢ` is `Binomial(n, pᵢ)`
- `multinomial_mean` — `E[Xᵢ] = n·pᵢ`
- `multinomial_covariance` — `Cov(Xᵢ,Xⱼ) = -n·pᵢ·pⱼ`

Gallery `meta.json` updated to `sorries: 3` (status stays `formalized`).

## Verification

`./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ02OQ01OQ01` → builds (3062 jobs); the support theorem is sorry-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)