### PR TITLE
research(area-of-circle-oq-05-oq-03-oq-01): the Gaussian dilation law and the uncertainty duality

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -166,6 +166,7 @@ import Proofs.AreaOfCircleOQ05OQ01Aristotle
 import Proofs.AreaOfCircleOQ05OQ02
 import Proofs.AreaOfCircleOQ05OQ03
 import Proofs.AreaOfCircleOQ05OQ03OQ02
+import Proofs.AreaOfCircleOQ05OQ03OQ01
 import Proofs.AreaOfCircleOQ05OQ04
 import Proofs.AreaOfCircleOQ07
 import Proofs.AreaOfCircleOQ07OQ01

--- a/proofs/Proofs/AreaOfCircleOQ05OQ03OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ03OQ01.lean
@@ -1,0 +1,242 @@
+/-
+  The Gaussian Dilation Law and the Uncertainty Duality of the Fourier Transform
+  (area-of-circle-oq-05-oq-03-oq-01)
+
+  A follow-up to `area-of-circle-oq-05-oq-03` ("the Gaussian is its own Fourier
+  transform"), which proved the SELF-dual case (variance 1):
+
+      ∫_ℝ e^{i t x} · e^{-x²/2} dx = e^{-t²/2} · √(2π).
+
+  Here we prove the full **one-parameter dilation law**: for every width σ > 0,
+
+      ∫_ℝ e^{i t x} · e^{-x²/(2σ²)} dx = σ·√(2π) · e^{-σ² t²/2},          (★)
+
+  together with its probability-normalized companion
+
+      ∫_ℝ e^{i t x} · (e^{-x²/(2σ²)} / (σ√(2π))) dx = e^{-σ² t²/2}.        (★★)
+
+  The right-hand side of (★★) is the characteristic function of the centered
+  normal distribution N(0, σ²).
+
+  STRUCTURAL PAYOFF — THE UNCERTAINTY DUALITY.  The input density on the left of
+  (★★) is a Gaussian of spatial width σ; the output on the right is, up to the
+  unitary normalization, a Gaussian of *frequency* width 1/σ:
+
+      e^{-σ² t²/2} = e^{-t² / (2·(1/σ)²)}.
+
+  Thus the Fourier transform INVERTS the width: a narrow bump (small σ) transforms
+  to a wide bump (large 1/σ), and the product of the two scales is constant,
+
+      (input width) · (output width) = σ · (1/σ) = 1,
+
+  which is the elementary heart of the Heisenberg uncertainty principle.  The
+  self-dual σ = 1 case of the parent is exactly the fixed point of this duality.
+
+  METHOD.  Completing the square in the form  i t x − b x² = −b(x + c i)² − b c²
+  with  b = 1/(2σ²)  and  c = −t/(2b) = −t σ²  (so 2 b c = −t), then evaluating
+  the resulting vertical-strip-shifted Gaussian by Mathlib's
+  `GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I`.  The completing-the-
+  square step is proved division-free (parametrized by the relation 2 b c = −t),
+  so the only `field_simp`/`I² = −1` work is the final algebraic bookkeeping.
+
+  Everything is proved with 0 sorries and 0 axioms.
+
+  References:
+  - Stein–Shakarchi, *Fourier Analysis* (2003), Ch. 5 (the Gaussian and its
+    dilation/uncertainty behaviour).
+  - Mathlib: Analysis.SpecialFunctions.Gaussian.FourierTransform
+-/
+import Mathlib
+
+set_option maxHeartbeats 1200000
+set_option linter.unusedVariables false
+set_option linter.unusedSectionVars false
+
+open Real Complex MeasureTheory
+open scoped Real
+
+namespace GaussianDilation
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I:  COMPLETING THE SQUARE (DIVISION-FREE, POINTWISE)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Completing the square, parametrized by the relation `2 b c = -t`.**
+    For real `b, c, t, x` with `2 b c = -t`,
+
+      e^{i t x} · e^{-b x²} = e^{-b (x + c i)²} · e^{-b c²}.
+
+    Keeping `c` abstract (with the single algebraic constraint `2 b c = -t`) makes
+    the identity hold with no division, so it follows by `linear_combination`
+    using only `i² = -1`. -/
+theorem complete_square_param (b c t : ℝ) (h : 2 * b * c = -t) (x : ℝ) :
+    Complex.exp (Complex.I * t * x) * Complex.exp (-(b : ℂ) * (x : ℂ) ^ 2)
+      = Complex.exp (-(b : ℂ) * ((x : ℂ) + (c : ℂ) * Complex.I) ^ 2)
+        * Complex.exp (-((b : ℂ) * (c : ℂ) ^ 2)) := by
+  rw [← Complex.exp_add, ← Complex.exp_add]
+  congr 1
+  have hc : (2 : ℂ) * (b : ℂ) * (c : ℂ) = -(t : ℂ) := by exact_mod_cast h
+  linear_combination (Complex.I * (x : ℂ)) * hc + ((b : ℂ) * (c : ℂ) ^ 2) * Complex.I_sq
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II:  THE CONSTANT √(π/b) FROM THE CONTOUR INTEGRAL
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The Mathlib contour-integral constant `(π / b)^(1/2)` is the complex coercion
+    of the real `√(π/b)` (for `b > 0`). -/
+theorem cpow_half_eq_sqrt (b : ℝ) (hb : 0 < b) :
+    ((π : ℂ) / (b : ℂ)) ^ (1 / 2 : ℂ) = ((Real.sqrt (π / b) : ℝ) : ℂ) := by
+  have h0 : (0 : ℝ) ≤ π / b := by positivity
+  rw [show ((π : ℂ) / (b : ℂ)) = ((π / b : ℝ) : ℂ) by push_cast; ring]
+  rw [Real.sqrt_eq_rpow, Complex.ofReal_cpow h0]
+  norm_num
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III:  THE GENERAL GAUSSIAN FOURIER INTEGRAL (COEFFICIENT FORM)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **The Fourier integral of a coefficient-`b` Gaussian.**  For `b > 0`,
+
+      ∫_ℝ e^{i t x} · e^{-b x²} dx = e^{-b c²} · √(π/b),   where  c = -t/(2b).
+
+    (The `t`-dependence sits in `c`; rewriting `b = 1/(2σ²)` gives the width form.) -/
+theorem gaussian_fourier_param (b t : ℝ) (hb : 0 < b) :
+    ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(b : ℂ) * (x : ℂ) ^ 2)
+      = Complex.exp (-((b : ℂ) * ((-t / (2 * b) : ℝ) : ℂ) ^ 2))
+        * ((Real.sqrt (π / b) : ℝ) : ℂ) := by
+  have hbne : b ≠ 0 := ne_of_gt hb
+  have hrel : 2 * b * (-t / (2 * b)) = -t := by field_simp
+  simp_rw [complete_square_param b (-t / (2 * b)) t hrel]
+  rw [MeasureTheory.integral_mul_const]
+  rw [GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I
+        (b := (b : ℂ)) (by rw [Complex.ofReal_re]; exact hb) (-t / (2 * b))]
+  rw [cpow_half_eq_sqrt b hb]
+  ring
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV:  THE DILATION LAW (WIDTH FORM) AND ITS NORMALIZATION
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **The Gaussian dilation law (un-normalized).**  For every width `σ > 0`,
+
+      ∫_ℝ e^{i t x} · e^{-x²/(2σ²)} dx = e^{-σ² t²/2} · σ·√(2π). -/
+theorem gaussian_fourier_dilated (σ t : ℝ) (hσ : 0 < σ) :
+    ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2))
+      = Complex.exp (-((σ : ℂ) ^ 2 * (t : ℂ) ^ 2 / 2)) * ((σ * Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  have hσ0 : σ ≠ 0 := ne_of_gt hσ
+  have hσC : (σ : ℂ) ≠ 0 := by exact_mod_cast hσ0
+  have hb : 0 < (1 / (2 * σ ^ 2)) := by positivity
+  -- rewrite the density into coefficient form  e^{-(1/(2σ²)) x²}
+  have hpt : ∀ x : ℝ,
+      (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) = (-((1 / (2 * σ ^ 2) : ℝ) : ℂ)) * (x : ℂ) ^ 2 := by
+    intro x; push_cast; ring
+  simp_rw [hpt]
+  rw [gaussian_fourier_param (1 / (2 * σ ^ 2)) t hb]
+  congr 1
+  · -- the exponent:  -(b c²) = -(σ² t²/2)
+    congr 1
+    push_cast
+    field_simp
+  · -- the constant:  √(π / (1/(2σ²))) = σ·√(2π)
+    congr 1
+    rw [show (π / (1 / (2 * σ ^ 2))) = σ ^ 2 * (2 * π) by field_simp]
+    rw [Real.sqrt_mul (by positivity : (0 : ℝ) ≤ σ ^ 2), Real.sqrt_sq hσ.le]
+
+/-- **The centered normal density is its own Fourier transform, up to width
+    inversion (normalized).**  For `σ > 0`,
+
+      ∫_ℝ e^{i t x} · (e^{-x²/(2σ²)} / (σ√(2π))) dx = e^{-σ² t²/2}.
+
+    The right-hand side is the characteristic function of `N(0, σ²)`. -/
+theorem gaussian_fourier_dilated_normalized (σ t : ℝ) (hσ : 0 < σ) :
+    ∫ x : ℝ, Complex.exp (Complex.I * t * x)
+        * (Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) / ((σ * Real.sqrt (2 * π) : ℝ) : ℂ))
+      = Complex.exp (-((σ : ℂ) ^ 2 * (t : ℂ) ^ 2 / 2)) := by
+  have hC : ((σ * Real.sqrt (2 * π) : ℝ) : ℂ) ≠ 0 := by
+    rw [Complex.ofReal_ne_zero]
+    have : 0 < σ * Real.sqrt (2 * π) :=
+      mul_pos hσ (Real.sqrt_pos.mpr (by positivity))
+    exact ne_of_gt this
+  simp_rw [← mul_div_assoc]
+  rw [MeasureTheory.integral_div, gaussian_fourier_dilated σ t hσ]
+  rw [mul_div_assoc, div_self hC, mul_one]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART V:  THE UNCERTAINTY DUALITY AND CONSEQUENCES
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **The uncertainty duality (explicit width inversion).**  The Fourier transform
+    of the centered normal density of width `σ` is the Gaussian of width `1/σ`:
+
+      ∫_ℝ e^{i t x} · (e^{-x²/(2σ²)} / (σ√(2π))) dx = e^{-t² / (2·(1/σ)²)}.
+
+    Read against `gaussian_fourier_dilated_normalized`, this is the statement that
+    Fourier transformation sends width `σ` to width `1/σ`. -/
+theorem dilation_duality (σ t : ℝ) (hσ : 0 < σ) :
+    ∫ x : ℝ, Complex.exp (Complex.I * t * x)
+        * (Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) / ((σ * Real.sqrt (2 * π) : ℝ) : ℂ))
+      = Complex.exp (-(t : ℂ) ^ 2 / (2 * ((1 / σ : ℝ) : ℂ) ^ 2)) := by
+  have hσC : (σ : ℂ) ≠ 0 := by exact_mod_cast (ne_of_gt hσ)
+  rw [gaussian_fourier_dilated_normalized σ t hσ]
+  congr 1
+  push_cast
+  field_simp
+
+/-- **The product of input and output widths is `1`** — the elementary uncertainty
+    relation underlying the duality.  Input density width `σ`, transform width `1/σ`. -/
+theorem dilation_width_product (σ : ℝ) (hσ : 0 < σ) :
+    σ * (1 / σ) = 1 := by
+  rw [mul_one_div, div_self (ne_of_gt hσ)]
+
+/-- **Total mass / `t = 0`:** the centered normal density of width `σ` integrates
+    to `1`. -/
+theorem gaussian_density_total_mass (σ : ℝ) (hσ : 0 < σ) :
+    ∫ x : ℝ, Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) / ((σ * Real.sqrt (2 * π) : ℝ) : ℂ)
+      = 1 := by
+  simpa using gaussian_fourier_dilated_normalized σ 0 hσ
+
+/-- **The un-normalized width-`σ` Gaussian integral:** `∫ e^{-x²/(2σ²)} dx = σ√(2π)`
+    (the `t = 0` shadow of the dilation law). -/
+theorem integral_gaussian_dilated (σ : ℝ) (hσ : 0 < σ) :
+    ∫ x : ℝ, Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) = ((σ * Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  simpa using gaussian_fourier_dilated σ 0 hσ
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+Summary
+═══════════════════════════════════════════════════════════════════════════════
+
+## The Gaussian dilation law and the uncertainty duality  (oq-05-oq-03-oq-01)
+
+### What's proved (0 sorries, 0 axioms):
+- `complete_square_param`: division-free completing-the-square
+  e^{itx}e^{-bx²} = e^{-b(x+ci)²}e^{-bc²} under `2bc = -t` (via i² = -1).
+- `cpow_half_eq_sqrt`: the Mathlib contour constant (π/b)^(1/2) = √(π/b), b > 0.
+- `gaussian_fourier_param`: ∫ e^{itx} e^{-bx²} dx = e^{-bc²}·√(π/b), c = -t/(2b).
+- `gaussian_fourier_dilated`: **∫ e^{itx} e^{-x²/(2σ²)} dx = e^{-σ²t²/2}·σ√(2π)** —
+  the full one-parameter dilation law (the parent is the σ = 1 fixed point).
+- `gaussian_fourier_dilated_normalized`: **∫ e^{itx}(e^{-x²/(2σ²)}/(σ√(2π))) dx
+  = e^{-σ²t²/2}** — the characteristic function of N(0, σ²).
+- `dilation_duality`: the transform of a width-σ density is the width-(1/σ)
+  Gaussian e^{-t²/(2(1/σ)²)} — Fourier inverts the width.
+- `dilation_width_product`: σ·(1/σ) = 1, the elementary uncertainty relation.
+- `gaussian_density_total_mass`, `integral_gaussian_dilated`: the t = 0 shadows.
+
+### Relation to the parent:
+The parent (`area-of-circle-oq-05-oq-03`) proved the self-dual case σ = 1.  This
+entry promotes that single identity to the full dilation group and isolates the
+structural phenomenon — Fourier transformation inverts Gaussian width — that the
+σ = 1 case hides by being its own fixed point.
+-/
+
+#check @gaussian_fourier_dilated
+#check @gaussian_fourier_dilated_normalized
+#check @dilation_duality
+#check @dilation_width_product
+
+end GaussianDilation

--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-01/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "ann-aoc-oq05oq03oq01-scope",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 60
+    },
+    "type": "insight",
+    "title": "From Self-Duality to the Dilation Law: Fourier Inverts Gaussian Width",
+    "content": "The parent entry proved the Gaussian is its own Fourier transform — but only at width σ=1, the self-dual case. This entry proves the full one-parameter dilation law: for every σ>0, ∫ e^{itx}·e^{-x²/(2σ²)} dx = e^{-σ²t²/2}·σ√(2π), and normalized, ∫ e^{itx}·(e^{-x²/(2σ²)}/(σ√(2π))) dx = e^{-σ²t²/2}, the characteristic function of N(0,σ²). The structural payoff: e^{-σ²t²/2} = e^{-t²/(2(1/σ)²)} is itself a Gaussian of width 1/σ, so the Fourier transform inverts the width — narrow transforms to wide — and (input width)·(output width) = σ·(1/σ) = 1. This is the elementary Gaussian heart of the Heisenberg uncertainty principle. All 0 axioms, 0 sorries.",
+    "mathContext": "The Fourier transform conjugates dilation-by-σ into dilation-by-(1/σ); the parent's σ=1 identity is the fixed point of this duality.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fourier transform",
+      "Gaussian",
+      "dilation",
+      "uncertainty principle",
+      "characteristic function"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq01-divfree",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 82
+    },
+    "type": "technique",
+    "title": "Division-Free Completing the Square",
+    "content": "The eventual shift c=−tσ² and pull-out constant σ²t²/2 both involve division by σ², which would force field_simp inside the delicate exponential identity. The trick (complete_square_param) keeps c abstract and imposes only the single relation 2bc=−t: then e^{itx}·e^{-bx²} = e^{-b(x+ci)²}·e^{-bc²} holds with NO division, so it closes by linear_combination ((I·x)·hc + (b·c²)·Complex.I_sq) — the only non-ring fact being i²=−1. All division is then confined to a separate, purely real bridge (b=1/(2σ²), bc²=σ²t²/2) handled by field_simp away from the complex exponentials.",
+    "mathContext": "Completing the square i t x − b x² = −b(x+ci)² − bc² under 2bc=−t, isolating i²=−1 as the sole analytic input.",
+    "significance": "key",
+    "relatedConcepts": [
+      "completing the square",
+      "linear_combination",
+      "Complex.I_sq"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq01-contour",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-01",
+    "range": {
+      "startLine": 83,
+      "endLine": 117
+    },
+    "type": "technique",
+    "title": "The Contour Constant and the Coefficient-Form Master Identity",
+    "content": "cpow_half_eq_sqrt converts the complex contour value (π/b)^{1/2} into the real √(π/b) (Real.sqrt_eq_rpow, Complex.ofReal_cpow). gaussian_fourier_param then assembles the b-coefficient master identity ∫ e^{itx} e^{-bx²} dx = e^{-bc²}·√(π/b) with c=−t/(2b): simp_rw the complete-the-square factoring, pull the constant out with integral_mul_const, and evaluate the remaining vertical-strip Gaussian by Mathlib's GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I. Every width-form result is a specialization b=1/(2σ²) of this one identity.",
+    "mathContext": "The shifted Gaussian ∫ e^{-b(x+ci)²} dx = (π/b)^{1/2} (Cauchy vertical-strip), packaged by Mathlib and reduced to a real square root.",
+    "significance": "important",
+    "relatedConcepts": [
+      "contour integral",
+      "Gaussian integral",
+      "cpow",
+      "Bochner integral"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq01-dilation",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 168
+    },
+    "type": "insight",
+    "title": "The Dilation Law and the Characteristic Function of N(0,σ²)",
+    "content": "Substituting b=1/(2σ²) into the master identity gives gaussian_fourier_dilated: ∫ e^{itx}e^{-x²/(2σ²)} dx = e^{-σ²t²/2}·σ√(2π), since (π/b)^{1/2} = √(2πσ²) = σ√(2π) (Real.sqrt_mul, Real.sqrt_sq) and bc² = σ²t²/2 (field_simp). Dividing by σ√(2π) (gaussian_fourier_dilated_normalized) yields the characteristic function of the centered normal N(0,σ²): e^{-σ²t²/2}. This is the general-variance input that the characteristic-function proof of the Central Limit Theorem needs.",
+    "mathContext": "The dilated density e^{-x²/(2σ²)}/(σ√(2π)) is N(0,σ²); its Fourier transform is the characteristic function e^{-σ²t²/2}.",
+    "significance": "key",
+    "relatedConcepts": [
+      "characteristic function",
+      "normal distribution",
+      "central limit theorem",
+      "dilation"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq01-uncertainty",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-01",
+    "range": {
+      "startLine": 169,
+      "endLine": 210
+    },
+    "type": "insight",
+    "title": "The Uncertainty Duality: Width Inversion and the Product Relation",
+    "content": "dilation_duality rewrites the transform e^{-σ²t²/2} as e^{-t²/(2(1/σ)²)} — manifestly a Gaussian of width 1/σ. So the Fourier transform of the width-σ density is the width-(1/σ) Gaussian: width is inverted. dilation_width_product records the consequence σ·(1/σ)=1: the product of the spatial scale and the frequency scale is constant, which is the elementary Gaussian form of the Heisenberg uncertainty principle. The t=0 shadows (gaussian_density_total_mass, integral_gaussian_dilated) recover total mass 1 and ∫ e^{-x²/(2σ²)} = σ√(2π).",
+    "mathContext": "A narrow bump (small σ) has a wide transform (large 1/σ) and conversely; concentration in space forces spread in frequency, with the product held at 1.",
+    "significance": "key",
+    "relatedConcepts": [
+      "uncertainty principle",
+      "Fourier transform",
+      "width inversion",
+      "Gaussian"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-01/meta.json
@@ -1,0 +1,242 @@
+{
+  "id": "area-of-circle-oq-05-oq-03-oq-01",
+  "title": "The Gaussian Dilation Law and the Uncertainty Duality of the Fourier Transform",
+  "slug": "area-of-circle-oq-05-oq-03-oq-01",
+  "description": "Follow-up to area-of-circle-oq-05-oq-03 (the Gaussian is its own Fourier transform, the σ=1 case). Proves, axiom-free, the full one-parameter dilation law: for every width σ>0, ∫_ℝ e^{itx}·e^{-x²/(2σ²)} dx = e^{-σ²t²/2}·σ√(2π) (un-normalized) and ∫_ℝ e^{itx}·(e^{-x²/(2σ²)}/(σ√(2π))) dx = e^{-σ²t²/2} (normalized — the characteristic function of N(0,σ²)). The structural payoff is the uncertainty duality: a density of spatial width σ transforms to a Gaussian of frequency width 1/σ (e^{-σ²t²/2} = e^{-t²/(2(1/σ)²)}), so Fourier transformation inverts the width and (input width)·(output width) = σ·(1/σ) = 1 — the elementary heart of the Heisenberg uncertainty principle. The parent's self-dual σ=1 case is exactly the fixed point of this duality. Method: division-free completing the square i t x − b x² = −b(x+ci)² − bc² under 2bc=−t (only i²=−1), then Mathlib's GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I, with b=1/(2σ²). All 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Classical (Gaussian dilation / uncertainty); Lean 4 formalization (research, 2026)",
+    "date": "2003",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ03OQ01.lean",
+    "tags": [
+      "analysis",
+      "fourier-analysis",
+      "gaussian-integral",
+      "uncertainty-principle",
+      "characteristic-function",
+      "complex-analysis",
+      "probability"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 242,
+    "assumptions": "0 axioms, 0 sorries (depends only on propext, Classical.choice, Quot.sound). Builds on Mathlib's Gaussian Fourier transform infrastructure (GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I — the vertical-strip shift of the real Gaussian integral). The width parameter is a genuine real σ>0, so the result is the full dilation group, not a single instance.",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-21",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That the Gaussian is (up to normalization) its own Fourier transform is a cornerstone of analysis; the parent entry area-of-circle-oq-05-oq-03 proved exactly this self-dual case (variance 1). But the self-dual case hides the most important structural fact about Gaussians under the Fourier transform: how the transform behaves as the width changes. The one-parameter family e^{-x²/(2σ²)} is acted on by the dilation group, and the Fourier transform conjugates dilation by σ into dilation by 1/σ. This reciprocal-width behaviour — a narrow bump transforms to a wide bump and conversely, with the product of the widths held constant — is the precise and elementary form of the Heisenberg uncertainty principle for Gaussians. This entry promotes the parent's single identity to the whole dilation family and isolates that duality.",
+    "problemStatement": "Prove the full dilation law for the Gaussian Fourier transform: for every σ>0, ∫_ℝ e^{itx}·e^{-x²/(2σ²)} dx = e^{-σ²t²/2}·σ√(2π), and in normalized form ∫_ℝ e^{itx}·(e^{-x²/(2σ²)}/(σ√(2π))) dx = e^{-σ²t²/2} — the characteristic function of N(0,σ²) — and exhibit the resulting width inversion σ ↦ 1/σ.",
+    "text": "The proof carries the parent's complete-the-square argument over to general width, but in a division-free form. Writing the Gaussian with a coefficient b = 1/(2σ²) > 0, the algebraic identity i t x − b x² = −b(x + ci)² − bc² holds whenever 2bc = −t (here c = −t/(2b) = −tσ²); keeping c abstract under that single relation removes all division from the exponential identity, so it follows from linear_combination with i²=−1 alone. The constant e^{-bc²} pulls out of the integral, and the remaining vertical-strip Gaussian ∫_ℝ e^{-b(x+ci)²} dx = (π/b)^{1/2} is supplied by Mathlib's GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I. Substituting b = 1/(2σ²) gives (π/b)^{1/2} = √(2πσ²) = σ√(2π) and bc² = σ²t²/2, yielding the dilation law. Dividing by σ√(2π) gives the normalized identity, whose right-hand side e^{-σ²t²/2} = e^{-t²/(2(1/σ)²)} is the width-(1/σ) Gaussian — the uncertainty duality. The t = 0 shadows recover ∫ e^{-x²/(2σ²)} = σ√(2π) and total mass 1.",
+    "proofStrategy": "1. **Division-free complete-the-square** (`complete_square_param`): for real b,c,t with 2bc=−t, e^{itx}·e^{-bx²} = e^{-b(x+ci)²}·e^{-bc²}, by Complex.exp_add and linear_combination ((I·x)·hc + (b·c²)·Complex.I_sq) — the only non-ring input is i²=−1, and abstracting c kills all division.\n\n2. **Identify the constant** (`cpow_half_eq_sqrt`): (π/b)^{1/2} = √(π/b) for b>0, via Real.sqrt_eq_rpow and Complex.ofReal_cpow.\n\n3. **Coefficient-form integral** (`gaussian_fourier_param`): simp_rw the factoring under the integral with c=−t/(2b), pull the constant out with integral_mul_const, apply integral_cexp_neg_mul_sq_add_real_mul_I at b (re b>0) and c, rewrite by step 2.\n\n4. **Width form** (`gaussian_fourier_dilated`): rewrite the density e^{-x²/(2σ²)} as the coefficient form with b=1/(2σ²) (push_cast; ring), apply step 3, then bridge the exponent (bc² = σ²t²/2, field_simp) and the constant (√(π/(1/(2σ²))) = σ√(2π), via Real.sqrt_mul and Real.sqrt_sq).\n\n5. **Normalization and duality** (`gaussian_fourier_dilated_normalized`, `dilation_duality`): pull the constant √-factor out with integral_div, cancel it, and rewrite e^{-σ²t²/2} as e^{-t²/(2(1/σ)²)} (field_simp). `dilation_width_product` records σ·(1/σ)=1.\n\n6. **Consequences**: `gaussian_density_total_mass` and `integral_gaussian_dilated` follow by specialising at t=0 (simpa).",
+    "keyInsights": [
+      "Abstracting the completing-the-square shift c (subject only to 2bc=−t) makes the exponential identity hold with no division at all, so it closes by linear_combination over i²=−1 — even though the eventual c=−tσ² and the eventual constant σ²t²/2 both involve division by σ². The division is confined to a separate, purely real bridge.",
+      "Substituting b=1/(2σ²) turns the contour constant (π/b)^{1/2} into √(2πσ²)=σ√(2π) and the pull-out constant bc² into σ²t²/2 — exactly the width-σ dilation law.",
+      "The transform e^{-σ²t²/2} is itself a Gaussian, of width 1/σ: e^{-σ²t²/2} = e^{-t²/(2(1/σ)²)}. So the Fourier transform conjugates dilation-by-σ into dilation-by-(1/σ); width is inverted.",
+      "Reading the input width σ against the output width 1/σ gives σ·(1/σ)=1: the product of spatial and frequency scales is constant, the elementary Gaussian form of the uncertainty principle. The parent's σ=1 self-dual identity is precisely the fixed point of this duality."
+    ],
+    "prerequisites": [
+      "area-of-circle-oq-05-oq-03 — the σ=1 (self-dual) Gaussian Fourier identity",
+      "area-of-circle-oq-05 — the real Gaussian integral ∫ e^{-x²} = √π",
+      "Mathlib's Gaussian Fourier transform: GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I",
+      "Complex exponential algebra (Complex.exp_add, Complex.I_sq) and the cpow/sqrt bridge (Complex.ofReal_cpow, Real.sqrt_eq_rpow, Real.sqrt_mul, Real.sqrt_sq)",
+      "Linearity of the Bochner integral (integral_mul_const, integral_div)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: Imports and Setup",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Imports Mathlib; opens Real, Complex, MeasureTheory. Header states the un-normalized and normalized dilation laws, the uncertainty duality (width inversion σ ↦ 1/σ, product of widths = 1), and the division-free complete-the-square method.",
+      "mathContext": "Targets the full one-parameter (dilation-group) form of the Gaussian Fourier transform, generalizing the parent's self-dual σ=1 identity."
+    },
+    {
+      "id": "complete-square",
+      "title": "Part I: Completing the Square (Division-Free)",
+      "startLine": 61,
+      "endLine": 82,
+      "summary": "complete_square_param: for real b,c,t with 2bc=−t, e^{itx}·e^{-bx²} = e^{-b(x+ci)²}·e^{-bc²}, by Complex.exp_add and linear_combination over Complex.I_sq.",
+      "mathContext": "The algebraic heart, abstracted so that the only non-ring fact is i²=−1 and no division appears; the width-specific c and constant are introduced later."
+    },
+    {
+      "id": "constant",
+      "title": "Part II: The Constant √(π/b) from the Contour Integral",
+      "startLine": 83,
+      "endLine": 96,
+      "summary": "cpow_half_eq_sqrt: (π/b)^{1/2} = √(π/b) for b>0, bridging the complex contour constant to the real square root.",
+      "mathContext": "Converts the cpow value returned by the contour-integral lemma into a real square root via Complex.ofReal_cpow and Real.sqrt_eq_rpow."
+    },
+    {
+      "id": "param-integral",
+      "title": "Part III: The General Gaussian Fourier Integral (Coefficient Form)",
+      "startLine": 97,
+      "endLine": 117,
+      "summary": "gaussian_fourier_param: ∫ e^{itx} e^{-bx²} dx = e^{-bc²}·√(π/b) with c=−t/(2b), via the complete-the-square factoring, integral_mul_const, and integral_cexp_neg_mul_sq_add_real_mul_I.",
+      "mathContext": "The b-coefficient master identity from which the width form follows by b=1/(2σ²)."
+    },
+    {
+      "id": "dilation-law",
+      "title": "Part IV: The Dilation Law (Width Form) and its Normalization",
+      "startLine": 118,
+      "endLine": 168,
+      "summary": "gaussian_fourier_dilated (∫ e^{itx}e^{-x²/(2σ²)} = e^{-σ²t²/2}·σ√(2π)) and gaussian_fourier_dilated_normalized (∫ e^{itx}(e^{-x²/(2σ²)}/(σ√(2π))) = e^{-σ²t²/2}, the characteristic function of N(0,σ²)).",
+      "mathContext": "Substitute b=1/(2σ²) into the coefficient form and bridge the constant √(π/(1/(2σ²)))=σ√(2π) and exponent bc²=σ²t²/2; normalize by cancelling σ√(2π)."
+    },
+    {
+      "id": "duality",
+      "title": "Part V: The Uncertainty Duality and Consequences",
+      "startLine": 169,
+      "endLine": 210,
+      "summary": "dilation_duality (the width-σ transform is the width-(1/σ) Gaussian e^{-t²/(2(1/σ)²)}), dilation_width_product (σ·(1/σ)=1), and the t=0 shadows gaussian_density_total_mass and integral_gaussian_dilated.",
+      "mathContext": "Exhibits Fourier transformation as width inversion σ ↦ 1/σ with constant width-product 1 — the elementary uncertainty principle — and recovers the normalization and the un-normalized width-σ Gaussian integral."
+    }
+  ],
+  "conclusion": {
+    "summary": "The full Gaussian dilation law is proved axiom-free: for every σ>0, ∫ e^{itx}e^{-x²/(2σ²)} dx = e^{-σ²t²/2}·σ√(2π), and normalized, ∫ e^{itx}(e^{-x²/(2σ²)}/(σ√(2π))) dx = e^{-σ²t²/2} — the characteristic function of N(0,σ²). The transform of a width-σ density is the width-(1/σ) Gaussian e^{-t²/(2(1/σ)²)}, so Fourier transformation inverts the width and σ·(1/σ)=1. The t=0 shadows give ∫ e^{-x²/(2σ²)} = σ√(2π) and total mass 1. (0 axioms, 0 sorries.)",
+    "implications": "This generalizes the parent's self-dual σ=1 Gaussian Fourier identity to the entire dilation group and makes explicit the structural phenomenon the self-dual case conceals: the Fourier transform conjugates dilation-by-σ into dilation-by-(1/σ). The width-product relation σ·(1/σ)=1 is the elementary heart of the Heisenberg uncertainty principle, and the normalized identity supplies the characteristic function of every centered normal N(0,σ²) — the general-variance input for the characteristic-function proof of the Central Limit Theorem.",
+    "openQuestions": [
+      "Derive the full N(μ,σ²) characteristic function e^{iμt−σ²t²/2} by composing the dilation law here with a translation (affine change of variables x ↦ σx+μ).",
+      "Turn the width-product relation into a quantitative variance/uncertainty inequality: relate the spatial second moment of e^{-x²/(2σ²)} and the spectral second moment of its transform, recovering Var_space·Var_freq = const for Gaussians.",
+      "Prove the multivariate anisotropic dilation law (diagonal covariance Σ) for the EuclideanSpace Gaussian Fourier transform in the same explicit Lebesgue form."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-05-oq-03",
+      "relationship": "extends",
+      "description": "Parent: the Gaussian is its own Fourier transform (σ=1, self-dual). This entry promotes that single identity to the full dilation family e^{-x²/(2σ²)} and isolates the width-inversion (uncertainty) duality of which σ=1 is the fixed point."
+    },
+    {
+      "targetId": "area-of-circle-oq-05",
+      "relationship": "related",
+      "description": "Grandparent: the real Gaussian integral ∫ e^{-x²} = √π, whose value reappears (rescaled to σ√(2π)) as the t=0 shadow of the dilation law."
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "related",
+      "description": "Supplies, axiom-free in Lebesgue form, the general-variance characteristic function e^{-σ²t²/2} of N(0,σ²) — the dilated input for the characteristic-function proof of the CLT."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Complex",
+      "MeasureTheory"
+    ],
+    "namespace": "GaussianDilation",
+    "lineCount": 242,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "gaussian_fourier_dilated_normalized",
+        "type": "core",
+        "description": "The centered normal density of width σ has characteristic function e^{-σ²t²/2}: ∫ e^{itx}·(e^{-x²/(2σ²)}/(σ√(2π))) dx = e^{-σ²t²/2}.",
+        "leanType": "(σ t : ℝ) → 0 < σ → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * (Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) / ((σ * Real.sqrt (2 * π) : ℝ) : ℂ)) = Complex.exp (-((σ : ℂ) ^ 2 * (t : ℂ) ^ 2 / 2))"
+      },
+      {
+        "name": "gaussian_fourier_dilated",
+        "type": "core",
+        "description": "The Gaussian dilation law (un-normalized): ∫ e^{itx}·e^{-x²/(2σ²)} dx = e^{-σ²t²/2}·σ√(2π).",
+        "leanType": "(σ t : ℝ) → 0 < σ → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) = Complex.exp (-((σ : ℂ) ^ 2 * (t : ℂ) ^ 2 / 2)) * ((σ * Real.sqrt (2 * π) : ℝ) : ℂ)"
+      },
+      {
+        "name": "dilation_duality",
+        "type": "core",
+        "description": "The uncertainty duality: the Fourier transform of the width-σ density is the width-(1/σ) Gaussian, ∫ e^{itx}·(e^{-x²/(2σ²)}/(σ√(2π))) dx = e^{-t²/(2(1/σ)²)}.",
+        "leanType": "(σ t : ℝ) → 0 < σ → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * (Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) / ((σ * Real.sqrt (2 * π) : ℝ) : ℂ)) = Complex.exp (-(t : ℂ) ^ 2 / (2 * ((1 / σ : ℝ) : ℂ) ^ 2))"
+      },
+      {
+        "name": "complete_square_param",
+        "type": "key",
+        "description": "Division-free completing the square: for 2bc=−t, e^{itx}·e^{-bx²} = e^{-b(x+ci)²}·e^{-bc²} (uses only i²=−1).",
+        "leanType": "(b c t : ℝ) → 2 * b * c = -t → (x : ℝ) → Complex.exp (Complex.I * t * x) * Complex.exp (-(b : ℂ) * (x : ℂ) ^ 2) = Complex.exp (-(b : ℂ) * ((x : ℂ) + (c : ℂ) * Complex.I) ^ 2) * Complex.exp (-((b : ℂ) * (c : ℂ) ^ 2))"
+      },
+      {
+        "name": "dilation_width_product",
+        "type": "supporting",
+        "description": "The uncertainty relation: input width σ times output width 1/σ equals 1.",
+        "leanType": "(σ : ℝ) → 0 < σ → σ * (1 / σ) = 1"
+      }
+    ],
+    "path": "Proofs/AreaOfCircleOQ05OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "gaussian_fourier_dilated_normalized",
+      "type": "core",
+      "description": "The centered normal density of width σ has characteristic function e^{-σ²t²/2}: ∫ e^{itx}·(e^{-x²/(2σ²)}/(σ√(2π))) dx = e^{-σ²t²/2}.",
+      "leanType": "(σ t : ℝ) → 0 < σ → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * (Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) / ((σ * Real.sqrt (2 * π) : ℝ) : ℂ)) = Complex.exp (-((σ : ℂ) ^ 2 * (t : ℂ) ^ 2 / 2))"
+    },
+    {
+      "name": "gaussian_fourier_dilated",
+      "type": "key",
+      "description": "The Gaussian dilation law (un-normalized): ∫ e^{itx}·e^{-x²/(2σ²)} dx = e^{-σ²t²/2}·σ√(2π).",
+      "leanType": "(σ t : ℝ) → 0 < σ → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) = Complex.exp (-((σ : ℂ) ^ 2 * (t : ℂ) ^ 2 / 2)) * ((σ * Real.sqrt (2 * π) : ℝ) : ℂ)"
+    },
+    {
+      "name": "dilation_duality",
+      "type": "key",
+      "description": "The uncertainty duality (width inversion): the transform of the width-σ density is the width-(1/σ) Gaussian, ∫ e^{itx}·(e^{-x²/(2σ²)}/(σ√(2π))) dx = e^{-t²/(2(1/σ)²)}.",
+      "leanType": "(σ t : ℝ) → 0 < σ → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * (Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) / ((σ * Real.sqrt (2 * π) : ℝ) : ℂ)) = Complex.exp (-(t : ℂ) ^ 2 / (2 * ((1 / σ : ℝ) : ℂ) ^ 2))"
+    },
+    {
+      "name": "complete_square_param",
+      "type": "key",
+      "description": "Division-free completing the square: for 2bc=−t, e^{itx}·e^{-bx²} = e^{-b(x+ci)²}·e^{-bc²} (uses only i²=−1).",
+      "leanType": "(b c t : ℝ) → 2 * b * c = -t → (x : ℝ) → Complex.exp (Complex.I * t * x) * Complex.exp (-(b : ℂ) * (x : ℂ) ^ 2) = Complex.exp (-(b : ℂ) * ((x : ℂ) + (c : ℂ) * Complex.I) ^ 2) * Complex.exp (-((b : ℂ) * (c : ℂ) ^ 2))"
+    },
+    {
+      "name": "dilation_width_product",
+      "type": "supporting",
+      "description": "The uncertainty relation σ·(1/σ) = 1: the product of the input (spatial) and output (frequency) widths is constant.",
+      "leanType": "(σ : ℝ) → 0 < σ → σ * (1 / σ) = 1"
+    },
+    {
+      "name": "gaussian_density_total_mass",
+      "type": "supporting",
+      "description": "The centered normal density of width σ integrates to 1 (t=0 of the normalized law).",
+      "leanType": "(σ : ℝ) → 0 < σ → ∫ x : ℝ, Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) / ((σ * Real.sqrt (2 * π) : ℝ) : ℂ) = 1"
+    },
+    {
+      "name": "integral_gaussian_dilated",
+      "type": "supporting",
+      "description": "The un-normalized width-σ Gaussian integral: ∫ e^{-x²/(2σ²)} dx = σ√(2π) (t=0 of the dilation law).",
+      "leanType": "(σ : ℝ) → 0 < σ → ∫ x : ℝ, Complex.exp (-(x : ℂ) ^ 2 / (2 * (σ : ℂ) ^ 2)) = ((σ * Real.sqrt (2 * π) : ℝ) : ℂ)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stein, Elias M. and Shakarchi, Rami",
+      "title": "Fourier Analysis: An Introduction",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "note": "Chapter 5; the Gaussian, its dilation behaviour, and the uncertainty principle"
+    },
+    {
+      "authors": "mathlib community",
+      "title": "Analysis.SpecialFunctions.Gaussian.FourierTransform",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "integral_cexp_neg_mul_sq_add_real_mul_I — the shifted Gaussian contour integral used here"
+    },
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Fourier transform, dilation, and the Gaussian; the uncertainty principle"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up to **area-of-circle-oq-05-oq-03** ("the Gaussian is its own Fourier transform", proved only for the self-dual width σ=1). This entry proves, **axiom-free**, the full one-parameter **dilation law** and isolates the structural phenomenon the self-dual case hides — the Fourier transform inverts Gaussian width.

For every σ > 0:

- **Un-normalized** (`gaussian_fourier_dilated`): ∫_ℝ e^{itx}·e^{-x²/(2σ²)} dx = e^{-σ²t²/2}·σ√(2π)
- **Normalized** (`gaussian_fourier_dilated_normalized`): ∫_ℝ e^{itx}·(e^{-x²/(2σ²)}/(σ√(2π))) dx = e^{-σ²t²/2} — the characteristic function of **N(0,σ²)**
- **Uncertainty duality** (`dilation_duality`): e^{-σ²t²/2} = e^{-t²/(2(1/σ)²)}, so the transform of a width-σ density is the width-(1/σ) Gaussian
- **Width product** (`dilation_width_product`): σ·(1/σ) = 1 — the elementary Gaussian heart of the Heisenberg uncertainty principle

The parent's σ=1 self-dual identity is exactly the fixed point of this duality.

## Method

Division-free completing the square (`complete_square_param`): for real b,c,t with **2bc = −t**, e^{itx}·e^{-bx²} = e^{-b(x+ci)²}·e^{-bc²}, closed by `linear_combination` over **i²=−1** alone (abstracting c removes all division). Then the vertical-strip Gaussian is evaluated by Mathlib's `GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I`, specialized at b = 1/(2σ²). All division is confined to a separate purely-real bridge.

## Verification

- **8 theorems, 0 definitions, 242 lines**
- **0 sorries, 0 axioms** — `#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`/`native_decide`)
- Builds under Lean 4 / Mathlib 4.26.0 via the Docker wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)