### PR TITLE
research(area-of-circle-oq-05-oq-03): the Gaussian is its own Fourier transform

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -157,6 +157,7 @@ import Proofs.AreaOfCircleOQ05Incomplete01
 import Proofs.AreaOfCircleOQ05OQ01
 import Proofs.AreaOfCircleOQ05OQ01Aristotle
 import Proofs.AreaOfCircleOQ05OQ02
+import Proofs.AreaOfCircleOQ05OQ03
 import Proofs.AreaOfCircleOQ05OQ04
 import Proofs.AreaOfCircleOQ07
 import Proofs.AreaOfCircleOQ07OQ01

--- a/proofs/Proofs/AreaOfCircleOQ05OQ03.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ03.lean
@@ -1,0 +1,172 @@
+/-
+  The Gaussian is its own Fourier Transform
+  (area-of-circle-oq-05-oq-03)
+
+  Open question from the `area-of-circle-oq-05` lineage (the Gaussian integral
+  ∫ e^{-x²} = √π) and a flagged gap in `CentralLimitTheorem.lean`, which
+  *axiomatizes* the Fourier self-duality of the Gaussian.  Here we prove that
+  identity from Mathlib, axiom-free, in explicit Lebesgue-integral form:
+
+      ∫_ℝ e^{i t x} · e^{-x²/2} dx = e^{-t²/2} · √(2π)        (un-normalized)
+
+  and its probability-normalized companion
+
+      ∫_ℝ e^{i t x} · (e^{-x²/2} / √(2π)) dx = e^{-t²/2}.      (normalized)
+
+  The right-hand side of the normalized identity is exactly `e^{-t²/2}`, the
+  characteristic function of the standard normal distribution: the standard
+  Gaussian density is, up to the unitary normalization, its own Fourier transform.
+
+  METHOD (the classical "complete the square"):
+      i t x - x²/2 = -½(x - i t)² - t²/2,
+  so the integrand factors as e^{-½(x - it)²} · e^{-t²/2}; the constant e^{-t²/2}
+  pulls out of the integral, and the remaining contour integral
+  ∫ e^{-½(x - it)²} dx = √(2π) is Mathlib's
+  `GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I` (a Cauchy / vertical-
+  strip shift of the real Gaussian integral) specialised at b = 1/2, c = -t.
+
+  Everything is proved with 0 sorries and 0 axioms.
+
+  HONEST SCOPE: `CentralLimitTheorem.lean` states its Gaussian Fourier identity
+  against an *abstract* `stdGaussian` measure that is itself introduced by `axiom`;
+  discharging that particular axiom requires first replacing the abstract measure
+  by the concrete `ProbabilityTheory.gaussianReal 0 1` and is a separate
+  integration step.  What is delivered here is the full mathematical content — the
+  concrete Lebesgue-integral Fourier identity — with no axioms.
+
+  References:
+  - The Gaussian integral and its Fourier self-duality, e.g. Stein–Shakarchi,
+    Fourier Analysis (2003), Ch. 5.
+  - Mathlib: Analysis.SpecialFunctions.Gaussian.FourierTransform
+-/
+import Mathlib
+
+set_option maxHeartbeats 1200000
+set_option linter.unusedVariables false
+set_option linter.unusedSectionVars false
+
+open Real Complex MeasureTheory
+open scoped Real
+
+namespace GaussianFourierTransform
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I:  COMPLETING THE SQUARE (POINTWISE)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Completing the square, at the level of the integrand.**  For every real `x`,
+
+      e^{i t x} · e^{-x²/2} = e^{-(1/2)(x + (-t)·i)²} · e^{-t²/2}.
+
+    This is the identity `i t x - x²/2 = -½(x - i t)² - t²/2` exponentiated; the
+    second factor on the right is the constant that will pull out of the integral. -/
+theorem gaussian_integrand_complete_square (t x : ℝ) :
+    Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)
+      = Complex.exp (-(((1 : ℝ) / 2 : ℝ) : ℂ) * ((x : ℂ) + ((-t : ℝ) : ℂ) * Complex.I) ^ 2)
+        * Complex.exp (-(t : ℂ) ^ 2 / 2) := by
+  rw [← Complex.exp_add, ← Complex.exp_add]
+  congr 1
+  push_cast
+  linear_combination (t : ℂ) ^ 2 / 2 * Complex.I_sq
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II:  THE CONSTANT √(2π) FROM THE CONTOUR INTEGRAL
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The Mathlib contour-integral constant `(π / (1/2))^(1/2)` is the complex
+    coercion of the real `√(2π)`. -/
+theorem cpow_half_eq_sqrt_two_pi :
+    ((π : ℂ) / (((1 : ℝ) / 2 : ℝ) : ℂ)) ^ (1 / 2 : ℂ)
+      = ((Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  have h0 : (0 : ℝ) ≤ 2 * π := by positivity
+  rw [show ((π : ℂ) / (((1 : ℝ) / 2 : ℝ) : ℂ)) = ((2 * π : ℝ) : ℂ) by push_cast; ring]
+  rw [Real.sqrt_eq_rpow, Complex.ofReal_cpow h0]
+  norm_num
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III:  THE GAUSSIAN FOURIER IDENTITY (LEBESGUE FORM)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **The Gaussian is its own Fourier transform (un-normalized).**
+
+      ∫_ℝ e^{i t x} · e^{-x²/2} dx = e^{-t²/2} · √(2π). -/
+theorem gaussian_fourier_real (t : ℝ) :
+    ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)
+      = Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  simp_rw [gaussian_integrand_complete_square t]
+  rw [MeasureTheory.integral_mul_const]
+  rw [GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I
+        (b := (((1 : ℝ) / 2 : ℝ) : ℂ)) (by rw [Complex.ofReal_re]; norm_num) (-t)]
+  rw [cpow_half_eq_sqrt_two_pi]
+  ring
+
+/-- **The standard Gaussian density is its own Fourier transform (normalized).**
+
+      ∫_ℝ e^{i t x} · (e^{-x²/2} / √(2π)) dx = e^{-t²/2}.
+
+    The right-hand side is the characteristic function of the standard normal
+    distribution `N(0,1)`. -/
+theorem gaussian_fourier_normalized (t : ℝ) :
+    ∫ x : ℝ, Complex.exp (Complex.I * t * x)
+        * (Complex.exp (-(x : ℂ) ^ 2 / 2) / ((Real.sqrt (2 * π) : ℝ) : ℂ))
+      = Complex.exp (-(t : ℂ) ^ 2 / 2) := by
+  have hC : ((Real.sqrt (2 * π) : ℝ) : ℂ) ≠ 0 := by
+    rw [Complex.ofReal_ne_zero]
+    have : 0 < Real.sqrt (2 * π) := Real.sqrt_pos.mpr (by positivity)
+    exact ne_of_gt this
+  simp_rw [← mul_div_assoc]
+  rw [MeasureTheory.integral_div, gaussian_fourier_real]
+  rw [mul_div_assoc, div_self hC, mul_one]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV:  CONSEQUENCES
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Total mass / `t = 0` specialisation:** the standard Gaussian density
+    integrates to `1`. -/
+theorem gaussian_density_total_mass :
+    ∫ x : ℝ, Complex.exp (-(x : ℂ) ^ 2 / 2) / ((Real.sqrt (2 * π) : ℝ) : ℂ) = 1 := by
+  simpa using gaussian_fourier_normalized 0
+
+/-- **The un-normalized Gaussian integral over ℝ:** `∫ e^{-x²/2} dx = √(2π)`
+    (the `t = 0` shadow of the Fourier identity). -/
+theorem integral_gaussian_half :
+    ∫ x : ℝ, Complex.exp (-(x : ℂ) ^ 2 / 2) = ((Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  simpa using gaussian_fourier_real 0
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+Summary
+═══════════════════════════════════════════════════════════════════════════════
+
+## The Gaussian is its own Fourier transform  (oq-05-oq-03)
+
+### What's proved (0 sorries, 0 axioms):
+- `gaussian_integrand_complete_square`: the pointwise factoring
+  e^{itx}·e^{-x²/2} = e^{-½(x-it)²}·e^{-t²/2} (completing the square, via I² = -1).
+- `cpow_half_eq_sqrt_two_pi`: the Mathlib contour constant (π/(1/2))^(1/2) = √(2π).
+- `gaussian_fourier_real`: **∫ e^{itx} e^{-x²/2} dx = e^{-t²/2}·√(2π)** — the
+  Gaussian Fourier self-duality in Lebesgue form.
+- `gaussian_fourier_normalized`: **∫ e^{itx}·(e^{-x²/2}/√(2π)) dx = e^{-t²/2}** —
+  the characteristic function of the standard normal.
+- `gaussian_density_total_mass`: the standard density integrates to 1.
+- `integral_gaussian_half`: ∫ e^{-x²/2} dx = √(2π).
+
+### Honest scope:
+The Fourier identity is proved here as a concrete Lebesgue integral.  The
+`CentralLimitTheorem.lean` axiom of the same name is phrased against an abstract
+`stdGaussian` measure introduced by `axiom`; discharging *that* axiom additionally
+requires replacing the abstract measure by `ProbabilityTheory.gaussianReal 0 1`,
+a separate bridge not attempted here.
+-/
+
+#check @gaussian_fourier_real
+#check @gaussian_fourier_normalized
+#check @gaussian_density_total_mass
+#check @integral_gaussian_half
+
+end GaussianFourierTransform

--- a/src/data/proofs/area-of-circle-oq-05-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-aoc-oq05oq03-scope",
+    "proofId": "area-of-circle-oq-05-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 54
+    },
+    "type": "insight",
+    "title": "The Gaussian's Fourier Self-Duality — Axiom-Free in Lebesgue Form",
+    "content": "The Gaussian is, up to normalization, its own Fourier transform. This entry proves the identity ∫ e^{itx}·e^{-x²/2} dx = e^{-t²/2}·√(2π) — and normalized, ∫ e^{itx}·(e^{-x²/2}/√(2π)) dx = e^{-t²/2} — with 0 axioms and 0 sorries. The normalized right-hand side is exactly the characteristic function of the standard normal N(0,1). The gallery's central-limit-theorem development currently introduces this identity as an axiom (against an abstract stdGaussian measure); here it is the proved mathematical content as a concrete Lebesgue integral.",
+    "mathContext": "Fourier transform of the standard Gaussian density = the same Gaussian; the characteristic-function input to the Central Limit Theorem.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fourier transform",
+      "Gaussian",
+      "characteristic function",
+      "central limit theorem"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03-complete-square",
+    "proofId": "area-of-circle-oq-05-oq-03",
+    "range": {
+      "startLine": 56,
+      "endLine": 71
+    },
+    "type": "technique",
+    "title": "Completing the Square over ℂ — only i² = −1 is Needed",
+    "content": "The whole computation rests on the exponent identity i t x − x²/2 = −½(x − it)² − t²/2. Both products of exponentials are first collapsed to single exponentials with Complex.exp_add; the resulting exponent equality is then closed by `push_cast` followed by `linear_combination (t²/2)·Complex.I_sq`. The difference of the two sides is exactly (t²/2)(i²+1), so feeding the single fact i² = −1 (Complex.I_sq) to linear_combination discharges it. After this step the t-dependence lives entirely in the constant e^{-t²/2}.",
+    "mathContext": "i t x − x²/2 = −½(x − it)² − t²/2; LHS − RHS = (t²/2)(i² + 1) = 0.",
+    "significance": "key",
+    "relatedConcepts": [
+      "completing the square",
+      "complex exponential",
+      "linear_combination"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03-constant",
+    "proofId": "area-of-circle-oq-05-oq-03",
+    "range": {
+      "startLine": 79,
+      "endLine": 88
+    },
+    "type": "technique",
+    "title": "The Shifted Gaussian Integral and its Constant √(2π)",
+    "content": "After completing the square, the remaining x-integral is ∫ e^{-½(x-it)²} dx — a Gaussian along a line shifted into the complex plane. Mathlib's GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I evaluates exactly this (it is a Cauchy vertical-strip argument that the shifted integral equals the real Gaussian integral), returning the complex value (π/b)^{1/2}. Specialised at b = 1/2 this is (π/(1/2))^{1/2} = (2π)^{1/2}, and cpow_half_eq_sqrt_two_pi bridges it to the real √(2π) via Complex.ofReal_cpow and Real.sqrt_eq_rpow.",
+    "mathContext": "∫ e^{-½(x-it)²} dx = (π/(1/2))^{1/2} = √(2π), independent of t.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "contour integral",
+      "vertical-strip shift",
+      "complex power",
+      "real square root"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03-assembly",
+    "proofId": "area-of-circle-oq-05-oq-03",
+    "range": {
+      "startLine": 95,
+      "endLine": 129
+    },
+    "type": "insight",
+    "title": "Assembling the Identity: Pull Out, Evaluate, Normalize",
+    "content": "With the integrand factored, the constant e^{-t²/2} pulls out of the integral (MeasureTheory.integral_mul_const), the shifted Gaussian evaluates to √(2π), and gaussian_fourier_real follows. For the normalized form, e^{itx}·(e^{-x²/2}/√(2π)) is regrouped as (e^{itx}·e^{-x²/2})/√(2π); the constant denominator pulls out (MeasureTheory.integral_div), and since √(2π) > 0 it cancels (div_self), leaving exactly e^{-t²/2}. The provider b = (1/2 : ℂ) has re = 1/2 > 0, the positivity the contour lemma requires.",
+    "mathContext": "∫ (f·c) = (∫ f)·c and ∫ (f/c) = (∫ f)/c (Bochner linearity); √(2π) ≠ 0 lets the normalization cancel.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bochner integral linearity",
+      "characteristic function",
+      "normalization"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03-consequences",
+    "proofId": "area-of-circle-oq-05-oq-03",
+    "range": {
+      "startLine": 130,
+      "endLine": 150
+    },
+    "type": "insight",
+    "title": "t = 0 Shadows: Total Mass 1 and ∫ e^{-x²/2} = √(2π)",
+    "content": "Setting t = 0 in the normalized identity gives that the standard Gaussian density has total mass 1 (gaussian_density_total_mass); setting t = 0 in the un-normalized identity gives ∫ e^{-x²/2} dx = √(2π) (integral_gaussian_half). Both fall out by `simpa` once the t-dependent exponentials collapse to 1. These are the probabilistic normalization and the half-variance Gaussian integral, recovered for free from the Fourier identity.",
+    "mathContext": "φ(0) = 1 for any characteristic function; ∫ e^{-x²/2} dx = √(2π) is the σ² = 1 Gaussian integral.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "probability density normalization",
+      "Gaussian integral",
+      "characteristic function at 0"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
@@ -1,0 +1,209 @@
+{
+  "id": "area-of-circle-oq-05-oq-03",
+  "title": "The Gaussian is its own Fourier Transform",
+  "slug": "area-of-circle-oq-05-oq-03",
+  "description": "Open question from the area-of-circle-oq-05 lineage (Gaussian integral ∫e^{-x²}=√π) and a flagged axiom in CentralLimitTheorem.lean. Proves, axiom-free, that the Gaussian is its own Fourier transform in explicit Lebesgue-integral form: ∫_ℝ e^{itx}·e^{-x²/2} dx = e^{-t²/2}·√(2π) (un-normalized) and ∫_ℝ e^{itx}·(e^{-x²/2}/√(2π)) dx = e^{-t²/2} (normalized — the characteristic function of N(0,1)). Method: complete the square i t x − x²/2 = −½(x−it)² − t²/2, pull out the constant e^{-t²/2}, and evaluate the remaining vertical-strip contour integral ∫ e^{-½(x-it)²} dx = √(2π) via Mathlib's GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I at b=1/2, c=-t. Corollaries: the standard density integrates to 1, and ∫ e^{-x²/2} dx = √(2π). All 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Classical (Gaussian Fourier self-duality); Lean 4 formalization (research, 2026)",
+    "date": "2003",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ03.lean",
+    "tags": [
+      "analysis",
+      "fourier-analysis",
+      "gaussian-integral",
+      "characteristic-function",
+      "complex-analysis",
+      "probability"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 172,
+    "assumptions": "0 axioms, 0 sorries. Builds on Mathlib's Gaussian Fourier transform infrastructure (GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I — the vertical-strip shift of the real Gaussian integral). HONEST SCOPE: CentralLimitTheorem.lean states its gaussian_fourier_identity against an abstract stdGaussian measure introduced by `axiom`; this file proves the full mathematical content as a concrete Lebesgue integral, but discharging that particular CLT axiom additionally requires replacing the abstract measure by ProbabilityTheory.gaussianReal 0 1, a separate bridge not attempted here.",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-21",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That the Gaussian function is (up to normalization) its own Fourier transform is one of the cornerstone computations of analysis — it underlies the heat kernel, the uncertainty principle, and the proof of the Central Limit Theorem via characteristic functions. The area-of-circle-oq-05 entry formalized the real Gaussian integral ∫e^{-x²}=√π; this entry takes the next step to the *Fourier* transform of the Gaussian. It is also a concrete answer to a gap flagged in the gallery's central-limit-theorem development, which currently axiomatizes the identity ∫ e^{itx} dN(0,1)(x) = e^{-t²/2}.",
+    "problemStatement": "Prove that the Fourier transform of the standard Gaussian is again a Gaussian: ∫_ℝ e^{itx}·e^{-x²/2} dx = e^{-t²/2}·√(2π), and in normalized form ∫_ℝ e^{itx}·(e^{-x²/2}/√(2π)) dx = e^{-t²/2} — the characteristic function of the standard normal distribution.",
+    "text": "The proof is the classical 'complete the square' argument, carried out over ℂ. Pointwise, e^{itx}·e^{-x²/2} = e^{-½(x-it)²}·e^{-t²/2}, because i t x − x²/2 = −½(x−it)² − t²/2 (an identity that uses only i² = −1). The constant factor e^{-t²/2} pulls out of the integral, leaving ∫_ℝ e^{-½(x-it)²} dx. This is a Gaussian integral along the horizontal line shifted into the complex plane; Mathlib's GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I (proved by a Cauchy vertical-strip argument reducing to the real Gaussian integral) evaluates it to (π/(1/2))^{1/2} = √(2π). Combining gives the un-normalized identity; dividing through by √(2π) gives the normalized one. The t = 0 specialisations recover ∫ e^{-x²/2} = √(2π) and that the standard density has total mass 1.",
+    "proofStrategy": "1. **Complete the square pointwise** (`gaussian_integrand_complete_square`): rewrite both products of exponentials as single exponentials (Complex.exp_add), then prove the exponent identity i t x − x²/2 = −½(x + (−t)i)² − t²/2 by `push_cast` and `linear_combination (t²/2)·Complex.I_sq` (the only nontrivial input is i² = −1).\n\n2. **Identify the constant** (`cpow_half_eq_sqrt_two_pi`): show the Mathlib contour constant (π/(1/2))^{1/2} equals the real √(2π), via π/(1/2) = 2π, Real.sqrt_eq_rpow, and Complex.ofReal_cpow.\n\n3. **Un-normalized identity** (`gaussian_fourier_real`): `simp_rw` the pointwise factoring under the integral, pull the constant e^{-t²/2} out with MeasureTheory.integral_mul_const, apply integral_cexp_neg_mul_sq_add_real_mul_I at b = (1/2 : ℂ) (re = 1/2 > 0) and c = −t, then rewrite the constant by step 2.\n\n4. **Normalized identity** (`gaussian_fourier_normalized`): rewrite e^{itx}·(g/√(2π)) as (e^{itx}·g)/√(2π) (mul_div_assoc), pull the constant out with MeasureTheory.integral_div, apply step 3, and cancel √(2π) (div_self, the denominator being nonzero since √(2π) > 0).\n\n5. **Consequences**: `gaussian_density_total_mass` and `integral_gaussian_half` follow by specialising the two identities at t = 0 (`simpa`).",
+    "keyInsights": [
+      "The entire computation is 'complete the square' over ℂ: i t x − x²/2 = −½(x − it)² − t²/2. The only algebraic fact needed beyond ring arithmetic is i² = −1, supplied to linear_combination as Complex.I_sq.",
+      "After completing the square the t-dependence sits entirely in the constant e^{-t²/2}, which pulls out of the integral; the remaining x-integral is t-independent and equals √(2π) for every t.",
+      "The shifted Gaussian integral ∫ e^{-½(x-it)²} dx — over a line displaced into the complex plane — equals the ordinary real Gaussian integral, a Cauchy vertical-strip fact packaged by Mathlib as integral_cexp_neg_mul_sq_add_real_mul_I.",
+      "Normalizing by √(2π) turns the identity into the characteristic function of N(0,1): φ(t) = e^{-t²/2}. This is exactly the input the characteristic-function proof of the Central Limit Theorem needs."
+    ],
+    "prerequisites": [
+      "area-of-circle-oq-05 — the real Gaussian integral ∫ e^{-x²} = √π",
+      "Mathlib's Gaussian Fourier transform: GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I",
+      "Complex exponential algebra (Complex.exp_add, Complex.I_sq) and the cpow/sqrt bridge (Complex.ofReal_cpow, Real.sqrt_eq_rpow)",
+      "Linearity of the Bochner integral (integral_mul_const, integral_div)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: Imports and Setup",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Imports Mathlib; opens Real, Complex, MeasureTheory. Header documents the un-normalized and normalized identities, the complete-the-square method, and the honest scope relative to the CLT axiom.",
+      "mathContext": "Targets the concrete Lebesgue-integral form of the Gaussian Fourier self-duality, drawing the contour integral from Mathlib's GaussianFourier development."
+    },
+    {
+      "id": "complete-square",
+      "title": "Part I: Completing the Square (Pointwise)",
+      "startLine": 56,
+      "endLine": 78,
+      "summary": "gaussian_integrand_complete_square: e^{itx}·e^{-x²/2} = e^{-½(x+(-t)i)²}·e^{-t²/2}, proved by Complex.exp_add and linear_combination with Complex.I_sq.",
+      "mathContext": "The algebraic heart: i t x − x²/2 = −½(x − it)² − t²/2, isolating the t-dependence into a pull-out constant."
+    },
+    {
+      "id": "constant",
+      "title": "Part II: The Constant √(2π) from the Contour Integral",
+      "startLine": 79,
+      "endLine": 94,
+      "summary": "cpow_half_eq_sqrt_two_pi: (π/(1/2))^{1/2} = √(2π), bridging Mathlib's complex contour constant to the real square root.",
+      "mathContext": "Converts the cpow value returned by the contour-integral lemma into the familiar real √(2π) via Complex.ofReal_cpow and Real.sqrt_eq_rpow."
+    },
+    {
+      "id": "fourier-identity",
+      "title": "Part III: The Gaussian Fourier Identity (Lebesgue Form)",
+      "startLine": 95,
+      "endLine": 129,
+      "summary": "gaussian_fourier_real (∫ e^{itx}e^{-x²/2} = e^{-t²/2}·√(2π)) and gaussian_fourier_normalized (∫ e^{itx}(e^{-x²/2}/√(2π)) = e^{-t²/2}).",
+      "mathContext": "Pull the constant out of the integral, evaluate the shifted Gaussian by the Mathlib contour lemma at b=1/2, c=-t, and (normalized) cancel √(2π)."
+    },
+    {
+      "id": "consequences",
+      "title": "Part IV: Consequences",
+      "startLine": 130,
+      "endLine": 150,
+      "summary": "gaussian_density_total_mass (standard density integrates to 1) and integral_gaussian_half (∫ e^{-x²/2} = √(2π)), both via t = 0.",
+      "mathContext": "The t = 0 shadows of the two Fourier identities recover normalization of the density and the half-variance Gaussian integral."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Gaussian Fourier self-duality is proved axiom-free in concrete Lebesgue form: ∫ e^{itx}e^{-x²/2} dx = e^{-t²/2}·√(2π), and normalized, ∫ e^{itx}(e^{-x²/2}/√(2π)) dx = e^{-t²/2} — the characteristic function of N(0,1). Specialisations at t = 0 recover ∫ e^{-x²/2} = √(2π) and total mass 1. (0 axioms, 0 sorries.)",
+    "implications": "This supplies the exact computation that the gallery's central-limit-theorem development currently axiomatizes (gaussian_fourier_identity). It is the characteristic-function input to the CLT and a building block for the heat kernel and uncertainty principle. It also extends the area-of-circle Gaussian-integral lineage from the value ∫e^{-x²}=√π to the full Fourier transform.",
+    "openQuestions": [
+      "Discharge the CentralLimitTheorem.lean axiom gaussian_fourier_identity by replacing its abstract `axiom stdGaussian` with ProbabilityTheory.gaussianReal 0 1 and rewriting the measure integral as the density-weighted Lebesgue integral proved here.",
+      "Prove the multivariate Gaussian Fourier transform (the EuclideanSpace version, integral_cexp_neg_mul_sq_norm_add) in the same explicit form.",
+      "Derive the general N(μ, σ²) characteristic function e^{iμt - σ²t²/2} by an affine change of variables."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-05",
+      "relationship": "extends",
+      "description": "Parent: the real Gaussian integral ∫ e^{-x²} = √π. This entry advances from the value of the Gaussian integral to the Fourier transform of the Gaussian."
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "related",
+      "description": "Provides, axiom-free in Lebesgue form, the Gaussian Fourier identity that the CLT entry currently introduces as an axiom (characteristic function of the standard normal = e^{-t²/2})."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Complex",
+      "MeasureTheory"
+    ],
+    "namespace": "GaussianFourierTransform",
+    "lineCount": 172,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "gaussian_fourier_normalized",
+        "type": "core",
+        "description": "The standard Gaussian density is its own Fourier transform: ∫ e^{itx}·(e^{-x²/2}/√(2π)) dx = e^{-t²/2}, the characteristic function of N(0,1).",
+        "leanType": "(t : ℝ) → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * (Complex.exp (-(x : ℂ) ^ 2 / 2) / ((Real.sqrt (2 * π) : ℝ) : ℂ)) = Complex.exp (-(t : ℂ) ^ 2 / 2)"
+      },
+      {
+        "name": "gaussian_fourier_real",
+        "type": "core",
+        "description": "Un-normalized Gaussian Fourier identity: ∫ e^{itx}·e^{-x²/2} dx = e^{-t²/2}·√(2π).",
+        "leanType": "(t : ℝ) → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2) = Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)"
+      },
+      {
+        "name": "gaussian_integrand_complete_square",
+        "type": "key",
+        "description": "Completing the square at the integrand level: e^{itx}·e^{-x²/2} = e^{-½(x+(-t)i)²}·e^{-t²/2}.",
+        "leanType": "(t x : ℝ) → Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2) = Complex.exp (-(((1 : ℝ) / 2 : ℝ) : ℂ) * ((x : ℂ) + ((-t : ℝ) : ℂ) * Complex.I) ^ 2) * Complex.exp (-(t : ℂ) ^ 2 / 2)"
+      },
+      {
+        "name": "integral_gaussian_half",
+        "type": "supporting",
+        "description": "The t = 0 shadow: ∫ e^{-x²/2} dx = √(2π).",
+        "leanType": "∫ x : ℝ, Complex.exp (-(x : ℂ) ^ 2 / 2) = ((Real.sqrt (2 * π) : ℝ) : ℂ)"
+      }
+    ],
+    "path": "Proofs/AreaOfCircleOQ05OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "gaussian_fourier_normalized",
+      "type": "core",
+      "description": "The standard Gaussian density is its own Fourier transform: ∫ e^{itx}·(e^{-x²/2}/√(2π)) dx = e^{-t²/2} — the characteristic function of N(0,1).",
+      "leanType": "(t : ℝ) → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * (Complex.exp (-(x : ℂ) ^ 2 / 2) / ((Real.sqrt (2 * π) : ℝ) : ℂ)) = Complex.exp (-(t : ℂ) ^ 2 / 2)"
+    },
+    {
+      "name": "gaussian_fourier_real",
+      "type": "key",
+      "description": "Un-normalized Gaussian Fourier identity: ∫ e^{itx}·e^{-x²/2} dx = e^{-t²/2}·√(2π).",
+      "leanType": "(t : ℝ) → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2) = Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)"
+    },
+    {
+      "name": "gaussian_integrand_complete_square",
+      "type": "key",
+      "description": "Completing the square at the integrand level: e^{itx}·e^{-x²/2} = e^{-½(x+(-t)i)²}·e^{-t²/2} (uses only i² = -1).",
+      "leanType": "(t x : ℝ) → Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2) = Complex.exp (-(((1 : ℝ) / 2 : ℝ) : ℂ) * ((x : ℂ) + ((-t : ℝ) : ℂ) * Complex.I) ^ 2) * Complex.exp (-(t : ℂ) ^ 2 / 2)"
+    },
+    {
+      "name": "gaussian_density_total_mass",
+      "type": "supporting",
+      "description": "The standard Gaussian density integrates to 1 (t = 0 of the normalized identity).",
+      "leanType": "∫ x : ℝ, Complex.exp (-(x : ℂ) ^ 2 / 2) / ((Real.sqrt (2 * π) : ℝ) : ℂ) = 1"
+    },
+    {
+      "name": "integral_gaussian_half",
+      "type": "supporting",
+      "description": "The t = 0 shadow of the un-normalized identity: ∫ e^{-x²/2} dx = √(2π).",
+      "leanType": "∫ x : ℝ, Complex.exp (-(x : ℂ) ^ 2 / 2) = ((Real.sqrt (2 * π) : ℝ) : ℂ)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stein, Elias M. and Shakarchi, Rami",
+      "title": "Fourier Analysis: An Introduction",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "note": "Chapter 5; the Gaussian as its own Fourier transform via completing the square"
+    },
+    {
+      "authors": "mathlib community",
+      "title": "Analysis.SpecialFunctions.Gaussian.FourierTransform",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "integral_cexp_neg_mul_sq_add_real_mul_I — the shifted Gaussian contour integral used here"
+    },
+    {
+      "authors": "Billingsley, Patrick",
+      "title": "Probability and Measure",
+      "year": "1995",
+      "venue": "Wiley",
+      "note": "Characteristic functions and the CLT; the standard normal characteristic function is e^{-t²/2}"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Open question from the **area-of-circle-oq-05** lineage (the Gaussian integral ∫ e^{-x²} = √π) and a flagged axiom in `CentralLimitTheorem.lean`. This entry proves, **axiom-free**, that the Gaussian is its own Fourier transform, in explicit Lebesgue-integral form:

> **∫_ℝ e^{itx}·e^{-x²/2} dx = e^{-t²/2}·√(2π)**   (un-normalized)
>
> **∫_ℝ e^{itx}·(e^{-x²/2}/√(2π)) dx = e^{-t²/2}**   (normalized — the characteristic function of N(0,1))

### Method — complete the square over ℂ
`i t x − x²/2 = −½(x − it)² − t²/2` (uses only `i² = −1`), so the integrand factors as `e^{-½(x-it)²}·e^{-t²/2}`. The constant `e^{-t²/2}` pulls out; the remaining shifted Gaussian `∫ e^{-½(x-it)²} dx = √(2π)` is Mathlib's `GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I` at `b = 1/2`, `c = -t`.

### What's proved (0 axioms, 0 sorries, no `native_decide`)
- `gaussian_integrand_complete_square` — the pointwise factoring (via `linear_combination … * Complex.I_sq`).
- `cpow_half_eq_sqrt_two_pi` — the contour constant `(π/(1/2))^{1/2} = √(2π)`.
- `gaussian_fourier_real` — the un-normalized identity.
- `gaussian_fourier_normalized` — the normalized identity (= characteristic function of the standard normal).
- `gaussian_density_total_mass` — the standard density integrates to 1.
- `integral_gaussian_half` — `∫ e^{-x²/2} dx = √(2π)`.

### Honest scope
`CentralLimitTheorem.lean` states its `gaussian_fourier_identity` against an **abstract** `stdGaussian` measure introduced by `axiom`. This file proves the full mathematical content as a concrete Lebesgue integral; discharging that specific CLT axiom additionally requires replacing the abstract measure with `ProbabilityTheory.gaussianReal 0 1` — a separate bridge, noted as future work.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.AreaOfCircleOQ05OQ03` — builds clean (Lean 4 / Mathlib 4.26.0).
- `#print axioms` on every main theorem: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. **0-axiom verified.**

172 lines, 6 theorems, 0 definitions. Gallery entry under `src/data/proofs/area-of-circle-oq-05-oq-03/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)