### PR TITLE
research(area-of-circle-oq-05-oq-03-oq-02): Gaussians form a convolution semigroup

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -163,6 +163,7 @@ import Proofs.AreaOfCircleOQ05OQ01
 import Proofs.AreaOfCircleOQ05OQ01Aristotle
 import Proofs.AreaOfCircleOQ05OQ02
 import Proofs.AreaOfCircleOQ05OQ03
+import Proofs.AreaOfCircleOQ05OQ03OQ02
 import Proofs.AreaOfCircleOQ05OQ04
 import Proofs.AreaOfCircleOQ07
 import Proofs.AreaOfCircleOQ07OQ01

--- a/proofs/Proofs/AreaOfCircleOQ05OQ03OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ03OQ02.lean
@@ -1,0 +1,216 @@
+/-
+  Gaussians form a convolution semigroup
+  (area-of-circle-oq-05-oq-03-oq-02)
+
+  A follow-up to `area-of-circle-oq-05-oq-03` ("The Gaussian is its own Fourier
+  transform").  That entry, and its sibling `…-oq-01` (the dilation / uncertainty
+  law), live entirely on the *Fourier* side.  Here we prove the complementary
+  *density-side* statement: the family of centred Gaussian densities is closed
+  under convolution, and the variances add.  Writing
+
+      φ_σ(x) = e^{-x²/(2σ²)} / (σ·√(2π))        (σ > 0)
+
+  for the centred normal density of standard deviation σ, the **convolution
+  semigroup law** is
+
+      ∫_ℝ φ_{σ₁}(y) · φ_{σ₂}(x − y) dy = φ_{√(σ₁²+σ₂²)}(x).        (★)
+
+  This is the analytic heart of "the sum of two independent normals is normal,
+  with variances adding" — i.e. the Gaussian / heat-kernel semigroup
+  (Chapman–Kolmogorov for Brownian motion).
+
+  HONEST SCOPE / NOVELTY.  Mathlib *does* contain the abstract,
+  measure-theoretic versions of this fact
+  (`ProbabilityTheory.gaussianReal_conv_gaussianReal` for `Measure.conv`, and
+  `gaussianReal_add_gaussianReal_of_indepFun` for sums of independent variables).
+  What is delivered here is the explicit Lebesgue-integral identity (★) in terms
+  of the elementary density `φ_σ`, computed directly by completing the square and
+  Mathlib's real Gaussian integral `integral_gaussian`.  This matches the
+  deliberate "concrete integral, no abstract measure" register of the parent
+  entries (the parent gives the concrete Fourier integral; here is the concrete
+  convolution integral).  Everything is proved with 0 sorries and 0 axioms.
+
+  METHOD ("complete the square in y").  With s = σ₁²+σ₂²,
+
+      y²/(2σ₁²) + (x−y)²/(2σ₂²)
+        = (s/(2σ₁²σ₂²))·(y − σ₁²x/s)²  +  x²/(2s),
+
+  so the integrand factors as a constant (the last, y-free term) times a single
+  shifted Gaussian in y; translation-invariance of Lebesgue measure removes the
+  shift, `integral_gaussian` evaluates the remaining integral to √(π/A), and the
+  prefactors collapse to exactly φ_{√s}(x).
+
+  We also record the Fourier-side shadow of (★): the product of the two
+  characteristic functions is the characteristic function of the convolution,
+  e^{-σ₁²t²/2}·e^{-σ₂²t²/2} = e^{-(σ₁²+σ₂²)t²/2}, and that convolution preserves
+  total mass (each φ_σ integrates to 1).
+
+  References:
+  - Stein–Shakarchi, *Fourier Analysis* (2003), Ch. 5 (the Gaussian / heat kernel).
+  - Mathlib: `Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral`
+    (`integral_gaussian`), `Mathlib.Probability.Distributions.Gaussian.Real`.
+-/
+import Mathlib
+
+set_option maxHeartbeats 1200000
+set_option linter.unusedVariables false
+set_option linter.unusedSectionVars false
+
+open Real MeasureTheory
+open scoped Real
+
+namespace GaussianConvolutionSemigroup
+
+/-- The centred Gaussian (normal) density of standard deviation `σ`:
+`φ_σ(x) = e^{-x²/(2σ²)} / (σ·√(2π))`, written here as a leading reciprocal times
+an exponential `e^{-(1/(2σ²))·x²}` to line up with `integral_gaussian`. -/
+noncomputable def φ (σ x : ℝ) : ℝ :=
+  (σ * Real.sqrt (2 * Real.pi))⁻¹ * Real.exp (-(1 / (2 * σ ^ 2)) * x ^ 2)
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I:  COMPLETING THE SQUARE (POINTWISE ALGEBRA)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Completing the square.**  The combined quadratic exponent of the two
+factors of the convolution integrand splits as a `y`-free constant plus a single
+centred square in `y`.  Here `s = σ₁²+σ₂²`, the curvature is `A = s/(2σ₁²σ₂²)`,
+the centre is `m = σ₁²x/s`, and the constant term is `B = x²/(2s)`. -/
+theorem complete_the_square (σ₁ σ₂ x y : ℝ)
+    (h₁ : σ₁ ≠ 0) (h₂ : σ₂ ≠ 0) (hs : σ₁ ^ 2 + σ₂ ^ 2 ≠ 0) :
+    -(1 / (2 * σ₁ ^ 2)) * y ^ 2 + -(1 / (2 * σ₂ ^ 2)) * (x - y) ^ 2
+      = -(x ^ 2 / (2 * (σ₁ ^ 2 + σ₂ ^ 2)))
+        + -((σ₁ ^ 2 + σ₂ ^ 2) / (2 * σ₁ ^ 2 * σ₂ ^ 2))
+          * (y - σ₁ ^ 2 * x / (σ₁ ^ 2 + σ₂ ^ 2)) ^ 2 := by
+  field_simp
+  ring
+
+/-- The two leading reciprocals of `φ_{σ₁}·φ_{σ₂}` collapse:
+`(σ₁√(2π))⁻¹·(σ₂√(2π))⁻¹ = 1/(σ₁σ₂·2π)` (using `√(2π)·√(2π) = 2π`). -/
+theorem prefactor_collapse (σ₁ σ₂ : ℝ) :
+    (σ₁ * Real.sqrt (2 * Real.pi))⁻¹ * (σ₂ * Real.sqrt (2 * Real.pi))⁻¹
+      = 1 / (σ₁ * σ₂ * (2 * Real.pi)) := by
+  rw [← mul_inv,
+      show σ₁ * Real.sqrt (2 * Real.pi) * (σ₂ * Real.sqrt (2 * Real.pi))
+        = σ₁ * σ₂ * (Real.sqrt (2 * Real.pi) * Real.sqrt (2 * Real.pi)) from by ring,
+      Real.mul_self_sqrt (by positivity), one_div]
+
+/-- Closed form for the residual Gaussian integral's value:
+`√(π / A) = σ₁σ₂·√(2π) / √(σ₁²+σ₂²)` where `A = (σ₁²+σ₂²)/(2σ₁²σ₂²)`. -/
+theorem sqrt_pi_div_A (σ₁ σ₂ : ℝ) (h₁ : 0 < σ₁) (h₂ : 0 < σ₂) :
+    Real.sqrt (Real.pi / ((σ₁ ^ 2 + σ₂ ^ 2) / (2 * σ₁ ^ 2 * σ₂ ^ 2)))
+      = σ₁ * σ₂ * Real.sqrt (2 * Real.pi) / Real.sqrt (σ₁ ^ 2 + σ₂ ^ 2) := by
+  have hπA : Real.pi / ((σ₁ ^ 2 + σ₂ ^ 2) / (2 * σ₁ ^ 2 * σ₂ ^ 2))
+      = (σ₁ * σ₂) ^ 2 * (2 * Real.pi) / (σ₁ ^ 2 + σ₂ ^ 2) := by
+    have : σ₁ ^ 2 + σ₂ ^ 2 ≠ 0 := by positivity
+    field_simp
+  rw [hπA, Real.sqrt_div (by positivity), Real.sqrt_mul (by positivity),
+      Real.sqrt_sq (by positivity)]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II:  THE CONVOLUTION SEMIGROUP LAW
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **The Gaussian convolution semigroup law (★).**  The convolution of two
+centred Gaussian densities is again a centred Gaussian density, with the
+variances adding:
+
+  `∫_ℝ φ_{σ₁}(y) · φ_{σ₂}(x − y) dy = φ_{√(σ₁²+σ₂²)}(x)`. -/
+theorem gaussian_convolution (σ₁ σ₂ : ℝ) (h₁ : 0 < σ₁) (h₂ : 0 < σ₂) (x : ℝ) :
+    (∫ y : ℝ, φ σ₁ y * φ σ₂ (x - y)) = φ (Real.sqrt (σ₁ ^ 2 + σ₂ ^ 2)) x := by
+  -- Abbreviations matching `complete_the_square`.
+  set s : ℝ := σ₁ ^ 2 + σ₂ ^ 2 with hs_def
+  have hspos : 0 < s := by rw [hs_def]; positivity
+  set A : ℝ := s / (2 * σ₁ ^ 2 * σ₂ ^ 2) with hA_def
+  have hApos : 0 < A := by rw [hA_def]; positivity
+  set m : ℝ := σ₁ ^ 2 * x / s with hm_def
+  set B : ℝ := x ^ 2 / (2 * s) with hB_def
+  -- Constant prefactor of the integrand.
+  set C : ℝ := 1 / (σ₁ * σ₂ * (2 * Real.pi)) with hC_def
+  -- Pointwise: the integrand is `C·e^{-B}` times a single shifted Gaussian in `y`.
+  have hpt : ∀ y : ℝ,
+      φ σ₁ y * φ σ₂ (x - y)
+        = C * Real.exp (-B) * Real.exp (-A * (y - m) ^ 2) := by
+    intro y
+    have hexp : -(1 / (2 * σ₁ ^ 2)) * y ^ 2 + -(1 / (2 * σ₂ ^ 2)) * (x - y) ^ 2
+        = -B + -A * (y - m) ^ 2 := by
+      rw [hB_def, hA_def, hm_def, hs_def]
+      exact complete_the_square σ₁ σ₂ x y h₁.ne' h₂.ne' (by positivity)
+    calc
+      φ σ₁ y * φ σ₂ (x - y)
+          = ((σ₁ * Real.sqrt (2 * Real.pi))⁻¹ * (σ₂ * Real.sqrt (2 * Real.pi))⁻¹)
+              * (Real.exp (-(1 / (2 * σ₁ ^ 2)) * y ^ 2)
+                  * Real.exp (-(1 / (2 * σ₂ ^ 2)) * (x - y) ^ 2)) := by
+            simp only [φ]; ring
+      _ = C * Real.exp (-(1 / (2 * σ₁ ^ 2)) * y ^ 2 + -(1 / (2 * σ₂ ^ 2)) * (x - y) ^ 2) := by
+            rw [prefactor_collapse, ← Real.exp_add, ← hC_def]
+      _ = C * Real.exp (-B + -A * (y - m) ^ 2) := by rw [hexp]
+      _ = C * Real.exp (-B) * Real.exp (-A * (y - m) ^ 2) := by
+            rw [Real.exp_add]; ring
+  -- Evaluate the integral.
+  calc
+    (∫ y : ℝ, φ σ₁ y * φ σ₂ (x - y))
+        = ∫ y : ℝ, (C * Real.exp (-B)) * Real.exp (-A * (y - m) ^ 2) := by
+          simp_rw [hpt]
+    _ = (C * Real.exp (-B)) * ∫ y : ℝ, Real.exp (-A * (y - m) ^ 2) := by
+          rw [integral_const_mul]
+    _ = (C * Real.exp (-B)) * ∫ u : ℝ, Real.exp (-A * u ^ 2) := by
+          rw [show (∫ y : ℝ, Real.exp (-A * (y - m) ^ 2))
+                = ∫ u : ℝ, Real.exp (-A * u ^ 2)
+              from integral_sub_right_eq_self (fun u => Real.exp (-A * u ^ 2)) m]
+    _ = (C * Real.exp (-B)) * Real.sqrt (Real.pi / A) := by
+          rw [integral_gaussian]
+    _ = φ (Real.sqrt s) x := by
+          -- Unfold the target density and reduce `(√s)² = s`.
+          simp only [φ]
+          rw [Real.sq_sqrt hspos.le]
+          -- The two exponentials agree: `-(1/(2s))·x² = -B`.
+          rw [show -(1 / (2 * s)) * x ^ 2 = -B from by rw [hB_def]; ring]
+          -- Closed form for `√(π/A)` and the scalar collapse.
+          rw [hC_def, hA_def, sqrt_pi_div_A σ₁ σ₂ h₁ h₂, ← hs_def]
+          rw [eq_comm]
+          have hsq : Real.sqrt (2 * Real.pi) * Real.sqrt (2 * Real.pi) = 2 * Real.pi :=
+            Real.mul_self_sqrt (by positivity)
+          have hsne : Real.sqrt s ≠ 0 := Real.sqrt_ne_zero'.mpr hspos
+          have h2pne : Real.sqrt (2 * Real.pi) ≠ 0 := Real.sqrt_ne_zero'.mpr (by positivity)
+          field_simp
+          nlinarith [hsq, Real.exp_pos (-B), Real.sqrt_nonneg s,
+            Real.sqrt_nonneg (2 * Real.pi)]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III:  COROLLARIES — MASS PRESERVATION AND THE FOURIER SHADOW
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Each centred Gaussian density integrates to `1`: convolution of probability
+densities is again a probability density.  (The total-mass invariant behind (★).) -/
+theorem gaussian_density_integral_eq_one (σ : ℝ) (hσ : 0 < σ) :
+    (∫ x : ℝ, φ σ x) = 1 := by
+  simp only [φ]
+  rw [integral_const_mul, integral_gaussian (1 / (2 * σ ^ 2))]
+  have h1 : Real.pi / (1 / (2 * σ ^ 2)) = (σ * Real.sqrt (2 * Real.pi)) ^ 2 := by
+    rw [mul_pow, Real.sq_sqrt (by positivity)]
+    field_simp
+  rw [h1, Real.sqrt_sq (by positivity)]
+  exact inv_mul_cancel₀ (by positivity)
+
+/-- The (real) characteristic function of the centred normal `N(0,σ²)`:
+`χ_σ(t) = e^{-σ²t²/2}` — the value proved on the Fourier side in
+`area-of-circle-oq-05-oq-03` (σ = 1) and `…-oq-01` (general σ). -/
+noncomputable def χ (σ t : ℝ) : ℝ := Real.exp (-(σ ^ 2) * t ^ 2 / 2)
+
+/-- **Fourier shadow of (★).**  The product of the two characteristic functions
+is the characteristic function of the convolution: the variances add.  This is
+exactly "Fourier transform turns convolution into multiplication" specialised to
+Gaussians, dual to the integral identity `gaussian_convolution`. -/
+theorem charFun_mul (σ₁ σ₂ t : ℝ) :
+    χ σ₁ t * χ σ₂ t = χ (Real.sqrt (σ₁ ^ 2 + σ₂ ^ 2)) t := by
+  simp only [χ]
+  rw [← Real.exp_add, Real.sq_sqrt (by positivity)]
+  ring_nf
+
+/-- Sanity check / normalisation: at `t = 0` every characteristic function is `1`. -/
+theorem charFun_zero (σ : ℝ) : χ σ 0 = 1 := by simp [χ]
+
+end GaussianConvolutionSemigroup

--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-02/annotations.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": "ann-aoc-oq05oq03oq02-scope",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 60
+    },
+    "type": "insight",
+    "title": "Gaussians Convolve to Gaussians — Variances Add (Axiom-Free, Density Form)",
+    "content": "The centred normal densities φ_σ(x)=e^{-x²/(2σ²)}/(σ√(2π)) are closed under convolution, and the variances add: ∫_ℝ φ_{σ₁}(y)·φ_{σ₂}(x−y) dy = φ_{√(σ₁²+σ₂²)}(x). This is the analytic heart of 'the sum of two independent normals is normal' — the Gaussian / heat-kernel semigroup. Where the parent entry proves the Fourier-side self-duality, this entry proves the complementary density-side semigroup law, axiom-free and as an explicit Lebesgue integral. Mathlib's gaussianReal_conv_gaussianReal states the same fact for abstract measure convolution; here it is computed concretely for the elementary density.",
+    "mathContext": "Convolution of N(0,σ₁²) and N(0,σ₂²) densities equals the N(0,σ₁²+σ₂²) density; the semigroup property of the Gaussian heat kernel.",
+    "significance": "key",
+    "relatedConcepts": [
+      "convolution",
+      "Gaussian",
+      "heat kernel",
+      "central limit theorem",
+      "characteristic function"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq02-complete-square",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-02",
+    "range": {
+      "startLine": 72,
+      "endLine": 111
+    },
+    "type": "technique",
+    "title": "Completing the Square in the Integration Variable",
+    "content": "The whole computation hinges on one algebraic identity (complete_the_square): y²/(2σ₁²)+(x−y)²/(2σ₂²) = A(y−m)² + B with s=σ₁²+σ₂², A=s/(2σ₁²σ₂²), m=σ₁²x/s, B=x²/(2s). Completing the square in y (not x) turns the two-factor integrand into a single shifted Gaussian times a y-free constant. The added-variance law lives entirely in the constant term B=x²/(2s); the curvature A and centre m are scaffolding that integrate away. Two scalar collapses are pre-computed here: prefactor_collapse (using √(2π)·√(2π)=2π) and sqrt_pi_div_A (the closed form √(π/A)=σ₁σ₂√(2π)/√s). All discharged by field_simp; ring and the Real.sqrt algebra lemmas.",
+    "mathContext": "Completing the square reduces a product of two Gaussians to one Gaussian; the residual integral is a translate of ∫ e^{-Au²}.",
+    "significance": "core",
+    "relatedConcepts": [
+      "completing the square",
+      "Gaussian integral",
+      "field_simp"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq02-convolution",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-02",
+    "range": {
+      "startLine": 112,
+      "endLine": 182
+    },
+    "type": "insight",
+    "title": "Translation-Invariance Removes the Shift; integral_gaussian Finishes",
+    "content": "After factoring the integrand as (C·e^{−B})·e^{−A(y−m)²}, the constant pulls out (integral_const_mul), translation-invariance of Lebesgue measure (integral_sub_right_eq_self) erases the centre m with no Jacobian, and Mathlib's integral_gaussian evaluates ∫ e^{−Au²} du = √(π/A). The prefactors then collapse to 1/(√s·√(2π)) and e^{−B}=e^{−x²/(2s)} matches φ_{√s} once (√s)²=s is applied — yielding exactly φ_{√(σ₁²+σ₂²)}(x).",
+    "mathContext": "The shifted Gaussian integral equals the centred one by translation-invariance; its value √(π/A) drives the variance-addition.",
+    "significance": "core",
+    "relatedConcepts": [
+      "translation invariance",
+      "Bochner integral",
+      "Gaussian integral"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq02-fourier-shadow",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-02",
+    "range": {
+      "startLine": 183,
+      "endLine": 216
+    },
+    "type": "insight",
+    "title": "The Fourier Shadow: Convolution Becomes Multiplication",
+    "content": "Two corollaries close the entry. gaussian_density_integral_eq_one shows each φ_σ integrates to 1, so convolution preserves total mass — the result is again a probability density. charFun_mul records the dual of the convolution law on the Fourier side: with χ_σ(t)=e^{−σ²t²/2} (the characteristic function proved in the parent and its dilation sibling), χ_{σ₁}(t)·χ_{σ₂}(t)=χ_{√(σ₁²+σ₂²)}(t). This is exactly 'the Fourier transform turns convolution into multiplication', specialised to Gaussians — the same variance-addition viewed from the two sides of the transform.",
+    "mathContext": "Convolution of densities ↔ multiplication of characteristic functions; the density and Fourier sides of the same semigroup.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "characteristic function",
+      "convolution theorem",
+      "probability density"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-02/meta.json
@@ -1,0 +1,207 @@
+{
+  "id": "area-of-circle-oq-05-oq-03-oq-02",
+  "title": "Gaussians Form a Convolution Semigroup",
+  "slug": "area-of-circle-oq-05-oq-03-oq-02",
+  "description": "A density-side follow-up to area-of-circle-oq-05-oq-03 (the Gaussian is its own Fourier transform). Proves, axiom-free and in explicit Lebesgue-integral form, that the centred Gaussian densities φ_σ(x)=e^{-x²/(2σ²)}/(σ√(2π)) are closed under convolution with variances adding: ∫_ℝ φ_{σ₁}(y)·φ_{σ₂}(x−y) dy = φ_{√(σ₁²+σ₂²)}(x). This is the analytic heart of 'the sum of two independent normals is normal' (the Gaussian / heat-kernel semigroup, Chapman–Kolmogorov). Method: complete the square in y, y²/(2σ₁²)+(x−y)²/(2σ₂²) = (s/(2σ₁²σ₂²))(y−σ₁²x/s)² + x²/(2s) with s=σ₁²+σ₂², so the integrand is a y-free constant times a single shifted Gaussian; translation-invariance of Lebesgue measure removes the shift, Mathlib's integral_gaussian evaluates the remainder to √(π/A), and the prefactors collapse to exactly φ_{√s}(x). Corollaries: total mass is preserved (each φ_σ integrates to 1), and the Fourier shadow χ_{σ₁}(t)·χ_{σ₂}(t)=χ_{√(σ₁²+σ₂²)}(t) (convolution ↦ multiplication of characteristic functions). All 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Classical (Gaussian convolution semigroup / heat kernel); Lean 4 formalization (research, 2026)",
+    "date": "2003",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ03OQ02.lean",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "convolution",
+      "heat-kernel",
+      "characteristic-function",
+      "probability"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 216,
+    "assumptions": "0 axioms, 0 sorries. Builds on Mathlib's real Gaussian integral (integral_gaussian : ∫ e^{-b x²} = √(π/b)) and translation-invariance of Lebesgue measure (integral_sub_right_eq_self). HONEST SCOPE / NOVELTY: Mathlib already contains the abstract measure-theoretic versions of this fact — ProbabilityTheory.gaussianReal_conv_gaussianReal (for Measure.conv) and gaussianReal_add_gaussianReal_of_indepFun (for sums of independent normals). What is delivered here is the complementary explicit Lebesgue-integral identity in terms of the elementary density φ_σ, computed directly by completing the square, matching the deliberate 'concrete integral, no abstract measure' register of the parent entries.",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-21",
+    "theoremCount": 7,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "That the convolution of two Gaussians is again a Gaussian — with variances adding — is one of the defining structural properties of the normal family. It is the reason the normal distribution is stable, the analytic statement that the heat semigroup e^{tΔ} is a semigroup (Chapman–Kolmogorov for Brownian motion: the transition densities at times s and t convolve to the density at time s+t), and the density-side counterpart of the characteristic-function identity used in the Central Limit Theorem. The parent entry area-of-circle-oq-05-oq-03 proved the Gaussian Fourier self-duality; its sibling …-oq-01 proved the dilation/uncertainty law. Both live on the Fourier side; this entry supplies the complementary density-side semigroup law.",
+    "problemStatement": "Prove, in explicit Lebesgue-integral form, that the centred Gaussian densities are closed under convolution and the variances add: writing φ_σ(x) = e^{-x²/(2σ²)}/(σ√(2π)) for the N(0,σ²) density, ∫_ℝ φ_{σ₁}(y)·φ_{σ₂}(x−y) dy = φ_{√(σ₁²+σ₂²)}(x).",
+    "text": "The proof is the classical 'complete the square in the integration variable y'. With s = σ₁²+σ₂², the combined quadratic exponent splits as y²/(2σ₁²)+(x−y)²/(2σ₂²) = A(y−m)² + B, where A = s/(2σ₁²σ₂²) is the curvature, m = σ₁²x/s the centre, and B = x²/(2s) a y-free constant. Hence the integrand factors as (constant)·e^{−A(y−m)²}: the leading reciprocals of the two densities collapse to 1/(σ₁σ₂·2π) using √(2π)·√(2π)=2π, and the y-free exponential e^{−B} pulls out. Translation-invariance of Lebesgue measure (integral_sub_right_eq_self) removes the shift m, and Mathlib's integral_gaussian evaluates ∫ e^{−Au²} du = √(π/A). The closed form √(π/A) = σ₁σ₂√(2π)/√s then makes the prefactors collapse to exactly 1/(√s·√(2π)), and e^{−B} = e^{−x²/(2s)} = e^{−x²/(2(√s)²)}, giving φ_{√s}(x). Two corollaries are recorded: each φ_σ integrates to 1 (so convolution preserves total mass — the result is again a probability density), and the Fourier shadow χ_{σ₁}(t)·χ_{σ₂}(t) = χ_{√(σ₁²+σ₂²)}(t) with χ_σ(t)=e^{−σ²t²/2}, the multiplicativity of characteristic functions under convolution.",
+    "proofStrategy": "1. **Complete the square** (`complete_the_square`): −(1/(2σ₁²))y² − (1/(2σ₂²))(x−y)² = −B − A(y−m)², an identity in σ₁,σ₂,x,y proved by `field_simp; ring`.\n\n2. **Prefactor collapse** (`prefactor_collapse`): (σ₁√(2π))⁻¹·(σ₂√(2π))⁻¹ = 1/(σ₁σ₂·2π), via `← mul_inv` and `Real.mul_self_sqrt`.\n\n3. **Residual integral value** (`sqrt_pi_div_A`): √(π/A) = σ₁σ₂√(2π)/√s, via `Real.sqrt_div`, `Real.sqrt_mul`, `Real.sqrt_sq`.\n\n4. **Convolution law** (`gaussian_convolution`): rewrite the integrand pointwise as (C·e^{−B})·e^{−A(y−m)²} (steps 1–2 plus `Real.exp_add`), pull the constant out with `integral_const_mul`, kill the shift with `integral_sub_right_eq_self`, evaluate with `integral_gaussian`, then collapse the scalars to φ_{√s}(x) (step 3, `Real.sq_sqrt`, `field_simp`).\n\n5. **Corollaries**: `gaussian_density_integral_eq_one` (∫ φ_σ = 1 by `integral_gaussian` at b=1/(2σ²)); `charFun_mul` (the Fourier-side product law by `Real.exp_add` and `Real.sq_sqrt`); `charFun_zero` (normalisation at t=0).",
+    "keyInsights": [
+      "Completing the square in the integration variable y (not in x) is what turns the two-factor integrand into a single shifted Gaussian times a y-free constant — the whole computation hinges on that one algebraic identity, dischargeable by field_simp; ring.",
+      "The added-variance law s = σ₁²+σ₂² emerges purely from the constant term B = x²/(2s) of the completed square; the curvature A and centre m are scaffolding that integrate away.",
+      "Translation-invariance of Lebesgue measure (∫ f(y−m) = ∫ f) is exactly what lets the centre m disappear without any change-of-variables Jacobian, reducing the shifted integral to Mathlib's integral_gaussian.",
+      "The result is the density-side dual of the parent's Fourier identity: convolution of densities ↔ multiplication of characteristic functions (charFun_mul), the same variance-addition seen from the two sides of the Fourier transform.",
+      "This is the concrete, density-level companion to Mathlib's abstract gaussianReal_conv_gaussianReal: same theorem, expressed as an honest Lebesgue integral of elementary densities rather than a convolution of measures."
+    ],
+    "prerequisites": [
+      "area-of-circle-oq-05-oq-03 — the Gaussian is its own Fourier transform (parent)",
+      "area-of-circle-oq-05 — the real Gaussian integral ∫ e^{-x²} = √π (grandparent lineage)",
+      "Mathlib's real Gaussian integral integral_gaussian : ∫ e^{-b x²} = √(π/b)",
+      "Translation-invariance of Lebesgue measure (integral_sub_right_eq_self) and linearity of the Bochner integral (integral_const_mul)",
+      "Real square-root algebra: Real.sqrt_div, Real.sqrt_mul, Real.sqrt_sq, Real.mul_self_sqrt"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: Imports, Setup, and the Density φ_σ",
+      "startLine": 1,
+      "endLine": 69,
+      "summary": "Imports Mathlib; opens Real, MeasureTheory. Header documents the semigroup law (★), the complete-the-square method, and the honest scope relative to Mathlib's abstract measure convolution. Defines φ σ x = (σ√(2π))⁻¹·e^{−(1/(2σ²))x²}.",
+      "mathContext": "Targets the concrete Lebesgue-integral form of the Gaussian convolution semigroup, complementing the parent's Fourier-side identity."
+    },
+    {
+      "id": "complete-square",
+      "title": "Part I: Completing the Square (Pointwise Algebra)",
+      "startLine": 72,
+      "endLine": 111,
+      "summary": "complete_the_square (the combined quadratic splits as −B − A(y−m)²), prefactor_collapse ((σ₁√(2π))⁻¹(σ₂√(2π))⁻¹ = 1/(σ₁σ₂·2π)), and sqrt_pi_div_A (√(π/A) = σ₁σ₂√(2π)/√s).",
+      "mathContext": "The algebraic heart: isolate the y-dependence into a single centred square and pre-compute the two scalar collapses needed at the end."
+    },
+    {
+      "id": "convolution",
+      "title": "Part II: The Convolution Semigroup Law",
+      "startLine": 112,
+      "endLine": 182,
+      "summary": "gaussian_convolution: ∫ φ_{σ₁}(y)·φ_{σ₂}(x−y) dy = φ_{√(σ₁²+σ₂²)}(x). Pointwise factor the integrand, pull out the constant, remove the shift by translation-invariance, evaluate by integral_gaussian, and collapse the scalars.",
+      "mathContext": "The main result: the centred normal family is a convolution semigroup with additive variances — the Gaussian / heat-kernel semigroup in explicit density form."
+    },
+    {
+      "id": "corollaries",
+      "title": "Part III: Mass Preservation and the Fourier Shadow",
+      "startLine": 183,
+      "endLine": 216,
+      "summary": "gaussian_density_integral_eq_one (∫ φ_σ = 1, so convolution preserves total mass), the characteristic function χ_σ(t)=e^{−σ²t²/2}, charFun_mul (χ_{σ₁}·χ_{σ₂}=χ_{√(σ₁²+σ₂²)}), and charFun_zero.",
+      "mathContext": "The convolution lands among probability densities, and on the Fourier side becomes multiplication of characteristic functions — the dual of the density-side law."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Gaussian convolution semigroup law is proved axiom-free in concrete Lebesgue form: ∫ φ_{σ₁}(y)·φ_{σ₂}(x−y) dy = φ_{√(σ₁²+σ₂²)}(x) — convolving two centred normal densities gives a centred normal density with the variances added. Corollaries: each density integrates to 1 (mass preserved), and the characteristic functions multiply, χ_{σ₁}(t)·χ_{σ₂}(t)=χ_{√(σ₁²+σ₂²)}(t). (0 axioms, 0 sorries.)",
+    "implications": "This is the density-side analytic heart of 'the sum of independent normals is normal', the semigroup property of the Gaussian heat kernel, and the input behind the characteristic-function proof of the Central Limit Theorem. It complements the parent area-of-circle-oq-05-oq-03 (Fourier self-duality) and its sibling …-oq-01 (dilation/uncertainty) by giving the convolution structure explicitly at the level of elementary densities, mirroring Mathlib's abstract gaussianReal_conv_gaussianReal without invoking the measure-convolution machinery.",
+    "openQuestions": [
+      "Bridge this explicit density convolution to Mathlib's measure-level ProbabilityTheory.gaussianReal_conv_gaussianReal by identifying φ_σ with the density (Radon–Nikodym derivative) of gaussianReal 0 σ² and rewriting Measure.conv as the integral convolution proved here.",
+      "Prove the non-centred semigroup law for means, ∫ φ_{μ₁,σ₁}(y)·φ_{μ₂,σ₂}(x−y) dy = φ_{μ₁+μ₂,√(σ₁²+σ₂²)}(x), by the same completing-the-square argument with an affine shift.",
+      "Establish the multivariate (EuclideanSpace) Gaussian convolution semigroup, the density form of the heat kernel e^{tΔ} on ℝⁿ."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-05-oq-03",
+      "relationship": "extends",
+      "description": "Parent: the Gaussian is its own Fourier transform. This entry gives the complementary density-side statement — convolution of Gaussians is Gaussian — whose Fourier shadow is the parent's multiplicativity of characteristic functions."
+    },
+    {
+      "targetId": "area-of-circle-oq-05",
+      "relationship": "related",
+      "description": "Grandparent lineage: the real Gaussian integral ∫ e^{-x²} = √π, the elementary value (via integral_gaussian) that drives the convolution computation here."
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The convolution semigroup / variance-addition law is the density-side mechanism behind the CLT; charFun_mul is exactly the characteristic-function multiplicativity the CLT uses."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory"
+    ],
+    "namespace": "GaussianConvolutionSemigroup",
+    "lineCount": 216,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "mainTheorems": [
+      {
+        "name": "gaussian_convolution",
+        "type": "core",
+        "description": "The Gaussian convolution semigroup law: ∫ φ_{σ₁}(y)·φ_{σ₂}(x−y) dy = φ_{√(σ₁²+σ₂²)}(x) — convolution of centred normal densities is a centred normal density with variances added.",
+        "leanType": "(σ₁ σ₂ : ℝ) → 0 < σ₁ → 0 < σ₂ → (x : ℝ) → (∫ y : ℝ, φ σ₁ y * φ σ₂ (x - y)) = φ (Real.sqrt (σ₁ ^ 2 + σ₂ ^ 2)) x"
+      },
+      {
+        "name": "complete_the_square",
+        "type": "key",
+        "description": "Completing the square in y: −(1/(2σ₁²))y² − (1/(2σ₂²))(x−y)² = −x²/(2s) − (s/(2σ₁²σ₂²))(y − σ₁²x/s)², s = σ₁²+σ₂².",
+        "leanType": "(σ₁ σ₂ x y : ℝ) → σ₁ ≠ 0 → σ₂ ≠ 0 → σ₁ ^ 2 + σ₂ ^ 2 ≠ 0 → -(1/(2*σ₁^2))*y^2 + -(1/(2*σ₂^2))*(x-y)^2 = -(x^2/(2*(σ₁^2+σ₂^2))) + -((σ₁^2+σ₂^2)/(2*σ₁^2*σ₂^2))*(y - σ₁^2*x/(σ₁^2+σ₂^2))^2"
+      },
+      {
+        "name": "charFun_mul",
+        "type": "key",
+        "description": "Fourier shadow of the convolution law: the characteristic functions multiply, χ_{σ₁}(t)·χ_{σ₂}(t) = χ_{√(σ₁²+σ₂²)}(t) with χ_σ(t)=e^{−σ²t²/2}.",
+        "leanType": "(σ₁ σ₂ t : ℝ) → χ σ₁ t * χ σ₂ t = χ (Real.sqrt (σ₁ ^ 2 + σ₂ ^ 2)) t"
+      },
+      {
+        "name": "gaussian_density_integral_eq_one",
+        "type": "supporting",
+        "description": "Each centred Gaussian density integrates to 1, so convolution preserves total mass (the result is again a probability density).",
+        "leanType": "(σ : ℝ) → 0 < σ → (∫ x : ℝ, φ σ x) = 1"
+      }
+    ],
+    "path": "Proofs/AreaOfCircleOQ05OQ03OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "gaussian_convolution",
+      "type": "core",
+      "description": "The Gaussian convolution semigroup law: ∫ φ_{σ₁}(y)·φ_{σ₂}(x−y) dy = φ_{√(σ₁²+σ₂²)}(x) — convolution of centred normal densities is a centred normal density with variances added.",
+      "leanType": "(σ₁ σ₂ : ℝ) → 0 < σ₁ → 0 < σ₂ → (x : ℝ) → (∫ y : ℝ, φ σ₁ y * φ σ₂ (x - y)) = φ (Real.sqrt (σ₁ ^ 2 + σ₂ ^ 2)) x"
+    },
+    {
+      "name": "complete_the_square",
+      "type": "key",
+      "description": "Completing the square in y: the combined quadratic exponent splits as −x²/(2s) − A(y−m)² with s = σ₁²+σ₂², A = s/(2σ₁²σ₂²), m = σ₁²x/s.",
+      "leanType": "(σ₁ σ₂ x y : ℝ) → σ₁ ≠ 0 → σ₂ ≠ 0 → σ₁ ^ 2 + σ₂ ^ 2 ≠ 0 → -(1/(2*σ₁^2))*y^2 + -(1/(2*σ₂^2))*(x-y)^2 = -(x^2/(2*(σ₁^2+σ₂^2))) + -((σ₁^2+σ₂^2)/(2*σ₁^2*σ₂^2))*(y - σ₁^2*x/(σ₁^2+σ₂^2))^2"
+    },
+    {
+      "name": "charFun_mul",
+      "type": "key",
+      "description": "Fourier shadow of the convolution law: the characteristic functions multiply, χ_{σ₁}(t)·χ_{σ₂}(t) = χ_{√(σ₁²+σ₂²)}(t) — convolution becomes multiplication under the Fourier transform.",
+      "leanType": "(σ₁ σ₂ t : ℝ) → χ σ₁ t * χ σ₂ t = χ (Real.sqrt (σ₁ ^ 2 + σ₂ ^ 2)) t"
+    },
+    {
+      "name": "gaussian_density_integral_eq_one",
+      "type": "supporting",
+      "description": "Each centred Gaussian density integrates to 1, so convolution preserves total mass (the result is again a probability density).",
+      "leanType": "(σ : ℝ) → 0 < σ → (∫ x : ℝ, φ σ x) = 1"
+    },
+    {
+      "name": "prefactor_collapse",
+      "type": "supporting",
+      "description": "The two leading reciprocals collapse: (σ₁√(2π))⁻¹·(σ₂√(2π))⁻¹ = 1/(σ₁σ₂·2π).",
+      "leanType": "(σ₁ σ₂ : ℝ) → (σ₁ * Real.sqrt (2 * Real.pi))⁻¹ * (σ₂ * Real.sqrt (2 * Real.pi))⁻¹ = 1 / (σ₁ * σ₂ * (2 * Real.pi))"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stein, Elias M. and Shakarchi, Rami",
+      "title": "Fourier Analysis: An Introduction",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "note": "Chapter 5; the Gaussian, its convolutions, and the heat kernel"
+    },
+    {
+      "authors": "mathlib community",
+      "title": "Analysis.SpecialFunctions.Gaussian.GaussianIntegral; Probability.Distributions.Gaussian.Real",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "integral_gaussian (the real Gaussian integral) and gaussianReal_conv_gaussianReal (the abstract measure-level convolution law complemented here)"
+    },
+    {
+      "authors": "Billingsley, Patrick",
+      "title": "Probability and Measure",
+      "year": "1995",
+      "venue": "Wiley",
+      "note": "Sums of independent random variables, convolution of densities, and stability of the normal family"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Gaussians Form a Convolution Semigroup

A **density-side** follow-up to `area-of-circle-oq-05-oq-03` ("The Gaussian is its own Fourier transform"). The parent and its sibling `…-oq-01` (dilation/uncertainty) both live on the *Fourier* side; this entry supplies the complementary **density-side semigroup law**, axiom-free and as an explicit Lebesgue integral.

### Main result (`gaussian_convolution`)
For the centred normal densities `φ_σ(x) = e^{-x²/(2σ²)} / (σ√(2π))`:

```
∫_ℝ φ_{σ₁}(y) · φ_{σ₂}(x − y) dy = φ_{√(σ₁²+σ₂²)}(x)
```

The convolution of two centred Gaussian densities is a centred Gaussian density, **with the variances adding** — the analytic heart of "the sum of two independent normals is normal" (the Gaussian / heat-kernel semigroup, Chapman–Kolmogorov).

### Method
Complete the square **in the integration variable** `y`: with `s = σ₁²+σ₂²`,
`y²/(2σ₁²)+(x−y)²/(2σ₂²) = (s/(2σ₁²σ₂²))(y−σ₁²x/s)² + x²/(2s)`, so the integrand is a `y`-free constant times one shifted Gaussian. Translation-invariance of Lebesgue measure (`integral_sub_right_eq_self`) removes the shift, Mathlib's `integral_gaussian` evaluates the remainder to `√(π/A)`, and the prefactors collapse to exactly `φ_{√s}(x)`.

### Corollaries
- `gaussian_density_integral_eq_one` — each `φ_σ` integrates to 1, so convolution preserves total mass (result is again a probability density).
- `charFun_mul` — Fourier shadow: `χ_{σ₁}(t)·χ_{σ₂}(t) = χ_{√(σ₁²+σ₂²)}(t)` with `χ_σ(t)=e^{−σ²t²/2}` (convolution ↦ multiplication of characteristic functions).

### Honest scope / novelty
Mathlib already has the **abstract measure-theoretic** versions (`ProbabilityTheory.gaussianReal_conv_gaussianReal` for `Measure.conv`, and `gaussianReal_add_gaussianReal_of_indepFun`). What is delivered here is the complementary **explicit Lebesgue-integral identity** for the elementary density `φ_σ`, matching the deliberate "concrete integral, no abstract measure" register of the parent entries.

### Verification
- **0 axioms, 0 sorries** — `#print axioms gaussian_convolution` lists only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- Docker build: `Build completed successfully (7743 jobs)`.
- 7 theorems, 2 definitions, 216 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)