### PR TITLE
research(arithmetic-series-oq-04-oq-03): ζ at negative integers from Faulhaber

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -197,6 +197,7 @@ import Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03
 import Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02
 import Proofs.ArithmeticSeriesOQ04
 import Proofs.ArithmeticSeriesOQ04OQ01
+import Proofs.ArithmeticSeriesOQ04OQ03
 import Proofs.ArsinhLogFormulaOQ01
 import Proofs.AutomorphicNumberOQ01
 import Proofs.AutomorphicNumberOQ01OQ01

--- a/proofs/Proofs/ArithmeticSeriesOQ04OQ03.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ04OQ03.lean
@@ -1,0 +1,215 @@
+import Mathlib
+
+/-
+# Arithmetic Series OQ-04 / OQ-03: Riemann ζ at negative integers from Faulhaber
+
+## The Open Question (parent OQ-04, third open question)
+
+Faulhaber's formula writes the power sum `∑_{k=1}^n k^p` as a polynomial in `n` whose
+coefficients are Bernoulli numbers. Its Bernoulli-polynomial form (Mathlib
+`Polynomial.sum_range_pow_eq_bernoulli_sub`) reads
+  `(p+1) · ∑_{k<n} k^p = B_{p+1}(n) − B_{p+1}`,
+where `B_{p+1} = B_{p+1}(0)` is the Bernoulli number subtracted off.
+
+> **Can we derive `ζ(−n) = −B_{n+1}/(n+1)` (the value of the Riemann zeta function at the
+> non-positive integers) from the power-sum formula, via analytic continuation?**
+
+## Answer
+
+**Yes.** The analytic continuation itself is carried out in Mathlib (the Hurwitz/Riemann zeta
+development), culminating in `riemannZeta_neg_nat_eq_bernoulli'`:
+  `ζ(−n) = −B'_{n+1}/(n+1)`     (with the `B'_1 = +1/2` convention),
+equivalently `riemannZeta_neg_nat_eq_bernoulli`:
+  `ζ(−n) = (−1)^n · B_{n+1}/(n+1)`.
+
+This file takes the result and makes the **Faulhaber ↔ ζ bridge explicit**:
+
+* the constant `B_{p+1}` that Faulhaber's identity subtracts off is, for `p ≥ 1`, exactly
+  `−(p+1)·ζ(−p)` (`faulhaber_constant_eq_zeta`);
+* the two Bernoulli conventions in the two Mathlib value formulas agree
+  (`bernoulli_convention_eq`);
+* the **trivial zeros** `ζ(−2n) = 0` (`n ≥ 1`) come directly from the vanishing of the odd
+  Bernoulli numbers `B'_{2n+1} = 0` (`zeta_neg_even`);
+* the famous special values `ζ(0) = −1/2`, `ζ(−1) = −1/12`, `ζ(−2) = 0`, `ζ(−3) = 1/120`
+  drop out of the same formula by reading off `B'_1, B'_2, B'_3, B'_4`.
+
+The identity `ζ(−1) = −1/12` is the rigorous shadow of the (divergent) "1 + 2 + 3 + ⋯ = −1/12":
+it is the regularized constant left over when the leading Faulhaber polynomial `½n(n+1)` is
+analytically continued.
+
+## Honest scope
+
+The hard analytic core — the functional equation and the continuation of `ζ` to `ℂ` — is
+Mathlib's. The new content here is the algebraic bridge identifying the subtracted Faulhaber
+constant with `(p+1)·ζ(−p)`, the convention reconciliation, and the closed list of consequences.
+
+Tags: number-theory, bernoulli, riemann-zeta, power-sums, faulhaber, analytic-continuation
+-/
+
+noncomputable section
+
+namespace ArithmeticSeriesOQ04OQ03
+
+open scoped Polynomial
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I: THE VALUE FORMULA — ζ(−n) IN TERMS OF BERNOULLI NUMBERS
+
+The answer to the open question, in both Mathlib conventions.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- **ζ at negative integers (B′ convention)**: `ζ(−n) = −B'_{n+1}/(n+1)`.
+
+    This is the classical formula `ζ(−n) = −B_{n+1}/(n+1)` of the open question, with the
+    `B'_1 = +1/2` convention. Direct restatement of Mathlib's
+    `riemannZeta_neg_nat_eq_bernoulli'`, the endpoint of the analytic continuation. -/
+theorem zeta_neg_nat (n : ℕ) :
+    riemannZeta (-(n : ℂ)) = -(bernoulli' (n + 1) : ℂ) / ((n : ℂ) + 1) :=
+  riemannZeta_neg_nat_eq_bernoulli' n
+
+/-- **ζ at negative integers (B convention)**: `ζ(−n) = (−1)^n · B_{n+1}/(n+1)`.
+
+    The sign `(−1)^n` absorbs the `B_1 = −1/2` vs `B'_1 = +1/2` difference. Restatement of
+    Mathlib's `riemannZeta_neg_nat_eq_bernoulli`. -/
+theorem zeta_neg_nat_bernoulli (n : ℕ) :
+    riemannZeta (-(n : ℂ)) = (-1) ^ n * (bernoulli (n + 1) : ℂ) / ((n : ℂ) + 1) :=
+  riemannZeta_neg_nat_eq_bernoulli n
+
+/-- The two value formulas agree: `−B'_{n+1} = (−1)^n · B_{n+1}`. This is the numerator
+    reconciliation of `zeta_neg_nat` and `zeta_neg_nat_bernoulli`, from
+    `bernoulli' m = (−1)^m · B_m`. -/
+theorem bernoulli_convention_eq (n : ℕ) :
+    -(bernoulli' (n + 1) : ℂ) = (-1) ^ n * (bernoulli (n + 1) : ℂ) := by
+  rw [show bernoulli' (n + 1) = (-1) ^ (n + 1) * bernoulli (n + 1) from
+        bernoulli'_eq_bernoulli (n + 1)]
+  push_cast
+  ring
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II: THE FAULHABER ↔ ζ BRIDGE
+
+Faulhaber's polynomial identity subtracts the constant `B_{p+1}`. For p ≥ 1 that
+constant is exactly `−(p+1)·ζ(−p)`.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- Faulhaber's Bernoulli-polynomial identity (Mathlib `sum_range_pow_eq_bernoulli_sub`):
+    `(p+1)·∑_{k<n} k^p = B_{p+1}(n) − B_{p+1}`. The subtracted constant `B_{p+1}` is the
+    object the bridge below identifies with `−(p+1)·ζ(−p)`. -/
+theorem faulhaber_sum_eq (n p : ℕ) :
+    ((p + 1 : ℚ) * ∑ k ∈ Finset.range n, (k : ℚ) ^ p) =
+      (Polynomial.bernoulli p.succ).eval (n : ℚ) - bernoulli p.succ :=
+  Polynomial.sum_range_pow_eq_bernoulli_sub n p
+
+/-- The subtracted constant equals the constant term of the Bernoulli polynomial:
+    `B_{p+1} = B_{p+1}(0)`. (Mathlib `Polynomial.bernoulli_eval_zero`.) -/
+theorem faulhaber_constant_is_eval_zero (p : ℕ) :
+    (Polynomial.bernoulli p.succ).eval 0 = bernoulli p.succ :=
+  Polynomial.bernoulli_eval_zero p.succ
+
+/-- **Clearing the denominator in the value formula**: for `p ≥ 1`,
+    `(p+1)·ζ(−p) = −B_{p+1}`. (For `p ≥ 1` the two Bernoulli conventions coincide, since
+    `B'_{p+1} = B_{p+1}` for `p+1 ≠ 1`.) -/
+theorem zeta_neg_nat_mul (p : ℕ) (hp : 1 ≤ p) :
+    ((p : ℂ) + 1) * riemannZeta (-(p : ℂ)) = -(bernoulli (p + 1) : ℂ) := by
+  have hne : ((p : ℂ) + 1) ≠ 0 := by
+    have : ((p : ℂ) + 1) = ((p + 1 : ℕ) : ℂ) := by push_cast; ring
+    rw [this]; exact_mod_cast Nat.succ_ne_zero p
+  rw [riemannZeta_neg_nat_eq_bernoulli', bernoulli_eq_bernoulli'_of_ne_one (by omega : p + 1 ≠ 1)]
+  field_simp
+
+/-- **The Faulhaber ↔ ζ bridge.** For `p ≥ 1`, the constant `B_{p+1}` that Faulhaber's
+    identity `(p+1)·∑_{k<n} k^p = B_{p+1}(n) − B_{p+1}` subtracts off is exactly
+    `−(p+1)·ζ(−p)`. Thus the analytically-continued zeta value is, up to the factor `(p+1)`
+    and a sign, the "missing constant term" of the power-sum polynomial. -/
+theorem faulhaber_constant_eq_zeta (p : ℕ) (hp : 1 ≤ p) :
+    (bernoulli (p + 1) : ℂ) = -(((p : ℂ) + 1) * riemannZeta (-(p : ℂ))) := by
+  rw [zeta_neg_nat_mul p hp, neg_neg]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III: THE TRIVIAL ZEROS — ζ(−2n) = 0
+
+Direct from the vanishing of the odd Bernoulli numbers B'_{2n+1} = 0 (n ≥ 1).
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- **Trivial zeros of ζ**: `ζ(−2n) = 0` for `n ≥ 1`.
+
+    From `zeta_neg_nat`, `ζ(−2n) = −B'_{2n+1}/(2n+1)`, and `B'_{2n+1} = 0` because `2n+1`
+    is odd and `> 1`. These are exactly the trivial zeros at the negative even integers. -/
+theorem zeta_neg_even (n : ℕ) (hn : 1 ≤ n) :
+    riemannZeta (-((2 * n : ℕ) : ℂ)) = 0 := by
+  rw [riemannZeta_neg_nat_eq_bernoulli',
+    bernoulli'_eq_zero_of_odd ⟨n, by ring⟩ (by omega : 1 < 2 * n + 1)]
+  simp
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV: SPECIAL VALUES
+
+ζ(0) = −1/2, ζ(−1) = −1/12, ζ(−2) = 0, ζ(−3) = 1/120 — read off from B'_1..B'_4.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- `ζ(0) = −1/2`, derived from the value formula: `ζ(0) = −B'_1/1 = −1/2`. -/
+theorem zeta_zero : riemannZeta 0 = -1 / 2 := by
+  have h := riemannZeta_neg_nat_eq_bernoulli' 0
+  rw [bernoulli'_one] at h
+  rw [show (0 : ℂ) = -((0 : ℕ) : ℂ) by norm_num, h]
+  push_cast
+  norm_num
+
+/-- `ζ(−1) = −1/12`, from `ζ(−1) = −B'_2/2 = −(1/6)/2`.
+
+    This is the rigorous form of the regularized sum `1 + 2 + 3 + ⋯ "=" −1/12`. -/
+theorem zeta_neg_one : riemannZeta (-(1 : ℂ)) = -1 / 12 := by
+  have h := riemannZeta_neg_nat_eq_bernoulli' 1
+  rw [bernoulli'_two] at h
+  rw [show (-(1 : ℂ)) = -((1 : ℕ) : ℂ) by norm_num, h]
+  push_cast
+  norm_num
+
+/-- `ζ(−2) = 0` — the first trivial zero. -/
+theorem zeta_neg_two : riemannZeta (-(2 : ℂ)) = 0 := by
+  rw [show (-(2 : ℂ)) = -((2 * 1 : ℕ) : ℂ) by norm_num]
+  exact zeta_neg_even 1 le_rfl
+
+/-- `ζ(−3) = 1/120`, from `ζ(−3) = −B'_4/4 = −(−1/30)/4`. -/
+theorem zeta_neg_three : riemannZeta (-(3 : ℂ)) = 1 / 120 := by
+  have h := riemannZeta_neg_nat_eq_bernoulli' 3
+  rw [bernoulli'_four] at h
+  rw [show (-(3 : ℂ)) = -((3 : ℕ) : ℂ) by norm_num, h]
+  push_cast
+  norm_num
+
+end ArithmeticSeriesOQ04OQ03
+
+end -- noncomputable section
+
+/-
+## Summary
+
+Answering parent OQ-04's third open question — deriving `ζ(−n) = −B_{n+1}/(n+1)` from the
+power-sum / Faulhaber formula via analytic continuation:
+
+**Value formula** (Mathlib endpoint of the analytic continuation):
+- `zeta_neg_nat`:            `ζ(−n) = −B'_{n+1}/(n+1)`        (B′ convention, `B'_1 = +1/2`)
+- `zeta_neg_nat_bernoulli`:  `ζ(−n) = (−1)^n·B_{n+1}/(n+1)`   (B convention)
+- `bernoulli_convention_eq`: the two numerators agree.
+
+**Faulhaber ↔ ζ bridge** (the new content):
+- `faulhaber_sum_eq`:           `(p+1)·∑_{k<n} k^p = B_{p+1}(n) − B_{p+1}`.
+- `zeta_neg_nat_mul`:           `(p+1)·ζ(−p) = −B_{p+1}` for `p ≥ 1`.
+- `faulhaber_constant_eq_zeta`: the subtracted constant `B_{p+1}` equals `−(p+1)·ζ(−p)`.
+
+**Trivial zeros**: `zeta_neg_even`: `ζ(−2n) = 0` for `n ≥ 1`, from `B'_{2n+1} = 0`.
+
+**Special values**: `ζ(0) = −1/2`, `ζ(−1) = −1/12`, `ζ(−2) = 0`, `ζ(−3) = 1/120`.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`. The analytic continuation
+is Mathlib's; the bridge and consequences are the contribution.
+-/

--- a/src/data/proofs/arithmetic-series-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-04-oq-03/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ann-value-formula",
+    "proofId": "arithmetic-series-oq-04-oq-03",
+    "range": {
+      "startLine": 60,
+      "endLine": 64
+    },
+    "type": "concept",
+    "title": "The Value Formula as the Endpoint of Analytic Continuation",
+    "content": "`zeta_neg_nat` is a clean restatement of Mathlib's `riemannZeta_neg_nat_eq_bernoulli'`: ζ(−n) = −B'_{n+1}/(n+1). This single line is the literal answer to the parent's open question. The hard work — meromorphically continuing ζ from the half-plane Re(s) > 1 to all of ℂ and proving the functional equation — lives entirely in Mathlib's Hurwitz/Riemann zeta development. The gallery contribution is to expose this endpoint with a clear name and then connect it back to the power-sum origin."
+  },
+  {
+    "id": "ann-convention",
+    "proofId": "arithmetic-series-oq-04-oq-03",
+    "range": {
+      "startLine": 75,
+      "endLine": 88
+    },
+    "type": "insight",
+    "title": "Two Conventions, One Value",
+    "content": "Mathlib ships the value formula twice: ζ(−n) = −B'_{n+1}/(n+1) (with B'_1 = +1/2) and ζ(−n) = (−1)^n·B_{n+1}/(n+1) (with B_1 = −1/2). `bernoulli_convention_eq` proves the numerators agree using B'_m = (−1)^m·B_m. The conventions differ only at the m = 1 entry, which is precisely why ζ(0) = −B'_1 = −1/2 needs the sign correction (−1)^0·B_1 = −1/2 to match."
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "arithmetic-series-oq-04-oq-03",
+    "range": {
+      "startLine": 124,
+      "endLine": 147
+    },
+    "type": "insight",
+    "title": "ζ(−p) Is the Missing Constant Term of the Faulhaber Polynomial",
+    "content": "Faulhaber's identity reads (p+1)·∑_{k<n} k^p = B_{p+1}(n) − B_{p+1}: the power-sum polynomial is the Bernoulli polynomial minus its constant term B_{p+1} = B_{p+1}(0), enforcing that the sum vanishes at n = 0. The theorem `faulhaber_constant_eq_zeta` shows this subtracted constant is exactly −(p+1)·ζ(−p) (for p ≥ 1). So the analytically-continued zeta value is, up to the factor (p+1) and a sign, the constant the power-sum polynomial 'wants but cannot have'. This is the algebraic heart of zeta-regularization."
+  },
+  {
+    "id": "ann-zeta-neg-one",
+    "proofId": "arithmetic-series-oq-04-oq-03",
+    "range": {
+      "startLine": 188,
+      "endLine": 196
+    },
+    "type": "insight",
+    "title": "ζ(−1) = −1/12 and 1 + 2 + 3 + ⋯",
+    "content": "Reading the (divergent) series 1 + 2 + 3 + ⋯ as ∑ k = ζ(−1), the regularized value is −1/12, obtained here as −B'_2/2 = −(1/6)/2. Through the bridge, −1/12 is the constant left over from the p = 1 Faulhaber polynomial ½n(n+1). This is the value that famously appears in the Casimir effect and in the bosonic-string critical dimension 26, where 1 + 2 + ⋯ + 24 is regularized to −1."
+  },
+  {
+    "id": "ann-trivial-zeros",
+    "proofId": "arithmetic-series-oq-04-oq-03",
+    "range": {
+      "startLine": 156,
+      "endLine": 168
+    },
+    "type": "concept",
+    "title": "Trivial Zeros Are Vanishing Odd Bernoulli Numbers",
+    "content": "`zeta_neg_even` proves ζ(−2n) = 0 for n ≥ 1 not by an analytic argument but by reading the value formula: ζ(−2n) = −B'_{2n+1}/(2n+1), and B'_{2n+1} = 0 because 2n+1 is odd and exceeds 1. These are precisely the trivial zeros of ζ at the negative even integers — the ones excluded from the Riemann Hypothesis, which concerns the nontrivial zeros on the critical line Re(s) = 1/2."
+  }
+]

--- a/src/data/proofs/arithmetic-series-oq-04-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-04-oq-03/meta.json
@@ -1,0 +1,221 @@
+{
+  "id": "arithmetic-series-oq-04-oq-03",
+  "title": "ζ at Negative Integers from Faulhaber: ζ(−n) = −B_{n+1}/(n+1)",
+  "slug": "arithmetic-series-oq-04-oq-03",
+  "description": "Answers parent OQ-04's third open question: derive the Riemann zeta values at the non-positive integers, ζ(−n) = −B'_{n+1}/(n+1), from the power-sum / Faulhaber formula via analytic continuation. The analytic continuation is Mathlib's (riemannZeta_neg_nat_eq_bernoulli'); this file makes the Faulhaber↔ζ bridge explicit — the constant B_{p+1} subtracted in Faulhaber's polynomial identity is exactly −(p+1)·ζ(−p) — and derives the trivial zeros ζ(−2n)=0 and the special values ζ(0)=−1/2, ζ(−1)=−1/12, ζ(−2)=0, ζ(−3)=1/120.",
+  "meta": {
+    "author": "Bernhard Riemann (1859); Leonhard Euler (functional equation, 1749); formalized in Lean 4",
+    "date": "1859",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArithmeticSeriesOQ04OQ03.lean",
+    "tags": [
+      "number-theory",
+      "bernoulli",
+      "riemann-zeta",
+      "power-sums",
+      "faulhaber",
+      "analytic-continuation",
+      "arithmetic-series"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 215,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, no `native_decide`. `#print axioms` reports only the three ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted under the project's axiom-integrity policy. The deep analytic content — the meromorphic continuation of the Riemann zeta function and the functional equation, culminating in `riemannZeta_neg_nat_eq_bernoulli'` — is supplied by Mathlib. The new content here (the Faulhaber↔ζ bridge, convention reconciliation, trivial zeros, and special values) is fully machine-checked over ℂ.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "riemannZeta_neg_nat_eq_bernoulli'",
+        "description": "ζ(−n) = −B'_{n+1}/(n+1), the endpoint of the analytic continuation (B'_1 = +1/2 convention)",
+        "module": "Mathlib.NumberTheory.LSeries.HurwitzZetaValues"
+      },
+      {
+        "theorem": "riemannZeta_neg_nat_eq_bernoulli",
+        "description": "ζ(−n) = (−1)^n·B_{n+1}/(n+1) (B_1 = −1/2 convention)",
+        "module": "Mathlib.NumberTheory.LSeries.HurwitzZetaValues"
+      },
+      {
+        "theorem": "Polynomial.sum_range_pow_eq_bernoulli_sub",
+        "description": "(p+1)·∑_{k<n} k^p = B_{p+1}(n) − B_{p+1}, the Bernoulli-polynomial form of Faulhaber's formula",
+        "module": "Mathlib.NumberTheory.BernoulliPolynomials"
+      },
+      {
+        "theorem": "bernoulli'_eq_bernoulli",
+        "description": "B'_n = (−1)^n·B_n, reconciling the two Bernoulli conventions",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli'_eq_zero_of_odd",
+        "description": "B'_n = 0 for odd n > 1, the source of the trivial zeros",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli_eq_bernoulli'_of_ne_one",
+        "description": "B_n = B'_n for n ≠ 1, used to collapse the conventions for p ≥ 1",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      }
+    ],
+    "dateAdded": "2026-06-21",
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Riemann zeta function ζ(s) = ∑ 1/n^s, convergent for Re(s) > 1, was continued to the whole complex plane (minus a simple pole at s = 1) by Bernhard Riemann in his 1859 memoir. Euler had already, in 1749, conjectured the functional equation relating ζ(s) and ζ(1−s) and computed values like ζ(−1) = −1/12 by audacious manipulation of divergent series. The values at the non-positive integers are rational and given by Bernoulli numbers: ζ(−n) = −B_{n+1}/(n+1). The even negative integers −2, −4, −6, … are the 'trivial zeros' of ζ (where odd Bernoulli numbers vanish), to be contrasted with the conjectured nontrivial zeros on the critical line Re(s) = 1/2.\n\nThe connection to power sums is not a coincidence. Faulhaber's formula expresses ∑_{k=1}^n k^p as a degree-(p+1) polynomial in n whose coefficients are Bernoulli numbers; ζ(−p) is, up to the factor (p+1) and a sign, the constant term that this polynomial 'wants' but cannot have (the power sum vanishes at n = 0). Reading 1 + 2 + 3 + ⋯ as the divergent value ζ(−1), the regularized answer −1/12 is exactly this leftover constant.",
+    "problemStatement": "**Open Question (parent arithmetic-series-oq-04, third open question)**: Can we derive ζ(−n) = −B_{n+1}/(n+1) from the power-sum formula via analytic continuation?\n\n**Answer: YES.** The continuation is carried out in Mathlib (`riemannZeta_neg_nat_eq_bernoulli'`: ζ(−n) = −B'_{n+1}/(n+1)). This file makes the bridge to Faulhaber explicit and reads off the trivial zeros and special values.",
+    "text": "A 215-line, fully verified (0 sorries, 0 axioms, no native_decide) formalization over ℂ. Part I restates the value formula in both Bernoulli conventions and proves they agree. Part II is the new content: Faulhaber's polynomial identity (p+1)·∑_{k<n} k^p = B_{p+1}(n) − B_{p+1}, the clearing of denominators (p+1)·ζ(−p) = −B_{p+1} for p ≥ 1, and the bridge theorem identifying the subtracted constant with −(p+1)·ζ(−p). Part III derives the trivial zeros ζ(−2n) = 0 (n ≥ 1) from B'_{2n+1} = 0. Part IV reads off ζ(0) = −1/2, ζ(−1) = −1/12, ζ(−2) = 0, ζ(−3) = 1/120.",
+    "proofStrategy": "The value formula is Mathlib's `riemannZeta_neg_nat_eq_bernoulli'`, the endpoint of its Hurwitz/Riemann zeta analytic-continuation development. The convention reconciliation `bernoulli_convention_eq` uses `bernoulli'_eq_bernoulli` then `push_cast; ring`. The denominator-clearing `zeta_neg_nat_mul` rewrites with the value formula, collapses B' to B via `bernoulli_eq_bernoulli'_of_ne_one` (valid since p+1 ≠ 1 for p ≥ 1), and finishes with `field_simp`; the bridge `faulhaber_constant_eq_zeta` is then one `neg_neg`. The trivial zeros follow by feeding `Odd (2n+1)` and `1 < 2n+1` to `bernoulli'_eq_zero_of_odd`. Each special value rewrites the integer argument as a `Nat` cast, applies the value formula, and closes with `push_cast; norm_num` after substituting the relevant Bernoulli value (B'_1 = 1/2, B'_2 = 1/6, B'_4 = −1/30).",
+    "keyInsights": [
+      "ζ(−n) = −B'_{n+1}/(n+1) is the literal answer to the open question; Mathlib has it as `riemannZeta_neg_nat_eq_bernoulli'`, so the analytic continuation is already done.",
+      "The bridge to Faulhaber is algebraic: the constant B_{p+1} subtracted in (p+1)·∑_{k<n} k^p = B_{p+1}(n) − B_{p+1} is exactly −(p+1)·ζ(−p) (for p ≥ 1). The zeta value is the 'missing constant term' of the power-sum polynomial.",
+      "ζ(−1) = −1/12 is the rigorous shadow of 1 + 2 + 3 + ⋯ '=' −1/12: it is the regularized constant left over from the Faulhaber polynomial ½n(n+1).",
+      "The trivial zeros ζ(−2n) = 0 (n ≥ 1) are not analytic accidents — they are the vanishing of the odd Bernoulli numbers B'_{2n+1} = 0, visible directly in the value formula.",
+      "The two Mathlib conventions ζ(−n) = −B'_{n+1}/(n+1) and ζ(−n) = (−1)^n·B_{n+1}/(n+1) agree because B'_m = (−1)^m·B_m; only the B_1 = ∓1/2 entry differs, which is why ζ(0) needs the sign."
+    ],
+    "prerequisites": [
+      "Riemann zeta function and its analytic continuation (used as a black box from Mathlib)",
+      "Bernoulli numbers, both conventions B and B'",
+      "Faulhaber's formula and its Bernoulli-polynomial form",
+      "Complex-number coercions and Finset sums in Lean 4/Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "value-formula",
+      "title": "Part I: The Value Formula ζ(−n) = −B_{n+1}/(n+1)",
+      "startLine": 53,
+      "endLine": 88,
+      "summary": "zeta_neg_nat: ζ(−n) = −B'_{n+1}/(n+1) (alias of Mathlib's riemannZeta_neg_nat_eq_bernoulli'). zeta_neg_nat_bernoulli: the (−1)^n·B_{n+1} form. bernoulli_convention_eq: the two numerators agree via B'_m = (−1)^m·B_m.",
+      "mathContext": "The answer to the open question. Mathlib's analytic continuation gives ζ(−n) = −B'_{n+1}/(n+1) with the B'_1 = +1/2 convention, equivalently ζ(−n) = (−1)^n·B_{n+1}/(n+1)."
+    },
+    {
+      "id": "faulhaber-bridge",
+      "title": "Part II: The Faulhaber ↔ ζ Bridge",
+      "startLine": 90,
+      "endLine": 147,
+      "summary": "faulhaber_sum_eq: (p+1)·∑_{k<n} k^p = B_{p+1}(n) − B_{p+1}. faulhaber_constant_is_eval_zero: B_{p+1} = B_{p+1}(0). zeta_neg_nat_mul: (p+1)·ζ(−p) = −B_{p+1} for p ≥ 1. faulhaber_constant_eq_zeta: the subtracted constant B_{p+1} equals −(p+1)·ζ(−p).",
+      "mathContext": "The new content: the constant that Faulhaber's polynomial subtracts off is, up to the factor (p+1) and a sign, the analytically-continued zeta value. This is the precise sense in which ζ(−p) 'is' the regularized power sum."
+    },
+    {
+      "id": "trivial-zeros",
+      "title": "Part III: The Trivial Zeros ζ(−2n) = 0",
+      "startLine": 149,
+      "endLine": 168,
+      "summary": "zeta_neg_even: ζ(−2n) = 0 for n ≥ 1, from the value formula and the vanishing of the odd Bernoulli number B'_{2n+1} = 0.",
+      "mathContext": "The trivial zeros of ζ at the negative even integers are exactly the zeros of the odd Bernoulli numbers, read straight off the value formula."
+    },
+    {
+      "id": "special-values",
+      "title": "Part IV: Special Values",
+      "startLine": 170,
+      "endLine": 208,
+      "summary": "zeta_zero: ζ(0) = −1/2. zeta_neg_one: ζ(−1) = −1/12. zeta_neg_two: ζ(−2) = 0. zeta_neg_three: ζ(−3) = 1/120.",
+      "mathContext": "The classical special values, each obtained by reading off the relevant Bernoulli number (B'_1 = 1/2, B'_2 = 1/6, B'_4 = −1/30). ζ(−1) = −1/12 is the rigorous form of 1 + 2 + 3 + ⋯ '=' −1/12."
+    }
+  ],
+  "conclusion": {
+    "summary": "Parent OQ-04's third open question is answered affirmatively: ζ(−n) = −B'_{n+1}/(n+1) is the endpoint of Mathlib's analytic continuation. This file pins down the precise link to Faulhaber's formula — the subtracted constant B_{p+1} is −(p+1)·ζ(−p) — and reads off the trivial zeros and the special values ζ(0) = −1/2, ζ(−1) = −1/12, ζ(−2) = 0, ζ(−3) = 1/120.",
+    "implications": "The identification of ζ(−p) with the missing constant term of the Faulhaber polynomial is the algebraic heart of zeta-regularization: it explains why 1 + 2 + 3 + ⋯ is assigned −1/12 and why the power-sum polynomials encode the zeta values at negative integers. The trivial zeros are the vanishing odd Bernoulli numbers. Via the functional equation these negative-integer values are dual to the even-integer values ζ(2k) = (−1)^{k+1}·2^{2k−1}·π^{2k}·B_{2k}/(2k)! also in Mathlib.",
+    "openQuestions": [
+      "Can the Faulhaber ↔ ζ bridge be lifted to the full functional equation, relating ζ(−p) to ζ(p+1) for all p?",
+      "Can the same regularization be formalized for the Hurwitz zeta function ζ(s, a), recovering the Bernoulli polynomials B_{p+1}(a) rather than just the constant B_{p+1}?",
+      "Can ζ(−1) = −1/12 be connected formally to its appearances in the Casimir effect and bosonic string theory (critical dimension 26)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "arithmetic-series-oq-04",
+      "relationship": "extends",
+      "description": "Parent: Faulhaber's formula for power sums via Bernoulli numbers. This entry answers its third open question."
+    },
+    {
+      "targetId": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "The trivial zeros ζ(−2n) = 0 proved here are exactly the trivial zeros excluded from the Riemann Hypothesis statement about nontrivial zeros on Re(s) = 1/2."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial (scoped)"
+    ],
+    "namespace": "ArithmeticSeriesOQ04OQ03",
+    "lineCount": 215,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "zeta_neg_nat",
+        "type": "core",
+        "description": "ζ(−n) = −B'_{n+1}/(n+1), the value formula answering the open question",
+        "leanType": "(n : ℕ) → riemannZeta (-(n : ℂ)) = -(bernoulli' (n + 1) : ℂ) / ((n : ℂ) + 1)"
+      },
+      {
+        "name": "faulhaber_constant_eq_zeta",
+        "type": "key",
+        "description": "The constant B_{p+1} subtracted in Faulhaber's identity equals −(p+1)·ζ(−p) for p ≥ 1",
+        "leanType": "(p : ℕ) → 1 ≤ p → (bernoulli (p + 1) : ℂ) = -(((p : ℂ) + 1) * riemannZeta (-(p : ℂ)))"
+      },
+      {
+        "name": "zeta_neg_even",
+        "type": "key",
+        "description": "Trivial zeros: ζ(−2n) = 0 for n ≥ 1, from B'_{2n+1} = 0",
+        "leanType": "(n : ℕ) → 1 ≤ n → riemannZeta (-((2 * n : ℕ) : ℂ)) = 0"
+      }
+    ],
+    "path": "Proofs/ArithmeticSeriesOQ04OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "zeta_neg_nat",
+      "type": "core",
+      "description": "ζ(−n) = −B'_{n+1}/(n+1), the answer to the open question (alias of riemannZeta_neg_nat_eq_bernoulli')",
+      "leanType": "(n : ℕ) → riemannZeta (-(n : ℂ)) = -(bernoulli' (n + 1) : ℂ) / ((n : ℂ) + 1)"
+    },
+    {
+      "name": "zeta_neg_nat_mul",
+      "type": "key",
+      "description": "(p+1)·ζ(−p) = −B_{p+1} for p ≥ 1, clearing the denominator",
+      "leanType": "(p : ℕ) → 1 ≤ p → ((p : ℂ) + 1) * riemannZeta (-(p : ℂ)) = -(bernoulli (p + 1) : ℂ)"
+    },
+    {
+      "name": "faulhaber_constant_eq_zeta",
+      "type": "key",
+      "description": "The Faulhaber ↔ ζ bridge: subtracted constant B_{p+1} = −(p+1)·ζ(−p)",
+      "leanType": "(p : ℕ) → 1 ≤ p → (bernoulli (p + 1) : ℂ) = -(((p : ℂ) + 1) * riemannZeta (-(p : ℂ)))"
+    },
+    {
+      "name": "zeta_neg_one",
+      "type": "key",
+      "description": "ζ(−1) = −1/12, the rigorous form of 1 + 2 + 3 + ⋯ '=' −1/12",
+      "leanType": "riemannZeta (-(1 : ℂ)) = -1 / 12"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Riemann, Bernhard",
+      "title": "Ueber die Anzahl der Primzahlen unter einer gegebenen Grösse",
+      "year": "1859",
+      "venue": "Monatsberichte der Berliner Akademie",
+      "note": "Introduces the analytic continuation and functional equation of ζ(s), the basis for evaluating ζ at negative integers"
+    },
+    {
+      "authors": "Euler, Leonhard",
+      "title": "Remarques sur un beau rapport entre les séries des puissances tant directes que réciproques",
+      "year": "1749",
+      "venue": "Mémoires de l'Académie des Sciences de Berlin",
+      "note": "Conjectures the functional equation and computes ζ(−n) values, including the (regularized) ζ(−1) = −1/12"
+    },
+    {
+      "authors": "Ireland, Kenneth; Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "Springer GTM 84, 2nd edition",
+      "note": "Chapter 15 derives ζ(−n) = −B_{n+1}/(n+1) from the power-sum formula and Bernoulli numbers, the algebraic route formalized here"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers parent **arithmetic-series-oq-04**'s third open question: *derive ζ(−n) = −B_{n+1}/(n+1) from the power-sum / Faulhaber formula via analytic continuation*.

The meromorphic continuation and functional equation are Mathlib's (`riemannZeta_neg_nat_eq_bernoulli'`). The new content is the explicit **Faulhaber ↔ ζ bridge** plus the consequences.

**`ArithmeticSeriesOQ04OQ03.lean`** — 215 lines, 12 theorems, 0 defs, **0 sorries, 0 axioms, no `native_decide`** (`#print axioms` → only propext/Classical.choice/Quot.sound).

### Part I — the value formula (OQ answer)
- `zeta_neg_nat`: ζ(−n) = −B'_{n+1}/(n+1)  (B′ convention)
- `zeta_neg_nat_bernoulli`: ζ(−n) = (−1)^n·B_{n+1}/(n+1)  (B convention)
- `bernoulli_convention_eq`: the two numerators agree (B'_m = (−1)^m·B_m)

### Part II — the Faulhaber ↔ ζ bridge (new content)
- `faulhaber_sum_eq`: (p+1)·∑_{k<n} k^p = B_{p+1}(n) − B_{p+1}
- `zeta_neg_nat_mul`: (p+1)·ζ(−p) = −B_{p+1} for p ≥ 1
- `faulhaber_constant_eq_zeta`: **the subtracted constant B_{p+1} is exactly −(p+1)·ζ(−p)** — ζ(−p) is the "missing constant term" of the power-sum polynomial

### Part III — trivial zeros
- `zeta_neg_even`: ζ(−2n) = 0 (n ≥ 1), straight from B'_{2n+1} = 0

### Part IV — special values
- ζ(0) = −1/2, ζ(−1) = −1/12 (the rigorous "1+2+3+⋯ = −1/12"), ζ(−2) = 0, ζ(−3) = 1/120

## Honest scope
The hard analytic core (continuation + functional equation) is Mathlib's. The contribution is the algebraic bridge identifying the subtracted Faulhaber constant with (p+1)·ζ(−p), the convention reconciliation, and the closed list of consequences — all machine-checked over ℂ.

## Verification
`./proofs/scripts/docker-build.sh Proofs.ArithmeticSeriesOQ04OQ03` → Build completed successfully (7743 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)