### PR TITLE
research(erdos-982-thin-vertex): the thin-vertex pigeonhole reduction [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2435,6 +2435,7 @@ import Proofs.Erdos980Problem
 import Proofs.Erdos981Problem
 import Proofs.Erdos982Aristotle
 import Proofs.Erdos982Problem
+import Proofs.Erdos982ThinVertex
 import Proofs.Erdos983Problem
 import Proofs.Erdos984Problem
 import Proofs.Erdos985Problem

--- a/proofs/Proofs/Erdos982ThinVertex.lean
+++ b/proofs/Proofs/Erdos982ThinVertex.lean
@@ -1,0 +1,220 @@
+/-
+Erdős Problem #982 — The "thin vertex" pigeonhole reduction
+
+Source: https://erdosproblems.com/982
+Parent file: Proofs/Erdos982Problem.lean (states the open conjecture with axioms)
+
+Statement of the open problem:
+If n distinct points in ℝ² form a convex polygon, then some vertex has at least
+⌊n/2⌋ distinct distances to the other vertices.  This remains OPEN; the best
+known lower bound is ≈ 0.361 n (Nivasch–Pach–Pinchasi–Zerbib 2013), while the
+regular polygon shows ⌊n/2⌋ would be best possible.
+
+WHAT THIS FILE PROVES (axiom-free, no `sorry`):
+
+The combinatorial *engine* behind every Moser-type bound, isolated cleanly and
+proved from scratch.  Fix a vertex `p`.  The other vertices fall into "distance
+classes": two vertices are in the same class iff they are equidistant from `p`
+(equivalently, they lie on a common circle centred at `p`).  Pigeonhole then
+relates the number of distinct distances to the size of the largest class:
+
+      (number of other vertices) ≤ (number of distinct distances) · (largest class).
+
+From this single inequality we extract three facts that pin down *exactly* where
+the difficulty of #982 lives:
+
+  1. `distinctDistances_ge_half`  — if no circle centred at `p` carries 3 of the
+     other vertices (every distance class has size ≤ 2), then `p` already sees
+     ≥ ⌊n/2⌋ distinct distances.  So the conjecture follows the instant one finds
+     such a "thin" vertex.  The bound is *tight*: the regular n-gon has all
+     classes of size ≤ 2 and exactly ⌊n/2⌋ distinct distances from each vertex.
+
+  2. `conjecture_of_exists_thin_vertex` — packaged for `maxDistinctDistances`:
+     a single thin vertex makes the #982 conjecture hold for that polygon.
+
+  3. `exists_three_equidistant_of_few_distances` — the contrapositive, and the
+     exact link to Erdős Problem #97: if `p` sees fewer than ⌊n/2⌋ distances then
+     some circle centred at `p` carries ≥ 3 other vertices.  Erdős conjectured
+     (#97) that one can always avoid 3 equidistant vertices; that was *disproved*,
+     which is precisely why #982 is hard — no purely combinatorial thin vertex is
+     guaranteed.
+
+None of these statements needs convex position: they are pure pigeonhole, and the
+genuinely geometric content of #982 is exactly the (open) claim that a thin vertex
+always exists.  That is the value of this file — it draws the line precisely.
+
+The general `M`-uniform bound `card_le_distinct_mul` underlies Moser's
+`f(n) ≥ ⌈n/3⌉` (a vertex with all classes ≤ 3) and every later refinement.
+-/
+
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Data.Finset.Card
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+
+open Finset
+
+namespace Erdos982ThinVertex
+
+/-
+## Part I: The abstract pigeonhole engine
+
+Nothing here is geometric.  For any function `f : α → β` and any finite set `s`,
+if every fibre of `f` over `s` has at most `M` elements, then `s` is no larger
+than `M` times the number of distinct values `f` takes on `s`.
+-/
+
+variable {α β : Type*} [DecidableEq β]
+
+/--
+**Uniform fibre pigeonhole.**
+If each value `b` in the image of `f` is attained by at most `M` elements of `s`,
+then `s.card ≤ (number of distinct values) * M`.
+-/
+theorem card_le_image_mul {s : Finset α} (f : α → β) {M : ℕ}
+    (hM : ∀ b ∈ s.image f, (s.filter (fun a => f a = b)).card ≤ M) :
+    s.card ≤ (s.image f).card * M := by
+  classical
+  rw [Finset.card_eq_sum_card_fiberwise
+        (f := f) (t := s.image f) (fun a ha => Finset.mem_image_of_mem f ha)]
+  calc ∑ b ∈ s.image f, (s.filter (fun a => f a = b)).card
+        ≤ ∑ _b ∈ s.image f, M := Finset.sum_le_sum hM
+    _ = (s.image f).card * M := by rw [Finset.sum_const, smul_eq_mul]
+
+/--
+**Distinct-value lower bound (floor division form).**
+A direct corollary: the number of distinct values is at least `s.card / M`.
+-/
+theorem image_card_ge_div {s : Finset α} (f : α → β) {M : ℕ}
+    (hM : ∀ b ∈ s.image f, (s.filter (fun a => f a = b)).card ≤ M) :
+    s.card / M ≤ (s.image f).card := by
+  exact Nat.div_le_of_le_mul (by rw [Nat.mul_comm]; exact card_le_image_mul f hM)
+
+/-
+## Part II: Distinct distances from a vertex
+
+We specialise the engine to `f = dist p`.  A "distance class" of `p` in `S` is a
+fibre of `q ↦ dist p q`: the set of vertices at one fixed distance, i.e. on one
+circle centred at `p`.
+-/
+
+/-- The Euclidean plane, ℝ² as an inner product space. -/
+abbrev Plane : Type := EuclideanSpace ℝ (Fin 2)
+
+/-- Number of distinct distances from `p` to the points of `S`. -/
+noncomputable def distinctDistancesFrom (p : Plane) (S : Finset Plane) : ℕ :=
+  (S.image (fun q => dist p q)).card
+
+/-- Maximum, over all vertices `p ∈ S`, of the distinct distances from `p` to the
+others.  This is the quantity the #982 conjecture lower-bounds by `⌊n/2⌋`. -/
+noncomputable def maxDistinctDistances (S : Finset Plane) : ℕ :=
+  S.sup (fun p => distinctDistancesFrom p (S.erase p))
+
+/--
+**Moser-type general bound.**
+If every circle centred at `p` carries at most `M` of the other `n-1` vertices,
+then `p` sees at least `(n-1)/M` distinct distances.  (`M = 3` is Moser's case.)
+-/
+theorem distinctDistances_ge_of_classes_le {p : Plane} {S : Finset Plane} {n : ℕ}
+    (hp : p ∈ S) (hcard : S.card = n) {M : ℕ}
+    (hM : ∀ d : ℝ, ((S.erase p).filter (fun q => dist p q = d)).card ≤ M) :
+    (n - 1) / M ≤ distinctDistancesFrom p (S.erase p) := by
+  have hcard' : (S.erase p).card = n - 1 := by
+    rw [Finset.card_erase_of_mem hp, hcard]
+  have := image_card_ge_div (s := S.erase p) (fun q => dist p q) (fun b _ => hM b)
+  rwa [hcard'] at this
+
+/--
+**Thin vertex ⇒ ⌊n/2⌋ distinct distances (the tight case).**
+If no circle centred at `p` carries 3 of the other vertices — every distance
+class has size ≤ 2 — then `p` already determines at least `⌊n/2⌋` distinct
+distances.  This is exactly the bound the regular polygon attains.
+-/
+theorem distinctDistances_ge_half {p : Plane} {S : Finset Plane} {n : ℕ}
+    (hp : p ∈ S) (hcard : S.card = n)
+    (h2 : ∀ d : ℝ, ((S.erase p).filter (fun q => dist p q = d)).card ≤ 2) :
+    n / 2 ≤ distinctDistancesFrom p (S.erase p) := by
+  have hcard' : (S.erase p).card = n - 1 := by
+    rw [Finset.card_erase_of_mem hp, hcard]
+  have hbound : (S.erase p).card ≤ distinctDistancesFrom p (S.erase p) * 2 :=
+    card_le_image_mul (s := S.erase p) (fun q => dist p q) (fun b _ => h2 b)
+  rw [hcard'] at hbound
+  -- (n-1) ≤ 2·k  ⟹  ⌊n/2⌋ ≤ k, using parity (the "diameter is unique" gain)
+  omega
+
+/--
+**A single thin vertex settles #982 for this polygon.**
+If some vertex `p ∈ S` has all distance classes of size ≤ 2, then
+`maxDistinctDistances S ≥ ⌊n/2⌋`, i.e. the Erdős #982 conjecture holds for `S`.
+-/
+theorem conjecture_of_exists_thin_vertex {S : Finset Plane} {n : ℕ} (hcard : S.card = n)
+    (h : ∃ p ∈ S, ∀ d : ℝ, ((S.erase p).filter (fun q => dist p q = d)).card ≤ 2) :
+    n / 2 ≤ maxDistinctDistances S := by
+  obtain ⟨p, hp, h2⟩ := h
+  calc n / 2 ≤ distinctDistancesFrom p (S.erase p) := distinctDistances_ge_half hp hcard h2
+    _ ≤ maxDistinctDistances S :=
+        Finset.le_sup (f := fun p => distinctDistancesFrom p (S.erase p)) hp
+
+/--
+**The obstruction, made explicit (link to Erdős #97).**
+Contrapositive of the thin-vertex bound: if `p` sees *fewer* than `⌊n/2⌋`
+distinct distances, then some circle centred at `p` carries **three** of the
+other vertices.  Erdős #97 asked whether such equidistant triples can always be
+avoided at some vertex; the answer is *no*, which is precisely what keeps #982 open.
+-/
+theorem exists_three_equidistant_of_few_distances {p : Plane} {S : Finset Plane} {n : ℕ}
+    (hp : p ∈ S) (hcard : S.card = n)
+    (hfew : distinctDistancesFrom p (S.erase p) < n / 2) :
+    ∃ d : ℝ, 3 ≤ ((S.erase p).filter (fun q => dist p q = d)).card := by
+  by_contra h
+  push_neg at h
+  have h2 : ∀ d : ℝ, ((S.erase p).filter (fun q => dist p q = d)).card ≤ 2 :=
+    fun d => Nat.lt_succ_iff.mp (h d)
+  have := distinctDistances_ge_half hp hcard h2
+  omega
+
+/-
+## Part III: A floor toward the conjecture, with no geometry assumed
+
+Every vertex of a polygon with ≥ 2 vertices sees at least one distance — so
+`maxDistinctDistances S ≥ 1`.  This discharges the `triangle_case` of the parent
+file (`n = 3` needs `≥ 1`) without invoking any axiom.
+-/
+
+/--
+**Trivial but axiom-free floor.**
+Any point set with at least two points has a vertex seeing ≥ 1 distinct distance.
+-/
+theorem maxDistinctDistances_pos {S : Finset Plane} (h : 2 ≤ S.card) :
+    1 ≤ maxDistinctDistances S := by
+  obtain ⟨p, hp⟩ := Finset.card_pos.mp (by omega : 0 < S.card)
+  have herase : (S.erase p).Nonempty := by
+    rw [← Finset.card_pos, Finset.card_erase_of_mem hp]; omega
+  have h1 : 1 ≤ distinctDistancesFrom p (S.erase p) := by
+    rw [distinctDistancesFrom, Nat.one_le_iff_ne_zero, Ne, Finset.card_eq_zero,
+        Finset.image_eq_empty]
+    exact herase.ne_empty
+  exact le_trans h1 (Finset.le_sup (f := fun p => distinctDistancesFrom p (S.erase p)) hp)
+
+/--
+**Triangle case (parent `triangle_case`), axiom-free.**
+Every triangle has a vertex with ≥ 1 distinct distance; the #982 bound `⌊3/2⌋ = 1`.
+-/
+theorem triangle_case (S : Finset Plane) (hcard : S.card = 3) :
+    1 ≤ maxDistinctDistances S :=
+  maxDistinctDistances_pos (by omega)
+
+/-
+## Part IV: Sanity check — the regular polygon side
+
+We record the abstract optimality witnessed above: a thin vertex gives `⌊n/2⌋`,
+and `⌊n/2⌋` is what the parent file's `regular_polygon_distances` axiom asserts is
+achieved.  The equality `⌈(n-1)/2⌉ = ⌊n/2⌋` (proved by `omega`) is the arithmetic
+reason the "diameter is unique" so the crude `(n-1)/2` is improved to `⌊n/2⌋`.
+-/
+
+/-- `⌈(n-1)/2⌉ = ⌊n/2⌋`: the unique-diameter arithmetic gain, for the record. -/
+theorem ceil_half_pred_eq_floor_half (n : ℕ) (hn : 1 ≤ n) :
+    (n - 1 + 1) / 2 = n / 2 := by
+  omega
+
+end Erdos982ThinVertex

--- a/src/data/proofs/erdos-982-thin-vertex/annotations.json
+++ b/src/data/proofs/erdos-982-thin-vertex/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "ann-erdos982thin-context",
+    "proofId": "erdos-982-thin-vertex",
+    "range": { "startLine": 1, "endLine": 57 },
+    "type": "concept",
+    "title": "Isolating the engine behind Erdős #982",
+    "content": "Erdős Problem #982 asks whether every convex n-gon has a vertex with at least ⌊n/2⌋ distinct distances to the other vertices — OPEN, with the best known bound ≈ 0.361n (Nivasch–Pach–Pinchasi–Zerbib 2013) and ⌊n/2⌋ attained by the regular polygon. The parent entry (Erdos982Problem.lean) states the conjecture and axiomatizes the published bounds. This file proves, axiom-free, the purely combinatorial core common to all Moser-type arguments and shows precisely where the genuine geometric difficulty sits. Fixing a vertex p, the other vertices split into 'distance classes': sets of vertices equidistant from p, i.e. lying on one circle centred at p. Pigeonhole relates the number of distinct distances to the size of the largest class. The geometric — and open — part is only that some vertex has all classes small.",
+    "mathContext": "$f(n)\\ge\\lfloor n/2\\rfloor$ is conjectured; here we prove the reduction $(n-1)\\le(\\#\\text{distances})\\cdot(\\text{largest class})$ and its consequences."
+  },
+  {
+    "id": "ann-erdos982thin-pigeonhole",
+    "proofId": "erdos-982-thin-vertex",
+    "range": { "startLine": 58, "endLine": 91 },
+    "type": "key-step",
+    "title": "The abstract fibre pigeonhole",
+    "content": "card_le_image_mul is fully general: for any f : α → β with DecidableEq β and any finite s, if every value b in the image is attained by at most M elements of s, then s.card ≤ (s.image f).card · M. The proof rewrites s.card as the fibrewise sum ∑_{b ∈ s.image f} #{a ∈ s | f a = b} via Finset.card_eq_sum_card_fiberwise, bounds each summand by M with Finset.sum_le_sum, and collapses ∑ M = (#image)·M with Finset.sum_const. image_card_ge_div repackages this as s.card/M ≤ #image using Nat.div_le_of_le_mul. Nothing here is geometric — this is the entire combinatorial content.",
+    "mathContext": "$s = \\bigsqcup_{b} f^{-1}(b)$ over $\\#(\\mathrm{im}\\,f)$ classes each of size $\\le M$, so $|s|\\le \\#(\\mathrm{im}\\,f)\\cdot M$."
+  },
+  {
+    "id": "ann-erdos982thin-moser",
+    "proofId": "erdos-982-thin-vertex",
+    "range": { "startLine": 112, "endLine": 131 },
+    "type": "technique",
+    "title": "The Moser-type general bound",
+    "content": "distinctDistances_ge_of_classes_le specialises the engine to f = dist p over S.erase p (the n−1 other vertices, card via Finset.card_erase_of_mem). If every circle centred at p carries ≤ M vertices, then p sees ≥ (n−1)/M distinct distances. M = 3 recovers Moser's 1952 bound f(n) ≥ ⌈n/3⌉; the entire family of published improvements (Erdős–Fishburn 1994, Dumitrescu 2006, NPPZ 2013) consists of better geometric bounds on M for a well-chosen vertex, not better combinatorics. The combinatorics is this one line.",
+    "mathContext": "All classes $\\le M \\Rightarrow \\#\\text{distances from }p \\ge \\dfrac{n-1}{M}$; Moser is $M=3$."
+  },
+  {
+    "id": "ann-erdos982thin-half",
+    "proofId": "erdos-982-thin-vertex",
+    "range": { "startLine": 132, "endLine": 162 },
+    "type": "key-step",
+    "title": "Thin vertex ⇒ ⌊n/2⌋, tight at the regular polygon",
+    "content": "distinctDistances_ge_half is the headline. If every distance class of p has size ≤ 2 (no three equidistant neighbours), then card_le_image_mul gives (n−1) ≤ (#distances)·2, and omega closes ⌊n/2⌋ ≤ #distances. The improvement of the crude ⌈(n−1)/2⌉ to the exact ⌊n/2⌋ is the parity fact ⌈(n−1)/2⌉ = ⌊n/2⌋ (recorded separately as ceil_half_pred_eq_floor_half): for even n the diametric neighbour forms a class of size 1, so one class is short and the bound rounds up. conjecture_of_exists_thin_vertex then lifts a single thin vertex to maxDistinctDistances via Finset.le_sup: one thin vertex settles #982 for that polygon.",
+    "mathContext": "All classes $\\le 2 \\Rightarrow \\#\\text{distances}\\ge\\lceil (n-1)/2\\rceil=\\lfloor n/2\\rfloor$, exactly the regular-polygon value."
+  },
+  {
+    "id": "ann-erdos982thin-obstruction",
+    "proofId": "erdos-982-thin-vertex",
+    "range": { "startLine": 163, "endLine": 174 },
+    "type": "concept",
+    "title": "The obstruction: link to Erdős #97",
+    "content": "exists_three_equidistant_of_few_distances is the contrapositive: if p sees fewer than ⌊n/2⌋ distinct distances then some circle centred at p passes through three other vertices (push_neg turns 'no class of size 3' into 'all classes ≤ 2', then the headline bound contradicts the hypothesis). This is the exact point where #982 stops being combinatorial. Erdős Problem #97 asked whether one can always find a vertex with no three equidistant neighbours — precisely a thin vertex — and that was DISPROVED. So a thin vertex is not guaranteed, the engine alone cannot close #982, and the gap to the conjecture is genuinely geometric. This file draws that line exactly.",
+    "mathContext": "$\\#\\text{distances from }p<\\lfloor n/2\\rfloor \\Rightarrow \\exists$ a circle at $p$ through $3$ vertices — the #97 configuration that cannot always be avoided."
+  },
+  {
+    "id": "ann-erdos982thin-floor",
+    "proofId": "erdos-982-thin-vertex",
+    "range": { "startLine": 176, "endLine": 220 },
+    "type": "key-step",
+    "title": "Axiom-free base case and the unique-diameter arithmetic",
+    "content": "maxDistinctDistances_pos proves that any set with ≥ 2 points has a vertex with ≥ 1 distinct distance: pick p, the erase is nonempty (Finset.card_erase_of_mem), so its image under dist p is nonempty (Finset.Nonempty.image), giving card ≥ 1, lifted by Finset.le_sup. triangle_case is the n = 3 instance ⌊3/2⌋ = 1 — the parent file left this as a sorry; here it is discharged without any axiom. ceil_half_pred_eq_floor_half records ⌈(n−1)/2⌉ = ⌊n/2⌋ (omega), the arithmetic reason the tight bound holds.",
+    "mathContext": "$|S|\\ge 2\\Rightarrow \\max\\text{distances}\\ge 1$ (the $n=3$ case), and $\\lceil(n-1)/2\\rceil=\\lfloor n/2\\rfloor$."
+  }
+]

--- a/src/data/proofs/erdos-982-thin-vertex/meta.json
+++ b/src/data/proofs/erdos-982-thin-vertex/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "erdos-982-thin-vertex",
+  "slug": "erdos-982-thin-vertex",
+  "title": "Erdős #982: The Thin-Vertex Pigeonhole Reduction",
+  "description": "An axiom-free isolation of the combinatorial engine behind every Moser-type lower bound for Erdős Problem #982 (distinct distances from a convex polygon vertex, OPEN). Fixing a vertex p, the other n−1 vertices split into distance classes — vertices equidistant from p, i.e. lying on a common circle centred at p. Pigeonhole gives (n−1) ≤ (#distinct distances)·(largest class). From this single inequality: (1) if no circle centred at p carries 3 other vertices (every class ≤ 2), then p already sees ≥ ⌊n/2⌋ distinct distances — exactly the conjectured bound, tight at the regular polygon; (2) a single such 'thin' vertex settles the #982 conjecture for that polygon; (3) the contrapositive — fewer than ⌊n/2⌋ distances forces a circle through 3 vertices — is the precise link to the disproved Erdős #97, showing why no purely combinatorial thin vertex is guaranteed and hence why #982 is hard. None of these statements uses convex position: the geometric content of #982 is exactly the open existence of a thin vertex. The general M-uniform bound underlies Moser's ⌈n/3⌉ and every refinement.",
+  "meta": {
+    "author": "Lean Genius Researcher-9",
+    "sourceUrl": "https://erdosproblems.com/982",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos982ThinVertex.lean",
+    "tags": [
+      "erdos",
+      "discrete-geometry",
+      "convex",
+      "distinct-distances",
+      "pigeonhole",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 220,
+    "theoremCount": 9,
+    "definitionCount": 3,
+    "erdosNumber": 982,
+    "erdosUrl": "https://erdosproblems.com/982",
+    "erdosProblemStatus": "open",
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. The four axioms of the parent entry (Erdos982Problem.lean: moser_bound, nppz_bound, regular_polygon_distances, stronger_conjecture_is_false) are NOT used or assumed here. All results depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (the latter two enter via `Real.decidableEq` for taking `Finset.image` of distances, hence the `noncomputable` definitions). The geometric core of #982 — that a thin vertex always exists — is explicitly NOT proved; it is the open content this file isolates.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_eq_sum_card_fiberwise",
+        "description": "Fibrewise cardinality: s.card = ∑_{b ∈ t} (s.filter (f · = b)).card when f maps s into t",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_le_sum",
+        "description": "Monotonicity of finite sums, used to bound each fibre by the uniform M",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.div_le_of_le_mul",
+        "description": "m ≤ k·n → m/k ≤ n, converting the product bound to the floor-division bound on #distinct distances",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "Finset.card_erase_of_mem",
+        "description": "(S.erase p).card = S.card − 1 for p ∈ S, giving the n−1 other vertices",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.le_sup",
+        "description": "f a ≤ s.sup f for a ∈ s, lifting a single thin vertex to maxDistinctDistances",
+        "module": "Mathlib.Data.Finset.Lattice.Fold"
+      },
+      {
+        "theorem": "EuclideanSpace",
+        "description": "ℝ² as an inner product space; the ambient plane",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      }
+    ],
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.PiL2",
+      "Mathlib.Data.Finset.Card",
+      "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos982ThinVertex",
+    "lineCount": 220,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos982ThinVertex.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "distinctDistances_ge_half",
+      "type": "headline",
+      "statement": "p ∈ S → S.card = n → (∀ d, #{q ∈ S.erase p | dist p q = d} ≤ 2) → n/2 ≤ distinctDistancesFrom p (S.erase p)",
+      "description": "If no circle centred at p carries 3 of the other vertices (every distance class has size ≤ 2), then p already determines at least ⌊n/2⌋ distinct distances. The parity gain from ⌈(n−1)/2⌉ to ⌊n/2⌋ (the 'diameter is unique' improvement) is discharged by omega.",
+      "significance": "Exactly the conjectured #982 bound, and tight: the regular n-gon has all distance classes ≤ 2 and attains precisely ⌊n/2⌋ distinct distances from every vertex. Reduces the conjecture to a purely geometric existence question."
+    },
+    {
+      "name": "conjecture_of_exists_thin_vertex",
+      "type": "headline",
+      "statement": "S.card = n → (∃ p ∈ S, ∀ d, #{q ∈ S.erase p | dist p q = d} ≤ 2) → n/2 ≤ maxDistinctDistances S",
+      "description": "Packaged for maxDistinctDistances: the existence of one thin vertex (no three equidistant neighbours) makes the Erdős #982 conjecture hold for the polygon S, via Finset.le_sup.",
+      "significance": "States the reduction cleanly — #982 ⟸ 'every convex polygon has a thin vertex'. This is the exact gap between the elementary engine and the open problem."
+    },
+    {
+      "name": "exists_three_equidistant_of_few_distances",
+      "type": "headline",
+      "statement": "p ∈ S → S.card = n → distinctDistancesFrom p (S.erase p) < n/2 → ∃ d, 3 ≤ #{q ∈ S.erase p | dist p q = d}",
+      "description": "Contrapositive of the thin-vertex bound: if p sees fewer than ⌊n/2⌋ distinct distances, some circle centred at p passes through three of the other vertices.",
+      "significance": "The precise link to Erdős Problem #97 (avoiding equidistant triples at some vertex), which was DISPROVED. That disproof is exactly why a thin vertex cannot be guaranteed combinatorially, and hence why #982 remains open."
+    },
+    {
+      "name": "card_le_image_mul",
+      "type": "core",
+      "statement": "(∀ b ∈ s.image f, #{a ∈ s | f a = b} ≤ M) → s.card ≤ (s.image f).card · M",
+      "description": "The abstract pigeonhole engine, for an arbitrary function f : α → β with decidable equality on β. Proved from Finset.card_eq_sum_card_fiberwise and Finset.sum_le_sum. Entirely non-geometric.",
+      "significance": "The single inequality from which every distinct-distance lower bound in this file (and Moser's ⌈n/3⌉) descends, by specialising f = dist p and bounding fibre sizes."
+    },
+    {
+      "name": "distinctDistances_ge_of_classes_le",
+      "type": "core",
+      "statement": "p ∈ S → S.card = n → (∀ d, #{q ∈ S.erase p | dist p q = d} ≤ M) → (n−1)/M ≤ distinctDistancesFrom p (S.erase p)",
+      "description": "Moser-type general bound: if every circle centred at p carries ≤ M of the other vertices, then p sees ≥ (n−1)/M distinct distances. M = 3 is Moser's 1952 case, M = 2 the regular-polygon-tight case.",
+      "significance": "Unifies the whole family of vertex distinct-distance lower bounds as instances of one fibre bound; the published improvements (Erdős–Fishburn, Dumitrescu, NPPZ) are improvements in the geometric bound on M, not in the combinatorics."
+    },
+    {
+      "name": "maxDistinctDistances_pos",
+      "type": "supporting",
+      "statement": "2 ≤ S.card → 1 ≤ maxDistinctDistances S",
+      "description": "Any point set with at least two points has a vertex seeing ≥ 1 distinct distance (the image of a nonempty erase is nonempty). Discharges the parent file's triangle_case axiom-free.",
+      "significance": "The n = 3 base case of #982 (⌊3/2⌋ = 1), proved without any of the parent's axioms."
+    }
+  ],
+  "sections": [
+    {
+      "id": "pigeonhole-engine",
+      "title": "Part I: The abstract pigeonhole engine",
+      "startLine": 58,
+      "endLine": 91,
+      "summary": "card_le_image_mul: for f : α → β with DecidableEq β, if every fibre over s has ≤ M elements then s.card ≤ (s.image f).card · M, via Finset.card_eq_sum_card_fiberwise + Finset.sum_le_sum + sum_const. image_card_ge_div: the floor-division corollary s.card/M ≤ (s.image f).card via Nat.div_le_of_le_mul. No geometry.",
+      "mathContext": "Partitioning s by the value of f into (s.image f).card classes each of size ≤ M forces s.card ≤ (#classes)·M, i.e. #classes ≥ s.card/M."
+    },
+    {
+      "id": "distinct-distances",
+      "title": "Part II: Distinct distances from a vertex",
+      "startLine": 92,
+      "endLine": 175,
+      "summary": "Plane = EuclideanSpace ℝ (Fin 2); distinctDistancesFrom p S = #(S.image (dist p ·)); maxDistinctDistances S = sup over p of distinctDistancesFrom p (S.erase p). Then: distinctDistances_ge_of_classes_le (Moser-type (n−1)/M), the headline distinctDistances_ge_half (classes ≤ 2 ⇒ ≥ ⌊n/2⌋, parity via omega), conjecture_of_exists_thin_vertex (lift one thin vertex to maxDistinctDistances), and exists_three_equidistant_of_few_distances (contrapositive, link to #97).",
+      "mathContext": "A distance class of p is a circle centred at p; with all classes ≤ 2 the n−1 neighbours need ≥ ⌈(n−1)/2⌉ = ⌊n/2⌋ circles, matching the regular polygon exactly."
+    },
+    {
+      "id": "axiom-free-floor",
+      "title": "Part III: A floor toward the conjecture, no geometry assumed",
+      "startLine": 176,
+      "endLine": 206,
+      "summary": "maxDistinctDistances_pos: a set with ≥ 2 points has a vertex with ≥ 1 distinct distance (nonempty erase ⇒ nonempty image). triangle_case: the n = 3 instance ⌊3/2⌋ = 1, discharging the parent file's sorried triangle_case without any axiom.",
+      "mathContext": "Every vertex sees at least one distance, so maxDistinctDistances ≥ 1 whenever |S| ≥ 2 — the trivial but axiom-free n = 3 base case."
+    },
+    {
+      "id": "regular-polygon-arithmetic",
+      "title": "Part IV: The unique-diameter arithmetic gain",
+      "startLine": 207,
+      "endLine": 220,
+      "summary": "ceil_half_pred_eq_floor_half: ⌈(n−1)/2⌉ = ⌊n/2⌋ for n ≥ 1 (Nat, via omega). Records the arithmetic reason the crude (n−1)/2 bound is improved to the tight ⌊n/2⌋ — the unique diameter contributes a class of size 1.",
+      "mathContext": "From a regular even n-gon vertex the diametric neighbour is unique (class size 1) and the rest pair up (size 2), giving exactly 1 + (n−2)/2 = n/2 = ⌊n/2⌋ distinct distances."
+    }
+  ]
+}


### PR DESCRIPTION
## Erdős Problem #982 — distinct distances from a convex polygon vertex (OPEN)

**Problem.** If $n$ distinct points form a convex polygon, must some vertex have $\ge \lfloor n/2\rfloor$ distinct distances to the other vertices? Open; best known $\approx 0.361n$ (Nivasch–Pach–Pinchasi–Zerbib 2013), with $\lfloor n/2\rfloor$ attained by the regular polygon.

The parent entry (`Erdos982Problem.lean`) states the conjecture with **4 axioms** and **3 sorries**. This sibling proves, **axiom-free**, the combinatorial engine common to every Moser-type bound and draws the exact line where the geometric difficulty begins.

### The reduction
Fix a vertex $p$. The other $n-1$ vertices fall into **distance classes** — sets equidistant from $p$, i.e. lying on one circle centred at $p$. A single pigeonhole inequality drives everything:
$$ (n-1)\ \le\ (\#\text{distinct distances from } p)\cdot(\text{largest class}). $$

### Results (all 0-axiom, 0-sorry, no `native_decide`)
- **`card_le_image_mul`** — the abstract fibre pigeonhole, for any `f : α → β`.
- **`distinctDistances_ge_half`** — if no circle at $p$ holds 3 vertices (every class $\le 2$) then $p$ already sees $\ge \lfloor n/2\rfloor$ distances. **Tight**: the regular $n$-gon attains exactly this. The $\lceil(n-1)/2\rceil=\lfloor n/2\rfloor$ parity gain is the "unique diameter".
- **`conjecture_of_exists_thin_vertex`** — one *thin* vertex makes the #982 conjecture hold for that polygon (`Finset.le_sup`).
- **`exists_three_equidistant_of_few_distances`** — contrapositive: fewer than $\lfloor n/2\rfloor$ distances forces a circle through **3** vertices. This is the precise link to Erdős **#97** (avoiding equidistant triples), which was **disproved** — exactly why a thin vertex is not guaranteed and #982 stays open.
- **`distinctDistances_ge_of_classes_le`** — Moser's $\lceil n/3\rceil$ is the $M=3$ instance; the published improvements are better geometric bounds on $M$, not better combinatorics.
- **`maxDistinctDistances_pos` / `triangle_case`** — the parent's sorried $n=3$ case, discharged with no axiom.

**Honest scope.** None of these statements uses convex position — they are pure pigeonhole. The genuinely geometric content of #982 (that a thin vertex always exists) is *not* proved; it is the open question this file isolates. Uses **none** of the parent's 4 axioms.

`#print axioms` on the headline results: `[propext, Classical.choice, Quot.sound]` only.

9 theorems · 3 defs · 220 lines · builds against Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)