### PR TITLE
research(geometric-series-oq-01-oq-01): Abel summability of Grandi's series

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2691,6 +2691,7 @@ import Proofs.GeneralQuartic
 import Proofs.GeneralQuarticAxiomsDischarge
 import Proofs.GeometricSeries
 import Proofs.GeometricSeriesOQ01
+import Proofs.GeometricSeriesOQ01OQ01
 import Proofs.GeometricSeriesOQ01Neumann
 import Proofs.GeometricSeriesOQ01OQ02
 import Proofs.GeometricSeriesOQ01OQ03

--- a/proofs/Proofs/GeometricSeriesOQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ01OQ01.lean
@@ -1,0 +1,79 @@
+import Mathlib
+
+/-!
+# Geometric Series OQ-01 / OQ-01: Abel Summability of Grandi's Series
+
+## The Open Question
+
+The parent (`GeometricSeriesOQ01`, the geometric series at the boundary `|r| = 1`) asks:
+
+> Can **Abel summability** of Grandi's series `1 − 1 + 1 − 1 + ⋯` be formalized? Abel summation
+> assigns `lim_{x→1⁻} ∑_{n=0}^∞ (−1)ⁿ xⁿ = lim_{x→1⁻} 1/(1+x) = 1/2`, an independent
+> confirmation of the Cesàro value `1/2`.
+
+## What this file proves
+
+* `grandi_power_series`: for `|x| < 1`, the Abel power series sums to the closed form
+  `∑'ₙ (−1)ⁿ xⁿ = 1/(1+x)` (the geometric series with ratio `−x`);
+* `grandi_abel_tendsto`: the **Abel limit** `lim_{x→1⁻} ∑'ₙ (−1)ⁿ xⁿ = 1/2`, the boundary value
+  of `1/(1+x)`.
+
+So Grandi's series is Abel summable to `1/2`, matching its Cesàro value — Abel's method and
+Cesàro's method agree here, as Frobenius's theorem guarantees in general.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/
+
+namespace GeometricSeriesOQ01OQ01
+
+open Filter Topology
+
+/-- **The Abel power series of Grandi's series.** For `|x| < 1`,
+    `∑'ₙ (−1)ⁿ xⁿ = 1/(1+x)` — the geometric series with ratio `−x`. -/
+theorem grandi_power_series {x : ℝ} (hx : |x| < 1) :
+    ∑' n : ℕ, (-1 : ℝ) ^ n * x ^ n = (1 + x)⁻¹ := by
+  have hnorm : ‖(-x : ℝ)‖ < 1 := by rwa [Real.norm_eq_abs, abs_neg]
+  have hgeo : ∑' n : ℕ, (-x : ℝ) ^ n = (1 - -x)⁻¹ := tsum_geometric_of_norm_lt_one hnorm
+  rw [show (1 - -x : ℝ) = 1 + x by ring] at hgeo
+  rw [← hgeo]
+  exact tsum_congr fun n => (neg_pow x n).symm
+
+/-- **Abel summability of Grandi's series.** The Abel limit of `∑ (−1)ⁿ xⁿ` as `x → 1⁻` is `1/2`,
+    the boundary value of the closed form `1/(1+x)`. -/
+theorem grandi_abel_tendsto :
+    Tendsto (fun x : ℝ => ∑' n : ℕ, (-1 : ℝ) ^ n * x ^ n)
+      (𝓝[<] 1) (𝓝 (1 / 2)) := by
+  -- on a left-neighborhood of 1, the series equals 1/(1+x)
+  have hev : (fun x : ℝ => ∑' n : ℕ, (-1 : ℝ) ^ n * x ^ n) =ᶠ[𝓝[<] 1] fun x => (1 + x)⁻¹ := by
+    filter_upwards [self_mem_nhdsWithin,
+      mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds (show (-1 : ℝ) < 1 by norm_num))]
+      with x hx1 hx2
+    exact grandi_power_series (abs_lt.mpr ⟨hx2, hx1⟩)
+  rw [tendsto_congr' hev]
+  -- 1/(1+x) → 1/(1+1) = 1/2 by continuity
+  have h2 : Tendsto (fun x : ℝ => (1 + x)⁻¹) (𝓝 1) (𝓝 (1 / 2)) := by
+    have hnum : Tendsto (fun x : ℝ => 1 + x) (𝓝 1) (𝓝 (1 + 1)) :=
+      tendsto_const_nhds.add tendsto_id
+    have hinv := hnum.inv₀ (by norm_num : (1 : ℝ) + 1 ≠ 0)
+    rwa [show ((1 : ℝ) + 1)⁻¹ = 1 / 2 by norm_num] at hinv
+  exact h2.mono_left nhdsWithin_le_nhds
+
+/-- Grandi's series is Abel summable to `1/2`, matching its Cesàro value. -/
+theorem grandi_abel_value : Tendsto (fun x : ℝ => ∑' n : ℕ, (-1 : ℝ) ^ n * x ^ n) (𝓝[<] 1)
+    (𝓝 (1 / 2)) := grandi_abel_tendsto
+
+end GeometricSeriesOQ01OQ01
+
+/-!
+## Summary
+
+Abel summability of Grandi's series, an independent confirmation of its Cesàro value:
+
+- `grandi_power_series`: `∑'ₙ (−1)ⁿ xⁿ = 1/(1+x)` for `|x| < 1` (geometric series, ratio `−x`).
+- `grandi_abel_tendsto`: `lim_{x→1⁻} ∑'ₙ (−1)ⁿ xⁿ = 1/2`, the boundary value of `1/(1+x)`.
+
+So `1 − 1 + 1 − 1 + ⋯` is Abel summable to `1/2`, agreeing with its Cesàro sum (Frobenius's
+theorem: Cesàro summability implies Abel summability to the same value).
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/

--- a/src/data/proofs/geometric-series-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01/annotations.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "ann-closed-form",
+    "proofId": "geometric-series-oq-01-oq-01",
+    "range": {
+      "startLine": 32,
+      "endLine": 42
+    },
+    "type": "insight",
+    "title": "Grandi's Abel Series Is a Geometric Series",
+    "content": "`grandi_power_series` recognizes that ∑ (−1)ⁿ xⁿ is the geometric series with ratio −x: since (−1)ⁿ xⁿ = (−x)ⁿ, Mathlib's tsum_geometric_of_norm_lt_one (applicable because ‖−x‖ = |x| < 1) gives the sum (1 − (−x))⁻¹ = 1/(1+x). The divergent boundary series 1 − 1 + 1 − ⋯ is thus encoded, for |x| < 1, by the analytic function 1/(1+x)."
+  },
+  {
+    "id": "ann-abel-limit",
+    "proofId": "geometric-series-oq-01-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 70
+    },
+    "type": "insight",
+    "title": "The Abel Sum Is the Boundary Value",
+    "content": "`grandi_abel_tendsto` computes the Abel sum as the radial limit x → 1⁻. On the left-neighborhood filter 𝓝[<] 1, the series eventually equals 1/(1+x) (because there x stays in (−1,1), so |x| < 1), and the limit transfers via tendsto_congr'. Then 1/(1+x) is continuous at x = 1 with value 1/(1+1) = 1/2 (Tendsto.inv₀), so the Abel sum is 1/2 — matching the Cesàro value, exactly as Frobenius's theorem predicts."
+  }
+]

--- a/src/data/proofs/geometric-series-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "geometric-series-oq-01-oq-01",
+  "title": "Abel Summability of Grandi's Series",
+  "slug": "geometric-series-oq-01-oq-01",
+  "description": "Answers the parent's first open question: formalize the Abel summability of Grandi's series 1−1+1−1+⋯. For |x|<1 the Abel power series ∑(−1)ⁿxⁿ sums to the closed form 1/(1+x) (geometric series with ratio −x), and its boundary value lim_{x→1⁻} 1/(1+x) = 1/2 is the Abel sum. So Grandi's series is Abel summable to 1/2, independently confirming its Cesàro value, as Frobenius's theorem guarantees.",
+  "meta": {
+    "author": "Niels Henrik Abel (1826); formalized in Lean 4",
+    "date": "1826",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "summability",
+      "abel-summation",
+      "grandi-series",
+      "geometric-series",
+      "divergent-series"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 79,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "originalContributions": [
+      "grandi_power_series: for |x|<1, ∑'ₙ (−1)ⁿ xⁿ = 1/(1+x) (the geometric series with ratio −x, via Mathlib's tsum_geometric_of_norm_lt_one).",
+      "grandi_abel_tendsto: the Abel limit lim_{x→1⁻} ∑'ₙ (−1)ⁿ xⁿ = 1/2, the boundary value of 1/(1+x).",
+      "grandi_abel_value: Grandi's series is Abel summable to 1/2, matching its Cesàro value."
+    ],
+    "prerequisites": [
+      "Geometric series and the closed form ∑ rⁿ = 1/(1−r) for |r|<1",
+      "Abel summation: the radial limit of a power series at the boundary",
+      "Filters, nhdsWithin, and continuity in Lean 4/Mathlib"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "tsum_geometric_of_norm_lt_one",
+        "description": "∑'ₙ ξⁿ = (1−ξ)⁻¹ for ‖ξ‖<1 — the geometric series, applied with ξ = −x",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Filter.Tendsto.inv₀",
+        "description": "limits commute with inversion at a nonzero value, giving lim 1/(1+x) = 1/(1+1)",
+        "module": "Mathlib.Topology.Algebra.GroupWithZero"
+      },
+      {
+        "theorem": "tendsto_congr'",
+        "description": "transfers a limit along an eventual equality (the series equals 1/(1+x) near 1)",
+        "module": "Mathlib.Order.Filter.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Grandi's series 1 − 1 + 1 − 1 + ⋯ diverges in the ordinary sense (its partial sums oscillate between 1 and 0), yet several regularization methods assign it the value 1/2. Abel's method (1826) does so by reading the series as the boundary value of a power series: ∑ (−1)ⁿ xⁿ converges for |x| < 1 to 1/(1+x), and letting x → 1⁻ gives 1/2. This is the canonical example of Abel summation, and it agrees with the Cesàro value — an instance of Frobenius's theorem, which says any Cesàro-summable series is Abel summable to the same value.\n\nThe parent gallery entry computes the Cesàro value of Grandi's series; this entry supplies the independent Abel confirmation, completing the picture of how the boundary of the geometric series' disk of convergence behaves.",
+    "problemStatement": "**Open Question (parent geometric-series-oq-01, OQ-01)**: can the Abel summability of Grandi's series be formalized — lim_{x→1⁻} ∑ (−1)ⁿ xⁿ = lim_{x→1⁻} 1/(1+x) = 1/2?\n\n**Result**: yes — the closed form and the boundary limit are both proved.",
+    "text": "A 79-line, fully verified (0 sorries, 0 axioms, no native_decide) file. grandi_power_series gives the closed form ∑'ₙ (−1)ⁿ xⁿ = 1/(1+x) for |x|<1; grandi_abel_tendsto proves the Abel limit at x → 1⁻ is 1/2; grandi_abel_value packages the conclusion.",
+    "proofStrategy": "grandi_power_series rewrites each term (−1)ⁿ xⁿ = (−x)ⁿ (neg_pow) and applies Mathlib's tsum_geometric_of_norm_lt_one to ξ = −x (with ‖−x‖ = |x| < 1), giving (1 − (−x))⁻¹ = (1+x)⁻¹. grandi_abel_tendsto first shows the series equals 1/(1+x) on a left-neighborhood of 1 (filter_upwards over the within-Iio-1 filter, where x < 1 and eventually x > −1 give |x| < 1) and transfers the limit via tendsto_congr'; then lim_{x→1} 1/(1+x) = 1/2 follows from Tendsto.inv₀ applied to x ↦ 1+x → 2, restricted from the full neighborhood by mono_left.",
+    "keyInsights": [
+      "Grandi's Abel power series is a disguised geometric series: ∑ (−1)ⁿ xⁿ = ∑ (−x)ⁿ = 1/(1+x) for |x| < 1.",
+      "The Abel sum is just the boundary value of the closed form: 1/(1+x) is continuous at x = 1 with value 1/2.",
+      "Working over the left-neighborhood filter 𝓝[<] 1 captures the one-sided radial limit x → 1⁻ precisely; on it the series eventually equals 1/(1+x) because x stays in (−1,1).",
+      "The result matches the Cesàro value 1/2, an instance of Frobenius's theorem (Cesàro ⟹ Abel, same value).",
+      "Mathlib's geometric-series and limit-of-inverse lemmas make the whole argument short and axiom-free."
+    ]
+  },
+  "sections": [
+    {
+      "id": "closed-form",
+      "title": "The Abel Power Series",
+      "startLine": 30,
+      "endLine": 42,
+      "summary": "grandi_power_series: ∑'ₙ (−1)ⁿ xⁿ = 1/(1+x) for |x| < 1.",
+      "mathContext": "Grandi's Abel series is the geometric series with ratio −x."
+    },
+    {
+      "id": "abel-limit",
+      "title": "The Abel Limit",
+      "startLine": 44,
+      "endLine": 70,
+      "summary": "grandi_abel_tendsto: lim_{x→1⁻} ∑'ₙ (−1)ⁿ xⁿ = 1/2, the boundary value of 1/(1+x). grandi_abel_value packages it.",
+      "mathContext": "The radial boundary limit of the closed form gives the Abel sum 1/2."
+    }
+  ],
+  "conclusion": {
+    "summary": "Grandi's series 1 − 1 + 1 − 1 + ⋯ is Abel summable to 1/2: its Abel power series ∑ (−1)ⁿ xⁿ equals 1/(1+x) for |x| < 1, whose boundary value as x → 1⁻ is 1/2. This independently confirms the Cesàro value.",
+    "implications": "The Abel and Cesàro values of Grandi's series agree, illustrating Frobenius's theorem (Cesàro summability implies Abel summability to the same value). Together with the parent's Cesàro computation, this completes the elementary regularization theory of the geometric series at the boundary |r| = 1.",
+    "openQuestions": [
+      "Formalize Frobenius's theorem in general (Cesàro summable ⟹ Abel summable to the same value).",
+      "Formalize Abel's theorem: a convergent series equals the radial limit of its power series.",
+      "Treat r = e^{2πiθ} with θ irrational, where the geometric series' boundary behavior is subtler."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the geometric series at the boundary |r| = 1, where the Cesàro value of Grandi's series is computed. This entry adds the Abel confirmation."
+    },
+    {
+      "targetId": "geometric-series-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling: Cesàro (C,1) regularity and its strict extension, the general theory behind the Cesàro value."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "GeometricSeriesOQ01OQ01",
+    "lineCount": 79,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "grandi_abel_tendsto",
+        "type": "core",
+        "description": "The Abel limit of Grandi's series is 1/2",
+        "leanType": "Tendsto (fun x : ℝ => ∑' n : ℕ, (-1)^n * x^n) (𝓝[<] 1) (𝓝 (1/2))"
+      },
+      {
+        "name": "grandi_power_series",
+        "type": "key",
+        "description": "The Abel power series closed form ∑ (−1)ⁿ xⁿ = 1/(1+x) for |x|<1",
+        "leanType": "{x : ℝ} → |x| < 1 → ∑' n : ℕ, (-1)^n * x^n = (1 + x)⁻¹"
+      }
+    ],
+    "path": "Proofs/GeometricSeriesOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "grandi_abel_tendsto",
+      "type": "core",
+      "description": "Abel summability of Grandi's series: the radial limit at x → 1⁻ is 1/2",
+      "leanType": "Tendsto (fun x : ℝ => ∑' n : ℕ, (-1)^n * x^n) (𝓝[<] 1) (𝓝 (1/2))"
+    },
+    {
+      "name": "grandi_power_series",
+      "type": "key",
+      "description": "∑ (−1)ⁿ xⁿ = 1/(1+x) for |x| < 1 (geometric series, ratio −x)",
+      "leanType": "{x : ℝ} → |x| < 1 → ∑' n : ℕ, (-1)^n * x^n = (1 + x)⁻¹"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Abel, Niels Henrik",
+      "title": "Recherches sur la série 1 + (m/1)x + (m(m−1)/1·2)x² + ⋯",
+      "year": "1826",
+      "venue": "Journal für die reine und angewandte Mathematik 1, 311–339",
+      "note": "Abel's theorem on the boundary behavior of power series, the basis of Abel summation"
+    },
+    {
+      "authors": "Hardy, G. H.",
+      "title": "Divergent Series",
+      "year": "1949",
+      "venue": "Oxford University Press",
+      "note": "Abel and Cesàro summation, Frobenius's theorem, and the value 1/2 for Grandi's series"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent's **OQ-01**: formalize the **Abel summability** of Grandi's series 1 − 1 + 1 − 1 + ⋯.

**`GeometricSeriesOQ01OQ01.lean`** — 79 lines, 3 theorems, **0 sorries, 0 axioms, no `native_decide`**.

- `grandi_power_series`: for |x| < 1, **∑'ₙ (−1)ⁿ xⁿ = 1/(1+x)** — the geometric series with ratio −x (Mathlib's `tsum_geometric_of_norm_lt_one`).
- `grandi_abel_tendsto`: the **Abel limit** `lim_{x→1⁻} ∑'ₙ (−1)ⁿ xⁿ = 1/2`, the boundary value of 1/(1+x).

So Grandi's series is Abel summable to 1/2, independently confirming its Cesàro value (an instance of Frobenius's theorem).

## Verification
`./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ01OQ01` → Build completed successfully (7743 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)