### PR TITLE
research(erdos-57-incomplete-01): bipartite ⟺ no odd closed walk — construction direction, axiom-free [verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1861,6 +1861,7 @@ import Proofs.Erdos577Problem
 import Proofs.Erdos578Problem
 import Proofs.Erdos579Problem
 import Proofs.Erdos57Aristotle
+import Proofs.Erdos57OddClosedWalk
 import Proofs.Erdos57Problem
 import Proofs.Erdos57ProblemAristotle
 import Proofs.Erdos580Problem

--- a/proofs/Proofs/Erdos57OddClosedWalk.lean
+++ b/proofs/Proofs/Erdos57OddClosedWalk.lean
@@ -1,0 +1,163 @@
+/-
+  Erdős Problem #57 — Companion: Odd Closed Walks and the Bipartite Characterization
+
+  Source: https://erdosproblems.com/57
+
+  The parent file `Proofs/Erdos57Problem.lean` axiomatizes the Liu–Montgomery (2020)
+  theorem and leaves one open `sorry`: the hard reverse direction of the bipartite
+  characterization `no odd cycle ⟹ 2-colorable`.  Mathlib itself lists this exact
+  statement as future work (`Mathlib.Combinatorics.SimpleGraph.Bipartite`: "Prove that
+  `G.IsBipartite` iff `G` does not contain an odd cycle").
+
+  This companion proves the genuinely hard *construction* direction in its clean
+  closed-walk form, fully and axiom-free:
+
+      `G.IsBipartite ↔ G has no odd closed walk`   (`isBipartite_iff_no_oddClosedWalk`)
+
+  * Forward (easy): a `Bool`-coloring forces every closed walk to have even length
+    (Mathlib's `Coloring.even_length_iff_congr`).
+  * Reverse (the construction): pick a base vertex in each connected component and color
+    every vertex by the parity of *some* walk back to its base.  Well-definedness of this
+    parity is exactly the hypothesis "no odd closed walk" (two walks with the same
+    endpoints close up into a closed walk, hence have equal parity), and an edge between
+    two equal-parity vertices would close up an odd walk — so the construction is a proper
+    2-coloring.
+
+  Consequences proved here (all 0-axiom):
+  * `oddCycle ⟹ has odd closed walk ⟹ ¬ bipartite`  (the easy obstruction direction,
+    relating back to the parent's `oddCycleLengths`), recovering
+    `oddCycleLengths_empty_of_isBipartite`;
+  * `has odd closed walk ⟹ 3 ≤ χ(G)`  (quantitative obstruction via Mathlib's
+    `Walk.three_le_chromaticNumber_of_odd_loop`).
+
+  The remaining gap to the parent's full *odd-cycle* characterization is now isolated to a
+  single purely combinatorial lemma — "every odd closed walk contains an odd cycle" —
+  which is NOT assumed anywhere below.
+-/
+
+import Mathlib
+import Proofs.Erdos57Problem
+
+open Set SimpleGraph
+
+namespace Erdos57
+
+variable {V : Type*} {G : SimpleGraph V}
+
+/-! ## Odd closed walks -/
+
+/-- `G` admits an *odd closed walk*: a walk `u → u` of odd length. -/
+def HasOddClosedWalk (G : SimpleGraph V) : Prop :=
+  ∃ (u : V) (p : G.Walk u u), Odd p.length
+
+/-- If `G` has no odd closed walk, then any two walks with the same endpoints have the
+same length parity: concatenating one with the reverse of the other yields a closed walk,
+which (by hypothesis) must have even length. -/
+theorem even_length_iff_of_noOddClosedWalk (h : ¬ HasOddClosedWalk G)
+    {x y : V} (p q : G.Walk x y) : Even p.length ↔ Even q.length := by
+  have hclosed : Even (p.length + q.length) := by
+    have hne : ¬ Odd (p.append q.reverse).length := fun hodd => h ⟨x, _, hodd⟩
+    rwa [Walk.length_append, Walk.length_reverse, Nat.not_odd_iff_even] at hne
+  exact Nat.even_add.mp hclosed
+
+/-! ## A canonical base vertex per connected component -/
+
+/-- A chosen representative vertex of `v`'s connected component. -/
+noncomputable def baseVertex (G : SimpleGraph V) (v : V) : V :=
+  (G.connectedComponentMk v).out
+
+theorem reachable_baseVertex (G : SimpleGraph V) (v : V) :
+    G.Reachable (baseVertex G v) v :=
+  ConnectedComponent.exact (G.connectedComponentMk v).out_eq
+
+/-- A chosen walk from `v`'s base vertex back to `v`. -/
+noncomputable def baseWalk (G : SimpleGraph V) (v : V) : G.Walk (baseVertex G v) v :=
+  (reachable_baseVertex G v).some
+
+/-! ## The parity 2-coloring -/
+
+/-- If `G` has no odd closed walk, the "parity of a walk to the base vertex" function is a
+proper `Bool`-coloring: adjacent vertices share a component, so their base vertices agree,
+and an edge between them would otherwise close up an odd walk. -/
+noncomputable def parityColoring (h : ¬ HasOddClosedWalk G) : G.Coloring Bool :=
+  Coloring.mk (fun v => decide (Odd (baseWalk G v).length)) <| by
+    intro u v hadj
+    -- Adjacent vertices lie in the same component, so their base vertices coincide.
+    have hcc : G.connectedComponentMk u = G.connectedComponentMk v :=
+      ConnectedComponent.connectedComponentMk_eq_of_adj hadj
+    have hbase : baseVertex G u = baseVertex G v := by
+      unfold baseVertex; rw [hcc]
+    -- Two walks `baseVertex u → v`: one through the edge `u-v`, one transported from `baseWalk v`.
+    have hpar :=
+      even_length_iff_of_noOddClosedWalk h
+        ((baseWalk G u).append (Walk.cons hadj Walk.nil))
+        ((baseWalk G v).copy hbase.symm rfl)
+    have hlen1 : ((baseWalk G u).append (Walk.cons hadj Walk.nil)).length
+        = (baseWalk G u).length + 1 := by simp [Walk.length_append]
+    have hlen2 : ((baseWalk G v).copy hbase.symm rfl).length
+        = (baseWalk G v).length := by simp [Walk.length_copy]
+    rw [hlen1, hlen2, Nat.even_add_one] at hpar
+    -- `hpar : ¬ Even (baseWalk u).length ↔ Even (baseWalk v).length`: opposite parities.
+    simp only [ne_eq, decide_eq_decide, ← Nat.not_even_iff_odd]
+    tauto
+
+/-! ## Bipartite ⟺ no odd closed walk -/
+
+/-- **Headline.** A simple graph is bipartite (2-colorable) iff it has no odd closed walk.
+
+The reverse direction is the component-wise parity construction (`parityColoring`); this is
+the direction Mathlib lists as future work for the odd-cycle version. -/
+theorem isBipartite_iff_no_oddClosedWalk (G : SimpleGraph V) :
+    G.IsBipartite ↔ ¬ HasOddClosedWalk G := by
+  constructor
+  · rintro ⟨c⟩ ⟨u, p, hodd⟩
+    -- Recolor the `Fin 2`-coloring to a `Bool`-coloring and apply the parity lemma.
+    have c' : G.Coloring Bool := G.recolorOfEquiv finTwoEquiv c
+    have hEven : Even p.length := (c'.even_length_iff_congr p).mpr Iff.rfl
+    exact (Nat.not_even_iff_odd.mpr hodd) hEven
+  · intro h
+    have hcol := (parityColoring h).colorable
+    rwa [Fintype.card_bool] at hcol
+
+/-! ## Consequences for odd cycles (the easy obstruction direction) -/
+
+/-- An odd cycle is in particular an odd closed walk. -/
+theorem hasOddClosedWalk_of_oddCycle {u : V} (c : G.Walk u u)
+    (_hc : c.IsCycle) (hodd : Odd c.length) : HasOddClosedWalk G :=
+  ⟨u, c, hodd⟩
+
+/-- If the set of odd cycle lengths is nonempty, then `G` has an odd closed walk. -/
+theorem hasOddClosedWalk_of_oddCycleLengths (hne : (oddCycleLengths G).Nonempty) :
+    HasOddClosedWalk G := by
+  obtain ⟨n, hn⟩ := hne
+  simp only [oddCycleLengths, cycleLengths, Set.mem_setOf_eq] at hn
+  obtain ⟨⟨u, p, _hp, hlen⟩, hodd⟩ := hn
+  exact ⟨u, p, by rw [hlen]; exact hodd⟩
+
+/-- If `G` has an odd cycle, it is not bipartite. -/
+theorem not_isBipartite_of_oddCycleLengths (hne : (oddCycleLengths G).Nonempty) :
+    ¬ G.IsBipartite := by
+  rw [isBipartite_iff_no_oddClosedWalk, not_not]
+  exact hasOddClosedWalk_of_oddCycleLengths hne
+
+/-- Forward direction of the parent's `bipartite_iff_no_odd_cycles`, recovered through the
+closed-walk framework: a bipartite graph has no odd cycles. -/
+theorem oddCycleLengths_empty_of_isBipartite (h : G.IsBipartite) :
+    oddCycleLengths G = ∅ := by
+  by_contra hne
+  exact not_isBipartite_of_oddCycleLengths (Set.nonempty_iff_ne_empty.mpr hne) h
+
+/-! ## Quantitative chromatic obstruction -/
+
+/-- A graph with an odd closed walk has chromatic number at least `3`. -/
+theorem three_le_chromaticNumber_of_hasOddClosedWalk (h : HasOddClosedWalk G) :
+    3 ≤ G.chromaticNumber := by
+  obtain ⟨u, p, hodd⟩ := h
+  exact p.three_le_chromaticNumber_of_odd_loop hodd
+
+/-- A graph with an odd cycle has chromatic number at least `3`. -/
+theorem three_le_chromaticNumber_of_oddCycleLengths
+    (hne : (oddCycleLengths G).Nonempty) : 3 ≤ G.chromaticNumber :=
+  three_le_chromaticNumber_of_hasOddClosedWalk (hasOddClosedWalk_of_oddCycleLengths hne)
+
+end Erdos57

--- a/src/data/proofs/erdos-57-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-57-incomplete-01/annotations.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "ann-57inc-header",
+    "proofId": "erdos-57-incomplete-01",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "concept",
+    "title": "Goal: the bipartite characterization, in closed-walk form",
+    "content": "The parent file `Proofs/Erdos57Problem.lean` axiomatizes the Liu–Montgomery (2020) theorem and leaves one open `sorry`: the hard reverse direction of the bipartite characterization, 'no odd cycle ⟹ 2-colorable'. Mathlib itself flags this exact statement as future work in `Mathlib.Combinatorics.SimpleGraph.Bipartite`.\n\nThis companion proves the genuinely hard *construction* direction in its clean closed-walk form, fully axiom-free:\n\n    G.IsBipartite ↔ G has no odd closed walk.\n\nThe odd-closed-walk version is the 'right' intermediate result: its construction direction is exactly the deferred half, while the odd-CYCLE version additionally needs the combinatorial lemma 'every odd closed walk contains an odd cycle' — which is assumed nowhere here."
+  },
+  {
+    "id": "ann-57inc-hasoddwalk",
+    "proofId": "erdos-57-incomplete-01",
+    "range": { "startLine": 47, "endLine": 61 },
+    "type": "definition",
+    "title": "Odd closed walks and parity well-definedness",
+    "content": "`HasOddClosedWalk G` asserts the existence of a walk `u → u` of odd length.\n\nThe key technical lemma `even_length_iff_of_noOddClosedWalk` says: if `G` has no odd closed walk, then any two walks `p, q : G.Walk x y` with the same endpoints have the same length parity. Proof: `p.append q.reverse` is a closed walk at `x` of length `p.length + q.length`; by hypothesis it cannot be odd, hence is even, hence the two summands share parity (`Nat.even_add`). This is exactly the well-definedness that makes the parity coloring legitimate."
+  },
+  {
+    "id": "ann-57inc-base",
+    "proofId": "erdos-57-incomplete-01",
+    "range": { "startLine": 63, "endLine": 75 },
+    "type": "definition",
+    "title": "A base vertex per connected component",
+    "content": "`baseVertex G v := (G.connectedComponentMk v).out` selects a canonical representative of `v`'s connected component using `ConnectedComponent.out`. Since `out_eq` gives `connectedComponentMk (baseVertex v) = connectedComponentMk v`, `ConnectedComponent.exact` yields `reachable_baseVertex : G.Reachable (baseVertex G v) v`. The chosen witness walk `baseWalk G v : G.Walk (baseVertex G v) v` is `(reachable_baseVertex G v).some`."
+  },
+  {
+    "id": "ann-57inc-coloring",
+    "proofId": "erdos-57-incomplete-01",
+    "range": { "startLine": 77, "endLine": 102 },
+    "type": "proof",
+    "title": "The parity 2-coloring (the construction Mathlib defers)",
+    "content": "`parityColoring h` colors each vertex `v` by `decide (Odd (baseWalk G v).length)` — the parity of a walk back to its component's base vertex. Validity (adjacent vertices get different colors): for `G.Adj u v`, both lie in the same component, so `baseVertex G u = baseVertex G v`. Forming two walks `baseVertex u → v` — one through the edge `u-v` (length `(baseWalk u).length + 1`), one transported from `baseWalk v` via `Walk.copy` (length `(baseWalk v).length`) — the parity lemma forces these to share parity, i.e. `(baseWalk u).length` and `(baseWalk v).length` have OPPOSITE parity. Hence the two `decide (Odd …)` values differ. This is the component-wise walk-parity construction, in full and axiom-free."
+  },
+  {
+    "id": "ann-57inc-headline",
+    "proofId": "erdos-57-incomplete-01",
+    "range": { "startLine": 104, "endLine": 120 },
+    "type": "theorem",
+    "title": "Headline: IsBipartite ⟺ no odd closed walk",
+    "content": "`isBipartite_iff_no_oddClosedWalk`. Forward (easy): from a `Fin 2`-coloring, recolor to `Bool` and apply `Coloring.even_length_iff_congr` at a closed walk (`c u ↔ c u` trivially) to force even length, contradicting an odd closed walk. Reverse (the construction): `parityColoring h` is a `Bool`-coloring, so `(parityColoring h).colorable` gives `Colorable (Fintype.card Bool) = Colorable 2 = IsBipartite`. This is the bipartite characterization's hard half, proved completely."
+  },
+  {
+    "id": "ann-57inc-cycles",
+    "proofId": "erdos-57-incomplete-01",
+    "range": { "startLine": 122, "endLine": 148 },
+    "type": "theorem",
+    "title": "Odd cycles obstruct bipartiteness (easy direction)",
+    "content": "An odd cycle is in particular an odd closed walk (`hasOddClosedWalk_of_oddCycle`), so a nonempty `oddCycleLengths G` yields an odd closed walk (`hasOddClosedWalk_of_oddCycleLengths`). Composing with the headline gives `not_isBipartite_of_oddCycleLengths` (odd cycle ⟹ not bipartite) and, contrapositively, `oddCycleLengths_empty_of_isBipartite` — recovering the parent's forward direction of `bipartite_iff_no_odd_cycles` through the closed-walk framework."
+  },
+  {
+    "id": "ann-57inc-chromatic",
+    "proofId": "erdos-57-incomplete-01",
+    "range": { "startLine": 150, "endLine": 163 },
+    "type": "theorem",
+    "title": "Quantitative obstruction: χ(G) ≥ 3",
+    "content": "`three_le_chromaticNumber_of_hasOddClosedWalk` upgrades the qualitative obstruction to a bound: an odd closed walk forces `3 ≤ G.chromaticNumber`, via Mathlib's `Walk.three_le_chromaticNumber_of_odd_loop`. Specializing to cycles, an odd cycle forces `χ(G) ≥ 3` (`three_le_chromaticNumber_of_oddCycleLengths`). The remaining gap to the parent's full odd-cycle characterization is now isolated to the single combinatorial lemma 'every odd closed walk contains an odd cycle', assumed nowhere here."
+  }
+]

--- a/src/data/proofs/erdos-57-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-57-incomplete-01/meta.json
@@ -1,0 +1,101 @@
+{
+  "id": "erdos-57-incomplete-01",
+  "title": "Erdős #57 Companion: Odd Closed Walks and the Bipartite Characterization",
+  "slug": "erdos-57-incomplete-01",
+  "description": "An axiom-free companion to Erdős #57 proving the hard construction direction of the bipartite characterization in its closed-walk form: a simple graph is bipartite iff it has no odd closed walk. The reverse direction is the component-wise parity 2-coloring — the exact step Mathlib lists as future work — and the easy direction recovers 'bipartite ⟹ no odd cycle'.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/57",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos57OddClosedWalk.lean",
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "chromatic-number",
+      "bipartite",
+      "odd-cycles",
+      "connectivity",
+      "combinatorics"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 57,
+    "erdosUrl": "https://erdosproblems.com/57",
+    "erdosProblemStatus": "solved",
+    "axiomCount": 0,
+    "lineCount": 163,
+    "assumptions": "None. Fully machine-checked; the five headline results depend only on the foundational axioms propext / Classical.choice / Quot.sound. The parent's `erdos_57` axiom and `sorry` are NOT used.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 4,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #57 (Erdős–Hajnal 1966, solved by Liu–Montgomery 2020) concerns the divergence of the reciprocal sum of odd cycle lengths in graphs of infinite chromatic number. Its foundation is the classical bipartite characterization: a graph is 2-colorable iff it contains no odd cycle. The parent formalization (`Proofs/Erdos57Problem.lean`) axiomatizes the deep Liu–Montgomery theorem and proves the easy direction of the bipartite characterization, but leaves the hard reverse direction (no odd cycle ⟹ 2-colorable) as its single open `sorry`. Notably, Mathlib itself lists this exact statement as future work in `Mathlib.Combinatorics.SimpleGraph.Bipartite`: 'Prove that G.IsBipartite iff G does not contain an odd cycle.' This companion supplies the genuinely hard construction direction in its clean and complete closed-walk form, fully axiom-free.",
+    "problemStatement": "A simple graph $G$ is bipartite (2-colorable) if and only if it has no closed walk of odd length: $G.\\mathrm{IsBipartite} \\iff \\neg\\, \\exists u,\\ \\exists p : G.\\mathrm{Walk}\\ u\\ u,\\ \\mathrm{Odd}\\ (\\mathrm{length}\\ p)$.",
+    "text": "A simple graph is bipartite iff it has no odd closed walk. The reverse direction is the component-wise parity 2-coloring; the forward direction and the odd-cycle obstruction follow. This isolates the parent's remaining gap to a single combinatorial lemma.",
+    "proofStrategy": "The forward direction (bipartite ⟹ no odd closed walk) is the parity argument: a Bool-coloring forces every closed walk to have even length (Mathlib's `Coloring.even_length_iff_congr`). The reverse direction (no odd closed walk ⟹ bipartite) is the construction Mathlib defers: choose a base vertex per connected component via `ConnectedComponent.out`, and color each vertex by the parity of the length of some walk back to its base (`parityColoring`). Well-definedness of the parity is exactly the no-odd-closed-walk hypothesis (`even_length_iff_of_noOddClosedWalk`: two walks with the same endpoints concatenate to a closed walk, hence have equal parity), and an edge between equal-parity endpoints would close up an odd walk — so the coloring is proper. The single basepoint mismatch for adjacent vertices is handled by transporting one walk with `Walk.copy`. Consequences: an odd cycle is an odd closed walk, so odd cycles obstruct bipartiteness (`not_isBipartite_of_oddCycleLengths`) and force χ(G) ≥ 3 via Mathlib's `Walk.three_le_chromaticNumber_of_odd_loop`. The framework recovers the parent's forward bipartite direction (`oddCycleLengths_empty_of_isBipartite`).",
+    "keyInsights": [
+      "The right intermediate object is the odd CLOSED WALK, not the odd cycle: bipartiteness is equivalent to having no odd closed walk, and this equivalence has a fully constructive proof, whereas the odd-cycle version additionally requires the combinatorial fact that every odd closed walk contains an odd cycle.",
+      "The reverse (construction) direction is the genuinely hard half and is exactly what Mathlib lists as future work — here it is proved in full, 0-axiom, by the component-wise walk-parity 2-coloring.",
+      "Parity well-definedness is precisely the no-odd-closed-walk hypothesis: any two walks between the same endpoints differ by a closed walk, which must be even, so the parity coloring is unambiguous.",
+      "The easy obstruction direction is recovered for free: an odd cycle is in particular an odd closed walk, giving both 'odd cycle ⟹ not bipartite' and the quantitative 'odd cycle ⟹ χ(G) ≥ 3'.",
+      "The remaining gap to the parent's full odd-cycle characterization is now isolated to a single purely combinatorial lemma — 'every odd closed walk contains an odd cycle' — which is assumed nowhere in this file."
+    ],
+    "prerequisites": [
+      "Graph theory: walks, closed walks, cycles, proper colorings, bipartite graphs",
+      "Connected components and reachability in simple graphs",
+      "Parity arguments (Even/Odd of natural numbers)"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos57Problem"
+    ],
+    "opens": [
+      "Set",
+      "SimpleGraph"
+    ],
+    "namespace": "Erdos57",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 4,
+    "path": "Proofs/Erdos57OddClosedWalk.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul; Hajnal, András",
+      "title": "On chromatic number of graphs and set-systems",
+      "year": "1966",
+      "venue": "Acta Mathematica Academiae Scientiarum Hungaricae, vol. 17, pp. 61–99",
+      "note": "Original conjecture behind Erdős #57; the bipartite characterization (χ ≤ 2 iff no odd cycle) is the base case of the cycle-richness hierarchy."
+    },
+    {
+      "authors": "Liu, Hong; Montgomery, Richard",
+      "title": "A solution to Erdős and Hajnal's odd cycle problem",
+      "year": "2020",
+      "venue": "Journal of the American Mathematical Society",
+      "note": "Solved Erdős #57. Axiomatized as `erdos_57` in the parent file; not used here."
+    },
+    {
+      "authors": "Mathlib Community",
+      "title": "Mathlib.Combinatorics.SimpleGraph.Bipartite",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "note": "Lists 'Prove that G.IsBipartite iff G does not contain an odd cycle' as future work — the construction direction proved here in closed-walk form."
+    }
+  ],
+  "sorries": 0,
+  "crossReferences": [
+    {
+      "targetId": "erdos-57",
+      "relationship": "extends",
+      "description": "Parent problem. This companion proves the hard construction direction of the bipartite characterization (the parent's single open `sorry`) in its closed-walk form, axiom-free, and recovers the parent's easy forward direction."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Companion to **Erdős Problem #57** (`Proofs/Erdos57Problem.lean`). The parent axiomatizes the deep Liu–Montgomery (2020) theorem and leaves **one open `sorry`**: the hard reverse direction of the bipartite characterization, *no odd cycle ⟹ 2-colorable*. Mathlib itself lists this exact statement as **future work** (`Mathlib.Combinatorics.SimpleGraph.Bipartite`).

This PR proves the genuinely hard **construction** direction in its clean closed-walk form, fully **axiom-free**:

```
G.IsBipartite ↔ G has no odd closed walk        (isBipartite_iff_no_oddClosedWalk)
```

### Proof
- **Forward (easy):** a `Bool`-coloring forces every closed walk to have even length (`Coloring.even_length_iff_congr`).
- **Reverse (the deferred half):** the component-wise **parity 2-coloring** (`parityColoring`). Pick a base vertex per connected component (`ConnectedComponent.out`) and color each vertex by the parity of *some* walk back to its base. Well-definedness of that parity is *exactly* the no-odd-closed-walk hypothesis (`even_length_iff_of_noOddClosedWalk`: two walks with the same endpoints concatenate to a closed walk, hence share parity), and an edge between equal-parity endpoints would close up an odd walk. The single basepoint mismatch for adjacent vertices is handled with `Walk.copy`.

### Consequences (all 0-axiom)
- `not_isBipartite_of_oddCycleLengths`: an odd cycle is an odd closed walk ⟹ not bipartite.
- `oddCycleLengths_empty_of_isBipartite`: recovers the parent's **forward** direction of `bipartite_iff_no_odd_cycles` through the closed-walk framework.
- `three_le_chromaticNumber_of_hasOddClosedWalk`: quantitative obstruction `χ(G) ≥ 3` via Mathlib's `Walk.three_le_chromaticNumber_of_odd_loop`.

### Honest scope
This does **not** close the parent's odd-*cycle* `sorry`. The remaining gap is now isolated to a single purely combinatorial lemma — *"every odd closed walk contains an odd cycle"* — which is **assumed nowhere** in this file. The closed-walk equivalence proved here is the constructively-complete intermediate result.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos57OddClosedWalk` — builds clean.
- 163 lines, 9 theorems / 4 definitions, **0 sorry, 0 axiom**.
- `#print axioms` on all five headline results: only `[propext, Classical.choice, Quot.sound]`. The parent's `erdos_57` axiom and `sorry` are **not** used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)