### PR TITLE
research(erdos-396-oq-04-oq-01-oq-01-oq-03): Catalan numbers are log-convex (the Turán inequality)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1651,6 +1651,7 @@ import Proofs.Erdos396OQ04OQ01
 import Proofs.Erdos396OQ04OQ01OQ01
 import Proofs.Erdos396OQ04OQ01OQ01OQ02
 import Proofs.Erdos396OQ04OQ01OQ01OQ01
+import Proofs.Erdos396OQ04OQ01OQ01OQ03
 import Proofs.Erdos396Problem
 import Proofs.Erdos397Problem
 import Proofs.Erdos398Problem

--- a/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ03.lean
@@ -1,0 +1,128 @@
+/-
+# Erdős Problem #396 — OQ-04 → OQ-01 → OQ-01 → OQ-03: Catalan numbers are log-convex (the Turán inequality)
+
+The grandparent `Erdos396OQ04OQ01` reads the two-term Catalan recurrence as the
+ratio of consecutive Catalan numbers, `r n = (4n+2)/(n+2) = 4 − 6/(n+2)`, and
+proves it is **strictly increasing** (`ratio_strictMono`).  The parent
+`Erdos396OQ04OQ01OQ01` repackages this as the harmonic **deficit**
+`δ n = 4 − r n = 6/(n+2)`.
+
+A strictly increasing ratio of consecutive terms is exactly the statement that the
+underlying sequence is **strictly log-convex**.  This file extracts that structural
+consequence for the Catalan numbers, in several equivalent forms.
+
+* **`deficit_strictAnti`** : the deficit `δ n = 6/(n+2)` is *strictly decreasing*,
+  refining the parent's `δ n → 0` to a monotone descent (equivalently `r n` rises
+  monotonically to its supremum `4`).
+
+* **`turan_real`** / **`turan_nat`** : the **Turán inequality**
+  `catalan(n+1)² < catalan n · catalan(n+2)`, over `ℝ` and over `ℕ`.  Substituting
+  `catalan(n+1) = r n · catalan n` and `catalan(n+2) = r(n+1)·r n·catalan n`, the
+  gap is `r n · catalan(n)² · (r(n+1) − r n) > 0`, positive precisely because the
+  ratio strictly increases.
+
+* **`hankel_det_pos`** : the `2×2` Hankel minor
+  `catalan n · catalan(n+2) − catalan(n+1)² > 0` — Turán phrased as determinant
+  positivity of the shifted Catalan moment matrix.
+
+* **`catalan_logConvex`** : the literal log-convexity inequality
+  `2·log(catalan(n+1)) < log(catalan n) + log(catalan(n+2))`, obtained by taking
+  logarithms of the (positive) Turán inequality.
+
+No Stirling estimate or asymptotic is used; everything follows from the recurrence
+ratio and its strict monotonicity established upstream.
+
+Reference: https://erdosproblems.com/396
+-/
+
+import Mathlib
+import Proofs.Erdos396OQ04OQ01OQ01
+
+open Nat Filter Topology Finset
+
+namespace Erdos396OQ01OQ01OQ03
+
+open Erdos396OQ01 Erdos396OQ01OQ01
+
+/-! ## The deficit descends monotonically -/
+
+/-- **The deficit is strictly decreasing.** `δ n = 6/(n+2)` strictly decreases,
+    refining the parent's `δ n → 0` to a monotone descent.  Equivalently the
+    ratio `r n = 4 − δ n` rises monotonically to its supremum `4`. -/
+theorem deficit_strictAnti : StrictAnti catalanDeficit := by
+  intro a b hab
+  rw [deficit_eq, deficit_eq]
+  have hcast : (a : ℝ) + 2 < (b : ℝ) + 2 := by exact_mod_cast Nat.add_lt_add_right hab 2
+  exact div_lt_div_of_pos_left (by norm_num) (by positivity) hcast
+
+/-! ## The Turán inequality (strict log-convexity) -/
+
+/-- The ratio strictly increases by one step: `r n < r (n+1)`. -/
+theorem ratio_lt_succ (n : ℕ) : catalanRatio n < catalanRatio (n + 1) :=
+  ratio_strictMono (Nat.lt_succ_self n)
+
+/-- **Turán inequality (real form).** `catalan(n+1)² < catalan n · catalan(n+2)`.
+
+    Writing `C(n+1) = r n · C n` and `C(n+2) = r(n+1) · r n · C n`, both sides are
+    multiples of `C(n)²`: the difference is `r n · C(n)² · (r(n+1) − r n)`, which is
+    positive precisely because the recurrence ratio strictly increases. -/
+theorem turan_real (n : ℕ) :
+    ((catalan (n + 1) : ℝ)) ^ 2 < (catalan n : ℝ) * (catalan (n + 2) : ℝ) := by
+  have e1 := catalan_succ_eq_ratio_mul n
+  have e2 := catalan_succ_eq_ratio_mul (n + 1)
+  -- express `C(n+2)` purely in terms of `r n`, `r (n+1)`, `C n`
+  have e2' : (catalan (n + 2) : ℝ)
+      = catalanRatio (n + 1) * (catalanRatio n * (catalan n : ℝ)) := by
+    rw [e2, e1]
+  rw [e1, e2']
+  have hc : (0 : ℝ) < (catalan n : ℝ) := by exact_mod_cast catalan_pos n
+  have hc2 : (0 : ℝ) < (catalan n : ℝ) ^ 2 := by positivity
+  have hr := ratio_pos n
+  have hmono := ratio_lt_succ n
+  -- gap = r n · C(n)² · (r(n+1) − r n) > 0
+  have key : 0 < catalanRatio n * (catalan n : ℝ) ^ 2
+      * (catalanRatio (n + 1) - catalanRatio n) :=
+    mul_pos (mul_pos hr hc2) (sub_pos.mpr hmono)
+  nlinarith [key]
+
+/-- **Turán inequality (integer form).** `catalan(n+1)² < catalan n · catalan(n+2)`
+    as a statement about natural numbers. -/
+theorem turan_nat (n : ℕ) : catalan (n + 1) ^ 2 < catalan n * catalan (n + 2) := by
+  have h := turan_real n
+  exact_mod_cast h
+
+/-- **Hankel-minor positivity.** The `2×2` shifted Catalan moment determinant
+    `catalan n · catalan(n+2) − catalan(n+1)²` is strictly positive — the
+    determinant phrasing of the Turán inequality. -/
+theorem hankel_det_pos (n : ℕ) :
+    0 < (catalan n : ℝ) * (catalan (n + 2) : ℝ) - ((catalan (n + 1) : ℝ)) ^ 2 :=
+  sub_pos.mpr (turan_real n)
+
+/-! ## Literal log-convexity -/
+
+/-- **Log-convexity of the Catalan numbers.**
+    `2·log(catalan(n+1)) < log(catalan n) + log(catalan(n+2))`.
+
+    This is the logarithm of the (strictly positive) Turán inequality: `log` is
+    strictly monotone on positives, `log (x²) = 2 log x` and
+    `log (x·y) = log x + log y`. -/
+theorem catalan_logConvex (n : ℕ) :
+    2 * Real.log (catalan (n + 1) : ℝ)
+      < Real.log (catalan n : ℝ) + Real.log (catalan (n + 2) : ℝ) := by
+  have hc1 : (0 : ℝ) < (catalan (n + 1) : ℝ) := by exact_mod_cast catalan_pos (n + 1)
+  have hc0 : (catalan n : ℝ) ≠ 0 := by exact_mod_cast (catalan_pos n).ne'
+  have hc2 : (catalan (n + 2) : ℝ) ≠ 0 := by exact_mod_cast (catalan_pos (n + 2)).ne'
+  have hlt := Real.log_lt_log (pow_pos hc1 2) (turan_real n)
+  rw [Real.log_pow, Real.log_mul hc0 hc2] at hlt
+  push_cast at hlt
+  linarith [hlt]
+
+/-! ## Sanity checks -/
+
+-- The general theorem specialises at small indices (`catalan` does not kernel-reduce
+-- under `decide`, so we instantiate the proven inequality directly).
+example : catalan 1 ^ 2 < catalan 0 * catalan 2 := turan_nat 0
+example : catalan 2 ^ 2 < catalan 1 * catalan 3 := turan_nat 1
+example : catalan 3 ^ 2 < catalan 2 * catalan 4 := turan_nat 2
+
+end Erdos396OQ01OQ01OQ03

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-e396oq04oq01oq01oq03-deficit",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-03",
+    "range": { "startLine": 52, "endLine": 56 },
+    "type": "key-step",
+    "title": "The deficit descends monotonically",
+    "content": "The parent showed only $\\delta\\,n = 6/(n+2) \\to 0$. Here it is upgraded to a strict descent: for $a < b$ one has $a+2 < b+2$, and $\\texttt{div\\_lt\\_div\\_of\\_pos\\_left}$ gives $6/(b+2) < 6/(a+2)$. Since $r\\,n = 4 - \\delta\\,n$, this is exactly the strict increase of the recurrence ratio toward its supremum $4$.",
+    "mathContext": "$\\delta$ strictly antitone $\\iff$ $r = 4 - \\delta$ strictly monotone."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq03-turanreal",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-03",
+    "range": { "startLine": 69, "endLine": 86 },
+    "type": "key-step",
+    "title": "The Turán gap is the ratio increment, scaled",
+    "content": "Rewriting $C(n+1) = r\\,n\\cdot C n$ and $C(n+2) = r(n+1)\\cdot r\\,n\\cdot C n$, both sides become multiples of $C(n)^2$. The difference $C n\\cdot C(n+2) - C(n+1)^2$ factors as $r\\,n\\cdot C(n)^2\\cdot(r(n+1) - r\\,n)$ — supplied to $\\texttt{nlinarith}$ as the positive witness $\\texttt{key}$. Each factor is positive (catalan positivity, ratio positivity, and the upstream strict monotonicity), so the whole gap is positive.",
+    "mathContext": "$C n\\,C(n+2) - C(n+1)^2 = r\\,n\\,C(n)^2\\,(r(n+1) - r\\,n) > 0$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq03-turannat",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-03",
+    "range": { "startLine": 90, "endLine": 92 },
+    "type": "key-step",
+    "title": "Integer form by casting",
+    "content": "Catalan numbers are natural numbers, so the real Turán inequality transfers verbatim to $\\mathbb{N}$ via $\\texttt{exact\\_mod\\_cast}$: $\\text{catalan}(n+1)^2 < \\text{catalan}\\,n\\cdot\\text{catalan}(n+2)$. This is the cleanest, foundation-free phrasing of log-convexity.",
+    "mathContext": "$\\text{catalan}(n+1)^2 < \\text{catalan}\\,n\\cdot\\text{catalan}(n+2)$ over $\\mathbb{N}$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq03-hankel",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-03",
+    "range": { "startLine": 97, "endLine": 99 },
+    "type": "insight",
+    "title": "Determinant phrasing: positive Hankel minor",
+    "content": "The Turán inequality is positivity of the $2\\times2$ minor $\\det\\begin{psmallmatrix} C n & C(n+1) \\\\ C(n+1) & C(n+2)\\end{psmallmatrix} = C n\\,C(n+2) - C(n+1)^2$ of the shifted Catalan moment (Hankel) matrix — obtained immediately as $\\texttt{sub\\_pos.mpr}$ of the Turán inequality.",
+    "mathContext": "$0 < C n\\,C(n+2) - C(n+1)^2$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq03-logconvex",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-03",
+    "range": { "startLine": 109, "endLine": 118 },
+    "type": "key-step",
+    "title": "Literal log-convexity by taking logs",
+    "content": "Applying $\\texttt{Real.log\\_lt\\_log}$ to the strictly positive Turán inequality, then $\\texttt{Real.log\\_pow}$ ($\\log x^2 = 2\\log x$) and $\\texttt{Real.log\\_mul}$ ($\\log(xy) = \\log x + \\log y$), yields the midpoint convexity of $n \\mapsto \\log\\text{catalan}\\,n$: $2\\log\\text{catalan}(n+1) < \\log\\text{catalan}\\,n + \\log\\text{catalan}(n+2)$.",
+    "mathContext": "$2\\log C(n+1) < \\log C n + \\log C(n+2)$, i.e. $\\log\\circ\\,\\text{catalan}$ is strictly midpoint-convex."
+  }
+]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,106 @@
+{
+  "id": "erdos-396-oq-04-oq-01-oq-01-oq-03",
+  "title": "Erdős #396 OQ-04 → OQ-01 → OQ-01 → OQ-03: Catalan Numbers Are Log-Convex (the Turán Inequality)",
+  "slug": "erdos-396-oq-04-oq-01-oq-01-oq-03",
+  "description": "The grandparent proves the Catalan recurrence ratio r n = (4n+2)/(n+2) = 4 − 6/(n+2) is strictly increasing. A strictly increasing ratio of consecutive terms is exactly strict log-convexity of the underlying sequence, so this follow-up extracts the structural consequence for the Catalan numbers. The deficit δ n = 6/(n+2) is shown strictly decreasing (refining the parent's δ n → 0 to a monotone descent). The Turán inequality catalan(n+1)² < catalan n · catalan(n+2) is proved over both ℝ and ℕ: substituting catalan(n+1) = r n · catalan n and catalan(n+2) = r(n+1)·r n·catalan n, the gap equals r n · catalan(n)² · (r(n+1) − r n) > 0, positive precisely because the ratio strictly increases. The same fact is phrased as positivity of the 2×2 Hankel minor catalan n · catalan(n+2) − catalan(n+1)², and taking logarithms of the positive Turán inequality gives the literal log-convexity statement 2·log(catalan(n+1)) < log(catalan n) + log(catalan(n+2)). No Stirling estimate or asymptotic is used.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/396",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos396OQ04OQ01OQ01OQ03.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "catalan",
+      "recurrence",
+      "log-convexity",
+      "turan-inequality",
+      "hankel-determinant",
+      "monotonicity",
+      "logarithm"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 396,
+    "erdosUrl": "https://erdosproblems.com/396",
+    "axiomCount": 0,
+    "lineCount": 128,
+    "assumptions": "0 axioms, 0 sorries. All results depend only on the foundational axioms propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool / native_decide). Built against Mathlib 4.26.0.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The grandparent Erdős #396 OQ-04 → OQ-01 reads the two-term Catalan recurrence as the multiplicative step r n = (4n+2)/(n+2) = 4 − 6/(n+2), and proves it is strictly increasing (ratio_strictMono), with r n < 4 and r n → 4. The parent OQ-04 → OQ-01 → OQ-01 repackages this as the harmonic deficit δ n = 4 − r n = 6/(n+2) with δ n → 0. A sequence of positive terms is (strictly) log-convex exactly when the ratio of consecutive terms is (strictly) increasing; for the Catalan numbers this is the classical Turán inequality catalan(n+1)² ≤ catalan n · catalan(n+2), a named structural property distinct from the asymptotic-rate questions pursued by the sibling entries. This entry makes that consequence explicit at the recurrence level.",
+    "problemStatement": "The upstream ratio r n = catalan(n+1)/catalan(n) is strictly increasing. Does this directly yield the strict log-convexity (Turán inequality) of the Catalan numbers, catalan(n+1)² < catalan n · catalan(n+2), with the gap controlled by the ratio increment r(n+1) − r n — and equivalently the literal logarithmic-midpoint inequality 2·log catalan(n+1) < log catalan n + log catalan(n+2)?",
+    "text": "Each Catalan step multiplies by the ratio: catalan(n+1) = r n · catalan n, hence catalan(n+2) = r(n+1)·r n·catalan n. The Turán difference factors as catalan n · catalan(n+2) − catalan(n+1)² = r n · catalan(n)² · (r(n+1) − r n), which is positive because catalan(n) > 0, r n > 0, and the ratio strictly increases (the upstream ratio_strictMono). This gives the real and integer forms of the Turán inequality, the determinant phrasing 0 < catalan n · catalan(n+2) − catalan(n+1)² (positivity of the 2×2 Hankel minor of the shifted Catalan moment matrix), and — applying strict monotonicity of log on positives together with log(x²) = 2 log x and log(xy) = log x + log y — the literal log-convexity 2·log catalan(n+1) < log catalan n + log catalan(n+2). The deficit δ n = 6/(n+2) is correspondingly strictly decreasing, refining the parent's δ n → 0 to a monotone descent of r n to its supremum 4.",
+    "proofStrategy": "Import the parent (Proofs.Erdos396OQ04OQ01OQ01), reusing the ratio definition and identities, the recurrence bridge catalan(n+1) = r n · catalan n, ratio positivity, strict monotonicity ratio_strictMono, catalan positivity, and the deficit identity δ n = 6/(n+2). (1) deficit_strictAnti: rewrite both sides via deficit_eq and apply div_lt_div_of_pos_left to the cast a+2 < b+2. (2) ratio_lt_succ: ratio_strictMono at n < n+1. (3) turan_real: rewrite catalan(n+1) and catalan(n+2) through catalan_succ_eq_ratio_mul, supply the positive product r n · catalan(n)² · (r(n+1) − r n) as a witness, and close with nlinarith. (4) turan_nat: cast turan_real with exact_mod_cast. (5) hankel_det_pos: sub_pos.mpr turan_real. (6) catalan_logConvex: apply Real.log_lt_log to the positive Turán inequality, then rewrite with Real.log_pow and Real.log_mul and finish with linarith.",
+    "keyInsights": [
+      "**Strictly increasing ratio = strict log-convexity.** A positive sequence is strictly log-convex exactly when the ratio of consecutive terms strictly increases. The grandparent already established ratio_strictMono for r n = catalan(n+1)/catalan(n), so the Turán inequality for Catalan numbers is its immediate structural reading — no new analytic input is needed.",
+      "**The Turán gap is the ratio increment, scaled.** Writing both sides through the recurrence, catalan n · catalan(n+2) − catalan(n+1)² = r n · catalan(n)² · (r(n+1) − r n). Every factor is manifestly positive, so the single inequality r n < r(n+1) (= the deficit decreasing) drives the whole result.",
+      "**One inequality, four faces.** The same positive quantity is the real Turán inequality, its integer form (Catalan numbers being integers), positivity of the 2×2 Hankel minor of the shifted Catalan moment matrix, and — after taking logs — the literal midpoint log-convexity 2·log catalan(n+1) < log catalan n + log catalan(n+2).",
+      "**A monotone refinement of the parent.** Strict monotonicity of the ratio is exactly strict antitonicity of the deficit δ n = 6/(n+2): the parent's δ n → 0 is upgraded to a strictly decreasing descent, so r n rises monotonically to its supremum 4."
+    ],
+    "prerequisites": [
+      "The grandparent ratio identity r n = 4 − 6/(n+2), its strict monotonicity ratio_strictMono, and the recurrence bridge catalan(n+1) = r n · catalan n",
+      "The parent deficit identity δ n = 6/(n+2)",
+      "Positivity of the Catalan numbers and the order lemma div_lt_div_of_pos_left",
+      "Strict monotonicity of log on positives, with log(x²) = 2 log x and log(xy) = log x + log y"
+    ]
+  },
+  "conclusion": {
+    "summary": "Because the Catalan recurrence ratio r n strictly increases (upstream ratio_strictMono), the Catalan numbers are strictly log-convex: the Turán inequality catalan(n+1)² < catalan n · catalan(n+2) holds over both ℝ and ℕ, with gap r n · catalan(n)² · (r(n+1) − r n) > 0. Equivalent phrasings are positivity of the 2×2 Hankel minor catalan n · catalan(n+2) − catalan(n+1)² and the literal log-convexity 2·log catalan(n+1) < log catalan n + log catalan(n+2). The deficit δ n = 6/(n+2) is correspondingly strictly decreasing, refining the parent's δ n → 0. All six theorems are fully machine-checked with no axioms or sorries.",
+    "implications": "The entry exhibits a named structural property of the Catalan numbers — log-convexity / the Turán inequality — as a direct consequence of the recurrence-ratio monotonicity established upstream, complementing the sibling entries that study the growth rate and the 3/2 critical exponent. The factored gap localises the whole phenomenon in the single increment r(n+1) − r n, and the Hankel-minor phrasing connects it to determinant positivity of the Catalan moment sequence.",
+    "openQuestions": [
+      "Does the same ratio-monotonicity argument give the stronger Newton-type log-concavity/convexity hierarchy, e.g. bounds on catalan n · catalan(n+2) / catalan(n+1)² = r(n+1)/r n, and does that quotient converge to 1 monotonically as n → ∞?",
+      "Is the full Hankel matrix of Catalan numbers (det = 1 classically) recoverable by an LU/Cholesky factorisation whose pivots are exactly the consecutive ratios r n, tying the 2×2 minor positivity proved here to total positivity of the Catalan moment matrix?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos396OQ04OQ01OQ01"
+    ],
+    "opens": [
+      "Nat",
+      "Filter",
+      "Topology",
+      "Finset"
+    ],
+    "namespace": "Erdos396OQ01OQ01OQ03",
+    "lineCount": 128,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos396OQ04OQ01OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Parent OQ: the deficit δ n = 4 − r n = 6/(n+2) is a harmonic tail with δ n → 0. This follow-up shows δ n is strictly decreasing (so r n is strictly increasing) and reads that monotonicity as the strict log-convexity (Turán inequality) of the Catalan numbers."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling OQ: exponentiates the harmonic deficit sum to extract the 3/2 critical exponent of Catalan growth. This entry instead uses the strict monotonicity of the ratio to prove log-convexity / the Turán inequality."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01",
+      "relationship": "ancestor",
+      "description": "Grandparent OQ: the asymptotics of the Catalan recurrence ratio r n = 4 − 6/(n+2), including the strict monotonicity ratio_strictMono that directly drives the Turán inequality here, and the recurrence catalan(n+1) = r n · catalan n."
+    },
+    {
+      "targetId": "erdos-396-oq-04",
+      "relationship": "ancestor",
+      "description": "The two-term Catalan recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan(n), the source of the ratio whose monotonicity is exploited here."
+    },
+    {
+      "targetId": "erdos-396",
+      "relationship": "ancestor",
+      "description": "Root problem: descending factorials dividing central binomial coefficients, whose base case rests on the Catalan numbers."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

A new child of the Catalan recurrence-ratio thread (Erdős #396 → OQ-04 → OQ-01 → OQ-01). The grandparent already proved the recurrence ratio `r n = catalan(n+1)/catalan(n) = 4 − 6/(n+2)` is **strictly increasing** (`ratio_strictMono`). A strictly increasing ratio of consecutive terms is *exactly* strict **log-convexity** of the sequence, so this entry reads that monotonicity off as the classical **Turán inequality** for the Catalan numbers — a named structural property not previously in the thread (the siblings study the growth rate and the 3/2 critical exponent).

## Results (`Proofs/Erdos396OQ04OQ01OQ01OQ03.lean`, 6 theorems, 0 defs)

- **`deficit_strictAnti`** — `δ n = 6/(n+2)` is *strictly decreasing*, refining the parent's `δ n → 0` to a monotone descent (equivalently `r n` rises monotonically to its supremum `4`).
- **`turan_real` / `turan_nat`** — `catalan(n+1)² < catalan n · catalan(n+2)` over ℝ and ℕ. The gap factors as `r n · catalan(n)² · (r(n+1) − r n) > 0`, positive precisely because the ratio strictly increases.
- **`hankel_det_pos`** — `0 < catalan n · catalan(n+2) − catalan(n+1)²`: positivity of the 2×2 Hankel minor of the shifted Catalan moment matrix (determinant phrasing of Turán).
- **`catalan_logConvex`** — `2·log catalan(n+1) < log catalan n + log catalan(n+2)`, the literal midpoint log-convexity, by taking logs of the positive Turán inequality.

No Stirling estimate or asymptotic is used; everything follows from the upstream ratio monotonicity.

## Verification

- Builds via `./proofs/scripts/docker-build.sh Proofs.Erdos396OQ04OQ01OQ01OQ03` (Mathlib 4.26.0).
- **0 axioms, 0 sorries, no `native_decide`**; depends only on `propext` / `Classical.choice` / `Quot.sound`.
- Gallery data added under `src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-03/` (meta + annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)