### PR TITLE
research(geometric-series-oq-08-...-oq-02-oq-01): solve (★∞) in closed form via the Eulerian polynomial [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2671,6 +2671,7 @@ import Proofs.GeometricSeriesOQ08OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01OQ02
+import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01
 import Proofs.GeometricSeriesOQ08OQ03
 import Proofs.GeometricSeriesOQ08OQ03OQ01
 import Proofs.GeometricSeriesOQ08OQ03OQ01OQ01

--- a/proofs/Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,145 @@
+import Mathlib
+import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01OQ02
+import Proofs.GeometricSeriesOQ07OQ01OQ01
+
+/-
+# Solving the infinite-limit recurrence (★∞) in closed form
+
+## What This Proves
+
+The parent `geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02` introduces the
+**infinite m-th moment**
+
+  infMoment m x  :=  ∑_{k=0}^{∞} kᵐ·xᵏ        (|x| < 1)
+
+and proves the binomial-convolution recurrence
+
+  (1 − x)·infMoment m x  =  0ᵐ  +  x·∑_{i<m} C(m,i)·infMoment i x.   (★∞)
+
+The sibling `geometric-series-oq-07-oq-01-oq-01` defines the Eulerian polynomial
+`eulerPoly m` (geometric normalisation, by its differential recurrence
+`E₀ = 1`, `E_{m+1} = X(1−X)·E'ₘ + (m+1)·X·Eₘ`) and proves the analytic
+Frobenius closed form `HasSum (kᵐ·rᵏ) (Eₘ(r)/(1−r)^{m+1})`.
+
+This entry **closes the loop** between the two lines:
+
+* `infMoment_eq_eulerPoly` — the headline closed form
+    `infMoment m x = Eₘ(x)/(1 − x)^{m+1}`,
+  identifying the tsum-defined infinite moment with the Eulerian closed form.
+* `eulerPoly_recurrence` — the **new polynomial identity** stating that the
+  Eulerian polynomials *satisfy the (★∞) binomial-convolution recurrence*:
+
+    (1 − X)·Eₘ  =  0ᵐ·(1 − X)^{m+1}  +  X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}   (over ℝ[X]).
+
+  This is the algebraic shadow of (★∞): it shows the *derivative-free* convolution
+  recurrence and the *differential* Eulerian recurrence encode the same sequence
+  of polynomials.  It is proved by `eq_of_infinite_eval_eq`: both sides agree at
+  every `r ∈ (−1, 1)` (an infinite set) by combining the closed form with (★∞),
+  hence agree as polynomials.
+* `infMoment_three` — the explicit infinite **third** moment
+    `∑ k³·xᵏ = x(1 + 4x + x²)/(1 − x)⁴`,
+  a closed form one step beyond the parent's `infMoment_two`, read straight off
+  `eulerPoly_three`.
+
+## Honest Scope
+
+The headline closed form is obtained by reusing the gallery's analytic Eulerian
+identity (`hasSum_pow_mul_geometric_eulerPoly`), which itself rests on Frobenius'
+identity and the Stirling moment formula — it is *not* re-derived from scratch by
+strong induction on (★∞).  The genuinely new content is the polynomial recurrence
+identity `eulerPoly_recurrence`, an explicit relation among the Eulerian
+polynomials and the binomial weights that is not in Mathlib, and the new explicit
+third-moment closed form.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and
+`sorry`-free.
+-/
+
+namespace GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01
+
+open Polynomial Finset
+open GeometricSeriesOQ08OQ01OQ01OQ01OQ02 (infMoment infMoment_recurrence)
+open GeometricSeriesOQ07OQ01OQ01
+  (eulerPoly hasSum_pow_mul_geometric_eulerPoly eulerPoly_one eulerPoly_two eulerPoly_three)
+
+/-! ## Part 1: the headline closed form -/
+
+/-- **The closed-form solution of (★∞).**  For `|x| < 1`, the infinite moment
+`infMoment m x = ∑_{k} kᵐ·xᵏ` equals the Eulerian-polynomial closed form
+`Eₘ(x)/(1 − x)^{m+1}`.  This identifies the tsum-defined object of the parent
+recurrence line with the Frobenius/Eulerian closed form of the sibling. -/
+theorem infMoment_eq_eulerPoly (m : ℕ) {x : ℝ} (hx : |x| < 1) :
+    infMoment m x = (eulerPoly m : ℝ[X]).eval x / (1 - x) ^ (m + 1) := by
+  simpa only [infMoment] using (hasSum_pow_mul_geometric_eulerPoly m hx).tsum_eq
+
+/-! ## Part 2: the Eulerian polynomials satisfy (★∞) -/
+
+/-- **The Eulerian polynomials satisfy the (★∞) binomial-convolution recurrence.**
+As an identity in `ℝ[X]`,
+
+  `(1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}`.
+
+This is the polynomial form of the infinite recurrence (★∞): clearing the
+denominators `(1 − x)^{i+1}` in the closed form turns the analytic convolution
+recurrence into a single polynomial identity, connecting the derivative-free
+Pascal recursion to the differential recurrence defining `eulerPoly`.
+
+Proof: both sides are polynomials that agree at every `r ∈ (−1, 1)` — there, by
+the closed form `infMoment i r = Eᵢ(r)/(1−r)^{i+1}` and the parent's (★∞), the
+two evaluations coincide — and `(−1, 1)` is infinite, so the polynomials are
+equal. -/
+theorem eulerPoly_recurrence (m : ℕ) :
+    (1 - X) * (eulerPoly m : ℝ[X])
+      = (0 : ℝ[X]) ^ m * (1 - X) ^ (m + 1)
+        + X * ∑ i ∈ range m, (m.choose i : ℝ[X]) * eulerPoly i * (1 - X) ^ (m - i) := by
+  apply eq_of_infinite_eval_eq
+  refine (Set.Ioo_infinite (show (-1 : ℝ) < 1 by norm_num)).mono ?_
+  intro r hr
+  rw [Set.mem_Ioo] at hr
+  have hr' : |r| < 1 := abs_lt.mpr ⟨hr.1, hr.2⟩
+  have h1 : (1 : ℝ) - r ≠ 0 := by have := hr.2; linarith
+  -- Express every Eulerian eval through the corresponding infinite moment.
+  have hE : ∀ i, (eulerPoly i : ℝ[X]).eval r = infMoment i r * (1 - r) ^ (i + 1) := by
+    intro i
+    rw [infMoment_eq_eulerPoly i hr', div_mul_cancel₀ _ (pow_ne_zero _ h1)]
+  -- Pull the common power out of the binomial sum.
+  have hsum :
+      (∑ i ∈ range m, (m.choose i : ℝ) * (eulerPoly i : ℝ[X]).eval r * (1 - r) ^ (m - i))
+        = (1 - r) ^ (m + 1) * ∑ i ∈ range m, (m.choose i : ℝ) * infMoment i r := by
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro i hi
+    have hi' : i < m := Finset.mem_range.mp hi
+    rw [hE i, show m + 1 = (i + 1) + (m - i) from by omega, pow_add]
+    ring
+  -- Reduce to the parent's infinite recurrence (★∞).
+  have hrec := infMoment_recurrence m hr'
+  simp only [Set.mem_setOf_eq, eval_mul, eval_sub, eval_one, eval_X, eval_add, eval_pow,
+    eval_zero, eval_finset_sum, eval_natCast]
+  rw [hE m, hsum]
+  linear_combination (1 - r) ^ (m + 1) * hrec
+
+/-! ## Part 3: low-order closed forms -/
+
+/-- Recovering the infinite first moment from the closed form:
+`infMoment 1 x = x/(1 − x)²` (consistency with the parent's `infMoment_one`). -/
+theorem infMoment_one {x : ℝ} (hx : |x| < 1) :
+    infMoment 1 x = x / (1 - x) ^ 2 := by
+  rw [infMoment_eq_eulerPoly 1 hx, eulerPoly_one, eval_X]
+
+/-- Recovering the infinite second moment from the closed form:
+`infMoment 2 x = x(1 + x)/(1 − x)³` (consistency with the parent's `infMoment_two`). -/
+theorem infMoment_two {x : ℝ} (hx : |x| < 1) :
+    infMoment 2 x = (x + x ^ 2) / (1 - x) ^ 3 := by
+  rw [infMoment_eq_eulerPoly 2 hx, eulerPoly_two]
+  simp [eval_add, eval_pow, eval_X]
+
+/-- **The infinite third moment**, one order beyond the parent's `infMoment_two`:
+`∑_{k} k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴`, read off the Eulerian polynomial
+`E₃ = X + 4X² + X³`. -/
+theorem infMoment_three {x : ℝ} (hx : |x| < 1) :
+    infMoment 3 x = (x + 4 * x ^ 2 + x ^ 3) / (1 - x) ^ 4 := by
+  rw [infMoment_eq_eulerPoly 3 hx, eulerPoly_three]
+  simp [eval_add, eval_mul, eval_pow, eval_X]
+
+end GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+  "slug": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ08OQ01OQ01OQ01OQ02",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01"
+    ],
+    "opens": [
+      "Polynomial",
+      "Finset"
+    ],
+    "namespace": "GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01",
+    "lineCount": 145,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Solving the Infinite-Limit Recurrence (★∞) in Closed Form: infMoment m x = Eₘ(x)/(1 − x)^{m+1}",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "eulerian",
+      "eulerian-polynomial",
+      "frobenius",
+      "moments",
+      "infinite-series",
+      "recurrence",
+      "closed-form",
+      "tsum",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 145,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "infMoment_eq_eulerPoly: the headline closed-form solution of the infinite recurrence (★∞). For |x| < 1, the infinite m-th moment infMoment m x = ∑'_{k} kᵐ·xᵏ (parent geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02) equals the Eulerian-polynomial closed form Eₘ(x)/(1 − x)^{m+1}, where Eₘ = eulerPoly m is the gallery's Eulerian polynomial (geometric-series-oq-07-oq-01-oq-01). It identifies the tsum-defined object of the convolution-recurrence line with the Frobenius/Eulerian closed form of the sibling line, closing the loop the parent's open question posed.",
+      "eulerPoly_recurrence: a NEW polynomial identity in ℝ[X] showing the Eulerian polynomials themselves satisfy the (★∞) binomial-convolution recurrence: (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}. This is the algebraic shadow of (★∞) — clearing the denominators (1 − x)^{i+1} from the closed form turns the analytic convolution recurrence into one polynomial identity, linking the derivative-free Pascal recursion to the differential recurrence E_{m+1} = X(1−X)·E'ₘ + (m+1)·X·Eₘ that defines eulerPoly. Proved via Polynomial.eq_of_infinite_eval_eq: both sides agree at every r ∈ (−1,1) (an infinite set) by the closed form plus the parent's (★∞), hence agree identically. Not present in Mathlib.",
+      "infMoment_three: the explicit infinite THIRD moment ∑_{k} k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴, one order beyond the parent's infMoment_two, read directly off the Eulerian polynomial E₃ = X + 4X² + X³ via the headline closed form.",
+      "infMoment_one / infMoment_two: re-derivations of the infinite first and second moments x/(1 − x)² and (x + x²)/(1 − x)³ from the general closed form, confirming consistency with the parent's directly-solved low-order cases."
+    ],
+    "prerequisites": [
+      "GeometricSeriesOQ07OQ01OQ01.hasSum_pow_mul_geometric_eulerPoly — the analytic Eulerian closed form HasSum (kᵐ·rᵏ) (Eₘ(r)/(1 − r)^{m+1}), whose tsum_eq yields the headline identity",
+      "GeometricSeriesOQ08OQ01OQ01OQ01OQ02.infMoment_recurrence — the parent's infinite binomial-convolution recurrence (★∞), used to prove the polynomial identity by evaluation",
+      "Polynomial.eq_of_infinite_eval_eq — two polynomials over an integral domain agreeing on an infinite set of points are equal",
+      "Set.Ioo_infinite — the open interval (−1,1) is infinite, supplying the infinite agreement set",
+      "eulerPoly_one / eulerPoly_two / eulerPoly_three — low-order Eulerian polynomial values for the explicit moment formulas"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.eq_of_infinite_eval_eq",
+        "description": "If two polynomials over an integral domain have eval x p = eval x q for an infinite set of x, then p = q. Promotes the pointwise recurrence identity on (−1,1) to a polynomial identity in ℝ[X].",
+        "module": "Mathlib.Algebra.Polynomial.Roots"
+      },
+      {
+        "theorem": "Set.Ioo_infinite",
+        "description": "The open interval (a,b) with a < b is infinite. Supplies the infinite agreement set (−1,1) on which the two sides of eulerPoly_recurrence coincide.",
+        "module": "Mathlib.Order.Interval.Set.Infinite"
+      },
+      {
+        "theorem": "HasSum.tsum_eq",
+        "description": "A HasSum statement determines the tsum. Converts the imported analytic Eulerian closed form into the headline identity infMoment m x = Eₘ(x)/(1 − x)^{m+1}.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+      "question": "Prove eulerPoly_recurrence purely algebraically, by induction on m from the differential recurrence E_{m+1} = X(1−X)·E'ₘ + (m+1)·X·Eₘ and Pascal's rule, without passing through the analytic moment formula. This would give an analysis-free derivation of the Eulerian closed form directly from (★∞), as the parent's open question originally envisioned.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent. The parent defines infMoment m x = ∑'_{k} kᵐ·xᵏ and proves the infinite binomial-convolution recurrence (★∞), solving it only at m = 0,1,2. This entry solves it in closed form for all m and proves the Eulerian polynomials satisfy (★∞) as a polynomial identity."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01",
+      "relationship": "uses",
+      "description": "Supplies the Eulerian polynomial eulerPoly (differential recurrence) and the analytic Frobenius closed form hasSum_pow_mul_geometric_eulerPoly, whose tsum_eq gives the headline identity. The new polynomial recurrence eulerPoly_recurrence is the binomial-convolution counterpart of that file's differential recurrence."
+    },
+    {
+      "targetId": "geometric-series-oq-08-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Ancestor (m = 2). Its second moment x(1 + x)/(1 − x)³ reappears here as infMoment_two from the general closed form; infMoment_three then continues the family one order further to ∑ k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers, ∑ kᵐ·xᵏ rational closed forms, Worpitzky's identity)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian polynomials, the moment sums ∑ kᵐ·xᵏ = Aₘ(x)/(1 − x)^{m+1}, and the recurrences relating them."
+    },
+    {
+      "title": "Mathlib4: Algebra.Polynomial.Roots (eq_of_infinite_eval_eq) and Order.Interval.Set.Infinite (Ioo_infinite)",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Provide the polynomial extensionality-on-infinite-sets lemma and the infinitude of open intervals, used to promote the pointwise recurrence to a polynomial identity."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For a real ratio x with |x| < 1, the infinite m-th moment infMoment m x = ∑'_{k} kᵐ·xᵏ — characterised in the parent by the binomial-convolution recurrence (★∞) — is solved in closed form: infMoment m x = Eₘ(x)/(1 − x)^{m+1}, with Eₘ the gallery's Eulerian polynomial. This identifies the tsum-defined recurrence object with the Frobenius/Eulerian closed form of the sibling line. The recurrence (★∞) is then shown to hold for the Eulerian polynomials themselves as a polynomial identity over ℝ[X], (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}, proved by evaluating both sides on the infinite set (−1,1). Specialising the closed form recovers the first and second moments and yields the new explicit third moment ∑ k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴. 145 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries; every result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The entry closes the loop between the gallery's two complementary descriptions of the infinite geometric moments: the derivative-free binomial-convolution recurrence (★∞) and the differential Eulerian-polynomial recurrence. The new polynomial identity eulerPoly_recurrence records, in Mathlib-free form, that the Eulerian polynomials satisfy the Pascal-weighted convolution recursion — a relation absent from Mathlib. Honest scope: the headline closed form reuses the gallery's analytic Frobenius identity rather than re-deriving it by strong induction on (★∞); the genuinely new content is the polynomial recurrence identity and the explicit third-moment closed form.",
+    "openQuestions": [
+      "Prove eulerPoly_recurrence purely algebraically by induction on m from the differential recurrence and Pascal's rule, giving an analysis-free derivation of the Eulerian closed form directly from (★∞)."
+    ]
+  }
+}

--- a/src/data/research/problems/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -1,0 +1,27 @@
+{
+  "id": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+  "name": "Solve (★∞) in closed form: infMoment m x = eulerPoly m x / (1−x)^{m+1}",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "knowledge": {
+    "progressSummary": "COMPLETE: 0-axiom verified, 145L 5thm, shipped as geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01. Headline closed form + NEW polynomial recurrence identity + explicit 3rd moment.",
+    "builtItems": [
+      "infMoment_eq_eulerPoly: headline closed form infMoment m x = (eulerPoly m).eval x/(1-x)^{m+1} via (hasSum_pow_mul_geometric_eulerPoly m hx).tsum_eq (GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01.lean)",
+      "eulerPoly_recurrence: NEW polynomial identity in ℝ[X] — Eulerian polys satisfy (★∞): (1-X)Eₘ = 0ᵐ(1-X)^{m+1} + X∑_{i<m}C(m,i)Eᵢ(1-X)^{m-i}; proved via Polynomial.eq_of_infinite_eval_eq on (-1,1)",
+      "infMoment_three: new explicit 3rd moment ∑k³xᵏ = (x+4x²+x³)/(1-x)⁴ from eulerPoly_three",
+      "infMoment_one / infMoment_two: consistency re-derivations from general closed form"
+    ],
+    "insights": [
+      "The closed form is one line: HasSum.tsum_eq on the imported analytic Eulerian identity (OQ07OQ01OQ01.hasSum_pow_mul_geometric_eulerPoly). The real content is the polynomial recurrence bridge.",
+      "eq_of_infinite_eval_eq + Set.Ioo_infinite promotes a pointwise identity on (-1,1) to a ℝ[X] polynomial identity — clean way to turn an analytic recurrence into an algebraic one without algebraic induction.",
+      "Power-combining in the binomial sum: (1-r)^{i+1}*(1-r)^{m-i} = (1-r)^{m+1} since (i+1)+(m-i)=m+1 for i<m (rw [show m+1=(i+1)+(m-i) from by omega, pow_add]; ring).",
+      "linear_combination (1-r)^{m+1} * hrec closes the final eval goal once both sides are expressed via infMoment and the parent (★∞) hrec."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks any recurrence linking Eulerian polynomials to the binomial-convolution (Pascal-weighted) recursion; eulerPoly_recurrence fills this for the geometric normalisation."
+    ],
+    "nextSteps": [
+      "Prove eulerPoly_recurrence purely algebraically by induction on m from the differential recurrence E_{m+1}=X(1-X)E'ₘ+(m+1)XEₘ and Pascal's rule, giving an analysis-free derivation of the closed form directly from (★∞) (recorded as child open question -oq-01)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Closes the open question on `geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02`: **solve the infinite binomial-convolution recurrence (★∞) in closed form and recover the Eulerian-polynomial numerator.**

The parent defines `infMoment m x = ∑'_{k} kᵐ·xᵏ` (|x| < 1) and proves
`(1 − x)·infMoment m x = 0ᵐ + x·∑_{i<m} C(m,i)·infMoment i x`  (★∞), solving it only at m = 0,1,2.

## What's new (`GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01.lean`, 145L, 5 thm)

- **`infMoment_eq_eulerPoly`** — the headline closed form `infMoment m x = (eulerPoly m).eval x / (1 − x)^{m+1}`, identifying the parent's tsum object with the sibling line's Frobenius/Eulerian closed form (`geometric-series-oq-07-oq-01-oq-01`).
- **`eulerPoly_recurrence`** — a *new* polynomial identity in `ℝ[X]` showing the Eulerian polynomials satisfy (★∞):
  `(1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}`.
  Proved via `Polynomial.eq_of_infinite_eval_eq`: both sides agree on the infinite set (−1,1). Not in Mathlib.
- **`infMoment_three`** — the new explicit third moment `∑ k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴`, one order past the parent.
- `infMoment_one` / `infMoment_two` — consistency re-derivations from the general formula.

## Honesty

The headline closed form **reuses** the gallery's analytic Frobenius identity (`hasSum_pow_mul_geometric_eulerPoly`) rather than re-deriving it by strong induction on (★∞). The genuinely new content is the polynomial recurrence identity `eulerPoly_recurrence` and the explicit third moment. A purely algebraic induction proof of the recurrence is recorded as a child open question.

## Verification

- Builds via `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01` ✓
- `#print axioms` on all 5 theorems: `propext, Classical.choice, Quot.sound` only — **0-axiom, no sorry, no native_decide**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)