### PR TITLE
research(minkowski-fundamental-theorem-oq-01-oq-02): homogeneity of the successive minima

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3003,6 +3003,7 @@ import Proofs.MidyTheorem
 import Proofs.MinkowskiFundamentalTheorem
 import Proofs.MinkowskiFundamentalTheoremOQ01
 import Proofs.MinkowskiFundamentalTheoremOQ01OQ01
+import Proofs.MinkowskiFundamentalTheoremOQ01OQ02
 import Proofs.MinkowskiFundamentalTheoremOQ02
 import Proofs.MinkowskiFundamentalTheoremOQ04
 import Proofs.MinkowskiTheoremOQ02

--- a/proofs/Proofs/MinkowskiFundamentalTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/MinkowskiFundamentalTheoremOQ01OQ02.lean
@@ -1,0 +1,242 @@
+/-
+  Homogeneity (Scaling Law) of the Successive Minima
+  (minkowski-fundamental-theorem-oq-01-oq-02)
+
+  Next step of `minkowski-fundamental-theorem-oq-01`, which built the successive
+  minima infrastructure (the i-th successive minimum
+
+      λᵢ(L, S) = inf { c > 0 : cS contains i+1 linearly independent lattice points })
+
+  and stated, but left open, Minkowski's second theorem product bound.  The
+  sibling file oq-01-oq-01 turned the order structure λ₀ ≤ ⋯ ≤ λₙ₋₁ into a
+  bracketing of the *product*.
+
+  Here we prove the most basic STRUCTURAL law that any honest treatment of the
+  successive minima must establish: their behaviour under rescaling of the convex
+  body.  Replacing `S` by `cS` (a `c`-fold dilation, `c > 0`) inverts every
+  successive minimum:
+
+      λᵢ(L, cS) = λᵢ(L, S) / c.
+
+  This is the geometric statement that "making the body `c` times bigger makes
+  every threshold `c` times smaller".  It is exactly the homogeneity property that
+  makes the product `λ₀ ⋯ λₙ₋₁ · vol(S)` of Minkowski's second theorem a *scaling
+  invariant*: under `S ↦ cS` the product of minima divides by `cⁿ` while the
+  volume multiplies by `cⁿ`, so the second-theorem quantity is unchanged.  We make
+  the minima half of that statement precise:
+
+      ∏ᵢ λᵢ(L, cS)  =  (∏ᵢ λᵢ(L, S)) / cⁿ.
+
+  Everything is proved with 0 sorries and 0 axioms, on top of the parent's custom
+  `Lattice`/`ConvexBody` API.  No attainment / non-emptiness hypothesis is needed:
+  the law holds verbatim even when a minimum is unattained, because in that case
+  both sides are `0` (the infimum of the empty set is `0` in ℝ, and `0 / c = 0`).
+
+  The engine is a self-contained scaling lemma for infima on ℝ,
+  `sInf_preimage_mul_right`, proved by elementary `csInf` antisymmetry — no measure
+  theory, no analysis.
+
+  References:
+  - Minkowski, Geometrie der Zahlen (1896)
+  - Cassels, An Introduction to the Geometry of Numbers (1959), Ch. VIII
+-/
+import Mathlib
+import Proofs.MinkowskiFundamentalTheorem
+import Proofs.MinkowskiFundamentalTheoremOQ01
+
+set_option maxHeartbeats 800000
+set_option linter.unusedVariables false
+set_option linter.unusedSectionVars false
+
+namespace MinkowskiSecondTheoremHomogeneity
+
+open MinkowskiFundamentalTheorem MinkowskiSecondTheorem Set
+open scoped Pointwise
+
+variable (n : ℕ) [NeZero n]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I:  A SCALING LAW FOR INFIMA ON ℝ
+═══════════════════════════════════════════════════════════════════════════════
+
+The whole homogeneity statement reduces to the following purely real-analytic
+fact: for a positive constant `c` and a set `A ⊆ ℝ` of non-negative reals, the
+infimum of the "stretched preimage" `{ d | d·c ∈ A }` is `sInf A / c`.  Because
+the admissible-scaling sets are exactly such non-negative sets, this single lemma
+drives every successive minimum.
+-/
+
+/-- **Scaling law for infima.**  For `c > 0` and a set `A` of non-negative reals,
+    `sInf { d | d * c ∈ A } = sInf A / c`.  The non-negativity hypothesis makes
+    `0` a common lower bound, and the empty case is covered automatically
+    (`sInf ∅ = 0 = 0 / c`). -/
+theorem sInf_preimage_mul_right {c : ℝ} (hc : 0 < c) (A : Set ℝ)
+    (hA0 : ∀ a ∈ A, 0 ≤ a) :
+    sInf {d : ℝ | d * c ∈ A} = sInf A / c := by
+  set B : Set ℝ := {d : ℝ | d * c ∈ A} with hB
+  have hAbdd : BddBelow A := ⟨0, hA0⟩
+  have hBbdd : BddBelow B := by
+    refine ⟨0, fun d hd => ?_⟩
+    have hdc : 0 ≤ d * c := hA0 _ hd
+    -- `0 ≤ d * c` and `0 < c` give `0 ≤ d`
+    exact le_of_mul_le_mul_right (by simpa using hdc) hc
+  by_cases hAne : A.Nonempty
+  · have hAne' : A.Nonempty := hAne
+    obtain ⟨a₀, ha₀⟩ := hAne
+    have hBne : B.Nonempty :=
+      ⟨a₀ / c, by simp only [hB, Set.mem_setOf_eq, div_mul_cancel₀ a₀ hc.ne']; exact ha₀⟩
+    apply le_antisymm
+    · -- `sInf B ≤ sInf A / c`
+      rw [le_div_iff₀ hc]
+      apply le_csInf hAne'
+      intro a ha
+      have hmem : a / c ∈ B := by
+        simp only [hB, Set.mem_setOf_eq, div_mul_cancel₀ a hc.ne']; exact ha
+      have hle : sInf B ≤ a / c := csInf_le hBbdd hmem
+      calc sInf B * c ≤ (a / c) * c := mul_le_mul_of_nonneg_right hle hc.le
+        _ = a := by field_simp
+    · -- `sInf A / c ≤ sInf B`
+      apply le_csInf hBne
+      intro d hd
+      rw [div_le_iff₀ hc]
+      exact csInf_le hAbdd hd
+  · -- `A` empty ⟹ `B` empty ⟹ both sides `0`
+    have hBempty : B = ∅ := by
+      rw [Set.eq_empty_iff_forall_notMem]
+      exact fun d hd => hAne ⟨d * c, hd⟩
+    rw [Set.not_nonempty_iff_eq_empty] at hAne
+    rw [hBempty, hAne]
+    simp [Real.sInf_empty]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II:  SCALING THE CONVEX BODY COMPOSES
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Dilating twice composes the factors: `d • (c • S) = (d·c) • S`. -/
+theorem ConvexBody.scale_scale (c d : ℝ) (S : ConvexBody n) :
+    (ConvexBody.scale n d (ConvexBody.scale n c S)).carrier
+      = (ConvexBody.scale n (d * c) S).carrier := by
+  simp only [ConvexBody.scale_carrier, smul_smul]
+
+/-- **The admissible-scaling set transforms by a stretch.**  Scaling the body by
+    `c > 0` pulls the admissible-scaling set back by `· * c`:
+
+      admissibleScalings (cS) i = { d | d·c ∈ admissibleScalings S i }. -/
+theorem admissibleScalings_scale (L : Lattice n) (S : ConvexBody n) {c : ℝ}
+    (hc : 0 < c) (i : Fin n) :
+    admissibleScalings n L (ConvexBody.scale n c S) i
+      = {d : ℝ | d * c ∈ admissibleScalings n L S i} := by
+  ext d
+  simp only [admissibleScalings, Set.mem_setOf_eq, ConvexBody.scale_scale,
+    mul_pos_iff_of_pos_right hc]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III:  HOMOGENEITY OF EACH SUCCESSIVE MINIMUM
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Homogeneity of the successive minima.**  For every dilation factor `c > 0`,
+
+      λᵢ(L, cS) = λᵢ(L, S) / c.
+
+    No attainment hypothesis is required: if `λᵢ(L, S)` is unattained (its
+    admissible set is empty) then so is `λᵢ(L, cS)`, and the identity reads
+    `0 = 0 / c`. -/
+theorem successiveMinimum_scale (L : Lattice n) (S : ConvexBody n) {c : ℝ} (hc : 0 < c)
+    (i : Fin n) :
+    successiveMinimum n L (ConvexBody.scale n c S) i = successiveMinimum n L S i / c := by
+  unfold successiveMinimum
+  rw [admissibleScalings_scale n L S hc i]
+  exact sInf_preimage_mul_right hc (admissibleScalings n L S i) (fun a ha => le_of_lt ha.1)
+
+/-- **Doubling the body halves every successive minimum:** `λᵢ(L, 2S) = λᵢ(L, S) / 2`. -/
+theorem successiveMinimum_scale_two (L : Lattice n) (S : ConvexBody n) (i : Fin n) :
+    successiveMinimum n L (ConvexBody.scale n 2 S) i = successiveMinimum n L S i / 2 :=
+  successiveMinimum_scale n L S (by norm_num) i
+
+/-- **Monotone-down in the body.**  Enlarging the body (`c ≥ 1`) does not increase
+    any successive minimum: `λᵢ(L, cS) ≤ λᵢ(L, S)`.  (Bigger body ⟹ smaller — or
+    equal — thresholds.) -/
+theorem successiveMinimum_scale_le (L : Lattice n) (S : ConvexBody n) {c : ℝ}
+    (hc : 1 ≤ c) (i : Fin n) :
+    successiveMinimum n L (ConvexBody.scale n c S) i ≤ successiveMinimum n L S i := by
+  have hc0 : 0 < c := lt_of_lt_of_le one_pos hc
+  rw [successiveMinimum_scale n L S hc0 i]
+  rw [div_le_iff₀ hc0]
+  -- `λᵢ(S) ≤ λᵢ(S) * c`, since `λᵢ(S) ≥ 0` and `c ≥ 1`
+  nlinarith [successiveMinimum_nonneg n L S i]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV:  HOMOGENEITY OF THE PRODUCT — THE SCALING INVARIANT
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Homogeneity of the product of successive minima.**
+
+      ∏ᵢ λᵢ(L, cS)  =  (∏ᵢ λᵢ(L, S)) / cⁿ.
+
+    Combined with the dilation law `vol(cS) = cⁿ vol(S)` for the volume, this is
+    precisely why the Minkowski second-theorem quantity `∏ᵢ λᵢ · vol(S)` is a
+    scaling invariant: the product of minima divides by `cⁿ` while the volume
+    multiplies by `cⁿ`. -/
+theorem prod_successiveMinimum_scale (L : Lattice n) (S : ConvexBody n) {c : ℝ}
+    (hc : 0 < c) :
+    ∏ i : Fin n, successiveMinimum n L (ConvexBody.scale n c S) i
+      = (∏ i : Fin n, successiveMinimum n L S i) / c ^ n := by
+  simp only [successiveMinimum_scale n L S hc, div_eq_mul_inv]
+  rw [Finset.prod_mul_distrib, Finset.prod_const, Finset.card_univ, Fintype.card_fin, inv_pow]
+
+/-- **The second-theorem product is scale-invariant.**  Granting only the volume
+    dilation law `vol(cS) = cⁿ vol(S)` (supplied here as a hypothesis, since the
+    parent's `HasVolume` is an abstract field), the quantity `∏ᵢ λᵢ · vol` that
+    appears on the left of Minkowski's second theorem is unchanged when the body is
+    rescaled:
+
+      (∏ᵢ λᵢ(L, cS)) · vol(cS) = (∏ᵢ λᵢ(L, S)) · vol(S). -/
+theorem secondTheorem_product_scale_invariant (L : Lattice n) (S : ConvexBody n) {c : ℝ}
+    (hc : 0 < c) (volS volcS : ℝ) (hvol : volcS = c ^ n * volS) :
+    (∏ i : Fin n, successiveMinimum n L (ConvexBody.scale n c S) i) * volcS
+      = (∏ i : Fin n, successiveMinimum n L S i) * volS := by
+  rw [prod_successiveMinimum_scale n L S hc, hvol]
+  have hcn : (c : ℝ) ^ n ≠ 0 := pow_ne_zero n hc.ne'
+  field_simp
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+Summary
+═══════════════════════════════════════════════════════════════════════════════
+
+## Homogeneity (scaling law) of the successive minima  (oq-01-oq-02)
+
+### What's proved (0 sorries, 0 axioms):
+- `sInf_preimage_mul_right`: the real-analysis engine — for `c > 0` and a set of
+  non-negative reals, `sInf {d | d·c ∈ A} = sInf A / c` (empty case included).
+- `ConvexBody.scale_scale`: dilations compose, `d • (c • S) = (d·c) • S`.
+- `admissibleScalings_scale`: scaling the body by `c` pulls back the admissible
+  set by `· * c`.
+- `successiveMinimum_scale`: **`λᵢ(L, cS) = λᵢ(L, S) / c`** — the homogeneity law,
+  no attainment hypothesis needed.
+- `successiveMinimum_scale_two`: the `c = 2` specialisation `λᵢ(L, 2S) = λᵢ(L,S)/2`.
+- `successiveMinimum_scale_le`: enlarging the body (`c ≥ 1`) lowers every minimum.
+- `prod_successiveMinimum_scale`: **`∏ᵢ λᵢ(L, cS) = (∏ᵢ λᵢ(L,S)) / cⁿ`**.
+- `secondTheorem_product_scale_invariant`: granting `vol(cS) = cⁿ vol(S)`, the
+  Minkowski-second-theorem quantity `∏ᵢ λᵢ · vol` is a scaling invariant.
+
+### Honest scope:
+This is the structural homogeneity of the successive minima and of the
+second-theorem product — the basic scaling covariance that any treatment must
+have.  The second theorem's product *bound* itself remains the open analytic core
+(unchanged from the parent files); here we only show that the quantity it bounds
+behaves correctly under rescaling of the body.
+-/
+
+#check @sInf_preimage_mul_right
+#check @ConvexBody.scale_scale
+#check @admissibleScalings_scale
+#check @successiveMinimum_scale
+#check @prod_successiveMinimum_scale
+#check @secondTheorem_product_scale_invariant
+
+end MinkowskiSecondTheoremHomogeneity

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-mft-oq01oq02-scope",
+    "proofId": "minkowski-fundamental-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
+    "type": "insight",
+    "title": "Homogeneity of the Successive Minima — Honest Scope",
+    "content": "The parent (minkowski-fundamental-theorem-oq-01) built the successive-minima framework, λᵢ(L, S) = inf{c > 0 : cS contains i+1 independent lattice points}, and left the second theorem's product bound open. This file isolates the single most basic structural property of that functional: its behaviour under dilation of the body. The headline λᵢ(L, cS) = λᵢ(L, S)/c is fully proved (0 axioms, 0 sorries) and needs no attainment hypothesis. The deep product bound itself remains the open analytic core — this file only shows the quantity it bounds rescales correctly.",
+    "mathContext": "Inverse-degree-1 homogeneity: dilating the body by c divides every successive minimum by c. This is what makes ∏ᵢ λᵢ·vol(S) a normalization-independent invariant in Minkowski's second theorem.",
+    "significance": "key",
+    "relatedConcepts": [
+      "successive minima",
+      "homogeneity",
+      "geometry of numbers",
+      "convex body dilation"
+    ]
+  },
+  {
+    "id": "ann-mft-oq01oq02-sinf-engine",
+    "proofId": "minkowski-fundamental-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 70,
+      "endLine": 108
+    },
+    "type": "technique",
+    "title": "The Real-Analysis Engine: Scaling an Infimum",
+    "content": "Every homogeneity statement reduces to one fact about infima on ℝ: for c > 0 and a set A of non-negative reals, sInf {d | d·c ∈ A} = sInf A/c. The proof is pure csInf antisymmetry. 0 is a common lower bound for A and its stretched preimage (from 0 ≤ d·c and 0 < c via le_of_mul_le_mul_right). The two inequalities use le_csInf / csInf_le, with le_div_iff₀ and div_le_iff₀ translating between the d-world and the (d·c)-world. The empty case — an unattained minimum — is closed automatically by Real.sInf_empty and zero_div, which is exactly why no attainment hypothesis is needed downstream.",
+    "mathContext": "sInf {d | d·c ∈ A} = sInf A/c. No measure theory or analysis — only the order-completeness of ℝ through conditional infima.",
+    "significance": "key",
+    "relatedConcepts": [
+      "conditional infimum",
+      "csInf antisymmetry",
+      "order completeness of ℝ"
+    ]
+  },
+  {
+    "id": "ann-mft-oq01oq02-pullback",
+    "proofId": "minkowski-fundamental-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 115,
+      "endLine": 131
+    },
+    "type": "technique",
+    "title": "Dilations Compose, and the Admissible Set Pulls Back",
+    "content": "Two dilations compose multiplicatively, d • (c • S) = (d·c) • S (ConvexBody.scale_scale, by smul_smul). Hence scaling the body by c turns the admissible-scaling condition for cS at factor d into the condition for S at factor d·c: admissibleScalings(cS) i = {d | d·c ∈ admissibleScalings(S) i}. The positivity sides match via mul_pos_iff_of_pos_right (0 < d·c ↔ 0 < d for c > 0), so the two set descriptions agree pointwise by Set.ext.",
+    "mathContext": "The admissible-scaling set of the dilated body is the (·*c)-preimage of the original — precisely the shape the infimum-scaling lemma consumes.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pointwise scalar action",
+      "smul_smul",
+      "set preimage under a stretch"
+    ]
+  },
+  {
+    "id": "ann-mft-oq01oq02-homogeneity",
+    "proofId": "minkowski-fundamental-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 138,
+      "endLine": 167
+    },
+    "type": "insight",
+    "title": "The Homogeneity Law and its Monotone Shadow",
+    "content": "Unfolding the successive minimum to the infimum of its admissible set, rewriting by the pullback, and applying the infimum-scaling lemma gives the headline λᵢ(L, cS) = λᵢ(L, S)/c. Immediate corollaries: doubling the body halves every minimum (λᵢ(L, 2S) = λᵢ(L, S)/2), and enlarging the body (c ≥ 1) cannot increase any minimum (successiveMinimum_scale_le, from div_le_iff₀ and nonnegativity of the minima). These capture the intuition that a bigger body meets the lattice sooner.",
+    "mathContext": "λᵢ(L, cS) = λᵢ(L, S)/c for all c > 0; specialisations and monotonicity in the body follow by elementary algebra of division.",
+    "significance": "key",
+    "relatedConcepts": [
+      "homogeneous functional",
+      "monotonicity in the body",
+      "division inequalities"
+    ]
+  },
+  {
+    "id": "ann-mft-oq01oq02-invariant",
+    "proofId": "minkowski-fundamental-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 169,
+      "endLine": 204
+    },
+    "type": "insight",
+    "title": "Why the Second-Theorem Quantity is a Scaling Invariant",
+    "content": "Taking the product of n minima, the c⁻¹ per factor accumulates to c⁻ⁿ: ∏ᵢ λᵢ(L, cS) = (∏ᵢ λᵢ(L, S))/cⁿ (prod_successiveMinimum_scale, via Finset.prod_mul_distrib + Finset.prod_const + inv_pow). The volume of a dilated body scales the other way, vol(cS) = cⁿ·vol(S). Multiplying the two, the cⁿ factors cancel: (∏ᵢ λᵢ(L, cS))·vol(cS) = (∏ᵢ λᵢ(L, S))·vol(S). So the quantity ∏ᵢ λᵢ·vol that Minkowski's second theorem brackets between (2ⁿ/n!)·covol and 2ⁿ·covol does not depend on how the body is normalized — the homogeneity makes the theorem a statement about the lattice and the body's shape, not its size.",
+    "mathContext": "∏ᵢ λᵢ(L, cS)·vol(cS) = ∏ᵢ λᵢ(L, S)·vol(S): the second-theorem quantity is invariant under S ↦ cS.",
+    "significance": "key",
+    "relatedConcepts": [
+      "scaling invariance",
+      "finite products",
+      "Minkowski's second theorem"
+    ]
+  }
+]

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,217 @@
+{
+  "id": "minkowski-fundamental-theorem-oq-01-oq-02",
+  "title": "Homogeneity (Scaling Law) of the Successive Minima",
+  "slug": "minkowski-fundamental-theorem-oq-01-oq-02",
+  "description": "Next step of minkowski-fundamental-theorem-oq-01 (which built the successive-minima infrastructure). Proves the most basic structural law any honest treatment of the successive minima must have: their behaviour under rescaling of the convex body. Dilating S by a factor c > 0 inverts every successive minimum, λᵢ(L, cS) = λᵢ(L, S)/c, with NO attainment hypothesis (the empty/unattained case reads 0 = 0/c). Consequences: doubling halves every minimum (λᵢ(L,2S)=λᵢ(L,S)/2), enlarging the body lowers every minimum, the product scales as ∏ᵢ λᵢ(L,cS) = (∏ᵢ λᵢ(L,S))/cⁿ, and — granting the volume dilation law vol(cS)=cⁿ·vol(S) — the Minkowski second-theorem quantity ∏ᵢ λᵢ·vol is a scaling invariant. The engine is a self-contained scaling lemma for infima on ℝ (sInf {d | d·c ∈ A} = sInf A/c) proved by elementary csInf antisymmetry. All 0 axioms, 0 sorries; the second theorem's product bound itself remains the open analytic core.",
+  "meta": {
+    "author": "Hermann Minkowski (1896); Lean 4 formalization (research, 2026)",
+    "date": "1896",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MinkowskiFundamentalTheoremOQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "geometry-of-numbers",
+      "minkowski-theorem",
+      "successive-minima",
+      "lattices",
+      "convex-bodies"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 242,
+    "assumptions": "0 axioms, 0 sorries. Built on the parent OQ-01 file's successive-minima API (Proofs.MinkowskiFundamentalTheoremOQ01) and the grandparent's Lattice / ConvexBody / HasVolume API. The homogeneity law successiveMinimum_scale needs NO attainment hypothesis — it holds verbatim when a minimum is unattained, since both sides are then 0. The only ingredient supplied as a hypothesis is the volume dilation law vol(cS) = cⁿ·vol(S) used in secondTheorem_product_scale_invariant, because the parent's HasVolume is an abstract field rather than a computed Lebesgue measure. HONEST SCOPE: the product bound of Minkowski's second theorem is NOT proved here (it is the open analytic core); this file establishes only that the quantity it bounds behaves correctly under rescaling of the body.",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-21",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Minkowski's *second* theorem (Geometrie der Zahlen, 1896) bounds the product of the successive minima λ₁ ≤ ⋯ ≤ λₙ of a symmetric convex body S with respect to a lattice L:\n\n    (2ⁿ / n!) · covolume(L) ≤ λ₁ λ₂ ⋯ λₙ · vol(S) ≤ 2ⁿ · covolume(L).\n\nThe successive minimum λᵢ(L, S) is the smallest dilation factor c > 0 such that cS contains i+1 linearly independent lattice points. The most elementary property of this functional — and the one that makes the second-theorem quantity well-posed — is its homogeneity: the minima are inverse-homogeneous of degree 1 in the body. The parent entry minkowski-fundamental-theorem-oq-01 built the framework and proved the order structure; the sibling oq-01-oq-01 bracketed the product. This entry isolates the scaling law itself.",
+    "problemStatement": "Determine how the successive minima transform when the convex body is dilated. Prove λᵢ(L, cS) = λᵢ(L, S)/c for every c > 0 and index i (with no attainment hypothesis), and deduce the product law ∏ᵢ λᵢ(L, cS) = (∏ᵢ λᵢ(L, S))/cⁿ together with the scale-invariance of the second-theorem quantity ∏ᵢ λᵢ · vol(S).",
+    "text": "Working on top of the parent's successiveMinimum and admissibleScalings, the file first proves a self-contained scaling lemma for infima on ℝ: for c > 0 and a set A of non-negative reals, sInf {d | d·c ∈ A} = sInf A/c (with the empty/unattained case 0 = 0/c handled automatically since sInf ∅ = 0). It then shows dilations compose (d • (c • S) = (d·c) • S) and that scaling the body by c pulls back the admissible-scaling set by (· * c). Feeding the set identity into the infimum lemma yields the homogeneity law λᵢ(L, cS) = λᵢ(L, S)/c. From it follow the c = 2 specialisation, monotone-down in the body for c ≥ 1, the product law ∏ᵢ λᵢ(L, cS) = (∏ᵢ λᵢ(L, S))/cⁿ, and — granting vol(cS) = cⁿ·vol(S) — the scale-invariance (∏ᵢ λᵢ(L, cS))·vol(cS) = (∏ᵢ λᵢ(L, S))·vol(S).",
+    "proofStrategy": "1. **Scaling law for infima** (`sInf_preimage_mul_right`): for c > 0 and A ⊆ ℝ with all elements ≥ 0, sInf {d | d·c ∈ A} = sInf A/c. Proved by csInf antisymmetry: 0 is a common lower bound (using le_of_mul_le_mul_right), and the two inequalities come from le_csInf / csInf_le with le_div_iff₀ / div_le_iff₀ converting between d and d·c. The empty case is closed by Real.sInf_empty and zero_div.\n\n2. **Dilations compose** (`ConvexBody.scale_scale`): d • (c • S) = (d·c) • S, by smul_smul on the carriers.\n\n3. **Admissible sets pull back** (`admissibleScalings_scale`): admissibleScalings(cS) i = {d | d·c ∈ admissibleScalings(S) i}, by Set.ext, scale_scale, and mul_pos_iff_of_pos_right to match the positivity condition 0 < d·c ↔ 0 < d.\n\n4. **Homogeneity** (`successiveMinimum_scale`): unfold successiveMinimum to sInf of the admissible set, rewrite by step 3, and apply step 1 with A = admissibleScalings(S) i (its elements are positive, hence ≥ 0).\n\n5. **Consequences**: successiveMinimum_scale_two (c = 2), successiveMinimum_scale_le (c ≥ 1, via div_le_iff₀ and nonnegativity of the minima), prod_successiveMinimum_scale (Finset.prod_mul_distrib + Finset.prod_const + inv_pow), and secondTheorem_product_scale_invariant (rewrite by the product law and vol(cS)=cⁿ·vol(S), then field_simp).",
+    "keyInsights": [
+      "The successive minima are inverse-homogeneous of degree 1 in the body: λᵢ(L, cS) = λᵢ(L, S)/c. Making the body c times bigger makes every threshold c times smaller — the defining geometric scaling of the functional.",
+      "The whole statement reduces to one purely real-analytic fact about infima: sInf of the stretched preimage {d | d·c ∈ A} equals sInf A/c. No measure theory and no analysis are needed — only csInf antisymmetry.",
+      "No attainment hypothesis is required (unlike the order-chain results of the sibling oq-01-oq-01). The law holds verbatim when a minimum is unattained, because then both admissible sets are empty and the identity reads 0 = 0/c — handled automatically by sInf ∅ = 0.",
+      "Homogeneity is exactly why the second-theorem quantity ∏ᵢ λᵢ · vol(S) is well-posed: under S ↦ cS the product of minima divides by cⁿ while the volume multiplies by cⁿ, so the quantity bounded by Minkowski's second theorem is a scaling invariant."
+    ],
+    "prerequisites": [
+      "minkowski-fundamental-theorem-oq-01 — the successive-minima infrastructure (successiveMinimum, admissibleScalings, ConvexBody.scale)",
+      "Minkowski's fundamental (first) theorem — see minkowski-fundamental-theorem",
+      "Infima of sets of reals (csInf_le, le_csInf, Real.sInf_empty) and order-of-division lemmas (le_div_iff₀, div_le_iff₀)",
+      "Finite products over Fin n (Finset.prod_mul_distrib, Finset.prod_const)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: Imports and Setup",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Imports Mathlib, the grandparent Proofs.MinkowskiFundamentalTheorem, and the parent Proofs.MinkowskiFundamentalTheoremOQ01; opens both namespaces, Set, and the Pointwise instances. Header documents the homogeneity law and the honest scope.",
+      "mathContext": "Reuses the parent's successiveMinimum / admissibleScalings / ConvexBody.scale, keeping the scaling argument inside the established successive-minima abstraction."
+    },
+    {
+      "id": "infimum-scaling",
+      "title": "Part I: A Scaling Law for Infima on ℝ",
+      "startLine": 57,
+      "endLine": 109,
+      "summary": "sInf_preimage_mul_right: for c > 0 and A a set of non-negative reals, sInf {d | d·c ∈ A} = sInf A/c, proved by csInf antisymmetry with the empty case handled automatically.",
+      "mathContext": "The single real-analytic engine behind every homogeneity statement: stretching the variable by a positive constant scales the infimum by the same constant."
+    },
+    {
+      "id": "scale-composition",
+      "title": "Part II: Scaling the Convex Body Composes",
+      "startLine": 110,
+      "endLine": 132,
+      "summary": "ConvexBody.scale_scale (d • (c • S) = (d·c) • S) and admissibleScalings_scale (admissibleScalings(cS) i = {d | d·c ∈ admissibleScalings(S) i}).",
+      "mathContext": "Dilations compose multiplicatively, so scaling the body by c is the same as a stretch (· * c) on the admissible-scaling parameter."
+    },
+    {
+      "id": "homogeneity",
+      "title": "Part III: Homogeneity of Each Successive Minimum",
+      "startLine": 133,
+      "endLine": 168,
+      "summary": "successiveMinimum_scale (λᵢ(L, cS) = λᵢ(L, S)/c), successiveMinimum_scale_two (c = 2), successiveMinimum_scale_le (c ≥ 1 lowers every minimum).",
+      "mathContext": "Combining the infimum scaling law with the admissible-set pullback gives the inverse-degree-1 homogeneity of the successive minima, plus its immediate monotone consequences."
+    },
+    {
+      "id": "product-invariant",
+      "title": "Part IV: Homogeneity of the Product — the Scaling Invariant",
+      "startLine": 169,
+      "endLine": 204,
+      "summary": "prod_successiveMinimum_scale (∏ᵢ λᵢ(L, cS) = (∏ᵢ λᵢ(L, S))/cⁿ) and secondTheorem_product_scale_invariant (granting vol(cS)=cⁿ·vol(S), the quantity ∏ᵢ λᵢ·vol is unchanged under rescaling).",
+      "mathContext": "The product of n minima scales by c⁻ⁿ; pairing it with the cⁿ scaling of the volume shows the Minkowski second-theorem quantity is a scaling invariant."
+    }
+  ],
+  "conclusion": {
+    "summary": "The successive minima are shown to be inverse-homogeneous of degree 1 in the convex body, λᵢ(L, cS) = λᵢ(L, S)/c, with no attainment hypothesis (0 axioms, 0 sorries). Consequences include the product law ∏ᵢ λᵢ(L, cS) = (∏ᵢ λᵢ(L, S))/cⁿ and — granting vol(cS) = cⁿ·vol(S) — the scale-invariance of the Minkowski second-theorem quantity ∏ᵢ λᵢ · vol(S).",
+    "implications": "Homogeneity is the structural prerequisite that makes Minkowski's second theorem a meaningful normalization-independent statement: both sides of (2ⁿ/n!)·covol ≤ ∏λᵢ·vol ≤ 2ⁿ·covol transform consistently under rescaling. The result is also a clean tool — it lets one normalize the body (e.g. so that λₙ₋₁ = 1) without loss of generality when attacking the open product bound.",
+    "openQuestions": [
+      "Prove the product bound secondTheorem_upper_statement: (∏ λᵢ)·vol(S) ≤ 2ⁿ·covolume(L), via a basis realizing the successive minima and simultaneous reduction.",
+      "Prove the matching lower bound (2ⁿ/n!)·covolume(L) ≤ (∏ λᵢ)·vol(S).",
+      "Supply the volume dilation law vol(cS) = cⁿ·vol(S) from the Lebesgue measure (rather than as a hypothesis), making secondTheorem_product_scale_invariant unconditional once HasVolume is instantiated by an actual measure."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "minkowski-fundamental-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the successive-minima infrastructure. This entry reuses its successiveMinimum / admissibleScalings / ConvexBody.scale and proves the homogeneity law that the parent did not address."
+    },
+    {
+      "targetId": "minkowski-fundamental-theorem-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling: bracketing of the product of successive minima by the extreme minima. Where that entry exploits the order chain (needing attainment), this entry proves the scaling law (needing no attainment)."
+    },
+    {
+      "targetId": "minkowski-fundamental-theorem",
+      "relationship": "related",
+      "description": "Grandparent: Minkowski's fundamental (first) theorem, whose Lattice / ConvexBody / HasVolume API underlies the whole successive-minima development."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.MinkowskiFundamentalTheorem",
+      "Proofs.MinkowskiFundamentalTheoremOQ01"
+    ],
+    "opens": [
+      "MinkowskiFundamentalTheorem",
+      "MinkowskiSecondTheorem",
+      "Set",
+      "Pointwise"
+    ],
+    "namespace": "MinkowskiSecondTheoremHomogeneity",
+    "lineCount": 242,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "successiveMinimum_scale",
+        "type": "core",
+        "description": "Homogeneity of the successive minima: dilating the body by c > 0 inverts every minimum, λᵢ(L, cS) = λᵢ(L, S)/c. No attainment hypothesis.",
+        "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → {c : ℝ} → 0 < c → (i : Fin n) → successiveMinimum n L (ConvexBody.scale n c S) i = successiveMinimum n L S i / c"
+      },
+      {
+        "name": "prod_successiveMinimum_scale",
+        "type": "key",
+        "description": "The product of the successive minima scales by c⁻ⁿ: ∏ᵢ λᵢ(L, cS) = (∏ᵢ λᵢ(L, S))/cⁿ.",
+        "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → {c : ℝ} → 0 < c → ∏ i, successiveMinimum n L (ConvexBody.scale n c S) i = (∏ i, successiveMinimum n L S i) / c ^ n"
+      },
+      {
+        "name": "secondTheorem_product_scale_invariant",
+        "type": "key",
+        "description": "Granting the volume dilation law vol(cS) = cⁿ·vol(S), the Minkowski second-theorem quantity ∏ᵢ λᵢ·vol is invariant under rescaling of the body.",
+        "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → {c : ℝ} → 0 < c → (volS volcS : ℝ) → volcS = c ^ n * volS → (∏ i, successiveMinimum n L (ConvexBody.scale n c S) i) * volcS = (∏ i, successiveMinimum n L S i) * volS"
+      },
+      {
+        "name": "sInf_preimage_mul_right",
+        "type": "supporting",
+        "description": "The real-analysis engine: for c > 0 and a set of non-negative reals, sInf {d | d·c ∈ A} = sInf A/c (empty case included).",
+        "leanType": "{c : ℝ} → 0 < c → (A : Set ℝ) → (∀ a ∈ A, 0 ≤ a) → sInf {d | d * c ∈ A} = sInf A / c"
+      }
+    ],
+    "path": "Proofs/MinkowskiFundamentalTheoremOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "successiveMinimum_scale",
+      "type": "core",
+      "description": "Homogeneity of the successive minima: dilating the body by c > 0 inverts every minimum, λᵢ(L, cS) = λᵢ(L, S)/c. No attainment hypothesis.",
+      "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → {c : ℝ} → 0 < c → (i : Fin n) → successiveMinimum n L (ConvexBody.scale n c S) i = successiveMinimum n L S i / c"
+    },
+    {
+      "name": "prod_successiveMinimum_scale",
+      "type": "key",
+      "description": "The product of the successive minima scales by c⁻ⁿ: ∏ᵢ λᵢ(L, cS) = (∏ᵢ λᵢ(L, S))/cⁿ.",
+      "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → {c : ℝ} → 0 < c → ∏ i, successiveMinimum n L (ConvexBody.scale n c S) i = (∏ i, successiveMinimum n L S i) / c ^ n"
+    },
+    {
+      "name": "secondTheorem_product_scale_invariant",
+      "type": "key",
+      "description": "Granting vol(cS) = cⁿ·vol(S), the Minkowski second-theorem quantity ∏ᵢ λᵢ·vol is invariant under rescaling of the body.",
+      "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → {c : ℝ} → 0 < c → (volS volcS : ℝ) → volcS = c ^ n * volS → (∏ i, successiveMinimum n L (ConvexBody.scale n c S) i) * volcS = (∏ i, successiveMinimum n L S i) * volS"
+    },
+    {
+      "name": "successiveMinimum_scale_le",
+      "type": "supporting",
+      "description": "Enlarging the body (c ≥ 1) does not increase any successive minimum: λᵢ(L, cS) ≤ λᵢ(L, S).",
+      "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → {c : ℝ} → 1 ≤ c → (i : Fin n) → successiveMinimum n L (ConvexBody.scale n c S) i ≤ successiveMinimum n L S i"
+    },
+    {
+      "name": "admissibleScalings_scale",
+      "type": "supporting",
+      "description": "Scaling the body by c > 0 pulls the admissible-scaling set back by (· * c): admissibleScalings(cS) i = {d | d·c ∈ admissibleScalings(S) i}.",
+      "leanType": "(n : ℕ) → [NeZero n] → (L : Lattice n) → (S : ConvexBody n) → {c : ℝ} → 0 < c → (i : Fin n) → admissibleScalings n L (ConvexBody.scale n c S) i = {d | d * c ∈ admissibleScalings n L S i}"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Minkowski, Hermann",
+      "title": "Geometrie der Zahlen",
+      "year": "1896",
+      "venue": "Leipzig: Teubner",
+      "note": "Introduces the successive minima and the second theorem bounding their product"
+    },
+    {
+      "authors": "Cassels, J. W. S.",
+      "title": "An Introduction to the Geometry of Numbers",
+      "year": "1959",
+      "venue": "Springer-Verlag, Grundlehren 99",
+      "note": "Chapter VIII; the homogeneity of the successive minima under dilation of the body is the basic scaling property of the functional"
+    },
+    {
+      "authors": "Gruber, P. M. and Lekkerkerker, C. G.",
+      "title": "Geometry of Numbers",
+      "year": "1987",
+      "venue": "North-Holland",
+      "note": "Comprehensive treatment of successive minima, their homogeneity, and transference theorems"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Next step of **minkowski-fundamental-theorem-oq-01** (which built the successive-minima infrastructure and left Minkowski's second-theorem product bound as an open scaffold). This entry proves the most basic *structural* law any honest treatment of the successive minima must have: their behaviour under **rescaling of the convex body**.

For the i-th successive minimum λᵢ(L, S) = inf{ c > 0 : cS contains i+1 independent lattice points }, dilating the body by a factor `c > 0` inverts every minimum:

> **λᵢ(L, cS) = λᵢ(L, S) / c**   — with **no attainment hypothesis** (the unattained case reads `0 = 0/c`).

### What's proved (0 axioms, 0 sorries, no `native_decide`)
- `sInf_preimage_mul_right` — the self-contained real-analysis engine: for `c > 0` and a set of non-negative reals, `sInf {d | d·c ∈ A} = sInf A / c` (empty case included), by elementary `csInf` antisymmetry.
- `ConvexBody.scale_scale` — dilations compose: `d • (c • S) = (d·c) • S`.
- `admissibleScalings_scale` — scaling the body pulls the admissible-scaling set back by `(· * c)`.
- `successiveMinimum_scale` — **the homogeneity law** `λᵢ(L, cS) = λᵢ(L, S)/c`.
- `successiveMinimum_scale_two` / `successiveMinimum_scale_le` — doubling halves every minimum; enlarging the body (`c ≥ 1`) lowers every minimum.
- `prod_successiveMinimum_scale` — `∏ᵢ λᵢ(L, cS) = (∏ᵢ λᵢ(L, S)) / cⁿ`.
- `secondTheorem_product_scale_invariant` — granting the volume dilation law `vol(cS) = cⁿ·vol(S)`, the Minkowski second-theorem quantity `∏ᵢ λᵢ · vol` is a **scaling invariant**.

### Why it matters
Homogeneity is exactly what makes Minkowski's second theorem a normalization-independent statement: under `S ↦ cS` the product of minima divides by `cⁿ` while the volume multiplies by `cⁿ`, so the bracketed quantity `∏ᵢ λᵢ·vol(S)` is unchanged. Neither the parent nor the sibling oq-01-oq-01 (which bracketed the product, needing attainment) addressed the scaling law; unlike those, this law needs no attainment hypothesis.

### Honest scope
The second theorem's product *bound* itself remains the open analytic core (unchanged). This file establishes only that the quantity it bounds behaves correctly under rescaling.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.MinkowskiFundamentalTheoremOQ01OQ02` — builds clean (Lean 4 / Mathlib 4.26.0).
- `#print axioms` on every main theorem: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. **0-axiom verified.**

242 lines, 8 theorems, 0 definitions. Gallery entry under `src/data/proofs/minkowski-fundamental-theorem-oq-01-oq-02/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)