### PR TITLE
research(erdos-733-oq-02): elementary rich-line bound via point-pair double counting [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2093,6 +2093,7 @@ import Proofs.Erdos731Problem
 import Proofs.Erdos732Problem
 import Proofs.Erdos733LimitBounds
 import Proofs.Erdos733Problem
+import Proofs.Erdos733RichLines
 import Proofs.Erdos734Problem
 import Proofs.Erdos735OQ04
 import Proofs.Erdos735OQ04Tetrahedron

--- a/proofs/Proofs/Erdos733RichLines.lean
+++ b/proofs/Proofs/Erdos733RichLines.lean
@@ -1,0 +1,185 @@
+/-
+# Erdős Problem #733 — the elementary rich-line bound
+
+**Parent.** `Erdos733Problem.lean` (registered) formalizes the count
+`f(n) = countLineCompatible n` of line-compatible sequences and records the
+Szemerédi–Trotter answer `f(n) = exp(Θ(√n))` as the two axioms `lower_bound`
+and `upper_bound`. Its **Part III** states, as an unproved docstring claim, the
+Szemerédi–Trotter corollary on rich lines:
+
+> *The number of k-rich lines (lines with ≥ k points) is `O(n²/k³ + n/k)`.*
+
+That corollary is exactly the engine that drives the (axiomatized) upper bound,
+yet the registered file proves nothing about it. This file fills that gap with
+the **elementary, unconditional** rich-line estimate — the baseline that
+Szemerédi–Trotter then improves.
+
+## The statement (fully proved here, 0 axioms, 0 sorries)
+
+For a finite point set `P` (`|P| = n`) and a family `lines` of subsets, *assume
+only the defining property of lines in the plane*: any two distinct lines meet
+in at most one point. Then for every `k`,
+
+> `#{ L : |L| ≥ k } · C(k,2)  ≤  C(n,2)`,  hence  `#{ L : |L| ≥ k } ≤ C(n,2) / C(k,2)`.
+
+This is the classic double-counting bound: each line `L` carries the `C(|L|,2)`
+two-element subsets of its points; because two distinct lines share at most one
+point, **no pair lies on two lines**, so the pair-sets are pairwise disjoint and
+together fit inside the `C(n,2)` pairs of `P`. Summing the lower estimate
+`C(k,2) ≤ C(|L|,2)` over the rich lines gives the bound.
+
+## Honest comparison with Szemerédi–Trotter
+
+The bound here is `#rich-lines = O(n²/k²)`. Szemerédi–Trotter improves the
+exponent on `k` from `2` to `3` (plus an `n/k` term): `O(n²/k³ + n/k)`. The
+improvement is genuinely deep — it is the content of the parent's axioms — but
+the `O(n²/k²)` baseline is completely elementary and is what we machine-check
+here. No incidence theorem, no real-analytic input: just the linear-space
+hypothesis (`hlin`) and counting two-element subsets.
+
+## On assumptions
+
+`hsub` (lines are subsets of the point set) and `hlin` (two distinct lines meet
+in ≤ 1 point) are **hypotheses of the theorems**, not axioms: every statement is
+`∀ P lines, hsub → hlin → …`. There are no `axiom` declarations and no
+assumption-carrying structure fields, so the file is genuinely 0-axiom.
+`hlin` is precisely the abstract "linear space" / "partial linear space"
+property satisfied by honest lines in `ℝ²` (two points determine a unique line),
+so the bound applies verbatim to the geometric setting of `Erdos733Problem`.
+-/
+
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Data.Nat.Choose.Basic
+
+open Finset
+
+namespace Erdos733RichLines
+
+/-!
+## The core double-counting inequality
+
+The sum, over all lines, of the number of point-pairs on each line is at most
+the total number of point-pairs `C(n,2)`. This is the heart of every rich-line
+bound; everything below is a corollary.
+-/
+
+/--
+**Pairs on distinct lines are disjoint.**
+If two lines `L₁ ≠ L₂` meet in at most one point, then no two-element subset of
+points lies on both: the two-element subsets they carry are disjoint families.
+-/
+theorem disjoint_pairs {V : Type*} [DecidableEq V]
+    {L₁ L₂ : Finset V} (h : (L₁ ∩ L₂).card ≤ 1) :
+    Disjoint (L₁.powersetCard 2) (L₂.powersetCard 2) := by
+  rw [Finset.disjoint_left]
+  intro s hs1 hs2
+  rw [Finset.mem_powersetCard] at hs1 hs2
+  have hss : s ⊆ L₁ ∩ L₂ := Finset.subset_inter hs1.1 hs2.1
+  have hle : s.card ≤ (L₁ ∩ L₂).card := Finset.card_le_card hss
+  rw [hs1.2] at hle
+  omega
+
+/--
+**Core bound (double counting of point-pairs).**
+For a finite point set `P` and a family `lines` of subsets, each pair of distinct
+lines meeting in at most one point,
+`∑_{L ∈ lines} C(|L|,2) ≤ C(|P|,2)`.
+-/
+theorem sum_choose_two_le {V : Type*} [DecidableEq V]
+    (P : Finset V) (lines : Finset (Finset V))
+    (hsub : ∀ L ∈ lines, L ⊆ P)
+    (hlin : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) :
+    ∑ L ∈ lines, (L.card).choose 2 ≤ (P.card).choose 2 := by
+  -- Rewrite each `C(|L|,2)` as the cardinality of the two-element subsets of `L`.
+  have hcard : ∀ L ∈ lines, (L.card).choose 2 = (L.powersetCard 2).card := by
+    intro L _
+    rw [Finset.card_powersetCard]
+  rw [Finset.sum_congr rfl hcard]
+  -- The pair-families are pairwise disjoint, so their sizes sum to the size of
+  -- their union.
+  have hdisj : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ →
+      Disjoint (L₁.powersetCard 2) (L₂.powersetCard 2) :=
+    fun L₁ h1 L₂ h2 hne => disjoint_pairs (hlin L₁ h1 L₂ h2 hne)
+  rw [← Finset.card_biUnion hdisj, ← Finset.card_powersetCard 2 P]
+  -- That union is contained in the two-element subsets of `P`.
+  apply Finset.card_le_card
+  intro s hs
+  rw [Finset.mem_biUnion] at hs
+  obtain ⟨L, hL, hsL⟩ := hs
+  rw [Finset.mem_powersetCard] at hsL ⊢
+  exact ⟨hsL.1.trans (hsub L hL), hsL.2⟩
+
+/-!
+## The rich-line bound
+-/
+
+/--
+**Elementary rich-line bound.**
+With `n = |P|`, the number of lines containing at least `k` points satisfies
+`#{ L : |L| ≥ k } · C(k,2) ≤ C(n,2)`.
+This is the unconditional baseline that Szemerédi–Trotter later sharpens.
+-/
+theorem rich_line_bound {V : Type*} [DecidableEq V]
+    (P : Finset V) (lines : Finset (Finset V))
+    (hsub : ∀ L ∈ lines, L ⊆ P)
+    (hlin : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1)
+    (k : ℕ) :
+    (lines.filter (fun L => k ≤ L.card)).card * k.choose 2 ≤ (P.card).choose 2 := by
+  set S := lines.filter (fun L => k ≤ L.card) with hS
+  calc S.card * k.choose 2
+      = ∑ _L ∈ S, k.choose 2 := (Finset.sum_const_nat (fun _ _ => rfl)).symm
+    _ ≤ ∑ L ∈ S, (L.card).choose 2 := by
+        apply Finset.sum_le_sum
+        intro L hL
+        rw [hS, Finset.mem_filter] at hL
+        exact Nat.choose_le_choose 2 hL.2
+    _ ≤ ∑ L ∈ lines, (L.card).choose 2 :=
+        Finset.sum_le_sum_of_subset (Finset.filter_subset _ _)
+    _ ≤ (P.card).choose 2 := sum_choose_two_le P lines hsub hlin
+
+/--
+**Rich-line count (division form).**
+For `k ≥ 2`, the number of `k`-rich lines is at most `C(n,2) / C(k,2)` (with
+`n = |P|`), the familiar `O(n²/k²)` estimate.
+-/
+theorem rich_line_count_le {V : Type*} [DecidableEq V]
+    (P : Finset V) (lines : Finset (Finset V))
+    (hsub : ∀ L ∈ lines, L ⊆ P)
+    (hlin : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1)
+    (k : ℕ) (hk : 2 ≤ k) :
+    (lines.filter (fun L => k ≤ L.card)).card ≤ (P.card).choose 2 / k.choose 2 := by
+  have hpos : 0 < k.choose 2 := Nat.choose_pos hk
+  rw [Nat.le_div_iff_mul_le hpos]
+  exact rich_line_bound P lines hsub hlin k
+
+/--
+**Number of proper lines.**
+A line with at least two points is "proper". Taking `k = 2` (so `C(2,2) = 1`),
+the number of proper lines is at most `C(n,2)` — each is charged to a distinct
+point-pair. (This is the easy direction of de Bruijn–Erdős-type counting.)
+-/
+theorem num_proper_lines_le {V : Type*} [DecidableEq V]
+    (P : Finset V) (lines : Finset (Finset V))
+    (hsub : ∀ L ∈ lines, L ⊆ P)
+    (hlin : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) :
+    (lines.filter (fun L => 2 ≤ L.card)).card ≤ (P.card).choose 2 := by
+  have h := rich_line_bound P lines hsub hlin 2
+  simpa using h
+
+/--
+**Monotonicity in `k`.**
+Fewer lines are `k'`-rich than `k`-rich when `k ≤ k'`; combined with
+`rich_line_bound` this lets a single pair budget control every threshold.
+-/
+theorem rich_lines_antitone {V : Type*} [DecidableEq V]
+    (lines : Finset (Finset V)) {k k' : ℕ} (hk : k ≤ k') :
+    (lines.filter (fun L => k' ≤ L.card)).card
+      ≤ (lines.filter (fun L => k ≤ L.card)).card := by
+  apply Finset.card_le_card
+  intro L hL
+  rw [Finset.mem_filter] at hL ⊢
+  exact ⟨hL.1, le_trans hk hL.2⟩
+
+end Erdos733RichLines

--- a/src/data/proofs/erdos-733-oq-02/annotations.json
+++ b/src/data/proofs/erdos-733-oq-02/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "e733rl-ann-01",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 73, "endLine": 82 },
+    "type": "concept",
+    "title": "Disjoint pairs: where linearity enters",
+    "content": "`disjoint_pairs` is the only place the geometry is used. Each line `L` carries the family `L.powersetCard 2` of its two-element point-subsets. If a two-element set `s` belonged to both `L₁.powersetCard 2` and `L₂.powersetCard 2`, then `s ⊆ L₁ ∩ L₂` with `|s| = 2`, forcing `|L₁ ∩ L₂| ≥ 2`. But the linear-space hypothesis says two distinct lines meet in at most one point, so the families are disjoint. No point-pair lies on two lines — this is exactly the fact that makes the counting work.",
+    "mathContext": "$s \\subseteq L_1 \\cap L_2,\\ |s| = 2 \\Rightarrow |L_1 \\cap L_2| \\ge 2$, contradicting $|L_1 \\cap L_2| \\le 1$."
+  },
+  {
+    "id": "e733rl-ann-02",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 90, "endLine": 112 },
+    "type": "technique",
+    "title": "Double counting via a disjoint biUnion",
+    "content": "`sum_choose_two_le` is the engine. Rewriting `C(|L|,2)` as `(L.powersetCard 2).card` (Finset.card_powersetCard) turns the sum over lines into a sum of cardinalities of pairwise-disjoint finsets. `Finset.card_biUnion` (using the disjointness from `disjoint_pairs`) collapses that sum into the cardinality of their union, and the union sits inside `P.powersetCard 2` because every line is a subset of `P`. Hence `∑_L C(|L|,2) ≤ C(n,2)`. This single inequality powers every rich-line bound below.",
+    "mathContext": "$\\sum_{L} \\binom{|L|}{2} = \\Big|\\bigsqcup_L \\binom{L}{2}\\Big| \\le \\Big|\\binom{P}{2}\\Big| = \\binom{n}{2}.$"
+  },
+  {
+    "id": "e733rl-ann-03",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 124, "endLine": 140 },
+    "type": "concept",
+    "title": "Charging rich lines to point-pairs",
+    "content": "`rich_line_bound` is the headline. Over the k-rich lines, the constant estimate `C(k,2) ≤ C(|L|,2)` (Nat.choose_le_choose, since `k ≤ |L|`) sums to `#{k-rich lines} · C(k,2) ≤ ∑_L C(|L|,2) ≤ C(n,2)`. Read combinatorially: every k-rich line is charged the `C(k,2)` pairs it must contain, no pair is charged twice (disjointness), and there are only `C(n,2)` pairs to spend. The count of k-rich lines is therefore at most `C(n,2)/C(k,2) = O(n²/k²)`.",
+    "mathContext": "$\\#\\{L : |L| \\ge k\\}\\cdot \\binom{k}{2} \\le \\sum_L \\binom{|L|}{2} \\le \\binom{n}{2}.$"
+  },
+  {
+    "id": "e733rl-ann-04",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 157, "endLine": 169 },
+    "type": "result",
+    "title": "k = 2: bounding the number of proper lines",
+    "content": "`num_proper_lines_le` specializes `rich_line_bound` at `k = 2`. Since `C(2,2) = 1`, the bound becomes `#{lines with ≥ 2 points} ≤ C(n,2)`: each proper line is charged to a distinct point-pair. This is the easy direction of de Bruijn–Erdős-style counting and shows that a linear space on n points has at most quadratically many lines.",
+    "mathContext": "$\\binom{2}{2} = 1 \\Rightarrow \\#\\{L : |L| \\ge 2\\} \\le \\binom{n}{2}.$"
+  },
+  {
+    "id": "e733rl-ann-05",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 40, "endLine": 56 },
+    "type": "caveat",
+    "title": "Honest scope: weaker than Szemerédi–Trotter, but unconditional and 0-axiom",
+    "content": "The bound here is `O(n²/k²)`; Szemerédi–Trotter improves the exponent on k from 2 to 3 (plus an `n/k` term): `O(n²/k³ + n/k)`. That improvement is the genuinely deep content the parent Erdős #733 file axiomatizes, and this entry does NOT discharge those axioms. What it does deliver is the elementary baseline, fully machine-checked with no incidence theorem. The linear-space conditions `hsub` and `hlin` are ordinary hypotheses, not structure-encoded axioms, so the file is genuinely 0-axiom under the project's axiom-integrity policy.",
+    "mathContext": "Elementary: $O(n^2/k^2)$. Szemerédi–Trotter: $O(n^2/k^3 + n/k)$."
+  }
+]

--- a/src/data/proofs/erdos-733-oq-02/meta.json
+++ b/src/data/proofs/erdos-733-oq-02/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "erdos-733-oq-02",
+  "title": "The Elementary Rich-Line Bound (Erdős #733)",
+  "slug": "erdos-733-oq-02",
+  "description": "Fills the unproved 'Part III' claim of the Erdős #733 formalization: that the number of k-rich lines (lines through at least k of n points) is bounded. The registered file states the Szemerédi–Trotter corollary O(n²/k³ + n/k) only as a docstring, with no proof. This entry proves the elementary, unconditional baseline #{lines with ≥ k points} · C(k,2) ≤ C(n,2), hence #{k-rich lines} ≤ C(n,2)/C(k,2) = O(n²/k²), by pure double counting of point-pairs: each line carries the C(|L|,2) two-element subsets of its points, distinct lines share at most one point so these pair-families are disjoint, and there are only C(n,2) pairs in all. The single hypothesis is the defining 'linear space' property of lines (two distinct lines meet in ≤ 1 point); no incidence theorem and no real-analytic input is used. Self-contained, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Erdős (problem); classical double-counting bound — formalized in Lean 4",
+    "sourceUrl": "https://www.erdosproblems.com/733",
+    "date": "1983",
+    "status": "verified",
+    "tags": [
+      "combinatorial-geometry",
+      "incidences",
+      "double-counting",
+      "extremal-combinatorics",
+      "szemeredi-trotter",
+      "erdos",
+      "rich-lines"
+    ],
+    "proofRepoPath": "Proofs/Erdos733RichLines.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "Finset.powersetCard",
+      "Finset.card_powersetCard",
+      "Finset.card_biUnion",
+      "Finset.card_le_card",
+      "Finset.sum_le_sum",
+      "Finset.sum_le_sum_of_subset",
+      "Finset.sum_const_nat",
+      "Nat.choose_le_choose",
+      "Nat.choose_pos",
+      "Nat.le_div_iff_mul_le"
+    ],
+    "originalContributions": [
+      "Machine-checked proof of the elementary rich-line bound #{lines with ≥ k points} · C(k,2) ≤ C(n,2), the unconditional baseline that Szemerédi–Trotter later sharpens — the registered Erdős #733 file states the corresponding corollary only as an unproved docstring",
+      "A clean double-counting argument: distinct lines (sharing ≤ 1 point) carry pairwise-disjoint families of two-element point-subsets, all contained in the C(n,2) pairs of the point set (sum_choose_two_le, disjoint_pairs)",
+      "Division form #{k-rich lines} ≤ C(n,2)/C(k,2) = O(n²/k²) and the de Bruijn–Erdős-style corollary #{proper lines} ≤ C(n,2) (rich_line_count_le, num_proper_lines_le)",
+      "Stated with the linear-space property as an explicit hypothesis rather than a structure-encoded axiom, so the result is genuinely 0-axiom and applies verbatim to honest lines in ℝ²"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 185,
+    "assumptions": "None encoded as axioms or structure fields. Every theorem takes the configuration data (point set P, family of lines) and the linear-space hypotheses hsub (each line ⊆ P) and hlin (two distinct lines meet in ≤ 1 point) as ordinary universally-quantified arguments. #print axioms reports only the standard foundational axioms (propext / Classical.choice / Quot.sound); no sorryAx, no Lean.ofReduceBool. The bound proved is the elementary O(n²/k²) estimate, strictly weaker than the Szemerédi–Trotter O(n²/k³ + n/k) that the parent file axiomatizes — this is disclosed explicitly in the file and is not claimed to discharge those axioms.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #733 asks for the number f(n) of 'line-compatible' multiplicity sequences realizable by n points in the plane; the answer f(n) = exp(Θ(√n)) was completed by Szemerédi and Trotter in 1983, whose incidence theorem controls how many lines can be rich (pass through many points). The registered formalization Erdos733Problem.lean encodes the two sharp bounds as axioms and, in its 'Part III', states the Szemerédi–Trotter corollary on rich lines — 'the number of k-rich lines is O(n²/k³ + n/k)' — purely as a docstring, proving nothing about it. Yet a weaker rich-line bound predates Szemerédi–Trotter by decades and is completely elementary: it follows from the single fact that two distinct lines meet in at most one point. This entry formalizes that elementary baseline.",
+    "problemStatement": "Let P be a finite set of n points and let `lines` be a family of subsets of P such that any two distinct lines meet in at most one point (the linear-space property of honest lines in ℝ²). Prove that for every threshold k, the number of lines containing at least k points satisfies #{L : |L| ≥ k} · C(k,2) ≤ C(n,2), and therefore #{L : |L| ≥ k} ≤ C(n,2)/C(k,2).",
+    "text": "The file is built around one double-counting identity. For a line L, its C(|L|,2) two-element subsets are the point-pairs it covers; in Lean these are L.powersetCard 2, whose cardinality is |L| choose 2 (Finset.card_powersetCard). The geometric content lives in disjoint_pairs: if two lines meet in at most one point, no pair of points lies on both, so their pair-families are disjoint. The core bound sum_choose_two_le then rewrites each C(|L|,2) as a cardinality, uses Finset.card_biUnion over the disjoint families, and bounds the union by the pairs of P to get ∑_{L} C(|L|,2) ≤ C(n,2). The headline rich_line_bound sums the trivial estimate C(k,2) ≤ C(|L|,2) over the k-rich lines (Nat.choose_le_choose) to obtain #{k-rich lines} · C(k,2) ≤ C(n,2). Two corollaries follow: rich_line_count_le divides through (Nat.le_div_iff_mul_le) to the familiar O(n²/k²) form, and num_proper_lines_le specializes to k = 2 (C(2,2) = 1) to bound the number of lines with at least two points by C(n,2). A monotonicity lemma rich_lines_antitone records that raising the threshold can only shrink the rich-line count.",
+    "proofStrategy": "Charge each k-rich line to the C(k,2) point-pairs it contains. Because distinct lines share at most one point, no point-pair is charged twice, so the total charge #{k-rich lines} · C(k,2) cannot exceed the C(n,2) available pairs. Formally this is a disjoint biUnion of two-element subsets sitting inside the two-element subsets of P; everything else is monotonicity of binomial coefficients and a Nat division step.",
+    "keyInsights": [
+      "The whole bound rests on one geometric fact — two distinct lines meet in at most one point — entered as the explicit hypothesis hlin, not as an incidence theorem. This is what makes it elementary and unconditional.",
+      "Counting point-pairs is the right currency: a k-rich line is worth C(k,2) pairs, and the budget of pairs is exactly C(n,2), so the rich lines are bounded by a clean ratio.",
+      "Disjointness of the pair-families (disjoint_pairs) is where linearity is used: a shared pair would force two lines to meet in two points, contradicting hlin.",
+      "The result is honestly weaker than Szemerédi–Trotter — O(n²/k²) versus O(n²/k³ + n/k) — and the file says so. It is the baseline the deep theorem improves, and it is the part that can be fully machine-checked with no axioms.",
+      "Stating the linear-space property as a hypothesis rather than a structure field keeps the entry genuinely 0-axiom under the project's axiom-integrity policy, while still applying verbatim to the geometric setting of the parent #733 file."
+    ],
+    "prerequisites": [
+      "Binomial coefficients and the identity that an m-set has C(m,2) two-element subsets",
+      "Double counting / the handshake principle in extremal combinatorics",
+      "Linear spaces (partial linear spaces): families of lines pairwise meeting in at most one point",
+      "Finset.powersetCard and disjoint biUnion cardinality in Lean/Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "core-double-counting",
+      "title": "The core double-counting inequality",
+      "startLine": 60,
+      "endLine": 112,
+      "summary": "disjoint_pairs shows that two lines meeting in ≤ 1 point carry disjoint families of two-element point-subsets. sum_choose_two_le then sums their sizes via a disjoint biUnion and bounds the result by the two-element subsets of P, giving ∑_{L} C(|L|,2) ≤ C(n,2).",
+      "mathContext": "Each line covers $\\binom{|L|}{2}$ point-pairs; distinct lines share at most one point, so the pair-families are disjoint and $\\sum_L \\binom{|L|}{2} \\le \\binom{n}{2}$."
+    },
+    {
+      "id": "rich-line-bound",
+      "title": "The rich-line bound",
+      "startLine": 114,
+      "endLine": 155,
+      "summary": "rich_line_bound charges each k-rich line C(k,2) pairs and sums: #{L : |L| ≥ k} · C(k,2) ≤ C(n,2). rich_line_count_le divides through to #{k-rich lines} ≤ C(n,2)/C(k,2), the O(n²/k²) estimate.",
+      "mathContext": "$\\#\\{L : |L| \\ge k\\}\\cdot \\binom{k}{2} \\le \\binom{n}{2}$, hence $\\#\\{L : |L| \\ge k\\} \\le \\binom{n}{2}/\\binom{k}{2} = O(n^2/k^2)$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Proper lines and monotonicity",
+      "startLine": 157,
+      "endLine": 185,
+      "summary": "num_proper_lines_le specializes to k = 2 (C(2,2) = 1): the number of lines with at least two points is at most C(n,2), the easy de Bruijn–Erdős direction. rich_lines_antitone records that raising the threshold only shrinks the rich-line count.",
+      "mathContext": "$k=2$: $\\#\\{L : |L| \\ge 2\\} \\le \\binom{n}{2}$. Monotonicity: $k \\le k' \\Rightarrow \\#\\{|L| \\ge k'\\} \\le \\#\\{|L| \\ge k\\}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-733",
+      "relationship": "extends",
+      "description": "The parent entry formalizes the count of line-compatible sequences and axiomatizes the sharp Szemerédi–Trotter bounds. Its Part III states the rich-line corollary O(n²/k³ + n/k) only as an unproved docstring; this entry supplies the elementary unconditional baseline #{k-rich lines} = O(n²/k²), fully machine-checked."
+    },
+    {
+      "targetId": "erdos-733-oq-01",
+      "relationship": "related",
+      "description": "OQ-01 addresses the limit constant λ = lim log f(n)/√n of the parent's count; this entry instead proves the elementary combinatorial estimate underlying the rich-line side of the Szemerédi–Trotter machinery."
+    }
+  ],
+  "conclusion": {
+    "summary": "The number of k-rich lines in an n-point configuration is at most C(n,2)/C(k,2) = O(n²/k²), proved by charging each rich line the C(k,2) point-pairs it covers and noting that distinct lines share at most one point, so no pair is double-charged against the C(n,2) available pairs. This fills the unproved Part III claim of the Erdős #733 formalization with a fully verified, 0-axiom statement.",
+    "implications": "The bound is the elementary baseline that Szemerédi–Trotter improves (to O(n²/k³ + n/k)), and it requires nothing beyond the linear-space property of lines. It pins down precisely how much of the rich-line corollary used in #733 is elementary double counting versus genuinely deep incidence geometry, and provides reusable Lean infrastructure (disjoint pair-families, the ∑ C(|L|,2) ≤ C(n,2) inequality) for further incidence-combinatorics formalization."
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Finset.Card",
+      "Mathlib.Data.Finset.Powerset",
+      "Mathlib.Algebra.Order.BigOperators.Group.Finset",
+      "Mathlib.Data.Nat.Choose.Basic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos733RichLines",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos733RichLines.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Szemerédi, Endre; Trotter, William T.",
+      "title": "Extremal problems in discrete geometry",
+      "year": "1983",
+      "venue": "Combinatorica 3, 381–392",
+      "note": "The sharp incidence theorem behind Erdős #733; its rich-line corollary O(n²/k³ + n/k) improves the elementary O(n²/k²) bound proved here."
+    },
+    {
+      "authors": "de Bruijn, Nicolaas G.; Erdős, Paul",
+      "title": "On a combinatorial problem",
+      "year": "1948",
+      "venue": "Indagationes Mathematicae 10, 421–423",
+      "note": "Classical linear-space counting; the k = 2 corollary here (#proper lines ≤ C(n,2)) is the easy direction of this circle of ideas."
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "Problem #733",
+      "year": "n.d.",
+      "venue": "erdosproblems.com",
+      "note": "Counting line-compatible multiplicity sequences; answer exp(Θ(√n)) via Szemerédi–Trotter."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "rich_line_bound",
+      "type": "core",
+      "description": "Elementary rich-line bound: with n = |P|, the number of lines containing at least k points satisfies #{L : |L| ≥ k} · C(k,2) ≤ C(n,2). The unconditional baseline Szemerédi–Trotter later sharpens.",
+      "leanType": "∀ {V} [DecidableEq V] (P : Finset V) (lines : Finset (Finset V)), (∀ L ∈ lines, L ⊆ P) → (∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) → ∀ k, (lines.filter (fun L => k ≤ L.card)).card * k.choose 2 ≤ (P.card).choose 2"
+    },
+    {
+      "name": "sum_choose_two_le",
+      "type": "core",
+      "description": "Core double-counting inequality: the total number of point-pairs covered by all lines is at most the C(n,2) pairs of the point set. Drives every rich-line bound.",
+      "leanType": "∀ {V} [DecidableEq V] (P : Finset V) (lines : Finset (Finset V)), (∀ L ∈ lines, L ⊆ P) → (∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) → ∑ L ∈ lines, (L.card).choose 2 ≤ (P.card).choose 2"
+    },
+    {
+      "name": "rich_line_count_le",
+      "type": "corollary",
+      "description": "Division form: for k ≥ 2 the number of k-rich lines is at most C(n,2)/C(k,2), the familiar O(n²/k²) estimate.",
+      "leanType": "∀ {V} [DecidableEq V] (P : Finset V) (lines : Finset (Finset V)), (∀ L ∈ lines, L ⊆ P) → (∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) → ∀ k, 2 ≤ k → (lines.filter (fun L => k ≤ L.card)).card ≤ (P.card).choose 2 / k.choose 2"
+    },
+    {
+      "name": "num_proper_lines_le",
+      "type": "corollary",
+      "description": "k = 2 specialization: the number of lines through at least two points is at most C(n,2) — each is charged to a distinct point-pair (de Bruijn–Erdős easy direction).",
+      "leanType": "∀ {V} [DecidableEq V] (P : Finset V) (lines : Finset (Finset V)), (∀ L ∈ lines, L ⊆ P) → (∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) → (lines.filter (fun L => 2 ≤ L.card)).card ≤ (P.card).choose 2"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up to **Erdős Problem #733** (line-compatible sequences, `exp(Θ(√n))` by Szemerédi–Trotter). The registered `Erdos733Problem.lean` axiomatizes the sharp bounds and states its **Part III** rich-line corollary — *"the number of k-rich lines is O(n²/k³ + n/k)"* — only as an **unproved docstring**. This PR fills that gap with the elementary, unconditional baseline, fully machine-checked.

### Main result
For a finite point set `P` (`|P| = n`) and a family `lines` of subsets where any two distinct lines meet in **at most one point** (the linear-space property of honest lines in ℝ²):

```
#{ L : |L| ≥ k } · C(k,2)  ≤  C(n,2)      -- rich_line_bound
#{ L : |L| ≥ k }           ≤  C(n,2)/C(k,2) = O(n²/k²)   -- rich_line_count_le
```

### Proof (pure double counting)
Each line `L` carries the `C(|L|,2)` two-element subsets of its points. Distinct lines share ≤ 1 point ⟹ **no point-pair lies on two lines**, so these pair-families are pairwise disjoint and together fit inside the `C(n,2)` pairs of `P` (`sum_choose_two_le`). Charging each k-rich line its `C(k,2)` pairs gives the bound. No incidence theorem, no real-analytic input.

### Contents (6 theorems, 185 lines)
- `disjoint_pairs` — pair-families of distinct lines are disjoint (where linearity is used)
- `sum_choose_two_le` — core: `∑_L C(|L|,2) ≤ C(n,2)`
- `rich_line_bound` — headline
- `rich_line_count_le` — division form `O(n²/k²)`
- `num_proper_lines_le` — `k=2`: `#proper lines ≤ C(n,2)` (de Bruijn–Erdős easy direction)
- `rich_lines_antitone` — monotonicity in the threshold

### Honesty / axiom integrity
- **Weaker than Szemerédi–Trotter** (`O(n²/k²)` vs `O(n²/k³ + n/k)`) — disclosed in-file; does **not** discharge the parent's axioms.
- The linear-space conditions are **ordinary universally-quantified hypotheses**, not structure-encoded axioms.
- `#print axioms` → only standard foundational axioms; **0 `axiom` declarations, 0 `sorry`, no `native_decide`**. Genuinely `verified` / 0-axiom.

### Build
`./proofs/scripts/docker-build.sh Proofs.Erdos733RichLines` ✓ (Mathlib v4.26.0, 730 jobs, 0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)