### PR TITLE
research(erdos-ko-rado-oq-02): de-axiomatize the EKR upper bound via Kruskal–Katona

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2518,6 +2518,7 @@ import Proofs.ErdosDivisibilityPigeonhole
 import Proofs.ErdosDivisibilityPigeonholeOQ01
 import Proofs.ErdosGinzburgZivOQ01
 import Proofs.ErdosKoRado
+import Proofs.ErdosKoRadoOQ02
 import Proofs.ErdosMordellChordIdentity
 import Proofs.ErdosMordellChordReduction
 import Proofs.ErdosMordellFeetAngleAristotle

--- a/proofs/Proofs/ErdosKoRadoOQ02.lean
+++ b/proofs/Proofs/ErdosKoRadoOQ02.lean
@@ -1,0 +1,171 @@
+/-
+# Erdős–Ko–Rado: the double-counting bound, de-axiomatized (OQ-02)
+
+The parent gallery entry `ErdosKoRado` formalizes the Erdős–Ko–Rado theorem via
+Katona's cyclic-permutation argument, but it leaves the heart of the proof —
+the upper bound
+
+    |𝒜| ≤ C(n-1, k-1)    for an intersecting family of k-sets, n ≥ 2k
+
+— as an `axiom` (`double_counting_bound`), because Katona's double count rests on
+a cyclic-interval lemma whose modular bookkeeping resisted a Lean formalization
+(see the sibling open question OQ-01, released unsolved).
+
+This file answers OQ-02 by discharging that axiom **completely, with zero axioms**,
+taking an entirely different route: Mathlib proves Erdős–Ko–Rado through the
+Kruskal–Katona shadow inequality (`Finset.erdos_ko_rado`), sidestepping cyclic
+intervals altogether. We
+
+  1. bridge the parent's bespoke predicate `IsIntersectingFamily A k` to Mathlib's
+     `Set.Intersecting` together with `Set.Sized k`;
+  2. obtain the upper bound `A.card ≤ (n-1).choose (k-1)` axiom-free; and
+  3. prove the bound is **sharp** — the star (all k-sets through a fixed point)
+     is an intersecting family of size exactly `(n-1).choose (k-1)` — so that the
+     maximum is pinned: it `IsGreatest`.
+
+The result is the full extremal statement of Erdős–Ko–Rado for the parent's
+predicate, machine-checked with no remaining assumptions.
+
+Self-contained: imports only Mathlib. The definitions `IsIntersectingFamily` and
+`Star` are reproduced verbatim from the parent (which is `axiomatized`; importing
+it would pull its nine axioms into this file).
+-/
+import Mathlib
+
+open Finset
+
+namespace ErdosKoRadoOQ02
+
+/- ## Definitions (verbatim from the parent entry) -/
+
+/-- A family of `k`-sets is intersecting if every two members share an element. -/
+def IsIntersectingFamily {n : ℕ} (A : Finset (Finset (Fin n))) (k : ℕ) : Prop :=
+  (∀ s ∈ A, s.card = k) ∧
+  ∀ s t, s ∈ A → t ∈ A → (s ∩ t).Nonempty
+
+/-- The star centered at `x`: all `k`-subsets of `Fin n` containing `x`. -/
+def Star {n : ℕ} (x : Fin n) (k : ℕ) : Finset (Finset (Fin n)) :=
+  (powersetCard k (univ : Finset (Fin n))).filter (fun s => x ∈ s)
+
+/- ## Bridge to Mathlib's `Set.Intersecting` / `Set.Sized` -/
+
+/-- The parent's uniformity condition is Mathlib's `Set.Sized k`. -/
+theorem sized_of_isIntersectingFamily {n k : ℕ} {A : Finset (Finset (Fin n))}
+    (hA : IsIntersectingFamily A k) : (A : Set (Finset (Fin n))).Sized k := by
+  intro s hs
+  exact hA.1 s (mem_coe.mp hs)
+
+/-- The parent's pairwise-nonempty-intersection condition is Mathlib's
+`Set.Intersecting`. The translation is `not_disjoint_iff_nonempty_inter`:
+two finsets are non-disjoint exactly when their intersection is nonempty. -/
+theorem intersecting_of_isIntersectingFamily {n k : ℕ} {A : Finset (Finset (Fin n))}
+    (hA : IsIntersectingFamily A k) : (A : Set (Finset (Fin n))).Intersecting := by
+  intro s hs t ht
+  rw [Finset.not_disjoint_iff_nonempty_inter]
+  exact hA.2 s t (mem_coe.mp hs) (mem_coe.mp ht)
+
+/- ## The upper bound, axiom-free -/
+
+/-- **The Erdős–Ko–Rado upper bound (the parent's `double_counting_bound`),
+de-axiomatized.** For an intersecting family of `k`-sets in `Fin n` with `n ≥ 2k`,
+
+    |A| ≤ C(n-1, k-1).
+
+Proof: bridge to Mathlib's predicates and invoke `Finset.erdos_ko_rado`, whose
+side condition `k ≤ n / 2` follows from `2k ≤ n`. No cyclic intervals, no axioms. -/
+theorem ekr_bound {n k : ℕ} (hn : n ≥ 2 * k)
+    (A : Finset (Finset (Fin n))) (hA : IsIntersectingFamily A k) :
+    A.card ≤ (n - 1).choose (k - 1) := by
+  have hle : k ≤ n / 2 := by
+    rw [Nat.le_div_iff_mul_le (by norm_num)]
+    omega
+  exact Finset.erdos_ko_rado (intersecting_of_isIntersectingFamily hA)
+    (sized_of_isIntersectingFamily hA) hle
+
+/- ## Sharpness: the star attains the bound -/
+
+/-- The star is an intersecting family of `k`-sets (every member contains the
+center, so any two intersect there). -/
+theorem star_is_intersecting {n k : ℕ} (_hk : 0 < k) (x : Fin n) :
+    IsIntersectingFamily (Star x k) k := by
+  unfold IsIntersectingFamily Star
+  refine ⟨?_, ?_⟩
+  · intro s hs
+    simp only [mem_filter, mem_powersetCard_univ] at hs
+    exact hs.1
+  · intro s t hs ht
+    simp only [mem_filter, mem_powersetCard_univ] at hs ht
+    exact ⟨x, mem_inter.mpr ⟨hs.2, ht.2⟩⟩
+
+/-- The star has exactly `C(n-1, k-1)` members: deleting the center is a bijection
+from `k`-sets through `x` onto `(k-1)`-subsets of the remaining `n-1` points. -/
+theorem star_card {n k : ℕ} (hk : 0 < k) (x : Fin n) :
+    (Star x k).card = (n - 1).choose (k - 1) := by
+  unfold Star
+  let target := powersetCard (k - 1) (univ.erase x)
+  have h_target_card : target.card = (n - 1).choose (k - 1) := by
+    simp only [target, card_powersetCard]
+    congr 1
+    simp [card_erase_of_mem (mem_univ x)]
+  rw [← h_target_card]
+  apply Finset.card_bij (fun s _ => s.erase x)
+  · intro s hs
+    simp only [mem_filter, mem_powersetCard_univ] at hs
+    simp only [target, mem_powersetCard]
+    refine ⟨?_, ?_⟩
+    · intro y hy
+      simp only [mem_erase] at hy ⊢
+      exact ⟨hy.1, mem_univ y⟩
+    · rw [card_erase_of_mem hs.2, hs.1]
+  · intro s₁ hs₁ s₂ hs₂ heq
+    simp only [mem_filter, mem_powersetCard_univ] at hs₁ hs₂
+    have h1 : s₁ = insert x (s₁.erase x) := (insert_erase hs₁.2).symm
+    have h2 : s₂ = insert x (s₂.erase x) := (insert_erase hs₂.2).symm
+    rw [h1, h2, heq]
+  · intro t ht
+    simp only [target, mem_powersetCard] at ht
+    have hx_notin : x ∉ t := by
+      intro hx
+      have hmem := ht.1 hx
+      rw [mem_erase] at hmem
+      exact hmem.1 rfl
+    refine ⟨insert x t, ?_, erase_insert hx_notin⟩
+    rw [mem_filter, mem_powersetCard_univ]
+    refine ⟨?_, mem_insert_self x t⟩
+    rw [card_insert_of_notMem hx_notin, ht.2]
+    omega
+
+/- ## The exact maximum -/
+
+/-- **The full extremal Erdős–Ko–Rado statement, axiom-free.** Among the sizes of
+all intersecting families of `k`-sets in `Fin n` (with `n ≥ 2k`, `k ≥ 1`), the
+greatest is exactly `C(n-1, k-1)`: the star achieves it (membership) and nothing
+exceeds it (the upper bound). -/
+theorem ekr_isGreatest {n k : ℕ} (hn : n ≥ 2 * k) (hk : 0 < k) :
+    IsGreatest {c | ∃ A : Finset (Finset (Fin n)), IsIntersectingFamily A k ∧ A.card = c}
+      ((n - 1).choose (k - 1)) := by
+  have hn0 : 0 < n := by omega
+  -- a center exists since `n > 0`
+  let x : Fin n := ⟨0, hn0⟩
+  refine ⟨⟨Star x k, star_is_intersecting hk x, star_card hk x⟩, ?_⟩
+  rintro c ⟨A, hA, rfl⟩
+  exact ekr_bound hn A hA
+
+/- ## Concrete instances -/
+
+/-- `n = 6, k = 3`: the maximum intersecting family has `C(5,2) = 10` members. -/
+theorem ekr_max_6_3 :
+    IsGreatest {c | ∃ A : Finset (Finset (Fin 6)), IsIntersectingFamily A 3 ∧ A.card = c} 10 := by
+  have h := ekr_isGreatest (n := 6) (k := 3) (by norm_num) (by norm_num)
+  norm_num at h
+  exact h
+
+/-- `n = 4, k = 2`: the maximum intersecting family of pairs has `C(3,1) = 3`
+members (the three pairs through a common point). -/
+theorem ekr_max_4_2 :
+    IsGreatest {c | ∃ A : Finset (Finset (Fin 4)), IsIntersectingFamily A 2 ∧ A.card = c} 3 := by
+  have h := ekr_isGreatest (n := 4) (k := 2) (by norm_num) (by norm_num)
+  norm_num at h
+  exact h
+
+end ErdosKoRadoOQ02

--- a/src/data/proofs/erdos-ko-rado-oq-02/annotations.json
+++ b/src/data/proofs/erdos-ko-rado-oq-02/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-bridge",
+    "proofId": "erdos-ko-rado-oq-02",
+    "range": {
+      "startLine": 53,
+      "endLine": 65
+    },
+    "type": "insight",
+    "title": "The Predicate Is Already in Mathlib",
+    "content": "The parent defines IsIntersectingFamily A k as 'every member has card k, and every two members have nonempty intersection'. These two clauses are, after translation, exactly Mathlib's Set.Sized k and Set.Intersecting. The only nontrivial step is intersecting_of_isIntersectingFamily, which rewrites with not_disjoint_iff_nonempty_inter: two finsets fail to be disjoint precisely when their intersection is nonempty. Once this bridge is in place, the heavy machinery is all Mathlib's."
+  },
+  {
+    "id": "ann-upper-bound",
+    "proofId": "erdos-ko-rado-oq-02",
+    "range": {
+      "startLine": 67,
+      "endLine": 84
+    },
+    "type": "insight",
+    "title": "Discharging the Axiom via Kruskal–Katona",
+    "content": "ekr_bound is the parent's axiomatized double_counting_bound, now a 0-axiom theorem. The parent reaches it through Katona's cyclic-permutation count, whose key lemma about pairwise-intersecting cyclic intervals resisted Lean formalization (sibling OQ-01, released unsolved). This proof takes Mathlib's entirely different route: Finset.erdos_ko_rado, derived from the Kruskal–Katona shadow inequality, with no cyclic intervals at all. Its side condition k ≤ n/2 is just the classical n ≥ 2k after one Nat.le_div_iff_mul_le rewrite."
+  },
+  {
+    "id": "ann-sharpness",
+    "proofId": "erdos-ko-rado-oq-02",
+    "range": {
+      "startLine": 99,
+      "endLine": 138
+    },
+    "type": "concept",
+    "title": "Counting the Star by Erasing the Center",
+    "content": "star_card shows the star — all k-sets through a fixed center x — has exactly C(n-1,k-1) members. The bijection is s ↦ s.erase x: deleting the center sends a k-set containing x to a (k-1)-subset of the remaining n-1 points, and inserting x back is the inverse (insert_erase / erase_insert). This is the lower-bound half: a concrete intersecting family meeting the upper bound, so the bound is sharp."
+  },
+  {
+    "id": "ann-exact-max",
+    "proofId": "erdos-ko-rado-oq-02",
+    "range": {
+      "startLine": 140,
+      "endLine": 170
+    },
+    "type": "insight",
+    "title": "From Inequality to Exact Maximum",
+    "content": "ekr_isGreatest combines the two directions into the full extremal statement: the maximum size over all intersecting families of k-sets (n ≥ 2k) is exactly C(n-1,k-1). The star (centered at the point 0, which exists since n ≥ 2k ≥ 2 > 0) witnesses that the value is attained, and ekr_bound caps every family from above. ekr_max_6_3 and ekr_max_4_2 instantiate this to the familiar maxima 10 = C(5,2) and 3 = C(3,1) — without native_decide, keeping the entry fully kernel-checked."
+  }
+]

--- a/src/data/proofs/erdos-ko-rado-oq-02/meta.json
+++ b/src/data/proofs/erdos-ko-rado-oq-02/meta.json
@@ -1,0 +1,198 @@
+{
+  "id": "erdos-ko-rado-oq-02",
+  "title": "The Erdős–Ko–Rado Bound, De-Axiomatized via Kruskal–Katona",
+  "slug": "erdos-ko-rado-oq-02",
+  "description": "Discharges the parent gallery entry's central axiom — the Erdős–Ko–Rado upper bound |𝒜| ≤ C(n-1,k-1) for an intersecting family of k-sets with n ≥ 2k, axiomatized there as 'double_counting_bound' because Katona's cyclic-interval lemma (sibling OQ-01) resisted formalization. This entry proves it with zero axioms by an entirely different route: bridge the parent's bespoke predicate IsIntersectingFamily to Mathlib's Set.Intersecting and Set.Sized, then invoke Mathlib's Finset.erdos_ko_rado (proved via the Kruskal–Katona shadow inequality, sidestepping cyclic intervals). Adds sharpness — the star attains the bound exactly — yielding the full extremal statement IsGreatest with the maximum pinned at C(n-1,k-1).",
+  "meta": {
+    "author": "Erdős, Ko, Rado (1961); Kruskal–Katona (1963/68); formalized in Lean 4",
+    "date": "1961",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ErdosKoRadoOQ02.lean",
+    "tags": [
+      "combinatorics",
+      "erdos",
+      "extremal-set-theory",
+      "intersecting-families",
+      "kruskal-katona",
+      "erdos-ko-rado"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 171,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "originalContributions": [
+      "ekr_bound: the Erdős–Ko–Rado upper bound |A| ≤ C(n-1,k-1) for the parent's IsIntersectingFamily predicate, proved with ZERO axioms — discharging the parent's axiomatized double_counting_bound by routing through Mathlib's Finset.erdos_ko_rado instead of Katona's cyclic-interval lemma.",
+      "sized_of_isIntersectingFamily / intersecting_of_isIntersectingFamily: the bridge identifying the parent's bespoke 'all sets size k, pairwise nonempty intersection' predicate with Mathlib's Set.Sized k and Set.Intersecting (via not_disjoint_iff_nonempty_inter).",
+      "star_card: the star (all k-sets through a fixed center) has exactly C(n-1,k-1) members, via the erase-the-center bijection onto (k-1)-subsets.",
+      "ekr_isGreatest: the full extremal statement — the maximum size over all intersecting families is exactly C(n-1,k-1) (IsGreatest), combining the axiom-free upper bound with star sharpness.",
+      "ekr_max_6_3 and ekr_max_4_2: the maxima are exactly 10 = C(5,2) for (n,k)=(6,3) and 3 = C(3,1) for (4,2), with no native_decide."
+    ],
+    "prerequisites": [
+      "Erdős–Ko–Rado theorem: an intersecting family of k-sets of an n-set, n ≥ 2k, has at most C(n-1,k-1) members",
+      "Mathlib's Finset.erdos_ko_rado (proved via the Kruskal–Katona shadow inequality)",
+      "Set.Intersecting and Set.Sized predicates on set families",
+      "IsGreatest and elementary Finset cardinality bijections"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.erdos_ko_rado",
+        "description": "The Erdős–Ko–Rado theorem in Mathlib: an intersecting, r-sized family in Fin n with r ≤ n/2 has card ≤ (n-1).choose (r-1), proved via Kruskal–Katona.",
+        "module": "Mathlib.Combinatorics.SetFamily.KruskalKatona"
+      },
+      {
+        "theorem": "Finset.not_disjoint_iff_nonempty_inter",
+        "description": "¬Disjoint s t ↔ (s ∩ t).Nonempty — the bridge from the parent's nonempty-intersection condition to Mathlib's Set.Intersecting.",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.card_bij",
+        "description": "Cardinality equality from an explicit bijection — used for the star count via s ↦ s.erase x.",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Erdős–Ko–Rado theorem (1961) is the cornerstone of extremal set theory: among all families of k-element subsets of an n-element set (n ≥ 2k) in which every two members intersect, the largest are the 'stars' — all k-sets through a fixed point — of size C(n-1,k-1). Katona's celebrated cyclic-permutation proof (1972) is short and elegant on paper, but its core double-counting step rests on a lemma about how many of the n cyclic intervals of length k can pairwise intersect, whose modular bookkeeping has stubbornly resisted Lean formalization (the sibling open question OQ-01 was released unsolved for exactly this reason). The parent gallery entry consequently leaves the upper bound as an axiom, 'double_counting_bound'.\n\nMathlib reaches Erdős–Ko–Rado by a completely different path: it derives the bound from the Kruskal–Katona shadow inequality, with no cyclic intervals anywhere. This entry exploits that to discharge the parent's axiom entirely — the bound becomes a 0-axiom theorem about the parent's own predicate — and then adds the matching lower bound (the star), pinning the maximum exactly.",
+    "problemStatement": "**Open Question (parent erdos-ko-rado, OQ-02)**: prove double_counting_bound — the Katona double count yielding |𝒜| ≤ C(n-1,k-1) for an intersecting family of k-sets with n ≥ 2k — which the parent entry axiomatizes.\n\n**This entry**: proves that bound with zero axioms via Mathlib's Kruskal–Katona route, and proves it sharp (the star attains it), giving the full extremal statement.",
+    "text": "A 171-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing only Mathlib. It reproduces the parent's definitions IsIntersectingFamily and Star verbatim (the parent is axiomatized, so importing it would import its nine axioms), bridges IsIntersectingFamily to Mathlib's Set.Sized k and Set.Intersecting, applies Finset.erdos_ko_rado for the upper bound, computes the star size by an erase-the-center bijection, and assembles the exact maximum as IsGreatest, with concrete (n,k) = (6,3) and (4,2) instances.",
+    "proofStrategy": "The bridge has two halves. sized_of_isIntersectingFamily turns the parent's 'every member has card k' directly into Set.Sized k. intersecting_of_isIntersectingFamily turns 'every two members have nonempty intersection' into Set.Intersecting by rewriting with not_disjoint_iff_nonempty_inter (non-disjoint ⇔ nonempty intersection). ekr_bound then supplies Finset.erdos_ko_rado's side condition k ≤ n/2 from the hypothesis 2k ≤ n (Nat.le_div_iff_mul_le) and applies it. For sharpness, star_is_intersecting is immediate (all members share the center), and star_card counts the star by the bijection s ↦ s.erase x onto the (k-1)-subsets of the remaining n-1 points (Finset.card_bij with card_erase_of_mem / insert_erase). ekr_isGreatest packages both directions: the star is a witness of size C(n-1,k-1) (using n > 0 from n ≥ 2k ≥ 2 to name a center), and ekr_bound caps every family.",
+    "keyInsights": [
+      "The parent's axiomatized bound is not actually hard once you abandon Katona's cyclic intervals — Mathlib already proves Erdős–Ko–Rado through Kruskal–Katona, so the whole double-counting axiom collapses to a two-line bridge plus one library call.",
+      "The bespoke predicate IsIntersectingFamily is, after translation, exactly Set.Sized k together with Set.Intersecting; the only nontrivial step is not_disjoint_iff_nonempty_inter linking 'nonempty intersection' to 'not disjoint'.",
+      "Finset.erdos_ko_rado's hypothesis r ≤ n/2 is the same as the classical n ≥ 2k after one Nat.le_div_iff_mul_le rewrite.",
+      "Sharpness is genuinely elementary: deleting the fixed center is a bijection from k-sets through it onto (k-1)-subsets of the other n-1 points, so the star has exactly C(n-1,k-1) members.",
+      "Combining the axiom-free upper bound with the star lower bound upgrades the result from an inequality to the exact extremal value: IsGreatest pins the maximum at C(n-1,k-1)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "bridge",
+      "title": "Bridging to Mathlib's Predicates",
+      "startLine": 51,
+      "endLine": 65,
+      "summary": "sized_of_isIntersectingFamily and intersecting_of_isIntersectingFamily translate the parent's IsIntersectingFamily into Set.Sized k and Set.Intersecting.",
+      "mathContext": "The bespoke 'uniform size k, pairwise nonempty intersection' predicate is Mathlib's Set.Sized + Set.Intersecting."
+    },
+    {
+      "id": "upper-bound",
+      "title": "The Upper Bound, Axiom-Free",
+      "startLine": 67,
+      "endLine": 84,
+      "summary": "ekr_bound: |A| ≤ C(n-1,k-1) via Finset.erdos_ko_rado, discharging the parent's double_counting_bound axiom with zero axioms.",
+      "mathContext": "Mathlib's Kruskal–Katona route replaces Katona's cyclic-interval lemma."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness: the Star Attains the Bound",
+      "startLine": 86,
+      "endLine": 138,
+      "summary": "star_is_intersecting and star_card (the erase-the-center bijection) show the star has exactly C(n-1,k-1) members.",
+      "mathContext": "The star is the extremal family; deleting the center bijects onto (k-1)-subsets."
+    },
+    {
+      "id": "exact-max",
+      "title": "The Exact Maximum",
+      "startLine": 140,
+      "endLine": 170,
+      "summary": "ekr_isGreatest pins the maximum at C(n-1,k-1) (IsGreatest); ekr_max_6_3 = 10 and ekr_max_4_2 = 3 instantiate it.",
+      "mathContext": "Combining the axiom-free upper bound with star sharpness gives the full extremal statement."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry replaces the parent gallery entry's central axiom — the Erdős–Ko–Rado upper bound |𝒜| ≤ C(n-1,k-1), axiomatized there as double_counting_bound — with a zero-axiom theorem, by bridging the parent's IsIntersectingFamily predicate to Mathlib's Set.Intersecting / Set.Sized and invoking Mathlib's Kruskal–Katona-based Finset.erdos_ko_rado. It then proves the bound sharp via the star, pinning the maximum exactly as IsGreatest ((n-1).choose (k-1)).",
+    "implications": "The hardest part of the parent's Katona formalization — the cyclic-interval double count (sibling OQ-01) — is not needed at all: Mathlib's Kruskal–Katona development already delivers the bound, so the parent's axiom is dischargeable. This converts the parent's flagship claim from 'axiomatized' to 'verified' for the parent's own predicate, and upgrades the inequality to the exact extremal value.",
+    "openQuestions": [
+      "Formalize EKR uniqueness: the star is the UNIQUE maximum intersecting family for n > 2k, not merely one maximizer.",
+      "Prove the parent's cyclic-interval lemma at_most_k_intersecting_cyclic_intervals directly, completing Katona's proof in Lean (sibling OQ-01).",
+      "Bridge the parent's other axiomatized extensions (Frankl t-intersecting, Hilton–Milner) to Mathlib or to direct proofs, where available."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-ko-rado",
+      "relationship": "extends",
+      "description": "Parent entry: formalizes EKR via Katona's cyclic proof but axiomatizes the upper bound (double_counting_bound). This entry discharges that axiom with zero axioms via Kruskal–Katona."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ErdosKoRadoOQ02",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "mainTheorems": [
+      {
+        "name": "ekr_bound",
+        "type": "core",
+        "description": "The Erdős–Ko–Rado upper bound |A| ≤ C(n-1,k-1) for an intersecting family of k-sets with n ≥ 2k, proved with zero axioms (discharges the parent's double_counting_bound).",
+        "leanType": "{n k : ℕ} → n ≥ 2 * k → (A : Finset (Finset (Fin n))) → IsIntersectingFamily A k → A.card ≤ (n - 1).choose (k - 1)"
+      },
+      {
+        "name": "star_card",
+        "type": "key",
+        "description": "The star has exactly C(n-1,k-1) members, via the erase-the-center bijection.",
+        "leanType": "{n k : ℕ} → 0 < k → (x : Fin n) → (Star x k).card = (n - 1).choose (k - 1)"
+      },
+      {
+        "name": "ekr_isGreatest",
+        "type": "key",
+        "description": "The maximum size over all intersecting families of k-sets (n ≥ 2k) is exactly C(n-1,k-1).",
+        "leanType": "{n k : ℕ} → n ≥ 2 * k → 0 < k → IsGreatest {c | ∃ A, IsIntersectingFamily A k ∧ A.card = c} ((n - 1).choose (k - 1))"
+      }
+    ],
+    "path": "Proofs/ErdosKoRadoOQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "ekr_bound",
+      "type": "core",
+      "description": "Axiom-free Erdős–Ko–Rado upper bound |A| ≤ C(n-1,k-1), discharging the parent's double_counting_bound.",
+      "leanType": "{n k : ℕ} → n ≥ 2 * k → (A : Finset (Finset (Fin n))) → IsIntersectingFamily A k → A.card ≤ (n - 1).choose (k - 1)"
+    },
+    {
+      "name": "ekr_isGreatest",
+      "type": "key",
+      "description": "The exact maximum: IsGreatest pins it at C(n-1,k-1).",
+      "leanType": "{n k : ℕ} → n ≥ 2 * k → 0 < k → IsGreatest {c | ∃ A, IsIntersectingFamily A k ∧ A.card = c} ((n - 1).choose (k - 1))"
+    },
+    {
+      "name": "ekr_max_6_3",
+      "type": "supporting",
+      "description": "For (n,k)=(6,3) the maximum is exactly 10 = C(5,2); for (4,2) it is 3 = C(3,1).",
+      "leanType": "IsGreatest {c | ∃ A : Finset (Finset (Fin 6)), IsIntersectingFamily A 3 ∧ A.card = c} 10"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul; Ko, Chao; Rado, Richard",
+      "title": "Intersection theorems for systems of finite sets",
+      "year": "1961",
+      "venue": "Quarterly Journal of Mathematics 12(1), 313–320",
+      "note": "The original Erdős–Ko–Rado theorem"
+    },
+    {
+      "authors": "Katona, Gyula O. H.",
+      "title": "A simple proof of the Erdős–Chao Ko–Rado theorem",
+      "year": "1972",
+      "venue": "Journal of Combinatorial Theory, Series B 13(2), 183–184",
+      "note": "The cyclic-permutation proof the parent entry formalizes (and axiomatizes the core lemma of)"
+    },
+    {
+      "authors": "Katona, Gyula O. H.",
+      "title": "A theorem of finite sets",
+      "year": "1968",
+      "venue": "Theory of Graphs (Proc. Colloq. Tihany), 187–207",
+      "note": "The Kruskal–Katona theorem, the route Mathlib uses to prove Erdős–Ko–Rado"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent gallery entry **erdos-ko-rado** formalizes the Erdős–Ko–Rado theorem via Katona's cyclic-permutation proof, but leaves the central claim — the upper bound

> |𝒜| ≤ C(n-1, k-1) for an intersecting family of k-sets in an n-set, n ≥ 2k

— as an **axiom** (`double_counting_bound`), because Katona's double count rests on a cyclic-interval lemma whose modular bookkeeping resisted Lean formalization (the sibling open question **OQ-01** was released unsolved for exactly this reason).

This entry answers **OQ-02** by discharging that axiom **completely, with zero axioms**, via an entirely different route. Mathlib proves Erdős–Ko–Rado through the **Kruskal–Katona shadow inequality** (`Finset.erdos_ko_rado`), with no cyclic intervals anywhere. So we:

1. **Bridge** the parent's bespoke predicate `IsIntersectingFamily A k` to Mathlib's `Set.Sized k` + `Set.Intersecting` (the only real step is `not_disjoint_iff_nonempty_inter`: non-disjoint ⇔ nonempty intersection);
2. **Obtain the upper bound** `ekr_bound : A.card ≤ (n-1).choose (k-1)` axiom-free, with the side condition `k ≤ n/2` coming from `n ≥ 2k` via one `Nat.le_div_iff_mul_le` rewrite;
3. **Prove it sharp** — `star_card` counts the star (all k-sets through a fixed center) as exactly `C(n-1,k-1)` by the erase-the-center bijection — and assemble `ekr_isGreatest`, pinning the **exact maximum** as `IsGreatest`.

Concrete maxima: `10 = C(5,2)` for `(n,k)=(6,3)` and `3 = C(3,1)` for `(4,2)`, with **no `native_decide`**.

This converts the parent's flagship claim from *axiomatized* to *verified* for the parent's own predicate, and upgrades the inequality to the exact extremal value.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.ErdosKoRadoOQ02` → `✔ Built Proofs.ErdosKoRadoOQ02`, build completed successfully.
- 171 lines, 8 theorems / 2 definitions, **0 sorries, 0 axioms, no native_decide** — verified.
- Self-contained: imports Mathlib only; the parent's `IsIntersectingFamily` and `Star` are reproduced verbatim (the parent is `axiomatized`, so importing it would pull its nine axioms into this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)