### PR TITLE
research(minkowski-fundamental-theorem-oq-01): successive-minima infrastructure for the second theorem [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2987,6 +2987,7 @@ import Proofs.MenelausTheorem
 import Proofs.MenelausTheoremOQ01
 import Proofs.MidyTheorem
 import Proofs.MinkowskiFundamentalTheorem
+import Proofs.MinkowskiFundamentalTheoremOQ01
 import Proofs.MinkowskiFundamentalTheoremOQ02
 import Proofs.MinkowskiFundamentalTheoremOQ04
 import Proofs.MinkowskiTheoremOQ02

--- a/proofs/Proofs/MinkowskiFundamentalTheoremOQ01.lean
+++ b/proofs/Proofs/MinkowskiFundamentalTheoremOQ01.lean
@@ -1,0 +1,208 @@
+/-
+  Successive Minima and Minkowski's Second Theorem — Infrastructure
+  (minkowski-fundamental-theorem-oq-01)
+
+  Open Question (from minkowski-fundamental-theorem, OQ #1):
+  "Can Minkowski's second theorem (on successive minima) be formalized with the
+  same infrastructure?"
+
+  Minkowski's second theorem refines the fundamental (first) theorem.  For a
+  lattice `L` and a symmetric convex body `S`, the i-th successive minimum is
+
+      λᵢ = inf { c > 0 : cS contains i linearly independent lattice points }.
+
+  The second theorem then bounds the product:
+
+      (2ⁿ / n!) · covolume(L) ≤ λ₁ λ₂ ⋯ λₙ · vol(S) ≤ 2ⁿ · covolume(L).
+
+  This file builds the infrastructure on top of the parent's custom Lattice /
+  ConvexBody API and proves the tractable structural facts (0 sorries, 0 axioms):
+
+  * `ConvexBody.scale` — scaling a symmetric convex body by a real factor stays a
+    symmetric convex body.
+  * `IndepLatticePoints` — the "`k` linearly independent lattice points in a set"
+    predicate, and its antitonicity in `k`.
+  * `successiveMinimum` — the i-th successive minimum, with positivity and
+    monotonicity (λ₀ ≤ λ₁ ≤ ⋯).
+  * `secondTheorem_upper_statement` — the precise statement of the upper bound.
+  * `firstMinimum_le_one_of_volume_gt` — the first successive minimum is ≤ 1
+    once `vol(S) > 2ⁿ covolume(L)`, derived directly from the parent's
+    `minkowski_fundamental` (the first theorem, in successive-minima language).
+
+  HONEST SCOPE: the deep analytic content — the product bound itself — is NOT
+  proved here; it is stated as a scaffold and left as the open core.  What is
+  delivered is the definitional framework plus the order structure and the
+  first-minimum specialization of the first theorem.
+
+  References:
+  - Minkowski, Geometrie der Zahlen (1896)
+  - Cassells, An Introduction to the Geometry of Numbers (1959), Ch. VIII
+-/
+import Mathlib
+import Proofs.MinkowskiFundamentalTheorem
+
+set_option maxHeartbeats 800000
+set_option linter.unusedVariables false
+set_option linter.unusedSectionVars false
+
+namespace MinkowskiSecondTheorem
+
+open MinkowskiFundamentalTheorem Set
+open scoped Pointwise
+
+variable (n : ℕ) [NeZero n]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I: SCALING A CONVEX BODY
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Scaling a symmetric convex body by a real factor `c` is again a symmetric
+    convex body (`c • S`).  Convexity and central symmetry are preserved for
+    every `c`; non-emptiness too. -/
+def ConvexBody.scale (c : ℝ) (S : ConvexBody n) : ConvexBody n where
+  carrier := c • S.carrier
+  convex := S.convex.smul c
+  symmetric := by
+    intro x hx
+    rw [Set.mem_smul_set] at hx ⊢
+    obtain ⟨y, hy, rfl⟩ := hx
+    exact ⟨-y, S.symmetric y hy, by rw [smul_neg]⟩
+  nonempty := S.nonempty.smul_set
+
+@[simp] theorem ConvexBody.scale_carrier (c : ℝ) (S : ConvexBody n) :
+    (ConvexBody.scale n c S).carrier = c • S.carrier := rfl
+
+/-- Scaling by `1` is the identity on the carrier. -/
+theorem ConvexBody.scale_one (S : ConvexBody n) :
+    (ConvexBody.scale n 1 S).carrier = S.carrier := by
+  simp [ConvexBody.scale_carrier, one_smul]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II: INDEPENDENT LATTICE POINTS IN A SET
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- `IndepLatticePoints L k T` holds when `T` contains `k` linearly independent
+    points of the lattice `L`. -/
+def IndepLatticePoints (L : Lattice n) (k : ℕ) (T : Set (EuclideanN n)) : Prop :=
+  ∃ v : Fin k → EuclideanN n,
+    LinearIndependent ℝ v ∧ ∀ i, v i ∈ T ∧ v i ∈ latticePoints n L
+
+/-- Containing `m` independent lattice points implies containing `k` of them
+    for any `k ≤ m` (drop the surplus coordinates). -/
+theorem IndepLatticePoints.mono {L : Lattice n} {k m : ℕ} {T : Set (EuclideanN n)}
+    (hkm : k ≤ m) (h : IndepLatticePoints n L m T) : IndepLatticePoints n L k T := by
+  obtain ⟨v, hli, hmem⟩ := h
+  exact ⟨v ∘ Fin.castLE hkm, hli.comp _ (Fin.castLE_injective hkm),
+    fun i => hmem (Fin.castLE hkm i)⟩
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III: THE SUCCESSIVE MINIMA
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The set of admissible scalings for the i-th successive minimum:
+    factors `c > 0` such that `cS` contains `i+1` linearly independent
+    lattice points. -/
+def admissibleScalings (L : Lattice n) (S : ConvexBody n) (i : Fin n) : Set ℝ :=
+  {c : ℝ | 0 < c ∧ IndepLatticePoints n L (i.val + 1) (ConvexBody.scale n c S).carrier}
+
+/-- The i-th successive minimum `λᵢ`. -/
+noncomputable def successiveMinimum (L : Lattice n) (S : ConvexBody n) (i : Fin n) : ℝ :=
+  sInf (admissibleScalings n L S i)
+
+/-- `0` is a lower bound for every set of admissible scalings. -/
+theorem admissibleScalings_bddBelow (L : Lattice n) (S : ConvexBody n) (i : Fin n) :
+    BddBelow (admissibleScalings n L S i) :=
+  ⟨0, fun c hc => le_of_lt hc.1⟩
+
+/-- Successive minima are non-negative. -/
+theorem successiveMinimum_nonneg (L : Lattice n) (S : ConvexBody n) (i : Fin n) :
+    0 ≤ successiveMinimum n L S i :=
+  Real.sInf_nonneg (fun c hc => le_of_lt hc.1)
+
+/-- A larger index has a smaller (or equal) admissible-scaling set: if `cS`
+    contains `j+1` independent lattice points then it contains `i+1` for `i ≤ j`. -/
+theorem admissibleScalings_subset (L : Lattice n) (S : ConvexBody n) {i j : Fin n}
+    (hij : i ≤ j) : admissibleScalings n L S j ⊆ admissibleScalings n L S i := by
+  intro c hc
+  exact ⟨hc.1, hc.2.mono _ (Nat.succ_le_succ (Fin.val_fin_le.mpr hij))⟩
+
+/-- The successive minima are monotone: `λᵢ ≤ λⱼ` for `i ≤ j`, provided the
+    higher minimum is actually attained (its admissible set is non-empty). -/
+theorem successiveMinimum_mono (L : Lattice n) (S : ConvexBody n) {i j : Fin n}
+    (hij : i ≤ j) (hne : (admissibleScalings n L S j).Nonempty) :
+    successiveMinimum n L S i ≤ successiveMinimum n L S j :=
+  csInf_le_csInf (admissibleScalings_bddBelow n L S i) hne
+    (admissibleScalings_subset n L S hij)
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV: MINKOWSKI'S SECOND THEOREM (statement) AND THE FIRST-MINIMUM BOUND
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The upper bound of Minkowski's second theorem, stated precisely:
+    `λ₁ ⋯ λₙ · vol(S) ≤ 2ⁿ · covolume(L)`.  Stated as a scaffold; the proof is
+    the open analytic core (it requires the simultaneous reduction of the body
+    along a basis realizing the successive minima). -/
+def secondTheorem_upper_statement (L : Lattice n) (S : ConvexBody n) [hv : HasVolume n S] : Prop :=
+  (∏ i : Fin n, successiveMinimum n L S i) * hv.volume ≤ (2 : ℝ) ^ n * L.covolume
+
+/-- **The first theorem in successive-minima language.**  When
+    `vol(S) > 2ⁿ covolume(L)`, the body `S` already contains a non-zero lattice
+    point, so a single independent lattice point lives in `1 · S`; hence the
+    first successive minimum `λ₀` is at most `1`.  This is the `i = 0` shadow of
+    Minkowski's second theorem, derived directly from `minkowski_fundamental`. -/
+theorem firstMinimum_le_one_of_volume_gt (L : Lattice n) (S : ConvexBody n)
+    [hv : HasVolume n S] (h_vol : hv.volume > criticalVolume n L) :
+    successiveMinimum n L S ⟨0, Nat.pos_of_ne_zero (NeZero.ne n)⟩ ≤ 1 := by
+  obtain ⟨x, hxS, hxL, hx0⟩ := minkowski_fundamental n L S h_vol
+  -- `1` is an admissible scaling for the first minimum.
+  have hmem : (1 : ℝ) ∈ admissibleScalings n L S ⟨0, Nat.pos_of_ne_zero (NeZero.ne n)⟩ := by
+    refine ⟨one_pos, ?_⟩
+    refine ⟨fun _ => x, ?_, ?_⟩
+    · -- a single non-zero vector is linearly independent
+      haveI : Unique (Fin ((⟨0, Nat.pos_of_ne_zero (NeZero.ne n)⟩ : Fin n).val + 1)) :=
+        (inferInstance : Unique (Fin 1))
+      rw [linearIndependent_unique_iff]
+      simpa using hx0
+    · intro i
+      rw [ConvexBody.scale_carrier, one_smul]
+      exact ⟨hxS, hxL⟩
+  exact csInf_le (admissibleScalings_bddBelow n L S _) hmem
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+Summary
+═══════════════════════════════════════════════════════════════════════════════
+
+## Successive minima infrastructure for Minkowski's second theorem
+   (answering OQ-01 of minkowski-fundamental-theorem)
+
+### What's proved (0 sorries, 0 axioms):
+- `ConvexBody.scale`: scaling preserves symmetric-convex-body structure.
+- `IndepLatticePoints` + `.mono`: the "k independent lattice points" predicate
+  and its antitonicity in k.
+- `successiveMinimum`: the i-th successive minimum λᵢ = inf of admissible
+  scalings, with `successiveMinimum_nonneg` (positivity) and
+  `successiveMinimum_mono` (λᵢ ≤ λⱼ for i ≤ j, when the higher minimum is attained).
+- `firstMinimum_le_one_of_volume_gt`: λ₀ ≤ 1 under the first-theorem hypothesis,
+  derived from the parent's `minkowski_fundamental`.
+
+### Honest scope:
+This is INFRASTRUCTURE + the first-minimum specialization, not the full second
+theorem.  The product bound `secondTheorem_upper_statement` is stated as a
+scaffold; its proof (and the matching lower bound) is the open analytic core,
+requiring a basis realizing the successive minima and a simultaneous reduction
+argument — left as the next step.
+-/
+
+#check @ConvexBody.scale
+#check @IndepLatticePoints
+#check @successiveMinimum
+#check @successiveMinimum_mono
+#check @firstMinimum_le_one_of_volume_gt
+#check @secondTheorem_upper_statement
+
+end MinkowskiSecondTheorem

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-01/annotations.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-01/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-mft-oq01-scope",
+    "proofId": "minkowski-fundamental-theorem-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
+    "type": "insight",
+    "title": "Infrastructure for the Second Theorem — Honest Scope",
+    "content": "The header states OQ-01 of the parent: can Minkowski's *second* theorem (on successive minima) be formalized with the same infrastructure? This file answers the infrastructure half affirmatively, building the successive-minima framework entirely on the parent's custom `Lattice` / `ConvexBody` / `HasVolume` API. Crucially, it is honest about scope: the order structure (λ₀ ≤ λ₁ ≤ ⋯), positivity, and the first-minimum bound λ₀ ≤ 1 are fully proved (0 axioms, 0 sorries), while the deep product bound λ₁⋯λₙ·vol(S) ≤ 2ⁿ·covolume(L) is stated as a Prop scaffold and left as the open analytic core — not hidden behind a sorry.",
+    "mathContext": "λᵢ = inf { c > 0 : cS contains i linearly independent lattice points }; the second theorem bounds (2ⁿ/n!)·covol(L) ≤ λ₁⋯λₙ·vol(S) ≤ 2ⁿ·covol(L).",
+    "significance": "key",
+    "relatedConcepts": [
+      "successive minima",
+      "geometry of numbers",
+      "Minkowski's second theorem",
+      "convex body"
+    ],
+    "prerequisites": [
+      "minkowski-fundamental-theorem",
+      "lattices",
+      "centrally symmetric convex bodies"
+    ]
+  },
+  {
+    "id": "ann-mft-oq01-scale",
+    "proofId": "minkowski-fundamental-theorem-oq-01",
+    "range": {
+      "startLine": 53,
+      "endLine": 78
+    },
+    "type": "concept",
+    "title": "Scaling Preserves the Convex-Body Structure",
+    "content": "`ConvexBody.scale c S` packages the dilation c • S back into the parent's `ConvexBody` structure. Convexity transfers via `Convex.smul`, central symmetry by pushing the negation through the pointwise action (`smul_neg`), and nonemptiness by `Set.Nonempty.smul_set`. The pointwise scalar multiplication c • (S.carrier) on a `Set (Fin n → ℝ)` requires the `Pointwise` scoped instances to be open — a small but essential engineering point. The scaled body cS is the object whose lattice content defines the successive minima.",
+    "mathContext": "For c > 0, cS is convex, centrally symmetric, and nonempty whenever S is; scaling is the operation the successive minima quantify over.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pointwise scalar multiplication",
+      "convexity",
+      "central symmetry"
+    ],
+    "prerequisites": [
+      "Pointwise set operations",
+      "Convex.smul"
+    ]
+  },
+  {
+    "id": "ann-mft-oq01-minima",
+    "proofId": "minkowski-fundamental-theorem-oq-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 137
+    },
+    "type": "insight",
+    "title": "Monotonicity of the Successive Minima is Order-Theoretic",
+    "content": "The i-th successive minimum is `sInf` of the admissible-scaling set {c > 0 : c•S contains i+1 independent lattice points}. The chain λ₀ ≤ λ₁ ≤ ⋯ requires no analysis: a larger index demands *more* independent lattice points, so the admissible sets are nested downward (`admissibleScalings_subset`, via `IndepLatticePoints.mono`). Since `csInf` is antitone in the set, the infima increase with the index. Boundedness below by 0 simultaneously yields nonnegativity (`Real.sInf_nonneg`). The only hypothesis needed for monotonicity is that the higher minimum is actually attained (its admissible set is nonempty).",
+    "mathContext": "i ≤ j ⟹ admissibleScalings j ⊆ admissibleScalings i ⟹ sInf(admissibleScalings i) ≤ sInf(admissibleScalings j), i.e. λᵢ ≤ λⱼ.",
+    "significance": "key",
+    "relatedConcepts": [
+      "infimum",
+      "antitone",
+      "linear independence",
+      "csInf_le_csInf"
+    ],
+    "prerequisites": [
+      "sInf / csInf on reals",
+      "linear independence of finite families"
+    ]
+  },
+  {
+    "id": "ann-mft-oq01-firstmin",
+    "proofId": "minkowski-fundamental-theorem-oq-01",
+    "range": {
+      "startLine": 150,
+      "endLine": 169
+    },
+    "type": "insight",
+    "title": "The First Theorem is the i = 0 Case of the Second",
+    "content": "`firstMinimum_le_one_of_volume_gt` derives λ₀ ≤ 1 directly from the parent's verified `minkowski_fundamental`: when vol(S) exceeds the critical volume 2ⁿ·covolume(L), the first theorem produces a nonzero lattice point x ∈ S. A single nonzero vector is linearly independent (needing the `Unique (Fin (0+1))` instance supplied explicitly), so 1 is an admissible scaling for the first minimum, whence λ₀ = sInf(...) ≤ 1. This exhibits the second theorem's upper bound as a genuine generalization of the first — the product bound restricted to a single factor.",
+    "mathContext": "vol(S) > 2ⁿ·covol(L) ⟹ ∃ 0 ≠ x ∈ S ∩ L ⟹ 1 ∈ admissibleScalings(0) ⟹ λ₀ ≤ 1.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Minkowski's first theorem",
+      "successive minima",
+      "linear independence of a single vector"
+    ],
+    "prerequisites": [
+      "minkowski_fundamental",
+      "csInf_le"
+    ]
+  }
+]

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-01/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-01/meta.json
@@ -1,0 +1,205 @@
+{
+  "id": "minkowski-fundamental-theorem-oq-01",
+  "title": "Successive Minima — Infrastructure for Minkowski's Second Theorem",
+  "slug": "minkowski-fundamental-theorem-oq-01",
+  "description": "Answers OQ-01 of minkowski-fundamental-theorem ('Can Minkowski's second theorem on successive minima be formalized with the same infrastructure?') by building the successive-minima framework directly on the parent's custom Lattice / ConvexBody API: scaling of symmetric convex bodies, the 'k independent lattice points in a set' predicate, the i-th successive minimum λᵢ with positivity and monotonicity (λ₀ ≤ λ₁ ≤ ⋯), the precise statement of the second-theorem upper bound, and the first-minimum specialization λ₀ ≤ 1 derived from the parent's first theorem. The deep product bound itself is stated as a scaffold and left as the open analytic core.",
+  "meta": {
+    "author": "Hermann Minkowski (1896); Lean 4 formalization (research, 2026)",
+    "date": "1896",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MinkowskiFundamentalTheoremOQ01.lean",
+    "tags": [
+      "number-theory",
+      "geometry-of-numbers",
+      "minkowski-theorem",
+      "successive-minima",
+      "lattices",
+      "convex-bodies"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 208,
+    "assumptions": "0 axioms, 0 sorries. Built on the parent file's custom Lattice / ConvexBody / HasVolume API (Proofs.MinkowskiFundamentalTheorem). The first-minimum bound is derived from the parent's verified `minkowski_fundamental` (first theorem). HONEST SCOPE: this is the definitional framework plus the order structure of the successive minima and the first-minimum specialization — NOT the full second theorem. The product bound λ₁⋯λₙ·vol(S) ≤ 2ⁿ·covolume(L) is stated as a Prop scaffold (`secondTheorem_upper_statement`) and is not proved here; its proof is the open analytic core.",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-21",
+    "theoremCount": 8,
+    "definitionCount": 5
+  },
+  "overview": {
+    "historicalContext": "Minkowski's *first* (fundamental) theorem states that a centrally symmetric convex body of volume greater than 2ⁿ·covolume(L) must contain a nonzero lattice point. In his 1896 *Geometrie der Zahlen* Minkowski went further and introduced the **successive minima** λ₁ ≤ λ₂ ≤ ⋯ ≤ λₙ of a symmetric convex body S with respect to a lattice L: λᵢ is the least scaling factor c such that cS contains i linearly independent lattice points. His *second* theorem sharpens the first by bounding the full product of the successive minima:\n\n    (2ⁿ / n!) · covolume(L) ≤ λ₁ λ₂ ⋯ λₙ · vol(S) ≤ 2ⁿ · covolume(L).\n\nThe upper bound generalizes the first theorem (which is essentially the λ₁ statement), while the lower bound is an independent and more delicate result. The second theorem is a cornerstone of the geometry of numbers, underlying transference theorems, reduction theory, and modern lattice-based cryptanalysis.",
+    "problemStatement": "**Open Question (minkowski-fundamental-theorem, OQ #1):** *Can Minkowski's second theorem (on successive minima) be formalized with the same infrastructure?*\n\nThis entry answers the **infrastructure** half affirmatively: the parent's custom `Lattice` / `ConvexBody` / `HasVolume` API is rich enough to define the successive minima and to derive their basic order structure and the first-minimum specialization of the first theorem. The deep analytic content of the second theorem — the product bound itself — is stated precisely as a scaffold but is left open.",
+    "text": "Working entirely on top of the parent file's bespoke geometry-of-numbers API, this file defines scaling of a symmetric convex body, the predicate `IndepLatticePoints L k T` ('T contains k linearly independent lattice points'), the admissible-scaling sets, and the i-th successive minimum `successiveMinimum L S i = sInf {c > 0 : cS contains i+1 independent lattice points}`. It then proves the monotonicity λ₀ ≤ λ₁ ≤ ⋯ (when the higher minimum is attained), positivity, and — as the `i = 0` shadow of the second theorem — that λ₀ ≤ 1 once vol(S) exceeds the critical volume, by feeding a nonzero lattice point from the parent's `minkowski_fundamental` into the admissible set for the first minimum.",
+    "proofStrategy": "1. **Scaling** (`ConvexBody.scale`): `c • S.carrier` is again convex (`Convex.smul`), centrally symmetric (push the negation through the pointwise scaling), and nonempty; this packages the scaled body cS into the parent's `ConvexBody` structure.\n\n2. **Independent lattice points** (`IndepLatticePoints`): existence of a linearly independent family `v : Fin k → ℝⁿ` lying in both the set and the lattice. Antitonicity in k (`.mono`) drops surplus coordinates via `Fin.castLE`.\n\n3. **Successive minima** (`successiveMinimum`): `sInf` of the admissible-scaling set `{c > 0 : c•S contains i+1 independent lattice points}`. The set is bounded below by 0, giving nonnegativity (`Real.sInf_nonneg`); a higher index has a smaller admissible set (`admissibleScalings_subset` via `IndepLatticePoints.mono`), giving monotonicity through `csInf_le_csInf` once the higher set is nonempty.\n\n4. **First-minimum bound** (`firstMinimum_le_one_of_volume_gt`): when vol(S) > 2ⁿ·covolume(L), the parent's `minkowski_fundamental` yields a nonzero x ∈ S ∩ L. A single nonzero vector is linearly independent, so 1 is an admissible scaling for λ₀; hence λ₀ = sInf(...) ≤ 1.\n\n5. **Second theorem upper bound** (`secondTheorem_upper_statement`): stated as a `Prop` scaffold `(∏ i, λᵢ) · vol(S) ≤ 2ⁿ · covolume(L)`; its proof requires a basis realizing the successive minima and a simultaneous reduction argument, and is left as the open core.",
+    "keyInsights": [
+      "The parent's custom `ConvexBody` / `Lattice` API is expressive enough to carry the entire successive-minima definitional layer — scaling, independent-lattice-point predicate, and the sInf-based minima — without leaving its abstraction.",
+      "Monotonicity of the successive minima is purely order-theoretic: a larger index demands more independent points, shrinking the admissible-scaling set, so its infimum can only grow (`csInf` is antitone in the set).",
+      "Minkowski's first theorem is exactly the i=0 case of the second: a nonzero lattice point in S is a single independent point in 1·S, so λ₀ ≤ 1 follows immediately from `minkowski_fundamental`.",
+      "Pointwise scalar multiplication on sets (`c • S.carrier`) requires the `Pointwise` scoped instances, and the single-vector linear-independence step needs the `Unique (Fin (0+1))` instance supplied explicitly — small but essential Lean-engineering details.",
+      "The genuine difficulty of the second theorem is concentrated entirely in the product bound, which is isolated here as a precise Prop scaffold rather than hidden behind a sorry."
+    ],
+    "prerequisites": [
+      "Minkowski's fundamental (first) theorem — see minkowski-fundamental-theorem in the gallery",
+      "Lattices and covolumes in ℝⁿ",
+      "Centrally symmetric convex bodies",
+      "Infima of sets of reals (sInf, csInf) and linear independence of finite families"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: Imports and Setup",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Imports Mathlib and the parent Proofs.MinkowskiFundamentalTheorem; opens the parent namespace, Set, and the Pointwise scoped instances. Header documents the second theorem and the honest scope.",
+      "mathContext": "The file reuses the parent's `Lattice`, `ConvexBody`, `HasVolume`, `criticalVolume`, `latticePoints`, and `minkowski_fundamental`, so the entire successive-minima layer stays inside the parent's abstraction."
+    },
+    {
+      "id": "scaling",
+      "title": "Part I: Scaling a Convex Body",
+      "startLine": 53,
+      "endLine": 78,
+      "summary": "ConvexBody.scale (c • S as a ConvexBody), scale_carrier (@[simp]), and scale_one.",
+      "mathContext": "Scaling by c > 0 dilates the body; convexity, central symmetry, and nonemptiness are all preserved under the pointwise action c • (·). The scaled body cS is the object whose lattice content defines the successive minima."
+    },
+    {
+      "id": "indep-lattice-points",
+      "title": "Part II: Independent Lattice Points in a Set",
+      "startLine": 79,
+      "endLine": 97,
+      "summary": "IndepLatticePoints L k T predicate and its antitonicity IndepLatticePoints.mono in k.",
+      "mathContext": "λᵢ counts how much the body must be scaled to capture i linearly independent lattice points; the predicate and its monotonicity in k are the combinatorial backbone of the definition."
+    },
+    {
+      "id": "successive-minima",
+      "title": "Part III: The Successive Minima",
+      "startLine": 98,
+      "endLine": 137,
+      "summary": "admissibleScalings, successiveMinimum (= sInf), admissibleScalings_bddBelow, successiveMinimum_nonneg, admissibleScalings_subset, and successiveMinimum_mono (λᵢ ≤ λⱼ for i ≤ j).",
+      "mathContext": "The i-th successive minimum is the infimum of admissible scalings. Boundedness below by 0 gives nonnegativity; the admissible sets are nested (more points ⟹ fewer scalings), so the infima are monotone in the index — exactly the chain λ₀ ≤ λ₁ ≤ ⋯ ≤ λₙ₋₁."
+    },
+    {
+      "id": "second-theorem-and-first-minimum",
+      "title": "Part IV: Second Theorem Statement and the First-Minimum Bound",
+      "startLine": 138,
+      "endLine": 169,
+      "summary": "secondTheorem_upper_statement (Prop scaffold for the product bound) and firstMinimum_le_one_of_volume_gt (λ₀ ≤ 1 from minkowski_fundamental).",
+      "mathContext": "The upper bound of the second theorem is stated precisely as a Prop but not proved (the open analytic core). The first-minimum bound λ₀ ≤ 1 is the i=0 shadow of the theorem and follows directly from the parent's first theorem: a nonzero lattice point in S witnesses that 1 is an admissible scaling."
+    }
+  ],
+  "conclusion": {
+    "summary": "The successive-minima framework for Minkowski's second theorem is fully constructible on the parent's custom geometry-of-numbers API, with the order structure (λ₀ ≤ λ₁ ≤ ⋯), positivity, and the first-minimum specialization λ₀ ≤ 1 all proved with 0 axioms and 0 sorries. The product bound of the second theorem is isolated as a precise Prop scaffold and remains the open analytic core.",
+    "implications": "This confirms that OQ-01's infrastructure question has a positive answer at the definitional and order-theoretic level: no new foundational machinery is needed to state and reason about successive minima beyond the parent's Lattice/ConvexBody API. The remaining work — the product bound and its matching lower bound — is purely the analytic reduction-of-bases argument, now cleanly separated from the framework.",
+    "openQuestions": [
+      "Prove the upper bound `secondTheorem_upper_statement`: (∏ λᵢ)·vol(S) ≤ 2ⁿ·covolume(L), via a basis realizing the successive minima and a simultaneous reduction argument.",
+      "State and prove the matching lower bound (2ⁿ/n!)·covolume(L) ≤ (∏ λᵢ)·vol(S).",
+      "Establish existence/attainment of each λᵢ (admissibleScalings nonempty) so that the monotonicity hypothesis `hne` can be discharged unconditionally."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "minkowski-fundamental-theorem",
+      "relationship": "extends",
+      "description": "Parent: Minkowski's fundamental (first) theorem. This entry reuses its Lattice / ConvexBody / HasVolume API and derives the first-minimum bound directly from its `minkowski_fundamental`."
+    },
+    {
+      "targetId": "minkowski-fundamental-theorem-oq-02",
+      "relationship": "related",
+      "description": "Sibling OQ-02: the Minkowski class number bound — another extension of the fundamental theorem, via the canonical embedding of number fields."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.MinkowskiFundamentalTheorem"
+    ],
+    "opens": [
+      "MinkowskiFundamentalTheorem",
+      "Set",
+      "Pointwise"
+    ],
+    "namespace": "MinkowskiSecondTheorem",
+    "lineCount": 208,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 5,
+    "mainTheorems": [
+      {
+        "name": "firstMinimum_le_one_of_volume_gt",
+        "type": "core",
+        "description": "The first successive minimum satisfies λ₀ ≤ 1 once vol(S) > 2ⁿ·covolume(L) — the i=0 shadow of the second theorem, derived from the parent's first theorem.",
+        "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → [hv : HasVolume n S] → hv.volume > criticalVolume n L → successiveMinimum n L S ⟨0, _⟩ ≤ 1"
+      },
+      {
+        "name": "successiveMinimum_mono",
+        "type": "key",
+        "description": "The successive minima are monotone: λᵢ ≤ λⱼ for i ≤ j (when the higher minimum's admissible set is nonempty).",
+        "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → {i j : Fin n} → i ≤ j → (admissibleScalings n L S j).Nonempty → successiveMinimum n L S i ≤ successiveMinimum n L S j"
+      },
+      {
+        "name": "secondTheorem_upper_statement",
+        "type": "supporting",
+        "description": "The precise Prop statement of the second theorem's upper bound (∏ λᵢ)·vol(S) ≤ 2ⁿ·covolume(L) — a scaffold, left as the open analytic core.",
+        "leanType": "(n : ℕ) → (L : Lattice n) → (S : ConvexBody n) → [HasVolume n S] → Prop"
+      }
+    ],
+    "path": "Proofs/MinkowskiFundamentalTheoremOQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "firstMinimum_le_one_of_volume_gt",
+      "type": "core",
+      "description": "The first successive minimum satisfies λ₀ ≤ 1 once vol(S) > 2ⁿ·covolume(L) — the i=0 shadow of the second theorem, derived from the parent's first theorem.",
+      "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → [hv : HasVolume n S] → hv.volume > criticalVolume n L → successiveMinimum n L S ⟨0, _⟩ ≤ 1"
+    },
+    {
+      "name": "successiveMinimum_mono",
+      "type": "key",
+      "description": "The successive minima are monotone: λᵢ ≤ λⱼ for i ≤ j (when the higher minimum's admissible set is nonempty).",
+      "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → {i j : Fin n} → i ≤ j → (admissibleScalings n L S j).Nonempty → successiveMinimum n L S i ≤ successiveMinimum n L S j"
+    },
+    {
+      "name": "successiveMinimum_nonneg",
+      "type": "supporting",
+      "description": "Every successive minimum is nonnegative (the admissible-scaling set is bounded below by 0).",
+      "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → (i : Fin n) → 0 ≤ successiveMinimum n L S i"
+    },
+    {
+      "name": "IndepLatticePoints.mono",
+      "type": "supporting",
+      "description": "Containing m independent lattice points implies containing k of them for any k ≤ m.",
+      "leanType": "{n : ℕ} → {L : Lattice n} → {k m : ℕ} → {T : Set (EuclideanN n)} → k ≤ m → IndepLatticePoints n L m T → IndepLatticePoints n L k T"
+    },
+    {
+      "name": "ConvexBody.scale",
+      "type": "supporting",
+      "description": "Scaling a symmetric convex body by a real factor c yields a symmetric convex body c • S.",
+      "leanType": "(n : ℕ) → ℝ → ConvexBody n → ConvexBody n"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Minkowski, Hermann",
+      "title": "Geometrie der Zahlen",
+      "year": "1896",
+      "venue": "Leipzig: Teubner",
+      "note": "Introduces the successive minima and proves the second theorem bounding their product"
+    },
+    {
+      "authors": "Cassels, J. W. S.",
+      "title": "An Introduction to the Geometry of Numbers",
+      "year": "1959",
+      "venue": "Springer-Verlag, Grundlehren 99",
+      "note": "Chapter VIII develops the successive minima and Minkowski's second theorem in full"
+    },
+    {
+      "authors": "Gruber, P. M. and Lekkerkerker, C. G.",
+      "title": "Geometry of Numbers",
+      "year": "1987",
+      "venue": "North-Holland",
+      "note": "Comprehensive modern treatment of successive minima, transference theorems, and reduction theory"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/minkowski-fundamental-theorem-oq-01.json
+++ b/src/data/research/problems/minkowski-fundamental-theorem-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "minkowski-fundamental-theorem-oq-01",
   "title": "Can Minkowski's second theorem (on successive minima) be formalized with the ...",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -29,11 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE (infrastructure): successive-minima framework + first-minimum bound shipped (PR #27450, verified 0-axiom). Product bound of the second theorem remains the open analytic core.",
+    "builtItems": [
+      "ConvexBody.scale (c • S as symmetric ConvexBody) in MinkowskiFundamentalTheoremOQ01.lean:63",
+      "IndepLatticePoints + .mono (k independent lattice points predicate, antitone in k) :88,:94",
+      "successiveMinimum = sInf admissibleScalings, with successiveMinimum_nonneg/_mono (λ₀≤λ₁≤⋯) :112,:121,:134",
+      "firstMinimum_le_one_of_volume_gt: λ₀≤1 from parent minkowski_fundamental :157",
+      "secondTheorem_upper_statement: Prop scaffold for (∏λᵢ)·vol(S)≤2ⁿ·covol(L) :149"
+    ],
+    "insights": [
+      "Parent custom Lattice/ConvexBody API is expressive enough for the full successive-minima definitional layer — no new foundations needed for OQ-01 infrastructure.",
+      "Monotonicity λ₀≤λ₁≤⋯ is order-theoretic: more independent points ⟹ nested-down admissible sets ⟹ csInf antitone. No analysis required.",
+      "Minkowski first theorem = i=0 case of second: nonzero lattice point in S ⟹ 1 admissible for λ₀ ⟹ λ₀≤1.",
+      "Build fixes for the abandoned draft: open scoped Pointwise for c•(Set ...); explicit Unique (Fin (0+1)) instance for single-vector linear independence."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove secondTheorem_upper_statement: (∏λᵢ)·vol(S)≤2ⁿ·covol(L) via basis realizing successive minima + simultaneous reduction.",
+      "Prove matching lower bound (2ⁿ/n!)·covol(L)≤(∏λᵢ)·vol(S).",
+      "Prove admissibleScalings nonempty (attainment of each λᵢ) to discharge the monotonicity hypothesis unconditionally."
+    ],
     "markdown": "# Knowledge Base: minkowski-fundamental-theorem-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

Answers **OQ-01** of `minkowski-fundamental-theorem` — *"Can Minkowski's second theorem (on successive minima) be formalized with the same infrastructure?"* — at the infrastructure + order-structure level, building the successive-minima framework directly on the parent file's custom `Lattice` / `ConvexBody` / `HasVolume` API.

`proofs/Proofs/MinkowskiFundamentalTheoremOQ01.lean` — 208 lines, 5 definitions, 8 theorems, **0 sorries, 0 axioms** (verified via docker build).

## What's proved
- `ConvexBody.scale` — `c • S` is again a symmetric convex body (convexity via `Convex.smul`, symmetry via `smul_neg`, nonempty via `Set.Nonempty.smul_set`).
- `IndepLatticePoints L k T` + `.mono` — the "k linearly independent lattice points in a set" predicate and its antitonicity in `k`.
- `successiveMinimum L S i = sInf {c > 0 : cS contains i+1 independent lattice points}`, with `successiveMinimum_nonneg` (positivity) and `successiveMinimum_mono` (λ₀ ≤ λ₁ ≤ ⋯, when the higher minimum is attained).
- `secondTheorem_upper_statement` — the precise `Prop` for the product bound `(∏ λᵢ)·vol(S) ≤ 2ⁿ·covolume(L)`, stated as a scaffold.
- `firstMinimum_le_one_of_volume_gt` — λ₀ ≤ 1 once `vol(S) > 2ⁿ·covolume(L)`, derived directly from the parent's verified `minkowski_fundamental` (the i = 0 shadow of the second theorem).

## Honest scope
This is the definitional framework, the order structure of the successive minima, and the first-minimum specialization — **not** the full second theorem. The product bound itself (the deep analytic core, requiring a basis realizing the successive minima and a simultaneous reduction argument) is stated as a `Prop` scaffold and left open. It is **not** hidden behind a `sorry`.

## Notes
This revives a previously-abandoned draft that did not compile. Two build breaks were fixed: a missing `open scoped Pointwise` (so `c • (Set ...)` resolves the pointwise `SMul`), and an explicit `Unique (Fin (0+1))` instance for the single-vector linear-independence step. Gallery entry added under `src/data/proofs/minkowski-fundamental-theorem-oq-01/` (meta.json + annotations.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)