### PR TITLE
research(catalan-numbers-oq-01-oq-02-oq-01): p-adic valuation of Catalan numbers at an arbitrary prime [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3554,3 +3554,4 @@ import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06
 
 import Proofs.ZetaRegularization
 import Proofs.CatalanNumbersOQ01OQ02
+import Proofs.CatalanNumbersOQ01OQ02OQ01

--- a/proofs/Proofs/CatalanNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CatalanNumbersOQ01OQ02OQ01.lean
@@ -1,0 +1,137 @@
+import Mathlib
+
+/-!
+# Catalan OQ-01-OQ-02-OQ-01: The `p`-adic Valuation of the Catalan Numbers
+
+The sibling entry `catalan-numbers-oq-01-oq-02` describes the **2-adic** valuation
+of the Catalan numbers `Cₙ = catalan n`, obtaining `v₂(Cₙ) = s₂(n+1) − 1` and the
+parity law `Cₙ` odd ⟺ `n + 1` is a power of two.  That argument was special to the
+prime `2`, where the binary digit sum is doubling-invariant: `s₂(2n) = s₂(n)`.
+
+This entry removes that restriction and describes the valuation of `Cₙ` at an
+**arbitrary prime `p`**.  The two ingredients are both general in `p`:
+
+* **Legendre's formula** `(p − 1)·v_p(m!) = m − s_p(m)`
+  (`sub_one_mul_padicValNat_factorial`), where `s_p` is the base-`p` digit sum, and
+* the factorisation `(2n)! = C(2n,n)·(n!)²`, giving the central-binomial valuation.
+
+Combining these with `(n+1)·Cₙ = C(2n,n)` (`succ_mul_catalan_eq_centralBinom`)
+yields the complete, division-free identity
+
+* `sub_one_mul_padicValNat_centralBinom` : `(p−1)·v_p(C(2n,n)) + s_p(2n) = 2·s_p(n)`
+* `sub_one_mul_padicValNat_catalan`      :
+    `(p−1)·(v_p(Cₙ) + v_p(n+1)) + s_p(2n) = 2·s_p(n)`
+
+and a clean **`p`-divisibility criterion** generalising the parity law:
+
+* `not_dvd_catalan_iff` :
+    `p ∤ Cₙ ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n)`.
+
+For `p = 2` this recovers the sibling's `Cₙ` odd ⟺ `v₂(n+1) + s₂(n) = 2·s₂(n)`,
+i.e. (via the carry identity) `s₂(n+1) = 1`.  The quantity `2·s_p(n) − s_p(2n)` is
+exactly `(p−1)` times Kummer's carry count for `n + n` in base `p`, so the headline
+identity is Kummer's theorem made explicit for the Catalan numbers.
+
+All results are fully machine-checked: `0` `sorry`, `0` `axiom`, no `native_decide`.
+-/
+
+open Nat
+
+namespace CatalanPAdic
+
+variable {p : ℕ}
+
+/-- `catalan n ≠ 0` (mirrors the sibling entry; needed for valuation splitting). -/
+theorem catalan_ne_zero (n : ℕ) : catalan n ≠ 0 := by
+  intro h
+  have hmul := succ_mul_catalan_eq_centralBinom n
+  rw [h, Nat.mul_zero] at hmul
+  exact (Nat.centralBinom_pos n).ne' hmul.symm
+
+/-- **Central-binomial valuation at a general prime.**
+`(p − 1)·v_p(C(2n,n)) + s_p(2n) = 2·s_p(n)`.
+
+Proved straight from Legendre's formula applied to `(2n)!` and `n!`, together with
+the factorisation `(2n)! = C(2n,n)·(n!)²`.  No base-`p` digit induction and no
+truncated subtraction: `s_p(m) ≤ m` (`digit_sum_le`) keeps every step additive. -/
+theorem sub_one_mul_padicValNat_centralBinom [hp : Fact p.Prime] (n : ℕ) :
+    (p - 1) * padicValNat p (Nat.centralBinom n) + (Nat.digits p (2 * n)).sum
+      = 2 * (Nat.digits p n).sum := by
+  -- Legendre's formula on `(2n)!` and `n!`.
+  have L2 := sub_one_mul_padicValNat_factorial (p := p) (2 * n)
+  have Ln := sub_one_mul_padicValNat_factorial (p := p) n
+  have b2 : (Nat.digits p (2 * n)).sum ≤ 2 * n := Nat.digit_sum_le p (2 * n)
+  have bn : (Nat.digits p n).sum ≤ n := Nat.digit_sum_le p n
+  -- Factorisation `(2n)! = C(2n,n)·n!·n!`.
+  have hC : Nat.centralBinom n ≠ 0 := (Nat.centralBinom_pos n).ne'
+  have hn! : (n ! : ℕ) ≠ 0 := Nat.factorial_ne_zero n
+  have hfac : Nat.centralBinom n * n ! * n ! = (2 * n)! := by
+    have h := Nat.choose_mul_factorial_mul_factorial (show n ≤ 2 * n by omega)
+    rw [show 2 * n - n = n by omega, ← Nat.centralBinom_eq_two_mul_choose] at h
+    exact h
+  -- Hence `v_p((2n)!) = v_p(C) + v_p(n!) + v_p(n!)`.
+  have hv : padicValNat p ((2 * n)!)
+      = padicValNat p (Nat.centralBinom n) + padicValNat p (n !) + padicValNat p (n !) := by
+    rw [← hfac, padicValNat.mul (Nat.mul_ne_zero hC hn!) hn!, padicValNat.mul hC hn!]
+  -- The single nonlinear step: distribute `(p−1)` over `hv`.
+  have hmul : (p - 1) * padicValNat p ((2 * n)!)
+      = (p - 1) * padicValNat p (Nat.centralBinom n) + 2 * ((p - 1) * padicValNat p (n !)) := by
+    rw [hv]; ring
+  omega
+
+/-- **The `p`-adic valuation of the Catalan numbers.**
+`(p − 1)·(v_p(Cₙ) + v_p(n+1)) + s_p(2n) = 2·s_p(n)`.
+
+Immediate from the central-binomial identity and `(n+1)·Cₙ = C(2n,n)`. -/
+theorem sub_one_mul_padicValNat_catalan [hp : Fact p.Prime] (n : ℕ) :
+    (p - 1) * (padicValNat p (catalan n) + padicValNat p (n + 1))
+      + (Nat.digits p (2 * n)).sum = 2 * (Nat.digits p n).sum := by
+  have hcb := sub_one_mul_padicValNat_centralBinom (p := p) n
+  have hmul := succ_mul_catalan_eq_centralBinom n
+  have hsplit : padicValNat p (Nat.centralBinom n)
+      = padicValNat p (n + 1) + padicValNat p (catalan n) := by
+    rw [← hmul, padicValNat.mul (by omega) (catalan_ne_zero n)]
+  have hexp : (p - 1) * padicValNat p (Nat.centralBinom n)
+      = (p - 1) * (padicValNat p (catalan n) + padicValNat p (n + 1)) := by
+    rw [hsplit]; ring
+  omega
+
+/-- **`p`-divisibility criterion for the Catalan numbers.**
+`p ∤ Cₙ ⟺ (p − 1)·v_p(n+1) + s_p(2n) = 2·s_p(n)`.
+
+This generalises the sibling's parity law: for `p = 2` the right side is
+`v₂(n+1) + s₂(n) = 2·s₂(n)`, i.e. `v₂(n+1) = s₂(n)`, which (with the carry identity)
+is equivalent to `n + 1` being a power of two. -/
+theorem not_dvd_catalan_iff [hp : Fact p.Prime] (n : ℕ) :
+    ¬ p ∣ catalan n ↔
+      (p - 1) * padicValNat p (n + 1) + (Nat.digits p (2 * n)).sum
+        = 2 * (Nat.digits p n).sum := by
+  have hcat : catalan n ≠ 0 := catalan_ne_zero n
+  have hdvd : p ∣ catalan n ↔ 1 ≤ padicValNat p (catalan n) := by
+    rw [← padicValNat_dvd_iff_le hcat, pow_one]
+  have hmain := sub_one_mul_padicValNat_catalan (p := p) n
+  have hexp : (p - 1) * (padicValNat p (catalan n) + padicValNat p (n + 1))
+      = (p - 1) * padicValNat p (catalan n) + (p - 1) * padicValNat p (n + 1) := by ring
+  constructor
+  · intro h
+    have hz : padicValNat p (catalan n) = 0 := by rw [hdvd] at h; omega
+    have hβ : (p - 1) * padicValNat p (catalan n) = 0 := by rw [hz, Nat.mul_zero]
+    omega
+  · intro h
+    rw [hdvd]
+    intro hle
+    have hp2 : 2 ≤ p := hp.out.two_le
+    have hzero : (p - 1) * padicValNat p (catalan n) = 0 := by omega
+    have : padicValNat p (catalan n) = 0 := by
+      rcases Nat.mul_eq_zero.mp hzero with h1 | h2
+      · omega
+      · exact h2
+    omega
+
+/-! ### Concrete example -/
+
+/-- `C₂ = 2` is not divisible by `3`.  The criterion's right side reads
+`(3−1)·v₃(3) + s₃(4) = 2·1 + 2 = 4 = 2·s₃(2) = 2·2`, consistent with `3 ∤ C₂`. -/
+example : ¬ (3 : ℕ) ∣ catalan 2 := by rw [catalan_two]; decide
+
+end CatalanPAdic

--- a/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "catalan-numbers-oq-01-oq-02-oq-01",
+  "title": "Catalan Numbers: the p-adic valuation at an arbitrary prime, (p−1)·(v_p(Cₙ)+v_p(n+1)) + s_p(2n) = 2·s_p(n)",
+  "slug": "catalan-numbers-oq-01-oq-02-oq-01",
+  "description": "Generalises the sibling entry's 2-adic valuation of the Catalan numbers to an arbitrary prime p, directly answering its first listed open question. The 2-adic argument was special to p = 2, where the binary digit sum is doubling-invariant (s₂(2n) = s₂(n)); at a general prime that simplification disappears and the quantity 2·s_p(n) − s_p(2n) — exactly (p−1) times Kummer's carry count for n + n in base p — genuinely appears. Working entirely from Legendre's formula (p−1)·v_p(m!) = m − s_p(m) and the factorisation (2n)! = C(2n,n)·(n!)², the entry proves the division-free central-binomial identity (p−1)·v_p(C(2n,n)) + s_p(2n) = 2·s_p(n), then, via (n+1)·Cₙ = C(2n,n), the full Catalan identity (p−1)·(v_p(Cₙ) + v_p(n+1)) + s_p(2n) = 2·s_p(n). The headline corollary is a p-divisibility criterion generalising the sibling's parity law: p ∤ Cₙ ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n); for p = 2 this collapses to v₂(n+1) = s₂(n), i.e. n+1 a power of two. No base-p digit induction and no truncated subtraction: the bound s_p(m) ≤ m (digit_sum_le) keeps every step additive, and a single ring step distributes (p−1) over the valuation split. Verified with 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Classical (Kummer/Legendre arithmetic of binomial coefficients); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CatalanNumbersOQ01OQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "catalan-numbers",
+      "p-adic-valuation",
+      "kummer-theorem",
+      "legendre-formula",
+      "digit-sum",
+      "central-binomial",
+      "divisibility",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "sub_one_mul_padicValNat_factorial",
+        "description": "Legendre's theorem: (p−1)·v_p(m!) = m − (digits p m).sum. Applied to (2n)! and n! it produces the additive equations (p−1)·v_p((2n)!) + s_p(2n) = 2n and (p−1)·v_p(n!) + s_p(n) = n, the whole engine of the proof. General in p — no specialisation to a fixed prime.",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "k ≤ n → C(n,k)·k!·(n−k)! = n!. At (n,k) = (2n,n) it gives (2n)! = C(2n,n)·n!·n!, letting v_p of (2n)! split as v_p(C(2n,n)) + 2·v_p(n!).",
+        "module": "Mathlib.Data.Nat.Choose.Factorization"
+      },
+      {
+        "theorem": "succ_mul_catalan_eq_centralBinom",
+        "description": "(n + 1) · catalan n = Nat.centralBinom n. The multiplicative bridge from the Catalan numbers to the central binomial coefficient; v_p of both sides splits the valuation as v_p(n+1) + v_p(catalan n) = v_p(C(2n,n)).",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "padicValNat.mul",
+        "description": "a ≠ 0 → b ≠ 0 → v_p(a·b) = v_p(a) + v_p(b). Additivity of the p-adic valuation, used to split v_p across (2n)! = C(2n,n)·n!·n! and (n+1)·catalan n.",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "padicValNat_dvd_iff_le",
+        "description": "a ≠ 0 → (pⁿ ∣ a ↔ n ≤ v_p(a)). Turns p ∣ catalan n into 1 ≤ v_p(catalan n), the bridge from divisibility to the valuation identity in the p-divisibility criterion.",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.digit_sum_le",
+        "description": "(digits p n).sum ≤ n. The bound that makes the ℕ subtractions in Legendre's formula exact, so omega can combine the equations additively without truncation.",
+        "module": "Mathlib.Data.Nat.Digits.Defs"
+      },
+      {
+        "theorem": "Nat.centralBinom_eq_two_mul_choose",
+        "description": "centralBinom n = (2n).choose n. Rewrites the factorisation lemma's output into central-binomial form.",
+        "module": "Mathlib.Combinatorics.Choose.Central"
+      }
+    ],
+    "originalContributions": [
+      "sub_one_mul_padicValNat_centralBinom: (p−1)·v_p(C(2n,n)) + s_p(2n) = 2·s_p(n) for any prime p. The general-p central-binomial valuation, proved from Legendre's formula on (2n)! and n! plus the factorisation (2n)! = C(2n,n)·(n!)² — no digit-sum Kummer lemma and no truncated subtraction.",
+      "sub_one_mul_padicValNat_catalan: (p−1)·(v_p(catalan n) + v_p(n+1)) + s_p(2n) = 2·s_p(n). The complete, division-free p-adic valuation identity for the Catalan numbers, obtained by splitting v_p across (n+1)·catalan n = C(2n,n).",
+      "not_dvd_catalan_iff: p ∤ catalan n ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n). A p-divisibility criterion generalising the sibling's parity law (p = 2 ⇒ v₂(n+1) = s₂(n) ⟺ n+1 a power of two).",
+      "Proof technique: every step is additive in ℕ — Legendre's truncated subtractions are made exact by digit_sum_le, and the only nonlinear move is a single ring step distributing (p−1) over the valuation split, after which omega closes each identity.",
+      "Concrete witness: 3 ∤ catalan 2, matching the criterion's right side (2·1 + s₃(4) = 4 = 2·s₃(2)); by kernel decide, no native_decide."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. No native_decide (the lone concrete example uses kernel `decide` on ¬ 3 ∣ 2, hence no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 137,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Kummer's theorem (1852) computes the p-adic valuation of a binomial coefficient C(m+n, m) as the number of carries when adding m and n in base p, equivalently (s_p(m) + s_p(n) − s_p(m+n))/(p−1); Legendre's formula gives v_p(m!) = (m − s_p(m))/(p−1). For the central binomial coefficient C(2n,n) the carry count is (2·s_p(n) − s_p(2n))/(p−1), and the extra factor n+1 dividing C(2n,n) — the Catalan denominator — contributes the −v_p(n+1) correction. The 2-adic case is famously clean because s₂(2n) = s₂(n), so the central-binomial valuation is simply s₂(n); at a general prime no such collapse occurs and the full quantity 2·s_p(n) − s_p(2n) must be carried.",
+    "problemStatement": "The sibling entry catalan-numbers-oq-01-oq-02 determines the 2-adic valuation v₂(catalan n) = s₂(n+1) − 1 and asks, as its first open question, for the exact p-adic valuation at odd primes p and a characterisation of when p ∤ catalan n. What is v_p(catalan n) for a general prime p?\n\n**Answer:** (p−1)·(v_p(catalan n) + v_p(n+1)) + s_p(2n) = 2·s_p(n), where s_p is the base-p digit sum; equivalently v_p(catalan n) = (2·s_p(n) − s_p(2n))/(p−1) − v_p(n+1). Consequently p ∤ catalan n if and only if (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n).",
+    "text": "Legendre's formula applied to (2n)! and n!, combined with the factorisation (2n)! = C(2n,n)·(n!)² and the Catalan bridge (n+1)·Cₙ = C(2n,n), yields the complete p-adic valuation of the Catalan numbers at an arbitrary prime, and a clean p-divisibility criterion — all with 0 axioms.",
+    "proofStrategy": "1. sub_one_mul_padicValNat_centralBinom: apply Legendre's formula to (2n)! and n! to get the exact additive equations (p−1)·v_p((2n)!) + s_p(2n) = 2n and (p−1)·v_p(n!) + s_p(n) = n (exactness from digit_sum_le). Use the factorisation (2n)! = C(2n,n)·n!·n! and valuation additivity to write v_p((2n)!) = v_p(C(2n,n)) + 2·v_p(n!); a single ring step distributes (p−1) over this split, and omega combines everything into (p−1)·v_p(C(2n,n)) + s_p(2n) = 2·s_p(n).\n2. sub_one_mul_padicValNat_catalan: take v_p across (n+1)·catalan n = C(2n,n); additivity gives v_p(C(2n,n)) = v_p(n+1) + v_p(catalan n). A ring step distributes (p−1) over the split and omega yields the Catalan identity.\n3. not_dvd_catalan_iff: p ∤ catalan n ⟺ v_p(catalan n) = 0 (via padicValNat_dvd_iff_le); substitute v_p(catalan n) = 0 into the Catalan identity. The reverse direction uses p ≥ 2 (so p − 1 ≠ 0) with Nat.mul_eq_zero to conclude v_p(catalan n) = 0 from (p−1)·v_p(catalan n) = 0.",
+    "keyInsights": [
+      "**Why p = 2 was special, and what replaces it.** The 2-adic proof used s₂(2n) = s₂(n) to reduce the central-binomial valuation to a single digit sum. No analogous identity holds at odd primes, so the genuine invariant is 2·s_p(n) − s_p(2n) = (p−1)·(carries of n + n in base p); the general theorem makes this Kummer carry count explicit for the Catalan numbers.",
+      "**Legendre alone suffices — Kummer's digit-sum lemma is not needed.** Rather than invoke the digit-sum form of Kummer's theorem (as the sibling did at p = 2), the central-binomial valuation here is reconstructed directly from Legendre's formula on (2n)! and n! together with (2n)! = C(2n,n)·(n!)². This keeps the argument elementary and uniform in p.",
+      "**Everything stays additive in ℕ.** Legendre's formula is stated with truncated subtraction; the bound s_p(m) ≤ m (digit_sum_le) certifies that no truncation occurs, so each statement is an exact additive identity that omega closes after one ring step distributing (p−1) over a valuation split.",
+      "**The criterion generalises the parity law.** For p = 2 the divisibility criterion (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n) becomes v₂(n+1) + s₂(n) = 2·s₂(n), i.e. v₂(n+1) = s₂(n), which (with the carry identity) is exactly n+1 being a power of two — recovering 'Cₙ odd ⟺ n = 2ᵏ − 1'."
+    ],
+    "exampleSections": [
+      {
+        "title": "The criterion at p = 3",
+        "mathContext": "C₂ = 2 is not divisible by 3. The criterion's right side reads (3−1)·v₃(3) + s₃(4) = 2·1 + 2 = 4 = 2·s₃(2) = 2·2, confirming 3 ∤ C₂. More generally C₅ = 42 = 2·3·7 has v₃(C₅) = 1: here s₃(5) = 3 (5 = 12₃), s₃(10) = 2 (10 = 101₃), v₃(6) = 1, and indeed (3−1)·(1 + 1) + 2 = 6 = 2·3 = 2·s₃(5)."
+      }
+    ]
+  },
+  "references": [
+    {
+      "authors": "Kummer, Ernst Eduard",
+      "title": "Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen",
+      "year": "1852",
+      "note": "J. Reine Angew. Math. 44 — the carry-counting theorem giving (p−1)·v_p(C(2n,n)) = 2·s_p(n) − s_p(2n)."
+    },
+    {
+      "authors": "Legendre, Adrien-Marie",
+      "title": "Théorie des nombres",
+      "year": "1830",
+      "note": "Legendre's formula v_p(m!) = (m − s_p(m))/(p−1), the sole engine of this entry."
+    },
+    {
+      "authors": "Deutsch, Emeric; Sagan, Bruce E.",
+      "title": "Congruences for Catalan and Motzkin numbers and related sequences",
+      "year": "2006",
+      "note": "J. Number Theory 117 — treats p-adic valuations and congruences of the Catalan numbers across primes."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "catalan-numbers-oq-01-oq-02",
+      "reason": "Parent entry: the 2-adic valuation v₂(catalan n) = s₂(n+1) − 1 and oddness ⟺ n = 2ᵏ−1. This entry answers that entry's first open question by generalising the valuation to an arbitrary prime p."
+    },
+    {
+      "id": "kummer-theorem-oq-04",
+      "reason": "Provides the central-binomial valuation in carry form; this entry re-derives it via Legendre and divides by the Catalan denominator n+1 at a general prime."
+    },
+    {
+      "id": "catalan-numbers-oq-01-oq-01",
+      "reason": "Sibling entry on the central-binomial reflection form of the Catalan numbers, also built on succ_mul_catalan_eq_centralBinom."
+    }
+  ],
+  "conclusion": {
+    "summary": "At an arbitrary prime p the Catalan valuation satisfies (p−1)·(v_p(catalan n) + v_p(n+1)) + s_p(2n) = 2·s_p(n) (sub_one_mul_padicValNat_catalan), built on the general-p central-binomial identity (p−1)·v_p(C(2n,n)) + s_p(2n) = 2·s_p(n) (sub_one_mul_padicValNat_centralBinom). The corollary p ∤ catalan n ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n) (not_dvd_catalan_iff) generalises the sibling's parity law. All results verified with 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Answers the sibling entry's first open question, extending the gallery's arithmetic of the Catalan numbers from the prime 2 to all primes, and demonstrates an elementary uniform-in-p route through Legendre's formula that avoids the digit-sum Kummer lemma and any base-p digit induction.",
+    "openQuestions": [
+      "Recast the criterion via Kummer carries: characterise the n for which the number of base-p carries in n + n equals v_p(n+1), giving p ∤ catalan n; describe the resulting index sets for small odd primes p.",
+      "Sum the valuation identity over n ≤ N to obtain the average p-adic valuation of the Catalan numbers and compare with the s_p(2n) − 2·s_p(n) digit-sum statistics."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "CatalanPAdic",
+    "lineCount": 137,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/CatalanNumbersOQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Generalises the sibling entry **catalan-numbers-oq-01-oq-02** (2-adic valuation `v₂(Cₙ) = s₂(n+1) − 1`, oddness ⟺ `n = 2ᵏ − 1`) to an **arbitrary prime `p`** — directly answering that entry's first listed open question.

The 2-adic argument was special to `p = 2`, where the binary digit sum is doubling-invariant (`s₂(2n) = s₂(n)`). At a general prime that collapse disappears and the genuine invariant `2·s_p(n) − s_p(2n)` — exactly `(p−1)` times Kummer's carry count for `n + n` in base `p` — must be carried.

## Results (`Proofs/CatalanNumbersOQ01OQ02OQ01.lean`, 137L, 4 thm)

- `sub_one_mul_padicValNat_centralBinom` : `(p−1)·v_p(C(2n,n)) + s_p(2n) = 2·s_p(n)`
- `sub_one_mul_padicValNat_catalan` : `(p−1)·(v_p(Cₙ) + v_p(n+1)) + s_p(2n) = 2·s_p(n)`
- `not_dvd_catalan_iff` : `p ∤ Cₙ ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n)` (generalises the parity law; `p = 2` ⇒ `v₂(n+1) = s₂(n)` ⟺ `n+1` a power of two)

## Method

Built entirely from **Legendre's formula** `(p−1)·v_p(m!) = m − s_p(m)` applied to `(2n)!` and `n!`, plus the factorisation `(2n)! = C(2n,n)·(n!)²` and the Catalan bridge `(n+1)·Cₙ = C(2n,n)`. No digit-sum Kummer lemma, no base-`p` digit induction, and no truncated subtraction: `digit_sum_le` keeps every step additive, and the only nonlinear move is one `ring` step distributing `(p−1)` over a valuation split, after which `omega` closes each identity.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CatalanNumbersOQ01OQ02OQ01` — Build completed successfully (7743 jobs)
- `#print axioms` on all three main theorems: `[propext, Classical.choice, Quot.sound]` only
- **0 sorries, 0 axioms, no `native_decide`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)