### PR TITLE
research(erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01): the exponential growth rate of the Catalan numbers is exactly 4

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3596,3 +3596,5 @@ import Proofs.CatalanNumbersOQ01OQ02OQ01
 import Proofs.MarkovEquation
 import Proofs.MantelTheoremOQ04OQ01
 
+
+import Proofs.Erdos396OQ04OQ01OQ01OQ02OQ01

--- a/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,160 @@
+/-
+# Erdős Problem #396 — OQ-04 → OQ-01 → OQ-01 → OQ-02 → OQ-01: the exponential growth rate of the Catalan numbers is exactly `4`
+
+The parent `Erdos396OQ04OQ01OQ01OQ02` isolates the **sub-exponential** correction
+to Catalan growth: it pins the polynomial exponent `3/2` in the asymptotic
+`catalan n ∼ 4^n / (n^{3/2} √π)` by telescoping the recurrence ratio through the
+logarithm.  That is the *fine* structure — the deviation of `catalan n / 4^n` from
+a constant.
+
+This follow-up nails the *coarse* structure: the **leading exponential rate**.
+We show
+
+  **`catalan_log_div_tendsto_log_four`** :
+    `(1/n)·log (catalan n) → log 4`,
+
+i.e. `catalan n = 4^{(1 + o(1)) n}`.  Equivalently, taking `n`-th roots,
+
+  **`catalan_rpow_tendsto_four`** :
+    `(catalan n)^{1/n} → 4`.
+
+This is the Cauchy–Hadamard statement that the **Catalan generating function**
+`∑ catalan n · xⁿ` has radius of convergence exactly `1/4`: the exponential rate
+`4` is the reciprocal of that radius, and the polynomial factor `n^{-3/2}` from the
+parent does not affect it.
+
+The proof needs only two elementary brackets on the central binomial coefficient,
+both already in Mathlib:
+
+* an **upper** bound `catalan n ≤ 4^n`, from
+  `(n+1)·catalan n = centralBinom n = (2n choose n) ≤ 2^{2n} = 4^n`
+  (`Nat.choose_le_two_pow`);
+* a **lower** bound `4^n ≤ 2 n² · catalan n` for `n ≥ 4`, from Erdős's
+  `Nat.four_pow_lt_mul_centralBinom : 4^n < n · centralBinom n` together with
+  `n(n+1) ≤ 2n²`.
+
+Passing to logarithms turns these into `log 4 − O((log n)/n) ≤ (log catalan n)/n ≤ log 4`,
+and the squeeze `(log n)/n → 0` (Mathlib's `Real.isLittleO_log_id_atTop`) forces the
+limit `log 4`.  No Stirling estimate is used.
+
+Reference: https://erdosproblems.com/396
+-/
+
+import Mathlib
+
+open Nat Filter Topology
+
+namespace Erdos396OQ04OQ01OQ01OQ02OQ01
+
+/-! ## Positivity and the two elementary brackets -/
+
+/-- Every Catalan number is positive (`(n+1)·catalan n = centralBinom n > 0`). -/
+theorem catalan_pos (n : ℕ) : 0 < catalan n := by
+  have h := succ_mul_catalan_eq_centralBinom n
+  have hc := Nat.centralBinom_pos n
+  rcases Nat.eq_zero_or_pos (catalan n) with h0 | hp
+  · rw [h0, Nat.mul_zero] at h; omega
+  · exact hp
+
+/-- **Upper bracket.**  `catalan n ≤ 4^n` for every `n`: the central binomial
+coefficient `(2n choose n)` is bounded by the row sum `2^{2n} = 4^n`, and
+`catalan n ≤ centralBinom n`. -/
+theorem catalan_le_four_pow (n : ℕ) : (catalan n : ℝ) ≤ 4 ^ n := by
+  have hcat_le_cb : catalan n ≤ Nat.centralBinom n := by
+    calc catalan n ≤ (n + 1) * catalan n :=
+          le_mul_of_one_le_left (Nat.zero_le _) (by omega)
+      _ = Nat.centralBinom n := succ_mul_catalan_eq_centralBinom n
+  have hcb_le : Nat.centralBinom n ≤ 4 ^ n := by
+    rw [Nat.centralBinom_eq_two_mul_choose]
+    calc (2 * n).choose n ≤ 2 ^ (2 * n) := Nat.choose_le_two_pow _ _
+      _ = 4 ^ n := by rw [pow_mul]; norm_num
+  have : catalan n ≤ 4 ^ n := le_trans hcat_le_cb hcb_le
+  exact_mod_cast this
+
+/-- **Lower bracket.**  For `n ≥ 4`, `4^n ≤ 2 n² · catalan n`.  From Erdős's bound
+`4^n < n · centralBinom n = n(n+1)·catalan n` and `n(n+1) ≤ 2n²`. -/
+theorem four_pow_le_two_sq_mul_catalan (n : ℕ) (hn : 4 ≤ n) :
+    (4 : ℝ) ^ n ≤ 2 * (n : ℝ) ^ 2 * catalan n := by
+  have h := Nat.four_pow_lt_mul_centralBinom n hn
+  have hcb := succ_mul_catalan_eq_centralBinom n
+  have hcat0 : (0 : ℝ) ≤ (catalan n : ℝ) := by positivity
+  have hn1 : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast (by omega : 1 ≤ n)
+  have hR : (4 : ℝ) ^ n ≤ (n : ℝ) * (Nat.centralBinom n : ℝ) := by exact_mod_cast h.le
+  have hcbR : (Nat.centralBinom n : ℝ) = ((n : ℝ) + 1) * (catalan n : ℝ) := by
+    exact_mod_cast hcb.symm
+  rw [hcbR] at hR
+  -- `hR : 4^n ≤ n·(n+1)·catalan n`; combine with `n(n+1) ≤ 2n²` (uses `n ≥ 1`).
+  nlinarith [hR, hcat0, hn1,
+    mul_nonneg (mul_nonneg (show (0 : ℝ) ≤ (n : ℝ) by linarith)
+      (show (0 : ℝ) ≤ (n : ℝ) - 1 by linarith)) hcat0]
+
+/-! ## The exponential growth rate -/
+
+/-- **The exponential growth rate of the Catalan numbers is `4`.**
+`(1/n)·log (catalan n) → log 4`.  This is the Cauchy–Hadamard statement that the
+Catalan generating function has radius of convergence `1/4`. -/
+theorem catalan_log_div_tendsto_log_four :
+    Tendsto (fun n : ℕ => Real.log (catalan n) / n) atTop (𝓝 (Real.log 4)) := by
+  -- Core analytic input: `(log n)/n → 0`.
+  have hlog : Tendsto (fun n : ℕ => Real.log n / n) atTop (𝓝 0) := by
+    simpa using
+      Real.isLittleO_log_id_atTop.tendsto_div_nhds_zero.comp tendsto_natCast_atTop_atTop
+  -- Lower flank `log 4 − (log 2)/n − 2·(log n)/n → log 4`.
+  have hlower : Tendsto
+      (fun n : ℕ => Real.log 4 - Real.log 2 / n - 2 * (Real.log n / n))
+      atTop (𝓝 (Real.log 4)) := by
+    have h1 : Tendsto (fun n : ℕ => Real.log 2 / (n : ℝ)) atTop (𝓝 0) := by
+      simpa [mul_one_div] using tendsto_one_div_atTop_nhds_zero_nat.const_mul (Real.log 2)
+    have h2 : Tendsto (fun n : ℕ => 2 * (Real.log n / n)) atTop (𝓝 0) := by
+      simpa using hlog.const_mul 2
+    have := ((tendsto_const_nhds (x := Real.log 4)).sub h1).sub h2
+    simpa using this
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le' hlower tendsto_const_nhds ?_ ?_
+  · -- lower flank ≤ `(log catalan n)/n`
+    filter_upwards [eventually_ge_atTop 4] with n hn
+    have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast (by omega : 0 < n)
+    have hcpos : (0 : ℝ) < (catalan n : ℝ) := by exact_mod_cast catalan_pos n
+    have hn2pos : (0 : ℝ) < (n : ℝ) ^ 2 := pow_pos hnpos 2
+    have h2n2pos : (0 : ℝ) < 2 * (n : ℝ) ^ 2 := mul_pos (by norm_num) hn2pos
+    have hle := four_pow_le_two_sq_mul_catalan n hn
+    have hlog_ineq : Real.log ((4 : ℝ) ^ n) ≤ Real.log (2 * (n : ℝ) ^ 2 * catalan n) :=
+      Real.log_le_log (by positivity) hle
+    rw [Real.log_pow] at hlog_ineq
+    have hexpand : Real.log (2 * (n : ℝ) ^ 2 * catalan n)
+        = Real.log 2 + 2 * Real.log n + Real.log (catalan n) := by
+      rw [Real.log_mul h2n2pos.ne' hcpos.ne', Real.log_mul (by norm_num) hn2pos.ne',
+        Real.log_pow]
+      push_cast; ring
+    rw [hexpand] at hlog_ineq
+    rw [← sub_nonneg]
+    have hrw : Real.log (catalan n) / ↑n
+          - (Real.log 4 - Real.log 2 / ↑n - 2 * (Real.log ↑n / ↑n))
+        = (Real.log (catalan n) - ↑n * Real.log 4 + Real.log 2 + 2 * Real.log ↑n) / ↑n := by
+      field_simp; ring
+    rw [hrw]
+    apply div_nonneg _ hnpos.le
+    linarith [hlog_ineq]
+  · -- `(log catalan n)/n ≤ log 4`
+    filter_upwards [eventually_ge_atTop 4] with n hn
+    have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast (by omega : 0 < n)
+    have hcpos : (0 : ℝ) < (catalan n : ℝ) := by exact_mod_cast catalan_pos n
+    have hle := catalan_le_four_pow n
+    have hlog_ineq : Real.log (catalan n) ≤ ↑n * Real.log 4 := by
+      have := Real.log_le_log hcpos hle
+      rwa [Real.log_pow] at this
+    rw [div_le_iff₀ hnpos]
+    linarith [hlog_ineq, mul_comm (n : ℝ) (Real.log 4)]
+
+/-- **`n`-th root form.**  `(catalan n)^{1/n} → 4`: the Catalan numbers grow like
+`4ⁿ` to leading exponential order.  Equivalently, the radius of convergence of
+`∑ catalan n · xⁿ` is `1/4`. -/
+theorem catalan_rpow_tendsto_four :
+    Tendsto (fun n : ℕ => (catalan n : ℝ) ^ ((1 : ℝ) / n)) atTop (𝓝 4) := by
+  have hmain := catalan_log_div_tendsto_log_four
+  have hexp := (Real.continuous_exp.tendsto (Real.log 4)).comp hmain
+  rw [Real.exp_log (by norm_num : (0 : ℝ) < 4)] at hexp
+  refine hexp.congr (fun n => ?_)
+  simp only [Function.comp_apply]
+  rw [Real.rpow_def_of_pos (by exact_mod_cast catalan_pos n), mul_one_div]
+
+end Erdos396OQ04OQ01OQ01OQ02OQ01

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-e396growthrate-pos",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 51, "endLine": 57 },
+    "type": "lemma",
+    "title": "Positivity of the Catalan numbers",
+    "content": "Every Catalan number is positive. The identity $(n+1)\\cdot\\mathrm{catalan}\\,n = \\binom{2n}{n} > 0$ forces $\\mathrm{catalan}\\,n \\neq 0$, since a zero factor would make the product vanish. Needed throughout to take logarithms.",
+    "mathContext": "$\\mathrm{catalan}\\,n > 0$ for all $n$."
+  },
+  {
+    "id": "ann-e396growthrate-upper",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 59, "endLine": 72 },
+    "type": "lemma",
+    "title": "Upper bracket: catalan n ≤ 4ⁿ",
+    "content": "The central binomial coefficient $\\binom{2n}{n}$ is one term of row $2n$ of Pascal's triangle, whose entries sum to $2^{2n}$, so $\\binom{2n}{n} \\le 2^{2n} = 4^n$ (Mathlib's `Nat.choose_le_two_pow`). Combined with $\\mathrm{catalan}\\,n \\le (n+1)\\cdot\\mathrm{catalan}\\,n = \\binom{2n}{n}$, this gives $\\mathrm{catalan}\\,n \\le 4^n$ for every $n$.",
+    "mathContext": "$\\mathrm{catalan}\\,n \\le \\binom{2n}{n} \\le 2^{2n} = 4^n$."
+  },
+  {
+    "id": "ann-e396growthrate-lower",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 74, "endLine": 89 },
+    "type": "lemma",
+    "title": "Lower bracket: 4ⁿ ≤ 2n²·catalan n",
+    "content": "Erdős's exponential lower bound on the central binomial coefficient, $4^n < n\\cdot\\binom{2n}{n}$ for $n \\ge 4$ (Mathlib's `Nat.four_pow_lt_mul_centralBinom`), rewrites via $\\binom{2n}{n} = (n+1)\\cdot\\mathrm{catalan}\\,n$ to $4^n < n(n+1)\\cdot\\mathrm{catalan}\\,n$. Since $n(n+1) \\le 2n^2$ for $n \\ge 1$ — the gap $2n^2 - n(n+1) = n(n-1)\\cdot\\mathrm{catalan}\\,n \\ge 0$ closes by `nlinarith` — we obtain $4^n \\le 2n^2\\cdot\\mathrm{catalan}\\,n$.",
+    "mathContext": "$4^n < n(n+1)\\,\\mathrm{catalan}\\,n \\le 2n^2\\,\\mathrm{catalan}\\,n$ for $n \\ge 4$."
+  },
+  {
+    "id": "ann-e396growthrate-main",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 93, "endLine": 146 },
+    "type": "theorem",
+    "title": "The exponential growth rate is log 4",
+    "content": "Taking logarithms of the two brackets and dividing by $n$ traps $(\\log \\mathrm{catalan}\\,n)/n$ between $\\log 4 - (\\log 2)/n - 2(\\log n)/n$ and $\\log 4$. Both flanks tend to $\\log 4$ because $(\\log n)/n \\to 0$ — Mathlib's `Real.isLittleO_log_id_atTop` composed with $n \\mapsto \\uparrow n \\to \\infty$. The squeeze theorem `tendsto_of_tendsto_of_tendsto_of_le_of_le'` then forces $(1/n)\\log(\\mathrm{catalan}\\,n) \\to \\log 4$.",
+    "mathContext": "$\\dfrac{1}{n}\\log(\\mathrm{catalan}\\,n) \\to \\log 4$."
+  },
+  {
+    "id": "ann-e396growthrate-rpow",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 148, "endLine": 158 },
+    "type": "theorem",
+    "title": "n-th root form: (catalan n)^{1/n} → 4",
+    "content": "Composing the logarithmic limit with the continuity of $\\exp$ gives $(\\mathrm{catalan}\\,n)^{1/n} = \\exp\\!\\big((\\log \\mathrm{catalan}\\,n)/n\\big) \\to \\exp(\\log 4) = 4$. This is the Cauchy–Hadamard statement that the Catalan generating function $\\sum \\mathrm{catalan}\\,n\\,x^n$ has radius of convergence exactly $1/4$.",
+    "mathContext": "$(\\mathrm{catalan}\\,n)^{1/n} \\to 4$; radius of convergence $= 1/4$."
+  }
+]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,98 @@
+{
+  "id": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01",
+  "title": "Erdős #396 OQ-04 → OQ-01 → OQ-01 → OQ-02 → OQ-01: The Exponential Growth Rate of the Catalan Numbers is Exactly 4",
+  "slug": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01",
+  "description": "Where the parent pins the sub-exponential exponent 3/2, this entry nails the leading exponential rate: (1/n)·log(catalan n) → log 4, equivalently (catalan n)^{1/n} → 4. This is the Cauchy–Hadamard statement that the Catalan generating function ∑ catalan n · xⁿ has radius of convergence exactly 1/4. The proof uses only two elementary brackets on the central binomial coefficient — the upper bound catalan n ≤ 4^n from (2n choose n) ≤ 2^{2n}, and the lower bound 4^n ≤ 2n²·catalan n from Erdős's 4^n < n·centralBinom n — passed through the logarithm and squeezed with (log n)/n → 0. No Stirling estimate is used.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/396",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ01.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "catalan",
+      "central-binomial",
+      "asymptotics",
+      "growth-rate",
+      "generating-functions",
+      "radius-of-convergence",
+      "limits"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 396,
+    "erdosUrl": "https://erdosproblems.com/396",
+    "axiomCount": 0,
+    "lineCount": 160,
+    "assumptions": "0 axioms, 0 sorries. Both headline theorems depend only on the foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool / native_decide). Built against Mathlib 4.26.0.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The classical Stirling asymptotic catalan n ∼ 4^n / (n^{3/2}√π) factors into a leading exponential rate 4^n and a sub-exponential correction n^{-3/2} (times the constant 1/√π). The parent chain isolated these two layers separately: Erdős #396 OQ-04 → OQ-01 → OQ-01 showed the recurrence deficit 4 − r n = 6/(n+2) is harmonic, and its child OQ-02 exponentiated that harmonic sum to pin the polynomial exponent 3/2. The exponent governs the fine, sub-exponential structure. This follow-up addresses the complementary coarse structure — the leading exponential order — and proves it is exactly 4, independent of the polynomial correction.",
+    "problemStatement": "What is the exponential growth rate of the Catalan numbers, i.e. the limit of (1/n)·log(catalan n) (equivalently of (catalan n)^{1/n})? And what does it say about the radius of convergence of the Catalan generating function?",
+    "text": "(1/n)·log(catalan n) → log 4, equivalently (catalan n)^{1/n} → 4. Hence the Catalan generating function ∑ catalan n · xⁿ has radius of convergence exactly 1/4. The polynomial factor n^{-3/2} from the parent does not affect this leading rate.",
+    "proofStrategy": "Bracket catalan n between two functions both growing like 4^n up to a polynomial factor. UPPER: catalan n ≤ centralBinom n = (2n choose n) ≤ 2^{2n} = 4^n, using succ_mul_catalan_eq_centralBinom and Nat.choose_le_two_pow (catalan_le_four_pow). LOWER: for n ≥ 4, Erdős's Nat.four_pow_lt_mul_centralBinom gives 4^n < n·centralBinom n = n(n+1)·catalan n, and n(n+1) ≤ 2n² (valid for n ≥ 1) yields 4^n ≤ 2n²·catalan n (four_pow_le_two_sq_mul_catalan; the n(n+1) ≤ 2n² step is closed by nlinarith with a n(n−1)·catalan n ≥ 0 hint). Taking logarithms of both brackets and dividing by n gives log 4 − (log 2)/n − 2·(log n)/n ≤ (log catalan n)/n ≤ log 4. The two flanks converge to log 4 because (log n)/n → 0 (Mathlib's Real.isLittleO_log_id_atTop composed with tendsto_natCast_atTop_atTop, plus tendsto_one_div_atTop_nhds_zero_nat); the squeeze theorem tendsto_of_tendsto_of_tendsto_of_le_of_le' delivers (catalan_log_div_tendsto_log_four). The n-th-root form (catalan_rpow_tendsto_four) follows by composing with the continuity of exp: (catalan n)^{1/n} = exp((log catalan n)/n) → exp(log 4) = 4.",
+    "keyInsights": [
+      "**The exponential growth rate is exactly 4.** The bare integer recurrence and two row-sum bounds on the central binomial coefficient already force (catalan n)^{1/n} → 4 — the leading-order content of the Stirling asymptotic, obtained with no factorial asymptotics.",
+      "**Coarse versus fine structure.** The parent entry pins the polynomial exponent 3/2 (the sub-exponential correction); this entry pins the exponential rate 4 (the leading order). They are independent: the n^{-3/2} factor is invisible to the n-th root because (n^{-3/2})^{1/n} → 1.",
+      "**Radius of convergence 1/4, rigorously.** The limit (catalan n)^{1/n} → 4 is precisely the Cauchy–Hadamard computation that the Catalan generating function ∑ catalan n · xⁿ has radius of convergence 1/4 — the reciprocal of the growth rate.",
+      "**A clean two-sided polynomial bracket suffices.** catalan n ≤ 4^n and 4^n ≤ 2n²·catalan n trap the Catalan numbers within a polynomial factor of 4^n; the logarithm converts the polynomial gap into an O((log n)/n) term that vanishes after dividing by n. The squeeze needs nothing sharper than 'polynomial factors are exponentially negligible'."
+    ],
+    "prerequisites": [
+      "Bounds on the central binomial coefficient: (2n choose n) ≤ 2^{2n} and Erdős's 4^n < n·centralBinom n",
+      "The Catalan–central-binomial identity (n+1)·catalan n = centralBinom n",
+      "Logarithm monotonicity, the limit (log n)/n → 0, and the squeeze theorem for sequences"
+    ]
+  },
+  "conclusion": {
+    "summary": "(1/n)·log(catalan n) → log 4, and equivalently (catalan n)^{1/n} → 4: the exponential growth rate of the Catalan numbers is exactly 4. The proof brackets catalan n between 4^n/(2n²) and 4^n using only central-binomial bounds, passes to logarithms, and squeezes with (log n)/n → 0. All five theorems are fully machine-checked with no axioms or sorries.",
+    "implications": "The result establishes, by elementary means, the leading exponential order of Catalan growth and hence that the Catalan generating function has radius of convergence exactly 1/4. Together with the parent entry — which pins the polynomial exponent 3/2 — it reconstructs both layers of the Stirling asymptotic catalan n ∼ 4^n/(n^{3/2}√π) except for the constant 1/√π, and does so without any factorial/Stirling input.",
+    "openQuestions": [
+      "Can the remaining constant be captured: does catalan n · n^{3/2} / 4^n → 1/√π, i.e. can Mathlib's Stirling formula be combined with this bracket and the parent's exponent to certify the full asymptotic constant?",
+      "Does the same central-binomial bracket prove (C(2n,n))^{1/n} → 4 and thereby the radius of convergence 1/4 for the generating function of the central binomial coefficients, the n^{-1/2} sibling of the n^{-3/2} Catalan case?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "Erdos396OQ04OQ01OQ01OQ02OQ01",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "Parent OQ: exponentiates the harmonic deficit sum to pin the sub-exponential exponent 3/2 (catalan n / 4^n ∼ n^{-3/2}). This follow-up pins the complementary leading exponential rate 4."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01",
+      "relationship": "ancestor",
+      "description": "The Catalan ratio deficit 4 − r n = 6/(n+2) is harmonic; its divergent running sum is the recurrence-level reason for the polynomial correction below 4^n."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01",
+      "relationship": "ancestor",
+      "description": "The Catalan recurrence ratio r n = 4 − 6/(n+2), with r n → 4: the limiting rate 4 whose exponential status is certified here."
+    },
+    {
+      "targetId": "erdos-396",
+      "relationship": "ancestor",
+      "description": "Root problem: descending factorials dividing central binomial coefficients, whose base case rests on the Catalan numbers."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

A child of the Catalan-growth chain under Erdős #396. Where the parent (`erdos-396-oq-04-oq-01-oq-01-oq-02`, PR #27503) pins the **sub-exponential exponent 3/2**, this entry pins the complementary **leading exponential rate**:

- **`catalan_log_div_tendsto_log_four`** : `(1/n)·log(catalan n) → log 4`
- **`catalan_rpow_tendsto_four`** : `(catalan n)^{1/n} → 4`

i.e. the Catalan generating function `∑ catalan n · xⁿ` has radius of convergence exactly `1/4` (Cauchy–Hadamard).

## Method

Two elementary central-binomial brackets — no Stirling estimate:

- **Upper** `catalan n ≤ 4^n`: from `catalan n ≤ (n+1)·catalan n = centralBinom n = (2n choose n) ≤ 2^{2n} = 4^n` (`Nat.choose_le_two_pow`).
- **Lower** `4^n ≤ 2n²·catalan n` (n ≥ 4): from Erdős's `Nat.four_pow_lt_mul_centralBinom : 4^n < n·centralBinom n` and `n(n+1) ≤ 2n²`.

Passing to logarithms and dividing by `n`:
`log 4 − (log 2)/n − 2(log n)/n ≤ (log catalan n)/n ≤ log 4`.
Both flanks → `log 4` because `(log n)/n → 0` (`Real.isLittleO_log_id_atTop`); the squeeze theorem delivers the limit. The n-th-root form follows by composing with continuity of `exp`.

The polynomial factor `n^{-3/2}` from the parent is invisible to the n-th root — coarse and fine structure are independent.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos396OQ04OQ01OQ01OQ02OQ01` → **Build completed successfully**
- `#print axioms` on both headline theorems: only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`/`native_decide`**.
- 160 lines, 5 theorems, 0 definitions, 0 sorries, 0 axioms. Mathlib 4.26.0.

Self-contained: imports only `Mathlib` (uses `Nat.centralBinom`/`catalan` directly, not the parent's recurrence-ratio infrastructure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)