### PR TITLE
research(derangements-convergence-oq-02): sign of error + sharp two-sided bracketing of 1/e

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -732,6 +732,7 @@ import Proofs.Derangements
 import Proofs.DerangementsConvergence
 import Proofs.DerangementsConvergenceOQ01
 import Proofs.DerangementsConvergenceOQ01OQ01
+import Proofs.DerangementsConvergenceOQ02
 import Proofs.DerangementsConvergenceOQ03
 import Proofs.DerangementsOQ02
 import Proofs.DerangementsOQ02OQ01

--- a/proofs/Proofs/DerangementsConvergenceOQ02.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ02.lean
@@ -1,0 +1,239 @@
+/-
+# Derangements: the sign of the error and sharp two-sided bracketing of 1/e
+
+Open Question: derangements-convergence-oq-02
+
+The parent file `DerangementsConvergence.lean` proves the *magnitude* of the
+approximation error:
+  |D(n)/n! - e⁻¹| ≤ 1/(n+1)!.
+
+This file pins down the *sign* of that error and the resulting sharp two-sided
+bracketing of 1/e by consecutive derangement ratios.  Writing
+  a(n) = D(n)/n! = ∑_{k=0}^n (-1)^k/k!   (the n-th partial sum of e⁻¹),
+the alternating structure forces:
+
+  * even partial sums lie strictly **above** e⁻¹,
+  * odd partial sums lie strictly **below** e⁻¹,
+
+so 1/e is *bracketed*:  a(2k+1) < e⁻¹ < a(2k).  The even-indexed ratios form a
+strictly decreasing sequence and the odd-indexed ratios a strictly increasing
+one, both converging to e⁻¹; these are *nested intervals* of exact width
+a(2k) - a(2k+1) = 1/(2k+1)! shrinking to 0.
+
+This is strictly more information than the parent's one-sided rate bound: it
+gives the exact sign of D(n)/n! - e⁻¹ for every n, not merely its size.
+
+## Main Results
+
+- `ratio_even_gt`     : e⁻¹ < a(2k)                          (even ratios above)
+- `ratio_odd_lt`      : a(2k+1) < e⁻¹                         (odd ratios below)
+- `numDerangements_bracket` : a(2k+1) < e⁻¹ < a(2k)          (two-sided bracket)
+- `aSeq_error_sign`   : 0 < (-1)^n · (a(n) - e⁻¹)            (exact sign, unified)
+- `numDerangements_error_sign` : same, in D(n)/n! form
+- `consecutive_error_opposite` : (a(n)-e⁻¹)·(a(n+1)-e⁻¹) < 0 (signs alternate)
+- `nested_interval_width` : a(2k) - a(2k+1) = 1/(2k+1)!      (exact nesting width)
+- `numDerangements_gt_of_even` : n!·e⁻¹ < D(n)   for even n
+- `numDerangements_lt_of_odd`  : D(n) < n!·e⁻¹   for odd  n
+
+All results are fully machine-checked: no `sorry`, no `axiom` declarations, and
+no structure-encoded assumptions (only Lean/Mathlib's foundational
+`propext` / `Classical.choice` / `Quot.sound`).
+
+## References
+
+- Montmort (1708), Euler (1751) — derangement numbers
+- Leibniz alternating series estimation (sign of the remainder)
+-/
+
+import Proofs.DerangementsConvergence
+import Mathlib.Tactic
+
+open Nat Real Filter Topology
+
+noncomputable section
+
+namespace DerangementsConvergenceOQ02
+
+/- ## §1. Sign of the alternating terms -/
+
+lemma altFactTerm_of_even {m : ℕ} (h : Even m) :
+    altFactTerm m = 1 / (m.factorial : ℝ) := by
+  simp only [altFactTerm]
+  rw [h.neg_one_pow]
+
+lemma altFactTerm_of_odd {m : ℕ} (h : Odd m) :
+    altFactTerm m = -(1 / (m.factorial : ℝ)) := by
+  simp only [altFactTerm]
+  rw [h.neg_one_pow]
+  ring
+
+/- ## §2. The two-step recurrence and strict monotonicity of subsequences -/
+
+/-- Stepping the partial sum by two adds two consecutive alternating terms. -/
+lemma aSeq_add_two (n : ℕ) :
+    altFactPartialSum (n + 2) =
+      altFactPartialSum n + altFactTerm (n + 1) + altFactTerm (n + 2) := by
+  have h1 := altFactPartialSum_succ (n + 1)
+  rw [altFactPartialSum_succ n] at h1
+  exact h1
+
+/-- The even-indexed ratios strictly decrease: a(2k+2) < a(2k). -/
+lemma aSeq_even_step (k : ℕ) :
+    altFactPartialSum (2 * k + 2) < altFactPartialSum (2 * k) := by
+  rw [aSeq_add_two]
+  rw [altFactTerm_of_odd (show Odd (2 * k + 1) from ⟨k, by ring⟩),
+      altFactTerm_of_even (show Even (2 * k + 2) from ⟨k + 1, by ring⟩)]
+  have hfac : ((2 * k + 1).factorial : ℝ) < ((2 * k + 2).factorial : ℝ) := by
+    exact_mod_cast (Nat.factorial_lt (by omega)).mpr (by omega)
+  have h1 : (1 : ℝ) / ((2 * k + 2).factorial : ℝ) < 1 / ((2 * k + 1).factorial : ℝ) :=
+    one_div_lt_one_div_of_lt (factorial_cast_pos' (2 * k + 1)) hfac
+  linarith
+
+/-- The odd-indexed ratios strictly increase: a(2k+1) < a(2k+3). -/
+lemma aSeq_odd_step (k : ℕ) :
+    altFactPartialSum (2 * k + 1) < altFactPartialSum (2 * k + 3) := by
+  rw [show (2 * k + 3) = (2 * k + 1) + 2 by ring, aSeq_add_two]
+  rw [altFactTerm_of_even (show Even ((2 * k + 1) + 1) from ⟨k + 1, by ring⟩),
+      altFactTerm_of_odd (show Odd ((2 * k + 1) + 2) from ⟨k + 1, by ring⟩)]
+  have hfac : (((2 * k + 1) + 1).factorial : ℝ) < (((2 * k + 1) + 2).factorial : ℝ) := by
+    exact_mod_cast (Nat.factorial_lt (by omega)).mpr (by omega)
+  have h1 : (1 : ℝ) / (((2 * k + 1) + 2).factorial : ℝ)
+      < 1 / (((2 * k + 1) + 1).factorial : ℝ) :=
+    one_div_lt_one_div_of_lt (factorial_cast_pos' ((2 * k + 1) + 1)) hfac
+  linarith
+
+lemma aeven_strictAnti : StrictAnti (fun k => altFactPartialSum (2 * k)) :=
+  strictAnti_nat_of_succ_lt (fun k => by
+    have h := aSeq_even_step k
+    simpa [Nat.mul_succ] using h)
+
+lemma aodd_strictMono : StrictMono (fun k => altFactPartialSum (2 * k + 1)) :=
+  strictMono_nat_of_lt_succ (fun k => by
+    have h := aSeq_odd_step k
+    simpa [Nat.mul_succ] using h)
+
+/- ## §3. Both subsequences converge to e⁻¹ -/
+
+/-- The partial sums a(n) = D(n)/n! tend to e⁻¹ (restatement of the parent). -/
+lemma aSeq_tendsto :
+    Tendsto altFactPartialSum atTop (nhds (rexp (-1))) :=
+  derangements_tendsto_inv_e.congr (fun n => derangements_div_factorial n)
+
+lemma tendsto_two_mul : Tendsto (fun k : ℕ => 2 * k) atTop atTop :=
+  tendsto_atTop_mono (fun k => by simp only [id_eq]; omega) tendsto_id
+
+lemma tendsto_two_mul_add_one : Tendsto (fun k : ℕ => 2 * k + 1) atTop atTop :=
+  tendsto_atTop_mono (fun k => by simp only [id_eq]; omega) tendsto_id
+
+lemma aeven_tendsto :
+    Tendsto (fun k => altFactPartialSum (2 * k)) atTop (nhds (rexp (-1))) := by
+  have h := aSeq_tendsto.comp tendsto_two_mul
+  simpa [Function.comp] using h
+
+lemma aodd_tendsto :
+    Tendsto (fun k => altFactPartialSum (2 * k + 1)) atTop (nhds (rexp (-1))) := by
+  have h := aSeq_tendsto.comp tendsto_two_mul_add_one
+  simpa [Function.comp] using h
+
+/- ## §4. Strictly monotone convergent sequences stay on one side of the limit -/
+
+/-- A strictly decreasing sequence stays strictly above its limit. -/
+lemma lt_of_strictAnti_tendsto {f : ℕ → ℝ} {L : ℝ} (hf : StrictAnti f)
+    (hL : Tendsto f atTop (nhds L)) (n : ℕ) : L < f n := by
+  have h1 : L ≤ f (n + 1) :=
+    le_of_tendsto hL (eventually_atTop.mpr ⟨n + 1, fun m hm => hf.antitone hm⟩)
+  exact lt_of_le_of_lt h1 (hf (Nat.lt_succ_self n))
+
+/-- A strictly increasing sequence stays strictly below its limit. -/
+lemma gt_of_strictMono_tendsto {f : ℕ → ℝ} {L : ℝ} (hf : StrictMono f)
+    (hL : Tendsto f atTop (nhds L)) (n : ℕ) : f n < L := by
+  have h1 : f (n + 1) ≤ L :=
+    ge_of_tendsto hL (eventually_atTop.mpr ⟨n + 1, fun m hm => hf.monotone hm⟩)
+  exact lt_of_lt_of_le (hf (Nat.lt_succ_self n)) h1
+
+/- ## §5. Main bracketing results -/
+
+/-- Even-indexed derangement ratios lie strictly above 1/e. -/
+theorem ratio_even_gt (k : ℕ) : rexp (-1) < altFactPartialSum (2 * k) :=
+  lt_of_strictAnti_tendsto aeven_strictAnti aeven_tendsto k
+
+/-- Odd-indexed derangement ratios lie strictly below 1/e. -/
+theorem ratio_odd_lt (k : ℕ) : altFactPartialSum (2 * k + 1) < rexp (-1) :=
+  gt_of_strictMono_tendsto aodd_strictMono aodd_tendsto k
+
+/-- For even `n`, the ratio is above 1/e. -/
+theorem aSeq_gt_of_even {n : ℕ} (hn : Even n) :
+    rexp (-1) < altFactPartialSum n := by
+  obtain ⟨k, rfl⟩ := hn
+  rw [← two_mul]
+  exact ratio_even_gt k
+
+/-- For odd `n`, the ratio is below 1/e. -/
+theorem aSeq_lt_of_odd {n : ℕ} (hn : Odd n) :
+    altFactPartialSum n < rexp (-1) := by
+  obtain ⟨k, rfl⟩ := hn
+  exact ratio_odd_lt k
+
+/-- **Two-sided bracketing.** Consecutive derangement ratios straddle 1/e:
+    D(2k+1)/(2k+1)! < e⁻¹ < D(2k)/(2k)!. -/
+theorem numDerangements_bracket (k : ℕ) :
+    (numDerangements (2 * k + 1) : ℝ) / ((2 * k + 1).factorial : ℝ) < rexp (-1) ∧
+    rexp (-1) < (numDerangements (2 * k) : ℝ) / ((2 * k).factorial : ℝ) := by
+  rw [derangements_div_factorial, derangements_div_factorial]
+  exact ⟨ratio_odd_lt k, ratio_even_gt k⟩
+
+/-- **Exact sign of the error.** For every `n`,
+    `(-1)^n · (a(n) - e⁻¹) > 0`: the approximation error alternates in sign. -/
+theorem aSeq_error_sign (n : ℕ) :
+    0 < (-1 : ℝ) ^ n * (altFactPartialSum n - rexp (-1)) := by
+  rcases Nat.even_or_odd n with he | ho
+  · rw [he.neg_one_pow, one_mul, sub_pos]
+    exact aSeq_gt_of_even he
+  · rw [ho.neg_one_pow, neg_one_mul, neg_pos, sub_neg]
+    exact aSeq_lt_of_odd ho
+
+/-- The sign statement in terms of the derangement ratio D(n)/n!. -/
+theorem numDerangements_error_sign (n : ℕ) :
+    0 < (-1 : ℝ) ^ n *
+      ((numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1)) := by
+  rw [derangements_div_factorial]
+  exact aSeq_error_sign n
+
+/-- Consecutive errors have opposite signs, hence negative product. -/
+theorem consecutive_error_opposite (n : ℕ) :
+    (altFactPartialSum n - rexp (-1)) * (altFactPartialSum (n + 1) - rexp (-1)) < 0 := by
+  rcases Nat.even_or_odd n with he | ho
+  · exact mul_neg_of_pos_of_neg
+      (by linarith [aSeq_gt_of_even he])
+      (by linarith [aSeq_lt_of_odd he.add_one])
+  · exact mul_neg_of_neg_of_pos
+      (by linarith [aSeq_lt_of_odd ho])
+      (by linarith [aSeq_gt_of_even ho.add_one])
+
+/-- **Exact nesting width.** The bracketing interval [a(2k+1), a(2k)] has width
+    exactly 1/(2k+1)!, which shrinks to 0. -/
+theorem nested_interval_width (k : ℕ) :
+    altFactPartialSum (2 * k) - altFactPartialSum (2 * k + 1)
+      = 1 / ((2 * k + 1).factorial : ℝ) := by
+  rw [altFactPartialSum_succ, altFactTerm_of_odd (show Odd (2 * k + 1) from ⟨k, by ring⟩)]
+  ring
+
+/- ## §6. Integer-side corollaries -/
+
+/-- For even `n`, the derangement count exceeds n!/e. -/
+theorem numDerangements_gt_of_even {n : ℕ} (hn : Even n) :
+    (n.factorial : ℝ) * rexp (-1) < (numDerangements n : ℝ) := by
+  have h := aSeq_gt_of_even hn
+  rw [← derangements_div_factorial, lt_div_iff₀ (factorial_cast_pos' n)] at h
+  rw [mul_comm]
+  exact h
+
+/-- For odd `n`, the derangement count is below n!/e. -/
+theorem numDerangements_lt_of_odd {n : ℕ} (hn : Odd n) :
+    (numDerangements n : ℝ) < (n.factorial : ℝ) * rexp (-1) := by
+  have h := aSeq_lt_of_odd hn
+  rw [← derangements_div_factorial, div_lt_iff₀ (factorial_cast_pos' n)] at h
+  rw [mul_comm]
+  exact h
+
+end DerangementsConvergenceOQ02

--- a/src/data/proofs/derangements-convergence-oq-02/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-02/annotations.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "ann-dcoq02-header",
+    "proofId": "derangements-convergence-oq-02",
+    "range": { "startLine": 1, "endLine": 57 },
+    "type": "concept",
+    "title": "Module Overview: Sign of the Error and Two-Sided Bracketing of 1/e",
+    "content": "The parent file proves only the magnitude of the approximation error, |D(n)/n! - e⁻¹| ≤ 1/(n+1)!. This module determines the error's sign. Writing a(n) = D(n)/n! = ∑_{k≤n}(-1)^k/k!, the alternating structure forces even partial sums strictly above e⁻¹ and odd ones strictly below, so consecutive derangement ratios bracket 1/e. The headline is the unified sign law (-1)^n·(D(n)/n! - e⁻¹) > 0 and the bracket D(2k+1)/(2k+1)! < e⁻¹ < D(2k)/(2k)!.",
+    "mathContext": "For an alternating series $\\sum (-1)^k c_k$ with $c_k$ strictly decreasing to $0$, the partial sums oscillate around the limit: even-indexed from above, odd-indexed from below. Here $c_k = 1/k!$ and the limit is $e^{-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["numDerangements", "altFactPartialSum", "alternating series", "e-constant"]
+  },
+  {
+    "id": "ann-dcoq02-signs",
+    "proofId": "derangements-convergence-oq-02",
+    "range": { "startLine": 58, "endLine": 70 },
+    "type": "technique",
+    "title": "Parity Determines the Sign of Each Taylor Term",
+    "content": "altFactTerm_of_even and altFactTerm_of_odd compute the k-th term (-1)^k/k! as +1/k! or -(1/k!) using Even.neg_one_pow and Odd.neg_one_pow. Producing the odd term as -(1/k!) rather than (-1)/k! is deliberate: it lets later linarith calls relate it to the positive quantity 1/k!.",
+    "mathContext": "$(-1)^k = 1$ when $k$ is even and $-1$ when $k$ is odd, so the $k$-th Taylor coefficient of $e^{-1}$ has sign $(-1)^k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Even.neg_one_pow", "Odd.neg_one_pow"]
+  },
+  {
+    "id": "ann-dcoq02-monotone",
+    "proofId": "derangements-convergence-oq-02",
+    "range": { "startLine": 71, "endLine": 114 },
+    "type": "technique",
+    "title": "Pairing Two Steps Makes the Even/Odd Subsequences Strictly Monotone",
+    "content": "aSeq_add_two expresses a(n+2) - a(n) as the sum of two consecutive alternating terms. At an even index this sum is 1/(2k+2)! - 1/(2k+1)! < 0 (even ratios decrease); at an odd index it is 1/(2k+2)! - 1/(2k+3)! > 0 (odd ratios increase). The strictness comes from Nat.factorial_lt. strictAnti_nat_of_succ_lt / strictMono_nat_of_lt_succ then upgrade the one-step facts to monotonicity of the whole subsequence.",
+    "mathContext": "Within an alternating series of strictly decreasing terms, $S_{n+2} - S_n = (-1)^{n+1}c_{n+1} + (-1)^{n+2}c_{n+2}$ has the sign of $(-1)^{n+1}$ because $c_{n+1} > c_{n+2}$.",
+    "significance": "key",
+    "relatedConcepts": ["strictAnti_nat_of_succ_lt", "strictMono_nat_of_lt_succ", "Nat.factorial_lt"]
+  },
+  {
+    "id": "ann-dcoq02-converge",
+    "proofId": "derangements-convergence-oq-02",
+    "range": { "startLine": 115, "endLine": 138 },
+    "type": "technique",
+    "title": "Both Subsequences Inherit the Limit 1/e",
+    "content": "aSeq_tendsto restates the parent's limit D(n)/n! → e⁻¹ for the partial-sum function. Composing with k ↦ 2k and k ↦ 2k+1 (which tend to infinity) gives that the even- and odd-indexed subsequences both converge to e⁻¹.",
+    "mathContext": "Every subsequence of a convergent sequence converges to the same limit; here both $a(2k)$ and $a(2k+1)$ tend to $e^{-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Filter.Tendsto.comp", "derangements_tendsto_inv_e"]
+  },
+  {
+    "id": "ann-dcoq02-onesided",
+    "proofId": "derangements-convergence-oq-02",
+    "range": { "startLine": 139, "endLine": 154 },
+    "type": "technique",
+    "title": "A Strictly Monotone Convergent Sequence Never Reaches Its Limit",
+    "content": "lt_of_strictAnti_tendsto and gt_of_strictMono_tendsto are the crux: a strictly decreasing sequence converging to L has every term strictly above L (its successor is already ≥ L by le_of_tendsto, and the term is strictly larger than its successor). This yields strictness in the bracket for free, avoiding any tail estimate.",
+    "mathContext": "If $x$ is strictly antitone and $x_n \\to L$, then $L \\le x_{n+1} < x_n$, hence $x_n > L$. Symmetrically for strictly monotone sequences.",
+    "significance": "key",
+    "relatedConcepts": ["le_of_tendsto", "ge_of_tendsto", "StrictAnti", "StrictMono"]
+  },
+  {
+    "id": "ann-dcoq02-main",
+    "proofId": "derangements-convergence-oq-02",
+    "range": { "startLine": 155, "endLine": 213 },
+    "type": "key_step",
+    "title": "Two-Sided Bracketing, Unified Sign Law, and Exact Nesting Width",
+    "content": "Combining monotonicity with the shared limit gives e⁻¹ < a(2k) and a(2k+1) < e⁻¹ (ratio_even_gt, ratio_odd_lt), hence the bracket numDerangements_bracket. Casing on the parity of n yields the unified sign law numDerangements_error_sign: (-1)^n·(D(n)/n! - e⁻¹) > 0, and the opposite-sign product consecutive_error_opposite. nested_interval_width pins the bracket width to exactly 1/(2k+1)!.",
+    "mathContext": "$D(2k+1)/(2k+1)! < e^{-1} < D(2k)/(2k)!$ with gap $a(2k) - a(2k+1) = 1/(2k+1)!$: a nested-interval construction of $e^{-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["numDerangements_bracket", "nested intervals", "alternating series estimation"]
+  },
+  {
+    "id": "ann-dcoq02-integer",
+    "proofId": "derangements-convergence-oq-02",
+    "range": { "startLine": 214, "endLine": 239 },
+    "type": "concept",
+    "title": "Integer-Side Corollaries: Each D(n) Sits Strictly on One Side of n!/e",
+    "content": "Clearing the positive denominator n! from the ratio bounds gives numDerangements_gt_of_even (D(n) > n!·e⁻¹ for even n) and numDerangements_lt_of_odd (D(n) < n!·e⁻¹ for odd n) — the signed refinement of the sibling's |D(n) - n!/e| < 1/2 rounding bound.",
+    "mathContext": "Multiplying $D(n)/n! \\gtrless e^{-1}$ by $n! > 0$ locates $D(n)$ above (even $n$) or below (odd $n$) $n!/e$.",
+    "significance": "supporting",
+    "relatedConcepts": ["lt_div_iff₀", "div_lt_iff₀", "n!/e rounding"]
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-02/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-02/meta.json
@@ -1,0 +1,231 @@
+{
+  "id": "derangements-convergence-oq-02",
+  "title": "The sign of the derangement error and sharp two-sided bracketing of 1/e",
+  "slug": "derangements-convergence-oq-02",
+  "description": "Refines the parent's magnitude bound |D(n)/n! - e⁻¹| ≤ 1/(n+1)! by pinning down the exact sign of the error: even partial sums D(2k)/(2k)! lie strictly above 1/e and odd ones D(2k+1)/(2k+1)! strictly below, so consecutive derangement ratios bracket 1/e in nested intervals of exact width 1/(2k+1)!. Unified sign law: (-1)^n·(D(n)/n! - e⁻¹) > 0 for every n.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ02.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "probability",
+      "e-constant",
+      "convergence",
+      "alternating-series",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. Fully machine-checked with only Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). Builds on the parent file DerangementsConvergence.lean (the alternating partial-sum representation D(n)/n! = ∑_{k≤n}(-1)^k/k! and the limit D(n)/n! → e⁻¹); the sign/bracketing content is derived here by elementary monotone-subsequence arguments.",
+    "dateAdded": "2026-06-21",
+    "lineCount": 239,
+    "theoremCount": 25,
+    "definitionCount": 0,
+    "originalContributions": [
+      "ratio_even_gt / ratio_odd_lt (PROVED): the even-indexed ratios D(2k)/(2k)! are strictly > e⁻¹ and the odd-indexed ratios D(2k+1)/(2k+1)! strictly < e⁻¹ — the sign of the approximation error, which the parent's |·| bound discards",
+      "numDerangements_bracket (PROVED): sharp two-sided bracket D(2k+1)/(2k+1)! < e⁻¹ < D(2k)/(2k)! — 1/e is trapped between consecutive derangement ratios",
+      "aSeq_error_sign / numDerangements_error_sign (PROVED): the unified sign law 0 < (-1)^n·(D(n)/n! - e⁻¹) for every n — the error alternates in sign with n",
+      "consecutive_error_opposite (PROVED): (a(n)-e⁻¹)·(a(n+1)-e⁻¹) < 0 — consecutive errors always have opposite signs",
+      "nested_interval_width (PROVED): the bracketing interval [a(2k+1), a(2k)] has exact width a(2k) - a(2k+1) = 1/(2k+1)!, shrinking monotonically to 0 (nested intervals converging to e⁻¹)",
+      "numDerangements_gt_of_even / numDerangements_lt_of_odd (PROVED): the integer-side form — D(n) > n!·e⁻¹ for even n and D(n) < n!·e⁻¹ for odd n, locating each derangement count strictly on one side of n!/e"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "numDerangements",
+        "description": "The derangement counting function D(n) (permutations with no fixed point).",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "strictAnti_nat_of_succ_lt / strictMono_nat_of_lt_succ",
+        "description": "A sequence on ℕ is strictly monotone iff each term compares with its immediate successor — used to upgrade the one-step even/odd inequalities to monotone subsequences.",
+        "module": "Mathlib.Order.Monotone.Basic"
+      },
+      {
+        "theorem": "le_of_tendsto / ge_of_tendsto",
+        "description": "Order limits: a one-sided eventual bound on a convergent sequence passes to its limit — the mechanism by which a strictly antitone (resp. monotone) convergent sequence stays strictly above (resp. below) its limit.",
+        "module": "Mathlib.Topology.Order.Basic"
+      },
+      {
+        "theorem": "Nat.factorial_lt",
+        "description": "Strict monotonicity of the factorial, n! < m! ↔ n < m (for 0 < n) — gives 1/(m+1)! < 1/m! that drives the one-step inequalities.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The number of derangements D(n) satisfies D(n)/n! = ∑_{k=0}^n (-1)^k/k!, the n-th partial sum of the Taylor series for e⁻¹. This is one of the cleanest occurrences of e in combinatorics (Montmort 1708, Euler 1751). The parent entry derangements-convergence proves the classical magnitude estimate |D(n)/n! - e⁻¹| ≤ 1/(n+1)! via the alternating series test. But the alternating series test carries more information than magnitude: for a series with terms of strictly decreasing absolute value, the partial sums oscillate around the limit, the even ones from above and the odd ones from below, and the remainder always has the sign of its first omitted term. This entry extracts exactly that refinement for derangements.",
+    "problemStatement": "**OQ-02 of derangements-convergence**\n\nThe parent establishes |D(n)/n! - e⁻¹| ≤ 1/(n+1)!. Determine the *sign* of D(n)/n! - e⁻¹ and the resulting two-sided localization of 1/e by the derangement ratios.",
+    "text": "For every k: D(2k+1)/(2k+1)! < e⁻¹ < D(2k)/(2k)!, and uniformly 0 < (-1)^n·(D(n)/n! - e⁻¹); the brackets are nested intervals of exact width 1/(2k+1)!.",
+    "proofStrategy": "Work with a(n) = D(n)/n! = altFactPartialSum n (the parent's representation). The one-step recurrence a(n+1) = a(n) + (-1)^(n+1)/(n+1)! gives, on pairing two steps, that the even-indexed subsequence k ↦ a(2k) is strictly decreasing and the odd-indexed subsequence k ↦ a(2k+1) strictly increasing (each pair adds -1/(odd)! + 1/(even)! < 0, resp. +1/(even)! - 1/(odd)! > 0, by strict monotonicity of the factorial). Both subsequences converge to e⁻¹ (the parent's limit composed with k ↦ 2k and k ↦ 2k+1). A strictly antitone convergent sequence stays strictly above its limit and a strictly monotone one strictly below (proved here from le_of_tendsto/ge_of_tendsto), yielding e⁻¹ < a(2k) and a(2k+1) < e⁻¹. The unified sign law and the opposite-sign product follow by casing on the parity of n; the exact nesting width is one application of the one-step recurrence.",
+    "keyInsights": [
+      "The parent's absolute-value bound is lossy: |D(n)/n! - e⁻¹| ≤ 1/(n+1)! throws away the sign of the error. The alternating structure determines that sign completely — (-1)^n·(D(n)/n! - e⁻¹) > 0 — so D(n)/n! is *never* exactly e⁻¹ and you always know which side it is on.",
+      "Sign + magnitude together upgrade one-sided approximation to genuine two-sided bracketing: 1/e is trapped strictly between two consecutive computable rationals D(2k+1)/(2k+1)! and D(2k)/(2k)!, the hallmark of an alternating series and the basis for interval-arithmetic estimates of e⁻¹.",
+      "Strictness comes for free from the order-limit lemmas, not from a delicate tail estimate: a strictly decreasing sequence converging to L has every term > L (its successor is already ≥ L, and it is strictly larger than its successor). This sidesteps having to prove the omitted tail is strictly positive.",
+      "The brackets are nested with an exact, not merely bounded, width: a(2k) - a(2k+1) = 1/(2k+1)! precisely. This is the sharp form of the parent's bound at even/odd index pairs and exhibits e⁻¹ as the unique common point of the shrinking intervals [a(2k+1), a(2k)]."
+    ],
+    "prerequisites": [
+      "The parent file's alternating-series representation D(n)/n! = ∑_{k≤n}(-1)^k/k! (altFactPartialSum) and the limit D(n)/n! → e⁻¹",
+      "Monotone-subsequence API: strictAnti_nat_of_succ_lt, strictMono_nat_of_lt_succ",
+      "Order limits le_of_tendsto / ge_of_tendsto and strict monotonicity of the factorial"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 57,
+      "summary": "Module docstring stating the sign/bracketing refinement, imports of the parent DerangementsConvergence and Mathlib.Tactic, and namespace DerangementsConvergenceOQ02.",
+      "mathContext": "Setting: a(n) = D(n)/n! = ∑_{k=0}^n (-1)^k/k!, the partial sums of e⁻¹; goal is the sign of a(n) - e⁻¹."
+    },
+    {
+      "id": "sec-signs",
+      "title": "§1 Signs of the Alternating Terms",
+      "startLine": 58,
+      "endLine": 70,
+      "summary": "altFactTerm_of_even and altFactTerm_of_odd evaluate the k-th term (-1)^k/k! to +1/k! or -(1/k!) according to the parity of k, via Even.neg_one_pow / Odd.neg_one_pow.",
+      "mathContext": "The k-th Taylor term of e⁻¹ is (-1)^k/k!; its sign is +1 for even k and -1 for odd k."
+    },
+    {
+      "id": "sec-monotone",
+      "title": "§2 Two-Step Recurrence and Strict Monotonicity of Subsequences",
+      "startLine": 71,
+      "endLine": 114,
+      "summary": "aSeq_add_two gives a(n+2) = a(n) + term(n+1) + term(n+2); aSeq_even_step and aSeq_odd_step show the even-indexed ratios strictly decrease and the odd-indexed strictly increase (each pair sign-controlled by 1/(m+1)! < 1/m!). These upgrade to StrictAnti / StrictMono on the subsequences.",
+      "mathContext": "Pairing consecutive alternating terms: a(2k+2) - a(2k) = 1/(2k+2)! - 1/(2k+1)! < 0 and a(2k+3) - a(2k+1) = 1/(2k+2)! - 1/(2k+3)! > 0."
+    },
+    {
+      "id": "sec-converge",
+      "title": "§3 Both Subsequences Converge to 1/e",
+      "startLine": 115,
+      "endLine": 138,
+      "summary": "aSeq_tendsto restates the parent limit D(n)/n! → e⁻¹ for the partial sums; composing with k ↦ 2k and k ↦ 2k+1 (tendsto_two_mul, tendsto_two_mul_add_one) gives aeven_tendsto and aodd_tendsto, the convergence of the even/odd subsequences to e⁻¹.",
+      "mathContext": "A subsequence of a convergent sequence has the same limit; both a(2k) and a(2k+1) converge to e⁻¹."
+    },
+    {
+      "id": "sec-onesided",
+      "title": "§4 Monotone Convergent Sequences Stay on One Side of the Limit",
+      "startLine": 139,
+      "endLine": 154,
+      "summary": "lt_of_strictAnti_tendsto: a strictly antitone sequence converging to L stays strictly above L; gt_of_strictMono_tendsto: a strictly monotone one stays strictly below L. Proved from le_of_tendsto / ge_of_tendsto on the tail.",
+      "mathContext": "If x is strictly decreasing with x → L, then for each n, L ≤ x(n+1) < x(n); the strictness from the single step gives x(n) > L."
+    },
+    {
+      "id": "sec-main",
+      "title": "§5 Main Bracketing Results",
+      "startLine": 155,
+      "endLine": 213,
+      "summary": "ratio_even_gt (e⁻¹ < a(2k)), ratio_odd_lt (a(2k+1) < e⁻¹), their parity-indexed forms aSeq_gt_of_even / aSeq_lt_of_odd, the two-sided bracket numDerangements_bracket, the unified sign laws aSeq_error_sign / numDerangements_error_sign, the opposite-sign product consecutive_error_opposite, and the exact width nested_interval_width.",
+      "mathContext": "Two-sided bracketing D(2k+1)/(2k+1)! < e⁻¹ < D(2k)/(2k)!, sign law (-1)^n·(D(n)/n! - e⁻¹) > 0, and nesting width a(2k) - a(2k+1) = 1/(2k+1)!."
+    },
+    {
+      "id": "sec-integer",
+      "title": "§6 Integer-Side Corollaries",
+      "startLine": 214,
+      "endLine": 239,
+      "summary": "numDerangements_gt_of_even (D(n) > n!·e⁻¹ for even n) and numDerangements_lt_of_odd (D(n) < n!·e⁻¹ for odd n), obtained by clearing the positive denominator n! from the ratio bounds.",
+      "mathContext": "Locating each derangement count relative to n!/e: above for even n, below for odd n (the signed refinement of |D(n) - n!/e| < 1/2)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "parent",
+      "description": "Parent entry: proves the magnitude bound |D(n)/n! - e⁻¹| ≤ 1/(n+1)! and the limit D(n)/n! → e⁻¹. This entry refines that bound by determining the sign of the error and the two-sided bracketing of 1/e, reusing the parent's altFactPartialSum representation and limit."
+    },
+    {
+      "targetId": "derangements-convergence-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling entry: derives D(n) = round(n!/e) from the |D(n) - n!/e| < 1/2 bound. This entry sharpens the location of D(n) relative to n!/e from 'within 1/2' to 'strictly above for even n, strictly below for odd n'."
+    },
+    {
+      "targetId": "derangements-convergence-oq-03-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling entry on the integer recurrence D(n+1) = (n+1)·D(n) + (-1)^(n+1); its exact ±1 remainder is the integer counterpart of the alternating sign refined here at the level of the e⁻¹ approximation."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "foundational",
+      "description": "Root entry: basic derangement definitions and the counting function numDerangements used throughout."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified refinement of the derangement convergence rate: the sign of D(n)/n! - e⁻¹ is exactly (-1)^n, so the even-indexed ratios sit strictly above 1/e and the odd-indexed strictly below, bracketing 1/e in nested intervals of exact width 1/(2k+1)!. Zero sorries, zero axioms beyond the foundational ones.",
+    "implications": "Sign-determined bracketing turns the partial sums D(n)/n! into a certified two-sided enclosure of e⁻¹: any odd ratio is a strict lower bound and any even ratio a strict upper bound, with explicit gap 1/(2k+1)!. This is the form needed for interval-arithmetic estimates of 1/e and exhibits the derangement ratios as a textbook nested-interval construction of e⁻¹. On the integer side it pins each derangement count strictly on one side of n!/e by parity, sharpening the rounding picture of the sibling entries."
+  },
+  "mainTheorems": [
+    {
+      "name": "numDerangements_bracket",
+      "type": "theorem",
+      "description": "Two-sided bracketing: consecutive derangement ratios straddle 1/e, D(2k+1)/(2k+1)! < e⁻¹ < D(2k)/(2k)!.",
+      "leanType": "(k : ℕ) → (numDerangements (2*k+1) : ℝ)/((2*k+1).factorial) < rexp (-1) ∧ rexp (-1) < (numDerangements (2*k) : ℝ)/((2*k).factorial)"
+    },
+    {
+      "name": "numDerangements_error_sign",
+      "type": "theorem",
+      "description": "Unified sign law: the approximation error D(n)/n! - e⁻¹ alternates in sign with n, i.e. (-1)^n·(D(n)/n! - e⁻¹) > 0 for every n.",
+      "leanType": "(n : ℕ) → 0 < (-1)^n * ((numDerangements n : ℝ)/(n.factorial) - rexp (-1))"
+    },
+    {
+      "name": "nested_interval_width",
+      "type": "theorem",
+      "description": "The bracketing intervals are nested with exact width a(2k) - a(2k+1) = 1/(2k+1)!.",
+      "leanType": "(k : ℕ) → altFactPartialSum (2*k) - altFactPartialSum (2*k+1) = 1/((2*k+1).factorial)"
+    },
+    {
+      "name": "numDerangements_gt_of_even",
+      "type": "theorem",
+      "description": "Integer-side form: for even n, the derangement count strictly exceeds n!/e.",
+      "leanType": "{n : ℕ} → Even n → (n.factorial : ℝ) * rexp (-1) < (numDerangements n : ℝ)"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.DerangementsConvergence",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "Real",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "DerangementsConvergenceOQ02",
+    "lineCount": 239,
+    "axiomCount": 0,
+    "theoremCount": 25,
+    "substantiveTheoremCount": 11,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsConvergenceOQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Leonhard Euler",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie de Berlin 7, pp. 255–270",
+      "note": "Origin of the derangement series D(n)/n! = ∑(-1)^k/k! whose alternating partial sums are bracketed here."
+    },
+    {
+      "authors": "Pierre Rémond de Montmort",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "venue": "Paris",
+      "note": "The matching/rencontre problem; first appearance of derangement counts."
+    },
+    {
+      "authors": "Tom M. Apostol",
+      "title": "Mathematical Analysis",
+      "year": "1974",
+      "venue": "Addison-Wesley, §8.14 (alternating series)",
+      "note": "Leibniz alternating series test, including the sign of the remainder and the two-sided bracketing of the sum by consecutive partial sums."
+    }
+  ]
+}

--- a/src/data/research/problems/derangements-convergence-oq-02.json
+++ b/src/data/research/problems/derangements-convergence-oq-02.json
@@ -1,0 +1,85 @@
+{
+  "slug": "derangements-convergence-oq-02",
+  "title": "Sign of the derangement error and sharp two-sided bracketing of 1/e",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "∀ k, (numDerangements (2*k+1) : ℝ)/((2*k+1)!) < rexp(-1) ∧ rexp(-1) < (numDerangements (2*k) : ℝ)/((2*k)!); and ∀ n, 0 < (-1)^n · ((numDerangements n : ℝ)/(n!) - rexp(-1)).",
+    "plain": "The parent entry proves the magnitude bound |D(n)/n! - e⁻¹| ≤ 1/(n+1)!. Determine the sign of D(n)/n! - e⁻¹ and the resulting two-sided localization of 1/e by consecutive derangement ratios.",
+    "whyMatters": [
+      "Sign information upgrades a one-sided rate bound to a certified two-sided enclosure of e⁻¹ (interval arithmetic).",
+      "Exhibits the derangement ratios as a textbook nested-interval construction of 1/e."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "ratio_even_gt / ratio_odd_lt: even ratios strictly above e⁻¹, odd ratios strictly below.",
+      "numDerangements_bracket: D(2k+1)/(2k+1)! < e⁻¹ < D(2k)/(2k)!.",
+      "aSeq_error_sign / numDerangements_error_sign: 0 < (-1)^n·(D(n)/n! - e⁻¹).",
+      "consecutive_error_opposite: consecutive errors have opposite signs.",
+      "nested_interval_width: exact width a(2k) - a(2k+1) = 1/(2k+1)!.",
+      "numDerangements_gt_of_even / numDerangements_lt_of_odd: integer-side localization relative to n!/e."
+    ],
+    "open": [],
+    "goal": "Refine the parent's magnitude bound to a sign-determined two-sided bracketing of 1/e. ACHIEVED — fully verified, 0 sorries, 0 axioms."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-21T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Sign of the alternating approximation error and nested-interval bracketing of e⁻¹.",
+    "blockers": [],
+    "nextAction": "None — entry complete.",
+    "attemptCounts": { "total": 1, "currentApproach": 1, "approachesTried": 1 }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: Proved the sign of D(n)/n! - e⁻¹ is (-1)^n, giving the sharp two-sided bracket D(2k+1)/(2k+1)! < e⁻¹ < D(2k)/(2k)! with exact nesting width 1/(2k+1)!. 25 declarations (11 substantive theorems), 0 sorries, 0 axioms. Built on the parent's altFactPartialSum representation and limit via monotone-subsequence arguments.",
+    "builtItems": [
+      "Created DerangementsConvergenceOQ02.lean (239 lines, 25 decls, 0 sorry, 0 axiom)",
+      "numDerangements_bracket: two-sided bracketing of 1/e by consecutive ratios",
+      "numDerangements_error_sign: unified alternating sign law for the error",
+      "nested_interval_width: exact bracket width 1/(2k+1)!"
+    ],
+    "insights": [
+      "The alternating series test gives more than magnitude: the remainder has the sign of its first omitted term, so D(n)/n! - e⁻¹ has sign exactly (-1)^n.",
+      "Strictness of the bracket comes from the order-limit lemmas (a strictly monotone convergent sequence never reaches its limit), not from a tail estimate.",
+      "Pairing two steps of the partial-sum recurrence makes the even/odd subsequences strictly monotone, with sign controlled by 1/(m+1)! < 1/m!."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: derangements-convergence-oq-02\n\nCompleted in one session. Refines the parent magnitude bound to a sign-determined two-sided bracketing of 1/e. See DerangementsConvergenceOQ02.lean."
+  },
+  "tags": [
+    "combinatorics",
+    "derangements",
+    "probability",
+    "e-constant",
+    "convergence",
+    "alternating-series"
+  ],
+  "relatedProofs": [
+    "derangements",
+    "derangements-convergence",
+    "derangements-convergence-oq-01",
+    "derangements-convergence-oq-03",
+    "derangements-convergence-oq-03-oq-02"
+  ],
+  "references": {
+    "papers": [
+      "Leonhard Euler, Calcul de la probabilité dans le jeu de rencontre (1751).",
+      "Tom M. Apostol, Mathematical Analysis (1974), §8.14 (alternating series)."
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Combinatorics.Derangements.Finite",
+      "Mathlib.Order.Monotone.Basic",
+      "Mathlib.Topology.Order.Basic"
+    ]
+  },
+  "started": "2026-06-21T00:00:00.000Z",
+  "lastUpdate": "2026-06-21T00:00:00.000Z",
+  "completed": "2026-06-21T00:00:00.000Z",
+  "leanFiles": ["Proofs/DerangementsConvergenceOQ02.lean"]
+}


### PR DESCRIPTION
## Summary

New gallery entry **derangements-convergence-oq-02** — a sign-level refinement of the parent `derangements-convergence`, which proves only the *magnitude* bound `|D(n)/n! - e⁻¹| ≤ 1/(n+1)!`.

Writing `a(n) = D(n)/n! = ∑_{k≤n}(-1)^k/k!`, the alternating structure determines the **sign** of the error completely:

- even partial sums lie strictly **above** `e⁻¹`,
- odd partial sums lie strictly **below** `e⁻¹`,

so consecutive derangement ratios **bracket** `1/e` in nested intervals.

## Main results (`Proofs/DerangementsConvergenceOQ02.lean`, 239L, 0 sorry, 0 axiom — verified)

- `ratio_even_gt` / `ratio_odd_lt`: `e⁻¹ < D(2k)/(2k)!` and `D(2k+1)/(2k+1)! < e⁻¹`
- `numDerangements_bracket`: `D(2k+1)/(2k+1)! < e⁻¹ < D(2k)/(2k)!`
- `aSeq_error_sign` / `numDerangements_error_sign`: `0 < (-1)^n·(D(n)/n! - e⁻¹)` for every `n`
- `consecutive_error_opposite`: consecutive errors have opposite signs
- `nested_interval_width`: exact width `a(2k) - a(2k+1) = 1/(2k+1)!`
- `numDerangements_gt_of_even` / `numDerangements_lt_of_odd`: `D(n) ≷ n!/e` by parity

## Proof strategy

The one-step recurrence `a(n+1) = a(n) + (-1)^(n+1)/(n+1)!` makes the even-indexed subsequence strictly decreasing and the odd-indexed strictly increasing (each pair sign-controlled by `1/(m+1)! < 1/m!`). Both subsequences converge to `e⁻¹` (parent limit composed with `k ↦ 2k`, `k ↦ 2k+1`). A strictly monotone convergent sequence never reaches its limit (`le_of_tendsto`/`ge_of_tendsto`), which delivers the strict bracketing without any tail estimate.

## Status

**Outcome**: completed — fully machine-checked, 0 sorries, 0 `axiom` declarations, no structure-encoded assumptions (only foundational `propext`/`Classical.choice`/`Quot.sound`).

Builds on `Proofs.DerangementsConvergence` (parent). Docker build of `Proofs.DerangementsConvergenceOQ02` succeeds.

🤖 Generated by researcher-11