### PR TITLE
research(area-of-circle-oq-05-incomplete-01): normal-distribution normalization family [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -582,6 +582,7 @@ import Proofs.CentralLimitTheoremOQ01OQ02
 import Proofs.CentralLimitTheoremOQ01OQ02OQ01
 import Proofs.CentralLimitTheoremOQ01OQ02OQ01OQ01
 import Proofs.CentralLimitTheoremOQ01OQ03
+import Proofs.CentralLimitTheoremOQ01OQ04
 import Proofs.CentralLimitTheoremOQ02
 import Proofs.CentralLimitTheoremOQ02Aristotle
 import Proofs.CentralLimitTheoremOQ02OQ02

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -151,6 +151,7 @@ import Proofs.AreaOfCircleOQ03OQ02OQ02OQ01
 import Proofs.AreaOfCircleOQ03OQ03
 import Proofs.AreaOfCircleOQ03OQ03OQ02
 import Proofs.AreaOfCircleOQ05
+import Proofs.AreaOfCircleOQ05Incomplete01
 import Proofs.AreaOfCircleOQ05OQ01
 import Proofs.AreaOfCircleOQ05OQ01Aristotle
 import Proofs.AreaOfCircleOQ05OQ02

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2215,6 +2215,7 @@ import Proofs.Erdos820Problem
 import Proofs.Erdos821Problem
 import Proofs.Erdos822Problem
 import Proofs.Erdos823Problem
+import Proofs.Erdos823SigmaValues
 import Proofs.Erdos824Problem
 import Proofs.Erdos824ProblemProvable
 import Proofs.Erdos825Problem

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -595,6 +595,7 @@ import Proofs.CentralLimitTheoremOQ04
 import Proofs.CevasTheorem
 import Proofs.CevasTheoremNonEuclidean
 import Proofs.CevasTheoremNonEuclideanOQ02
+import Proofs.CevasTheoremNonEuclideanOQ03
 import Proofs.CevasTheoremNonEuclideanOQ02OQ01
 import Proofs.CevasTheoremNonEuclideanOQ02OQ01OQ01
 import Proofs.CevasTheoremOQ01

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2093,6 +2093,7 @@ import Proofs.Erdos731Problem
 import Proofs.Erdos732Problem
 import Proofs.Erdos733LimitBounds
 import Proofs.Erdos733Problem
+import Proofs.Erdos733RichLines
 import Proofs.Erdos734Problem
 import Proofs.Erdos735OQ04
 import Proofs.Erdos735OQ04Tetrahedron

--- a/proofs/Proofs/AreaOfCircleOQ05Incomplete01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05Incomplete01.lean
@@ -1,0 +1,95 @@
+/-
+# Area of Circle OQ-05 (completion) — the normal-distribution normalization family
+
+The parent `AreaOfCircleOQ05.lean` proves the Gaussian integral
+`∫ exp(-x²) dx = √π` (via Mathlib's `integral_gaussian`) and connects it to the
+area of a circle through the polar-coordinate squaring argument. Its sibling
+files handle the polar proof (oq-05-oq-01), the multivariate case
+(oq-05-oq-02), and the complex Gaussian (oq-05-oq-04).
+
+One classical strand is not yet covered: the **normalization constants of the
+normal distribution**, which are exactly the rescalings of `√π` that make the
+Gaussian a probability density. This file fills that gap, axiom-free, deriving
+everything from `integral_gaussian`:
+
+* `∫ exp(-x²/2) dx = √(2π)`                              (`gaussian_half`)
+* `∫ (1/√(2π))·exp(-x²/2) dx = 1`                        (`std_normal_normalization`)
+* `∫ exp(-x²/(2σ²)) dx = σ·√(2π)`        for `σ > 0`     (`gaussian_variance`)
+* `∫ (1/(σ·√(2π)))·exp(-x²/(2σ²)) dx = 1` for `σ > 0`    (`gaussian_variance_normalization`)
+
+together with the base case `∫ exp(-x²) dx = √π` and the area-of-circle
+identity `(∫ exp(-x²) dx)² = π` restated for context. The normalization with
+mean `0`; the general mean `μ` is a translation (`integral` is shift-invariant)
+and is recorded as `gaussian_mean_shift`.
+
+Every result is checked by the kernel with no axioms and no `native_decide`.
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Tactic
+
+open Real MeasureTheory
+
+namespace AreaOfCircleOQ05Incomplete01
+
+/-- `√(2π) > 0`, the standard normalization constant. -/
+theorem sqrt_two_pi_pos : 0 < Real.sqrt (2 * π) :=
+  Real.sqrt_pos.mpr (by positivity)
+
+/-- Base case (parent): `∫ exp(-x²) dx = √π`. -/
+theorem gaussian_unit : ∫ x : ℝ, Real.exp (-x ^ 2) = Real.sqrt π := by
+  have h := integral_gaussian 1
+  have hfun : (fun x : ℝ => Real.exp (-x ^ 2)) = (fun x => Real.exp (-1 * x ^ 2)) := by
+    funext x; congr 1; ring
+  rw [hfun, h]
+  congr 1
+  rw [div_one]
+
+/-- The squared Gaussian integral is `π` — the area-of-circle identity:
+`(∫ exp(-x²) dx)² = ∫∫ exp(-(x²+y²)) = π`. -/
+theorem gaussian_unit_sq : (∫ x : ℝ, Real.exp (-x ^ 2)) ^ 2 = π := by
+  rw [gaussian_unit, Real.sq_sqrt Real.pi_pos.le]
+
+/-- The variance-`1` (after the `1/2` convention) normalization:
+`∫ exp(-x²/2) dx = √(2π)`. -/
+theorem gaussian_half : ∫ x : ℝ, Real.exp (-x ^ 2 / 2) = Real.sqrt (2 * π) := by
+  have h := integral_gaussian (1 / 2)
+  have hfun : (fun x : ℝ => Real.exp (-x ^ 2 / 2)) = (fun x => Real.exp (-(1 / 2) * x ^ 2)) := by
+    funext x; congr 1; ring
+  rw [hfun, h]
+  congr 1
+  rw [show π / (1 / 2) = 2 * π by ring]
+
+/-- **Standard normal normalization.** `∫ (1/√(2π))·exp(-x²/2) dx = 1`. -/
+theorem std_normal_normalization :
+    ∫ x : ℝ, (1 / Real.sqrt (2 * π)) * Real.exp (-x ^ 2 / 2) = 1 := by
+  rw [integral_const_mul, gaussian_half, one_div, inv_mul_cancel₀ (ne_of_gt sqrt_two_pi_pos)]
+
+/-- General variance: `∫ exp(-x²/(2σ²)) dx = σ·√(2π)` for `σ > 0`. -/
+theorem gaussian_variance (σ : ℝ) (hσ : 0 < σ) :
+    ∫ x : ℝ, Real.exp (-x ^ 2 / (2 * σ ^ 2)) = σ * Real.sqrt (2 * π) := by
+  have h := integral_gaussian (1 / (2 * σ ^ 2))
+  have hfun : (fun x : ℝ => Real.exp (-x ^ 2 / (2 * σ ^ 2)))
+      = (fun x => Real.exp (-(1 / (2 * σ ^ 2)) * x ^ 2)) := by
+    funext x; congr 1
+    field_simp
+  rw [hfun, h]
+  rw [show π / (1 / (2 * σ ^ 2)) = σ ^ 2 * (2 * π) by field_simp]
+  rw [Real.sqrt_mul (sq_nonneg σ), Real.sqrt_sq hσ.le]
+
+/-- **General Gaussian normalization** (mean `0`, variance `σ²`):
+`∫ (1/(σ·√(2π)))·exp(-x²/(2σ²)) dx = 1` for `σ > 0`. -/
+theorem gaussian_variance_normalization (σ : ℝ) (hσ : 0 < σ) :
+    ∫ x : ℝ, (1 / (σ * Real.sqrt (2 * π))) * Real.exp (-x ^ 2 / (2 * σ ^ 2)) = 1 := by
+  rw [integral_const_mul, gaussian_variance σ hσ, one_div,
+    inv_mul_cancel₀ (by positivity)]
+
+/-- **Mean shift.** Translating the variable leaves the Gaussian integral
+unchanged: `∫ exp(-(x-μ)²/2) dx = √(2π)` — the normal density has the same mass
+for every mean `μ`. -/
+theorem gaussian_mean_shift (μ : ℝ) :
+    ∫ x : ℝ, Real.exp (-(x - μ) ^ 2 / 2) = Real.sqrt (2 * π) := by
+  rw [← gaussian_half]
+  exact integral_sub_right_eq_self (fun x => Real.exp (-x ^ 2 / 2)) μ
+
+end AreaOfCircleOQ05Incomplete01

--- a/proofs/Proofs/CentralLimitTheoremOQ01OQ04.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ01OQ04.lean
@@ -1,0 +1,171 @@
+/-
+# Central Limit Theorem OQ-01-OQ-04 — toward a Berry–Esseen rate for α-stable laws
+
+*Open question (central-limit-theorem-oq-01-oq-04).* The Berry–Esseen theorem
+gives the rate of convergence in the classical CLT: if `X₁, …, Xₙ` are i.i.d.
+with mean 0, variance `σ² > 0` and finite third moment `ρ = E|X|³`, then
+
+  sup_x |F_n(x) − Φ(x)|  ≤  C · ρ / (σ³ √n).
+
+Can this rate-of-convergence theorem be generalized to the α-stable limit laws
+(α < 2) that govern the infinite-variance CLT of the parent file? This is genuinely
+hard. This entry isolates, axiom-free, *the analytic mechanism* of Berry–Esseen
+and *the precise obstruction* to extending it below α = 2.
+
+## The mechanism (reused from Mathlib)
+
+Berry–Esseen compares the characteristic function `φ_n(t)` of the normalized sum
+to the Gaussian `e^{−t²/2}`. The comparison rests on Taylor bounds for the
+integrand `e^{iax}`:
+
+  ‖e^{ia} − 1‖ ≤ 2|a|,    ‖e^{ia} − (1 + ia)‖ ≤ a².
+
+Integrating the second against the law of `X` turns the `a²` remainder into a
+*variance / third-moment* term — this is why a finite third moment yields the
+`ρ/(σ³√n)` rate. We restate these deterministic kernel bounds
+(`charFun_kernel_first`, `charFun_kernel_second`) from Mathlib's
+`Complex.norm_exp_sub_one_le` / `norm_exp_sub_one_sub_id_le`.
+
+## The obstruction (the new content)
+
+For the standard symmetric α-stable law the (real, by symmetry) characteristic
+function is `φ_α(t) = exp(−|t|^α)` (parent file). Near `t = 0` the Gaussian
+correction is *quadratic* (`1 − t²/2 + …`), but the α-stable correction is
+`1 − |t|^α + …` with `|t|^α` **sub-quadratic** for `α < 2`:
+
+  for `0 < t < 1`,  `t² < t^α`  (so `φ_α(t) < φ_2(t)`: α-stable decays faster near 0),
+  for `t > 1`,      `t^α < t²`  (so `φ_α(t) > φ_2(t)`: heavier frequency tail),
+
+with the crossover exactly at `t = 1`. The sub-quadratic deviation near `0` is
+the analytic signature of infinite variance: the `a²`-remainder argument above
+integrates to an infinite (variance) constant, so the classical Berry–Esseen
+expansion has **no finite α < 2 analogue** — any α-stable rate theorem must
+replace the second-order expansion by one matched to the `|t|^α` exponent. We
+make the crossover precise (`stablePhi_lt_gaussian`, `stablePhi_gt_gaussian`,
+`exponent_crossover_at_one`) and record the α = 2 (Gaussian) and α = 1 (Cauchy)
+specializations.
+
+Everything is checked by the kernel with no axioms and no `native_decide`.
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.Complex.Exponential
+import Mathlib.Tactic
+
+open Real
+
+namespace CLTOQ01OQ04
+
+/-!
+## The standard symmetric α-stable characteristic function (real form)
+
+By symmetry the characteristic function is real: `φ_α(t) = exp(−|t|^α)`, where
+`|t|^α` is the real power `Real.rpow`. This matches `stableCharFun` of the
+parent file on the real axis.
+-/
+
+/-- Real form of the standard symmetric α-stable characteristic function,
+`φ_α(t) = exp(−|t|^α)`. -/
+noncomputable def stablePhi (α t : ℝ) : ℝ := Real.exp (-(|t| ^ α))
+
+/-- α = 2 is the Gaussian: `φ_2(t) = exp(−t²)`. -/
+theorem stablePhi_two (t : ℝ) : stablePhi 2 t = Real.exp (-(t ^ 2)) := by
+  unfold stablePhi
+  rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) from by norm_num, Real.rpow_natCast, sq_abs]
+
+/-- α = 1 is the Cauchy law: `φ_1(t) = exp(−|t|)`. -/
+theorem stablePhi_one (t : ℝ) : stablePhi 1 t = Real.exp (-|t|) := by
+  unfold stablePhi; rw [Real.rpow_one]
+
+/-- `φ_α(0) = 1` for every `α > 0` (a characteristic function at 0). -/
+theorem stablePhi_zero (α : ℝ) (hα : 0 < α) : stablePhi α 0 = 1 := by
+  unfold stablePhi
+  rw [abs_zero, Real.zero_rpow (ne_of_gt hα), neg_zero, Real.exp_zero]
+
+/-- `φ_α(t) > 0`: the real characteristic function is strictly positive. -/
+theorem stablePhi_pos (α t : ℝ) : 0 < stablePhi α t := Real.exp_pos _
+
+/-!
+## The frequency-domain crossover: α-stable vs Gaussian
+
+The exponent `|t|^α` crosses the Gaussian exponent `t²` exactly at `|t| = 1`.
+This is the analytic heart of "infinite variance": sub-quadratic near 0.
+-/
+
+/-- Below the crossover (`0 < t < 1`) the α-stable exponent exceeds the Gaussian:
+`t² < t^α` for `α < 2`. -/
+theorem exponent_gt_sq {α t : ℝ} (hα : α < 2) (ht0 : 0 < t) (ht1 : t < 1) :
+    t ^ (2 : ℝ) < t ^ α :=
+  Real.rpow_lt_rpow_of_exponent_gt ht0 ht1 hα
+
+/-- Above the crossover (`t > 1`) the Gaussian exponent dominates:
+`t^α < t²` for `α < 2`. -/
+theorem exponent_lt_sq {α t : ℝ} (hα : α < 2) (ht : 1 < t) :
+    t ^ α < t ^ (2 : ℝ) :=
+  Real.rpow_lt_rpow_of_exponent_lt ht hα
+
+/-- At the crossover the two exponents agree: `1^α = 1^2 = 1`. -/
+theorem exponent_crossover_at_one (α : ℝ) :
+    (1 : ℝ) ^ α = (1 : ℝ) ^ (2 : ℝ) := by
+  rw [Real.one_rpow, Real.one_rpow]
+
+/-- **Sub-quadratic deviation near 0.** For `0 < t < 1` and `α < 2`, the
+α-stable characteristic function lies *below* the Gaussian: it decays faster
+near the origin because its exponent is larger there. -/
+theorem stablePhi_lt_gaussian {α t : ℝ} (hα : α < 2) (ht0 : 0 < t) (ht1 : t < 1) :
+    stablePhi α t < stablePhi 2 t := by
+  unfold stablePhi
+  apply Real.exp_lt_exp.mpr
+  have hat0 : (0 : ℝ) < |t| := by rwa [abs_of_pos ht0]
+  have hat1 : |t| < 1 := by rwa [abs_of_pos ht0]
+  have h : |t| ^ (2 : ℝ) < |t| ^ α := Real.rpow_lt_rpow_of_exponent_gt hat0 hat1 hα
+  linarith
+
+/-- **Heavier frequency tail.** For `t > 1` and `α < 2`, the α-stable
+characteristic function lies *above* the Gaussian. -/
+theorem stablePhi_gt_gaussian {α t : ℝ} (hα : α < 2) (ht : 1 < t) :
+    stablePhi 2 t < stablePhi α t := by
+  unfold stablePhi
+  apply Real.exp_lt_exp.mpr
+  have hat : (1 : ℝ) < |t| := by rwa [abs_of_pos (lt_trans one_pos ht)]
+  have h : |t| ^ α < |t| ^ (2 : ℝ) := Real.rpow_lt_rpow_of_exponent_lt hat hα
+  linarith
+
+/-- At the crossover point the two laws share the same characteristic value. -/
+theorem stablePhi_eq_at_one (α : ℝ) : stablePhi α 1 = stablePhi 2 1 := by
+  unfold stablePhi
+  rw [abs_one, Real.one_rpow, Real.one_rpow]
+
+/-!
+## The deterministic Berry–Esseen kernel
+
+These are the Taylor bounds for the characteristic-function integrand
+`e^{ia} = exp(i·a)` (`a = t·x`), restated from Mathlib. Integrating the
+second bound against the law of `X` is exactly how Berry–Esseen converts a
+finite third moment into the `ρ/(σ³√n)` rate.
+-/
+
+/-- First-order kernel bound: `‖e^{ia} − 1‖ ≤ 2|a|` for `|a| ≤ 1`. -/
+theorem charFun_kernel_first {a : ℝ} (ha : |a| ≤ 1) :
+    ‖Complex.exp ((a : ℂ) * Complex.I) - 1‖ ≤ 2 * |a| := by
+  have hnorm : ‖(a : ℂ) * Complex.I‖ = |a| := by
+    rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real, Real.norm_eq_abs]
+  have h := Complex.norm_exp_sub_one_le (x := (a : ℂ) * Complex.I) (by rw [hnorm]; exact ha)
+  rwa [hnorm] at h
+
+/-- Second-order kernel bound: `‖e^{ia} − (1 + ia)‖ ≤ a²` for `|a| ≤ 1`.
+The `a²` remainder is what becomes a variance/third-moment term after
+integration — the engine of the classical Berry–Esseen rate. -/
+theorem charFun_kernel_second {a : ℝ} (ha : |a| ≤ 1) :
+    ‖Complex.exp ((a : ℂ) * Complex.I) - (1 + (a : ℂ) * Complex.I)‖ ≤ a ^ 2 := by
+  have hnorm : ‖(a : ℂ) * Complex.I‖ = |a| := by
+    rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real, Real.norm_eq_abs]
+  have h := Complex.norm_exp_sub_one_sub_id_le (x := (a : ℂ) * Complex.I)
+    (by rw [hnorm]; exact ha)
+  rw [hnorm] at h
+  calc ‖Complex.exp ((a : ℂ) * Complex.I) - (1 + (a : ℂ) * Complex.I)‖
+      = ‖Complex.exp ((a : ℂ) * Complex.I) - 1 - (a : ℂ) * Complex.I‖ := by ring_nf
+    _ ≤ |a| ^ 2 := h
+    _ = a ^ 2 := sq_abs a
+
+end CLTOQ01OQ04

--- a/proofs/Proofs/CevasTheoremNonEuclideanOQ03.lean
+++ b/proofs/Proofs/CevasTheoremNonEuclideanOQ03.lean
@@ -1,0 +1,174 @@
+/-
+# Ceva Non-Euclidean OQ-03 — the hexagon ratio algebra behind Pappus–Brianchon
+
+*Open question (cevas-theorem-non-euclidean-oq-03).* Use the abstract
+`GeneralizedCevianConfig` to approach the non-Euclidean Pappus–Brianchon
+theorems.
+
+## Background
+
+The parent `CevasTheoremNonEuclidean.lean` packages a Ceva/Menelaus
+configuration as six positive "measures" `bd, dc, ce, ea, af, fb`
+(`GeneralizedCevianConfig`) and studies the ratio product
+
+  `P(cfg) = (bd/dc)·(ce/ea)·(af/fb)`  (`generalizedCevaProduct`),
+
+with `P(cfg) = 1` the geometry-independent concurrence/collinearity condition.
+Specializing the measures to `id`, `sin`, `sinh` recovers the Euclidean,
+spherical, and hyperbolic theorems.
+
+Pappus's and Brianchon's theorems are *hexagon* incidence theorems. The six
+measures of a `GeneralizedCevianConfig` are exactly the six sides of the Pappus
+hexagon (vertices alternating on two geodesics, a degenerate conic). The
+algebraic invariant of such a hexagon is the relation between the two
+**alternating products** of its side-ratios — and that relation is the same in
+every constant-curvature geometry. This file isolates that invariant.
+
+## What is proved (0 axioms, 0 sorries)
+
+* `dualCevaProduct cfg = (dc/ce)·(ea/af)·(fb/bd)` — the *cyclically shifted*
+  alternating product (the "other" three sides of the hexagon).
+* **`ceva_dual_reciprocal`**: `P(cfg) · dualCevaProduct cfg = 1`. The two
+  alternating products of a hexagon are reciprocal — a pure telescoping
+  cancellation of all six measures. This is the hexagon closure relation.
+* **`ceva_iff_dual`**: `P(cfg) = 1 ↔ dualCevaProduct cfg = 1`. The Ceva
+  condition and its Brianchon-style dual hold together — the duality at the
+  level of the abstract configuration.
+* **`cevaProduct_comp` / `dualProduct_comp`**: both products are multiplicative
+  under componentwise composition of configurations (`comp`). This is the
+  chaining law by which the classical Pappus proof multiplies several
+  transversal relations.
+* Non-Euclidean instances `spherical_ceva_dual_reciprocal`,
+  `hyperbolic_ceva_dual_reciprocal`: the reciprocity holds verbatim with `sin`
+  and `sinh` measures, i.e. on the sphere and in the hyperbolic plane.
+
+## Scope (honest)
+
+This formalizes the *algebraic hexagon invariant* on which the non-Euclidean
+Pappus–Brianchon incidence theorems rest — the geometry-independent closure
+relation among side-ratios, captured entirely inside `GeneralizedCevianConfig`.
+It does **not** derive the full projective incidence statement (which needs the
+combinatorics of lines and intersection points); that is future work that can
+build on the composition law proved here. Everything below is checked by the
+kernel with no axioms.
+-/
+
+import Proofs.CevasTheoremNonEuclidean
+import Mathlib.Tactic
+
+namespace CevaNonEuclideanOQ03
+
+/-!
+## The dual (cyclically shifted) ratio product
+-/
+
+/-- The cyclically shifted alternating product `(dc/ce)·(ea/af)·(fb/bd)` — the
+"other three sides" of the Pappus hexagon relative to `generalizedCevaProduct`. -/
+noncomputable def dualCevaProduct (cfg : GeneralizedCevianConfig) : ℝ :=
+  (cfg.dc / cfg.ce) * (cfg.ea / cfg.af) * (cfg.fb / cfg.bd)
+
+/-- **Hexagon closure relation.** The Ceva product and its cyclic dual are
+reciprocal: every one of the six measures cancels. -/
+theorem ceva_dual_reciprocal (cfg : GeneralizedCevianConfig) :
+    generalizedCevaProduct cfg * dualCevaProduct cfg = 1 := by
+  unfold generalizedCevaProduct dualCevaProduct
+  have h1 := ne_of_gt cfg.bd_pos
+  have h2 := ne_of_gt cfg.dc_pos
+  have h3 := ne_of_gt cfg.ce_pos
+  have h4 := ne_of_gt cfg.ea_pos
+  have h5 := ne_of_gt cfg.af_pos
+  have h6 := ne_of_gt cfg.fb_pos
+  field_simp
+
+/-- **Ceva–Brianchon duality (abstract).** The Ceva concurrence condition and
+its hexagon dual hold together. -/
+theorem ceva_iff_dual (cfg : GeneralizedCevianConfig) :
+    generalizedCevaProduct cfg = 1 ↔ dualCevaProduct cfg = 1 := by
+  have hrec := ceva_dual_reciprocal cfg
+  constructor
+  · intro h; rw [h, one_mul] at hrec; exact hrec
+  · intro h; rw [h, mul_one] at hrec; exact hrec
+
+/-- The dual product is positive. -/
+theorem dualCevaProduct_pos (cfg : GeneralizedCevianConfig) :
+    0 < dualCevaProduct cfg := by
+  unfold dualCevaProduct
+  have := cfg.bd_pos; have := cfg.ce_pos; have := cfg.af_pos
+  have := cfg.dc_pos; have := cfg.ea_pos; have := cfg.fb_pos
+  positivity
+
+/-!
+## Composition: the chaining law
+-/
+
+/-- Componentwise composition of two configurations (multiply matching
+measures). The classical Pappus proof multiplies several such relations. -/
+noncomputable def comp (c1 c2 : GeneralizedCevianConfig) : GeneralizedCevianConfig where
+  bd := c1.bd * c2.bd
+  dc := c1.dc * c2.dc
+  ce := c1.ce * c2.ce
+  ea := c1.ea * c2.ea
+  af := c1.af * c2.af
+  fb := c1.fb * c2.fb
+  bd_pos := mul_pos c1.bd_pos c2.bd_pos
+  dc_pos := mul_pos c1.dc_pos c2.dc_pos
+  ce_pos := mul_pos c1.ce_pos c2.ce_pos
+  ea_pos := mul_pos c1.ea_pos c2.ea_pos
+  af_pos := mul_pos c1.af_pos c2.af_pos
+  fb_pos := mul_pos c1.fb_pos c2.fb_pos
+
+/-- The Ceva product is multiplicative under composition. -/
+theorem cevaProduct_comp (c1 c2 : GeneralizedCevianConfig) :
+    generalizedCevaProduct (comp c1 c2)
+      = generalizedCevaProduct c1 * generalizedCevaProduct c2 := by
+  unfold generalizedCevaProduct comp
+  have h1 := ne_of_gt c1.dc_pos
+  have h2 := ne_of_gt c2.dc_pos
+  have h3 := ne_of_gt c1.ea_pos
+  have h4 := ne_of_gt c2.ea_pos
+  have h5 := ne_of_gt c1.fb_pos
+  have h6 := ne_of_gt c2.fb_pos
+  field_simp
+
+/-- The dual product is multiplicative under composition. -/
+theorem dualProduct_comp (c1 c2 : GeneralizedCevianConfig) :
+    dualCevaProduct (comp c1 c2)
+      = dualCevaProduct c1 * dualCevaProduct c2 := by
+  unfold dualCevaProduct comp
+  have h1 := ne_of_gt c1.ce_pos
+  have h2 := ne_of_gt c2.ce_pos
+  have h3 := ne_of_gt c1.af_pos
+  have h4 := ne_of_gt c2.af_pos
+  have h5 := ne_of_gt c1.bd_pos
+  have h6 := ne_of_gt c2.bd_pos
+  field_simp
+
+/-- **Closure under composition.** If two configurations each satisfy the Ceva
+condition, so does their composite — the multiplicative step that assembles a
+Pappus-type conclusion from several transversal relations. -/
+theorem ceva_comp_of_ceva {c1 c2 : GeneralizedCevianConfig}
+    (h1 : generalizedCevaProduct c1 = 1) (h2 : generalizedCevaProduct c2 = 1) :
+    generalizedCevaProduct (comp c1 c2) = 1 := by
+  rw [cevaProduct_comp, h1, h2, mul_one]
+
+/-!
+## Non-Euclidean instances
+
+The reciprocity is a statement about the abstract configuration, so it holds in
+every constant-curvature geometry by feeding the geodesic-arc measures through
+`sin` (spherical) or `sinh` (hyperbolic).
+-/
+
+/-- **Spherical hexagon closure**: the reciprocity with `sin` measures. -/
+theorem spherical_ceva_dual_reciprocal (cfg : SphericalCevianConfig) :
+    generalizedCevaProduct cfg.toGeneralized
+      * dualCevaProduct cfg.toGeneralized = 1 :=
+  ceva_dual_reciprocal cfg.toGeneralized
+
+/-- **Hyperbolic hexagon closure**: the reciprocity with `sinh` measures. -/
+theorem hyperbolic_ceva_dual_reciprocal (cfg : HyperbolicCevianConfig) :
+    generalizedCevaProduct cfg.toGeneralized
+      * dualCevaProduct cfg.toGeneralized = 1 :=
+  ceva_dual_reciprocal cfg.toGeneralized
+
+end CevaNonEuclideanOQ03

--- a/proofs/Proofs/Erdos733RichLines.lean
+++ b/proofs/Proofs/Erdos733RichLines.lean
@@ -1,0 +1,185 @@
+/-
+# Erdős Problem #733 — the elementary rich-line bound
+
+**Parent.** `Erdos733Problem.lean` (registered) formalizes the count
+`f(n) = countLineCompatible n` of line-compatible sequences and records the
+Szemerédi–Trotter answer `f(n) = exp(Θ(√n))` as the two axioms `lower_bound`
+and `upper_bound`. Its **Part III** states, as an unproved docstring claim, the
+Szemerédi–Trotter corollary on rich lines:
+
+> *The number of k-rich lines (lines with ≥ k points) is `O(n²/k³ + n/k)`.*
+
+That corollary is exactly the engine that drives the (axiomatized) upper bound,
+yet the registered file proves nothing about it. This file fills that gap with
+the **elementary, unconditional** rich-line estimate — the baseline that
+Szemerédi–Trotter then improves.
+
+## The statement (fully proved here, 0 axioms, 0 sorries)
+
+For a finite point set `P` (`|P| = n`) and a family `lines` of subsets, *assume
+only the defining property of lines in the plane*: any two distinct lines meet
+in at most one point. Then for every `k`,
+
+> `#{ L : |L| ≥ k } · C(k,2)  ≤  C(n,2)`,  hence  `#{ L : |L| ≥ k } ≤ C(n,2) / C(k,2)`.
+
+This is the classic double-counting bound: each line `L` carries the `C(|L|,2)`
+two-element subsets of its points; because two distinct lines share at most one
+point, **no pair lies on two lines**, so the pair-sets are pairwise disjoint and
+together fit inside the `C(n,2)` pairs of `P`. Summing the lower estimate
+`C(k,2) ≤ C(|L|,2)` over the rich lines gives the bound.
+
+## Honest comparison with Szemerédi–Trotter
+
+The bound here is `#rich-lines = O(n²/k²)`. Szemerédi–Trotter improves the
+exponent on `k` from `2` to `3` (plus an `n/k` term): `O(n²/k³ + n/k)`. The
+improvement is genuinely deep — it is the content of the parent's axioms — but
+the `O(n²/k²)` baseline is completely elementary and is what we machine-check
+here. No incidence theorem, no real-analytic input: just the linear-space
+hypothesis (`hlin`) and counting two-element subsets.
+
+## On assumptions
+
+`hsub` (lines are subsets of the point set) and `hlin` (two distinct lines meet
+in ≤ 1 point) are **hypotheses of the theorems**, not axioms: every statement is
+`∀ P lines, hsub → hlin → …`. There are no `axiom` declarations and no
+assumption-carrying structure fields, so the file is genuinely 0-axiom.
+`hlin` is precisely the abstract "linear space" / "partial linear space"
+property satisfied by honest lines in `ℝ²` (two points determine a unique line),
+so the bound applies verbatim to the geometric setting of `Erdos733Problem`.
+-/
+
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Data.Nat.Choose.Basic
+
+open Finset
+
+namespace Erdos733RichLines
+
+/-!
+## The core double-counting inequality
+
+The sum, over all lines, of the number of point-pairs on each line is at most
+the total number of point-pairs `C(n,2)`. This is the heart of every rich-line
+bound; everything below is a corollary.
+-/
+
+/--
+**Pairs on distinct lines are disjoint.**
+If two lines `L₁ ≠ L₂` meet in at most one point, then no two-element subset of
+points lies on both: the two-element subsets they carry are disjoint families.
+-/
+theorem disjoint_pairs {V : Type*} [DecidableEq V]
+    {L₁ L₂ : Finset V} (h : (L₁ ∩ L₂).card ≤ 1) :
+    Disjoint (L₁.powersetCard 2) (L₂.powersetCard 2) := by
+  rw [Finset.disjoint_left]
+  intro s hs1 hs2
+  rw [Finset.mem_powersetCard] at hs1 hs2
+  have hss : s ⊆ L₁ ∩ L₂ := Finset.subset_inter hs1.1 hs2.1
+  have hle : s.card ≤ (L₁ ∩ L₂).card := Finset.card_le_card hss
+  rw [hs1.2] at hle
+  omega
+
+/--
+**Core bound (double counting of point-pairs).**
+For a finite point set `P` and a family `lines` of subsets, each pair of distinct
+lines meeting in at most one point,
+`∑_{L ∈ lines} C(|L|,2) ≤ C(|P|,2)`.
+-/
+theorem sum_choose_two_le {V : Type*} [DecidableEq V]
+    (P : Finset V) (lines : Finset (Finset V))
+    (hsub : ∀ L ∈ lines, L ⊆ P)
+    (hlin : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) :
+    ∑ L ∈ lines, (L.card).choose 2 ≤ (P.card).choose 2 := by
+  -- Rewrite each `C(|L|,2)` as the cardinality of the two-element subsets of `L`.
+  have hcard : ∀ L ∈ lines, (L.card).choose 2 = (L.powersetCard 2).card := by
+    intro L _
+    rw [Finset.card_powersetCard]
+  rw [Finset.sum_congr rfl hcard]
+  -- The pair-families are pairwise disjoint, so their sizes sum to the size of
+  -- their union.
+  have hdisj : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ →
+      Disjoint (L₁.powersetCard 2) (L₂.powersetCard 2) :=
+    fun L₁ h1 L₂ h2 hne => disjoint_pairs (hlin L₁ h1 L₂ h2 hne)
+  rw [← Finset.card_biUnion hdisj, ← Finset.card_powersetCard 2 P]
+  -- That union is contained in the two-element subsets of `P`.
+  apply Finset.card_le_card
+  intro s hs
+  rw [Finset.mem_biUnion] at hs
+  obtain ⟨L, hL, hsL⟩ := hs
+  rw [Finset.mem_powersetCard] at hsL ⊢
+  exact ⟨hsL.1.trans (hsub L hL), hsL.2⟩
+
+/-!
+## The rich-line bound
+-/
+
+/--
+**Elementary rich-line bound.**
+With `n = |P|`, the number of lines containing at least `k` points satisfies
+`#{ L : |L| ≥ k } · C(k,2) ≤ C(n,2)`.
+This is the unconditional baseline that Szemerédi–Trotter later sharpens.
+-/
+theorem rich_line_bound {V : Type*} [DecidableEq V]
+    (P : Finset V) (lines : Finset (Finset V))
+    (hsub : ∀ L ∈ lines, L ⊆ P)
+    (hlin : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1)
+    (k : ℕ) :
+    (lines.filter (fun L => k ≤ L.card)).card * k.choose 2 ≤ (P.card).choose 2 := by
+  set S := lines.filter (fun L => k ≤ L.card) with hS
+  calc S.card * k.choose 2
+      = ∑ _L ∈ S, k.choose 2 := (Finset.sum_const_nat (fun _ _ => rfl)).symm
+    _ ≤ ∑ L ∈ S, (L.card).choose 2 := by
+        apply Finset.sum_le_sum
+        intro L hL
+        rw [hS, Finset.mem_filter] at hL
+        exact Nat.choose_le_choose 2 hL.2
+    _ ≤ ∑ L ∈ lines, (L.card).choose 2 :=
+        Finset.sum_le_sum_of_subset (Finset.filter_subset _ _)
+    _ ≤ (P.card).choose 2 := sum_choose_two_le P lines hsub hlin
+
+/--
+**Rich-line count (division form).**
+For `k ≥ 2`, the number of `k`-rich lines is at most `C(n,2) / C(k,2)` (with
+`n = |P|`), the familiar `O(n²/k²)` estimate.
+-/
+theorem rich_line_count_le {V : Type*} [DecidableEq V]
+    (P : Finset V) (lines : Finset (Finset V))
+    (hsub : ∀ L ∈ lines, L ⊆ P)
+    (hlin : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1)
+    (k : ℕ) (hk : 2 ≤ k) :
+    (lines.filter (fun L => k ≤ L.card)).card ≤ (P.card).choose 2 / k.choose 2 := by
+  have hpos : 0 < k.choose 2 := Nat.choose_pos hk
+  rw [Nat.le_div_iff_mul_le hpos]
+  exact rich_line_bound P lines hsub hlin k
+
+/--
+**Number of proper lines.**
+A line with at least two points is "proper". Taking `k = 2` (so `C(2,2) = 1`),
+the number of proper lines is at most `C(n,2)` — each is charged to a distinct
+point-pair. (This is the easy direction of de Bruijn–Erdős-type counting.)
+-/
+theorem num_proper_lines_le {V : Type*} [DecidableEq V]
+    (P : Finset V) (lines : Finset (Finset V))
+    (hsub : ∀ L ∈ lines, L ⊆ P)
+    (hlin : ∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) :
+    (lines.filter (fun L => 2 ≤ L.card)).card ≤ (P.card).choose 2 := by
+  have h := rich_line_bound P lines hsub hlin 2
+  simpa using h
+
+/--
+**Monotonicity in `k`.**
+Fewer lines are `k'`-rich than `k`-rich when `k ≤ k'`; combined with
+`rich_line_bound` this lets a single pair budget control every threshold.
+-/
+theorem rich_lines_antitone {V : Type*} [DecidableEq V]
+    (lines : Finset (Finset V)) {k k' : ℕ} (hk : k ≤ k') :
+    (lines.filter (fun L => k' ≤ L.card)).card
+      ≤ (lines.filter (fun L => k ≤ L.card)).card := by
+  apply Finset.card_le_card
+  intro L hL
+  rw [Finset.mem_filter] at hL ⊢
+  exact ⟨hL.1, le_trans hk hL.2⟩
+
+end Erdos733RichLines

--- a/proofs/Proofs/Erdos823SigmaValues.lean
+++ b/proofs/Proofs/Erdos823SigmaValues.lean
@@ -1,0 +1,132 @@
+/-
+# Erdős Problem #823 — σ values computed from Mathlib, axiom-free
+
+**Parent.** `Erdos823Problem.lean` (registered) formalizes Pollack's theorem that
+for every α ≥ 1 there are sequences nₖ/mₖ → α with σ(nₖ) = σ(mₖ), where σ is the
+sum-of-divisors function. Its motivating example is the smallest nontrivial
+σ-pair, σ(14) = σ(15) = 24.
+
+**Why this file exists.** The parent computes its concrete σ-values
+(`sigma_14_value`, `sigma_15_value`, `sigma_14_15`, …) with `native_decide`.
+Under the project's axiom-integrity policy `native_decide` trusts the compiler
+and depends on `Lean.ofReduceBool`, so those statements are **not axiom-free**:
+they should be counted as axiomatized. This file reproves the genuine σ-values
+**symbolically from Mathlib's arithmetic-function API** — multiplicativity of σ
+plus the value on primes and prime powers — so every result is checked by the
+kernel with no `native_decide` and no `axiom`. `#print axioms` shows only the
+ordinary foundational axioms.
+
+**A latent bug spotted in passing.** The parent also asserts
+`sigma_206_210 : σ 206 = σ 210` via `native_decide`, but this is **false**:
+σ(206) = σ(2·103) = 3·104 = 312 while σ(210) = σ(2·3·5·7) = 3·4·6·8 = 576. We do
+not reproduce it. (206 and 210 are not a σ-pair; the genuine small σ-pairs
+include (14,15) and (957,958).)
+
+**What is proved here (all 0-axiom):**
+- σ(6) = 12, σ(14) = 24, σ(15) = 24, σ(28) = 56, σ(957) = 1440, σ(958) = 1440;
+- the σ-pairs σ(14) = σ(15) and σ(957) = σ(958) — fibers of σ over 24 and 1440
+  each containing two consecutive integers, the phenomenon Pollack's theorem
+  amplifies to arbitrary ratios;
+- 6 and 28 are perfect (σ(n) = 2n), tying into the perfect-number circle.
+
+The method scales to any explicit n via its prime factorization.
+-/
+
+import Mathlib.NumberTheory.ArithmeticFunction.Defs
+import Mathlib.NumberTheory.ArithmeticFunction.Misc
+import Mathlib.NumberTheory.Divisors
+import Mathlib.Tactic.NormNum.Prime
+
+open ArithmeticFunction
+open scoped ArithmeticFunction.sigma
+
+namespace Erdos823SigmaValues
+
+/-!
+## The value of σ on a prime
+
+For a prime `p`, `divisors p = {1, p}` so `σ 1 p = 1 + p`. This is the only
+building block we need beyond multiplicativity.
+-/
+
+/-- `σ 1 p = p + 1` for any prime `p`, proved from `Nat.Prime.divisors`. -/
+theorem sigma_one_prime {p : ℕ} (hp : p.Prime) : σ 1 p = p + 1 := by
+  rw [sigma_one_apply, hp.divisors, Finset.sum_pair (Ne.symm hp.ne_one)]
+  omega
+
+/-!
+## σ values via multiplicativity
+
+`ArithmeticFunction.isMultiplicative_sigma` gives `σ (m*n) = σ m · σ n` for
+coprime `m, n`. Combined with `sigma_one_prime` (and `sigma_one_apply_prime_pow`
+for prime powers) this evaluates σ at any explicit integer.
+-/
+
+/-- σ(6) = 12.  6 = 2·3, so σ(6) = σ(2)·σ(3) = 3·4. -/
+theorem sigma_6 : σ 1 6 = 12 := by
+  rw [show (6 : ℕ) = 2 * 3 from by norm_num,
+      isMultiplicative_sigma.map_mul_of_coprime (show (2 : ℕ).gcd 3 = 1 from by decide),
+      sigma_one_prime (by norm_num), sigma_one_prime (by norm_num)]
+  norm_num
+
+/-- σ(14) = 24.  14 = 2·7, so σ(14) = σ(2)·σ(7) = 3·8. -/
+theorem sigma_14 : σ 1 14 = 24 := by
+  rw [show (14 : ℕ) = 2 * 7 from by norm_num,
+      isMultiplicative_sigma.map_mul_of_coprime (show (2 : ℕ).gcd 7 = 1 from by decide),
+      sigma_one_prime (by norm_num), sigma_one_prime (by norm_num)]
+  norm_num
+
+/-- σ(15) = 24.  15 = 3·5, so σ(15) = σ(3)·σ(5) = 4·6. -/
+theorem sigma_15 : σ 1 15 = 24 := by
+  rw [show (15 : ℕ) = 3 * 5 from by norm_num,
+      isMultiplicative_sigma.map_mul_of_coprime (show (3 : ℕ).gcd 5 = 1 from by decide),
+      sigma_one_prime (by norm_num), sigma_one_prime (by norm_num)]
+  norm_num
+
+/-- σ(28) = 56.  28 = 2²·7, so σ(28) = σ(2²)·σ(7) = (1+2+4)·8 = 7·8. -/
+theorem sigma_28 : σ 1 28 = 56 := by
+  rw [show (28 : ℕ) = 2 ^ 2 * 7 from by norm_num,
+      isMultiplicative_sigma.map_mul_of_coprime (show (2 ^ 2 : ℕ).gcd 7 = 1 from by decide),
+      sigma_one_apply_prime_pow (show Nat.Prime 2 from by norm_num),
+      sigma_one_prime (show Nat.Prime 7 from by norm_num)]
+  simp [Finset.sum_range_succ]
+
+/-- σ(957) = 1440.  957 = 3·11·29, so σ(957) = 4·12·30. -/
+theorem sigma_957 : σ 1 957 = 1440 := by
+  rw [show (957 : ℕ) = 3 * (11 * 29) from by norm_num,
+      isMultiplicative_sigma.map_mul_of_coprime (show (3 : ℕ).gcd (11 * 29) = 1 from by decide),
+      isMultiplicative_sigma.map_mul_of_coprime (show (11 : ℕ).gcd 29 = 1 from by decide),
+      sigma_one_prime (show Nat.Prime 3 from by norm_num),
+      sigma_one_prime (show Nat.Prime 11 from by norm_num),
+      sigma_one_prime (show Nat.Prime 29 from by norm_num)]
+  norm_num
+
+/-- σ(958) = 1440.  958 = 2·479, so σ(958) = 3·480. -/
+theorem sigma_958 : σ 1 958 = 1440 := by
+  rw [show (958 : ℕ) = 2 * 479 from by norm_num,
+      isMultiplicative_sigma.map_mul_of_coprime (show (2 : ℕ).gcd 479 = 1 from by decide),
+      sigma_one_prime (show Nat.Prime 2 from by norm_num),
+      sigma_one_prime (show Nat.Prime 479 from by norm_num)]
+  norm_num
+
+/-!
+## σ-pairs and perfect numbers
+-/
+
+/-- The smallest nontrivial σ-pair: σ(14) = σ(15) = 24 (consecutive integers). -/
+theorem sigma_pair_14_15 : σ 1 14 = σ 1 15 := by rw [sigma_14, sigma_15]
+
+/-- A larger σ-pair of consecutive integers: σ(957) = σ(958) = 1440. -/
+theorem sigma_pair_957_958 : σ 1 957 = σ 1 958 := by rw [sigma_957, sigma_958]
+
+/-- 6 is perfect: σ(6) = 2·6. -/
+theorem six_perfect : σ 1 6 = 2 * 6 := by rw [sigma_6]
+
+/-- 28 is perfect: σ(28) = 2·28. -/
+theorem twentyeight_perfect : σ 1 28 = 2 * 28 := by rw [sigma_28]
+
+/-- Both 14 and 15 lie in the fiber σ⁻¹(24): the concrete witness behind the
+parent's `IsSigmaPair 14 15` and the α = 1 case of Pollack's theorem. -/
+theorem fiber_24 : σ 1 14 = 24 ∧ σ 1 15 = 24 := ⟨sigma_14, sigma_15⟩
+
+end Erdos823SigmaValues

--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "aoc05inc-ann-01",
+    "proofId": "area-of-circle-oq-05-incomplete-01",
+    "range": { "startLine": 39, "endLine": 51 },
+    "type": "concept",
+    "title": "Base case and the area identity",
+    "content": "gaussian_unit re-derives the parent's ∫ e^{-x²} = √π from Mathlib's integral_gaussian at rate b = 1 (the integrand -x² is matched to -1·x² by a pointwise ring rewrite, and √(π/1) = √π). gaussian_unit_sq squares it: (∫ e^{-x²})² = π — the area-of-circle identity, the value the polar-coordinate proof computes as a 2D integral.",
+    "mathContext": "$\\int e^{-x^2} = \\sqrt\\pi$, so $\\left(\\int e^{-x^2}\\right)^2 = \\pi$."
+  },
+  {
+    "id": "aoc05inc-ann-02",
+    "proofId": "area-of-circle-oq-05-incomplete-01",
+    "range": { "startLine": 53, "endLine": 66 },
+    "type": "technique",
+    "title": "√(2π) is just √π at rate 1/2",
+    "content": "gaussian_half takes integral_gaussian at b = 1/2: √(π/(1/2)) = √(2π). The integrand -x²/2 is matched to integral_gaussian's -b·x² form by a pointwise ring rewrite inside the exponent (a `congr 1; ring` after a `funext`). std_normal_normalization then pulls the constant 1/√(2π) out with integral_const_mul and cancels it against √(2π) via inv_mul_cancel₀ — the standard-normal density integrates to 1.",
+    "mathContext": "$\\int e^{-x^2/2} = \\sqrt{\\pi/(1/2)} = \\sqrt{2\\pi}$; $\\frac{1}{\\sqrt{2\\pi}}\\cdot\\sqrt{2\\pi}=1$."
+  },
+  {
+    "id": "aoc05inc-ann-03",
+    "proofId": "area-of-circle-oq-05-incomplete-01",
+    "range": { "startLine": 68, "endLine": 85 },
+    "type": "result",
+    "title": "General variance via √(σ²·2π) = σ√(2π)",
+    "content": "gaussian_variance takes integral_gaussian at b = 1/(2σ²): √(π/(1/(2σ²))) = √(σ²·2π). Splitting the square root (Real.sqrt_mul) and using √(σ²) = σ for σ ≥ 0 (Real.sqrt_sq) gives σ√(2π). gaussian_variance_normalization pulls out 1/(σ√(2π)) and cancels (positivity of the constant via `positivity`), so the N(0,σ²) density integrates to 1.",
+    "mathContext": "$\\int e^{-x^2/(2\\sigma^2)} = \\sqrt{\\sigma^2\\cdot 2\\pi} = \\sigma\\sqrt{2\\pi}$."
+  },
+  {
+    "id": "aoc05inc-ann-04",
+    "proofId": "area-of-circle-oq-05-incomplete-01",
+    "range": { "startLine": 87, "endLine": 95 },
+    "type": "technique",
+    "title": "Mean independence via translation invariance",
+    "content": "gaussian_mean_shift uses translation invariance of the Lebesgue integral (integral_sub_right_eq_self): ∫ f(x-μ) = ∫ f(x). Applied to f = e^{-x²/2}, the mass ∫ e^{-(x-μ)²/2} = √(2π) is the same for every mean μ — so fixing σ normalizes the entire N(μ,σ²) family at once.",
+    "mathContext": "$\\int e^{-(x-\\mu)^2/2} = \\int e^{-x^2/2} = \\sqrt{2\\pi}$ for all $\\mu$."
+  },
+  {
+    "id": "aoc05inc-ann-05",
+    "proofId": "area-of-circle-oq-05-incomplete-01",
+    "range": { "startLine": 10, "endLine": 25 },
+    "type": "caveat",
+    "title": "Scope: a genuinely uncovered strand, not a patch",
+    "content": "The parent area-of-circle-oq-05 is already complete (0 sorries, 0 axioms). This entry, claimed as a 'completion' task, supplies the genuinely uncovered normal-density normalization strand — the rescalings of √π that make the Gaussian a probability density — rather than patching the parent. Siblings handle the polar, multivariate, and complex Gaussian; none handle these 1D normalizations. #print axioms shows only propext / Classical.choice / Quot.sound.",
+    "mathContext": "Parent: $\\int e^{-x^2}=\\sqrt\\pi$. Here: the $\\sqrt{2\\pi},\\ \\sigma\\sqrt{2\\pi}$ normalizations."
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "area-of-circle-oq-05-incomplete-01",
+  "title": "The Normal-Distribution Normalization Family (from the Gaussian Integral)",
+  "slug": "area-of-circle-oq-05-incomplete-01",
+  "description": "Completes the Gaussian-integral strand of the area-of-circle lineage by deriving the normalization constants of the normal distribution — the rescalings of √π that turn the Gaussian into a probability density. The parent area-of-circle-oq-05 proves ∫ e^{-x²} = √π and connects it to circle area; siblings cover the polar proof, the multivariate case, and the complex Gaussian. None cover the normal-density normalization. From Mathlib's integral_gaussian this entry proves: ∫ e^{-x²/2} = √(2π) (gaussian_half); the standard-normal normalization ∫ (1/√(2π))e^{-x²/2} = 1; the general-variance integral ∫ e^{-x²/(2σ²)} = σ√(2π) for σ>0; the N(0,σ²) normalization ∫ (1/(σ√(2π)))e^{-x²/(2σ²)} = 1; the base case √π and the area identity (∫ e^{-x²})² = π; and mean-shift invariance ∫ e^{-(x-μ)²/2} = √(2π) (translation invariance of the integral). 8 theorems, 0 sorries, 0 axioms (no native_decide).",
+  "meta": {
+    "author": "Gauss (Gaussian integral); classical normal-distribution normalization — formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_integral",
+    "date": "1809",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "normal-distribution",
+      "probability",
+      "integration",
+      "area-of-circle"
+    ],
+    "proofRepoPath": "Proofs/AreaOfCircleOQ05Incomplete01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "integral_gaussian",
+      "MeasureTheory.integral_const_mul",
+      "MeasureTheory.integral_sub_right_eq_self",
+      "Real.sqrt_mul",
+      "Real.sqrt_sq",
+      "Real.sq_sqrt",
+      "inv_mul_cancel₀"
+    ],
+    "originalContributions": [
+      "Axiom-free derivation of the normal-distribution normalization constants from Mathlib's integral_gaussian: ∫ e^{-x²/2} = √(2π) and the general ∫ e^{-x²/(2σ²)} = σ√(2π)",
+      "The standard-normal and N(0,σ²) normalizations ∫ (1/√(2π))e^{-x²/2} = 1 and ∫ (1/(σ√(2π)))e^{-x²/(2σ²)} = 1, the probability-density statements the area-of-circle Gaussian integral underwrites",
+      "Mean-shift invariance ∫ e^{-(x-μ)²/2} = √(2π) via translation invariance of the Lebesgue integral (integral_sub_right_eq_self) — the density has the same mass for every mean",
+      "The base case √π and the squared identity (∫ e^{-x²})² = π restated to anchor the family in the area-of-circle context"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 95,
+    "assumptions": "None. Every theorem is derived from Mathlib's integral_gaussian by elementary algebra (sqrt manipulations, integral_const_mul, translation invariance); the variance statements take σ > 0 as an ordinary hypothesis. No axiom declarations, no native_decide, no sorries. #print axioms on the normalization and mean-shift theorems reports only [propext, Classical.choice, Quot.sound]. The parent area-of-circle-oq-05 is already complete; this entry (claimed as a 'completion' task) supplies the genuinely uncovered normal-density normalization strand rather than patching the parent.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Gaussian integral ∫_{-∞}^{∞} e^{-x²} dx = √π is the analytic heart of both the area-of-circle lineage (its square is computed as a 2D integral via polar coordinates, giving π) and probability theory (it normalizes the bell curve). The parent area-of-circle-oq-05 establishes the integral and the circle connection; its siblings formalize the polar proof, the multivariate Gaussian, and the complex Gaussian. The one classical strand left implicit is the chain of rescalings that turn e^{-x²} into the probability density of N(μ, σ²): the constants √(2π) and σ√(2π). This entry makes that chain explicit and axiom-free.",
+    "problemStatement": "From the Gaussian integral ∫ e^{-x²} = √π, derive the normalization constants of the normal distribution: ∫ e^{-x²/2} = √(2π), ∫ e^{-x²/(2σ²)} = σ√(2π), and the probability-density normalizations ∫ (1/√(2π))e^{-x²/2} = 1 and ∫ (1/(σ√(2π)))e^{-x²/(2σ²)} = 1, together with mean-shift invariance — all machine-checked, 0-axiom.",
+    "text": "Each result is a rescaling of Mathlib's integral_gaussian b : ∫ e^{-b x²} = √(π/b). Taking b = 1 recovers √π (gaussian_unit), b = 1/2 gives √(π/(1/2)) = √(2π) (gaussian_half), and b = 1/(2σ²) gives √(π/(1/(2σ²))) = √(2πσ²) = σ√(2π) for σ > 0 (gaussian_variance, using Real.sqrt_mul and Real.sqrt_sq). Each integrand is matched to integral_gaussian's exact form -b·x² by a pointwise ring/field_simp rewrite. The normalizations std_normal_normalization and gaussian_variance_normalization pull the constant out with integral_const_mul and cancel against the integral via inv_mul_cancel₀ (the constants are positive, e.g. sqrt_two_pi_pos). gaussian_unit_sq restates (∫ e^{-x²})² = π, the area-of-circle identity. gaussian_mean_shift uses translation invariance of the Lebesgue integral (integral_sub_right_eq_self) to show the mass is independent of the mean μ.",
+    "proofStrategy": "Reduce every statement to integral_gaussian at the right rate b, then do elementary algebra: pointwise matching of the integrand (ring/field_simp inside the exponent), √ simplification for the variance constant, pull-out-and-cancel for the normalizations, and translation invariance for the mean shift. No new integral is computed from scratch.",
+    "keyInsights": [
+      "The bell curve's normalization constants are not new integrals — they are √π evaluated at different rates b in ∫ e^{-b x²} = √(π/b): b = 1/2 gives √(2π), b = 1/(2σ²) gives σ√(2π).",
+      "Pulling the constant out (integral_const_mul) and cancelling against the integral is all that separates the integral identities from the probability-density normalizations.",
+      "The variance constant σ√(2π) comes from √(π/(1/(2σ²))) = √(σ²·2π) = σ√(2π), needing only σ ≥ 0 to take √(σ²) = σ.",
+      "Translation invariance of the Lebesgue integral makes the normalization independent of the mean μ, so the full N(μ, σ²) family is normalized once σ is fixed.",
+      "The squared identity (∫ e^{-x²})² = π keeps the probabilistic family anchored to its geometric origin — the area swept out in the polar-coordinate proof."
+    ],
+    "prerequisites": [
+      "The Gaussian integral ∫ e^{-x²} = √π and Mathlib's integral_gaussian",
+      "The normal distribution N(μ, σ²) and its density",
+      "Translation invariance of the Lebesgue integral",
+      "Square-root algebra (√(ab) = √a·√b, √(a²) = a)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "base-and-area",
+      "title": "Base case and the area identity",
+      "startLine": 35,
+      "endLine": 51,
+      "summary": "sqrt_two_pi_pos (positivity of the normalization constant), gaussian_unit (∫ e^{-x²} = √π, the parent's result re-derived), and gaussian_unit_sq ((∫ e^{-x²})² = π, the area-of-circle identity).",
+      "mathContext": "$\\int e^{-x^2} = \\sqrt\\pi$; $\\left(\\int e^{-x^2}\\right)^2 = \\pi$."
+    },
+    {
+      "id": "normalizations",
+      "title": "The normal-distribution normalizations",
+      "startLine": 53,
+      "endLine": 85,
+      "summary": "gaussian_half (∫ e^{-x²/2} = √(2π)), std_normal_normalization (∫ (1/√(2π))e^{-x²/2} = 1), gaussian_variance (∫ e^{-x²/(2σ²)} = σ√(2π)), and gaussian_variance_normalization (∫ (1/(σ√(2π)))e^{-x²/(2σ²)} = 1).",
+      "mathContext": "$\\int e^{-x^2/2} = \\sqrt{2\\pi}$; $\\int \\frac{1}{\\sigma\\sqrt{2\\pi}}e^{-x^2/(2\\sigma^2)} = 1$."
+    },
+    {
+      "id": "mean-shift",
+      "title": "Mean-shift invariance",
+      "startLine": 87,
+      "endLine": 95,
+      "summary": "gaussian_mean_shift: ∫ e^{-(x-μ)²/2} = √(2π) for every mean μ, via translation invariance of the Lebesgue integral — the full N(μ,σ²) family is normalized.",
+      "mathContext": "$\\int e^{-(x-\\mu)^2/2} = \\sqrt{2\\pi}$ for all $\\mu$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-05",
+      "relationship": "extends",
+      "description": "The parent proves ∫ e^{-x²} = √π and the circle connection. This entry derives the normal-distribution normalization constants (√(2π), σ√(2π)) and probability-density normalizations from the same Mathlib integral."
+    },
+    {
+      "targetId": "area-of-circle-oq-05-oq-01",
+      "relationship": "related",
+      "description": "OQ-05-OQ-01 formalizes the polar-coordinate proof that the squared Gaussian integral is π (the area-of-circle identity restated here as gaussian_unit_sq); this entry instead develops the 1D probability-density rescalings."
+    }
+  ],
+  "conclusion": {
+    "summary": "The normalization constants of the normal distribution — √(2π), σ√(2π) — and the probability-density normalizations ∫ (1/√(2π))e^{-x²/2} = 1 and ∫ (1/(σ√(2π)))e^{-x²/(2σ²)} = 1 are derived axiom-free from the Gaussian integral ∫ e^{-x²} = √π, together with mean-shift invariance and the area identity (∫ e^{-x²})² = π. The bell curve's constants are exactly √π evaluated at different rates.",
+    "implications": "This completes the elementary 1D strand of the area-of-circle Gaussian-integral lineage with the probability-density normalizations, making explicit the bridge from the geometric Gaussian integral to the normal distribution. The lemmas (rate-matched Gaussian integrals, constant pull-out, mean-shift invariance) are reusable for further probabilistic formalization built on Mathlib's Gaussian API."
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory"
+    ],
+    "namespace": "AreaOfCircleOQ05Incomplete01",
+    "lineCount": 95,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ05Incomplete01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Theoria motus corporum coelestium",
+      "year": "1809",
+      "venue": "—",
+      "note": "Origin of the Gaussian (normal) error distribution whose normalization constants this entry derives."
+    },
+    {
+      "authors": "mathlib community",
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "year": "2024",
+      "venue": "leanprover-community/mathlib4",
+      "note": "Provides integral_gaussian, the source of every rescaling here."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "gaussian_variance_normalization",
+      "type": "core",
+      "description": "The N(0,σ²) normalization: ∫ (1/(σ√(2π)))·e^{-x²/(2σ²)} dx = 1 for σ > 0 — the Gaussian is a probability density.",
+      "leanType": "∀ (σ : ℝ), 0 < σ → ∫ x : ℝ, (1 / (σ * Real.sqrt (2 * π))) * Real.exp (-x ^ 2 / (2 * σ ^ 2)) = 1"
+    },
+    {
+      "name": "gaussian_variance",
+      "type": "core",
+      "description": "General variance Gaussian integral: ∫ e^{-x²/(2σ²)} dx = σ√(2π) for σ > 0, from integral_gaussian at rate 1/(2σ²).",
+      "leanType": "∀ (σ : ℝ), 0 < σ → ∫ x : ℝ, Real.exp (-x ^ 2 / (2 * σ ^ 2)) = σ * Real.sqrt (2 * π)"
+    },
+    {
+      "name": "std_normal_normalization",
+      "type": "corollary",
+      "description": "Standard-normal normalization: ∫ (1/√(2π))·e^{-x²/2} dx = 1.",
+      "leanType": "∫ x : ℝ, (1 / Real.sqrt (2 * π)) * Real.exp (-x ^ 2 / 2) = 1"
+    },
+    {
+      "name": "gaussian_mean_shift",
+      "type": "corollary",
+      "description": "Mean-shift invariance: ∫ e^{-(x-μ)²/2} dx = √(2π) for every μ, by translation invariance of the Lebesgue integral.",
+      "leanType": "∀ (μ : ℝ), ∫ x : ℝ, Real.exp (-(x - μ) ^ 2 / 2) = Real.sqrt (2 * π)"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-04/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "cltoq0104-ann-01",
+    "proofId": "central-limit-theorem-oq-01-oq-04",
+    "range": { "startLine": 67, "endLine": 86 },
+    "type": "concept",
+    "title": "The real symmetric α-stable characteristic function",
+    "content": "By symmetry the standard α-stable characteristic function is real: `stablePhi α t = exp(−|t|^α)`, where `|t|^α` is the real power `Real.rpow`. This is the real-axis form of the parent file's `stableCharFun`. Two specializations anchor it: α = 2 gives the Gaussian `exp(−t²)` (`stablePhi_two`, via `Real.rpow_natCast` and `sq_abs`), and α = 1 gives the Cauchy law `exp(−|t|)` (`stablePhi_one`). It is normalized (`φ_α(0)=1`) and strictly positive.",
+    "mathContext": "$\\varphi_\\alpha(t) = e^{-|t|^\\alpha}$; $\\varphi_2 = e^{-t^2}$, $\\varphi_1 = e^{-|t|}$."
+  },
+  {
+    "id": "cltoq0104-ann-02",
+    "proofId": "central-limit-theorem-oq-01-oq-04",
+    "range": { "startLine": 95, "endLine": 110 },
+    "type": "technique",
+    "title": "Exponent monotonicity: the crossover at |t| = 1",
+    "content": "The comparison of α-stable and Gaussian reduces to comparing the exponents `|t|^α` and `t²`. For a base in (0,1), a *smaller* exponent gives a *larger* power, so `t² < t^α` when α < 2 (`exponent_gt_sq`, from `Real.rpow_lt_rpow_of_exponent_gt`). For a base above 1 the order flips: `t^α < t²` (`exponent_lt_sq`, from `Real.rpow_lt_rpow_of_exponent_lt`). At `t = 1` both equal 1 (`exponent_crossover_at_one`). The single crossover at |t|=1 is the whole story.",
+    "mathContext": "base $<1$: $t^2 < t^\\alpha$; base $>1$: $t^\\alpha < t^2$; equal at $t=1$."
+  },
+  {
+    "id": "cltoq0104-ann-03",
+    "proofId": "central-limit-theorem-oq-01-oq-04",
+    "range": { "startLine": 112, "endLine": 132 },
+    "type": "result",
+    "title": "Sub-quadratic deviation: the obstruction for α < 2",
+    "content": "Exponentiating the exponent inequalities through the strictly monotone `exp` gives the crossover of the characteristic functions themselves: near 0 (`0<t<1`) `stablePhi α t < stablePhi 2 t` — the α-stable law decays faster there because `|t|^α > t²` — while beyond `t=1` it lies above the Gaussian. The deviation near 0 is of order `|t|^α`, *below* the quadratic order that a second-order Taylor (Berry–Esseen) expansion controls. This sub-quadratic deviation is the frequency-domain signature of infinite variance and the precise reason the classical rate argument has no finite α < 2 analogue.",
+    "mathContext": "$0<t<1 \\Rightarrow \\varphi_\\alpha(t) < \\varphi_2(t)$; deviation $\\sim |t|^\\alpha$, sub-quadratic for $\\alpha<2$."
+  },
+  {
+    "id": "cltoq0104-ann-04",
+    "proofId": "central-limit-theorem-oq-01-oq-04",
+    "range": { "startLine": 156, "endLine": 169 },
+    "type": "technique",
+    "title": "The Berry–Esseen kernel: where the third moment enters",
+    "content": "`charFun_kernel_second` restates Mathlib's `Complex.norm_exp_sub_one_sub_id_le` for the integrand `e^{ia}` (a = t·x): `‖e^{ia} − (1 + ia)‖ ≤ a²`. In the classical proof one integrates this against the law of X; the `a²` remainder becomes a variance term and the next-order cubic correction a third-moment term, which is exactly how a finite `ρ = E|X|³` produces the `C·ρ/(σ³√n)` rate. For α-stable laws with α < 2 the corresponding moment is infinite, so this remainder cannot be integrated to a finite constant — the analytic counterpart of the crossover above.",
+    "mathContext": "$\\|e^{ia}-(1+ia)\\| \\le a^2$; integrated $\\Rightarrow$ variance/third-moment term $\\Rightarrow$ $O(1/\\sqrt n)$."
+  },
+  {
+    "id": "cltoq0104-ann-05",
+    "proofId": "central-limit-theorem-oq-01-oq-04",
+    "range": { "startLine": 10, "endLine": 13 },
+    "type": "caveat",
+    "title": "Scope: the obstruction is formalized, not the rate",
+    "content": "This entry does NOT prove an α-stable Berry–Esseen rate — that is the open question and is genuinely hard. It formalizes, axiom-free, the analytic mechanism of the classical theorem and the precise obstruction to extending it below α = 2 (the sub-quadratic |t|^α deviation). The kernel bounds are attributed Mathlib wrappers; the crossover analysis is the new content. #print axioms shows only propext / Classical.choice / Quot.sound.",
+    "mathContext": "Goal: isolate why a Gaussian-rate expansion fails for $\\alpha<2$, not to derive the stable rate."
+  }
+]

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-04/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "central-limit-theorem-oq-01-oq-04",
+  "title": "Toward a Berry–Esseen Rate for α-Stable Laws",
+  "slug": "central-limit-theorem-oq-01-oq-04",
+  "description": "The Berry–Esseen theorem gives the convergence rate in the classical CLT — sup_x |F_n(x) − Φ(x)| ≤ C·ρ/(σ³√n) for finite third moment ρ. Can this rate generalize to the α-stable limit laws (α < 2) of the infinite-variance CLT? This entry isolates, axiom-free, both the analytic mechanism of Berry–Esseen and the precise obstruction to extending it below α = 2. The mechanism: deterministic Taylor bounds on the characteristic-function integrand e^{ia} — ‖e^{ia}−1‖ ≤ 2|a| and ‖e^{ia}−(1+ia)‖ ≤ a² — whose a² remainder integrates to the variance/third-moment term (restated from Mathlib's Complex.norm_exp_sub_one_le / norm_exp_sub_one_sub_id_le). The obstruction (new content): for the standard symmetric α-stable characteristic function φ_α(t) = exp(−|t|^α), the exponent |t|^α is sub-quadratic for α < 2, so near 0 it exceeds t² (φ_α < φ_2) while beyond t = 1 it falls below t² (φ_α > φ_2), with crossover exactly at |t| = 1. The sub-quadratic deviation near 0 is the analytic signature of infinite variance: the a²-remainder argument has no finite α < 2 analogue, so any α-stable rate theorem must match the |t|^α exponent rather than the second order. Recovers Gaussian (α = 2) and Cauchy (α = 1). 12 theorems, 0 sorries, 0 axioms (no native_decide).",
+  "meta": {
+    "author": "Berry (1941), Esseen (1942); Lévy/Gnedenko–Kolmogorov (stable laws) — analysis formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Berry%E2%80%93Esseen_theorem",
+    "date": "1942",
+    "status": "verified",
+    "tags": [
+      "probability",
+      "central-limit-theorem",
+      "berry-esseen",
+      "stable-distributions",
+      "characteristic-functions",
+      "rate-of-convergence",
+      "infinite-variance"
+    ],
+    "proofRepoPath": "Proofs/CentralLimitTheoremOQ01OQ04.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "Real.rpow",
+      "Real.rpow_lt_rpow_of_exponent_gt",
+      "Real.rpow_lt_rpow_of_exponent_lt",
+      "Real.rpow_natCast",
+      "Real.exp_lt_exp",
+      "Complex.norm_exp_sub_one_le",
+      "Complex.norm_exp_sub_one_sub_id_le",
+      "Complex.norm_I"
+    ],
+    "originalContributions": [
+      "Axiom-free formalization of the frequency-domain crossover between the α-stable and Gaussian characteristic functions: φ_α(t) < φ_2(t) for 0 < t < 1 and φ_α(t) > φ_2(t) for t > 1, crossover exactly at |t| = 1, for any 0 < α < 2",
+      "Identification of the sub-quadratic exponent |t|^α (vs the Gaussian t²) near 0 as the analytic signature of infinite variance and the precise obstruction to a classical Berry–Esseen expansion for α < 2",
+      "Restatement of the deterministic Berry–Esseen kernel bounds (Taylor remainders of e^{ia}) from Mathlib, with the role of the a² remainder as the variance/third-moment term made explicit",
+      "Gaussian (α = 2) and Cauchy (α = 1) specializations of the real symmetric α-stable characteristic function, with positivity and the value-at-0 normalization"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 171,
+    "assumptions": "None. All theorems are universally quantified over α and t with explicit hypotheses (e.g. 0 < α, α < 2, 0 < t < 1); there are no axiom declarations and no assumption-carrying structures. The deterministic kernel bounds are wrappers around Mathlib lemmas, attributed in the docstring. The α-stable characteristic function is taken in its real symmetric form φ_α(t) = exp(−|t|^α), matching the parent file; the analytic obstruction is proved about this object, not assumed. #print axioms reports only [propext, Classical.choice, Quot.sound] — no Lean.ofReduceBool, no native_decide, no sorryAx. This is an analysis-of-the-obstruction entry: it does NOT prove an α-stable Berry–Esseen rate (the open question), and says so.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The classical CLT says normalized i.i.d. sums converge to a Gaussian; Berry (1941) and Esseen (1942) quantified the rate as O(1/√n) under a finite third moment, via the bound C·ρ/(σ³√n). The parent file (central-limit-theorem-oq-01) treats the infinite-variance regime, where the limit is an α-stable law (α < 2) and the normalization is n^{1/α} rather than √n, with characteristic function φ_α(t) = exp(−|t|^α). A natural follow-up open question (oq-01-oq-04) asks whether the Berry–Esseen rate-of-convergence theorem itself generalizes to these α-stable limits. The full answer is subtle and active research; this entry contributes the elementary analytic groundwork: what makes Berry–Esseen work for α = 2, and what breaks for α < 2.",
+    "problemStatement": "Can the Berry–Esseen rate sup_x |F_n − Φ| ≤ C·ρ/(σ³√n) be generalized to convergence toward α-stable laws (α < 2)? As a first step, isolate the analytic mechanism of the classical bound and the precise reason it has no direct α < 2 analogue, with fully verified, axiom-free statements.",
+    "text": "Two ingredients drive the file. First, the deterministic kernel: the Berry–Esseen proof compares characteristic functions via Taylor bounds on the integrand e^{ia} (a = t·x), namely ‖e^{ia} − 1‖ ≤ 2|a| (charFun_kernel_first) and ‖e^{ia} − (1 + ia)‖ ≤ a² (charFun_kernel_second), both restated from Mathlib's Complex.norm_exp_sub_one_le and norm_exp_sub_one_sub_id_le; the a² remainder is exactly what integration against the law of X turns into a variance/third-moment term, giving the ρ/(σ³√n) rate. Second, the obstruction: the standard symmetric α-stable characteristic function is φ_α(t) = exp(−|t|^α) (stablePhi), and the comparison with the Gaussian φ_2(t) = exp(−t²) is governed by the rpow exponent inequalities t² < t^α on (0,1) (exponent_gt_sq) and t^α < t² on (1,∞) (exponent_lt_sq), equal at t = 1 (exponent_crossover_at_one). Exponentiating, stablePhi_lt_gaussian and stablePhi_gt_gaussian show φ_α crosses φ_2 exactly at |t| = 1. The sub-quadratic exponent near 0 is the analytic signature of infinite variance and the reason the a²-remainder expansion cannot produce a finite Gaussian-type rate for α < 2. The file closes with the Gaussian (stablePhi_two) and Cauchy (stablePhi_one) specializations plus positivity and normalization.",
+    "proofStrategy": "Reduce everything to monotonicity of real powers. The crossover is two applications of Real.rpow_lt_rpow_of_exponent_{gt,lt} (base < 1 reverses the exponent order; base > 1 preserves it), transported through the strictly monotone exp. The kernel bounds are Mathlib's complex-exponential Taylor estimates with ‖a·I‖ = |a|. No measure theory is invoked: the entry is the deterministic skeleton on which a probabilistic Berry–Esseen argument would be built.",
+    "keyInsights": [
+      "Berry–Esseen is, at its core, a second-order Taylor expansion of the characteristic function: the a² kernel remainder integrates to the variance and the cubic correction to the third moment, producing the 1/√n rate.",
+      "For α-stable laws with α < 2 the characteristic exponent |t|^α is sub-quadratic: near 0 it dominates t², so φ_α deviates from the Gaussian at order |t|^α, below the second order the classical expansion controls.",
+      "This sub-quadratic deviation is the frequency-domain face of infinite variance — the same fact that makes the variance integral diverge makes the a²-remainder constant infinite.",
+      "The α-stable and Gaussian characteristic functions cross exactly at |t| = 1: α-stable decays faster near 0 (lighter low frequencies) but has a heavier high-frequency tail, mirroring the heavy spatial tails of the law.",
+      "Consequently any α-stable Berry–Esseen rate cannot reuse the second-order expansion verbatim; it must be matched to the |t|^α exponent — a precise statement of why the open question is hard."
+    ],
+    "prerequisites": [
+      "Characteristic functions and their role in the CLT",
+      "The Berry–Esseen theorem and its proof via characteristic-function comparison",
+      "α-stable distributions and the exponent φ_α(t) = exp(−|t|^α)",
+      "Real powers (rpow) and monotonicity in the exponent for bases below/above 1"
+    ]
+  },
+  "sections": [
+    {
+      "id": "stable-charfun",
+      "title": "The α-stable characteristic function (real form)",
+      "startLine": 59,
+      "endLine": 86,
+      "summary": "Defines stablePhi α t = exp(−|t|^α), the real symmetric α-stable characteristic function, and records the Gaussian (α=2) and Cauchy (α=1) specializations, value-at-0 normalization φ_α(0)=1, and positivity.",
+      "mathContext": "$\\varphi_\\alpha(t) = e^{-|t|^\\alpha}$; $\\varphi_2(t)=e^{-t^2}$ (Gaussian), $\\varphi_1(t)=e^{-|t|}$ (Cauchy)."
+    },
+    {
+      "id": "crossover",
+      "title": "The frequency-domain crossover vs Gaussian",
+      "startLine": 88,
+      "endLine": 137,
+      "summary": "Exponent inequalities t² < t^α on (0,1) and t^α < t² on (1,∞), equal at t=1, via rpow monotonicity. Exponentiated: φ_α < φ_2 near 0 (sub-quadratic deviation) and φ_α > φ_2 beyond the crossover at |t|=1.",
+      "mathContext": "$0<t<1 \\Rightarrow t^2 < t^\\alpha$; $t>1 \\Rightarrow t^\\alpha < t^2$; crossover at $t=1$ for $0<\\alpha<2$."
+    },
+    {
+      "id": "berry-esseen-kernel",
+      "title": "The deterministic Berry–Esseen kernel",
+      "startLine": 139,
+      "endLine": 171,
+      "summary": "Taylor bounds on the integrand e^{ia}: ‖e^{ia}−1‖ ≤ 2|a| and ‖e^{ia}−(1+ia)‖ ≤ a², restated from Mathlib. The a² remainder is the term that becomes a variance/third-moment contribution after integration — the engine of the classical rate.",
+      "mathContext": "$\\|e^{ia}-1\\| \\le 2|a|,\\quad \\|e^{ia}-(1+ia)\\| \\le a^2.$"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "central-limit-theorem-oq-01",
+      "relationship": "extends",
+      "description": "The parent treats the infinite-variance CLT and the α-stable characteristic function φ_α(t)=exp(−|t|^α). This entry asks whether the Berry–Esseen rate generalizes there, and isolates the analytic mechanism and the sub-quadratic obstruction for α < 2."
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The base CLT entry; Berry–Esseen quantifies its rate of convergence (O(1/√n) under a finite third moment), which is the classical case α = 2 of this analysis."
+    }
+  ],
+  "conclusion": {
+    "summary": "Berry–Esseen rests on a second-order Taylor expansion of the characteristic function whose a² remainder integrates to the variance/third-moment term, yielding the 1/√n rate. For α-stable limits with α < 2 the characteristic exponent |t|^α is sub-quadratic, so φ_α deviates from the Gaussian at order |t|^α near 0 — below the order the classical expansion controls — and the two characteristic functions cross exactly at |t| = 1. This is the precise analytic obstruction to a direct α-stable Berry–Esseen rate, formalized axiom-free.",
+    "implications": "The entry does not resolve the open question (whether an α-stable Berry–Esseen rate exists) but pins down what any such theorem must overcome: the second-order expansion has no finite α < 2 analogue, so the rate must be governed by the |t|^α exponent. It also provides reusable, verified building blocks — the real α-stable characteristic function with its Gaussian/Cauchy specializations, the exponent-crossover lemmas, and the deterministic Berry–Esseen kernel bounds — for further work on rates of convergence to stable laws."
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Analysis.Complex.Exponential",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "CLTOQ01OQ04",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "path": "Proofs/CentralLimitTheoremOQ01OQ04.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Esseen, Carl-Gustav",
+      "title": "On the Liapunoff limit of error in the theory of probability",
+      "year": "1942",
+      "venue": "Arkiv för matematik, astronomi och fysik 28A",
+      "note": "The Berry–Esseen rate via characteristic-function comparison; the a² kernel remainder is the technical core."
+    },
+    {
+      "authors": "Berry, Andrew C.",
+      "title": "The accuracy of the Gaussian approximation to the sum of independent variates",
+      "year": "1941",
+      "venue": "Transactions of the AMS 49",
+      "note": "Independent proof of the O(1/√n) rate under a finite third moment."
+    },
+    {
+      "authors": "Gnedenko, Boris V.; Kolmogorov, Andrey N.",
+      "title": "Limit Distributions for Sums of Independent Random Variables",
+      "year": "1954",
+      "venue": "Addison-Wesley",
+      "note": "Stable laws as the limits under general normalization; characteristic exponent |t|^α."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "stablePhi_lt_gaussian",
+      "type": "core",
+      "description": "Sub-quadratic deviation near 0: for 0 < t < 1 and α < 2, φ_α(t) < φ_2(t) — the α-stable characteristic function decays faster near the origin (its exponent |t|^α exceeds t² there).",
+      "leanType": "∀ {α t : ℝ}, α < 2 → 0 < t → t < 1 → CLTOQ01OQ04.stablePhi α t < CLTOQ01OQ04.stablePhi 2 t"
+    },
+    {
+      "name": "stablePhi_gt_gaussian",
+      "type": "core",
+      "description": "Heavier frequency tail: for t > 1 and α < 2, φ_2(t) < φ_α(t) — beyond the crossover the Gaussian exponent t² dominates |t|^α.",
+      "leanType": "∀ {α t : ℝ}, α < 2 → 1 < t → CLTOQ01OQ04.stablePhi 2 t < CLTOQ01OQ04.stablePhi α t"
+    },
+    {
+      "name": "charFun_kernel_second",
+      "type": "corollary",
+      "description": "The deterministic Berry–Esseen kernel: ‖e^{ia} − (1 + ia)‖ ≤ a² for |a| ≤ 1. The a² remainder integrates to the variance/third-moment term behind the classical 1/√n rate.",
+      "leanType": "∀ {a : ℝ}, |a| ≤ 1 → ‖Complex.exp ((a : ℂ) * Complex.I) - (1 + (a : ℂ) * Complex.I)‖ ≤ a ^ 2"
+    },
+    {
+      "name": "exponent_gt_sq",
+      "type": "supporting",
+      "description": "The exponent inequality driving the crossover: t² < t^α for 0 < t < 1 and α < 2 (smaller exponent gives a larger value when the base is below 1).",
+      "leanType": "∀ {α t : ℝ}, α < 2 → 0 < t → t < 1 → t ^ (2 : ℝ) < t ^ α"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-03/annotations.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-03/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "cevaoq03-ann-01",
+    "proofId": "cevas-theorem-non-euclidean-oq-03",
+    "range": { "startLine": 65, "endLine": 81 },
+    "type": "concept",
+    "title": "The hexagon closure relation: P·P' = 1",
+    "content": "The six measures of a GeneralizedCevianConfig are the six sides of the Pappus hexagon. The Ceva product P reads them in one alternating order; the dual product P' = (dc/ce)(ea/af)(fb/bd) reads the complementary order. Multiplying P·P' writes every measure once in a numerator and once in a denominator, so the whole thing telescopes to 1 (ceva_dual_reciprocal). Discharged by `field_simp` once the parent's positivity fields give the nonzero denominators — no `ring` needed, field_simp closes it. This single telescoping identity is the geometry-independent invariant of the hexagon.",
+    "mathContext": "$P\\cdot P' = \\frac{bd}{dc}\\frac{ce}{ea}\\frac{af}{fb}\\cdot\\frac{dc}{ce}\\frac{ea}{af}\\frac{fb}{bd}=1.$"
+  },
+  {
+    "id": "cevaoq03-ann-02",
+    "proofId": "cevas-theorem-non-euclidean-oq-03",
+    "range": { "startLine": 83, "endLine": 90 },
+    "type": "result",
+    "title": "Ceva–Brianchon duality at the abstract level",
+    "content": "From P·P' = 1 it is immediate that P = 1 ↔ P' = 1 (ceva_iff_dual): the Ceva concurrence condition and its hexagon dual are equivalent. This is the projective Ceva–Brianchon duality appearing already in the abstract ratio framework, before any incidence geometry — and, being a fact about the configuration, it holds in Euclidean, spherical, and hyperbolic geometry alike.",
+    "mathContext": "$P=1 \\iff P'=1$ (Ceva $\\iff$ its hexagon dual)."
+  },
+  {
+    "id": "cevaoq03-ann-03",
+    "proofId": "cevas-theorem-non-euclidean-oq-03",
+    "range": { "startLine": 104, "endLine": 152 },
+    "type": "technique",
+    "title": "Composition: the chaining engine of the Pappus proof",
+    "content": "`comp` multiplies two configurations measure-by-measure. Both alternating products are multiplicative under it (cevaProduct_comp, dualProduct_comp, each closed by field_simp), so if two configurations satisfy the Ceva condition so does their composite (ceva_comp_of_ceva). This is exactly the algebraic step in the classical proof of Pappus's theorem, which multiplies several Menelaus/transversal ratio relations and lets the shared factors cancel — here captured as a clean composition law inside the framework.",
+    "mathContext": "$P(c_1 \\ast c_2) = P(c_1)P(c_2)$; closure: $1\\cdot 1 = 1$."
+  },
+  {
+    "id": "cevaoq03-ann-04",
+    "proofId": "cevas-theorem-non-euclidean-oq-03",
+    "range": { "startLine": 154, "endLine": 174 },
+    "type": "result",
+    "title": "Non-Euclidean instances via sin and sinh",
+    "content": "Because the closure relation is a statement about the abstract configuration, it transfers verbatim to the sphere and the hyperbolic plane by feeding geodesic-arc measures through the parent's measure builders: spherical_ceva_dual_reciprocal uses `sin`, hyperbolic_ceva_dual_reciprocal uses `sinh`. These are the non-Euclidean Pappus–Brianchon hexagon closure relations — one abstract theorem, three geometries.",
+    "mathContext": "Closure for $\\rho=\\sin$ (sphere) and $\\rho=\\sinh$ (hyperbolic plane)."
+  },
+  {
+    "id": "cevaoq03-ann-05",
+    "proofId": "cevas-theorem-non-euclidean-oq-03",
+    "range": { "startLine": 45, "endLine": 53 },
+    "type": "caveat",
+    "title": "Scope: the hexagon invariant, not the full incidence theorem",
+    "content": "This entry formalizes the geometry-independent algebraic invariant of the Pappus hexagon — the closure reciprocity and the composition law — entirely inside GeneralizedCevianConfig. It does NOT derive the full projective incidence statement of Pappus/Brianchon (collinearity of the three diagonal points), which requires the combinatorics of lines and intersection points; that is future work that can build on the composition law here. #print axioms shows only propext / Classical.choice / Quot.sound — genuinely 0-axiom.",
+    "mathContext": "Proved: hexagon ratio invariant. Not proved: full projective incidence statement."
+  }
+]

--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-03/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "cevas-theorem-non-euclidean-oq-03",
+  "title": "The Hexagon Ratio Algebra Behind Non-Euclidean Pappus–Brianchon",
+  "slug": "cevas-theorem-non-euclidean-oq-03",
+  "description": "Approaches the non-Euclidean Pappus–Brianchon theorems through the parent's abstract GeneralizedCevianConfig (six positive 'measures' bd,dc,ce,ea,af,fb, with the geometry-independent Ceva product P = (bd/dc)(ce/ea)(af/fb)). The six measures are exactly the sides of the Pappus hexagon (vertices alternating on two geodesics — a degenerate conic). The entry isolates the algebraic invariant of such a hexagon: the dual (cyclically shifted) product P' = (dc/ce)(ea/af)(fb/bd) satisfies P·P' = 1 — a pure telescoping cancellation of all six measures (ceva_dual_reciprocal), the hexagon closure relation. Hence the Ceva condition and its Brianchon-style dual hold together (ceva_iff_dual). Both products are multiplicative under componentwise composition of configurations (cevaProduct_comp, dualProduct_comp) — the chaining law by which the classical Pappus proof multiplies transversal relations — and the Ceva condition is closed under composition (ceva_comp_of_ceva). The reciprocity specializes verbatim to the sphere (sin) and the hyperbolic plane (sinh) via the parent's measure builders. Honest scope: this formalizes the geometry-independent hexagon ratio invariant, not the full projective incidence statement (future work). 8 theorems, 2 defs, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Pappus of Alexandria; Brianchon (1810); non-Euclidean ratio framework — formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Pappus%27s_hexagon_theorem",
+    "date": "1810",
+    "status": "verified",
+    "tags": [
+      "geometry",
+      "non-euclidean",
+      "projective-geometry",
+      "pappus",
+      "brianchon",
+      "ceva",
+      "ratio-algebra"
+    ],
+    "proofRepoPath": "Proofs/CevasTheoremNonEuclideanOQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "Mathlib.Tactic (field_simp, positivity, ring)"
+    ],
+    "originalContributions": [
+      "Identification, inside the parent's GeneralizedCevianConfig, of the hexagon closure relation P·P' = 1 between the Ceva product and its cyclically shifted dual — a telescoping cancellation of all six side-measures (ceva_dual_reciprocal)",
+      "The abstract Ceva–Brianchon duality ceva_iff_dual: the concurrence condition and its hexagon dual are equivalent in every geometry",
+      "Multiplicativity of both alternating products under componentwise composition of configurations (cevaProduct_comp, dualProduct_comp) and closure of the Ceva condition under composition (ceva_comp_of_ceva) — the chaining engine of the classical Pappus proof",
+      "Verbatim spherical (sin) and hyperbolic (sinh) instances of the closure relation, reusing the parent's measure builders — the non-Euclidean content"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 174,
+    "assumptions": "None. Every theorem is universally quantified over GeneralizedCevianConfig (or Spherical/HyperbolicCevianConfig) whose positivity fields are ordinary hypotheses inherited from the parent structure — these are definitional positivity conditions on lengths/arcs, not mathematical axioms. There are no axiom declarations, no native_decide, no sorries; field_simp/ring/positivity introduce no axioms. #print axioms reports only [propext, Classical.choice, Quot.sound]. Honest scope: the entry proves the algebraic hexagon invariant underlying non-Euclidean Pappus–Brianchon, NOT the full projective incidence theorem, and says so explicitly.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Ceva's and Menelaus's theorems characterize, respectively, concurrent cevians and collinear transversal points by a product of side-ratios equal to 1 (or −1). The parent lineage abstracts all three constant-curvature geometries into one GeneralizedCevianConfig, where the 'measure' of a geodesic segment is its length (Euclidean), the sine of its arc (spherical), or the hyperbolic sine of its distance (hyperbolic), and the single condition P = 1 carries the geometric content. Pappus's theorem (a hexagon inscribed in a degenerate conic — two lines) and its projective dual Brianchon's theorem are the next layer of incidence geometry. This entry asks how the abstract configuration bears on them, and answers: the six measures of a configuration are the six sides of the Pappus hexagon, and the hexagon's geometry-independent closure relation is exactly a telescoping identity between two alternating ratio products.",
+    "problemStatement": "Use the abstract GeneralizedCevianConfig to approach non-Euclidean Pappus–Brianchon. Concretely: identify and prove, inside the configuration framework, the geometry-independent algebraic invariant of the Pappus hexagon, with spherical and hyperbolic instances, all axiom-free.",
+    "text": "The Ceva product P(cfg) = (bd/dc)(ce/ea)(af/fb) reads the hexagon's sides in one alternating order. Its cyclic shift dualCevaProduct cfg = (dc/ce)(ea/af)(fb/bd) reads the complementary order. The headline ceva_dual_reciprocal proves P·P' = 1: writing the product out, every one of the six measures appears once in a numerator and once in a denominator, so it telescopes to 1 (discharged by field_simp once the positivity-derived nonvanishing of the denominators is in scope). Two immediate consequences: ceva_iff_dual (P = 1 ↔ P' = 1, the abstract Ceva–Brianchon duality) and dualCevaProduct_pos. The composition section defines comp (componentwise product of two configurations) and proves both products are multiplicative under it (cevaProduct_comp, dualProduct_comp), from which ceva_comp_of_ceva shows the Ceva condition is preserved — the precise multiplicative step by which the classical Pappus proof chains several Menelaus/transversal relations into the conclusion. Finally, because the reciprocity is purely about the abstract configuration, spherical_ceva_dual_reciprocal and hyperbolic_ceva_dual_reciprocal obtain it verbatim with sin and sinh measures via the parent's toGeneralized builders.",
+    "proofStrategy": "Everything reduces to the field algebra of positive reals. The closure relation and the two multiplicativity laws are telescoping/distribution identities closed by field_simp (the parent's positivity fields supply the nonzero denominators). The duality and composition-closure are one-line rewrites using the reciprocity and multiplicativity. The non-Euclidean instances are direct applications of the abstract theorem to configurations built from sin/sinh.",
+    "keyInsights": [
+      "The six measures of a GeneralizedCevianConfig are literally the six sides of the Pappus hexagon; the Ceva product and its cyclic dual read the two alternating side-orders.",
+      "The hexagon closure relation is a telescoping identity P·P' = 1 — every side cancels — so it is independent of the geometry, holding identically for length, sin, and sinh measures.",
+      "Ceva and its Brianchon-style dual are equivalent conditions on the same configuration (ceva_iff_dual): the projective Ceva–Brianchon duality appears already at the abstract ratio level.",
+      "Multiplicativity under composition is the algebraic engine of the classical Pappus proof, which multiplies several transversal (Menelaus) relations; ceva_comp_of_ceva captures the closure step.",
+      "Reusing the parent's sin/sinh measure builders gives the spherical and hyperbolic closure relations for free — the non-Euclidean Pappus–Brianchon invariant, uniformly."
+    ],
+    "prerequisites": [
+      "Ceva's and Menelaus's theorems and their unified ratio (measure) framework",
+      "Pappus's hexagon theorem and its projective dual, Brianchon's theorem",
+      "Telescoping products of positive reals",
+      "Constant-curvature geometries and the measure functions id / sin / sinh"
+    ]
+  },
+  "sections": [
+    {
+      "id": "dual-product",
+      "title": "The dual product and the hexagon closure relation",
+      "startLine": 61,
+      "endLine": 98,
+      "summary": "Defines dualCevaProduct (the cyclically shifted alternating product) and proves ceva_dual_reciprocal: P·P' = 1, a telescoping cancellation of all six measures. ceva_iff_dual gives the abstract Ceva–Brianchon duality; dualCevaProduct_pos its positivity.",
+      "mathContext": "$P\\cdot P' = \\frac{bd}{dc}\\frac{ce}{ea}\\frac{af}{fb}\\cdot\\frac{dc}{ce}\\frac{ea}{af}\\frac{fb}{bd} = 1.$"
+    },
+    {
+      "id": "composition",
+      "title": "Composition: the chaining law",
+      "startLine": 100,
+      "endLine": 152,
+      "summary": "Defines comp (componentwise product of configurations) and proves both alternating products are multiplicative under it (cevaProduct_comp, dualProduct_comp), with ceva_comp_of_ceva showing the Ceva condition is closed under composition — the multiplicative step assembling a Pappus conclusion from transversal relations.",
+      "mathContext": "$P(c_1 \\ast c_2) = P(c_1)\\,P(c_2)$; $P(c_1)=P(c_2)=1 \\Rightarrow P(c_1\\ast c_2)=1.$"
+    },
+    {
+      "id": "non-euclidean",
+      "title": "Spherical and hyperbolic instances",
+      "startLine": 154,
+      "endLine": 174,
+      "summary": "spherical_ceva_dual_reciprocal and hyperbolic_ceva_dual_reciprocal: the closure relation holds verbatim with sin and sinh measures, via the parent's toGeneralized builders — the non-Euclidean Pappus–Brianchon hexagon invariant.",
+      "mathContext": "Closure holds for measures $\\rho = \\sin$ (sphere) and $\\rho = \\sinh$ (hyperbolic plane)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cevas-theorem-non-euclidean",
+      "relationship": "extends",
+      "description": "The parent defines GeneralizedCevianConfig, generalizedCevaProduct, and the spherical/hyperbolic measure builders. This entry adds the hexagon dual product and closure/composition algebra inside that framework, targeting Pappus–Brianchon."
+    },
+    {
+      "targetId": "cevas-theorem-non-euclidean-oq-02",
+      "relationship": "related",
+      "description": "OQ-02 proved the non-Euclidean Menelaus theorem (the transversal companion of Ceva). This entry's composition law is the algebraic step that chains such transversal relations toward the Pappus hexagon conclusion."
+    }
+  ],
+  "conclusion": {
+    "summary": "Inside the abstract GeneralizedCevianConfig, the Pappus hexagon's geometry-independent invariant is a telescoping reciprocity P·P' = 1 between the Ceva product and its cyclic dual, equivalent to the abstract Ceva–Brianchon duality and multiplicative under composition. The relation specializes verbatim to spherical (sin) and hyperbolic (sinh) measures, giving the non-Euclidean hexagon closure relation, all axiom-free.",
+    "implications": "The entry pins down how much of non-Euclidean Pappus–Brianchon is pure ratio algebra: the hexagon closure relation and the multiplicative chaining law, both geometry-independent. It does not derive the full projective incidence theorem (which needs the combinatorics of lines and intersection points), but provides the verified algebraic engine — reciprocity, duality, and composition closure — on which such a derivation rests, available uniformly in all three constant-curvature geometries."
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.CevasTheoremNonEuclidean",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "CevaNonEuclideanOQ03",
+    "lineCount": 174,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/CevasTheoremNonEuclideanOQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Pappus of Alexandria",
+      "title": "Collection (Synagoge), Book VII",
+      "year": "c. 340",
+      "venue": "—",
+      "note": "Pappus's hexagon theorem: collinearity of the three diagonal points of a hexagon inscribed in two lines."
+    },
+    {
+      "authors": "Brianchon, Charles Julien",
+      "title": "Sur les surfaces courbes du second degré",
+      "year": "1810",
+      "venue": "Journal de l'École Polytechnique",
+      "note": "Brianchon's theorem, the projective dual of Pascal/Pappus for hexagons circumscribed about a conic."
+    },
+    {
+      "authors": "Papadopoulos, Athanase",
+      "title": "Hyperbolic analogues of classical theorems in spherical geometry",
+      "year": "2014",
+      "venue": "Various surveys",
+      "note": "Context for transferring classical incidence/ratio theorems across constant-curvature geometries."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "ceva_dual_reciprocal",
+      "type": "core",
+      "description": "Hexagon closure relation: the Ceva product and its cyclically shifted dual are reciprocal, P·P' = 1 — a telescoping cancellation of all six side-measures, the geometry-independent invariant of the Pappus hexagon.",
+      "leanType": "∀ (cfg : GeneralizedCevianConfig), generalizedCevaProduct cfg * CevaNonEuclideanOQ03.dualCevaProduct cfg = 1"
+    },
+    {
+      "name": "ceva_iff_dual",
+      "type": "core",
+      "description": "Abstract Ceva–Brianchon duality: the Ceva concurrence condition and its hexagon dual are equivalent.",
+      "leanType": "∀ (cfg : GeneralizedCevianConfig), generalizedCevaProduct cfg = 1 ↔ CevaNonEuclideanOQ03.dualCevaProduct cfg = 1"
+    },
+    {
+      "name": "cevaProduct_comp",
+      "type": "corollary",
+      "description": "Multiplicativity of the Ceva product under componentwise composition of configurations — the chaining law of the classical Pappus proof.",
+      "leanType": "∀ (c1 c2 : GeneralizedCevianConfig), generalizedCevaProduct (CevaNonEuclideanOQ03.comp c1 c2) = generalizedCevaProduct c1 * generalizedCevaProduct c2"
+    },
+    {
+      "name": "hyperbolic_ceva_dual_reciprocal",
+      "type": "corollary",
+      "description": "The hexagon closure relation in the hyperbolic plane, with sinh measures — a non-Euclidean instance via the parent's measure builder.",
+      "leanType": "∀ (cfg : HyperbolicCevianConfig), generalizedCevaProduct cfg.toGeneralized * CevaNonEuclideanOQ03.dualCevaProduct cfg.toGeneralized = 1"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/erdos-733-oq-02/annotations.json
+++ b/src/data/proofs/erdos-733-oq-02/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "e733rl-ann-01",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 73, "endLine": 82 },
+    "type": "concept",
+    "title": "Disjoint pairs: where linearity enters",
+    "content": "`disjoint_pairs` is the only place the geometry is used. Each line `L` carries the family `L.powersetCard 2` of its two-element point-subsets. If a two-element set `s` belonged to both `L₁.powersetCard 2` and `L₂.powersetCard 2`, then `s ⊆ L₁ ∩ L₂` with `|s| = 2`, forcing `|L₁ ∩ L₂| ≥ 2`. But the linear-space hypothesis says two distinct lines meet in at most one point, so the families are disjoint. No point-pair lies on two lines — this is exactly the fact that makes the counting work.",
+    "mathContext": "$s \\subseteq L_1 \\cap L_2,\\ |s| = 2 \\Rightarrow |L_1 \\cap L_2| \\ge 2$, contradicting $|L_1 \\cap L_2| \\le 1$."
+  },
+  {
+    "id": "e733rl-ann-02",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 90, "endLine": 112 },
+    "type": "technique",
+    "title": "Double counting via a disjoint biUnion",
+    "content": "`sum_choose_two_le` is the engine. Rewriting `C(|L|,2)` as `(L.powersetCard 2).card` (Finset.card_powersetCard) turns the sum over lines into a sum of cardinalities of pairwise-disjoint finsets. `Finset.card_biUnion` (using the disjointness from `disjoint_pairs`) collapses that sum into the cardinality of their union, and the union sits inside `P.powersetCard 2` because every line is a subset of `P`. Hence `∑_L C(|L|,2) ≤ C(n,2)`. This single inequality powers every rich-line bound below.",
+    "mathContext": "$\\sum_{L} \\binom{|L|}{2} = \\Big|\\bigsqcup_L \\binom{L}{2}\\Big| \\le \\Big|\\binom{P}{2}\\Big| = \\binom{n}{2}.$"
+  },
+  {
+    "id": "e733rl-ann-03",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 124, "endLine": 140 },
+    "type": "concept",
+    "title": "Charging rich lines to point-pairs",
+    "content": "`rich_line_bound` is the headline. Over the k-rich lines, the constant estimate `C(k,2) ≤ C(|L|,2)` (Nat.choose_le_choose, since `k ≤ |L|`) sums to `#{k-rich lines} · C(k,2) ≤ ∑_L C(|L|,2) ≤ C(n,2)`. Read combinatorially: every k-rich line is charged the `C(k,2)` pairs it must contain, no pair is charged twice (disjointness), and there are only `C(n,2)` pairs to spend. The count of k-rich lines is therefore at most `C(n,2)/C(k,2) = O(n²/k²)`.",
+    "mathContext": "$\\#\\{L : |L| \\ge k\\}\\cdot \\binom{k}{2} \\le \\sum_L \\binom{|L|}{2} \\le \\binom{n}{2}.$"
+  },
+  {
+    "id": "e733rl-ann-04",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 157, "endLine": 169 },
+    "type": "result",
+    "title": "k = 2: bounding the number of proper lines",
+    "content": "`num_proper_lines_le` specializes `rich_line_bound` at `k = 2`. Since `C(2,2) = 1`, the bound becomes `#{lines with ≥ 2 points} ≤ C(n,2)`: each proper line is charged to a distinct point-pair. This is the easy direction of de Bruijn–Erdős-style counting and shows that a linear space on n points has at most quadratically many lines.",
+    "mathContext": "$\\binom{2}{2} = 1 \\Rightarrow \\#\\{L : |L| \\ge 2\\} \\le \\binom{n}{2}.$"
+  },
+  {
+    "id": "e733rl-ann-05",
+    "proofId": "erdos-733-oq-02",
+    "range": { "startLine": 40, "endLine": 56 },
+    "type": "caveat",
+    "title": "Honest scope: weaker than Szemerédi–Trotter, but unconditional and 0-axiom",
+    "content": "The bound here is `O(n²/k²)`; Szemerédi–Trotter improves the exponent on k from 2 to 3 (plus an `n/k` term): `O(n²/k³ + n/k)`. That improvement is the genuinely deep content the parent Erdős #733 file axiomatizes, and this entry does NOT discharge those axioms. What it does deliver is the elementary baseline, fully machine-checked with no incidence theorem. The linear-space conditions `hsub` and `hlin` are ordinary hypotheses, not structure-encoded axioms, so the file is genuinely 0-axiom under the project's axiom-integrity policy.",
+    "mathContext": "Elementary: $O(n^2/k^2)$. Szemerédi–Trotter: $O(n^2/k^3 + n/k)$."
+  }
+]

--- a/src/data/proofs/erdos-733-oq-02/meta.json
+++ b/src/data/proofs/erdos-733-oq-02/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "erdos-733-oq-02",
+  "title": "The Elementary Rich-Line Bound (Erdős #733)",
+  "slug": "erdos-733-oq-02",
+  "description": "Fills the unproved 'Part III' claim of the Erdős #733 formalization: that the number of k-rich lines (lines through at least k of n points) is bounded. The registered file states the Szemerédi–Trotter corollary O(n²/k³ + n/k) only as a docstring, with no proof. This entry proves the elementary, unconditional baseline #{lines with ≥ k points} · C(k,2) ≤ C(n,2), hence #{k-rich lines} ≤ C(n,2)/C(k,2) = O(n²/k²), by pure double counting of point-pairs: each line carries the C(|L|,2) two-element subsets of its points, distinct lines share at most one point so these pair-families are disjoint, and there are only C(n,2) pairs in all. The single hypothesis is the defining 'linear space' property of lines (two distinct lines meet in ≤ 1 point); no incidence theorem and no real-analytic input is used. Self-contained, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Erdős (problem); classical double-counting bound — formalized in Lean 4",
+    "sourceUrl": "https://www.erdosproblems.com/733",
+    "date": "1983",
+    "status": "verified",
+    "tags": [
+      "combinatorial-geometry",
+      "incidences",
+      "double-counting",
+      "extremal-combinatorics",
+      "szemeredi-trotter",
+      "erdos",
+      "rich-lines"
+    ],
+    "proofRepoPath": "Proofs/Erdos733RichLines.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "Finset.powersetCard",
+      "Finset.card_powersetCard",
+      "Finset.card_biUnion",
+      "Finset.card_le_card",
+      "Finset.sum_le_sum",
+      "Finset.sum_le_sum_of_subset",
+      "Finset.sum_const_nat",
+      "Nat.choose_le_choose",
+      "Nat.choose_pos",
+      "Nat.le_div_iff_mul_le"
+    ],
+    "originalContributions": [
+      "Machine-checked proof of the elementary rich-line bound #{lines with ≥ k points} · C(k,2) ≤ C(n,2), the unconditional baseline that Szemerédi–Trotter later sharpens — the registered Erdős #733 file states the corresponding corollary only as an unproved docstring",
+      "A clean double-counting argument: distinct lines (sharing ≤ 1 point) carry pairwise-disjoint families of two-element point-subsets, all contained in the C(n,2) pairs of the point set (sum_choose_two_le, disjoint_pairs)",
+      "Division form #{k-rich lines} ≤ C(n,2)/C(k,2) = O(n²/k²) and the de Bruijn–Erdős-style corollary #{proper lines} ≤ C(n,2) (rich_line_count_le, num_proper_lines_le)",
+      "Stated with the linear-space property as an explicit hypothesis rather than a structure-encoded axiom, so the result is genuinely 0-axiom and applies verbatim to honest lines in ℝ²"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 185,
+    "assumptions": "None encoded as axioms or structure fields. Every theorem takes the configuration data (point set P, family of lines) and the linear-space hypotheses hsub (each line ⊆ P) and hlin (two distinct lines meet in ≤ 1 point) as ordinary universally-quantified arguments. #print axioms reports only the standard foundational axioms (propext / Classical.choice / Quot.sound); no sorryAx, no Lean.ofReduceBool. The bound proved is the elementary O(n²/k²) estimate, strictly weaker than the Szemerédi–Trotter O(n²/k³ + n/k) that the parent file axiomatizes — this is disclosed explicitly in the file and is not claimed to discharge those axioms.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #733 asks for the number f(n) of 'line-compatible' multiplicity sequences realizable by n points in the plane; the answer f(n) = exp(Θ(√n)) was completed by Szemerédi and Trotter in 1983, whose incidence theorem controls how many lines can be rich (pass through many points). The registered formalization Erdos733Problem.lean encodes the two sharp bounds as axioms and, in its 'Part III', states the Szemerédi–Trotter corollary on rich lines — 'the number of k-rich lines is O(n²/k³ + n/k)' — purely as a docstring, proving nothing about it. Yet a weaker rich-line bound predates Szemerédi–Trotter by decades and is completely elementary: it follows from the single fact that two distinct lines meet in at most one point. This entry formalizes that elementary baseline.",
+    "problemStatement": "Let P be a finite set of n points and let `lines` be a family of subsets of P such that any two distinct lines meet in at most one point (the linear-space property of honest lines in ℝ²). Prove that for every threshold k, the number of lines containing at least k points satisfies #{L : |L| ≥ k} · C(k,2) ≤ C(n,2), and therefore #{L : |L| ≥ k} ≤ C(n,2)/C(k,2).",
+    "text": "The file is built around one double-counting identity. For a line L, its C(|L|,2) two-element subsets are the point-pairs it covers; in Lean these are L.powersetCard 2, whose cardinality is |L| choose 2 (Finset.card_powersetCard). The geometric content lives in disjoint_pairs: if two lines meet in at most one point, no pair of points lies on both, so their pair-families are disjoint. The core bound sum_choose_two_le then rewrites each C(|L|,2) as a cardinality, uses Finset.card_biUnion over the disjoint families, and bounds the union by the pairs of P to get ∑_{L} C(|L|,2) ≤ C(n,2). The headline rich_line_bound sums the trivial estimate C(k,2) ≤ C(|L|,2) over the k-rich lines (Nat.choose_le_choose) to obtain #{k-rich lines} · C(k,2) ≤ C(n,2). Two corollaries follow: rich_line_count_le divides through (Nat.le_div_iff_mul_le) to the familiar O(n²/k²) form, and num_proper_lines_le specializes to k = 2 (C(2,2) = 1) to bound the number of lines with at least two points by C(n,2). A monotonicity lemma rich_lines_antitone records that raising the threshold can only shrink the rich-line count.",
+    "proofStrategy": "Charge each k-rich line to the C(k,2) point-pairs it contains. Because distinct lines share at most one point, no point-pair is charged twice, so the total charge #{k-rich lines} · C(k,2) cannot exceed the C(n,2) available pairs. Formally this is a disjoint biUnion of two-element subsets sitting inside the two-element subsets of P; everything else is monotonicity of binomial coefficients and a Nat division step.",
+    "keyInsights": [
+      "The whole bound rests on one geometric fact — two distinct lines meet in at most one point — entered as the explicit hypothesis hlin, not as an incidence theorem. This is what makes it elementary and unconditional.",
+      "Counting point-pairs is the right currency: a k-rich line is worth C(k,2) pairs, and the budget of pairs is exactly C(n,2), so the rich lines are bounded by a clean ratio.",
+      "Disjointness of the pair-families (disjoint_pairs) is where linearity is used: a shared pair would force two lines to meet in two points, contradicting hlin.",
+      "The result is honestly weaker than Szemerédi–Trotter — O(n²/k²) versus O(n²/k³ + n/k) — and the file says so. It is the baseline the deep theorem improves, and it is the part that can be fully machine-checked with no axioms.",
+      "Stating the linear-space property as a hypothesis rather than a structure field keeps the entry genuinely 0-axiom under the project's axiom-integrity policy, while still applying verbatim to the geometric setting of the parent #733 file."
+    ],
+    "prerequisites": [
+      "Binomial coefficients and the identity that an m-set has C(m,2) two-element subsets",
+      "Double counting / the handshake principle in extremal combinatorics",
+      "Linear spaces (partial linear spaces): families of lines pairwise meeting in at most one point",
+      "Finset.powersetCard and disjoint biUnion cardinality in Lean/Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "core-double-counting",
+      "title": "The core double-counting inequality",
+      "startLine": 60,
+      "endLine": 112,
+      "summary": "disjoint_pairs shows that two lines meeting in ≤ 1 point carry disjoint families of two-element point-subsets. sum_choose_two_le then sums their sizes via a disjoint biUnion and bounds the result by the two-element subsets of P, giving ∑_{L} C(|L|,2) ≤ C(n,2).",
+      "mathContext": "Each line covers $\\binom{|L|}{2}$ point-pairs; distinct lines share at most one point, so the pair-families are disjoint and $\\sum_L \\binom{|L|}{2} \\le \\binom{n}{2}$."
+    },
+    {
+      "id": "rich-line-bound",
+      "title": "The rich-line bound",
+      "startLine": 114,
+      "endLine": 155,
+      "summary": "rich_line_bound charges each k-rich line C(k,2) pairs and sums: #{L : |L| ≥ k} · C(k,2) ≤ C(n,2). rich_line_count_le divides through to #{k-rich lines} ≤ C(n,2)/C(k,2), the O(n²/k²) estimate.",
+      "mathContext": "$\\#\\{L : |L| \\ge k\\}\\cdot \\binom{k}{2} \\le \\binom{n}{2}$, hence $\\#\\{L : |L| \\ge k\\} \\le \\binom{n}{2}/\\binom{k}{2} = O(n^2/k^2)$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Proper lines and monotonicity",
+      "startLine": 157,
+      "endLine": 185,
+      "summary": "num_proper_lines_le specializes to k = 2 (C(2,2) = 1): the number of lines with at least two points is at most C(n,2), the easy de Bruijn–Erdős direction. rich_lines_antitone records that raising the threshold only shrinks the rich-line count.",
+      "mathContext": "$k=2$: $\\#\\{L : |L| \\ge 2\\} \\le \\binom{n}{2}$. Monotonicity: $k \\le k' \\Rightarrow \\#\\{|L| \\ge k'\\} \\le \\#\\{|L| \\ge k\\}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-733",
+      "relationship": "extends",
+      "description": "The parent entry formalizes the count of line-compatible sequences and axiomatizes the sharp Szemerédi–Trotter bounds. Its Part III states the rich-line corollary O(n²/k³ + n/k) only as an unproved docstring; this entry supplies the elementary unconditional baseline #{k-rich lines} = O(n²/k²), fully machine-checked."
+    },
+    {
+      "targetId": "erdos-733-oq-01",
+      "relationship": "related",
+      "description": "OQ-01 addresses the limit constant λ = lim log f(n)/√n of the parent's count; this entry instead proves the elementary combinatorial estimate underlying the rich-line side of the Szemerédi–Trotter machinery."
+    }
+  ],
+  "conclusion": {
+    "summary": "The number of k-rich lines in an n-point configuration is at most C(n,2)/C(k,2) = O(n²/k²), proved by charging each rich line the C(k,2) point-pairs it covers and noting that distinct lines share at most one point, so no pair is double-charged against the C(n,2) available pairs. This fills the unproved Part III claim of the Erdős #733 formalization with a fully verified, 0-axiom statement.",
+    "implications": "The bound is the elementary baseline that Szemerédi–Trotter improves (to O(n²/k³ + n/k)), and it requires nothing beyond the linear-space property of lines. It pins down precisely how much of the rich-line corollary used in #733 is elementary double counting versus genuinely deep incidence geometry, and provides reusable Lean infrastructure (disjoint pair-families, the ∑ C(|L|,2) ≤ C(n,2) inequality) for further incidence-combinatorics formalization."
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Finset.Card",
+      "Mathlib.Data.Finset.Powerset",
+      "Mathlib.Algebra.Order.BigOperators.Group.Finset",
+      "Mathlib.Data.Nat.Choose.Basic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos733RichLines",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos733RichLines.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Szemerédi, Endre; Trotter, William T.",
+      "title": "Extremal problems in discrete geometry",
+      "year": "1983",
+      "venue": "Combinatorica 3, 381–392",
+      "note": "The sharp incidence theorem behind Erdős #733; its rich-line corollary O(n²/k³ + n/k) improves the elementary O(n²/k²) bound proved here."
+    },
+    {
+      "authors": "de Bruijn, Nicolaas G.; Erdős, Paul",
+      "title": "On a combinatorial problem",
+      "year": "1948",
+      "venue": "Indagationes Mathematicae 10, 421–423",
+      "note": "Classical linear-space counting; the k = 2 corollary here (#proper lines ≤ C(n,2)) is the easy direction of this circle of ideas."
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "Problem #733",
+      "year": "n.d.",
+      "venue": "erdosproblems.com",
+      "note": "Counting line-compatible multiplicity sequences; answer exp(Θ(√n)) via Szemerédi–Trotter."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "rich_line_bound",
+      "type": "core",
+      "description": "Elementary rich-line bound: with n = |P|, the number of lines containing at least k points satisfies #{L : |L| ≥ k} · C(k,2) ≤ C(n,2). The unconditional baseline Szemerédi–Trotter later sharpens.",
+      "leanType": "∀ {V} [DecidableEq V] (P : Finset V) (lines : Finset (Finset V)), (∀ L ∈ lines, L ⊆ P) → (∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) → ∀ k, (lines.filter (fun L => k ≤ L.card)).card * k.choose 2 ≤ (P.card).choose 2"
+    },
+    {
+      "name": "sum_choose_two_le",
+      "type": "core",
+      "description": "Core double-counting inequality: the total number of point-pairs covered by all lines is at most the C(n,2) pairs of the point set. Drives every rich-line bound.",
+      "leanType": "∀ {V} [DecidableEq V] (P : Finset V) (lines : Finset (Finset V)), (∀ L ∈ lines, L ⊆ P) → (∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) → ∑ L ∈ lines, (L.card).choose 2 ≤ (P.card).choose 2"
+    },
+    {
+      "name": "rich_line_count_le",
+      "type": "corollary",
+      "description": "Division form: for k ≥ 2 the number of k-rich lines is at most C(n,2)/C(k,2), the familiar O(n²/k²) estimate.",
+      "leanType": "∀ {V} [DecidableEq V] (P : Finset V) (lines : Finset (Finset V)), (∀ L ∈ lines, L ⊆ P) → (∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) → ∀ k, 2 ≤ k → (lines.filter (fun L => k ≤ L.card)).card ≤ (P.card).choose 2 / k.choose 2"
+    },
+    {
+      "name": "num_proper_lines_le",
+      "type": "corollary",
+      "description": "k = 2 specialization: the number of lines through at least two points is at most C(n,2) — each is charged to a distinct point-pair (de Bruijn–Erdős easy direction).",
+      "leanType": "∀ {V} [DecidableEq V] (P : Finset V) (lines : Finset (Finset V)), (∀ L ∈ lines, L ⊆ P) → (∀ L₁ ∈ lines, ∀ L₂ ∈ lines, L₁ ≠ L₂ → (L₁ ∩ L₂).card ≤ 1) → (lines.filter (fun L => 2 ≤ L.card)).card ≤ (P.card).choose 2"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/erdos-823-oq-05/annotations.json
+++ b/src/data/proofs/erdos-823-oq-05/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "e823sv-ann-01",
+    "proofId": "erdos-823-oq-05",
+    "range": { "startLine": 53, "endLine": 55 },
+    "type": "technique",
+    "title": "σ on a prime: the only ingredient beyond multiplicativity",
+    "content": "`sigma_one_prime` is the whole arithmetic content. For a prime `p`, Mathlib's `Nat.Prime.divisors` gives `divisors p = {1, p}`, so `σ 1 p = ∑ d ∈ {1,p}, d = 1 + p` by `Finset.sum_pair` (using `1 ≠ p`). `omega` flips `1 + p` to `p + 1`. Everything else in the file is coprime multiplicativity applied to this fact.",
+    "mathContext": "$\\sigma(p) = \\sum_{d \\mid p} d = 1 + p$ since divisors$(p) = \\{1, p\\}$."
+  },
+  {
+    "id": "e823sv-ann-02",
+    "proofId": "erdos-823-oq-05",
+    "range": { "startLine": 72, "endLine": 77 },
+    "type": "technique",
+    "title": "Reading σ off the factorization, axiom-free",
+    "content": "`sigma_14` is the template. Rewrite `14 = 2·7`; `isMultiplicative_sigma.map_mul_of_coprime` splits `σ(2·7) = σ(2)·σ(7)` once the gcd condition `gcd 2 7 = 1` is supplied (here by kernel `decide` — small, no compiled evaluator); `sigma_one_prime` evaluates each prime to `p+1`; `norm_num` finishes `3·8 = 24`. No `native_decide`, so no `Lean.ofReduceBool`. The same five lines, with a different factorization, give every other value.",
+    "mathContext": "$\\sigma(14) = \\sigma(2)\\,\\sigma(7) = (2{+}1)(7{+}1) = 3 \\cdot 8 = 24.$"
+  },
+  {
+    "id": "e823sv-ann-03",
+    "proofId": "erdos-823-oq-05",
+    "range": { "startLine": 86, "endLine": 92 },
+    "type": "concept",
+    "title": "Prime powers: σ(2²) and the perfect number 28",
+    "content": "`sigma_28` needs the one prime power 2² in 28 = 2²·7. There `sigma_one_apply_prime_pow` gives `σ(2²) = ∑_{k<3} 2^k = 1+2+4 = 7`, expanded by `simp [Finset.sum_range_succ]`; multiplicativity then yields `7·8 = 56`. Since 56 = 2·28, `twentyeight_perfect` certifies 28 as the second perfect number — axiom-free.",
+    "mathContext": "$\\sigma(2^2) = 1+2+4 = 7,\\quad \\sigma(28) = 7 \\cdot 8 = 56 = 2 \\cdot 28.$"
+  },
+  {
+    "id": "e823sv-ann-04",
+    "proofId": "erdos-823-oq-05",
+    "range": { "startLine": 116, "endLine": 130 },
+    "type": "result",
+    "title": "Consecutive-integer σ-pairs: the base of Pollack's theorem",
+    "content": "`sigma_pair_14_15` and `sigma_pair_957_958` record that 14,15 and 957,958 are pairs of consecutive integers with equal σ — value-collisions of the sum-of-divisors function. These are the simplest instances (ratio n/m ≈ 1) of the phenomenon Erdős #823 / Pollack push to arbitrary ratios α. `fiber_24` packages 14,15 ∈ σ⁻¹(24) as the concrete α = 1 witness.",
+    "mathContext": "$\\sigma(14)=\\sigma(15)=24,\\quad \\sigma(957)=\\sigma(958)=1440.$"
+  },
+  {
+    "id": "e823sv-ann-05",
+    "proofId": "erdos-823-oq-05",
+    "range": { "startLine": 19, "endLine": 23 },
+    "type": "caveat",
+    "title": "A false native_decide claim in the parent",
+    "content": "While recomputing the parent's values, σ(206) and σ(210) come out 312 and 576 — so the parent's `sigma_206_210 : σ 206 = σ 210`, asserted by `native_decide`, is false. This entry does not reproduce it. The episode illustrates the policy point: a symbolic proof cannot close a false goal, but `native_decide` will happily certify whatever the compiled evaluator returns — another reason to prefer kernel-checked, axiom-free computation for facts presented as verified.",
+    "mathContext": "$\\sigma(206) = \\sigma(2\\cdot 103) = 3\\cdot 104 = 312 \\ne 576 = 3\\cdot 4\\cdot 6\\cdot 8 = \\sigma(210).$"
+  }
+]

--- a/src/data/proofs/erdos-823-oq-05/meta.json
+++ b/src/data/proofs/erdos-823-oq-05/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "erdos-823-oq-05",
+  "title": "σ Values from Mathlib, Axiom-Free (Erdős #823)",
+  "slug": "erdos-823-oq-05",
+  "description": "The registered Erdős #823 entry computes its concrete sum-of-divisors values — σ(14)=σ(15)=24 and friends — with native_decide, which depends on Lean.ofReduceBool and so is not axiom-free under the project's axiom-integrity policy. This entry reproves the genuine σ-values symbolically from Mathlib's arithmetic-function API: σ is multiplicative (isMultiplicative_sigma) and σ(p)=p+1 on primes (from Nat.Prime.divisors), so σ at any explicit n is its prime factorization read off coprime-multiplicatively. Proves σ(6)=12, σ(14)=24, σ(15)=24, σ(28)=56, σ(957)=1440, σ(958)=1440, the σ-pairs σ(14)=σ(15) and σ(957)=σ(958), and that 6 and 28 are perfect (σ(n)=2n). #print axioms reports only propext / Classical.choice / Quot.sound — no Lean.ofReduceBool, no native_decide, no sorry. In passing it documents a latent bug in the parent: sigma_206_210 (σ206=σ210, asserted via native_decide) is false (312≠576).",
+  "meta": {
+    "author": "Erdős (problem); Pollack 2015 (theorem) — σ-values formalized in Lean 4",
+    "sourceUrl": "https://www.erdosproblems.com/823",
+    "date": "2015",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "sum-of-divisors",
+      "arithmetic-functions",
+      "multiplicative-functions",
+      "perfect-numbers",
+      "axiom-free",
+      "erdos"
+    ],
+    "proofRepoPath": "Proofs/Erdos823SigmaValues.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "ArithmeticFunction.sigma",
+      "ArithmeticFunction.sigma_one_apply",
+      "ArithmeticFunction.sigma_one_apply_prime_pow",
+      "ArithmeticFunction.isMultiplicative_sigma",
+      "ArithmeticFunction.IsMultiplicative.map_mul_of_coprime",
+      "Nat.Prime.divisors",
+      "Finset.sum_pair",
+      "Finset.sum_range_succ"
+    ],
+    "originalContributions": [
+      "Kernel-checked, 0-axiom recomputation of the Erdős #823 σ-values that the registered file proves with native_decide (which depends on Lean.ofReduceBool and is therefore not axiom-free)",
+      "A reusable symbolic recipe: σ(p) = p+1 from Nat.Prime.divisors plus coprime multiplicativity evaluates σ at any explicit n from its factorization, with no decision-procedure trust",
+      "Verified σ-pairs σ(14)=σ(15)=24 and σ(957)=σ(958)=1440 — consecutive-integer fibers of σ that are the α=1 base case of Pollack's theorem",
+      "Verified perfectness of 6 and 28 (σ(n)=2n), and a documented correction of the parent's false native_decide claim sigma_206_210 (σ206=312 ≠ σ210=576)"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 132,
+    "assumptions": "None. Every theorem is proved by the kernel from Mathlib lemmas; the only tactics that touch decision procedures are kernel `decide` (for small gcd coprimality facts) and `norm_num` (arithmetic and primality), neither of which introduces axioms. #print axioms on the σ-values reports exactly [propext, Classical.choice, Quot.sound] — no Lean.ofReduceBool (which native_decide would add) and no sorryAx. This is the point of the entry: the parent's native_decide computations are replaced by genuinely axiom-free symbolic proofs.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #823 asks whether, for every α ≥ 1, there exist sequences nₖ, mₖ with nₖ/mₖ → α and σ(nₖ) = σ(mₖ); Pollack proved YES in 2015. The smallest nontrivial witness that σ can repeat values is σ(14) = σ(15) = 24 — two consecutive integers in the same fiber of the sum-of-divisors function. The registered formalization Erdos823Problem.lean states Pollack's theorem as an axiom and illustrates it with concrete σ-values computed by native_decide. Under the project's axiom-integrity policy native_decide is not axiom-free: it trusts the compiled evaluator and shows up as the axiom Lean.ofReduceBool. This entry removes that dependency by computing the same values symbolically.",
+    "problemStatement": "Reprove the concrete sum-of-divisors values used by Erdős #823 — σ(14), σ(15), σ(957), σ(958) and related — from Mathlib's arithmetic-function API rather than native_decide, so that the results are kernel-checked and genuinely axiom-free.",
+    "text": "The whole file rests on two Mathlib facts: σ is multiplicative (ArithmeticFunction.isMultiplicative_sigma, giving σ(mn) = σ(m)σ(n) when gcd(m,n)=1) and, for a prime p, divisors p = {1, p} (Nat.Prime.divisors), so σ(p) = 1 + p (sigma_one_prime, via Finset.sum_pair). Each value theorem rewrites n as a product of prime powers, applies map_mul_of_coprime to split σ across coprime factors (coprimality discharged by kernel `decide` on the small gcds), evaluates σ on each prime via sigma_one_prime (and sigma_one_apply_prime_pow for the 2² in 28), and finishes with norm_num. This yields σ(6)=12, σ(14)=24, σ(15)=24, σ(28)=56, σ(957)=1440, σ(958)=1440. From these, sigma_pair_14_15 and sigma_pair_957_958 record the consecutive-integer σ-pairs, six_perfect and twentyeight_perfect record σ(n)=2n for the first two perfect numbers, and fiber_24 packages 14, 15 ∈ σ⁻¹(24).",
+    "proofStrategy": "Read σ off the prime factorization. Multiplicativity reduces σ(n) to a product of σ(prime power) terms; primes give σ(p)=p+1 directly from their two-element divisor set; the lone prime power 2² is handled by Mathlib's prime-power formula. All side conditions (coprimality, primality) are small and discharged by decide/norm_num without invoking the compiled evaluator, so no Lean.ofReduceBool enters.",
+    "keyInsights": [
+      "native_decide is not free: it adds Lean.ofReduceBool to the axiom set, so 'σ(14)=24 by native_decide' is an axiomatized fact, not a verified one. Symbolic evaluation via multiplicativity avoids this entirely.",
+      "The only arithmetic input needed is σ(p)=p+1 for primes (their divisor set is {1,p}); everything else is coprime multiplicativity, which Mathlib already provides for σ.",
+      "σ(14)=σ(15)=24 and σ(957)=σ(958)=1440 exhibit two consecutive integers sharing a σ-value — the simplest manifestation of the value-collisions that Pollack's theorem amplifies to arbitrary ratios n/m.",
+      "The same machinery proves σ(6)=2·6 and σ(28)=2·28, certifying the first two perfect numbers axiom-free.",
+      "Recomputing the parent's values surfaced a real error: its native_decide claim σ(206)=σ(210) is false (312 vs 576). Symbolic proof would have refused to close it; the decision procedure silently encoded a false statement (or the file is excluded from the verified build)."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function σ and its multiplicativity",
+      "Reading an arithmetic function off a prime factorization",
+      "Perfect numbers (σ(n) = 2n) and σ-fibers",
+      "Lean's axiom accounting: native_decide vs kernel decide (Lean.ofReduceBool)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sigma-on-primes",
+      "title": "σ on a prime",
+      "startLine": 45,
+      "endLine": 55,
+      "summary": "sigma_one_prime: for a prime p, divisors p = {1, p} (Nat.Prime.divisors), so σ(p) = 1 + p via Finset.sum_pair. The single building block beyond multiplicativity.",
+      "mathContext": "$p$ prime $\\Rightarrow$ divisors$(p) = \\{1, p\\}$, hence $\\sigma(p) = 1 + p$."
+    },
+    {
+      "id": "sigma-values",
+      "title": "σ values via multiplicativity",
+      "startLine": 57,
+      "endLine": 110,
+      "summary": "sigma_6, sigma_14, sigma_15, sigma_28, sigma_957, sigma_958: each factors n into prime powers, splits σ across coprime factors (isMultiplicative_sigma.map_mul_of_coprime), evaluates on primes (sigma_one_prime) and on 2² (sigma_one_apply_prime_pow), and closes with norm_num.",
+      "mathContext": "$\\sigma(14)=\\sigma(2)\\sigma(7)=3\\cdot 8=24$; $\\sigma(957)=\\sigma(3)\\sigma(11)\\sigma(29)=4\\cdot 12\\cdot 30=1440$."
+    },
+    {
+      "id": "pairs-and-perfect",
+      "title": "σ-pairs and perfect numbers",
+      "startLine": 112,
+      "endLine": 132,
+      "summary": "sigma_pair_14_15 and sigma_pair_957_958 give the consecutive-integer σ-pairs; six_perfect and twentyeight_perfect certify σ(n)=2n for 6 and 28; fiber_24 packages 14, 15 ∈ σ⁻¹(24), the α=1 case of Pollack's theorem.",
+      "mathContext": "$\\sigma(14)=\\sigma(15)$, $\\sigma(957)=\\sigma(958)$; $\\sigma(6)=2\\cdot 6$, $\\sigma(28)=2\\cdot 28$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-823",
+      "relationship": "extends",
+      "description": "The parent formalizes Pollack's theorem and illustrates it with σ-values computed by native_decide (hence depending on Lean.ofReduceBool). This entry reproves those values symbolically and axiom-free, and documents that the parent's sigma_206_210 (σ206=σ210) is false."
+    }
+  ],
+  "conclusion": {
+    "summary": "The concrete sum-of-divisors values behind Erdős #823 — σ(14)=σ(15)=24, σ(957)=σ(958)=1440, σ(6)=12, σ(28)=56 — are reproved symbolically from σ's multiplicativity and its value on primes, replacing the parent's native_decide computations with kernel-checked, genuinely axiom-free proofs (#print axioms shows only propext/Classical.choice/Quot.sound).",
+    "implications": "Beyond removing an axiom dependency, the entry gives a reusable recipe for evaluating any multiplicative arithmetic function at an explicit integer from its factorization, and it underscores a methodological point: native_decide can silently certify even false statements (the parent's σ206=σ210), whereas symbolic proof cannot. The verified σ-pairs are the elementary base of the value-collision phenomenon Pollack's theorem generalizes."
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ArithmeticFunction.Defs",
+      "Mathlib.NumberTheory.ArithmeticFunction.Misc",
+      "Mathlib.NumberTheory.Divisors",
+      "Mathlib.Tactic.NormNum.Prime"
+    ],
+    "opens": [
+      "ArithmeticFunction",
+      "ArithmeticFunction.sigma"
+    ],
+    "namespace": "Erdos823SigmaValues",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos823SigmaValues.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Pollack, Paul",
+      "title": "Remarks on fibers of the sum-of-divisors function",
+      "year": "2015",
+      "venue": "Analytic number theory (Springer), 305–320",
+      "note": "Proves the affirmative answer to Erdős #823 for σ; σ-fibers contain pairs of arbitrary ratio."
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "Remarks on some problems in number theory",
+      "year": "1974",
+      "venue": "Math. Balkanica 4",
+      "note": "Poses the σ version and notes the analogous φ result is easy."
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "Problem #823",
+      "year": "n.d.",
+      "venue": "erdosproblems.com",
+      "note": "Equal sum of divisors with arbitrary ratio; motivating example σ(14)=σ(15)=24."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "sigma_one_prime",
+      "type": "core",
+      "description": "For any prime p, σ(p) = p + 1, proved from Nat.Prime.divisors (divisors p = {1, p}). The building block for all values.",
+      "leanType": "∀ {p : ℕ}, p.Prime → ArithmeticFunction.sigma 1 p = p + 1"
+    },
+    {
+      "name": "sigma_pair_14_15",
+      "type": "core",
+      "description": "The smallest nontrivial σ-pair: σ(14) = σ(15) = 24, two consecutive integers in the same σ-fiber — the α = 1 case of Pollack's theorem, proved axiom-free.",
+      "leanType": "ArithmeticFunction.sigma 1 14 = ArithmeticFunction.sigma 1 15"
+    },
+    {
+      "name": "sigma_pair_957_958",
+      "type": "corollary",
+      "description": "A larger consecutive-integer σ-pair: σ(957) = σ(958) = 1440.",
+      "leanType": "ArithmeticFunction.sigma 1 957 = ArithmeticFunction.sigma 1 958"
+    },
+    {
+      "name": "twentyeight_perfect",
+      "type": "corollary",
+      "description": "28 is perfect: σ(28) = 2·28 — proved via σ(2²·7) = 7·8 = 56, axiom-free.",
+      "leanType": "ArithmeticFunction.sigma 1 28 = 2 * 28"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent **area-of-circle-oq-05** proves the Gaussian integral `∫ e^{-x²} = √π` and is already complete; siblings cover the polar proof, the multivariate case, and the complex Gaussian. The one classical strand left uncovered is the **normalization constants of the normal distribution** — the rescalings of `√π` that make the Gaussian a probability density. This PR supplies them, **axiom-free**, from Mathlib's `integral_gaussian`.

### Results (8 theorems)
| theorem | statement |
|---|---|
| `gaussian_half` | `∫ e^{-x²/2} = √(2π)` (rate b=1/2) |
| `gaussian_variance` | `∫ e^{-x²/(2σ²)} = σ√(2π)`, σ>0 (rate b=1/(2σ²), √(σ²·2π)) |
| `std_normal_normalization` | `∫ (1/√(2π))·e^{-x²/2} = 1` |
| `gaussian_variance_normalization` | `∫ (1/(σ√(2π)))·e^{-x²/(2σ²)} = 1` |
| `gaussian_mean_shift` | `∫ e^{-(x-μ)²/2} = √(2π)` (translation invariance) |
| `gaussian_unit` / `gaussian_unit_sq` | `∫ e^{-x²}=√π`; `(∫ e^{-x²})²=π` (area identity) |

### Idea
The bell curve's constants are just `√π` evaluated at different rates in `∫ e^{-bx²} = √(π/b)`: `b=1/2 → √(2π)`, `b=1/(2σ²) → σ√(2π)`. Normalizations pull the constant out (`integral_const_mul`) and cancel; the mean shift is translation invariance of the Lebesgue integral (`integral_sub_right_eq_self`).

### Scope (honest)
The parent is already 0-sorry/0-axiom; this 'completion'-tagged task supplies the genuinely uncovered normal-density strand rather than patching the parent.

### Axiom integrity
`#print axioms` → **`[propext, Classical.choice, Quot.sound]`** only. No `native_decide`, no `sorry`, no `axiom`.

### Build
`./proofs/scripts/docker-build.sh Proofs.AreaOfCircleOQ05Incomplete01` ✓ (Mathlib v4.26.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)