### PR TITLE
research(solution-of-cubic oq-01-oq-01): discriminant of the general cubic and its invariance under the Tschirnhaus shift [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3271,6 +3271,7 @@ import Proofs.SkolemNoetherMatrixAut
 import Proofs.SkolemNoetherMatrixAutAristotle
 import Proofs.SolutionOfCubic
 import Proofs.SolutionOfCubicOQ01
+import Proofs.SolutionOfCubicOQ01OQ01
 import Proofs.SolutionOfCubicOQ03
 import Proofs.SolutionOfCubicOQ03OQ01
 import Proofs.SolutionOfCubicOQ03OQ02

--- a/proofs/Proofs/SolutionOfCubicOQ01OQ01.lean
+++ b/proofs/Proofs/SolutionOfCubicOQ01OQ01.lean
@@ -1,0 +1,201 @@
+import Proofs.SolutionOfCubicOQ01
+
+/-!
+# The Discriminant of the General Cubic and its Invariance under the Tschirnhaus Shift (Solution of Cubic, OQ-01-OQ-01)
+
+## What This Proves
+
+The parent file `SolutionOfCubicOQ01` proves the **Tschirnhaus shift** `x = t - b/(3a)`
+reduces the general cubic `a x³ + b x² + c x + d` to depressed form `a·(t³ + p t + q)`
+with `p = (3ac - b²)/(3a²)` and `q = (2b³ - 9abc + 27a²d)/(27a³)`. That parent's docstring
+left as an open question:
+
+  *"Formalize the discriminant of the general cubic in terms of a, b, c, d and relate it to
+  the depressed discriminant used by the parent."*
+
+This file answers exactly that. We define the classical **general cubic discriminant**
+
+  `Δ(a,b,c,d) = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d²`
+
+and prove the central structural fact: the Tschirnhaus shift carries it to the depressed
+polynomial discriminant up to the factor `a⁴`,
+
+  `Δ(a,b,c,d) = a⁴ · (−4p³ − 27q²)`.
+
+Geometrically, the discriminant of a degree-`n` polynomial scales by `a^(2n−2)` under a unit
+factor (`a⁴` for `n = 3`) and is **invariant under translation** `x ↦ t − b/(3a)`; both facts
+are visible in this single identity. We then bridge to the parent's Cardano discriminant
+`Δ_C = q²/4 + p³/27` (the quantity under the square root of Cardano's formula), establish the
+repeated-root criterion `Δ = 0`, and express `Δ` in the symmetric **root form**
+`a⁴·∏_{i<j}(xᵢ − xⱼ)²`.
+
+## Original Contributions
+- `generalDiscriminant` — the discriminant of `a x³ + b x² + c x + d` as a polynomial in
+  `a, b, c, d`.
+- `general_discriminant_eq_shift` — the headline: `Δ = a⁴ · (−4p³ − 27q²)`, the shift's
+  effect on the discriminant. This is the discriminant analogue of the parent's `cubic_depress`.
+- `depressedDisc_eq_cardano` / `general_discriminant_eq_cardano` — bridge to the parent's
+  Cardano discriminant `q²/4 + p³/27`: `−4p³ − 27q² = −108·(q²/4 + p³/27)`, so
+  `Δ = −108·a⁴·Δ_C`.
+- `general_discriminant_eq_zero_iff` — the shift preserves the repeated-root locus:
+  `Δ = 0 ⟺ −4p³ − 27q² = 0` (because `a ≠ 0`).
+- `generalDiscriminant_eq_root_form` — symmetric form: for a monic-times-`a` cubic with roots
+  `x₁, x₂, x₃` (Vieta), `Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))²`.
+- `repeated_root_iff` — `Δ = 0 ⟺ two of the roots coincide`, the geometric meaning of the
+  discriminant.
+
+## Proof Techniques
+The shift identity is a single field identity (`field_simp` clears the denominators of `p, q`
+using `a ≠ 0`, then `ring`). The root form is a pure polynomial identity (`ring` after
+substituting Vieta). The vanishing criteria use `a⁴ ≠ 0` (`pow_ne_zero`) and
+`NoZeroDivisors`. Everything is over `ℂ`, matching the parent, and is `0`-axiom.
+-/
+
+namespace SolutionOfCubicOQ01OQ01
+
+open SolutionOfCubic SolutionOfCubicOQ01
+
+/-! ## Part 1: The general cubic discriminant
+
+The discriminant of `a x³ + b x² + c x + d`, a polynomial in its four coefficients. -/
+
+/-- **The discriminant of the general cubic** `a x³ + b x² + c x + d`:
+`Δ = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d²`. -/
+def generalDiscriminant (a b c d : ℂ) : ℂ :=
+  18 * a * b * c * d - 4 * b ^ 3 * d + b ^ 2 * c ^ 2 - 4 * a * c ^ 3 - 27 * a ^ 2 * d ^ 2
+
+/-- The **polynomial discriminant** of the depressed cubic `t³ + p t + q`: `−4p³ − 27q²`.
+(This is the standard discriminant; it differs from the parent's Cardano discriminant
+`q²/4 + p³/27` by the factor `−108`, see `depressedDisc_eq_cardano`.) -/
+def depressedDisc (p q : ℂ) : ℂ := -4 * p ^ 3 - 27 * q ^ 2
+
+/-! ## Part 2: The shift identity — the discriminant under depression
+
+Substituting the depressed parameters `p, q` of the Tschirnhaus shift shows the general
+discriminant is `a⁴` times the depressed discriminant. -/
+
+/-- **The discriminant under the Tschirnhaus shift.** For `a ≠ 0`, the general cubic
+discriminant equals `a⁴` times the depressed polynomial discriminant of the shifted cubic:
+
+  `Δ(a,b,c,d) = a⁴ · (−4p³ − 27q²)`,   `p = depressedP a b c`, `q = depressedQ a b c d`.
+
+The `a⁴` is the `a^(2·3−2)` scaling of a cubic discriminant under a leading factor; the rest
+is the *translation invariance* of the discriminant under `x = t − b/(3a)`. This is the
+discriminant analogue of the parent's coefficient identity `cubic_depress`. -/
+theorem general_discriminant_eq_shift (a b c d : ℂ) (ha : a ≠ 0) :
+    generalDiscriminant a b c d
+      = a ^ 4 * depressedDisc (depressedP a b c) (depressedQ a b c d) := by
+  unfold generalDiscriminant depressedDisc depressedP depressedQ
+  field_simp
+  ring
+
+/-! ## Part 3: Bridge to the parent's Cardano discriminant
+
+The parent uses `Δ_C = q²/4 + p³/27` (the radicand of Cardano's formula). The polynomial
+discriminant is `−108` times it. -/
+
+/-- The depressed polynomial discriminant is `−108` times the parent's Cardano discriminant
+`Δ_C = q²/4 + p³/27`. So the two notions of "discriminant" agree up to a nonzero constant and
+in particular vanish together. -/
+theorem depressedDisc_eq_cardano (p q : ℂ) :
+    depressedDisc p q = -108 * SolutionOfCubic.discriminant p q := by
+  unfold depressedDisc SolutionOfCubic.discriminant
+  ring
+
+/-- The general discriminant in terms of the parent's Cardano discriminant of the depressed
+cubic: `Δ(a,b,c,d) = −108 · a⁴ · (q²/4 + p³/27)`. This is the explicit link the parent's
+open question asked for. -/
+theorem general_discriminant_eq_cardano (a b c d : ℂ) (ha : a ≠ 0) :
+    generalDiscriminant a b c d
+      = -108 * a ^ 4 *
+          SolutionOfCubic.discriminant (depressedP a b c) (depressedQ a b c d) := by
+  rw [general_discriminant_eq_shift a b c d ha, depressedDisc_eq_cardano]
+  ring
+
+/-! ## Part 4: The repeated-root locus is shift-invariant
+
+`Δ = 0` exactly when the depressed discriminant vanishes — the shift moves roots but not the
+condition that two of them collide. -/
+
+/-- **The shift preserves the repeated-root locus.** Since `a ≠ 0`, the general cubic has
+`Δ = 0` iff its depressed form has `−4p³ − 27q² = 0`. -/
+theorem general_discriminant_eq_zero_iff (a b c d : ℂ) (ha : a ≠ 0) :
+    generalDiscriminant a b c d = 0
+      ↔ depressedDisc (depressedP a b c) (depressedQ a b c d) = 0 := by
+  rw [general_discriminant_eq_shift a b c d ha]
+  constructor
+  · intro h
+    rcases mul_eq_zero.mp h with h' | h'
+    · exact absurd h' (pow_ne_zero 4 ha)
+    · exact h'
+  · intro h
+    rw [h, mul_zero]
+
+/-! ## Part 5: The symmetric root form
+
+For a cubic `a(x − x₁)(x − x₂)(x − x₃)` — i.e. coefficients given by Vieta — the discriminant
+is `a⁴` times the squared product of root differences. -/
+
+/-- **Root form of the discriminant.** If `b, c, d` are the Vieta coefficients of the roots
+`x₁, x₂, x₃` (so `a x³ + b x² + c x + d = a(x−x₁)(x−x₂)(x−x₃)`), then
+
+  `Δ(a,b,c,d) = a⁴ · ((x₁−x₂)(x₁−x₃)(x₂−x₃))²`.
+
+This is the classical symmetric expression; it makes manifest that `Δ` is a square (up to
+`a⁴`) and that it vanishes exactly when two roots coincide. -/
+theorem generalDiscriminant_eq_root_form (a x₁ x₂ x₃ b c d : ℂ)
+    (hb : b = -a * (x₁ + x₂ + x₃))
+    (hc : c = a * (x₁ * x₂ + x₁ * x₃ + x₂ * x₃))
+    (hd : d = -a * (x₁ * x₂ * x₃)) :
+    generalDiscriminant a b c d = a ^ 4 * ((x₁ - x₂) * (x₁ - x₃) * (x₂ - x₃)) ^ 2 := by
+  subst hb hc hd
+  unfold generalDiscriminant
+  ring
+
+/-- **The discriminant detects repeated roots.** For `a ≠ 0` and `x₁, x₂, x₃` the roots
+(via Vieta), `Δ = 0` iff two of the roots coincide. -/
+theorem repeated_root_iff (a x₁ x₂ x₃ b c d : ℂ) (ha : a ≠ 0)
+    (hb : b = -a * (x₁ + x₂ + x₃))
+    (hc : c = a * (x₁ * x₂ + x₁ * x₃ + x₂ * x₃))
+    (hd : d = -a * (x₁ * x₂ * x₃)) :
+    generalDiscriminant a b c d = 0 ↔ (x₁ = x₂ ∨ x₁ = x₃ ∨ x₂ = x₃) := by
+  rw [generalDiscriminant_eq_root_form a x₁ x₂ x₃ b c d hb hc hd]
+  constructor
+  · intro h
+    have hsq : ((x₁ - x₂) * (x₁ - x₃) * (x₂ - x₃)) ^ 2 = 0 := by
+      rcases mul_eq_zero.mp h with h' | h'
+      · exact absurd h' (pow_ne_zero 4 ha)
+      · exact h'
+    have hp : (x₁ - x₂) * (x₁ - x₃) * (x₂ - x₃) = 0 := sq_eq_zero_iff.mp hsq
+    rcases mul_eq_zero.mp hp with h2 | h2
+    · rcases mul_eq_zero.mp h2 with h3 | h3
+      · exact Or.inl (sub_eq_zero.mp h3)
+      · exact Or.inr (Or.inl (sub_eq_zero.mp h3))
+    · exact Or.inr (Or.inr (sub_eq_zero.mp h2))
+  · intro h
+    rcases h with h | h | h <;> subst h <;> ring
+
+/-! ## Part 6: Sanity checks -/
+
+/-- With `a = 1, b = 0` the cubic is already depressed (`p = c`, `q = d`), and the general
+discriminant reduces to the depressed discriminant `−4c³ − 27d²`. -/
+example (c d : ℂ) : generalDiscriminant 1 0 c d = depressedDisc c d := by
+  unfold generalDiscriminant depressedDisc; ring
+
+/-- The depressed cubic `t³ − 6t − 40` (the parent's worked example, root `t = 4`) has
+discriminant `−4·(−6)³ − 27·(−40)² = 864 − 43200 = −42336 ≠ 0`, so its roots are distinct. -/
+example : generalDiscriminant 1 0 (-6) (-40) = -42336 := by
+  unfold generalDiscriminant; norm_num
+
+/-- A perfect cube `(x − 2)³ = x³ − 6x² + 12x − 8` has a triple root, so `Δ = 0`. -/
+example : generalDiscriminant 1 (-6) 12 (-8) = 0 := by
+  unfold generalDiscriminant; norm_num
+
+end SolutionOfCubicOQ01OQ01
+
+-- Summary of key results
+#check SolutionOfCubicOQ01OQ01.general_discriminant_eq_shift
+#check SolutionOfCubicOQ01OQ01.general_discriminant_eq_cardano
+#check SolutionOfCubicOQ01OQ01.general_discriminant_eq_zero_iff
+#check SolutionOfCubicOQ01OQ01.generalDiscriminant_eq_root_form
+#check SolutionOfCubicOQ01OQ01.repeated_root_iff

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-soc-oq0101-shift",
+    "proofId": "solution-of-cubic-oq-01-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 90
+    },
+    "type": "insight",
+    "title": "The Discriminant under the Tschirnhaus Shift",
+    "body": "general_discriminant_eq_shift is the central identity: Δ(a,b,c,d) = a⁴·(−4p³ − 27q²). It packages two facts true in any degree. First, translation invariance: the depressed cubic t³ + pt + q has exactly the same root differences as the original (the shift x = t − b/(3a) adds the same constant to every root), so its monic discriminant −4p³ − 27q² already captures the root-difference data. Second, the leading-coefficient scaling a^(2n−2) = a⁴ for n = 3. The proof unfolds p, q (with their denominators 3a² and 27a³), clears them with field_simp under a ≠ 0, and closes with ring."
+  },
+  {
+    "id": "ann-soc-oq0101-cardano-bridge",
+    "proofId": "solution-of-cubic-oq-01-oq-01",
+    "range": {
+      "startLine": 100,
+      "endLine": 113
+    },
+    "type": "insight",
+    "title": "Two Discriminants Differ by −108",
+    "body": "The parent uses Δ_C = q²/4 + p³/27, the quantity under the square root in Cardano's formula. The standard polynomial discriminant is −4p³ − 27q² = −108·Δ_C. The factor −108 is nonzero, so the two notions vanish together and carry the same repeated-root information; depressedDisc_eq_cardano makes this precise and general_discriminant_eq_cardano lifts it to Δ = −108·a⁴·Δ_C — the explicit bridge the parent's open question asked for."
+  },
+  {
+    "id": "ann-soc-oq0101-zero-iff",
+    "proofId": "solution-of-cubic-oq-01-oq-01",
+    "range": {
+      "startLine": 122,
+      "endLine": 132
+    },
+    "type": "technique",
+    "title": "a⁴ ≠ 0 Transfers the Vanishing Condition",
+    "body": "general_discriminant_eq_zero_iff shows Δ = 0 ⟺ −4p³ − 27q² = 0. From Δ = a⁴·depressedDisc, mul_eq_zero splits a product into a⁴ = 0 ∨ depressedDisc = 0; pow_ne_zero 4 ha kills the first disjunct because a ≠ 0 in the field ℂ, leaving depressedDisc = 0. The shift moves the roots but preserves the condition that two of them collide."
+  },
+  {
+    "id": "ann-soc-oq0101-root-form",
+    "proofId": "solution-of-cubic-oq-01-oq-01",
+    "range": {
+      "startLine": 146,
+      "endLine": 176
+    },
+    "type": "insight",
+    "title": "Symmetric Root Form and the Repeated-Root Criterion",
+    "body": "generalDiscriminant_eq_root_form substitutes the Vieta expressions b = −a·σ₁, c = a·σ₂, d = −a·σ₃ and lets ring verify Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))². Exposing Δ as a square (up to a⁴) makes repeated_root_iff immediate: over ℂ a product of differences squared is zero iff one difference is zero, i.e. two roots coincide — proved by chaining sq_eq_zero_iff, mul_eq_zero, and sub_eq_zero."
+  }
+]

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-01/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "solution-of-cubic-oq-01-oq-01",
+  "title": "The Discriminant of the General Cubic and its Invariance under the Tschirnhaus Shift",
+  "slug": "solution-of-cubic-oq-01-oq-01",
+  "description": "Defines the general cubic discriminant Δ(a,b,c,d) = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² and proves it equals a⁴·(−4p³ − 27q²) under the parent's Tschirnhaus shift, exhibiting both the a^(2n−2) scaling and the translation invariance of the discriminant. Bridges to the parent's Cardano discriminant q²/4 + p³/27 (Δ = −108·a⁴·Δ_C), proves the repeated-root locus is shift-invariant, and gives the symmetric root form Δ = a⁴·∏(xᵢ−xⱼ)² with the repeated-root criterion.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Discriminant#Degree_3",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SolutionOfCubicOQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "cubic-equations",
+      "discriminant",
+      "cardano",
+      "tschirnhaus-transformation",
+      "polynomial-arithmetic",
+      "vieta",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [],
+    "originalContributions": [
+      "generalDiscriminant: the discriminant 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² of the general cubic a x³ + b x² + c x + d as a polynomial in its coefficients",
+      "general_discriminant_eq_shift: the headline identity Δ(a,b,c,d) = a⁴·(−4p³ − 27q²) for the depressed parameters p, q of the parent's Tschirnhaus shift — the discriminant analogue of cubic_depress, encoding both a^(2n−2) scaling and translation invariance",
+      "depressedDisc_eq_cardano / general_discriminant_eq_cardano: bridge −4p³ − 27q² = −108·(q²/4 + p³/27) to the parent's Cardano discriminant, giving Δ = −108·a⁴·Δ_C — the explicit link the parent's open question requested",
+      "general_discriminant_eq_zero_iff: the shift preserves the repeated-root locus, Δ = 0 ⟺ −4p³ − 27q² = 0 (since a ≠ 0)",
+      "generalDiscriminant_eq_root_form: symmetric form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))² for roots x₁, x₂, x₃ given by Vieta",
+      "repeated_root_iff: the geometric meaning Δ = 0 ⟺ two roots coincide"
+    ],
+    "dateAdded": "2026-06-21",
+    "prerequisites": [
+      "Tschirnhaus shift reduction of the general cubic (parent proof, OQ-01)",
+      "Cardano's discriminant q²/4 + p³/27 (grandparent proof)",
+      "Field arithmetic over the complex numbers; Vieta's formulas"
+    ],
+    "relatedProblems": [
+      {
+        "id": "solution-of-cubic-oq-01",
+        "relationship": "Parent: the Tschirnhaus shift reducing the general cubic to depressed form; this entry answers its open question on the general-cubic discriminant"
+      },
+      {
+        "id": "solution-of-cubic-oq-03-oq-01",
+        "relationship": "Sibling: discriminant of the depressed cubic in root form −4p³ − 27q² = ∏(differences)² over ℝ"
+      },
+      {
+        "id": "solution-of-cubic",
+        "relationship": "Grandparent: Cardano's formula and the Cardano discriminant q²/4 + p³/27"
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 201,
+    "assumptions": "None. All theorems fully proved from Mathlib with 0 axioms and 0 sorries. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms); no native_decide, no Lean.ofReduceBool.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The discriminant of a polynomial — the quantity that vanishes exactly when the polynomial has a repeated root — was studied by Lagrange, Gauss, and Sylvester (who coined the term in 1851). For the cubic a x³ + b x² + c x + d it is the degree-4 polynomial Δ = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d², classically obtained as a^(2n−2)·∏_{i<j}(xᵢ − xⱼ)² (with n = 3) or as the resultant of the cubic with its derivative. Over ℝ its sign separates the three regimes of the cubic: Δ > 0 (three distinct real roots), Δ = 0 (a repeated root), Δ < 0 (one real and two conjugate complex roots). The parent gallery entry depressed the general cubic via x = t − b/(3a); the natural companion question — which this entry answers — is how the discriminant transforms under that shift. The answer reflects two structural facts that hold for any degree: the discriminant is invariant under translation of the variable, and scales by a^(2n−2) under a leading factor a. For the cubic this is the single clean identity Δ(a,b,c,d) = a⁴·(−4p³ − 27q²).",
+    "problemStatement": "Define the discriminant of the general cubic a x³ + b x² + c x + d as a polynomial in a, b, c, d, prove it equals a⁴ times the depressed polynomial discriminant −4p³ − 27q² under the parent's Tschirnhaus shift, relate it to the parent's Cardano discriminant q²/4 + p³/27, and characterize Δ = 0 as the repeated-root condition.",
+    "proofStrategy": "The shift identity general_discriminant_eq_shift is a field identity: unfold the depressed parameters p, q (which carry denominators 3a² and 27a³), clear denominators with field_simp using a ≠ 0, and close with ring. The bridge to the Cardano discriminant is a pure ring identity (−4p³ − 27q² = −108·(q²/4 + p³/27)). The root form is a polynomial identity proved by substituting the Vieta expressions for b, c, d and calling ring. The vanishing criteria use a⁴ ≠ 0 (pow_ne_zero) together with the absence of zero divisors in ℂ; the repeated-root criterion further factors the squared product via mul_eq_zero / sq_eq_zero_iff / sub_eq_zero.",
+    "keyInsights": [
+      "Δ(a,b,c,d) = a⁴·(−4p³ − 27q²) packages two general facts at once: translation invariance (the depressed cubic has the same root-difference data, hence the same monic discriminant −4p³ − 27q²) and the a^(2n−2) = a⁴ scaling under the leading coefficient.",
+      "The 'discriminant' of the parent (q²/4 + p³/27, the radicand of Cardano's square root) and the standard polynomial discriminant −4p³ − 27q² differ only by the nonzero constant −108, so they vanish together and encode the same repeated-root information.",
+      "Because ℂ has no zero divisors and a⁴ ≠ 0, the entire content of 'Δ = 0' transfers cleanly between the general and depressed forms — the shift moves the roots but not the condition that two collide.",
+      "Writing Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))² in root form makes the repeated-root criterion immediate: a product of differences squared is zero iff one difference is zero.",
+      "Working over ℂ keeps 3 (and 108) automatically invertible, so the only side condition anywhere is a ≠ 0."
+    ],
+    "prerequisites": [
+      "The parent's Tschirnhaus shift and its depressed parameters depressedP, depressedQ",
+      "The Cardano discriminant q²/4 + p³/27 from the grandparent",
+      "Field arithmetic, Vieta's formulas, and the field_simp/ring tactics over ℂ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "general-discriminant",
+      "title": "Part 1: The General Cubic Discriminant",
+      "startLine": 58,
+      "endLine": 71,
+      "summary": "Defines generalDiscriminant a b c d = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² and depressedDisc p q = −4p³ − 27q², the polynomial discriminant of the depressed cubic.",
+      "mathContext": "The standard discriminant of the cubic; depressedDisc differs from the parent's Cardano discriminant q²/4 + p³/27 by the factor −108."
+    },
+    {
+      "id": "shift-identity",
+      "title": "Part 2: The Discriminant under the Tschirnhaus Shift",
+      "startLine": 72,
+      "endLine": 91,
+      "summary": "general_discriminant_eq_shift: Δ(a,b,c,d) = a⁴·(−4p³ − 27q²), proved by field_simp + ring. The a⁴ is the leading-coefficient scaling; the equality is the translation invariance of the discriminant.",
+      "mathContext": "The discriminant analogue of the parent's coefficient identity cubic_depress, here machine-checked."
+    },
+    {
+      "id": "cardano-bridge",
+      "title": "Part 3: Bridge to the Cardano Discriminant",
+      "startLine": 92,
+      "endLine": 113,
+      "summary": "depressedDisc_eq_cardano: −4p³ − 27q² = −108·(q²/4 + p³/27); general_discriminant_eq_cardano: Δ = −108·a⁴·Δ_C, the explicit link to the radicand of Cardano's formula.",
+      "mathContext": "Reconciles the two standard 'discriminants' of the cubic, differing only by the nonzero constant −108."
+    },
+    {
+      "id": "vanishing-locus",
+      "title": "Part 4: The Repeated-Root Locus is Shift-Invariant",
+      "startLine": 115,
+      "endLine": 132,
+      "summary": "general_discriminant_eq_zero_iff: Δ = 0 ⟺ −4p³ − 27q² = 0, using a⁴ ≠ 0 and the absence of zero divisors.",
+      "mathContext": "The shift moves the roots but preserves the condition that two of them coincide."
+    },
+    {
+      "id": "root-form",
+      "title": "Part 5: The Symmetric Root Form",
+      "startLine": 134,
+      "endLine": 176,
+      "summary": "generalDiscriminant_eq_root_form: for Vieta coefficients of roots x₁, x₂, x₃, Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))²; repeated_root_iff: Δ = 0 ⟺ two roots coincide.",
+      "mathContext": "The classical symmetric expression for the discriminant, exposing it as a square (up to a⁴) and giving the geometric repeated-root criterion."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Part 6: Sanity Checks",
+      "startLine": 178,
+      "endLine": 201,
+      "summary": "Specializes to a = 1, b = 0 (Δ = −4c³ − 27d²); confirms t³ − 6t − 40 has Δ = −42336 ≠ 0 (distinct roots) and (x − 2)³ has Δ = 0 (triple root).",
+      "mathContext": "Concrete confirmations on the parent's worked example and a perfect cube."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) formalization of the general cubic discriminant Δ = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d², its transformation Δ = a⁴·(−4p³ − 27q²) under the parent's Tschirnhaus shift, the bridge Δ = −108·a⁴·(q²/4 + p³/27) to the parent's Cardano discriminant, the shift-invariance of the repeated-root locus, and the symmetric root form a⁴·∏(xᵢ−xⱼ)² with the repeated-root criterion. 201 lines, 5 theorems, 2 definitions.",
+    "implications": "This closes the open question raised by the parent OQ-01: the gallery now has the general-cubic discriminant in coefficient form, tied both to the depressed discriminant and to Cardano's radicand. The identity Δ = a⁴·(monic discriminant) is the degree-3 instance of two general phenomena — translation invariance and a^(2n−2) scaling of the discriminant — and the root form connects to the splitting analysis in the sibling depressed-discriminant entry. Over ℝ the sign of Δ would further separate the three-real-roots and casus-irreducibilis regimes.",
+    "openQuestions": [
+      "Prove the sign trichotomy over ℝ: Δ > 0 ⟺ three distinct real roots, Δ < 0 ⟺ one real and two conjugate complex roots, connecting to the casus-irreducibilis sibling entry.",
+      "Derive the discriminant as the resultant Res(f, f') of the cubic and its derivative, matching the coefficient formula and generalizing the construction to higher degree."
+    ]
+  },
+  "status": "verified",
+  "badge": "verified",
+  "leanFile": {
+    "imports": [
+      "Proofs.SolutionOfCubicOQ01"
+    ],
+    "opens": [
+      "SolutionOfCubic",
+      "SolutionOfCubicOQ01"
+    ],
+    "namespace": "SolutionOfCubicOQ01OQ01",
+    "lineCount": 201,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "path": "Proofs/SolutionOfCubicOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "solution-of-cubic-oq-01",
+      "relationship": "extends",
+      "description": "Parent proof: the Tschirnhaus shift reducing the general cubic to depressed form. Its docstring asked to formalize the general-cubic discriminant and relate it to the depressed discriminant; this entry does exactly that, reusing the parent's depressedP and depressedQ."
+    },
+    {
+      "targetId": "solution-of-cubic-oq-03-oq-01",
+      "relationship": "complementary",
+      "description": "Sibling entry giving the depressed discriminant −4p³ − 27q² in root form ∏(differences)². This entry supplies the coefficient form for the general cubic and the a⁴ scaling that connects the two."
+    },
+    {
+      "targetId": "solution-of-cubic",
+      "relationship": "extends",
+      "description": "Grandparent proof: Cardano's formula and its discriminant q²/4 + p³/27. This entry shows the standard polynomial discriminant is −108 times that Cardano discriminant."
+    }
+  ],
+  "references": [
+    {
+      "key": "Sy1851",
+      "citation": "Sylvester, J.J., On a remarkable discovery in the theory of canonical forms and of hyperdeterminants, Philosophical Magazine, Ser. 4, vol. 2 (1851).",
+      "type": "article"
+    },
+    {
+      "key": "Ti01",
+      "citation": "Tignol, J.-P., Galois' Theory of Algebraic Equations, World Scientific (2001), Chapters 3–5.",
+      "type": "book"
+    },
+    {
+      "key": "CLO15",
+      "citation": "Cox, D., Little, J., O'Shea, D., Ideals, Varieties, and Algorithms, 4th ed., Springer (2015), Chapter 3: resultants and discriminants.",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question raised in the parent **solution-of-cubic-oq-01** (the Tschirnhaus shift): *formalize the discriminant of the general cubic in terms of a, b, c, d and relate it to the depressed discriminant.*

Defines the general cubic discriminant
```
Δ(a,b,c,d) = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d²
```
and proves the central structural identity
```
Δ(a,b,c,d) = a⁴ · (−4p³ − 27q²)   (p,q = parent's depressedP, depressedQ)
```
which simultaneously encodes the `a^(2n−2)` leading-coefficient scaling and the **translation invariance** of the discriminant under `x = t − b/(3a)`.

## Theorems (5 thm, 2 def, 201 lines)
- `general_discriminant_eq_shift` — Δ = a⁴·(−4p³ − 27q²), the discriminant analogue of the parent's `cubic_depress` (field_simp + ring).
- `depressedDisc_eq_cardano` / `general_discriminant_eq_cardano` — bridge to the grandparent's Cardano discriminant: −4p³ − 27q² = −108·(q²/4 + p³/27), so Δ = −108·a⁴·Δ_C.
- `general_discriminant_eq_zero_iff` — the shift preserves the repeated-root locus (a⁴ ≠ 0).
- `generalDiscriminant_eq_root_form` — symmetric form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))² via Vieta.
- `repeated_root_iff` — Δ = 0 ⟺ two roots coincide.

## Verification
- Docker build: `./proofs/scripts/docker-build.sh Proofs.SolutionOfCubicOQ01OQ01` — completes, 0 sorries.
- `#print axioms` on all 5 theorems: only `propext, Classical.choice, Quot.sound`. **0 axioms, no native_decide, no Lean.ofReduceBool.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)