### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-04): full multinomial covariance matrix — variance + diagonal [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -308,6 +308,7 @@ import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ01
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ02
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ02
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ03
+import Proofs.BinomialTheoremOQ02OQ01OQ01OQ04
 import Proofs.BinomialTheoremOQ02OQ01OQ02
 import Proofs.BinomialTheoremOQ02OQ01OQ03
 import Proofs.BinomialTheoremOQ02OQ01OQ04

--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ04.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ04.lean
@@ -1,0 +1,329 @@
+import Mathlib
+import Proofs.BinomialTheoremOQ02OQ01OQ01
+
+/-
+# The full second-order structure of the multinomial distribution
+
+## Open Question (slug: binomial-theorem-oq-02-oq-01-oq-01-oq-04)
+
+The parent `binomial-theorem-oq-02-oq-01-oq-01` formalises the multinomial PMF and
+proves the **mean** `E[Xᵢ] = n·pᵢ`, the **cross moment** `E[XᵢXⱼ] = n(n-1)pᵢpⱼ`
+(for `i ≠ j`), and the **off-diagonal covariance** `Cov(Xᵢ,Xⱼ) = -n·pᵢ·pⱼ`
+(again only for `i ≠ j`).  Its recorded follow-up asks for the **variance**
+`Var(Xᵢ) = n·pᵢ·(1-pᵢ)` and **the full covariance matrix**.
+
+The diagonal — the variance — is genuinely absent: the parent's covariance theorem
+explicitly requires `i ≠ j`.  This entry closes that gap and assembles the complete
+second-order description.
+
+## What This Proves
+
+All expectations are the discrete sums `∑_{k : ∑k = n} (value) · multinomial(s,k)·∏pⱼ^kⱼ`
+over `s.piAntidiag n`, matching the parent's convention.
+
+* `multinomial_second_factorial_moment` — the **diagonal second factorial moment**
+    `E[Xᵢ(Xᵢ-1)] = n(n-1)·pᵢ²`,
+  the single-coordinate analogue of the parent's cross moment, obtained by the same
+  absorption bijection applied to coordinate `i` (the surviving factor `(kᵢ-1)`
+  becomes the lowered count `k'ᵢ`, reducing the sum to `n·pᵢ` times the `(n-1)`-mean
+  of `Xᵢ`).
+* `multinomial_second_moment` — `E[Xᵢ²] = n(n-1)·pᵢ² + n·pᵢ`.
+* `multinomial_variance` — the **variance** `Var(Xᵢ) = E[(Xᵢ - n·pᵢ)²] = n·pᵢ·(1-pᵢ)`,
+  the missing diagonal of the covariance matrix.
+* `multinomial_covariance_matrix` — the **unified covariance-matrix entry**, valid for
+  *all* `i, j` (diagonal and off-diagonal at once):
+    `Cov(Xᵢ,Xⱼ) = E[(Xᵢ-n·pᵢ)(Xⱼ-n·pⱼ)] = n·pᵢ·(δᵢⱼ - pⱼ)`,
+  where `δᵢⱼ = if i = j then 1 else 0`.  Specialising `i = j` gives the variance
+  `n·pᵢ(1-pᵢ)`; specialising `i ≠ j` recovers the parent's `-n·pᵢ·pⱼ`.  This is the
+  `n·(diag(p) - p·pᵀ)` covariance matrix in coordinate form.
+
+## How it connects to the parent
+
+The off-diagonal case of `multinomial_covariance_matrix` is routed through the parent's
+public `multinomial_covariance`: the centred summand `(kᵢ-npᵢ)(kⱼ-npⱼ)·w` and the
+parent's `(kᵢkⱼ - n²pᵢpⱼ)·w` differ by a combination of `kᵢ·w` and `kⱼ·w` whose total
+mass vanishes (each summing to `n·pᵢ` resp. `n·pⱼ` by `multinomial_mean`), so the two
+sums coincide.  Only the diagonal genuinely needs the new absorption computation.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and
+`sorry`-free.
+-/
+
+namespace BinomialTheoremOQ02OQ01OQ01OQ04
+
+open Finset BigOperators
+open scoped Nat
+open BinomialTheoremOQ02OQ01OQ01 (multinomial_mean multinomial_covariance)
+
+/-! ## Part 1: the absorption engine (re-derived; the parent's copies are private) -/
+
+/-- **Absorption identity** (`ℕ` level).  For a composition `k` of `n` with `kᵢ ≥ 1`,
+lowering the `i`-th count by one absorbs the factor `kᵢ` into `n`:
+`kᵢ · multinomial(s,k) = n · multinomial(s, update k i (kᵢ-1))`. -/
+private theorem absorb {α : Type*} [DecidableEq α] (s : Finset α)
+    (k : α → ℕ) (n : ℕ) (i : α) (hi : i ∈ s) (hsum : ∑ j ∈ s, k j = n) (hki : k i ≠ 0) :
+    k i * Nat.multinomial s k =
+    n * Nat.multinomial s (Function.update k i (k i - 1)) := by
+  have hn : n ≠ 0 := by
+    have hle : k i ≤ ∑ j ∈ s, k j := Finset.single_le_sum (fun j _ => Nat.zero_le _) hi
+    omega
+  set P := ∏ j ∈ s.erase i, (k j)! with hP
+  have hk_prod : (∏ j ∈ s, (k j)!) = (k i)! * P :=
+    (Finset.mul_prod_erase s (fun j => (k j)!) hi).symm
+  have hk'_prod : (∏ j ∈ s, ((Function.update k i (k i - 1)) j)!) = (k i - 1)! * P := by
+    rw [← Finset.mul_prod_erase s (fun j => ((Function.update k i (k i - 1)) j)!) hi,
+        Function.update_self]
+    congr 1
+    exact Finset.prod_congr rfl
+      (fun j hj => by rw [Function.update_of_ne (Finset.ne_of_mem_erase hj)])
+  have hsum' : (∑ j ∈ s, (Function.update k i (k i - 1)) j) = n - 1 := by
+    rw [← Finset.add_sum_erase s (Function.update k i (k i - 1)) hi, Function.update_self]
+    have hcong : (∑ j ∈ s.erase i, (Function.update k i (k i - 1)) j) = ∑ j ∈ s.erase i, k j :=
+      Finset.sum_congr rfl
+        (fun j hj => by rw [Function.update_of_ne (Finset.ne_of_mem_erase hj)])
+    rw [hcong]
+    have he : k i + ∑ j ∈ s.erase i, k j = n := by
+      rw [Finset.add_sum_erase s k hi]; exact hsum
+    omega
+  have spec_k : (∏ j ∈ s, (k j)!) * Nat.multinomial s k = n ! := by
+    rw [Nat.multinomial_spec s k, hsum]
+  have spec_k' : (∏ j ∈ s, ((Function.update k i (k i - 1)) j)!) *
+      Nat.multinomial s (Function.update k i (k i - 1)) = (n - 1)! := by
+    rw [Nat.multinomial_spec s (Function.update k i (k i - 1)), hsum']
+  have hpos : 0 < (k i - 1)! * P := by
+    refine Nat.mul_pos (Nat.factorial_pos _) ?_
+    rw [hP]; exact Finset.prod_pos (fun j _ => Nat.factorial_pos _)
+  apply Nat.eq_of_mul_eq_mul_left hpos
+  calc (k i - 1)! * P * (k i * Nat.multinomial s k)
+      = (k i * (k i - 1)!) * P * Nat.multinomial s k := by ring
+    _ = (k i)! * P * Nat.multinomial s k := by rw [Nat.mul_factorial_pred hki]
+    _ = (∏ j ∈ s, (k j)!) * Nat.multinomial s k := by rw [hk_prod]
+    _ = n ! := spec_k
+    _ = n * (n - 1)! := (Nat.mul_factorial_pred hn).symm
+    _ = n * ((∏ j ∈ s, ((Function.update k i (k i - 1)) j)!) *
+            Nat.multinomial s (Function.update k i (k i - 1))) := by rw [spec_k']
+    _ = n * ((k i - 1)! * P * Nat.multinomial s (Function.update k i (k i - 1))) := by
+          rw [hk'_prod]
+    _ = (k i - 1)! * P * (n * Nat.multinomial s (Function.update k i (k i - 1))) := by ring
+
+/-- **Weighted absorption** (`ℝ` level): lowering the `i`-th count by one converts the
+weighted summand `kᵢ·multinomial(s,k)·∏pⱼ^kⱼ` into `n·pᵢ·multinomial(s,k')·∏pⱼ^k'ⱼ`. -/
+private theorem absorb_weighted {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (k : α → ℕ) (n : ℕ) (i : α)
+    (hi : i ∈ s) (hsum : ∑ l ∈ s, k l = n) (hki : k i ≠ 0) :
+    (k i : ℝ) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+    = (n : ℝ) * p i * ((Nat.multinomial s (Function.update k i (k i - 1)) : ℝ)
+        * ∏ l ∈ s, p l ^ (Function.update k i (k i - 1)) l) := by
+  have habs : (k i : ℝ) * (Nat.multinomial s k : ℝ)
+      = (n : ℝ) * (Nat.multinomial s (Function.update k i (k i - 1)) : ℝ) := by
+    exact_mod_cast absorb s k n i hi hsum hki
+  have hprod : (∏ l ∈ s, p l ^ k l)
+      = p i * ∏ l ∈ s, p l ^ (Function.update k i (k i - 1)) l := by
+    have hL : (∏ l ∈ s, p l ^ k l) = p i ^ k i * ∏ l ∈ s.erase i, p l ^ k l :=
+      (Finset.mul_prod_erase s (fun l => p l ^ k l) hi).symm
+    have hR : (∏ l ∈ s, p l ^ (Function.update k i (k i - 1)) l)
+        = p i ^ (k i - 1) * ∏ l ∈ s.erase i, p l ^ k l := by
+      rw [← Finset.mul_prod_erase s (fun l => p l ^ (Function.update k i (k i - 1)) l) hi]
+      congr 1
+      · rw [Function.update_self]
+      · exact Finset.prod_congr rfl
+          (fun l hl => by rw [Function.update_of_ne (Finset.ne_of_mem_erase hl)])
+    rw [hL, hR, ← mul_assoc]
+    congr 1
+    rw [← pow_succ']
+    congr 1
+    omega
+  calc (k i : ℝ) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+      = ((k i : ℝ) * (Nat.multinomial s k : ℝ)) * (∏ l ∈ s, p l ^ k l) := by ring
+    _ = ((n : ℝ) * (Nat.multinomial s (Function.update k i (k i - 1)) : ℝ))
+          * (p i * ∏ l ∈ s, p l ^ (Function.update k i (k i - 1)) l) := by rw [habs, hprod]
+    _ = (n : ℝ) * p i * ((Nat.multinomial s (Function.update k i (k i - 1)) : ℝ)
+          * ∏ l ∈ s, p l ^ (Function.update k i (k i - 1)) l) := by ring
+
+/-! ## Part 2: the diagonal second factorial moment -/
+
+/-- **The diagonal second factorial moment** `E[Xᵢ(Xᵢ-1)] = n·(n-1)·pᵢ²`.
+
+Proof: drop the `kᵢ = 0` terms and lower `Xᵢ` by the absorption bijection
+`k ↦ update k i (kᵢ-1)`.  The remaining factor `(kᵢ-1)` equals the lowered count
+`k'ᵢ`, so the sum becomes `n·pᵢ` times the *mean of `Xᵢ` in an `(n-1)`-trial
+multinomial*, which is `(n-1)·pᵢ` by `multinomial_mean`. -/
+theorem multinomial_second_factorial_moment {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i)
+    (i : α) (hi : i ∈ s) :
+    ∑ k ∈ s.piAntidiag n,
+      (k i : ℝ) * ((k i : ℝ) - 1) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+    = (n : ℝ) * ((n - 1 : ℕ) : ℝ) * p i * p i := by
+  obtain rfl | hn := Nat.eq_zero_or_pos n
+  · simp
+  rw [← Finset.sum_filter_of_ne (p := fun k => k i ≠ 0)
+        (fun k _ hfk hzero => hfk (by rw [hzero]; simp))]
+  rw [Finset.sum_nbij'
+        (i := fun k => Function.update k i (k i - 1))
+        (j := fun k' => Function.update k' i (k' i + 1))
+        (t := s.piAntidiag (n - 1))
+        (g := fun k' => (n : ℝ) * p i * (k' i : ℝ) *
+          ((Nat.multinomial s k' : ℝ) * ∏ l ∈ s, p l ^ k' l))]
+  · -- ∑ g = n·pᵢ · (mean of Xᵢ over n-1 trials) = n·pᵢ·(n-1)·pᵢ
+    have hfac : ∑ k' ∈ s.piAntidiag (n - 1),
+          (n : ℝ) * p i * (k' i : ℝ) * ((Nat.multinomial s k' : ℝ) * ∏ l ∈ s, p l ^ k' l)
+        = (n : ℝ) * p i * ∑ k' ∈ s.piAntidiag (n - 1),
+            (k' i : ℝ) * ((Nat.multinomial s k' : ℝ) * ∏ l ∈ s, p l ^ k' l) := by
+      rw [Finset.mul_sum]; exact Finset.sum_congr rfl (fun k' _ => by ring)
+    rw [hfac, multinomial_mean s p (n - 1) hp_sum hp_nonneg i hi]; ring
+  · intro k hk
+    rw [Finset.mem_filter, Finset.mem_piAntidiag] at hk
+    obtain ⟨⟨hksum, hksupp⟩, hki⟩ := hk
+    rw [Finset.mem_piAntidiag]
+    refine ⟨?_, ?_⟩
+    · have hcong : (∑ l ∈ s.erase i, (Function.update k i (k i - 1)) l) = ∑ l ∈ s.erase i, k l :=
+        Finset.sum_congr rfl
+          (fun l hl => by rw [Function.update_of_ne (Finset.ne_of_mem_erase hl)])
+      rw [← Finset.add_sum_erase s (Function.update k i (k i - 1)) hi, Function.update_self, hcong]
+      have he : k i + ∑ l ∈ s.erase i, k l = n := by
+        rw [Finset.add_sum_erase s k hi]; exact hksum
+      omega
+    · intro l hl
+      by_cases hli : l = i
+      · subst hli; exact hi
+      · rw [Function.update_of_ne hli] at hl; exact hksupp l hl
+  · intro k' hk'
+    rw [Finset.mem_piAntidiag] at hk'
+    obtain ⟨hk'sum, hk'supp⟩ := hk'
+    rw [Finset.mem_filter, Finset.mem_piAntidiag]
+    refine ⟨⟨?_, ?_⟩, ?_⟩
+    · have hcong : (∑ l ∈ s.erase i, (Function.update k' i (k' i + 1)) l) = ∑ l ∈ s.erase i, k' l :=
+        Finset.sum_congr rfl
+          (fun l hl => by rw [Function.update_of_ne (Finset.ne_of_mem_erase hl)])
+      rw [← Finset.add_sum_erase s (Function.update k' i (k' i + 1)) hi, Function.update_self, hcong]
+      have he : k' i + ∑ l ∈ s.erase i, k' l = n - 1 := by
+        rw [Finset.add_sum_erase s k' hi]; exact hk'sum
+      omega
+    · intro l hl
+      by_cases hli : l = i
+      · subst hli; exact hi
+      · rw [Function.update_of_ne hli] at hl; exact hk'supp l hl
+    · rw [Function.update_self]; exact Nat.succ_ne_zero _
+  · intro k hk
+    have hki : k i ≠ 0 := (Finset.mem_filter.mp hk).2
+    funext l
+    by_cases hli : l = i
+    · subst hli; rw [Function.update_self, Function.update_self]; omega
+    · rw [Function.update_of_ne hli, Function.update_of_ne hli]
+  · intro k' hk'
+    funext l
+    by_cases hli : l = i
+    · subst hli; rw [Function.update_self, Function.update_self]; omega
+    · rw [Function.update_of_ne hli, Function.update_of_ne hli]
+  · intro k hk
+    rw [Finset.mem_filter, Finset.mem_piAntidiag] at hk
+    obtain ⟨⟨hksum, _⟩, hki⟩ := hk
+    have hweighted := absorb_weighted s p k n i hi hksum hki
+    have hki1 : 1 ≤ k i := Nat.one_le_iff_ne_zero.mpr hki
+    have hrider : ((Function.update k i (k i - 1)) i : ℝ) = (k i : ℝ) - 1 := by
+      rw [Function.update_self, Nat.cast_sub hki1, Nat.cast_one]
+    calc (k i : ℝ) * ((k i : ℝ) - 1) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+        = ((k i : ℝ) - 1) * ((k i : ℝ) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)) := by
+          ring
+      _ = ((k i : ℝ) - 1) * ((n : ℝ) * p i *
+            ((Nat.multinomial s (Function.update k i (k i - 1)) : ℝ)
+              * ∏ l ∈ s, p l ^ (Function.update k i (k i - 1)) l)) := by rw [hweighted]
+      _ = (n : ℝ) * p i * ((Function.update k i (k i - 1)) i : ℝ) *
+            ((Nat.multinomial s (Function.update k i (k i - 1)) : ℝ)
+              * ∏ l ∈ s, p l ^ (Function.update k i (k i - 1)) l) := by rw [← hrider]; ring
+
+/-! ## Part 3: second moment, variance, and the covariance matrix -/
+
+/-- The **second moment** `E[Xᵢ²] = n·(n-1)·pᵢ² + n·pᵢ`, from `Xᵢ² = Xᵢ(Xᵢ-1) + Xᵢ`. -/
+theorem multinomial_second_moment {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i)
+    (i : α) (hi : i ∈ s) :
+    ∑ k ∈ s.piAntidiag n,
+      (k i : ℝ) ^ 2 * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+    = (n : ℝ) * ((n - 1 : ℕ) : ℝ) * p i * p i + (n : ℝ) * p i := by
+  have hfact := multinomial_second_factorial_moment s p n hp_sum hp_nonneg i hi
+  have hmean := multinomial_mean s p n hp_sum hp_nonneg i hi
+  have hsplit : ∀ k : α → ℕ,
+      (k i : ℝ) ^ 2 * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+      = (k i : ℝ) * ((k i : ℝ) - 1) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+        + (k i : ℝ) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l) := fun k => by ring
+  rw [Finset.sum_congr rfl (fun k _ => hsplit k), Finset.sum_add_distrib, hfact, hmean]
+
+/-- **The variance** `Var(Xᵢ) = E[(Xᵢ - n·pᵢ)²] = n·pᵢ·(1 - pᵢ)` — the missing
+diagonal of the multinomial covariance matrix. -/
+theorem multinomial_variance {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i)
+    (i : α) (hi : i ∈ s) :
+    ∑ k ∈ s.piAntidiag n,
+      ((k i : ℝ) - n * p i) ^ 2 * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+    = (n : ℝ) * p i * (1 - p i) := by
+  have hmass : ∑ k ∈ s.piAntidiag n,
+      (Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l = 1 := by
+    rw [← Finset.sum_pow_eq_sum_piAntidiag s p n, hp_sum, one_pow]
+  have hfact := multinomial_second_factorial_moment s p n hp_sum hp_nonneg i hi
+  have hmean := multinomial_mean s p n hp_sum hp_nonneg i hi
+  -- (kᵢ - npᵢ)² = kᵢ(kᵢ-1) + (1 - 2npᵢ)·kᵢ + (npᵢ)²
+  have hsplit : ∀ k : α → ℕ,
+      ((k i : ℝ) - n * p i) ^ 2 * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+      = (k i : ℝ) * ((k i : ℝ) - 1) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+        + (1 - 2 * (n * p i)) * ((k i : ℝ) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l))
+        + (n * p i) ^ 2 * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l) := fun k => by ring
+  rw [Finset.sum_congr rfl (fun k _ => hsplit k), Finset.sum_add_distrib, Finset.sum_add_distrib,
+      hfact, ← Finset.mul_sum, hmean, ← Finset.mul_sum, hmass, mul_one]
+  obtain rfl | hn := Nat.eq_zero_or_pos n
+  · simp
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hn.ne'
+  push_cast
+  ring
+
+/-- **The multinomial covariance matrix**, valid for *all* `i, j`:
+`Cov(Xᵢ,Xⱼ) = E[(Xᵢ - n·pᵢ)(Xⱼ - n·pⱼ)] = n·pᵢ·(δᵢⱼ - pⱼ)`, where
+`δᵢⱼ = if i = j then 1 else 0`.
+
+The diagonal `i = j` is the variance `n·pᵢ(1-pᵢ)` (`multinomial_variance`); the
+off-diagonal `i ≠ j` is the parent's `-n·pᵢ·pⱼ` (`multinomial_covariance`).  Together
+this is `n·(diag(p) - p·pᵀ)`, the complete second-order law of the multinomial. -/
+theorem multinomial_covariance_matrix {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i)
+    (i j : α) (hi : i ∈ s) (hj : j ∈ s) :
+    ∑ k ∈ s.piAntidiag n,
+      ((k i : ℝ) - n * p i) * ((k j : ℝ) - n * p j) *
+        ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+    = (n : ℝ) * p i * ((if i = j then 1 else 0) - p j) := by
+  by_cases hij : i = j
+  · -- diagonal: the variance
+    subst hij
+    rw [if_pos rfl]
+    have hvar := multinomial_variance s p n hp_sum hp_nonneg i hi
+    rw [← hvar]
+    apply Finset.sum_congr rfl
+    intro k _
+    ring
+  · -- off-diagonal: route through the parent's covariance
+    rw [if_neg hij]
+    have hmass : ∑ k ∈ s.piAntidiag n,
+        (Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l = 1 := by
+      rw [← Finset.sum_pow_eq_sum_piAntidiag s p n, hp_sum, one_pow]
+    have hcov := multinomial_covariance s p n hp_sum hp_nonneg i j hi hj hij
+    have hmeani := multinomial_mean s p n hp_sum hp_nonneg i hi
+    have hmeanj := multinomial_mean s p n hp_sum hp_nonneg j hj
+    -- centred summand = covariance summand + a vanishing linear combination
+    have hsplit : ∀ k : α → ℕ,
+        ((k i : ℝ) - n * p i) * ((k j : ℝ) - n * p j) *
+            ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+        = ((k i : ℝ) * (k j : ℝ) - n * p i * (n * p j)) *
+            ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l)
+          + (-(n * p j)) * ((k i : ℝ) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l))
+          + (-(n * p i)) * ((k j : ℝ) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l))
+          + (2 * (n * p i) * (n * p j)) *
+              ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l) := fun k => by ring
+    rw [Finset.sum_congr rfl (fun k _ => hsplit k), Finset.sum_add_distrib, Finset.sum_add_distrib,
+        Finset.sum_add_distrib, hcov, ← Finset.mul_sum, hmeani, ← Finset.mul_sum, hmeanj,
+        ← Finset.mul_sum, hmass, mul_one]
+    ring
+
+end BinomialTheoremOQ02OQ01OQ01OQ04

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-04",
+    "range": { "startLine": 5, "endLine": 61 },
+    "type": "concept",
+    "title": "Overview: completing the multinomial's second-order law",
+    "content": "The parent binomial-theorem-oq-02-oq-01-oq-01 proves the mean E[Xᵢ]=n·pᵢ, the cross moment E[XᵢXⱼ]=n(n-1)pᵢpⱼ, and the covariance Cov(Xᵢ,Xⱼ)=-n·pᵢpⱼ — but its covariance theorem carries the hypothesis i≠j, so the diagonal (the variance) is genuinely missing. This file supplies it: the diagonal second factorial moment, the second moment, the variance Var(Xᵢ)=n·pᵢ(1-pᵢ), and a single covariance-matrix formula Cov(Xᵢ,Xⱼ)=n·pᵢ·(δᵢⱼ-pⱼ) valid for all i,j. All expectations are finite sums over s.piAntidiag n, matching the parent's discrete convention. Everything is 0-axiom and sorry-free.",
+    "mathContext": "Covariance matrix $\\Sigma_{ij} = n p_i(\\delta_{ij} - p_j)$, i.e. $\\Sigma = n(\\operatorname{diag}(p) - p p^\\top)$; the diagonal $\\Sigma_{ii} = n p_i(1-p_i)$ is the variance.",
+    "significance": "supporting",
+    "relatedConcepts": ["multinomial distribution", "covariance matrix", "variance", "factorial moments"],
+    "prerequisites": ["multinomial PMF", "expectation as a finite sum"]
+  },
+  {
+    "id": "ann-absorb",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-04",
+    "range": { "startLine": 63, "endLine": 148 },
+    "type": "technique",
+    "title": "The absorption engine (re-derived locally)",
+    "content": "absorb is the combinatorial identity kᵢ·multinomial(s,k) = n·multinomial(s, update k i (kᵢ-1)): lowering the i-th count by one absorbs the factor kᵢ into n. absorb_weighted carries the probability weight, turning kᵢ·multinomial(s,k)·∏pⱼ^kⱼ into n·pᵢ·multinomial(s,k')·∏pⱼ^k'ⱼ. Both are proved from Nat.multinomial_spec and the factorial identity k·(k-1)! = k!. The parent file's copies are `private`, so they are re-derived here.",
+    "mathContext": "$k_i \\binom{n}{k} = n \\binom{n-1}{k - e_i}$ in multinomial form: $k_i \\cdot \\frac{n!}{\\prod_j k_j!} = n \\cdot \\frac{(n-1)!}{(k_i-1)!\\prod_{j\\ne i} k_j!}$.",
+    "significance": "key",
+    "relatedConcepts": ["multinomial coefficient", "absorption identity", "Nat.multinomial_spec"],
+    "prerequisites": ["factorials", "Finset.prod over erase"]
+  },
+  {
+    "id": "ann-second-factorial-moment",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-04",
+    "range": { "startLine": 150, "endLine": 237 },
+    "type": "theorem",
+    "title": "Diagonal second factorial moment E[Xᵢ(Xᵢ-1)] = n(n-1)pᵢ²",
+    "content": "The single-coordinate analogue of the parent's cross moment. After dropping the kᵢ=0 terms, the absorption bijection k ↦ update k i (kᵢ-1) maps onto compositions of n-1; the surviving factor (kᵢ-1) equals the lowered count k'ᵢ, so the sum becomes n·pᵢ times the (n-1)-trial mean of Xᵢ, which is (n-1)·pᵢ by multinomial_mean. The membership and inverse bookkeeping mirror the parent's cross-moment proof; only the summand correspondence differs (the rider is (kᵢ-1)→k'ᵢ rather than kⱼ).",
+    "mathContext": "$E[X_i(X_i-1)] = \\sum_{k} k_i(k_i-1)\\,P(X=k) = n p_i \\cdot E_{n-1}[X_i] = n p_i (n-1) p_i = n(n-1)p_i^2$.",
+    "significance": "key",
+    "relatedConcepts": ["factorial moment", "absorption bijection", "Finset.sum_nbij'"],
+    "prerequisites": ["multinomial_mean", "Nat.cast_sub"]
+  },
+  {
+    "id": "ann-second-moment",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-04",
+    "range": { "startLine": 239, "endLine": 255 },
+    "type": "theorem",
+    "title": "Second moment E[Xᵢ²] = n(n-1)pᵢ² + n·pᵢ",
+    "content": "Immediate from the decomposition Xᵢ² = Xᵢ(Xᵢ-1) + Xᵢ: split the summand, then apply the second factorial moment and the mean termwise.",
+    "mathContext": "$E[X_i^2] = E[X_i(X_i-1)] + E[X_i] = n(n-1)p_i^2 + n p_i$.",
+    "significance": "supporting",
+    "relatedConcepts": ["raw moments", "factorial moments"],
+    "prerequisites": ["multinomial_second_factorial_moment", "multinomial_mean"]
+  },
+  {
+    "id": "ann-variance",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-04",
+    "range": { "startLine": 256, "endLine": 288 },
+    "type": "theorem",
+    "title": "Variance Var(Xᵢ) = n·pᵢ·(1-pᵢ)",
+    "content": "The missing diagonal. Expanding the centred square gives (kᵢ-npᵢ)² = kᵢ(kᵢ-1) + (1-2npᵢ)kᵢ + (npᵢ)²; summing termwise uses the factorial moment, the mean, and total mass 1, then n=m+1 with push_cast and ring closes it (the n=0 case is simp).",
+    "mathContext": "$\\operatorname{Var}(X_i) = E[X_i^2] - (E[X_i])^2 = n(n-1)p_i^2 + n p_i - n^2 p_i^2 = n p_i(1-p_i)$.",
+    "significance": "key",
+    "relatedConcepts": ["variance", "centred second moment"],
+    "prerequisites": ["multinomial_second_factorial_moment", "multinomial_mean"]
+  },
+  {
+    "id": "ann-covariance-matrix",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-04",
+    "range": { "startLine": 289, "endLine": 329 },
+    "type": "theorem",
+    "title": "The unified covariance matrix Cov(Xᵢ,Xⱼ) = n·pᵢ·(δᵢⱼ - pⱼ)",
+    "content": "One formula for every entry. The i=j case reduces to the variance (the centred product becomes a square). The i≠j case is routed through the parent's multinomial_covariance: the centred summand (kᵢ-npᵢ)(kⱼ-npⱼ)·w and the parent's (kᵢkⱼ-n²pᵢpⱼ)·w differ by -(npⱼ)·kᵢ·w - (npᵢ)·kⱼ·w + 2n²pᵢpⱼ·w, whose total mass is -npⱼ·npᵢ - npᵢ·npⱼ + 2n²pᵢpⱼ = 0 (each piece evaluated by multinomial_mean and total mass 1). Hence the centred sum equals the parent's, namely -n·pᵢpⱼ.",
+    "mathContext": "$\\Sigma_{ij} = n p_i(\\delta_{ij} - p_j)$: diagonal $n p_i(1-p_i)$, off-diagonal $-n p_i p_j$; equivalently $\\Sigma = n(\\operatorname{diag}(p) - p p^\\top)$, the rank-deficient covariance supported on $\\{y : \\sum y_i = 0\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["covariance matrix", "Kronecker delta", "multinomial_covariance"],
+    "prerequisites": ["multinomial_variance", "multinomial_covariance", "multinomial_mean"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-04/meta.json
@@ -1,0 +1,94 @@
+{
+  "id": "binomial-theorem-oq-02-oq-01-oq-01-oq-04",
+  "slug": "binomial-theorem-oq-02-oq-01-oq-01-oq-04",
+  "title": "The Full Multinomial Covariance Matrix (Variance and Diagonal)",
+  "description": "Completes the second-order description of the multinomial distribution. The parent binomial-theorem-oq-02-oq-01-oq-01 proves the mean E[Xᵢ]=n·pᵢ, the cross moment E[XᵢXⱼ]=n(n-1)pᵢpⱼ, and the off-diagonal covariance Cov(Xᵢ,Xⱼ)=-n·pᵢ·pⱼ — but only for i≠j; the diagonal (the variance) is explicitly excluded. This entry proves the diagonal second factorial moment E[Xᵢ(Xᵢ-1)]=n(n-1)pᵢ² by the absorption bijection on coordinate i, hence the second moment E[Xᵢ²]=n(n-1)pᵢ²+n·pᵢ and the variance Var(Xᵢ)=n·pᵢ·(1-pᵢ). It then assembles the unified covariance-matrix entry Cov(Xᵢ,Xⱼ)=n·pᵢ·(δᵢⱼ-pⱼ) valid for ALL i,j, recovering the variance on the diagonal and routing the off-diagonal through the parent's covariance theorem (the centred summand and the parent's summand differ by a linear combination of Xᵢ·w and Xⱼ·w whose total mass vanishes). This is the n·(diag(p)-p·pᵀ) covariance matrix in coordinate form. All expectations are discrete finite sums over s.piAntidiag n, matching the parent's convention.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "date": "2026-06-21",
+    "status": "verified",
+    "tags": [
+      "probability",
+      "multinomial",
+      "variance",
+      "covariance-matrix",
+      "second-moment",
+      "factorial-moment",
+      "binomial-theorem"
+    ],
+    "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ04.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 329,
+    "assumptions": "None beyond Mathlib's foundational axioms (propext / Classical.choice / Quot.sound). 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. The probabilistic hypotheses ∑ p = 1 and 0 ≤ pᵢ are ordinary theorem hypotheses, not axioms. Verified by #print axioms on all four public theorems.",
+    "originalContributions": [
+      "multinomial_second_factorial_moment: E[Xᵢ(Xᵢ-1)] = n·(n-1)·pᵢ² — the single-coordinate analogue of the parent's cross moment, via the absorption bijection k ↦ update k i (kᵢ-1); the surviving factor (kᵢ-1) becomes the lowered count k'ᵢ, reducing the sum to n·pᵢ times the (n-1)-mean of Xᵢ",
+      "multinomial_second_moment: E[Xᵢ²] = n·(n-1)·pᵢ² + n·pᵢ, from Xᵢ² = Xᵢ(Xᵢ-1) + Xᵢ",
+      "multinomial_variance: Var(Xᵢ) = E[(Xᵢ-n·pᵢ)²] = n·pᵢ·(1-pᵢ) — the missing diagonal of the covariance matrix, by expanding the centred square as Xᵢ(Xᵢ-1) + (1-2npᵢ)Xᵢ + (npᵢ)² and combining the factorial moment, the mean, and total mass 1",
+      "multinomial_covariance_matrix: the unified entry Cov(Xᵢ,Xⱼ) = E[(Xᵢ-n·pᵢ)(Xⱼ-n·pⱼ)] = n·pᵢ·((if i=j then 1 else 0) - pⱼ) valid for ALL i,j — i=j gives the variance, i≠j is routed through the parent's multinomial_covariance by a mass-zero correction (each correction term sums to n·pᵢ resp. n·pⱼ by multinomial_mean)",
+      "absorb / absorb_weighted (private): the ℕ- and ℝ-level absorption identities re-derived locally (the parent's copies are private), the combinatorial engine kᵢ·multinomial(s,k) = n·multinomial(s,k')"
+    ],
+    "theoremCount": 6,
+    "substantiveTheoremCount": 4,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BinomialTheoremOQ02OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "BinomialTheoremOQ02OQ01OQ01OQ04",
+    "lineCount": 329,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "substantiveTheoremCount": 4,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ04.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "multinomial_covariance_matrix",
+      "type": "core",
+      "description": "The full multinomial covariance matrix, valid for all i,j: Cov(Xᵢ,Xⱼ) = n·pᵢ·(δᵢⱼ - pⱼ), unifying the variance (diagonal) and the off-diagonal covariance into one formula = n·(diag(p) - p·pᵀ).",
+      "leanType": "(s : Finset α) (p : α → ℝ) (n : ℕ) (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i) (i j : α) (hi : i ∈ s) (hj : j ∈ s) → ∑ k ∈ s.piAntidiag n, ((k i : ℝ) - n * p i) * ((k j : ℝ) - n * p j) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l) = (n : ℝ) * p i * ((if i = j then 1 else 0) - p j)"
+    },
+    {
+      "name": "multinomial_variance",
+      "type": "core",
+      "description": "The variance of a multinomial coordinate: Var(Xᵢ) = E[(Xᵢ-n·pᵢ)²] = n·pᵢ·(1-pᵢ) — the diagonal of the covariance matrix, absent from the parent (whose covariance theorem requires i≠j).",
+      "leanType": "(s : Finset α) (p : α → ℝ) (n : ℕ) (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i) (i : α) (hi : i ∈ s) → ∑ k ∈ s.piAntidiag n, ((k i : ℝ) - n * p i) ^ 2 * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l) = (n : ℝ) * p i * (1 - p i)"
+    },
+    {
+      "name": "multinomial_second_factorial_moment",
+      "type": "supporting",
+      "description": "The diagonal second factorial moment E[Xᵢ(Xᵢ-1)] = n·(n-1)·pᵢ², proved via the absorption bijection on coordinate i — the combinatorial heart that the variance rests on.",
+      "leanType": "(s : Finset α) (p : α → ℝ) (n : ℕ) (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i) (i : α) (hi : i ∈ s) → ∑ k ∈ s.piAntidiag n, (k i : ℝ) * ((k i : ℝ) - 1) * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l) = (n : ℝ) * ((n - 1 : ℕ) : ℝ) * p i * p i"
+    },
+    {
+      "name": "multinomial_second_moment",
+      "type": "supporting",
+      "description": "The second moment E[Xᵢ²] = n·(n-1)·pᵢ² + n·pᵢ, from the decomposition Xᵢ² = Xᵢ(Xᵢ-1) + Xᵢ.",
+      "leanType": "(s : Finset α) (p : α → ℝ) (n : ℕ) (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i) (i : α) (hi : i ∈ s) → ∑ k ∈ s.piAntidiag n, (k i : ℝ) ^ 2 * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l) = (n : ℝ) * ((n - 1 : ℕ) : ℝ) * p i * p i + (n : ℝ) * p i"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-01",
+      "relationship": "answers-question",
+      "description": "Completes the recorded follow-up of binomial-theorem-oq-02-oq-01-oq-01: the variance Var(Xᵢ)=n·pᵢ(1-pᵢ) and the full covariance matrix; uses its public multinomial_mean and multinomial_covariance."
+    },
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Sibling marginal-CLT entry whose open-question list names the multinomial covariance as input to a future joint (Cramér-Wold) CLT; this entry supplies the complete covariance matrix that such a joint CLT requires."
+    }
+  ]
+}

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-04.json
@@ -1,0 +1,65 @@
+{
+  "slug": "binomial-theorem-oq-02-oq-01-oq-01-oq-04",
+  "title": "The full multinomial covariance matrix: variance Var(Xᵢ)=n·pᵢ(1-pᵢ) and the unified entry Cov(Xᵢ,Xⱼ)=n·pᵢ(δᵢⱼ-pⱼ)",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "tractability": 8,
+  "significance": 6,
+  "started": "2026-06-21T00:00:00Z",
+  "lastUpdate": "2026-06-21T00:00:00Z",
+  "path": "full",
+  "problemStatement": "The parent binomial-theorem-oq-02-oq-01-oq-01 proves the multinomial mean, cross moment, and off-diagonal covariance (i≠j only). Its recorded follow-up asks for the variance Var(Xᵢ)=n·pᵢ(1-pᵢ) and the full covariance matrix. The diagonal is genuinely missing because the parent's covariance theorem requires i≠j.",
+  "leanFiles": [
+    {
+      "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ04.lean",
+      "filename": "BinomialTheoremOQ02OQ01OQ01OQ04.lean",
+      "lineCount": 329,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ04.lean"
+    }
+  ],
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-21T00:00:00Z",
+    "iteration": 1,
+    "focus": "Proved (0-axiom, verified) the diagonal second factorial moment E[Xᵢ(Xᵢ-1)]=n(n-1)pᵢ² via the absorption bijection on coordinate i, hence the second moment E[Xᵢ²]=n(n-1)pᵢ²+npᵢ, the variance Var(Xᵢ)=n·pᵢ(1-pᵢ), and the unified covariance-matrix entry Cov(Xᵢ,Xⱼ)=n·pᵢ(δᵢⱼ-pⱼ) for all i,j (= n·(diag(p)-p·pᵀ)). The off-diagonal case routes through the parent's public multinomial_covariance via a mass-zero correction.",
+    "blockers": [],
+    "nextAction": "Joint multinomial CLT via Cramér-Wold now has its complete covariance input. Optional: lift the discrete-sum moments to genuine PMF.toMeasure / integral expectations; package for a Mathlib contribution.",
+    "attemptCounts": { "total": 1, "currentApproach": 1, "approachesTried": 1 }
+  },
+  "knowledge": {
+    "insights": [
+      "The diagonal (variance) is genuinely absent from the parent: multinomial_covariance carries the hypothesis i≠j, so the i=j entry was never proved.",
+      "The single-coordinate second factorial moment E[Xᵢ(Xᵢ-1)]=n(n-1)pᵢ² is the exact analogue of the parent's cross moment: the same absorption bijection k↦update k i (kᵢ-1) applies, with the surviving factor (kᵢ-1) becoming the lowered count k'ᵢ instead of a separate coordinate kⱼ.",
+      "The unified covariance matrix Cov(Xᵢ,Xⱼ)=n·pᵢ(δᵢⱼ-pⱼ) does NOT require reproving the cross moment: the off-diagonal case can be obtained from the parent's public multinomial_covariance because the centred summand (kᵢ-npᵢ)(kⱼ-npⱼ)·w and the parent's (kᵢkⱼ-n²pᵢpⱼ)·w differ by a linear combination of kᵢ·w and kⱼ·w whose total mass vanishes (each summing to n·pᵢ resp. n·pⱼ by multinomial_mean, total mass 1)."
+    ],
+    "builtItems": [
+      "multinomial_second_factorial_moment : E[Xᵢ(Xᵢ-1)]=n(n-1)pᵢ² (BinomialTheoremOQ02OQ01OQ01OQ04.lean:151)",
+      "multinomial_second_moment : E[Xᵢ²]=n(n-1)pᵢ²+npᵢ (BinomialTheoremOQ02OQ01OQ01OQ04.lean:239)",
+      "multinomial_variance : Var(Xᵢ)=n·pᵢ(1-pᵢ) (BinomialTheoremOQ02OQ01OQ01OQ04.lean:256)",
+      "multinomial_covariance_matrix : Cov(Xᵢ,Xⱼ)=n·pᵢ(δᵢⱼ-pⱼ) for all i,j (BinomialTheoremOQ02OQ01OQ01OQ04.lean:289)",
+      "absorb / absorb_weighted (private) : ℕ- and ℝ-level absorption identities re-derived locally (parent's are private)"
+    ],
+    "mathlibGaps": [
+      "The parent's absorption lemmas (multinomial_absorb, multinomial_absorb_weighted, multinomial_cross_moment) are `private`, so the diagonal factorial moment had to re-derive the absorption engine."
+    ],
+    "nextSteps": [
+      "Lift the discrete finite-sum moments to genuine PMF.toMeasure / Lebesgue-integral expectations for tighter integration with Mathlib's probability framework.",
+      "Use the now-complete covariance matrix as the covariance input to a joint (vector) multinomial CLT via Cramér-Wold (the limit is the degenerate normal on {y : ∑yᵢ=0})."
+    ],
+    "progressSummary": "COMPLETE (verified, 0-axiom): full second-order description of the multinomial — variance + unified covariance matrix n·(diag(p)-p·pᵀ)."
+  },
+  "tags": [
+    "probability",
+    "multinomial",
+    "variance",
+    "covariance-matrix",
+    "second-moment",
+    "binomial-theorem"
+  ]
+}

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01.json
@@ -9,7 +9,8 @@
       "The absorption identity kᵢ·multinomial(s,k)=n·multinomial(s, kᵢ−1) is a single combinatorial engine: a no-division ℕ proof cancelling (kᵢ−1)!·∏_{j≠i}kⱼ! after Nat.multinomial_spec",
       "Mean and cross moment both reduce, via ONE Finset.sum_nbij' bijection lowering kᵢ, to the multinomial theorem on n−1 trials; the kⱼ factor in the cross moment rides along unchanged (j≠i), so E[XᵢXⱼ]=n·pᵢ·(mean of Xⱼ at n−1)=n(n−1)pᵢpⱼ",
       "Marginal of Xᵢ is Binomial(n,pᵢ): reindex compositions with kᵢ=m onto compositions of n−m on s∖{i} (zero the i-th coord), Nat.multinomial_insert splits off C(n,m), and ∑_{j≠i}pⱼ=1−pᵢ",
-      "Covariance Cov(Xᵢ,Xⱼ)=−n·pᵢ·pⱼ reflects the simplex constraint ΣXᵢ=n (negative correlation)"
+      "Covariance Cov(Xᵢ,Xⱼ)=−n·pᵢ·pⱼ reflects the simplex constraint ΣXᵢ=n (negative correlation)",
+      "Variance Var(Xᵢ)=n·pᵢ(1-pᵢ) and the full covariance matrix Cov(Xᵢ,Xⱼ)=n·pᵢ(δᵢⱼ-pⱼ) (= n·(diag(p)-p·pᵀ)) completed in child binomial-theorem-oq-02-oq-01-oq-01-oq-04 (verified, 0-axiom), via a diagonal second factorial moment by absorption + routing the off-diagonal through the existing covariance theorem."
     ],
     "builtItems": [
       "BinomialTheoremOQ02OQ01OQ01.lean: 707-line fully verified formalization (0 sorries, 0 axioms; #print axioms lists only propext/Classical.choice/Quot.sound)",


### PR DESCRIPTION
## Summary

Completes the **second-order description of the multinomial distribution**. The parent `binomial-theorem-oq-02-oq-01-oq-01` proves the mean `E[Xᵢ]=n·pᵢ`, the cross moment `E[XᵢXⱼ]=n(n-1)pᵢpⱼ`, and the off-diagonal covariance `Cov(Xᵢ,Xⱼ)=-n·pᵢpⱼ` — but its covariance theorem carries the hypothesis `i≠j`, so the **diagonal (the variance) was genuinely missing**. This entry supplies it and assembles the full covariance matrix.

## New results (all 0-axiom, sorry-free)

- `multinomial_second_factorial_moment`: `E[Xᵢ(Xᵢ-1)] = n(n-1)pᵢ²` — the single-coordinate analogue of the parent's cross moment, via the **absorption bijection** `k ↦ update k i (kᵢ-1)` (the surviving factor `(kᵢ-1)` becomes the lowered count `k'ᵢ`, reducing the sum to `n·pᵢ` × the `(n-1)`-mean of `Xᵢ`).
- `multinomial_second_moment`: `E[Xᵢ²] = n(n-1)pᵢ² + n·pᵢ`.
- `multinomial_variance`: `Var(Xᵢ) = n·pᵢ·(1-pᵢ)` — the missing diagonal.
- `multinomial_covariance_matrix`: the **unified entry** `Cov(Xᵢ,Xⱼ) = n·pᵢ·(δᵢⱼ - pⱼ)` valid for **all** `i,j` (= `n·(diag(p) - p·pᵀ)`). The `i=j` case is the variance; the `i≠j` case is routed through the parent's public `multinomial_covariance` via a **mass-zero correction** (the centred summand and the parent's summand differ by a combination of `kᵢ·w` and `kⱼ·w` whose total mass vanishes), so the cross moment need not be reproved.

All expectations are discrete finite sums over `s.piAntidiag n`, matching the parent's convention.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ02OQ01OQ01OQ04` → builds (7745 jobs), 0 sorries.
- `#print axioms` on all four public theorems → `[propext, Classical.choice, Quot.sound]` only (0-axiom, `verified`).
- 329 lines, 4 public theorems + 2 private absorption helpers (re-derived because the parent's are `private`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)