### PR TITLE
research(solution-of-cubic oq-01): reduce general cubic to depressed form via Tschirnhaus shift [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3262,6 +3262,7 @@ import Proofs.SkolemNoetherCSA
 import Proofs.SkolemNoetherMatrixAut
 import Proofs.SkolemNoetherMatrixAutAristotle
 import Proofs.SolutionOfCubic
+import Proofs.SolutionOfCubicOQ01
 import Proofs.SolutionOfCubicOQ03
 import Proofs.SolutionOfCubicOQ03OQ01
 import Proofs.SolutionOfCubicOQ03OQ02

--- a/proofs/Proofs/SolutionOfCubicOQ01.lean
+++ b/proofs/Proofs/SolutionOfCubicOQ01.lean
@@ -1,0 +1,161 @@
+import Proofs.SolutionOfCubic
+
+/-!
+# Reducing the General Cubic to Depressed Form (Solution of Cubic, OQ-01)
+
+## What This Proves
+
+The parent file `SolutionOfCubic` solves the **depressed** cubic `t³ + p t + q = 0`
+via Cardano's formula. But a textbook cubic comes in the *general* shape
+
+  `a x³ + b x² + c x + d = 0`   (`a ≠ 0`).
+
+The first — and historically essential — step of Cardano's method is the **Tschirnhaus
+shift** `x = t − b/(3a)`, which annihilates the quadratic term and produces a depressed
+cubic `t³ + p t + q` with
+
+  `p = (3ac − b²) / (3a²)`,   `q = (2b³ − 9abc + 27a²d) / (27a³)`.
+
+This file proves that reduction as a clean field identity, then *bridges it back* to the
+parent file: combining the shift with `SolutionOfCubic.cardano_formula` yields an explicit
+root of the **general** cubic, closing the loop from `a x³ + b x² + c x + d` all the way to
+a radical expression.
+
+## Original Contributions
+- `cubic_depress` — the core algebraic identity: the shifted general cubic equals
+  `a·(t³ + p t + q)`. This is exactly the statement quoted in the parent's docstring,
+  here proved rather than asserted.
+- `generalCubicEval_shift` — evaluation form: `general(t − b/3a) = a · depressed(t)`.
+- `general_root_of_depressed_root` / `depressed_root_of_general_root` — the shift is a
+  *bijection on roots*: `t ↦ t − b/(3a)` carries roots of the depressed cubic to roots of
+  the general cubic and back.
+- `general_cubic_cardano_root` — the payoff: an explicit Cardano root of the general
+  cubic, built from the parent's `cardano_formula`.
+
+## Proof Techniques
+Pure field arithmetic (`field_simp` + `ring`) for the shift; the parent's depressed-cubic
+theorems for the bridge. Everything is over `ℂ`, matching the parent, and is `0`-axiom.
+-/
+
+namespace SolutionOfCubicOQ01
+
+open Complex Polynomial SolutionOfCubic
+
+/-! ## Part 1: The depressed parameters
+
+Given a general cubic `a x³ + b x² + c x + d`, these are the `p` and `q` of the depressed
+cubic obtained from the shift `x = t − b/(3a)`. -/
+
+/-- Linear coefficient of the depressed cubic: `p = (3ac − b²)/(3a²)`. -/
+noncomputable def depressedP (a b c : ℂ) : ℂ := (3 * a * c - b ^ 2) / (3 * a ^ 2)
+
+/-- Constant coefficient of the depressed cubic: `q = (2b³ − 9abc + 27a²d)/(27a³)`. -/
+noncomputable def depressedQ (a b c d : ℂ) : ℂ :=
+  (2 * b ^ 3 - 9 * a * b * c + 27 * a ^ 2 * d) / (27 * a ^ 3)
+
+/-! ## Part 2: The core reduction identity
+
+Substituting `x = t − b/(3a)` into the general cubic gives `a · (t³ + p t + q)`. -/
+
+/-- **The Tschirnhaus shift.** For `a ≠ 0`, evaluating the general cubic
+`a x³ + b x² + c x + d` at `x = t − b/(3a)` produces `a · (t³ + p t + q)`, where `p` and
+`q` are the depressed parameters. In particular the `t²` term has vanished. -/
+theorem cubic_depress (a b c d t : ℂ) (ha : a ≠ 0) :
+    a * (t - b / (3 * a)) ^ 3 + b * (t - b / (3 * a)) ^ 2 + c * (t - b / (3 * a)) + d
+      = a * (t ^ 3 + depressedP a b c * t + depressedQ a b c d) := by
+  unfold depressedP depressedQ
+  field_simp
+  ring
+
+/-! ## Part 3: Evaluation form and the root bijection
+
+We package the general cubic as an evaluation function and relate its roots, under the
+shift, to roots of the parent's `depressedCubic`. -/
+
+/-- The general cubic `a x³ + b x² + c x + d` as an evaluation function. -/
+noncomputable def generalCubicEval (a b c d x : ℂ) : ℂ :=
+  a * x ^ 3 + b * x ^ 2 + c * x + d
+
+/-- Evaluation form of the shift: the general cubic at `t − b/(3a)` equals `a` times the
+parent's depressed cubic evaluated at `t`. -/
+theorem generalCubicEval_shift (a b c d t : ℂ) (ha : a ≠ 0) :
+    generalCubicEval a b c d (t - b / (3 * a))
+      = a * (depressedCubic (depressedP a b c) (depressedQ a b c d)).eval t := by
+  rw [generalCubicEval, depressedCubic_eval, cubic_depress a b c d t ha]
+
+/-- **Roots descend along the shift.** If `t` is a root of the depressed cubic, then
+`t − b/(3a)` is a root of the general cubic. -/
+theorem general_root_of_depressed_root (a b c d t : ℂ) (ha : a ≠ 0)
+    (ht : (depressedCubic (depressedP a b c) (depressedQ a b c d)).eval t = 0) :
+    generalCubicEval a b c d (t - b / (3 * a)) = 0 := by
+  rw [generalCubicEval_shift a b c d t ha, ht, mul_zero]
+
+/-- **Roots lift along the shift.** Conversely, if `x` is a root of the general cubic, then
+`t = x + b/(3a)` is a root of the depressed cubic. Together with the previous theorem this
+shows `t ↦ t − b/(3a)` is a bijection between the two root sets (its inverse is
+`x ↦ x + b/(3a)`). -/
+theorem depressed_root_of_general_root (a b c d x : ℂ) (ha : a ≠ 0)
+    (hx : generalCubicEval a b c d x = 0) :
+    (depressedCubic (depressedP a b c) (depressedQ a b c d)).eval (x + b / (3 * a)) = 0 := by
+  have hshift : generalCubicEval a b c d ((x + b / (3 * a)) - b / (3 * a))
+      = a * (depressedCubic (depressedP a b c) (depressedQ a b c d)).eval (x + b / (3 * a)) :=
+    generalCubicEval_shift a b c d (x + b / (3 * a)) ha
+  rw [add_sub_cancel_right, hx] at hshift
+  -- now `0 = a * eval`, and `a ≠ 0`, so `eval = 0`
+  have := hshift.symm
+  rcases mul_eq_zero.mp this with h | h
+  · exact absurd h ha
+  · exact h
+
+/-! ## Part 4: The payoff — a Cardano root of the *general* cubic
+
+Chaining the shift with the parent's `cardano_formula` gives an explicit root of the
+general cubic in Cardano form. -/
+
+/-- **General cubic, solved.** For `a ≠ 0`, if `u, v` satisfy the Cardano conditions for the
+*depressed* parameters — `u³ + v³ = −q` and `u v = −p/3` — then
+
+  `x = (u + v) − b/(3a)`
+
+is a root of the general cubic `a x³ + b x² + c x + d = 0`. This is Cardano's complete
+solution: the shift of Part 2 followed by the parent's depressed-cubic formula. -/
+theorem general_cubic_cardano_root (a b c d u v : ℂ) (ha : a ≠ 0)
+    (h_sum : u ^ 3 + v ^ 3 = -depressedQ a b c d)
+    (h_prod : u * v = -depressedP a b c / 3) :
+    generalCubicEval a b c d (u + v - b / (3 * a)) = 0 := by
+  apply general_root_of_depressed_root a b c d (u + v) ha
+  exact cardano_formula u v (depressedP a b c) (depressedQ a b c d) h_sum h_prod
+
+/-! ## Part 5: Sanity checks
+
+A monic cubic with a known integer root, run through the reduction. -/
+
+/-- For a *monic* cubic (`a = 1`) the shift is just `x = t − b/3`, `p = c − b²/3`,
+`q = 2b³/27 − bc/3 + d`. We confirm `depressedP` and `depressedQ` specialize correctly. -/
+example (b c : ℂ) : depressedP 1 b c = c - b ^ 2 / 3 := by
+  unfold depressedP; ring
+
+example (b c d : ℂ) : depressedQ 1 b c d = 2 * b ^ 3 / 27 - b * c / 3 + d := by
+  unfold depressedQ; ring
+
+/-- Concrete check of the full identity on `x³ − 3x² + ... `: the shift kills the quadratic
+term. With `a=1, b=-3`, the shift is `x = t + 1`. -/
+example (c d t : ℂ) :
+    (1 : ℂ) * (t - (-3) / (3 * 1)) ^ 3 + (-3) * (t - (-3) / (3 * 1)) ^ 2
+        + c * (t - (-3) / (3 * 1)) + d
+      = 1 * (t ^ 3 + depressedP 1 (-3) c * t + depressedQ 1 (-3) c d) :=
+  cubic_depress 1 (-3) c d t (by norm_num)
+
+/-- `x³ − 6x − 40 = 0` (already depressed: `a=1, b=0`) has root `x = 4`. Here the shift is
+the identity and `4 = (u+v) − 0` recovers the parent example. -/
+example : generalCubicEval 1 0 (-6) (-40) 4 = 0 := by
+  unfold generalCubicEval; norm_num
+
+end SolutionOfCubicOQ01
+
+-- Summary of key results
+#check SolutionOfCubicOQ01.cubic_depress
+#check SolutionOfCubicOQ01.generalCubicEval_shift
+#check SolutionOfCubicOQ01.general_root_of_depressed_root
+#check SolutionOfCubicOQ01.depressed_root_of_general_root
+#check SolutionOfCubicOQ01.general_cubic_cardano_root

--- a/src/data/proofs/solution-of-cubic-oq-01/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-soc-oq01-shift",
+    "proofId": "solution-of-cubic-oq-01",
+    "range": {
+      "startLine": 62,
+      "endLine": 78
+    },
+    "type": "insight",
+    "title": "The Tschirnhaus Shift Kills the Quadratic Term",
+    "content": "cubic_depress is the heart of the file: substituting x = t - b/(3a) into a·x³ + b·x² + c·x + d gives a·(t³ + p·t + q). The coefficient of t² after substitution is exactly b - 3a·(b/3a) = 0 — this single cancellation is the entire content of 'depressing' the cubic and is why the translation is by precisely b/(3a). Proof is one field_simp (clearing denominators using a ≠ 0) followed by ring. The parent file only asserts this formula in its docstring; here it is machine-checked."
+  },
+  {
+    "id": "ann-soc-oq01-bijection",
+    "proofId": "solution-of-cubic-oq-01",
+    "range": {
+      "startLine": 80,
+      "endLine": 125
+    },
+    "type": "insight",
+    "title": "Roots Transfer Both Ways Because a ≠ 0",
+    "content": "The general cubic equals a times the parent's depressedCubic evaluated at t (generalCubicEval_shift). Since a ≠ 0, a·w = 0 ⟺ w = 0, so the shift t ↦ t - b/(3a) is a bijection between the root set of the depressed cubic and that of the general cubic, with explicit inverse x ↦ x + b/(3a). Cardano's three depressed roots therefore yield all three roots of the general cubic."
+  },
+  {
+    "id": "ann-soc-oq01-cardano",
+    "proofId": "solution-of-cubic-oq-01",
+    "range": {
+      "startLine": 127,
+      "endLine": 150
+    },
+    "type": "insight",
+    "title": "Closing the Loop: a Radical Root of the General Cubic",
+    "content": "general_cubic_cardano_root composes the shift with the parent's cardano_formula: given u, v with u³ + v³ = -q and u·v = -p/3 for the depressed parameters p, q, the value (u+v) - b/(3a) is a root of a·x³ + b·x² + c·x + d = 0. This supplies the missing first half of Cardano's classical method, so the gallery now contains a complete machine-checked path from an arbitrary cubic to a radical solution."
+  }
+]

--- a/src/data/proofs/solution-of-cubic-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "solution-of-cubic-oq-01",
+  "title": "Reducing the General Cubic to Depressed Form (Tschirnhaus Shift)",
+  "slug": "solution-of-cubic-oq-01",
+  "description": "Proves the Tschirnhaus shift x = t - b/(3a) reduces the general cubic ax³ + bx² + cx + d (a ≠ 0) to the depressed form a·(t³ + pt + q) with p = (3ac - b²)/(3a²) and q = (2b³ - 9abc + 27a²d)/(27a³), shows the shift is a bijection on root sets, and chains it with the parent's Cardano formula to produce an explicit root of the general cubic.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cubic_equation#Depressed_cubic",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SolutionOfCubicOQ01.lean",
+    "tags": [
+      "algebra",
+      "cubic-equations",
+      "cardano",
+      "tschirnhaus-transformation",
+      "polynomial-arithmetic",
+      "depressed-cubic",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [],
+    "originalContributions": [
+      "cubic_depress: the core identity a·(t-b/3a)³ + b·(t-b/3a)² + c·(t-b/3a) + d = a·(t³ + pt + q), proving the quadratic term is annihilated",
+      "generalCubicEval_shift: evaluation form general(t - b/3a) = a · depressed(t) bridging to the parent's depressedCubic",
+      "general_root_of_depressed_root / depressed_root_of_general_root: the shift t ↦ t - b/(3a) is a bijection between the root sets of the depressed and general cubics (inverse x ↦ x + b/(3a))",
+      "general_cubic_cardano_root: an explicit Cardano root x = (u+v) - b/(3a) of the general cubic, obtained by composing the shift with the parent's cardano_formula"
+    ],
+    "dateAdded": "2026-06-21",
+    "prerequisites": [
+      "Cardano's formula for the depressed cubic (parent proof)",
+      "Field arithmetic over the complex numbers",
+      "Polynomial evaluation"
+    ],
+    "relatedProblems": [
+      {
+        "id": "solution-of-cubic",
+        "relationship": "Parent: Cardano's formula for the depressed cubic x³ + px + q = 0"
+      },
+      {
+        "id": "solution-of-cubic-oq-03",
+        "relationship": "Sibling: Vieta's formulas for the Cardano roots"
+      },
+      {
+        "id": "abel-ruffini",
+        "relationship": "Related: impossibility of a general radical formula for the quintic"
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 161,
+    "assumptions": "None. All theorems fully proved from Mathlib with 0 axioms and 0 sorries. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms); no native_decide, no Lean.ofReduceBool.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Cardano's *Ars Magna* (1545) presents the solution of the cubic in two stages. The second stage — the radical formula for the *depressed* cubic x³ + px + q = 0 — is the famous part, but it is useless without the first stage: turning an arbitrary cubic ax³ + bx² + cx + d into depressed form. The required device, x = t - b/(3a), is the simplest instance of a Tschirnhaus transformation (Ehrenfried Walther von Tschirnhaus, 1683), a polynomial change of variable used to remove unwanted terms. Geometrically the shift translates the graph so that its inflection point sits on the vertical axis, which is exactly the condition that the sum of the roots (the coefficient of t²) vanishes. The same idea — complete the cube — mirrors completing the square for the quadratic, and generalizes: a degree-n monic polynomial loses its xⁿ⁻¹ term under x = t - aₙ₋₁/n whenever n is invertible. The parent gallery entry solves the depressed cubic and merely *asserts* the reduction formulas in its docstring; this entry proves them and feeds the result back into the parent's Cardano machinery, closing the loop from the general cubic to a radical root.",
+    "problemStatement": "For a ≠ 0, prove the substitution x = t - b/(3a) transforms ax³ + bx² + cx + d into a·(t³ + pt + q) with p = (3ac - b²)/(3a²) and q = (2b³ - 9abc + 27a²d)/(27a³), and use this to express a root of the general cubic via Cardano's formula.",
+    "proofStrategy": "The reduction is a single field identity, discharged by field_simp (clearing the denominators introduced by the shift and by p, q, using a ≠ 0) followed by ring. The evaluation form rewrites the parent's depressedCubic_eval to expose the depressed cubic, and the root bijection follows because a ≠ 0 lets us cancel the factor a. Composing with the parent's cardano_formula yields the general-cubic root.",
+    "keyInsights": [
+      "The coefficient of t² after substitution is b - 3a·(b/3a) = 0: this single cancellation is the entire content of 'depressing' the cubic, and it is why the shift is x = t - b/(3a) and not some other translation.",
+      "The leading coefficient a is untouched by the shift, so the whole general cubic equals a·(depressed cubic). This factor a is harmless for finding roots (a ≠ 0) but must be tracked: roots transfer because a·w = 0 ⟺ w = 0.",
+      "The shift is a *bijection* on root sets with explicit inverse x ↦ x + b/(3a); every root of the general cubic is the image of exactly one depressed root, so Cardano's three depressed roots give all three general roots.",
+      "Proving the reduction over ℂ rather than a general field avoids characteristic hypotheses: 3 and its powers are automatically invertible, so field_simp needs only a ≠ 0.",
+      "Bridging to the parent (importing depressedCubic and cardano_formula) keeps the contribution genuinely new — it supplies the missing first half of Cardano's method rather than re-deriving the second half."
+    ],
+    "prerequisites": [
+      "Cardano's formula for the depressed cubic x³ + px + q = 0 (parent proof)",
+      "Field arithmetic and the field_simp/ring tactics",
+      "Polynomial evaluation over ℂ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "depressed-params",
+      "title": "Part 1: The Depressed Parameters",
+      "startLine": 49,
+      "endLine": 60,
+      "summary": "Defines p = (3ac - b²)/(3a²) and q = (2b³ - 9abc + 27a²d)/(27a³), the linear and constant coefficients of the depressed cubic produced by the shift.",
+      "mathContext": "These are the depressed coefficients obtained from the monic cubic x³ + (b/a)x² + (c/a)x + (d/a) via x = t - b/(3a); they specialize, for a monic input a = 1, to p = c - b²/3 and q = 2b³/27 - bc/3 + d."
+    },
+    {
+      "id": "core-reduction",
+      "title": "Part 2: The Core Reduction Identity",
+      "startLine": 62,
+      "endLine": 78,
+      "summary": "cubic_depress: a·(t-b/3a)³ + b·(t-b/3a)² + c·(t-b/3a) + d = a·(t³ + pt + q), proved by field_simp + ring. The t² term has vanished.",
+      "mathContext": "This is the literal statement quoted (but only asserted) in the parent file's docstring — the first stage of Cardano's method, here machine-checked."
+    },
+    {
+      "id": "root-bijection",
+      "title": "Part 3: Evaluation Form and the Root Bijection",
+      "startLine": 80,
+      "endLine": 125,
+      "summary": "Packages the general cubic as generalCubicEval, proves generalCubicEval_shift = a · depressed(t), and establishes the two directions of the root bijection between the general and depressed cubics.",
+      "mathContext": "Because a ≠ 0, a·w = 0 ⟺ w = 0, so roots transfer in both directions: t ↦ t - b/(3a) carries depressed roots to general roots, with inverse x ↦ x + b/(3a)."
+    },
+    {
+      "id": "cardano-payoff",
+      "title": "Part 4: A Cardano Root of the General Cubic",
+      "startLine": 127,
+      "endLine": 150,
+      "summary": "general_cubic_cardano_root: if u, v satisfy the Cardano conditions u³ + v³ = -q and uv = -p/3 for the depressed parameters, then (u+v) - b/(3a) is a root of the general cubic.",
+      "mathContext": "Chains the shift with the parent's cardano_formula, producing the complete classical solution of the general cubic in radical form."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Part 5: Sanity Checks",
+      "startLine": 152,
+      "endLine": 161,
+      "summary": "Specializes p, q to the monic case, verifies the shift kills the quadratic term on x³ - 3x² + ..., and recovers the parent's x³ - 6x - 40 example (root x = 4).",
+      "mathContext": "Concrete confirmations that the abstract reduction matches familiar worked examples."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) proof that the Tschirnhaus shift x = t - b/(3a) reduces the general cubic to depressed form, that the shift is a bijection on root sets, and that composing it with the parent's Cardano formula yields an explicit radical root of the general cubic. 161 lines, 5 theorems, 3 definitions.",
+    "implications": "This supplies the missing first half of Cardano's method in the gallery: the parent entry solves the depressed cubic, and this entry shows how every cubic is brought to that form and how its roots are recovered. Together they give a complete, machine-checked path from an arbitrary cubic equation to a radical solution. The same translation idea x ↦ t - aₙ₋₁/n underlies depressing quartics and higher-degree polynomials whenever the degree is invertible.",
+    "openQuestions": [
+      "Prove the analogous reduction for the general quartic ax⁴ + bx³ + cx² + dx + e via x = t - b/(4a), connecting to the resolvent-cubic solution chain.",
+      "Formalize the discriminant of the general cubic in terms of a, b, c, d and relate it to the depressed discriminant q²/4 + p³/27 used by the parent.",
+      "State the reduction over a general field of characteristic ≠ 3 (the minimal hypothesis), isolating exactly where invertibility of 3 is used.",
+      "Promote the root bijection to a statement about the multiset of roots / polynomial factorizations, showing the shift induces an isomorphism of splitting data."
+    ]
+  },
+  "status": "verified",
+  "badge": "verified",
+  "leanFile": {
+    "imports": [
+      "Proofs.SolutionOfCubic"
+    ],
+    "opens": [
+      "Complex",
+      "Polynomial",
+      "SolutionOfCubic"
+    ],
+    "namespace": "SolutionOfCubicOQ01",
+    "lineCount": 161,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 3,
+    "path": "Proofs/SolutionOfCubicOQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "solution-of-cubic",
+      "relationship": "extends",
+      "description": "Parent proof: Cardano's formula for the depressed cubic x³ + px + q = 0. The parent asserts the reduction formulas in its docstring but proves only the depressed case; this entry proves the reduction and feeds the result back into the parent's cardano_formula to solve the general cubic."
+    },
+    {
+      "targetId": "solution-of-cubic-oq-03",
+      "relationship": "complementary",
+      "description": "Sibling entry verifying Vieta's formulas for the three Cardano roots of the depressed cubic. Where that file analyzes the roots of the depressed form, this file shows how the general cubic is brought to that form in the first place."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "complementary",
+      "description": "Abel-Ruffini proves no general radical formula exists beyond degree 4. This entry completes the degree-3 radical solution (reduction + Cardano), marking the contrast with the unsolvable quintic."
+    },
+    {
+      "targetId": "general-quartic",
+      "relationship": "related",
+      "description": "Ferrari's quartic solution begins with the analogous depressing substitution x = t - b/(4a) and reduces to a resolvent cubic; the technique formalized here is the degree-3 prototype of that first step."
+    }
+  ],
+  "references": [
+    {
+      "key": "Ca45",
+      "citation": "Cardano, G., Artis Magnae, sive de Regulis Algebraicis Liber Unus, Johann Petreius, Nuremberg (1545). English translation: The Great Art, or The Rules of Algebra, MIT Press (1968), trans. T.R. Witmer.",
+      "type": "book"
+    },
+    {
+      "key": "Ti01",
+      "citation": "Tignol, J.-P., Galois' Theory of Algebraic Equations, World Scientific (2001), Chapters 3–5.",
+      "type": "book"
+    },
+    {
+      "key": "St10",
+      "citation": "Stillwell, J., Mathematics and Its History, 3rd ed., Springer Undergraduate Texts in Mathematics (2010), Chapters 6–7: cubic and quartic equations.",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/solution-of-cubic-oq-01.json
+++ b/src/data/research/problems/solution-of-cubic-oq-01.json
@@ -29,12 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SOLVED (verified, 0-axiom). Proved the Tschirnhaus shift x = t - b/(3a) reduces the general cubic ax³+bx²+cx+d (a≠0) to a·(t³+pt+q) with p=(3ac-b²)/(3a²), q=(2b³-9abc+27a²d)/(27a³). Established the shift is a root bijection (inverse x↦x+b/(3a)) and chained it with the parent's cardano_formula to yield an explicit radical root of the general cubic. File Proofs/SolutionOfCubicOQ01.lean (161L, 5 thm, 3 def, 0 sorry). #print axioms shows only propext/Classical.choice/Quot.sound — no native_decide.",
+    "builtItems": [
+      "cubic_depress: a·(t-b/3a)³ + b·(t-b/3a)² + c·(t-b/3a) + d = a·(t³ + pt + q) — the core reduction, field_simp + ring",
+      "generalCubicEval_shift: general(t - b/3a) = a · (parent depressedCubic).eval t",
+      "general_root_of_depressed_root and depressed_root_of_general_root: the shift is a bijection on root sets",
+      "general_cubic_cardano_root: explicit Cardano root (u+v) - b/(3a) of the general cubic, composing the shift with parent cardano_formula"
+    ],
+    "insights": [
+      "The t² coefficient after the substitution is b - 3a·(b/3a) = 0; this single cancellation IS 'depressing' the cubic and pins the translation at exactly b/(3a).",
+      "The leading coefficient a survives the shift, so general = a·depressed; a ≠ 0 makes a·w = 0 ⟺ w = 0, which is what makes roots transfer in both directions.",
+      "Working over ℂ instead of a general field avoids characteristic hypotheses: 3, 9, 27 are automatically invertible, so field_simp needs only a ≠ 0.",
+      "Importing the parent's depressedCubic and cardano_formula keeps the contribution new — it supplies Cardano's missing FIRST stage rather than re-deriving the second."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Knowledge Base: solution-of-cubic-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+    "nextSteps": [
+      "Analogous reduction for the general quartic via x = t - b/(4a), feeding the resolvent-cubic chain.",
+      "Express the general-cubic discriminant in a,b,c,d and relate it to the depressed q²/4 + p³/27.",
+      "Restate over a general field of characteristic ≠ 3, isolating where invertibility of 3 is used."
+    ],
+    "markdown": "# Knowledge Base: solution-of-cubic-oq-01\n\n## Problem Understanding\nReduce ax³+bx²+cx+d=0 (a≠0) to depressed form t³+pt+q=0 via x = t - b/(3a).\n\n## Result (SOLVED, verified, 0-axiom)\nProved cubic_depress (the reduction identity), the root bijection, and a Cardano root of the general cubic by composing the shift with the parent's cardano_formula. File: Proofs/SolutionOfCubicOQ01.lean.\n\n## Key technique\nfield_simp [a ≠ 0] + ring for the reduction; cancel the factor a (a≠0) for root transfer; reuse parent depressedCubic_eval and cardano_formula.\n"
   },
   "tags": [
     "algebra",


### PR DESCRIPTION
## Summary

Solves `solution-of-cubic-oq-01` ("Reduce General Cubic to Depressed Form"). Proves the first — and historically essential — stage of Cardano's method, which the parent `SolutionOfCubic` entry only **asserts** in its docstring: the Tschirnhaus shift `x = t - b/(3a)` reduces the general cubic `ax³ + bx² + cx + d` (`a ≠ 0`) to depressed form, then bridges back to the parent's Cardano formula to solve the general cubic.

## Results (`Proofs/SolutionOfCubicOQ01.lean`, 161L, 5 thm / 3 def, 0 sorry)

- **`cubic_depress`** — the core identity `a·(t-b/3a)³ + b·(t-b/3a)² + c·(t-b/3a) + d = a·(t³ + pt + q)` with `p = (3ac-b²)/(3a²)`, `q = (2b³-9abc+27a²d)/(27a³)`. The `t²` term is annihilated (`b - 3a·(b/3a) = 0`). One `field_simp` + `ring`.
- **`generalCubicEval_shift`** — evaluation form `general(t - b/3a) = a · (parent depressedCubic).eval t`.
- **`general_root_of_depressed_root` / `depressed_root_of_general_root`** — the shift `t ↦ t - b/(3a)` is a **bijection on root sets** (inverse `x ↦ x + b/(3a)`), since `a ≠ 0`.
- **`general_cubic_cardano_root`** — the payoff: composing the shift with the parent's `cardano_formula` gives an explicit radical root `(u+v) - b/(3a)` of the general cubic.

Plus sanity checks specializing to the monic case and recovering the parent's `x³-6x-40` example.

## Verification

- Builds clean: `./proofs/scripts/docker-build.sh Proofs.SolutionOfCubicOQ01` (1937 jobs).
- **0-axiom**: `#print axioms` on the main theorems lists only `propext, Classical.choice, Quot.sound`. No `native_decide`, no `Lean.ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)