### PR TITLE
research(erdos-220-oq-01): matching lower bound for squared gaps between reduced residues [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1354,6 +1354,7 @@ import Proofs.Erdos218Problem
 import Proofs.Erdos219Problem
 import Proofs.Erdos21Problem
 import Proofs.Erdos220Aristotle
+import Proofs.Erdos220OQ01
 import Proofs.Erdos220Problem
 import Proofs.Erdos220ProblemProvable
 import Proofs.Erdos221Problem

--- a/proofs/Proofs/Erdos220OQ01.lean
+++ b/proofs/Proofs/Erdos220OQ01.lean
@@ -1,0 +1,212 @@
+/-
+Erdős Problem #220 (follow-up OQ-01): A matching LOWER bound for the squared gaps
+between reduced residues.
+
+Source: https://erdosproblems.com/220
+Parent: Proofs/Erdos220Problem.lean (Montgomery–Vaughan upper bound, axiomatized)
+
+Background:
+Let n ≥ 2 and let 1 = a₁ < a₂ < ⋯ < a_{φ(n)} = n-1 be the reduced residues mod n,
+i.e. the integers in [1, n-1] coprime to n.  Montgomery and Vaughan (1986) proved the
+hard UPPER bound
+        ∑_{k} (a_{k+1} - a_k)² ≪ n²/φ(n).
+The parent entry states this as an axiom (the proof is genuinely analytic).
+
+This file supplies the EASY but complementary LOWER bound, which the parent only
+gestured at in its "Observation" comments and never proved:
+        ∑_{k} (a_{k+1} - a_k)² ≥ (n-2)²/(φ(n)-1).
+Since (n-2)²/(φ(n)-1) ≍ n²/φ(n), the two bounds together show that the
+Montgomery–Vaughan bound is TIGHT IN ORDER:
+        ∑_{k} (a_{k+1} - a_k)² ≍ n²/φ(n).
+
+The mechanism is elementary and self-contained:
+
+  • The φ(n)-1 gaps telescope: their sum is a_{φ(n)} - a₁ = (n-1) - 1 = n - 2.
+  • The Cauchy–Schwarz / Chebyshev inequality (∑ gᵢ)² ≤ m · ∑ gᵢ²
+    (`Finset.sq_sum_le_card_mul_sum_sq`) with m = φ(n)-1 gaps then forces
+        (n-2)² ≤ (φ(n)-1) · ∑ gᵢ².
+
+Everything below is proved with no `axiom`, no `sorry`, and no `native_decide`.
+
+References:
+- [MoVa86] Montgomery, Vaughan, "On the distribution of reduced residues",
+           Ann. of Math. (2) 123 (1986), 311-333.
+- [Er73]   Erdős posed the general γ ≥ 1 version.
+-/
+
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Data.Nat.Totient
+import Mathlib.Data.Finset.Sort
+import Mathlib.Algebra.Order.Chebyshev
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.Real.Basic
+
+open Finset Nat
+
+namespace Erdos220OQ01
+
+/-!
+## Part I: Reduced residues and their cardinality
+-/
+
+/-- The reduced residues modulo `n`: integers in `[1, n-1]` coprime to `n`. -/
+def reducedResidues (n : ℕ) : Finset ℕ :=
+  (Finset.range n).filter (fun m => 1 ≤ m ∧ Nat.Coprime m n)
+
+@[simp] theorem mem_reducedResidues {n m : ℕ} :
+    m ∈ reducedResidues n ↔ m < n ∧ 1 ≤ m ∧ Nat.Coprime m n := by
+  simp [reducedResidues, Finset.mem_filter, Finset.mem_range]
+
+/-- For `n ≥ 2` the reduced residues are exactly `φ(n)` in number.
+(The `1 ≤ m` clause only removes `m = 0`, which is already excluded since
+`gcd 0 n = n ≠ 1`.) -/
+theorem card_reducedResidues {n : ℕ} (hn : 2 ≤ n) :
+    (reducedResidues n).card = Nat.totient n := by
+  rw [Nat.totient_eq_card_coprime, reducedResidues]
+  apply congrArg Finset.card
+  apply Finset.filter_congr
+  intro x _
+  constructor
+  · rintro ⟨_, hc⟩
+    exact Nat.coprime_comm.mp hc
+  · intro hc
+    have hx1 : 1 ≤ x := by
+      rcases Nat.eq_zero_or_pos x with h0 | h0
+      · subst h0
+        rw [Nat.coprime_zero_right] at hc
+        omega
+      · exact h0
+    exact ⟨hx1, Nat.coprime_comm.mp hc⟩
+
+theorem totient_pos' {n : ℕ} (hn : 2 ≤ n) : 0 < Nat.totient n :=
+  Nat.totient_pos.mpr (by omega)
+
+/-!
+## Part II: The endpoints of the reduced-residue enumeration
+
+`1` is the least reduced residue and `n-1` is the greatest, for `n ≥ 2`.
+-/
+
+theorem coprime_pred_self {n : ℕ} (hn : 2 ≤ n) : Nat.Coprime (n - 1) n := by
+  have h : (1 : ℕ) + (n - 1) = n := by omega
+  have hco : Nat.Coprime (1 + (n - 1)) (n - 1) :=
+    (Nat.coprime_add_self_left).mpr (Nat.coprime_one_left _)
+  rw [h] at hco
+  exact hco.symm
+
+theorem one_mem_reducedResidues {n : ℕ} (hn : 2 ≤ n) : 1 ∈ reducedResidues n := by
+  simp only [mem_reducedResidues]
+  exact ⟨by omega, le_refl 1, Nat.coprime_one_left n⟩
+
+theorem pred_mem_reducedResidues {n : ℕ} (hn : 2 ≤ n) : n - 1 ∈ reducedResidues n := by
+  simp only [mem_reducedResidues]
+  exact ⟨by omega, by omega, coprime_pred_self hn⟩
+
+/-- The minimum reduced residue is `1` (for any chosen nonemptiness witness). -/
+theorem min'_reducedResidues {n : ℕ} (hn : 2 ≤ n) (H : (reducedResidues n).Nonempty) :
+    (reducedResidues n).min' H = 1 := by
+  apply le_antisymm
+  · exact Finset.min'_le _ 1 (one_mem_reducedResidues hn)
+  · exact Finset.le_min' _ _ _ (fun y hy => (mem_reducedResidues.mp hy).2.1)
+
+/-- The maximum reduced residue is `n-1` (for any chosen nonemptiness witness). -/
+theorem max'_reducedResidues {n : ℕ} (hn : 2 ≤ n) (H : (reducedResidues n).Nonempty) :
+    (reducedResidues n).max' H = n - 1 := by
+  apply le_antisymm
+  · exact Finset.max'_le _ _ _ (fun y hy => by
+      have := (mem_reducedResidues.mp hy).1; omega)
+  · exact Finset.le_max' _ (n - 1) (pred_mem_reducedResidues hn)
+
+/-!
+## Part III: The enumeration `E` and the gaps
+
+`E n hn k` is the `k`-th reduced residue (as a real number), padded with `0`
+outside the valid range so that telescoping is convenient.
+-/
+
+/-- The `k`-th reduced residue, as a real number (junk value `0` for `k ≥ φ(n)`). -/
+noncomputable def E (n : ℕ) (hn : 2 ≤ n) : ℕ → ℝ := fun k =>
+  if h : k < Nat.totient n then
+    (((reducedResidues n).orderEmbOfFin (card_reducedResidues hn) ⟨k, h⟩ : ℕ) : ℝ)
+  else 0
+
+/-- The `k`-th gap `a_{k+1} - a_k`, as a real number. -/
+noncomputable def gap (n : ℕ) (hn : 2 ≤ n) (k : ℕ) : ℝ := E n hn (k + 1) - E n hn k
+
+theorem E_zero {n : ℕ} (hn : 2 ≤ n) : E n hn 0 = 1 := by
+  have hpos := totient_pos' hn
+  rw [E, dif_pos hpos, Finset.orderEmbOfFin_zero (card_reducedResidues hn) hpos,
+    min'_reducedResidues hn]
+  norm_num
+
+theorem E_last {n : ℕ} (hn : 2 ≤ n) : E n hn (Nat.totient n - 1) = (n : ℝ) - 1 := by
+  have hpos := totient_pos' hn
+  have hlt : Nat.totient n - 1 < Nat.totient n := by omega
+  rw [E, dif_pos hlt]
+  rw [Finset.orderEmbOfFin_last (card_reducedResidues hn) hpos, max'_reducedResidues hn]
+  rw [Nat.cast_sub (by omega : 1 ≤ n)]
+  norm_num
+
+/-!
+## Part IV: The gaps telescope — their sum is `n - 2`
+-/
+
+/-- **Telescoping identity.** The `φ(n)-1` gaps between consecutive reduced residues
+sum to `a_{φ(n)} - a₁ = (n-1) - 1 = n - 2`. -/
+theorem sum_gaps {n : ℕ} (hn : 2 ≤ n) :
+    ∑ k ∈ Finset.range (Nat.totient n - 1), gap n hn k = (n : ℝ) - 2 := by
+  have htel : ∑ k ∈ Finset.range (Nat.totient n - 1), (E n hn (k + 1) - E n hn k)
+      = E n hn (Nat.totient n - 1) - E n hn 0 :=
+    Finset.sum_range_sub (E n hn) (Nat.totient n - 1)
+  calc ∑ k ∈ Finset.range (Nat.totient n - 1), gap n hn k
+      = ∑ k ∈ Finset.range (Nat.totient n - 1), (E n hn (k + 1) - E n hn k) := by
+        simp only [gap]
+    _ = E n hn (Nat.totient n - 1) - E n hn 0 := htel
+    _ = ((n : ℝ) - 1) - 1 := by rw [E_last hn, E_zero hn]
+    _ = (n : ℝ) - 2 := by ring
+
+/-!
+## Part V: The lower bound (main result)
+-/
+
+/-- **Cauchy–Schwarz lower bound (product form).**
+
+    (n - 2)² ≤ (φ(n) - 1) · ∑ (a_{k+1} - a_k)².
+
+Together with the Montgomery–Vaughan upper bound `∑ (a_{k+1}-a_k)² ≪ n²/φ(n)`
+this pins the order of magnitude of the squared-gap sum. -/
+theorem sq_le_card_mul_sumSq {n : ℕ} (hn : 2 ≤ n) :
+    ((n : ℝ) - 2) ^ 2
+      ≤ (Nat.totient n - 1 : ℕ) * ∑ k ∈ Finset.range (Nat.totient n - 1), (gap n hn k) ^ 2 := by
+  have hcheb := sq_sum_le_card_mul_sum_sq
+    (s := Finset.range (Nat.totient n - 1)) (f := gap n hn)
+  rw [sum_gaps hn, Finset.card_range] at hcheb
+  exact hcheb
+
+/-- **Matching lower bound (division form).**
+
+    (n - 2)²/(φ(n) - 1) ≤ ∑ (a_{k+1} - a_k)².
+
+For `n ≥ 3` the denominator `φ(n) - 1 ≥ 1` is positive, so dividing the product
+form is legitimate.  Since `(n-2)²/(φ(n)-1) ≍ n²/φ(n)`, this is the lower-bound
+companion of Montgomery–Vaughan, establishing
+    ∑ (a_{k+1} - a_k)² ≍ n²/φ(n). -/
+theorem sumSquaredGaps_lower_bound {n : ℕ} (hn : 3 ≤ n) :
+    ((n : ℝ) - 2) ^ 2 / (Nat.totient n - 1 : ℕ)
+      ≤ ∑ k ∈ Finset.range (Nat.totient n - 1), (gap n (show 2 ≤ n by omega) k) ^ 2 := by
+  have hn2 : 2 ≤ n := by omega
+  have hφ : 2 ≤ Nat.totient n := by
+    have hpos := totient_pos' hn2
+    have hne1 : Nat.totient n ≠ 1 := by
+      intro h
+      rcases Nat.totient_eq_one_iff.mp h with h1 | h2 <;> omega
+    omega
+  have hden : (0 : ℝ) < (Nat.totient n - 1 : ℕ) := by
+    have h1 : 1 ≤ Nat.totient n - 1 := by omega
+    exact_mod_cast h1
+  rw [div_le_iff₀ hden]
+  have hprod := sq_le_card_mul_sumSq hn2
+  rw [mul_comm] at hprod
+  exact hprod
+
+end Erdos220OQ01

--- a/src/data/proofs/erdos-220-oq-01/annotations.json
+++ b/src/data/proofs/erdos-220-oq-01/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "ann-erdos220oq01-context",
+    "proofId": "erdos-220-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "The easy lower half of Erdős #220",
+    "content": "Erdős Problem #220 asks whether ∑(a_{k+1} − a_k)² ≪ n²/φ(n) for the reduced residues a₁ < ⋯ < a_{φ(n)} mod n. The hard direction is the UPPER bound, proved by Montgomery and Vaughan (1986) and axiomatized in the parent entry. This file proves the complementary, entirely elementary LOWER bound ∑(a_{k+1} − a_k)² ≥ (n−2)²/(φ(n)−1). Because (n−2)²/(φ(n)−1) and n²/φ(n) have the same order of magnitude, the two bounds pin the squared-gap sum: ∑(a_{k+1} − a_k)² ≍ n²/φ(n). The parent's Part VI/VII comments asserted the matching lower behaviour ('if all gaps were average the squared sum would be exactly n²/φ(n)') but never proved it.",
+    "mathContext": "$\\sum_k (a_{k+1}-a_k)^2 \\ge \\dfrac{(n-2)^2}{\\varphi(n)-1} \\asymp \\dfrac{n^2}{\\varphi(n)}$, matching Montgomery–Vaughan from below."
+  },
+  {
+    "id": "ann-erdos220oq01-card",
+    "proofId": "erdos-220-oq-01",
+    "range": { "startLine": 48, "endLine": 82 },
+    "type": "key-step",
+    "title": "Counting the reduced residues: card = φ(n)",
+    "content": "reducedResidues n is the integers m ∈ [1, n−1] with gcd(m,n) = 1. card_reducedResidues identifies its cardinality with Mathlib's Nat.totient via Nat.totient_eq_card_coprime and Finset.filter_congr: the two filters over range n differ only in the predicate, and the discrepancy at m = 0 vanishes because gcd(0,n) = n ≠ 1 for n ≥ 2 (Nat.coprime_zero_right). For all m ≥ 1 the clause `1 ≤ m` is automatic and coprimality is symmetric (Nat.coprime_comm). The parent entry left the analogous card statement as a `sorry`.",
+    "mathContext": "$\\#\\{1\\le m<n: \\gcd(m,n)=1\\} = \\varphi(n)$ for $n\\ge 2$."
+  },
+  {
+    "id": "ann-erdos220oq01-endpoints",
+    "proofId": "erdos-220-oq-01",
+    "range": { "startLine": 84, "endLine": 119 },
+    "type": "key-step",
+    "title": "The extreme reduced residues are 1 and n − 1",
+    "content": "Both 1 and n − 1 are coprime to n: gcd(1,n) = 1 trivially, and gcd(n−1, n) = gcd(n−1, 1) = 1 (coprime_pred_self, derived from Nat.coprime_add_self_left). Since every reduced residue lies in [1, n−1], the minimum is 1 and the maximum is n − 1, proved by le_antisymm against Finset.min'_le / le_min' and max'_le / le_max'. These lemmas are stated for an arbitrary nonemptiness witness H, so they rewrite cleanly regardless of how the witness is produced downstream.",
+    "mathContext": "$a_1 = \\min = 1$ and $a_{\\varphi(n)} = \\max = n-1$."
+  },
+  {
+    "id": "ann-erdos220oq01-enum",
+    "proofId": "erdos-220-oq-01",
+    "range": { "startLine": 120, "endLine": 149 },
+    "type": "technique",
+    "title": "Enumerating a sorted finset with orderEmbOfFin",
+    "content": "Rather than manipulate Finset.sort directly, the k-th reduced residue is read off Mathlib's Finset.orderEmbOfFin — the strictly monotone order embedding Fin (s.card) ↪o ℕ of the sorted set. E n k casts this to ℝ, padding with 0 for k ≥ φ(n) so the value is a total function ℕ → ℝ. The endpoint lemmas orderEmbOfFin_zero (= min') and orderEmbOfFin_last (= max') then give E 0 = 1 and E (φ(n)−1) = n − 1 directly, without any low-level list reasoning.",
+    "mathContext": "$E(k)$ is the order-isomorphic image of $k$, so $E(0)=\\min=1$ and $E(\\varphi(n)-1)=\\max=n-1$."
+  },
+  {
+    "id": "ann-erdos220oq01-telescope",
+    "proofId": "erdos-220-oq-01",
+    "range": { "startLine": 150, "endLine": 167 },
+    "type": "key-step",
+    "title": "The gaps telescope to n − 2",
+    "content": "gap n k = E n (k+1) − E n k. Summing over k < φ(n) − 1, Finset.sum_range_sub (the additive-group telescoping lemma ∑(f(i+1) − f i) = f n − f 0) collapses the sum to E(φ(n)−1) − E(0) = (n−1) − 1 = n − 2. This is the total feeding Cauchy–Schwarz. Working over ℝ (not truncated ℕ subtraction) is what makes the group telescoping lemma applicable.",
+    "mathContext": "$\\sum_{k} (a_{k+1}-a_k) = a_{\\varphi(n)} - a_1 = (n-1) - 1 = n - 2$."
+  },
+  {
+    "id": "ann-erdos220oq01-bound",
+    "proofId": "erdos-220-oq-01",
+    "range": { "startLine": 168, "endLine": 212 },
+    "type": "key-step",
+    "title": "Cauchy–Schwarz closes the lower bound",
+    "content": "Chebyshev's special case sq_sum_le_card_mul_sum_sq gives (∑ gap)² ≤ (#gaps)·∑ gap². With #gaps = φ(n) − 1 (Finset.card_range) and ∑ gap = n − 2 (sum_gaps), this is exactly (n−2)² ≤ (φ(n)−1)·∑ gap² (sq_le_card_mul_sumSq, division-free). The headline sumSquaredGaps_lower_bound then divides through: for n ≥ 3, φ(n) ≥ 2 (Nat.totient_eq_one_iff rules out φ(n) = 1), so the denominator φ(n) − 1 is positive and div_le_iff₀ applies.",
+    "mathContext": "$(\\sum g_i)^2 \\le m\\sum g_i^2$ with $m=\\varphi(n)-1$ and $\\sum g_i = n-2$ gives $\\sum g_i^2 \\ge \\dfrac{(n-2)^2}{\\varphi(n)-1}$."
+  }
+]

--- a/src/data/proofs/erdos-220-oq-01/meta.json
+++ b/src/data/proofs/erdos-220-oq-01/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "erdos-220-oq-01",
+  "slug": "erdos-220-oq-01",
+  "title": "Erdős #220: A Matching Lower Bound for Squared Gaps Between Reduced Residues",
+  "description": "A complementary, axiom-free LOWER bound for the squared-gap sum of Erdős Problem #220. For n ≥ 3, with 1 = a₁ < ⋯ < a_{φ(n)} = n-1 the reduced residues mod n, the φ(n)-1 consecutive gaps telescope to a₍φ(n)₎ − a₁ = n − 2, and the Cauchy–Schwarz / Chebyshev inequality (∑gᵢ)² ≤ (φ(n)−1)·∑gᵢ² gives ∑(a_{k+1}−a_k)² ≥ (n−2)²/(φ(n)−1). Since (n−2)²/(φ(n)−1) ≍ n²/φ(n), this matches the Montgomery–Vaughan upper bound (which the parent entry axiomatizes) in order of magnitude, establishing ∑(a_{k+1}−a_k)² ≍ n²/φ(n).",
+  "meta": {
+    "author": "Lean Genius Researcher-8",
+    "sourceUrl": "https://erdosproblems.com/220",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos220OQ01.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "reduced-residues",
+      "totient",
+      "gaps",
+      "cauchy-schwarz",
+      "chebyshev"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 212,
+    "theoremCount": 13,
+    "definitionCount": 3,
+    "erdosNumber": 220,
+    "erdosUrl": "https://erdosproblems.com/220",
+    "erdosProblemStatus": "solved",
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. The enumeration of reduced residues uses Mathlib's `Finset.orderEmbOfFin` (strictly monotone enumeration of a sorted finite set); the telescoping identity uses `Finset.sum_range_sub`; the extremal inequality is Mathlib's `sq_sum_le_card_mul_sum_sq` (Chebyshev/Cauchy–Schwarz). Depends only on the standard foundational axioms propext / Classical.choice / Quot.sound. The hard Montgomery–Vaughan UPPER bound is NOT used or assumed here — this entry proves only the elementary matching lower half.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.totient_eq_card_coprime",
+        "description": "φ(n) = #{a ∈ range n | n.Coprime a}",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Finset.orderEmbOfFin",
+        "description": "Strictly monotone enumeration Fin (s.card) ↪o α of a finite set, with orderEmbOfFin_zero = min', orderEmbOfFin_last = max'",
+        "module": "Mathlib.Data.Finset.Sort"
+      },
+      {
+        "theorem": "Finset.sum_range_sub",
+        "description": "Telescoping: ∑_{i<n} (f(i+1) − f i) = f n − f 0 over an additive group",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "sq_sum_le_card_mul_sum_sq",
+        "description": "Chebyshev / Cauchy–Schwarz: (∑ f)² ≤ #s · ∑ f²",
+        "module": "Mathlib.Algebra.Order.Chebyshev"
+      },
+      {
+        "theorem": "Nat.totient_eq_one_iff",
+        "description": "φ(n) = 1 ↔ n = 1 ∨ n = 2 (used to get φ(n) ≥ 2 for n ≥ 3)",
+        "module": "Mathlib.Data.Nat.Totient"
+      }
+    ],
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Data.Nat.Totient",
+      "Mathlib.Data.Finset.Sort",
+      "Mathlib.Algebra.Order.Chebyshev",
+      "Mathlib.Algebra.BigOperators.Group.Finset.Basic",
+      "Mathlib.Data.Real.Basic"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "Erdos220OQ01",
+    "lineCount": 212,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos220OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "sumSquaredGaps_lower_bound",
+      "type": "headline",
+      "statement": "3 ≤ n → (n − 2)² / (φ(n) − 1) ≤ ∑_{k < φ(n)−1} (a_{k+1} − a_k)²",
+      "description": "The matching lower bound for the squared-gap sum, in division form. For n ≥ 3 the denominator φ(n) − 1 ≥ 1 is positive.",
+      "significance": "Companion of the axiomatized Montgomery–Vaughan upper bound. Since (n−2)²/(φ(n)−1) ≍ n²/φ(n), the two together show ∑(a_{k+1}−a_k)² ≍ n²/φ(n): the MV bound is tight in order."
+    },
+    {
+      "name": "sq_le_card_mul_sumSq",
+      "type": "core",
+      "statement": "2 ≤ n → (n − 2)² ≤ (φ(n) − 1) · ∑_{k < φ(n)−1} (a_{k+1} − a_k)²",
+      "description": "Product form of the lower bound, obtained from Chebyshev/Cauchy–Schwarz applied to the φ(n)−1 gaps together with the telescoping identity ∑ gap = n − 2.",
+      "significance": "The division-free heart of the result; avoids any positivity hypothesis on the totient."
+    },
+    {
+      "name": "sum_gaps",
+      "type": "core",
+      "statement": "2 ≤ n → ∑_{k < φ(n)−1} (a_{k+1} − a_k) = n − 2",
+      "description": "Telescoping identity: the consecutive gaps between reduced residues sum to a_{φ(n)} − a₁ = (n−1) − 1 = n − 2.",
+      "significance": "Supplies the exact total ∑ gap fed into Cauchy–Schwarz; combines the endpoint computations a₁ = 1 and a_{φ(n)} = n − 1."
+    },
+    {
+      "name": "card_reducedResidues",
+      "type": "supporting",
+      "statement": "2 ≤ n → (reducedResidues n).card = φ(n)",
+      "description": "The reduced residues in [1, n−1] number exactly φ(n) for n ≥ 2 (the `1 ≤ m` clause only removes m = 0, which is already non-coprime to n).",
+      "significance": "Identifies the enumeration index set as Fin (φ(n)); the parent entry left the analogous statement as a `sorry`."
+    },
+    {
+      "name": "max'_reducedResidues",
+      "type": "supporting",
+      "statement": "2 ≤ n → (reducedResidues n).max' H = n − 1",
+      "description": "The greatest reduced residue is n − 1, since gcd(n−1, n) = 1 and every reduced residue is < n.",
+      "significance": "Right endpoint a_{φ(n)} = n − 1 of the telescoping sum (paired with min' = 1)."
+    }
+  ],
+  "sections": [
+    {
+      "id": "reduced-residues",
+      "title": "Part I: Reduced residues and their cardinality",
+      "startLine": 48,
+      "endLine": 82,
+      "summary": "reducedResidues n = {1 ≤ m < n : gcd(m,n)=1}; membership simp lemma; card_reducedResidues (= φ(n) for n ≥ 2) via Nat.totient_eq_card_coprime + filter_congr; totient_pos'.",
+      "mathContext": "The φ(n) reduced residues are the integers of [1, n−1] coprime to n. The `1 ≤ m` constraint differs from Mathlib's totient filter only at m = 0, which is non-coprime to any n ≥ 2, so the cardinalities agree."
+    },
+    {
+      "id": "endpoints",
+      "title": "Part II: Endpoints of the enumeration",
+      "startLine": 84,
+      "endLine": 119,
+      "summary": "coprime_pred_self (gcd(n−1,n)=1); 1 and n−1 are reduced residues; min'_reducedResidues = 1; max'_reducedResidues = n−1, each proved for an arbitrary nonemptiness witness.",
+      "mathContext": "Since every reduced residue lies in [1, n−1] and both endpoints 1 and n−1 are coprime to n, the least reduced residue is a₁ = 1 and the greatest is a_{φ(n)} = n − 1."
+    },
+    {
+      "id": "enumeration-gaps",
+      "title": "Part III: The enumeration E and the gaps",
+      "startLine": 120,
+      "endLine": 149,
+      "summary": "E n k = the k-th reduced residue as a real (junk 0 for k ≥ φ(n)) via Finset.orderEmbOfFin; gap n k = E n (k+1) − E n k; E_zero = 1 and E_last = n − 1 from orderEmbOfFin_zero/last = min'/max'.",
+      "mathContext": "orderEmbOfFin gives the strictly increasing enumeration a₀ < a₁ < ⋯ of the sorted finite set, with a₀ = min' and a_{φ(n)−1} = max'. Padding with 0 outside the range makes the telescoping sum convenient to state over ℝ."
+    },
+    {
+      "id": "telescoping",
+      "title": "Part IV: The gaps telescope to n − 2",
+      "startLine": 150,
+      "endLine": 167,
+      "summary": "sum_gaps: ∑_{k<φ(n)−1} gap k = E(φ(n)−1) − E 0 = (n−1) − 1 = n − 2 via Finset.sum_range_sub and the endpoint values.",
+      "mathContext": "A telescoping sum: ∑(a_{k+1} − a_k) collapses to the difference of the extreme reduced residues, (n−1) − 1 = n − 2."
+    },
+    {
+      "id": "lower-bound",
+      "title": "Part V: The matching lower bound",
+      "startLine": 168,
+      "endLine": 212,
+      "summary": "sq_le_card_mul_sumSq: Chebyshev (∑ gap)² ≤ (φ(n)−1)·∑ gap² with ∑ gap = n−2 gives (n−2)² ≤ (φ(n)−1)·∑ gap². sumSquaredGaps_lower_bound divides through, using φ(n) ≥ 2 (from totient_eq_one_iff) for n ≥ 3.",
+      "mathContext": "Among φ(n)−1 nonnegative reals with fixed sum n−2, the sum of squares is minimized when all are equal, giving ∑ gap² ≥ (n−2)²/(φ(n)−1) ≍ n²/φ(n). This is the lower-bound companion to Montgomery–Vaughan."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A complementary, **axiom-free lower bound** for **Erdős Problem #220** (squared gaps between reduced residues), companion to the parent entry's axiomatized Montgomery–Vaughan upper bound.

Let `n ≥ 3` and let `1 = a₁ < a₂ < ⋯ < a_{φ(n)} = n-1` be the reduced residues mod `n`. Montgomery–Vaughan (1986) proved the hard **upper** bound `∑(a_{k+1}-a_k)² ≪ n²/φ(n)` (the parent `Erdos220Problem.lean` states it as an axiom). This PR supplies the easy **lower** bound, which the parent only gestured at in comments:

```
∑(a_{k+1} - a_k)²  ≥  (n-2)² / (φ(n) - 1)   ≍   n²/φ(n).
```

Since `(n-2)²/(φ(n)-1) ≍ n²/φ(n)`, the two bounds together pin the order of magnitude:
**`∑(a_{k+1}-a_k)² ≍ n²/φ(n)`** — Montgomery–Vaughan is tight in order.

## Mechanism (elementary, self-contained)

1. **Endpoints + telescoping** (`sum_gaps`): the `φ(n)-1` gaps telescope, `∑ gap = a_{φ(n)} - a₁ = (n-1) - 1 = n-2`, via `Finset.sum_range_sub` and `orderEmbOfFin_zero/last` (`= min'/max' = 1` and `n-1`).
2. **Cauchy–Schwarz / Chebyshev** (`sq_le_card_mul_sumSq`): `(∑ gap)² ≤ (φ(n)-1)·∑ gap²` from `sq_sum_le_card_mul_sum_sq`, giving `(n-2)² ≤ (φ(n)-1)·∑ gap²`.
3. **Divide** (`sumSquaredGaps_lower_bound`): for `n ≥ 3`, `φ(n) ≥ 2` (via `Nat.totient_eq_one_iff`), so the denominator is positive.

As a byproduct, `card_reducedResidues` proves `#{1 ≤ m < n : gcd(m,n)=1} = φ(n)` for `n ≥ 2` — a statement the parent entry left as a `sorry`.

## Verification

- `Proofs/Erdos220OQ01.lean` — **212 lines, 13 theorems, 3 definitions**.
- **0 axioms, 0 sorries, no `native_decide`.** `#print axioms sumSquaredGaps_lower_bound` → `[propext, Classical.choice, Quot.sound]` only.
- Builds under the Docker wrapper against Mathlib 4.26.0.

## Gallery

- `src/data/proofs/erdos-220-oq-01/{meta.json,annotations.json}` (status `verified`, badge `original`).
- Registered in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)