### PR TITLE
research(erdos-866-wip-01): uniform parity lower bound g_k(N) ≥ 1 for all k ≥ 3 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2281,6 +2281,7 @@ import Proofs.Erdos864Problem
 import Proofs.Erdos865Problem
 import Proofs.Erdos866Aristotle
 import Proofs.Erdos866Problem
+import Proofs.Erdos866Wip01
 import Proofs.Erdos867Problem
 import Proofs.Erdos868Problem
 import Proofs.Erdos869Problem

--- a/proofs/Proofs/Erdos866Wip01.lean
+++ b/proofs/Proofs/Erdos866Wip01.lean
@@ -1,0 +1,113 @@
+import Proofs.Erdos866Problem
+
+/-
+# Erdős Problem #866 — the uniform parity lower bound `g_k(N) ≥ 1`
+
+## The problem
+
+For `k ≥ 3`, Erdős #866 asks for the minimal threshold `g_k(N)` such that **every**
+`A ⊆ {1,…,2N}` with `|A| ≥ N + g_k(N)` contains all pairwise sums `b_i + b_j` of some
+`k`-element family `b_1,…,b_k`.  The exact growth of `g_k` is open for every `k ≥ 4`
+(known: `g_3 = 2`, `g_4 ≤ 2032`, `g_5 ≍ log N`, `g_6 ≍ √N`).
+
+## What this file proves
+
+The base file `Erdos866Problem.lean` proves `oddNumbers_no_triple`: the `N` odd numbers in
+`{1,…,2N}` contain the three pairwise sums of **no** `3`-element family (among any three
+integers two share parity, so one pairwise sum is even, hence not odd).  This file turns
+that observation into the clean, uniform lower bound it actually establishes:
+
+* `oddNumbers_no_config` — the odd numbers admit **no** `k`-configuration for **any**
+  `k ≥ 3` (a `k`-family contains a `3`-subfamily, and the parity obstruction already kills
+  that).
+* `exists_large_set_without_config` — there is a set `A ⊆ {1,…,2N}` of size `≥ N` with no
+  `k`-configuration; so `|A| = N` never forces one.
+* `Guarantees` / `not_guarantees_zero` / `g_k_ge_one` — packaging this as the threshold
+  statement: a threshold of `0` does **not** guarantee a configuration, i.e. every valid
+  threshold satisfies `g_k(N) ≥ 1` for all `k ≥ 3`.
+
+## Honesty / scope
+
+This is the *trivial* lower bound `g_k ≥ 1` — the one the parity construction gives
+uniformly in `k`.  It is not the deep content of #866 (the `log N` / `√N` growth for
+`k = 5, 6` needs Sidon/multiplicative constructions, and the upper bounds need extremal
+arguments — all open or hard).  The contribution here is a fully machine-checked,
+axiom-free, `k`-uniform statement of the elementary lower bound, generalizing the base
+file's single `k = 3` instance.
+
+Theorems: 5, Axioms: 0, Sorries: 0
+-/
+
+open Finset
+
+namespace Erdos866Wip01
+
+open Erdos866
+
+/-- The odd numbers in `{1,…,2N}` form a subset of the interval. -/
+theorem oddNumbers_subset (N : ℕ) : oddNumbers N ⊆ Erdos866.Interval N :=
+  Finset.filter_subset _ _
+
+/-!
+## The uniform parity obstruction
+
+Among any three integers two share parity, so one of their pairwise sums is even and thus
+not odd.  Since any `k`-family with `k ≥ 3` contains a 3-subfamily (indices `0, 1, 2`), the
+odd numbers contain a full pairwise-sum configuration of no `k`-family.
+-/
+
+/-- **Uniform parity lower bound.** For every `k ≥ 3`, the odd numbers in `{1,…,2N}`
+contain all pairwise sums of no `k`-element family.
+
+This generalizes `Erdos866.oddNumbers_no_triple` (the `k = 3` case) to all `k ≥ 3`: a
+`k`-family with `k ≥ 3` has at least three members, and among the first three two share
+parity, forcing one pairwise sum to be even and hence absent from the odd numbers. -/
+theorem oddNumbers_no_config (N : ℕ) {k : ℕ} (hk : 3 ≤ k) :
+    ¬ ∃ b : Fin k → ℤ, HasAllPairwiseSums (oddNumbers N) b := by
+  rintro ⟨b, hb⟩
+  -- Every pairwise sum that lands in the odd numbers is odd as a natural number.
+  have hodd : ∀ i j : Fin k, i < j → (b i + b j).toNat % 2 = 1 := by
+    intro i j hij
+    have hmem := hb i j hij
+    simp only [oddNumbers, Erdos866.Interval, Finset.mem_filter] at hmem
+    exact hmem.2
+  -- The three indices `0, 1, 2`, valid because `k ≥ 3`.
+  have h01 := hodd ⟨0, by omega⟩ ⟨1, by omega⟩ (Fin.mk_lt_mk.mpr (by omega))
+  have h02 := hodd ⟨0, by omega⟩ ⟨2, by omega⟩ (Fin.mk_lt_mk.mpr (by omega))
+  have h12 := hodd ⟨1, by omega⟩ ⟨2, by omega⟩ (Fin.mk_lt_mk.mpr (by omega))
+  -- Among `b 0, b 1, b 2` two share parity ⇒ an even sum ⇒ a `% 2 = 0` contradiction.
+  omega
+
+/-!
+## Threshold reformulation: `g_k(N) ≥ 1`
+-/
+
+/-- There is a set `A ⊆ {1,…,2N}` of size at least `N` containing all pairwise sums of no
+`k`-element family (for `k ≥ 3`).  The witness is the `N` odd numbers. -/
+theorem exists_large_set_without_config (N : ℕ) {k : ℕ} (hk : 3 ≤ k) :
+    ∃ A : Finset ℕ, A ⊆ Erdos866.Interval N ∧ N ≤ A.card ∧
+      ¬ ∃ b : Fin k → ℤ, HasAllPairwiseSums A b :=
+  ⟨oddNumbers N, oddNumbers_subset N, (oddNumbers_card N).ge, oddNumbers_no_config N hk⟩
+
+/-- `Guarantees N k g` means: every `A ⊆ {1,…,2N}` with `|A| ≥ N + g` contains all
+pairwise sums of some `k`-element family.  The Erdős threshold `g_k(N)` is the least `g`
+with `Guarantees N k g`. -/
+def Guarantees (N k g : ℕ) : Prop :=
+  ∀ A : Finset ℕ, A ⊆ Erdos866.Interval N → N + g ≤ A.card →
+    ∃ b : Fin k → ℤ, HasAllPairwiseSums A b
+
+/-- A threshold of `0` does **not** guarantee a configuration, for any `k ≥ 3`: the `N`
+odd numbers are a set of size `N = N + 0` with no `k`-configuration. -/
+theorem not_guarantees_zero (N : ℕ) {k : ℕ} (hk : 3 ≤ k) : ¬ Guarantees N k 0 := by
+  intro hG
+  exact oddNumbers_no_config N hk
+    (hG (oddNumbers N) (oddNumbers_subset N) (by simp [oddNumbers_card]))
+
+/-- **`g_k(N) ≥ 1` for all `k ≥ 3`.** Any threshold that actually guarantees a
+`k`-configuration must be at least `1`; equivalently, the minimal threshold is positive. -/
+theorem g_k_ge_one (N : ℕ) {k g : ℕ} (hk : 3 ≤ k) (hG : Guarantees N k g) : 1 ≤ g := by
+  rcases Nat.eq_zero_or_pos g with h | h
+  · exact absurd (h ▸ hG) (not_guarantees_zero N hk)
+  · exact h
+
+end Erdos866Wip01

--- a/src/data/proofs/erdos-866-wip-01/annotations.json
+++ b/src/data/proofs/erdos-866-wip-01/annotations.json
@@ -1,0 +1,71 @@
+[
+  {
+    "id": "ann-erdos866wip01-header",
+    "proofId": "erdos-866-wip-01",
+    "type": "concept",
+    "range": {
+      "startLine": 3,
+      "endLine": 39
+    },
+    "title": "Erdős #866 and the trivial uniform lower bound",
+    "content": "Erdős #866 asks for the minimal threshold g_k(N) such that every A ⊆ {1,…,2N} with |A| ≥ N + g_k(N) contains all pairwise sums b_i + b_j of some k-element family. The known landscape is non-uniform: g_3 = 2, g_4 ≤ 2032, g_5 ≍ log N, g_6 ≍ √N, with gaps and most cases open. The simplest universal obstruction is parity: the N odd numbers in {1,…,2N} form a half-density set whose pairwise sums are systematically excluded (sum of equal-parity numbers is even). The docstring states up front that this file proves only the trivial lower bound g_k ≥ 1, generalizing the base file's single k=3 lemma to all k ≥ 3, and makes no claim on the deep, open content of #866.",
+    "mathContext": "$g_k(N)$: least $g$ with $|A| \\ge N+g \\Rightarrow A$ contains all pairwise sums of some $k$-family. Parity gives $g_k(N) \\ge 1$ uniformly.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős problems",
+      "pairwise sums",
+      "parity obstruction",
+      "threshold functions"
+    ],
+    "prerequisites": [
+      "additive combinatorics",
+      "Erdős #866 base entry"
+    ]
+  },
+  {
+    "id": "ann-erdos866wip01-no-config",
+    "proofId": "erdos-866-wip-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 59,
+      "endLine": 79
+    },
+    "title": "oddNumbers_no_config: the uniform parity obstruction",
+    "content": "For every k ≥ 3, ¬∃ b : Fin k → ℤ, HasAllPairwiseSums (oddNumbers N) b. This generalizes the base file's oddNumbers_no_triple (k=3) to all k ≥ 3. Proof: assume a family b. First, every pairwise sum landing in the odd numbers is an odd natural ((b i + b j).toNat % 2 = 1), read off from oddNumbers membership. Then restrict to the indices 0,1,2 : Fin k, which exist because k ≥ 3 (built as ⟨0,_⟩,⟨1,_⟩,⟨2,_⟩ with ordering via Fin.mk_lt_mk). The three sums b0+b1, b0+b2, b1+b2 must all be odd; but among b 0, b 1, b 2 two share parity, so one sum is even — and omega, which understands Int.toNat and mod 2, derives the contradiction in a single call. The key reduction is that a k-configuration constrains the pairwise sums of its first three members, so every k ≥ 3 collapses to the triangle case.",
+    "mathContext": "Among $b_0, b_1, b_2$ two share parity $\\Rightarrow$ one of $b_0{+}b_1, b_0{+}b_2, b_1{+}b_2$ is even $\\Rightarrow$ not odd $\\Rightarrow$ contradiction.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "parity pigeonhole",
+      "Fin index ordering",
+      "Int.toNat",
+      "omega tactic"
+    ],
+    "prerequisites": [
+      "pigeonhole on parities",
+      "Fin.mk_lt_mk",
+      "Finset membership unfolding"
+    ]
+  },
+  {
+    "id": "ann-erdos866wip01-threshold",
+    "proofId": "erdos-866-wip-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 85,
+      "endLine": 113
+    },
+    "title": "Threshold reformulation: g_k(N) ≥ 1",
+    "content": "exists_large_set_without_config bundles the odd numbers as a witness set of size ≥ N (via oddNumbers_card) inside the interval with no k-configuration, so |A| = N never forces one. Guarantees N k g is a Prop capturing the threshold semantics — every A ⊆ {1,…,2N} with |A| ≥ N+g forces a configuration — which lets the bound be stated without an infimum encoding. not_guarantees_zero refutes g = 0 (the odd witness has size N = N+0 and no configuration), and g_k_ge_one concludes that any g with Guarantees N k g satisfies 1 ≤ g: the threshold g_k(N) is positive for all k ≥ 3. This is the formal statement of the elementary lower bound g_k(N) ≥ 1.",
+    "mathContext": "$\\neg\\,\\mathrm{Guarantees}(N,k,0)$ and $\\mathrm{Guarantees}(N,k,g) \\Rightarrow g \\ge 1$, i.e. $g_k(N) \\ge 1$ for $k \\ge 3$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "threshold function",
+      "lower bound packaging",
+      "extremal set construction"
+    ],
+    "prerequisites": [
+      "oddNumbers_no_config",
+      "cardinality of the odd numbers"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-866-wip-01/meta.json
+++ b/src/data/proofs/erdos-866-wip-01/meta.json
@@ -1,0 +1,184 @@
+{
+  "id": "erdos-866-wip-01",
+  "title": "Erdős #866: the uniform parity lower bound g_k(N) ≥ 1 for all k ≥ 3",
+  "slug": "erdos-866-wip-01",
+  "leanFile": {
+    "imports": [
+      "Proofs.Erdos866Problem"
+    ],
+    "opens": [
+      "Finset",
+      "Erdos866"
+    ],
+    "namespace": "Erdos866Wip01",
+    "lineCount": 113,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos866Wip01.lean",
+    "sorries": 0
+  },
+  "description": "Erdős Problem #866 asks for the minimal threshold g_k(N) such that every A ⊆ {1,…,2N} with |A| ≥ N + g_k(N) contains all pairwise sums of some k-element family (k ≥ 3); the growth of g_k is open for every k ≥ 4. The base file Erdos866Problem.lean proves only the k=3 instance oddNumbers_no_triple. This file generalizes the parity construction to a fully uniform statement: the N odd numbers in {1,…,2N} contain a complete pairwise-sum configuration of NO k-family for ANY k ≥ 3 (oddNumbers_no_config), hence a set of size N never forces a configuration (exists_large_set_without_config), hence the threshold g_k(N) is positive (g_k_ge_one). This is the trivial lower bound g_k ≥ 1 — honestly NOT the deep content of #866 — but it is formalized uniformly in k, axiom-free and sorry-free.",
+  "meta": {
+    "author": "Lean Genius researchers (2026)",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos866Wip01.lean",
+    "tags": [
+      "erdos-problems",
+      "additive-combinatorics",
+      "pairwise-sums",
+      "parity-argument",
+      "lower-bound",
+      "pigeonhole",
+      "combinatorics",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 113,
+    "assumptions": "The main conjecture of Erdős #866 (the exact growth of g_k(N) for k ≥ 4) remains OPEN; this entry proves only the elementary lower bound g_k(N) ≥ 1 and makes no claim about the open problem. The five Lean declarations themselves are fully machine-checked and depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound), confirmed via #print axioms — no axiom declarations, no structure-encoded assumptions, no sorries. Per gallery policy, an entry attached to an open Erdős problem is marked 'axiomatized' to reflect that the headline conjecture is unresolved, even though the formalized lower-bound lemmas carry no assumptions.",
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.filter_subset",
+        "description": "A filtered finset is a subset of the original (oddNumbers ⊆ Interval)",
+        "module": "Mathlib.Data.Finset.Filter"
+      },
+      {
+        "theorem": "Fin.mk_lt_mk",
+        "description": "Comparison of Fin elements by their underlying values (to order indices 0 < 1 < 2)",
+        "module": "Mathlib.Data.Fin.Basic"
+      },
+      {
+        "theorem": "Erdos866.oddNumbers_card",
+        "description": "The odd numbers in {1,…,2N} number exactly N (reused from the base file)",
+        "module": "Proofs.Erdos866Problem"
+      },
+      {
+        "theorem": "Erdos866.HasAllPairwiseSums",
+        "description": "Predicate: A contains every pairwise sum b_i + b_j of a family b (reused from the base file)",
+        "module": "Proofs.Erdos866Problem"
+      }
+    ],
+    "additionalFiles": [
+      "Proofs/Erdos866Problem.lean"
+    ],
+    "originalContributions": [
+      "oddNumbers_no_config: generalizes the base file's k=3 lemma oddNumbers_no_triple to ALL k ≥ 3 — the N odd numbers contain a full pairwise-sum configuration of no k-element family. The proof restricts any k-family (k ≥ 3) to its first three indices 0,1,2 and invokes the parity pigeonhole (among three integers two share parity, so one pairwise sum is even and not odd), discharged uniformly by omega over Int.toNat and mod 2.",
+      "exists_large_set_without_config: there is a set A ⊆ {1,…,2N} of size ≥ N (the odd numbers) with no k-configuration, witnessing that |A| = N is insufficient.",
+      "Guarantees N k g: a clean Prop capturing the threshold semantics of g_k(N) — every A of size ≥ N+g forces a configuration — making the lower bound expressible without choosing a specific minimal-threshold encoding.",
+      "not_guarantees_zero and g_k_ge_one: the threshold reformulation g_k(N) ≥ 1 for all k ≥ 3 — a guarantee threshold of 0 is refuted by the odd-numbers witness, so any valid threshold is at least 1."
+    ],
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #866 concerns how dense a subset of {1,…,2N} can be while avoiding the pairwise sums of a k-element set. The threshold function g_k(N) measures the excess over the trivial size N that forces such a configuration. The known landscape is strikingly non-uniform across k: g_3 = 2 (a finite constant), g_4 ≤ 2032, g_5 ≍ log N, and g_6 ≍ √N, with general bounds leaving gaps. The simplest universal obstruction is parity: the odd numbers are a half-density set in which the pairwise sums are systematically excluded, because the sum of two numbers of equal parity is even. This gives the trivial but uniform lower bound g_k(N) ≥ 1 for every k ≥ 3.",
+    "problemStatement": "For k ≥ 3, let g_k(N) be the least threshold such that every A ⊆ {1,…,2N} with |A| ≥ N + g_k(N) contains all pairwise sums b_i + b_j (i < j) of some family b_1,…,b_k. The exact growth of g_k is open for all k ≥ 4. This entry establishes the elementary lower bound g_k(N) ≥ 1, uniformly in k ≥ 3, via the odd-numbers construction.",
+    "proofStrategy": "The N odd numbers in {1,…,2N} are exhibited as a set of size N (Erdos866.oddNumbers_card) inside the interval (oddNumbers_subset). The core lemma oddNumbers_no_config shows they admit no k-configuration for k ≥ 3: from a hypothetical family b : Fin k → ℤ, the three pairwise sums of the indices 0,1,2 (valid since k ≥ 3) would all have to be odd naturals; but among b 0, b 1, b 2 two share parity, so one of those sums is even, and omega — handling Int.toNat and mod 2 — closes the contradiction. Packaging follows: exists_large_set_without_config bundles the witness, and via the Prop Guarantees, not_guarantees_zero / g_k_ge_one phrase the conclusion as the threshold bound g_k(N) ≥ 1.",
+    "keyInsights": [
+      "**Parity is a k-uniform obstruction.** The base file proves the k=3 case as a one-off; but the very same parity pigeonhole applies to any k ≥ 3 with no extra work, because the definition of a k-configuration already constrains the pairwise sums of the first three members. Restricting to indices 0,1,2 reduces every k ≥ 3 to the triangle case.",
+      "**The threshold bound needs no minimal-threshold encoding.** Rather than defining g_k(N) as an infimum (which complicates formal statements), the entry introduces the predicate Guarantees N k g and proves that g = 0 fails. This expresses 'g_k(N) ≥ 1' faithfully — any g that genuinely guarantees a configuration must exceed 0 — while keeping the statements first-order and omega-friendly.",
+      "**omega absorbs the parity case analysis.** The three-way pigeonhole (which two of b 0, b 1, b 2 share parity) and the conversion of an even integer's toNat back to an even natural are all linear/mod-2 facts that omega discharges in one call, so the contradiction proof is a single tactic line after the three membership facts are in hand.",
+      "**Honesty about depth.** This is the trivial lower bound. The mathematically hard parts of #866 — the log N and √N growth for k = 5, 6, and matching upper bounds — require Sidon-set / multiplicative constructions and extremal arguments that are open or far beyond a short formalization. The entry states this plainly and claims only the elementary bound."
+    ],
+    "prerequisites": [
+      "Erdős Problem #866 and the threshold function g_k(N) (base entry erdos-866)",
+      "Parity / pigeonhole arguments over the integers",
+      "Finset membership and cardinality in Lean (Mathlib)",
+      "Int.toNat and modular arithmetic as handled by the omega tactic"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "oddNumbers_no_config",
+      "type": "theorem",
+      "description": "For every k ≥ 3, ¬∃ b : Fin k → ℤ, HasAllPairwiseSums (oddNumbers N) b. The odd numbers in {1,…,2N} contain the pairwise sums of no k-element family — the uniform generalization of the base file's oddNumbers_no_triple."
+    },
+    {
+      "name": "exists_large_set_without_config",
+      "type": "theorem",
+      "description": "For k ≥ 3 there is A ⊆ Interval N with N ≤ |A| and no k-configuration (the odd numbers). A set of size N never forces a pairwise-sum configuration."
+    },
+    {
+      "name": "Guarantees",
+      "type": "definition",
+      "description": "Guarantees N k g : Prop — every A ⊆ {1,…,2N} with |A| ≥ N+g contains all pairwise sums of some k-family. The Erdős threshold g_k(N) is the least g with this property."
+    },
+    {
+      "name": "not_guarantees_zero",
+      "type": "theorem",
+      "description": "¬ Guarantees N k 0 for k ≥ 3: a threshold of 0 does not force a configuration, refuted by the odd-numbers witness of size N."
+    },
+    {
+      "name": "g_k_ge_one",
+      "type": "theorem",
+      "description": "If Guarantees N k g holds (k ≥ 3) then 1 ≤ g. The threshold g_k(N) is positive for all k ≥ 3 — the elementary lower bound g_k(N) ≥ 1."
+    }
+  ],
+  "references": [
+    {
+      "type": "problem-database",
+      "citation": "Erdős Problem #866, the Erdős Problems database (https://www.erdosproblems.com/866).",
+      "relevance": "The source problem on the threshold for forcing all pairwise sums of a k-element family inside a dense subset of {1,…,2N}."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.Data.Finset.*\" and the omega decision procedure. (accessed 2026)",
+      "relevance": "Finset cardinality/membership API and omega (handling Int.toNat and mod 2) used to formalize the parity obstruction."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "File Header and the Problem",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring stating Erdős #866, the threshold g_k(N), the known non-uniform landscape (g_3=2, g_4≤2032, g_5≍log N, g_6≍√N), and an explicit honesty note that this file proves only the trivial uniform lower bound g_k ≥ 1 via the odd-numbers construction, generalizing the base file's k=3 lemma. Imports the base file and opens Finset and the Erdos866 namespace.",
+      "mathContext": "$g_k(N)$ = least threshold forcing all pairwise sums of some $k$-family inside any $A \\subseteq \\{1,\\dots,2N\\}$ of size $\\ge N + g_k(N)$; open for $k \\ge 4$."
+    },
+    {
+      "id": "subset",
+      "title": "Odd numbers as a subset of the interval",
+      "startLine": 47,
+      "endLine": 49,
+      "summary": "oddNumbers_subset: the odd numbers are a subset of Interval N, immediate from Finset.filter_subset.",
+      "mathContext": "$\\mathrm{odd}(N) \\subseteq \\{1,\\dots,2N\\}$."
+    },
+    {
+      "id": "no-config",
+      "title": "The uniform parity obstruction",
+      "startLine": 51,
+      "endLine": 79,
+      "summary": "oddNumbers_no_config: for k ≥ 3 the odd numbers admit no k-configuration. From a hypothetical family, the pairwise sums of indices 0,1,2 must be odd naturals; among b 0, b 1, b 2 two share parity, so one sum is even, and omega closes the contradiction (handling Int.toNat and mod 2).",
+      "mathContext": "Among any three integers two share parity, so one pairwise sum is even, hence not in the odd numbers."
+    },
+    {
+      "id": "threshold",
+      "title": "Threshold reformulation g_k(N) ≥ 1",
+      "startLine": 81,
+      "endLine": 113,
+      "summary": "exists_large_set_without_config bundles the size-N odd witness; Guarantees N k g formalizes the threshold semantics; not_guarantees_zero refutes a threshold of 0; g_k_ge_one concludes that every valid threshold is at least 1.",
+      "mathContext": "$g = 0$ does not guarantee a configuration, so $g_k(N) \\ge 1$ for all $k \\ge 3$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Generalizing the base file's single k=3 parity lemma, this entry proves uniformly in k ≥ 3 that the N odd numbers in {1,…,2N} contain the pairwise sums of no k-element family, hence a set of size N never forces a configuration, hence the Erdős #866 threshold satisfies g_k(N) ≥ 1. All five declarations are axiom-free and sorry-free; the headline #866 conjecture (exact growth of g_k) remains open and untouched.",
+    "implications": "The entry upgrades a one-off k=3 observation into the clean, reusable, k-uniform elementary lower bound, and supplies a first-order threshold predicate (Guarantees) that downstream work could use to state sharper bounds. It deliberately does not attempt the deep, open content of #866.",
+    "openQuestions": [
+      "Prove g_3(N) = 2 (the known exact value) by establishing a size-(N+1) construction with no triple and the matching upper bound.",
+      "Formalize a super-constant lower bound for k = 5 (g_5 ≍ log N) or k = 6 (g_6 ≍ √N) via the appropriate Sidon/multiplicative constructions.",
+      "Determine whether g_4(N) is bounded and, if so, its exact value (open in the literature)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-866",
+      "relationship": "parent-problem",
+      "description": "The base Erdős #866 entry. Its lemma oddNumbers_no_triple is the k=3 case generalized here, and its oddNumbers_card supplies the size-N witness."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

**Erdős Problem #866** asks for the minimal threshold `g_k(N)` such that every `A ⊆ {1,…,2N}` with `|A| ≥ N + g_k(N)` contains all pairwise sums `b_i + b_j` of some `k`-element family. The growth of `g_k` is **open** for every `k ≥ 4` (known: `g_3 = 2`, `g_4 ≤ 2032`, `g_5 ≍ log N`, `g_6 ≍ √N`).

The base file `Erdos866Problem.lean` proves only the `k = 3` instance `oddNumbers_no_triple`. This PR adds `proofs/Proofs/Erdos866Wip01.lean` (113 lines, **4 theorems + 1 def, 0 axioms, 0 sorries**; `#print axioms` shows only `propext / Classical.choice / Quot.sound`) generalizing the parity construction to a **`k`-uniform lower bound**.

## What's proved

| Declaration | Statement |
|---|---|
| `oddNumbers_no_config` | for all `k ≥ 3`, the `N` odd numbers contain the pairwise sums of **no** `k`-family |
| `exists_large_set_without_config` | there is a set of size `≥ N` with no `k`-configuration |
| `Guarantees N k g` | threshold predicate: `|A| ≥ N+g ⟹` a config exists |
| `not_guarantees_zero` | `g = 0` does not guarantee a config |
| `g_k_ge_one` | every valid threshold satisfies `g_k(N) ≥ 1` |

## Proof idea

A `k`-configuration (`k ≥ 3`) constrains the pairwise sums of its first three members, so every `k ≥ 3` reduces to the triangle case: among `b 0, b 1, b 2` two share parity, so one pairwise sum is even and hence not odd. The contradiction (over `Int.toNat` and `mod 2`) is discharged by a single `omega`.

## Honest scope

This is the **trivial** lower bound `g_k ≥ 1` — the elementary parity bound, formalized uniformly in `k`. It is **not** the deep content of #866 (the `log N` / `√N` growth for `k = 5, 6`, and matching upper bounds, remain open or hard). The entry is marked `axiomatized` per gallery policy for an open Erdős problem, though the lemmas themselves carry no assumptions.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos866Wip01` → succeeds. `#print axioms` on all five declarations lists only the foundational axioms. Gallery data added under `src/data/proofs/erdos-866-wip-01/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)