### PR TITLE
research(area-of-circle-oq-05-oq-03-oq-03): the Gaussian Fourier shift theorem (translation ↔ modulation)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -169,6 +169,7 @@ import Proofs.AreaOfCircleOQ05OQ03OQ05
 import Proofs.AreaOfCircleOQ05OQ03OQ02
 import Proofs.AreaOfCircleOQ05OQ03OQ01
 import Proofs.AreaOfCircleOQ05OQ03OQ04
+import Proofs.AreaOfCircleOQ05OQ03OQ03
 import Proofs.AreaOfCircleOQ05OQ04
 import Proofs.AreaOfCircleOQ07
 import Proofs.AreaOfCircleOQ07OQ01

--- a/proofs/Proofs/AreaOfCircleOQ05OQ03OQ03.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ03OQ03.lean
@@ -1,0 +1,249 @@
+/-
+  The Gaussian Fourier transform: translation–modulation duality
+  (area-of-circle-oq-05-oq-03-oq-03)
+
+  Follow-up to `area-of-circle-oq-05-oq-03` ("the Gaussian is its own Fourier
+  transform"), which established, axiom-free and in explicit Lebesgue form,
+
+      ∫_ℝ e^{i t x} · e^{-x²/2} dx = e^{-t²/2} · √(2π).
+
+  The parent fixes the *centred, unmodulated* standard Gaussian.  Here we work out
+  what the Fourier transform does to the two elementary symmetries of that
+  density — translation in space and modulation by a phase — and show they are
+  exchanged by the transform.  This is the "shift theorem" of Fourier analysis,
+  made completely explicit for the Gaussian:
+
+    • TRANSLATION ↦ MODULATION
+        ∫_ℝ e^{i t x} · e^{-(x-a)²/2} dx = e^{i t a} · e^{-t²/2} · √(2π).
+      Translating the bump by `a` multiplies its transform by the unit-modulus
+      phase `e^{i t a}`.
+
+    • MODULATION ↦ TRANSLATION
+        ∫_ℝ e^{i t x} · (e^{i a x} · e^{-x²/2}) dx = e^{-(t+a)²/2} · √(2π).
+      Modulating the bump by `e^{i a x}` translates its transform by `a`
+      (`t ↦ t + a`).
+
+  These are dual statements: each is the other read through the inverse Fourier
+  transform.  Two consequences make the duality concrete:
+
+    • the modulus of the transform is *unchanged* by translation — the phase
+      `e^{i t a}` has absolute value 1, so a translated Gaussian and the centred
+      Gaussian have transforms of equal magnitude (only the phase moves);
+    • both identities specialise at `a = 0` back to the parent's
+      `gaussian_fourier_real`.
+
+  METHOD.  Both reduce to the parent identity by *elementary* manipulations that
+  need no new analysis:
+    • translation: factor `e^{i t x} = e^{i t a} · e^{i t (x-a)}`, pull the
+      constant out, and remove the shift with Lebesgue translation-invariance
+      `MeasureTheory.integral_sub_right_eq_self`;
+    • modulation: merge `e^{i t x} · e^{i a x} = e^{i (t+a) x}` and apply the
+      parent at `t + a`.
+  The base identity `gaussian_fourier_real` is reproved here verbatim (three short
+  lemmas) so the file is self-contained.
+
+  Everything is proved with 0 sorries and 0 axioms.
+
+  References:
+  - The shift theorem (translation/modulation duality), e.g. Stein–Shakarchi,
+    Fourier Analysis (2003), Ch. 5.
+  - Mathlib: Analysis.SpecialFunctions.Gaussian.FourierTransform
+-/
+import Mathlib
+
+set_option maxHeartbeats 1200000
+set_option linter.unusedVariables false
+set_option linter.unusedSectionVars false
+
+open Real Complex MeasureTheory
+open scoped Real
+
+namespace GaussianShiftTheorem
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I:  THE BASE GAUSSIAN FOURIER IDENTITY (reproved, self-contained)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Completing the square at the level of the integrand:
+    `e^{i t x} · e^{-x²/2} = e^{-(1/2)(x + (-t)·i)²} · e^{-t²/2}` (using `i² = -1`). -/
+theorem gaussian_integrand_complete_square (t x : ℝ) :
+    Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)
+      = Complex.exp (-(((1 : ℝ) / 2 : ℝ) : ℂ) * ((x : ℂ) + ((-t : ℝ) : ℂ) * Complex.I) ^ 2)
+        * Complex.exp (-(t : ℂ) ^ 2 / 2) := by
+  rw [← Complex.exp_add, ← Complex.exp_add]
+  congr 1
+  push_cast
+  linear_combination (t : ℂ) ^ 2 / 2 * Complex.I_sq
+
+/-- The Mathlib contour constant `(π / (1/2))^(1/2)` is the complex coercion of
+    the real `√(2π)`. -/
+theorem cpow_half_eq_sqrt_two_pi :
+    ((π : ℂ) / (((1 : ℝ) / 2 : ℝ) : ℂ)) ^ (1 / 2 : ℂ)
+      = ((Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  have h0 : (0 : ℝ) ≤ 2 * π := by positivity
+  rw [show ((π : ℂ) / (((1 : ℝ) / 2 : ℝ) : ℂ)) = ((2 * π : ℝ) : ℂ) by push_cast; ring]
+  rw [Real.sqrt_eq_rpow, Complex.ofReal_cpow h0]
+  norm_num
+
+/-- **The Gaussian is its own Fourier transform (un-normalized).**
+
+      ∫_ℝ e^{i t x} · e^{-x²/2} dx = e^{-t²/2} · √(2π). -/
+theorem gaussian_fourier_real (t : ℝ) :
+    ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)
+      = Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  simp_rw [gaussian_integrand_complete_square t]
+  rw [MeasureTheory.integral_mul_const]
+  rw [GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I
+        (b := (((1 : ℝ) / 2 : ℝ) : ℂ)) (by rw [Complex.ofReal_re]; norm_num) (-t)]
+  rw [cpow_half_eq_sqrt_two_pi]
+  ring
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II:  TRANSLATION ↦ MODULATION
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Translating the Gaussian multiplies its Fourier transform by a phase.**
+
+      ∫_ℝ e^{i t x} · e^{-(x-a)²/2} dx = e^{i t a} · (e^{-t²/2} · √(2π)).
+
+    Shifting the standard Gaussian by `a` in space introduces the unit-modulus
+    factor `e^{i t a}` in frequency. -/
+theorem gaussian_fourier_translation (t a : ℝ) :
+    ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-((x : ℂ) - a) ^ 2 / 2)
+      = Complex.exp (Complex.I * (t : ℂ) * (a : ℂ))
+          * (Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)) := by
+  -- factor the integrand as  e^{i t a} · ( e^{i t (x-a)} · e^{-(x-a)²/2} )
+  have key : ∀ x : ℝ,
+      Complex.exp (Complex.I * t * x) * Complex.exp (-((x : ℂ) - a) ^ 2 / 2)
+        = Complex.exp (Complex.I * (t : ℂ) * (a : ℂ))
+          * (Complex.exp (Complex.I * (t : ℂ) * ((x : ℂ) - a))
+              * Complex.exp (-((x : ℂ) - a) ^ 2 / 2)) := by
+    intro x
+    have e1 : Complex.exp (Complex.I * (t : ℂ) * (a : ℂ))
+          * Complex.exp (Complex.I * (t : ℂ) * ((x : ℂ) - a))
+        = Complex.exp (Complex.I * t * x) := by
+      rw [← Complex.exp_add]; congr 1; push_cast; ring
+    rw [← mul_assoc, e1]
+  simp_rw [key]
+  rw [MeasureTheory.integral_const_mul]
+  congr 1
+  -- remove the shift via Lebesgue translation-invariance, then apply the parent
+  have hF : (∫ x : ℝ, Complex.exp (Complex.I * (t : ℂ) * ((x : ℂ) - a))
+              * Complex.exp (-((x : ℂ) - a) ^ 2 / 2))
+      = ∫ x : ℝ, Complex.exp (Complex.I * (t : ℂ) * (x : ℂ))
+              * Complex.exp (-(x : ℂ) ^ 2 / 2) := by
+    have hcast : (∫ x : ℝ, Complex.exp (Complex.I * (t : ℂ) * ((x : ℂ) - a))
+                * Complex.exp (-((x : ℂ) - a) ^ 2 / 2))
+        = ∫ x : ℝ, (fun y : ℝ => Complex.exp (Complex.I * (t : ℂ) * (y : ℂ))
+                * Complex.exp (-(y : ℂ) ^ 2 / 2)) (x - a) := by
+      apply MeasureTheory.integral_congr_ae
+      filter_upwards with x
+      push_cast
+      ring
+    rw [hcast, MeasureTheory.integral_sub_right_eq_self
+        (fun y : ℝ => Complex.exp (Complex.I * (t : ℂ) * (y : ℂ))
+            * Complex.exp (-(y : ℂ) ^ 2 / 2)) a]
+  rw [hF, gaussian_fourier_real]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III:  MODULATION ↦ TRANSLATION
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Modulating the Gaussian translates its Fourier transform.**
+
+      ∫_ℝ e^{i t x} · (e^{i a x} · e^{-x²/2}) dx = e^{-(t+a)²/2} · √(2π).
+
+    Multiplying the standard Gaussian by the phase `e^{i a x}` shifts its
+    transform `t ↦ t + a`. -/
+theorem gaussian_fourier_modulation (t a : ℝ) :
+    ∫ x : ℝ, Complex.exp (Complex.I * t * x)
+        * (Complex.exp (Complex.I * a * x) * Complex.exp (-(x : ℂ) ^ 2 / 2))
+      = Complex.exp (-((t + a : ℝ) : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  have key : ∀ x : ℝ,
+      Complex.exp (Complex.I * t * x)
+          * (Complex.exp (Complex.I * a * x) * Complex.exp (-(x : ℂ) ^ 2 / 2))
+        = Complex.exp (Complex.I * ((t + a : ℝ) : ℂ) * (x : ℂ))
+            * Complex.exp (-(x : ℂ) ^ 2 / 2) := by
+    intro x
+    rw [← mul_assoc, ← Complex.exp_add]
+    have hexp : Complex.I * (t : ℂ) * (x : ℂ) + Complex.I * (a : ℂ) * (x : ℂ)
+        = Complex.I * ((t + a : ℝ) : ℂ) * (x : ℂ) := by
+      push_cast; ring
+    rw [hexp]
+  simp_rw [key]
+  rw [gaussian_fourier_real (t + a)]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV:  CONSEQUENCES — DUALITY AND THE PARENT AS A SPECIAL CASE
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Translation preserves the modulus of the transform.**  Because the phase
+    `e^{i t a}` has absolute value 1, the translated Gaussian and the centred
+    Gaussian have Fourier transforms of equal magnitude — translation only moves
+    the phase. -/
+theorem gaussian_fourier_translation_modulus (t a : ℝ) :
+    ‖∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-((x : ℂ) - a) ^ 2 / 2)‖
+      = ‖Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)‖ := by
+  rw [gaussian_fourier_translation, norm_mul]
+  have hphase : ‖Complex.exp (Complex.I * (t : ℂ) * (a : ℂ))‖ = 1 := by
+    rw [Complex.norm_exp]
+    simp [Complex.mul_re, Complex.mul_im]
+  rw [hphase, one_mul]
+
+/-- The translation identity recovers the parent `gaussian_fourier_real` at
+    `a = 0` (no shift, no phase). -/
+theorem gaussian_fourier_translation_recovers_parent (t : ℝ) :
+    ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)
+      = Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  simpa using gaussian_fourier_translation t 0
+
+/-- The modulation identity recovers the parent `gaussian_fourier_real` at
+    `a = 0` (no modulation, no shift in frequency). -/
+theorem gaussian_fourier_modulation_recovers_parent (t : ℝ) :
+    ∫ x : ℝ, Complex.exp (Complex.I * t * x)
+        * (1 * Complex.exp (-(x : ℂ) ^ 2 / 2))
+      = Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  have h := gaussian_fourier_modulation t 0
+  simpa using h
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+Summary
+═══════════════════════════════════════════════════════════════════════════════
+
+## Translation–modulation duality for the Gaussian Fourier transform
+   (area-of-circle-oq-05-oq-03-oq-03)
+
+### What's proved (0 sorries, 0 axioms):
+- `gaussian_fourier_real` (reproved, self-contained): the base identity
+  ∫ e^{itx} e^{-x²/2} = e^{-t²/2}·√(2π).
+- `gaussian_fourier_translation`: **∫ e^{itx} e^{-(x-a)²/2} = e^{ita}·e^{-t²/2}·√(2π)**
+  — translation in space ↦ modulation by the phase e^{ita}.
+- `gaussian_fourier_modulation`: **∫ e^{itx}·(e^{iax} e^{-x²/2}) = e^{-(t+a)²/2}·√(2π)**
+  — modulation in space ↦ translation t ↦ t+a in frequency.
+- `gaussian_fourier_translation_modulus`: the transform's magnitude is invariant
+  under translation (the phase has modulus 1).
+- `gaussian_fourier_translation_recovers_parent`,
+  `gaussian_fourier_modulation_recovers_parent`: both specialise at a = 0 to the
+  parent identity.
+
+### Honest scope:
+These are the standard "shift theorem" identities of Fourier analysis,
+instantiated on the explicit Gaussian density and proved as concrete Lebesgue
+integrals. No new analytic machinery is used: both reduce to the parent identity
+by translation-invariance of Lebesgue measure and the exponent algebra. The
+content is the *explicit duality* — that translation and modulation are exchanged
+by the Gaussian Fourier transform — for the concrete density, complementing the
+parent (self-duality) and the dilation/convolution siblings of this lineage.
+-/
+
+#check @gaussian_fourier_real
+#check @gaussian_fourier_translation
+#check @gaussian_fourier_modulation
+#check @gaussian_fourier_translation_modulus
+
+end GaussianShiftTheorem

--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-03/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-aoc-oq05oq03oq03-scope",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 60
+    },
+    "type": "insight",
+    "title": "The Fourier Shift Theorem, Explicit for the Gaussian",
+    "content": "The parent entry fixed the Fourier transform of the centred, unmodulated standard Gaussian. This entry works out the two elementary symmetries of that density — translation in space and modulation by a phase — and shows the transform exchanges them. Translation by a multiplies the transform by the unit-modulus phase e^{ita}; modulation by e^{iax} shifts the transform t ↦ t+a. The two statements are dual, each being the other read through the inverse transform. All proved in concrete Lebesgue form, 0 axioms, 0 sorries.",
+    "mathContext": "FT(f(·-a))(t) = e^{ita}·FT(f)(t) and FT(e^{ia·}f)(t) = FT(f)(t+a), instantiated on the Gaussian density.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fourier transform",
+      "shift theorem",
+      "translation",
+      "modulation",
+      "Gaussian"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq03-base",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-03",
+    "range": {
+      "startLine": 61,
+      "endLine": 105
+    },
+    "type": "technique",
+    "title": "Self-Contained Base Identity",
+    "content": "The base Gaussian Fourier identity ∫ e^{itx} e^{-x²/2} = e^{-t²/2}·√(2π) is reproved verbatim from the parent (three short lemmas: complete the square over ℂ via Complex.I_sq, identify the contour constant (π/(1/2))^{1/2} = √(2π), and evaluate via Mathlib's vertical-strip lemma integral_cexp_neg_mul_sq_add_real_mul_I). Reproving it keeps the file independent of the parent module.",
+    "mathContext": "∫ e^{itx} e^{-x²/2} dx = e^{-t²/2}·√(2π), the parent self-duality identity.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "completing the square",
+      "contour integral",
+      "Gaussian integral"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq03-translation",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-03",
+    "range": {
+      "startLine": 106,
+      "endLine": 146
+    },
+    "type": "technique",
+    "title": "Translation ↦ Modulation via Lebesgue Translation-Invariance",
+    "content": "To compute ∫ e^{itx} e^{-(x-a)²/2} dx, factor e^{itx} = e^{ita}·e^{it(x-a)}, pull the constant phase e^{ita} out with integral_const_mul, and observe the remaining integrand is the parent integrand evaluated at x-a. A cast-bridging integral_congr_ae rewrites (x:ℂ)-a as ↑(x-a) so MeasureTheory.integral_sub_right_eq_self fires and removes the shift, returning the parent value times e^{ita}. The practical subtlety: the ℝ→ℂ coercion must be normalised (↑(x-a) vs ↑x-↑a) before the translation-invariance lemma will match.",
+    "mathContext": "∫ e^{itx} e^{-(x-a)²/2} dx = e^{ita}·(e^{-t²/2}·√(2π)).",
+    "significance": "key",
+    "relatedConcepts": [
+      "translation invariance",
+      "integral_sub_right_eq_self",
+      "coercion normalisation",
+      "phase factor"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq03-modulation",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-03",
+    "range": {
+      "startLine": 147,
+      "endLine": 175
+    },
+    "type": "technique",
+    "title": "Modulation ↦ Translation by Merging Phases",
+    "content": "Modulation is the easy dual: e^{itx}·e^{iax} = e^{i(t+a)x} (Complex.exp_add together with a push_cast/ring exponent identity), so ∫ e^{itx}·(e^{iax} e^{-x²/2}) dx is just the parent identity at frequency t+a. The transform is translated t ↦ t+a.",
+    "mathContext": "∫ e^{itx}·(e^{iax} e^{-x²/2}) dx = e^{-(t+a)²/2}·√(2π).",
+    "significance": "key",
+    "relatedConcepts": [
+      "modulation",
+      "frequency shift",
+      "complex exponential"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq03-duality",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-03",
+    "range": {
+      "startLine": 176,
+      "endLine": 215
+    },
+    "type": "insight",
+    "title": "Magnitude Invariance and the Parent as a Special Case",
+    "content": "Because |e^{ita}| = 1 (Complex.norm_exp, the real part of i·t·a being 0), translation leaves the magnitude of the transform unchanged — it moves only the phase (gaussian_fourier_translation_modulus). Setting a = 0 in either identity recovers the parent self-duality. Together these make the translation/modulation duality concrete and tie the entry back to its parent.",
+    "mathContext": "‖FT(translate)‖ = ‖FT‖; both identities at a=0 give ∫ e^{itx} e^{-x²/2} = e^{-t²/2}√(2π).",
+    "significance": "key",
+    "relatedConcepts": [
+      "unit modulus",
+      "phase",
+      "duality",
+      "special case"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-03/meta.json
@@ -1,0 +1,202 @@
+{
+  "id": "area-of-circle-oq-05-oq-03-oq-03",
+  "title": "Gaussian Fourier transform: translation–modulation duality",
+  "slug": "area-of-circle-oq-05-oq-03-oq-03",
+  "description": "Follow-up to area-of-circle-oq-05-oq-03 (the Gaussian is its own Fourier transform). Makes the Fourier 'shift theorem' completely explicit for the standard Gaussian density and shows it exchanges the two elementary symmetries of the density — translation in space and modulation by a phase. TRANSLATION ↦ MODULATION: ∫_ℝ e^{itx}·e^{-(x-a)²/2} dx = e^{ita}·e^{-t²/2}·√(2π) (shifting the bump by a multiplies its transform by the unit-modulus phase e^{ita}). MODULATION ↦ TRANSLATION: ∫_ℝ e^{itx}·(e^{iax}·e^{-x²/2}) dx = e^{-(t+a)²/2}·√(2π) (modulating the bump by e^{iax} shifts its transform t ↦ t+a). Consequences: translation preserves the modulus of the transform (the phase has absolute value 1), and both identities specialise at a=0 to the parent. Each reduces to the parent identity by elementary means — translation-invariance of Lebesgue measure (integral_sub_right_eq_self) and exponent algebra — with no new analysis. All 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Classical (Fourier shift theorem); Lean 4 formalization (research, 2026)",
+    "date": "2003",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ03OQ03.lean",
+    "tags": [
+      "analysis",
+      "fourier-analysis",
+      "gaussian-integral",
+      "characteristic-function",
+      "complex-analysis",
+      "probability"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 249,
+    "assumptions": "0 axioms, 0 sorries. Reproves the base identity gaussian_fourier_real self-contained (three short lemmas via Mathlib's GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I), then derives the translation and modulation identities by translation-invariance of Lebesgue measure (MeasureTheory.integral_sub_right_eq_self) and complex exponent algebra. HONEST SCOPE: these are the standard 'shift theorem' identities of Fourier analysis instantiated on the explicit Gaussian density; no new analytic machinery is introduced beyond the parent.",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-21",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The 'shift theorem' — that translation and modulation are interchanged by the Fourier transform — is one of the first structural facts one learns about the transform, and it is the mechanism behind everything from beat frequencies to the phase of diffraction patterns. The parent entry (area-of-circle-oq-05-oq-03) pinned down the Fourier transform of the centred, unmodulated standard Gaussian. This entry asks what the transform does to the two basic moves one can make on that bump — slide it (translation) or twist it by a phase (modulation) — and finds the classical answer: the two operations are dual, exchanged by the transform. For the Gaussian this is fully explicit because its transform is again a Gaussian.",
+    "problemStatement": "Determine the Fourier transform of a translated Gaussian e^{-(x-a)²/2} and of a modulated Gaussian e^{iax}·e^{-x²/2}, and exhibit the duality between translation and modulation, working entirely with explicit Lebesgue integrals built on the parent identity ∫ e^{itx} e^{-x²/2} = e^{-t²/2}√(2π).",
+    "text": "Both identities reduce to the parent by elementary algebra. For translation, write e^{itx} = e^{ita}·e^{it(x-a)}; the constant e^{ita} pulls out of the integral, and the remaining integrand is the parent integrand evaluated at x-a, so Lebesgue translation-invariance (∫ f(x-a) dx = ∫ f(x) dx) removes the shift and returns the parent value, multiplied by the phase e^{ita}. For modulation, merge e^{itx}·e^{iax} = e^{i(t+a)x} and apply the parent at frequency t+a; the transform is simply shifted to t ↦ t+a. The two statements are dual: each is the other read through the inverse Fourier transform. Because |e^{ita}| = 1, translation leaves the magnitude of the transform unchanged — it moves only the phase — and at a = 0 both identities collapse back to the parent.",
+    "proofStrategy": "1. **Reprove the base identity** (gaussian_integrand_complete_square, cpow_half_eq_sqrt_two_pi, gaussian_fourier_real): completing the square over ℂ plus Mathlib's vertical-strip contour integral, copied verbatim from the parent so the file is self-contained.\n\n2. **Translation** (gaussian_fourier_translation): a pointwise factoring e^{itx}·e^{-(x-a)²/2} = e^{ita}·(e^{it(x-a)}·e^{-(x-a)²/2}) (Complex.exp_add + ring), then integral_const_mul to pull out e^{ita}, then a cast-bridging integral_congr_ae to rewrite (x:ℂ)-a as ↑(x-a) so MeasureTheory.integral_sub_right_eq_self applies, returning the parent value.\n\n3. **Modulation** (gaussian_fourier_modulation): merge the two phases into e^{i(t+a)x} (Complex.exp_add + a push_cast/ring exponent identity), then apply gaussian_fourier_real at t+a.\n\n4. **Consequences**: gaussian_fourier_translation_modulus (‖phase‖ = 1 via Complex.norm_exp, the real part of i·t·a being 0), and gaussian_fourier_translation_recovers_parent / gaussian_fourier_modulation_recovers_parent (specialise at a = 0 with simpa).",
+    "keyInsights": [
+      "Translation in space ↦ modulation in frequency: sliding the Gaussian by a multiplies its transform by the pure phase e^{ita}, leaving the magnitude untouched.",
+      "Modulation in space ↦ translation in frequency: twisting the Gaussian by e^{iax} simply shifts its transform t ↦ t+a. These are the two halves of the Fourier shift theorem, dual under the inverse transform.",
+      "No new analysis is needed beyond the parent: translation is handled by Lebesgue translation-invariance (integral_sub_right_eq_self) after pulling out the constant phase, and modulation by merging exponentials and re-using the parent at a shifted frequency.",
+      "The cast subtlety (x:ℂ)-a vs ↑(x-a) must be bridged with integral_congr_ae before the translation-invariance lemma will fire — a recurring practical point when combining ℝ→ℂ coercions with measure-theoretic rewrites."
+    ],
+    "prerequisites": [
+      "area-of-circle-oq-05-oq-03 — the Gaussian Fourier self-duality ∫ e^{itx} e^{-x²/2} = e^{-t²/2}√(2π) (reproved here)",
+      "Translation-invariance of Lebesgue measure: MeasureTheory.integral_sub_right_eq_self",
+      "Complex exponential algebra (Complex.exp_add) and Complex.norm_exp for the modulus computation",
+      "Linearity of the Bochner integral (integral_const_mul) and integral_congr_ae"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: Imports and Setup",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Imports Mathlib; opens Real, Complex, MeasureTheory. Header states the translation and modulation identities, their duality, and the elementary method.",
+      "mathContext": "Sets up the Fourier shift theorem for the explicit Gaussian density, building on the parent self-duality identity."
+    },
+    {
+      "id": "base",
+      "title": "Part I: The Base Gaussian Fourier Identity (reproved)",
+      "startLine": 61,
+      "endLine": 105,
+      "summary": "gaussian_integrand_complete_square, cpow_half_eq_sqrt_two_pi, gaussian_fourier_real — the parent identity ∫ e^{itx} e^{-x²/2} = e^{-t²/2}√(2π), reproved verbatim for self-containment.",
+      "mathContext": "Complete the square over ℂ and evaluate the vertical-strip contour integral via Mathlib's integral_cexp_neg_mul_sq_add_real_mul_I."
+    },
+    {
+      "id": "translation",
+      "title": "Part II: Translation ↦ Modulation",
+      "startLine": 106,
+      "endLine": 146,
+      "summary": "gaussian_fourier_translation: ∫ e^{itx} e^{-(x-a)²/2} = e^{ita}·(e^{-t²/2}·√(2π)), via factoring out e^{ita} and removing the shift with integral_sub_right_eq_self.",
+      "mathContext": "Translating the bump by a multiplies its transform by the unit phase e^{ita}; the shift is killed by Lebesgue translation-invariance."
+    },
+    {
+      "id": "modulation",
+      "title": "Part III: Modulation ↦ Translation",
+      "startLine": 147,
+      "endLine": 175,
+      "summary": "gaussian_fourier_modulation: ∫ e^{itx}·(e^{iax} e^{-x²/2}) = e^{-(t+a)²/2}·√(2π), via merging phases into e^{i(t+a)x} and applying the parent at t+a.",
+      "mathContext": "Modulating the bump by e^{iax} shifts its transform t ↦ t+a — the dual of translation."
+    },
+    {
+      "id": "consequences",
+      "title": "Part IV: Duality and the Parent as a Special Case",
+      "startLine": 176,
+      "endLine": 215,
+      "summary": "gaussian_fourier_translation_modulus (translation preserves the transform's magnitude, ‖e^{ita}‖=1) and the two a=0 specialisations recovering the parent.",
+      "mathContext": "The phase has modulus 1, so translation moves only the phase; setting a=0 returns the centred self-duality identity."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Fourier shift theorem is made explicit for the standard Gaussian: translation by a yields a phase e^{ita} on the transform (gaussian_fourier_translation), modulation by e^{iax} shifts the transform t ↦ t+a (gaussian_fourier_modulation), and the two are dual. Translation preserves the magnitude of the transform (the phase has modulus 1), and both identities reduce at a=0 to the parent self-duality. All in concrete Lebesgue form, 0 axioms, 0 sorries.",
+    "implications": "Completes the elementary symmetry picture for the Gaussian Fourier transform alongside the parent (self-duality) and the dilation/convolution siblings of this lineage: together they describe how the transform interacts with the affine and phase symmetries of the Gaussian density. The translation law with a phase is also the missing piece for the general N(μ,σ²) characteristic function e^{iμt - σ²t²/2}, obtained by combining this shift with the dilation law.",
+    "openQuestions": [
+      "Combine this translation law with the dilation law (area-of-circle-oq-05-oq-03-oq-01) to derive the full affine-Gaussian Fourier transform ∫ e^{itx} e^{-(x-a)²/(2σ²)} dx = σ√(2π)·e^{ita}·e^{-σ²t²/2}, and hence the N(μ,σ²) characteristic function.",
+      "Prove the analogous shift theorem for a general L¹ function (not just the Gaussian) as a reusable lemma: FT(f(·-a))(t) = e^{ita}·FT(f)(t)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-05-oq-03",
+      "relationship": "extends",
+      "description": "Parent: the Gaussian is its own Fourier transform. This entry adds the translation/modulation behaviour and recovers the parent as the a=0 case."
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "related",
+      "description": "The phase factor e^{ita} on a translated Gaussian is exactly the shift term in the general normal characteristic function e^{iμt-σ²t²/2} used in characteristic-function proofs of the CLT."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Complex",
+      "MeasureTheory"
+    ],
+    "namespace": "GaussianShiftTheorem",
+    "lineCount": 249,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "gaussian_fourier_translation",
+        "type": "core",
+        "description": "Translating the Gaussian multiplies its Fourier transform by a phase: ∫ e^{itx} e^{-(x-a)²/2} dx = e^{ita}·(e^{-t²/2}·√(2π)).",
+        "leanType": "(t a : ℝ) → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-((x : ℂ) - a) ^ 2 / 2) = Complex.exp (Complex.I * (t : ℂ) * (a : ℂ)) * (Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ))"
+      },
+      {
+        "name": "gaussian_fourier_modulation",
+        "type": "core",
+        "description": "Modulating the Gaussian translates its Fourier transform: ∫ e^{itx}·(e^{iax} e^{-x²/2}) dx = e^{-(t+a)²/2}·√(2π).",
+        "leanType": "(t a : ℝ) → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * (Complex.exp (Complex.I * a * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)) = Complex.exp (-((t + a : ℝ) : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)"
+      },
+      {
+        "name": "gaussian_fourier_translation_modulus",
+        "type": "key",
+        "description": "Translation preserves the magnitude of the transform: the phase e^{ita} has modulus 1.",
+        "leanType": "(t a : ℝ) → ‖∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-((x : ℂ) - a) ^ 2 / 2)‖ = ‖Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)‖"
+      },
+      {
+        "name": "gaussian_fourier_real",
+        "type": "supporting",
+        "description": "Base identity (reproved): ∫ e^{itx}·e^{-x²/2} dx = e^{-t²/2}·√(2π).",
+        "leanType": "(t : ℝ) → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2) = Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)"
+      }
+    ],
+    "path": "Proofs/AreaOfCircleOQ05OQ03OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "gaussian_fourier_translation",
+      "type": "core",
+      "description": "Translating the Gaussian multiplies its Fourier transform by the unit-modulus phase e^{ita}: ∫ e^{itx} e^{-(x-a)²/2} dx = e^{ita}·(e^{-t²/2}·√(2π)).",
+      "leanType": "(t a : ℝ) → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-((x : ℂ) - a) ^ 2 / 2) = Complex.exp (Complex.I * (t : ℂ) * (a : ℂ)) * (Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ))"
+    },
+    {
+      "name": "gaussian_fourier_modulation",
+      "type": "core",
+      "description": "Modulating the Gaussian translates its Fourier transform t ↦ t+a: ∫ e^{itx}·(e^{iax} e^{-x²/2}) dx = e^{-(t+a)²/2}·√(2π).",
+      "leanType": "(t a : ℝ) → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * (Complex.exp (Complex.I * a * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)) = Complex.exp (-((t + a : ℝ) : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)"
+    },
+    {
+      "name": "gaussian_fourier_translation_modulus",
+      "type": "key",
+      "description": "Translation preserves the magnitude of the transform (the phase e^{ita} has absolute value 1).",
+      "leanType": "(t a : ℝ) → ‖∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-((x : ℂ) - a) ^ 2 / 2)‖ = ‖Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)‖"
+    },
+    {
+      "name": "gaussian_fourier_translation_recovers_parent",
+      "type": "supporting",
+      "description": "The translation identity at a=0 recovers the parent self-duality identity.",
+      "leanType": "(t : ℝ) → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2) = Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stein, Elias M. and Shakarchi, Rami",
+      "title": "Fourier Analysis: An Introduction",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "note": "Chapter 5; the shift theorem (translation/modulation duality) and the Gaussian Fourier transform"
+    },
+    {
+      "authors": "mathlib community",
+      "title": "Analysis.SpecialFunctions.Gaussian.FourierTransform",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "integral_cexp_neg_mul_sq_add_real_mul_I — the shifted Gaussian contour integral reused in the base identity"
+    },
+    {
+      "authors": "Billingsley, Patrick",
+      "title": "Probability and Measure",
+      "year": "1995",
+      "venue": "Wiley",
+      "note": "Characteristic functions; the phase factor of a translated/mean-shifted normal"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up to **area-of-circle-oq-05-oq-03** ("the Gaussian is its own Fourier transform"). The parent fixed the Fourier transform of the centred, unmodulated standard Gaussian. This entry makes the Fourier **shift theorem** explicit for that density and shows the transform **exchanges its two elementary symmetries**:

- **Translation ↦ Modulation:** `∫ e^{itx} e^{-(x-a)²/2} dx = e^{ita}·e^{-t²/2}·√(2π)` — sliding the bump by `a` multiplies its transform by the unit-modulus phase `e^{ita}`.
- **Modulation ↦ Translation:** `∫ e^{itx}·(e^{iax} e^{-x²/2}) dx = e^{-(t+a)²/2}·√(2π)` — twisting the bump by `e^{iax}` shifts its transform `t ↦ t+a`.

These are dual: each is the other read through the inverse Fourier transform.

## Theorems (8 total, 0 defs)

- `gaussian_fourier_translation` — translation ↦ modulation
- `gaussian_fourier_modulation` — modulation ↦ translation
- `gaussian_fourier_translation_modulus` — translation preserves the transform's magnitude (`‖e^{ita}‖ = 1`)
- `gaussian_fourier_translation_recovers_parent`, `gaussian_fourier_modulation_recovers_parent` — both reduce at `a=0` to the parent
- base identity `gaussian_fourier_real` (+ two helpers) reproved verbatim so the file is self-contained

## Method

Both identities reduce to the parent by elementary means, **no new analysis**:
- translation: factor `e^{itx} = e^{ita}·e^{it(x-a)}`, pull out the constant phase (`integral_const_mul`), and remove the shift with Lebesgue translation-invariance `MeasureTheory.integral_sub_right_eq_self` (after bridging the `(x:ℂ)-a` vs `↑(x-a)` coercion with `integral_congr_ae`);
- modulation: merge `e^{itx}·e^{iax} = e^{i(t+a)x}` and apply the parent at `t+a`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AreaOfCircleOQ05OQ03OQ03` → **Build completed successfully**
- `#print axioms` → only `propext, Classical.choice, Quot.sound` → **0 axioms, 0 sorries, no native_decide**

## Honest scope

These are the standard shift-theorem identities of Fourier analysis, instantiated on the explicit Gaussian density and proved as concrete Lebesgue integrals — the value added over the parent is the **explicit translation/modulation duality** for the concrete density, complementing the dilation and convolution siblings of this lineage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)