### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-01): central-binomial lower bound & geometric growth of the Apéry numbers [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -221,6 +221,7 @@ import Proofs.BaselProblem
 import Proofs.BaselProblemOQ01OQ01
 import Proofs.BaselProblemOQ01OQ01OQ02
 import Proofs.BaselProblemOQ01OQ01OQ02Aristotle
+import Proofs.BaselProblemOQ01OQ01OQ02OQ01
 import Proofs.BaselProblemOQ01OQ01OQ02OQ02
 import Proofs.BaselProblemOQ01OQ01OQ02OQ03
 import Proofs.BaselProblemOQ01OQ03

--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,141 @@
+import Mathlib.Data.Nat.Choose.Central
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Tactic
+
+/-
+# Apéry numbers: the central-binomial lower bound and geometric growth
+
+## Context
+This is a self-contained, axiom-free companion to the Apéry / ζ(3) lineage
+(`BaselProblemOQ01OQ01OQ02.lean`).  That file proves the irrationality of ζ(3)
+*from five axioms*, one of which is an exponential **upper** bound on the Apéry
+numbers, `bₙ ≤ 34ⁿ`.  The opposite half of the squeeze — that the Apéry numbers
+grow *at least* geometrically — has no axiom-free witness there.  This file
+supplies it.
+
+## The Apéry numbers
+    bₙ = ∑_{k=0}^{n} C(n,k)² · C(n+k,k)²            (1, 5, 73, 1445, 33001, …)
+
+These positive integers drive Apéry's proof: `bₙ ζ(3) − aₙ → 0` geometrically
+while `bₙ → ∞`, and the competition forces irrationality.  For that argument the
+*divergence* of `bₙ` matters, so a clean lower bound is exactly the structural
+fact one wants.
+
+## What is proved (all 0-axiom, 0-sorry)
+* `aperyB_centralTerm` — the `k = n` summand is exactly `centralBinom n ²`.
+* `centralBinom_sq_le_aperyB` — `C(2n,n)² ≤ bₙ`  (drop every other term).
+* `two_pow_le_centralBinom` — `2ⁿ ≤ C(2n,n)`  (short induction, self-contained).
+* `four_pow_le_aperyB` — `4ⁿ ≤ bₙ`  (geometric lower bound).
+* `sixteen_pow_le_aperyB` — `16ⁿ ≤ 4n²·bₙ`  (sharper rate-16 bound from the
+  central term: `bₙ ≳ 16ⁿ / 4n²`, since `C(2n,n)² ≈ 16ⁿ/πn`).
+* `aperyB_tendsto_atTop` — `(bₙ : ℝ) → ∞`.
+
+The true growth rate is `(1+√2)⁴ = 17+12√2 ≈ 33.97`; the rigorous bounds here
+bracket the exponential base in `[4, 34]` (and `[16, 34]` up to a polynomial
+factor), which is all the irrationality squeeze needs from the lower side.
+
+Reference: Apéry (1979); van der Poorten, *A proof that Euler missed* (1979).
+-/
+
+open BigOperators Finset Nat Filter
+
+namespace AperyCentralBinom
+
+/-- The Apéry b-sequence `bₙ = ∑_{k≤n} C(n,k)² · C(n+k,k)²`. -/
+def aperyB (n : ℕ) : ℕ :=
+  ∑ k ∈ range (n + 1), (n.choose k) ^ 2 * ((n + k).choose k) ^ 2
+
+theorem aperyB_zero : aperyB 0 = 1 := by simp [aperyB]
+
+theorem aperyB_one : aperyB 1 = 5 := by simp [aperyB, Finset.sum_range_succ]
+
+theorem aperyB_two : aperyB 2 = 73 := by decide
+
+theorem aperyB_three : aperyB 3 = 1445 := by decide
+
+/-- Every Apéry number is positive. -/
+theorem aperyB_pos (n : ℕ) : 0 < aperyB n := by
+  unfold aperyB
+  apply Finset.sum_pos
+  · intro k hk
+    have h1 : 0 < n.choose k :=
+      Nat.choose_pos (Nat.lt_succ_iff.mp (Finset.mem_range.mp hk))
+    have h2 : 0 < (n + k).choose k := Nat.choose_pos (Nat.le_add_left k n)
+    positivity
+  · exact ⟨0, Finset.mem_range.mpr (Nat.succ_pos n)⟩
+
+-- ============================================================================
+-- The central term and the central-binomial lower bound
+-- ============================================================================
+
+/-- The `k = n` term of the Apéry sum is exactly the square of the central
+binomial coefficient: `C(n,n)² · C(2n,n)² = C(2n,n)²`. -/
+theorem aperyB_centralTerm (n : ℕ) :
+    (n.choose n) ^ 2 * ((n + n).choose n) ^ 2 = (Nat.centralBinom n) ^ 2 := by
+  rw [Nat.choose_self, one_pow, one_mul, Nat.centralBinom_eq_two_mul_choose, two_mul]
+
+/-- Dropping every summand except `k = n` gives `C(2n,n)² ≤ bₙ`. -/
+theorem centralBinom_sq_le_aperyB (n : ℕ) : (Nat.centralBinom n) ^ 2 ≤ aperyB n := by
+  rw [← aperyB_centralTerm]
+  unfold aperyB
+  exact Finset.single_le_sum (f := fun k => (n.choose k) ^ 2 * ((n + k).choose k) ^ 2)
+    (fun i _ => Nat.zero_le _) (Finset.mem_range.mpr (Nat.lt_succ_self n))
+
+-- ============================================================================
+-- A self-contained exponential bound on the central binomial coefficient
+-- ============================================================================
+
+/-- `2ⁿ ≤ C(2n,n)`.  Proved by induction using the Pascal-type identity
+`(n+1)·C(2n+2,n+1) = 2(2n+1)·C(2n,n)` (`Nat.succ_mul_centralBinom_succ`). -/
+theorem two_pow_le_centralBinom : ∀ n : ℕ, 2 ^ n ≤ Nat.centralBinom n
+  | 0 => by simp [Nat.centralBinom_zero]
+  | n + 1 => by
+    have ih := two_pow_le_centralBinom n
+    -- Multiply the target by (n+1) > 0 and use the central-binomial recurrence.
+    have h : (n + 1) * 2 ^ (n + 1) ≤ (n + 1) * Nat.centralBinom (n + 1) := by
+      calc (n + 1) * 2 ^ (n + 1)
+          = (2 * (n + 1)) * 2 ^ n := by ring
+        _ ≤ (2 * (2 * n + 1)) * Nat.centralBinom n := Nat.mul_le_mul (by omega) ih
+        _ = (n + 1) * Nat.centralBinom (n + 1) := (Nat.succ_mul_centralBinom_succ n).symm
+    exact Nat.le_of_mul_le_mul_left h (Nat.succ_pos n)
+
+/-- Geometric lower bound: `4ⁿ ≤ bₙ`. -/
+theorem four_pow_le_aperyB (n : ℕ) : 4 ^ n ≤ aperyB n := by
+  calc (4 : ℕ) ^ n
+      = (2 ^ n) ^ 2 := by
+        rw [show (4 : ℕ) = 2 ^ 2 by norm_num, ← pow_mul, ← pow_mul, Nat.mul_comm]
+    _ ≤ (Nat.centralBinom n) ^ 2 := Nat.pow_le_pow_left (two_pow_le_centralBinom n) 2
+    _ ≤ aperyB n := centralBinom_sq_le_aperyB n
+
+/-- Sharper rate-16 bound: `16ⁿ ≤ 4n²·bₙ`, i.e. `bₙ ≳ 16ⁿ / 4n²`.
+Uses the Erdős–Bertrand bound `4ⁿ ≤ 2n·C(2n,n)` and squares it. -/
+theorem sixteen_pow_le_aperyB (n : ℕ) (hn : 0 < n) :
+    16 ^ n ≤ 4 * n ^ 2 * aperyB n := by
+  have hC : 4 ^ n ≤ 2 * n * Nat.centralBinom n :=
+    Nat.four_pow_le_two_mul_self_mul_centralBinom n hn
+  calc (16 : ℕ) ^ n
+      = (4 ^ n) ^ 2 := by
+        rw [show (16 : ℕ) = 4 ^ 2 by norm_num, ← pow_mul, ← pow_mul, Nat.mul_comm]
+    _ ≤ (2 * n * Nat.centralBinom n) ^ 2 := Nat.pow_le_pow_left hC 2
+    _ = 4 * n ^ 2 * (Nat.centralBinom n) ^ 2 := by ring
+    _ ≤ 4 * n ^ 2 * aperyB n := by
+        gcongr
+        exact centralBinom_sq_le_aperyB n
+
+-- ============================================================================
+-- Divergence of the Apéry numbers
+-- ============================================================================
+
+/-- The Apéry numbers diverge to infinity: `(bₙ : ℝ) → ∞`.
+Squeeze above `4ⁿ → ∞` using `four_pow_le_aperyB`. -/
+theorem aperyB_tendsto_atTop :
+    Tendsto (fun n : ℕ => (aperyB n : ℝ)) atTop atTop := by
+  refine tendsto_atTop_mono (g := fun n : ℕ => (aperyB n : ℝ))
+    (f := fun n : ℕ => (4 : ℝ) ^ n) (fun n => ?_)
+    (tendsto_pow_atTop_atTop_of_one_lt (by norm_num : (1 : ℝ) < 4))
+  have h : (4 : ℕ) ^ n ≤ aperyB n := four_pow_le_aperyB n
+  calc (4 : ℝ) ^ n = ((4 ^ n : ℕ) : ℝ) := by push_cast; ring
+    _ ≤ (aperyB n : ℝ) := by exact_mod_cast h
+
+end AperyCentralBinom

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-basel-oq01010201-context",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 9, "endLine": 23 },
+    "type": "concept",
+    "title": "The lower half of Apéry's squeeze, axiom-free",
+    "content": "Apéry's proof that ζ(3) is irrational pits two sequences against each other: the Apéry numbers bₙ = ∑ C(n,k)²·C(n+k,k)² grow geometrically, while the linear forms bₙζ(3) − aₙ shrink geometrically. The parent file formalizes the whole proof but leans on five axioms, one of which bounds bₙ from ABOVE by 34ⁿ. No axiom-free statement there pins bₙ from BELOW. This file does exactly that, from scratch, with 0 axioms — the Apéry numbers grow at least like 4ⁿ (and, up to a polynomial factor, like 16ⁿ), and diverge to infinity.",
+    "mathContext": "$b_n=\\sum_{k=0}^n\\binom{n}{k}^2\\binom{n+k}{k}^2$ grows geometrically; here $4^n\\le b_n$ and $16^n\\le 4n^2 b_n$."
+  },
+  {
+    "id": "ann-basel-oq01010201-central-term",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 68, "endLine": 83 },
+    "type": "key-step",
+    "title": "The central binomial coefficient lives inside every Apéry number",
+    "content": "The single observation driving the entire file: the k = n summand of bₙ is C(n,n)²·C(n+n,n)² = 1·C(2n,n)² = C(2n,n)² (aperyB_centralTerm). Since every summand is a nonnegative integer, Finset.single_le_sum lets us discard all the others and keep just this one, yielding C(2n,n)² ≤ bₙ (centralBinom_sq_le_aperyB). The central binomial coefficient — whose growth is exactly understood — thus furnishes a lower bound on the much more intricate Apéry numbers.",
+    "mathContext": "$\\binom{n}{n}^2\\binom{2n}{n}^2=\\binom{2n}{n}^2\\le\\sum_k\\binom{n}{k}^2\\binom{n+k}{k}^2=b_n.$"
+  },
+  {
+    "id": "ann-basel-oq01010201-two-pow",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 85, "endLine": 109 },
+    "type": "technique",
+    "title": "2ⁿ ≤ C(2n,n) by a self-contained recurrence induction",
+    "content": "To turn C(2n,n)² ≤ bₙ into a clean geometric bound, two_pow_le_centralBinom proves 2ⁿ ≤ C(2n,n) without Stirling or analysis. The induction multiplies the goal 2^(n+1) ≤ C(2n+2,n+1) by the positive factor (n+1) and rewrites the right side with Mathlib's identity (n+1)·C(2n+2,n+1) = 2(2n+1)·C(2n,n); since 2(n+1) ≤ 2(2n+1) and 2ⁿ ≤ C(2n,n) by the inductive hypothesis, Nat.mul_le_mul closes the multiplied inequality, then Nat.le_of_mul_le_mul_left cancels the (n+1). Squaring gives 4ⁿ = (2ⁿ)² ≤ C(2n,n)² ≤ bₙ.",
+    "mathContext": "$(n+1)\\binom{2n+2}{n+1}=2(2n+1)\\binom{2n}{n}$ and $2(n+1)\\le 2(2n+1)$ give $2^{n+1}\\le\\binom{2n+2}{n+1}$."
+  },
+  {
+    "id": "ann-basel-oq01010201-sixteen",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 111, "endLine": 124 },
+    "type": "observation",
+    "title": "The sharper rate-16 bound from Erdős's central-binomial estimate",
+    "content": "The crude 4ⁿ wastes most of the central term's size. sixteen_pow_le_aperyB instead squares Mathlib's Erdős–Bertrand bound 4ⁿ ≤ 2n·C(2n,n) to get 16ⁿ ≤ (2n)²·C(2n,n)² = 4n²·C(2n,n)² ≤ 4n²·bₙ, i.e. bₙ ≳ 16ⁿ/4n². This recovers the genuine exponential order of the central term C(2n,n)² ≈ 16ⁿ/πn, leaving only a polynomial gap to the true Apéry growth rate (1+√2)⁴ = 17+12√2 ≈ 33.97.",
+    "mathContext": "$16^n=(4^n)^2\\le(2n\\binom{2n}{n})^2=4n^2\\binom{2n}{n}^2\\le 4n^2 b_n.$"
+  },
+  {
+    "id": "ann-basel-oq01010201-divergence",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 126, "endLine": 139 },
+    "type": "key-step",
+    "title": "Divergence bₙ → ∞ by squeezing above 4ⁿ",
+    "content": "The qualitative fact Apéry's argument needs from the lower side is just bₙ → ∞. With the pointwise real bound (4:ℝ)ⁿ ≤ bₙ (cast from four_pow_le_aperyB) and tendsto_pow_atTop_atTop_of_one_lt (since 1 < 4), tendsto_atTop_mono delivers Tendsto (fun n => (bₙ:ℝ)) atTop atTop. The denominators lcm(1,…,n)³ grow only like 27ⁿ at worst, so bₙ → ∞ at a geometric rate is precisely what keeps the integer-squeeze nontrivial.",
+    "mathContext": "$4^n\\to\\infty$ and $4^n\\le b_n\\Rightarrow b_n\\to\\infty$."
+  }
+]

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,174 @@
+{
+  "id": "basel-problem-oq-01-oq-01-oq-02-oq-01",
+  "slug": "basel-problem-oq-01-oq-01-oq-02-oq-01",
+  "title": "Apéry Numbers: the Central-Binomial Lower Bound and Geometric Growth",
+  "description": "A self-contained, axiom-free companion to the Apéry / ζ(3) lineage. The parent BaselProblemOQ01OQ01OQ02 proves ζ(3) irrational from five axioms, one of which is an exponential UPPER bound on the Apéry numbers bₙ = ∑ C(n,k)²·C(n+k,k)² (namely bₙ ≤ 34ⁿ); the opposite, lower half of the squeeze has no axiom-free witness there. This entry supplies it. Dropping every summand except k = n gives C(2n,n)² ≤ bₙ; a short self-contained induction proves 2ⁿ ≤ C(2n,n); together these yield the geometric lower bound 4ⁿ ≤ bₙ, the sharper rate-16 bound 16ⁿ ≤ 4n²·bₙ from the central term, and the divergence (bₙ : ℝ) → ∞. The rigorous bounds bracket the exponential growth base of bₙ in [4, 34] (and [16, 34] up to a polynomial factor); the true rate is (1+√2)⁴ = 17+12√2 ≈ 33.97.",
+  "meta": {
+    "author": "Lean Genius Researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean",
+    "tags": [
+      "apery",
+      "zeta-3",
+      "central-binomial",
+      "irrationality",
+      "number-theory",
+      "combinatorics",
+      "asymptotics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 141,
+    "theoremCount": 11,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. The illustrative value checks b₂ = 73 and b₃ = 1445 use kernel `decide` (not native_decide), so the whole file depends only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms — no Lean.ofReduceBool, no sorryAx). The Apéry numbers bₙ are redefined locally, so none of the five axioms of the parent file enter the dependency graph.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.centralBinom_eq_two_mul_choose",
+        "description": "centralBinom n = (2n).choose n",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.succ_mul_centralBinom_succ",
+        "description": "(n+1)·centralBinom(n+1) = 2(2n+1)·centralBinom n",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.four_pow_le_two_mul_self_mul_centralBinom",
+        "description": "4ⁿ ≤ 2n·centralBinom n (Erdős's Bertrand-postulate bound)",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Finset.single_le_sum",
+        "description": "a single nonnegative term is ≤ the whole sum",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "tendsto_pow_atTop_atTop_of_one_lt",
+        "description": "1 < r ⟹ rⁿ → ∞",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "tendsto_atTop_mono",
+        "description": "f ≤ g pointwise and f → ∞ ⟹ g → ∞",
+        "module": "Mathlib.Order.Filter.AtTopBot.Tendsto"
+      }
+    ],
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Choose.Central",
+      "Mathlib.Analysis.SpecificLimits.Basic",
+      "Mathlib.Algebra.Order.BigOperators.Group.Finset",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["BigOperators", "Finset", "Nat", "Filter"],
+    "namespace": "AperyCentralBinom",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "centralBinom_sq_le_aperyB",
+      "type": "core",
+      "statement": "(Nat.centralBinom n) ^ 2 ≤ aperyB n",
+      "description": "Dropping every Apéry summand except the k = n term — which is exactly C(2n,n)² — gives the central-binomial lower bound C(2n,n)² ≤ bₙ.",
+      "significance": "The structural lower bound that all geometric bounds build on; the central binomial coefficient sits inside every Apéry number."
+    },
+    {
+      "name": "four_pow_le_aperyB",
+      "type": "core",
+      "statement": "4 ^ n ≤ aperyB n",
+      "description": "Geometric lower bound: bₙ ≥ 4ⁿ, from C(2n,n)² ≥ (2ⁿ)² = 4ⁿ.",
+      "significance": "Pins the lower exponential base of the Apéry numbers, the half of the irrationality squeeze missing (axiom-free) from the parent."
+    },
+    {
+      "name": "sixteen_pow_le_aperyB",
+      "type": "core",
+      "statement": "0 < n → 16 ^ n ≤ 4 * n ^ 2 * aperyB n",
+      "description": "Sharper rate-16 bound bₙ ≳ 16ⁿ / 4n², obtained by squaring Erdős's central-binomial bound 4ⁿ ≤ 2n·C(2n,n).",
+      "significance": "Captures the actual exponential order of the central term C(2n,n)² ≈ 16ⁿ/πn, far closer to the true base 17+12√2 than the crude 4ⁿ."
+    },
+    {
+      "name": "two_pow_le_centralBinom",
+      "type": "supporting",
+      "statement": "2 ^ n ≤ Nat.centralBinom n",
+      "description": "A self-contained induction (using the central-binomial recurrence) showing the central binomial coefficient dominates 2ⁿ.",
+      "significance": "Supplies the clean factor needed for the 4ⁿ lower bound without invoking Stirling or analytic estimates."
+    },
+    {
+      "name": "aperyB_tendsto_atTop",
+      "type": "core",
+      "statement": "Tendsto (fun n => (aperyB n : ℝ)) atTop atTop",
+      "description": "The Apéry numbers diverge to infinity, by squeezing above 4ⁿ → ∞.",
+      "significance": "The qualitative fact the irrationality argument needs from the lower side: bₙ → ∞ while bₙζ(3) − aₙ → 0."
+    }
+  ],
+  "sections": [
+    {
+      "id": "definition-values",
+      "title": "Section 0: Definition and small values",
+      "startLine": 45,
+      "endLine": 66,
+      "summary": "The Apéry b-sequence bₙ = ∑_{k≤n} C(n,k)²·C(n+k,k)²; values b₀=1, b₁=5, b₂=73, b₃=1445 (the last two by kernel decide); positivity aperyB_pos via Finset.sum_pos.",
+      "mathContext": "$b_n=\\sum_{k=0}^n\\binom{n}{k}^2\\binom{n+k}{k}^2$, a sequence of positive integers $1,5,73,1445,33001,\\dots$"
+    },
+    {
+      "id": "central-term-bound",
+      "title": "Section I: The central term and its lower bound",
+      "startLine": 68,
+      "endLine": 83,
+      "summary": "aperyB_centralTerm: the k = n summand equals C(2n,n)² (since C(n,n)=1 and C(n+n,n)=centralBinom n). centralBinom_sq_le_aperyB: Finset.single_le_sum drops every other (nonnegative) term to leave C(2n,n)² ≤ bₙ.",
+      "mathContext": "The $k=n$ term is $\\binom{n}{n}^2\\binom{2n}{n}^2=\\binom{2n}{n}^2$; all terms are nonnegative, so $\\binom{2n}{n}^2\\le b_n$."
+    },
+    {
+      "id": "central-binom-exp",
+      "title": "Section II: Exponential bounds on the central binomial coefficient",
+      "startLine": 85,
+      "endLine": 124,
+      "summary": "two_pow_le_centralBinom: 2ⁿ ≤ C(2n,n) by induction, multiplying the target by (n+1) and applying succ_mul_centralBinom_succ. four_pow_le_aperyB: 4ⁿ = (2ⁿ)² ≤ C(2n,n)² ≤ bₙ. sixteen_pow_le_aperyB: square Erdős's 4ⁿ ≤ 2n·C(2n,n) to get 16ⁿ ≤ 4n²·bₙ.",
+      "mathContext": "$2^n\\le\\binom{2n}{n}$ gives $4^n\\le b_n$; squaring $4^n\\le 2n\\binom{2n}{n}$ gives $16^n\\le 4n^2 b_n$."
+    },
+    {
+      "id": "divergence",
+      "title": "Section III: Divergence",
+      "startLine": 126,
+      "endLine": 139,
+      "summary": "aperyB_tendsto_atTop: (bₙ : ℝ) → ∞ via tendsto_atTop_mono over the pointwise bound (4:ℝ)ⁿ ≤ bₙ together with tendsto_pow_atTop_atTop_of_one_lt.",
+      "mathContext": "$b_n\\ge 4^n\\to\\infty$, so $b_n\\to\\infty$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The geometric lower bound on the Apéry numbers — absent (axiom-free) from the parent ζ(3) file, which only bounds bₙ from above by 34ⁿ — is established here with 0 axioms and 0 sorries: C(2n,n)² ≤ bₙ, hence 4ⁿ ≤ bₙ, the sharper 16ⁿ ≤ 4n²·bₙ, and bₙ → ∞. The bounds bracket the exponential growth base of the Apéry numbers in [4, 34].",
+    "implications": "Apéry's irrationality proof for ζ(3) hinges on bₙ → ∞ (in fact growing geometrically) while bₙζ(3) − aₙ → 0 geometrically. This entry isolates and proves, assumption-free, the lower-growth fact, complementing the parent's axiomatized upper bound. The whole argument flows from the single observation that the central binomial coefficient squared is one of the Apéry summands.",
+    "openQuestions": [
+      "Sharpen the lower base from 4 (or 16 up to a polynomial factor) toward the true 17+12√2 by bounding the largest summand (near k ≈ 0.8n) rather than the central one.",
+      "Prove the matching axiom-free upper bound bₙ ≤ Cⁿ for some explicit C, closing the geometric two-sided estimate without the parent's recurrence axiom.",
+      "Formalize that every Apéry number is odd (a Kummer/Lucas mod-2 argument: the only odd summand mod 2 is the k = 0 term)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-01-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "The parent formalizes Apéry's proof of ζ(3) irrationality from five axioms and bounds bₙ above by 34ⁿ; this child proves the complementary geometric lower bound on bₙ with no axioms."
+    },
+    {
+      "targetId": "basel-problem-oq-01-oq-01-oq-02-oq-03",
+      "relationship": "related",
+      "description": "A sibling targeting Hanson's bound lcm(1,…,n) ≤ 3ⁿ, the other growth ingredient (denominator side) of the same irrationality squeeze."
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "ancestor",
+      "description": "The Basel lineage root (ζ(2) = π²/6); the Apéry numbers are the ζ(3) analogue of the rational approximations that make such zeta values tractable."
+    }
+  ]
+}

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-01.json
@@ -1,0 +1,78 @@
+{
+  "slug": "basel-problem-oq-01-oq-01-oq-02-oq-01",
+  "title": "Apéry numbers: the central-binomial lower bound and geometric growth",
+  "problemStatement": "Prove, with no axioms, a geometric lower bound on the Apéry numbers bₙ = ∑_{k≤n} C(n,k)²·C(n+k,k)². The parent basel-problem-oq-01-oq-01-oq-02 formalizes Apéry's ζ(3)-irrationality proof from five axioms, one of which is an exponential UPPER bound bₙ ≤ 34ⁿ; no axiom-free statement there bounds bₙ from below. Establish C(2n,n)² ≤ bₙ, 4ⁿ ≤ bₙ, the sharper 16ⁿ ≤ 4n²·bₙ, and bₙ → ∞.",
+  "significance": "Supplies the lower half of Apéry's growth squeeze (bₙ → ∞ geometrically) assumption-free, complementing the parent's axiomatized 34ⁿ upper bound. The whole argument flows from one observation: the central binomial coefficient squared is one of the Apéry summands, so its known growth bounds the intricate Apéry numbers below.",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "tractability": "high",
+  "started": "2026-06-21",
+  "completed": "2026-06-21",
+  "lastUpdate": "2026-06-21",
+  "path": "proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean",
+  "leanFiles": [
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ01.lean",
+      "lineCount": 141,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean"
+    }
+  ],
+  "relatedProofs": [
+    "basel-problem",
+    "basel-problem-oq-01",
+    "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-01-oq-02",
+    "basel-problem-oq-01-oq-01-oq-02-oq-01",
+    "basel-problem-oq-01-oq-01-oq-02-oq-02",
+    "basel-problem-oq-01-oq-01-oq-02-oq-03",
+    "basel-problem-oq-01-oq-03"
+  ],
+  "knownResults": [
+    "Apéry (1979): bₙ = ∑ C(n,k)²·C(n+k,k)² are positive integers driving ζ(3) irrationality",
+    "Erdős's Bertrand-postulate bound 4ⁿ ≤ 2n·C(2n,n) (Mathlib Nat.four_pow_le_two_mul_self_mul_centralBinom)",
+    "Central binomial recurrence (n+1)·C(2n+2,n+1) = 2(2n+1)·C(2n,n) (Mathlib Nat.succ_mul_centralBinom_succ)"
+  ],
+  "references": [],
+  "tags": [
+    "apery",
+    "zeta-3",
+    "central-binomial",
+    "irrationality",
+    "number-theory",
+    "combinatorics"
+  ],
+  "currentState": "Solved. 11 theorems, 1 definition, 0 axioms, 0 sorries, no native_decide. Builds against Mathlib 4.26.0.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: axiom-free geometric lower bound on the Apéry numbers. C(2n,n)² ≤ bₙ (drop all but the k=n term), 2ⁿ ≤ C(2n,n) (self-contained recurrence induction), hence 4ⁿ ≤ bₙ; sharper 16ⁿ ≤ 4n²·bₙ by squaring Erdős's bound; bₙ → ∞ by squeeze. Apéry numbers redefined locally so none of the parent's five axioms enter.",
+    "insights": [
+      "The k = n summand of bₙ is C(n,n)²·C(n+n,n)² = C(2n,n)² exactly, so a single Finset.single_le_sum gives the central-binomial lower bound C(2n,n)² ≤ bₙ with no combinatorics.",
+      "2ⁿ ≤ C(2n,n) needs no Stirling: multiply the goal 2^(n+1) ≤ C(2n+2,n+1) by (n+1), rewrite with the central-binomial recurrence (n+1)C(2n+2,n+1)=2(2n+1)C(2n,n), use 2(n+1) ≤ 2(2n+1) and the IH, then cancel (n+1) with Nat.le_of_mul_le_mul_left.",
+      "Squaring Mathlib's Erdős bound 4ⁿ ≤ 2n·C(2n,n) gives the much sharper 16ⁿ ≤ 4n²·bₙ — matching the genuine order C(2n,n)² ≈ 16ⁿ/πn of the central term, within a polynomial factor of the true rate 17+12√2.",
+      "Kernel `decide` (not native_decide) handles b₂=73 and b₃=1445, keeping the file fully 0-axiom (only propext/Classical.choice/Quot.sound; verified by #print axioms).",
+      "Defining aperyB locally (rather than importing the parent) keeps the five Apéry axioms out of the dependency graph entirely."
+    ],
+    "builtItems": [
+      "aperyB_centralTerm (BaselProblemOQ01OQ01OQ02OQ01.lean:74) — k=n summand = C(2n,n)²",
+      "centralBinom_sq_le_aperyB (:79) — C(2n,n)² ≤ bₙ",
+      "two_pow_le_centralBinom (:91) — 2ⁿ ≤ C(2n,n), self-contained induction",
+      "four_pow_le_aperyB (:104) — geometric lower bound 4ⁿ ≤ bₙ",
+      "sixteen_pow_le_aperyB (:113) — sharper 16ⁿ ≤ 4n²·bₙ",
+      "aperyB_tendsto_atTop (:132) — (bₙ:ℝ) → ∞"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the central-binomial growth bounds and recurrence but no facts about the Apéry numbers themselves (definition, integrality, growth, congruences)."
+    ],
+    "nextSteps": [
+      "Sharpen the lower base toward 17+12√2 by bounding the largest summand (near k ≈ 0.8n) instead of the central one.",
+      "Prove an axiom-free geometric UPPER bound bₙ ≤ Cⁿ, removing the parent's recurrence-based 34ⁿ axiom.",
+      "Formalize that every Apéry number is odd via a Kummer/Lucas mod-2 argument (only the k = 0 term survives mod 2)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Axiom-free companion to the Apéry / ζ(3) lineage. The parent `basel-problem-oq-01-oq-01-oq-02` formalizes Apéry's proof that ζ(3) is irrational from **five axioms**, one of which is an exponential **upper** bound on the Apéry numbers `bₙ = ∑_{k≤n} C(n,k)²·C(n+k,k)²` (namely `bₙ ≤ 34ⁿ`). Nothing there bounds `bₙ` from **below** without an axiom. This PR supplies the missing lower half of Apéry's growth squeeze — from scratch, **0 axioms / 0 sorries / no native_decide**.

The whole argument flows from one observation: **the central binomial coefficient squared is one of the Apéry summands**, so its well-understood growth bounds the intricate Apéry numbers below.

## Results (`Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean`, 11 thm / 1 def, 141 lines)

| Theorem | Statement |
|---|---|
| `aperyB_centralTerm` | the `k=n` summand is exactly `C(2n,n)²` |
| `centralBinom_sq_le_aperyB` | `C(2n,n)² ≤ bₙ` (drop every other nonnegative term) |
| `two_pow_le_centralBinom` | `2ⁿ ≤ C(2n,n)` — self-contained recurrence induction, no Stirling |
| `four_pow_le_aperyB` | `4ⁿ ≤ bₙ` (geometric lower bound) |
| `sixteen_pow_le_aperyB` | `16ⁿ ≤ 4n²·bₙ` — sharper, by squaring Erdős's `4ⁿ ≤ 2n·C(2n,n)` |
| `aperyB_tendsto_atTop` | `(bₙ : ℝ) → ∞` |

The rigorous bounds bracket the exponential growth base of `bₙ` in `[4, 34]` (and `[16, 34]` up to a polynomial factor); the true rate is `(1+√2)⁴ = 17+12√2 ≈ 33.97`. The rate-16 bound matches the genuine order `C(2n,n)² ≈ 16ⁿ/πn` of the central term.

## Axiom integrity

The Apéry numbers are **redefined locally**, so none of the parent's five axioms enter the dependency graph. `b₂ = 73` and `b₃ = 1445` use kernel `decide` (not `native_decide`). `#print axioms` on every result shows only `propext / Classical.choice / Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`. Genuinely **verified, 0-axiom**.

## Verification

`./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ01OQ01OQ02OQ01` — builds clean against Mathlib 4.26.0, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)