### PR TITLE
research(abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01): reflection is symmetric, escape cost is not (additive 5 vs multiplicative 6) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -28,6 +28,7 @@ import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01
 import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01
+import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01OQ01
 import Proofs.AbelRuffiniOQ04OQ02OQ03
 import Proofs.AbelRuffiniOQ04OQ03
 import Proofs.AbelRuffiniOQ04OQ07

--- a/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,205 @@
+/-
+# Abel–Ruffini — OQ-04 ▸ OQ-02 ▸ OQ-02 ▸ OQ-08 ▸ OQ-01 ▸ OQ-01 ▸ OQ-01 ▸ OQ-01 ▸ OQ-01
+
+## Reflection is symmetric; the escape *cost* is not (additive 5 vs multiplicative 6)
+
+The parent file (`…OQ-01`) contrasted the two type operations by claiming that
+**products reflect** solvability to their factors while **sums fail to
+preserve** it.  That pairing compares the wrong faces of the two operations.
+Reflection (solvability of the whole forces solvability of a piece) and
+preservation (solvability of the pieces forces solvability of the whole) are
+*different* directions, and the honest accounting is:
+
+* **Both operations reflect.**  A summand injects into the disjoint union
+  (`Sum.inl : α ↪ α ⊕ β`) exactly as a factor injects into the product, so
+  `card α ≤ card α + card β` and `card α ≤ card α · card β` alike.  Solvability of
+  `Perm (α ⊕ β)` *and* of `Perm (α × β)` therefore descends to `Perm α`
+  (`both_operations_reflect_solvability`).
+* **Neither operation preserves.**  `Perm (Fin 2)` and `Perm (Fin 3)` are
+  solvable, yet *both* `Perm (Fin 2 ⊕ Fin 3)` (5 points) and
+  `Perm (Fin 2 × Fin 3)` (6 points) are unsolvable
+  (`neither_operation_preserves_solvability`).
+
+So `⊕` and `×` sit on the *same* side of reflection and the *same* side of
+preservation.  What truly separates them is the **cost of escaping** the
+solvable range `{0,1,2,3,4}`:
+
+* **Additive escape is `5`.**  `5 = 2 + 3` is a sum of two solvable
+  cardinalities, and `5` is the least unsolvable degree.
+* **Multiplicative escape is `6`.**  No product of two solvable cardinalities
+  ever equals `5` — `5` is prime, so one factor would have to be `5 > 4`
+  (`no_solvable_product_equals_five`).  The first product of two *nontrivial*
+  solvable cardinalities that escapes is `2 · 3 = 6`
+  (`min_nontrivial_product_escape`).
+
+Hence the multiplicative boundary lies strictly *above* the additive one: the
+degree `5` is additively reachable from the solvable range but multiplicatively
+skipped (`escape_cost_asymmetry`).  This is the precise arithmetic shadow of the
+Abel–Ruffini threshold under the algebra of finite types.
+
+No `sorry`, no `axiom`, no `native_decide`.
+-/
+import Mathlib.GroupTheory.Solvable
+import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.GroupTheory.Perm.ViaEmbedding
+import Mathlib.Tactic
+import Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01
+
+open Equiv
+
+namespace AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01OQ01
+
+open AbelRuffiniOQ04OQ02OQ02OQ08 AbelRuffiniOQ04OQ02OQ02OQ08OQ01
+  AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01 AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01
+  AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01
+
+variable {α β : Type*}
+
+/-! ## §1  Reflection is symmetric between `⊕` and `×`
+
+A summand and a factor both inject into the composite carrier, so each only
+*grows* the point count: `card α ≤ card α + card β` and
+`card α ≤ card α · card β` (the latter once `β` is nonempty).  Solvability of the
+composite — an upper bound on the composite's point count — therefore forces the
+threshold on each piece.  The parent file proved the product half; here we add
+the sum half and package both. -/
+
+/-- **Sums reflect solvability (first summand).**  If `Perm (α ⊕ β)` is solvable
+then so is `Perm α`: the summand has no more points than the union. -/
+theorem perm_sum_reflects_solvable_left [DecidableEq α] [DecidableEq β]
+    [Fintype α] [Fintype β] (h : IsSolvable (Perm (α ⊕ β))) :
+    IsSolvable (Perm α) := by
+  rw [perm_sum_solvable_iff] at h
+  rw [perm_solvable_iff_card]
+  omega
+
+/-- **Sums reflect solvability (second summand).**  Symmetric statement for the
+right summand. -/
+theorem perm_sum_reflects_solvable_right [DecidableEq α] [DecidableEq β]
+    [Fintype α] [Fintype β] (h : IsSolvable (Perm (α ⊕ β))) :
+    IsSolvable (Perm β) := by
+  rw [perm_sum_solvable_iff] at h
+  rw [perm_solvable_iff_card]
+  omega
+
+/-- **Both operations reflect solvability.**  Reflection — solvability of the
+composite descends to a piece — holds for the disjoint union *and* for the
+product.  (The product half needs a nonempty cofactor so that the factor really
+injects; the sum half needs nothing.)  This corrects the parent file's framing:
+`⊕` is not the "non-reflecting" operation — it reflects exactly as `×` does. -/
+theorem both_operations_reflect_solvability :
+    (∀ (α β : Type) [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β],
+        IsSolvable (Perm (α ⊕ β)) → IsSolvable (Perm α)) ∧
+      (∀ (α β : Type) [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β]
+          [Nonempty β], IsSolvable (Perm (α × β)) → IsSolvable (Perm α)) := by
+  refine ⟨fun α β _ _ _ _ h => perm_sum_reflects_solvable_left h, ?_⟩
+  intro α β _ _ _ _ _ h
+  exact perm_solvable_of_prod_solvable h
+
+/-! ## §2  Neither operation preserves solvability
+
+The opposite direction fails for *both* constructions: solvable pieces can build
+an unsolvable composite.  The disjoint union of `2` and `3` points has `5`
+points; the product has `6`.  Both exceed the Abel–Ruffini threshold. -/
+
+/-- **The product `Perm (Fin 2 × Fin 3)` is not solvable** — it has `6` points. -/
+theorem perm_prod_fin_two_three_not_solvable :
+    ¬ IsSolvable (Perm (Fin 2 × Fin 3)) := by
+  rw [perm_prod_solvable_iff, Fintype.card_fin, Fintype.card_fin]
+  omega
+
+/-- **Neither operation preserves solvability.**  For the disjoint union and for
+the product alike, there are solvable pieces (`Perm (Fin 2)`, `Perm (Fin 3)`)
+whose composite is unsolvable.  Together with
+`both_operations_reflect_solvability` this places `⊕` and `×` on the *same* side
+of both implications: both reflect, neither preserves. -/
+theorem neither_operation_preserves_solvability :
+    ¬ (∀ (α β : Type) [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β],
+        IsSolvable (Perm α) → IsSolvable (Perm β) → IsSolvable (Perm (α ⊕ β))) ∧
+      ¬ (∀ (α β : Type) [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β],
+          IsSolvable (Perm α) → IsSolvable (Perm β) → IsSolvable (Perm (α × β))) := by
+  obtain ⟨hs2, hs3, hns⟩ := perm_sum_solvability_not_preserved
+  refine ⟨fun hbad => hns (hbad (Fin 2) (Fin 3) hs2 hs3), fun hbad => ?_⟩
+  exact perm_prod_fin_two_three_not_solvable (hbad (Fin 2) (Fin 3) hs2 hs3)
+
+/-! ## §3  The escape cost: additive `5`, multiplicative `6`
+
+What genuinely distinguishes the two operations is the *least* value outside the
+solvable range `{0,1,2,3,4}` that they can manufacture from solvable inputs.
+
+For sums it is `5` (`= 2 + 3`).  For products `5` is unreachable: `5` is prime,
+so a product equal to `5` needs a factor `5 > 4`, i.e. a piece that is *already*
+unsolvable.  The first product of two solvable cardinalities that escapes
+without a pre-unsolvable factor is therefore `2 · 3 = 6`. -/
+
+/-- **No product of two solvable cardinalities equals `5`.**  Since `5` is prime,
+`m · n = 5` forces a factor to be `5`, contradicting `m, n ≤ 4`. -/
+theorem no_solvable_product_equals_five (m n : ℕ) (hm : m ≤ 4) (hn : n ≤ 4) :
+    m * n ≠ 5 := by
+  interval_cases m <;> interval_cases n <;> omega
+
+/-- **No product of two nontrivial naturals equals `5`.**  A free-standing
+arithmetic fact (`5` prime): if `2 ≤ m` and `2 ≤ n` then `m · n ≠ 5`.  Used to
+show the multiplicative escape skips `5`. -/
+theorem no_nontrivial_product_equals_five (m n : ℕ) (hm : 2 ≤ m) (hn : 2 ≤ n) :
+    m * n ≠ 5 := by
+  rcases le_or_gt 3 m with h3 | h3
+  · have : 6 ≤ m * n := by
+      calc 6 = 3 * 2 := rfl
+        _ ≤ m * n := Nat.mul_le_mul h3 hn
+    omega
+  · interval_cases m
+    omega
+
+/-- **Minimal nontrivial multiplicative escape is `6`.**  Among products of two
+factors each at least `2`, every value that leaves the solvable range `{≤4}` is
+at least `6` — the value `5` is skipped — and `6 = 2 · 3` is attained.  This is
+the multiplicative analogue of "the additive escape is `5`". -/
+theorem min_nontrivial_product_escape :
+    (∀ m n : ℕ, 2 ≤ m → 2 ≤ n → 4 < m * n → 6 ≤ m * n) ∧
+      (2 ≤ 2 ∧ 2 ≤ 3 ∧ 2 * 3 = 6 ∧ 4 < 2 * 3) := by
+  refine ⟨fun m n hm hn h => ?_, by norm_num⟩
+  have h5 : m * n ≠ 5 := no_nontrivial_product_equals_five m n hm hn
+  omega
+
+/-! ## §4  The escape-cost asymmetry, in solvability terms
+
+Side by side: `5` is additively reachable from the solvable range and is
+unsolvable; the same `5` is *not* multiplicatively reachable from the solvable
+range; and the first multiplicative escape, `2 · 3 = 6`, is unsolvable.  The
+multiplicative boundary therefore lies strictly above the additive one. -/
+
+/-- **Escape-cost asymmetry.**  Three facts in one:
+
+1. *Additive escape at `5`*: `5 = 2 + 3` is a sum of two solvable cardinalities
+   and `Perm (Fin (2 + 3))` is unsolvable.
+2. *No multiplicative escape at `5`*: no product of two solvable cardinalities
+   equals `5`.
+3. *Multiplicative escape at `6`*: `6 = 2 · 3` is a product of two solvable
+   cardinalities and `Perm (Fin (2 * 3))` is unsolvable.
+
+So the degree `5` is additively reachable from `{≤4}` but multiplicatively
+skipped: the Abel–Ruffini threshold is crossed one step later under `×` than
+under `⊕`. -/
+theorem escape_cost_asymmetry :
+    (2 ≤ 4 ∧ 3 ≤ 4 ∧ 2 + 3 = 5 ∧ ¬ IsSolvable (Perm (Fin (2 + 3)))) ∧
+      (∀ m n, m ≤ 4 → n ≤ 4 → m * n ≠ 5) ∧
+      (2 ≤ 4 ∧ 3 ≤ 4 ∧ 2 * 3 = 6 ∧ ¬ IsSolvable (Perm (Fin (2 * 3)))) := by
+  refine ⟨⟨by omega, by omega, by omega, ?_⟩,
+    no_solvable_product_equals_five, by omega, by omega, by omega, ?_⟩
+  · exact (not_solvable_perm_card_eq_ge_five _).mpr (by omega)
+  · exact (not_solvable_perm_card_eq_ge_five _).mpr (by omega)
+
+/-- **The multiplicative boundary strictly exceeds the additive boundary.**  The
+least unsolvable degree reachable as a sum of two nontrivial solvable
+cardinalities is `5`; reachable as a product of two nontrivial solvable
+cardinalities it is `6`.  Stated as a strict inequality between the two minimal
+escapes. -/
+theorem multiplicative_boundary_above_additive :
+    (∃ m n, 2 ≤ m ∧ 2 ≤ n ∧ m ≤ 4 ∧ n ≤ 4 ∧ m + n = 5) ∧
+      (∀ m n, 2 ≤ m → 2 ≤ n → m * n ≠ 5) ∧
+      (5 : ℕ) < 6 := by
+  refine ⟨⟨2, 3, by omega, by omega, by omega, by omega, by omega⟩,
+    no_nontrivial_product_equals_five, by omega⟩
+
+end AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01OQ01

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-reflection-overview",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 64 },
+    "type": "concept",
+    "title": "Reflection and preservation are different directions",
+    "content": "The parent file paired the two type operations as 'products reflect, sums fail to preserve'. But **reflection** (solvability of the composite $\\Rightarrow$ solvability of a piece) and **preservation** (solvability of the pieces $\\Rightarrow$ solvability of the composite) are opposite implications. Compared honestly, both $\\oplus$ and $\\times$ reflect (each piece injects into the composite, so $|\\alpha| \\le |\\alpha|+|\\beta|$ and $|\\alpha| \\le |\\alpha|\\cdot|\\beta|$) and neither preserves (solvable $2$- and $3$-point systems combine to unsolvable $5$- and $6$-point ones). The surviving distinction is purely arithmetic — the **cost of escaping** the solvable range $\\{0,1,2,3,4\\}$."
+  },
+  {
+    "id": "ann-sum-reflects",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 104 },
+    "type": "insight",
+    "title": "Sums reflect solvability too",
+    "content": "`perm_sum_reflects_solvable_left` rewrites the union threshold $|\\alpha|+|\\beta| \\le 4$ and the summand threshold $|\\alpha| \\le 4$; since $|\\alpha| \\le |\\alpha|+|\\beta|$ is linear, `omega` closes it. So solvability of $S_{\\alpha\\oplus\\beta}$ descends to $S_\\alpha$ exactly as it does for a Cartesian factor. `both_operations_reflect_solvability` packages the two halves, showing $\\oplus$ is **not** the non-reflecting operation the parent suggested — reflection is symmetric between the two constructions."
+  },
+  {
+    "id": "ann-neither-preserves",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 106, "endLine": 135 },
+    "type": "insight",
+    "title": "Neither operation preserves solvability",
+    "content": "Reusing the parent's witness $S_{\\mathrm{Fin}\\,2}, S_{\\mathrm{Fin}\\,3}$ solvable, `neither_operation_preserves_solvability` shows their composite is unsolvable under **both** operations: $|\\mathrm{Fin}\\,2 \\oplus \\mathrm{Fin}\\,3| = 5$ and $|\\mathrm{Fin}\\,2 \\times \\mathrm{Fin}\\,3| = 6$, both $\\ge 5$. Together with the reflection result this puts $\\oplus$ and $\\times$ on the same side of both implications."
+  },
+  {
+    "id": "ann-no-product-five",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 137, "endLine": 156 },
+    "type": "technique",
+    "title": "5 is multiplicatively unreachable: a primality argument",
+    "content": "`no_solvable_product_equals_five` is `interval_cases m <;> interval_cases n <;> omega` — a finite check over $m, n \\le 4$. The mathematical content is that $5$ is prime: $m\\cdot n = 5$ forces $\\{m,n\\} = \\{1,5\\}$, but $5 > 4$. `no_nontrivial_product_equals_five` makes the same point without an upper bound: if $m \\ge 3$ then $m\\cdot n \\ge 3\\cdot 2 = 6 > 5$ (`Nat.mul_le_mul`), and the remaining case $m = 2$ gives $2n = 5$, impossible by parity (`omega`)."
+  },
+  {
+    "id": "ann-escape-six",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 158, "endLine": 172 },
+    "type": "insight",
+    "title": "The minimal nontrivial multiplicative escape is 6",
+    "content": "`min_nontrivial_product_escape`: for factors $m, n \\ge 2$, any product that leaves $\\{\\le 4\\}$ is $\\ge 6$. Once $m\\cdot n \\neq 5$ is known, `omega` finishes — treating the product as an atom $t$ with $t > 4$ and $t \\neq 5$, hence $t \\ge 6$. The value $6 = 2\\cdot 3$ is attained, so $6$ is exactly the multiplicative analogue of the additive escape $5 = 2+3$."
+  },
+  {
+    "id": "ann-escape-asymmetry",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 184, "endLine": 205 },
+    "type": "insight",
+    "title": "The boundary is crossed one step later under ×",
+    "content": "`escape_cost_asymmetry` collects three facts: $5 = 2+3$ is additively reachable from the solvable range and unsolvable; no product of two cardinalities $\\le 4$ equals $5$; and the first multiplicative escape $2\\cdot 3 = 6$ is unsolvable. `multiplicative_boundary_above_additive` records the resulting strict inequality $5 < 6$. So the degree $5$ — the Abel–Ruffini threshold — is additively reachable but multiplicatively skipped: $\\times$ crosses the boundary one step after $\\oplus$."
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,256 @@
+{
+  "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "slug": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "title": "Reflection Is Symmetric, the Escape Cost Is Not: Additive 5 vs Multiplicative 6 at the Abel–Ruffini Boundary",
+  "description": "The parent file contrasted the type operations ⊕ and × by claiming products REFLECT solvability to their factors while sums fail to PRESERVE it — but that pairing compares different directions. Reflection (solvability of the whole forces solvability of a piece) and preservation (solvability of the pieces forces solvability of the whole) are distinct, and the honest accounting is symmetric: BOTH operations reflect and NEITHER preserves. A summand injects into the disjoint union exactly as a factor injects into the product, so card α ≤ card α + card β and card α ≤ card α · card β alike — solvability of Perm (α ⊕ β) AND of Perm (α × β) both descend to Perm α (both_operations_reflect_solvability). And Perm (Fin 2), Perm (Fin 3) solvable yet both Perm (Fin 2 ⊕ Fin 3) (5 points) and Perm (Fin 2 × Fin 3) (6 points) unsolvable (neither_operation_preserves_solvability). What truly separates ⊕ from × is the COST of escaping the solvable range {0,1,2,3,4}: the additive escape is 5 (= 2 + 3), but no product of two solvable cardinalities ever equals 5 — 5 is prime, so a factor would have to be 5 > 4 (no_solvable_product_equals_five). The first product of two nontrivial solvable cardinalities that escapes is 2 · 3 = 6 (min_nontrivial_product_escape). Hence the multiplicative boundary lies strictly above the additive one: the degree 5 is additively reachable from the solvable range but multiplicatively skipped (escape_cost_asymmetry).",
+  "overview": {
+    "historicalContext": "Abel–Ruffini rests on S₅ being non-solvable. Classically Sₙ and Aₙ are solvable exactly for n ≤ 4, and the threshold is permanent under enlarging the carrier. The parent chain read that threshold through the two monoidal structures on finite types — disjoint union (which adds point counts) and Cartesian product (which multiplies them) — and proposed an asymmetry: products reflect solvability, sums do not preserve it. But this pairs two different implications. Reflection means the composite's solvability forces a piece's; preservation means the pieces' solvability forces the composite's. Once stated carefully, both ⊕ and × reflect (each piece injects into the composite) and neither preserves (solvable 2- and 3-point systems combine to unsolvable 5- and 6-point systems). The genuine difference between the two operations is arithmetic, not directional: the smallest value the operation can push out of {0,1,2,3,4} starting from solvable inputs.",
+    "modernSignificance": "Reading Perm as a functor on finite types, solvability of Perm (α ⊕ β) and Perm (α × β) is governed by card α + card β and card α · card β. Because a summand and a factor both inject into the composite carrier, the threshold card ≤ 4 is reflected to the pieces by BOTH operations — the directional asymmetry suggested earlier dissolves. The surviving, genuine distinction is the escape cost. Additively, the solvable range {0,1,2,3,4} first breaks closure at 2 + 3 = 5, the Abel–Ruffini degree. Multiplicatively, 5 is unreachable from solvable factors: 5 is prime, so m · n = 5 needs a factor 5 > 4, i.e. a piece already unsolvable. The first product of two nontrivial solvable cardinalities that escapes is 2 · 3 = 6. So the multiplicative boundary sits strictly above the additive one, and the degree 5 is additively reachable but multiplicatively skipped — the precise arithmetic shadow of the threshold under the algebra of finite types."
+  },
+  "meta": {
+    "author": "Classical (Sₙ/Aₙ solvable iff n ≤ 4); reflection-symmetry and escape-cost formalization original",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Symmetric_group",
+    "date": "1870",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "solvability",
+      "alternating-group",
+      "symmetric-group",
+      "product",
+      "disjoint-union",
+      "closure",
+      "classification",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.card_sum",
+        "description": "Fintype.card (α ⊕ β) = Fintype.card α + Fintype.card β. Behind perm_sum_solvable_iff, used to reflect solvability of the union to a summand via card α ≤ card α + card β.",
+        "module": "Mathlib.Data.Fintype.Sum"
+      },
+      {
+        "theorem": "Fintype.card_prod",
+        "description": "Fintype.card (α × β) = Fintype.card α * Fintype.card β. Behind perm_prod_solvable_iff, used both for product reflection and for the 6-point non-preservation witness Perm (Fin 2 × Fin 3).",
+        "module": "Mathlib.Data.Fintype.Prod"
+      },
+      {
+        "theorem": "Nat.mul_le_mul",
+        "description": "a ≤ b ∧ c ≤ d ⟹ a * c ≤ b * d. With 3 ≤ m and 2 ≤ n yields 6 ≤ m · n, the engine that forces every nontrivial multiplicative escape to be at least 6 (no_nontrivial_product_equals_five).",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Fintype.card_fin",
+        "description": "Fintype.card (Fin n) = n. Evaluates the concrete witnesses Perm (Fin 2 ⊕ Fin 3) at 5 points and Perm (Fin 2 × Fin 3) at 6 points for the non-preservation counterexamples.",
+        "module": "Mathlib.Data.Fintype.Card"
+      }
+    ],
+    "originalContributions": [
+      "perm_sum_reflects_solvable_left / perm_sum_reflects_solvable_right: sums REFLECT solvability to each summand (card α ≤ card α + card β), the missing half of the picture — disjoint union reflects exactly as product does",
+      "both_operations_reflect_solvability: reflection is symmetric between ⊕ and × — solvability of the composite descends to a piece for both operations, correcting the parent's framing that ⊕ was the non-reflecting operation",
+      "perm_prod_fin_two_three_not_solvable: the 6-point product Perm (Fin 2 × Fin 3) is unsolvable — the multiplicative counterpart of the 5-point union",
+      "neither_operation_preserves_solvability: NEITHER operation preserves solvability — solvable Perm (Fin 2), Perm (Fin 3) build unsolvable composites under both ⊕ (5 points) and × (6 points), placing the two operations on the same side of both implications",
+      "no_solvable_product_equals_five: no product of two solvable cardinalities (m, n ≤ 4) equals 5 — 5 is prime, so a factor would have to be 5 > 4; the multiplicative range skips the additive escape value",
+      "no_nontrivial_product_equals_five: the underlying prime fact — 2 ≤ m, 2 ≤ n ⟹ m · n ≠ 5 — via Nat.mul_le_mul (m ≥ 3 forces ≥ 6) and the m = 2 parity case",
+      "min_nontrivial_product_escape: the minimal nontrivial multiplicative escape is 6 — every product of two factors ≥ 2 that leaves {≤4} is at least 6 (5 skipped), and 6 = 2 · 3 is attained, the multiplicative analogue of 'additive escape is 5'",
+      "escape_cost_asymmetry: side by side — 5 is additively reachable from the solvable range and unsolvable, the same 5 is not multiplicatively reachable, and the first multiplicative escape 2 · 3 = 6 is unsolvable; the Abel–Ruffini threshold is crossed one step later under × than under ⊕",
+      "multiplicative_boundary_above_additive: the strict inequality 5 < 6 between the two minimal nontrivial escapes, packaged with their witnesses"
+    ],
+    "dateAdded": "2026-06-21",
+    "axiomCount": 0,
+    "lineCount": 205,
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used. The reflection lemmas rewrite the parent chain's thresholds (perm_sum_solvable_iff / perm_prod_solvable_iff / perm_solvable_iff_card) and close with omega; the escape-cost lemmas use only elementary Nat arithmetic (interval_cases, Nat.mul_le_mul, omega). `#print axioms` on escape_cost_asymmetry, both_operations_reflect_solvability, min_nontrivial_product_escape and multiplicative_boundary_above_additive reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "additionalFiles": [],
+    "relatedProblems": [
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01",
+        "relationship": "Parent — contrasted ⊕ and × by claiming products reflect solvability while sums fail to preserve it. This entry shows that pairing compares different directions: both operations reflect and neither preserves, so the genuine distinction is the escape cost — additive 5 versus multiplicative 6."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01",
+        "relationship": "Grandparent — the up-set {≥5} / down-set {≤4} partition of ℕ and the predicate not_solvable_perm_card_eq_ge_five used to certify the 5- and 6-point witnesses as unsolvable."
+      },
+      {
+        "id": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+        "relationship": "Ancestor — the intrinsic threshold IsSolvable (Perm α) ↔ Fintype.card α ≤ 4 behind every reflection step."
+      },
+      {
+        "id": "abel-ruffini",
+        "relationship": "Ancestor — Abel–Ruffini rests on S₅ non-solvable. escape_cost_asymmetry recovers 5 as the additive boundary and 6 as the multiplicative one, locating the classical threshold one step apart under the two type operations."
+      }
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Solvable",
+      "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Mathlib.GroupTheory.Perm.ViaEmbedding",
+      "Mathlib.Tactic",
+      "Proofs.AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Equiv"
+    ],
+    "namespace": "AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01OQ01",
+    "lineCount": 205,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "perm_sum_reflects_solvable_left",
+        "type": "core",
+        "description": "Sums reflect solvability to the first summand: if Perm (α ⊕ β) is solvable then so is Perm α, since card α ≤ card α + card β.",
+        "leanType": "[DecidableEq α] → [DecidableEq β] → [Fintype α] → [Fintype β] → IsSolvable (Perm (α ⊕ β)) → IsSolvable (Perm α)",
+        "line": 69
+      },
+      {
+        "name": "both_operations_reflect_solvability",
+        "type": "key",
+        "description": "Reflection is symmetric: solvability of the composite descends to a piece for the disjoint union AND for the product (the product half needing a nonempty cofactor). Corrects the parent's framing that ⊕ was the non-reflecting operation.",
+        "leanType": "(∀ (α β : Type) [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β], IsSolvable (Perm (α ⊕ β)) → IsSolvable (Perm α)) ∧ (∀ (α β : Type) [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β] [Nonempty β], IsSolvable (Perm (α × β)) → IsSolvable (Perm α))",
+        "line": 90
+      },
+      {
+        "name": "neither_operation_preserves_solvability",
+        "type": "key",
+        "description": "Neither ⊕ nor × preserves solvability: solvable Perm (Fin 2), Perm (Fin 3) build unsolvable composites under both — Perm (Fin 2 ⊕ Fin 3) (5 points) and Perm (Fin 2 × Fin 3) (6 points).",
+        "leanType": "¬ (∀ (α β : Type) [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β], IsSolvable (Perm α) → IsSolvable (Perm β) → IsSolvable (Perm (α ⊕ β))) ∧ ¬ (∀ (α β : Type) [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β], IsSolvable (Perm α) → IsSolvable (Perm β) → IsSolvable (Perm (α × β)))",
+        "line": 116
+      },
+      {
+        "name": "no_solvable_product_equals_five",
+        "type": "core",
+        "description": "No product of two solvable cardinalities equals 5: m, n ≤ 4 ⟹ m · n ≠ 5, since 5 is prime and a factor would have to be 5 > 4.",
+        "leanType": "(m n : ℕ) → m ≤ 4 → n ≤ 4 → m * n ≠ 5",
+        "line": 137
+      },
+      {
+        "name": "min_nontrivial_product_escape",
+        "type": "key",
+        "description": "The minimal nontrivial multiplicative escape is 6: every product of two factors ≥ 2 that leaves {≤4} is at least 6 (the value 5 is skipped), and 6 = 2 · 3 is attained.",
+        "leanType": "(∀ m n : ℕ, 2 ≤ m → 2 ≤ n → 4 < m * n → 6 ≤ m * n) ∧ (2 ≤ 2 ∧ 2 ≤ 3 ∧ 2 * 3 = 6 ∧ 4 < 2 * 3)",
+        "line": 158
+      },
+      {
+        "name": "escape_cost_asymmetry",
+        "type": "specialization",
+        "description": "Additive escape at 5, no multiplicative escape at 5, multiplicative escape at 6: the degree 5 is additively reachable from the solvable range and unsolvable, is not multiplicatively reachable, and the first multiplicative escape 2 · 3 = 6 is unsolvable.",
+        "leanType": "(2 ≤ 4 ∧ 3 ≤ 4 ∧ 2 + 3 = 5 ∧ ¬ IsSolvable (Perm (Fin (2 + 3)))) ∧ (∀ m n, m ≤ 4 → n ≤ 4 → m * n ≠ 5) ∧ (2 ≤ 4 ∧ 3 ≤ 4 ∧ 2 * 3 = 6 ∧ ¬ IsSolvable (Perm (Fin (2 * 3))))",
+        "line": 184
+      }
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "escape_cost_asymmetry",
+      "statement": "The degree 5 is additively reachable from the solvable cardinalities {0,1,2,3,4} (5 = 2 + 3) and is unsolvable; it is NOT multiplicatively reachable from them (no product of two cardinalities ≤ 4 equals 5); and the first multiplicative escape, 2 · 3 = 6, is unsolvable.",
+      "significance": "Isolates the genuine distinction between the two type operations once the spurious reflection/preservation asymmetry is removed: both ⊕ and × reflect solvability and neither preserves it, but their escape costs differ — the Abel–Ruffini boundary is crossed at additive degree 5 and at multiplicative degree 6, one step apart."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Documentation and Imports",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Module docstring re-examining the parent's reflection/preservation contrast: reflection and preservation are different directions, both operations reflect, neither preserves, and the real distinction is the escape cost (additive 5 vs multiplicative 6). Imports the parent chain and Mathlib group/permutation infrastructure.",
+      "mathContext": "Parent supplies perm_sum_solvable_iff, perm_prod_solvable_iff, perm_solvable_of_prod_solvable, perm_sum_solvability_not_preserved, perm_solvable_iff_card and not_solvable_perm_card_eq_ge_five."
+    },
+    {
+      "id": "reflection",
+      "title": "§1 Reflection is symmetric between ⊕ and ×",
+      "startLine": 65,
+      "endLine": 104,
+      "summary": "perm_sum_reflects_solvable_left/right reflect solvability of the union to each summand (card α ≤ card α + card β); both_operations_reflect_solvability packages reflection for both ⊕ and ×.",
+      "mathContext": "A summand and a factor each inject into the composite carrier, so the threshold card ≤ 4 is reflected to the pieces by both operations — the directional asymmetry suggested by the parent dissolves."
+    },
+    {
+      "id": "preservation",
+      "title": "§2 Neither operation preserves solvability",
+      "startLine": 105,
+      "endLine": 135,
+      "summary": "perm_prod_fin_two_three_not_solvable gives the 6-point product witness; neither_operation_preserves_solvability shows solvable Perm (Fin 2), Perm (Fin 3) build unsolvable composites under both ⊕ and ×.",
+      "mathContext": "Solvability of the pieces forces solvability of neither composite: the 2- and 3-point systems combine to 5 points under ⊕ and 6 points under ×, both beyond the threshold."
+    },
+    {
+      "id": "escape-cost",
+      "title": "§3 The escape cost: additive 5, multiplicative 6",
+      "startLine": 136,
+      "endLine": 173,
+      "summary": "no_solvable_product_equals_five and no_nontrivial_product_equals_five establish that 5 is multiplicatively unreachable from solvable factors (5 prime); min_nontrivial_product_escape identifies 6 as the minimal nontrivial multiplicative escape.",
+      "mathContext": "5 is the additive escape but is skipped multiplicatively: m · n = 5 needs a factor 5 > 4. With both factors ≥ 2 the first escape is 2 · 3 = 6."
+    },
+    {
+      "id": "asymmetry",
+      "title": "§4 The escape-cost asymmetry, in solvability terms",
+      "startLine": 174,
+      "endLine": 205,
+      "summary": "escape_cost_asymmetry puts the three facts side by side; multiplicative_boundary_above_additive states the strict inequality 5 < 6 between the two minimal nontrivial escapes with their witnesses.",
+      "mathContext": "The multiplicative boundary lies strictly above the additive one: the Abel–Ruffini threshold is crossed at additive degree 5 but only at multiplicative degree 6."
+    }
+  ],
+  "sorries": [],
+  "references": [
+    {
+      "authors": [
+        "C. Jordan"
+      ],
+      "title": "Traité des substitutions et des équations algébriques",
+      "year": "1870",
+      "venue": "Gauthier-Villars, Paris",
+      "note": "Sₙ and Aₙ solvable iff n ≤ 4; the inheritance of non-solvability with degree."
+    },
+    {
+      "authors": [
+        "É. Galois"
+      ],
+      "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
+      "year": "1846",
+      "venue": "Journal de Mathématiques Pures et Appliquées (published posthumously)",
+      "note": "Solvability by radicals iff solvable Galois group; S₅ as the minimal obstruction inherited by every higher degree."
+    },
+    {
+      "authors": [
+        "I. Stewart"
+      ],
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "Chapman and Hall/CRC, 4th edition",
+      "note": "Sₙ and Aₙ solvable iff n ≤ 4; subgroup-closure of solvability."
+    },
+    {
+      "authors": [
+        "The mathlib Community"
+      ],
+      "title": "The Lean Mathematical Library — Data.Fintype.Sum, Data.Fintype.Prod and GroupTheory.Solvable",
+      "year": "2020",
+      "venue": "Lean 4 / Mathlib",
+      "note": "Source of Fintype.card_sum, Fintype.card_prod and Nat.mul_le_mul, the arithmetic engines of the reflection and escape-cost lemmas."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent contrasted ⊕ and × as reflecting vs non-preserving. This entry shows that compares different directions: both reflect, neither preserves, and the real difference is the escape cost — additive 5 vs multiplicative 6."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent up-set/down-set partition; not_solvable_perm_card_eq_ge_five certifies the 5- and 6-point witnesses as unsolvable."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "Abel–Ruffini rests on S₅ non-solvable; escape_cost_asymmetry locates the classical threshold at additive degree 5 and multiplicative degree 6, one step apart under the two type operations."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Next link in the Abel–Ruffini OQ chain. The **parent** entry contrasted the type operations `⊕` and `×` as *"products reflect solvability to their factors, sums fail to preserve it"* — but that pairs two **different** implications. Reflection (solvability of the composite ⟹ solvability of a piece) and preservation (solvability of the pieces ⟹ solvability of the composite) are opposite directions. Stated honestly:

- **Both operations reflect.** A summand injects into `α ⊕ β` exactly as a factor injects into `α × β`, so `card α ≤ card α + card β` and `card α ≤ card α · card β` alike. `both_operations_reflect_solvability`.
- **Neither operation preserves.** `Perm (Fin 2)`, `Perm (Fin 3)` solvable, yet both `Perm (Fin 2 ⊕ Fin 3)` (5 pts) and `Perm (Fin 2 × Fin 3)` (6 pts) unsolvable. `neither_operation_preserves_solvability`.

The genuine distinction is the **escape cost** out of the solvable range `{0,1,2,3,4}`:

- **Additive escape = 5** (`= 2 + 3`).
- **Multiplicative escape = 6.** No product of two solvable cardinalities equals 5 — 5 is prime, so a factor would have to be `5 > 4` (`no_solvable_product_equals_five`). The first nontrivial multiplicative escape is `2 · 3 = 6` (`min_nontrivial_product_escape`).

So the multiplicative boundary lies strictly above the additive one: degree 5 is additively reachable but multiplicatively skipped (`escape_cost_asymmetry`, `multiplicative_boundary_above_additive`).

## Verification
- `proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01OQ01.lean` — 205 lines, 10 theorems, 0 defs.
- Builds clean via `docker-build.sh` (3068 jobs). **No `sorry`, no `axiom`, no `native_decide`.**
- `#print axioms` on the main results reports only `propext`, `Classical.choice`, `Quot.sound` — 0-axiom by project policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)