### PR TITLE
research(mantel-theorem-oq-04-oq-01): turanGraph n r ≃g complete r-partite graph on residue classes, general n [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3569,3 +3569,4 @@ import Proofs.ZetaRegularization
 import Proofs.CatalanNumbersOQ01OQ02
 import Proofs.CatalanNumbersOQ01OQ02OQ01
 import Proofs.MarkovEquation
+import Proofs.MantelTheoremOQ04OQ01

--- a/proofs/Proofs/MantelTheoremOQ04OQ01.lean
+++ b/proofs/Proofs/MantelTheoremOQ04OQ01.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2024-2026 lean-genius contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+
+/-!
+# The Turán graph as a complete multipartite graph (general `n`)
+
+`Proofs/MantelTheoremOQ04.lean` identifies the triangle-free (`r = 2`) extremal graph
+`turanGraph n 2` with the *balanced complete bipartite* graph `K_{⌈n/2⌉,⌊n/2⌋}` for arbitrary
+`n`, generalizing Mathlib's `completeEquipartiteGraph.turanGraph` (which only covers the
+balanced **equipartite** case `n = r · t`). This file takes the natural next step: the same
+identification for **every** number of parts `r`.
+
+Mathlib's `completeEquipartiteGraph.turanGraph` gives
+`completeEquipartiteGraph r t ≃g turanGraph (r * t) r`, i.e. it identifies `turanGraph n r` with
+a complete `r`-partite graph **only** when `r ∣ n` and all parts have equal size `t = n / r`.
+For general `n` the `r` residue classes mod `r` have sizes that differ by at most one — the parts
+are *balanced* but not *equal* — so the equipartite isomorphism does not apply.
+
+## Main results
+
+* `turanGraphIsoCompleteMultipartite` : for `0 < r`,
+  `completeMultipartiteGraph (fun j : Fin r => residue class j) ≃g turanGraph n r`,
+  where the `j`-th part is the set of vertices `v` with `v % r = j`. This realizes `turanGraph n r`
+  as a genuine complete `r`-partite graph for arbitrary `n`, the structural heart of Turán's
+  theorem. The bijection is `Equiv.sigmaFiberEquiv` of the colouring `v ↦ v % r`, so it carries
+  "different part" exactly to "different residue", i.e. to `turanGraph` adjacency.
+* `turanGraph_isCompleteMultipartite` : `(turanGraph n r).IsCompleteMultipartite` for `0 < r`,
+  transported from the canonical complete multipartite graph along the isomorphism.
+* `card_turanResidue` : the `j`-th part has size `(n + r - 1 - j) / r` — the exact balanced
+  cardinalities (`⌈(n - j) / r⌉`), so any two parts differ in size by at most one.
+* `sum_turanResidueSize` : `∑ j : Fin r, (n + r - 1 - j) / r = n`. The `r` residue classes
+  partition the `n` vertices; equivalently the balanced part sizes sum to `n`.
+-/
+
+open Finset Fintype SimpleGraph
+
+namespace Mantel
+
+variable (n r : ℕ)
+
+/-- The Turán colouring: a vertex `v : Fin n` of `turanGraph n r` is sent to its residue
+`v % r : Fin r`. Two vertices are adjacent in `turanGraph n r` iff they get different colours,
+so the colour classes are exactly the parts of the complete multipartite structure. -/
+def turanColor (hr : 0 < r) (v : Fin n) : Fin r := ⟨(v : ℕ) % r, Nat.mod_lt _ hr⟩
+
+@[simp] lemma turanColor_val (hr : 0 < r) (v : Fin n) :
+    ((turanColor n r hr v : Fin r) : ℕ) = (v : ℕ) % r := rfl
+
+/-- **`turanGraph n r` is a complete `r`-partite graph for arbitrary `n`.**
+
+The parts are the `r` residue classes `{v : Fin n | v % r = j}`, `j : Fin r`. Via
+`Equiv.sigmaFiberEquiv` of the colouring `turanColor`, "lying in different parts" corresponds
+exactly to "having different residues mod `r`", which is `turanGraph` adjacency. This generalizes
+Mathlib's `completeEquipartiteGraph.turanGraph` from the equipartite case `n = r · t` (equal parts)
+to all `n` (balanced parts differing in size by at most one). -/
+def turanGraphIsoCompleteMultipartite (hr : 0 < r) :
+    completeMultipartiteGraph (fun j : Fin r => {v : Fin n // turanColor n r hr v = j}) ≃g
+      turanGraph n r where
+  toEquiv := Equiv.sigmaFiberEquiv (turanColor n r hr)
+  map_rel_iff' := by
+    rintro ⟨j, v, hv⟩ ⟨j', w, hw⟩
+    simp only [Equiv.sigmaFiberEquiv_apply, turanGraph_adj, completeMultipartiteGraph,
+      comap_adj, top_adj, ne_eq]
+    -- `hv : turanColor v = j`, `hw : turanColor w = j'`; reduce both sides to `↑j ≠ ↑j'`.
+    have hvj : (v : ℕ) % r = (j : ℕ) := by rw [← turanColor_val n r hr v, hv]
+    have hwj : (w : ℕ) % r = (j' : ℕ) := by rw [← turanColor_val n r hr w, hw]
+    rw [hvj, hwj]
+    exact ⟨fun h he => h (by rw [he]), fun h he => h (Fin.ext he)⟩
+
+/-- **`turanGraph n r` is complete multipartite** (for `0 < r`): the negation of adjacency is
+transitive, i.e. "same part" is an equivalence. Transported from the canonical
+`completeMultipartiteGraph` along `turanGraphIsoCompleteMultipartite`. -/
+theorem turanGraph_isCompleteMultipartite (hr : 0 < r) :
+    (turanGraph n r).IsCompleteMultipartite :=
+  (completeMultipartiteGraph.isCompleteMultipartite _).comap
+    (turanGraphIsoCompleteMultipartite n r hr).symm.toEmbedding
+
+/-- Explicit bijection between `Fin ((n + r - 1 - j) / r)` and the `j`-th residue class of
+`turanGraph n r`. The `k`-th element of the class is `r * k + j`. This pins down the exact size
+of each part. -/
+def turanResidueEquiv (hr : 0 < r) (j : Fin r) :
+    Fin ((n + r - 1 - (j : ℕ)) / r) ≃ {v : Fin n // turanColor n r hr v = j} where
+  toFun k :=
+    ⟨⟨r * (k : ℕ) + (j : ℕ), by
+        have hb : ((k : ℕ) + 1) * r ≤ n + r - 1 - (j : ℕ) :=
+          (Nat.le_div_iff_mul_le hr).mp k.2
+        rw [add_one_mul] at hb
+        have hcomm : (k : ℕ) * r = r * (k : ℕ) := Nat.mul_comm _ _
+        have := j.2
+        omega⟩,
+      by
+        apply Fin.ext
+        rw [turanColor_val]
+        show (r * (k : ℕ) + (j : ℕ)) % r = (j : ℕ)
+        rw [Nat.mul_add_mod, Nat.mod_eq_of_lt j.2]⟩
+  invFun v :=
+    ⟨(v : Fin n) / r, by
+      have hv : ((v : Fin n) : ℕ) % r = (j : ℕ) := by rw [← turanColor_val n r hr (v : Fin n), v.2]
+      have hub : ((v : Fin n) : ℕ) < n := (v : Fin n).2
+      rw [← Nat.add_one_le_iff, Nat.le_div_iff_mul_le hr, add_one_mul]
+      have hdm := Nat.div_add_mod ((v : Fin n) : ℕ) r
+      have hcomm : ((v : Fin n) : ℕ) / r * r = r * (((v : Fin n) : ℕ) / r) := Nat.mul_comm _ _
+      omega⟩
+  left_inv k := by
+    apply Fin.ext
+    show (r * (k : ℕ) + (j : ℕ)) / r = (k : ℕ)
+    rw [Nat.mul_add_div hr, Nat.div_eq_of_lt j.2, add_zero]
+  right_inv v := by
+    apply Subtype.ext
+    apply Fin.ext
+    have hv : ((v : Fin n) : ℕ) % r = (j : ℕ) := by rw [← turanColor_val n r hr (v : Fin n), v.2]
+    show r * (((v : Fin n) : ℕ) / r) + (j : ℕ) = ((v : Fin n) : ℕ)
+    rw [← hv, Nat.div_add_mod]
+
+/-- **The `j`-th part of `turanGraph n r` has size `(n + r - 1 - j) / r = ⌈(n - j) / r⌉`.**
+These are the balanced Turán part sizes: as `j` ranges over `Fin r` the values take only the two
+consecutive integers `⌈n / r⌉` and `⌊n / r⌋`, so any two parts differ in size by at most one. -/
+theorem card_turanResidue (hr : 0 < r) (j : Fin r) :
+    Fintype.card {v : Fin n // turanColor n r hr v = j} = (n + r - 1 - (j : ℕ)) / r := by
+  rw [← Fintype.card_fin ((n + r - 1 - (j : ℕ)) / r)]
+  exact Fintype.card_congr (turanResidueEquiv n r hr j).symm
+
+/-- **The `r` residue classes partition the `n` vertices.** Equivalently, the balanced Turán part
+sizes sum to `n`: `∑ j : Fin r, ⌈(n - j) / r⌉ = n`. -/
+theorem sum_turanResidueSize (hr : 0 < r) :
+    ∑ j : Fin r, (n + r - 1 - (j : ℕ)) / r = n := by
+  have key : ∑ j : Fin r, Fintype.card {v : Fin n // turanColor n r hr v = j} = n := by
+    rw [← Fintype.card_sigma, Fintype.card_congr (Equiv.sigmaFiberEquiv (turanColor n r hr)),
+      Fintype.card_fin]
+  calc ∑ j : Fin r, (n + r - 1 - (j : ℕ)) / r
+      = ∑ j : Fin r, Fintype.card {v : Fin n // turanColor n r hr v = j} :=
+        Finset.sum_congr rfl (fun j _ => (card_turanResidue n r hr j).symm)
+    _ = n := key
+
+/-- The balanced complete-bipartite case `r = 2` recovers the part sizes `⌈n/2⌉` and `⌊n/2⌋`
+used in `MantelTheoremOQ04.lean`: residue `0` has `(n + 1) / 2` vertices and residue `1` has
+`n / 2`. -/
+theorem card_turanResidue_two (j : Fin 2) :
+    Fintype.card {v : Fin n // turanColor n 2 (by norm_num) v = j} =
+      if (j : ℕ) = 0 then (n + 1) / 2 else n / 2 := by
+  rw [card_turanResidue n 2 (by norm_num) j]
+  rcases (by omega : (j : ℕ) = 0 ∨ (j : ℕ) = 1) with hj | hj <;> simp [hj]
+
+end Mantel

--- a/src/data/proofs/mantel-theorem-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/mantel-theorem-oq-04-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "mantel-oq04oq01-ann-import",
+    "proofId": "mantel-theorem-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 5 },
+    "type": "concept",
+    "title": "Imports: Turán Graphs, Complete Multipartite Graphs, and Fibre Equivalences",
+    "content": "A single import Mathlib supplies everything: the residue-based turanGraph and its turanGraph_adj lemma, completeMultipartiteGraph (= comap Sigma.fst ⊤) with its comap_adj/top_adj reductions, the IsCompleteMultipartite predicate and its .comap transport, Equiv.sigmaFiberEquiv, and the Nat divmod lemmas (le_div_iff_mul_le, mul_add_div, mul_add_mod, div_add_mod). Unlike its sibling mantel-theorem-oq-04 this entry is self-contained over Mathlib and imports no other proof file.",
+    "mathContext": "Builds on $\\mathrm{turanGraph}\\,n\\,r$, $\\mathrm{completeMultipartiteGraph}$, $\\mathrm{IsCompleteMultipartite}$, and $\\mathrm{Equiv.sigmaFiberEquiv}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["turanGraph", "completeMultipartiteGraph", "IsCompleteMultipartite", "sigmaFiberEquiv"],
+    "prerequisites": ["simple graphs", "Turán's theorem", "graph isomorphism"]
+  },
+  {
+    "id": "mantel-oq04oq01-ann-docstring",
+    "proofId": "mantel-theorem-oq-04-oq-01",
+    "range": { "startLine": 7, "endLine": 38 },
+    "type": "concept",
+    "title": "Statement: The Turán Graph Is Complete r-Partite for Every n",
+    "content": "Mathlib defines the Turán graph residue-theoretically as turanGraph n r (adjacency v % r ≠ w % r on Fin n) and identifies it with a complete multipartite graph only in the equipartite case completeEquipartiteGraph r t ≃g turanGraph (r·t) r, which forces r ∣ n and all parts equal. The sibling mantel-theorem-oq-04 handled r = 2 for general n and posed the general-r case as open. This file settles it: turanGraph n r ≃g completeMultipartiteGraph over the r residue classes mod r, for every n and 0 < r, with the exact balanced part sizes computed.",
+    "mathContext": "$\\mathrm{turanGraph}\\,n\\,r \\cong \\mathrm{completeMultipartiteGraph}\\,(\\text{residue classes mod } r)$.",
+    "significance": "central",
+    "relatedConcepts": ["Turán graph", "complete multipartite graph", "residue classes", "balanced parts"],
+    "prerequisites": ["Turán's theorem", "graph isomorphism", "modular arithmetic"]
+  },
+  {
+    "id": "mantel-oq04oq01-ann-coloring",
+    "proofId": "mantel-theorem-oq-04-oq-01",
+    "range": { "startLine": 40, "endLine": 57 },
+    "type": "definition",
+    "title": "The Turán Colouring v ↦ v % r",
+    "content": "turanColor sends a vertex v : Fin n to its residue ⟨v % r, _⟩ : Fin r (bound by Nat.mod_lt, needing 0 < r). Two vertices are adjacent in turanGraph n r exactly when their colours differ, so the colour classes — the fibres of turanColor — are precisely the parts of the complete multipartite structure. The simp lemma turanColor_val exposes the underlying value (turanColor v : ℕ) = v % r so that membership facts can be rewritten to residue equalities.",
+    "mathContext": "$\\mathrm{turanColor}(v) = v \\bmod r : \\mathrm{Fin}\\,r$.",
+    "significance": "central",
+    "relatedConcepts": ["graph colouring", "residue", "fibre"],
+    "prerequisites": ["modular arithmetic", "Fin"]
+  },
+  {
+    "id": "mantel-oq04oq01-ann-iso",
+    "proofId": "mantel-theorem-oq-04-oq-01",
+    "range": { "startLine": 58, "endLine": 74 },
+    "type": "technique",
+    "title": "The Isomorphism via sigmaFiberEquiv",
+    "content": "turanGraphIsoCompleteMultipartite is the graph isomorphism completeMultipartiteGraph (fun j : Fin r => {v // turanColor v = j}) ≃g turanGraph n r. Its underlying bijection is Equiv.sigmaFiberEquiv (turanColor …) : (Σ j, {v // turanColor v = j}) ≃ Fin n — the canonical 'total space of fibres' equivalence, which supplies both directions and both round trips for free, sidestepping any hand-built dependent-Sigma inverse and HEq reasoning. The adjacency obligation map_rel_iff' rewrites comap_adj and top_adj, then uses the fibre-membership facts (v % r = ↑j, w % r = ↑j') to reduce both 'different residue' and 'different part' to ↑j ≠ ↑j', closed by Fin.ext.",
+    "mathContext": "$\\mathrm{Equiv.sigmaFiberEquiv}\\,f : (\\Sigma y, \\{x // f x = y\\}) \\simeq \\alpha$.",
+    "significance": "central",
+    "relatedConcepts": ["sigmaFiberEquiv", "graph isomorphism", "map_rel_iff", "fibre"],
+    "prerequisites": ["equivalences", "graph isomorphism", "comap of a graph"]
+  },
+  {
+    "id": "mantel-oq04oq01-ann-is-multipartite",
+    "proofId": "mantel-theorem-oq-04-oq-01",
+    "range": { "startLine": 75, "endLine": 82 },
+    "type": "key-step",
+    "title": "turanGraph Is Complete Multipartite",
+    "content": "turanGraph_isCompleteMultipartite shows (turanGraph n r).IsCompleteMultipartite for 0 < r. Since IsCompleteMultipartite (non-adjacency is transitive) is preserved under pullback along embeddings, the canonical completeMultipartiteGraph.isCompleteMultipartite is transported backwards along the isomorphism's symm.toEmbedding via IsCompleteMultipartite.comap. This connects the residue presentation to Mathlib's structural multipartite API.",
+    "mathContext": "$(\\mathrm{turanGraph}\\,n\\,r).\\mathrm{IsCompleteMultipartite}$.",
+    "significance": "central",
+    "relatedConcepts": ["IsCompleteMultipartite", "graph embedding", "transport of structure"],
+    "prerequisites": ["complete multipartite graphs", "graph embeddings"]
+  },
+  {
+    "id": "mantel-oq04oq01-ann-part-sizes",
+    "proofId": "mantel-theorem-oq-04-oq-01",
+    "range": { "startLine": 83, "endLine": 126 },
+    "type": "technique",
+    "title": "Exact Balanced Part Sizes via an Explicit Fibre Bijection",
+    "content": "turanResidueEquiv is the explicit bijection Fin ((n+r−1−j)/r) ≃ {v // turanColor v = j} sending k ↦ r·k + j (the k-th vertex in residue class j). Its four obligations are linear divmod facts: the Fin bound r·k+j < n comes from Nat.le_div_iff_mul_le (turning k < (n+r−1−j)/r into (k+1)·r ≤ n+r−1−j) plus omega; the residue (r·k+j) % r = j from Nat.mul_add_mod and Nat.mod_eq_of_lt; the round trips from Nat.mul_add_div / Nat.div_eq_of_lt and Nat.div_add_mod. A subtle point: omega treats k·r and r·k as distinct atoms (both factors are variables), so the commutativity k·r = r·k must be supplied by hand. card_turanResidue then reads off the part size (n+r−1−j)/r = ⌈(n−j)/r⌉ by Fintype.card_congr.",
+    "mathContext": "$\\#\\{v \\mid v \\bmod r = j\\} = (n+r-1-j)/r = \\lceil (n-j)/r\\rceil$.",
+    "significance": "central",
+    "relatedConcepts": ["fibre cardinality", "Euclidean division", "omega", "balanced partition"],
+    "prerequisites": ["Nat division lemmas", "Fintype.card"]
+  },
+  {
+    "id": "mantel-oq04oq01-ann-partition",
+    "proofId": "mantel-theorem-oq-04-oq-01",
+    "range": { "startLine": 127, "endLine": 147 },
+    "type": "key-step",
+    "title": "The Part Sizes Sum to n; the r = 2 Specialization",
+    "content": "sum_turanResidueSize proves ∑ j : Fin r, (n+r−1−j)/r = n. The fibre equivalence gives Fintype.card (Σ j, {v // turanColor v = j}) = card (Fin n) = n, and Fintype.card_sigma turns the left side into ∑ j, card (fibre j); rewriting each summand by card_turanResidue (inside a calc to avoid rewriting the n that occurs inside the summand) yields the identity. Combinatorially: the r residue classes partition the n vertices. card_turanResidue_two specializes to r = 2, recovering the (n+1)/2 and n/2 part sizes of mantel-theorem-oq-04.",
+    "mathContext": "$\\sum_{j<r} \\lceil (n-j)/r\\rceil = n$.",
+    "significance": "central",
+    "relatedConcepts": ["Fintype.card_sigma", "partition", "balanced parts"],
+    "prerequisites": ["Fintype cardinality", "finite sums"]
+  }
+]

--- a/src/data/proofs/mantel-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-04-oq-01/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "mantel-theorem-oq-04-oq-01",
+  "title": "The Turán Graph as a Complete r-Partite Graph for Arbitrary n",
+  "slug": "mantel-theorem-oq-04-oq-01",
+  "description": "A fully verified, axiom-free identification of Mathlib's Turán graph turanGraph n r with a genuine complete r-partite graph for every number of parts r and every n. This answers the general-r open question left by mantel-theorem-oq-04 (which proved only the r = 2 / complete-bipartite case): turanGraph n r ≃g completeMultipartiteGraph over the r residue classes mod r, where the j-th part is {v : Fin n | v % r = j}. The bijection is Equiv.sigmaFiberEquiv of the colouring v ↦ v % r, so 'lying in different parts' corresponds exactly to 'having different residues mod r', which is turanGraph adjacency. From the isomorphism the graph is shown to be complete multipartite (IsCompleteMultipartite). The exact part sizes are pinned down — the j-th part has cardinality (n + r − 1 − j) / r = ⌈(n − j)/r⌉, the balanced Turán sizes differing by at most one — via an explicit fibre bijection k ↦ r·k + j, and these sizes are verified to sum to n (the residue classes partition the vertices). Strictly generalizes Mathlib's equipartite-only completeEquipartiteGraph.turanGraph (which requires n = r·t with equal parts).",
+  "meta": {
+    "author": "lean-genius researcher agents, formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Tur%C3%A1n_graph",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "graph-theory",
+      "combinatorics",
+      "extremal-graph-theory",
+      "turan-graph",
+      "complete-multipartite",
+      "graph-isomorphism",
+      "residue-classes"
+    ],
+    "proofRepoPath": "Proofs/MantelTheoremOQ04OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.turanGraph",
+        "description": "The canonical (r+1)-clique-free Turán graph on Fin n with adjacency v % r ≠ w % r; turanGraph_adj is the adjacency lemma driving the map_rel_iff' check",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Extremal.Turan"
+      },
+      {
+        "theorem": "SimpleGraph.completeMultipartiteGraph",
+        "description": "The complete multipartite graph comap Sigma.fst ⊤ on a dependent family of part types Σ i, V i (adjacency exactly between different part indices); its adjacency reduces via comap_adj and top_adj",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Maps"
+      },
+      {
+        "theorem": "SimpleGraph.IsCompleteMultipartite.comap",
+        "description": "Transports the IsCompleteMultipartite property backwards along a graph embedding; applied to the symm of the isomorphism to show turanGraph n r is complete multipartite",
+        "module": "Mathlib.Combinatorics.SimpleGraph.CompleteMultipartite"
+      },
+      {
+        "theorem": "Equiv.sigmaFiberEquiv",
+        "description": "The natural equivalence (Σ y, {x // f x = y}) ≃ α between the total space of fibres of f and its domain; with f = the residue colouring it supplies the iso's underlying bijection for free, sidestepping any dependent-Sigma / HEq reasoning",
+        "module": "Mathlib.Logic.Equiv.Sum"
+      },
+      {
+        "theorem": "Nat.le_div_iff_mul_le",
+        "description": "a ≤ b / r ↔ a * r ≤ b for 0 < r; used together with Nat.div_add_mod, Nat.mul_add_div, Nat.mul_add_mod to discharge every Fin-bound and round-trip obligation of the explicit fibre bijection",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "turanColor: the Turán colouring v ↦ v % r : Fin r whose colour classes are exactly the parts of the complete multipartite structure",
+      "turanGraphIsoCompleteMultipartite: the graph isomorphism completeMultipartiteGraph (fun j : Fin r => {v : Fin n // v % r = j}) ≃g turanGraph n r for arbitrary n and 0 < r, with Equiv.sigmaFiberEquiv of turanColor as the underlying bijection; carries 'different part' to 'different residue mod r'. Strictly generalizes Mathlib's equipartite completeEquipartiteGraph.turanGraph (which needs n = r·t with equal parts) to all n with balanced (unequal) parts",
+      "turanGraph_isCompleteMultipartite: turanGraph n r is complete multipartite (IsCompleteMultipartite) for 0 < r, obtained by transporting the canonical completeMultipartiteGraph.isCompleteMultipartite backwards along the isomorphism's embedding",
+      "turanResidueEquiv / card_turanResidue: an explicit bijection Fin ((n+r−1−j)/r) ≃ {v // v % r = j} (k ↦ r·k + j) proving the j-th part has exactly (n+r−1−j)/r = ⌈(n−j)/r⌉ vertices — the balanced Turán part sizes, any two differing by at most one",
+      "sum_turanResidueSize: ∑ j : Fin r, (n+r−1−j)/r = n, i.e. the r residue classes partition the n vertices / the balanced part sizes sum to n, derived from Fintype.card_sigma applied to the fibre equivalence",
+      "card_turanResidue_two: the r = 2 specialization recovering the ⌈n/2⌉ and ⌊n/2⌋ part sizes used in mantel-theorem-oq-04"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCountNote": "0 axiom declarations, 0 sorries, 0 structure-encoded assumptions, no native_decide. All five results (#print axioms checked) depend only on propext/Classical.choice/Quot.sound, the foundational axioms the project does not count. The isomorphism and all cardinality identities are constructed and verified entirely from Mathlib's SimpleGraph, Equiv, and Nat divmod APIs."
+  },
+  "overview": {
+    "historicalContext": "The Turán graph T(n, r) — partition n vertices into r parts as equal as possible and join every cross pair — is the extremal graph of Turán's theorem (the unique K_{r+1}-free graph on n vertices with the maximum number of edges), generalizing Mantel's r = 2 triangle-free case. Mathlib defines it residue-theoretically as turanGraph n r on Fin n with v adjacent to w iff v % r ≠ w % r, which is convenient for clique-counting but hides the complete-multipartite structure. Mathlib supplies the identification with a complete multipartite graph only in the balanced equipartite case completeEquipartiteGraph r t ≃g turanGraph (r·t) r, which requires r ∣ n and all parts equal. The sibling entry mantel-theorem-oq-04 handled the unequal-parts phenomenon for r = 2 (parts ⌈n/2⌉, ⌊n/2⌋); its conclusion explicitly posed the general-r version as an open question. This entry settles it.",
+    "problemStatement": "Prove that Mathlib's Turán graph turanGraph n r is isomorphic to a genuine complete r-partite graph for every n (not only n divisible by r): exhibit the parts as the r residue classes mod r, establish that turanGraph n r is complete multipartite, and compute the exact (balanced) part sizes, verifying they sum to n.",
+    "proofStrategy": "Colour each vertex v : Fin n by its residue turanColor v = v % r : Fin r. The fibres of this colouring are the r residue classes {v // v % r = j}, and Equiv.sigmaFiberEquiv gives a canonical bijection (Σ j, fibre j) ≃ Fin n for free — crucially avoiding any hand-built dependent-Sigma inverse and the attendant HEq reasoning. Under this bijection the complete-multipartite adjacency 'different part index j ≠ j'' transports to 'different residue v % r ≠ w % r', which is exactly turanGraph adjacency, so the underlying equivalence is promoted to a graph isomorphism turanGraphIsoCompleteMultipartite by a one-line map_rel_iff' that rewrites comap_adj/top_adj and uses Fin.val injectivity on the residues. Completeness multipartiteness of turanGraph n r then follows by pulling IsCompleteMultipartite back along the isomorphism's embedding. For the exact part sizes, an explicit fibre bijection turanResidueEquiv : Fin ((n+r−1−j)/r) ≃ {v // v % r = j} sends k ↦ r·k + j; its four obligations (the Fin bound r·k+j < n, the residue (r·k+j) % r = j, and both round trips) reduce to linear divmod facts via Nat.le_div_iff_mul_le, Nat.mul_add_div, Nat.mul_add_mod and Nat.div_add_mod, closed by omega — after explicitly supplying the commutativity k·r = r·k that omega cannot infer between two variable factors. Finally Fintype.card_sigma applied to the fibre equivalence gives ∑ j, (n+r−1−j)/r = n.",
+    "keyInsights": [
+      "Realizing the parts as the fibres {v // v % r = j} of the residue colouring lets Equiv.sigmaFiberEquiv supply the vertex bijection for free, so the entire isomorphism collapses to a one-line adjacency check — no hand-built inverse, no HEq across dependent Sigma types.",
+      "'Different part' in the complete multipartite graph (j ≠ j') is definitionally 'different residue' (v % r ≠ w % r) because each vertex sits in the fibre of its own colour; this is precisely turanGraph adjacency, so adjacency preservation is immediate after comap_adj/top_adj.",
+      "Mathlib's equipartite completeEquipartiteGraph.turanGraph requires n = r·t with all parts equal; for general n the r residue classes have sizes ⌈(n−j)/r⌉ taking only the two consecutive values ⌈n/r⌉ and ⌊n/r⌋, so the parts are balanced but unequal — exactly the content that needed a fresh construction.",
+      "The exact part size (n+r−1−j)/r is obtained constructively from the explicit enumerating bijection k ↦ r·k + j rather than from a residue-counting lemma (which Mathlib does not provide in this form), and Fintype.card_sigma turns the single fibre equivalence into the partition identity ∑ sizes = n.",
+      "omega treats the products k·r and r·k as distinct opaque atoms because both factors are variables; supplying the commutativity equation by hand (Nat.mul_comm) is the small but essential step that lets the linear divmod bounds go through."
+    ]
+  },
+  "conclusion": {
+    "summary": "A complete, axiom-free and sorry-free realization of Mathlib's Turán graph turanGraph n r as a genuine complete r-partite graph for arbitrary n: the parts are the r residue classes mod r, the graph is shown to be complete multipartite, and the exact balanced part sizes (n+r−1−j)/r = ⌈(n−j)/r⌉ are computed and verified to sum to n. This answers the general-r open question posed by mantel-theorem-oq-04, of which the r = 2 complete-bipartite case was the special instance.",
+    "implications": "Provides a reusable bridge between Mathlib's residue-based turanGraph and the structural completeMultipartiteGraph / IsCompleteMultipartite API for every r and every n — a strict generalization of the equipartite-only completeEquipartiteGraph.turanGraph. The sigmaFiberEquiv-of-a-colouring pattern (parts as colour fibres) is a clean, HEq-free template for identifying any vertex-coloured graph with a complete multipartite graph; the constructive fibre enumeration gives a model for computing balanced residue-class cardinalities without a dedicated counting lemma.",
+    "openQuestions": [
+      "Combine turanGraphIsoCompleteMultipartite with Mathlib's chromatic-number results for completeMultipartiteGraph to conclude χ(turanGraph n r) = min(n, r) directly, and with the clique results to recover its K_{r+1}-freeness from the multipartite structure.",
+      "Derive the Turán edge count |E(turanGraph n r)| = (1 − 1/r)·n²/2 − (correction term) from the balanced part sizes (n+r−1−j)/r via the complete-multipartite edge formula ∑_{j<j'} sizeⱼ·sizeⱼ', closing the loop between this structural identification and the quantitative Turán bound."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "License and Imports",
+      "startLine": 1,
+      "endLine": 5,
+      "summary": "Apache-2.0 header and a single import of Mathlib, supplying the SimpleGraph turanGraph/completeMultipartiteGraph/IsCompleteMultipartite API, Equiv.sigmaFiberEquiv, and the Nat divmod lemmas.",
+      "mathContext": "Self-contained over Mathlib; no sibling-file dependency."
+    },
+    {
+      "id": "docstring",
+      "title": "Statement and Approach",
+      "startLine": 7,
+      "endLine": 38,
+      "summary": "Module docstring locating the result as the general-r generalization of the r = 2 complete-bipartite identification, explaining why Mathlib's equipartite isomorphism does not cover n ∤ r, and listing the four main results.",
+      "mathContext": "turanGraph n r ≃g completeMultipartiteGraph over residue classes mod r."
+    },
+    {
+      "id": "coloring",
+      "title": "The Turán Colouring",
+      "startLine": 40,
+      "endLine": 57,
+      "summary": "turanColor v = v % r : Fin r and the simp lemma turanColor_val exposing its underlying value as v % r; the colour classes are the parts of the multipartite structure.",
+      "mathContext": "v ↦ v % r : Fin n → Fin r."
+    },
+    {
+      "id": "iso",
+      "title": "The Complete Multipartite Isomorphism",
+      "startLine": 58,
+      "endLine": 74,
+      "summary": "turanGraphIsoCompleteMultipartite: the isomorphism completeMultipartiteGraph (fun j => {v // turanColor v = j}) ≃g turanGraph n r built on Equiv.sigmaFiberEquiv (turanColor …). The map_rel_iff' obligation rewrites comap_adj/top_adj and reduces both adjacencies to ↑j ≠ ↑j' via the fibre membership facts and Fin.ext.",
+      "mathContext": "$K(n_0,\\dots,n_{r-1}) \\cong \\mathrm{turanGraph}\\,n\\,r$, parts = residue classes."
+    },
+    {
+      "id": "is-multipartite",
+      "title": "turanGraph Is Complete Multipartite",
+      "startLine": 75,
+      "endLine": 82,
+      "summary": "turanGraph_isCompleteMultipartite: pulls IsCompleteMultipartite back from the canonical completeMultipartiteGraph along the symm of the isomorphism via IsCompleteMultipartite.comap.",
+      "mathContext": "$(\\mathrm{turanGraph}\\,n\\,r).\\mathrm{IsCompleteMultipartite}$ for $0 < r$."
+    },
+    {
+      "id": "part-sizes",
+      "title": "Exact Balanced Part Sizes",
+      "startLine": 83,
+      "endLine": 126,
+      "summary": "turanResidueEquiv: the explicit bijection Fin ((n+r−1−j)/r) ≃ {v // turanColor v = j}, k ↦ r·k + j, with all bounds and round trips reduced to linear divmod facts (Nat.le_div_iff_mul_le, Nat.mul_add_div, Nat.mul_add_mod, Nat.div_add_mod) and closed by omega after supplying k·r = r·k. card_turanResidue then reads off the part size (n+r−1−j)/r = ⌈(n−j)/r⌉.",
+      "mathContext": "$\\#\\{v : \\mathrm{Fin}\\,n \\mid v \\bmod r = j\\} = \\lceil (n-j)/r\\rceil$."
+    },
+    {
+      "id": "partition",
+      "title": "Sizes Sum to n and the r = 2 Case",
+      "startLine": 127,
+      "endLine": 147,
+      "summary": "sum_turanResidueSize: ∑ j, (n+r−1−j)/r = n via Fintype.card_sigma on the fibre equivalence (the residue classes partition the vertices). card_turanResidue_two specializes to r = 2, recovering the (n+1)/2 and n/2 part sizes of mantel-theorem-oq-04.",
+      "mathContext": "$\\sum_{j<r} \\lceil (n-j)/r\\rceil = n$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "mantel-theorem-oq-04",
+      "relationship": "extends",
+      "description": "mantel-theorem-oq-04 proved the r = 2 case (turanGraph n 2 ≃g K_{⌈n/2⌉,⌊n/2⌋}) and explicitly posed the general-r identification as an open question; this entry settles it for all r, recovering the r = 2 part sizes as card_turanResidue_two."
+    },
+    {
+      "targetId": "mantel-theorem",
+      "relationship": "related",
+      "description": "mantel-theorem proves the global edge bound ⌊n²/4⌋ and its tightness via turanGraph n 2; this entry exposes the complete-multipartite structure of the general Turán graph turanGraph n r underlying Turán's theorem."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Fintype",
+      "SimpleGraph"
+    ],
+    "namespace": "Mantel",
+    "lineCount": 147,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 3,
+    "path": "Proofs/MantelTheoremOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    "turanGraphIsoCompleteMultipartite",
+    "turanGraph_isCompleteMultipartite",
+    "card_turanResidue",
+    "sum_turanResidueSize"
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/mantel-theorem-oq-04.json
+++ b/src/data/research/problems/mantel-theorem-oq-04.json
@@ -3,7 +3,7 @@
   "statement": "A triangle-free graph on n vertices with exactly ⌊n²/4⌋ edges is isomorphic to the balanced complete bipartite graph K_{⌈n/2⌉,⌊n/2⌋}.",
   "question": "Identify the Mantel/Turán extremal graph concretely as the balanced complete bipartite graph, and re-state the equality characterization in that classical form.",
   "knowledge": {
-    "progressSummary": "COMPLETE: proved turanGraph n 2 ≃g completeBipartiteGraph (Fin ⌈n/2⌉) (Fin ⌊n/2⌋) for all n, and the complete-bipartite equality characterization mantel_equality_iff_completeBipartite. Verified, 0-axiom, 0-sorry (PR for gallery entry mantel-theorem-oq-04).",
+    "progressSummary": "PROGRESS: r=2 complete-bipartite form done; general-r complete-multipartite form now done (PR #27466 child oq-04-oq-01).",
     "builtItems": [
       "binEquiv (Proofs/MantelTheoremOQ04.lean): interleaved parity bijection Fin ⌈n/2⌉ ⊕ Fin ⌊n/2⌋ ≃ Fin n, inl k ↦ 2k, inr k ↦ 2k+1, inverse by parity v ↦ v/2; all Fin bounds and round-trips by omega",
       "turanGraphTwoIsoCompleteBipartite (Proofs/MantelTheoremOQ04.lean): graph isomorphism completeBipartiteGraph (Fin ⌈n/2⌉) (Fin ⌊n/2⌋) ≃g turanGraph n 2, general n",
@@ -13,7 +13,8 @@
       "turanGraph n 2 adjacency 'v % 2 ≠ w % 2' is exactly 'opposite side' of the parity bipartition; the right bijection is interleaved (evens↔left, odds↔right), NOT the block finSumFinEquiv which does not preserve mod-2 adjacency",
       "Mathlib's completeEquipartiteGraph.turanGraph only covers the equipartite case n = r·t (equal parts); for odd n the parts differ in size by one, so the general complete-bipartite identification needed a fresh construction",
       "Once the iso exists, the equality characterization is pure transport of structure (Iso.trans / Iso.symm) on top of the abstract mantel_equality_iff — no combinatorics is re-proved",
-      "map_rel_iff' adjacency proof: full `simp [completeBipartiteGraph_adj, turanGraph_adj, Nat.mul_add_mod]` reduces .val(mk) and mod-2 residues; `simp only` with Fin.val_mk did NOT fire (left ↑(2*↑a) unreduced and blocked omega)"
+      "map_rel_iff' adjacency proof: full `simp [completeBipartiteGraph_adj, turanGraph_adj, Nat.mul_add_mod]` reduces .val(mk) and mod-2 residues; `simp only` with Fin.val_mk did NOT fire (left ↑(2*↑a) unreduced and blocked omega)",
+      "RESOLVED (PR #27466, mantel-theorem-oq-04-oq-01): general-r identification turanGraph n r ≃g completeMultipartiteGraph over residue classes mod r, all n, via Equiv.sigmaFiberEquiv of v↦v%r; exact balanced part sizes (n+r-1-j)/r summing to n. r=2 case recovered."
     ],
     "mathlibGaps": [
       "No general (non-equipartite) bridge turanGraph n r ≃g complete r-partite graph for n not a multiple of r; only completeEquipartiteGraph.turanGraph (n = r·t) exists",


### PR DESCRIPTION
## Summary

Answers the **general-r open question** explicitly posed in the conclusion of `mantel-theorem-oq-04`:

> *Generalize `turanGraphTwoIsoCompleteBipartite` to `turanGraph n r ≃g` the complete r-partite graph on the r residue classes mod r, the general (non-equipartite) bridge of which the r = 2 case is proved here.*

This realizes Mathlib's residue-based Turán graph `turanGraph n r` (adjacency `v % r ≠ w % r`) as a genuine **complete r-partite graph for every `n`** — strictly generalizing Mathlib's equipartite-only `completeEquipartiteGraph.turanGraph`, which requires `n = r·t` with all parts equal.

## Results (`Proofs/MantelTheoremOQ04OQ01.lean`, 147L, 4 thm / 3 def)

- **`turanColor`** — the residue colouring `v ↦ v % r : Fin r`; its fibres are the parts.
- **`turanGraphIsoCompleteMultipartite`** — `completeMultipartiteGraph (fun j : Fin r => {v // v % r = j}) ≃g turanGraph n r`. The underlying bijection is `Equiv.sigmaFiberEquiv` of the colouring, so the whole iso collapses to a one-line `map_rel_iff'` (`"different part" ⟺ "different residue"`) — **no dependent-Sigma HEq reasoning**.
- **`turanGraph_isCompleteMultipartite`** — `(turanGraph n r).IsCompleteMultipartite`, pulled back along the iso embedding.
- **`turanResidueEquiv` / `card_turanResidue`** — explicit fibre bijection `k ↦ r·k + j` pins the j-th part size to `(n + r − 1 − j)/r = ⌈(n−j)/r⌉` (the balanced Turán sizes, any two differing by ≤ 1).
- **`sum_turanResidueSize`** — `∑ j : Fin r, (n+r−1−j)/r = n` (residue classes partition the vertices).
- **`card_turanResidue_two`** — r = 2 recovers the `⌈n/2⌉`, `⌊n/2⌋` sizes of `mantel-theorem-oq-04`.

## Verification

- Builds clean via Docker wrapper on the Mathlib v4.26.0 pin.
- `#print axioms` on all five results: only `propext / Classical.choice / Quot.sound`. **0 sorries, 0 axiom declarations, 0 structure-encoded assumptions, no `native_decide`.**
- Gallery entry `src/data/proofs/mantel-theorem-oq-04-oq-01/` (meta.json + annotations.json) added.

## Honest scope

Pure structural identification + exact part sizes. The quantitative Turán edge count `|E(T(n,r))|` is *not* derived here (left as a follow-up: combine the balanced sizes with the complete-multipartite edge formula).

🤖 Generated with [Claude Code](https://claude.com/claude-code)