### PR TITLE
research(furstenberg-correspondence-oq-01-incomplete-01-oq-01): explicit transitive point of the shift [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2623,6 +2623,7 @@ import Proofs.FurstenbergCorrespondence
 import Proofs.FurstenbergCorrespondenceOQ01
 import Proofs.FurstenbergCorrespondenceOQ02
 import Proofs.FurstenbergShiftChaos
+import Proofs.FurstenbergShiftTransitive
 import Proofs.GCDAlgorithm
 import Proofs.GCDAlgorithmOQ01
 import Proofs.GCDAlgorithmOQ01OQ03

--- a/proofs/Proofs/FurstenbergShiftTransitive.lean
+++ b/proofs/Proofs/FurstenbergShiftTransitive.lean
@@ -1,0 +1,192 @@
+/-
+# Furstenberg Correspondence OQ-01 (incomplete-01) → OQ-01: An Explicit Transitive Point
+
+## What This File Contains
+
+The parent file `FurstenbergShiftChaos` proves the shift `T : {0,1}^ℕ → {0,1}^ℕ`,
+`T(x)(n) = x(n+1)` is **chaotic in the sense of Devaney**.  Its topological-transitivity
+condition is stated in the *mixing* form: for **each pair** of nonempty open sets `U, V`
+there is *some* point of `U` whose orbit later enters `V` (witnessed by an ad-hoc `bridge`
+point depending on `U` and `V`).
+
+This file proves the genuinely stronger **Birkhoff transitivity** statement, which the
+parent listed as its first next step: there is a *single* point `z` whose entire forward
+orbit `{T^t z : t ∈ ℕ}` is **dense** in Cantor space.  Such a point is called a
+*transitive point*, and the underlying sequence a *universal* or *disjunctive* sequence —
+one in which **every finite word occurs as a factor**.
+
+The construction is completely explicit and constructive:
+
+* `enum : ℕ → List Bool` is a surjective enumeration of all finite binary words
+  (via `Encodable`).
+* `z` is the infinite concatenation `block 0 ++ block 1 ++ block 2 ++ …`, where
+  `block k = enum k ++ [false]` (the one-bit pad makes every block nonempty so the
+  `n`-th bit of `z` is always read from a long-enough finite prefix).
+* Because `enum` is surjective, every word `w` equals `enum k` for some `k`, and `w`
+  appears in `z` starting at the offset where block `k` begins.  Hence `z` is disjunctive,
+  and its orbit meets every nonempty open set, i.e. is dense.
+
+The headline results are `disjunctive`, `dense_orbit`, and `exists_transitive_point`.
+Everything is proved with **0 axioms and 0 sorries**.
+
+## Why this is more than the parent's mixing condition
+
+Mixing gives, *separately for every target*, a tailor-made starting point.  A transitive
+point is a *uniform* witness: one orbit that is dense, simultaneously approximating every
+configuration.  By the Birkhoff transitivity theorem the two notions coincide on a
+perfect Polish space like Cantor space, but exhibiting the explicit universal sequence is
+the constructive content — and it is exactly the symbolic object (a disjunctive / "rich"
+sequence) underlying normality and the topological route to recurrence.
+
+## References
+
+- G. D. Birkhoff, *Dynamical Systems* (1927) — transitive points.
+- R. L. Devaney, *An Introduction to Chaotic Dynamical Systems* (1989).
+- H. Furstenberg, *Recurrence in Ergodic Theory and Combinatorial Number Theory* (1981).
+-/
+import Mathlib
+import Proofs.FurstenbergShiftChaos
+
+namespace FurstenbergShiftTransitive
+
+open Set Topology Function FurstenbergShiftChaos
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART I: A SURJECTIVE ENUMERATION OF ALL FINITE WORDS
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- A surjective enumeration of all finite binary words, via `Encodable (List Bool)`. -/
+def enum (k : ℕ) : List Bool := (Encodable.decode (α := List Bool) k).getD []
+
+/-- Every finite word is hit by `enum`. -/
+theorem enum_surjective (w : List Bool) : ∃ k, enum k = w :=
+  ⟨Encodable.encode w, by simp [enum, Encodable.encodek]⟩
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART II: THE UNIVERSAL (DISJUNCTIVE) SEQUENCE
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The `k`-th padded block: the `k`-th word followed by one separator bit.  Padding makes
+    every block nonempty (length ≥ 1) without disturbing occurrences of the actual words. -/
+def block (k : ℕ) : List Bool := enum k ++ [false]
+
+theorem block_length (k : ℕ) : (block k).length = (enum k).length + 1 := by
+  simp [block]
+
+/-- The length-`k` initial concatenation `block 0 ++ block 1 ++ … ++ block (k-1)`. -/
+def concatPrefix : ℕ → List Bool
+  | 0 => []
+  | k + 1 => concatPrefix k ++ block k
+
+theorem concatPrefix_succ (k : ℕ) :
+    concatPrefix (k + 1) = concatPrefix k ++ block k := rfl
+
+/-- Offset at which block `k` begins in the infinite concatenation. -/
+def offset (k : ℕ) : ℕ := (concatPrefix k).length
+
+theorem offset_succ (k : ℕ) : offset (k + 1) = offset k + (enum k).length + 1 := by
+  unfold offset
+  rw [concatPrefix_succ, List.length_append, block_length]
+  omega
+
+/-- Every block has length ≥ 1, so the offsets are at least the index. -/
+theorem le_offset (k : ℕ) : k ≤ offset k := by
+  induction k with
+  | zero => simp [offset, concatPrefix]
+  | succ k ih => rw [offset_succ]; omega
+
+/-- The finite concatenations are nested: a longer one extends a shorter one. -/
+theorem concatPrefix_add (a d : ℕ) :
+    ∃ t, concatPrefix (a + d) = concatPrefix a ++ t := by
+  induction d with
+  | zero => exact ⟨[], by simp⟩
+  | succ d ih =>
+    obtain ⟨t, ht⟩ := ih
+    refine ⟨t ++ block (a + d), ?_⟩
+    rw [show a + (d + 1) = (a + d) + 1 from by omega, concatPrefix_succ, ht,
+      List.append_assoc]
+
+theorem concatPrefix_prefix {a b : ℕ} (h : a ≤ b) :
+    ∃ t, concatPrefix b = concatPrefix a ++ t := by
+  obtain ⟨d, rfl⟩ := Nat.le.dest h
+  exact concatPrefix_add a d
+
+/-- **Prefix stability.** The bit at any index that is already realized in two finite
+    concatenations is the same in both — concatenations agree wherever both are defined. -/
+theorem getD_concatPrefix_stable {a b n : ℕ} (ha : n < offset a) (hb : n < offset b) :
+    (concatPrefix a).getD n false = (concatPrefix b).getD n false := by
+  rcases le_total a b with hab | hab
+  · obtain ⟨t, ht⟩ := concatPrefix_prefix hab
+    rw [ht, List.getD_append _ _ _ _ ha]
+  · obtain ⟨t, ht⟩ := concatPrefix_prefix hab
+    rw [ht, List.getD_append _ _ _ _ hb]
+
+/-- The universal sequence: the infinite concatenation `block 0 block 1 block 2 …`.
+    Bit `n` is read off from the finite prefix `concatPrefix (n+1)`, which is long enough
+    because every block has length ≥ 1. -/
+def z : Cantor := fun n => (concatPrefix (n + 1)).getD n false
+
+theorem lt_offset_succ (n : ℕ) : n < offset (n + 1) :=
+  lt_of_lt_of_le (Nat.lt_succ_self n) (le_offset (n + 1))
+
+/-- Reading bit `n` of `z` from any sufficiently long finite prefix gives the same value. -/
+theorem z_eq (n N : ℕ) (h : n < offset N) : z n = (concatPrefix N).getD n false := by
+  rw [z]
+  exact getD_concatPrefix_stable (lt_offset_succ n) h
+
+/-- **Occurrence lemma.** The word `enum k` appears in `z` starting at `offset k`. -/
+theorem occ (k j : ℕ) (hj : j < (enum k).length) :
+    z (offset k + j) = (enum k).getD j false := by
+  have hlt : offset k + j < offset (k + 1) := by rw [offset_succ]; omega
+  have hle : (concatPrefix k).length ≤ offset k + j := Nat.le_add_right _ _
+  rw [z_eq _ (k + 1) hlt, concatPrefix_succ, List.getD_append_right _ _ _ _ hle]
+  have hidx : offset k + j - (concatPrefix k).length = j := by
+    show offset k + j - offset k = j
+    omega
+  rw [hidx, block]
+  exact List.getD_append (enum k) [false] false j hj
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART III: `z` IS DISJUNCTIVE, AND ITS ORBIT IS DENSE
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **`z` is disjunctive.** Every finite word occurs as a factor of `z`: there is a
+    starting position `t` at which `z` reads off `w`. -/
+theorem disjunctive (w : List Bool) :
+    ∃ t, ∀ i, i < w.length → z (t + i) = w.getD i false := by
+  obtain ⟨k, hk⟩ := enum_surjective w
+  refine ⟨offset k, fun i hi => ?_⟩
+  have hilen : i < (enum k).length := by rw [hk]; exact hi
+  rw [occ k i hilen, hk]
+
+/-- For every nonempty open set, some forward iterate of `z` lands in it. -/
+theorem orbit_mem (U : Set Cantor) (hU : IsOpen U) (hUne : U.Nonempty) :
+    ∃ t, shift^[t] z ∈ U := by
+  obtain ⟨y, hy⟩ := hUne
+  obtain ⟨m, hsub⟩ := exists_cyl_subset hU hy
+  obtain ⟨k, hk⟩ := enum_surjective (prefixWord y m)
+  refine ⟨offset k, hsub ((mem_Cyl_prefixWord_iff _ y m).mpr ?_)⟩
+  intro i hi
+  have hilen : i < (enum k).length := by rw [hk, prefixWord_length]; exact hi
+  rw [shift_iterate, Nat.add_comm i (offset k), occ k i hilen, hk,
+    prefixWord_getD y m i hi]
+
+/-- **An explicit transitive point.** The forward orbit of the disjunctive sequence `z`
+    is dense in Cantor space.  This is the Birkhoff transitivity strengthening of the
+    parent's mixing condition: a *single* universal point, not a target-dependent one. -/
+theorem dense_orbit : Dense (Set.range (fun t : ℕ => shift^[t] z)) := by
+  rw [dense_iff_inter_open]
+  intro U hU hUne
+  obtain ⟨t, ht⟩ := orbit_mem U hU hUne
+  exact ⟨shift^[t] z, ht, t, rfl⟩
+
+/-- **Existence of a transitive point.** The shift on Cantor space has a point whose
+    forward orbit is dense — exhibited explicitly as the universal sequence `z`. -/
+theorem exists_transitive_point :
+    ∃ x : Cantor, Dense (Set.range (fun t : ℕ => shift^[t] x)) :=
+  ⟨z, dense_orbit⟩
+
+-- Axiom audit: should report only `propext`, `Classical.choice`, `Quot.sound`.
+#print axioms exists_transitive_point
+
+end FurstenbergShiftTransitive

--- a/src/data/proofs/furstenberg-correspondence-oq-01-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01-incomplete-01-oq-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "furstenberg-correspondence-oq-01-incomplete-01-oq-01",
+  "title": "An Explicit Transitive Point of the Shift (Universal Sequence)",
+  "slug": "furstenberg-correspondence-oq-01-incomplete-01-oq-01",
+  "description": "A constructive Birkhoff transitive point for the shift T(x)(n) = x(n+1) on Cantor space {0,1}^ℕ: a single explicit sequence z whose entire forward orbit {T^t z} is dense. z is the infinite concatenation of all finite binary words (a universal/disjunctive sequence), so every finite word occurs as a factor of z. This strengthens the parent's mixing condition — which supplies a target-dependent witness for each pair of open sets — to one uniform universal point. Fully verified, 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Birkhoff (1927); construction in the style of disjunctive/normal sequences",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Transitive_point",
+    "date": "1927",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FurstenbergShiftTransitive.lean",
+    "tags": [
+      "ergodic-theory",
+      "dynamics",
+      "topological-dynamics",
+      "symbolic-dynamics",
+      "shift-dynamics",
+      "cantor-space",
+      "transitive-point",
+      "disjunctive-sequence",
+      "birkhoff-transitivity",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked; #print axioms exists_transitive_point reports only the foundational propext / Classical.choice / Quot.sound. No `axiom` declarations, no sorries, no native_decide.",
+    "dateAdded": "2026-06-21",
+    "mathlibDependencies": [
+      {
+        "theorem": "Encodable.encodek",
+        "description": "decode (encode a) = some a — gives a surjective enumeration of the (countable) set of finite words List Bool",
+        "module": "Mathlib.Logic.Encodable.Basic"
+      },
+      {
+        "theorem": "List.getD_append",
+        "description": "Indexing a concatenation within the left part agrees with the left part — used for prefix stability and word occurrence",
+        "module": "Mathlib.Data.List.Basic"
+      },
+      {
+        "theorem": "List.getD_append_right",
+        "description": "Indexing a concatenation past the left part reads the right part at the shifted index — locates a block inside the concatenation",
+        "module": "Mathlib.Data.List.Basic"
+      },
+      {
+        "theorem": "dense_iff_inter_open",
+        "description": "A set is dense iff it meets every nonempty open set — reduces orbit density to 'the orbit enters every nonempty open set'",
+        "module": "Mathlib.Topology.Basic"
+      }
+    ],
+    "originalContributions": [
+      "enum : ℕ → List Bool, a surjective enumeration of all finite binary words built from Encodable (List Bool); enum_surjective proves every word is hit",
+      "The universal sequence z, defined as the infinite concatenation block 0 ++ block 1 ++ … of padded words (block k = enum k ++ [false]); the one-bit pad guarantees offsets grow at least linearly so every bit of z is read from a finite prefix",
+      "Prefix-stability infrastructure (concatPrefix, offset, concatPrefix_prefix, getD_concatPrefix_stable, z_eq): the value of a bit is independent of which sufficiently long finite concatenation it is read from",
+      "occ: the occurrence lemma — the word enum k appears verbatim in z starting at offset k",
+      "disjunctive: every finite word occurs as a factor of z (z is a disjunctive sequence)",
+      "dense_orbit / exists_transitive_point: the forward orbit of z is dense, i.e. z is an explicit Birkhoff transitive point — strengthening the parent's per-target mixing witness to one uniform universal point"
+    ],
+    "prerequisites": [
+      "Product topology on ℕ → Bool (Cantor space) and word cylinders (reused from the parent)",
+      "Symbolic dynamics: the full one-sided shift",
+      "Countability of finite words (Encodable) and disjunctive/universal sequences",
+      "Birkhoff transitivity: existence of a point with dense orbit"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 192,
+    "relatedProblems": [
+      {
+        "id": "furstenberg-correspondence-oq-01-incomplete-01",
+        "relationship": "Direct strengthening: the parent proves Devaney chaos with transitivity in mixing form (a witness per pair of open sets); this entry constructs a single transitive point whose orbit is dense, the first 'next step' the parent listed"
+      },
+      {
+        "id": "furstenberg-correspondence-oq-01",
+        "relationship": "Same shift system on Cantor space; the universal sequence is the topological-recurrence object dual to the measure-theoretic correspondence"
+      },
+      {
+        "id": "furstenberg-correspondence",
+        "relationship": "Same shift dynamical system underlying the correspondence principle"
+      }
+    ],
+    "theoremCount": 15,
+    "definitionCount": 5
+  },
+  "crossReferences": [
+    {
+      "targetId": "furstenberg-correspondence-oq-01-incomplete-01",
+      "relationship": "extends",
+      "description": "Strengthens the parent's topological transitivity (stated in mixing form, with a target-dependent bridge point) to the existence of a single explicit transitive point with dense orbit"
+    },
+    {
+      "targetId": "furstenberg-correspondence-oq-01",
+      "relationship": "related",
+      "description": "Topological-recurrence structure of the same shift system whose measure-theoretic side the parent develops"
+    }
+  ],
+  "overview": "The parent file establishes that the shift T(x)(n) = x(n+1) on Cantor space is chaotic in the sense of Devaney, with topological transitivity stated in mixing form: for each pair of nonempty open sets U, V it produces an ad-hoc point of U whose orbit later enters V. Birkhoff transitivity asks for something uniform and stronger — a SINGLE point whose entire forward orbit is dense, simultaneously approximating every configuration. This entry constructs such a transitive point explicitly. The idea is the classical universal (disjunctive) sequence: enumerate all finite binary words via Encodable, then concatenate them into one infinite sequence z = block 0 ++ block 1 ++ block 2 ++ …, where each block is a word followed by a single padding bit (so blocks are nonempty and the n-th bit of z is always read from a finite prefix). Because the enumeration is surjective, every word w equals enum k for some k and therefore appears verbatim in z at the offset where block k begins — z is disjunctive. Given any nonempty open set U, shrink it to a prefix cylinder, realize that prefix as some enum k, and the shift T^{offset k} z lands in U. Hence the orbit of z meets every nonempty open set and is dense. The construction reuses the parent's word-cylinder neighbourhood basis and is verified with no axioms or sorries.",
+  "sections": [
+    {
+      "id": "enumeration",
+      "title": "A Surjective Enumeration of All Finite Words",
+      "startLine": 55,
+      "endLine": 64,
+      "summary": "enum k = (decode k).getD [] enumerates all finite binary words via Encodable (List Bool); enum_surjective shows every word is hit, using Encodable.encodek.",
+      "mathContext": "Countability of the set of finite words is the combinatorial input that makes a single universal sequence possible."
+    },
+    {
+      "id": "universal-sequence",
+      "title": "The Universal (Disjunctive) Sequence",
+      "startLine": 66,
+      "endLine": 148,
+      "summary": "Padded blocks block k = enum k ++ [false], their running concatenation concatPrefix and offsets offset, prefix stability (concatPrefix_prefix, getD_concatPrefix_stable, z_eq), the sequence z itself, and the occurrence lemma occ: enum k appears in z at offset k.",
+      "mathContext": "Concatenating an enumeration of all words yields a sequence containing every word; padding keeps offsets growing so the infinite concatenation is well-defined pointwise."
+    },
+    {
+      "id": "transitive-point",
+      "title": "z Is Disjunctive and Its Orbit Is Dense",
+      "startLine": 150,
+      "endLine": 192,
+      "summary": "disjunctive: every finite word occurs as a factor of z. orbit_mem: some iterate of z enters any nonempty open set. dense_orbit / exists_transitive_point: the forward orbit of z is dense — an explicit Birkhoff transitive point.",
+      "mathContext": "A dense orbit is the defining property of a transitive point; the explicit universal sequence makes Birkhoff transitivity constructive."
+    }
+  ],
+  "conclusion": "The shift on Cantor space has an explicit transitive point: the universal sequence z formed by concatenating all finite binary words. Every finite word occurs as a factor of z (z is disjunctive), so the forward orbit of z meets every nonempty open set and is therefore dense. This upgrades the parent's mixing condition — a separate, target-dependent witness for each pair of open sets — to a single uniform universal point, the constructive content of Birkhoff transitivity. The whole development is machine-checked with 0 axioms and 0 sorries, reusing the parent's word-cylinder neighbourhood basis.",
+  "leanFile": {
+    "path": "Proofs/FurstenbergShiftTransitive.lean",
+    "lineCount": 192,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 5,
+    "theoremCount": 15
+  },
+  "mainTheorems": [
+    {
+      "name": "exists_transitive_point",
+      "statement": "The shift on Cantor space has a point whose forward orbit is dense — exhibited explicitly as the universal sequence z.",
+      "isAxiomatized": false,
+      "significance": "The headline result: a constructive Birkhoff transitive point, strengthening the parent's per-target mixing witness to one uniform universal point."
+    },
+    {
+      "name": "dense_orbit",
+      "statement": "The forward orbit {T^t z : t ∈ ℕ} of the universal sequence z is dense in Cantor space.",
+      "isAxiomatized": false,
+      "significance": "Density of a single explicit orbit — the defining property of a transitive point."
+    },
+    {
+      "name": "disjunctive",
+      "statement": "Every finite binary word occurs as a factor of z.",
+      "isAxiomatized": false,
+      "significance": "The combinatorial heart: z is a disjunctive (universal) sequence, which is exactly why its orbit is dense."
+    },
+    {
+      "name": "occ",
+      "statement": "The word enum k appears verbatim in z starting at position offset k.",
+      "isAxiomatized": false,
+      "significance": "The occurrence lemma linking the surjective enumeration to factor occurrences in z."
+    },
+    {
+      "name": "enum_surjective",
+      "statement": "Every finite binary word equals enum k for some k.",
+      "isAxiomatized": false,
+      "significance": "Surjectivity of the word enumeration, the countability input to the whole construction."
+    }
+  ],
+  "references": [
+    {
+      "title": "Dynamical Systems",
+      "author": "G. D. Birkhoff",
+      "year": "1927",
+      "url": "https://doi.org/10.1090/coll/009"
+    },
+    {
+      "title": "An Introduction to Chaotic Dynamical Systems",
+      "author": "R. L. Devaney",
+      "year": "1989",
+      "url": "https://www.google.com/books/edition/An_Introduction_To_Chaotic_Dynamical_Sys/3wbvAAAAMAAJ"
+    },
+    {
+      "title": "Recurrence in Ergodic Theory and Combinatorial Number Theory",
+      "author": "H. Furstenberg",
+      "year": "1981",
+      "url": "https://press.princeton.edu/books/hardcover/9780691615363/recurrence-in-ergodic-theory-and-combinatorial-number-theory"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/furstenberg-correspondence-oq-01-incomplete-01-oq-01.json
+++ b/src/data/research/problems/furstenberg-correspondence-oq-01-incomplete-01-oq-01.json
@@ -1,0 +1,72 @@
+{
+  "slug": "furstenberg-correspondence-oq-01-incomplete-01-oq-01",
+  "title": "An Explicit Transitive Point of the Shift (Universal Sequence)",
+  "status": "completed",
+  "phase": "COMPLETE",
+  "tier": "graduated",
+  "significance": 6,
+  "tractability": 8,
+  "started": "2026-06-21T00:00:00.000Z",
+  "lastUpdate": "2026-06-21T00:00:00.000Z",
+  "path": "Proofs/FurstenbergShiftTransitive.lean",
+  "leanFiles": ["Proofs/FurstenbergShiftTransitive.lean"],
+  "relatedProofs": [
+    "furstenberg-correspondence-oq-01-incomplete-01",
+    "furstenberg-correspondence-oq-01",
+    "furstenberg-correspondence"
+  ],
+  "tags": [
+    "ergodic-theory",
+    "topological-dynamics",
+    "symbolic-dynamics",
+    "shift-dynamics",
+    "cantor-space",
+    "transitive-point",
+    "disjunctive-sequence",
+    "birkhoff-transitivity"
+  ],
+  "problemStatement": {
+    "formal": "\\exists z \\in \\{0,1\\}^{\\mathbb N},\\ \\overline{\\{T^t z : t \\in \\mathbb N\\}} = \\{0,1\\}^{\\mathbb N},\\ \\text{where } T(x)(n)=x(n+1)",
+    "plain": "Construct a single explicit point of Cantor space whose forward orbit under the shift is dense (a Birkhoff transitive point), strengthening the parent's mixing condition to one uniform universal witness.",
+    "whyMatters": [
+      "Carries out the parent's first listed next step: an explicit dense-orbit (transitive) point",
+      "The universal/disjunctive sequence is the canonical symbolic object behind normality and the topological route to recurrence",
+      "Fully verified (0 axioms, 0 sorries) by an explicit construction reusing the parent's word-cylinder basis"
+    ]
+  },
+  "currentState": {
+    "phase": "COMPLETE",
+    "since": "2026-06-21T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Explicit transitive point constructed and packaged (exists_transitive_point).",
+    "blockers": [],
+    "nextAction": "Optional: topological entropy log 2; connect to topological multiple recurrence / van der Waerden.",
+    "attemptCounts": { "total": 1, "currentApproach": 1, "approachesTried": 1 }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: constructed an explicit Birkhoff transitive point z for the shift on Cantor space — the universal/disjunctive sequence obtained by concatenating all finite binary words. Proved z is disjunctive (every word is a factor) and that its forward orbit is dense (dense_orbit / exists_transitive_point). 0 axioms, 0 sorries (Proofs/FurstenbergShiftTransitive.lean, 192 lines, 15 theorems / 5 defs).",
+    "builtItems": [
+      "enum / enum_surjective — a surjective enumeration of all finite words via Encodable (List Bool)",
+      "block / concatPrefix / offset — padded-block concatenation with offsets growing at least linearly",
+      "concatPrefix_prefix / getD_concatPrefix_stable / z_eq — prefix stability making the infinite concatenation well-defined pointwise",
+      "z + occ — the universal sequence and the lemma that enum k occurs in z at offset k",
+      "disjunctive — every finite word occurs as a factor of z",
+      "orbit_mem / dense_orbit / exists_transitive_point — the orbit of z meets every nonempty open set; it is an explicit transitive point"
+    ],
+    "insights": [
+      "Padding each enumerated word with one separator bit (block k = enum k ++ [false]) forces offsets to satisfy offset k ≥ k, so bit n of the infinite concatenation is always read from the finite prefix concatPrefix (n+1) — no choice / sigma-finite bookkeeping needed.",
+      "Prefix stability (List.getD_append on nested concatenations) is the only nontrivial glue: the value of a bit is independent of which long-enough prefix it is read from.",
+      "Surjectivity of enum (Encodable.encodek) turns 'every word is a factor' into 'every prefix cylinder is hit', which is exactly orbit density via the parent's exists_cyl_subset basis.",
+      "A transitive point is strictly more informative than the parent's per-pair mixing witness: one uniform orbit approximates every configuration."
+    ],
+    "mathlibGaps": [
+      "No packaged 'transitive point' / 'disjunctive sequence' API for the full shift in Mathlib v4.26.0",
+      "No topological-entropy computation for the full 2-shift"
+    ],
+    "nextSteps": [
+      "Prove topological entropy of the full 2-shift equals log 2",
+      "Derive the parent's topological transitivity (transitive) as a corollary of the single transitive point",
+      "Connect Devaney chaos to topological multiple recurrence / a topological proof of van der Waerden"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

A follow-up to **furstenberg-correspondence-oq-01-incomplete-01** (Devaney chaos of the shift), carrying out that entry's first listed next step: **construct an explicit dense-orbit (transitive) point**.

The parent proves topological transitivity in *mixing* form — for each pair of nonempty open sets it produces an ad-hoc bridge point of one whose orbit later enters the other. This entry proves the genuinely stronger **Birkhoff transitivity** statement: a **single explicit point** `z` whose entire forward orbit `{T^t z : t ∈ ℕ}` is **dense** in Cantor space.

`z` is the classical **universal / disjunctive sequence**: enumerate all finite binary words via `Encodable`, then concatenate them (each padded with one separator bit so offsets grow at least linearly and every bit is read from a finite prefix). Surjectivity of the enumeration ⟹ every word occurs as a factor of `z` (`disjunctive`) ⟹ the orbit meets every nonempty open set (`dense_orbit`, `exists_transitive_point`).

## Key results

- `enum_surjective` — surjective enumeration of all finite words (via `Encodable.encodek`)
- `occ` — the word `enum k` appears in `z` at `offset k` (prefix-stability glue: `getD_concatPrefix_stable`, `z_eq`)
- `disjunctive` — every finite word is a factor of `z`
- `dense_orbit` / `exists_transitive_point` — the forward orbit of `z` is dense; an explicit transitive point

## Verification

- `proofs/Proofs/FurstenbergShiftTransitive.lean` — 192 lines, 15 theorems / 5 defs
- Builds against Mathlib v4.26.0 (Docker wrapper)
- `#print axioms exists_transitive_point` → `propext, Classical.choice, Quot.sound` only
- **0 axioms, 0 sorries, no `native_decide`** → `status: verified`, `badge: original`

Reuses the parent's word-cylinder neighbourhood basis (`exists_cyl_subset`); no changes to the parent file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)