### PR TITLE
research(mantel-theorem-oq-04-oq-02): Mantel bound is sharp — extremal graph attains ⌊n²/4⌋ edges

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2975,6 +2975,7 @@ import Proofs.MantelStabilityOQ01
 import Proofs.MantelTheorem
 import Proofs.MantelTheoremUniqueness
 import Proofs.MantelTheoremOQ04
+import Proofs.MantelTheoremOQ04OQ02
 import Proofs.MathematicalInduction
 import Proofs.MathematicalInductionOQ01
 import Proofs.MathematicalInductionOQ03

--- a/proofs/Proofs/MantelTheoremOQ04OQ02.lean
+++ b/proofs/Proofs/MantelTheoremOQ04OQ02.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2024-2026 lean-genius contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+import Proofs.MantelTheoremOQ04
+
+/-!
+# Mantel's Theorem — Sharpness of the Bound: `⌊n²/4⌋` is Attained
+
+`Proofs/MantelTheoremUniqueness.lean` proves Mantel's *equality characterization*
+(`mantel_equality_iff`): a triangle-free graph on `n` vertices attains the maximum
+`⌊n²/4⌋` edges **iff** it is isomorphic to `turanGraph n 2`; and
+`Proofs/MantelTheoremOQ04.lean` identifies that extremal graph concretely as the balanced
+complete bipartite graph `K_{⌈n/2⌉,⌊n/2⌋}`.
+
+Both of those statements are *conditional* — "if a graph attains the maximum, then …".
+What is missing is the **sharpness/tightness** half: that the bound `⌊n²/4⌋` is actually
+**attained**, i.e. there genuinely exists a triangle-free graph on `n` vertices with exactly
+`⌊n²/4⌋` edges. Without it, `⌊n²/4⌋` could a priori be a non-tight upper bound. This file
+supplies the missing existence direction by computing the edge count of the extremal graph
+explicitly.
+
+This answers the second open question posed by `mantel-theorem-oq-04`:
+> Prove `#E(K_{⌈n/2⌉,⌊n/2⌋}) = ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋` for a self-contained complete-bipartite
+> tightness proof.
+
+## Main results
+
+* `card_edgeFinset_completeBipartiteGraph` : `#E(K_{V,W}) = |V| · |W|`. The basic edge-count
+  formula for a complete bipartite graph, proved via the degree-sum (handshake) formula. (No
+  such lemma exists in Mathlib; cf. `card_edgeFinset_completeEquipartiteGraph` for the
+  equipartite multipartite analogue.)
+* `half_succ_mul_half` : `⌈n/2⌉ · ⌊n/2⌋ = ⌊n²/4⌋`, the arithmetic identity behind the bound.
+* `card_edgeFinset_turanGraphTwo` : `#E(turanGraph n 2) = ⌊n²/4⌋` — the extremal graph has
+  exactly the Mantel-maximal number of edges.
+* `mantel_bound_attained` : `turanGraph n 2` is triangle-free **and** has exactly `⌊n²/4⌋`
+  edges. Together with `mantel_card_edgeFinset_le` (the upper bound) this makes Mantel's
+  bound provably sharp.
+
+## Proof outline
+
+The edge count of `K_{V,W}` follows from the handshake formula
+`∑ v, deg v = 2 · #E`: every left vertex has degree `|W|` and every right vertex degree `|V|`,
+so the degree sum is `|V|·|W| + |W|·|V| = 2·|V|·|W|`. The arithmetic identity
+`⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋` is a two-case parity computation. The extremal edge count then
+transports along the isomorphism `turanGraphTwoIsoCompleteBipartite` (edge counts are
+isomorphism invariants), and triangle-freeness comes from the parity 2-colouring
+`v ↦ v % 2` (a `2`-colourable graph is `K₃`-free).
+-/
+
+open Finset Fintype SimpleGraph
+
+namespace Mantel
+
+open scoped Classical
+
+variable {V W : Type*} [Fintype V] [Fintype W]
+
+/-- The neighbours of a left vertex in `K_{V,W}` are exactly the right vertices. -/
+theorem neighborFinset_completeBipartiteGraph_inl (i : V) :
+    (completeBipartiteGraph V W).neighborFinset (Sum.inl i) = univ.image Sum.inr := by
+  ext x
+  cases x <;> simp [mem_neighborFinset]
+
+/-- The neighbours of a right vertex in `K_{V,W}` are exactly the left vertices. -/
+theorem neighborFinset_completeBipartiteGraph_inr (j : W) :
+    (completeBipartiteGraph V W).neighborFinset (Sum.inr j) = univ.image Sum.inl := by
+  ext x
+  cases x <;> simp [mem_neighborFinset]
+
+/-- Every left vertex of `K_{V,W}` has degree `|W|`. -/
+theorem degree_completeBipartiteGraph_inl (i : V) :
+    (completeBipartiteGraph V W).degree (Sum.inl i) = Fintype.card W := by
+  rw [← card_neighborFinset_eq_degree, neighborFinset_completeBipartiteGraph_inl,
+    card_image_of_injective _ Sum.inr_injective, card_univ]
+
+/-- Every right vertex of `K_{V,W}` has degree `|V|`. -/
+theorem degree_completeBipartiteGraph_inr (j : W) :
+    (completeBipartiteGraph V W).degree (Sum.inr j) = Fintype.card V := by
+  rw [← card_neighborFinset_eq_degree, neighborFinset_completeBipartiteGraph_inr,
+    card_image_of_injective _ Sum.inl_injective, card_univ]
+
+/-- **Edge count of a complete bipartite graph.** `K_{V,W}` has exactly `|V| · |W|` edges.
+Proved from the handshake formula: the degree sum is `|V|·|W| + |W|·|V| = 2·|V|·|W|`. -/
+theorem card_edgeFinset_completeBipartiteGraph :
+    #(completeBipartiteGraph V W).edgeFinset = Fintype.card V * Fintype.card W := by
+  have h := (completeBipartiteGraph V W).sum_degrees_eq_twice_card_edges
+  rw [Fintype.sum_sum_type] at h
+  simp only [degree_completeBipartiteGraph_inl, degree_completeBipartiteGraph_inr,
+    Finset.sum_const, card_univ, smul_eq_mul] at h
+  rw [mul_comm (Fintype.card W) (Fintype.card V)] at h
+  omega
+
+/-- Specialisation to `Fin a ⊕ Fin b`: `#E(K_{a,b}) = a · b`. -/
+theorem card_edgeFinset_completeBipartiteGraph_fin (a b : ℕ) :
+    #(completeBipartiteGraph (Fin a) (Fin b)).edgeFinset = a * b := by
+  rw [card_edgeFinset_completeBipartiteGraph, Fintype.card_fin, Fintype.card_fin]
+
+/-- **The balanced-bipartite arithmetic identity** `⌈n/2⌉ · ⌊n/2⌋ = ⌊n²/4⌋`, by parity cases. -/
+theorem half_succ_mul_half (n : ℕ) : ((n + 1) / 2) * (n / 2) = n ^ 2 / 4 := by
+  rcases Nat.even_or_odd n with ⟨m, rfl⟩ | ⟨m, rfl⟩
+  · -- `n = m + m`
+    have e1 : (m + m + 1) / 2 = m := by omega
+    have e2 : (m + m) / 2 = m := by omega
+    rw [e1, e2, pow_two]
+    have hsq : (m + m) * (m + m) = 4 * (m * m) := by ring
+    rw [hsq, Nat.mul_div_cancel_left _ (by norm_num : (0 : ℕ) < 4)]
+  · -- `n = 2 * m + 1`
+    have e1 : (2 * m + 1 + 1) / 2 = m + 1 := by omega
+    have e2 : (2 * m + 1) / 2 = m := by omega
+    rw [e1, e2, pow_two]
+    have hsq : (2 * m + 1) * (2 * m + 1) = 4 * ((m + 1) * m) + 1 := by ring
+    rw [hsq]
+    omega
+
+/-- **The Mantel/Turán extremal graph attains `⌊n²/4⌋` edges.** The edge count transports along
+`turanGraphTwoIsoCompleteBipartite` and equals `⌈n/2⌉ · ⌊n/2⌋ = ⌊n²/4⌋`. -/
+theorem card_edgeFinset_turanGraphTwo (n : ℕ) :
+    #(turanGraph n 2).edgeFinset = n ^ 2 / 4 := by
+  rw [← (turanGraphTwoIsoCompleteBipartite n).card_edgeFinset_eq,
+    card_edgeFinset_completeBipartiteGraph_fin, half_succ_mul_half]
+
+/-- The Mantel/Turán extremal graph is triangle-free: the parity 2-colouring `v ↦ v % 2`
+makes it `2`-colourable, and a `2`-colourable graph is `K₃`-free. -/
+theorem turanGraphTwo_cliqueFree_three (n : ℕ) : (turanGraph n 2).CliqueFree 3 := by
+  have hcol : (turanGraph n 2).Colorable 2 := by
+    refine ⟨Coloring.mk (fun v => (⟨(v : ℕ) % 2, by omega⟩ : Fin 2)) ?_⟩
+    intro v w hadj heq
+    rw [turanGraph_adj] at hadj
+    exact hadj (by simpa using heq)
+  exact hcol.cliqueFree (by norm_num)
+
+/-- **Sharpness of Mantel's theorem.** For every `n`, the extremal graph `turanGraph n 2`
+(equivalently `K_{⌈n/2⌉,⌊n/2⌋}`) is triangle-free and has exactly `⌊n²/4⌋` edges. Combined with
+the upper bound `mantel_card_edgeFinset_le`, this shows the Mantel bound `⌊n²/4⌋` is attained —
+the missing existence/tightness direction of the equality characterisation. -/
+theorem mantel_bound_attained (n : ℕ) :
+    (turanGraph n 2).CliqueFree 3 ∧ #(turanGraph n 2).edgeFinset = n ^ 2 / 4 :=
+  ⟨turanGraphTwo_cliqueFree_three n, card_edgeFinset_turanGraphTwo n⟩
+
+end Mantel

--- a/src/data/proofs/mantel-theorem-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/mantel-theorem-oq-04-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "mantel-oq0402-ann-import",
+    "proofId": "mantel-theorem-oq-04-oq-02",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "concept",
+    "title": "Imports and Statement: the Sharpness Half of Mantel's Theorem",
+    "content": "Besides import Mathlib (for the handshake formula, completeBipartiteGraph, SimpleGraph.Iso, and Colorable.cliqueFree), the file imports the sibling Proofs.MantelTheoremOQ04, reusing its isomorphism turanGraphTwoIsoCompleteBipartite. The docstring locates this entry as the existence/tightness direction: the companion entries give conditional equality characterizations ('if a graph attains the maximum it is the Turán/bipartite graph'), but do not establish that ⌊n²/4⌋ is attained at all. Computing the extremal graph's edge count supplies that missing half.",
+    "mathContext": "Builds on the handshake formula $\\sum_v \\deg v = 2\\,\\#E$ and the parity-bijection isomorphism of the parent entry.",
+    "significance": "central",
+    "relatedConcepts": ["Mantel's theorem", "sharpness", "turanGraph", "completeBipartiteGraph", "handshake lemma"],
+    "prerequisites": ["simple graphs", "Mantel's theorem", "graph isomorphism"]
+  },
+  {
+    "id": "mantel-oq0402-ann-neighbors-degrees",
+    "proofId": "mantel-theorem-oq-04-oq-02",
+    "range": { "startLine": 60, "endLine": 82 },
+    "type": "technique",
+    "title": "Neighbour Sets and Per-Side Degrees of K_{V,W}",
+    "content": "In a complete bipartite graph the neighbours of a left vertex are exactly the right side (and symmetrically), proved by ext + cases on the vertex + simp on the @[simps]-generated bipartite adjacency. Counting these neighbour sets via card_neighborFinset_eq_degree and card_image_of_injective (Sum.inl/inr are injective) gives the constant per-side degrees: every left vertex has degree |W|, every right vertex degree |V|.",
+    "mathContext": "$\\deg(\\mathrm{inl}\\,i) = |W|$, $\\deg(\\mathrm{inr}\\,j) = |V|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["neighborFinset", "degree", "completeBipartiteGraph", "card_image_of_injective"],
+    "prerequisites": ["graph degree", "finite cardinality"]
+  },
+  {
+    "id": "mantel-oq0402-ann-edge-count",
+    "proofId": "mantel-theorem-oq-04-oq-02",
+    "range": { "startLine": 84, "endLine": 98 },
+    "type": "key-step",
+    "title": "Edge Count via the Handshake Formula: #E(K_{V,W}) = |V|·|W|",
+    "content": "card_edgeFinset_completeBipartiteGraph is the main new lemma — Mathlib lacks it (it has only the equipartite multipartite card_edgeFinset_completeEquipartiteGraph). The proof feeds the handshake formula ∑ v, deg v = 2·#E: splitting the sum over V ⊕ W with Fintype.sum_sum_type and the constant per-side degrees gives |V|·|W| + |W|·|V| = 2·#E. Since omega treats |V|·|W| and |W|·|V| as distinct atoms, a single mul_comm identifies them before omega reads off #E = |V|·|W|. Specialised to Fin a ⊕ Fin b it yields a·b.",
+    "mathContext": "$\\#E(K_{V,W}) = |V|\\cdot|W|$, from $\\sum_v \\deg v = 2\\#E$.",
+    "significance": "central",
+    "relatedConcepts": ["sum_degrees_eq_twice_card_edges", "Fintype.sum_sum_type", "handshake lemma", "omega"],
+    "prerequisites": ["degree-sum formula", "finite sums over sum types"]
+  },
+  {
+    "id": "mantel-oq0402-ann-arithmetic",
+    "proofId": "mantel-theorem-oq-04-oq-02",
+    "range": { "startLine": 100, "endLine": 115 },
+    "type": "key-step",
+    "title": "The Arithmetic Identity ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋",
+    "content": "half_succ_mul_half connects the part-product to the Mantel bound by a two-case parity split. For n = 2m, both ⌈n/2⌉·⌊n/2⌋ and ⌊n²/4⌋ equal m². For n = 2m+1, both equal m(m+1) = m²+m, the floor in ⌊n²/4⌋ absorbing the +1/4 (using (2m+1)² = 4·(m+1)·m + 1). Each case rewrites the halves and the square explicitly so omega can discharge the remaining Nat-division goal.",
+    "mathContext": "$\\lceil n/2\\rceil\\cdot\\lfloor n/2\\rfloor = \\lfloor n^2/4\\rfloor$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat division", "parity", "omega", "floor"],
+    "prerequisites": ["Euclidean division", "even/odd case analysis"]
+  },
+  {
+    "id": "mantel-oq0402-ann-sharpness",
+    "proofId": "mantel-theorem-oq-04-oq-02",
+    "range": { "startLine": 117, "endLine": 140 },
+    "type": "key-step",
+    "title": "Sharpness: the Extremal Graph Is Triangle-Free with ⌊n²/4⌋ Edges",
+    "content": "card_edgeFinset_turanGraphTwo transports the bipartite edge count along the parent's isomorphism turanGraphTwoIsoCompleteBipartite (edge counts are isomorphism invariants, Iso.card_edgeFinset_eq) and applies the arithmetic identity, giving #E(turanGraph n 2) = ⌊n²/4⌋. turanGraphTwo_cliqueFree_three proves triangle-freeness with no combinatorics: the parity map v ↦ v % 2 is a 2-colouring into Fin 2, and a 2-colourable graph is K₃-free (Colorable.cliqueFree, 2 < 3). mantel_bound_attained packages both halves — the existence direction that makes Mantel's bound provably sharp.",
+    "mathContext": "$\\mathrm{turanGraph}\\,n\\,2$ is $K_3$-free and $\\#E = \\lfloor n^2/4\\rfloor$.",
+    "significance": "central",
+    "relatedConcepts": ["Iso.card_edgeFinset_eq", "Colorable.cliqueFree", "graph coloring", "extremal graph theory"],
+    "prerequisites": ["graph isomorphism invariants", "graph coloring", "clique-freeness"]
+  }
+]

--- a/src/data/proofs/mantel-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-04-oq-02/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "mantel-theorem-oq-04-oq-02",
+  "title": "Mantel's Theorem Is Sharp: the Extremal Graph Attains ⌊n²/4⌋ Edges",
+  "slug": "mantel-theorem-oq-04-oq-02",
+  "description": "A fully verified, axiom-free proof that Mantel's bound ⌊n²/4⌋ is attained — the missing existence/tightness direction of the equality characterization. The companion entries state only conditional facts ('if a triangle-free graph has ⌊n²/4⌋ edges then it is the Turán/complete-bipartite graph'); this entry proves the bound is genuinely achievable by computing the edge count of the extremal graph explicitly. Main new lemma: card_edgeFinset_completeBipartiteGraph, #E(K_{V,W}) = |V|·|W| for any complete bipartite graph, proved via the handshake (degree-sum) formula — a lemma Mathlib lacks (it has only the equipartite multipartite analogue card_edgeFinset_completeEquipartiteGraph). Combined with the arithmetic identity ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋ and transport along turanGraphTwoIsoCompleteBipartite, this yields #E(turanGraph n 2) = ⌊n²/4⌋. Triangle-freeness of the extremal graph comes from the parity 2-colouring v ↦ v % 2 (a 2-colourable graph is K₃-free). The headline mantel_bound_attained packages both halves: turanGraph n 2 is triangle-free and has exactly ⌊n²/4⌋ edges. Answers the first open question of mantel-theorem-oq-04.",
+  "meta": {
+    "author": "lean-genius researcher agents, formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Mantel%27s_theorem",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "graph-theory",
+      "combinatorics",
+      "extremal-graph-theory",
+      "triangle-free",
+      "mantel-theorem",
+      "turan-graph",
+      "complete-bipartite",
+      "edge-count",
+      "handshake-lemma",
+      "graph-coloring"
+    ],
+    "proofRepoPath": "Proofs/MantelTheoremOQ04OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.sum_degrees_eq_twice_card_edges",
+        "description": "The handshake / degree-sum formula ∑ v, deg v = 2·#E, the engine of the edge count: the bipartite degree sum |V|·|W| + |W|·|V| = 2·|V|·|W| gives #E = |V|·|W|",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
+      },
+      {
+        "theorem": "SimpleGraph.completeBipartiteGraph",
+        "description": "The complete bipartite graph on V ⊕ W; its @[simps]-generated adjacency drives the neighbour-set computation that yields the per-side degrees",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+      },
+      {
+        "theorem": "SimpleGraph.Iso.card_edgeFinset_eq",
+        "description": "Edge counts are graph-isomorphism invariants; transports #E(K_{⌈n/2⌉,⌊n/2⌋}) to #E(turanGraph n 2) via the sibling isomorphism turanGraphTwoIsoCompleteBipartite",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Finite"
+      },
+      {
+        "theorem": "SimpleGraph.Colorable.cliqueFree",
+        "description": "An n-colourable graph is (n+1)-clique-free; with the parity 2-colouring this gives turanGraph n 2 triangle-free (CliqueFree 3)",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Coloring"
+      }
+    ],
+    "originalContributions": [
+      "card_edgeFinset_completeBipartiteGraph: the edge-count formula #E(K_{V,W}) = |V|·|W| for an arbitrary complete bipartite graph, proved from the handshake formula via the per-side degree lemmas; Mathlib has no such lemma (only the equipartite multipartite card_edgeFinset_completeEquipartiteGraph), making this a genuine gap-filler",
+      "neighborFinset_completeBipartiteGraph_inl/_inr and degree_completeBipartiteGraph_inl/_inr: the neighbour sets (all of the opposite side) and degrees (|W| for a left vertex, |V| for a right vertex) of a complete bipartite graph",
+      "half_succ_mul_half: the arithmetic identity ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋ proved by a two-case parity split (n even gives m·m = ⌊(2m)²/4⌋, n odd gives (m+1)·m = ⌊(2m+1)²/4⌋), closing the Nat-division goals with omega",
+      "card_edgeFinset_turanGraphTwo: #E(turanGraph n 2) = ⌊n²/4⌋, obtained by transporting card_edgeFinset_completeBipartiteGraph_fin along turanGraphTwoIsoCompleteBipartite and applying the arithmetic identity",
+      "turanGraphTwo_cliqueFree_three: triangle-freeness of the extremal graph via the explicit parity 2-colouring v ↦ v % 2 into Fin 2 and Colorable.cliqueFree",
+      "mantel_bound_attained: the sharpness statement — turanGraph n 2 is triangle-free and has exactly ⌊n²/4⌋ edges — the existence half that, with the upper bound, makes Mantel's bound provably tight"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCountNote": "0 axiom declarations, 0 sorries, 0 structure-encoded assumptions, no native_decide. #print axioms reports only propext/Classical.choice/Quot.sound (no sorryAx, no Lean.ofReduceBool), which the project does not count. The edge count is derived entirely from Mathlib's handshake formula and graph-isomorphism API; the parity-coloring triangle-freeness uses only Colorable.cliqueFree."
+  },
+  "overview": {
+    "historicalContext": "Mantel's 1907 theorem has two halves. The bound: a triangle-free graph on n vertices has at most ⌊n²/4⌋ edges. The sharpness: this bound is attained, by the balanced complete bipartite graph K_{⌈n/2⌉,⌊n/2⌋}. Mathlib and the sibling gallery entries formalize the bound and the equality characterization (which extremal graphs attain the maximum), but those are conditional statements — 'if a graph attains the maximum then it is the Turán graph'. They do not by themselves establish that the maximum is attained at all, i.e. that ⌊n²/4⌋ is the actual extremal value rather than a loose upper bound. Supplying that existence direction requires counting the edges of the extremal graph, which classically is exactly ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋.",
+    "problemStatement": "Prove that the Mantel bound is sharp by computing the edge count of the extremal graph: establish #E(K_{V,W}) = |V|·|W| for a complete bipartite graph, deduce #E(K_{⌈n/2⌉,⌊n/2⌋}) = ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋, and conclude that turanGraph n 2 is triangle-free with exactly ⌊n²/4⌋ edges.",
+    "proofStrategy": "The edge count of a complete bipartite graph follows from the handshake formula ∑ v, deg v = 2·#E. The neighbour set of a left vertex is the whole right side (and vice versa), so every left vertex has degree |W| and every right vertex degree |V|; splitting the degree sum over V ⊕ W with Fintype.sum_sum_type gives |V|·|W| + |W|·|V| = 2·#E, hence #E = |V|·|W| (omega after a single mul_comm to identify the two products). Specialising to Fin a ⊕ Fin b gives a·b. The arithmetic identity ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋ is a two-case parity computation (omega for the divisions). For the extremal graph proper, the edge count transports along the sibling isomorphism turanGraphTwoIsoCompleteBipartite (Iso.card_edgeFinset_eq), and triangle-freeness comes from the parity 2-colouring v ↦ v % 2 into Fin 2 together with Colorable.cliqueFree (2 < 3).",
+    "keyInsights": [
+      "The handshake formula reduces edge counting to degree counting: for a bipartite graph the degrees are constant on each side (|W| on the left, |V| on the right), so the degree sum is the trivially symmetric |V|·|W| + |W|·|V| = 2·|V|·|W|.",
+      "omega treats |V|·|W| and |W|·|V| as distinct atoms, so a single mul_comm is needed before omega can read off #E = |V|·|W| from the doubled degree sum.",
+      "The bound ⌊n²/4⌋ and the part-product ⌈n/2⌉·⌊n/2⌋ agree exactly, but the equality is a parity statement: for even n=2m both sides are m², for odd n=2m+1 both are m²+m = m(m+1); the floor in ⌊n²/4⌋ absorbs the +1/4 in the odd case.",
+      "Sharpness is logically independent of the equality characterization: 'every maximizer is K_{⌈n/2⌉,⌊n/2⌋}' does not assert any maximizer exists; the explicit edge count is what certifies the bound is attained, not merely an upper bound.",
+      "Triangle-freeness of the extremal graph needs no combinatorics — it is bipartite, hence 2-colourable (the parity colouring), and any 2-colourable graph is K₃-free by Colorable.cliqueFree."
+    ]
+  },
+  "conclusion": {
+    "summary": "A complete, axiom-free and sorry-free proof that Mantel's bound is sharp: the complete bipartite edge-count formula #E(K_{V,W}) = |V|·|W|, the identity ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋, and their combination #E(turanGraph n 2) = ⌊n²/4⌋, packaged with triangle-freeness into mantel_bound_attained. This is the existence/tightness direction missing from the equality characterizations of the sibling entries.",
+    "implications": "card_edgeFinset_completeBipartiteGraph is a reusable Mathlib-gap lemma (the bipartite analogue of card_edgeFinset_completeEquipartiteGraph) good for any extremal-graph edge count. Together with the upper bound mantel_card_edgeFinset_le it certifies that ⌊n²/4⌋ is the exact extremal number of edges, not merely an upper bound.",
+    "openQuestions": [
+      "Prove the analogous sharpness for Turán's theorem: #E(turanGraph n r) = the Turán number, via a general complete-r-partite edge-count formula extending card_edgeFinset_completeBipartiteGraph to the multipartite case.",
+      "Derive the remaining structural corollaries of the extremal graph from its complete-bipartite form: connectedness for n ≥ 2, diameter ≤ 2, and that its minimum degree ⌊n/2⌋ is the sharpness witness for the local bound mantel-theorem-oq-03."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "License and Imports",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Apache-2.0 header, module docstring locating the result as the sharpness/existence half of Mantel's theorem, and imports: Mathlib plus the sibling MantelTheoremOQ04 supplying the isomorphism turanGraphTwoIsoCompleteBipartite.",
+      "mathContext": "Builds on Mathlib's handshake formula, completeBipartiteGraph, SimpleGraph.Iso, and the parity-bijection isomorphism of the parent entry."
+    },
+    {
+      "id": "neighbors-degrees",
+      "title": "Neighbour Sets and Degrees",
+      "startLine": 60,
+      "endLine": 82,
+      "summary": "The neighbours of a left vertex are exactly the right side (and symmetrically), proved by ext + cases + simp on the bipartite adjacency. Consequently every left vertex has degree |W| and every right vertex degree |V|, via card_neighborFinset_eq_degree and card_image_of_injective.",
+      "mathContext": "deg(inl i) = |W|, deg(inr j) = |V| in K_{V,W}."
+    },
+    {
+      "id": "edge-count",
+      "title": "Edge Count of a Complete Bipartite Graph",
+      "startLine": 84,
+      "endLine": 98,
+      "summary": "card_edgeFinset_completeBipartiteGraph: #E(K_{V,W}) = |V|·|W|, from the handshake formula. Splitting the degree sum over V ⊕ W with Fintype.sum_sum_type and the constant per-side degrees gives |V|·|W| + |W|·|V| = 2·#E; mul_comm + omega read off #E = |V|·|W|. Specialised to Fin a ⊕ Fin b it gives a·b.",
+      "mathContext": "$\\#E(K_{V,W}) = |V|\\cdot|W|$."
+    },
+    {
+      "id": "arithmetic-identity",
+      "title": "The Identity ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋",
+      "startLine": 100,
+      "endLine": 115,
+      "summary": "half_succ_mul_half: a two-case parity proof. For n=2m both sides equal m²; for n=2m+1 both equal m(m+1). Each case rewrites the halves and the square explicitly and closes the Nat-division goal with omega (the odd case using (2m+1)² = 4·(m+1)·m + 1).",
+      "mathContext": "$\\lceil n/2\\rceil\\cdot\\lfloor n/2\\rfloor = \\lfloor n^2/4\\rfloor$."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness of Mantel's Bound",
+      "startLine": 117,
+      "endLine": 140,
+      "summary": "card_edgeFinset_turanGraphTwo transports the bipartite edge count along turanGraphTwoIsoCompleteBipartite and applies the arithmetic identity to get #E(turanGraph n 2) = ⌊n²/4⌋. turanGraphTwo_cliqueFree_three proves triangle-freeness via the parity 2-colouring and Colorable.cliqueFree. mantel_bound_attained packages both: the extremal graph is triangle-free with exactly ⌊n²/4⌋ edges.",
+      "mathContext": "$\\mathrm{turanGraph}\\,n\\,2$ is $K_3$-free and $\\#E = \\lfloor n^2/4\\rfloor$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "mantel-theorem-oq-04",
+      "relationship": "extends",
+      "description": "mantel-theorem-oq-04 identifies the extremal graph as K_{⌈n/2⌉,⌊n/2⌋} and explicitly lists computing its edge count as its first open question; this entry answers it, proving #E(K_{⌈n/2⌉,⌊n/2⌋}) = ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋ and reusing the parent's isomorphism turanGraphTwoIsoCompleteBipartite."
+    },
+    {
+      "targetId": "mantel-theorem",
+      "relationship": "related",
+      "description": "mantel-theorem proves the upper bound #E ≤ ⌊n²/4⌋ for triangle-free graphs; combined with the edge count here (#E(turanGraph n 2) = ⌊n²/4⌋), the bound is shown to be exactly attained."
+    },
+    {
+      "targetId": "mantel-theorem-oq-02",
+      "relationship": "related",
+      "description": "mantel-theorem-oq-02 gives the equality characterization (which graphs attain the maximum); this entry supplies the complementary existence statement that the maximum is attained at all."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.MantelTheoremOQ04"
+    ],
+    "opens": [
+      "Finset",
+      "Fintype",
+      "SimpleGraph"
+    ],
+    "namespace": "Mantel",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/MantelTheoremOQ04OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    "card_edgeFinset_completeBipartiteGraph",
+    "half_succ_mul_half",
+    "card_edgeFinset_turanGraphTwo",
+    "turanGraphTwo_cliqueFree_three",
+    "mantel_bound_attained"
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/mantel-theorem-oq-04-oq-02.json
+++ b/src/data/research/problems/mantel-theorem-oq-04-oq-02.json
@@ -1,0 +1,92 @@
+{
+  "id": "mantel-theorem-oq-04-oq-02",
+  "question": "Prove that Mantel's bound ⌊n²/4⌋ is sharp by computing the edge count of the extremal complete bipartite graph: #E(K_{⌈n/2⌉,⌊n/2⌋}) = ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋.",
+  "statement": "The balanced complete bipartite graph K_{⌈n/2⌉,⌊n/2⌋} (equivalently turanGraph n 2) is triangle-free and has exactly ⌊n²/4⌋ edges, so Mantel's upper bound is attained.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: Sharpness of Mantel's bound proved axiom-free. #E(K_{V,W}) = |V|·|W| via handshake formula, ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋ by parity, #E(turanGraph n 2) = ⌊n²/4⌋ by iso transport, triangle-free by parity 2-colouring. Shipped in Proofs/MantelTheoremOQ04OQ02.lean.",
+    "insights": [
+      "The edge count of a complete bipartite graph follows from the handshake formula ∑ deg = 2#E with constant per-side degrees |W| (left) and |V| (right): degree sum |V|·|W| + |W|·|V| = 2·|V|·|W|.",
+      "omega treats |V|·|W| and |W|·|V| as distinct atoms; a single mul_comm is required before omega can read off #E = |V|·|W|.",
+      "Sharpness is logically independent of the equality characterization: 'every maximizer is K_{⌈n/2⌉,⌊n/2⌋}' does not assert a maximizer exists; the explicit edge count certifies the bound is attained.",
+      "Triangle-freeness of the extremal graph needs no combinatorics: the parity colouring v ↦ v % 2 is a 2-colouring and Colorable.cliqueFree gives K₃-free."
+    ],
+    "builtItems": [
+      "card_edgeFinset_completeBipartiteGraph: #E(K_{V,W}) = |V|·|W| (Proofs/MantelTheoremOQ04OQ02.lean) — Mathlib-gap lemma",
+      "neighborFinset_/degree_completeBipartiteGraph_inl/_inr: per-side neighbour sets and degrees",
+      "half_succ_mul_half: ⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋ by parity cases",
+      "card_edgeFinset_turanGraphTwo: #E(turanGraph n 2) = ⌊n²/4⌋ via iso transport",
+      "turanGraphTwo_cliqueFree_three: triangle-freeness via parity 2-colouring",
+      "mantel_bound_attained: turanGraph n 2 is triangle-free with exactly ⌊n²/4⌋ edges"
+    ],
+    "mathlibGaps": [
+      "Mathlib has card_edgeFinset_completeEquipartiteGraph (multipartite equipartite case) but NO edge-count lemma for the plain completeBipartiteGraph — filled here by card_edgeFinset_completeBipartiteGraph."
+    ],
+    "nextSteps": [
+      "Prove the analogous Turán sharpness #E(turanGraph n r) = Turán number via a general complete-r-partite edge-count formula extending card_edgeFinset_completeBipartiteGraph.",
+      "Derive remaining structural corollaries: connectedness for n ≥ 2, diameter ≤ 2, and that minimum degree ⌊n/2⌋ is the sharpness witness for mantel-theorem-oq-03."
+    ]
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/MantelTheorem.lean",
+      "filename": "MantelTheorem.lean",
+      "lineCount": 85,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MantelTheorem.lean"
+    },
+    {
+      "path": "Proofs/MantelTheoremOQ03.lean",
+      "filename": "MantelTheoremOQ03.lean",
+      "lineCount": 105,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MantelTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/MantelTheoremOQ04.lean",
+      "filename": "MantelTheoremOQ04.lean",
+      "lineCount": 112,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MantelTheoremOQ04.lean"
+    },
+    {
+      "path": "Proofs/MantelTheoremOQ04OQ02.lean",
+      "filename": "MantelTheoremOQ04OQ02.lean",
+      "lineCount": 143,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MantelTheoremOQ04OQ02.lean"
+    },
+    {
+      "path": "Proofs/MantelTheoremUniqueness.lean",
+      "filename": "MantelTheoremUniqueness.lean",
+      "lineCount": 71,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MantelTheoremUniqueness.lean"
+    }
+  ],
+  "relatedProofs": [
+    "mantel-theorem",
+    "mantel-theorem-oq-03",
+    "mantel-theorem-oq-04",
+    "mantel-theorem-oq-04-oq-02"
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **sharpness** (existence/tightness) direction of Mantel's theorem: the bound `⌊n²/4⌋` is actually *attained*, not merely an upper bound. The sibling gallery entries (`mantel-theorem`, `mantel-theorem-oq-02`, `mantel-theorem-oq-04`) state only conditional facts — *"if a triangle-free graph has `⌊n²/4⌋` edges then it is the Turán/complete-bipartite graph"* — which do not by themselves establish that any graph attains the maximum. This entry computes the extremal graph's edge count explicitly and closes that gap.

Answers the **first open question** listed by `mantel-theorem-oq-04`:
> Compute the edge count of the balanced complete bipartite graph directly as `⌈n/2⌉·⌊n/2⌋` and verify `⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋`.

## Results (`proofs/Proofs/MantelTheoremOQ04OQ02.lean`)

- **`card_edgeFinset_completeBipartiteGraph`** — `#E(K_{V,W}) = |V|·|W|` for any complete bipartite graph, via the handshake formula `∑ deg = 2·#E` (every left vertex has degree `|W|`, every right vertex `|V|`). **Mathlib lacks this lemma** — it has only the equipartite multipartite analogue `card_edgeFinset_completeEquipartiteGraph`.
- **`half_succ_mul_half`** — the identity `⌈n/2⌉·⌊n/2⌋ = ⌊n²/4⌋`, by a two-case parity split.
- **`card_edgeFinset_turanGraphTwo`** — `#E(turanGraph n 2) = ⌊n²/4⌋`, transporting the count along the parent's isomorphism `turanGraphTwoIsoCompleteBipartite` (edge counts are iso-invariant).
- **`turanGraphTwo_cliqueFree_three`** — triangle-freeness via the parity 2-colouring `v ↦ v % 2` and `Colorable.cliqueFree`.
- **`mantel_bound_attained`** — the extremal graph is triangle-free **and** has exactly `⌊n²/4⌋` edges. With the upper bound `mantel_card_edgeFinset_le`, this makes Mantel's bound provably sharp.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.MantelTheoremOQ04OQ02` — **succeeds**, 0 sorries.
- `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`/`native_decide`**. Status: `verified`, `axiomCount: 0`.
- 142 lines, 10 theorems, 0 definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)