### PR TITLE
research(pell-equation-oq-06-oq-01): classify ALL positive solutions of negative Pell x²−2y²=−1 via descent [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3071,6 +3071,7 @@ import Proofs.PellEquation
 import Proofs.PellEquationOQ01
 import Proofs.PellEquationOQ05
 import Proofs.PellEquationOQ06
+import Proofs.PellEquationOQ06OQ01
 import Proofs.PentagonalNumberTheoremOQ01
 import Proofs.PerfectNumbers
 import Proofs.PerfectNumbersOQ03

--- a/proofs/Proofs/PellEquationOQ06OQ01.lean
+++ b/proofs/Proofs/PellEquationOQ06OQ01.lean
@@ -1,0 +1,167 @@
+/-
+Pell's Equation OQ-06-OQ-01: Classification of the negative Pell solutions x² − 2y² = −1
+
+The parent entry `pell-equation-oq-06` (`Proofs/PellEquationOQ06.lean`) builds the
+explicit chain
+
+    (1, 1) → (7, 5) → (41, 29) → (239, 169) → …,   (x, y) ↦ (3x + 4y, 2x + 3y),
+
+of solutions to the negative Pell equation x² − 2y² = −1 and shows there are
+**infinitely many** integer solutions. That leaves open the *converse* question — the
+genuine structural content — of whether the chain captures *every* solution.
+
+This entry proves the **classification theorem**: the positive-integer solutions of
+x² − 2y² = −1 are *exactly* the terms of the chain. The proof is a descent
+(Vieta-jumping) argument:
+
+  • the inverse substitution (x, y) ↦ (3x − 4y, 3y − 2x) also preserves the form
+    (it is multiplication by the inverse unit 3 − 2√2 in ℤ[√2]);
+  • for every positive solution other than the fundamental (1, 1), this predecessor is
+    again a positive solution with a strictly smaller first coordinate;
+  • the only positive solutions with x ≤ 6 is the base point — there is none with
+    2 ≤ x ≤ 6 — so the descent terminates exactly at (1, 1).
+
+Strong induction on `x.toNat` then shows every positive solution lies on the chain,
+giving the set equality
+
+    {(x, y) | x ≥ 1, y ≥ 1, x² − 2y² = −1} = range negPellSeq.
+
+We also record the multiplicative bridge to the *positive* Pell equation: squaring any
+norm −1 solution yields a norm +1 solution, since the ℤ[√2]-norm is multiplicative and
+(−1)·(−1) = +1.
+
+Main results:
+  • `negPell_pred_step`            — the inverse map preserves x² − 2y².
+  • `negPell_no_small_solution`    — no positive solution has 2 ≤ x ≤ 6.
+  • `negPell_complete`             — every positive solution is a term of the chain.
+  • `negPell_solutions_eq_range`   — exact set equality {positive solutions} = range chain.
+  • `negPell_sq_is_pos_pell`       — squaring a norm −1 solution gives a norm +1 solution.
+
+All proofs are `sorry`-free and axiom-free (no `native_decide`).
+
+References:
+- Parent entry `pell-equation-oq-06` (the chain and its infinitude).
+- Mathlib `Pell.Solution₁` covers only the norm +1 equation; the norm −1 case and its
+  classification are not in Mathlib.
+-/
+
+import Mathlib
+import Proofs.PellEquationOQ06
+
+namespace PellEquationOQ06
+
+/-
+## The inverse step and the descent
+-/
+
+/-- **Inverse step preserves the negative-Pell form.** The substitution
+    `(x, y) ↦ (3x − 4y, 3y − 2x)` (multiplication by the inverse unit `3 − 2√2`
+    of ℤ[√2]) keeps the value of `x² − 2y²` unchanged. -/
+theorem negPell_pred_step (x y : ℤ) (h : x ^ 2 - 2 * y ^ 2 = -1) :
+    (3 * x - 4 * y) ^ 2 - 2 * (3 * y - 2 * x) ^ 2 = -1 := by
+  linear_combination h
+
+/-- **There is no positive solution of `x² − 2y² = −1` with `2 ≤ x ≤ 6`.**
+    Combined with the base point `(1, 1)`, this is what makes the descent terminate. -/
+theorem negPell_no_small_solution (x y : ℤ) (hx2 : 2 ≤ x) (hx6 : x ≤ 6)
+    (hy : 1 ≤ y) : x ^ 2 - 2 * y ^ 2 ≠ -1 := by
+  intro h
+  have hyle : y ≤ 4 := by
+    nlinarith [h, mul_nonneg (by linarith : (0 : ℤ) ≤ 6 - x) (by linarith : (0 : ℤ) ≤ x),
+      sq_nonneg (y - 4)]
+  interval_cases x <;> interval_cases y <;> omega
+
+/-- **Classification (completeness).** Every positive-integer solution of
+    `x² − 2y² = −1` is a term of the chain `negPellSeq`. The proof descends along the
+    inverse step until it reaches the fundamental solution `(1, 1) = negPellSeq 0`. -/
+theorem negPell_complete (x y : ℤ) (hx : 1 ≤ x) (hy : 1 ≤ y)
+    (h : x ^ 2 - 2 * y ^ 2 = -1) : ∃ n, negPellSeq n = (x, y) := by
+  by_cases hx1 : x = 1
+  · -- base case: x = 1 forces y = 1
+    subst hx1
+    have hyle : y ≤ 1 := by nlinarith [sq_nonneg (y - 1)]
+    have hy1 : y = 1 := by omega
+    exact ⟨0, by rw [negPellSeq_zero, hy1]⟩
+  · -- x ≥ 2: rule out 2 ≤ x ≤ 6, then descend
+    have hx2 : 2 ≤ x := by omega
+    have hx7 : 7 ≤ x := by
+      by_contra hc
+      push_neg at hc
+      exact negPell_no_small_solution x y hx2 (by omega) hy h
+    -- y ≥ 5 from x ≥ 7
+    have hy5 : 5 ≤ y := by
+      nlinarith [h, mul_nonneg (by linarith : (0 : ℤ) ≤ x - 7) (by linarith : (0 : ℤ) ≤ x + 7)]
+    -- predecessor is strictly smaller: 3x − 4y < x  (from x < 2y)
+    have hx2y : x < 2 * y := by nlinarith [h, hx, hy]
+    have hlt : 3 * x - 4 * y < x := by linarith
+    -- predecessor is positive: 3x − 4y ≥ 1 and 3y − 2x ≥ 1
+    have hxfac : (3 * x - 4 * y - 1) * (3 * x + 4 * y + 1) = 2 * (y - 5) * (y + 1) := by
+      linear_combination 9 * h
+    have hxprod : 0 ≤ (3 * x - 4 * y - 1) * (3 * x + 4 * y + 1) := by
+      rw [hxfac]; nlinarith [hy5]
+    have hx'pos : 1 ≤ 3 * x - 4 * y := by
+      nlinarith [hxprod, (by linarith : (0 : ℤ) < 3 * x + 4 * y + 1)]
+    have hyfac : (3 * y - 2 * x) * (3 * y + 2 * x) = y ^ 2 + 4 := by linear_combination (-4) * h
+    have hy'pos0 : 0 < 3 * y - 2 * x := by
+      nlinarith [hyfac, sq_nonneg y, (by linarith : (0 : ℤ) < 3 * y + 2 * x)]
+    have hy'pos : 1 ≤ 3 * y - 2 * x := by omega
+    -- the predecessor is again a solution
+    have h' : (3 * x - 4 * y) ^ 2 - 2 * (3 * y - 2 * x) ^ 2 = -1 := negPell_pred_step x y h
+    -- recurse
+    obtain ⟨n, hn⟩ := negPell_complete (3 * x - 4 * y) (3 * y - 2 * x) hx'pos hy'pos h'
+    refine ⟨n + 1, ?_⟩
+    rw [negPellSeq_succ, hn]
+    dsimp only
+    simp only [Prod.mk.injEq]
+    constructor <;> ring
+termination_by x.toNat
+decreasing_by simp_wf; omega
+
+/-
+## Exact classification as a set equality
+-/
+
+/-- **The positive-integer solution set is exactly the chain.** Combining the parent's
+    forward direction (every chain term is a positive solution) with `negPell_complete`
+    (every positive solution is a chain term). -/
+theorem negPell_solutions_eq_range :
+    {p : ℤ × ℤ | 1 ≤ p.1 ∧ 1 ≤ p.2 ∧ p.1 ^ 2 - 2 * p.2 ^ 2 = -1} = Set.range negPellSeq := by
+  ext p
+  simp only [Set.mem_setOf_eq, Set.mem_range]
+  constructor
+  · rintro ⟨hx, hy, h⟩
+    obtain ⟨n, hn⟩ := negPell_complete p.1 p.2 hx hy h
+    exact ⟨n, by rw [hn]⟩
+  · rintro ⟨n, hn⟩
+    rw [← hn]
+    exact ⟨(negPellSeq_pos n).1, (negPellSeq_pos n).2, negPellSeq_norm n⟩
+
+/-
+## Multiplicative bridge to the positive Pell equation
+-/
+
+/-- **Squaring a norm −1 solution gives a norm +1 solution.** Since the ℤ[√2]-norm
+    `N(x, y) = x² − 2y²` is multiplicative and `(x + y√2)² = (x² + 2y²) + (2xy)√2`, a
+    solution of `x² − 2y² = −1` yields a solution of `X² − 2Y² = +1`, namely
+    `(X, Y) = (x² + 2y², 2xy)`. This connects the negative Pell chain to Mathlib's
+    `Pell.Solution₁` (the norm +1 equation). -/
+theorem negPell_sq_is_pos_pell (x y : ℤ) (h : x ^ 2 - 2 * y ^ 2 = -1) :
+    (x ^ 2 + 2 * y ^ 2) ^ 2 - 2 * (2 * x * y) ^ 2 = 1 := by
+  have key : (x ^ 2 + 2 * y ^ 2) ^ 2 - 2 * (2 * x * y) ^ 2 = (x ^ 2 - 2 * y ^ 2) ^ 2 := by
+    ring
+  rw [key, h]; norm_num
+
+/-- The squares of the negative-Pell chain give an explicit family of positive Pell
+    solutions: `(x² + 2y², 2xy)` for `(x, y) = negPellSeq n`. -/
+theorem negPellSeq_sq_is_pos_pell (n : ℕ) :
+    ((negPellSeq n).1 ^ 2 + 2 * (negPellSeq n).2 ^ 2) ^ 2
+        - 2 * (2 * (negPellSeq n).1 * (negPellSeq n).2) ^ 2 = 1 :=
+  negPell_sq_is_pos_pell _ _ (negPellSeq_norm n)
+
+example : ((7 : ℤ) ^ 2 + 2 * 5 ^ 2) ^ 2 - 2 * (2 * 7 * 5) ^ 2 = 1 := by norm_num
+
+#check @negPell_complete
+#check @negPell_solutions_eq_range
+#check @negPell_sq_is_pos_pell
+
+end PellEquationOQ06

--- a/src/data/proofs/pell-equation-oq-06-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-01/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "pell-equation-oq-06-oq-01",
+  "title": "Negative Pell x² − 2y² = −1: Classification of All Positive Solutions",
+  "slug": "pell-equation-oq-06-oq-01",
+  "description": "Upgrades the parent's infinitude result for the negative Pell equation x² − 2y² = −1 to an exact classification: the positive-integer solutions are precisely the terms of the chain (1,1)→(7,5)→(41,29)→… A descent (Vieta-jumping) argument along the inverse unit 3 − 2√2 of ℤ[√2] shows every positive solution reduces to the fundamental solution (1,1). Also records the multiplicative bridge to the positive Pell equation: squaring a norm −1 solution gives a norm +1 solution.",
+  "meta": {
+    "author": "Lean Genius (descent classification); Brahmagupta / Lagrange (classical theory)",
+    "date": "2026-06-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PellEquationOQ06OQ01.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "pell-equation",
+      "negative-pell",
+      "descent",
+      "vieta-jumping",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-21",
+    "lineCount": 167,
+    "originalContributions": [
+      "negPell_pred_step: the inverse substitution (x,y) ↦ (3x−4y, 3y−2x) (multiplication by the inverse unit 3−2√2 of ℤ[√2]) preserves x² − 2y², proved by a single linear_combination of the defining relation",
+      "negPell_no_small_solution: there is no positive-integer solution with 2 ≤ x ≤ 6, bounding y ≤ 4 from the form and finishing by interval_cases — the finite check that pins the descent's terminal point at (1,1)",
+      "negPell_complete: CLASSIFICATION — every positive-integer solution of x² − 2y² = −1 is a term of the chain negPellSeq, by strong induction on x.toNat via the descent predecessor (well-founded recursion)",
+      "negPell_solutions_eq_range: the exact set equality {(x,y) | x≥1, y≥1, x²−2y²=−1} = Set.range negPellSeq, packaging the parent's forward direction with the new converse",
+      "negPell_sq_is_pos_pell: squaring a norm −1 solution yields a norm +1 solution — (x²+2y²)² − 2(2xy)² = 1 — the multiplicative bridge (−1)·(−1)=+1 to the classical Pell equation and Mathlib's Pell.Solution₁",
+      "negPellSeq_sq_is_pos_pell: the chain's squares give an explicit infinite family of positive Pell (norm +1) solutions"
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. Imports the parent file Proofs/PellEquationOQ06.lean to reuse the chain negPellSeq and its forward properties (positivity, norm).",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pell-equation-oq-06",
+      "relationship": "extends",
+      "description": "The parent builds the chain (1,1)→(7,5)→(41,29)→… and proves there are infinitely many integer solutions of x² − 2y² = −1. This entry proves the converse — that the chain captures every positive solution — turning 'infinitely many exist' into the exact classification of the solution set."
+    },
+    {
+      "targetId": "pell-equation",
+      "relationship": "related",
+      "description": "The classical (norm +1) Pell equation x² − Dy² = 1. The bridge theorem negPell_sq_is_pos_pell maps each negative-Pell solution to a positive-Pell solution by squaring in ℤ[√2], reflecting that the norm is multiplicative and (−1)·(−1) = +1."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Brahmagupta (628 CE) discovered the composition law on solutions of x² − Dy² = N — the multiplicativity of the norm form of ℤ[√D] — which underlies both the chain that generates infinitely many solutions and the descent that classifies them. For the negative Pell equation x² − 2y² = −1 the fundamental solution is (1,1), and the fundamental unit of norm +1 is 3 + 2√2; multiplying by it advances along the solution chain, while multiplying by its inverse 3 − 2√2 descends. Lagrange's theory of continued fractions shows that, when the negative Pell equation is solvable (which for D = 2 it is, the period of √2 being odd), all solutions are obtained from the fundamental one by these unit multiplications. This entry formalizes that classification in the smallest case D = 2 by an explicit descent, since Mathlib's Pell.Solution₁ only covers the norm +1 equation.",
+    "problemStatement": "The parent entry shows x² − 2y² = −1 has infinitely many integer solutions, exhibited as a chain from (1,1). Are these all of them? Concretely: is every positive-integer solution (x,y) a term of the chain (1,1) → (7,5) → (41,29) → … ?",
+    "proofStrategy": "Descent / Vieta jumping. The inverse substitution (x,y) ↦ (3x−4y, 3y−2x) preserves the form (negPell_pred_step). For a positive solution other than (1,1) one shows, using the constraint x² = 2y² − 1, that x ≥ 7 (there is no solution with 2 ≤ x ≤ 6), hence y ≥ 5, and then that the predecessor (3x−4y, 3y−2x) is again a positive solution with strictly smaller first coordinate (3x − 4y < x because x < 2y, and 3x − 4y ≥ 1, 3y − 2x ≥ 1 from factored identities). Strong induction on x.toNat (well-founded recursion with decreasing_by) drives every positive solution down to (1,1) = negPellSeq 0, and replaying the forward step rebuilds it as negPellSeq (n+1). Packaging both directions gives the set equality with Set.range negPellSeq.",
+    "keyInsights": [
+      "The positivity and strict-decrease bounds for the descent are linear consequences of the quadratic constraint, made elementary by exact factored identities: (3x−4y−1)(3x+4y+1) = 2(y−5)(y+1) and (3y−2x)(3y+2x) = y²+4, each proved by a single linear_combination of x² − 2y² = −1. With one factor manifestly positive, the sign of the other is forced — turning a quadratic Diophantine inequality into an nlinarith-friendly product.",
+      "Termination of the descent rests on a finite fact: there is no solution with 2 ≤ x ≤ 6. Bounding y ≤ 4 from the form and running interval_cases over the 5×4 grid discharges it; the gap up to x = 7 is exactly the jump from the fundamental solution (1,1) to the next term (7,5).",
+      "x < 2y holds for every positive solution because x² = 2y² − 1 < 4y²; this single inequality both guarantees the predecessor's first coordinate strictly decreases and keeps the descent inside the positive quadrant.",
+      "The norm of ℤ[√2] is multiplicative, so squaring sends norm −1 to norm +1: (x²+2y²)² − 2(2xy)² = (x²−2y²)² = 1. The negative Pell chain therefore injects into the positive Pell solutions, recovering an infinite family of x² − 2y² = 1 solutions and connecting to Mathlib's Pell.Solution₁ machinery.",
+      "Mathlib formalizes only the norm +1 Pell equation (Pell.Solution₁); the norm −1 equation and its solution classification are absent, so the descent and the set-equality result here are genuinely new content rather than re-exports."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Research Context",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "States the open converse left by the parent (does the chain capture every solution?), outlines the descent strategy, and lists the five main results. Notes that Mathlib's Pell.Solution₁ covers only the norm +1 case.",
+      "mathContext": "The negative Pell equation $x^2 - 2y^2 = -1$ has fundamental solution $(1,1)$; the fundamental unit of $\\mathbb{Z}[\\sqrt2]$ of norm $+1$ is $3+2\\sqrt2$. Advancing by this unit gives the chain, descending by its inverse $3-2\\sqrt2$ classifies solutions."
+    },
+    {
+      "id": "descent",
+      "title": "The inverse step and the descent",
+      "startLine": 55,
+      "endLine": 124,
+      "summary": "negPell_pred_step proves the inverse map preserves the form; negPell_no_small_solution rules out 2 ≤ x ≤ 6; negPell_complete runs the strong-induction descent to show every positive solution is a chain term.",
+      "mathContext": "Descent by $(x,y)\\mapsto(3x-4y,\\,3y-2x)$. The factored identities $(3x-4y-1)(3x+4y+1)=2(y-5)(y+1)$ and $(3y-2x)(3y+2x)=y^2+4$ force $3x-4y\\ge1$ and $3y-2x\\ge1$ for $x\\ge7$; $x<2y$ forces strict decrease. Well-founded recursion on $x.\\mathrm{toNat}$ terminates at $(1,1)$."
+    },
+    {
+      "id": "classification",
+      "title": "Exact classification as a set equality",
+      "startLine": 125,
+      "endLine": 145,
+      "summary": "negPell_solutions_eq_range packages the forward direction (parent: chain terms are positive solutions) with negPell_complete (converse) into {positive solutions} = Set.range negPellSeq.",
+      "mathContext": "The set $\\{(x,y)\\mid x\\ge1,\\,y\\ge1,\\,x^2-2y^2=-1\\}$ equals $\\mathrm{range}\\,\\mathrm{negPellSeq}$ — the solution set is a single orbit under the unit group, with $(1,1)$ its generator."
+    },
+    {
+      "id": "bridge",
+      "title": "Multiplicative bridge to the positive Pell equation",
+      "startLine": 146,
+      "endLine": 167,
+      "summary": "negPell_sq_is_pos_pell: squaring a norm −1 solution gives a norm +1 solution (x²+2y², 2xy). negPellSeq_sq_is_pos_pell specializes to the chain, giving an explicit family of positive Pell solutions.",
+      "mathContext": "Multiplicativity of the $\\mathbb{Z}[\\sqrt2]$-norm: $(x^2+2y^2)^2-2(2xy)^2=(x^2-2y^2)^2=1$. The map sends the negative Pell chain into the classical Pell solutions (Mathlib's $\\texttt{Pell.Solution}_1$)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 167-line file (0 sorries, 0 axioms, no native_decide) upgrades the parent's infinitude result to the exact classification of the negative Pell equation x² − 2y² = −1: its positive-integer solutions are precisely the terms of the chain negPellSeq, proved by a descent (Vieta-jumping) along the inverse unit 3 − 2√2 of ℤ[√2]. The classification is packaged as the set equality {(x,y) | x≥1, y≥1, x²−2y²=−1} = Set.range negPellSeq. A multiplicative bridge (squaring) maps each negative-Pell solution to a positive-Pell solution.",
+    "implications": "Classification — not mere existence — is the structural payoff: the solution set is a single orbit under the unit group, generated by the fundamental solution (1,1). The descent technique (factored quadratic identities reducing inequalities to sign arguments, plus a finite no-small-solution check to anchor termination) is reusable for other norm-form Diophantine equations the Mathlib Pell API does not cover.",
+    "openQuestions": [
+      "Generalize the classification to the negative Pell equation x² − Dy² = −1 for other solvable D (those with odd continued-fraction period for √D), uniformly in D rather than the explicit D = 2 descent here.",
+      "Promote the squaring bridge negPell_sq_is_pos_pell into Mathlib's Pell.Solution₁ type, exhibiting the negative Pell chain as the 'half' of the positive Pell unit group of norm −1 elements."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 167,
+    "axiomCount": 0,
+    "path": "Proofs/PellEquationOQ06OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 6,
+    "imports": [
+      "Mathlib",
+      "Proofs.PellEquationOQ06"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/pell-equation-oq-06.json
+++ b/src/data/research/problems/pell-equation-oq-06.json
@@ -1,7 +1,7 @@
 {
   "slug": "pell-equation-oq-06",
   "title": "The Negative Pell Equation x² − 2y² = −1 Has Infinitely Many Solutions",
-  "phase": "ACT",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -54,7 +54,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S1 ACT (researcher-3, 2026-06-20): Built Proofs/PellEquationOQ06.lean from scratch — a self-contained, axiom-free proof that x²−2y²=−1 has infinitely many integer solutions. Strategy mirrors PellEquationOQ05's distinctness⟹infinite pattern but in the elementary ℤ setting: (1) negPell_step proves the form automorphism (x,y)↦(3x+4y,2x+3y) [mult by 3+2√2] preserves x²−2y² by a one-line ring identity; (2) negPellSeq is the explicit chain from (1,1); (3) negPellSeq_norm (induction + ring) shows every term solves the equation; (4) negPellSeq_pos (induction) gives both coords ≥1, feeding negPellSeq_fst_strictMono (strictMono_nat_of_lt_succ); (5) injectivity from StrictMono.injective on first coordinate; (6) negPell_solutions_infinite via Set.infinite_of_injective_forall_mem. Verified small terms (1,1)→(7,5)→(41,29)→(239,169) by rfl. No native_decide → 0 axioms. Gap filled: Mathlib's Pell.Solution₁ is norm +1 only; negative Pell is future work upstream."
+    "progressSummary": "S1 ACT (researcher-3, 2026-06-20): Built Proofs/PellEquationOQ06.lean from scratch — a self-contained, axiom-free proof that x²−2y²=−1 has infinitely many integer solutions. Strategy mirrors PellEquationOQ05's distinctness⟹infinite pattern but in the elementary ℤ setting: (1) negPell_step proves the form automorphism (x,y)↦(3x+4y,2x+3y) [mult by 3+2√2] preserves x²−2y² by a one-line ring identity; (2) negPellSeq is the explicit chain from (1,1); (3) negPellSeq_norm (induction + ring) shows every term solves the equation; (4) negPellSeq_pos (induction) gives both coords ≥1, feeding negPellSeq_fst_strictMono (strictMono_nat_of_lt_succ); (5) injectivity from StrictMono.injective on first coordinate; (6) negPell_solutions_infinite via Set.infinite_of_injective_forall_mem. Verified small terms (1,1)→(7,5)→(41,29)→(239,169) by rfl. No native_decide → 0 axioms. Gap filled: Mathlib's Pell.Solution₁ is norm +1 only; negative Pell is future work upstream. || S2 (researcher-8, 2026-06-21): COMPLETED follow-up child pell-equation-oq-06-oq-01 — exact CLASSIFICATION (descent) + norm−1→norm+1 squaring bridge, 0-axiom verified, builds in full Proofs aggregate.",
+    "builtItems": [
+      "Proofs/PellEquationOQ06OQ01.lean — CLASSIFICATION follow-up (gallery pell-equation-oq-06-oq-01): negPell_complete proves every positive solution of x²−2y²=−1 is a term of the chain (descent/Vieta-jumping on x.toNat via inverse unit 3−2√2); negPell_solutions_eq_range packages {x≥1,y≥1,x²−2y²=−1}=Set.range negPellSeq; negPell_sq_is_pos_pell bridges norm−1→norm+1. 167L 6thm 0-axiom verified."
+    ],
+    "insights": [
+      "Descent inequalities become elementary via exact factored identities proved by linear_combination of x²−2y²=−1: (3x−4y−1)(3x+4y+1)=2(y−5)(y+1) and (3y−2x)(3y+2x)=y²+4; one factor positive forces the sign of the other (nlinarith).",
+      "Termination of the descent anchored by a finite no-small-solution check: no positive solution has 2≤x≤6 (bound y≤4, interval_cases); the gap to x=7 is exactly the jump (1,1)→(7,5)."
+    ],
+    "nextSteps": [
+      "Generalize classification to x²−Dy²=−1 for other solvable D (odd CF period of √D), uniform in D.",
+      "Promote negPell_sq_is_pos_pell into Mathlib Pell.Solution₁ (negative Pell as norm−1 half of the unit group)."
+    ]
   },
   "references": {
     "papers": [],


### PR DESCRIPTION
## Summary

New axiom-free follow-up entry **pell-equation-oq-06-oq-01** that upgrades the parent's *infinitude* result for the negative Pell equation `x² − 2y² = −1` to an **exact classification** of its positive-integer solutions.

The parent (`pell-equation-oq-06`, `Proofs/PellEquationOQ06.lean`) builds the chain `(1,1)→(7,5)→(41,29)→…` and proves there are *infinitely many* solutions, but leaves open whether the chain captures **every** solution. This entry proves the converse.

## What's proved (`Proofs/PellEquationOQ06OQ01.lean`)

- **`negPell_pred_step`** — the inverse substitution `(x,y) ↦ (3x−4y, 3y−2x)` (multiplication by the inverse unit `3−2√2` of `ℤ[√2]`) preserves `x² − 2y²`, by one `linear_combination`.
- **`negPell_no_small_solution`** — there is no positive solution with `2 ≤ x ≤ 6` (bound `y ≤ 4` from the form, then `interval_cases`); the finite check that anchors the descent's terminal point at `(1,1)`.
- **`negPell_complete`** — *classification*: every positive solution is a term of `negPellSeq`, by strong induction on `x.toNat` through the descent predecessor (well-founded recursion).
- **`negPell_solutions_eq_range`** — the set equality `{(x,y) | x≥1, y≥1, x²−2y²=−1} = Set.range negPellSeq`.
- **`negPell_sq_is_pos_pell`** — squaring a norm `−1` solution gives a norm `+1` solution: `(x²+2y²)² − 2(2xy)² = 1`; the multiplicative bridge `(−1)·(−1)=+1` to the classical Pell equation (Mathlib's `Pell.Solution₁` covers only norm `+1`).

## Technique

Descent / Vieta jumping. The positivity and strict-decrease inequalities reduce to sign arguments via exact factored identities, each proved by a single `linear_combination` of `x² − 2y² = −1`:
`(3x−4y−1)(3x+4y+1) = 2(y−5)(y+1)` and `(3y−2x)(3y+2x) = y²+4`.

## Verification

- Builds via `./proofs/scripts/docker-build.sh Proofs.PellEquationOQ06OQ01` ✓ (and within the full `Proofs` aggregate).
- `#print axioms`: `propext`, `Classical.choice`, `Quot.sound` only — **0 axioms**, **0 sorries**, no `native_decide`.
- 167 lines, 6 theorems, 0 definitions.

Registered in `proofs/Proofs.lean`; gallery data in `src/data/proofs/pell-equation-oq-06-oq-01/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)