### PR TITLE
research(algebraic-numbers-countable-oq-07): algebraic reals are Lebesgue-null [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -48,6 +48,7 @@ import Proofs.AlgebraicNumbersCountableOQ02OQ04
 import Proofs.AlgebraicNumbersCountableOQ04
 import Proofs.AlgebraicNumbersCountableOQ05
 import Proofs.AlgebraicRealsMeager
+import Proofs.AlgebraicRealsNull
 import Proofs.AlternatingSeriesTestOQ01
 import Proofs.AmgmInequalityOQ02
 import Proofs.AmgmInequalityOQ02Aristotle

--- a/proofs/Proofs/AlgebraicRealsNull.lean
+++ b/proofs/Proofs/AlgebraicRealsNull.lean
@@ -1,0 +1,205 @@
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.MeasureTheory.Measure.Lebesgue.Complex
+import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
+import Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms
+import Mathlib.Tactic
+import Proofs.AlgebraicNumbersCountable
+
+/-!
+# The Algebraic Reals are Lebesgue-Null (Measure Zero)
+
+## Open Question (algebraic-numbers-countable-oq-07)
+
+The companion entry `algebraic-numbers-countable` proves the algebraic reals
+`{x : ℝ | IsAlgebraic ℚ x}` are *countable*, and `algebraic-reals-meager`
+strengthens "countable" to the topological statement that they are *meagre*
+(first category in `ℝ`). Both of those entries explicitly invoke a third,
+*measure-theoretic*, notion of smallness that they leave unformalized:
+
+> "Topological smallness sits alongside the measure-theoretic smallness
+>  (the algebraic reals are Lebesgue-null) and the cardinality smallness
+>  (they are countable)."
+
+This entry closes that gap. It supplies the **measure** pillar of the
+trichotomy:
+
+    algebraic reals  ⊆  ℝ        are simultaneously
+      • countable          (cardinality:  ℵ₀ < 𝔠)           — algebraic-numbers-countable
+      • meagre             (Baire category: first category) — algebraic-reals-meager
+      • Lebesgue-null      (measure:       μ = 0)           — THIS ENTRY
+
+Dually, the **transcendental** reals are co-small in all three senses: they
+have full measure, so *almost every real number is transcendental*. This is
+the measure-theoretic counterpart of Cantor's cardinality argument
+("almost all reals are transcendental" in the sense of ℵ₀ < 𝔠) and of the
+Baire-category argument (the transcendentals are comeagre, hence dense).
+
+The mathematics is short — a countable set is null because Lebesgue measure
+has no atoms — but the three small/co-small dichotomies (cardinality,
+category, measure) are genuinely independent notions, and only this one was
+missing from the gallery. A measure-theoretic *existence* corollary
+(`exists_transcendental_of_pos_measure`) is included: any set of positive
+Lebesgue measure must contain a transcendental number. This complements the
+two classical existence proofs already in the gallery — Cantor's
+counting argument and Liouville's explicit construction — with a third,
+measure-theoretic, route to the existence of transcendentals.
+
+## Main results
+
+* `algebraic_reals_null`           : `volume {x : ℝ | IsAlgebraic ℚ x} = 0`
+* `ae_transcendental`              : almost every real is transcendental
+* `transcendental_reals_conull`    : the transcendentals have full (conull) measure
+* `transcendental_full_on_interval`: transcendentals fill almost all of any interval
+* `exists_transcendental_of_pos_measure`
+                                   : a positive-measure set contains a transcendental
+* `algebraic_complex_null`         : `volume {z : ℂ | IsAlgebraic ℚ z} = 0`
+
+0 sorries, 0 axioms (no `native_decide`).
+-/
+
+open MeasureTheory Set
+
+namespace AlgebraicRealsNull
+
+-- ============================================================================
+-- § 1. The algebraic reals are null
+-- ============================================================================
+
+/-- **The algebraic reals have Lebesgue measure zero.**
+
+A countable set is null for any measure without atoms, and Lebesgue measure on
+`ℝ` has no atoms (`noAtoms_volume`). The countability of `{x | IsAlgebraic ℚ x}`
+is the parent result `AlgebraicNumbersCountable.algebraic_reals_countable`. -/
+theorem algebraic_reals_null :
+    volume {x : ℝ | IsAlgebraic ℚ x} = 0 :=
+  (AlgebraicNumbersCountable.algebraic_reals_countable).measure_zero volume
+
+/-- The algebraic reals of degree `≤ d` are null (a subset of a null set). -/
+theorem algebraicRealsOfBoundedDegree_null (d : ℕ) :
+    volume (AlgebraicNumbersCountable.algebraicRealsOfBoundedDegree d) = 0 :=
+  (AlgebraicNumbersCountable.algebraicRealsOfBoundedDegree_countable d).measure_zero volume
+
+-- ============================================================================
+-- § 2. The transcendentals are conull: almost every real is transcendental
+-- ============================================================================
+
+/-- The complement of the transcendentals is exactly the algebraic reals.
+
+`Transcendental ℚ x` is by definition `¬ IsAlgebraic ℚ x`, so the set of
+transcendentals is the complement of the algebraic set, and taking the
+complement again returns the algebraic set. -/
+theorem compl_transcendental_eq_algebraic :
+    {x : ℝ | Transcendental ℚ x}ᶜ = {x : ℝ | IsAlgebraic ℚ x} := by
+  ext x
+  simp only [mem_compl_iff, mem_setOf_eq, Transcendental, not_not]
+
+/-- **The transcendental reals are conull**: their complement (the algebraic
+reals) has measure zero. Equivalently, the transcendentals have full measure. -/
+theorem transcendental_reals_conull :
+    volume {x : ℝ | Transcendental ℚ x}ᶜ = 0 := by
+  rw [compl_transcendental_eq_algebraic]
+  exact algebraic_reals_null
+
+/-- **Almost every real number is transcendental.**
+
+Restated as an almost-everywhere statement for the Lebesgue measure: the set of
+`x` with `Transcendental ℚ x` is conull. -/
+theorem ae_transcendental :
+    ∀ᵐ x : ℝ ∂volume, Transcendental ℚ x := by
+  have hset : {x : ℝ | Transcendental ℚ x} = {x : ℝ | IsAlgebraic ℚ x}ᶜ := by
+    ext x; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
+  rw [Filter.eventually_iff, hset]
+  exact compl_mem_ae_iff.mpr algebraic_reals_null
+
+-- ============================================================================
+-- § 3. Transcendentals fill almost all of every interval
+-- ============================================================================
+
+/-- The algebraic reals contribute nothing to the measure of any interval:
+`volume (Ioo a b ∩ algebraic) = 0`. -/
+theorem algebraic_inter_interval_null (a b : ℝ) :
+    volume (Ioo a b ∩ {x : ℝ | IsAlgebraic ℚ x}) = 0 :=
+  measure_mono_null (inter_subset_right) algebraic_reals_null
+
+/-- **The transcendentals fill almost all of any interval**: the part of
+`Ioo a b` consisting of transcendental numbers has the full measure of the
+interval, `ENNReal.ofReal (b - a)`. -/
+theorem transcendental_full_on_interval (a b : ℝ) :
+    volume (Ioo a b ∩ {x : ℝ | Transcendental ℚ x}) = ENNReal.ofReal (b - a) := by
+  have hset : Ioo a b ∩ {x : ℝ | Transcendental ℚ x}
+      = Ioo a b \ {x : ℝ | IsAlgebraic ℚ x} := by
+    ext x
+    simp only [mem_inter_iff, mem_diff, mem_setOf_eq, Transcendental]
+  rw [hset, measure_diff_null algebraic_reals_null, Real.volume_Ioo]
+
+-- ============================================================================
+-- § 4. Measure-theoretic existence of transcendentals
+-- ============================================================================
+
+/-- **Any set of positive Lebesgue measure contains a transcendental number.**
+
+If `s` had no transcendental element, then `s ⊆ {algebraic}`, forcing
+`volume s ≤ volume {algebraic} = 0`, contradicting `0 < volume s`.
+
+This is a third, measure-theoretic, existence proof for transcendentals,
+alongside Cantor's counting argument and Liouville's explicit construction. -/
+theorem exists_transcendental_of_pos_measure {s : Set ℝ} (hs : 0 < volume s) :
+    ∃ x ∈ s, Transcendental ℚ x := by
+  by_contra h
+  push_neg at h
+  -- `h : ∀ x ∈ s, ¬ Transcendental ℚ x`, i.e. every point of `s` is algebraic.
+  have hsub : s ⊆ {x : ℝ | IsAlgebraic ℚ x} := by
+    intro x hx
+    have := h x hx
+    simpa only [mem_setOf_eq, Transcendental, not_not] using this
+  have : volume s = 0 := measure_mono_null hsub algebraic_reals_null
+  rw [this] at hs
+  exact lt_irrefl 0 hs
+
+/-- Every interval `Ioo a b` with `a < b` contains a transcendental number —
+the special case of `exists_transcendental_of_pos_measure` for intervals. -/
+theorem exists_transcendental_mem_Ioo {a b : ℝ} (hab : a < b) :
+    ∃ x ∈ Ioo a b, Transcendental ℚ x := by
+  apply exists_transcendental_of_pos_measure
+  rw [Real.volume_Ioo]
+  simp [ENNReal.ofReal_pos, sub_pos, hab]
+
+-- ============================================================================
+-- § 5. The complex algebraic numbers are null
+-- ============================================================================
+
+/-- Lebesgue measure on `ℂ` has no atoms.
+
+Transport the singleton `{z}` through the measure-preserving identification
+`ℂ ≃ᵐ ℝ × ℝ`; its image is a single point of `ℝ × ℝ`, which is null because
+the planar Lebesgue measure has no atoms. -/
+instance : NoAtoms (volume : Measure ℂ) := by
+  have hpair : NoAtoms (volume : Measure (ℝ × ℝ)) := Measure.prod.instNoAtoms_fst
+  refine ⟨fun z => ?_⟩
+  have hmp := Complex.volume_preserving_equiv_real_prod
+  have hpre : ({z} : Set ℂ)
+      = Complex.measurableEquivRealProd ⁻¹' {Complex.measurableEquivRealProd z} := by
+    ext w
+    simp only [mem_preimage, mem_singleton_iff, Complex.measurableEquivRealProd_apply,
+      Prod.mk.injEq, Complex.ext_iff]
+  rw [hpre, hmp.measure_preimage (measurableSet_singleton _).nullMeasurableSet]
+  exact measure_singleton _
+
+/-- **The complex algebraic numbers have (planar) Lebesgue measure zero.**
+
+Same argument as on `ℝ`: the set `{z : ℂ | IsAlgebraic ℚ z}` is countable
+(`AlgebraicNumbersCountable.algebraic_complex_countable`) and `volume` on `ℂ`
+has no atoms. -/
+theorem algebraic_complex_null :
+    volume {z : ℂ | IsAlgebraic ℚ z} = 0 :=
+  (AlgebraicNumbersCountable.algebraic_complex_countable).measure_zero volume
+
+/-- Almost every complex number is transcendental. -/
+theorem ae_transcendental_complex :
+    ∀ᵐ z : ℂ ∂volume, Transcendental ℚ z := by
+  have hset : {z : ℂ | Transcendental ℚ z} = {z : ℂ | IsAlgebraic ℚ z}ᶜ := by
+    ext z; simp only [mem_setOf_eq, mem_compl_iff, Transcendental]
+  rw [Filter.eventually_iff, hset]
+  exact compl_mem_ae_iff.mpr algebraic_complex_null
+
+end AlgebraicRealsNull

--- a/src/data/proofs/algebraic-numbers-countable-oq-07/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-oq07-countable-implies-null",
+    "proofId": "algebraic-numbers-countable-oq-07",
+    "range": {
+      "startLine": 70,
+      "endLine": 80
+    },
+    "type": "concept",
+    "title": "Countable Implies Null for an Atomless Measure",
+    "content": "The main theorem `algebraic_reals_null` is a one-liner: `(AlgebraicNumbersCountable.algebraic_reals_countable).measure_zero volume`. It chains two facts. First, the parent entry's `algebraic_reals_countable` says `{x : ℝ | IsAlgebraic ℚ x}` is countable. Second, `Set.Countable.measure_zero` says any countable set is null — but only for a measure with `[NoAtoms μ]`. Lebesgue measure supplies this via the instance `Real.noAtoms_volume`. The implication countable ⟹ null genuinely needs atomlessness: for a Dirac measure a single point already has full mass.",
+    "mathContext": "Set.Countable.measure_zero : s.Countable → ∀ (μ : Measure α) [NoAtoms μ], μ s = 0. A countable set is a countable union of singletons; atomlessness makes each singleton null, and countable subadditivity sums them to 0.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Set.Countable.measure_zero",
+      "MeasureTheory.NoAtoms",
+      "Real.noAtoms_volume",
+      "Lebesgue measure"
+    ],
+    "prerequisites": [
+      "Countability of the algebraic reals (parent entry)",
+      "Atomlessness of Lebesgue measure"
+    ]
+  },
+  {
+    "id": "ann-oq07-transcendental-complement",
+    "proofId": "algebraic-numbers-countable-oq-07",
+    "range": {
+      "startLine": 81,
+      "endLine": 117
+    },
+    "type": "concept",
+    "title": "Transcendentals as a Set-Complement, and the a.e. Statement",
+    "content": "`Transcendental ℚ x` is definitionally `¬ IsAlgebraic ℚ x`, so the set of transcendentals is exactly the complement of the algebraic reals (`compl_transcendental_eq_algebraic`). This makes the conull and almost-everywhere statements immediate: `transcendental_reals_conull` rewrites the complement to the algebraic set and applies `algebraic_reals_null`; `ae_transcendental` translates 'the complement is null' into the measure filter via `compl_mem_ae_iff : sᶜ ∈ ae μ ↔ μ s = 0`.",
+    "mathContext": "{x | Transcendental ℚ x} = {x | IsAlgebraic ℚ x}ᶜ. Then sᶜ ∈ ae volume ↔ volume s = 0, so ∀ᵐ x, Transcendental ℚ x is equivalent to volume {algebraic} = 0.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Transcendental",
+      "compl_mem_ae_iff",
+      "Filter.eventually_iff",
+      "almost everywhere"
+    ],
+    "prerequisites": [
+      "Definition of Transcendental as ¬ IsAlgebraic",
+      "The almost-everywhere filter"
+    ]
+  },
+  {
+    "id": "ann-oq07-interval-full-measure",
+    "proofId": "algebraic-numbers-countable-oq-07",
+    "range": {
+      "startLine": 118,
+      "endLine": 143
+    },
+    "type": "technique",
+    "title": "Transcendentals Carry the Full Measure of Any Interval",
+    "content": "Inside an interval the algebraic reals remain null (`algebraic_inter_interval_null`, by monotonicity of measure into the global null set). The transcendental part of `Ioo a b` equals `Ioo a b \\ {algebraic}`, and `measure_diff_null` says removing a null set leaves the measure unchanged, so the transcendental part has the full measure `ENNReal.ofReal (b − a)` of the interval (`transcendental_full_on_interval`). The key rewrite identifies the set-difference: `Ioo a b ∩ {transcendental} = Ioo a b \\ {algebraic}` because transcendental = ¬ algebraic.",
+    "mathContext": "measure_diff_null : μ t = 0 → μ (s \\ t) = μ s. With s = Ioo a b, t = {algebraic} and Real.volume_Ioo : volume (Ioo a b) = ofReal (b - a).",
+    "significance": "high",
+    "relatedConcepts": [
+      "measure_diff_null",
+      "Real.volume_Ioo",
+      "measure_mono_null",
+      "set difference"
+    ],
+    "prerequisites": [
+      "Monotonicity of measure",
+      "Measure of an interval"
+    ]
+  },
+  {
+    "id": "ann-oq07-existence-of-transcendentals",
+    "proofId": "algebraic-numbers-countable-oq-07",
+    "range": {
+      "startLine": 144,
+      "endLine": 168
+    },
+    "type": "insight",
+    "title": "A Measure-Theoretic Existence Proof for Transcendentals",
+    "content": "`exists_transcendental_of_pos_measure` proves that any set `s` of positive Lebesgue measure must contain a transcendental number — a third existence proof alongside Cantor's counting and Liouville's explicit construction. The argument is purely negative: if `s` had no transcendental element, every point of `s` would be algebraic, so `s ⊆ {algebraic}`; monotonicity then forces `volume s ≤ volume {algebraic} = 0`, contradicting `0 < volume s`. The interval special case `exists_transcendental_mem_Ioo` follows since `volume (Ioo a b) = ofReal (b − a) > 0`.",
+    "mathContext": "By contradiction with push_neg: ¬(∃ x ∈ s, Transcendental ℚ x) gives s ⊆ {algebraic}; measure_mono_null sends volume s to 0. This is the 'a random real is almost surely transcendental' phenomenon made into an existence statement.",
+    "significance": "high",
+    "relatedConcepts": [
+      "measure_mono_null",
+      "Set.not_subset",
+      "existence of transcendentals",
+      "probabilistic method"
+    ],
+    "prerequisites": [
+      "Monotonicity of measure into a null set",
+      "The algebraic reals are null"
+    ]
+  },
+  {
+    "id": "ann-oq07-complex-atomless",
+    "proofId": "algebraic-numbers-countable-oq-07",
+    "range": {
+      "startLine": 169,
+      "endLine": 205
+    },
+    "type": "technique",
+    "title": "Atomlessness of the Planar Lebesgue Measure via a Measure-Preserving Equivalence",
+    "content": "To run the same argument on ℂ one needs `NoAtoms (volume : Measure ℂ)`, which is not a single named instance for ℂ. The proof transports a singleton `{z}` through the measure-preserving identification `Complex.measurableEquivRealProd : ℂ ≃ᵐ ℝ × ℝ`: `{z}` is the preimage of the single point `{e z}`, so by `MeasurePreserving.measure_preimage` its volume equals the planar volume of that point, which is zero because `volume` on ℝ × ℝ is `Measure.prod` of two atomless factors (`Measure.prod.instNoAtoms_fst`). With the instance in hand, `algebraic_complex_null` and `ae_transcendental_complex` mirror the real case.",
+    "mathContext": "MeasurePreserving.measure_preimage : MeasurePreserving f μ ν → NullMeasurableSet s ν → μ (f ⁻¹' s) = ν s. Here f = measurableEquivRealProd, s = {e z}, ν = volume on ℝ × ℝ; measure_singleton gives ν {e z} = 0.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "Complex.volume_preserving_equiv_real_prod",
+      "MeasurePreserving.measure_preimage",
+      "Measure.prod.instNoAtoms_fst",
+      "measure_singleton"
+    ],
+    "prerequisites": [
+      "Measure-preserving maps",
+      "Product measures and atomlessness"
+    ]
+  }
+]

--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -1,0 +1,189 @@
+{
+  "id": "algebraic-numbers-countable-oq-07",
+  "title": "The Algebraic Reals are Lebesgue-Null: Almost Every Real is Transcendental",
+  "slug": "algebraic-numbers-countable-oq-07",
+  "description": "Supplies the measure-theoretic pillar of the smallness trichotomy for the algebraic numbers. The companion entries prove the algebraic reals are countable (cardinality) and meagre (Baire category); this entry proves they are Lebesgue-null (measure zero) — a countable set is null because Lebesgue measure has no atoms. Dually, the transcendentals have full measure: almost every real number is transcendental. Includes a measure-theoretic existence proof of transcendentals (any positive-measure set contains one) and the complex analogue. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicRealsNull.lean",
+    "tags": [
+      "set-theory",
+      "measure-theory",
+      "lebesgue-measure",
+      "algebraic-numbers",
+      "transcendental-numbers",
+      "almost-everywhere",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 205,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-21",
+    "assumptions": "",
+    "originalContributions": [
+      "algebraic_reals_null: volume {x : ℝ | IsAlgebraic ℚ x} = 0 — the algebraic reals have Lebesgue measure zero",
+      "algebraicRealsOfBoundedDegree_null: each bounded-degree stratum of algebraic reals is null",
+      "compl_transcendental_eq_algebraic: the complement of the transcendentals is exactly the algebraic reals",
+      "transcendental_reals_conull: the transcendentals are conull (their complement has measure zero)",
+      "ae_transcendental: almost every real number is transcendental (∀ᵐ x ∂volume, Transcendental ℚ x)",
+      "algebraic_inter_interval_null: the algebraic reals contribute zero measure to any interval",
+      "transcendental_full_on_interval: the transcendentals fill almost all of any interval Ioo a b, with full measure ofReal (b − a)",
+      "exists_transcendental_of_pos_measure: any set of positive Lebesgue measure contains a transcendental number — a measure-theoretic existence proof",
+      "exists_transcendental_mem_Ioo: every nondegenerate interval contains a transcendental number",
+      "NoAtoms (volume : Measure ℂ): the planar Lebesgue measure has no atoms (transported via ℂ ≃ᵐ ℝ × ℝ)",
+      "algebraic_complex_null: the complex algebraic numbers have planar Lebesgue measure zero",
+      "ae_transcendental_complex: almost every complex number is transcendental"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Cantor's 1874 theorem that the algebraic numbers are countable already implies, by cardinality alone, that 'almost every' real number is transcendental — there are only ℵ₀ algebraic reals against 𝔠 = 2^ℵ₀ reals. But 'almost every' has three independent precise meanings, and cardinality is only one of them. A subset of ℝ can be 'small' in the sense of cardinality (countable), in the sense of Baire category (meagre / first category), or in the sense of measure (Lebesgue-null). These three notions are genuinely independent: there exist meagre sets of full measure and null sets of second category, so no two of the three imply each other.\n\nThe algebraic reals happen to be small in all three senses simultaneously, and the gallery already records two of the three pillars. The companion entry `algebraic-numbers-countable` establishes the cardinality pillar (countable, ℵ₀ < 𝔠) and `algebraic-reals-meager` establishes the Baire-category pillar (meagre, hence the transcendentals are comeagre and dense). Both of those entries explicitly point at the third, measure-theoretic, pillar — 'the algebraic reals are Lebesgue-null' — but leave it unformalized. This entry closes that gap.\n\nThe measure-theoretic statement is the easiest of the three to prove once Cantor's countability is in hand: a countable set is null for any measure that puts no mass on individual points, and Lebesgue measure on ℝ is exactly such a measure (it has no atoms). So 'almost every real is transcendental' holds in the measure sense — the strongest everyday meaning of 'almost every' — and not merely in the cardinality sense.",
+    "problemStatement": "**Open question (measure pillar)**: The algebraic reals are known to be countable (`algebraic-numbers-countable`) and meagre (`algebraic-reals-meager`). Complete the smallness trichotomy by proving they are also **Lebesgue-null**, and dually that the transcendental reals have **full measure** — so that 'almost every real is transcendental' holds in the measure-theoretic sense, not just the cardinality sense.\n\n**Main theorem**: `volume {x : ℝ | IsAlgebraic ℚ x} = 0`. Equivalently, `∀ᵐ x ∂volume, Transcendental ℚ x`.",
+    "proofStrategy": "The argument is short and rests on one structural fact about Lebesgue measure.\n\n**Step 1 — atoms.** Lebesgue measure `volume` on ℝ has no atoms: every singleton has measure zero. This is the Mathlib instance `Real.noAtoms_volume`, and the general lemma `Set.Countable.measure_zero` upgrades it to: any countable set is null.\n\n**Step 2 — algebraic reals are null.** The parent entry proves `{x : ℝ | IsAlgebraic ℚ x}` is countable (`AlgebraicNumbersCountable.algebraic_reals_countable`). Combining with Step 1 gives `algebraic_reals_null`.\n\n**Step 3 — transcendentals are conull.** `Transcendental ℚ x` is by definition `¬ IsAlgebraic ℚ x`, so the transcendentals are the set-complement of the algebraic reals. Their complement therefore has measure zero (`transcendental_reals_conull`), which is exactly the almost-everywhere statement `ae_transcendental` via `compl_mem_ae_iff`.\n\n**Step 4 — interval and existence consequences.** Inside any interval the algebraic part is still null, so the transcendentals carry the full measure `ofReal (b − a)` of the interval (`transcendental_full_on_interval`, via `measure_diff_null`). A clean structural corollary: any set of positive measure must contain a transcendental, since otherwise it would be a subset of a null set (`exists_transcendental_of_pos_measure`).\n\n**Step 5 — complex case.** The same argument runs on ℂ once one knows `volume` on ℂ has no atoms. This is obtained by transporting a singleton `{z}` through the measure-preserving identification `ℂ ≃ᵐ ℝ × ℝ` (`Complex.volume_preserving_equiv_real_prod`); its image is a single point of ℝ × ℝ, which is null because the planar Lebesgue measure has no atoms (a product of atomless measures is atomless).",
+    "keyInsights": [
+      "The three notions of smallness — countable (cardinality), meagre (Baire category), and null (Lebesgue measure) — are logically independent in general, so each requires its own proof. The algebraic reals happen to be small in all three senses, and this entry supplies the one (measure) that was missing from the gallery.",
+      "Countable ⟹ null is not automatic for an arbitrary measure: it requires the measure to be atomless (no point masses). Lebesgue measure qualifies (`Real.noAtoms_volume`), so the implication goes through via `Set.Countable.measure_zero`. For a measure with atoms (e.g. a Dirac mass), a countable set can have positive measure.",
+      "`Transcendental ℚ x` unfolds definitionally to `¬ IsAlgebraic ℚ x`, so the transcendentals are literally the set-complement of the algebraic reals. This makes the conull/almost-everywhere statements immediate from the null statement via `compl_mem_ae_iff`.",
+      "The existence corollary `exists_transcendental_of_pos_measure` is a third, measure-theoretic, proof that transcendentals exist — alongside Cantor's counting argument (cardinality) and Liouville's explicit construction (analysis). The proof is purely negative: a set with no transcendental would sit inside the null algebraic set, forcing its measure to be zero.",
+      "The complex analogue needs `NoAtoms (volume : Measure ℂ)`, which is not a single named Mathlib instance for ℂ but follows by transporting singletons through the measure-preserving `ℂ ≃ᵐ ℝ × ℝ` to the planar measure, where atomlessness comes from `Measure.prod` of two atomless factors."
+    ],
+    "prerequisites": [
+      "AlgebraicNumbersCountable: the parent entry — countability of the algebraic reals and complex algebraic numbers",
+      "Set.Countable.measure_zero: a countable set is null for any atomless measure",
+      "Real.noAtoms_volume: Lebesgue measure on ℝ has no atoms",
+      "compl_mem_ae_iff: sᶜ ∈ ae μ ↔ μ s = 0 — the bridge from measure-zero to almost-everywhere",
+      "measure_diff_null: removing a null set does not change a set's measure",
+      "Complex.volume_preserving_equiv_real_prod: ℂ ≃ᵐ ℝ × ℝ is measure preserving"
+    ],
+    "furtherWork": "Natural follow-ups: (1) Strengthen to a quantitative statement — the Hausdorff dimension of the algebraic reals is 0 (a countable set has dimension 0), refining 'measure zero'. (2) Liouville numbers give an explicit comeagre but measure-zero set of transcendentals; contrasting that null-but-comeagre set with this entry's conull transcendentals sharpens the independence of category and measure. (3) Formalize the three-way independence directly by exhibiting a meagre set of full measure inside ℝ. (4) Establish the same null result for algebraic numbers in higher-dimensional ℝⁿ or for the ring of algebraic integers inside the adeles."
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 69,
+      "summary": "Imports (Lebesgue measure on ℝ and ℂ, NoAtoms typeclass, the parent countability entry), the module docstring stating the open question and the cardinality/category/measure trichotomy, the list of main results, and the namespace with opens (MeasureTheory, Set).",
+      "mathContext": "Open question: complete the smallness trichotomy by proving the algebraic reals are Lebesgue-null."
+    },
+    {
+      "id": "section-1-algebraic-null",
+      "title": "§1. The Algebraic Reals are Null",
+      "startLine": 70,
+      "endLine": 80,
+      "summary": "`algebraic_reals_null`: volume {x : ℝ | IsAlgebraic ℚ x} = 0, from countability (parent) + atomless Lebesgue measure. `algebraicRealsOfBoundedDegree_null`: each bounded-degree stratum is null as a subset.",
+      "mathContext": "A countable set is null for the atomless Lebesgue measure: $\\mathrm{vol}\\{x : \\mathrm{IsAlgebraic}_\\mathbb{Q}\\,x\\} = 0$."
+    },
+    {
+      "id": "section-2-conull-transcendentals",
+      "title": "§2. The Transcendentals are Conull",
+      "startLine": 81,
+      "endLine": 117,
+      "summary": "`compl_transcendental_eq_algebraic`: the complement of the transcendentals is the algebraic reals. `transcendental_reals_conull`: the transcendentals have conull complement. `ae_transcendental`: almost every real is transcendental.",
+      "mathContext": "$\\{x : \\mathrm{Transcendental}_\\mathbb{Q}\\,x\\}^c = \\{x : \\mathrm{IsAlgebraic}_\\mathbb{Q}\\,x\\}$ is null, so a.e. $x$ is transcendental."
+    },
+    {
+      "id": "section-3-intervals",
+      "title": "§3. Transcendentals Fill Almost All of Every Interval",
+      "startLine": 118,
+      "endLine": 143,
+      "summary": "`algebraic_inter_interval_null`: algebraic reals contribute zero measure to any interval. `transcendental_full_on_interval`: the transcendental part of Ioo a b has the full measure ofReal (b − a), via measure_diff_null.",
+      "mathContext": "$\\mathrm{vol}(\\mathrm{Ioo}\\,a\\,b \\cap \\{\\text{transcendental}\\}) = \\mathrm{ofReal}(b-a)$."
+    },
+    {
+      "id": "section-4-existence",
+      "title": "§4. Measure-Theoretic Existence of Transcendentals",
+      "startLine": 144,
+      "endLine": 168,
+      "summary": "`exists_transcendental_of_pos_measure`: any positive-measure set contains a transcendental (else it would be a subset of the null algebraic set). `exists_transcendental_mem_Ioo`: the special case for intervals.",
+      "mathContext": "$0 < \\mathrm{vol}(s) \\implies \\exists x \\in s,\\ \\mathrm{Transcendental}_\\mathbb{Q}\\,x$."
+    },
+    {
+      "id": "section-5-complex",
+      "title": "§5. The Complex Algebraic Numbers are Null",
+      "startLine": 169,
+      "endLine": 205,
+      "summary": "Local instance `NoAtoms (volume : Measure ℂ)` by transporting singletons through ℂ ≃ᵐ ℝ × ℝ. `algebraic_complex_null`: complex algebraic numbers have planar measure zero. `ae_transcendental_complex`: almost every complex number is transcendental.",
+      "mathContext": "$\\mathrm{vol}\\{z : \\mathbb{C} \\mid \\mathrm{IsAlgebraic}_\\mathbb{Q}\\,z\\} = 0$ via the atomless planar Lebesgue measure."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry completes the smallness trichotomy for the algebraic numbers by supplying its measure-theoretic pillar: the algebraic reals (and complex algebraic numbers) have Lebesgue measure zero, so almost every real (and complex) number is transcendental. The proof is short — a countable set is null because Lebesgue measure is atomless — but it records the one of the three independent smallness notions (cardinality, Baire category, measure) that was missing from the gallery. All 11 theorems are proved with 0 sorries and 0 axioms.",
+    "implications": "With this entry, the gallery records all three senses in which 'almost every real is transcendental': cardinality (ℵ₀ < 𝔠, parent entry), Baire category (the transcendentals are comeagre, `algebraic-reals-meager`), and measure (the transcendentals are conull, this entry). Because the three notions are logically independent, each is a genuinely separate theorem, and only by proving all three is the statement 'the algebraic reals are negligible' established in every standard sense.\n\nThe measure-theoretic existence corollary adds a third route to the existence of transcendentals — any positive-measure set contains one — complementing Cantor's counting proof and Liouville's explicit construction. This is the prototype of a probabilistic/measure-theoretic existence argument: a randomly chosen real (uniform on any interval) is transcendental with probability one.",
+    "openQuestions": [
+      "Refine 'measure zero' to 'Hausdorff dimension zero': a countable set has Hausdorff dimension 0, which is strictly stronger than Lebesgue-null. Formalizing $\\dim_H\\{x : \\mathrm{IsAlgebraic}_\\mathbb{Q}\\,x\\} = 0$ would sharpen this entry and connect to the fractal-geometry hierarchy of negligible sets.",
+      "Exhibit the independence of category and measure directly using transcendentals: the Liouville numbers are a comeagre (residual) set that is nonetheless Lebesgue-null, while this entry's transcendentals are conull. Formalizing both inside one file would demonstrate that 'comeagre' and 'conull' are incomparable notions of largeness even within the transcendentals.",
+      "Generalize to ℝⁿ and ℂⁿ: the set of points with at least one algebraic coordinate is null in ℝⁿ, and the algebraic points (all coordinates algebraic) are countable hence null. State and prove the n-dimensional version, where 'almost every point has all coordinates transcendental and algebraically independent'.",
+      "Probabilistic phrasing: for any atomless Borel probability measure μ on ℝ (e.g. a Gaussian), the algebraic reals are still μ-null, so a μ-random real is almost surely transcendental. The present proof already works verbatim for any atomless measure — formalize the general `[NoAtoms μ]` statement and specialize to named distributions."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "extends",
+      "description": "The parent entry proves the algebraic reals are countable (the cardinality pillar of smallness). This entry consumes that countability theorem directly (`algebraic_reals_countable`) and upgrades it to the measure pillar: countable ⟹ null because Lebesgue measure is atomless. Together they give two of the three independent senses in which the algebraic reals are negligible."
+    },
+    {
+      "targetId": "algebraic-reals-meager",
+      "relationship": "complementary",
+      "description": "Provides the Baire-category pillar of the same smallness trichotomy: the algebraic reals are meagre (first category) and the transcendentals are comeagre (residual), hence dense. This entry provides the measure pillar (null / conull). The two are logically independent — meagre does not imply null and vice versa — so both are needed to establish that the algebraic reals are small in every standard sense. The `algebraic-reals-meager` docstring explicitly names 'the algebraic reals are Lebesgue-null' as the measure-theoretic counterpart, which this entry formalizes."
+    },
+    {
+      "targetId": "algebraic-numbers-countable-oq-02-oq-03",
+      "relationship": "complementary",
+      "description": "Computes the exact cardinality of the transcendental reals: #transcendentals = 𝔠 = 2^ℵ₀ (the cardinality version of 'almost every real is transcendental'). This entry gives the measure version of the same slogan: the transcendentals are conull. The two together show the transcendentals are large in both the cardinality and the measure senses, while the algebraic reals are small in both."
+    },
+    {
+      "targetId": "liouville-theorem",
+      "relationship": "complementary",
+      "description": "Liouville's 1844 explicit construction of a transcendental number. This entry instead proves transcendentals exist by measure (`exists_transcendental_of_pos_measure`): any positive-measure set contains one, without naming it. Liouville numbers are themselves a striking foil — they form a comeagre but measure-zero set of transcendentals, contrasting with this entry's conull set of transcendentals, illustrating that Baire category and Lebesgue measure are independent notions of largeness."
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "complementary",
+      "description": "Hermite's 1873 proof that e is transcendental names a single concrete transcendental. This entry proves almost every real is transcendental without exhibiting any. The contrast mirrors the classical division of labour: constructive transcendence proofs (Hermite, Lindemann, Liouville) name specific numbers, while cardinality, category, and measure arguments show the transcendentals are abundant without naming one."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/AlgebraicRealsNull.lean",
+    "lineCount": 205,
+    "theoremCount": 11,
+    "axiomCount": 0,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": [
+        "G. Cantor"
+      ],
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik (Crelle's Journal), vol. 77, pp. 258–262",
+      "note": "Cantor's original countability theorem for the algebraic numbers, which (with the atomlessness of Lebesgue measure) yields the measure-zero result formalized here."
+    },
+    {
+      "authors": [
+        "J. C. Oxtoby"
+      ],
+      "title": "Measure and Category: A Survey of the Analogies between Topological and Measure Spaces",
+      "year": "1980",
+      "venue": "Springer, Graduate Texts in Mathematics 2",
+      "note": "The classic reference on the independence and analogy between Baire category and Lebesgue measure, the conceptual backdrop for the smallness trichotomy this entry completes."
+    },
+    {
+      "authors": [
+        "W. Rudin"
+      ],
+      "title": "Real and Complex Analysis",
+      "year": "1987",
+      "venue": "McGraw-Hill",
+      "note": "Standard source for the fact that countable subsets of ℝ are Lebesgue-null and for the atomlessness of Lebesgue measure."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/algebraic-numbers-countable-oq-07.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-07.json
@@ -1,0 +1,97 @@
+{
+  "slug": "algebraic-numbers-countable-oq-07",
+  "title": "Algebraic Numbers Countable: The Algebraic Reals are Lebesgue-Null",
+  "phase": "COMPLETED",
+  "status": "active",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "volume {x : ℝ | IsAlgebraic ℚ x} = 0  ∧  ∀ᵐ x ∂volume, Transcendental ℚ x",
+    "plain": "The algebraic reals are known to be countable (cardinality) and meagre (Baire category). Complete the smallness trichotomy by proving they are also Lebesgue-null (measure zero), and dually that almost every real number is transcendental.",
+    "whyMatters": [
+      "Cardinality, Baire category, and Lebesgue measure are three logically independent notions of 'smallness'; only by proving all three is the algebraic reals' negligibility established in every standard sense.",
+      "Gives the measure-theoretic version of 'almost every real is transcendental', the strongest everyday reading of the slogan.",
+      "Yields a third existence proof for transcendentals (any positive-measure set contains one), alongside Cantor's counting and Liouville's construction."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "The algebraic reals are countable (parent entry algebraic-numbers-countable)",
+      "The algebraic reals are meagre / first category (algebraic-reals-meager)",
+      "A countable set is Lebesgue-null because Lebesgue measure is atomless (Mathlib Set.Countable.measure_zero + Real.noAtoms_volume)"
+    ],
+    "open": [],
+    "goal": "Formalize volume {x : ℝ | IsAlgebraic ℚ x} = 0 and the dual conull/almost-everywhere transcendence statements, plus the complex analogue."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-21",
+    "iteration": 1,
+    "focus": "Measure-theoretic pillar of the smallness trichotomy: algebraic reals are Lebesgue-null.",
+    "blockers": [],
+    "nextAction": "Done — 11 theorems, 0 sorries, 0 axioms, verified.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED: Proved the algebraic reals (and complex algebraic numbers) have Lebesgue measure zero, supplying the measure pillar of the cardinality/category/measure smallness trichotomy. Dually, almost every real (and complex) number is transcendental, and any positive-measure set contains a transcendental. 11 theorems, 0 sorries, 0 axioms (only propext/Classical.choice/Quot.sound).",
+    "builtItems": [
+      "algebraic_reals_null: volume {x : ℝ | IsAlgebraic ℚ x} = 0 in Proofs/AlgebraicRealsNull.lean",
+      "ae_transcendental: almost every real is transcendental (∀ᵐ x ∂volume, Transcendental ℚ x)",
+      "transcendental_full_on_interval: transcendentals carry the full measure ofReal (b − a) of any interval",
+      "exists_transcendental_of_pos_measure: any positive-measure set contains a transcendental",
+      "NoAtoms (volume : Measure ℂ) + algebraic_complex_null: complex algebraic numbers are null"
+    ],
+    "insights": [
+      "Countable ⟹ null requires the measure to be atomless; Lebesgue measure qualifies via Real.noAtoms_volume, so Set.Countable.measure_zero applies to the parent's countability theorem in one line.",
+      "Transcendental ℚ x is definitionally ¬ IsAlgebraic ℚ x, so the transcendentals are the set-complement of the algebraic reals; conull and a.e. statements follow from compl_mem_ae_iff.",
+      "The complex case needs NoAtoms (volume : Measure ℂ), which is not a single named instance; transport singletons through the measure-preserving ℂ ≃ᵐ ℝ × ℝ to the atomless planar measure (Measure.prod.instNoAtoms_fst).",
+      "measure_diff_null gives the interval full-measure result directly: Ioo a b ∩ {transcendental} = Ioo a b \\ {algebraic}, and removing the null algebraic set leaves the interval's measure unchanged."
+    ],
+    "mathlibGaps": [
+      "No single named NoAtoms instance for volume on ℂ; derived locally via the measure-preserving equivalence to ℝ × ℝ."
+    ],
+    "nextSteps": [
+      "Refine measure-zero to Hausdorff dimension zero for the algebraic reals.",
+      "Contrast with Liouville numbers (comeagre but null) to formalize independence of category and measure.",
+      "Generalize to ℝⁿ / ℂⁿ and to arbitrary atomless Borel probability measures."
+    ],
+    "markdown": "# Knowledge Base: algebraic-numbers-countable-oq-07\n\n## Result\n\nThe algebraic reals are Lebesgue-null, completing the cardinality/category/measure smallness trichotomy. Dually, almost every real (and complex) number is transcendental, and any positive-measure set contains a transcendental.\n\n## Key technique\n\nA countable set is null for any atomless measure (`Set.Countable.measure_zero` + `Real.noAtoms_volume`), so the parent's countability theorem upgrades to measure zero in one line. The complex case transports singletons through the measure-preserving `ℂ ≃ᵐ ℝ × ℝ`.\n"
+  },
+  "leanFiles": [
+    "Proofs/AlgebraicRealsNull.lean"
+  ],
+  "references": {
+    "papers": [
+      "G. Cantor, Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen, Crelle 77 (1874) 258–262",
+      "J. C. Oxtoby, Measure and Category, Springer GTM 2 (1980)"
+    ],
+    "urls": [],
+    "mathlib": [
+      "Set.Countable.measure_zero",
+      "MeasureTheory.Real.noAtoms_volume",
+      "MeasureTheory.compl_mem_ae_iff",
+      "MeasureTheory.measure_diff_null",
+      "Complex.volume_preserving_equiv_real_prod"
+    ]
+  },
+  "relatedProofs": [
+    "algebraic-numbers-countable",
+    "algebraic-reals-meager",
+    "algebraic-numbers-countable-oq-02-oq-03",
+    "liouville-theorem"
+  ],
+  "tags": [
+    "set-theory",
+    "measure-theory",
+    "lebesgue-measure",
+    "algebraic-numbers",
+    "transcendental-numbers",
+    "almost-everywhere"
+  ],
+  "started": "2026-06-21",
+  "lastUpdate": "2026-06-21"
+}


### PR DESCRIPTION
## Summary
Research session for **algebraic-numbers-countable-oq-07**. Supplies the **measure-theoretic pillar** of the smallness trichotomy for the algebraic numbers.

The gallery already records that the algebraic reals are:
- **countable** (cardinality: ℵ₀ < 𝔠) — `algebraic-numbers-countable`
- **meagre** (Baire category: first category) — `algebraic-reals-meager`

Both of those entries' docstrings explicitly name "the algebraic reals are Lebesgue-null" as the missing measure-theoretic counterpart. This entry formalizes it.

## Main results (`Proofs/AlgebraicRealsNull.lean`)
- `algebraic_reals_null` : `volume {x : ℝ | IsAlgebraic ℚ x} = 0` — a countable set is null because Lebesgue measure is atomless
- `ae_transcendental` : almost every real number is transcendental
- `transcendental_reals_conull` : the transcendentals are conull (full measure)
- `transcendental_full_on_interval` : transcendentals carry the full measure `ofReal (b − a)` of any interval
- `exists_transcendental_of_pos_measure` : any positive-measure set contains a transcendental — a third existence proof alongside Cantor's counting and Liouville's construction
- `algebraic_complex_null` / `ae_transcendental_complex` : complex analogue, with `NoAtoms (volume : Measure ℂ)` derived by transporting singletons through `ℂ ≃ᵐ ℝ × ℝ`

## Verification
- 11 theorems, 0 sorries, 0 axioms
- `#print axioms` lists only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`)
- Built with `./proofs/scripts/docker-build.sh Proofs.AlgebraicRealsNull`

## Honesty
The mathematics is short — countable ⟹ null for an atomless measure — but it records the one of three *logically independent* smallness notions (cardinality, category, measure) that was missing from the gallery. No deep new theorem; the value is completing the trichotomy and adding the measure-theoretic existence corollary.

## Status
**Outcome**: completed
**Next Steps**: refine to Hausdorff dimension 0; contrast with Liouville numbers (comeagre but null) to formalize independence of category and measure; generalize to ℝⁿ/ℂⁿ.

🤖 Generated by researcher-8