### PR TITLE
research(erdos-396-oq-04-oq-01-oq-01-oq-02): the 3/2 critical exponent of Catalan growth emerges from the recurrence

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1644,6 +1644,7 @@ import Proofs.Erdos395Problem
 import Proofs.Erdos396OQ04
 import Proofs.Erdos396OQ04OQ01
 import Proofs.Erdos396OQ04OQ01OQ01
+import Proofs.Erdos396OQ04OQ01OQ01OQ02
 import Proofs.Erdos396Problem
 import Proofs.Erdos397Problem
 import Proofs.Erdos398Problem

--- a/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02.lean
@@ -1,0 +1,213 @@
+/-
+# Erdős Problem #396 — OQ-04 → OQ-01 → OQ-01 → OQ-02: the `3/2` critical exponent of Catalan growth emerges from the recurrence
+
+The grandparent `Erdos396OQ04OQ01` reads the two-term Catalan recurrence as a
+statement about the ratio of consecutive Catalan numbers,
+`r n = (4n+2)/(n+2) = 4 − 6/(n+2)`, and the parent `Erdos396OQ04OQ01OQ01` shows
+the **deficit** `δ n = 4 − r n = 6/(n+2)` is the tail of a harmonic series, with
+`∑_{k<n} δ k = 6·(H_{n+1} − 1)` diverging.  That qualitative observation explains
+*why* `catalan n` is sub-`4^n` by a polynomial factor.
+
+This follow-up makes the polynomial factor **quantitative** and, crucially,
+extracts its exponent.  Writing each multiplicative step normalised by the
+limiting rate, `r k / 4 = 1 − (3/2)/(k+2)`, the elementary logarithm bound
+`log y ≤ y − 1` gives `log (r k / 4) ≤ −(3/2)/(k+2)`.  Telescoping the recurrence
+through the logarithm,
+
+  `log (catalan n / 4^n) = ∑_{k<n} log (r k / 4) ≤ −(3/2)·(H_{n+1} − 1)`,
+
+so the normalised Catalan numbers obey the explicit bound
+
+  **`catalan_div_le_exp`** : `catalan n / 4^n ≤ exp(−(3/2)·(H_{n+1} − 1))`.
+
+Because `H_{n+1} − 1 ∼ log n`, the right-hand side is `∼ n^{−3/2}`: the
+coefficient `3/2` is *exactly* the critical exponent appearing in the classical
+asymptotic `catalan n ∼ 4^n / (n^{3/2} √π)`.  The same Mathlib inequality applied
+to the reciprocal yields a matching lower bound `log (r k / 4) ≥ −3/(2k+1)`, so
+the recurrence pins `log (catalan n / 4^n)` between two harmonic-type sums *both*
+carrying the leading coefficient `3/2` — the exponent is forced by the recurrence,
+not an artefact of one estimate.
+
+Squeezing `0 ≤ catalan n / 4^n ≤ exp(−(3/2)(H_{n+1} − 1)) → 0` gives an
+**independent, rate-quantified proof** that the normalised Catalan numbers vanish
+(**`catalan_div_tendsto_zero`**), driven entirely by the divergence of the
+harmonic deficit sum from the parent.
+
+No Stirling estimate is used; everything follows from the recurrence ratio, the
+parent's harmonic deficit identity, and `Real.log_le_sub_one_of_pos`.
+
+Reference: https://erdosproblems.com/396
+-/
+
+import Mathlib
+import Proofs.Erdos396OQ04OQ01OQ01
+
+open Nat Filter Topology Finset
+
+namespace Erdos396OQ01OQ01OQ02
+
+open Erdos396OQ01 Erdos396OQ01OQ01
+
+/-! ## The normalised step `r k / 4` and its logarithm -/
+
+/-- The recurrence ratio normalised by the limiting growth rate:
+    `r k / 4 = 1 − (3/2)/(k+2)`. -/
+theorem ratioQuarter_eq (k : ℕ) :
+    catalanRatio k / 4 = 1 - (3 / 2) / ((k : ℝ) + 2) := by
+  rw [ratio_eq_four_sub]; ring
+
+/-- The normalised step is strictly positive. -/
+theorem ratioQuarter_pos (k : ℕ) : 0 < catalanRatio k / 4 := by
+  have := ratio_pos k; positivity
+
+/-- **Upper bound on the log step.** `log (r k / 4) ≤ −(3/2)/(k+2)`.
+
+    This is the elementary inequality `log y ≤ y − 1` at `y = r k / 4`, where
+    `y − 1 = −(3/2)/(k+2)` is (a quarter of) the parent's deficit. -/
+theorem log_ratioQuarter_le (k : ℕ) :
+    Real.log (catalanRatio k / 4) ≤ -(3 / 2) / ((k : ℝ) + 2) := by
+  have h := Real.log_le_sub_one_of_pos (ratioQuarter_pos k)
+  have he : catalanRatio k / 4 - 1 = -(3 / 2) / ((k : ℝ) + 2) := by
+    rw [ratioQuarter_eq]; ring
+  rw [he] at h; exact h
+
+/-- **Lower bound on the log step.** `log (r k / 4) ≥ −3/(2k+1)`.
+
+    The same Mathlib inequality applied to the reciprocal `(r k / 4)⁻¹ = 4 / r k`:
+    `log ((r k/4)⁻¹) ≤ (r k/4)⁻¹ − 1`, and `(r k/4)⁻¹ − 1 = 3/(2k+1)`. -/
+theorem log_ratioQuarter_ge (k : ℕ) :
+    -(3 / ((2 * (k : ℝ) + 1))) ≤ Real.log (catalanRatio k / 4) := by
+  have hpos := ratioQuarter_pos k
+  have h := Real.log_le_sub_one_of_pos (inv_pos.mpr hpos)
+  rw [Real.log_inv] at h
+  -- `(r k / 4)⁻¹ − 1 = 3/(2k+1)`
+  have hr : catalanRatio k = (4 * k + 2) / ((k : ℝ) + 2) := rfl
+  have hk2 : ((k : ℝ) + 2) ≠ 0 := by positivity
+  have hnum : (4 * (k : ℝ) + 2) ≠ 0 := by positivity
+  have he : (catalanRatio k / 4)⁻¹ - 1 = 3 / (2 * (k : ℝ) + 1) := by
+    rw [hr]; field_simp; ring
+  rw [he] at h
+  linarith
+
+/-! ## Telescoping the recurrence through the logarithm -/
+
+/-- **Log-telescoping.** `log (catalan n / 4^n) = ∑_{k<n} log (r k / 4)`.
+
+    Each Catalan step multiplies by `r n`, so normalised by `4` at each step the
+    product collapses; taking logs turns the product into the sum. -/
+theorem normLog_eq_sum (n : ℕ) :
+    Real.log ((catalan n : ℝ) / 4 ^ n)
+      = ∑ k ∈ Finset.range n, Real.log (catalanRatio k / 4) := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    have hcat : (0 : ℝ) < (catalan m : ℝ) / 4 ^ m := by
+      have := catalan_pos m; positivity
+    have hstep : ((catalan (m + 1) : ℝ) / 4 ^ (m + 1))
+        = (catalanRatio m / 4) * ((catalan m : ℝ) / 4 ^ m) := by
+      rw [catalan_succ_eq_ratio_mul]
+      have h4 : (4 : ℝ) ^ m ≠ 0 := by positivity
+      field_simp
+      ring
+    rw [Finset.sum_range_succ, ← ih, hstep,
+      Real.log_mul (ne_of_gt (ratioQuarter_pos m)) (ne_of_gt hcat)]
+    ring
+
+/-! ## The `3/2`-exponent bound -/
+
+/-- **Quantitative upper bound on the log.**
+    `log (catalan n / 4^n) ≤ −(3/2)·(H_{n+1} − 1)`.
+
+    Summing the per-step bound and recognising `∑_{k<n} (3/2)/(k+2)` as a quarter
+    of the parent's harmonic deficit sum `∑ δ k = 6·(H_{n+1} − 1)`. -/
+theorem normLog_le (n : ℕ) :
+    Real.log ((catalan n : ℝ) / 4 ^ n) ≤ -(3 / 2) * (realHarmonic (n + 1) - 1) := by
+  rw [normLog_eq_sum]
+  -- bound the sum termwise
+  have hsum_le : ∑ k ∈ Finset.range n, Real.log (catalanRatio k / 4)
+      ≤ ∑ k ∈ Finset.range n, (-(3 / 2) / ((k : ℝ) + 2)) :=
+    Finset.sum_le_sum (fun k _ => log_ratioQuarter_le k)
+  -- evaluate the comparison sum via the parent's deficit identity
+  have hval : ∑ k ∈ Finset.range n, (-(3 / 2) / ((k : ℝ) + 2))
+      = -(3 / 2) * (realHarmonic (n + 1) - 1) := by
+    have hterm : ∀ k ∈ Finset.range n,
+        (-(3 / 2) / ((k : ℝ) + 2)) = (-(1 / 4)) * catalanDeficit k := by
+      intro k _
+      rw [deficit_eq]; ring
+    rw [Finset.sum_congr rfl hterm, ← Finset.mul_sum, deficit_sum_eq]
+    ring
+  rw [← hval]; exact hsum_le
+
+/-- **Headline: the `3/2`-exponent decay bound.**
+    `catalan n / 4^n ≤ exp(−(3/2)·(H_{n+1} − 1))`.
+
+    Since `H_{n+1} − 1 ∼ log n`, the bound is `∼ n^{−3/2}`: the recurrence alone
+    forces the critical exponent `3/2` of `catalan n ∼ 4^n / (n^{3/2} √π)`. -/
+theorem catalan_div_le_exp (n : ℕ) :
+    (catalan n : ℝ) / 4 ^ n ≤ Real.exp (-(3 / 2) * (realHarmonic (n + 1) - 1)) := by
+  have hpos : (0 : ℝ) < (catalan n : ℝ) / 4 ^ n := by
+    have := catalan_pos n; positivity
+  calc (catalan n : ℝ) / 4 ^ n
+      = Real.exp (Real.log ((catalan n : ℝ) / 4 ^ n)) := (Real.exp_log hpos).symm
+    _ ≤ Real.exp (-(3 / 2) * (realHarmonic (n + 1) - 1)) :=
+        Real.exp_le_exp.mpr (normLog_le n)
+
+/-- **Multiplicative form.**
+    `catalan n ≤ 4^n · exp(−(3/2)·(H_{n+1} − 1))`. -/
+theorem catalan_le_exp_mul (n : ℕ) :
+    (catalan n : ℝ) ≤ 4 ^ n * Real.exp (-(3 / 2) * (realHarmonic (n + 1) - 1)) := by
+  have h4 : (0 : ℝ) < 4 ^ n := by positivity
+  have h := catalan_div_le_exp n
+  rw [div_le_iff₀ h4] at h
+  linarith [h]
+
+/-- **Two-sided log bracket.** The recurrence pins `log (catalan n / 4^n)` between
+    two harmonic-type sums, *both* with leading coefficient `3/2`:
+    `−∑_{k<n} 3/(2k+1) ≤ log (catalan n / 4^n) ≤ −(3/2)·(H_{n+1} − 1)`.
+
+    The exponent `3/2` is therefore forced from both sides, not an artefact of a
+    single estimate. -/
+theorem normLog_bracket (n : ℕ) :
+    -(∑ k ∈ Finset.range n, 3 / (2 * (k : ℝ) + 1)) ≤ Real.log ((catalan n : ℝ) / 4 ^ n)
+      ∧ Real.log ((catalan n : ℝ) / 4 ^ n) ≤ -(3 / 2) * (realHarmonic (n + 1) - 1) := by
+  refine ⟨?_, normLog_le n⟩
+  rw [normLog_eq_sum, ← Finset.sum_neg_distrib]
+  exact Finset.sum_le_sum (fun k _ => log_ratioQuarter_ge k)
+
+/-! ## Independent convergence with explicit rate -/
+
+/-- The exponential bound vanishes: `exp(−(3/2)·(H_{n+1} − 1)) → 0`.
+
+    Driven entirely by the divergence of the parent's harmonic deficit sum. -/
+theorem expBound_tendsto_zero :
+    Tendsto (fun n => Real.exp (-(3 / 2) * (realHarmonic (n + 1) - 1))) atTop (𝓝 0) := by
+  have hH : Tendsto (fun n => realHarmonic (n + 1)) atTop atTop :=
+    realHarmonic_tendsto_atTop.comp (tendsto_add_atTop_nat 1)
+  have hsub : Tendsto (fun n => realHarmonic (n + 1) - 1) atTop atTop :=
+    Filter.tendsto_atTop_add_const_right atTop (-1) hH
+  have hbot : Tendsto (fun n => -(3 / 2) * (realHarmonic (n + 1) - 1)) atTop atBot :=
+    Filter.Tendsto.const_mul_atTop_of_neg (by norm_num : -(3 / 2 : ℝ) < 0) hsub
+  exact Real.tendsto_exp_atBot.comp hbot
+
+/-- **Independent, rate-quantified proof that the normalised Catalan numbers
+    vanish.** `catalan n / 4^n → 0`, squeezed by the explicit `3/2`-exponent
+    bound rather than by Stirling. -/
+theorem catalan_div_tendsto_zero :
+    Tendsto (fun n => (catalan n : ℝ) / 4 ^ n) atTop (𝓝 0) := by
+  apply squeeze_zero (fun n => by positivity) catalan_div_le_exp expBound_tendsto_zero
+
+/-! ## Sanity checks -/
+
+/-- At `k = 0` the normalised step is `r 0 / 4 = 1/4`, and the upper bound there
+    is `−(3/2)/2 = −3/4`. -/
+example : catalanRatio 0 / 4 = 1 / 4 := by rw [ratioQuarter_eq]; norm_num
+
+/-- `−(3/2)/(0+2) = −3/4` matches the per-step bound at `k = 0`. -/
+example : (-(3 / 2) / ((0 : ℝ) + 2)) = -(3 / 4) := by norm_num
+
+/-- The `n = 1` bound: `log (catalan 1 / 4) = log (1/4) ≤ −(3/2)(H₂ − 1) = −3/4`.
+    Here `H₂ = 1 + 1/2`, so the right side is `−(3/2)(1/2) = −3/4`. -/
+example : -(3 / 2 : ℝ) * (realHarmonic 2 - 1) = -(3 / 4) := by
+  rw [realHarmonic_succ, realHarmonic_one]; norm_num
+
+end Erdos396OQ01OQ01OQ02

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-e396oq04oq01oq01oq02-ratioquarter",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 55,
+      "endLine": 58
+    },
+    "type": "key-step",
+    "title": "The 3/2 appears in one normalised step",
+    "content": "Dividing the parent's ratio identity $r\\,k = 4 - 6/(k+2)$ by the limiting rate $4$ gives $r\\,k/4 = 1 - (3/2)/(k+2)$ — a single $\\texttt{ring}$ rewrite. The coefficient $3/2$ of the harmonic correction is *exactly* the critical exponent of the Catalan asymptotic $\\text{catalan}\\,n \\sim 4^n/(n^{3/2}\\sqrt{\\pi})$, exposed here before any summation or limit.",
+    "mathContext": "$\\dfrac{r\\,k}{4} = \\dfrac{1}{4}\\left(4 - \\dfrac{6}{k+2}\\right) = 1 - \\dfrac{3/2}{k+2}$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02-logle",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 67,
+      "endLine": 76
+    },
+    "type": "key-step",
+    "title": "Elementary log bound on each step",
+    "content": "The single Mathlib inequality $\\log y \\le y - 1$ (valid for $y > 0$) at $y = r\\,k/4$ gives $\\log(r\\,k/4) \\le r\\,k/4 - 1 = -(3/2)/(k+2)$ — exactly a quarter of the parent's deficit $\\delta\\,k = 6/(k+2)$. This is the only analytic ingredient; everything downstream is summation and exponentiation.",
+    "mathContext": "$\\log\\frac{r\\,k}{4} \\le \\frac{r\\,k}{4} - 1 = -\\frac{3/2}{k+2} = -\\frac{1}{4}\\,\\delta\\,k.$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02-logge",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 78,
+      "endLine": 90
+    },
+    "type": "observation",
+    "title": "Reciprocal gives a matching lower bound",
+    "content": "Applying the *same* inequality to $(r\\,k/4)^{-1} = 4/r\\,k$ and using $\\log(x^{-1}) = -\\log x$ yields $\\log(r\\,k/4) \\ge -3/(2k+1)$. Both bounds carry leading coefficient $3/2$, so the exponent is pinned from both sides — it is intrinsic to the recurrence, not an artefact of one estimate.",
+    "mathContext": "$-\\log\\frac{r\\,k}{4} = \\log\\frac{4}{r\\,k} \\le \\frac{4}{r\\,k} - 1 = \\frac{3}{2k+1}.$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02-telescope",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 98,
+      "endLine": 114
+    },
+    "type": "key-step",
+    "title": "Telescoping through the logarithm",
+    "content": "Because each Catalan step multiplies by $r\\,m$, normalising by $4$ at every step makes the product collapse: $\\log(\\text{catalan}\\,n/4^n) = \\sum_{k<n} \\log(r\\,k/4)$. The induction's successor step factors $\\text{catalan}(m{+}1)/4^{m+1} = (r\\,m/4)\\cdot(\\text{catalan}\\,m/4^m)$ and splits the logarithm with $\\texttt{Real.log\\_mul}$ (both factors positive). This exact finite identity is the bridge from the integer recurrence to the asymptotic.",
+    "mathContext": "$\\log\\frac{\\text{catalan}\\,n}{4^n} = \\sum_{k=0}^{n-1} \\log\\frac{r\\,k}{4}.$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02-normlogle",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 123,
+      "endLine": 144
+    },
+    "type": "key-step",
+    "title": "Summing to the harmonic deficit",
+    "content": "Summing the per-step bound and recognising each comparison term $-(3/2)/(k+2)$ as $-(1/4)\\,\\delta\\,k$, the parent's deficit sum $\\sum_{k<n}\\delta\\,k = 6\\,(H_{n+1}-1)$ collapses the right-hand side to $-(3/2)\\,(H_{n+1}-1)$. The log of the normalised Catalan number is thus controlled by a harmonic number with the critical coefficient $3/2$.",
+    "mathContext": "$\\log\\frac{\\text{catalan}\\,n}{4^n} \\le \\sum_{k<n}\\left(-\\tfrac{1}{4}\\delta\\,k\\right) = -\\tfrac{3}{2}\\,(H_{n+1}-1).$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02-headline",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 146,
+      "endLine": 155
+    },
+    "type": "key-step",
+    "title": "Headline: the 3/2-exponent decay bound",
+    "content": "Exponentiating via $x = \\exp(\\log x)$ (for $x > 0$) and monotonicity of $\\exp$ gives the headline bound $\\text{catalan}\\,n / 4^n \\le \\exp\\!\\big(-(3/2)\\,(H_{n+1}-1)\\big)$. Since $H_{n+1}-1 \\sim \\log n$, the right side is $\\sim n^{-3/2}$: the recurrence alone forces the critical exponent $3/2$ of $\\text{catalan}\\,n \\sim 4^n/(n^{3/2}\\sqrt\\pi)$, with no Stirling estimate.",
+    "mathContext": "$\\dfrac{\\text{catalan}\\,n}{4^n} \\le \\exp\\!\\Big(-\\tfrac{3}{2}(H_{n+1}-1)\\Big) \\sim n^{-3/2}.$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02-bracket",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 170,
+      "endLine": 175
+    },
+    "type": "observation",
+    "title": "Two-sided log bracket",
+    "content": "Combining the per-step upper and lower bounds, the recurrence pins $\\log(\\text{catalan}\\,n/4^n)$ between $-\\sum_{k<n} 3/(2k+1)$ and $-(3/2)(H_{n+1}-1)$ — two harmonic-type sums both with leading coefficient $3/2$. The exponent $3/2$ is therefore forced from both directions.",
+    "mathContext": "$-\\sum_{k<n}\\frac{3}{2k+1} \\le \\log\\frac{\\text{catalan}\\,n}{4^n} \\le -\\frac{3}{2}(H_{n+1}-1).$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02-squeeze",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 182,
+      "endLine": 197
+    },
+    "type": "observation",
+    "title": "Independent, rate-quantified vanishing",
+    "content": "The bound $\\exp(-(3/2)(H_{n+1}-1)) \\to 0$ because the parent's harmonic deficit sum diverges. Squeezing $0 \\le \\text{catalan}\\,n/4^n \\le \\exp(-(3/2)(H_{n+1}-1))$ then proves $\\text{catalan}\\,n/4^n \\to 0$ — an independent proof of the vanishing, driven by harmonic divergence rather than Stirling, with the decay rate made explicit.",
+    "mathContext": "$0 \\le \\dfrac{\\text{catalan}\\,n}{4^n} \\le \\exp\\!\\Big(-\\tfrac{3}{2}(H_{n+1}-1)\\Big) \\to 0.$"
+  }
+]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,101 @@
+{
+  "id": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+  "title": "Erdős #396 OQ-04 → OQ-01 → OQ-01 → OQ-02: The 3/2 Critical Exponent of Catalan Growth Emerges from the Recurrence",
+  "slug": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+  "description": "Exponentiating the parent's harmonic deficit sum extracts the critical exponent 3/2 of Catalan asymptotics directly from the recurrence. Normalising each multiplicative step, r k / 4 = 1 − (3/2)/(k+2), the elementary bound log y ≤ y − 1 gives log(r k / 4) ≤ −(3/2)/(k+2); telescoping through the logarithm yields log(catalan n / 4^n) = ∑_{k<n} log(r k / 4) ≤ −(3/2)·(H_{n+1} − 1), so catalan n / 4^n ≤ exp(−(3/2)·(H_{n+1} − 1)). Since H_{n+1} − 1 ∼ log n, the bound is ∼ n^{−3/2}: the recurrence alone forces the exponent 3/2 of catalan n ∼ 4^n/(n^{3/2}√π). The same Mathlib inequality applied to the reciprocal pins log(catalan n / 4^n) between two harmonic-type sums both carrying coefficient 3/2, and squeezing the explicit bound gives an independent, rate-quantified proof that catalan n / 4^n → 0.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/396",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos396OQ04OQ01OQ01OQ02.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "catalan",
+      "recurrence",
+      "asymptotics",
+      "harmonic-series",
+      "logarithm",
+      "critical-exponent",
+      "limits"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 396,
+    "erdosUrl": "https://erdosproblems.com/396",
+    "axiomCount": 0,
+    "lineCount": 213,
+    "assumptions": "0 axioms, 0 sorries. All results depend only on the foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool / native_decide). Built against Mathlib 4.26.0.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The grandparent Erdős #396 OQ-04 → OQ-01 reads the two-term Catalan recurrence as the multiplicative step r n = (4n+2)/(n+2) = 4 − 6/(n+2), with r n < 4 and r n → 4. The parent OQ-04 → OQ-01 → OQ-01 shows the deficit δ n = 4 − r n equals exactly 6/(n+2), a harmonic tail, with cumulative sum ∑_{k<n} δ k = 6·(H_{n+1} − 1) diverging — explaining qualitatively why Catalan growth is sub-4^n by a polynomial factor. The classical Stirling asymptotic catalan n ∼ 4^n/(n^{3/2}√π) carries the specific polynomial factor n^{−3/2}; the parent's first open question asked whether exponentiating the log-deficit sum recovers that exponent at the recurrence level. This entry answers the upper-bound half affirmatively.",
+    "problemStatement": "Upgrade the parent's qualitative harmonic divergence to a quantitative bound that exhibits the critical exponent 3/2. Concretely: by exponentiating ∑_{k<n} log(r k / 4) = ∑_{k<n} log(1 − δ k / 4), does the recurrence force a bound of the form catalan n / 4^n ≤ exp(−(3/2)·(H_{n+1} − 1)) ∼ n^{−3/2}?",
+    "text": "Normalising the step, r k / 4 = 1 − (3/2)/(k+2). The elementary inequality log y ≤ y − 1 at y = r k / 4 gives log(r k / 4) ≤ −(3/2)/(k+2), a quarter of the parent deficit. Telescoping the recurrence through the logarithm gives log(catalan n / 4^n) = ∑_{k<n} log(r k / 4), and summing the per-step bound (recognising ∑ (3/2)/(k+2) as a quarter of ∑ δ k = 6·(H_{n+1} − 1)) yields log(catalan n / 4^n) ≤ −(3/2)·(H_{n+1} − 1). Exponentiating: catalan n / 4^n ≤ exp(−(3/2)·(H_{n+1} − 1)), equivalently catalan n ≤ 4^n·exp(−(3/2)·(H_{n+1} − 1)). The same inequality applied to (r k / 4)⁻¹ gives log(r k / 4) ≥ −3/(2k+1), bracketing log(catalan n / 4^n) between two harmonic-type sums both with leading coefficient 3/2. Squeezing 0 ≤ catalan n / 4^n ≤ exp(−(3/2)(H_{n+1} − 1)) → 0 proves catalan n / 4^n → 0 with an explicit rate, independently of Stirling.",
+    "proofStrategy": "Import the parent (Proofs.Erdos396OQ04OQ01OQ01), reusing the ratio identity r n = 4 − 6/(n+2), the deficit identity δ n = 6/(n+2), the deficit running-sum 6·(H_{n+1} − 1), the harmonic recurrence, and the harmonic divergence. (1) ratioQuarter_eq: r k / 4 = 1 − (3/2)/(k+2) by `ring`. (2) log_ratioQuarter_le: apply Real.log_le_sub_one_of_pos to r k / 4 > 0 and rewrite r k/4 − 1 = −(3/2)/(k+2). (3) log_ratioQuarter_ge: apply the same lemma to (r k/4)⁻¹, use Real.log_inv, and compute (r k/4)⁻¹ − 1 = 3/(2k+1) via field_simp. (4) normLog_eq_sum: induction on n; the successor step factors (catalan (m+1):ℝ)/4^(m+1) = (r m/4)·(catalan m/4^m) via catalan_succ_eq_ratio_mul and field_simp, then splits the logarithm with Real.log_mul (both factors positive). (5) normLog_le: Finset.sum_le_sum with the per-step bound, then evaluate the comparison sum termwise as (−1/4)·δ k and apply the parent's deficit_sum_eq. (6) catalan_div_le_exp: x = exp(log x) (Real.exp_log, x > 0) and Real.exp_le_exp.mpr. (7) catalan_le_exp_mul: div_le_iff₀. (8) normLog_bracket: combine the two per-step bounds, distributing the negation over the sum. (9) expBound_tendsto_zero: realHarmonic(n+1) − 1 → ∞ (as in the parent), times −3/2 < 0 → atBot (Tendsto.const_mul_atTop_of_neg), composed with Real.tendsto_exp_atBot. (10) catalan_div_tendsto_zero: squeeze_zero with positivity, catalan_div_le_exp, and expBound_tendsto_zero.",
+    "keyInsights": [
+      "**The exponent 3/2 is visible in a single normalised step.** Dividing the recurrence step by the limiting rate, r k / 4 = 1 − (3/2)/(k+2): the coefficient 3/2 of the harmonic correction is precisely the critical exponent of the Catalan asymptotic, exposed before any summation or limit.",
+      "**Telescoping through the logarithm turns the recurrence into the asymptotic.** Because each Catalan step multiplies by r k, the logarithm of the normalised value is the exact finite sum log(catalan n / 4^n) = ∑_{k<n} log(r k / 4). The elementary bound log y ≤ y − 1 converts this into the parent's harmonic deficit sum, and exponentiating returns the bound catalan n / 4^n ≤ exp(−(3/2)·(H_{n+1} − 1)) ∼ n^{−3/2}.",
+      "**The exponent is forced from both sides.** Applying the very same Mathlib inequality to the reciprocal yields log(r k / 4) ≥ −3/(2k+1), so log(catalan n / 4^n) is bracketed between two harmonic-type sums *both* with leading coefficient 3/2. The 3/2 is intrinsic to the recurrence, not an artefact of one inequality.",
+      "**An independent, rate-quantified proof that catalan n / 4^n → 0.** Squeezing the normalised Catalan numbers between 0 and the explicit exponential bound — which vanishes purely because the parent's harmonic deficit sum diverges — recovers the vanishing of catalan n / 4^n without invoking Stirling, with the decay rate made explicit."
+    ],
+    "prerequisites": [
+      "The parent deficit identity δ n = 6/(n+2) and its running sum ∑_{k<n} δ k = 6·(H_{n+1} − 1)",
+      "The grandparent ratio identity r n = 4 − 6/(n+2) and the recurrence catalan(n+1) = r n · catalan n",
+      "The elementary logarithm inequality log y ≤ y − 1 (Real.log_le_sub_one_of_pos) and exp/log monotonicity",
+      "Divergence of the harmonic series and the squeeze theorem for sequences"
+    ]
+  },
+  "conclusion": {
+    "summary": "Exponentiating the parent's harmonic deficit sum, the recurrence alone forces catalan n / 4^n ≤ exp(−(3/2)·(H_{n+1} − 1)), equivalently catalan n ≤ 4^n·exp(−(3/2)·(H_{n+1} − 1)). Since H_{n+1} − 1 ∼ log n the bound is ∼ n^{−3/2}, exhibiting the critical exponent 3/2 of catalan n ∼ 4^n/(n^{3/2}√π) at the level of the integer recurrence. A reciprocal estimate brackets log(catalan n / 4^n) between two harmonic-type sums both with coefficient 3/2, and a squeeze gives an independent proof that catalan n / 4^n → 0. All eleven theorems are fully machine-checked with no axioms or sorries.",
+    "implications": "The entry answers the upper-bound half of the parent's first open question: the polynomial factor below 4^n is not merely sub-exponential but carries the specific exponent 3/2, and that exponent is extracted by purely recurrence-level reasoning (one elementary logarithm inequality plus the harmonic deficit sum), with no Stirling estimate. The matching reciprocal bound shows the exponent is two-sided, and the squeeze proof reframes the convergence catalan n / 4^n → 0 as a direct consequence of the harmonic divergence established by the parent.",
+    "openQuestions": [
+      "Can the lower bracket −∑_{k<n} 3/(2k+1) be combined with the harmonic asymptotic H_m = log m + γ + o(1) to produce a fully two-sided estimate c₁·4^n/n^{3/2} ≤ catalan n ≤ c₂·4^n/n^{3/2} with explicit constants, closing the gap to Stirling at the recurrence level?",
+      "Does the analogous normalised step for the central-binomial recurrence, (8n+4)/(2n+2)/4 = 1 − (1/2)/(n+1), exponentiate to the matching bound C(2n,n)/4^n ≤ exp(−(1/2)·H_n) ∼ n^{−1/2}, recovering the 1/2 exponent of C(2n,n) ∼ 4^n/√(πn)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos396OQ04OQ01OQ01"
+    ],
+    "opens": [
+      "Nat",
+      "Filter",
+      "Topology",
+      "Finset"
+    ],
+    "namespace": "Erdos396OQ01OQ01OQ02",
+    "lineCount": 213,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Parent OQ: the deficit δ n = 4 − r n = 6/(n+2) is a harmonic tail with ∑_{k<n} δ k = 6·(H_{n+1} − 1) diverging. This follow-up exponentiates that sum to extract the critical exponent 3/2, answering the upper-bound half of the parent's first open question."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01",
+      "relationship": "ancestor",
+      "description": "Grandparent OQ: the asymptotics of the Catalan recurrence ratio r n = 4 − 6/(n+2), with r n < 4, strict monotonicity, and r n → 4, and the recurrence catalan(n+1) = r n · catalan n telescoped here through the logarithm."
+    },
+    {
+      "targetId": "erdos-396-oq-04",
+      "relationship": "ancestor",
+      "description": "The two-term Catalan recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan(n), the source of the ratio whose normalised logarithm is summed here."
+    },
+    {
+      "targetId": "erdos-396",
+      "relationship": "ancestor",
+      "description": "Root problem: descending factorials dividing central binomial coefficients, whose base case rests on the Catalan numbers."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

A new verified follow-up in the **Erdős #396 → OQ-04 → OQ-01 → OQ-01** Catalan-recurrence chain. It **answers the upper-bound half of the parent's first open question**: exponentiating the parent's harmonic deficit sum extracts the *critical exponent 3/2* of Catalan asymptotics directly from the integer recurrence — no Stirling estimate.

## The result

Normalising each multiplicative step by the limiting rate `4`:

```
r k / 4 = 1 − (3/2)/(k+2)
```

The coefficient `3/2` is already the critical exponent of `catalan n ∼ 4^n/(n^{3/2}√π)`, visible in one step. The elementary Mathlib inequality `log y ≤ y − 1` then gives `log(r k/4) ≤ −(3/2)/(k+2)` (a quarter of the parent deficit `δ k = 6/(k+2)`). Telescoping the recurrence through the logarithm,

```
log(catalan n / 4^n) = ∑_{k<n} log(r k / 4) ≤ −(3/2)·(H_{n+1} − 1)
```

and exponentiating yields the headline bound

```
catalan n / 4^n ≤ exp(−(3/2)·(H_{n+1} − 1))   ~ n^{−3/2}.
```

Applying the *same* inequality to the reciprocal gives `log(r k/4) ≥ −3/(2k+1)`, **bracketing** `log(catalan n/4^n)` between two harmonic-type sums both carrying coefficient `3/2` — the exponent is forced from both sides. Squeezing `0 ≤ catalan n/4^n ≤ exp(−(3/2)(H_{n+1}−1)) → 0` gives an **independent, rate-quantified proof** that the normalised Catalan numbers vanish, driven by the parent's harmonic divergence rather than Stirling.

## Verification

- **11 theorems, 0 definitions, 213 lines**, builds against Mathlib 4.26.0 via `docker-build.sh`.
- **0 axioms, 0 sorries.** `#print axioms` on the headline theorems lists only `propext` / `Classical.choice` / `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool` / `native_decide`.
- Self-contained: imports only the **merged** parent `Proofs.Erdos396OQ04OQ01OQ01` (reuses the ratio identity, deficit identity, deficit running-sum, and harmonic divergence); the log-telescoping is reproved inline.

## Files

- `proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02.lean`
- `src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02/{meta,annotations}.json`
- manifest line in `proofs/Proofs.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)