### PR TITLE
research(pell-equation-oq-02): the size of the fundamental Pell solution

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3117,6 +3117,7 @@ import Proofs.PascalsHexagonOQ02
 import Proofs.PascalsHexagonOQ03
 import Proofs.PellEquation
 import Proofs.PellEquationOQ01
+import Proofs.PellEquationOQ02
 import Proofs.PellEquationOQ05
 import Proofs.PellEquationOQ06
 import Proofs.PellEquationOQ06OQ01

--- a/proofs/Proofs/PellEquationOQ02.lean
+++ b/proofs/Proofs/PellEquationOQ02.lean
@@ -1,0 +1,105 @@
+import Mathlib
+
+/-!
+# Pell's Equation OQ-02: The Size of the Fundamental Solution
+
+## The Open Question
+
+The parent (`PellEquation.lean`) records open questions about the **size of the fundamental
+solution** of `x² − D y² = 1`: heuristically `log(x₁ + y₁√D) ≈ √D`, but the distribution is
+poorly understood, and its relationship to the continued-fraction period is subtle.
+
+## What this file proves
+
+We give the elementary, rigorous facts about the size of solutions, using Mathlib's
+`Pell.Solution₁` theory:
+
+* `x_sq_ge_d_add_one`: every nontrivial solution (`x > 1`) satisfies `x² ≥ D + 1`, i.e.
+  `x > √D` — the rigorous lower bound behind the heuristic `x₁ ≈ √D`;
+* `IsFundamental.x_sq_ge_d_add_one`: the fundamental solution obeys the same bound;
+* `IsFundamental.is_minimal`: the fundamental solution has the **smallest** `x` among all
+  nontrivial solutions (Mathlib's `IsFundamental.x_le_x`), so its size is the genuine extremal
+  quantity the open question asks about;
+* concrete fundamental solutions for `D = 2, 3, 5` with their sizes, illustrating the irregular
+  growth `(3,2), (2,1), (9,4)`.
+
+**Honest scope.** The deep content — the *upper* bound / distribution of `x₁` and its link to the
+continued-fraction period — remains open; this file pins down the elementary lower bound and the
+extremal (minimality) characterization.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/
+
+namespace PellEquationOQ02
+
+open Pell Pell.Solution₁
+
+variable {d : ℤ}
+
+/-- **Lower bound on the size of a nontrivial solution.** Any solution with `x > 1` satisfies
+    `x² ≥ D + 1` (so `x > √D`): since `y ≠ 0` forces `y² ≥ 1` and `D > 0`, the Pell relation
+    `x² = 1 + D y² ≥ 1 + D`. -/
+theorem x_sq_ge_d_add_one {a : Solution₁ d} (ha : 1 < a.x) : a.x ^ 2 ≥ d + 1 := by
+  have hd : 0 < d := Solution₁.d_pos_of_one_lt_x ha
+  have hy : a.y ≠ 0 := Solution₁.y_ne_zero_of_one_lt_x ha
+  have hy1 : 1 ≤ a.y ^ 2 := by
+    have h0 : a.y ^ 2 ≠ 0 := pow_ne_zero 2 hy
+    have h1 := sq_nonneg a.y
+    omega
+  have hx := a.prop_x
+  nlinarith [mul_nonneg hd.le (by linarith : (0 : ℤ) ≤ a.y ^ 2 - 1)]
+
+/-- The fundamental solution satisfies the same size lower bound `x² ≥ D + 1`. -/
+theorem IsFundamental.x_sq_ge_d_add_one {a : Solution₁ d} (h : IsFundamental a) :
+    a.x ^ 2 ≥ d + 1 :=
+  _root_.PellEquationOQ02.x_sq_ge_d_add_one h.1
+
+/-- **The fundamental solution is the smallest.** Among all nontrivial solutions, the fundamental
+    one minimizes `x` — so the "size of the fundamental solution" is a genuine extremal quantity.
+    (Restatement of Mathlib's `IsFundamental.x_le_x`.) -/
+theorem IsFundamental.is_minimal {a : Solution₁ d} (h : IsFundamental a) {b : Solution₁ d}
+    (hb : 1 < b.x) : a.x ≤ b.x :=
+  h.x_le_x hb
+
+/-! ## Concrete fundamental solutions for small D -/
+
+/-- `(3, 2)` solves `x² − 2y² = 1` (the fundamental solution for `D = 2`). -/
+def sol2 : Solution₁ (2 : ℤ) := Solution₁.mk 3 2 (by norm_num)
+
+theorem sol2_x : sol2.x = 3 := by simp [sol2]
+theorem sol2_y : sol2.y = 2 := by simp [sol2]
+
+/-- `(2, 1)` solves `x² − 3y² = 1` (the fundamental solution for `D = 3`). -/
+def sol3 : Solution₁ (3 : ℤ) := Solution₁.mk 2 1 (by norm_num)
+
+theorem sol3_x : sol3.x = 2 := by simp [sol3]
+
+/-- `(9, 4)` solves `x² − 5y² = 1` (the fundamental solution for `D = 5`). -/
+def sol5 : Solution₁ (5 : ℤ) := Solution₁.mk 9 4 (by norm_num)
+
+theorem sol5_x : sol5.x = 9 := by simp [sol5]
+
+/-- The concrete solutions illustrate the size lower bound `x² ≥ D + 1`:
+    `9 ≥ 3`, `4 ≥ 4`, `81 ≥ 6`. The irregular jump `x₁ = 3, 2, 9` for `D = 2, 3, 5` is the
+    "poorly understood distribution" of the open question. -/
+theorem concrete_bounds :
+    sol2.x ^ 2 ≥ (2 : ℤ) + 1 ∧ sol3.x ^ 2 ≥ (3 : ℤ) + 1 ∧ sol5.x ^ 2 ≥ (5 : ℤ) + 1 := by
+  refine ⟨?_, ?_, ?_⟩ <;> simp [sol2_x, sol3_x, sol5_x] <;> norm_num
+
+end PellEquationOQ02
+
+/-!
+## Summary
+
+The elementary size theory of Pell solutions:
+
+- `x_sq_ge_d_add_one`: every nontrivial solution has `x² ≥ D + 1` (`x > √D`).
+- `IsFundamental.x_sq_ge_d_add_one`, `IsFundamental.is_minimal`: the fundamental solution obeys
+  the bound and is the smallest nontrivial solution.
+- `sol2`, `sol3`, `sol5` and `concrete_bounds`: fundamental solutions `(3,2), (2,1), (9,4)` for
+  `D = 2, 3, 5`, illustrating both the bound and the irregular growth.
+
+The upper bound / distribution of `x₁` and its continued-fraction-period connection remain open.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/

--- a/src/data/proofs/pell-equation-oq-02/annotations.json
+++ b/src/data/proofs/pell-equation-oq-02/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-lower-bound",
+    "proofId": "pell-equation-oq-02",
+    "range": {
+      "startLine": 41,
+      "endLine": 56
+    },
+    "type": "insight",
+    "title": "x > √D, Rigorously",
+    "content": "`x_sq_ge_d_add_one` proves every nontrivial solution satisfies x² ≥ D + 1. The argument is the Pell relation itself: a solution with x > 1 must have y ≠ 0 (Mathlib's y_ne_zero_of_one_lt_x), so the integer y² ≥ 1, and x² = 1 + Dy² ≥ 1 + D with D > 0. This is the rigorous floor under the heuristic log(x₁ + y₁√D) ≈ √D — the fundamental solution can never be smaller than √D in its x-coordinate."
+  },
+  {
+    "id": "ann-minimal",
+    "proofId": "pell-equation-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 67
+    },
+    "type": "concept",
+    "title": "The Fundamental Solution Is the Smallest",
+    "content": "`IsFundamental.is_minimal` (from Mathlib's IsFundamental.x_le_x) records that the fundamental solution minimizes x among all nontrivial solutions. This is why 'the size of the fundamental solution' is a well-posed extremal quantity: it is the smallest a Pell solution can be, and the open question asks how that minimum grows with D."
+  },
+  {
+    "id": "ann-concrete",
+    "proofId": "pell-equation-oq-02",
+    "range": {
+      "startLine": 71,
+      "endLine": 100
+    },
+    "type": "concept",
+    "title": "Irregular Growth at Small D",
+    "content": "The explicit fundamental solutions (3,2) for D=2, (2,1) for D=3, and (9,4) for D=5 already display the erratic behavior of x₁: it jumps 3 → 2 → 9 as D goes 2 → 3 → 5, with no monotonicity. (For D = 61 the fundamental x₁ is 1766319049.) `concrete_bounds` verifies each satisfies x² ≥ D+1. This irregularity is precisely the 'poorly understood distribution' the open question highlights."
+  }
+]

--- a/src/data/proofs/pell-equation-oq-02/meta.json
+++ b/src/data/proofs/pell-equation-oq-02/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "pell-equation-oq-02",
+  "title": "The Size of the Fundamental Pell Solution: x² ≥ D + 1",
+  "slug": "pell-equation-oq-02",
+  "description": "Addresses the size aspect of the parent Pell open questions (heuristically log(x₁+y₁√D) ≈ √D, distribution poorly understood). Using Mathlib's Pell.Solution₁ theory, proves the rigorous lower bound that every nontrivial solution x²−Dy²=1 with x>1 satisfies x² ≥ D+1 (so x > √D), that the fundamental solution obeys the bound and is the smallest nontrivial solution, and exhibits the concrete fundamental solutions (3,2), (2,1), (9,4) for D=2,3,5 illustrating the irregular growth.",
+  "meta": {
+    "author": "Brahmagupta (628 CE); Joseph-Louis Lagrange; formalized in Lean 4",
+    "date": "628",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PellEquationOQ02.lean",
+    "tags": [
+      "number-theory",
+      "pell-equation",
+      "diophantine",
+      "fundamental-solution",
+      "quadratic-fields"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 105,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "originalContributions": [
+      "x_sq_ge_d_add_one: every nontrivial Pell solution (x>1) satisfies x² ≥ D+1, the rigorous lower bound behind the heuristic x₁ ≈ √D.",
+      "IsFundamental.x_sq_ge_d_add_one: the fundamental solution obeys the same bound.",
+      "IsFundamental.is_minimal: the fundamental solution has the smallest x among nontrivial solutions (so its size is a genuine extremal quantity).",
+      "sol2, sol3, sol5 and concrete_bounds: the fundamental solutions (3,2), (2,1), (9,4) for D=2,3,5, illustrating both the bound and the irregular growth of x₁."
+    ],
+    "prerequisites": [
+      "Pell's equation x² − Dy² = 1 and its fundamental solution",
+      "Mathlib's Pell.Solution₁ group of solutions",
+      "Elementary integer inequalities"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Pell.Solution₁.prop_x",
+        "description": "x² = 1 + D y² for any solution — the Pell relation",
+        "module": "Mathlib.NumberTheory.Pell"
+      },
+      {
+        "theorem": "Pell.Solution₁.y_ne_zero_of_one_lt_x",
+        "description": "a nontrivial solution (x>1) has y ≠ 0, hence y² ≥ 1",
+        "module": "Mathlib.NumberTheory.Pell"
+      },
+      {
+        "theorem": "Pell.IsFundamental.x_le_x",
+        "description": "the fundamental solution minimizes x among nontrivial solutions",
+        "module": "Mathlib.NumberTheory.Pell"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Pell's equation x² − Dy² = 1 (for D > 0 not a perfect square) has infinitely many solutions, all generated from a unique smallest positive one — the fundamental solution (x₁, y₁). Brahmagupta (628 CE) and Bhāskara II gave composition methods, and Lagrange (1768) proved existence via continued fractions. A persistent theme is the *size* of (x₁, y₁): it can be astonishingly large (for D = 61 the fundamental x₁ is 1766319049), and its distribution as a function of D is genuinely poorly understood. The heuristic is log(x₁ + y₁√D) ≈ √D, and the precise behavior is tied to the period of the continued fraction of √D.\n\nThis entry pins down the elementary, rigorous part: how *small* the fundamental solution can be. Since a nontrivial solution forces y ≠ 0, the Pell relation x² = 1 + Dy² gives x² ≥ D + 1, i.e. x > √D — a clean lower bound matching the heuristic's leading behavior. The deep upper bound and the period connection stay open.",
+    "problemStatement": "**Open Question (parent pell-equation, size/period cluster)**: understand the size of the fundamental solution x₁ as a function of D, and its relation to the continued-fraction period.\n\n**This entry**: proves the rigorous lower bound x² ≥ D+1 for every nontrivial solution, that the fundamental solution is the smallest, and gives concrete small-D data.",
+    "text": "A 105-line, fully verified (0 sorries, 0 axioms, no native_decide) file built on Mathlib's Pell.Solution₁. x_sq_ge_d_add_one proves x² ≥ D+1 for x>1; IsFundamental.x_sq_ge_d_add_one and IsFundamental.is_minimal handle the fundamental solution; sol2/sol3/sol5 and concrete_bounds give the explicit fundamental solutions for D = 2, 3, 5.",
+    "proofStrategy": "x_sq_ge_d_add_one uses Mathlib's y_ne_zero_of_one_lt_x (a nontrivial solution has y ≠ 0) and d_pos_of_one_lt_x (D > 0); from y ≠ 0 the integer y² ≥ 1 (omega on the atom y², knowing it is nonnegative and nonzero), and the Pell relation prop_x (x² = 1 + Dy²) gives x² = 1 + Dy² ≥ 1 + D by nlinarith with the product hint D·(y²−1) ≥ 0. The fundamental corollaries specialize via h.1 (x>1) and Mathlib's IsFundamental.x_le_x (minimality). The concrete solutions are Solution₁.mk with the equation discharged by norm_num, and concrete_bounds is norm_num after substituting the x-values.",
+    "keyInsights": [
+      "A nontrivial Pell solution must have y ≠ 0, so y² ≥ 1, and the Pell relation x² = 1 + Dy² immediately gives x² ≥ D + 1.",
+      "Hence x > √D for every nontrivial solution — the rigorous floor under the heuristic x₁ ≈ √D.",
+      "The fundamental solution is the smallest nontrivial one (Mathlib's IsFundamental.x_le_x), so its size is the genuine extremal quantity the open question concerns.",
+      "The explicit fundamental solutions (3,2), (2,1), (9,4) for D = 2, 3, 5 show how irregular x₁ is even for tiny D — the 'poorly understood distribution'.",
+      "Working over Mathlib's Solution₁ group keeps the elementary size facts short and lets omega/nlinarith handle the integer inequalities."
+    ]
+  },
+  "sections": [
+    {
+      "id": "lower-bound",
+      "title": "The Size Lower Bound",
+      "startLine": 38,
+      "endLine": 67,
+      "summary": "x_sq_ge_d_add_one (x²≥D+1 for x>1), IsFundamental.x_sq_ge_d_add_one, IsFundamental.is_minimal.",
+      "mathContext": "Every nontrivial solution has x > √D; the fundamental solution is the smallest."
+    },
+    {
+      "id": "concrete",
+      "title": "Concrete Fundamental Solutions",
+      "startLine": 69,
+      "endLine": 100,
+      "summary": "sol2 = (3,2), sol3 = (2,1), sol5 = (9,4) and concrete_bounds verifying the lower bound.",
+      "mathContext": "Explicit small-D fundamental solutions illustrating the irregular growth of x₁."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry establishes the elementary size theory of Pell solutions: every nontrivial solution satisfies x² ≥ D+1 (x > √D), the fundamental solution obeys this bound and is the smallest nontrivial solution, and the concrete fundamental solutions (3,2), (2,1), (9,4) for D = 2, 3, 5 exhibit the irregular growth of x₁.",
+    "implications": "The lower bound x² ≥ D+1 is the rigorous floor matching the heuristic log(x₁+y₁√D) ≈ √D, and the minimality characterization frames x₁ as the genuine extremal quantity. These are the elementary anchors for the deep open questions on the upper bound, the distribution of x₁, and its relation to the continued-fraction period of √D.",
+    "openQuestions": [
+      "Prove an upper bound or average-order result for x₁ as a function of D (the distribution is poorly understood).",
+      "Relate the size of x₁ to the period length of the continued fraction of √D.",
+      "Formalize the negative Pell equation x² − Dy² = −1 and when it is solvable (e.g. via the period parity)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "pell-equation",
+      "relationship": "extends",
+      "description": "Parent: Pell's equation and its fundamental solution. This entry pins down the elementary size lower bound for x₁."
+    },
+    {
+      "targetId": "pell-equation-oq-06-oq-01",
+      "relationship": "related",
+      "description": "Negative Pell classification — a sibling thread on solution structure."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Pell",
+      "Pell.Solution₁"
+    ],
+    "namespace": "PellEquationOQ02",
+    "lineCount": 105,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "mainTheorems": [
+      {
+        "name": "x_sq_ge_d_add_one",
+        "type": "core",
+        "description": "Every nontrivial Pell solution satisfies x² ≥ D+1 (x > √D)",
+        "leanType": "{d : ℤ} → {a : Solution₁ d} → 1 < a.x → a.x ^ 2 ≥ d + 1"
+      },
+      {
+        "name": "IsFundamental.is_minimal",
+        "type": "key",
+        "description": "The fundamental solution has the smallest x among nontrivial solutions",
+        "leanType": "{d : ℤ} → {a : Solution₁ d} → IsFundamental a → {b : Solution₁ d} → 1 < b.x → a.x ≤ b.x"
+      },
+      {
+        "name": "concrete_bounds",
+        "type": "key",
+        "description": "The fundamental solutions for D = 2, 3, 5 satisfy the size lower bound",
+        "leanType": "sol2.x ^ 2 ≥ 2 + 1 ∧ sol3.x ^ 2 ≥ 3 + 1 ∧ sol5.x ^ 2 ≥ 5 + 1"
+      }
+    ],
+    "path": "Proofs/PellEquationOQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "x_sq_ge_d_add_one",
+      "type": "core",
+      "description": "Size lower bound for nontrivial Pell solutions: x² ≥ D+1",
+      "leanType": "{d : ℤ} → {a : Solution₁ d} → 1 < a.x → a.x ^ 2 ≥ d + 1"
+    },
+    {
+      "name": "IsFundamental.is_minimal",
+      "type": "key",
+      "description": "The fundamental solution is the smallest nontrivial solution",
+      "leanType": "{d : ℤ} → {a : Solution₁ d} → IsFundamental a → {b : Solution₁ d} → 1 < b.x → a.x ≤ b.x"
+    },
+    {
+      "name": "concrete_bounds",
+      "type": "supporting",
+      "description": "Explicit fundamental solutions (3,2),(2,1),(9,4) satisfy the bound",
+      "leanType": "sol2.x ^ 2 ≥ 2 + 1 ∧ sol3.x ^ 2 ≥ 3 + 1 ∧ sol5.x ^ 2 ≥ 5 + 1"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Lagrange, Joseph-Louis",
+      "title": "Solution d'un problème d'arithmétique",
+      "year": "1768",
+      "venue": "Miscellanea Taurinensia",
+      "note": "Existence of the fundamental solution via continued fractions"
+    },
+    {
+      "authors": "Lenstra, Hendrik W.",
+      "title": "Solving the Pell Equation",
+      "year": "2002",
+      "venue": "Notices of the AMS 49(2), 182–192",
+      "note": "Modern survey of the size of the fundamental solution and algorithms"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Addresses the **size** aspect of the parent Pell open questions (heuristically `log(x₁+y₁√D) ≈ √D`, distribution poorly understood), using Mathlib's `Pell.Solution₁`.

**`PellEquationOQ02.lean`** — 105 lines, 8 theorems, 3 defs, **0 sorries, 0 axioms, no `native_decide`**.

- `x_sq_ge_d_add_one`: every nontrivial solution (x>1) satisfies **x² ≥ D+1** (so x > √D) — the rigorous floor under the heuristic x₁ ≈ √D.
- `IsFundamental.x_sq_ge_d_add_one` / `IsFundamental.is_minimal`: the fundamental solution obeys the bound and is the **smallest** nontrivial solution (Mathlib's `IsFundamental.x_le_x`), so its size is a genuine extremal quantity.
- `sol2`, `sol3`, `sol5`, `concrete_bounds`: the fundamental solutions **(3,2), (2,1), (9,4)** for D = 2, 3, 5 — illustrating the irregular growth of x₁ (3 → 2 → 9).

## Honest scope
The elementary *lower* bound and minimality. The *upper* bound / distribution of x₁ and its continued-fraction-period connection (the deep content of the OQ) remain open.

## Verification
`./proofs/scripts/docker-build.sh Proofs.PellEquationOQ02` → Build completed successfully (7743 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)