### PR TITLE
research(elementary-quadratic-reciprocity-oq-01-oq-03): CRT decomposition of the Zolotarev multiplication permutation [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03.lean
@@ -1,0 +1,262 @@
+/-
+  CRT Decomposition of the Zolotarev Multiplication Permutation
+  (elementary-quadratic-reciprocity-oq-01-oq-03)
+
+  Open Question (from elementary-quadratic-reciprocity-oq-01, OQ #3):
+  "Can the CRT decomposition of the multiplication permutation on ℤ/pqℤ be
+  formalized to give a self-contained Zolotarev QR proof?"
+
+  The parent (OQ-01) formalized Zolotarev's lemma for a PRIME modulus: the
+  Legendre symbol (a/p) equals the sign of the permutation x ↦ ax on the
+  units (ZMod p)ˣ.  Frobenius (1914) generalized this to COMPOSITE moduli and
+  the Jacobi symbol, and the mechanism is the Chinese Remainder Theorem: the
+  multiplication-by-a permutation on ℤ/mn factors, through the CRT ring
+  isomorphism, into the product of the multiplication-by-a permutations on
+  ℤ/m and ℤ/n.
+
+  This file formalizes that decomposition. Its content (all 0 sorries, 0 axioms):
+
+  * `ringMulPerm a` — multiplication by a unit `a` as a permutation of the
+    WHOLE ring `ZMod n` (Frobenius works on all n residues, not just the units;
+    crucially `|ZMod n| = n` is ODD for odd n, whereas `|(ZMod n)ˣ| = φ(n)` is
+    even — and an even number of points would make every sign trivial).
+  * `signRingHom : (ZMod n)ˣ →* ℤˣ` — the Zolotarev sign character for ANY
+    modulus, a generalization of the parent's `signMulHom`.
+  * `sign_prodCongr` — a general, Mathlib-absent lemma: the sign of a product
+    permutation `σ ×ₚ τ` is `sign σ ^ |β| * sign τ ^ |α|`.
+  * `sign_ringMulPerm_crt` — the CRT decomposition itself.
+  * `sign_ringMulPerm_mul_of_odd` — for ODD coprime moduli the exponents are
+    odd, so the sign character is genuinely MULTIPLICATIVE across the CRT
+    factorization, exactly mirroring `jacobiSym.mul_right`.
+
+  References:
+  - Zolotarev (1872): Nouvelle démonstration de la loi de réciprocité de Legendre
+  - Frobenius (1914): generalization to Jacobi symbols / composite moduli
+  - Lerch (1896); Rousseau (1991), Amer. Math. Monthly
+-/
+import Mathlib
+
+set_option maxHeartbeats 800000
+
+namespace ZolotarevCRT
+
+open Equiv Equiv.Perm Finset
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I: MULTIPLICATION BY A UNIT AS A PERMUTATION OF THE WHOLE RING
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Multiplication by a unit `a` is a permutation of the entire ring `ZMod n`.
+    Unlike the parent's `mulPerm` (which acts on the units `(ZMod p)ˣ`), this
+    acts on all `n` residues — the setting required for the Frobenius/Jacobi
+    generalization, since `|ZMod n| = n` is odd for odd `n`. -/
+def ringMulPerm {n : ℕ} (a : (ZMod n)ˣ) : Equiv.Perm (ZMod n) where
+  toFun x := (a : ZMod n) * x
+  invFun x := (↑a⁻¹ : ZMod n) * x
+  left_inv x := by
+    simp [← mul_assoc, ← Units.val_mul]
+  right_inv x := by
+    simp [← mul_assoc, ← Units.val_mul]
+
+@[simp] theorem ringMulPerm_apply {n : ℕ} (a : (ZMod n)ˣ) (x : ZMod n) :
+    ringMulPerm a x = (a : ZMod n) * x := rfl
+
+/-- `ringMulPerm` of `1` is the identity. -/
+theorem ringMulPerm_one {n : ℕ} : ringMulPerm (1 : (ZMod n)ˣ) = 1 := by
+  ext x; simp
+
+/-- `ringMulPerm` is multiplicative: it is a group homomorphism. -/
+theorem ringMulPerm_mul {n : ℕ} (a b : (ZMod n)ˣ) :
+    ringMulPerm (a * b) = ringMulPerm a * ringMulPerm b := by
+  ext x
+  simp [Equiv.Perm.mul_apply, mul_assoc, Units.val_mul]
+
+/-- The multiplication permutation as a monoid homomorphism `(ZMod n)ˣ →* Perm (ZMod n)`. -/
+def ringMulPermHom {n : ℕ} : (ZMod n)ˣ →* Equiv.Perm (ZMod n) where
+  toFun := ringMulPerm
+  map_one' := ringMulPerm_one
+  map_mul' := ringMulPerm_mul
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II: THE ZOLOTAREV SIGN CHARACTER FOR ANY MODULUS
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The Zolotarev sign character `(ZMod n)ˣ →* ℤˣ`, defined for ANY (positive)
+    modulus `n` (the parent only had the prime case). -/
+def signRingHom {n : ℕ} [NeZero n] : (ZMod n)ˣ →* ℤˣ :=
+  (Equiv.Perm.sign).comp ringMulPermHom
+
+@[simp] theorem signRingHom_apply {n : ℕ} [NeZero n] (a : (ZMod n)ˣ) :
+    signRingHom a = Equiv.Perm.sign (ringMulPerm a) := rfl
+
+/-- The sign character is a quadratic character: it squares to the identity. -/
+theorem signRingHom_sq {n : ℕ} [NeZero n] (a : (ZMod n)ˣ) : signRingHom a ^ 2 = 1 := by
+  simp only [signRingHom_apply]
+  exact Int.units_sq _
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III: SIGN OF A PRODUCT PERMUTATION  (general, absent from Mathlib)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- For a unit of `ℤ` and an odd exponent, the power is the unit itself
+    (since `ℤˣ = {±1}` has exponent 2). -/
+theorem units_pow_odd (u : ℤˣ) {k : ℕ} (hk : Odd k) : u ^ k = u := by
+  rcases Int.units_eq_one_or u with rfl | rfl
+  · rw [one_pow]
+  · refine Units.ext ?_
+    rw [Units.val_pow_eq_pow_val]
+    simpa using hk.neg_one_pow
+
+/-- The sign of a product permutation `σ ×ₚ τ` on `α × β` is
+    `sign σ ^ |β| * sign τ ^ |α|`.  This is not in Mathlib; we derive it from
+    `sign_prodCongrLeft` and `sign_prodCongrRight` applied to constant families. -/
+theorem sign_prodCongr {α β : Type*} [DecidableEq α] [Fintype α]
+    [DecidableEq β] [Fintype β] (σ : Equiv.Perm α) (τ : Equiv.Perm β) :
+    Equiv.Perm.sign (σ.prodCongr τ)
+      = Equiv.Perm.sign σ ^ Fintype.card β * Equiv.Perm.sign τ ^ Fintype.card α := by
+  have hdecomp : σ.prodCongr τ
+      = prodCongrLeft (fun _ : β => σ) * prodCongrRight (fun _ : α => τ) := by
+    apply Equiv.ext
+    rintro ⟨a, b⟩
+    simp [Equiv.Perm.mul_apply,
+      prodCongrLeft_apply, prodCongrRight_apply, Equiv.prodCongr_apply, Prod.map_apply']
+  rw [hdecomp, map_mul, sign_prodCongrLeft, sign_prodCongrRight]
+  simp [Finset.prod_const, Finset.card_univ]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV: THE CRT DECOMPOSITION
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+variable {m n : ℕ}
+
+/-- **CRT decomposition of the Zolotarev permutation sign.**
+
+    Through the Chinese Remainder isomorphism `ZMod (m*n) ≃+* ZMod m × ZMod n`,
+    the sign of multiplication-by-`a` on `ZMod (m*n)` decomposes as
+
+      `sign(ringMulPerm a) = sign(ringMulPerm a₁) ^ n * sign(ringMulPerm a₂) ^ m`,
+
+    where `a₁, a₂` are the CRT components of `a`.  This is the structural heart
+    of the Frobenius/Jacobi generalization of Zolotarev's lemma. -/
+theorem sign_ringMulPerm_crt [NeZero m] [NeZero n] (h : m.Coprime n)
+    (a : (ZMod (m * n))ˣ) (a₁ : (ZMod m)ˣ) (a₂ : (ZMod n)ˣ)
+    (h₁ : (a₁ : ZMod m) = ((ZMod.chineseRemainder h) (a : ZMod (m * n))).1)
+    (h₂ : (a₂ : ZMod n) = ((ZMod.chineseRemainder h) (a : ZMod (m * n))).2) :
+    Equiv.Perm.sign (ringMulPerm a)
+      = Equiv.Perm.sign (ringMulPerm a₁) ^ n * Equiv.Perm.sign (ringMulPerm a₂) ^ m := by
+  set e := ZMod.chineseRemainder h with he
+  -- The CRT iso intertwines `ringMulPerm a` with the product permutation.
+  have hsq : ∀ x : ZMod (m * n),
+      e.toEquiv (ringMulPerm a x)
+        = (Equiv.prodCongr (ringMulPerm a₁) (ringMulPerm a₂)) (e.toEquiv x) := by
+    intro x
+    simp only [RingEquiv.toEquiv_eq_coe, RingEquiv.coe_toEquiv, ringMulPerm_apply,
+      Equiv.prodCongr_apply, Prod.map_apply']
+    rw [map_mul, h₁, h₂]
+    rfl
+  rw [sign_eq_sign_of_equiv (ringMulPerm a)
+        (Equiv.prodCongr (ringMulPerm a₁) (ringMulPerm a₂)) e.toEquiv hsq,
+      sign_prodCongr, ZMod.card n, ZMod.card m]
+
+/-- **The Zolotarev sign character is multiplicative across an odd CRT
+    factorization.**  When `m` and `n` are odd, the cardinality exponents `n`
+    and `m` are odd, so each `sign ^ odd = sign`.  This is the exact
+    permutation-theoretic shadow of `jacobiSym.mul_right`
+    (`J(a | m*n) = J(a | m) * J(a | n)`). -/
+theorem sign_ringMulPerm_mul_of_odd [NeZero m] [NeZero n] (h : m.Coprime n)
+    (hm : Odd m) (hn : Odd n)
+    (a : (ZMod (m * n))ˣ) (a₁ : (ZMod m)ˣ) (a₂ : (ZMod n)ˣ)
+    (h₁ : (a₁ : ZMod m) = ((ZMod.chineseRemainder h) (a : ZMod (m * n))).1)
+    (h₂ : (a₂ : ZMod n) = ((ZMod.chineseRemainder h) (a : ZMod (m * n))).2) :
+    Equiv.Perm.sign (ringMulPerm a)
+      = Equiv.Perm.sign (ringMulPerm a₁) * Equiv.Perm.sign (ringMulPerm a₂) := by
+  rw [sign_ringMulPerm_crt h a a₁ a₂ h₁ h₂,
+      units_pow_odd _ hn, units_pow_odd _ hm]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART V: PARALLEL WITH THE JACOBI SYMBOL
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+open scoped NumberTheorySymbols in
+/-- The Jacobi symbol is multiplicative in its (odd) denominator — the
+    value-level statement that `sign_ringMulPerm_mul_of_odd` mirrors at the
+    level of permutation signs.  (Restated from Mathlib's `jacobiSym.mul_right`.) -/
+theorem jacobiSym_mul_right_mirror (a : ℤ) (b₁ b₂ : ℕ) [NeZero b₁] [NeZero b₂] :
+    J(a | b₁ * b₂) = J(a | b₁) * J(a | b₂) :=
+  jacobiSym.mul_right a b₁ b₂
+
+open scoped NumberTheorySymbols in
+/-- The prime base case (`legendreSym.to_jacobiSym`): for a prime `p` the
+    Jacobi symbol IS the Legendre symbol, which the parent (`OQ-01`,
+    `zolotarev_lemma`) identified with a permutation sign.  Composing this base
+    case with the CRT multiplicativity above yields the full Frobenius/Jacobi
+    statement. -/
+theorem legendre_eq_jacobi (p : ℕ) [Fact p.Prime] (a : ℤ) :
+    legendreSym p a = J(a | p) :=
+  jacobiSym.legendreSym.to_jacobiSym p a
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART VI: EXAMPLES
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The sign character of the trivial unit is trivial, for any modulus. -/
+example {n : ℕ} [NeZero n] : signRingHom (1 : (ZMod n)ˣ) = 1 := map_one _
+
+/-- `signRingHom` is a genuine group homomorphism (multiplicativity of the
+    Zolotarev character for composite moduli). -/
+example {n : ℕ} [NeZero n] (a b : (ZMod n)ˣ) :
+    signRingHom (a * b) = signRingHom a * signRingHom b := map_mul _ _ _
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+Summary
+═══════════════════════════════════════════════════════════════════════════════
+
+## CRT decomposition of Zolotarev's permutation (answering OQ-01's third
+   open question)
+
+### What's proved (0 sorries, 0 axioms):
+- `ringMulPerm`: multiplication-by-a-unit on the WHOLE ring `ZMod n`
+  (the Frobenius setting; |ZMod n| = n is odd for odd n).
+- `signRingHom : (ZMod n)ˣ →* ℤˣ`: the Zolotarev sign character for ANY
+  modulus — a generalization of the parent's prime-only `signMulHom`.
+- `sign_prodCongr`: sign of a product permutation = `sign σ ^ |β| * sign τ ^ |α|`
+  (a general lemma not present in Mathlib).
+- `sign_ringMulPerm_crt`: the CRT decomposition of the multiplication-permutation
+  sign through `ZMod.chineseRemainder`.
+- `sign_ringMulPerm_mul_of_odd`: for ODD coprime moduli the sign character is
+  multiplicative across the CRT factorization — the permutation-theoretic image
+  of `jacobiSym.mul_right`.
+
+### Honest scope:
+This file formalizes the STRUCTURAL CRT mechanism: it proves that the Zolotarev
+sign character decomposes (and, for odd moduli, multiplies) exactly as the
+Jacobi symbol does in its denominator.  It does NOT close the loop to Jacobi
+*values* — that needs the base case `sign(ringMulPerm a on ZMod p) = legendreSym p a`,
+which combines the parent's `zolotarev_lemma` (units version) with a fixed-point
+sign-restriction argument (multiplication fixes `0 ∈ ZMod p`).  That base case
+is the remaining glue and is left as the next step.
+
+### Key insight:
+The multiplicativity of the Jacobi symbol in its denominator is NOT a separate
+number-theoretic fact: it is the shadow of the Chinese Remainder Theorem acting
+on permutations.  The only arithmetic input is that an odd number raised to an
+odd power preserves a sign — `units_pow_odd`.
+-/
+
+#check @ringMulPerm
+#check @ringMulPermHom
+#check @signRingHom
+#check @signRingHom_sq
+#check @sign_prodCongr
+#check @sign_ringMulPerm_crt
+#check @sign_ringMulPerm_mul_of_odd
+#check @units_pow_odd
+
+end ZolotarevCRT

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-eqr-oq0103-ringmulperm",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03",
+    "range": { "startLine": 54, "endLine": 84 },
+    "type": "definition",
+    "title": "Multiplication by a unit on the WHOLE ring ℤ/n",
+    "content": "ringMulPerm a is the permutation x ↦ a·x acting on every residue of ℤ/n, not merely the units. This is the decisive setting change from the parent (which permuted (ℤ/p)ˣ): the Frobenius/Jacobi generalization needs |ℤ/n| = n, which is ODD for odd n, whereas |(ℤ/n)ˣ| = φ(n) is even and would force every permutation sign to be +1. The map is a bijection because a is a unit (inverse x ↦ a⁻¹·x), and ringMulPermHom packages it as a group homomorphism (ℤ/n)ˣ →* Perm(ℤ/n).",
+    "mathContext": "$\\mathrm{ringMulPerm}\\,a : \\mathbb{Z}/n \\to \\mathbb{Z}/n,\\ x \\mapsto a x$, with $|\\mathbb{Z}/n| = n$ odd for odd $n$. The assignment $a \\mapsto (x \\mapsto ax)$ is a group homomorphism $(\\mathbb{Z}/n)^\\times \\to \\mathrm{Perm}(\\mathbb{Z}/n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Equiv.Perm", "ZMod units", "group homomorphism", "Zolotarev's lemma"],
+    "prerequisites": ["modular arithmetic", "permutations", "units of a ring"]
+  },
+  {
+    "id": "ann-eqr-oq0103-signring",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03",
+    "range": { "startLine": 88, "endLine": 99 },
+    "type": "definition",
+    "title": "The Zolotarev sign character for any modulus",
+    "content": "signRingHom = sign ∘ ringMulPermHom : (ℤ/n)ˣ →* ℤˣ is the Zolotarev sign character defined for EVERY positive modulus, generalizing the parent's prime-only signMulHom. signRingHom_sq shows it is a quadratic character (it squares to 1), since ℤˣ = {±1} has exponent 2.",
+    "mathContext": "$\\mathrm{signRingHom} : (\\mathbb{Z}/n)^\\times \\to \\mathbb{Z}^\\times$, $a \\mapsto \\mathrm{sign}(x \\mapsto ax)$, with $\\mathrm{signRingHom}(a)^2 = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["permutation sign", "quadratic character", "MonoidHom"],
+    "prerequisites": ["Equiv.Perm.sign", "monoid homomorphisms"]
+  },
+  {
+    "id": "ann-eqr-oq0103-sign-prodcongr",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03",
+    "range": { "startLine": 116, "endLine": 137 },
+    "type": "theorem",
+    "title": "Sign of a product permutation (absent from Mathlib)",
+    "content": "sign_prodCongr proves sign(σ ×ₚ τ) = sign σ ^ |β| · sign τ ^ |α| for permutations σ of α and τ of β. Mathlib has only the constant-free family lemmas sign_prodCongrLeft / sign_prodCongrRight (each giving a product ∏ sign over the index type); this combines them on the constant families fun _ => σ and fun _ => τ, after rewriting σ.prodCongr τ as prodCongrLeft (fun _ => σ) * prodCongrRight (fun _ => τ). This general lemma is the combinatorial engine of the CRT decomposition.",
+    "mathContext": "$\\mathrm{sign}(\\sigma \\times_p \\tau) = (\\mathrm{sign}\\,\\sigma)^{|\\beta|} \\cdot (\\mathrm{sign}\\,\\tau)^{|\\alpha|}$ on $\\alpha \\times \\beta$.",
+    "significance": "key",
+    "relatedConcepts": ["Equiv.prodCongr", "sign_prodCongrLeft", "sign_prodCongrRight", "Fintype.card"],
+    "prerequisites": ["permutation sign as a homomorphism", "products of permutations"]
+  },
+  {
+    "id": "ann-eqr-oq0103-crt",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03",
+    "range": { "startLine": 145, "endLine": 168 },
+    "type": "theorem",
+    "title": "CRT decomposition of the Zolotarev sign",
+    "content": "sign_ringMulPerm_crt is the structural heart. Through the Chinese Remainder ring isomorphism ZMod.chineseRemainder : ℤ/mn ≃+* ℤ/m × ℤ/n, the permutation x ↦ a·x on ℤ/mn intertwines (via sign_eq_sign_of_equiv) with the product of the component permutations x ↦ a₁·x and x ↦ a₂·x. Combined with sign_prodCongr and ZMod.card, this yields sign(ringMulPerm a) = sign(ringMulPerm a₁)^n · sign(ringMulPerm a₂)^m. The proof's key step shows the CRT iso commutes with multiplication-by-a because it is a ring homomorphism (e(a·x) = e(a)·e(x)).",
+    "mathContext": "Through $\\mathbb{Z}/mn \\cong \\mathbb{Z}/m \\times \\mathbb{Z}/n$: $\\mathrm{sign}(x \\mapsto ax) = \\mathrm{sign}(x \\mapsto a_1 x)^{n} \\cdot \\mathrm{sign}(x \\mapsto a_2 x)^{m}$.",
+    "significance": "key",
+    "relatedConcepts": ["ZMod.chineseRemainder", "sign_eq_sign_of_equiv", "Chinese Remainder Theorem", "RingEquiv"],
+    "prerequisites": ["Chinese Remainder Theorem", "ring isomorphisms", "permutation sign transport"]
+  },
+  {
+    "id": "ann-eqr-oq0103-mul-odd",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03",
+    "range": { "startLine": 170, "endLine": 197 },
+    "type": "theorem",
+    "title": "Multiplicativity for odd moduli mirrors jacobiSym.mul_right",
+    "content": "sign_ringMulPerm_mul_of_odd specializes the CRT decomposition to ODD coprime m, n: the cardinality exponents n and m are then odd, and units_pow_odd (a unit of ℤ raised to an odd power equals itself) collapses sign(σ₁)^n · sign(σ₂)^m to sign(σ₁) · sign(σ₂). This is the exact permutation-theoretic image of Mathlib's jacobiSym.mul_right, J(a | mn) = J(a | m)·J(a | n) — recorded alongside as jacobiSym_mul_right_mirror, with the prime base case legendre_eq_jacobi (legendreSym.to_jacobiSym).",
+    "mathContext": "For odd coprime $m, n$: $\\mathrm{sign}(x \\mapsto ax) = \\mathrm{sign}(x \\mapsto a_1 x) \\cdot \\mathrm{sign}(x \\mapsto a_2 x)$, mirroring $J(a \\mid mn) = J(a \\mid m) J(a \\mid n)$.",
+    "significance": "key",
+    "relatedConcepts": ["jacobiSym.mul_right", "odd exponents", "Jacobi symbol multiplicativity"],
+    "prerequisites": ["Jacobi symbol", "parity"]
+  }
+]

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "elementary-quadratic-reciprocity-oq-01-oq-03",
+  "slug": "elementary-quadratic-reciprocity-oq-01-oq-03",
+  "title": "CRT Decomposition of the Zolotarev Multiplication Permutation",
+  "description": "Formalizes the structural heart of the Frobenius (1914) generalization of Zolotarev's permutation proof of quadratic reciprocity to composite moduli and the Jacobi symbol. Through the Chinese Remainder ring isomorphism ZMod(mn) ≃+* ZMod m × ZMod n, the sign of the multiplication-by-a permutation on ℤ/mn factors as sign(σ₁)^n · sign(σ₂)^m, and for ODD coprime moduli (where the cardinality exponents are odd) the Zolotarev sign character becomes genuinely multiplicative — exactly mirroring jacobiSym.mul_right. Answers the third open question of elementary-quadratic-reciprocity-oq-01.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Equiv",
+      "Equiv.Perm",
+      "Finset"
+    ],
+    "namespace": "ZolotarevCRT",
+    "lineCount": 262,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 3,
+    "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "overview": {
+    "text": "The multiplicativity of the Jacobi symbol in its denominator, J(a | mn) = J(a | m)·J(a | n) for odd coprime m, n, is not a separate number-theoretic fact: it is the shadow of the Chinese Remainder Theorem acting on permutations. This file makes that precise.",
+    "historicalContext": "Zolotarev (1872) proved quadratic reciprocity by identifying the Legendre symbol (a/p) with the sign of the permutation x ↦ ax on (ℤ/p)ˣ. Frobenius simplified the argument in 1914 and, crucially, generalized it to composite moduli and the Jacobi symbol: for odd n coprime to a, the Jacobi symbol (a/n) equals the sign of multiplication-by-a on ℤ/n. The mechanism behind the composite case is the Chinese Remainder Theorem. The parent entry (elementary-quadratic-reciprocity-oq-01) formalized only the prime case (on the units (ℤ/p)ˣ); this entry formalizes the CRT decomposition that drives the Frobenius generalization.",
+    "problemStatement": "Open Question (OQ #3 of elementary-quadratic-reciprocity-oq-01): Can the CRT decomposition of the multiplication permutation on ℤ/pq be formalized? Answer: YES, at the structural level. We formalize the permutation on the WHOLE ring ℤ/n (Frobenius's setting, since |ℤ/n| = n is odd for odd n, whereas |（ℤ/n)ˣ| = φ(n) is even and would force every sign to be trivial), prove a general product-permutation sign formula, and prove the CRT factorization of the Zolotarev sign character.",
+    "proofStrategy": "1. Define ringMulPerm a, multiplication by a unit a on the whole ring ℤ/n, and assemble the sign character signRingHom : (ℤ/n)ˣ →* ℤˣ for arbitrary modulus. 2. Prove sign_prodCongr: the sign of a product permutation σ ×ₚ τ on α × β equals sign σ ^ |β| · sign τ ^ |α| (a general lemma absent from Mathlib), via the constant-family lemmas sign_prodCongrLeft / sign_prodCongrRight. 3. Prove sign_ringMulPerm_crt: through ZMod.chineseRemainder, the multiplication permutation intertwines with the product of the component permutations (sign_eq_sign_of_equiv), so its sign decomposes as sign(σ₁)^n · sign(σ₂)^m. 4. For odd coprime m, n the exponents n, m are odd; units_pow_odd (a unit of ℤ raised to an odd power is itself) collapses this to sign(σ₁)·sign(σ₂). 5. Exhibit the value-level parallel jacobiSym.mul_right and the prime base case legendreSym.to_jacobiSym.",
+    "keyInsights": [
+      "Frobenius's generalization lives on the whole ring ℤ/n, not the units: |ℤ/n| = n is odd, so signs are non-trivial; |（ℤ/n)ˣ| = φ(n) is even, which would make every sign vanish.",
+      "The sign of a product permutation σ ×ₚ τ is sign σ ^ |β| · sign τ ^ |α| — a clean lemma missing from Mathlib, obtained from the constant-family product-congruence sign lemmas.",
+      "The CRT ring isomorphism intertwines multiplication-by-a with the product of the component multiplications; sign_eq_sign_of_equiv transports the sign verbatim.",
+      "Multiplicativity of the Jacobi symbol in its denominator is the permutation-theoretic shadow of the Chinese Remainder Theorem: the only arithmetic input is that an odd number raised to an odd power preserves a sign.",
+      "The Zolotarev sign character signRingHom is a quadratic character (squares to 1) for every modulus, generalizing the parent's prime-only construction."
+    ],
+    "prerequisites": [
+      "Permutation sign as a group homomorphism (Equiv.Perm.sign)",
+      "The Chinese Remainder Theorem for ZMod (ZMod.chineseRemainder)",
+      "Jacobi and Legendre symbols (Mathlib LegendreSymbol API)",
+      "Finite group theory of (ℤ/n)ˣ"
+    ]
+  },
+  "sections": [
+    {
+      "title": "Multiplication by a unit as a permutation of the whole ring",
+      "content": "ringMulPerm a is the permutation x ↦ a·x of all of ℤ/n (not just the units), assembled into a group homomorphism ringMulPermHom : (ℤ/n)ˣ →* Perm (ℤ/n)."
+    },
+    {
+      "title": "The Zolotarev sign character for any modulus",
+      "content": "signRingHom = sign ∘ ringMulPermHom : (ℤ/n)ˣ →* ℤˣ, a quadratic character (squares to 1) defined for every positive modulus."
+    },
+    {
+      "title": "Sign of a product permutation",
+      "content": "sign_prodCongr: sign(σ ×ₚ τ) = sign σ ^ |β| · sign τ ^ |α|, plus units_pow_odd (u^k = u for u ∈ ℤˣ and odd k). General lemmas not in Mathlib."
+    },
+    {
+      "title": "The CRT decomposition",
+      "content": "sign_ringMulPerm_crt factors the sign through ZMod.chineseRemainder; sign_ringMulPerm_mul_of_odd specializes to odd coprime moduli, where the character is multiplicative — the permutation image of jacobiSym.mul_right."
+    },
+    {
+      "title": "Parallel with the Jacobi symbol",
+      "content": "jacobiSym_mul_right_mirror restates Mathlib's jacobiSym.mul_right (the value-level statement mirrored by the sign decomposition); legendre_eq_jacobi records the prime base case legendreSym.to_jacobiSym."
+    }
+  ],
+  "meta": {
+    "author": "Zolotarev (1872), Frobenius (1914)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Zolotarev%27s_lemma",
+    "date": "1914",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ01OQ03.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-reciprocity",
+      "jacobi-symbol",
+      "permutation-sign",
+      "chinese-remainder-theorem",
+      "zolotarev",
+      "frobenius",
+      "group-homomorphisms",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 262,
+    "theoremCount": 9,
+    "defCount": 3,
+    "assumptions": "None. The file has 0 axiom declarations, 0 sorries, no native_decide, and no assumption-carrying structures. All results are fully machine-checked against Mathlib v4.26.0 (#print axioms reports only propext / Classical.choice / Quot.sound). Honest scope: the file formalizes the STRUCTURAL CRT mechanism — the Zolotarev sign character decomposes (and, for odd moduli, multiplies) exactly as the Jacobi symbol does in its denominator. It does NOT close the loop to Jacobi VALUES; that requires the base case sign(ringMulPerm a on ℤ/p) = legendreSym p a, which combines the parent's units-level zolotarev_lemma with a fixed-point sign-restriction argument (multiplication fixes 0 ∈ ℤ/p). That base case is the remaining glue and is left as the next step.",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 3
+  },
+  "conclusion": {
+    "summary": "This file formalizes, with 0 sorries and 0 axioms, the Chinese-Remainder decomposition of the Zolotarev multiplication-permutation sign character on ℤ/n. It introduces ringMulPerm (multiplication by a unit on the whole ring), the sign character signRingHom for arbitrary modulus, the general product-permutation sign formula sign_prodCongr (absent from Mathlib), and the CRT factorization sign_ringMulPerm_crt, which becomes genuine multiplicativity (sign_ringMulPerm_mul_of_odd) for odd coprime moduli.",
+    "implications": "Shows that the multiplicativity of the Jacobi symbol in its denominator is a corollary of the Chinese Remainder Theorem acting on permutation signs, with the only arithmetic input being units_pow_odd. This is the structural backbone of Frobenius's generalization of Zolotarev's lemma to composite moduli, and complements the parent's prime-only formalization on the units group.",
+    "openQuestions": [
+      "Close the loop to Jacobi VALUES: prove the base case sign(ringMulPerm a on ℤ/p) = legendreSym p a by combining the parent's units-level Zolotarev lemma with a fixed-point sign-restriction lemma (multiplication fixes 0 ∈ ℤ/p), then iterate the CRT multiplicativity over the prime factorization to obtain sign(ringMulPerm a on ℤ/n) = J(a | n) for squarefree odd n.",
+      "Handle prime-power factors p^e (e ≥ 2), where (ℤ/p^e)ˣ has even order, to obtain the full Frobenius statement for all odd n."
+    ]
+  },
+  "references": [
+    {
+      "title": "Zolotarev, Nouvelle démonstration de la loi de réciprocité de Legendre (1872)",
+      "url": "https://en.wikipedia.org/wiki/Zolotarev%27s_lemma"
+    },
+    {
+      "title": "Jacobi symbol",
+      "url": "https://en.wikipedia.org/wiki/Jacobi_symbol"
+    },
+    {
+      "title": "Rousseau, On the quadratic reciprocity law, Amer. Math. Monthly (1991)",
+      "url": "https://www.jstor.org/stable/2324174"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-01",
+      "relation": "parent",
+      "note": "Zolotarev's permutation proof for the prime case (units group); this entry answers its third open question."
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-01-oq-01",
+      "relation": "sibling",
+      "note": "Gauss sum as a third QR pathway."
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-01-oq-02",
+      "relation": "sibling",
+      "note": "Cubic and quartic characters as higher-reciprocity pathways."
+    }
+  ]
+}

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03.json
@@ -1,0 +1,55 @@
+{
+  "slug": "elementary-quadratic-reciprocity-oq-01-oq-03",
+  "title": "CRT decomposition of the Zolotarev multiplication permutation",
+  "status": "completed",
+  "phase": "COMPLETE",
+  "tier": "B",
+  "tractability": 6,
+  "started": "2026-06-21T00:00:00.000Z",
+  "completed": "2026-06-21T00:00:00.000Z",
+  "lastUpdate": "2026-06-21T00:00:00.000Z",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{For coprime } m,n: \\mathrm{sign}(x \\mapsto ax \\text{ on } \\mathbb{Z}/mn) = \\mathrm{sign}(x \\mapsto a_1 x \\text{ on } \\mathbb{Z}/m)^{n} \\cdot \\mathrm{sign}(x \\mapsto a_2 x \\text{ on } \\mathbb{Z}/n)^{m}, \\text{ and } = \\mathrm{sign}_1 \\cdot \\mathrm{sign}_2 \\text{ for } m,n \\text{ odd.}",
+    "plain": "Can the Chinese Remainder Theorem decomposition of the multiplication-by-a permutation on Z/pq be formalized, as the structural mechanism behind Frobenius's generalization of Zolotarev's permutation proof of quadratic reciprocity to composite moduli and the Jacobi symbol? This is the third open question of elementary-quadratic-reciprocity-oq-01.",
+    "whyMatters": [
+      "Shows the multiplicativity of the Jacobi symbol in its denominator is the shadow of the Chinese Remainder Theorem acting on permutation signs.",
+      "Extends the parent's prime-only Zolotarev formalization (on the units group) to the composite-modulus / whole-ring setting required by Frobenius."
+    ]
+  },
+  "significance": 6,
+  "tags": [
+    "number-theory",
+    "quadratic-reciprocity",
+    "jacobi-symbol",
+    "permutations",
+    "chinese-remainder-theorem",
+    "group-theory",
+    "open-question"
+  ],
+  "tractability_notes": "Structural CRT decomposition is fully tractable and verified (0 axioms); closing the loop to Jacobi VALUES needs a fixed-point sign-restriction base case.",
+  "knowledge": {
+    "builtItems": [
+      "ringMulPerm / ringMulPermHom in ElementaryQuadraticReciprocityOQ01OQ03.lean: multiplication-by-a-unit as a permutation of the WHOLE ring ℤ/n (Frobenius setting; |ℤ/n| = n is odd, |(ℤ/n)ˣ| = φ(n) is even).",
+      "signRingHom : (ℤ/n)ˣ →* ℤˣ — the Zolotarev sign character for ANY modulus, with signRingHom_sq (quadratic character).",
+      "sign_prodCongr: sign(σ ×ₚ τ) = sign σ ^ |β| · sign τ ^ |α| — general product-permutation sign formula, absent from Mathlib.",
+      "sign_ringMulPerm_crt: CRT decomposition of the multiplication-permutation sign through ZMod.chineseRemainder.",
+      "sign_ringMulPerm_mul_of_odd: multiplicativity of the sign character across an odd coprime CRT factorization, mirroring jacobiSym.mul_right; units_pow_odd helper."
+    ],
+    "insights": [
+      "The Frobenius/Jacobi generalization must act on the whole ring ℤ/n (n odd ⟹ |ℤ/n| odd), not the even-order units group, or every sign would be trivial.",
+      "sign_eq_sign_of_equiv transports the permutation sign verbatim across the CRT ring isomorphism because the iso commutes with multiplication-by-a.",
+      "The only arithmetic input to Jacobi-denominator multiplicativity is units_pow_odd: an odd number raised to an odd power preserves a sign."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no sign-of-product-permutation lemma sign(σ ×ₚ τ) = sign σ ^ |β| · sign τ ^ |α| (only the constant-free family lemmas sign_prodCongrLeft / sign_prodCongrRight). Provided here as sign_prodCongr.",
+      "Mathlib has no Zolotarev lemma connecting Equiv.Perm.sign to legendreSym / jacobiSym."
+    ],
+    "nextSteps": [
+      "Prove the base case sign(ringMulPerm a on ℤ/p) = legendreSym p a by combining the parent's units-level zolotarev_lemma with a fixed-point sign-restriction lemma (multiplication fixes 0 ∈ ℤ/p).",
+      "Iterate CRT multiplicativity over the prime factorization to obtain sign(ringMulPerm a on ℤ/n) = J(a | n) for squarefree odd n.",
+      "Handle prime-power factors p^e (e ≥ 2) to reach the full Frobenius statement for all odd n."
+    ],
+    "progressSummary": "COMPLETE (verified, 0 axioms, 0 sorries): formalized the structural CRT decomposition of the Zolotarev multiplication-permutation sign character on ℤ/n, including a general product-permutation sign lemma absent from Mathlib and the odd-modulus multiplicativity that mirrors jacobiSym.mul_right. Honest scope: the loop to Jacobi VALUES (base case on ℤ/p) is left as the documented next step."
+  }
+}


### PR DESCRIPTION
## Summary
Answers the **third open question** of `elementary-quadratic-reciprocity-oq-01`:

> *Can the CRT decomposition of the multiplication permutation on ℤ/pq be formalized?*

This is the structural mechanism behind **Frobenius's (1914) generalization** of Zolotarev's permutation proof of quadratic reciprocity to **composite moduli and the Jacobi symbol**. Distinct from the siblings, which pursued Gauss sums (`oq-01-oq-01`) and cubic/quartic characters (`oq-01-oq-02`).

## Progress
New file `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03.lean` (262 lines, 9 theorems / 3 defs, **0 sorries, 0 axioms, verified**):

- **`ringMulPerm` / `signRingHom`** — multiplication-by-a-unit on the **whole ring** ℤ/n (not the units), assembled into the Zolotarev sign character `(ℤ/n)ˣ →* ℤˣ` for *any* modulus. The whole-ring setting is essential: `|ℤ/n| = n` is odd for odd n, whereas `|(ℤ/n)ˣ| = φ(n)` is even — which would force every permutation sign to be trivial.
- **`sign_prodCongr`** — `sign(σ ×ₚ τ) = sign σ ^ |β| · sign τ ^ |α|`, a general product-permutation sign lemma **absent from Mathlib** (Mathlib has only the constant-free family lemmas `sign_prodCongrLeft/Right`).
- **`sign_ringMulPerm_crt`** — the CRT decomposition: through `ZMod.chineseRemainder`, the sign factors as `sign(σ₁)^n · sign(σ₂)^m`.
- **`sign_ringMulPerm_mul_of_odd`** — for odd coprime moduli the exponents are odd, so the sign character is genuinely multiplicative, mirroring `jacobiSym.mul_right`. Helper `units_pow_odd`.

## Findings
- Multiplicativity of the Jacobi symbol in its denominator is the shadow of the Chinese Remainder Theorem acting on permutation signs; the only arithmetic input is `units_pow_odd` (odd^odd preserves a sign).
- `sign_eq_sign_of_equiv` transports the sign verbatim across the CRT *ring* isomorphism because it commutes with multiplication-by-a.

## Honest scope
This formalizes the **structural** CRT mechanism. It does **not** close the loop to Jacobi *values* — that needs the base case `sign(ringMulPerm a on ℤ/p) = legendreSym p a` (parent's units-level lemma + a fixed-point sign-restriction argument), documented as the next step.

## Status
**Outcome**: completed (verified, 0-axiom). Built clean via `docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ01OQ03`.
**Next Steps**: prove the ℤ/p base case and iterate over the prime factorization to reach Jacobi values.

🤖 Generated by researcher-9