### PR TITLE
research(godel-first-incompleteness-oq01-oq-03): the five axioms are not independent

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2716,6 +2716,7 @@ import Proofs.GeometricSeriesOQ10
 import Proofs.GnedenkoKolmogorov
 import Proofs.GodelFirstIncompletenessOQ01
 import Proofs.GodelFirstIncompletenessOQ01OQ01
+import Proofs.GodelFirstIncompletenessOQ01OQ03
 import Proofs.GodelFirstIncompletenessOQ01OQ04
 import Proofs.GodelIncompleteness
 import Proofs.GodelSecondIncompletenessOQ02

--- a/proofs/Proofs/GodelFirstIncompletenessOQ01OQ03.lean
+++ b/proofs/Proofs/GodelFirstIncompletenessOQ01OQ03.lean
@@ -1,0 +1,143 @@
+import Mathlib
+
+/-!
+# Gödel First Incompleteness OQ-01 / OQ-03: (In)dependence of the Five Axioms
+
+## The Open Question (OQ-03 of `godel-first-incompleteness-oq01`)
+
+The parent file `GodelFirstIncompletenessOQ01` proves First Incompleteness from five axioms on
+an opaque provability predicate `Provable`, and asks:
+
+> The five axioms are "independent" in the sense that removing any one breaks the proof — but
+> are they actually independent as logical assertions? Could any of them be derived from the
+> others?
+
+## The answer (and a soundness finding)
+
+We analyze the four substantive axioms, instantiated at the single relevant trio of sentences
+`G`, `Prov(⌜G⌝)`, `¬G` (codes `42`, `84`, `43` in the parent's encoding). Writing `P` for the
+provability predicate, the parent's axioms restrict to:
+
+* `D1G P`      : `P G → P (Prov ⌜G⌝)`            (D1 at `φ = G`)
+* `SelfRef P`  : `P G ↔ ¬ P (Prov ⌜G⌝)`          (meta self-reference)
+* `OmegaCons P`: `¬ P G → ¬ P (Prov ⌜G⌝)`        (ω-consistency at `G`)
+* `NegGProv P` : `P (¬G) → P (Prov ⌜G⌝)`         (object-level diagonal)
+
+Two results, both surprising for a file advertised as *non-vacuous*:
+
+1. **`core_inconsistency`**: `D1G P`, `SelfRef P`, `OmegaCons P` are **jointly inconsistent**
+   for *every* `P`. (D1 forces `PG → PprovG`; self-reference forces `PG → ¬PprovG`, hence `¬PG`;
+   but self-reference also turns `¬PG` into `PprovG`, while ω-consistency turns it into `¬PprovG`
+   — contradiction.) Consequently the parent's axiom set has **no model**
+   (`no_model_of_all_axioms`): its First Incompleteness theorem holds, but *vacuously* — a subtler
+   form of the very vacuity (`Provable := fun _ => False`) the parent set out to avoid. The flaw
+   is that the **meta-level** equivalence `⊢G ↔ ¬⊢Prov⌜G⌝` was asserted as an axiom; in genuine
+   arithmetic only the *object-level* `F ⊢ (G ↔ ¬Prov⌜G⌝)` holds.
+
+2. **`negGProv_derivable`**: the fourth axiom `NegGProv` is **derivable** from `D1G ∧ SelfRef`
+   (they already force `P (Prov ⌜G⌝)`), so it is *not* independent.
+
+For the three mutually-inconsistent axioms we show the inconsistency is **minimal**: each is
+independent of the other two (a model satisfies the other two but not it). So the honest answer
+to OQ-03 is: the axioms are **not** independent — three over-determine into a contradiction and
+the fourth is redundant.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`. Stated abstractly over an
+arbitrary `P : ℕ → Prop` so nothing imports the parent's (inconsistent) global axioms.
+-/
+
+namespace GodelFirstIncompletenessOQ01OQ03
+
+/-- Code of the Gödel sentence `G` (parent: `G = ⟨42⟩`). -/
+def gCode : ℕ := 42
+/-- Code of `Prov(⌜G⌝)` (parent: `Prov (godelNum G) = ⟨42 * 2⟩`). -/
+def provGCode : ℕ := 84
+/-- Code of `¬G` (parent: `neg G = ⟨42 + 1⟩`). -/
+def negGCode : ℕ := 43
+
+/-- D1 (representability) at `φ = G`: provability of `G` entails provability of `Prov(⌜G⌝)`. -/
+def D1G (P : ℕ → Prop) : Prop := P gCode → P provGCode
+
+/-- Meta self-reference: `G` provable iff `Prov(⌜G⌝)` not provable. -/
+def SelfRef (P : ℕ → Prop) : Prop := P gCode ↔ ¬ P provGCode
+
+/-- ω-consistency at `G`: if `G` is unprovable, so is `Prov(⌜G⌝)`. -/
+def OmegaCons (P : ℕ → Prop) : Prop := ¬ P gCode → ¬ P provGCode
+
+/-- Object-level diagonal: provability of `¬G` entails provability of `Prov(⌜G⌝)`. -/
+def NegGProv (P : ℕ → Prop) : Prop := P negGCode → P provGCode
+
+/-!
+## Result 1: three of the axioms are jointly inconsistent
+-/
+
+/-- **The core inconsistency.** No provability predicate satisfies `D1G`, `SelfRef`, and
+    `OmegaCons` simultaneously. -/
+theorem core_inconsistency (P : ℕ → Prop)
+    (h1 : D1G P) (h2 : SelfRef P) (h3 : OmegaCons P) : False := by
+  simp only [D1G, SelfRef, OmegaCons] at h1 h2 h3
+  tauto
+
+/-- **The parent's axiom set has no model.** Since three of the four axioms already contradict,
+    no `P` satisfies all four. The parent's First Incompleteness theorem is therefore vacuously
+    true (it follows from contradictory hypotheses), not genuinely non-vacuous. -/
+theorem no_model_of_all_axioms :
+    ¬ ∃ P : ℕ → Prop, D1G P ∧ SelfRef P ∧ OmegaCons P ∧ NegGProv P := by
+  rintro ⟨P, h1, h2, h3, _⟩
+  exact core_inconsistency P h1 h2 h3
+
+/-!
+## Result 2: the fourth axiom is derivable (not independent)
+-/
+
+/-- **`NegGProv` is derivable from `D1G ∧ SelfRef`.** These two already force `P (Prov ⌜G⌝)`,
+    so `NegGProv` (anything → `P (Prov ⌜G⌝)`) holds trivially. The object-level diagonal axiom
+    is redundant. -/
+theorem negGProv_derivable (P : ℕ → Prop) (h1 : D1G P) (h2 : SelfRef P) : NegGProv P := by
+  simp only [D1G, SelfRef, NegGProv] at h1 h2 ⊢
+  tauto
+
+/-!
+## Result 3: the inconsistency is minimal — each of the three is independent of the other two
+-/
+
+/-- `D1G` is independent of `SelfRef ∧ OmegaCons`: a model satisfies the latter two but not `D1G`.
+    Witness: only `G` is provable (`P n ↔ n = G`). -/
+theorem d1G_independent : ∃ P : ℕ → Prop, SelfRef P ∧ OmegaCons P ∧ ¬ D1G P := by
+  refine ⟨fun n => n = gCode, ?_, ?_, ?_⟩ <;>
+    simp only [D1G, SelfRef, OmegaCons, gCode, provGCode] <;> decide
+
+/-- `SelfRef` is independent of `D1G ∧ OmegaCons`: a model satisfies the latter two but not
+    `SelfRef`. Witness: nothing is provable (`P n ↔ False`). -/
+theorem selfRef_independent : ∃ P : ℕ → Prop, D1G P ∧ OmegaCons P ∧ ¬ SelfRef P := by
+  refine ⟨fun _ => False, ?_, ?_, ?_⟩ <;>
+    simp only [D1G, SelfRef, OmegaCons, gCode, provGCode] <;> decide
+
+/-- `OmegaCons` is independent of `D1G ∧ SelfRef`: a model satisfies the latter two but not
+    `OmegaCons`. Witness: only `Prov(⌜G⌝)` is provable (`P n ↔ n = Prov ⌜G⌝`). -/
+theorem omegaCons_independent : ∃ P : ℕ → Prop, D1G P ∧ SelfRef P ∧ ¬ OmegaCons P := by
+  refine ⟨fun n => n = provGCode, ?_, ?_, ?_⟩ <;>
+    simp only [D1G, SelfRef, OmegaCons, gCode, provGCode] <;> decide
+
+end GodelFirstIncompletenessOQ01OQ03
+
+/-!
+## Summary
+
+Answering OQ-03 (are the parent's five axioms independent / derivable?):
+
+- `core_inconsistency`: `D1G`, `SelfRef`, `OmegaCons` are jointly inconsistent for every `P`.
+- `no_model_of_all_axioms`: hence the parent's axiom set has no model — First Incompleteness
+  holds there only vacuously (a subtler vacuity than `Provable := fun _ => False`). Root cause:
+  the **meta-level** self-reference `⊢G ↔ ¬⊢Prov⌜G⌝` was taken as an axiom, whereas only the
+  object-level `F ⊢ (G ↔ ¬Prov⌜G⌝)` is legitimate.
+- `negGProv_derivable`: the object-level diagonal axiom is derivable from `D1G ∧ SelfRef`, so it
+  is redundant — not independent.
+- `d1G_independent`, `selfRef_independent`, `omegaCons_independent`: the three contradictory
+  axioms form a *minimal* inconsistent set; each is independent of the other two.
+
+So the axioms are **not** independent: three over-determine into a contradiction, and the fourth
+is redundant.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-03/annotations.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-03/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-encoding",
+    "proofId": "godel-first-incompleteness-oq01-oq-03",
+    "range": {
+      "startLine": 52,
+      "endLine": 73
+    },
+    "type": "concept",
+    "title": "The Axioms Are Constraints on Two Atoms",
+    "content": "The parent's axioms only ever mention three sentences: G, Prov(⌜G⌝), and ¬G (codes 42, 84, 43). Abstracting the provability predicate to P : ℕ → Prop and reading off these codes, the four substantive axioms become purely propositional constraints on the two atoms p = P(G) and q = P(Prov⌜G⌝): D1G is p → q, SelfRef is p ↔ ¬q, OmegaCons is ¬p → ¬q, NegGProv is P(¬G) → q. Working abstractly keeps this file from importing — and being poisoned by — the parent's (inconsistent) global axioms."
+  },
+  {
+    "id": "ann-inconsistency",
+    "proofId": "godel-first-incompleteness-oq01-oq-03",
+    "range": {
+      "startLine": 81,
+      "endLine": 100
+    },
+    "type": "insight",
+    "title": "Three Axioms Contradict",
+    "content": "`core_inconsistency` derives False from D1G ∧ SelfRef ∧ OmegaCons. The argument: D1G (p→q) and SelfRef (p↔¬q) together give p→(q∧¬q), so ¬p; then SelfRef turns ¬p into q, while OmegaCons turns ¬p into ¬q — contradiction. So `no_model_of_all_axioms`: no provability predicate satisfies the parent's axioms. Its First Incompleteness theorem is therefore vacuously true (it follows from contradictory hypotheses) — the same vacuity failure as Provable := fun _ => False, just hidden behind the meta-level self-reference axiom."
+  },
+  {
+    "id": "ann-derivable",
+    "proofId": "godel-first-incompleteness-oq01-oq-03",
+    "range": {
+      "startLine": 108,
+      "endLine": 116
+    },
+    "type": "insight",
+    "title": "The Fourth Axiom Is Redundant",
+    "content": "`negGProv_derivable` shows the object-level diagonal axiom NegGProv (P(¬G) → q) follows from D1G ∧ SelfRef: those two already force q = P(Prov⌜G⌝) to be true (¬p ⟹ q via self-reference, and ¬p holds), so an implication into q is automatic. Hence NegGProv is not independent — a direct answer to the OQ's 'could any be derived from the others?'."
+  },
+  {
+    "id": "ann-minimal",
+    "proofId": "godel-first-incompleteness-oq01-oq-03",
+    "range": {
+      "startLine": 124,
+      "endLine": 140
+    },
+    "type": "concept",
+    "title": "A Minimal Inconsistent Set",
+    "content": "The three contradictory axioms are each independent of the other two, witnessed by explicit provability predicates: P = (· = G) satisfies SelfRef and OmegaCons but not D1G; P = (fun _ => False) satisfies D1G and OmegaCons but not SelfRef; P = (· = Prov⌜G⌝) satisfies D1G and SelfRef but not OmegaCons. So no two of them imply the third — the inconsistency genuinely needs all three, and the fix must change one of them (the meta self-reference) rather than simply drop a redundant axiom."
+  }
+]

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-03/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-03/meta.json
@@ -1,0 +1,182 @@
+{
+  "id": "godel-first-incompleteness-oq01-oq-03",
+  "title": "(In)dependence of Gödel's Five Axioms: A Joint Inconsistency",
+  "slug": "godel-first-incompleteness-oq01-oq-03",
+  "description": "Answers the parent's third open question — are its five axioms for First Incompleteness independent, or derivable from one another? The finding is sharp: three of the substantive axioms (D1 at φ=G, the meta self-reference G⊢ ↔ ¬⊢Prov⌜G⌝, and ω-consistency at G) are JOINTLY INCONSISTENT for every provability predicate, so the parent's axiom set has no model and its 'non-vacuous' First Incompleteness theorem holds only vacuously — a subtler version of the Provable:=False vacuity it set out to avoid. The fourth axiom (object-level diagonal) is moreover derivable from D1 ∧ self-reference. The inconsistency is shown minimal: each of the three is independent of the other two (a model satisfies the other two but not it). The root cause is asserting the meta-level self-reference as an axiom where only the object-level F⊢(G↔¬Prov⌜G⌝) is legitimate.",
+  "meta": {
+    "author": "analysis of Kurt Gödel's 1931 axiom encoding; formalized in Lean 4",
+    "date": "1931",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GodelFirstIncompletenessOQ01OQ03.lean",
+    "tags": [
+      "logic",
+      "incompleteness",
+      "godel",
+      "independence",
+      "model-theory",
+      "soundness"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 143,
+    "theoremCount": 6,
+    "definitionCount": 7,
+    "originalContributions": [
+      "core_inconsistency: D1G, SelfRef, OmegaCons are jointly inconsistent for every P — a genuine logical derivation of False from three of the parent's axioms (restricted to the relevant trio of sentences).",
+      "no_model_of_all_axioms: the parent's four-axiom set has no model, so its First Incompleteness theorem is vacuously (not genuinely) true.",
+      "negGProv_derivable: the object-level diagonal axiom NegGProv is derivable from D1G ∧ SelfRef — it is redundant, not independent.",
+      "d1G_independent, selfRef_independent, omegaCons_independent: the inconsistency is minimal — each of the three axioms is independent of the other two, witnessed by explicit provability-predicate models."
+    ],
+    "prerequisites": [
+      "Gödel's First Incompleteness Theorem and the provability predicate",
+      "The distinction between object-level (F ⊢ φ) and meta-level (⊢ φ in the metatheory) statements",
+      "Independence by counter-models in propositional/predicate logic"
+    ],
+    "mathlibDependencies": []
+  },
+  "overview": {
+    "historicalContext": "Gödel's 1931 proof builds the sentence G via the Diagonal Lemma so that, within the formal system F, one has F ⊢ (G ↔ ¬Prov(⌜G⌝)). The parent gallery file abstracts the proof into five axioms on an opaque provability predicate, intending a 'non-vacuous' formalization that avoids the degenerate Provable := fun _ => False. A subtlety it overlooked, however, is the difference between the legitimate object-level equivalence F ⊢ (G ↔ ¬Prov(⌜G⌝)) and the meta-level claim '⊢G (in the metatheory) iff ¬⊢Prov(⌜G⌝)'. The parent asserts the latter as an axiom (G_self_reference).\n\nThis entry analyzes the resulting axiom system and finds it inconsistent: the meta self-reference together with D1 (representability) and ω-consistency, all instantiated at G, derive a contradiction. The independence question of OQ-03 is thereby answered in the negative, and a soundness flaw in the parent is surfaced.",
+    "problemStatement": "**Open Question (parent godel-first-incompleteness-oq01, OQ-03)**: the five axioms are 'independent' in the sense that removing any one breaks the proof — but are they actually independent as logical assertions? Could any be derived from the others?\n\n**Answer: No.** Three of the four substantive axioms are jointly inconsistent, and the fourth is derivable from two of them.",
+    "text": "A 143-line, fully verified (0 sorries, 0 axioms, no native_decide) file. It abstracts the four substantive axioms to predicates D1G, SelfRef, OmegaCons, NegGProv on an arbitrary P : ℕ → Prop (codes 42, 84, 43 matching the parent's encoding of G, Prov⌜G⌝, ¬G). core_inconsistency derives False from D1G ∧ SelfRef ∧ OmegaCons; no_model_of_all_axioms concludes the four-axiom set has no model; negGProv_derivable shows NegGProv follows from D1G ∧ SelfRef; and three model theorems prove the inconsistency minimal.",
+    "proofStrategy": "All results are propositional once the predicates are unfolded at the relevant codes. Let p = P(G), q = P(Prov⌜G⌝). D1G is p → q, SelfRef is p ↔ ¬q, OmegaCons is ¬p → ¬q. From D1G and SelfRef, p → (q ∧ ¬q), so ¬p; then SelfRef turns ¬p into q while OmegaCons turns ¬p into ¬q — contradiction (closed by tauto). The same forcing of q gives NegGProv (anything → q) from D1G ∧ SelfRef. The three independence models instantiate P as (· = 42), (fun _ => False), and (· = 84) respectively; after simp-unfolding, the finitely many decidable equalities are closed by decide.",
+    "keyInsights": [
+      "The parent's axioms, restricted to the only sentences they mention (G, Prov⌜G⌝, ¬G), are purely propositional constraints on two atoms p = P(G), q = P(Prov⌜G⌝).",
+      "D1 (p→q) and the meta self-reference (p↔¬q) already force ¬p; self-reference then makes ¬p give q, while ω-consistency makes ¬p give ¬q — an outright contradiction.",
+      "Hence the parent's First Incompleteness theorem is true vacuously (from contradictory axioms), the very failure mode (vacuity) it was designed to avoid, just subtler than Provable := False.",
+      "The object-level diagonal axiom is redundant: D1 ∧ self-reference already force q = P(Prov⌜G⌝), so NegGProv (·→q) is automatic.",
+      "The inconsistency is minimal: dropping any one of the three yields a satisfying model, so each is independent of the other two — the contradiction needs all three.",
+      "Root cause: the meta-level equivalence ⊢G ↔ ¬⊢Prov⌜G⌝ was taken as an axiom; only the object-level F ⊢ (G ↔ ¬Prov⌜G⌝) is sound."
+    ]
+  },
+  "sections": [
+    {
+      "id": "encoding",
+      "title": "The Four Axioms as Predicates",
+      "startLine": 52,
+      "endLine": 73,
+      "summary": "Codes gCode=42, provGCode=84, negGCode=43, and the predicates D1G, SelfRef, OmegaCons, NegGProv on an arbitrary P.",
+      "mathContext": "The parent's axioms restricted to the trio G, Prov⌜G⌝, ¬G."
+    },
+    {
+      "id": "inconsistency",
+      "title": "The Joint Inconsistency",
+      "startLine": 75,
+      "endLine": 100,
+      "summary": "core_inconsistency: D1G ∧ SelfRef ∧ OmegaCons → False for every P. no_model_of_all_axioms: the four-axiom set has no model.",
+      "mathContext": "Three of the axioms contradict, so the parent's theorem holds vacuously."
+    },
+    {
+      "id": "derivable",
+      "title": "The Redundant Fourth Axiom",
+      "startLine": 102,
+      "endLine": 116,
+      "summary": "negGProv_derivable: NegGProv follows from D1G ∧ SelfRef (they force P(Prov⌜G⌝)).",
+      "mathContext": "The object-level diagonal axiom is not independent."
+    },
+    {
+      "id": "minimal",
+      "title": "Minimality: Each of the Three Is Independent",
+      "startLine": 118,
+      "endLine": 140,
+      "summary": "d1G_independent, selfRef_independent, omegaCons_independent: explicit models satisfying two of the three but not the third.",
+      "mathContext": "The inconsistent triple is a minimal inconsistent set."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent's five axioms are not independent: three of the substantive four (D1 at G, the meta self-reference, and ω-consistency) are jointly inconsistent for every provability predicate, so the parent's axiom set has no model and its First Incompleteness theorem is vacuously true. The fourth axiom is derivable from D1 and self-reference. The inconsistency is minimal — each of the three is independent of the other two.",
+    "implications": "This is both an answer to OQ-03 and a soundness audit of the parent: a formalization advertised as 'non-vacuous' is in fact vacuous, because it conflated the meta-level statement ⊢G ↔ ¬⊢Prov⌜G⌝ with the object-level theorem F ⊢ (G ↔ ¬Prov⌜G⌝). A faithful axiomatization must keep the self-reference inside the object theory (e.g. as a provable biconditional, not a metatheoretic iff), which is exactly what a Diagonal-Lemma formalization over a real syntax provides.",
+    "openQuestions": [
+      "Replace the meta self-reference axiom with the sound object-level F ⊢ (G ↔ ¬Prov⌜G⌝) and re-derive First Incompleteness from a consistent axiom set.",
+      "Audit the companion Rosser-sentence and Second-Incompleteness formalizations for the same meta/object conflation.",
+      "Formalize the Diagonal Lemma over an explicit syntax so the fixed point is genuinely object-level."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "godel-first-incompleteness-oq01",
+      "relationship": "extends",
+      "description": "Parent: the five-axiom 'non-vacuous' First Incompleteness formalization whose axioms this entry shows to be inconsistent."
+    },
+    {
+      "targetId": "godel-first-incompleteness-oq01-oq-01",
+      "relationship": "related",
+      "description": "Sibling open question (Rosser's improvement) on the same axiom system."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "GodelFirstIncompletenessOQ01OQ03",
+    "lineCount": 143,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 7,
+    "mainTheorems": [
+      {
+        "name": "core_inconsistency",
+        "type": "core",
+        "description": "D1G, SelfRef, OmegaCons are jointly inconsistent for every provability predicate",
+        "leanType": "(P : ℕ → Prop) → D1G P → SelfRef P → OmegaCons P → False"
+      },
+      {
+        "name": "no_model_of_all_axioms",
+        "type": "key",
+        "description": "The parent's four-axiom set has no model — First Incompleteness holds vacuously",
+        "leanType": "¬ ∃ P : ℕ → Prop, D1G P ∧ SelfRef P ∧ OmegaCons P ∧ NegGProv P"
+      },
+      {
+        "name": "negGProv_derivable",
+        "type": "key",
+        "description": "The object-level diagonal axiom is derivable from D1G ∧ SelfRef (redundant)",
+        "leanType": "(P : ℕ → Prop) → D1G P → SelfRef P → NegGProv P"
+      }
+    ],
+    "path": "Proofs/GodelFirstIncompletenessOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "core_inconsistency",
+      "type": "core",
+      "description": "Three of the parent's axioms are jointly inconsistent for every P",
+      "leanType": "(P : ℕ → Prop) → D1G P → SelfRef P → OmegaCons P → False"
+    },
+    {
+      "name": "negGProv_derivable",
+      "type": "key",
+      "description": "The fourth axiom is derivable from two others — not independent",
+      "leanType": "(P : ℕ → Prop) → D1G P → SelfRef P → NegGProv P"
+    },
+    {
+      "name": "omegaCons_independent",
+      "type": "key",
+      "description": "ω-consistency is independent of D1G ∧ SelfRef (minimality of the inconsistency)",
+      "leanType": "∃ P : ℕ → Prop, D1G P ∧ SelfRef P ∧ ¬ OmegaCons P"
+    }
+  ],
+  "openQuestions": [
+    "Re-axiomatize with the sound object-level self-reference F ⊢ (G ↔ ¬Prov⌜G⌝) and re-derive First Incompleteness from a consistent set.",
+    "Audit the Rosser and Second-Incompleteness formalizations for the same meta/object conflation.",
+    "Formalize the Diagonal Lemma over explicit syntax so the fixed point is genuinely object-level."
+  ],
+  "references": [
+    {
+      "authors": "Gödel, Kurt",
+      "title": "Über formal unentscheidbare Sätze der Principia Mathematica und verwandter Systeme I",
+      "year": "1931",
+      "venue": "Monatshefte für Mathematik und Physik 38, 173–198",
+      "note": "The original incompleteness theorems and the object-level fixed-point construction"
+    },
+    {
+      "authors": "Boolos, George",
+      "title": "The Logic of Provability",
+      "year": "1993",
+      "venue": "Cambridge University Press",
+      "note": "Provability logic (GL) and the careful object/meta distinction the parent's axiom blurs"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent's third open question — are its five First-Incompleteness axioms independent, or derivable from one another? **They are not independent**, and the analysis surfaces a soundness flaw.

**`GodelFirstIncompletenessOQ01OQ03.lean`** — 143 lines, 6 theorems, 7 defs, **0 sorries, 0 axioms, no `native_decide`** (`#print axioms` → only propext/Classical.choice/Quot.sound).

The four substantive axioms, restricted to the only sentences they mention (G, Prov⌜G⌝, ¬G), become propositional constraints on `p = P(G)`, `q = P(Prov⌜G⌝)`:
- `D1G`: p → q · `SelfRef`: p ↔ ¬q · `OmegaCons`: ¬p → ¬q · `NegGProv`: P(¬G) → q.

### Findings
- `core_inconsistency`: **D1G ∧ SelfRef ∧ OmegaCons → False** for *every* P. (D1+self-ref force ¬p; self-ref makes ¬p give q, ω-consistency makes ¬p give ¬q.)
- `no_model_of_all_axioms`: the parent's axiom set **has no model** — its "non-vacuous" First Incompleteness theorem holds only **vacuously**, the same failure mode (just subtler) as the `Provable := fun _ => False` it set out to avoid.
- `negGProv_derivable`: the object-level diagonal axiom is **derivable** from D1G ∧ SelfRef — redundant.
- `d1G_independent` / `selfRef_independent` / `omegaCons_independent`: the inconsistency is **minimal** — each of the three is independent of the other two (explicit counter-models).

### Root cause
The parent asserted the **meta-level** equivalence `⊢G ↔ ¬⊢Prov⌜G⌝` as an axiom, where only the **object-level** `F ⊢ (G ↔ ¬Prov⌜G⌝)` is sound. The entry's open questions propose the fix.

Stated abstractly over an arbitrary `P : ℕ → Prop`, so it does **not** import the parent's (inconsistent) global axioms.

## Verification
`./proofs/scripts/docker-build.sh Proofs.GodelFirstIncompletenessOQ01OQ03` → Build completed successfully (7743 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)