### PR TITLE
research(geometric-series-oq-01-oq-02): gallery data for Cesàro (C,1) regularity

### DIFF
--- a/src/data/proofs/geometric-series-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-02/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-average-partials",
+    "proofId": "geometric-series-oq-01-oq-02",
+    "range": {
+      "startLine": 59,
+      "endLine": 68
+    },
+    "type": "insight",
+    "title": "Average the Partial Sums, Not the Terms",
+    "content": "The (C,1) mean is the average of the *partial sums* Sₙ = ∑_{i<n} aᵢ, not of the terms aₙ. This distinction is essential: averaging the terms gives (1/n)∑_{k<n} aₖ = Sₙ/n → 0 whenever ∑ aₙ converges, which is the wrong object. `cesaroMean S n = (1/n)·∑_{k<n} S k` averages the partial-sum sequence, matching Mathlib's Filter.Tendsto.cesaro convention exactly (division by n over range n)."
+  },
+  {
+    "id": "ann-regularity",
+    "proofId": "geometric-series-oq-01-oq-02",
+    "range": {
+      "startLine": 74,
+      "endLine": 86
+    },
+    "type": "concept",
+    "title": "Regularity in One Line",
+    "content": "`cesaroSummable_of_tendsto` is the regularity (consistency) property: if the partial sums converge to s, so does their Cesàro mean. Because cesaroMean is precisely the averaging operator of Mathlib's Filter.Tendsto.cesaro, the proof is the single application h.cesaro. The HasSum corollary chains through HasSum.tendsto_sum_nat, so any unconditionally summable series has (C,1)-summable ordered partial sums. Regularity is what makes Cesàro a legitimate extension of the limit — it never contradicts ordinary convergence."
+  },
+  {
+    "id": "ann-closed-form",
+    "proofId": "geometric-series-oq-01-oq-02",
+    "range": {
+      "startLine": 92,
+      "endLine": 124
+    },
+    "type": "insight",
+    "title": "A Closed Form Tames the Grandi Mean",
+    "content": "`sum_grandiPartial` proves ∑_{k<n} Sₖ = (n − Sₙ)/2 by induction from the parent's grandi_double_sum (2Sₙ = 1 − (−1)ⁿ). This turns the Cesàro mean into the explicit grandiCesaroMean_eq: σₙ = (1/n)·(n − Sₙ)/2, so σₙ − 1/2 = −Sₙ/(2n). Since |Sₙ| ≤ 1 (it is 0 or 1), the error is ≤ 1/(2n) → 0, giving grandiCesaroMean_tendsto: the Grandi Cesàro mean converges to 1/2."
+  },
+  {
+    "id": "ann-strict",
+    "proofId": "geometric-series-oq-01-oq-02",
+    "range": {
+      "startLine": 154,
+      "endLine": 187
+    },
+    "type": "insight",
+    "title": "Strictness via Two Subsequences",
+    "content": "`grandi_partial_not_tendsto` shows the partial sums diverge: the even subsequence is constantly 0 and the odd subsequence is constantly 1 (the parent's grandi_even, grandi_odd), so uniqueness of limits (tendsto_nhds_unique) would force both L = 0 and L = 1, a contradiction. Combined with the Cesàro convergence to 1/2, `cesaro_strictly_extends_convergence` records that (C,1) summability is strictly stronger than convergence — it sums a genuinely divergent series."
+  }
+]

--- a/src/data/proofs/geometric-series-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-02/meta.json
@@ -1,0 +1,195 @@
+{
+  "id": "geometric-series-oq-01-oq-02",
+  "title": "Cesàro (C,1) Regularity and Its Strict Extension of Convergence",
+  "slug": "geometric-series-oq-01-oq-02",
+  "description": "Formalizes the general statement behind the parent's bespoke Grandi computation: the regularity (consistency) of (C,1) Cesàro summation — if the partial sums of ∑aₙ converge to s, the Cesàro mean converges to s too — and the strict-extension fact that Grandi's series 1−1+1−1+⋯ is (C,1) summable to 1/2 while its partial sums diverge (oscillating 0,1,0,1,…). Regularity is a one-line consequence of Mathlib's Filter.Tendsto.cesaro; strictness is witnessed via the closed form ∑_{k<n} Sₖ = (n−Sₙ)/2.",
+  "meta": {
+    "author": "Ernesto Cesàro (1890); formalized in Lean 4",
+    "date": "1890",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "summability",
+      "cesaro",
+      "grandi-series",
+      "divergent-series",
+      "geometric-series"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 198,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "originalContributions": [
+      "cesaroSummable_of_tendsto: regularity of (C,1) summation — convergence of the partial sums to s implies (C,1) summability to s, via Filter.Tendsto.cesaro on the partial-sum sequence.",
+      "cesaroSummable_of_hasSum: the HasSum corollary — an unconditionally summable series has (C,1)-summable ordered partial sums.",
+      "sum_grandiPartial: the closed form ∑_{k<n} Sₖ = (n − Sₙ)/2 for the running sum of Grandi partial sums.",
+      "grandiCesaroMean_tendsto: the Cesàro mean of Grandi's series converges to 1/2, with the explicit bound |σₙ − 1/2| = |Sₙ|/(2n) ≤ 1/(2n).",
+      "grandi_partial_not_tendsto: Grandi's partial sums diverge (even subsequence → 0, odd → 1).",
+      "cesaro_strictly_extends_convergence: (C,1) summability is strictly stronger than convergence, witnessed by Grandi."
+    ],
+    "prerequisites": [
+      "Cesàro (C,1) summation and the notion of regularity of a summation method",
+      "Grandi's series and its partial sums",
+      "Filter limits and Filter.Tendsto.cesaro in Lean 4/Mathlib"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Filter.Tendsto.cesaro",
+        "description": "If u → s then the Cesàro averages of u → s — the engine of regularity",
+        "module": "Mathlib.Analysis.PSeries"
+      },
+      {
+        "theorem": "HasSum.tendsto_sum_nat",
+        "description": "HasSum a s implies the ordered partial sums tend to s",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "tendsto_nhds_unique",
+        "description": "uniqueness of limits, used to derive the contradiction L = 0 and L = 1",
+        "module": "Mathlib.Topology.Separation"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Ernesto Cesàro introduced, around 1890, the averaging method now named after him: assign to a series the limit of the averages of its partial sums when that limit exists. It is the prototypical 'regular' summation method — it agrees with ordinary convergence whenever the latter holds, yet sums some divergent series too. Grandi's series 1 − 1 + 1 − 1 + ⋯, whose partial sums oscillate 1, 0, 1, 0, …, is the classic example: ordinarily divergent, but Cesàro summable to 1/2.\n\nThe parent entry computes the Grandi Cesàro value by hand. This file isolates the two general principles that computation instantiates: regularity (the method is consistent with convergence) and strictness (the method sums strictly more series than converge). Together these are the defining features that make Cesàro summation a genuine and useful extension of the limit.",
+    "problemStatement": "**Open Question (parent geometric-series-oq-01, OQ-02)**: state and prove the general theorem behind the concrete Grandi computation — the regularity of (C,1) summation (convergence ⟹ Cesàro summability to the same value), and that (C,1) summability strictly extends convergence.\n\n**Result**: both are formalized — regularity via Filter.Tendsto.cesaro, strictness via Grandi.",
+    "text": "A 198-line, fully verified (0 sorries, 0 axioms) file. It defines cesaroMean S n = (1/n)·∑_{k<n} S k and CesaroSummable. M1 (regularity): cesaroSummable_of_tendsto and its HasSum corollary. M2 (strict extension): the closed form sum_grandiPartial ∑_{k<n} Sₖ = (n − Sₙ)/2, the bound grandi_partial_abs_le_one, the convergence grandiCesaroMean_tendsto (σₙ → 1/2), the divergence grandi_partial_not_tendsto, and the packaged cesaro_strictly_extends_convergence.",
+    "proofStrategy": "Regularity is immediate: cesaroMean is exactly the averaging operator of Mathlib's Filter.Tendsto.cesaro applied to the partial-sum sequence, so cesaroSummable_of_tendsto = h.cesaro; the HasSum corollary chains through HasSum.tendsto_sum_nat. For strictness, sum_grandiPartial is proved by induction using the parent's grandi_double_sum (2Sₙ = 1 − (−1)ⁿ), giving the closed form for the Cesàro mean grandiCesaroMean_eq; then |σₙ − 1/2| = |Sₙ|/(2n) ≤ 1/(2n) → 0 via an explicit ε–N argument (exists_nat_gt). Divergence of the partial sums uses the even/odd subsequences (parent's grandi_even = 0, grandi_odd = 1) and tendsto_nhds_unique to force the contradictory L = 0 and L = 1.",
+    "keyInsights": [
+      "The object one Cesàro-averages is the partial-sum sequence Sₙ, not the terms aₙ — averaging the terms gives 0 whenever the series converges, which is not the (C,1) mean.",
+      "Regularity is a one-liner once the right object is averaged: Mathlib's Filter.Tendsto.cesaro does all the work.",
+      "Grandi witnesses strictness: its Cesàro mean converges to 1/2 while its partial sums oscillate and have no limit.",
+      "The closed form ∑_{k<n} Sₖ = (n − Sₙ)/2 reduces the Cesàro limit to the elementary bound |Sₙ| ≤ 1, so σₙ − 1/2 = −Sₙ/(2n) → 0.",
+      "Divergence is proved by exhibiting two subsequences (even → 0, odd → 1) and invoking uniqueness of limits."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Cesàro Mean and Summability",
+      "startLine": 59,
+      "endLine": 68,
+      "summary": "cesaroMean S n = (1/n)·∑_{k<n} S k and CesaroSummable S L, matching Mathlib's Filter.Tendsto.cesaro convention.",
+      "mathContext": "The (C,1) average of the partial-sum sequence."
+    },
+    {
+      "id": "regularity",
+      "title": "M1: Regularity of (C,1) Summation",
+      "startLine": 74,
+      "endLine": 86,
+      "summary": "cesaroSummable_of_tendsto: convergence of the partial sums to s ⟹ (C,1) summability to s. cesaroSummable_of_hasSum: the HasSum corollary.",
+      "mathContext": "Consistency of Cesàro summation with ordinary convergence, via Filter.Tendsto.cesaro."
+    },
+    {
+      "id": "grandi",
+      "title": "M2: Grandi — (C,1) Summable but Divergent",
+      "startLine": 92,
+      "endLine": 187,
+      "summary": "sum_grandiPartial closed form; grandiCesaroMean_tendsto (σₙ → 1/2); grandi_partial_not_tendsto (divergent partial sums); cesaro_strictly_extends_convergence.",
+      "mathContext": "Grandi's series witnesses that (C,1) summability strictly extends convergence."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file establishes the two structural properties of (C,1) Cesàro summation that the parent's Grandi computation instantiates: regularity (convergence ⟹ Cesàro summability to the same value) and strictness (Grandi is Cesàro summable to 1/2 while divergent). Regularity reduces to Mathlib's Filter.Tendsto.cesaro; strictness is proved via an explicit closed form and an ε–N bound.",
+    "implications": "Regularity and strictness together justify Cesàro summation as a genuine extension of the limit: it never contradicts convergence and sums strictly more. This is the foundation for the Tauberian theory (Hardy–Littlewood: a Cesàro-summable series with aₙ = O(1/n) converges) and connects to Abel summation, which assigns Grandi the same value 1/2 from the interior of the disk of convergence.",
+    "openQuestions": [
+      "Formalize the Hardy–Littlewood Tauberian theorem: if σₙ → s and aₙ = O(1/n) then ∑ aₙ = s.",
+      "Formalize Abel summability of Grandi's series, lim_{x→1⁻} ∑ (−1)ⁿ xⁿ = 1/2, and Frobenius's theorem (Cesàro ⟹ Abel with the same value).",
+      "Extend to (C,k) summation and the inclusion hierarchy (C,k) ⊂ (C,k+1)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the geometric series at the boundary |r|=1, where the concrete Grandi Cesàro value 1/2 is computed by hand. This entry proves the general regularity and strictness behind it."
+    },
+    {
+      "targetId": "geometric-series-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Sibling open question on the boundary behavior of the geometric series."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ01"
+    ],
+    "opens": [
+      "Finset",
+      "Filter"
+    ],
+    "namespace": "GeometricSeriesOQ01OQ02",
+    "lineCount": 198,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "mainTheorems": [
+      {
+        "name": "cesaroSummable_of_tendsto",
+        "type": "core",
+        "description": "Regularity: convergence of the partial sums to s implies (C,1) summability to s",
+        "leanType": "{a : ℕ → ℝ} → {s : ℝ} → Tendsto (fun N => ∑ i ∈ range N, a i) atTop (nhds s) → CesaroSummable (fun N => ∑ i ∈ range N, a i) s"
+      },
+      {
+        "name": "cesaro_strictly_extends_convergence",
+        "type": "key",
+        "description": "(C,1) summability strictly extends convergence, witnessed by Grandi's series",
+        "leanType": "CesaroSummable (fun N => ∑ i ∈ range N, (-1:ℝ)^i) (1/2) ∧ ¬ ∃ L, Tendsto (fun N => ∑ i ∈ range N, (-1:ℝ)^i) atTop (nhds L)"
+      },
+      {
+        "name": "grandiCesaroMean_tendsto",
+        "type": "key",
+        "description": "The Cesàro mean of Grandi's series converges to 1/2",
+        "leanType": "CesaroSummable (fun N => ∑ i ∈ range N, (-1:ℝ)^i) (1/2)"
+      }
+    ],
+    "path": "Proofs/GeometricSeriesOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "cesaroSummable_of_tendsto",
+      "type": "core",
+      "description": "Regularity of (C,1) summation: convergence ⟹ Cesàro summability to the same value",
+      "leanType": "{a : ℕ → ℝ} → {s : ℝ} → Tendsto (fun N => ∑ i ∈ range N, a i) atTop (nhds s) → CesaroSummable (fun N => ∑ i ∈ range N, a i) s"
+    },
+    {
+      "name": "cesaro_strictly_extends_convergence",
+      "type": "key",
+      "description": "Grandi witnesses that (C,1) summability strictly extends convergence",
+      "leanType": "CesaroSummable (fun N => ∑ i ∈ range N, (-1:ℝ)^i) (1/2) ∧ ¬ ∃ L, Tendsto (fun N => ∑ i ∈ range N, (-1:ℝ)^i) atTop (nhds L)"
+    },
+    {
+      "name": "sum_grandiPartial",
+      "type": "supporting",
+      "description": "Closed form for the running sum of Grandi partial sums: ∑_{k<n} Sₖ = (n − Sₙ)/2",
+      "leanType": "(n : ℕ) → ∑ k ∈ range n, (∑ i ∈ range k, (-1:ℝ)^i) = ((n:ℝ) - ∑ i ∈ range n, (-1:ℝ)^i) / 2"
+    }
+  ],
+  "openQuestions": [
+    "Formalize the Hardy–Littlewood Tauberian theorem: σₙ → s and aₙ = O(1/n) imply ∑ aₙ = s.",
+    "Formalize Abel summability of Grandi (lim_{x→1⁻} 1/(1+x) = 1/2) and Frobenius's theorem linking Cesàro and Abel.",
+    "Extend to the (C,k) hierarchy and prove the inclusions (C,k) ⊂ (C,k+1)."
+  ],
+  "references": [
+    {
+      "authors": "Cesàro, Ernesto",
+      "title": "Sur la multiplication des séries",
+      "year": "1890",
+      "venue": "Bulletin des sciences mathématiques 14, 114–120",
+      "note": "Introduces the averaging (C,1) summation method"
+    },
+    {
+      "authors": "Hardy, G. H.",
+      "title": "Divergent Series",
+      "year": "1949",
+      "venue": "Oxford University Press",
+      "note": "The standard reference on Cesàro, Abel, and Tauberian theory; regularity and the (C,k) hierarchy"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The verified Lean proof **`GeometricSeriesOQ01OQ02.lean`** (Cesàro (C,1) regularity + strict extension) is already on `main` and registered in the manifest, but it had **no gallery entry**. This PR ships the missing `meta.json` + `annotations.json` so it appears in the gallery.

The proof (0 sorries, 0 axioms) establishes:
- `cesaroSummable_of_tendsto`: **regularity** of (C,1) summation — convergence of the partial sums to s ⟹ Cesàro mean → s (via Mathlib's `Filter.Tendsto.cesaro`).
- `cesaro_strictly_extends_convergence`: **strict extension** — Grandi's series is (C,1) summable to 1/2 while its partial sums diverge (even subsequence → 0, odd → 1).
- supporting closed form `sum_grandiPartial`: ∑_{k<n} Sₖ = (n − Sₙ)/2.

Verified against the current toolchain: `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ01OQ02` → Build completed successfully; `#print axioms` → only propext/Classical.choice/Quot.sound.

This PR is **gallery data only** (no Lean changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)