### PR TITLE
research(lucas-theorem-oq-01-oq-02): Sierpiński count — 3^m odd entries in first 2^m rows of Pascal's triangle [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2972,6 +2972,7 @@ import Proofs.LovaszLocalLemmaOQ02
 import Proofs.LovaszLocalLemmaOQ02Aristotle
 import Proofs.LucasLehmerTestOQ01
 import Proofs.LucasTheoremOQ01
+import Proofs.LucasTheoremOQ01OQ02
 import Proofs.MachinFromAddition
 import Proofs.MantelStabilityOQ01
 import Proofs.MantelTheorem

--- a/proofs/Proofs/LucasTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/LucasTheoremOQ01OQ02.lean
@@ -1,0 +1,115 @@
+import Mathlib
+import Proofs.LucasTheoremOQ01
+
+/-!
+# The Sierpiński count: `3^m` odd entries in the first `2^m` rows of Pascal's triangle
+
+The parent file (`Proofs.LucasTheoremOQ01`) proves **Glaisher's closed form** for the
+number of odd entries in a *single* row of Pascal's triangle:
+
+> `oddCount n = 2 ^ s₂(n)`,
+
+where `s₂(n)` is the binary digit sum of `n`.  This file answers the listed next step
+"sum over rows": the **total** number of odd entries in the first `2^m` rows
+(`n = 0, 1, …, 2^m − 1`) is exactly
+
+> `∑_{n < 2^m} oddCount n = 3^m`.
+
+This is the arithmetic shadow of the **Sierpiński triangle**: colouring the odd entries
+of Pascal's triangle black produces the Sierpiński gasket, and the count `3^m` over a
+`2^m`-tall block is precisely the self-similarity that gives the gasket its fractal
+(Hausdorff) dimension `log₂ 3 ≈ 1.585`.
+
+The engine is the single new digit lemma
+`s2_two_pow_add : s₂(2^m + k) = s₂(k) + 1` for `k < 2^m` (prepending a leading `1`-bit
+adds one to the digit sum), combined with the parent's Glaisher formula.  The sum then
+satisfies the doubling recursion `T(m+1) = T(m) + 2·T(m) = 3·T(m)`, because the upper
+half `[2^m, 2^{m+1})` reindexes to `2^m + k` and each term `2^{s₂(2^m+k)} = 2·2^{s₂ k}`
+is doubled.
+
+All results are fully machine-checked: `0` `sorry`, `0` `axiom`, no `native_decide`.
+-/
+
+open Nat Finset
+
+open LucasOddEntries
+
+namespace LucasSierpinski
+
+/-! ## The binary digit sum: step relation and leading-bit lemma -/
+
+/-- The binary-digit-sum recursion `s₂ n = (n mod 2) + s₂(n / 2)`, valid for **all** `n`
+(the parent's `s2_pos` requires `0 < n`; the `n = 0` case is `0 = 0 + 0`). -/
+theorem s2_step (n : ℕ) : s2 n = n % 2 + s2 (n / 2) := by
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · simp [s2]
+  · exact s2_pos n hn
+
+/-- Prepending a leading `1`-bit at position `m` increments the binary digit sum:
+for `k < 2^m`, the binary expansion of `2^m + k` is that of `k` with a fresh top `1`,
+so `s₂(2^m + k) = s₂(k) + 1`. -/
+theorem s2_two_pow_add (m : ℕ) : ∀ k, k < 2 ^ m → s2 (2 ^ m + k) = s2 k + 1 := by
+  induction m with
+  | zero =>
+    intro k hk
+    interval_cases k
+    -- `s₂(2^0 + 0) = s₂ 1 = 1 = s₂ 0 + 1`
+    simp only [pow_zero, Nat.add_zero]
+    rw [s2_step 1, s2_zero]
+  | succ m ih =>
+    intro k hk
+    rw [s2_step (2 ^ (m + 1) + k)]
+    -- The new top bit is even, so the low bit is unchanged: `(2^{m+1} + k) % 2 = k % 2`.
+    have e1 : (2 ^ (m + 1) + k) % 2 = k % 2 := by
+      rw [pow_succ]; omega
+    -- Halving drops to one lower level: `(2^{m+1} + k) / 2 = 2^m + k / 2`.
+    have e2 : (2 ^ (m + 1) + k) / 2 = 2 ^ m + k / 2 := by
+      rw [pow_succ]; omega
+    have hk2 : k / 2 < 2 ^ m := by
+      rw [pow_succ] at hk; omega
+    rw [e1, e2, ih (k / 2) hk2, s2_step k]
+    ring
+
+/-! ## The Sierpiński sum identity -/
+
+/-- The sum of `2^{s₂ n}` over a `2^m`-block is `3^m`.  This is the abstract form of the
+Sierpiński count, independent of the binomial-coefficient interpretation. -/
+theorem sum_two_pow_s2 (m : ℕ) : ∑ n ∈ range (2 ^ m), 2 ^ s2 n = 3 ^ m := by
+  induction m with
+  | zero => simp [s2_zero]
+  | succ m ih =>
+    -- Split `[0, 2^{m+1}) = [0, 2^m) ∪ [2^m, 2^{m+1})` via `2^{m+1} = 2^m + 2^m`.
+    have hsplit : (2 : ℕ) ^ (m + 1) = 2 ^ m + 2 ^ m := by rw [pow_succ]; ring
+    rw [hsplit, Finset.sum_range_add]
+    -- The upper half doubles, by the leading-bit lemma.
+    have hsecond : ∑ n ∈ range (2 ^ m), 2 ^ s2 (2 ^ m + n)
+        = 2 * ∑ n ∈ range (2 ^ m), 2 ^ s2 n := by
+      rw [Finset.mul_sum]
+      refine Finset.sum_congr rfl (fun n hn => ?_)
+      rw [Finset.mem_range] at hn
+      rw [s2_two_pow_add m n hn, pow_succ]
+      ring
+    rw [hsecond, ih, pow_succ]
+    ring
+
+/-! ## The Pascal-triangle count -/
+
+/-- **Sierpiński count.** The total number of odd entries in the first `2^m` rows of
+Pascal's triangle (rows `0, 1, …, 2^m − 1`) equals `3^m`.  Combined with the fractal
+self-similarity `oddCount` exhibits, this is the discrete origin of the Sierpiński
+gasket's Hausdorff dimension `log₂ 3`. -/
+theorem sum_oddCount_eq_three_pow (m : ℕ) :
+    ∑ n ∈ range (2 ^ m), oddCount n = 3 ^ m := by
+  rw [← sum_two_pow_s2 m]
+  exact Finset.sum_congr rfl (fun n _ => oddCount_eq_two_pow_s2 n)
+
+/-! ## Sanity checks -/
+
+/-- The first `4 = 2²` rows `1 | 1 1 | 1 2 1 | 1 3 3 1` contain
+`1 + 2 + 2 + 4 = 9 = 3²` odd entries. -/
+example : ∑ n ∈ range (2 ^ 2), oddCount n = 9 := by decide
+
+/-- The first `8 = 2³` rows contain `3³ = 27` odd entries. -/
+example : ∑ n ∈ range (2 ^ 3), oddCount n = 27 := by decide
+
+end LucasSierpinski

--- a/src/data/proofs/lucas-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lucas-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,119 @@
+{
+  "id": "lucas-theorem-oq-01-oq-02",
+  "title": "Sierpiński count: the first 2^m rows of Pascal's triangle hold 3^m odd entries",
+  "slug": "lucas-theorem-oq-01-oq-02",
+  "description": "The parent entry (lucas-theorem-oq-01) proves Glaisher's closed form for the number of odd entries in a single row of Pascal's triangle, oddCount n = 2^(s₂ n), where s₂(n) is the binary digit sum. This entry answers the parent's listed 'sum over rows' open question: the TOTAL number of odd entries in the first 2^m rows (n = 0, 1, …, 2^m − 1) equals exactly 3^m, i.e. ∑_{n < 2^m} oddCount n = 3^m. This is the arithmetic shadow of the Sierpiński triangle — colouring the odd entries of Pascal's triangle black produces the Sierpiński gasket, and the count 3^m over a 2^m-tall block is precisely the self-similarity giving the gasket its Hausdorff dimension log₂ 3 ≈ 1.585. The engine is a single new binary-digit lemma s2_two_pow_add: for k < 2^m, s₂(2^m + k) = s₂(k) + 1 (prepending a leading 1-bit adds one to the digit sum), proved by induction on m via the all-n digit-sum recursion s₂ n = (n mod 2) + s₂(n/2). The block sum then satisfies the doubling recursion T(m+1) = T(m) + 2·T(m) = 3·T(m): the upper half [2^m, 2^{m+1}) reindexes (via Finset.sum_range_add) to 2^m + k, and each term 2^(s₂(2^m+k)) = 2·2^(s₂ k) is doubled. Verified with 0 axioms, 0 sorries, no native_decide (the two concrete block checks use kernel decide).",
+  "meta": {
+    "author": "Classical (Sierpiński count, after Lucas 1878 / Glaisher 1899); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LucasTheoremOQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "binomial-coefficients",
+      "lucas-theorem",
+      "pascals-triangle",
+      "binary-digit-sum",
+      "sierpinski",
+      "fractal-dimension",
+      "parity",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-21",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_add",
+        "description": "∑ x ∈ range (m + n), f x = (∑ x ∈ range m, f x) + ∑ x ∈ range n, f (m + x). Splits the block [0, 2^{m+1}) = [0, 2^m) ∪ [2^m, 2^{m+1}) and reindexes the upper half to 2^m + k, the key step of the doubling recursion.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "c · ∑ f = ∑ (c · f). Pulls the factor 2 out of the upper-half sum once each term 2^(s₂(2^m+k)) = 2·2^(s₂ k) has been doubled by the leading-bit lemma.",
+        "module": "Mathlib.Algebra.BigOperators.Ring"
+      },
+      {
+        "theorem": "Finset.sum_congr",
+        "description": "Termwise equality of summands gives equality of sums. Used to apply the leading-bit lemma s₂(2^m+k) = s₂ k + 1 (and the parent's Glaisher formula) under the sum.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "sum_oddCount_eq_three_pow (Sierpiński count): ∑_{n < 2^m} oddCount n = 3^m — the total number of odd entries in the first 2^m rows of Pascal's triangle is 3^m. Obtained by rewriting oddCount = 2^(s₂ ·) (parent's Glaisher formula) under the sum and invoking the abstract identity.",
+      "sum_two_pow_s2: ∑_{n < 2^m} 2^(s₂ n) = 3^m, the digit-sum form of the Sierpiński count, proved by induction on m using the block-doubling recursion T(m+1) = 3·T(m).",
+      "s2_two_pow_add: for k < 2^m, s₂(2^m + k) = s₂(k) + 1 — prepending a leading 1-bit at position m increments the binary digit sum. Proved by induction on m via the halving step (2^{m+1}+k)/2 = 2^m + k/2 and (2^{m+1}+k) % 2 = k % 2.",
+      "s2_step: the binary-digit-sum recursion s₂ n = (n mod 2) + s₂(n/2) extended to all n (the parent's s2_pos requires 0 < n; the n = 0 case is the identity 0 = 0 + 0)."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. No native_decide — the two concrete block checks (∑_{n<4} oddCount n = 9, ∑_{n<8} oddCount n = 27) use kernel `decide`, so no Lean.ofReduceBool. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas and the parent entry's Glaisher formula.",
+    "lineCount": 115,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Reducing Pascal's triangle modulo 2 — keeping only the parity of each binomial coefficient — produces the Sierpiński triangle (Stephen Wolfram and others popularised the picture, though the gasket is due to Wacław Sierpiński, 1915). Glaisher's 1899 row count oddCount n = 2^(s₂ n) gives the per-row population of black cells; summing it over a power-of-two block of rows yields the clean total 3^m. That 3-versus-2 ratio between a doubling of the row range and the tripling of the odd-entry count is exactly the self-similarity dimension of the gasket, log₂ 3 ≈ 1.585.",
+    "problemStatement": "The parent entry proves that row n of Pascal's triangle has 2^(s₂ n) odd entries and lists, as an open question, the cumulative count: how many odd entries appear across the first 2^m rows together?\n\n**Answer:** exactly 3^m. Equivalently ∑_{n < 2^m} 2^(s₂ n) = 3^m.",
+    "text": "Glaisher's formula reduces the cumulative count to the pure digit-sum series ∑_{n<2^m} 2^(s₂ n). Splitting the row range at its midpoint 2^m and observing that every index in the upper half is its lower-half mirror with one extra leading 1-bit (so its 2^(s₂ ·) weight is doubled) gives the recursion total(m+1) = total(m) + 2·total(m) = 3·total(m), whence 3^m.",
+    "proofStrategy": "1. s2_step: extend the parent's digit-sum recursion s₂ n = n%2 + s₂(n/2) to n = 0 (trivially 0 = 0 + 0).\n2. s2_two_pow_add: by induction on m, s₂(2^m + k) = s₂(k) + 1 for k < 2^m. The successor step uses (2^{m+1}+k) % 2 = k % 2 and (2^{m+1}+k)/2 = 2^m + k/2 (both by omega after rw [pow_succ]), then the inductive hypothesis and s2_step.\n3. sum_two_pow_s2: induction on m. Write 2^{m+1} = 2^m + 2^m and apply Finset.sum_range_add to split the sum. By the leading-bit lemma each upper-half term doubles, so the upper half equals 2·(lower half); combine with the inductive hypothesis to get 3^{m+1}.\n4. sum_oddCount_eq_three_pow: rewrite oddCount = 2^(s₂ ·) under the sum (parent's oddCount_eq_two_pow_s2) and invoke sum_two_pow_s2.",
+    "keyInsights": [
+      "Glaisher's per-row formula turns a cumulative combinatorial count into a clean digit-sum series ∑ 2^(s₂ n), where the self-similar doubling structure is transparent.",
+      "The midpoint split [0, 2^{m+1}) = [0, 2^m) ⊔ [2^m, 2^{m+1}) is exactly the recursive subdivision of the Sierpiński gasket: the upper block is a shifted copy of the lower block with one extra black-cell-doubling bit.",
+      "The leading-bit lemma s₂(2^m + k) = s₂(k) + 1 is the single arithmetic fact carrying the whole result; everything else is Finset.sum_range_add bookkeeping.",
+      "The ratio 3 = 1 + 2 (the block plus its doubled mirror) against a doubling of the row count is the discrete source of the dimension log₂ 3."
+    ],
+    "exampleSections": [
+      {
+        "title": "The first 4 = 2² rows",
+        "mathContext": "Rows 0–3 are 1 | 1 1 | 1 2 1 | 1 3 3 1, with odd-entry counts 1, 2, 2, 4 (= 2^(s₂ n) for n = 0,1,2,3). Their total is 1 + 2 + 2 + 4 = 9 = 3². The file verifies ∑_{n<4} oddCount n = 9 and ∑_{n<8} oddCount n = 27 by kernel decide."
+      }
+    ]
+  },
+  "references": [
+    {
+      "authors": "É. Lucas",
+      "title": "Théorie des fonctions numériques simplement périodiques",
+      "year": "1878",
+      "note": "American Journal of Mathematics 1, 184–196 & 197–240. The digit-product congruence underlying Glaisher's parity count."
+    },
+    {
+      "authors": "J.W.L. Glaisher",
+      "title": "On the residue of a binomial-theorem coefficient with respect to a prime modulus",
+      "year": "1899",
+      "note": "Quarterly Journal of Pure and Applied Mathematics 30, 150–156. The per-row odd-entry count 2^(s₂ n) that this entry sums over a power-of-two block."
+    },
+    {
+      "authors": "S. Wolfram",
+      "title": "Geometry of binomial coefficients",
+      "year": "1984",
+      "note": "American Mathematical Monthly 91, 566–571. Connects Pascal's triangle mod 2 to the Sierpiński gasket and its fractal dimension log₂ 3; the 3^m block count is the discrete version of that dimension."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "lucas-theorem-oq-01",
+      "reason": "Direct parent: provides Glaisher's per-row formula oddCount n = 2^(s₂ n) and the digit-sum recursion s2_pos, both reused here to sum over rows."
+    }
+  ],
+  "conclusion": {
+    "summary": "Building on the parent's Glaisher formula, this entry proves the Sierpiński count: the first 2^m rows of Pascal's triangle together contain exactly 3^m odd entries (∑_{n<2^m} oddCount n = 3^m). The proof reduces the cumulative count to the digit-sum series ∑ 2^(s₂ n), splits the row range at its midpoint, and uses the leading-bit lemma s₂(2^m+k) = s₂(k)+1 to obtain the doubling recursion T(m+1) = 3·T(m) — all with 0 axioms and no native_decide.",
+    "implications": "The 3^m count over a 2^m-tall block is the exact discrete origin of the Sierpiński gasket's Hausdorff dimension log₂ 3, and the block-doubling recursion generalises to the count of entries not divisible by an odd prime p (replacing the per-row weight 2^(s₂ n) by ∏(nᵢ+1) and the ratio 3 by (p(p+1)/2)).",
+    "openQuestions": [
+      "Generalise to an odd prime p: the number of entries in rows 0..p^m − 1 not divisible by p is (p(p+1)/2)^m, summing Fine's per-row count ∏(nᵢ+1) over a p^m-block; formalize via the same midpoint-split recursion with p branches.",
+      "Cumulative count to an arbitrary height N (not just N = 2^m): express ∑_{n<N} 2^(s₂ n) via the base-2 expansion of N, recovering 3^m at N = 2^m and giving the row-by-row growth of the Sierpiński population."
+    ]
+  },
+  "leanFile": {
+    "imports": ["Mathlib", "Proofs.LucasTheoremOQ01"],
+    "opens": ["Nat", "Finset", "LucasOddEntries"],
+    "namespace": "LucasSierpinski",
+    "lineCount": 115,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/LucasTheoremOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/lucas-theorem-oq-01.json
+++ b/src/data/research/problems/lucas-theorem-oq-01.json
@@ -29,10 +29,11 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Glaisher closed form oddCount n = 2^(s₂ n) proved (0-axiom, no native_decide) on top of Mathlib Lucas.",
+    "progressSummary": "COMPLETE: Glaisher closed form + Sierpiński block sum 3^m (child oq-02) both proved 0-axiom. Remaining next step: Fine general-p per-row count.",
     "builtItems": [
       "proofs/Proofs/LucasTheoremOQ01.lean (206L, 10thm/3def, 0-axiom verified, no native_decide): lucas_theorem (re-export), lucas_mod_two, odd_choose_two_mul, odd_choose_two_mul_add_one, oddCount_two_mul, oddCount_two_mul_add_one, s2_pos, oddCount_eq_two_pow_s2 (Glaisher), oddCount_isPowerOfTwo.",
-      "Gallery: src/data/proofs/lucas-theorem-oq-01/meta.json"
+      "Gallery: src/data/proofs/lucas-theorem-oq-01/meta.json",
+      "lucas-theorem-oq-01-oq-02 (PR #27478): ∑_{n<2^m} oddCount n = 3^m (Sierpiński count) via leading-bit lemma s₂(2^m+k)=s₂(k)+1 + doubling recursion T(m+1)=3T(m). 0-axiom verified."
     ],
     "insights": [
       "Lucas mod 2 (Mathlib Choose.choose_modEq_choose_mod_mul_choose_div_nat, p=2) gives pointwise parity: C(2n,k) odd ⟺ k even ∧ C(n,k/2) odd (top digit 0, C(0,1)=0); C(2n+1,k) odd ⟺ C(n,k/2) odd for all k (top digit 1, C(1,0)=C(1,1)=1).",


### PR DESCRIPTION
## Summary

Answers the **"sum over rows"** open question listed by the parent entry `lucas-theorem-oq-01` (Glaisher's per-row count `oddCount n = 2^(s₂ n)`):

> The total number of odd entries in the first `2^m` rows of Pascal's triangle (rows `0 … 2^m − 1`) is exactly **`3^m`**, i.e. `∑_{n < 2^m} oddCount n = 3^m`.

This is the discrete origin of the **Sierpiński gasket's Hausdorff dimension `log₂ 3 ≈ 1.585`**: doubling the row range triples the black-cell population.

## Mathematics

- **`s2_two_pow_add`** (new engine): for `k < 2^m`, `s₂(2^m + k) = s₂(k) + 1` — prepending a leading 1-bit increments the binary digit sum. Proved by induction on `m` via `(2^{m+1}+k)/2 = 2^m + k/2` and `(2^{m+1}+k) % 2 = k % 2`.
- **`sum_two_pow_s2`**: `∑_{n<2^m} 2^(s₂ n) = 3^m`. Midpoint split (`Finset.sum_range_add`) gives the doubling recursion `T(m+1) = T(m) + 2·T(m) = 3·T(m)`.
- **`sum_oddCount_eq_three_pow`**: the Pascal-triangle statement, via the parent's Glaisher formula under the sum.

## Verification

- ✅ Builds against Mathlib 4.26.0 (`Proofs.LucasTheoremOQ01OQ02`)
- ✅ **0 axioms, 0 sorries**, **no `native_decide`** (axiom check: only `propext`, `Classical.choice`, `Quot.sound`)
- 4 theorems, 0 definitions, 115 lines
- Reuses parent `Proofs.LucasTheoremOQ01` (`oddCount_eq_two_pow_s2`, `s2_pos`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)