### PR TITLE
research(cauchy-schwarz-oq-01-oq-01-oq-02-oq-01): Robertson–Schrödinger uncertainty relation [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -506,6 +506,7 @@ import Proofs.CauchySchwarzOQ01
 import Proofs.CauchySchwarzOQ01OQ01
 import Proofs.CauchySchwarzOQ01OQ01OQ01
 import Proofs.CauchySchwarzOQ01OQ01OQ02
+import Proofs.CauchySchwarzOQ01OQ01OQ02OQ01
 import Proofs.CauchySchwarzOQ01OQ02
 import Proofs.CauchySchwarzOQ01OQ03
 import Proofs.CauchySchwarzOQ01OQ04

--- a/proofs/Proofs/CauchySchwarzOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ01OQ02.lean
@@ -50,8 +50,7 @@ theorem expVal_im_zero (A : E →ₗ[ℂ] E) (hA : A.IsSymmetric) (ψ : E) :
   have hself : ⟪ψ, A ψ⟫_ℂ = starRingEnd ℂ ⟪ψ, A ψ⟫_ℂ := by
     rw [inner_conj_symm, ← hA ψ ψ]
   have h := congr_arg Complex.im hself
-  simp only [RCLike.star_def, starRingEnd_apply, map_star,
-             RCLike.conj_im, neg_eq_iff_eq_neg, neg_neg] at h
+  rw [Complex.conj_im] at h
   linarith
 
 -- The expectation value equals its complex conjugate
@@ -59,8 +58,8 @@ theorem expVal_self_conj (A : E →ₗ[ℂ] E) (hA : A.IsSymmetric) (ψ : E) :
     starRingEnd ℂ (expVal A ψ) = expVal A ψ := by
   have him := expVal_im_zero A hA ψ
   apply Complex.ext
-  · simp [starRingEnd_apply, Complex.conj_re]
-  · simp [starRingEnd_apply, Complex.conj_im, him]
+  · exact Complex.conj_re _
+  · rw [Complex.conj_im, him, neg_zero]
 
 /-! ## Part III: Commutator and centered vectors -/
 

--- a/proofs/Proofs/CauchySchwarzOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,194 @@
+/-
+# The Robertson–Schrödinger Uncertainty Relation
+
+Open Question: cauchy-schwarz-oq-01-oq-01-oq-02-oq-01
+Parent: cauchy-schwarz-oq-01-oq-01-oq-02 ("Robertson's uncertainty inequality from Cauchy-Schwarz")
+
+The parent entry derives **Robertson's** inequality
+  ΔA(ψ) · ΔB(ψ)  ≥  (1/2) · |⟨ψ|[A,B]|ψ⟩|
+by applying Cauchy–Schwarz to the centered vectors u = (A−⟨A⟩)ψ, v = (B−⟨B⟩)ψ and
+keeping **only the antisymmetric (imaginary) part** of ⟪u,v⟫.
+
+The Cauchy–Schwarz inequality actually controls the *full* modulus
+  ‖u‖²·‖v‖²  ≥  |⟪u,v⟫|²  =  (Re⟪u,v⟫)²  +  (Im⟪u,v⟫)² .
+The imaginary part is the commutator (the Robertson term); the **real part is the
+covariance** ½⟨{A,B}⟩ − ⟨A⟩⟨B⟩ (the anticommutator term that Robertson throws away).
+Retaining it gives **Schrödinger's (1930) strengthening**:
+
+  σ_A² · σ_B²  ≥  ( ½⟨{A,B}⟩ − ⟨A⟩⟨B⟩ )²  +  ( ½ |⟨[A,B]⟩| )² .
+
+This is strictly sharper than Robertson whenever the covariance is nonzero, and it
+reduces to Robertson on dropping the (nonnegative) covariance square. This file proves
+the strengthening, the covariance identity behind it, and that it dominates Robertson.
+
+All results are 0-axiom, building on the parent file's symmetric-operator API.
+-/
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.InnerProductSpace.Symmetric
+import Mathlib.Analysis.RCLike.Basic
+import Mathlib.Tactic
+import Proofs.CauchySchwarzOQ01OQ01OQ02
+
+open scoped InnerProductSpace
+open Complex
+
+namespace CauchySchwarzOQ01OQ01OQ02OQ01
+
+open CauchySchwarzOQ01OQ01OQ02 (expVal stdDev commutatorEV expVal_self_conj
+  centered_antisymmetric_eq_commutator)
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+
+/-! ## Part I: A scalar identity for the squared modulus -/
+
+/-- `‖z‖² = (Re z)² + (Im z)²` for a complex number. -/
+private theorem cnorm_sq (z : ℂ) : ‖z‖ ^ 2 = z.re ^ 2 + z.im ^ 2 := by
+  rw [Complex.sq_norm, Complex.normSq_apply]; ring
+
+/-! ## Part II: The covariance (anticommutator) functional -/
+
+/-- The anticommutator expectation value `⟨ψ|{A,B}|ψ⟩ = ⟨ψ|(AB+BA)|ψ⟩`. -/
+noncomputable def anticommutatorEV (A B : E →ₗ[ℂ] E) (ψ : E) : ℂ :=
+  ⟪ψ, A (B ψ) + B (A ψ)⟫_ℂ
+
+/-- The (symmetric) covariance of `A` and `B` in the state `ψ`:
+`Cov(A,B) = ½⟨{A,B}⟩ − ⟨A⟩⟨B⟩`. This is the quantity Robertson discards. -/
+noncomputable def covarianceEV (A B : E →ₗ[ℂ] E) (ψ : E) : ℝ :=
+  (anticommutatorEV A B ψ / 2 - expVal A ψ * expVal B ψ).re
+
+/-- Expansion of a centered inner product, mirroring the parent's private helper.
+For symmetric `X` and a unit state, `⟪Xψ − ⟨X⟩ψ, Yψ − ⟨Y⟩ψ⟫ = ⟨ψ|XY|ψ⟩ − ⟨X⟩⟨Y⟩`. -/
+private theorem inner_centered_eq
+    {X Y : E →ₗ[ℂ] E} (hX : X.IsSymmetric)
+    (ψ : E) (hψψ : ⟪ψ, ψ⟫_ℂ = 1)
+    (hXreal : starRingEnd ℂ ⟪ψ, X ψ⟫_ℂ = ⟪ψ, X ψ⟫_ℂ) :
+    ⟪X ψ - ⟪ψ, X ψ⟫_ℂ • ψ, Y ψ - ⟪ψ, Y ψ⟫_ℂ • ψ⟫_ℂ =
+    ⟪ψ, X (Y ψ)⟫_ℂ - ⟪ψ, X ψ⟫_ℂ * ⟪ψ, Y ψ⟫_ℂ := by
+  simp only [inner_sub_left, inner_sub_right, inner_smul_left, inner_smul_right]
+  rw [hX ψ (Y ψ), hX ψ ψ, hψψ, hXreal]
+  ring
+
+/-- Unit-norm states have `⟪ψ,ψ⟫ = 1`. -/
+private theorem inner_self_one {ψ : E} (hψ : ‖ψ‖ = 1) : ⟪ψ, ψ⟫_ℂ = (1 : ℂ) := by
+  have h := @inner_self_eq_norm_sq_to_K ℂ E _ _ _ ψ
+  simp only [RCLike.ofReal_pow] at h
+  rw [h, hψ]; norm_num
+
+/-- **Covariance identity.** The real part of the centered inner product `⟪u,v⟫`
+(with `u,v` the centered vectors) is exactly the covariance `½⟨{A,B}⟩ − ⟨A⟩⟨B⟩`. -/
+theorem covarianceEV_eq_re
+    (A B : E →ₗ[ℂ] E) (hA : A.IsSymmetric) (hB : B.IsSymmetric)
+    (ψ : E) (hψ : ‖ψ‖ = 1) :
+    covarianceEV A B ψ =
+      (⟪A ψ - (expVal A ψ) • ψ, B ψ - (expVal B ψ) • ψ⟫_ℂ).re := by
+  have hψψ : ⟪ψ, ψ⟫_ℂ = (1 : ℂ) := inner_self_one hψ
+  have hAreal : starRingEnd ℂ ⟪ψ, A ψ⟫_ℂ = ⟪ψ, A ψ⟫_ℂ := expVal_self_conj A hA ψ
+  have hBreal : starRingEnd ℂ ⟪ψ, B ψ⟫_ℂ = ⟪ψ, B ψ⟫_ℂ := expVal_self_conj B hB ψ
+  set u := A ψ - (expVal A ψ) • ψ with hu
+  set v := B ψ - (expVal B ψ) • ψ with hv
+  -- Expand both ⟪u,v⟫ and ⟪v,u⟫ via the centered-inner expansion.
+  have huv : (⟪u, v⟫_ℂ : ℂ) = ⟪ψ, A (B ψ)⟫_ℂ - ⟪ψ, A ψ⟫_ℂ * ⟪ψ, B ψ⟫_ℂ := by
+    rw [hu, hv]; exact inner_centered_eq hA ψ hψψ hAreal (Y := B)
+  have hvu : (⟪v, u⟫_ℂ : ℂ) = ⟪ψ, B (A ψ)⟫_ℂ - ⟪ψ, B ψ⟫_ℂ * ⟪ψ, A ψ⟫_ℂ := by
+    rw [hu, hv]; exact inner_centered_eq hB ψ hψψ hBreal (Y := A)
+  -- ⟪v,u⟫ = conj ⟪u,v⟫, so ⟪u,v⟫ + ⟪v,u⟫ = 2 · Re⟪u,v⟫.
+  have hconj : (⟪v, u⟫_ℂ : ℂ) = starRingEnd ℂ ⟪u, v⟫_ℂ := (inner_conj_symm v u).symm
+  have hsum : (⟪u, v⟫_ℂ : ℂ) + ⟪v, u⟫_ℂ =
+      anticommutatorEV A B ψ - 2 * (expVal A ψ * expVal B ψ) := by
+    rw [huv, hvu]
+    unfold anticommutatorEV expVal
+    rw [inner_add_right]
+    ring
+  -- Take real parts. Re of the symmetric sum = 2·Re⟪u,v⟫ (since ⟪v,u⟫ = conj⟪u,v⟫).
+  have hsumre : (anticommutatorEV A B ψ - 2 * (expVal A ψ * expVal B ψ)).re
+      = 2 * (⟪u, v⟫_ℂ).re := by
+    rw [← hsum, hconj, Complex.add_re, Complex.conj_re]; ring
+  -- covarianceEV is the real part of (sum)/2.
+  unfold covarianceEV
+  have hdiv : anticommutatorEV A B ψ / 2 - expVal A ψ * expVal B ψ =
+      (anticommutatorEV A B ψ - 2 * (expVal A ψ * expVal B ψ)) / 2 := by ring
+  rw [hdiv, Complex.div_ofNat_re, hsumre]; ring
+
+/-! ## Part III: The Robertson–Schrödinger inequality -/
+
+/-- **Robertson–Schrödinger uncertainty relation.** For symmetric operators `A`, `B`
+and a unit state `ψ`,
+  σ_A² · σ_B²  ≥  Cov(A,B)²  +  ( ½ |⟨[A,B]⟩| )² .
+The first term on the right is the anticommutator (covariance) contribution that
+strengthens Robertson; the second is the Robertson commutator term itself. -/
+theorem robertson_schrodinger_inequality
+    (A B : E →ₗ[ℂ] E) (hA : A.IsSymmetric) (hB : B.IsSymmetric)
+    (ψ : E) (hψ : ‖ψ‖ = 1) :
+    stdDev A ψ ^ 2 * stdDev B ψ ^ 2 ≥
+      covarianceEV A B ψ ^ 2 + ((1/2 : ℝ) * ‖commutatorEV A B ψ‖) ^ 2 := by
+  set u := A ψ - (expVal A ψ) • ψ with hu
+  set v := B ψ - (expVal B ψ) • ψ with hv
+  set w : ℂ := ⟪u, v⟫_ℂ with hw
+  -- (1) Full Cauchy–Schwarz: ‖w‖² ≤ ‖u‖²·‖v‖².
+  have hcs : ‖w‖ ≤ ‖u‖ * ‖v‖ := norm_inner_le_norm u v
+  have hcs2 : ‖w‖ ^ 2 ≤ ‖u‖ ^ 2 * ‖v‖ ^ 2 := by
+    have hmul : (‖u‖ * ‖v‖) ^ 2 = ‖u‖ ^ 2 * ‖v‖ ^ 2 := by ring
+    nlinarith [norm_nonneg w, norm_nonneg u, norm_nonneg v, hcs]
+  -- (2) stdDev² = ‖·‖² for the centered vectors (definitional).
+  have hsA : stdDev A ψ ^ 2 = ‖u‖ ^ 2 := by rw [hu]; rfl
+  have hsB : stdDev B ψ ^ 2 = ‖v‖ ^ 2 := by rw [hv]; rfl
+  -- (3) Real part of w is the covariance.
+  have hRe : covarianceEV A B ψ = w.re := by
+    rw [hw, hu, hv]; exact covarianceEV_eq_re A B hA hB ψ hψ
+  -- (4) Imaginary part of w carries the commutator: w − conj w = commutatorEV.
+  have hcomm : (w : ℂ) - starRingEnd ℂ w = commutatorEV A B ψ := by
+    have h := centered_antisymmetric_eq_commutator A B hA hB ψ hψ
+    simp only at h
+    have hconj : starRingEnd ℂ w = (⟪v, u⟫_ℂ : ℂ) := by
+      rw [hw]; exact inner_conj_symm v u
+    rw [hconj, hw]; exact h
+  -- From hcomm: commutator is purely imaginary, with im = 2·w.im.
+  have hcomm_im : (commutatorEV A B ψ).im = 2 * w.im := by
+    rw [← hcomm, Complex.sub_im, Complex.conj_im]; ring
+  have hcomm_re : (commutatorEV A B ψ).re = 0 := by
+    rw [← hcomm, Complex.sub_re, Complex.conj_re, sub_self]
+  have hcomm_normsq : ‖commutatorEV A B ψ‖ ^ 2 = 4 * w.im ^ 2 := by
+    rw [cnorm_sq, hcomm_re, hcomm_im]; ring
+  -- (5) Assemble: RHS = w.re² + w.im² = ‖w‖² ≤ ‖u‖²‖v‖² = LHS.
+  have hRHS : covarianceEV A B ψ ^ 2 + ((1/2 : ℝ) * ‖commutatorEV A B ψ‖) ^ 2
+      = w.re ^ 2 + w.im ^ 2 := by
+    rw [hRe]
+    have : ((1/2 : ℝ) * ‖commutatorEV A B ψ‖) ^ 2 = (1/4) * ‖commutatorEV A B ψ‖ ^ 2 := by
+      ring
+    rw [this, hcomm_normsq]; ring
+  have hwsq : ‖w‖ ^ 2 = w.re ^ 2 + w.im ^ 2 := cnorm_sq w
+  rw [hsA, hsB, ge_iff_le, hRHS, ← hwsq]
+  exact hcs2
+
+/-! ## Part IV: Robertson is the weaker corollary -/
+
+/-- **Schrödinger ⟹ Robertson.** Dropping the (nonnegative) covariance square recovers
+the parent's Robertson bound `σ_A·σ_B ≥ ½|⟨[A,B]⟩|`. The strengthening is therefore
+genuine: equality in Robertson forces the covariance to vanish. -/
+theorem robertson_of_schrodinger
+    (A B : E →ₗ[ℂ] E) (hA : A.IsSymmetric) (hB : B.IsSymmetric)
+    (ψ : E) (hψ : ‖ψ‖ = 1) :
+    stdDev A ψ * stdDev B ψ ≥ (1/2 : ℝ) * ‖commutatorEV A B ψ‖ := by
+  have hRS := robertson_schrodinger_inequality A B hA hB ψ hψ
+  have hcov : covarianceEV A B ψ ^ 2 ≥ 0 := sq_nonneg _
+  -- σ_A²σ_B² ≥ (½‖[A,B]‖)², and both sides nonnegative ⇒ take square roots.
+  have hsq : (stdDev A ψ * stdDev B ψ) ^ 2 ≥ ((1/2 : ℝ) * ‖commutatorEV A B ψ‖) ^ 2 := by
+    have hsplit : stdDev A ψ ^ 2 * stdDev B ψ ^ 2 = (stdDev A ψ * stdDev B ψ) ^ 2 := by ring
+    nlinarith [hRS, hcov]
+  have hpos : (0 : ℝ) ≤ (1/2 : ℝ) * ‖commutatorEV A B ψ‖ := by positivity
+  have hstd : (0 : ℝ) ≤ stdDev A ψ * stdDev B ψ := by
+    apply mul_nonneg <;> exact norm_nonneg _
+  nlinarith [hsq, hpos, hstd]
+
+/-- **Covariance as the gap.** The exact Schrödinger identity packaged as a gap:
+σ_A²σ_B² − (½|⟨[A,B]⟩|)² ≥ Cov(A,B)² ≥ 0, with the first ≥ being the inequality and
+the covariance² the explicit amount by which Schrödinger improves on Robertson. -/
+theorem schrodinger_gap_nonneg
+    (A B : E →ₗ[ℂ] E) (hA : A.IsSymmetric) (hB : B.IsSymmetric)
+    (ψ : E) (hψ : ‖ψ‖ = 1) :
+    stdDev A ψ ^ 2 * stdDev B ψ ^ 2 - ((1/2 : ℝ) * ‖commutatorEV A B ψ‖) ^ 2
+      ≥ covarianceEV A B ψ ^ 2 := by
+  have hRS := robertson_schrodinger_inequality A B hA hB ψ hψ
+  linarith
+
+end CauchySchwarzOQ01OQ01OQ02OQ01

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "rs-01",
+    "proofId": "cauchy-schwarz-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 46
+    },
+    "type": "insight",
+    "title": "The Squared-Modulus Split: Re² + Im²",
+    "content": "`cnorm_sq z : ‖z‖² = (Re z)² + (Im z)²` (via `Complex.sq_norm` then `Complex.normSq_apply`) is the algebraic heart of the strengthening. Cauchy–Schwarz controls the full modulus ‖⟪u,v⟫‖²; this identity resolves it into two nonnegative pieces — the imaginary part (Robertson's commutator term) and the real part (the covariance Robertson discards). Keeping both gives Schrödinger."
+  },
+  {
+    "id": "rs-02",
+    "proofId": "cauchy-schwarz-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 57
+    },
+    "type": "definition",
+    "title": "The Covariance Functional Robertson Throws Away",
+    "content": "`anticommutatorEV A B ψ = ⟪ψ,(AB+BA)ψ⟫` and `covarianceEV A B ψ = Re(½⟨{A,B}⟩ − ⟨A⟩⟨B⟩)`. This is the quantum covariance of the observables A and B in the state ψ. Robertson's 1929 inequality drops it entirely; Schrödinger's 1930 refinement is exactly what you get by keeping it."
+  },
+  {
+    "id": "rs-03",
+    "proofId": "cauchy-schwarz-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 114
+    },
+    "type": "technique",
+    "title": "Covariance = Real Part of the Centered Inner Product",
+    "content": "`covarianceEV_eq_re` proves Cov(A,B) = Re⟪u,v⟫ for the centered vectors u = Aψ−⟨A⟩ψ, v = Bψ−⟨B⟩ψ. Since ⟪v,u⟫ = conj⟪u,v⟫, the symmetric sum ⟪u,v⟫ + ⟪v,u⟫ = 2·Re⟪u,v⟫ expands (reusing the parent's `inner_centered_eq`) to ⟨{A,B}⟩ − 2⟨A⟩⟨B⟩. Halving via `Complex.div_ofNat_re` matches covarianceEV exactly — the real part Robertson never uses."
+  },
+  {
+    "id": "rs-04",
+    "proofId": "cauchy-schwarz-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 123,
+      "endLine": 165
+    },
+    "type": "insight",
+    "title": "Full Cauchy–Schwarz Gives Both Terms at Once",
+    "content": "`robertson_schrodinger_inequality` applies ‖⟪u,v⟫‖ ≤ ‖u‖·‖v‖, squares it, and splits ‖⟪u,v⟫‖² = Re² + Im². The real part is the covariance (Part II); the imaginary part carries the commutator — the parent's identity ⟪u,v⟫ − conj⟪u,v⟫ = ⟨[A,B]⟩ shows [A,B] is purely imaginary with im = 2·Im⟪u,v⟫, so ‖⟨[A,B]⟩‖² = 4·(Im⟪u,v⟫)². Assembling: σ_A²σ_B² ≥ Cov² + (½|⟨[A,B]⟩|)²."
+  },
+  {
+    "id": "rs-05",
+    "proofId": "cauchy-schwarz-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 172,
+      "endLine": 196
+    },
+    "type": "insight",
+    "title": "Robertson is the Corollary; the Gap is Cov²",
+    "content": "`robertson_of_schrodinger` recovers the parent's σ_A·σ_B ≥ ½|⟨[A,B]⟩| by dropping the nonnegative Cov(A,B)² and taking square roots. `schrodinger_gap_nonneg` records the exact improvement: σ_A²σ_B² − (½|⟨[A,B]⟩|)² ≥ Cov(A,B)². Equality in Robertson therefore forces Cov(A,B) = 0 — the strengthening is genuine precisely for correlated observables."
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "cauchy-schwarz-oq-01-oq-01-oq-02-oq-01",
+  "title": "The Robertson–Schrödinger Uncertainty Relation",
+  "slug": "cauchy-schwarz-oq-01-oq-01-oq-02-oq-01",
+  "description": "Strengthens the parent's Robertson inequality to Schrödinger's (1930) sharper relation σ_A²·σ_B² ≥ (½⟨{A,B}⟩ − ⟨A⟩⟨B⟩)² + (½|⟨[A,B]⟩|)² by retaining the real (covariance) part of the Cauchy–Schwarz term that Robertson discards. Proves the covariance identity, the full inequality, and that it dominates Robertson — all 0-axiom on the parent's symmetric-operator API.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Uncertainty_principle#Robertson%E2%80%93Schr%C3%B6dinger_uncertainty_relations",
+    "date": "1930",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "inner-product-spaces",
+      "functional-analysis",
+      "quantum-mechanics",
+      "cauchy-schwarz",
+      "operators",
+      "uncertainty-principle",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ01OQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound). Builds on the parent file's symmetric-operator API.",
+    "lineCount": 194,
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "mathlibDependencies": [
+      {
+        "theorem": "norm_inner_le_norm",
+        "description": "Cauchy-Schwarz inequality: ‖⟪u,v⟫‖ ≤ ‖u‖·‖v‖ — the full-modulus form retaining real and imaginary parts",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "inner_conj_symm",
+        "description": "Conjugate symmetry: star⟪x,y⟫ = ⟪y,x⟫, identifying ⟪v,u⟫ with conj⟪u,v⟫",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "Complex.sq_norm",
+        "description": "‖z‖² = normSq z, expanding the squared modulus into re² + im²",
+        "module": "Mathlib.Data.Complex.Basic"
+      },
+      {
+        "theorem": "Complex.div_ofNat_re",
+        "description": "(z / n).re = z.re / n for numeral n, used to halve the symmetric-sum real part cleanly",
+        "module": "Mathlib.Data.Complex.Basic"
+      },
+      {
+        "theorem": "LinearMap.IsSymmetric",
+        "description": "Self-adjoint operators: ⟪Ax,y⟫ = ⟪x,Ay⟫",
+        "module": "Mathlib.Analysis.InnerProductSpace.Symmetric"
+      }
+    ],
+    "originalContributions": [
+      "anticommutatorEV: the anticommutator expectation value ⟪ψ,(AB+BA)ψ⟫_ℂ",
+      "covarianceEV: the symmetric covariance Cov(A,B) = ½⟨{A,B}⟩ − ⟨A⟩⟨B⟩ that Robertson discards",
+      "covarianceEV_eq_re: the covariance equals the real part of the centered inner product ⟪u,v⟫ — the half of Cauchy–Schwarz Robertson throws away",
+      "robertson_schrodinger_inequality: σ_A²·σ_B² ≥ Cov(A,B)² + (½|⟨[A,B]⟩|)², the full Schrödinger strengthening from the complex modulus |⟪u,v⟫|² = Re² + Im²",
+      "robertson_of_schrodinger: dropping the nonnegative covariance square recovers the parent's Robertson bound, so the strengthening is genuine",
+      "schrodinger_gap_nonneg: the exact gap σ_A²σ_B² − (½|⟨[A,B]⟩|)² ≥ Cov(A,B)² quantifies how much Schrödinger improves on Robertson"
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "**Schrödinger's Uncertainty Relation (1930)**\n\nIn 1929 Robertson proved the general uncertainty inequality $\\Delta A \\cdot \\Delta B \\geq \\frac{1}{2}|\\langle[A,B]\\rangle|$ by applying Cauchy–Schwarz to the centered vectors $u = (A-\\langle A\\rangle)\\psi$ and $v = (B-\\langle B\\rangle)\\psi$ and keeping only the **antisymmetric (imaginary) part** of $\\langle u,v\\rangle$.\n\nOne year later, Erwin Schrödinger observed that Cauchy–Schwarz actually controls the *full* modulus\n$$\\|u\\|^2\\,\\|v\\|^2 \\geq |\\langle u,v\\rangle|^2 = (\\operatorname{Re}\\langle u,v\\rangle)^2 + (\\operatorname{Im}\\langle u,v\\rangle)^2.$$\nThe imaginary part is the commutator (Robertson's term); the **real part is the covariance** $\\tfrac{1}{2}\\langle\\{A,B\\}\\rangle - \\langle A\\rangle\\langle B\\rangle$ — the anticommutator contribution Robertson discards. Retaining it gives the strictly sharper Schrödinger relation\n$$\\sigma_A^2\\,\\sigma_B^2 \\geq \\Big(\\tfrac{1}{2}\\langle\\{A,B\\}\\rangle - \\langle A\\rangle\\langle B\\rangle\\Big)^2 + \\Big(\\tfrac{1}{2}|\\langle[A,B]\\rangle|\\Big)^2,$$\nwhich improves on Robertson whenever the observables are correlated.",
+    "problemStatement": "**Robertson–Schrödinger Uncertainty Relation**\n\nFor symmetric operators A, B on a complex inner product space E and any unit vector ψ (‖ψ‖ = 1):\n$$\\sigma_A^2 \\cdot \\sigma_B^2 \\geq \\operatorname{Cov}(A,B)^2 + \\Big(\\tfrac{1}{2}|\\langle\\psi,[A,B]\\psi\\rangle|\\Big)^2$$\nwhere $\\sigma_A = \\|A\\psi - \\langle A\\rangle\\psi\\|$ and $\\operatorname{Cov}(A,B) = \\tfrac{1}{2}\\langle\\{A,B\\}\\rangle - \\langle A\\rangle\\langle B\\rangle$.\n\nThe parent entry's Robertson bound is the corollary obtained by dropping the nonnegative covariance square.",
+    "text": "Schrödinger's strengthening of the uncertainty principle follows from the same Cauchy–Schwarz step as Robertson — by keeping the real part of the centered inner product instead of discarding it.",
+    "proofStrategy": "1. **Scalar identity** (Part I): For any z ∈ ℂ, ‖z‖² = (Re z)² + (Im z)², via `Complex.sq_norm` + `Complex.normSq_apply`.\n2. **Covariance functional** (Part II): Define anticommutatorEV and covarianceEV, then prove `covarianceEV_eq_re`: Cov(A,B) = Re⟪u,v⟫ for the centered vectors. The sum ⟪u,v⟫ + ⟪v,u⟫ = ⟪u,v⟫ + conj⟪u,v⟫ = 2·Re⟪u,v⟫ equals ⟨{A,B}⟩ − 2⟨A⟩⟨B⟩ after expansion (reusing the parent's centered-inner expansion and the reality of expectation values).\n3. **Full inequality** (Part III): `robertson_schrodinger_inequality`. Apply the full Cauchy–Schwarz ‖⟪u,v⟫‖ ≤ ‖u‖·‖v‖, square it, and rewrite ‖⟪u,v⟫‖² = Re² + Im². Re⟪u,v⟫ is the covariance (Part II); Im⟪u,v⟫ carries the commutator (the parent's antisymmetric identity gives ⟪u,v⟫ − conj⟪u,v⟫ = ⟨[A,B]⟩, so [A,B] is purely imaginary with im = 2·Im⟪u,v⟫).\n4. **Robertson corollary** (Part IV): `robertson_of_schrodinger` drops Cov(A,B)² ≥ 0 and takes square roots; `schrodinger_gap_nonneg` packages the exact gap.",
+    "keyInsights": [
+      "**Robertson discards half of Cauchy–Schwarz.** Cauchy–Schwarz bounds the full modulus |⟪u,v⟫|² = (Re⟪u,v⟫)² + (Im⟪u,v⟫)². Robertson keeps only the imaginary part (the commutator); Schrödinger keeps both. The real part is exactly the covariance.",
+      "**The covariance is the real part of the centered inner product.** ⟪u,v⟫ + ⟪v,u⟫ = 2·Re⟪u,v⟫ because ⟪v,u⟫ = conj⟪u,v⟫, and this symmetric sum expands to ⟨{A,B}⟩ − 2⟨A⟩⟨B⟩ — twice the covariance.",
+      "**The commutator is purely imaginary.** From the parent's identity ⟪u,v⟫ − conj⟪u,v⟫ = ⟨[A,B]⟩, the commutator EV has zero real part and imaginary part 2·Im⟪u,v⟫, so ‖⟨[A,B]⟩‖² = 4·(Im⟪u,v⟫)².",
+      "**Schrödinger strictly dominates Robertson.** σ_A²σ_B² − (½|⟨[A,B]⟩|)² ≥ Cov(A,B)² ≥ 0, so equality in Robertson forces the covariance to vanish: correlated observables obey a strictly tighter bound.",
+      "**No new analytic input.** The strengthening reuses the very same Cauchy–Schwarz application as the parent — the only change is bookkeeping of the real part instead of throwing it away."
+    ],
+    "prerequisites": [
+      "Complex inner product spaces",
+      "Symmetric (self-adjoint) linear operators",
+      "Cauchy-Schwarz inequality (full modulus form)",
+      "Robertson's uncertainty inequality (parent entry)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "modulus-identity",
+      "title": "Part I: Squared-Modulus Identity",
+      "summary": "Private helper cnorm_sq: ‖z‖² = (Re z)² + (Im z)² for z ∈ ℂ, via Complex.sq_norm and Complex.normSq_apply. This is the algebraic split that separates the Robertson (imaginary) and covariance (real) contributions.",
+      "startLine": 42,
+      "endLine": 46,
+      "mathContext": "Cauchy–Schwarz controls $\\|\\langle u,v\\rangle\\|^2$, which the identity $\\|z\\|^2 = (\\operatorname{Re} z)^2 + (\\operatorname{Im} z)^2$ resolves into the covariance square plus the commutator square."
+    },
+    {
+      "id": "covariance-functional",
+      "title": "Part II: The Covariance (Anticommutator) Functional",
+      "summary": "Defines anticommutatorEV A B ψ = ⟪ψ,(AB+BA)ψ⟫ and covarianceEV A B ψ = Re(½⟨{A,B}⟩ − ⟨A⟩⟨B⟩). Proves covarianceEV_eq_re: the covariance equals Re⟪u,v⟫ for the centered vectors u, v.",
+      "startLine": 48,
+      "endLine": 114,
+      "mathContext": "Expanding $\\langle u,v\\rangle + \\langle v,u\\rangle$ (reusing the parent's centered-inner expansion and reality of $\\langle A\\rangle,\\langle B\\rangle$) gives $\\langle\\{A,B\\}\\rangle - 2\\langle A\\rangle\\langle B\\rangle$. Since $\\langle v,u\\rangle = \\overline{\\langle u,v\\rangle}$, the sum is $2\\operatorname{Re}\\langle u,v\\rangle$, so $\\operatorname{Re}\\langle u,v\\rangle = \\tfrac{1}{2}\\langle\\{A,B\\}\\rangle - \\langle A\\rangle\\langle B\\rangle = \\operatorname{Cov}(A,B)$."
+    },
+    {
+      "id": "robertson-schrodinger",
+      "title": "Part III: The Robertson–Schrödinger Inequality",
+      "summary": "Proves robertson_schrodinger_inequality: σ_A²·σ_B² ≥ Cov(A,B)² + (½‖⟨[A,B]⟩‖)². Applies full Cauchy–Schwarz to the centered u, v, squares it, and splits ‖⟪u,v⟫‖² = Re² + Im² with Re = covariance (Part II) and Im carrying the commutator (parent's antisymmetric identity).",
+      "startLine": 116,
+      "endLine": 165,
+      "mathContext": "$\\sigma_A^2\\sigma_B^2 = \\|u\\|^2\\|v\\|^2 \\geq \\|\\langle u,v\\rangle\\|^2 = (\\operatorname{Re}\\langle u,v\\rangle)^2 + (\\operatorname{Im}\\langle u,v\\rangle)^2 = \\operatorname{Cov}(A,B)^2 + \\big(\\tfrac{1}{2}|\\langle[A,B]\\rangle|\\big)^2$, using $\\|\\langle[A,B]\\rangle\\|^2 = 4(\\operatorname{Im}\\langle u,v\\rangle)^2$."
+    },
+    {
+      "id": "robertson-corollary",
+      "title": "Part IV: Robertson is the Weaker Corollary",
+      "summary": "robertson_of_schrodinger drops the nonnegative covariance square and takes square roots to recover the parent's σ_A·σ_B ≥ ½|⟨[A,B]⟩|. schrodinger_gap_nonneg packages the exact improvement: σ_A²σ_B² − (½|⟨[A,B]⟩|)² ≥ Cov(A,B)².",
+      "startLine": 167,
+      "endLine": 198,
+      "mathContext": "Equality in Robertson forces $\\operatorname{Cov}(A,B) = 0$: the Schrödinger relation is strictly sharper precisely when the two observables are correlated in the state ψ."
+    }
+  ],
+  "conclusion": {
+    "summary": "Schrödinger's strengthening of the uncertainty principle is formalized with 0 sorries and 0 axioms, answering the parent's first open question: yes, the tighter covariance-including form can be derived in Lean 4 — from the same Cauchy–Schwarz step, simply by keeping the real part.",
+    "implications": "The covariance term that Robertson discards is recovered exactly, showing the Heisenberg–Robertson bound is non-tight precisely for correlated observables. The proof reuses the parent's entire symmetric-operator API (expVal, stdDev, commutatorEV, the centered-inner expansion, and the antisymmetric commutator identity), demonstrating that the strengthening costs no new analytic machinery.",
+    "openQuestions": [
+      "Can equality conditions for the Schrödinger relation (the squeezed/coherent states) be characterized in Lean?",
+      "Can the relation be specialized to the canonical commutator [x̂,p̂] = iℏ to recover the covariance-corrected position–momentum bound?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Basic",
+      "Mathlib.Analysis.InnerProductSpace.Symmetric",
+      "Mathlib.Analysis.RCLike.Basic",
+      "Mathlib.Tactic",
+      "Proofs.CauchySchwarzOQ01OQ01OQ02"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "Complex"
+    ],
+    "namespace": "CauchySchwarzOQ01OQ01OQ02OQ01",
+    "lineCount": 194,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "path": "Proofs/CauchySchwarzOQ01OQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "E. Schrödinger",
+      "title": "Zum Heisenbergschen Unschärfeprinzip",
+      "year": "1930",
+      "venue": "Sitzungsberichte der Preussischen Akademie der Wissenschaften, Physikalisch-mathematische Klasse 14:296–303",
+      "note": "Original derivation of the covariance-strengthened uncertainty relation"
+    },
+    {
+      "authors": "H. P. Robertson",
+      "title": "The Uncertainty Principle",
+      "year": "1929",
+      "venue": "Physical Review 34(1):163–164",
+      "note": "The weaker commutator-only inequality strengthened here"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent: Robertson's uncertainty inequality. This entry retains the real (covariance) part of the Cauchy–Schwarz term Robertson discards, yielding Schrödinger's sharper relation, and proves Robertson is the corollary."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "uses",
+      "description": "The full-modulus Cauchy–Schwarz inequality ‖⟪u,v⟫‖² ≤ ‖u‖²·‖v‖² is the single analytic input; the strengthening comes from not discarding (Re⟪u,v⟫)²."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "lineCount": 148,
+    "lineCount": 147,
     "theoremCount": 8,
     "definitionCount": 3,
     "mathlibDependencies": [
@@ -146,7 +146,7 @@
       "Complex"
     ],
     "namespace": "CauchySchwarzOQ01OQ01OQ02",
-    "lineCount": 148,
+    "lineCount": 147,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 3,


### PR DESCRIPTION
## Summary

Strengthens the parent entry's **Robertson** uncertainty inequality to **Schrödinger's (1930)** sharper relation — answering the parent's own first listed open question:

$$\sigma_A^2 \cdot \sigma_B^2 \;\geq\; \big(\tfrac{1}{2}\langle\{A,B\}\rangle - \langle A\rangle\langle B\rangle\big)^2 + \big(\tfrac{1}{2}|\langle[A,B]\rangle|\big)^2$$

Robertson applies Cauchy–Schwarz to the centered vectors $u=(A-\langle A\rangle)\psi$, $v=(B-\langle B\rangle)\psi$ and keeps only the **imaginary** part of $\langle u,v\rangle$ (the commutator). But Cauchy–Schwarz controls the **full** modulus $\|\langle u,v\rangle\|^2 = (\operatorname{Re}\langle u,v\rangle)^2 + (\operatorname{Im}\langle u,v\rangle)^2$. The real part is the **covariance** $\tfrac12\langle\{A,B\}\rangle-\langle A\rangle\langle B\rangle$ Robertson discards; keeping it yields Schrödinger's strictly sharper bound.

## What's proved (`CauchySchwarzOQ01OQ01OQ02OQ01.lean`, 194L, 7 thm / 2 def)

- **`anticommutatorEV`, `covarianceEV`** — the covariance functional Robertson throws away
- **`covarianceEV_eq_re`** — $\operatorname{Cov}(A,B) = \operatorname{Re}\langle u,v\rangle$, the discarded half of Cauchy–Schwarz
- **`robertson_schrodinger_inequality`** — the full relation, assembled from $\|\langle u,v\rangle\|^2 = \operatorname{Re}^2 + \operatorname{Im}^2$
- **`robertson_of_schrodinger`** — Robertson is the corollary (drop $\operatorname{Cov}^2 \ge 0$, take roots)
- **`schrodinger_gap_nonneg`** — the exact improvement is $\operatorname{Cov}(A,B)^2$, so equality in Robertson forces zero covariance

Reuses the parent's symmetric-operator API in full (`expVal`, `stdDev`, `commutatorEV`, the centered-inner expansion, the antisymmetric commutator identity) — **no new analytic input**.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CauchySchwarzOQ01OQ01OQ02OQ01` — **build completed successfully**
- `#print axioms` on all four headline theorems: only `propext, Classical.choice, Quot.sound` → **0-axiom, verified**

## Parent repair

The parent `CauchySchwarzOQ01OQ01OQ02.lean` had bit-rotted against Mathlib 4.26.0 (three `simp only` calls with renamed lemmas in `expVal_im_zero`/`expVal_self_conj`). Replaced with stable `Complex.conj_re`/`Complex.conj_im` rewrites and updated its meta `lineCount` (148→147). Parent now builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)