### PR TITLE
research(erdos-396-oq-04-oq-01-oq-01-oq-01): Catalan as a telescoping product of recurrence ratios

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1650,6 +1650,7 @@ import Proofs.Erdos396OQ04
 import Proofs.Erdos396OQ04OQ01
 import Proofs.Erdos396OQ04OQ01OQ01
 import Proofs.Erdos396OQ04OQ01OQ01OQ02
+import Proofs.Erdos396OQ04OQ01OQ01OQ01
 import Proofs.Erdos396Problem
 import Proofs.Erdos397Problem
 import Proofs.Erdos398Problem

--- a/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ01.lean
@@ -1,0 +1,162 @@
+/-
+# Erdős Problem #396 — OQ-04 → OQ-01 → OQ-01 → OQ-01: Catalan as a telescoping product of recurrence ratios
+
+The grandparent entry `Erdos396OQ04OQ01` reads the two-term Catalan recurrence
+as a statement about the **ratio** of consecutive Catalan numbers,
+
+  `r n = (4n+2)/(n+2) = 4 − 6/(n+2)`,        with `catalan (n+1) = r n · catalan n`,
+
+and the parent `Erdos396OQ04OQ01OQ01` studies the *additive* running total of the
+ratios, `∑_{k<n} r k = 4n − 6·(H_{n+1} − 1)`.
+
+This follow-up takes the **multiplicative** view that the recurrence itself
+suggests. Because each step multiplies by `r k`, the recurrence telescopes into a
+closed product
+
+* **`catalan_eq_prod_ratio`** : `(catalan n : ℝ) = ∏_{k<n} r k` — the Catalan
+  number *is* the product of the first `n` recurrence ratios.
+
+This is the exact multiplicative companion of the parent's sum identity, and the
+two are bridged by the logarithm:
+
+* **`log_catalan_eq_sum_log_ratio`** : `log (catalan n) = ∑_{k<n} log (r k)`.
+
+Reading the product against the limiting rate `4` gives the normalized Catalan
+sequence as a product of factors below `1`:
+
+* **`catalan_div_four_pow_eq_prod`** : `catalan n / 4^n = ∏_{k<n} (r k / 4)`, each
+  factor `r k / 4 < 1` (**`ratio_div_four_lt_one`**), so
+* **`catalan_div_four_pow_strictAnti`** : `catalan (n+1)/4^{n+1} < catalan n/4^n`
+  — the normalized sequence `catalan n / 4^n` is **strictly decreasing**, the
+  multiplicative shadow of the polynomial correction in `catalan n ∼ 4^n/(n^{3/2}√π)`.
+
+The product form also recovers the grandparent's growth bound directly:
+
+* **`prod_ratio_lt_four_pow`** : `∏_{k<n} r k < 4^n` for `n ≥ 1`, i.e.
+  `catalan n < 4^n`, now as a strict product inequality (every factor `< 4`).
+
+Everything is derived from the grandparent's ratio identities by telescoping; no
+Stirling estimate or central-binomial bound is used.
+
+Reference: https://erdosproblems.com/396
+-/
+
+import Mathlib
+import Proofs.Erdos396OQ04OQ01
+
+open Nat Filter Topology Finset
+
+namespace Erdos396OQ01OQ01OQ01
+
+open Erdos396OQ01
+
+/- ## The telescoping product -/
+
+/-- **Telescoping product identity.** `(catalan n : ℝ) = ∏_{k<n} r k`: the `n`-th
+    Catalan number is exactly the product of the first `n` recurrence ratios.
+    Each step of the recurrence multiplies by `r k`, so the recurrence collapses
+    to a finite product. -/
+theorem catalan_eq_prod_ratio (n : ℕ) :
+    (catalan n : ℝ) = ∏ k ∈ Finset.range n, catalanRatio k := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [Finset.prod_range_succ, ← ih, catalan_succ_eq_ratio_mul]
+    ring
+
+/-- The product of ratios is strictly positive. -/
+theorem prod_ratio_pos (n : ℕ) : 0 < ∏ k ∈ Finset.range n, catalanRatio k :=
+  Finset.prod_pos (fun k _ => ratio_pos k)
+
+/-- `catalan n / 4^n > 0`. -/
+theorem catalan_div_four_pow_pos (n : ℕ) : 0 < (catalan n : ℝ) / 4 ^ n := by
+  apply _root_.div_pos
+  · exact_mod_cast catalan_pos n
+  · positivity
+
+/- ## The sum–product bridge -/
+
+/-- **Logarithmic bridge.** `log (catalan n) = ∑_{k<n} log (r k)`. The logarithm
+    converts the telescoping product into the parent's additive running total of
+    the (log-)ratios. -/
+theorem log_catalan_eq_sum_log_ratio (n : ℕ) :
+    Real.log (catalan n) = ∑ k ∈ Finset.range n, Real.log (catalanRatio k) := by
+  rw [catalan_eq_prod_ratio, Real.log_prod]
+  intro k _
+  exact (ratio_pos k).ne'
+
+/- ## The normalized sequence `catalan n / 4^n` -/
+
+/-- Each normalized factor is below `1`: `r n / 4 < 1`. -/
+theorem ratio_div_four_lt_one (n : ℕ) : catalanRatio n / 4 < 1 := by
+  rw [div_lt_one (by norm_num : (0 : ℝ) < 4)]
+  exact ratio_lt_four n
+
+/-- **Normalized product form.** `catalan n / 4^n = ∏_{k<n} (r k / 4)`: dividing
+    the telescoping product by `4^n` distributes over the factors. -/
+theorem catalan_div_four_pow_eq_prod (n : ℕ) :
+    (catalan n : ℝ) / 4 ^ n = ∏ k ∈ Finset.range n, catalanRatio k / 4 := by
+  rw [catalan_eq_prod_ratio, Finset.prod_div_distrib, Finset.prod_const,
+      Finset.card_range]
+
+/-- Factoring out one normalized step:
+    `catalan (n+1)/4^{n+1} = (r n / 4) · (catalan n / 4^n)`. -/
+theorem catalan_div_four_pow_succ (n : ℕ) :
+    (catalan (n + 1) : ℝ) / 4 ^ (n + 1)
+      = (catalanRatio n / 4) * ((catalan n : ℝ) / 4 ^ n) := by
+  rw [catalan_succ_eq_ratio_mul, pow_succ]
+  field_simp
+
+/-- **The normalized Catalan sequence is strictly decreasing.**
+    `catalan (n+1)/4^{n+1} < catalan n/4^n`.
+
+    Each new factor `r n / 4` is strictly below `1`, so multiplying by it strictly
+    shrinks the positive quantity `catalan n / 4^n`. This is the multiplicative
+    reason `catalan n / 4^n` carries the polynomial correction `~ 1/(n^{3/2}√π)`
+    below the bare exponential `4^n` — proved here purely from the recurrence. -/
+theorem catalan_div_four_pow_strictAnti (n : ℕ) :
+    (catalan (n + 1) : ℝ) / 4 ^ (n + 1) < (catalan n : ℝ) / 4 ^ n := by
+  rw [catalan_div_four_pow_succ]
+  calc (catalanRatio n / 4) * ((catalan n : ℝ) / 4 ^ n)
+      < 1 * ((catalan n : ℝ) / 4 ^ n) :=
+        mul_lt_mul_of_pos_right (ratio_div_four_lt_one n) (catalan_div_four_pow_pos n)
+    _ = (catalan n : ℝ) / 4 ^ n := one_mul _
+
+/- ## Growth bound, product form -/
+
+/-- **Product-form growth bound.** `∏_{k<n} r k < 4^n` for `n ≥ 1`, equivalently
+    `catalan n < 4^n`: a strict product inequality because every factor `r k < 4`. -/
+theorem prod_ratio_lt_four_pow (n : ℕ) (hn : 1 ≤ n) :
+    ∏ k ∈ Finset.range n, catalanRatio k < 4 ^ n := by
+  have hne : (Finset.range n).Nonempty := by
+    rw [Finset.nonempty_range_iff]; omega
+  calc ∏ k ∈ Finset.range n, catalanRatio k
+      < ∏ k ∈ Finset.range n, (4 : ℝ) :=
+        Finset.prod_lt_prod_of_nonempty (fun k _ => ratio_pos k)
+          (fun k _ => ratio_lt_four k) hne
+    _ = 4 ^ n := by rw [Finset.prod_const, Finset.card_range]
+
+/-- The grandparent's bound `catalan n < 4^n` (`n ≥ 1`), recovered from the
+    product form. -/
+theorem catalan_lt_four_pow_of_prod (n : ℕ) (hn : 1 ≤ n) :
+    (catalan n : ℝ) < 4 ^ n := by
+  rw [catalan_eq_prod_ratio]
+  exact prod_ratio_lt_four_pow n hn
+
+/- ## Sanity checks -/
+
+/-- The telescoping product over the first three ratios is `catalan 3 = 5`:
+    `r 0 · r 1 · r 2 = 1 · 2 · (5/2) = 5`. -/
+example : ∏ k ∈ Finset.range 3, catalanRatio k = 5 := by
+  rw [Finset.prod_range_succ, Finset.prod_range_succ, Finset.prod_range_succ,
+      Finset.prod_range_zero, catalanRatio, catalanRatio, catalanRatio]
+  norm_num
+
+/-- The normalized value at `n = 3`: `catalan 3 / 4^3 = 5/64`. -/
+example : (catalan 3 : ℝ) / 4 ^ 3 = 5 / 64 := by
+  rw [catalan_eq_prod_ratio, Finset.prod_range_succ, Finset.prod_range_succ,
+      Finset.prod_range_succ, Finset.prod_range_zero,
+      catalanRatio, catalanRatio, catalanRatio]
+  norm_num
+
+end Erdos396OQ01OQ01OQ01

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-e396oq04oq01oq01oq01-telescope",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 65
+    },
+    "type": "key-step",
+    "title": "The recurrence telescopes into a closed product",
+    "content": "`catalan_eq_prod_ratio` proves $(\\mathrm{catalan}\\,n : \\mathbb{R}) = \\prod_{k<n} r_k$ where $r_k = (4k+2)/(k+2)$. The proof is a one-line induction: `Finset.prod_range_succ` peels off the top factor $r_m$, and the grandparent's quotient identity $\\mathrm{catalan}(m+1) = r_m\\cdot\\mathrm{catalan}\\,m$ matches it, closed by `ring`. Because every step of the recurrence is exactly a multiplication by $r_k$, iterating it collapses to a finite product — the multiplicative companion of the parent's additive identity $\\sum_{k<n} r_k = 4n - 6(H_{n+1}-1)$.",
+    "mathContext": "$(\\mathrm{catalan}\\,n : \\mathbb{R}) = \\prod_{k<n}\\frac{4k+2}{k+2}$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01-logbridge",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 88
+    },
+    "type": "insight",
+    "title": "Logarithms bridge the sum and product views",
+    "content": "`log_catalan_eq_sum_log_ratio` gives $\\log(\\mathrm{catalan}\\,n) = \\sum_{k<n}\\log(r_k)$ via `Real.log_prod` applied to the telescoping product (each factor is nonzero by the grandparent's `ratio_pos`). This is the precise link between this entry's multiplicative identity and the parent's additive running total: the logarithm of the product is the sum of the log-ratios.",
+    "mathContext": "$\\log(\\mathrm{catalan}\\,n) = \\sum_{k<n}\\log\\frac{4k+2}{k+2}$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01-strictanti",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 125
+    },
+    "type": "key-step",
+    "title": "The normalized sequence catalan n / 4^n is strictly decreasing",
+    "content": "`catalan_div_four_pow_eq_prod` writes $\\mathrm{catalan}\\,n / 4^n = \\prod_{k<n}(r_k/4)$ by distributing the division over the product (`Finset.prod_div_distrib`, with $\\prod_{k<n} 4 = 4^n$). Every factor satisfies $r_k/4 < 1$ (`ratio_div_four_lt_one`, from the grandparent's $r_k < 4$). Factoring out one step gives $\\mathrm{catalan}(n+1)/4^{n+1} = (r_n/4)\\cdot(\\mathrm{catalan}\\,n/4^n)$, so `catalan_div_four_pow_strictAnti` concludes strict decrease via `mul_lt_mul_of_pos_right`: multiplying a positive quantity by a factor below 1 strictly shrinks it. This is the multiplicative, recurrence-level shadow of the polynomial correction $1/(n^{3/2}\\sqrt\\pi)$ below the bare exponential $4^n$.",
+    "mathContext": "$\\frac{\\mathrm{catalan}(n+1)}{4^{n+1}} < \\frac{\\mathrm{catalan}\\,n}{4^n}$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01-prodbound",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 127,
+      "endLine": 145
+    },
+    "type": "key-step",
+    "title": "The 4^n growth bound as a strict product inequality",
+    "content": "`prod_ratio_lt_four_pow` proves $\\prod_{k<n} r_k < 4^n$ for $n\\ge 1$ using `Finset.prod_lt_prod_of_nonempty`: every factor is positive (`ratio_pos`) and strictly below 4 (`ratio_lt_four`), and the range is nonempty. Combined with the telescoping identity this recovers the grandparent's bound $\\mathrm{catalan}\\,n < 4^n$ — now multiplicatively, as a strict product comparison rather than by induction.",
+    "mathContext": "$\\prod_{k<n} r_k < \\prod_{k<n} 4 = 4^n,\\quad n\\ge 1$"
+  }
+]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,93 @@
+{
+  "id": "erdos-396-oq-04-oq-01-oq-01-oq-01",
+  "title": "Erdős #396 OQ-04 → OQ-01 → OQ-01 → OQ-01: Catalan as a Telescoping Product of Recurrence Ratios",
+  "slug": "erdos-396-oq-04-oq-01-oq-01-oq-01",
+  "description": "The Catalan recurrence multiplies by r k = (4k+2)/(k+2) at each step, so it telescopes into a closed product: (catalan n : ℝ) = ∏_{k<n} r k. Logarithms bridge this to the parent's additive running total (log catalan n = ∑_{k<n} log r k), and dividing by 4^n gives catalan n / 4^n = ∏_{k<n} (r k / 4) with every factor below 1 — so the normalized sequence catalan n / 4^n is strictly decreasing. The product form recovers catalan n < 4^n as a strict product inequality. All from the recurrence, no Stirling.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/396",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos396OQ04OQ01OQ01OQ01.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "catalan",
+      "recurrence",
+      "telescoping-product",
+      "growth-bounds",
+      "logarithm"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 396,
+    "erdosUrl": "https://erdosproblems.com/396",
+    "axiomCount": 0,
+    "lineCount": 162,
+    "assumptions": "0 axioms, 0 sorries. All results depend only on the foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool / native_decide). Built against Mathlib 4.26.0.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #396 concerns descending-factorial divisibility of central binomial coefficients, whose base case rests on the Catalan numbers catalan n = C(2n,n)/(n+1). The grandparent entry Erdős #396 OQ-04 → OQ-01 reads the two-term recurrence as the multiplicative step r n = (4n+2)/(n+2) = 4 − 6/(n+2), with catalan(n+1) = r n · catalan n, and proves r n < 4, r strictly increasing, r n → 4. The parent OQ-01 → OQ-01 studies the additive running total of the ratios, ∑_{k<n} r k = 4n − 6·(H_{n+1} − 1). The grandparent's first open question explicitly asks whether tracking the product of the normalized steps along the recurrence recovers the polynomial correction in catalan n ∼ 4^n/(n^{3/2}√π). This entry takes that multiplicative view.",
+    "problemStatement": "The recurrence multiplies by r k at every step. Read multiplicatively rather than additively: does the recurrence telescope into a closed product for catalan n, how does it relate to the parent's sum identity, and what does dividing by 4^n reveal about the normalized sequence catalan n / 4^n?",
+    "text": "The recurrence catalan(n+1) = r n · catalan n telescopes to (catalan n : ℝ) = ∏_{k<n} r k. Taking logs gives log(catalan n) = ∑_{k<n} log(r k). Dividing by 4^n gives catalan n / 4^n = ∏_{k<n} (r k / 4) with each factor r k / 4 < 1, so catalan n / 4^n is strictly decreasing; and the product form yields catalan n < 4^n (n ≥ 1) as a strict product inequality.",
+    "proofStrategy": "The telescoping identity (catalan n : ℝ) = ∏_{k<n} r k is a one-line induction on n using Finset.prod_range_succ and the grandparent's quotient identity catalan_succ_eq_ratio_mul (catalan(n+1) = r n · catalan n), closed by ring. Strict positivity of the product is Finset.prod_pos with the grandparent's ratio_pos. The logarithmic bridge log(catalan n) = ∑_{k<n} log(r k) is Real.log_prod applied to the telescoping product (each factor nonzero). The normalized product catalan n / 4^n = ∏_{k<n} (r k / 4) is Finset.prod_div_distrib together with ∏_{k<n} 4 = 4^n (Finset.prod_const, Finset.card_range). Each normalized factor satisfies r n / 4 < 1 by div_lt_one and the grandparent's ratio_lt_four. Factoring out one step, catalan(n+1)/4^{n+1} = (r n / 4)·(catalan n / 4^n), and strict anti-monotonicity follows from mul_lt_mul_of_pos_right since r n / 4 < 1 and catalan n / 4^n > 0. The strict product growth bound ∏_{k<n} r k < 4^n (n ≥ 1) is Finset.prod_lt_prod_of_nonempty (every factor positive and < 4), recovering catalan n < 4^n.",
+    "keyInsights": [
+      "**The recurrence telescopes into a closed product.** Because each step of the Catalan recurrence is exactly a multiplication by r k, iterating it collapses to (catalan n : ℝ) = ∏_{k<n} r k — the multiplicative companion of the parent's additive identity ∑_{k<n} r k = 4n − 6·(H_{n+1} − 1).",
+      "**Logarithms are the bridge between the sum and product views.** log(catalan n) = ∑_{k<n} log(r k) turns the telescoping product into a sum of log-ratios, linking this entry's multiplicative identity to the parent's additive one.",
+      "**The normalized sequence catalan n / 4^n is a product of factors below 1.** Dividing by 4^n gives ∏_{k<n} (r k / 4) with every factor r k / 4 < 1, so catalan n / 4^n is strictly decreasing — the multiplicative, recurrence-level shadow of the polynomial correction 1/(n^{3/2}√π) below the bare exponential 4^n, exactly the product view the grandparent's open question requested.",
+      "**The 4^n growth bound becomes a strict product inequality.** ∏_{k<n} r k < ∏_{k<n} 4 = 4^n for n ≥ 1 because every factor r k < 4, recovering catalan n < 4^n multiplicatively rather than by induction."
+    ],
+    "prerequisites": [
+      "Catalan numbers and the two-term recurrence catalan(n+1) = (4n+2)/(n+2)·catalan(n)",
+      "Finite products over Finset.range and telescoping",
+      "Real logarithm of a product (Real.log_prod)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Catalan recurrence multiplies by r k = (4k+2)/(k+2) at each step, so it telescopes into the closed product (catalan n : ℝ) = ∏_{k<n} r k. Logarithms bridge this to the parent's additive identity: log(catalan n) = ∑_{k<n} log(r k). Dividing by 4^n gives catalan n / 4^n = ∏_{k<n} (r k / 4), where each factor r k / 4 < 1, so the normalized sequence catalan n / 4^n is strictly decreasing. The product form also recovers catalan n < 4^n (n ≥ 1) as a strict product inequality, since every factor r k < 4. All eight theorems are fully machine-checked with no axioms or sorries.",
+    "implications": "The result completes the multiplicative reading of the Catalan recurrence requested by the grandparent's open question: the same step ratios whose additive total is harmonic have a multiplicative total that is exactly the Catalan number. The strictly decreasing normalized sequence catalan n / 4^n is the recurrence-level reason Catalan growth sits below the bare exponential 4^n, obtained without Stirling or any central-binomial estimate. The logarithmic identity ties the additive (parent) and multiplicative (this entry) views together.",
+    "openQuestions": [
+      "The factors r k / 4 = 1 − 3/(2(k+2)) shrink the normalized sequence; can ∏_{k<n} (1 − 3/(2(k+2))) be bounded below by c/n^{3/2} using log(1−x) ≥ −x − x² style estimates to obtain a two-sided c·4^n/n^{3/2} ≤ catalan n bound at the recurrence level?",
+      "Does the telescoping-product technique applied to the central-binomial recurrence (n+1)·C(2(n+1),n+1) = 2(2n+1)·C(2n,n) give C(2n,n) = ∏_{k<n} 2(2k+1)/(k+1) and hence the matching growth law C(2n,n) ∼ 4^n/√(πn)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos396OQ04OQ01"
+    ],
+    "opens": [
+      "Nat",
+      "Filter",
+      "Topology",
+      "Finset"
+    ],
+    "namespace": "Erdos396OQ01OQ01OQ01",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos396OQ04OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Parent OQ: the additive view — the ratio deficit δ k = 6/(k+2) is harmonic and the running sum ∑_{k<n} r k = 4n − 6·(H_{n+1} − 1). This follow-up takes the multiplicative view, telescoping the same ratios into the closed product catalan n = ∏_{k<n} r k."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01",
+      "relationship": "ancestor",
+      "description": "Grandparent OQ: the recurrence ratio r n = (4n+2)/(n+2) = 4 − 6/(n+2), with r n < 4 and catalan(n+1) = r n · catalan n. Its first open question asked for the product view developed here."
+    },
+    {
+      "targetId": "erdos-396",
+      "relationship": "ancestor",
+      "description": "Root problem: descending factorials dividing central binomial coefficients, whose base case rests on the Catalan numbers studied here."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Fourth-generation follow-up in the Erdős #396 Catalan-recurrence chain. The grandparent (`erdos-396-oq-04-oq-01`) read the recurrence as the multiplicative step `r k = (4k+2)/(k+2) = 4 − 6/(k+2)`, with `catalan(k+1) = r k · catalan k`. The parent (`...-oq-01-oq-01`) studied the **additive** running total `∑_{k<n} r k = 4n − 6(H_{n+1}−1)`. This entry takes the **multiplicative** view that the grandparent's first open question explicitly requested.

Because each recurrence step multiplies by `r k`, it telescopes into a closed product:

- **`catalan_eq_prod_ratio`** — `(catalan n : ℝ) = ∏_{k<n} r k`. One-line induction via `Finset.prod_range_succ` + the grandparent's quotient identity.
- **`log_catalan_eq_sum_log_ratio`** — `log(catalan n) = ∑_{k<n} log(r k)`. The logarithm is the bridge to the parent's additive identity.
- **`catalan_div_four_pow_eq_prod`** — `catalan n / 4^n = ∏_{k<n} (r k / 4)`, every factor `r k / 4 < 1` (`ratio_div_four_lt_one`), hence
- **`catalan_div_four_pow_strictAnti`** — the normalized sequence `catalan n / 4^n` is **strictly decreasing**: the multiplicative, recurrence-level shadow of the polynomial correction `1/(n^{3/2}√π)` below `4^n`.
- **`prod_ratio_lt_four_pow`** — `∏_{k<n} r k < 4^n` (n ≥ 1), recovering `catalan n < 4^n` as a strict product inequality.

No Stirling, no central-binomial estimate — everything telescopes from the recurrence.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos396OQ04OQ01OQ01OQ01` ✔ (7744 jobs, builds clean)
- `#print axioms` on the headline theorems: only `propext`, `Classical.choice`, `Quot.sound` — **0-axiom verified**, no `sorryAx`, no `Lean.ofReduceBool`/`native_decide`.
- 162 lines, 8 theorems, 0 definitions, 0 sorries. Mathlib 4.26.0.

## Gallery

`src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01/` (meta.json + annotations.json), cross-referenced to parent/ancestors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)