### PR TITLE
research(mean-value-theorem-oq-02-oq-01): Taylor remainder estimates + series convergence [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2959,6 +2959,7 @@ import Proofs.MatrixPosDefSqrtOQ01
 import Proofs.MatrixSimilarityInvariantsOQ01
 import Proofs.MeanValueTheorem
 import Proofs.MeanValueTheoremOQ02
+import Proofs.MeanValueTheoremOQ02OQ01
 import Proofs.MeanValueTheoremOQ02OQ02UIcc
 import Proofs.MeanValueTheoremOQ02OQ04
 import Proofs.MeanValueTheoremOQ02OQ04OQ01

--- a/proofs/Proofs/MeanValueTheoremOQ02OQ01.lean
+++ b/proofs/Proofs/MeanValueTheoremOQ02OQ01.lean
@@ -1,0 +1,164 @@
+import Proofs.MeanValueTheoremOQ02
+import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+
+/-!
+# Mean Value Theorem OQ-02-OQ-01: Taylor remainder *estimates* and series convergence
+
+## The open question (from `mean-value-theorem-oq-02`)
+
+The parent entry proved Taylor's theorem with the **Lagrange remainder** as an exact
+equality (`MeanValueTheoremOQ02.taylor_lagrange_remainder`):
+
+  f(b) - Tₙ(b) = f⁽ⁿ⁺¹⁾(c)/(n+1)! · (b-a)ⁿ⁺¹   for some c ∈ (a,b).
+
+The open follow-up asks: how does this exact remainder turn **derivative control into
+function-value control**, and how does it drive the convergence of the Taylor *series*?
+That is the bridge `whyMatters` highlights ("Taylor remainder estimates depend on
+converting derivative control into function-value control").
+
+## What this file proves (all from the parent's exact Lagrange remainder)
+
+* `taylor_remainder_bound` — if `|f⁽ⁿ⁺¹⁾| ≤ M` on `(a,b)` then
+    `|f(b) - Tₙ(b)| ≤ M/(n+1)! · (b-a)ⁿ⁺¹`.
+  This is the sharp `(n+1)!` estimate (sharper than Mathlib's
+  `taylor_mean_remainder_bound`, which carries the weaker `n!`), obtained directly by
+  taking absolute values in the Lagrange equality.
+
+* `taylorPolynomial_tendsto` — if **all** derivatives of `f` are uniformly bounded by a
+  single constant `M` on `(a,b)`, then `Tₙ(b) → f(b)`, i.e. the Taylor series of `f`
+  centered at `a` converges to `f(b)`.  The engine is `(b-a)ⁿ⁺¹/(n+1)! → 0`.
+
+* `iteratedDeriv_exp`, `taylorPolynomial_exp` — the iterated derivatives of `exp` are
+  `exp`, so its Taylor polynomial at `0` is the partial exponential sum `∑ xᵏ/k!`.
+
+* `exp_taylor_tendsto` — the headline concrete payoff: for `x > 0`,
+    `∑_{k≤n} xᵏ/k! → exp x`,
+  derived purely from the remainder estimate (every derivative of `exp` on `(0,x)` is
+  bounded by `exp x`).
+
+## Honesty / scope
+
+The Lagrange remainder itself comes from Mathlib via the parent file; this file's
+contribution is the *estimate* layer (derivative bound ⇒ value bound ⇒ series
+convergence) and its application to `exp`.  Mathlib of course already knows the
+exponential series converges; the point here is that it falls out of the MVT/Taylor
+remainder machinery rather than from the power-series definition.
+
+Theorems: 5, Axioms: 0, Sorries: 0
+-/
+
+noncomputable section
+
+open Real Set Filter Topology MeanValueTheoremOQ02
+
+namespace MeanValueTheoremOQ02OQ01
+
+/-!
+## Part I: The Taylor remainder estimate
+
+Taking absolute values in the parent's exact Lagrange remainder converts a bound on the
+`(n+1)`-th derivative into a bound on the approximation error.
+-/
+
+/-- **Taylor remainder estimate (sharp constant).**
+
+If `f` is `(n+1)`-times continuously differentiable and its `(n+1)`-th derivative is
+bounded in absolute value by `M` on `(a,b)`, then the `n`-th Taylor polynomial
+approximates `f(b)` with error at most `M/(n+1)! · (b-a)ⁿ⁺¹`.
+
+This is the direct payoff of the Lagrange remainder: derivative control becomes
+function-value control. -/
+theorem taylor_remainder_bound
+    (f : ℝ → ℝ) (a b : ℝ) (hab : a < b) (n : ℕ) (M : ℝ)
+    (hf : ContDiff ℝ (n + 1) f)
+    (hM : ∀ x ∈ Set.Ioo a b, |iteratedDeriv (n + 1) f x| ≤ M) :
+    |f b - taylorPolynomial f a n b| ≤
+      M / ((n + 1).factorial : ℝ) * (b - a) ^ (n + 1) := by
+  obtain ⟨c, hc, heq⟩ := taylor_lagrange_remainder f a b hab n hf
+  have hfac : (0 : ℝ) < ((n + 1).factorial : ℝ) := by
+    exact_mod_cast (n + 1).factorial_pos
+  have hba : (0 : ℝ) < (b - a) ^ (n + 1) := pow_pos (sub_pos.mpr hab) _
+  rw [heq, abs_mul, abs_div, abs_of_pos hfac, abs_of_pos hba]
+  gcongr
+  exact hM c hc
+
+/-!
+## Part II: Convergence of the Taylor series
+
+If a single constant `M` bounds *every* derivative of `f` on `(a,b)`, the remainder
+estimate forces `Tₙ(b) → f(b)`, because `(b-a)ⁿ⁺¹/(n+1)! → 0`.
+-/
+
+/-- **Convergence of the Taylor series from a uniform derivative bound.**
+
+If `f` is smooth and there is a single constant `M` bounding the absolute value of
+*all* of its derivatives on `(a,b)`, then its Taylor polynomials at `a` converge to
+`f(b)`. Functions like `sin`, `cos`, and `exp` (on a bounded interval) satisfy this. -/
+theorem taylorPolynomial_tendsto
+    (f : ℝ → ℝ) (a b : ℝ) (hab : a < b) (M : ℝ)
+    (hf : ContDiff ℝ ⊤ f)
+    (hM : ∀ n : ℕ, ∀ x ∈ Set.Ioo a b, |iteratedDeriv n f x| ≤ M) :
+    Tendsto (fun n => taylorPolynomial f a n b) atTop (𝓝 (f b)) := by
+  -- The error bound `g n = M · (b-a)ⁿ⁺¹/(n+1)!`.
+  set g : ℕ → ℝ := fun n => M * ((b - a) ^ (n + 1) / ((n + 1).factorial : ℝ)) with hg_def
+  -- The remainder estimate applied at each `n`.
+  have hbnd : ∀ n, |taylorPolynomial f a n b - f b| ≤ g n := by
+    intro n
+    have h := taylor_remainder_bound f a b hab n M (hf.of_le le_top)
+      (fun x hx => hM (n + 1) x hx)
+    rw [abs_sub_comm]
+    refine h.trans_eq ?_
+    rw [hg_def]; ring
+  -- The error bound tends to `0` (terms of the convergent series `M·∑ (b-a)ᵏ/k!`).
+  have hg : Tendsto g atTop (𝓝 0) := by
+    have hs : Summable (fun k : ℕ => M * ((b - a) ^ k / (k.factorial : ℝ))) :=
+      (Real.summable_pow_div_factorial (b - a)).mul_left M
+    have h0 := hs.tendsto_atTop_zero
+    exact h0.comp (tendsto_add_atTop_nat 1)
+  -- Squeeze: the (signed) error tends to `0`, hence `Tₙ(b) → f(b)`.
+  have hF : Tendsto (fun n => taylorPolynomial f a n b - f b) atTop (𝓝 0) := by
+    refine squeeze_zero_norm (fun n => ?_) hg
+    simpa [Real.norm_eq_abs] using hbnd n
+  have := hF.add (tendsto_const_nhds (x := f b))
+  simpa using this
+
+/-!
+## Part III: The exponential function
+
+The iterated derivatives of `exp` are all `exp`, so its Taylor polynomial at `0` is the
+familiar partial sum `∑ xᵏ/k!`, and the remainder machinery yields convergence.
+-/
+
+/-- Every iterated derivative of `Real.exp` is `Real.exp` itself. -/
+theorem iteratedDeriv_exp (n : ℕ) : iteratedDeriv n Real.exp = Real.exp := by
+  rw [iteratedDeriv_eq_iterate]
+  exact Real.iter_deriv_exp n
+
+/-- The `n`-th Taylor polynomial of `exp` centered at `0` is the partial exponential
+sum `∑_{k≤n} xᵏ/k!`. -/
+theorem taylorPolynomial_exp (n : ℕ) (x : ℝ) :
+    taylorPolynomial Real.exp 0 n x =
+      ∑ k ∈ Finset.range (n + 1), x ^ k / (k.factorial : ℝ) := by
+  simp only [taylorPolynomial, iteratedDeriv_exp, Real.exp_zero, sub_zero]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  ring
+
+/-- **Convergence of the exponential Taylor series**, derived from the Taylor remainder
+estimate.
+
+For `x > 0`, the partial sums `∑_{k≤n} xᵏ/k!` converge to `exp x`. The key bound is that
+every derivative of `exp` on `(0,x)` is at most `exp x`, so the uniform-bound
+convergence result applies. -/
+theorem exp_taylor_tendsto {x : ℝ} (hx : 0 < x) :
+    Tendsto (fun n => ∑ k ∈ Finset.range (n + 1), x ^ k / (k.factorial : ℝ))
+      atTop (𝓝 (Real.exp x)) := by
+  have hM : ∀ n : ℕ, ∀ y ∈ Set.Ioo (0 : ℝ) x, |iteratedDeriv n Real.exp y| ≤ Real.exp x := by
+    intro n y hy
+    rw [iteratedDeriv_exp, abs_of_pos (Real.exp_pos y)]
+    exact Real.exp_le_exp.mpr (le_of_lt hy.2)
+  have key := taylorPolynomial_tendsto Real.exp 0 x hx (Real.exp x) Real.contDiff_exp hM
+  exact key.congr (fun n => taylorPolynomial_exp n x)
+
+end MeanValueTheoremOQ02OQ01

--- a/src/data/proofs/mean-value-theorem-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-01/annotations.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "ann-mvt02oq01-header",
+    "proofId": "mean-value-theorem-oq-02-oq-01",
+    "type": "concept",
+    "range": {
+      "startLine": 6,
+      "endLine": 50
+    },
+    "title": "From exact remainder to estimate to series convergence",
+    "content": "The module docstring frames the OQ-01 follow-up of mean-value-theorem-oq-02: the parent proved Taylor's theorem with the EXACT Lagrange remainder f(b) − Tₙ(b) = f⁽ⁿ⁺¹⁾(c)/(n+1)!·(b−a)ⁿ⁺¹, but the exact form contains an unknown intermediate point c and so cannot be evaluated. Its real utility is as a source of ESTIMATES. This file builds the estimate layer in three steps: (I) absolute values turn a derivative bound |f⁽ⁿ⁺¹⁾| ≤ M into the error bound M/(n+1)!·(b−a)ⁿ⁺¹; (II) a uniform bound on ALL derivatives forces the Taylor polynomials to converge to f(b); (III) the exponential series ∑ xᵏ/k! → exp x falls out as the concrete payoff. The honesty note records that the Lagrange remainder is reused from the ancestor and that Mathlib already knows the exp series converges — the contribution is the MVT-rooted derivation of these facts, all 0-axiom / 0-sorry.",
+    "mathContext": "Exact: $f(b) - T_n(b) = \\frac{f^{(n+1)}(c)}{(n+1)!}(b-a)^{n+1}$. Estimate: $|f(b) - T_n(b)| \\le \\frac{M}{(n+1)!}(b-a)^{n+1}$ when $|f^{(n+1)}| \\le M$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Taylor's theorem",
+      "Lagrange remainder",
+      "error estimates",
+      "Taylor series convergence"
+    ],
+    "prerequisites": [
+      "Taylor's theorem with Lagrange remainder",
+      "iterated derivatives",
+      "limits of sequences"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq01-remainder-bound",
+    "proofId": "mean-value-theorem-oq-02-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 73,
+      "endLine": 87
+    },
+    "title": "taylor_remainder_bound: the sharp Taylor remainder estimate",
+    "content": "If f is C^{n+1} and |iteratedDeriv (n+1) f x| ≤ M for all x ∈ (a,b), then |f b − taylorPolynomial f a n b| ≤ M/(n+1)!·(b−a)ⁿ⁺¹. The proof is a one-line abstraction of the ancestor's exact remainder: obtain the Lagrange witness c ∈ (a,b) with f b − Tₙ(b) = iteratedDeriv (n+1) f c/(n+1)!·(b−a)ⁿ⁺¹; rewrite, then since both (n+1)! and (b−a)ⁿ⁺¹ are positive, normalize the absolute value (abs_mul, abs_div, abs_of_pos twice) and close by gcongr, which reduces the goal to |iteratedDeriv (n+1) f c| ≤ M — exactly the hypothesis applied at c. The factorial denominator is the sharp (n+1)!, strictly better than Mathlib's general taylor_mean_remainder_bound (which delivers only 1/n!), because the exact scalar Lagrange remainder already carries the optimal factor.",
+    "mathContext": "$|f(b) - T_n(b)| \\le \\dfrac{M}{(n+1)!}(b-a)^{n+1}$. Sharpness: the $(n+1)!$ matches the exact Lagrange form, unlike the vector-valued $n!$ bound.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Lagrange remainder",
+      "gcongr",
+      "derivative bounds",
+      "sharp constants"
+    ],
+    "prerequisites": [
+      "absolute value of products and quotients",
+      "monotonicity of multiplication (gcongr)"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq01-tendsto",
+    "proofId": "mean-value-theorem-oq-02-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 99,
+      "endLine": 127
+    },
+    "title": "taylorPolynomial_tendsto: convergence from a uniform derivative bound",
+    "content": "If f is C^∞ and a single constant M bounds |iteratedDeriv n f| on (a,b) for EVERY n, then taylorPolynomial f a n b → f b. The error |Tₙ(b) − f b| is bounded by g(n) = M·(b−a)ⁿ⁺¹/(n+1)! via the Part I estimate (applied at order n+1 with the n-independent bound). g → 0 because g is the M-scaled, index-shifted tail of the convergent exponential series ∑ (b−a)ᵏ/k!: Real.summable_pow_div_factorial gives summability, Summable.tendsto_atTop_zero gives terms → 0, and composing with tendsto_add_atTop_nat 1 performs the k = n+1 reindex. squeeze_zero_norm then drives the signed error Tₙ(b) − f b to 0, and adding the constant f b (Tendsto.add tendsto_const_nhds) yields Tₙ(b) → f b. Functions like sin, cos (M = 1 globally) and exp on a bounded interval satisfy the uniform-bound hypothesis.",
+    "mathContext": "$|f^{(n)}| \\le M$ on $(a,b)$ for all $n$ $\\Rightarrow$ $T_n(b) \\to f(b)$, the engine being $\\dfrac{(b-a)^{n+1}}{(n+1)!} \\to 0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Taylor series convergence",
+      "squeeze theorem",
+      "summable sequences",
+      "uniform derivative bound"
+    ],
+    "prerequisites": [
+      "summability of the exponential series",
+      "sandwich theorem squeeze_zero_norm",
+      "reindexing limits"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq01-iterderiv-exp",
+    "proofId": "mean-value-theorem-oq-02-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 135,
+      "endLine": 139
+    },
+    "title": "iteratedDeriv_exp and taylorPolynomial_exp",
+    "content": "iteratedDeriv n Real.exp = Real.exp: convert iteratedDeriv to the n-fold iterate of deriv (iteratedDeriv_eq_iterate) and apply Real.iter_deriv_exp (deriv^[n] exp = exp). As a consequence taylorPolynomial Real.exp 0 n x simplifies (simp with iteratedDeriv_exp, Real.exp_zero, sub_zero, then ring on each term) to the exponential partial sum ∑_{k≤n} xᵏ/k!, since every coefficient iteratedDeriv k exp 0 / k! = exp 0 / k! = 1/k! and (x − 0)ᵏ = xᵏ.",
+    "mathContext": "$\\frac{d^n}{dx^n}e^x = e^x$, so $T_n^{\\exp,0}(x) = \\sum_{k=0}^{n} \\frac{x^k}{k!}$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "iterated derivatives of exp",
+      "Taylor polynomial of exp",
+      "exponential partial sum"
+    ],
+    "prerequisites": [
+      "iteratedDeriv_eq_iterate",
+      "deriv of exp"
+    ]
+  },
+  {
+    "id": "ann-mvt02oq01-exp-tendsto",
+    "proofId": "mean-value-theorem-oq-02-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 154,
+      "endLine": 163
+    },
+    "title": "exp_taylor_tendsto: the exponential series from the remainder estimate",
+    "content": "For x > 0, ∑_{k≤n} xᵏ/k! → exp x. The key bound: on (0,x) every iterated derivative of exp equals exp y, and exp y ≤ exp x (Real.exp_le_exp.mpr, y < x), so M = exp x bounds all derivatives. Apply taylorPolynomial_tendsto to exp on (0,x) with this M and Real.contDiff_exp for smoothness, obtaining taylorPolynomial exp 0 n x → exp x; finally rewrite the Taylor polynomial as the partial sum via key.congr with taylorPolynomial_exp. This recovers the convergence of the exponential series from differential data (all derivatives of exp are exp) fed through the Taylor remainder machinery — a complementary, MVT-rooted derivation of a fact Mathlib otherwise obtains from the power-series definition of exp.",
+    "mathContext": "$\\sum_{k\\le n} \\dfrac{x^k}{k!} \\to e^x$ for $x>0$. Uniform bound: $|\\frac{d^n}{dy^n}e^y| = e^y \\le e^x$ for $y \\in (0,x)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "exponential series",
+      "Taylor remainder estimate",
+      "Tendsto.congr",
+      "exp monotonicity"
+    ],
+    "prerequisites": [
+      "taylorPolynomial_tendsto",
+      "monotonicity of exp",
+      "smoothness of exp"
+    ]
+  }
+]

--- a/src/data/proofs/mean-value-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-01/meta.json
@@ -1,0 +1,225 @@
+{
+  "id": "mean-value-theorem-oq-02-oq-01",
+  "title": "Taylor remainder estimates: derivative control to function-value control, and convergence of the Taylor series",
+  "slug": "mean-value-theorem-oq-02-oq-01",
+  "leanFile": {
+    "imports": [
+      "Proofs.MeanValueTheoremOQ02",
+      "Mathlib.Analysis.SpecialFunctions.ExpDeriv",
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Set",
+      "Filter",
+      "Topology",
+      "MeanValueTheoremOQ02"
+    ],
+    "namespace": "MeanValueTheoremOQ02OQ01",
+    "lineCount": 164,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/MeanValueTheoremOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "description": "Answers the OQ-01 follow-up of mean-value-theorem-oq-02: how does the parent's exact Lagrange remainder turn derivative control into function-value control, and drive convergence of the Taylor series? Taking absolute values in the parent's `taylor_lagrange_remainder` yields the sharp remainder estimate |f(b) − Tₙ(b)| ≤ M/(n+1)!·(b−a)ⁿ⁺¹ from a bound |f⁽ⁿ⁺¹⁾| ≤ M (sharper than Mathlib's `taylor_mean_remainder_bound`, which carries the weaker n!). A uniform bound on ALL derivatives then forces Tₙ(b) → f(b) via (b−a)ⁿ⁺¹/(n+1)! → 0. The concrete payoff: for x > 0 the exponential partial sums ∑_{k≤n} xᵏ/k! converge to exp x, derived entirely from the remainder estimate (every derivative of exp on (0,x) is bounded by exp x). All 5 theorems are fully machine-checked, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius researchers (2026)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MeanValueTheoremOQ02OQ01.lean",
+    "tags": [
+      "calculus",
+      "taylor-theorem",
+      "mean-value-theorem",
+      "taylor-remainder",
+      "series-convergence",
+      "exponential-function",
+      "analysis",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 164,
+    "assumptions": "None. All five theorems depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound), confirmed via #print axioms. The exact Lagrange remainder is reused from the ancestor file Proofs/MeanValueTheoremOQ02.lean as a proven theorem (taylor_lagrange_remainder), which is itself 0-axiom (discharged from Mathlib's taylor_mean_remainder_lagrange_iteratedDeriv); no axioms or sorries are introduced or inherited.",
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "taylor_mean_remainder_lagrange_iteratedDeriv",
+        "description": "Lagrange remainder with the global iterated derivative (used by the ancestor file to ground taylor_lagrange_remainder)",
+        "module": "Mathlib.Analysis.Calculus.Taylor"
+      },
+      {
+        "theorem": "Real.summable_pow_div_factorial",
+        "description": "Summable (fun n ↦ xⁿ/n!) for any real x; its tail tending to 0 powers the convergence theorem",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Summable.tendsto_atTop_zero",
+        "description": "The terms of a summable sequence tend to 0",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Order"
+      },
+      {
+        "theorem": "squeeze_zero_norm",
+        "description": "Sandwich theorem: if ‖f n‖ ≤ a n and a → 0 then f → 0",
+        "module": "Mathlib.Analysis.Normed.Group.Continuity"
+      },
+      {
+        "theorem": "tendsto_add_atTop_nat",
+        "description": "Reindexing n ↦ n+1 preserves limits at infinity (used to shift the summable index by one)",
+        "module": "Mathlib.Order.Filter.AtTopBot.Basic"
+      },
+      {
+        "theorem": "Real.iter_deriv_exp",
+        "description": "deriv^[n] exp = exp; iterated derivatives of the exponential are exp itself",
+        "module": "Mathlib.Analysis.SpecialFunctions.ExpDeriv"
+      },
+      {
+        "theorem": "Real.contDiff_exp",
+        "description": "exp is C^∞ (in fact analytic) at every smoothness order",
+        "module": "Mathlib.Analysis.SpecialFunctions.ExpDeriv"
+      },
+      {
+        "theorem": "MeanValueTheoremOQ02.taylor_lagrange_remainder",
+        "description": "Exact Lagrange remainder f(b) − Tₙ(b) = f⁽ⁿ⁺¹⁾(c)/(n+1)!·(b−a)ⁿ⁺¹, reused from the ancestor file",
+        "module": "Proofs.MeanValueTheoremOQ02"
+      }
+    ],
+    "additionalFiles": [
+      "Proofs/MeanValueTheoremOQ02.lean"
+    ],
+    "originalContributions": [
+      "taylor_remainder_bound: the sharp Taylor remainder estimate |f(b) − Tₙ(b)| ≤ M/(n+1)!·(b−a)ⁿ⁺¹ obtained by taking absolute values in the ancestor's exact Lagrange equality. The (n+1)! denominator is sharper than Mathlib's taylor_mean_remainder_bound (which only delivers C·(b−a)ⁿ⁺¹/n!), because the Lagrange form already supplies the optimal factorial.",
+      "taylorPolynomial_tendsto: a clean convergence criterion — if a single constant M bounds the absolute value of EVERY derivative of f on (a,b), then the Taylor polynomials Tₙ(b) converge to f(b). The proof squeezes the remainder estimate against M·(b−a)ⁿ⁺¹/(n+1)!, whose limit is 0 because it is the (n+1)-th term of the convergent series M·∑ (b−a)ᵏ/k!.",
+      "iteratedDeriv_exp / taylorPolynomial_exp: the iterated derivatives of exp are exp, so its Taylor polynomial centered at 0 is exactly the exponential partial sum ∑_{k≤n} xᵏ/k!.",
+      "exp_taylor_tendsto: the headline application — for x > 0, ∑_{k≤n} xᵏ/k! → exp x, derived purely from the remainder estimate by bounding every derivative of exp on (0,x) by exp x. This recovers the exponential series convergence from the MVT/Taylor remainder machinery rather than from the power-series definition."
+    ],
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Taylor's theorem (Brook Taylor, 1715) with the Lagrange form of the remainder (Joseph-Louis Lagrange, 1797) is the higher-order Mean Value Theorem: it expresses f(b) as its degree-n Taylor polynomial plus an error term f⁽ⁿ⁺¹⁾(c)/(n+1)!·(b−a)ⁿ⁺¹ for some intermediate point c. The exact equality is mainly useful as a tool for *estimates*: bounding |f⁽ⁿ⁺¹⁾| on the interval immediately bounds the approximation error, and a uniform bound on all derivatives turns the partial sums into a convergent series. This is the standard route (Rudin, Principles of Mathematical Analysis, Thm 5.15 and §8) by which the elementary transcendental functions are shown equal to their Taylor series. This entry isolates that estimate layer on top of the ancestor file's exact remainder.",
+    "problemStatement": "Question (OQ-01 of mean-value-theorem-oq-02): the ancestor proved Taylor's theorem with the exact Lagrange remainder. How does this exact remainder convert derivative control into function-value control, and how does it drive convergence of the Taylor *series*? Concretely: (1) from |f⁽ⁿ⁺¹⁾| ≤ M derive the explicit error bound; (2) from a uniform bound on all derivatives derive Tₙ(b) → f(b); (3) apply this to exp to recover ∑ xᵏ/k! → exp x.",
+    "proofStrategy": "Three parts. Part I (taylor_remainder_bound): take absolute values in the ancestor's exact equality f(b) − Tₙ(b) = f⁽ⁿ⁺¹⁾(c)/(n+1)!·(b−a)ⁿ⁺¹; since (n+1)! > 0 and (b−a)ⁿ⁺¹ > 0, gcongr reduces the goal to |f⁽ⁿ⁺¹⁾(c)| ≤ M, supplied by the hypothesis at the witness c ∈ (a,b). Part II (taylorPolynomial_tendsto): bound |Tₙ(b) − f(b)| by g(n) = M·(b−a)ⁿ⁺¹/(n+1)!; show g → 0 by recognising it as the index-shifted, M-scaled terms of the convergent series ∑ (b−a)ᵏ/k! (Real.summable_pow_div_factorial → Summable.tendsto_atTop_zero → tendsto_add_atTop_nat 1); then squeeze_zero_norm gives Tₙ(b) − f(b) → 0, and adding the constant f(b) yields Tₙ(b) → f(b). Part III (exp): iteratedDeriv_exp via iteratedDeriv_eq_iterate + Real.iter_deriv_exp; taylorPolynomial_exp by simp + ring; exp_taylor_tendsto applies Part II with M = exp x (every derivative of exp on (0,x) equals exp y ≤ exp x), then rewrites the Taylor polynomial as the exponential partial sum with Tendsto.congr.",
+    "keyInsights": [
+      "**The exact remainder is the wrong final object; the estimate is the useful one.** The Lagrange equality contains an unknown intermediate point c, so it cannot be evaluated. Its value is entirely as a tool for *bounds*: replacing the unknown f⁽ⁿ⁺¹⁾(c) by any uniform bound M produces a computable, sharp error estimate. taylor_remainder_bound performs exactly this one-line abstraction.",
+      "**Sharp factorial for free.** Because the Lagrange form already carries 1/(n+1)!, the estimate inherits the optimal (n+1)! denominator. Mathlib's general taylor_mean_remainder_bound, which is proved through a vector-valued MVT on the Taylor polynomial, only achieves the weaker 1/n!. Routing the bound through the exact scalar Lagrange remainder is both shorter and tighter.",
+      "**Convergence is a single squeeze.** Once the estimate is in hand, convergence of the Taylor series needs no further analysis: a uniform derivative bound M makes the error at most M·(b−a)ⁿ⁺¹/(n+1)!, and (b−a)ᵏ/k! → 0 is a standard consequence of the summability of the exponential series. The whole convergence theorem is a sandwich argument.",
+      "**exp from the MVT side.** Mathlib defines exp by its power series and derives convergence definitionally. Here the convergence ∑ xᵏ/k! → exp x falls out instead from differential data (all derivatives of exp are exp, hence bounded by exp x on (0,x)) fed through the Taylor remainder estimate — a complementary, MVT-rooted derivation of the same fact."
+    ],
+    "prerequisites": [
+      "Taylor's theorem with the Lagrange remainder (ancestor entry mean-value-theorem-oq-02)",
+      "Iterated derivatives (Mathlib iteratedDeriv) and ContDiff smoothness",
+      "Summability of the exponential series and limits of sequences (Filter.Tendsto)",
+      "The sandwich/squeeze theorem for sequences"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "taylor_remainder_bound",
+      "type": "theorem",
+      "description": "If f is C^{n+1} and |iteratedDeriv (n+1) f| ≤ M on (a,b), then |f b − taylorPolynomial f a n b| ≤ M/(n+1)!·(b−a)ⁿ⁺¹. The sharp Taylor remainder estimate, obtained by taking absolute values in the ancestor's exact Lagrange remainder."
+    },
+    {
+      "name": "taylorPolynomial_tendsto",
+      "type": "theorem",
+      "description": "If f is C^∞ and a single constant M bounds |iteratedDeriv n f| on (a,b) for all n, then taylorPolynomial f a n b → f b. Convergence of the Taylor series from a uniform derivative bound, proved by squeezing the remainder estimate against M·(b−a)ⁿ⁺¹/(n+1)! → 0."
+    },
+    {
+      "name": "iteratedDeriv_exp",
+      "type": "theorem",
+      "description": "iteratedDeriv n Real.exp = Real.exp for every n. Every iterated derivative of the exponential is the exponential itself."
+    },
+    {
+      "name": "taylorPolynomial_exp",
+      "type": "theorem",
+      "description": "taylorPolynomial Real.exp 0 n x = ∑_{k≤n} xᵏ/k!. The Taylor polynomial of exp centered at 0 is the exponential partial sum."
+    },
+    {
+      "name": "exp_taylor_tendsto",
+      "type": "theorem",
+      "description": "For x > 0, ∑_{k≤n} xᵏ/k! → exp x. The convergence of the exponential Taylor series, derived from the Taylor remainder estimate by bounding every derivative of exp on (0,x) by exp x."
+    }
+  ],
+  "references": [
+    {
+      "type": "textbook",
+      "citation": "Rudin, W. (1976). \"Principles of Mathematical Analysis,\" 3rd ed. McGraw-Hill. Theorem 5.15 (Taylor's theorem) and §8 (the exponential and logarithmic functions).",
+      "relevance": "Standard source for Taylor's theorem with the Lagrange remainder and for deriving the convergence of elementary functions to their Taylor series from derivative bounds — exactly the estimate-to-convergence route formalized here."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.Analysis.Calculus.Taylor\" — taylor_mean_remainder_lagrange_iteratedDeriv, taylor_mean_remainder_bound. (accessed 2026)",
+      "relevance": "The ancestor file grounds taylor_lagrange_remainder on the former; taylor_remainder_bound here achieves a sharper (n+1)! constant than the latter by routing through the exact scalar Lagrange remainder."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.Analysis.SpecificLimits.Normed\" — Real.summable_pow_div_factorial; \"Mathlib.Analysis.SpecialFunctions.ExpDeriv\" — Real.iter_deriv_exp, Real.contDiff_exp. (accessed 2026)",
+      "relevance": "Summability of the exponential series drives the convergence squeeze; the iterated-derivative and smoothness facts for exp drive the concrete application."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "File Header and Imports",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Module docstring stating the OQ-01 question (how the exact Lagrange remainder yields estimates and series convergence) and the four contributions, with an honesty note that the Lagrange remainder is reused from the ancestor file and Mathlib already knows the exp series converges — the point being the MVT-rooted derivation. Imports the ancestor file plus Mathlib's exp-derivative and specific-limits modules; opens Real/Set/Filter/Topology and the ancestor namespace.",
+      "mathContext": "Taylor's theorem with Lagrange remainder $f(b) - T_n(b) = \\frac{f^{(n+1)}(c)}{(n+1)!}(b-a)^{n+1}$ as the foundation for the estimate layer built here."
+    },
+    {
+      "id": "part1-bound",
+      "title": "Part I: The Taylor Remainder Estimate",
+      "startLine": 59,
+      "endLine": 87,
+      "summary": "taylor_remainder_bound: absolute values in the ancestor's exact Lagrange remainder give |f b − Tₙ(b)| ≤ M/(n+1)!·(b−a)ⁿ⁺¹. Proof obtains the Lagrange witness c, rewrites with the equality, normalizes |·| of the positive factorial and positive power, and closes by gcongr against the derivative bound at c.",
+      "mathContext": "$|f(b) - T_n(b)| \\le \\dfrac{M}{(n+1)!}\\,(b-a)^{n+1}$ whenever $|f^{(n+1)}| \\le M$ on $(a,b)$."
+    },
+    {
+      "id": "part2-convergence",
+      "title": "Part II: Convergence of the Taylor Series",
+      "startLine": 88,
+      "endLine": 127,
+      "summary": "taylorPolynomial_tendsto: a uniform bound M on all derivatives forces Tₙ(b) → f(b). The error is bounded by g(n) = M·(b−a)ⁿ⁺¹/(n+1)!; g → 0 because it is the index-shifted, M-scaled tail of the convergent series ∑ (b−a)ᵏ/k!; squeeze_zero_norm then drives the signed error to 0 and adding the constant f(b) finishes.",
+      "mathContext": "If $|f^{(n)}| \\le M$ on $(a,b)$ for all $n$, then $T_n(b) \\to f(b)$, since $\\frac{(b-a)^{n+1}}{(n+1)!} \\to 0$."
+    },
+    {
+      "id": "part3-exp",
+      "title": "Part III: The Exponential Function",
+      "startLine": 128,
+      "endLine": 164,
+      "summary": "iteratedDeriv_exp (= exp via iteratedDeriv_eq_iterate + Real.iter_deriv_exp), taylorPolynomial_exp (= ∑ xᵏ/k! via simp + ring), and exp_taylor_tendsto: for x > 0 the partial sums converge to exp x, applying Part II with M = exp x and rewriting the Taylor polynomial as the exponential partial sum via Tendsto.congr.",
+      "mathContext": "$\\sum_{k\\le n} \\dfrac{x^k}{k!} \\to e^x$ for $x>0$, since every derivative of $\\exp$ on $(0,x)$ is at most $e^x$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Building only on the ancestor's exact Lagrange remainder, this entry formalizes the estimate layer of Taylor's theorem: derivative bounds become function-value bounds (taylor_remainder_bound, with a sharp (n+1)! denominator), uniform derivative bounds become Taylor-series convergence (taylorPolynomial_tendsto), and the exponential series ∑ xᵏ/k! → exp x is recovered from this machinery (exp_taylor_tendsto). All five results are fully machine-checked with no axioms and no sorries.",
+    "implications": "The remainder estimate is the practical content of Taylor's theorem: it is what underlies numerical error bounds and the identification of analytic functions with their Taylor series. By isolating it from the exact remainder and giving a clean uniform-bound convergence criterion, this entry provides a reusable bridge for downstream entries that need to certify Taylor approximations of specific functions (exp is demonstrated; sin/cos satisfy the same uniform-bound hypothesis with M = 1).",
+    "openQuestions": [
+      "Extend exp_taylor_tendsto to all real x (including x ≤ 0) by using the symmetric interval and |x| as the radius, or by an even/odd derivative-sign argument.",
+      "Formalize the analogous convergence for sin and cos, where the uniform bound M = 1 holds globally, giving convergence of the Taylor series on all of ℝ directly from taylorPolynomial_tendsto.",
+      "State a quantitative (non-asymptotic) version: an explicit n making the exp partial-sum error below a prescribed ε on a given interval, read off from taylor_remainder_bound."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "mean-value-theorem-oq-02",
+      "relationship": "parent-problem",
+      "description": "The parent entry: Taylor's theorem with the exact Lagrange remainder. Its theorem taylor_lagrange_remainder is the sole mathematical input to this file's estimate layer."
+    },
+    {
+      "targetId": "mean-value-theorem",
+      "relationship": "ancestor",
+      "description": "The base Mean Value Theorem (Wiedijk #75). Taylor's theorem is its higher-order generalization, and the n=0 case of the remainder estimate is the Lipschitz form |f(b) − f(a)| ≤ M·(b−a)."
+    },
+    {
+      "targetId": "mean-value-theorem-oq-02-oq-04-oq-01",
+      "relationship": "complementary",
+      "description": "A sibling that refutes a FALSE uniform Taylor bound under real-only analyticity hypotheses (Runge phenomenon). This entry's bounds are genuine because they assume an explicit derivative bound M rather than trying to extract one from a sup bound on f."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **OQ-01 follow-up** of `mean-value-theorem-oq-02`: how does the parent's *exact* Lagrange remainder turn **derivative control into function-value control**, and drive convergence of the Taylor *series*?

New file `proofs/Proofs/MeanValueTheoremOQ02OQ01.lean` (164 lines, **5 theorems, 0 axioms, 0 sorries** — `#print axioms` shows only `propext / Classical.choice / Quot.sound`), built entirely on the ancestor's proven `taylor_lagrange_remainder`.

> Note: the parent `MeanValueTheoremOQ02.lean` already removed its Taylor axiom, so the original "remove the remaining axiom" target was already met. This PR delivers the genuine mathematical follow-up — the *estimate* layer.

## What's proved

| Theorem | Statement |
|---|---|
| `taylor_remainder_bound` | `\|f b − Tₙ(b)\| ≤ M/(n+1)!·(b−a)^{n+1}` from `\|f^{(n+1)}\| ≤ M` |
| `taylorPolynomial_tendsto` | uniform bound on **all** derivatives ⟹ `Tₙ(b) → f b` |
| `iteratedDeriv_exp` | `iteratedDeriv n exp = exp` |
| `taylorPolynomial_exp` | `taylorPolynomial exp 0 n x = ∑_{k≤n} xᵏ/k!` |
| `exp_taylor_tendsto` | for `x > 0`, `∑_{k≤n} xᵏ/k! → exp x` |

## Why it matters

- **Sharp constant for free.** Taking absolute values in the *exact* scalar Lagrange remainder yields the optimal `(n+1)!` denominator — strictly sharper than Mathlib's general `taylor_mean_remainder_bound` (which only gives `n!`).
- **Convergence is one squeeze.** A uniform derivative bound `M` makes the error `≤ M·(b−a)^{n+1}/(n+1)!`, which `→ 0` because it is the index-shifted, `M`-scaled tail of the convergent exponential series `∑ (b−a)ᵏ/k!`.
- **exp from the MVT side.** Recovers `∑ xᵏ/k! → exp x` from differential data (all derivatives of `exp` are `exp`) through the Taylor remainder machinery — complementary to Mathlib's power-series definition.

## Verification

`./proofs/scripts/docker-build.sh Proofs.MeanValueTheoremOQ02OQ01` → build succeeds. `#print axioms` on all five theorems lists only the foundational axioms. Gallery data added under `src/data/proofs/mean-value-theorem-oq-02-oq-01/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)