### PR TITLE
research(erdos-2-oq-03): axiom-free structural cost of a large minimum modulus [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1479,6 +1479,7 @@ import Proofs.Erdos29Problem
 import Proofs.Erdos2OQ01
 import Proofs.Erdos2OQ01Aristotle
 import Proofs.Erdos2Problem
+import Proofs.Erdos2OQ03
 import Proofs.Erdos300Problem
 import Proofs.Erdos301Problem
 import Proofs.Erdos302Aristotle

--- a/proofs/Proofs/Erdos2OQ03.lean
+++ b/proofs/Proofs/Erdos2OQ03.lean
@@ -1,0 +1,234 @@
+/-
+  Erdős Problem #2 — Open Question OQ-03:
+  "Can the Balister et al. bound of 616,000 be further improved?"
+
+  Source problem: https://erdosproblems.com/2
+  Related formalization: Proofs/Erdos2Problem.lean
+
+  ---------------------------------------------------------------------------
+  Scope and honesty
+  ---------------------------------------------------------------------------
+  The open question OQ-03 asks for a *quantitative* improvement to the upper
+  bound 616,000 (Balister–Bollobás–Morris–Sahasrabudhe–Tiba, 2022) on the
+  minimum modulus of a covering system.  That is a wide-open research-level
+  quantitative problem and is NOT resolved here.
+
+  What this file contributes is the elementary *structural arithmetic* that
+  every such bound must respect — the counting constraints that any covering
+  system with a large minimum modulus is forced to obey.  These are the "soft"
+  consequences of the classical density inequality
+
+        Σ 1/nᵢ ≥ 1                                       (reciprocal-sum bound)
+
+  which the parent file `Erdos2Problem.lean` axiomatizes as
+  `Erdos2.reciprocal_sum_ge_one`.  Here we do NOT use that axiom: every theorem
+  takes the reciprocal-sum bound as an explicit hypothesis
+  `cs.reciprocalSum ≥ 1`, so the whole file is axiom-free (0 `axiom`
+  declarations, 0 `sorry`, no `native_decide`).
+
+  This file is deliberately SELF-CONTAINED: the parent `Erdos2Problem.lean`
+  currently fails to compile under Lean 4.26.0 / Mathlib (its theorem
+  `hough_bound` forward-references the `balister_bound` axiom declared later in
+  the file).  We therefore re-introduce the minimal definitions we need rather
+  than importing it, so this contribution is independently verifiable.
+
+  Main results (all conditional on the classical reciprocal-sum bound):
+
+  * `reciprocalSum_le`    — Σ 1/nᵢ ≤ k/m  when every modulus is ≥ m
+                            (k = number of congruence classes).
+  * `card_classes_ge`     — a covering system with minimum modulus ≥ m has at
+                            least m congruence classes (k ≥ m).
+  * `maxModulus_ge`       — with distinct moduli all in [m, M], necessarily
+                            2m ≤ M + 1, i.e. the moduli must span a factor-2
+                            range; a maximal modulus ≥ 2m − 1 is forced.
+  * `improvement_cost`    — the combined structural price of a min modulus ≥ m.
+  * `card_bound_tight`    — the count bound k ≥ m is tight (the trivial
+                            {0, 1 mod 2} system realises k = m = 2).
+
+  Interpretation w.r.t. OQ-03: any covering system witnessing a minimum
+  modulus m needs ≥ m classes and a modulus ≥ 2m − 1.  Pushing the *lower*
+  bound (currently Owens' 42) therefore has an unavoidable combinatorial cost,
+  and any improved *upper* bound M must be consistent with `maxModulus_ge`.
+-/
+
+import Mathlib
+
+open Set Finset
+
+namespace Erdos2OQ03
+
+/- ## Minimal covering-system definitions (self-contained) -/
+
+/-- An arithmetic progression represented as a pair (residue, modulus). -/
+structure CongruenceClass where
+  residue : ℕ
+  modulus : ℕ
+  modulus_pos : modulus ≥ 2
+
+/-- The set of integers in a congruence class. -/
+def CongruenceClass.toSet (c : CongruenceClass) : Set ℤ :=
+  { x | x ≡ c.residue [ZMOD c.modulus] }
+
+/-- A covering system is a finite list of congruence classes that cover all
+    integers. -/
+structure CoveringSystem where
+  classes : List CongruenceClass
+  nonempty : classes.length ≥ 1
+  covers : ∀ x : ℤ, ∃ c ∈ classes, x ∈ c.toSet
+
+/-- The list of moduli in a covering system. -/
+def CoveringSystem.moduli (cs : CoveringSystem) : List ℕ :=
+  cs.classes.map CongruenceClass.modulus
+
+/-- A covering system has distinct moduli. -/
+def CoveringSystem.hasDistinctModuli (cs : CoveringSystem) : Prop :=
+  cs.moduli.Nodup
+
+/-- A covering system has minimum modulus at least `m`. -/
+def CoveringSystem.hasMinModulusAtLeast (cs : CoveringSystem) (m : ℕ) : Prop :=
+  ∀ c ∈ cs.classes, m ≤ c.modulus
+
+/-- The reciprocal sum of the moduli, `Σ 1/nᵢ`. -/
+def CoveringSystem.reciprocalSum (cs : CoveringSystem) : ℚ :=
+  (cs.moduli.map (fun n : ℕ => (1 : ℚ) / (n : ℚ))).sum
+
+/- ## The reciprocal-sum upper bound -/
+
+/--
+If every modulus of `cs` is at least `m ≥ 1`, then the reciprocal sum is at
+most `k / m`, where `k = cs.classes.length` is the number of congruence
+classes.  This is the trivial half of the density picture: each summand
+`1/nᵢ` is at most `1/m`.
+-/
+theorem reciprocalSum_le (cs : CoveringSystem) {m : ℕ} (hm : 1 ≤ m)
+    (hmin : cs.hasMinModulusAtLeast m) :
+    cs.reciprocalSum ≤ (cs.classes.length : ℚ) / m := by
+  rw [CoveringSystem.reciprocalSum, CoveringSystem.moduli, List.map_map]
+  -- goal: (cs.classes.map ((fun n => 1/↑n) ∘ modulus)).sum ≤ k/m
+  have hbound : ∀ x ∈ cs.classes.map ((fun n : ℕ => (1 : ℚ) / (n : ℚ)) ∘ CongruenceClass.modulus),
+      x ≤ (1 : ℚ) / m := by
+    intro x hx
+    rw [List.mem_map] at hx
+    obtain ⟨c, hc, rfl⟩ := hx
+    simp only [Function.comp_apply]
+    exact one_div_le_one_div_of_le (by exact_mod_cast hm) (by exact_mod_cast hmin c hc)
+  have h := List.sum_le_card_nsmul _ _ hbound
+  rwa [List.length_map, nsmul_eq_mul, mul_one_div] at h
+
+/- ## Lower bound on the number of congruence classes -/
+
+/--
+**Class-count bound.**  A covering system whose minimum modulus is at least
+`m` must contain at least `m` congruence classes.
+
+This is the elementary engine behind every quantitative attack on Erdős #2:
+to have a large minimum modulus you are forced to use many classes.  It is
+conditional on the classical reciprocal-sum bound `cs.reciprocalSum ≥ 1`
+(parent axiom `Erdos2.reciprocal_sum_ge_one`), supplied here as a hypothesis.
+-/
+theorem card_classes_ge (cs : CoveringSystem) {m : ℕ} (hm : 1 ≤ m)
+    (hmin : cs.hasMinModulusAtLeast m) (hrec : cs.reciprocalSum ≥ 1) :
+    m ≤ cs.classes.length := by
+  have hmpos : (0 : ℚ) < m := by exact_mod_cast (show 0 < m by omega)
+  have hle : (1 : ℚ) ≤ (cs.classes.length : ℚ) / m :=
+    le_trans hrec (reciprocalSum_le cs hm hmin)
+  have : (m : ℚ) ≤ (cs.classes.length : ℚ) := (one_le_div hmpos).1 hle
+  exact_mod_cast this
+
+/- ## The moduli must span a wide range -/
+
+/--
+**Spread bound.**  If a covering system has *distinct* moduli, all lying in
+the interval `[m, M]`, then `2m ≤ M + 1`.  Equivalently the largest modulus
+is at least `2m − 1`: the moduli cannot all be confined to a narrow window
+above the minimum.
+
+Proof: `card_classes_ge` forces at least `m` classes, while distinctness
+confines the moduli to `Icc m M`, which has only `M + 1 − m` elements.
+-/
+theorem maxModulus_ge (cs : CoveringSystem) {m M : ℕ} (hm : 1 ≤ m)
+    (hdist : cs.hasDistinctModuli)
+    (hmin : cs.hasMinModulusAtLeast m)
+    (hmax : ∀ c ∈ cs.classes, c.modulus ≤ M)
+    (hrec : cs.reciprocalSum ≥ 1) :
+    2 * m ≤ M + 1 := by
+  have hcard : m ≤ cs.classes.length := card_classes_ge cs hm hmin hrec
+  have hnd : cs.moduli.Nodup := hdist
+  have hsub : cs.moduli.toFinset ⊆ Finset.Icc m M := by
+    intro n hn
+    rw [List.mem_toFinset, CoveringSystem.moduli, List.mem_map] at hn
+    obtain ⟨c, hc, rfl⟩ := hn
+    exact Finset.mem_Icc.2 ⟨hmin c hc, hmax c hc⟩
+  have hk : cs.classes.length ≤ M + 1 - m :=
+    calc cs.classes.length
+        = cs.moduli.length := by simp [CoveringSystem.moduli]
+      _ = cs.moduli.toFinset.card := (List.toFinset_card_of_nodup hnd).symm
+      _ ≤ (Finset.Icc m M).card := Finset.card_le_card hsub
+      _ = M + 1 - m := Nat.card_Icc m M
+  omega
+
+/--
+**Structural cost of a large minimum modulus.**  Packaging the two bounds:
+a covering system with distinct moduli, minimum modulus ≥ `m`, and all moduli
+≤ `M` must use at least `m` classes and reach a modulus ≥ `2m − 1`.
+
+This is the structural content behind OQ-03: any hypothetical covering system
+that improves the known bounds is constrained by these inequalities.
+-/
+theorem improvement_cost (cs : CoveringSystem) {m M : ℕ} (hm : 1 ≤ m)
+    (hdist : cs.hasDistinctModuli)
+    (hmin : cs.hasMinModulusAtLeast m)
+    (hmax : ∀ c ∈ cs.classes, c.modulus ≤ M)
+    (hrec : cs.reciprocalSum ≥ 1) :
+    m ≤ cs.classes.length ∧ 2 * m ≤ M + 1 :=
+  ⟨card_classes_ge cs hm hmin hrec, maxModulus_ge cs hm hdist hmin hmax hrec⟩
+
+/- ## Tightness of the class-count bound -/
+
+/-- A modulus-2 congruence class: even integers. -/
+def mod2_even : CongruenceClass := ⟨0, 2, by norm_num⟩
+/-- A modulus-2 congruence class: odd integers. -/
+def mod2_odd : CongruenceClass := ⟨1, 2, by norm_num⟩
+
+/-- The integers are covered by the even and odd classes. -/
+theorem even_odd_cover : ∀ x : ℤ, x ∈ mod2_even.toSet ∨ x ∈ mod2_odd.toSet := by
+  intro x
+  unfold mod2_even mod2_odd CongruenceClass.toSet
+  simp only [mem_setOf_eq, Int.ModEq]
+  rcases Int.emod_two_eq_zero_or_one x with h | h
+  · left; omega
+  · right; omega
+
+/-- The trivial covering system `{0 mod 2, 1 mod 2}`. -/
+def trivialCover : CoveringSystem where
+  classes := [mod2_even, mod2_odd]
+  nonempty := by simp
+  covers := fun x => by
+    rcases even_odd_cover x with h | h
+    · exact ⟨mod2_even, by simp, h⟩
+    · exact ⟨mod2_odd, by simp, h⟩
+
+/-- Its reciprocal sum is exactly `1/2 + 1/2 = 1`. -/
+theorem trivialCover_reciprocalSum : trivialCover.reciprocalSum = 1 := by
+  simp [CoveringSystem.reciprocalSum, CoveringSystem.moduli, trivialCover,
+    mod2_even, mod2_odd]
+  norm_num
+
+/--
+**The class-count bound is tight.**  There is a covering system attaining
+`k = m` exactly: the trivial mod-2 cover has minimum modulus `m = 2` and
+exactly `k = 2` classes, with reciprocal sum `1`.  So `card_classes_ge`
+cannot be improved to `m < k` in general.
+-/
+theorem card_bound_tight :
+    ∃ (cs : CoveringSystem) (m : ℕ),
+      1 ≤ m ∧ cs.hasMinModulusAtLeast m ∧ cs.reciprocalSum ≥ 1 ∧
+        cs.classes.length = m := by
+  refine ⟨trivialCover, 2, by norm_num, ?_, ?_, ?_⟩
+  · intro c hc
+    simp only [trivialCover, List.mem_cons, List.not_mem_nil, or_false] at hc
+    rcases hc with rfl | rfl <;> simp [mod2_even, mod2_odd]
+  · rw [trivialCover_reciprocalSum]
+  · simp [trivialCover]
+
+end Erdos2OQ03

--- a/src/data/proofs/erdos-2-oq-03/meta.json
+++ b/src/data/proofs/erdos-2-oq-03/meta.json
@@ -1,0 +1,107 @@
+{
+  "id": "erdos-2-oq-03",
+  "title": "Erdős Problem #2 (OQ-03): Structural Cost of a Large Minimum Modulus",
+  "slug": "erdos-2-oq-03",
+  "description": "Axiom-free structural arithmetic behind the covering-systems bound problem: any covering system with minimum modulus m has at least m congruence classes and a modulus ≥ 2m−1.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://erdosproblems.com/2",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos2OQ03.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "covering-systems",
+      "modular-arithmetic",
+      "combinatorics",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "erdosNumber": 2,
+    "erdosUrl": "https://erdosproblems.com/2",
+    "erdosProblemStatus": "solved",
+    "axiomCount": 0,
+    "lineCount": 234,
+    "theoremCount": 7,
+    "definitionCount": 10,
+    "dateAdded": "2026-06-21",
+    "assumptions": "All main theorems are conditional on the classical reciprocal-sum density bound Σ 1/nᵢ ≥ 1 for covering systems, which is supplied as an explicit hypothesis (not an axiom). The parent entry erdos-2 records this bound as the axiom Erdos2.reciprocal_sum_ge_one; here it appears only as a theorem hypothesis, so every declaration is axiom-free (depends solely on propext, Classical.choice, Quot.sound).",
+    "relatedProblems": [
+      {
+        "id": "erdos-2",
+        "relationship": "Parent entry: formalizes the solved status of the minimum-modulus problem (Hough 2015; Balister–Bollobás–Morris–Sahasrabudhe–Tiba 2022, bound 616,000; Owens 2014, construction with min modulus 42) via three axioms, including the density bound reciprocal_sum_ge_one. OQ-03 asks whether the 616,000 upper bound can be improved. This entry isolates the elementary counting constraints any such bound must respect, taking the density bound as a hypothesis rather than an axiom, and is self-contained because the parent file currently fails to compile under Lean 4.26.0 (a forward reference to the balister_bound axiom)."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős (c. 1950) asked whether the minimum modulus of a covering system with distinct moduli ≥ 2 can be arbitrarily large — 'perhaps my favourite problem', with a $1000 prize. Constructions raised the record minimum modulus to 2, 3, 20, 36, 40, 42 (Owens 2014), and most experts expected the answer YES. Hough (2015) stunned the field by proving NO: every covering system has a modulus ≤ 10^16, via the Lovász Local Lemma building on Filaseta–Ford–Konyagin–Pomerance–Yu (2007). Balister, Bollobás, Morris, Sahasrabudhe and Tiba (2022) sharpened the bound to 616,000 with their 'distortion method' (Annals of Mathematics). The exact maximum minimum modulus is open, lying between 42 and 616,000. Open question OQ-03 asks specifically whether the 616,000 upper bound can be pushed lower.",
+    "problemStatement": "OQ-03: Can the Balister et al. upper bound of 616,000 on the minimum modulus of a covering system be improved? This is a wide-open quantitative research problem and is NOT resolved here. Instead this entry formalizes, with no axioms, the elementary structural arithmetic that every covering system with a large minimum modulus must obey — the soft consequences of the classical density inequality Σ 1/nᵢ ≥ 1.",
+    "proofStrategy": "Every theorem is conditional on the density bound cs.reciprocalSum ≥ 1, given as a hypothesis. (1) reciprocalSum_le: if all moduli are ≥ m then Σ 1/nᵢ ≤ k/m, since each summand is ≤ 1/m (List.sum_le_card_nsmul). (2) card_classes_ge: combining with Σ 1/nᵢ ≥ 1 gives k ≥ m — a large minimum modulus forces many classes. (3) maxModulus_ge: if moreover the moduli are distinct and all ≤ M, then the k moduli are distinct integers in [m, M], so k ≤ M+1−m (List.toFinset_card_of_nodup + Nat.card_Icc); with k ≥ m this yields 2m ≤ M+1, i.e. a modulus ≥ 2m−1 is forced. (4) improvement_cost packages both. (5) card_bound_tight shows k ≥ m is sharp via the trivial {0,1 mod 2} cover (k = m = 2, reciprocal sum 1).",
+    "significance": "These bounds make explicit why pushing the lower bound (Owens' 42) is combinatorially expensive — a minimum modulus m requires at least m congruence classes and forces the moduli to span a factor-2 range — and frame the constraints any improved upper bound for OQ-03 must respect. The contribution is honest about scope: it is the easy structural skeleton, not a quantitative improvement to 616,000, and the deep density bound itself is assumed rather than reproved."
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Self-contained covering-system definitions",
+      "startLine": 60,
+      "endLine": 93,
+      "summary": "Re-introduces CongruenceClass (residue, modulus ≥ 2), CoveringSystem (a nonempty list of classes covering ℤ), and the derived notions moduli, hasDistinctModuli, hasMinModulusAtLeast, and reciprocalSum = Σ 1/nᵢ. The file is self-contained because the parent Erdos2Problem.lean does not currently compile.",
+      "mathContext": "A covering system is a finite family of arithmetic progressions aᵢ mod nᵢ (nᵢ ≥ 2) whose union is all of ℤ. The minimum modulus is min nᵢ."
+    },
+    {
+      "id": "reciprocal-sum-bound",
+      "title": "§ The reciprocal-sum upper bound",
+      "startLine": 95,
+      "endLine": 117,
+      "summary": "reciprocalSum_le: if every modulus is ≥ m ≥ 1 then Σ 1/nᵢ ≤ k/m, where k is the number of classes. Each summand 1/nᵢ ≤ 1/m, and the list-sum bound List.sum_le_card_nsmul does the rest.",
+      "mathContext": "This is the elementary upper half of the density picture; the matching lower half (Σ 1/nᵢ ≥ 1) is the classical density fact assumed as a hypothesis."
+    },
+    {
+      "id": "class-count",
+      "title": "§ Lower bound on the number of classes",
+      "startLine": 118,
+      "endLine": 137,
+      "summary": "card_classes_ge: a covering system with minimum modulus ≥ m has at least m congruence classes (k ≥ m), obtained by combining 1 ≤ Σ 1/nᵢ ≤ k/m.",
+      "mathContext": "The elementary engine behind quantitative work on Erdős #2: a large minimum modulus forces a large number of progressions."
+    },
+    {
+      "id": "spread",
+      "title": "§ The moduli must span a wide range",
+      "startLine": 138,
+      "endLine": 184,
+      "summary": "maxModulus_ge: distinct moduli all in [m, M] force 2m ≤ M+1 (a modulus ≥ 2m−1 exists), since k distinct integers in [m, M] satisfy k ≤ M+1−m while k ≥ m. improvement_cost packages the count and spread bounds.",
+      "mathContext": "The moduli of a covering system cannot be confined to a narrow window just above the minimum; this is the structural constraint any improved bound for OQ-03 must respect."
+    },
+    {
+      "id": "tightness",
+      "title": "§ Tightness of the class-count bound",
+      "startLine": 186,
+      "endLine": 234,
+      "summary": "The trivial covering system {0 mod 2, 1 mod 2} has reciprocal sum exactly 1 and realises k = m = 2 (card_bound_tight), so the bound k ≥ m cannot be improved in general.",
+      "mathContext": "Demonstrates sharpness of card_classes_ge at the smallest possible minimum modulus."
+    }
+  ],
+  "conclusion": {
+    "summary": "We give an axiom-free formalization of the structural arithmetic underlying Erdős Problem #2 and its open question OQ-03. Conditional only on the classical density bound Σ 1/nᵢ ≥ 1 (supplied as a hypothesis, not an axiom), we prove that a covering system with minimum modulus m has at least m congruence classes and a modulus at least 2m−1, and that the class-count bound is sharp.",
+    "implications": "These inequalities quantify the combinatorial cost of a large minimum modulus and constrain any covering system relevant to improving the known bounds (Owens' 42 from below, Balister et al.'s 616,000 from above). The deep quantitative question OQ-03 — whether 616,000 can be improved — remains open and is untouched here.",
+    "openQuestions": [
+      "Can the Balister et al. upper bound of 616,000 be improved? (OQ-03, open)",
+      "What is the exact maximum possible minimum modulus, between 42 and 616,000?",
+      "Can the classical density bound Σ 1/nᵢ ≥ 1 itself be formalized axiom-free (e.g. via a residue-counting argument), removing the remaining hypothesis?"
+    ]
+  },
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Set", "Finset"],
+    "namespace": "Erdos2OQ03",
+    "lineCount": 234,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 10,
+    "path": "Proofs/Erdos2OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-2-oq-03.json
+++ b/src/data/research/problems/erdos-2-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "erdos-2-oq-03",
   "title": "Can the Balister et al",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -31,11 +31,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "Formalized (axiom-free) the elementary structural arithmetic behind Erdős #2 / OQ-03: conditional on the classical density bound Σ 1/nᵢ ≥ 1 (taken as a hypothesis, not an axiom), a covering system with minimum modulus m must have at least m congruence classes and a modulus ≥ 2m−1. The deep quantitative OQ-03 (improving 616,000) is untouched. Self-contained because the parent Erdos2Problem.lean does not compile under Lean 4.26.0.",
+    "builtItems": [
+      "reciprocalSum_le: all moduli ≥ m ⟹ Σ 1/nᵢ ≤ k/m (k = #classes)",
+      "card_classes_ge: min modulus ≥ m ⟹ ≥ m congruence classes",
+      "maxModulus_ge: distinct moduli in [m,M] ⟹ 2m ≤ M+1 (modulus ≥ 2m−1 forced)",
+      "improvement_cost: combined count+spread structural cost",
+      "card_bound_tight: k ≥ m sharp via {0,1 mod 2} (k=m=2, recip sum 1)"
+    ],
+    "insights": [
+      "The reciprocal-sum lower bound Σ 1/nᵢ ≥ 1 is the entire engine: paired with the trivial upper bound Σ 1/nᵢ ≤ k/m it forces k ≥ m, linking large minimum modulus to many classes.",
+      "Distinctness + Nat.card_Icc converts the class count into a span constraint 2m ≤ M+1, so covering moduli cannot cluster just above the minimum.",
+      "Parent Erdos2Problem.lean is bit-rotted: hough_bound forward-references the balister_bound axiom declared later, so the file fails to compile under Lean 4.26.0; downstream entries must be self-contained."
+    ],
+    "mathlibGaps": [
+      "No lemma counting residues of an arithmetic progression inside an interval (P/n exact count when n | P), which is what an axiom-free proof of Σ 1/nᵢ ≥ 1 would need."
+    ],
+    "nextSteps": [
+      "Prove the density bound Σ 1/nᵢ ≥ 1 axiom-free via a residue-counting argument over the lcm of the moduli, removing the remaining hypothesis.",
+      "Strengthen the spread bound using harmonic sums: distinct moduli ≥ m with Σ 1/nᵢ ≥ 1 force the largest modulus to be ≳ e·m, not just 2m−1."
+    ]
   },
   "tags": [
     "seeker-selected",


### PR DESCRIPTION
## Erdős Problem #2 — Open Question OQ-03

**OQ-03**: *Can the Balister et al. (2022) upper bound of 616,000 on the minimum modulus of a covering system be improved?*

That quantitative research question is **wide open and is not resolved here.** What this entry adds is the elementary **structural arithmetic** any covering system with a large minimum modulus must obey — the soft consequences of the classical density inequality $\sum 1/n_i \ge 1$.

### Honest scope
Every theorem is **conditional on the density bound** `cs.reciprocalSum ≥ 1` (the parent's axiom `reciprocal_sum_ge_one`), supplied here as an explicit **hypothesis, not an axiom**. So the whole file is axiom-free.

### Results
| Theorem | Statement |
|---|---|
| `reciprocalSum_le` | all moduli ≥ m ⟹ Σ 1/nᵢ ≤ k/m |
| `card_classes_ge` | min modulus ≥ m ⟹ ≥ m congruence classes |
| `maxModulus_ge` | distinct moduli in [m,M] ⟹ 2m ≤ M+1 (a modulus ≥ 2m−1 is forced) |
| `improvement_cost` | combined structural price of a large minimum modulus |
| `card_bound_tight` | k ≥ m is sharp ({0,1 mod 2} realises k = m = 2) |

**Interpretation:** a covering system witnessing minimum modulus m needs ≥ m classes and a modulus ≥ 2m−1 — quantifying why pushing the lower bound (Owens' 42) is combinatorially expensive, and constraining any improved upper bound for OQ-03.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos2OQ03` → **Build succeeded**
- `#print axioms` on all 5 main theorems → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).
- 234L, 7 thm / 10 def, **0 sorry, 0 axiom, no native_decide**.

### Note
**Self-contained**: the parent `Erdos2Problem.lean` does not compile under Lean 4.26.0 (its `hough_bound` forward-references the `balister_bound` axiom declared later in the file), so the minimal covering-system definitions are re-introduced here rather than imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)