### PR TITLE
research(chebyshev-bounds-oq-02): the second Chebyshev function ψ and Legendre's identity

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -637,6 +637,7 @@ import Proofs.CevasTheoremOQ04
 import Proofs.CevasTheoremOQ04OQ01
 import Proofs.CevasTheoremSinRatio
 import Proofs.ChebyshevBounds
+import Proofs.ChebyshevBoundsOQ02
 import Proofs.ChebyshevBoundsOQ04
 import Proofs.ChebyshevBoundsOQ04Aristotle
 import Proofs.ChebyshevBoundsOQ04OQ01

--- a/proofs/Proofs/ChebyshevBoundsOQ02.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ02.lean
@@ -1,0 +1,135 @@
+import Mathlib
+
+/-
+# Chebyshev Bounds OQ-02: The Second Chebyshev Function ψ and Legendre's Identity
+
+## Open Question (parent chebyshev-bounds, second open question)
+
+The parent develops explicit bounds on π(n) and θ(n) = ∑_{p ≤ n} log p via central binomial
+coefficients. One listed open direction is the **second Chebyshev function**
+`ψ(x) = ∑_{p^k ≤ x} log p` and the partial-summation machinery linking it to θ and to the
+Prime Number Theorem.
+
+## What this file proves
+
+The second Chebyshev function is, in von Mangoldt form, `ψ(n) = ∑_{m ≤ n} Λ(m)`, where
+`Λ(m) = log p` if `m = p^k` is a prime power and `0` otherwise (Mathlib's
+`ArithmeticFunction.vonMangoldt`). The keystone connecting ψ to the factorial — the identity at
+the heart of Chebyshev's elementary method — is **Legendre's identity**:
+
+> **`log(n!) = ∑_{d=1}^{n} Λ(d) · ⌊n/d⌋`.**
+
+It follows by writing `log(n!) = ∑_{m≤n} log m`, expanding each `log m = ∑_{d ∣ m} Λ(d)`
+(Mathlib's `vonMangoldt_sum`), and swapping the order of summation: each `d ≤ n` contributes
+`Λ(d)` once for each of its `⌊n/d⌋` multiples in `[1,n]`. This identity is exactly what powers
+the Chebyshev bounds `θ(n), ψ(n) = Θ(n)` (via `log(2n)! − 2·log n! ` telescoping), so it is the
+right elementary foundation for this thread.
+
+We also record the basic structure of ψ (nonnegativity, monotonicity) and the bound
+`ψ(n) ≤ log(n!)`.
+
+Tags: number-theory, primes, chebyshev, von-mangoldt, prime-counting, analytic-number-theory
+-/
+
+open Finset ArithmeticFunction
+
+namespace ChebyshevBoundsOQ02
+
+/-- The **second Chebyshev function** `ψ(n) = ∑_{m ≤ n} Λ(m) = ∑_{p^k ≤ n} log p`, in von
+    Mangoldt form. -/
+noncomputable def chebyshevPsi (n : ℕ) : ℝ := ∑ m ∈ Finset.Icc 1 n, Λ m
+
+/-- ψ is nonnegative (von Mangoldt is nonnegative). -/
+theorem chebyshevPsi_nonneg (n : ℕ) : 0 ≤ chebyshevPsi n :=
+  Finset.sum_nonneg fun _ _ => vonMangoldt_nonneg
+
+/-- ψ is monotone in `n`. -/
+theorem chebyshevPsi_mono {m n : ℕ} (h : m ≤ n) : chebyshevPsi m ≤ chebyshevPsi n :=
+  Finset.sum_le_sum_of_subset_of_nonneg
+    (Finset.Icc_subset_Icc_right h) (fun _ _ _ => vonMangoldt_nonneg)
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+LEGENDRE'S IDENTITY: log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- `∏_{m=1}^{n} m = n!`. -/
+theorem prod_Icc_id_eq_factorial (n : ℕ) : ∏ m ∈ Finset.Icc 1 n, m = Nat.factorial n := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [Finset.prod_Icc_succ_top (by omega), ih, Nat.factorial_succ, mul_comm]
+
+/-- For `m ∈ [1,n]`, the divisors of `m` are exactly the elements of `[1,n]` dividing `m`. -/
+theorem divisors_eq_filter {m n : ℕ} (hm : m ∈ Finset.Icc 1 n) :
+    m.divisors = (Finset.Icc 1 n).filter (· ∣ m) := by
+  rw [Finset.mem_Icc] at hm
+  ext d
+  simp only [Nat.mem_divisors, Finset.mem_filter, Finset.mem_Icc]
+  constructor
+  · rintro ⟨hd, hm0⟩
+    exact ⟨⟨Nat.pos_of_mem_divisors (Nat.mem_divisors.2 ⟨hd, hm0⟩),
+      (Nat.le_of_dvd (by omega) hd).trans hm.2⟩, hd⟩
+  · rintro ⟨_, hd⟩
+    exact ⟨hd, by omega⟩
+
+/-- The number of multiples of `d` in `[1,n]` is `⌊n/d⌋`. -/
+theorem card_multiples_Icc (d n : ℕ) :
+    ((Finset.Icc 1 n).filter (d ∣ ·)).card = n / d := by
+  have hset : Finset.Icc 1 n = Finset.Ioc 0 n := by
+    ext x; simp only [Finset.mem_Icc, Finset.mem_Ioc]; omega
+  rw [hset, Nat.Ioc_filter_dvd_card_eq_div]
+
+/-- **Legendre's identity** (the Chebyshev/Legendre formula): the logarithm of `n!` is the
+    weighted sum of von Mangoldt values, each `Λ(d)` counted `⌊n/d⌋` times.
+
+    `log(n!) = ∑_{d=1}^{n} Λ(d) · ⌊n/d⌋`. -/
+theorem log_factorial_eq_sum (n : ℕ) :
+    Real.log (Nat.factorial n : ℝ) = ∑ d ∈ Finset.Icc 1 n, Λ d * (n / d : ℕ) := by
+  -- log(n!) = ∑_{m≤n} log m
+  have hfact : Real.log (Nat.factorial n : ℝ) = ∑ m ∈ Finset.Icc 1 n, Real.log (m : ℝ) := by
+    rw [← prod_Icc_id_eq_factorial, Nat.cast_prod, Real.log_prod]
+    intro m hm
+    rw [Finset.mem_Icc] at hm
+    exact_mod_cast (Nat.cast_pos.2 (by omega : 0 < m)).ne'
+  rw [hfact]
+  -- each log m = ∑_{d ∣ m} Λ d
+  have hstep : ∀ m ∈ Finset.Icc 1 n, Real.log (m : ℝ) =
+      ∑ d ∈ Finset.Icc 1 n, (if d ∣ m then Λ d else 0) := by
+    intro m hm
+    rw [← vonMangoldt_sum, divisors_eq_filter hm, Finset.sum_filter]
+  rw [Finset.sum_congr rfl hstep, Finset.sum_comm]
+  -- swap: ∑_d ∑_m (if d∣m then Λ d) = ∑_d Λ d * #{m : d∣m}
+  refine Finset.sum_congr rfl fun d _ => ?_
+  rw [← Finset.sum_filter, Finset.sum_const, card_multiples_Icc, nsmul_eq_mul, mul_comm]
+
+/-- **ψ(n) ≤ log(n!)**: each von Mangoldt term is dominated by the corresponding log. -/
+theorem chebyshevPsi_le_log_factorial (n : ℕ) :
+    chebyshevPsi n ≤ Real.log (Nat.factorial n : ℝ) := by
+  rw [chebyshevPsi, ← prod_Icc_id_eq_factorial, Nat.cast_prod, Real.log_prod]
+  · refine Finset.sum_le_sum fun m _ => ?_
+    simpa using vonMangoldt_le_log
+  · intro m hm
+    rw [Finset.mem_Icc] at hm
+    exact_mod_cast (Nat.cast_pos.2 (by omega : 0 < m)).ne'
+
+end ChebyshevBoundsOQ02
+
+/-
+## Summary
+
+The second Chebyshev function ψ in von Mangoldt form and Legendre's identity, the elementary
+engine of the Chebyshev bounds:
+
+- `chebyshevPsi`:               ψ(n) = ∑_{m≤n} Λ(m) = ∑_{p^k≤n} log p, with `chebyshevPsi_nonneg`,
+  `chebyshevPsi_mono`.
+- `log_factorial_eq_sum`:       **log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋** (Legendre's identity), via
+  log m = ∑_{d∣m} Λ(d) and a summation swap counting multiples.
+- `chebyshevPsi_le_log_factorial`: ψ(n) ≤ log(n!).
+
+Uses Mathlib's `ArithmeticFunction.vonMangoldt` (`vonMangoldt_sum`, `vonMangoldt_le_log`) and
+`Nat.Ioc_filter_dvd_card_eq_div`.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/

--- a/src/data/proofs/chebyshev-bounds-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-psi",
+    "proofId": "chebyshev-bounds-oq-02",
+    "range": {
+      "startLine": 38,
+      "endLine": 49
+    },
+    "type": "concept",
+    "title": "The Second Chebyshev Function in von Mangoldt Form",
+    "content": "ψ(x) = ∑_{p^k ≤ x} log p sums log p once for each prime power p^k ≤ x. Written with the von Mangoldt function Λ — which is log p on prime powers p^k and 0 elsewhere — this is simply ψ(n) = ∑_{m ≤ n} Λ(m). This packaging is what makes Mathlib's vonMangoldt_sum (∑_{d∣m} Λ(d) = log m) directly usable, and it gives nonnegativity and monotonicity for free from the same property of Λ."
+  },
+  {
+    "id": "ann-divisors-filter",
+    "proofId": "chebyshev-bounds-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 82
+    },
+    "type": "insight",
+    "title": "Making Both Inner Sums Range Over [1,n]",
+    "content": "The summation swap needs both inner sums over the *same fixed* set. `divisors_eq_filter` does this: for m ∈ [1,n], every divisor of m is itself ≤ m ≤ n, so m.divisors equals the elements of [1,n] dividing m. With that, log m = ∑_{d∈[1,n]} (if d∣m then Λ d else 0). `card_multiples_Icc` supplies the dual count — the number of multiples of d in [1,n] is ⌊n/d⌋ — by rewriting [1,n] as (0,n] and invoking Nat.Ioc_filter_dvd_card_eq_div."
+  },
+  {
+    "id": "ann-legendre",
+    "proofId": "chebyshev-bounds-oq-02",
+    "range": {
+      "startLine": 88,
+      "endLine": 105
+    },
+    "type": "insight",
+    "title": "Legendre's Identity — a Fubini Swap",
+    "content": "log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋ is proved in three moves: expand log(n!) = ∑_{m≤n} log m; replace each log m by its von Mangoldt divisor sum ∑_{d∣m} Λ(d); then swap the order of the two finite sums over [1,n] (Finset.sum_comm). After the swap, the d-th inner sum collects Λ(d) once per multiple of d in [1,n] — exactly ⌊n/d⌋ of them. This is the elementary identity from which Chebyshev's bounds θ(n), ψ(n) = Θ(n) follow by telescoping log((2n)!) − 2 log(n!) and comparing with the central binomial coefficient."
+  },
+  {
+    "id": "ann-psi-bound",
+    "proofId": "chebyshev-bounds-oq-02",
+    "range": {
+      "startLine": 107,
+      "endLine": 115
+    },
+    "type": "concept",
+    "title": "A First Bound: ψ(n) ≤ log(n!)",
+    "content": "Since Λ(m) ≤ log m termwise (vonMangoldt_le_log) — the von Mangoldt value is log p ≤ log m on a prime power m = p^k and 0 otherwise — summing over [1,n] gives ψ(n) = ∑ Λ(m) ≤ ∑ log m = log(n!). This is the easy half of the chain that, combined with Legendre's identity, brackets ψ(n) between constant multiples of n in the full Chebyshev argument."
+  }
+]

--- a/src/data/proofs/chebyshev-bounds-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02/meta.json
@@ -1,0 +1,204 @@
+{
+  "id": "chebyshev-bounds-oq-02",
+  "title": "The Second Chebyshev Function ψ and Legendre's Identity log(n!) = ∑ Λ(d)⌊n/d⌋",
+  "slug": "chebyshev-bounds-oq-02",
+  "description": "Introduces the second Chebyshev function ψ(n) = ∑_{m≤n} Λ(m) = ∑_{p^k≤n} log p in von Mangoldt form, and proves Legendre's identity log(n!) = ∑_{d=1}^n Λ(d)·⌊n/d⌋ — the elementary engine behind the Chebyshev prime-counting bounds. The proof expands log(n!) = ∑_{m≤n} log m, rewrites each log m = ∑_{d∣m} Λ(d) via Mathlib's vonMangoldt_sum, and swaps the summation order, counting the ⌊n/d⌋ multiples of d. Also records ψ's nonnegativity, monotonicity, and the bound ψ(n) ≤ log(n!). Answers the parent chebyshev-bounds' second open direction (the ψ function).",
+  "meta": {
+    "author": "Pafnuty Chebyshev (1852); Adrien-Marie Legendre; formalized in Lean 4",
+    "date": "1852",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevBoundsOQ02.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "chebyshev",
+      "von-mangoldt",
+      "prime-counting",
+      "analytic-number-theory"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 135,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, no `native_decide`. `#print axioms` reports only the three ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted under the project's axiom-integrity policy. Uses Mathlib's ArithmeticFunction.vonMangoldt development (vonMangoldt_sum, vonMangoldt_le_log, vonMangoldt_nonneg) and Nat.Ioc_filter_dvd_card_eq_div; all results are fully machine-checked.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.vonMangoldt_sum",
+        "description": "∑_{d ∣ n} Λ(d) = log n — the divisor-sum identity for the von Mangoldt function",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt"
+      },
+      {
+        "theorem": "ArithmeticFunction.vonMangoldt_le_log",
+        "description": "Λ(n) ≤ log n, giving ψ(n) ≤ log(n!)",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt"
+      },
+      {
+        "theorem": "Nat.Ioc_filter_dvd_card_eq_div",
+        "description": "#{x ∈ (0,n] : d ∣ x} = ⌊n/d⌋ — counts the multiples of d in [1,n]",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Real.log_prod",
+        "description": "log of a product is the sum of logs (for positive factors), turning log(n!) into ∑ log m",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "dateAdded": "2026-06-22",
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Pafnuty Chebyshev, in his 1848–1852 work, gave the first substantial unconditional results toward the Prime Number Theorem, proving that π(x) is of order x/log x. His method is elementary and combinatorial: study the prime factorisation of n! through Legendre's formula for the exponent of a prime in n!, packaged as the second Chebyshev function ψ(x) = ∑_{p^k ≤ x} log p. The cornerstone is the identity log(n!) = ∑_{d=1}^n Λ(d)·⌊n/d⌋, where Λ is the von Mangoldt function (Λ(p^k) = log p, else 0). Telescoping log((2n)!) − 2 log(n!) against this identity, and comparing with the central binomial coefficient, yields ψ(n) and θ(n) = Θ(n), hence π(n) = Θ(n/log n).\n\nThe von Mangoldt function makes the bookkeeping clean: ∑_{d ∣ m} Λ(d) = log m precisely because the prime powers dividing m account for log m = ∑_p (v_p(m)) log p. Mathlib formalises this as vonMangoldt_sum, which is the key the present file turns.",
+    "problemStatement": "**Open Question (parent chebyshev-bounds, second open direction)**: Formalize the second Chebyshev function ψ(x) = ∑_{p^k ≤ x} log p and the elementary identities linking it to the factorial and to θ.\n\n**Result**: ψ is defined in von Mangoldt form and Legendre's identity log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋ is proved, along with ψ's basic structure and the bound ψ(n) ≤ log(n!).",
+    "text": "A 135-line, fully verified (0 sorries, 0 axioms, no native_decide) file. It defines chebyshevPsi n = ∑_{m∈[1,n]} Λ(m) and proves chebyshevPsi_nonneg and chebyshevPsi_mono. Two supporting lemmas — divisors_eq_filter (for m ∈ [1,n], the divisors of m are the elements of [1,n] dividing m) and card_multiples_Icc (the count of multiples of d in [1,n] is ⌊n/d⌋, from Nat.Ioc_filter_dvd_card_eq_div) — feed the headline log_factorial_eq_sum: log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋. Finally chebyshevPsi_le_log_factorial bounds ψ(n) ≤ log(n!).",
+    "proofStrategy": "log_factorial_eq_sum proceeds in three moves. (1) log(n!) = ∑_{m∈[1,n]} log m: rewrite n! = ∏_{m∈[1,n]} m (the one-line induction prod_Icc_id_eq_factorial), then Nat.cast_prod and Real.log_prod (each factor positive). (2) Each log m = ∑_{d∈[1,n]} (if d ∣ m then Λ d else 0): apply vonMangoldt_sum in reverse to get ∑_{d∣m} Λ d, rewrite the divisor set as the [1,n]-filter (divisors_eq_filter), and unfold Finset.sum_filter. (3) Swap the two finite sums over [1,n] with Finset.sum_comm, then collapse the inner sum: ∑_{m} (if d∣m then Λ d else 0) = (#multiples of d) • Λ d = ⌊n/d⌋ · Λ d via Finset.sum_filter, Finset.sum_const, and card_multiples_Icc. chebyshevPsi_le_log_factorial compares termwise using vonMangoldt_le_log after the same log(n!) = ∑ log m expansion.",
+    "keyInsights": [
+      "ψ in von Mangoldt form ψ(n) = ∑_{m≤n} Λ(m) makes Mathlib's vonMangoldt_sum (∑_{d∣m} Λ(d) = log m) directly applicable.",
+      "Legendre's identity log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋ is a Fubini swap: counting each d's contribution log-weighted over its ⌊n/d⌋ multiples in [1,n].",
+      "The multiple-count ⌊n/d⌋ is exactly Nat.Ioc_filter_dvd_card_eq_div once [1,n] is rewritten as (0,n].",
+      "For m ∈ [1,n], the divisors of m all lie in [1,n], so m.divisors equals the [1,n]-filter dividing m — the bridge that lets both inner sums range over the same fixed set [1,n] for the swap.",
+      "This identity is the elementary engine of the Chebyshev bounds: telescoping log((2n)!) − 2 log(n!) against it, with the central binomial coefficient, yields ψ(n), θ(n) = Θ(n)."
+    ],
+    "prerequisites": [
+      "The von Mangoldt function Λ and the identity ∑_{d∣n} Λ(d) = log n",
+      "Logarithm of a product; factorials",
+      "Finset summation interchange (Fubini) and divisor counting in Lean 4/Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "psi-def",
+      "title": "The Second Chebyshev Function ψ",
+      "startLine": 38,
+      "endLine": 49,
+      "summary": "chebyshevPsi n = ∑_{m∈[1,n]} Λ(m), with chebyshevPsi_nonneg and chebyshevPsi_mono.",
+      "mathContext": "ψ(x) = ∑_{p^k≤x} log p in von Mangoldt form; nonnegative and monotone."
+    },
+    {
+      "id": "support",
+      "title": "Supporting Lemmas",
+      "startLine": 57,
+      "endLine": 82,
+      "summary": "prod_Icc_id_eq_factorial: ∏_{m≤n} m = n!. divisors_eq_filter: m.divisors = [1,n]-filter dividing m for m∈[1,n]. card_multiples_Icc: #multiples of d in [1,n] = ⌊n/d⌋.",
+      "mathContext": "The divisor-set identification and multiple-count feeding the Fubini swap."
+    },
+    {
+      "id": "legendre",
+      "title": "Legendre's Identity",
+      "startLine": 84,
+      "endLine": 105,
+      "summary": "log_factorial_eq_sum: log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋, via log(n!)=∑log m, log m=∑_{d∣m}Λ(d), and a summation swap.",
+      "mathContext": "The elementary engine of the Chebyshev prime-counting bounds."
+    },
+    {
+      "id": "psi-bound",
+      "title": "ψ(n) ≤ log(n!)",
+      "startLine": 107,
+      "endLine": 115,
+      "summary": "chebyshevPsi_le_log_factorial: termwise Λ(m) ≤ log m gives ψ(n) ≤ log(n!).",
+      "mathContext": "A first quantitative bound on ψ from von Mangoldt ≤ log."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file formalizes the second Chebyshev function ψ(n) = ∑_{m≤n} Λ(m) in von Mangoldt form and proves Legendre's identity log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋, the elementary identity at the heart of Chebyshev's method, along with ψ's nonnegativity, monotonicity, and the bound ψ(n) ≤ log(n!).",
+    "implications": "Legendre's identity is the standard starting point for the elementary Chebyshev bounds θ(n), ψ(n) = Θ(n) and hence π(n) = Θ(n/log n): telescoping log((2n)!) − 2 log(n!) against it and comparing with the central binomial coefficient bounds ψ from both sides. Formalizing ψ in von Mangoldt form also connects this thread to Mathlib's analytic number theory, where ψ(x) ∼ x is the form of the Prime Number Theorem dual to π(x) ∼ x/log x.",
+    "openQuestions": [
+      "Derive the explicit Chebyshev bounds c₁·n ≤ ψ(n) ≤ c₂·n by telescoping Legendre's identity against the central binomial coefficient.",
+      "Prove ψ(n) − θ(n) = ∑_{k≥2} θ(n^{1/k}) = O(√n log² n), so ψ and θ have the same main term.",
+      "Connect ψ(x) ∼ x to π(x) ∼ x/log x via Abel/partial summation, working toward the Prime Number Theorem."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-bounds",
+      "relationship": "extends",
+      "description": "Parent: explicit Chebyshev bounds on π(n) and θ(n). This entry adds the second Chebyshev function ψ and Legendre's identity."
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge",
+      "relationship": "related",
+      "description": "Works toward the Prime Number Theorem, for which ψ(x) ∼ x is the natural formulation."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "ArithmeticFunction"
+    ],
+    "namespace": "ChebyshevBoundsOQ02",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "mainTheorems": [
+      {
+        "name": "log_factorial_eq_sum",
+        "type": "core",
+        "description": "Legendre's identity: log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋",
+        "leanType": "(n : ℕ) → Real.log (Nat.factorial n : ℝ) = ∑ d ∈ Finset.Icc 1 n, Λ d * (n / d : ℕ)"
+      },
+      {
+        "name": "chebyshevPsi",
+        "type": "key",
+        "description": "The second Chebyshev function ψ(n) = ∑_{m≤n} Λ(m)",
+        "leanType": "(n : ℕ) → ℝ"
+      },
+      {
+        "name": "chebyshevPsi_le_log_factorial",
+        "type": "key",
+        "description": "ψ(n) ≤ log(n!)",
+        "leanType": "(n : ℕ) → chebyshevPsi n ≤ Real.log (Nat.factorial n : ℝ)"
+      }
+    ],
+    "path": "Proofs/ChebyshevBoundsOQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "log_factorial_eq_sum",
+      "type": "core",
+      "description": "Legendre's identity log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋, the elementary engine of the Chebyshev bounds",
+      "leanType": "(n : ℕ) → Real.log (Nat.factorial n : ℝ) = ∑ d ∈ Finset.Icc 1 n, Λ d * (n / d : ℕ)"
+    },
+    {
+      "name": "chebyshevPsi",
+      "type": "key",
+      "description": "The second Chebyshev function ψ(n) = ∑_{m≤n} Λ(m) = ∑_{p^k≤n} log p",
+      "leanType": "(n : ℕ) → ℝ"
+    },
+    {
+      "name": "card_multiples_Icc",
+      "type": "supporting",
+      "description": "The number of multiples of d in [1,n] is ⌊n/d⌋",
+      "leanType": "(d n : ℕ) → ((Finset.Icc 1 n).filter (d ∣ ·)).card = n / d"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Chebyshev, Pafnuty L.",
+      "title": "Mémoire sur les nombres premiers",
+      "year": "1852",
+      "venue": "Journal de mathématiques pures et appliquées 17, 366–390",
+      "note": "The elementary bounds on π(x) via factorials and the function ψ"
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer UTM",
+      "note": "Chapter 4 develops ψ, θ, the von Mangoldt function, and Legendre's identity log(n!) = ∑ Λ(d)⌊n/d⌋"
+    },
+    {
+      "authors": "Tenenbaum, Gérald",
+      "title": "Introduction to Analytic and Probabilistic Number Theory",
+      "year": "2015",
+      "venue": "AMS, 3rd edition",
+      "note": "Chebyshev's method and the relation ψ(x) ∼ x ⟺ π(x) ∼ x/log x"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers parent **chebyshev-bounds**'s second open direction: formalize the **second Chebyshev function ψ** and the elementary identity tying it to the factorial.

**`ChebyshevBoundsOQ02.lean`** — 135 lines, 7 theorems, 1 def, **0 sorries, 0 axioms, no `native_decide`** (`#print axioms` → only propext/Classical.choice/Quot.sound).

### The function
- `chebyshevPsi`: ψ(n) = ∑_{m≤n} Λ(m) = ∑_{p^k≤n} log p, in von Mangoldt form, with `chebyshevPsi_nonneg` and `chebyshevPsi_mono`.

### Legendre's identity (the headline)
- `log_factorial_eq_sum`: **log(n!) = ∑_{d=1}^{n} Λ(d)·⌊n/d⌋** — the elementary engine of the Chebyshev bounds. Proved by expanding log(n!) = ∑_{m≤n} log m, rewriting each log m = ∑_{d∣m} Λ(d) (Mathlib's `vonMangoldt_sum`), and a Fubini swap counting the ⌊n/d⌋ multiples of each d in [1,n] (`Nat.Ioc_filter_dvd_card_eq_div`).

### Bound
- `chebyshevPsi_le_log_factorial`: ψ(n) ≤ log(n!), termwise from `vonMangoldt_le_log`.

## Honest scope
This is the elementary foundation. Deriving the explicit two-sided bounds ψ(n) = Θ(n) by telescoping `log((2n)!) − 2 log(n!)` against this identity is the natural next step (noted as an open question in the entry).

## Verification
`./proofs/scripts/docker-build.sh Proofs.ChebyshevBoundsOQ02` → Build completed successfully (7743 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)