### PR TITLE
research(arithmetic-series-oq-03): zeta-regularize 1+2+3+⋯=-1/12 in closed form [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3546,3 +3546,5 @@ import Proofs.MellinPowerConvergenceOQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ04
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06
+
+import Proofs.ZetaRegularization

--- a/proofs/Proofs/ZetaRegularization.lean
+++ b/proofs/Proofs/ZetaRegularization.lean
@@ -1,0 +1,140 @@
+/-
+# Zeta Regularization of Divergent Power Sums  (ζ(-1) = -1/12)
+
+Follow-up to the *Arithmetic Series* gallery entry (open question OQ-03):
+the analytic continuation of the Riemann zeta function assigns *finite* values
+to the otherwise divergent power-sum series
+
+  1 + 2 + 3 + 4 + ⋯   "="   ζ(-1)  = -1/12,
+  1 + 1 + 1 + 1 + ⋯   "="   ζ( 0)  = -1/2,
+  1 + 4 + 9 + 16 + ⋯  "="   ζ(-2)  =  0,
+  1 + 8 + 27 + 64 + ⋯ "="   ζ(-3)  =  1/120.
+
+These are *not* the limits of the partial sums (which diverge); they are the
+values of the analytically continued zeta function at non-positive integers,
+the standard "zeta regularization" used in physics (Casimir effect, string
+theory) and in Ramanujan summation.
+
+The single structural fact behind every value is Mathlib's
+`riemannZeta_neg_nat_eq_bernoulli`:
+
+  ζ(-k) = (-1)^k · B_{k+1} / (k+1),
+
+so each regularized value is a *rational* number determined by a Bernoulli
+number.  This file:
+
+* evaluates the four classical values above in closed form (`ζ(-1) = -1/12`
+  is the headline);
+* proves the infinite family of **trivial zeros**: the regularized sum of
+  every even power `∑ n^{2k}` (k ≥ 1) vanishes;
+* records the **rationality** of every regularized value.
+
+Everything is a fully verified, axiom-free consequence of Mathlib's analytic
+continuation of ζ; the divergent-series interpretation is informal narrative.
+
+## Scope / honesty
+
+The analytic heavy lifting — meromorphic continuation of ζ and the value
+formula at negative integers — is Mathlib's.  The contribution here is the
+explicit closed-form evaluation of the classical regularized values, the
+trivial-zero family stated directly on the power index, and the rationality
+corollary.  No new analysis is proved.
+-/
+
+import Mathlib.NumberTheory.LSeries.HurwitzZetaValues
+import Mathlib.NumberTheory.Bernoulli
+import Mathlib.Tactic
+
+namespace ZetaRegularization
+
+open scoped Real
+
+/-! ## The regularized power sum -/
+
+/-- The zeta-regularized value assigned to the (divergent) power-sum series
+`∑ₙ nᵖ`, defined as the analytic continuation `ζ(-p)`.  For `p = 1` this is the
+famous "`1 + 2 + 3 + ⋯ = -1/12`". -/
+noncomputable def regularizedPowerSum (p : ℕ) : ℂ := riemannZeta (-(p : ℂ))
+
+/-! ## Bernoulli value at 4 (Mathlib only ships `bernoulli'_four`) -/
+
+/-- `B₄ = -1/30`.  Mathlib ships `bernoulli'_four`; the signed Bernoulli number
+agrees with the unsigned one away from index `1`. -/
+theorem bernoulli_four : bernoulli 4 = -1 / 30 := by
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by norm_num), bernoulli'_four]
+
+/-! ## Closed-form classical values -/
+
+/-- **ζ(0) = -1/2** — the regularization of `1 + 1 + 1 + ⋯`. -/
+theorem regularizedPowerSum_zero : regularizedPowerSum 0 = -1 / 2 := by
+  unfold regularizedPowerSum
+  simp [riemannZeta_zero]
+
+/-- **ζ(-1) = -1/12** — the regularization of `1 + 2 + 3 + ⋯`.  The headline
+identity. -/
+theorem riemannZeta_neg_one : riemannZeta (-1) = -1 / 12 := by
+  have h := riemannZeta_neg_nat_eq_bernoulli 1
+  rw [Nat.cast_one] at h
+  rw [h]
+  norm_num [bernoulli_two]
+
+/-- `1 + 2 + 3 + ⋯ = -1/12` in the regularized sense. -/
+theorem regularizedPowerSum_one : regularizedPowerSum 1 = -1 / 12 := by
+  unfold regularizedPowerSum
+  rw [Nat.cast_one]
+  exact riemannZeta_neg_one
+
+/-- **ζ(-2) = 0** — the regularization of `1 + 4 + 9 + ⋯`. -/
+theorem riemannZeta_neg_two : riemannZeta (-2) = 0 := by
+  have h := riemannZeta_neg_two_mul_nat_add_one 0
+  norm_num at h
+  exact h
+
+/-- **ζ(-3) = 1/120** — the regularization of `1 + 8 + 27 + ⋯`. -/
+theorem riemannZeta_neg_three : riemannZeta (-3) = 1 / 120 := by
+  have h := riemannZeta_neg_nat_eq_bernoulli 3
+  rw [show ((3 : ℕ) : ℂ) = 3 by norm_num] at h
+  rw [h, bernoulli_four]
+  norm_num
+
+/-! ## The trivial zeros: every even power regularizes to `0` -/
+
+/-- **Trivial zeros.**  For every `k ≥ 1` the regularized sum of the even power
+series `∑ₙ n^{2k}` vanishes: `ζ(-2k) = 0`.  An infinite family. -/
+theorem regularizedPowerSum_even (k : ℕ) (hk : 0 < k) :
+    regularizedPowerSum (2 * k) = 0 := by
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hk.ne'
+  unfold regularizedPowerSum
+  have h := riemannZeta_neg_two_mul_nat_add_one n
+  convert h using 2
+  push_cast
+  ring
+
+/-! ## Rationality of every regularized value -/
+
+/-- Every zeta-regularized power sum is a **rational** number, given explicitly
+by `(-1)^p · B_{p+1} / (p+1)`. -/
+theorem regularizedPowerSum_rational (p : ℕ) :
+    ∃ q : ℚ, regularizedPowerSum p = (q : ℂ) := by
+  refine ⟨(-1) ^ p * bernoulli (p + 1) / (p + 1), ?_⟩
+  unfold regularizedPowerSum
+  rw [riemannZeta_neg_nat_eq_bernoulli p]
+  push_cast
+  ring
+
+/-! ## Sanity: the four classical values, packaged -/
+
+/-- The four classical regularized values in one statement. -/
+theorem classical_values :
+    regularizedPowerSum 0 = -1 / 2 ∧
+    regularizedPowerSum 1 = -1 / 12 ∧
+    regularizedPowerSum 2 = 0 ∧
+    regularizedPowerSum 3 = 1 / 120 := by
+  refine ⟨regularizedPowerSum_zero, regularizedPowerSum_one, ?_, ?_⟩
+  · have := regularizedPowerSum_even 1 one_pos
+    simpa using this
+  · unfold regularizedPowerSum
+    rw [show ((3 : ℕ) : ℂ) = 3 by norm_num]
+    exact riemannZeta_neg_three
+
+end ZetaRegularization

--- a/src/data/proofs/arithmetic-series-oq-03/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-03/annotations.json
@@ -1,0 +1,111 @@
+[
+  {
+    "id": "ann-zeta-reg-definition",
+    "proofId": "arithmetic-series-oq-03",
+    "range": {
+      "startLine": 54,
+      "endLine": 57
+    },
+    "type": "concept",
+    "title": "Regularization, Not Summation",
+    "content": "`regularizedPowerSum p` is *defined* to be `riemannZeta (-(p : ℂ))`. This is the crux of the '1 + 2 + 3 + ⋯ = -1/12' statement: it is not a claim about the limit of partial sums (which diverge to +∞), but the value of the analytically continued zeta function at s = -p. The Dirichlet series ζ(s) = ∑ n^{-s} converges only for Re s > 1; Mathlib's `riemannZeta` is its meromorphic continuation to all of ℂ, and we read off the regularized value at the negative integer -p.",
+    "mathContext": "$$\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s} \\quad (\\mathrm{Re}\\,s > 1), \\qquad \\text{continued to } \\zeta : \\mathbb{C}\\setminus\\{1\\} \\to \\mathbb{C}.$$\nThe regularized value of $\\sum_{n\\ge 1} n^p$ is $\\zeta(-p)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "analytic continuation",
+      "Dirichlet series",
+      "divergent series",
+      "zeta regularization"
+    ],
+    "prerequisites": [
+      "riemannZeta",
+      "meromorphic continuation"
+    ]
+  },
+  {
+    "id": "ann-zeta-reg-bernoulli-formula",
+    "proofId": "arithmetic-series-oq-03",
+    "range": {
+      "startLine": 75,
+      "endLine": 80
+    },
+    "type": "technique",
+    "title": "The One Lemma Behind Every Value",
+    "content": "The headline ζ(-1) = -1/12 is obtained by specializing Mathlib's `riemannZeta_neg_nat_eq_bernoulli` to k = 1, giving ζ(-1) = (-1)^1 · B₂ / 2. After rewriting the cast ((1:ℕ):ℂ) = 1, the tactic `norm_num [bernoulli_two]` substitutes B₂ = 1/6 and computes -(1/6)/2 = -1/12. The same lemma drives ζ(-3) = 1/120 (with B₄ = -1/30) and the rationality theorem; only the Bernoulli arithmetic and cast bookkeeping differ.",
+    "mathContext": "$$\\zeta(-k) = \\frac{(-1)^k B_{k+1}}{k+1}, \\qquad \\zeta(-1) = \\frac{-B_2}{2} = \\frac{-1/6}{2} = -\\frac{1}{12}.$$",
+    "significance": "core",
+    "relatedConcepts": [
+      "Bernoulli numbers",
+      "functional equation",
+      "norm_num"
+    ],
+    "prerequisites": [
+      "riemannZeta_neg_nat_eq_bernoulli",
+      "bernoulli_two"
+    ]
+  },
+  {
+    "id": "ann-zeta-reg-bernoulli-four",
+    "proofId": "arithmetic-series-oq-03",
+    "range": {
+      "startLine": 63,
+      "endLine": 65
+    },
+    "type": "technique",
+    "title": "Two Bernoulli Conventions",
+    "content": "Mathlib ships `bernoulli'_four : B'₄ = -1/30` (the +1/2 convention) but the zeta value formula uses `bernoulli` (the -1/2 convention). The helper `bernoulli_four` transports the value via `bernoulli_eq_bernoulli'_of_ne_one`, which states the signed and unsigned Bernoulli numbers agree for every index n ≠ 1. Since 4 ≠ 1, B₄ = B'₄ = -1/30. The two conventions differ only at index 1 (B₁ = -1/2 vs B'₁ = +1/2), corresponding to summing over k ∈ {0,…,n-1} vs {1,…,n}.",
+    "mathContext": "$$B_n = B'_n \\text{ for } n \\ne 1, \\qquad B_1 = -\\tfrac12,\\ B'_1 = +\\tfrac12.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bernoulli numbers",
+      "sign conventions"
+    ],
+    "prerequisites": [
+      "bernoulli_eq_bernoulli'_of_ne_one",
+      "bernoulli'_four"
+    ]
+  },
+  {
+    "id": "ann-zeta-reg-trivial-zeros",
+    "proofId": "arithmetic-series-oq-03",
+    "range": {
+      "startLine": 103,
+      "endLine": 114
+    },
+    "type": "concept",
+    "title": "The Trivial Zeros as an Infinite Family",
+    "content": "`regularizedPowerSum_even` proves ζ(-2k) = 0 for every k ≥ 1 — so all the even-power divergent series 1+4+9+⋯, 1+16+81+⋯, … regularize to 0. The proof writes k = n+1 and applies `riemannZeta_neg_two_mul_nat_add_one n`, matching the casts with `push_cast; ring`. These are exactly the *trivial zeros* of ζ; their non-trivial counterparts on the critical line Re s = 1/2 are the subject of the Riemann Hypothesis.",
+    "mathContext": "$$\\zeta(-2) = \\zeta(-4) = \\zeta(-6) = \\cdots = 0.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "trivial zeros",
+      "Riemann Hypothesis",
+      "functional equation"
+    ],
+    "prerequisites": [
+      "riemannZeta_neg_two_mul_nat_add_one"
+    ]
+  },
+  {
+    "id": "ann-zeta-reg-rationality",
+    "proofId": "arithmetic-series-oq-03",
+    "range": {
+      "startLine": 116,
+      "endLine": 126
+    },
+    "type": "concept",
+    "title": "Every Regularized Value Is Rational",
+    "content": "`regularizedPowerSum_rational` exhibits, for each p, an explicit rational q = (-1)^p B_{p+1}/(p+1) with ζ(-p) = q. After applying the value formula, `push_cast; ring` checks that the complex value equals the cast of q. This rationality is the negative-integer mirror of ζ(2k) ∈ π^{2k}·ℚ and contrasts sharply with the conjectural transcendence of the odd values ζ(2k+1).",
+    "mathContext": "$$\\zeta(-p) = \\frac{(-1)^p B_{p+1}}{p+1} \\in \\mathbb{Q} \\quad \\text{for all } p \\in \\mathbb{N}.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "rationality",
+      "Bernoulli numbers",
+      "transcendence of odd zeta values"
+    ],
+    "prerequisites": [
+      "riemannZeta_neg_nat_eq_bernoulli",
+      "push_cast"
+    ]
+  }
+]

--- a/src/data/proofs/arithmetic-series-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-03/meta.json
@@ -1,0 +1,234 @@
+{
+  "id": "arithmetic-series-oq-03",
+  "title": "Zeta Regularization: 1 + 2 + 3 + ⋯ = -1/12",
+  "slug": "arithmetic-series-oq-03",
+  "description": "The Riemann zeta function's analytic continuation assigns finite values to divergent power-sum series: ζ(-1) = -1/12, ζ(0) = -1/2, ζ(-2) = 0, ζ(-3) = 1/120. This file evaluates the four classical zeta-regularized values in closed form, proves the infinite family of trivial zeros (every even power sum regularizes to 0), and shows every regularized value is rational. Built on Mathlib's value formula ζ(-k) = (-1)^k B_{k+1}/(k+1). Fully verified, 0 axioms.",
+  "meta": {
+    "author": "Bernhard Riemann (1859); zeta regularization (Hardy, Ramanujan); formalized in Lean 4",
+    "date": "1859",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ZetaRegularization.lean",
+    "tags": [
+      "number-theory",
+      "riemann-zeta",
+      "bernoulli",
+      "analytic-continuation",
+      "regularization",
+      "arithmetic-series",
+      "divergent-series"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 140,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide`. All eight theorems depend only on the ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted; `#print axioms` shows no `sorryAx` and no `Lean.ofReduceBool`. The analytic content — meromorphic continuation of ζ and its values at negative integers — is Mathlib's (`riemannZeta_neg_nat_eq_bernoulli`, `riemannZeta_neg_two_mul_nat_add_one`, `riemannZeta_zero`). The contribution here is the explicit closed-form evaluation of the classical regularized values, the trivial-zero family stated on the power index, and the rationality corollary. No new analysis is proved.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "riemannZeta_neg_nat_eq_bernoulli",
+        "description": "ζ(-k) = (-1)^k · B_{k+1} / (k+1) for k ∈ ℕ — values of ζ at non-positive integers via Bernoulli numbers",
+        "module": "Mathlib.NumberTheory.LSeries.HurwitzZetaValues"
+      },
+      {
+        "theorem": "riemannZeta_neg_two_mul_nat_add_one",
+        "description": "ζ(-2(n+1)) = 0 — the trivial zeros of the Riemann zeta function",
+        "module": "Mathlib.NumberTheory.LSeries.RiemannZeta"
+      },
+      {
+        "theorem": "riemannZeta_zero",
+        "description": "ζ(0) = -1/2",
+        "module": "Mathlib.NumberTheory.LSeries.RiemannZeta"
+      },
+      {
+        "theorem": "bernoulli_two",
+        "description": "B₂ = 1/6",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli'_four",
+        "description": "B'₄ = -1/30",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      }
+    ],
+    "dateAdded": "2026-06-21",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The identity '1 + 2 + 3 + 4 + ⋯ = -1/12' is one of the most famous counterintuitive statements in mathematics. It does not mean the partial sums converge — they diverge to +∞. Rather, it records the value of the analytically continued Riemann zeta function ζ(s) = ∑ n^{-s} (defined for Re s > 1) at s = -1.\n\nEuler computed values like ζ(-1) = -1/12 and ζ(-3) = 1/120 already in the 1740s, using divergent-series manipulations that predate any rigorous notion of analytic continuation. Riemann's 1859 memoir put ζ on a rigorous footing as a meromorphic function on ℂ, and the functional equation relates ζ(-n) to ζ(n+1), giving ζ(-n) = -B_{n+1}/(n+1) in terms of Bernoulli numbers.\n\nG. H. Hardy's *Divergent Series* (1949) and Ramanujan's notebooks developed systematic 'summation methods' that assign -1/12 to 1+2+3+⋯ consistently. In physics this 'zeta regularization' is a standard tool: it computes the Casimir force between conducting plates and appears in the calculation of the critical dimension (26) of bosonic string theory.",
+    "problemStatement": "**Open Question (arithmetic-series-oq-03)**: Can we make rigorous the zeta-regularized values of the divergent power-sum series, in particular the famous ζ(-1) = -1/12?\n\nThe arithmetic-series entry computes the (convergent) finite sums ∑_{k=1}^n k^p. This follow-up asks for the *regularized* value assigned to the infinite divergent series ∑_{n≥1} n^p, namely ζ(-p):\n$$1 + 2 + 3 + \\cdots \\;\\text{'='}\\; \\zeta(-1) = -\\tfrac{1}{12}, \\qquad 1^2 + 2^2 + 3^2 + \\cdots \\;\\text{'='}\\; \\zeta(-2) = 0.$$\n\n**Answer: YES** — each value is ζ(-p) = (-1)^p B_{p+1}/(p+1), a rational number, via Mathlib's analytic continuation of ζ.",
+    "text": "A 140-line, fully verified (0-axiom, no native_decide) formalization. The regularized power sum is defined as `regularizedPowerSum p = ζ(-p)`. The four classical values are evaluated in closed form: ζ(0) = -1/2, ζ(-1) = -1/12 (the headline), ζ(-2) = 0, ζ(-3) = 1/120. The trivial-zero family `regularizedPowerSum_even` shows ζ(-2k) = 0 for every k ≥ 1 (an infinite family). The rationality theorem `regularizedPowerSum_rational` exhibits, for each p, an explicit rational q with ζ(-p) = q, namely q = (-1)^p B_{p+1}/(p+1). The headline ζ(-1) = -1/12 is obtained by specializing Mathlib's `riemannZeta_neg_nat_eq_bernoulli` to k=1 and using B₂ = 1/6.",
+    "proofStrategy": "Every value flows from the single Mathlib fact `riemannZeta_neg_nat_eq_bernoulli k : ζ(-k) = (-1)^k · B_{k+1}/(k+1)`.\n\n**ζ(-1) = -1/12**: specialize to k=1, rewrite the cast ((1:ℕ):ℂ) = 1, then `norm_num [bernoulli_two]` (B₂ = 1/6 gives -B₂/2 = -1/12).\n\n**ζ(-3) = 1/120**: specialize to k=3; here B₄ = -1/30 is needed, supplied by the helper `bernoulli_four` (Mathlib ships `bernoulli'_four = -1/30`; the signed and unsigned Bernoulli numbers agree away from index 1 via `bernoulli_eq_bernoulli'_of_ne_one`). Then -B₄/4 = 1/120.\n\n**ζ(0) = -1/2**: -0 = 0, so this is `riemannZeta_zero`.\n\n**Trivial zeros ζ(-2k) = 0 (k ≥ 1)**: write k = n+1 and apply `riemannZeta_neg_two_mul_nat_add_one n`; the casts match after `push_cast; ring`.\n\n**Rationality**: provide q = (-1)^p B_{p+1}/(p+1) as a rational; after `riemannZeta_neg_nat_eq_bernoulli`, `push_cast; ring` shows the complex value equals the cast of q.",
+    "keyInsights": [
+      "ζ(-1) = -1/12 is *not* a sum of the divergent series; it is the value of the analytic continuation of ζ at s = -1. The formalization makes this precise by defining the regularized sum directly as ζ(-p), never claiming the partial sums converge.",
+      "A single Mathlib lemma, `riemannZeta_neg_nat_eq_bernoulli`, gives ζ(-k) = (-1)^k B_{k+1}/(k+1) and powers every closed-form value here. The work is the explicit Bernoulli arithmetic and cast bookkeeping.",
+      "The even power sums all regularize to 0 — this is exactly the trivial-zero phenomenon ζ(-2k) = 0, here phrased directly on the power index 2k rather than on the zeta argument. It is an infinite family, in contrast to the four sporadic odd/zero values.",
+      "Every regularized value is rational: ζ(-p) ∈ ℚ for all p ∈ ℕ. This is the negative-integer analogue of the fact that ζ(2k) is a rational multiple of π^{2k} (and contrasts sharply with the conjectural irrationality/transcendence of the ζ(2k+1)).",
+      "Mathlib carries two Bernoulli conventions: `bernoulli` (B₁ = -1/2) and `bernoulli'` (B'₁ = +1/2). The value formula at negative integers uses `bernoulli`; B₄ = -1/30 must be transported from `bernoulli'_four` via `bernoulli_eq_bernoulli'_of_ne_one` (they agree for n ≠ 1)."
+    ],
+    "prerequisites": [
+      "The Riemann zeta function and its analytic continuation",
+      "Bernoulli numbers (basic values B₂ = 1/6, B₄ = -1/30)",
+      "The notion of regularization / summation of divergent series",
+      "Complex-number casts and rational arithmetic in Lean 4/Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "Part I: The Regularized Power Sum",
+      "startLine": 50,
+      "endLine": 65,
+      "summary": "regularizedPowerSum p := ζ(-p), the analytic continuation assigning a finite value to the divergent series ∑ n^p. Helper bernoulli_four: B₄ = -1/30 via bernoulli_eq_bernoulli'_of_ne_one + bernoulli'_four.",
+      "mathContext": "The divergent series $\\sum_{n\\ge 1} n^p$ has no limit, but the zeta function $\\zeta(s) = \\sum_{n\\ge 1} n^{-s}$ (convergent for $\\mathrm{Re}\\,s > 1$) continues meromorphically to all of $\\mathbb{C}$, and $\\zeta(-p)$ is the regularized value assigned to $\\sum n^p$."
+    },
+    {
+      "id": "classical-values",
+      "title": "Part II: Closed-Form Classical Values",
+      "startLine": 67,
+      "endLine": 101,
+      "summary": "regularizedPowerSum_zero: ζ(0) = -1/2. riemannZeta_neg_one: ζ(-1) = -1/12 (headline). regularizedPowerSum_one: 1+2+3+⋯ = -1/12. riemannZeta_neg_two: ζ(-2) = 0. riemannZeta_neg_three: ζ(-3) = 1/120.",
+      "mathContext": "The four classical regularized values: $\\zeta(0) = -\\tfrac12$ ('$1+1+1+\\cdots$'), $\\zeta(-1) = -\\tfrac{1}{12}$ ('$1+2+3+\\cdots$'), $\\zeta(-2) = 0$ ('$1+4+9+\\cdots$'), $\\zeta(-3) = \\tfrac{1}{120}$ ('$1+8+27+\\cdots$'). Each equals $(-1)^p B_{p+1}/(p+1)$."
+    },
+    {
+      "id": "trivial-zeros",
+      "title": "Part III: The Trivial Zeros (Infinite Family)",
+      "startLine": 103,
+      "endLine": 114,
+      "summary": "regularizedPowerSum_even: ζ(-2k) = 0 for all k ≥ 1. The even power sums all regularize to zero — the trivial zeros of ζ phrased on the power index.",
+      "mathContext": "The Riemann zeta function vanishes at the negative even integers: $\\zeta(-2) = \\zeta(-4) = \\zeta(-6) = \\cdots = 0$. Equivalently, every even-power divergent series $\\sum n^{2k}$ ($k \\ge 1$) regularizes to $0$. These are the *trivial zeros*; the non-trivial zeros (the subject of the Riemann Hypothesis) lie in the critical strip."
+    },
+    {
+      "id": "rationality",
+      "title": "Part IV: Rationality of Every Regularized Value",
+      "startLine": 116,
+      "endLine": 139,
+      "summary": "regularizedPowerSum_rational: ∀ p, ∃ q ∈ ℚ, ζ(-p) = q, explicitly q = (-1)^p B_{p+1}/(p+1). classical_values: the four headline values packaged together.",
+      "mathContext": "Unlike the positive even values $\\zeta(2k) \\in \\pi^{2k}\\mathbb{Q}$ (transcendental) and the mysterious odd values $\\zeta(2k+1)$, the negative-integer values $\\zeta(-p)$ are all *rational*, given exactly by Bernoulli numbers. This rationality is what makes zeta regularization yield clean closed-form answers like $-1/12$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization answers arithmetic-series-oq-03 affirmatively: the zeta-regularized values of the divergent power sums are rigorously available through Mathlib's analytic continuation of ζ. The headline ζ(-1) = -1/12 ('1+2+3+⋯ = -1/12'), together with ζ(0) = -1/2, ζ(-2) = 0, ζ(-3) = 1/120, the infinite family of trivial zeros ζ(-2k) = 0, and the rationality of every value, are all fully verified with 0 axioms and no native_decide.",
+    "implications": "Zeta regularization turns formally divergent expressions into finite, well-defined numbers and is indispensable in mathematical physics: it computes the Casimir effect and fixes the critical dimension of bosonic string theory. The rationality of ζ(-p) (via Bernoulli numbers) is the negative-integer mirror of ζ(2k) ∈ π^{2k}ℚ, and the vanishing ζ(-2k) = 0 are precisely the trivial zeros whose non-trivial counterparts the Riemann Hypothesis concerns.",
+    "openQuestions": [
+      "Can we connect this regularized value directly to a summation method (Abel, Cesàro, or Ramanujan summation) and prove the corresponding regularized sum of 1+2+3+⋯ equals ζ(-1) by that method, rather than by analytic continuation?",
+      "Can we formalize the functional equation ζ(s) = 2^s π^{s-1} sin(πs/2) Γ(1-s) ζ(1-s) and derive ζ(-1) = -1/12 from ζ(2) = π²/6 directly through it?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "arithmetic-series",
+      "relationship": "extends",
+      "description": "Parent: computes the convergent finite sums ∑_{k=1}^n k^p; this entry treats the divergent infinite series ∑_{n≥1} n^p via zeta regularization"
+    },
+    {
+      "targetId": "arithmetic-series-oq-04",
+      "relationship": "related",
+      "description": "Faulhaber's formula: its open questions explicitly ask to derive ζ(-n) = -B_{n+1}/(n+1); this entry realizes that value formula and its consequences"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "ζ(2) = π²/6 is the positive-even mirror of these negative-integer values; both come from Bernoulli numbers via the functional equation"
+    },
+    {
+      "targetId": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "The trivial zeros ζ(-2k) = 0 proved here are the counterpart of the non-trivial zeros that the Riemann Hypothesis locates on the critical line"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.LSeries.HurwitzZetaValues",
+      "Mathlib.NumberTheory.Bernoulli",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real (scoped)"
+    ],
+    "namespace": "ZetaRegularization",
+    "lineCount": 140,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "mainTheorems": [
+      {
+        "name": "riemannZeta_neg_one",
+        "type": "core",
+        "description": "ζ(-1) = -1/12 — the regularized value of 1 + 2 + 3 + ⋯",
+        "leanType": "riemannZeta (-1) = -1 / 12"
+      },
+      {
+        "name": "regularizedPowerSum_even",
+        "type": "key",
+        "description": "Trivial zeros: ζ(-2k) = 0 for every k ≥ 1 (an infinite family)",
+        "leanType": "(k : ℕ) → 0 < k → regularizedPowerSum (2 * k) = 0"
+      },
+      {
+        "name": "regularizedPowerSum_rational",
+        "type": "key",
+        "description": "Every regularized value is rational: ζ(-p) = (-1)^p B_{p+1}/(p+1) ∈ ℚ",
+        "leanType": "(p : ℕ) → ∃ q : ℚ, regularizedPowerSum p = (q : ℂ)"
+      }
+    ],
+    "path": "Proofs/ZetaRegularization.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "riemannZeta_neg_one",
+      "type": "core",
+      "description": "ζ(-1) = -1/12 — the famous regularized value of 1 + 2 + 3 + ⋯",
+      "leanType": "riemannZeta (-1) = -1 / 12"
+    },
+    {
+      "name": "regularizedPowerSum_one",
+      "type": "key",
+      "description": "1 + 2 + 3 + ⋯ = -1/12 in the regularized sense (ζ(-1))",
+      "leanType": "regularizedPowerSum 1 = -1 / 12"
+    },
+    {
+      "name": "regularizedPowerSum_even",
+      "type": "key",
+      "description": "Trivial zeros: every even power sum ∑ n^{2k} (k ≥ 1) regularizes to 0",
+      "leanType": "(k : ℕ) → 0 < k → regularizedPowerSum (2 * k) = 0"
+    },
+    {
+      "name": "regularizedPowerSum_rational",
+      "type": "key",
+      "description": "Every zeta-regularized value is a rational number",
+      "leanType": "(p : ℕ) → ∃ q : ℚ, regularizedPowerSum p = (q : ℂ)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Riemann, Bernhard",
+      "title": "Ueber die Anzahl der Primzahlen unter einer gegebenen Grösse",
+      "year": "1859",
+      "venue": "Monatsberichte der Berliner Akademie",
+      "note": "Establishes ζ as a meromorphic function on ℂ and proves the functional equation, which gives the values at negative integers ζ(-n) = -B_{n+1}/(n+1)"
+    },
+    {
+      "authors": "Hardy, G. H.",
+      "title": "Divergent Series",
+      "year": "1949",
+      "venue": "Oxford University Press",
+      "note": "Systematic theory of summation methods assigning consistent finite values to divergent series, including the regularization giving 1+2+3+⋯ = -1/12"
+    },
+    {
+      "authors": "Elizalde, E.",
+      "title": "Ten Physical Applications of Spectral Zeta Functions",
+      "year": "1995",
+      "venue": "Springer Lecture Notes in Physics m35",
+      "note": "Zeta regularization in mathematical physics: Casimir energy, vacuum energies, and the appearance of ζ(-1) = -1/12 in the bosonic string critical dimension"
+    },
+    {
+      "authors": "Ireland, Kenneth; Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "Springer GTM 84, 2nd edition",
+      "note": "Chapter 15: Bernoulli numbers, the power sum formula, and the relation ζ(-n) = -B_{n+1}/(n+1); the algebraic background to the Mathlib value formula"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/arithmetic-series-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-03.json
@@ -1,13 +1,13 @@
 {
   "slug": "arithmetic-series-oq-03",
   "title": "Arithmetic Series: Riemann Zeta Regularization zeta(-1) = -1/12",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in number theory: Arithmetic Series: Riemann Zeta Regularization zeta(-1) = -1/12.",
+    "formal": "\\zeta(-1) = -1/12,\\ \\zeta(0)=-1/2,\\ \\zeta(-2)=0,\\ \\zeta(-3)=1/120;\\ \\zeta(-2k)=0\\ (k\\ge1);\\ \\zeta(-p)\\in\\mathbb{Q}",
+    "plain": "Zeta regularization of divergent power sums: the famous 1+2+3+...=-1/12 and its companions, via the analytic continuation of the Riemann zeta function.",
     "whyMatters": []
   },
   "knownResults": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-04-03T22:29:17.627Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Solved: ζ-regularized power sums evaluated in closed form, 0-axiom verified.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — entry shipped.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: 8 theorems + 1 def, 140L, 0-axiom verified (no native_decide). Shipped as gallery entry arithmetic-series-oq-03.",
+    "builtItems": [
+      "ZetaRegularization.riemannZeta_neg_one : ζ(-1)=-1/12 (Proofs/ZetaRegularization.lean:75)",
+      "regularizedPowerSum_even : ζ(-2k)=0 for k≥1 (ZetaRegularization.lean:104)",
+      "regularizedPowerSum_rational : ∀p, ∃q:ℚ, ζ(-p)=q (ZetaRegularization.lean:117)",
+      "bernoulli_four : B₄=-1/30 helper (ZetaRegularization.lean:63)"
+    ],
+    "insights": [
+      "ζ(-1)=-1/12 is the value of the analytically-continued zeta at s=-1, NOT a convergent sum; formalized by defining regularizedPowerSum p := riemannZeta(-(p:ℂ)).",
+      "Mathlib riemannZeta_neg_nat_eq_bernoulli k : ζ(-k)=(-1)^k B_{k+1}/(k+1) powers every closed-form value (k=1→-1/12, k=3→1/120) and the rationality corollary.",
+      "Even power sums all regularize to 0 (trivial zeros ζ(-2k)=0, k≥1) via riemannZeta_neg_two_mul_nat_add_one — an infinite family phrased on the power index.",
+      "All negative-integer zeta values are rational, the mirror of ζ(2k)∈π^{2k}ℚ."
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Connect ζ(-1) to an explicit summation method (Abel/Ramanujan) rather than analytic continuation.",
+      "Formalize the functional equation and derive ζ(-1)=-1/12 from ζ(2)=π²/6 directly."
+    ]
   },
   "tags": [
     "seeker-selected",
@@ -69,214 +82,6 @@
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
-    {
-      "path": "Proofs/ArithmeticSeries.lean",
-      "filename": "ArithmeticSeries.lean",
-      "lineCount": 180,
-      "theoremCount": 11,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeries.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ00.lean",
-      "filename": "ArithmeticSeriesOQ00.lean",
-      "lineCount": 161,
-      "theoremCount": 11,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ00.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
-      "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 282,
-      "theoremCount": 12,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ00OQ01.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ00OQ02.lean",
-      "filename": "ArithmeticSeriesOQ00OQ02.lean",
-      "lineCount": 121,
-      "theoremCount": 11,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ00OQ02.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02.lean",
-      "filename": "ArithmeticSeriesOQ02.lean",
-      "lineCount": 210,
-      "theoremCount": 12,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ01.lean",
-      "filename": "ArithmeticSeriesOQ02OQ01.lean",
-      "lineCount": 174,
-      "theoremCount": 10,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
-      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
-      "lineCount": 218,
-      "theoremCount": 6,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
-      "filename": "ArithmeticSeriesOQ02OQ02.lean",
-      "lineCount": 155,
-      "theoremCount": 9,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean",
-      "filename": "ArithmeticSeriesOQ02OQ02OQ01.lean",
-      "lineCount": 166,
-      "theoremCount": 8,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean",
-      "filename": "ArithmeticSeriesOQ02OQ02OQ03.lean",
-      "lineCount": 208,
-      "theoremCount": 11,
-      "axiomCount": 0,
-      "defCount": 3,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
-      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
-      "lineCount": 508,
-      "theoremCount": 27,
-      "axiomCount": 0,
-      "defCount": 4,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ03.lean",
-      "filename": "ArithmeticSeriesOQ02OQ03.lean",
-      "lineCount": 164,
-      "theoremCount": 10,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ03.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ03Aristotle.lean",
-      "filename": "ArithmeticSeriesOQ02OQ03Aristotle.lean",
-      "lineCount": 40,
-      "theoremCount": 1,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": true,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ03Aristotle.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
-      "filename": "ArithmeticSeriesOQ02OQ04.lean",
-      "lineCount": 159,
-      "theoremCount": 11,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean",
-      "filename": "ArithmeticSeriesOQ02OQ04OQ01.lean",
-      "lineCount": 170,
-      "theoremCount": 12,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
-      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
-      "lineCount": 79,
-      "theoremCount": 2,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02.lean",
-      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02.lean",
-      "lineCount": 119,
-      "theoremCount": 3,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ04.lean",
-      "filename": "ArithmeticSeriesOQ04.lean",
-      "lineCount": 198,
-      "theoremCount": 16,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ04OQ01.lean",
-      "filename": "ArithmeticSeriesOQ04OQ01.lean",
-      "lineCount": 306,
-      "theoremCount": 19,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04OQ01.lean"
-    }
+    "proofs/Proofs/ZetaRegularization.lean"
   ]
 }


### PR DESCRIPTION
## Summary

Solves **arithmetic-series-oq-03** (zeta regularization of divergent power sums). Makes rigorous the famous **1 + 2 + 3 + ⋯ = -1/12** and its companions by reading off the values of the analytically-continued Riemann zeta function at non-positive integers.

`regularizedPowerSum p := riemannZeta (-(p:ℂ))` — the regularized value of the divergent series ∑ₙ nᵖ.

### Closed-form classical values
| series | value | theorem |
|---|---|---|
| 1+1+1+⋯ = ζ(0) | **-1/2** | `regularizedPowerSum_zero` |
| 1+2+3+⋯ = ζ(-1) | **-1/12** | `riemannZeta_neg_one` (headline) |
| 1+4+9+⋯ = ζ(-2) | **0** | `riemannZeta_neg_two` |
| 1+8+27+⋯ = ζ(-3) | **1/120** | `riemannZeta_neg_three` |

### Structural results
- **Trivial zeros (infinite family):** `regularizedPowerSum_even` — ζ(-2k) = 0 for every k ≥ 1.
- **Rationality:** `regularizedPowerSum_rational` — for every p, ζ(-p) = (-1)ᵖ·B_{p+1}/(p+1) ∈ ℚ.

### Verification
- **8 theorems + 1 definition, 140 lines, 0 axioms**, no `native_decide`.
- `#print axioms` on every result shows only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. **Fully verified.**
- Builds clean against Mathlib 4.26.0 via `docker-build.sh Proofs.ZetaRegularization`.

### Mathlib foundation (the analytic work is Mathlib's)
- `riemannZeta_neg_nat_eq_bernoulli` : ζ(-k) = (-1)ᵏ·B_{k+1}/(k+1)
- `riemannZeta_neg_two_mul_nat_add_one` : ζ(-2(n+1)) = 0
- `riemannZeta_zero` : ζ(0) = -1/2

### Honesty / scope
The meromorphic continuation of ζ and its negative-integer value formula are Mathlib's. The contribution here is the explicit closed-form evaluation of the classical regularized values, the trivial-zero family stated on the power index, and the rationality corollary. No new analysis is proved; the divergent-series interpretation is informal narrative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)