### PR TITLE
research(erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02): the 1/2 critical exponent of the central binomial coefficient from the recurrence

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1650,6 +1650,7 @@ import Proofs.Erdos396OQ04
 import Proofs.Erdos396OQ04OQ01
 import Proofs.Erdos396OQ04OQ01OQ01
 import Proofs.Erdos396OQ04OQ01OQ01OQ02
+import Proofs.Erdos396OQ04OQ01OQ01OQ02OQ02
 import Proofs.Erdos396OQ04OQ01OQ01OQ01
 import Proofs.Erdos396Problem
 import Proofs.Erdos397Problem

--- a/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02.lean
@@ -1,0 +1,248 @@
+/-
+# Erdős Problem #396 — OQ-04 → OQ-01 → OQ-01 → OQ-02 → OQ-02: the `1/2` critical exponent of the central binomial coefficient
+
+The sibling `Erdos396OQ04OQ01OQ01OQ02` extracts the `3/2` critical exponent of
+the Catalan numbers from their two-term recurrence: writing each normalised step
+`r k / 4 = 1 − (3/2)/(k+2)`, the elementary logarithm bound `log y ≤ y − 1`
+telescopes to `catalan n / 4^n ≤ exp(−(3/2)·(H_{n+1} − 1)) ∼ n^{−3/2}`.
+
+That entry's closing open question asked whether the *same* recurrence-level
+machinery applied to the **central binomial coefficient** `C(2n,n)` recovers its
+`1/2` exponent.  This file answers it affirmatively.  Mathlib's recurrence
+`(n+1)·C(2(n+1),n+1) = 2·(2n+1)·C(2n,n)` reads as a ratio statement
+`s n = (4n+2)/(n+1) = 4 − 2/(n+1)`, whose deficit `2/(n+1)` is the **un-shifted**
+harmonic tail (compare the Catalan deficit `6/(n+2)`).  Normalising by the
+limiting rate,
+
+  `s k / 4 = 1 − (1/2)/(k+1)`,
+
+the same `log y ≤ y − 1` gives `log (s k / 4) ≤ −(1/2)/(k+1)`, and telescoping
+the recurrence through the logarithm yields
+
+  `log (C(2n,n) / 4^n) = ∑_{k<n} log (s k / 4) ≤ −(1/2)·H_n`,
+
+so
+
+  **`centralBinom_div_le_exp`** : `C(2n,n) / 4^n ≤ exp(−(1/2)·H_n)`.
+
+Because `H_n ∼ log n`, the right-hand side is `∼ n^{−1/2}`: the coefficient
+`1/2` is exactly the critical exponent of the classical asymptotic
+`C(2n,n) ∼ 4^n / √(π n)`.  Applying the inequality to the reciprocal gives the
+matching lower bracket `log (s k / 4) ≥ −1/(2k+1)`, so `log (C(2n,n)/4^n)` is
+pinned between two harmonic-type sums *both* carrying leading coefficient `1/2`.
+
+The exponents of the two threads are tied together cleanly by
+`C(2n,n) = (n+1)·catalan n` (**`centralBinom_eq_succ_mul_catalan`**): the extra
+linear factor `n+1` is *exactly* the difference between the `1/2` exponent here
+and the `3/2` exponent of the Catalan numbers — `3/2 = 1/2 + 1` at the level of
+the polynomial decay rate.
+
+Squeezing `0 ≤ C(2n,n)/4^n ≤ exp(−(1/2)·H_n) → 0` gives an independent,
+rate-quantified proof that the normalised central binomial coefficients vanish
+(**`centralBinom_div_tendsto_zero`**).  No Stirling estimate is used.
+
+Reference: https://erdosproblems.com/396
+-/
+
+import Mathlib
+import Proofs.Erdos396OQ04OQ01OQ01
+
+open Nat Filter Topology Finset
+
+namespace Erdos396OQ01OQ01OQ02OQ02
+
+open Erdos396OQ01OQ01
+
+/-! ## The central-binomial recurrence ratio `s n` -/
+
+/-- The ratio of consecutive central binomial coefficients implied by Mathlib's
+    recurrence `(n+1)·C(2(n+1),n+1) = 2·(2n+1)·C(2n,n)`:
+    `s n = (4n+2)/(n+1) = 4 − 2/(n+1)`. -/
+noncomputable def cbRatio (n : ℕ) : ℝ := (4 * n + 2) / ((n : ℝ) + 1)
+
+/-- `s n` is strictly positive. -/
+theorem cbRatio_pos (n : ℕ) : 0 < cbRatio n := by
+  rw [cbRatio]; positivity
+
+/-- **The recurrence as a ratio.** `C(2(n+1),n+1) = s n · C(2n,n)` over `ℝ`,
+    the normalised reading of `Nat.succ_mul_centralBinom_succ`. -/
+theorem centralBinom_succ_eq_ratio_mul (n : ℕ) :
+    (centralBinom (n + 1) : ℝ) = cbRatio n * centralBinom n := by
+  have h := congrArg (Nat.cast (R := ℝ)) (Nat.succ_mul_centralBinom_succ n)
+  push_cast at h
+  have hn1 : ((n : ℝ) + 1) ≠ 0 := by positivity
+  rw [cbRatio]
+  field_simp
+  linear_combination h
+
+/-! ## The normalised step `s k / 4` and its logarithm -/
+
+/-- The recurrence ratio normalised by the limiting growth rate:
+    `s k / 4 = 1 − (1/2)/(k+1)`. -/
+theorem cbRatioQuarter_eq (k : ℕ) :
+    cbRatio k / 4 = 1 - (1 / 2) / ((k : ℝ) + 1) := by
+  rw [cbRatio]
+  have hk1 : ((k : ℝ) + 1) ≠ 0 := by positivity
+  field_simp
+  ring
+
+/-- The normalised step is strictly positive. -/
+theorem cbRatioQuarter_pos (k : ℕ) : 0 < cbRatio k / 4 := by
+  have := cbRatio_pos k; positivity
+
+/-- **Upper bound on the log step.** `log (s k / 4) ≤ −(1/2)/(k+1)`.
+
+    The elementary inequality `log y ≤ y − 1` at `y = s k / 4`, where
+    `y − 1 = −(1/2)/(k+1)` is (a quarter of) the deficit `2/(k+1)`. -/
+theorem log_cbRatioQuarter_le (k : ℕ) :
+    Real.log (cbRatio k / 4) ≤ -(1 / 2) / ((k : ℝ) + 1) := by
+  have h := Real.log_le_sub_one_of_pos (cbRatioQuarter_pos k)
+  have he : cbRatio k / 4 - 1 = -(1 / 2) / ((k : ℝ) + 1) := by
+    rw [cbRatioQuarter_eq]; ring
+  rw [he] at h; exact h
+
+/-- **Lower bound on the log step.** `log (s k / 4) ≥ −1/(2k+1)`.
+
+    The same Mathlib inequality applied to the reciprocal:
+    `(s k / 4)⁻¹ − 1 = 1/(2k+1)`. -/
+theorem log_cbRatioQuarter_ge (k : ℕ) :
+    -(1 / ((2 * (k : ℝ) + 1))) ≤ Real.log (cbRatio k / 4) := by
+  have hpos := cbRatioQuarter_pos k
+  have h := Real.log_le_sub_one_of_pos (inv_pos.mpr hpos)
+  rw [Real.log_inv] at h
+  have hk1 : ((k : ℝ) + 1) ≠ 0 := by positivity
+  have hnum : (4 * (k : ℝ) + 2) ≠ 0 := by positivity
+  have hden : (2 * (k : ℝ) + 1) ≠ 0 := by positivity
+  have he : (cbRatio k / 4)⁻¹ - 1 = 1 / (2 * (k : ℝ) + 1) := by
+    rw [cbRatio]; field_simp; ring
+  rw [he] at h
+  linarith
+
+/-! ## Telescoping the recurrence through the logarithm -/
+
+/-- **Log-telescoping.** `log (C(2n,n) / 4^n) = ∑_{k<n} log (s k / 4)`.
+
+    Each step multiplies by `s n`, so normalised by `4` the product collapses;
+    taking logs turns the product into the sum. -/
+theorem normLog_eq_sum (n : ℕ) :
+    Real.log ((centralBinom n : ℝ) / 4 ^ n)
+      = ∑ k ∈ Finset.range n, Real.log (cbRatio k / 4) := by
+  induction n with
+  | zero => simp [Nat.centralBinom_zero]
+  | succ m ih =>
+    have hcb : (0 : ℝ) < (centralBinom m : ℝ) / 4 ^ m := by
+      have := Nat.centralBinom_pos m; positivity
+    have hstep : ((centralBinom (m + 1) : ℝ) / 4 ^ (m + 1))
+        = (cbRatio m / 4) * ((centralBinom m : ℝ) / 4 ^ m) := by
+      rw [centralBinom_succ_eq_ratio_mul]
+      have h4 : (4 : ℝ) ^ m ≠ 0 := by positivity
+      field_simp
+      ring
+    rw [Finset.sum_range_succ, ← ih, hstep,
+      Real.log_mul (ne_of_gt (cbRatioQuarter_pos m)) (ne_of_gt hcb)]
+    ring
+
+/-! ## The `1/2`-exponent bound -/
+
+/-- **Quantitative upper bound on the log.**
+    `log (C(2n,n) / 4^n) ≤ −(1/2)·H_n`. -/
+theorem normLog_le (n : ℕ) :
+    Real.log ((centralBinom n : ℝ) / 4 ^ n) ≤ -(1 / 2) * realHarmonic n := by
+  rw [normLog_eq_sum]
+  have hsum_le : ∑ k ∈ Finset.range n, Real.log (cbRatio k / 4)
+      ≤ ∑ k ∈ Finset.range n, (-(1 / 2) / ((k : ℝ) + 1)) :=
+    Finset.sum_le_sum (fun k _ => log_cbRatioQuarter_le k)
+  have hval : ∑ k ∈ Finset.range n, (-(1 / 2) / ((k : ℝ) + 1))
+      = -(1 / 2) * realHarmonic n := by
+    rw [realHarmonic, Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro k _
+    ring
+  rw [← hval]; exact hsum_le
+
+/-- **Headline: the `1/2`-exponent decay bound.**
+    `C(2n,n) / 4^n ≤ exp(−(1/2)·H_n)`.
+
+    Since `H_n ∼ log n`, the bound is `∼ n^{−1/2}`: the recurrence alone forces
+    the critical exponent `1/2` of `C(2n,n) ∼ 4^n / √(π n)`. -/
+theorem centralBinom_div_le_exp (n : ℕ) :
+    (centralBinom n : ℝ) / 4 ^ n ≤ Real.exp (-(1 / 2) * realHarmonic n) := by
+  have hpos : (0 : ℝ) < (centralBinom n : ℝ) / 4 ^ n := by
+    have := Nat.centralBinom_pos n; positivity
+  calc (centralBinom n : ℝ) / 4 ^ n
+      = Real.exp (Real.log ((centralBinom n : ℝ) / 4 ^ n)) := (Real.exp_log hpos).symm
+    _ ≤ Real.exp (-(1 / 2) * realHarmonic n) := Real.exp_le_exp.mpr (normLog_le n)
+
+/-- **Multiplicative form.** `C(2n,n) ≤ 4^n · exp(−(1/2)·H_n)`. -/
+theorem centralBinom_le_exp_mul (n : ℕ) :
+    (centralBinom n : ℝ) ≤ 4 ^ n * Real.exp (-(1 / 2) * realHarmonic n) := by
+  have h4 : (0 : ℝ) < 4 ^ n := by positivity
+  have h := centralBinom_div_le_exp n
+  rw [div_le_iff₀ h4] at h
+  linarith [h]
+
+/-- **Two-sided log bracket.** The recurrence pins `log (C(2n,n) / 4^n)` between
+    two harmonic-type sums, *both* with leading coefficient `1/2`:
+    `−∑_{k<n} 1/(2k+1) ≤ log (C(2n,n) / 4^n) ≤ −(1/2)·H_n`. -/
+theorem normLog_bracket (n : ℕ) :
+    -(∑ k ∈ Finset.range n, 1 / (2 * (k : ℝ) + 1)) ≤ Real.log ((centralBinom n : ℝ) / 4 ^ n)
+      ∧ Real.log ((centralBinom n : ℝ) / 4 ^ n) ≤ -(1 / 2) * realHarmonic n := by
+  refine ⟨?_, normLog_le n⟩
+  rw [normLog_eq_sum, ← Finset.sum_neg_distrib]
+  exact Finset.sum_le_sum (fun k _ => log_cbRatioQuarter_ge k)
+
+/-! ## Structural link to the Catalan `3/2` exponent -/
+
+/-- **`C(2n,n) = (n+1)·catalan n`** over `ℝ`.  The linear factor `n+1` is exactly
+    the difference between the `1/2` exponent of `C(2n,n)` proved here and the
+    `3/2` exponent of `catalan n` proved in the sibling: `3/2 = 1/2 + 1` at the
+    level of polynomial decay. -/
+theorem centralBinom_eq_succ_mul_catalan (n : ℕ) :
+    (centralBinom n : ℝ) = ((n : ℝ) + 1) * catalan n := by
+  have h := congrArg (Nat.cast (R := ℝ)) (succ_mul_catalan_eq_centralBinom n)
+  push_cast at h
+  linarith [h]
+
+/-- The normalised Catalan ratio is the normalised central-binomial ratio divided
+    by the linear factor: `catalan n / 4^n = (C(2n,n)/4^n) / (n+1)`. -/
+theorem catalan_div_eq_centralBinom_div (n : ℕ) :
+    (catalan n : ℝ) / 4 ^ n = ((centralBinom n : ℝ) / 4 ^ n) / ((n : ℝ) + 1) := by
+  rw [centralBinom_eq_succ_mul_catalan]
+  have hn1 : ((n : ℝ) + 1) ≠ 0 := by positivity
+  field_simp
+
+/-! ## Independent convergence with explicit rate -/
+
+/-- The exponential bound vanishes: `exp(−(1/2)·H_n) → 0`, driven by the
+    divergence of the harmonic series `H_n → ∞`. -/
+theorem expBound_tendsto_zero :
+    Tendsto (fun n => Real.exp (-(1 / 2) * realHarmonic n)) atTop (𝓝 0) := by
+  have hbot : Tendsto (fun n => -(1 / 2) * realHarmonic n) atTop atBot :=
+    Filter.Tendsto.const_mul_atTop_of_neg (by norm_num : -(1 / 2 : ℝ) < 0)
+      realHarmonic_tendsto_atTop
+  exact Real.tendsto_exp_atBot.comp hbot
+
+/-- **Independent, rate-quantified proof that the normalised central binomial
+    coefficients vanish.** `C(2n,n) / 4^n → 0`, squeezed by the explicit
+    `1/2`-exponent bound rather than by Stirling. -/
+theorem centralBinom_div_tendsto_zero :
+    Tendsto (fun n => (centralBinom n : ℝ) / 4 ^ n) atTop (𝓝 0) := by
+  apply squeeze_zero (fun n => by positivity) centralBinom_div_le_exp expBound_tendsto_zero
+
+/-! ## Sanity checks -/
+
+/-- At `k = 0` the normalised step is `s 0 / 4 = 1/2`. -/
+example : cbRatio 0 / 4 = 1 / 2 := by rw [cbRatioQuarter_eq]; norm_num
+
+/-- The per-step upper bound at `k = 0` is `−(1/2)/1 = −1/2`. -/
+example : (-(1 / 2) / ((0 : ℝ) + 1)) = -(1 / 2) := by norm_num
+
+/-- `C(0,0) = 1`, `catalan 0 = 1`, so the structural identity reads `1 = 1·1`. -/
+example : (centralBinom 0 : ℝ) = ((0 : ℝ) + 1) * catalan 0 := by
+  rw [centralBinom_eq_succ_mul_catalan]; norm_num
+
+/-- `C(2,1) = 2 = (1+1)·catalan 1 = 2·1`. -/
+example : (centralBinom 1 : ℝ) = ((1 : ℝ) + 1) * catalan 1 := by
+  rw [centralBinom_eq_succ_mul_catalan]; norm_num
+
+end Erdos396OQ01OQ01OQ02OQ02

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02-ratio",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 67,
+      "endLine": 79
+    },
+    "type": "key-step",
+    "title": "Mathlib's recurrence as a ratio step",
+    "content": "Mathlib's $\\texttt{Nat.succ\\_mul\\_centralBinom\\_succ}$ states $(n+1)\\,C(2(n+1),n+1) = 2(2n+1)\\,C(2n,n)$. Casting to $\\mathbb{R}$, clearing the denominator with $\\texttt{field\\_simp}$, and closing with $\\texttt{linear\\_combination}$ gives the multiplicative reading $C(2(n+1),n+1) = s\\,n \\cdot C(2n,n)$ with $s\\,n = (4n+2)/(n+1) = 4 - 2/(n+1)$. This is the exact analogue of the Catalan ratio $r\\,n = 4 - 6/(n+2)$.",
+    "mathContext": "$s\\,n = \\dfrac{2(2n+1)}{n+1} = \\dfrac{4n+2}{n+1} = 4 - \\dfrac{2}{n+1}$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02-ratioquarter",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 82,
+      "endLine": 88
+    },
+    "type": "key-step",
+    "title": "The 1/2 appears in one normalised step",
+    "content": "Dividing the ratio by the limiting rate $4$ gives $s\\,k/4 = 1 - (1/2)/(k+1)$. The coefficient $1/2$ of the harmonic correction is *exactly* the critical exponent of the central-binomial asymptotic $C(2n,n) \\sim 4^n/\\sqrt{\\pi n}$, exposed before any summation or limit. Compare the Catalan coefficient $3/2$ from the shifted tail $6/(k+2)$: here the deficit $2/(k+1)$ is the *un-shifted* harmonic tail.",
+    "mathContext": "$\\dfrac{s\\,k}{4} = \\dfrac{1}{4}\\left(4 - \\dfrac{2}{k+1}\\right) = 1 - \\dfrac{1/2}{k+1}$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02-logle",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 93,
+      "endLine": 101
+    },
+    "type": "key-step",
+    "title": "Elementary log bound on each step",
+    "content": "The single Mathlib inequality $\\log y \\le y - 1$ (valid for $y > 0$, $\\texttt{Real.log\\_le\\_sub\\_one\\_of\\_pos}$) at $y = s\\,k/4$ gives $\\log(s\\,k/4) \\le s\\,k/4 - 1 = -(1/2)/(k+1)$. No analytic estimate is used — just one elementary convexity inequality applied termwise.",
+    "mathContext": "$\\log\\!\\left(\\dfrac{s\\,k}{4}\\right) \\le \\dfrac{s\\,k}{4} - 1 = -\\dfrac{1/2}{k+1}$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02-logge",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 104,
+      "endLine": 121
+    },
+    "type": "key-step",
+    "title": "Matching lower bound from the reciprocal",
+    "content": "Applying the *same* inequality to the reciprocal $(s\\,k/4)^{-1}$ and using $\\log(x^{-1}) = -\\log x$ gives $\\log(s\\,k/4) \\ge -((s\\,k/4)^{-1} - 1) = -1/(2k+1)$, since $(s\\,k/4)^{-1} - 1 = 1/(2k+1)$ by $\\texttt{field\\_simp}$. The log step is thus pinned from both sides by harmonic-type terms with the same leading coefficient $1/2$.",
+    "mathContext": "$\\left(\\dfrac{s\\,k}{4}\\right)^{-1} - 1 = \\dfrac{2(k+1)}{2k+1} - 1 = \\dfrac{1}{2k+1}$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02-telescope",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 123,
+      "endLine": 145
+    },
+    "type": "key-step",
+    "title": "Telescoping the recurrence through the logarithm",
+    "content": "Because each step multiplies by $s\\,k$, the normalised value $C(2m,m)/4^m$ obeys $C(2(m+1),m+1)/4^{m+1} = (s\\,m/4)\\cdot(C(2m,m)/4^m)$. Induction with $\\texttt{Real.log\\_mul}$ (both factors positive) collapses the product into the exact finite sum $\\log(C(2n,n)/4^n) = \\sum_{k<n} \\log(s\\,k/4)$.",
+    "mathContext": "$\\log\\!\\left(\\dfrac{C(2n,n)}{4^n}\\right) = \\sum_{k<n} \\log\\!\\left(\\dfrac{s\\,k}{4}\\right)$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02-normlogle",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 147,
+      "endLine": 161
+    },
+    "type": "key-step",
+    "title": "Summing to the harmonic bound −(1/2)·Hₙ",
+    "content": "Summing the per-step bound with $\\texttt{Finset.sum\\_le\\_sum}$ and recognising $\\sum_{k<n} (1/2)/(k+1) = (1/2)\\,H_n$ (via $\\texttt{Finset.mul\\_sum}$ against the parent's $\\texttt{realHarmonic}$) gives $\\log(C(2n,n)/4^n) \\le -(1/2)\\,H_n$. Here the harmonic sum appears *un-shifted* as $H_n = \\sum_{k<n} 1/(k+1)$, where the Catalan version produced $H_{n+1} - 1$.",
+    "mathContext": "$\\log\\!\\left(\\dfrac{C(2n,n)}{4^n}\\right) \\le -\\tfrac{1}{2}\\,H_n,\\quad H_n = \\sum_{k<n}\\dfrac{1}{k+1}$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02-headline",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 163,
+      "endLine": 174
+    },
+    "type": "insight",
+    "title": "Headline: the 1/2-exponent decay bound",
+    "content": "Exponentiating via $x = \\exp(\\log x)$ and monotonicity gives the headline $C(2n,n)/4^n \\le \\exp(-(1/2)\\,H_n)$. Since $H_n \\sim \\log n$, the right side is $\\sim n^{-1/2}$: the recurrence *alone* forces the critical exponent $1/2$ of $C(2n,n) \\sim 4^n/\\sqrt{\\pi n}$, with no Stirling estimate anywhere in the chain.",
+    "mathContext": "$\\dfrac{C(2n,n)}{4^n} \\le \\exp\\!\\left(-\\tfrac{1}{2}H_n\\right) \\sim n^{-1/2}.$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02-bridge",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 196,
+      "endLine": 213
+    },
+    "type": "insight",
+    "title": "One linear factor separates 3/2 from 1/2",
+    "content": "The identity $C(2n,n) = (n+1)\\,\\text{catalan}\\,n$ ($\\texttt{succ\\_mul\\_catalan\\_eq\\_centralBinom}$) means the two normalised sequences differ by exactly the factor $n+1$. That single linear factor is the *entire* difference between the exponents: $3/2 = 1/2 + 1$. The recurrence-level analysis makes the relationship between the two classical asymptotics fully transparent.",
+    "mathContext": "$\\dfrac{\\text{catalan}\\,n}{4^n} = \\dfrac{1}{n+1}\\cdot\\dfrac{C(2n,n)}{4^n}\\ \\Longrightarrow\\ n^{-3/2} = (n+1)^{-1}\\,n^{-1/2}.$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02-squeeze",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 216,
+      "endLine": 229
+    },
+    "type": "key-step",
+    "title": "Independent, rate-quantified convergence",
+    "content": "The bound $\\exp(-(1/2)H_n) \\to 0$ holds purely because the harmonic series diverges ($\\texttt{realHarmonic\\_tendsto\\_atTop}$, times $-1/2 < 0 \\to \\texttt{atBot}$, then $\\texttt{Real.tendsto\\_exp\\_atBot}$). Squeezing $0 \\le C(2n,n)/4^n \\le \\exp(-(1/2)H_n)$ gives $C(2n,n)/4^n \\to 0$ with an explicit rate, independently of Stirling.",
+    "mathContext": "$0 \\le \\dfrac{C(2n,n)}{4^n} \\le \\exp\\!\\left(-\\tfrac{1}{2}H_n\\right) \\to 0.$"
+  }
+]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+  "title": "Erdős #396 OQ-04 → OQ-01 → OQ-01 → OQ-02 → OQ-02: The 1/2 Critical Exponent of the Central Binomial Coefficient",
+  "slug": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+  "description": "The sibling extracted the 3/2 exponent of the Catalan numbers from their recurrence; its closing open question asked whether the same machinery recovers the 1/2 exponent of the central binomial coefficient C(2n,n). It does. Mathlib's recurrence (n+1)·C(2(n+1),n+1) = 2(2n+1)·C(2n,n) reads as the ratio s n = (4n+2)/(n+1) = 4 − 2/(n+1), with deficit 2/(n+1) — the un-shifted harmonic tail. Normalising, s k / 4 = 1 − (1/2)/(k+1); the elementary bound log y ≤ y − 1 gives log(s k / 4) ≤ −(1/2)/(k+1); telescoping through the logarithm yields log(C(2n,n)/4^n) = ∑_{k<n} log(s k / 4) ≤ −(1/2)·H_n, so C(2n,n)/4^n ≤ exp(−(1/2)·H_n) ∼ n^{−1/2}: the recurrence alone forces the exponent 1/2 of C(2n,n) ∼ 4^n/√(πn). A reciprocal estimate gives the matching lower bracket. The identity C(2n,n) = (n+1)·catalan n ties the two threads: the extra linear factor n+1 is exactly the difference 3/2 = 1/2 + 1 between the two decay exponents.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/396",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "central-binomial",
+      "catalan",
+      "recurrence",
+      "asymptotics",
+      "harmonic-series",
+      "logarithm",
+      "critical-exponent",
+      "limits"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 396,
+    "erdosUrl": "https://erdosproblems.com/396",
+    "axiomCount": 0,
+    "lineCount": 248,
+    "assumptions": "0 axioms, 0 sorries. All results depend only on the foundational axioms propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool / native_decide). Built against Mathlib 4.26.0.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 15,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The thread reads the two-term Catalan recurrence as a multiplicative step and tracks its deficit below the limiting rate 4. The grandparent established r n = 4 − 6/(n+2) → 4; the parent showed the deficit δ n = 6/(n+2) is a harmonic tail whose running sum diverges; and the sibling OQ-02 exponentiated that sum to extract the critical exponent 3/2 of catalan n ∼ 4^n/(n^{3/2}√π) at the recurrence level. The sibling's second open question asked whether the identical machinery, applied to the central binomial coefficient C(2n,n), recovers its 1/2 exponent from the classical asymptotic C(2n,n) ∼ 4^n/√(πn). This entry answers that question affirmatively.",
+    "problemStatement": "Does the normalised step of the central-binomial recurrence (n+1)·C(2(n+1),n+1) = 2(2n+1)·C(2n,n), namely s k / 4 = (4k+2)/(4(k+1)) = 1 − (1/2)/(k+1), exponentiate to the bound C(2n,n)/4^n ≤ exp(−(1/2)·H_n) ∼ n^{−1/2}, recovering the critical exponent 1/2 of the central binomial coefficient by purely recurrence-level reasoning?",
+    "text": "Mathlib's recurrence Nat.succ_mul_centralBinom_succ gives, over ℝ, C(2(n+1),n+1) = s n · C(2n,n) with s n = (4n+2)/(n+1) = 4 − 2/(n+1). Normalising by the limiting rate, s k / 4 = 1 − (1/2)/(k+1), so the harmonic correction has coefficient 1/2 — exactly the critical exponent — visible in a single step (compare the Catalan coefficient 3/2). The elementary inequality log y ≤ y − 1 at y = s k / 4 gives log(s k / 4) ≤ −(1/2)/(k+1). Telescoping the recurrence through the logarithm, log(C(2n,n)/4^n) = ∑_{k<n} log(s k / 4); summing the per-step bound and recognising ∑_{k<n} (1/2)/(k+1) = (1/2)·H_n yields log(C(2n,n)/4^n) ≤ −(1/2)·H_n. Exponentiating gives C(2n,n)/4^n ≤ exp(−(1/2)·H_n), equivalently C(2n,n) ≤ 4^n·exp(−(1/2)·H_n). The same inequality applied to (s k / 4)⁻¹ gives log(s k / 4) ≥ −1/(2k+1), bracketing log(C(2n,n)/4^n) between two harmonic-type sums both with leading coefficient 1/2. Squeezing 0 ≤ C(2n,n)/4^n ≤ exp(−(1/2)·H_n) → 0 proves C(2n,n)/4^n → 0 with an explicit rate, independently of Stirling. Finally C(2n,n) = (n+1)·catalan n exhibits the linear factor n+1 as the precise difference 3/2 = 1/2 + 1 between the two decay exponents.",
+    "proofStrategy": "Import the parent (Proofs.Erdos396OQ04OQ01OQ01) to reuse the harmonic sequence realHarmonic m = ∑_{i<m} 1/(i+1), its successor recurrence, and its divergence realHarmonic_tendsto_atTop. (1) cbRatio defines s n = (4n+2)/(n+1); cbRatio_pos by positivity. (2) centralBinom_succ_eq_ratio_mul: cast Nat.succ_mul_centralBinom_succ to ℝ, field_simp, and close with linear_combination. (3) cbRatioQuarter_eq: s k / 4 = 1 − (1/2)/(k+1) by field_simp; ring. (4) cbRatioQuarter_pos by positivity. (5) log_cbRatioQuarter_le: Real.log_le_sub_one_of_pos at s k/4 and rewrite s k/4 − 1 = −(1/2)/(k+1). (6) log_cbRatioQuarter_ge: same lemma at (s k/4)⁻¹, Real.log_inv, and (s k/4)⁻¹ − 1 = 1/(2k+1) via field_simp. (7) normLog_eq_sum: induction; successor step factors C(2(m+1),m+1)/4^(m+1) = (s m/4)·(C(2m,m)/4^m) and splits the log with Real.log_mul. (8) normLog_le: Finset.sum_le_sum with the per-step bound, then ∑ −(1/2)/(k+1) = −(1/2)·realHarmonic n by Finset.mul_sum. (9) centralBinom_div_le_exp: x = exp(log x) and Real.exp_le_exp.mpr. (10) centralBinom_le_exp_mul: div_le_iff₀. (11) normLog_bracket: combine both per-step bounds. (12) centralBinom_eq_succ_mul_catalan: cast succ_mul_catalan_eq_centralBinom. (13) catalan_div_eq_centralBinom_div: field_simp. (14) expBound_tendsto_zero: −(1/2)·realHarmonic n → atBot (Tendsto.const_mul_atTop_of_neg) composed with Real.tendsto_exp_atBot. (15) centralBinom_div_tendsto_zero: squeeze_zero.",
+    "keyInsights": [
+      "**The exponent 1/2 is visible in a single normalised step.** Dividing the central-binomial recurrence step by the limiting rate, s k / 4 = 1 − (1/2)/(k+1): the coefficient 1/2 of the harmonic correction is precisely the critical exponent of C(2n,n) ∼ 4^n/√(πn), exposed before any summation or limit. Where the Catalan deficit is the shifted harmonic tail 6/(k+2) with coefficient 3/2, the central-binomial deficit is the un-shifted tail 2/(k+1) with coefficient 1/2.",
+      "**Telescoping through the logarithm turns the recurrence into the asymptotic.** Each step multiplies by s k, so log(C(2n,n)/4^n) = ∑_{k<n} log(s k / 4) exactly; the elementary bound log y ≤ y − 1 converts this into −(1/2)·H_n, and exponentiating returns C(2n,n)/4^n ≤ exp(−(1/2)·H_n) ∼ n^{−1/2}.",
+      "**The exponent is forced from both sides.** Applying the same Mathlib inequality to the reciprocal yields log(s k / 4) ≥ −1/(2k+1), so log(C(2n,n)/4^n) is bracketed between two harmonic-type sums *both* with leading coefficient 1/2 — the 1/2 is intrinsic to the recurrence, not an artefact of one inequality.",
+      "**One linear factor separates the two exponents.** The identity C(2n,n) = (n+1)·catalan n means the central-binomial and Catalan normalised sequences differ by exactly the factor n+1. That single factor is the entire difference between the exponents: 3/2 = 1/2 + 1. The recurrence-level analysis makes the relationship between the two classical asymptotics transparent.",
+      "**An independent, rate-quantified proof that C(2n,n)/4^n → 0.** Squeezing between 0 and the explicit exponential bound — which vanishes purely because the harmonic series diverges — recovers the vanishing of the normalised central binomial coefficients without invoking Stirling, with the decay rate made explicit."
+    ],
+    "prerequisites": [
+      "Mathlib's central-binomial recurrence Nat.succ_mul_centralBinom_succ and positivity Nat.centralBinom_pos",
+      "The parent's harmonic sequence realHarmonic m = ∑_{i<m} 1/(i+1) and its divergence realHarmonic_tendsto_atTop",
+      "The elementary logarithm inequality log y ≤ y − 1 (Real.log_le_sub_one_of_pos) and exp/log monotonicity",
+      "The identity C(2n,n) = (n+1)·catalan n (succ_mul_catalan_eq_centralBinom) and the squeeze theorem for sequences"
+    ]
+  },
+  "conclusion": {
+    "summary": "The central-binomial recurrence, normalised by its limiting rate, forces C(2n,n)/4^n ≤ exp(−(1/2)·H_n), equivalently C(2n,n) ≤ 4^n·exp(−(1/2)·H_n). Since H_n ∼ log n the bound is ∼ n^{−1/2}, exhibiting the critical exponent 1/2 of C(2n,n) ∼ 4^n/√(πn) at the level of the integer recurrence. A reciprocal estimate brackets log(C(2n,n)/4^n) between two harmonic-type sums both with coefficient 1/2, and a squeeze gives an independent proof that C(2n,n)/4^n → 0. The identity C(2n,n) = (n+1)·catalan n ties the result to the sibling's 3/2 exponent: the linear factor n+1 is exactly the difference 3/2 = 1/2 + 1. All fifteen theorems are fully machine-checked with no axioms or sorries.",
+    "implications": "The entry closes the sibling's second open question: the same one-line logarithm inequality plus harmonic divergence that produced the Catalan 3/2 exponent produces the central-binomial 1/2 exponent, with no Stirling estimate. Making the structural identity C(2n,n) = (n+1)·catalan n explicit shows the two classical asymptotics are a single recurrence-level phenomenon separated by one linear factor, and the matching reciprocal bound shows each exponent is two-sided.",
+    "openQuestions": [
+      "Combining the lower bracket −∑_{k<n} 1/(2k+1) with H_m = log m + γ + o(1), can one extract explicit constants c₁, c₂ with c₁·4^n/√n ≤ C(2n,n) ≤ c₂·4^n/√n directly from the recurrence, isolating the √π constant as the only ingredient genuinely requiring an analytic (Wallis/Stirling) input?",
+      "The Catalan deficit is the shifted harmonic tail 6/(k+2) and the central-binomial deficit the un-shifted tail 2/(k+1); for which two-term integer recurrences a_{n+1} = ((αn+β)/(γn+δ))·a_n does this normalised-step method pin the polynomial decay exponent as the harmonic coefficient (β/δ − α/γ-type) of the deficit, and what is the general statement?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos396OQ04OQ01OQ01"
+    ],
+    "opens": [
+      "Nat",
+      "Filter",
+      "Topology",
+      "Finset"
+    ],
+    "namespace": "Erdos396OQ01OQ01OQ02OQ02",
+    "lineCount": 248,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "Sibling/parent OQ: extracts the 3/2 critical exponent of the Catalan numbers from their recurrence by exponentiating the harmonic deficit sum. This entry answers that file's second open question by running the identical machinery on the central binomial coefficient to recover its 1/2 exponent, and links the two via C(2n,n) = (n+1)·catalan n."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01",
+      "relationship": "ancestor",
+      "description": "The deficit δ n = 6/(n+2) is a harmonic tail with ∑_{k<n} δ k = 6·(H_{n+1} − 1) diverging; this entry reuses the same harmonic sequence realHarmonic and its divergence for the central-binomial deficit 2/(n+1)."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01",
+      "relationship": "ancestor",
+      "description": "Grandparent OQ: the asymptotics of the Catalan recurrence ratio r n = 4 − 6/(n+2) → 4. The present central-binomial ratio s n = 4 − 2/(n+1) is the parallel statement for C(2n,n)."
+    },
+    {
+      "targetId": "erdos-396",
+      "relationship": "ancestor",
+      "description": "Root problem: descending factorials dividing central binomial coefficients. The central binomial coefficient C(2n,n) studied here is the root object whose growth rate is bounded."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of the sibling Catalan-3/2 entry (`erdos-396-oq-04-oq-01-oq-01-oq-02`): run the identical normalised-step / log-telescope machinery on the **central binomial coefficient** `C(2n,n)` and recover its **1/2 critical exponent**.

Mathlib's recurrence `(n+1)·C(2(n+1),n+1) = 2(2n+1)·C(2n,n)` reads as the ratio `s n = (4n+2)/(n+1) = 4 − 2/(n+1)`, whose deficit `2/(n+1)` is the **un-shifted** harmonic tail (vs. the Catalan deficit `6/(n+2)`). Normalising by the limiting rate:

- `s k / 4 = 1 − (1/2)/(k+1)` — the coefficient **1/2** is the critical exponent, visible in one step.
- `log y ≤ y − 1` ⟹ `log(s k/4) ≤ −(1/2)/(k+1)`.
- Telescope: `log(C(2n,n)/4^n) = ∑_{k<n} log(s k/4) ≤ −(1/2)·H_n`.
- **Headline** `centralBinom_div_le_exp`: `C(2n,n)/4^n ≤ exp(−(1/2)·H_n) ∼ n^{−1/2}`, the exponent of `C(2n,n) ∼ 4^n/√(πn)`.
- Reciprocal gives the matching lower bracket `log(s k/4) ≥ −1/(2k+1)` (both sides coefficient 1/2).
- Squeeze ⟹ `C(2n,n)/4^n → 0`, rate-quantified, **no Stirling**.

### Structural tie to the parent thread
`centralBinom_eq_succ_mul_catalan`: `C(2n,n) = (n+1)·catalan n`. The linear factor `n+1` is **exactly** the difference between the two decay exponents: `3/2 = 1/2 + 1`. The two classical asymptotics are one recurrence-level phenomenon separated by one linear factor.

## Verification
- **15 theorems / 1 def, 248 lines**, builds against Mathlib 4.26.0 via `./proofs/scripts/docker-build.sh Proofs.Erdos396OQ04OQ01OQ01OQ02OQ02` ✓
- **0 axioms, 0 sorries, no `native_decide`** — only `propext`/`Classical.choice`/`Quot.sound`.

## Files
- `proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02.lean`
- `proofs/Proofs.lean` (manifest import)
- `src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)