### PR TITLE
research(erdos-10-wip-01): subadditivity of representation and binary popcount

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1111,6 +1111,7 @@ import Proofs.Erdos10OQ02Decidable
 import Proofs.Erdos10OQ02Popcount
 import Proofs.Erdos10PrimePlusPowers
 import Proofs.Erdos10Problem
+import Proofs.Erdos10WIP01
 import Proofs.Erdos1100OQ01Aristotle
 import Proofs.Erdos1100Problem
 import Proofs.Erdos1100ProblemAristotle

--- a/proofs/Proofs/Erdos10WIP01.lean
+++ b/proofs/Proofs/Erdos10WIP01.lean
@@ -1,0 +1,146 @@
+import Proofs.Erdos10OQ02
+import Proofs.Erdos10OQ02Popcount
+
+/-
+# Erdős #10 — WIP: subadditivity of representation and binary popcount
+
+## Context (parent Erdős Problem #10: sums of a prime and powers of 2)
+
+The Erdős–Graham question asks for a constant `k` with every large integer a prime plus at
+most `k` powers of 2. The gallery's `Erdos10OQ02` thread built the machinery:
+
+* `RepWithAtMost k n` — `n` is a sum of at most `k` powers of 2;
+* `repWithAtMost_iff_repDistinct` — `≤ k` powers ⟺ `≤ k` *distinct* powers (reduction lemma);
+* `repWithAtMost_iff_bitIndices_length` — `RepWithAtMost k n ↔ popcount(n) ≤ k`, where
+  `popcount(n) = (Nat.bitIndices n).length` is the binary popcount.
+
+This file adds the **additive structure** that thread was missing:
+
+> **`RepWithAtMost` is subadditive**: if `a` needs `≤ j` powers and `b` needs `≤ k`, then
+> `a + b` needs `≤ j + k` (`repWithAtMost_add`).
+
+Concatenating the two exponent multisets witnesses it. Feeding the *minimal* representations
+(the popcount ones) through this gives, with no extra work, the classical arithmetic fact
+
+> **binary popcount is subadditive**: `popcount(a + b) ≤ popcount(a) + popcount(b)`
+> (`bitIndices_length_add_le`),
+
+— a carry-counting statement here proved purely through the powers-of-2 representation lemma.
+We close with the prime-plus-popcount characterization `isPrimePlusKPowers_iff_popcount`, the
+`O(log)` form of the Erdős #10 predicate that the witness searches (e.g. Grechuk's
+`1117175146`) ultimately rest on.
+
+Tags: number-theory, primes, powers-of-two, binary, popcount, additive-combinatorics, erdos
+-/
+
+namespace Erdos10WIP01
+
+open Erdos10OQ02
+
+/-- Shorthand for the binary popcount `(Nat.bitIndices n).length`: the minimal number of
+    *distinct* powers of two summing to `n`. -/
+abbrev popcount (n : ℕ) : ℕ := (Nat.bitIndices n).length
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I: SUBADDITIVITY OF REPRESENTATION
+
+Concatenating exponent multisets adds both the term counts and the sums.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- **Subadditivity of `RepWithAtMost`.** If `a` is a sum of at most `j` powers of two and
+    `b` is a sum of at most `k`, then `a + b` is a sum of at most `j + k`: just take the
+    union (multiset sum) of the two exponent multisets. -/
+theorem repWithAtMost_add {j k a b : ℕ}
+    (ha : RepWithAtMost j a) (hb : RepWithAtMost k b) :
+    RepWithAtMost (j + k) (a + b) := by
+  obtain ⟨s, hs_card, hs_sum⟩ := ha
+  obtain ⟨t, ht_card, ht_sum⟩ := hb
+  refine ⟨s + t, ?_, ?_⟩
+  · rw [Multiset.card_add]; exact Nat.add_le_add hs_card ht_card
+  · rw [powSum_add, hs_sum, ht_sum]
+
+/-- A single power of two is a sum of one power of two. -/
+theorem repWithAtMost_one_pow (a : ℕ) : RepWithAtMost 1 (2 ^ a) :=
+  ⟨{a}, by simp, by simp [powSum]⟩
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II: BINARY POPCOUNT IS SUBADDITIVE
+
+The popcount representation is the minimal one; subadditivity of representation passes
+straight to subadditivity of popcount.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- Every `n` is a sum of exactly `popcount(n)` distinct powers of two — its binary
+    representation. (The `k = popcount n` case of the characterization.) -/
+theorem repWithAtMost_popcount (n : ℕ) : RepWithAtMost (popcount n) n :=
+  (repWithAtMost_iff_bitIndices_length (popcount n) n).2 le_rfl
+
+/-- `popcount n ≤ k` exactly when `n` is a sum of at most `k` powers of two — the popcount
+    is the *minimal* number of powers needed. -/
+theorem popcount_le_iff (k n : ℕ) : popcount n ≤ k ↔ RepWithAtMost k n :=
+  (repWithAtMost_iff_bitIndices_length k n).symm
+
+/-- **Binary popcount is subadditive**: `popcount(a + b) ≤ popcount(a) + popcount(b)`.
+
+    Proof via representation: `a` is a sum of `popcount(a)` powers and `b` of `popcount(b)`,
+    so by `repWithAtMost_add` their sum `a + b` is a sum of `popcount(a) + popcount(b)` powers,
+    whence its minimal count `popcount(a + b)` is at most that. The carries in binary addition
+    can only *merge* bits (`2^a + 2^a = 2^{a+1}`), never create them. -/
+theorem bitIndices_length_add_le (a b : ℕ) :
+    popcount (a + b) ≤ popcount a + popcount b :=
+  (popcount_le_iff _ _).2 (repWithAtMost_add (repWithAtMost_popcount a) (repWithAtMost_popcount b))
+
+/-- Iterated subadditivity: `popcount(∑ aᵢ) ≤ ∑ popcount(aᵢ)` over a list. -/
+theorem bitIndices_length_sum_le (l : List ℕ) :
+    popcount l.sum ≤ (l.map popcount).sum := by
+  induction l with
+  | nil => simp [popcount]
+  | cons a t ih =>
+    simp only [List.sum_cons, List.map_cons]
+    exact (bitIndices_length_add_le a t.sum).trans (Nat.add_le_add_left ih _)
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III: THE PRIME-PLUS-POPCOUNT CHARACTERIZATION
+
+The Erdős #10 predicate in its O(log)-checkable form.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- **Prime-plus-popcount characterization.** `n` is a prime plus at most `k` powers of two
+    iff there is a prime `p ≤ n` whose offset `n − p` has binary popcount at most `k`. This is
+    the efficient (`O(log)` per prime) form behind the concrete witness searches for Erdős #10
+    (e.g. the smallest even integer needing 3 powers, `906`, and Grechuk's `1117175146`). -/
+theorem isPrimePlusKPowers_iff_popcount (k n : ℕ) :
+    IsPrimePlusKPowers k n ↔ ∃ p : ℕ, p.Prime ∧ p ≤ n ∧ popcount (n - p) ≤ k := by
+  constructor
+  · rintro ⟨p, hp, m, hm, rfl⟩
+    exact ⟨p, hp, Nat.le_add_right p m,
+      by rw [Nat.add_sub_cancel_left]; exact (popcount_le_iff k m).2 hm⟩
+  · rintro ⟨p, hp, hpn, hpc⟩
+    exact ⟨p, hp, n - p, (popcount_le_iff k (n - p)).1 hpc, by omega⟩
+
+end Erdos10WIP01
+
+/-
+## Summary
+
+Adding the additive structure to the Erdős #10 powers-of-two thread:
+
+- `repWithAtMost_add`: `RepWithAtMost` is subadditive — `a` needs `≤ j`, `b` needs `≤ k`
+  ⟹ `a + b` needs `≤ j + k` (union of exponent multisets).
+- `bitIndices_length_add_le`: **binary popcount is subadditive**,
+  `popcount(a + b) ≤ popcount(a) + popcount(b)`, derived purely through the representation
+  lemma (carries only merge bits). `bitIndices_length_sum_le` is the list version.
+- `isPrimePlusKPowers_iff_popcount`: the Erdős #10 predicate as `∃ prime p ≤ n, popcount(n−p) ≤ k`
+  — the `O(log)` form the concrete witness searches rely on.
+
+Built on `Erdos10OQ02` (`RepWithAtMost`, `powSum_add`, `IsPrimePlusKPowers`) and
+`Erdos10OQ02Popcount` (`repWithAtMost_iff_bitIndices_length`).
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/

--- a/src/data/proofs/erdos-10-wip-01/annotations.json
+++ b/src/data/proofs/erdos-10-wip-01/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-rep-add",
+    "proofId": "erdos-10-wip-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 60
+    },
+    "type": "insight",
+    "title": "Representation Cost Is Subadditive",
+    "content": "`repWithAtMost_add` is the structural heart of the file: if a is a sum of at most j powers of two (witness multiset s) and b a sum of at most k (witness t), then the union s + t witnesses that a + b is a sum of at most j + k powers. The term count adds by `Multiset.card_add` and the value adds by the parent's `powSum_add`. No cleverage on the specific exponents is needed — concatenation is the whole argument."
+  },
+  {
+    "id": "ann-popcount-subadd",
+    "proofId": "erdos-10-wip-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 102
+    },
+    "type": "insight",
+    "title": "Popcount Subadditivity, for Free",
+    "content": "`bitIndices_length_add_le` proves popcount(a+b) ≤ popcount(a)+popcount(b) without touching binary digits directly. The popcount representation is the *minimal* one (`repWithAtMost_popcount`), so a is a sum of popcount(a) powers and b of popcount(b); subadditivity of representation combines them into a representation of a+b with popcount(a)+popcount(b) powers; and the minimality direction (`popcount_le_iff`) reads off the bound. The arithmetic content — that carries in binary addition only merge bits (2^a+2^a = 2^{a+1}), never create them — is delivered entirely through the powers-of-2 representation lemma."
+  },
+  {
+    "id": "ann-prime-popcount",
+    "proofId": "erdos-10-wip-01",
+    "range": {
+      "startLine": 120,
+      "endLine": 138
+    },
+    "type": "concept",
+    "title": "The Erdős #10 Predicate in O(log) Form",
+    "content": "`isPrimePlusKPowers_iff_popcount` rewrites 'n is a prime plus at most k powers of two' as 'there is a prime p ≤ n whose offset n − p has binary popcount at most k'. The powers component m = n − p is the only place the representation cost lives, and it is now an O(log)-evaluable popcount rather than a multiset search. This is the predicate the concrete Granville–Soundararajan witness searches rest on — the smallest even integer needing 3 powers (906) and Grechuk's counterexample 1117175146 to the k = 3 conjecture."
+  }
+]

--- a/src/data/proofs/erdos-10-wip-01/meta.json
+++ b/src/data/proofs/erdos-10-wip-01/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "erdos-10-wip-01",
+  "title": "Erdős #10: Subadditivity of Representation and Binary Popcount",
+  "slug": "erdos-10-wip-01",
+  "description": "Adds the additive structure missing from the Erdős #10 powers-of-two thread. Proves RepWithAtMost is subadditive (a needs ≤j powers, b needs ≤k ⟹ a+b needs ≤j+k, by union of exponent multisets) and derives — purely through the powers-of-2 representation lemma — that binary popcount is subadditive: popcount(a+b) ≤ popcount(a)+popcount(b). Closes with the prime-plus-popcount characterization IsPrimePlusKPowers k n ↔ ∃ prime p≤n, popcount(n−p)≤k, the O(log) form behind the concrete witness searches for Erdős #10. Built on the verified Erdos10OQ02 / Erdos10OQ02Popcount thread.",
+  "meta": {
+    "author": "Erdős & Graham (problem); formalized in Lean 4",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos10WIP01.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "powers-of-two",
+      "binary",
+      "popcount",
+      "additive-combinatorics",
+      "erdos-problem"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 146,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, no `native_decide`. `#print axioms` reports only the ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted under the project's axiom-integrity policy. Imports the verified Erdos10OQ02 and Erdos10OQ02Popcount files and reuses RepWithAtMost, powSum_add, IsPrimePlusKPowers, and repWithAtMost_iff_bitIndices_length; all new results are fully machine-checked.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Multiset.card_add",
+        "description": "card (s + t) = card s + card t — drives the subadditive term count",
+        "module": "Mathlib.Data.Multiset.Basic"
+      },
+      {
+        "theorem": "Nat.bitIndices",
+        "description": "The list of positions of set bits; its length is the binary popcount",
+        "module": "Mathlib.Data.Nat.BitIndices"
+      }
+    ],
+    "dateAdded": "2026-06-22",
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "parentDependencies": [
+      "Erdos10OQ02",
+      "Erdos10OQ02Popcount"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #10 asks whether some fixed k makes every sufficiently large integer a prime plus at most k powers of 2 — a question Erdős called 'probably unattackable', and which he and Graham conjectured has no such k. Gallagher (1975) showed the representable set has density arbitrarily close to 1; Granville–Soundararajan (1998) conjectured k = 3 suffices for odd integers; Grechuk found that 1117175146 is not a prime plus at most 3 powers of 2. The gallery's Erdos10OQ02 thread formalized the combinatorial backbone: representability by at most k powers of 2 reduces to k *distinct* powers, whose minimal count is the binary popcount, giving an O(log n) decision procedure.\n\nThe one structural fact that thread never recorded is how representation behaves under addition. Concatenating two exponent multisets shows that representing a + b costs at most the sum of the costs of a and b — subadditivity. Specialized to the minimal (popcount) representations, this yields the classical fact that the binary popcount is subadditive, popcount(a+b) ≤ popcount(a)+popcount(b): adding two numbers in binary can only merge bits via carries (2^a + 2^a = 2^{a+1}), never create them.",
+    "problemStatement": "**Work-in-progress on Erdős Problem #10**: extend the powers-of-two representation thread with its additive structure — subadditivity of `RepWithAtMost`, the resulting subadditivity of binary popcount, and the O(log) prime-plus-popcount form of the Erdős #10 predicate.",
+    "text": "A 146-line, fully verified (0 sorries, 0 axioms, no native_decide) file building on the thread. Part I proves repWithAtMost_add: the union of the two exponent multisets witnesses RepWithAtMost (j+k) (a+b). Part II passes this through the minimal popcount representations to obtain bitIndices_length_add_le: popcount(a+b) ≤ popcount(a)+popcount(b), plus the list-iterated bitIndices_length_sum_le. Part III gives isPrimePlusKPowers_iff_popcount: n is a prime plus ≤ k powers iff some prime p ≤ n has popcount(n−p) ≤ k.",
+    "proofStrategy": "`repWithAtMost_add` takes the witnessing multisets s (for a) and t (for b) and returns s + t: `Multiset.card_add` gives card(s+t) = card s + card t ≤ j + k, and the parent's `powSum_add` gives powSum(s+t) = a + b. For popcount subadditivity, `repWithAtMost_popcount` (the k = popcount n case of `repWithAtMost_iff_bitIndices_length`) supplies minimal representations of a and b; `repWithAtMost_add` combines them into a representation of a + b with popcount(a)+popcount(b) powers; and `popcount_le_iff` (the reverse iff) reads off popcount(a+b) ≤ popcount(a)+popcount(b). The list version is a one-line induction. The prime-plus-popcount characterization unfolds IsPrimePlusKPowers and rewrites the powers component m = n − p through `repWithAtMost_iff_bitIndices_length`, with `omega` discharging the arithmetic p + (n − p) = n under p ≤ n.",
+    "keyInsights": [
+      "Representation cost is subadditive: concatenating exponent multisets adds both the term counts and the sums, so RepWithAtMost (j+k) (a+b) follows from RepWithAtMost j a and RepWithAtMost k b.",
+      "Feeding the minimal (popcount) representations through subadditivity yields popcount(a+b) ≤ popcount(a)+popcount(b) for free — a carry-counting fact proved purely via the powers-of-2 representation lemma.",
+      "Binary addition's carries only merge bits (2^a + 2^a = 2^{a+1}); they never increase the total bit count, which is the combinatorial content of popcount subadditivity.",
+      "The prime-plus-popcount characterization turns the Erdős #10 predicate into ∃ prime p ≤ n with popcount(n−p) ≤ k — O(log) per prime, the efficient form the concrete witness searches (906, Grechuk's 1117175146) rely on.",
+      "Reusing the verified thread (powSum_add, repWithAtMost_iff_bitIndices_length) keeps the additive layer short and self-evidently correct."
+    ],
+    "prerequisites": [
+      "The Erdős #10 powers-of-two thread (RepWithAtMost, powSum, popcount characterization)",
+      "Multisets and their cardinality in Lean 4/Mathlib",
+      "Binary representation / Nat.bitIndices"
+    ]
+  },
+  "sections": [
+    {
+      "id": "rep-subadd",
+      "title": "Part I: Subadditivity of Representation",
+      "startLine": 42,
+      "endLine": 66,
+      "summary": "repWithAtMost_add: RepWithAtMost j a → RepWithAtMost k b → RepWithAtMost (j+k) (a+b), via the union of exponent multisets. repWithAtMost_one_pow: a single power costs one.",
+      "mathContext": "Concatenating exponent multisets adds term counts (Multiset.card_add) and sums (powSum_add)."
+    },
+    {
+      "id": "popcount-subadd",
+      "title": "Part II: Binary Popcount Is Subadditive",
+      "startLine": 68,
+      "endLine": 112,
+      "summary": "repWithAtMost_popcount, popcount_le_iff: the popcount is the minimal power count. bitIndices_length_add_le: popcount(a+b) ≤ popcount(a)+popcount(b). bitIndices_length_sum_le: the list version.",
+      "mathContext": "Minimal representations + subadditivity of representation give subadditivity of popcount; carries only merge bits."
+    },
+    {
+      "id": "prime-popcount",
+      "title": "Part III: The Prime-Plus-Popcount Characterization",
+      "startLine": 114,
+      "endLine": 138,
+      "summary": "isPrimePlusKPowers_iff_popcount: IsPrimePlusKPowers k n ↔ ∃ prime p ≤ n, popcount(n−p) ≤ k.",
+      "mathContext": "The O(log)-checkable form of the Erdős #10 predicate behind the concrete witness searches."
+    }
+  ],
+  "conclusion": {
+    "summary": "This WIP file equips the Erdős #10 powers-of-two thread with its additive structure: RepWithAtMost is subadditive, and consequently binary popcount is subadditive — popcount(a+b) ≤ popcount(a)+popcount(b) — derived entirely through the powers-of-2 representation lemma. It also records the prime-plus-popcount characterization, the O(log) form of the Erdős #10 predicate.",
+    "implications": "Subadditivity is the structural property that makes the powers-of-2 cost behave well under the additive decompositions central to Erdős #10, and the popcount corollary is a clean arithmetic fact obtained without bit-level carry bookkeeping. The prime-plus-popcount characterization is the practical engine for verifying or refuting concrete witnesses such as Grechuk's 1117175146.",
+    "openQuestions": [
+      "Use isPrimePlusKPowers_iff_popcount with a verified prime sieve to certify a concrete Granville–Soundararajan witness (e.g. that 1117175146 is not a prime plus ≤ 3 powers of 2) without native_decide.",
+      "Prove a matching lower bound popcount(a+b) ≥ |popcount(a) − popcount(b)| or characterize equality (no carries) in the subadditive bound.",
+      "Formalize the covering-congruence construction giving infinitely many even integers not in S_3."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-10",
+      "relationship": "extends",
+      "description": "Parent: Erdős Problem #10, sums of a prime and powers of 2."
+    },
+    {
+      "targetId": "erdos-10-oq-02",
+      "relationship": "extends",
+      "description": "Builds on the reduction lemma and popcount decision procedure of the OQ-02 thread, adding additive structure."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.Erdos10OQ02",
+      "Proofs.Erdos10OQ02Popcount"
+    ],
+    "opens": [
+      "Erdos10OQ02"
+    ],
+    "namespace": "Erdos10WIP01",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "mainTheorems": [
+      {
+        "name": "bitIndices_length_add_le",
+        "type": "core",
+        "description": "Binary popcount is subadditive: popcount(a+b) ≤ popcount(a)+popcount(b)",
+        "leanType": "(a b : ℕ) → popcount (a + b) ≤ popcount a + popcount b"
+      },
+      {
+        "name": "repWithAtMost_add",
+        "type": "key",
+        "description": "RepWithAtMost is subadditive, via the union of exponent multisets",
+        "leanType": "RepWithAtMost j a → RepWithAtMost k b → RepWithAtMost (j + k) (a + b)"
+      },
+      {
+        "name": "isPrimePlusKPowers_iff_popcount",
+        "type": "key",
+        "description": "The Erdős #10 predicate as ∃ prime p ≤ n with popcount(n−p) ≤ k",
+        "leanType": "(k n : ℕ) → IsPrimePlusKPowers k n ↔ ∃ p : ℕ, p.Prime ∧ p ≤ n ∧ popcount (n - p) ≤ k"
+      }
+    ],
+    "path": "Proofs/Erdos10WIP01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "bitIndices_length_add_le",
+      "type": "core",
+      "description": "Binary popcount is subadditive: popcount(a+b) ≤ popcount(a)+popcount(b), via the representation lemma",
+      "leanType": "(a b : ℕ) → popcount (a + b) ≤ popcount a + popcount b"
+    },
+    {
+      "name": "repWithAtMost_add",
+      "type": "key",
+      "description": "Subadditivity of RepWithAtMost",
+      "leanType": "RepWithAtMost j a → RepWithAtMost k b → RepWithAtMost (j + k) (a + b)"
+    },
+    {
+      "name": "isPrimePlusKPowers_iff_popcount",
+      "type": "key",
+      "description": "Prime-plus-popcount characterization, the O(log) form of the Erdős #10 predicate",
+      "leanType": "(k n : ℕ) → IsPrimePlusKPowers k n ↔ ∃ p : ℕ, p.Prime ∧ p ≤ n ∧ popcount (n - p) ≤ k"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Gallagher, Patrick X.",
+      "title": "Primes and powers of 2",
+      "year": "1975",
+      "venue": "Inventiones Mathematicae 29, 125–142",
+      "note": "Density of the representable set tends to 1"
+    },
+    {
+      "authors": "Granville, Andrew; Soundararajan, Kannan",
+      "title": "A binary additive problem of Erdős and the order of 2 mod p²",
+      "year": "1998",
+      "venue": "Ramanujan Journal 2, 283–298",
+      "note": "Conjectures k = 3 for odd integers; the witness searches use the prime-plus-popcount predicate"
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "Problems and results on combinatorial number theory",
+      "year": "1973",
+      "venue": "A survey of combinatorial theory",
+      "note": "The original 'prime plus k powers of 2' problem, called 'probably unattackable'"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

A WIP contribution to **Erdős Problem #10** (sums of a prime and powers of 2). The gallery's `Erdos10OQ02` thread built `RepWithAtMost`, the reduction lemma, and the popcount decision procedure — but never recorded how representation behaves under **addition**. This PR adds that.

**`Erdos10WIP01.lean`** — 146 lines, 7 theorems, 1 def, **0 sorries, 0 axioms, no `native_decide`** (`#print axioms` → only propext/Classical.choice/Quot.sound). Imports and reuses the verified thread.

### Subadditivity of representation
- `repWithAtMost_add`: `RepWithAtMost j a → RepWithAtMost k b → RepWithAtMost (j+k) (a+b)`, witnessed by the union of the two exponent multisets (`Multiset.card_add` + the parent's `powSum_add`).

### Binary popcount is subadditive — for free
- `bitIndices_length_add_le`: **`popcount(a+b) ≤ popcount(a)+popcount(b)`**, derived purely through the representation lemma: feed the *minimal* (popcount) representations of `a` and `b` through `repWithAtMost_add`. The carry-counting content — carries only merge bits (`2^a+2^a=2^{a+1}`), never create them — falls out with no bit-level bookkeeping. `bitIndices_length_sum_le` is the list version.

### The Erdős #10 predicate in O(log) form
- `isPrimePlusKPowers_iff_popcount`: `IsPrimePlusKPowers k n ↔ ∃ prime p ≤ n, popcount(n−p) ≤ k` — the efficient form behind the concrete witness searches (e.g. Grechuk's `1117175146`).

## Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos10WIP01` → Build completed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)