### PR TITLE
research(chinese-remainder-constructive-oq-03-oq-01): optimality of prime RNS bases for all k [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -630,6 +630,7 @@ import Proofs.ChebyshevSumMonotoneOQ01
 import Proofs.ChevalleyWarningTheoremOQ01
 import Proofs.ChineseRemainderConstructive
 import Proofs.ChineseRemainderConstructiveOQ03
+import Proofs.ChineseRemainderConstructiveOQ03OQ01
 import Proofs.ChineseRemainderConstructiveOQ03OQ03
 import Proofs.ChineseRemainderConstructiveOQ04
 import Proofs.ChineseRemainderConstructiveOQ04OQ02

--- a/proofs/Proofs/ChineseRemainderConstructiveOQ03OQ01.lean
+++ b/proofs/Proofs/ChineseRemainderConstructiveOQ03OQ01.lean
@@ -1,0 +1,275 @@
+/-
+  Chinese Remainder Theorem — OQ-03-OQ-01:
+  Optimality of prime RNS bases for ALL k (not just k ≤ 6)
+
+  The parent file `ChineseRemainderConstructiveOQ03` formalizes efficient
+  Residue Number System (RNS) bases. There the "primorial" — the product of
+  the first k primes, which is the dynamic range of the k-channel prime base —
+  is a *lookup table* defined only for k ≤ 6:
+
+      def primorial : ℕ → ℕ
+        | 0 => 1 | 1 => 2 | 2 => 6 | 3 => 30 | 4 => 210 | 5 => 2310 | 6 => 30030
+        | _ => 0
+
+  and the growth bound `primorial k ≥ 2^k` is proved by `interval_cases`,
+  valid only for 1 ≤ k ≤ 6. The parent docstring states the bound holds for all
+  k "but proving it generally requires a proper definition of the k-th prime."
+
+  This file supplies exactly that proper definition, using Mathlib's `Nat.nth`
+  (the n-th element of an infinite set), and proves the optimality-relevant
+  facts for ALL k:
+
+  * `kthPrime i = Nat.nth Nat.Prime i` — the i-th prime (0-indexed), defined
+    for every i, with `kthPrime` prime, ≥ 2, strictly monotone, injective.
+  * `primorialProper k = ∏ first k primes` — defined for every k.
+  * `primorialProper_ge_two_pow : 2^k ≤ primorialProper k` for ALL k.
+  * `primorialProper_strictMono` — the dynamic range strictly increases in k.
+  * The first-k-primes list is pairwise coprime and bounded below by 2 for
+    every k, hence yields a genuine `RNSBase` with k channels and dynamic
+    range ≥ 2^k for ALL k (`firstPrimeBase`).
+  * Cross-check: the proper primorial reproduces the classical primorial values
+    `1, 2, 6, 30, 210, 2310, 30030` for k = 0..6.
+
+  This does NOT settle the deeper open question of *full* optimality of prime
+  bases (that consecutive primes maximize the dynamic range subject to a width
+  budget under all coprimality decompositions) — that remains open. What is
+  delivered is the all-k generalization of the growth lower bound, the missing
+  piece the parent explicitly deferred.
+
+  NOTE: the parent file `ChineseRemainderConstructiveOQ03.lean` no longer
+  compiles against the current Mathlib (4.26.0) — it has bit-rotted. So this
+  file is deliberately SELF-CONTAINED: it re-declares a minimal `RNSBase`
+  structure rather than importing the parent, and cross-checks the primorial
+  values against the classical sequence directly.
+
+  Status: VERIFIED
+  Axioms: 0
+  Sorries: 0
+
+  References:
+  [Gar59] Garner "The residue number system" (1959)
+  [SS67] Szabó-Tanaka "Residue Arithmetic and Its Applications" (1967)
+
+  Tags: number-theory, modular-arithmetic, algorithms, prime-counting, classical
+-/
+
+import Mathlib
+
+namespace RNSBasesAllK
+
+open Nat
+
+-- ============================================================
+-- SECTION 0: Minimal RNS base (self-contained re-declaration)
+-- ============================================================
+
+/-- An RNS base: a list of pairwise coprime moduli, all ≥ 2.
+    (Mirrors the parent's `RNSBases.RNSBase`, re-declared here because the
+    parent file no longer compiles against the current Mathlib.) -/
+structure RNSBase where
+  moduli : List ℕ
+  coprime : moduli.Pairwise Nat.Coprime
+  ge_two : ∀ m ∈ moduli, m ≥ 2
+
+/-- Number of channels (moduli). -/
+def RNSBase.channels (b : RNSBase) : ℕ := b.moduli.length
+
+/-- Dynamic range: product of all moduli. -/
+def RNSBase.dynamicRange (b : RNSBase) : ℕ := b.moduli.prod
+
+-- ============================================================
+-- SECTION I: A proper k-th prime, defined for all k
+-- ============================================================
+
+/-- The `i`-th prime (0-indexed): `kthPrime 0 = 2`, `kthPrime 1 = 3`, ….
+    Uses Mathlib's `Nat.nth`, the enumerator of the infinite set of primes,
+    so it is total: defined for every `i : ℕ`. -/
+noncomputable def kthPrime (i : ℕ) : ℕ := Nat.nth Nat.Prime i
+
+/-- Every `kthPrime i` is prime. -/
+theorem kthPrime_prime (i : ℕ) : (kthPrime i).Prime := Nat.prime_nth_prime i
+
+/-- Every `kthPrime i` is at least 2. -/
+theorem kthPrime_two_le (i : ℕ) : 2 ≤ kthPrime i := (kthPrime_prime i).two_le
+
+/-- Every `kthPrime i` is positive. -/
+theorem kthPrime_pos (i : ℕ) : 0 < kthPrime i := (kthPrime_prime i).pos
+
+/-- The prime enumerator is strictly monotone (primes are infinite). -/
+theorem kthPrime_strictMono : StrictMono kthPrime :=
+  Nat.nth_strictMono Nat.infinite_setOf_prime
+
+/-- Distinct indices give distinct primes. -/
+theorem kthPrime_injective : Function.Injective kthPrime :=
+  kthPrime_strictMono.injective
+
+/-- Characterization: the `(count Prime n)`-th prime is `n`, for prime `n`. -/
+theorem kthPrime_count {n : ℕ} (hn : n.Prime) :
+    kthPrime (Nat.count Nat.Prime n) = n :=
+  Nat.nth_count hn
+
+theorem kthPrime_zero : kthPrime 0 = 2 := by
+  have hc : Nat.count Nat.Prime 2 = 0 := by decide
+  have h := kthPrime_count (n := 2) (by norm_num)
+  rwa [hc] at h
+
+theorem kthPrime_one : kthPrime 1 = 3 := by
+  have hc : Nat.count Nat.Prime 3 = 1 := by decide
+  have h := kthPrime_count (n := 3) (by norm_num)
+  rwa [hc] at h
+
+theorem kthPrime_two : kthPrime 2 = 5 := by
+  have hc : Nat.count Nat.Prime 5 = 2 := by decide
+  have h := kthPrime_count (n := 5) (by norm_num)
+  rwa [hc] at h
+
+theorem kthPrime_three : kthPrime 3 = 7 := by
+  have hc : Nat.count Nat.Prime 7 = 3 := by decide
+  have h := kthPrime_count (n := 7) (by norm_num)
+  rwa [hc] at h
+
+theorem kthPrime_four : kthPrime 4 = 11 := by
+  have hc : Nat.count Nat.Prime 11 = 4 := by decide
+  have h := kthPrime_count (n := 11) (by norm_num)
+  rwa [hc] at h
+
+theorem kthPrime_five : kthPrime 5 = 13 := by
+  have hc : Nat.count Nat.Prime 13 = 5 := by decide
+  have h := kthPrime_count (n := 13) (by norm_num)
+  rwa [hc] at h
+
+-- ============================================================
+-- SECTION II: The proper primorial, defined for all k
+-- ============================================================
+
+/-- The first `k` primes, as a list: `[kthPrime 0, …, kthPrime (k-1)]`. -/
+noncomputable def firstPrimes (k : ℕ) : List ℕ := (List.range k).map kthPrime
+
+/-- The proper primorial: the product of the first `k` primes.
+    Unlike the parent's lookup table, this is defined for EVERY `k`. -/
+noncomputable def primorialProper (k : ℕ) : ℕ := (firstPrimes k).prod
+
+theorem firstPrimes_succ (k : ℕ) :
+    firstPrimes (k + 1) = firstPrimes k ++ [kthPrime k] := by
+  unfold firstPrimes
+  rw [List.range_succ, List.map_append]
+  rfl
+
+theorem primorialProper_zero : primorialProper 0 = 1 := by
+  unfold primorialProper firstPrimes; simp
+
+/-- The defining recurrence: each step multiplies by the next prime. -/
+theorem primorialProper_succ (k : ℕ) :
+    primorialProper (k + 1) = primorialProper k * kthPrime k := by
+  unfold primorialProper
+  rw [firstPrimes_succ, List.prod_append]
+  simp
+
+/-- The proper primorial is always positive. -/
+theorem primorialProper_pos : ∀ k, 0 < primorialProper k
+  | 0 => by simp [primorialProper, firstPrimes]
+  | (k + 1) => by
+      rw [primorialProper_succ]
+      exact Nat.mul_pos (primorialProper_pos k) (kthPrime_pos k)
+
+/-- **Main result.** The growth lower bound `2^k ≤ primorialProper k` holds for
+    ALL `k`, generalizing the parent's `interval_cases` proof for k ≤ 6.
+    Each of the `k` prime factors is at least 2, so the product dominates `2^k`. -/
+theorem primorialProper_ge_two_pow : ∀ k, 2 ^ k ≤ primorialProper k
+  | 0 => by simp [primorialProper, firstPrimes]
+  | (k + 1) => by
+      rw [pow_succ, primorialProper_succ]
+      exact Nat.mul_le_mul (primorialProper_ge_two_pow k) (kthPrime_two_le k)
+
+/-- The dynamic range of the k-channel prime base strictly increases with `k`. -/
+theorem primorialProper_strictMono : StrictMono primorialProper := by
+  apply strictMono_nat_of_lt_succ
+  intro k
+  rw [primorialProper_succ]
+  have h1 := primorialProper_pos k
+  have h2 := kthPrime_two_le k
+  calc primorialProper k < primorialProper k * 2 := by omega
+    _ ≤ primorialProper k * kthPrime k := Nat.mul_le_mul (le_refl _) h2
+
+/-- Consequence: the dynamic range is unbounded — for every target `M` there is
+    a number of channels `k` whose prime base exceeds it. -/
+theorem primorialProper_unbounded (M : ℕ) : ∃ k, M < primorialProper k :=
+  ⟨M + 1, lt_of_lt_of_le (by have := Nat.lt_two_pow_self (n := M + 1); omega)
+    (primorialProper_ge_two_pow (M + 1))⟩
+
+-- ============================================================
+-- SECTION III: Cross-check against the parent lookup table
+-- ============================================================
+
+/-- Cross-check: the proper primorial reproduces the classical primorial
+    sequence `1, 2, 6, 30, 210, 2310, 30030` for `k = 0, …, 6`. This confirms
+    the all-`k` definition specializes correctly to the parent's lookup table. -/
+theorem primorialProper_values :
+    primorialProper 0 = 1 ∧ primorialProper 1 = 2 ∧ primorialProper 2 = 6 ∧
+    primorialProper 3 = 30 ∧ primorialProper 4 = 210 ∧
+    primorialProper 5 = 2310 ∧ primorialProper 6 = 30030 := by
+  refine ⟨primorialProper_zero, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    simp [primorialProper_succ, primorialProper_zero,
+      kthPrime_zero, kthPrime_one, kthPrime_two, kthPrime_three,
+      kthPrime_four, kthPrime_five]
+
+-- ============================================================
+-- SECTION IV: The prime RNS base, valid for all k
+-- ============================================================
+
+/-- Every modulus in `firstPrimes k` is at least 2. -/
+theorem firstPrimes_ge_two {k m : ℕ} (hm : m ∈ firstPrimes k) : 2 ≤ m := by
+  unfold firstPrimes at hm
+  rw [List.mem_map] at hm
+  obtain ⟨i, _, rfl⟩ := hm
+  exact kthPrime_two_le i
+
+/-- The first `k` primes are pairwise coprime — for EVERY `k`.
+    (Parent only checked specific small lists like `[2,3,5]`, `[2,3,5,7,11,13]`.) -/
+theorem firstPrimes_pairwise_coprime (k : ℕ) :
+    (firstPrimes k).Pairwise Nat.Coprime := by
+  unfold firstPrimes
+  refine (List.pairwise_lt_range (n := k)).map kthPrime (fun a b hab => ?_)
+  exact (Nat.coprime_primes (kthPrime_prime a) (kthPrime_prime b)).mpr
+    (fun h => (Nat.ne_of_lt hab) (kthPrime_injective h))
+
+/-- The genuine RNS base on the first `k` primes — valid for every `k`. -/
+noncomputable def firstPrimeBase (k : ℕ) : RNSBase where
+  moduli := firstPrimes k
+  coprime := firstPrimes_pairwise_coprime k
+  ge_two := fun _ hm => firstPrimes_ge_two hm
+
+/-- The prime base has exactly `k` channels. -/
+theorem firstPrimeBase_channels (k : ℕ) : (firstPrimeBase k).channels = k := by
+  unfold RNSBase.channels firstPrimeBase firstPrimes
+  simp
+
+/-- Its dynamic range is the proper primorial. -/
+theorem firstPrimeBase_dynamicRange (k : ℕ) :
+    (firstPrimeBase k).dynamicRange = primorialProper k := rfl
+
+/-- **Optimality bound for all k.** For every number of channels `k`, the
+    first-`k`-primes RNS base achieves dynamic range at least `2^k`. This is the
+    all-`k` generalization of the parent's `primorial_growth_lower` (k ≤ 6). -/
+theorem firstPrimeBase_dynamicRange_ge_two_pow (k : ℕ) :
+    2 ^ k ≤ (firstPrimeBase k).dynamicRange := by
+  rw [firstPrimeBase_dynamicRange]
+  exact primorialProper_ge_two_pow k
+
+-- ============================================================
+-- SECTION V: Summary
+-- ============================================================
+
+/-- Capstone: for every `k`, there is a valid RNS base with exactly `k`
+    channels whose dynamic range is at least `2^k`. The k-th prime is given by
+    a total, proper definition (`Nat.nth Nat.Prime`), settling the all-`k`
+    growth bound the parent file deferred. -/
+theorem prime_base_growth_all_k (k : ℕ) :
+    (firstPrimeBase k).channels = k ∧ 2 ^ k ≤ (firstPrimeBase k).dynamicRange :=
+  ⟨firstPrimeBase_channels k, firstPrimeBase_dynamicRange_ge_two_pow k⟩
+
+#check @prime_base_growth_all_k
+#check @primorialProper_ge_two_pow
+#check @primorialProper_values
+
+end RNSBasesAllK

--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-01/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-kth-prime-def",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-01",
+    "range": {
+      "startLine": 84,
+      "endLine": 104
+    },
+    "type": "insight",
+    "title": "A Total k-th Prime via Nat.nth",
+    "content": "`kthPrime i := Nat.nth Nat.Prime i` defines the i-th prime (0-indexed) for EVERY i, replacing the parent's lookup table that was only defined for k ≤ 6. `Nat.nth p` enumerates the elements of `{n | p n}` in increasing order, so for the infinite set of primes it is total. From `Nat.prime_nth_prime` we get `(kthPrime i).Prime`, hence `2 ≤ kthPrime i` and `0 < kthPrime i`. Strict monotonicity comes from `Nat.nth_strictMono Nat.infinite_setOf_prime`, and injectivity from `StrictMono.injective`.",
+    "mathContext": "The map $i \\mapsto p_i$ (the $i$-th prime) is a total, strictly increasing function $\\mathbb{N} \\to \\mathbb{N}$. Mathlib realizes it as `Nat.nth Nat.Prime`, the order-isomorphism between $\\mathbb{N}$ and the infinite set $\\{p : p \\text{ prime}\\}$. Totality is exactly what the parent file lacked: its `primorial` was a finite case table, so it could only state the growth bound for $k \\le 6$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.nth",
+      "Nat.prime_nth_prime",
+      "Nat.nth_strictMono",
+      "Nat.infinite_setOf_prime"
+    ],
+    "prerequisites": [
+      "Mathlib.Data.Nat.Nth",
+      "Mathlib.Data.Nat.PrimeFin"
+    ]
+  },
+  {
+    "id": "ann-small-prime-values",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-01",
+    "range": {
+      "startLine": 106,
+      "endLine": 139
+    },
+    "type": "technique",
+    "title": "Pinning Small Prime Values 0-Axiom (No native_decide)",
+    "content": "`kthPrime 0..5 = 2,3,5,7,11,13` are proved without native_decide, keeping the file free of `Lean.ofReduceBool`. The characterization `Nat.nth_count : p n → Nat.nth p (Nat.count p n) = n` says the `(count Prime n)`-th prime is `n`. For each concrete prime `n`, `Nat.count Nat.Prime n` (the number of primes below `n`) reduces under kernel `decide`, so e.g. `Nat.count Nat.Prime 7 = 3` gives `kthPrime 3 = 7`.",
+    "mathContext": "`Nat.count p n` counts how many $m < n$ satisfy $p$, and for prime $n$ this count is exactly the index of $n$ in the prime enumeration. Using kernel `decide` (not `native_decide`) means the reductions are checked by the Lean kernel itself, so `#print axioms` reports only `propext, Classical.choice, Quot.sound` — the proof is genuinely axiom-free.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.nth_count",
+      "Nat.count",
+      "kernel decide vs native_decide"
+    ],
+    "prerequisites": [
+      "Mathlib.Data.Nat.Nth"
+    ]
+  },
+  {
+    "id": "ann-growth-bound",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-01",
+    "range": {
+      "startLine": 175,
+      "endLine": 182
+    },
+    "type": "insight",
+    "title": "The All-k Growth Bound 2^k ≤ primorialProper k",
+    "content": "`primorialProper_ge_two_pow` proves `2^k ≤ primorialProper k` for EVERY k — the main deliverable, generalizing the parent's `interval_cases` proof for k ≤ 6. The whole argument is a two-line induction: the recurrence `primorialProper (k+1) = primorialProper k · kthPrime k` and `pow_succ` reduce the step to `2^k · 2 ≤ primorialProper k · kthPrime k`, which is `Nat.mul_le_mul` applied to the induction hypothesis and `2 ≤ kthPrime k`.",
+    "mathContext": "The $k$-th primorial $p_1 p_2 \\cdots p_k$ is a product of $k$ factors each $\\ge 2$, so it dominates $2^k$. In RNS terms: a $k$-channel prime base has dynamic range at least $2^k$, i.e. at least $k$ bits of range — uniformly in $k$, not just for the small tabulated bases. The parent file explicitly deferred this 'to a proper definition of the k-th prime'; here it is a corollary of that definition.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.mul_le_mul",
+      "pow_succ",
+      "primorial"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "product recurrence primorialProper_succ"
+    ]
+  },
+  {
+    "id": "ann-pairwise-coprime",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-01",
+    "range": {
+      "startLine": 229,
+      "endLine": 235
+    },
+    "type": "insight",
+    "title": "First k Primes are Pairwise Coprime for Every k",
+    "content": "`firstPrimes_pairwise_coprime` proves the list `[kthPrime 0, …, kthPrime (k-1)]` is `Pairwise Nat.Coprime` for EVERY k. `List.pairwise_lt_range` gives that `List.range k` is pairwise `<`, and `List.Pairwise.map` transports it along `kthPrime`: for `a < b`, injectivity makes `kthPrime a ≠ kthPrime b`, and `Nat.coprime_primes` turns distinctness of two primes into coprimality. The parent only verified specific small lists like `[2,3,5]` and `[2,3,5,7,11,13]` by `decide`.",
+    "mathContext": "Distinct primes are coprime ($\\gcd(p, q) = 1$ for $p \\ne q$ prime), so any set of distinct primes is pairwise coprime — exactly the CRT precondition for an RNS base. Injectivity of the prime enumerator upgrades 'distinct indices' to 'distinct primes', giving pairwise coprimality of the first $k$ primes for all $k$ at once.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.coprime_primes",
+      "List.Pairwise.map",
+      "List.pairwise_lt_range"
+    ],
+    "prerequisites": [
+      "Mathlib.Data.Nat.Prime.Basic",
+      "List.Pairwise"
+    ]
+  },
+  {
+    "id": "ann-capstone",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-01",
+    "range": {
+      "startLine": 260,
+      "endLine": 270
+    },
+    "type": "insight",
+    "title": "Capstone: a Valid k-Channel Base with Range ≥ 2^k for All k",
+    "content": "`firstPrimeBase k : RNSBase` packages the pairwise coprimality and the ≥ 2 bound into a genuine RNS base on the first k primes, for every k. `firstPrimeBase_channels` shows it has exactly k channels and `firstPrimeBase_dynamicRange` that its dynamic range is `primorialProper k`. The capstone `prime_base_growth_all_k` combines these: for every k there is a valid RNS base with k channels and dynamic range at least 2^k — the all-k statement the parent deferred.",
+    "mathContext": "This is the constructive payoff: not just a numeric bound on a number, but a witnessed family of valid RNS bases — one for each channel count $k$ — each provably CRT-correct (pairwise coprime moduli $\\ge 2$) and each with dynamic range $\\ge 2^k$. The honest scope: this establishes the growth lower bound, not full optimality (that consecutive primes maximize range under a width budget), which remains open.",
+    "significance": "key",
+    "relatedConcepts": [
+      "RNSBase",
+      "dynamic range",
+      "Chinese Remainder Theorem"
+    ],
+    "prerequisites": [
+      "firstPrimes_pairwise_coprime",
+      "primorialProper_ge_two_pow"
+    ]
+  }
+]

--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-01/meta.json
@@ -1,0 +1,120 @@
+{
+  "id": "chinese-remainder-constructive-oq-03-oq-01",
+  "title": "CRT RNS: Optimality of Prime Bases for All k",
+  "slug": "chinese-remainder-constructive-oq-03-oq-01",
+  "description": "Generalizes the parent's primorial growth bound from the k ≤ 6 lookup table to ALL k, by giving a proper total definition of the k-th prime via Mathlib's Nat.nth Nat.Prime. Proves primorialProper k ≥ 2^k for every k, that the proper primorial is strictly increasing and unbounded, that the first-k-primes list is pairwise coprime and bounded below by 2 for every k, and packages this into a genuine RNSBase (firstPrimeBase) with k channels and dynamic range ≥ 2^k for all k. Cross-checks the proper primorial against the classical sequence 1,2,6,30,210,2310,30030 for k=0..6.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChineseRemainderConstructiveOQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "modular-arithmetic",
+      "rns",
+      "prime-counting",
+      "primorial"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 275,
+    "assumptions": "None. Fully machine-checked, 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms reports only propext, Classical.choice, Quot.sound (no Lean.ofReduceBool; the small prime values are computed by kernel `decide` on Nat.count, not native_decide). The deeper open question of full optimality of prime bases (maximizing dynamic range under a width budget over all coprimality decompositions) is NOT settled — this entry delivers only the all-k growth lower bound the parent explicitly deferred.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 26,
+    "dateAdded": "2026-06-21",
+    "definitionCount": 6
+  },
+  "overview": {
+    "historicalContext": "Residue Number Systems were introduced by Harvey Garner in 1959 for parallel computer arithmetic. The dynamic range of a k-channel RNS base on the first k primes is the k-th primorial p_1·p_2·…·p_k, and a basic efficiency fact is that this grows at least like 2^k. The parent entry ChineseRemainderConstructiveOQ03 formalized RNS bases but defined the primorial only as a hand-written lookup table for k ≤ 6, proving the growth bound primorial k ≥ 2^k by interval_cases over that finite range. Its docstring explicitly noted that the bound holds for all k 'but proving it generally requires a proper definition of the k-th prime.' This entry supplies that missing definition and the all-k bound.",
+    "problemStatement": "Can the optimality (growth) of prime RNS bases be proved for all k, not just k ≤ 6 — which requires a proper, total definition of the k-th prime rather than a finite lookup table? Specifically: define the k-th prime for every k, define the primorial (product of the first k primes) for every k, and prove the dynamic-range lower bound primorial k ≥ 2^k for all k.",
+    "proofStrategy": "Define kthPrime i := Nat.nth Nat.Prime i, the i-th element of the (infinite) set of primes, which is total. From Mathlib's Nat.prime_nth_prime, Nat.nth_strictMono, and Nat.infinite_setOf_prime we get that every kthPrime i is prime, ≥ 2, strictly monotone in i, and injective. Define primorialProper k as the product of [kthPrime 0, …, kthPrime (k-1)]. A one-line recurrence primorialProper (k+1) = primorialProper k · kthPrime k drives a clean induction: 2^(k+1) = 2^k·2 ≤ primorialProper k · kthPrime k since each factor is ≥ 2 (Nat.mul_le_mul). Strict monotonicity and unboundedness follow from positivity and each prime being ≥ 2 (with Nat.lt_two_pow_self for unboundedness). Distinct indices give distinct primes (injectivity), so the first-k-primes list is pairwise coprime via Nat.coprime_primes; combined with the ≥ 2 bound this builds a genuine RNSBase for every k. Small prime values (kthPrime 0..5 = 2,3,5,7,11,13) are pinned by the characterization Nat.nth_count together with kernel `decide` on Nat.count Nat.Prime, keeping the file native_decide-free and 0-axiom.",
+    "keyInsights": [
+      "The right object is Mathlib's Nat.nth Nat.Prime — the enumerator of an infinite set — which makes 'the k-th prime' a total function and immediately replaces the parent's k ≤ 6 lookup table for every k.",
+      "All the optimality-relevant facts reduce to one recurrence primorialProper (k+1) = primorialProper k · kthPrime k and the single inequality 2 ≤ kthPrime k. The growth bound 2^k ≤ primorialProper k is then a two-line induction (pow_succ + Nat.mul_le_mul), in contrast to the parent's finite interval_cases.",
+      "Injectivity of kthPrime (from strict monotonicity) turns the abstract Nat.coprime_primes ('distinct primes are coprime') into pairwise coprimality of the entire first-k-primes list for every k — the parent only checked specific small lists like [2,3,5] and [2,3,5,7,11,13].",
+      "Concrete prime values can be obtained 0-axiom without native_decide: Nat.nth_count gives kthPrime (count Prime n) = n for prime n, and Nat.count Nat.Prime n reduces under kernel `decide` for small n, so kthPrime 0..5 = 2,3,5,7,11,13 are provable while #print axioms stays free of Lean.ofReduceBool.",
+      "The result is honestly a generalization of a growth lower bound, not a resolution of full optimality: showing consecutive primes MAXIMIZE the dynamic range subject to a channel-width budget over all coprimality decompositions remains open. This entry closes exactly the gap the parent deferred and no more."
+    ]
+  },
+  "sections": [
+    {
+      "id": "rns-base",
+      "title": "Minimal RNS Base (Self-Contained)",
+      "startLine": 62,
+      "endLine": 78,
+      "summary": "Re-declares a minimal RNSBase structure (pairwise coprime moduli ≥ 2) with channels and dynamicRange, mirroring the parent's RNSBase. This is self-contained because the parent file ChineseRemainderConstructiveOQ03.lean no longer compiles against Mathlib 4.26.0 (it has bit-rotted)."
+    },
+    {
+      "id": "kth-prime",
+      "title": "A Proper k-th Prime, Defined for All k",
+      "startLine": 81,
+      "endLine": 139,
+      "summary": "Defines kthPrime i := Nat.nth Nat.Prime i and proves it is prime, ≥ 2, positive, strictly monotone, and injective (from Nat.prime_nth_prime, Nat.nth_strictMono, Nat.infinite_setOf_prime). Pins the small values kthPrime 0..5 = 2,3,5,7,11,13 via Nat.nth_count + kernel decide on Nat.count, with no native_decide."
+    },
+    {
+      "id": "proper-primorial",
+      "title": "The Proper Primorial and the All-k Growth Bound",
+      "startLine": 142,
+      "endLine": 198,
+      "summary": "Defines firstPrimes k and primorialProper k (product of the first k primes) for every k, with recurrence primorialProper (k+1) = primorialProper k · kthPrime k. Proves the main result primorialProper_ge_two_pow: 2^k ≤ primorialProper k for ALL k, plus positivity, strict monotonicity, and unboundedness."
+    },
+    {
+      "id": "cross-check",
+      "title": "Cross-Check Against the Classical Sequence",
+      "startLine": 201,
+      "endLine": 215,
+      "summary": "primorialProper_values confirms the all-k definition reproduces the classical primorial sequence 1, 2, 6, 30, 210, 2310, 30030 for k = 0..6, matching the parent's lookup table exactly."
+    },
+    {
+      "id": "prime-base",
+      "title": "The Prime RNS Base, Valid for All k",
+      "startLine": 217,
+      "endLine": 258,
+      "summary": "Proves every modulus in firstPrimes k is ≥ 2 and that firstPrimes k is pairwise coprime for every k (via injectivity + Nat.coprime_primes). Packages these into firstPrimeBase k : RNSBase with exactly k channels and dynamic range = primorialProper k ≥ 2^k for all k."
+    },
+    {
+      "id": "summary",
+      "title": "Capstone",
+      "startLine": 260,
+      "endLine": 273,
+      "summary": "prime_base_growth_all_k: for every k there is a valid RNS base with exactly k channels and dynamic range at least 2^k, settling the all-k growth bound the parent deferred."
+    }
+  ],
+  "conclusion": {
+    "summary": "YES — the growth/optimality lower bound for prime RNS bases can be proved for ALL k. Defining the k-th prime as Nat.nth Nat.Prime i makes 'the first k primes' a total construction, and the primorial primorialProper k = ∏ first k primes then satisfies primorialProper k ≥ 2^k for every k by a two-line induction, generalizing the parent's interval_cases proof for k ≤ 6. The first-k-primes list is pairwise coprime and ≥ 2 for every k, yielding a genuine RNSBase with k channels and dynamic range ≥ 2^k for all k. The construction reproduces the classical primorial values 1,2,6,30,210,2310,30030 for k=0..6.",
+    "implications": "The efficiency claim that a k-channel prime RNS base provides at least 2^k dynamic range — i.e. at least k bits of range per the k channels — now holds uniformly in k rather than only for the small bases tabulated in hardware references. The proper k-th-prime definition also makes the whole RNS-base framework scale to arbitrarily many channels with machine-checked coprimality.",
+    "openQuestions": [
+      "Full optimality remains open: does the first-k-primes base MAXIMIZE the dynamic range among all k-channel bases whose moduli are pairwise coprime and bounded by a fixed channel width w? This requires reasoning over all prime-power decompositions, not just the growth bound.",
+      "Can a sharper lower bound than 2^k (e.g. reflecting the actual prime growth, primorial k = e^{(1+o(1)) p_k} by the prime number theorem) be formalized for all k?",
+      "What is the optimal trade-off between dynamic range and maximum channel width when the k-th prime is allowed to grow — i.e. the analogue of this bound under a hard cap on max(m_i)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chinese-remainder-constructive-oq-03",
+      "relationship": "extends",
+      "description": "Parent entry: efficient RNS bases. This entry supplies the proper k-th-prime definition the parent explicitly deferred and generalizes its primorial growth bound from k ≤ 6 to all k."
+    },
+    {
+      "targetId": "chinese-remainder-constructive-oq-03-oq-03",
+      "relationship": "related",
+      "description": "Sibling entry extending the same RNS-base framework with a power-of-2 channel; this entry instead extends the prime-channel growth bound to all k."
+    },
+    {
+      "targetId": "chinese-remainder-constructive",
+      "relationship": "foundational",
+      "description": "The constructive CRT proof providing the RNSBase / dynamic-range framework this entry builds on (re-declared locally here because the parent's RNS file no longer compiles)."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 275,
+    "path": "Proofs/ChineseRemainderConstructiveOQ03OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 6,
+    "theoremCount": 26
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Generalizes the parent **OQ-03** (efficient RNS bases) primorial growth bound from a **k ≤ 6 lookup table** to **ALL k**, by supplying the proper k-th-prime definition the parent file explicitly deferred.

The parent defined the primorial as a hand-written case table valid only for k ≤ 6:
```lean
def primorial : ℕ → ℕ
  | 0 => 1 | 1 => 2 | 2 => 6 | 3 => 30 | 4 => 210 | 5 => 2310 | 6 => 30030 | _ => 0
```
and proved `primorial k ≥ 2^k` only by `interval_cases` over that range, with a docstring noting the general bound 'requires a proper definition of the k-th prime.'

## What's delivered

Using Mathlib's `Nat.nth Nat.Prime` (the total enumerator of the infinite set of primes):

- `kthPrime i = Nat.nth Nat.Prime i` — total, prime, ≥ 2, strictly monotone, injective.
- `primorialProper k` = product of the first k primes, defined for **every** k.
- **`primorialProper_ge_two_pow : 2^k ≤ primorialProper k` for ALL k** (two-line induction).
- `primorialProper_strictMono` + `primorialProper_unbounded`.
- `firstPrimes_pairwise_coprime` — first k primes pairwise coprime for every k (vs parent's specific small lists).
- `firstPrimeBase k : RNSBase` — a genuine RNS base with exactly k channels and dynamic range ≥ 2^k, for all k.
- `primorialProper_values` — cross-check reproducing the classical 1, 2, 6, 30, 210, 2310, 30030 for k = 0..6.

## Verification

- **0 sorries, 0 axioms.** `#print axioms` on the capstone reports only `propext, Classical.choice, Quot.sound` — small prime values use **kernel `decide`** (via `Nat.nth_count` + `Nat.count`), **not `native_decide`**, so no `Lean.ofReduceBool`.
- Builds against Mathlib 4.26.0 (`./proofs/scripts/docker-build.sh Proofs.ChineseRemainderConstructiveOQ03OQ01`).
- **Self-contained**: re-declares a minimal `RNSBase` rather than importing the parent, because `ChineseRemainderConstructiveOQ03.lean` no longer compiles against Mathlib 4.26.0 (bit-rotted — errors at lines 227/237/301/312).

## Honest scope

This closes exactly the gap the parent deferred (the **growth lower bound** for all k) and no more. **Full optimality** — that consecutive primes *maximize* the dynamic range subject to a channel-width budget over all coprimality decompositions — remains **open**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)