### PR TITLE
research(erdos-396-…-oq-02-oq-02-oq-02): explicit constants in the 1/2 exponent, bracketing 1/√π

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1652,6 +1652,7 @@ import Proofs.Erdos396OQ04OQ01
 import Proofs.Erdos396OQ04OQ01OQ01
 import Proofs.Erdos396OQ04OQ01OQ01OQ02
 import Proofs.Erdos396OQ04OQ01OQ01OQ02OQ02
+import Proofs.Erdos396OQ04OQ01OQ01OQ02OQ02OQ02
 import Proofs.Erdos396OQ04OQ01OQ01OQ01
 import Proofs.Erdos396OQ04OQ01OQ01OQ03
 import Proofs.Erdos396Problem

--- a/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean
+++ b/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean
@@ -1,0 +1,250 @@
+/-
+# Erdős Problem #396 — OQ-04 → OQ-01 → OQ-01 → OQ-02 → OQ-02 → OQ-02: explicit constants in the `1/2` exponent, bracketing the Wallis constant `1/√π`
+
+The parent entry `Erdos396OQ04OQ01OQ01OQ02OQ02` extracts the `1/2` critical
+exponent of the central binomial coefficient `C(2n,n)` from its two-term
+recurrence: normalising each step by the limiting rate `4` and applying
+`log y ≤ y − 1` telescopes to `C(2n,n)/4^n ≤ exp(−(1/2)·H_n) ∼ n^{−1/2}`,
+with a matching reciprocal lower bracket of the same `1/2` order.  Both brackets
+were *order* statements — they pinned the exponent `1/2` but left the leading
+constant in `C(2n,n) ∼ 4^n/√(π n)` (the analytic Wallis/Stirling number `1/√π`)
+unaddressed.
+
+That entry's first closing open question asked:
+
+> Can one extract **explicit constants** `c₁, c₂` with
+> `c₁·4^n/√n ≤ C(2n,n) ≤ c₂·4^n/√n` directly from the recurrence, isolating
+> the `√π` constant as the only ingredient genuinely requiring an analytic input?
+
+This file answers it affirmatively with completely elementary constants, no
+Stirling and no Wallis limit.  The engine is two **squared** integer bounds,
+each a one-line induction over the recurrence:
+
+  **`centralBinom_sq_lower`** : `16^n ≤ 4·n·C(2n,n)^2`   (for `n ≥ 1`),
+  **`centralBinom_sq_upper`** : `(3n+1)·C(2n,n)^2 ≤ 16^n` (for all `n`).
+
+Writing `a_n = C(2n,n)/4^n` and `16^n = (4^n)^2`, these say
+`(2√n·a_n)^2 ≥ 1` and `(√(3n+1)·a_n)^2 ≤ 1`; taking square roots gives the
+explicit two-sided bound
+
+  **`centralBinom_bracket`** : `(1/2)·4^n/√n ≤ C(2n,n) ≤ (1/√3)·4^n/√n`
+  (for `n ≥ 1`),
+
+so `c₁ = 1/2` and `c₂ = 1/√3` work.  The squared recurrence step is the pair of
+elementary polynomial identities
+
+  `16·(3n+1)·(n+1)^2 − 4·(3n+4)·(2n+1)^2 = 4n ≥ 0`   (upper step),
+  `(2n+1)^2 − 4n·(n+1) = 1 ≥ 0`                       (lower step),
+
+which are exactly the deficits driving the harmonic telescoping of the parent.
+
+Finally **`wallis_constant_bracketed`** records that the *true* constant `1/√π`
+of `C(2n,n) ∼ 4^n/√(π n)` lies strictly between the two elementary constants:
+
+  `1/2 < 1/√π < 1/√3`,
+
+equivalent to `3 < π < 4`.  Thus the recurrence alone brackets the asymptotic
+constant inside `(1/2, 1/√3)`; pinning it to the single value `1/√π` is the
+*only* step that genuinely needs an analytic (Wallis/Stirling) input — precisely
+the dichotomy the open question anticipated.
+
+All theorems are fully machine-checked with no axioms or sorries.
+-/
+
+import Mathlib
+
+open Nat Finset
+
+namespace Erdos396OQ04OQ01OQ01OQ02OQ02OQ02
+
+/-! ## The recurrence over `ℝ`
+
+Mathlib's `Nat.succ_mul_centralBinom_succ` reads `(n+1)·C(2(n+1),n+1) =
+2·(2n+1)·C(2n,n)`.  We cast it to `ℝ` once and square it; everything below is
+driven by this single identity. -/
+
+/-- The central-binomial recurrence over `ℝ`:
+    `(n+1)·C(2(n+1),n+1) = 2·(2n+1)·C(2n,n)`. -/
+theorem cb_rec (n : ℕ) :
+    ((n : ℝ) + 1) * (centralBinom (n + 1) : ℝ)
+      = 2 * (2 * (n : ℝ) + 1) * (centralBinom n : ℝ) := by
+  have h := congrArg (Nat.cast (R := ℝ)) (Nat.succ_mul_centralBinom_succ n)
+  push_cast at h
+  linarith [h]
+
+/-- The **squared** recurrence, the only form used in the inductions:
+    `(n+1)^2·C(2(n+1),n+1)^2 = 4·(2n+1)^2·C(2n,n)^2`. -/
+theorem cb_rec_sq (n : ℕ) :
+    ((n : ℝ) + 1) ^ 2 * (centralBinom (n + 1) : ℝ) ^ 2
+      = 4 * (2 * (n : ℝ) + 1) ^ 2 * (centralBinom n : ℝ) ^ 2 := by
+  have e : (((n : ℝ) + 1) * (centralBinom (n + 1) : ℝ)) ^ 2
+      = (2 * (2 * (n : ℝ) + 1) * (centralBinom n : ℝ)) ^ 2 := by
+    rw [cb_rec]
+  linear_combination e
+
+/-! ## The two squared integer bounds -/
+
+/-- **Upper squared bound.** `(3n+1)·C(2n,n)^2 ≤ 16^n` for every `n`.
+    The induction step is the polynomial identity
+    `16·(3n+1)·(n+1)^2 − 4·(3n+4)·(2n+1)^2 = 4n ≥ 0`. -/
+theorem centralBinom_sq_upper (n : ℕ) :
+    (3 * (n : ℝ) + 1) * (centralBinom n : ℝ) ^ 2 ≤ 16 ^ n := by
+  induction n with
+  | zero => simp [Nat.centralBinom_zero]
+  | succ n ih =>
+    push_cast
+    set x : ℝ := (centralBinom n : ℝ) with hx
+    set y : ℝ := (centralBinom (n + 1) : ℝ) with hy
+    have hN1 : (0 : ℝ) < ((n : ℝ) + 1) ^ 2 := by positivity
+    have hpow : (16 : ℝ) ^ (n + 1) = 16 * 16 ^ n := by rw [pow_succ]; ring
+    -- IH multiplied by the positive factor `16·(n+1)^2`
+    have ih' : 16 * ((n : ℝ) + 1) ^ 2 * ((3 * (n : ℝ) + 1) * x ^ 2)
+        ≤ 16 * ((n : ℝ) + 1) ^ 2 * 16 ^ n :=
+      mul_le_mul_of_nonneg_left ih (by positivity)
+    -- the squared recurrence, pre-multiplied by the step's linear factor `(3n+4)`
+    have hkey : (3 * (n : ℝ) + 4) * (((n : ℝ) + 1) ^ 2 * y ^ 2)
+        = (3 * (n : ℝ) + 4) * (4 * (2 * (n : ℝ) + 1) ^ 2 * x ^ 2) := by
+      rw [cb_rec_sq n]
+    -- target multiplied through by `(n+1)^2`
+    have hmul : (3 * ((n : ℝ) + 1) + 1) * y ^ 2 * ((n : ℝ) + 1) ^ 2
+        ≤ 16 ^ (n + 1) * ((n : ℝ) + 1) ^ 2 := by
+      rw [hpow]
+      nlinarith [ih', hkey, mul_nonneg (Nat.cast_nonneg n) (sq_nonneg x)]
+    exact le_of_mul_le_mul_right hmul hN1
+
+/-- **Lower squared bound.** `16^n ≤ 4·n·C(2n,n)^2` for every `n ≥ 1`.
+    The induction step is the polynomial identity
+    `(2n+1)^2 − 4n·(n+1) = 1 ≥ 0`.  (The bound fails at `n = 0`, where the
+    right-hand side is `0`.) -/
+theorem centralBinom_sq_lower (n : ℕ) (hn : 1 ≤ n) :
+    (16 : ℝ) ^ n ≤ 4 * (n : ℝ) * (centralBinom n : ℝ) ^ 2 := by
+  induction n, hn using Nat.le_induction with
+  | base =>
+    have h1 : centralBinom 1 = 2 := by decide
+    rw [h1]; norm_num
+  | succ n hn ih =>
+    push_cast
+    set x : ℝ := (centralBinom n : ℝ) with hx
+    set y : ℝ := (centralBinom (n + 1) : ℝ) with hy
+    have hN1 : (0 : ℝ) < ((n : ℝ) + 1) ^ 2 := by positivity
+    have hpow : (16 : ℝ) ^ (n + 1) = 16 * 16 ^ n := by rw [pow_succ]; ring
+    have hnR : (0 : ℝ) ≤ (n : ℝ) := Nat.cast_nonneg n
+    -- IH multiplied by the positive factor `16·(n+1)^2`
+    have ih' : 16 * ((n : ℝ) + 1) ^ 2 * 16 ^ n
+        ≤ 16 * ((n : ℝ) + 1) ^ 2 * (4 * (n : ℝ) * x ^ 2) :=
+      mul_le_mul_of_nonneg_left ih (by positivity)
+    -- the squared recurrence, pre-multiplied by the step's linear factor `4(n+1)`
+    have hkey : (4 * ((n : ℝ) + 1)) * (((n : ℝ) + 1) ^ 2 * y ^ 2)
+        = (4 * ((n : ℝ) + 1)) * (4 * (2 * (n : ℝ) + 1) ^ 2 * x ^ 2) := by
+      rw [cb_rec_sq n]
+    have hmul : (16 : ℝ) ^ (n + 1) * ((n : ℝ) + 1) ^ 2
+        ≤ 4 * ((n : ℝ) + 1) * y ^ 2 * ((n : ℝ) + 1) ^ 2 := by
+      rw [hpow]
+      nlinarith [ih', hkey, mul_nonneg (by positivity : (0:ℝ) ≤ (n:ℝ) + 1) (sq_nonneg x)]
+    exact le_of_mul_le_mul_right hmul hN1
+
+/-! ## The explicit real bracket
+
+Square roots of the two bounds give the explicit constants `1/2` and `1/√3`. -/
+
+/-- Positivity of `C(2n,n)` over `ℝ`. -/
+theorem cb_pos (n : ℕ) : (0 : ℝ) < (centralBinom n : ℝ) := by
+  exact_mod_cast Nat.centralBinom_pos n
+
+/-- `16^n = 4^n · 4^n` over `ℝ`. -/
+theorem pow16_eq (n : ℕ) : (16 : ℝ) ^ n = 4 ^ n * 4 ^ n := by
+  rw [show (16 : ℝ) = 4 * 4 by norm_num, mul_pow]
+
+/-- **Explicit lower constant `1/2`.** For `n ≥ 1`, `(1/2)·4^n/√n ≤ C(2n,n)`. -/
+theorem centralBinom_lower_const (n : ℕ) (hn : 1 ≤ n) :
+    (1 / 2) * 4 ^ n / Real.sqrt n ≤ (centralBinom n : ℝ) := by
+  have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+  have hsqrt : (0 : ℝ) < Real.sqrt n := Real.sqrt_pos.mpr hnpos
+  have hsn : (Real.sqrt n) ^ 2 = (n : ℝ) := Real.sq_sqrt hnpos.le
+  rw [div_le_iff₀ hsqrt]
+  -- reduces to `(1/2)·4^n ≤ C·√n`; both sides positive, so compare squares
+  have hcsn : ((centralBinom n : ℝ) * Real.sqrt n) ^ 2
+      = (centralBinom n : ℝ) ^ 2 * (n : ℝ) := by rw [mul_pow, hsn]
+  have hsq : (1 / 2 * 4 ^ n) ^ 2 ≤ ((centralBinom n : ℝ) * Real.sqrt n) ^ 2 := by
+    rw [hcsn]
+    nlinarith [centralBinom_sq_lower n hn, pow16_eq n]
+  have hlpos : (0 : ℝ) < 1 / 2 * 4 ^ n := by positivity
+  have hrpos : (0 : ℝ) ≤ (centralBinom n : ℝ) * Real.sqrt n := by positivity
+  have hsum : (0 : ℝ) < 1 / 2 * 4 ^ n + (centralBinom n : ℝ) * Real.sqrt n :=
+    add_pos_of_pos_of_nonneg hlpos hrpos
+  nlinarith [hsq, hsum]
+
+/-- **Explicit upper constant `1/√3`.** For `n ≥ 1`, `C(2n,n) ≤ (1/√3)·4^n/√n`.
+    (Sharper still — the squared bound gives `C(2n,n) ≤ 4^n/√(3n+1)`.) -/
+theorem centralBinom_upper_const (n : ℕ) (hn : 1 ≤ n) :
+    (centralBinom n : ℝ) ≤ (1 / Real.sqrt 3) * 4 ^ n / Real.sqrt n := by
+  have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+  have hsqrtn : (0 : ℝ) < Real.sqrt n := Real.sqrt_pos.mpr hnpos
+  have hsqrt3 : (0 : ℝ) < Real.sqrt 3 := Real.sqrt_pos.mpr (by norm_num)
+  have hsn : (Real.sqrt n) ^ 2 = (n : ℝ) := Real.sq_sqrt hnpos.le
+  have hs3 : (Real.sqrt 3) ^ 2 = (3 : ℝ) := Real.sq_sqrt (by norm_num)
+  rw [le_div_iff₀ hsqrtn]
+  -- reduces to `C·√n ≤ (1/√3)·4^n`; both sides ≥ 0, so compare squares
+  have hcsn : ((centralBinom n : ℝ) * Real.sqrt n) ^ 2
+      = (centralBinom n : ℝ) ^ 2 * (n : ℝ) := by rw [mul_pow, hsn]
+  have hrhs2 : (1 / Real.sqrt 3 * 4 ^ n) ^ 2 = (1 / 3) * (4 ^ n * 4 ^ n) := by
+    rw [mul_pow, div_pow, one_pow, hs3]; ring
+  have hsq : ((centralBinom n : ℝ) * Real.sqrt n) ^ 2 ≤ (1 / Real.sqrt 3 * 4 ^ n) ^ 2 := by
+    rw [hcsn, hrhs2]
+    nlinarith [centralBinom_sq_upper n, pow16_eq n,
+      mul_nonneg hnpos.le (sq_nonneg (centralBinom n : ℝ)), sq_nonneg (centralBinom n : ℝ)]
+  have hlpos : (0 : ℝ) ≤ (centralBinom n : ℝ) * Real.sqrt n := by positivity
+  have hrpos : (0 : ℝ) < 1 / Real.sqrt 3 * 4 ^ n := by positivity
+  have hsum : (0 : ℝ) < (centralBinom n : ℝ) * Real.sqrt n + 1 / Real.sqrt 3 * 4 ^ n :=
+    add_pos_of_nonneg_of_pos hlpos hrpos
+  nlinarith [hsq, hsum]
+
+/-- **The explicit two-sided bracket.** For `n ≥ 1`,
+    `(1/2)·4^n/√n ≤ C(2n,n) ≤ (1/√3)·4^n/√n`, with the elementary constants
+    `c₁ = 1/2` and `c₂ = 1/√3` produced directly from the recurrence. -/
+theorem centralBinom_bracket (n : ℕ) (hn : 1 ≤ n) :
+    (1 / 2) * 4 ^ n / Real.sqrt n ≤ (centralBinom n : ℝ)
+      ∧ (centralBinom n : ℝ) ≤ (1 / Real.sqrt 3) * 4 ^ n / Real.sqrt n :=
+  ⟨centralBinom_lower_const n hn, centralBinom_upper_const n hn⟩
+
+/-! ## The true constant `1/√π` is bracketed by the elementary constants
+
+`C(2n,n) ∼ 4^n/√(π n)`, so the genuine leading constant is `1/√π`.  The
+recurrence-derived bracket `(1/2, 1/√3)` contains it — and that containment is
+exactly `3 < π < 4`. -/
+
+/-- `√4 = 2`. -/
+private theorem sqrt_four : Real.sqrt 4 = 2 := by
+  rw [show (4 : ℝ) = 2 ^ 2 by norm_num]; exact Real.sqrt_sq (by norm_num)
+
+/-- `1/2 < 1/√π`, equivalently `√π < 2`, equivalently `π < 4`. -/
+theorem half_lt_inv_sqrt_pi : (1 : ℝ) / 2 < 1 / Real.sqrt Real.pi := by
+  have hpi : (0 : ℝ) < Real.pi := Real.pi_pos
+  have hsqrt : (0 : ℝ) < Real.sqrt Real.pi := Real.sqrt_pos.mpr hpi
+  have hlt : Real.sqrt Real.pi < 2 := by
+    rw [← sqrt_four]
+    exact Real.sqrt_lt_sqrt hpi.le (by linarith [Real.pi_lt_four])
+  exact one_div_lt_one_div_of_lt hsqrt hlt
+
+/-- `1/√π < 1/√3`, equivalently `√3 < √π`, equivalently `3 < π`. -/
+theorem inv_sqrt_pi_lt_inv_sqrt_three : 1 / Real.sqrt Real.pi < 1 / Real.sqrt 3 := by
+  have hpi : (0 : ℝ) < Real.pi := Real.pi_pos
+  have hsqrt3 : (0 : ℝ) < Real.sqrt 3 := Real.sqrt_pos.mpr (by norm_num)
+  have hlt : Real.sqrt 3 < Real.sqrt Real.pi :=
+    Real.sqrt_lt_sqrt (by norm_num) (by linarith [Real.pi_gt_three])
+  exact one_div_lt_one_div_of_lt hsqrt3 hlt
+
+/-- **The Wallis/Stirling constant is bracketed.** The elementary constants
+    `1/2` and `1/√3` produced by the recurrence sandwich the true leading
+    constant `1/√π` of `C(2n,n) ∼ 4^n/√(π n)`:
+
+      `1/2 < 1/√π < 1/√3`.
+
+    Equivalently `3 < π < 4`.  Hence the recurrence pins the asymptotic constant
+    to the open interval `(1/2, 1/√3)`; identifying it as exactly `1/√π` is the
+    single step that requires an analytic (Wallis/Stirling) input. -/
+theorem wallis_constant_bracketed :
+    (1 : ℝ) / 2 < 1 / Real.sqrt Real.pi ∧ 1 / Real.sqrt Real.pi < 1 / Real.sqrt 3 :=
+  ⟨half_lt_inv_sqrt_pi, inv_sqrt_pi_lt_inv_sqrt_three⟩
+
+end Erdos396OQ04OQ01OQ01OQ02OQ02OQ02

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02oq02-recsq",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02",
+    "range": { "startLine": 77, "endLine": 84 },
+    "type": "key-step",
+    "title": "Squaring the recurrence",
+    "content": "Mathlib's $\\texttt{Nat.succ\\_mul\\_centralBinom\\_succ}$ gives $(n+1)\\,C(2(n+1),n+1) = 2(2n+1)\\,C(2n,n)$ over $\\mathbb{R}$ (lemma $\\texttt{cb\\_rec}$). Squaring both sides removes the linear factors into squares: $(n+1)^2\\,C(2(n+1),n+1)^2 = 4(2n+1)^2\\,C(2n,n)^2$. This single squared identity, proved with one $\\texttt{linear\\_combination}$, drives every induction below — the square is what lets a $\\sqrt n$ asymptotic become an integer relation.",
+    "mathContext": "$(n+1)^2\\,C(2(n+1),n+1)^2 = 4(2n+1)^2\\,C(2n,n)^2$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02oq02-upper",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02",
+    "range": { "startLine": 90, "endLine": 117 },
+    "type": "key-step",
+    "title": "Upper squared bound (3n+1)·C(2n,n)² ≤ 16ⁿ",
+    "content": "Induction on $n$. The step pre-multiplies the squared recurrence by the linear factor $3n+4$, after which $\\texttt{nlinarith}$ need only verify the polynomial nonnegativity $16(3n+1)(n+1)^2 - 4(3n+4)(2n+1)^2 = 4n \\ge 0$. The base case is the equality $1\\cdot 1 = 1$. This is the squared form of the parent's $1/2$-deficit; the deficit appears here as the integer $4n$.",
+    "mathContext": "$(3n+1)\\,C(2n,n)^2 \\le 16^n$, equivalently $C(2n,n)/4^n \\le 1/\\sqrt{3n+1}$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02oq02-lower",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02",
+    "range": { "startLine": 119, "endLine": 149 },
+    "type": "key-step",
+    "title": "Lower squared bound 16ⁿ ≤ 4n·C(2n,n)²",
+    "content": "$\\texttt{Nat.le\\_induction}$ from base $n=1$ (where $C(2,1)=2$ gives $16 \\le 16$). The step pre-multiplies the squared recurrence by $4(n+1)$, reducing the goal to the polynomial nonnegativity $(2n+1)^2 - 4n(n+1) = 1 \\ge 0$. The bound genuinely fails at $n=0$ (right side $0$), so the hypothesis $n \\ge 1$ is essential.",
+    "mathContext": "$16^n \\le 4n\\,C(2n,n)^2$, equivalently $C(2n,n)/4^n \\ge 1/(2\\sqrt n)$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02oq02-bracket",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02",
+    "range": { "startLine": 159, "endLine": 215 },
+    "type": "key-step",
+    "title": "Taking square roots: the explicit constants 1/2 and 1/√3",
+    "content": "Each squared bound becomes a bound on $C(2n,n)$ by comparing squares of nonnegative reals: from $16^n = (4^n)^2$ and the integer bounds, $\\tfrac12\\,4^n/\\sqrt n \\le C(2n,n) \\le \\tfrac{1}{\\sqrt3}\\,4^n/\\sqrt n$. The upper constant uses $\\sqrt{3n+1} \\ge \\sqrt 3\\,\\sqrt n$. These are the explicit constants $c_1 = 1/2$, $c_2 = 1/\\sqrt3$ requested by the parent's open question — produced directly from the recurrence, with no Stirling.",
+    "mathContext": "$\\dfrac{1}{2}\\cdot\\dfrac{4^n}{\\sqrt n} \\le C(2n,n) \\le \\dfrac{1}{\\sqrt 3}\\cdot\\dfrac{4^n}{\\sqrt n}$."
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq02oq02oq02-wallis",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02",
+    "range": { "startLine": 221, "endLine": 249 },
+    "type": "insight",
+    "title": "The Wallis constant 1/√π is bracketed — and that is just 3 < π < 4",
+    "content": "The genuine asymptotic constant of $C(2n,n) \\sim 4^n/\\sqrt{\\pi n}$ is $1/\\sqrt\\pi \\approx 0.564$. It lies strictly inside the elementary bracket: $\\tfrac12 < 1/\\sqrt\\pi < 1/\\sqrt3$. By monotonicity of $\\sqrt{\\cdot}$ this is exactly $3 < \\pi < 4$, supplied by $\\texttt{Real.pi\\_gt\\_three}$ and $\\texttt{Real.pi\\_lt\\_four}$. So the recurrence pins the constant to $(1/2, 1/\\sqrt3) \\approx (0.500, 0.577)$, and identifying it as precisely $1/\\sqrt\\pi$ is the single step that requires an analytic (Wallis/Stirling) input — the dichotomy the parent's open question anticipated.",
+    "mathContext": "$\\tfrac12 < \\tfrac{1}{\\sqrt\\pi} < \\tfrac{1}{\\sqrt3} \\iff 3 < \\pi < 4$."
+  }
+]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02/meta.json
@@ -1,0 +1,82 @@
+{
+  "id": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02",
+  "slug": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02",
+  "title": "Erdős #396 OQ-04 → OQ-01 → OQ-01 → OQ-02 → OQ-02 → OQ-02: Explicit Constants in the 1/2 Exponent, Bracketing the Wallis Constant 1/√π",
+  "description": "The parent entry pinned the 1/2 critical exponent of the central binomial coefficient C(2n,n) from its recurrence, but only as an order statement: it fixed the power n^{−1/2} in C(2n,n) ∼ 4^n/√(πn) while leaving the leading constant 1/√π untouched. Its first closing open question asked whether explicit constants c₁, c₂ with c₁·4^n/√n ≤ C(2n,n) ≤ c₂·4^n/√n can be extracted directly from the recurrence, isolating √π as the only genuinely analytic ingredient. This entry answers it with completely elementary constants and no Stirling/Wallis limit. The engine is two squared integer bounds, each a one-line induction over the recurrence: 16^n ≤ 4n·C(2n,n)^2 (n ≥ 1) and (3n+1)·C(2n,n)^2 ≤ 16^n. Writing 16^n = (4^n)^2 and taking square roots gives (1/2)·4^n/√n ≤ C(2n,n) ≤ (1/√3)·4^n/√n, so c₁ = 1/2 and c₂ = 1/√3. The induction steps are the polynomial identities 16(3n+1)(n+1)^2 − 4(3n+4)(2n+1)^2 = 4n ≥ 0 (upper) and (2n+1)^2 − 4n(n+1) = 1 ≥ 0 (lower) — exactly the deficits driving the parent's harmonic telescoping. Finally the true constant 1/√π is shown to lie strictly between the two elementary constants: 1/2 < 1/√π < 1/√3, equivalent to 3 < π < 4. Hence the recurrence alone brackets the asymptotic constant inside (1/2, 1/√3); pinning it to exactly 1/√π is the single step requiring an analytic input.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "Erdos396OQ04OQ01OQ01OQ02OQ02OQ02",
+    "lineCount": 250,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/396",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "central-binomial",
+      "recurrence",
+      "asymptotics",
+      "critical-exponent",
+      "explicit-constants",
+      "wallis-constant",
+      "pi-bounds",
+      "induction"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 396,
+    "erdosUrl": "https://erdosproblems.com/396",
+    "axiomCount": 0,
+    "lineCount": 250,
+    "assumptions": "0 axioms, 0 sorries. All results depend only on the foundational axioms propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool / native_decide). Built against Mathlib 4.26.0.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 13,
+    "definitionCount": 0
+  },
+  "overview": "{\"historicalContext\":\"The central-binomial thread reads the two-term recurrence (n+1)C(2(n+1),n+1) = 2(2n+1)C(2n,n) as a multiplicative step with limiting rate 4 and tracks its deficit. The parent extracted the 1/2 critical exponent of C(2n,n) ∼ 4^n/√(πn) by exponentiating the harmonic deficit sum: it pinned the power n^{−1/2} but, being a logarithm-of-harmonic-sum estimate, said nothing about the leading constant 1/√π. The classical route to that constant is the Wallis product / Stirling's formula. This entry shows the recurrence by itself already brackets the constant in an explicit elementary interval, and that closing the bracket to the single value 1/√π is precisely the lone analytic step the parent's open question anticipated.\",\"keyInsights\":[\"Squaring removes the square root from the asymptotic: the bound C(2n,n) ∼ c·4^n/√n is equivalent to (√n·C(2n,n)/4^n)^2 ≈ c^2, an inequality between the integers 16^n = (4^n)^2 and multiples of C(2n,n)^2, provable by clean induction.\",\"The two induction steps reduce to the elementary polynomial nonnegativities 16(3n+1)(n+1)^2 − 4(3n+4)(2n+1)^2 = 4n ≥ 0 (upper) and (2n+1)^2 − 4n(n+1) = 1 ≥ 0 (lower) — the same recurrence deficits that drive the parent's harmonic telescoping, here in squared form.\",\"The explicit constants c₁ = 1/2 and c₂ = 1/√3 bracket the true Wallis/Stirling constant 1/√π, and the containment 1/2 < 1/√π < 1/√3 is exactly the statement 3 < π < 4.\",\"No Stirling and no Wallis limit are used anywhere: the only transcendental input is the comparison of π with the integers 3 and 4.\"],\"prerequisites\":[\"The central binomial recurrence Nat.succ_mul_centralBinom_succ\",\"Real square roots: Real.sq_sqrt, Real.sqrt_lt_sqrt, Real.sqrt_pos\",\"Elementary π bounds Real.pi_gt_three and Real.pi_lt_four\",\"Induction (plain and Nat.le_induction) and nlinarith for polynomial certificates\"],\"problemStatement\":\"Erdős #396 concerns descending factorials dividing central binomial coefficients. This descendant entry sharpens the parent's 1/2-exponent statement into explicit two-sided constants for C(2n,n)/4^n, and locates the analytic Wallis constant 1/√π relative to those constants.\",\"proofStrategy\":\"Cast the recurrence to ℝ and square it once (cb_rec, cb_rec_sq). Prove the two squared integer bounds by induction, each step pre-multiplying the squared recurrence by the relevant linear factor so nlinarith only has to verify a polynomial nonnegativity. Take square roots (comparing squares of nonnegative reals) to obtain the explicit real bracket (1/2)·4^n/√n ≤ C(2n,n) ≤ (1/√3)·4^n/√n. Finally bracket 1/√π between 1/2 and 1/√3 via 3 < π < 4.\",\"text\":\"The parent's logarithmic telescoping fixed the exponent 1/2 but discarded the constant. Squaring the target asymptotic turns the √n into an integer relation, and the central-binomial recurrence — squared — drives a two-line induction that bounds C(2n,n)^2 between explicit rational multiples of 16^n. Square roots restore the √n and produce honest constants 1/2 and 1/√3. The genuine asymptotic constant 1/√π sits strictly inside this elementary bracket, and that fact is nothing more than 3 < π < 4: the recurrence does all the work up to identifying the single number π, which is where (and only where) an analytic input is required.\"}",
+  "conclusion": {
+    "summary": "Two squared integer bounds derived by induction from the central-binomial recurrence — 16^n ≤ 4n·C(2n,n)^2 (n ≥ 1) and (3n+1)·C(2n,n)^2 ≤ 16^n — yield, after taking square roots, the explicit two-sided estimate (1/2)·4^n/√n ≤ C(2n,n) ≤ (1/√3)·4^n/√n. This answers the parent's open question with the elementary constants c₁ = 1/2 and c₂ = 1/√3, obtained directly from the recurrence with no Stirling or Wallis input. The true leading constant 1/√π of C(2n,n) ∼ 4^n/√(πn) is then shown to lie strictly between them: 1/2 < 1/√π < 1/√3, equivalently 3 < π < 4. All thirteen theorems are fully machine-checked with no axioms or sorries.",
+    "implications": "The entry sharpens the parent's order-only 1/2 exponent into honest explicit constants and isolates exactly where analysis is unavoidable. The squared-bound technique — replace the √n asymptotic by an integer inequality, prove it by induction on the squared recurrence, then take roots — is reusable for any sequence with a two-term hypergeometric recurrence whose constant one wants to bracket without Stirling. The dichotomy is sharp: the recurrence pins the constant to the open interval (1/2, 1/√3) ≈ (0.500, 0.577), and the genuine value 1/√π ≈ 0.564 is recovered only by the analytic comparison 3 < π < 4.",
+    "openQuestions": [
+      "The bracket (1/2, 1/√3) comes from the crude constants in 4^n/√(3n+1) ≤ C(2n,n)... and 4^n/(2√n) ≤ C(2n,n). Iterating the squared recurrence with a sharper inductive invariant (e.g. (4n+1)·C(2n,n)^2 ≤ 16^n / matching lower) should tighten the interval around 1/√π; what is the optimal one-parameter family of squared bounds, and does its limit reproduce the Wallis product?",
+      "Does the same squared-recurrence-plus-roots scheme give explicit constants for the Catalan asymptotic catalan n ∼ 4^n/(√π·n^{3/2}), bracketing its constant 1/√π via 3 < π < 4 in one parallel induction, thereby unifying the constants of both threads through C(2n,n) = (n+1)·catalan n?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+      "relationship": "parent",
+      "description": "Parent OQ: extracts the 1/2 critical exponent of C(2n,n) from the recurrence as an order statement (C(2n,n)/4^n ≤ exp(−(1/2)H_n) ∼ n^{−1/2}). This entry answers that file's first closing open question by producing explicit constants 1/2 and 1/√3 with c₁·4^n/√n ≤ C(2n,n) ≤ c₂·4^n/√n and bracketing the Wallis constant 1/√π between them."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01-oq-02",
+      "relationship": "ancestor",
+      "description": "The Catalan 3/2-exponent sibling whose own open question seeded the parent. The Catalan asymptotic constant is likewise 1/√π, and the present squared-bound method is proposed to bracket it in a parallel induction (open question 2)."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01",
+      "relationship": "ancestor",
+      "description": "Grandparent OQ: the asymptotics of the recurrence ratio. The squared central-binomial recurrence used here is the squared form of the ratio s n = 4 − 2/(n+1) studied there."
+    },
+    {
+      "targetId": "erdos-396",
+      "relationship": "ancestor",
+      "description": "Root problem: descending factorials dividing central binomial coefficients. C(2n,n) is the root object; this entry gives explicit two-sided control on its growth."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first closing open question** of the merged parent entry #27514 (the `1/2` critical exponent of the central binomial coefficient):

> Can one extract **explicit constants** `c₁, c₂` with `c₁·4ⁿ/√n ≤ C(2n,n) ≤ c₂·4ⁿ/√n` directly from the recurrence, isolating `√π` as the only ingredient genuinely requiring an analytic input?

**Yes**, with completely elementary constants and no Stirling / Wallis limit.

## What it proves

Two **squared integer bounds**, each a one-line induction over the squared recurrence `(n+1)²·C(2(n+1),n+1)² = 4(2n+1)²·C(2n,n)²`:

| theorem | statement | induction-step polynomial |
|---|---|---|
| `centralBinom_sq_lower` | `16ⁿ ≤ 4n·C(2n,n)²` (n≥1) | `(2n+1)² − 4n(n+1) = 1 ≥ 0` |
| `centralBinom_sq_upper` | `(3n+1)·C(2n,n)² ≤ 16ⁿ` | `16(3n+1)(n+1)² − 4(3n+4)(2n+1)² = 4n ≥ 0` |

Since `16ⁿ = (4ⁿ)²`, taking square roots gives the explicit bracket

```
centralBinom_bracket :  (1/2)·4ⁿ/√n  ≤  C(2n,n)  ≤  (1/√3)·4ⁿ/√n     (n ≥ 1)
```

so `c₁ = 1/2`, `c₂ = 1/√3` — produced directly from the recurrence.

Finally `wallis_constant_bracketed`: the **true** constant `1/√π` of `C(2n,n) ∼ 4ⁿ/√(πn)` lies strictly between the two elementary constants,

```
1/2 < 1/√π < 1/√3      ⟺      3 < π < 4
```

(`Real.pi_gt_three`, `Real.pi_lt_four`). The recurrence pins the asymptotic constant to `(1/2, 1/√3) ≈ (0.500, 0.577)`; identifying it as exactly `1/√π ≈ 0.564` is the single step that requires an analytic (Wallis/Stirling) input — exactly the dichotomy the open question anticipated.

## Verification

- 250 lines, 13 theorems, 0 definitions
- **0 axioms, 0 sorries, no `native_decide`** (depends only on `propext`/`Classical.choice`/`Quot.sound`)
- Builds against Mathlib 4.26.0 via `./proofs/scripts/docker-build.sh Proofs.Erdos396OQ04OQ01OQ01OQ02OQ02OQ02`
- Self-contained (`import Mathlib` only)
- Gallery data added under `src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)