### PR TITLE
research(automorphic-number-oq-01-oq-02): complementary pairing + last-digit uniqueness of automorphic idempotents [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -190,6 +190,7 @@ import Proofs.ArithmeticSeriesOQ04OQ01
 import Proofs.ArsinhLogFormulaOQ01
 import Proofs.AutomorphicNumberOQ01
 import Proofs.AutomorphicNumberOQ01OQ01
+import Proofs.AutomorphicNumberOQ01OQ02
 import Proofs.BallotProblem
 import Proofs.BallotProblemOQ01
 import Proofs.BallotProblemOQ01OQ01

--- a/proofs/Proofs/AutomorphicNumberOQ01OQ02.lean
+++ b/proofs/Proofs/AutomorphicNumberOQ01OQ02.lean
@@ -1,0 +1,212 @@
+import Mathlib
+import Proofs.AutomorphicNumberOQ01
+
+/-!
+# The complementary pairing of automorphic idempotents
+
+## What This Proves
+
+The parent file `AutomorphicNumberOQ01` shows that for every `k ≥ 1` the ring
+`ZMod (10 ^ k)` has **exactly four idempotents** `e * e = e` — equivalently four
+`k`-digit automorphic residues `n ^ 2 ≡ n (mod 10 ^ k)`, namely `0`, `1`, and the
+familiar `…5` / `…6` numbers (`5, 6`; `25, 76`; `376, 625`; …).
+
+This file describes the **structure** of those four residues, not just their count.
+
+* **Orthogonal complement algebra.** In any commutative ring, if `e` is idempotent then
+  so is `1 - e`, and the two are *orthogonal complements*:
+  `e + (1 - e) = 1` and `e * (1 - e) = 0`.
+* **Complementary pair (main theorem).** `automorphic_complementary_pair`: the four
+  idempotents of `ZMod (10 ^ k)` are exactly `{0, 1, a, 1 - a}` for a nontrivial
+  idempotent `a` (one of the `…5`/`…6` automorphic numbers).  The two nontrivial ones,
+  `a` and `1 - a`, satisfy `a + (1 - a) = 1` and `a * (1 - a) = 0`; concretely
+  `5 + 6 = 1`, `5 * 6 = 0` in `ZMod 10`, etc.  So `0 ↔ 1` and `…5 ↔ …6` are the two
+  complementary pairs.
+* **Last digit determines the residue (main theorem).** `same_last_digit`: two
+  automorphic residues modulo `10 ^ k` that share the same last digit
+  (`(10 : ZMod (10 ^ k)) ∣ e - f`) are equal.  Hence each of the four residues has a
+  *distinct* last digit, and an automorphic number is pinned down by its final digit.
+
+The engine for the last-digit theorem is the elementary identity
+`(e - f) ^ 3 = e - f` for idempotents `e, f` (a difference of idempotents is "tripotent"),
+combined with the fact that a difference lying in the nil ideal `(10)` of `ZMod (10 ^ k)`
+is nilpotent; a tripotent nilpotent element is `0`.  This is exactly the uniqueness of
+idempotent lifts modulo a nil ideal, proved here from scratch.
+
+## Status
+
+Fully machine-checked: `0` sorries, `0` axioms.  Builds on the verified parent file.
+-/
+
+namespace AutomorphicNumberOQ01OQ02
+
+open Finset
+
+/-! ## Orthogonal-complement algebra (any commutative ring) -/
+
+variable {R : Type*} [CommRing R]
+
+/-- If `e` is idempotent then so is its complement `1 - e`. -/
+theorem compl_idem {e : R} (he : e * e = e) : (1 - e) * (1 - e) = 1 - e := by
+  linear_combination he
+
+/-- An idempotent and its complement are **orthogonal**: their product is `0`. -/
+theorem mul_compl {e : R} (he : e * e = e) : e * (1 - e) = 0 := by
+  linear_combination -he
+
+/-- An idempotent and its complement **add to one**. -/
+theorem add_compl (e : R) : e + (1 - e) = 1 := by ring
+
+/-- A difference of idempotents is **tripotent**: `(e - f) ^ 3 = e - f`.  This is the
+algebraic engine behind uniqueness of idempotent lifts. -/
+theorem idem_diff_cube {e f : R} (he : e * e = e) (hf : f * f = f) :
+    (e - f) ^ 3 = e - f := by
+  linear_combination (e + 1 - 3 * f) * he + (3 * e - f - 1) * hf
+
+/-- An element that is both **idempotent and nilpotent** is `0`. -/
+theorem idem_nil_zero {g : R} (hg : g * g = g) (h : IsNilpotent g) : g = 0 := by
+  obtain ⟨m, hm⟩ := h
+  have hpow : ∀ j : ℕ, g ^ (j + 1) = g := by
+    intro j
+    induction j with
+    | zero => simp
+    | succ n ih => rw [pow_succ, ih, hg]
+  rcases Nat.eq_zero_or_pos m with hm0 | hmpos
+  · subst hm0
+    have h1 : (1 : R) = 0 := by simpa using hm
+    haveI := subsingleton_of_zero_eq_one h1.symm
+    exact Subsingleton.elim _ _
+  · obtain ⟨j, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hmpos.ne'
+    rw [hpow j] at hm
+    exact hm
+
+/-- **Uniqueness of idempotent lifts modulo a nil ideal.**  If `e, f` are idempotents
+whose difference is nilpotent, then `e = f`. -/
+theorem idem_eq_of_sub_nilpotent {e f : R} (he : e * e = e) (hf : f * f = f)
+    (h : IsNilpotent (e - f)) : e = f := by
+  have hcube : (e - f) ^ 3 = e - f := idem_diff_cube he hf
+  -- `(e - f) ^ 2` is idempotent: `(e-f)^4 = (e-f)·(e-f)^3 = (e-f)·(e-f) = (e-f)^2`.
+  have hsqidem : (e - f) ^ 2 * (e - f) ^ 2 = (e - f) ^ 2 := by
+    calc (e - f) ^ 2 * (e - f) ^ 2 = (e - f) * (e - f) ^ 3 := by ring
+      _ = (e - f) * (e - f) := by rw [hcube]
+      _ = (e - f) ^ 2 := by ring
+  -- and nilpotent, being a power of the nilpotent `e - f`.
+  have hnil2 : IsNilpotent ((e - f) ^ 2) := by
+    obtain ⟨n, hn⟩ := h
+    exact ⟨n, by rw [← pow_mul, mul_comm, pow_mul, hn]; simp⟩
+  have hd2 : (e - f) ^ 2 = 0 := idem_nil_zero hsqidem hnil2
+  have hd0 : e - f = 0 := by
+    rw [← hcube]
+    calc (e - f) ^ 3 = (e - f) * (e - f) ^ 2 := by ring
+      _ = (e - f) * 0 := by rw [hd2]
+      _ = 0 := by rw [mul_zero]
+  exact sub_eq_zero.mp hd0
+
+/-! ## The four automorphic residues of `ZMod (10 ^ k)` -/
+
+/-- In `ZMod (10 ^ k)` the element `10` is nilpotent: `10 ^ k = 0`. -/
+theorem ten_pow_eq_zero (k : ℕ) : (10 : ZMod (10 ^ k)) ^ k = 0 := by
+  have h : ((10 ^ k : ℕ) : ZMod (10 ^ k)) = 0 := ZMod.natCast_self _
+  calc (10 : ZMod (10 ^ k)) ^ k = ((10 ^ k : ℕ) : ZMod (10 ^ k)) := by push_cast; ring
+    _ = 0 := h
+
+/-- **Last digit determines the residue.**  Two automorphic residues modulo `10 ^ k`
+whose difference is divisible by `10` (i.e. they share their last digit) are equal.
+Consequently the four idempotents of `ZMod (10 ^ k)` have four *distinct* last digits. -/
+theorem same_last_digit {k : ℕ} {e f : ZMod (10 ^ k)}
+    (he : e * e = e) (hf : f * f = f) (hdvd : (10 : ZMod (10 ^ k)) ∣ (e - f)) :
+    e = f := by
+  obtain ⟨c, hc⟩ := hdvd
+  have hnil : IsNilpotent (e - f) :=
+    ⟨k, by rw [hc, mul_pow, ten_pow_eq_zero, zero_mul]⟩
+  exact idem_eq_of_sub_nilpotent he hf hnil
+
+/-- **Main theorem — the complementary pairing.**  For every `k ≥ 1` the four
+idempotents of `ZMod (10 ^ k)` are exactly `{0, 1, a, 1 - a}` where `a` is a nontrivial
+idempotent (one of the `…5` / `…6` automorphic numbers).  The two nontrivial residues
+`a` and `1 - a` are orthogonal complements: `a + (1 - a) = 1` and `a * (1 - a) = 0`. -/
+theorem automorphic_complementary_pair (k : ℕ) (hk : 0 < k) :
+    ∃ a b : ZMod (10 ^ k),
+      a * a = a ∧ b * b = b ∧ a ≠ 0 ∧ a ≠ 1 ∧ b ≠ 0 ∧ b ≠ 1 ∧
+      a + b = 1 ∧ a * b = 0 ∧ a ≠ b ∧
+      (univ.filter (fun e : ZMod (10 ^ k) => e * e = e)) = {0, 1, a, b} := by
+  haveI : Fact (1 < 10 ^ k) := ⟨Nat.one_lt_pow hk.ne' (by norm_num)⟩
+  set S := univ.filter (fun e : ZMod (10 ^ k) => e * e = e) with hSdef
+  have hScard : S.card = 4 := AutomorphicNumberOQ01.automorphic_idempotent_count k hk
+  -- `{0, 1} ⊆ S` and there are 4 idempotents, so an idempotent `a ∉ {0, 1}` exists.
+  have hmemS : ∀ x : ZMod (10 ^ k), x ∈ S ↔ x * x = x := by
+    intro x; rw [hSdef]; simp
+  have hsub01 : ({0, 1} : Finset (ZMod (10 ^ k))) ⊆ S := by
+    intro x hx
+    simp only [mem_insert, mem_singleton] at hx
+    rw [hmemS]
+    rcases hx with rfl | rfl <;> simp
+  have hcard01 : ({0, 1} : Finset (ZMod (10 ^ k))).card = 2 := by
+    rw [card_insert_of_notMem (by simp), card_singleton]
+  -- Since `S` has 4 elements but `{0, 1}` only 2, some idempotent lies outside `{0, 1}`.
+  have hex : ∃ a ∈ S, a ∉ ({0, 1} : Finset (ZMod (10 ^ k))) := by
+    by_contra h
+    push_neg at h
+    have hsubset : S ⊆ ({0, 1} : Finset (ZMod (10 ^ k))) := fun x hx => h x hx
+    have hle := card_le_card hsubset
+    rw [hScard, hcard01] at hle
+    omega
+  obtain ⟨a, ha_S, ha_not⟩ := hex
+  have ha : a * a = a := (hmemS a).mp ha_S
+  have ha0 : a ≠ 0 := by intro h; apply ha_not; simp [h]
+  have ha1 : a ≠ 1 := by intro h; apply ha_not; simp [h]
+  -- The complement `b = 1 - a` is the other nontrivial idempotent.
+  have hb : (1 - a) * (1 - a) = 1 - a := compl_idem ha
+  have hb0 : (1 - a) ≠ 0 := by intro h; exact ha1 (by linear_combination -h)
+  have hb1 : (1 - a) ≠ 1 := by intro h; exact ha0 (by linear_combination -h)
+  have hab : a ≠ 1 - a := by
+    intro heq
+    have h2a : (1 : ZMod (10 ^ k)) = 2 * a := by linear_combination -heq
+    have : a = 1 := by
+      calc a = a * 1 := (mul_one a).symm
+        _ = a * (2 * a) := by rw [h2a]
+        _ = 2 * (a * a) := by ring
+        _ = 2 * a := by rw [ha]
+        _ = 1 := h2a.symm
+    exact ha1 this
+  refine ⟨a, 1 - a, ha, hb, ha0, ha1, hb0, hb1, add_compl a, mul_compl ha, hab, ?_⟩
+  -- The four distinct idempotents `0, 1, a, 1 - a` exhaust the 4-element set `S`.
+  have hsub : ({0, 1, a, 1 - a} : Finset (ZMod (10 ^ k))) ⊆ S := by
+    intro x hx
+    simp only [mem_insert, mem_singleton] at hx
+    rw [hmemS]
+    rcases hx with rfl | rfl | rfl | rfl
+    · simp
+    · simp
+    · exact ha
+    · exact hb
+  have hcard4 : ({0, 1, a, 1 - a} : Finset (ZMod (10 ^ k))).card = 4 := by
+    have m1 : a ∉ ({1 - a} : Finset (ZMod (10 ^ k))) := by simpa using hab
+    have m2 : (1 : ZMod (10 ^ k)) ∉ ({a, 1 - a} : Finset (ZMod (10 ^ k))) := by
+      simp only [mem_insert, mem_singleton, not_or]
+      exact ⟨fun h => ha1 h.symm, fun h => hb1 h.symm⟩
+    have m3 : (0 : ZMod (10 ^ k)) ∉ ({1, a, 1 - a} : Finset (ZMod (10 ^ k))) := by
+      simp only [mem_insert, mem_singleton, not_or]
+      exact ⟨zero_ne_one, fun h => ha0 h.symm, fun h => hb0 h.symm⟩
+    rw [show ({0, 1, a, 1 - a} : Finset (ZMod (10 ^ k)))
+          = insert 0 (insert 1 (insert a {1 - a})) from rfl,
+        card_insert_of_notMem m3, card_insert_of_notMem m2,
+        card_insert_of_notMem m1, card_singleton]
+  exact (eq_of_subset_of_card_le hsub (by rw [hScard, hcard4])).symm
+
+/-! ## Concrete complementary pairs
+
+The two nontrivial idempotents of `ZMod (10 ^ k)` are the classic automorphic numbers
+ending in `…5` and `…6`.  Here are the smallest pairs, verified by `decide`: each pair
+sums to `1` and multiplies to `0`, exactly as `automorphic_complementary_pair` predicts. -/
+
+/-- `5` and `6` are complementary idempotents mod `10`. -/
+example : (5 : ZMod 10) + 6 = 1 ∧ (5 : ZMod 10) * 6 = 0 := by decide
+
+/-- `25` and `76` are complementary idempotents mod `100`. -/
+example : (25 : ZMod 100) + 76 = 1 ∧ (25 : ZMod 100) * 76 = 0 := by decide
+
+/-- `376` and `625` are complementary idempotents mod `1000`. -/
+example : (376 : ZMod 1000) + 625 = 1 ∧ (376 : ZMod 1000) * 625 = 0 := by decide
+
+end AutomorphicNumberOQ01OQ02

--- a/src/data/proofs/automorphic-number-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-02/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-autonum-oq01oq02-context",
+    "proofId": "automorphic-number-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "concept",
+    "title": "From counting to structure: the four residues as two complementary pairs",
+    "content": "The parent entry proves ZMod (10^k) has exactly four automorphic residues e²≡e (its four idempotents), and the first follow-up explains the count as 2^ω(n). This entry asks what those four residues ARE, not how many. The answer: they organize into two orthogonal complementary pairs. In any commutative ring the complement 1-e of an idempotent is again idempotent, and the two are orthogonal — e+(1-e)=1 and e·(1-e)=0. For 10^k the trivial pair is {0,1} and the nontrivial pair is the classic {…5,…6}: 5+6=1, 5·6=0 mod 10; 25+76=1, 25·76=0 mod 100; 376+625=1, 376·625=0 mod 1000. A second theorem shows each residue is pinned down by its last digit, so the four have four distinct final digits.",
+    "mathContext": "The idempotents of a commutative ring form a Boolean algebra; for $\\mathbb{Z}/10^k$ it is the four-element algebra with atoms the $\\dots5$ and $\\dots6$ automorphic numbers, paired by complementation $e\\mapsto 1-e$."
+  },
+  {
+    "id": "ann-autonum-oq01oq02-complement",
+    "proofId": "automorphic-number-oq-01-oq-02",
+    "range": { "startLine": 45, "endLine": 60 },
+    "type": "key-step",
+    "title": "Orthogonal-complement algebra of idempotents",
+    "content": "Three one-line identities valid in every commutative ring R. compl_idem: if e²=e then (1-e)²=1-e, so the complement is idempotent (a single linear_combination of e²=e). mul_compl: e·(1-e)=0 — an idempotent and its complement are orthogonal. add_compl: e+(1-e)=1 by ring. Together these say {0,1} and {e,1-e} are complementary pairs of idempotents; specialized to a nontrivial idempotent a of ZMod (10^k) they produce the second nontrivial idempotent 1-a and the relations a+(1-a)=1, a·(1-a)=0.",
+    "mathContext": "$e^2=e \\Rightarrow (1-e)^2=1-e$, $e(1-e)=0$, $e+(1-e)=1$: complementation is an involution on idempotents and complementary idempotents are orthogonal."
+  },
+  {
+    "id": "ann-autonum-oq01oq02-uniqueness",
+    "proofId": "automorphic-number-oq-01-oq-02",
+    "range": { "startLine": 61, "endLine": 104 },
+    "type": "key-step",
+    "title": "Uniqueness of idempotent lifts modulo a nil ideal",
+    "content": "The algebraic engine. idem_diff_cube proves the tripotent identity (e-f)³=e-f for any two idempotents — a single linear_combination of the two idempotency hypotheses with explicit cofactors (e+1-3f) and (3e-f-1). idem_nil_zero proves an element that is both idempotent and nilpotent is 0 (an idempotent g satisfies g^(n)=g for n≥1, so a vanishing power forces g=0; the exponent-0 case makes the ring subsingleton). idem_eq_of_sub_nilpotent then combines them: if e-f is nilpotent, the cube identity makes (e-f)² idempotent, and a power of the nilpotent e-f, hence nilpotent — so (e-f)²=0, whence e-f=(e-f)³=(e-f)·(e-f)²=0. No Mathlib idempotent-lifting lemma is used; the whole argument is the four lines (e-f)³=e-f, (e-f)²·(e-f)²=(e-f)², nilpotency, collapse.",
+    "mathContext": "A difference of idempotents is tripotent: $(e-f)^3=e-f$. Over a nil ideal this collapses to $e=f$, the uniqueness of idempotent lifts (the ring-theoretic heart of Hensel-style lifting of idempotents)."
+  },
+  {
+    "id": "ann-autonum-oq01oq02-lastdigit",
+    "proofId": "automorphic-number-oq-01-oq-02",
+    "range": { "startLine": 105, "endLine": 127 },
+    "type": "key-step",
+    "title": "The last digit determines the automorphic residue",
+    "content": "ten_pow_eq_zero records that 10 is nilpotent in ZMod (10^k): (10)^k = ↑(10^k) = 0 by ZMod.natCast_self. same_last_digit then says two automorphic residues e, f with 10 ∣ (e-f) — i.e. the same last digit — are equal: writing e-f = 10·c gives (e-f)^k = 10^k·c^k = 0, so e-f is nilpotent and idem_eq_of_sub_nilpotent forces e = f. The kernel of reduction ZMod (10^k) → ZMod 10 is the nil ideal (10), so idempotents inject under reduction mod 10 and the final digit is a complete invariant — each of the four residues has a distinct last digit (0, 1, 5, 6).",
+    "mathContext": "$(10)$ is a nil ideal of $\\mathbb{Z}/10^k$, so the reduction $\\mathbb{Z}/10^k\\to\\mathbb{Z}/10$ is injective on idempotents: an automorphic number is determined by its last digit."
+  },
+  {
+    "id": "ann-autonum-oq01oq02-pairing",
+    "proofId": "automorphic-number-oq-01-oq-02",
+    "range": { "startLine": 128, "endLine": 212 },
+    "type": "technique",
+    "title": "Assembling the complementary pair and concrete examples",
+    "content": "automorphic_complementary_pair extracts the full structure from the parent's count. Since the idempotent set S has card 4 (automorphic_idempotent_count) but {0,1} has card 2, card_le_card forces an idempotent a ∉ {0,1} to exist; a is nontrivial (a≠0, a≠1). Its complement 1-a is the other nontrivial idempotent (compl_idem, with 1-a≠0,1 from a≠1,0), orthogonal to a (mul_compl), summing to 1 (add_compl), and distinct from a — for a=1-a would give 1=2a and then a=a·1=a·2a=2a²=2a=1, contradicting a≠1. The four distinct idempotents 0,1,a,1-a then fill the 4-element set, so eq_of_subset_of_card_le upgrades {0,1,a,1-a} ⊆ S to S = {0,1,a,1-a}. The closing decide examples exhibit the smallest nontrivial pairs 5/6, 25/76, 376/625, each satisfying a+b=1 and ab=0 exactly as predicted.",
+    "mathContext": "The four idempotents are $\\{0,1,a,1-a\\}$; the nontrivial pair $a,1-a$ are the $\\dots5/\\dots6$ automorphic numbers with $a+(1-a)=1$, $a(1-a)=0$ — e.g. $5+6=1$, $5\\cdot 6=0\\pmod{10}$."
+  }
+]

--- a/src/data/proofs/automorphic-number-oq-01-oq-02/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-02/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "automorphic-number-oq-01-oq-02",
+  "slug": "automorphic-number-oq-01-oq-02",
+  "title": "The Complementary Pairing of Automorphic Idempotents mod 10^k",
+  "description": "The parent entry counts the automorphic residues n²≡n (mod 10^k) — the idempotents of ZMod (10^k) — and the first follow-up explains the count as 2^ω(n). This entry describes their STRUCTURE rather than their number. First, the orthogonal-complement algebra of any commutative ring: if e is idempotent then so is 1-e, with e+(1-e)=1 and e·(1-e)=0. Second, the main pairing theorem: for k≥1 the four idempotents of ZMod (10^k) are exactly {0, 1, a, 1-a} for a nontrivial idempotent a (one of the classic …5/…6 automorphic numbers), and the two nontrivial residues a and 1-a are orthogonal complements — concretely 5+6=1 and 5·6=0 mod 10, 25+76=1 and 25·76=0 mod 100, 376+625=1 and 376·625=0 mod 1000. So the four residues split into the two complementary pairs {0,1} and {…5,…6}. Third, a last-digit uniqueness theorem: two automorphic residues mod 10^k whose difference is divisible by 10 (i.e. sharing their last digit) are equal — so each of the four residues has a distinct last digit and an automorphic number is pinned down by its final digit. The engine is the elementary identity (e-f)³=e-f for idempotents e,f (a difference of idempotents is tripotent), combined with the fact that an element of the nil ideal (10) of ZMod (10^k) is nilpotent; a tripotent nilpotent element is 0. This is exactly the uniqueness of idempotent lifts modulo a nil ideal, proved here from scratch with no Mathlib lifting lemma.",
+  "meta": {
+    "author": "Lean Genius Researcher-11",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AutomorphicNumberOQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "automorphic-numbers",
+      "idempotents",
+      "zmod",
+      "orthogonal-complement",
+      "nilpotent",
+      "idempotent-lifting",
+      "chinese-remainder-theorem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 212,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. The three `decide` calls are kernel decisions on concrete finite data (the complementary-pair identities 5+6=1, 5·6=0 in ZMod 10; 25+76=1, 25·76=0 in ZMod 100; 376+625=1, 376·625=0 in ZMod 1000). Results depend only on the standard foundational axioms propext / Classical.choice / Quot.sound. Builds on the verified parent entry AutomorphicNumberOQ01.lean, reusing its automorphic_idempotent_count (the count = 4) to extract a nontrivial idempotent.",
+    "mathlibDependencies": [
+      {
+        "theorem": "IsNilpotent",
+        "description": "An element x with x^n = 0 for some n; the difference of two distinct idempotents lying in the nil ideal (10) of ZMod (10^k) is nilpotent",
+        "module": "Mathlib.RingTheory.Nilpotent.Defs"
+      },
+      {
+        "theorem": "ZMod.natCast_self",
+        "description": "(↑n : ZMod n) = 0; gives (10 : ZMod (10^k))^k = 0, the nilpotency of 10 that makes the kernel of reduction mod 10 a nil ideal",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.card_le_card",
+        "description": "s ⊆ t → s.card ≤ t.card; combined with the parent's count = 4 and |{0,1}| = 2 it forces an idempotent outside {0,1} to exist",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.eq_of_subset_of_card_le",
+        "description": "s ⊆ t and t.card ≤ s.card give s = t; promotes {0,1,a,1-a} ⊆ S with both of card 4 to the set equality S = {0,1,a,1-a}",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "subsingleton_of_zero_eq_one",
+        "description": "0 = 1 in a ring forces it to be subsingleton; used to discharge the degenerate exponent-0 case when an idempotent is nilpotent",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      },
+      {
+        "theorem": "AutomorphicNumberOQ01.automorphic_idempotent_count",
+        "description": "The verified parent result that ZMod (10^k) has exactly 4 idempotents; the starting point for extracting the nontrivial complementary pair",
+        "module": "Proofs.AutomorphicNumberOQ01"
+      }
+    ],
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AutomorphicNumberOQ01"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "AutomorphicNumberOQ01OQ02",
+    "lineCount": 212,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/AutomorphicNumberOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "automorphic_complementary_pair",
+      "type": "headline",
+      "statement": "0 < k → ∃ a b : ZMod (10^k), a*a=a ∧ b*b=b ∧ a≠0 ∧ a≠1 ∧ b≠0 ∧ b≠1 ∧ a+b=1 ∧ a*b=0 ∧ a≠b ∧ (univ.filter (e ↦ e*e=e)) = {0,1,a,b}",
+      "description": "The four idempotents of ZMod (10^k) are exactly {0, 1, a, 1-a} for a nontrivial idempotent a (a …5/…6 automorphic number). The two nontrivial residues are orthogonal complements: a+(1-a)=1 and a·(1-a)=0. So the residues split into the two complementary pairs {0,1} and {…5,…6}.",
+      "significance": "Upgrades the parent's bare count of 4 to a structural description: the automorphic residues are not four unrelated numbers but two complementary pairs, mirroring the Boolean-algebra structure of idempotents in a commutative ring."
+    },
+    {
+      "name": "same_last_digit",
+      "type": "headline",
+      "statement": "e*e=e → f*f=f → (10 : ZMod (10^k)) ∣ (e - f) → e = f",
+      "description": "Two automorphic residues mod 10^k that share their last digit (differ by a multiple of 10) are equal. Hence the four residues have four distinct last digits, and an automorphic number is determined by its final digit.",
+      "significance": "A concrete arithmetic consequence of uniqueness of idempotent lifts modulo the nil ideal (10): the last digit is a complete invariant of an automorphic residue."
+    },
+    {
+      "name": "idem_eq_of_sub_nilpotent",
+      "type": "core",
+      "statement": "e*e=e → f*f=f → IsNilpotent (e - f) → e = f",
+      "description": "Uniqueness of idempotent lifts modulo a nil ideal in any commutative ring: idempotents with nilpotent difference coincide. Proved from the tripotent identity (e-f)³=e-f — so (e-f)² is an idempotent that is also nilpotent, hence 0, forcing e-f = (e-f)³ = (e-f)·(e-f)² = 0.",
+      "significance": "The general ring-theoretic engine; specialized to ZMod (10^k) it yields the last-digit uniqueness theorem without invoking any Mathlib idempotent-lifting machinery."
+    },
+    {
+      "name": "idem_diff_cube",
+      "type": "core",
+      "statement": "e*e=e → f*f=f → (e - f)^3 = e - f",
+      "description": "A difference of idempotents in a commutative ring is tripotent. Proved by a single linear_combination of the two idempotency hypotheses.",
+      "significance": "The purely algebraic identity underlying uniqueness of idempotent lifts; the cube collapses back to the element itself."
+    },
+    {
+      "name": "compl_idem",
+      "type": "supporting",
+      "statement": "e*e=e → (1 - e)*(1 - e) = 1 - e",
+      "description": "The complement 1-e of an idempotent e is idempotent (any commutative ring).",
+      "significance": "Half of the orthogonal-complement algebra; makes 1-a a second idempotent once a is one."
+    },
+    {
+      "name": "mul_compl",
+      "type": "supporting",
+      "statement": "e*e=e → e*(1 - e) = 0",
+      "description": "An idempotent and its complement are orthogonal: their product vanishes.",
+      "significance": "The orthogonality a·(1-a)=0 of the nontrivial automorphic pair, e.g. 5·6=0 mod 10."
+    },
+    {
+      "name": "idem_nil_zero",
+      "type": "supporting",
+      "statement": "g*g=g → IsNilpotent g → g = 0",
+      "description": "An element that is simultaneously idempotent and nilpotent is zero (an idempotent satisfies g^(n)=g for n≥1, so a vanishing power forces g=0).",
+      "significance": "The step that converts the tripotent-plus-nilpotent (e-f)² into 0."
+    },
+    {
+      "name": "ten_pow_eq_zero",
+      "type": "supporting",
+      "statement": "(10 : ZMod (10^k))^k = 0",
+      "description": "10 is nilpotent in ZMod (10^k); a difference divisible by 10 is therefore nilpotent.",
+      "significance": "Identifies (10) as a nil ideal, the hypothesis that makes the last-digit theorem an instance of idempotent-lift uniqueness."
+    }
+  ],
+  "sections": [
+    {
+      "id": "complement-algebra",
+      "title": "Part I: Orthogonal-complement algebra",
+      "startLine": 45,
+      "endLine": 60,
+      "summary": "In any commutative ring R: compl_idem (1-e is idempotent when e is), mul_compl (e·(1-e)=0), add_compl (e+(1-e)=1). Each is a one-line linear_combination or ring identity.",
+      "mathContext": "The idempotents of a commutative ring form a Boolean algebra under meet = ·, join = e+f-ef, and complement 1-e; this part records the complement and orthogonality laws."
+    },
+    {
+      "id": "idempotent-lift-uniqueness",
+      "title": "Part II: Uniqueness of idempotent lifts modulo a nil ideal",
+      "startLine": 62,
+      "endLine": 103,
+      "summary": "idem_diff_cube: (e-f)³=e-f for idempotents (one linear_combination). idem_nil_zero: idempotent + nilpotent ⇒ 0. idem_eq_of_sub_nilpotent: if e-f is nilpotent then (e-f)² is idempotent (from the cube identity) and nilpotent, hence 0, so e-f=(e-f)³=(e-f)(e-f)²=0.",
+      "mathContext": "A difference of idempotents is tripotent; in the presence of nilpotency this collapses to equality, which is precisely the uniqueness of idempotent lifts over a nil ideal."
+    },
+    {
+      "id": "last-digit",
+      "title": "Part III: The last digit determines the residue",
+      "startLine": 105,
+      "endLine": 126,
+      "summary": "ten_pow_eq_zero: (10)^k=0 in ZMod (10^k) via ZMod.natCast_self. same_last_digit: a difference divisible by 10 is nilpotent (its k-th power vanishes), so idem_eq_of_sub_nilpotent forces equality — automorphic residues with the same last digit coincide.",
+      "mathContext": "The kernel of reduction ZMod (10^k) → ZMod 10 is the nil ideal (10); idempotents inject under reduction mod 10, so the last digit is a complete invariant."
+    },
+    {
+      "id": "complementary-pair",
+      "title": "Part IV: The complementary pairing of the four residues",
+      "startLine": 128,
+      "endLine": 195,
+      "summary": "automorphic_complementary_pair: the parent's count = 4 with |{0,1}| = 2 yields (card_le_card) an idempotent a ∉ {0,1}; its complement 1-a is the other nontrivial idempotent, with a+(1-a)=1, a·(1-a)=0, and a ≠ 1-a (else a=1). The four distinct idempotents 0,1,a,1-a fill the 4-element set, so the idempotent set equals {0,1,a,1-a}.",
+      "mathContext": "Beyond counting, the residues organize into two orthogonal complementary pairs {0,1} and {…5,…6}; the concrete examples 5/6, 25/76, 376/625 exhibit a+b=1, ab=0."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A structural follow-up to the automorphic-number entries. The parent (`AutomorphicNumberOQ01`) proves `ZMod (10^k)` has **exactly four** automorphic residues `n² ≡ n (mod 10^k)` — its four idempotents — and the first follow-up (`…OQ01OQ01`) explains the count as `2^ω(n)`. This entry describes **what those four residues are**, not how many.

### Results (all in `Proofs/AutomorphicNumberOQ01OQ02.lean`)

**Orthogonal-complement algebra** (any commutative ring): `e²=e ⟹ (1-e)²=1-e`, `e·(1-e)=0`, `e+(1-e)=1` — each a one-line `linear_combination`/`ring`.

**`automorphic_complementary_pair`** (headline): the four idempotents of `ZMod (10^k)` are exactly `{0, 1, a, 1-a}` for a nontrivial idempotent `a` (one of the classic `…5`/`…6` automorphic numbers), and the two nontrivial residues are **orthogonal complements**: `a + (1-a) = 1` and `a·(1-a) = 0`. So the four residues split into the complementary pairs `{0,1}` and `{…5,…6}`. Concrete `decide` witnesses: `5+6=1, 5·6=0` mod 10; `25+76=1, 25·76=0` mod 100; `376+625=1, 376·625=0` mod 1000.

**`same_last_digit`** (headline): two automorphic residues with `10 ∣ (e-f)` — i.e. sharing their last digit — are **equal**. Hence the four residues have four *distinct* last digits, and an automorphic number is pinned down by its final digit.

**`idem_eq_of_sub_nilpotent`** (core): uniqueness of idempotent lifts modulo a nil ideal in any commutative ring, proved **from scratch** — no Mathlib lifting lemma. The engine is the tripotent identity `(e-f)³ = e-f` for idempotents plus *idempotent ∧ nilpotent ⟹ 0*: so `(e-f)²` is idempotent and nilpotent, hence `0`, forcing `e-f = (e-f)³ = (e-f)·(e-f)² = 0`. `ten_pow_eq_zero` identifies `(10)` as the nil ideal of `ZMod (10^k)`.

### Verification

- **212 lines, 9 theorems, 0 definitions, 0 sorries.**
- `#print axioms` on all three headline/core theorems: only `propext`, `Classical.choice`, `Quot.sound` — **no `Lean.ofReduceBool`, no `native_decide`, no `sorryAx`**. Genuinely 0-axiom verified.
- Builds against Mathlib 4.26.0 via the Docker wrapper; reuses the verified parent's `automorphic_idempotent_count`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)