### PR TITLE
research(erdos-1007-oq-05-oq-01): foundations of the graph dimension

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -912,6 +912,7 @@ import Proofs.Erdos1007OQ01
 import Proofs.Erdos1007OQ01Aristotle
 import Proofs.Erdos1007OQ01OQ01
 import Proofs.Erdos1007OQ05
+import Proofs.Erdos1007OQ05OQ01
 import Proofs.Erdos1007Problem
 import Proofs.Erdos1008OQ01
 import Proofs.Erdos1008OQ04

--- a/proofs/Proofs/Erdos1007OQ05OQ01.lean
+++ b/proofs/Proofs/Erdos1007OQ05OQ01.lean
@@ -1,0 +1,109 @@
+import Mathlib
+
+/-!
+# Erdős #1007 OQ-05 / OQ-01: Foundations of the Graph Dimension
+
+## Context
+
+`Erdos1007OQ05.lean` studies the **graph dimension** — the minimum Euclidean dimension `n` in
+which a graph has a unit-distance embedding (`UnitDistanceEmbedding`). Its first open question
+asks whether `min_edges_dimension_4` can be approached **computationally**, by enumerating small
+graphs and checking their dimension. Any such procedure needs the basic monotonicity and bound
+facts about unit embeddings — which the parent never establishes. This file supplies them.
+
+## What this file proves
+
+* `embedding_mono` / `hasUnitEmbedding_mono`: **monotonicity** — a graph embeddable in `ℝⁿ` is
+  embeddable in `ℝᵐ` for every `m ≥ n` (pad the extra coordinates with `0`). So the set of
+  admissible dimensions is up-closed, and the dimension is the *minimum* of an up-set.
+* `hasUnitEmbedding_zero_of_edgeless`: the edgeless graph embeds in `ℝ⁰` (dimension `0`).
+* `no_edge_of_hasUnitEmbedding_zero`: conversely, a graph embeddable in `ℝ⁰` has **no edges** —
+  an edge would need two points at distance `1` in a `0`-dimensional space, impossible. So
+  dimension `0` ⟺ edgeless.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`. The `UnitDistanceEmbedding`
+structure and `hasUnitEmbedding` predicate mirror `Erdos1007Problem.lean`, reproduced locally
+because that file is currently bit-rotted under the 4.26.0 toolchain (`Nat.find` `DecidablePred`
+synthesis and `LT V` failures) and cannot be imported. These results are about `hasUnitEmbedding`
+directly and use no axioms.
+-/
+
+namespace Erdos1007OQ05OQ01
+
+open Finset
+
+/-- A unit-distance embedding of a graph in `ℝⁿ` (mirrors `Erdos1007Problem.UnitDistanceEmbedding`). -/
+structure UnitDistanceEmbedding (V : Type*) (adj : V → V → Prop) (n : ℕ) where
+  embed : V → Fin n → ℝ
+  unit_edges : ∀ u v, adj u v →
+    Real.sqrt (Finset.univ.sum fun i => (embed u i - embed v i) ^ 2) = 1
+
+/-- A graph can be embedded as unit distances in `ℝⁿ`. -/
+def hasUnitEmbedding (V : Type*) (adj : V → V → Prop) (n : ℕ) : Prop :=
+  Nonempty (UnitDistanceEmbedding V adj n)
+
+/-- **Monotonicity of unit embeddings.** A unit-distance embedding in `ℝⁿ` extends to one in
+    `ℝᵐ` for any `m ≥ n` by padding the new coordinates with `0` (distances are unchanged). -/
+def embedding_mono {V : Type*} {adj : V → V → Prop} {n m : ℕ} (hnm : n ≤ m)
+    (e : UnitDistanceEmbedding V adj n) : UnitDistanceEmbedding V adj m := by
+  classical
+  refine ⟨fun v i => if h : (i : ℕ) < n then e.embed v ⟨i, h⟩ else 0, ?_⟩
+  intro u v huv
+  set G : ℕ → ℝ := fun j =>
+    ((if h : j < n then e.embed u ⟨j, h⟩ else 0) - (if h : j < n then e.embed v ⟨j, h⟩ else 0)) ^ 2
+    with hG
+  have hGzero : ∀ j ∈ range m, j ∉ range n → G j = 0 := by
+    intro j _ hj
+    simp only [mem_range, not_lt] at hj
+    simp only [hG, dif_neg (not_lt.mpr hj), sub_zero]
+    ring
+  have hsub : range n ⊆ range m := fun x hx =>
+    Finset.mem_range.mpr (lt_of_lt_of_le (Finset.mem_range.mp hx) hnm)
+  have hsum : (∑ i : Fin m, G (i : ℕ)) = ∑ i : Fin n, (e.embed u i - e.embed v i) ^ 2 := by
+    rw [Fin.sum_univ_eq_sum_range G m,
+      (Finset.sum_subset hsub hGzero).symm,
+      ← Fin.sum_univ_eq_sum_range G n]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    simp only [hG, dif_pos i.isLt, Fin.eta]
+  rw [hsum]
+  exact e.unit_edges u v huv
+
+/-- Monotonicity at the level of `hasUnitEmbedding`. -/
+theorem hasUnitEmbedding_mono {V : Type*} {adj : V → V → Prop} {n m : ℕ} (hnm : n ≤ m)
+    (h : hasUnitEmbedding V adj n) : hasUnitEmbedding V adj m :=
+  h.elim fun e => ⟨embedding_mono hnm e⟩
+
+/-- The edgeless graph embeds in `ℝ⁰`: there are no edge constraints to satisfy. -/
+theorem hasUnitEmbedding_zero_of_edgeless {V : Type*} {adj : V → V → Prop}
+    (h : ∀ u v, ¬ adj u v) : hasUnitEmbedding V adj 0 :=
+  ⟨⟨fun _ _ => 0, fun u v huv => absurd huv (h u v)⟩⟩
+
+/-- Conversely, a graph embeddable in `ℝ⁰` has no edges: an edge would force two points at
+    distance `1` in a `0`-dimensional space, but every distance there is `0`. -/
+theorem no_edge_of_hasUnitEmbedding_zero {V : Type*} {adj : V → V → Prop}
+    (h : hasUnitEmbedding V adj 0) : ∀ u v, ¬ adj u v := by
+  obtain ⟨e⟩ := h
+  intro u v huv
+  have hone := e.unit_edges u v huv
+  simp only [Finset.univ_eq_empty, Finset.sum_empty, Real.sqrt_zero] at hone
+  exact absurd hone (by norm_num)
+
+/-- **Dimension `0` ⟺ edgeless.** A graph embeds in `ℝ⁰` exactly when it has no edges. -/
+theorem hasUnitEmbedding_zero_iff_edgeless {V : Type*} {adj : V → V → Prop} :
+    hasUnitEmbedding V adj 0 ↔ ∀ u v, ¬ adj u v :=
+  ⟨no_edge_of_hasUnitEmbedding_zero, hasUnitEmbedding_zero_of_edgeless⟩
+
+end Erdos1007OQ05OQ01
+
+/-!
+## Summary
+
+Basic structure of the graph dimension, prerequisite to any computational dimension check:
+
+- `embedding_mono` / `hasUnitEmbedding_mono`: unit-embeddability is monotone in the dimension
+  (pad coordinates with `0`), so the admissible dimensions form an up-set.
+- `hasUnitEmbedding_zero_iff_edgeless`: a graph embeds in `ℝ⁰` iff it is edgeless — the base case
+  of the dimension.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/

--- a/src/data/proofs/erdos-1007-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1007-oq-05-oq-01/annotations.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "ann-mono",
+    "proofId": "erdos-1007-oq-05-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 70
+    },
+    "type": "insight",
+    "title": "Padding With Zeros Preserves Distances",
+    "content": "`embedding_mono` extends a unit-distance embedding from ℝⁿ to ℝᵐ (m ≥ n) by sending each new coordinate to 0. The squared distance is unchanged because the appended coordinates contribute (0−0)² = 0. Formally, both coordinate sums are rewritten to Finset.range sums (Fin.sum_univ_eq_sum_range) and the range-m sum collapses to the range-n sum via Finset.sum_subset, the dropped terms vanishing. Consequently `hasUnitEmbedding_mono`: embeddability is monotone in the ambient dimension, so the admissible dimensions form an up-set and the graph dimension is its minimum."
+  },
+  {
+    "id": "ann-base",
+    "proofId": "erdos-1007-oq-05-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 100
+    },
+    "type": "concept",
+    "title": "Dimension 0 Means Edgeless",
+    "content": "`hasUnitEmbedding_zero_iff_edgeless` characterizes the base of the dimension hierarchy. An edgeless graph embeds in ℝ⁰ trivially (the unit-distance condition is vacuous). Conversely, if a graph embeds in ℝ⁰ then any edge would force √(∑ over Fin 0 of squared differences) = √0 = 0 to equal 1 — impossible. So a graph has dimension 0 exactly when it has no edges, the starting point for any inductive or computational analysis of higher dimensions."
+  }
+]

--- a/src/data/proofs/erdos-1007-oq-05-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05-oq-01/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "erdos-1007-oq-05-oq-01",
+  "title": "Foundations of the Graph Dimension: Monotonicity and the Edgeless Base Case",
+  "slug": "erdos-1007-oq-05-oq-01",
+  "description": "Toward the parent's first open question (a computational approach to min_edges_dimension_4 via graph enumeration), this entry supplies the structural facts about unit-distance embeddings that any dimension-checking procedure needs but the parent never establishes: monotonicity of embeddability (a graph embeddable in ℝⁿ embeds in ℝᵐ for m≥n by padding coordinates with 0), so the admissible dimensions form an up-set; and the base case — a graph embeds in ℝ⁰ exactly when it is edgeless (an edge would need two points at distance 1 in 0 dimensions).",
+  "meta": {
+    "author": "Paul Erdős (problem #1007); formalized in Lean 4",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1007OQ05OQ01.lean",
+    "tags": [
+      "graph-theory",
+      "metric-geometry",
+      "unit-distance",
+      "graph-dimension",
+      "erdos-problem",
+      "euclidean-embedding"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 109,
+    "theoremCount": 4,
+    "definitionCount": 4,
+    "originalContributions": [
+      "embedding_mono: a unit-distance embedding in ℝⁿ extends to ℝᵐ for any m≥n by padding the new coordinates with 0 (squared distances unchanged).",
+      "hasUnitEmbedding_mono: unit-embeddability is monotone in the dimension — the admissible dimensions form an up-set, so the dimension is the minimum of an up-set.",
+      "hasUnitEmbedding_zero_of_edgeless / no_edge_of_hasUnitEmbedding_zero: a graph embeds in ℝ⁰ iff it has no edges.",
+      "hasUnitEmbedding_zero_iff_edgeless: the base case dimension 0 ⟺ edgeless."
+    ],
+    "prerequisites": [
+      "Unit-distance embeddings of graphs and the graph (Euclidean) dimension",
+      "Finset sums and coordinate padding in Lean 4/Mathlib"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Fin.sum_univ_eq_sum_range",
+        "description": "∑ over Fin n equals ∑ over range n — converts the padded coordinate sums for comparison",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      },
+      {
+        "theorem": "Finset.sum_subset",
+        "description": "a sum over a subset equals the larger sum when the extra terms vanish — drops the padded (zero) coordinates",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The (Euclidean) dimension of a graph is the least n for which the graph has a unit-distance embedding in ℝⁿ — vertices placed so that adjacent ones are at distance exactly 1. Erdős, Harary, and Tutte introduced the notion, and determining the minimum number of edges of a graph of a given dimension is a hard extremal question: House (2013) proved a 4-dimensional graph has at least 9 edges, with K_{3,3} the unique minimizer, and Chaffee–Noble (2016) handled dimension 5. The gallery's Erdős #1007 thread records these as axioms.\n\nThe parent's first open question asks whether the dimension-4 bound can instead be obtained computationally, by enumerating the finitely many small graphs and checking each one's dimension. Such an enumeration rests on basic facts about the dimension that the formalization had not proved: that embeddability only improves with more ambient dimensions, and what the smallest dimension (0) means. This entry establishes exactly those foundations.",
+    "problemStatement": "**Open Question (parent erdos-1007-oq-05, OQ-01)**: can min_edges_dimension_4 be approached computationally — enumerate graphs with ≤ 8 edges and check dimensions?\n\n**This entry**: supplies the prerequisite structure of the graph dimension — monotonicity of unit-embeddability and the edgeless characterization of dimension 0.",
+    "text": "A 109-line, fully verified (0 sorries, 0 axioms, no native_decide) file. It reproduces the parent's UnitDistanceEmbedding structure and hasUnitEmbedding predicate, then proves embedding_mono (padding extends an embedding to higher dimension), hasUnitEmbedding_mono, the two directions hasUnitEmbedding_zero_of_edgeless and no_edge_of_hasUnitEmbedding_zero, and the combined hasUnitEmbedding_zero_iff_edgeless.",
+    "proofStrategy": "embedding_mono pads the embedding map: the new map sends coordinate i to the old coordinate if i < n and to 0 otherwise. The padded squared distance equals the original because the extra coordinates contribute (0−0)² = 0; formally, both coordinate sums are rewritten to Finset.range sums (Fin.sum_univ_eq_sum_range) and the range-m sum reduces to the range-n sum via Finset.sum_subset (the dropped terms vanish). For the base case, the edgeless graph embeds in ℝ⁰ with the trivial map (unit_edges is vacuous), and conversely an edge in ℝ⁰ forces √(∑ over Fin 0) = √0 = 0 = 1, a contradiction.",
+    "keyInsights": [
+      "Unit-embeddability is monotone in the ambient dimension: padding with zero coordinates never changes a distance, so ℝⁿ-embeddability implies ℝᵐ-embeddability for m ≥ n.",
+      "Hence the set of dimensions in which a graph embeds is an up-set, and the graph dimension is its minimum — the well-definedness any dimension computation relies on.",
+      "Dimension 0 is the base case: only the edgeless graph embeds in ℝ⁰, because any edge would demand two points at distance 1 where all distances are 0.",
+      "The padding argument is a clean coordinate-sum reindexing (Fin → range, then drop the vanishing tail), needing no geometry beyond 'extra zero coordinates cost nothing'.",
+      "These foundations are exactly what a computational enumeration of small graphs and their dimensions must assume."
+    ]
+  },
+  "sections": [
+    {
+      "id": "monotonicity",
+      "title": "Monotonicity of Embeddability",
+      "startLine": 44,
+      "endLine": 76,
+      "summary": "embedding_mono (pad an ℝⁿ embedding to ℝᵐ, m≥n) and hasUnitEmbedding_mono.",
+      "mathContext": "Admissible dimensions form an up-set; the dimension is its minimum."
+    },
+    {
+      "id": "base-case",
+      "title": "The Edgeless Base Case",
+      "startLine": 78,
+      "endLine": 100,
+      "summary": "hasUnitEmbedding_zero_of_edgeless, no_edge_of_hasUnitEmbedding_zero, hasUnitEmbedding_zero_iff_edgeless.",
+      "mathContext": "A graph embeds in ℝ⁰ iff it has no edges."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry establishes the structural foundations of the graph dimension that a computational approach to min_edges_dimension_4 requires: unit-embeddability is monotone in the ambient dimension (so the admissible dimensions form an up-set), and a graph embeds in ℝ⁰ exactly when it is edgeless.",
+    "implications": "Monotonicity makes the graph dimension well-behaved as the minimum of an up-set and lets any enumeration restrict attention to the least admissible dimension; the edgeless characterization fixes the base of the dimension hierarchy. Together they are the groundwork for a verified dimension-checking procedure on small graphs, the route the parent's open question proposes toward House's 4-dimensional bound.",
+    "openQuestions": [
+      "Build a decidable dimension-checking procedure for explicit small graphs (the parent's computational route to min_edges_dimension_4).",
+      "Prove an upper bound graphDimension ≤ |V| from the scaled-basis embedding (Erdos1007OQ05.hasUnitEmbedding_exists_irr).",
+      "Characterize dimension ≤ 1 (paths/matchings) as the next case above the edgeless base."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1007-oq-05",
+      "relationship": "extends",
+      "description": "Parent: graph-dimension axiom-elimination analysis. This entry supplies the monotonicity and base-case foundations its first open question needs."
+    },
+    {
+      "targetId": "erdos-1007",
+      "relationship": "related",
+      "description": "Root: Erdős Problem #1007 on graph dimension."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos1007OQ05OQ01",
+    "lineCount": 109,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 4,
+    "mainTheorems": [
+      {
+        "name": "hasUnitEmbedding_mono",
+        "type": "core",
+        "description": "Unit-embeddability is monotone in the ambient dimension",
+        "leanType": "{V : Type*} → {adj : V → V → Prop} → {n m : ℕ} → n ≤ m → hasUnitEmbedding V adj n → hasUnitEmbedding V adj m"
+      },
+      {
+        "name": "hasUnitEmbedding_zero_iff_edgeless",
+        "type": "key",
+        "description": "A graph embeds in ℝ⁰ iff it is edgeless",
+        "leanType": "{V : Type*} → {adj : V → V → Prop} → (hasUnitEmbedding V adj 0 ↔ ∀ u v, ¬ adj u v)"
+      },
+      {
+        "name": "embedding_mono",
+        "type": "key",
+        "description": "Pad a ℝⁿ unit embedding to ℝᵐ for m ≥ n",
+        "leanType": "{V : Type*} → {adj : V → V → Prop} → {n m : ℕ} → n ≤ m → UnitDistanceEmbedding V adj n → UnitDistanceEmbedding V adj m"
+      }
+    ],
+    "path": "Proofs/Erdos1007OQ05OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "hasUnitEmbedding_mono",
+      "type": "core",
+      "description": "Monotonicity of unit-embeddability in the ambient dimension",
+      "leanType": "{V : Type*} → {adj : V → V → Prop} → {n m : ℕ} → n ≤ m → hasUnitEmbedding V adj n → hasUnitEmbedding V adj m"
+    },
+    {
+      "name": "hasUnitEmbedding_zero_iff_edgeless",
+      "type": "key",
+      "description": "Dimension-0 base case: embeds in ℝ⁰ iff edgeless",
+      "leanType": "{V : Type*} → {adj : V → V → Prop} → (hasUnitEmbedding V adj 0 ↔ ∀ u v, ¬ adj u v)"
+    },
+    {
+      "name": "embedding_mono",
+      "type": "key",
+      "description": "Coordinate-padding extends an embedding to higher dimension",
+      "leanType": "{V : Type*} → {adj : V → V → Prop} → {n m : ℕ} → n ≤ m → UnitDistanceEmbedding V adj n → UnitDistanceEmbedding V adj m"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul; Harary, Frank; Tutte, William T.",
+      "title": "On the dimension of a graph",
+      "year": "1965",
+      "venue": "Mathematika 12, 118–122",
+      "note": "Introduces the Euclidean dimension of a graph"
+    },
+    {
+      "authors": "House, John",
+      "title": "A 4-dimensional graph has at least 9 edges",
+      "year": "2013",
+      "venue": "Discrete Mathematics 313(18), 1783–1789",
+      "note": "The min_edges_dimension_4 result the parent's open question targets computationally"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Toward the parent's **OQ-01** (a *computational* route to `min_edges_dimension_4` by enumerating small graphs and checking dimensions), this PR supplies the structural facts about unit-distance embeddings that any such procedure needs — but the parent never established.

**`Erdos1007OQ05OQ01.lean`** — 109 lines, 4 theorems, 4 defs, **0 sorries, 0 axioms, no `native_decide`**.

- `embedding_mono` / `hasUnitEmbedding_mono`: **monotonicity** — a graph embeddable in ℝⁿ embeds in ℝᵐ for every m ≥ n (pad new coordinates with 0; distances are unchanged). So the admissible dimensions form an **up-set** and the graph dimension is its minimum.
- `hasUnitEmbedding_zero_iff_edgeless`: **dimension 0 ⟺ edgeless** — a graph embeds in ℝ⁰ iff it has no edges (an edge would need two points at distance 1 in 0 dimensions).

## Honest scope
This is the groundwork (monotonicity + base case), not the deep House (2013) bound itself — building the actual dimension-checking procedure is the documented next step.

## Note
Self-contained: `UnitDistanceEmbedding`/`hasUnitEmbedding` mirror `Erdos1007Problem.lean`, reproduced locally because that file is **currently bit-rotted** under 4.26.0 (`Nat.find` `DecidablePred` / `LT V` synthesis failures) and can't be imported.

## Verification
`./proofs/scripts/docker-build.sh Proofs.Erdos1007OQ05OQ01` → Build completed successfully (7743 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)