### PR TITLE
research(erdos-396-oq-04-oq-01-oq-01): the Catalan ratio deficit is harmonic

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1640,6 +1640,7 @@ import Proofs.Erdos395OQ01Incomplete01
 import Proofs.Erdos395Problem
 import Proofs.Erdos396OQ04
 import Proofs.Erdos396OQ04OQ01
+import Proofs.Erdos396OQ04OQ01OQ01
 import Proofs.Erdos396Problem
 import Proofs.Erdos397Problem
 import Proofs.Erdos398Problem

--- a/proofs/Proofs/Erdos396OQ04OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos396OQ04OQ01OQ01.lean
@@ -1,0 +1,133 @@
+/-
+# Erdős Problem #396 — OQ-04 → OQ-01 → OQ-01: the Catalan ratio deficit is harmonic
+
+The parent entry `Erdos396OQ04OQ01` reads the two-term Catalan recurrence as a
+statement about the ratio of consecutive Catalan numbers,
+
+  `r n = (4n+2)/(n+2) = 4 − 6/(n+2)`,
+
+and shows `r n < 4`, `r` is strictly increasing, and `r n → 4`.
+
+This follow-up looks at the **deficit** `δ n = 4 − r n`, the amount by which the
+`n`-th multiplicative step falls short of the limiting growth rate `4`.  From the
+partial-fraction identity the deficit is *exactly* `δ n = 6/(n+2)`, the tail of a
+harmonic series.  The headline is a sharp convergence-versus-divergence
+dichotomy:
+
+* **`deficit_tendsto_zero`** : `δ n → 0` — individual steps approach the rate `4`;
+* **`deficit_sum_eq`** : `∑_{k<n} δ k = 6·(H_{n+1} − 1)`, where
+  `H m = ∑_{i<m} 1/(i+1)` is the `m`-th harmonic number — the cumulative
+  shortfall is a harmonic partial sum;
+* **`deficit_sum_tendsto_atTop`** : `∑_{k<n} δ k → ∞`.
+
+So although every ratio individually races up to `4`, the **total** distance the
+ratios lag behind `4` is harmonic and therefore *diverges*.  This is the precise
+discrete reason the asymptotic refinement of `catalan n ∼ 4^n / (n^{3/2}√π)`
+carries a polynomial correction below `4^n`: the multiplicative deficits do not
+sum to a finite constant.
+
+As a corollary we get a closed form for the running sum of the ratios
+(**`ratio_sum_eq`**): `∑_{k<n} r k = 4n − 6·(H_{n+1} − 1)`.
+
+Everything is derived from the parent's ratio identity together with the
+divergence of the harmonic series; no Stirling estimate is used.
+
+Reference: https://erdosproblems.com/396
+-/
+
+import Mathlib
+import Proofs.Erdos396OQ04OQ01
+
+open Nat Filter Topology Finset
+
+namespace Erdos396OQ01OQ01
+
+open Erdos396OQ01
+
+/-- The `n`-th **deficit** of the Catalan recurrence ratio: how far the step
+    `r n` falls short of the limiting growth rate `4`. -/
+noncomputable def catalanDeficit (n : ℕ) : ℝ := 4 - catalanRatio n
+
+/-- The `m`-th harmonic number `H m = ∑_{i<m} 1/(i+1)` as a real number. -/
+noncomputable def realHarmonic (m : ℕ) : ℝ := ∑ i ∈ Finset.range m, (1 : ℝ) / (i + 1)
+
+/-- **Deficit identity.** `δ n = 6/(n+2)` — the deficit is the tail of a
+    harmonic series. -/
+theorem deficit_eq (n : ℕ) : catalanDeficit n = 6 / ((n : ℝ) + 2) := by
+  rw [catalanDeficit, ratio_eq_four_sub]; ring
+
+/-- The deficit is strictly positive. -/
+theorem deficit_pos (n : ℕ) : 0 < catalanDeficit n := by
+  rw [deficit_eq]; positivity
+
+/-- **Individual steps approach the rate `4`.** `δ n → 0`. -/
+theorem deficit_tendsto_zero : Tendsto catalanDeficit atTop (𝓝 0) := by
+  have h : Tendsto (fun n => 4 - catalanRatio n) atTop (𝓝 (4 - 4)) :=
+    tendsto_const_nhds.sub ratio_tendsto_four
+  simpa [catalanDeficit, sub_self] using h
+
+/-- The harmonic partial sum recurrence `H (m+1) = H m + 1/(m+1)`. -/
+theorem realHarmonic_succ (m : ℕ) :
+    realHarmonic (m + 1) = realHarmonic m + 1 / ((m : ℝ) + 1) := by
+  simp [realHarmonic, Finset.sum_range_succ]
+
+/-- `H 1 = 1`. -/
+theorem realHarmonic_one : realHarmonic 1 = 1 := by
+  simp [realHarmonic]
+
+/-- **Cumulative deficit is a harmonic partial sum.**
+    `∑_{k<n} δ k = 6·(H_{n+1} − 1)`. -/
+theorem deficit_sum_eq (n : ℕ) :
+    ∑ k ∈ Finset.range n, catalanDeficit k = 6 * (realHarmonic (n + 1) - 1) := by
+  induction n with
+  | zero => simp [realHarmonic_one]
+  | succ m ih =>
+    have hH : realHarmonic (m + 1 + 1) = realHarmonic (m + 1) + 1 / ((m : ℝ) + 2) := by
+      rw [realHarmonic_succ (m + 1)]; push_cast; ring
+    rw [Finset.sum_range_succ, ih, deficit_eq, hH]; ring
+
+/-- **Running sum of the ratios.** `∑_{k<n} r k = 4n − 6·(H_{n+1} − 1)`. -/
+theorem ratio_sum_eq (n : ℕ) :
+    ∑ k ∈ Finset.range n, catalanRatio k = 4 * n - 6 * (realHarmonic (n + 1) - 1) := by
+  have hsplit : ∑ k ∈ Finset.range n, catalanRatio k
+      = ∑ k ∈ Finset.range n, ((4 : ℝ) - catalanDeficit k) := by
+    apply Finset.sum_congr rfl
+    intro k _
+    rw [catalanDeficit]; ring
+  rw [hsplit, Finset.sum_sub_distrib, deficit_sum_eq]
+  simp [Finset.sum_const, Finset.card_range]
+  ring
+
+/-- The harmonic partial sums diverge (Mathlib's harmonic-series divergence). -/
+theorem realHarmonic_tendsto_atTop : Tendsto realHarmonic atTop atTop := by
+  unfold realHarmonic
+  exact Real.tendsto_sum_range_one_div_nat_succ_atTop
+
+/-- **Cumulative shortfall diverges.** `∑_{k<n} δ k → ∞`.
+
+    The contrast with `deficit_tendsto_zero` is the whole point: each step's
+    deficit vanishes, yet the deficits sum to a harmonic series and so their
+    running total is unbounded. -/
+theorem deficit_sum_tendsto_atTop :
+    Tendsto (fun n => ∑ k ∈ Finset.range n, catalanDeficit k) atTop atTop := by
+  have hH : Tendsto (fun n => realHarmonic (n + 1)) atTop atTop :=
+    realHarmonic_tendsto_atTop.comp (tendsto_add_atTop_nat 1)
+  have hsub : Tendsto (fun n => realHarmonic (n + 1) - 1) atTop atTop :=
+    Filter.tendsto_atTop_add_const_right atTop (-1) hH
+  have hmul : Tendsto (fun n => 6 * (realHarmonic (n + 1) - 1)) atTop atTop :=
+    Filter.Tendsto.const_mul_atTop (by norm_num : (0 : ℝ) < 6) hsub
+  exact hmul.congr (fun n => (deficit_sum_eq n).symm)
+
+/- ## Sanity checks -/
+
+/-- `δ 0 = 3`: `r 0 = 1`, so the first step lags `4` by `3`. -/
+example : catalanDeficit 0 = 3 := by rw [deficit_eq]; norm_num
+
+/-- Cumulative deficit over the first two steps:
+    `δ 0 + δ 1 = 3 + 2 = 5 = 6·(H₃ − 1) = 6·(1 + 1/2 + 1/3 − 1)`. -/
+example : ∑ k ∈ Finset.range 2, catalanDeficit k = 5 := by
+  rw [Finset.sum_range_succ, Finset.sum_range_succ]
+  simp only [Finset.range_zero, Finset.sum_empty]
+  rw [deficit_eq, deficit_eq]; norm_num
+
+end Erdos396OQ01OQ01

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-e396oq04oq01oq01-defs",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 47,
+      "endLine": 52
+    },
+    "type": "definition",
+    "title": "The deficit and the harmonic number",
+    "content": "Two definitions set the stage: the **deficit** $\\delta\\,n = 4 - r\\,n$, measuring how far the $n$-th Catalan step lags the limiting growth rate $4$; and the real **harmonic number** $H\\,m = \\sum_{i<m} 1/(i+1)$, the running sum the deficits will turn out to equal. The ratio $r\\,n$ is imported from the parent entry.",
+    "mathContext": "$\\delta\\,n = 4 - r\\,n$, $\\quad H\\,m = \\sum_{i=0}^{m-1} \\frac{1}{i+1}$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01-deficit-eq",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 54,
+      "endLine": 57
+    },
+    "type": "key-step",
+    "title": "The deficit is a harmonic tail",
+    "content": "Directly from the parent's partial-fraction identity $r\\,n = 4 - 6/(n+2)$, the deficit is *exactly* $\\delta\\,n = 6/(n+2)$ — a single $\\texttt{ring}$ rewrite. This is the crux: the shortfall from the rate $4$ is a harmonic term, decaying like $1/n$ rather than geometrically.",
+    "mathContext": "$\\delta\\,n = 4 - \\left(4 - \\frac{6}{n+2}\\right) = \\frac{6}{n+2}$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01-tendsto-zero",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 67
+    },
+    "type": "observation",
+    "title": "Each step's deficit vanishes",
+    "content": "Since $r\\,n \\to 4$ (parent), the deficit $\\delta\\,n = 4 - r\\,n \\to 0$. Individually the steps race up to the limiting rate $4$. This is one half of the dichotomy; the other half — that the deficits nonetheless sum to infinity — is the heart of the entry.",
+    "mathContext": "$\\delta\\,n \\to 4 - 4 = 0$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01-sum-eq",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 87
+    },
+    "type": "key-step",
+    "title": "Cumulative deficit is a harmonic partial sum",
+    "content": "The headline identity $\\sum_{k<n} \\delta\\,k = 6\\,(H_{n+1} - 1)$, proved by induction on $n$. The base case computes $H_1 = 1$. The successor case peels the top term with $\\texttt{Finset.sum\\_range\\_succ}$, expands $H_{m+2} = H_{m+1} + 1/(m+2)$ via the harmonic recurrence (with a $\\texttt{push\\_cast}$ to align $\\uparrow(m+1)+1 = \\uparrow m + 2$), and closes by $\\texttt{ring}$. The constant $-1$ reflects dropping the $i=0$ term $1/1$, since the deficit sum starts at $1/(0+2)$.",
+    "mathContext": "$\\sum_{k=0}^{n-1} \\frac{6}{k+2} = 6\\sum_{j=2}^{n+1}\\frac{1}{j} = 6\\,(H_{n+1} - 1)$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01-divergence",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 101,
+      "endLine": 121
+    },
+    "type": "key-step",
+    "title": "The cumulative shortfall diverges",
+    "content": "The sharp contrast with $\\delta\\,n \\to 0$: because $\\sum_{k<n}\\delta\\,k = 6\\,(H_{n+1}-1)$ is a harmonic partial sum, it diverges to $+\\infty$. The proof transports Mathlib's harmonic-series divergence $\\texttt{Real.tendsto\\_sum\\_range\\_one\\_div\\_nat\\_succ\\_atTop}$ along the closed form: shift $n \\mapsto n+1$, subtract the constant $1$, scale by $6 > 0$, then rewrite by the closed form with $\\texttt{Tendsto.congr}$. Terms tending to $0$ whose series diverges — the textbook phenomenon, here forced by a combinatorial recurrence.",
+    "mathContext": "$\\sum_{k<n}\\delta\\,k = 6\\,(H_{n+1}-1) \\to \\infty$ since $H_m \\to \\infty$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01-ratio-sum",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 89,
+      "endLine": 99
+    },
+    "type": "key-step",
+    "title": "Closed form for the ratio running sum",
+    "content": "Splitting $r\\,k = 4 - \\delta\\,k$ and summing via $\\texttt{Finset.sum\\_sub\\_distrib}$ gives the closed form $\\sum_{k<n} r\\,k = 4n - 6\\,(H_{n+1} - 1)$, expressing the partial sums of the Catalan ratios entirely in terms of harmonic numbers.",
+    "mathContext": "$\\sum_{k<n} r\\,k = 4n - \\sum_{k<n}\\delta\\,k = 4n - 6\\,(H_{n+1}-1)$."
+  }
+]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,94 @@
+{
+  "id": "erdos-396-oq-04-oq-01-oq-01",
+  "title": "Erdős #396 OQ-04 → OQ-01 → OQ-01: The Catalan Ratio Deficit is Harmonic",
+  "slug": "erdos-396-oq-04-oq-01-oq-01",
+  "description": "The deficit δ n = 4 − r n of the Catalan recurrence ratio equals exactly 6/(n+2), the tail of a harmonic series. This yields a sharp dichotomy: each step's deficit vanishes (δ n → 0), yet the cumulative deficit ∑_{k<n} δ k = 6·(H_{n+1} − 1) is a harmonic partial sum and therefore diverges. As a corollary, the running sum of ratios has the closed form ∑_{k<n} r k = 4n − 6·(H_{n+1} − 1). This is the precise discrete reason Catalan growth carries a polynomial correction below 4^n.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/396",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos396OQ04OQ01OQ01.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "catalan",
+      "recurrence",
+      "asymptotics",
+      "harmonic-series",
+      "divergence",
+      "limits"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 396,
+    "erdosUrl": "https://erdosproblems.com/396",
+    "axiomCount": 0,
+    "lineCount": 133,
+    "assumptions": "0 axioms, 0 sorries. All results depend only on the foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool / native_decide). Built against Mathlib 4.26.0.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The parent entry Erdős #396 OQ-04 → OQ-01 reads the two-term Catalan recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan(n) as a statement about the multiplicative step r n = (4n+2)/(n+2), showing via the partial-fraction identity r n = 4 − 6/(n+2) that r n < 4, that r is strictly increasing, and that r n → 4. The constant 4 is the exponential growth rate appearing in the Stirling asymptotic catalan n ∼ 4^n / (n^{3/2}√π); the polynomial factor n^{-3/2} is the part of the asymptotic NOT captured by the bare growth rate. This follow-up isolates the source of that polynomial correction at the level of the recurrence.",
+    "problemStatement": "Quantify the deficit δ n = 4 − r n by which each step of the Catalan recurrence falls short of the limiting growth rate 4. How does the deficit behave individually, and what is the behaviour of its running sum?",
+    "text": "The deficit δ n = 4 − r n equals exactly 6/(n+2). Individually δ n → 0, but the cumulative deficit ∑_{k<n} δ k = 6·(H_{n+1} − 1) is a harmonic partial sum, hence ∑_{k<n} δ k → ∞. Consequently ∑_{k<n} r k = 4n − 6·(H_{n+1} − 1).",
+    "proofStrategy": "Reuse the parent's identity r n = 4 − 6/(n+2) (imported from Proofs.Erdos396OQ04OQ01). Define the deficit δ n = 4 − r n and prove δ n = 6/(n+2) by a one-line `ring` rewrite. Define the real harmonic number H m = ∑_{i<m} 1/(i+1) and prove its one-step recurrence H(m+1) = H m + 1/(m+1) by `Finset.sum_range_succ`. The headline identity ∑_{k<n} δ k = 6·(H_{n+1} − 1) is proved by induction on n: the base case computes H 1 = 1, and the successor case peels the top term with `Finset.sum_range_succ`, expands H(m+2) = H(m+1) + 1/(m+2) via the harmonic recurrence (with a `push_cast` to align the cast (↑(m+1)+1) = ↑m+2), and closes by `ring`. The divergence ∑_{k<n} δ k → ∞ is obtained by transporting Mathlib's harmonic-series divergence `Real.tendsto_sum_range_one_div_nat_succ_atTop` along the closed form: shift n ↦ n+1 (`tendsto_add_atTop_nat`), subtract the constant 1 (`tendsto_atTop_add_const_right`), scale by 6 > 0 (`Tendsto.const_mul_atTop`), then `Tendsto.congr` with the closed form. The ratio running sum follows by splitting r k = 4 − δ k via `Finset.sum_sub_distrib`.",
+    "keyInsights": [
+      "**The deficit is the tail of a harmonic series.** The amount δ n = 4 − r n by which the n-th Catalan step lags the limiting rate 4 is *exactly* 6/(n+2) — a harmonic term, not a geometrically small correction. This single identity drives everything.",
+      "**A sharp convergence-versus-divergence dichotomy.** The deficits vanish individually (δ n → 0) yet their cumulative sum diverges (∑ δ k → ∞), because ∑_{k<n} 6/(k+2) = 6·(H_{n+1} − 1) is a harmonic partial sum. Convergence of the terms and convergence of their sum genuinely part ways here.",
+      "**This is why Catalan growth is sub-4^n by a polynomial factor.** Since log(catalan n / 4^n) accumulates the logarithms of the ratios r k / 4 = 1 − δ k / 4, and the deficits sum to a harmonic (divergent) series rather than a convergent one, the product ∏(r k / 4) tends to 0 — the recurrence-level reason the Stirling asymptotic carries the n^{-3/2} correction below 4^n rather than a positive constant multiple of 4^n.",
+      "**Closed form for the ratio running sum.** Summing r k = 4 − δ k gives ∑_{k<n} r k = 4n − 6·(H_{n+1} − 1), expressing the partial sums of the Catalan ratios entirely in terms of harmonic numbers."
+    ],
+    "prerequisites": [
+      "The parent ratio identity r n = 4 − 6/(n+2) for the Catalan recurrence",
+      "Harmonic numbers and divergence of the harmonic series",
+      "Limits of real sequences (Filter.Tendsto, atTop) and finite-sum manipulation"
+    ]
+  },
+  "conclusion": {
+    "summary": "The deficit δ n = 4 − r n of the Catalan recurrence ratio equals exactly 6/(n+2). Individually the deficits vanish (δ n → 0), but their running total is the harmonic partial sum ∑_{k<n} δ k = 6·(H_{n+1} − 1), which diverges to +∞. As a corollary the running sum of the ratios is ∑_{k<n} r k = 4n − 6·(H_{n+1} − 1). All nine theorems are fully machine-checked with no axioms or sorries.",
+    "implications": "The result pinpoints, purely at the level of the integer recurrence, why the Catalan numbers grow strictly slower than 4^n by a polynomial factor: the multiplicative deficits from the rate 4 are harmonic and so do not sum to a finite constant. It exhibits a clean textbook instance of the distinction between a sequence tending to 0 and its series converging, arising naturally from a combinatorial recurrence.",
+    "openQuestions": [
+      "Can the harmonic deficit sum be upgraded to the sharp two-sided estimate c·4^n/n^{3/2} ≤ catalan n ≤ 4^n by exponentiating ∑ log(1 − δ k/4) and comparing the harmonic deficit sum 6·(H_{n+1}−1) against (3/2)·log n + O(1)?",
+      "Does the analogous deficit for the central-binomial recurrence (n+1)·C(2(n+1),n+1) = 2(2n+1)·C(2n,n), namely 4 − (8n+4)/(2n+2) = 2/(n+1), sum to a harmonic series with the matching 1/2 exponent, recovering C(2n,n) ∼ 4^n/√(πn) at the recurrence level?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos396OQ04OQ01"
+    ],
+    "opens": [
+      "Nat",
+      "Filter",
+      "Topology",
+      "Finset"
+    ],
+    "namespace": "Erdos396OQ01OQ01",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "path": "Proofs/Erdos396OQ04OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-396-oq-04-oq-01",
+      "relationship": "parent",
+      "description": "Parent OQ: the asymptotics of the Catalan recurrence ratio r n = 4 − 6/(n+2), with r n < 4, strict monotonicity, and r n → 4. This follow-up studies the deficit 4 − r n and its harmonic running sum."
+    },
+    {
+      "targetId": "erdos-396-oq-04",
+      "relationship": "ancestor",
+      "description": "The two-term Catalan recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan(n), the source of the ratio whose deficit is analysed here."
+    },
+    {
+      "targetId": "erdos-396",
+      "relationship": "ancestor",
+      "description": "Root problem: descending factorials dividing central binomial coefficients, whose base case rests on the Catalan numbers."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up to **erdos-396-oq-04-oq-01** (asymptotics of the Catalan recurrence ratio `r n = 4 − 6/(n+2)`). This entry studies the **deficit** `δ n = 4 − r n`, the amount by which each multiplicative step of the Catalan recurrence falls short of the limiting growth rate `4`.

**Headline — a sharp convergence-vs-divergence dichotomy:**
- `deficit_eq`: `δ n = 6/(n+2)` exactly — the deficit is the tail of a harmonic series.
- `deficit_tendsto_zero`: `δ n → 0` — each step approaches the rate `4`.
- `deficit_sum_eq`: `∑_{k<n} δ k = 6·(H_{n+1} − 1)`, where `H m = ∑_{i<m} 1/(i+1)` — the cumulative deficit is a harmonic partial sum.
- `deficit_sum_tendsto_atTop`: `∑_{k<n} δ k → ∞` — yet the running total diverges.
- `ratio_sum_eq`: `∑_{k<n} r k = 4n − 6·(H_{n+1} − 1)` (corollary, closed form for the ratio running sum).

**Why it matters.** The deficits vanish individually but sum to a harmonic (divergent) series, so the product `∏(r k / 4)` tends to `0`. This is the precise recurrence-level reason the Catalan numbers grow strictly slower than `4^n` by a polynomial factor — the `n^{-3/2}` correction in `catalan n ∼ 4^n/(n^{3/2}√π)` — proved with no Stirling estimate.

## Verification
- **9 theorems, 2 definitions, 0 sorries, 0 axioms** (`#print axioms`: only `propext`/`Classical.choice`/`Quot.sound`; no `sorryAx`, no `Lean.ofReduceBool`/`native_decide`).
- Builds against Mathlib 4.26.0 via `./proofs/scripts/docker-build.sh Proofs.Erdos396OQ04OQ01OQ01`.
- Imports and builds on the merged parent `Proofs.Erdos396OQ04OQ01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)