### PR TITLE
research(abel-ruffini-oq-04-oq-02-oq-02-oq-08[+oq-01]): Aα↔Sα solvability bridge + cardinality-intrinsic classification [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -23,6 +23,7 @@ import Proofs.AbelRuffiniOQ04OQ01
 import Proofs.AbelRuffiniOQ04OQ02
 import Proofs.AbelRuffiniOQ04OQ02OQ02
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ06
+import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08
 import Proofs.AbelRuffiniOQ04OQ02OQ03
 import Proofs.AbelRuffiniOQ04OQ03
 import Proofs.AbelRuffiniOQ04OQ07

--- a/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08.lean
@@ -1,0 +1,167 @@
+/-
+# The Aₐ ↔ Sₐ Solvability Bridge: the Sign Extension is Transparent to Solvability
+  (Abel-Ruffini OQ-04-OQ-02-OQ-02-OQ-08)
+
+Open question spawned from `AbelRuffiniOQ04OQ02OQ02` (Aₙ solvable iff n ≤ 4):
+
+  "The alternating classification (Aₙ solvable iff n ≤ 4) and the symmetric
+   classification (Sₙ solvable iff n ≤ 4) share a threshold. Is that coincidence,
+   or is there a structural reason — independent of the threshold and of the
+   choice of underlying set — forcing the two to agree?"
+
+## Answer: a single equivalence, for an ARBITRARY finite set.
+
+For **any** finite type `α`, the alternating group `Aα` is solvable *iff* the full
+symmetric group `Sα` is solvable:
+
+  **Bridge:   IsSolvable (alternatingGroup α)  ↔  IsSolvable (Perm α).**
+
+The sign extension `1 → Aα → Sα → {±1} → 1` is completely transparent to
+solvability, in both directions:
+
+  * (→)  If the kernel `Aα` is solvable then, because the quotient
+         `Sα / Aα ≅ ℤ/2` is abelian (hence solvable), the middle group `Sα` is
+         solvable. Concretely `Aα.subtype : Aα →* Sα` has image `Aα`, and
+         `Perm.sign : Sα →* ℤˣ` has kernel exactly `Aα`
+         (`mem_alternatingGroup`), so `ker sign ≤ range subtype` and
+         `solvable_of_ker_le_range` applies.
+  * (←)  `Aα` is a *subgroup* of `Sα`, and subgroups of solvable groups are
+         solvable (`subgroup_solvable_of_solvable`).
+
+This is the structural fact the two sibling classifications only recorded
+numerically. It holds with no cardinality hypothesis at all, so the threshold
+agreement at `n = 5` is *forced*, not coincidental: specialising the bridge to
+`α = Fin n` makes the parent's `alternating_solvable_iff` (Aₙ solvable ↔ n ≤ 4)
+and the sibling `AbelRuffiniOQ04OQ02` classification (Sₙ solvable ↔ n ≤ 4)
+*literally the same theorem* viewed through the sign sequence.
+
+| n  | Aₙ solvable | Sₙ solvable | bridge says |
+|----|-------------|-------------|-------------|
+| ≤4 | yes         | yes         | agree ✓     |
+| ≥5 | no          | no          | agree ✓     |
+
+The transition at `n = 5` is the algebraic heart of Abel–Ruffini: a general
+quintic has Galois group `S₅`, non-solvable because its alternating subgroup
+`A₅` is simple and non-abelian — hence no solution in radicals.
+
+Parent:  `AbelRuffiniOQ04OQ02OQ02.lean`  (Aₙ solvable iff n ≤ 4)
+Sibling: `AbelRuffiniOQ04OQ02.lean`       (Sₙ solvable iff n ≤ 4)
+Sibling: `AbelRuffiniOQ04OQ02OQ02OQ06.lean` (derived-length gap A₄ vs A₅)
+
+References:
+- Galois (1832); Jordan, *Traité des substitutions* (1870)
+- Hungerford, *Algebra* (1974), §II.7;  Lang, *Algebra* (3rd ed.), §I.8
+-/
+
+import Mathlib.GroupTheory.Solvable
+import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.Tactic
+import Proofs.AbelRuffiniOQ04OQ02OQ02
+
+set_option linter.unusedVariables false
+set_option linter.unusedTactic false
+
+open Equiv
+
+namespace AbelRuffiniOQ04OQ02OQ02OQ08
+
+open AbelRuffiniOQ04OQ02OQ02
+
+-- ============================================================
+-- PART 1: The Sign Exact Sequence, Both Directions (any finite α)
+-- ============================================================
+
+variable {α : Type*} [DecidableEq α] [Fintype α]
+
+/-- **Kernel direction (general `α`).** If the alternating subgroup `Aα` is
+solvable, then the full symmetric group `Sα` is solvable.
+
+This is the substantive half: it uses the short exact sequence
+`1 → Aα → Sα → {±1} → 1`. The map `Aα.subtype : Aα →* Sα` has image `Aα`, and
+`Perm.sign : Sα →* ℤˣ` has kernel exactly `Aα`, so `ker sign ≤ range subtype`.
+With kernel and quotient both solvable, `solvable_of_ker_le_range` delivers `Sα`. -/
+theorem sym_solvable_of_alternating_solvable
+    (h : IsSolvable (alternatingGroup α)) : IsSolvable (Perm α) := by
+  apply solvable_of_ker_le_range (alternatingGroup α).subtype Perm.sign
+  intro x hx
+  rw [MonoidHom.mem_ker] at hx
+  exact ⟨⟨x, Perm.mem_alternatingGroup.mpr hx⟩, rfl⟩
+
+/-- **Subgroup direction (general `α`).** If the symmetric group `Sα` is solvable,
+then its alternating subgroup `Aα` is solvable, because subgroups of solvable
+groups are solvable (`subgroup_solvable_of_solvable`). -/
+theorem alternating_solvable_of_sym_solvable
+    (h : IsSolvable (Perm α)) : IsSolvable (alternatingGroup α) := by
+  haveI := h
+  infer_instance
+
+-- ============================================================
+-- PART 2: The Solvability Bridge (any finite α)
+-- ============================================================
+
+/-- **Solvability bridge (any finite `α`).** The alternating group `Aα` is
+solvable *iff* the symmetric group `Sα` is solvable. The index-2 sign extension
+is completely transparent to solvability — passing to the abelian quotient `ℤ/2`
+neither creates nor destroys it — with no hypothesis on the cardinality of `α`. -/
+theorem alternating_solvable_iff_sym_solvable (α : Type*) [DecidableEq α] [Fintype α] :
+    IsSolvable (alternatingGroup α) ↔ IsSolvable (Perm α) :=
+  ⟨sym_solvable_of_alternating_solvable, alternating_solvable_of_sym_solvable⟩
+
+/-- Contrapositive form, both directions: `Sα` is non-solvable iff `Aα` is. -/
+theorem sym_not_solvable_iff_alternating_not_solvable (α : Type*) [DecidableEq α] [Fintype α] :
+    ¬IsSolvable (Perm α) ↔ ¬IsSolvable (alternatingGroup α) :=
+  not_congr (alternating_solvable_iff_sym_solvable α).symm
+
+-- ============================================================
+-- PART 3: Specialisation to Fin n — the threshold agreement is forced
+-- ============================================================
+
+/-- Specialising the bridge to `α = Fin n`: `Aₙ` solvable iff `Sₙ` solvable. -/
+theorem alternating_fin_solvable_iff_sym_fin_solvable (n : ℕ) :
+    IsSolvable (alternatingGroup (Fin n)) ↔ IsSolvable (Perm (Fin n)) :=
+  alternating_solvable_iff_sym_solvable (Fin n)
+
+/-- **The symmetric classification is the alternating one, via the bridge.**
+Combining the bridge with the parent's `alternating_solvable_iff` recovers
+`Sₙ` solvable ↔ `n ≤ 4` (matching the sibling entry `AbelRuffiniOQ04OQ02`'s
+`solvable_iff_le_four`) — but now *derived* from the alternating classification
+rather than proved independently. The two thresholds are one theorem. -/
+theorem sym_solvable_iff (n : ℕ) : IsSolvable (Perm (Fin n)) ↔ n ≤ 4 := by
+  rw [← alternating_fin_solvable_iff_sym_fin_solvable, alternating_solvable_iff]
+
+/-- The full chain at a glance: `Sₙ` solvable ↔ `Aₙ` solvable ↔ `n ≤ 4`. -/
+theorem solvability_trichotomy (n : ℕ) :
+    (IsSolvable (Perm (Fin n)) ↔ IsSolvable (alternatingGroup (Fin n))) ∧
+      (IsSolvable (Perm (Fin n)) ↔ n ≤ 4) :=
+  ⟨(alternating_fin_solvable_iff_sym_fin_solvable n).symm, sym_solvable_iff n⟩
+
+-- ============================================================
+-- PART 4: Corollaries and the joint sharp threshold
+-- ============================================================
+
+/-- For `n ≤ 4`, `Sₙ` is solvable (transport the parent's `Aₙ` solvability). -/
+theorem sym_solvable_of_le_four {n : ℕ} (hn : n ≤ 4) : IsSolvable (Perm (Fin n)) :=
+  sym_solvable_of_alternating_solvable (alternating_solvable_of_le_four hn)
+
+/-- For `n ≥ 5`, `Sₙ` is NOT solvable: the bridge moves the parent's
+`an_not_solvable_of_ge_five` across the sign sequence. -/
+theorem sym_not_solvable_of_ge_five {n : ℕ} (hn : 5 ≤ n) :
+    ¬IsSolvable (Perm (Fin n)) := by
+  rw [sym_not_solvable_iff_alternating_not_solvable]
+  exact an_not_solvable_of_ge_five hn
+
+/-- S₄ (order 24) is solvable — the largest solvable symmetric group (Ferrari's
+quartic formula). -/
+theorem s4_solvable : IsSolvable (Perm (Fin 4)) := sym_solvable_of_le_four (le_refl 4)
+
+/-- S₅ (order 120) is NOT solvable — the obstruction to a general quintic formula. -/
+theorem s5_not_solvable : ¬IsSolvable (Perm (Fin 5)) := sym_not_solvable_of_ge_five (le_refl 5)
+
+/-- **Joint sharp threshold.** At `n = 4` both A₄ and S₄ are solvable; at `n = 5`
+both A₅ and S₅ fail. The bridge forces the two transitions to coincide. -/
+theorem joint_sharp_threshold :
+    (IsSolvable (alternatingGroup (Fin 4)) ∧ IsSolvable (Perm (Fin 4))) ∧
+      (¬IsSolvable (alternatingGroup (Fin 5)) ∧ ¬IsSolvable (Perm (Fin 5))) :=
+  ⟨⟨a4_solvable, s4_solvable⟩, ⟨a5_not_solvable, s5_not_solvable⟩⟩
+
+end AbelRuffiniOQ04OQ02OQ02OQ08

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-bridge-header",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+    "range": { "startLine": 1, "endLine": 64 },
+    "type": "concept",
+    "title": "The Solvability Bridge: Motivation and Statement",
+    "content": "Two sibling gallery entries record the same threshold from different sides: the parent `AbelRuffiniOQ04OQ02OQ02` proves $A_n$ solvable $\\iff n \\leq 4$, and `AbelRuffiniOQ04OQ02` proves $S_n$ solvable $\\iff n \\leq 4$. This entry asks *why* the two thresholds coincide and answers with a single equivalence valid for an **arbitrary** finite type $\\alpha$:\n$$\\mathrm{IsSolvable}(A_\\alpha) \\iff \\mathrm{IsSolvable}(S_\\alpha).$$\nThe equivalence carries no cardinality hypothesis, so the agreement of the two classifications is *forced* rather than coincidental. Specialising to $\\alpha = \\mathrm{Fin}\\,n$ makes the alternating and symmetric classifications literally the same theorem viewed through the sign exact sequence $1 \\to A_\\alpha \\to S_\\alpha \\to \\{\\pm 1\\} \\to 1$.\n\n**Why a bridge and not just a chain.** One could deduce $S_n$ solvable $\\iff A_n$ solvable cheaply by chaining the two pre-existing `\\iff n \\leq 4` results. The point of this entry is that the bridge needs *neither* threshold: the forward direction is the short-exact-sequence extension lemma `solvable_of_ker_le_range`, the backward direction is `subgroup_solvable_of_solvable`. Both are pure group theory, so the equivalence holds for every finite $\\alpha$ — including those for which neither classification is even stated. The threshold facts then drop out as corollaries, not as inputs.",
+    "mathContext": "An extension $1 \\to N \\to G \\to Q \\to 1$ with $N$ and $Q$ solvable has $G$ solvable (closure of solvable groups under extensions); and every subgroup of a solvable group is solvable. The sign sequence realises $A_\\alpha = \\ker(\\mathrm{sign})$ as a normal subgroup with abelian quotient $S_\\alpha / A_\\alpha \\cong \\mathbb{Z}/2$ (for $|\\alpha| \\geq 2$; trivial otherwise). Both hypotheses for the extension lemma are therefore automatic once $A_\\alpha$ is solvable, giving the forward direction; the backward direction is immediate since $A_\\alpha \\leq S_\\alpha$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "solvable group",
+      "alternating group",
+      "symmetric group",
+      "short exact sequence of groups",
+      "extension-closure of solvable groups",
+      "sign homomorphism",
+      "subgroups of solvable groups are solvable",
+      "Abel-Ruffini theorem"
+    ],
+    "prerequisites": [
+      "group theory",
+      "solvable groups and the derived series",
+      "normal subgroups and quotient groups",
+      "Mathlib `IsSolvable` typeclass"
+    ]
+  },
+  {
+    "id": "ann-bridge-both-directions",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+    "range": { "startLine": 70, "endLine": 96 },
+    "type": "proof-step",
+    "title": "The Two Directions of the Sign Extension",
+    "content": "`sym_solvable_of_alternating_solvable` (the substantive half) applies `solvable_of_ker_le_range` to the pair $(\\,A_\\alpha.\\mathrm{subtype} : A_\\alpha \\to S_\\alpha,\\ \\mathrm{sign} : S_\\alpha \\to \\mathbb{Z}^\\times\\,)$. The side goal $\\ker(\\mathrm{sign}) \\leq \\mathrm{range}(\\mathrm{subtype})$ is discharged by taking $x$ with $\\mathrm{sign}\\,x = 1$ and exhibiting the witness $\\langle x, \\mathrm{mem\\_alternatingGroup.mpr}\\,hx\\rangle$, since membership in the alternating group is *by definition* $\\mathrm{sign}\\,x = 1$. `alternating_solvable_of_sym_solvable` (the easy half) just registers the hypothesis as an instance and lets `subgroup_solvable_of_solvable` fire via type-class resolution — `A_\\alpha` being a `Subgroup (Perm \\alpha)`.\n\nBoth lemmas are stated for a general `[DecidableEq \\alpha] [Fintype \\alpha]`, the exact hypotheses `Perm.sign` and `alternatingGroup` require — no `Fin n` anywhere.",
+    "mathContext": "`solvable_of_ker_le_range (f : G' →* G) (g : G →* G'')` proves `IsSolvable G` from `IsSolvable G'`, `IsSolvable G''` and `g.ker ≤ f.range`. Here $G' = A_\\alpha$, $G = S_\\alpha$, $G'' = \\mathbb{Z}^\\times$; `IsSolvable G''` holds because $\\mathbb{Z}^\\times$ is commutative. The kernel inclusion is an equality in disguise: `alternatingGroup α = (Perm.sign).ker`, so $\\ker(\\mathrm{sign})$ is exactly the range of the subgroup inclusion. The reverse direction uses the instance `subgroup_solvable_of_solvable (H : Subgroup G) [IsSolvable G] : IsSolvable H`, itself `solvable_of_solvable_injective H.subtype_injective`.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "solvable_of_ker_le_range",
+      "subgroup_solvable_of_solvable",
+      "Perm.sign kernel = alternatingGroup",
+      "MonoidHom.mem_ker",
+      "type-class resolution for subgroup solvability"
+    ],
+    "prerequisites": [
+      "monoid homomorphisms, kernels and ranges",
+      "Mathlib `Subgroup.subtype`",
+      "Lean 4 instance synthesis (`haveI`/`infer_instance`)"
+    ]
+  },
+  {
+    "id": "ann-bridge-iff",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+    "range": { "startLine": 98, "endLine": 113 },
+    "type": "key-insight",
+    "title": "The Bridge Equivalence (and its Contrapositive)",
+    "content": "`alternating_solvable_iff_sym_solvable` packages the two directions into the headline equivalence $\\mathrm{IsSolvable}(A_\\alpha) \\iff \\mathrm{IsSolvable}(S_\\alpha)$ for every finite $\\alpha$. `sym_not_solvable_iff_alternating_not_solvable` is the negated form, obtained by `not_congr` — useful because non-solvability is the form in which both Abel–Ruffini and Mathlib's `Equiv.Perm.not_solvable` are stated. Conceptually the lemma says the sign extension is *solvability-transparent*: tacking on the abelian $\\mathbb{Z}/2$ quotient never changes the solvability status of the group, in either direction.",
+    "mathContext": "The equivalence is the antisymmetric combination of the two one-directional lemmas. Its contrapositive $\\neg\\mathrm{IsSolvable}(S_\\alpha) \\iff \\neg\\mathrm{IsSolvable}(A_\\alpha)$ is logically equivalent but more directly composable with `an_not_solvable_of_ge_five` and `Equiv.Perm.not_solvable`, both phrased as negations.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "if and only if",
+      "not_congr",
+      "solvability-transparent extension",
+      "abelian quotient ℤ/2",
+      "contrapositive reformulation"
+    ],
+    "prerequisites": [
+      "propositional logic in Lean (`Iff`, `not_congr`)",
+      "the two directional lemmas above"
+    ]
+  },
+  {
+    "id": "ann-bridge-fin-specialisation",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+    "range": { "startLine": 115, "endLine": 136 },
+    "type": "proof-step",
+    "title": "Forcing the Threshold Agreement on Fin n",
+    "content": "Specialising the bridge to $\\alpha = \\mathrm{Fin}\\,n$ gives `alternating_fin_solvable_iff_sym_fin_solvable`. Composing it with the parent's `alternating_solvable_iff` yields `sym_solvable_iff : IsSolvable (Perm (Fin n)) \\iff n \\leq 4` as a *single rewrite* — recovering the sibling entry `AbelRuffiniOQ04OQ02`'s `solvable_iff_le_four`, but now *derived* from the alternating classification through the bridge rather than proved independently. `solvability_trichotomy` exhibits the full chain $S_n$ solvable $\\iff A_n$ solvable $\\iff n \\leq 4$ in one statement.",
+    "mathContext": "The rewrite `rw [← alternating_fin_solvable_iff_sym_fin_solvable, alternating_solvable_iff]` turns the goal `IsSolvable (Perm (Fin n)) ↔ n ≤ 4` first into `IsSolvable (alternatingGroup (Fin n)) ↔ n ≤ 4` (using the bridge backwards) and then closes it with the parent theorem. This makes explicit that the two classical thresholds are not two facts but one fact seen on either side of the sign sequence.",
+    "significance": "important",
+    "relatedConcepts": [
+      "specialisation α = Fin n",
+      "parent `alternating_solvable_iff`",
+      "sibling `solvable_iff_le_four`",
+      "rewriting along an iff",
+      "solvability trichotomy"
+    ],
+    "prerequisites": [
+      "the bridge equivalence",
+      "the parent alternating-group classification",
+      "Lean 4 `rw` with iff lemmas"
+    ]
+  },
+  {
+    "id": "ann-bridge-corollaries",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+    "range": { "startLine": 138, "endLine": 168 },
+    "type": "concept",
+    "title": "Corollaries and the Joint Sharp Threshold",
+    "content": "The bridge transports the parent's small/large results across the sign sequence: `sym_solvable_of_le_four` ($S_n$ solvable for $n \\leq 4$), `sym_not_solvable_of_ge_five` ($S_n$ not solvable for $n \\geq 5$), and the named instances `s4_solvable`, `s5_not_solvable`. `joint_sharp_threshold` collects the sharp dichotomy on *both* families simultaneously — $A_4$ and $S_4$ solvable, $A_5$ and $S_5$ not — making visible that the transition at $n = 5$ happens in lockstep for the two groups, exactly as the bridge predicts. The non-solvability of $S_5$ is the precise group-theoretic obstruction behind Abel–Ruffini: the general quintic has Galois group $S_5$.",
+    "mathContext": "$|S_4| = 24$ is the largest solvable symmetric group (composition series $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4 \\trianglelefteq S_4$ with abelian factors $\\mathbb{Z}/2,\\mathbb{Z}/2,\\mathbb{Z}/3,\\mathbb{Z}/2$), corresponding to Ferrari's quartic formula. $|S_5| = 120$ is non-solvable because $A_5$ (order 60) is simple and non-abelian, so no radical formula exists for the general quintic.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sharp threshold at n = 5",
+      "Ferrari's quartic formula",
+      "general quintic and Abel-Ruffini",
+      "composition series of S_4",
+      "joint dichotomy A_n / S_n"
+    ],
+    "prerequisites": [
+      "the bridge and its Fin n specialisation",
+      "the parent's `an_not_solvable_of_ge_five` and `a4_solvable`"
+    ]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08/meta.json
@@ -1,0 +1,257 @@
+{
+  "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+  "title": "The Aα ↔ Sα Solvability Bridge",
+  "slug": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+  "description": "For any finite type α, the alternating group Aα is solvable if and only if the symmetric group Sα is solvable. The index-2 sign extension 1 → Aα → Sα → ℤ/2 → 1 is transparent to solvability in both directions, with no cardinality hypothesis. Specialising to α = Fin n forces the agreement of the alternating classification (Aₙ solvable iff n ≤ 4) and the symmetric classification (Sₙ solvable iff n ≤ 4) — the two thresholds are one theorem viewed through the sign sequence.",
+  "meta": {
+    "author": "Classical (Galois, Jordan); bridge formalization original",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Solvable_group",
+    "date": "1832",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02OQ02OQ08.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "solvability",
+      "alternating-group",
+      "symmetric-group",
+      "exact-sequence",
+      "classification",
+      "research",
+      "extension"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "solvable_of_ker_le_range",
+        "description": "Extension lemma: if kernel and quotient image are solvable and ker g ≤ range f, the middle group is solvable. Drives the forward direction Aα solvable ⟹ Sα solvable.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "subgroup_solvable_of_solvable",
+        "description": "Every subgroup of a solvable group is solvable (instance). Drives the backward direction Sα solvable ⟹ Aα solvable, since Aα ≤ Sα.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "Equiv.Perm.mem_alternatingGroup",
+        "description": "f ∈ alternatingGroup α ↔ sign f = 1 — identifies Aα with the kernel of the sign homomorphism, supplying the ker ≤ range witness.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Alternating"
+      },
+      {
+        "theorem": "IsSolvable",
+        "description": "Solvable-group typeclass via the derived series: G solvable iff G^(n) = {e} for some n.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "MonoidHom.mem_ker",
+        "description": "Membership in the kernel of a monoid homomorphism: x ∈ ker f ↔ f x = 1.",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      }
+    ],
+    "originalContributions": [
+      "alternating_solvable_iff_sym_solvable: the headline bridge IsSolvable(Aα) ↔ IsSolvable(Sα) for ANY finite α — neither sibling entry states this; both are Fin-n-and-threshold specific",
+      "sym_solvable_of_alternating_solvable / alternating_solvable_of_sym_solvable: the two directional lemmas, general α, via the sign exact sequence and subgroup-solvability",
+      "sym_not_solvable_iff_alternating_not_solvable: contrapositive form composable with Abel-Ruffini's negative results",
+      "sym_solvable_iff: recovers Sₙ solvable ↔ n ≤ 4 as a one-rewrite COROLLARY of the bridge plus the parent's alternating classification (no independent reproof)",
+      "joint_sharp_threshold: A₄/S₄ solvable and A₅/S₅ not, exhibiting the lockstep transition the bridge forces"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 167,
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used; the named small-case instances (s4_solvable etc.) reach back through the parent's `decide`-based, native_decide-free A₄ argument, so the kernel-checked status is preserved. `#print axioms` on the main results reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "additionalFiles": [],
+    "relatedProblems": [
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02",
+        "relationship": "Parent — proves Aₙ solvable iff n ≤ 4. This entry generalizes the relationship between Aₙ and Sₙ to arbitrary finite α and shows the symmetric classification is the alternating one transported across the sign sequence."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-02",
+        "relationship": "Sibling — proves Sₙ solvable iff n ≤ 4 (`solvable_iff_le_four`). This entry's `sym_solvable_iff` recovers that statement as a corollary of the bridge, exhibiting the two classifications as a single theorem rather than two independent ones."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-06",
+        "relationship": "Sibling — quantifies the A₄-vs-A₅ derived-length gap. Complementary: that entry measures the gap inside the alternating family; this one shows the gap is identical in the symmetric family via the bridge."
+      },
+      {
+        "id": "abel-ruffini",
+        "relationship": "Ancestor — Abel-Ruffini's impossibility rests on S₅ being non-solvable. This entry locates that non-solvability precisely in A₅ ⊂ S₅ via the solvability-transparent sign extension."
+      },
+      {
+        "id": "abel-ruffini-oq-04",
+        "relationship": "Ancestor sub-entry exposing the chain A₅ simple ⟹ S₅ not solvable ⟹ Abel-Ruffini; the bridge makes the middle implication an iff for every finite α."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The solvability of permutation groups is the algebraic heart of the Abel–Ruffini theorem. Galois (1832) proved that A₅ is simple — the first non-abelian simple group — and that a polynomial is solvable by radicals iff its Galois group is solvable; the general quintic, with Galois group S₅, is therefore not solvable by radicals. Jordan (1870) generalized simplicity to all Aₙ (n ≥ 5) and systematized composition series, while Hölder (1889) proved the uniqueness of composition factors. Classically, the symmetric and alternating solvability classifications are proved side by side, sharing the threshold n = 5. This entry isolates the structural reason the two thresholds coincide: the sign extension 1 → Aα → Sα → ℤ/2 → 1 neither creates nor destroys solvability, so Aα is solvable exactly when Sα is — for every finite set α, with no appeal to the threshold itself.",
+    "modernSignificance": "Phrasing the Aα/Sα relationship as a cardinality-free equivalence turns two parallel classification theorems into one: the symmetric classification becomes a one-line corollary of the alternating one (or vice versa). This is the cleanest formal statement of why 'symmetric' and 'alternating' solvability are the same question, and it composes directly with Abel–Ruffini's non-solvability obstruction."
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Documentation and Imports",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Module docstring stating the bridge, the two-direction argument, and the forced threshold agreement; imports Mathlib.GroupTheory.Solvable, Mathlib.GroupTheory.SpecificGroups.Alternating, Mathlib.Tactic, and the parent Proofs.AbelRuffiniOQ04OQ02OQ02.",
+      "mathContext": "The two Mathlib group-theory imports furnish `solvable_of_ker_le_range`, the `subgroup_solvable_of_solvable` instance, `Perm.sign`, `alternatingGroup`, and `mem_alternatingGroup`. The parent import supplies `alternating_solvable_iff`, `alternating_solvable_of_le_four`, `an_not_solvable_of_ge_five`, `a4_solvable`, and `a5_not_solvable`, which the corollaries transport across the sign sequence."
+    },
+    {
+      "id": "directions",
+      "title": "The Sign Exact Sequence, Both Directions (any finite α)",
+      "startLine": 70,
+      "endLine": 96,
+      "summary": "`sym_solvable_of_alternating_solvable` (forward, via solvable_of_ker_le_range with the witness from mem_alternatingGroup) and `alternating_solvable_of_sym_solvable` (backward, via subgroup_solvable_of_solvable), both general in α.",
+      "mathContext": "Forward: solvable_of_ker_le_range on (Aα.subtype, Perm.sign); side goal ker sign ≤ range subtype solved by mem_alternatingGroup. Backward: haveI := h; infer_instance fires the subgroup-solvability instance for Aα ≤ Sα."
+    },
+    {
+      "id": "bridge",
+      "title": "The Solvability Bridge",
+      "startLine": 98,
+      "endLine": 113,
+      "summary": "`alternating_solvable_iff_sym_solvable` packages both directions into IsSolvable(Aα) ↔ IsSolvable(Sα); `sym_not_solvable_iff_alternating_not_solvable` is the not_congr contrapositive.",
+      "mathContext": "The equivalence is the antisymmetric pairing of the two directional lemmas; the negated form is the composable shape for Abel-Ruffini-style non-solvability statements."
+    },
+    {
+      "id": "fin-specialisation",
+      "title": "Specialisation to Fin n — the Threshold Agreement is Forced",
+      "startLine": 115,
+      "endLine": 136,
+      "summary": "`alternating_fin_solvable_iff_sym_fin_solvable` (bridge on Fin n), `sym_solvable_iff` (Sₙ solvable ↔ n ≤ 4 by a single rewrite using the parent), and `solvability_trichotomy` (the full chain).",
+      "mathContext": "rw [← alternating_fin_solvable_iff_sym_fin_solvable, alternating_solvable_iff] reduces the symmetric classification to the parent's alternating classification, recovering the sibling's solvable_iff_le_four as a derived corollary."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries and the Joint Sharp Threshold",
+      "startLine": 138,
+      "endLine": 167,
+      "summary": "Transported corollaries sym_solvable_of_le_four, sym_not_solvable_of_ge_five, s4_solvable, s5_not_solvable, and joint_sharp_threshold (A₄/S₄ solvable, A₅/S₅ not).",
+      "mathContext": "S₄ (order 24) is the largest solvable symmetric group; S₅ (order 120) is non-solvable because A₅ is simple non-abelian — the precise Abel–Ruffini obstruction for the general quintic."
+    }
+  ],
+  "conclusion": {
+    "summary": "For any finite type α, `alternating_solvable_iff_sym_solvable` proves IsSolvable(alternatingGroup α) ↔ IsSolvable(Perm α) with no cardinality hypothesis: the index-2 sign extension is transparent to solvability. The forward direction is the extension lemma solvable_of_ker_le_range applied to the sign sequence; the backward direction is the subgroup-solvability instance. Specialising to Fin n and composing with the parent's alternating classification recovers Sₙ solvable ↔ n ≤ 4 as a one-rewrite corollary (sym_solvable_iff), so the two classical thresholds are exhibited as a single theorem. 167 lines, 12 theorems, 0 definitions, 0 sorries, 0 axioms; no native_decide.",
+    "futureDirections": [
+      "Transport solvability invariance under cardinality: IsSolvable(alternatingGroup α) ↔ IsSolvable(alternatingGroup β) whenever Fintype.card α = Fintype.card β, via a permutation MulEquiv.",
+      "Strengthen the bridge to a derived-length comparison: derived length of Sα is at most one more than that of Aα, with equality detected by the sign quotient.",
+      "Connect the bridge to the Galois side: any polynomial whose Galois group contains Aα (n ≥ 5) is not solvable by radicals, phrased through the transported non-solvability."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Solvable",
+      "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Mathlib.Tactic",
+      "Proofs.AbelRuffiniOQ04OQ02OQ02"
+    ],
+    "opens": ["Equiv"],
+    "namespace": "AbelRuffiniOQ04OQ02OQ02OQ08",
+    "lineCount": 167,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "alternating_solvable_iff_sym_solvable",
+        "type": "core",
+        "description": "For any finite α, IsSolvable (alternatingGroup α) ↔ IsSolvable (Perm α). The headline bridge: the sign extension is transparent to solvability, with no cardinality hypothesis.",
+        "leanType": "(α : Type*) → [DecidableEq α] → [Fintype α] → (IsSolvable (alternatingGroup α) ↔ IsSolvable (Perm α))",
+        "line": 106
+      },
+      {
+        "name": "sym_solvable_of_alternating_solvable",
+        "type": "key",
+        "description": "Forward direction (general α): Aα solvable ⟹ Sα solvable, via solvable_of_ker_le_range on the sign sequence.",
+        "leanType": "IsSolvable (alternatingGroup α) → IsSolvable (Perm α)",
+        "line": 83
+      },
+      {
+        "name": "alternating_solvable_of_sym_solvable",
+        "type": "key",
+        "description": "Backward direction (general α): Sα solvable ⟹ Aα solvable, via subgroup_solvable_of_solvable.",
+        "leanType": "IsSolvable (Perm α) → IsSolvable (alternatingGroup α)",
+        "line": 93
+      },
+      {
+        "name": "sym_solvable_iff",
+        "type": "specialization",
+        "description": "Sₙ solvable ↔ n ≤ 4, recovered as a one-rewrite corollary of the bridge and the parent's alternating classification (matches sibling AbelRuffiniOQ04OQ02's solvable_iff_le_four).",
+        "leanType": "(n : ℕ) → (IsSolvable (Perm (Fin n)) ↔ n ≤ 4)",
+        "line": 129
+      },
+      {
+        "name": "joint_sharp_threshold",
+        "type": "specialization",
+        "description": "The lockstep dichotomy: A₄ and S₄ solvable, A₅ and S₅ not — the transition the bridge forces to happen simultaneously in both families.",
+        "leanType": "(IsSolvable (alternatingGroup (Fin 4)) ∧ IsSolvable (Perm (Fin 4))) ∧ (¬IsSolvable (alternatingGroup (Fin 5)) ∧ ¬IsSolvable (Perm (Fin 5)))",
+        "line": 162
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Parent: Aₙ solvable iff n ≤ 4. This entry generalizes the Aₙ↔Sₙ relationship to arbitrary finite α and transports the parent's results across the sign sequence."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02",
+      "relationship": "related",
+      "description": "Sibling symmetric-group classification (Sₙ solvable iff n ≤ 4). Its solvable_iff_le_four is recovered here as a corollary of the bridge."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02-oq-06",
+      "relationship": "related",
+      "description": "Sibling derived-length gap A₄ vs A₅; complementary quantitative view of the same n = 5 transition."
+    }
+  ],
+  "references": [
+    {
+      "authors": ["É. Galois"],
+      "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
+      "year": "1846",
+      "venue": "Journal de Mathématiques Pures et Appliquées (published posthumously)",
+      "note": "Polynomial solvable by radicals iff Galois group solvable; A₅ simple is the quintic obstruction."
+    },
+    {
+      "authors": ["C. Jordan"],
+      "title": "Traité des substitutions et des équations algébriques",
+      "year": "1870",
+      "venue": "Gauthier-Villars, Paris",
+      "note": "Composition series for Aₙ and Sₙ; Aₙ simple for n ≥ 5."
+    },
+    {
+      "authors": ["O. Hölder"],
+      "title": "Zurückführung einer beliebigen algebraischen Gleichung auf eine Kette von Gleichungen",
+      "year": "1889",
+      "venue": "Mathematische Annalen 34: 26–56",
+      "note": "Jordan–Hölder uniqueness of composition factors, the foundation for intrinsic solvability."
+    },
+    {
+      "authors": ["I. Stewart"],
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "Chapman and Hall/CRC, 4th edition",
+      "note": "Chapters 12–13: Sₙ and Aₙ solvable iff n ≤ 4, including the closure of solvable groups under extensions."
+    },
+    {
+      "authors": ["The mathlib Community"],
+      "title": "The Lean Mathematical Library — GroupTheory.Solvable",
+      "year": "2020",
+      "venue": "Lean 4 / Mathlib",
+      "note": "Source of solvable_of_ker_le_range and subgroup_solvable_of_solvable, the two engines of the bridge."
+    }
+  ],
+  "sorries": [],
+  "mainTheorems": [
+    {
+      "name": "alternating_solvable_iff_sym_solvable",
+      "statement": "For any finite α, IsSolvable (alternatingGroup α) ↔ IsSolvable (Perm α).",
+      "significance": "The structural reason the alternating and symmetric solvability classifications share a threshold: the sign extension is transparent to solvability for every finite set."
+    }
+  ]
+}


### PR DESCRIPTION
Two stacked, tightly-coupled research contributions on the Abel–Ruffini solvability chain (the second imports the first, hence one branch/PR).

## Commit 1 — `abel-ruffini-oq-04-oq-02-oq-02-oq-08`: the Aα ↔ Sα solvability bridge
Proves `IsSolvable (alternatingGroup α) ↔ IsSolvable (Perm α)` for an arbitrary finite type α, with **no cardinality hypothesis**. The sign exact sequence `1 → Aα → Sα → ℤ/2 → 1` neither creates nor destroys solvability:
- (→) `ker(sign) = Aα`, abelian quotient ⟹ `solvable_of_ker_le_range`;
- (←) `Aα ≤ Sα`, subgroups of solvable groups are solvable.

Specialising to `Fin n` makes the alternating classification (Aₙ solvable ↔ n ≤ 4) and the symmetric classification (Sₙ solvable ↔ n ≤ 4) literally the same theorem. 167L, 12 thm, 0 def.

## Commit 2 — `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01`: solvability is intrinsic to `Fintype.card α`
Realizes the bridge's first listed future direction. A bijection `e : α ≃ β` induces the conjugation isomorphism `Equiv.permCongrHom e : Perm α ≃* Perm β`; sign-invariance of `permCongr` carries `alternatingGroup α` exactly onto `alternatingGroup β` (`map_permCongrHom_alternating`), giving the canonical `alternatingCongr : alternatingGroup α ≃* alternatingGroup β`. Solvability is a `MulEquiv` invariant (`isSolvable_congr`), so it depends on α only through `Fintype.card α`. Composing with the Fin n classifications lifts both thresholds off `Fin n`:

- `perm_solvable_iff_card`        : `IsSolvable (Perm α) ↔ Fintype.card α ≤ 4`
- `alternating_solvable_iff_card` : `IsSolvable (alternatingGroup α) ↔ Fintype.card α ≤ 4`

for **any** finite type α. Corollaries: equal cardinality ⟹ equisolvable and (stronger) isomorphic alternating groups; a coordinate-free sharp threshold. 174L, 12 thm, 1 def.

## Verification
Both files: 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions, no `native_decide`. `#print axioms` on the main results of each reports only `propext, Classical.choice, Quot.sound`. Builds against Mathlib 4.26.0 via the Docker wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)