### PR TITLE
research(shannon-source-coding-oq-04-incomplete-01): the type partition identity and the multinomial theorem

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3270,6 +3270,7 @@ import Proofs.ShannonSourceCodingOQ02
 import Proofs.ShannonSourceCodingOQ03
 import Proofs.ShannonSourceCodingOQ04
 import Proofs.ShannonSourceCodingOQ04Aristotle
+import Proofs.ShannonSourceCodingOQ04Incomplete01
 import Proofs.ShapleyFolkman
 import Proofs.ShapleyFolkmanAristotle
 import Proofs.ShapleyFolkmanOQ01

--- a/proofs/Proofs/ShannonSourceCodingOQ04Incomplete01.lean
+++ b/proofs/Proofs/ShannonSourceCodingOQ04Incomplete01.lean
@@ -1,0 +1,180 @@
+import Proofs.ShannonSourceCodingOQ04
+
+/-
+# Method of Types: the Type Partition Identity and the Multinomial Theorem
+
+## Context (parent shannon-source-coding-oq-04)
+
+The parent file formalizes the method-of-types proof of Shannon's source coding theorem. It
+proves, for an alphabet `Fin k` and block length `n`:
+
+* `type_class_size_eq_multinomial`: `|T_f| = multinomial(f) = n! / ∏(f i)!`;
+* `type_class_size_le_entropy_pow`: `|T_f| ≤ exp(n·H(f/n))`;
+* `count_types_le`: there are at most `(n+1)^k` distinct types;
+* `total_sequences_eq`: there are `k^n` sequences in total.
+
+What the parent never does is **sum over the types**. The whole point of the method of types is
+that the type classes *partition* the sequence space, so the `k^n` sequences are accounted for,
+class by class. This file supplies that missing identity:
+
+> **`k^n = ∑_{types f} |T_f| = ∑_{types f} multinomial(f)`.**
+
+This is exactly the **multinomial theorem** (`(1 + 1 + ⋯ + 1)^n = k^n`) realized combinatorially
+through the empirical-distribution partition. It is the bookkeeping backbone the source coding
+argument rests on, and it closes the loop between `total_sequences_eq` and
+`type_class_size_eq_multinomial`.
+
+Tags: information-theory, combinatorics, method-of-types, multinomial, partition, source-coding
+-/
+
+open Finset BigOperators
+
+namespace ShannonSourceCodingOQ04Incomplete01
+
+open MethodOfTypes
+
+variable {k : ℕ} [NeZero k]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I: INDEXING THE TYPES
+
+A type is an empirical distribution: a function `Fin k → ℕ` summing to `n` with each entry
+`≤ n`. We index types by `Fin k → Fin (n+1)` (each count lives in `{0,…,n}`) constrained to
+sum to `n`. This is precisely the index set behind the parent's `count_types_le`.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- Each empirical count is at most the block length `n`. -/
+theorem empDist_le (n : ℕ) (x : Fin n → Fin k) (i : Fin k) : empDist n x i ≤ n := by
+  refine (Finset.card_filter_le _ _).trans ?_
+  simp [Finset.card_univ, Fintype.card_fin]
+
+/-- The set of valid types: `Fin k → Fin (n+1)` whose entries sum to `n`.
+    Its cardinality is bounded by `(n+1)^k` (parent's `count_types_le`). -/
+def typeIndex (n : ℕ) : Finset (Fin k → Fin (n + 1)) :=
+  Finset.univ.filter fun g => ∑ i, (g i : ℕ) = n
+
+/-- The type map sending a sequence to its empirical distribution, valued in `Fin (n+1)`. -/
+def typeMap (n : ℕ) (x : Fin n → Fin k) : Fin k → Fin (n + 1) :=
+  fun i => ⟨empDist n x i, Nat.lt_succ_of_le (empDist_le n x i)⟩
+
+/-- The type map lands in the type index: empirical counts sum to `n`. -/
+theorem typeMap_mem (n : ℕ) (x : Fin n → Fin k) : typeMap n x ∈ typeIndex (k := k) n := by
+  simp only [typeIndex, typeMap, Finset.mem_filter, Finset.mem_univ, true_and]
+  simpa using empDist_sum n x
+
+/-- A type index `g` recovers a count function summing to `n`. -/
+theorem typeIndex_sum {n : ℕ} {g : Fin k → Fin (n + 1)} (hg : g ∈ typeIndex (k := k) n) :
+    ∑ i, ((g i : ℕ)) = n := (Finset.mem_filter.mp hg).2
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II: THE FIBER OF THE TYPE MAP IS A TYPE CLASS
+
+The sequences mapping to a given type `g` are exactly the type class `T_{g}`.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- The fiber of `typeMap` over a type `g` is exactly the type class of `g`. -/
+theorem fiber_eq_typeClass (n : ℕ) (g : Fin k → Fin (n + 1)) (hg : ∑ i, ((g i : ℕ)) = n) :
+    (Finset.univ.filter fun x : Fin n → Fin k => typeMap n x = g) =
+      typeClass n (fun i => (g i : ℕ)) hg := by
+  ext x
+  simp only [typeClass, typeMap, Finset.mem_filter, Finset.mem_univ, true_and, funext_iff,
+    Fin.ext_iff]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III: THE TYPE PARTITION IDENTITY
+
+`k^n = ∑_{types g} |T_g| = ∑_{types g} multinomial(g)`.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- **Type partition (counting form)**: the `k^n` sequences split, class by class, across the
+    distinct types — `k^n = ∑_{types g} |T_g|`. The type classes partition the sequence space. -/
+theorem total_eq_sum_type_class_card (n : ℕ) :
+    (k : ℕ) ^ n =
+      ∑ g ∈ typeIndex (k := k) n,
+        (Finset.univ.filter fun x : Fin n → Fin k => typeMap n x = g).card := by
+  have h := Finset.card_eq_sum_card_fiberwise
+    (s := (Finset.univ : Finset (Fin n → Fin k))) (t := typeIndex (k := k) n)
+    (f := typeMap n) (fun x _ => typeMap_mem n x)
+  rwa [total_sequences_eq] at h
+
+/-- **Type partition (multinomial form) = the Multinomial Theorem.**
+    `k^n = ∑_{types g} multinomial(g)`. Each type class has multinomial size, and the classes
+    partition the `k^n` sequences, so the multinomial coefficients of all types summing to `n`
+    add up to `k^n`. This is `(1 + ⋯ + 1)^n = k^n` read through the empirical-distribution
+    partition. -/
+theorem total_eq_sum_multinomial (n : ℕ) :
+    (k : ℕ) ^ n =
+      ∑ g ∈ typeIndex (k := k) n, Nat.multinomial Finset.univ (fun i => (g i : ℕ)) := by
+  rw [total_eq_sum_type_class_card]
+  refine Finset.sum_congr rfl fun g hg => ?_
+  rw [fiber_eq_typeClass n g (typeIndex_sum hg), type_class_size_eq_multinomial]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV: CONSEQUENCES
+
+A dominant type class is large; and the partition gives a clean alternative route to the
+parent's lower bound `k^n / (n+1)^k`.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- The number of valid types is at most `(n+1)^k` (the parent's `count_types_le`, restated
+    for `typeIndex`). -/
+theorem typeIndex_card_le (n : ℕ) : (typeIndex (k := k) n).card ≤ (n + 1) ^ k :=
+  count_types_le n
+
+/-- **A dominant type class exists**, via the partition: since `k^n = ∑_{types g} |T_g|` over at
+    most `(n+1)^k` types, some type class has at least the average, `k^n ≤ (n+1)^k · |T_g|`.
+    This recovers the parent's `dominant_type_lower_bound` directly from the partition identity
+    (no separate pigeonhole over sequences needed). -/
+theorem exists_dominant_type_class (n : ℕ) :
+    ∃ g ∈ typeIndex (k := k) n,
+      (k : ℕ) ^ n ≤ (n + 1) ^ k *
+        (Finset.univ.filter fun x : Fin n → Fin k => typeMap n x = g).card := by
+  by_cases hempty : (typeIndex (k := k) n) = ∅
+  · -- impossible: typeMap of any sequence lands in typeIndex, so it is nonempty
+    exact absurd (typeMap_mem n (fun _ => ⟨0, Nat.pos_of_ne_zero (NeZero.ne k)⟩))
+      (hempty ▸ Finset.notMem_empty _)
+  · obtain ⟨g, hg, hmax⟩ := Finset.exists_max_image (typeIndex (k := k) n)
+      (fun g => (Finset.univ.filter fun x : Fin n → Fin k => typeMap n x = g).card)
+      (Finset.nonempty_of_ne_empty hempty)
+    refine ⟨g, hg, ?_⟩
+    calc (k : ℕ) ^ n
+        = ∑ g' ∈ typeIndex (k := k) n,
+            (Finset.univ.filter fun x : Fin n → Fin k => typeMap n x = g').card :=
+          total_eq_sum_type_class_card n
+      _ ≤ ∑ _g' ∈ typeIndex (k := k) n,
+            (Finset.univ.filter fun x : Fin n → Fin k => typeMap n x = g).card :=
+          Finset.sum_le_sum fun g' hg' => hmax g' hg'
+      _ = (typeIndex (k := k) n).card *
+            (Finset.univ.filter fun x : Fin n → Fin k => typeMap n x = g).card := by
+          rw [Finset.sum_const, smul_eq_mul]
+      _ ≤ (n + 1) ^ k *
+            (Finset.univ.filter fun x : Fin n → Fin k => typeMap n x = g).card :=
+          Nat.mul_le_mul_right _ (typeIndex_card_le n)
+
+end ShannonSourceCodingOQ04Incomplete01
+
+/-
+## Summary
+
+The missing bookkeeping identity of the method of types — the type classes partition the
+sequence space:
+
+- `total_eq_sum_type_class_card`: `k^n = ∑_{types g} |T_g|`.
+- `total_eq_sum_multinomial`:     `k^n = ∑_{types g} multinomial(g)` — the multinomial theorem
+  realized through the empirical-distribution partition.
+- `exists_dominant_type_class`:   `∃ g, k^n ≤ (n+1)^k · |T_g|` — the dominant-type lower bound,
+  obtained directly from the partition (averaging over ≤ (n+1)^k types).
+
+Built on the parent's `type_class_size_eq_multinomial`, `total_sequences_eq`, and
+`count_types_le`.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/

--- a/src/data/proofs/shannon-source-coding-oq-04-incomplete-01/annotations.json
+++ b/src/data/proofs/shannon-source-coding-oq-04-incomplete-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-typemap",
+    "proofId": "shannon-source-coding-oq-04-incomplete-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 90
+    },
+    "type": "concept",
+    "title": "The Type Map: Sequence ↦ Empirical Distribution",
+    "content": "`typeMap n x i = ⟨empDist n x i, …⟩` records, for each symbol i, how many times it appears in x — packaged as a value in Fin (n+1) since counts never exceed n (`empDist_le`). `typeMap_mem` then shows the result is a valid type: the counts sum to the block length n (the parent's `empDist_sum`). This map is the lens through which the sequence space is organized by type."
+  },
+  {
+    "id": "ann-fiber",
+    "proofId": "shannon-source-coding-oq-04-incomplete-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 105
+    },
+    "type": "insight",
+    "title": "The Fiber Is a Type Class",
+    "content": "`fiber_eq_typeClass` is the bridge: the set of sequences mapping to a given type g — the fiber of the type map over g — is exactly the parent's type class T_g. Both sides reduce, via Fin.ext_iff and funext_iff, to the condition `∀ i, empDist n x i = (g i).val`. Once the fibers are identified with the type classes, the partition identity is immediate."
+  },
+  {
+    "id": "ann-partition",
+    "proofId": "shannon-source-coding-oq-04-incomplete-01",
+    "range": {
+      "startLine": 124,
+      "endLine": 145
+    },
+    "type": "insight",
+    "title": "The Partition Identity = the Multinomial Theorem",
+    "content": "`total_eq_sum_type_class_card` applies `Finset.card_eq_sum_card_fiberwise` to the type map: the k^n sequences split, class by class, across the types, so k^n = ∑_{types g} |T_g|. Rewriting each class by the parent's `type_class_size_eq_multinomial` gives `total_eq_sum_multinomial`: k^n = ∑_{types g} multinomial(g). This is the multinomial theorem (1+⋯+1)^n = k^n, obtained not by algebraic expansion but by partitioning sequences according to their empirical distribution — the combinatorial accounting at the heart of the method of types."
+  },
+  {
+    "id": "ann-dominant",
+    "proofId": "shannon-source-coding-oq-04-incomplete-01",
+    "range": {
+      "startLine": 161,
+      "endLine": 180
+    },
+    "type": "insight",
+    "title": "The Dominant Type Class, Straight from the Partition",
+    "content": "`exists_dominant_type_class` derives the dominant-type lower bound k^n ≤ (n+1)^k·|T_g| by a clean averaging argument: the sum of class sizes equals k^n, there are at most (n+1)^k classes (`count_types_le`), so the largest class is at least the average. This recovers the parent's `dominant_type_lower_bound` directly from the partition identity, without a separate pigeonhole over the k^n sequences — the exponential share carried by the dominant type is exactly what powers the source coding achievability bound."
+  }
+]

--- a/src/data/proofs/shannon-source-coding-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04-incomplete-01/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "shannon-source-coding-oq-04-incomplete-01",
+  "title": "Method of Types: The Type Partition Identity and the Multinomial Theorem",
+  "slug": "shannon-source-coding-oq-04-incomplete-01",
+  "description": "Supplies the missing bookkeeping identity of the method of types: the type classes partition the sequence space, so k^n = ∑_{types g} |T_g| = ∑_{types g} multinomial(g). This is the multinomial theorem (1+⋯+1)^n = k^n realized through the empirical-distribution partition, closing the loop between the parent's total_sequences_eq and type_class_size_eq_multinomial. A corollary derives the dominant-type lower bound k^n ≤ (n+1)^k·|T_g| directly from the partition by averaging over the ≤ (n+1)^k types. Builds on the (fully verified) parent shannon-source-coding-oq-04.",
+  "meta": {
+    "author": "Imre Csiszár, János Körner (method of types, 1981); formalized in Lean 4",
+    "date": "1981",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShannonSourceCodingOQ04Incomplete01.lean",
+    "tags": [
+      "information-theory",
+      "combinatorics",
+      "method-of-types",
+      "multinomial",
+      "partition",
+      "source-coding",
+      "entropy"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 180,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, no `native_decide`. `#print axioms` reports only the three ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted under the project's axiom-integrity policy. Imports the parent shannon-source-coding-oq-04 (itself 0-sorry, 0-axiom verified) and reuses its type-class machinery; all new results are fully machine-checked.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_eq_sum_card_fiberwise",
+        "description": "Partitions a finset's cardinality into the cardinalities of the fibers of a map into a target finset — the engine of the type partition",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.exists_max_image",
+        "description": "A nonempty finset has an element maximizing a ℕ-valued function — used for the dominant-type corollary",
+        "module": "Mathlib.Data.Finset.Lattice"
+      },
+      {
+        "theorem": "Nat.multinomial",
+        "description": "The multinomial coefficient n!/∏(f i)!, the size of each type class",
+        "module": "Mathlib.Combinatorics.Choose.Multinomial"
+      }
+    ],
+    "dateAdded": "2026-06-22",
+    "theoremCount": 8,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The method of types, developed systematically by Csiszár and Körner (1981), is a combinatorial technique that replaces probabilistic arguments in information theory with exact counting. A sequence over an alphabet of size k is classified by its 'type' — its empirical distribution, i.e. how many times each symbol appears. Two facts drive everything: there are only polynomially many types ((n+1)^k of them), while there are exponentially many sequences (k^n); and each type class T_f has exactly multinomial(f) = n!/∏(f i)! members. The parent file formalizes these facts and the entropy bound |T_f| ≤ exp(n·H(f/n)).\n\nThe organizing principle that makes the method work, however, is that the type classes *partition* the sequence space: every sequence has exactly one type. Summed over all types, the class sizes must reconstruct the total count k^n. This is the multinomial theorem, ∑ multinomial(f) = k^n, viewed combinatorially. The parent proves the per-class facts but never assembles them into this partition identity; this file does.",
+    "problemStatement": "**Task (parent shannon-source-coding-oq-04)**: Complete the method-of-types development. The parent is fully verified, so the remaining content is the bookkeeping identity that ties the pieces together: the type classes partition the sequence space, giving k^n = ∑_{types g} |T_g| = ∑_{types g} multinomial(g).",
+    "text": "A 180-line, fully verified (0 sorries, 0 axioms, no native_decide) file building on the parent. Part I indexes the types as Fin k → Fin (n+1) summing to n, and defines the type map sending a sequence to its empirical distribution. Part II proves the fiber of the type map over a type g is exactly the type class T_g. Part III is the headline: the partition identity k^n = ∑ |T_g| (via card_eq_sum_card_fiberwise) and its multinomial form k^n = ∑ multinomial(g). Part IV derives the dominant-type lower bound k^n ≤ (n+1)^k·|T_g| by averaging the partition over the ≤ (n+1)^k types.",
+    "proofStrategy": "The type map F : (Fin n → Fin k) → (Fin k → Fin (n+1)) sends x to its empirical distribution (bounded by n, hence valued in Fin (n+1)). `typeMap_mem` shows F lands in the type index (counts sum to n, by the parent's empDist_sum). `fiber_eq_typeClass` identifies the fiber F⁻¹(g) with the parent's type class via Fin.ext_iff and funext_iff. The partition identity `total_eq_sum_type_class_card` is then a direct application of `Finset.card_eq_sum_card_fiberwise` with the total count rewritten by the parent's `total_sequences_eq`. The multinomial form `total_eq_sum_multinomial` rewrites each fiber by the parent's `type_class_size_eq_multinomial`. The dominant-type corollary `exists_dominant_type_class` takes the max-size type (Finset.exists_max_image), bounds the sum of class sizes above by (#types)·(max size), and uses `count_types_le` to replace #types with (n+1)^k.",
+    "keyInsights": [
+      "The type classes partition the sequence space — every sequence has exactly one empirical distribution — so summing class sizes over all types reconstructs k^n.",
+      "k^n = ∑ multinomial(g) over types is literally the multinomial theorem (1+⋯+1)^n = k^n, expressed through the empirical-distribution partition rather than algebraic expansion.",
+      "Finset.card_eq_sum_card_fiberwise is the perfect tool: the type map's fibers are the type classes, so the partition identity is a one-line corollary once the fiber is identified.",
+      "The dominant-type lower bound k^n ≤ (n+1)^k·|T_g| falls straight out of the partition by averaging — no separate pigeonhole over the k^n sequences is needed (a cleaner route than the parent's dominant_type_lower_bound).",
+      "Importing the verified parent and reusing empDist_sum, type_class_size_eq_multinomial, total_sequences_eq, and count_types_le keeps the new file short and focused on the assembly step."
+    ],
+    "prerequisites": [
+      "The method of types: types, type classes, empirical distributions (parent file)",
+      "Multinomial coefficients",
+      "Finset fiberwise cardinality decomposition in Lean 4/Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "indexing",
+      "title": "Part I: Indexing the Types",
+      "startLine": 49,
+      "endLine": 90,
+      "summary": "empDist_le: each count ≤ n. typeIndex: types as Fin k → Fin (n+1) summing to n. typeMap: sequence ↦ empirical distribution. typeMap_mem, typeIndex_sum.",
+      "mathContext": "Types are empirical distributions; indexed as bounded count vectors summing to the block length."
+    },
+    {
+      "id": "fiber",
+      "title": "Part II: The Fiber Is a Type Class",
+      "startLine": 92,
+      "endLine": 110,
+      "summary": "fiber_eq_typeClass: the sequences mapping to a type g are exactly the type class T_g.",
+      "mathContext": "Identifying the fiber of the type map with the parent's type class is the bridge to the partition."
+    },
+    {
+      "id": "partition",
+      "title": "Part III: The Type Partition Identity",
+      "startLine": 112,
+      "endLine": 145,
+      "summary": "total_eq_sum_type_class_card: k^n = ∑_{types g} |T_g|. total_eq_sum_multinomial: k^n = ∑_{types g} multinomial(g) — the multinomial theorem via partition.",
+      "mathContext": "The headline identity assembling per-class counts into the total, closing total_sequences_eq with type_class_size_eq_multinomial."
+    },
+    {
+      "id": "consequences",
+      "title": "Part IV: Consequences",
+      "startLine": 147,
+      "endLine": 180,
+      "summary": "typeIndex_card_le: ≤ (n+1)^k types. exists_dominant_type_class: k^n ≤ (n+1)^k·|T_g| for a dominant type g, by averaging the partition.",
+      "mathContext": "The dominant-type lower bound derived cleanly from the partition identity."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file supplies the partition identity at the heart of the method of types: the type classes partition the k^n sequences, so k^n = ∑_{types g} |T_g| = ∑_{types g} multinomial(g). It closes the loop between the parent's total_sequences_eq and type_class_size_eq_multinomial, and derives the dominant-type lower bound k^n ≤ (n+1)^k·|T_g| directly by averaging.",
+    "implications": "The partition identity is the combinatorial accounting that the source coding theorem rests on: the exponentially many sequences are organized into polynomially many type classes, with the dominant class carrying an exponential share. Expressed as ∑ multinomial(g) = k^n it is the multinomial theorem, here proved through the empirical-distribution partition rather than algebraic expansion.",
+    "openQuestions": [
+      "Prove the matching entropy lower bound |T_g| ≥ exp(n·H(g/n))/(n+1)^k by showing T_g is the most probable type class under its own distribution.",
+      "Strengthen source_coding_achievability_mot to the true achievability statement (covering probability ≥ 1−δ) using the dominant type class.",
+      "Formalize the converse (no code below rate H(p) succeeds) via the type-counting bound."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-source-coding-oq-04",
+      "relationship": "extends",
+      "description": "Parent: method-of-types proof of source coding. This entry adds the type partition identity assembling its per-class facts."
+    },
+    {
+      "targetId": "shannon-source-coding",
+      "relationship": "related",
+      "description": "Root: Shannon's source coding theorem."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.ShannonSourceCodingOQ04"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators",
+      "MethodOfTypes"
+    ],
+    "namespace": "ShannonSourceCodingOQ04Incomplete01",
+    "lineCount": 180,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "mainTheorems": [
+      {
+        "name": "total_eq_sum_multinomial",
+        "type": "core",
+        "description": "k^n = ∑_{types g} multinomial(g): the multinomial theorem via the empirical-distribution partition",
+        "leanType": "(n : ℕ) → (k : ℕ) ^ n = ∑ g ∈ typeIndex n, Nat.multinomial Finset.univ (fun i => (g i : ℕ))"
+      },
+      {
+        "name": "total_eq_sum_type_class_card",
+        "type": "key",
+        "description": "k^n = ∑_{types g} |T_g|: the type classes partition the sequence space",
+        "leanType": "(n : ℕ) → (k : ℕ) ^ n = ∑ g ∈ typeIndex n, (Finset.univ.filter fun x => typeMap n x = g).card"
+      },
+      {
+        "name": "exists_dominant_type_class",
+        "type": "key",
+        "description": "A dominant type class: k^n ≤ (n+1)^k·|T_g|, by averaging the partition over ≤ (n+1)^k types",
+        "leanType": "(n : ℕ) → ∃ g ∈ typeIndex n, (k : ℕ) ^ n ≤ (n + 1) ^ k * (Finset.univ.filter fun x => typeMap n x = g).card"
+      }
+    ],
+    "path": "Proofs/ShannonSourceCodingOQ04Incomplete01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "total_eq_sum_multinomial",
+      "type": "core",
+      "description": "k^n = ∑_{types g} multinomial(g): the multinomial theorem realized via the method-of-types partition",
+      "leanType": "(n : ℕ) → (k : ℕ) ^ n = ∑ g ∈ typeIndex n, Nat.multinomial Finset.univ (fun i => (g i : ℕ))"
+    },
+    {
+      "name": "total_eq_sum_type_class_card",
+      "type": "key",
+      "description": "k^n = ∑_{types g} |T_g|: type classes partition the sequence space",
+      "leanType": "(n : ℕ) → (k : ℕ) ^ n = ∑ g ∈ typeIndex n, (Finset.univ.filter fun x => typeMap n x = g).card"
+    },
+    {
+      "name": "fiber_eq_typeClass",
+      "type": "supporting",
+      "description": "The fiber of the type map over g is exactly the type class T_g",
+      "leanType": "(n : ℕ) → (g : Fin k → Fin (n+1)) → (hg : ∑ i, (g i : ℕ) = n) → (Finset.univ.filter fun x => typeMap n x = g) = typeClass n (fun i => (g i : ℕ)) hg"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Csiszár, Imre; Körner, János",
+      "title": "Information Theory: Coding Theorems for Discrete Memoryless Systems",
+      "year": "2011",
+      "venue": "Cambridge University Press, 2nd edition",
+      "note": "Chapter 2 develops the method of types, including the type-counting and partition facts"
+    },
+    {
+      "authors": "Cover, Thomas M.; Thomas, Joy A.",
+      "title": "Elements of Information Theory",
+      "year": "2006",
+      "venue": "Wiley, 2nd edition",
+      "note": "Chapter 11 presents the method of types and the source coding theorem"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent **shannon-source-coding-oq-04** (method-of-types proof of Shannon source coding) is fully verified, but it never **sums over the types**. The organizing identity of the method — that the type classes *partition* the sequence space — was missing. This PR supplies it.

**`ShannonSourceCodingOQ04Incomplete01.lean`** — 180 lines, 8 theorems, 2 defs, **0 sorries, 0 axioms, no `native_decide`** (`#print axioms` → only propext/Classical.choice/Quot.sound). Imports the verified parent and reuses its machinery.

### The partition identity
- `total_eq_sum_type_class_card`: **k^n = ∑_{types g} |T_g|** — every sequence has exactly one type, so the class sizes reconstruct the total. Proved via `Finset.card_eq_sum_card_fiberwise` (the type map's fibers are the type classes, `fiber_eq_typeClass`) and the parent's `total_sequences_eq`.
- `total_eq_sum_multinomial`: **k^n = ∑_{types g} multinomial(g)** — the **multinomial theorem** (1+⋯+1)^n = k^n realized through the empirical-distribution partition, closing the loop between the parent's `total_sequences_eq` and `type_class_size_eq_multinomial`.

### Consequence
- `exists_dominant_type_class`: **k^n ≤ (n+1)^k·|T_g|** for a dominant type g — the dominant-type lower bound obtained directly by averaging the partition over the ≤ (n+1)^k types (a cleaner route than the parent's pigeonhole-over-sequences `dominant_type_lower_bound`).

## Verification
`./proofs/scripts/docker-build.sh Proofs.ShannonSourceCodingOQ04Incomplete01` → Build completed successfully (7744 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)