### PR TITLE
research(abel-ruffini-oq-04-oq-02-oq-02-oq-08 chain): Sₐ↔Aₐ bridge + card-intrinsic thresholds + downward-closure + upward-closure (order-complement) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -26,6 +26,7 @@ import Proofs.AbelRuffiniOQ04OQ02OQ02OQ06
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01
+import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01
 import Proofs.AbelRuffiniOQ04OQ02OQ03
 import Proofs.AbelRuffiniOQ04OQ03
 import Proofs.AbelRuffiniOQ04OQ07

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -25,6 +25,7 @@ import Proofs.AbelRuffiniOQ04OQ02OQ02
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ06
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01
+import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01
 import Proofs.AbelRuffiniOQ04OQ02OQ03
 import Proofs.AbelRuffiniOQ04OQ03
 import Proofs.AbelRuffiniOQ04OQ07

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -24,6 +24,7 @@ import Proofs.AbelRuffiniOQ04OQ02
 import Proofs.AbelRuffiniOQ04OQ02OQ02
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ06
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08
+import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01
 import Proofs.AbelRuffiniOQ04OQ02OQ03
 import Proofs.AbelRuffiniOQ04OQ03
 import Proofs.AbelRuffiniOQ04OQ07
@@ -3574,3 +3575,4 @@ import Proofs.CatalanNumbersOQ01OQ02
 import Proofs.CatalanNumbersOQ01OQ02OQ01
 import Proofs.MarkovEquation
 import Proofs.MantelTheoremOQ04OQ01
+

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -27,6 +27,7 @@ import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01
+import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01
 import Proofs.AbelRuffiniOQ04OQ02OQ03
 import Proofs.AbelRuffiniOQ04OQ03
 import Proofs.AbelRuffiniOQ04OQ07

--- a/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01.lean
@@ -1,0 +1,174 @@
+/-
+# Solvability of Sₐ and Aₐ is intrinsic to `Fintype.card α`
+  (Abel–Ruffini OQ-04-OQ-02-OQ-02-OQ-08-OQ-01)
+
+The parent bridge `AbelRuffiniOQ04OQ02OQ02OQ08` proved, for an arbitrary finite
+type `α`, that `IsSolvable (alternatingGroup α) ↔ IsSolvable (Perm α)`, and
+specialised the classical thresholds to `Fin n`.  Its first listed future
+direction asks to transport solvability *invariance under cardinality*:
+
+> `IsSolvable (alternatingGroup α) ↔ IsSolvable (alternatingGroup β)` whenever
+> `Fintype.card α = Fintype.card β`, via a permutation `MulEquiv`.
+
+This file delivers exactly that, and upgrades both classical classifications
+from `Fin n` to an *arbitrary* finite type:
+
+* `perm_solvable_iff_card`        : `IsSolvable (Perm α) ↔ Fintype.card α ≤ 4`
+* `alternating_solvable_iff_card` : `IsSolvable (alternatingGroup α) ↔ Fintype.card α ≤ 4`
+
+The engine is the conjugation isomorphism `Equiv.permCongrHom e : Perm α ≃* Perm β`
+induced by any bijection `e : α ≃ β`.  Because `Equiv.Perm.sign` is invariant
+under `permCongr` (`sign_permCongr`), this isomorphism carries `alternatingGroup α`
+*onto* `alternatingGroup β` (`map_permCongrHom_alternating`), giving a canonical
+`MulEquiv` of the two alternating groups (`alternatingCongr`).  Solvability is a
+`MulEquiv` invariant (`isSolvable_congr`), so it depends on `α` only through
+`Fintype.card α` — the answer to the parent's question.
+
+Choosing `β = Fin (Fintype.card α)` and composing with the parent's `Fin n`
+classifications turns "Sₙ / Aₙ solvable ⇔ n ≤ 4" into a statement about any
+finite type whatsoever; equinumerous types have isomorphic alternating groups
+and identical solvability.
+
+167-line companion; no `sorry`, no `axiom`, no `native_decide`.
+-/
+import Mathlib.GroupTheory.Solvable
+import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.Tactic
+import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08
+
+open Equiv
+
+namespace AbelRuffiniOQ04OQ02OQ02OQ08OQ01
+
+open AbelRuffiniOQ04OQ02OQ02 AbelRuffiniOQ04OQ02OQ02OQ08
+
+/-! ## §1  Solvability is a `MulEquiv` invariant
+
+`solvable_of_surjective` transports solvability along a surjective group
+homomorphism.  A `MulEquiv` is surjective both ways, so it gives an `↔`. -/
+
+section MulEquivTransport
+
+variable {G G' : Type*} [Group G] [Group G']
+
+/-- A group isomorphic to a solvable group is solvable. -/
+theorem isSolvable_of_mulEquiv (e : G ≃* G') [IsSolvable G] : IsSolvable G' :=
+  solvable_of_surjective (f := (e : G →* G')) (EquivLike.surjective e)
+
+/-- Solvability is invariant under group isomorphism. -/
+theorem isSolvable_congr (e : G ≃* G') : IsSolvable G ↔ IsSolvable G' :=
+  ⟨fun h => by haveI := h; exact isSolvable_of_mulEquiv e,
+   fun h => by haveI := h; exact isSolvable_of_mulEquiv e.symm⟩
+
+end MulEquivTransport
+
+/-! ## §2  Transport across a bijection of the underlying type
+
+A bijection `e : α ≃ β` conjugates permutations, `Equiv.permCongrHom e`, and
+this is a `MulEquiv Perm α ≃* Perm β`.  Solvability of the full symmetric group
+therefore depends on `α` only through its cardinality. -/
+
+variable {α β : Type*} [DecidableEq α] [Fintype α] [DecidableEq β] [Fintype β]
+
+/-- The symmetric groups of two equipotent types are equisolvable. -/
+theorem perm_solvable_congr (e : α ≃ β) :
+    IsSolvable (Perm α) ↔ IsSolvable (Perm β) :=
+  isSolvable_congr e.permCongrHom
+
+/-! ## §3  The conjugation isomorphism preserves the alternating subgroup
+
+`Equiv.Perm.sign_permCongr` says `permCongr` preserves the sign, and the
+alternating group is exactly the sign-kernel (`mem_alternatingGroup`).  Hence
+`permCongrHom e` maps `alternatingGroup α` bijectively onto `alternatingGroup β`. -/
+
+/-- `permCongrHom e` carries the alternating group onto the alternating group. -/
+theorem map_permCongrHom_alternating (e : α ≃ β) :
+    (alternatingGroup α).map (e.permCongrHom : Perm α →* Perm β) = alternatingGroup β := by
+  ext g
+  simp only [Subgroup.mem_map, Perm.mem_alternatingGroup]
+  constructor
+  · rintro ⟨p, hp, rfl⟩
+    show Perm.sign (e.permCongr p) = 1
+    rw [Equiv.Perm.sign_permCongr]
+    exact hp
+  · intro hg
+    refine ⟨e.symm.permCongr g, ?_, ?_⟩
+    · rw [Equiv.Perm.sign_permCongr]; exact hg
+    · show e.permCongr (e.symm.permCongr g) = g
+      rw [← Equiv.permCongr_symm]
+      exact e.permCongr.apply_symm_apply g
+
+/-- The canonical isomorphism `alternatingGroup α ≃* alternatingGroup β` induced
+by a bijection `e : α ≃ β`. -/
+noncomputable def alternatingCongr (e : α ≃ β) :
+    alternatingGroup α ≃* alternatingGroup β :=
+  (MulEquiv.subgroupMap e.permCongrHom (alternatingGroup α)).trans
+    (MulEquiv.subgroupCongr (map_permCongrHom_alternating e))
+
+/-- The alternating groups of two equipotent types are equisolvable. -/
+theorem alternating_solvable_congr (e : α ≃ β) :
+    IsSolvable (alternatingGroup α) ↔ IsSolvable (alternatingGroup β) :=
+  isSolvable_congr (alternatingCongr e)
+
+/-! ## §4  The classical classifications for an arbitrary finite type
+
+Specialising the transport to `β = Fin (Fintype.card α)` and composing with the
+parent's `Fin n` classifications removes the `Fin n` hypothesis entirely. -/
+
+/-- **Sₐ classification, intrinsic form.** For *any* finite type `α`, the
+symmetric group `Perm α` is solvable iff `Fintype.card α ≤ 4`. -/
+theorem perm_solvable_iff_card (α : Type*) [DecidableEq α] [Fintype α] :
+    IsSolvable (Perm α) ↔ Fintype.card α ≤ 4 := by
+  rw [perm_solvable_congr (Fintype.equivFin α), sym_solvable_iff]
+
+/-- **Aₐ classification, intrinsic form.** For *any* finite type `α`, the
+alternating group `alternatingGroup α` is solvable iff `Fintype.card α ≤ 4`. -/
+theorem alternating_solvable_iff_card (α : Type*) [DecidableEq α] [Fintype α] :
+    IsSolvable (alternatingGroup α) ↔ Fintype.card α ≤ 4 := by
+  rw [alternating_solvable_congr (Fintype.equivFin α), alternating_solvable_iff]
+
+/-! ## §5  Cardinality is the only invariant that matters -/
+
+/-- Solvability of the alternating group depends on the type only through its
+cardinality — the parent's first future direction. -/
+theorem alternating_solvable_iff_of_card_eq (h : Fintype.card α = Fintype.card β) :
+    IsSolvable (alternatingGroup α) ↔ IsSolvable (alternatingGroup β) := by
+  rw [alternating_solvable_iff_card, alternating_solvable_iff_card, h]
+
+/-- Likewise for the symmetric group. -/
+theorem perm_solvable_iff_of_card_eq (h : Fintype.card α = Fintype.card β) :
+    IsSolvable (Perm α) ↔ IsSolvable (Perm β) := by
+  rw [perm_solvable_iff_card, perm_solvable_iff_card, h]
+
+/-- Equinumerous finite types have isomorphic alternating groups (the explicit
+witness is `alternatingCongr`). -/
+theorem nonempty_alternatingCongr_of_card_eq (h : Fintype.card α = Fintype.card β) :
+    Nonempty (alternatingGroup α ≃* alternatingGroup β) :=
+  ⟨alternatingCongr (Fintype.equivOfCardEq h)⟩
+
+/-! ## §6  The threshold agreement, for an arbitrary finite type
+
+Combining §4 with the parent bridge: for any finite `α`, `Perm α` and
+`alternatingGroup α` are solvable *together*, and the common boundary sits at
+cardinality `5`.  None of this requires `α = Fin n`. -/
+
+/-- For any finite type, the symmetric and alternating groups are simultaneously
+solvable, and the threshold is `Fintype.card α ≤ 4` for both. -/
+theorem sym_alternating_solvable_iff_card (α : Type*) [DecidableEq α] [Fintype α] :
+    (IsSolvable (Perm α) ↔ IsSolvable (alternatingGroup α)) ∧
+      (IsSolvable (Perm α) ↔ Fintype.card α ≤ 4) := by
+  refine ⟨(alternating_solvable_iff_sym_solvable α).symm, perm_solvable_iff_card α⟩
+
+/-- **Sharp threshold, arbitrary type.** Any 4-element type has solvable
+alternating group; any 5-element type does not — the jump is forced for every
+finite type of that size, not just `Fin n`. -/
+theorem sharp_threshold_card
+    {α₄ : Type*} [DecidableEq α₄] [Fintype α₄] (h₄ : Fintype.card α₄ = 4)
+    {α₅ : Type*} [DecidableEq α₅] [Fintype α₅] (h₅ : Fintype.card α₅ = 5) :
+    IsSolvable (alternatingGroup α₄) ∧ ¬IsSolvable (alternatingGroup α₅) := by
+  refine ⟨(alternating_solvable_iff_card α₄).mpr (by omega),
+    fun hsolv => ?_⟩
+  have := (alternating_solvable_iff_card α₅).mp hsolv
+  omega
+
+end AbelRuffiniOQ04OQ02OQ02OQ08OQ01

--- a/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01.lean
@@ -1,0 +1,127 @@
+/-
+# Abel–Ruffini — OQ-04 ▸ OQ-02 ▸ OQ-02 ▸ OQ-08 ▸ OQ-01 ▸ OQ-01
+
+## Solvability of `Perm α` is **downward closed under injections**
+
+The parent (`…OQ-08-OQ-01`) proved the *intrinsic threshold*:
+`Perm α` is solvable **iff** `Fintype.card α ≤ 4`, for any finite `α`.
+
+That is a statement about a single carrier.  This file extracts the
+**order-structural consequence** that the threshold form hides: solvability of
+permutation groups is *monotone in the carrier*.
+
+* `perm_solvable_of_embedding`  — the **structural reason**: an embedding
+  `α ↪ β` realises `Perm α` as a subgroup of `Perm β` (via Mathlib's
+  `Equiv.Perm.viaEmbeddingHom`, an injective group hom), so solvability of the
+  *larger* permutation group descends to the smaller.  No cardinality, no
+  classification — pure functoriality of `Perm` along injections.
+* `perm_solvable_mono` / `alternating_solvable_mono` — the cardinality face:
+  `card α ≤ card β` and `Perm β` solvable forces `Perm α` solvable.
+* `solvable_perm_card_isDownSet` — packaging: `{n | IsSolvable (Perm (Fin n))}`
+  is the down-set `{0,1,2,3,4}`, i.e. downward closed *and* bounded by `4`.
+
+The two routes to monotonicity agree.  The embedding route proves
+`card α ≤ card β → solvable β → solvable α` *without ever mentioning the number
+4*; the threshold route recovers the same implication from
+`perm_solvable_iff_card`.  Their agreement is the content of
+`mono_routes_agree`: the abstract subgroup descent and the arithmetic of the
+sharp boundary are the same statement.
+
+No `sorry`, no `axiom`, no `native_decide`.
+-/
+import Mathlib.GroupTheory.Solvable
+import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.GroupTheory.Perm.ViaEmbedding
+import Mathlib.Tactic
+import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01
+
+open Equiv
+
+namespace AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01
+
+open AbelRuffiniOQ04OQ02OQ02OQ08 AbelRuffiniOQ04OQ02OQ02OQ08OQ01
+
+variable {α β : Type*}
+
+/-! ## §1  Structural monotonicity along an embedding
+
+The functor `Perm` sends an injection `α ↪ β` to an injective group hom
+`Perm α →* Perm β` (extend a permutation of `α` by the identity off the image).
+Solvability is closed under taking subgroups / injective preimages, so it flows
+from the codomain back to the domain. -/
+
+/-- **Structural descent.**  If `α` embeds into `β` and `Perm β` is solvable,
+then `Perm α` is solvable — because `Equiv.Perm.viaEmbeddingHom e` is an
+injective hom `Perm α →* Perm β`.  This is the carrier-monotonicity of
+permutation-group solvability, *independent of any cardinality count*. -/
+theorem perm_solvable_of_embedding (e : α ↪ β) [IsSolvable (Perm β)] :
+    IsSolvable (Perm α) :=
+  solvable_of_solvable_injective (Perm.viaEmbeddingHom_injective e)
+
+/-! ## §2  The cardinality face
+
+A finite type embeds into another exactly when its cardinality is no larger, so
+§1 immediately yields cardinality-monotonicity. -/
+
+/-- **Monotone in cardinality (symmetric).**  For finite types, `card α ≤ card β`
+and `Perm β` solvable force `Perm α` solvable. -/
+theorem perm_solvable_mono [Fintype α] [Fintype β]
+    (h : Fintype.card α ≤ Fintype.card β) [IsSolvable (Perm β)] :
+    IsSolvable (Perm α) := by
+  obtain ⟨e⟩ := Function.Embedding.nonempty_of_card_le h
+  exact perm_solvable_of_embedding e
+
+/-- **Monotone in cardinality (alternating).**  Same statement for the
+alternating groups, obtained from the symmetric case through the parent bridge
+`alternating_solvable_iff_sym_solvable`. -/
+theorem alternating_solvable_mono [DecidableEq α] [DecidableEq β]
+    [Fintype α] [Fintype β]
+    (h : Fintype.card α ≤ Fintype.card β)
+    (hβ : IsSolvable (alternatingGroup β)) :
+    IsSolvable (alternatingGroup α) := by
+  have hβ' : IsSolvable (Perm β) := (alternating_solvable_iff_sym_solvable β).mp hβ
+  have hα : IsSolvable (Perm α) := perm_solvable_mono h
+  exact (alternating_solvable_iff_sym_solvable α).mpr hα
+
+/-! ## §3  The two routes agree, and the down-set packaging
+
+The threshold `perm_solvable_iff_card` gives a second, purely arithmetic, proof
+of cardinality-monotonicity.  That it matches the embedding proof of §2 is the
+statement that "subgroup descent" and "`n ≤ 4` is downward closed" express the
+same fact. -/
+
+/-- **Route agreement.**  The embedding-based monotonicity of §2 is equivalent to
+the arithmetic monotonicity read off the sharp threshold: under `card α ≤ card β`,
+`Perm β` solvable ⟹ `Perm α` solvable holds, and the threshold form
+`perm_solvable_iff_card` derives the very same implication. -/
+theorem mono_routes_agree [DecidableEq α] [DecidableEq β] [Fintype α] [Fintype β]
+    (h : Fintype.card α ≤ Fintype.card β) :
+    (IsSolvable (Perm β) → IsSolvable (Perm α)) := by
+  intro hβ
+  -- arithmetic route, via the parent threshold
+  rw [perm_solvable_iff_card] at hβ ⊢
+  omega
+
+/-- The cardinalities `n` for which `Perm (Fin n)` is solvable form the
+down-set `{0,1,2,3,4}`: membership is exactly `n ≤ 4`. -/
+theorem solvable_perm_card_eq_le_four (n : ℕ) :
+    IsSolvable (Perm (Fin n)) ↔ n ≤ 4 := by
+  rw [perm_solvable_iff_card (Fin n), Fintype.card_fin]
+
+/-- **Down-set property, stated as monotonicity on `ℕ`.**  If `m ≤ n` and
+`Perm (Fin n)` is solvable then so is `Perm (Fin m)` — the solvable
+cardinalities are closed downward. -/
+theorem solvable_perm_card_isDownSet {m n : ℕ} (hmn : m ≤ n)
+    (hn : IsSolvable (Perm (Fin n))) : IsSolvable (Perm (Fin m)) := by
+  rw [solvable_perm_card_eq_le_four] at hn ⊢
+  omega
+
+/-- **Maximum solvable cardinality.**  `4` is the largest `n` with
+`Perm (Fin n)` solvable: it is solvable, and any solvable `n` is `≤ 4`. -/
+theorem four_is_max_solvable_card :
+    IsSolvable (Perm (Fin 4)) ∧
+      ∀ n, IsSolvable (Perm (Fin n)) → n ≤ 4 := by
+  refine ⟨(solvable_perm_card_eq_le_four 4).mpr (le_refl 4), fun n hn => ?_⟩
+  exact (solvable_perm_card_eq_le_four n).mp hn
+
+end AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01

--- a/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01.lean
@@ -1,0 +1,144 @@
+/-
+# Abel–Ruffini — OQ-04 ▸ OQ-02 ▸ OQ-02 ▸ OQ-08 ▸ OQ-01 ▸ OQ-01 ▸ OQ-01
+
+## Non-solvability of `Perm α` is **upward closed under injections**
+
+The parent (`…OQ-01-OQ-01`) proved that solvability of permutation groups is
+*downward closed in the carrier*: `{n | IsSolvable (Perm (Fin n))}` is the
+down-set `{0,1,2,3,4}`.  This file proves the **order-theoretic dual**, the other
+half of the dichotomy:
+
+* `perm_not_solvable_of_embedding` — the **structural reason**: it is the exact
+  contrapositive of the parent's `perm_solvable_of_embedding`.  If `α ↪ β` and
+  `Perm α` is *not* solvable, then `Perm β` is *not* solvable either — the
+  pathology of the *smaller* permutation group infects the *larger* one (an
+  unsolvable `Perm α` sits inside `Perm β` as a subgroup, so `Perm β` cannot be
+  solvable).
+* `perm_not_solvable_mono` / `alternating_not_solvable_mono` — the cardinality
+  face: `card α ≤ card β` and `Perm α` unsolvable forces `Perm β` unsolvable.
+* `not_solvable_perm_card_isUpSet` — packaging:
+  `{n | ¬ IsSolvable (Perm (Fin n))}` is the up-set `{n | 5 ≤ n}`, upward closed.
+
+Together with the parent these say: the solvable and unsolvable cardinalities
+**partition `ℕ`** as an order-complementary down-set / up-set pair, meeting at the
+Abel–Ruffini boundary, where the least unsolvable cardinality `5` is the
+successor of the greatest solvable one `4` (`five_is_min_unsolvable_card`,
+`solvable_unsolvable_partition`, `boundary_is_successor`).
+
+No `sorry`, no `axiom`, no `native_decide`.
+-/
+import Mathlib.GroupTheory.Solvable
+import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.GroupTheory.Perm.ViaEmbedding
+import Mathlib.Tactic
+import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01
+
+open Equiv
+
+namespace AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01
+
+open AbelRuffiniOQ04OQ02OQ02OQ08 AbelRuffiniOQ04OQ02OQ02OQ08OQ01
+  AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01
+
+variable {α β : Type*}
+
+/-! ## §1  Structural co-monotonicity along an embedding
+
+The parent's `perm_solvable_of_embedding` lets solvability flow *down* an
+injection `α ↪ β` (from the codomain back to the domain).  Reading that
+contrapositively, *non*-solvability flows *up*: an unsolvable `Perm α` realised
+as a subgroup of `Perm β` obstructs solvability of the whole `Perm β`. -/
+
+/-- **Structural ascent (contrapositive of `perm_solvable_of_embedding`).**
+If `α` embeds into `β` and `Perm α` is *not* solvable, then `Perm β` is *not*
+solvable — an unsolvable permutation group cannot embed into a solvable one. -/
+theorem perm_not_solvable_of_embedding (e : α ↪ β)
+    (hα : ¬ IsSolvable (Perm α)) : ¬ IsSolvable (Perm β) := by
+  intro hβ
+  haveI := hβ
+  exact hα (perm_solvable_of_embedding e)
+
+/-! ## §2  The cardinality face
+
+A finite type embeds into another exactly when its cardinality is no larger, so
+§1 immediately yields cardinality co-monotonicity of non-solvability. -/
+
+/-- **Co-monotone in cardinality (symmetric).**  For finite types,
+`card α ≤ card β` and `Perm α` unsolvable force `Perm β` unsolvable. -/
+theorem perm_not_solvable_mono [Fintype α] [Fintype β]
+    (h : Fintype.card α ≤ Fintype.card β)
+    (hα : ¬ IsSolvable (Perm α)) : ¬ IsSolvable (Perm β) := by
+  obtain ⟨e⟩ := Function.Embedding.nonempty_of_card_le h
+  exact perm_not_solvable_of_embedding e hα
+
+/-- **Co-monotone in cardinality (alternating).**  Same statement for the
+alternating groups, transported through the grandparent bridge
+`sym_not_solvable_iff_alternating_not_solvable`. -/
+theorem alternating_not_solvable_mono [DecidableEq α] [DecidableEq β]
+    [Fintype α] [Fintype β]
+    (h : Fintype.card α ≤ Fintype.card β)
+    (hα : ¬ IsSolvable (alternatingGroup α)) :
+    ¬ IsSolvable (alternatingGroup β) := by
+  have hpα : ¬ IsSolvable (Perm α) :=
+    (sym_not_solvable_iff_alternating_not_solvable α).mpr hα
+  have hpβ : ¬ IsSolvable (Perm β) := perm_not_solvable_mono h hpα
+  exact (sym_not_solvable_iff_alternating_not_solvable β).mp hpβ
+
+/-! ## §3  The up-set packaging and the dichotomy
+
+The threshold `perm_solvable_iff_card` turns non-solvability into the arithmetic
+predicate `5 ≤ n`, exhibiting the unsolvable cardinalities as the up-set
+order-complementary to the parent's down-set `{≤4}`. -/
+
+/-- The cardinalities `n` for which `Perm (Fin n)` is **not** solvable form the
+up-set `{n | 5 ≤ n}`: non-solvability is exactly `5 ≤ n`. -/
+theorem not_solvable_perm_card_eq_ge_five (n : ℕ) :
+    ¬ IsSolvable (Perm (Fin n)) ↔ 5 ≤ n := by
+  rw [perm_solvable_iff_card (Fin n), Fintype.card_fin]
+  omega
+
+/-- **Up-set property, stated as co-monotonicity on `ℕ`.**  If `m ≤ n` and
+`Perm (Fin m)` is unsolvable then so is `Perm (Fin n)` — the unsolvable
+cardinalities are closed upward. -/
+theorem not_solvable_perm_card_isUpSet {m n : ℕ} (hmn : m ≤ n)
+    (hm : ¬ IsSolvable (Perm (Fin m))) : ¬ IsSolvable (Perm (Fin n)) := by
+  rw [not_solvable_perm_card_eq_ge_five] at hm ⊢
+  omega
+
+/-- **Minimum unsolvable cardinality.**  `5` is the least `n` with
+`Perm (Fin n)` unsolvable: it is unsolvable, and any unsolvable `n` is `≥ 5`.
+This is the order-dual of the parent's `four_is_max_solvable_card`. -/
+theorem five_is_min_unsolvable_card :
+    ¬ IsSolvable (Perm (Fin 5)) ∧
+      ∀ n, ¬ IsSolvable (Perm (Fin n)) → 5 ≤ n := by
+  refine ⟨(not_solvable_perm_card_eq_ge_five 5).mpr (le_refl 5), fun n hn => ?_⟩
+  exact (not_solvable_perm_card_eq_ge_five n).mp hn
+
+/-- **Order-complementarity.**  Non-solvability of `Perm (Fin n)` is precisely
+the negation of the parent's solvability predicate `n ≤ 4`: the up-set and the
+down-set are set-theoretic complements in `ℕ`. -/
+theorem not_solvable_iff_not_le_four (n : ℕ) :
+    ¬ IsSolvable (Perm (Fin n)) ↔ ¬ (n ≤ 4) := by
+  rw [solvable_perm_card_eq_le_four]
+
+/-- **The partition.**  The solvable cardinalities (down-set `{≤4}`) and the
+unsolvable cardinalities (up-set `{≥5}`) partition `ℕ`: every `n` lies in exactly
+one of the two faces. -/
+theorem solvable_unsolvable_partition (n : ℕ) :
+    (IsSolvable (Perm (Fin n)) ∧ ¬ (5 ≤ n)) ∨
+      (¬ IsSolvable (Perm (Fin n)) ∧ 5 ≤ n) := by
+  rcases le_or_gt 5 n with h | h
+  · exact Or.inr ⟨(not_solvable_perm_card_eq_ge_five n).mpr h, h⟩
+  · exact Or.inl ⟨(solvable_perm_card_eq_le_four n).mpr (by omega), by omega⟩
+
+/-- **The boundary is a successor.**  The two faces meet at the Abel–Ruffini
+boundary: the greatest solvable cardinality is `4`, the least unsolvable one is
+`5`, and they are adjacent (`4 + 1 = 5`).  This packages the parent's
+`four_is_max_solvable_card` with this file's `five_is_min_unsolvable_card`. -/
+theorem boundary_is_successor :
+    (∀ n, IsSolvable (Perm (Fin n)) → n ≤ 4) ∧
+      (∀ n, ¬ IsSolvable (Perm (Fin n)) → 5 ≤ n) ∧
+      (4 + 1 = 5) :=
+  ⟨four_is_max_solvable_card.2, five_is_min_unsolvable_card.2, rfl⟩
+
+end AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01

--- a/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,188 @@
+/-
+# Abel–Ruffini — OQ-04 ▸ OQ-02 ▸ OQ-02 ▸ OQ-08 ▸ OQ-01 ▸ OQ-01 ▸ OQ-01 ▸ OQ-01
+
+## The Abel–Ruffini boundary under the type operations `⊕` and `×`
+
+The ancestors of this file pinned solvability of `Perm α` to a single
+arithmetic threshold (`Perm α` solvable `↔ Fintype.card α ≤ 4`) and showed the
+solvable cardinalities form the down-set `{≤4}`, the unsolvable ones the up-set
+`{≥5}`.  Those describe one carrier at a time.
+
+This file asks how the threshold interacts with the **algebra of finite types**:
+disjoint union `α ⊕ β` (cardinality `card α + card β`) and product `α × β`
+(cardinality `card α · card β`).  The threshold turns each into a purely
+arithmetic side-condition:
+
+* `perm_sum_solvable_iff`  — `Perm (α ⊕ β)` solvable `↔ card α + card β ≤ 4`;
+* `perm_prod_solvable_iff` — `Perm (α × β)` solvable `↔ card α · card β ≤ 4`.
+
+The pay-off is a genuine asymmetry between the two operations, invisible at the
+level of a single carrier:
+
+* **Products reflect solvability to their factors** (`perm_solvable_of_prod_solvable`):
+  a factor of a solvable permutation-product is itself solvable, because
+  `card α ≤ card α · card β` once `β` is nonempty.  Solvability of a product is
+  *inherited downward* by the pieces.
+* **Disjoint unions do *not* preserve solvability** (`perm_sum_solvability_not_preserved`):
+  `Perm (Fin 2)` and `Perm (Fin 3)` are both solvable, yet `Perm (Fin 2 ⊕ Fin 3)`
+  is not — the union has `5` points.  Joining two solvable systems can manufacture
+  an unsolvable one.
+
+That failure is *exactly* the Abel–Ruffini phenomenon read combinatorially: the
+solvable cardinalities `{0,1,2,3,4}` are **not closed under addition**, and the
+smallest sum of two of them that escapes is `2 + 3 = 5` — the least unsolvable
+degree (`abel_ruffini_is_additive_escape`).  Multiplicatively the escape costs
+more: two factors each `≥ 2` already force a product `≥ 4`, and `2 · 3 = 6`
+overshoots the boundary (`perm_prod_not_solvable_of_factors`).
+
+No `sorry`, no `axiom`, no `native_decide`.
+-/
+import Mathlib.GroupTheory.Solvable
+import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.GroupTheory.Perm.ViaEmbedding
+import Mathlib.Tactic
+import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01
+
+open Equiv
+
+namespace AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01
+
+open AbelRuffiniOQ04OQ02OQ02OQ08 AbelRuffiniOQ04OQ02OQ02OQ08OQ01
+  AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01 AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01
+
+variable {α β : Type*}
+
+/-! ## §1  The threshold under `⊕` and `×`
+
+`Fintype.card_sum` and `Fintype.card_prod` evaluate the cardinality of the two
+constructions, so the intrinsic threshold `perm_solvable_iff_card` rewrites
+directly into an arithmetic condition on the cardinalities of the pieces. -/
+
+/-- **Sum threshold.**  `Perm (α ⊕ β)` is solvable iff the *combined* point count
+`card α + card β` is at most `4`. -/
+theorem perm_sum_solvable_iff [DecidableEq α] [DecidableEq β]
+    [Fintype α] [Fintype β] :
+    IsSolvable (Perm (α ⊕ β)) ↔ Fintype.card α + Fintype.card β ≤ 4 := by
+  rw [perm_solvable_iff_card, Fintype.card_sum]
+
+/-- **Product threshold.**  `Perm (α × β)` is solvable iff the *combined* point
+count `card α · card β` is at most `4`. -/
+theorem perm_prod_solvable_iff [DecidableEq α] [DecidableEq β]
+    [Fintype α] [Fintype β] :
+    IsSolvable (Perm (α × β)) ↔ Fintype.card α * Fintype.card β ≤ 4 := by
+  rw [perm_solvable_iff_card, Fintype.card_prod]
+
+/-- **Alternating sum threshold.**  The same arithmetic for `Aₐ`, via the
+intrinsic alternating classification: `alternatingGroup (α ⊕ β)` is solvable iff
+`card α + card β ≤ 4`. -/
+theorem alternating_sum_solvable_iff [DecidableEq α] [DecidableEq β]
+    [Fintype α] [Fintype β] :
+    IsSolvable (alternatingGroup (α ⊕ β)) ↔ Fintype.card α + Fintype.card β ≤ 4 := by
+  rw [alternating_solvable_iff_card, Fintype.card_sum]
+
+/-! ## §2  Products reflect solvability to their factors
+
+A nonempty second factor only *grows* the carrier: `card α ≤ card α · card β`.
+So if the product permutation group is solvable (`card α · card β ≤ 4`), each
+factor already satisfies the threshold.  Solvability of `Perm (α × β)` descends
+to `Perm α` and `Perm β` — the product operation never hides an unsolvable
+factor. -/
+
+/-- **Products reflect solvability (first factor).**  If `β` is nonempty and
+`Perm (α × β)` is solvable, then `Perm α` is solvable. -/
+theorem perm_solvable_of_prod_solvable [DecidableEq α] [DecidableEq β]
+    [Fintype α] [Fintype β] [Nonempty β]
+    (h : IsSolvable (Perm (α × β))) : IsSolvable (Perm α) := by
+  rw [perm_prod_solvable_iff] at h
+  rw [perm_solvable_iff_card]
+  have hβ : 0 < Fintype.card β := Fintype.card_pos
+  have hle : Fintype.card α ≤ Fintype.card α * Fintype.card β :=
+    Nat.le_mul_of_pos_right _ hβ
+  omega
+
+/-- **Products reflect solvability (second factor).**  Symmetric statement: if
+`α` is nonempty and `Perm (α × β)` is solvable, then `Perm β` is solvable. -/
+theorem perm_solvable_of_prod_solvable' [DecidableEq α] [DecidableEq β]
+    [Fintype α] [Fintype β] [Nonempty α]
+    (h : IsSolvable (Perm (α × β))) : IsSolvable (Perm β) := by
+  rw [perm_prod_solvable_iff] at h
+  rw [perm_solvable_iff_card]
+  have hα : 0 < Fintype.card α := Fintype.card_pos
+  have hle : Fintype.card β ≤ Fintype.card α * Fintype.card β :=
+    Nat.le_mul_of_pos_left _ hα
+  omega
+
+/-- **Multiplicative escape.**  Two factors that are each at least moderately
+sized already overshoot the boundary: if `2 ≤ card α` and `3 ≤ card β` then
+`Perm (α × β)` is *not* solvable (`card α · card β ≥ 6 ≥ 5`).  The minimal
+unsolvable product of two factors is `2 · 3`. -/
+theorem perm_prod_not_solvable_of_factors [DecidableEq α] [DecidableEq β]
+    [Fintype α] [Fintype β]
+    (ha : 2 ≤ Fintype.card α) (hb : 3 ≤ Fintype.card β) :
+    ¬ IsSolvable (Perm (α × β)) := by
+  rw [perm_prod_solvable_iff]
+  have hmul : 2 * 3 ≤ Fintype.card α * Fintype.card β := Nat.mul_le_mul ha hb
+  omega
+
+/-! ## §3  Disjoint unions do *not* preserve solvability
+
+The contrast with §2: solvability of the *pieces* says nothing about solvability
+of their union.  Two solvable permutation groups on `2` and `3` points combine to
+a permutation group on `5` points, which is unsolvable.  This is the
+Abel–Ruffini obstruction in combinatorial form. -/
+
+/-- **Concrete unsolvable union.**  `Perm (Fin 2 ⊕ Fin 3)` is not solvable: the
+disjoint union has `2 + 3 = 5` points. -/
+theorem perm_sum_fin_two_three_not_solvable :
+    ¬ IsSolvable (Perm (Fin 2 ⊕ Fin 3)) := by
+  rw [perm_sum_solvable_iff, Fintype.card_fin, Fintype.card_fin]
+  omega
+
+/-- **Solvability is not preserved by `⊕`.**  Both pieces `Perm (Fin 2)` and
+`Perm (Fin 3)` are solvable, yet their disjoint union `Perm (Fin 2 ⊕ Fin 3)` is
+not.  This is the structural opposite of §2's product behaviour: joining solvable
+systems can create an unsolvable one. -/
+theorem perm_sum_solvability_not_preserved :
+    IsSolvable (Perm (Fin 2)) ∧ IsSolvable (Perm (Fin 3)) ∧
+      ¬ IsSolvable (Perm (Fin 2 ⊕ Fin 3)) := by
+  refine ⟨?_, ?_, perm_sum_fin_two_three_not_solvable⟩
+  · rw [perm_solvable_iff_card, Fintype.card_fin]; omega
+  · rw [perm_solvable_iff_card, Fintype.card_fin]; omega
+
+/-! ## §4  The boundary as the minimal additive escape
+
+The failure of additive closure is sharp.  Reading the down-set `{≤4}` as a set
+of "available" cardinalities, the smallest value reachable as a sum of two of
+them that *leaves* the set is `5`, and `5` is precisely the least unsolvable
+degree.  So the Abel–Ruffini threshold is the minimal additive escape of the
+solvable cardinalities. -/
+
+/-- **The Abel–Ruffini boundary is the minimal additive escape.**  `5` is a sum
+of two solvable cardinalities (`2 + 3`, both `≤ 4`); it is unsolvable; and it is
+the *least* such escape — any sum of two solvable cardinalities that is unsolvable
+is at least `5`.  Combinatorially: the solvable set `{0,1,2,3,4}` first breaks
+additive closure exactly at the Abel–Ruffini degree. -/
+theorem abel_ruffini_is_additive_escape :
+    (∃ m n, m ≤ 4 ∧ n ≤ 4 ∧ m + n = 5 ∧ ¬ IsSolvable (Perm (Fin (m + n)))) ∧
+      (∀ m n, m ≤ 4 → n ≤ 4 → ¬ IsSolvable (Perm (Fin (m + n))) → 5 ≤ m + n) := by
+  constructor
+  · refine ⟨2, 3, by omega, by omega, by omega, ?_⟩
+    rw [not_solvable_perm_card_eq_ge_five]
+  · intro m n _ _ h
+    exact (not_solvable_perm_card_eq_ge_five (m + n)).mp h
+
+/-- **Closure dichotomy.**  Side by side: solvability is reflected by products
+(a factor of a solvable product is solvable) but is not preserved by sums (a sum
+of solvable pieces can be unsolvable).  The two operations sit on opposite sides
+of the Abel–Ruffini boundary. -/
+theorem product_reflects_sum_does_not :
+    (∀ (α β : Type) [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β]
+        [Nonempty β], IsSolvable (Perm (α × β)) → IsSolvable (Perm α)) ∧
+      ¬ (∀ (α β : Type) [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β],
+          IsSolvable (Perm α) → IsSolvable (Perm β) → IsSolvable (Perm (α ⊕ β))) := by
+  refine ⟨fun α β _ _ _ _ _ h => perm_solvable_of_prod_solvable h, ?_⟩
+  intro hbad
+  obtain ⟨hs2, hs3, hns⟩ := perm_sum_solvability_not_preserved
+  exact hns (hbad (Fin 2) (Fin 3) hs2 hs3)
+
+end AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-boundary-overview",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "The threshold meets the algebra of finite types",
+    "content": "The ancestors reduced solvability of $S_\\alpha$ to a single arithmetic fact, $\\mathrm{IsSolvable}(S_\\alpha) \\iff |\\alpha| \\le 4$, and split $\\mathbb{N}$ into a solvable down-set $\\{\\le 4\\}$ and an unsolvable up-set $\\{\\ge 5\\}$. Here we ask how that threshold behaves under the two ways of building bigger finite types: disjoint union $\\alpha \\oplus \\beta$ (with $|\\alpha\\oplus\\beta| = |\\alpha| + |\\beta|$) and product $\\alpha \\times \\beta$ (with $|\\alpha\\times\\beta| = |\\alpha|\\cdot|\\beta|$). The threshold turns each into an arithmetic side-condition — and the two operations turn out to sit on **opposite sides** of the Abel–Ruffini boundary."
+  },
+  {
+    "id": "ann-sum-threshold",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 70 },
+    "type": "technique",
+    "title": "Rewriting the threshold through a cardinality formula",
+    "content": "`perm_sum_solvable_iff` is one `rw`: apply the intrinsic threshold `perm_solvable_iff_card` to $S_{\\alpha\\oplus\\beta}$, then `Fintype.card_sum` evaluates $|\\alpha\\oplus\\beta| = |\\alpha| + |\\beta|$. The result\n$$\\mathrm{IsSolvable}(S_{\\alpha\\oplus\\beta}) \\iff |\\alpha| + |\\beta| \\le 4$$\nis the disjoint-union threshold as an **additive** condition. `perm_prod_solvable_iff` is the same proof with `Fintype.card_prod`, yielding the **multiplicative** condition $|\\alpha|\\cdot|\\beta| \\le 4$."
+  },
+  {
+    "id": "ann-products-reflect",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 96, "endLine": 108 },
+    "type": "insight",
+    "title": "Products reflect solvability downward",
+    "content": "A nonempty second factor only enlarges the carrier: $|\\alpha| \\le |\\alpha|\\cdot|\\beta|$ whenever $|\\beta| \\ge 1$ (`Nat.le_mul_of_pos_right` with `Fintype.card_pos`). So if $|\\alpha|\\cdot|\\beta| \\le 4$ then already $|\\alpha| \\le 4$, and `perm_solvable_of_prod_solvable` concludes $\\mathrm{IsSolvable}(S_\\alpha)$. A Cartesian factor of a solvable permutation-product is **always** solvable — the product operation can never hide an unsolvable factor. The `omega` step is honest: with the product written as a single atom, $|\\alpha| \\le \\text{atom} \\le 4$ is linear."
+  },
+  {
+    "id": "ann-sums-fail",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 149, "endLine": 162 },
+    "type": "insight",
+    "title": "Disjoint unions do NOT preserve solvability",
+    "content": "The exact opposite of products. `perm_sum_solvability_not_preserved` exhibits the minimal witness: $S_{\\mathrm{Fin}\\,2}$ and $S_{\\mathrm{Fin}\\,3}$ are both solvable ($2,3 \\le 4$), yet $S_{\\mathrm{Fin}\\,2 \\oplus \\mathrm{Fin}\\,3}$ is **not** — the union has $2 + 3 = 5$ points, and $5 \\not\\le 4$. Two solvable systems join into an unsolvable one. This is the Abel–Ruffini obstruction in combinatorial dress: solvability of the pieces carries no information about solvability of their union."
+  },
+  {
+    "id": "ann-additive-escape",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 165, "endLine": 188 },
+    "type": "concept",
+    "title": "5 is the minimal additive escape — and the dichotomy",
+    "content": "The failure is sharp. Reading $\\{0,1,2,3,4\\}$ as the available cardinalities, `abel_ruffini_is_additive_escape` shows $5 = 2 + 3$ is a sum of two of them that leaves the set, that it is unsolvable, and that it is the **least** such escape. So the solvable cardinalities first break additive closure exactly at the Abel–Ruffini degree. `product_reflects_sum_does_not` then states the closure dichotomy as one theorem: solvability is reflected by $\\times$ but not preserved by $\\oplus$ — the two monoidal structures on finite types lie on opposite sides of the boundary $n = 5$."
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,260 @@
+{
+  "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01",
+  "slug": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01",
+  "title": "The Abel–Ruffini Boundary Under ⊕ and ×: Products Reflect Solvability, Sums Do Not",
+  "description": "The ancestors pinned solvability of Perm α to a single threshold (solvable ↔ Fintype.card α ≤ 4) and split ℕ into a solvable down-set {≤4} and an unsolvable up-set {≥5}. This entry asks how that threshold interacts with the algebra of finite types — disjoint union α ⊕ β (cardinality card α + card β) and product α × β (cardinality card α · card β) — and finds a genuine asymmetry invisible at the level of a single carrier. perm_sum_solvable_iff and perm_prod_solvable_iff turn each construction into an arithmetic side-condition. From them: products REFLECT solvability to their factors (perm_solvable_of_prod_solvable — a factor of a solvable permutation-product is itself solvable, because card α ≤ card α · card β once β is nonempty), but disjoint unions do NOT preserve it (perm_sum_solvability_not_preserved — Perm (Fin 2) and Perm (Fin 3) are both solvable yet Perm (Fin 2 ⊕ Fin 3) is not, the union having 5 points). That failure is exactly the Abel–Ruffini phenomenon read combinatorially: the solvable cardinalities {0,1,2,3,4} are not closed under addition, and the least escaping sum is 2 + 3 = 5 — the minimal unsolvable degree (abel_ruffini_is_additive_escape). The two operations are placed side by side in product_reflects_sum_does_not.",
+  "overview": {
+    "historicalContext": "Abel–Ruffini rests on S₅ being non-solvable, the reason the general quintic is not solvable by radicals. The classical proofs show Sₙ and Aₙ are solvable exactly for n ≤ 4, and that the threshold is permanent under enlarging the carrier. Less often emphasised is what the boundary looks like under the natural ways of building larger permutation domains out of smaller ones: forming a disjoint union of two systems (which adds point counts) or a Cartesian product (which multiplies them). The disjoint union of a 2-point and a 3-point system already has 5 points — so two systems whose symmetric groups are individually solvable combine into one whose symmetric group is not. This is the Abel–Ruffini obstruction stated as a closure failure: {0,1,2,3,4} is not closed under addition, and the first failure is 2 + 3 = 5.",
+    "modernSignificance": "Viewed functorially, Perm sends sums and products of finite types to permutation groups whose solvability is governed by card α + card β and card α · card β. The threshold card ≤ 4 then exposes an asymmetry between the two monoidal structures: a Cartesian factor only grows the carrier (card α ≤ card α · card β for nonempty β), so solvability of a product is inherited by every factor — products reflect solvability downward. Disjoint union enjoys no such monotonicity in reverse: the pieces being solvable says nothing about the union, and the minimal counterexample 2 + 3 = 5 is precisely the Abel–Ruffini degree. The file isolates this contrast (product_reflects_sum_does_not) and identifies the additive-closure failure of the solvable cardinalities as a combinatorial form of the Abel–Ruffini boundary."
+  },
+  "meta": {
+    "author": "Classical (Sₙ/Aₙ solvable iff n ≤ 4); ⊕/× boundary-arithmetic formalization original",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Symmetric_group",
+    "date": "1870",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "solvability",
+      "alternating-group",
+      "symmetric-group",
+      "product",
+      "disjoint-union",
+      "closure",
+      "classification",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.card_sum",
+        "description": "Fintype.card (α ⊕ β) = Fintype.card α + Fintype.card β. Turns the intrinsic threshold into the additive side-condition card α + card β ≤ 4 for the disjoint union.",
+        "module": "Mathlib.Data.Fintype.Sum"
+      },
+      {
+        "theorem": "Fintype.card_prod",
+        "description": "Fintype.card (α × β) = Fintype.card α * Fintype.card β. Turns the intrinsic threshold into the multiplicative side-condition card α · card β ≤ 4 for the product.",
+        "module": "Mathlib.Data.Fintype.Prod"
+      },
+      {
+        "theorem": "Nat.le_mul_of_pos_right",
+        "description": "n ≤ n * m when 0 < m. With Fintype.card_pos (a nonempty finite type has positive cardinality) this gives card α ≤ card α · card β, the engine of products reflecting solvability to their factors.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.mul_le_mul",
+        "description": "a ≤ b ∧ c ≤ d ⟹ a * c ≤ b * d. With 2 ≤ card α and 3 ≤ card β yields 6 ≤ card α · card β, forcing the product permutation group unsolvable.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Fintype.card_fin",
+        "description": "Fintype.card (Fin n) = n. Evaluates the concrete witness Perm (Fin 2 ⊕ Fin 3) at 5 points for the non-preservation counterexample.",
+        "module": "Mathlib.Data.Fintype.Card"
+      }
+    ],
+    "originalContributions": [
+      "perm_sum_solvable_iff: Perm (α ⊕ β) solvable ↔ card α + card β ≤ 4 — the Abel–Ruffini threshold under disjoint union, an additive side-condition on the combined point count",
+      "perm_prod_solvable_iff: Perm (α × β) solvable ↔ card α · card β ≤ 4 — the threshold under Cartesian product, a multiplicative side-condition",
+      "alternating_sum_solvable_iff: the same additive threshold for the alternating group Aₐ, via the intrinsic alternating classification",
+      "perm_solvable_of_prod_solvable / perm_solvable_of_prod_solvable': products REFLECT solvability to their factors — for nonempty complementary factor, solvability of Perm (α × β) forces solvability of each factor, because card α ≤ card α · card β",
+      "perm_prod_not_solvable_of_factors: multiplicative escape — 2 ≤ card α and 3 ≤ card β force Perm (α × β) unsolvable (card ≥ 6); the minimal unsolvable product of two factors is 2 · 3",
+      "perm_sum_solvability_not_preserved: solvability is NOT preserved by ⊕ — Perm (Fin 2) and Perm (Fin 3) are solvable yet Perm (Fin 2 ⊕ Fin 3) is not, the structural opposite of the product behaviour",
+      "abel_ruffini_is_additive_escape: 5 is the minimal additive escape of the solvable cardinalities — a sum of two solvable cardinalities (2 + 3), unsolvable, and the least such; {0,1,2,3,4} first breaks additive closure exactly at the Abel–Ruffini degree",
+      "product_reflects_sum_does_not: the closure dichotomy packaged — solvability is reflected by products but not preserved by sums, the two operations sitting on opposite sides of the boundary"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 188,
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used. All thresholds rewrite the parent chain's intrinsic classification (perm_solvable_iff_card / alternating_solvable_iff_card) through Fintype.card_sum / Fintype.card_prod; the reflection and escape lemmas use only elementary Nat arithmetic (Nat.le_mul_of_pos_right, Nat.mul_le_mul, omega). `#print axioms` on all main results reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "additionalFiles": [],
+    "relatedProblems": [
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01",
+        "relationship": "Parent — proved the unsolvable cardinalities form the up-set {≥5} and the solvable ones the down-set {≤4}, partitioning ℕ at the boundary 5. This entry takes the same threshold and studies how it behaves under the type operations ⊕ and ×, exhibiting the additive-closure failure {2 + 3 = 5} as the combinatorial seed of that boundary."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+        "relationship": "Grandparent — the intrinsic threshold IsSolvable (Perm α) ↔ Fintype.card α ≤ 4 and its alternating analogue. perm_sum_solvable_iff / perm_prod_solvable_iff / alternating_sum_solvable_iff rewrite it through Fintype.card_sum and Fintype.card_prod."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+        "relationship": "Ancestor — the Aα ↔ Sα solvability bridge, supplying the intrinsic alternating classification behind alternating_sum_solvable_iff."
+      },
+      {
+        "id": "abel-ruffini",
+        "relationship": "Ancestor — Abel–Ruffini rests on S₅ being non-solvable. abel_ruffini_is_additive_escape recovers 5 as the minimal additive escape of the solvable cardinalities, the combinatorial form of the boundary; perm_sum_solvability_not_preserved exhibits Fin 2 ⊕ Fin 3 as the smallest disjoint union manufacturing it."
+      }
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Solvable",
+      "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Mathlib.GroupTheory.Perm.ViaEmbedding",
+      "Mathlib.Tactic",
+      "Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Equiv"
+    ],
+    "namespace": "AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01",
+    "lineCount": 188,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "perm_sum_solvable_iff",
+        "type": "core",
+        "description": "Sum threshold: Perm (α ⊕ β) is solvable iff the combined point count card α + card β is at most 4.",
+        "leanType": "[DecidableEq α] → [DecidableEq β] → [Fintype α] → [Fintype β] → (IsSolvable (Perm (α ⊕ β)) ↔ Fintype.card α + Fintype.card β ≤ 4)",
+        "line": 63
+      },
+      {
+        "name": "perm_prod_solvable_iff",
+        "type": "core",
+        "description": "Product threshold: Perm (α × β) is solvable iff the combined point count card α · card β is at most 4.",
+        "leanType": "[DecidableEq α] → [DecidableEq β] → [Fintype α] → [Fintype β] → (IsSolvable (Perm (α × β)) ↔ Fintype.card α * Fintype.card β ≤ 4)",
+        "line": 70
+      },
+      {
+        "name": "perm_solvable_of_prod_solvable",
+        "type": "key",
+        "description": "Products reflect solvability to their factors: if β is nonempty and Perm (α × β) is solvable, then Perm α is solvable, because card α ≤ card α · card β.",
+        "leanType": "[Nonempty β] → IsSolvable (Perm (α × β)) → IsSolvable (Perm α)",
+        "line": 93
+      },
+      {
+        "name": "perm_prod_not_solvable_of_factors",
+        "type": "key",
+        "description": "Multiplicative escape: 2 ≤ card α and 3 ≤ card β force Perm (α × β) unsolvable (card ≥ 6); the minimal unsolvable product of two factors is 2 · 3.",
+        "leanType": "(2 ≤ Fintype.card α) → (3 ≤ Fintype.card β) → ¬ IsSolvable (Perm (α × β))",
+        "line": 119
+      },
+      {
+        "name": "perm_sum_solvability_not_preserved",
+        "type": "core",
+        "description": "Solvability is not preserved by ⊕: Perm (Fin 2) and Perm (Fin 3) are solvable, yet Perm (Fin 2 ⊕ Fin 3) is not — the structural opposite of the product behaviour.",
+        "leanType": "IsSolvable (Perm (Fin 2)) ∧ IsSolvable (Perm (Fin 3)) ∧ ¬ IsSolvable (Perm (Fin 2 ⊕ Fin 3))",
+        "line": 145
+      },
+      {
+        "name": "abel_ruffini_is_additive_escape",
+        "type": "specialization",
+        "description": "5 is the minimal additive escape of the solvable cardinalities: a sum of two solvable cardinalities (2 + 3), unsolvable, and the least such — {0,1,2,3,4} first breaks additive closure exactly at the Abel–Ruffini degree.",
+        "leanType": "(∃ m n, m ≤ 4 ∧ n ≤ 4 ∧ m + n = 5 ∧ ¬ IsSolvable (Perm (Fin (m + n)))) ∧ (∀ m n, m ≤ 4 → n ≤ 4 → ¬ IsSolvable (Perm (Fin (m + n))) → 5 ≤ m + n)",
+        "line": 165
+      }
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "product_reflects_sum_does_not",
+      "statement": "Solvability of symmetric groups is reflected by Cartesian products (a factor of a solvable product is solvable) but is not preserved by disjoint unions (a sum of solvable pieces can be unsolvable).",
+      "significance": "Reads the Abel–Ruffini threshold through the two monoidal structures on finite types and isolates their asymmetry: products inherit solvability downward, sums do not, and the additive failure 2 + 3 = 5 is exactly the minimal unsolvable degree."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Documentation and Imports",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Module docstring framing the goal (how the solvability threshold interacts with ⊕ and ×) and the headline asymmetry (products reflect, sums do not). Imports Mathlib.GroupTheory.Solvable, SpecificGroups.Alternating, Perm.ViaEmbedding, Mathlib.Tactic, and the parent chain Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01.",
+      "mathContext": "The parent chain supplies perm_solvable_iff_card, alternating_solvable_iff_card and the up-set predicate not_solvable_perm_card_eq_ge_five; Mathlib supplies Fintype.card_sum and Fintype.card_prod."
+    },
+    {
+      "id": "thresholds",
+      "title": "§1 The threshold under ⊕ and ×",
+      "startLine": 57,
+      "endLine": 82,
+      "summary": "perm_sum_solvable_iff and perm_prod_solvable_iff rewrite the intrinsic threshold through Fintype.card_sum / Fintype.card_prod into additive and multiplicative side-conditions; alternating_sum_solvable_iff gives the additive form for the alternating group.",
+      "mathContext": "Fintype.card_sum and Fintype.card_prod evaluate the cardinality of the two constructions, so perm_solvable_iff_card (card ≤ 4) becomes an arithmetic condition on the cardinalities of the pieces."
+    },
+    {
+      "id": "products-reflect",
+      "title": "§2 Products reflect solvability to their factors",
+      "startLine": 83,
+      "endLine": 130,
+      "summary": "perm_solvable_of_prod_solvable(') use card α ≤ card α · card β (Nat.le_mul_of_pos_right with Fintype.card_pos) to descend solvability of the product to each factor; perm_prod_not_solvable_of_factors gives the multiplicative escape 2 · 3 ≥ 6.",
+      "mathContext": "A nonempty second factor only grows the carrier, so the product threshold card α · card β ≤ 4 implies each factor's threshold; conversely two moderately sized factors overshoot the boundary."
+    },
+    {
+      "id": "sums-fail",
+      "title": "§3 Disjoint unions do not preserve solvability",
+      "startLine": 131,
+      "endLine": 162,
+      "summary": "perm_sum_fin_two_three_not_solvable evaluates the 5-point union as unsolvable; perm_sum_solvability_not_preserved packages the contrast — both pieces solvable, union not.",
+      "mathContext": "Solvability of the pieces says nothing about solvability of their union: two solvable permutation groups on 2 and 3 points combine to one on 5 points, the Abel–Ruffini obstruction in combinatorial form."
+    },
+    {
+      "id": "boundary",
+      "title": "§4 The boundary as the minimal additive escape",
+      "startLine": 163,
+      "endLine": 188,
+      "summary": "abel_ruffini_is_additive_escape shows 5 is a sum of two solvable cardinalities, unsolvable, and the least such; product_reflects_sum_does_not states the closure dichotomy as a single side-by-side theorem.",
+      "mathContext": "The solvable set {0,1,2,3,4} first breaks additive closure exactly at the Abel–Ruffini degree 5; products and sums sit on opposite sides of that boundary."
+    }
+  ],
+  "sorries": [],
+  "references": [
+    {
+      "authors": [
+        "C. Jordan"
+      ],
+      "title": "Traité des substitutions et des équations algébriques",
+      "year": "1870",
+      "venue": "Gauthier-Villars, Paris",
+      "note": "Sₙ and Aₙ solvable iff n ≤ 4; the inheritance of non-solvability with degree."
+    },
+    {
+      "authors": [
+        "É. Galois"
+      ],
+      "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
+      "year": "1846",
+      "venue": "Journal de Mathématiques Pures et Appliquées (published posthumously)",
+      "note": "Solvability by radicals iff solvable Galois group; S₅ as the minimal obstruction inherited by every higher degree."
+    },
+    {
+      "authors": [
+        "I. Stewart"
+      ],
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "Chapman and Hall/CRC, 4th edition",
+      "note": "Sₙ and Aₙ solvable iff n ≤ 4; subgroup-closure of solvability."
+    },
+    {
+      "authors": [
+        "The mathlib Community"
+      ],
+      "title": "The Lean Mathematical Library — Data.Fintype.Sum, Data.Fintype.Prod and GroupTheory.Solvable",
+      "year": "2020",
+      "venue": "Lean 4 / Mathlib",
+      "note": "Source of Fintype.card_sum, Fintype.card_prod, Nat.le_mul_of_pos_right and Nat.mul_le_mul, the arithmetic engines of the ⊕/× thresholds."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent up-set / down-set partition of ℕ at the boundary 5. This entry studies the same threshold under the type operations ⊕ and ×, exhibiting the additive-closure failure 2 + 3 = 5 as the combinatorial seed of the boundary."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent intrinsic threshold IsSolvable (Perm α) ↔ Fintype.card α ≤ 4, rewritten here through Fintype.card_sum and Fintype.card_prod into additive and multiplicative side-conditions."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "Abel–Ruffini rests on S₅ non-solvable; abel_ruffini_is_additive_escape recovers 5 as the minimal additive escape of the solvable cardinalities, and perm_sum_solvability_not_preserved gives Fin 2 ⊕ Fin 3 as the smallest disjoint union manufacturing it."
+    }
+  ]
+}

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,89 @@
+[
+  {
+    "id": "ann-upset-overview",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "concept",
+    "title": "The dual face: from a down-set to an up-set",
+    "content": "The parent showed the solvable cardinalities form a **down-set**: $\\{n : \\mathrm{IsSolvable}(S_{\\mathrm{Fin}\\,n})\\} = \\{0,1,2,3,4\\}$, downward closed under injections. This entry proves the complementary face. The non-solvable cardinalities form an **up-set**:\n$$\\alpha \\hookrightarrow \\beta \\ \\wedge\\ \\neg\\,\\mathrm{IsSolvable}(S_\\alpha) \\ \\Longrightarrow\\ \\neg\\,\\mathrm{IsSolvable}(S_\\beta).$$\nThis is not a new mechanism but the **contrapositive** of the parent's `perm_solvable_of_embedding`, carrying equal structural weight: where solvability flows *down* an injection, non-solvability flows *up*. The two faces are order-complements partitioning $\\mathbb{N}$, meeting at the Abel–Ruffini boundary $n = 5$.",
+    "mathContext": "An order-complementary pair: the down-set {≤4} of solvable cardinalities and the up-set {≥5} of non-solvable ones. solvable_unsolvable_partition and boundary_is_successor make the partition and its meeting point explicit.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "symmetric group",
+      "solvable group",
+      "up-set / upper set",
+      "order complement",
+      "contrapositive of subgroup closure"
+    ],
+    "prerequisites": [
+      "group theory",
+      "solvable groups",
+      "permutation groups",
+      "order theory (up-sets and down-sets)"
+    ]
+  },
+  {
+    "id": "ann-structural-ascent",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01",
+    "range": { "startLine": 45, "endLine": 60 },
+    "type": "technique",
+    "title": "Non-solvability flows up an injection",
+    "content": "`perm_not_solvable_of_embedding` is the exact contrapositive of the parent's structural descent. Given $e : \\alpha \\hookrightarrow \\beta$ and $\\neg\\,\\mathrm{IsSolvable}(S_\\alpha)$, assume for contradiction that $S_\\beta$ is solvable; register that assumption as a typeclass instance (`haveI := hβ`), then the parent's `perm_solvable_of_embedding e` produces solvability of $S_\\alpha$, contradicting the hypothesis:\n```\nintro hβ; haveI := hβ\nexact hα (perm_solvable_of_embedding e)\n```\nThe mathematical content is the contrapositive of 'subgroups of solvable groups are solvable': a group containing an unsolvable subgroup ($S_\\alpha \\hookrightarrow S_\\beta$ via $\\texttt{viaEmbeddingHom}$) cannot itself be solvable. No cardinalities, no appeal to the value $5$.",
+    "mathContext": "The instance dance `intro hβ; haveI := hβ` is needed because perm_solvable_of_embedding takes [IsSolvable (Perm β)] as a typeclass argument, not a plain hypothesis.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Equiv.Perm.viaEmbeddingHom_injective",
+      "solvable_of_solvable_injective",
+      "contrapositive",
+      "subgroup obstruction to solvability"
+    ],
+    "prerequisites": [
+      "group homomorphisms",
+      "subgroups of solvable groups",
+      "proof by contradiction",
+      "typeclass instances in Lean"
+    ]
+  },
+  {
+    "id": "ann-cardinality-face",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01",
+    "range": { "startLine": 61, "endLine": 86 },
+    "type": "technique",
+    "title": "Cardinality co-monotonicity, symmetric and alternating",
+    "content": "`perm_not_solvable_mono` turns the cardinality hypothesis $|\\alpha| \\le |\\beta|$ into an embedding via `Function.Embedding.nonempty_of_card_le` and feeds it to §1: a non-solvable $S_\\alpha$ forces a non-solvable $S_\\beta$. `alternating_not_solvable_mono` lifts this to alternating groups by sandwiching it between two uses of the grandparent bridge `sym_not_solvable_iff_alternating_not_solvable`: $\\neg\\,\\mathrm{IsSolvable}(A_\\alpha) \\to \\neg\\,\\mathrm{IsSolvable}(S_\\alpha) \\to \\neg\\,\\mathrm{IsSolvable}(S_\\beta) \\to \\neg\\,\\mathrm{IsSolvable}(A_\\beta)$. The sign extension is transparent to non-solvability in both families simultaneously.",
+    "mathContext": "A finite type embeds into another exactly when its cardinality is no larger, so structural ascent and cardinality co-monotonicity coincide once an embedding is produced.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "Function.Embedding.nonempty_of_card_le",
+      "alternating group",
+      "sign exact sequence",
+      "co-monotonicity"
+    ],
+    "prerequisites": [
+      "finite cardinality",
+      "alternating groups",
+      "the Aα ↔ Sα solvability bridge"
+    ]
+  },
+  {
+    "id": "ann-upset-partition",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01",
+    "range": { "startLine": 87, "endLine": 144 },
+    "type": "concept",
+    "title": "The up-set {≥5} and the partition at the boundary",
+    "content": "Negating the grandparent threshold $\\mathrm{IsSolvable}(S_{\\mathrm{Fin}\\,n}) \\iff n \\le 4$ through `Fintype.card_fin` gives `not_solvable_perm_card_eq_ge_five`: $\\neg\\,\\mathrm{IsSolvable}(S_{\\mathrm{Fin}\\,n}) \\iff 5 \\le n$. From it, `not_solvable_perm_card_isUpSet` (upward closure) and `five_is_min_unsolvable_card` ($5$ is the least non-solvable cardinality) are one `omega` each — the order-dual of the parent's `four_is_max_solvable_card`. The capstones tie the two faces together: `solvable_unsolvable_partition` shows every $n$ lies in exactly one of $\\{$solvable, $n<5\\}$ or $\\{$non-solvable, $n\\ge 5\\}$, and `boundary_is_successor` records that the maximal solvable cardinality $4$ and the minimal non-solvable one $5$ are adjacent — the Abel–Ruffini threshold as a single order-complement.",
+    "mathContext": "The negated predicate 5 ≤ n is upward closed, the set-theoretic complement of the parent's down-set predicate n ≤ 4; together they partition ℕ and the two extremal cardinalities are successive.",
+    "significance": "high",
+    "relatedConcepts": [
+      "up-set with minimum element",
+      "order complement",
+      "partition of ℕ",
+      "Abel–Ruffini boundary"
+    ],
+    "prerequisites": [
+      "order theory (up-sets, complements)",
+      "Fintype.card_fin",
+      "the symmetric-group solvability threshold"
+    ]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,245 @@
+{
+  "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01",
+  "slug": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01",
+  "title": "Non-Solvability of Sₐ is Upward Closed Under Injections",
+  "description": "The order-theoretic dual of the parent. Where the parent proved solvability of permutation groups is downward closed in the carrier — {n | IsSolvable (Perm (Fin n))} is the down-set {0,1,2,3,4} — this entry proves the complementary face: non-solvability is upward closed. The structural engine perm_not_solvable_of_embedding is the exact contrapositive of the parent's perm_solvable_of_embedding: if α ↪ β and Perm α is NOT solvable, then Perm β is NOT solvable, because an unsolvable permutation group cannot embed into a solvable one. From it, perm_not_solvable_mono and alternating_not_solvable_mono give the cardinality face, and not_solvable_perm_card_isUpSet packages {n | ¬ IsSolvable (Perm (Fin n))} as the up-set {n | 5 ≤ n}. Together with the parent the two faces partition ℕ as an order-complementary down-set / up-set pair (solvable_unsolvable_partition), meeting at the Abel–Ruffini boundary where the least unsolvable cardinality 5 is the successor of the greatest solvable one 4 (five_is_min_unsolvable_card, boundary_is_successor).",
+  "overview": {
+    "historicalContext": "That S₅ is non-solvable is the algebraic obstruction underlying the Abel–Ruffini theorem, and the reason the general quintic is not solvable by radicals. But the threshold cannot rise as the degree grows: because Sₘ embeds in Sₙ for m ≤ n (fix the last n − m points), once S₅ fails to be solvable every Sₙ with n ≥ 5 contains a non-solvable subgroup and so is itself non-solvable. The parent entry exposed the down-set structure of the solvable cardinalities; this entry isolates the dual statement that the non-solvable cardinalities are an up-set, the precise sense in which non-solvability, once it appears, is permanent under enlarging the carrier.",
+    "modernSignificance": "Subgroup-closure of solvability has a contrapositive of equal structural weight: a group with an unsolvable subgroup is itself unsolvable. Applied to the functor Perm on finite sets and injections, this makes non-solvability a covariant (upward) property of the carrier — the mirror of the parent's contravariant solvability. Stating it via the same injective hom Equiv.Perm.viaEmbeddingHom keeps the argument cardinality-free; the up-set packaging (5 is the minimum non-solvable cardinality) is the order-theoretic seed of Abel–Ruffini, and pairing it with the parent's down-set exhibits the full solvability dichotomy of symmetric groups as a single order-complement at the boundary n = 5."
+  },
+  "meta": {
+    "author": "Classical (subgroup monotonicity of Sₙ); upward-closure formalization original",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Symmetric_group",
+    "date": "1870",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "solvability",
+      "alternating-group",
+      "symmetric-group",
+      "embedding",
+      "monotonicity",
+      "up-set",
+      "classification",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Equiv.Perm.viaEmbeddingHom_injective",
+        "description": "viaEmbeddingHom e is injective, realizing Perm α as a subgroup of Perm β. Reused from the parent's structural descent, now read contrapositively to obstruct solvability of Perm β.",
+        "module": "Mathlib.GroupTheory.Perm.ViaEmbedding"
+      },
+      {
+        "theorem": "solvable_of_solvable_injective",
+        "description": "An injective group hom into a solvable group forces the domain solvable. Its contrapositive — an unsolvable domain forces the codomain unsolvable — is the content of perm_not_solvable_of_embedding.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "Function.Embedding.nonempty_of_card_le",
+        "description": "For finite types, Fintype.card α ≤ Fintype.card β yields an embedding α ↪ β. Converts the cardinality hypothesis into the embedding the structural lemma consumes.",
+        "module": "Mathlib.Logic.Embedding.Basic"
+      },
+      {
+        "theorem": "Fintype.card_fin",
+        "description": "Fintype.card (Fin n) = n. Turns the carrier-intrinsic threshold into the arithmetic predicate 5 ≤ n for the up-set packaging.",
+        "module": "Mathlib.Data.Fintype.Card"
+      }
+    ],
+    "originalContributions": [
+      "perm_not_solvable_of_embedding: the exact contrapositive of the parent's perm_solvable_of_embedding — if α ↪ β and Perm α is NOT solvable then Perm β is NOT solvable, with NO cardinality count. Non-solvability flows UP an injection.",
+      "perm_not_solvable_mono: card α ≤ card β ∧ ¬ IsSolvable (Perm α) ⟹ ¬ IsSolvable (Perm β), the cardinality face of the structural ascent",
+      "alternating_not_solvable_mono: the same co-monotonicity for alternating groups, routed through the grandparent bridge sym_not_solvable_iff_alternating_not_solvable",
+      "not_solvable_perm_card_isUpSet: {n | ¬ IsSolvable (Perm (Fin n))} is upward closed (m ≤ n ∧ ¬ solvable m ⟹ ¬ solvable n) — the up-set {n | 5 ≤ n}",
+      "five_is_min_unsolvable_card: 5 is the minimum cardinality with non-solvable Perm — the order-dual of the parent's four_is_max_solvable_card",
+      "solvable_unsolvable_partition + boundary_is_successor: the solvable down-set {≤4} and unsolvable up-set {≥5} are order-complementary and partition ℕ, meeting at the Abel–Ruffini boundary where 5 = 4 + 1"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 144,
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used. perm_not_solvable_of_embedding is the contrapositive of the parent's structural descent and depends only on Mathlib (viaEmbeddingHom_injective, solvable_of_solvable_injective); the cardinality and up-set corollaries depend transitively on the parent's classification, which is decide-based and native_decide-free. `#print axioms` on all main results reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "additionalFiles": [],
+    "relatedProblems": [
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01",
+        "relationship": "Parent — proved solvability of Perm is downward closed under injections ({n | solvable} = down-set {0,1,2,3,4}). This entry is the order-theoretic dual: non-solvability is upward closed, and perm_not_solvable_of_embedding is the literal contrapositive of the parent's perm_solvable_of_embedding."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+        "relationship": "Grandparent — the intrinsic threshold IsSolvable (Perm α) ↔ Fintype.card α ≤ 4. not_solvable_perm_card_eq_ge_five negates it through Fintype.card_fin to obtain the up-set predicate 5 ≤ n."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+        "relationship": "Ancestor — the Aα ↔ Sα solvability bridge. alternating_not_solvable_mono routes the alternating co-monotonicity through its sym_not_solvable_iff_alternating_not_solvable."
+      },
+      {
+        "id": "abel-ruffini",
+        "relationship": "Ancestor — Abel–Ruffini rests on S₅ being non-solvable; five_is_min_unsolvable_card is the order-theoretic statement that 5 is the minimal non-solvable cardinality, and not_solvable_perm_card_isUpSet is the structural reason no larger Sₙ recovers solvability."
+      }
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Solvable",
+      "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Mathlib.GroupTheory.Perm.ViaEmbedding",
+      "Mathlib.Tactic",
+      "Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01"
+    ],
+    "opens": [
+      "Equiv"
+    ],
+    "namespace": "AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "perm_not_solvable_of_embedding",
+        "type": "core",
+        "description": "Structural ascent (contrapositive of perm_solvable_of_embedding): an embedding α ↪ β with Perm α NOT solvable forces Perm β NOT solvable. An unsolvable permutation group cannot embed into a solvable one. No cardinality, no classification.",
+        "leanType": "(e : α ↪ β) → ¬ IsSolvable (Perm α) → ¬ IsSolvable (Perm β)",
+        "line": 55
+      },
+      {
+        "name": "perm_not_solvable_mono",
+        "type": "core",
+        "description": "Cardinality co-monotonicity for symmetric groups: Fintype.card α ≤ Fintype.card β and ¬ IsSolvable (Perm α) force ¬ IsSolvable (Perm β).",
+        "leanType": "[Fintype α] → [Fintype β] → (Fintype.card α ≤ Fintype.card β) → ¬ IsSolvable (Perm α) → ¬ IsSolvable (Perm β)",
+        "line": 68
+      },
+      {
+        "name": "alternating_not_solvable_mono",
+        "type": "key",
+        "description": "Cardinality co-monotonicity for alternating groups, transported through the grandparent bridge sym_not_solvable_iff_alternating_not_solvable.",
+        "leanType": "(Fintype.card α ≤ Fintype.card β) → ¬ IsSolvable (alternatingGroup α) → ¬ IsSolvable (alternatingGroup β)",
+        "line": 77
+      },
+      {
+        "name": "not_solvable_perm_card_isUpSet",
+        "type": "specialization",
+        "description": "The non-solvable cardinalities are upward closed: m ≤ n and ¬ IsSolvable (Perm (Fin m)) force ¬ IsSolvable (Perm (Fin n)).",
+        "leanType": "{m n : ℕ} → (m ≤ n) → ¬ IsSolvable (Perm (Fin m)) → ¬ IsSolvable (Perm (Fin n))",
+        "line": 103
+      },
+      {
+        "name": "five_is_min_unsolvable_card",
+        "type": "specialization",
+        "description": "5 is the least cardinality with non-solvable symmetric group: Perm (Fin 5) is not solvable, and any non-solvable Perm (Fin n) has n ≥ 5. The order-dual of the parent's four_is_max_solvable_card.",
+        "leanType": "¬ IsSolvable (Perm (Fin 5)) ∧ ∀ n, ¬ IsSolvable (Perm (Fin n)) → 5 ≤ n",
+        "line": 111
+      },
+      {
+        "name": "solvable_unsolvable_partition",
+        "type": "specialization",
+        "description": "The solvable down-set {≤4} and the unsolvable up-set {≥5} partition ℕ: every n lies in exactly one of the two faces.",
+        "leanType": "(n : ℕ) → (IsSolvable (Perm (Fin n)) ∧ ¬ (5 ≤ n)) ∨ (¬ IsSolvable (Perm (Fin n)) ∧ 5 ≤ n)",
+        "line": 127
+      }
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "perm_not_solvable_of_embedding",
+      "statement": "An embedding α ↪ β with Perm α not solvable forces Perm β not solvable — non-solvability of permutation groups is upward closed under injections.",
+      "significance": "The contrapositive of the parent's downward-closure: it is the structural reason the non-solvability of S₅ is inherited by every larger symmetric group, the order-theoretic seed of Abel–Ruffini."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Documentation and Imports",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring framing the goal (the order-theoretic dual of the parent: non-solvability is an up-set) and naming the engine (the contrapositive of perm_solvable_of_embedding). Imports Mathlib.GroupTheory.Solvable, SpecificGroups.Alternating, Perm.ViaEmbedding, Mathlib.Tactic, and the parent Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01.",
+      "mathContext": "The parent supplies perm_solvable_of_embedding, perm_solvable_iff_card, solvable_perm_card_eq_le_four and four_is_max_solvable_card; the grandparent-bridge supplies sym_not_solvable_iff_alternating_not_solvable."
+    },
+    {
+      "id": "structural",
+      "title": "§1 Structural co-monotonicity along an embedding",
+      "startLine": 45,
+      "endLine": 60,
+      "summary": "perm_not_solvable_of_embedding: assume Perm β solvable, register it as an instance, and apply the parent's perm_solvable_of_embedding to contradict the unsolvability of Perm α. Non-solvability flows up the injection.",
+      "mathContext": "Perm is functorial on injections and solvability is subgroup-closed; the contrapositive of 'subgroups of solvable groups are solvable' is 'a group containing an unsolvable subgroup is unsolvable'."
+    },
+    {
+      "id": "cardinality",
+      "title": "§2 The cardinality face",
+      "startLine": 61,
+      "endLine": 86,
+      "summary": "perm_not_solvable_mono converts card α ≤ card β into an embedding (Function.Embedding.nonempty_of_card_le) and applies §1; alternating_not_solvable_mono transports the conclusion across the grandparent bridge to alternating groups.",
+      "mathContext": "A finite type embeds into another exactly when its cardinality is no larger, so the structural ascent of §1 is precisely cardinality co-monotonicity once an embedding is produced."
+    },
+    {
+      "id": "upset",
+      "title": "§3 The up-set packaging and the dichotomy",
+      "startLine": 87,
+      "endLine": 144,
+      "summary": "not_solvable_perm_card_eq_ge_five negates perm_solvable_iff_card via Fintype.card_fin; not_solvable_perm_card_isUpSet and five_is_min_unsolvable_card present {n | ¬ solvable (Perm (Fin n))} = {n | 5 ≤ n} as an up-set with minimum 5; not_solvable_iff_not_le_four, solvable_unsolvable_partition and boundary_is_successor exhibit the down-set/up-set order-complement meeting at n = 5.",
+      "mathContext": "The negated threshold 5 ≤ n is upward closed, the order-complement of the parent's down-set n ≤ 4; the two partition ℕ and meet at the Abel–Ruffini boundary, where the minimal non-solvable cardinality 5 is the successor of the maximal solvable one 4."
+    }
+  ],
+  "sorries": [],
+  "references": [
+    {
+      "authors": [
+        "C. Jordan"
+      ],
+      "title": "Traité des substitutions et des équations algébriques",
+      "year": "1870",
+      "venue": "Gauthier-Villars, Paris",
+      "note": "Aₙ simple for n ≥ 5; the embedding Sₘ ↪ Sₙ and the inheritance of non-solvability with degree."
+    },
+    {
+      "authors": [
+        "É. Galois"
+      ],
+      "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
+      "year": "1846",
+      "venue": "Journal de Mathématiques Pures et Appliquées (published posthumously)",
+      "note": "Solvability by radicals iff solvable Galois group; S₅ as the minimal obstruction inherited by every higher degree."
+    },
+    {
+      "authors": [
+        "I. Stewart"
+      ],
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "Chapman and Hall/CRC, 4th edition",
+      "note": "Sₙ and Aₙ solvable iff n ≤ 4; a group with an unsolvable subgroup is unsolvable."
+    },
+    {
+      "authors": [
+        "The mathlib Community"
+      ],
+      "title": "The Lean Mathematical Library — GroupTheory.Perm.ViaEmbedding and GroupTheory.Solvable",
+      "year": "2020",
+      "venue": "Lean 4 / Mathlib",
+      "note": "Source of Equiv.Perm.viaEmbeddingHom_injective and solvable_of_solvable_injective, whose contrapositive drives the upward closure."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent downward-closure of solvability ({n | solvable} = down-set {0,1,2,3,4}). This entry is its order-theoretic dual: non-solvability is upward closed, and perm_not_solvable_of_embedding is the literal contrapositive of perm_solvable_of_embedding."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent intrinsic threshold IsSolvable (Perm α) ↔ Fintype.card α ≤ 4, negated here through Fintype.card_fin to the up-set predicate 5 ≤ n."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "Abel–Ruffini rests on S₅ non-solvable; five_is_min_unsolvable_card states that 5 is the minimal non-solvable cardinality and the up-set property explains why no larger Sₙ recovers solvability."
+    }
+  ]
+}

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01/annotations.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": "ann-downset-overview",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "From a threshold to a down-set",
+    "content": "The parent proved a single-carrier statement: $\\mathrm{IsSolvable}(S_\\alpha) \\iff |\\alpha| \\le 4$. Read as a subset of $\\mathbb{N}$, $\\{n : \\mathrm{IsSolvable}(S_{\\mathrm{Fin}\\,n})\\} = \\{0,1,2,3,4\\}$ — but the *threshold form* of the theorem does not, by itself, say this set is **downward closed**; that is an extra structural fact. This entry isolates it. The headline is not the number $4$ but the implication\n$$\\alpha \\hookrightarrow \\beta \\ \\wedge\\ \\mathrm{IsSolvable}(S_\\beta) \\ \\Longrightarrow\\ \\mathrm{IsSolvable}(S_\\alpha),$$\nproved with no cardinality count at all. Monotonicity is logically *prior* to the value of the boundary: it is the reason the threshold is a down-set rather than an arbitrary subset.",
+    "mathContext": "Two independent proofs of cardinality-monotonicity are given and shown to coincide (mono_routes_agree): the embedding/subgroup route (§1–2) and the arithmetic route from the parent threshold (§3).",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "symmetric group",
+      "solvable group",
+      "down-set / lower set",
+      "monotonicity",
+      "subgroup closure of solvability"
+    ],
+    "prerequisites": [
+      "group theory",
+      "solvable groups",
+      "permutation groups",
+      "order theory (down-sets)"
+    ]
+  },
+  {
+    "id": "ann-structural-descent",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01",
+    "range": { "startLine": 49, "endLine": 66 },
+    "type": "technique",
+    "title": "Functoriality of Perm along injections",
+    "content": "`perm_solvable_of_embedding` is a two-line proof with real content. An embedding $e : \\alpha \\hookrightarrow \\beta$ acts on permutations: a permutation of $\\alpha$ is pushed to a permutation of $\\beta$ that fixes everything outside the image of $e$. Mathlib packages this as the group hom $\\texttt{Equiv.Perm.viaEmbeddingHom}\\,e : S_\\alpha \\to^* S_\\beta$, and `viaEmbeddingHom_injective` says it is injective. So $S_\\alpha$ is (isomorphic to) a subgroup of $S_\\beta$. Solvability is closed under subgroups — equivalently, under injective preimages — which is exactly `solvable_of_solvable_injective`. Composing the two:\n```\nsolvable_of_solvable_injective (Perm.viaEmbeddingHom_injective e)\n```\nNo cardinalities, no appeal to the value $4$. This is the abstract reason behind the numerical threshold.",
+    "mathContext": "Perm is a functor from finite sets with injections to groups; IsSolvable is a subgroup-closed group property, hence contravariant (downward) in the carrier.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Equiv.Perm.viaEmbeddingHom",
+      "injective group homomorphism",
+      "subgroups of solvable groups",
+      "functoriality"
+    ],
+    "prerequisites": [
+      "group homomorphisms",
+      "subgroups",
+      "embeddings"
+    ]
+  },
+  {
+    "id": "ann-cardinality-face",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 95 },
+    "type": "technique",
+    "title": "Cardinality ≤ becomes an embedding",
+    "content": "To turn the structural lemma into a statement about $\\texttt{Fintype.card}$, one only needs that $|\\alpha| \\le |\\beta|$ produces an embedding $\\alpha \\hookrightarrow \\beta$ — `Function.Embedding.nonempty_of_card_le`. Destructuring the resulting `Nonempty` and feeding the witness to `perm_solvable_of_embedding` gives `perm_solvable_mono`. The alternating version `alternating_solvable_mono` does not need a new idea: the parent bridge `alternating_solvable_iff_sym_solvable` converts solvability of $A_\\beta$ to solvability of $S_\\beta$, applies the symmetric monotonicity, then converts back to $A_\\alpha$.",
+    "mathContext": "For finite types, card α ≤ card β ⟺ ∃ embedding α ↪ β, so cardinality-monotonicity is exactly the structural descent specialized.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "Fintype.card",
+      "Function.Embedding.nonempty_of_card_le",
+      "alternating group bridge"
+    ],
+    "prerequisites": [
+      "finite types",
+      "cardinality and embeddings"
+    ]
+  },
+  {
+    "id": "ann-routes-agree-downset",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01",
+    "range": { "startLine": 96, "endLine": 127 },
+    "type": "insight",
+    "title": "Two proofs of the same down-closedness",
+    "content": "`mono_routes_agree` re-proves the monotone implication a second way: rewrite both `IsSolvable (Perm β)` and the goal through the parent threshold `perm_solvable_iff_card`, leaving the pure arithmetic goal $|\\beta| \\le 4 \\to |\\alpha| \\le 4$ under $|\\alpha| \\le |\\beta|$, closed by `omega`. That the abstract subgroup-descent of §1 and this arithmetic both establish the same implication is the precise sense in which 'subgroup descent' and 'the down-closedness of $n \\le 4$' are one statement. The remaining lemmas package the consequence: `solvable_perm_card_isDownSet` (the solvable cardinalities are closed downward) and `four_is_max_solvable_card` ($4$ is the maximum solvable cardinality — the order-theoretic shadow of $S_5$ being the minimal non-solvable symmetric group).",
+    "mathContext": "A bounded down-set of ℕ with maximum 4 is exactly {0,1,2,3,4}; 5 is its minimal exclusion, which is the seed of Abel–Ruffini.",
+    "significance": "high",
+    "relatedConcepts": [
+      "down-set with maximum",
+      "minimal non-solvable group",
+      "S₅",
+      "omega"
+    ],
+    "prerequisites": [
+      "order theory",
+      "the parent cardinality threshold"
+    ]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01/meta.json
@@ -1,0 +1,236 @@
+{
+  "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01",
+  "slug": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01",
+  "title": "Solvability of Sₐ is Downward Closed Under Injections",
+  "description": "The parent proved the intrinsic threshold IsSolvable (Perm α) ↔ Fintype.card α ≤ 4. This entry extracts the order-structural consequence the threshold form hides: solvability of permutation groups is monotone in the carrier. The structural reason is perm_solvable_of_embedding — an embedding α ↪ β realizes Perm α as a subgroup of Perm β through Mathlib's injective hom Equiv.Perm.viaEmbeddingHom, so solvability of the larger permutation group descends to the smaller, with NO cardinality count and NO classification. From it, perm_solvable_mono and alternating_solvable_mono give the cardinality face (card α ≤ card β ∧ solvable β ⟹ solvable α), and solvable_perm_card_isDownSet packages {n | IsSolvable (Perm (Fin n))} as the down-set {0,1,2,3,4}. The embedding route and the arithmetic threshold route agree (mono_routes_agree): abstract subgroup descent and the down-closedness of n ≤ 4 are the same statement.",
+  "overview": {
+    "historicalContext": "That Sₘ is a subgroup of Sₙ for m ≤ n — fix the last n − m points and permute the first m — is one of the oldest observations about symmetric groups, and the immediate reason the solvable-by-radicals threshold cannot rise as the degree grows: once S₅ is non-solvable, every Sₙ with n ≥ 5 inherits a non-solvable subgroup and so is itself non-solvable. The parent entry phrased the Galois/Ruffini–Abel classification as an iff with Fintype.card α ≤ 4 on a single carrier. The monotonicity that makes that threshold a genuine down-set — solvable on a small set whenever solvable on a larger one — is logically prior to the exact value 4, and is what this entry isolates and formalizes.",
+    "modernSignificance": "Carrier-monotonicity is the functorial content of the classification: Perm is a functor from the category of finite sets and injections to groups, and IsSolvable is a property of groups closed under subgroups, so solvability of permutation groups is a contravariant (downward) property in the carrier. Stating it via Equiv.Perm.viaEmbeddingHom keeps the proof free of any cardinality count — it is the abstract reason behind the numerical threshold, not a corollary of it. The down-set packaging (4 is the maximum solvable cardinality) is the order-theoretic shadow of S₅ being the minimal non-solvable symmetric group, the seed of Abel–Ruffini."
+  },
+  "meta": {
+    "author": "Classical (subgroup monotonicity of Sₙ); structural-descent formalization original",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Symmetric_group",
+    "date": "1870",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "solvability",
+      "alternating-group",
+      "symmetric-group",
+      "embedding",
+      "monotonicity",
+      "down-set",
+      "classification",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Equiv.Perm.viaEmbeddingHom",
+        "description": "An embedding e : α ↪ β as a group hom Perm α →* Perm β: a permutation of α is extended by the identity off the image of e. The functorial action of Perm on injections.",
+        "module": "Mathlib.GroupTheory.Perm.ViaEmbedding"
+      },
+      {
+        "theorem": "Equiv.Perm.viaEmbeddingHom_injective",
+        "description": "viaEmbeddingHom e is injective, so it realizes Perm α as a subgroup of Perm β. The hinge of the structural descent.",
+        "module": "Mathlib.GroupTheory.Perm.ViaEmbedding"
+      },
+      {
+        "theorem": "solvable_of_solvable_injective",
+        "description": "An injective group hom f : G →* G' with G' solvable forces G solvable (G embeds as a subgroup of a solvable group). Composed with viaEmbeddingHom_injective to descend solvability.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "Function.Embedding.nonempty_of_card_le",
+        "description": "For finite types, Fintype.card α ≤ Fintype.card β yields a (nonempty) embedding α ↪ β. Converts the cardinality hypothesis into the embedding the structural lemma consumes.",
+        "module": "Mathlib.Logic.Embedding.Basic"
+      }
+    ],
+    "originalContributions": [
+      "perm_solvable_of_embedding: an embedding α ↪ β descends solvability Perm β ⟹ Perm α via viaEmbeddingHom — carrier-monotonicity of permutation-group solvability, with NO cardinality count and NO appeal to the n ≤ 4 threshold",
+      "perm_solvable_mono: card α ≤ card β ∧ IsSolvable (Perm β) ⟹ IsSolvable (Perm α), the cardinality face of the structural descent",
+      "alternating_solvable_mono: the same monotonicity for alternating groups, routed through the parent bridge alternating_solvable_iff_sym_solvable",
+      "mono_routes_agree: the embedding route and the arithmetic threshold route prove the SAME implication — abstract subgroup descent equals the down-closedness of n ≤ 4",
+      "solvable_perm_card_isDownSet: {n | IsSolvable (Perm (Fin n))} is downward closed (m ≤ n ∧ solvable n ⟹ solvable m)",
+      "four_is_max_solvable_card: 4 is the maximum cardinality with solvable Perm — the order-theoretic shadow of S₅ being the minimal non-solvable symmetric group"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 127,
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used. The structural lemma perm_solvable_of_embedding depends only on Mathlib (viaEmbeddingHom_injective, solvable_of_solvable_injective); the cardinality and down-set corollaries depend transitively on the parent's classification, which is decide-based and native_decide-free. `#print axioms` reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "additionalFiles": [],
+    "relatedProblems": [
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+        "relationship": "Parent — proved the intrinsic threshold IsSolvable (Perm α) ↔ Fintype.card α ≤ 4. This entry derives the monotonicity/down-set structure behind that threshold, and reuses perm_solvable_iff_card to give the arithmetic route in mono_routes_agree."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+        "relationship": "Grandparent — the Aα ↔ Sα solvability bridge. alternating_solvable_mono routes the alternating monotonicity through its alternating_solvable_iff_sym_solvable."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02",
+        "relationship": "Ancestor — Aₙ solvable iff n ≤ 4 for Fin n, the classification whose down-set structure is exposed here."
+      },
+      {
+        "id": "abel-ruffini",
+        "relationship": "Ancestor — Abel–Ruffini rests on S₅ being non-solvable; four_is_max_solvable_card is the order-theoretic statement that 5 is the minimal non-solvable cardinality, with the subgroup-descent lemma explaining why no larger Sₙ recovers solvability."
+      }
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Solvable",
+      "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Mathlib.GroupTheory.Perm.ViaEmbedding",
+      "Mathlib.Tactic",
+      "Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01"
+    ],
+    "opens": [
+      "Equiv"
+    ],
+    "namespace": "AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "perm_solvable_of_embedding",
+        "type": "core",
+        "description": "Structural descent: an embedding α ↪ β makes Perm α a subgroup of Perm β (via the injective hom viaEmbeddingHom), so IsSolvable (Perm β) forces IsSolvable (Perm α). No cardinality, no classification.",
+        "leanType": "(e : α ↪ β) → [IsSolvable (Perm β)] → IsSolvable (Perm α)",
+        "line": 57
+      },
+      {
+        "name": "perm_solvable_mono",
+        "type": "core",
+        "description": "Cardinality monotonicity for symmetric groups: Fintype.card α ≤ Fintype.card β and IsSolvable (Perm β) force IsSolvable (Perm α).",
+        "leanType": "[Fintype α] → [Fintype β] → (Fintype.card α ≤ Fintype.card β) → [IsSolvable (Perm β)] → IsSolvable (Perm α)",
+        "line": 68
+      },
+      {
+        "name": "alternating_solvable_mono",
+        "type": "key",
+        "description": "Cardinality monotonicity for alternating groups, obtained from the symmetric case through the parent bridge alternating_solvable_iff_sym_solvable.",
+        "leanType": "(Fintype.card α ≤ Fintype.card β) → IsSolvable (alternatingGroup β) → IsSolvable (alternatingGroup α)",
+        "line": 77
+      },
+      {
+        "name": "mono_routes_agree",
+        "type": "key",
+        "description": "The embedding route and the arithmetic threshold route prove the same implication: under card α ≤ card β, solvable β ⟹ solvable α, derived here purely from perm_solvable_iff_card and omega.",
+        "leanType": "(Fintype.card α ≤ Fintype.card β) → (IsSolvable (Perm β) → IsSolvable (Perm α))",
+        "line": 97
+      },
+      {
+        "name": "solvable_perm_card_isDownSet",
+        "type": "specialization",
+        "description": "The solvable cardinalities are downward closed: m ≤ n and IsSolvable (Perm (Fin n)) force IsSolvable (Perm (Fin m)).",
+        "leanType": "{m n : ℕ} → (m ≤ n) → IsSolvable (Perm (Fin n)) → IsSolvable (Perm (Fin m))",
+        "line": 114
+      },
+      {
+        "name": "four_is_max_solvable_card",
+        "type": "specialization",
+        "description": "4 is the largest cardinality with solvable symmetric group: Perm (Fin 4) is solvable, and any solvable Perm (Fin n) has n ≤ 4.",
+        "leanType": "IsSolvable (Perm (Fin 4)) ∧ ∀ n, IsSolvable (Perm (Fin n)) → n ≤ 4",
+        "line": 121
+      }
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "perm_solvable_of_embedding",
+      "statement": "An embedding α ↪ β with Perm β solvable forces Perm α solvable — solvability of permutation groups is downward closed under injections."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Documentation and Imports",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Module docstring framing the goal (extract the order-structural monotonicity hidden by the parent's threshold form) and naming the engine (viaEmbeddingHom). Imports Mathlib.GroupTheory.Solvable, SpecificGroups.Alternating, Perm.ViaEmbedding, Mathlib.Tactic, and the parent Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01.",
+      "mathContext": "Perm.ViaEmbedding supplies viaEmbeddingHom and its injectivity; Solvable supplies solvable_of_solvable_injective; the parent supplies perm_solvable_iff_card and (via its parent) alternating_solvable_iff_sym_solvable."
+    },
+    {
+      "id": "structural",
+      "title": "§1 Structural monotonicity along an embedding",
+      "startLine": 49,
+      "endLine": 66,
+      "summary": "perm_solvable_of_embedding: solvable_of_solvable_injective applied to viaEmbeddingHom_injective e. An embedding realizes Perm α as a subgroup of Perm β, and solvability descends — with no mention of cardinality.",
+      "mathContext": "Perm is functorial on injections: e : α ↪ β induces an injective group hom Perm α →* Perm β by extending permutations with the identity off im e. Solvability is closed under subgroups, hence flows from codomain to domain."
+    },
+    {
+      "id": "cardinality",
+      "title": "§2 The cardinality face",
+      "startLine": 67,
+      "endLine": 95,
+      "summary": "perm_solvable_mono converts card α ≤ card β into an embedding (Function.Embedding.nonempty_of_card_le) and applies §1; alternating_solvable_mono transports the conclusion across the parent bridge to alternating groups.",
+      "mathContext": "A finite type embeds into another exactly when its cardinality is no larger, so the structural descent of §1 is precisely cardinality monotonicity once an embedding is produced."
+    },
+    {
+      "id": "downset",
+      "title": "§3 Route agreement and the down-set packaging",
+      "startLine": 96,
+      "endLine": 127,
+      "summary": "mono_routes_agree re-derives the monotone implication arithmetically from perm_solvable_iff_card + omega, matching §2; solvable_perm_card_eq_le_four, solvable_perm_card_isDownSet, and four_is_max_solvable_card present {n | solvable (Perm (Fin n))} = {0,1,2,3,4} as a bounded down-set.",
+      "mathContext": "The threshold n ≤ 4 is downward closed and bounded by 4, so it is the down-set with maximum 4 — the order-theoretic shadow of S₅ being the minimal non-solvable symmetric group."
+    }
+  ],
+  "sorries": [],
+  "references": [
+    {
+      "authors": ["C. Jordan"],
+      "title": "Traité des substitutions et des équations algébriques",
+      "year": "1870",
+      "venue": "Gauthier-Villars, Paris",
+      "note": "Aₙ simple for n ≥ 5; the embedding Sₘ ↪ Sₙ and the monotonicity of solvability with degree."
+    },
+    {
+      "authors": ["É. Galois"],
+      "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
+      "year": "1846",
+      "venue": "Journal de Mathématiques Pures et Appliquées (published posthumously)",
+      "note": "Solvability by radicals iff solvable Galois group; S₅ as the minimal obstruction inherited by every higher degree."
+    },
+    {
+      "authors": ["I. Stewart"],
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "Chapman and Hall/CRC, 4th edition",
+      "note": "Sₙ and Aₙ solvable iff n ≤ 4; subgroups of solvable groups are solvable."
+    },
+    {
+      "authors": ["The mathlib Community"],
+      "title": "The Lean Mathematical Library — GroupTheory.Perm.ViaEmbedding and GroupTheory.Solvable",
+      "year": "2020",
+      "venue": "Lean 4 / Mathlib",
+      "note": "Source of Equiv.Perm.viaEmbeddingHom, viaEmbeddingHom_injective, and solvable_of_solvable_injective."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+      "relationship": "extends",
+      "description": "Parent intrinsic threshold IsSolvable (Perm α) ↔ Fintype.card α ≤ 4. This entry exposes its monotonicity/down-set structure and reuses perm_solvable_iff_card for the arithmetic route."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+      "relationship": "extends",
+      "description": "Grandparent Aα ↔ Sα bridge; alternating_solvable_mono routes the alternating monotonicity through its alternating_solvable_iff_sym_solvable."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "Abel–Ruffini rests on S₅ non-solvable; four_is_max_solvable_card is the order-theoretic statement that 5 is the minimal non-solvable cardinality."
+    }
+  ]
+}

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-card-intrinsic-overview",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "concept",
+    "title": "Lifting the n ≤ 4 thresholds off Fin n",
+    "content": "The classical theorems say '$S_n$ is solvable iff $n \\le 4$' and '$A_n$ is solvable iff $n \\le 4$', where $n$ implicitly means the index set $\\{1,\\dots,n\\}$ — `Fin n` in Lean. But solvability is a property of the abstract group, and the symmetric/alternating group of an $n$-element set does not depend on *which* $n$-element set you take. This entry proves the type-theoretically clean form:\n$$\\mathrm{IsSolvable}(S_\\alpha) \\iff |\\alpha| \\le 4, \\qquad \\mathrm{IsSolvable}(A_\\alpha) \\iff |\\alpha| \\le 4$$\nfor an **arbitrary** finite type $\\alpha$, with $|\\alpha| = \\texttt{Fintype.card}\\,\\alpha$. The only invariant that survives is the cardinality.\n\nThe whole file is powered by one map: a bijection $e : \\alpha \\simeq \\beta$ induces the conjugation isomorphism $\\texttt{permCongrHom}\\,e : S_\\alpha \\simeq^* S_\\beta$, $\\sigma \\mapsto e\\,\\sigma\\,e^{-1}$. Because conjugation preserves parity, this isomorphism also matches up the alternating subgroups, and solvability — being a group-isomorphism invariant — cannot tell $\\alpha$ from $\\beta$ once $|\\alpha| = |\\beta|$.",
+    "mathContext": "Choosing $\\beta = \\mathrm{Fin}(|\\alpha|)$ via `Fintype.equivFin` reduces every arbitrary-type statement to the corresponding `Fin n` statement proved by the ancestor entries.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "symmetric group",
+      "alternating group",
+      "solvable group",
+      "conjugation of permutations",
+      "cardinality as a complete invariant",
+      "Fintype.card"
+    ],
+    "prerequisites": [
+      "group theory",
+      "solvable groups",
+      "permutation groups",
+      "Mathlib IsSolvable and Fintype"
+    ]
+  },
+  {
+    "id": "ann-isSolvable-congr",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+    "range": { "startLine": 45, "endLine": 63 },
+    "type": "technique",
+    "title": "Solvability is a group-isomorphism invariant",
+    "content": "Mathlib provides `solvable_of_surjective : Function.Surjective f → [IsSolvable G] → IsSolvable G'` — the derived series of $G$ surjects onto that of $G'$, so $G'$ inherits solvability. A `MulEquiv` $e : G \\simeq^* G'$ is surjective, and so is its inverse $e^{-1}$; feeding both into `solvable_of_surjective` yields the equivalence\n$$\\texttt{isSolvable\\_congr} : \\mathrm{IsSolvable}\\,G \\iff \\mathrm{IsSolvable}\\,G'.$$\nThe small implementation wrinkle is that `solvable_of_surjective` consumes `[IsSolvable G]` as an instance, while the two halves of the iff receive it as an ordinary hypothesis `h`; `haveI := h` promotes it back to an instance. The underlying function of $e$ as a `MonoidHom`, `(e : G →* G')`, has the same surjectivity as `e` itself (`EquivLike.surjective e`), definitionally.",
+    "mathContext": "This is the engine that makes every later transport free: once you have a MulEquiv between two groups, their solvability verdicts are identical.",
+    "significance": "important",
+    "relatedConcepts": [
+      "derived series",
+      "solvable_of_surjective",
+      "MulEquiv",
+      "EquivLike.surjective"
+    ],
+    "prerequisites": ["solvable groups", "group homomorphisms", "Lean typeclass resolution"]
+  },
+  {
+    "id": "ann-map-permCongrHom-alternating",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+    "range": { "startLine": 78, "endLine": 112 },
+    "type": "key-step",
+    "title": "Conjugation preserves the alternating subgroup",
+    "content": "The crux of the transport for alternating groups: the conjugation isomorphism carries $A_\\alpha$ exactly onto $A_\\beta$,\n$$(\\texttt{alternatingGroup}\\,\\alpha).\\mathrm{map}\\,(\\texttt{permCongrHom}\\,e) = \\texttt{alternatingGroup}\\,\\beta.$$\nProof is a membership `ext g`. Since $A = \\ker(\\mathrm{sign})$ (`mem_alternatingGroup`: $f \\in A \\iff \\mathrm{sign}\\,f = 1$), and `sign_permCongr` gives $\\mathrm{sign}(e.\\texttt{permCongr}\\,p) = \\mathrm{sign}\\,p$:\n• ($\\subseteq$) an image $e.\\texttt{permCongr}\\,p$ has the same sign as $p$, so it is even when $p$ is.\n• ($\\supseteq$) given even $g \\in S_\\beta$, the preimage $e^{-1}.\\texttt{permCongr}\\,g$ is even and maps to $g$; the round-trip $e.\\texttt{permCongr}(e^{-1}.\\texttt{permCongr}\\,g) = g$ is `permCongr_symm` ($e.\\texttt{permCongr}^{-1} = e^{-1}.\\texttt{permCongr}$) followed by `apply_symm_apply`.\n\nA Lean detail worth noting: the goal displays the image as the `MonoidHom` coercion `↑e.permCongrHom p`, which is *definitionally* `e.permCongr p`; a `show e.permCongr p = …` step re-exposes it so `sign_permCongr` rewrites. `alternatingCongr` then packages this equality (`subgroupMap` + `subgroupCongr`) into the isomorphism $A_\\alpha \\simeq^* A_\\beta$.",
+    "mathContext": "Conjugation is an inner-ish automorphism of the ambient permutation group transported across a relabelling; parity is conjugation-invariant, so the even permutations are matched with the even permutations.",
+    "significance": "important",
+    "relatedConcepts": [
+      "alternatingGroup = ker(sign)",
+      "sign_permCongr",
+      "Subgroup.map",
+      "MulEquiv.subgroupMap",
+      "Equiv.permCongr_symm"
+    ],
+    "prerequisites": ["kernels and images of group homomorphisms", "sign of a permutation", "subgroup map"]
+  },
+  {
+    "id": "ann-classifications",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+    "range": { "startLine": 113, "endLine": 129 },
+    "type": "key-step",
+    "title": "Reducing the arbitrary-type classification to Fin n",
+    "content": "With the transport in hand, the classifications are two-line rewrites. For the symmetric group:\n$$\\mathrm{IsSolvable}(S_\\alpha) \\overset{\\texttt{perm\\_solvable\\_congr}\\,(\\texttt{equivFin}\\,\\alpha)}{\\iff} \\mathrm{IsSolvable}(S_{\\mathrm{Fin}\\,|\\alpha|}) \\overset{\\texttt{sym\\_solvable\\_iff}}{\\iff} |\\alpha| \\le 4.$$\nThe alternating version is identical with `alternating_solvable_congr` and the grandparent's `alternating_solvable_iff`. `Fintype.equivFin α : α ≃ Fin (Fintype.card α)` is the bijection that turns the abstract type into the concrete index set the ancestor theorems were proved for. No new group theory is needed at this step — only the transport plus the already-formalized `Fin n` verdicts.",
+    "mathContext": "This is the moment the 'arbitrary finite type' generality is cashed out: every finite type is, up to a chosen bijection, a `Fin n`, and solvability cannot see the bijection.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "Fintype.equivFin",
+      "sym_solvable_iff",
+      "alternating_solvable_iff",
+      "classification by cardinality"
+    ],
+    "prerequisites": ["finite types", "the Fin n solvability classifications"]
+  },
+  {
+    "id": "ann-card-eq-and-sharp",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+    "range": { "startLine": 130, "endLine": 174 },
+    "type": "observation",
+    "title": "Equinumerous types are indistinguishable; the jump at 5 is forced everywhere",
+    "content": "Once solvability is pinned to $|\\alpha|$, two consequences are immediate. First, equal cardinality forces equal solvability — `alternating_solvable_iff_of_card_eq` and `perm_solvable_iff_of_card_eq` rewrite both sides through the card classification and finish with `h`. Second, `nonempty_alternatingCongr_of_card_eq` records that equinumerous finite types actually have *isomorphic* alternating groups, with the explicit witness `alternatingCongr (Fintype.equivOfCardEq h)` — not merely 'both solvable or both not'.\n\nFinally `sharp_threshold_card` exhibits the dichotomy concretely: any 4-element type has solvable alternating group and any 5-element type does not, with the contradiction at the boundary discharged by `omega` on the cardinality hypotheses. This is the coordinate-free form of the $A_5$ obstruction underlying Abel-Ruffini: it is a property of *five-element sets*, not of the particular set $\\{1,2,3,4,5\\}$.",
+    "mathContext": "The existence of the isomorphism (not just the biconditional on solvability) is the strongest form of 'cardinality is the only invariant' at the level of the groups themselves.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Fintype.equivOfCardEq",
+      "group isomorphism",
+      "A₅ obstruction",
+      "Abel-Ruffini theorem",
+      "sharp threshold"
+    ],
+    "prerequisites": ["finite cardinality", "group isomorphism", "omega tactic"]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01/meta.json
@@ -1,0 +1,273 @@
+{
+  "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+  "slug": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+  "title": "Solvability of Sₐ and Aₐ is Intrinsic to the Cardinality",
+  "description": "For an arbitrary finite type α, both IsSolvable (Perm α) ↔ Fintype.card α ≤ 4 and IsSolvable (alternatingGroup α) ↔ Fintype.card α ≤ 4 — the classical n ≤ 4 thresholds, lifted off Fin n to any finite set. The engine is the conjugation isomorphism Equiv.permCongrHom e : Perm α ≃* Perm β induced by a bijection e : α ≃ β; sign-invariance of permCongr carries the alternating subgroup onto the alternating subgroup, giving a canonical MulEquiv alternatingGroup α ≃* alternatingGroup β. Solvability is a MulEquiv invariant, so it depends on α only through Fintype.card α — answering the parent bridge's first future direction.",
+  "overview": {
+    "historicalContext": "The classical statements 'Sₙ solvable iff n ≤ 4' (Ruffini–Abel, Galois) and 'Aₙ solvable iff n ≤ 4' (Jordan) are invariably phrased for the concrete index set {1, …, n}, i.e. Fin n in type theory. Mathematically nothing depends on which n-element set is used: a bijection of the underlying set conjugates permutations and so induces an isomorphism of symmetric groups, and of alternating groups, because conjugation preserves the parity (sign) of a permutation. This entry makes that folklore precise. The parent bridge AbelRuffiniOQ04OQ02OQ02OQ08 had already shown the sign extension 1 → Aα → Sα → ℤ/2 → 1 is transparent to solvability for arbitrary α; its first listed future direction asked to transport solvability invariance across cardinality 'via a permutation MulEquiv'. That is exactly what is delivered here, and as a byproduct both classical classifications are upgraded from Fin n to any finite type.",
+    "modernSignificance": "Stating the classifications for an arbitrary finite type, rather than Fin n, is the type-theoretically correct form: it removes an artificial dependence on a chosen enumeration and exposes Fintype.card α as the sole invariant governing solvability. The same MulEquiv that powers the transport, alternatingCongr, is the canonical isomorphism witnessing that equinumerous finite types have isomorphic alternating groups — useful whenever a permutation group arises on an unindexed set (roots of a polynomial, vertices of a graph, a basis) and one wants the solvability verdict without first choosing coordinates."
+  },
+  "meta": {
+    "author": "Classical (Galois, Jordan); cardinality-transport formalization original",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Symmetric_group",
+    "date": "1832",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "solvability",
+      "alternating-group",
+      "symmetric-group",
+      "group-isomorphism",
+      "permCongr",
+      "classification",
+      "research",
+      "transport"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "solvable_of_surjective",
+        "description": "If G is solvable and f : G →* G' is surjective, then G' is solvable. Applied to a MulEquiv both ways, it makes solvability a group-isomorphism invariant (isSolvable_congr).",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "Equiv.permCongrHom",
+        "description": "A bijection e : α ≃ β as a multiplicative isomorphism Perm α ≃* Perm β (conjugation). The transport engine of the whole file.",
+        "module": "Mathlib.Algebra.Group.End"
+      },
+      {
+        "theorem": "Equiv.Perm.sign_permCongr",
+        "description": "sign (e.permCongr p) = sign p — conjugation preserves parity. This is why permCongrHom maps the alternating group onto the alternating group.",
+        "module": "Mathlib.GroupTheory.Perm.Sign"
+      },
+      {
+        "theorem": "MulEquiv.subgroupMap / MulEquiv.subgroupCongr",
+        "description": "A MulEquiv restricts to H ≃* H.map f, and equal subgroups are isomorphic. Composed to build the canonical alternatingGroup α ≃* alternatingGroup β.",
+        "module": "Mathlib.Algebra.Group.Subgroup.Map"
+      },
+      {
+        "theorem": "Fintype.equivFin / Fintype.equivOfCardEq",
+        "description": "α ≃ Fin (card α), and α ≃ β whenever card α = card β. Specialising the transport to Fin (card α) reduces the arbitrary-type classification to the parent's Fin n classification.",
+        "module": "Mathlib.Data.Fintype.EquivFin"
+      }
+    ],
+    "originalContributions": [
+      "perm_solvable_iff_card: IsSolvable (Perm α) ↔ Fintype.card α ≤ 4 for an ARBITRARY finite type α (parent/siblings state it only for Fin n)",
+      "alternating_solvable_iff_card: IsSolvable (alternatingGroup α) ↔ Fintype.card α ≤ 4 for an arbitrary finite type α",
+      "isSolvable_congr: solvability is invariant under group isomorphism (MulEquiv both directions through solvable_of_surjective) — a small reusable lemma",
+      "map_permCongrHom_alternating: permCongrHom e carries alternatingGroup α exactly onto alternatingGroup β, via sign-invariance",
+      "alternatingCongr: the canonical isomorphism alternatingGroup α ≃* alternatingGroup β induced by a bijection α ≃ β",
+      "alternating_solvable_iff_of_card_eq / perm_solvable_iff_of_card_eq: solvability depends on α only through Fintype.card α — the parent's first future direction, realized",
+      "nonempty_alternatingCongr_of_card_eq: equinumerous finite types have isomorphic alternating groups, with alternatingCongr as the explicit witness",
+      "sharp_threshold_card: any 4-element type has solvable alternating group, any 5-element type does not — the jump is forced for every finite type of that size, not just Fin n"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 174,
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used. `#print axioms` on perm_solvable_iff_card, alternating_solvable_iff_card, alternating_solvable_iff_of_card_eq, nonempty_alternatingCongr_of_card_eq, and sharp_threshold_card reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`. (The classification corollaries depend transitively on the parent's Fin n results, which are themselves decide-based and native_decide-free.)",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "additionalFiles": [],
+    "relatedProblems": [
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+        "relationship": "Parent — the Aα ↔ Sα solvability bridge for arbitrary finite α. Its first future direction ('transport solvability invariance under cardinality, via a permutation MulEquiv') is exactly this entry. This entry also reuses the parent's bridge (alternating_solvable_iff_sym_solvable) and its sym_solvable_iff corollary."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02",
+        "relationship": "Grandparent — proves Aₙ solvable iff n ≤ 4 for Fin n. This entry lifts that classification to an arbitrary finite type by transporting along Fintype.equivFin."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-02",
+        "relationship": "Ancestor sibling — proves Sₙ solvable iff n ≤ 4 for Fin n. perm_solvable_iff_card lifts the symmetric classification to an arbitrary finite type."
+      },
+      {
+        "id": "abel-ruffini",
+        "relationship": "Ancestor — Abel-Ruffini rests on S₅ being non-solvable. This entry shows any 5-element type, however presented, has non-solvable symmetric and alternating groups, so the obstruction is coordinate-free."
+      }
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Solvable",
+      "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Mathlib.Tactic",
+      "Proofs.AbelRuffiniOQ04OQ02OQ02OQ08"
+    ],
+    "opens": [
+      "Equiv"
+    ],
+    "namespace": "AbelRuffiniOQ04OQ02OQ02OQ08OQ01",
+    "lineCount": 174,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "mainTheorems": [
+      {
+        "name": "alternating_solvable_iff_card",
+        "type": "core",
+        "description": "For ANY finite type α, the alternating group is solvable iff Fintype.card α ≤ 4 — the Jordan classification lifted off Fin n.",
+        "leanType": "(α : Type*) → [DecidableEq α] → [Fintype α] → (IsSolvable (alternatingGroup α) ↔ Fintype.card α ≤ 4)",
+        "line": 126
+      },
+      {
+        "name": "perm_solvable_iff_card",
+        "type": "core",
+        "description": "For ANY finite type α, the symmetric group is solvable iff Fintype.card α ≤ 4 — the Abel-Ruffini/Galois classification lifted off Fin n.",
+        "leanType": "(α : Type*) → [DecidableEq α] → [Fintype α] → (IsSolvable (Perm α) ↔ Fintype.card α ≤ 4)",
+        "line": 120
+      },
+      {
+        "name": "isSolvable_congr",
+        "type": "key",
+        "description": "Solvability is invariant under group isomorphism: a MulEquiv G ≃* G' gives IsSolvable G ↔ IsSolvable G', via solvable_of_surjective applied both ways.",
+        "leanType": "(e : G ≃* G') → (IsSolvable G ↔ IsSolvable G')",
+        "line": 59
+      },
+      {
+        "name": "map_permCongrHom_alternating",
+        "type": "key",
+        "description": "The conjugation isomorphism permCongrHom e carries alternatingGroup α exactly onto alternatingGroup β, because permCongr preserves the sign.",
+        "leanType": "(e : α ≃ β) → (alternatingGroup α).map (e.permCongrHom : Perm α →* Perm β) = alternatingGroup β",
+        "line": 85
+      },
+      {
+        "name": "alternatingCongr",
+        "type": "definition",
+        "description": "The canonical isomorphism alternatingGroup α ≃* alternatingGroup β induced by a bijection e : α ≃ β (subgroupMap of permCongrHom followed by subgroupCongr).",
+        "leanType": "(e : α ≃ β) → (alternatingGroup α ≃* alternatingGroup β)",
+        "line": 103
+      },
+      {
+        "name": "alternating_solvable_iff_of_card_eq",
+        "type": "specialization",
+        "description": "Solvability of the alternating group depends on the type only through its cardinality — the parent's first future direction made precise.",
+        "leanType": "(Fintype.card α = Fintype.card β) → (IsSolvable (alternatingGroup α) ↔ IsSolvable (alternatingGroup β))",
+        "line": 134
+      },
+      {
+        "name": "sharp_threshold_card",
+        "type": "specialization",
+        "description": "Any 4-element type has solvable alternating group; any 5-element type does not — the n = 5 jump is forced for every finite type of that size.",
+        "leanType": "Fintype.card α₄ = 4 → Fintype.card α₅ = 5 → IsSolvable (alternatingGroup α₄) ∧ ¬IsSolvable (alternatingGroup α₅)",
+        "line": 165
+      }
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "alternating_solvable_iff_card",
+      "statement": "For any finite type α: IsSolvable (alternatingGroup α) ↔ Fintype.card α ≤ 4."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Documentation and Imports",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring framing the goal (lift the n ≤ 4 thresholds off Fin n to an arbitrary finite type) and naming the engine (permCongrHom + sign-invariance). Imports Mathlib.GroupTheory.Solvable, Mathlib.GroupTheory.SpecificGroups.Alternating, Mathlib.Tactic, and the parent Proofs.AbelRuffiniOQ04OQ02OQ02OQ08.",
+      "mathContext": "The parent import supplies the bridge alternating_solvable_iff_sym_solvable, the corollary sym_solvable_iff, and (transitively) the grandparent's alternating_solvable_iff for Fin n. Mathlib supplies solvable_of_surjective, Equiv.permCongrHom, sign_permCongr, MulEquiv.subgroupMap/subgroupCongr, and Fintype.equivFin/equivOfCardEq."
+    },
+    {
+      "id": "mulequiv-transport",
+      "title": "§1 Solvability is a MulEquiv invariant",
+      "startLine": 45,
+      "endLine": 63,
+      "summary": "isSolvable_of_mulEquiv pushes solvability forward along a MulEquiv (its underlying MonoidHom is surjective); isSolvable_congr packages both directions into an iff.",
+      "mathContext": "Closure of solvable groups under surjective images (solvable_of_surjective) applied to a MulEquiv and its inverse. This is the abstract reason any coordinate change is invisible to solvability."
+    },
+    {
+      "id": "perm-transport",
+      "title": "§2 Transport across a bijection of the underlying type",
+      "startLine": 64,
+      "endLine": 77,
+      "summary": "perm_solvable_congr: a bijection e : α ≃ β makes Perm α and Perm β equisolvable, via the conjugation isomorphism permCongrHom.",
+      "mathContext": "Equiv.permCongrHom e : Perm α ≃* Perm β is conjugation σ ↦ e ∘ σ ∘ e⁻¹ packaged as a multiplicative isomorphism."
+    },
+    {
+      "id": "alternating-preserved",
+      "title": "§3 The conjugation isomorphism preserves the alternating subgroup",
+      "startLine": 78,
+      "endLine": 112,
+      "summary": "map_permCongrHom_alternating shows permCongrHom e maps alternatingGroup α onto alternatingGroup β (forward: sign of the image equals sign of the source; backward: the preimage e.symm.permCongr g works). alternatingCongr assembles the resulting MulEquiv of alternating groups.",
+      "mathContext": "alternatingGroup = ker(sign); since sign (e.permCongr p) = sign p, conjugation sends sign-1 permutations to sign-1 permutations bijectively, so it restricts to an isomorphism of kernels."
+    },
+    {
+      "id": "classifications",
+      "title": "§4 The classical classifications for an arbitrary finite type",
+      "startLine": 113,
+      "endLine": 129,
+      "summary": "perm_solvable_iff_card and alternating_solvable_iff_card: transport along Fintype.equivFin α to Fin (card α), then apply the parent's/grandparent's Fin n classifications.",
+      "mathContext": "Fintype.equivFin α : α ≃ Fin (Fintype.card α) reduces the arbitrary-type statement to the Fin n statement, where sym_solvable_iff and alternating_solvable_iff close the goal by a single rewrite."
+    },
+    {
+      "id": "cardinality-only",
+      "title": "§5 Cardinality is the only invariant that matters",
+      "startLine": 130,
+      "endLine": 148,
+      "summary": "alternating_solvable_iff_of_card_eq, perm_solvable_iff_of_card_eq, and nonempty_alternatingCongr_of_card_eq: equal cardinality forces identical solvability and an explicit isomorphism of alternating groups.",
+      "mathContext": "Rewriting both sides through the card classification collapses the equivalence to Fintype.card α ≤ 4 ↔ Fintype.card β ≤ 4, true once the cardinalities agree."
+    },
+    {
+      "id": "threshold-agreement",
+      "title": "§6 The threshold agreement, for an arbitrary finite type",
+      "startLine": 149,
+      "endLine": 174,
+      "summary": "sym_alternating_solvable_iff_card records that Perm α and alternatingGroup α are solvable together with the common boundary at card ≤ 4; sharp_threshold_card exhibits the forced jump between 4-element and 5-element types.",
+      "mathContext": "Combines §4 with the parent bridge (alternating_solvable_iff_sym_solvable). The sharp statement uses omega on the cardinality hypotheses once the classifications are in hand."
+    }
+  ],
+  "sorries": [],
+  "references": [
+    {
+      "authors": ["É. Galois"],
+      "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
+      "year": "1846",
+      "venue": "Journal de Mathématiques Pures et Appliquées (published posthumously)",
+      "note": "Polynomial solvable by radicals iff Galois group solvable; S₅ is the quintic obstruction."
+    },
+    {
+      "authors": ["C. Jordan"],
+      "title": "Traité des substitutions et des équations algébriques",
+      "year": "1870",
+      "venue": "Gauthier-Villars, Paris",
+      "note": "Aₙ simple for n ≥ 5; the classification of solvable Aₙ and Sₙ."
+    },
+    {
+      "authors": ["I. Stewart"],
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "Chapman and Hall/CRC, 4th edition",
+      "note": "Sₙ and Aₙ solvable iff n ≤ 4; conjugation and the parity of permutations."
+    },
+    {
+      "authors": ["The mathlib Community"],
+      "title": "The Lean Mathematical Library — GroupTheory.Perm.Sign and GroupTheory.Solvable",
+      "year": "2020",
+      "venue": "Lean 4 / Mathlib",
+      "note": "Source of Equiv.permCongrHom, sign_permCongr, solvable_of_surjective, and the subgroup-map isomorphisms."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08",
+      "relationship": "extends",
+      "description": "Parent bridge Aα ↔ Sα. This entry realizes its first future direction — transport of solvability invariance across cardinality via a permutation MulEquiv — and reuses its bridge and sym_solvable_iff corollary."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Grandparent Aₙ solvable iff n ≤ 4 (Fin n). Lifted here to an arbitrary finite type via Fintype.equivFin."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02",
+      "relationship": "related",
+      "description": "Sibling Sₙ solvable iff n ≤ 4 (Fin n). perm_solvable_iff_card is the arbitrary-finite-type form."
+    }
+  ]
+}


### PR DESCRIPTION
## Abel–Ruffini solvability chain (oq-04 ▸ oq-02 ▸ oq-02 ▸ oq-08 …)

A coherent stack of **0-axiom, native_decide-free, verified** entries on the solvability of symmetric/alternating groups, each extending the last:

1. **`…-oq-08`** — the **Aα ↔ Sα solvability bridge**: the index-2 sign extension `1 → Aα → Sα → ℤ/2 → 1` is transparent to solvability for *any* finite α (no cardinality hypothesis).
2. **`…-oq-08-oq-01`** — solvability is **intrinsic to `Fintype.card α`**: `IsSolvable (Perm α) ↔ Fintype.card α ≤ 4`, lifting the n≤4 thresholds off `Fin n` to any finite carrier.
3. **`…-oq-08-oq-01-oq-01`** — solvability is **downward closed under injections**: `perm_solvable_of_embedding` (via Mathlib's `viaEmbeddingHom_injective` + `solvable_of_solvable_injective`, no cardinality count), packaging `{n | IsSolvable (Perm (Fin n))}` as the **down-set `{0,1,2,3,4}`**.
4. **`…-oq-08-oq-01-oq-01-oq-01`** *(new)* — the **order-theoretic dual**: non-solvability is **upward closed under injections**. `perm_not_solvable_of_embedding` is the exact contrapositive of (3); `not_solvable_perm_card_isUpSet` packages `{n | ¬ IsSolvable (Perm (Fin n))}` as the **up-set `{n | 5 ≤ n}`**. `solvable_unsolvable_partition` + `boundary_is_successor` exhibit the two faces as an **order-complement partitioning ℕ**, meeting at the Abel–Ruffini boundary where the least unsolvable cardinality `5` is the successor of the greatest solvable one `4` (`five_is_min_unsolvable_card` is the dual of `four_is_max_solvable_card`).$'\n'5. **`…-oq-08-oq-01-oq-01-oq-01-oq-01`** *(new)* — the **boundary under the type operations `⊕` and `×`**. `perm_sum_solvable_iff` / `perm_prod_solvable_iff` turn the threshold into additive/multiplicative side-conditions. The pay-off is a genuine asymmetry: **products reflect solvability** to their factors (`perm_solvable_of_prod_solvable`, since `card α ≤ card α · card β`), but **disjoint unions do NOT preserve it** (`perm_sum_solvability_not_preserved` — `Perm (Fin 2)` and `Perm (Fin 3)` solvable, yet `Perm (Fin 2 ⊕ Fin 3)` is not, the union having 5 points). That additive-closure failure is the Abel–Ruffini boundary read combinatorially: the least escaping sum is `2 + 3 = 5` (`abel_ruffini_is_additive_escape`), the minimal unsolvable degree. `product_reflects_sum_does_not` states the dichotomy side by side.$'\n\nEach new file builds' under the Docker wrapper; `#print axioms` on every main result reports only `propext`, `Classical.choice`, `Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`. Gallery entries (meta.json + annotations.json) added for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)