### PR TITLE
research(perfect-numbers-oq-02): the abundancy index — perfect ⟺ ∑ 1/d = 2

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3106,6 +3106,7 @@ import Proofs.PellEquationOQ06
 import Proofs.PellEquationOQ06OQ01
 import Proofs.PentagonalNumberTheoremOQ01
 import Proofs.PerfectNumbers
+import Proofs.PerfectNumbersOQ02
 import Proofs.PerfectNumbersOQ03
 import Proofs.PerfectNumbersOQ05
 import Proofs.PerfectNumbersOQ06

--- a/proofs/Proofs/PerfectNumbersOQ02.lean
+++ b/proofs/Proofs/PerfectNumbersOQ02.lean
@@ -1,0 +1,108 @@
+import Mathlib
+
+/-
+# Perfect Numbers OQ-02: The Abundancy Index and the Reciprocal-Divisor Characterization
+
+## Context (parent perfect-numbers: the Euclid–Euler theorem)
+
+A positive integer `n` is **perfect** when it equals the sum of its proper divisors
+(`6 = 1+2+3`, `28 = 1+2+4+7+14`), equivalently `σ(n) = 2n`. The parent develops the
+Euclid–Euler classification of even perfect numbers.
+
+## What this file proves
+
+The **abundancy index** of `n` is `I(n) = σ(n)/n`, and a clean, convention-free way to write it
+is as the **sum of the reciprocals of the divisors of `n`**:
+
+> **`I(n) = ∑_{d ∣ n} 1/d`.**
+
+The reason is the divisor involution `d ↦ n/d`: pairing each divisor with its cofactor turns
+`∑_{d∣n} 1/d` into `(1/n)·∑_{d∣n} (n/d) = (1/n)·∑_{d∣n} d = σ(n)/n`. From this the perfect-number
+condition becomes the elegant statement
+
+> **`n` is perfect ⟺ `∑_{d ∣ n} 1/d = 2`.**
+
+So a perfect number is exactly one whose divisor reciprocals sum to `2`; for `6`, indeed
+`1/1 + 1/2 + 1/3 + 1/6 = 2`. We give the index identity, the iff, and the concrete value at the
+first two perfect numbers `6` and `28`.
+
+Tags: number-theory, perfect-numbers, divisors, abundancy, sigma, sum-of-divisors
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/
+
+open Finset
+
+namespace PerfectNumbersOQ02
+
+/-- The **abundancy index** of `n`, written as the sum of the reciprocals of its divisors:
+    `I(n) = ∑_{d ∣ n} 1/d`. (For `n > 0` this equals `σ(n)/n`.) -/
+noncomputable def abundancyIndex (n : ℕ) : ℚ := ∑ d ∈ n.divisors, (d : ℚ)⁻¹
+
+/-- **The reciprocal-divisor sum is `σ(n)/n`.** Pairing each divisor `d` with its cofactor
+    `n/d` (the involution `d ↦ n/d` on the divisors) gives
+    `∑_{d∣n} 1/d = (1/n)·∑_{d∣n} d = σ(n)/n`. -/
+theorem abundancyIndex_eq_sigma_div {n : ℕ} (hn : 0 < n) :
+    abundancyIndex n = (∑ i ∈ n.divisors, (i : ℕ) : ℚ) / n := by
+  have hrw : ∀ d ∈ n.divisors, (d : ℚ)⁻¹ = ((n / d : ℕ) : ℚ) / n := by
+    intro d hd
+    obtain ⟨hdvd, _⟩ := Nat.mem_divisors.mp hd
+    have hd0 : (d : ℚ) ≠ 0 := by
+      have := Nat.pos_of_mem_divisors hd; exact_mod_cast this.ne'
+    rw [Nat.cast_div hdvd hd0]
+    field_simp
+  rw [abundancyIndex, Finset.sum_congr rfl hrw, ← Finset.sum_div, Nat.sum_div_divisors,
+    ← Nat.cast_sum]
+
+/-- **The reciprocal-divisor characterization of perfect numbers.**
+    `n` is perfect iff the reciprocals of its divisors sum to `2`:
+    `n.Perfect ↔ ∑_{d ∣ n} 1/d = 2`. -/
+theorem perfect_iff_abundancyIndex_eq_two {n : ℕ} (hn : 0 < n) :
+    n.Perfect ↔ abundancyIndex n = 2 := by
+  have hn0 : (n : ℚ) ≠ 0 := by exact_mod_cast hn.ne'
+  rw [Nat.perfect_iff_sum_divisors_eq_two_mul hn, abundancyIndex_eq_sigma_div hn, div_eq_iff hn0,
+    ← Nat.cast_sum]
+  constructor
+  · intro h; rw [h]; push_cast; ring
+  · intro h; exact_mod_cast h
+
+/-- A perfect number has divisor reciprocals summing to exactly `2`. -/
+theorem abundancyIndex_eq_two_of_perfect {n : ℕ} (hn : 0 < n) (hp : n.Perfect) :
+    ∑ d ∈ n.divisors, (d : ℚ)⁻¹ = 2 :=
+  (perfect_iff_abundancyIndex_eq_two hn).mp hp
+
+/-! ## Concrete values at the first perfect numbers -/
+
+/-- `6` is a perfect number. -/
+theorem perfect_six : Nat.Perfect 6 :=
+  (Nat.perfect_iff_sum_divisors_eq_two_mul (by norm_num)).mpr (by decide)
+
+/-- `28` is a perfect number. -/
+theorem perfect_twentyEight : Nat.Perfect 28 :=
+  (Nat.perfect_iff_sum_divisors_eq_two_mul (by norm_num)).mpr (by decide)
+
+/-- `6` is perfect: `1/1 + 1/2 + 1/3 + 1/6 = 2`. -/
+theorem abundancyIndex_six : abundancyIndex 6 = 2 :=
+  (perfect_iff_abundancyIndex_eq_two (by norm_num)).mp perfect_six
+
+/-- `28` is perfect: its divisor reciprocals sum to `2`. -/
+theorem abundancyIndex_twentyEight : abundancyIndex 28 = 2 :=
+  (perfect_iff_abundancyIndex_eq_two (by norm_num)).mp perfect_twentyEight
+
+end PerfectNumbersOQ02
+
+/-
+## Summary
+
+The abundancy index and the reciprocal-divisor characterization of perfect numbers:
+
+- `abundancyIndex`:                      `I(n) = ∑_{d∣n} 1/d`.
+- `abundancyIndex_eq_sigma_div`:         `I(n) = σ(n)/n`, via the divisor involution `d ↦ n/d`.
+- `perfect_iff_abundancyIndex_eq_two`:   **`n` is perfect ⟺ `∑_{d∣n} 1/d = 2`.**
+- `abundancyIndex_six`, `abundancyIndex_twentyEight`: the value `2` at `6` and `28`.
+
+Uses Mathlib's `Nat.sum_div_divisors` (the divisor involution) and
+`Nat.perfect_iff_sum_divisors_eq_two_mul`.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/

--- a/src/data/proofs/perfect-numbers-oq-02/annotations.json
+++ b/src/data/proofs/perfect-numbers-oq-02/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-index",
+    "proofId": "perfect-numbers-oq-02",
+    "range": {
+      "startLine": 44,
+      "endLine": 56
+    },
+    "type": "insight",
+    "title": "The Divisor Involution Turns Reciprocals into σ(n)/n",
+    "content": "`abundancyIndex_eq_sigma_div` proves I(n) = ∑_{d∣n} 1/d = σ(n)/n. The mechanism is the involution d ↦ n/d on the divisors of n: each reciprocal 1/d equals the cofactor (n/d)/n (since for d ∣ n the natural cofactor n/d casts exactly to (n:ℚ)/(d:ℚ)), so factoring 1/n out leaves (1/n)·∑_{d∣n} (n/d) = (1/n)·∑_{d∣n} d = σ(n)/n. Mathlib packages the involution as Nat.sum_div_divisors: ∑_{d∣n} f(n/d) = ∑_{d∣n} f(d)."
+  },
+  {
+    "id": "ann-characterization",
+    "proofId": "perfect-numbers-oq-02",
+    "range": {
+      "startLine": 62,
+      "endLine": 73
+    },
+    "type": "insight",
+    "title": "Perfect ⟺ Divisor Reciprocals Sum to 2",
+    "content": "`perfect_iff_abundancyIndex_eq_two` is the headline: n is perfect exactly when ∑_{d∣n} 1/d = 2. The proof rewrites perfectness as σ(n) = 2n (Nat.perfect_iff_sum_divisors_eq_two_mul) and the index as σ(n)/n, clears the denominator, and matches the two integer equations by casting. This convention-free form generalizes immediately: a k-perfect number is one with ∑_{d∣n} 1/d = k, so multiply perfect numbers fit the same template."
+  },
+  {
+    "id": "ann-concrete",
+    "proofId": "perfect-numbers-oq-02",
+    "range": {
+      "startLine": 82,
+      "endLine": 100
+    },
+    "type": "concept",
+    "title": "6 and 28, Checked by Kernel Decide",
+    "content": "perfect_six and perfect_twentyEight establish that 6 and 28 are perfect using ordinary kernel `decide` on the divisor-sum condition ∑_{d∣n} d = 2n — no native_decide, so the entry stays axiom-free. Feeding them into the characterization gives 1/1 + 1/2 + 1/3 + 1/6 = 2 and the analogous identity for 28, the smallest concrete witnesses of the reciprocal-sum-equals-2 property."
+  }
+]

--- a/src/data/proofs/perfect-numbers-oq-02/meta.json
+++ b/src/data/proofs/perfect-numbers-oq-02/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "perfect-numbers-oq-02",
+  "title": "The Abundancy Index: Perfect ⟺ ∑_{d∣n} 1/d = 2",
+  "slug": "perfect-numbers-oq-02",
+  "description": "Characterizes perfect numbers via the abundancy index I(n) = σ(n)/n, written as the sum of the reciprocals of the divisors of n: I(n) = ∑_{d∣n} 1/d (by the divisor involution d ↦ n/d). The main result is the convention-free characterization: n is perfect ⟺ ∑_{d∣n} 1/d = 2. Includes the concrete values at the first two perfect numbers, 6 and 28. A fresh branch of the perfect-numbers thread (Euclid–Euler parent).",
+  "meta": {
+    "author": "classical (abundancy index); formalized in Lean 4",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PerfectNumbersOQ02.lean",
+    "tags": [
+      "number-theory",
+      "perfect-numbers",
+      "divisors",
+      "abundancy",
+      "sigma",
+      "sum-of-divisors"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 108,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, no `native_decide`. The concrete values at 6 and 28 use ordinary kernel `decide` (not `native_decide`), so `#print axioms` reports only propext, Classical.choice, Quot.sound — the ordinary foundational axioms, not counted under the project's axiom-integrity policy. Uses Mathlib's Nat.sum_div_divisors and Nat.perfect_iff_sum_divisors_eq_two_mul.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sum_div_divisors",
+        "description": "∑_{d∣n} f(n/d) = ∑_{d∣n} f(d) — the divisor involution d ↦ n/d, the heart of the index identity",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "Nat.perfect_iff_sum_divisors_eq_two_mul",
+        "description": "n.Perfect ↔ ∑_{d∣n} d = 2n (for n > 0)",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "Nat.cast_div",
+        "description": "casts (n/d : ℕ) to (n:ℚ)/(d:ℚ) when d ∣ n, turning each divisor reciprocal into a cofactor",
+        "module": "Mathlib.Data.Nat.Cast.Basic"
+      }
+    ],
+    "dateAdded": "2026-06-22",
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "A positive integer is perfect when it equals the sum of its proper divisors: 6 = 1+2+3, 28 = 1+2+4+7+14. Equivalently σ(n) = 2n, where σ is the sum-of-divisors function. The abundancy index I(n) = σ(n)/n measures how 'rich' n is in divisors: I(n) < 2 means deficient, I(n) = 2 perfect, I(n) > 2 abundant. A classical and especially clean way to write the index uses the divisor involution d ↦ n/d: pairing each divisor with its cofactor turns σ(n)/n into the sum of the reciprocals of the divisors, ∑_{d∣n} 1/d. In these terms a perfect number is exactly one whose divisor reciprocals sum to 2 — for 6, indeed 1/1 + 1/2 + 1/3 + 1/6 = 2.\n\nThis reciprocal form is the natural language for many results about perfect and multiply perfect numbers (a k-perfect number has ∑_{d∣n} 1/d = k), and it is the form in which abundancy is usually studied.",
+    "problemStatement": "**Open Question (parent perfect-numbers, second branch)**: characterize perfect numbers through the abundancy index.\n\n**Result**: I(n) = σ(n)/n equals ∑_{d∣n} 1/d, and n is perfect ⟺ ∑_{d∣n} 1/d = 2.",
+    "text": "A 108-line, fully verified (0 sorries, 0 axioms, no native_decide) file. It defines abundancyIndex n = ∑_{d∣n} (d:ℚ)⁻¹, proves abundancyIndex_eq_sigma_div (I(n) = σ(n)/n via the divisor involution), and the headline perfect_iff_abundancyIndex_eq_two (n.Perfect ⟺ ∑_{d∣n} 1/d = 2). It records perfect_six and perfect_twentyEight (via kernel decide on the divisor-sum condition) and the resulting abundancyIndex_six = abundancyIndex_twentyEight = 2.",
+    "proofStrategy": "abundancyIndex_eq_sigma_div rewrites each reciprocal 1/d as (n/d)/n: for d ∣ n the cast (n/d : ℕ) becomes (n:ℚ)/(d:ℚ) (Nat.cast_div), and (n/d)/n = 1/d (field_simp). Factoring 1/n out (Finset.sum_div) and applying the divisor involution Nat.sum_div_divisors (∑ f(n/d) = ∑ f(d)) turns ∑ (n/d) into ∑ d = σ(n). perfect_iff_abundancyIndex_eq_two rewrites n.Perfect as σ(n) = 2n (Nat.perfect_iff_sum_divisors_eq_two_mul) and the index as σ(n)/n, clears the denominator (div_eq_iff), folds the cast (Nat.cast_sum), and matches the two integer equations by exact_mod_cast. The concrete values come from feeding perfect_six / perfect_twentyEight (kernel decide on ∑ d = 2n) into the iff.",
+    "keyInsights": [
+      "The divisor involution d ↦ n/d (Mathlib's Nat.sum_div_divisors) is exactly what turns ∑_{d∣n} 1/d into σ(n)/n: every reciprocal pairs with a cofactor.",
+      "The abundancy index I(n) = σ(n)/n = ∑_{d∣n} 1/d is a convention-free, scale-aware measure: deficient < 2, perfect = 2, abundant > 2.",
+      "Perfect ⟺ ∑_{d∣n} 1/d = 2 makes the perfect-number condition a statement purely about reciprocals, generalizing cleanly to k-perfect numbers (∑ 1/d = k).",
+      "The cast 1/d = (n/d)/n holds because for d ∣ n the natural cofactor n/d casts exactly to (n:ℚ)/(d:ℚ) (Nat.cast_div).",
+      "The first perfect numbers 6 and 28 satisfy ∑ 1/d = 2 by ordinary kernel decide on the divisor-sum condition — no native_decide needed."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function σ and perfect numbers",
+      "The divisor involution d ↦ n/d on the divisors of n",
+      "Rational arithmetic and Nat→ℚ casts in Lean 4/Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "index",
+      "title": "The Abundancy Index as a Reciprocal Sum",
+      "startLine": 36,
+      "endLine": 56,
+      "summary": "abundancyIndex n = ∑_{d∣n} (d:ℚ)⁻¹. abundancyIndex_eq_sigma_div: I(n) = σ(n)/n, via the divisor involution.",
+      "mathContext": "Pairing each divisor with its cofactor turns the reciprocal sum into σ(n)/n."
+    },
+    {
+      "id": "characterization",
+      "title": "The Reciprocal-Divisor Characterization",
+      "startLine": 58,
+      "endLine": 78,
+      "summary": "perfect_iff_abundancyIndex_eq_two: n.Perfect ⟺ ∑_{d∣n} 1/d = 2. abundancyIndex_eq_two_of_perfect: the forward direction.",
+      "mathContext": "Perfect numbers are exactly those whose divisor reciprocals sum to 2."
+    },
+    {
+      "id": "concrete",
+      "title": "Concrete Values at 6 and 28",
+      "startLine": 80,
+      "endLine": 100,
+      "summary": "perfect_six, perfect_twentyEight (kernel decide), and abundancyIndex_six = abundancyIndex_twentyEight = 2.",
+      "mathContext": "1/1 + 1/2 + 1/3 + 1/6 = 2 and the analogous sum for 28."
+    }
+  ],
+  "conclusion": {
+    "summary": "Perfect numbers are characterized by their abundancy index: I(n) = σ(n)/n equals the sum of the reciprocals of the divisors of n, and n is perfect exactly when ∑_{d∣n} 1/d = 2. The first perfect numbers 6 and 28 illustrate it concretely.",
+    "implications": "The reciprocal form is the natural setting for abundancy: deficient (< 2), perfect (= 2), abundant (> 2), and k-perfect (= k). It connects this entry to the deficiency results (every prime power is deficient) and to the broader study of multiply perfect numbers and the abundancy-image problem (which rationals arise as σ(n)/n).",
+    "openQuestions": [
+      "Which rationals ≥ 1 arise as σ(n)/n? (The abundancy-image problem — e.g. 5/3 is known not to be an abundancy index.)",
+      "Characterize k-perfect numbers (∑_{d∣n} 1/d = k) and reproduce the small known examples.",
+      "Combine with the deficiency results to show every proper divisor of a perfect number is deficient and every proper multiple is abundant."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "perfect-numbers",
+      "relationship": "extends",
+      "description": "Parent: the Euclid–Euler theorem on even perfect numbers. This entry adds the abundancy-index characterization."
+    },
+    {
+      "targetId": "perfect-numbers-oq-05",
+      "relationship": "related",
+      "description": "Deficiency of prime powers (σ(p^k) < 2p^k), i.e. abundancy index < 2."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "PerfectNumbersOQ02",
+    "lineCount": 108,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "mainTheorems": [
+      {
+        "name": "perfect_iff_abundancyIndex_eq_two",
+        "type": "core",
+        "description": "n is perfect ⟺ ∑_{d∣n} 1/d = 2",
+        "leanType": "{n : ℕ} → 0 < n → (n.Perfect ↔ abundancyIndex n = 2)"
+      },
+      {
+        "name": "abundancyIndex_eq_sigma_div",
+        "type": "key",
+        "description": "I(n) = σ(n)/n, via the divisor involution d ↦ n/d",
+        "leanType": "{n : ℕ} → 0 < n → abundancyIndex n = (∑ i ∈ n.divisors, (i : ℕ) : ℚ) / n"
+      },
+      {
+        "name": "abundancyIndex_six",
+        "type": "key",
+        "description": "1/1 + 1/2 + 1/3 + 1/6 = 2",
+        "leanType": "abundancyIndex 6 = 2"
+      }
+    ],
+    "path": "Proofs/PerfectNumbersOQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "perfect_iff_abundancyIndex_eq_two",
+      "type": "core",
+      "description": "The reciprocal-divisor characterization: n is perfect ⟺ ∑_{d∣n} 1/d = 2",
+      "leanType": "{n : ℕ} → 0 < n → (n.Perfect ↔ abundancyIndex n = 2)"
+    },
+    {
+      "name": "abundancyIndex_eq_sigma_div",
+      "type": "key",
+      "description": "The abundancy index as a reciprocal sum equals σ(n)/n",
+      "leanType": "{n : ℕ} → 0 < n → abundancyIndex n = (∑ i ∈ n.divisors, (i : ℕ) : ℚ) / n"
+    },
+    {
+      "name": "abundancyIndex_eq_two_of_perfect",
+      "type": "supporting",
+      "description": "A perfect number has divisor reciprocals summing to 2",
+      "leanType": "{n : ℕ} → 0 < n → n.Perfect → ∑ d ∈ n.divisors, (d : ℚ)⁻¹ = 2"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Dickson, Leonard Eugene",
+      "title": "History of the Theory of Numbers, Vol. I: Divisibility and Primality",
+      "year": "1919",
+      "venue": "Carnegie Institution of Washington",
+      "note": "Chapter I surveys perfect, abundant, and deficient numbers and the abundancy index"
+    },
+    {
+      "authors": "Guy, Richard K.",
+      "title": "Unsolved Problems in Number Theory",
+      "year": "2004",
+      "venue": "Springer, 3rd edition",
+      "note": "Section B on perfect and multiply perfect numbers and the abundancy-image problem"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

A fresh branch of the **perfect-numbers** thread (Euclid–Euler parent): the **abundancy index** characterization.

**`PerfectNumbersOQ02.lean`** — 108 lines, 7 theorems, 1 def, **0 sorries, 0 axioms, no `native_decide`** (`#print axioms` → only propext/Classical.choice/Quot.sound; the concrete values use ordinary kernel `decide`).

### Results
- `abundancyIndex`: I(n) = ∑_{d∣n} 1/d.
- `abundancyIndex_eq_sigma_div`: **I(n) = σ(n)/n**, via the divisor involution d ↦ n/d (Mathlib's `Nat.sum_div_divisors`) — each reciprocal pairs with its cofactor.
- `perfect_iff_abundancyIndex_eq_two`: **n is perfect ⟺ ∑_{d∣n} 1/d = 2.**
- `perfect_six`, `perfect_twentyEight`, `abundancyIndex_six = abundancyIndex_twentyEight = 2`: the first two perfect numbers (1/1+1/2+1/3+1/6 = 2).

The reciprocal form is convention-free and generalizes directly to k-perfect numbers (∑ 1/d = k).

## Verification
`./proofs/scripts/docker-build.sh Proofs.PerfectNumbersOQ02` → Build completed successfully (7743 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)