### PR TITLE
research(cayley-hamilton-minpoly-oq-04-oq-01): cyclic vectors for maximal-nilpotent matrices over any field [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -548,6 +548,7 @@ import Proofs.CayleyHamiltonMinpolyOQ03OQ02
 import Proofs.CayleyHamiltonMinpolyOQ04
 import Proofs.CayleyHamiltonMinpolyOQ04Backward
 import Proofs.CayleyHamiltonMinpolyOQ04BackwardAristotle
+import Proofs.CayleyHamiltonMinpolyOQ04OQ01
 import Proofs.CayleyHamiltonMinpolyOQ05
 import Proofs.CayleyHamiltonMinpolyOQ05OQ01
 import Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ01

--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ04OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ04OQ01.lean
@@ -1,0 +1,238 @@
+/-
+  Cayley–Hamilton / Minimal Polynomial, OQ-04 follow-up OQ-01:
+  The constructive CONVERSE for the maximal-nilpotent case, over ANY field.
+
+  Parent: Proofs/CayleyHamiltonMinpolyOQ04.lean
+          ("Nonderogatory Matrices and Cyclic Vectors")
+  Sibling: Proofs/CayleyHamiltonMinpolyOQ04Backward.lean
+          (converse for INFINITE fields; final assembly left as 1 `sorry`)
+
+  Background.
+  A matrix M ∈ M_n(K) is *nonderogatory* when minpoly K M = charpoly M.  The
+  parent entry proves the easy direction (a cyclic vector ⟹ nonderogatory) and
+  *axiomatizes* the converse `nonderogatory_has_cyclic_vector`.  The Backward
+  sibling discharges that axiom for infinite fields, but its main assembly is a
+  `sorry` (a `normalizedFactors`/`DecidableEq` import clash).
+
+  This file isolates the one case of the converse that needs neither an infinite
+  field nor the rational-canonical-form / factorisation machinery: the
+  **maximal-nilpotent** matrices `N` with `Nⁿ = 0` and `Nⁿ⁻¹ ≠ 0` (a single
+  Jordan block at 0).  For these we CONSTRUCT a cyclic vector explicitly over an
+  ARBITRARY field — including the finite fields the infinite-field theorem cannot
+  reach.
+
+  The three Krylov-independence helpers used here are mathematically those of the
+  Backward sibling, but are reproved inline (self-contained) because the sibling's
+  *downstream* assembly does not currently compile against Mathlib 4.26.0; the
+  helpers themselves are clean (no `sorry`, no `axiom`).
+
+  We also characterise this case arithmetically: for `0 < n`,
+        minpoly K N = Xⁿ   ⟺   Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0,
+  via the fact that the minimal polynomial of such an `N` divides `Xⁿ` and `X` is
+  prime, so `minpoly K N = Xⁱ` with `i = n` forced by `Nⁿ⁻¹ ≠ 0`.
+
+  Everything is proved with no `axiom`, no `sorry`, and no `native_decide`.
+
+  References:
+  - Hoffman & Kunze, "Linear Algebra" §7.1–7.2 (cyclic vectors, single block)
+  - Roman, "Advanced Linear Algebra" §10.4
+-/
+
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
+import Mathlib.LinearAlgebra.LinearIndependent.Basic
+import Mathlib.Algebra.GroupWithZero.Associated
+import Mathlib.Algebra.Polynomial.RingDivision
+import Mathlib.Tactic
+
+namespace CayleyHamiltonMinpolyOQ04OQ01
+
+open Matrix Polynomial
+
+variable {K : Type*} [Field K] {n : ℕ}
+
+/-!
+## Part 0: Cyclic vectors and inlined Krylov-independence helpers
+
+`IsCyclicVector M v` says no nonzero polynomial of degree `< n` annihilates `v`
+under `M`; equivalently the Krylov vectors `{v, Mv, …, Mⁿ⁻¹v}` are a basis.  The
+three lemmas below are self-contained copies of the proven helpers in the
+`CayleyHamiltonMinpolyOQ04Backward` sibling.
+-/
+
+/-- A vector `v` is a cyclic vector for `M` if no nonzero polynomial of degree `< n`
+annihilates `v` under `M`. -/
+def IsCyclicVector (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K) : Prop :=
+  ∀ p : K[X], p.natDegree < n → (aeval M p).mulVec v = 0 → p = 0
+
+/-- A nonzero matrix has a vector outside its kernel. -/
+theorem exists_mulVec_ne_zero {A : Matrix (Fin n) (Fin n) K} (hA : A ≠ 0) :
+    ∃ v : Fin n → K, A.mulVec v ≠ 0 := by
+  by_contra hall
+  push_neg at hall
+  apply hA
+  funext i j
+  specialize hall (Pi.single j 1)
+  have : (A.mulVec (Pi.single j 1)) i = 0 := congr_fun hall i
+  simp only [mulVec, dotProduct, Pi.single_apply] at this
+  simpa using this
+
+/-- If `{v, Mv, …, Mⁿ⁻¹v}` are linearly independent, then `v` is a cyclic vector. -/
+theorem isCyclicVector_of_linearIndependent
+    (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K)
+    (hli : LinearIndependent K (fun k : Fin n => (M ^ (k : ℕ)).mulVec v)) :
+    IsCyclicVector M v := by
+  intro p hp hann
+  suffices h : ∀ k : Fin n, p.coeff ↑k = 0 by
+    ext m; simp only [Polynomial.coeff_zero]
+    by_cases hm : m < n
+    · exact h ⟨m, hm⟩
+    · exact Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)
+  apply Fintype.linearIndependent_iff.mp hli
+  have heval : aeval M p = ∑ i ∈ Finset.range n, p.coeff i • M ^ i :=
+    aeval_eq_sum_range' hp M
+  have hdist : ∀ (s : Finset ℕ),
+      (∑ i ∈ s, p.coeff i • M ^ i).mulVec v =
+      ∑ i ∈ s, p.coeff i • (M ^ i).mulVec v := by
+    intro s
+    induction s using Finset.induction with
+    | empty => simp [Matrix.zero_mulVec]
+    | @insert a s ha ih =>
+      rw [Finset.sum_insert ha, Matrix.add_mulVec, ih,
+          Finset.sum_insert ha, Matrix.smul_mulVec]
+  rw [Fin.sum_univ_eq_sum_range (fun k => p.coeff k • (M ^ k).mulVec v) n, ← hdist, ← heval]
+  exact hann
+
+/-- For a nilpotent matrix `N` with `Nⁿ = 0` and `Nⁿ⁻¹ v ≠ 0`, the Krylov vectors
+`{v, Nv, …, Nⁿ⁻¹v}` are linearly independent. -/
+theorem nilpotent_krylov_independent
+    (N : Matrix (Fin n) (Fin n) K) (hnil : N ^ n = 0)
+    (v : Fin n → K) (hv : (N ^ (n - 1)).mulVec v ≠ 0) :
+    LinearIndependent K (fun k : Fin n => (N ^ (k : ℕ)).mulVec v) := by
+  rw [Fintype.linearIndependent_iff]
+  intro c hc
+  suffices main : ∀ j : ℕ, (hj : j < n) → c ⟨j, hj⟩ = 0 from
+    fun i => main ↑i i.isLt
+  intro j hj
+  induction j using Nat.strongRecOn with
+  | ind j ih =>
+    have happ : ∑ k : Fin n, c k • (N ^ (n - 1 - j + ↑k)).mulVec v = 0 := by
+      have h0 := congr_arg (fun w => (N ^ (n - 1 - j)).mulVec w) hc
+      simp only [Matrix.mulVec_zero] at h0
+      have hdist : (N ^ (n - 1 - j)).mulVec (∑ k : Fin n, c k • (N ^ (↑k : ℕ)).mulVec v) =
+          ∑ k : Fin n, c k • (N ^ (n - 1 - j)).mulVec ((N ^ (↑k : ℕ)).mulVec v) := by
+        rw [← Matrix.mulVecLin_apply]; rw [map_sum]
+        congr 1; ext k; rw [map_smul, Matrix.mulVecLin_apply]
+      rw [hdist] at h0
+      simp only [Matrix.mulVec_mulVec, ← pow_add] at h0
+      exact h0
+    have hred : ∑ k : Fin n, c k • (N ^ (n - 1 - j + ↑k)).mulVec v =
+                c ⟨j, hj⟩ • (N ^ (n - 1)).mulVec v := by
+      rw [Finset.sum_eq_single_of_mem ⟨j, hj⟩ (Finset.mem_univ _)]
+      · congr 1; congr 1; congr 1
+        exact Nat.sub_add_cancel (Nat.le_sub_one_of_lt hj)
+      · intro k _ hk
+        have hk_val : (↑k : ℕ) ≠ j := fun h => hk (Fin.ext h)
+        rcases lt_or_gt_of_ne hk_val with hlt | hgt
+        · have : c k = 0 := by
+            have := ih ↑k hlt k.isLt
+            rwa [show (⟨↑k, k.isLt⟩ : Fin n) = k from Fin.eta k k.isLt] at this
+          simp [this]
+        · have hge : n ≤ n - 1 - j + ↑k := by
+            have := Nat.le_sub_one_of_lt hj
+            omega
+          have hpow : N ^ (n - 1 - j + ↑k) = 0 := by
+            obtain ⟨d, hd⟩ := Nat.exists_eq_add_of_le hge
+            rw [hd, pow_add, hnil, zero_mul]
+          simp [hpow, Matrix.zero_mulVec]
+    rw [hred] at happ
+    rcases smul_eq_zero.mp happ with h | h
+    · exact h
+    · exact absurd h hv
+
+/-!
+## Part I: The constructive cyclic vector
+
+For a maximal-nilpotent matrix (`Nⁿ = 0`, `Nⁿ⁻¹ ≠ 0`) over any field we obtain a
+cyclic vector directly, with no factorisation and no infinitude assumption.
+-/
+
+/-- **Constructive converse, maximal-nilpotent case.**
+If `Nⁿ = 0` and `Nⁿ⁻¹ ≠ 0`, then `N` has a cyclic vector — over an ARBITRARY
+field `K`.  The witness is any `v` with `Nⁿ⁻¹ v ≠ 0`; its Krylov vectors
+`{v, Nv, …, Nⁿ⁻¹v}` are then linearly independent. -/
+theorem maximal_nilpotent_has_cyclic_vector
+    {N : Matrix (Fin n) (Fin n) K} (hnil : N ^ n = 0) (hne : N ^ (n - 1) ≠ 0) :
+    ∃ v, IsCyclicVector N v := by
+  obtain ⟨v, hv⟩ := exists_mulVec_ne_zero hne
+  exact ⟨v, isCyclicVector_of_linearIndependent N v
+    (nilpotent_krylov_independent N hnil v hv)⟩
+
+/-!
+## Part II: Arithmetic characterisation via the minimal polynomial
+-/
+
+/-- For a maximal-nilpotent matrix the minimal polynomial is exactly `Xⁿ`. -/
+theorem minpoly_eq_X_pow_of_maximal_nilpotent
+    {N : Matrix (Fin n) (Fin n) K} (hn : 0 < n)
+    (hnil : N ^ n = 0) (hne : N ^ (n - 1) ≠ 0) :
+    minpoly K N = X ^ n := by
+  have haeval : aeval N (X ^ n : K[X]) = 0 := by rw [map_pow, aeval_X]; exact hnil
+  have hdvd : minpoly K N ∣ X ^ n := minpoly.dvd K N haeval
+  obtain ⟨i, hi_le, hassoc⟩ := (dvd_prime_pow prime_X n).mp hdvd
+  have hmono : minpoly K N = X ^ i :=
+    eq_of_monic_of_associated (minpoly.monic (isIntegral N)) (monic_X_pow i) hassoc
+  have hNi : N ^ i = 0 := by
+    have := minpoly.aeval K N
+    rw [hmono, map_pow, aeval_X] at this
+    exact this
+  have hi_ge : n ≤ i := by
+    by_contra hlt
+    push_neg at hlt
+    apply hne
+    have hsplit : n - 1 = (n - 1 - i) + i := by omega
+    rw [hsplit, pow_add, hNi, mul_zero]
+  rw [hmono, le_antisymm hi_le hi_ge]
+
+/-- A maximal-nilpotent matrix has `natDegree (minpoly K N) = n`: its minimal
+polynomial reaches the full degree `n` of the characteristic polynomial — the
+nonderogatory condition expressed at the level of the minimal polynomial. -/
+theorem natDegree_minpoly_eq_of_maximal_nilpotent
+    {N : Matrix (Fin n) (Fin n) K} (hn : 0 < n)
+    (hnil : N ^ n = 0) (hne : N ^ (n - 1) ≠ 0) :
+    (minpoly K N).natDegree = n := by
+  rw [minpoly_eq_X_pow_of_maximal_nilpotent hn hnil hne, natDegree_X_pow]
+
+/-- Converse half of the characterisation: `minpoly K N = Xⁿ` recovers maximal
+nilpotency `Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0`. -/
+theorem maximal_nilpotent_of_minpoly_eq_X_pow
+    {N : Matrix (Fin n) (Fin n) K} (hn : 0 < n)
+    (hmp : minpoly K N = X ^ n) :
+    N ^ n = 0 ∧ N ^ (n - 1) ≠ 0 := by
+  refine ⟨?_, ?_⟩
+  · have := minpoly.aeval K N
+    rw [hmp, map_pow, aeval_X] at this
+    exact this
+  · intro hcontra
+    have haeval : aeval N (X ^ (n - 1) : K[X]) = 0 := by rw [map_pow, aeval_X]; exact hcontra
+    have hdvd : minpoly K N ∣ X ^ (n - 1) := minpoly.dvd K N haeval
+    have hle := Polynomial.natDegree_le_of_dvd hdvd (pow_ne_zero _ (X_ne_zero (R := K)))
+    rw [hmp, natDegree_X_pow, natDegree_X_pow] at hle
+    omega
+
+/-- **Characterisation.** For `0 < n` a matrix is maximal-nilpotent iff its
+minimal polynomial is `Xⁿ`. -/
+theorem minpoly_eq_X_pow_iff_maximal_nilpotent
+    {N : Matrix (Fin n) (Fin n) K} (hn : 0 < n) :
+    minpoly K N = X ^ n ↔ N ^ n = 0 ∧ N ^ (n - 1) ≠ 0 :=
+  ⟨maximal_nilpotent_of_minpoly_eq_X_pow hn,
+   fun ⟨h1, h2⟩ => minpoly_eq_X_pow_of_maximal_nilpotent hn h1 h2⟩
+
+/-- A matrix with `minpoly K N = Xⁿ` (maximal nilpotent) has a cyclic vector. -/
+theorem has_cyclic_vector_of_minpoly_eq_X_pow
+    {N : Matrix (Fin n) (Fin n) K} (hn : 0 < n) (hmp : minpoly K N = X ^ n) :
+    ∃ v, IsCyclicVector N v := by
+  obtain ⟨h1, h2⟩ := maximal_nilpotent_of_minpoly_eq_X_pow hn hmp
+  exact maximal_nilpotent_has_cyclic_vector h1 h2
+
+end CayleyHamiltonMinpolyOQ04OQ01

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-chminpolyoq04oq01-context",
+    "proofId": "cayley-hamilton-minpoly-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 55 },
+    "type": "concept",
+    "title": "Isolating the case of the converse that needs no infinite field",
+    "content": "A matrix M is nonderogatory when minpoly K M = charpoly M, equivalently when it has a cyclic vector. The parent entry proves the easy direction (cyclic ⟹ nonderogatory) and axiomatizes the converse. The OQ04Backward sibling proves the converse for infinite fields but its main assembly is a `sorry` (a normalizedFactors/DecidableEq import clash). This file handles the one case of the converse that needs neither an infinite field nor rational-canonical-form machinery: maximal-nilpotent matrices N with Nⁿ = 0 and Nⁿ⁻¹ ≠ 0, i.e. a single Jordan block at 0. For these we construct a cyclic vector EXPLICITLY over an arbitrary field, finite ones included.",
+    "mathContext": "Single nilpotent Jordan block: $N^n=0$, $N^{n-1}\\ne 0$. Cyclic vector exists over any field $K$."
+  },
+  {
+    "id": "ann-chminpolyoq04oq01-helpers",
+    "proofId": "cayley-hamilton-minpoly-oq-04-oq-01",
+    "range": { "startLine": 56, "endLine": 160 },
+    "type": "technique",
+    "title": "Krylov-independence helpers, reproved inline",
+    "content": "Three lemmas drive the construction. exists_mulVec_ne_zero: a nonzero matrix sends some standard basis vector outside its kernel. isCyclicVector_of_linearIndependent: if {v, Mv, …, Mⁿ⁻¹v} are linearly independent then no nonzero polynomial of degree < n annihilates v (uses aeval_eq_sum_range' to expand p(M) over the power basis, then Fintype.linearIndependent_iff). nilpotent_krylov_independent: for Nⁿ=0 and Nⁿ⁻¹v≠0, applying Nⁿ⁻¹⁻ʲ to a linear relation ∑cₖNᵏv=0 kills the high-degree terms by nilpotency and the low-degree terms by induction, leaving cⱼNⁿ⁻¹v=0 hence cⱼ=0 (descending strong induction). These are the proven helpers of the OQ04Backward sibling, reproduced here because that sibling's downstream assembly no longer compiles against Mathlib 4.26.0.",
+    "mathContext": "Apply $N^{\\,n-1-j}$ to $\\sum_k c_k N^k v = 0$: terms with $k>j$ vanish ($N^{\\ge n}=0$), terms with $k<j$ vanish by IH, leaving $c_j N^{n-1}v = 0$."
+  },
+  {
+    "id": "ann-chminpolyoq04oq01-construction",
+    "proofId": "cayley-hamilton-minpoly-oq-04-oq-01",
+    "range": { "startLine": 161, "endLine": 174 },
+    "type": "key-step",
+    "title": "The explicit cyclic vector",
+    "content": "maximal_nilpotent_has_cyclic_vector is a three-line composition: since Nⁿ⁻¹ ≠ 0, exists_mulVec_ne_zero yields v with Nⁿ⁻¹v ≠ 0; nilpotent_krylov_independent makes its Krylov vectors linearly independent; isCyclicVector_of_linearIndependent upgrades that to cyclicity. No infinitude of K and no factorization are used, so this covers finite fields — exactly the gap left open by the infinite-field theorem.",
+    "mathContext": "Any $v\\notin\\ker N^{n-1}$ is cyclic: $\\{v,Nv,\\dots,N^{n-1}v\\}$ is a basis."
+  },
+  {
+    "id": "ann-chminpolyoq04oq01-minpoly",
+    "proofId": "cayley-hamilton-minpoly-oq-04-oq-01",
+    "range": { "startLine": 175, "endLine": 238 },
+    "type": "key-step",
+    "title": "Minimal polynomial = Xⁿ, and the iff characterization",
+    "content": "minpoly_eq_X_pow_of_maximal_nilpotent: Nⁿ = 0 gives aeval N (Xⁿ) = 0, so minpoly K N ∣ Xⁿ; since X is prime (prime_X), dvd_prime_pow gives minpoly associated to Xⁱ, and eq_of_monic_of_associated (both monic) makes minpoly = Xⁱ; then Nⁱ = 0, so i ≥ n (else Nⁿ⁻¹ = Nⁿ⁻¹⁻ⁱ·Nⁱ = 0), forcing i = n. The converse maximal_nilpotent_of_minpoly_eq_X_pow reads Nⁿ = 0 off aeval, and rules out Nⁿ⁻¹ = 0 by a degree comparison (minpoly would divide Xⁿ⁻¹). Together they give the iff and natDegree(minpoly) = n, linking the construction to the parent's degree-based nonderogatory characterization.",
+    "mathContext": "$\\mu\\mid X^n$, $X$ prime $\\Rightarrow \\mu = X^i$; $N^{n-1}\\ne 0\\Rightarrow i=n$, so $\\mu = X^n$ and $\\deg\\mu = n$."
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-04-oq-01",
+  "slug": "cayley-hamilton-minpoly-oq-04-oq-01",
+  "title": "Nonderogatory Converse: Cyclic Vectors for Maximal-Nilpotent Matrices over Any Field",
+  "description": "The constructive converse of the cyclic-vector / nonderogatory equivalence, for the maximal-nilpotent case, over an ARBITRARY field. The parent entry (cayley-hamilton-minpoly-oq-04) proves cyclic ⟹ nonderogatory and axiomatizes the converse; the OQ04Backward sibling proves the converse for infinite fields but leaves its main assembly as a `sorry`. This file isolates the single case needing neither an infinite field nor factorization machinery: a matrix N with Nⁿ = 0 and Nⁿ⁻¹ ≠ 0 (a single Jordan block at 0). For these we construct a cyclic vector explicitly — over any field, including finite ones — by taking any v with Nⁿ⁻¹v ≠ 0 and showing its Krylov vectors {v, Nv, …, Nⁿ⁻¹v} are linearly independent. It also gives the arithmetic characterization minpoly K N = Xⁿ ⟺ (Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0) and natDegree(minpoly K N) = n.",
+  "meta": {
+    "author": "Lean Genius Researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ04OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "cayley-hamilton",
+      "minimal-polynomial",
+      "nonderogatory",
+      "cyclic-vector",
+      "nilpotent",
+      "krylov",
+      "matrices"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 238,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. Depends only on the standard foundational axioms propext / Classical.choice / Quot.sound. The three Krylov-independence helper lemmas are reproved inline (self-contained) rather than imported from the CayleyHamiltonMinpolyOQ04Backward sibling, whose downstream assembly does not currently compile against Mathlib 4.26.0 (a bit-rotted `ring` step plus its documented `sorry`); the helpers themselves are clean. This entry proves the converse only for the maximal-nilpotent (single Jordan block) case — it does NOT discharge the parent's general axiom.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.isIntegral",
+        "description": "A matrix over a field is integral, so its minimal polynomial is defined and monic",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly"
+      },
+      {
+        "theorem": "minpoly.dvd",
+        "description": "If aeval N q = 0 then minpoly K N ∣ q",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "dvd_prime_pow",
+        "description": "a ∣ pⁿ ↔ ∃ k ≤ n, Associated a (pᵏ) for prime p",
+        "module": "Mathlib.Algebra.GroupWithZero.Associated"
+      },
+      {
+        "theorem": "Polynomial.prime_X",
+        "description": "X is prime in K[X]",
+        "module": "Mathlib.Algebra.Polynomial.RingDivision"
+      },
+      {
+        "theorem": "Polynomial.eq_of_monic_of_associated",
+        "description": "associated monic polynomials are equal (gives minpoly = Xⁱ)",
+        "module": "Mathlib.Algebra.Polynomial.Monic"
+      },
+      {
+        "theorem": "Polynomial.aeval_eq_sum_range'",
+        "description": "aeval x p = ∑_{i<n} p.coeff i • xⁱ when natDegree p < n",
+        "module": "Mathlib.Algebra.Polynomial.AlgebraMap"
+      }
+    ],
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly",
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",
+      "Mathlib.LinearAlgebra.LinearIndependent.Basic",
+      "Mathlib.Algebra.GroupWithZero.Associated",
+      "Mathlib.Algebra.Polynomial.RingDivision",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial"
+    ],
+    "namespace": "CayleyHamiltonMinpolyOQ04OQ01",
+    "lineCount": 238,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "maximal_nilpotent_has_cyclic_vector",
+      "type": "headline",
+      "statement": "Nⁿ = 0 → Nⁿ⁻¹ ≠ 0 → ∃ v, IsCyclicVector N v",
+      "description": "Constructive converse for the maximal-nilpotent case over an arbitrary field: a single-Jordan-block nilpotent matrix has a cyclic vector. The witness is any v with Nⁿ⁻¹v ≠ 0.",
+      "significance": "Discharges the converse direction (axiomatized by the parent) for the nilpotent case over ALL fields — including finite fields, which the infinite-field sibling cannot reach — with an explicit construction and no factorization machinery."
+    },
+    {
+      "name": "minpoly_eq_X_pow_iff_maximal_nilpotent",
+      "type": "core",
+      "statement": "0 < n → (minpoly K N = Xⁿ ↔ Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0)",
+      "description": "Arithmetic characterization of the maximal-nilpotent matrices via their minimal polynomial.",
+      "significance": "Identifies the hypothesis Nⁿ=0 ∧ Nⁿ⁻¹≠0 with the clean polynomial condition minpoly = Xⁿ, connecting the construction to the nonderogatory (minpoly-degree-n) framing."
+    },
+    {
+      "name": "minpoly_eq_X_pow_of_maximal_nilpotent",
+      "type": "core",
+      "statement": "0 < n → Nⁿ = 0 → Nⁿ⁻¹ ≠ 0 → minpoly K N = Xⁿ",
+      "description": "The minimal polynomial of a maximal-nilpotent matrix is exactly Xⁿ: it divides Xⁿ (since Nⁿ=0), so equals Xⁱ (X prime + associated monics equal), and i = n is forced by Nⁿ⁻¹ ≠ 0.",
+      "significance": "The forward half of the characterization; the only place factorization (prime X) enters, and only at the elementary level of prime-power divisors."
+    },
+    {
+      "name": "natDegree_minpoly_eq_of_maximal_nilpotent",
+      "type": "supporting",
+      "statement": "0 < n → Nⁿ = 0 → Nⁿ⁻¹ ≠ 0 → (minpoly K N).natDegree = n",
+      "description": "A maximal-nilpotent matrix has minimal polynomial of full degree n — the nonderogatory condition stated at the level of the minimal polynomial degree.",
+      "significance": "Bridges the construction to the parent's degree-based nonderogatory characterizations (natDegree minpoly = n)."
+    },
+    {
+      "name": "has_cyclic_vector_of_minpoly_eq_X_pow",
+      "type": "supporting",
+      "statement": "0 < n → minpoly K N = Xⁿ → ∃ v, IsCyclicVector N v",
+      "description": "Cyclic-vector existence stated directly from the minimal-polynomial hypothesis minpoly K N = Xⁿ.",
+      "significance": "Convenience form combining the characterization with the constructive headline."
+    }
+  ],
+  "sections": [
+    {
+      "id": "helpers",
+      "title": "Part 0: Cyclic vectors and inlined Krylov-independence helpers",
+      "startLine": 56,
+      "endLine": 160,
+      "summary": "IsCyclicVector def; exists_mulVec_ne_zero (nonzero matrix misses a kernel vector); isCyclicVector_of_linearIndependent (LI Krylov vectors ⟹ cyclic, via aeval_eq_sum_range'); nilpotent_krylov_independent (Nⁿ=0, Nⁿ⁻¹v≠0 ⟹ Krylov LI by descending strong induction).",
+      "mathContext": "A cyclic vector v is one whose Krylov sequence {v, Nv, …, Nⁿ⁻¹v} spans, equivalently is linearly independent. The nilpotent independence lemma applies Nⁿ⁻¹⁻ʲ to a linear relation and peels coefficients one at a time."
+    },
+    {
+      "id": "construction",
+      "title": "Part I: The constructive cyclic vector",
+      "startLine": 161,
+      "endLine": 174,
+      "summary": "maximal_nilpotent_has_cyclic_vector: pick v with Nⁿ⁻¹v ≠ 0 (exists_mulVec_ne_zero on Nⁿ⁻¹), get Krylov LI (nilpotent_krylov_independent), conclude cyclic (isCyclicVector_of_linearIndependent).",
+      "mathContext": "For a single Jordan block at 0, any vector not killed by Nⁿ⁻¹ generates the whole space under N; this works over any field with no genericity argument."
+    },
+    {
+      "id": "characterization",
+      "title": "Part II: Arithmetic characterisation via the minimal polynomial",
+      "startLine": 175,
+      "endLine": 238,
+      "summary": "minpoly = Xⁿ for maximal nilpotent (divides Xⁿ; X prime ⟹ minpoly = Xⁱ; Nⁿ⁻¹≠0 ⟹ i=n); natDegree = n; converse minpoly=Xⁿ ⟹ maximal nilpotent; the iff; and cyclic-vector existence from minpoly=Xⁿ.",
+      "mathContext": "The minimal polynomial of a single nilpotent Jordan block of size n is Xⁿ; conversely minpoly = Xⁿ forces Nⁿ = 0 with Nⁿ⁻¹ ≠ 0 (else minpoly would divide Xⁿ⁻¹ and have degree < n)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The **constructive converse** of the nonderogatory / cyclic-vector equivalence, for the **maximal-nilpotent case, over an arbitrary field** — a follow-up to `cayley-hamilton-minpoly-oq-04` ("Nonderogatory Matrices and Cyclic Vectors").

A matrix `M ∈ Mₙ(K)` is *nonderogatory* when `minpoly K M = charpoly M`, equivalently when it has a **cyclic vector**. The parent entry proves the easy direction (cyclic ⟹ nonderogatory) and **axiomatizes** the converse. The `OQ04Backward` sibling proves the converse for *infinite* fields, but its main assembly is a `sorry`.

This PR settles the one case of the converse that needs **neither an infinite field nor factorization machinery**: matrices `N` with `Nⁿ = 0` and `Nⁿ⁻¹ ≠ 0` — a single Jordan block at `0`. The cyclic vector is constructed **explicitly**, valid over **any** field including the finite ones the infinite-field theorem cannot reach:

```
take any v with Nⁿ⁻¹v ≠ 0  ⟹  {v, Nv, …, Nⁿ⁻¹v} linearly independent  ⟹  v cyclic.
```

It also gives the arithmetic characterization

```
minpoly K N = Xⁿ   ⟺   Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0          (0 < n)
natDegree (minpoly K N) = n                          (maximal nilpotent)
```

via `minpoly ∣ Xⁿ`, primality of `X`, and equality of associated monic polynomials.

## What this does and does not claim

- ✅ Discharges the converse **for the maximal-nilpotent case, over all fields** with an explicit construction.
- ❌ Does **not** discharge the parent's general axiom (arbitrary nonderogatory matrices).

## Verification

- `Proofs/CayleyHamiltonMinpolyOQ04OQ01.lean` — **238 lines, 9 theorems, 1 definition**.
- **0 axioms, 0 sorries, no `native_decide`.** `#print axioms` → `propext / Classical.choice / Quot.sound` only.
- Builds under the Docker wrapper against Mathlib 4.26.0.

The three Krylov-independence helper lemmas are reproved **inline** (self-contained): the `CayleyHamiltonMinpolyOQ04Backward` sibling no longer compiles against Mathlib 4.26.0 (a bit-rotted `ring` step in `gcd_aeval_mulVec_eq_zero` plus its documented `sorry`), so it cannot be imported. The helpers themselves are clean.

## Gallery

- `src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/{meta.json,annotations.json}` (status `verified`, badge `original`).
- Registered in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)