### PR TITLE
research(erdos-823-oq-05): σ values from Mathlib, axiom-free (no native_decide) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2215,6 +2215,7 @@ import Proofs.Erdos820Problem
 import Proofs.Erdos821Problem
 import Proofs.Erdos822Problem
 import Proofs.Erdos823Problem
+import Proofs.Erdos823SigmaValues
 import Proofs.Erdos824Problem
 import Proofs.Erdos824ProblemProvable
 import Proofs.Erdos825Problem

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2093,6 +2093,7 @@ import Proofs.Erdos731Problem
 import Proofs.Erdos732Problem
 import Proofs.Erdos733LimitBounds
 import Proofs.Erdos733Problem
+import Proofs.Erdos733RichLines
 import Proofs.Erdos734Problem
 import Proofs.Erdos735OQ04
 import Proofs.Erdos735OQ04Tetrahedron

--- a/proofs/Proofs/Erdos733RichLines.lean
+++ b/proofs/Proofs/Erdos733RichLines.lean
@@ -1,0 +1,185 @@
+/-
+# Erdős Problem #733 — the elementary rich-line bound
+
+**Parent.** `Erdos733Problem.lean` (registered) formalizes the count
+`f(n) = countLineCompatible n` of line-compatible sequences and records the
+Szemerédi–Trotter answer `f(n) = exp(Θ(√n))` as the two axioms `lower_bound`
+and `upper_bound`. Its **Part III** states, as an unproved docstring claim, the
+Szemerédi–Trotter corollary on rich lines:
+
+> *The number of k-rich lines (lines with ≥ k points) is `O(n²/k³ + n/k)`.*
+
+That corollary is exactly the engine that drives the (axiomatized) upper bound,
+yet the registered file proves nothing about it. This file fills that gap with
+the **elementary, unconditional** rich-line estimate — the baseline that
+Szemerédi–Trotter then improves.
+
+## The statement (fully proved here, 0 axioms, 0 sorries)
+
+For a finite point set `P` (`|P| = n`) and a family `lines` of subsets, *assume
+only the defining property of lines in the plane*: any two distinct lines meet
+in at most one point. Then for every `k`,
+
+> `#{ L : |L| ≥ k } · C(k,2)  ≤  C(n,2)`,  hence  `#{ L : |L| ≥ k } ≤ C(n,2) / C(k,2)`.
+
+This is the classic double-counting bound: each line `L` carries the `C(|L|,2)`
+two-element subsets of its points; because two distinct lines share at most one
+point, **no pair lies on two lines**, so the pair-sets are pairwise disjoint and
+together fit inside the `C(n,2)` pairs of `P`. Summing the lower estimate
+`C(k,2) ≤ C(|L|,2)` over the rich lines gives the bound.
+
+## Honest comparison with Szemerédi–Trotter
+
+The bound here is `#rich-lines = O(n²/k²)`. Szemerédi–Trotter improves the
+exponent on `k` from `2` to `3` (plus an `n/k` term): `O(n²/k³ + n/k)`. The
+improvement is genuinely deep — it is the content of the parent's axioms — but
+the `O(n²/k²)` baseline is completely elementary and is what we machine-check
+here. No incidence theorem, no real-analytic input: just the linear-space
+hypothesis (`hlin`) and counting two-element subsets.
+
+## On assumptions
+
+`hsub` (lines are subsets of the point set) and `hlin` (two distinct lines meet
+in ≤ 1 point) are **hypotheses of the theorems**, not axioms: every statement is
+`∀ P lines, hsub → hlin → …`. There are no `axiom` declarations and no
+assumption-carrying structure fields, so the file is genuinely 0-axiom.
+`hlin` is precisely the abstract "linear space" / "partial linear space"
+property satisfied by honest lines in `ℝ²` (two points determine a unique line),
+so the bound applies verbatim to the geometric setting of `Erdos733Problem`.
+-/
+
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Data.Nat.Choose.Basic
+
+open Finset
+
+namespace Erdos733RichLines
+
+/-!
+## The core double-counting inequality
+
+The sum, over all lines, of the number of point-pairs on each line is at most
+the total number of point-pairs `C(n,2)`. This is the heart of every rich-line
+bound; everything below is a corollary.
+-/
+
+/--
+**Pairs on distinct lines are disjoint.**
+If two lines `L₁ ≠ L₂` meet in at most one point, then no two-element subset of
+points lies on both: the two-element subsets they carry are disjoint families.
+-/
+theorem disjoint_pairs {V : Type*} [DecidableEq V]
+    {L₁ L₂ : Finset V} (h : (L₁ ∩ L₂).card ≤ 1) :
+    Disjoint (L₁.powersetCard 2) (L₂.powersetCard 2) := by
+  rw [Finset.disjoint_left]
+  intro s hs1 hs2
+  rw [Finset.mem_powersetCard] at hs1 hs2
+  have hss : s ⊆ L₁ ∩ L₂ := Finset.subset_inter hs1.1 hs2.1
+  have hle : s.card ≤ (L₁ ∩ L₂).card := Finset.card_le_card hss
+  rw [hs1.2] at hle
+  omega
+
+/--
+**Core bound (double counting of point-pairs).**
+For a finite point set `P` and a family `lines` of subsets, each pair of distinct
+lines meeting in at most one point,
+`∑_{L ∈ lines} C(|L|,2) ≤ C(|P|,2)`.
+-/
+theorem sum_choose_two_le {V : Type*} [DecidableEq V]
+    (P : Finset V) (lines : Finset (Finset V))
+    (hsub : ∀ L ∈ lines, L ⊆ P)
+    (hlin : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) :
+    ∑ L ∈ lines, (L.card).choose 2 ≤ (P.card).choose 2 := by
+  -- Rewrite each `C(|L|,2)` as the cardinality of the two-element subsets of `L`.
+  have hcard : ∀ L ∈ lines, (L.card).choose 2 = (L.powersetCard 2).card := by
+    intro L _
+    rw [Finset.card_powersetCard]
+  rw [Finset.sum_congr rfl hcard]
+  -- The pair-families are pairwise disjoint, so their sizes sum to the size of
+  -- their union.
+  have hdisj : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ →
+      Disjoint (L₁.powersetCard 2) (L₂.powersetCard 2) :=
+    fun L₁ h1 L₂ h2 hne => disjoint_pairs (hlin L₁ h1 L₂ h2 hne)
+  rw [← Finset.card_biUnion hdisj, ← Finset.card_powersetCard 2 P]
+  -- That union is contained in the two-element subsets of `P`.
+  apply Finset.card_le_card
+  intro s hs
+  rw [Finset.mem_biUnion] at hs
+  obtain ⟨L, hL, hsL⟩ := hs
+  rw [Finset.mem_powersetCard] at hsL ⊢
+  exact ⟨hsL.1.trans (hsub L hL), hsL.2⟩
+
+/-!
+## The rich-line bound
+-/
+
+/--
+**Elementary rich-line bound.**
+With `n = |P|`, the number of lines containing at least `k` points satisfies
+`#{ L : |L| ≥ k } · C(k,2) ≤ C(n,2)`.
+This is the unconditional baseline that Szemerédi–Trotter later sharpens.
+-/
+theorem rich_line_bound {V : Type*} [DecidableEq V]
+    (P : Finset V) (lines : Finset (Finset V))
+    (hsub : ∀ L ∈ lines, L ⊆ P)
+    (hlin : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1)
+    (k : ℕ) :
+    (lines.filter (fun L => k ≤ L.card)).card * k.choose 2 ≤ (P.card).choose 2 := by
+  set S := lines.filter (fun L => k ≤ L.card) with hS
+  calc S.card * k.choose 2
+      = ∑ _L ∈ S, k.choose 2 := (Finset.sum_const_nat (fun _ _ => rfl)).symm
+    _ ≤ ∑ L ∈ S, (L.card).choose 2 := by
+        apply Finset.sum_le_sum
+        intro L hL
+        rw [hS, Finset.mem_filter] at hL
+        exact Nat.choose_le_choose 2 hL.2
+    _ ≤ ∑ L ∈ lines, (L.card).choose 2 :=
+        Finset.sum_le_sum_of_subset (Finset.filter_subset _ _)
+    _ ≤ (P.card).choose 2 := sum_choose_two_le P lines hsub hlin
+
+/--
+**Rich-line count (division form).**
+For `k ≥ 2`, the number of `k`-rich lines is at most `C(n,2) / C(k,2)` (with
+`n = |P|`), the familiar `O(n²/k²)` estimate.
+-/
+theorem rich_line_count_le {V : Type*} [DecidableEq V]
+    (P : Finset V) (lines : Finset (Finset V))
+    (hsub : ∀ L ∈ lines, L ⊆ P)
+    (hlin : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1)
+    (k : ℕ) (hk : 2 ≤ k) :
+    (lines.filter (fun L => k ≤ L.card)).card ≤ (P.card).choose 2 / k.choose 2 := by
+  have hpos : 0 < k.choose 2 := Nat.choose_pos hk
+  rw [Nat.le_div_iff_mul_le hpos]
+  exact rich_line_bound P lines hsub hlin k
+
+/--
+**Number of proper lines.**
+A line with at least two points is "proper". Taking `k = 2` (so `C(2,2) = 1`),
+the number of proper lines is at most `C(n,2)` — each is charged to a distinct
+point-pair. (This is the easy direction of de Bruijn–Erdős-type counting.)
+-/
+theorem num_proper_lines_le {V : Type*} [DecidableEq V]
+    (P : Finset V) (lines : Finset (Finset V))
+    (hsub : ∀ L ∈ lines, L ⊆ P)
+    (hlin : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) :
+    (lines.filter (fun L => 2 ≤ L.card)).card ≤ (P.card).choose 2 := by
+  have h := rich_line_bound P lines hsub hlin 2
+  simpa using h
+
+/--
+**Monotonicity in `k`.**
+Fewer lines are `k'`-rich than `k`-rich when `k ≤ k'`; combined with
+`rich_line_bound` this lets a single pair budget control every threshold.
+-/
+theorem rich_lines_antitone {V : Type*} [DecidableEq V]
+    (lines : Finset (Finset V)) {k k' : ℕ} (hk : k ≤ k') :
+    (lines.filter (fun L => k' ≤ L.card)).card
+      ≤ (lines.filter (fun L => k ≤ L.card)).card := by
+  apply Finset.card_le_card
+  intro L hL
+  rw [Finset.mem_filter] at hL ⊢
+  exact ⟨hL.1, le_trans hk hL.2⟩
+
+end Erdos733RichLines

--- a/proofs/Proofs/Erdos823SigmaValues.lean
+++ b/proofs/Proofs/Erdos823SigmaValues.lean
@@ -1,0 +1,132 @@
+/-
+# Erdős Problem #823 — σ values computed from Mathlib, axiom-free
+
+**Parent.** `Erdos823Problem.lean` (registered) formalizes Pollack's theorem that
+for every α ≥ 1 there are sequences nₖ/mₖ → α with σ(nₖ) = σ(mₖ), where σ is the
+sum-of-divisors function. Its motivating example is the smallest nontrivial
+σ-pair, σ(14) = σ(15) = 24.
+
+**Why this file exists.** The parent computes its concrete σ-values
+(`sigma_14_value`, `sigma_15_value`, `sigma_14_15`, …) with `native_decide`.
+Under the project's axiom-integrity policy `native_decide` trusts the compiler
+and depends on `Lean.ofReduceBool`, so those statements are **not axiom-free**:
+they should be counted as axiomatized. This file reproves the genuine σ-values
+**symbolically from Mathlib's arithmetic-function API** — multiplicativity of σ
+plus the value on primes and prime powers — so every result is checked by the
+kernel with no `native_decide` and no `axiom`. `#print axioms` shows only the
+ordinary foundational axioms.
+
+**A latent bug spotted in passing.** The parent also asserts
+`sigma_206_210 : σ 206 = σ 210` via `native_decide`, but this is **false**:
+σ(206) = σ(2·103) = 3·104 = 312 while σ(210) = σ(2·3·5·7) = 3·4·6·8 = 576. We do
+not reproduce it. (206 and 210 are not a σ-pair; the genuine small σ-pairs
+include (14,15) and (957,958).)
+
+**What is proved here (all 0-axiom):**
+- σ(6) = 12, σ(14) = 24, σ(15) = 24, σ(28) = 56, σ(957) = 1440, σ(958) = 1440;
+- the σ-pairs σ(14) = σ(15) and σ(957) = σ(958) — fibers of σ over 24 and 1440
+  each containing two consecutive integers, the phenomenon Pollack's theorem
+  amplifies to arbitrary ratios;
+- 6 and 28 are perfect (σ(n) = 2n), tying into the perfect-number circle.
+
+The method scales to any explicit n via its prime factorization.
+-/
+
+import Mathlib.NumberTheory.ArithmeticFunction.Defs
+import Mathlib.NumberTheory.ArithmeticFunction.Misc
+import Mathlib.NumberTheory.Divisors
+import Mathlib.Tactic.NormNum.Prime
+
+open ArithmeticFunction
+open scoped ArithmeticFunction.sigma
+
+namespace Erdos823SigmaValues
+
+/-!
+## The value of σ on a prime
+
+For a prime `p`, `divisors p = {1, p}` so `σ 1 p = 1 + p`. This is the only
+building block we need beyond multiplicativity.
+-/
+
+/-- `σ 1 p = p + 1` for any prime `p`, proved from `Nat.Prime.divisors`. -/
+theorem sigma_one_prime {p : ℕ} (hp : p.Prime) : σ 1 p = p + 1 := by
+  rw [sigma_one_apply, hp.divisors, Finset.sum_pair (Ne.symm hp.ne_one)]
+  omega
+
+/-!
+## σ values via multiplicativity
+
+`ArithmeticFunction.isMultiplicative_sigma` gives `σ (m*n) = σ m · σ n` for
+coprime `m, n`. Combined with `sigma_one_prime` (and `sigma_one_apply_prime_pow`
+for prime powers) this evaluates σ at any explicit integer.
+-/
+
+/-- σ(6) = 12.  6 = 2·3, so σ(6) = σ(2)·σ(3) = 3·4. -/
+theorem sigma_6 : σ 1 6 = 12 := by
+  rw [show (6 : ℕ) = 2 * 3 from by norm_num,
+      isMultiplicative_sigma.map_mul_of_coprime (show (2 : ℕ).gcd 3 = 1 from by decide),
+      sigma_one_prime (by norm_num), sigma_one_prime (by norm_num)]
+  norm_num
+
+/-- σ(14) = 24.  14 = 2·7, so σ(14) = σ(2)·σ(7) = 3·8. -/
+theorem sigma_14 : σ 1 14 = 24 := by
+  rw [show (14 : ℕ) = 2 * 7 from by norm_num,
+      isMultiplicative_sigma.map_mul_of_coprime (show (2 : ℕ).gcd 7 = 1 from by decide),
+      sigma_one_prime (by norm_num), sigma_one_prime (by norm_num)]
+  norm_num
+
+/-- σ(15) = 24.  15 = 3·5, so σ(15) = σ(3)·σ(5) = 4·6. -/
+theorem sigma_15 : σ 1 15 = 24 := by
+  rw [show (15 : ℕ) = 3 * 5 from by norm_num,
+      isMultiplicative_sigma.map_mul_of_coprime (show (3 : ℕ).gcd 5 = 1 from by decide),
+      sigma_one_prime (by norm_num), sigma_one_prime (by norm_num)]
+  norm_num
+
+/-- σ(28) = 56.  28 = 2²·7, so σ(28) = σ(2²)·σ(7) = (1+2+4)·8 = 7·8. -/
+theorem sigma_28 : σ 1 28 = 56 := by
+  rw [show (28 : ℕ) = 2 ^ 2 * 7 from by norm_num,
+      isMultiplicative_sigma.map_mul_of_coprime (show (2 ^ 2 : ℕ).gcd 7 = 1 from by decide),
+      sigma_one_apply_prime_pow (show Nat.Prime 2 from by norm_num),
+      sigma_one_prime (show Nat.Prime 7 from by norm_num)]
+  simp [Finset.sum_range_succ]
+
+/-- σ(957) = 1440.  957 = 3·11·29, so σ(957) = 4·12·30. -/
+theorem sigma_957 : σ 1 957 = 1440 := by
+  rw [show (957 : ℕ) = 3 * (11 * 29) from by norm_num,
+      isMultiplicative_sigma.map_mul_of_coprime (show (3 : ℕ).gcd (11 * 29) = 1 from by decide),
+      isMultiplicative_sigma.map_mul_of_coprime (show (11 : ℕ).gcd 29 = 1 from by decide),
+      sigma_one_prime (show Nat.Prime 3 from by norm_num),
+      sigma_one_prime (show Nat.Prime 11 from by norm_num),
+      sigma_one_prime (show Nat.Prime 29 from by norm_num)]
+  norm_num
+
+/-- σ(958) = 1440.  958 = 2·479, so σ(958) = 3·480. -/
+theorem sigma_958 : σ 1 958 = 1440 := by
+  rw [show (958 : ℕ) = 2 * 479 from by norm_num,
+      isMultiplicative_sigma.map_mul_of_coprime (show (2 : ℕ).gcd 479 = 1 from by decide),
+      sigma_one_prime (show Nat.Prime 2 from by norm_num),
+      sigma_one_prime (show Nat.Prime 479 from by norm_num)]
+  norm_num
+
+/-!
+## σ-pairs and perfect numbers
+-/
+
+/-- The smallest nontrivial σ-pair: σ(14) = σ(15) = 24 (consecutive integers). -/
+theorem sigma_pair_14_15 : σ 1 14 = σ 1 15 := by rw [sigma_14, sigma_15]
+
+/-- A larger σ-pair of consecutive integers: σ(957) = σ(958) = 1440. -/
+theorem sigma_pair_957_958 : σ 1 957 = σ 1 958 := by rw [sigma_957, sigma_958]
+
+/-- 6 is perfect: σ(6) = 2·6. -/
+theorem six_perfect : σ 1 6 = 2 * 6 := by rw [sigma_6]
+
+/-- 28 is perfect: σ(28) = 2·28. -/
+theorem twentyeight_perfect : σ 1 28 = 2 * 28 := by rw [sigma_28]
+
+/-- Both 14 and 15 lie in the fiber σ⁻¹(24): the concrete witness behind the
+parent's `IsSigmaPair 14 15` and the α = 1 case of Pollack's theorem. -/
+theorem fiber_24 : σ 1 14 = 24 ∧ σ 1 15 = 24 := ⟨sigma_14, sigma_15⟩
+
+end Erdos823SigmaValues

--- a/src/data/proofs/erdos-733-oq-02/annotations.json
+++ b/src/data/proofs/erdos-733-oq-02/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "e733rl-ann-01",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 73, "endLine": 82 },
+    "type": "concept",
+    "title": "Disjoint pairs: where linearity enters",
+    "content": "`disjoint_pairs` is the only place the geometry is used. Each line `L` carries the family `L.powersetCard 2` of its two-element point-subsets. If a two-element set `s` belonged to both `L₁.powersetCard 2` and `L₂.powersetCard 2`, then `s ⊆ L₁ ∩ L₂` with `|s| = 2`, forcing `|L₁ ∩ L₂| ≥ 2`. But the linear-space hypothesis says two distinct lines meet in at most one point, so the families are disjoint. No point-pair lies on two lines — this is exactly the fact that makes the counting work.",
+    "mathContext": "$s \\subseteq L_1 \\cap L_2,\\ |s| = 2 \\Rightarrow |L_1 \\cap L_2| \\ge 2$, contradicting $|L_1 \\cap L_2| \\le 1$."
+  },
+  {
+    "id": "e733rl-ann-02",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 90, "endLine": 112 },
+    "type": "technique",
+    "title": "Double counting via a disjoint biUnion",
+    "content": "`sum_choose_two_le` is the engine. Rewriting `C(|L|,2)` as `(L.powersetCard 2).card` (Finset.card_powersetCard) turns the sum over lines into a sum of cardinalities of pairwise-disjoint finsets. `Finset.card_biUnion` (using the disjointness from `disjoint_pairs`) collapses that sum into the cardinality of their union, and the union sits inside `P.powersetCard 2` because every line is a subset of `P`. Hence `∑_L C(|L|,2) ≤ C(n,2)`. This single inequality powers every rich-line bound below.",
+    "mathContext": "$\\sum_{L} \\binom{|L|}{2} = \\Big|\\bigsqcup_L \\binom{L}{2}\\Big| \\le \\Big|\\binom{P}{2}\\Big| = \\binom{n}{2}.$"
+  },
+  {
+    "id": "e733rl-ann-03",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 124, "endLine": 140 },
+    "type": "concept",
+    "title": "Charging rich lines to point-pairs",
+    "content": "`rich_line_bound` is the headline. Over the k-rich lines, the constant estimate `C(k,2) ≤ C(|L|,2)` (Nat.choose_le_choose, since `k ≤ |L|`) sums to `#{k-rich lines} · C(k,2) ≤ ∑_L C(|L|,2) ≤ C(n,2)`. Read combinatorially: every k-rich line is charged the `C(k,2)` pairs it must contain, no pair is charged twice (disjointness), and there are only `C(n,2)` pairs to spend. The count of k-rich lines is therefore at most `C(n,2)/C(k,2) = O(n²/k²)`.",
+    "mathContext": "$\\#\\{L : |L| \\ge k\\}\\cdot \\binom{k}{2} \\le \\sum_L \\binom{|L|}{2} \\le \\binom{n}{2}.$"
+  },
+  {
+    "id": "e733rl-ann-04",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 157, "endLine": 169 },
+    "type": "result",
+    "title": "k = 2: bounding the number of proper lines",
+    "content": "`num_proper_lines_le` specializes `rich_line_bound` at `k = 2`. Since `C(2,2) = 1`, the bound becomes `#{lines with ≥ 2 points} ≤ C(n,2)`: each proper line is charged to a distinct point-pair. This is the easy direction of de Bruijn–Erdős-style counting and shows that a linear space on n points has at most quadratically many lines.",
+    "mathContext": "$\\binom{2}{2} = 1 \\Rightarrow \\#\\{L : |L| \\ge 2\\} \\le \\binom{n}{2}.$"
+  },
+  {
+    "id": "e733rl-ann-05",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 40, "endLine": 56 },
+    "type": "caveat",
+    "title": "Honest scope: weaker than Szemerédi–Trotter, but unconditional and 0-axiom",
+    "content": "The bound here is `O(n²/k²)`; Szemerédi–Trotter improves the exponent on k from 2 to 3 (plus an `n/k` term): `O(n²/k³ + n/k)`. That improvement is the genuinely deep content the parent Erdős #733 file axiomatizes, and this entry does NOT discharge those axioms. What it does deliver is the elementary baseline, fully machine-checked with no incidence theorem. The linear-space conditions `hsub` and `hlin` are ordinary hypotheses, not structure-encoded axioms, so the file is genuinely 0-axiom under the project's axiom-integrity policy.",
+    "mathContext": "Elementary: $O(n^2/k^2)$. Szemerédi–Trotter: $O(n^2/k^3 + n/k)$."
+  }
+]

--- a/src/data/proofs/erdos-733-oq-02/meta.json
+++ b/src/data/proofs/erdos-733-oq-02/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "erdos-733-oq-02",
+  "title": "The Elementary Rich-Line Bound (Erdős #733)",
+  "slug": "erdos-733-oq-02",
+  "description": "Fills the unproved 'Part III' claim of the Erdős #733 formalization: that the number of k-rich lines (lines through at least k of n points) is bounded. The registered file states the Szemerédi–Trotter corollary O(n²/k³ + n/k) only as a docstring, with no proof. This entry proves the elementary, unconditional baseline #{lines with ≥ k points} · C(k,2) ≤ C(n,2), hence #{k-rich lines} ≤ C(n,2)/C(k,2) = O(n²/k²), by pure double counting of point-pairs: each line carries the C(|L|,2) two-element subsets of its points, distinct lines share at most one point so these pair-families are disjoint, and there are only C(n,2) pairs in all. The single hypothesis is the defining 'linear space' property of lines (two distinct lines meet in ≤ 1 point); no incidence theorem and no real-analytic input is used. Self-contained, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Erdős (problem); classical double-counting bound — formalized in Lean 4",
+    "sourceUrl": "https://www.erdosproblems.com/733",
+    "date": "1983",
+    "status": "verified",
+    "tags": [
+      "combinatorial-geometry",
+      "incidences",
+      "double-counting",
+      "extremal-combinatorics",
+      "szemeredi-trotter",
+      "erdos",
+      "rich-lines"
+    ],
+    "proofRepoPath": "Proofs/Erdos733RichLines.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "Finset.powersetCard",
+      "Finset.card_powersetCard",
+      "Finset.card_biUnion",
+      "Finset.card_le_card",
+      "Finset.sum_le_sum",
+      "Finset.sum_le_sum_of_subset",
+      "Finset.sum_const_nat",
+      "Nat.choose_le_choose",
+      "Nat.choose_pos",
+      "Nat.le_div_iff_mul_le"
+    ],
+    "originalContributions": [
+      "Machine-checked proof of the elementary rich-line bound #{lines with ≥ k points} · C(k,2) ≤ C(n,2), the unconditional baseline that Szemerédi–Trotter later sharpens — the registered Erdős #733 file states the corresponding corollary only as an unproved docstring",
+      "A clean double-counting argument: distinct lines (sharing ≤ 1 point) carry pairwise-disjoint families of two-element point-subsets, all contained in the C(n,2) pairs of the point set (sum_choose_two_le, disjoint_pairs)",
+      "Division form #{k-rich lines} ≤ C(n,2)/C(k,2) = O(n²/k²) and the de Bruijn–Erdős-style corollary #{proper lines} ≤ C(n,2) (rich_line_count_le, num_proper_lines_le)",
+      "Stated with the linear-space property as an explicit hypothesis rather than a structure-encoded axiom, so the result is genuinely 0-axiom and applies verbatim to honest lines in ℝ²"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 185,
+    "assumptions": "None encoded as axioms or structure fields. Every theorem takes the configuration data (point set P, family of lines) and the linear-space hypotheses hsub (each line ⊆ P) and hlin (two distinct lines meet in ≤ 1 point) as ordinary universally-quantified arguments. #print axioms reports only the standard foundational axioms (propext / Classical.choice / Quot.sound); no sorryAx, no Lean.ofReduceBool. The bound proved is the elementary O(n²/k²) estimate, strictly weaker than the Szemerédi–Trotter O(n²/k³ + n/k) that the parent file axiomatizes — this is disclosed explicitly in the file and is not claimed to discharge those axioms.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #733 asks for the number f(n) of 'line-compatible' multiplicity sequences realizable by n points in the plane; the answer f(n) = exp(Θ(√n)) was completed by Szemerédi and Trotter in 1983, whose incidence theorem controls how many lines can be rich (pass through many points). The registered formalization Erdos733Problem.lean encodes the two sharp bounds as axioms and, in its 'Part III', states the Szemerédi–Trotter corollary on rich lines — 'the number of k-rich lines is O(n²/k³ + n/k)' — purely as a docstring, proving nothing about it. Yet a weaker rich-line bound predates Szemerédi–Trotter by decades and is completely elementary: it follows from the single fact that two distinct lines meet in at most one point. This entry formalizes that elementary baseline.",
+    "problemStatement": "Let P be a finite set of n points and let `lines` be a family of subsets of P such that any two distinct lines meet in at most one point (the linear-space property of honest lines in ℝ²). Prove that for every threshold k, the number of lines containing at least k points satisfies #{L : |L| ≥ k} · C(k,2) ≤ C(n,2), and therefore #{L : |L| ≥ k} ≤ C(n,2)/C(k,2).",
+    "text": "The file is built around one double-counting identity. For a line L, its C(|L|,2) two-element subsets are the point-pairs it covers; in Lean these are L.powersetCard 2, whose cardinality is |L| choose 2 (Finset.card_powersetCard). The geometric content lives in disjoint_pairs: if two lines meet in at most one point, no pair of points lies on both, so their pair-families are disjoint. The core bound sum_choose_two_le then rewrites each C(|L|,2) as a cardinality, uses Finset.card_biUnion over the disjoint families, and bounds the union by the pairs of P to get ∑_{L} C(|L|,2) ≤ C(n,2). The headline rich_line_bound sums the trivial estimate C(k,2) ≤ C(|L|,2) over the k-rich lines (Nat.choose_le_choose) to obtain #{k-rich lines} · C(k,2) ≤ C(n,2). Two corollaries follow: rich_line_count_le divides through (Nat.le_div_iff_mul_le) to the familiar O(n²/k²) form, and num_proper_lines_le specializes to k = 2 (C(2,2) = 1) to bound the number of lines with at least two points by C(n,2). A monotonicity lemma rich_lines_antitone records that raising the threshold can only shrink the rich-line count.",
+    "proofStrategy": "Charge each k-rich line to the C(k,2) point-pairs it contains. Because distinct lines share at most one point, no point-pair is charged twice, so the total charge #{k-rich lines} · C(k,2) cannot exceed the C(n,2) available pairs. Formally this is a disjoint biUnion of two-element subsets sitting inside the two-element subsets of P; everything else is monotonicity of binomial coefficients and a Nat division step.",
+    "keyInsights": [
+      "The whole bound rests on one geometric fact — two distinct lines meet in at most one point — entered as the explicit hypothesis hlin, not as an incidence theorem. This is what makes it elementary and unconditional.",
+      "Counting point-pairs is the right currency: a k-rich line is worth C(k,2) pairs, and the budget of pairs is exactly C(n,2), so the rich lines are bounded by a clean ratio.",
+      "Disjointness of the pair-families (disjoint_pairs) is where linearity is used: a shared pair would force two lines to meet in two points, contradicting hlin.",
+      "The result is honestly weaker than Szemerédi–Trotter — O(n²/k²) versus O(n²/k³ + n/k) — and the file says so. It is the baseline the deep theorem improves, and it is the part that can be fully machine-checked with no axioms.",
+      "Stating the linear-space property as a hypothesis rather than a structure field keeps the entry genuinely 0-axiom under the project's axiom-integrity policy, while still applying verbatim to the geometric setting of the parent #733 file."
+    ],
+    "prerequisites": [
+      "Binomial coefficients and the identity that an m-set has C(m,2) two-element subsets",
+      "Double counting / the handshake principle in extremal combinatorics",
+      "Linear spaces (partial linear spaces): families of lines pairwise meeting in at most one point",
+      "Finset.powersetCard and disjoint biUnion cardinality in Lean/Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "core-double-counting",
+      "title": "The core double-counting inequality",
+      "startLine": 60,
+      "endLine": 112,
+      "summary": "disjoint_pairs shows that two lines meeting in ≤ 1 point carry disjoint families of two-element point-subsets. sum_choose_two_le then sums their sizes via a disjoint biUnion and bounds the result by the two-element subsets of P, giving ∑_{L} C(|L|,2) ≤ C(n,2).",
+      "mathContext": "Each line covers $\\binom{|L|}{2}$ point-pairs; distinct lines share at most one point, so the pair-families are disjoint and $\\sum_L \\binom{|L|}{2} \\le \\binom{n}{2}$."
+    },
+    {
+      "id": "rich-line-bound",
+      "title": "The rich-line bound",
+      "startLine": 114,
+      "endLine": 155,
+      "summary": "rich_line_bound charges each k-rich line C(k,2) pairs and sums: #{L : |L| ≥ k} · C(k,2) ≤ C(n,2). rich_line_count_le divides through to #{k-rich lines} ≤ C(n,2)/C(k,2), the O(n²/k²) estimate.",
+      "mathContext": "$\\#\\{L : |L| \\ge k\\}\\cdot \\binom{k}{2} \\le \\binom{n}{2}$, hence $\\#\\{L : |L| \\ge k\\} \\le \\binom{n}{2}/\\binom{k}{2} = O(n^2/k^2)$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Proper lines and monotonicity",
+      "startLine": 157,
+      "endLine": 185,
+      "summary": "num_proper_lines_le specializes to k = 2 (C(2,2) = 1): the number of lines with at least two points is at most C(n,2), the easy de Bruijn–Erdős direction. rich_lines_antitone records that raising the threshold only shrinks the rich-line count.",
+      "mathContext": "$k=2$: $\\#\\{L : |L| \\ge 2\\} \\le \\binom{n}{2}$. Monotonicity: $k \\le k' \\Rightarrow \\#\\{|L| \\ge k'\\} \\le \\#\\{|L| \\ge k\\}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-733",
+      "relationship": "extends",
+      "description": "The parent entry formalizes the count of line-compatible sequences and axiomatizes the sharp Szemerédi–Trotter bounds. Its Part III states the rich-line corollary O(n²/k³ + n/k) only as an unproved docstring; this entry supplies the elementary unconditional baseline #{k-rich lines} = O(n²/k²), fully machine-checked."
+    },
+    {
+      "targetId": "erdos-733-oq-01",
+      "relationship": "related",
+      "description": "OQ-01 addresses the limit constant λ = lim log f(n)/√n of the parent's count; this entry instead proves the elementary combinatorial estimate underlying the rich-line side of the Szemerédi–Trotter machinery."
+    }
+  ],
+  "conclusion": {
+    "summary": "The number of k-rich lines in an n-point configuration is at most C(n,2)/C(k,2) = O(n²/k²), proved by charging each rich line the C(k,2) point-pairs it covers and noting that distinct lines share at most one point, so no pair is double-charged against the C(n,2) available pairs. This fills the unproved Part III claim of the Erdős #733 formalization with a fully verified, 0-axiom statement.",
+    "implications": "The bound is the elementary baseline that Szemerédi–Trotter improves (to O(n²/k³ + n/k)), and it requires nothing beyond the linear-space property of lines. It pins down precisely how much of the rich-line corollary used in #733 is elementary double counting versus genuinely deep incidence geometry, and provides reusable Lean infrastructure (disjoint pair-families, the ∑ C(|L|,2) ≤ C(n,2) inequality) for further incidence-combinatorics formalization."
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Finset.Card",
+      "Mathlib.Data.Finset.Powerset",
+      "Mathlib.Algebra.Order.BigOperators.Group.Finset",
+      "Mathlib.Data.Nat.Choose.Basic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos733RichLines",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos733RichLines.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Szemerédi, Endre; Trotter, William T.",
+      "title": "Extremal problems in discrete geometry",
+      "year": "1983",
+      "venue": "Combinatorica 3, 381–392",
+      "note": "The sharp incidence theorem behind Erdős #733; its rich-line corollary O(n²/k³ + n/k) improves the elementary O(n²/k²) bound proved here."
+    },
+    {
+      "authors": "de Bruijn, Nicolaas G.; Erdős, Paul",
+      "title": "On a combinatorial problem",
+      "year": "1948",
+      "venue": "Indagationes Mathematicae 10, 421–423",
+      "note": "Classical linear-space counting; the k = 2 corollary here (#proper lines ≤ C(n,2)) is the easy direction of this circle of ideas."
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "Problem #733",
+      "year": "n.d.",
+      "venue": "erdosproblems.com",
+      "note": "Counting line-compatible multiplicity sequences; answer exp(Θ(√n)) via Szemerédi–Trotter."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "rich_line_bound",
+      "type": "core",
+      "description": "Elementary rich-line bound: with n = |P|, the number of lines containing at least k points satisfies #{L : |L| ≥ k} · C(k,2) ≤ C(n,2). The unconditional baseline Szemerédi–Trotter later sharpens.",
+      "leanType": "∀ {V} [DecidableEq V] (P : Finset V) (lines : Finset (Finset V)), (∀ L ∈ lines, L ⊆ P) → (∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) → ∀ k, (lines.filter (fun L => k ≤ L.card)).card * k.choose 2 ≤ (P.card).choose 2"
+    },
+    {
+      "name": "sum_choose_two_le",
+      "type": "core",
+      "description": "Core double-counting inequality: the total number of point-pairs covered by all lines is at most the C(n,2) pairs of the point set. Drives every rich-line bound.",
+      "leanType": "∀ {V} [DecidableEq V] (P : Finset V) (lines : Finset (Finset V)), (∀ L ∈ lines, L ⊆ P) → (∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) → ∑ L ∈ lines, (L.card).choose 2 ≤ (P.card).choose 2"
+    },
+    {
+      "name": "rich_line_count_le",
+      "type": "corollary",
+      "description": "Division form: for k ≥ 2 the number of k-rich lines is at most C(n,2)/C(k,2), the familiar O(n²/k²) estimate.",
+      "leanType": "∀ {V} [DecidableEq V] (P : Finset V) (lines : Finset (Finset V)), (∀ L ∈ lines, L ⊆ P) → (∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) → ∀ k, 2 ≤ k → (lines.filter (fun L => k ≤ L.card)).card ≤ (P.card).choose 2 / k.choose 2"
+    },
+    {
+      "name": "num_proper_lines_le",
+      "type": "corollary",
+      "description": "k = 2 specialization: the number of lines through at least two points is at most C(n,2) — each is charged to a distinct point-pair (de Bruijn–Erdős easy direction).",
+      "leanType": "∀ {V} [DecidableEq V] (P : Finset V) (lines : Finset (Finset V)), (∀ L ∈ lines, L ⊆ P) → (∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) → (lines.filter (fun L => 2 ≤ L.card)).card ≤ (P.card).choose 2"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/erdos-823-oq-05/annotations.json
+++ b/src/data/proofs/erdos-823-oq-05/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "e823sv-ann-01",
+    "proofId": "erdos-823-oq-05",
+    "range": { "startLine": 53, "endLine": 55 },
+    "type": "technique",
+    "title": "σ on a prime: the only ingredient beyond multiplicativity",
+    "content": "`sigma_one_prime` is the whole arithmetic content. For a prime `p`, Mathlib's `Nat.Prime.divisors` gives `divisors p = {1, p}`, so `σ 1 p = ∑ d ∈ {1,p}, d = 1 + p` by `Finset.sum_pair` (using `1 ≠ p`). `omega` flips `1 + p` to `p + 1`. Everything else in the file is coprime multiplicativity applied to this fact.",
+    "mathContext": "$\\sigma(p) = \\sum_{d \\mid p} d = 1 + p$ since divisors$(p) = \\{1, p\\}$."
+  },
+  {
+    "id": "e823sv-ann-02",
+    "proofId": "erdos-823-oq-05",
+    "range": { "startLine": 72, "endLine": 77 },
+    "type": "technique",
+    "title": "Reading σ off the factorization, axiom-free",
+    "content": "`sigma_14` is the template. Rewrite `14 = 2·7`; `isMultiplicative_sigma.map_mul_of_coprime` splits `σ(2·7) = σ(2)·σ(7)` once the gcd condition `gcd 2 7 = 1` is supplied (here by kernel `decide` — small, no compiled evaluator); `sigma_one_prime` evaluates each prime to `p+1`; `norm_num` finishes `3·8 = 24`. No `native_decide`, so no `Lean.ofReduceBool`. The same five lines, with a different factorization, give every other value.",
+    "mathContext": "$\\sigma(14) = \\sigma(2)\\,\\sigma(7) = (2{+}1)(7{+}1) = 3 \\cdot 8 = 24.$"
+  },
+  {
+    "id": "e823sv-ann-03",
+    "proofId": "erdos-823-oq-05",
+    "range": { "startLine": 86, "endLine": 92 },
+    "type": "concept",
+    "title": "Prime powers: σ(2²) and the perfect number 28",
+    "content": "`sigma_28` needs the one prime power 2² in 28 = 2²·7. There `sigma_one_apply_prime_pow` gives `σ(2²) = ∑_{k<3} 2^k = 1+2+4 = 7`, expanded by `simp [Finset.sum_range_succ]`; multiplicativity then yields `7·8 = 56`. Since 56 = 2·28, `twentyeight_perfect` certifies 28 as the second perfect number — axiom-free.",
+    "mathContext": "$\\sigma(2^2) = 1+2+4 = 7,\\quad \\sigma(28) = 7 \\cdot 8 = 56 = 2 \\cdot 28.$"
+  },
+  {
+    "id": "e823sv-ann-04",
+    "proofId": "erdos-823-oq-05",
+    "range": { "startLine": 116, "endLine": 130 },
+    "type": "result",
+    "title": "Consecutive-integer σ-pairs: the base of Pollack's theorem",
+    "content": "`sigma_pair_14_15` and `sigma_pair_957_958` record that 14,15 and 957,958 are pairs of consecutive integers with equal σ — value-collisions of the sum-of-divisors function. These are the simplest instances (ratio n/m ≈ 1) of the phenomenon Erdős #823 / Pollack push to arbitrary ratios α. `fiber_24` packages 14,15 ∈ σ⁻¹(24) as the concrete α = 1 witness.",
+    "mathContext": "$\\sigma(14)=\\sigma(15)=24,\\quad \\sigma(957)=\\sigma(958)=1440.$"
+  },
+  {
+    "id": "e823sv-ann-05",
+    "proofId": "erdos-823-oq-05",
+    "range": { "startLine": 19, "endLine": 23 },
+    "type": "caveat",
+    "title": "A false native_decide claim in the parent",
+    "content": "While recomputing the parent's values, σ(206) and σ(210) come out 312 and 576 — so the parent's `sigma_206_210 : σ 206 = σ 210`, asserted by `native_decide`, is false. This entry does not reproduce it. The episode illustrates the policy point: a symbolic proof cannot close a false goal, but `native_decide` will happily certify whatever the compiled evaluator returns — another reason to prefer kernel-checked, axiom-free computation for facts presented as verified.",
+    "mathContext": "$\\sigma(206) = \\sigma(2\\cdot 103) = 3\\cdot 104 = 312 \\ne 576 = 3\\cdot 4\\cdot 6\\cdot 8 = \\sigma(210).$"
+  }
+]

--- a/src/data/proofs/erdos-823-oq-05/meta.json
+++ b/src/data/proofs/erdos-823-oq-05/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "erdos-823-oq-05",
+  "title": "σ Values from Mathlib, Axiom-Free (Erdős #823)",
+  "slug": "erdos-823-oq-05",
+  "description": "The registered Erdős #823 entry computes its concrete sum-of-divisors values — σ(14)=σ(15)=24 and friends — with native_decide, which depends on Lean.ofReduceBool and so is not axiom-free under the project's axiom-integrity policy. This entry reproves the genuine σ-values symbolically from Mathlib's arithmetic-function API: σ is multiplicative (isMultiplicative_sigma) and σ(p)=p+1 on primes (from Nat.Prime.divisors), so σ at any explicit n is its prime factorization read off coprime-multiplicatively. Proves σ(6)=12, σ(14)=24, σ(15)=24, σ(28)=56, σ(957)=1440, σ(958)=1440, the σ-pairs σ(14)=σ(15) and σ(957)=σ(958), and that 6 and 28 are perfect (σ(n)=2n). #print axioms reports only propext / Classical.choice / Quot.sound — no Lean.ofReduceBool, no native_decide, no sorry. In passing it documents a latent bug in the parent: sigma_206_210 (σ206=σ210, asserted via native_decide) is false (312≠576).",
+  "meta": {
+    "author": "Erdős (problem); Pollack 2015 (theorem) — σ-values formalized in Lean 4",
+    "sourceUrl": "https://www.erdosproblems.com/823",
+    "date": "2015",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "sum-of-divisors",
+      "arithmetic-functions",
+      "multiplicative-functions",
+      "perfect-numbers",
+      "axiom-free",
+      "erdos"
+    ],
+    "proofRepoPath": "Proofs/Erdos823SigmaValues.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "ArithmeticFunction.sigma",
+      "ArithmeticFunction.sigma_one_apply",
+      "ArithmeticFunction.sigma_one_apply_prime_pow",
+      "ArithmeticFunction.isMultiplicative_sigma",
+      "ArithmeticFunction.IsMultiplicative.map_mul_of_coprime",
+      "Nat.Prime.divisors",
+      "Finset.sum_pair",
+      "Finset.sum_range_succ"
+    ],
+    "originalContributions": [
+      "Kernel-checked, 0-axiom recomputation of the Erdős #823 σ-values that the registered file proves with native_decide (which depends on Lean.ofReduceBool and is therefore not axiom-free)",
+      "A reusable symbolic recipe: σ(p) = p+1 from Nat.Prime.divisors plus coprime multiplicativity evaluates σ at any explicit n from its factorization, with no decision-procedure trust",
+      "Verified σ-pairs σ(14)=σ(15)=24 and σ(957)=σ(958)=1440 — consecutive-integer fibers of σ that are the α=1 base case of Pollack's theorem",
+      "Verified perfectness of 6 and 28 (σ(n)=2n), and a documented correction of the parent's false native_decide claim sigma_206_210 (σ206=312 ≠ σ210=576)"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 132,
+    "assumptions": "None. Every theorem is proved by the kernel from Mathlib lemmas; the only tactics that touch decision procedures are kernel `decide` (for small gcd coprimality facts) and `norm_num` (arithmetic and primality), neither of which introduces axioms. #print axioms on the σ-values reports exactly [propext, Classical.choice, Quot.sound] — no Lean.ofReduceBool (which native_decide would add) and no sorryAx. This is the point of the entry: the parent's native_decide computations are replaced by genuinely axiom-free symbolic proofs.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #823 asks whether, for every α ≥ 1, there exist sequences nₖ, mₖ with nₖ/mₖ → α and σ(nₖ) = σ(mₖ); Pollack proved YES in 2015. The smallest nontrivial witness that σ can repeat values is σ(14) = σ(15) = 24 — two consecutive integers in the same fiber of the sum-of-divisors function. The registered formalization Erdos823Problem.lean states Pollack's theorem as an axiom and illustrates it with concrete σ-values computed by native_decide. Under the project's axiom-integrity policy native_decide is not axiom-free: it trusts the compiled evaluator and shows up as the axiom Lean.ofReduceBool. This entry removes that dependency by computing the same values symbolically.",
+    "problemStatement": "Reprove the concrete sum-of-divisors values used by Erdős #823 — σ(14), σ(15), σ(957), σ(958) and related — from Mathlib's arithmetic-function API rather than native_decide, so that the results are kernel-checked and genuinely axiom-free.",
+    "text": "The whole file rests on two Mathlib facts: σ is multiplicative (ArithmeticFunction.isMultiplicative_sigma, giving σ(mn) = σ(m)σ(n) when gcd(m,n)=1) and, for a prime p, divisors p = {1, p} (Nat.Prime.divisors), so σ(p) = 1 + p (sigma_one_prime, via Finset.sum_pair). Each value theorem rewrites n as a product of prime powers, applies map_mul_of_coprime to split σ across coprime factors (coprimality discharged by kernel `decide` on the small gcds), evaluates σ on each prime via sigma_one_prime (and sigma_one_apply_prime_pow for the 2² in 28), and finishes with norm_num. This yields σ(6)=12, σ(14)=24, σ(15)=24, σ(28)=56, σ(957)=1440, σ(958)=1440. From these, sigma_pair_14_15 and sigma_pair_957_958 record the consecutive-integer σ-pairs, six_perfect and twentyeight_perfect record σ(n)=2n for the first two perfect numbers, and fiber_24 packages 14, 15 ∈ σ⁻¹(24).",
+    "proofStrategy": "Read σ off the prime factorization. Multiplicativity reduces σ(n) to a product of σ(prime power) terms; primes give σ(p)=p+1 directly from their two-element divisor set; the lone prime power 2² is handled by Mathlib's prime-power formula. All side conditions (coprimality, primality) are small and discharged by decide/norm_num without invoking the compiled evaluator, so no Lean.ofReduceBool enters.",
+    "keyInsights": [
+      "native_decide is not free: it adds Lean.ofReduceBool to the axiom set, so 'σ(14)=24 by native_decide' is an axiomatized fact, not a verified one. Symbolic evaluation via multiplicativity avoids this entirely.",
+      "The only arithmetic input needed is σ(p)=p+1 for primes (their divisor set is {1,p}); everything else is coprime multiplicativity, which Mathlib already provides for σ.",
+      "σ(14)=σ(15)=24 and σ(957)=σ(958)=1440 exhibit two consecutive integers sharing a σ-value — the simplest manifestation of the value-collisions that Pollack's theorem amplifies to arbitrary ratios n/m.",
+      "The same machinery proves σ(6)=2·6 and σ(28)=2·28, certifying the first two perfect numbers axiom-free.",
+      "Recomputing the parent's values surfaced a real error: its native_decide claim σ(206)=σ(210) is false (312 vs 576). Symbolic proof would have refused to close it; the decision procedure silently encoded a false statement (or the file is excluded from the verified build)."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function σ and its multiplicativity",
+      "Reading an arithmetic function off a prime factorization",
+      "Perfect numbers (σ(n) = 2n) and σ-fibers",
+      "Lean's axiom accounting: native_decide vs kernel decide (Lean.ofReduceBool)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sigma-on-primes",
+      "title": "σ on a prime",
+      "startLine": 45,
+      "endLine": 55,
+      "summary": "sigma_one_prime: for a prime p, divisors p = {1, p} (Nat.Prime.divisors), so σ(p) = 1 + p via Finset.sum_pair. The single building block beyond multiplicativity.",
+      "mathContext": "$p$ prime $\\Rightarrow$ divisors$(p) = \\{1, p\\}$, hence $\\sigma(p) = 1 + p$."
+    },
+    {
+      "id": "sigma-values",
+      "title": "σ values via multiplicativity",
+      "startLine": 57,
+      "endLine": 110,
+      "summary": "sigma_6, sigma_14, sigma_15, sigma_28, sigma_957, sigma_958: each factors n into prime powers, splits σ across coprime factors (isMultiplicative_sigma.map_mul_of_coprime), evaluates on primes (sigma_one_prime) and on 2² (sigma_one_apply_prime_pow), and closes with norm_num.",
+      "mathContext": "$\\sigma(14)=\\sigma(2)\\sigma(7)=3\\cdot 8=24$; $\\sigma(957)=\\sigma(3)\\sigma(11)\\sigma(29)=4\\cdot 12\\cdot 30=1440$."
+    },
+    {
+      "id": "pairs-and-perfect",
+      "title": "σ-pairs and perfect numbers",
+      "startLine": 112,
+      "endLine": 132,
+      "summary": "sigma_pair_14_15 and sigma_pair_957_958 give the consecutive-integer σ-pairs; six_perfect and twentyeight_perfect certify σ(n)=2n for 6 and 28; fiber_24 packages 14, 15 ∈ σ⁻¹(24), the α=1 case of Pollack's theorem.",
+      "mathContext": "$\\sigma(14)=\\sigma(15)$, $\\sigma(957)=\\sigma(958)$; $\\sigma(6)=2\\cdot 6$, $\\sigma(28)=2\\cdot 28$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-823",
+      "relationship": "extends",
+      "description": "The parent formalizes Pollack's theorem and illustrates it with σ-values computed by native_decide (hence depending on Lean.ofReduceBool). This entry reproves those values symbolically and axiom-free, and documents that the parent's sigma_206_210 (σ206=σ210) is false."
+    }
+  ],
+  "conclusion": {
+    "summary": "The concrete sum-of-divisors values behind Erdős #823 — σ(14)=σ(15)=24, σ(957)=σ(958)=1440, σ(6)=12, σ(28)=56 — are reproved symbolically from σ's multiplicativity and its value on primes, replacing the parent's native_decide computations with kernel-checked, genuinely axiom-free proofs (#print axioms shows only propext/Classical.choice/Quot.sound).",
+    "implications": "Beyond removing an axiom dependency, the entry gives a reusable recipe for evaluating any multiplicative arithmetic function at an explicit integer from its factorization, and it underscores a methodological point: native_decide can silently certify even false statements (the parent's σ206=σ210), whereas symbolic proof cannot. The verified σ-pairs are the elementary base of the value-collision phenomenon Pollack's theorem generalizes."
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ArithmeticFunction.Defs",
+      "Mathlib.NumberTheory.ArithmeticFunction.Misc",
+      "Mathlib.NumberTheory.Divisors",
+      "Mathlib.Tactic.NormNum.Prime"
+    ],
+    "opens": [
+      "ArithmeticFunction",
+      "ArithmeticFunction.sigma"
+    ],
+    "namespace": "Erdos823SigmaValues",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos823SigmaValues.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Pollack, Paul",
+      "title": "Remarks on fibers of the sum-of-divisors function",
+      "year": "2015",
+      "venue": "Analytic number theory (Springer), 305–320",
+      "note": "Proves the affirmative answer to Erdős #823 for σ; σ-fibers contain pairs of arbitrary ratio."
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "Remarks on some problems in number theory",
+      "year": "1974",
+      "venue": "Math. Balkanica 4",
+      "note": "Poses the σ version and notes the analogous φ result is easy."
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "Problem #823",
+      "year": "n.d.",
+      "venue": "erdosproblems.com",
+      "note": "Equal sum of divisors with arbitrary ratio; motivating example σ(14)=σ(15)=24."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "sigma_one_prime",
+      "type": "core",
+      "description": "For any prime p, σ(p) = p + 1, proved from Nat.Prime.divisors (divisors p = {1, p}). The building block for all values.",
+      "leanType": "∀ {p : ℕ}, p.Prime → ArithmeticFunction.sigma 1 p = p + 1"
+    },
+    {
+      "name": "sigma_pair_14_15",
+      "type": "core",
+      "description": "The smallest nontrivial σ-pair: σ(14) = σ(15) = 24, two consecutive integers in the same σ-fiber — the α = 1 case of Pollack's theorem, proved axiom-free.",
+      "leanType": "ArithmeticFunction.sigma 1 14 = ArithmeticFunction.sigma 1 15"
+    },
+    {
+      "name": "sigma_pair_957_958",
+      "type": "corollary",
+      "description": "A larger consecutive-integer σ-pair: σ(957) = σ(958) = 1440.",
+      "leanType": "ArithmeticFunction.sigma 1 957 = ArithmeticFunction.sigma 1 958"
+    },
+    {
+      "name": "twentyeight_perfect",
+      "type": "corollary",
+      "description": "28 is perfect: σ(28) = 2·28 — proved via σ(2²·7) = 7·8 = 56, axiom-free.",
+      "leanType": "ArithmeticFunction.sigma 1 28 = 2 * 28"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Task: *"Prove σ(14) and related values from Mathlib (remove axioms)."*

The registered **Erdős #823** entry (`Erdos823Problem.lean`) computes its concrete sum-of-divisors values — `σ(14)=σ(15)=24`, etc. — with `native_decide`. Per the project's **axiom-integrity policy**, `native_decide` trusts the compiled evaluator and depends on `Lean.ofReduceBool`, so those statements are **not axiom-free**. This PR reproves the genuine values **symbolically from Mathlib's arithmetic-function API**, kernel-checked and 0-axiom.

### Method
```
σ multiplicative (isMultiplicative_sigma)  +  σ(p) = p+1  (Nat.Prime.divisors → {1,p})
  ⟹  σ(n) read off its prime factorization, coprime-multiplicatively
```
Coprimality side-conditions use **kernel `decide`** (small gcds — *not* `native_decide`); primality uses `norm_num`.

### Proved (12 theorems, 132 lines)
- Values: `σ(6)=12`, `σ(14)=24`, `σ(15)=24`, `σ(28)=56`, `σ(957)=1440`, `σ(958)=1440`
- σ-pairs: `σ(14)=σ(15)`, `σ(957)=σ(958)` — consecutive integers in a common σ-fiber (the α=1 base of Pollack's theorem)
- Perfect numbers: `σ(6)=2·6`, `σ(28)=2·28`
- `fiber_24`: 14, 15 ∈ σ⁻¹(24)

### Axiom check
`#print axioms` on the σ-values → **`[propext, Classical.choice, Quot.sound]`** only. **No `Lean.ofReduceBool`, no `native_decide`, no `sorry`, no `axiom`.** Genuinely `verified` / 0-axiom.

### Latent bug documented
Recomputing surfaced that the parent's `sigma_206_210 : σ 206 = σ 210` (asserted via `native_decide`) is **false**: σ(206)=σ(2·103)=312, σ(210)=σ(2·3·5·7)=576. Not reproduced here. A symbolic proof cannot close a false goal — `native_decide` can.

### Build
`./proofs/scripts/docker-build.sh Proofs.Erdos823SigmaValues` ✓ (Mathlib v4.26.0, 0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)