### PR TITLE
research(area-of-circle-oq-05-oq-03-oq-05): the first Hermite function is a Fourier eigenfunction

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -165,6 +165,7 @@ import Proofs.AreaOfCircleOQ05OQ01
 import Proofs.AreaOfCircleOQ05OQ01Aristotle
 import Proofs.AreaOfCircleOQ05OQ02
 import Proofs.AreaOfCircleOQ05OQ03
+import Proofs.AreaOfCircleOQ05OQ03OQ05
 import Proofs.AreaOfCircleOQ05OQ03OQ02
 import Proofs.AreaOfCircleOQ05OQ03OQ01
 import Proofs.AreaOfCircleOQ05OQ04

--- a/proofs/Proofs/AreaOfCircleOQ05OQ03OQ05.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ03OQ05.lean
@@ -1,0 +1,301 @@
+/-
+  The first Hermite function is a Fourier eigenfunction
+  (area-of-circle-oq-05-oq-03-oq-05)
+
+  A follow-up open question from `area-of-circle-oq-05-oq-03` ("The Gaussian is
+  its own Fourier transform").  The parent proves that the Gaussian density
+  e^{-x²/2} is fixed by the Fourier transform — it is the *ground state*, the
+  eigenfunction with eigenvalue 1.  Here we climb one rung of the Hermite ladder
+  and prove that the **first Hermite function**
+
+      ψ₁(x) = x · e^{-x²/2}
+
+  is again a Fourier eigenfunction, now with eigenvalue `i` (the first excited
+  state of the harmonic oscillator).  Concretely, in explicit Lebesgue-integral
+  form,
+
+      ∫_ℝ e^{i t x} · x · e^{-x²/2} dx = i · t · e^{-t²/2} · √(2π)
+                                       = (i · √(2π)) · ψ₁(t).
+
+  Since ψ₁(t) = t·e^{-t²/2}, the right-hand side is `i·√(2π)·ψ₁(t)`, i.e. ψ₁ is
+  carried to a constant (i·√(2π)) times itself: it is an eigenfunction of the
+  (un-normalized) Fourier transform with eigenvalue `i·√(2π)`, equivalently
+  eigenvalue `i` under the unitary normalization.  Together with the parent
+  (Gaussian ↦ eigenvalue 1 = i⁰) this exhibits the first two rungs of the
+  classical Fourier eigenvalue ladder `iⁿ`.
+
+  METHOD.  Differentiate the parent Gaussian Fourier identity
+      F(t) := ∫ e^{i t x} e^{-x²/2} dx = e^{-t²/2}·√(2π)
+  with respect to the frequency `t`.  Differentiating under the integral sign
+  pulls down a factor `i x`:
+      F'(t) = ∫ (i x) e^{i t x} e^{-x²/2} dx,
+  while differentiating the closed form gives F'(t) = -t·e^{-t²/2}·√(2π).
+  Equating and dividing by `i` yields the stated value.  The differentiation
+  under the integral is justified by `hasDerivAt_integral_of_dominated_loc_of_deriv_le`
+  with the `t`-independent dominating function `|x|·e^{-x²/2}` (the derivative in
+  `t` has modulus `|x|·e^{-x²/2}` because `|e^{i t x}| = 1`).
+
+  Everything is proved with 0 sorries and 0 axioms.
+
+  References:
+  - Hermite functions as eigenfunctions of the Fourier transform, e.g.
+    Stein–Shakarchi, Fourier Analysis (2003), Ch. 5–6; Folland, Harmonic
+    Analysis in Phase Space.
+  - Mathlib: Analysis.SpecialFunctions.Gaussian.FourierTransform,
+    Analysis.Calculus.ParametricIntegral.
+-/
+import Mathlib
+
+set_option maxHeartbeats 1200000
+set_option linter.unusedVariables false
+set_option linter.unusedSectionVars false
+
+open Real Complex MeasureTheory
+open scoped Real
+
+namespace GaussianHermiteFourier
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I:  THE PARENT GAUSSIAN FOURIER IDENTITY (reproved, self-contained)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Completing the square at the level of the integrand:
+    e^{i t x} · e^{-x²/2} = e^{-(1/2)(x + (-t)·i)²} · e^{-t²/2}. -/
+theorem integrand_complete_square (t x : ℝ) :
+    Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)
+      = Complex.exp (-(((1 : ℝ) / 2 : ℝ) : ℂ) * ((x : ℂ) + ((-t : ℝ) : ℂ) * Complex.I) ^ 2)
+        * Complex.exp (-(t : ℂ) ^ 2 / 2) := by
+  rw [← Complex.exp_add, ← Complex.exp_add]
+  congr 1
+  push_cast
+  linear_combination (t : ℂ) ^ 2 / 2 * Complex.I_sq
+
+/-- The Mathlib contour constant `(π/(1/2))^(1/2)` is the coercion of `√(2π)`. -/
+theorem cpow_half_eq_sqrt_two_pi :
+    ((π : ℂ) / (((1 : ℝ) / 2 : ℝ) : ℂ)) ^ (1 / 2 : ℂ)
+      = ((Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  have h0 : (0 : ℝ) ≤ 2 * π := by positivity
+  rw [show ((π : ℂ) / (((1 : ℝ) / 2 : ℝ) : ℂ)) = ((2 * π : ℝ) : ℂ) by push_cast; ring]
+  rw [Real.sqrt_eq_rpow, Complex.ofReal_cpow h0]
+  norm_num
+
+/-- **The Gaussian is its own Fourier transform** (parent result, reproved):
+    ∫ e^{i t x} e^{-x²/2} dx = e^{-t²/2}·√(2π). -/
+theorem gaussian_fourier_real (t : ℝ) :
+    ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)
+      = Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  simp_rw [integrand_complete_square t]
+  rw [MeasureTheory.integral_mul_const]
+  rw [GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I
+        (b := (((1 : ℝ) / 2 : ℝ) : ℂ)) (by rw [Complex.ofReal_re]; norm_num) (-t)]
+  rw [cpow_half_eq_sqrt_two_pi]
+  ring
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II:  ANALYTIC INGREDIENTS FOR DIFFERENTIATION UNDER THE INTEGRAL
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The norm of the integrand `e^{i t x}·e^{-x²/2}` is the real Gaussian
+    `e^{-(1/2)x²}` (the phase has modulus one). -/
+theorem norm_integrand (t x : ℝ) :
+    ‖Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)‖
+      = Real.exp (-(1 / 2) * x ^ 2) := by
+  rw [norm_mul, Complex.norm_exp, Complex.norm_exp]
+  have h1 : (Complex.I * (t : ℂ) * (x : ℂ)).re = 0 := by
+    simp [Complex.mul_re, Complex.mul_im]
+  have h2 : (-(x : ℂ) ^ 2 / 2).re = -(1 / 2) * x ^ 2 := by
+    have : (-(x : ℂ) ^ 2 / 2) = (((-(1 / 2) * x ^ 2 : ℝ)) : ℂ) := by push_cast; ring
+    rw [this, Complex.ofReal_re]
+  rw [h1, h2, Real.exp_zero, one_mul]
+
+/-- Integrability of the Gaussian Fourier integrand for each frequency `t`. -/
+theorem integrable_integrand (t : ℝ) :
+    Integrable (fun x : ℝ =>
+      Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)) := by
+  refine Integrable.mono' (g := fun x : ℝ => Real.exp (-(1 / 2) * x ^ 2))
+    (integrable_exp_neg_mul_sq (by norm_num : (0 : ℝ) < 1 / 2)) ?_ ?_
+  · apply Continuous.aestronglyMeasurable
+    fun_prop
+  · exact Filter.Eventually.of_forall (fun x => le_of_eq (norm_integrand t x))
+
+/-- The pointwise `t`-derivative of the integrand brings down a factor `i x`. -/
+theorem hasDerivAt_integrand (t x : ℝ) :
+    HasDerivAt (fun s : ℝ => Complex.exp (Complex.I * s * x) * Complex.exp (-(x : ℂ) ^ 2 / 2))
+      (Complex.I * x * Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)) t := by
+  have hbase :
+      HasDerivAt (fun z : ℂ => Complex.exp (Complex.I * z * x) * Complex.exp (-(x : ℂ) ^ 2 / 2))
+        (Complex.exp (Complex.I * (t : ℂ) * x) * (Complex.I * 1 * x)
+          * Complex.exp (-(x : ℂ) ^ 2 / 2)) (t : ℂ) := by
+    have hlin : HasDerivAt (fun z : ℂ => Complex.I * z * (x : ℂ)) (Complex.I * 1 * (x : ℂ)) (t : ℂ) :=
+      ((hasDerivAt_id (t : ℂ)).const_mul Complex.I).mul_const (x : ℂ)
+    exact (hlin.cexp).mul_const (Complex.exp (-(x : ℂ) ^ 2 / 2))
+  have := hbase.comp_ofReal (z := t)
+  convert this using 1
+  ring
+
+/-- The dominating function `‖x · e^{-(1/2)x²}‖ = |x|·e^{-(1/2)x²}` is integrable. -/
+theorem integrable_bound :
+    Integrable (fun x : ℝ => ‖(x : ℝ) * Real.exp (-(1 / 2) * x ^ 2)‖) :=
+  (integrable_mul_exp_neg_mul_sq (by norm_num : (0 : ℝ) < 1 / 2)).norm
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III:  THE FIRST HERMITE FOURIER EIGENFUNCTION
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **The first Hermite function is a Fourier eigenfunction.**
+
+      ∫_ℝ e^{i t x} · x · e^{-x²/2} dx = i · t · e^{-t²/2} · √(2π). -/
+theorem gaussian_fourier_first_hermite (t : ℝ) :
+    (∫ x : ℝ, (x : ℂ) * Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2))
+      = Complex.I * t * Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ) := by
+  -- Differentiate F(s) = ∫ e^{i s x} e^{-x²/2} dx under the integral sign at s = t.
+  obtain ⟨_, hderiv⟩ := hasDerivAt_integral_of_dominated_loc_of_deriv_le
+    (ε := 1)
+    (bound := fun x : ℝ => ‖(x : ℝ) * Real.exp (-(1 / 2) * x ^ 2)‖)
+    (F := fun s x : ℝ => Complex.exp (Complex.I * s * x) * Complex.exp (-(x : ℂ) ^ 2 / 2))
+    (F' := fun s x : ℝ =>
+      Complex.I * x * Complex.exp (Complex.I * s * x) * Complex.exp (-(x : ℂ) ^ 2 / 2))
+    (x₀ := t)
+    one_pos
+    (Filter.Eventually.of_forall (fun s => (integrable_integrand s).aestronglyMeasurable))
+    (integrable_integrand t)
+    (by
+      apply Continuous.aestronglyMeasurable
+      fun_prop)
+    (by
+      refine Filter.Eventually.of_forall (fun x s _ => ?_)
+      refine le_of_eq ?_
+      show ‖Complex.I * (x : ℂ) * Complex.exp (Complex.I * (s : ℝ) * x)
+            * Complex.exp (-(x : ℂ) ^ 2 / 2)‖ = ‖(x : ℝ) * Real.exp (-(1 / 2) * x ^ 2)‖
+      rw [show Complex.I * (x : ℂ) * Complex.exp (Complex.I * s * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)
+            = Complex.exp (Complex.I * s * x) * Complex.exp (-(x : ℂ) ^ 2 / 2) * (Complex.I * (x : ℂ))
+          by ring]
+      rw [norm_mul, norm_integrand, norm_mul, Complex.norm_I, one_mul, Complex.norm_real,
+          Real.norm_eq_abs, Real.norm_eq_abs, abs_mul, Real.abs_exp]
+      exact mul_comm _ _)
+    integrable_bound
+    (Filter.Eventually.of_forall (fun x s _ => hasDerivAt_integrand s x))
+  -- Replace the integral by the parent closed form, then differentiate it.
+  have hclosed : (fun s : ℝ =>
+        ∫ x : ℝ, Complex.exp (Complex.I * s * x) * Complex.exp (-(x : ℂ) ^ 2 / 2))
+      = (fun s : ℝ => Complex.exp (-(s : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)) :=
+    funext gaussian_fourier_real
+  rw [hclosed] at hderiv
+  -- Derivative of the closed form e^{-s²/2}·√(2π) is -s·e^{-s²/2}·√(2π).
+  have hderiv2 :
+      HasDerivAt (fun s : ℝ => Complex.exp (-(s : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ))
+        (-(t : ℂ) * Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)) t := by
+    have hbase :
+        HasDerivAt (fun z : ℂ => Complex.exp (-z ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ))
+          (Complex.exp (-(t : ℂ) ^ 2 / 2) * (-(t : ℂ))
+            * ((Real.sqrt (2 * π) : ℝ) : ℂ)) (t : ℂ) := by
+      have hquad : HasDerivAt (fun z : ℂ => -z ^ 2 / 2) (-(t : ℂ)) (t : ℂ) := by
+        have h : HasDerivAt (fun z : ℂ => z ^ 2) (2 * (t : ℂ)) (t : ℂ) := by
+          simpa using hasDerivAt_pow 2 (t : ℂ)
+        convert h.neg.div_const 2 using 1
+        ring
+      exact (hquad.cexp).mul_const ((Real.sqrt (2 * π) : ℝ) : ℂ)
+    have := hbase.comp_ofReal (z := t)
+    convert this using 1
+    ring
+  -- Equate the two derivatives of the same function.
+  have heq :
+      (∫ x : ℝ,
+          Complex.I * x * Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2))
+        = -(t : ℂ) * Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ) :=
+    hderiv.unique hderiv2
+  -- Pull the constant factor `i` out of the integral.
+  rw [show (fun x : ℝ =>
+        Complex.I * x * Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2))
+      = (fun x : ℝ =>
+        Complex.I * ((x : ℂ) * Complex.exp (Complex.I * t * x)
+          * Complex.exp (-(x : ℂ) ^ 2 / 2))) from by funext x; ring] at heq
+  rw [MeasureTheory.integral_const_mul] at heq
+  -- Solve `i · J = R` for `J`, using `i·(-i) = 1` (no `i² = -1` needed for the cast step).
+  rw [show Complex.I * t * Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)
+        = -Complex.I * (-(t : ℂ) * Complex.exp (-(t : ℂ) ^ 2 / 2)
+          * ((Real.sqrt (2 * π) : ℝ) : ℂ)) from by ring]
+  rw [← heq, ← mul_assoc, neg_mul, Complex.I_mul_I, neg_neg, one_mul]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV:  EIGENFUNCTION FORM AND CONSEQUENCES
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Eigenfunction form.**  Writing ψ₁(x) = x·e^{-x²/2} for the first Hermite
+    function, the Fourier transform carries ψ₁ to `(i·√(2π))·ψ₁`:
+
+      ∫ e^{i t x} ψ₁(x) dx = (i·√(2π)) · ψ₁(t).
+
+    So ψ₁ is a Fourier eigenfunction with eigenvalue `i·√(2π)` (eigenvalue `i`
+    after unitary normalization), the first excited state above the Gaussian. -/
+theorem first_hermite_fourier_eigenfunction (t : ℝ) :
+    (∫ x : ℝ, Complex.exp (Complex.I * t * x) * ((x : ℂ) * Complex.exp (-(x : ℂ) ^ 2 / 2)))
+      = (Complex.I * ((Real.sqrt (2 * π) : ℝ) : ℂ)) * ((t : ℂ) * Complex.exp (-(t : ℂ) ^ 2 / 2)) := by
+  rw [show (fun x : ℝ => Complex.exp (Complex.I * t * x) * ((x : ℂ) * Complex.exp (-(x : ℂ) ^ 2 / 2)))
+        = (fun x : ℝ => (x : ℂ) * Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2))
+      from by funext x; ring]
+  rw [gaussian_fourier_first_hermite]
+  ring
+
+/-- **Odd-integrand sanity check (`t = 0`).**  The first moment of the Gaussian
+    vanishes: ∫ x·e^{-x²/2} dx = 0. -/
+theorem first_moment_gaussian_zero :
+    (∫ x : ℝ, (x : ℂ) * Complex.exp (-(x : ℂ) ^ 2 / 2)) = 0 := by
+  have h := gaussian_fourier_first_hermite 0
+  simp only [Complex.ofReal_zero, mul_zero, zero_mul, Complex.exp_zero, mul_one] at h
+  simpa using h
+
+/-- **Normalized eigenvalue.**  Dividing by `√(2π)`, the normalized first Hermite
+    function `x·e^{-x²/2}/√(2π)` has Fourier eigenvalue exactly `i`:
+
+      ∫ e^{i t x} · (x·e^{-x²/2}/√(2π)) dx = i · (t·e^{-t²/2}). -/
+theorem first_hermite_fourier_normalized (t : ℝ) :
+    (∫ x : ℝ, Complex.exp (Complex.I * t * x)
+        * ((x : ℂ) * Complex.exp (-(x : ℂ) ^ 2 / 2) / ((Real.sqrt (2 * π) : ℝ) : ℂ)))
+      = Complex.I * ((t : ℂ) * Complex.exp (-(t : ℂ) ^ 2 / 2)) := by
+  have hC : ((Real.sqrt (2 * π) : ℝ) : ℂ) ≠ 0 := by
+    rw [Complex.ofReal_ne_zero]
+    exact ne_of_gt (Real.sqrt_pos.mpr (by positivity))
+  rw [show (fun x : ℝ => Complex.exp (Complex.I * t * x)
+        * ((x : ℂ) * Complex.exp (-(x : ℂ) ^ 2 / 2) / ((Real.sqrt (2 * π) : ℝ) : ℂ)))
+      = (fun x : ℝ => (Complex.exp (Complex.I * t * x)
+        * ((x : ℂ) * Complex.exp (-(x : ℂ) ^ 2 / 2))) / ((Real.sqrt (2 * π) : ℝ) : ℂ))
+      from by funext x; ring]
+  rw [MeasureTheory.integral_div, first_hermite_fourier_eigenfunction]
+  field_simp
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+Summary
+═══════════════════════════════════════════════════════════════════════════════
+
+## The first Hermite function is a Fourier eigenfunction  (oq-05-oq-03-oq-05)
+
+### What's proved (0 sorries, 0 axioms):
+- `gaussian_fourier_real`: the parent identity ∫ e^{itx} e^{-x²/2} = e^{-t²/2}√(2π),
+  reproved self-contained.
+- `gaussian_fourier_first_hermite`: **∫ e^{itx}·x·e^{-x²/2} dx = i·t·e^{-t²/2}·√(2π)** —
+  the Fourier transform of the first Hermite function ψ₁(x) = x·e^{-x²/2},
+  obtained by differentiating the parent identity under the integral sign.
+- `first_hermite_fourier_eigenfunction`: the eigenfunction form
+  ∫ e^{itx} ψ₁(x) dx = (i·√(2π))·ψ₁(t) — ψ₁ is a Fourier eigenfunction with
+  eigenvalue i·√(2π) (eigenvalue i normalized), the first excited state.
+- `first_hermite_fourier_normalized`: the unitary-normalized eigenvalue is exactly i.
+- `first_moment_gaussian_zero`: the t = 0 shadow ∫ x·e^{-x²/2} dx = 0.
+
+### Relation to the parent:
+The parent shows the Gaussian (ground state) has Fourier eigenvalue 1 = i⁰; this
+child shows the first Hermite function (first excited state) has eigenvalue i = i¹,
+exhibiting the next rung of the Fourier eigenvalue ladder iⁿ.
+-/
+
+#check @gaussian_fourier_first_hermite
+#check @first_hermite_fourier_eigenfunction
+#check @first_hermite_fourier_normalized
+#check @first_moment_gaussian_zero
+
+end GaussianHermiteFourier

--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-05/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-05/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "ann-aoc-oq05oq03oq05-scope",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 59
+    },
+    "type": "insight",
+    "title": "Climbing the Hermite Ladder: From Eigenvalue 1 to Eigenvalue i",
+    "content": "The parent entry proved the Gaussian e^{-x²/2} is its own Fourier transform — the ground state, eigenvalue 1 = i⁰. This entry proves the first excited state: the first Hermite function ψ₁(x) = x·e^{-x²/2} satisfies ∫ e^{itx}·x·e^{-x²/2} dx = i·t·e^{-t²/2}·√(2π) = (i·√(2π))·ψ₁(t). Because ψ₁(t) = t·e^{-t²/2}, the Fourier transform carries ψ₁ to a constant (i·√(2π)) times itself: ψ₁ is a Fourier eigenfunction with eigenvalue i·√(2π), eigenvalue exactly i under unitary normalization. So the eigenvalue ladder runs 1, i, … = iⁿ, and this is its n=1 rung. These ψ_n are also the eigenstates of the quantum harmonic oscillator. All 0 axioms, 0 sorries.",
+    "mathContext": "ψ_n = H_n·e^{-x²/2} has Fourier eigenvalue iⁿ; the parent is n=0 (eigenvalue 1), this is n=1 (eigenvalue i).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fourier transform",
+      "Hermite functions",
+      "eigenfunction",
+      "quantum harmonic oscillator",
+      "Gaussian"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq05-parent",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-05",
+    "range": {
+      "startLine": 60,
+      "endLine": 96
+    },
+    "type": "technique",
+    "title": "Reproving the Parent Identity Self-Contained",
+    "content": "The argument differentiates the parent Gaussian Fourier identity F(t) = ∫ e^{itx} e^{-x²/2} dx = e^{-t²/2}√(2π), so the file reproves it (gaussian_fourier_real) rather than importing it — keeping the entry self-contained. The proof is the classical complete-the-square (integrand_complete_square: i t x − x²/2 = −½(x−it)² − t²/2, closed by linear_combination over Complex.I_sq), followed by Mathlib's vertical-strip contour integral GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I at b=1/2, c=−t, with cpow_half_eq_sqrt_two_pi converting the contour constant (π/(1/2))^{1/2} to √(2π).",
+    "mathContext": "F(t) = e^{-t²/2}√(2π) is the function whose frequency-derivative produces the first Hermite integral.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "completing the square",
+      "Gaussian Fourier transform",
+      "contour integral"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq05-dominator",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-05",
+    "range": {
+      "startLine": 97,
+      "endLine": 144
+    },
+    "type": "technique",
+    "title": "A Frequency-Independent Dominating Function",
+    "content": "Differentiation under the integral sign needs a single integrable function that dominates the t-derivative of the integrand uniformly over a ball of frequencies. The key observation (norm_integrand): the t-derivative i x e^{itx} e^{-x²/2} has modulus exactly |x|·e^{-x²/2} for EVERY t, because the phase e^{itx} has modulus one (the real part of i t x is 0). So the t-independent dominator |x|·e^{-x²/2} = ‖x·e^{-(1/2)x²}‖ works for all frequencies at once; it is integrable by integrable_mul_exp_neg_mul_sq (integrable_bound). The pointwise derivative itself (hasDerivAt_integrand) is assembled from HasDerivAt.cexp on the linear phase and HasDerivAt.comp_ofReal to pass from the complex to the real variable.",
+    "mathContext": "The four hypotheses of hasDerivAt_integral_of_dominated_loc_of_deriv_le, all anchored on the modulus-one phase.",
+    "significance": "key",
+    "relatedConcepts": [
+      "differentiation under the integral sign",
+      "dominated convergence",
+      "Gaussian integrability",
+      "HasDerivAt.cexp"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq05-main",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-05",
+    "range": {
+      "startLine": 145,
+      "endLine": 224
+    },
+    "type": "insight",
+    "title": "Multiplication by x is Differentiation in Frequency",
+    "content": "The whole result is one differentiation of F(t) = e^{-t²/2}√(2π) in the frequency variable. Differentiating under the integral pulls down i x from the phase: F'(t) = ∫ i x e^{itx} e^{-x²/2} dx. Differentiating the closed form gives F'(t) = −t e^{-t²/2}√(2π). Equating (HasDerivAt.unique) yields i·(∫ x e^{itx} e^{-x²/2} dx) = −t e^{-t²/2}√(2π); pulling i out (integral_const_mul) and multiplying by −i — using i·(−i)=1 (Complex.I_mul_I), which is pure ring algebra, not i²=−1 — gives ∫ x e^{itx} e^{-x²/2} dx = i t e^{-t²/2}√(2π). The factor x·e^{-x²/2} in the integrand is exactly what one frequency-derivative produces: multiplication by position is differentiation in momentum.",
+    "mathContext": "gaussian_fourier_first_hermite: the Fourier transform of ψ₁(x) = x·e^{-x²/2}, obtained by ∂_t of the parent identity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "differentiation under the integral sign",
+      "position-momentum duality",
+      "HasDerivAt.unique",
+      "Complex.I_mul_I"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq05-consequences",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-05",
+    "range": {
+      "startLine": 225,
+      "endLine": 301
+    },
+    "type": "insight",
+    "title": "Reading Off the Eigenvalue and the Vanishing First Moment",
+    "content": "Reassociating the headline identity (first_hermite_fourier_eigenfunction) puts it in eigenfunction form ∫ e^{itx} ψ₁(x) dx = (i·√(2π))·ψ₁(t): ψ₁ is mapped to a fixed constant times itself, eigenvalue i·√(2π). Dividing by √(2π) (first_hermite_fourier_normalized) gives the unitary eigenvalue exactly i — one factor of i above the Gaussian's eigenvalue 1, the n=1 rung of the ladder iⁿ. Specialising t=0 (first_moment_gaussian_zero) recovers the elementary odd-integrand fact ∫ x·e^{-x²/2} dx = 0: the Gaussian's first moment vanishes, consistent with the eigenvalue identity collapsing to 0 at t=0.",
+    "mathContext": "The eigenvalue i·√(2π) (normalized i) and the t=0 shadow, the first excited rung above the Gaussian ground state.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "eigenvalue",
+      "first moment",
+      "unitary normalization",
+      "Fourier eigenvalue ladder"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-05/meta.json
@@ -1,0 +1,229 @@
+{
+  "id": "area-of-circle-oq-05-oq-03-oq-05",
+  "title": "The First Hermite Function is a Fourier Eigenfunction",
+  "slug": "area-of-circle-oq-05-oq-03-oq-05",
+  "description": "Follow-up to area-of-circle-oq-05-oq-03 (the Gaussian is its own Fourier transform). The parent shows the Gaussian density e^{-x²/2} is the Fourier ground state — the eigenfunction with eigenvalue 1 = i⁰. This entry climbs one rung of the Hermite ladder and proves, axiom-free, that the first Hermite function ψ₁(x) = x·e^{-x²/2} is again a Fourier eigenfunction, now with eigenvalue i: ∫_ℝ e^{itx}·x·e^{-x²/2} dx = i·t·e^{-t²/2}·√(2π) = (i·√(2π))·ψ₁(t). Since ψ₁(t) = t·e^{-t²/2}, the transform carries ψ₁ to a constant times itself, so ψ₁ is a Fourier eigenfunction with eigenvalue i·√(2π) (eigenvalue exactly i after unitary normalization) — the first excited state of the quantum harmonic oscillator above the Gaussian ground state. Together with the parent this exhibits the first two rungs of the classical Fourier eigenvalue ladder iⁿ. Method: differentiate the parent identity F(t) = ∫ e^{itx} e^{-x²/2} dx = e^{-t²/2}√(2π) with respect to the frequency t; differentiation under the integral sign (justified by Mathlib's hasDerivAt_integral_of_dominated_loc_of_deriv_le with the t-independent dominating function |x|·e^{-x²/2}) pulls down a factor i x, and equating with the derivative of the closed form gives the value. All 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Classical (Hermite functions as Fourier eigenfunctions); Lean 4 formalization (research, 2026)",
+    "date": "2003",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ03OQ05.lean",
+    "tags": [
+      "analysis",
+      "fourier-analysis",
+      "gaussian-integral",
+      "hermite-functions",
+      "eigenfunction",
+      "differentiation-under-integral",
+      "complex-analysis",
+      "harmonic-oscillator"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 301,
+    "assumptions": "0 axioms, 0 sorries (depends only on propext, Classical.choice, Quot.sound). Builds on Mathlib's Gaussian Fourier transform (GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I), the parametric differentiation-under-the-integral lemma (hasDerivAt_integral_of_dominated_loc_of_deriv_le), and the Gaussian integrability lemmas integrable_exp_neg_mul_sq / integrable_mul_exp_neg_mul_sq.",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-22",
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Hermite functions ψ_n(x) = H_n(x)·e^{-x²/2} are the eigenfunctions of the Fourier transform: ψ_n has eigenvalue (−i)^n (or i^n, depending on the sign convention of the transform). They are simultaneously the eigenstates of the quantum harmonic oscillator, with ψ_0 the Gaussian ground state and ψ_1 the first excited state. The parent entry area-of-circle-oq-05-oq-03 proved the n=0 case — the Gaussian is fixed by the Fourier transform, eigenvalue 1. This entry proves the n=1 case from scratch in explicit Lebesgue-integral form, exhibiting the next rung of the eigenvalue ladder and the mechanism (one differentiation in the frequency variable) that climbs it.",
+    "problemStatement": "Prove that the first Hermite function ψ₁(x) = x·e^{-x²/2} is a Fourier eigenfunction: ∫_ℝ e^{itx}·x·e^{-x²/2} dx = i·t·e^{-t²/2}·√(2π) = (i·√(2π))·ψ₁(t), so that ψ₁ is carried to (i·√(2π)) times itself (eigenvalue i after unitary normalization), the first excited state above the Gaussian ground state.",
+    "text": "The whole result is one differentiation of the parent identity in the frequency variable. The parent gives F(t) = ∫ e^{itx} e^{-x²/2} dx = e^{-t²/2}·√(2π). Differentiating under the integral sign brings down a factor i x from the phase e^{itx}: F'(t) = ∫ i x e^{itx} e^{-x²/2} dx. Differentiating the closed form gives F'(t) = −t e^{-t²/2}√(2π). Equating, i·(∫ x e^{itx} e^{-x²/2} dx) = −t e^{-t²/2}√(2π), and multiplying by −i (using i·(−i)=1) gives ∫ x e^{itx} e^{-x²/2} dx = i t e^{-t²/2}√(2π). The differentiation under the integral is the only analytic subtlety; it is discharged by Mathlib's hasDerivAt_integral_of_dominated_loc_of_deriv_le, whose hypotheses are met with the frequency-independent dominating function |x|·e^{-x²/2} (the t-derivative of the integrand has modulus exactly |x|·e^{-x²/2} because the phase has modulus one), itself integrable by integrable_mul_exp_neg_mul_sq. The t=0 shadow recovers the odd-integrand fact ∫ x e^{-x²/2} dx = 0, and dividing by √(2π) gives the unitary eigenvalue i.",
+    "proofStrategy": "1. **Reprove the parent** (`gaussian_fourier_real`): ∫ e^{itx} e^{-x²/2} dx = e^{-t²/2}√(2π), via complete-the-square (integrand_complete_square) and GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I — kept self-contained.\n\n2. **Analytic ingredients** (`norm_integrand`, `integrable_integrand`, `hasDerivAt_integrand`, `integrable_bound`): the integrand norm is the real Gaussian e^{-(1/2)x²}; the integrand is integrable for each t; its pointwise t-derivative is i x e^{itx} e^{-x²/2} (HasDerivAt via .cexp and HasDerivAt.comp_ofReal); the dominating function ‖x·e^{-(1/2)x²}‖ is integrable.\n\n3. **Differentiate under the integral** (`gaussian_fourier_first_hermite`): apply hasDerivAt_integral_of_dominated_loc_of_deriv_le to get HasDerivAt (∫ e^{i·x} e^{-x²/2}) (∫ i x e^{i t x} e^{-x²/2}) t; rewrite the integral by the parent closed form; differentiate the closed form (−t e^{-t²/2}√(2π)); equate via HasDerivAt.unique; pull i out of the integral (integral_const_mul) and solve i·J = R for J using i·(−i)=1 (Complex.I_mul_I).\n\n4. **Eigenfunction form and consequences** (`first_hermite_fourier_eigenfunction`, `first_moment_gaussian_zero`, `first_hermite_fourier_normalized`): reassociate to read off ψ₁ ↦ (i√(2π))ψ₁; specialise t=0 for the vanishing first moment; divide by √(2π) for the normalized eigenvalue i.",
+    "keyInsights": [
+      "Multiplication by x in physical space is differentiation in frequency space: the factor x·e^{-x²/2} in the integrand is produced (up to i) by differentiating the parent Gaussian Fourier identity once in t. This is the operational content of the position–momentum duality.",
+      "The eigenvalue jumps from 1 (Gaussian, i⁰) to i (first Hermite, i¹): each rung of the Hermite ladder multiplies the Fourier eigenvalue by i, and one frequency-derivative is exactly what climbs one rung.",
+      "Differentiation under the integral is legitimate here because the t-derivative of the integrand has modulus |x|·e^{-x²/2} INDEPENDENT of t — the phase e^{itx} has modulus one — so a single integrable dominating function works uniformly on a frequency ball.",
+      "Dividing i·J = R by i needs i·(−i)=1, NOT i²=−1: the cast J = −i·R is pure ring algebra plus Complex.I_mul_I, so no completing-the-square machinery is needed for the final step."
+    ],
+    "prerequisites": [
+      "area-of-circle-oq-05-oq-03 — the Gaussian is its own Fourier transform (the n=0 / ground-state case, reproved here)",
+      "area-of-circle-oq-05 — the real Gaussian integral ∫ e^{-x²} = √π",
+      "Mathlib's parametric integral calculus: hasDerivAt_integral_of_dominated_loc_of_deriv_le (differentiation under the integral sign)",
+      "Mathlib's Gaussian integrability: integrable_exp_neg_mul_sq, integrable_mul_exp_neg_mul_sq, and the contour lemma GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I",
+      "Complex exponential derivative calculus: HasDerivAt.cexp, HasDerivAt.comp_ofReal, Complex.I_mul_I"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: Imports and Setup",
+      "startLine": 1,
+      "endLine": 59,
+      "summary": "Imports Mathlib; opens Real, Complex, MeasureTheory. Header states the first-Hermite Fourier eigenfunction identity ∫ e^{itx}·x·e^{-x²/2} dx = i·t·e^{-t²/2}·√(2π), its reading as the eigenvalue-i excited state above the Gaussian ground state, and the differentiate-the-parent method.",
+      "mathContext": "Targets the n=1 rung of the Hermite/Fourier eigenfunction ladder iⁿ, generalizing the parent's n=0 self-dual Gaussian."
+    },
+    {
+      "id": "parent",
+      "title": "Part I: The Parent Gaussian Fourier Identity (reproved)",
+      "startLine": 60,
+      "endLine": 96,
+      "summary": "integrand_complete_square, cpow_half_eq_sqrt_two_pi, and gaussian_fourier_real reprove ∫ e^{itx} e^{-x²/2} dx = e^{-t²/2}√(2π), self-contained, via completing the square and the Mathlib contour lemma.",
+      "mathContext": "The function F(t) whose frequency-derivative produces the first Hermite integral."
+    },
+    {
+      "id": "analytic",
+      "title": "Part II: Analytic Ingredients for Differentiation Under the Integral",
+      "startLine": 97,
+      "endLine": 144,
+      "summary": "norm_integrand (‖e^{itx}e^{-x²/2}‖ = e^{-(1/2)x²}), integrable_integrand (integrability for each t), hasDerivAt_integrand (pointwise t-derivative = i x e^{itx} e^{-x²/2}, via HasDerivAt.cexp and HasDerivAt.comp_ofReal), and integrable_bound (the dominating function ‖x·e^{-(1/2)x²}‖ is integrable).",
+      "mathContext": "The four hypotheses of the dominated differentiation-under-the-integral lemma, all built around the t-independent dominator |x|·e^{-x²/2}."
+    },
+    {
+      "id": "main",
+      "title": "Part III: The First Hermite Fourier Eigenfunction",
+      "startLine": 145,
+      "endLine": 224,
+      "summary": "gaussian_fourier_first_hermite: ∫ e^{itx}·x·e^{-x²/2} dx = i·t·e^{-t²/2}·√(2π), by differentiating the parent identity under the integral (hasDerivAt_integral_of_dominated_loc_of_deriv_le), equating with the derivative of the closed form via HasDerivAt.unique, and solving i·J = −t e^{-t²/2}√(2π) using i·(−i)=1.",
+      "mathContext": "The headline result: the Fourier transform of the first Hermite function ψ₁(x) = x·e^{-x²/2}."
+    },
+    {
+      "id": "consequences",
+      "title": "Part IV: Eigenfunction Form and Consequences",
+      "startLine": 225,
+      "endLine": 301,
+      "summary": "first_hermite_fourier_eigenfunction (∫ e^{itx} ψ₁(x) dx = (i√(2π))·ψ₁(t), the eigenfunction reading), first_moment_gaussian_zero (the t=0 shadow ∫ x·e^{-x²/2} dx = 0), and first_hermite_fourier_normalized (the unitary-normalized eigenvalue is exactly i).",
+      "mathContext": "Reads off the eigenvalue i·√(2π) (normalized i), the next rung above the Gaussian's eigenvalue 1, and records the vanishing first moment."
+    }
+  ],
+  "conclusion": {
+    "summary": "The first Hermite function ψ₁(x) = x·e^{-x²/2} is proved, axiom-free, to be a Fourier eigenfunction: ∫ e^{itx}·x·e^{-x²/2} dx = i·t·e^{-t²/2}·√(2π) = (i·√(2π))·ψ₁(t). So the Fourier transform carries ψ₁ to (i·√(2π)) times itself — eigenvalue i·√(2π), eigenvalue exactly i after unitary normalization. The t=0 shadow gives ∫ x·e^{-x²/2} dx = 0. (0 axioms, 0 sorries.)",
+    "implications": "Together with the parent (Gaussian ↦ eigenvalue 1 = i⁰) this exhibits the first two rungs of the Fourier eigenvalue ladder iⁿ on the Hermite functions, and shows the mechanism that climbs the ladder: a single differentiation in the frequency variable converts the eigenvalue-1 Gaussian into the eigenvalue-i first Hermite function. The same differentiate-under-the-integral step, iterated, reaches every ψ_n. These are simultaneously the eigenstates of the quantum harmonic oscillator, so the result is the n=1 case of the spectral identification of the Fourier transform with the oscillator Hamiltonian's symmetry.",
+    "openQuestions": [
+      "Prove the second Hermite function ψ₂(x) = (x²−1)·e^{-x²/2} has Fourier eigenvalue −1 (= i²), by differentiating twice — the next rung, requiring the integrability of x²·e^{-x²/2} as dominator.",
+      "Establish the general statement that ψ_n = H_n·e^{-x²/2} has Fourier eigenvalue iⁿ by induction on n, threading the differentiation-under-the-integral step through the Hermite recurrence.",
+      "Connect ψ₁'s eigenvalue to the quantum harmonic oscillator: show the Fourier transform intertwines the creation operator a† = x − d/dx with multiplication by i, so a† raises the eigenvalue by a factor i."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-05-oq-03",
+      "relationship": "extends",
+      "description": "Parent: the Gaussian is its own Fourier transform (n=0, eigenvalue 1). This entry differentiates that identity once in the frequency variable to obtain the n=1 Hermite eigenfunction (eigenvalue i)."
+    },
+    {
+      "targetId": "area-of-circle-oq-05-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Sibling: the Gaussian dilation law and uncertainty duality — another structural extension of the parent Gaussian Fourier identity, in the width direction rather than the Hermite-ladder direction."
+    },
+    {
+      "targetId": "area-of-circle-oq-05",
+      "relationship": "related",
+      "description": "Grandparent: the real Gaussian integral ∫ e^{-x²} = √π, whose value √(2π) reappears as the constant in the eigenvalue i·√(2π)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Complex",
+      "MeasureTheory"
+    ],
+    "namespace": "GaussianHermiteFourier",
+    "lineCount": 301,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "gaussian_fourier_first_hermite",
+        "type": "core",
+        "description": "The first Hermite function is a Fourier eigenfunction: ∫ e^{itx}·x·e^{-x²/2} dx = i·t·e^{-t²/2}·√(2π).",
+        "leanType": "(t : ℝ) → (∫ x : ℝ, (x : ℂ) * Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)) = Complex.I * t * Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)"
+      },
+      {
+        "name": "first_hermite_fourier_eigenfunction",
+        "type": "core",
+        "description": "Eigenfunction form: ∫ e^{itx} ψ₁(x) dx = (i·√(2π))·ψ₁(t) with ψ₁(x) = x·e^{-x²/2}, so ψ₁ has Fourier eigenvalue i·√(2π).",
+        "leanType": "(t : ℝ) → (∫ x : ℝ, Complex.exp (Complex.I * t * x) * ((x : ℂ) * Complex.exp (-(x : ℂ) ^ 2 / 2))) = (Complex.I * ((Real.sqrt (2 * π) : ℝ) : ℂ)) * ((t : ℂ) * Complex.exp (-(t : ℂ) ^ 2 / 2))"
+      },
+      {
+        "name": "first_hermite_fourier_normalized",
+        "type": "key",
+        "description": "The unitary-normalized first Hermite function has Fourier eigenvalue exactly i: ∫ e^{itx}·(x·e^{-x²/2}/√(2π)) dx = i·(t·e^{-t²/2}).",
+        "leanType": "(t : ℝ) → (∫ x : ℝ, Complex.exp (Complex.I * t * x) * ((x : ℂ) * Complex.exp (-(x : ℂ) ^ 2 / 2) / ((Real.sqrt (2 * π) : ℝ) : ℂ))) = Complex.I * ((t : ℂ) * Complex.exp (-(t : ℂ) ^ 2 / 2))"
+      },
+      {
+        "name": "hasDerivAt_integrand",
+        "type": "key",
+        "description": "The pointwise frequency-derivative of the Gaussian Fourier integrand brings down a factor i x: d/dt [e^{itx} e^{-x²/2}] = i x e^{itx} e^{-x²/2}.",
+        "leanType": "(t x : ℝ) → HasDerivAt (fun s : ℝ => Complex.exp (Complex.I * s * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)) (Complex.I * x * Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)) t"
+      },
+      {
+        "name": "first_moment_gaussian_zero",
+        "type": "supporting",
+        "description": "The vanishing first moment (t=0 shadow): ∫ x·e^{-x²/2} dx = 0.",
+        "leanType": "(∫ x : ℝ, (x : ℂ) * Complex.exp (-(x : ℂ) ^ 2 / 2)) = 0"
+      }
+    ],
+    "path": "Proofs/AreaOfCircleOQ05OQ03OQ05.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "gaussian_fourier_first_hermite",
+      "type": "core",
+      "description": "The first Hermite function is a Fourier eigenfunction: ∫ e^{itx}·x·e^{-x²/2} dx = i·t·e^{-t²/2}·√(2π).",
+      "leanType": "(t : ℝ) → (∫ x : ℝ, (x : ℂ) * Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)) = Complex.I * t * Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)"
+    },
+    {
+      "name": "first_hermite_fourier_eigenfunction",
+      "type": "key",
+      "description": "Eigenfunction form: ∫ e^{itx} ψ₁(x) dx = (i·√(2π))·ψ₁(t) with ψ₁(x) = x·e^{-x²/2}, so ψ₁ has Fourier eigenvalue i·√(2π) (eigenvalue i normalized), the first excited state above the Gaussian ground state.",
+      "leanType": "(t : ℝ) → (∫ x : ℝ, Complex.exp (Complex.I * t * x) * ((x : ℂ) * Complex.exp (-(x : ℂ) ^ 2 / 2))) = (Complex.I * ((Real.sqrt (2 * π) : ℝ) : ℂ)) * ((t : ℂ) * Complex.exp (-(t : ℂ) ^ 2 / 2))"
+    },
+    {
+      "name": "first_hermite_fourier_normalized",
+      "type": "key",
+      "description": "The unitary-normalized first Hermite function has Fourier eigenvalue exactly i: ∫ e^{itx}·(x·e^{-x²/2}/√(2π)) dx = i·(t·e^{-t²/2}).",
+      "leanType": "(t : ℝ) → (∫ x : ℝ, Complex.exp (Complex.I * t * x) * ((x : ℂ) * Complex.exp (-(x : ℂ) ^ 2 / 2) / ((Real.sqrt (2 * π) : ℝ) : ℂ))) = Complex.I * ((t : ℂ) * Complex.exp (-(t : ℂ) ^ 2 / 2))"
+    },
+    {
+      "name": "hasDerivAt_integrand",
+      "type": "key",
+      "description": "Multiplication by x is frequency-differentiation: d/dt [e^{itx} e^{-x²/2}] = i x e^{itx} e^{-x²/2} — the step that climbs one Hermite rung.",
+      "leanType": "(t x : ℝ) → HasDerivAt (fun s : ℝ => Complex.exp (Complex.I * s * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)) (Complex.I * x * Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2)) t"
+    },
+    {
+      "name": "first_moment_gaussian_zero",
+      "type": "supporting",
+      "description": "The vanishing first moment of the Gaussian (t=0 shadow of the eigenfunction identity, the odd-integrand fact): ∫ x·e^{-x²/2} dx = 0.",
+      "leanType": "(∫ x : ℝ, (x : ℂ) * Complex.exp (-(x : ℂ) ^ 2 / 2)) = 0"
+    },
+    {
+      "name": "gaussian_fourier_real",
+      "type": "supporting",
+      "description": "The parent identity (reproved self-contained): ∫ e^{itx} e^{-x²/2} dx = e^{-t²/2}·√(2π), the function differentiated to obtain the Hermite result.",
+      "leanType": "(t : ℝ) → ∫ x : ℝ, Complex.exp (Complex.I * t * x) * Complex.exp (-(x : ℂ) ^ 2 / 2) = Complex.exp (-(t : ℂ) ^ 2 / 2) * ((Real.sqrt (2 * π) : ℝ) : ℂ)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stein, Elias M. and Shakarchi, Rami",
+      "title": "Fourier Analysis: An Introduction",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "note": "Chapters 5–6; the Gaussian, the Hermite functions, and the eigenfunctions of the Fourier transform"
+    },
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Harmonic Analysis in Phase Space",
+      "year": "1989",
+      "venue": "Princeton University Press",
+      "note": "Hermite functions as eigenfunctions of the Fourier transform and eigenstates of the harmonic oscillator"
+    },
+    {
+      "authors": "mathlib community",
+      "title": "Analysis.Calculus.ParametricIntegral and Analysis.SpecialFunctions.Gaussian",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "hasDerivAt_integral_of_dominated_loc_of_deriv_le and the Gaussian Fourier / integrability lemmas used here"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## The first Hermite function is a Fourier eigenfunction

A follow-up to **area-of-circle-oq-05-oq-03** ("the Gaussian is its own Fourier transform"). The parent shows the Gaussian density `e^{-x²/2}` is the Fourier **ground state** — the eigenfunction with eigenvalue `1 = i⁰`. This entry climbs one rung of the Hermite ladder and proves, **axiom-free**, that the **first Hermite function** `ψ₁(x) = x·e^{-x²/2}` is again a Fourier eigenfunction, now with eigenvalue `i`:

```
∫_ℝ e^{itx}·x·e^{-x²/2} dx = i·t·e^{-t²/2}·√(2π) = (i·√(2π))·ψ₁(t)
```

Since `ψ₁(t) = t·e^{-t²/2}`, the transform carries `ψ₁` to a constant `(i·√(2π))` times itself — eigenvalue `i·√(2π)`, eigenvalue exactly `i` after unitary normalization. Together with the parent this exhibits the first two rungs of the classical Fourier eigenvalue ladder `iⁿ` on the Hermite functions (the eigenstates of the quantum harmonic oscillator).

### Method
Differentiate the parent identity `F(t) = ∫ e^{itx} e^{-x²/2} dx = e^{-t²/2}√(2π)` with respect to the **frequency** `t`. Differentiation under the integral sign pulls down a factor `i x`:
`F'(t) = ∫ i x e^{itx} e^{-x²/2} dx`, while the closed form gives `F'(t) = -t e^{-t²/2}√(2π)`. Equating and solving `i·J = R` (using `i·(-i)=1`) yields the value. The differentiation is justified by Mathlib's `hasDerivAt_integral_of_dominated_loc_of_deriv_le` with the **frequency-independent** dominating function `|x|·e^{-x²/2}` — the `t`-derivative has modulus `|x|·e^{-x²/2}` because the phase has modulus one.

### What's proved (0 sorries, 0 axioms)
- `gaussian_fourier_first_hermite` — **∫ e^{itx}·x·e^{-x²/2} dx = i·t·e^{-t²/2}·√(2π)**
- `first_hermite_fourier_eigenfunction` — eigenfunction form `∫ e^{itx} ψ₁(x) dx = (i·√(2π))·ψ₁(t)`
- `first_hermite_fourier_normalized` — the unitary-normalized eigenvalue is exactly `i`
- `first_moment_gaussian_zero` — the `t=0` shadow `∫ x·e^{-x²/2} dx = 0`
- `gaussian_fourier_real` — the parent identity, reproved self-contained

### Verification
- `./proofs/scripts/docker-build.sh Proofs.AreaOfCircleOQ05OQ03OQ05` — **Build completed successfully (7743 jobs)**
- `#print axioms` on all four results: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. **0 axioms.**
- 301 lines, 9 theorems, 0 definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)