### PR TITLE
research(basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01): axiom-free upper bound bₙ ≤ 64ⁿ and parity of the Apéry numbers [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -225,6 +225,7 @@ import Proofs.BaselProblemOQ01OQ01
 import Proofs.BaselProblemOQ01OQ01OQ02
 import Proofs.BaselProblemOQ01OQ01OQ02Aristotle
 import Proofs.BaselProblemOQ01OQ01OQ02OQ01
+import Proofs.BaselProblemOQ01OQ01OQ02OQ01OQ01
 import Proofs.BaselProblemOQ01OQ01OQ02OQ02
 import Proofs.BaselProblemOQ01OQ01OQ02OQ03
 import Proofs.BaselProblemOQ01OQ03

--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01OQ01.lean
@@ -1,0 +1,158 @@
+import Proofs.BaselProblemOQ01OQ01OQ02OQ01
+import Mathlib.Data.Nat.Choose.Vandermonde
+import Mathlib.Algebra.BigOperators.NatAntidiagonal
+import Mathlib.Tactic
+
+/-
+# Apéry numbers: an axiom-free geometric UPPER bound, and parity
+
+## Context
+The companion file `BaselProblemOQ01OQ01OQ02OQ01.lean` builds the Apéry
+`b`-sequence
+    bₙ = ∑_{k=0}^{n} C(n,k)² · C(n+k,k)²            (1, 5, 73, 1445, 33001, …)
+and proves the **lower** half of the geometric squeeze that drives Apéry's
+irrationality proof for ζ(3): `4ⁿ ≤ bₙ` (and a sharper rate-16 bound).  The
+parent irrationality file `BaselProblemOQ01OQ01OQ02.lean` supplies the
+**upper** half only as an *axiom*: a recurrence-based bound `bₙ ≤ 34ⁿ`.
+
+This file removes the need for that axiom on the elementary side by proving a
+fully self-contained, 0-axiom geometric upper bound, and — separately — pins
+the *parity* of every Apéry number.
+
+## What is proved (all 0-axiom, 0-sorry)
+* `sum_choose_sq` — Vandermonde on the diagonal: `∑_{k} C(n,k)² = C(2n,n)`.
+* `aperyB_le_centralBinom_cube` — `bₙ ≤ C(2n,n)³`.  Every `C(n+k,k)` is
+  dominated by the central coefficient `C(2n,n)`, and the leftover row
+  `∑ C(n,k)²` collapses to `C(2n,n)` by Vandermonde — so no polynomial factor
+  survives.
+* `centralBinom_le_four_pow` — `C(2n,n) ≤ 4ⁿ` (drop to a single term of
+  `∑_i C(2n,i) = 2^{2n}`).
+* `aperyB_le_64_pow` — `bₙ ≤ 64ⁿ`, a clean axiom-free geometric upper bound.
+  Combined with the parent's `4ⁿ ≤ bₙ`, this brackets the exponential base of
+  the Apéry numbers in `[4, 64]` with zero axioms (the true base is the
+  irrational `(1+√2)⁴ = 17+12√2 ≈ 33.97`).
+* `two_dvd_choose_mul` — for `k ≥ 1`, `C(n,k)·C(n+k,k)` is even.  Key identity:
+  the trinomial-revision `C(n,k)·C(n+k,k) = C(n+k,2k)·C(2k,k)` exposes the
+  central factor `C(2k,k)`, which is even for `k ≥ 1`.
+* `aperyB_odd` — **every Apéry number is odd.**  Modulo 2 only the `k = 0`
+  summand (`= 1`) survives; all others carry the even factor above.
+
+Reference: Apéry (1979); van der Poorten, *A proof that Euler missed* (1979).
+-/
+
+open BigOperators Finset Nat
+
+namespace AperyCentralBinom
+
+-- ============================================================================
+-- Vandermonde on the diagonal: the squared binomial row sums to C(2n,n)
+-- ============================================================================
+
+/-- Vandermonde's identity specialised to the diagonal:
+`∑_{k=0}^{n} C(n,k)² = C(2n,n) = centralBinom n`.  (Pair the `k`-th term with the
+`(n-k)`-th term in the antidiagonal expansion of `(n+n).choose n`.) -/
+theorem sum_choose_sq (n : ℕ) :
+    ∑ k ∈ range (n + 1), (n.choose k) ^ 2 = Nat.centralBinom n := by
+  rw [Nat.centralBinom_eq_two_mul_choose, two_mul, Nat.add_choose_eq,
+    Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk]
+  apply Finset.sum_congr rfl
+  intro k hk
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+  rw [Nat.choose_symm hk, pow_two]
+
+-- ============================================================================
+-- The geometric UPPER bound
+-- ============================================================================
+
+/-- `bₙ ≤ C(2n,n)³`.  Each `C(n+k,k)` (for `k ≤ n`) is bounded by the central
+coefficient, and the residual `∑ C(n,k)²` is itself `C(2n,n)` by Vandermonde. -/
+theorem aperyB_le_centralBinom_cube (n : ℕ) :
+    aperyB n ≤ (Nat.centralBinom n) ^ 3 := by
+  have key : aperyB n
+      ≤ ∑ k ∈ range (n + 1), (n.choose k) ^ 2 * (Nat.centralBinom n) ^ 2 := by
+    unfold aperyB
+    apply Finset.sum_le_sum
+    intro k hk
+    rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+    have hb : (n + k).choose k ≤ Nat.centralBinom n :=
+      le_trans (Nat.choose_le_choose k (by omega)) (Nat.choose_le_centralBinom k n)
+    exact Nat.mul_le_mul (Nat.le_refl _) (Nat.pow_le_pow_left hb 2)
+  calc aperyB n
+      ≤ ∑ k ∈ range (n + 1), (n.choose k) ^ 2 * (Nat.centralBinom n) ^ 2 := key
+    _ = (∑ k ∈ range (n + 1), (n.choose k) ^ 2) * (Nat.centralBinom n) ^ 2 := by
+        rw [← Finset.sum_mul]
+    _ = Nat.centralBinom n * (Nat.centralBinom n) ^ 2 := by rw [sum_choose_sq]
+    _ = (Nat.centralBinom n) ^ 3 := by ring
+
+/-- `C(2n,n) ≤ 4ⁿ`.  Drop to a single term of `∑_i C(2n,i) = 2^{2n} = 4ⁿ`. -/
+theorem centralBinom_le_four_pow (n : ℕ) : Nat.centralBinom n ≤ 4 ^ n := by
+  have h : Nat.centralBinom n ≤ 2 ^ (2 * n) := by
+    rw [Nat.centralBinom_eq_two_mul_choose]
+    calc (2 * n).choose n
+        ≤ ∑ i ∈ range (2 * n + 1), (2 * n).choose i :=
+          Finset.single_le_sum (fun i _ => Nat.zero_le _)
+            (Finset.mem_range.mpr (by omega))
+      _ = 2 ^ (2 * n) := Nat.sum_range_choose (2 * n)
+  calc Nat.centralBinom n
+      ≤ 2 ^ (2 * n) := h
+    _ = 4 ^ n := by rw [show (4 : ℕ) = 2 ^ 2 by norm_num, ← pow_mul]
+
+/-- Clean axiom-free geometric upper bound: `bₙ ≤ 64ⁿ`.  With the parent's
+`4ⁿ ≤ bₙ` this brackets the Apéry exponential base in `[4, 64]`. -/
+theorem aperyB_le_64_pow (n : ℕ) : aperyB n ≤ 64 ^ n := by
+  calc aperyB n
+      ≤ (Nat.centralBinom n) ^ 3 := aperyB_le_centralBinom_cube n
+    _ ≤ (4 ^ n) ^ 3 := Nat.pow_le_pow_left (centralBinom_le_four_pow n) 3
+    _ = 64 ^ n := by
+        rw [show (64 : ℕ) = 4 ^ 3 by norm_num, ← pow_mul, ← pow_mul, Nat.mul_comm]
+
+-- ============================================================================
+-- Parity: every Apéry number is odd
+-- ============================================================================
+
+/-- For `k ≥ 1`, the product `C(n,k)·C(n+k,k)` is even.  The trinomial-revision
+identity `C(n,k)·C(n+k,k) = C(n+k,2k)·C(2k,k)` exposes the central binomial
+factor `C(2k,k)`, which is even whenever `k ≥ 1`. -/
+theorem two_dvd_choose_mul (n k : ℕ) (hk : 1 ≤ k) :
+    2 ∣ n.choose k * (n + k).choose k := by
+  -- `choose_mul` with `s = k ≤ 2k` gives the revision identity.
+  have h := Nat.choose_mul (n := n + k) (k := 2 * k) (s := k) (by omega)
+  have e1 : n + k - k = n := by omega
+  have e2 : 2 * k - k = k := by omega
+  rw [e1, e2] at h
+  -- h : (n+k).choose (2*k) * (2*k).choose k = (n+k).choose k * n.choose k
+  have hcentral : 2 ∣ (2 * k).choose k := by
+    have h2 := Nat.two_dvd_centralBinom_of_one_le (n := k) hk
+    rwa [Nat.centralBinom_eq_two_mul_choose] at h2
+  have hdvd : 2 ∣ (n + k).choose k * n.choose k := h ▸ hcentral.mul_left _
+  rw [Nat.mul_comm]
+  exact hdvd
+
+/-- Each summand of `bₙ` with `k ≥ 1` is even (it is the square of an even
+number). -/
+theorem two_dvd_aperyB_term (n k : ℕ) (hk : 1 ≤ k) :
+    2 ∣ (n.choose k) ^ 2 * ((n + k).choose k) ^ 2 := by
+  have h := two_dvd_choose_mul n k hk
+  have hsq : (n.choose k) ^ 2 * ((n + k).choose k) ^ 2
+      = (n.choose k * (n + k).choose k) * (n.choose k * (n + k).choose k) := by ring
+  rw [hsq]
+  exact h.mul_right _
+
+/-- **Every Apéry number is odd.**  Modulo 2 only the `k = 0` term (which is `1`)
+survives; every later term carries the even factor `C(n,k)·C(n+k,k)`. -/
+theorem aperyB_odd (n : ℕ) : Odd (aperyB n) := by
+  unfold aperyB
+  rw [Finset.sum_range_succ']
+  -- peel the `k = 0` term `(C(n,0))²·(C(n,0))² = 1`
+  have h0 : (n.choose 0) ^ 2 * ((n + 0).choose 0) ^ 2 = 1 := by simp
+  rw [h0]
+  have heven : 2 ∣ ∑ k ∈ range n,
+      (n.choose (k + 1)) ^ 2 * ((n + (k + 1)).choose (k + 1)) ^ 2 := by
+    apply Finset.dvd_sum
+    intro k _
+    exact two_dvd_aperyB_term n (k + 1) (Nat.succ_le_succ (Nat.zero_le k))
+  obtain ⟨m, hm⟩ := heven
+  rw [hm]
+  exact ⟨m, by ring⟩
+
+end AperyCentralBinom

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-basel-oq0101020101-context",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 6, "endLine": 41 },
+    "type": "concept",
+    "title": "Closing the parent's two open questions, axiom-free",
+    "content": "The parent companion pinned the Apéry numbers bₙ = ∑ C(n,k)²·C(n+k,k)² from below (4ⁿ ≤ bₙ) but left two things open and axiom-free: a matching geometric UPPER bound, and the parity of bₙ. The grandparent ζ(3) irrationality file supplies the upper half only as an axiom (bₙ ≤ 34ⁿ). This file removes the need for that axiom on the elementary side — proving bₙ ≤ 64ⁿ from scratch — and shows every Apéry number is odd. Together with 4ⁿ ≤ bₙ the exponential base is now bracketed in [4, 64] with zero axioms; the true base is the irrational (1+√2)⁴ = 17+12√2 ≈ 33.97.",
+    "mathContext": "$4^n\\le b_n\\le 64^n$ and $b_n$ odd, both with $0$ axioms."
+  },
+  {
+    "id": "ann-basel-oq0101020101-vandermonde",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 51, "endLine": 61 },
+    "type": "key-step",
+    "title": "Vandermonde on the diagonal keeps the bound geometric",
+    "content": "sum_choose_sq proves ∑_{k≤n} C(n,k)² = C(2n,n). Writing centralBinom n = (n+n).choose n and expanding over the antidiagonal (Nat.add_choose_eq) produces ∑ C(n,k)·C(n,n-k); pairing each term with its mirror via Nat.choose_symm turns it into ∑ C(n,k)². This exact cancellation is what stops the upper bound from leaking an n-fold polynomial factor: the squared-binomial row is precisely the central coefficient, not merely bounded by it.",
+    "mathContext": "$\\sum_{k=0}^n\\binom{n}{k}^2=\\sum_k\\binom{n}{k}\\binom{n}{n-k}=\\binom{2n}{n}.$"
+  },
+  {
+    "id": "ann-basel-oq0101020101-upper",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 107 },
+    "type": "technique",
+    "title": "bₙ ≤ C(2n,n)³ ≤ 64ⁿ",
+    "content": "aperyB_le_centralBinom_cube bounds each factor C(n+k,k) (for k ≤ n) by the central coefficient C(2n,n) — via Nat.choose_le_choose then Nat.choose_le_centralBinom — so bₙ ≤ ∑ C(n,k)²·C(2n,n)² = (∑ C(n,k)²)·C(2n,n)² = C(2n,n)·C(2n,n)² = C(2n,n)³ using the Vandermonde collapse. Then centralBinom_le_four_pow gives C(2n,n) ≤ 4ⁿ by keeping a single term of ∑_i C(2n,i) = 2^(2n), and aperyB_le_64_pow chains to bₙ ≤ (4ⁿ)³ = 64ⁿ — a fully axiom-free geometric upper bound.",
+    "mathContext": "$b_n\\le\\binom{2n}{n}^3\\le(4^n)^3=64^n.$"
+  },
+  {
+    "id": "ann-basel-oq0101020101-parity",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 113, "endLine": 156 },
+    "type": "key-step",
+    "title": "Every Apéry number is odd, via trinomial revision",
+    "content": "two_dvd_choose_mul shows C(n,k)·C(n+k,k) is even for k ≥ 1: the subset-of-a-subset identity Nat.choose_mul, instantiated at C(n+k,2k)·C(2k,k) = C(n+k,k)·C(n,k), exposes the central binomial factor C(2k,k), even for k ≥ 1 (Nat.two_dvd_centralBinom_of_one_le). Each summand of bₙ is the square of this product, hence also even (two_dvd_aperyB_term). aperyB_odd then peels the k = 0 term (= 1) with Finset.sum_range_succ' and absorbs the even remainder: bₙ ≡ 1 (mod 2).",
+    "mathContext": "$\\binom{n}{k}\\binom{n+k}{k}=\\binom{n+k}{2k}\\binom{2k}{k}$, and $2\\mid\\binom{2k}{k}$ for $k\\ge1$."
+  },
+  {
+    "id": "ann-basel-oq0101020101-bracket",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 107 },
+    "type": "observation",
+    "title": "A two-sided geometric bracket with no axioms",
+    "content": "Combining aperyB_le_64_pow with the parent's four_pow_le_aperyB gives 4ⁿ ≤ bₙ ≤ 64ⁿ entirely without axioms. On the elementary side this makes the grandparent ζ(3) file's axiomatic bₙ ≤ 34ⁿ unnecessary for establishing geometric growth. The gap between the crude base 64 and the true 17+12√2 ≈ 33.97 comes from bounding every C(n+k,k) by C(2n,n) uniformly rather than near the dominant index k ≈ 0.8n — the natural next sharpening.",
+    "mathContext": "$4^n\\le b_n\\le 64^n$; true base $(1+\\sqrt2)^4=17+12\\sqrt2\\approx 33.97$."
+  }
+]

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01",
+  "slug": "basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01",
+  "title": "Apéry Numbers: an Axiom-Free Geometric Upper Bound, and Parity",
+  "description": "A self-contained, axiom-free companion that answers two open questions left by its parent (basel-problem-oq-01-oq-01-oq-02-oq-01). That entry pinned the Apéry numbers bₙ = ∑ C(n,k)²·C(n+k,k)² from BELOW (4ⁿ ≤ bₙ) but left the matching axiom-free UPPER bound and the parity statement open; the grandparent ζ(3) irrationality file supplies the upper half only as an axiom (bₙ ≤ 34ⁿ). This file removes the need for that axiom on the elementary side: bounding every C(n+k,k) by the central coefficient C(2n,n) and collapsing the residual row ∑ C(n,k)² = C(2n,n) by Vandermonde gives bₙ ≤ C(2n,n)³, and C(2n,n) ≤ 4ⁿ then yields the clean geometric upper bound bₙ ≤ 64ⁿ. Combined with the parent's 4ⁿ ≤ bₙ this brackets the exponential base of the Apéry numbers in [4, 64] with zero axioms (the true base is the irrational (1+√2)⁴ = 17+12√2 ≈ 33.97). Separately, the trinomial-revision identity C(n,k)·C(n+k,k) = C(n+k,2k)·C(2k,k) exposes the even central factor C(2k,k) for k ≥ 1, so modulo 2 only the k = 0 summand survives: every Apéry number is odd.",
+  "meta": {
+    "author": "Lean Genius Researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ01OQ01OQ02OQ01OQ01.lean",
+    "tags": [
+      "apery",
+      "zeta-3",
+      "central-binomial",
+      "vandermonde",
+      "parity",
+      "irrationality",
+      "number-theory",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 159,
+    "theoremCount": 7,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. Verified via #print axioms: aperyB_le_64_pow, aperyB_odd, aperyB_le_centralBinom_cube and two_dvd_choose_mul each depend only on the standard foundational axioms propext / Classical.choice / Quot.sound — no Lean.ofReduceBool, no sorryAx. The Apéry numbers bₙ are inherited from the parent companion (also axiom-free), so none of the five axioms of the grandparent ζ(3) irrationality file enter the dependency graph.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.add_choose_eq",
+        "description": "Vandermonde: (m+n).choose k = ∑ over the antidiagonal of C(m,i)·C(n,j)",
+        "module": "Mathlib.Data.Nat.Choose.Vandermonde"
+      },
+      {
+        "theorem": "Nat.centralBinom_eq_two_mul_choose",
+        "description": "centralBinom n = (2n).choose n",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.choose_le_centralBinom",
+        "description": "C(n+k,k) ≤ C(2n,n): the central coefficient dominates",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.choose_mul",
+        "description": "C(n,k)·C(k,s) = C(n,s)·C(n-s,k-s): the subset-of-a-subset (trinomial revision) identity",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.two_dvd_centralBinom_of_one_le",
+        "description": "C(2k,k) is even for k ≥ 1",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.sum_range_choose",
+        "description": "∑_{i≤2n} C(2n,i) = 2^(2n)",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      }
+    ],
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.BaselProblemOQ01OQ01OQ02OQ01",
+      "Mathlib.Data.Nat.Choose.Vandermonde",
+      "Mathlib.Algebra.BigOperators.NatAntidiagonal",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["BigOperators", "Finset", "Nat"],
+    "namespace": "AperyCentralBinom",
+    "lineCount": 159,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "aperyB_le_64_pow",
+      "type": "core",
+      "statement": "aperyB n ≤ 64 ^ n",
+      "description": "A clean, fully axiom-free geometric upper bound on the Apéry numbers. With the parent's 4ⁿ ≤ bₙ it brackets the exponential base of bₙ in [4, 64].",
+      "significance": "Answers the parent's open question of a matching axiom-free upper bound bₙ ≤ Cⁿ, removing the need for the grandparent ζ(3) file's axiomatic bₙ ≤ 34ⁿ on the elementary side."
+    },
+    {
+      "name": "aperyB_le_centralBinom_cube",
+      "type": "core",
+      "statement": "aperyB n ≤ (Nat.centralBinom n) ^ 3",
+      "description": "The structural upper bound: each C(n+k,k) is dominated by the central coefficient C(2n,n), and the residual row ∑ C(n,k)² is itself C(2n,n) by Vandermonde — so no polynomial factor survives.",
+      "significance": "Reduces the intricate Apéry upper bound to pure central-binomial growth, the engine behind the geometric 64ⁿ estimate."
+    },
+    {
+      "name": "sum_choose_sq",
+      "type": "supporting",
+      "statement": "∑ k ∈ range (n+1), (n.choose k)^2 = Nat.centralBinom n",
+      "description": "Vandermonde's identity on the diagonal: pairing the k-th term with the (n-k)-th in the antidiagonal expansion of (n+n).choose n collapses ∑ C(n,k)² to C(2n,n).",
+      "significance": "The exact cancellation that prevents an n-fold polynomial loss in the upper bound; the squared-binomial row sum is precisely the central coefficient."
+    },
+    {
+      "name": "two_dvd_choose_mul",
+      "type": "core",
+      "statement": "1 ≤ k → 2 ∣ n.choose k * (n + k).choose k",
+      "description": "For k ≥ 1 the product C(n,k)·C(n+k,k) is even. The trinomial-revision identity C(n,k)·C(n+k,k) = C(n+k,2k)·C(2k,k) exposes the central binomial factor C(2k,k), which is even for k ≥ 1.",
+      "significance": "The parity engine: it makes every Apéry summand with k ≥ 1 even, so only the k = 0 term survives modulo 2."
+    },
+    {
+      "name": "aperyB_odd",
+      "type": "core",
+      "statement": "Odd (aperyB n)",
+      "description": "Every Apéry number is odd. Modulo 2 only the k = 0 summand (which equals 1) survives; all later terms carry the even factor C(n,k)·C(n+k,k).",
+      "significance": "Answers the parent's open question on parity, a clean arithmetic invariant of the entire Apéry sequence 1, 5, 73, 1445, 33001, …."
+    }
+  ],
+  "sections": [
+    {
+      "id": "vandermonde-diagonal",
+      "title": "Section I: Vandermonde on the diagonal",
+      "startLine": 47,
+      "endLine": 61,
+      "summary": "sum_choose_sq: ∑_{k≤n} C(n,k)² = C(2n,n). Expand (n+n).choose n over the antidiagonal (Nat.add_choose_eq) and pair the k-th and (n-k)-th factors via Nat.choose_symm.",
+      "mathContext": "$\\sum_{k=0}^n\\binom{n}{k}^2=\\binom{2n}{n}$, the diagonal case of Vandermonde's convolution."
+    },
+    {
+      "id": "geometric-upper",
+      "title": "Section II: The geometric upper bound",
+      "startLine": 63,
+      "endLine": 107,
+      "summary": "aperyB_le_centralBinom_cube: bound each C(n+k,k) ≤ C(2n,n) and collapse ∑ C(n,k)² = C(2n,n), giving bₙ ≤ C(2n,n)³. centralBinom_le_four_pow: C(2n,n) ≤ 4ⁿ from a single term of ∑_i C(2n,i) = 2^(2n). aperyB_le_64_pow: chain to bₙ ≤ (4ⁿ)³ = 64ⁿ.",
+      "mathContext": "$b_n\\le\\binom{2n}{n}^3\\le(4^n)^3=64^n$, bracketing the growth base in $[4,64]$."
+    },
+    {
+      "id": "parity",
+      "title": "Section III: Every Apéry number is odd",
+      "startLine": 109,
+      "endLine": 156,
+      "summary": "two_dvd_choose_mul: the revision identity C(n,k)·C(n+k,k) = C(n+k,2k)·C(2k,k) makes the product even for k ≥ 1. two_dvd_aperyB_term: each k ≥ 1 summand is its square, hence even. aperyB_odd: peel the k = 0 term (= 1) with Finset.sum_range_succ' and absorb the even remainder.",
+      "mathContext": "Modulo 2, $b_n\\equiv\\binom{n}{0}^2\\binom{n}{0}^2=1$, so $b_n$ is odd."
+    }
+  ],
+  "conclusion": {
+    "summary": "Two open questions of the parent companion are settled, both 0-axiom and 0-sorry. (1) The matching axiom-free geometric UPPER bound: bₙ ≤ C(2n,n)³ ≤ 64ⁿ, obtained by dominating every C(n+k,k) by the central coefficient and using Vandermonde to collapse the residual squared-binomial row to C(2n,n) — no polynomial factor survives. With the parent's 4ⁿ ≤ bₙ this brackets the Apéry exponential base in [4, 64] without any axioms. (2) Parity: every Apéry number is odd, via the trinomial-revision identity C(n,k)·C(n+k,k) = C(n+k,2k)·C(2k,k) whose central factor C(2k,k) is even for k ≥ 1, leaving only the k = 0 term modulo 2.",
+    "implications": "On the elementary side this dispenses with the grandparent ζ(3) irrationality file's axiomatic upper bound bₙ ≤ 34ⁿ: a self-contained two-sided geometric estimate 4ⁿ ≤ bₙ ≤ 64ⁿ now holds with zero axioms. The Vandermonde collapse ∑ C(n,k)² = C(2n,n) is what keeps the upper bound geometric rather than merely sub-exponential, and the parity result is a clean arithmetic invariant of the full sequence.",
+    "openQuestions": [
+      "Tighten the upper constant from 64 toward the true base 17+12√2 ≈ 33.97 by bounding C(n+k,k) more carefully near the dominant index k ≈ 0.8n rather than uniformly by C(2n,n).",
+      "Determine the Apéry numbers modulo higher powers of 2 (or modulo small primes p) — e.g. bₙ mod 8, extending the k = 0 survival argument with sharper Kummer/Lucas valuations of C(2k,k)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-01-oq-01-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "The parent proves the geometric LOWER bound 4ⁿ ≤ bₙ axiom-free and explicitly lists the matching axiom-free upper bound and the parity statement as open; this child proves both."
+    },
+    {
+      "targetId": "basel-problem-oq-01-oq-01-oq-02",
+      "relationship": "ancestor",
+      "description": "The grandparent formalizes Apéry's proof of ζ(3) irrationality from five axioms, one of which is the upper bound bₙ ≤ 34ⁿ; this entry replaces the need for it on the elementary side with bₙ ≤ 64ⁿ."
+    },
+    {
+      "targetId": "basel-problem-oq-01-oq-01-oq-02-oq-03",
+      "relationship": "related",
+      "description": "A sibling targeting Hanson's bound lcm(1,…,n) ≤ 3ⁿ, the denominator-side growth ingredient of the same irrationality squeeze."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A self-contained, **0-axiom / 0-sorry** companion that settles the two open questions left by its parent (`basel-problem-oq-01-oq-01-oq-02-oq-01`), which pinned the Apéry numbers bₙ = ∑ C(n,k)²·C(n+k,k)² from below (4ⁿ ≤ bₙ) but left the matching upper bound and the parity statement open. The grandparent ζ(3) irrationality file supplies the upper half only as an **axiom** (bₙ ≤ 34ⁿ); this file removes the need for it on the elementary side.

## What is proved

- **`sum_choose_sq`** — Vandermonde on the diagonal: ∑_{k≤n} C(n,k)² = C(2n,n).
- **`aperyB_le_centralBinom_cube`** — bₙ ≤ C(2n,n)³. Each C(n+k,k) is dominated by the central coefficient; the residual squared-binomial row collapses to C(2n,n) by Vandermonde, so **no polynomial factor survives**.
- **`centralBinom_le_four_pow`** — C(2n,n) ≤ 4ⁿ (single term of ∑ C(2n,i) = 2^{2n}).
- **`aperyB_le_64_pow`** — **bₙ ≤ 64ⁿ**, a clean axiom-free geometric upper bound. With the parent's 4ⁿ ≤ bₙ this brackets the Apéry exponential base in **[4, 64]** with zero axioms (true base (1+√2)⁴ = 17+12√2 ≈ 33.97).
- **`two_dvd_choose_mul`** — for k ≥ 1, C(n,k)·C(n+k,k) is even, via the trinomial-revision identity C(n,k)·C(n+k,k) = C(n+k,2k)·C(2k,k) exposing the even central factor C(2k,k).
- **`aperyB_odd`** — **every Apéry number is odd**: modulo 2 only the k = 0 summand (= 1) survives.

## Verification

- Builds against Mathlib 4.26.0 via `docker-build.sh`.
- `#print axioms` on the headline results returns only `propext`, `Classical.choice`, `Quot.sound` — no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`.
- The Apéry numbers are inherited from the parent (also axiom-free), so none of the grandparent ζ(3) file's five axioms enter the dependency graph.

## Honest scope

The upper constant 64 is crude (true base ≈ 33.97) because C(n+k,k) is bounded uniformly by C(2n,n) rather than near the dominant index k ≈ 0.8n — flagged as the natural next sharpening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)