### PR TITLE
research: Hadwiger-Nelson χ(ℝ²) ≤ 7 fully verified — prove covering_radius [0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos643StarLowerBound.lean
+++ b/proofs/Proofs/Erdos643StarLowerBound.lean
@@ -1,0 +1,225 @@
+/-
+# Erdős Problem #643 — A general-`t` lower bound via the full star
+
+Erdős Problem #643 concerns the extremal function `f(n,t)`: the least number of
+edges forcing any `t`-uniform hypergraph on `n` vertices to contain a *crossed
+pair*, i.e. four edges `A, B, C, D` with
+
+  `A ∪ B = C ∪ D`   and   `A ∩ B = C ∩ D = ∅`   and   `{A,B} ≠ {C,D}`.
+
+The conjecture (OPEN for `t ≥ 3`) is `f(n,t) = (1 + o(1))·C(n,t-1)`.
+
+The parent formalization `Erdos643Problem.lean` establishes the `t = 3` lower
+bound `f(n,3) ≥ C(n-1,2) + ⌊(n-1)/3⌋` via a Star ∪ Matching construction, but
+leaves the **general** lower bound `f(n,t) ≥ C(n-1,t-1) + ⌊(n-1)/t⌋` as a `sorry`.
+
+This file isolates the *dominant term* of that lower bound, axiom-free, for
+**every** `t ≥ 1`. The construction is the **full star** `St₀ = { e : e.card = t,
+0 ∈ e }`: all `t`-subsets through a fixed vertex `0`. Any two of its edges share
+`0`, hence are never disjoint, so the star contains no crossed pair. It has
+exactly `C(n-1,t-1)` edges, giving
+
+  `f(n,t) ≥ C(n-1,t-1) + 1`     (for all `t ≥ 1`, `n ≥ 1`).
+
+We further prove the exact binomial identity `(n-k)·C(n,k) = n·C(n-1,k)` and use
+it to show `C(n-1,t-1)/C(n,t-1) → 1`, i.e. the star is the **asymptotically
+optimal** construction for the lower bound:
+
+  `f(n,t) ≥ (1 + o(1))·C(n,t-1)`.
+
+This delivers the lower half of the conjecture's main term for all `t`; the
+second-order matching term `⌊(n-1)/t⌋` and the matching upper bound remain open
+(axiomatized / `sorry` in the parent).
+
+Self-contained (the parent file does not currently build against Mathlib 4.26.0),
+re-declaring the minimal definitions with identical semantics to `Erdos643Problem`.
+
+Reference: https://erdosproblems.com/643
+-/
+
+import Mathlib
+
+namespace Erdos643Star
+
+open Finset
+open scoped Classical
+
+/-! ## Definitions (identical semantics to the parent `Erdos643Problem`) -/
+
+/-- A hypergraph is a collection of edges (finite subsets of vertices). -/
+abbrev Hypergraph (V : Type*) := Set (Finset V)
+
+/-- A hypergraph is `t`-uniform if every edge has exactly `t` vertices. -/
+def IsUniform {V : Type*} (H : Hypergraph V) (t : ℕ) : Prop :=
+  ∀ e, e ∈ H → e.card = t
+
+/-- The number of edges in a hypergraph. -/
+noncomputable def edgeCount {V : Type*} (H : Hypergraph V) : ℕ := H.ncard
+
+/-- Four edges form a *crossed pair*: same union, both pairs disjoint, and the
+unordered pairs differ. -/
+def IsCrossedPair {V : Type*} (A B C D : Finset V) : Prop :=
+  A ∪ B = C ∪ D ∧ A ∩ B = ∅ ∧ C ∩ D = ∅ ∧ ({A, B} : Set (Finset V)) ≠ {C, D}
+
+/-- A hypergraph contains a crossed pair. -/
+def HasCrossedPair {V : Type*} (H : Hypergraph V) : Prop :=
+  ∃ A B C D : Finset V, A ∈ H ∧ B ∈ H ∧ C ∈ H ∧ D ∈ H ∧ IsCrossedPair A B C D
+
+/-- There is a `t`-uniform crossed-pair-free hypergraph on `Fin n` with exactly
+`k` edges. -/
+def CrossedPairFreeWithEdges (n t k : ℕ) : Prop :=
+  ∃ H : Hypergraph (Fin n), IsUniform H t ∧ edgeCount H = k ∧ ¬HasCrossedPair H
+
+/-- The extremal function: the least `m` such that every `t`-uniform hypergraph on
+`n` vertices with `≥ m` edges contains a crossed pair. Well-defined because the
+number of `t`-subsets is `C(n,t)`, so no crossed-pair-free family can have more
+than `C(n,t)` edges. -/
+noncomputable def f (n t : ℕ) : ℕ :=
+  Nat.find (⟨Nat.choose n t + 1, by
+    rintro k hk ⟨H, hUnif, hCard, -⟩
+    have hsub : H ⊆ ↑(Finset.powersetCard t (Finset.univ : Finset (Fin n))) := by
+      intro e he
+      rw [Finset.mem_coe, Finset.mem_powersetCard]
+      exact ⟨Finset.subset_univ e, hUnif e he⟩
+    have hle : H.ncard ≤ Nat.choose n t := by
+      refine le_trans (Set.ncard_le_ncard hsub
+        (Finset.powersetCard t Finset.univ).finite_toSet) ?_
+      rw [Set.ncard_coe_finset, Finset.card_powersetCard, Finset.card_univ,
+        Fintype.card_fin]
+    unfold edgeCount at hCard
+    omega⟩ : ∃ m, ∀ k ≥ m, ¬CrossedPairFreeWithEdges n t k)
+
+/-! ## The full star construction -/
+
+/-- The **full star** at vertex `0`: all `t`-element edges containing `0`. -/
+def starHypergraph (n t : ℕ) [NeZero n] : Hypergraph (Fin n) :=
+  { e | e.card = t ∧ (0 : Fin n) ∈ e }
+
+/-- The star is `t`-uniform. -/
+lemma starHypergraph_isUniform (n t : ℕ) [NeZero n] :
+    IsUniform (starHypergraph n t) t :=
+  fun _ he => he.1
+
+/-- The star has no crossed pair: any two edges both contain `0`, so they are
+never disjoint, contradicting `A ∩ B = ∅`. -/
+lemma starHypergraph_noCrossedPair (n t : ℕ) [NeZero n] :
+    ¬HasCrossedPair (starHypergraph n t) := by
+  rintro ⟨A, B, _, _, hA, hB, _, _, _, hAB, _, _⟩
+  have hA0 : (0 : Fin n) ∈ A := hA.2
+  have hB0 : (0 : Fin n) ∈ B := hB.2
+  simp_all +decide [Finset.ext_iff]
+
+/-- The star has exactly `C(n-1,t-1)` edges. -/
+lemma starHypergraph_card (n t : ℕ) [NeZero n] (ht : 1 ≤ t) :
+    edgeCount (starHypergraph n t) = Nat.choose (n - 1) (t - 1) := by
+  unfold edgeCount starHypergraph
+  rw [show {e : Finset (Fin n) | e.card = t ∧ (0 : Fin n) ∈ e}
+        = ↑(Finset.image (fun s : Finset (Fin n) => insert (0 : Fin n) s)
+            (Finset.powersetCard (t - 1) ((Finset.univ : Finset (Fin n)).erase 0)))
+        from ?_]
+  · rw [Set.ncard_coe_finset, Finset.card_image_of_injOn]
+    · rw [Finset.card_powersetCard, Finset.card_erase_of_mem (Finset.mem_univ _),
+        Finset.card_univ, Fintype.card_fin]
+    · intro s hs t' ht' hst
+      rw [Finset.mem_coe, Finset.mem_powersetCard] at hs ht'
+      have h0s : (0 : Fin n) ∉ s := fun h => (Finset.mem_erase.mp (hs.1 h)).1 rfl
+      have h0t : (0 : Fin n) ∉ t' := fun h => (Finset.mem_erase.mp (ht'.1 h)).1 rfl
+      have := congrArg (fun u => Finset.erase u (0 : Fin n)) hst
+      simpa [Finset.erase_insert h0s, Finset.erase_insert h0t] using this
+  · ext e
+    simp only [Set.mem_setOf_eq, Finset.coe_image, Set.mem_image, Finset.mem_coe,
+      Finset.mem_powersetCard]
+    constructor
+    · rintro ⟨hcard, h0⟩
+      exact ⟨e.erase 0,
+        ⟨fun x hx => Finset.mem_erase.mpr ⟨(Finset.mem_erase.mp hx).1, Finset.mem_univ x⟩,
+          by rw [Finset.card_erase_of_mem h0, hcard]⟩,
+        Finset.insert_erase h0⟩
+    · rintro ⟨s, ⟨hssub, hscard⟩, rfl⟩
+      have h0s : (0 : Fin n) ∉ s := fun h => (Finset.mem_erase.mp (hssub h)).1 rfl
+      exact ⟨by rw [Finset.card_insert_of_notMem h0s, hscard]; omega,
+        Finset.mem_insert_self 0 s⟩
+
+/-- The star witnesses a crossed-pair-free family with `C(n-1,t-1)` edges. -/
+lemma star_crossedPairFree (n t : ℕ) [NeZero n] (ht : 1 ≤ t) :
+    CrossedPairFreeWithEdges n t (Nat.choose (n - 1) (t - 1)) :=
+  ⟨starHypergraph n t, starHypergraph_isUniform n t,
+    starHypergraph_card n t ht, starHypergraph_noCrossedPair n t⟩
+
+/-! ## The general-`t` lower bound -/
+
+/-- **Main result.** For every `t ≥ 1` and `n ≥ 1`,
+`f(n,t) ≥ C(n-1,t-1) + 1`. The full star at `0` is a crossed-pair-free family
+with `C(n-1,t-1)` edges, so any family forced to contain a crossed pair must be
+strictly larger. -/
+theorem f_ge_star (n t : ℕ) (ht : 1 ≤ t) (hn : 1 ≤ n) :
+    Nat.choose (n - 1) (t - 1) + 1 ≤ f n t := by
+  haveI : NeZero n := ⟨by omega⟩
+  unfold f
+  rw [Nat.le_find_iff]
+  intro m hm hp
+  exact hp (Nat.choose (n - 1) (t - 1)) (by omega) (star_crossedPairFree n t ht)
+
+/-- The lower bound in the form matching the parent's `f_lower_bound` signature
+(`t ≥ 2`, `n ≥ t`): `f(n,t) ≥ C(n-1,t-1) + 1`, the main term of the conjectured
+lower bound, now for all `t ≥ 2`. -/
+theorem f_ge_main_term (n t : ℕ) (ht : 2 ≤ t) (hn : t ≤ n) :
+    Nat.choose (n - 1) (t - 1) + 1 ≤ f n t :=
+  f_ge_star n t (by omega) (by omega)
+
+/-- Specialization to `t = 3`: `f(n,3) ≥ C(n-1,2) + 1`. This recovers the main
+term of the parent's `f_three_lower_bound = C(n-1,2) + ⌊(n-1)/3⌋` (the parent's
+extra `⌊(n-1)/3⌋` matching term is a strictly second-order improvement). -/
+theorem f_three_ge_main_term (n : ℕ) (hn : 3 ≤ n) :
+    Nat.choose (n - 1) 2 + 1 ≤ f n 3 :=
+  f_ge_main_term n 3 (by norm_num) hn
+
+/-! ## Asymptotic optimality of the star bound -/
+
+/-- The exact "column" identity for binomial coefficients:
+`(n - k)·C(n,k) = n·C(n-1,k)` for `n ≥ 1`. Combining the Pascal-type recurrences
+`succ_mul_choose_eq` and `choose_succ_right_eq`. -/
+theorem choose_pred_identity (n k : ℕ) (hn : 1 ≤ n) :
+    (n - k) * Nat.choose n k = n * Nat.choose (n - 1) k := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  simp only [Nat.add_sub_cancel]
+  have h1 := Nat.add_one_mul_choose_eq m k
+  have h2 := Nat.choose_succ_right_eq (m + 1) k
+  rw [h1, h2]
+  ring
+
+/-- The ratio `C(n-1,t-1)/C(n,t-1)` tends to `1`: the full star captures the
+asymptotically dominant term of the lower bound. Equivalently
+`f(n,t) ≥ (1 + o(1))·C(n,t-1)`, the lower half of the Erdős #643 conjecture's
+main term, for every fixed `t ≥ 1`. -/
+theorem star_ratio_tendsto (t : ℕ) (ht : 1 ≤ t) :
+    Filter.Tendsto
+      (fun n : ℕ => (Nat.choose (n - 1) (t - 1) : ℝ) / Nat.choose n (t - 1))
+      Filter.atTop (nhds 1) := by
+  have hden : Filter.Tendsto (fun n : ℕ => (↑n : ℝ)) Filter.atTop Filter.atTop :=
+    tendsto_natCast_atTop_atTop
+  have hzero : Filter.Tendsto (fun n : ℕ => (↑(t - 1) : ℝ) / (↑n))
+      Filter.atTop (nhds 0) :=
+    Filter.Tendsto.div_atTop tendsto_const_nhds hden
+  have hlim : Filter.Tendsto (fun n : ℕ => 1 - (↑(t - 1) : ℝ) / (↑n))
+      Filter.atTop (nhds (1 - 0)) :=
+    Filter.Tendsto.const_sub 1 hzero
+  rw [sub_zero] at hlim
+  refine Filter.Tendsto.congr' ?_ hlim
+  filter_upwards [Filter.eventually_ge_atTop t] with n hn
+  have ha : t - 1 ≤ n := by omega
+  have hn1 : 1 ≤ n := by omega
+  have hCpos : (0 : ℝ) < Nat.choose n (t - 1) := by
+    exact_mod_cast Nat.choose_pos ha
+  have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn1
+  have hid := choose_pred_identity n (t - 1) hn1
+  have hsub : ((n - (t - 1) : ℕ) : ℝ) = (n : ℝ) - ((t - 1 : ℕ) : ℝ) := by
+    rw [Nat.cast_sub ha]
+  have hRHS : (Nat.choose (n - 1) (t - 1) : ℝ) / (Nat.choose n (t - 1) : ℝ)
+      = ((n : ℝ) - ((t - 1 : ℕ) : ℝ)) / (n : ℝ) := by
+    rw [div_eq_div_iff hCpos.ne' hnpos.ne', ← hsub,
+      mul_comm (Nat.choose (n - 1) (t - 1) : ℝ) (n : ℝ)]
+    exact_mod_cast hid.symm
+  rw [hRHS, sub_div, div_self hnpos.ne']
+
+end Erdos643Star

--- a/proofs/Proofs/UnitDistanceHN7.lean
+++ b/proofs/Proofs/UnitDistanceHN7.lean
@@ -93,12 +93,12 @@ theorem color_sublattice_min_norm (da db : ℤ)
       (2 * da - 5 * m) ^ 2 + 3 * m ^ 2 := by ring
   by_cases hm0 : m = 0
   · subst hm0
-    have hda : da ≠ 0 := by intro h; apply hne; constructor <;> simp_all
-    have : 0 < da ^ 2 := sq_pos_of_ne_zero da hda
+    have hda : da ≠ 0 := by rintro rfl; exact hne (by simp_all)
+    have : 0 < da ^ 2 := sq_pos_of_ne_zero hda
     set Q' := da ^ 2 - 5 * da * 0 + 7 * 0 ^ 2
     omega
   · have hm2 : m ^ 2 ≥ 1 := by
-      have := sq_pos_of_ne_zero m hm0; omega
+      have := sq_pos_of_ne_zero hm0; omega
     set Q' := da ^ 2 - 5 * da * m + 7 * m ^ 2
     have : 4 * Q' ≥ 3 := by nlinarith [sq_nonneg (2 * da - 5 * m)]
     omega
@@ -107,15 +107,295 @@ theorem color_sublattice_min_norm (da db : ℤ)
 -- Part III: Geometric Lemmas
 -- ============================================================================
 
+/-- Position in the plane with real axial coordinates `(q, r)`:
+    `pos(q,r) = q·e₁ + r·e₂ = (s√3·(q + r/2), 3s/2·r)`.
+    Generalizes `hexCenter` to real (non-integer) coordinates. -/
+def hexPos (q r : ℝ) : Plane :=
+  (EuclideanSpace.equiv (Fin 2) ℝ).symm
+    ![hexSideLength * Real.sqrt 3 * (q + r / 2),
+      3 * hexSideLength / 2 * r]
+
+/-- A point equals the `hexPos` of its own axial coordinates: the axial maps
+    `axialQ, axialR` invert the basis map `hexPos`. -/
+theorem hexPos_axial (p : Plane) : hexPos (axialQ p) (axialR p) = p := by
+  have hs : (hexSideLength : ℝ) ≠ 0 :=
+    (by norm_num [hexSideLength] : (0 : ℝ) < hexSideLength).ne'
+  have h3 : Real.sqrt 3 ≠ 0 := (by positivity : (0 : ℝ) < Real.sqrt 3).ne'
+  ext i
+  fin_cases i
+  · show hexSideLength * Real.sqrt 3 * (axialQ p + axialR p / 2) = p 0
+    simp only [axialQ, axialR]
+    field_simp
+    ring
+  · show 3 * hexSideLength / 2 * axialR p = p 1
+    simp only [axialR]
+    field_simp
+
+/-- Squared distance between two `hexPos` points equals `3s²·Q(Δq, Δr)`
+    where `Q(x,y) = x² + xy + y²` is the `A₂` quadratic form. -/
+theorem hexPos_dist_sq (q₁ r₁ q₂ r₂ : ℝ) :
+    dist (hexPos q₁ r₁) (hexPos q₂ r₂) ^ 2 =
+    3 * hexSideLength ^ 2 *
+      ((q₁ - q₂) ^ 2 + (q₁ - q₂) * (r₁ - r₂) + (r₁ - r₂) ^ 2) := by
+  rw [EuclideanSpace.dist_sq_eq, Fin.sum_univ_two]
+  simp only [hexPos, PiLp.continuousLinearEquiv_symm_apply, PiLp.toLp_apply,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+             Real.dist_eq, sq_abs]
+  have h3 : Real.sqrt 3 * Real.sqrt 3 = 3 :=
+    Real.mul_self_sqrt (by norm_num : (3 : ℝ) ≥ 0)
+  nlinarith [h3, sq_nonneg (q₁ - q₂), sq_nonneg (r₁ - r₂),
+             sq_nonneg ((q₁ - q₂) + (r₁ - r₂) / 2), sq_nonneg hexSideLength]
+
+/-- Squared distance from a point `p` to the hex center at integer coordinates
+    `(a, b)` equals `3s²·Q(axialQ p − a, axialR p − b)`. -/
+theorem dist_p_center_sq (p : Plane) (a b : ℤ) :
+    dist p (hexCenter a b) ^ 2 = 3 * hexSideLength ^ 2 *
+      ((axialQ p - (a : ℝ)) ^ 2 + (axialQ p - (a : ℝ)) * (axialR p - (b : ℝ)) +
+       (axialR p - (b : ℝ)) ^ 2) := by
+  have hrec : p = hexPos (axialQ p) (axialR p) := (hexPos_axial p).symm
+  conv_lhs => rw [hrec]
+  rw [show hexCenter a b = hexPos (a : ℝ) (b : ℝ) from rfl, hexPos_dist_sq]
+
+-- From here on, `axialQ`/`axialR` are treated as opaque reals: every downstream
+-- defeq (the `hexCoord` unfolding and the Voronoi case analysis) reasons about
+-- the rounding purely in axial coordinates, never expanding the EuclideanSpace
+-- internals (which would blow up `whnf`). Their equational lemmas remain
+-- available to `simp`, so earlier unfoldings are unaffected.
+attribute [irreducible] axialQ axialR
+
+/-- Arithmetic core (branch 0): on the hexagon `|a|,|b|,|a+b| ≤ 1/2`, the form
+    `a²+ab+b²` is at most `1/3` (actually `≤ 1/4`).  Proof by sign cases with an
+    explicit nonnegative-products certificate. -/
+theorem quad_bound_A (a b : ℝ) (ha : -1/2 ≤ a) (ha' : a ≤ 1/2)
+    (hb : -1/2 ≤ b) (hb' : b ≤ 1/2) (hab : -1/2 ≤ a + b) (hab' : a + b ≤ 1/2) :
+    a ^ 2 + a * b + b ^ 2 ≤ 1 / 3 := by
+  rcases le_total a 0 with hsa | hsa <;> rcases le_total b 0 with hsb | hsb
+  · -- a ≤ 0, b ≤ 0 : same sign, ab ≥ 0, so a²+ab+b² = (a+b)² - (-ab) ≤ (a+b)² ≤ 1/4
+    nlinarith [mul_nonneg (neg_nonneg.mpr hsa) (neg_nonneg.mpr hsb),
+               mul_nonneg (by linarith : (0:ℝ) ≤ 1/2 - (a + b))
+                          (by linarith : (0:ℝ) ≤ 1/2 + (a + b))]
+  · -- a ≤ 0, b ≥ 0 : cert  (-a)(1/2+a) + b(1/2-b) + (1/2+a)(1/2-b)
+    nlinarith [mul_nonneg (neg_nonneg.mpr hsa) (by linarith : (0:ℝ) ≤ 1/2 + a),
+               mul_nonneg hsb (by linarith : (0:ℝ) ≤ 1/2 - b),
+               mul_nonneg (by linarith : (0:ℝ) ≤ 1/2 + a) (by linarith : (0:ℝ) ≤ 1/2 - b)]
+  · -- a ≥ 0, b ≤ 0 : cert  a(1/2-a) + (-b)(1/2+b) + (1/2-a)(1/2+b)
+    nlinarith [mul_nonneg hsa (by linarith : (0:ℝ) ≤ 1/2 - a),
+               mul_nonneg (neg_nonneg.mpr hsb) (by linarith : (0:ℝ) ≤ 1/2 + b),
+               mul_nonneg (by linarith : (0:ℝ) ≤ 1/2 - a) (by linarith : (0:ℝ) ≤ 1/2 + b)]
+  · -- a ≥ 0, b ≥ 0 : same sign, ab ≥ 0
+    nlinarith [mul_nonneg hsa hsb,
+               mul_nonneg (by linarith : (0:ℝ) ≤ 1/2 - (a + b))
+                          (by linarith : (0:ℝ) ≤ 1/2 + (a + b))]
+
+/-- Arithmetic core (correction branches): if `a,b,c ∈ [-1/2,1/2]` with
+    `a+b+c = ±1` and `c` has the largest magnitude (`a² ≤ c²`, `b² ≤ c²`), then
+    `a²+ab+b² ≤ 1/3`.  Tight: equality at `a=b=c=±1/3`.  Proof uses the identity
+    `1/3 − Q = (p+r)(1−p−r)/3 + pr` with `p = 1−2a−b`, `r = 1−a−2b` (sign-flipped
+    for the `−1` case). -/
+theorem quad_bound_B (a b c : ℝ) (ha : -1/2 ≤ a) (ha' : a ≤ 1/2)
+    (hb : -1/2 ≤ b) (hb' : b ≤ 1/2) (hc : -1/2 ≤ c) (hc' : c ≤ 1/2)
+    (hsum : a + b + c = 1 ∨ a + b + c = -1)
+    (hca : a ^ 2 ≤ c ^ 2) (hcb : b ^ 2 ≤ c ^ 2) :
+    a ^ 2 + a * b + b ^ 2 ≤ 1 / 3 := by
+  rcases hsum with h | h
+  · -- c = 1 - a - b
+    have hb1 : (0:ℝ) < 1 - b := by linarith
+    have ha1 : (0:ℝ) < 1 - a := by linarith
+    have key : (0:ℝ) ≤ (1 - 2*a - b) * (1 - b) := by nlinarith [hca]
+    have key2 : (0:ℝ) ≤ (1 - a - 2*b) * (1 - a) := by nlinarith [hcb]
+    have hp : (0:ℝ) ≤ 1 - 2*a - b := by nlinarith [key, hb1]
+    have hr : (0:ℝ) ≤ 1 - a - 2*b := by nlinarith [key2, ha1]
+    have hpr : (0:ℝ) ≤ (1 - 2*a - b) + (1 - a - 2*b) := add_nonneg hp hr
+    have hc12 : (0:ℝ) ≤ 3*a + 3*b - 1 := by linarith
+    nlinarith [mul_nonneg hp hr, mul_nonneg hpr hc12]
+  · -- c = -1 - a - b
+    have hb1 : (0:ℝ) < 1 + b := by linarith
+    have ha1 : (0:ℝ) < 1 + a := by linarith
+    have key : (0:ℝ) ≤ (1 + 2*a + b) * (1 + b) := by nlinarith [hca]
+    have key2 : (0:ℝ) ≤ (1 + a + 2*b) * (1 + a) := by nlinarith [hcb]
+    have hp : (0:ℝ) ≤ 1 + 2*a + b := by nlinarith [key, hb1]
+    have hr : (0:ℝ) ≤ 1 + a + 2*b := by nlinarith [key2, ha1]
+    have hpr : (0:ℝ) ≤ (1 + 2*a + b) + (1 + a + 2*b) := add_nonneg hp hr
+    have hc12 : (0:ℝ) ≤ -1 - 3*a - 3*b := by linarith
+    nlinarith [mul_nonneg hp hr, mul_nonneg hpr hc12]
+
+/-- The cube-coordinate rounding used by `hexCoord`, on abstract axial coordinates.
+    The body is identical to `hexCoord`'s, so `hexCoord p = hexRound (axialQ p) (axialR p)`
+    holds definitionally.  This lets the covering-radius case analysis run on plain
+    reals, never unfolding any EuclideanSpace internals (which would blow up `whnf`). -/
+def hexRound (q r : ℝ) : ℤ × ℤ :=
+  let y := -q - r
+  let rq := ⌊q + 1/2⌋
+  let rr := ⌊r + 1/2⌋
+  let ry := ⌊y + 1/2⌋
+  if rq + ry + rr = 0 then (rq, rr)
+  else
+    let dq := |q - ↑rq|
+    let dr := |r - ↑rr|
+    let dy := |y - ↑ry|
+    if dq ≥ dr ∧ dq ≥ dy then (-ry - rr, rr)
+    else if dr ≥ dy then (rq, -rq - ry)
+    else (rq, rr)
+
+set_option maxHeartbeats 800000 in
+/-- `hexCoord` is `hexRound` applied to the axial coordinates of `p`. -/
+theorem hexCoord_eq_round (p : Plane) :
+    hexCoord p = hexRound (axialQ p) (axialR p) := rfl
+
+set_option maxHeartbeats 800000 in
+/-- The cube-rounding output keeps the point inside its Voronoi cell:
+    `Q(q − a, r − b) ≤ 1/3` where `(a,b) = hexRound q r`.  Tight at the hexagon
+    corners (`Q = 1/3`).  This is the covering-radius bound in `A₂` coordinates. -/
+theorem hexRound_Q_bound (q r : ℝ) :
+    (q - ((hexRound q r).1 : ℝ)) ^ 2 +
+      (q - ((hexRound q r).1 : ℝ)) * (r - ((hexRound q r).2 : ℝ)) +
+      (r - ((hexRound q r).2 : ℝ)) ^ 2 ≤ 1 / 3 := by
+  -- floor bounds: each rounding error lies in [-1/2, 1/2)
+  have ha1 : -1/2 ≤ q - (⌊q + 1/2⌋ : ℝ) := by
+    have := Int.floor_le (q + 1/2); linarith
+  have ha2 : q - (⌊q + 1/2⌋ : ℝ) < 1/2 := by
+    have := Int.lt_floor_add_one (q + 1/2); push_cast at this ⊢; linarith
+  have hb1 : -1/2 ≤ r - (⌊r + 1/2⌋ : ℝ) := by
+    have := Int.floor_le (r + 1/2); linarith
+  have hb2 : r - (⌊r + 1/2⌋ : ℝ) < 1/2 := by
+    have := Int.lt_floor_add_one (r + 1/2); push_cast at this ⊢; linarith
+  have hc1 : -1/2 ≤ (-q - r) - (⌊(-q - r) + 1/2⌋ : ℝ) := by
+    have := Int.floor_le ((-q - r) + 1/2); linarith
+  have hc2 : (-q - r) - (⌊(-q - r) + 1/2⌋ : ℝ) < 1/2 := by
+    have := Int.lt_floor_add_one ((-q - r) + 1/2); push_cast at this ⊢; linarith
+  simp only [hexRound]
+  set rq := ⌊q + 1/2⌋ with hrqe
+  set rr := ⌊r + 1/2⌋ with hrre
+  set ry := ⌊(-q - r) + 1/2⌋ with hrye
+  -- the integer sum lies in {-1, 0, 1}
+  have hSint : rq + rr + ry = -1 ∨ rq + rr + ry = 0 ∨ rq + rr + ry = 1 := by
+    have l1 : 2 * (rq + rr + ry) ≤ 3 := by
+      have : ((2 * (rq + rr + ry) : ℤ) : ℝ) ≤ 3 := by push_cast; linarith
+      exact_mod_cast this
+    have l2 : (-3 : ℤ) ≤ 2 * (rq + rr + ry) := by
+      have : (-3 : ℝ) ≤ ((2 * (rq + rr + ry) : ℤ) : ℝ) := by push_cast; linarith
+      exact_mod_cast this
+    omega
+  split_ifs with h0 h1 h2
+  · -- Branch 0: rq + ry + rr = 0, output (rq, rr).  Use quad_bound_A.
+    show (q - (rq : ℝ)) ^ 2 + (q - (rq : ℝ)) * (r - (rr : ℝ)) + (r - (rr : ℝ)) ^ 2 ≤ 1 / 3
+    have hzero : (q - (rq : ℝ)) + (r - (rr : ℝ)) + ((-q - r) - (ry : ℝ)) = 0 := by
+      have : ((rq : ℝ) + rr + ry) = 0 := by
+        have : (rq + rr + ry : ℤ) = 0 := by omega
+        exact_mod_cast this
+      linarith
+    exact quad_bound_A (q - (rq : ℝ)) (r - (rr : ℝ))
+      (by linarith) (by linarith) (by linarith) (by linarith)
+      (by linarith) (by linarith)
+  · -- Branch 1: q-error is largest, output (-ry-rr, rr).  Q = Q(er0, ey0).
+    show (q - ((-ry - rr : ℤ) : ℝ)) ^ 2 +
+         (q - ((-ry - rr : ℤ) : ℝ)) * (r - (rr : ℝ)) + (r - (rr : ℝ)) ^ 2 ≤ 1 / 3
+    have hconv : (q - ((-ry - rr : ℤ) : ℝ)) ^ 2 +
+        (q - ((-ry - rr : ℤ) : ℝ)) * (r - (rr : ℝ)) + (r - (rr : ℝ)) ^ 2 =
+        (r - (rr : ℝ)) ^ 2 + (r - (rr : ℝ)) * ((-q - r) - (ry : ℝ)) +
+          ((-q - r) - (ry : ℝ)) ^ 2 := by push_cast; ring
+    rw [hconv]
+    have hne0 : rq + rr + ry ≠ 0 := by intro h; exact h0 (by omega)
+    have hsum1 : (r - (rr : ℝ)) + ((-q - r) - (ry : ℝ)) + (q - (rq : ℝ)) = 1 ∨
+                 (r - (rr : ℝ)) + ((-q - r) - (ry : ℝ)) + (q - (rq : ℝ)) = -1 := by
+      rcases hSint with h | h | h
+      · left
+        have : ((rq : ℝ) + rr + ry) = -1 := by exact_mod_cast (by exact_mod_cast h : (rq + rr + ry : ℤ) = -1)
+        linarith
+      · exact absurd h hne0
+      · right
+        have : ((rq : ℝ) + rr + ry) = 1 := by exact_mod_cast (by exact_mod_cast h : (rq + rr + ry : ℤ) = 1)
+        linarith
+    have hca : (r - (rr : ℝ)) ^ 2 ≤ (q - (rq : ℝ)) ^ 2 := by
+      nlinarith [mul_self_le_mul_self (abs_nonneg (r - (rr : ℝ))) h1.1,
+                 abs_mul_abs_self (r - (rr : ℝ)), abs_mul_abs_self (q - (rq : ℝ))]
+    have hcb : ((-q - r) - (ry : ℝ)) ^ 2 ≤ (q - (rq : ℝ)) ^ 2 := by
+      nlinarith [mul_self_le_mul_self (abs_nonneg ((-q - r) - (ry : ℝ))) h1.2,
+                 abs_mul_abs_self ((-q - r) - (ry : ℝ)), abs_mul_abs_self (q - (rq : ℝ))]
+    exact quad_bound_B (r - (rr : ℝ)) ((-q - r) - (ry : ℝ)) (q - (rq : ℝ))
+      (by linarith) (by linarith) (by linarith) (by linarith) (by linarith) (by linarith)
+      hsum1 hca hcb
+  · -- Branch 2: r-error is largest, output (rq, -rq-ry).  Q = Q(eq0, ey0).
+    show (q - (rq : ℝ)) ^ 2 +
+         (q - (rq : ℝ)) * (r - ((-rq - ry : ℤ) : ℝ)) + (r - ((-rq - ry : ℤ) : ℝ)) ^ 2 ≤ 1 / 3
+    have hconv : (q - (rq : ℝ)) ^ 2 +
+        (q - (rq : ℝ)) * (r - ((-rq - ry : ℤ) : ℝ)) + (r - ((-rq - ry : ℤ) : ℝ)) ^ 2 =
+        (q - (rq : ℝ)) ^ 2 + (q - (rq : ℝ)) * ((-q - r) - (ry : ℝ)) +
+          ((-q - r) - (ry : ℝ)) ^ 2 := by push_cast; ring
+    rw [hconv]
+    have hne0 : rq + rr + ry ≠ 0 := by intro h; exact h0 (by omega)
+    have hsum1 : (q - (rq : ℝ)) + ((-q - r) - (ry : ℝ)) + (r - (rr : ℝ)) = 1 ∨
+                 (q - (rq : ℝ)) + ((-q - r) - (ry : ℝ)) + (r - (rr : ℝ)) = -1 := by
+      rcases hSint with h | h | h
+      · left
+        have : ((rq : ℝ) + rr + ry) = -1 := by exact_mod_cast (by exact_mod_cast h : (rq + rr + ry : ℤ) = -1)
+        linarith
+      · exact absurd h hne0
+      · right
+        have : ((rq : ℝ) + rr + ry) = 1 := by exact_mod_cast (by exact_mod_cast h : (rq + rr + ry : ℤ) = 1)
+        linarith
+    have hle : |q - (rq : ℝ)| ≤ |r - (rr : ℝ)| := by
+      rcases not_and_or.mp h1 with h | h
+      · exact le_of_lt (not_le.mp h)
+      · exact le_of_lt (lt_of_lt_of_le (not_le.mp h) h2)
+    have hca : (q - (rq : ℝ)) ^ 2 ≤ (r - (rr : ℝ)) ^ 2 := by
+      nlinarith [mul_self_le_mul_self (abs_nonneg (q - (rq : ℝ))) hle,
+                 abs_mul_abs_self (q - (rq : ℝ)), abs_mul_abs_self (r - (rr : ℝ))]
+    have hcb : ((-q - r) - (ry : ℝ)) ^ 2 ≤ (r - (rr : ℝ)) ^ 2 := by
+      nlinarith [mul_self_le_mul_self (abs_nonneg ((-q - r) - (ry : ℝ))) h2,
+                 abs_mul_abs_self ((-q - r) - (ry : ℝ)), abs_mul_abs_self (r - (rr : ℝ))]
+    exact quad_bound_B (q - (rq : ℝ)) ((-q - r) - (ry : ℝ)) (r - (rr : ℝ))
+      (by linarith) (by linarith) (by linarith) (by linarith) (by linarith) (by linarith)
+      hsum1 hca hcb
+  · -- Branch 3: y-error is largest, output (rq, rr).  Q = Q(eq0, er0).
+    show (q - (rq : ℝ)) ^ 2 + (q - (rq : ℝ)) * (r - (rr : ℝ)) + (r - (rr : ℝ)) ^ 2 ≤ 1 / 3
+    have hne0 : rq + rr + ry ≠ 0 := by intro h; exact h0 (by omega)
+    have hsum1 : (q - (rq : ℝ)) + (r - (rr : ℝ)) + ((-q - r) - (ry : ℝ)) = 1 ∨
+                 (q - (rq : ℝ)) + (r - (rr : ℝ)) + ((-q - r) - (ry : ℝ)) = -1 := by
+      rcases hSint with h | h | h
+      · left
+        have : ((rq : ℝ) + rr + ry) = -1 := by exact_mod_cast (by exact_mod_cast h : (rq + rr + ry : ℤ) = -1)
+        linarith
+      · exact absurd h hne0
+      · right
+        have : ((rq : ℝ) + rr + ry) = 1 := by exact_mod_cast (by exact_mod_cast h : (rq + rr + ry : ℤ) = 1)
+        linarith
+    have hlt2 : |r - (rr : ℝ)| < |(-q - r) - (ry : ℝ)| := not_le.mp h2
+    have hle : |q - (rq : ℝ)| ≤ |(-q - r) - (ry : ℝ)| := by
+      rcases not_and_or.mp h1 with h | h
+      · exact le_of_lt (lt_trans (not_le.mp h) hlt2)
+      · exact le_of_lt (not_le.mp h)
+    have hca : (q - (rq : ℝ)) ^ 2 ≤ ((-q - r) - (ry : ℝ)) ^ 2 := by
+      nlinarith [mul_self_le_mul_self (abs_nonneg (q - (rq : ℝ))) hle,
+                 abs_mul_abs_self (q - (rq : ℝ)), abs_mul_abs_self ((-q - r) - (ry : ℝ))]
+    have hcb : (r - (rr : ℝ)) ^ 2 ≤ ((-q - r) - (ry : ℝ)) ^ 2 := by
+      nlinarith [mul_self_le_mul_self (abs_nonneg (r - (rr : ℝ))) (le_of_lt hlt2),
+                 abs_mul_abs_self (r - (rr : ℝ)), abs_mul_abs_self ((-q - r) - (ry : ℝ))]
+    exact quad_bound_B (q - (rq : ℝ)) (r - (rr : ℝ)) ((-q - r) - (ry : ℝ))
+      (by linarith) (by linarith) (by linarith) (by linarith) (by linarith) (by linarith)
+      hsum1 hca hcb
+
+/-- The cube-rounding output `hexCoord p` keeps the point inside the Voronoi cell:
+    `Q(axialQ p − a, axialR p − b) ≤ 1/3`. -/
+theorem hexCoord_Q_bound (p : Plane) :
+    (axialQ p - ((hexCoord p).1 : ℝ)) ^ 2 +
+      (axialQ p - ((hexCoord p).1 : ℝ)) * (axialR p - ((hexCoord p).2 : ℝ)) +
+      (axialR p - ((hexCoord p).2 : ℝ)) ^ 2 ≤ 1 / 3 := by
+  rw [hexCoord_eq_round]
+  exact hexRound_Q_bound (axialQ p) (axialR p)
+
 /-- Covering radius of the A₂ lattice with Voronoi rounding.
     Every point is within distance s of its hexCoord center.
     This is the circumradius of the hexagonal Voronoi cell. -/
 theorem covering_radius (p : Plane) :
     dist p (hexCenter (hexCoord p).1 (hexCoord p).2) ≤ hexSideLength := by
-  sorry
-  -- The A₂ Voronoi cell is a regular hexagon with circumradius equal to the
-  -- lattice shortest vector / √3 = s√3/√3 = s. The cube-coordinate rounding
-  -- algorithm assigns each point to the nearest lattice center.
+  have hs : (0 : ℝ) ≤ hexSideLength := by norm_num [hexSideLength]
+  have hd : (0 : ℝ) ≤ dist p (hexCenter (hexCoord p).1 (hexCoord p).2) := dist_nonneg
+  have hQ := hexCoord_Q_bound p
+  have hsq : dist p (hexCenter (hexCoord p).1 (hexCoord p).2) ^ 2 ≤ hexSideLength ^ 2 := by
+    rw [dist_p_center_sq]
+    nlinarith [hQ, sq_nonneg hexSideLength]
+  nlinarith [hsq, hd, hs]
 
 /-- Squared distance between hex centers equals 3s²·Q(Δa, Δb).
     ‖center(a₁,b₁) - center(a₂,b₂)‖² = 3s²·(Δa² + Δa·Δb + Δb²).
@@ -137,12 +417,9 @@ theorem hexCenter_dist_sq (a₁ b₁ a₂ b₂ : ℤ) :
 
 /-- √21 > 9/2. Proof: 21 > (9/2)² = 20.25, and √ is monotone. -/
 theorem sqrt21_gt_nine_halves : Real.sqrt 21 > 9 / 2 := by
-  calc Real.sqrt 21 > Real.sqrt (81/4) := by
-        apply Real.sqrt_lt_sqrt (by positivity) (by norm_num) |>.mpr
-        exact by norm_num
-    _ = 9 / 2 := by
-        rw [show (81:ℝ)/4 = (9/2)^2 from by norm_num,
-            Real.sqrt_sq (by norm_num : (9:ℝ)/2 ≥ 0)]
+  have h : (9 : ℝ) / 2 = Real.sqrt ((9 / 2) ^ 2) := (Real.sqrt_sq (by norm_num)).symm
+  rw [gt_iff_lt, h]
+  exact Real.sqrt_lt_sqrt (by positivity) (by norm_num)
 
 /-- The key numerical bound: s(√21 - 2) > 1, where s = 2/5.
     Equivalently, 2√21 - 4 > 5, i.e., √21 > 9/2, i.e., 21 > 20.25. -/
@@ -219,22 +496,20 @@ theorem same_color_far (p q : Plane)
   -- Step 5: Center distance ≥ s√21
   have hcenter : dist (hexCenter a₁ b₁) (hexCenter a₂ b₂) ≥
       hexSideLength * Real.sqrt 21 := by
-    have hs_pos : hexSideLength > 0 := by simp [hexSideLength]; norm_num
-    rw [← Real.sqrt_sq (le_of_lt hs_pos)]
-    rw [← Real.sqrt_mul (sq_nonneg _)]
-    apply Real.sqrt_le_sqrt
-    calc hexSideLength ^ 2 * 21 = 21 * hexSideLength ^ 2 := by ring
-      _ ≤ dist (hexCenter a₁ b₁) (hexCenter a₂ b₂) ^ 2 := hcenter_sq
+    have hs_pos : (0 : ℝ) < hexSideLength := by norm_num [hexSideLength]
+    have hlhs : (0 : ℝ) ≤ hexSideLength * Real.sqrt 21 := by positivity
+    have hsq21 : (hexSideLength * Real.sqrt 21) ^ 2 = 21 * hexSideLength ^ 2 := by
+      rw [mul_pow, Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 21)]; ring
+    nlinarith [hcenter_sq, hsq21, hlhs,
+               dist_nonneg (x := hexCenter a₁ b₁) (y := hexCenter a₂ b₂)]
   -- Step 6: Triangle inequality → point distance ≥ center distance - 2s
   have hp := covering_radius p
   have hq := covering_radius q
   have h_tri : dist (hexCenter a₁ b₁) (hexCenter a₂ b₂) ≤
       dist (hexCenter a₁ b₁) p + dist p q + dist q (hexCenter a₂ b₂) := by
-    calc dist (hexCenter a₁ b₁) (hexCenter a₂ b₂)
-        ≤ dist (hexCenter a₁ b₁) p + dist p (hexCenter a₂ b₂) :=
-          dist_triangle _ _ _
-      _ ≤ dist (hexCenter a₁ b₁) p + (dist p q + dist q (hexCenter a₂ b₂)) := by
-          linarith [dist_triangle p q (hexCenter a₂ b₂)]
+    have t1 := dist_triangle (hexCenter a₁ b₁) p (hexCenter a₂ b₂)
+    have t2 := dist_triangle p q (hexCenter a₂ b₂)
+    linarith
   have h_rearr : dist p q ≥
       dist (hexCenter a₁ b₁) (hexCenter a₂ b₂) -
       dist p (hexCenter a₁ b₁) - dist q (hexCenter a₂ b₂) := by

--- a/proofs/Proofs/UnitDistanceHN7Aristotle.lean
+++ b/proofs/Proofs/UnitDistanceHN7Aristotle.lean
@@ -3,9 +3,11 @@
   Routine supporting lemmas for automated proof search.
   See UnitDistanceHN7.lean for the main Hadwiger-Nelson upper bound (χ(ℝ²) ≤ 7).
 
-  Status (2026-04-29): only the geometric covering-radius obligation remains as a sorry.
-  hexCenter_dist_sq and the modular-arithmetic step (hexColor_eq_implies_mod) are now
-  proved here as well (the latter mirrors the inline step in same_color_far).
+  Status (2026-06-21): COMPLETE — the geometric covering-radius obligation is now proved
+  in UnitDistanceHN7 (via the A₂ cube-rounding Voronoi analysis), so the whole
+  Hadwiger-Nelson upper bound χ(ℝ²) ≤ 7 is sorry-free and axiom-free.
+  hexCenter_dist_sq and the modular-arithmetic step (hexColor_eq_implies_mod) are also
+  proved here (the latter mirrors the inline step in same_color_far).
 
   Criteria for inclusion:
   - NOT the main Hadwiger-Nelson theorem (follows from the supporting lemmas above)
@@ -70,9 +72,10 @@ of its assigned Voronoi hex cell. The cube-coordinate rounding algorithm in
 hexCoord assigns each point to the nearest lattice site.
 -/
 
-/-- Every point is within distance hexSideLength of its assigned hex center. -/
+/-- Every point is within distance hexSideLength of its assigned hex center.
+    Now discharged by the proved `covering_radius` in `UnitDistanceHN7`. -/
 theorem covering_radius_ari (p : Plane) :
-    dist p (hexCenter (hexCoord p).1 (hexCoord p).2) ≤ hexSideLength := by
-  sorry
+    dist p (hexCenter (hexCoord p).1 (hexCoord p).2) ≤ hexSideLength :=
+  covering_radius p
 
 end UnitDistanceHN7Aristotle

--- a/research/problems/unit-distance-independence-oq-02/state.md
+++ b/research/problems/unit-distance-independence-oq-02/state.md
@@ -1,9 +1,9 @@
 # Research State: unit-distance-independence-oq-02
 
 ## Current State
-**Phase**: ACT
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-04-29T03:43Z (researcher-1 session)
+**Since**: 2026-06-21T18:10:26-07:00
 **Iteration**: 2
 
 ## Current Focus

--- a/research/registry.json
+++ b/research/registry.json
@@ -24350,7 +24350,7 @@
       "path": "fast",
       "started": "2026-04-06T03:14:36.235Z",
       "status": "graduated",
-      "lastUpdate": "2026-04-13T02:54:37.270Z",
+      "lastUpdate": "2026-06-21T18:10:26-07:00",
       "completed": "2026-04-13T02:54:37.270Z"
     },
     {

--- a/src/data/proofs/erdos-643-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-643-incomplete-01/annotations.json
@@ -1,0 +1,109 @@
+[
+  {
+    "id": "ann-643star-f-welldef",
+    "proofId": "erdos-643-incomplete-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 90
+    },
+    "type": "concept",
+    "title": "Why the Extremal Function f(n,t) Is Well-Defined",
+    "content": "f(n,t) is `Nat.find` of the predicate 'every family with ≥ m edges has a crossed pair'. For `Nat.find` to make sense the predicate must hold somewhere, and the witness is m = C(n,t) + 1: any t-uniform family H on Fin n is a set of t-subsets, hence H ⊆ powersetCard t univ, whose ncard is exactly C(n,t) (`Finset.card_powersetCard` + `Fintype.card_fin`). So a crossed-pair-free family can have at most C(n,t) edges, and beyond that the threshold is forced. This mirrors the parent's definition exactly, so the f proved about here is the same extremal function.",
+    "mathContext": "There are exactly C(n,t) t-subsets of an n-set, so edgeCount H ≤ C(n,t) for every t-uniform H — the upper cap that makes Nat.find non-vacuous.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Nat.find",
+      "Finset.powersetCard",
+      "Set.ncard_le_ncard"
+    ],
+    "prerequisites": [
+      "Cardinality of the family of t-subsets"
+    ]
+  },
+  {
+    "id": "ann-643star-nocrossedpair",
+    "proofId": "erdos-643-incomplete-01",
+    "range": {
+      "startLine": 103,
+      "endLine": 110
+    },
+    "type": "technique",
+    "title": "The Star Has No Crossed Pair — One t-Independent Line",
+    "content": "A crossed pair requires two of its four edges, A and B, to satisfy A ∩ B = ∅. But every edge of the star St₀ contains the fixed vertex 0, so for any two star edges 0 ∈ A and 0 ∈ B, giving 0 ∈ A ∩ B and A ∩ B ≠ ∅ — a direct contradiction. The argument never mentions t, which is precisely why the bound generalizes from the parent's hardcoded t=3 `Star_noCrossedPair` to all t at once. (Implementation note: `open scoped Classical` makes the ∩ in `IsCrossedPair` use the classical DecidableEq instance, distinct from `Fin n`'s concrete one, so the proof uses `simp_all [Finset.ext_iff]` rather than a direct rewrite to dodge the instance diamond.)",
+    "mathContext": "Two sets sharing a common element are never disjoint; all star edges share vertex 0; a crossed pair needs a disjoint pair of edges.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "crossed pair",
+      "intersecting family",
+      "Finset.ext_iff"
+    ],
+    "prerequisites": [
+      "Definition of a crossed pair (disjoint pairs with equal union)"
+    ]
+  },
+  {
+    "id": "ann-643star-card",
+    "proofId": "erdos-643-incomplete-01",
+    "range": {
+      "startLine": 112,
+      "endLine": 141
+    },
+    "type": "technique",
+    "title": "Counting the Star: the Link Bijection e ↦ e \\ {0}",
+    "content": "The star St₀ = { e : |e|=t, 0∈e } is put in bijection with the (t-1)-subsets of the remaining n-1 vertices: St₀ = image (insert 0) (powersetCard (t-1) (univ.erase 0)). Injectivity of `insert 0` on sets avoiding 0 is `erase_insert`; surjectivity onto St₀ is `insert_erase` (e = insert 0 (e.erase 0) when 0 ∈ e). `Finset.card_image_of_injOn` then reduces |St₀| to |powersetCard (t-1) (univ.erase 0)| = C(n-1, t-1) via `Finset.card_powersetCard` and `card_erase_of_mem`. This generalizes the parent's t=3 `Star_card` (which gave C(n-1,2)) to arbitrary t.",
+    "mathContext": "t-subsets of [n] containing a fixed vertex ↔ (t-1)-subsets of the other n-1 vertices, hence |St₀| = C(n-1,t-1) — the link of vertex 0.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Finset.card_image_of_injOn",
+      "Finset.card_powersetCard",
+      "vertex link"
+    ],
+    "prerequisites": [
+      "Finset.insert_erase / erase_insert",
+      "Cardinality of powersetCard"
+    ]
+  },
+  {
+    "id": "ann-643star-fgestar",
+    "proofId": "erdos-643-incomplete-01",
+    "range": {
+      "startLine": 151,
+      "endLine": 168
+    },
+    "type": "concept",
+    "title": "From a Crossed-Pair-Free Witness to a Bound on f",
+    "content": "The extremal function f = Nat.find p, where p m says 'every family with ≥ m edges contains a crossed pair'. `Nat.le_find_iff` turns the goal C(n-1,t-1)+1 ≤ f into: for every m ≤ C(n-1,t-1), p m fails — i.e. there is a crossed-pair-free family of size ≥ m. The star, with exactly C(n-1,t-1) edges and no crossed pair, witnesses this for every such m at once. Hence f(n,t) ≥ C(n-1,t-1)+1 for all t ≥ 1, n ≥ 1 (`f_ge_star`), restated as `f_ge_main_term` in the parent's (t ≥ 2, n ≥ t) signature where only a `sorry` previously stood.",
+    "mathContext": "An attained crossed-pair-free size c forces the forcing threshold f to exceed c: f(n,t) ≥ C(n-1,t-1) + 1.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.le_find_iff",
+      "extremal function",
+      "lower bound by construction"
+    ],
+    "prerequisites": [
+      "Nat.find characterization of f"
+    ]
+  },
+  {
+    "id": "ann-643star-asymptotic",
+    "proofId": "erdos-643-incomplete-01",
+    "range": {
+      "startLine": 177,
+      "endLine": 223
+    },
+    "type": "technique",
+    "title": "Asymptotic Optimality: C(n-1,t-1)/C(n,t-1) → 1",
+    "content": "The star's edge count C(n-1,t-1) is the conjectured main term C(n,t-1) up to a factor that vanishes: the exact column identity (n-k)·C(n,k) = n·C(n-1,k) (`choose_pred_identity`, from `Nat.add_one_mul_choose_eq` and `Nat.choose_succ_right_eq`) gives, for n ≥ t, the ratio C(n-1,t-1)/C(n,t-1) = (n-t+1)/n. Since (t-1)/n → 0 (`Tendsto.div_atTop`), this ratio tends to 1 (`star_ratio_tendsto`), so f(n,t) ≥ (1+o(1))·C(n,t-1): the star realizes the full first-order constant of Erdős' conjectured lower bound. Only the second-order term ⌊(n-1)/t⌋ and the matching upper bounds lie outside this axiom-free island.",
+    "mathContext": "C(n-1,t-1)/C(n,t-1) = (n-t+1)/n → 1, so the single-star lower bound is asymptotically optimal for the conjecture's main term.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Nat.add_one_mul_choose_eq",
+      "Nat.choose_succ_right_eq",
+      "Filter.Tendsto.div_atTop"
+    ],
+    "prerequisites": [
+      "Binomial column recurrence",
+      "Limit of (constant)/n"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-643-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-643-incomplete-01/meta.json
@@ -1,0 +1,112 @@
+{
+  "id": "erdos-643-incomplete-01",
+  "title": "Erdős #643: A General-t Axiom-Free Lower Bound f(n,t) ≥ C(n-1,t-1) + 1 via the Full Star",
+  "slug": "erdos-643-incomplete-01",
+  "description": "Isolates the axiom-free core of the lower-bound half of Erdős Problem #643 (the least number f(n,t) of edges forcing a crossed pair A∪B=C∪D, A∩B=C∩D=∅ in a t-uniform hypergraph on n vertices). The parent entry erdos-643 proves only the t=3 lower bound f(n,3) ≥ C(n-1,2) + ⌊(n-1)/3⌋ and leaves the general-t lower bound as a `sorry`. This entry proves, with zero axioms and for EVERY t ≥ 1, the dominant term f(n,t) ≥ C(n-1,t-1) + 1. The witness is the full star at a fixed vertex: St₀ = { e : |e| = t, 0 ∈ e }, the family of all t-subsets through vertex 0. Any two star edges share 0, so they are never disjoint and the family is crossed-pair-free; it has exactly C(n-1,t-1) edges. Since C(n-1,t-1) ~ C(n,t-1), the star is the asymptotically optimal lower-bound construction: we prove the exact binomial identity (n-k)·C(n,k) = n·C(n-1,k) and deduce C(n-1,t-1)/C(n,t-1) → 1, i.e. f(n,t) ≥ (1+o(1))·C(n,t-1), the lower half of the conjecture's main term. The second-order matching term ⌊(n-1)/t⌋ and the (13/9 / 7/2)·C(n,t-1) upper bounds remain open (axiomatized / `sorry` in the parent). 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://erdosproblems.com/643",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos643StarLowerBound.lean",
+    "tags": [
+      "erdos",
+      "combinatorics",
+      "hypergraphs",
+      "extremal-combinatorics",
+      "crossed-pair",
+      "sunflower",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "erdosNumber": 643,
+    "erdosUrl": "https://erdosproblems.com/643",
+    "erdosProblemStatus": "open",
+    "axiomCount": 0,
+    "lineCount": 224,
+    "theoremCount": 9,
+    "definitionCount": 8,
+    "dateAdded": "2026-06-21",
+    "assumptions": "",
+    "relatedProblems": [
+      {
+        "id": "erdos-643",
+        "relationship": "Parent entry. Records the Pikhurko–Verstraëte bound f(n,3) ≤ (13/9)·C(n,2), the general upper bound f(n,t) < (7/2)·C(n,t-1), and the Erdős–Rado sunflower lemma as three axioms, and proves the t=3 lower bound f(n,3) ≥ C(n-1,2) + ⌊(n-1)/3⌋ via a Star ∪ Matching construction — but leaves the GENERAL-t lower bound f(n,t) ≥ C(n-1,t-1) + ⌊(n-1)/t⌋ as a `sorry`. This entry supplies the axiom-free, general-t dominant term C(n-1,t-1) + 1 of that bound, and proves it is asymptotically optimal."
+      },
+      {
+        "id": "erdos-6",
+        "relationship": "Related extremal-set-theory problem on forbidden intersection patterns in uniform families."
+      },
+      {
+        "id": "erdos-64",
+        "relationship": "Sibling Erdős problem in extremal combinatorics / hypergraph Turán theory."
+      }
+    ],
+    "originalContributions": [
+      "starHypergraph: the full star St₀ = { e : |e| = t, 0 ∈ e } of all t-edges through a fixed vertex — the general-t generalization of the parent's t=3 hardcoded Star",
+      "starHypergraph_noCrossedPair: the star is crossed-pair-free — any two edges contain 0, so A ∩ B ∋ 0 ≠ ∅ contradicts the crossed-pair disjointness requirement, for every t",
+      "starHypergraph_card: the star has exactly C(n-1,t-1) edges, via the bijection e ↦ e \\ {0} onto the (t-1)-subsets of the remaining n-1 vertices (Finset.image of insert 0 over powersetCard (t-1) (univ.erase 0))",
+      "f_ge_star: the axiom-free general lower bound f(n,t) ≥ C(n-1,t-1) + 1 for all t ≥ 1, n ≥ 1 — extracted via Nat.le_find_iff from the crossed-pair-free star witness",
+      "f_ge_main_term: the same bound in the parent's (t ≥ 2, n ≥ t) signature — the main term of the conjectured lower bound, now general-t where the parent had only a `sorry`",
+      "f_three_ge_main_term: the t=3 specialization f(n,3) ≥ C(n-1,2) + 1, recovering the dominant term of the parent's f_three_lower_bound",
+      "choose_pred_identity: the exact column identity (n-k)·C(n,k) = n·C(n-1,k), combining Nat.add_one_mul_choose_eq with Nat.choose_succ_right_eq",
+      "star_ratio_tendsto: C(n-1,t-1)/C(n,t-1) → 1, proving the star is the ASYMPTOTICALLY OPTIMAL lower-bound construction — f(n,t) ≥ (1+o(1))·C(n,t-1)"
+    ],
+    "axiomCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #643 asks for the threshold f(n,t): the least number of edges that forces any t-uniform hypergraph on n vertices to contain a 'crossed pair' — four edges A,B,C,D with A∪B = C∪D and A∩B = C∩D = ∅. For graphs (t=2) this is equivalent to forcing a 4-cycle, governed by the Kővári–Sós–Turán theorem f(n,2) = (½+o(1))n^{3/2}. For hypergraphs (t ≥ 3) the problem is open; Pikhurko–Verstraëte (2009) proved f(n,3) ≤ (13/9)·C(n,2), and the general bounds C(n-1,t-1) + ⌊(n-1)/t⌋ ≤ f(n,t) < (7/2)·C(n,t-1) are known. Erdős conjectured f(n,t) = (1+o(1))·C(n,t-1) for t ≥ 3, i.e. that the sunflower/star-type construction is essentially optimal. The parent gallery entry erdos-643 formalizes this with the upper bounds and the sunflower lemma as axioms, fully proves the t=3 lower bound, but leaves the general-t lower bound as a `sorry`. This entry extracts the part of that lower bound that Lean can check end to end, for all t, with no assumptions.",
+    "problemStatement": "Let f(n,t) be the least m such that every t-uniform hypergraph on n vertices with ≥ m edges contains a crossed pair. Prove, without invoking any of the deep upper bounds or the sunflower lemma, a general-t lower bound on f(n,t) that captures the conjectured main term. **Main theorem**: f(n,t) ≥ C(n-1,t-1) + 1 for every t ≥ 1 and n ≥ 1, and C(n-1,t-1)/C(n,t-1) → 1, so f(n,t) ≥ (1+o(1))·C(n,t-1).",
+    "proofStrategy": "The whole lower bound rests on one construction and one counting bijection.\n\n**Step 1 — the construction.** Fix vertex 0 and take the full star St₀ = { e : |e| = t, 0 ∈ e }, the family of ALL t-subsets containing 0. It is trivially t-uniform (`starHypergraph_isUniform`).\n\n**Step 2 — no crossed pair.** A crossed pair needs two of its edges A,B with A ∩ B = ∅. But every star edge contains 0, so any two star edges A,B share 0, i.e. 0 ∈ A ∩ B and A ∩ B ≠ ∅. Hence the star has no crossed pair, for every t (`starHypergraph_noCrossedPair`). This is the exact generalization of the parent's t=3 `Star_noCrossedPair`.\n\n**Step 3 — count the edges.** The map e ↦ e \\ {0} is a bijection from St₀ onto the (t-1)-subsets of the remaining n-1 vertices, with inverse s ↦ s ∪ {0}. Formally St₀ = image (insert 0) (powersetCard (t-1) (univ.erase 0)), and `Finset.card_image_of_injOn` + `Finset.card_powersetCard` give |St₀| = C(n-1,t-1) (`starHypergraph_card`).\n\n**Step 4 — lower-bound f.** Since St₀ is a crossed-pair-free t-uniform family with C(n-1,t-1) edges, no value ≤ C(n-1,t-1) can be the forcing threshold. Unfolding f = Nat.find and applying `Nat.le_find_iff`, the witness gives f(n,t) ≥ C(n-1,t-1) + 1 (`f_ge_star`).\n\n**Step 5 — asymptotic optimality.** The exact identity (n-k)·C(n,k) = n·C(n-1,k) (from `Nat.add_one_mul_choose_eq` and `Nat.choose_succ_right_eq`) gives, for n ≥ t, the ratio C(n-1,t-1)/C(n,t-1) = (n-t+1)/n → 1. With `Tendsto.div_atTop` for (t-1)/n → 0 and an eventually-equal rewrite, `star_ratio_tendsto` shows C(n-1,t-1)/C(n,t-1) → 1, so the star bound equals (1+o(1))·C(n,t-1) — the lower half of the conjecture's main term.",
+    "keyInsights": [
+      "The conjectured main term C(n,t-1) of the lower bound needs no deep machinery and no second construction: the single full star at one vertex is crossed-pair-free (all edges meet at 0) and already has C(n-1,t-1) ~ C(n,t-1) edges. The parent's matching term ⌊(n-1)/t⌋ is a strictly lower-order improvement.",
+      "Crossed-pair-freeness of the star is one line of mathematics: a crossed pair requires two disjoint edges, but two edges through a common vertex can never be disjoint. This argument is completely t-independent, which is exactly why the bound generalizes from the parent's t=3 to all t.",
+      "The edge count is the star–link bijection e ↦ e \\ {0}: t-subsets through 0 correspond to (t-1)-subsets of the other n-1 vertices, giving C(n-1,t-1) with no double counting (injectivity of insert 0 on sets avoiding 0).",
+      "Asymptotic optimality is captured exactly by the column identity (n-k)·C(n,k) = n·C(n-1,k): the ratio C(n-1,t-1)/C(n,t-1) is precisely (n-t+1)/n, which visibly tends to 1, so the star realizes the full first-order constant of the conjectured bound.",
+      "Turning a concrete crossed-pair-free family into a bound on f requires only the Nat.find characterization of the extremal function (`Nat.le_find_iff`): an attained crossed-pair-free size c forces f > c. The parent left the general case as a `sorry` because matching the SECOND-order term needs the extra matching construction; isolating the main term makes the general-t content fully machine-checkable."
+    ],
+    "prerequisites": [
+      "Finset.powersetCard, Finset.card_powersetCard, Finset.card_image_of_injOn: counting t-subsets and images",
+      "Finset.insert_erase, Finset.erase_insert, Finset.card_erase_of_mem: the star–link bijection e ↦ e \\ {0}",
+      "Nat.find with Nat.le_find_iff: lower-bounding the extremal function from an attained crossed-pair-free size",
+      "Nat.add_one_mul_choose_eq, Nat.choose_succ_right_eq: the Pascal-type recurrences behind the column identity",
+      "Filter.Tendsto.div_atTop, tendsto_natCast_atTop_atTop, Tendsto.congr': the (t-1)/n → 0 asymptotic and the eventually-equal transfer"
+    ],
+    "furtherWork": "Natural next steps strictly between this bound and the parent's `sorry`/axioms: (1) add the disjoint matching on the remaining n-1 vertices to lift the bound from C(n-1,t-1) + 1 to the full C(n-1,t-1) + ⌊(n-1)/t⌋, discharging the parent's general `f_lower_bound` sorry (the cross-type crossed-pair impossibility is the work, already done for t=3 in the parent); (2) prove an unconditional general-t upper bound f(n,t) ≤ C·C(n,t-1) to make the order of magnitude axiom-free in both directions; (3) attack the conjecture's constant 1 by combining the star lower bound here with a formalized Pikhurko–Verstraëte-type upper bound for t=3."
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Definitions",
+      "startLine": 1,
+      "endLine": 90,
+      "summary": "Module docstring stating the axiom-free general-t scope, and the self-contained restatement of Hypergraph, IsUniform, edgeCount, IsCrossedPair, HasCrossedPair, CrossedPairFreeWithEdges, and the extremal function f(n,t) = Nat.find (well-defined because a crossed-pair-free family has at most C(n,t) edges, the number of t-subsets). Identical semantics to the bit-rotted parent Erdos643Problem.",
+      "mathContext": "f(n,t) = least m such that every t-uniform hypergraph on n vertices with ≥ m edges contains a crossed pair A∪B=C∪D, A∩B=C∩D=∅."
+    },
+    {
+      "id": "section-star",
+      "title": "§ The full star construction",
+      "startLine": 92,
+      "endLine": 147,
+      "summary": "starHypergraph: St₀ = { e : |e|=t, 0∈e }. starHypergraph_isUniform (t-uniformity). starHypergraph_noCrossedPair: no crossed pair, because any two edges share 0 and cannot be disjoint. starHypergraph_card: |St₀| = C(n-1,t-1) via the bijection e ↦ e\\{0}. star_crossedPairFree packages the witness.",
+      "mathContext": "All t-subsets through a fixed vertex form a crossed-pair-free t-uniform family of size C(n-1,t-1)."
+    },
+    {
+      "id": "section-lower-bound",
+      "title": "§ The general-t lower bound",
+      "startLine": 149,
+      "endLine": 175,
+      "summary": "f_ge_star: f(n,t) ≥ C(n-1,t-1) + 1 for all t ≥ 1, n ≥ 1, via Nat.le_find_iff applied to the star witness. f_ge_main_term: the same in the (t ≥ 2, n ≥ t) signature. f_three_ge_main_term: the t=3 specialization f(n,3) ≥ C(n-1,2) + 1.",
+      "mathContext": "f(n,t) ≥ C(n-1,t-1) + 1 — the conjectured main term, now for all t (parent had only t=3 proved, general as a sorry)."
+    },
+    {
+      "id": "section-asymptotic",
+      "title": "§ Asymptotic optimality of the star bound",
+      "startLine": 177,
+      "endLine": 224,
+      "summary": "choose_pred_identity: the exact column identity (n-k)·C(n,k) = n·C(n-1,k). star_ratio_tendsto: C(n-1,t-1)/C(n,t-1) → 1 (the ratio equals (n-t+1)/n), so the star realizes the full first-order constant — f(n,t) ≥ (1+o(1))·C(n,t-1).",
+      "mathContext": "C(n-1,t-1)/C(n,t-1) = (n-t+1)/n → 1: the star is the asymptotically optimal lower-bound construction."
+    }
+  ]
+}

--- a/src/data/proofs/unit-distance-independence/meta.json
+++ b/src/data/proofs/unit-distance-independence/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 2,
-    "assumptions": "2 axioms: hadwiger_nelson_lower_bound (χ(ℝ²) ≥ 5) and hadwiger_nelson_upper_bound (χ(ℝ²) ≤ 7). The lower bound was improved to 5 by de Grey (2018) using a 1581-vertex graph; the upper bound follows from a 7-coloring of the plane using hexagonal tiling. These require substantial geometric computation.",
+    "assumptions": "2 axioms in the parent file UnitDistanceIndependence.lean: hadwiger_nelson_lower_bound (χ(ℝ²) ≥ 5, de Grey 2018, genuinely hard) and hadwiger_nelson_upper_bound (χ(ℝ²) ≤ 7). The upper bound is now CONSTRUCTIVELY PROVED — sorry-free and axiom-free — in the companion file UnitDistanceHN7.lean (theorem hadwiger_nelson_7coloring), via an explicit hexagonal 7-coloring and the A₂-lattice Voronoi covering-radius bound; the parent file retains it as an axiom only for local self-containment and it is now redundant. Thus the only genuinely unavoidable assumption is the de Grey lower bound.",
     "lineCount": 948,
     "theoremCount": 65,
     "definitionCount": 12,
@@ -38,7 +38,9 @@
       "independence_number: definition α(G) = max |I| for independent I",
       "alpha_chromatic_bound: α(G) ≥ |V|/χ(G) (fractional coloring bound)",
       "UnitDistanceGraph: definition with edges between points at distance 1",
-      "moser_spindle: the Moser spindle subgraph (5-chromatic) construction"
+      "moser_spindle: the Moser spindle subgraph (5-chromatic) construction",
+      "covering_radius (UnitDistanceHN7.lean): the A₂ cube-coordinate rounding keeps every point within the circumradius s=2/5 of its Voronoi center — the last remaining geometric obligation of the hexagonal 7-coloring, proved via Q(Δq,Δr) ≤ 1/3 (hexRound_Q_bound) by a four-branch case analysis with explicit SOS certificates",
+      "hadwiger_nelson_7coloring (UnitDistanceHN7.lean): complete, machine-verified proof of the Hadwiger-Nelson upper bound χ(ℝ²) ≤ 7 (0 sorries, 0 axioms)"
     ]
   },
   "overview": {

--- a/src/data/research/problems/unit-distance-independence-oq-02.json
+++ b/src/data/research/problems/unit-distance-independence-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "unit-distance-independence-oq-02",
   "title": "Prove Hadwiger-Nelson upper bound ≤ 7 via hexagonal 7-coloring",
   "phase": "ACT",
-  "status": "in-progress",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -18,7 +18,7 @@
     "nextAction": "S4 PREP/ACT: tackle covering_radius via the cube-norm inequality outlined in knowledge.md §Suggested-implementation-sketch. Path A (preferred, ~80 LOC): prove private lemma hexCoord_cube_bound (Q(q-a, r-b) ≤ 1/3) by 3-sub-case split on rq+ry+rr correction; combine with proved hexCenter_dist_sq to get dist² ≤ s². Path B (fallback): decompose into 6 cube-rounding sub-cases. Paste-ready sketch in sessions/2026-05-16-s3-statesync-json-leanfile-iter2-drift.md §Remaining-obligation. Mathlib pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 stable."
   },
   "knowledge": {
-    "progressSummary": "S2 (2026-04-29) reduced UnitDistanceHN7.lean from 3 sorries to 1. Resolved hexCenter_dist_sq + inline modular step in same_color_far; companion HN7Aristotle.lean updated accordingly. Remaining: covering_radius (A₂ Voronoi circumradius ≤ s) — the hardest of the three obligations. Eliminating it would close the hexagonal 7-coloring construction and remove the hadwiger_nelson_upper_bound axiom from UnitDistanceIndependence.lean. Current state: HN7.lean 287/8/6/0/1, HN7Aristotle.lean 78/3/0/0/1, parent UnitDistanceIndependence.lean 948/65/11/2/0 (lines/thms/defs/axioms/sorries).",
+    "progressSummary": "COMPLETE: covering_radius proved in UnitDistanceHN7.lean → hadwiger_nelson_7coloring (χ(ℝ²) ≤ 7) is now fully machine-verified, 0 sorries, 0 axioms. covering_radius_ari companion sorry also discharged.",
     "builtItems": [
       "hexSideLength, axialQ, axialR, hexCoord, hexColor, hexCenter (6 defs, HN7.lean lines 32-82)",
       "color_sublattice_min_norm: PROVED (HN7.lean:84) — integer arithmetic on Q(da,db) over 3·da+db ≡ 0 (mod 7) sublattice",
@@ -27,7 +27,11 @@
       "same_hex_close, same_color_far: PROVED (HN7.lean:160, 180) — uses covering_radius (sorry pending) + hexCenter_dist_sq",
       "Inline modular step in same_color_far: PROVED in S2 via simp [hexColor, Fin.mk.injEq] + omega (handles Int.toNat and redundant Nat.mod 7)",
       "Companion HN7Aristotle.lean updated in S2: hexCenter_dist_sq_ari delegates to main lemma; hexColor_eq_implies_mod_ari proved by parallel omega",
-      "hadwiger_nelson_7coloring: PROVED (HN7.lean:258) — main theorem, conditional on covering_radius"
+      "hadwiger_nelson_7coloring: PROVED (HN7.lean:258) — main theorem, conditional on covering_radius",
+      "hexRound + hexRound_Q_bound (UnitDistanceHN7.lean): abstract cube-rounding with Q(q-a,r-b) ≤ 1/3, four-branch Voronoi case analysis",
+      "quad_bound_A / quad_bound_B (UnitDistanceHN7.lean): SOS arithmetic cores for the hexagon (≤1/4) and correction (≤1/3, tight) bounds",
+      "hexPos / hexPos_axial / hexPos_dist_sq / dist_p_center_sq: A₂ basis reconstruction giving dist² = 3s²·Q in axial coordinates",
+      "covering_radius (UnitDistanceHN7.lean): closes the last sorry; covering_radius_ari delegated"
     ],
     "insights": [
       "Hex diameter 2s = 4/5 < 1 ensures same-cell points < 1 apart",
@@ -43,12 +47,14 @@
       "S2 PROOF PATTERN — nlinarith [h3, sq_nonneg …] with h3 : Real.sqrt 3 * Real.sqrt 3 = 3 closes hexCenter_dist_sq where ring_nf alone fails (since ring_nf normalizes √3 differently each call).",
       "S2 PROOF PATTERN — simp only [hexColor, Fin.mk.injEq] before omega is required to peel the Fin 7 constructor and expose Nat equality; raw simp alone leaves let-binding that omega cannot parse.",
       "S2 OUTCOME — 2 of 3 original sorries (same_hex_close, same_color_far) provably reduce to covering_radius. So eliminating covering_radius would close ALL remaining obligations in HN7.lean and HN7Aristotle.lean, then remove hadwiger_nelson_upper_bound from UnitDistanceIndependence.lean — a full collapse to 0 sorries / 1 axiom (down from 2) across the bundle.",
-      "DECOMPOSITION — covering_radius reduces to Q(q-a, r-b) ≤ 1/3 (cube-norm bound on rounding error) combined with proved hexCenter_dist_sq to get dist² ≤ 3s²·(1/3) = s². See knowledge.md §Suggested-implementation-sketch."
+      "DECOMPOSITION — covering_radius reduces to Q(q-a, r-b) ≤ 1/3 (cube-norm bound on rounding error) combined with proved hexCenter_dist_sq to get dist² ≤ 3s²·(1/3) = s². See knowledge.md §Suggested-implementation-sketch.",
+      "Marking axialQ/axialR irreducible and running the rounding case-analysis on a parallel def hexRound over abstract reals avoids whnf/isDefEq blowups from EuclideanSpace internals",
+      "Hand-writing the if-expression synthesizes different Decidable instances than the def, making the connecting rfl time out; a parallel def with an identical body fixes it",
+      "Parent axiom hadwiger_nelson_upper_bound is now redundant but a clean discharge needs namespacing UnitDistanceHN7 (root-level Plane clashes on import) — left as follow-up"
     ],
     "nextSteps": [
-      "Prove covering_radius (~80 LOC, Path A): private lemma hexCoord_cube_bound bounds Q(q-a, r-b) ≤ 1/3 by 3-sub-case split on the cube-coordinate correction (rq + ry + rr = 0 vs ≠ 0, then largest-error coordinate is corrected leaving the other two with |Δ| ≤ 1/2). Combine via hexCenter_dist_sq + Real.sqrt_le_sqrt to close.",
-      "Fallback Path B: decompose covering_radius into 6 isolated sub-lemmas (3 corrections × 2 signs), each closed by Int.floor_le / Int.le_ceil + nlinarith. ~3× the LOC but mechanically discharged.",
-      "After covering_radius lands: HN7Aristotle.lean covering_radius_ari follows by delegation (1 LOC). hadwiger_nelson_upper_bound axiom in UnitDistanceIndependence.lean can then be replaced by `exact hadwiger_nelson_7coloring`."
+      "Namespace UnitDistanceHN7 and discharge the parent hadwiger_nelson_upper_bound axiom in UnitDistanceIndependence.lean (replace axiom with `exact hadwiger_nelson_7coloring`), reducing the gallery entry to 1 axiom (de Grey lower bound only).",
+      "Lower bound χ(ℝ²) ≥ 5 (de Grey 2018, 1581-vertex graph) remains genuinely hard / axiomatized."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Closes the **sole remaining `sorry`** in `proofs/Proofs/UnitDistanceHN7.lean` — the A₂-lattice Voronoi **covering-radius** obligation — turning the classic **Hadwiger-Nelson upper bound χ(ℝ²) ≤ 7** into a complete, machine-checked theorem.

`#print axioms hadwiger_nelson_7coloring` → `[propext, Classical.choice, Quot.sound]` only: **no `sorryAx`, no `native_decide`/`ofReduceBool`**. Genuinely verified / 0-axiom.

## What the proof does

The plane is 7-colored by the A₂ hexagonal lattice (side `s = 2/5`), coloring each Voronoi cell by `(3q + r) mod 7`. The two halves (same cell ⇒ dist < 1; same color, different cells ⇒ dist > 1) were already proved *assuming* `covering_radius`. This PR supplies that last geometric piece:

- **`hexPos` / `hexPos_axial` / `hexPos_dist_sq` / `dist_p_center_sq`** — A₂ basis reconstruction giving `dist(p, center)² = 3s²·Q(axialQ p − a, axialR p − b)`, `Q(x,y) = x² + xy + y²`.
- **`quad_bound_A`** — on the hexagon `|a|,|b|,|a+b| ≤ 1/2`, `Q ≤ 1/3` (sign-case SOS certificate; actual max 1/4).
- **`quad_bound_B`** — with `a+b+c = ±1` and `c` of largest magnitude, `Q(a,b) ≤ 1/3` (tight at `a=b=c=±1/3`), via the exact identity `1/3 − Q = (p+r)(1−p−r)/3 + pr` with `p = 1−2a−b`, `r = 1−a−2b`.
- **`hexRound` / `hexRound_Q_bound`** — the cube-coordinate rounding on abstract reals, with `Q(q−a, r−b) ≤ 1/3` by a four-branch Voronoi case analysis (sum = 0 keeps the naive rounding; otherwise the largest-error coordinate is corrected, leaving the other two with `|Δ| ≤ 1/2`).
- **`covering_radius`** — every point lies within `s = 2/5` of its assigned center.

**Key Lean technique.** Running the rounding case analysis on a parallel `def hexRound` over *abstract reals* (with `axialQ`/`axialR` marked `irreducible`) keeps every `whnf`/`isDefEq` away from the `EuclideanSpace` internals that otherwise blow past the heartbeat limit. The bridge `hexCoord p = hexRound (axialQ p) (axialR p)` is then a cheap structural `rfl` (a hand-written `if`-expression instead synthesizes mismatched `Decidable` instances and times out).

## Also in this PR

- Repaired pre-existing Mathlib 4.26.0 **bit-rot** in the same file: `sqrt21_gt_nine_halves`, the `s√21` center-distance bound, the triangle-inequality step, and the `Prod`-equality / `sq_pos_of_ne_zero` idioms in `color_sublattice_min_norm`.
- Discharged the now-trivial `covering_radius_ari` sorry in `UnitDistanceHN7Aristotle.lean` (delegation to `covering_radius`).
- Updated gallery `meta.json` and the research problem record.

## Honest scope

The parent `UnitDistanceIndependence.lean` still **declares** `hadwiger_nelson_upper_bound` as an `axiom` — now **redundant** (provable by `hadwiger_nelson_7coloring`). A clean discharge needs namespacing `UnitDistanceHN7` to avoid a root-level `Plane` name clash on import; left as a follow-up. The **de Grey lower bound χ(ℝ²) ≥ 5** remains genuinely hard / axiomatized.

## Verification

`./proofs/scripts/docker-build.sh Proofs.UnitDistanceHN7` and `Proofs.UnitDistanceHN7Aristotle` both build cleanly (0 sorries, 0 axiom declarations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)