### PR TITLE
research(erdos-396-oq-04-oq-01): asymptotics of the Catalan recurrence ratio (r→4, catalan n ≤ 4ⁿ) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1636,6 +1636,7 @@ import Proofs.Erdos395OQ01
 import Proofs.Erdos395OQ01Incomplete01
 import Proofs.Erdos395Problem
 import Proofs.Erdos396OQ04
+import Proofs.Erdos396OQ04OQ01
 import Proofs.Erdos396Problem
 import Proofs.Erdos397Problem
 import Proofs.Erdos398Problem

--- a/proofs/Proofs/Erdos396OQ04OQ01.lean
+++ b/proofs/Proofs/Erdos396OQ04OQ01.lean
@@ -1,0 +1,187 @@
+/-
+# Erdős Problem #396 — OQ-04 → OQ-01: Asymptotics of the Catalan recurrence ratio
+
+The parent entry `Erdos396OQ04` proves the elementary two-term Catalan
+recurrence
+
+  `(n+2) · catalan (n+1) = 2·(2n+1) · catalan n`,
+
+equivalently `catalan (n+1) = (4n+2)/(n+2) · catalan n`. This follow-up reads
+that recurrence **as a statement about the ratio of consecutive Catalan
+numbers** and extracts its asymptotics.
+
+Let `r n = (4n+2)/(n+2)` be the exact multiplicative step of the recurrence.
+The key algebraic observation is the partial-fraction identity
+
+  `r n = 4 − 6/(n+2)`,
+
+which immediately gives three facts Mathlib does not record:
+
+* **`ratio_lt_four`** : `r n < 4` for every `n` (the step never reaches `4`);
+* **`ratio_strictMono`** : `r` is strictly increasing (it climbs toward `4`);
+* **`ratio_tendsto_four`** : `r n → 4` as `n → ∞`.
+
+Combined with the recurrence this yields purely from the recurrence — without
+Stirling's formula or any central-binomial estimate — the classical growth
+bounds
+
+* **`catalan_succ_lt_four_mul`** : `catalan (n+1) < 4 · catalan n`, and
+* **`catalan_lt_four_pow`** : `catalan n < 4^n` for `n ≥ 1`, with the clean
+  `catalan_le_four_pow` : `catalan n ≤ 4^n` for all `n`.
+
+The ratio limit `r n → 4` is the discrete shadow of the exponential growth rate
+`4` of the Catalan numbers (`catalan n ∼ 4^n / (n^{3/2}√π)`); here it is proved
+directly from the integer recurrence.
+
+Reference: https://erdosproblems.com/396
+-/
+
+import Mathlib
+
+open Nat Filter Topology
+
+namespace Erdos396OQ01
+
+/- ## The two-term Catalan recurrence (re-derived, self-contained)
+
+We reprove the recurrence from the two Mathlib facts so this file does not
+depend on the parent build. -/
+
+/-- `C(2(n+1), n+1) = 2·(2n+1) · catalan n`. -/
+theorem centralBinom_succ_eq (n : ℕ) :
+    Nat.centralBinom (n + 1) = 2 * (2 * n + 1) * catalan n := by
+  have h := Nat.succ_mul_centralBinom_succ n
+  rw [← succ_mul_catalan_eq_centralBinom n] at h
+  refine Nat.eq_of_mul_eq_mul_left (show 0 < n + 1 by omega) ?_
+  rw [h]; ring
+
+/-- **Two-term Catalan recurrence.** `(n+2)·catalan(n+1) = 2·(2n+1)·catalan n`. -/
+theorem catalan_recurrence (n : ℕ) :
+    (n + 2) * catalan (n + 1) = 2 * (2 * n + 1) * catalan n := by
+  have h := succ_mul_catalan_eq_centralBinom (n + 1)
+  rw [centralBinom_succ_eq] at h
+  exact h
+
+/-- Positivity of the Catalan numbers (Mathlib has no `catalan_pos`).
+    From `(n+1)·catalan n = C(2n,n) > 0`. -/
+theorem catalan_pos (n : ℕ) : 0 < catalan n := by
+  have h := succ_mul_catalan_eq_centralBinom n
+  rcases Nat.eq_zero_or_pos (catalan n) with hz | hp
+  · rw [hz, mul_zero] at h
+    exact absurd h.symm (Nat.centralBinom_pos n).ne'
+  · exact hp
+
+/- ## The recurrence ratio -/
+
+/-- The exact multiplicative step of the recurrence,
+    `r n = (4n+2)/(n+2) = 2·(2n+1)/(n+2)`, as a real number. -/
+noncomputable def catalanRatio (n : ℕ) : ℝ := (4 * n + 2) / (n + 2)
+
+/-- **Partial-fraction form.** `r n = 4 − 6/(n+2)`. The whole asymptotic
+    behaviour of the ratio is read off this identity. -/
+theorem ratio_eq_four_sub (n : ℕ) :
+    catalanRatio n = 4 - 6 / ((n : ℝ) + 2) := by
+  have hpos : (n : ℝ) + 2 ≠ 0 := by positivity
+  rw [catalanRatio]
+  field_simp
+  ring
+
+/-- The ratio is the genuine quotient of consecutive Catalan numbers:
+    `(catalan (n+1) : ℝ) = r n · catalan n`. -/
+theorem catalan_succ_eq_ratio_mul (n : ℕ) :
+    (catalan (n + 1) : ℝ) = catalanRatio n * catalan n := by
+  have h := catalan_recurrence n
+  have hcast : ((n : ℝ) + 2) * (catalan (n + 1) : ℝ)
+      = (4 * (n : ℝ) + 2) * (catalan n : ℝ) := by
+    have h2 := congrArg (fun k : ℕ => (k : ℝ)) h
+    push_cast at h2
+    linear_combination h2
+  have hpos : (0 : ℝ) < (n : ℝ) + 2 := by positivity
+  rw [catalanRatio, div_mul_eq_mul_div, eq_div_iff hpos.ne']
+  linear_combination hcast
+
+/-- The step never reaches `4`: `r n < 4`. -/
+theorem ratio_lt_four (n : ℕ) : catalanRatio n < 4 := by
+  rw [ratio_eq_four_sub]
+  have : (0 : ℝ) < 6 / ((n : ℝ) + 2) := by positivity
+  linarith
+
+/-- The step is positive: `0 < r n`. -/
+theorem ratio_pos (n : ℕ) : 0 < catalanRatio n := by
+  rw [catalanRatio]; positivity
+
+/-- The ratio is strictly increasing in `n` (it climbs monotonically to `4`). -/
+theorem ratio_strictMono : StrictMono catalanRatio := by
+  apply strictMono_nat_of_lt_succ
+  intro n
+  rw [ratio_eq_four_sub, ratio_eq_four_sub]
+  have hkey : (6 : ℝ) / (((n : ℝ) + 1) + 2) < 6 / ((n : ℝ) + 2) := by
+    rw [div_lt_div_iff₀ (by positivity) (by positivity)]
+    nlinarith [Nat.cast_nonneg (α := ℝ) n]
+  push_cast
+  linarith [hkey]
+
+/-- **Ratio limit.** `r n → 4` as `n → ∞`. -/
+theorem ratio_tendsto_four : Tendsto catalanRatio atTop (𝓝 4) := by
+  have hden : Tendsto (fun n : ℕ => ((n : ℝ) + 2)) atTop atTop :=
+    tendsto_natCast_atTop_atTop.atTop_add tendsto_const_nhds
+  have hinv : Tendsto (fun n : ℕ => 6 / ((n : ℝ) + 2)) atTop (𝓝 0) := by
+    have h0 := hden.inv_tendsto_atTop
+    have hmul := h0.const_mul (6 : ℝ)
+    simpa [div_eq_mul_inv] using hmul
+  have hsub : Tendsto (fun n : ℕ => 4 - 6 / ((n : ℝ) + 2)) atTop (𝓝 (4 - 0)) :=
+    tendsto_const_nhds.sub hinv
+  rw [sub_zero] at hsub
+  exact hsub.congr (fun n => (ratio_eq_four_sub n).symm)
+
+/- ## Growth bounds from the recurrence -/
+
+/-- **Sub-`4` growth, integer form.** `catalan (n+1) < 4 · catalan n`.
+
+    From `(n+2)·catalan(n+1) = (4n+2)·catalan n < (4n+8)·catalan n
+    = 4(n+2)·catalan n`, cancelling the positive factor `n+2`. -/
+theorem catalan_succ_lt_four_mul (n : ℕ) :
+    catalan (n + 1) < 4 * catalan n := by
+  have hc : 0 < catalan n := catalan_pos n
+  have hrec := catalan_recurrence n
+  have h2 : 2 * (2 * n + 1) < (n + 2) * 4 := by omega
+  have hstep : 2 * (2 * n + 1) * catalan n < (n + 2) * 4 * catalan n :=
+    mul_lt_mul_of_pos_right h2 hc
+  have hkey : (n + 2) * catalan (n + 1) < (n + 2) * (4 * catalan n) := by
+    rw [hrec]
+    calc 2 * (2 * n + 1) * catalan n
+        < (n + 2) * 4 * catalan n := hstep
+      _ = (n + 2) * (4 * catalan n) := by ring
+  exact Nat.lt_of_mul_lt_mul_left hkey
+
+/-- `catalan n ≤ 4^n` for every `n`. -/
+theorem catalan_le_four_pow (n : ℕ) : catalan n ≤ 4 ^ n := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    have h1 : catalan (k + 1) < 4 * catalan k := catalan_succ_lt_four_mul k
+    have h2 : 4 * catalan k ≤ 4 * 4 ^ k := Nat.mul_le_mul (le_refl 4) ih
+    have h3 : 4 * 4 ^ k = 4 ^ (k + 1) := by rw [pow_succ]; ring
+    omega
+
+/-- **Strict growth bound.** `catalan n < 4^n` for `n ≥ 1`. -/
+theorem catalan_lt_four_pow (n : ℕ) (hn : 1 ≤ n) : catalan n < 4 ^ n := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : n ≠ 0)
+  have h1 : catalan (m + 1) < 4 * catalan m := catalan_succ_lt_four_mul m
+  have h2 : 4 * catalan m ≤ 4 * 4 ^ m := Nat.mul_le_mul (le_refl 4) (catalan_le_four_pow m)
+  have h3 : 4 * 4 ^ m = 4 ^ (m + 1) := by rw [pow_succ]; ring
+  rw [← h3]
+  exact lt_of_lt_of_le h1 h2
+
+/- ## Sanity checks -/
+
+/-- `r 0 = 1`: `catalan 1 = catalan 0`. -/
+example : catalanRatio 0 = 1 := by rw [catalanRatio]; norm_num
+
+/-- `r 2 = 10/4 = 5/2`: `catalan 3 = (5/2)·catalan 2`, i.e. `5 = (5/2)·2`. -/
+example : catalanRatio 2 = 5 / 2 := by rw [catalanRatio]; norm_num
+
+/-- Growth at `n = 3`: `catalan 3 = 5 < 4³ = 64`. -/
+example : catalan 3 < 4 ^ 3 := catalan_lt_four_pow 3 (by norm_num)
+
+end Erdos396OQ01

--- a/src/data/proofs/erdos-396-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-e396oq04oq01-recurrence",
+    "proofId": "erdos-396-oq-04-oq-01",
+    "range": {
+      "startLine": 51,
+      "endLine": 75
+    },
+    "type": "key-step",
+    "title": "The two-term Catalan recurrence (self-contained)",
+    "content": "The file re-derives the closed form $C(2(n+1),n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$ and the recurrence $(n+2)\\,\\mathrm{catalan}(n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$ directly from Mathlib's `Nat.succ_mul_centralBinom_succ` and `succ_mul_catalan_eq_centralBinom`, so it does not depend on the parent build. It also supplies `catalan_pos`, which Mathlib lacks, from $(n+1)\\,\\mathrm{catalan}\\,n = C(2n,n) > 0$.",
+    "mathContext": "$(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$, i.e. $C_{n+1} = \\frac{4n+2}{n+2}\\,C_n$."
+  },
+  {
+    "id": "ann-e396oq04oq01-partialfraction",
+    "proofId": "erdos-396-oq-04-oq-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 102
+    },
+    "type": "key-step",
+    "title": "Partial-fraction form r n = 4 − 6/(n+2)",
+    "content": "The multiplicative step is `catalanRatio n = (4n+2)/(n+2)`. The single identity $r(n) = 4 - \\frac{6}{n+2}$ (proved by `field_simp; ring`, using $4(n+2) - (4n+2) = 6$) encodes the whole asymptotic story: the constant $4$ is the limit, and the positive tail $\\frac{6}{n+2}$ forces both $r(n) < 4$ and strict growth of $r$. The step is the genuine quotient of consecutive Catalan numbers: $(\\mathrm{catalan}(n+1):\\mathbb{R}) = r(n)\\cdot\\mathrm{catalan}\\,n$.",
+    "mathContext": "$r(n) = \\dfrac{4n+2}{n+2} = 4 - \\dfrac{6}{n+2}$."
+  },
+  {
+    "id": "ann-e396oq04oq01-limit",
+    "proofId": "erdos-396-oq-04-oq-01",
+    "range": {
+      "startLine": 104,
+      "endLine": 140
+    },
+    "type": "key-step",
+    "title": "Ratio bounded by 4, increasing, and converging to 4",
+    "content": "From the partial-fraction form: `ratio_lt_four` ($r(n) < 4$, the step never reaches $4$); `ratio_strictMono` ($r$ strictly increases, since $\\frac{6}{n+2}$ strictly decreases — via `div_lt_div_iff₀`); and `ratio_tendsto_four` ($r(n) \\to 4$), proved by sending $n+2 \\to \\infty$ with `Tendsto.inv_tendsto_atTop` so that $\\frac{6}{n+2} \\to 0$. This is the recurrence-level shadow of the exponential growth rate $4$ in $\\mathrm{catalan}\\,n \\sim 4^n/(n^{3/2}\\sqrt{\\pi})$.",
+    "mathContext": "$r(n) < 4$, $r$ strictly increasing, $\\lim_{n\\to\\infty} r(n) = 4$."
+  },
+  {
+    "id": "ann-e396oq04oq01-growth",
+    "proofId": "erdos-396-oq-04-oq-01",
+    "range": {
+      "startLine": 142,
+      "endLine": 173
+    },
+    "type": "concept",
+    "title": "Catalan growth bounds from the recurrence",
+    "content": "Because $4n+2 < 4(n+2)$, the recurrence gives `catalan_succ_lt_four_mul`: $\\mathrm{catalan}(n+1) < 4\\,\\mathrm{catalan}\\,n$, by cancelling the positive factor $n+2$ with `Nat.lt_of_mul_lt_mul_left`. Induction then yields `catalan_le_four_pow`: $\\mathrm{catalan}\\,n \\le 4^n$ for all $n$ (and the strict `catalan_lt_four_pow`: $\\mathrm{catalan}\\,n < 4^n$ for $n \\ge 1$) — the standard upper bound, obtained purely from the recurrence with no Stirling estimate.",
+    "mathContext": "$\\mathrm{catalan}(n+1) < 4\\,\\mathrm{catalan}\\,n$ and $\\mathrm{catalan}\\,n \\le 4^n$."
+  }
+]

--- a/src/data/proofs/erdos-396-oq-04-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01/meta.json
@@ -1,0 +1,86 @@
+{
+  "id": "erdos-396-oq-04-oq-01",
+  "title": "Erdős #396 OQ-04 → OQ-01: Asymptotics of the Catalan Recurrence Ratio",
+  "slug": "erdos-396-oq-04-oq-01",
+  "description": "Reading the two-term Catalan recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan(n) as the multiplicative step r n = (4n+2)/(n+2), the partial-fraction identity r n = 4 − 6/(n+2) gives r n < 4, strict monotonicity, and the limit r n → 4. From the recurrence alone this yields catalan(n+1) < 4·catalan(n) and catalan(n) ≤ 4^n — Catalan growth without Stirling or any central-binomial estimate.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/396",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos396OQ04OQ01.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "catalan",
+      "recurrence",
+      "asymptotics",
+      "limits",
+      "growth-bounds"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 396,
+    "erdosUrl": "https://erdosproblems.com/396",
+    "axiomCount": 0,
+    "lineCount": 187,
+    "assumptions": "0 axioms, 0 sorries. All results depend only on the foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool / native_decide). Built against Mathlib 4.26.0.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #396 concerns descending-factorial divisibility of central binomial coefficients, whose base case rests on the Catalan numbers catalan n = C(2n,n)/(n+1). The parent entry Erdős #396 OQ-04 proved the elementary two-term recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan(n) from Mathlib's central binomial recurrence. That recurrence is exactly the multiplicative step of the Catalan sequence; the classical fact that the Catalan numbers grow like 4^n / (n^{3/2}√π) is reflected in the step ratio tending to 4. Mathlib records neither this ratio nor its limit, nor a 4^n growth bound for catalan derived from the recurrence.",
+    "problemStatement": "Read the two-term Catalan recurrence as a statement about the ratio r n = catalan(n+1)/catalan(n) = (4n+2)/(n+2) of consecutive Catalan numbers. What is its exact behaviour, and what growth bounds for the Catalan numbers themselves follow purely from the recurrence?",
+    "text": "The multiplicative step r n = (4n+2)/(n+2) of the Catalan recurrence satisfies r n = 4 − 6/(n+2); hence r n < 4, r is strictly increasing, and r n → 4. From the recurrence this gives catalan(n+1) < 4·catalan(n) and catalan(n) ≤ 4^n.",
+    "proofStrategy": "Re-derive the closed form C(2(n+1),n+1) = 2(2n+1)·catalan(n) and the two-term recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan(n) self-contained from Mathlib's `Nat.succ_mul_centralBinom_succ` and `succ_mul_catalan_eq_centralBinom` (so the file does not depend on the parent build), and supply the missing `catalan_pos` from `Nat.centralBinom_pos`. Define catalanRatio n = (4n+2)/(n+2) : ℝ and prove the partial-fraction identity r n = 4 − 6/(n+2) by `field_simp; ring`. From it: r n < 4 (positive subtracted term), strict monotonicity via `strictMono_nat_of_lt_succ` and `div_lt_div_iff₀` (the term 6/(n+2) strictly decreases), and the limit r n → 4 via `Tendsto.inv_tendsto_atTop` on n+2 → ∞. The genuine quotient identity (catalan(n+1):ℝ) = r n · catalan n is obtained by casting the recurrence and `linear_combination`. The integer growth bound catalan(n+1) < 4·catalan(n) follows from (4n+2) < 4(n+2) and `Nat.lt_of_mul_lt_mul_left`, and induction gives catalan(n) ≤ 4^n (strict for n ≥ 1).",
+    "keyInsights": [
+      "**The recurrence ratio is a partial fraction.** The step r n = (4n+2)/(n+2) equals 4 − 6/(n+2). This single identity encodes the entire asymptotics: the constant 4 is the limiting ratio, and the −6/(n+2) tail explains both why r n < 4 always and why r is strictly increasing toward 4.",
+      "**The ratio limit is the discrete shadow of exponential growth rate 4.** catalan(n+1)/catalan(n) → 4 is the elementary, recurrence-level counterpart of the Stirling asymptotic catalan n ∼ 4^n / (n^{3/2}√π) — proved here directly from the integer recurrence, with no analytic estimate of binomial coefficients.",
+      "**Growth bounds fall out without Stirling.** Because (4n+2) < 4(n+2), the recurrence gives catalan(n+1) < 4·catalan(n) by a single cancellation, and induction yields the clean bound catalan(n) ≤ 4^n (strict for n ≥ 1) — the standard upper bound, obtained purely from the recurrence.",
+      "**Mathlib has no `catalan_pos`.** Positivity of the Catalan numbers, needed to cancel catalan n in the growth step, is supplied here from `(n+1)·catalan n = C(2n,n) > 0`."
+    ],
+    "prerequisites": [
+      "Catalan numbers and the central binomial recurrence",
+      "Limits of real sequences (Filter.Tendsto, atTop)",
+      "Elementary divisibility and induction in ℕ"
+    ]
+  },
+  "conclusion": {
+    "summary": "The multiplicative step of the Catalan recurrence, r n = (4n+2)/(n+2), satisfies the partial-fraction identity r n = 4 − 6/(n+2). From this single observation: r n < 4 for all n, r is strictly increasing, and r n → 4 as n → ∞. The step is the genuine ratio of consecutive Catalan numbers, (catalan(n+1):ℝ) = r n · catalan n. Combining the step with the recurrence gives the integer growth bound catalan(n+1) < 4·catalan(n) and, by induction, catalan(n) ≤ 4^n (strict for n ≥ 1). All twelve theorems are fully machine-checked with no axioms or sorries.",
+    "implications": "The result turns the parent's algebraic recurrence into a sharp asymptotic statement: the Catalan sequence grows by a factor strictly below 4 at every step, with that factor converging exactly to 4. This is the recurrence-level explanation of the exponential growth rate 4 in the Stirling asymptotic, and it supplies the standard 4^n upper bound for the Catalan numbers through purely elementary means.",
+    "openQuestions": [
+      "Can the gap 4 − r n = 6/(n+2) be promoted to a two-sided estimate c·4^n/n^{3/2} ≤ catalan n ≤ 4^n by tracking the product ∏(1 − 6/(2(2k+1))) along the recurrence, recovering the polynomial correction without Stirling?",
+      "Does the same ratio-as-partial-fraction technique applied to (n+1)·C(2(n+1),n+1) = 2(2n+1)·C(2n,n) give the matching central-binomial growth law C(2n,n) ∼ 4^n/√(πn) at the recurrence level?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "Erdos396OQ01",
+    "lineCount": 187,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos396OQ04OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-396-oq-04",
+      "relationship": "parent",
+      "description": "Parent OQ: the two-term Catalan recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan(n). This follow-up reads that recurrence as a ratio and extracts its asymptotics and the resulting Catalan growth bounds."
+    },
+    {
+      "targetId": "erdos-396",
+      "relationship": "ancestor",
+      "description": "Root problem: descending factorials dividing central binomial coefficients, whose base case rests on the Catalan numbers studied here."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up open question building on **Erdős #396 OQ-04** (the two-term Catalan recurrence `(n+2)·catalan(n+1) = 2(2n+1)·catalan(n)`). This entry reads that recurrence as the **multiplicative step** `r n = catalan(n+1)/catalan(n) = (4n+2)/(n+2)` and extracts its asymptotics.

The whole story comes from one partial-fraction identity:

> **`r n = 4 − 6/(n+2)`**

From it:
- **`ratio_lt_four`** — `r n < 4` for every `n` (the step never reaches 4)
- **`ratio_strictMono`** — `r` is strictly increasing (climbs toward 4)
- **`ratio_tendsto_four`** — `r n → 4` as `n → ∞`
- **`catalan_succ_eq_ratio_mul`** — `(catalan(n+1):ℝ) = r n · catalan n` (the step is the genuine ratio)

Combined with the recurrence, this gives Catalan growth **without Stirling or any central-binomial estimate**:
- **`catalan_succ_lt_four_mul`** — `catalan(n+1) < 4·catalan n`
- **`catalan_le_four_pow`** — `catalan n ≤ 4^n` (and strict `catalan_lt_four_pow` for `n ≥ 1`)

The limit `r n → 4` is the recurrence-level shadow of the exponential growth rate 4 in `catalan n ∼ 4^n/(n^{3/2}√π)`.

## Details
- **File**: `proofs/Proofs/Erdos396OQ04OQ01.lean` (187 lines, 12 theorems, 1 def, 0 sorries)
- **Self-contained**: re-derives the closed form + recurrence from Mathlib's `Nat.succ_mul_centralBinom_succ` / `succ_mul_catalan_eq_centralBinom`, and supplies `catalan_pos` (Mathlib has none) from `Nat.centralBinom_pos`.
- **Verified, 0-axiom**: `#print axioms` shows only `propext` / `Classical.choice` / `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`/`native_decide`.
- Builds against Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)