### PR TITLE
research(burnside-counting-oq-04): index-2 orbit folding extends Burnside to dihedral D_n

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -630,6 +630,7 @@ import Proofs.ChebyshevSumMonotoneOQ01
 import Proofs.ChevalleyWarningTheoremOQ01
 import Proofs.ChineseRemainderConstructive
 import Proofs.ChineseRemainderConstructiveOQ03
+import Proofs.ChineseRemainderConstructiveOQ03OQ01
 import Proofs.ChineseRemainderConstructiveOQ03OQ03
 import Proofs.ChineseRemainderConstructiveOQ04
 import Proofs.ChineseRemainderConstructiveOQ04OQ02

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -432,6 +432,7 @@ import Proofs.BurnsideCounting
 import Proofs.BurnsideCountingOQ03
 import Proofs.BurnsideCountingOQ03Aristotle
 import Proofs.BurnsideCountingOQ03OQ03
+import Proofs.BurnsideCountingOQ04
 import Proofs.BurnsideCountingOQ05
 import Proofs.CantorDiagonalization
 import Proofs.CantorDiagonalizationOQ01

--- a/proofs/Proofs/BurnsideCountingOQ04.lean
+++ b/proofs/Proofs/BurnsideCountingOQ04.lean
@@ -1,0 +1,157 @@
+import Mathlib.GroupTheory.GroupAction.Quotient
+import Mathlib.GroupTheory.SpecificGroups.Dihedral
+import Mathlib.Data.Fintype.Card
+import Mathlib.Tactic
+
+/-
+# Burnside Counting, OQ-04: Extending to the Dihedral Group via Index-2 Folding
+
+## What This Proves
+
+The parent entry `burnside-counting` counts binary necklaces of length `n`: orbits of
+colorings under the **cyclic** rotation group `ℤ/nℤ`.  This file answers the open question
+"extend to the dihedral group `D_n`" by isolating the exact mechanism that relates
+**bracelet** counting (dihedral orbits, rotations *and* reflections) to **necklace**
+counting (cyclic orbits, rotations only).
+
+The dihedral group `D_n` contains the cyclic rotation group as a subgroup of **index 2**:
+`|D_n| = 2n = 2·|ℤ/nℤ|`.  Everything about "adding reflections to Burnside" is captured by
+the following abstract statement, proved here with no extra axioms:
+
+  **Index-2 orbit folding.**  If a finite group `G` acts on a finite set `X` and `H ≤ G`,
+  then
+    `|X/G|·|G| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|`.
+
+  Applied with `G = D_n`, `H = ℤ/nℤ`, this reads
+    `(bracelets)·2n = (necklaces)·n + Σ_{reflections} |Fix|`,
+  i.e. the classical "bracelets = (necklaces + reflection fixed points)/2".
+
+We then specialise: when `|G| = 2|H|` (the dihedral case) we obtain the doubling form
+  `2·|X/G|·|H| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|`,
+and we plug in the classical data for binary length-4 colourings
+(`|necklaces| = 6`, `|H| = 4`, reflection fixed points `= 24`) to recover
+`|bracelets| = 6`.
+
+## Honesty / Scope
+
+The headline theorem `index_two_orbit_folding` is the genuine contribution: it is a clean,
+fully general, axiom-free derivation that holds for *any* subgroup, with the dihedral
+extension as its motivating instance.  The numeric corollary
+`binary_four_bracelet_count` takes the classical reflection-fixed-point total (24) and
+necklace count (6) for length-4 binary colourings as hypotheses and *derives* the bracelet
+count from the folding theorem; it does not recompute those two finite counts inside Lean
+(that would require rebuilding the parent's concrete orbit-quotient `Fintype`, which the
+parent itself only closes with `native_decide`).  So this is an exact algebraic reduction,
+not a from-scratch enumeration.
+
+## Mathlib Dependencies
+- `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` : Burnside's lemma
+- `Mathlib.GroupTheory.SpecificGroups.Dihedral` : `DihedralGroup n`, `DihedralGroup.card`
+-/
+
+namespace BurnsideCountingOQ04
+
+open Finset MulAction
+
+/-! ## Part I: The index-2 orbit-folding theorem -/
+
+/-- **Index-2 orbit folding (Burnside, split by a subgroup).**
+
+For a finite group `G` acting on a finite set `X` and any subgroup `H ≤ G`,
+the Burnside count over `G` decomposes as the Burnside count over `H` plus the
+contribution of the elements outside `H`:
+
+  `|X/G|·|G| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|`.
+
+With `G = D_n` and `H` the rotation subgroup `ℤ/nℤ`, the second summand ranges over the
+reflections, so this is precisely the bracelets-from-necklaces formula. -/
+theorem index_two_orbit_folding
+    {G X : Type*} [Group G] [MulAction G X] [Fintype G] [Fintype X]
+    (H : Subgroup G) [DecidablePred (· ∈ H)]
+    [∀ g : G, Fintype (fixedBy X g)] [∀ h : H, Fintype (fixedBy X h)]
+    [Fintype (orbitRel.Quotient G X)] [Fintype (orbitRel.Quotient H X)] :
+    Fintype.card (orbitRel.Quotient G X) * Fintype.card G
+      = Fintype.card (orbitRel.Quotient H X) * Fintype.card H
+        + ∑ g ∈ Finset.univ.filter (fun g => ¬ (g ∈ H)),
+            Fintype.card (fixedBy X g) := by
+  -- Burnside's lemma applied to the full group `G`.
+  have hG : ∑ g : G, Fintype.card (fixedBy X g)
+      = Fintype.card (orbitRel.Quotient G X) * Fintype.card G :=
+    MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group G X
+  -- The restricted action of `H` fixes a coloring iff the underlying element of `G` does:
+  -- `fixedBy X (h : G)` and `fixedBy X h` are definitionally the same set, so their
+  -- cardinalities agree (only the `Fintype` instances differ).
+  have hcard : ∀ h : H, Fintype.card (fixedBy X (h : G)) = Fintype.card (fixedBy X h) :=
+    fun h => Fintype.card_congr (Equiv.refl _)
+  -- Burnside's lemma applied to the subgroup `H`.
+  have hH : ∑ h : H, Fintype.card (fixedBy X (h : G))
+      = Fintype.card (orbitRel.Quotient H X) * Fintype.card H := by
+    rw [Finset.sum_congr rfl (fun h _ => hcard h)]
+    exact MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group H X
+  -- Split the Burnside sum over `G` into the `H`-part and the complement.
+  have hsplit := Finset.sum_filter_add_sum_filter_not (Finset.univ : Finset G)
+    (fun g => g ∈ H) (fun g => Fintype.card (fixedBy X g))
+  -- The `H`-part of the sum equals the Burnside sum over the subgroup `H`.
+  have hrot : ∑ g ∈ Finset.univ.filter (fun g => g ∈ H), Fintype.card (fixedBy X g)
+      = ∑ h : H, Fintype.card (fixedBy X (h : G)) :=
+    Finset.sum_subtype (Finset.univ.filter (fun g => g ∈ H)) (fun x => by simp)
+      (fun g => Fintype.card (fixedBy X g))
+  rw [← hG, ← hsplit, hrot, hH]
+
+/-! ## Part II: The dihedral (index-2) specialisation -/
+
+/-- **Dihedral doubling form.**  When `|G| = 2·|H|` — the defining size relation of the
+dihedral group over its rotation subgroup — folding rearranges to
+
+  `2·|X/G|·|H| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|`,
+
+i.e. `bracelets·2|H| = necklaces·|H| + (reflection fixed points)`. -/
+theorem dihedral_doubling
+    {G X : Type*} [Group G] [MulAction G X] [Fintype G] [Fintype X]
+    (H : Subgroup G) [DecidablePred (· ∈ H)]
+    [∀ g : G, Fintype (fixedBy X g)] [∀ h : H, Fintype (fixedBy X h)]
+    [Fintype (orbitRel.Quotient G X)] [Fintype (orbitRel.Quotient H X)]
+    (hindex : Fintype.card G = 2 * Fintype.card H) :
+    2 * Fintype.card (orbitRel.Quotient G X) * Fintype.card H
+      = Fintype.card (orbitRel.Quotient H X) * Fintype.card H
+        + ∑ g ∈ Finset.univ.filter (fun g => ¬ (g ∈ H)),
+            Fintype.card (fixedBy X g) := by
+  have h := index_two_orbit_folding (G := G) (X := X) H
+  rw [hindex] at h
+  rw [← h]; ring
+
+/-- `DihedralGroup n` has order `2n`: the size relation that makes the rotation subgroup
+have index 2.  (Re-export of `DihedralGroup.card` for context.) -/
+theorem dihedralGroup_card (n : ℕ) [NeZero n] :
+    Fintype.card (DihedralGroup n) = 2 * n :=
+  DihedralGroup.card
+
+/-! ## Part III: Numeric instance — binary length-4 bracelets
+
+We plug the classical length-4 binary data into the folding theorem.
+
+The parent entry establishes the necklace (cyclic-orbit) count `|X/H| = 6` with `|H| = 4`.
+For the dihedral group `D_4` (order 8) the four reflections of the square fix, respectively,
+`8, 8, 4, 4` colourings (two axes through opposite vertices, two through opposite edge
+midpoints), for a reflection total of `24`.  Folding then forces the bracelet count to be 6:
+
+  `bracelets·8 = necklaces·4 + 24 = 24 + 24 = 48`,  so  `bracelets = 6`.
+
+These two inputs (`necklaces = 6`, reflection total `= 24`) are taken as hypotheses; the
+theorem derives the bracelet count purely from `index_two_orbit_folding`. -/
+theorem binary_four_bracelet_count
+    {G X : Type*} [Group G] [MulAction G X] [Fintype G] [Fintype X]
+    (H : Subgroup G) [DecidablePred (· ∈ H)]
+    [∀ g : G, Fintype (fixedBy X g)] [∀ h : H, Fintype (fixedBy X h)]
+    [Fintype (orbitRel.Quotient G X)] [Fintype (orbitRel.Quotient H X)]
+    (hG : Fintype.card G = 8) (hH : Fintype.card H = 4)
+    (hnecklaces : Fintype.card (orbitRel.Quotient H X) = 6)
+    (hreflections :
+      (∑ g ∈ Finset.univ.filter (fun g => ¬ (g ∈ H)), Fintype.card (fixedBy X g)) = 24) :
+    Fintype.card (orbitRel.Quotient G X) = 6 := by
+  have h := index_two_orbit_folding (G := G) (X := X) H
+  rw [hG, hH, hnecklaces, hreflections] at h
+  -- `|X/G| * 8 = 6 * 4 + 24 = 48`
+  omega
+
+end BurnsideCountingOQ04

--- a/proofs/Proofs/ChineseRemainderConstructiveOQ03OQ01.lean
+++ b/proofs/Proofs/ChineseRemainderConstructiveOQ03OQ01.lean
@@ -1,0 +1,275 @@
+/-
+  Chinese Remainder Theorem — OQ-03-OQ-01:
+  Optimality of prime RNS bases for ALL k (not just k ≤ 6)
+
+  The parent file `ChineseRemainderConstructiveOQ03` formalizes efficient
+  Residue Number System (RNS) bases. There the "primorial" — the product of
+  the first k primes, which is the dynamic range of the k-channel prime base —
+  is a *lookup table* defined only for k ≤ 6:
+
+      def primorial : ℕ → ℕ
+        | 0 => 1 | 1 => 2 | 2 => 6 | 3 => 30 | 4 => 210 | 5 => 2310 | 6 => 30030
+        | _ => 0
+
+  and the growth bound `primorial k ≥ 2^k` is proved by `interval_cases`,
+  valid only for 1 ≤ k ≤ 6. The parent docstring states the bound holds for all
+  k "but proving it generally requires a proper definition of the k-th prime."
+
+  This file supplies exactly that proper definition, using Mathlib's `Nat.nth`
+  (the n-th element of an infinite set), and proves the optimality-relevant
+  facts for ALL k:
+
+  * `kthPrime i = Nat.nth Nat.Prime i` — the i-th prime (0-indexed), defined
+    for every i, with `kthPrime` prime, ≥ 2, strictly monotone, injective.
+  * `primorialProper k = ∏ first k primes` — defined for every k.
+  * `primorialProper_ge_two_pow : 2^k ≤ primorialProper k` for ALL k.
+  * `primorialProper_strictMono` — the dynamic range strictly increases in k.
+  * The first-k-primes list is pairwise coprime and bounded below by 2 for
+    every k, hence yields a genuine `RNSBase` with k channels and dynamic
+    range ≥ 2^k for ALL k (`firstPrimeBase`).
+  * Cross-check: the proper primorial reproduces the classical primorial values
+    `1, 2, 6, 30, 210, 2310, 30030` for k = 0..6.
+
+  This does NOT settle the deeper open question of *full* optimality of prime
+  bases (that consecutive primes maximize the dynamic range subject to a width
+  budget under all coprimality decompositions) — that remains open. What is
+  delivered is the all-k generalization of the growth lower bound, the missing
+  piece the parent explicitly deferred.
+
+  NOTE: the parent file `ChineseRemainderConstructiveOQ03.lean` no longer
+  compiles against the current Mathlib (4.26.0) — it has bit-rotted. So this
+  file is deliberately SELF-CONTAINED: it re-declares a minimal `RNSBase`
+  structure rather than importing the parent, and cross-checks the primorial
+  values against the classical sequence directly.
+
+  Status: VERIFIED
+  Axioms: 0
+  Sorries: 0
+
+  References:
+  [Gar59] Garner "The residue number system" (1959)
+  [SS67] Szabó-Tanaka "Residue Arithmetic and Its Applications" (1967)
+
+  Tags: number-theory, modular-arithmetic, algorithms, prime-counting, classical
+-/
+
+import Mathlib
+
+namespace RNSBasesAllK
+
+open Nat
+
+-- ============================================================
+-- SECTION 0: Minimal RNS base (self-contained re-declaration)
+-- ============================================================
+
+/-- An RNS base: a list of pairwise coprime moduli, all ≥ 2.
+    (Mirrors the parent's `RNSBases.RNSBase`, re-declared here because the
+    parent file no longer compiles against the current Mathlib.) -/
+structure RNSBase where
+  moduli : List ℕ
+  coprime : moduli.Pairwise Nat.Coprime
+  ge_two : ∀ m ∈ moduli, m ≥ 2
+
+/-- Number of channels (moduli). -/
+def RNSBase.channels (b : RNSBase) : ℕ := b.moduli.length
+
+/-- Dynamic range: product of all moduli. -/
+def RNSBase.dynamicRange (b : RNSBase) : ℕ := b.moduli.prod
+
+-- ============================================================
+-- SECTION I: A proper k-th prime, defined for all k
+-- ============================================================
+
+/-- The `i`-th prime (0-indexed): `kthPrime 0 = 2`, `kthPrime 1 = 3`, ….
+    Uses Mathlib's `Nat.nth`, the enumerator of the infinite set of primes,
+    so it is total: defined for every `i : ℕ`. -/
+noncomputable def kthPrime (i : ℕ) : ℕ := Nat.nth Nat.Prime i
+
+/-- Every `kthPrime i` is prime. -/
+theorem kthPrime_prime (i : ℕ) : (kthPrime i).Prime := Nat.prime_nth_prime i
+
+/-- Every `kthPrime i` is at least 2. -/
+theorem kthPrime_two_le (i : ℕ) : 2 ≤ kthPrime i := (kthPrime_prime i).two_le
+
+/-- Every `kthPrime i` is positive. -/
+theorem kthPrime_pos (i : ℕ) : 0 < kthPrime i := (kthPrime_prime i).pos
+
+/-- The prime enumerator is strictly monotone (primes are infinite). -/
+theorem kthPrime_strictMono : StrictMono kthPrime :=
+  Nat.nth_strictMono Nat.infinite_setOf_prime
+
+/-- Distinct indices give distinct primes. -/
+theorem kthPrime_injective : Function.Injective kthPrime :=
+  kthPrime_strictMono.injective
+
+/-- Characterization: the `(count Prime n)`-th prime is `n`, for prime `n`. -/
+theorem kthPrime_count {n : ℕ} (hn : n.Prime) :
+    kthPrime (Nat.count Nat.Prime n) = n :=
+  Nat.nth_count hn
+
+theorem kthPrime_zero : kthPrime 0 = 2 := by
+  have hc : Nat.count Nat.Prime 2 = 0 := by decide
+  have h := kthPrime_count (n := 2) (by norm_num)
+  rwa [hc] at h
+
+theorem kthPrime_one : kthPrime 1 = 3 := by
+  have hc : Nat.count Nat.Prime 3 = 1 := by decide
+  have h := kthPrime_count (n := 3) (by norm_num)
+  rwa [hc] at h
+
+theorem kthPrime_two : kthPrime 2 = 5 := by
+  have hc : Nat.count Nat.Prime 5 = 2 := by decide
+  have h := kthPrime_count (n := 5) (by norm_num)
+  rwa [hc] at h
+
+theorem kthPrime_three : kthPrime 3 = 7 := by
+  have hc : Nat.count Nat.Prime 7 = 3 := by decide
+  have h := kthPrime_count (n := 7) (by norm_num)
+  rwa [hc] at h
+
+theorem kthPrime_four : kthPrime 4 = 11 := by
+  have hc : Nat.count Nat.Prime 11 = 4 := by decide
+  have h := kthPrime_count (n := 11) (by norm_num)
+  rwa [hc] at h
+
+theorem kthPrime_five : kthPrime 5 = 13 := by
+  have hc : Nat.count Nat.Prime 13 = 5 := by decide
+  have h := kthPrime_count (n := 13) (by norm_num)
+  rwa [hc] at h
+
+-- ============================================================
+-- SECTION II: The proper primorial, defined for all k
+-- ============================================================
+
+/-- The first `k` primes, as a list: `[kthPrime 0, …, kthPrime (k-1)]`. -/
+noncomputable def firstPrimes (k : ℕ) : List ℕ := (List.range k).map kthPrime
+
+/-- The proper primorial: the product of the first `k` primes.
+    Unlike the parent's lookup table, this is defined for EVERY `k`. -/
+noncomputable def primorialProper (k : ℕ) : ℕ := (firstPrimes k).prod
+
+theorem firstPrimes_succ (k : ℕ) :
+    firstPrimes (k + 1) = firstPrimes k ++ [kthPrime k] := by
+  unfold firstPrimes
+  rw [List.range_succ, List.map_append]
+  rfl
+
+theorem primorialProper_zero : primorialProper 0 = 1 := by
+  unfold primorialProper firstPrimes; simp
+
+/-- The defining recurrence: each step multiplies by the next prime. -/
+theorem primorialProper_succ (k : ℕ) :
+    primorialProper (k + 1) = primorialProper k * kthPrime k := by
+  unfold primorialProper
+  rw [firstPrimes_succ, List.prod_append]
+  simp
+
+/-- The proper primorial is always positive. -/
+theorem primorialProper_pos : ∀ k, 0 < primorialProper k
+  | 0 => by simp [primorialProper, firstPrimes]
+  | (k + 1) => by
+      rw [primorialProper_succ]
+      exact Nat.mul_pos (primorialProper_pos k) (kthPrime_pos k)
+
+/-- **Main result.** The growth lower bound `2^k ≤ primorialProper k` holds for
+    ALL `k`, generalizing the parent's `interval_cases` proof for k ≤ 6.
+    Each of the `k` prime factors is at least 2, so the product dominates `2^k`. -/
+theorem primorialProper_ge_two_pow : ∀ k, 2 ^ k ≤ primorialProper k
+  | 0 => by simp [primorialProper, firstPrimes]
+  | (k + 1) => by
+      rw [pow_succ, primorialProper_succ]
+      exact Nat.mul_le_mul (primorialProper_ge_two_pow k) (kthPrime_two_le k)
+
+/-- The dynamic range of the k-channel prime base strictly increases with `k`. -/
+theorem primorialProper_strictMono : StrictMono primorialProper := by
+  apply strictMono_nat_of_lt_succ
+  intro k
+  rw [primorialProper_succ]
+  have h1 := primorialProper_pos k
+  have h2 := kthPrime_two_le k
+  calc primorialProper k < primorialProper k * 2 := by omega
+    _ ≤ primorialProper k * kthPrime k := Nat.mul_le_mul (le_refl _) h2
+
+/-- Consequence: the dynamic range is unbounded — for every target `M` there is
+    a number of channels `k` whose prime base exceeds it. -/
+theorem primorialProper_unbounded (M : ℕ) : ∃ k, M < primorialProper k :=
+  ⟨M + 1, lt_of_lt_of_le (by have := Nat.lt_two_pow_self (n := M + 1); omega)
+    (primorialProper_ge_two_pow (M + 1))⟩
+
+-- ============================================================
+-- SECTION III: Cross-check against the parent lookup table
+-- ============================================================
+
+/-- Cross-check: the proper primorial reproduces the classical primorial
+    sequence `1, 2, 6, 30, 210, 2310, 30030` for `k = 0, …, 6`. This confirms
+    the all-`k` definition specializes correctly to the parent's lookup table. -/
+theorem primorialProper_values :
+    primorialProper 0 = 1 ∧ primorialProper 1 = 2 ∧ primorialProper 2 = 6 ∧
+    primorialProper 3 = 30 ∧ primorialProper 4 = 210 ∧
+    primorialProper 5 = 2310 ∧ primorialProper 6 = 30030 := by
+  refine ⟨primorialProper_zero, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    simp [primorialProper_succ, primorialProper_zero,
+      kthPrime_zero, kthPrime_one, kthPrime_two, kthPrime_three,
+      kthPrime_four, kthPrime_five]
+
+-- ============================================================
+-- SECTION IV: The prime RNS base, valid for all k
+-- ============================================================
+
+/-- Every modulus in `firstPrimes k` is at least 2. -/
+theorem firstPrimes_ge_two {k m : ℕ} (hm : m ∈ firstPrimes k) : 2 ≤ m := by
+  unfold firstPrimes at hm
+  rw [List.mem_map] at hm
+  obtain ⟨i, _, rfl⟩ := hm
+  exact kthPrime_two_le i
+
+/-- The first `k` primes are pairwise coprime — for EVERY `k`.
+    (Parent only checked specific small lists like `[2,3,5]`, `[2,3,5,7,11,13]`.) -/
+theorem firstPrimes_pairwise_coprime (k : ℕ) :
+    (firstPrimes k).Pairwise Nat.Coprime := by
+  unfold firstPrimes
+  refine (List.pairwise_lt_range (n := k)).map kthPrime (fun a b hab => ?_)
+  exact (Nat.coprime_primes (kthPrime_prime a) (kthPrime_prime b)).mpr
+    (fun h => (Nat.ne_of_lt hab) (kthPrime_injective h))
+
+/-- The genuine RNS base on the first `k` primes — valid for every `k`. -/
+noncomputable def firstPrimeBase (k : ℕ) : RNSBase where
+  moduli := firstPrimes k
+  coprime := firstPrimes_pairwise_coprime k
+  ge_two := fun _ hm => firstPrimes_ge_two hm
+
+/-- The prime base has exactly `k` channels. -/
+theorem firstPrimeBase_channels (k : ℕ) : (firstPrimeBase k).channels = k := by
+  unfold RNSBase.channels firstPrimeBase firstPrimes
+  simp
+
+/-- Its dynamic range is the proper primorial. -/
+theorem firstPrimeBase_dynamicRange (k : ℕ) :
+    (firstPrimeBase k).dynamicRange = primorialProper k := rfl
+
+/-- **Optimality bound for all k.** For every number of channels `k`, the
+    first-`k`-primes RNS base achieves dynamic range at least `2^k`. This is the
+    all-`k` generalization of the parent's `primorial_growth_lower` (k ≤ 6). -/
+theorem firstPrimeBase_dynamicRange_ge_two_pow (k : ℕ) :
+    2 ^ k ≤ (firstPrimeBase k).dynamicRange := by
+  rw [firstPrimeBase_dynamicRange]
+  exact primorialProper_ge_two_pow k
+
+-- ============================================================
+-- SECTION V: Summary
+-- ============================================================
+
+/-- Capstone: for every `k`, there is a valid RNS base with exactly `k`
+    channels whose dynamic range is at least `2^k`. The k-th prime is given by
+    a total, proper definition (`Nat.nth Nat.Prime`), settling the all-`k`
+    growth bound the parent file deferred. -/
+theorem prime_base_growth_all_k (k : ℕ) :
+    (firstPrimeBase k).channels = k ∧ 2 ^ k ≤ (firstPrimeBase k).dynamicRange :=
+  ⟨firstPrimeBase_channels k, firstPrimeBase_dynamicRange_ge_two_pow k⟩
+
+#check @prime_base_growth_all_k
+#check @primorialProper_ge_two_pow
+#check @primorialProper_values
+
+end RNSBasesAllK

--- a/src/data/proofs/burnside-counting-oq-04/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "burnside-counting-oq-04",
+  "title": "Burnside to the Dihedral Group: Index-2 Orbit Folding",
+  "slug": "burnside-counting-oq-04",
+  "description": "Extends Burnside necklace counting to the dihedral group by isolating the exact mechanism relating bracelet counts (dihedral orbits, rotations and reflections) to necklace counts (cyclic orbits, rotations only). The dihedral group D_n contains the rotation group ℤ/nℤ as an index-2 subgroup (|D_n| = 2n). The headline theorem `index_two_orbit_folding` proves, for any finite group G acting on a finite set X and any subgroup H ≤ G, that |X/G|·|G| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|, by splitting the Burnside sum over G into its H-part (re-summed as Burnside over the subgroup) and the complement. Instantiated at G = D_n, H = ℤ/nℤ this is precisely the classical 'bracelets = (necklaces + reflection fixed points)/2'. A doubling corollary handles the |G| = 2|H| case, and a numeric corollary plugs in the classical length-4 binary data (necklaces = 6, |H| = 4, reflection total = 24) to recover 6 bracelets. Fully verified, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Burnside / Pólya theory; formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ04.lean",
+    "tags": [
+      "combinatorics",
+      "group-action",
+      "burnside",
+      "dihedral-group",
+      "necklaces",
+      "bracelets",
+      "orbit-counting",
+      "subgroup",
+      "index-two"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group",
+        "description": "Burnside's lemma: Σ_{g∈G} |Fix(g)| = |X/G|·|G|. Applied both to the full group G and to the subgroup H; the difference of the two instances is the engine of the folding identity.",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "Finset.sum_filter_add_sum_filter_not",
+        "description": "Splits the Burnside sum over G into the part with g ∈ H and the complement g ∉ H (the reflections).",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_subtype",
+        "description": "Re-indexes the g ∈ H part of the sum over G as a sum over the subgroup H, matching the form of Burnside's lemma for H.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Fintype.card_congr",
+        "description": "Bridges the two Fintype instances on fixedBy X (h:G) versus the restricted-action fixedBy X h (definitionally equal sets), so the subgroup Burnside sum lines up term by term.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "DihedralGroup.card",
+        "description": "|DihedralGroup n| = 2n, the order relation that makes the rotation subgroup index 2 — re-exported to anchor the dihedral instance.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Dihedral"
+      }
+    ],
+    "originalContributions": [
+      "index_two_orbit_folding: for any finite group G acting on a finite set X and any subgroup H ≤ G, |X/G|·|G| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|, proved by splitting the Burnside sum over G and re-summing the H-part as Burnside over H (handling the restricted-action Fintype mismatch via Fintype.card_congr on the definitionally equal fixed-point sets)",
+      "dihedral_doubling: the |G| = 2|H| specialisation giving 2·|X/G|·|H| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|, i.e. bracelets·2|H| = necklaces·|H| + (reflection fixed points)",
+      "dihedralGroup_card: re-export of |DihedralGroup n| = 2n, the order relation that places the rotation group at index 2",
+      "binary_four_bracelet_count: plugging the classical length-4 binary data (|necklaces| = 6, |H| = 4, reflection total = 24) into the folding theorem forces the bracelet count to be 6"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound (confirmed via #print axioms on all four theorems).",
+    "lineCount": 157,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Burnside's lemma counts orbits of a finite group action as the average number of fixed points. For the cyclic group ℤ/nℤ acting on the n beads of a cycle it yields the necklace numbers; for the larger dihedral group D_n — which adjoins the n reflections to the n rotations — it yields the bracelet numbers (OEIS A000029). Because the rotation group sits inside D_n as a subgroup of index 2, the bracelet count is the average of the necklace count and the reflection contribution: |bracelets| = (|necklaces| + (reflection fixed points)/n)/2. This 'folding' relationship is the standard way the dihedral count is reduced to the cyclic one, and it is an instance of a purely group-theoretic fact about any index-2 (indeed any) subgroup.",
+    "problemStatement": "Extend Burnside necklace counting to the dihedral group D_n. How does the bracelet count (orbits under rotations and reflections) relate to the necklace count (orbits under rotations alone)?",
+    "text": "For a finite group G acting on a finite set X and any subgroup H ≤ G, |X/G|·|G| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|. With G = D_n and H = ℤ/nℤ this is bracelets·2n = necklaces·n + Σ_{reflections} |Fix|.",
+    "proofStrategy": "Apply Burnside's lemma (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group) twice: once to G, giving Σ_{g∈G} |Fix(g)| = |X/G|·|G|, and once to the subgroup H acting by restriction, giving Σ_{h∈H} |Fix(h)| = |X/H|·|H|. Split the first sum by membership in H using Finset.sum_filter_add_sum_filter_not, re-index the H-part as a sum over the subgroup via Finset.sum_subtype, and identify it with the subgroup Burnside sum — the only subtlety is that fixedBy X (h:G) and the restricted-action fixedBy X h are definitionally equal sets carrying different Fintype instances, reconciled by Fintype.card_congr (Equiv.refl _). What remains is exactly the complement sum Σ_{g ∉ H} |Fix(g)|. The doubling corollary substitutes |G| = 2|H| and rearranges; the numeric corollary substitutes the classical length-4 data and finishes by omega.",
+    "keyInsights": [
+      "Adding reflections to Burnside is, abstractly, nothing more than splitting the Burnside sum along an index-2 subgroup: the rotation part re-sums to the necklace count, the reflection part is the leftover complement sum",
+      "The restricted action of a subgroup H ≤ G fixes a point iff the underlying element of G does, so fixedBy X (h:G) = fixedBy X h definitionally; only the Fintype instances differ, which Fintype.card_congr absorbs",
+      "The result is stated for an arbitrary subgroup, not just index 2 — the dihedral case is the motivating instance, obtained by also assuming |G| = 2|H|",
+      "Combined with the rotation count k^gcd(n,r) (oq-03) and the reflection count k^((n+1)/2) (oq-05), this folding theorem is the assembly step those entries leave open: it is exactly what turns per-symmetry fixed-point counts into the dihedral bracelet number"
+    ],
+    "prerequisites": [
+      "Group actions, orbits, and the orbit-counting (Burnside/Cauchy–Frobenius) lemma",
+      "Subgroups and the restricted action of a subgroup on the same set",
+      "Finite sums over a group split by a subgroup membership predicate"
+    ]
+  },
+  "sections": [
+    {
+      "id": "folding",
+      "title": "The Index-2 Orbit-Folding Theorem",
+      "startLine": 68,
+      "endLine": 99,
+      "summary": "Burnside on G minus Burnside on the subgroup H equals the complement sum: |X/G|·|G| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|.",
+      "mathContext": "$|X/G|\\,|G| = |X/H|\\,|H| + \\sum_{g \\notin H} |\\mathrm{Fix}(g)|$."
+    },
+    {
+      "id": "doubling",
+      "title": "The Dihedral Doubling Form",
+      "startLine": 101,
+      "endLine": 127,
+      "summary": "When |G| = 2|H| (the dihedral size relation), folding rearranges to 2·|X/G|·|H| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|; |DihedralGroup n| = 2n anchors the instance.",
+      "mathContext": "$2\\,|X/G|\\,|H| = |X/H|\\,|H| + \\sum_{g \\notin H} |\\mathrm{Fix}(g)|,\\quad |D_n| = 2n$."
+    },
+    {
+      "id": "numeric",
+      "title": "Binary Length-4 Bracelets = 6",
+      "startLine": 129,
+      "endLine": 157,
+      "summary": "Plugging |necklaces| = 6, |H| = 4, reflection total = 24 into the folding theorem forces |bracelets| = 6: bracelets·8 = 6·4 + 24 = 48.",
+      "mathContext": "$|\\text{bracelets}| \\cdot 8 = 6\\cdot 4 + 24 = 48 \\Rightarrow |\\text{bracelets}| = 6$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Burnside, W.",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "note": "The orbit-counting (Cauchy–Frobenius) lemma underlying necklace and bracelet enumeration"
+    },
+    {
+      "authors": "Pólya, G.",
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "note": "Enumeration under group actions; dihedral bracelet counts"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "burnside-counting",
+      "relationship": "extends",
+      "description": "Extends the base cyclic necklace count to the dihedral group by giving the abstract index-2 folding that relates bracelet counts to necklace counts."
+    },
+    {
+      "targetId": "burnside-counting-oq-03",
+      "relationship": "related",
+      "description": "oq-03 supplies the rotation-fixed counts k^gcd(n,r); this entry is the assembly step that combines per-symmetry fixed-point counts into the dihedral orbit count."
+    },
+    {
+      "targetId": "burnside-counting-oq-05",
+      "relationship": "related",
+      "description": "oq-05 supplies the reflection-fixed counts k^((n+1)/2) for odd cycles and lists 'assemble into a closed dihedral count via Burnside' as an open question; this folding theorem is exactly that assembly mechanism."
+    }
+  ],
+  "conclusion": {
+    "summary": "Adding reflections to Burnside necklace counting is captured abstractly by index-2 orbit folding: for any finite G acting on finite X and any subgroup H ≤ G, |X/G|·|G| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)|. With G = D_n and H = ℤ/nℤ this is the classical bracelets-from-necklaces formula; the file proves it with 0 axioms and no native_decide, adds the |G| = 2|H| doubling form, and verifies the length-4 binary instance (6 bracelets).",
+    "implications": "Provides the reusable assembly step that turns per-symmetry fixed-point counts (rotation counts of oq-03, reflection counts of oq-05) into dihedral orbit counts, stated in full generality for any subgroup rather than only the dihedral case.",
+    "openQuestions": [
+      "Build a concrete dihedral action on Coloring n k and discharge the necklace and reflection-total hypotheses of binary_four_bracelet_count by kernel computation, yielding an unconditional |bracelets| = 6 (the parent closes the analogous cyclic count only with native_decide).",
+      "Specialise the folding theorem to a fully formalized closed form for the binary bracelet numbers b(n) = (necklaces(n) + reflection-total(n))/(2n) for general n."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "MulAction"
+    ],
+    "namespace": "BurnsideCountingOQ04",
+    "lineCount": 157,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/BurnsideCountingOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-01/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-kth-prime-def",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-01",
+    "range": {
+      "startLine": 84,
+      "endLine": 104
+    },
+    "type": "insight",
+    "title": "A Total k-th Prime via Nat.nth",
+    "content": "`kthPrime i := Nat.nth Nat.Prime i` defines the i-th prime (0-indexed) for EVERY i, replacing the parent's lookup table that was only defined for k ≤ 6. `Nat.nth p` enumerates the elements of `{n | p n}` in increasing order, so for the infinite set of primes it is total. From `Nat.prime_nth_prime` we get `(kthPrime i).Prime`, hence `2 ≤ kthPrime i` and `0 < kthPrime i`. Strict monotonicity comes from `Nat.nth_strictMono Nat.infinite_setOf_prime`, and injectivity from `StrictMono.injective`.",
+    "mathContext": "The map $i \\mapsto p_i$ (the $i$-th prime) is a total, strictly increasing function $\\mathbb{N} \\to \\mathbb{N}$. Mathlib realizes it as `Nat.nth Nat.Prime`, the order-isomorphism between $\\mathbb{N}$ and the infinite set $\\{p : p \\text{ prime}\\}$. Totality is exactly what the parent file lacked: its `primorial` was a finite case table, so it could only state the growth bound for $k \\le 6$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.nth",
+      "Nat.prime_nth_prime",
+      "Nat.nth_strictMono",
+      "Nat.infinite_setOf_prime"
+    ],
+    "prerequisites": [
+      "Mathlib.Data.Nat.Nth",
+      "Mathlib.Data.Nat.PrimeFin"
+    ]
+  },
+  {
+    "id": "ann-small-prime-values",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-01",
+    "range": {
+      "startLine": 106,
+      "endLine": 139
+    },
+    "type": "technique",
+    "title": "Pinning Small Prime Values 0-Axiom (No native_decide)",
+    "content": "`kthPrime 0..5 = 2,3,5,7,11,13` are proved without native_decide, keeping the file free of `Lean.ofReduceBool`. The characterization `Nat.nth_count : p n → Nat.nth p (Nat.count p n) = n` says the `(count Prime n)`-th prime is `n`. For each concrete prime `n`, `Nat.count Nat.Prime n` (the number of primes below `n`) reduces under kernel `decide`, so e.g. `Nat.count Nat.Prime 7 = 3` gives `kthPrime 3 = 7`.",
+    "mathContext": "`Nat.count p n` counts how many $m < n$ satisfy $p$, and for prime $n$ this count is exactly the index of $n$ in the prime enumeration. Using kernel `decide` (not `native_decide`) means the reductions are checked by the Lean kernel itself, so `#print axioms` reports only `propext, Classical.choice, Quot.sound` — the proof is genuinely axiom-free.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.nth_count",
+      "Nat.count",
+      "kernel decide vs native_decide"
+    ],
+    "prerequisites": [
+      "Mathlib.Data.Nat.Nth"
+    ]
+  },
+  {
+    "id": "ann-growth-bound",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-01",
+    "range": {
+      "startLine": 175,
+      "endLine": 182
+    },
+    "type": "insight",
+    "title": "The All-k Growth Bound 2^k ≤ primorialProper k",
+    "content": "`primorialProper_ge_two_pow` proves `2^k ≤ primorialProper k` for EVERY k — the main deliverable, generalizing the parent's `interval_cases` proof for k ≤ 6. The whole argument is a two-line induction: the recurrence `primorialProper (k+1) = primorialProper k · kthPrime k` and `pow_succ` reduce the step to `2^k · 2 ≤ primorialProper k · kthPrime k`, which is `Nat.mul_le_mul` applied to the induction hypothesis and `2 ≤ kthPrime k`.",
+    "mathContext": "The $k$-th primorial $p_1 p_2 \\cdots p_k$ is a product of $k$ factors each $\\ge 2$, so it dominates $2^k$. In RNS terms: a $k$-channel prime base has dynamic range at least $2^k$, i.e. at least $k$ bits of range — uniformly in $k$, not just for the small tabulated bases. The parent file explicitly deferred this 'to a proper definition of the k-th prime'; here it is a corollary of that definition.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.mul_le_mul",
+      "pow_succ",
+      "primorial"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "product recurrence primorialProper_succ"
+    ]
+  },
+  {
+    "id": "ann-pairwise-coprime",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-01",
+    "range": {
+      "startLine": 229,
+      "endLine": 235
+    },
+    "type": "insight",
+    "title": "First k Primes are Pairwise Coprime for Every k",
+    "content": "`firstPrimes_pairwise_coprime` proves the list `[kthPrime 0, …, kthPrime (k-1)]` is `Pairwise Nat.Coprime` for EVERY k. `List.pairwise_lt_range` gives that `List.range k` is pairwise `<`, and `List.Pairwise.map` transports it along `kthPrime`: for `a < b`, injectivity makes `kthPrime a ≠ kthPrime b`, and `Nat.coprime_primes` turns distinctness of two primes into coprimality. The parent only verified specific small lists like `[2,3,5]` and `[2,3,5,7,11,13]` by `decide`.",
+    "mathContext": "Distinct primes are coprime ($\\gcd(p, q) = 1$ for $p \\ne q$ prime), so any set of distinct primes is pairwise coprime — exactly the CRT precondition for an RNS base. Injectivity of the prime enumerator upgrades 'distinct indices' to 'distinct primes', giving pairwise coprimality of the first $k$ primes for all $k$ at once.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.coprime_primes",
+      "List.Pairwise.map",
+      "List.pairwise_lt_range"
+    ],
+    "prerequisites": [
+      "Mathlib.Data.Nat.Prime.Basic",
+      "List.Pairwise"
+    ]
+  },
+  {
+    "id": "ann-capstone",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-01",
+    "range": {
+      "startLine": 260,
+      "endLine": 270
+    },
+    "type": "insight",
+    "title": "Capstone: a Valid k-Channel Base with Range ≥ 2^k for All k",
+    "content": "`firstPrimeBase k : RNSBase` packages the pairwise coprimality and the ≥ 2 bound into a genuine RNS base on the first k primes, for every k. `firstPrimeBase_channels` shows it has exactly k channels and `firstPrimeBase_dynamicRange` that its dynamic range is `primorialProper k`. The capstone `prime_base_growth_all_k` combines these: for every k there is a valid RNS base with k channels and dynamic range at least 2^k — the all-k statement the parent deferred.",
+    "mathContext": "This is the constructive payoff: not just a numeric bound on a number, but a witnessed family of valid RNS bases — one for each channel count $k$ — each provably CRT-correct (pairwise coprime moduli $\\ge 2$) and each with dynamic range $\\ge 2^k$. The honest scope: this establishes the growth lower bound, not full optimality (that consecutive primes maximize range under a width budget), which remains open.",
+    "significance": "key",
+    "relatedConcepts": [
+      "RNSBase",
+      "dynamic range",
+      "Chinese Remainder Theorem"
+    ],
+    "prerequisites": [
+      "firstPrimes_pairwise_coprime",
+      "primorialProper_ge_two_pow"
+    ]
+  }
+]

--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-01/meta.json
@@ -1,0 +1,120 @@
+{
+  "id": "chinese-remainder-constructive-oq-03-oq-01",
+  "title": "CRT RNS: Optimality of Prime Bases for All k",
+  "slug": "chinese-remainder-constructive-oq-03-oq-01",
+  "description": "Generalizes the parent's primorial growth bound from the k ≤ 6 lookup table to ALL k, by giving a proper total definition of the k-th prime via Mathlib's Nat.nth Nat.Prime. Proves primorialProper k ≥ 2^k for every k, that the proper primorial is strictly increasing and unbounded, that the first-k-primes list is pairwise coprime and bounded below by 2 for every k, and packages this into a genuine RNSBase (firstPrimeBase) with k channels and dynamic range ≥ 2^k for all k. Cross-checks the proper primorial against the classical sequence 1,2,6,30,210,2310,30030 for k=0..6.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChineseRemainderConstructiveOQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "modular-arithmetic",
+      "rns",
+      "prime-counting",
+      "primorial"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 275,
+    "assumptions": "None. Fully machine-checked, 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms reports only propext, Classical.choice, Quot.sound (no Lean.ofReduceBool; the small prime values are computed by kernel `decide` on Nat.count, not native_decide). The deeper open question of full optimality of prime bases (maximizing dynamic range under a width budget over all coprimality decompositions) is NOT settled — this entry delivers only the all-k growth lower bound the parent explicitly deferred.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 26,
+    "dateAdded": "2026-06-21",
+    "definitionCount": 6
+  },
+  "overview": {
+    "historicalContext": "Residue Number Systems were introduced by Harvey Garner in 1959 for parallel computer arithmetic. The dynamic range of a k-channel RNS base on the first k primes is the k-th primorial p_1·p_2·…·p_k, and a basic efficiency fact is that this grows at least like 2^k. The parent entry ChineseRemainderConstructiveOQ03 formalized RNS bases but defined the primorial only as a hand-written lookup table for k ≤ 6, proving the growth bound primorial k ≥ 2^k by interval_cases over that finite range. Its docstring explicitly noted that the bound holds for all k 'but proving it generally requires a proper definition of the k-th prime.' This entry supplies that missing definition and the all-k bound.",
+    "problemStatement": "Can the optimality (growth) of prime RNS bases be proved for all k, not just k ≤ 6 — which requires a proper, total definition of the k-th prime rather than a finite lookup table? Specifically: define the k-th prime for every k, define the primorial (product of the first k primes) for every k, and prove the dynamic-range lower bound primorial k ≥ 2^k for all k.",
+    "proofStrategy": "Define kthPrime i := Nat.nth Nat.Prime i, the i-th element of the (infinite) set of primes, which is total. From Mathlib's Nat.prime_nth_prime, Nat.nth_strictMono, and Nat.infinite_setOf_prime we get that every kthPrime i is prime, ≥ 2, strictly monotone in i, and injective. Define primorialProper k as the product of [kthPrime 0, …, kthPrime (k-1)]. A one-line recurrence primorialProper (k+1) = primorialProper k · kthPrime k drives a clean induction: 2^(k+1) = 2^k·2 ≤ primorialProper k · kthPrime k since each factor is ≥ 2 (Nat.mul_le_mul). Strict monotonicity and unboundedness follow from positivity and each prime being ≥ 2 (with Nat.lt_two_pow_self for unboundedness). Distinct indices give distinct primes (injectivity), so the first-k-primes list is pairwise coprime via Nat.coprime_primes; combined with the ≥ 2 bound this builds a genuine RNSBase for every k. Small prime values (kthPrime 0..5 = 2,3,5,7,11,13) are pinned by the characterization Nat.nth_count together with kernel `decide` on Nat.count Nat.Prime, keeping the file native_decide-free and 0-axiom.",
+    "keyInsights": [
+      "The right object is Mathlib's Nat.nth Nat.Prime — the enumerator of an infinite set — which makes 'the k-th prime' a total function and immediately replaces the parent's k ≤ 6 lookup table for every k.",
+      "All the optimality-relevant facts reduce to one recurrence primorialProper (k+1) = primorialProper k · kthPrime k and the single inequality 2 ≤ kthPrime k. The growth bound 2^k ≤ primorialProper k is then a two-line induction (pow_succ + Nat.mul_le_mul), in contrast to the parent's finite interval_cases.",
+      "Injectivity of kthPrime (from strict monotonicity) turns the abstract Nat.coprime_primes ('distinct primes are coprime') into pairwise coprimality of the entire first-k-primes list for every k — the parent only checked specific small lists like [2,3,5] and [2,3,5,7,11,13].",
+      "Concrete prime values can be obtained 0-axiom without native_decide: Nat.nth_count gives kthPrime (count Prime n) = n for prime n, and Nat.count Nat.Prime n reduces under kernel `decide` for small n, so kthPrime 0..5 = 2,3,5,7,11,13 are provable while #print axioms stays free of Lean.ofReduceBool.",
+      "The result is honestly a generalization of a growth lower bound, not a resolution of full optimality: showing consecutive primes MAXIMIZE the dynamic range subject to a channel-width budget over all coprimality decompositions remains open. This entry closes exactly the gap the parent deferred and no more."
+    ]
+  },
+  "sections": [
+    {
+      "id": "rns-base",
+      "title": "Minimal RNS Base (Self-Contained)",
+      "startLine": 62,
+      "endLine": 78,
+      "summary": "Re-declares a minimal RNSBase structure (pairwise coprime moduli ≥ 2) with channels and dynamicRange, mirroring the parent's RNSBase. This is self-contained because the parent file ChineseRemainderConstructiveOQ03.lean no longer compiles against Mathlib 4.26.0 (it has bit-rotted)."
+    },
+    {
+      "id": "kth-prime",
+      "title": "A Proper k-th Prime, Defined for All k",
+      "startLine": 81,
+      "endLine": 139,
+      "summary": "Defines kthPrime i := Nat.nth Nat.Prime i and proves it is prime, ≥ 2, positive, strictly monotone, and injective (from Nat.prime_nth_prime, Nat.nth_strictMono, Nat.infinite_setOf_prime). Pins the small values kthPrime 0..5 = 2,3,5,7,11,13 via Nat.nth_count + kernel decide on Nat.count, with no native_decide."
+    },
+    {
+      "id": "proper-primorial",
+      "title": "The Proper Primorial and the All-k Growth Bound",
+      "startLine": 142,
+      "endLine": 198,
+      "summary": "Defines firstPrimes k and primorialProper k (product of the first k primes) for every k, with recurrence primorialProper (k+1) = primorialProper k · kthPrime k. Proves the main result primorialProper_ge_two_pow: 2^k ≤ primorialProper k for ALL k, plus positivity, strict monotonicity, and unboundedness."
+    },
+    {
+      "id": "cross-check",
+      "title": "Cross-Check Against the Classical Sequence",
+      "startLine": 201,
+      "endLine": 215,
+      "summary": "primorialProper_values confirms the all-k definition reproduces the classical primorial sequence 1, 2, 6, 30, 210, 2310, 30030 for k = 0..6, matching the parent's lookup table exactly."
+    },
+    {
+      "id": "prime-base",
+      "title": "The Prime RNS Base, Valid for All k",
+      "startLine": 217,
+      "endLine": 258,
+      "summary": "Proves every modulus in firstPrimes k is ≥ 2 and that firstPrimes k is pairwise coprime for every k (via injectivity + Nat.coprime_primes). Packages these into firstPrimeBase k : RNSBase with exactly k channels and dynamic range = primorialProper k ≥ 2^k for all k."
+    },
+    {
+      "id": "summary",
+      "title": "Capstone",
+      "startLine": 260,
+      "endLine": 273,
+      "summary": "prime_base_growth_all_k: for every k there is a valid RNS base with exactly k channels and dynamic range at least 2^k, settling the all-k growth bound the parent deferred."
+    }
+  ],
+  "conclusion": {
+    "summary": "YES — the growth/optimality lower bound for prime RNS bases can be proved for ALL k. Defining the k-th prime as Nat.nth Nat.Prime i makes 'the first k primes' a total construction, and the primorial primorialProper k = ∏ first k primes then satisfies primorialProper k ≥ 2^k for every k by a two-line induction, generalizing the parent's interval_cases proof for k ≤ 6. The first-k-primes list is pairwise coprime and ≥ 2 for every k, yielding a genuine RNSBase with k channels and dynamic range ≥ 2^k for all k. The construction reproduces the classical primorial values 1,2,6,30,210,2310,30030 for k=0..6.",
+    "implications": "The efficiency claim that a k-channel prime RNS base provides at least 2^k dynamic range — i.e. at least k bits of range per the k channels — now holds uniformly in k rather than only for the small bases tabulated in hardware references. The proper k-th-prime definition also makes the whole RNS-base framework scale to arbitrarily many channels with machine-checked coprimality.",
+    "openQuestions": [
+      "Full optimality remains open: does the first-k-primes base MAXIMIZE the dynamic range among all k-channel bases whose moduli are pairwise coprime and bounded by a fixed channel width w? This requires reasoning over all prime-power decompositions, not just the growth bound.",
+      "Can a sharper lower bound than 2^k (e.g. reflecting the actual prime growth, primorial k = e^{(1+o(1)) p_k} by the prime number theorem) be formalized for all k?",
+      "What is the optimal trade-off between dynamic range and maximum channel width when the k-th prime is allowed to grow — i.e. the analogue of this bound under a hard cap on max(m_i)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chinese-remainder-constructive-oq-03",
+      "relationship": "extends",
+      "description": "Parent entry: efficient RNS bases. This entry supplies the proper k-th-prime definition the parent explicitly deferred and generalizes its primorial growth bound from k ≤ 6 to all k."
+    },
+    {
+      "targetId": "chinese-remainder-constructive-oq-03-oq-03",
+      "relationship": "related",
+      "description": "Sibling entry extending the same RNS-base framework with a power-of-2 channel; this entry instead extends the prime-channel growth bound to all k."
+    },
+    {
+      "targetId": "chinese-remainder-constructive",
+      "relationship": "foundational",
+      "description": "The constructive CRT proof providing the RNSBase / dynamic-range framework this entry builds on (re-declared locally here because the parent's RNS file no longer compiles)."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 275,
+    "path": "Proofs/ChineseRemainderConstructiveOQ03OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 6,
+    "theoremCount": 26
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question **"extend Burnside necklace counting to the dihedral group $D_n$"** by isolating the abstract mechanism that relates **bracelet** counts (dihedral orbits — rotations *and* reflections) to **necklace** counts (cyclic orbits — rotations only).

The rotation group sits inside $D_n$ as a subgroup of **index 2** ($|D_n| = 2n$), so everything about "adding reflections to Burnside" is a special case of a general fact about subgroups:

**`index_two_orbit_folding`** — for any finite group $G$ acting on a finite set $X$ and any subgroup $H \le G$,
$$|X/G|\cdot|G| = |X/H|\cdot|H| + \sum_{g \notin H} |\mathrm{Fix}(g)|.$$
Proof: apply Burnside's lemma to both $G$ and the restricted action of $H$, split the Burnside sum over $G$ by $H$-membership (`Finset.sum_filter_add_sum_filter_not`), and re-index the $H$-part (`Finset.sum_subtype`) to match Burnside over the subgroup. The only subtlety is that `fixedBy X (h:G)` and the restricted-action `fixedBy X h` are definitionally equal sets carrying different `Fintype` instances, reconciled by `Fintype.card_congr (Equiv.refl _)`.

With $G = D_n$, $H = \mathbb{Z}/n\mathbb{Z}$ this reads $\text{bracelets}\cdot 2n = \text{necklaces}\cdot n + \sum_{\text{reflections}}|\mathrm{Fix}|$ — the classical "bracelets = (necklaces + reflection fixed points)/2".

## Theorems
- `index_two_orbit_folding` — the headline general result.
- `dihedral_doubling` — the $|G| = 2|H|$ specialisation: $2|X/G||H| = |X/H||H| + \sum_{g\notin H}|\mathrm{Fix}(g)|$.
- `dihedralGroup_card` — $|D_n| = 2n$, the order relation that places the rotation group at index 2.
- `binary_four_bracelet_count` — plugging the classical length-4 binary data ($\text{necklaces}=6$, $|H|=4$, reflection total $=24$) into the folding theorem forces $\text{bracelets}=6$.

## Honesty / scope
The folding theorem is the genuine contribution: clean, fully general, axiom-free. The numeric corollary takes the necklace count and reflection total as **hypotheses** and derives the bracelet count — an exact algebraic reduction, not a from-scratch enumeration (recomputing those two finite counts would require rebuilding the parent's concrete orbit-quotient `Fintype`, which the parent only closes with `native_decide`). This complements sibling `oq-05`, whose listed open question is exactly "assemble the per-symmetry fixed-point counts into a dihedral count via Burnside".

## Verification
- `./proofs/scripts/docker-build.sh Proofs.BurnsideCountingOQ04` ✓ (3062 jobs)
- `#print axioms` on all four theorems → only `propext`, `Classical.choice`, `Quot.sound`. **0 axioms, 0 sorries, no `native_decide`.**

157 lines, 4 theorems, 0 defs.