### PR TITLE
research(russell-1-plus-1-oq-01): ℕ as a Natural Numbers Object (Lawvere) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3009,6 +3009,7 @@ import Proofs.NthRootIrrationalOQ01OQ01Real
 import Proofs.NthRootIrrationalOQ02
 import Proofs.OSBridge
 import Proofs.OnePlusOne
+import Proofs.OnePlusOneOQ01
 import Proofs.OnePlusOneOQ04
 import Proofs.OpenMappingTheoremOQ01
 import Proofs.OrderOneAddMulPrimeOQ01

--- a/proofs/Proofs/OnePlusOneOQ01.lean
+++ b/proofs/Proofs/OnePlusOneOQ01.lean
@@ -1,0 +1,220 @@
+/-
+# ℕ as a Natural Numbers Object — the categorical face of Peano arithmetic
+
+## What This Proves
+The parent entry (`OnePlusOne.lean`) builds the natural numbers as a *type-theoretic*
+inductive type and proves `1 + 1 = 2` by definitional computation. This follow-up answers
+the entry's open question — *how do the foundations of mathematics (set theory, type
+theory, category theory) relate?* — with one concrete, machine-checked bridge:
+
+  **The inductively-defined `ℕ` is a Natural Numbers Object (Lawvere, 1964): it is the
+  initial algebra of the endofunctor `X ↦ 1 + X`.**
+
+Concretely, for every type `A` with a chosen point `a : A` and an endomap `f : A → A`,
+there is a **unique** `u : ℕ → A` with `u 0 = a` and `u (succ n) = f (u n)`.  In categorical
+language `a` is an arrow `1 → A`, `f` is `A → A`, and `u` is the unique mediating arrow out
+of the initial `(point, endomap)`-algebra `(ℕ, zero, succ)`.  This single universal property
+is simultaneously:
+
+  * the **type-theoretic** recursor / iterator (`iter` below — existence is just `ℕ.rec`),
+  * the **set-theoretic** Dedekind recursion theorem (in ZFC it is a *theorem* requiring a
+    transfinite-free but non-trivial construction; here existence is a computation rule),
+  * the **category-theoretic** statement that `(ℕ, zero, succ)` is an initial object in the
+    category of `(point, endomap)`-algebras.
+
+We then *recover* addition and multiplication as the unique maps named by this universal
+property, and prove **Lambek's lemma** in concrete form: the structure map `1 + ℕ → ℕ`
+(i.e. `none ↦ 0`, `some n ↦ succ n`) is a bijection, so `ℕ ≅ 1 + ℕ`.
+
+## Approach
+- **Foundation (from Mathlib):** None.  Like the parent, this file imports nothing.  The
+  recursor, `funext` (which rests only on `Quot.sound`), `Option`, and `ExistsUnique` are all
+  Lean-core.  This keeps the foundational point honest: the universal property is genuinely
+  available with no analytic or set-theoretic scaffolding.
+- **Original Contributions:** A self-contained proof that the Peano naturals satisfy the
+  Lawvere Natural Numbers Object universal property (existence + uniqueness), the derivation
+  of `+` and `*` from that property, and a concrete Lambek isomorphism `ℕ ≅ 1 + ℕ`.
+- **Proof Techniques Demonstrated:** Initial-algebra reasoning, `∃!` over a function space
+  (closed by `funext`), iteration/catamorphism, structural induction for uniqueness.
+
+## Status
+- [x] Complete proof
+- [ ] Uses Mathlib for main result
+- [x] Proves extensions/corollaries
+- [x] Pedagogical example
+- [ ] Incomplete (has sorries)
+
+## Mathlib Dependencies
+None.  Self-contained; the only non-constructive ingredient is `Quot.sound` (used by
+`funext` to phrase uniqueness as an equality of functions), one of Lean's three foundational
+axioms and not a mathematical assumption.
+-/
+
+namespace PeanoNNO
+
+-- ============================================================
+-- PART 1: The Peano naturals (the same inductive type as the parent)
+-- ============================================================
+
+/-- The Peano naturals: the initial algebra of `X ↦ 1 + X`, presented as an inductive type.
+The two constructors `zero : 1 → ℕ` and `succ : ℕ → ℕ` are precisely the structure map of the
+algebra, split into its two components. -/
+inductive ℕ where
+  | zero : ℕ
+  | succ : ℕ → ℕ
+  deriving Repr
+
+open ℕ
+
+def one : ℕ := succ zero
+def two : ℕ := succ (succ zero)
+
+-- ============================================================
+-- PART 2: The iterator — the EXISTENCE half of the universal property
+-- ============================================================
+
+/-- `iter f a` is the canonical map out of `ℕ`: it sends `zero ↦ a` and iterates `f`.
+
+Categorically this is the unique algebra homomorphism `(ℕ, zero, succ) → (A, a, f)`, a.k.a.
+the *catamorphism* (`fold`) for the `(point, endomap)`-algebra structure.  Its very
+definition *is* the recursor `ℕ.rec`, so existence of a mediating arrow is a computation
+rule, not a proof obligation. -/
+def iter {A : Type} (f : A → A) (a : A) : ℕ → A
+  | zero   => a
+  | succ n => f (iter f a n)
+
+/-- First defining equation: `iter` respects the point `zero ↦ a`.  Holds by `rfl`. -/
+theorem iter_zero {A : Type} (f : A → A) (a : A) : iter f a zero = a := rfl
+
+/-- Second defining equation: `iter` is an algebra homomorphism, `iter ∘ succ = f ∘ iter`.
+Holds by `rfl` (the recursor's iota rule). -/
+theorem iter_succ {A : Type} (f : A → A) (a : A) (n : ℕ) :
+    iter f a (succ n) = f (iter f a n) := rfl
+
+-- ============================================================
+-- PART 3: Uniqueness — the INITIALITY half of the universal property
+-- ============================================================
+
+/-- Any map satisfying the two algebra-homomorphism equations *is* `iter f a`.  This is the
+content of initiality: the mediating arrow is unique.  Proved by structural induction — the
+induction principle of the inductive type delivers exactly the uniqueness that the
+set-theoretic recursion theorem must establish by a separate argument. -/
+theorem iter_unique {A : Type} (f : A → A) (a : A) (u : ℕ → A)
+    (h0 : u zero = a) (hs : ∀ n, u (succ n) = f (u n)) :
+    ∀ n, u n = iter f a n := by
+  intro n
+  induction n with
+  | zero => rw [h0, iter_zero]
+  | succ n ih => rw [hs, ih, iter_succ]
+
+/-- **Lawvere's Natural Numbers Object universal property.**
+For every type `A`, point `a : A`, and endomap `f : A → A`, there is a *unique* `u : ℕ → A`
+with `u zero = a` and `u (succ n) = f (u n)`.
+
+This says `(ℕ, zero, succ)` is the **initial** `(point, endomap)`-algebra, i.e. the initial
+algebra of the functor `X ↦ 1 + X`.  Existence is `iter`; uniqueness is `iter_unique` lifted
+to an equality of functions via `funext`.
+
+(We spell out the `∃!` by hand — `there is one solution, and any solution equals it` — to keep
+the file Mathlib-free, since the `∃!` notation lives in Mathlib.) -/
+theorem nno_universal {A : Type} (a : A) (f : A → A) :
+    ∃ u : ℕ → A, (u zero = a ∧ ∀ n, u (succ n) = f (u n)) ∧
+      ∀ v : ℕ → A, (v zero = a ∧ ∀ n, v (succ n) = f (v n)) → v = u := by
+  refine ⟨iter f a, ⟨iter_zero f a, fun n => iter_succ f a n⟩, ?_⟩
+  intro v hv
+  exact funext (fun n => iter_unique f a v hv.1 hv.2 n)
+
+-- ============================================================
+-- PART 4: Addition and multiplication, RECOVERED from the universal property
+-- ============================================================
+
+/-- Addition is the map named by the universal property at the algebra `(n, succ)`:
+`add n = iter succ n`.  Thus `+` is not an extra primitive — it is forced by initiality. -/
+def add (n : ℕ) : ℕ → ℕ := iter succ n
+
+theorem add_zero (n : ℕ) : add n zero = n := rfl
+theorem add_succ (n m : ℕ) : add n (succ m) = succ (add n m) := rfl
+
+/-- 1 + 1 = 2, recovered through the universal property rather than as a bare `rfl`. -/
+theorem one_add_one : add one one = two := rfl
+
+/-- **Addition is characterized by the universal property.**  Any `g` solving the same two
+equations as `add n` must equal `add n` — a direct corollary of initiality. -/
+theorem add_eq_unique (n : ℕ) (g : ℕ → ℕ)
+    (h0 : g zero = n) (hs : ∀ m, g (succ m) = succ (g m)) : g = add n :=
+  funext (fun m => iter_unique succ n g h0 hs m)
+
+/-- Multiplication is the map named by the universal property at the algebra `(zero, add n)`:
+`mul n = iter (add n) zero`.  So `*` too is forced by initiality, layered over `+`. -/
+def mul (n : ℕ) : ℕ → ℕ := iter (add n) zero
+
+theorem mul_zero (n : ℕ) : mul n zero = zero := rfl
+theorem mul_succ (n m : ℕ) : mul n (succ m) = add n (mul n m) := rfl
+
+-- ============================================================
+-- PART 5: Lambek's lemma — the structure map is an isomorphism, ℕ ≅ 1 + ℕ
+-- ============================================================
+
+/-- The structure map of the algebra, `1 + ℕ → ℕ`, presented via `Option` (`Option ℕ` is the
+type `1 + ℕ`): `none` is the point `zero`, `some n` is `succ n`. -/
+def structMap : Option ℕ → ℕ
+  | none   => zero
+  | some n => succ n
+
+/-- The candidate inverse `ℕ → 1 + ℕ`: `zero ↦ none`, `succ n ↦ some n`.  Its existence is the
+"every natural is zero or a successor, uniquely" fact. -/
+def structInv : ℕ → Option ℕ
+  | zero   => none
+  | succ n => some n
+
+theorem structMap_leftInv : ∀ x : Option ℕ, structInv (structMap x) = x
+  | none   => rfl
+  | some _ => rfl
+
+theorem structInv_rightInv : ∀ n : ℕ, structMap (structInv n) = n
+  | zero   => rfl
+  | succ _ => rfl
+
+/-- **Lambek's lemma, concrete form.**  `structMap : 1 + ℕ → ℕ` is a two-sided inverse of
+`structInv`, hence a bijection: `ℕ ≅ 1 + ℕ`.  Lambek's lemma says the structure map of an
+*initial* algebra is always an isomorphism; here we exhibit the iso explicitly, witnessing
+that `ℕ` is a fixed point of the functor `X ↦ 1 + X`. -/
+theorem lambek : (∀ x : Option ℕ, structInv (structMap x) = x) ∧
+    (∀ n : ℕ, structMap (structInv n) = n) :=
+  ⟨structMap_leftInv, structInv_rightInv⟩
+
+-- Axiom audit: the headline results rest only on `Quot.sound` (used by `funext`), with no
+-- `sorryAx` and no `Lean.ofReduceBool`.  The defining-equation and Lambek lemmas are fully
+-- axiom-free (`rfl` / structural case analysis).
+#print axioms nno_universal
+#print axioms iter_unique
+#print axioms add_eq_unique
+#print axioms lambek
+
+end PeanoNNO
+
+/-
+## PART 6: How the three foundations meet at `ℕ`
+
+The single theorem `nno_universal` is the meeting point of the three foundational traditions
+named in the open question:
+
+* **Type theory.**  Existence of the mediating map is `ℕ.rec`; its computation rules
+  (`iter_zero`, `iter_succ`) hold by `rfl`.  Recursion is *built in*.
+
+* **Set theory.**  The same statement is Dedekind's recursion theorem (1888): given a set `A`,
+  an element `a ∈ A`, and `f : A → A`, there is a unique `u : ℕ → A` with `u 0 = a` and
+  `u(n⁺) = f(u n)`.  In ZFC this is a genuine theorem — one proves the recursion *exists* by
+  taking a union of approximating partial functions and verifying it is functional.  Russell
+  and Whitehead's 362 pages live on this side of the bridge.
+
+* **Category theory.**  Lawvere (1964) packaged the universal property as the definition of a
+  *Natural Numbers Object*: an initial algebra for `X ↦ 1 + X`.  `nno_universal` is exactly
+  initiality, and Lambek's lemma (`lambek`) is the categorical reason `ℕ ≅ 1 + ℕ`.
+
+The point is not that one foundation is "right".  It is that `ℕ` is *the same object* in all
+three — pinned down, up to unique isomorphism, by one universal property.  Type theory makes
+that property a definitional computation; set theory makes it a theorem to be proved; category
+theory makes it a definition to be characterized.  This file checks, with no axioms beyond
+`Quot.sound`, that the type-theoretic `ℕ` satisfies the categorical specification.
+-/

--- a/src/data/proofs/russell-1-plus-1-oq-01/annotations.json
+++ b/src/data/proofs/russell-1-plus-1-oq-01/annotations.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "russnno-ann-01",
+    "proofId": "russell-1-plus-1-oq-01",
+    "range": { "startLine": 82, "endLine": 92 },
+    "type": "concept",
+    "title": "The Iterator IS the Recursor — Existence for Free",
+    "content": "`iter f a : ℕ → A` is the canonical map out of ℕ: it sends `zero` to the point `a` and iterates the endomap `f`. Categorically it is the unique algebra homomorphism `(ℕ, zero, succ) → (A, a, f)`, the catamorphism or `fold`. Its definition by pattern matching elaborates directly to `ℕ.rec`, so the two defining equations `iter_zero` (`iter f a zero = a`) and `iter_succ` (`iter f a (succ n) = f (iter f a n)`) hold by `rfl`. This is the existence half of the Natural Numbers Object universal property: in type theory it is a computation rule, not a theorem to prove.",
+    "mathContext": "$\\mathrm{iter}\\,f\\,a\\,(0) = a,\\quad \\mathrm{iter}\\,f\\,a\\,(S n) = f(\\mathrm{iter}\\,f\\,a\\,n).$ The mediating arrow $u$ of the universal property is $u = \\mathrm{iter}\\,f\\,a$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "catamorphism / fold",
+      "primitive recursion",
+      "algebra homomorphism",
+      "the recursor ℕ.rec"
+    ],
+    "prerequisites": [
+      "inductive types and their recursors",
+      "iota-reduction (the computation rule for recursors)"
+    ]
+  },
+  {
+    "id": "russnno-ann-02",
+    "proofId": "russell-1-plus-1-oq-01",
+    "range": { "startLine": 102, "endLine": 115 },
+    "type": "concept",
+    "title": "Uniqueness = Initiality = Structural Induction",
+    "content": "`iter_unique` proves that any `u : ℕ → A` satisfying the two algebra equations equals `iter f a` pointwise. The proof is a three-line structural induction: the base case rewrites by `u zero = a` and `iter_zero`, and the successor case rewrites by `u (succ n) = f (u n)`, the inductive hypothesis, and `iter_succ`. This uniqueness is exactly what makes ℕ the *initial* algebra: the mediating arrow is unique. It is also precisely the content the set-theoretic recursion theorem must establish by a separate union-of-approximations argument — here it is delivered by the induction principle of the inductive type.",
+    "mathContext": "If $u(0)=a$ and $u(S n)=f(u\\,n)$ for all $n$, then $u(n)=\\mathrm{iter}\\,f\\,a\\,(n)$ for all $n$, by induction on $n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "initiality of an algebra",
+      "structural induction",
+      "Dedekind recursion theorem",
+      "uniqueness of mediating morphisms"
+    ],
+    "prerequisites": [
+      "the induction principle for ℕ",
+      "rewriting with hypotheses (rw)"
+    ]
+  },
+  {
+    "id": "russnno-ann-03",
+    "proofId": "russell-1-plus-1-oq-01",
+    "range": { "startLine": 120, "endLine": 126 },
+    "type": "theorem",
+    "title": "Lawvere's Natural Numbers Object Universal Property",
+    "content": "`nno_universal` is the headline: for every type `A`, point `a : A`, and endomap `f : A → A` there is a unique `u : ℕ → A` with `u zero = a` and `u (succ n) = f (u n)`. This says `(ℕ, zero, succ)` is the initial algebra of the functor `X ↦ 1 + X` — Lawvere's 1964 definition of a Natural Numbers Object. Existence is supplied by `iter` (with its `rfl` computation rules); uniqueness is `iter_unique` lifted from a pointwise equality to an equality of functions by `funext`. The `∃!` is spelled out by hand as `there is a solution, and every solution equals it` to keep the file Mathlib-free. This single statement is the bridge the parent entry's open question asks for: it is simultaneously the type-theoretic recursor, the set-theoretic recursion theorem, and the category-theoretic initiality of ℕ.",
+    "mathContext": "$\\forall A\\,(a:A)\\,(f:A\\to A),\\ \\exists!\\,u:\\mathbb{N}\\to A,\\ u(0)=a \\,\\wedge\\, \\forall n,\\ u(S n)=f(u\\,n).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Natural Numbers Object (Lawvere)",
+      "initial algebra of X ↦ 1 + X",
+      "universal property",
+      "function extensionality (funext, Quot.sound)"
+    ],
+    "prerequisites": [
+      "universal properties and initial objects",
+      "function extensionality",
+      "the iterator and its uniqueness (iter, iter_unique)"
+    ]
+  },
+  {
+    "id": "russnno-ann-04",
+    "proofId": "russell-1-plus-1-oq-01",
+    "range": { "startLine": 133, "endLine": 147 },
+    "type": "concept",
+    "title": "Addition and Multiplication Are Forced by Initiality",
+    "content": "Rather than positing `+` and `×` as new primitives, the file derives them from the universal property. `add n := iter succ n` is the unique map named by the property at the algebra `(n, succ)`; its equations `add n zero = n` and `add n (succ m) = succ (add n m)` hold by `rfl`, and `one_add_one : add one one = two` re-derives 1+1=2 through the universal property. `add_eq_unique` then proves that *any* function solving the same recurrence equals `add n` — addition is the unique solution, not a free choice. Multiplication `mul n := iter (add n) zero` is the same construction one layer up, with `mul n (succ m) = add n (mul n m)`.",
+    "mathContext": "$n + {-} = \\mathrm{iter}\\,S\\,n$, so $n+0=n$ and $n+(S m)=S(n+m)$; $n\\cdot{-} = \\mathrm{iter}\\,(n+{-})\\,0$, so $n\\cdot 0 = 0$ and $n\\cdot(S m)=n+(n\\cdot m)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "primitive recursion from the recursor",
+      "uniqueness of solutions to a recurrence",
+      "Peano addition and multiplication"
+    ],
+    "prerequisites": [
+      "the iterator iter and its uniqueness",
+      "definitional equality (rfl)"
+    ]
+  },
+  {
+    "id": "russnno-ann-05",
+    "proofId": "russell-1-plus-1-oq-01",
+    "range": { "startLine": 160, "endLine": 184 },
+    "type": "theorem",
+    "title": "Lambek's Lemma: ℕ ≅ 1 + ℕ",
+    "content": "Lambek's lemma states that the structure map of an *initial* algebra is always an isomorphism. Here it is exhibited concretely: `structMap : Option ℕ → ℕ` (with `Option ℕ` the type `1 + ℕ`) sends `none ↦ zero` and `some n ↦ succ n`, and `structInv : ℕ → Option ℕ` is its candidate inverse. The two round-trip identities `structMap_leftInv` and `structInv_rightInv` are proved by case analysis (each case is `rfl`) and packaged in `lambek`, witnessing the bijection ℕ ≅ 1 + ℕ. This is the categorical reason every natural number is *uniquely* either zero or a successor — ℕ is a fixed point of the functor `X ↦ 1 + X`.",
+    "mathContext": "$\\mathrm{structMap}\\circ\\mathrm{structInv}=\\mathrm{id}_{\\mathbb{N}}$ and $\\mathrm{structInv}\\circ\\mathrm{structMap}=\\mathrm{id}_{1+\\mathbb{N}}$, hence $\\mathbb{N}\\cong 1+\\mathbb{N}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lambek's lemma",
+      "fixed point of an endofunctor",
+      "bijection / isomorphism",
+      "Option as the coproduct 1 + X"
+    ],
+    "prerequisites": [
+      "initial algebras and their structure maps",
+      "case analysis on an inductive type"
+    ]
+  }
+]

--- a/src/data/proofs/russell-1-plus-1-oq-01/meta.json
+++ b/src/data/proofs/russell-1-plus-1-oq-01/meta.json
@@ -1,0 +1,198 @@
+{
+  "id": "russell-1-plus-1-oq-01",
+  "title": "ℕ as a Natural Numbers Object",
+  "slug": "russell-1-plus-1-oq-01",
+  "description": "Answers the russell-1-plus-1 open question — how do set theory, type theory, and category theory relate? — with one machine-checked bridge: the inductively-defined ℕ is a Natural Numbers Object (Lawvere, 1964), i.e. the initial algebra of the functor X ↦ 1 + X. For every (point a, endomap f) there is a unique u : ℕ → A with u 0 = a and u (succ n) = f (u n). Addition and multiplication are then recovered as the maps the universal property names, and Lambek's lemma is proved concretely as ℕ ≅ 1 + ℕ. Self-contained, no Mathlib, 0 sorries, 0 axioms (beyond Quot.sound).",
+  "meta": {
+    "author": "Lawvere (NNO, 1964); Lambek (1968); Dedekind (recursion, 1888) — formalized in Lean 4",
+    "sourceUrl": "https://ncatlab.org/nlab/show/natural+numbers+object",
+    "date": "1964",
+    "status": "verified",
+    "tags": [
+      "foundations",
+      "category-theory",
+      "type-theory",
+      "universal-property",
+      "initial-algebra",
+      "peano-arithmetic"
+    ],
+    "proofRepoPath": "Proofs/OnePlusOneOQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [],
+    "originalContributions": [
+      "Self-contained proof that the Peano naturals satisfy Lawvere's Natural Numbers Object universal property (existence via the iterator, uniqueness via structural induction)",
+      "Addition and multiplication recovered as the unique maps named by the universal property, not posited as extra primitives",
+      "Concrete Lambek isomorphism ℕ ≅ 1 + ℕ exhibiting ℕ as a fixed point of X ↦ 1 + X",
+      "Explicit prose bridge identifying the single universal property across set-theoretic (Dedekind recursion), type-theoretic (the recursor), and category-theoretic (initial algebra) foundations"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 220,
+    "assumptions": "None mathematical. The only non-constructive ingredient is Quot.sound, used by funext to state uniqueness as an equality of functions; it is one of Lean's three foundational axioms and not a mathematical assumption. #print axioms reports no sorryAx and no Lean.ofReduceBool.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 13,
+    "definitionCount": 7
+  },
+  "overview": {
+    "historicalContext": "The parent entry proves 1+1=2 by building the natural numbers as a type-theoretic inductive type. Its closing open question asks how the competing foundations of mathematics — set theory, type theory, category theory — relate to one another. The natural numbers are the perfect test case, because all three traditions agree on what ℕ is, while disagreeing on what kind of thing a foundation is. In 1888 Dedekind isolated the recursion theorem: given a set A, a point a ∈ A, and a map f : A → A, there is a unique sequence u with u(0) = a and u(n+1) = f(u(n)). In 1964 Lawvere recast this as a universal property, defining a Natural Numbers Object in any category with a terminal object, thereby making 'the natural numbers' a category-theoretic notion characterized up to unique isomorphism. In type theory the same property is simply the recursor of the inductive type ℕ. This entry checks, with no axioms beyond Quot.sound, that the type-theoretic ℕ meets the categorical specification.",
+    "problemStatement": "Show that the inductively-defined Peano naturals ℕ form a Natural Numbers Object: for every type A, point a : A, and endomap f : A → A, there exists a unique function u : ℕ → A satisfying u(zero) = a and u(succ n) = f(u n). Equivalently, (ℕ, zero, succ) is the initial algebra of the endofunctor X ↦ 1 + X. Recover addition and multiplication from this universal property and prove Lambek's lemma ℕ ≅ 1 + ℕ.",
+    "text": "The file is Mathlib-free, mirroring the parent's foundational minimalism. It redefines ℕ inductively, then defines the iterator iter f a : ℕ → A whose two computation rules (iter_zero, iter_succ) hold by rfl — this is the existence half of the universal property and is literally the recursor ℕ.rec. Uniqueness (iter_unique) is a one-line structural induction: any u satisfying the two algebra-homomorphism equations equals iter f a pointwise. Packaging existence and uniqueness yields nno_universal, an ∃! over the function space closed by funext. The entry then recovers add n := iter succ n and mul n := iter (add n) zero, proving their defining equations by rfl and showing (add_eq_unique) that addition is the only solution of its recurrence — so + and × are forced by initiality rather than added as primitives. Finally it presents Lambek's lemma concretely: the structure map structMap : Option ℕ → ℕ (none ↦ zero, some n ↦ succ n) and its inverse structInv form a bijection, witnessing ℕ ≅ 1 + ℕ. A closing essay maps the single theorem nno_universal onto the three foundational traditions.",
+    "proofStrategy": "Existence is free: the iterator is the recursor, so iter_zero and iter_succ are definitional (rfl). Uniqueness is the only real content and is exactly structural induction — the induction principle of the inductive type delivers what the set-theoretic recursion theorem must establish by a union-of-approximations argument. Lifting pointwise uniqueness to a function equality uses funext (hence Quot.sound). Addition and multiplication are then instances of the universal property at specific algebras, and Lambek's lemma is a direct case analysis exhibiting the two round-trip identities.",
+    "keyInsights": [
+      "Existence of the mediating arrow is not a theorem but a computation rule: iter is ℕ.rec, so iter_zero and iter_succ are proved by rfl. Type theory builds recursion in where set theory must derive it.",
+      "Uniqueness is the categorical heart of the matter — it is precisely initiality — and it is exactly the induction principle of the inductive type, discharged by a three-line induction in iter_unique.",
+      "Addition is not an independent primitive: add n = iter succ n is the unique map the universal property names at the algebra (n, succ), and add_eq_unique proves no other function satisfies its recurrence. Multiplication is the same one layer up.",
+      "Lambek's lemma — the structure map of an initial algebra is an isomorphism — appears here as the concrete bijection ℕ ≅ 1 + ℕ, the statement that every natural number is uniquely either zero or a successor.",
+      "The same universal property is Dedekind's recursion theorem (a theorem to prove in ZFC), Lawvere's NNO definition (a property to characterize in a category), and the recursor (a definition in type theory): one object, three foundational stances.",
+      "The proof is axiom-free in the strong sense relevant to the gallery: #print axioms lists at most Quot.sound (from funext) and the ordinary foundational axioms — no sorryAx, no Lean.ofReduceBool — so the result is genuinely verified, not axiomatized."
+    ],
+    "prerequisites": [
+      "Inductive types and their recursors / induction principles in dependent type theory",
+      "Universal properties and initial objects in category theory",
+      "Initial algebras of endofunctors (here X ↦ 1 + X) and the catamorphism / fold",
+      "Lambek's lemma: the structure map of an initial algebra is an isomorphism"
+    ]
+  },
+  "sections": [
+    {
+      "id": "peano-naturals",
+      "title": "The Peano naturals",
+      "startLine": 55,
+      "endLine": 70,
+      "summary": "Redefines ℕ as the inductive type with constructors zero and succ — the structure map of the X ↦ 1 + X algebra split into its two components — plus abbreviations one and two.",
+      "mathContext": "$\\mathbb{N} ::= 0 \\mid S(n)$; the pair $(\\mathrm{zero}, \\mathrm{succ})$ is an algebra structure $1 + \\mathbb{N} \\to \\mathbb{N}$."
+    },
+    {
+      "id": "iterator-existence",
+      "title": "The iterator: existence",
+      "startLine": 72,
+      "endLine": 92,
+      "summary": "Defines iter f a : ℕ → A, the canonical map out of ℕ (the catamorphism / fold). Its two computation rules iter_zero and iter_succ hold by rfl, giving the existence half of the universal property for free.",
+      "mathContext": "$\\mathrm{iter}\\,f\\,a$ is the unique algebra homomorphism $(\\mathbb{N}, 0, S) \\to (A, a, f)$; existence is the recursor $\\mathbb{N}.\\mathrm{rec}$."
+    },
+    {
+      "id": "uniqueness-nno",
+      "title": "Uniqueness and the NNO universal property",
+      "startLine": 94,
+      "endLine": 126,
+      "summary": "iter_unique proves by structural induction that any map solving the two algebra equations equals iter f a. nno_universal packages existence and uniqueness into an ∃! over ℕ → A, the statement that (ℕ, zero, succ) is the initial (point, endomap)-algebra.",
+      "mathContext": "Lawvere's NNO: $\\forall A\\,a\\,f,\\ \\exists!\\,u : \\mathbb{N} \\to A,\\ u(0) = a \\wedge u(S n) = f(u\\,n)$ — initiality of $\\mathbb{N}$."
+    },
+    {
+      "id": "recovered-operations",
+      "title": "Addition and multiplication recovered",
+      "startLine": 127,
+      "endLine": 152,
+      "summary": "Defines add n = iter succ n and mul n = iter (add n) zero, recovering 1+1=2 (one_add_one) through the universal property. add_eq_unique shows addition is the only solution of its recurrence — + and × are forced by initiality.",
+      "mathContext": "$n + {-} = \\mathrm{iter}\\,S\\,n$ and $n \\cdot {-} = \\mathrm{iter}\\,(n + {-})\\,0$; the recurrences characterize them uniquely."
+    },
+    {
+      "id": "lambek-iso",
+      "title": "Lambek's lemma: ℕ ≅ 1 + ℕ",
+      "startLine": 154,
+      "endLine": 184,
+      "summary": "Presents the structure map structMap : Option ℕ → ℕ and its inverse structInv, with the two round-trip identities (structMap_leftInv, structInv_rightInv) packaged in lambek — a concrete witness that the initial-algebra structure map is an isomorphism.",
+      "mathContext": "Lambek's lemma: the structure map of an initial algebra is iso, so $\\mathbb{N} \\cong 1 + \\mathbb{N}$ (every natural is uniquely $0$ or a successor)."
+    },
+    {
+      "id": "three-foundations",
+      "title": "How the three foundations meet at ℕ",
+      "startLine": 196,
+      "endLine": 220,
+      "summary": "Closing essay identifying the single universal property nno_universal as Dedekind's recursion theorem (set theory), the recursor (type theory), and Lawvere's NNO / initial algebra (category theory) — one object pinned down up to unique isomorphism by one property.",
+      "mathContext": "Set theory: recursion is a theorem. Type theory: recursion is definitional. Category theory: recursion is a universal property."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "russell-1-plus-1",
+      "relationship": "extends",
+      "description": "The parent entry builds ℕ type-theoretically and proves 1+1=2 by rfl; this follow-up answers its open question by showing that same ℕ satisfies the category-theoretic Natural Numbers Object specification, with 1+1=2 re-derived through the universal property."
+    },
+    {
+      "targetId": "russell-1-plus-1-oq-04",
+      "relationship": "related",
+      "description": "OQ-04 dissects the reduction rules that make 1+1=2 a definitional rfl across ℕ encodings; this entry instead abstracts away from any encoding to the universal property those encodings all realize."
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "related",
+      "description": "Both concern the expressive structure of foundational systems: Cantor's argument bounds the cardinality of an enumeration, while this entry pins down ℕ itself by a universal property shared across foundations."
+    }
+  ],
+  "conclusion": {
+    "summary": "The natural numbers are the same object in set theory, type theory, and category theory — pinned down, up to unique isomorphism, by a single universal property. This entry proves that the type-theoretic ℕ satisfies Lawvere's Natural Numbers Object specification: existence of the mediating map is the recursor (definitional), uniqueness is structural induction (initiality), and the whole package is an ∃! closed by funext. Addition and multiplication fall out as the maps the property names, and Lambek's lemma reappears as the concrete bijection ℕ ≅ 1 + ℕ.",
+    "implications": "Foundational architecture: the open question 'how do the foundations relate?' has, for ℕ, a precise answer. They differ in what status they assign to the recursion principle — a theorem to prove (Dedekind/ZFC), a definition built into the kernel (type theory), or a universal property to characterize (Lawvere) — but they agree on the object. This is a concrete instance of the broader fact that inductive types in type theory are internal initial algebras, making category-theoretic universal properties available by computation rather than by external construction."
+  },
+  "leanFile": {
+    "imports": [],
+    "opens": [
+      "ℕ"
+    ],
+    "namespace": "PeanoNNO",
+    "lineCount": 220,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 7,
+    "path": "Proofs/OnePlusOneOQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Lawvere, F. William",
+      "title": "An elementary theory of the category of sets",
+      "year": "1964",
+      "venue": "Proceedings of the National Academy of Sciences 52(6)",
+      "note": "Introduces the Natural Numbers Object as a universal property characterizing ℕ in any suitable category."
+    },
+    {
+      "authors": "Lambek, Joachim",
+      "title": "A fixpoint theorem for complete categories",
+      "year": "1968",
+      "venue": "Mathematische Zeitschrift 103",
+      "note": "Lambek's lemma: the structure map of an initial algebra is an isomorphism; here ℕ ≅ 1 + ℕ."
+    },
+    {
+      "authors": "Dedekind, Richard",
+      "title": "Was sind und was sollen die Zahlen?",
+      "year": "1888",
+      "venue": "Vieweg, Braunschweig",
+      "note": "The recursion theorem: the set-theoretic form of the same universal property, requiring a genuine existence proof."
+    },
+    {
+      "authors": "Whitehead, Alfred North; Russell, Bertrand",
+      "title": "Principia Mathematica",
+      "year": "1910",
+      "venue": "Cambridge University Press, Vol. I",
+      "note": "The logicist, set-theoretic route to arithmetic that the type-theoretic universal property short-circuits."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "nno_universal",
+      "type": "core",
+      "description": "ℕ is a Natural Numbers Object: for every (point a, endomap f) there is a unique u : ℕ → A with u(0) = a and u(succ n) = f(u n). Equivalently, (ℕ, zero, succ) is the initial algebra of X ↦ 1 + X.",
+      "leanType": "∀ {A : Type} (a : A) (f : A → A), ∃ u : ℕ → A, (u zero = a ∧ ∀ n, u (succ n) = f (u n)) ∧ ∀ v, (v zero = a ∧ ∀ n, v (succ n) = f (v n)) → v = u"
+    },
+    {
+      "name": "iter_unique",
+      "type": "supporting",
+      "description": "Any map satisfying the two algebra-homomorphism equations equals the iterator — the initiality (uniqueness) half of the universal property.",
+      "leanType": "∀ {A} (f : A → A) (a : A) (u : ℕ → A), u zero = a → (∀ n, u (succ n) = f (u n)) → ∀ n, u n = iter f a n"
+    },
+    {
+      "name": "add_eq_unique",
+      "type": "corollary",
+      "description": "Addition is the unique solution of its recurrence — + is forced by the universal property, not posited.",
+      "leanType": "∀ (n : ℕ) (g : ℕ → ℕ), g zero = n → (∀ m, g (succ m) = succ (g m)) → g = add n"
+    },
+    {
+      "name": "lambek",
+      "type": "corollary",
+      "description": "Lambek's lemma, concrete form: structMap and structInv are mutually inverse, so ℕ ≅ 1 + ℕ.",
+      "leanType": "(∀ x : Option ℕ, structInv (structMap x) = x) ∧ (∀ n : ℕ, structMap (structInv n) = n)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **russell-1-plus-1** open question — *how do the foundations of mathematics (set theory, type theory, category theory) relate?* — with one concrete, machine-checked bridge:

> The inductively-defined ℕ is a **Natural Numbers Object** (Lawvere, 1964): the **initial algebra** of the endofunctor `X ↦ 1 + X`.

The parent entry builds ℕ type-theoretically and proves `1 + 1 = 2` by `rfl`. This follow-up shows that *same* ℕ satisfies the **category-theoretic** specification of the natural numbers, tying the type-theoretic, set-theoretic, and categorical traditions to a single universal property.

## What's proved (`Proofs/OnePlusOneOQ01.lean`, self-contained, no Mathlib)

- **`nno_universal`** (headline): for every type `A`, point `a : A`, endomap `f : A → A`, there is a **unique** `u : ℕ → A` with `u 0 = a` and `u (succ n) = f (u n)`.
  - Existence = the iterator `iter` (literally `ℕ.rec`; computation rules hold by `rfl`).
  - Uniqueness = structural induction (`iter_unique`) = **initiality**, lifted to a function equality by `funext`.
- **`add_eq_unique`**: addition `add n = iter succ n` is the *unique* solution of its recurrence — `+` and `×` are **forced by initiality**, not posited. `one_add_one` re-derives 1+1=2 through the universal property.
- **`lambek`**: concrete **Lambek's lemma**, the bijection `ℕ ≅ 1 + ℕ` via `Option` (every natural is uniquely zero or a successor).
- Closing essay maps the single property onto Dedekind recursion (set theory), the recursor (type theory), and the NNO / initial algebra (category theory).

## Verification

- Docker-built clean against `Proofs.OnePlusOneOQ01` (Lean v4.26.0).
- `#print axioms`: `nno_universal`/`add_eq_unique` depend only on **`Quot.sound`** (from `funext`); `iter_unique`/`lambek` depend on **no axioms**. No `sorryAx`, no `Lean.ofReduceBool`, no `Classical.choice`/`propext`. Per the gallery axiom policy this is **verified, 0-axiom**.
- 220 lines, 13 theorems, 7 definitions, 0 sorries. Mathlib-free (mirrors the parent's foundational minimalism).

## Gallery

- `src/data/proofs/russell-1-plus-1-oq-01/{meta.json,annotations.json}`
- `crossReferences` link to the parent `russell-1-plus-1` (extends) and sibling `russell-1-plus-1-oq-04` (related).

🤖 Generated with [Claude Code](https://claude.com/claude-code)