### PR TITLE
research(automorphic-number-oq-01-oq-01): idempotent count of ZMod n is 2^ω(n) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -188,6 +188,7 @@ import Proofs.ArithmeticSeriesOQ04
 import Proofs.ArithmeticSeriesOQ04OQ01
 import Proofs.ArsinhLogFormulaOQ01
 import Proofs.AutomorphicNumberOQ01
+import Proofs.AutomorphicNumberOQ01OQ01
 import Proofs.BallotProblem
 import Proofs.BallotProblemOQ01
 import Proofs.BallotProblemOQ01OQ01

--- a/proofs/Proofs/AutomorphicNumberOQ01.lean
+++ b/proofs/Proofs/AutomorphicNumberOQ01.lean
@@ -80,7 +80,7 @@ theorem idem_eq_zero_or_one {p : ℕ} [hp : Fact p.Prime] {k : ℕ} (hk : 0 < k)
     · have hpos : 0 < n := Nat.pos_of_ne_zero hn0
       have hpnm : ¬ p ∣ (n - 1) := by
         intro hd
-        have h2 : p ∣ n - (n - 1) := Nat.dvd_sub' hpn hd
+        have h2 : p ∣ n - (n - 1) := Nat.dvd_sub hpn hd
         rw [Nat.sub_sub_self hpos] at h2
         have h3 := Nat.le_of_dvd Nat.one_pos h2
         have h4 := hp.out.two_le
@@ -122,8 +122,10 @@ theorem idem_card_prime_pow {p : ℕ} [hp : Fact p.Prime] {k : ℕ} (hk : 0 < k)
     | exact Finset.card_pair zero_ne_one
     | exact Finset.card_doubleton zero_ne_one
 
-/-- Idempotents transport across a ring isomorphism. -/
-def idemCongr {R S : Type*} [Mul R] [Mul S] (f : R ≃+* S) :
+/-- Idempotents transport across a multiplicative isomorphism.  (Only the multiplicative
+structure matters, so this is stated for a `MulEquiv`; ring isomorphisms coerce via
+`RingEquiv.toMulEquiv`.) -/
+def idemCongr {R S : Type*} [Mul R] [Mul S] (f : R ≃* S) :
     {e : R // e * e = e} ≃ {e : S // e * e = e} where
   toFun e := ⟨f e.1, by rw [← map_mul, e.2]⟩
   invFun e := ⟨f.symm e.1, by rw [← map_mul, e.2]⟩
@@ -146,16 +148,26 @@ theorem automorphic_idempotent_count (k : ℕ) (hk : 0 < k) :
     (univ.filter (fun e : ZMod (10 ^ k) => e * e = e)).card = 4 := by
   haveI : Fact (Nat.Prime 2) := ⟨by norm_num⟩
   haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
-  rw [show (10 : ℕ) ^ k = 2 ^ k * 5 ^ k from by
-        rw [show (10 : ℕ) = 2 * 5 from rfl, mul_pow]]
+  haveI : NeZero ((10 : ℕ) ^ k) := ⟨pow_ne_zero k (by norm_num)⟩
+  haveI : NeZero ((2 : ℕ) ^ k * 5 ^ k) :=
+    ⟨mul_ne_zero (pow_ne_zero k (by norm_num)) (pow_ne_zero k (by norm_num))⟩
   have hcop : Nat.Coprime (2 ^ k) (5 ^ k) := by
     rw [Nat.coprime_pow_left_iff hk, Nat.coprime_pow_right_iff hk]; decide
-  rw [← Fintype.card_subtype (fun e : ZMod (2 ^ k * 5 ^ k) => e * e = e),
-      Fintype.card_congr (idemCongr (ZMod.chineseRemainder hcop)),
-      Fintype.card_congr (idemProd (R := ZMod (2 ^ k)) (S := ZMod (5 ^ k))),
-      Fintype.card_prod,
-      idem_card_prime_pow (p := 2) hk,
-      idem_card_prime_pow (p := 5) hk]
+  have h10 : (10 : ℕ) ^ k = 2 ^ k * 5 ^ k := by
+    rw [show (10 : ℕ) = 2 * 5 from rfl, mul_pow]
+  -- Count idempotents over the coprime product modulus `2 ^ k * 5 ^ k`.
+  have key : Fintype.card {e : ZMod (2 ^ k * 5 ^ k) // e * e = e} = 4 := by
+    rw [Fintype.card_congr (idemCongr (ZMod.chineseRemainder hcop).toMulEquiv),
+        Fintype.card_congr (idemProd (R := ZMod (2 ^ k)) (S := ZMod (5 ^ k))),
+        Fintype.card_prod,
+        idem_card_prime_pow (p := 2) hk,
+        idem_card_prime_pow (p := 5) hk]
+  -- Transport along the type equality `ZMod (10 ^ k) = ZMod (2 ^ k * 5 ^ k)`, avoiding a
+  -- rewrite under the dependent `NeZero` instance.
+  have hcast : {e : ZMod (10 ^ k) // e * e = e} ≃ {e : ZMod (2 ^ k * 5 ^ k) // e * e = e} :=
+    Equiv.cast (congrArg (fun N => {e : ZMod N // e * e = e}) h10)
+  rw [← Fintype.card_subtype (fun e : ZMod (10 ^ k) => e * e = e),
+      Fintype.card_congr hcast, key]
 
 /-! ## Concrete automorphic numbers
 

--- a/proofs/Proofs/AutomorphicNumberOQ01OQ01.lean
+++ b/proofs/Proofs/AutomorphicNumberOQ01OQ01.lean
@@ -1,0 +1,135 @@
+import Mathlib
+import Proofs.AutomorphicNumberOQ01
+
+/-!
+# Why exactly four? Counting automorphic residues for an arbitrary modulus
+
+## What This Proves
+
+The parent file `AutomorphicNumberOQ01` shows that `ZMod (10 ^ k)` has **exactly four
+idempotents** for every `k ≥ 1`, equivalently four `k`-digit automorphic residues
+`n ^ 2 ≡ n (mod 10 ^ k)`.  The number `4` is not magic: it is `2 ^ 2`, and the exponent
+`2` is the number of *distinct primes* dividing `10 ^ k` (namely `2` and `5`).
+
+This file proves the underlying general law.  For **every** `n ≥ 1`,
+
+```
+idempotent_count :
+  Nat.card {e : ZMod n // e * e = e} = 2 ^ n.primeFactors.card
+```
+
+i.e. the number of idempotents (= "automorphic residues") of `ZMod n` is `2 ^ ω(n)`,
+where `ω(n)` is the number of distinct prime factors of `n`.  The parent's "exactly four
+mod `10 ^ k`" is the special case `ω(10 ^ k) = 2`.
+
+## Strategy
+
+The counting function `numIdem n := #{idempotents of ZMod n}` is a **multiplicative
+arithmetic function**:
+
+* `numIdem 1 = 1`;
+* for coprime `m, n ≥ 1`, the Chinese Remainder isomorphism
+  `ZMod (m * n) ≃+* ZMod m × ZMod n` transports idempotents (`idemCongr` from the parent)
+  and idempotents of a product split componentwise (`idemProd`), so
+  `numIdem (m * n) = numIdem m · numIdem n`.
+
+Evaluating a multiplicative function over the prime factorization
+(`IsMultiplicative.multiplicative_factorization`) reduces the count to the prime-power
+case, which the parent already settled: `numIdem (p ^ k) = 2` for every prime `p` and
+`k ≥ 1` (`idem_card_prime_pow`).  The product of `2` over the `ω(n)` prime factors is
+`2 ^ ω(n)`.
+
+## Status
+
+Fully machine-checked: `0` sorries, `0` axioms.  Builds on the verified parent file.
+-/
+
+namespace AutomorphicNumberOQ01OQ01
+
+open Finset AutomorphicNumberOQ01 ArithmeticFunction
+
+/-- The arithmetic function `n ↦ #{idempotents of ZMod n}`.  By the arithmetic-function
+convention the value at `0` is set to `0` (so that it is a genuine `ArithmeticFunction`);
+all results below concern `n ≥ 1`, where the value is the honest idempotent count. -/
+noncomputable def numIdem : ArithmeticFunction ℕ :=
+  ⟨fun n => if n = 0 then 0 else Nat.card {e : ZMod n // e * e = e}, by simp⟩
+
+@[simp] lemma numIdem_apply (n : ℕ) :
+    numIdem n = if n = 0 then 0 else Nat.card {e : ZMod n // e * e = e} := rfl
+
+/-- For `n ≥ 1`, `numIdem n` is exactly the number of idempotents of `ZMod n`. -/
+lemma numIdem_pos {n : ℕ} (hn : n ≠ 0) :
+    numIdem n = Nat.card {e : ZMod n // e * e = e} := by
+  rw [numIdem_apply, if_neg hn]
+
+/-- `ZMod 1` is trivial, so its unique element is the only idempotent. -/
+lemma numIdem_one : numIdem 1 = 1 := by
+  rw [numIdem_pos one_ne_zero, Nat.card_eq_fintype_card]
+  decide
+
+/-- The idempotent count of a prime power is `2` — the parent's `idem_card_prime_pow`. -/
+lemma numIdem_prime_pow {p : ℕ} (hp : p.Prime) {k : ℕ} (hk : 0 < k) :
+    numIdem (p ^ k) = 2 := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : NeZero (p ^ k) := ⟨pow_ne_zero k hp.pos.ne'⟩
+  rw [numIdem_pos (pow_ne_zero k hp.pos.ne'), Nat.card_eq_fintype_card]
+  exact idem_card_prime_pow hk
+
+/-- Idempotent counts multiply across coprime moduli, via the Chinese Remainder
+isomorphism (`idemCongr`) and componentwise splitting over a product (`idemProd`). -/
+lemma numIdem_mul_coprime {m n : ℕ} (hm : m ≠ 0) (hn : n ≠ 0) (h : m.Coprime n) :
+    numIdem (m * n) = numIdem m * numIdem n := by
+  rw [numIdem_pos (mul_ne_zero hm hn), numIdem_pos hm, numIdem_pos hn,
+      Nat.card_congr (idemCongr (ZMod.chineseRemainder h).toMulEquiv),
+      Nat.card_congr (idemProd (R := ZMod m) (S := ZMod n)),
+      Nat.card_prod]
+
+/-- `numIdem` is a multiplicative arithmetic function. -/
+lemma numIdem_isMultiplicative : numIdem.IsMultiplicative := by
+  rw [IsMultiplicative.iff_ne_zero]
+  exact ⟨numIdem_one, fun hm hn h => numIdem_mul_coprime hm hn h⟩
+
+/-- **Main theorem (arithmetic-function form).** For every `n ≥ 1`,
+`numIdem n = 2 ^ ω(n)`, where `ω(n) = n.primeFactors.card`. -/
+theorem numIdem_eq_two_pow (n : ℕ) (hn : 0 < n) :
+    numIdem n = 2 ^ n.primeFactors.card := by
+  rw [numIdem_isMultiplicative.multiplicative_factorization numIdem hn.ne']
+  have hterm : n.factorization.prod (fun p k => numIdem (p ^ k))
+      = n.factorization.prod (fun _ _ => 2) := by
+    apply Finsupp.prod_congr
+    intro p hp
+    have hk : n.factorization p ≠ 0 := Finsupp.mem_support_iff.mp hp
+    rw [Nat.support_factorization] at hp
+    exact numIdem_prime_pow (Nat.prime_of_mem_primeFactors hp) (Nat.pos_of_ne_zero hk)
+  rw [hterm, Finsupp.prod, Finset.prod_const, Nat.support_factorization]
+
+/-- **Main theorem.** The number of idempotents of `ZMod n` — equivalently, the number of
+`automorphic` residues `e ^ 2 ≡ e (mod n)` — is `2 ^ ω(n)`, where `ω(n)` is the number of
+distinct primes dividing `n`. -/
+theorem idempotent_count (n : ℕ) (hn : 0 < n) :
+    Nat.card {e : ZMod n // e * e = e} = 2 ^ n.primeFactors.card := by
+  rw [← numIdem_pos hn.ne', numIdem_eq_two_pow n hn]
+
+/-- The count is `2` exactly when `n` is a prime power (one distinct prime). -/
+theorem idempotent_count_prime_pow {p : ℕ} (hp : p.Prime) {k : ℕ} (hk : 0 < k) :
+    Nat.card {e : ZMod (p ^ k) // e * e = e} = 2 := by
+  rw [← numIdem_pos (pow_ne_zero k hp.pos.ne'), numIdem_prime_pow hp hk]
+
+/-- `10 ^ k` has exactly the two prime factors `2` and `5`. -/
+lemma primeFactors_ten_pow {k : ℕ} (hk : 0 < k) :
+    (10 ^ k).primeFactors.card = 2 := by
+  rw [Nat.primeFactors_pow 10 hk.ne', show (10 : ℕ) = 2 * 5 from rfl,
+      Nat.primeFactors_mul (by norm_num) (by norm_num),
+      Nat.Prime.primeFactors (by norm_num : Nat.Prime 2),
+      Nat.Prime.primeFactors (by norm_num : Nat.Prime 5)]
+  decide
+
+/-- **Recovers the parent's count.** Since `ω(10 ^ k) = 2`, the modulus `10 ^ k` has
+`2 ^ 2 = 4` automorphic residues — the four idempotents `0, 1, …5, …6`. -/
+theorem automorphic_count_ten_pow (k : ℕ) (hk : 0 < k) :
+    Nat.card {e : ZMod (10 ^ k) // e * e = e} = 4 := by
+  have hpos : 0 < (10 : ℕ) ^ k := pow_pos (by norm_num) k
+  rw [idempotent_count _ hpos, primeFactors_ten_pow hk]
+  norm_num
+
+end AutomorphicNumberOQ01OQ01

--- a/src/data/proofs/automorphic-number-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-01/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-autonum-oq01oq01-context",
+    "proofId": "automorphic-number-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "concept",
+    "title": "Why exactly four? Counting automorphic residues mod n",
+    "content": "An automorphic number is one whose square ends in itself: 5²=25, 6²=36, 25²=625, 76²=5776. Reducing mod 10^k, an automorphic residue is precisely an idempotent of ZMod (10^k): an element with e²=e. The parent entry proves there are exactly four of them for every k≥1 (namely 0, 1, and the two nontrivial residues ending in …5 and …6). But why four? The answer is structural: 4 = 2², and the exponent 2 is the number of distinct primes dividing 10 (i.e. 2 and 5). This file proves the general law — for every n≥1, the number of idempotents of ZMod n equals 2^ω(n), where ω(n) counts the distinct prime factors of n — and recovers the decimal '4' as the case ω(10^k)=2.",
+    "mathContext": "Automorphic residue mod n ⟺ idempotent of ZMod n; the count is $2^{\\omega(n)}$, with $\\omega(10^k)=2$ giving the classical four."
+  },
+  {
+    "id": "ann-autonum-oq01oq01-numidem",
+    "proofId": "automorphic-number-oq-01-oq-01",
+    "range": { "startLine": 51, "endLine": 76 },
+    "type": "definition",
+    "title": "Packaging the count as an arithmetic function",
+    "content": "numIdem n is defined as Nat.card {e : ZMod n // e*e=e} for n≥1, with the value at 0 set to 0 so that it is a genuine ArithmeticFunction ℕ (the arithmetic-function convention demands f(0)=0). Using Nat.card rather than Fintype.card sidesteps any Fintype-instance bookkeeping and makes the multiplicativity proof one rewrite chain. numIdem_one records that ZMod 1 is trivial (its unique element is the only idempotent), and numIdem_prime_pow re-exports the parent's prime-power count idem_card_prime_pow = 2 in Nat.card form.",
+    "mathContext": "$\\mathrm{numIdem}(n)=\\#\\{e\\in\\mathbb{Z}/n : e^2=e\\}$, an arithmetic function with $\\mathrm{numIdem}(p^k)=2$."
+  },
+  {
+    "id": "ann-autonum-oq01oq01-multiplicative",
+    "proofId": "automorphic-number-oq-01-oq-01",
+    "range": { "startLine": 77, "endLine": 90 },
+    "type": "key-step",
+    "title": "Multiplicativity from the Chinese Remainder Theorem",
+    "content": "For coprime m, n the ring isomorphism ZMod (mn) ≃+* ZMod m × ZMod n (ZMod.chineseRemainder), coerced to a MulEquiv, transports idempotents via the parent's idemCongr, and idempotents of a product ring split componentwise via idemProd. Chaining Nat.card_congr through both equivalences and then Nat.card_prod gives numIdem(mn) = numIdem m · numIdem n. Combined with numIdem 1 = 1 and IsMultiplicative.iff_ne_zero, numIdem is a multiplicative arithmetic function. Only the multiplicative structure is used — which is exactly why the parent's idemCongr is correctly stated for a MulEquiv, not a RingEquiv.",
+    "mathContext": "$\\gcd(m,n)=1\\Rightarrow \\mathbb{Z}/mn\\cong\\mathbb{Z}/m\\times\\mathbb{Z}/n$, so an idempotent mod $mn$ is a pair of idempotents and the count multiplies."
+  },
+  {
+    "id": "ann-autonum-oq01oq01-factorization",
+    "proofId": "automorphic-number-oq-01-oq-01",
+    "range": { "startLine": 91, "endLine": 116 },
+    "type": "key-step",
+    "title": "Evaluating a multiplicative function over the factorization",
+    "content": "IsMultiplicative.multiplicative_factorization writes numIdem n (for n>0) as the product of numIdem(p^k) over the prime factorization of n. Every prime p in the support contributes numIdem(p^(factorization)) = 2 (numIdem_prime_pow, since support membership forces both primality and a positive exponent). The product of the constant 2 over the ω(n) = #support prime factors collapses via Finset.prod_const to 2^(support.card), and Nat.support_factorization rewrites the support as n.primeFactors. The result, restated with Nat.card, is idempotent_count: #{idempotents of ZMod n} = 2^ω(n).",
+    "mathContext": "A multiplicative function is determined by its prime-power values; $\\mathrm{numIdem}\\equiv 2$ there, so $\\mathrm{numIdem}(n)=\\prod_{p\\mid n}2 = 2^{\\omega(n)}$."
+  },
+  {
+    "id": "ann-autonum-oq01oq01-decimal",
+    "proofId": "automorphic-number-oq-01-oq-01",
+    "range": { "startLine": 117, "endLine": 135 },
+    "type": "technique",
+    "title": "Recovering 'exactly four' — and the parent regression fix",
+    "content": "primeFactors_ten_pow computes ω(10^k)=2: Nat.primeFactors_pow strips the exponent, then 10 = 2·5 splits as a coprime product (Nat.primeFactors_mul, Nat.Prime.primeFactors) into {2}∪{5}, whose card 2 is checked by kernel `decide` on concrete finite data. Substituting into idempotent_count yields automorphic_count_ten_pow: Nat.card {e : ZMod (10^k) // e²=e} = 2² = 4 — the classical four automorphic residues 0, 1, …5, …6. The same theorem gives 2 for any prime power and 8 for a modulus with three distinct primes. This session also repaired a build-rot in the parent file against Mathlib 4.26.0: idemCongr/idemProd were stated for a RingEquiv that requires an additive structure absent from the bare [Mul R] hypotheses (corrected to MulEquiv, the right notion for idempotency), and the renamed Nat.dvd_sub' → Nat.dvd_sub was updated.",
+    "mathContext": "$\\#\\{e\\in\\mathbb{Z}/10^k : e^2=e\\}=2^{\\omega(10^k)}=2^2=4$; the count grows as $2^{\\#\\text{distinct primes}}$, not with the size of the modulus."
+  }
+]

--- a/src/data/proofs/automorphic-number-oq-01-oq-01/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-01/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "automorphic-number-oq-01-oq-01",
+  "slug": "automorphic-number-oq-01-oq-01",
+  "title": "Why Exactly Four? Counting Automorphic Residues mod n as 2^ω(n)",
+  "description": "The parent entry shows ZMod (10^k) has exactly four automorphic residues n²≡n (mod 10^k) — equivalently four idempotents. The number 4 is not magic: it is 2², and the exponent 2 is the number of distinct primes dividing 10^k (namely 2 and 5). This file proves the underlying general law: for every n ≥ 1 the number of idempotents of ZMod n — the automorphic residues mod n — is exactly 2^ω(n), where ω(n) is the count of distinct prime factors of n. The proof packages the idempotent count as a multiplicative arithmetic function: numIdem 1 = 1, and for coprime m, n the Chinese Remainder isomorphism ZMod (mn) ≃+* ZMod m × ZMod n transports idempotents (the parent's idemCongr) and idempotents of a product split componentwise (idemProd), so numIdem (mn) = numIdem m · numIdem n. Evaluating a multiplicative function across the prime factorization (IsMultiplicative.multiplicative_factorization) reduces the count to the prime-power case, which the parent already settled — numIdem (p^k) = 2 for every prime p and k ≥ 1 — and the product of 2 over the ω(n) prime factors is 2^ω(n). The parent's 'exactly four mod 10^k' is recovered as the special case ω(10^k) = 2. This session also repaired a build regression in the parent file against Mathlib 4.26.0 (idemCongr was declared with a RingEquiv requiring an absent additive structure — corrected to a MulEquiv since idempotency is purely multiplicative — and Nat.dvd_sub' was renamed to Nat.dvd_sub).",
+  "meta": {
+    "author": "Lean Genius Researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AutomorphicNumberOQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "automorphic-numbers",
+      "idempotents",
+      "zmod",
+      "chinese-remainder-theorem",
+      "arithmetic-functions",
+      "multiplicative-functions",
+      "prime-factorization"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 135,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. All `decide` calls are kernel decisions on concrete finite data (the idempotent count of ZMod 1, and the union {2} ∪ {5} for the prime factors of 10). Results depend only on the standard foundational axioms propext / Classical.choice / Quot.sound; Classical.choice / Quot.sound enter via Nat.card / Real-free Fintype reasoning. Builds on the verified parent entry AutomorphicNumberOQ01.lean, reusing its idem_card_prime_pow, idemCongr, and idemProd.",
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.IsMultiplicative.multiplicative_factorization",
+        "description": "Evaluates a multiplicative arithmetic function f at n>0 as the product of f(p^k) over the prime factorization of n",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Defs"
+      },
+      {
+        "theorem": "ArithmeticFunction.IsMultiplicative.iff_ne_zero",
+        "description": "A function is multiplicative iff f(1)=1 and f(mn)=f(m)f(n) for coprime m,n≥1 — the convenient form used to verify numIdem is multiplicative",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Defs"
+      },
+      {
+        "theorem": "ZMod.chineseRemainder",
+        "description": "For coprime m,n the ring isomorphism ZMod (m*n) ≃+* ZMod m × ZMod n; coerced to a MulEquiv to transport idempotents",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.card_prod",
+        "description": "Nat.card (α × β) = Nat.card α * Nat.card β, giving componentwise multiplicativity of the idempotent count",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      },
+      {
+        "theorem": "Nat.card_congr",
+        "description": "An equivalence α ≃ β yields Nat.card α = Nat.card β, used to transport idempotent subtypes across CRT and the product splitting",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      },
+      {
+        "theorem": "Nat.support_factorization",
+        "description": "n.factorization.support = n.primeFactors, converting the factorization product index to the set of distinct primes",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.primeFactors_pow",
+        "description": "(n^k).primeFactors = n.primeFactors for k≠0, used to compute ω(10^k)=2 for the parent-recovery corollary",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      }
+    ],
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AutomorphicNumberOQ01"
+    ],
+    "opens": [
+      "Finset",
+      "AutomorphicNumberOQ01",
+      "ArithmeticFunction"
+    ],
+    "namespace": "AutomorphicNumberOQ01OQ01",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/AutomorphicNumberOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "idempotent_count",
+      "type": "headline",
+      "statement": "0 < n → Nat.card {e : ZMod n // e * e = e} = 2 ^ n.primeFactors.card",
+      "description": "The number of idempotents of ZMod n — equivalently the number of automorphic residues e²≡e (mod n) — is 2^ω(n), where ω(n) is the number of distinct primes dividing n.",
+      "significance": "The general law behind the parent's 'exactly four mod 10^k'. Four = 2^2 because 10 has exactly two distinct prime factors; the count is governed entirely by ω(n), not the size of n."
+    },
+    {
+      "name": "numIdem_eq_two_pow",
+      "type": "headline",
+      "statement": "0 < n → numIdem n = 2 ^ n.primeFactors.card",
+      "description": "Arithmetic-function form: the multiplicative function numIdem n = #{idempotents of ZMod n} evaluates to 2^ω(n) via factorization, since numIdem(p^k)=2 on every prime power.",
+      "significance": "Isolates the structural reason for the count: numIdem is a multiplicative arithmetic function whose only prime-power value is the constant 2."
+    },
+    {
+      "name": "automorphic_count_ten_pow",
+      "type": "headline",
+      "statement": "0 < k → Nat.card {e : ZMod (10 ^ k) // e * e = e} = 4",
+      "description": "Recovers the parent's count: since ω(10^k) = 2, the modulus 10^k has 2^2 = 4 automorphic residues — the four idempotents 0, 1, …5, …6.",
+      "significance": "Shows the general theorem specializes exactly to the classical decimal automorphic-number count, with the '4' explained as 2^(number of prime factors)."
+    },
+    {
+      "name": "numIdem_mul_coprime",
+      "type": "core",
+      "statement": "m ≠ 0 → n ≠ 0 → m.Coprime n → numIdem (m * n) = numIdem m * numIdem n",
+      "description": "Idempotent counts multiply across coprime moduli. The Chinese Remainder isomorphism ZMod (mn) ≃+* ZMod m × ZMod n transports idempotents (idemCongr) and a product's idempotents split componentwise (idemProd), giving the count via Nat.card_congr and Nat.card_prod.",
+      "significance": "The multiplicativity that makes the count a multiplicative arithmetic function; the engine behind the factorization reduction."
+    },
+    {
+      "name": "numIdem_isMultiplicative",
+      "type": "core",
+      "statement": "numIdem.IsMultiplicative",
+      "description": "numIdem is a multiplicative arithmetic function: numIdem 1 = 1 and numIdem(mn)=numIdem m · numIdem n for coprime m,n≥1, via IsMultiplicative.iff_ne_zero.",
+      "significance": "Unlocks IsMultiplicative.multiplicative_factorization, reducing the whole count to prime powers."
+    },
+    {
+      "name": "idempotent_count_prime_pow",
+      "type": "supporting",
+      "statement": "p.Prime → 0 < k → Nat.card {e : ZMod (p ^ k) // e * e = e} = 2",
+      "description": "The prime-power case: ZMod (p^k) has exactly two idempotents (0 and 1). Wraps the parent's idem_card_prime_pow into the Nat.card formulation.",
+      "significance": "The base case of the multiplicative evaluation; 2 = 2^1 = 2^ω(p^k), consistent with the general formula."
+    }
+  ],
+  "sections": [
+    {
+      "id": "numidem-definition",
+      "title": "Part I: The idempotent-count arithmetic function",
+      "startLine": 51,
+      "endLine": 76,
+      "summary": "numIdem n := (if n = 0 then 0 else Nat.card {e : ZMod n // e*e=e}) packaged as an ArithmeticFunction ℕ (value 0 at 0 by convention). numIdem_pos: for n≠0 the value is the honest idempotent count. numIdem_one: ZMod 1 is trivial so its single element is the only idempotent (count 1). numIdem_prime_pow: the count of a prime power is 2, reusing the parent's idem_card_prime_pow via Nat.card_eq_fintype_card.",
+      "mathContext": "Idempotents of ZMod n are exactly the automorphic residues e²≡e (mod n); counting them defines a function of n we will show is multiplicative."
+    },
+    {
+      "id": "multiplicativity",
+      "title": "Part II: Multiplicativity via Chinese Remainder",
+      "startLine": 77,
+      "endLine": 90,
+      "summary": "numIdem_mul_coprime: for coprime m,n≥1, the CRT MulEquiv ZMod (mn) ≃* ZMod m × ZMod n transports idempotents (idemCongr) and a product splits componentwise (idemProd), so Nat.card_congr + Nat.card_prod give numIdem(mn)=numIdem m · numIdem n. numIdem_isMultiplicative: assembles numIdem 1 = 1 with this into IsMultiplicative via iff_ne_zero.",
+      "mathContext": "By CRT an idempotent mod mn is a pair of idempotents (mod m, mod n); the count is therefore multiplicative on coprime arguments."
+    },
+    {
+      "id": "factorization-count",
+      "title": "Part III: Evaluating across the prime factorization",
+      "startLine": 91,
+      "endLine": 116,
+      "summary": "numIdem_eq_two_pow: IsMultiplicative.multiplicative_factorization writes numIdem n as the product of numIdem(p^k) over the factorization; each factor is 2 (numIdem_prime_pow on primes in the support), so the product of the constant 2 over the ω(n) prime factors is 2^ω(n) (Finset.prod_const, Nat.support_factorization). idempotent_count restates it as Nat.card of the idempotent subtype; idempotent_count_prime_pow is the ω=1 case.",
+      "mathContext": "A multiplicative function is determined by its prime-power values; numIdem is constantly 2 there, so numIdem n = 2^(#distinct primes of n)."
+    },
+    {
+      "id": "decimal-recovery",
+      "title": "Part IV: Recovering the classical decimal count",
+      "startLine": 117,
+      "endLine": 135,
+      "summary": "primeFactors_ten_pow: ω(10^k)=2 via Nat.primeFactors_pow then splitting 10 = 2·5 (Nat.primeFactors_mul, Nat.Prime.primeFactors). automorphic_count_ten_pow: substituting into idempotent_count gives 2^2 = 4 — the four classical automorphic residues 0, 1, …5, …6 mod 10^k.",
+      "mathContext": "The decimal '4' of the parent entry is exactly 2^ω(10^k) = 2^2; the same theorem gives 2 for any prime power, 8 for n with three prime factors, etc."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to the **automorphic-number-oq-01** entry, which proves `ZMod (10^k)` has exactly **four** idempotents — the four `k`-digit automorphic residues `n² ≡ n (mod 10^k)` (0, 1, …5, …6). This PR answers *why four*: it is `2² `, and the exponent `2` is the number of **distinct primes** dividing `10` (namely 2 and 5). The general law is proved:

> For every `n ≥ 1`, the number of idempotents of `ZMod n` — equivalently the number of automorphic residues mod `n` — is `2^ω(n)`, where `ω(n)` counts the distinct prime factors of `n`.

## Mathematical content (`AutomorphicNumberOQ01OQ01.lean`, 135 L, 10 thm + 1 def)

- **`idempotent_count`** (headline): `Nat.card {e : ZMod n // e*e=e} = 2 ^ n.primeFactors.card`.
- The count `numIdem n` is packaged as a **multiplicative arithmetic function**: `numIdem 1 = 1`, and for coprime `m, n` the Chinese Remainder iso `ZMod (mn) ≃* ZMod m × ZMod n` transports idempotents (parent's `idemCongr`) and a product's idempotents split componentwise (`idemProd`), so `numIdem (mn) = numIdem m · numIdem n`.
- `IsMultiplicative.multiplicative_factorization` evaluates it over the prime factorization; each prime power contributes `numIdem (p^k) = 2` (the parent's `idem_card_prime_pow`), and the product of `2` over the `ω(n)` factors is `2^ω(n)`.
- **`automorphic_count_ten_pow`**: recovers the classical `4 = 2^ω(10^k)`.

## Parent regression fix (`AutomorphicNumberOQ01.lean`)

The parent had **bit-rotted** against Mathlib 4.26.0 (no longer compiled). Repaired and re-verified:
- `idemCongr`/`idemProd` were stated for a `RingEquiv` (`≃+*`) under bare `[Mul R] [Mul S]`, which lacks the additive structure `RingEquiv` requires (elaborated to `sorry`). Since idempotency is purely multiplicative, switched to **`MulEquiv` (`≃*`)** — `RingEquiv` coerces via `.toMulEquiv`.
- `Nat.dvd_sub'` → `Nat.dvd_sub` (renamed upstream).
- The main theorem's modulus rewrite broke the dependent `NeZero` instance; replaced with an `Equiv.cast` transport along `ZMod (10^k) = ZMod (2^k·5^k)`.

## Status

**Outcome**: completed — verified, **0 sorries, 0 axioms** (kernel `decide` only, no `native_decide`).

**Files**
- `proofs/Proofs/AutomorphicNumberOQ01OQ01.lean` (new)
- `proofs/Proofs/AutomorphicNumberOQ01.lean` (regression fix)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/automorphic-number-oq-01-oq-01/{meta,annotations}.json`

**Next steps**: explicit structure of the two nontrivial idempotents (`a+b=1`, `ab=0`, complementary involution `e ↦ 1-e`); Hensel-lifting / projective-limit structure across `k`.

🤖 Generated by researcher-8