### PR TITLE
research(binary-gcd-oq-03-oq-02-incomplete-01): unimodular group structure behind Schönhage HGCD [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -291,6 +291,7 @@ import Proofs.BinaryGcdOQ02OQ02
 import Proofs.BinaryGcdOQ03
 import Proofs.BinaryGcdOQ03OQ01
 import Proofs.BinaryGcdOQ03OQ02
+import Proofs.BinaryGcdOQ03OQ02Incomplete01
 import Proofs.BinaryGcdOQ03OQ02PathA
 import Proofs.BinomialTheorem
 import Proofs.BinomialTheoremOQ01

--- a/proofs/Proofs/BinaryGcdOQ03OQ02Incomplete01.lean
+++ b/proofs/Proofs/BinaryGcdOQ03OQ02Incomplete01.lean
@@ -1,0 +1,284 @@
+/-
+  Schönhage's Recursive HGCD — the Unimodular Group Structure behind GCD Preservation
+  ===================================================================================
+
+  Problem: binary-gcd-oq-03-oq-02-incomplete-01
+  "Schönhage's Recursive HGCD: GCD Preservation and Matrix Invariants"
+
+  The parent entry `binary-gcd-oq-03-oq-02` (BinaryGcdOQ03OQ02.lean) formalizes
+  Schönhage's recursive half-GCD and proves that the accumulated cofactor matrix
+  has determinant ±1 and preserves the GCD when applied to a pair (a, b). Its
+  GCD-preservation theorem is *one-directional* (for ℕ pairs), and several of its
+  credited results lean on `native_decide` (so it carries `Lean.ofReduceBool`).
+
+  This companion supplies the missing STRUCTURAL story, fully axiom-free and with
+  NO `native_decide`:
+
+    * The 2×2 integer cofactor matrices with det = ±1 form a GROUP. We give the
+      explicit inverse (adjugate scaled by the determinant) and prove
+      `M * M⁻¹ = M⁻¹ * M = I` for unimodular M, plus closure of det = ±1 under
+      product and inverse.
+    * The induced action `(a,b) ↦ M·(a,b)` on ℤ² is a BIJECTION when det = ±1;
+      its inverse is the action of `M⁻¹`. GCD preservation is the *shadow* of this
+      bijection.
+    * Consequently the generated ideal `(a, b) = (u, v)` is invariant, and hence
+      `Int.gcd` is preserved in BOTH directions — the converse half that the
+      parent never states, here for ℤ pairs.
+
+  This isolates the algebraic invariant of Schönhage's HGCD (a unimodular linear
+  action) from the algorithmic recursion, and explains *why* size-reduction is
+  the only genuinely hard part: gcd-preservation is forced by group theory.
+
+  Self-contained: a fresh `HGCDMatrix` structure is defined here, so the file has
+  no dependency on the parent's `native_decide` results. 0 sorries, 0 axioms.
+-/
+
+import Mathlib.Data.Int.GCD
+import Mathlib.RingTheory.Ideal.Span
+import Mathlib.Tactic
+
+namespace SchonhageHGCD
+
+/-- A 2×2 integer cofactor matrix `[[α, β], [γ, δ]]`, as accumulated by
+    Schönhage's recursive half-GCD. Acting on a column `(a, b)` it produces
+    `(α·a + β·b, γ·a + δ·b)`. -/
+structure HGCDMatrix where
+  α : ℤ
+  β : ℤ
+  γ : ℤ
+  δ : ℤ
+  deriving DecidableEq
+
+namespace HGCDMatrix
+
+/-- The identity cofactor matrix. -/
+def id : HGCDMatrix := ⟨1, 0, 0, 1⟩
+
+/-- Determinant `α·δ − β·γ`. -/
+def det (M : HGCDMatrix) : ℤ := M.α * M.δ - M.β * M.γ
+
+/-- Matrix product (row-by-column). -/
+def mul (M N : HGCDMatrix) : HGCDMatrix :=
+  ⟨M.α * N.α + M.β * N.γ,
+   M.α * N.β + M.β * N.δ,
+   M.γ * N.α + M.δ * N.γ,
+   M.γ * N.β + M.δ * N.δ⟩
+
+/-- The action on a column vector `(a, b)`. -/
+def apply (M : HGCDMatrix) (a b : ℤ) : ℤ × ℤ :=
+  (M.α * a + M.β * b, M.γ * a + M.δ * b)
+
+/-- The adjugate `[[δ, −β], [−γ, α]]`. -/
+def adj (M : HGCDMatrix) : HGCDMatrix := ⟨M.δ, -M.β, -M.γ, M.α⟩
+
+/-- The inverse of a unimodular matrix: adjugate scaled by the determinant.
+    For `det = ±1` this is a genuine two-sided inverse (since `det² = 1`). -/
+def inv (M : HGCDMatrix) : HGCDMatrix :=
+  ⟨M.det * M.δ, M.det * (-M.β), M.det * (-M.γ), M.det * M.α⟩
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART I: RING-LEVEL IDENTITIES (det, product, action)
+-- ═══════════════════════════════════════════════════════════════
+
+@[simp] theorem det_id : id.det = 1 := by simp [id, det]
+
+/-- Determinant is multiplicative — the engine of the det = ±1 invariant. -/
+theorem det_mul (M N : HGCDMatrix) : (M.mul N).det = M.det * N.det := by
+  simp only [mul, det]; ring
+
+/-- The adjugate has the same determinant as `M`. -/
+@[simp] theorem det_adj (M : HGCDMatrix) : M.adj.det = M.det := by
+  simp only [adj, det]; ring
+
+/-- The action of a product is the composition of the actions. -/
+theorem apply_mul (M N : HGCDMatrix) (a b : ℤ) :
+    (M.mul N).apply a b = M.apply (N.apply a b).1 (N.apply a b).2 := by
+  rw [Prod.ext_iff]
+  refine ⟨?_, ?_⟩ <;> · simp only [mul, apply]; ring
+
+@[simp] theorem apply_id (a b : ℤ) : id.apply a b = (a, b) := by
+  simp [id, apply]
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART II: THE INVERSE AND THE UNIMODULAR GROUP
+-- ═══════════════════════════════════════════════════════════════
+
+/-- `M · adj(M)` is the scalar matrix `det·I`. -/
+theorem mul_adj (M : HGCDMatrix) :
+    M.mul M.adj = ⟨M.det, 0, 0, M.det⟩ := by
+  simp only [mul, adj, det, HGCDMatrix.mk.injEq]
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> ring
+
+/-- `adj(M) · M` is the scalar matrix `det·I`. -/
+theorem adj_mul (M : HGCDMatrix) :
+    M.adj.mul M = ⟨M.det, 0, 0, M.det⟩ := by
+  simp only [mul, adj, det, HGCDMatrix.mk.injEq]
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> ring
+
+/-- For a unimodular matrix `det² = 1`. -/
+theorem det_sq_eq_one {M : HGCDMatrix} (h : M.det = 1 ∨ M.det = -1) :
+    M.det * M.det = 1 := by
+  rcases h with h | h <;> rw [h] <;> ring
+
+/-- `M · M⁻¹` is the scalar matrix `det²·I` (a pure algebraic identity). -/
+theorem mul_inv_scalar (M : HGCDMatrix) :
+    M.mul M.inv = ⟨M.det * M.det, 0, 0, M.det * M.det⟩ := by
+  simp only [mul, inv, det, HGCDMatrix.mk.injEq]
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> ring
+
+/-- `M⁻¹ · M` is the scalar matrix `det²·I` (a pure algebraic identity). -/
+theorem inv_mul_scalar (M : HGCDMatrix) :
+    M.inv.mul M = ⟨M.det * M.det, 0, 0, M.det * M.det⟩ := by
+  simp only [mul, inv, det, HGCDMatrix.mk.injEq]
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> ring
+
+/-- Right inverse: `M · M⁻¹ = I` when `det = ±1`. -/
+theorem mul_inv (M : HGCDMatrix) (h : M.det = 1 ∨ M.det = -1) :
+    M.mul M.inv = id := by
+  rw [mul_inv_scalar, det_sq_eq_one h]; rfl
+
+/-- Left inverse: `M⁻¹ · M = I` when `det = ±1`. -/
+theorem inv_mul (M : HGCDMatrix) (h : M.det = 1 ∨ M.det = -1) :
+    M.inv.mul M = id := by
+  rw [inv_mul_scalar, det_sq_eq_one h]; rfl
+
+/-- The inverse of a unimodular matrix is again unimodular (same determinant),
+    so the det = ±1 matrices are closed under inverse. -/
+theorem det_inv (M : HGCDMatrix) (h : M.det = 1 ∨ M.det = -1) :
+    M.inv.det = M.det := by
+  have h1 : M.det * M.inv.det = 1 := by rw [← det_mul, mul_inv M h, det_id]
+  rcases h with h | h <;> rw [h] at h1 ⊢ <;> linarith
+
+/-- The product of two unimodular matrices is unimodular: closure of the group
+    under multiplication (via multiplicativity of the determinant). -/
+theorem det_mul_unimodular {M N : HGCDMatrix}
+    (hM : M.det = 1 ∨ M.det = -1) (hN : N.det = 1 ∨ N.det = -1) :
+    (M.mul N).det = 1 ∨ (M.mul N).det = -1 := by
+  rw [det_mul]
+  rcases hM with hM | hM <;> rcases hN with hN | hN <;> rw [hM, hN] <;> norm_num
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART III: THE ACTION ON ℤ² IS A BIJECTION
+-- ═══════════════════════════════════════════════════════════════
+
+/-- The action of `M` as a function `ℤ² → ℤ²`. -/
+def act (M : HGCDMatrix) : ℤ × ℤ → ℤ × ℤ := fun p => M.apply p.1 p.2
+
+/-- Applying `M⁻¹` undoes applying `M`: a left inverse on pairs. -/
+theorem act_inv_act (M : HGCDMatrix) (h : M.det = 1 ∨ M.det = -1) (p : ℤ × ℤ) :
+    M.inv.act (M.act p) = p := by
+  obtain ⟨a, b⟩ := p
+  show M.inv.apply (M.apply a b).1 (M.apply a b).2 = (a, b)
+  rw [← apply_mul M.inv M a b, inv_mul M h, apply_id]
+
+/-- Applying `M` undoes applying `M⁻¹`: a right inverse on pairs. -/
+theorem act_act_inv (M : HGCDMatrix) (h : M.det = 1 ∨ M.det = -1) (p : ℤ × ℤ) :
+    M.act (M.inv.act p) = p := by
+  obtain ⟨a, b⟩ := p
+  show M.apply (M.inv.apply a b).1 (M.inv.apply a b).2 = (a, b)
+  rw [← apply_mul M M.inv a b, mul_inv M h, apply_id]
+
+/-- **The HGCD action is a bijection of ℤ².**
+
+    This is the structural heart of GCD preservation: a unimodular cofactor
+    matrix permutes the integer lattice, with `M⁻¹` as its inverse permutation. -/
+theorem act_bijective (M : HGCDMatrix) (h : M.det = 1 ∨ M.det = -1) :
+    Function.Bijective M.act :=
+  Function.bijective_iff_has_inverse.mpr
+    ⟨M.inv.act, act_inv_act M h, act_act_inv M h⟩
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART IV: GCD / IDEAL INVARIANCE (BOTH DIRECTIONS)
+-- ═══════════════════════════════════════════════════════════════
+
+/-- Forward divisor transfer: any common divisor of `(a, b)` divides both
+    entries of `M.apply a b` (these are integer linear combinations). -/
+theorem dvd_apply_of_dvd (M : HGCDMatrix) {a b d : ℤ}
+    (hda : d ∣ a) (hdb : d ∣ b) :
+    d ∣ (M.apply a b).1 ∧ d ∣ (M.apply a b).2 := by
+  simp only [apply]
+  exact ⟨dvd_add (hda.mul_left M.α) (hdb.mul_left M.β),
+         dvd_add (hda.mul_left M.γ) (hdb.mul_left M.δ)⟩
+
+/-- **Common divisors are exactly preserved** by a unimodular action: `d` divides
+    both inputs iff it divides both outputs. The backward direction comes *for
+    free* from the inverse matrix — no separate Cramer computation is needed. -/
+theorem dvd_apply_iff (M : HGCDMatrix) (h : M.det = 1 ∨ M.det = -1) {a b d : ℤ} :
+    (d ∣ a ∧ d ∣ b) ↔ (d ∣ (M.apply a b).1 ∧ d ∣ (M.apply a b).2) := by
+  constructor
+  · rintro ⟨hda, hdb⟩
+    exact dvd_apply_of_dvd M hda hdb
+  · rintro ⟨hu, hv⟩
+    -- recover (a, b) = M⁻¹ · (M · (a,b)) and push divisibility through M⁻¹
+    have hrec : M.inv.apply (M.apply a b).1 (M.apply a b).2 = (a, b) := by
+      have := act_inv_act M h (a, b)
+      simpa only [act] using this
+    have hres := dvd_apply_of_dvd M.inv hu hv
+    rw [hrec] at hres
+    exact hres
+
+/-- **GCD preservation, both directions, for ℤ pairs.**
+
+    `Int.gcd (M.apply a b) = Int.gcd a b` for any unimodular `M`. Unlike the
+    parent's one-directional ℕ statement, this is an equality of integer gcds,
+    proved symmetrically from the common-divisor equivalence. -/
+theorem gcd_apply_eq (M : HGCDMatrix) (h : M.det = 1 ∨ M.det = -1) (a b : ℤ) :
+    Int.gcd (M.apply a b).1 (M.apply a b).2 = Int.gcd a b := by
+  set u := (M.apply a b).1
+  set v := (M.apply a b).2
+  apply Nat.dvd_antisymm
+  · -- Int.gcd u v ∣ Int.gcd a b : it divides u and v, hence (via M⁻¹) a and b
+    have hu : (↑(Int.gcd u v) : ℤ) ∣ u := Int.gcd_dvd_left u v
+    have hv : (↑(Int.gcd u v) : ℤ) ∣ v := Int.gcd_dvd_right u v
+    have hd := (dvd_apply_iff M h (d := (↑(Int.gcd u v) : ℤ))).mpr ⟨hu, hv⟩
+    exact Int.dvd_gcd hd.1 hd.2
+  · -- Int.gcd a b ∣ Int.gcd u v : it divides a and b, hence u and v
+    have hda : (↑(Int.gcd a b) : ℤ) ∣ a := Int.gcd_dvd_left a b
+    have hdb : (↑(Int.gcd a b) : ℤ) ∣ b := Int.gcd_dvd_right a b
+    have hd := (dvd_apply_iff M h (d := (↑(Int.gcd a b) : ℤ))).mp ⟨hda, hdb⟩
+    exact Int.dvd_gcd hd.1 hd.2
+
+/-- **The generated ideal is invariant**: `(u, v) = (a, b)` as ideals of ℤ, where
+    `(u, v) = M.apply a b` for unimodular `M`. This is the ideal-theoretic form of
+    GCD preservation; the reverse inclusion is supplied by the inverse matrix. -/
+theorem span_apply_eq (M : HGCDMatrix) (h : M.det = 1 ∨ M.det = -1) (a b : ℤ) :
+    Ideal.span {(M.apply a b).1, (M.apply a b).2} = Ideal.span ({a, b} : Set ℤ) := by
+  set u := (M.apply a b).1 with hu_def
+  set v := (M.apply a b).2 with hv_def
+  apply le_antisymm
+  · -- u, v ∈ (a, b): both are linear combinations of a and b
+    rw [Ideal.span_le]
+    have ha : a ∈ Ideal.span ({a, b} : Set ℤ) := Ideal.subset_span (by simp)
+    have hb : b ∈ Ideal.span ({a, b} : Set ℤ) := Ideal.subset_span (by simp)
+    intro x hx
+    rw [hu_def, hv_def] at hx
+    simp only [apply, Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+    rcases hx with hx | hx <;> rw [hx, SetLike.mem_coe] <;>
+      exact Ideal.add_mem _ (Ideal.mul_mem_left _ _ ha) (Ideal.mul_mem_left _ _ hb)
+  · -- a, b ∈ (u, v): recover them via the inverse matrix
+    rw [Ideal.span_le]
+    have hu : u ∈ Ideal.span ({u, v} : Set ℤ) := Ideal.subset_span (by simp)
+    have hv : v ∈ Ideal.span ({u, v} : Set ℤ) := Ideal.subset_span (by simp)
+    have hrec : M.inv.apply u v = (a, b) := by
+      have := act_inv_act M h (a, b)
+      simpa only [act, hu_def, hv_def] using this
+    have hav : a ∈ Ideal.span ({u, v} : Set ℤ) := by
+      have hx : (M.inv.apply u v).1 ∈ Ideal.span ({u, v} : Set ℤ) := by
+        simp only [apply]
+        exact Ideal.add_mem _ (Ideal.mul_mem_left _ _ hu) (Ideal.mul_mem_left _ _ hv)
+      rwa [hrec] at hx
+    have hbv : b ∈ Ideal.span ({u, v} : Set ℤ) := by
+      have hx : (M.inv.apply u v).2 ∈ Ideal.span ({u, v} : Set ℤ) := by
+        simp only [apply]
+        exact Ideal.add_mem _ (Ideal.mul_mem_left _ _ hu) (Ideal.mul_mem_left _ _ hv)
+      rwa [hrec] at hx
+    intro x hx
+    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+    rcases hx with hx | hx <;> rw [hx, SetLike.mem_coe]
+    · exact hav
+    · exact hbv
+
+end HGCDMatrix
+
+end SchonhageHGCD
+

--- a/src/data/proofs/binary-gcd-oq-03-oq-02-incomplete-01/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02-incomplete-01/annotations.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": "ann-unimodular-overview",
+    "proofId": "binary-gcd-oq-03-oq-02-incomplete-01",
+    "range": { "startLine": 1, "endLine": 77 },
+    "type": "concept",
+    "title": "GCD Preservation as the Shadow of a Unimodular Group Action",
+    "content": "Every fast GCD scheme — Lehmer, Schönhage's recursive half-GCD, GMP's `mpn_hgcd` — accumulates a **cofactor matrix** $M$ and reduces a pair $(a,b)$ by evaluating $M\\cdot(a,b)^T$. Correctness hinges on one algebraic fact: $M$ lies in $\\mathrm{GL}_2(\\mathbb{Z})$, the **unimodular group** of $2\\times 2$ integer matrices with $\\det = \\pm 1$, and the unimodular group acts on $\\mathbb{Z}^2$ by lattice automorphisms that fix the generated ideal — hence the GCD.\n\nThe parent entry formalizes the recursive algorithm and proves $\\det = \\pm 1$ together with one-directional GCD preservation, but several of its credited facts use `native_decide` (so it carries `Lean.ofReduceBool`). This companion isolates the **group structure** instead: it defines a fresh `HGCDMatrix` type, gives the explicit inverse, proves $M\\cdot M^{-1}=M^{-1}\\cdot M = I$ for unimodular $M$, shows the induced action on $\\mathbb{Z}^2$ is a bijection, and deduces two-directional GCD and ideal invariance — all with **0 axioms** and no `native_decide`.",
+    "mathContext": "$\\mathrm{GL}_2(\\mathbb{Z}) = \\{M \\in M_2(\\mathbb{Z}) : \\det M = \\pm 1\\}$ acts on $\\mathbb{Z}^2$. The adjugate $\\operatorname{adj}(M) = \\begin{pmatrix}\\delta & -\\beta\\\\ -\\gamma & \\alpha\\end{pmatrix}$ satisfies $M\\,\\operatorname{adj}(M) = (\\det M)\\,I$. Scaling by $\\det M$ gives a genuine two-sided inverse precisely because $(\\det M)^2 = 1$ when $\\det M = \\pm 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "general linear group GL₂(ℤ)",
+      "unimodular matrices",
+      "adjugate and Cramer's rule",
+      "lattice automorphisms",
+      "Schönhage half-GCD"
+    ],
+    "prerequisites": [
+      "matrix determinants and the adjugate",
+      "GCD and ideal theory over ℤ",
+      "group axioms",
+      "binary-gcd-oq-03-oq-02 (parent: recursive HGCD)"
+    ]
+  },
+  {
+    "id": "ann-ring-identities",
+    "proofId": "binary-gcd-oq-03-oq-02-incomplete-01",
+    "range": { "startLine": 79, "endLine": 100 },
+    "type": "technique",
+    "title": "Determinant Multiplicativity and the Composition Law",
+    "content": "Two identities power everything downstream. **Determinant multiplicativity** `det_mul` ($\\det(MN) = \\det M \\cdot \\det N$) is the engine of the $\\det = \\pm 1$ invariant: it is what makes $\\pm 1$ a *closed* condition under products. The **composition law** `apply_mul` states that the action of a product is the composition of the actions — $(M\\cdot N)$ applied to $(a,b)$ equals $M$ applied to $N$'s output. This is the algebraic glue that lets Schönhage's two recursive calls chain into one correct reduction, and here it is exactly what turns the matrix inverse into a left/right inverse on pairs.",
+    "mathContext": "For $2\\times 2$ matrices both facts are polynomial identities closed by `ring` after unfolding the definitions; `apply_mul` is proved componentwise via `Prod.ext_iff`.",
+    "significance": "important",
+    "relatedConcepts": ["determinant", "matrix-vector action", "functoriality of the action"],
+    "prerequisites": ["matrix multiplication", "ring identities"]
+  },
+  {
+    "id": "ann-inverse-group",
+    "proofId": "binary-gcd-oq-03-oq-02-incomplete-01",
+    "range": { "startLine": 102, "endLine": 158 },
+    "type": "key-step",
+    "title": "The Explicit Inverse and the Group Axioms",
+    "content": "The heart of the file. The adjugate satisfies $M\\,\\operatorname{adj}(M) = \\operatorname{adj}(M)\\,M = (\\det M)\\,I$ (`mul_adj`, `adj_mul`), pure ring identities. Scaling the adjugate by $\\det M$ defines `inv`, and `mul_inv_scalar`/`inv_mul_scalar` show $M\\cdot M^{-1} = (\\det M)^2\\,I$ — again pure `ring`. Combining with $(\\det M)^2 = 1$ (`det_sq_eq_one`) gives the two-sided inverse laws `mul_inv` and `inv_mul`. Finally `det_inv` (the inverse is unimodular with the same determinant) and `det_mul_unimodular` (a product of unimodulars is unimodular) are the **group axioms** restricted to the $\\det = \\pm 1$ condition: the cofactor matrices form a group.",
+    "mathContext": "Factoring through the scalar-matrix identity $M\\cdot M^{-1} = \\det^2\\cdot I$ keeps every algebraic step a pure ring identity; only the final collapse $\\det^2 = 1$ uses the unimodularity hypothesis. `det_inv` is read off from $\\det M \\cdot \\det(M^{-1}) = \\det(I) = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["adjugate", "two-sided inverse", "GL₂(ℤ) group axioms", "unimodularity"],
+    "prerequisites": ["adjugate identity", "determinant multiplicativity"]
+  },
+  {
+    "id": "ann-bijection",
+    "proofId": "binary-gcd-oq-03-oq-02-incomplete-01",
+    "range": { "startLine": 160, "endLine": 190 },
+    "type": "key-step",
+    "title": "The HGCD Action is a Bijection of ℤ²",
+    "content": "Lifting the matrix inverse to the action: `act_inv_act` and `act_act_inv` show that applying $M^{-1}$ undoes applying $M$ on pairs (each a one-line consequence of `apply_mul` + the inverse laws + `apply_id`). Packaged by `Function.bijective_iff_has_inverse`, this yields `act_bijective`: **a unimodular cofactor matrix permutes the integer lattice $\\mathbb{Z}^2$, with $M^{-1}$ as its inverse permutation.** This is the structural reason GCD preservation holds — and why it holds in *both* directions.",
+    "mathContext": "A linear map $\\mathbb{Z}^2\\to\\mathbb{Z}^2$ is bijective iff its matrix is in $\\mathrm{GL}_2(\\mathbb{Z})$. The explicit inverse furnishes both the left and right inverse simultaneously.",
+    "significance": "key",
+    "relatedConcepts": ["bijection", "lattice automorphism", "left/right inverse", "permutation of ℤ²"],
+    "prerequisites": ["composition law apply_mul", "two-sided inverse laws"]
+  },
+  {
+    "id": "ann-gcd-both-directions",
+    "proofId": "binary-gcd-oq-03-oq-02-incomplete-01",
+    "range": { "startLine": 192, "endLine": 243 },
+    "type": "key-step",
+    "title": "Two-Directional GCD Preservation for ℤ Pairs",
+    "content": "The arithmetic payoff. `dvd_apply_of_dvd` transfers a common divisor of $(a,b)$ forward to the output (linear combinations). `dvd_apply_iff` upgrades this to an **equivalence**: the converse comes *for free* by applying the forward lemma to $M^{-1}$ and rewriting via `act_inv_act` — no separate Cramer computation. From the equal common-divisor sets, `gcd_apply_eq` proves $\\gcd(M\\cdot(a,b)) = \\gcd(a,b)$ in **both directions** for $\\mathbb{Z}$ pairs (the parent states only one direction, for $\\mathbb{N}$), by `Nat.dvd_antisymm` plus `Int.dvd_gcd` and `Int.gcd_dvd_left/right`.",
+    "mathContext": "Common divisors are preserved exactly because the action is invertible: $d\\mid a, d\\mid b \\iff d\\mid u, d\\mid v$ where $(u,v) = M\\cdot(a,b)$. Equal divisor sets force equal gcds by mutual divisibility.",
+    "significance": "key",
+    "relatedConcepts": ["gcd preservation", "common divisors", "Bézout/ideal", "antisymmetry of divisibility"],
+    "prerequisites": ["bijective action", "Int.gcd lemmas"]
+  },
+  {
+    "id": "ann-ideal-invariance",
+    "proofId": "binary-gcd-oq-03-oq-02-incomplete-01",
+    "range": { "startLine": 244, "endLine": 284 },
+    "type": "concept",
+    "title": "Ideal Invariance: (a,b) = (u,v)",
+    "content": "The cleanest statement of the invariant: `span_apply_eq` proves the generated ideals are equal, $(u,v) = (a,b)$ in $\\mathbb{Z}$, where $(u,v) = M\\cdot(a,b)$. The forward inclusion holds because $u,v$ are linear combinations of $a,b$; the reverse inclusion is supplied by the inverse matrix (recovering $a,b$ as linear combinations of $u,v$). Over $\\mathbb{Z}$ this is equivalent to GCD preservation, but the ideal form is symmetric by construction and generalizes verbatim to any commutative ring — exhibiting Schönhage's HGCD invariant in its most structural form.",
+    "mathContext": "In a PID, $\\langle a,b\\rangle = \\langle \\gcd(a,b)\\rangle$, so ideal invariance and gcd invariance coincide over $\\mathbb{Z}$. The proof uses `Ideal.span_le`, `Ideal.subset_span`, and the module closure lemmas `Ideal.mul_mem_left`/`Ideal.add_mem`.",
+    "significance": "important",
+    "relatedConcepts": ["ideal span", "principal ideal domain", "Bézout identity", "module closure"],
+    "prerequisites": ["ideals over ℤ", "the inverse matrix"]
+  }
+]

--- a/src/data/proofs/binary-gcd-oq-03-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02-incomplete-01/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "binary-gcd-oq-03-oq-02-incomplete-01",
+  "title": "Schönhage's HGCD: The Unimodular Group Structure behind GCD Preservation",
+  "slug": "binary-gcd-oq-03-oq-02-incomplete-01",
+  "description": "A self-contained, axiom-free companion to the Schönhage recursive HGCD entry (binary-gcd-oq-03-oq-02). The parent proves that the accumulated cofactor matrix has determinant ±1 and preserves the GCD (one direction, for ℕ pairs), but several of its credited facts use native_decide, so it carries Lean.ofReduceBool. This file isolates the algebraic invariant of HGCD — a unimodular linear action — and proves the structural facts the parent omits: the 2×2 integer cofactor matrices with det = ±1 form a GROUP (explicit inverse = adjugate scaled by the determinant, two-sided M·M⁻¹ = M⁻¹·M = I, closure under product and inverse); the induced action on ℤ² is a BIJECTION whose inverse is the action of M⁻¹; and consequently the generated ideal (a,b) = (u,v) is invariant and Int.gcd is preserved in BOTH directions for ℤ pairs. GCD preservation is thus exhibited as the shadow of an invertible (group-theoretic) action, with NO native_decide and 0 axioms.",
+  "sorries": 0,
+  "meta": {
+    "author": "Schönhage (1971); structural formalization in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Half-GCD_algorithm",
+    "date": "1971",
+    "status": "verified",
+    "tags": [
+      "algorithms",
+      "number-theory",
+      "gcd",
+      "computational-algebra",
+      "matrices",
+      "group-theory",
+      "unimodular"
+    ],
+    "proofRepoPath": "Proofs/BinaryGcdOQ03OQ02Incomplete01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 284,
+    "dateAdded": "2026-06-21",
+    "theoremCount": 21,
+    "definitionCount": 7,
+    "assumptions": "None. The file is fully machine-checked with no `axiom` declarations, no `sorry`, and no `native_decide` — `#print axioms` for the headline theorems (`act_bijective`, `gcd_apply_eq`, `span_apply_eq`) lists only the foundational `propext`, `Classical.choice`, and `Quot.sound`. In particular it does NOT depend on `Lean.ofReduceBool`, unlike the parent entry.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.gcd_dvd_left / Int.gcd_dvd_right",
+        "description": "The integer gcd divides each argument; used to transfer divisibility through the matrix action.",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Int.dvd_gcd",
+        "description": "A common divisor of two integers divides their gcd; the antisymmetry half of gcd preservation.",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Ideal.span_le / Ideal.subset_span / Ideal.mul_mem_left / Ideal.add_mem",
+        "description": "Span membership and closure used for the ideal-invariance theorem span_apply_eq.",
+        "module": "Mathlib.RingTheory.Ideal.Span"
+      },
+      {
+        "theorem": "Function.bijective_iff_has_inverse",
+        "description": "Turns the two-sided inverse on pairs into a bijection of ℤ².",
+        "module": "Mathlib.Logic.Function.Basic"
+      }
+    ],
+    "originalContributions": [
+      "HGCDMatrix.inv: an explicit inverse for a 2×2 integer cofactor matrix (adjugate scaled by the determinant), valid as a genuine two-sided inverse precisely when det = ±1.",
+      "mul_inv / inv_mul: M·M⁻¹ = M⁻¹·M = I for unimodular M, factored through the pure-ring scalar-matrix identities mul_inv_scalar / inv_mul_scalar (M·M⁻¹ = det²·I) and det² = 1.",
+      "det_inv and det_mul_unimodular: the det = ±1 matrices are closed under inverse and product — the group axioms for the unimodular cofactor group.",
+      "act_bijective: the HGCD action (a,b) ↦ M·(a,b) is a bijection of ℤ² when det = ±1, with M⁻¹ as its inverse permutation. This is the structural reason GCD is preserved.",
+      "dvd_apply_iff: a unimodular action preserves the set of common divisors exactly, with the backward direction obtained for free from the inverse matrix (no separate Cramer computation).",
+      "gcd_apply_eq: Int.gcd is preserved in BOTH directions for ℤ pairs — the converse half the parent never states.",
+      "span_apply_eq: the generated ideal (u,v) = (a,b) is invariant under the unimodular action — the ideal-theoretic form of GCD preservation."
+    ],
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Arnold Schönhage (1971) extended Lehmer's hybrid GCD to optimal O(M(n)·log n) bit complexity by recursively computing a cofactor matrix on the top half of the bits. The correctness of every such scheme rests on a single algebraic fact: the accumulated cofactor matrix lies in GL₂(ℤ) — the unimodular group of 2×2 integer matrices with determinant ±1 — and the unimodular group acts on column vectors by permutations that preserve the generated ideal, hence the GCD. The parent entry (binary-gcd-oq-03-oq-02) formalizes the recursive algorithm and proves det = ±1 and one-directional GCD preservation; this companion supplies the group-theoretic backbone that explains why that preservation must hold.",
+    "problemStatement": "Exhibit GCD preservation under Schönhage's HGCD cofactor matrices as a consequence of the unimodular group structure: give the explicit matrix inverse, prove the det = ±1 matrices form a group, show the induced action on ℤ² is a bijection, and deduce two-directional GCD/ideal invariance — all axiom-free and without native_decide.",
+    "proofStrategy": "Part I establishes the ring-level identities: determinant multiplicativity (det_mul), the adjugate's determinant (det_adj), and the composition law apply_mul stating that the action of a product is the composition of the actions. Part II builds the group: the scalar-matrix identities M·adj(M) = adj(M)·M = det·I (mul_adj/adj_mul), the inverse via the adjugate scaled by the determinant, the two-sided inverse laws mul_inv/inv_mul (factored through M·M⁻¹ = det²·I and det² = 1), and closure of det = ±1 under inverse and product (det_inv, det_mul_unimodular). Part III lifts the inverse to the action: act_inv_act and act_act_inv show M⁻¹ undoes M on pairs, and act_bijective packages this as a bijection of ℤ². Part IV harvests the arithmetic: dvd_apply_of_dvd transfers common divisors forward, dvd_apply_iff makes the transfer an equivalence using the inverse for the converse, gcd_apply_eq proves two-directional Int.gcd preservation by antisymmetry, and span_apply_eq proves the ideal (a,b) = (u,v) is invariant.",
+    "keyInsights": [
+      "GCD preservation is the shadow of a bijection. Because a unimodular matrix acts invertibly on ℤ², the set of common divisors — and the generated ideal — are preserved exactly, in both directions, with no appeal to Cramer's rule beyond the inverse itself.",
+      "The inverse is the whole game. Once M⁻¹ is exhibited (adjugate scaled by det, a two-sided inverse exactly when det² = 1), the converse divisor transfer, the bijectivity, and the reverse ideal inclusion all follow by applying the forward lemma to M⁻¹.",
+      "Self-containment buys axiom-freeness. By re-deriving the cofactor structure on a fresh HGCDMatrix type, the file avoids the parent's native_decide results entirely; #print axioms lists only propext/Classical.choice/Quot.sound.",
+      "det = ±1 ⇔ membership in GL₂(ℤ). The closure lemmas det_inv and det_mul_unimodular are exactly the group axioms restricted to the determinant ±1 condition, making explicit that Schönhage's cofactor matrices live in a group."
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header, Imports, and the HGCDMatrix Type",
+      "startLine": 1,
+      "endLine": 77,
+      "summary": "Module docstring framing the unimodular-group story and its contrast with the parent. Imports Mathlib's Int.GCD, Ideal.Span, and Tactic. Defines a fresh 2×2 integer cofactor matrix HGCDMatrix with its identity, determinant, product, column action apply, adjugate, and the determinant-scaled adjugate inverse."
+    },
+    {
+      "id": "part-i-ring-identities",
+      "title": "Part I — Ring-level identities",
+      "startLine": 79,
+      "endLine": 100,
+      "summary": "Determinant multiplicativity det_mul, the adjugate determinant det_adj, the composition law apply_mul ((M·N) acts as M after N), and the identity action apply_id."
+    },
+    {
+      "id": "part-ii-group",
+      "title": "Part II — The inverse and the unimodular group",
+      "startLine": 102,
+      "endLine": 158,
+      "summary": "Scalar-matrix identities mul_adj/adj_mul (M·adj(M) = det·I), det² = 1 for unimodular matrices, the scalar forms mul_inv_scalar/inv_mul_scalar (M·M⁻¹ = det²·I), the two-sided inverse laws mul_inv/inv_mul, and group closure det_inv and det_mul_unimodular."
+    },
+    {
+      "id": "part-iii-bijection",
+      "title": "Part III — The action on ℤ² is a bijection",
+      "startLine": 160,
+      "endLine": 190,
+      "summary": "The action as a function act, the left/right inverse on pairs act_inv_act/act_act_inv, and the headline act_bijective: a unimodular cofactor matrix permutes the integer lattice with M⁻¹ as inverse permutation."
+    },
+    {
+      "id": "part-iv-gcd-ideal",
+      "title": "Part IV — GCD / ideal invariance (both directions)",
+      "startLine": 192,
+      "endLine": 284,
+      "summary": "Forward divisor transfer dvd_apply_of_dvd, the common-divisor equivalence dvd_apply_iff (converse for free from the inverse), two-directional gcd_apply_eq for ℤ pairs, and the ideal-invariance span_apply_eq ((a,b) = (u,v))."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "oq-01",
+      "question": "Can this unimodular cofactor group be identified with a Mathlib `Matrix.GeneralLinearGroup (Fin 2) ℤ` (or `Matrix.SpecialLinearGroup` for the det = 1 subgroup), transporting the bijective action to Mathlib's `Matrix.toLin` machinery?",
+      "difficulty": "medium",
+      "tags": ["mathlib-bridge", "GL2", "group-theory"]
+    },
+    {
+      "id": "oq-02",
+      "question": "Does the bijective-action viewpoint give a cleaner route to a CONDITIONAL size-reduction bound for the parent's recursive HGCD, by tracking how the unimodular action moves the ℤ-lattice norm rather than individual entries?",
+      "difficulty": "hard",
+      "tags": ["size-reduction", "quotient-stability"]
+    }
+  ],
+  "leanFile": {
+    "namespace": "SchonhageHGCD.HGCDMatrix",
+    "lineCount": 284,
+    "axiomCount": 0,
+    "theoremCount": 21,
+    "definitionCount": 7,
+    "path": "Proofs/BinaryGcdOQ03OQ02Incomplete01.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "conclusion": {
+    "summary": "This companion isolates the algebraic invariant behind Schönhage's recursive HGCD: the accumulated cofactor matrices form the unimodular group GL₂(ℤ)±1, whose action on ℤ² is a bijection. From the explicit inverse alone follow two-directional GCD preservation and ideal invariance for ℤ pairs — the converse the parent omits — entirely axiom-free and with no native_decide. It makes precise that GCD-preservation is forced by group theory, so the only genuinely hard part of formalizing HGCD is the (still-open) size-reduction bound."
+  },
+  "crossReferences": [
+    {
+      "targetId": "binary-gcd-oq-03-oq-02",
+      "relationship": "parent",
+      "description": "Schönhage's recursive HGCD entry. It formalizes the recursive algorithm and proves det = ±1 and one-directional GCD preservation for ℕ pairs, but relies on native_decide for several credited facts (carrying Lean.ofReduceBool). This companion re-derives the cofactor structure on a fresh type to supply the missing group-theoretic backbone — explicit inverse, bijective action, two-directional GCD/ideal invariance — fully axiom-free."
+    },
+    {
+      "targetId": "binary-gcd-oq-03",
+      "relationship": "foundational",
+      "description": "The Lehmer–Schönhage hybrid GCD providing the single-level cofactor infrastructure (CofactorMatrix, gcd_cofactor_eq). The unimodular-group facts proved here abstract exactly the det = ±1 invariant those constructions rely on."
+    },
+    {
+      "targetId": "binary-gcd",
+      "relationship": "foundational",
+      "description": "Stein's binary GCD (1967), the conceptual predecessor of every fast GCD. Schönhage's HGCD pushes the chain to O(M(n)·log n); its correctness rests on the unimodular action made explicit in this file."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A self-contained, **axiom-free** companion to the Schönhage recursive HGCD entry (`binary-gcd-oq-03-oq-02`). The parent formalizes the recursive half-GCD algorithm and proves the cofactor matrix has determinant ±1 and preserves the GCD — but **one-directionally, for ℕ pairs**, and several of its credited facts use `native_decide` (so it carries `Lean.ofReduceBool`).

This file isolates the *algebraic invariant* of HGCD — a **unimodular linear action** — and proves the structural facts the parent omits, with **0 axioms and no `native_decide`**.

## What's new

- **The unimodular group.** The 2×2 integer cofactor matrices with `det = ±1` form a group: explicit inverse `inv` (adjugate scaled by the determinant), two-sided laws `M·M⁻¹ = M⁻¹·M = I` (`mul_inv`/`inv_mul`), and closure under product and inverse (`det_mul_unimodular`, `det_inv`).
- **The action on ℤ² is a bijection** (`act_bijective`): a unimodular cofactor matrix permutes the integer lattice with `M⁻¹` as its inverse permutation. *GCD preservation is the shadow of this bijection.*
- **Two-directional GCD preservation** (`gcd_apply_eq`) for ℤ pairs — the converse half the parent never states — and **ideal invariance** `(a,b) = (u,v)` (`span_apply_eq`). The converse divisor transfer comes *for free* from the inverse matrix, with no separate Cramer computation.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.BinaryGcdOQ03OQ02Incomplete01` — builds clean (3058 jobs).
- 284 lines, 21 theorems, 7 defs, **0 sorries**.
- `#print axioms` for `act_bijective`, `gcd_apply_eq`, `span_apply_eq` lists only `propext`, `Classical.choice`, `Quot.sound` — **no `Lean.ofReduceBool`, no `sorryAx`**.

## Honest scope

This is the *structural* / group-theoretic backbone of HGCD correctness, deliberately abstracted from the recursive algorithm. It does **not** make progress on the still-open size-reduction bound or the O(M(n) log n) bit-complexity goal — it makes precise *why* GCD preservation is forced by group theory, leaving size reduction as the genuinely hard remaining part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)